### PR TITLE
[Text] Account for font leading so descenders are not clipped

### DIFF
--- a/Libraries/Text/RCTShadowText.m
+++ b/Libraries/Text/RCTShadowText.m
@@ -14,7 +14,9 @@ NSString *const RCTReactTagAttributeName = @"ReactTagAttributeName";
 static css_dim_t RCTMeasure(void *context, float width)
 {
   RCTShadowText *shadowText = (__bridge RCTShadowText *)context;
-  CGSize computedSize = [[shadowText attributedString] boundingRectWithSize:(CGSize){isnan(width) ? CGFLOAT_MAX : width, CGFLOAT_MAX} options:NSStringDrawingUsesLineFragmentOrigin context:nil].size;
+  CGSize computedSize = [[shadowText attributedString] boundingRectWithSize:(CGSize){isnan(width) ? CGFLOAT_MAX : width, CGFLOAT_MAX}
+                                                                    options:NSStringDrawingUsesLineFragmentOrigin | NSStringDrawingUsesFontLeading
+                                                                    context:nil].size;
   
   css_dim_t result;
   result.dimensions[CSS_WIDTH] = RCTCeilPixelValue(computedSize.width);


### PR DESCRIPTION
Prior to this diff, descenders (the hanging tail on letters like g and j) were clipped on the last line because the text measurer did not account for the font leading. With `NSStringDrawingUsesFontLeading` it honors the fonts line spacing.

To test: open the Text demo of the UIExplorer and see that the bottom of the letter g is no longer clipped off.
## Before

![Screenshot Before](https://cloud.githubusercontent.com/assets/379606/6364746/1c5527a0-bc60-11e4-8aeb-2147a6eb6596.png)
## After

![Screenshot After](https://cloud.githubusercontent.com/assets/379606/6364747/1e9abe58-bc60-11e4-8c34-9f20ad8572ff.png)
