### PR TITLE
[ListView] Update curRenderedRowsCount when data source changes

### DIFF
--- a/Libraries/CustomComponents/ListView/ListView.js
+++ b/Libraries/CustomComponents/ListView/ListView.js
@@ -262,7 +262,16 @@ var ListView = React.createClass({
 
   componentWillReceiveProps: function(nextProps) {
     if (this.props.dataSource !== nextProps.dataSource) {
-      this.setState({prevRenderedRowsCount: 0});
+      this.setState((state, props) => {
+        var rowsToRender = Math.min(
+          state.curRenderedRowsCount + props.pageSize,
+          props.dataSource.getRowCount()
+        );
+        return {
+          prevRenderedRowsCount: 0,
+          curRenderedRowsCount: rowsToRender,
+        };
+      });
     }
   },
 
@@ -412,22 +421,21 @@ var ListView = React.createClass({
   },
 
   _pageInNewRows: function() {
-    var rowsToRender = Math.min(
-      this.state.curRenderedRowsCount + this.props.pageSize,
-      this.props.dataSource.getRowCount()
-    );
-    this.setState(
-      {
-        prevRenderedRowsCount: this.state.curRenderedRowsCount,
+    this.setState((state, props) => {
+      var rowsToRender = Math.min(
+        state.curRenderedRowsCount + props.pageSize,
+        props.dataSource.getRowCount()
+      );
+      return {
+        prevRenderedRowsCount: state.curRenderedRowsCount,
         curRenderedRowsCount: rowsToRender
-      },
-      () => {
-        this._measureAndUpdateScrollProps();
-        this.setState({
-          prevRenderedRowsCount: this.state.curRenderedRowsCount,
-        });
-      }
-    );
+      };
+    }, () => {
+      this._measureAndUpdateScrollProps();
+      this.setState(state => ({
+        prevRenderedRowsCount: state.curRenderedRowsCount,
+      }));
+    });
   },
 
   _getDistanceFromEnd: function(scrollProperties) {


### PR DESCRIPTION
When a new data source is provided, update `curRenderedRowsCount` in addition to `prevRenderedRowsCount`. What was happening is that I had an empty data source, so `curRenderedRowsCount` and `prevRenderedRowsCount` both settled at zero after the first few frames and `curRenderedRowsCount` wasn't getting increased when the data source was updated.

I also changed the `setState` calls to use the transactional API since several of the new state values are computed from the old ones.

Maybe fixes #1547