### PR TITLE
[SliderIOS] Add thumbTintColor property

### DIFF
--- a/Libraries/Components/SliderIOS/SliderIOS.js
+++ b/Libraries/Components/SliderIOS/SliderIOS.js
@@ -57,6 +57,11 @@ var SliderIOS = React.createClass({
     maximumValue: PropTypes.number,
 
     /**
+     * The color used for the thumb which you drag across the slider
+     */
+    thumbTintColor: PropTypes.string,
+
+    /**
      * Callback continuously called while the user is dragging the slider.
      */
     onValueChange: PropTypes.func,
@@ -86,6 +91,7 @@ var SliderIOS = React.createClass({
         value={this.props.value}
         maximumValue={this.props.maximumValue}
         minimumValue={this.props.minimumValue}
+        thumbTintColor={this.props.thumbTintColor}
         onChange={this._onValueChange}
       />
     );
@@ -106,6 +112,7 @@ if (Platform.OS === 'ios') {
     value: true,
     minimumValue: true,
     maximumValue: true,
+    thumbTintColor: true,
   };
 
   var RCTSlider = createReactIOSNativeComponentClass({

--- a/React/Views/RCTSliderManager.m
+++ b/React/Views/RCTSliderManager.m
@@ -22,6 +22,10 @@ RCT_EXPORT_MODULE()
   UISlider *slider = [[UISlider alloc] init];
   [slider addTarget:self action:@selector(sliderValueChanged:) forControlEvents:UIControlEventValueChanged];
   [slider addTarget:self action:@selector(sliderTouchEnd:) forControlEvents:UIControlEventTouchUpInside];
+  // UIKit bug with slider means it has to be initialised with an image before thumbTintColor works
+  // See http://stackoverflow.com/questions/19061157/ios-7-uislider-thumbtintcolor-does-not-change
+  [slider setThumbImage:slider.currentThumbImage forState:UIControlStateNormal ];
+
   return slider;
 }
 

--- a/React/Views/RCTSliderManager.m
+++ b/React/Views/RCTSliderManager.m
@@ -50,5 +50,6 @@ RCT_EXPORT_MODULE()
 RCT_EXPORT_VIEW_PROPERTY(value, float);
 RCT_EXPORT_VIEW_PROPERTY(minimumValue, float);
 RCT_EXPORT_VIEW_PROPERTY(maximumValue, float);
+RCT_EXPORT_VIEW_PROPERTY(thumbTintColor, UIColor);
 
 @end


### PR DESCRIPTION
This PR is an attempt to continue on from #799 and add the `thumbTintColor` property to `SliderIOS`

Unfortunately this doesn't work due to what seems to be [a bug in UIKit](http://stackoverflow.com/questions/19061157/ios-7-uislider-thumbtintcolor-does-not-change). I have tried to add the workaround but it still doesn't seem to work. Unfortunately I'm not experienced with Objective C so I'm not sure where to go next but I thought it was worth providing the PR for someone to continue on from...