### PR TITLE
[Tests] Update tests to run on io.js with the latest version of jest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,13 +15,13 @@ install:
   - cp $(brew --prefix nvm)/nvm-exec .nvm/
   - export NVM_DIR=.nvm
   - source $(brew --prefix nvm)/nvm.sh
-  - nvm install v0.10
+  - nvm install iojs-v2
   - npm config set spin=false
   - npm install
 
 script:
 - |
-  nvm use v0.10
+  nvm use iojs-v2
 
   if [ "$TEST_TYPE" = objc ]
   then

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "yargs": "1.3.2"
   },
   "devDependencies": {
-    "jest-cli": "0.4.5",
+    "jest-cli": "facebook/jest#0.5.x",
     "babel-eslint": "3.1.5",
     "eslint": "0.21.2",
     "eslint-plugin-react": "2.3.0"

--- a/packager/react-packager/src/JSTransformer/__tests__/Cache-test.js
+++ b/packager/react-packager/src/JSTransformer/__tests__/Cache-test.js
@@ -229,7 +229,7 @@ describe('JSTransformer Cache', function() {
         return Promise.resolve('baz value');
       });
 
-      jest.runAllTicks();
+      jest.runAllImmediates();
       expect(fs.writeFile).toBeCalled();
     });
   });


### PR DESCRIPTION
[This is a preview diff for getting RN's tests to pass with a future version of jest that supports io.js and other future versions of Node. This can be merged once the diff to update jest is merged upstream and published.]

Updates the tests in small ways so they run on io.js with two updates:

 - The Cache test which relies on Promises uses `runAllImmediates` for modern versions of Node because bluebird uses `setImmediate` instead of `process.nextTick` for Node >0.10.

Test Plan: Run `npm test` with the latest version of jest.