### PR TITLE
[TouchableHighlight] Preserve underlay style when restoring inactive props

### DIFF
--- a/Libraries/Components/Touchable/TouchableHighlight.js
+++ b/Libraries/Components/Touchable/TouchableHighlight.js
@@ -156,7 +156,10 @@ var TouchableHighlight = React.createClass({
     this._hideTimeout = null;
     if (this.refs[UNDERLAY_REF]) {
       this.refs[CHILD_REF].setNativeProps(INACTIVE_CHILD_PROPS);
-      this.refs[UNDERLAY_REF].setNativeProps(INACTIVE_UNDERLAY_PROPS);
+      this.refs[UNDERLAY_REF].setNativeProps({
+        ...INACTIVE_UNDERLAY_PROPS,
+        style: this.state.underlayStyle,
+      });
     }
   },
 


### PR DESCRIPTION
If you give a TouchableHighlight component some styling (e.g. a background color) with the `underlayStyle` prop, the style is wiped away after touching the component. This diff restores the `underlayStyle`.

Test Plan: Create a TouchableHighlight that receives `underlayStyle={{style:
'blue'}}`. It initially has a blue background. Touch it and let go. See the blue background now comes back as expected.
