### PR TITLE
fixing the image orientation in the camera roll

### DIFF
--- a/Libraries/Image/RCTImageLoader.m
+++ b/Libraries/Image/RCTImageLoader.m
@@ -75,7 +75,7 @@ static dispatch_queue_t RCTImageLoaderQueue(void)
           @autoreleasepool {
             ALAssetRepresentation *representation = [asset defaultRepresentation];
             ALAssetOrientation orientation = [representation orientation];
-            UIImage *image = [UIImage imageWithCGImage:[representation fullResolutionImage] scale:1.0f orientation:(UIImageOrientation)orientation];
+            UIImage *image = [UIImage imageWithCGImage:[asset thumbnail] scale:1.0f orientation:UIImageOrientationUp];
             RCTDispatchCallbackOnMainQueue(callback, nil, image);
           }
         });

--- a/Libraries/Image/RCTImageLoader.m
+++ b/Libraries/Image/RCTImageLoader.m
@@ -73,8 +73,7 @@ static dispatch_queue_t RCTImageLoaderQueue(void)
           // Also make sure the image is released immediately after it's used so it
           // doesn't spike the memory up during the process.
           @autoreleasepool {
-            ALAssetRepresentation *representation = [asset defaultRepresentation];
-            UIImage *image = [UIImage imageWithCGImage:[asset thumbnail] scale:1.0f orientation:UIImageOrientationUp];
+            UIImage *image = [UIImage imageWithCGImage:[asset thumbnail]];
             RCTDispatchCallbackOnMainQueue(callback, nil, image);
           }
         });

--- a/Libraries/Image/RCTImageLoader.m
+++ b/Libraries/Image/RCTImageLoader.m
@@ -74,7 +74,6 @@ static dispatch_queue_t RCTImageLoaderQueue(void)
           // doesn't spike the memory up during the process.
           @autoreleasepool {
             ALAssetRepresentation *representation = [asset defaultRepresentation];
-            ALAssetOrientation orientation = [representation orientation];
             UIImage *image = [UIImage imageWithCGImage:[asset thumbnail] scale:1.0f orientation:UIImageOrientationUp];
             RCTDispatchCallbackOnMainQueue(callback, nil, image);
           }


### PR DESCRIPTION
This is a pretty annoying bug for us, we would like to release our application soon. There are two things here for the asset size as well as the orientation of the images in the camera roll. Fixes issue with respect to #1567 