### PR TITLE
Use only one package for dependencies, for now. Fixes #225

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,8 +35,7 @@
   "scripts": {
     "test": "jest",
     "lint": "node linter.js Examples/",
-    "start": "./packager/packager.sh",
-    "postinstall": "cd packager && npm install"
+    "start": "./packager/packager.sh"
   },
   "bin": {
     "react-native-start": "packager/packager.sh"
@@ -48,7 +47,19 @@
     "react-tools": "0.13.0-rc2",
     "rebound": "^0.0.12",
     "source-map": "0.1.31",
-    "stacktrace-parser": "0.1.1"
+    "stacktrace-parser": "0.1.1",
+    "absolute-path": "0.0.0",
+    "debug": "~2.1.0",
+    "joi": "~5.1.0",
+    "module-deps": "3.5.6",
+    "optimist": "0.6.1",
+    "q": "1.0.1",
+    "sane": "1.0.1",
+    "uglify-js": "~2.4.16",
+    "underscore": "1.7.0",
+    "worker-farm": "1.1.0",
+    "yargs": "1.3.2",
+    "ws": "0.4.31"
   },
   "devDependencies": {
     "jest-cli": "0.2.1",

--- a/packager/package.json
+++ b/packager/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "react-native-cli",
   "version": "0.1.2",
+  "name": "react-native-packager",
   "description": "Build native apps with React!",
   "repository": {
     "type": "git",
@@ -23,22 +23,7 @@
     "lint": "node linter.js Examples/",
     "start": "./packager/packager.sh"
   },
-  "dependencies": {
-    "absolute-path": "0.0.0",
-    "debug": "~2.1.0",
-    "joi": "~5.1.0",
-    "module-deps": "3.5.6",
-    "optimist": "0.6.1",
-    "q": "1.0.1",
-    "sane": "1.0.1",
-    "source-map": "0.1.31",
-    "stacktrace-parser": "0.1.1",
-    "uglify-js": "~2.4.16",
-    "underscore": "1.7.0",
-    "worker-farm": "1.1.0",
-    "yargs": "1.3.2",
-    "ws": "0.4.31"
-  },
+  "dependencies": {},
   "devDependencies": {
     "jest-cli": "0.2.1",
     "eslint": "0.9.2"


### PR DESCRIPTION
We should separate out the packages but for now we this is a quick fix