### PR TITLE
Fixed broken image link for AddToLibraries.png

### DIFF
--- a/docs/LinkingLibraries.md
+++ b/docs/LinkingLibraries.md
@@ -31,7 +31,7 @@ folder.
 Drag this file to your project on Xcode (usually under the `Libaries` group
 on Xcode);
 
-![](/react-native/img/AddToLibraries.png)
+![](https://github.com/facebook/react-native/blob/master/website/src/react-native/img/AddToLibraries.png)
 
 ### Step 2
 


### PR DESCRIPTION
Image for AddToLibraries.png failed to load. Fixed link to load same image. Did not touch source code.

![screen shot 2015-03-31 at 7 14 22 pm](https://cloud.githubusercontent.com/assets/10624395/6933330/7c4eac0e-d7da-11e4-8bf4-8949d52f093b.png)
