### PR TITLE
Add promise support to AsyncStorage

### DIFF
--- a/Examples/UIExplorer/AsyncStorageExample.js
+++ b/Examples/UIExplorer/AsyncStorageExample.js
@@ -38,7 +38,8 @@ var BasicStorageExample = React.createClass({
           this._appendMessage('Initialized with no selection on disk.');
         }
       })
-      .catch((error) => this._appendMessage('AsyncStorage error: ' + error.message));
+      .catch((error) => this._appendMessage('AsyncStorage error: ' + error.message))
+      .done();
     });
   },
   getInitialState() {
@@ -84,13 +85,15 @@ var BasicStorageExample = React.createClass({
     this.setState({selectedValue});
     AsyncStorage.setItem(STORAGE_KEY, selectedValue)
       .then(() => this._appendMessage('Saved selection to disk: ' + selectedValue))
-      .catch((error) => this._appendMessage('AsyncStorage error: ' + error.message));
+      .catch((error) => this._appendMessage('AsyncStorage error: ' + error.message))
+      .done();
   },
 
   _removeStorage() {
     AsyncStorage.removeItem(STORAGE_KEY)
       .then(() => this._appendMessage('Selection removed from disk.'))
-      .catch((error) => { this._appendMessage('AsyncStorage error: ' + error.message) });
+      .catch((error) => { this._appendMessage('AsyncStorage error: ' + error.message) })
+      .done();
     });
   },
 

--- a/Examples/UIExplorer/AsyncStorageExample.js
+++ b/Examples/UIExplorer/AsyncStorageExample.js
@@ -30,8 +30,8 @@ var COLORS = ['red', 'orange', 'yellow', 'green', 'blue'];
 var BasicStorageExample = React.createClass({
   componentDidMount() {
     AsyncStorage.getItem(STORAGE_KEY)
-      .then(value => {
-        if(value !== null){
+      .then((value) => {
+        if (value !== null){
           this.setState({selectedValue: value});
           this._appendMessage('Recovered selection from disk: ' + value);
         } else {

--- a/Examples/UIExplorer/AsyncStorageExample.js
+++ b/Examples/UIExplorer/AsyncStorageExample.js
@@ -29,15 +29,16 @@ var COLORS = ['red', 'orange', 'yellow', 'green', 'blue'];
 
 var BasicStorageExample = React.createClass({
   componentDidMount() {
-    AsyncStorage.getItem(STORAGE_KEY, (error, value) => {
-      if (error) {
-        this._appendMessage('AsyncStorage error: ' + error.message);
-      } else if (value !== null) {
-        this.setState({selectedValue: value});
-        this._appendMessage('Recovered selection from disk: ' + value);
-      } else {
-        this._appendMessage('Initialized with no selection on disk.');
-      }
+    AsyncStorage.getItem(STORAGE_KEY)
+      .then(value => {
+        if(value !== null){
+          this.setState({selectedValue: value});
+          this._appendMessage('Recovered selection from disk: ' + value);
+        } else {
+          this._appendMessage('Initialized with no selection on disk.');
+        }
+      })
+      .catch((error) => this._appendMessage('AsyncStorage error: ' + error.message));
     });
   },
   getInitialState() {
@@ -81,22 +82,15 @@ var BasicStorageExample = React.createClass({
 
   _onValueChange(selectedValue) {
     this.setState({selectedValue});
-    AsyncStorage.setItem(STORAGE_KEY, selectedValue, (error) => {
-      if (error) {
-        this._appendMessage('AsyncStorage error: ' + error.message);
-      } else {
-        this._appendMessage('Saved selection to disk: ' + selectedValue);
-      }
-    });
+    AsyncStorage.setItem(STORAGE_KEY, selectedValue)
+      .then(() => this._appendMessage('Saved selection to disk: ' + selectedValue))
+      .catch((error) => this._appendMessage('AsyncStorage error: ' + error.message));
   },
 
   _removeStorage() {
-    AsyncStorage.removeItem(STORAGE_KEY, (error) => {
-      if (error) {
-        this._appendMessage('AsyncStorage error: ' + error.message);
-      } else {
-        this._appendMessage('Selection removed from disk.');
-      }
+    AsyncStorage.removeItem(STORAGE_KEY)
+      .then(() => this._appendMessage('Selection removed from disk.'))
+      .catch((error) => { this._appendMessage('AsyncStorage error: ' + error.message) });
     });
   },
 

--- a/Libraries/Storage/AsyncStorage.ios.js
+++ b/Libraries/Storage/AsyncStorage.ios.js
@@ -37,11 +37,18 @@ var AsyncStorage = {
   getItem: function(
     key: string,
     callback: (error: ?Error, result: ?string) => void
-  ): void {
-    RCTAsyncStorage.multiGet([key], function(errors, result) {
-      // Unpack result to get value from [[key,value]]
-      var value = (result && result[0] && result[0][1]) ? result[0][1] : null;
-      callback((errors && convertError(errors[0])) || null, value);
+  ): any {
+    return new Promise((resolve, reject) => {
+      RCTAsyncStorage.multiGet([key], function(errors, result) {
+        // Unpack result to get value from [[key,value]]
+        var value = (result && result[0] && result[0][1]) ? result[0][1] : null;
+        callback((errors && convertError(errors[0])) || null, value);
+        if(errors) {
+          reject(convertError(errors[0]));
+        } else {
+          resolve(value);
+        }
+      });
     });
   },
 
@@ -53,18 +60,32 @@ var AsyncStorage = {
     key: string,
     value: string,
     callback: ?(error: ?Error) => void
-  ): void {
-    RCTAsyncStorage.multiSet([[key,value]], function(errors) {
-      callback && callback((errors && convertError(errors[0])) || null);
+  ): any {
+    return new Promise((resolve, reject) => {
+      RCTAsyncStorage.multiSet([[key,value]], function(errors) {
+        callback && callback((errors && convertError(errors[0])) || null);
+        if(errors) {
+          reject(convertError(errors[0]));
+        } else {
+          resolve(null);
+        }
+      });
     });
   },
 
   removeItem: function(
     key: string,
     callback: ?(error: ?Error) => void
-  ): void {
-    RCTAsyncStorage.multiRemove([key], function(errors) {
-      callback && callback((errors && convertError(errors[0])) || null);
+  ): any {
+    return new Promise((resolve, reject) => {
+      RCTAsyncStorage.multiRemove([key], function(errors) {
+        callback && callback((errors && convertError(errors[0])) || null);
+        if(errors) {
+          reject(convertError(errors[0]));
+        } else {
+          resolve(null);
+        }
+      });
     });
   },
 
@@ -77,10 +98,17 @@ var AsyncStorage = {
     key: string,
     value: string,
     callback: ?(error: ?Error) => void
-  ): void {
-    RCTAsyncStorage.multiMerge([[key,value]], function(errors) {
-      callback && callback((errors && convertError(errors[0])) || null);
-    });
+  ): any {
+    return new Promise((resolve, reject) => {
+      RCTAsyncStorage.multiMerge([[key,value]], function(errors) {
+        callback && callback((errors && convertError(errors[0])) || null);
+        if(errors) {
+          reject(convertError(errors[0]));
+        } else {
+          resolve(null);
+        }
+      });
+    })
   },
 
   /**
@@ -89,8 +117,15 @@ var AsyncStorage = {
    * own keys instead.
    */
   clear: function(callback: ?(error: ?Error) => void) {
-    RCTAsyncStorage.clear(function(error) {
-      callback && callback(convertError(error));
+    return new Promise((resolve, reject) => {
+      RCTAsyncStorage.clear(function(error) {
+        //callback && callback(convertError(error));
+        if(errors && convertError(error)){
+          reject(convertError(error));
+        } else {
+          resolve(null);
+        }
+      });
     });
   },
 
@@ -98,8 +133,15 @@ var AsyncStorage = {
    * Gets *all* keys known to the system, for all callers, libraries, etc.
    */
   getAllKeys: function(callback: (error: ?Error) => void) {
-    RCTAsyncStorage.getAllKeys(function(error, keys) {
-      callback(convertError(error), keys);
+    return new Promise((resolve, reject) => {
+      RCTAsyncStorage.getAllKeys(function(error, keys) {
+        callback(convertError(error), keys);
+        if(error) {
+          reject(convertError(error));
+        } else {
+          resolve(keys);
+        }
+      });
     });
   },
 
@@ -122,12 +164,17 @@ var AsyncStorage = {
   multiGet: function(
     keys: Array<string>,
     callback: (errors: ?Array<Error>, result: ?Array<Array<string>>) => void
-  ): void {
-    RCTAsyncStorage.multiGet(keys, function(errors, result) {
-      callback(
-        (errors && errors.map((error) => convertError(error))) || null,
-        result
-      );
+  ): any {
+    return new Promise((resolve, reject) => {
+      RCTAsyncStorage.multiGet(keys, function(errors, result) {
+        var error = (errors && errors.map((error) => convertError(error))) || null;
+        callback(error, result);
+        if(errors) {
+          reject(error);
+        } else {
+          resolve(result);
+        }
+      });
     });
   },
 
@@ -140,11 +187,17 @@ var AsyncStorage = {
   multiSet: function(
     keyValuePairs: Array<Array<string>>,
     callback: ?(errors: ?Array<Error>) => void
-  ): void {
-    RCTAsyncStorage.multiSet(keyValuePairs, function(errors) {
-      callback && callback(
-        (errors && errors.map((error) => convertError(error))) || null
-      );
+  ): any {
+    return new Promise((resolve, reject) => {
+      RCTAsyncStorage.multiSet(keyValuePairs, function(errors) {
+        var error = (errors && errors.map((error) => convertError(error))) || null;
+        callback && callback(error);
+        if(errors) {
+          reject(error);
+        } else {
+          resolve(null);
+        }
+      });
     });
   },
 
@@ -154,11 +207,17 @@ var AsyncStorage = {
   multiRemove: function(
     keys: Array<string>,
     callback: ?(errors: ?Array<Error>) => void
-  ): void {
-    RCTAsyncStorage.multiRemove(keys, function(errors) {
-      callback && callback(
-        (errors && errors.map((error) => convertError(error))) || null
-      );
+  ): any {
+    return new Promise((resolve, reject) => {
+      RCTAsyncStorage.multiRemove(keys, function(errors) {
+        var error = (errors && errors.map((error) => convertError(error))) || null;
+        callback && callback(error);
+        if(errors) {
+          reject(error);
+        } else {
+          resolve(null);
+        }
+      });
     });
   },
 
@@ -171,11 +230,17 @@ var AsyncStorage = {
   multiMerge: function(
     keyValuePairs: Array<Array<string>>,
     callback: ?(errors: ?Array<Error>) => void
-  ): void {
-    RCTAsyncStorage.multiMerge(keyValuePairs, function(errors) {
-      callback && callback(
-        (errors && errors.map((error) => convertError(error))) || null
-      );
+  ): any {
+    return new Promise((resolve, reject) => {
+      RCTAsyncStorage.multiMerge(keyValuePairs, function(errors) {
+        var error = (errors && errors.map((error) => convertError(error))) || null;
+        callback && callback(error);
+        if(errors) {
+          reject(error);
+        } else {
+          resolve(null);
+        }
+      });
     });
   },
 };

--- a/Libraries/Storage/AsyncStorage.ios.js
+++ b/Libraries/Storage/AsyncStorage.ios.js
@@ -123,7 +123,7 @@ var AsyncStorage = {
     return new Promise((resolve, reject) => {
       RCTAsyncStorage.clear(function(error) {
         //callback && callback(convertError(error));
-        if(errors && convertError(error)){
+        if(error && convertError(error)){
           reject(convertError(error));
         } else {
           resolve(null);

--- a/Libraries/Storage/AsyncStorage.ios.js
+++ b/Libraries/Storage/AsyncStorage.ios.js
@@ -38,13 +38,13 @@ var AsyncStorage = {
   getItem: function(
     key: string,
     callback: (error: ?Error, result: ?string) => void
-  ): any {
+  ): Promise {
     return new Promise((resolve, reject) => {
       RCTAsyncStorage.multiGet([key], function(errors, result) {
         // Unpack result to get value from [[key,value]]
         var value = (result && result[0] && result[0][1]) ? result[0][1] : null;
         callback && callback((errors && convertError(errors[0])) || null, value);
-        if(errors) {
+        if (errors) {
           reject(convertError(errors[0]));
         } else {
           resolve(value);
@@ -61,11 +61,11 @@ var AsyncStorage = {
     key: string,
     value: string,
     callback: ?(error: ?Error) => void
-  ): any {
+  ): Promise {
     return new Promise((resolve, reject) => {
       RCTAsyncStorage.multiSet([[key,value]], function(errors) {
         callback && callback((errors && convertError(errors[0])) || null);
-        if(errors) {
+        if (errors) {
           reject(convertError(errors[0]));
         } else {
           resolve(null);
@@ -79,11 +79,11 @@ var AsyncStorage = {
   removeItem: function(
     key: string,
     callback: ?(error: ?Error) => void
-  ): any {
+  ): Promise {
     return new Promise((resolve, reject) => {
       RCTAsyncStorage.multiRemove([key], function(errors) {
         callback && callback((errors && convertError(errors[0])) || null);
-        if(errors) {
+        if (errors) {
           reject(convertError(errors[0]));
         } else {
           resolve(null);
@@ -101,11 +101,11 @@ var AsyncStorage = {
     key: string,
     value: string,
     callback: ?(error: ?Error) => void
-  ): any {
+  ): Promise {
     return new Promise((resolve, reject) => {
       RCTAsyncStorage.multiMerge([[key,value]], function(errors) {
         callback && callback((errors && convertError(errors[0])) || null);
-        if(errors) {
+        if (errors) {
           reject(convertError(errors[0]));
         } else {
           resolve(null);
@@ -119,11 +119,11 @@ var AsyncStorage = {
    * don't want to call this - use removeItem or multiRemove to clear only your
    * own keys instead. Returns a `Promise` object.
    */
-  clear: function(callback: ?(error: ?Error) => void) {
+  clear: function(callback: ?(error: ?Error) => void): Promise {
     return new Promise((resolve, reject) => {
       RCTAsyncStorage.clear(function(error) {
         //callback && callback(convertError(error));
-        if(error && convertError(error)){
+        if (error && convertError(error)){
           reject(convertError(error));
         } else {
           resolve(null);
@@ -135,11 +135,11 @@ var AsyncStorage = {
   /**
    * Gets *all* keys known to the system, for all callers, libraries, etc. Returns a `Promise` object.
    */
-  getAllKeys: function(callback: (error: ?Error) => void) {
+  getAllKeys: function(callback: (error: ?Error) => void): Promise {
     return new Promise((resolve, reject) => {
       RCTAsyncStorage.getAllKeys(function(error, keys) {
         callback && callback(convertError(error), keys);
-        if(error) {
+        if (error) {
           reject(convertError(error));
         } else {
           resolve(keys);
@@ -167,12 +167,12 @@ var AsyncStorage = {
   multiGet: function(
     keys: Array<string>,
     callback: (errors: ?Array<Error>, result: ?Array<Array<string>>) => void
-  ): any {
+  ): Promise {
     return new Promise((resolve, reject) => {
       RCTAsyncStorage.multiGet(keys, function(errors, result) {
         var error = (errors && errors.map((error) => convertError(error))) || null;
         callback && callback(error, result);
-        if(errors) {
+        if (errors) {
           reject(error);
         } else {
           resolve(result);
@@ -190,12 +190,12 @@ var AsyncStorage = {
   multiSet: function(
     keyValuePairs: Array<Array<string>>,
     callback: ?(errors: ?Array<Error>) => void
-  ): any {
+  ): Promise {
     return new Promise((resolve, reject) => {
       RCTAsyncStorage.multiSet(keyValuePairs, function(errors) {
         var error = (errors && errors.map((error) => convertError(error))) || null;
         callback && callback(error);
-        if(errors) {
+        if (errors) {
           reject(error);
         } else {
           resolve(null);
@@ -210,12 +210,12 @@ var AsyncStorage = {
   multiRemove: function(
     keys: Array<string>,
     callback: ?(errors: ?Array<Error>) => void
-  ): any {
+  ): Promise {
     return new Promise((resolve, reject) => {
       RCTAsyncStorage.multiRemove(keys, function(errors) {
         var error = (errors && errors.map((error) => convertError(error))) || null;
         callback && callback(error);
-        if(errors) {
+        if (errors) {
           reject(error);
         } else {
           resolve(null);
@@ -233,12 +233,12 @@ var AsyncStorage = {
   multiMerge: function(
     keyValuePairs: Array<Array<string>>,
     callback: ?(errors: ?Array<Error>) => void
-  ): any {
+  ): Promise {
     return new Promise((resolve, reject) => {
       RCTAsyncStorage.multiMerge(keyValuePairs, function(errors) {
         var error = (errors && errors.map((error) => convertError(error))) || null;
         callback && callback(error);
-        if(errors) {
+        if (errors) {
           reject(error);
         } else {
           resolve(null);

--- a/Libraries/Storage/AsyncStorage.ios.js
+++ b/Libraries/Storage/AsyncStorage.ios.js
@@ -27,12 +27,13 @@ var RCTAsyncStorage = RCTAsyncRocksDBStorage || RCTAsyncLocalStorage;
  * operates globally.
  *
  * This JS code is a simple facad over the native iOS implementation to provide
- * a clear JS API, real Error objects, and simple non-multi functions.
+ * a clear JS API, real Error objects, and simple non-multi functions. Each 
+ * method returns a `Promise` object.
  */
 var AsyncStorage = {
   /**
    * Fetches `key` and passes the result to `callback`, along with an `Error` if
-   * there is any.
+   * there is any. Returns a `Promise` object.
    */
   getItem: function(
     key: string,
@@ -54,7 +55,7 @@ var AsyncStorage = {
 
   /**
    * Sets `value` for `key` and calls `callback` on completion, along with an
-   * `Error` if there is any.
+   * `Error` if there is any. Returns a `Promise` object.
    */
   setItem: function(
     key: string,
@@ -72,7 +73,9 @@ var AsyncStorage = {
       });
     });
   },
-
+  /**
+   * Returns a `Promise` object.
+   */
   removeItem: function(
     key: string,
     callback: ?(error: ?Error) => void
@@ -90,7 +93,7 @@ var AsyncStorage = {
   },
 
   /**
-   * Merges existing value with input value, assuming they are stringified json.
+   * Merges existing value with input value, assuming they are stringified json. Returns a `Promise` object.
    *
    * Not supported by all native implementations.
    */
@@ -114,7 +117,7 @@ var AsyncStorage = {
   /**
    * Erases *all* AsyncStorage for all clients, libraries, etc.  You probably
    * don't want to call this - use removeItem or multiRemove to clear only your
-   * own keys instead.
+   * own keys instead. Returns a `Promise` object.
    */
   clear: function(callback: ?(error: ?Error) => void) {
     return new Promise((resolve, reject) => {
@@ -130,7 +133,7 @@ var AsyncStorage = {
   },
 
   /**
-   * Gets *all* keys known to the system, for all callers, libraries, etc.
+   * Gets *all* keys known to the system, for all callers, libraries, etc. Returns a `Promise` object.
    */
   getAllKeys: function(callback: (error: ?Error) => void) {
     return new Promise((resolve, reject) => {
@@ -157,7 +160,7 @@ var AsyncStorage = {
 
   /**
    * multiGet invokes callback with an array of key-value pair arrays that
-   * matches the input format of multiSet.
+   * matches the input format of multiSet. Returns a `Promise` object.
    *
    *   multiGet(['k1', 'k2'], cb) -> cb([['k1', 'val1'], ['k2', 'val2']])
    */
@@ -180,7 +183,7 @@ var AsyncStorage = {
 
   /**
    * multiSet and multiMerge take arrays of key-value array pairs that match
-   * the output of multiGet, e.g.
+   * the output of multiGet, e.g. Returns a `Promise` object.
    *
    *   multiSet([['k1', 'val1'], ['k2', 'val2']], cb);
    */
@@ -202,7 +205,7 @@ var AsyncStorage = {
   },
 
   /**
-   * Delete all the keys in the `keys` array.
+   * Delete all the keys in the `keys` array. Returns a `Promise` object.
    */
   multiRemove: function(
     keys: Array<string>,
@@ -223,7 +226,7 @@ var AsyncStorage = {
 
   /**
    * Merges existing values with input values, assuming they are stringified
-   * json.
+   * json. Returns a `Promise` object.
    *
    * Not supported by all native implementations.
    */

--- a/Libraries/Storage/AsyncStorage.ios.js
+++ b/Libraries/Storage/AsyncStorage.ios.js
@@ -43,7 +43,7 @@ var AsyncStorage = {
       RCTAsyncStorage.multiGet([key], function(errors, result) {
         // Unpack result to get value from [[key,value]]
         var value = (result && result[0] && result[0][1]) ? result[0][1] : null;
-        callback((errors && convertError(errors[0])) || null, value);
+        callback && callback((errors && convertError(errors[0])) || null, value);
         if(errors) {
           reject(convertError(errors[0]));
         } else {
@@ -138,7 +138,7 @@ var AsyncStorage = {
   getAllKeys: function(callback: (error: ?Error) => void) {
     return new Promise((resolve, reject) => {
       RCTAsyncStorage.getAllKeys(function(error, keys) {
-        callback(convertError(error), keys);
+        callback && callback(convertError(error), keys);
         if(error) {
           reject(convertError(error));
         } else {
@@ -171,7 +171,7 @@ var AsyncStorage = {
     return new Promise((resolve, reject) => {
       RCTAsyncStorage.multiGet(keys, function(errors, result) {
         var error = (errors && errors.map((error) => convertError(error))) || null;
-        callback(error, result);
+        callback && callback(error, result);
         if(errors) {
           reject(error);
         } else {


### PR DESCRIPTION
Since `AsyncStorage` is the primary cache, it would be nice to stick with fetch's promise model and make the common use-case of: 
1) check cache
2) make request if cache is invalid
more straightforward. Currently if I want to check a cache prior to using fetch (or another promise-based XHR lib) I have to provide a callback. I left the callback support and `resolve`/`reject` the promise after the callback has been applied.