### PR TITLE
[AnimationExperimental] Fixed CATransaction completion block invoke immediately

### DIFF
--- a/Libraries/Animation/RCTAnimationExperimentalManager.m
+++ b/Libraries/Animation/RCTAnimationExperimentalManager.m
@@ -235,7 +235,6 @@ RCT_EXPORT_METHOD(startAnimation:(NSNumber *)reactTag
       @try {
         [view.layer setValue:toValue forKey:keypath];
         NSString *animationKey = [@"RCT" stringByAppendingString:RCTJSONStringify(@{@"tag": animationTag, @"key": keypath}, nil)];
-        [view.layer addAnimation:animation forKey:animationKey];
         if (!completionBlockSet) {
           strongSelf->_callbackRegistry[animationTag] = callback;
           [CATransaction setCompletionBlock:^{
@@ -247,6 +246,7 @@ RCT_EXPORT_METHOD(startAnimation:(NSNumber *)reactTag
           }];
           completionBlockSet = YES;
         }
+        [view.layer addAnimation:animation forKey:animationKey];
       }
       @catch (NSException *exception) {
         return RCTInvalidAnimationProp(strongSelf->_callbackRegistry, animationTag, keypath, toValue);


### PR DESCRIPTION
[CATransaction Class Reference](https://developer.apple.com/library/mac/documentation/GraphicsImaging/Reference/CATransaction_class/index.html)

In Tasks > Getting and Setting Completion Block Objects > Discussion:

The completion block object that is guaranteed to be called (on the main thread) as soon as all animations subsequently added by this transaction group have completed (or have been removed.) If no animations are added before the current transaction group is committed (or the completion block is set to a different value,) the block will be invoked immediately.