### PR TITLE
[NavigatorIOS] Fix pop method to properly refresh the navigatorBar

### DIFF
--- a/Libraries/Components/Navigation/NavigatorIOS.ios.js
+++ b/Libraries/Components/Navigation/NavigatorIOS.ios.js
@@ -507,9 +507,7 @@ var NavigatorIOS = React.createClass({
           this.setState({
             requestedTopOfStack: newRequestedTopOfStack,
             makingNavigatorRequest: true,
-            // Not actually updating the indices yet until we get the native
-            // `onNavigationComplete`.
-            updatingAllIndicesAtOrBeyond: null,
+            updatingAllIndicesAtOrBeyond: this.state.requestedTopOfStack - n,
           });
         });
       }


### PR DESCRIPTION
When using nativator.pop() the navigatorBar doesn't refresh properly if we change navigationBarHidden.

## Current result:

When navigator.pop() is called, the navbar doesn't show up, even avec navigationBarHidden set back to true. See between Statusbar and Movie poster in the example below.

![bad](https://cloud.githubusercontent.com/assets/55496/8683849/77effa30-2a75-11e5-9f32-9be6fa87efac.gif)

    // Not actually updating the indices yet until we get the native
    // `onNavigationComplete`.
    updatingAllIndicesAtOrBeyond: null,

https://github.com/facebook/react-native/blob/master/Libraries/Components/Navigation/NavigatorIOS.ios.js#L510-L512

## Expected result (after fix)

The View need to be refreshed in pop method anyway.

    updatingAllIndicesAtOrBeyond: this.state.requestedTopOfStack - n,

Now, navbar appears properly.

![good](https://cloud.githubusercontent.com/assets/55496/8683907/be9d2714-2a75-11e5-8fda-653e68869076.gif)
