### PR TITLE
[ReactNative] Add "RCTNativeAppEventEmitter"

### DIFF
--- a/Libraries/NativeApp/RCTNativeAppEventEmitter.js
+++ b/Libraries/NativeApp/RCTNativeAppEventEmitter.js
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule RCTNativeAppEventEmitter
+ * @flow
+ */
+'use strict';
+
+var EventEmitter = require('EventEmitter');
+
+var RCTNativeAppEventEmitter = new EventEmitter();
+
+module.exports = RCTNativeAppEventEmitter;

--- a/Libraries/react-native/react-native.js
+++ b/Libraries/react-native/react-native.js
@@ -58,6 +58,7 @@ var ReactNative = Object.assign(Object.create(require('React')), {
 
   // Plugins
   DeviceEventEmitter: require('RCTDeviceEventEmitter'),
+  NativeAppEventEmitter: require('RCTNativeAppEventEmitter'),
   NativeModules: require('NativeModules'),
   requireNativeComponent: require('requireNativeComponent'),
 


### PR DESCRIPTION
As mentioned in #906, [in the docs it mentions sending native app events](http://facebook.github.io/react-native/docs/nativemodulesios.html#sending-events-to-javascript) eg: calendar event reminder received, through the `RCTNativeAppEventEmitter`, but the JS module for that is missing. This adds it - it's nothing more than an instance of `EventEmitter`, just like [RCTDeviceEventEmitter](https://github.com/facebook/react-native/blob/master/Libraries/Device/RCTDeviceEventEmitter.js).