### PR TITLE
Added size information for webviews

### DIFF
--- a/Libraries/Components/WebView/WebView.ios.js
+++ b/Libraries/Components/WebView/WebView.ios.js
@@ -89,6 +89,19 @@ var WebView = React.createClass({
     automaticallyAdjustContentInsets: PropTypes.bool,
     shouldInjectAJAXHandler: PropTypes.bool,
     contentInset: EdgeInsetsPropType,
+    /**
+     * (navState) => void
+     *
+     * Called when the navigation state changes (for example, when the web view finishes loading).
+     *
+     *   - navState.canGoBack
+     *   - navState.canGoForward
+     *   - navState.url
+     *   - navState.title
+     *   - navState.loading
+     *   - navState.contentWidth
+     *   - navState.contentHeight
+     */
     onNavigationStateChange: PropTypes.func,
     startInLoadingState: PropTypes.bool, // force WebView to show loadingView on first load
     style: View.propTypes.style,

--- a/React/Views/RCTWebView.m
+++ b/React/Views/RCTWebView.m
@@ -112,6 +112,8 @@
 {
   NSURL *url = _webView.request.URL;
   NSString *title = [_webView stringByEvaluatingJavaScriptFromString:@"document.title"];
+  float contentWidth = [[_webView stringByEvaluatingJavaScriptFromString:@"document.body.clientWidth"] floatValue];
+  float contentHeight = [[_webView stringByEvaluatingJavaScriptFromString:@"document.body.clientHeight"] floatValue];
   NSMutableDictionary *event = [[NSMutableDictionary alloc] initWithDictionary: @{
     @"target": self.reactTag,
     @"url": url ? [url absoluteString] : @"",
@@ -119,6 +121,8 @@
     @"title": title,
     @"canGoBack": @([_webView canGoBack]),
     @"canGoForward" : @([_webView canGoForward]),
+    @"contentWidth" : @(contentWidth),
+    @"contentHeight" : @(contentHeight),
   }];
 
   return event;


### PR DESCRIPTION
It can be useful to know the content size of a webview after it has finished loading.  With this commit I have added the ability to get to this information via the `onNavigationStateChange` function.  I also added more documentation for that function to explain what properties are available.