### PR TITLE
App Extension support

### DIFF
--- a/Libraries/ActionSheetIOS/RCTActionSheetManager.m
+++ b/Libraries/ActionSheetIOS/RCTActionSheetManager.m
@@ -62,7 +62,7 @@ RCT_EXPORT_METHOD(showActionSheetWithOptions:(NSDictionary *)options
 
   _callbacks[RCTKeyForInstance(actionSheet)] = successCallback;
 
-  UIWindow *appWindow = [UIApplication sharedApplication].delegate.window;
+  UIWindow *appWindow = RCTSharedApplication().delegate.window;
   if (appWindow == nil) {
     RCTLogError(@"Tried to display action sheet but there is no application window. options: %@", options);
     return;
@@ -87,8 +87,13 @@ RCT_EXPORT_METHOD(showShareActionSheetWithOptions:(NSDictionary *)options
     failureCallback(@[@"No `url` or `message` to share"]);
     return;
   }
+  if (RCTRunningInAppExtension()) {
+    failureCallback(@[@"Unable to show action sheet from app extension"]);
+    return;
+  }
+
   UIActivityViewController *share = [[UIActivityViewController alloc] initWithActivityItems:items applicationActivities:nil];
-  UIViewController *ctrl = [UIApplication sharedApplication].delegate.window.rootViewController;
+  UIViewController *ctrl = RCTSharedApplication().delegate.window.rootViewController;
 
 #if __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_8_0
 
@@ -146,7 +151,7 @@ RCT_EXPORT_METHOD(showShareActionSheetWithOptions:(NSDictionary *)options
     RCTLogWarn(@"No callback registered for action sheet: %@", actionSheet.title);
   }
 
-  [[UIApplication sharedApplication].delegate.window makeKeyWindow];
+  [RCTSharedApplication().delegate.window makeKeyWindow];
 }
 
 #pragma mark Private

--- a/Libraries/ActionSheetIOS/RCTActionSheetManager.m
+++ b/Libraries/ActionSheetIOS/RCTActionSheetManager.m
@@ -43,6 +43,11 @@ RCT_EXPORT_METHOD(showActionSheetWithOptions:(NSDictionary *)options
                   failureCallback:(__unused RCTResponseSenderBlock)failureCallback
                   successCallback:(RCTResponseSenderBlock)successCallback)
 {
+  if (RCTRunningInAppExtension()) {
+    RCTLogError(@"Unable to show action sheet from app extension");
+    return;
+  }
+  
   UIActionSheet *actionSheet = [UIActionSheet new];
 
   actionSheet.title = options[@"title"];

--- a/Libraries/CameraRoll/RCTImagePickerManager.m
+++ b/Libraries/CameraRoll/RCTImagePickerManager.m
@@ -10,6 +10,8 @@
 
 #import "RCTImagePickerManager.h"
 #import "RCTRootView.h"
+#import "RCTLog.h"
+#import "RCTUtils.h"
 
 #import <UIKit/UIKit.h>
 
@@ -53,7 +55,12 @@ RCT_EXPORT_METHOD(openCameraDialog:(NSDictionary *)config
                   successCallback:(RCTResponseSenderBlock)callback
                   cancelCallback:(RCTResponseSenderBlock)cancelCallback)
 {
-  UIWindow *keyWindow = [UIApplication sharedApplication].keyWindow;
+  if (RCTRunningInAppExtension()) {
+    cancelCallback(@[@"Camera access is unavailable in an app extension"]);
+    return;
+  }
+  
+  UIWindow *keyWindow = RCTSharedApplication().keyWindow;
   UIViewController *rootViewController = keyWindow.rootViewController;
 
   UIImagePickerController *imagePicker = [UIImagePickerController new];
@@ -75,7 +82,12 @@ RCT_EXPORT_METHOD(openSelectDialog:(NSDictionary *)config
                   successCallback:(RCTResponseSenderBlock)callback
                   cancelCallback:(RCTResponseSenderBlock)cancelCallback)
 {
-  UIWindow *keyWindow = [UIApplication sharedApplication].keyWindow;
+  if (RCTRunningInAppExtension()) {
+    cancelCallback(@[@"Image picker is currently unavailable in an app extension"]);
+    return;
+  }
+  
+  UIWindow *keyWindow = RCTSharedApplication().keyWindow;
   UIViewController *rootViewController = keyWindow.rootViewController;
 
   UIImagePickerController *imagePicker = [UIImagePickerController new];
@@ -109,7 +121,7 @@ didFinishPickingMediaWithInfo:(NSDictionary *)info
   [_pickerCallbacks removeObjectAtIndex:index];
   [_pickerCancelCallbacks removeObjectAtIndex:index];
 
-  UIWindow *keyWindow = [UIApplication sharedApplication].keyWindow;
+  UIWindow *keyWindow = RCTSharedApplication().keyWindow;
   UIViewController *rootViewController = keyWindow.rootViewController;
   [rootViewController dismissViewControllerAnimated:YES completion:nil];
 
@@ -125,7 +137,7 @@ didFinishPickingMediaWithInfo:(NSDictionary *)info
   [_pickerCallbacks removeObjectAtIndex:index];
   [_pickerCancelCallbacks removeObjectAtIndex:index];
 
-  UIWindow *keyWindow = [UIApplication sharedApplication].keyWindow;
+  UIWindow *keyWindow = RCTSharedApplication().keyWindow;
   UIViewController *rootViewController = keyWindow.rootViewController;
   [rootViewController dismissViewControllerAnimated:YES completion:nil];
 

--- a/Libraries/LinkingIOS/RCTLinkingManager.m
+++ b/Libraries/LinkingIOS/RCTLinkingManager.m
@@ -58,14 +58,20 @@ RCT_EXPORT_MODULE()
 RCT_EXPORT_METHOD(openURL:(NSURL *)URL)
 {
   // Doesn't really matter what thread we call this on since it exits the app
-  [[UIApplication sharedApplication] openURL:URL];
+  [RCTSharedApplication() openURL:URL];
 }
 
 RCT_EXPORT_METHOD(canOpenURL:(NSURL *)URL
                   callback:(RCTResponseSenderBlock)callback)
 {
+  if (RCTRunningInAppExtension()) {
+    // Technically Today widgets can open urls, but supporting that would require
+    // a reference to the NSExtensionContext
+    callback(@[@(NO)]);
+  }
+
   // This can be expensive, so we deliberately don't call on main thread
-  BOOL canOpen = [[UIApplication sharedApplication] canOpenURL:URL];
+  BOOL canOpen = [RCTSharedApplication() canOpenURL:URL];
   callback(@[@(canOpen)]);
 }
 

--- a/Libraries/PushNotificationIOS/RCTPushNotificationManager.m
+++ b/Libraries/PushNotificationIOS/RCTPushNotificationManager.m
@@ -122,7 +122,7 @@ RCT_EXPORT_MODULE()
  */
 RCT_EXPORT_METHOD(setApplicationIconBadgeNumber:(NSInteger)number)
 {
-  [UIApplication sharedApplication].applicationIconBadgeNumber = number;
+  RCTSharedApplication().applicationIconBadgeNumber = number;
 }
 
 /**
@@ -131,12 +131,16 @@ RCT_EXPORT_METHOD(setApplicationIconBadgeNumber:(NSInteger)number)
 RCT_EXPORT_METHOD(getApplicationIconBadgeNumber:(RCTResponseSenderBlock)callback)
 {
   callback(@[
-    @([UIApplication sharedApplication].applicationIconBadgeNumber)
+    @(RCTSharedApplication().applicationIconBadgeNumber)
   ]);
 }
 
 RCT_EXPORT_METHOD(requestPermissions:(NSDictionary *)permissions)
 {
+  if (RCTRunningInAppExtension()) {
+    return;
+  }
+
   UIUserNotificationType types = UIUserNotificationTypeNone;
   if (permissions) {
     if ([permissions[@"alert"] boolValue]) {
@@ -152,15 +156,16 @@ RCT_EXPORT_METHOD(requestPermissions:(NSDictionary *)permissions)
     types = UIUserNotificationTypeAlert | UIUserNotificationTypeBadge | UIUserNotificationTypeSound;
   }
 
+  UIApplication *app = RCTSharedApplication();
 #if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_8_0
 
   id notificationSettings = [UIUserNotificationSettings settingsForTypes:types categories:nil];
-  [[UIApplication sharedApplication] registerUserNotificationSettings:notificationSettings];
-  [[UIApplication sharedApplication] registerForRemoteNotifications];
-
+  [app registerUserNotificationSettings:notificationSettings];
+  [app registerForRemoteNotifications];
+  
 #else
-
-  [[UIApplication sharedApplication] registerForRemoteNotificationTypes:types];
+  
+  [app registerForRemoteNotificationTypes:types];
 
 #endif
 
@@ -168,19 +173,25 @@ RCT_EXPORT_METHOD(requestPermissions:(NSDictionary *)permissions)
 
 RCT_EXPORT_METHOD(abandonPermissions)
 {
-  [[UIApplication sharedApplication] unregisterForRemoteNotifications];
+  [RCTSharedApplication() unregisterForRemoteNotifications];
 }
 
 RCT_EXPORT_METHOD(checkPermissions:(RCTResponseSenderBlock)callback)
 {
+  if (RCTRunningInAppExtension()) {
+    NSDictionary *permissions = @{@"alert": @(NO), @"badge": @(NO), @"sound": @(NO)};
+    callback(@[permissions]);
+    return;
+  }
+
   NSUInteger types = 0;
   if ([UIApplication instancesRespondToSelector:@selector(currentUserNotificationSettings)]) {
-    types = [[UIApplication sharedApplication] currentUserNotificationSettings].types;
+    types = [RCTSharedApplication() currentUserNotificationSettings].types;
   } else {
 
 #if __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_8_0
 
-    types = [[UIApplication sharedApplication] enabledRemoteNotificationTypes];
+    types = [RCTSharedApplication() enabledRemoteNotificationTypes];
 
 #endif
 

--- a/Libraries/PushNotificationIOS/RCTPushNotificationManager.m
+++ b/Libraries/PushNotificationIOS/RCTPushNotificationManager.m
@@ -214,13 +214,13 @@ RCT_EXPORT_METHOD(checkPermissions:(RCTResponseSenderBlock)callback)
 
 RCT_EXPORT_METHOD(presentLocalNotification:(UILocalNotification *)notification)
 {
-  [[UIApplication sharedApplication] presentLocalNotificationNow:notification];
+  [RCTSharedApplication() presentLocalNotificationNow:notification];
 }
 
 
 RCT_EXPORT_METHOD(scheduleLocalNotification:(UILocalNotification *)notification)
 {
-  [[UIApplication sharedApplication] scheduleLocalNotification:notification];
+  [RCTSharedApplication() scheduleLocalNotification:notification];
 }
 
 @end

--- a/Libraries/PushNotificationIOS/RCTPushNotificationManager.m
+++ b/Libraries/PushNotificationIOS/RCTPushNotificationManager.m
@@ -158,17 +158,12 @@ RCT_EXPORT_METHOD(requestPermissions:(NSDictionary *)permissions)
 
   UIApplication *app = RCTSharedApplication();
 #if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_8_0
-
   id notificationSettings = [UIUserNotificationSettings settingsForTypes:types categories:nil];
   [app registerUserNotificationSettings:notificationSettings];
   [app registerForRemoteNotifications];
-  
 #else
-  
   [app registerForRemoteNotificationTypes:types];
-
 #endif
-
 }
 
 RCT_EXPORT_METHOD(abandonPermissions)

--- a/React/Base/RCTPerfStats.m
+++ b/React/Base/RCTPerfStats.m
@@ -10,6 +10,7 @@
 #import "RCTPerfStats.h"
 
 #import "RCTDefines.h"
+#import "RCTUtils.h"
 
 #if RCT_DEV
 
@@ -66,7 +67,11 @@ RCT_EXPORT_MODULE()
 
 - (void)show
 {
-  UIView *targetView = [UIApplication sharedApplication].delegate.window.rootViewController.view;
+  if (RCTRunningInAppExtension()) {
+    return;
+  }
+  
+  UIView *targetView = RCTSharedApplication().delegate.window.rootViewController.view;
 
   targetView.frame = (CGRect){
     targetView.frame.origin,

--- a/React/Base/RCTUtils.h
+++ b/React/Base/RCTUtils.h
@@ -11,6 +11,7 @@
 
 #import <CoreGraphics/CoreGraphics.h>
 #import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
 #import "RCTAssert.h"
 #import "RCTDefines.h"
@@ -50,6 +51,16 @@ RCT_EXTERN NSDictionary *RCTJSErrorFromNSError(NSError *error);
 
 // Returns YES if React is running in a test environment
 RCT_EXTERN BOOL RCTRunningInTestEnvironment(void);
+
+// Returns YES if React is running in an iOS App Extension
+RCT_EXTERN BOOL RCTRunningInAppExtension(void);
+
+// Returns the shared UIApplication instance, or nil if running in an App Extension
+RCT_EXTERN UIApplication *RCTSharedApplication(void);
+
+// Return a UIAlertView initialized with the given values
+// or nil if running in an app extension
+RCT_EXTERN UIAlertView *RCTAlertView(NSString *title, NSString *message, id delegate, NSString *cancelButtonTitle, NSArray *otherButtonTitles);
 
 // Return YES if image has an alpha component
 RCT_EXTERN BOOL RCTImageHasAlpha(CGImageRef image);

--- a/React/Base/RCTUtils.m
+++ b/React/Base/RCTUtils.m
@@ -362,8 +362,10 @@ id RCTAlertView(NSString *title, NSString *message, id delegate, NSString *cance
   alertView.title = title;
   alertView.message = message;
   alertView.delegate = delegate;
-  [alertView addButtonWithTitle:cancelButtonTitle];
-  alertView.cancelButtonIndex = 0;
+  if (cancelButtonTitle != nil) {
+    [alertView addButtonWithTitle:cancelButtonTitle];
+    alertView.cancelButtonIndex = 0;
+  }
   for (NSString *buttonTitle in otherButtonTitles)
   {
     [alertView addButtonWithTitle:buttonTitle];

--- a/React/Base/RCTUtils.m
+++ b/React/Base/RCTUtils.m
@@ -337,6 +337,44 @@ BOOL RCTRunningInTestEnvironment(void)
   return isTestEnvironment;
 }
 
+BOOL RCTRunningInAppExtension(void)
+{
+  return [[[[NSBundle mainBundle] bundlePath] pathExtension] isEqualToString:@"appex"];
+}
+
+id RCTSharedApplication(void)
+{
+  if (RCTRunningInAppExtension()) {
+    return nil;
+  }
+  
+  return [[UIApplication class] performSelector:@selector(sharedApplication)];
+}
+
+id RCTAlertView(NSString *title, NSString *message, id delegate, NSString *cancelButtonTitle, NSArray *otherButtonTitles)
+{
+  if (RCTRunningInAppExtension()) {
+    RCTLogError(@"RCTAlertView is unavailable when running in an app extension");
+    return nil;
+  }
+  
+  UIAlertView *alertView = [UIAlertView alloc];
+  
+  NSInvocation *initInvocation = [NSInvocation invocationWithMethodSignature:
+                                  [alertView methodSignatureForSelector:
+                                   @selector(initWithTitle:message:delegate:cancelButtonTitle:otherButtonTitles:)]];
+  [initInvocation setTarget:alertView];
+  [initInvocation setSelector:@selector(initWithTitle:message:delegate:cancelButtonTitle:otherButtonTitles:)];
+  [initInvocation setArgument:&title atIndex:2];
+  [initInvocation setArgument:&message atIndex:3];
+  [initInvocation setArgument:&delegate atIndex:4];
+  [initInvocation setArgument:&cancelButtonTitle atIndex:5];
+  [initInvocation setArgument:&otherButtonTitles atIndex:6];
+  [initInvocation invoke];
+  [initInvocation getReturnValue:&alertView];
+  return alertView;
+}
+
 BOOL RCTImageHasAlpha(CGImageRef image)
 {
   switch (CGImageGetAlphaInfo(image)) {

--- a/React/Base/RCTUtils.m
+++ b/React/Base/RCTUtils.m
@@ -358,20 +358,16 @@ id RCTAlertView(NSString *title, NSString *message, id delegate, NSString *cance
     return nil;
   }
   
-  UIAlertView *alertView = [UIAlertView alloc];
-  
-  NSInvocation *initInvocation = [NSInvocation invocationWithMethodSignature:
-                                  [alertView methodSignatureForSelector:
-                                   @selector(initWithTitle:message:delegate:cancelButtonTitle:otherButtonTitles:)]];
-  [initInvocation setTarget:alertView];
-  [initInvocation setSelector:@selector(initWithTitle:message:delegate:cancelButtonTitle:otherButtonTitles:)];
-  [initInvocation setArgument:&title atIndex:2];
-  [initInvocation setArgument:&message atIndex:3];
-  [initInvocation setArgument:&delegate atIndex:4];
-  [initInvocation setArgument:&cancelButtonTitle atIndex:5];
-  [initInvocation setArgument:&otherButtonTitles atIndex:6];
-  [initInvocation invoke];
-  [initInvocation getReturnValue:&alertView];
+  UIAlertView *alertView = [[UIAlertView alloc] init];
+  alertView.title = title;
+  alertView.message = message;
+  alertView.delegate = delegate;
+  [alertView addButtonWithTitle:cancelButtonTitle];
+  alertView.cancelButtonIndex = 0;
+  for (NSString *buttonTitle in otherButtonTitles)
+  {
+    [alertView addButtonWithTitle:buttonTitle];
+  }
   return alertView;
 }
 

--- a/React/Modules/RCTAlertManager.m
+++ b/React/Modules/RCTAlertManager.m
@@ -76,7 +76,6 @@ RCT_EXPORT_METHOD(alertWithArgs:(NSDictionary *)args
   }
   
   UIAlertView *alertView = RCTAlertView(title, nil, self, nil, nil);
-
   NSMutableArray *buttonKeys = [[NSMutableArray alloc] initWithCapacity:buttons.count];
 
   if ([type isEqualToString:@"plain-text"]) {

--- a/React/Modules/RCTAlertManager.m
+++ b/React/Modules/RCTAlertManager.m
@@ -11,6 +11,7 @@
 
 #import "RCTAssert.h"
 #import "RCTLog.h"
+#import "RCTUtils.h"
 
 @interface RCTAlertManager() <UIAlertViewDelegate>
 
@@ -69,12 +70,13 @@ RCT_EXPORT_METHOD(alertWithArgs:(NSDictionary *)args
     RCTLogError(@"Must have at least one button.");
     return;
   }
-
-  UIAlertView *alertView = [[UIAlertView alloc] initWithTitle:title
-                                                      message:nil
-                                                     delegate:self
-                                            cancelButtonTitle:nil
-                                            otherButtonTitles:nil];
+  
+  if (RCTRunningInAppExtension()) {
+    RCTLogError(@"RCTAlertManager is unavailable when running in an app extension");
+    return;
+  }
+  
+  UIAlertView *alertView = RCTAlertView(title, nil, self, nil, nil);
 
   NSMutableArray *buttonKeys = [[NSMutableArray alloc] initWithCapacity:buttons.count];
 

--- a/React/Modules/RCTAlertManager.m
+++ b/React/Modules/RCTAlertManager.m
@@ -72,7 +72,6 @@ RCT_EXPORT_METHOD(alertWithArgs:(NSDictionary *)args
   }
   
   if (RCTRunningInAppExtension()) {
-    RCTLogError(@"RCTAlertManager is unavailable when running in an app extension");
     return;
   }
   

--- a/React/Modules/RCTAppState.m
+++ b/React/Modules/RCTAppState.m
@@ -12,6 +12,7 @@
 #import "RCTAssert.h"
 #import "RCTBridge.h"
 #import "RCTEventDispatcher.h"
+#import "RCTUtils.h"
 
 static NSString *RCTCurrentAppBackgroundState()
 {
@@ -25,7 +26,11 @@ static NSString *RCTCurrentAppBackgroundState()
     };
   });
 
-  return states[@([UIApplication sharedApplication].applicationState)] ?: @"unknown";
+  if (RCTRunningInAppExtension()) {
+    return @"extension";
+  }
+
+  return states[@(RCTSharedApplication().applicationState)] ?: @"unknown";
 }
 
 @implementation RCTAppState

--- a/React/Modules/RCTDevMenu.m
+++ b/React/Modules/RCTDevMenu.m
@@ -407,11 +407,8 @@ RCT_EXPORT_MODULE()
   Class chromeExecutorClass = NSClassFromString(@"RCTWebSocketExecutor");
   if (!chromeExecutorClass) {
     [items addObject:[RCTDevMenuItem buttonItemWithTitle:@"Chrome Debugger Unavailable" handler:^{
-      [[[UIAlertView alloc] initWithTitle:@"Chrome Debugger Unavailable"
-                                  message:@"You need to include the RCTWebSocket library to enable Chrome debugging"
-                                 delegate:nil
-                        cancelButtonTitle:@"OK"
-                        otherButtonTitles:nil] show];
+      UIAlertView *alert = RCTAlertView(@"Chrome Debugger Unavailable", @"You need to include the RCTWebSocket library to enable Chrome debugging", nil, @"OK", nil);
+      [alert show];
     }]];
   } else {
     BOOL isDebuggingInChrome = _executorClass && _executorClass == chromeExecutorClass;
@@ -474,7 +471,7 @@ RCT_EXPORT_METHOD(show)
   actionSheet.cancelButtonIndex = actionSheet.numberOfButtons - 1;
 
   actionSheet.actionSheetStyle = UIBarStyleBlack;
-  [actionSheet showInView:[UIApplication sharedApplication].keyWindow.rootViewController.view];
+  [actionSheet showInView:RCTSharedApplication().keyWindow.rootViewController.view];
   _actionSheet = actionSheet;
   _presentedItems = items;
 }

--- a/React/Modules/RCTDevMenu.m
+++ b/React/Modules/RCTDevMenu.m
@@ -444,7 +444,7 @@ RCT_EXPORT_MODULE()
 
 RCT_EXPORT_METHOD(show)
 {
-  if (_actionSheet || !_bridge) {
+  if (_actionSheet || !_bridge || RCTRunningInAppExtension()) {
     return;
   }
 

--- a/React/Modules/RCTRedBox.m
+++ b/React/Modules/RCTRedBox.m
@@ -126,7 +126,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
 {
   self.hidden = YES;
   [self resignFirstResponder];
-  [[UIApplication sharedApplication].delegate.window makeKeyWindow];
+  [RCTSharedApplication().delegate.window makeKeyWindow];
 }
 
 - (void)reload

--- a/React/Modules/RCTStatusBarManager.m
+++ b/React/Modules/RCTStatusBarManager.m
@@ -11,6 +11,7 @@
 
 #import "RCTEventDispatcher.h"
 #import "RCTLog.h"
+#import "RCTUtils.h"
 
 @implementation RCTConvert (UIStatusBar)
 
@@ -97,8 +98,8 @@ RCT_EXPORT_METHOD(setStyle:(UIStatusBarStyle)statusBarStyle
     RCTLogError(@"RCTStatusBarManager module requires that the \
                 UIViewControllerBasedStatusBarAppearance key in the Info.plist is set to NO");
   } else {
-    [[UIApplication sharedApplication] setStatusBarStyle:statusBarStyle
-                                                animated:animated];
+    [RCTSharedApplication() setStatusBarStyle:statusBarStyle
+                                     animated:animated];
   }
 }
 
@@ -109,8 +110,8 @@ RCT_EXPORT_METHOD(setHidden:(BOOL)hidden
     RCTLogError(@"RCTStatusBarManager module requires that the \
                 UIViewControllerBasedStatusBarAppearance key in the Info.plist is set to NO");
   } else {
-    [[UIApplication sharedApplication] setStatusBarHidden:hidden
-                                            withAnimation:animation];
+    [RCTSharedApplication() setStatusBarHidden:hidden
+                                 withAnimation:animation];
   }
 }
 

--- a/React/Modules/RCTStatusBarManager.m
+++ b/React/Modules/RCTStatusBarManager.m
@@ -117,7 +117,7 @@ RCT_EXPORT_METHOD(setHidden:(BOOL)hidden
 
 RCT_EXPORT_METHOD(setNetworkActivityIndicatorVisible:(BOOL)visible)
 {
-  [UIApplication sharedApplication].networkActivityIndicatorVisible = visible;
+  RCTSharedApplication().networkActivityIndicatorVisible = visible;
 }
 
 @end


### PR DESCRIPTION
This adds workarounds for the code that was preventing React from compiling when linked against an iOS App Extension target.

Some iOS APIs are unavailable to App Extensions, and Xcode's static analysis will catch attempts to use methods that have been flagged as unavailable.

React currently uses two APIs that are off limits to extensions: `[UIApplication sharedApplication]` and `[UIAlertView initWith ...]`.

This commit adds a helper function to `RCTUtils.[hm]` called `RCTRunningInAppExtension()`, which returns `YES` if, at runtime, it can be determined that we're running in an app extension (by checking whether the path to `[NSBundle mainBundle]` has the `"appex"` path extension).

It also adds a `RCTSharedApplication()` function, which will return `nil` if running in an App Extension. If running in an App, `RCTSharedApplication()` calls `sharedApplication` by calling `performSelector:` on the `UIApplication` class.  This passes the static analysis check, and, in my opinion, obeys the "spirit of the law" by only calling `sharedApplication` after we've determined that it's kosher to do so.

Existing calls to `[UIApplication sharedApplication]` have been replaced with calls to `RCTSharedApplication()`, with `nil` checks where appropriate.

The absence of `UIAlertView` is similarly handled with a runtime workaround.  If we're running in an App, the  `RCTAlertView(NSString *title, NSString *message, id delegate, NSString *cancelButtonTitle, NSArray *otherButtonTitles)` function uses `NSInvocation` to call the extension-unavailable `initWithTitle:message:delegate:cancelButtonTitle:otherButtonTitles:` selector.  In an Extension it just logs an error and returns `nil`.

As a result of these changes, React can be linked into a shared library that is then linked into both an App and an App Extension. When running in the App, all existing functionality will continue to work as before.  When running in the Extension, `AlertIOS` will be unavailable, as will APIs that depend on access to `[UIApplication sharedApplication]`.

APIs that are unavailable to extensions are: 
- `RCTActionSheetManager` - uses `sharedApplication` to access the `window` of the app delegate
- `RCTImagePickerManager` - uses `sharedApplication` to get the `keyWindow` property
- `RCTLinkingManager` - uses `sharedApplication` to open URLs
- `RCTPushNotificationManager` - uses `sharedApplication` to badge the app icon and register for permissions
- `RCTDevMenu` - uses `sharedApplication` to get the `keyWindow` property
- `RCTPerfStats` - uses `sharedApplication` to access the `window` of the app delegate

`RCTAppState` has been updated to return `"extension"` if running in an app extension.

This PR doesn't attempt to expose the `NSExtensionContext` to javascript, although a native module could be written to do so.

`UIExplorer` integration and unit tests all pass.  I have a basic proof of concept app, but it needs some cleanup; I'll push it to a repo soonish
