### PR TITLE
Correct homepage code examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Custom iOS views can be exposed by subclassing `RCTViewManager`, implementing a 
 
 @implementation MyCustomViewManager
 
-RCT_EXPORT_MODULE();
+RCT_EXPORT_MODULE()
 
 - (UIView *)view
 {

--- a/README.md
+++ b/README.md
@@ -177,6 +177,8 @@ Custom iOS views can be exposed by subclassing `RCTViewManager`, implementing a 
 
 @implementation MyCustomViewManager
 
+RCT_EXPORT_MODULE();
+
 - (UIView *)view
 {
   return [[MyCustomView alloc] init];

--- a/website/src/react-native/index.js
+++ b/website/src/react-native/index.js
@@ -215,12 +215,14 @@ var Message = React.createClass({
 
 @implementation MyCustomViewManager
 
+RCT_EXPORT_MODULE()
+
 - (UIView *)view
 {
   return [[MyCustomView alloc] init];
 }
 
-RCT_EXPORT_VIEW_PROPERTY(myCustomProperty);
+RCT_EXPORT_VIEW_PROPERTY(myCustomProperty, NSString);
 @end`}
           </Prism>
           <Prism>


### PR DESCRIPTION
The examples for Extensibility on the home page are broken :(.

RCT_EXPORT_MODULE() is missing, and RCT_EXPORT_VIEW_PROPERTY's signature has changed to accept a type as the 2nd argument.