### PR TITLE
Add support for exporting Swift modules

### DIFF
--- a/React/Base/RCTBridgeModule.h
+++ b/React/Base/RCTBridgeModule.h
@@ -69,7 +69,7 @@ typedef void (^RCTResponseSenderBlock)(NSArray *response);
   @end \
   @interface objc_name (RCTExternModule) <RCTBridgeModule> \
   @end \
-  @implementation objc_name \
+  @implementation objc_name (RCTExternModule) \
   RCT_EXPORT_MODULE(js_name)
 
 /**

--- a/React/Base/RCTBridgeModule.h
+++ b/React/Base/RCTBridgeModule.h
@@ -32,6 +32,64 @@ typedef void (^RCTResponseSenderBlock)(NSArray *response);
 @property (nonatomic, weak) RCTBridge *bridge;
 
 /**
+ * Use this macro in a private Objective-C implementation file to automatically
+ * register an external module with the bridge when it loads. This allows you to
+ * register Swift or private Objective-C classes with the bridge.
+ *
+ * For example if one wanted to export a Swift class to the bridge:
+ *
+ *   MyModule.swift:
+ *
+ *       @objc(MyModule) class MyModule: NSObject {
+ *   
+ *        @objc func doSomething(string: String! withA a: Int, andB b: Int) { ... }
+ *
+ *       }
+ *
+ *   MyModuleExport.m:
+ *
+ *      #import "RCTBridgeModule.h"
+ *
+ *      @interface RCT_EXTERN_MODULE(MyModule, NSObject)
+ *
+ *      RCT_EXTERN_METHOD(doSomething:(NSString *)string withA:(NSInteger)a andB:(NSInteger)b)
+ *
+ *      @end
+ *
+ *  this will now expose MyModule and the method to JavaScript via `NativeModules.MyModule.doSomething`
+ */
+#define RCT_EXTERN_MODULE(objc_name, objc_supername) \
+  RCT_EXTERN_REMAP_MODULE(, objc_name, objc_supername)
+
+/**
+ * Similar to RCT_EXTERN_MODULE but allows setting a custom JavaScript name
+ */
+#define RCT_EXTERN_REMAP_MODULE(js_name, objc_name, objc_supername) \
+  objc_name : objc_supername \
+  @end \
+  @interface objc_name (RCTExternModule) <RCTBridgeModule> \
+  @end \
+  @implementation objc_name \
+  RCT_EXPORT_MODULE(js_name)
+
+/**
+ * Use this macro in accordance with RCT_EXTERN_MODULE to export methods
+ * of an external module.
+ */
+#define RCT_EXTERN_METHOD(method) \
+  RCT_EXTERN_REMAP_METHOD(, method)
+
+/**
+ * Similar to RCT_EXTERN_REMAP_METHOD but allows setting a custom JavaScript name
+ */
+#define RCT_EXTERN_REMAP_METHOD(js_name, method) \
+  - (void)__rct_export__##method { \
+    __attribute__((used, section("__DATA,RCTExport"))) \
+    __attribute__((__aligned__(1))) \
+    static const char *__rct_export_entry__[] = { __func__, #method, #js_name }; \
+  }
+
+/**
  * Place this macro in your class implementation to automatically register
  * your module with the bridge when it loads. The optional js_name argument
  * will be used as the JS module name. If omitted, the JS module name will
@@ -73,11 +131,7 @@ typedef void (^RCTResponseSenderBlock)(NSArray *response);
  * { ... }
  */
 #define RCT_REMAP_METHOD(js_name, method) \
-  - (void)__rct_export__##method { \
-    __attribute__((used, section("__DATA,RCTExport"))) \
-    __attribute__((__aligned__(1))) \
-    static const char *__rct_export_entry__[] = { __func__, #method, #js_name }; \
-  } \
+  RCT_EXTERN_REMAP_METHOD(js_name, method) \
   - (void)method
 
 /**


### PR DESCRIPTION
External modules are any Objective-C class in which the implementation is private. This currently will be most useful for Swift classes but also has potential to allow exposing methods on 3rd party libraries to the bridge.