### PR TITLE
[Chrome Debugger] Update ws dependency to 0.7.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "underscore": "1.7.0",
     "wordwrap": "^1.0.0",
     "worker-farm": "^1.3.1",
-    "ws": "0.4.31",
+    "ws": "^0.7.2",
     "yargs": "1.3.2"
   },
   "devDependencies": {


### PR DESCRIPTION
ws 0.7.2 officially supports io.js

Test Plan: Run the UIExplorer in the Chrome debugger and verify that it's running fine.