### PR TITLE
Changing Error to Warning

### DIFF
--- a/Libraries/Network/RCTNetworking.m
+++ b/Libraries/Network/RCTNetworking.m
@@ -381,7 +381,7 @@ RCT_EXPORT_MODULE()
 
   NSString *responseText = [[NSString alloc] initWithData:data encoding:encoding];
   if (!responseText && data.length) {
-    RCTLogError(@"Received data was invalid.");
+    RCTLogWarn(@"Received data was invalid.");
     return;
   }
 


### PR DESCRIPTION
As discussed with @nicklockwood in the issue https://github.com/facebook/react-native/issues/1780, the error should be changed to a warning to not break fetch() to send a POST to a remote API without wanting to parse the reply. E.g. google sends back an empty 1x1px gif when POSTing something to google analytics.