### PR TITLE
[Scroll] RFC: Add scrollWithoutAnimationTo to immediately scroll

### DIFF
--- a/Libraries/Components/ScrollView/ScrollView.js
+++ b/Libraries/Components/ScrollView/ScrollView.js
@@ -195,6 +195,14 @@ var ScrollView = React.createClass({
     );
   },
 
+  scrollWithoutAnimationTo: function(destY?: number, destX?: number) {
+    RCTUIManager.scrollWithoutAnimationTo(
+      this.getNodeHandle(),
+      destX || 0,
+      destY || 0
+    );
+  },
+
   render: function() {
     var contentContainerStyle = [
       this.props.horizontal && styles.contentContainerHorizontal,

--- a/React/Modules/RCTUIManager.m
+++ b/React/Modules/RCTUIManager.m
@@ -1048,6 +1048,20 @@ static void RCTMeasureLayout(RCTShadowView *view,
   }];
 }
 
+- (void)scrollToOffsetWithoutAnimationWithView:(NSNumber *)reactTag scrollToOffsetX:(NSNumber *)offsetX offsetY:(NSNumber *)offsetY
+{
+  RCT_EXPORT(scrollWithoutAnimationTo);
+
+  [self addUIBlock:^(RCTUIManager *uiManager, RCTSparseArray *viewRegistry){
+    UIView *view = viewRegistry[reactTag];
+    if ([view conformsToProtocol:@protocol(RCTScrollableProtocol)]) {
+      [(id<RCTScrollableProtocol>)view scrollToOffset:CGPointMake([offsetX floatValue], [offsetY floatValue]) animated:NO];
+    } else {
+      RCTLogError(@"tried to scrollToOffsetWithoutAnimation: on non-RCTScrollableProtocol view %@ with tag %@", view, reactTag);
+    }
+  }];
+}
+
 - (void)zoomToRectWithView:(NSNumber *)reactTag rect:(NSDictionary *)rectDict
 {
   RCT_EXPORT(zoomToRect);


### PR DESCRIPTION
This is an API like setting the contentOffset except it is imperative, which is usually what you want unless the scroll view is a controlled component (for that to be realistic, JS would need to drive the scroll physics and specify the contentOffset during each frame without interruptions like the GC or CPU-hungry JS).
