### PR TITLE
[Packager] add host argument for packager.

### DIFF
--- a/packager/packager.js
+++ b/packager/packager.js
@@ -39,6 +39,10 @@ var options = parseCommandLine([{
   default: 8081,
   type: 'string',
 }, {
+  command: 'host',
+  default: '::',
+  type: 'string',
+}, {
   command: 'root',
   type: 'string',
   description: 'add another root(s) to be used by the packager in this project',
@@ -258,5 +262,5 @@ function runServer(
     .use(connect.compress())
     .use(connect.errorHandler());
 
-  return http.createServer(app).listen(options.port, '::', readyCallback);
+  return http.createServer(app).listen(options.port, options.host, readyCallback);
 }


### PR DESCRIPTION
Now packager only listen to "::", which is IPv6 "Any address".
It failed to run in IPv4 Environment. 

So I think it's necessary to let user define host by cli argument.

It's also for security reason. When working on a public network, it's much safer to listen with localhost instead of ::, which may let everyone in same network be able to get your code from debugger-ui.