### PR TITLE
make array test length, not truthy-ness

### DIFF
--- a/Libraries/Components/ScrollView/ScrollView.js
+++ b/Libraries/Components/ScrollView/ScrollView.js
@@ -279,7 +279,7 @@ var ScrollView = React.createClass({
     }
 
     var children = this.props.children;
-    if (this.props.stickyHeaderIndices) {
+    if (this.props.stickyHeaderIndices.length) {
       children = ReactChildren.map(children, (child) => {
         if (child) {
           return <View collapsible={false}>{child}</View>;


### PR DESCRIPTION
`stickyHeaderIndices` is an array, so the test is always true. This means new children are always mapped, which shouldn't be the case. 

This "fixes" https://github.com/facebook/react-native/issues/2023 - but only when you don't have stickyHeaderIndices. The real problem is the re-mapping children breaks measurement, but that should be a separate fix (I think).

