### PR TITLE
add transformOrigin style property

### DIFF
--- a/Libraries/Animation/Animated/Animated.js
+++ b/Libraries/Animation/Animated/Animated.js
@@ -816,6 +816,11 @@ class AnimatedStyle extends AnimatedWithChildren {
         style[key] = value.getAnimatedValue();
       }
     }
+    // if a transformOrigin value is set, it must be passed up with `.getAnimatedValue()` since the two are
+    // dependent on one another. This is kind of a hacky way to accomplish this. Open to other suggestions.
+    if (style.transform && !style.transformOrigin && this._style.transformOrigin) {
+      style.transformOrigin = this._style.transformOrigin;
+    }
     return style;
   }
 

--- a/Libraries/StyleSheet/TransformPropTypes.js
+++ b/Libraries/StyleSheet/TransformPropTypes.js
@@ -28,6 +28,11 @@ var TransformPropTypes = {
       ReactPropTypes.shape({translateY: ReactPropTypes.number})
     ])
   ),
+  transformOrigin: ReactPropTypes.shape({
+    x: ReactPropTypes.number,
+    y: ReactPropTypes.number,
+    z: ReactPropTypes.number,
+  }),
 
   /*
    * `transformMatrix` accepts a 4x4 matrix expressed as a row-major ordered

--- a/Libraries/StyleSheet/precomputeStyle.js
+++ b/Libraries/StyleSheet/precomputeStyle.js
@@ -44,7 +44,7 @@ function precomputeStyle(style: ?Object): ?Object {
  * interface to native code.
  */
 function _precomputeTransforms(style: Object): Object {
-  var {transform} = style;
+  var {transform, transformOrigin} = style;
   var result = MatrixMath.createIdentityMatrix();
 
   transform.forEach(transformation => {
@@ -94,6 +94,12 @@ function _precomputeTransforms(style: Object): Object {
     }
   });
 
+  if (transformOrigin) {
+    // adjusts the `result` transform matrix to be applied from
+    // the corresponding `transformOrigin`
+    _applyTransformOrigin(result, transformOrigin);
+  }
+
   // Android does not support the direct application of a transform matrix to
   // a view, so we need to decompose the result matrix into transforms that can
   // get applied in the specific order of (1) translate (2) scale (3) rotate.
@@ -123,6 +129,70 @@ function _multiplyTransform(
   var argsWithIdentity = [matrixToApply].concat(args);
   matrixMathFunction.apply(this, argsWithIdentity);
   MatrixMath.multiplyInto(result, result, matrixToApply);
+}
+
+/**
+ * Takes a transform matrix and an origin, and applies a transformation to
+ * the matrix to change the transform origin. Mutates the passed in matrix.
+ */
+function _applyTransformOrigin(
+  matrix: Array<number>,
+  origin: Object
+): void {
+  origin = _normalizeOrigin(origin);
+  var translate = MatrixMath.createIdentityMatrix();
+  var untranslate = MatrixMath.createIdentityMatrix();
+  MatrixMath.reuseTranslate3dCommand(
+    translate,
+    origin.x,
+    origin.y,
+    origin.z
+  );
+  MatrixMath.reuseTranslate3dCommand(
+    untranslate,
+    -origin.x,
+    -origin.y,
+    -origin.z
+  );
+  MatrixMath.multiplyInto(matrix, translate, matrix);
+  MatrixMath.multiplyInto(matrix, matrix, untranslate);
+}
+
+function _normalizeOrigin(input: Object): Object {
+  var output = { x: 0, y: 0, z: 0 };
+
+  if (typeof input === 'string') {
+    // user is using string short-hand.
+  } else if (typeof input === 'object') {
+    if (input.x) {
+      invariant(
+        typeof input.x === 'number',
+        'transformOrigin expects a number for x'
+      );
+      output.x = input.x;
+    }
+    if (input.y) {
+      invariant(
+          typeof input.y === 'number',
+          'transformOrigin expects a number for y'
+      );
+      output.y = input.y;
+    }
+    if (input.z) {
+      invariant(
+          typeof input.z === 'number',
+          'transformOrigin expects a number for z'
+      );
+      output.z = input.z;
+    }
+  } else {
+    invariant(
+      false,
+      'transformOrigin should be a string or an object'
+    );
+  }
+
+  return output;
 }
 
 /**

--- a/Libraries/StyleSheet/precomputeStyle.js
+++ b/Libraries/StyleSheet/precomputeStyle.js
@@ -158,40 +158,41 @@ function _applyTransformOrigin(
   MatrixMath.multiplyInto(matrix, matrix, untranslate);
 }
 
+/**
+ * Accepts the user passed in "transformOrigin" property, which
+ * in the future could be a something other than an object, and
+ * normalizes it to an {x, y, z} point.
+ * 
+ * Right now this function is little more than an optimized
+ * Object.assign, but in the future it could be more complicated.
+ */
 function _normalizeOrigin(input: Object): Object {
   var output = { x: 0, y: 0, z: 0 };
-
-  if (typeof input === 'string') {
-    // user is using string short-hand.
-  } else if (typeof input === 'object') {
-    if (input.x) {
-      invariant(
-        typeof input.x === 'number',
-        'transformOrigin expects a number for x'
-      );
-      output.x = input.x;
-    }
-    if (input.y) {
-      invariant(
-          typeof input.y === 'number',
-          'transformOrigin expects a number for y'
-      );
-      output.y = input.y;
-    }
-    if (input.z) {
-      invariant(
-          typeof input.z === 'number',
-          'transformOrigin expects a number for z'
-      );
-      output.z = input.z;
-    }
-  } else {
-    invariant(
+  invariant(
       false,
       'transformOrigin should be a string or an object'
+  );
+  if (input.x) {
+    invariant(
+      typeof input.x === 'number',
+      'transformOrigin expects a number for x'
     );
+    output.x = input.x;
   }
-
+  if (input.y) {
+    invariant(
+        typeof input.y === 'number',
+        'transformOrigin expects a number for y'
+    );
+    output.y = input.y;
+  }
+  if (input.z) {
+    invariant(
+        typeof input.z === 'number',
+        'transformOrigin expects a number for z'
+    );
+    output.z = input.z;
+  }
   return output;
 }
 


### PR DESCRIPTION
This PR was being discussed in this issue: https://github.com/facebook/react-native/issues/1964

I've decided to submit a PR just so that the conversation can have a bit more context with the code involved, etc.

[transform-origin spec](https://developer.mozilla.org/en-US/docs/Web/CSS/transform-origin)
### How it works

the transform origin property works by defining a translation matrix `T` which translates to the desired origin, and transforming a transform matrix `M` into `M'` by the following formula:

`M' = TMT^-1`

This is accomplished in the `precomputeStyle` method and only introduces new code paths if the `transformOrigin` property is assigned.
### Known Issues with this PR
1. The CSS spec interprets `transform-origin: 0px 0px` as placing the transform origin at the bottom left of the transformed element, where-as this code puts `transformOrigin: { x: 0, y: 0 }` to mean the center of the element (the default origin). This issue is difficult to remedy because in `precomputeStyle`, we don't have any knowledge of the width/height of the element in order to actually calculate what the "bottom left" of the element would be.  For similar reasons, this makes it difficult to include other aspects of the CSS spec for this property, such as percentage values, etc.
2. The transform origin property allows for x, y, and z points. If we want to animate these values with the new animated API, a new `AnimatedValueXYZ` class would need to be created, or the existing `AnimatedXY` class should be extended. I've left untouched for now as the `z` property of transformOrigin is seldom needed.
3. The `transform` style property and the `transformOrigin` style property are not independent of one another, which mens that if we are animating one of them, the other must be included in the passed up style props to `.setNativeProps`. In order to accomplish this, a small check was added to the `AnimatedStyle::getAnimatedValue()` method. I'm open to suggestions on how we could potentially make this cleaner.
### Example Usage:

``` jsx
                <Animated.View style={{
                    transform: [
                        {
                            rotateY: loading.interpolate({
                                inputRange: [0, 1],
                                outputRange: ['90deg', '0deg']
                            })
                        }
                    ],
                    transformOrigin: { x: -140, }
                }}>
                    ...
                </Animated.View>
```
