### PR TITLE
[Image] Initial PoC implementation of cache policy for images

### DIFF
--- a/React/Base/RCTCache.h
+++ b/React/Base/RCTCache.h
@@ -23,7 +23,7 @@
 
 #pragma mark - Insertion
 
-- (void)setData:(NSData *)data forKey:(NSString *)key;
+- (void)setData:(NSData *)data forKey:(NSString *)key expireAt:(NSDate *)expireAt;
 - (void)removeAllData;
 
 @end

--- a/React/Base/RCTCache.m
+++ b/React/Base/RCTCache.m
@@ -158,6 +158,12 @@ static BOOL RCTSetExtendedAttribute(NSURL *fileURL, NSString *key, NSString *val
 
 - (BOOL)hasDataForKey:(NSString *)key
 {
+  NSString *cacheExpirationKey = [key stringByAppendingString:@":expireAt"];
+  NSDate *expirationDate = _storage[cacheExpirationKey] ? _storage[cacheExpirationKey] : nil;
+
+  if (expirationDate == nil || [NSDate date] > expirationDate) {
+    return NO;
+  }
   return _storage[key] != nil;
 }
 
@@ -179,7 +185,7 @@ static BOOL RCTSetExtendedAttribute(NSURL *fileURL, NSString *key, NSString *val
   }];
 }
 
-- (void)setData:(NSData *)data forKey:(NSString *)key
+- (void)setData:(NSData *)data forKey:(NSString *)key expireAt:(NSDate *)expireAt
 {
   NSParameterAssert(key.length > 0);
   RCTCacheRecord *record = _storage[key];
@@ -188,6 +194,11 @@ static BOOL RCTSetExtendedAttribute(NSURL *fileURL, NSString *key, NSString *val
 
     record = [[RCTCacheRecord alloc] initWithUUID:[NSUUID UUID]];
     _storage[key] = record;
+  }
+
+  if (expireAt) {
+    NSString *cacheExpirationKey = [key stringByAppendingString:@":expireAt"];
+    _storage[cacheExpirationKey] = expireAt;
   }
 
   NSURL *fileURL = [_cacheDirectoryURL URLByAppendingPathComponent:record.UUID.UUIDString];


### PR DESCRIPTION
TL;DR: Be able to reload network images.

![http://zippy.gfycat.com/AlertWelloffAztecant.gif](http://zippy.gfycat.com/AlertWelloffAztecant.gif)
```jsx
<View style={[styles.container, styles.skillTest]}>
      <Image
        source={uri:"http://lorempixel.com/600/600/?" +this.state.i}}
        style={{width: Theme.vw*70, height: Theme.vw*70}}
       />
      <TouchableHighlight style={[styles.button]} onPress={() => { this.setState({i: this.state.i+1})}}>
         <Text>Reload image from the same address</Text>
      </TouchableHighlight>
</View>
```
Related: https://github.com/facebook/react-native/issues/1397

If this whole cache thing does make sense, then we should add handlers for HTTP headers: 
- [ ] `Cache-control:max-age`
- [ ] `E-tag`
- [ ] `Last-modified`

### Cons

Adds unnecessary complexity to `react-native` core, plus there are intricate pieces of HTTP protocol. Maybe it should be done outside of the native component, in js instead. But would be awesome if at least Image would have a cache flushing mechanism. 