### PR TITLE
[RootView] Asynchronously load the bundle to give time to configure the root view

### DIFF
--- a/React/Base/RCTRootView.m
+++ b/React/Base/RCTRootView.m
@@ -318,7 +318,9 @@ static Class _globalExecutorClass;
   }
 
   _scriptURL = scriptURL;
-  [self loadBundle];
+  dispatch_async(dispatch_get_main_queue(), ^{
+    [self loadBundle];
+  });
 }
 
 - (void)layoutSubviews


### PR DESCRIPTION
If you construct an RCTRootView you may want to configure the executor. However the constructor synchronously calls `loadBundle` and sets up the executor and bridge. This is a quick fix that uses dispatch_async to allow the current pass of the runloop time to set up the executor.

Tested by constructing an RCTRootView and then customizing the executor class on the next line. Works with this patch.

Fixes #288