### PR TITLE
Fixed image link for AddToSearchPaths.png

### DIFF
--- a/docs/LinkingLibraries.md
+++ b/docs/LinkingLibraries.md
@@ -64,4 +64,4 @@ Paths`. There you should include the path to you library (if it has relevant
 files on subdirectories remember to make it `recursive`, like `React` on the
 example).
 
-![](/react-native/img/AddToSearchPaths.png)
+![](https://github.com/facebook/react-native/blob/master/website/src/react-native/img/AddToSearchPaths.png)


### PR DESCRIPTION
AddToSearchPaths.png failed to load properly. Fixed link to load same image from "react-native/website/src/react-native/img". Did not touch source code.


![screen shot 2015-03-31 at 7 27 12 pm](https://cloud.githubusercontent.com/assets/10624395/6933425/23f871d2-d7dc-11e4-876f-7d4249b83a6f.png)
