### PR TITLE
PR: Enable remote debugging automatically upon launch of the application

### DIFF
--- a/Examples/UIExplorer/UIExplorer/AppDelegate.m
+++ b/Examples/UIExplorer/UIExplorer/AppDelegate.m
@@ -42,6 +42,7 @@
   // jsCodeLocation = [[NSBundle mainBundle] URLForResource:@"main" withExtension:@"jsbundle"];
 
   RCTRootView *rootView = [[RCTRootView alloc] initWithBundleURL:jsCodeLocation
+                                                withDebugEnabled:NO  // YES to enable debugging upon app launch
                                                       moduleName:@"UIExplorerApp"
                                                    launchOptions:launchOptions];
 

--- a/Libraries/RCTTest/RCTTestRunner.m
+++ b/Libraries/RCTTest/RCTTestRunner.m
@@ -67,6 +67,7 @@
   RCTTestModule *testModule = [[RCTTestModule alloc] initWithSnapshotController:_snapshotController view:nil];
   testModule.testSelector = test;
   RCTBridge *bridge = [[RCTBridge alloc] initWithBundlePath:_script
+                                                withDebugEnabled:NO
                                                 moduleProvider:^(){
                                                   return @[testModule];
                                                 }

--- a/React/Base/RCTBridge.h
+++ b/React/Base/RCTBridge.h
@@ -49,6 +49,7 @@ extern NSString *RCTBridgeModuleNameForClass(Class bridgeModuleClass);
  * parameters or configuration.
  */
 - (instancetype)initWithBundlePath:(NSString *)bundlepath
+                  withDebugEnabled:(BOOL)debugEnabled
                     moduleProvider:(RCTBridgeModuleProviderBlock)block
                      launchOptions:(NSDictionary *)launchOptions NS_DESIGNATED_INITIALIZER;
 

--- a/React/Base/RCTBridge.m
+++ b/React/Base/RCTBridge.m
@@ -514,6 +514,7 @@ static NSDictionary *RCTLocalModulesConfig()
 static id<RCTJavaScriptExecutor> _latestJSExecutor;
 
 - (instancetype)initWithBundlePath:(NSString *)bundlePath
+                  withDebugEnabled:(BOOL)debugEnabled
                     moduleProvider:(RCTBridgeModuleProviderBlock)block
                      launchOptions:(NSDictionary *)launchOptions
 {
@@ -521,6 +522,11 @@ static id<RCTJavaScriptExecutor> _latestJSExecutor;
     _bundlePath = bundlePath;
     _moduleProvider = block;
     _launchOptions = launchOptions;
+#if DEBUG
+    if (debugEnabled == YES) {
+      self.executorClass = NSClassFromString(@"RCTWebSocketExecutor");
+    }
+#endif
     [self setUp];
     [self bindKeys];
   }

--- a/React/Base/RCTRootView.h
+++ b/React/Base/RCTRootView.h
@@ -31,6 +31,7 @@ extern NSString *const RCTReloadViewsNotification;
  * to all the instances.
  */
 - (instancetype)initWithBundleURL:(NSURL *)bundleURL
+                 withDebugEnabled:(BOOL)debugginEnable
                        moduleName:(NSString *)moduleName
                     launchOptions:(NSDictionary *)launchOptions;
 
@@ -72,6 +73,11 @@ extern NSString *const RCTReloadViewsNotification;
  */
 - (void)reload;
 + (void)reloadAll;
+
+/**
+ * Method to allow programmatic debug enable upon boot of the application
+ */
+- (void)toggleDebug;
 
 @property (nonatomic, weak) UIViewController *backingViewController;
 

--- a/React/Base/RCTRootView.h
+++ b/React/Base/RCTRootView.h
@@ -74,11 +74,6 @@ extern NSString *const RCTReloadViewsNotification;
 - (void)reload;
 + (void)reloadAll;
 
-/**
- * Method to allow programmatic debug enable upon boot of the application
- */
-- (void)toggleDebug;
-
 @property (nonatomic, weak) UIViewController *backingViewController;
 
 @property (nonatomic, strong, readonly) UIView *contentView;

--- a/React/Base/RCTRootView.m
+++ b/React/Base/RCTRootView.m
@@ -74,10 +74,12 @@ NSString *const RCTReloadViewsNotification = @"RCTReloadViewsNotification";
 }
 
 - (instancetype)initWithBundleURL:(NSURL *)bundleURL
+                  withDebugEnabled:(BOOL)debugEnabled
                        moduleName:(NSString *)moduleName
                     launchOptions:(NSDictionary *)launchOptions
 {
   RCTBridge *bridge = [[RCTBridge alloc] initWithBundlePath:bundleURL.absoluteString
+                                           withDebugEnabled:debugEnabled
                                              moduleProvider:nil
                                               launchOptions:launchOptions];
   return [self initWithBridge:bridge


### PR DESCRIPTION
I've had issues recently where I wanted debugging enabled upon launch of the application.  This patch does just that.

From AppDelegate.m, the end developer can change one boolean on the RootView initialization. 
```
  RCTRootView *rootView = [[RCTRootView alloc] initWithBundleURL:jsCodeLocation
                                                withDebugEnabled:NO  // YES to enable debugging upon app launch
                                                      moduleName:@"UIExplorerApp"
                                                   launchOptions:launchOptions];
```
This Boolean cascades the RootView into the Bridge instantiation, 
```
- (instancetype)initWithBundleURL:(NSURL *)bundleURL
                  withDebugEnabled:(BOOL)debugEnabled
                       moduleName:(NSString *)moduleName
                    launchOptions:(NSDictionary *)launchOptions
{
  RCTBridge *bridge = [[RCTBridge alloc] initWithBundlePath:bundleURL.absoluteString
                                           withDebugEnabled:debugEnabled
                                             moduleProvider:nil
                                              launchOptions:launchOptions];
  return [self initWithBridge:bridge
                   moduleName:moduleName];
}
```


where if YES, the executor class is configured  as   

 self.executorClass = NSClassFromString(@"RCTWebSocketExecutor");

```
- (instancetype)initWithBundlePath:(NSString *)bundlePath
                  withDebugEnabled:(BOOL)debugEnabled
                    moduleProvider:(RCTBridgeModuleProviderBlock)block
                     launchOptions:(NSDictionary *)launchOptions
{
  if ((self = [super init])) {
    _bundlePath = bundlePath;
    _moduleProvider = block;
    _launchOptions = launchOptions;
#if DEBUG
    if (debugEnabled == YES) {
      self.executorClass = NSClassFromString(@"RCTWebSocketExecutor");
    }
#endif
    [self setUp];
    [self bindKeys];
  }

  return self;
}
```
