### PR TITLE
Fix typo of function name in ListView documentation

### DIFF
--- a/Libraries/CustomComponents/ListView/ListView.js
+++ b/Libraries/CustomComponents/ListView/ListView.js
@@ -87,7 +87,7 @@ var SCROLLVIEW_REF = 'listviewscroll';
  * smoothly while dynamically loading potentially very large (or conceptually
  * infinite) data sets:
  *
- *  * Only re-render changed rows - the hasRowChanged function provided to the
+ *  * Only re-render changed rows - the rowHasChanged function provided to the
  *    data source tells the ListView if it needs to re-render a row because the
  *    source data has changed - see ListViewDataSource for more details.
  *


### PR DESCRIPTION
When I read documents, I usually 'search within page' to see where they talk about specific things.
So I found this fix to be pretty useful. Hope it'll be merged!