### PR TITLE
Upgrade jstransform to support `export type..`

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "debug": "~2.1.0",
     "image-size": "0.3.5",
     "joi": "~5.1.0",
-    "jstransform": "10.1.0",
+    "jstransform": "11.0.0",
     "module-deps": "3.5.6",
     "optimist": "0.6.1",
     "promise": "^7.0.0",


### PR DESCRIPTION
The new version of flow supports the useful `export type`. Yet the version of jstransform the packager is using doesn't understand it. This upgrades to the latest version of jstransform which supports `export type` (https://github.com/facebook/jstransform/commit/9fa67a651a4cc3e613ea9d4d310350bcc2d18777)