### PR TITLE
[Image] Add support for tintColor to remote images

### DIFF
--- a/Examples/UIExplorer/ImageExample.js
+++ b/Examples/UIExplorer/ImageExample.js
@@ -194,23 +194,46 @@ exports.examples = [
       'pixels to the tint color.',
     render: function() {
       return (
-        <View style={styles.horizontal}>
-          <Image
-            source={require('image!uie_thumb_normal')}
-            style={[styles.icon, {tintColor: 'blue' }]}
-          />
-          <Image
-            source={require('image!uie_thumb_normal')}
-            style={[styles.icon, styles.leftMargin, {tintColor: 'green' }]}
-          />
-          <Image
-            source={require('image!uie_thumb_normal')}
-            style={[styles.icon, styles.leftMargin, {tintColor: 'red' }]}
-          />
-          <Image
-            source={require('image!uie_thumb_normal')}
-            style={[styles.icon, styles.leftMargin, {tintColor: 'black' }]}
-          />
+        <View>
+          <View style={styles.horizontal}>
+            <Image
+              source={require('image!uie_thumb_normal')}
+              style={[styles.icon, {tintColor: '#5ac8fa' }]}
+            />
+            <Image
+              source={require('image!uie_thumb_normal')}
+              style={[styles.icon, styles.leftMargin, {tintColor: '#4cd964' }]}
+            />
+            <Image
+              source={require('image!uie_thumb_normal')}
+              style={[styles.icon, styles.leftMargin, {tintColor: '#ff2d55' }]}
+            />
+            <Image
+              source={require('image!uie_thumb_normal')}
+              style={[styles.icon, styles.leftMargin, {tintColor: '#8e8e93' }]}
+            />
+          </View>
+          <Text style={styles.sectionText}>
+            It also works with downloaded images:
+          </Text>
+          <View style={styles.horizontal}>
+            <Image
+              source={smallImage}
+              style={[styles.base, {tintColor: '#5ac8fa' }]}
+            />
+            <Image
+              source={smallImage}
+              style={[styles.base, styles.leftMargin, {tintColor: '#4cd964' }]}
+            />
+            <Image
+              source={smallImage}
+              style={[styles.base, styles.leftMargin, {tintColor: '#ff2d55' }]}
+            />
+            <Image
+              source={smallImage}
+              style={[styles.base, styles.leftMargin, {tintColor: '#8e8e93' }]}
+            />
+          </View>
         </View>
       );
     },
@@ -282,6 +305,9 @@ var styles = StyleSheet.create({
   },
   background: {
     backgroundColor: '#222222'
+  },
+  sectionText: {
+    marginVertical: 6,
   },
   nestedText: {
     marginLeft: 12,

--- a/Libraries/Image/RCTImageDownloader.h
+++ b/Libraries/Image/RCTImageDownloader.h
@@ -38,6 +38,7 @@ typedef void (^RCTImageDownloadCancellationBlock)(void);
                                                     size:(CGSize)size
                                                    scale:(CGFloat)scale
                                               resizeMode:(UIViewContentMode)resizeMode
+                                               tintColor:(UIColor *)tintColor
                                          backgroundColor:(UIColor *)backgroundColor
                                            progressBlock:(RCTDataProgressBlock)progressBlock
                                                    block:(RCTImageDownloadBlock)block;

--- a/Libraries/Image/RCTImageDownloader.m
+++ b/Libraries/Image/RCTImageDownloader.m
@@ -132,6 +132,7 @@ CGRect RCTClipRect(CGSize, CGFloat, CGSize, CGFloat, UIViewContentMode);
                                                     size:(CGSize)size
                                                    scale:(CGFloat)scale
                                               resizeMode:(UIViewContentMode)resizeMode
+                                               tintColor:(UIColor *)tintColor
                                          backgroundColor:(UIColor *)backgroundColor
                                            progressBlock:(RCTDataProgressBlock)progressBlock
                                                    block:(RCTImageDownloadBlock)block
@@ -173,6 +174,10 @@ CGRect RCTClipRect(CGSize, CGFloat, CGSize, CGFloat, UIViewContentMode);
       if (blendColor) {
         [blendColor setFill];
         UIRectFill((CGRect){CGPointZero, destSize});
+      }
+      if (tintColor) {
+        image = [image imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
+        [tintColor setFill];
       }
       [image drawInRect:imageRect];
       image = UIGraphicsGetImageFromCurrentImageContext();

--- a/Libraries/Image/RCTNetworkImageView.h
+++ b/Libraries/Image/RCTNetworkImageView.h
@@ -29,6 +29,11 @@
 @property (nonatomic, strong) NSURL *imageURL;
 
 /**
+ * Whether the image should be masked with this view's tint color.
+ */
+@property (nonatomic, assign) BOOL tinted;
+
+/**
  * By default, changing imageURL will reset whatever existing image was present
  * and revert to defaultImage while the new image loads. In certain obscure cases you
  * may want to disable this behavior and instead keep displaying the previous image

--- a/Libraries/Image/RCTNetworkImageView.m
+++ b/Libraries/Image/RCTNetworkImageView.m
@@ -60,6 +60,12 @@ RCT_NOT_IMPLEMENTED(-initWithCoder:(NSCoder *)aDecoder)
   [self _updateImage];
 }
 
+- (void)setTintColor:(UIColor *)tintColor
+{
+  super.tintColor = tintColor;
+  [self _updateImage];
+}
+
 - (void)setProgressHandlerRegistered:(BOOL)progressHandlerRegistered
 {
   _progressHandlerRegistered = progressHandlerRegistered;
@@ -144,9 +150,14 @@ RCT_NOT_IMPLEMENTED(-initWithCoder:(NSCoder *)aDecoder)
         }
       }];
     } else {
-      _downloadToken = [_imageDownloader downloadImageForURL:imageURL size:self.bounds.size scale:RCTScreenScale()
-                                                  resizeMode:self.contentMode backgroundColor:self.backgroundColor
-                                                  progressBlock:progressHandler block:^(UIImage *image, NSError *error) {
+      _downloadToken = [_imageDownloader downloadImageForURL:imageURL
+                                                        size:self.bounds.size
+                                                       scale:RCTScreenScale()
+                                                  resizeMode:self.contentMode
+                                                   tintColor:_tinted ? self.tintColor : nil
+                                             backgroundColor:self.backgroundColor
+                                                  progressBlock:progressHandler
+                                                          block:^(UIImage *image, NSError *error) {
         if (image) {
           dispatch_async(dispatch_get_main_queue(), ^{
             if (imageURL != self.imageURL) {

--- a/Libraries/Image/RCTNetworkImageViewManager.m
+++ b/Libraries/Image/RCTNetworkImageViewManager.m
@@ -31,6 +31,16 @@ RCT_REMAP_VIEW_PROPERTY(defaultImageSrc, defaultImage, UIImage)
 RCT_REMAP_VIEW_PROPERTY(src, imageURL, NSURL)
 RCT_REMAP_VIEW_PROPERTY(resizeMode, contentMode, UIViewContentMode)
 RCT_EXPORT_VIEW_PROPERTY(progressHandlerRegistered, BOOL)
+RCT_CUSTOM_VIEW_PROPERTY(tintColor, UIColor, RCTNetworkImageView)
+{
+  if (json) {
+    view.tinted = YES;
+    view.tintColor = [RCTConvert UIColor:json];
+  } else {
+    view.tinted = defaultView.tinted;
+    view.tintColor = defaultView.tintColor;
+  }
+}
 
 - (NSDictionary *)customDirectEventTypes
 {


### PR DESCRIPTION
Remote images now support the `tintColor` prop.

Also picked nicer demo colors for the UIExplorer example.

Fixes #1867 

Test Plan: Looked at the UIExplorer's Image demo, which has tintColor working with remote images. Temporarily modified the example to test switching the tint color between blue and red and between blue and null to verify that reconciliation was working.