### PR TITLE
Set constructor properly in createReactNativeComponentClass

### DIFF
--- a/Libraries/ReactNative/createReactNativeComponentClass.js
+++ b/Libraries/ReactNative/createReactNativeComponentClass.js
@@ -36,6 +36,7 @@ var createReactNativeComponentClass = function(
   };
   Constructor.displayName = viewConfig.uiViewClassName;
   Constructor.prototype = new ReactNativeBaseComponent(viewConfig);
+  Constructor.prototype.constructor = Constructor;
 
   return Constructor;
 };


### PR DESCRIPTION
Without this, the displayName property wasn't found when looking at
`.constructor` on a component instance. Fixes facebook/react-devtools#92.