### PR TITLE
[ActivityIndicator] Add the onLayout prop to the outer container view

### DIFF
--- a/Libraries/Components/ActivityIndicatorIOS/ActivityIndicatorIOS.ios.js
+++ b/Libraries/Components/ActivityIndicatorIOS/ActivityIndicatorIOS.ios.js
@@ -65,10 +65,12 @@ var ActivityIndicatorIOS = React.createClass({
   },
 
   render: function() {
-    var {style, ...props} = this.props;
+    var {onLayout, style, ...props} = this.props;
     var sizeStyle = (this.props.size === 'large') ? styles.sizeLarge : styles.sizeSmall;
     return (
-      <View style={[styles.container, sizeStyle, style]}>
+      <View
+        onLayout={onLayout}
+        style={[styles.container, sizeStyle, style]}>
         <RCTActivityIndicatorView {...props} />
       </View>
     );


### PR DESCRIPTION
ActivityIndicator was forwarding all of its props except `style` to the inner native view. This meant that onLayout would report a zero-sized frame that was relative to the wrapper view instead of the parent of the ActivityIndicator.

This diff adds `onLayout` to the wrapper view instead of the native view.

In general, all components that forward props need to be audited in this manner.

Test Plan: `<ActivityIndicator onLayout={...} />` reports the size of the spinner plus a position relative to its parent view.