### PR TITLE
add all keyboard types for keyboardType enum prop

### DIFF
--- a/Libraries/Components/TextInput/TextInput.ios.js
+++ b/Libraries/Components/TextInput/TextInput.ios.js
@@ -134,11 +134,29 @@ var TextInput = React.createClass({
      */
     editable: PropTypes.bool,
     /**
-     * Determines which keyboard to open, e.g.`numeric`.
+     * Determines which keyboard to open, e.g.`decimal`.
+     *
+     * - `ascii` is short for `asciiCapable`
+     * - `number` is short for `numberPad`
+     * - `phone` is short for `phonePad`
+     * - `email` is short for `emailAddress`
+     * - `number` is short for `numberPad`
+     * - `numeric` is an alias for `decimal`
+     * - `web` is short for `webSearch`
      */
     keyboardType: PropTypes.oneOf([
       'default',
-      'numeric',
+      'asciiCapable', 'ascii',
+      'numbersAndPunctuation',
+      'url',
+      'numberPad', 'number',
+      'phonePad', 'phone',
+      'namePhonePad',
+      'emailAddress', 'email',
+      'decimal', 'numeric',
+      'twitter',
+      'webSearch', 'web',
+      'alphabet',
     ]),
     /**
      * If true, the text input can be multiple lines. Default value is false.

--- a/React/Base/RCTConvert.m
+++ b/React/Base/RCTConvert.m
@@ -116,8 +116,17 @@ RCT_ENUM_CONVERTER(UIScrollViewKeyboardDismissMode, (@{
 }), UIScrollViewKeyboardDismissModeNone, integerValue)
 
 RCT_ENUM_CONVERTER(UIKeyboardType, (@{
-  @"numeric": @(UIKeyboardTypeDecimalPad),
   @"default": @(UIKeyboardTypeDefault),
+  @"asciiCapable": @(UIKeyboardTypeASCIICapable), @"ascii": @(UIKeyboardTypeASCIICapable),
+  @"numbersAndPunctuation": @(UIKeyboardTypeNumbersAndPunctuation),
+  @"url": @(UIKeyboardTypeURL),
+  @"numberPad": @(UIKeyboardTypeNumberPad), @"number": @(UIKeyboardTypeNumberPad),
+  @"phonePad": @(UIKeyboardTypePhonePad), @"phone": @(UIKeyboardTypePhonePad),
+  @"namePhonePad": @(UIKeyboardTypeNamePhonePad),
+  @"emailAddress": @(UIKeyboardTypeEmailAddress), @"email": @(UIKeyboardTypeEmailAddress),
+  @"decimal": @(UIKeyboardTypeDecimalPad), @"numeric": @(UIKeyboardTypeDecimalPad),
+  @"twitter": @(UIKeyboardTypeTwitter),
+  @"webSearch": @(UIKeyboardTypeWebSearch), @"web": @(UIKeyboardTypeWebSearch),
 }), UIKeyboardTypeDefault, integerValue)
 
 RCT_ENUM_CONVERTER(UIViewContentMode, (@{


### PR DESCRIPTION
This adds the entire suite of keyboardTypes to the enum.

I matched the enums with the constants (`UIKeyboardTypeNumbersAndPunctuation ` becomes `numbersAndPunctuation`).

I also added shortcut enums for the popular and verbose names. (`ascii`, `number`, `phone`, etc).
