### PR TITLE
SampleApp: Defining all configuration specific in app.plist to not having to modify AppDelegate.m

### DIFF
--- a/Examples/SampleApp/README.md
+++ b/Examples/SampleApp/README.md
@@ -1,0 +1,32 @@
+
+## Configuration
+
+`app.plist` define user-specific configuration.
+
+There are 2 options:
+
+### Option 1: development server
+
+Start the server from the repository root:
+
+```
+$ npm start
+```
+
+To run on device, edit `app.plist`'s `devServer` field and change `localhost` to the IP address of your computer
+(you can get this by typing `ifconfig` into the terminal and selecting the
+`inet` value under `en0:`) and make sure your computer and iOS device are
+on the same Wi-Fi network.
+
+### Option 2: bundled
+
+To re-generate the static bundle
+from the root of your project directory, run
+
+```
+$ react-native bundle --minify
+```
+
+see http://facebook.github.io/react-native/docs/runningondevice.html
+
+Then, remove `devServer` field from the `app.plist`.

--- a/Examples/SampleApp/SampleApp.xcodeproj/project.pbxproj
+++ b/Examples/SampleApp/SampleApp.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
 		146834051AC3E58100842450 /* libReact.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 146834041AC3E56700842450 /* libReact.a */; };
+		340D62621B6139DF00318552 /* app.plist in Resources */ = {isa = PBXBuildFile; fileRef = 340D62611B6139DF00318552 /* app.plist */; };
 		832341BD1AAA6AB300B99B32 /* libRCTText.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 832341B51AAA6A8300B99B32 /* libRCTText.a */; };
 /* End PBXBuildFile section */
 
@@ -125,6 +126,7 @@
 		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = iOS/Info.plist; sourceTree = "<group>"; };
 		13B07FB71A68108700A75B9A /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = iOS/main.m; sourceTree = "<group>"; };
 		146833FF1AC3E56700842450 /* React.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = React.xcodeproj; path = ../../React/React.xcodeproj; sourceTree = "<group>"; };
+		340D62611B6139DF00318552 /* app.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = app.plist; sourceTree = "<group>"; };
 		78C398B01ACF4ADC00677621 /* RCTLinking.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTLinking.xcodeproj; path = ../../Libraries/LinkingIOS/RCTLinking.xcodeproj; sourceTree = "<group>"; };
 		832341B01AAA6A8300B99B32 /* RCTText.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTText.xcodeproj; path = ../../Libraries/Text/RCTText.xcodeproj; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -233,6 +235,7 @@
 		13B07FAE1A68108700A75B9A /* SampleApp */ = {
 			isa = PBXGroup;
 			children = (
+				340D62611B6139DF00318552 /* app.plist */,
 				008F07F21AC5B25A0029DE68 /* main.jsbundle */,
 				13B07FAF1A68108700A75B9A /* AppDelegate.h */,
 				13B07FB01A68108700A75B9A /* AppDelegate.m */,
@@ -505,6 +508,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				340D62621B6139DF00318552 /* app.plist in Resources */,
 				008F07F31AC5B25A0029DE68 /* main.jsbundle in Resources */,
 				13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */,
 				13B07FBD1A68108700A75B9A /* LaunchScreen.xib in Resources */,
@@ -600,7 +604,7 @@
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)/../../React/**",
 				);
-				INFOPLIST_FILE = "iOS/Info.plist";
+				INFOPLIST_FILE = iOS/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = SampleApp;
@@ -616,7 +620,7 @@
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)/../../React/**",
 				);
-				INFOPLIST_FILE = "iOS/Info.plist";
+				INFOPLIST_FILE = iOS/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = SampleApp;

--- a/Examples/SampleApp/app.plist
+++ b/Examples/SampleApp/app.plist
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>initialProps</key>
+	<dict>
+		<key>hello</key>
+		<string>world</string>
+	</dict>
+	<key>devServer</key>
+	<string>http://localhost:8081/Examples/SampleApp/index.ios.bundle</string>
+</dict>
+</plist>

--- a/Examples/SampleApp/iOS/AppDelegate.m
+++ b/Examples/SampleApp/iOS/AppDelegate.m
@@ -17,33 +17,16 @@
 {
   NSURL *jsCodeLocation;
 
-  /**
-   * Loading JavaScript code - uncomment the one you want.
-   *
-   * OPTION 1
-   * Load from development server. Start the server from the repository root:
-   *
-   * $ npm start
-   *
-   * To run on device, change `localhost` to the IP address of your computer
-   * (you can get this by typing `ifconfig` into the terminal and selecting the
-   * `inet` value under `en0:`) and make sure your computer and iOS device are
-   * on the same Wi-Fi network.
-   */
+  NSString *settingsPath = [[NSBundle mainBundle] pathForResource:@"app" ofType:@"plist"];
+  NSDictionary *settings = [[NSDictionary alloc] initWithContentsOfFile:settingsPath];
 
-  jsCodeLocation = [NSURL URLWithString:@"http://localhost:8081/Examples/SampleApp/index.ios.bundle"];
-
-  /**
-   * OPTION 2
-   * Load from pre-bundled file on disk. To re-generate the static bundle
-   * from the root of your project directory, run
-   *
-   * $ react-native bundle --minify
-   *
-   * see http://facebook.github.io/react-native/docs/runningondevice.html
-   */
-
-//   jsCodeLocation = [[NSBundle mainBundle] URLForResource:@"main" withExtension:@"jsbundle"];
+  NSString* devServer = [settings objectForKey:@"devServer"];
+  if (devServer != nil) {
+    jsCodeLocation = [NSURL URLWithString:devServer];
+  }
+  else {
+    jsCodeLocation = [[NSBundle mainBundle] URLForResource:@"main" withExtension:@"jsbundle"];
+  }
 
   RCTRootView *rootView = [[RCTRootView alloc] initWithBundleURL:jsCodeLocation
                                                       moduleName:@"SampleApp"
@@ -52,9 +35,14 @@
   self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
   UIViewController *rootViewController = [[UIViewController alloc] init];
   rootViewController.view = rootView;
+
+  rootView.initialProperties =  [settings objectForKey:@"initialProps"];
+
   self.window.rootViewController = rootViewController;
   [self.window makeKeyAndVisible];
   return YES;
+
+
 }
 
 @end

--- a/Examples/SampleApp/index.ios.js
+++ b/Examples/SampleApp/index.ios.js
@@ -14,6 +14,7 @@ var {
 
 var SampleApp = React.createClass({
   render: function() {
+    console.log(this.props);
     return (
       <View style={styles.container}>
         <Text style={styles.welcome}>


### PR DESCRIPTION
I've made some changes in `AppDelegate.m` so it uses a `app.plist` that contains all your app specific configuration and in order to not have to change any line of Objective-C.

and here is the default `app.plist`:

<img width="663" alt="screen shot 2015-07-23 at 17 15 46" src="https://cloud.githubusercontent.com/assets/211411/8854095/7b274560-315e-11e5-8bed-4e079249a8ac.png">

This also allow to set the `initialProps` that are passed to the Root component in order to inject some custom settings (that are specific for each dev working on an App),  for instance the URL of your app API:

```js
class Root extends Component {
  render () {
    const {
      apiURL
    } = this.props;
    return <App baseURL={apiURL} />;
  }
}
```

also I've created a "devServer" field where user can set it's react-native server URL, and if not provided it will fallback on the bundled JS.