### PR TITLE
[Image] Improved loading of Assets Library and Photos Framework images.

### DIFF
--- a/Examples/UIExplorer/AssetScaledImageExample.ios.js
+++ b/Examples/UIExplorer/AssetScaledImageExample.ios.js
@@ -1,0 +1,132 @@
+/**
+ * The examples provided by Facebook are for non-commercial testing and
+ * evaluation purposes only.
+ *
+ * Facebook reserves all rights not expressly granted.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON INFRINGEMENT. IN NO EVENT SHALL
+ * FACEBOOK BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * @flow
+ */
+'use strict';
+
+var React = require('react-native');
+var {
+  Image,
+  StyleSheet,
+  Text,
+  View,
+  ScrollView
+} = React;
+
+var AssetScaledImageExample = React.createClass({
+
+  getInitialState() {
+    return {
+      asset: this.props.asset
+    };
+  },
+
+  render() {
+    var asset = this.state.asset;
+    return (
+      <ScrollView>
+
+        <View style={ styles.row }>
+          <Image
+            source={{ uri: asset.node.image.uri }}
+            style={ styles.imageWide }
+          />
+        </View> 
+
+        <View style={ styles.row }>
+          <Image
+            source={{ uri: asset.node.image.uri }}
+            style={ styles.imageThumb }
+          />
+          <Image
+            source={{ uri: asset.node.image.uri }}
+            style={ styles.imageThumb }
+          />
+          <Image
+            source={{ uri: asset.node.image.uri }}
+            style={ styles.imageThumb }
+          />
+        </View>
+
+        <View style={ styles.row }>
+          <Image
+            source={{ uri: asset.node.image.uri  }}
+            style={ styles.imageT1 }
+          />
+          <Image
+            source={{ uri: asset.node.image.uri  }}
+            style={ styles.imageT2 }
+          />
+        </View>
+
+
+     
+        
+      </ScrollView>
+    );
+  },
+  
+
+});
+
+var styles = StyleSheet.create({
+  row: {
+    padding: 5,
+    flex: 1,
+    flexDirection: 'row',
+    alignSelf: 'center'
+  },
+  
+  textColumn: {
+    flex: 1,
+    flexDirection: 'column'
+  },
+  
+  imageWide: {
+    borderWidth: 1,
+    borderColor: 'black',
+    width: 320,
+    height: 240,
+    margin: 5,
+  },
+
+  imageThumb: {
+    borderWidth: 1,
+    borderColor: 'black',
+    width: 100,
+    height: 100, 
+    margin: 5
+  },
+  
+  imageT1: {
+    borderWidth: 1,
+    borderColor: 'black',
+    width: 212,
+    height: 320,
+    margin: 5, 
+  },
+
+  imageT2: {
+    borderWidth: 1,
+    borderColor: 'black',
+    width: 100,
+    height: 320,
+    margin: 5,     
+  },
+
+});
+
+exports.title = '<AssetScaledImageExample>';
+exports.description = 'Example component that displays the automatic scaling capabilities of the <Image /> tag';
+module.exports = AssetScaledImageExample;

--- a/Examples/UIExplorer/CameraRollExample.ios.js
+++ b/Examples/UIExplorer/CameraRollExample.ios.js
@@ -24,9 +24,11 @@ var {
   SwitchIOS,
   Text,
   View,
+  TouchableOpacity
 } = React;
 
 var CameraRollView = require('./CameraRollView.ios');
+var AssetScaledImageExampleView = require('./AssetScaledImageExample.ios');
 
 var CAMERA_ROLL_VIEW = 'camera_roll_view';
 
@@ -54,7 +56,7 @@ var CameraRollExample = React.createClass({
         <Text>{'Group Type: ' + this.state.groupTypes}</Text>
         <CameraRollView
           ref={CAMERA_ROLL_VIEW}
-          batchSize={5}
+          batchSize={20}
           groupTypes={this.state.groupTypes}
           renderImage={this._renderImage}
         />
@@ -62,24 +64,35 @@ var CameraRollExample = React.createClass({
     );
   },
 
+  loadAsset(asset){
+    this.props.navigator.push({
+      title: "Camera Roll Image",
+      component: AssetScaledImageExampleView,
+      backButtonTitle: 'Back',
+      passProps: { asset: asset },
+    });
+  },
+  
   _renderImage(asset) {
     var imageSize = this.state.bigImages ? 150 : 75;
     var imageStyle = [styles.image, {width: imageSize, height: imageSize}];
     var location = asset.node.location.longitude ?
       JSON.stringify(asset.node.location) : 'Unknown location';
     return (
-      <View key={asset} style={styles.row}>
-        <Image
-          source={asset.node.image}
-          style={imageStyle}
-        />
-        <View style={styles.info}>
-          <Text style={styles.url}>{asset.node.image.uri}</Text>
-          <Text>{location}</Text>
-          <Text>{asset.node.group_name}</Text>
-          <Text>{new Date(asset.node.timestamp).toString()}</Text>
+      <TouchableOpacity onPress={ this.loadAsset.bind( this, asset ) }>
+        <View key={asset} style={styles.row}>
+          <Image
+            source={{ uri: asset.node.image.uri }}
+            style={imageStyle}
+          />
+          <View style={styles.info}>
+            <Text style={styles.url}>{asset.node.image.uri}</Text>
+            <Text>{location}</Text>
+            <Text>{asset.node.group_name}</Text>
+            <Text>{new Date(asset.node.timestamp).toString()}</Text>
+          </View>
         </View>
-      </View>
+      </TouchableOpacity>
     );
   },
 

--- a/Examples/UIExplorer/createExamplePage.js
+++ b/Examples/UIExplorer/createExamplePage.js
@@ -55,6 +55,7 @@ var createExamplePage = function(title: ?string, exampleModule: ExampleModule)
       var result = example.render(null);
       if (result) {
         renderedComponent = result;
+        result.props.navigator = this.props.navigator;
       }
       (React: Object).render = originalRender;
       (React: Object).renderComponent = originalRenderComponent;

--- a/Libraries/Image/RCTImageLoader.m
+++ b/Libraries/Image/RCTImageLoader.m
@@ -67,6 +67,64 @@ static dispatch_queue_t RCTImageLoaderQueue(void)
                        callback:callback];
 }
 
+//
+// Why use a custom scaling method:
+// http://www.mindsea.com/2012/12/downscaling-huge-alassets-without-fear-of-sigkill/
+//     Greater efficiency, reduced memory overhead.
++(UIImage *)scaledImageForAssetRepresentation:(ALAssetRepresentation *)representation
+                                         size:(CGSize)size
+                                        scale:(CGFloat)scale
+                                  orientation:(UIImageOrientation)orientation
+{
+  UIImage *image;
+  NSData *data = nil;
+
+  uint8_t *buffer = (uint8_t *)malloc(sizeof(uint8_t)*[representation size]);
+  if (buffer != NULL) {
+    NSError *error = nil;
+    NSUInteger bytesRead = [representation getBytes:buffer fromOffset:0 length:[representation size] error:&error];
+    data = [NSData dataWithBytes:buffer length:bytesRead];
+    
+    free(buffer);
+  }
+  
+  if ([data length]) {
+    CGImageSourceRef sourceRef = CGImageSourceCreateWithData((__bridge CFDataRef)data, nil);
+    
+    NSMutableDictionary *options = [NSMutableDictionary dictionary];
+ 
+    CGSize source = representation.dimensions;
+    CGFloat mW = size.width / source.width;
+    CGFloat mH = size.height / source.height;
+    
+    if (mH > mW) {
+      size.width = size.height / source.height * source.width;
+    } else if (mW > mH) {
+      size.height = size.width / source.width * source.height;
+    }
+    
+    CGFloat maxPixelSize = MAX(size.width, size.height) * scale;
+ 
+    [options setObject:(id)kCFBooleanTrue forKey:(id)kCGImageSourceShouldAllowFloat];
+    [options setObject:(id)kCFBooleanTrue forKey:(id)kCGImageSourceCreateThumbnailWithTransform];
+    [options setObject:(id)kCFBooleanTrue forKey:(id)kCGImageSourceCreateThumbnailFromImageAlways];
+    [options setObject:(id)[NSNumber numberWithFloat:maxPixelSize] forKey:(id)kCGImageSourceThumbnailMaxPixelSize];
+    
+    CGImageRef imageRef = CGImageSourceCreateThumbnailAtIndex(sourceRef, 0, (__bridge CFDictionaryRef)options);
+    
+    if (imageRef) {
+      image = [UIImage imageWithCGImage:imageRef scale:[representation scale] orientation:orientation];
+      CGImageRelease(imageRef);
+    }
+    
+    if (sourceRef) {
+      CFRelease(sourceRef);
+    }
+  }
+  
+  return image;
+}
+
 + (void)loadImageWithTag:(NSString *)imageTag
                     size:(CGSize)size
                    scale:(CGFloat)scale
@@ -87,28 +145,17 @@ static dispatch_queue_t RCTImageLoaderQueue(void)
 
             BOOL useMaximumSize = CGSizeEqualToSize(size, CGSizeZero);
             ALAssetOrientation orientation = ALAssetOrientationUp;
-            CGImageRef imageRef = NULL;
+            ALAssetRepresentation *representation = [asset defaultRepresentation];
+            
+            UIImage *image;
 
-            if (!useMaximumSize) {
-              imageRef = asset.thumbnail;
-            }
-            if (RCTUpscalingRequired((CGSize){CGImageGetWidth(imageRef), CGImageGetHeight(imageRef)}, 1, size, scale, resizeMode)) {
-              if (!useMaximumSize) {
-                imageRef = asset.aspectRatioThumbnail;
-              }
-              if (RCTUpscalingRequired((CGSize){CGImageGetWidth(imageRef), CGImageGetHeight(imageRef)}, 1, size, scale, resizeMode)) {
-                ALAssetRepresentation *representation = [asset defaultRepresentation];
-                orientation = [representation orientation];
-                if (!useMaximumSize) {
-                  imageRef = [representation fullScreenImage];
-                }
-                if (RCTUpscalingRequired((CGSize){CGImageGetWidth(imageRef), CGImageGetHeight(imageRef)}, 1, size, scale, resizeMode)) {
-                  imageRef = [representation fullResolutionImage];
-                }
-              }
-            }
+            if (useMaximumSize) {
+              image = [UIImage imageWithCGImage:representation.fullResolutionImage scale:scale orientation:(UIImageOrientation)orientation];
 
-            UIImage *image = [UIImage imageWithCGImage:imageRef scale:scale orientation:(UIImageOrientation)orientation];
+            } else {
+              image = [self scaledImageForAssetRepresentation:representation size:size scale:scale orientation:(UIImageOrientation)orientation];
+            }
+            
             RCTDispatchCallbackOnMainQueue(callback, nil, image);
           }
         });
@@ -137,12 +184,25 @@ static dispatch_queue_t RCTImageLoaderQueue(void)
     }
 
     PHAsset *asset = [results firstObject];
-    CGSize targetSize = CGSizeEqualToSize(size, CGSizeZero) ? PHImageManagerMaximumSize : size;
+    
+    PHImageRequestOptions *imageOptions = [[PHImageRequestOptions alloc] init];
+
+    BOOL useMaximumSize = CGSizeEqualToSize(size, CGSizeZero);
+    CGSize targetSize;
+    
+    if ( useMaximumSize ){
+      targetSize = PHImageManagerMaximumSize;
+      imageOptions.resizeMode = PHImageRequestOptionsResizeModeNone;
+    } else {
+      targetSize = size;
+      imageOptions.resizeMode = PHImageRequestOptionsResizeModeFast;
+    }
+
     PHImageContentMode contentMode = PHImageContentModeAspectFill;
     if (resizeMode == UIViewContentModeScaleAspectFit) {
       contentMode = PHImageContentModeAspectFit;
     }
-    [[PHImageManager defaultManager] requestImageForAsset:asset targetSize:targetSize contentMode:contentMode options:nil resultHandler:^(UIImage *result, NSDictionary *info) {
+    [[PHImageManager defaultManager] requestImageForAsset:asset targetSize:targetSize contentMode:contentMode options:imageOptions resultHandler:^(UIImage *result, NSDictionary *info) {
       if (result) {
         RCTDispatchCallbackOnMainQueue(callback, nil, result);
       } else {

--- a/Libraries/Image/RCTImageLoader.m
+++ b/Libraries/Image/RCTImageLoader.m
@@ -79,10 +79,10 @@ static dispatch_queue_t RCTImageLoaderQueue(void)
   UIImage *image;
   NSData *data = nil;
 
-  uint8_t *buffer = (uint8_t *)malloc(sizeof(uint8_t)*[representation size]);
+  uint8_t *buffer = (uint8_t *)malloc(sizeof(uint8_t)*(NSUInteger)[representation size]);
   if (buffer != NULL) {
     NSError *error = nil;
-    NSUInteger bytesRead = [representation getBytes:buffer fromOffset:0 length:[representation size] error:&error];
+    NSUInteger bytesRead = [representation getBytes:buffer fromOffset:0 length:(NSUInteger)[representation size] error:&error];
     data = [NSData dataWithBytes:buffer length:bytesRead];
     
     free(buffer);

--- a/Libraries/Image/RCTImageLoader.m
+++ b/Libraries/Image/RCTImageLoader.m
@@ -79,10 +79,8 @@ static dispatch_queue_t RCTImageLoaderQueue(void)
   UIImage *image;
   NSData *data = nil;
 
-  uint8_t *buffer = (uint8_t *)malloc(sizeof(uint8_t)*[representation size]);
   if (buffer != NULL) {
     NSError *error = nil;
-    NSUInteger bytesRead = [representation getBytes:buffer fromOffset:0 length:[representation size] error:&error];
     data = [NSData dataWithBytes:buffer length:bytesRead];
     
     free(buffer);

--- a/Libraries/Image/RCTImageLoader.m
+++ b/Libraries/Image/RCTImageLoader.m
@@ -79,8 +79,10 @@ static dispatch_queue_t RCTImageLoaderQueue(void)
   UIImage *image;
   NSData *data = nil;
 
+  uint8_t *buffer = (uint8_t *)malloc(sizeof(uint8_t)*[representation size]);
   if (buffer != NULL) {
     NSError *error = nil;
+    NSUInteger bytesRead = [representation getBytes:buffer fromOffset:0 length:[representation size] error:&error];
     data = [NSData dataWithBytes:buffer length:bytesRead];
     
     free(buffer);

--- a/Libraries/Image/RCTImageLoader.m
+++ b/Libraries/Image/RCTImageLoader.m
@@ -194,7 +194,7 @@ static dispatch_queue_t RCTImageLoaderQueue(void)
       targetSize = PHImageManagerMaximumSize;
       imageOptions.resizeMode = PHImageRequestOptionsResizeModeNone;
     } else {
-      targetSize = size;
+      targetSize = CGSizeMake(size.width * scale, size.height * scale);
       imageOptions.resizeMode = PHImageRequestOptionsResizeModeFast;
     }
 


### PR DESCRIPTION
Update to https://github.com/facebook/react-native/pull/1969

--
Recent improvements allow RCTImageLoader to select a more appropriate sized image based on the layout dimensions. Sizes:

	- asset.thumbnail
	- asset.aspectRatioThumbnail
	- asset.defaultRepresentation.fullScreenImage
	- asset.defaultRepresentation.fullResolutionImage

Prior, only the fullResolutionImage was used. This was memory intensive and resulted in crashes when loading several large images at once. The updated implementation works well, but can be made more efficient:

Consider loading 10 8MP (3264x2448) images in 150x150 pixel containers. The target size (150x150) is larger than asset.thumbnail (approx 100x100), therefore the fullScreenImage representation is used instead (approx 1334x1000).

This commit will scale the asset to the minimum size required while taking into account original aspect ratio and device scale. Memory usage is considerably lower and many more images can be loaded in 
sequence without having to worry about memory warnings/crashes.

Memory comparison:

... | Master | This PR
---- | ------------ | -------------
8MP image to 150x150 thumb | 5.2mb (scaled to 1334x1000) | 468kb (scaled to 400x300)
8MP image to 320x240 thumb | 5.2mb | 1.2mb
100 images from camera roll 150x150 | 176.2mb spike | 138.3mb spike

Additional reading:
http://www.mindsea.com/2012/12/downscaling-huge-alassets-without-fear-of-sigkill/

Support has been added for both ALAssets and Photos Framework.

Also added additional example: tap an image from the Camera Roll Example to see multiple versions of the image at different resolutions.



![screen shot 2015-07-15 at 2 30 47 pm](https://cloud.githubusercontent.com/assets/542/8706550/50ba6d90-2afe-11e5-936d-32755c52bc90.png)
