### PR TITLE
Fix for RCTTabBar not rotating correctly

### DIFF
--- a/React/Views/RCTTabBar.m
+++ b/React/Views/RCTTabBar.m
@@ -27,13 +27,6 @@
 @synthesize currentTopLayoutGuide = _currentTopLayoutGuide;
 @synthesize currentBottomLayoutGuide = _currentBottomLayoutGuide;
 
-- (void)viewWillLayoutSubviews
-{
-  [super viewWillLayoutSubviews];
-  _currentTopLayoutGuide = self.topLayoutGuide;
-  _currentBottomLayoutGuide = self.bottomLayoutGuide;
-}
-
 @end
 
 @interface RCTTabBar() <UITabBarControllerDelegate>
@@ -97,7 +90,7 @@
 
 - (void)layoutSubviews
 {
-  // we're not calling [super layoutSubviews] to prevent improper resizing
+  [super layoutSubviews];
   _tabController.view.frame = self.bounds;
 }
 

--- a/React/Views/RCTTabBar.m
+++ b/React/Views/RCTTabBar.m
@@ -97,7 +97,7 @@
 
 - (void)layoutSubviews
 {
-  [super layoutSubviews];
+  // we're not calling [super layoutSubviews] to prevent improper resizing
   _tabController.view.frame = self.bounds;
 }
 


### PR DESCRIPTION
As soon as we call `[super layoutSubviews]` the frame does not resize properly and stays cut-off. Removing this call seems to fix the issue and I also couldn't notice any negative effects.