### PR TITLE
[DevTools] Browser dev tools should open default browser

### DIFF
--- a/Libraries/RCTWebSocketDebugger/RCTWebSocketExecutor.m
+++ b/Libraries/RCTWebSocketDebugger/RCTWebSocketExecutor.m
@@ -48,7 +48,7 @@ typedef void (^WSMessageCallback)(NSError *error, NSDictionary *reply);
     _injectedObjects = [[NSMutableDictionary alloc] init];
     [_socket setDelegateDispatchQueue:_jsQueue];
 
-    NSURL *startDevToolsURL = [NSURL URLWithString:@"/launch-chrome-devtools" relativeToURL:URL];
+    NSURL *startDevToolsURL = [NSURL URLWithString:@"/launch-browser-devtools" relativeToURL:url];
     [NSURLConnection connectionWithRequest:[NSURLRequest requestWithURL:startDevToolsURL] delegate:nil];
 
     if (![self connectToProxy]) {
@@ -66,7 +66,7 @@ typedef void (^WSMessageCallback)(NSError *error, NSDictionary *reply);
       retries--;
     }
     if (!runtimeIsReady) {
-      RCTLogError(@"Runtime is not ready. Do you have Chrome open?");
+      RCTLogError(@"Runtime is not ready. Do you have your browser open?");
       [self invalidate];
       return nil;
     }

--- a/packager/debugger.html
+++ b/packager/debugger.html
@@ -113,7 +113,7 @@ function loadScript(src, callback) {
 </head>
 <body>
   <p>
-    React Native JS code runs inside this Chrome tab
+    React Native JS code runs inside this browser tab
   </p>
   <p>Press <span class="shortcut">⌘⌥J</span> to open Developer Tools. Enable <a href="http://stackoverflow.com/a/17324511/232122" target="_blank">Pause On Caught Exceptions</a> for a better debugging experience.</p>
   <p>Status: <span id="status">Loading</span></p>

--- a/packager/packager.js
+++ b/packager/packager.js
@@ -159,22 +159,30 @@ function openStackFrameInEditor(req, res, next) {
 }
 
 function getDevToolsLauncher(options) {
+  var connected = false;
   return function(req, res, next) {
     if (req.url === '/debugger-ui') {
       var debuggerPath = path.join(__dirname, 'debugger.html');
       res.writeHead(200, {'Content-Type': 'text/html'});
       fs.createReadStream(debuggerPath).pipe(res);
     } else if (req.url === '/launch-browser-devtools') {
-      var debuggerURL = 'http://localhost:' + options.port + '/debugger-ui';
-      console.log('Launching Dev Tools in default browser...');
-      exec('open' + ' ' + debuggerURL, function(err, stdout, stderr) {
-        if (err) {
-          console.log('Failed to open ' + debuggerURL, err);
-        }
-        console.log(stdout);
-        console.warn(stderr);
-      });
-      res.end('OK');
+      if (connected) {
+        console.log('Already connect to Dev Tools in default browser...');
+        res.end('OK');
+      }
+      else {
+        var debuggerURL = 'http://localhost:' + options.port + '/debugger-ui';
+        console.log('Launching Dev Tools in default browser...');
+        connected = true;
+        exec('open' + ' ' + debuggerURL, function(err, stdout, stderr) {
+          if (err) {
+            console.log('Failed to open ' + debuggerURL, err);
+          }
+          console.log(stdout);
+          console.warn(stderr);
+        });
+        res.end('OK');
+      }
     } else {
       next();
     }

--- a/packager/packager.js
+++ b/packager/packager.js
@@ -164,13 +164,12 @@ function getDevToolsLauncher(options) {
       var debuggerPath = path.join(__dirname, 'debugger.html');
       res.writeHead(200, {'Content-Type': 'text/html'});
       fs.createReadStream(debuggerPath).pipe(res);
-    } else if (req.url === '/launch-chrome-devtools') {
+    } else if (req.url === '/launch-browser-devtools') {
       var debuggerURL = 'http://localhost:' + options.port + '/debugger-ui';
-      var script = 'launchChromeDevTools.applescript';
-      console.log('Launching Dev Tools...');
-      exec(path.join(__dirname, script) + ' ' + debuggerURL, function(err, stdout, stderr) {
+      console.log('Launching Dev Tools in default browser...');
+      exec('open' + ' ' + debuggerURL, function(err, stdout, stderr) {
         if (err) {
-          console.log('Failed to run ' + script, err);
+          console.log('Failed to open ' + debuggerURL, err);
         }
         console.log(stdout);
         console.warn(stderr);


### PR DESCRIPTION
This changes the browser dev tools tunneling to open the default browser using *nix’s `open` command instead of applescript.

Benefits:
* leave browser tooling decisions to the user.
* linux support

Limitations:
* Doesn’t detect whether the tab is already open and focus if so (like the Chrome applescript implementation did).

I think that limitation needs to be tackled before merging. I’m not really sure where to start to tackle that. I suspect this is low priority to your team, but is this something you’d be interested in?

Closes #492 