### PR TITLE
Implement XmlHttpRequestBase#getAllResponseHeaders and getResponseHeader

### DIFF
--- a/Libraries/Network/XMLHttpRequestBase.js
+++ b/Libraries/Network/XMLHttpRequestBase.js
@@ -53,13 +53,22 @@ class XMLHttpRequestBase {
   }
 
   getAllResponseHeaders(): ?string {
-    /* Stub */
-    return '';
+    if (this.responseHeaders) {
+      var headers = [];
+      for (var headerName in this.responseHeaders) {
+        headers.push(headerName + ': ' + this.responseHeaders[headerName]);
+      }
+      return headers.join('\n');
+    }
+    return null;
   }
 
   getResponseHeader(header: string): ?string {
-    /* Stub */
-    return '';
+    if (this.responseHeaders) {
+      var value = this.responseHeaders[header];
+      return value != undefined ? value : null;
+    }
+    return null;
   }
 
   setRequestHeader(header: string, value: any): void {


### PR DESCRIPTION
Used https://github.com/facebook/react-native/pull/382 as inspiration
but modified to return null instead of undefined as per the spec at
https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest

This unblocks use of Dropbox.js within a react-native app, as well
as any other libraries that make use of these methods in XHR usage.

Closes https://github.com/facebook/react-native/issues/872