### PR TITLE
Upgrade to underscore 1.8.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "source-map": "0.1.31",
     "stacktrace-parser": "frantic/stacktrace-parser#493c5e5638",
     "uglify-js": "~2.4.16",
-    "underscore": "1.7.0",
+    "underscore": "1.8.3",
     "worker-farm": "^1.3.1",
     "ws": "0.4.31",
     "yargs": "1.3.2"


### PR DESCRIPTION
Since the packager doesn't allow multiple versions of libraries (see #1646) and underscore is quite a useful library that others will use it makes sense to have the latest version as the dependency I think.