### PR TITLE
[Pod] Add an "All" subspec that pulls in all non-test libraries

### DIFF
--- a/React.podspec
+++ b/React.podspec
@@ -31,6 +31,14 @@ Pod::Spec.new do |s|
     ss.frameworks      = "JavaScriptCore"
   end
 
+  s.subspec 'All' do |ss|
+    ss.dependency        'React/Core'
+    ss.source_files    = "Libraries/**/*.{h,m}"
+    ss.preserve_paths  = "Libraries/**/*.js"
+    ss.exclude_files   = "Libraries/RCTTest"
+    ss.libraries       = "icucore"
+  end
+
   s.subspec 'RCTActionSheet' do |ss|
     ss.dependency       'React/Core'
     ss.source_files   = "Libraries/ActionSheetIOS/*.{h,m}"


### PR DESCRIPTION
Some of the libraries don't have subspecs defined, and I don't think we want a subspec for each library in the long run anyway after a package manager client (like npm and CocoaPods) has been built. Adding "All" as a reasonable short-term solution.