### PR TITLE
Fix Link to Troubleshooting in GettingStarted.md

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -29,4 +29,4 @@ In the newly created folder `AwesomeProject/`
 
 Congratulations! You've just successfully run and modified your first React Native app.
 
-_If you run into any issues getting started, see the [troubleshooting page](/react-native/docs/troubleshooting.html#content)._
+_If you run into any issues getting started, see the [troubleshooting page](https://github.com/facebook/react-native/blob/master/docs/Troubleshooting.md)._


### PR DESCRIPTION
-The link to the troubleshooting page, when navigating from Github (and not the Github Pages site), lead to a 404. My pr replaces the link with a link to the Github troubleshooting page. Not sure what would make sense, and the previous situation might be preferable.