### PR TITLE
[ReactNative|Easy] Change watchman too-long error message

### DIFF
--- a/packager/react-packager/src/FileWatcher/index.js
+++ b/packager/react-packager/src/FileWatcher/index.js
@@ -73,7 +73,7 @@ function createWatcher(rootConfig) {
       var rejectTimeout = setTimeout(function() {
         reject(new Error([
           'Watcher took too long to load',
-          'Try running `watchman` from your terminal',
+          'Try running `watchman version` from your terminal',
           'https://facebook.github.io/watchman/docs/troubleshooting.html',
         ].join('\n')));
       }, MAX_WAIT_TIME);


### PR DESCRIPTION
@wez Mentioned this in Issue #239 -- right now when watchman takes too long we recommend you run `watchman` from your terminal which actually expects some arguments, so it prints out the following:

```
[pcottle:~/Desktop/react-native:changeErrorMessage]$ watchman 
{
    "error": "invalid command (expected an array with some elements!)",
    "cli_validated": true,
    "version": "3.0.0"
}
```

basically this ends up being more confusing since the command we recommend you run errors out, so lets change it to `watchman version` which at least exists cleanly.

I kept the troubleshooting link as https://facebook.github.io/watchman/docs/troubleshooting.html since it sounds like we will update that with the issue people run into in #239 