### PR TITLE
missing '.' in ListView.DataSource example

### DIFF
--- a/Libraries/CustomComponents/ListView/ListView.js
+++ b/Libraries/CustomComponents/ListView/ListView.js
@@ -61,7 +61,7 @@ var SCROLLVIEW_REF = 'listviewscroll';
  *
  * ```
  * getInitialState: function() {
- *   var ds = new ListViewDataSource({rowHasChanged: (r1, r2) => r1 !== r2});
+ *   var ds = new ListView.DataSource({rowHasChanged: (r1, r2) => r1 !== r2});
  *   return {
  *     dataSource: ds.cloneWithRows(['row 1', 'row 2']),
  *   };


### PR DESCRIPTION
The `ListView.DataSource` example is missing a period. Previously looked like a method i.e.` ListViewDataSource`