### PR TITLE
Escape URL string before creating an NSURL

### DIFF
--- a/Libraries/Network/RCTDataManager.m
+++ b/Libraries/Network/RCTDataManager.m
@@ -35,8 +35,10 @@ RCT_EXPORT_METHOD(queryData:(NSString *)queryType
       queryDict = RCTJSONParse(query, NULL);
     }
 
+    // Escape url entities
+    NSString *urlStr = [queryDict[@"url"] stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
     // Build request
-    NSURL *url = [NSURL URLWithString:queryDict[@"url"]];
+    NSURL *url = [NSURL URLWithString:urlStr];
     NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url];
     request.HTTPMethod = queryDict[@"method"] ?: @"GET";
     request.allHTTPHeaderFields = queryDict[@"headers"];


### PR DESCRIPTION
If we make a request that contains a pipe character, URLWithString will return null.  This fix escapes these and other characters before creating the NSURL.