### PR TITLE
Manually start packager and print logs when tests fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_script:
 script: ./build.sh 8.1
 
 after_script:
-  - pkill -9 `cat packager.pid`
+  - pkill -9 -F packager.pid
   - cat packager.log
   - rm packager.log
   - rm packager.pid


### PR DESCRIPTION
Checking if this can help us debug problems in future. The idea is to run packager before build and save its output to a log file. After test runs we will print the content of the log.
