### PR TITLE
Enable jest unit testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "init.sh",
     "LICENSE",
     "PATENTS",
-    "README.md"
+    "README.md",
+    "jestSupport"
   ],
   "scripts": {
     "test": "jest",

--- a/packager/transformer.js
+++ b/packager/transformer.js
@@ -15,8 +15,8 @@ var babel = require('babel');
 function transform(srcTxt, filename, options) {
   var result = babel.transform(srcTxt, {
     retainLines: true,
-    compact: true,
-    comments: false,
+    compact: false,
+    comments: true,
     filename: filename,
     whitelist: [
       'es6.arrowFunctions',
@@ -36,6 +36,7 @@ function transform(srcTxt, filename, options) {
     sourceFileName: filename,
     sourceMaps: false,
     extra: options || {},
+    auxiliaryCommentBefore: "istanbul ignore next",
   });
 
   return {


### PR DESCRIPTION
I would like to unit test my React Native javascript code using Jest, to do that I need to transform my code in the same way the packager does.

React Native has a Jest scriptPreprocessor and setupEnvScriptFile but does not include them in the npm package. This pull request adds jestSupport to the npm package.

To enable accurate code coverage we need to also ignore babel generated code using istanbul ignore statements. This pull request allows for use of istanbul ignore statements.

The following commits along with the jest configuration has allowed my team to unit test with React Native and have accurate code coverage.

Let me know what I need to do to get this merged.

```
"jest": {
    "scriptPreprocessor": "<rootDir>/node_modules/react-native/jestSupport/scriptPreprocess.js",
    "setupEnvScriptFile": "<rootDir>/node_modules/react-native/jestSupport/env.js",
    "testFileExtensions": [
      "js"
    ],
    "unmockedModulePathPatterns": [
      "source-map"
    ],
    "collectCoverage": true
  }
```