### PR TITLE
[CLI] Deprecate optimist in favor of yargs

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -9,11 +9,11 @@
     "glob": "*",
     "jstransform": "*",
     "mkdirp": "*",
-    "optimist": "0.6.0",
     "react": "~0.12.0",
     "react-docgen": "^1.1.0",
     "react-page-middleware": "git://github.com/facebook/react-page-middleware.git",
-    "request": "*"
+    "request": "*",
+    "yargs": "^3.8.0"
   },
   "devDependencies": {
     "bluebird": "^2.9.21"

--- a/website/server/convert.js
+++ b/website/server/convert.js
@@ -10,10 +10,12 @@
 var fs = require('fs')
 var glob = require('glob');
 var mkdirp = require('mkdirp');
-var optimist = require('optimist');
+var yargs = require('yargs');
 var path = require('path');
 var extractDocs = require('./extractDocs');
-var argv = optimist.argv;
+
+var yargs = require('yargs');
+var argv = yargs.argv;
 
 function splitHeader(content) {
   var lines = content.split('\n');

--- a/website/server/server.js
+++ b/website/server/server.js
@@ -10,12 +10,12 @@
 "use strict";
 var connect = require('connect');
 var http = require('http');
-var optimist = require('optimist');
 var path = require('path');
 var reactMiddleware = require('react-page-middleware');
 var convert = require('./convert.js');
 
-var argv = optimist.argv;
+var yargs = require('yargs');
+var argv = yargs.argv;
 
 var PROJECT_ROOT = path.resolve(__dirname, '..');
 var FILE_SERVE_ROOT = path.join(PROJECT_ROOT, 'src');


### PR DESCRIPTION
`optimist` is long time deprecated. There are several active alternative libraries. [yargs](https://github.com/bcoe/yargs) is direct successor to `optimist`. If it's OK, main dependency should also be changed for consistency.