### PR TITLE
[Packager] Add option for remote packager in info.plist

### DIFF
--- a/Examples/2048/2048/AppDelegate.m
+++ b/Examples/2048/2048/AppDelegate.m
@@ -15,6 +15,7 @@
 #import "AppDelegate.h"
 
 #import "RCTRootView.h"
+#import "RCTUtils.h"
 
 @implementation AppDelegate
 
@@ -36,7 +37,7 @@
    * on the same Wi-Fi network.
    */
 
-  jsCodeLocation = [NSURL URLWithString:@"http://localhost:8081/Examples/2048/Game2048.includeRequire.runModule.bundle"];
+  jsCodeLocation = RCTServerURLWithPath(@"/Examples/2048/Game2048.includeRequire.runModule.bundle");
 
   /**
    * OPTION 2

--- a/Examples/Movies/Movies/AppDelegate.m
+++ b/Examples/Movies/Movies/AppDelegate.m
@@ -16,6 +16,7 @@
 
 #import "RCTLinkingManager.h"
 #import "RCTRootView.h"
+#import "RCTUtils.h"
 
 @implementation AppDelegate
 
@@ -36,8 +37,8 @@
    * `inet` value under `en0:`) and make sure your computer and iOS device are
    * on the same Wi-Fi network.
    */
-
-  jsCodeLocation = [NSURL URLWithString:@"http://localhost:8081/Examples/Movies/MoviesApp.includeRequire.runModule.bundle"];
+  
+  jsCodeLocation = RCTServerURLWithPath(@"/Examples/Movies/MoviesApp.includeRequire.runModule.bundle");
 
   /**
    * OPTION 2

--- a/Examples/SampleApp/iOS/AppDelegate.m
+++ b/Examples/SampleApp/iOS/AppDelegate.m
@@ -10,6 +10,7 @@
 #import "AppDelegate.h"
 
 #import "RCTRootView.h"
+#import "RCTUtils.h"
 
 @implementation AppDelegate
 
@@ -31,7 +32,7 @@
    * on the same Wi-Fi network.
    */
 
-  jsCodeLocation = [NSURL URLWithString:@"http://localhost:8081/Examples/SampleApp/index.ios.bundle"];
+  jsCodeLocation = RCTServerURLWithPath(@"/Examples/SampleApp/index.ios.bundle");
 
   /**
    * OPTION 2

--- a/Examples/TicTacToe/TicTacToe/AppDelegate.m
+++ b/Examples/TicTacToe/TicTacToe/AppDelegate.m
@@ -15,6 +15,7 @@
 #import "AppDelegate.h"
 
 #import "RCTRootView.h"
+#import "RCTUtils.h"
 
 @implementation AppDelegate
 
@@ -36,7 +37,7 @@
    * on the same Wi-Fi network.
    */
 
-  jsCodeLocation = [NSURL URLWithString:@"http://localhost:8081/Examples/TicTacToe/TicTacToeApp.includeRequire.runModule.bundle"];
+  jsCodeLocation = RCTServerURLWithPath(@"/Examples/TicTacToe/TicTacToeApp.includeRequire.runModule.bundle");
 
   /**
    * OPTION 2

--- a/Examples/UIExplorer/UIExplorer/AppDelegate.m
+++ b/Examples/UIExplorer/UIExplorer/AppDelegate.m
@@ -15,6 +15,7 @@
 #import "AppDelegate.h"
 
 #import "RCTRootView.h"
+#import "RCTUtils.h"
 
 @implementation AppDelegate
 
@@ -36,7 +37,7 @@
    * on the same Wi-Fi network.
    */
 
-  jsCodeLocation = [NSURL URLWithString:@"http://localhost:8081/Examples/UIExplorer/UIExplorerApp.includeRequire.runModule.bundle?dev=true"];
+  jsCodeLocation = RCTServerURLWithPath(@"/Examples/UIExplorer/UIExplorerApp.includeRequire.runModule.bundle?dev=true");
 
   /**
    * OPTION 2

--- a/Libraries/WebSocket/RCTWebSocketExecutor.m
+++ b/Libraries/WebSocket/RCTWebSocketExecutor.m
@@ -35,7 +35,7 @@ typedef void (^RCTWSMessageCallback)(NSError *error, NSDictionary *reply);
 
 - (instancetype)init
 {
-  return [self initWithURL:[NSURL URLWithString:@"http://localhost:8081/debugger-proxy"]];
+  return [self initWithURL:RCTServerURLWithPath(@"/debugger-proxy")];
 }
 
 - (instancetype)initWithURL:(NSURL *)URL

--- a/React/Base/RCTRedBox.m
+++ b/React/Base/RCTRedBox.m
@@ -102,7 +102,7 @@
   NSData *stackFrameJSON = [RCTJSONStringify(stackFrame, nil) dataUsingEncoding:NSUTF8StringEncoding];
   NSString *postLength = [NSString stringWithFormat:@"%lu", (unsigned long)[stackFrameJSON length]];
   NSMutableURLRequest *request = [[NSMutableURLRequest alloc] init];
-  request.URL = [NSURL URLWithString:@"http://localhost:8081/open-stack-frame"];
+  request.URL = RCTServerURLWithPath(@"/open-stack-frame");
   request.HTTPMethod = @"POST";
   request.HTTPBody = stackFrameJSON;
   [request setValue:postLength forHTTPHeaderField:@"Content-Length"];

--- a/React/Base/RCTUtils.h
+++ b/React/Base/RCTUtils.h
@@ -52,3 +52,6 @@ RCT_EXTERN NSDictionary *RCTMakeAndLogError(NSString *message, id toStringify, N
 
 // Returns YES if React is running in a test environment
 RCT_EXTERN BOOL RCTRunningInTestEnvironment(void);
+
+// Returns the path to the React Native packager
+NSURL* RCTServerURLWithPath(NSString *bundleUrl);

--- a/React/Base/RCTUtils.m
+++ b/React/Base/RCTUtils.m
@@ -261,3 +261,15 @@ BOOL RCTRunningInTestEnvironment(void)
   });
   return _isTestEnvironment;
 }
+
+NSURL* RCTServerURLWithPath(NSString *bundleUrl)
+{
+  NSString *url = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"ReactServer"];
+  
+  if (url == nil){
+    url = @"http://localhost:8081";
+  }
+  
+  return [NSURL URLWithString:[NSString stringWithFormat:@"%@%@", url, bundleUrl]];
+}
+

--- a/docs/Debugging.md
+++ b/docs/Debugging.md
@@ -29,3 +29,11 @@ To activate Live Reload do the following:
 1. Run your application in the iOS simulator.
 2. Press ```Control + Command + Z```.
 3. You will now see the `Enable/Disable Live Reload`, `Reload` and `Enable/Disable Debugging` options.
+
+## Specifying the location of the React Native Packager
+When you are developing the application using an iOS device, you may want to change the location of the React Native Packager. Instead of this being the default `http://localhost:8081` you can change the address to any network reachable machine and make full use of the React Native toolkit. The location is stored in the `info.plist` file of your iOS project, to change it do the following:
+
+1. Select the info.plist file in Xcode's Project Navigator window
+2. Right click, and select `Add Row`
+3. Enter `ReactServer` for the key name and the type should be `String`
+4. Enter the location of your development machine in the value field e.g. `http://localhost:8081`


### PR DESCRIPTION
Add an option to add a `ReactServer` key to info.plist that specifies a location to a remote server running the packager. This allows you to easily change the location of the packager for on-device debugging without having to root around in various parts of the code, namely AppDelegate.m and RCTWebSocketExecutor.m (if you want debugging).