### PR TITLE
[Cosmetic] Fix some lint warnings

### DIFF
--- a/Libraries/Sample/Sample.android.js
+++ b/Libraries/Sample/Sample.android.js
@@ -10,7 +10,7 @@ var warning = require('warning');
 
 var Sample = {
   test: function() {
-    warning("Not yet implemented for Android.");
+    warning('Not yet implemented for Android.');
   }
 };
 

--- a/Libraries/Sample/Sample.ios.js
+++ b/Libraries/Sample/Sample.ios.js
@@ -5,7 +5,6 @@
 'use strict';
 
 var NativeSample = require('NativeModules').Sample;
-var invariant = require('invariant');
 
 /**
  * High-level docs for the Sample iOS API can be written here.


### PR DESCRIPTION
1. Use singlequote instead of doublequoe on Sample.android.js
1. Remove invariant of Sample.ios.js that is not used