### PR TITLE
[StatusBar] Add ability to toggle the network activity indicator in the status bar + example in UIExplorer

### DIFF
--- a/Examples/UIExplorer/StatusBarIOSExample.js
+++ b/Examples/UIExplorer/StatusBarIOSExample.js
@@ -83,6 +83,26 @@ exports.examples = [{
       </View>
     );
   },
+}, {
+  title: 'Status Bar Network Activity Indicator',
+  render() {
+    return (
+      <View>
+        <TouchableHighlight style={styles.wrapper}
+          onPress={() => StatusBarIOS.setNetworkActivityIndicatorVisible(true)}>
+          <View style={styles.button}>
+            <Text>setNetworkActivityIndicatorVisible(true)</Text>
+          </View>
+        </TouchableHighlight>
+        <TouchableHighlight style={styles.wrapper}
+          onPress={() => StatusBarIOS.setNetworkActivityIndicatorVisible(false)}>
+          <View style={styles.button}>
+            <Text>setNetworkActivityIndicatorVisible(false)</Text>
+          </View>
+        </TouchableHighlight>
+      </View>
+    );
+  },
 }];
 
 var styles = StyleSheet.create({

--- a/Libraries/Components/StatusBar/StatusBarIOS.ios.js
+++ b/Libraries/Components/StatusBar/StatusBarIOS.ios.js
@@ -35,6 +35,10 @@ var StatusBarIOS = {
     animation = animation || 'none';
     RCTStatusBarManager.setHidden(hidden, animation);
   },
+
+  setNetworkActivityIndicatorVisible(visible: boolean) {
+    RCTStatusBarManager.setNetworkActivityIndicatorVisible(visible);
+  },
 };
 
 module.exports = StatusBarIOS;

--- a/React/Modules/RCTStatusBarManager.m
+++ b/React/Modules/RCTStatusBarManager.m
@@ -71,4 +71,9 @@ RCT_EXPORT_METHOD(setHidden:(BOOL)hidden
   }
 }
 
+RCT_EXPORT_METHOD(setNetworkActivityIndicatorVisible:(BOOL)visible)
+{
+  [[UIApplication sharedApplication] setNetworkActivityIndicatorVisible:visible];
+}
+
 @end


### PR DESCRIPTION
Added the ability to turn on and off the network activity indicator using:

```
StatusBarIOS.setNetworkActivityIndicatorVisible(true)
```
and
```
StatusBarIOS.setNetworkActivityIndicatorVisible(false)
```

Also added an example to the UIExplorer example app.

Fix #986