### PR TITLE
[Runtimes] Alterations to enable the use of other objc based runtimes.

### DIFF
--- a/React/Base/RCTBridgeModule.h
+++ b/React/Base/RCTBridgeModule.h
@@ -81,6 +81,24 @@ typedef void (^RCTResponseSenderBlock)(NSArray *response);
   - (void)method
 
 /**
+ * Conforming classes may return an array of mixed NSStrings or [NSString,
+ * NSString], representing selector name or selector name and js method name,
+ * respectively. This is an alternative to the above RCT_EXPORT_METHOD macro.
+ */
++ (NSArray *)methodsToExport;
+
+/**
+ * An array of JavaScript methods that the class will call via the
+ * -[RCTBridge enqueueJSCall:args:] method. Each method should be specified
+ * as a string of the form "JSModuleName.jsMethodName". Attempting to call a
+ * method that has not been registered will result in an error. If a method
+ * has already been registered by another class, it is not necessary to
+ * register it again, but it is good practice. Registering the same method
+ * more than once is silently ignored and will not result in an error.
+ */
++ (NSArray *)JSMethods;
+
+/**
  * Injects constants into JS. These constants are made accessible via
  * NativeModules.ModuleName.X. This method is called when the module is
  * registered by the bridge. It is only called once for the lifetime of the


### PR DESCRIPTION
Hi, here's a pull request I hope you will consider.

This commit enables the use of alternative objc based runtimes.

Specifically, it has been tested to work with RubyMotion, but the changes should enable use in other runtimes where Protocol conformance is not easily stated and/or the ability to modify the data segment is not available.

The changes amount to -
1) Not relying on stated conformance to the RCTBridgeModule to solely determine modules to export
2) Having a class method that allows exporting of methods - in addition to RCT_EXPORT.

For 1), it's arguably more idiomatic in objc to check if an object quacks in the way we like, rather than applying a blanket check for compliance to a whole protocol. But the benefit to this duck typing is that if the alternate language/runtime has no natural way to express protocol conformance, things may function correctly as long as the appropriate methods are available.

I've tested the sample applications and ran the integration tests, everything appears to work fine. This is a code change that should be examined carefully though.

I've completed the CLA process.
