### PR TITLE
[JS Executors] Add ability to execute non-nodeJS javascript with JS executors

### DIFF
--- a/React/Base/RCTJavaScriptExecutor.h
+++ b/React/Base/RCTJavaScriptExecutor.h
@@ -22,6 +22,15 @@ typedef void (^RCTJavaScriptCallback)(id json, NSError *error);
  */
 @protocol RCTJavaScriptExecutor <RCTInvalidating>
 
+
+/**
+ * Executes given string on JS thread and calls the given callback
+ * with JSValue and JSContext as a result of the JS module call.
+ */
+- (void)executeJSString:(NSString*)execString
+                context:(NSNumber *)executorID
+               callback:(RCTJavaScriptCallback)onComplete;
+
 /**
  * Executes given method with arguments on JS thread and calls the given callback
  * with JSValue and JSContext as a result of the JS module call.

--- a/React/Executors/RCTWebViewExecutor.m
+++ b/React/Executors/RCTWebViewExecutor.m
@@ -77,18 +77,38 @@ static void RCTReportError(RCTJavaScriptCallback callback, NSString *fmt, ...)
   return webView;
 }
 
+- (void)executeJSString:(NSString *)execString
+                context:(NSNumber *)executorID
+               callback:(RCTJavaScriptCallback)onComplete
+{
+    RCTAssert(onComplete != nil, @"");
+    [self executeBlockOnJavaScriptQueue:^{
+        if (!self.isValid || ![RCTGetExecutorID(self) isEqualToNumber:executorID]) {
+            return;
+        }
+        
+        NSString *ret = [_webView stringByEvaluatingJavaScriptFromString:execString];
+        if (ret.length == 0) {
+            RCTReportError(onComplete, @"Empty return string: JavaScript error running script: %@", execString);
+            return;
+        }
+        
+        NSError *error;
+        id objcValue = RCTJSONParse(ret, &error);
+        if (!objcValue) {
+            RCTReportError(onComplete, @"Cannot parse json response: %@", error);
+            return;
+        }
+        onComplete(objcValue, nil);
+    }];
+}
+
 - (void)executeJSCall:(NSString *)name
                method:(NSString *)method
             arguments:(NSArray *)arguments
               context:(NSNumber *)executorID
              callback:(RCTJavaScriptCallback)onComplete
 {
-  RCTAssert(onComplete != nil, @"");
-  [self executeBlockOnJavaScriptQueue:^{
-    if (!self.isValid || ![RCTGetExecutorID(self) isEqualToNumber:executorID]) {
-      return;
-    }
-
     NSError *error;
     NSString *argsString = RCTJSONStringify(arguments, &error);
     if (!argsString) {
@@ -97,19 +117,7 @@ static void RCTReportError(RCTJavaScriptCallback callback, NSString *fmt, ...)
     }
     NSString *execString = [NSString stringWithFormat:@"JSON.stringify(require('%@').%@.apply(null, %@));", name, method, argsString];
 
-    NSString *ret = [_webView stringByEvaluatingJavaScriptFromString:execString];
-    if (ret.length == 0) {
-      RCTReportError(onComplete, @"Empty return string: JavaScript error running script: %@", execString);
-      return;
-    }
-
-    id objcValue = RCTJSONParse(ret, &error);
-    if (!objcValue) {
-      RCTReportError(onComplete, @"Cannot parse json response: %@", error);
-      return;
-    }
-    onComplete(objcValue, nil);
-  }];
+    [self executeJSString:execString context:executorID callback:onComplete];
 }
 
 /**


### PR DESCRIPTION
(This is my first PR here, so let me know what I am doing wrong!  Reading the guidelines, it looks like I did the indents wrong, I'll go back and fix that if you think this PR is worth merging.)


## What & Why

I am an objective-C iOS programmer, however the product I work on has both web and iOS versions.  For many of the views, there is logic needed around decorating various model objects.  For example, we might have several sources of a persons' work history.  There might be duplicates between the sources, so we have logic to know when a given 'work' model is a duplicate, and how to merge work model objects together.  Currently this logic is duplicated in the front-end client code of the web application and the iOS application.  This duplication of logic has grown in recent months and is a constant source of issues.

## Goal

We want to share a very basic set of functions for manipulating low level models, between a web application and an iOS application.  These functions would be written in javascript and would not rely on Node modules.

## Solution

I looked into ReactNative and really liked how it abstracted *how* the javascript executes (currently JavaScriptCore vs WebViews).  Rather than duplicating this functionality, along with a bunch of the other string and object helper functions, I tried to use ReactNative to accomplish this sharing of code.  

I created a totally normal objective-c iOS application using the wizard, and added a single .js file to the xcodeproj containing:

```javascript
decorator = function(json) {
   if (typeof json == "string") {
      data = JSON.parse(json);
   } else {
      data = json;
   }

   if (data) {
      data.decorated_field = "I've been decorated";
   }
   return JSON.stringify(data);
}  
```

Then in the view controller I added this code:

```objc
    NSString *path = [[NSBundle bundleForClass:[self class]] pathForResource:@"foo" ofType: @"js"];
    NSString *script = [NSString stringWithContentsOfFile:path encoding:NSUTF8StringEncoding error:nil];
    _scriptURL = [NSURL URLWithString:path];
    
    _executor = RCTCreateExecutor(RCTContextExecutor.class);

    [_executor executeApplicationScript:script sourceURL:_scriptURL onComplete:^(NSError *error) {
        NSString* execString = @"decorator({model_field:\"foo\"})";
        [_executor executeJSString:execString context:RCTGetExecutorID(_executor) callback:^(id json, NSError *error) {
            NSLog(@"JSON: %@", json);
        }];
    }];
```

This allows me to use the ReactNative executor functionality to run that decorator function in the javascript file, from objective C.   Giving me the decorated output:

```
{"model_field":"foo","decorated_field":"I've been decorated"}
```

In this way, this javascript file could be stored in a submodule and used directly from the web application, or from the iOS application.  Currently, I think it would be easiest to just embed the javascript in the binary for iOS, but conceivably it could be stored on a server and downloaded dynamically.

## The Pull Request

The changes I had to make were to allow direct execution of the javascript functions, rather than forcing the use of nodeJS.  I didn't change the existing API, but rather added the new ```executeJSString:context:callback``` function.  I abstracted the shared code in the ```executeJSCall``` function a bit, and tried to make it a bit cleaner.   The only real difference would be in the way the profiling is done, it no longer tracks the method & name that is passed to the ```executeJSCall```, but rather just the string that the executor ends up executing.   


Thoughts?
