### PR TITLE
Fix incorrect lowercase response headers set for XHR responses

### DIFF
--- a/Libraries/Network/XMLHttpRequestBase.js
+++ b/Libraries/Network/XMLHttpRequestBase.js
@@ -154,7 +154,7 @@ class XMLHttpRequestBase {
     this._lowerCaseResponseHeaders =
       Object.keys(headers).reduce((lcaseHeaders, headerName) => {
         lcaseHeaders[headerName.toLowerCase()] = headers[headerName];
-        return headers;
+        return lcaseHeaders;
       }, {});
   }
 


### PR DESCRIPTION
Trivial change to fix the lowercase response headers set for XHR responses.

What would happen is the first iterated header wouldn't be part of `_lowerCaseResponseHeaders`.
Also it would mutate the original `responseHeaders` object, mixing lowercase headers with the original values.