### PR TITLE
[NativeModules] Support for loading React and/or native modules as a dynamic framework

### DIFF
--- a/React/Base/RCTBridge.m
+++ b/React/Base/RCTBridge.m
@@ -62,6 +62,180 @@ typedef struct section RCTHeaderSection;
               [[[NSThread currentThread] name] isEqualToString:@"com.facebook.React.JavaScript"], \
             @"This method must be called on JS thread")
 
+
+/**
+ * This class encapsulates the extraction of strings from a named section of an RCTHeaderValue.
+ *
+ * It provides implementations of -isEqual: and -hash to allow storing in a Cocoa collection
+ *
+ * Specifically, its hash value is the address of the mach_header for the binary that contains
+ * a given address.  This makes it cheap to create many RCTHeaderStringExtractor objects and
+ * de-duplicate those that refer to the same mach_header by sticking them in an NSSet.
+ */
+@interface RCTHeaderStringExtractor : NSObject
+
+- (instancetype)initWithAddressFromSharedObject:(const void *)address;
+- (NSArray *)stringsFromSection:(NSString *)sectionName;
+- (NSArray *)stringArraysFromSection:(NSString *)sectionName entriesPerArray:(NSUInteger)arraySize;
+@end
+
+@implementation RCTHeaderStringExtractor
+{
+  RCTHeaderValue _mach_header;
+}
+
+- (instancetype)initWithAddressFromSharedObject:(const void *)address
+{
+  if (!(self = [super init])) {
+    return nil;
+  }
+  
+  Dl_info info;
+  dladdr(address, &info);
+  const RCTHeaderValue mach_header = (RCTHeaderValue)info.dli_fbase;
+  _mach_header = mach_header;
+  
+  return self;
+}
+
+- (BOOL)isEqualToExtractor:(RCTHeaderStringExtractor *)extractor {
+  return extractor->_mach_header == _mach_header;
+}
+
+- (BOOL)isEqual:(id)object {
+  if (![object isKindOfClass:[self class]]) {
+    return NO;
+  }
+  
+  return [self isEqualToExtractor:(RCTHeaderStringExtractor *)object];
+}
+
+- (NSUInteger)hash {
+  return _mach_header;
+}
+
+- (NSArray *)stringsFromSection:(NSString *)sectionName
+{
+  const RCTHeaderSection *section = RCTGetSectByNameFromHeader((void *)_mach_header, "__DATA", [sectionName UTF8String]);
+  
+  NSMutableArray *stringArray = [NSMutableArray array];
+  if (section) {
+    for (RCTHeaderValue addr = section->offset;
+         addr < section->offset + section->size;
+         addr += sizeof(const char **)) {
+      
+      // Get data entry
+      NSString *entry = @(*(const char **)(_mach_header + addr));
+      [stringArray addObject:entry];
+    }
+  }
+  return stringArray;
+}
+
+- (NSArray *)stringArraysFromSection:(NSString *)sectionName entriesPerArray:(NSUInteger)arraySize
+{
+  const RCTHeaderSection *section = RCTGetSectByNameFromHeader((void *)_mach_header, "__DATA", [sectionName UTF8String]);
+  NSMutableArray *results = [NSMutableArray array];
+  if (section) {
+    
+    for (RCTHeaderValue addr = section->offset;
+         addr < section->offset + section->size;
+         addr += sizeof(const char **) * arraySize) {
+      
+      // Get data entry
+      const char **entries = (const char **)(_mach_header + addr);
+      NSMutableArray *innerArray = [NSMutableArray array];
+      
+      for (int i=0; i < arraySize; i++) {
+        const char *entry = entries[i];
+        if (entry != NULL) {
+          [innerArray addObject:@(entry)];
+        }
+      }
+      [results addObject:innerArray];
+    }
+  }
+  
+  return results;
+}
+
+@end
+
+NSSet *RCTHeaderStringExtractors;
+dispatch_queue_t RCTHeaderStringExtratorQueue;
+
+/**
+ * This function registers the mach binary that contains the symbol at the given address
+ * as a provider of React Native modules.  This must be called prior to instantiating
+ * any instances of RCTBridge for registration to be effective.
+ */
+void RCTRegisterModuleProviderContainingAddress(const void *address) {
+  static dispatch_once_t dispatchToken;
+  dispatch_once(&dispatchToken, ^{
+    RCTHeaderStringExtratorQueue = dispatch_queue_create("com.facebook.React.ModuleNameExtractor", DISPATCH_QUEUE_SERIAL);
+    RCTHeaderStringExtractors = [NSMutableSet set];
+  });
+  
+  dispatch_sync(RCTHeaderStringExtratorQueue, ^{
+    RCTHeaderStringExtractor *moduleExtractor = [[RCTHeaderStringExtractor alloc] initWithAddressFromSharedObject:address];
+    
+    [(NSMutableSet *)RCTHeaderStringExtractors addObject:moduleExtractor];
+  });
+}
+
+/**
+ * This function registers the mach binary that contains the caller as a provider of
+ * React Native modules.  This must be called prior to instantiating any instances of
+ * RCTBridge for registration to be effective.
+ */
+void RCTRegisterModuleProvider(void) {
+  const void *caller = __builtin_return_address(0);
+  RCTRegisterModuleProviderContainingAddress(caller);
+}
+
+/**
+ * This function enumerates the RCTHeaderStringExtractors for the registered
+ * native module providers and extracts all strings from the given named section.
+ * Returns the set of strings from all providers, with duplicates removed.
+ */
+NSArray *RCTStringsFromSection(NSString *sectionName) {
+  NSMutableArray *allStrings = [NSMutableArray array];
+  dispatch_sync(RCTHeaderStringExtratorQueue, ^{
+    for (RCTHeaderStringExtractor *extractor in RCTHeaderStringExtractors) {
+      [allStrings addObjectsFromArray:[extractor stringsFromSection:sectionName]];
+    }
+  });
+  return allStrings;
+}
+
+/**
+ * This function enumerates the RCTHeaderStringExtractors for the registered
+ * native module providers and returns extracted strings grouped in a two-dimensional
+ * array whose inner arrays are of a maximum size `stringsPerArray`
+ */
+NSArray *RCTStringArraysFromSection(NSString *sectionName, NSUInteger stringsPerArray) {
+  NSMutableArray *results = [NSMutableArray array];
+  dispatch_sync(RCTHeaderStringExtratorQueue, ^{
+    for (RCTHeaderStringExtractor *extractor in RCTHeaderStringExtractors) {
+      [results addObjectsFromArray:[extractor stringArraysFromSection:sectionName entriesPerArray:stringsPerArray]];
+    }
+  });
+  return results;
+}
+
+
+NSArray *RCTExportedModuleNames() {
+  return RCTStringsFromSection(@"RCTExportModule");
+}
+
+NSArray *RCTExportedMethodNames() {
+  return RCTStringArraysFromSection(@"RCTExport", 3);
+}
+
+NSArray *RCTImportedMethodNames() {
+  return RCTStringsFromSection(@"RCTImport");
+}
+
 NSString *const RCTEnqueueNotification = @"RCTEnqueueNotification";
 NSString *const RCTDequeueNotification = @"RCTDequeueNotification";
 
@@ -94,23 +268,7 @@ static NSArray *RCTJSMethods(void)
   dispatch_once(&onceToken, ^{
     NSMutableSet *uniqueMethods = [NSMutableSet set];
 
-    Dl_info info;
-    dladdr(&RCTJSMethods, &info);
-
-    const RCTHeaderValue mach_header = (RCTHeaderValue)info.dli_fbase;
-    const RCTHeaderSection *section = RCTGetSectByNameFromHeader((void *)mach_header, "__DATA", "RCTImport");
-
-    if (section) {
-      for (RCTHeaderValue addr = section->offset;
-           addr < section->offset + section->size;
-           addr += sizeof(const char **)) {
-
-        // Get data entry
-        NSString *entry = @(*(const char **)(mach_header + addr));
-        [uniqueMethods addObject:entry];
-      }
-    }
-
+    [uniqueMethods addObjectsFromArray:RCTImportedMethodNames()];
     JSMethods = [uniqueMethods allObjects];
   });
 
@@ -135,41 +293,28 @@ static NSArray *RCTBridgeModuleClassesByModuleID(void)
     RCTModuleNamesByID = [[NSMutableArray alloc] init];
     RCTModuleClassesByID = [[NSMutableArray alloc] init];
 
-    Dl_info info;
-    dladdr(&RCTBridgeModuleClassesByModuleID, &info);
+    for (NSString *entry in RCTExportedModuleNames()) {
+      NSArray *parts = [[entry substringWithRange:(NSRange){2, entry.length - 3}]
+                        componentsSeparatedByString:@" "];
 
-    const RCTHeaderValue mach_header = (RCTHeaderValue)info.dli_fbase;
-    const RCTHeaderSection *section = RCTGetSectByNameFromHeader((void *)mach_header, "__DATA", "RCTExportModule");
-
-    if (section) {
-      for (RCTHeaderValue addr = section->offset;
-           addr < section->offset + section->size;
-           addr += sizeof(const char **)) {
-
-        // Get data entry
-        NSString *entry = @(*(const char **)(mach_header + addr));
-        NSArray *parts = [[entry substringWithRange:(NSRange){2, entry.length - 3}]
-                          componentsSeparatedByString:@" "];
-
-        // Parse class name
-        NSString *moduleClassName = parts[0];
-        NSRange categoryRange = [moduleClassName rangeOfString:@"("];
-        if (categoryRange.length) {
-          moduleClassName = [moduleClassName substringToIndex:categoryRange.location];
-        }
-
-        // Get class
-        Class cls = NSClassFromString(moduleClassName);
-        RCTAssert([cls conformsToProtocol:@protocol(RCTBridgeModule)],
-                  @"%@ does not conform to the RCTBridgeModule protocol",
-                  NSStringFromClass(cls));
-
-        // Register module
-        NSString *moduleName = RCTBridgeModuleNameForClass(cls);
-        ((NSMutableDictionary *)RCTModuleIDsByName)[moduleName] = @(RCTModuleNamesByID.count);
-        [(NSMutableArray *)RCTModuleNamesByID addObject:moduleName];
-        [(NSMutableArray *)RCTModuleClassesByID addObject:cls];
+      // Parse class name
+      NSString *moduleClassName = parts[0];
+      NSRange categoryRange = [moduleClassName rangeOfString:@"("];
+      if (categoryRange.length) {
+        moduleClassName = [moduleClassName substringToIndex:categoryRange.location];
       }
+
+      // Get class
+      Class cls = NSClassFromString(moduleClassName);
+      RCTAssert([cls conformsToProtocol:@protocol(RCTBridgeModule)],
+                @"%@ does not conform to the RCTBridgeModule protocol",
+                NSStringFromClass(cls));
+
+      // Register module
+      NSString *moduleName = RCTBridgeModuleNameForClass(cls);
+      ((NSMutableDictionary *)RCTModuleIDsByName)[moduleName] = @(RCTModuleNamesByID.count);
+      [(NSMutableArray *)RCTModuleNamesByID addObject:moduleName];
+      [(NSMutableArray *)RCTModuleClassesByID addObject:cls];
     }
 
     if (RCT_DEBUG) {
@@ -542,38 +687,29 @@ static RCTSparseArray *RCTExportedMethodsByModuleID(void)
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{
 
-    Dl_info info;
-    dladdr(&RCTExportedMethodsByModuleID, &info);
-
-    const RCTHeaderValue mach_header = (RCTHeaderValue)info.dli_fbase;
-    const RCTHeaderSection *section = RCTGetSectByNameFromHeader((void *)mach_header, "__DATA", "RCTExport");
-
-    if (section == NULL) {
-      return;
-    }
+    NSArray *nativeMethodNameArrays = RCTExportedMethodNames();
 
     NSArray *classes = RCTBridgeModuleClassesByModuleID();
     NSMutableDictionary *methodsByModuleClassName = [NSMutableDictionary dictionaryWithCapacity:[classes count]];
 
-    for (RCTHeaderValue addr = section->offset;
-         addr < section->offset + section->size;
-         addr += sizeof(const char **) * 3) {
-
-      // Get data entry
-      const char **entries = (const char **)(mach_header + addr);
+    for (NSArray *entries in nativeMethodNameArrays) {
 
       // Create method
       RCTModuleMethod *moduleMethod;
-      if (entries[2] == NULL) {
-
+      if (entries.count < 3) {
+        NSString *reactName = entries[0];
+        NSString *jsName = entries[1];
         // Legacy support for RCT_EXPORT()
-        moduleMethod = [[RCTModuleMethod alloc] initWithReactMethodName:@(entries[0])
-                                                         objCMethodName:@(entries[0])
-                                                           JSMethodName:strlen(entries[1]) ? @(entries[1]) : nil];
+        moduleMethod = [[RCTModuleMethod alloc] initWithReactMethodName:reactName
+                                                         objCMethodName:reactName
+                                                           JSMethodName:jsName.length > 0 ? jsName : nil];
       } else {
-        moduleMethod = [[RCTModuleMethod alloc] initWithReactMethodName:@(entries[0])
-                                                         objCMethodName:strlen(entries[1]) ? @(entries[1]) : nil
-                                                           JSMethodName:strlen(entries[2]) ? @(entries[2]) : nil];
+        NSString *reactName = entries[0];
+        NSString *objcName = entries[1];
+        NSString *jsName = entries[2];
+        moduleMethod = [[RCTModuleMethod alloc] initWithReactMethodName:reactName
+                                                         objCMethodName:objcName.length > 0 ? objcName : nil
+                                                           JSMethodName:jsName.length > 0 ? jsName : nil];
       }
 
       // Cache method

--- a/React/Base/RCTBridgeModule.h
+++ b/React/Base/RCTBridgeModule.h
@@ -8,6 +8,7 @@
  */
 
 #import <Foundation/Foundation.h>
+#import "RCTDefines.h"
 
 @class RCTBridge;
 
@@ -49,7 +50,10 @@ extern const dispatch_queue_t RCTJSThread;
  */
 #define RCT_EXPORT_MODULE(js_name) \
   + (NSString *)moduleName { __attribute__((used, section("__DATA,RCTExportModule" \
-  ))) static const char *__rct_export_entry__ = { __func__ }; return @#js_name; }
+  ))) static const char *__rct_export_entry__ = { __func__ }; return @#js_name; } \
+  RCT_EXTERN void RCTRegisterModuleProvider(void); \
+  + (void)load { static dispatch_once_t dispatchToken; dispatch_once(&dispatchToken, ^{ \
+  RCTRegisterModuleProvider(); }); }
 
 /**
  * Wrap the parameter line of your method implementation with this macro to


### PR DESCRIPTION
This adds support for dynamically loading React as a framework.  If accepted, closes #579.  IntegrationTests all run successfully.

 This introduces several changes to RCTBridge.m

- extraction of strings from a mach_header section has been encapsulated in a helper class `RCTHeaderStringExtractor`.
- instances of this class are stored in an `NSSet` and uniqued by the address of their associated mach_header.
- a registration function `RCTRegisterModuleProviderContainingAddress(const void *address)` registers the binary containing a given address as a "module provider" and creates a `RCTHeaderStringExtractor` for the binary's mach_header.  A convienience helper function `RCTRegisterModuleProvider(void)` does the same, but registers the caller instead of requiring an explicit address.
- during the static `RCTBridge` initialization, all registered module providers are scanned, rather than just the binary in which `RCTBridge` is contained.

In RCTBridgeModule.h:
- the RCT_EXPORT_MODULE macro now includes a definition for `+ (void) load` that calls `RCTRegisterModuleProvider` - this allows registration of all module providers without changes to the existing api, but does potentially break native modules that already provide an implementation of `load`

A simple example project is a available at https://github.com/yusefnapora/react-dynamic-linking-example - it uses Cocoapods to install this branch with the `use_frameworks!` directive, which forces React to be compiled as a dynamic framework instead of a static library.  React components are loaded from both the framework and the app binary.


Concerns:
My biggest problem with this approach is the `load` hook for native modules; any existing native modules that currently provide an implementation of `+ (void)load` will refuse to compile.  I chose this approach because it doesn't require any explicit registration of the binary containing the modules; when the class loader invokes `load`, that will happen automatically for all "module providers".  As a result, this approach doesn't require "module providers" to know or care about whether they'll be linked dynamically or statically.

I also haven't measured the performance impact of the additional calls to `load` and `RCTRegisterModuleProvider` for each native module.  I suspect it's minimal, as the only work involved is calling `dladdr` to obtain the mach header, and creation of a `RCTHeaderStringExtractor`, which is fairly lightweight.  While a `RCTHeaderStringExtractor` is created for each invocation of `RCTRegisterModuleProvider`, only one is stored per mach header, as they are stored in an `NSSet` and `hash`ed by the mach header address.

Perhaps a compromise to allow native modules to define a `load` hook would be to check whether the class responds to a (hypothetical) `rct_load` class method and, if so, call it from the macro-provided `load` method. 

Please let me know if anything is unclear or I can do anything to help make this work.
