### PR TITLE
Make bounds and resizeMode of gif network images respond to styles

### DIFF
--- a/Libraries/Image/RCTNetworkImageView.m
+++ b/Libraries/Image/RCTNetworkImageView.m
@@ -62,7 +62,6 @@
       _downloadToken = [_imageDownloader downloadDataForURL:imageURL block:^(NSData *data, NSError *error) {
         if (data) {
           CAKeyframeAnimation *animation = RCTGIFImageWithData(data);
-          self.layer.bounds = CGRectMake(0, 0, self.bounds.size.width, self.bounds.size.height);
           self.layer.contentsScale = RCTScreenScale();
           self.layer.contentsGravity = kCAGravityResizeAspect;
           self.layer.minificationFilter = kCAFilterLinear;

--- a/Libraries/Image/RCTNetworkImageView.m
+++ b/Libraries/Image/RCTNetworkImageView.m
@@ -62,9 +62,8 @@
       _downloadToken = [_imageDownloader downloadDataForURL:imageURL block:^(NSData *data, NSError *error) {
         if (data) {
           CAKeyframeAnimation *animation = RCTGIFImageWithData(data);
-          CGImageRef firstFrame = (__bridge CGImageRef)animation.values.firstObject;
-          self.layer.bounds = CGRectMake(0, 0, CGImageGetWidth(firstFrame), CGImageGetHeight(firstFrame));
-          self.layer.contentsScale = 1.0;
+          self.layer.bounds = CGRectMake(0, 0, self.bounds.size.width, self.bounds.size.height);
+          self.layer.contentsScale = RCTScreenScale();
           self.layer.contentsGravity = kCAGravityResizeAspect;
           self.layer.minificationFilter = kCAFilterLinear;
           self.layer.magnificationFilter = kCAFilterLinear;

--- a/Libraries/Image/RCTNetworkImageView.m
+++ b/Libraries/Image/RCTNetworkImageView.m
@@ -62,7 +62,7 @@
       _downloadToken = [_imageDownloader downloadDataForURL:imageURL block:^(NSData *data, NSError *error) {
         if (data) {
           CAKeyframeAnimation *animation = RCTGIFImageWithData(data);
-          self.layer.contentsScale = RCTScreenScale();
+          self.layer.contentsScale = 1.0;
           self.layer.minificationFilter = kCAFilterLinear;
           self.layer.magnificationFilter = kCAFilterLinear;
           [self.layer addAnimation:animation forKey:@"contents"];

--- a/Libraries/Image/RCTNetworkImageView.m
+++ b/Libraries/Image/RCTNetworkImageView.m
@@ -63,7 +63,6 @@
         if (data) {
           CAKeyframeAnimation *animation = RCTGIFImageWithData(data);
           self.layer.contentsScale = RCTScreenScale();
-          self.layer.contentsGravity = kCAGravityResizeAspect;
           self.layer.minificationFilter = kCAFilterLinear;
           self.layer.magnificationFilter = kCAFilterLinear;
           [self.layer addAnimation:animation forKey:@"contents"];


### PR DESCRIPTION
@vjeux and I were discussing this in irc an discovered that network gif images did not respond how they should to width, height or flex properties. This PR fixes that, so now you can do `flex: 1` on a gif image to have it stretch to the whole screen. [Minimum reproducible example here](https://gist.github.com/brentvatne/f745377b0789162a28df) - try this without and then with the changes of this PR to see.