### PR TITLE
Remove duplication in ScrollResponder.js

### DIFF
--- a/Libraries/Components/ScrollResponder.js
+++ b/Libraries/Components/ScrollResponder.js
@@ -12,7 +12,6 @@
 'use strict';
 
 var NativeModules = require('NativeModules');
-var NativeModules = require('NativeModules');
 var RCTDeviceEventEmitter = require('RCTDeviceEventEmitter');
 var Subscribable = require('Subscribable');
 var TextInputState = require('TextInputState');


### PR DESCRIPTION
I think this line is a legacy code from `NativeModulesDeprecated`.