### PR TITLE
[Lint]: update lint packages, fix lint errors

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -55,7 +55,7 @@
     "no-debugger": 1,                // disallow use of debugger
     "no-dupe-keys": 1,               // disallow duplicate keys when creating object literals
     "no-empty": 0,                   // disallow empty statements
-    "no-empty-class": 1,             // disallow the use of empty character classes in regular expressions
+    "no-empty-character-class": 1,   // disallow the use of empty character classes in regular expressions
     "no-ex-assign": 1,               // disallow assigning to the exception in a catch block
     "no-extra-boolean-cast": 1,      // disallow double-negation boolean casts in a boolean context
     "no-extra-parens": 0,            // disallow unnecessary parentheses (off by default)
@@ -126,9 +126,7 @@
   // Strict Mode
   // These rules relate to using strict mode.
 
-    "global-strict": [2, "always"],  // require or disallow the "use strict" pragma in the global scope (off by default in the node environment)
-    "no-extra-strict": 1,            // disallow unnecessary use of "use strict"; when already in strict mode
-    "strict": 0,                     // require that all functions are run in strict mode
+    "strict": [1, "global"],        // require that all functions are run in strict mode
 
   // Variables
   // These rules have to do with variable declarations.
@@ -163,7 +161,7 @@
     "no-multi-spaces": 0,
     "brace-style": 0,                // enforce one true brace style (off by default)
     "camelcase": 0,                  // require camel case names
-    "consistent-this": [1, "self"],            // enforces consistent naming when capturing the current execution context (off by default)
+    "consistent-this": [1, "self"],  // enforces consistent naming when capturing the current execution context (off by default)
     "eol-last": 1,                   // enforce newline at the end of file, with no multiple empty lines
     "func-names": 0,                 // require function expressions to have a name (off by default)
     "func-style": 0,                 // enforces use of function declarations or expressions (off by default)
@@ -174,11 +172,9 @@
     "no-lonely-if": 0,               // disallow if as the only statement in an else block (off by default)
     "no-new-object": 1,              // disallow use of the Object constructor
     "no-spaced-func": 1,             // disallow space between function identifier and application
-    "no-space-before-semi": 1,       // disallow space before semicolon
     "no-ternary": 0,                 // disallow the use of ternary operators (off by default)
     "no-trailing-spaces": 1,         // disallow trailing whitespace at the end of lines
     "no-underscore-dangle": 0,       // disallow dangling underscores in identifiers
-    "no-wrap-func": 1,               // disallow wrapping of non-IIFE statements in parens
     "no-mixed-spaces-and-tabs": 1,   // disallow mixed spaces and tabs for indentation
     "quotes": [1, "single", "avoid-escape"], // specify whether double or single quotes should be used
     "quote-props": 0,                // require quotes around object literal property names (off by default)

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   ],
   "scripts": {
     "test": "jest",
-    "lint": "node linter.js Examples/ Libraries/",
+    "lint": "eslint Examples/ Libraries/",
     "start": "./packager/packager.sh || true"
   },
   "bin": {
@@ -81,8 +81,8 @@
   },
   "devDependencies": {
     "jest-cli": "0.5.0",
-    "babel-eslint": "3.1.5",
-    "eslint": "0.21.2",
-    "eslint-plugin-react": "2.3.0"
+    "babel-eslint": "4.0.10",
+    "eslint": "1.1.0",
+    "eslint-plugin-react": "3.2.3"
   }
 }


### PR DESCRIPTION
@cesarandreu pointed out running eslint on react-native resulted in `t.isReferencedIdentifier is not a function` issues on the babel #linting channel on slack.

- update eslint, babel-eslint, eslint-plugin-react
- fix eslint errors: `Error - t.isReferencedIdentifier is not a function`
- fix lint npm script

I see there's also https://github.com/facebook/react-native/pull/1736 from @ide which would fix it too