### PR TITLE
[ListView] I change the `_onScroll` function in ListView

### DIFF
--- a/Libraries/CustomComponents/ListView/ListView.js
+++ b/Libraries/CustomComponents/ListView/ListView.js
@@ -526,9 +526,9 @@ var ListView = React.createClass({
     var nearEnd = this._getDistanceFromEnd(this.scrollProperties) < this.props.onEndReachedThreshold;
     if (nearEnd &&
         this.props.onEndReached &&
-        this.scrollProperties.contentHeight !== this._sentEndForContentHeight &&
+        this.scrollProperties.offsetY !== this._sentEndForOffsetY &&
         this.state.curRenderedRowsCount === this.props.dataSource.getRowCount()) {
-      this._sentEndForContentHeight = this.scrollProperties.contentHeight;
+      this._sentEndForOffsetY = this.scrollProperties.offsetY;
       this.props.onEndReached(e);
     } else {
       this._renderMoreRowsIfNeeded();


### PR DESCRIPTION
There is a bug that when I use ListView in [noder](https://github.com/soliury/noder-react-native) , in the `PagelistView` Component, when user pull down the list, it will update the topics. when the listView reach the end, it will get more topics. And there is bug, when I pull down the list , so it will fetch the topic, and then I quickly pull to listView end, the `onEndReached` will fired. But at the same time, the `_fetchTopic` is fetching ,  so the `_fetchTopic` in `onEndReached` will don't work. And then, another time to pull to end in ListView it won't run `onEndReached` function. 

Because in the older code, it show:

```
_onScroll: function(e) {
    this.scrollProperties.visibleHeight = e.nativeEvent.layoutMeasurement.height;
    this.scrollProperties.contentHeight = e.nativeEvent.contentSize.height;
    this.scrollProperties.offsetY = e.nativeEvent.contentOffset.y;
    this._updateVisibleRows(e);
    var nearEnd = this._getDistanceFromEnd(this.scrollProperties) < this.props.onEndReachedThreshold;
    if (nearEnd &&
        this.props.onEndReached &&
        this.scrollProperties.contentHeight !== this._sentEndForContentHeight &&
        this.state.curRenderedRowsCount === this.props.dataSource.getRowCount()) {
      this._sentEndForContentHeight = this.scrollProperties.contentHeight;
      this.props.onEndReached(e);
    } else {
      this._renderMoreRowsIfNeeded();
    }

    this.props.onScroll && this.props.onScroll(e);
  },
});
```

It will save the current `contentHeight` to `this._sentEndForContentHeight` , if the `onEndReached` have failed one time(because networking is bad or something) the ListView contentHeight won't change, so the `this.scrollProperties.contentHeight == this._sentEndForContentHeight` alway equal to `true` . So the `onEndReached` won't run again. 

Please checkout.
