### PR TITLE
Added sudo to getting started for npm install

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -18,7 +18,7 @@ next: tutorial
 
 ## Quick start
 
-- `npm install -g react-native-cli`
+- `sudo npm install -g react-native-cli`
 - `react-native init AwesomeProject`
 
 In the newly created folder `AwesomeProject/`


### PR DESCRIPTION
The `sudo` command is required for most secure mac systems to install global npm modules. 