### PR TITLE
Lint code - change double quotes to single in website/jsdocs

### DIFF
--- a/website/jsdocs/TypeExpressionParser.js
+++ b/website/jsdocs/TypeExpressionParser.js
@@ -8,7 +8,7 @@
  */
 
 /*global exports:true*/
-"use strict";
+'use strict';
 
 var Syntax = require('esprima-fb').Syntax;
 
@@ -25,7 +25,7 @@ function reverseObject(/*object*/ object) /*object*/ {
   var reversed = {};
   for (var key in object) {
     if (object.hasOwnProperty(key)) {
-      reversed[object[key]] = key
+      reversed[object[key]] = key;
     }
   }
   return reversed;
@@ -452,16 +452,16 @@ exports.popTypeVariables = popTypeVariables;
 function fromFlowAnnotation(/*object*/ annotation, state) /*?object*/ {
   var ast;
   switch (annotation.type) {
-    case "NumberTypeAnnotation":
-      return createAst(SYMBOLS.SIMPLE, "number", 0);
-    case "StringTypeAnnotation":
-      return createAst(SYMBOLS.SIMPLE, "string", 0);
-    case "BooleanTypeAnnotation":
-      return createAst(SYMBOLS.SIMPLE, "boolean", 0);
-    case "AnyTypeAnnotation": // fallthrough
-    case "VoidTypeAnnotation":
+    case 'NumberTypeAnnotation':
+      return createAst(SYMBOLS.SIMPLE, 'number', 0);
+    case 'StringTypeAnnotation':
+      return createAst(SYMBOLS.SIMPLE, 'string', 0);
+    case 'BooleanTypeAnnotation':
+      return createAst(SYMBOLS.SIMPLE, 'boolean', 0);
+    case 'AnyTypeAnnotation': // fallthrough
+    case 'VoidTypeAnnotation':
       return null;
-    case "NullableTypeAnnotation":
+    case 'NullableTypeAnnotation':
       ast = fromFlowAnnotation(annotation.typeAnnotation, state);
       if (ast) {
         ast.nullable = true;
@@ -486,10 +486,10 @@ function fromFlowAnnotation(/*object*/ annotation, state) /*?object*/ {
       // to render a simple function instead of a detailed one
       if ((params.length || returnType)
            && params.length === annotation.params.length) {
-        return createAst(SYMBOLS.FUNCTION, [params, returnType], 0)
+        return createAst(SYMBOLS.FUNCTION, [params, returnType], 0);
       }
       return createAst(SYMBOLS.SIMPLE, 'function', 0);
-    case "GenericTypeAnnotation":
+    case 'GenericTypeAnnotation':
       var alias = getTypeAlias(annotation.id, state);
       if (alias) {
         return fromFlowAnnotation(alias, state);
@@ -497,7 +497,7 @@ function fromFlowAnnotation(/*object*/ annotation, state) /*?object*/ {
 
       // Qualified type identifiers are not handled by runtime typechecker,
       // so simply omit the annotation for now.
-      if (annotation.id.type === "QualifiedTypeIdentifier") {
+      if (annotation.id.type === 'QualifiedTypeIdentifier') {
         return null;
       }
 
@@ -521,12 +521,12 @@ function fromFlowAnnotation(/*object*/ annotation, state) /*?object*/ {
       );
 
       switch (name) {
-        case "mixed": // fallthrough
-        case "$Enum":
+        case 'mixed': // fallthrough
+        case '$Enum':
           // Not supported
           return null;
-        case "array": // fallthrough
-        case "promise":
+        case 'array': // fallthrough
+        case 'promise':
           if (annotation.typeParameters) {
             var parametricAst = fromFlowAnnotation(
               annotation.typeParameters.params[0],

--- a/website/jsdocs/findExportDefinition.js
+++ b/website/jsdocs/findExportDefinition.js
@@ -8,7 +8,7 @@
  */
 
 /*jslint node: true */
-"use strict";
+'use strict';
 
 var esprima = require('esprima-fb');
 var Syntax = esprima.Syntax;
@@ -278,6 +278,6 @@ function findExportDefinition(ast) {
   }
 
   return null;
-};
+}
 
 module.exports = findExportDefinition;

--- a/website/jsdocs/generic-function-visitor.js
+++ b/website/jsdocs/generic-function-visitor.js
@@ -9,7 +9,7 @@
 
 /*global exports:true*/
 /*jslint node:true*/
-"use strict";
+'use strict';
 
 var util = require('util');
 
@@ -278,7 +278,7 @@ function renderParams(/*?object*/ params) /*string*/ {
     var returnParam = '\"returns\":' + '\'' + params.returns + '\'';
     formattedParams.push(returnParam);
   }
-  return "{" + formattedParams.join(',') + "}";
+  return '{' + formattedParams.join(',') + '}';
 }
 
 function getModuleName(state) {

--- a/website/jsdocs/jsdocs.js
+++ b/website/jsdocs/jsdocs.js
@@ -8,7 +8,7 @@
  */
 
 /*jslint node: true */
-"use strict";
+'use strict';
 
 var esprima = require('esprima-fb');
 var fs = require('fs');
@@ -17,7 +17,7 @@ var Syntax = esprima.Syntax;
 var findExportDefinition = require('./findExportDefinition');
 var genericTransform = require('./generic-function-visitor');
 var genericVisitor = genericTransform.visitorList[0];
-var traverseFlat = require('./traverseFlat')
+var traverseFlat = require('./traverseFlat');
 var parseTypehint = require('./TypeExpressionParser').parse;
 
 // Don't save object properties source code that is longer than this
@@ -76,7 +76,7 @@ function stripStaticUpstreamWarning(docblock) {
     return docblock;
   }
   // Esprima strips out the starting and ending tokens, so add them back
-  docblock = "/*" + docblock + "*/\n";
+  docblock = '/*' + docblock + '*/\n';
   return docblock;
 }
 
@@ -104,13 +104,13 @@ function getFileDocBlock(commentsForFile) {
   var docblock;
   commentsForFile.some(function(comment, i) {
     if (comment.loc.start.line === 1) {
-      var lines = comment.value.split("\n");
+      var lines = comment.value.split('\n');
       var filteredLines = lines.filter(function(line) {
         var hasCopyright = !!line.match(/^\s*\*\s+Copyright/);
         var hasProvides = !!line.match(/^\s*\*\s+@provides/);
         return !hasCopyright && !hasProvides;
       });
-      docblock = filteredLines.join("\n");
+      docblock = filteredLines.join('\n');
       return true;
     }
   });
@@ -149,7 +149,7 @@ function getDocBlock(node, commentsForFile, linesForFile) {
           var lineComment = commentsForFile[ii];
           if (lineComment.loc.end.line === line) {
             docblock = '//' + lineComment.value +
-              (docblock ? "\n" + docblock : "");
+              (docblock ? '\n' + docblock : '');
             line--;
           } else {
             break;
@@ -463,7 +463,7 @@ function getRequireData(node) {
  * @return {?object} data
  */
 function parseSource(source) {
-  var lines = source.split("\n");
+  var lines = source.split('\n');
   var ast = esprima.parse(source, {
     loc: true,
     comment: true,

--- a/website/jsdocs/meta.js
+++ b/website/jsdocs/meta.js
@@ -9,7 +9,7 @@
 
 /*global exports:true*/
 /*jslint node:true*/
-"use strict";
+'use strict';
 
 var util = require('util');
 

--- a/website/jsdocs/traverseFlat.js
+++ b/website/jsdocs/traverseFlat.js
@@ -9,7 +9,7 @@
 
 /*global exports:true*/
 /*jslint node:true*/
-"use strict";
+'use strict';
 
 var Syntax = require('esprima-fb').Syntax;
 

--- a/website/jsdocs/type.js
+++ b/website/jsdocs/type.js
@@ -8,7 +8,7 @@
  */
 
 /*global exports:true*/
-"use strict";
+'use strict';
 
 var util = require('util');
 


### PR DESCRIPTION
Lint code, change double to single quotes where applicable. Add/Remove semicolons where needed to reflect code style.

**website/jsdocs/**