### PR TITLE
[Text] Ensure that the text background is transparent by default

### DIFF
--- a/Libraries/Text/RCTText.m
+++ b/Libraries/Text/RCTText.m
@@ -33,6 +33,7 @@
     _textStorage = [[NSTextStorage alloc] init];
     [_textStorage addLayoutManager:_layoutManager];
 
+    self.opaque = NO;
     self.contentMode = UIViewContentModeRedraw;
   }
 


### PR DESCRIPTION
For a very simple view I was observing that the text background was black and had to manually be set to transparent. This ensures that text nodes have a transparent background by default.

Test Plan: This example component no longer renders what looks like a black block, and instead displays legible text.

    var Example = React.createClass({
      render: function() {
          return (
            <View style={styles.container}>
              <Text>hello</Text>
            </View>
          );
      },
    });

    var styles = StyleSheet.create({
      container: {
        flex: 1,
      },
    };