### PR TITLE
Update NativeModule documentation to show correct event emitter usage

### DIFF
--- a/docs/NativeModulesIOS.md
+++ b/docs/NativeModulesIOS.md
@@ -256,9 +256,9 @@ The native module can signal events to JavaScript without being invoked directly
 JavaScript code can subscribe to these events:
 
 ```javascript
-var { DeviceEventEmitter } = require('react-native');
+var { NativeAppEventEmitter } = require('react-native');
 
-var subscription = DeviceEventEmitter.addListener(
+var subscription = NativeAppEventEmitter.addListener(
   'EventReminder',
   (reminder) => console.log(reminder.name)
 );


### PR DESCRIPTION
It looks like in the various changes to native module events, the documentation has become a little confused. As far as I can tell, if you use `sendAppEventWithName` then the `NativeAppEventEmitter` is used and if `sendDeviceEventWithName` then it should be `DeviceEventEmitter`.