### PR TITLE
[Errors] Include unique IDs in the exception manager methods

### DIFF
--- a/React/Modules/RCTExceptionsManager.h
+++ b/React/Modules/RCTExceptionsManager.h
@@ -13,9 +13,9 @@
 
 @protocol RCTExceptionsManagerDelegate <NSObject>
 
-- (void)handleSoftJSExceptionWithMessage:(NSString *)message stack:(NSArray *)stack;
-- (void)handleFatalJSExceptionWithMessage:(NSString *)message stack:(NSArray *)stack;
-- (void)updateJSExceptionWithMessage:(NSString *)message stack:(NSArray *)stack;
+- (void)handleSoftJSExceptionWithID:(NSNumber *)exceptionID message:(NSString *)message stack:(NSArray *)stack;
+- (void)handleFatalJSExceptionWithID:(NSNumber *)exceptionID message:(NSString *)message stack:(NSArray *)stack;
+- (void)updateJSExceptionWithID:(NSNumber *)exceptionID message:(NSString *)message stack:(NSArray *)stack;
 
 @end
 

--- a/React/Modules/RCTExceptionsManager.m
+++ b/React/Modules/RCTExceptionsManager.m
@@ -36,22 +36,24 @@ RCT_EXPORT_MODULE()
   return [self initWithDelegate:nil];
 }
 
-RCT_EXPORT_METHOD(reportSoftException:(NSString *)message
+RCT_EXPORT_METHOD(reportSoftException:(NSNumber *)exceptionID
+                  message:(NSString *)message
                   stack:(NSArray *)stack)
 {
   // TODO(#7070533): report a soft error to the server
   if (_delegate) {
-    [_delegate handleSoftJSExceptionWithMessage:message stack:stack];
+    [_delegate handleSoftJSExceptionWithID:exceptionID message:message stack:stack];
     return;
   }
   [[RCTRedBox sharedInstance] showErrorMessage:message withStack:stack];
 }
 
-RCT_EXPORT_METHOD(reportFatalException:(NSString *)message
+RCT_EXPORT_METHOD(reportFatalException:(NSNumber *)exceptionID
+                  message:(NSString *)message
                   stack:(NSArray *)stack)
 {
   if (_delegate) {
-    [_delegate handleFatalJSExceptionWithMessage:message stack:stack];
+    [_delegate handleFatalJSExceptionWithID:exceptionID message:message stack:stack];
     return;
   }
 
@@ -85,11 +87,12 @@ RCT_EXPORT_METHOD(reportFatalException:(NSString *)message
   }
 }
 
-RCT_EXPORT_METHOD(updateExceptionMessage:(NSString *)message
+RCT_EXPORT_METHOD(updateException:(NSNumber *)exceptionID
+                  message:(NSString *)message
                   stack:(NSArray *)stack)
 {
   if (_delegate) {
-    [_delegate updateJSExceptionWithMessage:message stack:stack];
+    [_delegate updateJSExceptionWithID:exceptionID message:message stack:stack];
     return;
   }
 
@@ -100,6 +103,6 @@ RCT_EXPORT_METHOD(updateExceptionMessage:(NSString *)message
 RCT_EXPORT_METHOD(reportUnhandledException:(NSString *)message
                   stack:(NSArray *)stack)
 {
-  [self reportFatalException:message stack:stack];
+  [self reportFatalException:@0 message:message stack:stack];
 }
 @end


### PR DESCRIPTION
The exception manager sometimes passes info about the same error more than once to native--this is because it asynchronously fetches and applies the source map, so it later can provide a more accurate stack trace.

This diff includes IDs (just an incrementing counter) so that the native code--specifically the delegate methods--can associate the error info without source maps with the info w/source maps for the same error. This is useful for error logs.

This is a breaking change because of the new exceptionID argument but I expect it will mostly affect just FB and advanced users who will get a clear compiler error.