### PR TITLE
Warn when installing globally react-native instead of react-native-cli

### DIFF
--- a/local-cli/wrong-react-native.js
+++ b/local-cli/wrong-react-native.js
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+console.error([
+  '\033[31mLooks like you installed react-native globally, maybe you meant react-native-cli?',
+  'To fix the issue, run:\033[0m',
+  'npm uninstall -g react-native',
+  'npm install -g react-native-cli'
+].join('\n'));

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "start": "./packager/packager.sh"
   },
   "bin": {
+    "react-native": "local-cli/wrong-react-native.js",
     "react-native-start": "packager/packager.sh"
   },
   "dependencies": {


### PR DESCRIPTION
This adds a react-native binary that just output some instructions.

![screen shot 2015-04-08 at 8 15 41 am](https://cloud.githubusercontent.com/assets/197597/7048368/8891832c-ddc7-11e4-9e7d-593bd6793108.png)
