### PR TITLE
Fail generating website if any page throws an error

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -14,5 +14,8 @@
     "react-docgen": "^1.1.0",
     "react-page-middleware": "git://github.com/facebook/react-page-middleware.git",
     "request": "*"
+  },
+  "devDependencies": {
+    "bluebird": "^2.9.21"
   }
 }


### PR DESCRIPTION
This will prevent us from having pages on the site that just show error
stack traces -- instead, Travis will fail with an error and we'll
notice sooner.

I cleaned up this logic to use promises which was way easier to track
for the error behavior and should be simpler to follow regardless.