### PR TITLE
Added support for React installed in the application via Cocoapods

### DIFF
--- a/packager/packager.js
+++ b/packager/packager.js
@@ -63,6 +63,9 @@ if (options.projectRoots) {
   if (__dirname.match(/node_modules\/react-native\/packager$/)) {
     // packager is running from node_modules of another project
     options.projectRoots = [path.resolve(__dirname, '../../..')];
+  } else if (__dirname.match(/Pods\/React\/packager$/)) {
+    // packager is running from node_modules of another project
+    options.projectRoots = [path.resolve(__dirname, '../../..')];
   } else {
     options.projectRoots = [path.resolve(__dirname, '..')];
   }
@@ -84,6 +87,8 @@ if (options.assetRoots) {
   }
 } else {
   if (__dirname.match(/node_modules\/react-native\/packager$/)) {
+    options.assetRoots = [path.resolve(__dirname, '../../..')];
+  } else if (__dirname.match(/Pods\/React\/packager$/)) {
     options.assetRoots = [path.resolve(__dirname, '../../..')];
   } else {
     options.assetRoots = [path.resolve(__dirname, '..')];


### PR DESCRIPTION
Similarly to npm-installed react, this change makes changes to the packager so that it understands that it's been installed via Cocoapods and determines the project and asset roots properly (from the main application directory).