### PR TITLE
Add observers for local notifications

### DIFF
--- a/Libraries/PushNotificationIOS/PushNotificationIOS.js
+++ b/Libraries/PushNotificationIOS/PushNotificationIOS.js
@@ -22,6 +22,7 @@ var _initialNotification = RCTPushNotificationManager &&
 
 var DEVICE_NOTIF_EVENT = 'remoteNotificationReceived';
 var NOTIF_REGISTER_EVENT = 'remoteNotificationsRegistered';
+var DEVICE_LOCAL_NOTIF_EVENT = 'localNotificationReceived';
 
 /**
  * Handle push notifications for your app, including permission handling and
@@ -76,6 +77,17 @@ class PushNotificationIOS {
   }
 
   /**
+   * Cancel local notifications.
+   *
+   * Optionally restricts the set of canceled notifications to those
+   * notifications whose userInfo fields match the corresponding fields
+   * in details.
+   */
+  static cancelLocalNotifications(details: Object) {
+    RCTPushNotificationManager.cancelLocalNotifications(details);
+  }
+
+  /**
    * Attaches a listener to remote notification events while the app is running
    * in the foreground or the background.
    *
@@ -88,8 +100,8 @@ class PushNotificationIOS {
    */
   static addEventListener(type: string, handler: Function) {
     invariant(
-      type === 'notification' || type === 'register',
-      'PushNotificationIOS only supports `notification` and `register` events'
+      type === 'notification' || type === 'register' || type === 'local_notification',
+      'PushNotificationIOS only supports `notification`, `register` and `local_notification` events'
     );
     var listener;
     if (type === 'notification') {
@@ -104,6 +116,13 @@ class PushNotificationIOS {
         NOTIF_REGISTER_EVENT,
         (registrationInfo) => {
           handler(registrationInfo.deviceToken);
+        }
+      );
+    } else if (type === 'local_notification') {
+      _notifHandlers[handler] = RCTDeviceEventEmitter.addListener(
+        DEVICE_LOCAL_NOTIF_EVENT,
+        (notifData) => {
+          handler(new PushNotificationIOS(notifData));
         }
       );
     }
@@ -180,8 +199,8 @@ class PushNotificationIOS {
    */
   static removeEventListener(type: string, handler: Function) {
     invariant(
-      type === 'notification' || type === 'register',
-      'PushNotificationIOS only supports `notification` and `register` events'
+      type === 'notification' || type === 'register' || type === 'local_notification',
+      'PushNotificationIOS only supports `notification`, `register` and `local_notification` events'
     );
     var listener = _notifHandlers.get(handler);
     if (!listener) {

--- a/Libraries/PushNotificationIOS/RCTPushNotificationManager.h
+++ b/Libraries/PushNotificationIOS/RCTPushNotificationManager.h
@@ -16,5 +16,6 @@
 + (void)application:(UIApplication *)application didRegisterUserNotificationSettings:(UIUserNotificationSettings *)notificationSettings;
 + (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken;
 + (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)notification;
++ (void)application:(UIApplication *)application didReceiveLocalNotification:(NSDictionary *)notification;
 
 @end

--- a/Libraries/PushNotificationIOS/RCTPushNotificationManager.m
+++ b/Libraries/PushNotificationIOS/RCTPushNotificationManager.m
@@ -111,7 +111,7 @@ RCT_EXPORT_MODULE()
                                                     userInfo:notification];
 }
 
-+ (void)application:(UIApplication *)application didReceiveLocalNotification:(UILocalNotification *)notification
++ (void)application:(__unused UIApplication *)application didReceiveLocalNotification:(UILocalNotification *)notification
 {
   NSMutableDictionary *notificationDict = [NSMutableDictionary dictionaryWithDictionary:notification.userInfo];
   [notificationDict setObject:notification.alertBody forKey:@"alertBody"];

--- a/Libraries/PushNotificationIOS/RCTPushNotificationManager.m
+++ b/Libraries/PushNotificationIOS/RCTPushNotificationManager.m
@@ -36,6 +36,7 @@ NSString *const RCTRemoteNotificationsRegistered = @"RemoteNotificationsRegister
   UILocalNotification *notification = [[UILocalNotification alloc] init];
   notification.fireDate = [RCTConvert NSDate:details[@"fireDate"]] ?: [NSDate date];
   notification.alertBody = [RCTConvert NSString:details[@"alertBody"]];
+  notification.userInfo = details[@"userInfo"] ? [RCTConvert NSDictionary:details[@"userInfo"]] : nil;
   return notification;
 }
 


### PR DESCRIPTION
This commit adds the delegate hooks so that local notifications get
passed onto the JS and adds a new event listener type for local
notifications.

Also add functions to clear local notifications