### PR TITLE
[Bridge] Don't reload if the bridge was invalidated

### DIFF
--- a/React/Base/RCTBridge.m
+++ b/React/Base/RCTBridge.m
@@ -824,9 +824,14 @@ static id<RCTJavaScriptExecutor> _latestJSExecutor;
   /**
    * AnyThread
    */
+  __weak RCTBridge *weakSelf = self;
   dispatch_async(dispatch_get_main_queue(), ^{
-    [self invalidate];
-    [self setUp];
+    if (!weakSelf.isValid) {
+      return;
+    }
+
+    [weakSelf invalidate];
+    [weakSelf setUp];
   });
 }
 


### PR DESCRIPTION
If you have nested RCTBridges that are both subscribed to reload notifications, this diff guards against the following:

1. outer bridge receives reload notification, runs dispatch_async
2. inner bridge receives reload notification, runs dispatch_async
3. dispatch block for the outer bridge runs first. it invalidates the batched bridge, which runs user code that calls `-[innerBridge invalidate]`
4. dispatch block for the inner bridge runs. inner bridge has been invalidated and is intended to be thrown away, but instead it reloads itself

cc @tadeuzagallo 