### PR TITLE
[Crashfix] Ensure that the image response is non-nil before caching it

### DIFF
--- a/Libraries/Image/RCTImageDownloader.m
+++ b/Libraries/Image/RCTImageDownloader.m
@@ -90,9 +90,11 @@ CGRect RCTClipRect(CGSize, CGFloat, CGSize, CGFloat, UIViewContentMode);
           runBlocks(NO, data, error);
         }
 
-        RCTImageDownloader *strongSelf = weakSelf;
-        NSCachedURLResponse *cachedResponse = [[NSCachedURLResponse alloc] initWithResponse:response data:data userInfo:nil storagePolicy:NSURLCacheStorageAllowed];
-        [strongSelf->_cache storeCachedResponse:cachedResponse forDataTask:task];
+        if (response) {
+          RCTImageDownloader *strongSelf = weakSelf;
+          NSCachedURLResponse *cachedResponse = [[NSCachedURLResponse alloc] initWithResponse:response data:data userInfo:nil storagePolicy:NSURLCacheStorageAllowed];
+          [strongSelf->_cache storeCachedResponse:cachedResponse forDataTask:task];
+        }
         task = nil;
       }];
 


### PR DESCRIPTION
If you try to create a cached response from a nil response the app will crash. Looking at the code that uses NSURLSession and NSURLCache, this fix looks correct to me.

Fixes #1850 

Test Plan: Load app with remote images and reload it (which was triggering a craash for me) -- no longer crashes upon reload.