### PR TITLE
[Flow] Add @providesModule to react-native.js so Flow picks it up

### DIFF
--- a/Libraries/react-native/react-native.js
+++ b/Libraries/react-native/react-native.js
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  *
+ * @providesModule react-native
  * @flow
  */
 'use strict';


### PR DESCRIPTION
When Flow is configured to use Haste paths it can't find "react-native", which doesn't have a `@providesModule` directive. I've seen a couple of other people comment on this. Adding it so that Flow support is better.