### PR TITLE
Fix animation bug in 32bit when fromValue is double.

### DIFF
--- a/Libraries/Animation/RCTAnimationExperimentalManager.m
+++ b/Libraries/Animation/RCTAnimationExperimentalManager.m
@@ -217,6 +217,11 @@ RCT_EXPORT_METHOD(startAnimation:(NSNumber *)reactTag
       }
 
       NSValue *fromValue = [view.layer.presentationLayer valueForKeyPath:keypath];
+#if !CGFLOAT_IS_DOUBLE
+      if ([fromValue isKindOfClass:[NSNumber class]]) {
+        fromValue = [NSNumber numberWithFloat:[(NSNumber *)fromValue doubleValue]];
+      }
+#endif
       CGFloat fromFields[count];
       [fromValue getValue:fromFields];
 


### PR DESCRIPTION
Now `RCTAnimationExperimentalManager` is not working on 32bit devices.

```
NSValue *fromValue = [view.layer.presentationLayer valueForKeyPath:keypath];
CGFloat fromFields[count];
[fromValue getValue:fromFields];
```

If the fromValue is kind of double value which needs two bytes in 32bit device and the count is 1, the fromFileds array will go wrong.