### PR TITLE
[PushNotifications] Add an event for remote notification registration, and improve permissions request

### DIFF
--- a/Libraries/PushNotificationIOS/PushNotificationIOS.js
+++ b/Libraries/PushNotificationIOS/PushNotificationIOS.js
@@ -21,6 +21,7 @@ var _initialNotification = RCTPushNotificationManager &&
   RCTPushNotificationManager.initialNotification;
 
 var DEVICE_NOTIF_EVENT = 'remoteNotificationReceived';
+var NOTIF_REGISTER_EVENT = 'remoteNotificationsRegistered';
 
 /**
  * Handle push notifications for your app, including permission handling and
@@ -50,30 +51,72 @@ class PushNotificationIOS {
   }
 
   /**
-   * Attaches a listener to remote notifications while the app is running in the
-   * foreground or the background.
+   * Attaches a listener to remote notification events while the app is running
+   * in the foreground or the background.
    *
-   * The handler will get be invoked with an instance of `PushNotificationIOS`
+   * Valid events are:
+   *
+   * - `notification` : Fired when a remote notification is received. The
+   *   handler will be invoked with an instance of `PushNotificationIOS`.
+   * - `register`: Fired when the user registers for remote notifications. The
+   *   handler will be invoked with a hex string representing the deviceToken.
    */
   static addEventListener(type: string, handler: Function) {
     invariant(
-      type === 'notification',
-      'PushNotificationIOS only supports `notification` events'
+      type === 'notification' || type === 'register',
+      'PushNotificationIOS only supports `notification` and `register` events'
     );
-    _notifHandlers[handler] = RCTDeviceEventEmitter.addListener(
-      DEVICE_NOTIF_EVENT,
-      (notifData) => {
-        handler(new PushNotificationIOS(notifData));
-      }
-    );
+    if (type === 'notification') {
+      _notifHandlers[handler] = RCTDeviceEventEmitter.addListener(
+        DEVICE_NOTIF_EVENT,
+        (notifData) => {
+          handler(new PushNotificationIOS(notifData));
+        }
+      );
+    } else if (type === 'register') {
+      _notifHandlers[handler] = RCTDeviceEventEmitter.addListener(
+        NOTIF_REGISTER_EVENT,
+        (registrationInfo) => {
+          handler(registrationInfo.deviceToken);
+        }
+      );
+    }
   }
 
   /**
-   * Requests all notification permissions from iOS, prompting the user's
-   * dialog box.
+   * Requests notification permissions from iOS, prompting the user's
+   * dialog box. By default, it will request all notification permissions, but
+   * a subset of these can be requested by passing a map of requested
+   * permissions.
+   * The following permissions are supported:
+   *
+   *   - `alert`
+   *   - `badge`
+   *   - `sound`
+   *
+   * If a map is provided to the method, only the permissions with truthy values
+   * will be requested.
    */
-  static requestPermissions() {
-    RCTPushNotificationManager.requestPermissions();
+  static requestPermissions(permissions?: {
+    alert?: boolean,
+    badge?: boolean,
+    sound?: boolean
+  }) {
+    var requestedPermissions = {};
+    if (permissions) {
+      requestedPermissions = {
+        alert: !!permissions.alert,
+        badge: !!permissions.badge,
+        sound: !!permissions.sound
+      };
+    } else {
+      requestedPermissions = {
+        alert: true,
+        badge: true,
+        sound: true
+      };
+    }
+    RCTPushNotificationManager.requestPermissions(requestedPermissions);
   }
 
   /**
@@ -98,8 +141,8 @@ class PushNotificationIOS {
    */
   static removeEventListener(type: string, handler: Function) {
     invariant(
-      type === 'notification',
-      'PushNotificationIOS only supports `notification` events'
+      type === 'notification' || type === 'register',
+      'PushNotificationIOS only supports `notification` and `register` events'
     );
     if (!_notifHandlers[handler]) {
       return;

--- a/Libraries/PushNotificationIOS/RCTPushNotificationManager.h
+++ b/Libraries/PushNotificationIOS/RCTPushNotificationManager.h
@@ -14,6 +14,7 @@
 @interface RCTPushNotificationManager : NSObject <RCTBridgeModule>
 
 + (void)application:(UIApplication *)application didRegisterUserNotificationSettings:(UIUserNotificationSettings *)notificationSettings;
++ (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken;
 + (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)notification;
 
 @end

--- a/Libraries/PushNotificationIOS/RCTPushNotificationManager.m
+++ b/Libraries/PushNotificationIOS/RCTPushNotificationManager.m
@@ -12,6 +12,14 @@
 #import "RCTBridge.h"
 #import "RCTEventDispatcher.h"
 
+#if __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_8_0
+
+#define UIUserNotificationTypeAlert UIRemoteNotificationTypeAlert
+#define UIUserNotificationTypeBadge UIRemoteNotificationTypeBadge
+#define UIUserNotificationTypeSound UIRemoteNotificationTypeSound
+
+#endif
+
 NSString *const RCTRemoteNotificationReceived = @"RemoteNotificationReceived";
 NSString *const RCTRemoteNotificationsRegistered = @"RemoteNotificationsRegistered";
 
@@ -127,7 +135,7 @@ RCT_EXPORT_METHOD(requestPermissions:(NSDictionary *)permissions)
   }
   Class _UIUserNotificationSettings;
   if ((_UIUserNotificationSettings = NSClassFromString(@"UIUserNotificationSettings"))) {
-    UIUserNotificationSettings *notificationSettings = [UIUserNotificationSettings settingsForTypes:types categories:nil];
+    id notificationSettings = [_UIUserNotificationSettings settingsForTypes:types categories:nil];
     [[UIApplication sharedApplication] registerUserNotificationSettings:notificationSettings];
     
     [[UIApplication sharedApplication] registerForRemoteNotifications];
@@ -144,15 +152,6 @@ RCT_EXPORT_METHOD(requestPermissions:(NSDictionary *)permissions)
 
 RCT_EXPORT_METHOD(checkPermissions:(RCTResponseSenderBlock)callback)
 {
-
-#if __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_8_0
-
-#define UIUserNotificationTypeAlert UIRemoteNotificationTypeAlert
-#define UIUserNotificationTypeBadge UIRemoteNotificationTypeBadge
-#define UIUserNotificationTypeSound UIRemoteNotificationTypeSound
-
-#endif
-
   NSUInteger types = 0;
   if ([UIApplication instancesRespondToSelector:@selector(currentUserNotificationSettings)]) {
     types = [[[UIApplication sharedApplication] currentUserNotificationSettings] types];


### PR DESCRIPTION
In order to add Push support to the Parse JS SDK in React Native, we need a way to receive the APNS device token from the JS context. This adds another event to PushNotificationIOS, so that code can respond to a successful registration.

Additionally, I've updated the `requestPermissions` call to accept an optional map of parameters. This way, developers can request a subset of user notification types.