### PR TITLE
add maximumValue and minimumValue as valid attributes for native Slider

### DIFF
--- a/Libraries/Components/SliderIOS/SliderIOS.js
+++ b/Libraries/Components/SliderIOS/SliderIOS.js
@@ -82,6 +82,8 @@ var SliderIOS = React.createClass({
       <RCTSlider
         style={[styles.slider, this.props.style]}
         value={this.props.value}
+        maximumValue={this.props.maximumValue}
+        minimumValue={this.props.minimumValue}
         onChange={this._onValueChange}
       />
     );
@@ -94,8 +96,15 @@ var styles = StyleSheet.create({
   },
 });
 
+var validAttributes = {
+  ...ReactIOSViewAttributes.UIView,
+  value: true,
+  minimumValue: true,
+  maximumValue: true,
+};
+
 var RCTSlider = createReactIOSNativeComponentClass({
-  validAttributes: merge(ReactIOSViewAttributes.UIView, {value: true}),
+  validAttributes: validAttributes,
   uiViewClassName: 'RCTSlider',
 });
 


### PR DESCRIPTION
Noticed that the minimumValue and maximumValue for the SliderIOS component isn't actually picked up by the native slider that gets rendered. Issue #442

Test Plan: Add minimumValue and maximumValue prop to <SliderIOS> component in SliderIOSExample.js for UIExplorer (see screenshots)

![sliderios_maximumvalue](https://cloud.githubusercontent.com/assets/1103836/6946764/9ebe8db8-d870-11e4-84e5-7c31a955f9c0.png)
![sliderios_minimumvalue](https://cloud.githubusercontent.com/assets/1103836/6946765/9ec0031e-d870-11e4-8a1b-2371a5aa033a.png)
