### PR TITLE
Fixed broken image for AddToBuildPhases.png

### DIFF
--- a/docs/LinkingLibraries.md
+++ b/docs/LinkingLibraries.md
@@ -39,7 +39,7 @@ Click on your main project file (the one that represents the `.xcodeproj`)
 select `Build Phases` and drag the static library from the `Products` folder
 insed the Library you are importing to `Link Binary With Libraries`
 
-![](/react-native/img/AddToBuildPhases.png)
+![](https://github.com/facebook/react-native/blob/master/website/src/react-native/img/AddToBuildPhases.png)
 
 ### Step 3
 


### PR DESCRIPTION
Image for AddToBuildPhases.png failed to load. Fixed link to load same image from "react-native/website/src/react-native/img". Did not touch source code.

![screen shot 2015-03-31 at 7 20 45 pm](https://cloud.githubusercontent.com/assets/10624395/6933374/38c433e0-d7db-11e4-8db1-e65001352cee.png)
