### PR TITLE
[ScrollView] Pick data from older event on coalescing.

### DIFF
--- a/React/Views/RCTScrollView.m
+++ b/React/Views/RCTScrollView.m
@@ -114,8 +114,16 @@ RCT_NOT_IMPLEMENTED(-init)
   return YES;
 }
 
-- (id<RCTEvent>)coalesceWithEvent:(id<RCTEvent>)newEvent
+- (RCTScrollEvent *)coalesceWithEvent:(RCTScrollEvent *)newEvent
 {
+  NSArray *updatedChildFrames = [_userData[@"updatedChildFrames"] arrayByAddingObjectsFromArray:newEvent->_userData[@"updatedChildFrames"]];
+
+  if (updatedChildFrames) {
+    NSMutableDictionary *userData = [newEvent->_userData mutableCopy];
+    userData[@"updatedChildFrames"] = updatedChildFrames;
+    newEvent->_userData = userData;
+  }
+  
   return newEvent;
 }
 


### PR DESCRIPTION
The `ScrollView` sends important `updatedChildFrames` data to the `ListView` to be able to implement `onChangeVisibleRows` method. Coalescing operates very strongly on older devices like the iPhone 4s where this data is then lost.

Fixes #1782.

`ListView` has a method called `onChangeVisibleRows` that is called whenever the rows visible on screen change. This method is critical to be able to implement deletion/creation of views and hence be conservative in memory usage. I have an infinite scrolling view which uses this method to only render the full rows for what is visible on screen and put placeholders for everything else.

In the `RCTEventDispatcher`, we [coalesce events](https://github.com/facebook/react-native/blob/522fd33d6f3c8fb339b0dde35b05df34c1233306/React/Base/RCTEventDispatcher.m#L135-L152) that are meant to be sent across the bridge. They are [dequeued](https://github.com/facebook/react-native/blob/522fd33d6f3c8fb339b0dde35b05df34c1233306/React/Base/RCTEventDispatcher.m#L180-L188) on each and every `RCTFrameUpdate`.

But when we [coalesce the events](https://github.com/facebook/react-native/blob/522fd33d6f3c8fb339b0dde35b05df34c1233306/React/Views/RCTScrollView.m#L117-L120) for `RCTScrollView`, we are only picking the latest event. This means that the `updatedChildFrames` [generated here](https://github.com/facebook/react-native/blob/522fd33d6f3c8fb339b0dde35b05df34c1233306/React/Views/RCTScrollView.m#L533-L552) are lost and the `ListView` in JS, does not know about the new frames of the rows - and hence cannot correctly calculate the `onChangeVisibleRows` changes.

To test my theory, I turned off coalescing in code and JS receives all the events. Hence, the coalescing method needs to take into account the `childUpdatedFrames` object from previous events [here](https://github.com/facebook/react-native/blob/522fd33d6f3c8fb339b0dde35b05df34c1233306/React/Views/RCTScrollView.m#L117-L120):

```
- (id<RCTEvent>)coalesceWithEvent:(id<RCTEvent>)newEvent
{
  return newEvent;
}
```
Currently, it is blindly picking up the latest event. It should instead do a merge of the events taking care of `childUpdatedFrames`.