### PR TITLE
[Pods] Define a subspec for LinkingIOS

### DIFF
--- a/React.podspec
+++ b/React.podspec
@@ -103,4 +103,10 @@ Pod::Spec.new do |s|
     ss.source_files     = "Libraries/WebSocket/*.{h,m}"
     ss.preserve_paths   = "Libraries/WebSocket/*.js"
   end
+
+  s.subspec 'RCTLinkingIOS' do |ss|
+    ss.dependency         'React/Core'
+    ss.source_files     = "Libraries/LinkingIOS/*.{h,m}"
+    ss.preserve_paths   = "Libraries/LinkingIOS/*.js"
+  end
 end


### PR DESCRIPTION
Summary:
Adds a CocoaPods subspec for LinkingIOS

Discussed in issue #667

Test Plan:  Pull in the subspec and run a sample which calls
RCTLinkingManager.openURL(url);