### PR TITLE
Profiling will not work if the bundleURL has no port.

### DIFF
--- a/React/Base/RCTBatchedBridge.m
+++ b/React/Base/RCTBatchedBridge.m
@@ -728,7 +728,12 @@ RCT_NOT_IMPLEMENTED(-initWithBundleURL:(__unused NSURL *)bundleURL
   [_javaScriptExecutor executeBlockOnJavaScriptQueue:^{
     NSString *log = RCTProfileEnd(self);
     NSURL *bundleURL = _parentBridge.bundleURL;
-    NSString *URLString = [NSString stringWithFormat:@"%@://%@:%@/profile", bundleURL.scheme, bundleURL.host, bundleURL.port];
+    NSString *URLString;
+    if (bundleURL.port) {
+      URLString = [NSString stringWithFormat:@"%@://%@:%@/profile", bundleURL.scheme, bundleURL.host, bundleURL.port];
+    } else {
+      URLString = [NSString stringWithFormat:@"%@://%@/profile", bundleURL.scheme, bundleURL.host];
+    }
     NSURL *URL = [NSURL URLWithString:URLString];
     NSMutableURLRequest *URLRequest = [NSMutableURLRequest requestWithURL:URL];
     URLRequest.HTTPMethod = @"POST";


### PR DESCRIPTION
If the bundleURL has no port(default 80) , the profile request URL will be `<scheme>://<host>:<null>/profile`, that will not work. So we should decide if the port exsits first.