### PR TITLE
Add end-to-end test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ before_install:
   - brew update
 install:
   - brew reinstall flow watchman xctool
+  - npm config set spin=false
   - npm install
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,9 @@ script:
       node server/generate.js
     fi
 
+  elif [ "$TEST_TYPE" = e2e ]
+  then
+    ./scripts/e2e-test.sh
   else
     echo "Unknown test type: $TEST_TYPE"
     exit 1
@@ -57,6 +60,7 @@ env:
     - TEST_TYPE=objc
     - TEST_TYPE=js
     - TEST_TYPE=build_website
+    - TEST_TYPE=e2e
   global:
     - secure: "HlmG8M2DmBUSBh6KH1yVIe/8gR4iibg4WfcHq1x/xYQxGbvleq7NOo04V6eFHnl9cvZCu+PKH0841WLnGR7c4BBf47GVu/o16nXzggPumHKy++lDzxFPlJ1faMDfjg/5vjbAxRUe7D3y98hQSeGHH4tedc8LvTaFLVu7iiGqvjU="
 

--- a/scripts/.gitignore
+++ b/scripts/.gitignore
@@ -1,0 +1,1 @@
+.published-packages

--- a/scripts/.gitignore
+++ b/scripts/.gitignore
@@ -1,1 +1,0 @@
-.published-packages

--- a/scripts/e2e-npmrc
+++ b/scripts/e2e-npmrc
@@ -1,0 +1,5 @@
+; travis:travis
+_auth=dHJhdmlzOnRyYXZpcw==
+email=travis@example.com
+spin=false
+registry=http://localhost:4873/

--- a/scripts/e2e-sinopia.config.yml
+++ b/scripts/e2e-sinopia.config.yml
@@ -1,4 +1,4 @@
-storage: .published-packages
+storage: /tmp/sinopia-package-cache
 
 uplinks:
   npmjs:

--- a/scripts/e2e-sinopia.config.yml
+++ b/scripts/e2e-sinopia.config.yml
@@ -1,0 +1,21 @@
+storage: .published-packages
+
+uplinks:
+  npmjs:
+    url: https://registry.npmjs.org/
+
+packages:
+  'react-native':
+    allow_access: $all
+    allow_publish: $all
+
+  'react-native-cli':
+    allow_access: $all
+    allow_publish: $all
+
+  '*':
+    allow_access: $all
+    proxy: npmjs
+
+logs:
+  - {type: file, path: sinopia.log, format: pretty, level: http}

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -31,12 +31,16 @@ which sinopia || npm install -g sinopia
 [ -f ~/.npmrc ] && cp ~/.npmrc ~/.npmrc.bak
 cp $SCRIPTS/e2e-npmrc ~/.npmrc
 
-[ -d $SCRIPTS/.published-packages ] && rm -r $SCRIPTS/.published-packages
 sinopia --config $SCRIPTS/e2e-sinopia.config.yml &
 SINOPIA_PID=$!
 
+# Make sure to remove old version of react-native in
+# case it was cached
+npm unpublish react-native --force
+npm unpublish react-native-cli --force
 npm publish $ROOT
 npm publish $ROOT/react-native-cli
+
 
 npm install -g react-native-cli
 react-native init EndToEndTest
@@ -44,4 +48,5 @@ cd EndToEndTest
 
 # Make sure we installed local version of react-native
 ls `basename $MARKER` > /dev/null
-xctool -scheme EndToEndTest -sdk iphonesimulator8.1 test
+
+xctool -scheme EndToEndTest -sdk iphonesimulator test

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# Abort the mission if any command fails
+set -e
+
+SCRIPTS=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+ROOT=$(dirname $SCRIPTS)
+TEMP=$(mktemp -d /tmp/react-native-XXXXXXXX)
+
+# To make sure we actually installed the local version
+# of react-native, we will create a temp file inside SampleApp
+# and check that it exists after `react-native init`
+MARKER=$(mktemp $ROOT/Examples/SampleApp/XXXXXXXX)
+
+function cleanup {
+  kill -9 $SINOPIA_PID
+  mv ~/.npmrc.bak ~/.npmrc
+  rm $MARKER
+}
+trap cleanup EXIT
+
+cd $TEMP
+
+# sinopia is npm registry proxy, it is used to make npm
+# think react-native and react-native-cli are actually
+# published on npm
+which sinopia || npm install -g sinopia
+
+# but in order to make npm use sinopia we temporarily
+# replace its config file
+[ -f ~/.npmrc ] && cp ~/.npmrc ~/.npmrc.bak
+cp $SCRIPTS/e2e-npmrc ~/.npmrc
+
+[ -d $SCRIPTS/.published-packages ] && rm -r $SCRIPTS/.published-packages
+sinopia --config $SCRIPTS/e2e-sinopia.config.yml &
+SINOPIA_PID=$!
+
+npm publish $ROOT
+npm publish $ROOT/react-native-cli
+
+npm install -g react-native-cli
+react-native init EndToEndTest
+cd EndToEndTest
+
+# Make sure we installed local version of react-native
+ls `basename $MARKER` > /dev/null
+xctool -scheme EndToEndTest -sdk iphonesimulator8.2 test

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -13,9 +13,9 @@ TEMP=$(mktemp -d /tmp/react-native-XXXXXXXX)
 MARKER=$(mktemp $ROOT/Examples/SampleApp/XXXXXXXX)
 
 function cleanup {
-  kill -9 $SINOPIA_PID
-  mv ~/.npmrc.bak ~/.npmrc
   rm $MARKER
+  [ $SINOPIA_PID ] && kill -9 $SINOPIA_PID
+  [ -f ~/.npmrc.bak ] && mv ~/.npmrc.bak ~/.npmrc
 }
 trap cleanup EXIT
 
@@ -44,4 +44,4 @@ cd EndToEndTest
 
 # Make sure we installed local version of react-native
 ls `basename $MARKER` > /dev/null
-xctool -scheme EndToEndTest -sdk iphonesimulator8.2 test
+xctool -scheme EndToEndTest -sdk iphonesimulator8.1 test


### PR DESCRIPTION
The idea is to create a test that makes sure our npm publishing and `react-native init` workflow is smooth.
