### PR TITLE
[PushNotification] Unregister for remote notifications support.

### DIFF
--- a/Libraries/PushNotificationIOS/PushNotificationIOS.js
+++ b/Libraries/PushNotificationIOS/PushNotificationIOS.js
@@ -76,6 +76,18 @@ class PushNotificationIOS {
   }
 
   /**
+   * Unregister for all remote notifications received via Apple Push Notification service.
+   *
+   * You should call this method in rare circumstances only, such as when a new version of
+   * the app removes support for all types of remote notifications. Users can temporarily
+   * prevent apps from receiving remote notifications through the Notifications section of
+   * the Settings app. Apps unregistered through this method can always re-register.
+   */
+  static abandonPermissions() {
+    RCTPushNotificationManager.abandonPermissions();
+  }
+  
+  /**
    * See what push permissions are currently enabled. `callback` will be
    * invoked with a `permissions` object:
    *

--- a/Libraries/PushNotificationIOS/RCTPushNotificationManager.m
+++ b/Libraries/PushNotificationIOS/RCTPushNotificationManager.m
@@ -102,6 +102,11 @@ RCT_EXPORT_METHOD(requestPermissions)
   }
 }
 
+RCT_EXPORT_METHOD(abandonPermissions)
+{
+  [[UIApplication sharedApplication] unregisterForRemoteNotifications];
+}
+
 RCT_EXPORT_METHOD(checkPermissions:(RCTResponseSenderBlock)callback)
 {
 


### PR DESCRIPTION
See iOS Developer Library: [- unregisterForRemoteNotifications](https://developer.apple.com/library/ios/documentation/UIKit/Reference/UIApplication_Class/index.html#//apple_ref/occ/instm/UIApplication/unregisterForRemoteNotifications).

Unregister for all remote notifications received via Apple Push Notification service.

**Discussion**
You should call this method in rare circumstances only, such as when a new version of the app removes support for all types of remote notifications. Users can temporarily prevent apps from receiving remote notifications through the Notifications section of the Settings app. Apps unregistered through this method can always re-register.