### PR TITLE
Fix nil block completion for TaskCompletionWrapper running XCode7.0

### DIFF
--- a/Libraries/Image/RCTDownloadTaskWrapper.m
+++ b/Libraries/Image/RCTDownloadTaskWrapper.m
@@ -62,7 +62,7 @@ static void *const RCTDownloadTaskWrapperProgressBlockKey = (void *)&RCTDownload
 
 - (NSURLSessionDownloadTask *)downloadData:(NSURL *)url progressBlock:(RCTDataProgressBlock)progressBlock completionBlock:(RCTDataCompletionBlock)completionBlock
 {
-  NSURLSessionDownloadTask *task = [_URLSession downloadTaskWithURL:url completionHandler:nil];
+  NSURLSessionDownloadTask *task = [_URLSession downloadTaskWithURL:url];
   task.rct_completionBlock = completionBlock;
   task.rct_progressBlock = progressBlock;
 


### PR DESCRIPTION
Libraries/Image/RCTDownloadTaskWrapper.m is not compiling using XCode 7.0 Beta.
This patch fix this issue #1955 .