### PR TITLE
[Packager] Windows support for Packager - Blacklist changes

### DIFF
--- a/packager/blacklist.js
+++ b/packager/blacklist.js
@@ -8,11 +8,14 @@
  */
 'use strict';
 
+var path = require("path"); // used for path separator
+
 // Don't forget to everything listed here to `testConfig.json`
 // modulePathIgnorePatterns.
 var sharedBlacklist = [
   __dirname,
   'website',
+  '/.git',             // added because nodeWatcher does not ignore hidden files
   'node_modules/react-tools/src/utils/ImmutableObject.js',
   'node_modules/react-tools/src/core/ReactInstanceHandles.js',
   'node_modules/react-tools/src/event/EventPropagators.js'
@@ -40,7 +43,9 @@ var platformBlacklists = {
 };
 
 function escapeRegExp(str) {
-  return str.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&');
+  var escaped = str.replace(/[\-\[\]\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&');
+  // convert the '/' into an escaped local file separator
+  return escaped.replace(/\//g,"\\"+path.sep);
 }
 
 function blacklist(platform, additionalBlacklist) {

--- a/packager/packager.js
+++ b/packager/packager.js
@@ -56,8 +56,9 @@ if (options.projectRoots) {
     options.projectRoots = options.projectRoots.split(',');
   }
 } else {
-  if (__dirname.match(/node_modules\/react-native\/packager$/)) {
-    // packager is running from node_modules of another project
+  // match on either path separator
+  if (__dirname.match(/node_modules[\/\\]react-native[\/\\]packager$/)) {
+     // packager is running from node_modules of another project
     options.projectRoots = [path.resolve(__dirname, '../../..')];
   } else {
     options.projectRoots = [path.resolve(__dirname, '..')];
@@ -79,7 +80,8 @@ if (options.assetRoots) {
     options.assetRoots = options.assetRoots.split(',');
   }
 } else {
-  if (__dirname.match(/node_modules\/react-native\/packager$/)) {
+  // match on either path separator
+  if (__dirname.match(/node_modules[\/\\]react-native[\/\\]packager$/)) {
     options.assetRoots = [path.resolve(__dirname, '../../..')];
   } else {
     options.assetRoots = [path.resolve(__dirname, '..')];


### PR DESCRIPTION
Another Pull Request implementing the changes in issue #468 - Enabled Packager to run on Windows
This change relates to the blacklist fixes. It includes the path conversion for blacklist and changes to the default watched directory.  It has no impact on Mac OSX.