### PR TITLE
Making console write to the Safari debugger console as well as NSLog

### DIFF
--- a/React.podspec
+++ b/React.podspec
@@ -25,7 +25,6 @@ Pod::Spec.new do |s|
   s.frameworks   = "JavaScriptCore"
   s.requires_arc = true
   s.prepare_command = 'npm install'
-  s.libraries    = 'icucore'
 
   s.subspec 'RCTActionSheet' do |ss|
     ss.source_files = "Libraries/ActionSheetIOS/*.{h,m}"
@@ -64,6 +63,7 @@ Pod::Spec.new do |s|
 
   s.subspec 'RCTWebSocketDebugger' do |ss|
     ss.source_files = "Libraries/RCTWebSocketDebugger/*.{h,m}"
+    ss.libraries    = 'icucore'
   end
 
   s.subspec 'RCTText' do |ss|

--- a/React.podspec
+++ b/React.podspec
@@ -1,78 +1,93 @@
 Pod::Spec.new do |s|
-  s.name         = "React"
-  s.version      = "0.3.1"
-  s.summary      = "Build high quality mobile apps using React."
-  s.description= <<-DESC
-                   React Native apps are built using the React JS framework,
-                   and render directly to native UIKit elements using a fully
-                   asynchronous architecture. There is no browser and no HTML.
-                   We have picked what we think is the best set of features from
-                   these and other technologies to build what we hope to become
-                   the best product development framework available, with an
-                   emphasis on iteration speed, developer delight, continuity
-                   of technology, and absolutely beautiful and fast products
-                   with no compromises in quality or capability.
-                   DESC
-  s.homepage     = "http://facebook.github.io/react-native/"
-  s.license      = "BSD"
-  s.author       = "Facebook"
-  s.platform     = :ios, "7.0"
-  s.source       = { :git => "https://github.com/facebook/react-native.git", :tag => "v#{s.version}" }
-  s.source_files = "React/**/*.{c,h,m}"
-  s.resources    = "Resources/*.png"
-  s.preserve_paths = "cli.js", "Libraries/**/*.js", "lint", "linter.js", "node_modules", "package.json", "packager", "PATENTS", "react-native-cli"
-  s.exclude_files = "**/__tests__/*", "IntegrationTests/*"
-  s.frameworks   = "JavaScriptCore"
-  s.requires_arc = true
-  s.prepare_command = 'npm install'
+  s.name               = "React"
+  s.version            = "0.3.1"
+  s.summary            = "Build high quality mobile apps using React."
+  s.description        = <<-DESC
+                           React Native apps are built using the React JS
+                           framework, and render directly to native UIKit
+                           elements using a fully asynchronous architecture.
+                           There is no browser and no HTML. We have picked what
+                           we think is the best set of features from these and
+                           other technologies to build what we hope to become
+                           the best product development framework available,
+                           with an emphasis on iteration speed, developer
+                           delight, continuity of technology, and absolutely
+                           beautiful and fast products with no compromises in
+                           quality or capability.
+                        DESC
+  s.homepage           = "http://facebook.github.io/react-native/"
+  s.license            = "BSD"
+  s.author             = "Facebook"
+  s.source             = { :git => "https://github.com/facebook/react-native.git", :tag => "v#{s.version}" }
+  s.default_subspec    = 'Core'
+  s.requires_arc       = true
+  s.platform           = :ios, "7.0"
+  s.prepare_command    = 'npm install'
+  s.preserve_paths     = "cli.js", "Libraries/**/*.js", "lint", "linter.js", "node_modules", "package.json", "packager", "PATENTS", "react-native-cli"
+
+  s.subspec 'Core' do |ss|
+    ss.source_files    = "React/**/*.{c,h,m}"
+    ss.exclude_files   = "**/__tests__/*", "IntegrationTests/*"
+    ss.frameworks      = "JavaScriptCore"
+  end
 
   s.subspec 'RCTActionSheet' do |ss|
-    ss.source_files = "Libraries/ActionSheetIOS/*.{h,m}"
+    ss.dependency       'React/Core'
+    ss.source_files   = "Libraries/ActionSheetIOS/*.{h,m}"
     ss.preserve_paths = "Libraries/ActionSheetIOS/*.js"
   end
 
   s.subspec 'RCTAdSupport' do |ss|
-    ss.source_files = "Libraries/RCTAdSupport/*.{h,m}"
-    ss.preserve_paths = "Libraries/RCTAdSupport/*.js"
+    ss.dependency        'React/Core'
+    ss.source_files    = "Libraries/AdSupport/*.{h,m}"
+    ss.preserve_paths  = "Libraries/AdSupport/*.js"
   end
 
   s.subspec 'RCTAnimation' do |ss|
-    ss.source_files = "Libraries/Animation/*.{h,m}"
-    ss.preserve_paths = "Libraries/Animation/*.js"
+    ss.dependency        'React/Core'
+    ss.source_files    = "Libraries/Animation/*.{h,m}"
+    ss.preserve_paths  = "Libraries/Animation/*.js"
   end
 
   s.subspec 'RCTGeolocation' do |ss|
-    ss.source_files = "Libraries/Geolocation/*.{h,m}"
-    ss.preserve_paths = "Libraries/Geolocation/*.js"
+    ss.dependency        'React/Core'
+    ss.source_files    = "Libraries/Geolocation/*.{h,m}"
+    ss.preserve_paths  = "Libraries/Geolocation/*.js"
   end
 
   s.subspec 'RCTImage' do |ss|
-    ss.source_files = "Libraries/Image/*.{h,m}"
-    ss.preserve_paths = "Libraries/Image/*.js"
+    ss.dependency        'React/Core'
+    ss.source_files    = "Libraries/Image/*.{h,m}"
+    ss.preserve_paths  = "Libraries/Image/*.js"
   end
 
   s.subspec 'RCTNetwork' do |ss|
-    ss.source_files = "Libraries/Network/*.{h,m}"
-    ss.preserve_paths = "Libraries/Network/*.js"
+    ss.dependency        'React/Core'
+    ss.source_files    = "Libraries/Network/*.{h,m}"
+    ss.preserve_paths  = "Libraries/Network/*.js"
   end
 
   s.subspec 'RCTPushNotification' do |ss|
-    ss.source_files = "Libraries/PushNotificationIOS/*.{h,m}"
-    ss.preserve_paths = "Libraries/PushNotificationIOS/*.js"
+    ss.dependency        'React/Core'
+    ss.source_files    = "Libraries/PushNotificationIOS/*.{h,m}"
+    ss.preserve_paths  = "Libraries/PushNotificationIOS/*.js"
   end
 
   s.subspec 'RCTWebSocketDebugger' do |ss|
-    ss.source_files = "Libraries/RCTWebSocketDebugger/*.{h,m}"
-    ss.libraries    = 'icucore'
+    ss.libraries       = 'icucore'
+    ss.dependency        'React/Core'
+    ss.source_files    = "Libraries/RCTWebSocketDebugger/*.{h,m}"
   end
 
   s.subspec 'RCTText' do |ss|
-    ss.source_files = "Libraries/Text/*.{h,m}"
-    ss.preserve_paths = "Libraries/Text/*.js"
+    ss.dependency        'React/Core'
+    ss.source_files    = "Libraries/Text/*.{h,m}"
+    ss.preserve_paths  = "Libraries/Text/*.js"
   end
 
   s.subspec 'RCTVibration' do |ss|
-    ss.source_files = "Libraries/Vibration/*.{h,m}"
-    ss.preserve_paths = "Libraries/Vibration/*.js"
+    ss.dependency        'React/Core'
+    ss.source_files    = "Libraries/Vibration/*.{h,m}"
+    ss.preserve_paths  = "Libraries/Vibration/*.js"
   end
 end


### PR DESCRIPTION
We still write to NSLog or similar as well

There may be some performance penalty but I don't think so unless the REPL
window is open. It would not be hard to add a flag to this if necessary.
This will definitely make debugging and development easier.