### PR TITLE
Check if colorCache dictionary < 2048

### DIFF
--- a/React/Base/RCTConvert.m
+++ b/React/Base/RCTConvert.m
@@ -595,8 +595,8 @@ RCT_CGSTRUCT_CONVERTER(CGAffineTransform, (@[
     color = [UIColor whiteColor];
   }
 
-  // Cache and return
-  if (json) {
+  // Cache if possible and return
+  if (json && [colorCache count] < 204) {
     colorCache[json] = color;
   }
   return color;


### PR DESCRIPTION
I have a problem with animations which affects color changing. It leads to massive RCTConvert calls and app crashes at the line `RCTConvert.m:600`.
This is a super simple hack to help the app stays out of crashes. 
