### PR TITLE
[GeoLocation] invalidate timer after success or error callback

### DIFF
--- a/Libraries/Geolocation/RCTLocationObserver.m
+++ b/Libraries/Geolocation/RCTLocationObserver.m
@@ -85,7 +85,9 @@ static NSDictionary *RCTPositionError(RCTPositionErrorCode code, NSString *msg /
 
 - (void)dealloc
 {
-  [_timeoutTimer invalidate];
+  if (_timeoutTimer.valid) {
+    [_timeoutTimer invalidate];
+  }
 }
 
 @end
@@ -273,6 +275,7 @@ RCT_EXPORT_METHOD(getCurrentPosition:(RCTLocationOptions)options
   // Fire all queued callbacks
   for (RCTLocationRequest *request in _pendingRequests) {
     request.successBlock(@[_lastLocationEvent]);
+    [request.timeoutTimer invalidate];
   }
   [_pendingRequests removeAllObjects];
 
@@ -311,6 +314,7 @@ RCT_EXPORT_METHOD(getCurrentPosition:(RCTLocationOptions)options
   // Fire all queued error callbacks
   for (RCTLocationRequest *request in _pendingRequests) {
     request.errorBlock(@[jsError]);
+    [request.timeoutTimer invalidate];
   }
   [_pendingRequests removeAllObjects];
 


### PR DESCRIPTION
Just trying to [getCurrentPosition](https://github.com/facebook/react-native/blob/master/Libraries/Geolocation/Geolocation.js#L45) , and found the `errorBlock` of location request in timeout handler would cause red error like this:

```
2015-05-10 17:50:39.607 [warn][tid:com.facebook.React.JavaScript] "Warning: Cannot find callback with CBID 5. Native module may have invoked both the success callback and the error callback."
2015-05-10 17:50:39.610 [error][tid:com.facebook.React.JavaScript] "Error: null is not an object (evaluating 'cb.apply')
 stack: 
  _invokeCallback  index.ios.bundle:7593
  <unknown>        index.ios.bundle:7656
  <unknown>        index.ios.bundle:7648
  perform          index.ios.bundle:6157
  batchedUpdates   index.ios.bundle:13786
  batchedUpdates   index.ios.bundle:4689
  <unknown>        index.ios.bundle:7647
  applyWithGuard   index.ios.bundle:882
  guardReturn      index.ios.bundle:7421
  processBatch     index.ios.bundle:7646
 URL: http://192.168.100.182:8081/index.ios.bundle
 line: 7593
 message: null is not an object (evaluating 'cb.apply')"
```

![img_0837](https://cloud.githubusercontent.com/assets/239970/7553804/3879b99c-f73d-11e4-9c17-55f6ce419651.PNG)

~~I'm not sure if there is a better way to avoid multiple callback which caused the error, 
but I don't think that the `errorBlock` should be called in timeout handler.
So, just remove it.~~

update: to invalidate the timer after success or error callback.


I just use the [demo code of Geolocation](http://facebook.github.io/react-native/docs/geolocation.html#examples)