### PR TITLE
Use font name for weight if no weight property available

### DIFF
--- a/React/Base/RCTConvert.m
+++ b/React/Base/RCTConvert.m
@@ -754,8 +754,33 @@ RCT_ENUM_CONVERTER(RCTFontStyle, (@{
 
 static RCTFontWeight RCTWeightOfFont(UIFont *font)
 {
+  static NSDictionary *nameToWeight;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    nameToWeight = @{
+      @"normal": @(UIFontWeightRegular),
+      @"bold": @(UIFontWeightBold),
+      @"ultralight": @(UIFontWeightUltraLight),
+      @"thin": @(UIFontWeightThin),
+      @"light": @(UIFontWeightLight),
+      @"regular": @(UIFontWeightRegular),
+      @"medium": @(UIFontWeightMedium),
+      @"semibold": @(UIFontWeightSemibold),
+      @"bold": @(UIFontWeightBold),
+      @"heavy": @(UIFontWeightHeavy),
+      @"black": @(UIFontWeightBlack),
+    };
+  });
   NSDictionary *traits = [font.fontDescriptor objectForKey:UIFontDescriptorTraitsAttribute];
-  return [traits[UIFontWeightTrait] doubleValue];
+  double weight = [traits[UIFontWeightTrait] doubleValue];
+  if (weight == 0.0) {
+    for (NSString *name in nameToWeight) {
+      if ([font.fontName.lowercaseString containsString:name]) {
+        return [nameToWeight[name] doubleValue];
+      }
+    }
+  }
+  return weight;
 }
 
 static BOOL RCTFontIsItalic(UIFont *font)


### PR DESCRIPTION
Some custom fonts don't return a UIFontWeightTrait that is representative of their actual weight. For example, "AktivGrotesk-Light" and "AktivGrotesk-Medium" both return UIFontWeightTrait 0. While this is of course an issue with the font files themselves, licensing issues can make it difficult to modify them directly. When using these fonts, specifying weights in JS has no effect. I propose that if no weight information is available, we inspect the name of the font for weighting.