### PR TITLE
Fix packager.sh arg parsing

### DIFF
--- a/packager/packager.js
+++ b/packager/packager.js
@@ -36,19 +36,24 @@ var webSocketProxy = require('./webSocketProxy.js');
 var options = parseCommandLine([{
   command: 'port',
   default: 8081,
+  type: 'string',
 }, {
   command: 'root',
   description: 'add another root(s) to be used by the packager in this project',
+  type: 'string',
 }, {
   command: 'assetRoots',
-  description: 'specify the root directories of app assets'
+  description: 'specify the root directories of app assets',
+  type: 'string',
 }, {
   command: 'platform',
   default: 'ios',
-  description: 'Specify the platform-specific blacklist (ios, android, web).'
+  description: 'Specify the platform-specific blacklist (ios, android, web).',
+  type: 'string',
 }, {
   command: 'skipflow',
-  description: 'Disable flow checks'
+  description: 'Disable flow checks',
+  type: 'boolean',
 }]);
 
 if (options.projectRoots) {


### PR DESCRIPTION
All option arguments currently get parsed as booleans. This fixes that and makes it possible again to run the packager with arguments, e.g.:

    react-native/packager/packager.sh --root .

(This is a follow-up to D2089601 / b46c94.)