### PR TITLE
Add import RCTBridge.h for event sending example

### DIFF
--- a/docs/NativeModulesIOS.md
+++ b/docs/NativeModulesIOS.md
@@ -178,6 +178,11 @@ The native module can signal events to JavaScript without being invoked directly
 
 ```objective-c
 #import "RCTBridge.h" 
+#import "RCTEventDispatcher.h"
+
+@implementation CalendarManager
+
+@synthesize bridge = _bridge; 
 
 - (void)calendarEventReminderReceived:(NSNotification *)notification
 {
@@ -185,6 +190,8 @@ The native module can signal events to JavaScript without being invoked directly
   [self.bridge.eventDispatcher sendAppEventWithName:@"EventReminder"
                                                body:@{@"name": eventName}];
 }
+
+@end
 ```
 
 JavaScript code can subscribe to these events:

--- a/docs/NativeModulesIOS.md
+++ b/docs/NativeModulesIOS.md
@@ -177,6 +177,8 @@ Note that the constants are exported only at initialization time, so if you chan
 The native module can signal events to JavaScript without being invoked directly. The easiest way to do this is to use `eventDispatcher`:
 
 ```objective-c
+#import "RCTBridge.h" 
+
 - (void)calendarEventReminderReceived:(NSNotification *)notification
 {
   NSString *eventName = notification.userInfo[@"name"];


### PR DESCRIPTION
The example omitted the `#import "RCTBridge.h"`, which will lead to CE.