### PR TITLE
[Image] Support loading images from application home directory.

### DIFF
--- a/React/Base/RCTConvert.m
+++ b/React/Base/RCTConvert.m
@@ -634,8 +634,8 @@ RCT_CGSTRUCT_CONVERTER(CGAffineTransform, (@[
     NSURL *url = [NSURL URLWithString:path];
     NSData *imageData = [NSData dataWithContentsOfURL:url];
     image = [UIImage imageWithData:imageData];
-  } else if ([path isAbsolutePath]) {
-    image = [UIImage imageWithContentsOfFile:path];
+  } else if ([path isAbsolutePath] || [path hasPrefix:@"~"]) {
+    image = [UIImage imageWithContentsOfFile:path.stringByExpandingTildeInPath];
   } else {
     image = [UIImage imageNamed:path];
     if (!image) {


### PR DESCRIPTION
Image source uri's prefixed with ~ are expanded into a full path to
the app directory.

For example: `~/Documents/foo.png` is expanded into `Users/arbesfeld/Library/Developer/CoreSimulator/Devices/977988DF-A8BC-4CE5-A27A-75807A6DF085/data/Containers/Data/Application/CBEFC261-5900-4EF9-8646-603BC57B094A/Documents/foo.png`.

This lets us store and use images from the application home directory with the `Image` component:

```
<Image source={{uri: '~/Documents/foo.png', width: 300, height: 300}} />
```

Resolves #1178 