### PR TITLE
[ReactNative] Do flow check when running packager

### DIFF
--- a/React/Base/RCTRedBox.m
+++ b/React/Base/RCTRedBox.m
@@ -172,6 +172,7 @@
     cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleSubtitle reuseIdentifier:@"cell"];
     cell.textLabel.textColor = [[UIColor whiteColor] colorWithAlphaComponent:0.9];
     cell.textLabel.font = [UIFont fontWithName:@"Menlo-Regular" size:14];
+    cell.textLabel.numberOfLines = 2;
     cell.detailTextLabel.textColor = [[UIColor whiteColor] colorWithAlphaComponent:0.7];
     cell.detailTextLabel.font = [UIFont fontWithName:@"Menlo-Regular" size:11];
     cell.detailTextLabel.lineBreakMode = NSLineBreakByTruncatingMiddle;
@@ -196,7 +197,7 @@
     CGRect boundingRect = [_lastErrorMessage boundingRectWithSize:CGSizeMake(tableView.frame.size.width - 30, CGFLOAT_MAX) options:NSStringDrawingUsesLineFragmentOrigin attributes:attributes context:nil];
     return ceil(boundingRect.size.height) + 40;
   } else {
-    return 44;
+    return 50;
   }
 }
 

--- a/packager/packager.js
+++ b/packager/packager.js
@@ -39,6 +39,9 @@ var options = parseCommandLine([{
 }, {
   command: 'assetRoots',
   description: 'specify the root directories of app assets'
+}, {
+  command: 'skipflow',
+  description: 'Disable flow checks'
 }]);
 
 if (options.projectRoots) {
@@ -151,13 +154,13 @@ function getDevToolsLauncher(options) {
 }
 
 // A status page so the React/project.pbxproj build script
-// can verify that packager is running on 8081 and not 
+// can verify that packager is running on 8081 and not
 // another program / service.
 function statusPageMiddleware(req, res, next) {
   if (req.url === '/status') {
     res.end('packager-status:running');
   } else {
-    next();   
+    next();
   }
 }
 
@@ -168,6 +171,7 @@ function getAppMiddleware(options) {
     cacheVersion: '2',
     transformModulePath: require.resolve('./transformer.js'),
     assetRoots: options.assetRoots,
+    skipflow: options.skipflow,
   });
 }
 


### PR DESCRIPTION
Summary: Catch flow errors as soon and as actionably as possible, rather than at
commit or land time with console output.  Errors are reported such that they are
clickable in the RedBox to jump to source.

Task ID: #6684329

Reviewers: amasad,frantic

CC: vjeux,mroch,bhosmer

Test Plan:
screencast verifies that flow errors show up correctly and that normal errors
with stack traces still work as expected:

https://www.facebook.com/pxlcld/mdsS

Also tested `npm start -- --skipflow` to make sure the app will still build with
flow errors in that case.

Changed the name of the flow command to make sure installation detection logic
works correctly.