### PR TITLE
[Timers] Batch setImmediate handlers

### DIFF
--- a/Libraries/Utilities/MessageQueue.js
+++ b/Libraries/Utilities/MessageQueue.js
@@ -104,7 +104,9 @@ class MessageQueue {
 
   flushedQueue() {
     BridgeProfiling.profile('JSTimersExecution.callImmediates()');
-    guard(() => JSTimersExecution.callImmediates());
+    guard(() => {
+      ReactUpdates.batchedUpdates(JSTimersExecution.callImmediates);
+    });
     BridgeProfiling.profileEnd();
     let queue = this._queue;
     this._queue = [[],[],[]];


### PR DESCRIPTION
Wraps the setImmediate handlers in a `batchUpdates` call before they are synchronously executed at the end of the JS execution loop.

Test Plan: Added two `setImmediate` calls to `componentDidMount` in UIExplorerApp. Each handler calls `setState`, and `componentWillUpdate` logs its state. With this diff, we can see the state updates are successfully batched.

```javascript
componentDidMount() {
  setImmediate(() => {
    console.log('immediate 1');
    this.setState({a: 1});
  });
  setImmediate(() => {
    console.log('immediate 2');
    this.setState({a: 2});
  });
},

componentWillUpdate(nextProps, nextState) {
  console.log('componentWillUpdate with next state.a =', nextState.a);
},
```

**Before:**

"immediate 1"
"componentWillUpdate with next state.a =", 1
"immediate 2"
"componentWillUpdate with next state.a =", 2

**After:**

"immediate 1"
"immediate 2"
"componentWillUpdate with next state.a =", 2

Addresses the batching issue in #1232. cc @vjeux @spicyj 