### PR TITLE
[docs] Make it clear which Guides are platform-specific

### DIFF
--- a/docs/Accessibility.md
+++ b/docs/Accessibility.md
@@ -1,10 +1,10 @@
 ---
 id: accessibility
-title: Accessibility
+title: Accessibility (iOS)
 layout: docs
 category: Guides
 permalink: docs/accessibility.html
-next: nativemodulesios
+next: native-modules-ios
 ---
 
 Accessibility on iOS encompasses many topics, but for many, accessibility is synonymous with VoiceOver, a technology available since iOS 3.0. It acts as a screen reader, allowing people with visual impairments to use their iOS devices. Click [here](https://developer.apple.com/accessibility/ios/) to learn more.

--- a/docs/DirectManipulation.md
+++ b/docs/DirectManipulation.md
@@ -4,7 +4,7 @@ title: Direct Manipulation
 layout: docs
 category: Guides
 permalink: docs/direct-manipulation.html
-next: linking-libraries
+next: linking-libraries-ios
 ---
 
 It is sometimes necessary to make changes directly to a component

--- a/docs/EmbeddedApp.md
+++ b/docs/EmbeddedApp.md
@@ -1,9 +1,9 @@
 ---
-id: embedded-app
-title: Integration with Existing App
+id: embedded-app-ios
+title: Integrating with Existing Apps (iOS)
 layout: docs
 category: Guides
-permalink: docs/embedded-app.html
+permalink: docs/embedded-app-ios.html
 next: javascript-environment
 ---
 

--- a/docs/JavaScriptEnvironment.md
+++ b/docs/JavaScriptEnvironment.md
@@ -11,11 +11,10 @@ next: navigator-comparison
 
 When using React Native, you're going to be running your JavaScript code in two environments:
 
-* In the simulator and on the phone: [JavaScriptCore](http://trac.webkit.org/wiki/JavaScriptCore) which is the JavaScript engine that powers Safari and web views. Due to the absence of writable executable memory in iOS apps, it doesn't run with JIT.
+* On iOS simulators and devices, Android emulators and devices React Native uses [JavaScriptCore](http://trac.webkit.org/wiki/JavaScriptCore) which is the JavaScript engine that powers Safari. On iOS JSC doesn't use JIT due to the absence of writable executable memory in iOS apps.
 * When using Chrome debugging, it runs all the JavaScript code within Chrome itself and communicates with Objective-C via WebSocket. So you are using [V8](https://code.google.com/p/v8/).
 
 While both environments are very similar, you may end up hitting some inconsistencies. We're likely going to experiment with other JS engines in the future, so it's best to avoid relying on specifics of any runtime.
-
 
 ## JavaScript Syntax Transformers
 

--- a/docs/LinkingLibraries.md
+++ b/docs/LinkingLibraries.md
@@ -1,9 +1,9 @@
 ---
-id: linking-libraries
-title: Linking Libraries
+id: linking-libraries-ios
+title: Linking Libraries (iOS)
 layout: docs
 category: Guides
-permalink: docs/linking-libraries.html
+permalink: docs/linking-libraries-ios.html
 next: debugging
 ---
 

--- a/docs/NativeComponentsIOS.md
+++ b/docs/NativeComponentsIOS.md
@@ -1,9 +1,9 @@
 ---
-id: nativecomponentsios
+id: native-components-ios
 title: Native UI Components (iOS)
 layout: docs
 category: Guides
-permalink: docs/nativecomponentsios.html
+permalink: docs/native-components-ios.html
 next: direct-manipulation
 ---
 

--- a/docs/NativeModulesIOS.md
+++ b/docs/NativeModulesIOS.md
@@ -1,10 +1,10 @@
 ---
-id: nativemodulesios
+id: native-modules-ios
 title: Native Modules (iOS)
 layout: docs
 category: Guides
-permalink: docs/nativemodulesios.html
-next: nativecomponentsios
+permalink: docs/native-modules-ios.html
+next: native-components-ios
 ---
 
 Sometimes an app needs access to platform API, and React Native doesn't have a corresponding module yet. Maybe you want to reuse some existing Objective-C, Swift or C++ code without having to reimplement it in JavaScript, or write some high performance, multi-threaded code such as for image processing, a database, or any number of advanced extensions.

--- a/docs/RunningOnDevice.md
+++ b/docs/RunningOnDevice.md
@@ -1,10 +1,10 @@
 ---
-id: runningondevice
-title: Running On Device
+id: running-on-device-ios
+title: Running On Device (iOS)
 layout: docs
 category: Guides
-permalink: docs/runningondevice.html
-next: embedded-app
+permalink: docs/running-on-device-ios.html
+next: embedded-app-ios
 ---
 
 Note that running on device requires [Apple Developer account](https://developer.apple.com/register/index.action) and provisioning your iPhone. This guide covers only React Native specific topic.

--- a/docs/Testing.md
+++ b/docs/Testing.md
@@ -4,7 +4,7 @@ title: Testing
 layout: docs
 category: Guides
 permalink: docs/testing.html
-next: runningondevice
+next: running-on-device-ios
 ---
 
 ## Running Tests and Contributing


### PR DESCRIPTION
This is in preparation for open sourcing React Native for Android.
Also add hyphens to URLs for consistency. This can break people's
browser bookmarks but it's better to be consistent and we can
redirect to docs: https://github.com/facebook/react-native/issues/2137

Test plan: Ran the website locally using `cd website; npm start`
and checked all pages render correctly.
http://i.imgur.com/RrPNgRr.png

Will update "Getting Started", "Tutorial", "Debugging" and
"Testing" separately.