### PR TITLE
[MapView] add image support for annotation callouts, refactored config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,3 +82,4 @@ env:
 branches:
   only:
     - master
+    - /^.*-stable$/

--- a/Examples/UIExplorer/MapViewExample.js
+++ b/Examples/UIExplorer/MapViewExample.js
@@ -179,6 +179,18 @@ var MapViewExample = React.createClass({
       longitude: region.longitude,
       latitude: region.latitude,
       title: 'You Are Here',
+      rightCallout: {
+        type: "button",
+        onPress: function() {
+          console.info("You clicked me");
+        }
+      },
+      leftCallout: {
+        type: "image",
+        config: {
+          image: "http://facebook.github.io/react-native/img/opengraph.png?2"
+        }
+      }
     }];
   },
 

--- a/Libraries/Components/MapView/MapView.js
+++ b/Libraries/Components/MapView/MapView.js
@@ -171,11 +171,6 @@ var MapView = React.createClass({
       rightCallout: React.PropTypes.arrayOf(React.PropTypes.shape({
 
         /**
-         * Bool, whether the callout is enabled or not
-         */
-        enabled: React.PropTypes.bool,
-
-        /**
          * Type of the callout. If image, set src in config
          */
         type: React.PropTypes.oneOf([
@@ -205,11 +200,6 @@ var MapView = React.createClass({
        * Left callout
        */
       leftCallout: React.PropTypes.arrayOf(React.PropTypes.shape({
-
-        /**
-         * Bool, whether the callout is enabled or not
-         */
-        enabled: React.PropTypes.bool,
 
         /**
          * Type of the callout. If image, set src in config

--- a/Libraries/Components/MapView/MapView.js
+++ b/Libraries/Components/MapView/MapView.js
@@ -191,6 +191,21 @@ var MapView = React.createClass({
           /**
            * Is being used when type == image. use the same input as for Image
            */
+          imageSize: React.PropTypes.shape({
+            /**
+             * Width of the image to be initialized
+             */
+            width: React.PropTypes.number,
+
+            /**
+             * Height of the image to be initialized
+             */
+            height: React.PropTypes.number
+          }),
+
+          /**
+           * Is being used when type == image. use the same input as for Image
+           */
           image: React.PropTypes.string,
 
           /**
@@ -223,6 +238,21 @@ var MapView = React.createClass({
          * Additional config parameters to pass to the callout.
          */
         config: React.PropTypes.shape({
+
+          /**
+           * Is being used when type == image. use the same input as for Image
+           */
+          imageSize: React.PropTypes.shape({
+            /**
+             * Width of the image to be initialized
+             */
+            width: React.PropTypes.number,
+
+            /**
+             * Height of the image to be initialized
+             */
+            height: React.PropTypes.number
+          }),
 
           /**
            * Is being used when type == image. use the same input as for Image

--- a/Libraries/Components/MapView/MapView.js
+++ b/Libraries/Components/MapView/MapView.js
@@ -168,11 +168,13 @@ var MapView = React.createClass({
       /**
        * Right callout
        */
-      rightCallout: {
+      rightCallout: React.PropTypes.arrayOf(React.PropTypes.shape({
+
         /**
          * Bool, whether the callout is enabled or not
          */
         enabled: React.PropTypes.bool,
+
         /**
          * Type of the callout. If image, set src in config
          */
@@ -180,30 +182,35 @@ var MapView = React.createClass({
           'button',
           'image'
         ]),
+
         /**
          * Callback for when the accessory is clicked
          * Currently only works on button and not image
          */
         onPress: React.PropTypes.func,
+
         /**
          * Additional config parameters to pass to the callout. 
          */
-        config: {
+        config: React.PropTypes.arrayOf(React.PropTypes.shape({
+
           /**
            * Is being used when type == image. use the same input as for Image
            */
           src: React.PropTypes.string
-        }
-      },
+        }))
+      })),
 
       /**
        * Left callout
        */
-      leftCallout: {
+      leftCallout: React.PropTypes.arrayOf(React.PropTypes.shape({
+
         /**
          * Bool, whether the callout is enabled or not
          */
         enabled: React.PropTypes.bool,
+
         /**
          * Type of the callout. If image, set src in config
          */
@@ -211,21 +218,24 @@ var MapView = React.createClass({
           'button',
           'image'
         ]),
+
         /**
          * Callback for when the accessory is clicked
          * Currently only works on button and not image
          */
         onPress: React.PropTypes.func,
+
         /**
          * Additional config parameters to pass to the callout. 
          */
-        config: {
+        config: React.PropTypes.arrayOf(React.PropTypes.shape({
+
           /**
            * Is being used when type == image. use the same input as for Image
            */
           src: React.PropTypes.string
-        }
-      },
+        }))
+      })),
 
       /**
        * annotation id

--- a/Libraries/Components/MapView/MapView.js
+++ b/Libraries/Components/MapView/MapView.js
@@ -23,6 +23,7 @@ var deepDiffer = require('deepDiffer');
 var insetsDiffer = require('insetsDiffer');
 var merge = require('merge');
 var requireNativeComponent = require('requireNativeComponent');
+var resolveAssetSource = require('resolveAssetSource');
 
 type Event = Object;
 type MapRegion = {
@@ -50,7 +51,6 @@ var MapView = React.createClass({
       annotations: newAnnotations
     });
   },
-
   componentWillMount: function() {
     if (this.props.annotations) {
       this.checkAnnotationIds(this.props.annotations);
@@ -141,7 +141,7 @@ var MapView = React.createClass({
        * to be displayed.
        */
       latitudeDelta: React.PropTypes.number.isRequired,
-      longitudeDelta: React.PropTypes.number.isRequired,
+      longitudeDelta: React.PropTypes.number.isRequired
     }),
 
     /**
@@ -166,16 +166,66 @@ var MapView = React.createClass({
       subtitle: React.PropTypes.string,
 
       /**
-       * Whether the Annotation has callout buttons.
+       * Right callout
        */
-      hasLeftCallout: React.PropTypes.bool,
-      hasRightCallout: React.PropTypes.bool,
+      rightCallout: {
+        /**
+         * Bool, whether the callout is enabled or not
+         */
+        enabled: React.PropTypes.bool,
+        /**
+         * Type of the callout. If image, set src in config
+         */
+        type: React.PropTypes.oneOf([
+          'button',
+          'image'
+        ]),
+        /**
+         * Callback for when the accessory is clicked
+         * Currently only works on button and not image
+         */
+        onPress: React.PropTypes.func,
+        /**
+         * Additional config parameters to pass to the callout. 
+         */
+        config: {
+          /**
+           * Is being used when type == image. use the same input as for Image
+           */
+          src: React.PropTypes.string
+        }
+      },
 
       /**
-       * Event handlers for callout buttons.
+       * Left callout
        */
-      onLeftCalloutPress: React.PropTypes.func,
-      onRightCalloutPress: React.PropTypes.func,
+      leftCallout: {
+        /**
+         * Bool, whether the callout is enabled or not
+         */
+        enabled: React.PropTypes.bool,
+        /**
+         * Type of the callout. If image, set src in config
+         */
+        type: React.PropTypes.oneOf([
+          'button',
+          'image'
+        ]),
+        /**
+         * Callback for when the accessory is clicked
+         * Currently only works on button and not image
+         */
+        onPress: React.PropTypes.func,
+        /**
+         * Additional config parameters to pass to the callout. 
+         */
+        config: {
+          /**
+           * Is being used when type == image. use the same input as for Image
+           */
+          src: React.PropTypes.string
+        }
+      },
 
       /**
        * annotation id
@@ -242,9 +292,9 @@ var MapView = React.createClass({
         if (annotation.id === event.nativeEvent.annotationId) {
           // Pass the right function
           if (event.nativeEvent.side === 'left') {
-            annotation.onLeftCalloutPress && annotation.onLeftCalloutPress(event.nativeEvent);
+            annotation.leftCallout.onPress && annotation.leftCallout.onPress(event.nativeEvent);
           } else if (event.nativeEvent.side === 'right') {
-            annotation.onRightCalloutPress && annotation.onRightCalloutPress(event.nativeEvent);
+            annotation.rightCallout.onPress && annotation.rightCallout.onPress(event.nativeEvent);
           }
         }
       }

--- a/Libraries/Components/MapView/MapView.js
+++ b/Libraries/Components/MapView/MapView.js
@@ -196,7 +196,7 @@ var MapView = React.createClass({
           /**
            * Default Image is being used when the image has to get loaded
            */
-          defaultImage: React.PropTypes.string
+          defaultImage: React.PropTypes.shape
         })
       }),
 
@@ -232,7 +232,7 @@ var MapView = React.createClass({
           /**
            * Default Image is being used when the image has to get loaded
            */
-          defaultImage: React.PropTypes.string
+          defaultImage: React.PropTypes.shape
         })
       }),
 

--- a/Libraries/Components/MapView/MapView.js
+++ b/Libraries/Components/MapView/MapView.js
@@ -36,8 +36,7 @@ type MapRegion = {
 var MapView = React.createClass({
   mixins: [NativeMethodsMixin],
 
-  checkAnnotationIds: function (annotations: Array<Object>) {
-
+  checkAnnotationData: function(annotations: Array<Object>) {
     var newAnnotations = annotations.map(function (annotation) {
       if (!annotation.id) {
         // TODO: add a base64 (or similar) encoder here
@@ -53,13 +52,13 @@ var MapView = React.createClass({
   },
   componentWillMount: function() {
     if (this.props.annotations) {
-      this.checkAnnotationIds(this.props.annotations);
+      this.checkAnnotationData(this.props.annotations);
     }
   },
 
   componentWillReceiveProps: function(nextProps: Object) {
     if (nextProps.annotations) {
-      this.checkAnnotationIds(nextProps.annotations);
+      this.checkAnnotationData(nextProps.annotations);
     }
   },
 
@@ -168,7 +167,7 @@ var MapView = React.createClass({
       /**
        * Right callout
        */
-      rightCallout: React.PropTypes.arrayOf(React.PropTypes.shape({
+      rightCallout: React.PropTypes.shape({
 
         /**
          * Type of the callout. If image, set src in config
@@ -185,21 +184,26 @@ var MapView = React.createClass({
         onPress: React.PropTypes.func,
 
         /**
-         * Additional config parameters to pass to the callout. 
+         * Additional config parameters to pass to the callout.
          */
-        config: React.PropTypes.arrayOf(React.PropTypes.shape({
+        config: React.PropTypes.shape({
 
           /**
            * Is being used when type == image. use the same input as for Image
            */
-          src: React.PropTypes.string
-        }))
-      })),
+          image: React.PropTypes.string,
+
+          /**
+           * Default Image is being used when the image has to get loaded
+           */
+          defaultImage: React.PropTypes.string
+        })
+      }),
 
       /**
        * Left callout
        */
-      leftCallout: React.PropTypes.arrayOf(React.PropTypes.shape({
+      leftCallout: React.PropTypes.shape({
 
         /**
          * Type of the callout. If image, set src in config
@@ -216,16 +220,21 @@ var MapView = React.createClass({
         onPress: React.PropTypes.func,
 
         /**
-         * Additional config parameters to pass to the callout. 
+         * Additional config parameters to pass to the callout.
          */
-        config: React.PropTypes.arrayOf(React.PropTypes.shape({
+        config: React.PropTypes.shape({
 
           /**
            * Is being used when type == image. use the same input as for Image
            */
-          src: React.PropTypes.string
-        }))
-      })),
+          image: React.PropTypes.string,
+
+          /**
+           * Default Image is being used when the image has to get loaded
+           */
+          defaultImage: React.PropTypes.string
+        })
+      }),
 
       /**
        * annotation id

--- a/React.podspec
+++ b/React.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                = "React"
-  s.version             = "0.14.0-rc"
+  s.version             = "0.14.0"
   s.summary             = "Build high quality mobile apps using React."
   s.description         = <<-DESC
                             React Native apps are built using the React JS

--- a/React.podspec
+++ b/React.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                = "React"
-  s.version             = "0.8.0"
+  s.version             = "0.14.0-rc"
   s.summary             = "Build high quality mobile apps using React."
   s.description         = <<-DESC
                             React Native apps are built using the React JS

--- a/React/Base/RCTBatchedBridge.m
+++ b/React/Base/RCTBatchedBridge.m
@@ -197,13 +197,20 @@ RCT_EXTERN NSArray *RCTGetModuleClasses(void);
     // Force JS __DEV__ value to match RCT_DEBUG
     if (shouldOverrideDev) {
       NSString *sourceString = [[NSString alloc] initWithData:source encoding:NSUTF8StringEncoding];
-      NSRange range = [sourceString rangeOfString:@"__DEV__="];
+      NSRange range = [sourceString rangeOfString:@"\\b__DEV__\\s*?=\\s*?(!1|!0|false|true)"
+                                          options:NSRegularExpressionSearch];
+
       RCTAssert(range.location != NSNotFound, @"It looks like the implementation"
                 "of __DEV__ has changed. Update -[RCTBatchedBridge loadSource:].");
-      NSRange valueRange = {range.location + range.length, 2};
-      if ([[sourceString substringWithRange:valueRange] isEqualToString:@"!1"]) {
-        source = [[sourceString stringByReplacingCharactersInRange:valueRange withString:@" 1"] dataUsingEncoding:NSUTF8StringEncoding];
+
+      NSString *valueString = [sourceString substringWithRange:range];
+      if ([valueString rangeOfString:@"!1"].length) {
+        valueString = [valueString stringByReplacingOccurrencesOfString:@"!1" withString:@"!0"];
+      } else if ([valueString rangeOfString:@"false"].length) {
+        valueString = [valueString stringByReplacingOccurrencesOfString:@"false" withString:@"true"];
       }
+      source = [[sourceString stringByReplacingCharactersInRange:range withString:valueString]
+                dataUsingEncoding:NSUTF8StringEncoding];
     }
 
     _onSourceLoad(error, source);

--- a/React/Modules/RCTPointAnnotation.h
+++ b/React/Modules/RCTPointAnnotation.h
@@ -9,11 +9,24 @@
 
 #import <MapKit/MapKit.h>
 
+typedef enum{
+  RCTPointAnnotationTypeButton,
+  RCTPointAnnotationTypeImage
+} RCTPointAnnotationCalloutType;
+
 @interface RCTPointAnnotation : MKPointAnnotation <MKAnnotation>
 
 @property (nonatomic, copy) NSString *identifier;
+
 @property (nonatomic, assign) BOOL hasLeftCallout;
 @property (nonatomic, assign) BOOL hasRightCallout;
+
+@property (nonatomic, assign) RCTPointAnnotationCalloutType leftCalloutType;
+@property (nonatomic, assign) RCTPointAnnotationCalloutType rightCalloutType;
+
+@property (nonatomic, copy) NSDictionary *rightCalloutConfig;
+@property (nonatomic, copy) NSDictionary *leftCalloutConfig;
+
 @property (nonatomic, assign) BOOL animateDrop;
 
 @end

--- a/React/Views/RCTConvert+MapKit.m
+++ b/React/Views/RCTConvert+MapKit.m
@@ -63,16 +63,22 @@ RCT_ENUM_CONVERTER(MKMapType, (@{
   shape.leftCalloutConfig = [RCTConvert NSDictionary:json[@"leftCallout"][@"config"]];
   shape.rightCalloutConfig = [RCTConvert NSDictionary:json[@"rightCallout"][@"config"]];
   
-  shape.hasLeftCallout = [RCTConvert BOOL:json[@"leftCallout"][@"enabled"]];
-  shape.hasRightCallout = [RCTConvert BOOL:json[@"rightCallout"][@"enabled"]];
+  shape.hasLeftCallout = false;
+  if ([[RCTConvert NSDictionary:json[@"leftCallout"]] count] > 0) {
+    shape.hasLeftCallout = true;
+  }
+
+  shape.hasRightCallout = false;
+  if ([[RCTConvert NSDictionary:json[@"rightCallout"]] count] > 0) {
+    shape.hasRightCallout = true;
+  }
 
   shape.leftCalloutType = RCTPointAnnotationTypeButton;
-  shape.rightCalloutType = RCTPointAnnotationTypeButton;
-  
   if ([[RCTConvert NSString:json[@"leftCallout"][@"type"]] isEqual: @"image"]) {
     shape.leftCalloutType = RCTPointAnnotationTypeImage;
   }
 
+  shape.rightCalloutType = RCTPointAnnotationTypeButton;
   if ([[RCTConvert NSString:json[@"rightCallout"][@"type"]] isEqual: @"image"]) {
     shape.rightCalloutType = RCTPointAnnotationTypeImage;
   }

--- a/React/Views/RCTConvert+MapKit.m
+++ b/React/Views/RCTConvert+MapKit.m
@@ -58,9 +58,25 @@ RCT_ENUM_CONVERTER(MKMapType, (@{
   shape.title = [RCTConvert NSString:json[@"title"]];
   shape.subtitle = [RCTConvert NSString:json[@"subtitle"]];
   shape.identifier = [RCTConvert NSString:json[@"id"]];
-  shape.hasLeftCallout = [RCTConvert BOOL:json[@"hasLeftCallout"]];
-  shape.hasRightCallout = [RCTConvert BOOL:json[@"hasRightCallout"]];
   shape.animateDrop = [RCTConvert BOOL:json[@"animateDrop"]];
+
+  shape.leftCalloutConfig = [RCTConvert NSDictionary:json[@"leftCallout"][@"config"]];
+  shape.rightCalloutConfig = [RCTConvert NSDictionary:json[@"rightCallout"][@"config"]];
+  
+  shape.hasLeftCallout = [RCTConvert BOOL:json[@"leftCallout"][@"enabled"]];
+  shape.hasRightCallout = [RCTConvert BOOL:json[@"rightCallout"][@"enabled"]];
+
+  shape.leftCalloutType = RCTPointAnnotationTypeButton;
+  shape.rightCalloutType = RCTPointAnnotationTypeButton;
+  
+  if ([[RCTConvert NSString:json[@"leftCallout"][@"type"]] isEqual: @"image"]) {
+    shape.leftCalloutType = RCTPointAnnotationTypeImage;
+  }
+
+  if ([[RCTConvert NSString:json[@"rightCallout"][@"type"]] isEqual: @"image"]) {
+    shape.rightCalloutType = RCTPointAnnotationTypeImage;
+  }
+
   return shape;
 }
 

--- a/React/Views/RCTMapManager.m
+++ b/React/Views/RCTMapManager.m
@@ -97,8 +97,14 @@ RCT_CUSTOM_VIEW_PROPERTY(region, MKCoordinateRegion, RCTMap)
         } else {
           // If we don't have a packager asset, we have to fetch it from interwebs
           NSString *uri = [RCTConvert NSString:annotation.leftCalloutConfig[@"image"]];
-          UIImage *image = [UIImage imageWithData:[NSData dataWithContentsOfURL:[NSURL URLWithString:uri]]];
-          UIImageView *calloutImage = [[UIImageView alloc] initWithImage:image];
+          // Init image with placeholder / default image
+          NSString *defaultUri = [RCTConvert NSString:annotation.leftCalloutConfig[@"defaultImage"][@"uri"]];
+          UIImageView *calloutImage = [[UIImageView alloc] initWithImage:[UIImage imageNamed:defaultUri]];
+
+          [NSURLConnection sendAsynchronousRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:uri]] queue:[NSOperationQueue mainQueue] completionHandler:^(NSURLResponse *response, NSData *data, NSError *error) {
+              calloutImage.image = [UIImage imageWithData:data];
+            }];
+
           annotationView.leftCalloutAccessoryView = calloutImage;
         }
       }
@@ -121,8 +127,14 @@ RCT_CUSTOM_VIEW_PROPERTY(region, MKCoordinateRegion, RCTMap)
         } else {
           // If we don't have a packager asset, we have to fetch it from interwebs
           NSString *uri = [RCTConvert NSString:annotation.rightCalloutConfig[@"image"]];
-          UIImage *image = [UIImage imageWithData:[NSData dataWithContentsOfURL:[NSURL URLWithString:uri]]];
-          UIImageView *calloutImage = [[UIImageView alloc] initWithImage:image];
+          // Init image with placeholder / default image
+          NSString *defaultUri = [RCTConvert NSString:annotation.rightCalloutConfig[@"defaultImage"][@"uri"]];
+          UIImageView *calloutImage = [[UIImageView alloc] initWithImage:[UIImage imageNamed:defaultUri]];
+
+          [NSURLConnection sendAsynchronousRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:uri]] queue:[NSOperationQueue mainQueue] completionHandler:^(NSURLResponse *response, NSData *data, NSError *error) {
+              calloutImage.image = [UIImage imageWithData:data];
+            }];
+
           annotationView.rightCalloutAccessoryView = calloutImage;
         }
       }

--- a/React/Views/RCTMapManager.m
+++ b/React/Views/RCTMapManager.m
@@ -87,20 +87,46 @@ RCT_CUSTOM_VIEW_PROPERTY(region, MKCoordinateRegion, RCTMap)
   annotationView.leftCalloutAccessoryView = nil;
   if (annotation.hasLeftCallout) {
     if (annotation.leftCalloutType == RCTPointAnnotationTypeImage) {
-      NSString *uri = [RCTConvert NSString:annotation.leftCalloutConfig[@"src"][@"uri"]];
-      UIImageView *calloutImage = [[UIImageView alloc] initWithImage:[UIImage imageNamed:uri]];
-      annotationView.leftCalloutAccessoryView = calloutImage;
+      if ([annotation.leftCalloutConfig objectForKey:@"image"] != nil) {
+        if ([annotation.leftCalloutConfig[@"image"] isKindOfClass: [NSDictionary class]] &&
+            [annotation.leftCalloutConfig[@"image"] objectForKey:@"__packager_asset"] != nil) {
+          // We have a local ressource, no web loading necessary
+          NSString *uri = [RCTConvert NSString:annotation.leftCalloutConfig[@"image"][@"uri"]];
+          UIImageView *calloutImage = [[UIImageView alloc] initWithImage:[UIImage imageNamed:uri]];
+          annotationView.leftCalloutAccessoryView = calloutImage;
+        } else {
+          // If we don't have a packager asset, we have to fetch it from interwebs
+          NSString *uri = [RCTConvert NSString:annotation.leftCalloutConfig[@"image"]];
+          UIImage *image = [UIImage imageWithData:[NSData dataWithContentsOfURL:[NSURL URLWithString:uri]]];
+          UIImageView *calloutImage = [[UIImageView alloc] initWithImage:image];
+          annotationView.leftCalloutAccessoryView = calloutImage;
+        }
+      }
+
     } else {
       annotationView.leftCalloutAccessoryView = [UIButton buttonWithType:UIButtonTypeDetailDisclosure];
     }
   }
-  
+
   annotationView.rightCalloutAccessoryView = nil;
   if (annotation.hasRightCallout) {
     if (annotation.rightCalloutType == RCTPointAnnotationTypeImage) {
-      NSString *uri = [RCTConvert NSString:annotation.rightCalloutConfig[@"src"][@"uri"]];
-      UIImageView *calloutImage = [[UIImageView alloc] initWithImage:[UIImage imageNamed:uri]];
-      annotationView.rightCalloutAccessoryView = calloutImage;
+      if ([annotation.rightCalloutConfig objectForKey:@"image"] != nil) {
+        if ([annotation.rightCalloutConfig[@"image"] isKindOfClass: [NSDictionary class]] &&
+            [annotation.rightCalloutConfig[@"image"] objectForKey:@"__packager_asset"] != nil) {
+          // We have a local ressource, no web loading necessary
+          NSString *uri = [RCTConvert NSString:annotation.rightCalloutConfig[@"image"][@"uri"]];
+          UIImageView *calloutImage = [[UIImageView alloc] initWithImage:[UIImage imageNamed:uri]];
+          annotationView.rightCalloutAccessoryView = calloutImage;
+        } else {
+          // If we don't have a packager asset, we have to fetch it from interwebs
+          NSString *uri = [RCTConvert NSString:annotation.rightCalloutConfig[@"image"]];
+          UIImage *image = [UIImage imageWithData:[NSData dataWithContentsOfURL:[NSURL URLWithString:uri]]];
+          UIImageView *calloutImage = [[UIImageView alloc] initWithImage:image];
+          annotationView.rightCalloutAccessoryView = calloutImage;
+        }
+      }
+
     } else {
       annotationView.rightCalloutAccessoryView = [UIButton buttonWithType:UIButtonTypeDetailDisclosure];
     }

--- a/React/Views/RCTMapManager.m
+++ b/React/Views/RCTMapManager.m
@@ -73,6 +73,52 @@ RCT_CUSTOM_VIEW_PROPERTY(region, MKCoordinateRegion, RCTMap)
   }
 }
 
+- (bool)isLocalImage: (NSDictionary *)config
+{
+  if (config[@"image"] != nil) {
+    if ([config[@"image"] isKindOfClass:[NSDictionary class]]) {
+      if ([config[@"image"] objectForKey:@"__packager_asset"] != nil) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+- (UIImageView *)generateCalloutImageAccessory:(NSDictionary *)config
+{
+  UIGraphicsBeginImageContextWithOptions(CGSizeMake(36, 36), NO, 0.0);
+  UIImage *blank = UIGraphicsGetImageFromCurrentImageContext();
+  UIGraphicsEndImageContext();
+
+  UIImageView *calloutImageView = [[UIImageView alloc] initWithImage:blank];
+
+  if ([self isLocalImage:config]) {
+    // We have a local ressource, no web loading necessary
+    NSString *ressourceName = [RCTConvert NSString:config[@"image"][@"uri"]];
+    calloutImageView.image = [UIImage imageNamed:ressourceName];
+  } else {
+    NSString *uri = [RCTConvert NSString:config[@"image"]];
+
+    if (config[@"defaultImage"] != nil) {
+      NSString *defaultImagePath = [RCTConvert NSString:config[@"defaultImage"][@"uri"]];
+      calloutImageView.image = [UIImage imageNamed:defaultImagePath];
+    }
+
+    // Load the real image async and replace the image with it
+    [NSURLConnection sendAsynchronousRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:uri]] queue:[NSOperationQueue mainQueue] completionHandler:^(NSURLResponse *response, NSData *data, NSError *error) {
+        if (!error) {
+          if ([@[@200, @301, @302, @304] containsObject:@([(NSHTTPURLResponse *)response statusCode])]) {
+            calloutImageView.image = [UIImage imageWithData:data];
+          }
+        }
+    }];
+  }
+
+  return calloutImageView;
+}
+
 - (MKAnnotationView *)mapView:(__unused MKMapView *)mapView viewForAnnotation:(RCTPointAnnotation *)annotation
 {
   if (![annotation isKindOfClass:[RCTPointAnnotation class]]) {
@@ -86,61 +132,19 @@ RCT_CUSTOM_VIEW_PROPERTY(region, MKCoordinateRegion, RCTMap)
 
   annotationView.leftCalloutAccessoryView = nil;
   if (annotation.hasLeftCallout) {
+    annotationView.leftCalloutAccessoryView = [UIButton buttonWithType:UIButtonTypeDetailDisclosure];
+
     if (annotation.leftCalloutType == RCTPointAnnotationTypeImage) {
-      if ([annotation.leftCalloutConfig objectForKey:@"image"] != nil) {
-        if ([annotation.leftCalloutConfig[@"image"] isKindOfClass: [NSDictionary class]] &&
-            [annotation.leftCalloutConfig[@"image"] objectForKey:@"__packager_asset"] != nil) {
-          // We have a local ressource, no web loading necessary
-          NSString *uri = [RCTConvert NSString:annotation.leftCalloutConfig[@"image"][@"uri"]];
-          UIImageView *calloutImage = [[UIImageView alloc] initWithImage:[UIImage imageNamed:uri]];
-          annotationView.leftCalloutAccessoryView = calloutImage;
-        } else {
-          // If we don't have a packager asset, we have to fetch it from interwebs
-          NSString *uri = [RCTConvert NSString:annotation.leftCalloutConfig[@"image"]];
-          // Init image with placeholder / default image
-          NSString *defaultUri = [RCTConvert NSString:annotation.leftCalloutConfig[@"defaultImage"][@"uri"]];
-          UIImageView *calloutImage = [[UIImageView alloc] initWithImage:[UIImage imageNamed:defaultUri]];
-
-          [NSURLConnection sendAsynchronousRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:uri]] queue:[NSOperationQueue mainQueue] completionHandler:^(NSURLResponse *response, NSData *data, NSError *error) {
-              calloutImage.image = [UIImage imageWithData:data];
-            }];
-
-          annotationView.leftCalloutAccessoryView = calloutImage;
-        }
-      }
-
-    } else {
-      annotationView.leftCalloutAccessoryView = [UIButton buttonWithType:UIButtonTypeDetailDisclosure];
+      annotationView.leftCalloutAccessoryView = [self generateCalloutImageAccessory:annotation.leftCalloutConfig];
     }
   }
 
   annotationView.rightCalloutAccessoryView = nil;
   if (annotation.hasRightCallout) {
+    annotationView.rightCalloutAccessoryView = [UIButton buttonWithType:UIButtonTypeDetailDisclosure];
+
     if (annotation.rightCalloutType == RCTPointAnnotationTypeImage) {
-      if ([annotation.rightCalloutConfig objectForKey:@"image"] != nil) {
-        if ([annotation.rightCalloutConfig[@"image"] isKindOfClass: [NSDictionary class]] &&
-            [annotation.rightCalloutConfig[@"image"] objectForKey:@"__packager_asset"] != nil) {
-          // We have a local ressource, no web loading necessary
-          NSString *uri = [RCTConvert NSString:annotation.rightCalloutConfig[@"image"][@"uri"]];
-          UIImageView *calloutImage = [[UIImageView alloc] initWithImage:[UIImage imageNamed:uri]];
-          annotationView.rightCalloutAccessoryView = calloutImage;
-        } else {
-          // If we don't have a packager asset, we have to fetch it from interwebs
-          NSString *uri = [RCTConvert NSString:annotation.rightCalloutConfig[@"image"]];
-          // Init image with placeholder / default image
-          NSString *defaultUri = [RCTConvert NSString:annotation.rightCalloutConfig[@"defaultImage"][@"uri"]];
-          UIImageView *calloutImage = [[UIImageView alloc] initWithImage:[UIImage imageNamed:defaultUri]];
-
-          [NSURLConnection sendAsynchronousRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:uri]] queue:[NSOperationQueue mainQueue] completionHandler:^(NSURLResponse *response, NSData *data, NSError *error) {
-              calloutImage.image = [UIImage imageWithData:data];
-            }];
-
-          annotationView.rightCalloutAccessoryView = calloutImage;
-        }
-      }
-
-    } else {
-      annotationView.rightCalloutAccessoryView = [UIButton buttonWithType:UIButtonTypeDetailDisclosure];
+      annotationView.rightCalloutAccessoryView = [self generateCalloutImageAccessory:annotation.rightCalloutConfig];
     }
   }
 
@@ -207,6 +211,7 @@ RCT_CUSTOM_VIEW_PROPERTY(region, MKCoordinateRegion, RCTMap)
   mapView.hasStartedRendering = YES;
   [self _emitRegionChangeEvent:mapView continuous:NO];
 }
+
 
 #pragma mark Private
 

--- a/React/Views/RCTMapManager.m
+++ b/React/Views/RCTMapManager.m
@@ -86,12 +86,24 @@ RCT_CUSTOM_VIEW_PROPERTY(region, MKCoordinateRegion, RCTMap)
 
   annotationView.leftCalloutAccessoryView = nil;
   if (annotation.hasLeftCallout) {
-    annotationView.leftCalloutAccessoryView = [UIButton buttonWithType:UIButtonTypeDetailDisclosure];
+    if (annotation.leftCalloutType == RCTPointAnnotationTypeImage) {
+      NSString *uri = [RCTConvert NSString:annotation.leftCalloutConfig[@"src"][@"uri"]];
+      UIImageView *calloutImage = [[UIImageView alloc] initWithImage:[UIImage imageNamed:uri]];
+      annotationView.leftCalloutAccessoryView = calloutImage;
+    } else {
+      annotationView.leftCalloutAccessoryView = [UIButton buttonWithType:UIButtonTypeDetailDisclosure];
+    }
   }
-
+  
   annotationView.rightCalloutAccessoryView = nil;
   if (annotation.hasRightCallout) {
-    annotationView.rightCalloutAccessoryView = [UIButton buttonWithType:UIButtonTypeDetailDisclosure];
+    if (annotation.rightCalloutType == RCTPointAnnotationTypeImage) {
+      NSString *uri = [RCTConvert NSString:annotation.rightCalloutConfig[@"src"][@"uri"]];
+      UIImageView *calloutImage = [[UIImageView alloc] initWithImage:[UIImage imageNamed:uri]];
+      annotationView.rightCalloutAccessoryView = calloutImage;
+    } else {
+      annotationView.rightCalloutAccessoryView = [UIButton buttonWithType:UIButtonTypeDetailDisclosure];
+    }
   }
 
   return annotationView;

--- a/React/Views/RCTMapManager.m
+++ b/React/Views/RCTMapManager.m
@@ -130,21 +130,19 @@ RCT_CUSTOM_VIEW_PROPERTY(region, MKCoordinateRegion, RCTMap)
   annotationView.canShowCallout = true;
   annotationView.animatesDrop = annotation.animateDrop;
 
-  annotationView.leftCalloutAccessoryView = nil;
-  if (annotation.hasLeftCallout) {
-    annotationView.leftCalloutAccessoryView = [UIButton buttonWithType:UIButtonTypeDetailDisclosure];
+  for (NSString *side in @[@"left", @"right"]) {
+    NSString *accessoryViewSelector = [NSString stringWithFormat:@"%@CalloutAccessoryView", side];
+    NSString *typeSelector = [NSString stringWithFormat:@"%@CalloutType", side];
+    NSString *hasCheckSelector = [NSString stringWithFormat:@"has%@Callout", [side capitalizedString]];
+    NSString *configSelector = [NSString stringWithFormat:@"%@CalloutConfig", side];
 
-    if (annotation.leftCalloutType == RCTPointAnnotationTypeImage) {
-      annotationView.leftCalloutAccessoryView = [self generateCalloutImageAccessory:annotation.leftCalloutConfig];
-    }
-  }
+    [annotationView setValue:nil forKey:accessoryViewSelector];
+    if ([annotation valueForKey:hasCheckSelector]) {
+      [annotationView setValue:[UIButton buttonWithType:UIButtonTypeDetailDisclosure] forKey:accessoryViewSelector];
 
-  annotationView.rightCalloutAccessoryView = nil;
-  if (annotation.hasRightCallout) {
-    annotationView.rightCalloutAccessoryView = [UIButton buttonWithType:UIButtonTypeDetailDisclosure];
-
-    if (annotation.rightCalloutType == RCTPointAnnotationTypeImage) {
-      annotationView.rightCalloutAccessoryView = [self generateCalloutImageAccessory:annotation.rightCalloutConfig];
+      if ([[annotation valueForKey:typeSelector] integerValue] == RCTPointAnnotationTypeImage) {
+        [annotationView setValue:[self generateCalloutImageAccessory:[annotation valueForKey:configSelector]] forKey:accessoryViewSelector];
+      }
     }
   }
 

--- a/React/Views/RCTMapManager.m
+++ b/React/Views/RCTMapManager.m
@@ -88,7 +88,21 @@ RCT_CUSTOM_VIEW_PROPERTY(region, MKCoordinateRegion, RCTMap)
 
 - (UIImageView *)generateCalloutImageAccessory:(NSDictionary *)config
 {
-  UIGraphicsBeginImageContextWithOptions(CGSizeMake(36, 36), NO, 0.0);
+  // Default width / height is 54
+  int imageWidth = 54;
+  int imageHeight = 54;
+
+  if (config[@"imageSize"] != nil) {
+    if ([config[@"imageSize"] objectForKey:@"height"] != nil) {
+      imageHeight = [RCTConvert int:config[@"imageSize"][@"height"]];
+    }
+
+    if ([config[@"imageSize"] objectForKey:@"width"] != nil) {
+      imageWidth = [RCTConvert int:config[@"imageSize"][@"width"]];
+    }
+  }
+
+  UIGraphicsBeginImageContextWithOptions(CGSizeMake(imageWidth, imageHeight), NO, 0.0);
   UIImage *blank = UIGraphicsGetImageFromCurrentImageContext();
   UIGraphicsEndImageContext();
 

--- a/ReactAndroid/gradle.properties
+++ b/ReactAndroid/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=0.12.0-SNAPSHOT
+VERSION_NAME=0.14.0
 GROUP=com.facebook.react
 
 POM_NAME=ReactNative

--- a/local-cli/generator-android/templates/src/app/build.gradle
+++ b/local-cli/generator-android/templates/src/app/build.gradle
@@ -74,5 +74,5 @@ android {
 dependencies {
     compile fileTree(dir: "libs", include: ["*.jar"])
     compile "com.android.support:appcompat-v7:23.0.1"
-    compile "com.facebook.react:react-native:0.13.0"
+    compile "com.facebook.react:react-native:0.14.+"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native",
-  "version": "0.14.0-rc",
+  "version": "0.14.0",
   "description": "A framework for building native apps using React",
   "license": "BSD-3-Clause",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native",
-  "version": "0.12.0",
+  "version": "0.14.0",
   "description": "A framework for building native apps using React",
   "license": "BSD-3-Clause",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native",
-  "version": "0.14.0",
+  "version": "0.14.0-rc",
   "description": "A framework for building native apps using React",
   "license": "BSD-3-Clause",
   "repository": {


### PR DESCRIPTION
Addition / refactor to https://github.com/facebook/react-native/pull/1247

I realized while using the new callouts that support for images is still missing and that more callout types might get added in the future which is a bit awkward with the old config method. Refactored the code a bit and added image support to make sure there won't be bigger issues later on. 

<img width="374" alt="screen shot 2015-07-08 at 8 02 59 pm" src="https://cloud.githubusercontent.com/assets/688326/8569170/aaeb4da6-25af-11e5-8556-fea676f1b0cc.png">

Example:
```
  leftCallout: {
    type: "button",
    onPress: function () {
      console.info("Test left");
    }
  },
  rightCallout: {
    type: "image",
    config: {
      image: require("image!myIcon")
      // Or
      image: "http://www.google.com/icon.png"
      // Will use the local defaultImage until the web resource has been loaded
      defaultImage: require("image!myIcon")   
     }
 }
```

Difference from the last version
```
hasRightCallout: true,
onRightCalloutPress: function() {}
```
becomes to
```
  rightCallout: {
    type: "button",
    onPress: function () {}
  }
```

- Moved left and right into their own config objects
- added `type` for allowing to pick the accessory type (currently `button` and `image`)
- moved `on...CalloutPress` into new config under `onPress`
- added `config` sub object for passing additional parameters to the accessory. Currently supported are `image` when type is image, and `defaultImage` when `image` is not a local ressource