### PR TITLE
[RCTBridge] Clean up reload notification observer

### DIFF
--- a/React/Base/RCTBridge.m
+++ b/React/Base/RCTBridge.m
@@ -789,6 +789,7 @@ static id<RCTJavaScriptExecutor> _latestJSExecutor;
    * This runs only on the main thread, but crashes the subclass
    * RCTAssertMainThread();
    */
+  [[NSNotificationCenter defaultCenter] removeObserver:self];
   [self invalidate];
 }
 
@@ -1161,7 +1162,6 @@ RCT_BRIDGE_WARN(_invokeAndProcessModule:(NSString *)module method:(NSString *)me
 
   void (^mainThreadInvalidate)(void) = ^{
 
-    [[NSNotificationCenter defaultCenter] removeObserver:self];
     [_mainDisplayLink invalidate];
     _mainDisplayLink = nil;
 


### PR DESCRIPTION
After the RCTBatchedBridge refactor, the `-[NSNotificationCenter addObserver]` and `[removeObserver]` calls got divided between RCTBridge and RCTBatchedBridge. This diff does two things:

 - Moved `removeObserver` out of RTCBatchedBridge and into `-[RCTBridge invalidate]`
 - Moved `addObserver` from `bindKeys` to `setUp`. This is so that `-[RCTBridge reload]` will re-add the observer after invalidating and removing the observer

cc @tadeuzagallo 