### PR TITLE
[website] the react npm package doesn't capitalize the r

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -3,7 +3,7 @@
     "start": "node server/server.js"
   },
   "dependencies": {
-    "React": "~0.12.0",
+    "react": "~0.12.0",
     "optimist": "0.6.0",
     "react-page-middleware": "git://github.com/facebook/react-page-middleware.git",
     "connect": "2.8.3",


### PR DESCRIPTION
Without this `npm install` fails.
With this, `npm install` works as expected.
