### PR TITLE
Fix updating RCTText with new text of the same size

### DIFF
--- a/Libraries/Text/RCTText.m
+++ b/Libraries/Text/RCTText.m
@@ -94,21 +94,18 @@
   return UIEdgeInsetsInsetRect(self.bounds, _contentInset);
 }
 
-- (void)layoutSubviews
-{
-  [super layoutSubviews];
-
-  // The header comment for `size` says that a height of 0.0 should be enough,
-  // but it isn't.
-  _textContainer.size = CGSizeMake([self textFrame].size.width, CGFLOAT_MAX);
-}
-
 - (void)drawRect:(CGRect)rect
 {
-  CGPoint origin = [self textFrame].origin;
+  CGRect textFrame = [self textFrame];
+
+  // We reset the text container size every time because RCTShadowText's
+  // RCTMeasure overrides it. The header comment for `size` says that a height
+  // of 0.0 should be enough, but it isn't.
+  _textContainer.size = CGSizeMake(textFrame.size.width, CGFLOAT_MAX);
+
   NSRange glyphRange = [_layoutManager glyphRangeForTextContainer:_textContainer];
-  [_layoutManager drawBackgroundForGlyphRange:glyphRange atPoint:origin];
-  [_layoutManager drawGlyphsForGlyphRange:glyphRange atPoint:origin];
+  [_layoutManager drawBackgroundForGlyphRange:glyphRange atPoint:textFrame.origin];
+  [_layoutManager drawGlyphsForGlyphRange:glyphRange atPoint:textFrame.origin];
 }
 
 - (NSNumber *)reactTagAtPoint:(CGPoint)point


### PR DESCRIPTION
Fixes #979.

Previously, a Text whose width is determined automatically (as opposed to set by a container) would position the text incorrectly after an update to the text *if* the text's width did not change (i.e., when changing only digits in a font with tabular numbers).

Every time RCTShadowText's RCTMeasure runs, it sets the text container's size to be the maximum allowed size for the text. When RCTText's drawRect is called later, it relied on layoutSubviews having been called to set the text container's size back to the proper width. But if RCTMeasure returned the same dimensions as last time, then RCTText's frame wasn't reset and so layoutSubviews was never re-called. With this change, we set the textContainer's size each time we draw the text.

We could also fix this by using a different NSTextContainer instance in RCTMeasure. Not sure what the pros and cons of that are.