### PR TITLE
Fix EaseInBounce and EaseInOutBounce scoping bug

### DIFF
--- a/Libraries/Animation/AnimationUtils.js
+++ b/Libraries/Animation/AnimationUtils.js
@@ -183,7 +183,7 @@ var defaults = {
     return (t * t * ((s + 1) * t + s) + 2) / 2;
   },
   easeInBounce: function(t) {
-    return 1 - this.easeOutBounce(1 - t);
+    return 1 - defaults.easeOutBounce(1 - t);
   },
   easeOutBounce: function(t) {
     if (t < (1 / 2.75)) {
@@ -201,9 +201,9 @@ var defaults = {
   },
   easeInOutBounce: function(t) {
     if (t < 0.5) {
-      return this.easeInBounce(t * 2) / 2;
+      return defaults.easeInBounce(t * 2) / 2;
     }
-    return this.easeOutBounce(t * 2 - 1) / 2 + 0.5;
+    return defaults.easeOutBounce(t * 2 - 1) / 2 + 0.5;
   },
 };
 


### PR DESCRIPTION
*Problem:* In `AnimationUtils`, two functions were trying to reference other easing functions from `this`, but it was not bound to the appropriate scope, so when I tried to use either `EaseInBounce` or `EaseInOutBounce` in my animations it threw `undefined is not an object` exceptions.

*Solution:* Reference the functions off of `defaults`, which is bound in the scope of the functions.