### PR TITLE
[Pods] Define a subspec for ART

### DIFF
--- a/React.podspec
+++ b/React.podspec
@@ -32,6 +32,12 @@ Pod::Spec.new do |s|
     ss.frameworks       = "JavaScriptCore"
   end
 
+  s.subspec 'ART' do |ss|
+    ss.dependency         'React/Core'
+    ss.source_files     = "Libraries/ART/**/*.{h,m}"
+    ss.preserve_paths   = "Libraries/ART/**/*.js"
+  end
+
   s.subspec 'RCTActionSheet' do |ss|
     ss.dependency         'React/Core'
     ss.source_files     = "Libraries/ActionSheetIOS/*.{h,m}"


### PR DESCRIPTION
Adds a CocoaPods subspec for ART.

cc @a2 @spicyj 

Test Plan: Pull in the subspec and run the VectorWidget example from react-art.