### PR TITLE
Fix for #930: Slow rendering of CameraRoll images

### DIFF
--- a/Libraries/Image/RCTImageLoader.m
+++ b/Libraries/Image/RCTImageLoader.m
@@ -67,7 +67,9 @@ NSError *errorWithMessage(NSString *message)
             ALAssetRepresentation *representation = [asset defaultRepresentation];
             ALAssetOrientation orientation = [representation orientation];
             UIImage *image = [UIImage imageWithCGImage:[representation fullResolutionImage] scale:1.0f orientation:(UIImageOrientation)orientation];
-            callback(nil, image);
+            dispatch_async(dispatch_get_main_queue(), ^{
+              callback(nil, image);
+            });
           }
         });
       } else {


### PR DESCRIPTION
Fix slow CameraRoll image load times by wrapping the callback in a dispatch_async call using the default serial queue.