### PR TITLE
Fix typo in PanResponder documentation

### DIFF
--- a/Libraries/vendor/react/browser/eventPlugins/PanResponder.js
+++ b/Libraries/vendor/react/browser/eventPlugins/PanResponder.js
@@ -64,7 +64,7 @@ var currentCentroidY = TouchHistoryMath.currentCentroidY;
  *         // The accumulated gesture distance since becoming responder is
  *         // gestureState.d{x,y}
  *       },
- *       onResponderTerminationRequest: (evt, gestureState) => true,
+ *       onPanResponderTerminationRequest: (evt, gestureState) => true,
  *       onPanResponderRelease: (evt, gestureState) => {
  *         // The user has released all touches while this view is the
  *         // responder. This typically means a gesture has succeeded


### PR DESCRIPTION
The documentation said the config object expected `onResponderTerminationRequest` but it expects `onPanResponderTerminationRequest`.