### PR TITLE
[Bridge] Check self.isValid in RCTBatchedBridge after initial script evaluation

### DIFF
--- a/React/Base/RCTBatchedBridge.m
+++ b/React/Base/RCTBatchedBridge.m
@@ -340,6 +340,10 @@ RCT_EXTERN NSArray *RCTGetModuleClasses(void);
   sourceCodeModule.scriptText = sourceCode;
 
   [self enqueueApplicationScript:sourceCode url:self.bundleURL onComplete:^(NSError *loadError) {
+    if (!self.isValid) {
+      return;
+    }
+
     if (loadError) {
       dispatch_async(dispatch_get_main_queue(), ^{
         [self stopLoadingWithError:loadError];


### PR DESCRIPTION
I noticed that sometimes the batched bridge would be valid before `[self enqueueApplicationScript:url:onComplete:]` but then become invalid in the completion callback. This diff checks `self.isValid` inside of the callback.

Test Plan: Load app a couple of times and see that my `RCTJavaScriptDidLoadNotification` observer is never notified by an invalid batched bridge.