### PR TITLE
[UIExplorer] Add mapType example for MapView

### DIFF
--- a/Examples/UIExplorer/MapViewExample.js
+++ b/Examples/UIExplorer/MapViewExample.js
@@ -208,6 +208,40 @@ var MapViewExample = React.createClass({
 
 });
 
+var MapViewTypeExample = React.createClass({
+  statics: {
+    mapTypes: ['standard', 'satellite', 'hybrid']
+  },
+
+  getInitialState() {
+    return { mapType: MapViewTypeExample.mapTypes[0] }
+  },
+
+  render() {
+    return (
+      <View>
+        <MapView style={styles.map} showsUserLocation={true} mapType={this.state.mapType} />
+        <View style={{flexDirection: 'row', alignItems: 'center', justifyContent: 'center',}}>
+          {this._renderMapTypeButtons()}
+        </View>
+      </View>
+    )
+  },
+
+  _renderMapTypeButtons() {
+    return MapViewTypeExample.mapTypes.map((mapType) => {
+      return (
+        <View style={styles.changeButton} key={mapType}>
+          <Text onPress={() => this.setState({mapType})}>
+            {mapType}
+          </Text>
+        </View>
+      )
+    })
+  },
+});
+
+
 var styles = StyleSheet.create({
   map: {
     height: 150,
@@ -248,6 +282,12 @@ exports.examples = [
     title: 'Map shows user location',
     render() {
       return  <MapView style={styles.map} showsUserLocation={true} />;
+    }
+  },
+  {
+    title: 'Map types',
+    render() {
+      return  <MapViewTypeExample />;
     }
   }
 ];

--- a/Libraries/Components/MapView/MapView.js
+++ b/Libraries/Components/MapView/MapView.js
@@ -84,14 +84,14 @@ var MapView = React.createClass({
 
     /**
      * The map type to be displayed.
-     * 
+     *
      * - standard: standard road map (default)
      * - satellite: satellite view
      * - hybrid: satellite view with roads and points of interest overlayed
      */
     mapType: React.PropTypes.oneOf([
-      'standard', 
-      'satellite', 
+      'standard',
+      'satellite',
       'hybrid',
     ]),
 


### PR DESCRIPTION
While looking into #1812 I noticed that we don't have an example for this in UIExplorer, it seems useful so I added it in.

Test plan: Go to MapView in UIExplorer, toggle between different mapTypes using the buttons provided