### PR TITLE
adding .xcworkspace to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ DerivedData
 
 # OS X
 .DS_Store
+*.xcworkspace
 
 # Node
 node_modules


### PR DESCRIPTION
This folder is created by xcode when one of the examples is run.  Probably makes since to include this in the .gitignore as it doesn't make sense to keep the compiled native code under source control.