### PR TITLE
[Init] Add executor providers to RCTBridge's init method

### DIFF
--- a/React/Base/RCTBridge.h
+++ b/React/Base/RCTBridge.h
@@ -17,6 +17,7 @@
 
 @class RCTBridge;
 @class RCTEventDispatcher;
+@protocol RCTJavaScriptExecutorSource;
 
 /**
  * This notification triggers a reload of all bridges currently running.
@@ -36,7 +37,7 @@ extern NSString *const RCTJavaScriptDidFailToLoadNotification;
 /**
  * This block can be used to instantiate modules that require additional
  * init parameters, or additional configuration prior to being used.
- * The bridge will call this block to instatiate the modules, and will
+ * The bridge will call this block to instantiate the modules, and will
  * be responsible for invalidating/releasing them when the bridge is destroyed.
  * For this reason, the block should always return new module instances, and
  * module instances should not be shared between bridges.
@@ -57,13 +58,18 @@ RCT_EXTERN NSString *RCTBridgeModuleNameForClass(Class bridgeModuleClass);
  * The designated initializer. This creates a new bridge on top of the specified
  * executor. The bridge should then be used for all subsequent communication
  * with the JavaScript code running in the executor. Modules will be automatically
- * instantiated using the default contructor, but you can optionally pass in an
+ * instantiated using the default constructor, but you can optionally pass in an
  * array of pre-initialized module instances if they require additional init
  * parameters or configuration.
  */
 - (instancetype)initWithBundleURL:(NSURL *)bundleURL
                    moduleProvider:(RCTBridgeModuleProviderBlock)block
-                    launchOptions:(NSDictionary *)launchOptions NS_DESIGNATED_INITIALIZER;
+                    launchOptions:(NSDictionary *)launchOptions
+                   executorSource:(id<RCTJavaScriptExecutorSource>)executorSource NS_DESIGNATED_INITIALIZER;
+
+- (instancetype)initWithBundleURL:(NSURL *)bundleURL
+                   moduleProvider:(RCTBridgeModuleProviderBlock)block
+                    launchOptions:(NSDictionary *)launchOptions;
 
 /**
  * This method is used to call functions in the JavaScript application context.
@@ -90,7 +96,10 @@ static const char *__rct_import_##module##_##method##__ = #module"."#method;
  */
 @property (nonatomic, copy) NSURL *bundleURL;
 
-@property (nonatomic, strong) Class executorClass;
+/**
+ * The source of JavaScript executors used by this bridge.
+ */
+@property (nonatomic, strong, readonly) id<RCTJavaScriptExecutorSource> executorSource;
 
 /**
  * The event dispatcher is a wrapper around -enqueueJSCall:args: that provides a

--- a/React/Base/RCTJavaScriptExecutor.h
+++ b/React/Base/RCTJavaScriptExecutor.h
@@ -61,14 +61,12 @@ typedef void (^RCTJavaScriptCallback)(id json, NSError *error);
 @end
 
 static const char *RCTJavaScriptExecutorID = "RCTJavaScriptExecutorID";
-__used static id<RCTJavaScriptExecutor> RCTCreateExecutor(Class executorClass)
+__used static void RCTSetNewExecutorID(id<RCTJavaScriptExecutor> executor)
 {
   static NSUInteger executorID = 0;
-  id<RCTJavaScriptExecutor> executor = [[executorClass alloc] init];
   if (executor) {
     objc_setAssociatedObject(executor, RCTJavaScriptExecutorID, @(++executorID), OBJC_ASSOCIATION_RETAIN);
   }
-  return executor;
 }
 
 __used static NSNumber *RCTGetExecutorID(id<RCTJavaScriptExecutor> executor)

--- a/React/Base/RCTJavaScriptExecutorSource.h
+++ b/React/Base/RCTJavaScriptExecutorSource.h
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <Foundation/Foundation.h>
+
+@protocol RCTJavaScriptExecutor;
+
+@protocol RCTJavaScriptExecutorSource <NSObject>
+
+/**
+ * Return a new JavaScript executor to run a React application.
+ */
+- (id<RCTJavaScriptExecutor>)executor;
+
+@end

--- a/React/Base/RCTRootView.h
+++ b/React/Base/RCTRootView.h
@@ -11,6 +11,8 @@
 
 #import "RCTBridge.h"
 
+@class RCTStandardExecutorSource;
+
 /**
  * This notification is sent when the first subviews are added to the root view
  * after the application has loaded. This is used to hide the `loadingView`, and
@@ -63,11 +65,11 @@ extern NSString *const RCTContentDidAppearNotification;
 @property (nonatomic, copy) NSDictionary *initialProperties;
 
 /**
- * The class of the RCTJavaScriptExecutor to use with this view.
- * If not specified, it will default to using RCTContextExecutor.
- * Changes will take effect next time the bundle is reloaded.
+ * The source of the JavaScript executors that this RCTRootView uses. Set the
+ * executor type through the provider and reload the RCTRootView for a new
+ * executor.
  */
-@property (nonatomic, strong) Class executorClass;
+@property (nonatomic, strong, readonly) RCTStandardExecutorSource *executorSource;
 
 /**
  * The backing view controller of the root view.

--- a/React/Base/RCTRootView.m
+++ b/React/Base/RCTRootView.m
@@ -13,7 +13,6 @@
 
 #import "RCTAssert.h"
 #import "RCTBridge.h"
-#import "RCTContextExecutor.h"
 #import "RCTEventDispatcher.h"
 #import "RCTKeyCommands.h"
 #import "RCTLog.h"
@@ -22,7 +21,6 @@
 #import "RCTUIManager.h"
 #import "RCTUtils.h"
 #import "RCTView.h"
-#import "RCTWebViewExecutor.h"
 #import "UIView+React.h"
 
 NSString *const RCTContentDidAppearNotification = @"RCTContentDidAppearNotification";

--- a/React/Base/RCTStandardExecutorSource.h
+++ b/React/Base/RCTStandardExecutorSource.h
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <Foundation/Foundation.h>
+
+#import "RCTJavaScriptExecutorSource.h"
+
+typedef NS_ENUM(NSUInteger, RCTStandardExecutorType) {
+  RCTStandardExecutorTypeDefault,
+  RCTStandardExecutorTypeUIWebView,
+  RCTStandardExecutorTypeWebSocket,
+};
+
+@interface RCTStandardExecutorSource : NSObject <RCTJavaScriptExecutorSource>
+
+@property (nonatomic) RCTStandardExecutorType executorType;
+
+- (id<RCTJavaScriptExecutor>)executor;
+
+@end

--- a/React/Base/RCTStandardExecutorSource.m
+++ b/React/Base/RCTStandardExecutorSource.m
@@ -1,0 +1,48 @@
+// Copyright 2015-present Facebook. All rights reserved.
+
+#import "RCTStandardExecutorSource.h"
+
+#import "RCTContextExecutor.h"
+#import "RCTJavaScriptExecutor.h"
+#import "RCTLog.h"
+#import "RCTWebViewExecutor.h"
+
+@implementation RCTStandardExecutorSource
+
+- (instancetype)init
+{
+  if (self = [super init]) {
+    _executorType = RCTStandardExecutorTypeDefault;
+  }
+  return self;
+}
+
+- (id<RCTJavaScriptExecutor>)executor
+{
+  switch (_executorType) {
+    case RCTStandardExecutorTypeDefault:
+      return [[RCTContextExecutor alloc] init];
+    case RCTStandardExecutorTypeUIWebView: {
+      Class executorClass = NSClassFromString(@"RCTWebViewExecutor");
+      if (!executorClass) {
+        RCTLogError(@"Safari debugger is available only in development mode");
+        executorClass = [RCTContextExecutor class];
+      }
+      return [[executorClass alloc] init];
+    }
+    case RCTStandardExecutorTypeWebSocket: {
+      Class executorClass = NSClassFromString(@"RCTWebSocketExecutor");
+      if (!executorClass) {
+        [[[UIAlertView alloc] initWithTitle:@"Chrome Debugger Unavailable"
+                                    message:@"You need to include the RCTWebSocket library to enable Chrome debugging"
+                                   delegate:nil
+                          cancelButtonTitle:@"OK"
+                          otherButtonTitles:nil] show];
+        executorClass = [RCTContextExecutor class];
+      }
+      return [[executorClass alloc] init];
+    }
+  }
+}
+
+@end

--- a/React/React.xcodeproj/project.pbxproj
+++ b/React/React.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		58114A171AAE854800E7D092 /* RCTPickerManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 58114A151AAE854800E7D092 /* RCTPickerManager.m */; };
 		58114A501AAE93D500E7D092 /* RCTAsyncLocalStorage.m in Sources */ = {isa = PBXBuildFile; fileRef = 58114A4E1AAE93D500E7D092 /* RCTAsyncLocalStorage.m */; };
 		58C571C11AA56C1900CDF9C8 /* RCTDatePickerManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 58C571BF1AA56C1900CDF9C8 /* RCTDatePickerManager.m */; };
+		78B543961ADA560C00791665 /* RCTStandardExecutorSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 78B543951ADA560C00791665 /* RCTStandardExecutorSource.m */; };
 		830A229E1A66C68A008503DA /* RCTRootView.m in Sources */ = {isa = PBXBuildFile; fileRef = 830A229D1A66C68A008503DA /* RCTRootView.m */; };
 		830BA4551A8E3BDA00D53203 /* RCTCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 830BA4541A8E3BDA00D53203 /* RCTCache.m */; };
 		832348161A77A5AA00B55238 /* Layout.c in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FC71A68125100A75B9A /* Layout.c */; };
@@ -195,6 +196,9 @@
 		58114A4F1AAE93D500E7D092 /* RCTAsyncLocalStorage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTAsyncLocalStorage.h; sourceTree = "<group>"; };
 		58C571BF1AA56C1900CDF9C8 /* RCTDatePickerManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTDatePickerManager.m; sourceTree = "<group>"; };
 		58C571C01AA56C1900CDF9C8 /* RCTDatePickerManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTDatePickerManager.h; sourceTree = "<group>"; };
+		78B543941ADA560C00791665 /* RCTStandardExecutorSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTStandardExecutorSource.h; sourceTree = "<group>"; };
+		78B543951ADA560C00791665 /* RCTStandardExecutorSource.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTStandardExecutorSource.m; sourceTree = "<group>"; };
+		78B543AD1ADC604F00791665 /* RCTJavaScriptExecutorSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTJavaScriptExecutorSource.h; sourceTree = "<group>"; };
 		830213F31A654E0800B993E6 /* RCTBridgeModule.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RCTBridgeModule.h; sourceTree = "<group>"; };
 		830A229C1A66C68A008503DA /* RCTRootView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTRootView.h; sourceTree = "<group>"; };
 		830A229D1A66C68A008503DA /* RCTRootView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTRootView.m; sourceTree = "<group>"; };
@@ -407,6 +411,7 @@
 				83CBBA661A601EF300E9B192 /* RCTEventDispatcher.m */,
 				83CBBA4C1A601E3B00E9B192 /* RCTInvalidating.h */,
 				83CBBA631A601ECA00E9B192 /* RCTJavaScriptExecutor.h */,
+				78B543AD1ADC604F00791665 /* RCTJavaScriptExecutorSource.h */,
 				13A1F71C1A75392D00D3D453 /* RCTKeyCommands.h */,
 				13A1F71D1A75392D00D3D453 /* RCTKeyCommands.m */,
 				83CBBA4D1A601E3B00E9B192 /* RCTLog.h */,
@@ -415,6 +420,8 @@
 				83CBBA591A601E9000E9B192 /* RCTRedBox.m */,
 				830A229C1A66C68A008503DA /* RCTRootView.h */,
 				830A229D1A66C68A008503DA /* RCTRootView.m */,
+				78B543941ADA560C00791665 /* RCTStandardExecutorSource.h */,
+				78B543951ADA560C00791665 /* RCTStandardExecutorSource.m */,
 				00C1A2B11AC0B7E000E89A1C /* RCTDevMenu.h */,
 				00C1A2B21AC0B7E000E89A1C /* RCTDevMenu.m */,
 				83BEE46C1A6D19BC00B5863B /* RCTSparseArray.h */,
@@ -529,6 +536,7 @@
 				13B080201A69489C00A75B9A /* RCTActivityIndicatorViewManager.m in Sources */,
 				13E067561A70F44B002CDEE1 /* RCTViewManager.m in Sources */,
 				58C571C11AA56C1900CDF9C8 /* RCTDatePickerManager.m in Sources */,
+				78B543961ADA560C00791665 /* RCTStandardExecutorSource.m in Sources */,
 				13B080061A6947C200A75B9A /* RCTScrollViewManager.m in Sources */,
 				146459261B06C49500B389AA /* RCTFPSGraph.m in Sources */,
 				14200DAA1AC179B3008EE6BA /* RCTJavaScriptLoader.m in Sources */,


### PR DESCRIPTION
If you construct an RCTBridge you may want to configure the executor. However the constructor synchronously calls `setUp` and sets up the executor. Instead, let the code that constructs the bridge specify the executor and a debug executor up front. This allows for customizing the web view executor with a UIWebView of your choice, or configuring the URL of the debugger proxy that the web socket executor connects to.

Now that RCTRootView takes a bridge in one of its initializers, it is possible to create a bridge with a custom executor and then use that to set up a root view.

Fixes #288 and supersedes #291