### PR TITLE
[RFC: Exports] Add `invariant` to the exports for Flow compatibility

### DIFF
--- a/Libraries/react-native/react-native.js
+++ b/Libraries/react-native/react-native.js
@@ -62,6 +62,9 @@ var ReactNative = Object.assign(Object.create(require('React')), {
   NativeModules: require('NativeModules'),
   requireNativeComponent: require('requireNativeComponent'),
 
+  // Utilities
+  invariant: require('invariant'),
+
   addons: {
     LinkedStateMixin: require('LinkedStateMixin'),
     Perf: undefined,


### PR DESCRIPTION
This is kind of weird but bear with me... [Flow special-cases `invariant`](https://github.com/facebook/flow/blob/0f56d1742967b855ab5ee5eaee93d2edfc503e54/src/typing/type_inference_js.ml#L2048) so having it available is useful when using Flow. `invariant` is more of a Flow thing than a React thing, but React Native is also setting up the environment with `setTimeout` and `require` so it's kind of a gray area. Alternatively publishing `invariant` to npm instead of using static_upstream's copy would work too.