### PR TITLE
Include jestSupport for npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "init.sh",
     "LICENSE",
     "PATENTS",
-    "README.md"
+    "README.md",
+    "jestSupport"
   ],
   "scripts": {
     "test": "jest",


### PR DESCRIPTION
https://github.com/facebook/react-native/pull/1639 was closed for unknown reason. This will help unit test with Jest without manually copying them into node_modules/react-native.