### PR TITLE
Add additional keyboardTypes to TextInput

### DIFF
--- a/Examples/UIExplorer/TextInputExample.js
+++ b/Examples/UIExplorer/TextInputExample.js
@@ -160,6 +160,65 @@ exports.examples = [
     }
   },
   {
+    title: 'Keyboard type',
+    render: function() {
+      return (
+        <View>
+          <TextInput
+            keyboardType="default"
+            placeholder="default"
+            style={styles.default}
+          />
+          <TextInput
+            keyboardType="ascii"
+            placeholder="ascii"
+            style={styles.default}
+          />
+          <TextInput
+            keyboardType="email"
+            placeholder="email"
+            style={styles.default}
+          />
+          <TextInput
+            keyboardType="numbers-and-punctuation"
+            placeholder="numbers-and-punctuation"
+            style={styles.default}
+          />
+          <TextInput
+            keyboardType="numeric"
+            placeholder="numeric"
+            style={styles.default}
+          />
+          <TextInput
+            keyboardType="pin"
+            placeholder="pin"
+            style={styles.default}
+          />
+          <TextInput
+            keyboardType="phone-name"
+            placeholder="phone-name"
+            style={styles.default}
+          />
+          <TextInput
+            keyboardType="search"
+            placeholder="search"
+            style={styles.default}
+          />
+          <TextInput
+            keyboardType="twitter"
+            placeholder="twitter"
+            style={styles.default}
+          />
+          <TextInput
+            keyboardType="url"
+            placeholder="url"
+            style={styles.default}
+          />
+        </View>
+      );
+    }
+  },
+  {
     title: 'Auto-correct',
     render: function() {
       return (

--- a/Libraries/Components/TextInput/TextInput.ios.js
+++ b/Libraries/Components/TextInput/TextInput.ios.js
@@ -137,8 +137,16 @@ var TextInput = React.createClass({
      * Determines which keyboard to open, e.g.`numeric`.
      */
     keyboardType: PropTypes.oneOf([
+      'ascii',
       'default',
+      'email',
+      'numbers-and-punctuation',
       'numeric',
+      'pin',
+      'phone-name',
+      'search',
+      'twitter',
+      'url',
     ]),
     /**
      * If true, the text input can be multiple lines. Default value is false.

--- a/React/Base/RCTConvert.m
+++ b/React/Base/RCTConvert.m
@@ -116,8 +116,16 @@ RCT_ENUM_CONVERTER(UIScrollViewKeyboardDismissMode, (@{
 }), UIScrollViewKeyboardDismissModeNone, integerValue)
 
 RCT_ENUM_CONVERTER(UIKeyboardType, (@{
-  @"numeric": @(UIKeyboardTypeDecimalPad),
+  @"ascii": @(UIKeyboardTypeASCIICapable),
   @"default": @(UIKeyboardTypeDefault),
+  @"email": @(UIKeyboardTypeEmailAddress),
+  @"numbers-and-punctuation": @(UIKeyboardTypeNumbersAndPunctuation),
+  @"numeric": @(UIKeyboardTypeDecimalPad),
+  @"pin": @(UIKeyboardTypeNumberPad),
+  @"phone-name": @(UIKeyboardTypeNamePhonePad),
+  @"search": @(UIKeyboardTypeWebSearch),
+  @"twitter": @(UIKeyboardTypeTwitter),
+  @"url": @(UIKeyboardTypeURL),
 }), UIKeyboardTypeDefault, integerValue)
 
 RCT_ENUM_CONVERTER(UIViewContentMode, (@{


### PR DESCRIPTION
This PR adds the remaining keyboard types for iOS to TextInput:

https://developer.apple.com/library/ios/documentation/UIKit/Reference/UITextInputTraits_Protocol/index.html#//apple_ref/c/tdef/UIKeyboardType

Open to suggestions on the propTypes for keyboardType. Currently, they are:

```js
keyboardType: PropTypes.oneOf([
  'ascii',
  'default',
  'email',
  'numbers-and-punctuation',
  'numeric',
  'pin',
  'phone-name',
  'search',
  'twitter',
  'url',
]),
```
