### PR TITLE
[NO MERGE]Try to fix the react-native view initialized twice

### DIFF
--- a/React/Modules/RCTUIManager.m
+++ b/React/Modules/RCTUIManager.m
@@ -806,7 +806,7 @@ RCT_EXPORT_METHOD(createView:(NSNumber *)reactTag
         // Note the default is setup after the props are read for the first time ever
         // for this className - this is ok because we only use the default for restoring
         // defaults, which never happens on first creation.
-        uiManager->_defaultViews[viewName] = [manager view];
+        uiManager->_defaultViews[viewName] = view;
       }
 
       // Set properties


### PR DESCRIPTION
Related issues: brentvatne/react-native-video#29

RT:
I added a log:
```objc
- (UIView *)view
{
  NSLog(@"RCTVideo init RCTVideo init");
  return [[RCTVideo alloc] initWithEventDispatcher:self.bridge.eventDispatcher];
}
```

result:
```
2015-05-06 02:50:18.218 gouhuo-native[67470:4294635] RCTVideo init RCTVideo init
2015-05-06 02:50:18.218 gouhuo-native[67470:4294635] RCTVideo init RCTVideo init
```
