### PR TITLE
[Docs] Update installation docs to reference io.js instead of Node

### DIFF
--- a/docs/EmbeddedApp.md
+++ b/docs/EmbeddedApp.md
@@ -12,7 +12,8 @@ Since React makes no assumptions about the rest of your technology stack – it�
 ## Requirements
 
 - [CocoaPods](http://cocoapods.org/) – `gem install cocoapods`
-- [Node.js](http://nodejs.org) – `brew install node`
+- [io.js](http://iojs.org) – `brew install iojs && brew link iojs --force` or from [nvm](https://github.com/creationix/nvm)
+  - You may have to run `brew unlink node` if you have previously installed Node
 
 ## Install React Native Using CocoaPods
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -12,7 +12,7 @@ next: tutorial
 1. OS X - This repo only contains the iOS (7+) implementation right now, and Xcode only runs on Mac.
 2. [Xcode](https://developer.apple.com/xcode/downloads/) 6.3 or higher is recommended.
 3. [Homebrew](http://brew.sh/) is the recommended way to install node, watchman, and flow.
-4. `brew install node`. New to [node](https://nodejs.org/) or [npm](https://docs.npmjs.com/)?
+4. `brew install iojs && brew link iojs --force`. You may need to run `brew unlink node` if you have previously installed Node. New to [io.js](https://iojs.org/) or [npm](https://docs.npmjs.com/)?
 5. `brew install watchman`. We recommend installing [watchman](https://facebook.github.io/watchman/docs/install.html), otherwise you might hit a node file watching bug.
 6. `brew install flow`. If you want to use [flow](http://www.flowtype.org).
 

--- a/docs/Tutorial.md
+++ b/docs/Tutorial.md
@@ -16,7 +16,7 @@ We assume you have experience writing websites with React. If not, you can learn
 
 ## Setup
 
-React Native requires OSX, Xcode, [Homebrew](http://brew.sh/), node (we recommend installing this via Homebrew), npm (installed automatically with node), and [watchman](https://facebook.github.io/watchman/docs/install.html). [Flow](https://github.com/facebook/flow) is optional.
+React Native requires OSX, Xcode, [Homebrew](http://brew.sh/), io.js (we recommend installing this via [nvm](https://github.com/creationix/nvm) or Homebrew), npm (installed automatically with io.js), and [watchman](https://facebook.github.io/watchman/docs/install.html). [Flow](https://github.com/facebook/flow) is optional.
 
 After installing these dependencies there are two simple commands to get a React Native project all set up for development.
 
@@ -31,7 +31,7 @@ After installing these dependencies there are two simple commands to get a React
 
 ## Development
 
-You can now open this new project (`AwesomeProject/AwesomeProject.xcodeproj`) in Xcode and simply build and run it with cmd+R. Doing so will also start a node server which enables live code reloading. With this you can see your changes by pressing cmd+R in the simulator rather than recompiling in Xcode.
+You can now open this new project (`AwesomeProject/AwesomeProject.xcodeproj`) in Xcode and simply build and run it with cmd+R. Doing so will also start a Node server which enables live code reloading. With this you can see your changes by pressing cmd+R in the simulator rather than recompiling in Xcode.
 
 For this tutorial we'll be building a simple version of the Movies app that fetches 25 movies that are in theaters and displays them in a ListView.
 


### PR DESCRIPTION
It's pretty straightforward -- io.js is available through Homebrew so all you run is `brew install iojs` and then you can still run `node` from the command line. Also mentioned nvm since it's really good for switching between Node/io.js versions.

Docs for #1737 