### PR TITLE
Adds missing space character to CLI error message

### DIFF
--- a/react-native-cli/index.js
+++ b/react-native-cli/index.js
@@ -44,7 +44,7 @@ if (cli) {
     }
   } else {
     console.error(
-      'Command `%s` unrecognized.' +
+      'Command `%s` unrecognized. ' +
       'Did you mean to run this inside a react-native project?',
       args[0]
     );


### PR DESCRIPTION
Before:
> Command `foo` unrecognized.Did you mean to run this inside a react-native project?

After:
> Command `foo` unrecognized. Did you mean to run this inside a react-native project?