### PR TITLE
[Loader] Post a notification when the JS fails to load

### DIFF
--- a/React/Base/RCTBridge.h
+++ b/React/Base/RCTBridge.h
@@ -29,6 +29,11 @@ extern NSString *const RCTReloadNotification;
 extern NSString *const RCTJavaScriptDidLoadNotification;
 
 /**
+ * This notification fires when the bridge failed to load.
+ */
+extern NSString *const RCTJavaScriptDidFailToLoadNotification;
+
+/**
  * This block can be used to instantiate modules that require additional
  * init parameters, or additional configuration prior to being used.
  * The bridge will call this block to instatiate the modules, and will

--- a/React/Base/RCTBridge.m
+++ b/React/Base/RCTBridge.m
@@ -31,6 +31,7 @@
 
 NSString *const RCTReloadNotification = @"RCTReloadNotification";
 NSString *const RCTJavaScriptDidLoadNotification = @"RCTJavaScriptDidLoadNotification";
+NSString *const RCTJavaScriptDidFailToLoadNotification = @"RCTJavaScriptDidFailToLoadNotification";
 
 dispatch_queue_t const RCTJSThread = nil;
 
@@ -1090,6 +1091,10 @@ RCT_BRIDGE_WARN(_invokeAndProcessModule:(NSString *)module method:(NSString *)me
       sourceCodeModule.scriptURL = bundleURL;
       sourceCodeModule.scriptText = script;
       if (error != nil) {
+        NSDictionary *userInfo = @{@"error": error};
+        [[NSNotificationCenter defaultCenter] postNotificationName:RCTJavaScriptDidFailToLoadNotification
+                                                            object:self
+                                                          userInfo:userInfo];
 
         NSArray *stack = [[error userInfo] objectForKey:@"stack"];
         if (stack) {


### PR DESCRIPTION
This provides a way to get notified when a bridge fails to load JS, allowing apps to handle the error.

Test Plan: run the UIExplorer app with the packager server not running, and verify that the notification is posted.