### PR TITLE
Packager status page & build validating against it.

### DIFF
--- a/React/React.xcodeproj/project.pbxproj
+++ b/React/React.xcodeproj/project.pbxproj
@@ -445,7 +445,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if nc -w 5 -z localhost 8081 ; then\n  if ! curl -s \"http://localhost:8081/packager-status\" | grep -q \"packager-status:running\" ; then\n    echo \"Port 8081 already in use, packager is either not running or not running correctly\"\n    exit 2\n  fi\nelse\n  open $SRCROOT/../packager/launchPackager.command || echo \"Can't start packager automatically\"\nfi";
+			shellScript = "if nc -w 5 -z localhost 8081 ; then\n  if ! curl -s \"http://localhost:8081/status\" | grep -q \"packager-status:running\" ; then\n    echo \"Port 8081 already in use, packager is either not running or not running correctly\"\n    exit 2\n  fi\nelse\n  open $SRCROOT/../packager/launchPackager.command || echo \"Can't start packager automatically\"\nfi";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/React/React.xcodeproj/project.pbxproj
+++ b/React/React.xcodeproj/project.pbxproj
@@ -445,7 +445,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "nc -w 5 -z localhost 8081 > /dev/null 2>&1 || open $SRCROOT/../packager/launchPackager.command || echo \"Can't start packager automatically\"";
+			shellScript = "if nc -w 5 -z localhost 8081 ; then\n  if ! curl -s \"http://localhost:8081/packager-status\" | grep -q \"packager-status:running\" ; then\n    echo \"Port 8081 already in use, packager is either not running or not running correctly\"\n    exit 2\n  fi\nelse\n  open $SRCROOT/../packager/launchPackager.command || echo \"Can't start packager automatically\"\nfi";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/packager/packager.js
+++ b/packager/packager.js
@@ -153,12 +153,10 @@ function getDevToolsLauncher(options) {
 // A status page so the React/project.pbxproj build script
 // can verify that packager is running on 8081 and not 
 // another program / service.
-function statusPageMiddleware (req, res, next) {
+function statusPageMiddleware(req, res, next) {
   if (req.url === '/status') {
     res.end('packager-status:running');
-  }
-  else
-  {
+  } else {
     next();   
   }
 }

--- a/packager/packager.js
+++ b/packager/packager.js
@@ -154,8 +154,7 @@ function getDevToolsLauncher(options) {
 // can verify that packager is running on 8081 and not 
 // another program / service.
 function statusPageMiddleware (req, res, next) {
-  if (req.url == '/status')
-  {
+  if (req.url === '/status') {
     res.end('packager-status:running');
   }
   else

--- a/packager/packager.js
+++ b/packager/packager.js
@@ -153,8 +153,8 @@ function getDevToolsLauncher(options) {
 // A status page so the React/project.pbxproj build script
 // can verify that packager is running on 8081 and not 
 // another program / service.
-function statusPageMiddleware(req, res, next){
-  if(req.url == '/packager-status')
+function statusPageMiddleware (req, res, next) {
+  if (req.url == '/status')
   {
     res.end('packager-status:running');
   }

--- a/packager/packager.js
+++ b/packager/packager.js
@@ -150,6 +150,20 @@ function getDevToolsLauncher(options) {
   };
 }
 
+// A status page so the React/project.pbxproj build script
+// can verify that packager is running on 8081 and not 
+// another program / service.
+function statusPageMiddleware(req, res, next){
+  if(req.url == '/packager-status')
+  {
+    res.end('packager-status:running');
+  }
+  else
+  {
+    next();   
+  }
+}
+
 function getAppMiddleware(options) {
   return ReactPackager.middleware({
     projectRoots: options.projectRoots,
@@ -168,6 +182,7 @@ function runServer(
     .use(loadRawBody)
     .use(openStackFrameInEditor)
     .use(getDevToolsLauncher(options))
+    .use(statusPageMiddleware)
     .use(getAppMiddleware(options));
 
   options.projectRoots.forEach(function(root) {


### PR DESCRIPTION
Creating a packager status page so React can validate a proper packager instance is running on 8081.

See #257 for details on this bug.

The biggest thing in this PR is I have it perform an exit 2 in the build script if the check fails. This will cause the build to fail, they can click on the error and see a nice message. Not sure if there is a way to throw a warning instead.

Also, I broke the bash script into several lines, in the Xcode editor it looks fine but in the source code it looks less than ideal. We might want to break that out into it's own bash script that is called. Let me know if you want to do that.