### PR TITLE
Bundle script instead of curl

### DIFF
--- a/Examples/SampleApp/iOS/AppDelegate.m
+++ b/Examples/SampleApp/iOS/AppDelegate.m
@@ -29,9 +29,10 @@
   jsCodeLocation = [NSURL URLWithString:@"http://localhost:8081/Examples/SampleApp/index.ios.bundle"];
 
   // OPTION 2
-  // Load from pre-bundled file on disk. To re-generate the static bundle, run
+  // Load from pre-bundled file on disk. To re-generate the static bundle,
+  // from the root of your project directory, run
   //
-  // $ curl 'http://localhost:8081/Examples/SampleApp/index.ios.bundle?dev=false&minify=true' -o iOS/main.jsbundle
+  // $ react-native bundle
   //
   // and uncomment the next following line
   // jsCodeLocation = [[NSBundle mainBundle] URLForResource:@"main" withExtension:@"jsbundle"];

--- a/docs/RunningOnDevice.md
+++ b/docs/RunningOnDevice.md
@@ -28,12 +28,12 @@ You can also pack all the JavaScript code within the app itself. This way you ca
 1. Open `iOS/AppDelegate.m`
 2. Follow the instructions for "OPTION 2":
   * Uncomment `jsCodeLocation = [[NSBundle mainBundle] ...`
-  * Run given `curl` command in terminal from the root directory of your app
+  * Run the `react-native bundle` command in terminal from the root directory of your app
 
-Packager supports a couple of options:
+The bundle script supports a couple of flags:
 
-* `dev` (true by default) - sets the value of `__DEV__` variable. When `true` it turns on a bunch of useful development warnings. For production it is recommended to use `dev=false`.
-* `minify` (false by default) - whether or not to pipe the JS code through UglifyJS.
+* `--dev` - sets the value of `__DEV__` variable to true. When `true` it turns on a bunch of useful development warnings. For production it is recommended to set `__DEV__=false`.
+* `--minify` - pipe the JS code through UglifyJS.
 
 ## Troubleshooting
 

--- a/local-cli/bundle.js
+++ b/local-cli/bundle.js
@@ -1,0 +1,65 @@
+var http = require('http');
+var fs = require('fs');
+var path = require('path');
+var chalk = require('chalk');
+var blacklist = require('../packager/blacklist.js');
+var ReactPackager = require('../packager/react-packager');
+
+var OUT_PATH = 'iOS/main.jsbundle';
+
+function getBundle(flags) {
+
+  var options = {
+    projectRoots: [path.resolve(__dirname, '../../..')],
+    transformModulePath: require.resolve('../packager/transformer.js'),
+    assetRoots: [path.resolve(__dirname, '../../..')],
+    cacheVersion: '2',
+    blacklistRE: blacklist('ios')
+  };
+
+  var url = '/index.ios.bundle?dev=' + flags.dev;
+
+  console.log('Building package...');
+  ReactPackager.buildPackageFromUrl(options, url)
+    .done(function(bundle) {
+      console.log('Build complete');
+      fs.writeFile(OUT_PATH, bundle.getSource({
+        inlineSourceMap: false,
+        minify: flags.minify
+      }), function(err) {
+        if (err) {
+          console.log(chalk.red('Error saving bundle to disk'));
+          throw err;
+        } else {
+          console.log('Successfully saved bundle to ' + OUT_PATH);
+        }
+      });
+    });
+}
+
+function showHelp() {
+  console.log([
+    'Usage: react-native bundle [options]',
+    '',
+    'Options:',
+    '  --dev\t\tsets DEV flag to true',
+    '  --minify\tminify js bundle'
+  ].join('\n'));
+  process.exit(1);
+}
+
+module.exports = {
+  init: function(args) {
+    var flags = {
+      help: args.indexOf('--help') !== -1,
+      dev: args.indexOf('--dev') !== -1,
+      minify: args.indexOf('--minify') !== -1
+    }
+
+    if (flags.help) {
+      showHelp();
+    } else {
+      getBundle(flags);
+    }
+  }
+}

--- a/local-cli/cli.js
+++ b/local-cli/cli.js
@@ -7,6 +7,7 @@
 var spawn = require('child_process').spawn;
 var path = require('path');
 var install = require('./install.js');
+var bundle = require('./bundle.js');
 
 function printUsage() {
   console.log([
@@ -14,7 +15,8 @@ function printUsage() {
     '',
     'Commands:',
     '  start: starts the webserver',
-    '  install: installs npm react components'
+    '  install: installs npm react components',
+    '  bundle: builds the javascript bundle for offline use'
   ].join('\n'));
   process.exit(1);
 }
@@ -35,6 +37,9 @@ function run() {
     break;
   case 'install':
     install.init();
+    break;
+  case 'bundle':
+    bundle.init(args);
     break;
   default:
     console.error('Command `%s` unrecognized', args[0]);


### PR DESCRIPTION
This is an initial stab at creating a node-based bundling script so that you don't have to manually run `curl`. My idea was to have it as a command under `react-native`. It allows command line flags for `dev` and `minify`. It still requires the server to be up, but I hope to detect that and maybe automatically run the server in the future.

Wondering if this is a good idea and if so, the right approach.