### PR TITLE
[Image] Warn for width/height props

### DIFF
--- a/Libraries/Image/Image.ios.js
+++ b/Libraries/Image/Image.ios.js
@@ -119,6 +119,11 @@ var Image = React.createClass({
     if (this.props.style && this.props.style.tintColor) {
       warning(RawImage === RCTStaticImage, 'tintColor style only supported on static images.');
     }
+    
+    warning(
+      this.props.width === undefined && this.props.height === undefined,
+      'Width and height props are not supported. Please set them using a style instead.'
+    );
 
     var contentModes = NativeModules.UIManager.UIView.ContentMode;
     var resizeMode;


### PR DESCRIPTION
If the user passes in a width or height prop to the Image component, warn them that they should set these values using style instead.