### PR TITLE
[RCTBridge] Have RCTBridge.loading return RCTBatchedBridge.loading

### DIFF
--- a/React/Base/RCTBridge.m
+++ b/React/Base/RCTBridge.m
@@ -835,6 +835,11 @@ static id<RCTJavaScriptExecutor> _latestJSExecutor;
   _batchedBridge = [[RCTBatchedBridge alloc] initWithParentBridge:self];
 }
 
+- (BOOL)isLoading
+{
+  return _batchedBridge.loading;
+}
+
 - (BOOL)isValid
 {
   return _batchedBridge.isValid;


### PR DESCRIPTION
The parent RCTBridge no longer tracks the JS loading since that has been handed off to the RCTBatchedBridge. To make the `loading` property accurate again, just expose the batch bridge's loading property from the parent bridge (note: I didn't make it KVO-compliant).

Fixes #1199 