### PR TITLE
[Headers] Add an umbrella header for the library

### DIFF
--- a/React/React.h
+++ b/React/React.h
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import "RCTAssert.h"
+#import "RCTBridge.h"
+#import "RCTBridgeDelegate.h"
+#import "RCTBridgeMethod.h"
+#import "RCTBridgeModule.h"
+#import "RCTConvert.h"
+#import "RCTDefines.h"
+#import "RCTEventDispatcher.h"
+#import "RCTFPSGraph.h"
+#import "RCTFrameUpdate.h"
+#import "RCTInvalidating.h"
+#import "RCTJavaScriptExecutor.h"
+#import "RCTJavaScriptLoader.h"
+#import "RCTJSMethodRegistrar.h"
+#import "RCTKeyboardObserver.h"
+#import "RCTKeyCommands.h"
+#import "RCTLog.h"
+#import "RCTModuleData.h"
+#import "RCTModuleMap.h"
+#import "RCTModuleMethod.h"
+#import "RCTPerformanceLogger.h"
+#import "RCTPerfStats.h"
+#import "RCTProfile.h"
+#import "RCTRootView.h"
+#import "RCTSparseArray.h"
+#import "RCTTouchHandler.h"
+#import "RCTURLRequestDelegate.h"
+#import "RCTURLRequestHandler.h"
+#import "RCTUtils.h"
+
+#import "RCTContextExecutor.h"
+#import "RCTWebViewExecutor.h"
+
+#import "RCTAccessibilityManager.h"
+#import "RCTAlertManager.h"
+#import "RCTAppState.h"
+#import "RCTAsyncLocalStorage.h"
+#import "RCTDevLoadingView.h"
+#import "RCTDevMenu.h"
+#import "RCTExceptionsManager.h"
+#import "RCTPointAnnotation.h"
+#import "RCTRedBox.h"
+#import "RCTSourceCode.h"
+#import "RCTStatusBarManager.h"
+#import "RCTTiming.h"
+#import "RCTUIManager.h"
+
+#import "RCTAnimationType.h"
+#import "RCTAutoInsetsProtocol.h"
+#import "RCTComponent.h"
+#import "RCTConvert+CoreLocation.h"
+#import "RCTConvert+MapKit.h"
+#import "RCTPointerEvents.h"
+#import "RCTScrollableProtocol.h"
+#import "RCTShadowView.h"
+#import "RCTView.h"
+#import "RCTViewControllerProtocol.h"
+#import "RCTViewManager.h"
+#import "UIView+React.h"

--- a/React/React.xcodeproj/project.pbxproj
+++ b/React/React.xcodeproj/project.pbxproj
@@ -238,6 +238,7 @@
 		63F014BE1B02080B003B75D2 /* RCTPointAnnotation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTPointAnnotation.h; sourceTree = "<group>"; };
 		63F014BF1B02080B003B75D2 /* RCTPointAnnotation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTPointAnnotation.m; sourceTree = "<group>"; };
 		6A15FB0C1BDF663500531DFB /* RCTRootViewInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTRootViewInternal.h; sourceTree = "<group>"; };
+		78BEE2481ABABC2E00F44561 /* React.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = React.h; sourceTree = "<group>"; };
 		830213F31A654E0800B993E6 /* RCTBridgeModule.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RCTBridgeModule.h; sourceTree = "<group>"; };
 		830A229C1A66C68A008503DA /* RCTRootView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTRootView.h; sourceTree = "<group>"; };
 		830A229D1A66C68A008503DA /* RCTRootView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTRootView.m; sourceTree = "<group>"; };
@@ -467,6 +468,7 @@
 		83CBBA2F1A601D0F00E9B192 /* React */ = {
 			isa = PBXGroup;
 			children = (
+				78BEE2481ABABC2E00F44561 /* React.h */,
 				83CBBA491A601E3B00E9B192 /* Base */,
 				134FCB381A6E7F0800051CC8 /* Executors */,
 				13B07FC41A68125100A75B9A /* Layout */,

--- a/scripts/generate-umbrella-header.sh
+++ b/scripts/generate-umbrella-header.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+set -e
+
+SCRIPTS=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+ROOT=$(dirname $SCRIPTS)
+
+LIBRARY_NAME="React"
+UMBRELLA_HEADER_PATH="${ROOT}/React/${LIBRARY_NAME}.h"
+
+cd $ROOT
+
+LIBRARY_HEADERS="\
+$(find React/Base -name "*.h" -exec basename {} \;)
+
+$(find React/Executors -name "*.h" -exec basename {} \;)
+
+$(find React/Modules -name "*.h" -exec basename {} \;)
+
+RCTAnimationType.h
+RCTAutoInsetsProtocol.h
+RCTComponent.h
+RCTConvert+CoreLocation.h
+RCTConvert+MapKit.h
+RCTPointerEvents.h
+RCTScrollableProtocol.h
+RCTShadowView.h
+RCTView.h
+RCTViewControllerProtocol.h
+RCTViewManager.h
+UIView+React.h\
+"
+
+echo \
+"/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+$(
+  echo "${LIBRARY_HEADERS}" |
+  awk -v lib="${LIBRARY_NAME}" '{if (NF) print "#import \""$0"\""; else print;}'
+ )\
+" > "${UMBRELLA_HEADER_PATH}"


### PR DESCRIPTION
Previous discussion in #261, looks like I accidentally closed it...

The umbrella header allows projects that link React Native to import it in standard fashion: `#import <React/React.h>`. Only some headers are included based on what I've found to be useful.

Generated with `scripts/generate-umbrella-header.sh`, which is a script that scans the Base and Executors directories for all headers and also includes some handpicked Views headers as well.