### PR TITLE
Add links to homebrew, node, and npm to Setup

### DIFF
--- a/docs/Tutorial.md
+++ b/docs/Tutorial.md
@@ -16,7 +16,7 @@ We assume you have experience writing websites with React. If not, you can learn
 
 ## Setup
 
-React Native requires OSX, Xcode, Homebrew, node, npm, and [watchman](https://facebook.github.io/watchman/docs/install.html). [Flow](https://github.com/facebook/flow) is optional.
+React Native requires OSX, Xcode, [Homebrew](http://brew.sh/), [node](https://nodejs.org/download/), [npm](http://blog.npmjs.org/post/85484771375/how-to-install-npm), and [watchman](https://facebook.github.io/watchman/docs/install.html). [Flow](https://github.com/facebook/flow) is optional.
 
 After installing these dependencies there are two simple commands to get a React Native project all set up for development.
 


### PR DESCRIPTION
Watchmen had a link attached, so I added links for homebrew, node, and npm in case users are completely new to React

Before: 
![image](https://cloud.githubusercontent.com/assets/5377436/7055736/e082688e-de13-11e4-9256-abbd1ce2c8ac.png)

After: 
![image](https://cloud.githubusercontent.com/assets/5377436/7055738/ed2a86b6-de13-11e4-9b57-0301a2c3fb11.png)
