### PR TITLE
Adds additional info for creating Swift modules

### DIFF
--- a/docs/NativeModulesIOS.md
+++ b/docs/NativeModulesIOS.md
@@ -302,4 +302,11 @@ RCT_EXTERN_METHOD(addEvent:(NSString *)name location:(NSString *)location date:(
 @end
 ```
 
+For those of you new to Swift and Objective-C, whenver you [mix the two languages in an iOS project](https://developer.apple.com/library/prerelease/ios/documentation/Swift/Conceptual/BuildingCocoaApps/MixandMatch.html), you will also need an additional bridging file, known as a bridging header, to expose the Objective-C files to Swift. Xcode will offer to create this header file for you if you add your Swift file to your app through the Xcode `File>New File` menu option. You will need to import `RCTBridgeModule.h` in this header file.
+
+```objc
+// CalendarManager-Bridging-Header.h
+#import "RCTBridgeModule.h"
+```
+
 You can also use `RCT_EXTERN_REMAP_MODULE` and `RCT_EXTERN_REMAP_METHOD` to alter the JavaScript name of the module or methods you are exporting. For more information see [`RCTBridgeModule`](https://github.com/facebook/react-native/blob/master/React/Base/RCTBridgeModule.h).

--- a/docs/NativeModulesIOS.md
+++ b/docs/NativeModulesIOS.md
@@ -302,7 +302,7 @@ RCT_EXTERN_METHOD(addEvent:(NSString *)name location:(NSString *)location date:(
 @end
 ```
 
-For those of you new to Swift and Objective-C, whenver you [mix the two languages in an iOS project](https://developer.apple.com/library/prerelease/ios/documentation/Swift/Conceptual/BuildingCocoaApps/MixandMatch.html), you will also need an additional bridging file, known as a bridging header, to expose the Objective-C files to Swift. Xcode will offer to create this header file for you if you add your Swift file to your app through the Xcode `File>New File` menu option. You will need to import `RCTBridgeModule.h` in this header file.
+For those of you new to Swift and Objective-C, whenever you [mix the two languages in an iOS project](https://developer.apple.com/library/prerelease/ios/documentation/Swift/Conceptual/BuildingCocoaApps/MixandMatch.html), you will also need an additional bridging file, known as a bridging header, to expose the Objective-C files to Swift. Xcode will offer to create this header file for you if you add your Swift file to your app through the Xcode `File>New File` menu option. You will need to import `RCTBridgeModule.h` in this header file.
 
 ```objc
 // CalendarManager-Bridging-Header.h


### PR DESCRIPTION
This may be common knowledge for most Swift/ObjC guys, but it took me quite a while to figure out why I was getting an error when creating/exporting my module. As a web guy coming to the "native" world, it was a bit confusing. I would imagine a lot of RCTN users will be in the same boat.

This is in regards to the following issue https://github.com/facebook/react-native/issues/1468