### PR TITLE
[TouchableHighlight] Set default underlayColor to UITableCell's gray

### DIFF
--- a/Libraries/Components/Touchable/TouchableHighlight.js
+++ b/Libraries/Components/Touchable/TouchableHighlight.js
@@ -29,7 +29,7 @@ var onlyChild = require('onlyChild');
 
 var DEFAULT_PROPS = {
   activeOpacity: 0.8,
-  underlayColor: 'black',
+  underlayColor: '#efeff4',
 };
 
 /**


### PR DESCRIPTION
The default was black, which doesn't seem very useful as a default. This diff makes it a light gray that iOS uses and is a better default. I don't think many (or any?) apps were relying on the black default so I'm not too concerned about backwards compatibility here.