### PR TITLE
When the app is rotated, reload the root view.

### DIFF
--- a/React/Base/RCTRootView.m
+++ b/React/Base/RCTRootView.m
@@ -109,6 +109,10 @@ NSString *const RCTReloadViewsNotification = @"RCTReloadViewsNotification";
                                              selector:@selector(reload)
                                                  name:RCTReloadViewsNotification
                                                object:_bridge];
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(reload)
+                                                 name:UIDeviceOrientationDidChangeNotification
+                                               object:nil];
     if (_bridge.loaded) {
       [self bundleFinishedLoading];
     } else {


### PR DESCRIPTION
A simple fix to rotation issue: on rotate simply reload the root view. 

Ideally it should animate the changes, but until I figure out how to do that this should do.

~~Fixes~~ Workaround #813.