### PR TITLE
AnimatedTransformMatrix allows for complex/compound 3d animations

### DIFF
--- a/Libraries/Animation/Animated/Animated.js
+++ b/Libraries/Animation/Animated/Animated.js
@@ -780,6 +780,51 @@ class AnimatedTransform extends AnimatedWithChildren {
   }
 }
 
+class AnimatedTransformMatrix extends AnimatedWithChildren {
+  _transformMatrix: Array<Object>;
+
+  constructor(transformMatrix: Array<Object>) {
+    super();
+    this._transformMatrix = transformMatrix;
+  }
+
+  __getValue(): Array<Number> {
+    return this._transformMatrix.map(x => {
+      if (x instanceof Animated) {
+        return x.__getValue();
+      } else {
+        return x;
+      }
+    });
+  }
+
+  getAnimatedValue(): Array<Number> {
+    return this._transformMatrix.map(x => {
+      if (x instanceof Animated) {
+        return x.getAnimatedValue();
+      } else {
+        return x;
+      }
+    });
+  }
+
+  attach(): void {
+    this._transformMatrix.forEach(x => {
+      if (x instanceof Animated) {
+        x.addChild(this);
+      }
+    });
+  }
+
+  detach(): void {
+    this._transformMatrix.forEach(x => {
+      if (x instanceof Animated) {
+        x.removeChild(this);
+      }
+    });
+  }
+}
+
 class AnimatedStyle extends AnimatedWithChildren {
   _style: Object;
 
@@ -790,6 +835,12 @@ class AnimatedStyle extends AnimatedWithChildren {
       style = {
         ...style,
         transform: new AnimatedTransform(style.transform),
+      };
+    }
+    if (style.transformMatrix) {
+      style = {
+        ...style,
+        transformMatrix: new AnimatedTransformMatrix(style.transformMatrix),
       };
     }
     this._style = style;


### PR DESCRIPTION
Implemented `AnimatedTransformMatrix` following suit from `AnimatedTransform` class. Pretty straight-forward.

I looked in the test suite and there wasn't really anything testing `AnimatedTransform` specifically, so I didn't add any tests for `AnimatedTransformMatrix`, but I could add some if necessary.

Example usage:

```js
var CoverFlow = React.createClass({

    getInitialState() {
        return {
            x: new Animated.Value(0)
        };
    },

    render: function () {

        var { x } = this.state;

        var scale = x.interpolate({
            inputRange: [0, 30, 31],
            outputRange: [1, 0.5, 0.5]
        });

        var transformMatrix = [
            +1.0, +0.0, +0.0, -0.0035,
            +0.0, +1.0, +0.0, +0.0,
            +0.0, +0.0, +1.0, +0.0,
               x, +0.0, +0.0, scale
        ];

        return (
            <View
                style={styles.container}
                {...this.responder.panHandlers}
                >
                <Animated.Image
                    style={[styles.image, { transformMatrix }]}
                    source={imageSource} />
            </View>
        );
    }
});
```

Also note that in the following:

```js
    if (style.transformMatrix) {
      style = {
        ...style,
        transformMatrix: new AnimatedTransformMatrix(style.transformMatrix),
      };
    }
```
we don't need to handle the scenario where both `transform` and `transformMatrix` are present, since they cannot both be specified at the same time.