### PR TITLE
[Docs] Fix formatting for "JavaScript method names" section in docs

### DIFF
--- a/docs/NativeModulesIOS.md
+++ b/docs/NativeModulesIOS.md
@@ -51,7 +51,8 @@ var CalendarManager = require('NativeModules').CalendarManager;
 CalendarManager.addEvent('Birthday Party', '4 Privet Drive, Surrey');
 ```
 
-> **NOTE:** JavaScript method names
+> **NOTE**: JavaScript method names
+>
 > The name of the method exported to JavaScript is the native method's name up to the first colon. React Native also defines a macro called `RCT_REMAP_METHOD` to specify the JavaScript method's name. This is useful when multiple native methods are the same up to the first colon and would have conflicting JavaScript names.
 
 The return type of bridge methods is always `void`. React Native bridge is asynchronous, so the only way to pass a result to JavaScript is by using callbacks or emitting events (see below).


### PR DESCRIPTION
Simple fix - GitHub's markdown is processed differently than Jekyll's, so just fixing things up to look better.