### PR TITLE
Update SegmentedControlIOSExample.js

### DIFF
--- a/Examples/UIExplorer/SegmentedControlIOSExample.js
+++ b/Examples/UIExplorer/SegmentedControlIOSExample.js
@@ -118,7 +118,7 @@ var EventSegmentedControlExample = React.createClass({
 
   _onChange(event) {
     this.setState({
-      selectedIndex: event.nativeEvent.selectedIndex,
+      selectedIndex: event.nativeEvent.selectedSegmentIndex,
     });
   },
 


### PR DESCRIPTION
`event.nativeEvent` now uses `selectedSegmentIndex`, not `selectedIndex`.