### PR TITLE
[AppStateIOS] Fix and simplify AppStateIOS's event subscriptions

### DIFF
--- a/Examples/UIExplorer/AppStateIOSExample.js
+++ b/Examples/UIExplorer/AppStateIOSExample.js
@@ -24,6 +24,7 @@ var {
 } = React;
 
 var AppStateSubscription = React.createClass({
+  _appStateListener: null,
   getInitialState() {
     return {
       appState: AppStateIOS.currentState,
@@ -31,10 +32,15 @@ var AppStateSubscription = React.createClass({
     };
   },
   componentDidMount: function() {
-    AppStateIOS.addEventListener('change', this._handleAppStateChange);
+    this._appStateListener = AppStateIOS.addListener(
+      this._handleAppStateChange
+    );
   },
   componentWillUnmount: function() {
-    AppStateIOS.removeEventListener('change', this._handleAppStateChange);
+    if (this._appStateListener) {
+      this._appStateListener.remove();
+      this._appStateListener = null;
+    }
   },
   _handleAppStateChange: function(appState) {
     var previousAppStates = this.state.previousAppStates.slice();

--- a/Libraries/AppStateIOS/AppStateIOS.android.js
+++ b/Libraries/AppStateIOS/AppStateIOS.android.js
@@ -15,12 +15,8 @@ var warning = require('warning');
 
 class AppStateIOS {
 
-  static addEventListener(type, handler) {
+  static addListener(handler) {
     warning('Cannot listen to AppStateIOS events on Android.');
-  }
-
-  static removeEventListener(type, handler) {
-    warning('Cannot remove AppStateIOS listener on Android.');
   }
 
 }

--- a/Libraries/AppStateIOS/AppStateIOS.ios.js
+++ b/Libraries/AppStateIOS/AppStateIOS.ios.js
@@ -71,18 +71,13 @@ var _appStateHandlers = {};
  * the app is only visible to the user when in the `active` state, and the null
  * state will happen only momentarily.
  */
-
 var AppStateIOS = {
 
   /**
-   * Add a handler to AppState changes by listening to the `change` event type
-   * and providing the handler
+   * Add a handler to AppState changes and returns a subscription
    */
-  addEventListener: function(
-    type: string,
-    handler: Function
-  ) {
-    _appStateHandlers[handler] = RCTDeviceEventEmitter.addListener(
+  addListener(handler: Function) {
+    return RCTDeviceEventEmitter.addListener(
       DEVICE_APPSTATE_EVENT,
       (appStateData) => {
         handler(appStateData.app_state);
@@ -90,22 +85,7 @@ var AppStateIOS = {
     );
   },
 
-  /**
-   * Remove a handler by passing the `change` event type and the handler
-   */
-  removeEventListener: function(
-    type: string,
-    handler: Function
-  ) {
-    if (!_appStateHandlers[handler]) {
-      return;
-    }
-    _appStateHandlers[handler].remove();
-    _appStateHandlers[handler] = null;
-  },
-
   currentState: (null : ?String),
-
 };
 
 RCTDeviceEventEmitter.addListener(


### PR DESCRIPTION
The prior implementation of the subscription API was using a function as a key in an object, which I removed. I also simplified the API by removing the unused `type` argument and making the API match that of Facebook's EventEmitter (call subscription.remove() instead of removeEventListener).

Updated the UIExplorer example, which prints out the "active" and "background" states when I background the app in the simulator. No JS errors when I browse around the example and unsubscribe from the event.

There is a bug where the "inactive" state is never hit. This is partly because Apple actually never notifies the app when it is inactive, so we need to listen to UIApplicationWillResignActiveNotification and assume the app will become inactive. Leaving that for another diff if I get around to it or someone else wants to fix it up.