### PR TITLE
[WebSocket] binaryType='arraybuffer' support

### DIFF
--- a/Libraries/WebSocket/RCTWebSocketManager.m
+++ b/Libraries/WebSocket/RCTWebSocketManager.m
@@ -82,8 +82,19 @@ RCT_EXPORT_METHOD(close:(NSNumber *)socketID)
 
 - (void)webSocket:(RCTSRWebSocket *)webSocket didReceiveMessage:(id)message
 {
+
+  NSString * type;
+
+  if ([message isKindOfClass:[NSData class]]) {
+    type = @"binary";
+    message = [message base64EncodedStringWithOptions:0];
+  } else {
+    type = @"text";
+  }
+
   [_bridge.eventDispatcher sendDeviceEventWithName:@"websocketMessage" body:@{
     @"data": message,
+    @"type": type,
     @"id": webSocket.reactTag
   }];
 }

--- a/Libraries/WebSocket/WebSocket.ios.js
+++ b/Libraries/WebSocket/WebSocket.ios.js
@@ -16,6 +16,8 @@ var RCTWebSocketManager = require('NativeModules').WebSocketManager;
 
 var WebSocketBase = require('WebSocketBase');
 
+var base64 = require('base64-js');
+
 var WebSocketId = 0;
 
 class WebSocket extends WebSocketBase {
@@ -58,9 +60,20 @@ class WebSocket extends WebSocketBase {
           if (ev.id !== id) {
             return;
           }
-          this.onmessage && this.onmessage({
-            data: ev.data
-          });
+
+          var message;
+
+          if (ev.type === 'text') {
+            message = {
+              data: ev.data
+            };
+          } else if (ev.type === 'binary') {
+            message = {
+              data: base64.toByteArray(ev.data).buffer
+            };
+          }
+
+          this.onmessage && this.onmessage(message);
         }.bind(this)
       ),
       RCTDeviceEventEmitter.addListener(

--- a/package.json
+++ b/package.json
@@ -67,7 +67,8 @@
     "underscore": "1.7.0",
     "worker-farm": "^1.3.1",
     "ws": "0.4.31",
-    "yargs": "1.3.2"
+    "yargs": "1.3.2",
+    "base64-js": "0.0.8"
   },
   "devDependencies": {
     "jest-cli": "0.4.5",


### PR DESCRIPTION
Support for binary websocket messages. Currently binary messages crash the application. More info in https://github.com/facebook/react-native/issues/1730