### PR TITLE
Fix a crash in RCTAsyncLocalStorage when the value is not a string.

### DIFF
--- a/React/Modules/RCTAsyncLocalStorage.m
+++ b/React/Modules/RCTAsyncLocalStorage.m
@@ -157,7 +157,7 @@ static dispatch_queue_t RCTFileQueue(void)
     return RCTMakeAndLogError(@"Entries must be arrays of the form [key: string, value: string], got: ", entry, nil);
   }
   if (![entry[1] isKindOfClass:[NSString class]]) {
-    return RCTMakeAndLogError(@"Values must be strings, got: ", entry[1], entry[0]);
+    return RCTMakeAndLogError(@"Values must be strings, got: ", entry[1], @{@"key": entry[0]});
   }
   NSString *key = entry[0];
   id errorOut = RCTErrorForKey(key);


### PR DESCRIPTION
When you forget to pass the value parameter to AsyncStorage.setItem the entire app would crash instead of showing a useful error message. The problem was that the error function used in the file expected a dictionary but was passed the value of the key which caused the crash.