### PR TITLE
Fix typo and broken link.

### DIFF
--- a/docs/EmbeddedApp.md
+++ b/docs/EmbeddedApp.md
@@ -3,7 +3,7 @@ id: embedded-app
 title: Integration with Existing App
 layout: docs
 category: Guides
-permalink: docs/embeded-app.html
+permalink: docs/embedded-app.html
 next: activityindicatorios
 ---
 

--- a/docs/RunningOnDevice.md
+++ b/docs/RunningOnDevice.md
@@ -19,7 +19,7 @@ You can iterate quickly on device using development server. To do that, your lap
 
 > Hint
 >
-> Shake the device to open developemt menu (reload, debug, etc.)
+> Shake the device to open development menu (reload, debug, etc.)
 
 ## Using offline bundle
 


### PR DESCRIPTION
- Fixed a typo.
- Fixed **Next →** link at GUIDES Running On Device.