### PR TITLE
Fix jsdocs for multi-line ES6-style methods

### DIFF
--- a/website/jsdocs/jsdocs.js
+++ b/website/jsdocs/jsdocs.js
@@ -209,13 +209,21 @@ function sanitizeTypehint(string) {
 
 /**
  * @param {object} node
+ * @param {object} docNode  Node used for location/docblock purposes
  * @param {object} state
  * @param {string} source
  * @param {array<object>} commentsForFile
  * @param {array<string>} linesForFile
  * @return {object}
  */
-function getFunctionData(node, state, source, commentsForFile, linesForFile) {
+function getFunctionData(
+  node,
+  docNode,
+  state,
+  source,
+  commentsForFile,
+  linesForFile
+) {
   var params = [];
   var typechecks = commentsForFile.typechecks;
   var typehintsFromBlock = null;
@@ -287,9 +295,9 @@ function getFunctionData(node, state, source, commentsForFile, linesForFile) {
     });
   }
   return {
-    line: node.loc.start.line,
+    line: docNode.loc.start.line,
     source: source.substring.apply(source, node.range),
-    docblock: getDocBlock(node, commentsForFile, linesForFile),
+    docblock: getDocBlock(docNode, commentsForFile, linesForFile),
     modifiers: [],
     params: params,
     tparams: tparams,
@@ -320,7 +328,7 @@ function getObjectData(node, state, source, scopeChain,
 
     switch (property.value.type) {
     case Syntax.FunctionExpression:
-      var methodData = getFunctionData(property.value, state, source,
+      var methodData = getFunctionData(property.value, property, state, source,
         commentsForFile, linesForFile);
       methodData.name = property.key.name || property.key.value;
       methodData.source = source.substring.apply(source, property.range);
@@ -335,7 +343,8 @@ function getObjectData(node, state, source, scopeChain,
       if (expr) {
         if (expr.type === Syntax.FunctionDeclaration) {
           var functionData =
-            getFunctionData(expr, state, source, commentsForFile, linesForFile);
+            getFunctionData(expr, property, state, source, commentsForFile,
+              linesForFile);
           functionData.name = property.key.name || property.key.value;
           functionData.modifiers.push('static');
           methods.push(functionData);
@@ -389,7 +398,7 @@ function getClassData(node, state, source, commentsForFile, linesForFile) {
     if (bodyItem.type === Syntax.MethodDefinition) {
       if (bodyItem.value.type === Syntax.FunctionExpression) {
         var methodData =
-          getFunctionData(bodyItem.value, state, source,
+          getFunctionData(bodyItem.value, bodyItem, state, source,
             commentsForFile, linesForFile);
         methodData.name = bodyItem.key.name;
         methodData.source = source.substring.apply(source, bodyItem.range);
@@ -529,7 +538,8 @@ function parseSource(source) {
         break;
       case Syntax.FunctionDeclaration:
       case Syntax.FunctionExpression:
-        data = getFunctionData(definition, _state, source, ast.comments, lines);
+        data = getFunctionData(definition, definition, _state, source,
+          ast.comments, lines);
         data.type = 'function';
         break;
       default:


### PR DESCRIPTION
Summary:
The function definition and body can be in different places for multi-line declarations, so the docblock might not get pulled in. None of the existing docs seem to be affected, but putting up the fix for posterity.

Test Plan:
I modified `AlertIOS.alert` (in Libraries/Utilties/AlertIOS.js) to actually have a docblock, and ran `website/publish.sh` (with the push bit commented out). The added doc doesn't get picked up with the current code, but it does with the fix.

PS @vjeux: seems like https://github.com/facebook/react-native/commit/14c5a23eabe95a1741b601f2161476bcadecc78c never got merged in?