### PR TITLE
Specify Flow version in SampleApp .flowconfig

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -37,4 +37,4 @@ Examples/UIExplorer/ImageMocks.js
 module.system=haste
 
 [version]
-0.10.0
+0.11.0

--- a/.flowconfig
+++ b/.flowconfig
@@ -37,4 +37,4 @@ Examples/UIExplorer/ImageMocks.js
 module.system=haste
 
 [version]
-0.11.0
+0.10.0

--- a/Examples/SampleApp/_flowconfig
+++ b/Examples/SampleApp/_flowconfig
@@ -31,3 +31,6 @@ node_modules/react-native/Libraries/react-native/react-native-interface.js
 
 [options]
 module.system=haste
+
+[version]
+0.10.0

--- a/Examples/SampleApp/_flowconfig
+++ b/Examples/SampleApp/_flowconfig
@@ -33,4 +33,4 @@ node_modules/react-native/Libraries/react-native/react-native-interface.js
 module.system=haste
 
 [version]
-0.10.0
+0.11.0


### PR DESCRIPTION
Each version of Flow includes breaking changes, so let's be extremely specific which version of Flow each generated project is expected for 0 errors. We will bump this dependency as new versions of Flow are released and as we update react-native to work with the new version of Flow.

I tested by doing

```Bash
cd react-native
mkdir Testing
cd Testing
../init.sh Foo
cat .flowconfig
```