### PR TITLE
Update example code in "Sending events to JavaScript"

### DIFF
--- a/Libraries/Image/RCTImageLoader.m
+++ b/Libraries/Image/RCTImageLoader.m
@@ -95,6 +95,15 @@ NSError *errorWithMessage(NSString *message) {
         callback(nil, [UIImage imageWithData:data]);
       }
     }];
+  } else if ([imageTag hasPrefix:@"file"]) {
+    NSURL *url = [NSURL URLWithString:imageTag];
+    if (!url) {
+      NSString *errorMessage = [NSString stringWithFormat:@"Invalid URL: %@", imageTag];
+      callback(errorWithMessage(errorMessage), nil);
+      return;
+    }
+    NSData *data = [NSData dataWithContentsOfURL:url];
+    callback(nil, [UIImage imageWithData:data]);
   } else {
     NSString *errorMessage = [NSString stringWithFormat:@"Unrecognized tag protocol: %@", imageTag];
     NSError *error = errorWithMessage(errorMessage);

--- a/Libraries/Image/RCTImageLoader.m
+++ b/Libraries/Image/RCTImageLoader.m
@@ -95,15 +95,6 @@ NSError *errorWithMessage(NSString *message) {
         callback(nil, [UIImage imageWithData:data]);
       }
     }];
-  } else if ([imageTag hasPrefix:@"file"]) {
-    NSURL *url = [NSURL URLWithString:imageTag];
-    if (!url) {
-      NSString *errorMessage = [NSString stringWithFormat:@"Invalid URL: %@", imageTag];
-      callback(errorWithMessage(errorMessage), nil);
-      return;
-    }
-    NSData *data = [NSData dataWithContentsOfURL:url];
-    callback(nil, [UIImage imageWithData:data]);
   } else {
     NSString *errorMessage = [NSString stringWithFormat:@"Unrecognized tag protocol: %@", imageTag];
     NSError *error = errorWithMessage(errorMessage);

--- a/docs/NativeModulesIOS.md
+++ b/docs/NativeModulesIOS.md
@@ -187,7 +187,7 @@ The native module can signal events to JavaScript without being invoked directly
 - (void)calendarEventReminderReceived:(NSNotification *)notification
 {
   NSString *eventName = notification.userInfo[@"name"];
-  [self.bridge.eventDispatcher sendAppEventWithName:@"EventReminder"
+  [self.bridge.eventDispatcher sendDeviceEventWithName:@"EventReminder"
                                                body:@{@"name": eventName}];
 }
 


### PR DESCRIPTION
We should call "sendDeviceEventWithName" instead of "sendAppEventWithName" in

```
- (void)calendarEventReminderReceived:(NSNotification *)notification
{
  NSString *eventName = notification.userInfo[@"name"];
  [self.bridge.eventDispatcher sendAppEventWithName:@"EventReminder"
                                               body:@{@"name": eventName}];
}
```