### PR TITLE
[RFC][ListView] Add getInnerViewNode, scrollTo, scrollWithoutAnimationTo

### DIFF
--- a/Libraries/CustomComponents/ListView/ListView.js
+++ b/Libraries/CustomComponents/ListView/ListView.js
@@ -198,9 +198,23 @@ var ListView = React.createClass({
     };
   },
 
+  getInnerViewNode: function() {
+    return this.refs[SCROLLVIEW_REF].getInnerViewNode();
+  },
+
+  scrollTo: function(destY, destX) {
+    this.refs[SCROLLVIEW_REF].scrollTo(destY, destX);
+  },
+
+  scrollWithoutAnimationTo: function(destY, destX) {
+    this.refs[SCROLLVIEW_REF].scrollWithoutAnimationTo(destY, destX);
+  },
+
   /**
    * Provides a handle to the underlying scroll responder to support operations
    * such as scrollTo.
+   *
+   * Deprecated: instead call scrollTo, etc. directly on this component
    */
   getScrollResponder: function() {
     return this.refs[SCROLLVIEW_REF];


### PR DESCRIPTION
After building some scroll view components (pull-to-refresh, infinite scroll) one of the most important features I found was composition of different scroll views. This diff adds scroll view methods to ListView so that it too acts like a scroll view and can be composed.

This is an RFC because I have another approach that is a little more robust but perhaps more obtuse. See #766.