### PR TITLE
[npm] Upgrade to stacktrace-parser 0.1.2, which supports io.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "sane": "^1.1.2",
     "semver": "^4.3.6",
     "source-map": "0.1.31",
-    "stacktrace-parser": "frantic/stacktrace-parser#493c5e5638",
+    "stacktrace-parser": "^0.1.2",
     "uglify-js": "~2.4.16",
     "underscore": "1.7.0",
     "wordwrap": "^1.0.0",


### PR DESCRIPTION
stacktrace-parser used to list only Node 0.10 under its list of supported engines. This new version includes Node 1.x and 2.x (i.e. io.js) as well, which addresses the warning during `npm install`.

There's no problem with using the older version of stacktrace-parser; this just clears the warning.

Test Plan: Run `npm install` under io.js -- no more warnings about a mismatched Node version.