### PR TITLE
[RCTDevMenu] Store live reload config outside of RCTDevMenu

### DIFF
--- a/React/Base/RCTDevMenu.h
+++ b/React/Base/RCTDevMenu.h
@@ -47,6 +47,24 @@
 
 @end
 
+@interface RCTDevMenuConfiguration : NSObject {
+  NSTimeInterval liveReloadPeriod;
+  BOOL liveReloadEnabled;
+}
+
+@property (nonatomic, assign) NSTimeInterval liveReloadPeriod;
+@property (nonatomic, assign) BOOL liveReloadEnabled;
+
++ (RCTDevMenuConfiguration *)sharedInstance;
+
++ (NSTimeInterval)getLiveReloadPeriod;
++ (BOOL)getLiveReloadEnabled;
+
++ (void)setLiveReloadPeriod:(NSTimeInterval)liveReloadPeriod;
++ (void)setLiveReloadEnabled:(BOOL)liveReloadEnabled;
+
+@end
+
 /**
  * This category makes the developer menu instance available via the
  * RCTBridge, which is useful for any class that needs to access the menu.

--- a/React/Base/RCTDevMenu.h
+++ b/React/Base/RCTDevMenu.h
@@ -47,10 +47,7 @@
 
 @end
 
-@interface RCTDevMenuConfiguration : NSObject {
-  NSTimeInterval liveReloadPeriod;
-  BOOL liveReloadEnabled;
-}
+@interface RCTDevMenuConfiguration : NSObject
 
 @property (nonatomic, assign) NSTimeInterval liveReloadPeriod;
 @property (nonatomic, assign) BOOL liveReloadEnabled;
@@ -64,6 +61,7 @@
 + (void)setLiveReloadEnabled:(BOOL)liveReloadEnabled;
 
 @end
+
 
 /**
  * This category makes the developer menu instance available via the

--- a/React/Base/RCTDevMenu.m
+++ b/React/Base/RCTDevMenu.m
@@ -36,24 +36,6 @@ static NSString *const RCTShowDevMenuNotification = @"RCTShowDevMenuNotification
 
 @end
 
-@interface RCTDevMenuConfiguration : NSObject {
-  NSTimeInterval liveReloadPeriod;
-  BOOL liveReloadEnabled;
-}
-
-@property (nonatomic, assign) NSTimeInterval liveReloadPeriod;
-@property (nonatomic, assign) BOOL liveReloadEnabled;
-
-+ (RCTDevMenuConfiguration *)sharedInstance;
-
-+ (NSTimeInterval)getLiveReloadPeriod;
-+ (BOOL)getLiveReloadEnabled;
-
-+ (void)setLiveReloadPeriod:(NSTimeInterval)liveReloadPeriod;
-+ (void)setLiveReloadEnabled:(BOOL)liveReloadEnabled;
-
-@end
-
 @implementation RCTDevMenuConfiguration
 
 @synthesize liveReloadPeriod;
@@ -130,11 +112,6 @@ RCT_EXPORT_MODULE()
                                                object:nil];
   }
   return self;
-}
-
-- (void)dealloc
-{
-  [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
 - (void)showOnShake
@@ -276,6 +253,7 @@ RCT_EXPORT_MODULE()
   [_actionSheet dismissWithClickedButtonIndex:_actionSheet.cancelButtonIndex animated:YES];
   [_updateTimer invalidate];
   _updateTimer = nil;
+  [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
 @end

--- a/React/Base/RCTDevMenu.m
+++ b/React/Base/RCTDevMenu.m
@@ -38,14 +38,11 @@ static NSString *const RCTShowDevMenuNotification = @"RCTShowDevMenuNotification
 
 @implementation RCTDevMenuConfiguration
 
-@synthesize liveReloadPeriod;
-@synthesize liveReloadEnabled;
-
 static RCTDevMenuConfiguration *sharedObject;
 + (RCTDevMenuConfiguration *)sharedInstance
 {
   if (sharedObject == nil) {
-    sharedObject = [[super allocWithZone:NULL] init];
+    sharedObject = [[super alloc] init];
   }
 
   return sharedObject;

--- a/React/Base/RCTDevMenu.m
+++ b/React/Base/RCTDevMenu.m
@@ -36,6 +36,65 @@ static NSString *const RCTShowDevMenuNotification = @"RCTShowDevMenuNotification
 
 @end
 
+@interface RCTDevMenuConfiguration : NSObject {
+  NSTimeInterval liveReloadPeriod;
+  BOOL liveReloadEnabled;
+}
+
+@property (nonatomic, assign) NSTimeInterval liveReloadPeriod;
+@property (nonatomic, assign) BOOL liveReloadEnabled;
+
++ (RCTDevMenuConfiguration *)sharedInstance;
+
++ (NSTimeInterval)getLiveReloadPeriod;
++ (BOOL)getLiveReloadEnabled;
+
++ (void)setLiveReloadPeriod:(NSTimeInterval)liveReloadPeriod;
++ (void)setLiveReloadEnabled:(BOOL)liveReloadEnabled;
+
+@end
+
+@implementation RCTDevMenuConfiguration
+
+@synthesize liveReloadPeriod;
+@synthesize liveReloadEnabled;
+
+static RCTDevMenuConfiguration *sharedObject;
++ (RCTDevMenuConfiguration *)sharedInstance
+{
+  if (sharedObject == nil) {
+    sharedObject = [[super allocWithZone:NULL] init];
+  }
+
+  return sharedObject;
+}
+
++ (NSTimeInterval)getLiveReloadPeriod
+{
+  RCTDevMenuConfiguration *shared = [RCTDevMenuConfiguration sharedInstance];
+  return shared.liveReloadPeriod;
+}
+
++ (BOOL)getLiveReloadEnabled
+{
+  RCTDevMenuConfiguration *shared = [RCTDevMenuConfiguration sharedInstance];
+  return shared.liveReloadEnabled;
+}
+
++ (void)setLiveReloadPeriod:(NSTimeInterval)liveReloadPeriod
+{
+  RCTDevMenuConfiguration *shared = [RCTDevMenuConfiguration sharedInstance];
+  shared.liveReloadPeriod = liveReloadPeriod;
+}
+
++ (void)setLiveReloadEnabled:(BOOL)liveReloadEnabled
+{
+  RCTDevMenuConfiguration *shared = [RCTDevMenuConfiguration sharedInstance];
+  shared.liveReloadEnabled = liveReloadEnabled;
+}
+
+@end
+
 @interface RCTDevMenu () <UIActionSheetDelegate>
 
 @end
@@ -63,7 +122,8 @@ RCT_EXPORT_MODULE()
   if ((self = [super init])) {
 
     _shakeToShow = YES;
-    _liveReloadPeriod = 1.0; // 1 second
+    _liveReloadPeriod = [RCTDevMenuConfiguration getLiveReloadPeriod] ?: 1.0; // 1 second
+    self.liveReloadEnabled = [RCTDevMenuConfiguration getLiveReloadEnabled];
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(showOnShake)
                                                  name:RCTShowDevMenuNotification
@@ -161,6 +221,7 @@ RCT_EXPORT_MODULE()
   }
 
   _liveReloadEnabled = enabled;
+  [RCTDevMenuConfiguration setLiveReloadEnabled:enabled];
   if (_liveReloadEnabled) {
 
     _updateTimer = [NSTimer scheduledTimerWithTimeInterval:_liveReloadPeriod
@@ -169,7 +230,6 @@ RCT_EXPORT_MODULE()
                                                   userInfo:nil
                                                    repeats:YES];
   } else {
-
     [_updateTimer invalidate];
     _updateTimer = nil;
   }
@@ -178,10 +238,12 @@ RCT_EXPORT_MODULE()
 - (void)setLiveReloadPeriod:(NSTimeInterval)liveReloadPeriod
 {
   _liveReloadPeriod = liveReloadPeriod;
-  if (_liveReloadEnabled) {
-    self.liveReloadEnabled = NO;
-    self.liveReloadEnabled = YES;
-  }
+  [RCTDevMenuConfiguration setLiveReloadPeriod:liveReloadPeriod];
+
+   if (_liveReloadEnabled) {
+     self.liveReloadEnabled = NO;
+     self.liveReloadEnabled = YES;
+   }
 }
 
 - (void)pollForUpdates


### PR DESCRIPTION
Config was being nuked each time a reload occurred because RCTDevMenu is dealloc'd and reinitialized, see #1067 

cc @tadeuzagallo @nicklockwood 