### PR TITLE
support data URIs and absolute file paths in CameraRoll.saveImageWithTag

### DIFF
--- a/Libraries/CameraRoll/CameraRoll.js
+++ b/Libraries/CameraRoll/CameraRoll.js
@@ -95,10 +95,12 @@ class CameraRoll {
   /**
    * Saves the image with tag `tag` to the camera roll.
    *
-   * @param {string} tag - Can be any of the three kinds of tags we accept:
+   * @param {string} tag - Can be any of the five kinds of tags we accept:
    *                       1. URL
    *                       2. assets-library tag
    *                       3. tag returned from storing an image in memory
+   *                       4. data URI
+   *                       5. absolute file path
    */
   static saveImageWithTag(tag, successCallback, errorCallback) {
     invariant(

--- a/Libraries/Image/RCTImageLoader.m
+++ b/Libraries/Image/RCTImageLoader.m
@@ -119,6 +119,12 @@ NSError *errorWithMessage(NSString *message)
         callback(nil, [UIImage imageWithData:data]);
       }
     }];
+  } else if ([imageTag hasPrefix:@"data:"]) {
+    NSURL *url = [NSURL URLWithString:imageTag];
+    NSData *imageData = [NSData dataWithContentsOfURL:url];
+    callback(nil, [UIImage imageWithData:imageData]);
+  } else if([imageTag isAbsolutePath]) {
+    callback(nil, [UIImage imageWithContentsOfFile:imageTag]);
   } else {
     NSString *errorMessage = [NSString stringWithFormat:@"Unrecognized tag protocol: %@", imageTag];
     NSError *error = errorWithMessage(errorMessage);


### PR DESCRIPTION
This adds support for saving data URI's and full file paths to CameraRoll using roughly the same code for handling these schemes as is used by the Image component.

There are probably several use cases for this, among which is being able to get images from [react-native-camera](https://github.com/lwansbrough/react-native-camera) to the CameraRoll.