### PR TITLE
Add more documentation in ListViewDataSource

### DIFF
--- a/Libraries/CustomComponents/ListView/ListViewDataSource.js
+++ b/Libraries/CustomComponents/ListView/ListViewDataSource.js
@@ -100,6 +100,10 @@ class ListViewDataSource {
    * The default extractor expects data of one of the following forms:
    *
    *      { sectionID_1: { rowID_1: <rowData1>, ... }, ... }
+   * 
+   *    or
+   * 
+   *      { sectionID_1: [ <rowData1>, <rowData2>, ... ], ... }
    *
    *    or
    *


### PR DESCRIPTION
ListViewDataSource's default data extractor can actually expect another data form:

`{ sectionID_1: [ <rowData1>, <rowData2>, ... ], ... }`