### PR TITLE
Force `responseHeaders` to lower case to respect case-insensitivity

### DIFF
--- a/Libraries/Network/XMLHttpRequestBase.js
+++ b/Libraries/Network/XMLHttpRequestBase.js
@@ -66,7 +66,7 @@ class XMLHttpRequestBase {
 
   getResponseHeader(header: string): ?string {
     if (this.responseHeaders) {
-      var value = this.responseHeaders[header];
+      var value = this.responseHeaders[header.toLowerCase()];
       return value !== undefined ? value : null;
     }
     return null;
@@ -132,6 +132,11 @@ class XMLHttpRequestBase {
       return;
     }
     this.status = status;
+    // Headers should be case-insensitive
+    for (var header in responseHeaders) {
+      responseHeaders[header.toLowerCase()] = responseHeaders[header];
+      delete responseHeaders[header];
+    }
     this.responseHeaders = responseHeaders || {};
     this.responseText = responseText;
     this._setReadyState(this.DONE);

--- a/Libraries/Network/XMLHttpRequestBase.js
+++ b/Libraries/Network/XMLHttpRequestBase.js
@@ -133,11 +133,11 @@ class XMLHttpRequestBase {
     }
     this.status = status;
     // Headers should be case-insensitive
+    var lcResponseHeaders = {};
     for (var header in responseHeaders) {
-      responseHeaders[header.toLowerCase()] = responseHeaders[header];
-      delete responseHeaders[header];
+      lcResponseHeaders[header.toLowerCase()] = responseHeaders[header];
     }
-    this.responseHeaders = responseHeaders || {};
+    this.responseHeaders = lcResponseHeaders;
     this.responseText = responseText;
     this._setReadyState(this.DONE);
     this._sendLoad();


### PR DESCRIPTION
`XMLHttpRequest.getResponseHeader` is case-insensitive, therefor the React-Native implementation needs to mimic this behavior as to not break libraries that are dependent on this.

There is a corresponding issue in `superagent` but this is the root cause (https://github.com/visionmedia/superagent/issues/636).