### PR TITLE
Use new simple jstransform API

### DIFF
--- a/packager/react-packager/src/JSTransformer/__tests__/Transformer-test.js
+++ b/packager/react-packager/src/JSTransformer/__tests__/Transformer-test.js
@@ -39,7 +39,7 @@ describe('Transformer', function() {
 
   pit('should loadFileAndTransform', function() {
     workers.mockImpl(function(data, callback) {
-      callback(null, { code: 'transformed', map: 'sourceMap' });
+      callback(null, { code: 'transformed', sourceMap: 'sourceMap' });
     });
     require('fs').readFile.mockImpl(function(file, callback) {
       callback(null, 'content');

--- a/packager/react-packager/src/JSTransformer/index.js
+++ b/packager/react-packager/src/JSTransformer/index.js
@@ -104,7 +104,7 @@ Transformer.prototype.loadFileAndTransform = function(filePath) {
 
             return new ModuleTransport({
               code: res.code,
-              map: res.map,
+              map: res.sourceMap,
               sourcePath: filePath,
               sourceCode: sourceCode,
             });

--- a/packager/transformer.js
+++ b/packager/transformer.js
@@ -10,40 +10,21 @@
  */
 'use strict';
 
-var jstransform = require('jstransform').transform;
-
-var reactVisitors =
-  require('react-tools/vendor/fbtransform/visitors').getAllVisitors();
-var staticTypeSyntax =
-  require('jstransform/visitors/type-syntax').visitorList;
-var trailingCommaVisitors =
-  require('jstransform/visitors/es7-trailing-comma-visitors.js').visitorList;
-
-// Note that reactVisitors now handles ES6 classes, rest parameters, arrow
-// functions, template strings, and object short notation.
-var visitorList = reactVisitors.concat(trailingCommaVisitors);
+var jstransform = require('jstransform/simple').transform;
 
 function transform(srcTxt, filename) {
   var options = {
     es3: true,
-    sourceType: 'nonStrictModule',
-    filename: filename,
+    harmony: true,
+    react: true,
+    stripTypes: true,
+    utility: true,
+    nonStrictEs6module: true,
+    sourceFilename: filename,
+    sourceMap: true
   };
 
-  // These tranforms mostly just erase type annotations and static typing
-  // related statements, but they were conflicting with other tranforms.
-  // Running them first solves that problem
-  var staticTypeSyntaxResult = jstransform(
-    staticTypeSyntax,
-    srcTxt,
-    options
-  );
-
-  return jstransform(
-    visitorList,
-    staticTypeSyntaxResult.code,
-    options
-  );
+  return jstransform(srcTxt, options);
 }
 
 module.exports = function(data, callback) {


### PR DESCRIPTION
We might not care about this at this point but it simplifies the transform complexity and leaves that to jstransform. The new simple API is pretty identical in functionality and output as babel will be so this might be a good stepping stone.

About the changes to the JSTransformer code, we could keep that identical and just capture the output of the transform itself, mapping sourceMap to map there.

There will be a couple changes to the transformed code, for the better. I think since you're using `react-tools` to get those visitors, you're actually pulling from an older `jstransform`, then picking up the 2 other visitors (unless npm gets tricked and uses the newer jstransform inside react-tools, which it shouldn't do). On top of the newer transform, the `es3` option also makes sure trailing commas in arrays are stripped (though do you need the `es3` option? I would have thought `es5` would be more appropriate but I don't know what JSC actually looks like). The other change here is that I flipped the utility flag. That just transforms `undefined` to `void 0`, though not sure if we care or need to do that. Happy to turn it back off.

Tests pass, but at only 16 tests I'm not entirely convinced, and I didn't actually build the app…

cc @amasad 