### PR TITLE
[Navigator] Pop route from stack when dismissed via gesture.

### DIFF
--- a/Libraries/CustomComponents/Navigator/Navigator.js
+++ b/Libraries/CustomComponents/Navigator/Navigator.js
@@ -736,6 +736,7 @@ var Navigator = React.createClass({
     if (transitionVelocity < 0 || this._doesGestureOverswipe(releaseGestureAction)) {
       this._transitionToFromIndexWithVelocity(transitionVelocity);
     } else {
+      this._handlePop();
       this._transitionToToIndexWithVelocity(transitionVelocity);
     }
   },


### PR DESCRIPTION
This PR fixes an issue described in #1014 where a route is not being removed from the stack when dismissed via a pop gesture.