### PR TITLE
[UIExplorer] Removing the clear interval button if timer is not shown

### DIFF
--- a/Examples/UIExplorer/TimerExample.js
+++ b/Examples/UIExplorer/TimerExample.js
@@ -180,20 +180,24 @@ exports.examples = [
         },
 
         render: function() {
+          var timer, toggleText, clearInterval;
           if (this.state.showTimer) {
-            var timer =
+            timer =
               <TimerTester ref="interval" dt={25} type="setInterval" />;
-            var toggleText = 'Unmount timer';
+            toggleText = 'Unmount timer';
+            clearInterval =
+              <Button onPress={() => this.refs.interval.clear() }>
+                Clear interval
+              </Button>;
           } else {
-            var timer = null;
-            var toggleText = 'Mount new timer';
+            timer = null;
+            toggleText = 'Mount new timer';
+            clearInterval = null;
           }
           return (
             <View>
               {timer}
-              <Button onPress={() => this.refs.interval.clear() }>
-                Clear interval
-              </Button>
+              {clearInterval}
               <Button onPress={this._toggleTimer}>
                 {toggleText}
               </Button>


### PR DESCRIPTION
In UIexplorer, for the Timers, TimerMixin page:

At the bottom, press Unmount timer, then press Clear Interval, it will show an error. This PR fixes that.