### PR TITLE
[Scroll] Include content insets in scroll events

### DIFF
--- a/React/Base/RCTEventDispatcher.m
+++ b/React/Base/RCTEventDispatcher.m
@@ -97,6 +97,12 @@ RCT_IMPORT_METHOD(RCTEventEmitter, receiveEvent);
       @"x": @(scrollView.contentOffset.x),
       @"y": @(scrollView.contentOffset.y)
     },
+    @"contentInset": @{
+      @"top": @(scrollView.contentInset.top),
+      @"left": @(scrollView.contentInset.left),
+      @"bottom": @(scrollView.contentInset.bottom),
+      @"right": @(scrollView.contentInset.right)
+    },
     @"contentSize": @{
       @"width": @(scrollView.contentSize.width),
       @"height": @(scrollView.contentSize.height)


### PR DESCRIPTION
When calculating how far the user has scrolled, it is necessary to know the content insets where:

    number of pixels scrolled = content offset + leading content inset for the scroll axis

This diff adds the contentInset field to native scroll events.