### PR TITLE
Add backgroundImage style support and examples

### DIFF
--- a/Examples/UIExplorer/BackgroundImageExample.js
+++ b/Examples/UIExplorer/BackgroundImageExample.js
@@ -1,0 +1,125 @@
+/**
+ * The examples provided by Facebook are for non-commercial testing and
+ * evaluation purposes only.
+ *
+ * Facebook reserves all rights not expressly granted.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON INFRINGEMENT. IN NO EVENT SHALL
+ * FACEBOOK BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+'use strict';
+
+var React = require('react-native');
+var {
+  StyleSheet,
+  View
+} = React;
+
+var {width, height} = require('Dimensions').get('window');
+
+var styles = StyleSheet.create({
+  box: {
+    width: width - 40,
+    height: 100,
+  },
+  bg1: {
+    backgroundColor: '#eee',
+  },
+  bg2: {
+    backgroundColor: '#eee',
+    backgroundRepeat: 'repeat-x',
+  },
+  bg3: {
+    backgroundColor: '#eee',
+    backgroundRepeat: 'repeat-y',
+  },
+  bg4: {
+    backgroundColor: '#eee',
+    backgroundRepeat: 'no-repeat',
+  },
+  bg5: {
+    backgroundColor: '#eee',
+    backgroundSize: {width: 16, height: 16},
+  },
+  bg6: {
+    backgroundColor: '#eee',
+    backgroundPosition: {x: 20, y: 20},
+  },
+  bg7: {
+    borderWidth: 10,
+    borderColor: 'brown',
+  },
+  bg8: {
+    borderWidth: 10,
+    borderLeftWidth: 20,
+    borderColor: 'brown',
+  },
+  bgBase64: {
+    backgroundImage: 'data:image/png;charset=utf-8;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAMAAABEpIrGAAAABGdBTUEAALGPC/xhBQAAAAFzUkdCAK7OHOkAAAEmUExURQAAAKi2tqe3t39/f6i2tqm2tq23t7CwsKq2tqm2tqi3t6i2tqqqqv///6e3t6i3t7+/v6i3t6m3t6m3t6i2tqqzs6i3t6e3t6i2tqa2tqi3t6q1tay4uKi5uam3t6m2tqi3t6q4uKm3t6i1tai2tqq3t6m2tqi3t6i2tqm3t6m3t6m2tqm3t6Wysqi4uKm2tqe3t6i4uKi3t6i3t6i2tqm2tqm3t6e1tai3t6i3t7Kysqi2tqq4uKy0tKm3t6m2tqi3t6W0tKm3t6e0tKa1tai3t6m1tai3t6i3t6m3t5+/v6i2tqm3t6i2tqm3t6i2tqi2tqq4uKi3t6i3t6i3t6m2tqa0tKq0tKi3t6m2tqi3t6m3t6q1tam3t6q3t6O2tqi0tKm3t+PG1XkAAABhdFJOUwA1IAKCuxkNaV9HkwMBT44EMqTIpRv1QMkuiy0oLGu/fEh6O6lO06hq65J3/RRT9FJzlquU324mw+MKikUftoyaEa8pNL1l5IfLCO2qptHs/jb5eZnlNxhVsMDKQtw5Dj48l0d6AAAA8klEQVQ4y2NgoDZglyagQJaFgAJFVgIKODWZ8StgSdTFr0AkURC/AotEA/wKLBMN8cozBSQaASke7LJcggyBiYlAf5qJYleQEC3OnZior2diLYDDgrhEMBDGLhsvyScFUeDPERaO7AomTm1+kahYsUQkEBQqbKylJMcIViCjoG6aiAWIyXNzwU0REI3hkIp0h0pJhARHSLJjcYYtRN4VVygxCwlJAOV97Fywy/Ny2DOIJyb6MTA6OGJXwMbA4JyY6MvAYMWOMy68vBM98MemZ6IbfgVOiTb4FfAnmuNXoKHDjl+BqhqBZK+sQkABGx/VczMAIYMw06u3NvkAAAAASUVORK5CYII=',
+  },
+});
+
+exports.title = 'BackgroundImage';
+exports.description = 'Background Image';
+exports.examples = [
+  {
+    title: 'BackgroundImage',
+    description: 'Base64 BackgroundImage, repeat, backgroundColor',
+    render() {
+      return <View style={[styles.box, styles.bg1, styles.bgBase64]} />;
+    }
+  },
+  {
+    title: 'backgroundRepeat',
+    description: 'repeat-x',
+    render() {
+      return <View style={[styles.box, styles.bg2, styles.bgBase64]} />;
+    }
+  },
+  {
+    title: 'backgroundRepeat',
+    description: 'repeat-y',
+    render() {
+      return <View style={[styles.box, styles.bg3, styles.bgBase64]} />;
+    }
+  },
+  {
+    title: 'backgroundRepeat',
+    description: 'no-repeat',
+    render() {
+      return <View style={[styles.box, styles.bg4, styles.bgBase64]} />;
+    }
+  },
+  {
+    title: 'backgroundSize',
+    description: 'backgroundSize',
+    render() {
+      return <View style={[styles.box, styles.bg5, styles.bgBase64]} />;
+    }
+  },
+  {
+    title: 'backgroundPosition',
+    description: 'backgroundPosition',
+    render() {
+      return <View style={[styles.box, styles.bg6, styles.bgBase64]} />;
+    }
+  },
+  {
+    title: 'With Same-Width Borders',
+    description: 'Same-Width borders',
+    render() {
+      return <View style={[styles.box, styles.bg7, styles.bgBase64]} />;
+    }
+  },
+  {
+    title: 'With Custom-Width Borders',
+    description: 'Custom-Width borders',
+    render() {
+      return <View style={[styles.box, styles.bg8, styles.bgBase64]} />;
+    }
+  },
+];

--- a/Examples/UIExplorer/UIExplorerList.js
+++ b/Examples/UIExplorer/UIExplorerList.js
@@ -78,6 +78,7 @@ if (Platform.OS === 'ios') {
     require('./AppStateIOSExample'),
     require('./AsyncStorageExample'),
     require('./BorderExample'),
+    require('./BackgroundImageExample'),
     require('./CameraRollExample.ios'),
     require('./LayoutEventsExample'),
     require('./NetInfoExample'),

--- a/Libraries/Components/View/ViewStylePropTypes.js
+++ b/Libraries/Components/View/ViewStylePropTypes.js
@@ -22,6 +22,16 @@ var ViewStylePropTypes = {
   ...LayoutPropTypes,
   ...TransformPropTypes,
   backgroundColor: ReactPropTypes.string,
+  backgroundImage: ReactPropTypes.string,
+  backgroundPosition: ReactPropTypes.shape(
+    {x: ReactPropTypes.number, y: ReactPropTypes.number}
+  ),
+  backgroundSize: ReactPropTypes.shape(
+    {width: ReactPropTypes.number, height: ReactPropTypes.number}
+  ),
+  backgroundRepeat: ReactPropTypes.oneOf(
+    ['repeat', 'repeat-x', 'repeat-y', 'no-repeat']
+  ),
   borderColor: ReactPropTypes.string,
   borderTopColor: ReactPropTypes.string,
   borderRightColor: ReactPropTypes.string,

--- a/React/Base/RCTBackgroundRepeatType.h
+++ b/React/Base/RCTBackgroundRepeatType.h
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <Foundation/Foundation.h>
+
+typedef NS_ENUM(NSInteger, RCTBackgroundRepeatType) {
+  RCTBackgroundRepeatTypeRepeat = 0,
+  RCTBackgroundRepeatTypeRepeatX,
+  RCTBackgroundRepeatTypeRepeatY,
+  RCTBackgroundRepeatTypeNoRepeat,
+};

--- a/React/Base/RCTConvert.h
+++ b/React/Base/RCTConvert.h
@@ -15,6 +15,7 @@
 #import "RCTDefines.h"
 #import "RCTLog.h"
 #import "RCTPointerEvents.h"
+#import "RCTBackgroundRepeatType.h"
 
 /**
  * This class provides a collection of conversion functions for mapping
@@ -126,6 +127,7 @@ typedef BOOL css_clip_t;
 
 + (RCTPointerEvents)RCTPointerEvents:(id)json;
 + (RCTAnimationType)RCTAnimationType:(id)json;
++ (RCTBackgroundRepeatType)RCTBackgroundRepeatType:(id)json;
 
 @end
 

--- a/React/Base/RCTConvert.m
+++ b/React/Base/RCTConvert.m
@@ -1000,6 +1000,13 @@ RCT_ENUM_CONVERTER(RCTAnimationType, (@{
   @"keyboard": @(RCTAnimationTypeKeyboard),
 }), RCTAnimationTypeEaseInEaseOut, integerValue)
 
+RCT_ENUM_CONVERTER(RCTBackgroundRepeatType, (@{
+  @"repeat": @(RCTBackgroundRepeatTypeRepeat),
+  @"repeat-x": @(RCTBackgroundRepeatTypeRepeatX),
+  @"repeat-y": @(RCTBackgroundRepeatTypeRepeatY),
+  @"no-repeat": @(RCTBackgroundRepeatTypeNoRepeat)
+}), RCTBackgroundRepeatTypeRepeat, integerValue)
+
 @end
 
 BOOL RCTSetProperty(id target, NSString *keyPath, SEL type, id json)

--- a/React/React.xcodeproj/project.pbxproj
+++ b/React/React.xcodeproj/project.pbxproj
@@ -241,6 +241,7 @@
 		83CBBA971A6020BB00E9B192 /* RCTTouchHandler.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTTouchHandler.m; sourceTree = "<group>"; };
 		83CBBACA1A6023D300E9B192 /* RCTConvert.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTConvert.h; sourceTree = "<group>"; };
 		83CBBACB1A6023D300E9B192 /* RCTConvert.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTConvert.m; sourceTree = "<group>"; };
+		C7D194FB1B463BDD00A057CD /* RCTBackgroundRepeatType.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTBackgroundRepeatType.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -426,6 +427,7 @@
 				830213F31A654E0800B993E6 /* RCTBridgeModule.h */,
 				83CBBACA1A6023D300E9B192 /* RCTConvert.h */,
 				83CBBACB1A6023D300E9B192 /* RCTConvert.m */,
+				C7D194FB1B463BDD00A057CD /* RCTBackgroundRepeatType.h */,
 				13AF1F851AE6E777005F5298 /* RCTDefines.h */,
 				83CBBA651A601EF300E9B192 /* RCTEventDispatcher.h */,
 				83CBBA661A601EF300E9B192 /* RCTEventDispatcher.m */,

--- a/React/Views/RCTView.h
+++ b/React/Views/RCTView.h
@@ -12,6 +12,7 @@
 #import <UIKit/UIKit.h>
 
 #import "RCTPointerEvents.h"
+#import "RCTBackgroundRepeatType.h"
 
 @protocol RCTAutoInsetsProtocol;
 
@@ -80,5 +81,13 @@ typedef void (^RCTViewEventHandler)(RCTView *view);
 @property (nonatomic, assign) CGFloat borderBottomWidth;
 @property (nonatomic, assign) CGFloat borderLeftWidth;
 @property (nonatomic, assign) CGFloat borderWidth;
+
+/**
+ * Background Image.
+ */
+@property (nonatomic, strong) NSString *backgroundImage;
+@property (nonatomic, assign) CGPoint backgroundPosition;
+@property (nonatomic, assign) CGSize backgroundSize;
+@property (nonatomic, assign) RCTBackgroundRepeatType backgroundRepeat;
 
 @end

--- a/React/Views/RCTViewManager.m
+++ b/React/Views/RCTViewManager.m
@@ -169,6 +169,30 @@ RCT_CUSTOM_VIEW_PROPERTY(borderWidth, CGFloat, RCTView)
     view.layer.borderWidth = json ? [RCTConvert CGFloat:json] : defaultView.layer.borderWidth;
   }
 }
+RCT_CUSTOM_VIEW_PROPERTY(backgroundImage, NSString, RCTView)
+{
+  if ([view respondsToSelector:@selector(setBackgroundImage:)]) {
+    view.backgroundImage = json ?: defaultView.backgroundImage;
+  }
+}
+RCT_CUSTOM_VIEW_PROPERTY(backgroundSize, CGSize, RCTView)
+{
+  if ([view respondsToSelector:@selector(setBackgroundSize:)]) {
+    view.backgroundSize = json ? [RCTConvert CGSize:json] : defaultView.backgroundSize;
+  }
+}
+RCT_CUSTOM_VIEW_PROPERTY(backgroundPosition, CGPoint, RCTView)
+{
+  if ([view respondsToSelector:@selector(setBackgroundPosition:)]) {
+    view.backgroundPosition = json ? [RCTConvert CGPoint:json] : defaultView.backgroundPosition;
+  }
+}
+RCT_CUSTOM_VIEW_PROPERTY(backgroundRepeat, RCTBackgroundRepeatType, RCTView)
+{
+  if ([view respondsToSelector:@selector(setBackgroundRepeat:)]) {
+    view.backgroundRepeat = json ? [RCTConvert RCTBackgroundRepeatType:json] : defaultView.backgroundRepeat;
+  }
+}
 RCT_CUSTOM_VIEW_PROPERTY(onAccessibilityTap, BOOL, __unused RCTView)
 {
   view.accessibilityTapHandler = [self eventHandlerWithName:@"topAccessibilityTap" json:json];


### PR DESCRIPTION
Add backgroundImage style support for RCTViews:

* `backgroundImage` - support local files, such as base64 image files.
* `backgroundSize` - specify the size of background image. for example: {width: 50, height: 50}.
* `backgroundPosition` - set initial position. only support length values. for example: {x: 20, y: 20}.
* `backgroundRepeat` - define how background images are repeated. can be one of `['repeat', 'repeat-x', 'repeat-y', 'no-repeat']`

#### Example:
```
var styles = StyleSheet.create({
  bg: {
    backgroundImage: 'data:image/png;charset=utf-8;base64,...',
    backgroundSize: {width: 16, height: 16},
    backgroundPosition: {x: 10, y: 10},
    backgroundRepeat: 'repeat',
  }
});
```

#### Screenshots:

![ios-simulator-screen-shot-2015 7 3 - 3 20 19](https://cloud.githubusercontent.com/assets/245979/8494440/a479b532-2197-11e5-8d11-851d7f6f65d2.png)
![ios-simulator-screen-shot-2015 7 3 - 3 20 43](https://cloud.githubusercontent.com/assets/245979/8494444/a90408e6-2197-11e5-8341-2e0c7f06d4dc.png)