### PR TITLE
[Packager] Fix when loading a path that can't be handled

### DIFF
--- a/packager/react-packager/src/DependencyResolver/DependencyGraph/index.js
+++ b/packager/react-packager/src/DependencyResolver/DependencyGraph/index.js
@@ -150,7 +150,16 @@ class DependencyGraph {
 
   getOrderedDependencies(entryPath) {
     return this.load().then(() => {
-      const absolutePath = path.resolve(this._getAbsolutePath(entryPath));
+      const absPath = this._getAbsolutePath(entryPath);
+
+      if (absPath == null) {
+        throw new NotFoundError(
+          'Could not find source file at %s',
+          entryPath
+        );
+      }
+
+      const absolutePath = path.resolve(absPath);
 
       if (absolutePath == null) {
         throw new NotFoundError(


### PR DESCRIPTION
[Packager] Adds `NotFoundError` when loading a path that can't be handled

Resolves https://github.com/facebook/react-native/issues/1944