### PR TITLE
[Text] Add textDecoration style attributes

### DIFF
--- a/Examples/UIExplorer/TextExample.ios.js
+++ b/Examples/UIExplorer/TextExample.ios.js
@@ -184,11 +184,17 @@ exports.examples = [
         <Text style={{strikeThrough: 'none'}}>
           None strikeThrough line
         </Text>
-        <Text style={{strikeThrough: 'single'}}>
+        <Text style={{strikeThrough: 'solid'}}>
           Single strikeThrough line
         </Text>
-        <Text style={{strikeThrough: 'double', strikeThroughColor: '#C40000'}}>
+        <Text style={{strikeThrough: 'double', strikeThroughColor: '#00ff00'}}>
           Double strikeThrough line with custom color
+        </Text>
+        <Text style={{strikeThrough: 'dashed', strikeThroughColor: 'red'}}>
+          Dashed strikeThrough line with custom color
+        </Text>
+        <Text style={{strikeThrough: 'dotted', strikeThroughColor: '#0000ff'}}>
+          Dotted strikeThrough line with custom color
         </Text>
       </View>
     );

--- a/Examples/UIExplorer/TextExample.ios.js
+++ b/Examples/UIExplorer/TextExample.ios.js
@@ -177,24 +177,39 @@ exports.examples = [
     );
   },
 }, {
-  title: 'StrikeThrough',
+  title: 'Text Decoration',
   render: function() {
     return (
       <View>
-        <Text style={{strikeThrough: 'none'}}>
-          None strikeThrough line
+        <Text style={{textDecorationLine: 'underline', textDecorationStyle: 'solid'}}>
+          Solid underline
         </Text>
-        <Text style={{strikeThrough: 'solid'}}>
-          Single strikeThrough line
+        <Text style={{textDecorationLine: 'underline', textDecorationStyle: 'double', textDecorationColor: '#ff0000'}}>
+          Double underline line with custom color
         </Text>
-        <Text style={{strikeThrough: 'double', strikeThroughColor: '#00ffff'}}>
-          Double strikeThrough line with custom color
+        <Text style={{textDecorationLine: 'underline', textDecorationStyle: 'dashed', textDecorationColor: '#9CDC40'}}>
+          Dashed underline with custom color
         </Text>
-        <Text style={{strikeThrough: 'dashed', strikeThroughColor: 'red'}}>
-          Dashed strikeThrough line with custom color
-        </Text>
-        <Text style={{strikeThrough: 'dotted', strikeThroughColor: 'blue'}}>
+        <Text style={{textDecorationLine: 'underline', textDecorationStyle: 'dotted', textDecorationColor: 'blue'}}>
           Dotted strikeThrough line with custom color
+        </Text>
+        <Text style={{textDecorationLine: 'none'}}>
+          None textDecoration line
+        </Text>
+        <Text style={{textDecorationLine: 'line-through', textDecorationStyle: 'solid'}}>
+          Solid line-through
+        </Text>
+        <Text style={{textDecorationLine: 'line-through', textDecorationStyle: 'double', textDecorationColor: '#ff0000'}}>
+          Double line-through line with custom color
+        </Text>
+        <Text style={{textDecorationLine: 'line-through', textDecorationStyle: 'dashed', textDecorationColor: '#9CDC40'}}>
+          Dashed line-through with custom color
+        </Text>
+        <Text style={{textDecorationLine: 'line-through', textDecorationStyle: 'dotted', textDecorationColor: 'blue'}}>
+          Dotted line-through line with custom color
+        </Text>
+        <Text style={{textDecorationLine: 'underline line-through'}}>
+          Both underline and line-through
         </Text>
       </View>
     );

--- a/Examples/UIExplorer/TextExample.ios.js
+++ b/Examples/UIExplorer/TextExample.ios.js
@@ -191,7 +191,7 @@ exports.examples = [
           Dashed underline with custom color
         </Text>
         <Text style={{textDecorationLine: 'underline', textDecorationStyle: 'dotted', textDecorationColor: 'blue'}}>
-          Dotted strikeThrough line with custom color
+          Dotted underline line with custom color
         </Text>
         <Text style={{textDecorationLine: 'none'}}>
           None textDecoration line

--- a/Examples/UIExplorer/TextExample.ios.js
+++ b/Examples/UIExplorer/TextExample.ios.js
@@ -185,28 +185,28 @@ exports.examples = [
           Solid underline
         </Text>
         <Text style={{textDecorationLine: 'underline', textDecorationStyle: 'double', textDecorationColor: '#ff0000'}}>
-          Double underline line with custom color
+          Double underline with custom color
         </Text>
         <Text style={{textDecorationLine: 'underline', textDecorationStyle: 'dashed', textDecorationColor: '#9CDC40'}}>
           Dashed underline with custom color
         </Text>
         <Text style={{textDecorationLine: 'underline', textDecorationStyle: 'dotted', textDecorationColor: 'blue'}}>
-          Dotted underline line with custom color
+          Dotted underline with custom color
         </Text>
         <Text style={{textDecorationLine: 'none'}}>
-          None textDecoration line
+          None textDecoration
         </Text>
         <Text style={{textDecorationLine: 'line-through', textDecorationStyle: 'solid'}}>
           Solid line-through
         </Text>
         <Text style={{textDecorationLine: 'line-through', textDecorationStyle: 'double', textDecorationColor: '#ff0000'}}>
-          Double line-through line with custom color
+          Double line-through with custom color
         </Text>
         <Text style={{textDecorationLine: 'line-through', textDecorationStyle: 'dashed', textDecorationColor: '#9CDC40'}}>
           Dashed line-through with custom color
         </Text>
         <Text style={{textDecorationLine: 'line-through', textDecorationStyle: 'dotted', textDecorationColor: 'blue'}}>
-          Dotted line-through line with custom color
+          Dotted line-through with custom color
         </Text>
         <Text style={{textDecorationLine: 'underline line-through'}}>
           Both underline and line-through

--- a/Examples/UIExplorer/TextExample.ios.js
+++ b/Examples/UIExplorer/TextExample.ios.js
@@ -177,6 +177,23 @@ exports.examples = [
     );
   },
 }, {
+  title: 'StrikeThrough',
+  render: function() {
+    return (
+      <View>
+        <Text style={{strikeThrough: 'none'}}>
+          None strikeThrough line
+        </Text>
+        <Text style={{strikeThrough: 'single'}}>
+          Single strikeThrough line
+        </Text>
+        <Text style={{strikeThrough: 'double', strikeThroughColor: '#C40000'}}>
+          Double strikeThrough line with custom color
+        </Text>
+      </View>
+    );
+  },
+}, {
   title: 'Nested',
   description: 'Nested text components will inherit the styles of their ' +
     'parents (only backgroundColor is inherited from non-Text parents).  ' +

--- a/Examples/UIExplorer/TextExample.ios.js
+++ b/Examples/UIExplorer/TextExample.ios.js
@@ -187,13 +187,13 @@ exports.examples = [
         <Text style={{strikeThrough: 'solid'}}>
           Single strikeThrough line
         </Text>
-        <Text style={{strikeThrough: 'double', strikeThroughColor: '#00ff00'}}>
+        <Text style={{strikeThrough: 'double', strikeThroughColor: '#00ffff'}}>
           Double strikeThrough line with custom color
         </Text>
         <Text style={{strikeThrough: 'dashed', strikeThroughColor: 'red'}}>
           Dashed strikeThrough line with custom color
         </Text>
-        <Text style={{strikeThrough: 'dotted', strikeThroughColor: '#0000ff'}}>
+        <Text style={{strikeThrough: 'dotted', strikeThroughColor: 'blue'}}>
           Dotted strikeThrough line with custom color
         </Text>
       </View>

--- a/Libraries/Text/RCTShadowText.h
+++ b/Libraries/Text/RCTShadowText.h
@@ -27,6 +27,8 @@ extern NSString *const RCTReactTagAttributeName;
 @property (nonatomic, assign) NSTextAlignment textAlign;
 @property (nonatomic, strong) UIColor *textBackgroundColor;
 @property (nonatomic, assign) NSWritingDirection writingDirection;
+@property (nonatomic, assign) NSUnderlineStyle strikeThrough;
+@property (nonatomic, strong) UIColor *strikeThroughColor;
 
 - (void)recomputeText;
 

--- a/Libraries/Text/RCTShadowText.h
+++ b/Libraries/Text/RCTShadowText.h
@@ -8,6 +8,7 @@
  */
 
 #import "RCTShadowView.h"
+#import "RCTTextDecorationType.h"
 
 extern NSString *const RCTIsHighlightedAttributeName;
 extern NSString *const RCTReactTagAttributeName;
@@ -27,8 +28,9 @@ extern NSString *const RCTReactTagAttributeName;
 @property (nonatomic, assign) NSTextAlignment textAlign;
 @property (nonatomic, strong) UIColor *textBackgroundColor;
 @property (nonatomic, assign) NSWritingDirection writingDirection;
-@property (nonatomic, assign) NSUnderlineStyle strikeThrough;
-@property (nonatomic, strong) UIColor *strikeThroughColor;
+@property (nonatomic, strong) UIColor *textDecorationColor;
+@property (nonatomic, assign) NSUnderlineStyle textDecorationStyle;
+@property (nonatomic, assign) RCTTextDecorationType textDecorationLine;
 
 - (void)recomputeText;
 

--- a/Libraries/Text/RCTShadowText.m
+++ b/Libraries/Text/RCTShadowText.m
@@ -250,6 +250,14 @@ static css_dim_t RCTMeasure(void *context, float width)
                              value:paragraphStyle
                              range:(NSRange){0, attributedString.length}];
   }
+  
+  //line-through
+  self.strikeThrough = _strikeThrough ?: NSUnderlineStyleNone;
+  [self _addAttribute: NSStrikethroughStyleAttributeName withValue:[NSNumber numberWithInt:self.strikeThrough] toAttributedString:attributedString];
+  if(_strikeThroughColor) {
+    [self _addAttribute: NSStrikethroughColorAttributeName withValue: _strikeThroughColor toAttributedString:attributedString];
+  }
+  
 }
 
 - (void)fillCSSNode:(css_node_t *)node
@@ -291,5 +299,7 @@ RCT_TEXT_PROPERTY(ShadowOffset, _shadowOffset, CGSize)
 RCT_TEXT_PROPERTY(TextAlign, _textAlign, NSTextAlignment)
 RCT_TEXT_PROPERTY(TextBackgroundColor, _textBackgroundColor, UIColor *)
 RCT_TEXT_PROPERTY(WritingDirection, _writingDirection, NSWritingDirection)
+RCT_TEXT_PROPERTY(StrikeThrough, _strikeThrough, NSUnderlineStyle);
+RCT_TEXT_PROPERTY(StrikeThroughColor, _strikeThroughColor, UIColor *);
 
 @end

--- a/Libraries/Text/RCTShadowText.m
+++ b/Libraries/Text/RCTShadowText.m
@@ -251,11 +251,19 @@ static css_dim_t RCTMeasure(void *context, float width)
                              range:(NSRange){0, attributedString.length}];
   }
   
-  //line-through
-  self.strikeThrough = _strikeThrough ?: NSUnderlineStyleNone;
-  [self _addAttribute: NSStrikethroughStyleAttributeName withValue:[NSNumber numberWithInt:self.strikeThrough] toAttributedString:attributedString];
-  if(_strikeThroughColor) {
-    [self _addAttribute: NSStrikethroughColorAttributeName withValue: _strikeThroughColor toAttributedString:attributedString];
+ 
+  //underline and line-through
+  _textDecorationStyle = _textDecorationStyle ? : NSUnderlineStyleSingle;
+  if(_textDecorationLine == RCTTextDecorationTypeUnderline || _textDecorationLine == RCTTextDecorationTypeUnderlineStrikethrough) {
+    [self _addAttribute: NSUnderlineStyleAttributeName withValue:[NSNumber numberWithInt:_textDecorationStyle] toAttributedString:attributedString];
+  }
+  if(_textDecorationLine == RCTTextDecorationTypeStrikethrough || _textDecorationLine == RCTTextDecorationTypeUnderlineStrikethrough){
+    [self _addAttribute: NSStrikethroughStyleAttributeName withValue:[NSNumber numberWithInt:_textDecorationStyle] toAttributedString:attributedString];
+  }
+  
+  if(_textDecorationColor) {
+    [self _addAttribute: NSStrikethroughColorAttributeName withValue: _textDecorationColor toAttributedString:attributedString];
+    [self _addAttribute: NSUnderlineColorAttributeName withValue: _textDecorationColor toAttributedString:attributedString];
   }
   
 }
@@ -299,7 +307,8 @@ RCT_TEXT_PROPERTY(ShadowOffset, _shadowOffset, CGSize)
 RCT_TEXT_PROPERTY(TextAlign, _textAlign, NSTextAlignment)
 RCT_TEXT_PROPERTY(TextBackgroundColor, _textBackgroundColor, UIColor *)
 RCT_TEXT_PROPERTY(WritingDirection, _writingDirection, NSWritingDirection)
-RCT_TEXT_PROPERTY(StrikeThrough, _strikeThrough, NSUnderlineStyle);
-RCT_TEXT_PROPERTY(StrikeThroughColor, _strikeThroughColor, UIColor *);
+RCT_TEXT_PROPERTY(TextDecorationStyle, _textDecorationStyle, NSUnderlineStyle);
+RCT_TEXT_PROPERTY(TextDecorationColor, _textDecorationColor, UIColor *);
+RCT_TEXT_PROPERTY(TextDecorationLine, _textDecorationLine, RCTTextDecorationType);
 
 @end

--- a/Libraries/Text/RCTTextManager.m
+++ b/Libraries/Text/RCTTextManager.m
@@ -40,8 +40,9 @@ RCT_REMAP_VIEW_PROPERTY(containerBackgroundColor, backgroundColor, UIColor)
 #pragma mark - Shadow properties
 
 RCT_EXPORT_SHADOW_PROPERTY(writingDirection, NSWritingDirection)
-RCT_EXPORT_SHADOW_PROPERTY(strikeThrough, NSUnderlineStyle)
-RCT_EXPORT_SHADOW_PROPERTY(strikeThroughColor, UIColor)
+RCT_EXPORT_SHADOW_PROPERTY(textDecorationStyle, NSUnderlineStyle)
+RCT_EXPORT_SHADOW_PROPERTY(textDecorationColor, UIColor)
+RCT_EXPORT_SHADOW_PROPERTY(textDecorationLine, RCTTextDecorationType)
 RCT_EXPORT_SHADOW_PROPERTY(color, UIColor)
 RCT_EXPORT_SHADOW_PROPERTY(fontFamily, NSString)
 RCT_EXPORT_SHADOW_PROPERTY(fontSize, CGFloat)

--- a/Libraries/Text/RCTTextManager.m
+++ b/Libraries/Text/RCTTextManager.m
@@ -40,6 +40,8 @@ RCT_REMAP_VIEW_PROPERTY(containerBackgroundColor, backgroundColor, UIColor)
 #pragma mark - Shadow properties
 
 RCT_EXPORT_SHADOW_PROPERTY(writingDirection, NSWritingDirection)
+RCT_EXPORT_SHADOW_PROPERTY(strikeThrough, NSUnderlineStyle)
+RCT_EXPORT_SHADOW_PROPERTY(strikeThroughColor, UIColor)
 RCT_EXPORT_SHADOW_PROPERTY(color, UIColor)
 RCT_EXPORT_SHADOW_PROPERTY(fontFamily, NSString)
 RCT_EXPORT_SHADOW_PROPERTY(fontSize, CGFloat)

--- a/Libraries/Text/TextStylePropTypes.js
+++ b/Libraries/Text/TextStylePropTypes.js
@@ -35,7 +35,7 @@ var TextStylePropTypes = Object.assign(Object.create(ViewStylePropTypes), {
   ),
   letterSpacing: ReactPropTypes.number,
   strikeThrough:ReactPropTypes.oneOf(
-    ['none' /*default*/, 'single', 'double']
+    ['none' /*default*/, 'solid', 'double', 'dotted','dashed']
   ),
   strikeThroughColor: ReactPropTypes.string
 });

--- a/Libraries/Text/TextStylePropTypes.js
+++ b/Libraries/Text/TextStylePropTypes.js
@@ -34,6 +34,10 @@ var TextStylePropTypes = Object.assign(Object.create(ViewStylePropTypes), {
     ['auto' /*default*/, 'ltr', 'rtl']
   ),
   letterSpacing: ReactPropTypes.number,
+  strikeThrough:ReactPropTypes.oneOf(
+    ['none' /*default*/, 'single', 'double']
+  ),
+  strikeThroughColor: ReactPropTypes.string
 });
 
 // Text doesn't support padding correctly (#4841912)

--- a/Libraries/Text/TextStylePropTypes.js
+++ b/Libraries/Text/TextStylePropTypes.js
@@ -34,10 +34,13 @@ var TextStylePropTypes = Object.assign(Object.create(ViewStylePropTypes), {
     ['auto' /*default*/, 'ltr', 'rtl']
   ),
   letterSpacing: ReactPropTypes.number,
-  strikeThrough:ReactPropTypes.oneOf(
-    ['none' /*default*/, 'solid', 'double', 'dotted','dashed']
+  textDecorationLine:ReactPropTypes.oneOf(
+    ['none' /*default*/, 'underline', 'line-through', 'underline line-through']
   ),
-  strikeThroughColor: ReactPropTypes.string
+  textDecorationStyle:ReactPropTypes.oneOf(
+    ['solid' /*default*/, 'double', 'dotted','dashed']
+  ),
+  textDecorationColor: ReactPropTypes.string,
 });
 
 // Text doesn't support padding correctly (#4841912)

--- a/React/Base/RCTConvert.h
+++ b/React/Base/RCTConvert.h
@@ -51,6 +51,7 @@
 + (NSTimeInterval)NSTimeInterval:(id)json;
 
 + (NSTextAlignment)NSTextAlignment:(id)json;
++ (NSUnderlineStyle)NSUnderlineStyle:(id)json;
 + (NSWritingDirection)NSWritingDirection:(id)json;
 + (UITextAutocapitalizationType)UITextAutocapitalizationType:(id)json;
 + (UITextFieldViewMode)UITextFieldViewMode:(id)json;

--- a/React/Base/RCTConvert.h
+++ b/React/Base/RCTConvert.h
@@ -12,9 +12,11 @@
 
 #import "Layout.h"
 #import "RCTAnimationType.h"
+#import "RCTTextDecorationType.h"
 #import "RCTDefines.h"
 #import "RCTLog.h"
 #import "RCTPointerEvents.h"
+
 
 /**
  * This class provides a collection of conversion functions for mapping
@@ -121,6 +123,7 @@ typedef BOOL css_clip_t;
 
 + (RCTPointerEvents)RCTPointerEvents:(id)json;
 + (RCTAnimationType)RCTAnimationType:(id)json;
++ (RCTTextDecorationType)RCTTextDecorationType:(id)json;
 
 @end
 

--- a/React/Base/RCTConvert.m
+++ b/React/Base/RCTConvert.m
@@ -202,6 +202,12 @@ RCT_ENUM_CONVERTER(NSTextAlignment, (@{
   @"justify": @(NSTextAlignmentJustified),
 }), NSTextAlignmentNatural, integerValue)
 
+RCT_ENUM_CONVERTER(NSUnderlineStyle, (@{
+  @"none": @(NSUnderlineStyleNone),
+  @"single": @(NSUnderlineStyleSingle),
+  @"double": @(NSUnderlineStyleDouble),
+}), NSUnderlineStyleNone, integerValue)
+
 RCT_ENUM_CONVERTER(NSWritingDirection, (@{
   @"auto": @(NSWritingDirectionNatural),
   @"ltr": @(NSWritingDirectionLeftToRight),

--- a/React/Base/RCTConvert.m
+++ b/React/Base/RCTConvert.m
@@ -204,8 +204,10 @@ RCT_ENUM_CONVERTER(NSTextAlignment, (@{
 
 RCT_ENUM_CONVERTER(NSUnderlineStyle, (@{
   @"none": @(NSUnderlineStyleNone),
-  @"single": @(NSUnderlineStyleSingle),
+  @"solid": @(NSUnderlineStyleSingle),
   @"double": @(NSUnderlineStyleDouble),
+  @"dotted": @(NSUnderlinePatternDot | NSUnderlineStyleSingle),
+  @"dashed": @(NSUnderlinePatternDash | NSUnderlineStyleSingle),
 }), NSUnderlineStyleNone, integerValue)
 
 RCT_ENUM_CONVERTER(NSWritingDirection, (@{

--- a/React/Base/RCTConvert.m
+++ b/React/Base/RCTConvert.m
@@ -203,12 +203,18 @@ RCT_ENUM_CONVERTER(NSTextAlignment, (@{
 }), NSTextAlignmentNatural, integerValue)
 
 RCT_ENUM_CONVERTER(NSUnderlineStyle, (@{
-  @"none": @(NSUnderlineStyleNone),
   @"solid": @(NSUnderlineStyleSingle),
   @"double": @(NSUnderlineStyleDouble),
   @"dotted": @(NSUnderlinePatternDot | NSUnderlineStyleSingle),
   @"dashed": @(NSUnderlinePatternDash | NSUnderlineStyleSingle),
-}), NSUnderlineStyleNone, integerValue)
+}), NSUnderlineStyleSingle, integerValue)
+
+RCT_ENUM_CONVERTER(RCTTextDecorationType, (@{
+  @"none": @(RCTTextDecorationTypeNone),
+  @"underline": @(RCTTextDecorationTypeUnderline),
+  @"line-through": @(RCTTextDecorationTypeStrikethrough),
+  @"underline line-through": @(RCTTextDecorationTypeUnderlineStrikethrough),
+}), RCTTextDecorationTypeNone, integerValue)
 
 RCT_ENUM_CONVERTER(NSWritingDirection, (@{
   @"auto": @(NSWritingDirectionNatural),

--- a/React/React.xcodeproj/project.pbxproj
+++ b/React/React.xcodeproj/project.pbxproj
@@ -226,6 +226,7 @@
 		83CBBA971A6020BB00E9B192 /* RCTTouchHandler.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTTouchHandler.m; sourceTree = "<group>"; };
 		83CBBACA1A6023D300E9B192 /* RCTConvert.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTConvert.h; sourceTree = "<group>"; };
 		83CBBACB1A6023D300E9B192 /* RCTConvert.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTConvert.m; sourceTree = "<group>"; };
+		E3BBC8EB1ADE6F47001BBD81 /* RCTTextDecorationType.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RCTTextDecorationType.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -361,6 +362,7 @@
 				13B080241A694A8400A75B9A /* RCTWrapperViewController.m */,
 				13E067531A70F44B002CDEE1 /* UIView+React.h */,
 				13E067541A70F44B002CDEE1 /* UIView+React.m */,
+				E3BBC8EB1ADE6F47001BBD81 /* RCTTextDecorationType.h */,
 			);
 			path = Views;
 			sourceTree = "<group>";

--- a/React/Views/RCTTextDecorationType.h
+++ b/React/Views/RCTTextDecorationType.h
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <Foundation/Foundation.h>
+
+typedef NS_ENUM(NSInteger, RCTTextDecorationType) {
+  RCTTextDecorationTypeNone = 0,
+  RCTTextDecorationTypeUnderline,
+  RCTTextDecorationTypeStrikethrough,
+  RCTTextDecorationTypeUnderlineStrikethrough,
+};


### PR DESCRIPTION
I add `textDecorationLine`, `textDecorationStyle`, `textDecorationColor` style property for Text module.

And it follows the CSS naming convention and using method is same with CSS.

1. `textDecorationLine` refers to: https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line
2. `textDecorationStyle` refers to: https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style
3. `textDecorationColor`refers to: https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color

Here is a simple demo:

```javascript
<Text style={{textDecorationLine: 'underline', textDecorationStyle: 'solid'}}>
  Solid underline
</Text>
<Text style={{textDecorationLine: 'underline', textDecorationStyle: 'double', textDecorationColor: '#ff0000'}}>
  Double underline with custom color
</Text>
<Text style={{textDecorationLine: 'underline', textDecorationStyle: 'dashed', textDecorationColor: '#9CDC40'}}>
  Dashed underline with custom color
</Text>
<Text style={{textDecorationLine: 'underline', textDecorationStyle: 'dotted', textDecorationColor: 'blue'}}>
  Dotted underline with custom color
</Text>
<Text style={{textDecorationLine: 'none'}}>
  None textDecoration
</Text>
<Text style={{textDecorationLine: 'line-through', textDecorationStyle: 'solid'}}>
  Solid line-through
</Text>
<Text style={{textDecorationLine: 'line-through', textDecorationStyle: 'double', textDecorationColor: '#ff0000'}}>
  Double line-through with custom color
</Text>
<Text style={{textDecorationLine: 'line-through', textDecorationStyle: 'dashed', textDecorationColor: '#9CDC40'}}>
  Dashed line-through with custom color
</Text>
<Text style={{textDecorationLine: 'line-through', textDecorationStyle: 'dotted', textDecorationColor: 'blue'}}>
  Dotted line-through with custom color
</Text>
<Text style={{textDecorationLine: 'underline line-through'}}>
  Both underline and line-through
</Text>
```

￼
![2015-04-15 8 48 20](https://cloud.githubusercontent.com/assets/1238134/7158989/9451071a-e3b1-11e4-929e-a71c10f0884e.png)