### PR TITLE
Fixed broken image link for EmbeddedAppExample.png

### DIFF
--- a/docs/EmbeddedApp.md
+++ b/docs/EmbeddedApp.md
@@ -150,7 +150,7 @@ This command will start up a React Native development server within our CocoaPod
 
 Now compile and run your app. You shall now see your React Native app running inside of the `ReactView`.
 
-![Example](/react-native/img/EmbeddedAppExample.png)
+![Example](https://github.com/facebook/react-native/blob/master/website/src/react-native/img/EmbeddedAppExample.png)
 
 Live reload works from the simulator, too! You’ve got a simple React component totally encapsulated behind an Objective-C `UIView` subclass.
 


### PR DESCRIPTION
Image link for EmbeddedAppExample.png failed to load. Fixed link to load original image. Did not touch source code.


![screen shot 2015-03-31 at 7 02 28 pm](https://cloud.githubusercontent.com/assets/10624395/6933196/dbc5816e-d7d8-11e4-90be-3a7905615f83.png)
