### PR TITLE
[Packager] Auto populate remote packager in info.plist

### DIFF
--- a/Examples/2048/2048.xcodeproj/project.pbxproj
+++ b/Examples/2048/2048.xcodeproj/project.pbxproj
@@ -143,6 +143,7 @@
 				13B07F871A680F5B00A75B9A /* Sources */,
 				13B07F8C1A680F5B00A75B9A /* Frameworks */,
 				13B07F8E1A680F5B00A75B9A /* Resources */,
+				DA71AC921B06A5A10023A08E /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -229,6 +230,22 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		DA71AC921B06A5A10023A08E /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if [[ $VALID_ARCHS == *\"armv\"* && $CONFIGURATION == \"Debug\" ]] ; then\n  IP_ADDR=$(ifconfig | grep \"inet \" | grep -v 127.0.0.1 | awk '{print $2}')\n  PACKAGER_URL=\"http://$IP_ADDR:8081\"\n\n  echo \"Writing IP address of host ($PACKAGER_URL) to info.plist...\";\n  if ! /usr/libexec/PlistBuddy -c \"Set :ReactServer $PACKAGER_URL\" $INFOPLIST_FILE ; then\n    /usr/libexec/PlistBuddy -c \"Add :ReactServer string $PACKAGER_URL\" $INFOPLIST_FILE\n  fi\nfi";
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		13B07F871A680F5B00A75B9A /* Sources */ = {

--- a/Examples/Movies/Movies.xcodeproj/project.pbxproj
+++ b/Examples/Movies/Movies.xcodeproj/project.pbxproj
@@ -181,6 +181,7 @@
 				13B07F871A680F5B00A75B9A /* Sources */,
 				13B07F8C1A680F5B00A75B9A /* Frameworks */,
 				13B07F8E1A680F5B00A75B9A /* Resources */,
+				DADAF4C81B06A5F30069223E /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -289,6 +290,22 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		DADAF4C81B06A5F30069223E /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if [[ $VALID_ARCHS == *\"armv\"* && $CONFIGURATION == \"Debug\" ]] ; then\n  IP_ADDR=$(ifconfig | grep \"inet \" | grep -v 127.0.0.1 | awk '{print $2}')\n  PACKAGER_URL=\"http://$IP_ADDR:8081\"\n\n  echo \"Writing IP address of host ($PACKAGER_URL) to info.plist...\";\n  if ! /usr/libexec/PlistBuddy -c \"Set :ReactServer $PACKAGER_URL\" $INFOPLIST_FILE ; then\n    /usr/libexec/PlistBuddy -c \"Add :ReactServer string $PACKAGER_URL\" $INFOPLIST_FILE\n  fi\nfi";
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		13B07F871A680F5B00A75B9A /* Sources */ = {

--- a/Examples/SampleApp/SampleApp.xcodeproj/project.pbxproj
+++ b/Examples/SampleApp/SampleApp.xcodeproj/project.pbxproj
@@ -334,6 +334,7 @@
 				13B07F871A680F5B00A75B9A /* Sources */,
 				13B07F8C1A680F5B00A75B9A /* Frameworks */,
 				13B07F8E1A680F5B00A75B9A /* Resources */,
+				DAFFEB2A1B06A61200653BD2 /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -512,6 +513,22 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		DAFFEB2A1B06A61200653BD2 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if [[ $VALID_ARCHS == *\"armv\"* && $CONFIGURATION == \"Debug\" ]] ; then\n  IP_ADDR=$(ifconfig | grep \"inet \" | grep -v 127.0.0.1 | awk '{print $2}')\n  PACKAGER_URL=\"http://$IP_ADDR:8081\"\n\n  echo \"Writing IP address of host ($PACKAGER_URL) to info.plist...\";\n  if ! /usr/libexec/PlistBuddy -c \"Set :ReactServer $PACKAGER_URL\" $INFOPLIST_FILE ; then\n    /usr/libexec/PlistBuddy -c \"Add :ReactServer string $PACKAGER_URL\" $INFOPLIST_FILE\n  fi\nfi";
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		00E356EA1AD99517003FC87E /* Sources */ = {

--- a/Examples/TicTacToe/TicTacToe.xcodeproj/project.pbxproj
+++ b/Examples/TicTacToe/TicTacToe.xcodeproj/project.pbxproj
@@ -143,6 +143,7 @@
 				13B07F871A680F5B00A75B9A /* Sources */,
 				13B07F8C1A680F5B00A75B9A /* Frameworks */,
 				13B07F8E1A680F5B00A75B9A /* Resources */,
+				DAFFEB371B06A63400653BD2 /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -229,6 +230,22 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		DAFFEB371B06A63400653BD2 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if [[ $VALID_ARCHS == *\"armv\"* && $CONFIGURATION == \"Debug\" ]] ; then\n  IP_ADDR=$(ifconfig | grep \"inet \" | grep -v 127.0.0.1 | awk '{print $2}')\n  PACKAGER_URL=\"http://$IP_ADDR:8081\"\n\n  echo \"Writing IP address of host ($PACKAGER_URL) to info.plist...\";\n  if ! /usr/libexec/PlistBuddy -c \"Set :ReactServer $PACKAGER_URL\" $INFOPLIST_FILE ; then\n    /usr/libexec/PlistBuddy -c \"Add :ReactServer string $PACKAGER_URL\" $INFOPLIST_FILE\n  fi\nfi";
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		13B07F871A680F5B00A75B9A /* Sources */ = {

--- a/Examples/UIExplorer/UIExplorer.xcodeproj/project.pbxproj
+++ b/Examples/UIExplorer/UIExplorer.xcodeproj/project.pbxproj
@@ -350,6 +350,7 @@
 				13B07F871A680F5B00A75B9A /* Sources */,
 				13B07F8C1A680F5B00A75B9A /* Frameworks */,
 				13B07F8E1A680F5B00A75B9A /* Resources */,
+				DAFFEB461B06A65200653BD2 /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -538,6 +539,22 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		DAFFEB461B06A65200653BD2 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if [[ $VALID_ARCHS == *\"armv\"* && $CONFIGURATION == \"Debug\" ]] ; then\n  IP_ADDR=$(ifconfig | grep \"inet \" | grep -v 127.0.0.1 | awk '{print $2}')\n  PACKAGER_URL=\"http://$IP_ADDR:8081\"\n\n  echo \"Writing IP address of host ($PACKAGER_URL) to info.plist...\";\n  if ! /usr/libexec/PlistBuddy -c \"Set :ReactServer $PACKAGER_URL\" $INFOPLIST_FILE ; then\n    /usr/libexec/PlistBuddy -c \"Add :ReactServer string $PACKAGER_URL\" $INFOPLIST_FILE\n  fi\nfi";
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		004D289A1AAF61C70097A701 /* Sources */ = {


### PR DESCRIPTION
Feature suggested by @frantic in #548. Adds a run script build phase to the Xcode project that automatically populates the `ReactServer` value in the `info.plist` file so that remote debugging "just works". It only populates the value if the user is building an `armv*` binary in debug mode so you won't accidentally populate the value when do a release build.