### PR TITLE
[RCTScrollView] Make ScrollView detect taps on sticky headers

### DIFF
--- a/React/Views/RCTScrollView.m
+++ b/React/Views/RCTScrollView.m
@@ -238,11 +238,7 @@ CGFloat const ZINDEX_STICKY_HEADER = 50;
     }
   }];
 
-  if (stickyHeader) {
-    return stickyHeader;
-  } else {
-    return [super hitTest:point withEvent:event];
-  }
+  return stickyHeader ?: [super hitTest:point withEvent:event];
 }
 
 @end

--- a/React/Views/RCTScrollView.m
+++ b/React/Views/RCTScrollView.m
@@ -223,6 +223,28 @@ CGFloat const ZINDEX_STICKY_HEADER = 50;
   }
 }
 
+- (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event
+{
+  __block UIView *stickyHeader;
+
+  [_stickyHeaderIndices enumerateIndexesWithOptions:0 usingBlock:^(NSUInteger idx, BOOL *stop) {
+    stickyHeader = [self contentView].reactSubviews[idx];
+    CGPoint convertedPoint = [stickyHeader convertPoint:point fromView:self];
+
+    if ([stickyHeader hitTest:convertedPoint withEvent:event]) {
+      *stop = YES;
+    } else {
+      stickyHeader = nil;
+    }
+  }];
+
+  if (stickyHeader) {
+    return stickyHeader;
+  } else {
+    return [super hitTest:point withEvent:event];
+  }
+}
+
 @end
 
 @implementation RCTScrollView


### PR DESCRIPTION
As per discussion with @nicklockwood in #875, make `RCTScrollView` check its sticky headers for hitTests first.

Test Plan: Have a sticky header in a ScrollView with a Touchable onPress action, scroll a bit after it docks and try tapping, should respond to tap.