### PR TITLE
Sort StyleProps alphabetically

### DIFF
--- a/Libraries/StyleSheet/StyleSheetValidation.js
+++ b/Libraries/StyleSheet/StyleSheetValidation.js
@@ -26,7 +26,7 @@ class StyleSheetValidation {
     if (allStylePropTypes[prop] === undefined) {
       var message1 = '"' + prop + '" is not a valid style property.';
       var message2 = '\nValid style props: ' +
-        JSON.stringify(Object.keys(allStylePropTypes), null, '  ');
+        JSON.stringify(Object.keys(allStylePropTypes).sort(), null, '  ');
       styleError(message1, style, caller, message2);
     }
     var error = allStylePropTypes[prop](


### PR DESCRIPTION
Sorting the StyleProps alphabetically makes it easier to scan through the list of available props e.g. in case of typos.

Filled out the FB CLA form just now.

Related to #1605 