### PR TITLE
Add ES6 modules to whitelist

### DIFF
--- a/packager/react-packager/.babelrc
+++ b/packager/react-packager/.babelrc
@@ -10,6 +10,7 @@
     "es6.constants",
     "es6.classes",
     "es6.destructuring",
+    "es6.modules",
     "es6.parameters.rest",
     "es6.properties.computed",
     "es6.properties.shorthand",

--- a/packager/transformer.js
+++ b/packager/transformer.js
@@ -23,6 +23,7 @@ function transform(srcTxt, filename, options) {
       'es6.blockScoping',
       'es6.classes',
       'es6.destructuring',
+      'es6.modules',
       'es6.parameters.rest',
       'es6.properties.computed',
       'es6.properties.shorthand',


### PR DESCRIPTION
Babel support the ES6 module syntax and will per default transpile it to commonjs syntax: https://babeljs.io/docs/usage/modules/

This syntax is a lot cleaner than the current way of requiring and destructing. These is no reason not to allow this :-)

Example
```js
import React, { Component, View, Text } from 'react-native'

class Foobar extends Component {
  render() {
    return (
      <View><Text>Foo</Text></View>
    )
  }
}

export default Foobar 
```

The reason for the extra ```React``` import is that the transpiled JSX is ```React.createElement(...)```