### PR TITLE
[AdSupportIOS] better module exports for AdSupportIOS

### DIFF
--- a/Examples/UIExplorer/AdSupportIOSExample.js
+++ b/Examples/UIExplorer/AdSupportIOSExample.js
@@ -15,13 +15,12 @@
  */
 'use strict';
 
-var AdSupportIOS = require('AdSupportIOS');
-
 var React = require('react-native');
 var {
   StyleSheet,
   Text,
   View,
+  AdSupportIOS,
 } = React;
 
 exports.framework = 'React';

--- a/Libraries/AdSupport/AdSupportIOS.js
+++ b/Libraries/AdSupport/AdSupportIOS.js
@@ -13,7 +13,7 @@
 
 var AdSupport = require('NativeModules').AdSupport;
 
-module.exports = {
+var AdSupportIOS = {
   getAdvertisingId: function(onSuccess: Function, onFailure: Function) {
     AdSupport.getAdvertisingId(onSuccess, onFailure);
   },
@@ -22,3 +22,5 @@ module.exports = {
     AdSupport.getAdvertisingTrackingEnabled(onSuccess, onFailure);
   },
 };
+
+module.exports = AdSupportIOS;

--- a/Libraries/react-native/react-native.js
+++ b/Libraries/react-native/react-native.js
@@ -40,6 +40,7 @@ var ReactNative = Object.assign(Object.create(require('React')), {
   WebView: require('WebView'),
 
   // APIs
+  AdSupportIOS: require('AdSupportIOS'),
   AlertIOS: require('AlertIOS'),
   Animation: require('Animation'),
   AppRegistry: require('AppRegistry'),


### PR DESCRIPTION
# Before:
```javascript
var AdSupportIOS = require('AdSupportIOS');
```
# After:
```javascript
var React = require('react-native');
var {
  //...
  AdSupportIOS,
  //...
} = React;
```