### PR TITLE
[Image] Remove resizeMode from nativeOnlyProps to get rid of warning

### DIFF
--- a/Libraries/Image/Image.ios.js
+++ b/Libraries/Image/Image.ios.js
@@ -178,7 +178,6 @@ var nativeOnlyProps = {
   src: true,
   defaultImageSrc: true,
   imageTag: true,
-  resizeMode: true,
 };
 if (__DEV__) {
   verifyPropTypes(Image, RCTStaticImage.viewConfig, nativeOnlyProps);


### PR DESCRIPTION
@chirag04 pointed out in irc that he was getting warnings about using the `resizeMode` prop on `Image`. My understanding is that it **should** be used as a prop, and that using it in the style was slated to be deprecated.

![screen_shot_2015-06-18_at_11 43 14_am_720](https://cloud.githubusercontent.com/assets/90494/8235824/1f495610-1599-11e5-898a-752ae030866e.png)

This pull request gets rid of the warning message above, but stops short of adding a warning when using `resizeMode` via style - I would like to continue and add that warning if you agree @vjeux 