### PR TITLE
[ActivityIndicator] Specify a width

### DIFF
--- a/Libraries/Components/ActivityIndicatorIOS/ActivityIndicatorIOS.ios.js
+++ b/Libraries/Components/ActivityIndicatorIOS/ActivityIndicatorIOS.ios.js
@@ -81,9 +81,11 @@ var styles = StyleSheet.create({
     justifyContent: 'center',
   },
   sizeSmall: {
+    width: 20,
     height: 20,
   },
   sizeLarge: {
+    width: 36,
     height: 36,
   }
 });


### PR DESCRIPTION
The activity indicator was treated as a zero-width element without an explicit width. Fill it in so the style dimensions match what is displayed on the screen.

Test Plan: Render an ActivityIndicator with a background, and see that the background shows up as a square behind the spinner instead of not showing up at all (since it was 0px wide previously).