### PR TITLE
Allow live reload even on errors.

### DIFF
--- a/React/Base/RCTBridge.m
+++ b/React/Base/RCTBridge.m
@@ -1087,10 +1087,6 @@ RCT_INNER_BRIDGE_ONLY(_invokeAndProcessModule:(NSString *)module method:(NSStrin
         [[NSNotificationCenter defaultCenter] postNotificationName:RCTJavaScriptDidFailToLoadNotification
                                                             object:_parentBridge
                                                           userInfo:userInfo];
-        
-        [[NSNotificationCenter defaultCenter] postNotificationName:RCTJavaScriptDidLoadNotification
-                                                            object:_parentBridge
-                                                          userInfo:@{ @"bridge": self }];
 
       } else {
 

--- a/React/Base/RCTBridge.m
+++ b/React/Base/RCTBridge.m
@@ -1061,6 +1061,8 @@ RCT_INNER_BRIDGE_ONLY(_invokeAndProcessModule:(NSString *)module method:(NSStrin
 
     RCTJavaScriptLoader *loader = [[RCTJavaScriptLoader alloc] initWithBridge:self];
     [loader loadBundleAtURL:bundleURL onComplete:^(NSError *error, NSString *script) {
+      
+      [[RCTRedBox sharedInstance] dismiss];
 
       _loading = NO;
       if (!self.isValid) {
@@ -1085,6 +1087,17 @@ RCT_INNER_BRIDGE_ONLY(_invokeAndProcessModule:(NSString *)module method:(NSStrin
         [[NSNotificationCenter defaultCenter] postNotificationName:RCTJavaScriptDidFailToLoadNotification
                                                             object:_parentBridge
                                                           userInfo:userInfo];
+        
+        /**
+         * Register the display link to start sending js calls after everything
+         * is setup
+         */
+        NSRunLoop *targetRunLoop = [_javaScriptExecutor isKindOfClass:[RCTContextExecutor class]] ? [NSRunLoop currentRunLoop] : [NSRunLoop mainRunLoop];
+        [_jsDisplayLink addToRunLoop:targetRunLoop forMode:NSRunLoopCommonModes];
+        
+        [[NSNotificationCenter defaultCenter] postNotificationName:RCTJavaScriptDidLoadNotification
+                                                            object:_parentBridge
+                                                          userInfo:@{ @"bridge": self }];
 
       } else {
 

--- a/React/Base/RCTBridge.m
+++ b/React/Base/RCTBridge.m
@@ -1088,13 +1088,6 @@ RCT_INNER_BRIDGE_ONLY(_invokeAndProcessModule:(NSString *)module method:(NSStrin
                                                             object:_parentBridge
                                                           userInfo:userInfo];
         
-        /**
-         * Register the display link to start sending js calls after everything
-         * is setup
-         */
-        NSRunLoop *targetRunLoop = [_javaScriptExecutor isKindOfClass:[RCTContextExecutor class]] ? [NSRunLoop currentRunLoop] : [NSRunLoop mainRunLoop];
-        [_jsDisplayLink addToRunLoop:targetRunLoop forMode:NSRunLoopCommonModes];
-        
         [[NSNotificationCenter defaultCenter] postNotificationName:RCTJavaScriptDidLoadNotification
                                                             object:_parentBridge
                                                           userInfo:@{ @"bridge": self }];

--- a/React/Base/RCTDevMenu.m
+++ b/React/Base/RCTDevMenu.m
@@ -115,6 +115,11 @@ RCT_EXPORT_MODULE()
                            selector:@selector(jsLoaded:)
                                name:RCTJavaScriptDidLoadNotification
                              object:nil];
+    
+    [notificationCenter addObserver:self
+                           selector:@selector(jsLoaded:)
+                               name:RCTJavaScriptDidFailToLoadNotification
+                             object:nil];
 
     _defaults = [NSUserDefaults standardUserDefaults];
     _settings = [[NSMutableDictionary alloc] init];


### PR DESCRIPTION
Live reload is disabled when an error has occurred. This requires the developer to fix the error and then switch to the simulator to reload the device manually; impacting developer flow and increasing alt tabbing. This pull request fixes that by allowing live reload to work even on errors.

This fixes issue: #1343.