### PR TITLE
Remove false annotation

### DIFF
--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -217,8 +217,6 @@ var TextInput = React.createClass({
      */
     onFocus: PropTypes.func,
     /**
-     * (text: string) => void
-     *
      * Callback that is called when the text input's text changes.
      */
     onChange: PropTypes.func,


### PR DESCRIPTION
I'd love to add annotations letting people know that this function and a few others take `SyntheticEvent`s but that may be inconsistent with the rest of the docs. For now, this particular annotation should be removed