### PR TITLE
[CocoaPods] Run `npm install --production` when installing React.podspec

### DIFF
--- a/React.podspec
+++ b/React.podspec
@@ -22,7 +22,7 @@ Pod::Spec.new do |s|
   s.default_subspec     = 'Core'
   s.requires_arc        = true
   s.platform            = :ios, "7.0"
-  s.prepare_command     = 'npm install'
+  s.prepare_command     = 'npm install --production'
   s.preserve_paths      = "cli.js", "Libraries/**/*.js", "lint", "linter.js", "node_modules", "package.json", "packager", "PATENTS", "react-native-cli"
   s.header_mappings_dir = "."
 


### PR DESCRIPTION
This omits the devDependencies (e.g. test infra), which are intended only for people working on RN.

Part of #1737.