### PR TITLE
[Tests] Fix FileWatcher

### DIFF
--- a/packager/react-packager/src/FileWatcher/__tests__/FileWatcher-test.js
+++ b/packager/react-packager/src/FileWatcher/__tests__/FileWatcher-test.js
@@ -20,7 +20,7 @@ describe('FileWatcher', function() {
     });
   });
 
-  it('it should get the watcher instance when ready', function() {
+  pit('it should get the watcher instance when ready', function() {
     var fileWatcher = new FileWatcher(['rootDir']);
     return fileWatcher._loading.then(function(watchers) {
       watchers.forEach(function(watcher) {


### PR DESCRIPTION
Need to use `pit` instead of `it`. I changed .toBe(false) instead of .toBe(true) just to make sure that the content is actually executed

![screen shot 2015-03-14 at 11 37 36 am](https://cloud.githubusercontent.com/assets/197597/6652995/8c7be776-ca3e-11e4-902c-e47386d48f08.png)
