### PR TITLE
[RFC][ScrollView] Default scrollsToTop to false

### DIFF
--- a/Libraries/Components/ScrollView/ScrollView.js
+++ b/Libraries/Components/ScrollView/ScrollView.js
@@ -224,6 +224,10 @@ var ScrollView = React.createClass({
     scrollIndicatorInsets: EdgeInsetsPropType,
     /**
      * When true, the scroll view scrolls to top when the status bar is tapped.
+     * Unlike iOS, the default value is false so the scroll-to-top behavior is
+     * not accidentally disabled when adding another scroll view; if there are
+     * two scroll views for which scrollsToTop is true, the system disables
+     * scroll-to-top entirely.
      * The default value is true.
      * @platform ios
      */
@@ -353,6 +357,7 @@ var ScrollView = React.createClass({
         !this.props.horizontal;
 
     var props = {
+      scrollsToTop={false}
       ...this.props,
       alwaysBounceHorizontal,
       alwaysBounceVertical,


### PR DESCRIPTION
On iOS if you have two scroll views that have `scrollsToTop` set to true then neither scrolls to the top. We can't change that, but I was thinking it might be better to have scroll views opt into the scroll-to-top behavior so that adding new scroll views to your app doesn't disable scroll-to-top.

The motivation for this came from when I embedded a community-authored component that contained a scroll view and noticed that my screen no longer scrolled to the top anymore. The author of the component should have set `scrollsToTop` to false but every other person writing a component with a scroll view is going to have the same problem.

This would be a breaking change since scroll views for scene roots would have to set `scrollsToTop={true}`.