### PR TITLE
reset state on new props

### DIFF
--- a/Libraries/CustomComponents/Navigator/Navigator.js
+++ b/Libraries/CustomComponents/Navigator/Navigator.js
@@ -297,14 +297,22 @@ var Navigator = React.createClass({
   },
 
   getInitialState: function() {
-    var routeStack = this.props.initialRouteStack || [this.props.initialRoute];
+    return this._getInitialStateFromProps(this.props);
+  },
+
+  componentWillReceiveProps: function(props) {
+    this.setState(this._getInitialStateFromProps(props));
+  },
+
+  _getInitialStateFromProps: function(props) {
+    var routeStack = props.initialRouteStack || [props.initialRoute];
     invariant(
       routeStack.length >= 1,
       'Navigator requires props.initialRoute or props.initialRouteStack.'
     );
     var initialRouteIndex = routeStack.length - 1;
-    if (this.props.initialRoute) {
-      initialRouteIndex = routeStack.indexOf(this.props.initialRoute);
+    if (props.initialRoute) {
+      initialRouteIndex = routeStack.indexOf(props.initialRoute);
       invariant(
         initialRouteIndex !== -1,
         'initialRoute is not in initialRouteStack.'
@@ -312,7 +320,7 @@ var Navigator = React.createClass({
     }
     return {
       sceneConfigStack: routeStack.map(
-        (route) => this.props.configureScene(route)
+        (route) => props.configureScene(route)
       ),
       idStack: routeStack.map(() => getuid()),
       routeStack,


### PR DESCRIPTION
So, this isn't really the perfect pull request to do this, but what I'm trying to accomplish is making the Navigator more declarative. If I change the initialRouteStack (might need to introduce a new routes prop so that the naming isn't confusing), it would be nice if the navigator rerendered with the new stack. Obviously blowing away the existing stack  wouldn't be ideal in all cases, but I can't think of a better way to blow away the existing navigator and replace it with a new one with the updated stack of routes.

Alternatively, it might be nice to have `resetTo` accept an array of routes.