### PR TITLE
[css-layout] Only exit from layoutNode when no children

### DIFF
--- a/React/Layout/Layout.c
+++ b/React/Layout/Layout.c
@@ -397,7 +397,9 @@ static void layoutNodeImpl(css_node_t *node, float parentMaxWidth) {
           getPaddingAndBorderAxis(node, CSS_FLEX_DIRECTION_COLUMN);
       }
     }
-    return;
+    if (node->children_count == 0) {
+      return;
+    }
   }
 
   // Pre-fill some dimensions straight from the parent


### PR DESCRIPTION
Following https://github.com/facebook/react-native/pull/1538#issuecomment-116354660, this imports the one line change from https://github.com/facebook/css-layout/pull/84.