### PR TITLE
Fixed inline function to process last symbol (iOS9)

### DIFF
--- a/Libraries/Utilities/buildStyleInterpolator.js
+++ b/Libraries/Utilities/buildStyleInterpolator.js
@@ -116,7 +116,7 @@ var inline = function(func, replaceWithArgs) {
     return '\\b' + paramName + '\\b';
   }).join('|');
   var replaceRegex = new RegExp(replaceRegexStr, 'g');
-  var fnBody = fnStr.substring(fnStr.indexOf('{') + 1, fnStr.lastIndexOf('}') - 1);
+  var fnBody = fnStr.substring(fnStr.indexOf('{') + 1, fnStr.lastIndexOf('}'));
   var newFnBody = fnBody.replace(replaceRegex, function(parameterName) {
     var indexInParameterNames = parameterNames.indexOf(parameterName);
     var replacementName = replaceWithArgs[indexInParameterNames];


### PR DESCRIPTION
### TL/DR: 
```
a="function() {return [22]}" 
a.substring(a.indexOf("{")+1,a.indexOf("}")-1) // "return [22"
a.substring(a.indexOf("{")+1,a.indexOf("}")) // "return [22]"
```

### In long: why it is broken now and why it worked before:

I've installed latest iOS 9 and started to see really strange issues when code is minified:
```
Invariant Violation: Application app has not been registered."
2015-06-18 16:29:05.898 [error][tid:com.facebook.React.JavaScript] "Error: Unexpected identifier 'transformMatrix'. Expected ']' to end a subscript expression
```

After some investigation it turns out that new Safari returned a bit different string representation for a MatrixOps.unroll. On old safari:
`function(e,t,n,r,o,i,a,s,u,c,l,p,d,h,f,m,g){t=e[0],n=e[1],r=e[2],o=e[3],i=e[4],a=e[5],s=e[6],u=e[7],c=e[8],l=e[9],p=e[10],d=e[11],h=e[12],f=e[13],m=e[14],g=e[15];}` 
while using latest iOS:
`function (e,t,n,r,o,i,a,s,u,c,l,p,d,h,f,m,g){t=e[0],n=e[1],r=e[2],o=e[3],i=e[4],a=e[5],s=e[6],u=e[7],c=e[8],l=e[9],p=e[10],d=e[11],h=e[12],f=e[13],m=e[14],g=e[15]}`

Notice additional ; when using old Safari.

So later on when setNextMatrixAndDetectChange is executed it generates the code like:
```
...
var transformMatrix = result.transformMatrix !== undefined ? result.transformMatrix : (result.transformMatrix = []);
m0=transformMatrix[0],m1=transformMatrix[1],m2=transformMatrix[2],m3=transformMatrix[3],m4=transformMatrix[4],m5=transformMatrix[5],m6=transformMatrix[6],m7=transformMatrix[7],m8=transformMatrix[8],m9=transformMatrix[9],m10=transformMatrix[10],m11=transformMatrix[11],m12=transformMatrix[12],m13=transformMatrix[13],m14=transformMatrix[14],m15=transformMatrix[15
transformMatrix[0]=1,transformMatrix[1]=0,transformMatrix[2]=0,transformMatrix[3]=0,transformMatrix[4]=0,transformMatrix[5]=1,transformMatrix[6]=0,transformMatrix[7]=0,transformMatrix[8]=0,transformMatrix[9]=0,transformMatrix[10]=1,transformMatrix[11]=0,transformMatrix[12]=transformTranslateReuseOp[0],transformMatrix[13]=transformTranslateReuseOp[1],transformMatrix[14]=transformTranslateReuseOp[2],transformMatrix[15]=
didChange=didChange||m0!==transformMatrix[0]||m1!==transformMatrix[1]||m2!==transformMatrix[2]||m3!==transformMatrix[3]||m4!==transformMatrix[4]||m5!==transformMatrix[5]||m6!==transformMatrix[6]||m7!==transformMatrix[7]||m8!==transformMatrix[8]||m9!==transformMatrix[9]||m10!==transformMatrix[10]||m11!==transformMatrix[11]||m12!==transformMatrix[12]||m13!==transformMatrix[13]||m14!==transformMatrix[14]||m15!==transformMatrix[15
  return didChange;
};
```

which is missing latest ]