### PR TITLE
Return the appropriate status code from XHR

### DIFF
--- a/Libraries/Network/RCTDataManager.m
+++ b/Libraries/Network/RCTDataManager.m
@@ -50,8 +50,9 @@
         } else {
           encoding = NSUTF8StringEncoding;
         }
+        int responseCode = (int)[((NSHTTPURLResponse *)response) statusCode];
         NSString *returnData = [[NSString alloc] initWithData:data encoding:encoding];
-        responseJSON = @{@"status": @200, @"responseText": returnData};
+        responseJSON = @{@"status": @(responseCode), @"responseText": returnData};
       } else {
         responseJSON = @{@"status": @0, @"responseText": [connectionError localizedDescription]};
       }


### PR DESCRIPTION
Some libraries use the HTTP status code to interact with APIs. Rather than hardcoding the response code to 200, this sets the server-reported status code as the `status` property of an XHR instance.
