### PR TITLE
[TouchableOpacity] Reset opacity to the inactiveValue rather than always 1.0

### DIFF
--- a/Libraries/Components/Touchable/TouchableOpacity.js
+++ b/Libraries/Components/Touchable/TouchableOpacity.js
@@ -14,16 +14,15 @@
 
 var NativeMethodsMixin = require('NativeMethodsMixin');
 var POPAnimationMixin = require('POPAnimationMixin');
-var StyleSheetRegistry = require('StyleSheetRegistry');
 var React = require('React');
 var Touchable = require('Touchable');
 var TouchableWithoutFeedback = require('TouchableWithoutFeedback');
 
 var cloneWithProps = require('cloneWithProps');
 var ensureComponentIsNative = require('ensureComponentIsNative');
+var flattenStyle = require('flattenStyle');
 var keyOf = require('keyOf');
 var onlyChild = require('onlyChild');
-var flattenStyle = require('flattenStyle');
 
 /**
  * A wrapper for making views respond properly to touches.
@@ -107,7 +106,7 @@ var TouchableOpacity = React.createClass({
   },
 
   touchableHandleActivePressOut: function() {
-    var childStyle = flattenStyle(this.refs[CHILD_REF].props.style || {});
+    var childStyle = flattenStyle(this.refs[CHILD_REF].props.style) || {};
     this.setOpacityTo(childStyle.opacity === undefined ? 1 : childStyle.opacity);
     this.props.onPressOut && this.props.onPressOut();
   },

--- a/Libraries/Components/Touchable/TouchableOpacity.js
+++ b/Libraries/Components/Touchable/TouchableOpacity.js
@@ -23,6 +23,7 @@ var cloneWithProps = require('cloneWithProps');
 var ensureComponentIsNative = require('ensureComponentIsNative');
 var keyOf = require('keyOf');
 var onlyChild = require('onlyChild');
+var flattenStyle = require('flattenStyle');
 
 /**
  * A wrapper for making views respond properly to touches.
@@ -106,13 +107,8 @@ var TouchableOpacity = React.createClass({
   },
 
   touchableHandleActivePressOut: function() {
-    var childStyle = this.refs[CHILD_REF].props.style;
-
-    if (typeof childStyle === 'number') {
-      childStyle = StyleSheetRegistry.getStyleByID(childStyle);
-    }
-
-    this.setOpacityTo(childStyle && childStyle.opacity || 1);
+    var childStyle = flattenStyle(this.refs[CHILD_REF].props.style || {});
+    this.setOpacityTo(childStyle.opacity === undefined ? 1 : childStyle.opacity);
     this.props.onPressOut && this.props.onPressOut();
   },
 

--- a/Libraries/Components/Touchable/TouchableOpacity.js
+++ b/Libraries/Components/Touchable/TouchableOpacity.js
@@ -14,6 +14,7 @@
 
 var NativeMethodsMixin = require('NativeMethodsMixin');
 var POPAnimationMixin = require('POPAnimationMixin');
+var StyleSheetRegistry = require('StyleSheetRegistry');
 var React = require('React');
 var Touchable = require('Touchable');
 var TouchableWithoutFeedback = require('TouchableWithoutFeedback');
@@ -105,12 +106,17 @@ var TouchableOpacity = React.createClass({
   },
 
   touchableHandleActivePressOut: function() {
-    this.setOpacityTo(1.0);
+    var childStyle = this.refs[CHILD_REF].props.style;
+
+    if (typeof childStyle === 'number') {
+      childStyle = StyleSheetRegistry.getStyleByID(childStyle);
+    }
+
+    this.setOpacityTo(childStyle && childStyle.opacity || 1);
     this.props.onPressOut && this.props.onPressOut();
   },
 
   touchableHandlePress: function() {
-    this.setOpacityTo(1.0);
     this.props.onPress && this.props.onPress();
   },
 


### PR DESCRIPTION
As per #941 - fixes bug with `TouchabeOpacity` always reseting child opacity to `1.0` after press.

A note about the code: we could probably use a general `getNativeProp(propName, callback)` function rather than `getOpacity` but just used that as it was simpler for this specific PR, perhaps that refactor could be left to another - or maybe there is a way to do this already that I missed.

Before:
![bug](https://cloud.githubusercontent.com/assets/90494/7287207/52d6a686-e907-11e4-8e16-04b2ddd0582c.gif)

After:
![after](https://cloud.githubusercontent.com/assets/90494/7287689/5aca4776-e90c-11e4-8c40-aa6bd3e822d8.gif)

Example code:
```javascript
'use strict';

var React = require('react-native');
var {
  AppRegistry,
  StyleSheet,
  Text,
  View,
  TouchableOpacity,
} = React;


var TestIt = React.createClass({
  render() {
    return (
      <View style={styles.container}>
        <TouchableOpacity activeOpacity={0.3}>
          <View style={styles.searchButton}>
            <Text>Search</Text>
          </View>
        </TouchableOpacity>
      </View>
    );
  }
});

var styles = StyleSheet.create({
  searchButton: {
    opacity: 0.5,
    width: 120,
    height: 50,
    top: 35,
    alignSelf: 'center',
    borderRadius: 10,
    borderColor: '#da766b',
    backgroundColor: '#e01a3c',
    borderWidth: 1,
  },
  container: {
    flex: 1,
    justifyContent: 'center',
    alignItems: 'center',
    backgroundColor: '#F5FCFF',
  },
});

AppRegistry.registerComponent('TestIt', () => TestIt);
```