### PR TITLE
Update element inspector item text

### DIFF
--- a/React/Base/RCTDevMenu.m
+++ b/React/Base/RCTDevMenu.m
@@ -309,7 +309,7 @@ RCT_EXPORT_MODULE()
     self.showFPS = !_showFPS;
   }]];
 
-  [items addObject:[[RCTDevMenuItem alloc] initWithTitle:@"Inspect Element" handler:^{
+  [items addObject:[[RCTDevMenuItem alloc] initWithTitle:@"Toggle Element Inspector" handler:^{
     [_bridge.eventDispatcher sendDeviceEventWithName:@"toggleElementInspector" body:nil];
   }]];
 


### PR DESCRIPTION
Hooray for bike shedding!

Anyway, the *Inspect Element* menu item seems like a misnomer. It doesn't inspect an element, it toggles the tool on/off.

It would be even more awesome if this button behaved the same way as the others, but since the inspector is implemented in JavaScript (and can thus be Cmd + R'd away), that's not quite as trivial.