### PR TITLE
[Flow] Install flow-bin and use that for packager Flow check

### DIFF
--- a/Examples/SampleApp/_flowconfig
+++ b/Examples/SampleApp/_flowconfig
@@ -15,6 +15,9 @@
 .*/node_modules/react-tools/src/core/ReactInstanceHandles.js
 .*/node_modules/react-tools/src/event/EventPropagators.js
 
+# Ignore flow-bin
+.*/node_modules/flow-bin/.*
+
 # Ignore commoner tests
 .*/node_modules/react-tools/node_modules/commoner/test/.*
 

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "chalk": "^1.0.0",
     "connect": "2.8.3",
     "debug": "~2.1.0",
+    "flow-bin": "^0.11.0",
     "graceful-fs": "^3.0.6",
     "image-size": "0.3.5",
     "joi": "~5.1.0",

--- a/packager/getFlowTypeCheckMiddleware.js
+++ b/packager/getFlowTypeCheckMiddleware.js
@@ -36,12 +36,12 @@ function getFlowTypeCheckMiddleware(options) {
     try {
       // Quote the path to the binary in case of spaces. Also need to escape
       // the single quotes with '\''. So 'Bob's path' becomes 'Bob'\''s path'
-      flowbin = "'"+require('flow-bin').replace(/'/g, "'\\''")+"'";
+      flowbin = "'" + require('flow-bin').replace(/'/g, "'\\''") + "'";
     } catch (ex) {
       flowbin = 'flow';
     }
 
-    exec('command -v '+flowbin+' >/dev/null 2>&1', function(error, stdout) {
+    exec('command -v ' + flowbin + ' >/dev/null 2>&1', function(error, stdout) {
       if (error) {
         if (!hasWarned.noFlow) {
           hasWarned.noFlow = true;

--- a/packager/getFlowTypeCheckMiddleware.js
+++ b/packager/getFlowTypeCheckMiddleware.js
@@ -34,7 +34,9 @@ function getFlowTypeCheckMiddleware(options) {
     // whatever is in the path
     var flowbin;
     try {
-      flowbin = require('flow-bin');
+      // Quote the path to the binary in case of spaces. Also need to escape
+      // the single quotes with '\''. So 'Bob's path' becomes 'Bob'\''s path'
+      flowbin = "'"+require('flow-bin').replace(/'/g, "'\\''")+"'";
     } catch (ex) {
       flowbin = 'flow';
     }

--- a/packager/packager.js
+++ b/packager/packager.js
@@ -213,8 +213,7 @@ function runServer(
     .use(openStackFrameInEditor)
     .use(getDevToolsLauncher(options))
     .use(statusPageMiddleware)
-    // Temporarily disable flow check until it's more stable
-    //.use(getFlowTypeCheckMiddleware(options))
+    .use(getFlowTypeCheckMiddleware(options))
     .use(getAppMiddleware(options));
 
   options.projectRoots.forEach(function(root) {

--- a/react-native-cli/index.js
+++ b/react-native-cli/index.js
@@ -94,8 +94,16 @@ function init(name) {
       process.exit(1);
     }
 
-    var cli = require(CLI_MODULE_PATH());
-    cli.init(root, projectName);
+    run('npm install --save flow-bin@0.10.0', function(e) {
+      if (e) {
+        console.error(
+          '`npm install --save flow-bin@0.10.0` failed. Continuing anyway.'
+        );
+      }
+
+      var cli = require(CLI_MODULE_PATH());
+      cli.init(root, projectName);
+    });
   });
 }
 

--- a/react-native-cli/index.js
+++ b/react-native-cli/index.js
@@ -94,16 +94,8 @@ function init(name) {
       process.exit(1);
     }
 
-    run('npm install --save flow-bin@0.10.0', function(e) {
-      if (e) {
-        console.error(
-          '`npm install --save flow-bin@0.10.0` failed. Continuing anyway.'
-        );
-      }
-
-      var cli = require(CLI_MODULE_PATH());
-      cli.init(root, projectName);
-    });
+    var cli = require(CLI_MODULE_PATH());
+    cli.init(root, projectName);
   });
 }
 


### PR DESCRIPTION
Flow is versioned with semver, and almost every deploy includes a breaking change. We can address this by installing the [`flow-bin`](https://github.com/sindresorhus/flow-bin) package...a very simple npm package that downloads the correct binary based on the operating system and the version. Then the packager can use the correct version of Flow, even if a more recent version of Flow is available.

This is a sister PR to https://github.com/facebook/react-native/pull/1097 which also sticks the version number in the `.flowconfig`, so that users will get a clear error if they try to do Flow checks with the wrong version of Flow.

This means when we update react-native to work with a new version of Flow, we need to update the version number in `react-native-cli/index.js` and in `Examples/SampleApp/_flowconfig`. When a user wants to update the version of Flow they're using locally, they will just need to edit their `.flowconfig` and their `package.json`. We should document this somewhere.

Future work includes maybe transitioning people from installing flow with homebrew to globally installing some wrapper script, which can intelligently find which flow binary to use (like looking for a flow-bin package, for example).