### PR TITLE
[UIManager] Fix strong reference and add validity check

### DIFF
--- a/React/Modules/RCTUIManager.m
+++ b/React/Modules/RCTUIManager.m
@@ -283,12 +283,13 @@ static NSDictionary *RCTViewConfigForModule(Class managerClass)
 {
   __weak RCTUIManager *weakSelf = self;
   dispatch_async(self.methodQueue, ^{
-    __weak RCTUIManager *strongSelf = weakSelf;
-    if (strongSelf) {
-      [[NSNotificationCenter defaultCenter] postNotificationName:RCTUIManagerWillUpdateViewsDueToContentSizeMultiplierChangeNotification
-                                                          object:strongSelf];
-      [strongSelf batchDidComplete];
+    RCTUIManager *strongSelf = weakSelf;
+    if (!strongSelf.isValid) {
+      return;
     }
+    [[NSNotificationCenter defaultCenter] postNotificationName:RCTUIManagerWillUpdateViewsDueToContentSizeMultiplierChangeNotification
+                                                        object:strongSelf];
+    [strongSelf batchDidComplete];
   });
 }
 


### PR DESCRIPTION
A strong reference to the UIManager from within a block was marked weak for some reason. Made it strong, and also checked if it was still valid rather than just non-nil.