### PR TITLE
Add support for selecting media from library

### DIFF
--- a/Libraries/Utilities/ImagePickerIOS.js
+++ b/Libraries/Utilities/ImagePickerIOS.js
@@ -14,7 +14,7 @@
 var RCTImagePicker = require('NativeModules').ImagePickerIOS;
 
 var ImagePickerIOS = {
-  openSelectDialog: function(config, successCallback, cancelCallback) {
+  openSelectDialog: function(config: Object, successCallback: Function, cancelCallback: Function) {
     var successCallback = successCallback || function () {};
     var cancelCallback = cancelCallback || function () {};
     var defaultConfig = {

--- a/Libraries/Utilities/ImagePickerIOS.js
+++ b/Libraries/Utilities/ImagePickerIOS.js
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule ImagePickerIOS
+ * @flow
+ */
+'use strict';
+
+var RCTImagePicker = require('NativeModules').ImagePickerIOS;
+
+var ImagePickerIOS = {
+  openSelectDialog: function(config, successCallback, cancelCallback) {
+    var successCallback = successCallback || function () {};
+    var cancelCallback = cancelCallback || function () {};
+
+    return RCTImagePicker.openSelectDialog(config, successCallback, cancelCallback);
+  },
+};
+
+module.exports = ImagePickerIOS;

--- a/Libraries/Utilities/ImagePickerIOS.js
+++ b/Libraries/Utilities/ImagePickerIOS.js
@@ -14,6 +14,27 @@
 var RCTImagePicker = require('NativeModules').ImagePickerIOS;
 
 var ImagePickerIOS = {
+  canRecordVideos: function(callback) {
+    var callback = callback || function () {};
+    return RCTImagePicker.canRecordVideos(callback);
+  },
+  canUseCamera: function(callback) {
+    var callback = callback || function () {};
+    return RCTImagePicker.canUseCamera(callback);
+  },
+  openCameraDialog: function(config: Object, successCallback: Function, cancelCallback: Function) {
+    var successCallback = successCallback || function () {};
+    var cancelCallback = cancelCallback || function () {};
+    var defaultConfig = {
+      videoMode: false
+    }
+
+    for (var c in config) {
+      defaultConfig[c] = config[c];
+    }
+
+    return RCTImagePicker.openCameraDialog(defaultConfig, successCallback, cancelCallback);
+  },
   openSelectDialog: function(config: Object, successCallback: Function, cancelCallback: Function) {
     var successCallback = successCallback || function () {};
     var cancelCallback = cancelCallback || function () {};

--- a/Libraries/Utilities/ImagePickerIOS.js
+++ b/Libraries/Utilities/ImagePickerIOS.js
@@ -17,8 +17,16 @@ var ImagePickerIOS = {
   openSelectDialog: function(config, successCallback, cancelCallback) {
     var successCallback = successCallback || function () {};
     var cancelCallback = cancelCallback || function () {};
+    var defaultConfig = {
+      showImages: true,
+      showVideos: false
+    }
 
-    return RCTImagePicker.openSelectDialog(config, successCallback, cancelCallback);
+    for (var c in config) {
+      defaultConfig[c] = config[c];
+    }
+
+    return RCTImagePicker.openSelectDialog(defaultConfig, successCallback, cancelCallback);
   },
 };
 

--- a/Libraries/Utilities/ImagePickerIOS.js
+++ b/Libraries/Utilities/ImagePickerIOS.js
@@ -14,11 +14,11 @@
 var RCTImagePicker = require('NativeModules').ImagePickerIOS;
 
 var ImagePickerIOS = {
-  canRecordVideos: function(callback) {
+  canRecordVideos: function(callback: Function) {
     var callback = callback || function () {};
     return RCTImagePicker.canRecordVideos(callback);
   },
-  canUseCamera: function(callback) {
+  canUseCamera: function(callback: Function) {
     var callback = callback || function () {};
     return RCTImagePicker.canUseCamera(callback);
   },

--- a/Libraries/react-native/react-native.js
+++ b/Libraries/react-native/react-native.js
@@ -43,6 +43,7 @@ var ReactNative = Object.assign(Object.create(require('React')), {
 
   // APIs
   AlertIOS: require('AlertIOS'),
+  ImagePickerIOS: require('ImagePickerIOS'),
   AppRegistry: require('AppRegistry'),
   AppStateIOS: require('AppStateIOS'),
   AsyncStorage: require('AsyncStorage'),

--- a/React.podspec
+++ b/React.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                = "React"
-  s.version             = "0.4.4"
+  s.version             = "0.6.0-rc"
   s.summary             = "Build high quality mobile apps using React."
   s.description         = <<-DESC
                             React Native apps are built using the React JS

--- a/React/Modules/RCTImagePickerController.h
+++ b/React/Modules/RCTImagePickerController.h
@@ -1,0 +1,14 @@
+//
+//  RCTImagePickerController.h
+//  React
+//
+//  Created by David Mohl on 5/16/15.
+//  Copyright (c) 2015 Facebook. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+#import "RCTViewManager.h"
+
+@interface RCTImagePickerController : RCTViewManager
+
+@end

--- a/React/Modules/RCTImagePickerController.m
+++ b/React/Modules/RCTImagePickerController.m
@@ -1,0 +1,16 @@
+//
+//  RCTImagePickerController.m
+//  React
+//
+//  Created by David Mohl on 5/16/15.
+//  Copyright (c) 2015 Facebook. All rights reserved.
+//
+
+#import "RCTImagePickerController.h"
+#import "RCTViewManager.h"
+
+@implementation RCTImagePickerController
+
+RCT_EXPORT_MODULE()
+
+@end

--- a/React/Modules/RCTImagePickerManager.h
+++ b/React/Modules/RCTImagePickerManager.h
@@ -1,0 +1,14 @@
+//
+//  RCTImagePickerManager.h
+//  React
+//
+//  Created by David Mohl on 6/13/15.
+//  Copyright © 2015 Facebook. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "RCTBridgeModule.h"
+#import <UIKit/UIKit.h>
+
+@interface RCTImagePickerManager : UIViewController <RCTBridgeModule,UIImagePickerControllerDelegate,UINavigationControllerDelegate>
+@end

--- a/React/Modules/RCTImagePickerManager.m
+++ b/React/Modules/RCTImagePickerManager.m
@@ -1,0 +1,88 @@
+//
+//  RCTImagePickerManager.m
+//  React
+//
+//  Created by David Mohl on 6/13/15.
+//  Copyright © 2015 Facebook. All rights reserved.
+//
+
+#import "RCTImagePickerManager.h"
+#import "RCTRootView.h"
+
+@implementation RCTImagePickerManager
+{
+  NSMutableArray *_pickers;
+  NSMutableArray *_pickerCallbacks;
+  NSMutableArray *_pickerCancelCallbacks;
+}
+
+RCT_EXPORT_MODULE(ImagePicker);
+
+- (instancetype)init {
+  if ((self = [super init])) {
+    _pickers = [[NSMutableArray alloc] init];
+    _pickerCallbacks = [[NSMutableArray alloc] init];
+    _pickerCancelCallbacks = [[NSMutableArray alloc] init];
+  }
+  return self;
+}
+
+- (void)viewDidLoad {
+  [super viewDidLoad];
+}
+
+RCT_EXPORT_METHOD(selectPhoto:(RCTResponseSenderBlock)callback onCancel:(RCTResponseSenderBlock)errorCallback)
+{
+  NSLog(@"Doing something cool now");
+
+  UIWindow *keyWindow = [[UIApplication sharedApplication] keyWindow];
+  UIViewController *rootViewController = keyWindow.rootViewController;
+
+  UIImagePickerController *imagePicker = [[UIImagePickerController alloc] init];
+  imagePicker.delegate = self;
+
+  [_pickers addObject:imagePicker];
+  [_pickerCallbacks addObject:callback];
+  [_pickerCancelCallbacks addObject:errorCallback];
+
+  [rootViewController presentViewController:imagePicker animated:YES completion:nil];
+}
+
+-(void)imagePickerController:(UIImagePickerController *)picker didFinishPickingMediaWithInfo:(NSDictionary *)info
+{
+  NSUInteger index = [_pickers indexOfObject:picker];
+  RCTResponseSenderBlock callback = _pickerCallbacks[index];
+
+  NSLog(@"%@", info);
+
+  [_pickers removeObjectAtIndex:index];
+  [_pickerCallbacks removeObjectAtIndex:index];
+  [_pickerCancelCallbacks removeObjectAtIndex:index];
+
+  UIWindow *keyWindow = [[UIApplication sharedApplication] keyWindow];
+  UIViewController *rootViewController = keyWindow.rootViewController;
+  [rootViewController dismissViewControllerAnimated:YES completion:nil];
+
+  callback(@[
+             [info[UIImagePickerControllerReferenceURL] absoluteString]
+             ]);
+}
+
+- (void)imagePickerControllerDidCancel:(UIImagePickerController *)picker
+{
+
+  NSUInteger index = [_pickers indexOfObject:picker];
+  RCTResponseSenderBlock callback = _pickerCancelCallbacks[index];
+
+  [_pickers removeObjectAtIndex:index];
+  [_pickerCallbacks removeObjectAtIndex:index];
+  [_pickerCancelCallbacks removeObjectAtIndex:index];
+
+  UIWindow *keyWindow = [[UIApplication sharedApplication] keyWindow];
+  UIViewController *rootViewController = keyWindow.rootViewController;
+  [rootViewController dismissViewControllerAnimated:YES completion:nil];
+
+  callback(@[]);
+}
+
+@end

--- a/React/Modules/RCTImagePickerManager.m
+++ b/React/Modules/RCTImagePickerManager.m
@@ -8,6 +8,7 @@
 
 #import "RCTImagePickerManager.h"
 #import "RCTRootView.h"
+#import <MobileCoreServices/UTCoreTypes.h>
 
 @implementation RCTImagePickerManager
 {
@@ -31,19 +32,29 @@ RCT_EXPORT_MODULE(ImagePicker);
   [super viewDidLoad];
 }
 
-RCT_EXPORT_METHOD(selectPhoto:(RCTResponseSenderBlock)callback onCancel:(RCTResponseSenderBlock)errorCallback)
+RCT_EXPORT_METHOD(selectPhoto:(NSDictionary *)config andSuccessCallback:(RCTResponseSenderBlock)callback andCancelCallback:(RCTResponseSenderBlock)cancelCallback)
 {
-  NSLog(@"Doing something cool now");
-
   UIWindow *keyWindow = [[UIApplication sharedApplication] keyWindow];
   UIViewController *rootViewController = keyWindow.rootViewController;
 
   UIImagePickerController *imagePicker = [[UIImagePickerController alloc] init];
   imagePicker.delegate = self;
+  imagePicker.sourceType = UIImagePickerControllerSourceTypePhotoLibrary;
+
+  NSMutableArray *allowedTypes = [[NSMutableArray alloc] init];
+  if ([config[@"showImages"] boolValue]) {
+    [allowedTypes addObject:(NSString *)kUTTypeImage];
+  }
+  
+  if ([config[@"showVideos"] boolValue]) {
+    [allowedTypes addObject:(NSString *)kUTTypeMovie];
+  }
+  
+  imagePicker.mediaTypes = allowedTypes;
 
   [_pickers addObject:imagePicker];
   [_pickerCallbacks addObject:callback];
-  [_pickerCancelCallbacks addObject:errorCallback];
+  [_pickerCancelCallbacks addObject:cancelCallback];
 
   [rootViewController presentViewController:imagePicker animated:YES completion:nil];
 }
@@ -52,8 +63,6 @@ RCT_EXPORT_METHOD(selectPhoto:(RCTResponseSenderBlock)callback onCancel:(RCTResp
 {
   NSUInteger index = [_pickers indexOfObject:picker];
   RCTResponseSenderBlock callback = _pickerCallbacks[index];
-
-  NSLog(@"%@", info);
 
   [_pickers removeObjectAtIndex:index];
   [_pickerCallbacks removeObjectAtIndex:index];

--- a/React/Modules/RCTImagePickerManager.m
+++ b/React/Modules/RCTImagePickerManager.m
@@ -32,6 +32,41 @@ RCT_EXPORT_MODULE(ImagePickerIOS);
   [super viewDidLoad];
 }
 
+RCT_EXPORT_METHOD(canRecordVideos:(RCTResponseSenderBlock)callback)
+{
+  NSArray *availableMediaTypes = [UIImagePickerController availableMediaTypesForSourceType:UIImagePickerControllerSourceTypeCamera];
+  callback(@[
+      [NSNumber numberWithBool:[availableMediaTypes containsObject:(NSString *)kUTTypeMovie]]
+      ]);
+}
+
+RCT_EXPORT_METHOD(canUseCamera:(RCTResponseSenderBlock)callback)
+{
+  callback(@[
+      [NSNumber numberWithBool:[UIImagePickerController isSourceTypeAvailable:UIImagePickerControllerSourceTypeCamera]]
+      ]);
+}
+
+RCT_EXPORT_METHOD(openCameraDialog:(NSDictionary *)config andSuccessCallback:(RCTResponseSenderBlock)callback andCancelCallback:(RCTResponseSenderBlock)cancelCallback)
+{
+  UIWindow *keyWindow = [[UIApplication sharedApplication] keyWindow];
+  UIViewController *rootViewController = keyWindow.rootViewController;
+
+  UIImagePickerController *imagePicker = [[UIImagePickerController alloc] init];
+  imagePicker.delegate = self;
+  imagePicker.sourceType = UIImagePickerControllerSourceTypeCamera;
+
+  if ([config[@"videoMode"] boolValue]) {
+    imagePicker.cameraCaptureMode = UIImagePickerControllerCameraCaptureModeVideo;
+  }
+
+  [_pickers addObject:imagePicker];
+  [_pickerCallbacks addObject:callback];
+  [_pickerCancelCallbacks addObject:cancelCallback];
+
+  [rootViewController presentViewController:imagePicker animated:YES completion:nil];
+}
+
 RCT_EXPORT_METHOD(openSelectDialog:(NSDictionary *)config andSuccessCallback:(RCTResponseSenderBlock)callback andCancelCallback:(RCTResponseSenderBlock)cancelCallback)
 {
   UIWindow *keyWindow = [[UIApplication sharedApplication] keyWindow];
@@ -45,11 +80,11 @@ RCT_EXPORT_METHOD(openSelectDialog:(NSDictionary *)config andSuccessCallback:(RC
   if ([config[@"showImages"] boolValue]) {
     [allowedTypes addObject:(NSString *)kUTTypeImage];
   }
-  
+
   if ([config[@"showVideos"] boolValue]) {
     [allowedTypes addObject:(NSString *)kUTTypeMovie];
   }
-  
+
   imagePicker.mediaTypes = allowedTypes;
 
   [_pickers addObject:imagePicker];

--- a/React/Modules/RCTImagePickerManager.m
+++ b/React/Modules/RCTImagePickerManager.m
@@ -17,7 +17,7 @@
   NSMutableArray *_pickerCancelCallbacks;
 }
 
-RCT_EXPORT_MODULE(ImagePicker);
+RCT_EXPORT_MODULE(ImagePickerIOS);
 
 - (instancetype)init {
   if ((self = [super init])) {
@@ -32,7 +32,7 @@ RCT_EXPORT_MODULE(ImagePicker);
   [super viewDidLoad];
 }
 
-RCT_EXPORT_METHOD(selectPhoto:(NSDictionary *)config andSuccessCallback:(RCTResponseSenderBlock)callback andCancelCallback:(RCTResponseSenderBlock)cancelCallback)
+RCT_EXPORT_METHOD(openSelectDialog:(NSDictionary *)config andSuccessCallback:(RCTResponseSenderBlock)callback andCancelCallback:(RCTResponseSenderBlock)cancelCallback)
 {
   UIWindow *keyWindow = [[UIApplication sharedApplication] keyWindow];
   UIViewController *rootViewController = keyWindow.rootViewController;

--- a/React/React.xcodeproj/project.pbxproj
+++ b/React/React.xcodeproj/project.pbxproj
@@ -59,6 +59,8 @@
 		58114A171AAE854800E7D092 /* RCTPickerManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 58114A151AAE854800E7D092 /* RCTPickerManager.m */; };
 		58114A501AAE93D500E7D092 /* RCTAsyncLocalStorage.m in Sources */ = {isa = PBXBuildFile; fileRef = 58114A4E1AAE93D500E7D092 /* RCTAsyncLocalStorage.m */; };
 		58C571C11AA56C1900CDF9C8 /* RCTDatePickerManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 58C571BF1AA56C1900CDF9C8 /* RCTDatePickerManager.m */; };
+		63EC66F51B2C0FC9006B8A09 /* RCTImagePickerManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 63EC66F41B2C0FC9006B8A09 /* RCTImagePickerManager.m */; };
+		63F014C01B02080B003B75D2 /* RCTPointAnnotation.m in Sources */ = {isa = PBXBuildFile; fileRef = 63F014BF1B02080B003B75D2 /* RCTPointAnnotation.m */; };
 		830A229E1A66C68A008503DA /* RCTRootView.m in Sources */ = {isa = PBXBuildFile; fileRef = 830A229D1A66C68A008503DA /* RCTRootView.m */; };
 		830BA4551A8E3BDA00D53203 /* RCTCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 830BA4541A8E3BDA00D53203 /* RCTCache.m */; };
 		832348161A77A5AA00B55238 /* Layout.c in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FC71A68125100A75B9A /* Layout.c */; };
@@ -198,6 +200,10 @@
 		58114A4F1AAE93D500E7D092 /* RCTAsyncLocalStorage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTAsyncLocalStorage.h; sourceTree = "<group>"; };
 		58C571BF1AA56C1900CDF9C8 /* RCTDatePickerManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTDatePickerManager.m; sourceTree = "<group>"; };
 		58C571C01AA56C1900CDF9C8 /* RCTDatePickerManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTDatePickerManager.h; sourceTree = "<group>"; };
+		63EC66F31B2C0FC9006B8A09 /* RCTImagePickerManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTImagePickerManager.h; sourceTree = "<group>"; };
+		63EC66F41B2C0FC9006B8A09 /* RCTImagePickerManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTImagePickerManager.m; sourceTree = "<group>"; };
+		63F014BE1B02080B003B75D2 /* RCTPointAnnotation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTPointAnnotation.h; sourceTree = "<group>"; };
+		63F014BF1B02080B003B75D2 /* RCTPointAnnotation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTPointAnnotation.m; sourceTree = "<group>"; };
 		830213F31A654E0800B993E6 /* RCTBridgeModule.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RCTBridgeModule.h; sourceTree = "<group>"; };
 		830A229C1A66C68A008503DA /* RCTRootView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTRootView.h; sourceTree = "<group>"; };
 		830A229D1A66C68A008503DA /* RCTRootView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTRootView.m; sourceTree = "<group>"; };
@@ -276,6 +282,10 @@
 				13B07FEE1A69327A00A75B9A /* RCTTiming.m */,
 				13E067481A70F434002CDEE1 /* RCTUIManager.h */,
 				13E067491A70F434002CDEE1 /* RCTUIManager.m */,
+				63F014BE1B02080B003B75D2 /* RCTPointAnnotation.h */,
+				63F014BF1B02080B003B75D2 /* RCTPointAnnotation.m */,
+				63EC66F31B2C0FC9006B8A09 /* RCTImagePickerManager.h */,
+				63EC66F41B2C0FC9006B8A09 /* RCTImagePickerManager.m */,
 			);
 			path = Modules;
 			sourceTree = "<group>";
@@ -573,6 +583,7 @@
 				134FCB3E1A6E7F0800051CC8 /* RCTWebViewExecutor.m in Sources */,
 				13B0801C1A69489C00A75B9A /* RCTNavItem.m in Sources */,
 				1403F2B31B0AE60700C2A9A4 /* RCTPerfStats.m in Sources */,
+				63EC66F51B2C0FC9006B8A09 /* RCTImagePickerManager.m in Sources */,
 				83CBBA691A601EF300E9B192 /* RCTEventDispatcher.m in Sources */,
 				13E0674A1A70F434002CDEE1 /* RCTUIManager.m in Sources */,
 				13B0801B1A69489C00A75B9A /* RCTNavigatorManager.m in Sources */,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native",
-  "version": "0.4.4",
+  "version": "0.6.0-rc",
   "description": "A framework for building native apps using React",
   "license": "BSD-3-Clause",
   "repository": {

--- a/website/server/extractDocs.js
+++ b/website/server/extractDocs.js
@@ -187,6 +187,7 @@ var apis = [
   '../Libraries/Components/StatusBar/StatusBarIOS.ios.js',
   '../Libraries/StyleSheet/StyleSheet.js',
   '../Libraries/Vibration/VibrationIOS.ios.js',
+  '../Libraries/Utilities/ImagePickerIOS.ios.js',
 ];
 
 var styles = [


### PR DESCRIPTION
This PR adds support for UIImagePickerController to allow selecting a photo / video from the users camera roll. 

![ios simulator screen shot jun 14 2015 4 50 03 pm](https://cloud.githubusercontent.com/assets/688326/8147758/ae6dc8d4-12b6-11e5-80f0-2bcaa964a5d8.png)

Example: 

Selecting something from camera roll
```
ImagePickerIOS.openSelectDialog(<config>, <successCallback>, <cancelCallback>);

ImagePickerIOS.openSelectDialog({
   showImages: true, // defaults to true
   showVideos: false // defaults to false
}, function (data) {
  console.info("Got a callback!");
  console.info(data); // file URL as in assets-library://asset/asset.JPG?id=E2741A73-D185-44B6-A2E6-2D55F69CD088&ext=JPG
}, function() {
  console.info("Cancelled");
});
```

Using camera
```
ImagePickerIOS.openCameraDialog(<config>, <successCallback>, <cancelCallback>);

ImagePickerIOS.openSelectDialog({
   videoMode: false, // defaults to true, whether to record videos instead
}, function (data) {
  console.info("Got a callback!");
  console.info(data); // file URL as in assets-library://asset/asset.JPG?id=E2741A73-D185-44B6-A2E6-2D55F69CD088&ext=JPG
}, function() {
  console.info("Cancelled");
});
```

I also implemented `canRecordVideos` and `canUseCamera` for devices that are either not capable of shooting a picture or video. 
```
ImagePickerIOS.canRecordVideos(callback);
ImagePickerIOS.canUseCamera(callback);
```