### PR TITLE
[Navigator] Guard `navigator.state.routeStack` from accidental mutation

### DIFF
--- a/Libraries/CustomComponents/Navigator/Navigator.js
+++ b/Libraries/CustomComponents/Navigator/Navigator.js
@@ -1002,7 +1002,8 @@ var Navigator = React.createClass({
   },
 
   getCurrentRoutes: function() {
-    return this.state.routeStack;
+    // Clone before returning to avoid caller mutating the stack
+    return this.state.routeStack.slice();
   },
 
   _handleItemRef: function(itemId, route, ref) {


### PR DESCRIPTION
A minor improvement suggestion: `Navigator.getCurrentRoutes()` probably shouldn't return its `routeStack` backing array as-is, because the caller may mutate it, causing the internal state of the navigator to go out of sync. Instead a shallow copy of the routes should be returned.

I stumbled on this problem in my app by attempting to read the navigator state as follows:
```
let routes = Navigator.getCurrentRoutes();
let current = routes.pop();
let previous = routes.pop();
```

Which led to an exception at next navigation event.

CLA signed.
 