### PR TITLE
[podspec] Include podspec in npm distribution

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "main": "Libraries/react-native/react-native.js",
   "files": [
     "React",
+    "React.podspec",
     "Examples/SampleApp",
     "Libraries",
     "packager",


### PR DESCRIPTION
The way RCT_EXPORT_MODULE currently works, any module that is included as a pod also needs react itself to be included as a pod.

npm seems to be the preferred way to get the latest copy of react (compared to github directly or the cocoapods repo) so what this diff enables is including react as a pod if it was installed via npm.