### PR TITLE
[CLI] Validation check for "React" package name

### DIFF
--- a/react-native-cli/index.js
+++ b/react-native-cli/index.js
@@ -65,6 +65,15 @@ function validatePackageName(name) {
     );
     process.exit(1);
   }
+
+  if (name === 'React') {
+    console.error(
+      '"%s" is not a valid name for a project. Please do not use the reserve ' +
+        'word "React".',
+      name
+    );
+    process.exit(1);
+  }
 }
 
 function init(name) {

--- a/react-native-cli/index.js
+++ b/react-native-cli/index.js
@@ -68,8 +68,8 @@ function validatePackageName(name) {
 
   if (name === 'React') {
     console.error(
-      '"%s" is not a valid name for a project. Please do not use the reserve ' +
-        'word "React".',
+      '"%s" is not a valid name for a project. Please do not use the ' +
+        'reserved word "React".',
       name
     );
     process.exit(1);


### PR DESCRIPTION
`React` (with a capital) should be a reserve word and should not be used as a project name since it will break the Sample app when generated.

Previously, the CLI replaced all occurrences of `SampleApp` with whatever the user specified. If they happen to input 'React', it would generate this:

```javascript
var React = React.createClass({ ...

...

AppRegistry.registerComponent('React', () => React);
```

...which is a redefinition of React, causing `createClass` to not be defined, in turn causing the app to crash on the very first run after init, without the user modifying anything.

This commit adds a validation check prompting the user that `React` is not a valid project name.

Discussion here: http://stackoverflow.com/a/30416864/4932710