### PR TITLE
Replace percent escapes in file URL before using as path

### DIFF
--- a/React/Base/RCTJavaScriptLoader.m
+++ b/React/Base/RCTJavaScriptLoader.m
@@ -64,7 +64,8 @@
 
   if ([scriptURL isFileURL]) {
     NSString *bundlePath = [[NSBundle bundleForClass:[self class]] resourcePath];
-    NSString *localPath = [scriptURL.absoluteString substringFromIndex:@"file://".length];
+    NSString *decodedPath = [scriptURL.absoluteString stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+    NSString *localPath = [decodedPath substringFromIndex:@"file://".length];
 
     if (![localPath hasPrefix:bundlePath]) {
       NSString *absolutePath = [NSString stringWithFormat:@"%@/%@", bundlePath, localPath];


### PR DESCRIPTION
This is to fix a bug that prevents bundling of projects that contain spaces (or other special characters) in their names.

#### Reproduction steps before the fix
 1. Create a project with a space in the name:
    ![screen shot 2015-04-16 at 17 23 46](https://cloud.githubusercontent.com/assets/1121616/7176887/63af36de-e45d-11e4-9aa9-40586560b716.png)

 2. Follow the steps in `OPTION 2` for running from a bundled file, i.e. create the `main.bundle` file, add it to the project if is not there already, and uncomment `jsCodeLocation = [[NSBundle mainBundle] URLForResource:@"main" withExtension:@"jsbundle"];`
 3. Run the application. This is what happens:
   
![screen shot 2015-04-16 at 17 27 48](https://cloud.githubusercontent.com/assets/1121616/7176955/f139764a-e45d-11e4-8dc8-3c13aab70828.png)

To prove that it has to do with a space in the name, refactor the project name to not contain a space:

![screen shot 2015-04-16 at 17 28 27](https://cloud.githubusercontent.com/assets/1121616/7176966/056b6c9a-e45e-11e4-93c1-984321e6fdb3.png)

Run the project again, and now it runs successfully:

![screen shot 2015-04-16 at 17 30 18](https://cloud.githubusercontent.com/assets/1121616/7177000/4747183a-e45e-11e4-927b-056cfd9c6240.png)

#### The fix
The `scriptURL` variable passed to the `onComplete` method contains url-encoded spaces (`%20`), which we need to convert back to spaces before using the URL as a path. This is achieved with `stringByReplacingPercentEscapesUsingEncoding`, which allows us to fix the bug without break any  existining APIs.

Note: This is my first pull request to a Facebook open source project, and I just completed the CLA.