### PR TITLE
Make AsyncStorage types match the implementations

### DIFF
--- a/Libraries/Storage/AsyncStorage.ios.js
+++ b/Libraries/Storage/AsyncStorage.ios.js
@@ -37,7 +37,7 @@ var AsyncStorage = {
    */
   getItem: function(
     key: string,
-    callback: (error: ?Error, result: ?string) => void
+    callback?: ?(error: ?Error, result: ?string) => void
   ): Promise {
     return new Promise((resolve, reject) => {
       RCTAsyncStorage.multiGet([key], function(errors, result) {
@@ -60,7 +60,7 @@ var AsyncStorage = {
   setItem: function(
     key: string,
     value: string,
-    callback: ?(error: ?Error) => void
+    callback?: ?(error: ?Error) => void
   ): Promise {
     return new Promise((resolve, reject) => {
       RCTAsyncStorage.multiSet([[key,value]], function(errors) {
@@ -78,7 +78,7 @@ var AsyncStorage = {
    */
   removeItem: function(
     key: string,
-    callback: ?(error: ?Error) => void
+    callback?: ?(error: ?Error) => void
   ): Promise {
     return new Promise((resolve, reject) => {
       RCTAsyncStorage.multiRemove([key], function(errors) {
@@ -100,7 +100,7 @@ var AsyncStorage = {
   mergeItem: function(
     key: string,
     value: string,
-    callback: ?(error: ?Error) => void
+    callback?: ?(error: ?Error) => void
   ): Promise {
     return new Promise((resolve, reject) => {
       RCTAsyncStorage.multiMerge([[key,value]], function(errors) {
@@ -119,7 +119,7 @@ var AsyncStorage = {
    * don't want to call this - use removeItem or multiRemove to clear only your
    * own keys instead. Returns a `Promise` object.
    */
-  clear: function(callback: ?(error: ?Error) => void): Promise {
+  clear: function(callback?: ?(error: ?Error) => void): Promise {
     return new Promise((resolve, reject) => {
       RCTAsyncStorage.clear(function(error) {
         callback && callback(convertError(error));
@@ -135,7 +135,7 @@ var AsyncStorage = {
   /**
    * Gets *all* keys known to the system, for all callers, libraries, etc. Returns a `Promise` object.
    */
-  getAllKeys: function(callback: (error: ?Error) => void): Promise {
+  getAllKeys: function(callback?: ?(error: ?Error, keys: ?Array<string>) => void): Promise {
     return new Promise((resolve, reject) => {
       RCTAsyncStorage.getAllKeys(function(error, keys) {
         callback && callback(convertError(error), keys);
@@ -166,7 +166,7 @@ var AsyncStorage = {
    */
   multiGet: function(
     keys: Array<string>,
-    callback: (errors: ?Array<Error>, result: ?Array<Array<string>>) => void
+    callback?: ?(errors: ?Array<Error>, result: ?Array<Array<string>>) => void
   ): Promise {
     return new Promise((resolve, reject) => {
       RCTAsyncStorage.multiGet(keys, function(errors, result) {
@@ -189,7 +189,7 @@ var AsyncStorage = {
    */
   multiSet: function(
     keyValuePairs: Array<Array<string>>,
-    callback: ?(errors: ?Array<Error>) => void
+    callback?: ?(errors: ?Array<Error>) => void
   ): Promise {
     return new Promise((resolve, reject) => {
       RCTAsyncStorage.multiSet(keyValuePairs, function(errors) {
@@ -209,7 +209,7 @@ var AsyncStorage = {
    */
   multiRemove: function(
     keys: Array<string>,
-    callback: ?(errors: ?Array<Error>) => void
+    callback?: ?(errors: ?Array<Error>) => void
   ): Promise {
     return new Promise((resolve, reject) => {
       RCTAsyncStorage.multiRemove(keys, function(errors) {
@@ -232,7 +232,7 @@ var AsyncStorage = {
    */
   multiMerge: function(
     keyValuePairs: Array<Array<string>>,
-    callback: ?(errors: ?Array<Error>) => void
+    callback?: ?(errors: ?Array<Error>) => void
   ): Promise {
     return new Promise((resolve, reject) => {
       RCTAsyncStorage.multiMerge(keyValuePairs, function(errors) {


### PR DESCRIPTION
The `getAllKeys` callback type was completely missing the return value, and all of the callbacks are optional. This just fixes the types to match what the implementations are doing.