### PR TITLE
[MapView] Support for annotation callouts, annotation press, callout presses and pin animation

### DIFF
--- a/Libraries/Components/MapView/MapView.js
+++ b/Libraries/Components/MapView/MapView.js
@@ -38,16 +38,9 @@ var MapView = React.createClass({
   checkAnnotationIds: function (annotations: Array<Object>) {
 
     var newAnnotations = annotations.map(function (annotation) {
-      // If no ID has been set, generate a unique one to make sure annotation
-      // events are being dispatched correctly
-      // http://stackoverflow.com/questions/105034/create-guid-uuid-in-javascript
       if (!annotation['id']) {
-        var uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
-          var r = Math.random()*16|0, v = c == 'x' ? r : (r&0x3|0x8);
-          return v.toString(16);
-        });
-
-        annotation['id'] = uuid;
+        // TODO: add a base64 (or similar) encoder here
+        annotation['id'] = encodeURIComponent(JSON.stringify(annotation));
       }
 
       return annotation;

--- a/React/Modules/RCTPointAnnotation.h
+++ b/React/Modules/RCTPointAnnotation.h
@@ -1,0 +1,18 @@
+//
+//  RCTPointAnnotation.h
+//  React
+//
+//  Created by David Mohl on 5/12/15.
+//  Copyright (c) 2015 Facebook. All rights reserved.
+//
+
+#import <MapKit/MapKit.h>
+
+@interface RCTPointAnnotation : MKPointAnnotation <MKAnnotation>
+
+@property NSString *identifier;
+@property BOOL hasLeftCallout;
+@property BOOL hasRightCallout;
+@property BOOL animateDrop;
+
+@end

--- a/React/Modules/RCTPointAnnotation.m
+++ b/React/Modules/RCTPointAnnotation.m
@@ -1,0 +1,13 @@
+//
+//  RCTPointAnnotation.m
+//  React
+//
+//  Created by David Mohl on 5/12/15.
+//  Copyright (c) 2015 Facebook. All rights reserved.
+//
+
+#import "RCTPointAnnotation.h"
+
+@implementation RCTPointAnnotation
+
+@end

--- a/React/React.xcodeproj/project.pbxproj
+++ b/React/React.xcodeproj/project.pbxproj
@@ -59,6 +59,7 @@
 		58114A171AAE854800E7D092 /* RCTPickerManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 58114A151AAE854800E7D092 /* RCTPickerManager.m */; };
 		58114A501AAE93D500E7D092 /* RCTAsyncLocalStorage.m in Sources */ = {isa = PBXBuildFile; fileRef = 58114A4E1AAE93D500E7D092 /* RCTAsyncLocalStorage.m */; };
 		58C571C11AA56C1900CDF9C8 /* RCTDatePickerManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 58C571BF1AA56C1900CDF9C8 /* RCTDatePickerManager.m */; };
+		63F014C01B02080B003B75D2 /* RCTPointAnnotation.m in Sources */ = {isa = PBXBuildFile; fileRef = 63F014BF1B02080B003B75D2 /* RCTPointAnnotation.m */; };
 		830A229E1A66C68A008503DA /* RCTRootView.m in Sources */ = {isa = PBXBuildFile; fileRef = 830A229D1A66C68A008503DA /* RCTRootView.m */; };
 		830BA4551A8E3BDA00D53203 /* RCTCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 830BA4541A8E3BDA00D53203 /* RCTCache.m */; };
 		832348161A77A5AA00B55238 /* Layout.c in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FC71A68125100A75B9A /* Layout.c */; };
@@ -200,6 +201,8 @@
 		58114A4F1AAE93D500E7D092 /* RCTAsyncLocalStorage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTAsyncLocalStorage.h; sourceTree = "<group>"; };
 		58C571BF1AA56C1900CDF9C8 /* RCTDatePickerManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTDatePickerManager.m; sourceTree = "<group>"; };
 		58C571C01AA56C1900CDF9C8 /* RCTDatePickerManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTDatePickerManager.h; sourceTree = "<group>"; };
+		63F014BE1B02080B003B75D2 /* RCTPointAnnotation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTPointAnnotation.h; sourceTree = "<group>"; };
+		63F014BF1B02080B003B75D2 /* RCTPointAnnotation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTPointAnnotation.m; sourceTree = "<group>"; };
 		830213F31A654E0800B993E6 /* RCTBridgeModule.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RCTBridgeModule.h; sourceTree = "<group>"; };
 		830A229C1A66C68A008503DA /* RCTRootView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTRootView.h; sourceTree = "<group>"; };
 		830A229D1A66C68A008503DA /* RCTRootView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTRootView.m; sourceTree = "<group>"; };
@@ -278,6 +281,8 @@
 				13B07FEE1A69327A00A75B9A /* RCTTiming.m */,
 				13E067481A70F434002CDEE1 /* RCTUIManager.h */,
 				13E067491A70F434002CDEE1 /* RCTUIManager.m */,
+				63F014BE1B02080B003B75D2 /* RCTPointAnnotation.h */,
+				63F014BF1B02080B003B75D2 /* RCTPointAnnotation.m */,
 			);
 			path = Modules;
 			sourceTree = "<group>";
@@ -573,6 +578,7 @@
 				830BA4551A8E3BDA00D53203 /* RCTCache.m in Sources */,
 				137327E71AA5CF210034F82E /* RCTTabBar.m in Sources */,
 				00C1A2B31AC0B7E000E89A1C /* RCTDevMenu.m in Sources */,
+				63F014C01B02080B003B75D2 /* RCTPointAnnotation.m in Sources */,
 				14435CE51AAC4AE100FC20F4 /* RCTMap.m in Sources */,
 				134FCB3E1A6E7F0800051CC8 /* RCTWebViewExecutor.m in Sources */,
 				13B0801C1A69489C00A75B9A /* RCTNavItem.m in Sources */,

--- a/React/Views/RCTConvert+MapKit.h
+++ b/React/Views/RCTConvert+MapKit.h
@@ -7,7 +7,7 @@
 //
 
 #import <MapKit/MapKit.h>
-
+#import "RCTPointAnnotation.h"
 #import "RCTConvert.h"
 
 @interface RCTConvert (MapKit)
@@ -16,8 +16,12 @@
 + (MKCoordinateRegion)MKCoordinateRegion:(id)json;
 + (MKShape *)MKShape:(id)json;
 + (MKMapType)MKMapType:(id)json;
++ (RCTPointAnnotation *)RCTPointAnnotation:(id)json;
 
 typedef NSArray MKShapeArray;
 + (MKShapeArray *)MKShapeArray:(id)json;
+
+typedef NSArray RCTPointAnnotationArray;
++ (RCTPointAnnotationArray *)RCTPointAnnotationArray:(id)json;
 
 @end

--- a/React/Views/RCTConvert+MapKit.m
+++ b/React/Views/RCTConvert+MapKit.m
@@ -7,8 +7,8 @@
 //
 
 #import "RCTConvert+MapKit.h"
-
 #import "RCTConvert+CoreLocation.h"
+#import "RCTPointAnnotation.h"
 
 @implementation RCTConvert(MapKit)
 
@@ -48,5 +48,21 @@ RCT_ENUM_CONVERTER(MKMapType, (@{
   @"satellite": @(MKMapTypeSatellite),
   @"hybrid": @(MKMapTypeHybrid),
 }), MKMapTypeStandard, integerValue)
+
++ (RCTPointAnnotation *)RCTPointAnnotation:(id)json
+{
+  json = [self NSDictionary:json];
+  RCTPointAnnotation *shape = [[RCTPointAnnotation alloc] init];
+  shape.coordinate = [self CLLocationCoordinate2D:json];
+  shape.title = [RCTConvert NSString:json[@"title"]];
+  shape.subtitle = [RCTConvert NSString:json[@"subtitle"]];
+  shape.identifier = [RCTConvert NSString:json[@"id"]];
+  shape.hasLeftCallout = [RCTConvert BOOL:json[@"hasLeftCallout"]];
+  shape.hasRightCallout = [RCTConvert BOOL:json[@"hasRightCallout"]];
+  shape.animateDrop = [RCTConvert BOOL:json[@"animateDrop"]];
+  return shape;
+}
+
+RCT_ARRAY_CONVERTER(RCTPointAnnotation)
 
 @end

--- a/React/Views/RCTMap.h
+++ b/React/Views/RCTMap.h
@@ -26,6 +26,7 @@ extern const CGFloat RCTMapZoomBoundBuffer;
 @property (nonatomic, assign) CGFloat maxDelta;
 @property (nonatomic, assign) UIEdgeInsets legalLabelInsets;
 @property (nonatomic, strong) NSTimer *regionChangeObserveTimer;
+@property (nonatomic, strong) NSMutableArray *annotationIds;
 
 - (void)setAnnotations:(RCTPointAnnotationArray *)annotations;
 

--- a/React/Views/RCTMap.h
+++ b/React/Views/RCTMap.h
@@ -27,6 +27,6 @@ extern const CGFloat RCTMapZoomBoundBuffer;
 @property (nonatomic, assign) UIEdgeInsets legalLabelInsets;
 @property (nonatomic, strong) NSTimer *regionChangeObserveTimer;
 
-- (void)setAnnotations:(MKShapeArray *)annotations;
+- (void)setAnnotations:(RCTPointAnnotationArray *)annotations;
 
 @end

--- a/React/Views/RCTMap.m
+++ b/React/Views/RCTMap.m
@@ -26,9 +26,9 @@ const CGFloat RCTMapZoomBoundBuffer = 0.01;
 - (instancetype)init
 {
   if ((self = [super init])) {
-
+    
     _hasStartedRendering = NO;
-
+    
     // Find Apple link label
     for (UIView *subview in self.subviews) {
       if ([NSStringFromClass(subview.class) isEqualToString:@"MKAttributionLabel"]) {
@@ -55,7 +55,7 @@ const CGFloat RCTMapZoomBoundBuffer = 0.01;
 - (void)layoutSubviews
 {
   [super layoutSubviews];
-
+  
   if (_legalLabel) {
     dispatch_async(dispatch_get_main_queue(), ^{
       CGRect frame = _legalLabel.frame;
@@ -86,7 +86,7 @@ const CGFloat RCTMapZoomBoundBuffer = 0.01;
       }
     }
     super.showsUserLocation = showsUserLocation;
-
+    
     // If it needs to show user location, force map view centered
     // on user's current location on user location updates
     _followUserLocation = showsUserLocation;
@@ -99,7 +99,7 @@ const CGFloat RCTMapZoomBoundBuffer = 0.01;
   if (!CLLocationCoordinate2DIsValid(region.center)) {
     return;
   }
-
+  
   // If new span values are nil, use old values instead
   if (!region.span.latitudeDelta) {
     region.span.latitudeDelta = self.region.span.latitudeDelta;
@@ -107,17 +107,57 @@ const CGFloat RCTMapZoomBoundBuffer = 0.01;
   if (!region.span.longitudeDelta) {
     region.span.longitudeDelta = self.region.span.longitudeDelta;
   }
-
+  
   // Animate to new position
   [super setRegion:region animated:animated];
 }
 
 - (void)setAnnotations:(RCTPointAnnotationArray *)annotations
 {
-  [self removeAnnotations:self.annotations];
-  if (annotations.count) {
-    [self addAnnotations:annotations];
+  NSMutableArray *newAnnotationIds = [[NSMutableArray alloc] init];
+  NSMutableArray *annotationsToDelete = [[NSMutableArray alloc] init];
+  NSMutableArray *annotationsToAdd = [[NSMutableArray alloc] init];
+  
+  for (RCTPointAnnotation *annotation in annotations) {
+    if (![annotation isKindOfClass:[RCTPointAnnotation class]]) {
+      continue;
+    }
+    
+    [newAnnotationIds addObject:annotation.identifier];
+    
+    // If the current set does not contain the new annotation, mark it as add
+    if (![self.annotationIds containsObject:annotation.identifier]) {
+      [annotationsToAdd addObject:annotation];
+    }
   }
+  
+  for (RCTPointAnnotation *annotation in self.annotations) {
+    if (![annotation isKindOfClass:[RCTPointAnnotation class]]) {
+      continue;
+    }
+    
+    // If the new set does not contain an existing annotation, mark it as delete
+    if (![newAnnotationIds containsObject:annotation.identifier]) {
+      [annotationsToDelete addObject:annotation];
+    }
+  }
+  
+  if (annotationsToDelete.count) {
+    [self removeAnnotations:annotationsToDelete];
+  }
+  
+  if (annotationsToAdd.count) {
+    [self addAnnotations:annotationsToAdd];
+  }
+  
+  NSMutableArray *newIds = [[NSMutableArray alloc] init];
+  for (RCTPointAnnotation *anno in self.annotations) {
+    if ([anno isKindOfClass:[MKUserLocation class]]) {
+      continue;
+    }
+    [newIds addObject:anno.identifier];
+  }
+  self.annotationIds = newIds;
 }
 
 @end

--- a/React/Views/RCTMap.m
+++ b/React/Views/RCTMap.m
@@ -112,7 +112,7 @@ const CGFloat RCTMapZoomBoundBuffer = 0.01;
   [super setRegion:region animated:animated];
 }
 
-- (void)setAnnotations:(MKShapeArray *)annotations
+- (void)setAnnotations:(RCTPointAnnotationArray *)annotations
 {
   [self removeAnnotations:self.annotations];
   if (annotations.count) {

--- a/React/Views/RCTMapManager.m
+++ b/React/Views/RCTMapManager.m
@@ -55,34 +55,23 @@ RCT_CUSTOM_VIEW_PROPERTY(region, MKCoordinateRegion, RCTMap)
 
 
 
-- (void)mapView:(MKMapView *)mapView didSelectAnnotationView:(MKAnnotationView *)view {
+- (void)mapView:(MKMapView *)mapView didSelectAnnotationView:(MKAnnotationView *)view
+{
   if (![view.annotation isKindOfClass:[MKUserLocation class]]) {
     
     RCTPointAnnotation *annotation = (RCTPointAnnotation *)view.annotation;
-    
-    NSString *title;
-    if (view.annotation.title == nil) {
-      title = @"";
-    } else {
-      title = annotation.title;
-    }
-    
-    NSString *subtitle;
-    if (view.annotation.subtitle == nil) {
-      subtitle = @"";
-    } else {
-      subtitle = annotation.subtitle;
-    }
+    NSString *title = view.annotation.title ?: @"";
+    NSString *subtitle = view.annotation.subtitle ?: @"";
     
     NSDictionary *event = @{
-                            @"target": [mapView reactTag],
+                            @"target": mapView.reactTag,
                             @"action": @"annotation-click",
                             @"annotation": @{
                                 @"id": annotation.identifier,
                                 @"title": title,
                                 @"subtitle": subtitle,
-                                @"latitude": [NSNumber numberWithDouble: annotation.coordinate.latitude],
-                                @"longitude": [NSNumber numberWithDouble: annotation.coordinate.longitude]
+                                @"latitude": @(annotation.coordinate.latitude),
+                                @"longitude": @(annotation.coordinate.longitude)
                                 }
                             };
     
@@ -92,21 +81,21 @@ RCT_CUSTOM_VIEW_PROPERTY(region, MKCoordinateRegion, RCTMap)
 
 - (MKAnnotationView *)mapView:(MKMapView *)mapView viewForAnnotation:(RCTPointAnnotation *)annotation
 {
-  if ([annotation isKindOfClass:[MKUserLocation class]])
+  if ([annotation isKindOfClass:[MKUserLocation class]]) {
     return nil;
+  }
 
   MKPinAnnotationView *annotationView = [[MKPinAnnotationView alloc] initWithAnnotation:annotation reuseIdentifier:@"RCTAnnotation"];
   
   annotationView.canShowCallout = true;
-  
-  if (annotation.animateDrop) {
-    annotationView.animatesDrop = true;
-  }
+  annotationView.animatesDrop = annotation.animateDrop;
 
+  annotationView.leftCalloutAccessoryView = nil;
   if (annotation.hasLeftCallout) {
     annotationView.leftCalloutAccessoryView = [UIButton buttonWithType:UIButtonTypeDetailDisclosure];
   }
 
+  annotationView.rightCalloutAccessoryView = nil;
   if (annotation.hasRightCallout) {
     annotationView.rightCalloutAccessoryView = [UIButton buttonWithType:UIButtonTypeDetailDisclosure];
   }
@@ -118,16 +107,10 @@ RCT_CUSTOM_VIEW_PROPERTY(region, MKCoordinateRegion, RCTMap)
 {
   // Pass to js
   RCTPointAnnotation *annotation = (RCTPointAnnotation *)view.annotation;
-  NSString *side;
-  if (control == view.leftCalloutAccessoryView) {
-    side = @"left";
-  }
-  else if (control == view.rightCalloutAccessoryView) {
-    side = @"right";
-  }
+  NSString *side = (control == view.leftCalloutAccessoryView) ? @"left" : @"right";
 
   NSDictionary *event = @{
-      @"target": [mapView reactTag],
+      @"target": mapView.reactTag,
       @"side": side,
       @"action": @"callout-click",
       @"annotationId": annotation.identifier
@@ -230,7 +213,7 @@ RCT_CUSTOM_VIEW_PROPERTY(region, MKCoordinateRegion, RCTMap)
 #define FLUSH_NAN(value) (isnan(value) ? 0 : value)
 
   NSDictionary *event = @{
-    @"target": [mapView reactTag],
+    @"target": mapView.reactTag,
     @"continuous": @(continuous),
     @"region": @{
       @"latitude": @(FLUSH_NAN(region.center.latitude)),


### PR DESCRIPTION
Started from here - https://github.com/facebook/react-native/issues/1120. Most functionality for annotations were missing so I started implementing and somehow got caught up until the entire thing was done. 

![screen shot 2015-05-12 at 10 07 43 pm](https://cloud.githubusercontent.com/assets/688326/7588677/8479a7a4-f8f9-11e4-99a4-1dc3c7691810.png)


2 new events:
- callout presses (left / right)
- annotation presses

6 new properties for annotations:
- hasLeftCallout
- hasRightCallout
- onLeftCalloutPress
- onRightCalloutPress
- animateDrop
- id 

1 new property for MapView
- onAnnotationPress

--- 
Now the important thing is, that I implemented all of this the way "I would do it". I am not sure this is the 'reacty' way so please let me know my mistakes :smile: 

The problem is that there is no real way to identify annotations which makes it difficult to distinguish which one got clicked. The idea is to pass a `id` and whether it has callouts the entire way with the annotation. I had to subclass `MKAnnotation` for this and implemented a custom `RCTPointAnnotation` which adds `id`, `hasLeftCallout`, `hasRightCallout` and `animateDrop`. 

I added `RCTPointAnnotation` and `RCTPointAnnotationArray` into a new `RCTConvert` method. 

The user is able to overwrite the id on the annotation directly, but if no id is set, I am generating one on `componentWillMount` or `componentWillReceiveProps`. This id will also get passed into `onAnnotationPress`

---

I am setting the callout accessory always to `UIButtonTypeDetailDisclosure`. Todo at some point would be to allow custom UIButtons and Images