### PR TITLE
Increase base font-weight

### DIFF
--- a/website/src/react-native/css/react-native.css
+++ b/website/src/react-native/css/react-native.css
@@ -1,7 +1,6 @@
 html {
   font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
   font-family: proxima-nova, "Helvetica Neue", Helvetica, Arial, sans-serif;
-  font-weight: 300;
   color: #484848;
   line-height: 1.28;
 }
@@ -16,7 +15,7 @@ p {
 
 .subHeader {
   font-size: 21px;
-  font-weight: 200;
+  font-weight: 300;
   line-height: 30px;
   margin-bottom: 10px;
 }


### PR DESCRIPTION
300 is too light for an already light typeface, especially on body type.

We can probably get away with it on headers but I'll leave the rest as is. The hero unit is the only other place where numeric weights are used but I didn't check those.
