### PR TITLE
Purpose: Lint and style check ObjectiveC code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ DerivedData
 *.ipa
 *.xcuserstate
 project.xcworkspace
+scripts/compile_commands.json
 
 # OS X
 .DS_Store

--- a/scripts/objc-lint.sh
+++ b/scripts/objc-lint.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+brew cask install Caskroom/cask/oclint
+
+xctool -project ../Examples/UIExplorer/UIExplorer.xcodeproj \
+        -scheme UIExplorer -sdk iphonesimulator \
+        -destination 'platform=iOS Simulator,name=iPhone 5,OS=8.4' \
+        -reporter json-compilation-database:compile_commands.json \
+  clean build
+
+# http://docs.oclint.org/en/dev/customizing/rules.html
+oclint-json-compilation-database compile_commands.json -- -rc LONG_LINE=200 CYCLOMATIC_COMPLEXITY=25


### PR DESCRIPTION
It's hard to contribute to native part of `react-native` for me. Of course tests are the most important, but do you consider adding linters too?
Linters also could distract and restrict too much. Now it looks like this:
```
...
react-native/React/Views/RCTNavItem.m:53:3: ivar assignment outside accessors or init P2
...
react-native/React/Modules/RCTUIManager.m:525:7: long variable name P3 Variable name with 21 characters is longer than the threshold of 20
...
react-native/React/Modules/RCTUIManager.m:1114:1: deep nested block P3 Block depth of 6 exceeds limit of 5
...
react-native/React/Modules/RCTUIManager.m:81:1: high npath complexity P2 NPath Complexity Number 258 exceeds limit of 200
...
react-native/Libraries/PushNotificationIOS/RCTPushNotificationManager.m:87:31: unused method parameter P3 The parameter 'application' is unused.
...
P1=0[0] P2=339[10] P3=545[20]
```
(P for Priority)

- [ ] Add `oclint` and `ocstyle` (or write custom rules for `oslint` for consistent code styling conventions, sush as whitespaces, new lines, code blocks formatting, etc.).
- [ ] Setup [rules](http://docs.oclint.org/en/dev/customizing/rules.html) such as CODE_COMPLEXITY to avoid most of the current warnings and adopt linter to `react-native` conventions. Update code to [Suppress OCLint Warnings](http://docs.oclint.org/en/dev/howto/suppress.html).
- [ ] Leave it as an option just for contributors and if it will work properly for a certain time then eventually add it to .travisci