### PR TITLE
[Packager] Include Content-Type headers with bundle and source maps

### DIFF
--- a/packager/react-packager/src/Server/__tests__/Server-test.js
+++ b/packager/react-packager/src/Server/__tests__/Server-test.js
@@ -39,6 +39,7 @@ describe('processRequest', function() {
       requestHandler(
         { url: requrl },
         {
+          setHeader: jest.genMockFunction(),
           end: function(res) {
             resolve(res);
           }

--- a/packager/react-packager/src/Server/index.js
+++ b/packager/react-packager/src/Server/index.js
@@ -358,13 +358,17 @@ Server.prototype.processRequest = function(req, res, next) {
   building.then(
     function(p) {
       if (requestType === 'bundle') {
-        res.end(p.getSource({
+        var bundleSource = p.getSource({
           inlineSourceMap: options.inlineSourceMap,
           minify: options.minify,
-        }));
+        });
+        res.setHeader('Content-Type', 'application/javascript');
+        res.end(bundleSource);
         Activity.endEvent(startReqEventId);
       } else if (requestType === 'map') {
-        res.end(JSON.stringify(p.getSourceMap()));
+        var sourceMap = JSON.stringify(p.getSourceMap());
+        res.setHeader('Content-Type', 'application/json');
+        res.end(sourceMap);
         Activity.endEvent(startReqEventId);
       }
     },


### PR DESCRIPTION
The packager did not send back the Content-Type headers. Adding these.

Test Plan: Run UIExplorer in JSC to ensure the bundle loads. Run it in the Chrome debugger to ensure that source maps load.