### PR TITLE
Fixed broken image link

### DIFF
--- a/docs/EmbeddedApp.md
+++ b/docs/EmbeddedApp.md
@@ -85,7 +85,7 @@ React.AppRegistry.registerComponent('SimpleApp', () => SimpleApp);
 
 You should now add a container view for the React Native component. It can be any `UIView` in your app.
 
-![Container view example](/react-native/img/EmbeddedAppContainerViewExample.png)
+![Container view example](https://github.com/facebook/react-native/blob/master/website/src/react-native/img/EmbeddedAppContainerViewExample.png)
 
 However, let's subclass `UIView` for the sake of clean code. Let's name it `ReactView`. Open up `Yourproject.xcworkspace` and create a new class `ReactView` (You can name it whatever you like :)).
 


### PR DESCRIPTION
Original link to image for EmbeddedAppContainerViewExample.png failed. Fixed link to load same image. Did not touch source code.

![screen shot 2015-03-31 at 6 55 43 pm](https://cloud.githubusercontent.com/assets/10624395/6933118/0be81f88-d7d8-11e4-877a-949420262410.png)

