### PR TITLE
add local notification api schedule and present

### DIFF
--- a/Libraries/PushNotificationIOS/PushNotificationIOS.js
+++ b/Libraries/PushNotificationIOS/PushNotificationIOS.js
@@ -36,6 +36,31 @@ class PushNotificationIOS {
   _badgeCount: number;
 
   /**
+   * Schedules the localNotification for immediate presentation.
+   *
+   * details is an object containing:
+   *
+   * - `alertBody` : The message displayed in the notification alert.
+   *
+   */
+  static presentLocalNotification(details: object) {
+    RCTPushNotificationManager.presentLocalNotification(details);
+  }
+
+  /**
+   * Schedules the localNotification for future presentation.
+   *
+   * details is an object containing:
+   *
+   * - `fireDate` : The date and time when the system should deliver the notification.
+   * - `alertBody` : The message displayed in the notification alert.
+   *
+   */
+  static scheduleLocalNotification(details: object) {
+    RCTPushNotificationManager.scheduleLocalNotification(details);
+  }
+
+  /**
    * Sets the badge number for the app icon on the home screen
    */
   static setApplicationIconBadgeNumber(number: number) {

--- a/Libraries/PushNotificationIOS/RCTPushNotificationManager.m
+++ b/Libraries/PushNotificationIOS/RCTPushNotificationManager.m
@@ -11,6 +11,7 @@
 
 #import "RCTBridge.h"
 #import "RCTEventDispatcher.h"
+#import "RCTConvert.h"
 
 #if __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_8_0
 
@@ -174,6 +175,27 @@ RCT_EXPORT_METHOD(checkPermissions:(RCTResponseSenderBlock)callback)
   return @{
     @"initialNotification": _initialNotification ?: [NSNull null]
   };
+}
+
+- (UILocalNotification *)createNotification:(NSDictionary*)details
+{
+  UILocalNotification *notification = [UILocalNotification new];
+
+  notification.fireDate = details[@"fireDate"] ? [RCTConvert NSDate:details[@"fireDate"]] : [NSDate new];
+  notification.alertBody = details[@"alertBody"] ? [RCTConvert NSString:details[@"alertBody"]] : nil;
+
+  return notification;
+}
+
+RCT_EXPORT_METHOD(presentLocalNotification:(NSDictionary *)details)
+{
+  [[UIApplication sharedApplication] presentLocalNotificationNow:[self createNotification:details]];
+}
+
+
+RCT_EXPORT_METHOD(scheduleLocalNotification:(NSDictionary *)details)
+{
+  [[UIApplication sharedApplication] scheduleLocalNotification:[self createNotification:details]];
 }
 
 @end


### PR DESCRIPTION
Add local notifications to the push library. 
```
  var PushNotificationIOS = React.PushNotificationIOS;
  PushNotificationIOS.requestPermissions();

  var notification = {
    "fireDate": Date.now() + 10000,
    "alertBody":"Whats up pumpkin"
  };

  PushNotificationIOS.scheduleLocalNotification(notification);
 //lock screen or move away from app
```

Apple has another api for pushing immediately instead of scheduling, like when your background delegate has been called with some new data (bluetooth, location, etc)
```
  var PushNotificationIOS = React.PushNotificationIOS;
  PushNotificationIOS.requestPermissions();

  var notification = {
    "alertBody":"Whats up pumpkin"
  };

  PushNotificationIOS.presentLocalNotification(notification);
 //lock screen or move away from app
```

Closed https://github.com/facebook/react-native/pull/843 looks related:

See https://developer.apple.com/library/ios/documentation/iPhone/Reference/UILocalNotification_Class/ for much more available in the api for eventual implementation.