### PR TITLE
unify use of password and secureTextEntry for TextInput

### DIFF
--- a/Examples/UIExplorer/TextInputExample.js
+++ b/Examples/UIExplorer/TextInputExample.js
@@ -251,7 +251,7 @@ exports.examples = [
       return (
         <View>
           <WithLabel label="true">
-            <TextInput secureTextEntry={true} style={styles.default} value="abc" />
+            <TextInput password={true} style={styles.default} value="abc" />
           </WithLabel>
         </View>
       );

--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -198,12 +198,6 @@ var TextInput = React.createClass({
      * automatically enables it when there is text. Default value is false.
      */
     enablesReturnKeyAutomatically: PropTypes.bool,
-
-    /**
-     * If true, the text input obscures the text entered so that sensitive text
-     * like passwords stay secure. Default value is false.
-     */
-    secureTextEntry: PropTypes.bool,
     /**
      * If true, the text input can be multiple lines. Default value is false.
      */
@@ -421,7 +415,7 @@ var TextInput = React.createClass({
           keyboardType={keyboardType}
           returnKeyType={returnKeyType}
           enablesReturnKeyAutomatically={this.props.enablesReturnKeyAutomatically}
-          secureTextEntry={this.props.secureTextEntry}
+          secureTextEntry={this.props.password || this.props.secureTextEntry}
           onFocus={this._onFocus}
           onBlur={this._onBlur}
           onChange={this._onChange}
@@ -466,7 +460,7 @@ var TextInput = React.createClass({
           keyboardType={keyboardType}
           returnKeyType={returnKeyType}
           enablesReturnKeyAutomatically={this.props.enablesReturnKeyAutomatically}
-          secureTextEntry={this.props.secureTextEntry}
+          secureTextEntry={this.props.password || this.props.secureTextEntry}
           onFocus={this._onFocus}
           onBlur={this._onBlur}
           onChange={this._onChange}
@@ -505,7 +499,7 @@ var TextInput = React.createClass({
         onFocus={this._onFocus}
         onBlur={this._onBlur}
         onChange={this._onChange}
-        password={this.props.password}
+        password={this.props.password || this.props.secureTextEntry}
         placeholder={this.props.placeholder}
         value={this.props.value}
         testID={this.props.testID}


### PR DESCRIPTION
Currently, the documentation shows both `password` and `secureTextEntry` as props for TextInput. However, the `password` prop is only passed to the Android component, so it does not work as expected for iOS developers. This PR prefers `password` over `secureTextEntry` but won't break anybody's code.