### PR TITLE
Add a link to the Facebook community

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,7 @@ Facebook has a [bounty program](https://www.facebook.com/whitehat/) for the safe
 ## How to Get in Touch
 
 * IRC - [#reactnative on freenode](http://webchat.freenode.net/?channels=reactnative)
+* [Facebook group](https://www.facebook.com/groups/react.native.community/)
 
 ## Style Guide
 


### PR DESCRIPTION
Someone on IRC mentioned the Facebook community for React Native, but I don't
see it mentioned in any of the docs.