### PR TITLE
Make TouchableHighlight default underlayColor similar to iPhone

### DIFF
--- a/Libraries/Components/Touchable/TouchableHighlight.js
+++ b/Libraries/Components/Touchable/TouchableHighlight.js
@@ -29,7 +29,7 @@ var onlyChild = require('onlyChild');
 
 var DEFAULT_PROPS = {
   activeOpacity: 0.8,
-  underlayColor: 'black',
+  underlayColor: 'rgba(0, 0, 0, 0.15)',
 };
 
 /**


### PR DESCRIPTION
This "feature" is making everyone nuts. I set the default color to look similar to the iPhone default like in the following image:

![img_4355](https://cloud.githubusercontent.com/assets/566971/7213792/50dc12e6-e540-11e4-901b-6ae9b7f83d1d.PNG)

So it looks more like:

![screen shot 2015-04-17 at 8 23 53 pm](https://cloud.githubusercontent.com/assets/566971/7213794/58f579e0-e540-11e4-804b-65a75d79857d.png)
