### PR TITLE
Allow react-native init <project-or-dir-name>

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -38,8 +38,8 @@ function run() {
   // Here goes any cli commands we need to
 }
 
-function init() {
-  spawn('sh', [path.resolve(__dirname, 'init.sh')], {stdio:'inherit'});
+function init(root, projectName) {
+  spawn(path.resolve(__dirname, 'init.sh'), [projectName], {stdio:'inherit'});
 }
 
 module.exports = {

--- a/init.sh
+++ b/init.sh
@@ -14,7 +14,7 @@ def cp(src, dest, app_name)
 end
 
 def main(dest, app_name)
-  source = File.expand_path("../../Examples/SampleApp", __FILE__)
+  source = File.expand_path("../Examples/SampleApp", __FILE__)
   files = Dir.chdir(source) { Dir["**/*"] }
     .reject { |file| file["project.xcworkspace"] || file["xcuserdata"] }
     .each { |file|

--- a/react-native-cli/index.js
+++ b/react-native-cli/index.js
@@ -8,16 +8,18 @@ var fs = require('fs');
 var path = require('path');
 var spawn = require('child_process').spawn;
 
-var CLI_MODULE_PATH = path.resolve(
-  process.cwd(),
-  'node_modules',
-  'react-native',
-  'cli'
-);
+var CLI_MODULE_PATH = function() {
+  return path.resolve(
+    process.cwd(),
+    'node_modules',
+    'react-native',
+    'cli'
+  );
+};
 
 var cli;
 try {
-  cli = require(CLI_MODULE_PATH);
+  cli = require(CLI_MODULE_PATH());
 } catch(e) {}
 
 if (cli) {
@@ -66,7 +68,10 @@ function init(name) {
   var packageJson = {
     name: projectName,
     version: '0.0.1',
-    private: true
+    private: true,
+    scripts: {
+      start: "react-native start"
+    }
   };
   fs.writeFileSync(path.join(root, 'package.json'), JSON.stringify(packageJson));
   process.chdir(root);
@@ -77,7 +82,7 @@ function init(name) {
       process.exit(1);
     }
 
-    var cli = require(CLI_MODULE_PATH);
+    var cli = require(CLI_MODULE_PATH());
     cli.init(root, projectName);
   });
 }


### PR DESCRIPTION
1. This allows `react-native init .` or `react-native init MyAwesomeProject`. No need to create folder, cd into it and run `react-native`. Rails does it like this.
2. Instead of doing `npm init` it just creates a `package.json` file. `npm init` asks way too many questions if all user wants is to start a new project.

cc @amasad , @vjeux 
