### PR TITLE
[Lint] Update space-unary-ops rule in eslintrc (fixes Atom linter crash)

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -175,7 +175,7 @@
     "space-in-parens": 0,            // require or disallow spaces inside parentheses (off by default)
     "space-infix-ops": 1,            // require spaces around operators
     "space-return-throw-case": 1,    // require a space after return, throw, and case
-    "space-unary-word-ops": 1,       // require a space around word operators such as typeof (off by default)
+    "space-unary-ops": [1, { "words": true, "nonwords": false }], // require or disallow spaces before/after unary operators (words on by default, nonwords off by default)
     "max-nested-callbacks": 0,       // specify the maximum depth callbacks can be nested (off by default)
     "one-var": 0,                    // allow just one var statement per function (off by default)
     "wrap-regex": 0,                 // require regex literals to be wrapped in parentheses (off by default)


### PR DESCRIPTION
`space-unary-word-ops` was replaced with `space-unary-ops`. This fixes an error in Atom with linter-eslint installed: https://github.com/AtomLinter/linter-eslint/issues/24