### PR TITLE
[TextInput] Remove focus on TextInput if property `editable` is …

### DIFF
--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -537,7 +537,9 @@ var TextInput = React.createClass({
   },
 
   _onPress: function(event: Event) {
-    this.focus();
+    if (this.props.editable || this.props.editable === undefined) {
+      this.focus();
+    }
   },
 
   _onChange: function(event: Event) {


### PR DESCRIPTION
Clicking on a TextField with editable set to false still would trigger a keyboard event. 
In this case that the TextField was a multiline, it would scroll you down to the bottom.
