### PR TITLE
[Bridge] Make RCTJavaScriptDidFailToLoadNotification match DidLoad notif

### DIFF
--- a/React/Base/RCTBridge.m
+++ b/React/Base/RCTBridge.m
@@ -1108,9 +1108,9 @@ RCT_BRIDGE_WARN(_invokeAndProcessModule:(NSString *)module method:(NSString *)me
                                            withDetails:[error localizedFailureReason]];
         }
 
-        NSDictionary *userInfo = @{@"error": error};
+        NSDictionary *userInfo = @{@"bridge": self, @"error": error};
         [[NSNotificationCenter defaultCenter] postNotificationName:RCTJavaScriptDidFailToLoadNotification
-                                                            object:self
+                                                            object:_parentBridge
                                                           userInfo:userInfo];
 
       } else {


### PR DESCRIPTION
Add the RCTBatchedBridge object to the notification's userInfo for consistency with RCTJavaScriptDidLoadNotification, and set the target object to `_parentBridge`.

cc @nicklockwood @tadeuzagallo 