### PR TITLE
[Docs] Note about transformMatrix

### DIFF
--- a/Libraries/StyleSheet/TransformPropTypes.js
+++ b/Libraries/StyleSheet/TransformPropTypes.js
@@ -23,6 +23,12 @@ var TransformPropTypes = {
       ReactPropTypes.shape({translateY: ReactPropTypes.number})
     ])
   ),
+
+  /*
+   * `transformMatrix` accepts a 4x4 matrix expressed as a row-major ordered
+   * array. This property is DEPRECATED and cannot be used simultaneously with
+   * the `transform` property.
+   */
   transformMatrix: ReactPropTypes.arrayOf(ReactPropTypes.number),
 
   // DEPRECATED


### PR DESCRIPTION
For documentation about how `transformMatrix` cannot be used simultaneously with `transform`.  Also, deprecation warning for `transformMatrix`.