### PR TITLE
Expose html prop on WebView

### DIFF
--- a/Libraries/Components/WebView/WebView.ios.js
+++ b/Libraries/Components/WebView/WebView.ios.js
@@ -60,7 +60,8 @@ var WebView = React.createClass({
   propTypes: {
     renderError: PropTypes.func.isRequired, // view to show if there's an error
     renderLoading: PropTypes.func.isRequired, // loading indicator to show
-    url: PropTypes.string.isRequired,
+    url: PropTypes.string,
+    html: PropTypes.string,
     automaticallyAdjustContentInsets: PropTypes.bool,
     shouldInjectAJAXHandler: PropTypes.bool,
     contentInset: EdgeInsetsPropType,
@@ -115,6 +116,7 @@ var WebView = React.createClass({
         key="webViewKey"
         style={webViewStyles}
         url={this.props.url}
+        html={this.props.html}
         shouldInjectAJAXHandler={this.props.shouldInjectAJAXHandler}
         contentInset={this.props.contentInset}
         automaticallyAdjustContentInsets={this.props.automaticallyAdjustContentInsets}
@@ -182,6 +184,7 @@ var WebView = React.createClass({
 var RCTWebView = createReactIOSNativeComponentClass({
   validAttributes: merge(ReactIOSViewAttributes.UIView, {
     url: true,
+    html: true,
     contentInset: {diff: insetsDiffer},
     automaticallyAdjustContentInsets: true,
     shouldInjectAJAXHandler: true

--- a/React/Views/RCTWebView.m
+++ b/React/Views/RCTWebView.m
@@ -73,6 +73,11 @@
   [_webView loadRequest:[NSURLRequest requestWithURL:URL]];
 }
 
+- (void)setHTML:(NSString *)HTML
+{
+  [_webView loadHTMLString:HTML baseURL:nil];
+}
+
 - (void)layoutSubviews
 {
   [super layoutSubviews];

--- a/React/Views/RCTWebViewManager.m
+++ b/React/Views/RCTWebViewManager.m
@@ -22,6 +22,7 @@
 }
 
 RCT_REMAP_VIEW_PROPERTY(url, URL, NSURL);
+RCT_REMAP_VIEW_PROPERTY(html, HTML, NSString);
 RCT_EXPORT_VIEW_PROPERTY(contentInset, UIEdgeInsets);
 RCT_EXPORT_VIEW_PROPERTY(automaticallyAdjustContentInsets, UIEdgeInsets);
 RCT_EXPORT_VIEW_PROPERTY(shouldInjectAJAXHandler, BOOL);


### PR DESCRIPTION
Allows setting of HTML directly on webview to support #506. This is a starting point, and feedback/improvement is requested.

1. if `startInLoadingState` is true, the HTML content will never show since the load event never fires

2. Neither html nor url are set as required props any more