### PR TITLE
Fix reference to GeoLocationExample

### DIFF
--- a/Examples/UIExplorer/GeoLocationExample.js
+++ b/Examples/UIExplorer/GeoLocationExample.js
@@ -1,7 +1,7 @@
 /**
  * Copyright 2004-present Facebook. All Rights Reserved.
  *
- * @providesModule GeolocationExample
+ * @providesModule GeoLocationExample
  */
 /* eslint no-console: 0 */
 'use strict';

--- a/Examples/UIExplorer/UIExplorerList.js
+++ b/Examples/UIExplorer/UIExplorerList.js
@@ -32,7 +32,7 @@ var EXAMPLES = [
   require('./ActivityIndicatorExample'),
   require('./ScrollViewExample'),
   require('./DatePickerExample'),
-  require('./GeolocationExample'),
+  require('./GeoLocationExample'),
   require('./TabBarExample'),
   require('./SwitchExample'),
   require('./SliderExample'),


### PR DESCRIPTION
Tiny PR to fix the UIExplorer app, which currently won't run after Friday's updates.
