### PR TITLE
NavigatorIOS - Enable barTintColor and titleTextColor props

### DIFF
--- a/Libraries/Components/Navigation/NavigatorIOS.ios.js
+++ b/Libraries/Components/Navigation/NavigatorIOS.ios.js
@@ -506,7 +506,9 @@ var NavigatorIOS = React.createClass({
           backButtonTitle={route.backButtonTitle}
           rightButtonTitle={route.rightButtonTitle}
           onNavRightButtonTap={route.onRightButtonPress}
-          tintColor={this.props.tintColor}>
+          tintColor={this.props.tintColor}
+          barTintColor={this.props.barTintColor}
+          titleTextColor={this.props.titleTextColor}>
           <Component
             navigator={this.navigator}
             route={route}

--- a/ReactKit/Views/RCTWrapperViewController.m
+++ b/ReactKit/Views/RCTWrapperViewController.m
@@ -70,10 +70,7 @@
       bar.barTintColor = _navItem.barTintColor;
     }
     if (_navItem.tintColor) {
-      BOOL canSetTintColor = _navItem.barTintColor == nil;
-      if (canSetTintColor) {
-        bar.tintColor = _navItem.tintColor;
-      }
+      bar.tintColor = _navItem.tintColor;
     }
     if (_navItem.titleTextColor) {
       [bar setTitleTextAttributes:@{NSForegroundColorAttributeName : _navItem.titleTextColor}];


### PR DESCRIPTION
I assume these props were ignored for a reason. Curious as to why as they seem to behave properly for me. So... a question wrapped in code :)
