### PR TITLE
Do not polyfill document when platform == 'web'

### DIFF
--- a/packager/packager.js
+++ b/packager/packager.js
@@ -226,6 +226,13 @@ function getAppMiddleware(options) {
     transformerPath = path.resolve(process.cwd(), transformerPath);
   }
 
+  var polyfillModuleNames = [];
+  if (options.platform != 'web') {
+    polyfillModuleNames.push(require.resolve(
+      '../Libraries/JavaScriptAppEngine/polyfills/document.js'
+    ));
+  }
+
   return ReactPackager.middleware({
     nonPersistent: options.nonPersistent,
     projectRoots: options.projectRoots,
@@ -234,11 +241,7 @@ function getAppMiddleware(options) {
     transformModulePath: transformerPath,
     assetRoots: options.assetRoots,
     assetExts: ['png', 'jpeg', 'jpg'],
-    polyfillModuleNames: [
-      require.resolve(
-        '../Libraries/JavaScriptAppEngine/polyfills/document.js'
-      ),
-    ],
+    polyfillModuleNames: polyfillModuleNames,
   });
 }
 


### PR DESCRIPTION
I'd like to use the react-native packager for a web project I'm working on (because it's fast!). However, the packager essentially forces ExecutionEnvironment.canUseDOM to be false by requiring polyfills/document.js.