### PR TITLE
[Bugfix] XMLHttpRequest: Fix lowercase headers being returned with uppercase keys

### DIFF
--- a/Libraries/Network/XMLHttpRequestBase.js
+++ b/Libraries/Network/XMLHttpRequestBase.js
@@ -154,7 +154,7 @@ class XMLHttpRequestBase {
     this._lowerCaseResponseHeaders =
       Object.keys(headers).reduce((lcaseHeaders, headerName) => {
         lcaseHeaders[headerName.toLowerCase()] = headers[headerName];
-        return headers;
+        return lcaseHeaders;
       }, {});
   }
 


### PR DESCRIPTION
In the `XMLHttpRequestBase` class, the value `this._lowerCaseResponseHeaders` is currently returning uppercased values. This is causing things like the `Content-Type` to not be parsed correctly with `getResponseHeader` which causes JSON to be parsed as a single string.

This bug was introduced by this commit: https://github.com/facebook/react-native/commit/e00b9ac8f38fb1b7968c4bc5253a47656362fc5b

I'm not positive, but I think this may fix the bug reported at #1780