### PR TITLE
[Touches] Let only the nearest ancestor root view process touches

### DIFF
--- a/React/Base/RCTRootView.m
+++ b/React/Base/RCTRootView.m
@@ -35,7 +35,7 @@ NSString *const RCTContentDidAppearNotification = @"RCTContentDidAppearNotificat
 
 @end
 
-@interface RCTRootContentView : RCTView <RCTInvalidating>
+@interface RCTRootContentView : RCTView <RCTInvalidating, UIGestureRecognizerDelegate>
 
 @property (nonatomic, readonly) BOOL contentHasAppeared;
 @property (nonatomic, readonly, strong) RCTTouchHandler *touchHandler;
@@ -327,6 +327,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
     _bridge = bridge;
     self.reactTag = reactTag;
     _touchHandler = [[RCTTouchHandler alloc] initWithBridge:_bridge];
+    _touchHandler.delegate = self;
     [self addGestureRecognizer:_touchHandler];
     [_bridge.uiManager registerRootView:self withSizeFlexibility:sizeFlexibility];
     self.layer.backgroundColor = NULL;
@@ -380,5 +381,21 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder:(nonnull NSCoder *)aDecoder)
                       args:@[self.reactTag]];
   }
 }
+
+#pragma mark - UIGestureRecognizerDelegate
+
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldReceiveTouch:(UITouch *)touch
+{
+  if (![gestureRecognizer isKindOfClass:[RCTTouchHandler class]]) {
+    return YES;
+  }
+
+  UIView *currentView = touch.view;
+  while (currentView && ![currentView isReactRootView]) {
+    currentView = currentView.superview;
+  }
+  return currentView == self;
+}
+
 
 @end


### PR DESCRIPTION
This is to support nested root views with independent bridges by preventing touches in the inner root view from being handled by the outer one.

Previously, touches were handled by both touch handlers. This was problematic because the outer touch handler would dispatch a JS touch event to the outer bridge with a react tag from the inner root's descendant view. So if you touched view 7 in the inner root view, then view 7 in the outer root view would also receive a touch event. Instead, we want touches in the inner root view to stay in the inner root view.

Performance-wise, I profiled this diff and didn't see an impact. On the start of each touch (when the finger goes down, not when it is dragged), the view hierarchy is traversed upwards until the first root view which is on the order of 10 property lookups for a typical view hierarchy.

Test Plan: Tapped around in an inner root view and saw that components in the outer root view like text fields, etc were no longer receiving mystery touches.