### PR TITLE
Fixed scrollResponder's scroll to keyboard for horizontal-scroll /pagination enabled scroll views

### DIFF
--- a/Libraries/Components/ScrollResponder.js
+++ b/Libraries/Components/ScrollResponder.js
@@ -442,7 +442,12 @@ var ScrollResponderMixin = {
     if (this.preventNegativeScrollOffset) {
       scrollOffsetY = Math.max(0, scrollOffsetY);
     }
-    this.scrollResponderScrollTo(0, scrollOffsetY);
+    
+    //For horizontal scroll enabled scroll views, current x position of the scroll view needs to be taken into account to
+    // preserve the horizontal scroll offset and prevent the scroll view from scrolling back.
+    ScrollViewManager.getScrollViewPosition(React.findNodeHandle(this), (x, y)=>{
+      this.scrollResponderScrollTo(x, scrollOffsetY);
+    });
 
     this.additionalOffset = 0;
     this.preventNegativeScrollOffset = false;

--- a/Libraries/Components/ScrollResponder.js
+++ b/Libraries/Components/ScrollResponder.js
@@ -445,7 +445,7 @@ var ScrollResponderMixin = {
     
     //For horizontal scroll enabled scroll views, current x position of the scroll view needs to be taken into account to
     // preserve the horizontal scroll offset and prevent the scroll view from scrolling back.
-    ScrollViewManager.getScrollViewPosition(React.findNodeHandle(this), (x, y)=>{
+    ScrollViewManager.getScrollViewPosition(React.findNodeHandle(this), (x, y) => {
       this.scrollResponderScrollTo(x, scrollOffsetY);
     });
 

--- a/React/Views/RCTScrollView.h
+++ b/React/Views/RCTScrollView.h
@@ -51,6 +51,7 @@
 
 - (void)endRefreshing;
 
+- (CGPoint) getScrollViewPosition;
 @end
 
 @interface RCTEventDispatcher (RCTScrollView)

--- a/React/Views/RCTScrollView.m
+++ b/React/Views/RCTScrollView.m
@@ -882,6 +882,10 @@ RCT_SET_AND_PRESERVE_OFFSET(setScrollIndicatorInsets, UIEdgeInsets);
   [_scrollView.refreshControl endRefreshing];
 }
 
+- (CGPoint) getScrollViewPosition {
+  return [_scrollView bounds].origin;
+};
+
 @end
 
 @implementation RCTEventDispatcher (RCTScrollView)

--- a/React/Views/RCTScrollViewManager.m
+++ b/React/Views/RCTScrollViewManager.m
@@ -176,4 +176,13 @@ RCT_EXPORT_METHOD(zoomToRect:(nonnull NSNumber *)reactTag withRect:(CGRect)rect)
   ];
 }
 
+RCT_EXPORT_METHOD(getScrollViewPosition: (NSNumber *)reactTag
+                  callback: (RCTResponseSenderBlock)callback) {
+  [self.bridge.uiManager addUIBlock:^(RCTUIManager *uiManager, RCTSparseArray *viewRegistry) {
+    RCTScrollView *scrollView = viewRegistry[reactTag];
+    CGPoint origin = [scrollView getScrollViewPosition];
+    callback(@[@(origin.x),@(origin.y)]);
+  }];
+}
+
 @end

--- a/React/Views/RCTScrollViewManager.m
+++ b/React/Views/RCTScrollViewManager.m
@@ -178,10 +178,10 @@ RCT_EXPORT_METHOD(zoomToRect:(nonnull NSNumber *)reactTag withRect:(CGRect)rect)
 
 RCT_EXPORT_METHOD(getScrollViewPosition: (NSNumber *)reactTag
                   callback: (RCTResponseSenderBlock)callback) {
-  [self.bridge.uiManager addUIBlock:^(RCTUIManager *uiManager, RCTSparseArray *viewRegistry) {
-    RCTScrollView *scrollView = viewRegistry[reactTag];
+  [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry){
+    RCTScrollView *scrollView = ( RCTScrollView* )viewRegistry[reactTag];
     CGPoint origin = [scrollView getScrollViewPosition];
-    callback(@[@(origin.x),@(origin.y)]);
+    callback(@[@(origin.x), @(origin.y)]);
   }];
 }
 


### PR DESCRIPTION
Current implementation always assumes the x offset of the scroll view to be 0 and calculates only the y offset to scroll the view to keyboard. However, for horizontal scroll views, this forces the scroll view to jump back to 0 coordinate in the x direction and consequently hang. The fix addresses this bug.