### PR TITLE
Fixed name of Chrome window, Connects to #297

### DIFF
--- a/packager/launchChromeDevTools.applescript
+++ b/packager/launchChromeDevTools.applescript
@@ -10,7 +10,7 @@
 on run argv
   set theURL to item 1 of argv
 
-  tell application "Google Chrome"
+  tell application "Chrome"
     activate
 
     if (count every window) = 0 then


### PR DESCRIPTION
Hi!

I have the same problem as described here https://github.com/facebook/react-native/issues/297
It could occurs after restarting `packager.sh` or `debuger-ui` page.

I found simple solution that works for me, but I am not 100% sure it will works for any user with this problem.

How could this be tested automatically?