### PR TITLE
[ReactNative] Navigator fix for sceneStyle

### DIFF
--- a/Libraries/CustomComponents/Navigator/Navigator.js
+++ b/Libraries/CustomComponents/Navigator/Navigator.js
@@ -689,7 +689,7 @@ var Navigator = React.createClass({
    */
   _enableScene: function(sceneIndex) {
     // First, determine what the defined styles are for scenes in this navigator
-    var sceneStyle = flattenStyle(this.props.sceneStyle);
+    var sceneStyle = flattenStyle([styles.baseScene, this.props.sceneStyle]);
     // Then restore the left value for this scene
     var enabledSceneNativeProps = {
       left: sceneStyle.left,


### PR DESCRIPTION
Fixes https://github.com/facebook/react-native/issues/1332

When the absolute left position is not set to zero on a provided sceneStyle, scene enabling is broken and no scene will be visible when it is pushed. This was broken recently when the scene disabling was modified to push the scenes offscreen.

Test Plan: Tested when pushing a scene Navigator in the UIExplorer example while sceneStyle is set on the Navigator