### PR TITLE
Fixes #738 by including missing local-cli folder in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "Examples/SampleApp",
     "Libraries",
     "packager",
+    "local-cli",
     "cli.js",
     "init.sh",
     "LICENSE",


### PR DESCRIPTION
`local-cli` was missing under files in `package.json`, so the folder was missing when people were doing `npm install` or `react-native init`.