### PR TITLE
NavigatorIOS custom navbar colors

### DIFF
--- a/Examples/UIExplorer/NavigatorIOSExample.js
+++ b/Examples/UIExplorer/NavigatorIOSExample.js
@@ -104,7 +104,7 @@ var NavigatorIOSExample = React.createClass({
                 this.props.navigator.replacePreviousAndPop(prevRoute);
               },
               passProps: {
-                text: 'This page has custom color for the nav bar',
+                text: 'This page has custom colors for the nav bar',
               }
             });
           })}

--- a/Examples/UIExplorer/NavigatorIOSExample.js
+++ b/Examples/UIExplorer/NavigatorIOSExample.js
@@ -92,6 +92,22 @@ var NavigatorIOSExample = React.createClass({
               }
             });
           })}
+          {this._renderRow('Custom Nav Bar Colors', () => {
+            this.props.customNavBarColors();
+            this.props.navigator.push({
+              title: NavigatorIOSExample.title,
+              component: EmptyPage,
+              rightButtonTitle: 'Reset',
+              onRightButtonPress: () => {
+                var prevRoute = this.props.route;
+                this.props.resetNavBarColors();
+                this.props.navigator.replacePreviousAndPop(prevRoute);
+              },
+              passProps: {
+                text: 'This page has custom color for the nav bar',
+              }
+            });
+          })}
           {this._renderRow('Pop', () => {
             this.props.navigator.pop();
           })}

--- a/Examples/UIExplorer/UIExplorerApp.js
+++ b/Examples/UIExplorer/UIExplorerApp.js
@@ -21,7 +21,6 @@ var UIExplorerList = require('./UIExplorerList');
 var {
   AppRegistry,
   NavigatorIOS,
-  StatusBarIOS,
   StyleSheet,
 } = React;
 
@@ -31,18 +30,17 @@ var UIExplorerApp = React.createClass({
     return {
       openExternalExample: (null: ?React.Component),
       tintColor: '#008888',
-      barTintColor: null,
-      titleTextColor: null,
+      barTintColor: (null: ?string),
+      titleTextColor: (null: ?string),
     };
   },
 
   _customNavColors: function() {
     this.setState({
       tintColor: '#FFFFFF',
-      barTintColor: '#4F6BA5',
+      barTintColor: '#05A5D1',
       titleTextColor: '#FFFFFF',
     });
-    StatusBarIOS.setStyle(StatusBarIOS.Style['lightContent']);
   },
 
   _resetNavColors: function() {
@@ -51,7 +49,6 @@ var UIExplorerApp = React.createClass({
       barTintColor: "#F7F7F7",
       titleTextColor: '#000000',
     });
-    StatusBarIOS.setStyle(StatusBarIOS.Style['default']);
   },
 
   render: function() {

--- a/Examples/UIExplorer/UIExplorerApp.js
+++ b/Examples/UIExplorer/UIExplorerApp.js
@@ -21,6 +21,7 @@ var UIExplorerList = require('./UIExplorerList');
 var {
   AppRegistry,
   NavigatorIOS,
+  StatusBarIOS,
   StyleSheet,
 } = React;
 
@@ -29,7 +30,28 @@ var UIExplorerApp = React.createClass({
   getInitialState: function() {
     return {
       openExternalExample: (null: ?React.Component),
+      tintColor: '#008888',
+      barTintColor: null,
+      titleTextColor: null,
     };
+  },
+
+  _customNavColors: function() {
+    this.setState({
+      tintColor: '#FFFFFF',
+      barTintColor: '#4F6BA5',
+      titleTextColor: '#FFFFFF',
+    });
+    StatusBarIOS.setStyle(StatusBarIOS.Style['lightContent']);
+  },
+
+  _resetNavColors: function() {
+    this.setState({
+      tintColor: "#008888",
+      barTintColor: "#F7F7F7",
+      titleTextColor: '#000000',
+    });
+    StatusBarIOS.setStyle(StatusBarIOS.Style['default']);
   },
 
   render: function() {
@@ -53,10 +75,14 @@ var UIExplorerApp = React.createClass({
             onExternalExampleRequested: (example) => {
               this.setState({ openExternalExample: example, });
             },
+            customNavBarColors: () => this._customNavColors(),
+            resetNavBarColors: () => this._resetNavColors(),
           }
         }}
         itemWrapperStyle={styles.itemWrapper}
-        tintColor='#008888'
+        tintColor={this.state.tintColor}
+        barTintColor={this.state.barTintColor}
+        titleTextColor={this.state.titleTextColor}
       />
     );
   }

--- a/Examples/UIExplorer/UIExplorerList.js
+++ b/Examples/UIExplorer/UIExplorerList.js
@@ -187,10 +187,17 @@ class UIExplorerList extends React.Component {
       );
       return;
     }
+    if (example.displayName === "NavigatorIOSExample") {
+      var props = {
+        customNavBarColors: this.props.customNavBarColors,
+        resetNavBarColors: this.props.resetNavBarColors,
+      }
+    }
     var Component = makeRenderable(example);
     this.props.navigator.push({
       title: Component.title,
       component: Component,
+      passProps: props || {},
     });
   }
 }

--- a/Libraries/Components/Navigation/NavigatorIOS.ios.js
+++ b/Libraries/Components/Navigation/NavigatorIOS.ios.js
@@ -252,6 +252,16 @@ var NavigatorIOS = React.createClass({
      */
     tintColor: PropTypes.string,
 
+    /**
+     * The background color of the navigation bar
+     */
+    barTintColor: PropTypes.string,
+
+    /**
+     * The text color of the navigation bar title
+     */
+    titleTextColor: PropTypes.string,
+
   },
 
   navigator: (undefined: ?Object),
@@ -554,7 +564,9 @@ var NavigatorIOS = React.createClass({
           rightButtonTitle={route.rightButtonTitle}
           onNavRightButtonTap={route.onRightButtonPress}
           navigationBarHidden={this.props.navigationBarHidden}
-          tintColor={this.props.tintColor}>
+          tintColor={this.props.tintColor}
+          barTintColor={this.props.barTintColor}
+          titleTextColor={this.props.titleTextColor}>
           <Component
             navigator={this.navigator}
             route={route}

--- a/React/Views/RCTWrapperViewController.m
+++ b/React/Views/RCTWrapperViewController.m
@@ -80,10 +80,7 @@
       bar.barTintColor = _navItem.barTintColor;
     }
     if (_navItem.tintColor) {
-      BOOL canSetTintColor = _navItem.barTintColor == nil;
-      if (canSetTintColor) {
-        bar.tintColor = _navItem.tintColor;
-      }
+      bar.tintColor = _navItem.tintColor;
     }
     if (_navItem.titleTextColor) {
       [bar setTitleTextAttributes:@{NSForegroundColorAttributeName : _navItem.titleTextColor}];


### PR DESCRIPTION
tintColor, barTintColor, titleTextColor UIExplorer example added.

Based on @ericvicenti comments on pull request #695, this commit includes the example in the same view with a Reset button to default colors.