### PR TITLE
[ListView] Operate on the true scroll responder instead of the scroll component

### DIFF
--- a/Libraries/CustomComponents/ListView/ListView.js
+++ b/Libraries/CustomComponents/ListView/ListView.js
@@ -221,7 +221,7 @@ var ListView = React.createClass({
    * such as scrollTo.
    */
   getScrollResponder: function() {
-    return this.refs[SCROLLVIEW_REF];
+    return this.refs[SCROLLVIEW_REF].getScrollResponder();
   },
 
   setNativeProps: function(props) {
@@ -399,14 +399,15 @@ var ListView = React.createClass({
    */
 
   _measureAndUpdateScrollProps: function() {
+    var scrollComponent = this.getScrollResponder();
     RCTUIManager.measureLayout(
-      this.refs[SCROLLVIEW_REF].getInnerViewNode(),
-      React.findNodeHandle(this.refs[SCROLLVIEW_REF]),
+      scrollComponent.getInnerViewNode(),
+      React.findNodeHandle(scrollComponent),
       logError,
       this._setScrollContentHeight
     );
     RCTUIManager.measureLayoutRelativeToParent(
-      React.findNodeHandle(this.refs[SCROLLVIEW_REF]),
+      React.findNodeHandle(scrollComponent),
       logError,
       this._setScrollVisibleHeight
     );
@@ -414,7 +415,7 @@ var ListView = React.createClass({
     // RKScrollViewManager.calculateChildFrames not available on every platform
     RKScrollViewManager && RKScrollViewManager.calculateChildFrames &&
       RKScrollViewManager.calculateChildFrames(
-        React.findNodeHandle(this.refs[SCROLLVIEW_REF]),
+        React.findNodeHandle(scrollComponent),
         this._updateChildFrames,
       );
   },


### PR DESCRIPTION
When composing scroll views, `this.refs[SCROLLVIEW_REF]` may refer to another higher-order scroll component instead of a ScrollView. This can cause issues if you expect to need it to be a ScrollView backed by an RCTScrollView.

The solution is to call `getScrollResponder()` - as long as all higher-order scroll components implement this method, it will make its way down to the true ScrollView, which is what ListView wants here.

Test Plan: Load an app with composed scroll views and no longer get a crash in `calculateChildFrames:(NSNumber *)reactTag callback:(RCTResponseSenderBlock)callback`.