### PR TITLE
[ReactNative] Navigator clean scenes popped with gesture

### DIFF
--- a/Libraries/CustomComponents/Navigator/Navigator.js
+++ b/Libraries/CustomComponents/Navigator/Navigator.js
@@ -829,7 +829,16 @@ var Navigator = React.createClass({
       }
     } else {
       // The gesture has enough velocity to complete, so we transition to the gesture's destination
-      this._transitionTo(destIndex, transitionVelocity);
+      this._transitionTo(
+        destIndex,
+        transitionVelocity,
+        null,
+        () => {
+          if (releaseGestureAction === 'pop') {
+            this._cleanScenesPastIndex(destIndex);
+          }
+        }
+      );
     }
     this._detachGesture();
   },


### PR DESCRIPTION
Fixes https://github.com/facebook/react-native/issues/1252

Scenes dismissed/popped via a gesture were not being removed. This is probably a regression from an earlier refactor.

Test plan: log statements after scene focusing now reports that `navigator.getCurrentRoutes().length` lowers after gesture. Tested on UIExplorer Navigator example