### PR TITLE
[Pods] Preserve the local-cli directory

### DIFF
--- a/React.podspec
+++ b/React.podspec
@@ -23,7 +23,7 @@ Pod::Spec.new do |s|
   s.requires_arc        = true
   s.platform            = :ios, "7.0"
   s.prepare_command     = 'npm install --production'
-  s.preserve_paths      = "cli.js", "Libraries/**/*.js", "lint", "linter.js", "node_modules", "package.json", "packager", "PATENTS", "react-native-cli"
+  s.preserve_paths      = "cli.js", "Libraries/**/*.js", "lint", "linter.js", "node_modules", "package.json", "packager", "PATENTS", "react-native-cli", "local-cli"
   s.header_mappings_dir = "."
 
   s.subspec 'Core' do |ss|


### PR DESCRIPTION
In continuation of the discussion [here](https://github.com/facebook/react-native/issues/363#issuecomment-113177502) in #363, the global `react-native-cli` refers to the `local-cli` directory when run inside the project. But when installed via `Pods`, this folder is deleted as it is not listed in the `preserve_paths` config in the pod spec.