### PR TITLE
[RootView] Fix positioning of the root view content (frame -> bounds)

### DIFF
--- a/React/Base/RCTRootView.m
+++ b/React/Base/RCTRootView.m
@@ -169,7 +169,7 @@ RCT_IMPORT_METHOD(ReactIOS, unmountComponentAtNodeAndRemoveContainer)
   [super layoutSubviews];
   if (_contentView) {
     _contentView.frame = self.bounds;
-    [_bridge.uiManager setFrame:self.frame forRootView:_contentView];
+    [_bridge.uiManager setFrame:self.bounds forRootView:_contentView];
   }
 }
 


### PR DESCRIPTION
The root view's content was being rendered at the wrong offset when it was not positioned at (0, 0) exactly, because the shadow view's frame was set to the root view's frame when it should have been set to the root view's bounds instead.

Test Plan: Render a root view positioned at (0, 100) and see that its content is positioned where the root view is, not at (0, 200).