### PR TITLE
#!/bin/bash => #!/usr/bin/env bash

### DIFF
--- a/packager/launchPackager.command
+++ b/packager/launchPackager.command
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright (c) 2015-present, Facebook, Inc.
 # All rights reserved.

--- a/packager/packager.sh
+++ b/packager/packager.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright (c) 2015-present, Facebook, Inc.
 # All rights reserved.


### PR DESCRIPTION
This change makes `npm start` work correctly on e.g. NixOS.