### PR TITLE
[Initialization] Decouple script loading and environment setup from the root view

### DIFF
--- a/Examples/Movies/AppDelegate.m
+++ b/Examples/Movies/AppDelegate.m
@@ -2,14 +2,13 @@
 
 #import "AppDelegate.h"
 
-#import "RCTRootView.h"
+#import "RCTRootViewController.h"
 
 @implementation AppDelegate
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
   NSURL *jsCodeLocation;
-  RCTRootView *rootView = [[RCTRootView alloc] init];
 
   // Loading JavaScript code - uncomment the one you want.
 
@@ -30,13 +29,12 @@
   // and uncomment the next following line
   // jsCodeLocation = [[NSBundle mainBundle] URLForResource:@"main" withExtension:@"jsbundle"];
 
-  rootView.scriptURL = jsCodeLocation;
-  rootView.moduleName = @"MoviesApp";
+  RCTRootViewController *viewController = [[RCTRootViewController alloc] init];
+  viewController.moduleName = @"MoviesApp";
+  viewController.scriptURL = jsCodeLocation;
 
   self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
-  UIViewController *rootViewController = [[UIViewController alloc] init];
-  rootViewController.view = rootView;
-  self.window.rootViewController = rootViewController;
+  self.window.rootViewController = viewController;
   [self.window makeKeyAndVisible];
   return YES;
 }

--- a/Examples/TicTacToe/AppDelegate.m
+++ b/Examples/TicTacToe/AppDelegate.m
@@ -2,14 +2,13 @@
 
 #import "AppDelegate.h"
 
-#import "RCTRootView.h"
+#import "RCTRootViewController.h"
 
 @implementation AppDelegate
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
   NSURL *jsCodeLocation;
-  RCTRootView *rootView = [[RCTRootView alloc] init];
 
   // Loading JavaScript code - uncomment the one you want.
 
@@ -30,13 +29,12 @@
   // and uncomment the next following line
   // jsCodeLocation = [[NSBundle mainBundle] URLForResource:@"main" withExtension:@"jsbundle"];
 
-  rootView.scriptURL = jsCodeLocation;
-  rootView.moduleName = @"TicTacToeApp";
+  RCTRootViewController *viewController = [[RCTRootViewController alloc] init];
+  viewController.moduleName = @"TicTacToeApp";
+  viewController.scriptURL = jsCodeLocation;
 
   self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
-  UIViewController *rootViewController = [[UIViewController alloc] init];
-  rootViewController.view = rootView;
-  self.window.rootViewController = rootViewController;
+  self.window.rootViewController = viewController;
   [self.window makeKeyAndVisible];
   return YES;
 }

--- a/Examples/UIExplorer/AppDelegate.m
+++ b/Examples/UIExplorer/AppDelegate.m
@@ -2,14 +2,13 @@
 
 #import "AppDelegate.h"
 
-#import "RCTRootView.h"
+#import "RCTRootViewController.h"
 
 @implementation AppDelegate
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
   NSURL *jsCodeLocation;
-  RCTRootView *rootView = [[RCTRootView alloc] init];
 
   // Loading JavaScript code - uncomment the one you want.
 
@@ -30,13 +29,12 @@
   // and uncomment the next following line
   // jsCodeLocation = [[NSBundle mainBundle] URLForResource:@"main" withExtension:@"jsbundle"];
 
-  rootView.scriptURL = jsCodeLocation;
-  rootView.moduleName = @"UIExplorerApp";
+  RCTRootViewController *viewController = [[RCTRootViewController alloc] init];
+  viewController.moduleName = @"UIExplorerApp";
+  viewController.scriptURL = jsCodeLocation;
 
   self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
-  UIViewController *rootViewController = [[UIViewController alloc] init];
-  rootViewController.view = rootView;
-  self.window.rootViewController = rootViewController;
+  self.window.rootViewController = viewController;
   [self.window makeKeyAndVisible];
   return YES;
 }

--- a/IntegrationTests/AppDelegate.m
+++ b/IntegrationTests/AppDelegate.m
@@ -2,14 +2,13 @@
 
 #import "AppDelegate.h"
 
-#import "RCTRootView.h"
+#import "RCTRootViewController.h"
 
 @implementation AppDelegate
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
   NSURL *jsCodeLocation;
-  RCTRootView *rootView = [[RCTRootView alloc] init];
 
   // Loading JavaScript code - uncomment the one you want.
 
@@ -30,13 +29,12 @@
   // and uncomment the next following line
   // jsCodeLocation = [[NSBundle mainBundle] URLForResource:@"main" withExtension:@"jsbundle"];
 
-  rootView.scriptURL = jsCodeLocation;
-  rootView.moduleName = @"IntegrationTestsApp";
+  RCTRootViewController *viewController = [[RCTRootViewController alloc] init];
+  viewController.moduleName = @"IntegrationTestsApp";
+  viewController.scriptURL = jsCodeLocation;
 
   self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
-  UIViewController *rootViewController = [[UIViewController alloc] init];
-  rootViewController.view = rootView;
-  self.window.rootViewController = rootViewController;
+  self.window.rootViewController = viewController;
   [self.window makeKeyAndVisible];
   return YES;
 }

--- a/Libraries/RCTTest/RCTTestRunner.m
+++ b/Libraries/RCTTest/RCTTestRunner.m
@@ -3,7 +3,7 @@
 #import "RCTTestRunner.h"
 
 #import "RCTRedBox.h"
-#import "RCTRootView.h"
+#import "RCTRootViewController.h"
 #import "RCTTestModule.h"
 #import "RCTUtils.h"
 
@@ -34,15 +34,14 @@
 - (void)runTest:(NSString *)moduleName initialProps:(NSDictionary *)initialProps expectErrorBlock:(BOOL(^)(NSString *error))expectErrorBlock
 {
   RCTTestModule *testModule = [[RCTTestModule alloc] init];
-  RCTRootView *rootView = [[RCTRootView alloc] init];
-  UIViewController *vc = [[[[UIApplication sharedApplication] delegate] window] rootViewController];
-  vc.view = rootView;
-  rootView.moduleProvider = ^(void){
+  RCTRootViewController *rootViewController = [[RCTRootViewController alloc] init];
+  [[UIApplication sharedApplication].delegate window].rootViewController = rootViewController;
+  rootViewController.moduleProvider = ^(void){
     return @[testModule];
   };
-  rootView.moduleName = moduleName;
-  rootView.initialProperties = initialProps;
-  rootView.scriptURL = [NSURL URLWithString:_script];
+  rootViewController.moduleName = moduleName;
+  rootViewController.initialProperties = initialProps;
+  rootViewController.scriptURL = [NSURL URLWithString:_script];
 
   NSDate *date = [NSDate dateWithTimeIntervalSinceNow:TIMEOUT_SECONDS];
   NSString *error = [[RCTRedBox sharedInstance] currentErrorMessage];

--- a/ReactKit/Base/RCTRedBox.m
+++ b/ReactKit/Base/RCTRedBox.m
@@ -110,7 +110,7 @@
 
 - (void)reload
 {
-  [[NSNotificationCenter defaultCenter] postNotificationName:@"RCTReloadNotification" object:nil userInfo:nil];
+  [[NSNotificationCenter defaultCenter] postNotificationName:RCTReloadNotification object:self];
   [self dismiss];
 }
 

--- a/ReactKit/Base/RCTRootView.h
+++ b/ReactKit/Base/RCTRootView.h
@@ -2,52 +2,6 @@
 
 #import <UIKit/UIKit.h>
 
-#import "RCTBridge.h"
-
 @interface RCTRootView : UIView
-
-/**
- * The URL of the bundled application script (required).
- * Setting this will clear the view contents, and trigger
- * an asynchronous load/download and execution of the script.
- */
-@property (nonatomic, strong) NSURL *scriptURL;
-
-/**
- * The name of the JavaScript module to execute within the
- * specified scriptURL (required). Setting this will not have
- * any immediate effect, but it must be done prior to loading
- * the script.
- */
-@property (nonatomic, copy) NSString *moduleName;
-
-/**
- * A block that returns an array of pre-allocated modules.  These
- * modules will take precedence over any automatically registered
- * modules of the same name.
- */
-@property (nonatomic, copy) RCTBridgeModuleProviderBlock moduleProvider;
-
-/**
- * The default properties to apply to the view when the script bundle
- * is first loaded. Defaults to nil/empty.
- */
-@property (nonatomic, copy) NSDictionary *initialProperties;
-
-/**
- * The class of the RCTJavaScriptExecutor to use with this view.
- * If not specified, it will default to using RCTContextExecutor.
- * Changes will take effect next time the bundle is reloaded.
- */
-@property (nonatomic, strong) Class executorClass;
-
-/**
- * Reload this root view, or all root views, respectively.
- */
-- (void)reload;
-+ (void)reloadAll;
-
-- (void)startOrResetInteractionTiming;
-- (NSDictionary *)endAndResetInteractionTiming;
 
 @end

--- a/ReactKit/Base/RCTRootView.m
+++ b/ReactKit/Base/RCTRootView.m
@@ -2,53 +2,9 @@
 
 #import "RCTRootView.h"
 
-#import "RCTBridge.h"
-#import "RCTContextExecutor.h"
-#import "RCTEventDispatcher.h"
-#import "RCTKeyCommands.h"
-#import "RCTLog.h"
-#import "RCTRedBox.h"
-#import "RCTSourceCode.h"
-#import "RCTTouchHandler.h"
-#import "RCTUIManager.h"
-#import "RCTUtils.h"
-#import "RCTWebViewExecutor.h"
 #import "UIView+ReactKit.h"
 
-NSString *const RCTReloadNotification = @"RCTReloadNotification";
-
 @implementation RCTRootView
-{
-  RCTBridge *_bridge;
-  RCTTouchHandler *_touchHandler;
-  id<RCTJavaScriptExecutor> _executor;
-}
-
-static Class _globalExecutorClass;
-
-+ (void)initialize
-{
-
-#if DEBUG
-
-  // Register Cmd-R as a global refresh key
-  [[RCTKeyCommands sharedInstance] registerKeyCommandWithInput:@"r"
-                                                 modifierFlags:UIKeyModifierCommand
-                                                        action:^(UIKeyCommand *command) {
-                                                          [self reloadAll];
-                                                        }];
-
-  // Cmd-D reloads using the web view executor, allows attaching from Safari dev tools.
-  [[RCTKeyCommands sharedInstance] registerKeyCommandWithInput:@"d"
-                                                 modifierFlags:UIKeyModifierCommand
-                                                        action:^(UIKeyCommand *command) {
-                                                          _globalExecutorClass = [RCTWebViewExecutor class];
-                                                          [self reloadAll];
-                                                        }];
-
-#endif
-
-}
 
 - (id)initWithCoder:(NSCoder *)aDecoder
 {
@@ -61,7 +17,6 @@ static Class _globalExecutorClass;
 - (instancetype)initWithFrame:(CGRect)frame
 {
   if ((self = [super initWithFrame:frame])) {
-    self.backgroundColor = [UIColor whiteColor];
     [self setUp];
   }
   return self;
@@ -74,181 +29,11 @@ static Class _globalExecutorClass;
   static NSInteger rootViewTag = 1;
   self.reactTag = @(rootViewTag);
   rootViewTag += 10;
-
-  // Add reload observer
-  [[NSNotificationCenter defaultCenter] addObserver:self
-                                           selector:@selector(reload)
-                                               name:RCTReloadNotification
-                                             object:nil];
-}
-
-+ (NSArray *)JSMethods
-{
-  return @[
-    @"AppRegistry.runApplication",
-    @"ReactIOS.unmountComponentAtNodeAndRemoveContainer"
-  ];
-}
-
-- (void)dealloc
-{
-  [[NSNotificationCenter defaultCenter] removeObserver:self];
-
-  [_bridge enqueueJSCall:@"ReactIOS.unmountComponentAtNodeAndRemoveContainer"
-                    args:@[self.reactTag]];
-
-  // TODO: eventually we'll want to be able to share the bridge between
-  // multiple rootviews, in which case we'll need to move this elsewhere
-  [_bridge invalidate];
-}
-
-- (void)bundleFinishedLoading:(NSError *)error
-{
-  if (error != nil) {
-    NSArray *stack = [[error userInfo] objectForKey:@"stack"];
-    if (stack) {
-      [[RCTRedBox sharedInstance] showErrorMessage:[error localizedDescription] withStack:stack];
-    } else {
-      [[RCTRedBox sharedInstance] showErrorMessage:[error localizedDescription] withDetails:[error localizedFailureReason]];
-    }
-  } else {
-
-    [_bridge.uiManager registerRootView:self];
-
-    NSString *moduleName = _moduleName ?: @"";
-    NSDictionary *appParameters = @{
-      @"rootTag": self.reactTag,
-      @"initialProps": self.initialProperties ?: @{},
-    };
-    [_bridge enqueueJSCall:@"AppRegistry.runApplication"
-                      args:@[moduleName, appParameters]];
-  }
-}
-
-- (void)loadBundle
-{
-  // Clear view
-  [self.subviews makeObjectsPerformSelector:@selector(removeFromSuperview)];
-
-  if (!_scriptURL) {
-    return;
-  }
-
-  // Clean up
-  [self removeGestureRecognizer:_touchHandler];
-  [_touchHandler invalidate];
-  [_executor invalidate];
-  [_bridge invalidate];
-
-  // Choose local executor if specified, followed by global, followed by default
-  _executor = [[_executorClass ?: _globalExecutorClass ?: [RCTContextExecutor class] alloc] init];
-  _bridge = [[RCTBridge alloc] initWithExecutor:_executor moduleProvider:_moduleProvider];
-  _touchHandler = [[RCTTouchHandler alloc] initWithBridge:_bridge];
-  [self addGestureRecognizer:_touchHandler];
-
-  // Load the bundle
-  NSURLSessionDataTask *task = [[NSURLSession sharedSession] dataTaskWithURL:_scriptURL completionHandler:
-                                ^(NSData *data, NSURLResponse *response, NSError *error) {
-
-    // Handle general request errors
-    if (error) {
-      if ([[error domain] isEqualToString:NSURLErrorDomain]) {
-        NSDictionary *userInfo = @{
-          NSLocalizedDescriptionKey: @"Could not connect to development server. Ensure node server is running - run 'npm start' from ReactKit root",
-          NSLocalizedFailureReasonErrorKey: [error localizedDescription],
-          NSUnderlyingErrorKey: error,
-        };
-        error = [NSError errorWithDomain:@"JSServer"
-                                    code:error.code
-                                userInfo:userInfo];
-      }
-      [self bundleFinishedLoading:error];
-      return;
-    }
-
-    // Parse response as text
-    NSStringEncoding encoding = NSUTF8StringEncoding;
-    if (response.textEncodingName != nil) {
-      CFStringEncoding cfEncoding = CFStringConvertIANACharSetNameToEncoding((CFStringRef)response.textEncodingName);
-      if (cfEncoding != kCFStringEncodingInvalidId) {
-        encoding = CFStringConvertEncodingToNSStringEncoding(cfEncoding);
-      }
-    }
-    NSString *rawText = [[NSString alloc] initWithData:data encoding:encoding];
-
-    // Handle HTTP errors
-    if ([response isKindOfClass:[NSHTTPURLResponse class]] && [(NSHTTPURLResponse *)response statusCode] != 200) {
-      NSDictionary *userInfo;
-      NSDictionary *errorDetails = RCTJSONParse(rawText, nil);
-      if ([errorDetails isKindOfClass:[NSDictionary class]]) {
-        userInfo = @{
-          NSLocalizedDescriptionKey: errorDetails[@"message"] ?: @"No message provided",
-          @"stack": @[@{
-            @"methodName": errorDetails[@"description"] ?: @"",
-            @"file": errorDetails[@"filename"] ?: @"",
-            @"lineNumber": errorDetails[@"lineNumber"] ?: @0
-          }]
-        };
-      } else {
-        userInfo = @{NSLocalizedDescriptionKey: rawText};
-      }
-      error = [NSError errorWithDomain:@"JSServer"
-                                  code:[(NSHTTPURLResponse *)response statusCode]
-                              userInfo:userInfo];
-
-      [self bundleFinishedLoading:error];
-      return;
-    }
-
-    // Success!
-    RCTSourceCode *sourceCodeModule = _bridge.modules[NSStringFromClass([RCTSourceCode class])];
-    sourceCodeModule.scriptURL = _scriptURL;
-    sourceCodeModule.scriptText = rawText;
-
-    [_bridge enqueueApplicationScript:rawText url:_scriptURL onComplete:^(NSError *error) {
-      dispatch_async(dispatch_get_main_queue(), ^{
-        [self bundleFinishedLoading:error];
-      });
-    }];
-
-  }];
-
-  [task resume];
-}
-
-- (void)setScriptURL:(NSURL *)scriptURL
-{
-  if ([_scriptURL isEqual:scriptURL]) {
-    return;
-  }
-
-  _scriptURL = scriptURL;
-  [self loadBundle];
 }
 
 - (BOOL)isReactRootView
 {
   return YES;
-}
-
-- (void)reload
-{
-  [self loadBundle];
-}
-
-+ (void)reloadAll
-{
-  [[NSNotificationCenter defaultCenter] postNotificationName:RCTReloadNotification object:nil];
-}
-
-- (void)startOrResetInteractionTiming
-{
-  [_touchHandler startOrResetInteractionTiming];
-}
-
-- (NSDictionary *)endAndResetInteractionTiming
-{
-  return [_touchHandler endAndResetInteractionTiming];
 }
 
 @end

--- a/ReactKit/Base/RCTRootViewController.h
+++ b/ReactKit/Base/RCTRootViewController.h
@@ -1,0 +1,71 @@
+// Copyright 2004-present Facebook. All rights reserved.
+
+#import <UIKit/UIKit.h>
+
+#import "RCTBridge.h"
+#import "RCTJSMethodRegistrar.h"
+
+@class RCTRootView;
+
+/**
+ * Convenience class for initializing a React Native view controller. It creates
+ * default JavaScript executors and creates an `RCTRootView` for its view.
+ *
+ * The view controller also manages reloading the JavaScript source code and
+ * the contents of its `RCTRootView`.
+ *
+ * In more advanced applications, you may want to use `RCTRootView` and
+ * `RCTBridge` directly.
+ */
+@interface RCTRootViewController : UIViewController <RCTJSMethodRegistrar>
+
+/**
+ * The same view as `self.view` but statically typed as `RCTRootView`.
+ */
+@property (nonatomic, strong, readonly) RCTRootView *reactRootView;
+
+/**
+ * The URL of the bundled application script (required).
+ * Setting this will clear the view contents, and trigger
+ * an asynchronous load/download and execution of the script.
+ */
+@property (nonatomic, strong) NSURL *scriptURL;
+
+/**
+ * The name of the JavaScript module to execute within the
+ * specified scriptURL (required). Setting this will not have
+ * any immediate effect, but it must be done prior to loading
+ * the script.
+ */
+@property (nonatomic, copy) NSString *moduleName;
+
+/**
+ * A block that returns an array of pre-allocated modules.  These
+ * modules will take precedence over any automatically registered
+ * modules of the same name.
+ */
+@property (nonatomic, copy) RCTBridgeModuleProviderBlock moduleProvider;
+
+/**
+ * The default properties to apply to the view when the script bundle
+ * is first loaded. Defaults to nil/empty.
+ */
+@property (nonatomic, copy) NSDictionary *initialProperties;
+
+/**
+ * The class of the RCTJavaScriptExecutor to use with this view controller.
+ * If not specified, it will default to using RCTContextExecutor.
+ * Changes will take effect next time the bundle is reloaded.
+ */
+@property (nonatomic, strong) Class executorClass;
+
+/**
+ * Reload the root view, or all root views, respectively.
+ */
+- (void)reload;
++ (void)reloadAll;
+
+- (void)startOrResetInteractionTiming;
+- (NSDictionary *)endAndResetInteractionTiming;
+
+@end

--- a/ReactKit/Base/RCTRootViewController.m
+++ b/ReactKit/Base/RCTRootViewController.m
@@ -1,0 +1,250 @@
+// Copyright 2004-present Facebook. All rights reserved.
+
+#import "RCTRootViewController.h"
+
+#import "RCTBridge.h"
+#import "RCTContextExecutor.h"
+#import "RCTEventDispatcher.h"
+#import "RCTKeyCommands.h"
+#import "RCTLog.h"
+#import "RCTRedBox.h"
+#import "RCTRootView.h"
+#import "RCTSourceCode.h"
+#import "RCTTouchHandler.h"
+#import "RCTUIManager.h"
+#import "RCTUtils.h"
+#import "RCTWebViewExecutor.h"
+#import "UIView+ReactKit.h"
+
+@implementation RCTRootViewController
+{
+  RCTBridge *_bridge;
+  RCTTouchHandler *_touchHandler;
+  id <RCTJavaScriptExecutor> _executor;
+}
+
+static Class _globalExecutorClass;
+
++ (void)initialize
+{
+
+#if DEBUG
+
+  // Register Cmd-R as a global refresh key
+  [[RCTKeyCommands sharedInstance] registerKeyCommandWithInput:@"r"
+                                                 modifierFlags:UIKeyModifierCommand
+                                                        action:^(UIKeyCommand *command) {
+                                                          [self reloadAll];
+                                                        }];
+
+  // Cmd-D reloads using the web view executor, allows attaching from Safari dev tools in iOS 7.
+  [[RCTKeyCommands sharedInstance] registerKeyCommandWithInput:@"d"
+                                                 modifierFlags:UIKeyModifierCommand
+                                                        action:^(UIKeyCommand *command) {
+                                                          _globalExecutorClass = [RCTWebViewExecutor class];
+                                                          [self reloadAll];
+                                                        }];
+
+#endif
+
+}
+
+- (instancetype)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil
+{
+  if ((self = [super initWithNibName:nibNameOrNil bundle:nibBundleOrNil])) {
+    // Add reload observer
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(reload)
+                                                 name:RCTReloadNotification
+                                               object:nil];
+  }
+  return self;
+}
+
+- (void)dealloc
+{
+  [[NSNotificationCenter defaultCenter] removeObserver:self];
+
+  [_bridge enqueueJSCall:@"ReactIOS.unmountComponentAtNodeAndRemoveContainer"
+                    args:@[self.reactRootView.reactTag]];
+
+  // TODO: eventually we'll want to be able to share the bridge between
+  // multiple rootviews, in which case we'll need to move this elsewhere
+  [_bridge invalidate];
+}
+
+- (RCTRootView *)reactRootView
+{
+  NSAssert([self.view isKindOfClass:[RCTRootView class]],
+           @"RCTRootViewController's view must be an RCTRootView");
+  return (RCTRootView *)self.view;
+}
+
++ (NSArray *)JSMethods
+{
+  return @[
+    @"AppRegistry.runApplication",
+    @"ReactIOS.unmountComponentAtNodeAndRemoveContainer",
+  ];
+}
+
+#pragma mark - Life Cycle
+
+- (void)loadView
+{
+  self.view = [[RCTRootView alloc] init];
+}
+
+- (void)viewDidLoad
+{
+  [super viewDidLoad];
+
+  self.view.backgroundColor = [UIColor whiteColor];
+}
+
+#pragma mark - Loading JavaScript and Rendering Components
+
+- (void)bundleFinishedLoading:(NSError *)error
+{
+  if (error != nil) {
+    NSArray *stack = [[error userInfo] objectForKey:@"stack"];
+    if (stack) {
+      [[RCTRedBox sharedInstance] showErrorMessage:[error localizedDescription] withStack:stack];
+    } else {
+      [[RCTRedBox sharedInstance] showErrorMessage:[error localizedDescription] withDetails:[error localizedFailureReason]];
+    }
+  } else {
+    [_bridge.uiManager registerRootViewController:self];
+
+    NSString *moduleName = _moduleName ?: @"";
+    NSDictionary *appParameters = @{
+      @"rootTag": self.reactRootView.reactTag,
+      @"initialProps": self.initialProperties ?: @{},
+    };
+    [_bridge enqueueJSCall:@"AppRegistry.runApplication"
+                      args:@[moduleName, appParameters]];
+  }
+}
+
+- (void)loadBundle
+{
+  // Clear view
+  [self.view.subviews makeObjectsPerformSelector:@selector(removeFromSuperview)];
+
+  if (!_scriptURL) {
+    return;
+  }
+
+  // Clean up
+  [self.view removeGestureRecognizer:_touchHandler];
+  [_touchHandler invalidate];
+  [_executor invalidate];
+  [_bridge invalidate];
+
+  // Choose local executor if specified, followed by global, followed by default
+  _executor = [[_executorClass ?: _globalExecutorClass ?: [RCTContextExecutor class] alloc] init];
+  _bridge = [[RCTBridge alloc] initWithExecutor:_executor moduleProvider:_moduleProvider];
+  _touchHandler = [[RCTTouchHandler alloc] initWithBridge:_bridge];
+  [self.view addGestureRecognizer:_touchHandler];
+
+  // Load the bundle
+  NSURLSessionDataTask *task = [[NSURLSession sharedSession] dataTaskWithURL:_scriptURL completionHandler:
+                                ^(NSData *data, NSURLResponse *response, NSError *error) {
+
+    // Handle general request errors
+    if (error) {
+      if ([[error domain] isEqualToString:NSURLErrorDomain]) {
+        NSDictionary *userInfo = @{
+          NSLocalizedDescriptionKey: @"Could not connect to development server. Ensure node server is running - run 'npm start' from ReactKit root",
+          NSLocalizedFailureReasonErrorKey: [error localizedDescription],
+          NSUnderlyingErrorKey: error,
+        };
+        error = [NSError errorWithDomain:@"JSServer"
+                                    code:error.code
+                                userInfo:userInfo];
+      }
+      [self bundleFinishedLoading:error];
+      return;
+    }
+
+    // Parse response as text
+    NSStringEncoding encoding = NSUTF8StringEncoding;
+    if (response.textEncodingName != nil) {
+      CFStringEncoding cfEncoding = CFStringConvertIANACharSetNameToEncoding((CFStringRef)response.textEncodingName);
+      if (cfEncoding != kCFStringEncodingInvalidId) {
+        encoding = CFStringConvertEncodingToNSStringEncoding(cfEncoding);
+      }
+    }
+    NSString *rawText = [[NSString alloc] initWithData:data encoding:encoding];
+
+    // Handle HTTP errors
+    if ([response isKindOfClass:[NSHTTPURLResponse class]] && [(NSHTTPURLResponse *)response statusCode] != 200) {
+      NSDictionary *userInfo;
+      NSDictionary *errorDetails = RCTJSONParse(rawText, nil);
+      if ([errorDetails isKindOfClass:[NSDictionary class]]) {
+        userInfo = @{
+          NSLocalizedDescriptionKey: errorDetails[@"message"] ?: @"No message provided",
+          @"stack": @[@{
+            @"methodName": errorDetails[@"description"] ?: @"",
+            @"file": errorDetails[@"filename"] ?: @"",
+            @"lineNumber": errorDetails[@"lineNumber"] ?: @0
+          }]
+        };
+      } else {
+        userInfo = @{NSLocalizedDescriptionKey: rawText};
+      }
+      error = [NSError errorWithDomain:@"JSServer"
+                                  code:[(NSHTTPURLResponse *)response statusCode]
+                              userInfo:userInfo];
+
+      [self bundleFinishedLoading:error];
+      return;
+    }
+
+    // Success!
+    RCTSourceCode *sourceCodeModule = _bridge.modules[NSStringFromClass([RCTSourceCode class])];
+    sourceCodeModule.scriptURL = _scriptURL;
+    sourceCodeModule.scriptText = rawText;
+
+    [_bridge enqueueApplicationScript:rawText url:_scriptURL onComplete:^(NSError *error) {
+      dispatch_async(dispatch_get_main_queue(), ^{
+        [self bundleFinishedLoading:error];
+      });
+    }];
+
+  }];
+
+  [task resume];
+}
+
+- (void)setScriptURL:(NSURL *)scriptURL
+{
+  if ([_scriptURL isEqual:scriptURL]) {
+    return;
+  }
+
+  _scriptURL = scriptURL;
+  [self loadBundle];
+}
+
+- (void)reload
+{
+  [self loadBundle];
+}
+
++ (void)reloadAll
+{
+  [[NSNotificationCenter defaultCenter] postNotificationName:RCTReloadNotification object:nil];
+}
+
+- (void)startOrResetInteractionTiming
+{
+  [_touchHandler startOrResetInteractionTiming];
+}
+
+- (NSDictionary *)endAndResetInteractionTiming
+{
+  return [_touchHandler endAndResetInteractionTiming];
+}
+
+@end

--- a/ReactKit/Base/RCTUtils.h
+++ b/ReactKit/Base/RCTUtils.h
@@ -11,6 +11,9 @@
 extern "C" {
 #endif
 
+// NSNotification specifying that the application should reload its JavaScript and views
+extern NSString *const RCTReloadNotification;
+
 // Utility functions for JSON object <-> string serialization/deserialization
 NSString *RCTJSONStringify(id jsonObject, NSError **error);
 id RCTJSONParse(NSString *jsonString, NSError **error);

--- a/ReactKit/Base/RCTUtils.m
+++ b/ReactKit/Base/RCTUtils.m
@@ -5,11 +5,12 @@
 #import <mach/mach_time.h>
 #import <objc/runtime.h>
 
+#import <CommonCrypto/CommonCrypto.h>
 #import <UIKit/UIKit.h>
 
-#import <CommonCrypto/CommonCrypto.h>
-
 #import "RCTLog.h"
+
+NSString *const RCTReloadNotification = @"RCTReload";
 
 NSString *RCTJSONStringify(id jsonObject, NSError **error)
 {

--- a/ReactKit/Modules/RCTUIManager.h
+++ b/ReactKit/Modules/RCTUIManager.h
@@ -7,7 +7,7 @@
 #import "RCTInvalidating.h"
 #import "RCTViewManager.h"
 
-@class RCTRootView;
+@class RCTRootViewController;
 
 @protocol RCTScrollableProtocol;
 
@@ -25,11 +25,16 @@
 @property (nonatomic, readwrite, weak) id<UIScrollViewDelegate> nativeMainScrollDelegate;
 
 /**
- * Register a root view with the RCTUIManager. Theoretically, a single manager
- * can support multiple root views, however this feature is not currently exposed
- * and may eventually be removed.
+ * Register a root view controller with the RCTUIManager. Theoretically, a
+ * single manager can support multiple root views, however this feature is not
+ * currently exposed and may eventually be removed.
  */
-- (void)registerRootView:(RCTRootView *)rootView;
+- (void)registerRootViewController:(RCTRootViewController *)rootViewController;
+
+/**
+ * Removes the given root view controller from the RCTUIManager.
+ */
+- (void)removeRootViewController:(RCTRootViewController *)rootViewController;
 
 /**
  * Schedule a block to be executed on the UI thread. Useful if you need to execute

--- a/ReactKit/ReactKit.xcodeproj/project.pbxproj
+++ b/ReactKit/ReactKit.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		58114A171AAE854800E7D092 /* RCTPickerManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 58114A151AAE854800E7D092 /* RCTPickerManager.m */; };
 		58114A501AAE93D500E7D092 /* RCTAsyncLocalStorage.m in Sources */ = {isa = PBXBuildFile; fileRef = 58114A4E1AAE93D500E7D092 /* RCTAsyncLocalStorage.m */; };
 		58C571C11AA56C1900CDF9C8 /* RCTDatePickerManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 58C571BF1AA56C1900CDF9C8 /* RCTDatePickerManager.m */; };
+		78177F471A8DEDC700E0AFE1 /* RCTRootViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 78177F451A8DEDC700E0AFE1 /* RCTRootViewController.m */; };
 		830A229E1A66C68A008503DA /* RCTRootView.m in Sources */ = {isa = PBXBuildFile; fileRef = 830A229D1A66C68A008503DA /* RCTRootView.m */; };
 		830BA4551A8E3BDA00D53203 /* RCTCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 830BA4541A8E3BDA00D53203 /* RCTCache.m */; };
 		832348161A77A5AA00B55238 /* Layout.c in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FC71A68125100A75B9A /* Layout.c */; };
@@ -162,6 +163,8 @@
 		58114A4F1AAE93D500E7D092 /* RCTAsyncLocalStorage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTAsyncLocalStorage.h; sourceTree = "<group>"; };
 		58C571BF1AA56C1900CDF9C8 /* RCTDatePickerManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTDatePickerManager.m; sourceTree = "<group>"; };
 		58C571C01AA56C1900CDF9C8 /* RCTDatePickerManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTDatePickerManager.h; sourceTree = "<group>"; };
+		78177F451A8DEDC700E0AFE1 /* RCTRootViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTRootViewController.m; sourceTree = "<group>"; };
+		78177F461A8DEDC700E0AFE1 /* RCTRootViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTRootViewController.h; sourceTree = "<group>"; };
 		830213F31A654E0800B993E6 /* RCTBridgeModule.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RCTBridgeModule.h; sourceTree = "<group>"; };
 		830A229C1A66C68A008503DA /* RCTRootView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTRootView.h; sourceTree = "<group>"; };
 		830A229D1A66C68A008503DA /* RCTRootView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTRootView.m; sourceTree = "<group>"; };
@@ -370,6 +373,9 @@
 				83CBBA591A601E9000E9B192 /* RCTRedBox.m */,
 				830A229C1A66C68A008503DA /* RCTRootView.h */,
 				830A229D1A66C68A008503DA /* RCTRootView.m */,
+				78177F461A8DEDC700E0AFE1 /* RCTRootViewController.h */,
+				78177F451A8DEDC700E0AFE1 /* RCTRootViewController.m */,
+				13B07FCD1A683B5F00A75B9A /* RCTScrollableProtocol.h */,
 				83BEE46C1A6D19BC00B5863B /* RCTSparseArray.h */,
 				83BEE46D1A6D19BC00B5863B /* RCTSparseArray.m */,
 				83CBBA961A6020BB00E9B192 /* RCTTouchHandler.h */,
@@ -461,6 +467,8 @@
 				13B07FEF1A69327A00A75B9A /* RCTAlertManager.m in Sources */,
 				83CBBACC1A6023D300E9B192 /* RCTConvert.m in Sources */,
 				830A229E1A66C68A008503DA /* RCTRootView.m in Sources */,
+				78177F471A8DEDC700E0AFE1 /* RCTRootViewController.m in Sources */,
+				1302F0FD1A78550100EBEF02 /* RCTStaticImage.m in Sources */,
 				13B07FF01A69327A00A75B9A /* RCTExceptionsManager.m in Sources */,
 				83CBBA5A1A601E9000E9B192 /* RCTRedBox.m in Sources */,
 				83CBBA511A601E3B00E9B192 /* RCTAssert.m in Sources */,


### PR DESCRIPTION
Introduces RCTRootViewController, which handles the controller-appropriate work that RCTRootView was doing. This decouples the view from the script loading and JS environment setup (w/the bridge), which helps ReactKit be less of a framework and more of a library.

One thing that's valuable about moving in this direction is that the more the initialization of the JS environment can be customized (while still providing convenience classes & methods for small apps), the more it encourages established apps to try out ReactKit. I believe this is especially true for apps that use something like Cordova, ex: using the existing Cordova web view's JS context to run React Native and slowly replacing bits of Cordova.

The example apps have been updated and work. On the Facebook side you will need to replace RCTRootView with RCTRootViewController which should be fairly mechanical with VC containment (I hope!)
