### PR TITLE
Fix property name in ExpandingText.js

### DIFF
--- a/Libraries/Text/ExpandingText.js
+++ b/Libraries/Text/ExpandingText.js
@@ -32,7 +32,7 @@ var styles = StyleSheet.create({
  * More example code in `ExpandingTextExample.js`
  */
 var ExpandingText = React.createClass({
-  PropTypes: {
+  propTypes: {
     /**
      * Text to be displayed. Text will be truncated if the character length
      * is greater than the truncLength property.


### PR DESCRIPTION
I believe this is a typo. With this fix, the props are displayed properly:

![screen shot 2015-03-05 at 12 42 47 am](https://cloud.githubusercontent.com/assets/179026/6501726/c9bad0a4-c2d0-11e4-846a-38a4842e1d55.png)
