### PR TITLE
#1331 Add information about ReactNative to runtime.

### DIFF
--- a/Libraries/JavaScriptAppEngine/Initialization/InitializeJavaScriptAppEngine.js
+++ b/Libraries/JavaScriptAppEngine/Initialization/InitializeJavaScriptAppEngine.js
@@ -118,6 +118,11 @@ function setUpGeolocation() {
   GLOBAL.navigator.geolocation = require('Geolocation');
 }
 
+function setUpProduct() {
+  GLOBAL.navigator.product = 'ReactNative';
+  GLOBAL.navigator.productSub = GLOBAL.navigator.rnVersion = RN_VERSION;
+}
+
 function setUpWebSockets() {
   GLOBAL.WebSocket = require('WebSocket');
 }
@@ -135,5 +140,6 @@ setUpPromise();
 setUpXHR();
 setUpRedBoxConsoleErrorHandler();
 setUpGeolocation();
+setUpProduct();
 setUpWebSockets();
 setupProfile();

--- a/packager/react-packager/src/Server/__tests__/Server-test.js
+++ b/packager/react-packager/src/Server/__tests__/Server-test.js
@@ -55,6 +55,7 @@ describe('processRequest', function() {
   var watcherFunc = jest.genMockFunction();
   var requestHandler;
   var triggerFileChange;
+  var rnVersion = "var RN_VERSION = '" + require('../../../../../package.json').version + "';";
 
   beforeEach(function() {
     Packager = require('../../Packager');
@@ -93,7 +94,7 @@ describe('processRequest', function() {
       requestHandler,
       'mybundle.bundle?runModule=true'
     ).then(function(response) {
-      expect(response).toEqual('this is the source');
+      expect(response).toEqual(rnVersion + 'this is the source');
     });
   });
 
@@ -102,7 +103,7 @@ describe('processRequest', function() {
       requestHandler,
       'mybundle.runModule.bundle'
     ).then(function(response) {
-      expect(response).toEqual('this is the source');
+      expect(response).toEqual(rnVersion + 'this is the source');
     });
   });
 
@@ -120,7 +121,7 @@ describe('processRequest', function() {
       requestHandler,
       'index.ios.includeRequire.bundle'
     ).then(function(response) {
-      expect(response).toEqual('this is the source');
+      expect(response).toEqual(rnVersion + 'this is the source');
       expect(Packager.prototype.package).toBeCalledWith(
         'index.ios.js',
         true,
@@ -183,7 +184,7 @@ describe('processRequest', function() {
 
       return makeRequest(requestHandler, 'mybundle.bundle?runModule=true')
         .then(function(response) {
-          expect(response).toEqual('this is the first source');
+          expect(response).toEqual(rnVersion + 'this is the first source');
           expect(packageFunc.mock.calls.length).toBe(1);
           triggerFileChange('all','path/file.js', options.projectRoots[0]);
           jest.runAllTimers();
@@ -193,7 +194,7 @@ describe('processRequest', function() {
           expect(packageFunc.mock.calls.length).toBe(2);
           return makeRequest(requestHandler, 'mybundle.bundle?runModule=true')
             .then(function(response) {
-              expect(response).toEqual('this is the rebuilt source');
+              expect(response).toEqual(rnVersion + 'this is the rebuilt source');
             });
         });
     });

--- a/packager/react-packager/src/Server/index.js
+++ b/packager/react-packager/src/Server/index.js
@@ -358,7 +358,8 @@ Server.prototype.processRequest = function(req, res, next) {
   building.then(
     function(p) {
       if (requestType === 'bundle') {
-        var bundleSource = p.getSource({
+        var rnGlobalVersion =  "var RN_VERSION = '" + require('../../../../package.json').version + "';";
+        var bundleSource = rnGlobalVersion + p.getSource({
           inlineSourceMap: options.inlineSourceMap,
           minify: options.minify,
         });


### PR DESCRIPTION
This allows to determine what kind of react runtime used, for some purposes (#1331). 
```javascript
console.log(navigator.product) // ReactNative
console.log(navigator.productSub, navigator.rnVersion) // 0.8.0 0.8.0
```
How to inject `react-native` version better than concatenating one string to another on the Server.js step? On the dependency resolver side, patching `prelude.js`? Or there are other ways to know that react native version is? 