### PR TITLE
[WebSocket] Reason can be null which causes an exception with NSDictionary in websocketClosed

### DIFF
--- a/Libraries/WebSocket/RCTWebSocketManager.m
+++ b/Libraries/WebSocket/RCTWebSocketManager.m
@@ -107,7 +107,7 @@ RCT_EXPORT_METHOD(close:(NSNumber *)socketID)
 {
   [_bridge.eventDispatcher sendDeviceEventWithName:@"websocketClosed" body:@{
     @"code": @(code),
-    @"reason": reason,
+    @"reason": reason ? reason : [NSNull null],
     @"clean": @(wasClean),
     @"id": webSocket.reactTag
   }];


### PR DESCRIPTION
I am not 100% sure what causes reason to be null but it does happen.