### PR TITLE
[TextView] Define missing properties and add getters

### DIFF
--- a/Libraries/Text/RCTTextView.h
+++ b/Libraries/Text/RCTTextView.h
@@ -21,6 +21,8 @@
 @property (nonatomic, assign) BOOL selectTextOnFocus;
 @property (nonatomic, assign) UIEdgeInsets contentInset;
 @property (nonatomic, assign) BOOL automaticallyAdjustContentInsets;
+@property (nonatomic, strong) NSString *text;
+@property (nonatomic, strong) UIColor *textColor;
 @property (nonatomic, strong) UIColor *placeholderTextColor;
 @property (nonatomic, assign) UIFont *font;
 

--- a/Libraries/Text/RCTTextView.m
+++ b/Libraries/Text/RCTTextView.m
@@ -72,11 +72,20 @@
   }
 }
 
+- (UIFont *)font
+{
+  return _textView.font;
+}
+
 - (void)setFont:(UIFont *)font
 {
-  _font = font;
-  _textView.font = _font;
+  _textView.font = font;
   [self updatePlaceholder];
+}
+
+- (UIColor *)textColor
+{
+  return _textView.textColor;
 }
 
 - (void)setTextColor:(UIColor *)textColor
@@ -104,6 +113,11 @@
 {
   _contentInset = contentInset;
   [self updateFrames];
+}
+
+- (NSString *)text
+{
+  return _textView.text;
 }
 
 - (void)setText:(NSString *)text
@@ -146,7 +160,6 @@
 - (void)textViewDidBeginEditing:(UITextView *)textView
 {
   if (_clearTextOnFocus) {
-    [_textView setText:@""];
     _textView.text = @"";
     [self _setPlaceholderVisibility];
   }


### PR DESCRIPTION
Some of the RCTTextView properties weren't set up correctly which would cause bugs when you'd set a property and then unset it, trying to revert to the default. This requires reading the default value from the dummy view instance, but some of these properties didn't have getters which was causing issues.

Fixes #1174 

Test Plan: Create a `<TextInput multiline={true}>` component. Give it a style with `color: 'blue'`, and then on the next render pass remove the style. No more red box.