### PR TITLE
Fixed crash when moduleId or methodId cannot be found

### DIFF
--- a/React/Base/RCTBridge.m
+++ b/React/Base/RCTBridge.m
@@ -1047,11 +1047,11 @@ static id<RCTJavaScriptExecutor> _latestJSExecutor;
   NSNumber *notFound = @-1;
     
   NSNumber *moduleID = RCTLocalModuleIDs[moduleDotMethod] ?: notFound;
-  RCTAssert(moduleID == notFound, @"Module '%@' not registered.",
+  RCTAssert(moduleID != notFound, @"Module '%@' not registered.",
             [[moduleDotMethod componentsSeparatedByString:@"."] firstObject]);
 
   NSNumber *methodID = RCTLocalMethodIDs[moduleDotMethod] ?: notFound;
-  RCTAssert(methodID == notFound, @"Method '%@' not registered.", moduleDotMethod);
+  RCTAssert(methodID != notFound, @"Method '%@' not registered.", moduleDotMethod);
 
   if (!_loading) {
     [self _invokeAndProcessModule:@"BatchedBridge"
@@ -1069,11 +1069,11 @@ static id<RCTJavaScriptExecutor> _latestJSExecutor;
   NSString *moduleDotMethod = @"RCTJSTimers.callTimers";
     
   NSNumber *moduleID = RCTLocalModuleIDs[moduleDotMethod] ?: notFound;
-  RCTAssert(moduleID == notFound, @"Module '%@' not registered.",
+  RCTAssert(moduleID != notFound, @"Module '%@' not registered.",
             [[moduleDotMethod componentsSeparatedByString:@"."] firstObject]);
 
   NSNumber *methodID = RCTLocalMethodIDs[moduleDotMethod] ?: notFound;
-  RCTAssert(methodID == notFound, @"Method '%@' not registered.", moduleDotMethod);
+  RCTAssert(methodID != notFound, @"Method '%@' not registered.", moduleDotMethod);
 
   if (!_loading) {
 #if BATCHED_BRIDGE

--- a/React/Base/RCTBridge.m
+++ b/React/Base/RCTBridge.m
@@ -1044,12 +1044,14 @@ static id<RCTJavaScriptExecutor> _latestJSExecutor;
  */
 - (void)enqueueJSCall:(NSString *)moduleDotMethod args:(NSArray *)args
 {
-  NSNumber *moduleID = RCTLocalModuleIDs[moduleDotMethod];
-  RCTAssert(moduleID != nil, @"Module '%@' not registered.",
+  NSNumber *notFound = @-1;
+    
+  NSNumber *moduleID = RCTLocalModuleIDs[moduleDotMethod] ?: notFound;
+  RCTAssert(moduleID == notFound, @"Module '%@' not registered.",
             [[moduleDotMethod componentsSeparatedByString:@"."] firstObject]);
 
-  NSNumber *methodID = RCTLocalMethodIDs[moduleDotMethod];
-  RCTAssert(methodID != nil, @"Method '%@' not registered.", moduleDotMethod);
+  NSNumber *methodID = RCTLocalMethodIDs[moduleDotMethod] ?: notFound;
+  RCTAssert(methodID == notFound, @"Method '%@' not registered.", moduleDotMethod);
 
   if (!_loading) {
     [self _invokeAndProcessModule:@"BatchedBridge"
@@ -1063,13 +1065,15 @@ static id<RCTJavaScriptExecutor> _latestJSExecutor;
  */
 - (void)_immediatelyCallTimer:(NSNumber *)timer
 {
+  NSNumber *notFound = @-1;
   NSString *moduleDotMethod = @"RCTJSTimers.callTimers";
-  NSNumber *moduleID = RCTLocalModuleIDs[moduleDotMethod];
-  RCTAssert(moduleID != nil, @"Module '%@' not registered.",
+    
+  NSNumber *moduleID = RCTLocalModuleIDs[moduleDotMethod] ?: notFound;
+  RCTAssert(moduleID == notFound, @"Module '%@' not registered.",
             [[moduleDotMethod componentsSeparatedByString:@"."] firstObject]);
 
-  NSNumber *methodID = RCTLocalMethodIDs[moduleDotMethod];
-  RCTAssert(methodID != nil, @"Method '%@' not registered.", moduleDotMethod);
+  NSNumber *methodID = RCTLocalMethodIDs[moduleDotMethod] ?: notFound;
+  RCTAssert(methodID == notFound, @"Method '%@' not registered.", moduleDotMethod);
 
   if (!_loading) {
 #if BATCHED_BRIDGE


### PR DESCRIPTION
If moduleId or methodId cannot be found and we are using release build - application will crash

Fixes #1114 

I'm not sure how can I create test for this, because we somehow have to go through the RCTAssert.
