### PR TITLE
[Image] Really improve the quality of mis-sized images w/trilinear filtering

### DIFF
--- a/ReactKit/Views/RCTNetworkImageView.m
+++ b/ReactKit/Views/RCTNetworkImageView.m
@@ -52,6 +52,8 @@
     if (reset) {
       self.layer.contentsScale = _defaultImage.scale;
       self.layer.contents = (__bridge id)_defaultImage.CGImage;
+      self.layer.minificationFilter = kCAFilterTrilinear;
+      self.layer.magnificationFilter = kCAFilterTrilinear;
     }
     if ([imageURL.pathExtension caseInsensitiveCompare:@"gif"] == NSOrderedSame) {
       _downloadToken = [_imageDownloader downloadDataForURL:imageURL block:^(NSData *data, NSError *error) {
@@ -61,6 +63,8 @@
           self.layer.bounds = CGRectMake(0, 0, CGImageGetWidth(firstFrame), CGImageGetHeight(firstFrame));
           self.layer.contentsScale = 1.0;
           self.layer.contentsGravity = kCAGravityResizeAspect;
+          self.layer.minificationFilter = kCAFilterLinear;
+          self.layer.magnificationFilter = kCAFilterLinear;
           [self.layer addAnimation:animation forKey:@"contents"];
         }
         // TODO: handle errors

--- a/ReactKit/Views/RCTStaticImage.m
+++ b/ReactKit/Views/RCTStaticImage.m
@@ -20,6 +20,10 @@
   if (!UIEdgeInsetsEqualToEdgeInsets(UIEdgeInsetsZero, _capInsets)) {
     image = [image resizableImageWithCapInsets:_capInsets resizingMode:UIImageResizingModeStretch];
   }
+
+  // Apply trilinear filtering to smooth out mis-sized images
+  self.layer.minificationFilter = kCAFilterTrilinear;
+  self.layer.magnificationFilter = kCAFilterTrilinear;
   
   super.image = image;
 }


### PR DESCRIPTION
Images whose intrinsic dimensions don't match the view's dimensions suffer from jaggies. Applying `kCAFilterTrilinear` makes this way better. If you accurately size your images then there's no difference, good job (y)

I left GIFs using the default linear filtering since they are more intensive to begin with and GIFs are generally for animation these days anyway.
