### PR TITLE
[Images] Bail out when GIF data is in unexpected format instead of crashing

### DIFF
--- a/ReactKit/Base/RCTConvert.m
+++ b/ReactKit/Base/RCTConvert.m
@@ -446,6 +446,9 @@ RCT_STRUCT_CONVERTER(CGAffineTransform, (@[@"a", @"b", @"c", @"d", @"tx", @"ty"]
     }
 
     imageSource = CGImageSourceCreateWithData((CFDataRef)data, NULL);
+  } else {
+      RCTLogMustFix(@"Expected NSString or NSData for GIF, received %@: %@", [json class], json);
+      return nil;
   }
 
   if (!UTTypeConformsTo(CGImageSourceGetType(imageSource), kUTTypeGIF)) {


### PR DESCRIPTION
When the GIF data is not a string nor NSData, `imageSource` is some unknown value set to whatever memory was on the stack. Calling `CGImageSourceGetType` on it has undefined behavior, and if it makes through to the CFRelease (maybe because it is NULL) then CFRelease will crash. This fixes a clang warning.
