### PR TITLE
[Crashfix] Replace dispatch_get_current_queue with DISPATCH_CURRENT_QUEUE_LABEL

### DIFF
--- a/React/Base/RCTAssert.m
+++ b/React/Base/RCTAssert.m
@@ -75,19 +75,12 @@ NSString *RCTCurrentThreadName(void)
   NSThread *thread = [NSThread currentThread];
   NSString *threadName = [thread isMainThread] ? @"main" : thread.name;
   if (threadName.length == 0) {
-#if DEBUG // This is DEBUG not RCT_DEBUG because it *really* must not ship in RC
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    const char *label = dispatch_queue_get_label(dispatch_get_current_queue());
+    const char *label = dispatch_queue_get_label(DISPATCH_CURRENT_QUEUE_LABEL);
     if (label && strlen(label) > 0) {
       threadName = @(label);
     } else {
       threadName = [NSString stringWithFormat:@"%p", thread];
     }
-#pragma clang diagnostic pop
-#else
-    threadName = [NSString stringWithFormat:@"%p", thread];
-#endif
   }
   return threadName;
 }


### PR DESCRIPTION
I encountered a crash when `RCTCurrentThreadName` called `dispatch_get_current_queue`. There are reports of it crashing e.g. https://github.com/CocoaLumberjack/CocoaLumberjack/issues/108 so better not to call it at all, plus it is deprecated.

Since we still want helpful debugging information, use `DISPATCH_CURRENT_QUEUE_LABEL` instead. It's kind of strange that this constant is defined to be NULL and the docs for `dispatch_get_queue_label` say not to pass in NULL, but in practice `DISPATCH_CURRENT_QUEUE_LABEL` is provided by the iOS SDK and works correctly.

Test Plan: Set a breakpoint inside of `RCTCurrentThreadName` and inspect the name of the thread returned from `dispatch_get_queue_label`. Get valid-looking values like "com.facebook.React.RCTSettingsManagerQueue".

Tested Cmd-R for good measure. The app refreshed fine without any crashes.