### PR TITLE
Add placeholderTextColor to TextInput component

### DIFF
--- a/Libraries/Components/TextInput/TextInput.ios.js
+++ b/Libraries/Components/TextInput/TextInput.ios.js
@@ -339,6 +339,7 @@ var TextInput = React.createClass({
           onSubmitEditing={this.props.onSubmitEditing}
           onSelectionChangeShouldSetResponder={() => true}
           placeholder={this.props.placeholder}
+          placeholderTextColor={this.props.placeholderTextColor}
           text={this.state.bufferedValue}
           autoCapitalize={autoCapitalize}
           autoCorrect={this.props.autoCorrect}


### PR DESCRIPTION
Looks like the placeholderTextColor prop was left out of the non-multiline textinput component.  Trivial commit that adds it.