### PR TITLE
Fix docs->image width over 100%，avoid scroll-x

### DIFF
--- a/css/react-native.css
+++ b/css/react-native.css
@@ -700,6 +700,10 @@ figure {
   width: 650px;
 }
 
+.inner-content a {
+  word-break: break-word;
+}
+
 .nosidebar .inner-content {
   float: none;
   margin: 0 auto;


### PR DESCRIPTION
See the page: http://facebook.github.io/react-native/docs/image.html#content