### PR TITLE
Cancel contents animation before setting new contents in RCTNetworkImageView

### DIFF
--- a/Libraries/Image/RCTNetworkImageView.m
+++ b/Libraries/Image/RCTNetworkImageView.m
@@ -75,6 +75,7 @@
     } else {
       _downloadToken = [_imageDownloader downloadImageForURL:imageURL size:self.bounds.size scale:RCTScreenScale() block:^(UIImage *image, NSError *error) {
         if (image) {
+          [self.layer removeAnimationForKey:@"contents"];
           self.layer.contentsScale = image.scale;
           self.layer.contents = (__bridge id)image.CGImage;
         }


### PR DESCRIPTION
This is a fix for #322

When setting a new image via the imageURL property, the new image
doesn't always replace the previous one when it is finished downloading
because the image view has a previously instated layer animation
on its contents. This cancels any animation prior to setting the new
contents to fix the issue.