### PR TITLE
[AlertIOS] AlertIOS.alert title and message are always strings

### DIFF
--- a/Libraries/Utilities/AlertIOS.js
+++ b/Libraries/Utilities/AlertIOS.js
@@ -54,8 +54,8 @@ class AlertIOS {
   ): void {
     var callbacks = [];
     var buttonsSpec = [];
-    title = title || '';
-    message = message || '';
+    title = (title || '').toString();
+    message = (message || '').toString();
     buttons = buttons || [DEFAULT_BUTTON];
     type = type || '';
 


### PR DESCRIPTION
Prevents a crash by always using the parameters string representation. With this pull request the message is being consistent to passing a non-strings in an `alert`. This fixes #1835.