### PR TITLE
Check for packager dependencies in packager by trying to load them and catching the error

### DIFF
--- a/packager/packager.js
+++ b/packager/packager.js
@@ -16,25 +16,33 @@ var isAbsolutePath = require('absolute-path');
 
 var getFlowTypeCheckMiddleware = require('./getFlowTypeCheckMiddleware');
 
-if (!fs.existsSync(path.resolve(__dirname, '..', 'node_modules'))) {
+try {
+  var chalk = require('chalk');
+  var connect = require('connect');
+  var ReactPackager = require('./react-packager');
+  var blacklist = require('./blacklist.js');
+  var checkNodeVersion = require('./checkNodeVersion');
+  var formatBanner = require('./formatBanner');
+  var launchEditor = require('./launchEditor.js');
+  var parseCommandLine = require('./parseCommandLine.js');
+  var webSocketProxy = require('./webSocketProxy.js');
+} catch (err) {
+  // Throw the error unless we know how to handle it
+  var isMissingModule = err.message && err.message.indexOf('Cannot find module') === 0
+  if (!isMissingModule) {
+    throw err
+  }
+
   console.log(
     '\n' +
-    'Could not find dependencies.\n' +
+    err.toString() +
+    '\n\n' +
+    'Could not load dependencies.\n' +
     'Ensure dependencies are installed - ' +
     'run \'npm install\' from project root.\n'
   );
   process.exit();
 }
-
-var chalk = require('chalk');
-var connect = require('connect');
-var ReactPackager = require('./react-packager');
-var blacklist = require('./blacklist.js');
-var checkNodeVersion = require('./checkNodeVersion');
-var formatBanner = require('./formatBanner');
-var launchEditor = require('./launchEditor.js');
-var parseCommandLine = require('./parseCommandLine.js');
-var webSocketProxy = require('./webSocketProxy.js');
 
 var options = parseCommandLine([{
   command: 'port',

--- a/packager/packager.js
+++ b/packager/packager.js
@@ -12,11 +12,10 @@ var fs = require('fs');
 var path = require('path');
 var execFile = require('child_process').execFile;
 var http = require('http');
-var isAbsolutePath = require('absolute-path');
-
-var getFlowTypeCheckMiddleware = require('./getFlowTypeCheckMiddleware');
 
 try {
+  var isAbsolutePath = require('absolute-path');
+  var getFlowTypeCheckMiddleware = require('./getFlowTypeCheckMiddleware');
   var chalk = require('chalk');
   var connect = require('connect');
   var ReactPackager = require('./react-packager');


### PR DESCRIPTION
npm 3.0.0 changes the file structure for dependencies to try to avoid nesting them. This leads to false positives when checking for a node_modules directory within react-native because it's dependencies may be stored in the parent project's node_modules directory.