### PR TITLE
[Errors] Fix Red Box by fixing providesModule parsing

### DIFF
--- a/packager/react-packager/src/DependencyResolver/haste/DependencyGraph/index.js
+++ b/packager/react-packager/src/DependencyResolver/haste/DependencyGraph/index.js
@@ -437,8 +437,9 @@ DependecyGraph.prototype._processModule = function(modulePath) {
     .then(function(content) {
       var moduleDocBlock = docblock.parseAsObject(content);
       if (moduleDocBlock.providesModule || moduleDocBlock.provides) {
-        moduleData.id =
-          moduleDocBlock.providesModule || moduleDocBlock.provides;
+        moduleData.id = /^(\S*)/.exec(
+          moduleDocBlock.providesModule || moduleDocBlock.provides
+        )[1];
 
         // Incase someone wants to require this module via
         // packageName/path/to/module


### PR DESCRIPTION
cc @amasad 

An error occurred while trying to display the Red Box since loadSourceMap was not included in the JS 
bundle. This is because node-haste was treating its docblock as a multiline directive which doesn't make sense for `@providesModule`.

In loadSourceMap.js's case, the directive's value was parsed as "loadSourceMap -- disabled flow due to mysterious validation errors --".

There are two fixes: add a newline under the `@providesModule` directive, and change the module ID code to look at only the first token of the directive. I opted for the latter so we avoid this class of bugs entirely and AFAIK it's nonsensical to have multiple `@providesModule` values anyway.

Test Plan: Run the packager, trigger an error in an app, see the red box now show up again.