### PR TITLE
Force curl to use IPv4

### DIFF
--- a/React/React.xcodeproj/project.pbxproj
+++ b/React/React.xcodeproj/project.pbxproj
@@ -452,7 +452,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if nc -w 5 -z localhost 8081 ; then\n  if ! curl -s \"http://localhost:8081/status\" | grep -q \"packager-status:running\" ; then\n    echo \"Port 8081 already in use, packager is either not running or not running correctly\"\n    exit 2\n  fi\nelse\n  open $SRCROOT/../packager/launchPackager.command || echo \"Can't start packager automatically\"\nfi";
+			shellScript = "if nc -w 5 -z localhost 8081 ; then\n  if ! curl -4 -s \"http://localhost:8081/status\" | grep -q \"packager-status:running\" ; then\n    echo \"Port 8081 already in use, packager is either not running or not running correctly\"\n    exit 2\n  fi\nelse\n  open $SRCROOT/../packager/launchPackager.command || echo \"Can't start packager automatically\"\nfi";
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
Due to a curl bug, `curl localhost` doesn't work if there's an IPv6 entry in `/etc/hosts` (I believe OSX Yosemite has this by default).

Say you've run `npm start` manually. When you run your project from XCode the build will fail citing:

```
Connection to localhost port 8081 [tcp/sunproxyadmin] succeeded!
Port 8081 already in use, packager is either not running or not running correctly
```

On any subsequent compile you must quit the packager first before compilation to avoid the compile time error (PITA).

There is only one packager instance running, but the script fails to detect the instance properly. Another possible solution (instead of forcing IPv4 mode) would be to use `0.0.0.0` in place of `localhost`.