### PR TITLE
[Image] Add examples to UIExplorer, fix some bugs

### DIFF
--- a/Examples/UIExplorer/ImageExample.js
+++ b/Examples/UIExplorer/ImageExample.js
@@ -21,9 +21,40 @@ var {
   StyleSheet,
   Text,
   View,
+  ActivityIndicatorIOS
 } = React;
 
 var ImageCapInsetsExample = require('./ImageCapInsetsExample');
+
+var NetworkImage = React.createClass({
+  watchID: (null: ?number),
+
+  getInitialState: function() {
+    return {
+      error: false,
+      loading: true,
+      progress: 0
+    };
+  },
+  render: function() {
+    var loader = this.state.loading ?
+      <View style={styles.progress}>
+        <Text>{this.state.progress}%</Text>
+        <ActivityIndicatorIOS style={{marginLeft:5}}/>
+      </View> : null;
+    return this.state.error ?
+      <Text>{this.state.error}</Text> :
+      <Image
+          source={this.props.source}
+          style={styles.base}
+          onLoadError={(e) => this.setState({error: e.nativeEvent.error})}
+          onLoadProgress={(e) => this.setState({progress: Math.max(0, Math.round(100 * e.nativeEvent.written / e.nativeEvent.total))}) }
+          onLoadEnd={() => this.setState({loading: false, error: false})}
+          onLoadAbort={() => this.setState({error: 'Loading has aborted'})} >
+      {loader}
+      </Image>
+  }
+});
 
 exports.displayName = (undefined: ?string);
 exports.framework = 'React';
@@ -56,6 +87,20 @@ exports.examples = [
           <Image source={require('image!uie_comment_normal')} style={styles.icon} />
           <Image source={require('image!uie_comment_highlighted')} style={styles.icon} />
         </View>
+      );
+    },
+  },
+  {
+    title: 'Error Handler',
+    render: function() {
+      return <NetworkImage source={{uri: 'http://TYPO_ERROR_facebook.github.io/react/img/logo_og.png'}} />
+    },
+  },
+  {
+    title: 'Image Download Progress',
+    render: function() {
+      return (
+        <NetworkImage source={{uri: 'http://facebook.github.io/origami/public/images/blog-hero.jpg?r=1'}}/>
       );
     },
   },
@@ -299,6 +344,12 @@ var styles = StyleSheet.create({
   base: {
     width: 38,
     height: 38,
+  },
+  progress: {
+    flex: 1,
+    alignItems: 'center',
+    flexDirection: 'row',
+    width: 100
   },
   leftMargin: {
     marginLeft: 10,

--- a/Libraries/Image/RCTDownloadTaskWrapper.m
+++ b/Libraries/Image/RCTDownloadTaskWrapper.m
@@ -66,7 +66,6 @@ static void *const RCTDownloadTaskWrapperProgressBlockKey = (void *)&RCTDownload
   task.rct_completionBlock = completionBlock;
   task.rct_progressBlock = progressBlock;
 
-  [task resume];
   return task;
 }
 

--- a/Libraries/Image/RCTImageDownloader.m
+++ b/Libraries/Image/RCTImageDownloader.m
@@ -96,7 +96,7 @@ CGRect RCTClipRect(CGSize, CGFloat, CGSize, CGFloat, UIViewContentMode);
           runBlocks(NO, data, error);
         }
 
-        if (response) {
+        if (response && !error) {
           RCTImageDownloader *strongSelf = weakSelf;
           NSCachedURLResponse *cachedResponse = [[NSCachedURLResponse alloc] initWithResponse:response data:data userInfo:nil storagePolicy:NSURLCacheStorageAllowed];
           [strongSelf->_cache storeCachedResponse:cachedResponse forRequest:request];

--- a/Libraries/Image/RCTNetworkImageView.m
+++ b/Libraries/Image/RCTNetworkImageView.m
@@ -86,6 +86,8 @@ RCT_NOT_IMPLEMENTED(-initWithCoder:(NSCoder *)aDecoder)
 {
   if (![_imageURL isEqual:imageURL] && _downloadToken) {
     [_imageDownloader cancelDownload:_downloadToken];
+    NSDictionary *event = @{ @"target": self.reactTag };
+    [_eventDispatcher sendInputEventWithName:@"loadAbort" body:event];
     _downloadToken = nil;
   }
 
@@ -146,8 +148,8 @@ RCT_NOT_IMPLEMENTED(-initWithCoder:(NSCoder *)aDecoder)
             loadEndHandler();
           });
         } else if (error) {
-          errorHandler([error description]);
-        }
+          errorHandler([error localizedDescription]);
+        } 
       }];
     } else {
       _downloadToken = [_imageDownloader downloadImageForURL:imageURL
@@ -170,8 +172,8 @@ RCT_NOT_IMPLEMENTED(-initWithCoder:(NSCoder *)aDecoder)
             loadEndHandler();
           });
         } else if (error) {
-          errorHandler([error description]);
-        }
+          errorHandler([error localizedDescription]);
+        } 
       }];
     }
   }

--- a/Libraries/Image/RCTNetworkImageViewManager.m
+++ b/Libraries/Image/RCTNetworkImageViewManager.m
@@ -47,7 +47,7 @@ RCT_CUSTOM_VIEW_PROPERTY(tintColor, UIColor, RCTNetworkImageView)
   return @{
     @"loadStart":    @{ @"registrationName": @"onLoadStart" },
     @"loadProgress": @{ @"registrationName": @"onLoadProgress" },
-    @"loaded":       @{ @"registrationName": @"onLoaded" },
+    @"loaded":       @{ @"registrationName": @"onLoadEnd" },
     @"loadError":    @{ @"registrationName": @"onLoadError" },
     @"loadAbort":    @{ @"registrationName": @"onLoadAbort" },
   };


### PR DESCRIPTION
Add two simple examples.
![image](https://cloud.githubusercontent.com/assets/1004115/8674092/03052652-2a55-11e5-8531-8f01c7970af4.png)

Also:
- do not start the task at DownloadTaskWrapper (it starts from ImageDowloader if image isn't cached yet);
- fire `onLoadAbor`t event;
- send more readable `error.localizedDescription` with `onLoadError`;
- rename `onLoaded` to `onLoadEnd`