### PR TITLE
[View] Keep view's aspect ratio based on new prop

### DIFF
--- a/Libraries/Components/View/View.js
+++ b/Libraries/Components/View/View.js
@@ -183,6 +183,21 @@ var View = React.createClass({
     style: stylePropType,
 
     /**
+     * Makes the view resize in a fixed `aspectRatio` as the prop. It can be
+     * a number or a rectangle. As the width changes due to flex layout,
+     * the height will change in proportion with same aspect ratio. Use this
+     * to wrap images and other components, where you would like the aspect
+     * ratio to be maintained.
+     */
+    aspectRatio: PropTypes.oneOfType([
+      PropTypes.number,
+      PropTypes.shape({
+        width: PropTypes.number,
+        height: PropTypes.number,
+      }),
+    ]),
+
+    /**
      * This is a special performance property exposed by RCTView and is useful
      * for scrolling content when there are many subviews, most of which are
      * offscreen. For this property to be effective, it must be applied to a

--- a/Libraries/Image/Image.ios.js
+++ b/Libraries/Image/Image.ios.js
@@ -94,6 +94,19 @@ var Image = React.createClass({
      */
     resizeMode: PropTypes.oneOf(['cover', 'contain', 'stretch']),
     /**
+     * Makes the image resize in a fixed `aspectRatio` as the prop. It can be
+     * a number or a rectangle. As the width changes due to flex layout,
+     * the height will change in proportion with same aspect ratio. Use this
+     * to wrap images where you would like the aspect ratio to be maintained.
+     */
+    aspectRatio: PropTypes.oneOfType([
+      PropTypes.number,
+      PropTypes.shape({
+        width: PropTypes.number,
+        height: PropTypes.number,
+      }),
+    ]),
+    /**
      * A unique identifier for this element to be used in UI Automation
      * testing scripts.
      */

--- a/Libraries/ReactNative/ReactNativeViewAttributes.js
+++ b/Libraries/ReactNative/ReactNativeViewAttributes.js
@@ -35,6 +35,12 @@ ReactNativeViewAttributes.RCTView = merge(
   // many subviews that extend outside its bound. The subviews must also have
   // overflow: hidden, as should the containing view (or one of its superviews).
   removeClippedSubviews: true,
+
+  // This property makes the view resize in the same aspect ratio as the 
+  // `aspectRatio` rectangle. As the width changes due to flex layout,
+  // the height will change in proportion with same aspect ratio.
+  aspectRatio: true,
+
 });
 
 module.exports = ReactNativeViewAttributes;

--- a/React/Views/RCTShadowView.h
+++ b/React/Views/RCTShadowView.h
@@ -112,6 +112,12 @@ typedef void (^RCTApplierBlock)(RCTSparseArray *viewRegistry);
 @property (nonatomic, assign) CGFloat flex;
 
 /**
+ * Makes the box rigid, and sizes itself in flex with the
+ * defined aspect ratio of the CGSize rectangle.
+ */
+@property (nonatomic, assign) CGSize aspectRatio;
+
+/**
  * Calculate property changes that need to be propagated to the view.
  * The applierBlocks set contains RCTApplierBlock functions that must be applied
  * on the main thread in order to update the view.

--- a/React/Views/RCTShadowView.m
+++ b/React/Views/RCTShadowView.m
@@ -87,10 +87,9 @@ static void RCTProcessMetaProps(const float metaProps[META_PROP_COUNT], float st
 }
 
 /*
- * Sets the measure function on the cssNode, when the
- * aspectRatio rectangle is set. This helps calculate
- * the height of the node based on width of parent and
- * maintains the aspect ratio of the node.
+ * Sets the measure function on the cssNode, when the aspectRatio rectangle is
+ * set. This helps calculate the height of the node based on width of the parent
+ * and maintains the aspect ratio of the node.
  */
 static css_dim_t RCTAspectRatioMeasure(void *context, float width)
 {

--- a/React/Views/RCTViewManager.m
+++ b/React/Views/RCTViewManager.m
@@ -275,4 +275,14 @@ RCT_REMAP_SHADOW_PROPERTY(position, positionType, css_position_type_t)
 
 RCT_REMAP_SHADOW_PROPERTY(onLayout, hasOnLayout, BOOL)
 
+RCT_CUSTOM_SHADOW_PROPERTY(aspectRatio, CGSize, RCTShadowView) {
+  if ([view respondsToSelector:@selector(setAspectRatio:)]) {
+    if ([json isKindOfClass:NSDictionary.class]) {
+      [view setAspectRatio:[RCTConvert CGSize:json]];
+    } else {
+      [view setAspectRatio:CGSizeMake([RCTConvert CGFloat:json], 1.0f)];
+    }
+  }
+}
+
 @end

--- a/React/Views/RCTViewManager.m
+++ b/React/Views/RCTViewManager.m
@@ -279,8 +279,10 @@ RCT_CUSTOM_SHADOW_PROPERTY(aspectRatio, CGSize, RCTShadowView) {
   if ([view respondsToSelector:@selector(setAspectRatio:)]) {
     if ([json isKindOfClass:NSDictionary.class]) {
       [view setAspectRatio:[RCTConvert CGSize:json]];
-    } else {
+    } else if (json) {
       [view setAspectRatio:CGSizeMake([RCTConvert CGFloat:json], 1.0f)];
+    } else {
+      [view setAspectRatio:defaultView.aspectRatio];
     }
   }
 }


### PR DESCRIPTION
Continues from #858.

Current behaviour:
1. When a static image is configured with `<Image source=require("image_name.jpg") />`, the packager adds the `width` and `height` into the `source` prop. Hence there is no need of setting dimensions in `style`.
2. But for remote images, this `width` and `height` is forcefully set on the `style` prop, which means if one uses only `alignSelf: 'stretch'` to layout the image, the `height` would not change in the same ratio as the `width` inherited from the parent.

This pull request fixes this. I believe the basic problem that this attempts to solve is very genuine. It includes a `measure` function on NetworkImageView to maintain aspect ratio of image when dimensions are known beforehand.

Now just like automatic sizing and layout of text, the same would work for images that actually take the entire width of the device, and the height would be configured automatically based on the calculated aspect ratio of the image:
```jsx
<View style={{flex: 1, paddingTop: 20}}>
  <Image
    style={{margin: 5}}
    source={{
      uri: "http://placehold.it/800x100",
      height: 100,
      width: 800
    }}
  />
  <Image
    style={{margin: 5}}
    source={{
      uri: "http://placehold.it/600x300",
      height: 300,
      width: 600
    }}
  />
  <Image
    style={{margin: 5}}
    source={{
      uri: "http://placehold.it/400x400",
      height: 400,
      width: 400
    }}
  />
</View>
```
![Screenshots comparing the output of above code on devices with different widths.](http://i.imgur.com/XwvXTGY.png)

Open to suggestions on how to improve this pull request.