### PR TITLE
[CameraRoll] Add assetThumbnail prop

### DIFF
--- a/Examples/UIExplorer/CameraRollExample.ios.js
+++ b/Examples/UIExplorer/CameraRollExample.ios.js
@@ -70,6 +70,7 @@ var CameraRollExample = React.createClass({
     return (
       <View key={asset} style={styles.row}>
         <Image
+          assetThumbnail={true}
           source={asset.node.image}
           style={imageStyle}
         />

--- a/Libraries/Image/Image.ios.js
+++ b/Libraries/Image/Image.ios.js
@@ -197,7 +197,7 @@ var nativeOnlyProps = {
   defaultImageSrc: true,
   imageTag: true,
   contentMode: true,
-  assetThumb:true,
+  assetThumbnail:true,
 };
 if (__DEV__) {
   verifyPropTypes(Image, RCTStaticImage.viewConfig, nativeOnlyProps);

--- a/Libraries/Image/Image.ios.js
+++ b/Libraries/Image/Image.ios.js
@@ -66,6 +66,11 @@ var Image = React.createClass({
       uri: PropTypes.string,
     }),
     /**
+     * Force display of the ALAsset in thumbnail format 
+     * This property reduce the memory size and only work with ALAsset
+     */
+    assetThumbnail: PropTypes.bool,
+    /**
      * A static image to display while downloading the final image off the
      * network.
      */
@@ -163,7 +168,11 @@ var Image = React.createClass({
       tintColor: style.tintColor,
     });
     if (isStored) {
-      nativeProps.imageTag = source.uri;
+      if (this.props.assetThumbnail === true){
+        nativeProps.assetThumbnail = source.uri;
+      }else{
+        nativeProps.imageTag = source.uri;
+      }
     } else {
       nativeProps.src = source.uri;
     }
@@ -188,6 +197,7 @@ var nativeOnlyProps = {
   defaultImageSrc: true,
   imageTag: true,
   contentMode: true,
+  assetThumb:true,
 };
 if (__DEV__) {
   verifyPropTypes(Image, RCTStaticImage.viewConfig, nativeOnlyProps);

--- a/Libraries/Image/RCTCameraRollManager.m
+++ b/Libraries/Image/RCTCameraRollManager.m
@@ -25,7 +25,7 @@ RCT_EXPORT_METHOD(saveImageWithTag:(NSString *)imageTag
                   successCallback:(RCTResponseSenderBlock)successCallback
                   errorCallback:(RCTResponseSenderBlock)errorCallback)
 {
-  [RCTImageLoader loadImageWithTag:imageTag callback:^(NSError *loadError, UIImage *loadedImage) {
+  [RCTImageLoader loadImageWithTag:imageTag thumb:NO callback:^(NSError *loadError, UIImage *loadedImage) {
     if (loadError) {
       errorCallback(@[[loadError localizedDescription]]);
       return;

--- a/Libraries/Image/RCTImageLoader.h
+++ b/Libraries/Image/RCTImageLoader.h
@@ -21,6 +21,6 @@
  * Will always call callback on main thread.
  */
 + (void)loadImageWithTag:(NSString *)tag
+                   thumb:(BOOL)thumb
                 callback:(void (^)(NSError *error, id /* UIImage or CAAnimation */ image))callback;
-
 @end

--- a/Libraries/Image/RCTImageLoader.m
+++ b/Libraries/Image/RCTImageLoader.m
@@ -65,7 +65,7 @@ static void RCTDispatchCallbackOnMainQueue(void (^callback)(NSError *, id), NSEr
  * Can be called from any thread.
  * Will always call callback on main thread.
  */
-+ (void)loadImageWithTag:(NSString *)imageTag callback:(void (^)(NSError *error, id image))callback
++ (void)loadImageWithTag:(NSString *)imageTag thumb:(BOOL)thumb callback:(void (^)(NSError *error, id image))callback
 {
   if ([imageTag hasPrefix:@"assets-library"]) {
     [[RCTImageLoader assetsLibrary] assetForURL:[NSURL URLWithString:imageTag] resultBlock:^(ALAsset *asset) {
@@ -77,10 +77,17 @@ static void RCTDispatchCallbackOnMainQueue(void (^callback)(NSError *, id), NSEr
         dispatch_async(RCTImageLoaderQueue(), ^{
           // Also make sure the image is released immediately after it's used so it
           // doesn't spike the memory up during the process.
+          
           @autoreleasepool {
+            UIImage *image = nil;
             ALAssetRepresentation *representation = [asset defaultRepresentation];
             ALAssetOrientation orientation = [representation orientation];
-            UIImage *image = [UIImage imageWithCGImage:[representation fullResolutionImage] scale:1.0f orientation:(UIImageOrientation)orientation];
+            if (!thumb){
+              image = [UIImage imageWithCGImage:[representation fullResolutionImage] scale:1.0f orientation:(UIImageOrientation)orientation];
+            }else{
+              image = [UIImage imageWithCGImage:[asset thumbnail] scale:1.0f orientation:(UIImageOrientation)orientation];
+            }
+            
             RCTDispatchCallbackOnMainQueue(callback, nil, image);
           }
         });

--- a/Libraries/Image/RCTStaticImageManager.m
+++ b/Libraries/Image/RCTStaticImageManager.m
@@ -54,7 +54,7 @@ RCT_CUSTOM_VIEW_PROPERTY(tintColor, UIColor, RCTStaticImage)
 RCT_CUSTOM_VIEW_PROPERTY(imageTag, NSString, RCTStaticImage)
 {
   if (json) {
-    [RCTImageLoader loadImageWithTag:[RCTConvert NSString:json] callback:^(NSError *error, id image) {
+    [RCTImageLoader loadImageWithTag:[RCTConvert NSString:json] thumb:NO callback:^(NSError *error, id image) {
       if (error) {
         RCTLogWarn(@"%@", error.localizedDescription);
       }
@@ -70,5 +70,26 @@ RCT_CUSTOM_VIEW_PROPERTY(imageTag, NSString, RCTStaticImage)
     view.image = defaultView.image;
   }
 }
+RCT_CUSTOM_VIEW_PROPERTY(assetThumbnail, NSString, RCTStaticImage)
+{
+  if (json) {
+    [RCTImageLoader loadImageWithTag:[RCTConvert NSString:json] thumb:YES callback:^(NSError *error, id image) {
+      if (error) {
+        RCTLogWarn(@"%@", error.localizedDescription);
+      }
+      if ([image isKindOfClass:[CAAnimation class]]) {
+        [view.layer addAnimation:image forKey:@"contents"];
+      } else {
+        [view.layer removeAnimationForKey:@"contents"];
+        view.image = image;
+      }
+    }];
+  } else {
+    [view.layer removeAnimationForKey:@"contents"];
+    view.image = defaultView.image;
+  }
+}
+
+
 
 @end


### PR DESCRIPTION
Load Assets from Photo library and a memory warning is send.
Add a property in Image to force the display to use the [asset thumbnail] method

Related Issue https://github.com/facebook/react-native/issues/779