### PR TITLE
Fixed #632 using relative path instead of absolute path for Image tag

### DIFF
--- a/docs/EmbeddedApp.md
+++ b/docs/EmbeddedApp.md
@@ -85,7 +85,7 @@ React.AppRegistry.registerComponent('SimpleApp', () => SimpleApp);
 
 You should now add a container view for the React Native component. It can be any `UIView` in your app.
 
-![Container view example](https://github.com/facebook/react-native/blob/master/website/src/react-native/img/EmbeddedAppContainerViewExample.png)
+![Container view example](/react-native/img/EmbeddedAppContainerViewExample.png)
 
 However, let's subclass `UIView` for the sake of clean code. Let's name it `ReactView`. Open up `Yourproject.xcworkspace` and create a new class `ReactView` (You can name it whatever you like :)).
 
@@ -150,7 +150,7 @@ This command will start up a React Native development server within our CocoaPod
 
 Now compile and run your app. You shall now see your React Native app running inside of the `ReactView`.
 
-![Example](https://github.com/facebook/react-native/blob/master/website/src/react-native/img/EmbeddedAppExample.png)
+![Example](/react-native/img/EmbeddedAppExample.png)
 
 Live reload works from the simulator, too! You’ve got a simple React component totally encapsulated behind an Objective-C `UIView` subclass.
 


### PR DESCRIPTION
It cannot see the some images that are using absolute path on the [web page](http://facebook.github.io/react-native/docs/embeded-app.html#content),

so I think it should use absolute path.