### PR TITLE
[Packager] Allow imports that are relative to the project root

### DIFF
--- a/packager/react-packager/src/DependencyResolver/DependencyGraph/index.js
+++ b/packager/react-packager/src/DependencyResolver/DependencyGraph/index.js
@@ -262,7 +262,27 @@ class DependencyGraph {
           .catch(() => this._loadAsDir(potentialModulePath));
       }
 
-      throw new Error('Unable to resolve dependency');
+      // If we haven't found the file yet, attempt to find the file using an absolute
+      // import from the root of the project.
+      const searchQueue = [];
+      for (let currDir = path.dirname(fromModule.path);
+           currDir !== '/';
+           currDir = path.dirname(currDir)) {
+        searchQueue.push(
+          path.join(currDir, realModuleName)
+        );
+      }
+
+      let p = Promise.reject(new Error('Unable to resolve dependency'));
+      searchQueue.forEach(potentialModulePath => {
+        p = p.catch(
+          () => this._loadAsFile(potentialModulePath)
+        ).catch(
+          () => this._loadAsDir(potentialModulePath)
+        );
+      });
+
+      return p;
     });
   }
 


### PR DESCRIPTION
This is related to #637.

From that issue to quote @JaapRood:
Browserify and webpack both let you use [symlinks in the node_modules folder](https://github.com/substack/browserify-handbook#symlink) to reference modules. This is mainly useful for preventing `../../../../` requires.

With a symlink setup from the project root setup like:

`ln -s src/app node_modules/app`

in any file in the project you can:

```
var  app = require('app');
var somethingElse  = require('app/lib/something-else');
```

However, the packager can't resolve them: `Requiring unknown module "app".`

@ide did some investigation and found that support for symlinks was most likely not going to happen for watchman [facebook/watchman#105](https://github.com/facebook/watchman/issues/105)

To get around this in our app, we've been building a library and keeping it at the project root. With this pull request, we can then find these modules and our import statements are:

```
import MyLib from "my_lib"
import SomethingElse from "my_lib/very/deep/nested/file/something_else"
```

from anywhere in our project, not just at the root. This is similar to what [`resolve.root`](http://webpack.github.io/docs/configuration.html#resolve-root) for those familiar with webpack allows.

Thoughts? I know this isn't a solution to the symlinks problem but it helps alleviate the problem for some use cases and allows us to have clean import statements for our core internal modules.