### PR TITLE
[ReactNative] Export EdgeInsetsPropType and PointPropType

### DIFF
--- a/Libraries/react-native/react-native.js
+++ b/Libraries/react-native/react-native.js
@@ -62,6 +62,10 @@ var ReactNative = Object.assign(Object.create(require('React')), {
   NativeModules: require('NativeModules'),
   requireNativeComponent: require('requireNativeComponent'),
 
+  // Prop Types
+  EdgeInsetsPropType: require('EdgeInsetsPropType'),
+  PointPropType: require('PointPropType'),
+
   addons: {
     LinkedStateMixin: require('LinkedStateMixin'),
     Perf: undefined,


### PR DESCRIPTION
Added some more exports to React that are either necessary or often useful for component authors.
