### PR TITLE
Adding `scrollWithoutAnimationTo` method for ScrollViews

### DIFF
--- a/Libraries/Components/ScrollView/ScrollView.js
+++ b/Libraries/Components/ScrollView/ScrollView.js
@@ -191,7 +191,17 @@ var ScrollView = React.createClass({
     RCTUIManager.scrollTo(
       this.getNodeHandle(),
       destX || 0,
-      destY || 0
+      destY || 0,
+      true
+    );
+  },
+
+  scrollWithoutAnimationTo: function(destY?: number, destX?: number) {
+    RCTUIManager.scrollTo(
+      this.getNodeHandle(),
+      destX || 0,
+      destY || 0,
+      false
     );
   },
 

--- a/React/Modules/RCTUIManager.m
+++ b/React/Modules/RCTUIManager.m
@@ -1034,14 +1034,14 @@ static void RCTMeasureLayout(RCTShadowView *view,
   }];
 }
 
-- (void)scrollToOffsetWithView:(NSNumber *)reactTag scrollToOffsetX:(NSNumber *)offsetX offsetY:(NSNumber *)offsetY
+- (void)scrollToOffsetWithView:(NSNumber *)reactTag scrollToOffsetX:(NSNumber *)offsetX offsetY:(NSNumber *)offsetY animated:(BOOL)animated
 {
   RCT_EXPORT(scrollTo);
 
   [self addUIBlock:^(RCTUIManager *uiManager, RCTSparseArray *viewRegistry){
     UIView *view = viewRegistry[reactTag];
     if ([view conformsToProtocol:@protocol(RCTScrollableProtocol)]) {
-      [(id<RCTScrollableProtocol>)view scrollToOffset:CGPointMake([offsetX floatValue], [offsetY floatValue])];
+      [(id<RCTScrollableProtocol>)view scrollToOffset:CGPointMake([offsetX floatValue], [offsetY floatValue]) animated:animated];
     } else {
       RCTLogError(@"tried to scrollToOffset: on non-RCTScrollableProtocol view %@ with tag %@", view, reactTag);
     }


### PR DESCRIPTION
Implementing the consensus approach from the comments on
this PR:
https://github.com/facebook/react-native/pull/486

We use a boolean flag in the Obj-C code to determine whether
to animate or not, and then provide two public JS functions
that call the Obj-C with or without the flag.