### PR TITLE
Change default scene config outgoing animation

### DIFF
--- a/Libraries/CustomComponents/Navigator/NavigatorSceneConfigs.js
+++ b/Libraries/CustomComponents/Navigator/NavigatorSceneConfigs.js
@@ -361,7 +361,7 @@ var BaseConfig = {
   // Animation interpolators for horizontal transitioning:
   animationInterpolators: {
     into: buildStyleInterpolator(FromTheRight),
-    out: buildStyleInterpolator(FadeToTheLeft),
+    out: buildStyleInterpolator(ToTheLeft),
   },
 };
 


### PR DESCRIPTION
I noticed some problems with the `FadeToTheLeft` outgoing animation. It would stop moving before it had reached the edge of the screen and before it had completely faded out. This gave a brief effect that made the outgoing screen appear burned-in to the current screen.

I changed the default to be `ToTheLeft` because it works properly and seems like an appropriate default.

The other option here, if you guys don't want the `BaseConfig` changed, might be to implement `PushToTheRight` with the same animationInterpolators that I gave `BaseConfig` and then I could undo the change I made here to `BaseConfig`.

Thoughts?