### PR TITLE
XMLHttpRequest: ignore case for request headers

### DIFF
--- a/Libraries/Network/XMLHttpRequestBase.js
+++ b/Libraries/Network/XMLHttpRequestBase.js
@@ -73,7 +73,7 @@ class XMLHttpRequestBase {
   }
 
   setRequestHeader(header: string, value: any): void {
-    this._headers[header] = value;
+    this._headers[header.toLowerCase()] = value;
   }
 
   open(method: string, url: string, async: ?boolean): void {


### PR DESCRIPTION
HTTP headers are case-insensitive, so we should treat them that way when they're being set on `XMLHttpRequest`.