### PR TITLE
[TextInput] Implements `onKeyPress`

### DIFF
--- a/Examples/UIExplorer/TextInputExample.ios.js
+++ b/Examples/UIExplorer/TextInputExample.ios.js
@@ -42,6 +42,7 @@ var TextEventsExample = React.createClass({
       curText: '<No Event>',
       prevText: '<No Event>',
       prev2Text: '<No Event>',
+      prev3Text: '<No Event>',
     };
   },
 
@@ -51,6 +52,7 @@ var TextEventsExample = React.createClass({
         curText: text,
         prevText: state.curText,
         prev2Text: state.prevText,
+        prev3Text: state.prev2Text,
       };
     });
   },
@@ -73,12 +75,16 @@ var TextEventsExample = React.createClass({
           onSubmitEditing={(event) => this.updateText(
             'onSubmitEditing text: ' + event.nativeEvent.text
           )}
+          onKeyPress={(event) => this.updateText(
+            'onKeyPress key: ' + event.nativeEvent.key
+          )}
           style={styles.default}
         />
         <Text style={styles.eventLabel}>
           {this.state.curText}{'\n'}
           (prev: {this.state.prevText}){'\n'}
-          (prev2: {this.state.prev2Text})
+          (prev2: {this.state.prev2Text}){'\n'}
+          (prev3: {this.state.prev3Text})
         </Text>
       </View>
     );

--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -230,6 +230,13 @@ var TextInput = React.createClass({
      */
     onSubmitEditing: PropTypes.func,
     /**
+     * Callback that is called when a key is pressed.
+     * Pressed key value is passed as an argument to the callback handler.
+     * Fires before onChange callbacks.
+     * @platform ios
+     */
+    onKeyPress: PropTypes.func,
+    /**
      * Invoked on mount and layout changes with `{x, y, width, height}`.
      */
     onLayout: PropTypes.func,

--- a/Libraries/Text/RCTText.xcodeproj/project.pbxproj
+++ b/Libraries/Text/RCTText.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		131B6AC11AF0CD0600FFC3E0 /* RCTTextViewManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 131B6ABF1AF0CD0600FFC3E0 /* RCTTextViewManager.m */; };
 		1362F1001B4D51F400E06D8C /* RCTTextField.m in Sources */ = {isa = PBXBuildFile; fileRef = 1362F0FD1B4D51F400E06D8C /* RCTTextField.m */; };
 		1362F1011B4D51F400E06D8C /* RCTTextFieldManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 1362F0FF1B4D51F400E06D8C /* RCTTextFieldManager.m */; };
+		559B87851B5EFEFB00D7E62F /* RCTTextKeyValueConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = 559B87841B5EFEFB00D7E62F /* RCTTextKeyValueConstants.m */; };
 		58B511CE1A9E6C5C00147676 /* RCTRawTextManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 58B511C71A9E6C5C00147676 /* RCTRawTextManager.m */; };
 		58B511CF1A9E6C5C00147676 /* RCTShadowRawText.m in Sources */ = {isa = PBXBuildFile; fileRef = 58B511C91A9E6C5C00147676 /* RCTShadowRawText.m */; };
 		58B511D01A9E6C5C00147676 /* RCTShadowText.m in Sources */ = {isa = PBXBuildFile; fileRef = 58B511CB1A9E6C5C00147676 /* RCTShadowText.m */; };
@@ -39,6 +40,8 @@
 		1362F0FD1B4D51F400E06D8C /* RCTTextField.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTTextField.m; sourceTree = "<group>"; };
 		1362F0FE1B4D51F400E06D8C /* RCTTextFieldManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTTextFieldManager.h; sourceTree = "<group>"; };
 		1362F0FF1B4D51F400E06D8C /* RCTTextFieldManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTTextFieldManager.m; sourceTree = "<group>"; };
+		559B87831B5EFEFB00D7E62F /* RCTTextKeyValueConstants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTTextKeyValueConstants.h; sourceTree = "<group>"; };
+		559B87841B5EFEFB00D7E62F /* RCTTextKeyValueConstants.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTTextKeyValueConstants.m; sourceTree = "<group>"; };
 		58B5119B1A9E6C1200147676 /* libRCTText.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libRCTText.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		58B511C61A9E6C5C00147676 /* RCTRawTextManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTRawTextManager.h; sourceTree = "<group>"; };
 		58B511C71A9E6C5C00147676 /* RCTRawTextManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTRawTextManager.m; sourceTree = "<group>"; };
@@ -84,6 +87,8 @@
 				131B6ABD1AF0CD0600FFC3E0 /* RCTTextView.m */,
 				131B6ABE1AF0CD0600FFC3E0 /* RCTTextViewManager.h */,
 				131B6ABF1AF0CD0600FFC3E0 /* RCTTextViewManager.m */,
+				559B87831B5EFEFB00D7E62F /* RCTTextKeyValueConstants.h */,
+				559B87841B5EFEFB00D7E62F /* RCTTextKeyValueConstants.m */,
 				58B5119C1A9E6C1200147676 /* Products */,
 			);
 			indentWidth = 2;
@@ -156,6 +161,7 @@
 			files = (
 				58B511D11A9E6C5C00147676 /* RCTTextManager.m in Sources */,
 				131B6AC01AF0CD0600FFC3E0 /* RCTTextView.m in Sources */,
+				559B87851B5EFEFB00D7E62F /* RCTTextKeyValueConstants.m in Sources */,
 				58B511CE1A9E6C5C00147676 /* RCTRawTextManager.m in Sources */,
 				1362F1001B4D51F400E06D8C /* RCTTextField.m in Sources */,
 				58B512161A9E6EFF00147676 /* RCTText.m in Sources */,

--- a/Libraries/Text/RCTTextField.h
+++ b/Libraries/Text/RCTTextField.h
@@ -21,7 +21,10 @@
 @property (nonatomic, assign) NSInteger mostRecentEventCount;
 @property (nonatomic, strong) NSNumber *maxLength;
 
+@property (nonatomic, assign) BOOL textWasPasted;
+
 - (instancetype)initWithEventDispatcher:(RCTEventDispatcher *)eventDispatcher NS_DESIGNATED_INITIALIZER;
 - (void)textFieldDidChange;
+- (void)sendKeyValueForString:(NSString *)string;
 
 @end

--- a/Libraries/Text/RCTTextField.m
+++ b/Libraries/Text/RCTTextField.m
@@ -13,6 +13,7 @@
 #import "RCTEventDispatcher.h"
 #import "RCTUtils.h"
 #import "UIView+React.h"
+#import "RCTTextKeyValueConstants.h"
 
 @implementation RCTTextField
 {
@@ -38,6 +39,32 @@
 
 RCT_NOT_IMPLEMENTED(- (instancetype)initWithFrame:(CGRect)frame)
 RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
+
+- (void)sendKeyValueForString:(NSString *)string
+{
+  NSString *keyValue;
+  
+  if ([string isEqualToString:RCTNewlineRawValue]) {
+    keyValue = RCTEnterKeyValue;
+  } else if ([string isEqualToString:@""]) {
+    keyValue = RCTBackspaceKeyValue;
+  } else {
+    keyValue = string;
+  }
+  
+  [_eventDispatcher sendTextEventWithType:RCTTextEventTypeKeyPress
+                                 reactTag:self.reactTag
+                                     text:nil
+                                      key:keyValue
+                               eventCount:_nativeEventCount];
+}
+
+// This method is overriden for `onKeyPress`. The manager will not send a keyPress for text that was pasted.
+- (void)paste:(id)sender
+{
+  _textWasPasted = YES;
+  [super paste:sender];
+}
 
 - (void)setText:(NSString *)text
 {
@@ -134,6 +161,7 @@ static void RCTUpdatePlaceholder(RCTTextField *self)
   [_eventDispatcher sendTextEventWithType:RCTTextEventTypeChange
                                  reactTag:self.reactTag
                                      text:self.text
+                                      key:nil
                                eventCount:_nativeEventCount];
 }
 
@@ -142,6 +170,7 @@ static void RCTUpdatePlaceholder(RCTTextField *self)
   [_eventDispatcher sendTextEventWithType:RCTTextEventTypeEnd
                                  reactTag:self.reactTag
                                      text:self.text
+                                      key:nil
                                eventCount:_nativeEventCount];
 }
 - (void)textFieldSubmitEditing
@@ -149,6 +178,7 @@ static void RCTUpdatePlaceholder(RCTTextField *self)
   [_eventDispatcher sendTextEventWithType:RCTTextEventTypeSubmit
                                  reactTag:self.reactTag
                                      text:self.text
+                                      key:nil
                                eventCount:_nativeEventCount];
 }
 
@@ -162,6 +192,7 @@ static void RCTUpdatePlaceholder(RCTTextField *self)
   [_eventDispatcher sendTextEventWithType:RCTTextEventTypeFocus
                                  reactTag:self.reactTag
                                      text:self.text
+                                      key:nil
                                eventCount:_nativeEventCount];
 }
 
@@ -181,6 +212,7 @@ static void RCTUpdatePlaceholder(RCTTextField *self)
     [_eventDispatcher sendTextEventWithType:RCTTextEventTypeBlur
                                    reactTag:self.reactTag
                                        text:self.text
+                                        key:nil
                                  eventCount:_nativeEventCount];
   }
   return result;

--- a/Libraries/Text/RCTTextFieldManager.m
+++ b/Libraries/Text/RCTTextFieldManager.m
@@ -31,6 +31,13 @@ RCT_EXPORT_MODULE()
 
 - (BOOL)textField:(RCTTextField *)textField shouldChangeCharactersInRange:(NSRange)range replacementString:(NSString *)string
 {
+  // Only allow single keypresses for onKeyPress, pasted text will not be sent.
+  if (textField.textWasPasted == NO) {
+    [textField sendKeyValueForString:string];
+  } else {
+    [textField setTextWasPasted:NO];
+  }
+  
   if (textField.maxLength == nil || [string isEqualToString:@"\n"]) {  // Make sure forms can be submitted via return
     return YES;
   }
@@ -52,6 +59,13 @@ RCT_EXPORT_MODULE()
   } else {
     return YES;
   }
+}
+
+// This method allows us to detect a `Backspace` keyPress even when there is no more text in the TextField
+- (BOOL)keyboardInputShouldDelete:(RCTTextField *)textField
+{
+  [self textField:textField shouldChangeCharactersInRange:NSMakeRange(0, 0) replacementString:@""];
+  return YES;
 }
 
 RCT_EXPORT_VIEW_PROPERTY(caretHidden, BOOL)

--- a/Libraries/Text/RCTTextKeyValueConstants.h
+++ b/Libraries/Text/RCTTextKeyValueConstants.h
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+extern NSString *const RCTNewlineRawValue;
+
+extern NSString *const RCTBackspaceKeyValue;
+extern NSString *const RCTEnterKeyValue;

--- a/Libraries/Text/RCTTextKeyValueConstants.m
+++ b/Libraries/Text/RCTTextKeyValueConstants.m
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <Foundation/Foundation.h>
+
+NSString *const RCTNewlineRawValue = @"\n";
+
+NSString *const RCTBackspaceKeyValue = @"Backspace";
+NSString *const RCTEnterKeyValue = @"Enter";

--- a/Libraries/Text/RCTTextView.m
+++ b/Libraries/Text/RCTTextView.m
@@ -13,6 +13,7 @@
 #import "RCTEventDispatcher.h"
 #import "RCTUtils.h"
 #import "UIView+React.h"
+#import "RCTTextKeyValueConstants.h"
 
 @implementation RCTTextView
 {
@@ -138,6 +139,20 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
 
 - (BOOL)textView:(UITextView *)textView shouldChangeTextInRange:(NSRange)range replacementText:(NSString *)text
 {
+  /**
+   * Only allow single keypresses for onKeyPress, most text pasted in will not be sent.
+   *
+   * Unfortunately, UITextView for some reason doesn't implement `paste:sender` like UITextField, so we have
+   * no way of distinguishing a single character paste from a single character keyPress. :(
+   * I'm assuming this is a bug in iOS, but I couldn't find out for sure.
+   *
+   * End result: Single character pastes will register and fire a keyPress event with the character
+   * that was pasted.
+   */
+  if (text.length <= 1) {
+    [self sendKeyValueForText:text];
+  }
+  
   if (_maxLength == nil) {
     return YES;
   }
@@ -159,6 +174,25 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
   } else {
     return YES;
   }
+}
+
+- (void)sendKeyValueForText:(NSString *)text
+{
+  NSString *keyValue;
+  
+  if ([text isEqualToString:RCTNewlineRawValue]) {
+    keyValue = RCTEnterKeyValue;
+  } else if ([text isEqualToString:@""]) {
+    keyValue = RCTBackspaceKeyValue;
+  } else {
+    keyValue = text;
+  }
+  
+  [_eventDispatcher sendTextEventWithType:RCTTextEventTypeKeyPress
+                                 reactTag:self.reactTag
+                                     text:nil
+                                      key:keyValue
+                               eventCount:_nativeEventCount];
 }
 
 - (void)setText:(NSString *)text
@@ -213,6 +247,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
   [_eventDispatcher sendTextEventWithType:RCTTextEventTypeFocus
                                  reactTag:self.reactTag
                                      text:textView.text
+                                      key:nil
                                eventCount:_nativeEventCount];
 }
 
@@ -223,6 +258,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
   [_eventDispatcher sendTextEventWithType:RCTTextEventTypeChange
                                  reactTag:self.reactTag
                                      text:textView.text
+                                      key:nil
                                eventCount:_nativeEventCount];
 
 }
@@ -232,6 +268,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
   [_eventDispatcher sendTextEventWithType:RCTTextEventTypeEnd
                                  reactTag:self.reactTag
                                      text:textView.text
+                                      key:nil
                                eventCount:_nativeEventCount];
 }
 
@@ -251,6 +288,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
     [_eventDispatcher sendTextEventWithType:RCTTextEventTypeBlur
                                    reactTag:self.reactTag
                                        text:_textView.text
+                                        key:nil
                                  eventCount:_nativeEventCount];
   }
   return result;

--- a/React/Base/RCTEventDispatcher.h
+++ b/React/Base/RCTEventDispatcher.h
@@ -16,7 +16,8 @@ typedef NS_ENUM(NSInteger, RCTTextEventType) {
   RCTTextEventTypeBlur,
   RCTTextEventTypeChange,
   RCTTextEventTypeSubmit,
-  RCTTextEventTypeEnd
+  RCTTextEventTypeEnd,
+  RCTTextEventTypeKeyPress
 };
 
 typedef NS_ENUM(NSInteger, RCTScrollEventType) {
@@ -95,6 +96,7 @@ RCT_EXTERN NSString *RCTNormalizeInputEventName(NSString *eventName);
 - (void)sendTextEventWithType:(RCTTextEventType)type
                      reactTag:(NSNumber *)reactTag
                          text:(NSString *)text
+                          key:(NSString *)key
                    eventCount:(NSInteger)eventCount;
 
 /**

--- a/React/Base/RCTEventDispatcher.m
+++ b/React/Base/RCTEventDispatcher.m
@@ -132,6 +132,7 @@ RCT_EXPORT_MODULE()
 - (void)sendTextEventWithType:(RCTTextEventType)type
                      reactTag:(NSNumber *)reactTag
                          text:(NSString *)text
+                          key:(NSString *)key
                    eventCount:(NSInteger)eventCount
 {
   static NSString *events[] = {
@@ -140,16 +141,23 @@ RCT_EXPORT_MODULE()
     @"change",
     @"submitEditing",
     @"endEditing",
+    @"keyPress"
   };
-
-  [self sendInputEventWithName:events[type] body:text ? @{
-    @"text": text,
-    @"eventCount": @(eventCount),
-    @"target": reactTag
-  } : @{
+  
+  NSMutableDictionary *body = [[NSMutableDictionary alloc] initWithDictionary:@{
     @"eventCount": @(eventCount),
     @"target": reactTag
   }];
+  
+  if (text) {
+    body[@"text"] = text;
+  }
+  
+  if (key) {
+    body[@"key"] = key;
+  }
+  
+  [self sendInputEventWithName:events[type] body:body];
 }
 
 - (void)sendEvent:(id<RCTEvent>)event

--- a/React/Views/RCTViewManager.m
+++ b/React/Views/RCTViewManager.m
@@ -81,6 +81,7 @@ RCT_EXPORT_MODULE()
     @"blur",
     @"submitEditing",
     @"endEditing",
+    @"keyPress",
 
     // Touch events
     @"touchStart",


### PR DESCRIPTION
- When a key is pressed, it's `key value` is passed as an argument to the callback handler.
 - For `Enter` and `Backspace` keys, I'm using their `key value` as defined [here](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key#Key_values). As per @JonasJonny & @brentvatne's [suggestion](https://github.com/facebook/react-native/issues/1882#issuecomment-123485883).

- Example
```javascript
 _handleKeyPress: function(e) {
      console.log(e.nativeEvent.key);
  },

  render: function() {
    return (
      <View style={styles.container}>
        <TextInput
            style={{width: 150, height: 25, borderWidth: 0.5}}
            onKeyPress={this._handleKeyPress}
        />
        <TextInput
            style={{width: 150, height: 100, borderWidth: 0.5}}
            onKeyPress={this._handleKeyPress}
            multiline={true}
        />
      </View>
    );
  }
```
- Implements [shouldChangeCharactersInRange](https://developer.apple.com/library/prerelease/ios/documentation/UIKit/Reference/UITextFieldDelegate_Protocol/#//apple_ref/occ/intfm/UITextFieldDelegate/textField:shouldChangeCharactersInRange:replacementString:), `keyboardInputShouldDelete` and [deleteBackward](https://developer.apple.com/library/ios/documentation/UIKit/Reference/UIKeyInput_Protocol/#//apple_ref/occ/intfm/UIKeyInput/deleteBackward) for `RCTTextField`
 - `keyboardInputShouldDelete` and `deleteBackward` were implemented because `UITextField` doesn't trigger `shouldChangeCharactersInRange` when the field is empty, preventing us from having a true `keyPress` event.
 - Unfortunately, it looks like `keyboardInputShouldDelete` is not documented as alluded to in this [StackOverflow answer](http://stackoverflow.com/a/25862878/4932710). However, I'm only using it because of a bug in iOS 8.0 to 8.2 where the `deleteBackward` method doesn't trigger. This might cause this whole feature to be a no-op, though. :(

- Implements [shouldChangeTextInRange](https://developer.apple.com/library/prerelease/ios/documentation/UIKit/Reference/UITextViewDelegate_Protocol/#//apple_ref/occ/intfm/UITextViewDelegate/textView:shouldChangeTextInRange:replacementText:) for `RCTTextView`
 - This one is nice and simple since `UITextViews` (used for multi-line TextInputs) trigger this method even when the textView is empty.

- Addresses issue: https://github.com/facebook/react-native/issues/1882