### PR TITLE
[Navigator] Pass route into onItemRef

### DIFF
--- a/Libraries/CustomComponents/Navigator/Navigator.js
+++ b/Libraries/CustomComponents/Navigator/Navigator.js
@@ -253,7 +253,7 @@ var Navigator = React.createClass({
     onDidFocus: PropTypes.func,
 
     /**
-     * Will be called with (ref, indexInStack) when the scene ref changes
+     * Will be called with (ref, indexInStack, route) when the scene ref changes
      */
     onItemRef: PropTypes.func,
 
@@ -1159,13 +1159,13 @@ var Navigator = React.createClass({
     return this.state.routeStack;
   },
 
-  _handleItemRef: function(itemId, ref) {
+  _handleItemRef: function(itemId, route, ref) {
     this._itemRefs[itemId] = ref;
     var itemIndex = this.state.idStack.indexOf(itemId);
     if (itemIndex === -1) {
       return;
     }
-    this.props.onItemRef && this.props.onItemRef(ref, itemIndex);
+    this.props.onItemRef && this.props.onItemRef(ref, itemIndex, route);
   },
 
   _cleanScenesPastIndex: function(index) {
@@ -1273,7 +1273,7 @@ var Navigator = React.createClass({
         }}
         style={[styles.baseScene, this.props.sceneStyle, disabledSceneStyle]}>
         {React.cloneElement(child, {
-          ref: this._handleItemRef.bind(null, this.state.idStack[i]),
+          ref: this._handleItemRef.bind(null, this.state.idStack[i], route),
         })}
       </View>
     );


### PR DESCRIPTION
The index alone isn't so useful; pass the route as well. (I am using this to implement componentWill/DidFocus in a library instead of onWill/DidFocus; #1153).

Test Plan: Set up a navigator with a couple of scenes, and see that when onItemRef is called for each one, the route is passed in as the third argument.