### PR TITLE
Don't try to commit website on Travis if no changes

### DIFF
--- a/website/publish.sh
+++ b/website/publish.sh
@@ -23,7 +23,10 @@ node server/generate.js
 cp -R build/react-native/* ../../react-native-gh-pages/
 rm -Rf build/
 cd ../../react-native-gh-pages
-git add --all
-git commit -m "update website"
-git push
+git status
+if ! git diff-index --quiet HEAD --; then
+  git add -A .
+  git commit -m "update website"
+  git push origin gh-pages
+fi
 cd ../react-native/website


### PR DESCRIPTION
This was causing the build to fail if the website hadn't changed,
because `git commit` would exit 1. This matches what we do on React now.