### PR TITLE
Rename babel's es6.parameters.rest option to es6.parameters

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "dependencies": {
     "absolute-path": "0.0.0",
     "babel": "5.4.3",
-    "babel-core": "^5.6.4",
+    "babel-core": "^5.6.11",
     "bluebird": "^2.9.21",
     "chalk": "^1.0.0",
     "connect": "2.8.3",

--- a/packager/react-packager/.babelrc
+++ b/packager/react-packager/.babelrc
@@ -10,7 +10,7 @@
     "es6.constants",
     "es6.classes",
     "es6.destructuring",
-    "es6.parameters.rest",
+    "es6.parameters",
     "es6.properties.computed",
     "es6.properties.shorthand",
     "es6.spread",

--- a/packager/transformer.js
+++ b/packager/transformer.js
@@ -23,7 +23,7 @@ function transform(srcTxt, filename, options) {
       'es6.blockScoping',
       'es6.classes',
       'es6.destructuring',
-      'es6.parameters.rest',
+      'es6.parameters',
       'es6.properties.computed',
       'es6.properties.shorthand',
       'es6.spread',


### PR DESCRIPTION
The old name was deprecated and spits out a bunch of annoying log messages now.

See https://github.com/babel/babel/commit/c0fd4c1f9e0b18231f585c4fa793e4cb0e01aed1