### PR TITLE
use zPosition in RCTViewHitTest to properly route touches

### DIFF
--- a/React/Views/RCTView.m
+++ b/React/Views/RCTView.m
@@ -18,31 +18,22 @@ static const RCTBorderSide RCTBorderSideCount = 4;
 
 static UIView *RCTViewHitTest(UIView *view, CGPoint point, UIEvent *event)
 {
-  NSMutableArray *hits = [[NSMutableArray alloc] init];
+  float currentZ = -HUGE_VALF;
+  UIView *highestView = nil;
+  
   for (UIView *subview in [view.subviews reverseObjectEnumerator]) {
     if (!subview.isHidden && subview.isUserInteractionEnabled && subview.alpha > 0) {
       CGPoint convertedPoint = [subview convertPoint:point fromView:view];
-      UIView *subviewHitTestView = [subview hitTest:convertedPoint withEvent:event];
-      if (subviewHitTestView != nil) {
-        [hits addObject:subviewHitTestView];
+      if (highestView == nil || subview.layer.zPosition > currentZ) {
+        UIView *subviewHitTestView = [subview hitTest:convertedPoint withEvent:event];
+        if (subviewHitTestView != nil) {
+          currentZ = subview.layer.zPosition;
+          highestView = subviewHitTestView;
+        }
       }
     }
   }
-
-  float z = -HUGE_VALF;
-  UIView *highestView;
-  for (UIView *subview in [hits objectEnumerator]) {
-    if (subview.layer.zPosition > z) {
-      highestView = subview;
-      z = subview.layer.zPosition;
-    }
-  }
-  
-  if (highestView != nil) {
-    return highestView;
-  }
-  
-  return nil;
+  return highestView;
 }
 
 @implementation UIView (RCTViewUnmounting)

--- a/React/Views/RCTView.m
+++ b/React/Views/RCTView.m
@@ -18,15 +18,30 @@ static const RCTBorderSide RCTBorderSideCount = 4;
 
 static UIView *RCTViewHitTest(UIView *view, CGPoint point, UIEvent *event)
 {
+  NSMutableArray *hits = [[NSMutableArray alloc] init];
   for (UIView *subview in [view.subviews reverseObjectEnumerator]) {
     if (!subview.isHidden && subview.isUserInteractionEnabled && subview.alpha > 0) {
       CGPoint convertedPoint = [subview convertPoint:point fromView:view];
       UIView *subviewHitTestView = [subview hitTest:convertedPoint withEvent:event];
       if (subviewHitTestView != nil) {
-        return subviewHitTestView;
+        [hits addObject:subviewHitTestView];
       }
     }
   }
+
+  float z = -HUGE_VALF;
+  UIView *highestView;
+  for (UIView *subview in [hits objectEnumerator]) {
+    if (subview.layer.zPosition > z) {
+      highestView = subview;
+      z = subview.layer.zPosition;
+    }
+  }
+  
+  if (highestView != nil) {
+    return highestView;
+  }
+  
   return nil;
 }
 


### PR DESCRIPTION
Fixes https://github.com/facebook/react-native/issues/696.  Previously the hit test would return the first suitable, fully nested, view it found.  Changed the test to store all hits and chose the one with the greatest zPosition.  

The change can be seen in the UIExplorer <ListView> - Paging example.  Previously presses would fall through the sticky section headers, now the headers correctly catch the presses and the row animation underneath is not triggered.