### PR TITLE
Add links to node and npm in Requirements

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -12,7 +12,7 @@ next: tutorial
 1. OS X - This repo only contains the iOS implementation right now, and Xcode only runs on Mac.
 2. New to Xcode?  [Download it](https://developer.apple.com/xcode/downloads/) from the Mac App Store.
 3. [Homebrew](http://brew.sh/) is the recommended way to install node, watchman, and flow.
-4. `brew install node`. New to node or npm?
+4. `brew install node`. New to [node](https://nodejs.org/) or [npm](https://docs.npmjs.com/)?
 5. `brew install watchman`. We recommend installing [watchman](https://facebook.github.io/watchman/docs/install.html), otherwise you might hit a node file watching bug.
 6. `brew install flow`. If you want to use [flow](http://www.flowtype.org).
 


### PR DESCRIPTION
In getting started, it asks if you are new to node and npm, but there are no links to explain what either is. I believe these links help to clarify.

Previously: 
![image](https://cloud.githubusercontent.com/assets/5377436/6858043/738717fa-d3d9-11e4-95df-5953e2e6abf3.png)

Proposed change: 
![image](https://cloud.githubusercontent.com/assets/5377436/6858048/7e11a7e4-d3d9-11e4-988f-e93110665e9e.png)
