### PR TITLE
[LayoutManager] MessageQueueMixin._invokeCallback : do not call cb when it does not exist

### DIFF
--- a/Libraries/Utilities/MessageQueue.js
+++ b/Libraries/Utilities/MessageQueue.js
@@ -261,7 +261,7 @@ var MessageQueueMixin = {
         'both the success callback and the error callback.',
          cbID
       );
-      cb.apply(scope, args);
+      if (cb) cb.apply(scope, args);
     } catch(ie_requires_catch) {
       throw ie_requires_catch;
     } finally {


### PR DESCRIPTION
I'm not sure if it is intentional to call `cb` even when it does not exist.

As it is calling `warning` just before, i would say it should just stay a warning and should not throw.

I will try to find why i get this warning, but until then this fix allows me to run my app correctly