### PR TITLE
Fixes reference to ReactPackager middleware

### DIFF
--- a/packager/packager.js
+++ b/packager/packager.js
@@ -67,7 +67,7 @@ function openStackFrameInEditor(req, res, next) {
 }
 
 function getAppMiddleware(options) {
-  return ReactPackager.catalystMiddleware({
+  return ReactPackager.middleware({
     dev: true,
     projectRoot: options.projectRoot,
     blacklistRE: blacklist(false),


### PR DESCRIPTION
The name of the middleware was changed from _catalystMiddleware_ to
_middleware_ in
https://github.com/facebook/react-native/commit/4f613e20d23e391ff2d85526627afd847f785980#diff-4516c33155b29ed9993bcd9d7734904dL19
