### PR TITLE
Renamed hasMove to hasMark

### DIFF
--- a/Examples/TicTacToe/TicTacToeApp.js
+++ b/Examples/TicTacToe/TicTacToeApp.js
@@ -39,7 +39,7 @@ class Board {
     return this;
   }
 
-  hasMove(row: number, col: number): boolean {
+  hasMark(row: number, col: number): boolean {
     return this.grid[row][col] !== 0;
   }
 
@@ -175,7 +175,7 @@ var TicTacToeApp = React.createClass({
   },
 
   handleCellPress(row: number, col: number) {
-    if (this.state.board.hasMove(row, col)) {
+    if (this.state.board.hasMark(row, col)) {
       return;
     }
 


### PR DESCRIPTION
Since you are marking the squares and it returns true if the square was
marked.  To me if I ask if a square has a Move, I don't know at first if it meant it
had a Move available or a Move already made. Move feels more like
a chess term where you are moving pieces around.  Anyway, small rename
for readability / logical consistency.
