### PR TITLE
[CLI] react-native start won't run from dir with spaces

### DIFF
--- a/packager/packager.sh
+++ b/packager/packager.sh
@@ -10,4 +10,4 @@
 ulimit -n 4096
 
 THIS_DIR=$(dirname "$0")
-node $THIS_DIR/packager.js "$@"
+node "$THIS_DIR/packager.js" "$@"


### PR DESCRIPTION
Running "react-native start" from /Users/kevin/Dropbox (Personal)/Projects/AwesomeProject/ produces the following error

Error: Cannot find module '/Users/kevin/Dropbox'
    at Function.Module._resolveFilename (module.js:322:15)
    at Function.Module._load (module.js:264:25)
    at Function.Module.runMain (module.js:487:10)
    at startup (node.js:111:16)
    at node.js:809:3