### PR TITLE
[Geolocation] Add permissionTypeIOS option

### DIFF
--- a/Libraries/Geolocation/Geolocation.js
+++ b/Libraries/Geolocation/Geolocation.js
@@ -26,6 +26,7 @@ type GeoOptions = {
   timeout: number;
   maximumAge: number;
   enableHighAccuracy: bool;
+  backgroundMode: bool;
 }
 
 /**

--- a/Libraries/Geolocation/Geolocation.js
+++ b/Libraries/Geolocation/Geolocation.js
@@ -58,10 +58,8 @@ var Geolocation = {
     geo_error?: Function,
     geo_options?: GeoOptions
   ) {
-    geo_options = geo_options || {};
-    geo_options.permissionTypeIOS = geo_options.permissionTypeIOS || 'IN_USE';
     invariant(
-      PERMISSION_TYPES.indexOf(geo_options.permissionTypeIOS) > -1,
+      !geo_options || !geo_options.permissionTypeIOS || PERMISSION_TYPES.indexOf(geo_options.permissionTypeIOS) > -1,
       'Invalid permissionTypeIOS option value.'
     );
     invariant(
@@ -80,10 +78,8 @@ var Geolocation = {
    * options: timeout (ms), maximumAge (ms), enableHighAccuracy (bool)
    */
   watchPosition: function(success: Function, error?: Function, options?: GeoOptions): number {
-    options = options || {};
-    options.permissionTypeIOS = options.permissionTypeIOS || 'IN_USE';
     invariant(
-      PERMISSION_TYPES.indexOf(options.permissionTypeIOS) > -1,
+      !options || !options.permissionTypeIOS || PERMISSION_TYPES.indexOf(options.permissionTypeIOS) > -1,
       'Invalid permissionTypeIOS option value.'
     );
 

--- a/Libraries/Geolocation/Geolocation.js
+++ b/Libraries/Geolocation/Geolocation.js
@@ -18,6 +18,8 @@ var invariant = require('invariant');
 var logError = require('logError');
 var warning = require('warning');
 
+var PERMISSION_TYPES = ['IN_USE', 'ALWAYS'];
+
 var subscriptions = [];
 
 var updatesEnabled = false;
@@ -26,7 +28,7 @@ type GeoOptions = {
   timeout: number;
   maximumAge: number;
   enableHighAccuracy: bool;
-  backgroundMode: bool;
+  permissionTypeIOS: string;
 }
 
 /**
@@ -56,12 +58,18 @@ var Geolocation = {
     geo_error?: Function,
     geo_options?: GeoOptions
   ) {
+    geo_options = geo_options || {};
+    geo_options.permissionTypeIOS = geo_options.permissionTypeIOS || 'IN_USE';
+    invariant(
+      PERMISSION_TYPES.indexOf(geo_options.permissionTypeIOS) > -1,
+      'Invalid permissionTypeIOS option value.'
+    );
     invariant(
       typeof geo_success === 'function',
       'Must provide a valid geo_success callback.'
     );
     RCTLocationObserver.getCurrentPosition(
-      geo_options || {},
+      geo_options,
       geo_success,
       geo_error || logError
     );
@@ -72,8 +80,15 @@ var Geolocation = {
    * options: timeout (ms), maximumAge (ms), enableHighAccuracy (bool)
    */
   watchPosition: function(success: Function, error?: Function, options?: GeoOptions): number {
+    options = options || {};
+    options.permissionTypeIOS = options.permissionTypeIOS || 'IN_USE';
+    invariant(
+      PERMISSION_TYPES.indexOf(options.permissionTypeIOS) > -1,
+      'Invalid permissionTypeIOS option value.'
+    );
+
     if (!updatesEnabled) {
-      RCTLocationObserver.startObserving(options || {});
+      RCTLocationObserver.startObserving(options);
       updatesEnabled = true;
     }
     var watchID = subscriptions.length;
@@ -129,6 +144,6 @@ var Geolocation = {
       subscriptions = [];
     }
   }
-};
+}
 
 module.exports = Geolocation;

--- a/Libraries/Geolocation/Geolocation.js
+++ b/Libraries/Geolocation/Geolocation.js
@@ -18,7 +18,7 @@ var invariant = require('invariant');
 var logError = require('logError');
 var warning = require('warning');
 
-var PERMISSION_TYPES = ['IN_USE', 'ALWAYS'];
+var PERMISSION_TYPES = ['always', 'inUse'];
 
 var subscriptions = [];
 
@@ -84,7 +84,7 @@ var Geolocation = {
     );
 
     if (!updatesEnabled) {
-      RCTLocationObserver.startObserving(options);
+      RCTLocationObserver.startObserving(options || {});
       updatesEnabled = true;
     }
     var watchID = subscriptions.length;
@@ -140,6 +140,6 @@ var Geolocation = {
       subscriptions = [];
     }
   }
-}
+};
 
 module.exports = Geolocation;

--- a/Libraries/Geolocation/Geolocation.js
+++ b/Libraries/Geolocation/Geolocation.js
@@ -67,7 +67,7 @@ var Geolocation = {
       'Must provide a valid geo_success callback.'
     );
     RCTLocationObserver.getCurrentPosition(
-      geo_options,
+      geo_options || {},
       geo_success,
       geo_error || logError
     );

--- a/Libraries/Geolocation/RCTLocationObserver.m
+++ b/Libraries/Geolocation/RCTLocationObserver.m
@@ -25,8 +25,9 @@ typedef NS_ENUM(NSInteger, RCTPositionErrorCode) {
   RCTPositionErrorTimeout,
 };
 
-static NSString *const PERMISSION_TYPE_ALWAYS = @"ALWAYS";
-static NSString *const PERMISSIONS_KEY = @"permissionTypeIOS";
+static NSString *const RCTPermissionTypeAlways = @"always";
+static NSString *const RCTPermissionTypeInUse = @"inUse";
+static NSString *const RCTPermissionKey = @"permissionTypeIOS";
 
 #define RCT_DEFAULT_LOCATION_ACCURACY kCLLocationAccuracyHundredMeters
 
@@ -134,8 +135,7 @@ RCT_EXPORT_MODULE()
     _locationManager.distanceFilter = RCT_DEFAULT_LOCATION_ACCURACY;
     _locationManager.delegate = self;
   }
-
-  if ([permissionType isEqualToString:PERMISSION_TYPE_ALWAYS] && [_locationManager respondsToSelector:@selector(requestAlwaysAuthorization)]) {
+  if ([permissionType isEqualToString:RCTPermissionTypeAlways] && [_locationManager respondsToSelector:@selector(requestAlwaysAuthorization)]) {
     [_locationManager requestAlwaysAuthorization];
   }
   // Defaults to minimal permission: `requestWhenInUseAuthorization`
@@ -164,7 +164,6 @@ RCT_EXPORT_MODULE()
 
 RCT_EXPORT_METHOD(startObserving:(NSDictionary*)options)
 {
-  NSLog(@"***$$$$$$$$$$$$$$$$$$$$$$$$ START OBS");
   [self checkLocationConfig:options];
   _observerOptions = [RCTConvert RCTLocationOptions:options];
 
@@ -174,7 +173,7 @@ RCT_EXPORT_METHOD(startObserving:(NSDictionary*)options)
   }
 
   _locationManager.desiredAccuracy = _observerOptions.accuracy;
-  [self beginLocationUpdates:options[PERMISSIONS_KEY]];
+  [self beginLocationUpdates:options[@"permissionTypeIOS"]];
   _observingLocation = YES;
 }
 
@@ -246,7 +245,7 @@ RCT_EXPORT_METHOD(getCurrentPosition:(NSDictionary*)options
 
   // Configure location manager and begin updating location
   _locationManager.desiredAccuracy = MIN(_locationManager.desiredAccuracy, locationOptions.accuracy);
-  [self beginLocationUpdates:options[PERMISSIONS_KEY]];
+  [self beginLocationUpdates:options[RCTPermissionKey]];
 }
 
 #pragma mark - CLLocationManagerDelegate
@@ -333,7 +332,7 @@ RCT_EXPORT_METHOD(getCurrentPosition:(NSDictionary*)options
 
 - (void)checkLocationConfig:(NSDictionary*)options
 {
-  if([options[PERMISSIONS_KEY] isEqualToString:PERMISSION_TYPE_ALWAYS] && ![[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSLocationAlwaysUsageDescription"]) {
+  if([options[RCTPermissionKey] isEqualToString:RCTPermissionTypeAlways] && ![[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSLocationAlwaysUsageDescription"]) {
     //@TODO we should also check that the location background capability exists, and we should cache the results
     RCTLogError(@"NSLocationAlwaysUsageDescription key must be present in Info.plist for 'ALWAYS' authorization.");
   }

--- a/Libraries/Geolocation/RCTLocationObserver.m
+++ b/Libraries/Geolocation/RCTLocationObserver.m
@@ -334,7 +334,7 @@ RCT_EXPORT_METHOD(getCurrentPosition:(NSDictionary*)options
 {
   if([options[RCTPermissionKey] isEqualToString:RCTPermissionTypeAlways] && ![[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSLocationAlwaysUsageDescription"]) {
     //@TODO we should also check that the location background capability exists, and we should cache the results
-    RCTLogError(@"NSLocationAlwaysUsageDescription key must be present in Info.plist for 'ALWAYS' authorization.");
+    RCTLogError(@"NSLocationAlwaysUsageDescription key must be present in Info.plist for 'always' authorization.");
   }
   else if (![[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSLocationWhenInUseUsageDescription"]) {
     RCTLogError(@"NSLocationWhenInUseUsageDescription key must be present in Info.plist to use geolocation.");

--- a/Libraries/Geolocation/RCTLocationObserver.m
+++ b/Libraries/Geolocation/RCTLocationObserver.m
@@ -25,13 +25,15 @@ typedef NS_ENUM(NSInteger, RCTPositionErrorCode) {
   RCTPositionErrorTimeout,
 };
 
+static NSString *const PERMISSION_TYPE_ALWAYS = @"ALWAYS";
+static NSString *const PERMISSIONS_KEY = @"permissionTypeIOS";
+
 #define RCT_DEFAULT_LOCATION_ACCURACY kCLLocationAccuracyHundredMeters
 
 typedef struct {
   double timeout;
   double maximumAge;
   double accuracy;
-  bool backgroundMode;
 } RCTLocationOptions;
 
 @implementation RCTConvert (RCTLocationOptions)
@@ -42,8 +44,7 @@ typedef struct {
   return (RCTLocationOptions){
     .timeout = [RCTConvert NSTimeInterval:options[@"timeout"]] ?: INFINITY,
     .maximumAge = [RCTConvert NSTimeInterval:options[@"maximumAge"]] ?: INFINITY,
-    .accuracy = [RCTConvert BOOL:options[@"enableHighAccuracy"]] ? kCLLocationAccuracyBest : RCT_DEFAULT_LOCATION_ACCURACY,
-    .backgroundMode = [RCTConvert BOOL:options[@"backgroundMode"]]
+    .accuracy = [RCTConvert BOOL:options[@"enableHighAccuracy"]] ? kCLLocationAccuracyBest : RCT_DEFAULT_LOCATION_ACCURACY
   };
 }
 
@@ -126,7 +127,7 @@ RCT_EXPORT_MODULE()
 
 #pragma mark - Private API
 
-- (void)beginLocationUpdates:(RCTLocationOptions)options
+- (void)beginLocationUpdates:(NSString*)permissionType
 {
   if (!_locationManager) {
     _locationManager = [CLLocationManager new];
@@ -134,9 +135,10 @@ RCT_EXPORT_MODULE()
     _locationManager.delegate = self;
   }
 
-  if (options.backgroundMode && [_locationManager respondsToSelector:@selector(requestAlwaysAuthorization)]) {
+  if ([permissionType isEqualToString:PERMISSION_TYPE_ALWAYS] && [_locationManager respondsToSelector:@selector(requestAlwaysAuthorization)]) {
     [_locationManager requestAlwaysAuthorization];
   }
+  // Defaults to minimal permission: `requestWhenInUseAuthorization`
   else if ([_locationManager respondsToSelector:@selector(requestWhenInUseAuthorization)]) {
     [_locationManager requestWhenInUseAuthorization];
   }
@@ -160,18 +162,19 @@ RCT_EXPORT_MODULE()
 
 #pragma mark - Public API
 
-RCT_EXPORT_METHOD(startObserving:(RCTLocationOptions)options)
+RCT_EXPORT_METHOD(startObserving:(NSDictionary*)options)
 {
+  NSLog(@"***$$$$$$$$$$$$$$$$$$$$$$$$ START OBS");
   [self checkLocationConfig:options];
+  _observerOptions = [RCTConvert RCTLocationOptions:options];
 
   // Select best options
-  _observerOptions = options;
   for (RCTLocationRequest *request in _pendingRequests) {
     _observerOptions.accuracy = MIN(_observerOptions.accuracy, request.options.accuracy);
   }
 
   _locationManager.desiredAccuracy = _observerOptions.accuracy;
-  [self beginLocationUpdates:_observerOptions];
+  [self beginLocationUpdates:options[PERMISSIONS_KEY]];
   _observingLocation = YES;
 }
 
@@ -186,11 +189,12 @@ RCT_EXPORT_METHOD(stopObserving)
   }
 }
 
-RCT_EXPORT_METHOD(getCurrentPosition:(RCTLocationOptions)options
+RCT_EXPORT_METHOD(getCurrentPosition:(NSDictionary*)options
                   withSuccessCallback:(RCTResponseSenderBlock)successBlock
                   errorCallback:(RCTResponseSenderBlock)errorBlock)
 {
   [self checkLocationConfig:options];
+  RCTLocationOptions locationOptions = [RCTConvert RCTLocationOptions:options];
 
   if (!successBlock) {
     RCTLogError(@"%@.getCurrentPosition called with nil success parameter.", [self class]);
@@ -217,8 +221,8 @@ RCT_EXPORT_METHOD(getCurrentPosition:(RCTLocationOptions)options
 
   // Check if previous recorded location exists and is good enough
   if (_lastLocationEvent &&
-      CFAbsoluteTimeGetCurrent() - [RCTConvert NSTimeInterval:_lastLocationEvent[@"timestamp"]] < options.maximumAge &&
-      [_lastLocationEvent[@"coords"][@"accuracy"] doubleValue] >= options.accuracy) {
+      CFAbsoluteTimeGetCurrent() - [RCTConvert NSTimeInterval:_lastLocationEvent[@"timestamp"]] < locationOptions.maximumAge &&
+      [_lastLocationEvent[@"coords"][@"accuracy"] doubleValue] >= locationOptions.accuracy) {
 
     // Call success block with most recent known location
     successBlock(@[_lastLocationEvent]);
@@ -229,8 +233,8 @@ RCT_EXPORT_METHOD(getCurrentPosition:(RCTLocationOptions)options
   RCTLocationRequest *request = [RCTLocationRequest new];
   request.successBlock = successBlock;
   request.errorBlock = errorBlock ?: ^(NSArray *args){};
-  request.options = options;
-  request.timeoutTimer = [NSTimer scheduledTimerWithTimeInterval:options.timeout
+  request.options = locationOptions;
+  request.timeoutTimer = [NSTimer scheduledTimerWithTimeInterval:locationOptions.timeout
                                                           target:self
                                                         selector:@selector(timeout:)
                                                         userInfo:request
@@ -241,8 +245,8 @@ RCT_EXPORT_METHOD(getCurrentPosition:(RCTLocationOptions)options
   [_pendingRequests addObject:request];
 
   // Configure location manager and begin updating location
-  _locationManager.desiredAccuracy = MIN(_locationManager.desiredAccuracy, options.accuracy);
-  [self beginLocationUpdates:options];
+  _locationManager.desiredAccuracy = MIN(_locationManager.desiredAccuracy, locationOptions.accuracy);
+  [self beginLocationUpdates:options[PERMISSIONS_KEY]];
 }
 
 #pragma mark - CLLocationManagerDelegate
@@ -327,14 +331,14 @@ RCT_EXPORT_METHOD(getCurrentPosition:(RCTLocationOptions)options
   }
 }
 
-- (void)checkLocationConfig:(RCTLocationOptions)options
+- (void)checkLocationConfig:(NSDictionary*)options
 {
-  if (![[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSLocationWhenInUseUsageDescription"]) {
-    RCTLogError(@"NSLocationWhenInUseUsageDescription key must be present in Info.plist to use geolocation.");
-  }
-  if(options.backgroundMode && ![[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSLocationAlwaysUsageDescription"]) {
+  if([options[PERMISSIONS_KEY] isEqualToString:PERMISSION_TYPE_ALWAYS] && ![[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSLocationAlwaysUsageDescription"]) {
     //@TODO we should also check that the location background capability exists, and we should cache the results
-    RCTLogError(@"NSLocationAlwaysUsageDescription key must be present in Info.plist to use geolocation in backgroundMode.");
+    RCTLogError(@"NSLocationAlwaysUsageDescription key must be present in Info.plist for 'ALWAYS' authorization.");
+  }
+  else if (![[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSLocationWhenInUseUsageDescription"]) {
+    RCTLogError(@"NSLocationWhenInUseUsageDescription key must be present in Info.plist to use geolocation.");
   }
 }
 


### PR DESCRIPTION
This adds backgroundMode to the geolocation options. When `options.backgroundMode === true` for both gelocation.getCurrentPosition and gelocation.watchPosition:
1. Enforce `NSLocationAlwaysUsageDescription` is set in Info.plist
2. Requests `requestAlwaysAuthorization` as opposed to `requestWhenInUseAuthorization`