### PR TITLE
Enum Constants Explanation

### DIFF
--- a/docs/NativeModulesIOS.md
+++ b/docs/NativeModulesIOS.md
@@ -230,6 +230,43 @@ console.log(CalendarManager.firstDayOfTheWeek);
 
 Note that the constants are exported only at initialization time, so if you change `constantsToExport` values at runtime it won't affect the JavaScript environment.
 
+###Enum Constants
+
+Enums that are defined via `NS_ENUM` cannot be used as method arguments without first extending RCTConvert.
+
+In order to export the following `NS_ENUM` definition:
+```objc
+typedef NS_ENUM(NSInteger, MyEnumType)
+{
+  kEnumOne,
+  kEnumTwo,
+};
+```
+
+You must create a class extension of RCTConvert like so:
+```objc
+@implementation RCTConvert (MyEnumExtension)
+  RCT_ENUM_CONVERTER(MyEnumType, (@{ @"enumOne" : @(kEnumOne),
+                                     @"enumTwo" : @(kEnumTwo),
+                      kEnumOne, integerValue)
+@end
+```
+
+You can then define methods and export your enum constants like this:
+
+```objc
+- (NSDictionary *)constantsToExport
+{
+  return @{ @"enumOne" : @(kEnumOne),
+            @"enumTwo" : @(kEnumTwo) }
+};
+    
+RCT_EXPORT_METHOD(doSomethingWithEnum:(MyEnumType)enum
+                           completion:(RCTResponseSenderBlock)callback)
+```
+
+Your enum will then be automatically unwrapped using the selector provided (`integerValue` in the above example) before being passed to your exported method.
+
 
 ## Sending Events to JavaScript
 

--- a/docs/NativeModulesIOS.md
+++ b/docs/NativeModulesIOS.md
@@ -230,25 +230,28 @@ console.log(CalendarManager.firstDayOfTheWeek);
 
 Note that the constants are exported only at initialization time, so if you change `constantsToExport` values at runtime it won't affect the JavaScript environment.
 
-###Enum Constants
+### Enum Constants
 
 Enums that are defined via `NS_ENUM` cannot be used as method arguments without first extending RCTConvert.
 
 In order to export the following `NS_ENUM` definition:
+
 ```objc
-typedef NS_ENUM(NSInteger, MyEnumType)
-{
-  kEnumOne,
-  kEnumTwo,
+typedef NS_ENUM(NSInteger, UIStatusBarAnimation) {
+    UIStatusBarAnimationNone,
+    UIStatusBarAnimationFade,
+    UIStatusBarAnimationSlide,
 };
 ```
 
 You must create a class extension of RCTConvert like so:
+
 ```objc
-@implementation RCTConvert (MyEnumExtension)
-  RCT_ENUM_CONVERTER(MyEnumType, (@{ @"enumOne" : @(kEnumOne),
-                                     @"enumTwo" : @(kEnumTwo),
-                      kEnumOne, integerValue)
+@implementation RCTConvert (StatusBarAnimation)
+  RCT_ENUM_CONVERTER(UIStatusBarAnimation, (@{ @"statusBarAnimationNone" : @(UIStatusBarAnimationNone),
+                                               @"statusBarAnimationFade" : @(UIStatusBarAnimationFade),
+                                               @"statusBarAnimationSlide" : @(UIStatusBarAnimationSlide),
+                      UIStatusBarAnimationNone, integerValue)
 @end
 ```
 
@@ -257,12 +260,13 @@ You can then define methods and export your enum constants like this:
 ```objc
 - (NSDictionary *)constantsToExport
 {
-  return @{ @"enumOne" : @(kEnumOne),
-            @"enumTwo" : @(kEnumTwo) }
+  return @{ @"statusBarAnimationNone" : @(UIStatusBarAnimationNone),
+            @"statusBarAnimationFade" : @(UIStatusBarAnimationFade),
+            @"statusBarAnimationSlide" : @(UIStatusBarAnimationSlide) }
 };
     
-RCT_EXPORT_METHOD(doSomethingWithEnum:(MyEnumType)enum
-                           completion:(RCTResponseSenderBlock)callback)
+RCT_EXPORT_METHOD(updateStatusBarAnimation:(UIStatusBarAnimation)animation
+                                completion:(RCTResponseSenderBlock)callback)
 ```
 
 Your enum will then be automatically unwrapped using the selector provided (`integerValue` in the above example) before being passed to your exported method.


### PR DESCRIPTION
Explains the use of `RCT_ENUM_CONVERTER` for using `NS_ENUM` arguments in exported functions.