### PR TITLE
[Debugger] Debugger won't start due to spaces in directory path

### DIFF
--- a/packager/packager.js
+++ b/packager/packager.js
@@ -10,7 +10,7 @@
 
 var fs = require('fs');
 var path = require('path');
-var exec = require('child_process').exec;
+var execFile = require('child_process').execFile;
 var http = require('http');
 
 var getFlowTypeCheckMiddleware = require('./getFlowTypeCheckMiddleware');
@@ -168,7 +168,7 @@ function getDevToolsLauncher(options) {
       var debuggerURL = 'http://localhost:' + options.port + '/debugger-ui';
       var script = 'launchChromeDevTools.applescript';
       console.log('Launching Dev Tools...');
-      exec(path.join(__dirname, script) + ' ' + debuggerURL, function(err, stdout, stderr) {
+      execFile(path.join(__dirname, script), [debuggerURL], function(err, stdout, stderr) {
         if (err) {
           console.log('Failed to run ' + script, err);
         }


### PR DESCRIPTION
Similar issue to #214. When I attempt to do command + D in the simulator, I get the following issue.

```
Launching Dev Tools...
Failed to run launchChromeDevTools.applescript { [Error: Command failed: /bin/sh -c /Users/ricky/Dropbox (Personal)/Sites/AwesomeProject/node_modules/react-native/packager/launchChromeDevTools.applescript http://localhost:8081/debugger-ui
/bin/sh: -c: line 0: syntax error near unexpected token `Personal'
/bin/sh: -c: line 0: `/Users/ricky/Dropbox (Personal)/Sites/AwesomeProject/node_modules/react-native/packager/launchChromeDevTools.applescript http://localhost:8081/debugger-ui'
]
  killed: false,
  code: 2,
  signal: null,
  cmd: '/bin/sh -c /Users/ricky/Dropbox (Personal)/Sites/AwesomeProject/node_modules/react-native/packager/launchChromeDevTools.applescript http://localhost:8081/debugger-ui' }

/bin/sh: -c: line 0: syntax error near unexpected token `Personal'
/bin/sh: -c: line 0: `/Users/ricky/Dropbox (Personal)/Sites/AwesomeProject/node_modules/react-native/packager/launchChromeDevTools.applescript http://localhost:8081/debugger-ui'

[11:47:30 AM] <START> request:/index.ios.bundle
[11:47:30 AM] <END>   request:/index.ios.bundle(11ms)
```

![debugger issue](https://cloud.githubusercontent.com/assets/111761/6871419/c948aace-d478-11e4-9a10-a76d72e6c291.png)