### PR TITLE
Also call the original `console` methods if they exist

### DIFF
--- a/packager/react-packager/src/DependencyResolver/haste/polyfills/console.js
+++ b/packager/react-packager/src/DependencyResolver/haste/polyfills/console.js
@@ -26,9 +26,10 @@
     error: 4
   };
 
-  var originalConsole = global.console;
 
   function setupConsole(global) {
+
+    var originalConsole = global.console;
 
     if (!global.nativeLoggingHook) {
       return;
@@ -140,19 +141,13 @@
     // If available, also call the original `console` method since that is sometimes useful
     // Ex. On OS X, this will let you see rich output to the Safari REPL console
     if (originalConsole) {
-      for (var methodName in global.console) {
-        if (global.console.hasOwnProperty(methodName)) {
-          if (originalConsole[methodName]) {
-            (function () {
-              var nativeMethod = global.console[methodName];
-              global.console[methodName] = function () {
-                originalConsole[methodName].apply(originalConsole, arguments);
-                nativeMethod.apply(global.console, arguments);
-              };
-            })();
-          }
-        }
-      }
+      Object.keys(global.console).forEach((methodName) => {
+        var nativeMethod = global.console[methodName];
+        global.console[methodName] = function () {
+          originalConsole[methodName].apply(originalConsole, arguments);
+          nativeMethod.apply(global.console, arguments);
+        };
+      });
     }
 
   }

--- a/packager/react-packager/src/DependencyResolver/haste/polyfills/console.js
+++ b/packager/react-packager/src/DependencyResolver/haste/polyfills/console.js
@@ -26,6 +26,8 @@
     error: 4
   };
 
+  var originalConsole = global.console;
+
   function setupConsole(global) {
 
     if (!global.nativeLoggingHook) {
@@ -134,6 +136,24 @@
       trace: getNativeLogFunction(LOG_LEVELS.trace),
       table: consoleTablePolyfill
     };
+
+    // If available, also call the original `console` method since that is sometimes useful
+    // Ex. On OS X, this will let you see rich output to the Safari REPL console
+    if (originalConsole) {
+      for (var methodName in global.console) {
+        if (global.console.hasOwnProperty(methodName)) {
+          if (originalConsole[methodName]) {
+            (function () {
+              var nativeMethod = global.console[methodName];
+              global.console[methodName] = function () {
+                originalConsole[methodName].apply(originalConsole, arguments);
+                nativeMethod.apply(global.console, arguments);
+              };
+            })();
+          }
+        }
+      }
+    }
 
   }
 


### PR DESCRIPTION
Ex. When `console.log` or similar is called, this will call
the original method, which can be quite useful.

For example, under iOS, this will log to the Safari console debugger,
which has an expandable UI for inspecting objects, etc., and is also
just useful if you are using that as a REPL.

I don't believe this incurs a meaningful performance penalty unless
the console is open, but it would be easy to stick behind a flag
if that is a problem.

A slightly different version of this patch was submitted a while ago
and merged but something got screwed up with the merge and this change
was not actually pulled in. (See the weird unrelated commits and changes
attached to the PR #205)