### PR TITLE
[Text] Highlight text when onPress provided and suppressHighlight != false

### DIFF
--- a/Libraries/Text/RCTShadowText.h
+++ b/Libraries/Text/RCTShadowText.h
@@ -9,7 +9,6 @@
 
 #import "RCTShadowView.h"
 
-extern NSString *const RCTIsHighlightedAttributeName;
 extern NSString *const RCTReactTagAttributeName;
 
 @interface RCTShadowText : RCTShadowView

--- a/Libraries/Text/RCTShadowText.m
+++ b/Libraries/Text/RCTShadowText.m
@@ -16,7 +16,6 @@
 #import "RCTText.h"
 #import "RCTUtils.h"
 
-NSString *const RCTIsHighlightedAttributeName = @"IsHighlightedAttributeName";
 NSString *const RCTReactTagAttributeName = @"ReactTagAttributeName";
 
 @implementation RCTShadowText
@@ -179,12 +178,14 @@ static css_dim_t RCTMeasure(void *context, float width)
     [child setTextComputed];
   }
 
-  if (_color) {
+  if (_color && _isHighlighted) {
+    [self _addAttribute:NSForegroundColorAttributeName withValue:[_color colorWithAlphaComponent:0.2f] toAttributedString:attributedString];
+  } else if (!_color && _isHighlighted) {
+    [self _addAttribute:NSForegroundColorAttributeName withValue:[[UIColor darkTextColor] colorWithAlphaComponent:0.2f] toAttributedString:attributedString];
+  } else if (_color && !_isHighlighted) {
     [self _addAttribute:NSForegroundColorAttributeName withValue:_color toAttributedString:attributedString];
   }
-  if (_isHighlighted) {
-    [self _addAttribute:RCTIsHighlightedAttributeName withValue:@YES toAttributedString:attributedString];
-  }
+
   if (useBackgroundColor && self.backgroundColor) {
     [self _addAttribute:NSBackgroundColorAttributeName withValue:self.backgroundColor toAttributedString:attributedString];
   }


### PR DESCRIPTION
As per #303, prompted by the more recent issue #1863, this seems like something we should be supporting. This is a pretty simple implementation of it that just changes the opacity of the font color (or `[UIColor darkTextColor]` if none is provided) to 0.2 (same as TouchableOpacity). Works on nested text so you can provide touchable links.

![touchy](https://cloud.githubusercontent.com/assets/90494/8558567/f4472854-24b9-11e5-9649-b45738705c95.gif)

[Example code if you want to try it](https://gist.github.com/brentvatne/a61355f95427b3b608ab)