### PR TITLE
Remove unnecessary imports for RCTHTTPRequestHandler to fix Cocoapods build

### DIFF
--- a/Libraries/Network/RCTHTTPRequestHandler.m
+++ b/Libraries/Network/RCTHTTPRequestHandler.m
@@ -11,9 +11,6 @@
 
 #import "RCTAssert.h"
 #import "RCTConvert.h"
-#import "RCTEventDispatcher.h"
-#import "RCTImageLoader.h"
-#import "RCTLog.h"
 #import "RCTUtils.h"
 
 @interface RCTHTTPRequestHandler () <NSURLSessionDataDelegate>

--- a/Libraries/Network/RCTHTTPRequestHandler.m
+++ b/Libraries/Network/RCTHTTPRequestHandler.m
@@ -9,10 +9,6 @@
 
 #import "RCTHTTPRequestHandler.h"
 
-#import "RCTAssert.h"
-#import "RCTConvert.h"
-#import "RCTUtils.h"
-
 @interface RCTHTTPRequestHandler () <NSURLSessionDataDelegate>
 
 @end


### PR DESCRIPTION
@tadeuzagallo - We discussed this ~a week ago when I was putting together the 0.7.0-rc release, only got around to creating the PR for it now so it's properly sync'd.