### PR TITLE
[Packager]Prompt a meanful message if entry path doesn't exists.

### DIFF
--- a/packager/react-packager/src/DependencyResolver/DependencyGraph/index.js
+++ b/packager/react-packager/src/DependencyResolver/DependencyGraph/index.js
@@ -21,6 +21,7 @@ const getAssetDataFromName = require('../../lib/getAssetDataFromName');
 const isAbsolutePath = require('absolute-path');
 const path = require('path');
 const util = require('util');
+const assert = require('assert');
 
 const validateOpts = declareOpts({
   roots: {
@@ -150,7 +151,7 @@ class DependencyGraph {
 
   getOrderedDependencies(entryPath) {
     return this.load().then(() => {
-      const absolutePath = path.resolve(this._getAbsolutePath(entryPath));
+      const absolutePath = path.resolve(this._getAbsolutePath(entryPath) || assert(false, "Cannot find "+entryPath));
 
       if (absolutePath == null) {
         throw new NotFoundError(


### PR DESCRIPTION
React native prompt a exception with "TypeError: Arguments to path.resolve must be strings" when index.ios.js doesn't exists.

"AssertionError: Cannot find Examples/SampleApp/index.ios.js" should be better.