### PR TITLE
[WebView][Api Change] Support for local files, inline html and relative requires.

### DIFF
--- a/Examples/UIExplorer/UIExplorer.xcodeproj/project.pbxproj
+++ b/Examples/UIExplorer/UIExplorer.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		004D28A31AAF61C70097A701 /* UIExplorerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 004D28A21AAF61C70097A701 /* UIExplorerTests.m */; };
+		0A1576D91B1C90D400CD8C98 /* WebViewTestFolder in Resources */ = {isa = PBXBuildFile; fileRef = 0A1576D81B1C90D400CD8C98 /* WebViewTestFolder */; };
 		13417FE91AA91432003F314A /* libRCTImage.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 13417FE81AA91428003F314A /* libRCTImage.a */; };
 		134180011AA9153C003F314A /* libRCTText.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 13417FEF1AA914B8003F314A /* libRCTText.a */; };
 		1341802C1AA9178B003F314A /* libRCTNetwork.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 1341802B1AA91779003F314A /* libRCTNetwork.a */; };
@@ -125,6 +126,7 @@
 		004D289E1AAF61C70097A701 /* UIExplorerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = UIExplorerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		004D28A11AAF61C70097A701 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		004D28A21AAF61C70097A701 /* UIExplorerTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = UIExplorerTests.m; sourceTree = "<group>"; };
+		0A1576D81B1C90D400CD8C98 /* WebViewTestFolder */ = {isa = PBXFileReference; lastKnownFileType = folder; name = WebViewTestFolder; path = UIExplorer/WebViewTestFolder; sourceTree = "<group>"; };
 		13417FE31AA91428003F314A /* RCTImage.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTImage.xcodeproj; path = ../../Libraries/Image/RCTImage.xcodeproj; sourceTree = "<group>"; };
 		13417FEA1AA914B8003F314A /* RCTText.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTText.xcodeproj; path = ../../Libraries/Text/RCTText.xcodeproj; sourceTree = "<group>"; };
 		134180261AA91779003F314A /* RCTNetwork.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTNetwork.xcodeproj; path = ../../Libraries/Network/RCTNetwork.xcodeproj; sourceTree = "<group>"; };
@@ -271,6 +273,7 @@
 				13B07FB61A68108700A75B9A /* Info.plist */,
 				13B07FB11A68108700A75B9A /* LaunchScreen.xib */,
 				13B07FB71A68108700A75B9A /* main.m */,
+				0A1576D81B1C90D400CD8C98 /* WebViewTestFolder */,
 			);
 			name = UIExplorer;
 			sourceTree = "<group>";
@@ -565,6 +568,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0A1576D91B1C90D400CD8C98 /* WebViewTestFolder in Resources */,
 				13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */,
 				13B07FBD1A68108700A75B9A /* LaunchScreen.xib in Resources */,
 			);

--- a/Examples/UIExplorer/UIExplorer/WebViewTestFolder/index.html
+++ b/Examples/UIExplorer/UIExplorer/WebViewTestFolder/index.html
@@ -1,0 +1,1 @@
+<script src="index.js" type="text/javascript"></script>

--- a/Examples/UIExplorer/UIExplorer/WebViewTestFolder/index.js
+++ b/Examples/UIExplorer/UIExplorer/WebViewTestFolder/index.js
@@ -1,0 +1,1 @@
+document.write('It works in a file!');

--- a/Examples/UIExplorer/UIExplorer/WebViewTestFolder/inline.js
+++ b/Examples/UIExplorer/UIExplorer/WebViewTestFolder/inline.js
@@ -1,0 +1,1 @@
+document.write('It works inline!');

--- a/Examples/UIExplorer/WebViewExample.js
+++ b/Examples/UIExplorer/WebViewExample.js
@@ -32,17 +32,23 @@ var DISABLED_WASH = 'rgba(255,255,255,0.25)';
 
 var TEXT_INPUT_REF = 'urlInput';
 var WEBVIEW_REF = 'webview';
+
 var DEFAULT_URL = 'https://m.facebook.com';
+var LOCAL_BASE_URL = '/WebViewTestFolder/';
+var LOCAL_INDEX_URL = 'index.html';
+var INLINE_HTML = '<script src="inline.js" type="text/javascript"></script>';
 
 var WebViewExample = React.createClass({
 
   getInitialState: function() {
     return {
-      url: DEFAULT_URL,
       status: 'No Page Loaded',
       backButtonEnabled: false,
       forwardButtonEnabled: false,
       loading: true,
+      source:{
+        uri:DEFAULT_URL,
+      }
     };
   },
 
@@ -54,6 +60,15 @@ var WebViewExample = React.createClass({
 
   render: function() {
     this.inputText = this.state.url;
+
+    var webViewProps = {
+      ref: WEBVIEW_REF,
+      automaticallyAdjustContentInsets: false,
+      style: styles.webView,
+      onNavigationStateChange: this.onNavigationStateChange,
+      source: this.state.source,
+      startInLoadingState: true,
+    }
 
     return (
       <View style={[styles.container]}>
@@ -88,16 +103,22 @@ var WebViewExample = React.createClass({
               </Text>
             </View>
           </TouchableOpacity>
+          <TouchableOpacity onPress={this.pressLocalFileButton}>
+            <View style={styles.goButton}>
+              <Text>
+                 Local(File)
+              </Text>
+            </View>
+          </TouchableOpacity>
+          <TouchableOpacity onPress={this.pressLocalInlineButton}>
+            <View style={styles.goButton}>
+              <Text>
+                 Local(Inline)
+              </Text>
+            </View>
+          </TouchableOpacity>
         </View>
-        <WebView
-          ref={WEBVIEW_REF}
-          automaticallyAdjustContentInsets={false}
-          style={styles.webView}
-          url={this.state.url}
-          javaScriptEnabledAndroid={true}
-          onNavigationStateChange={this.onNavigationStateChange}
-          startInLoadingState={true}
-        />
+        <WebView {...webViewProps}/>
         <View style={styles.statusBar}>
           <Text style={styles.statusBarText}>{this.state.status}</Text>
         </View>
@@ -132,16 +153,42 @@ var WebViewExample = React.createClass({
   },
 
   pressGoButton: function() {
+
     var url = this.inputText.toLowerCase();
+
     if (url === this.state.url) {
       this.reload();
     } else {
       this.setState({
-        url: url,
+        source:{
+          uri: url,
+          html: null,
+          baseUrl: null,
+        },
       });
     }
     // dismiss keyoard
     this.refs[TEXT_INPUT_REF].blur();
+  },
+
+  pressLocalFileButton: function() {
+    this.setState({
+      source:{
+        baseUrl: LOCAL_BASE_URL,
+        uri: LOCAL_INDEX_URL,
+        html: null,
+      },
+    });
+  },
+
+  pressLocalInlineButton: function() {
+    this.setState({
+      source:{
+        uri: null,
+        html: INLINE_HTML,
+        baseUrl: LOCAL_BASE_URL,
+      },
+    });
   },
 
 });

--- a/Libraries/Components/WebView/WebView.ios.js
+++ b/Libraries/Components/WebView/WebView.ios.js
@@ -79,8 +79,13 @@ var WebView = React.createClass({
   },
 
   propTypes: {
-    url: PropTypes.string,
-    html: PropTypes.string,
+    url: PropTypes.string, // Deprecated
+    html: PropTypes.string, // Deprecated
+    source: PropTypes.shape({
+      uri: PropTypes.string, // Supports remote and file protocol, or relative if baseUrl is also passed
+      baseUrl: PropTypes.string, // From your project root
+      html: PropTypes.string, // Inline html, if you pass a baseUrl you can require relative files inside
+    }),
     renderError: PropTypes.func, // view to show if there's an error
     renderLoading: PropTypes.func, // loading indicator to show
     bounces: PropTypes.bool,
@@ -147,6 +152,7 @@ var WebView = React.createClass({
         style={webViewStyles}
         url={this.props.url}
         html={this.props.html}
+        source={this.props.source}
         bounces={this.props.bounces}
         scrollEnabled={this.props.scrollEnabled}
         shouldInjectAJAXHandler={this.props.shouldInjectAJAXHandler}

--- a/React/Views/RCTWebView.h
+++ b/React/Views/RCTWebView.h
@@ -13,6 +13,7 @@
 
 @interface RCTWebView : RCTView
 
+@property (nonatomic, strong) NSDictionary *source;
 @property (nonatomic, strong) NSURL *URL;
 @property (nonatomic, assign) UIEdgeInsets contentInset;
 @property (nonatomic, assign) BOOL shouldInjectAJAXHandler;

--- a/React/Views/RCTWebViewManager.m
+++ b/React/Views/RCTWebViewManager.m
@@ -23,6 +23,7 @@ RCT_EXPORT_MODULE()
   return [[RCTWebView alloc] initWithEventDispatcher:self.bridge.eventDispatcher];
 }
 
+RCT_EXPORT_VIEW_PROPERTY(source, NSDictionary);
 RCT_REMAP_VIEW_PROPERTY(url, URL, NSURL);
 RCT_REMAP_VIEW_PROPERTY(html, HTML, NSString);
 RCT_REMAP_VIEW_PROPERTY(bounces, _webView.scrollView.bounces, BOOL);


### PR DESCRIPTION
(This PR is not ready to be merged, creating it for feedback on the api as per recommendation from @brentvatne in #1481)

# Features
* Support for local files using the file protocol, e.g file://htdocs/index.html
* Support for relative requires, e.g in the above file index.js would refer to htdocs/index.js
* Support for inline html (Also supports relative requires through baseUrl, solves #1442) 
* Added 2 buttons and a local test folder to UIExplorer, for testing this (this can be replaced by automated tests perhaps? Apologies, my obj-c/react testing knowledge is still limited)

# New api
```javascript
<WebView source={{uri: string, html: string, baseUrl: string}} />

<WebView source={{uri: 'file://htdocs/index.html'}} />
//is equivalent to 
<WebView source={{uri: 'index.html', baseUrl: '/htdocs'}} />

//Can also directly input the contents of the above index.html
<WebView source={{
  baseUrl: '/htdocs', 
  html: '<script src="index.js"></script>' /* this would load htdocs/index.js */}} />
```

# Future breaking changes

Both the ````url```` and ````html```` props are deprecated, in favor of the source object. ````url```` was also changed to the ````uri```` key, for parity with the ````<Image/>```` element's source object.
They still work as before if no source object is passed, although both methods do not seamlessly operate.

# Issues with the current state

- [ ] Setting inline html replaces the current navigation item. I'm not sure there is any relevant use case for having both uri's and inline html seamlessly navigate between one another, or even navigate between 2 different inline html(s). However, this could be accomplished by temporarily saving a file with the inline html, and pointing to it instead. I'm leaning more towards not supporting this though.
- [ ] I'm not sure how to deprecate remapped properties (url and html), can I get some say-so on this?
- [ ] Perhaps throw an exception if an invalid prop combination is passed? I'm not sure what the react recommended way is to indicate to the developer they have done this