### PR TITLE
[ListView] Make LVDS.getSectionLengths() be indexed by section ID

### DIFF
--- a/Libraries/Components/ListView/ListViewDataSource.js
+++ b/Libraries/Components/ListView/ListViewDataSource.js
@@ -245,12 +245,14 @@ class ListViewDataSource {
   }
 
   /**
-   * Returns an array containing the number of rows in each section
+   * Returns a mapping from sectionIDs to the number of rows in each respective
+   * section
    */
-  getSectionLengths(): Array<number> {
-    var results = [];
+  getSectionLengths(): {[key: string], number} {
+    var results = {};
     for (var ii = 0; ii < this.sectionIdentities.length; ii++) {
-      results.push(this.rowIdentities[ii].length);
+      var sectionID = this.sectionIdentities[ii];
+      results[sectionID] = this.rowIdentities[ii].length;
     }
     return results;
   }


### PR DESCRIPTION
Currently ListViewDataSource.getSectionLengths() returns an array of section lengths, where the nth element of the array is the number of rows in the nth section. There is a tiny bit of an API mismatch since elsewhere section IDs, which are strings, are primarily used. This diff changes getSectionLengths to return an object whose keys are section IDs and values are the number of rows in each respective section.

Before: `[10, 20, 30]`
After: `{firstSection: 10, secondSection: 20, thirdSection: 30}`
