### PR TITLE
Adds cacheEnabled, cookiesEnabled, schemes to WebView

### DIFF
--- a/Libraries/Components/WebView/WebView.ios.js
+++ b/Libraries/Components/WebView/WebView.ios.js
@@ -87,6 +87,9 @@ var WebView = React.createClass({
     renderError: PropTypes.func, // view to show if there's an error
     renderLoading: PropTypes.func, // loading indicator to show
     bounces: PropTypes.bool,
+    cacheEnabled: PropTypes.bool,
+    cookiesEnabled: PropTypes.bool,
+    schemes: PropTypes.object,
     scrollEnabled: PropTypes.bool,
     automaticallyAdjustContentInsets: PropTypes.bool,
     contentInset: EdgeInsetsPropType,
@@ -161,6 +164,9 @@ var WebView = React.createClass({
         html={this.props.html}
         injectedJavaScript={this.props.injectedJavaScript}
         bounces={this.props.bounces}
+        cacheEnabled={this.props.cacheEnabled}
+        cookiesEnabled={this.props.cookiesEnabled}
+        schemes={this.props.schemes}
         scrollEnabled={this.props.scrollEnabled}
         contentInset={this.props.contentInset}
         automaticallyAdjustContentInsets={this.props.automaticallyAdjustContentInsets}

--- a/React/Views/RCTWebView.h
+++ b/React/Views/RCTWebView.h
@@ -19,6 +19,7 @@ extern NSString *const RCTJSNavigationScheme;
 @property (nonatomic, assign) UIEdgeInsets contentInset;
 @property (nonatomic, assign) BOOL automaticallyAdjustContentInsets;
 @property (nonatomic, copy) NSString *injectedJavaScript;
+@property (nonatomic, strong) NSDictionary *schemes;
 
 - (instancetype)initWithEventDispatcher:(RCTEventDispatcher *)eventDispatcher NS_DESIGNATED_INITIALIZER;
 

--- a/React/Views/RCTWebView.m
+++ b/React/Views/RCTWebView.m
@@ -45,7 +45,7 @@ NSString *const RCTJSNavigationScheme = @"react-js-navigation";
     _automaticallyAdjustContentInsets = YES;
     _contentInset = UIEdgeInsetsZero;
     _eventDispatcher = eventDispatcher;
-    _schemes = [NSDictionary dictionaryWithObject:[NSNumber numberWithBool:YES] forKey:@"*"];
+    _schemes = @{ @"*": @YES };
     _webView = [[UIWebView alloc] initWithFrame:self.bounds];
     _webView.delegate = self;
     [self addSubview:_webView];
@@ -87,7 +87,7 @@ RCT_NOT_IMPLEMENTED(-initWithCoder:(NSCoder *)aDecoder)
 {
   if (!cookiesEnabled) {
     NSHTTPCookieStorage *storage = [NSHTTPCookieStorage sharedHTTPCookieStorage];
-    for (NSHTTPCookie *cookie in [storage cookies]) {
+    for (NSHTTPCookie *cookie in storage.cookies) {
       [storage deleteCookie:cookie];
     }
     [[NSUserDefaults standardUserDefaults] synchronize];
@@ -181,14 +181,14 @@ RCT_NOT_IMPLEMENTED(-initWithCoder:(NSCoder *)aDecoder)
   NSString *scheme = request.URL.scheme;
   
   NSNumber *catchAllScheme;
-  if ([_schemes objectForKey:@"*"] == nil) {
-    catchAllScheme = [NSNumber numberWithBool:YES];
+  if (_schemes[@"*"] == nil) {
+    catchAllScheme = @YES;
   }
   else {
-    catchAllScheme = [_schemes valueForKey:@"*"];
+    catchAllScheme = _schemes[@"*"];
   }
   
-  NSNumber *schemeInSchemes = [_schemes objectForKey:scheme];
+  NSNumber *schemeInSchemes = _schemes[scheme];
   
   if ((schemeInSchemes != nil && ![schemeInSchemes boolValue])
       || (schemeInSchemes == nil && ![catchAllScheme boolValue])) {

--- a/React/Views/RCTWebViewManager.m
+++ b/React/Views/RCTWebViewManager.m
@@ -26,10 +26,13 @@ RCT_EXPORT_MODULE()
 RCT_REMAP_VIEW_PROPERTY(url, URL, NSURL);
 RCT_REMAP_VIEW_PROPERTY(html, HTML, NSString);
 RCT_REMAP_VIEW_PROPERTY(bounces, _webView.scrollView.bounces, BOOL);
+RCT_REMAP_VIEW_PROPERTY(cacheEnabled, CacheEnabled, BOOL);
+RCT_REMAP_VIEW_PROPERTY(cookiesEnabled, CookiesEnabled, BOOL);
 RCT_REMAP_VIEW_PROPERTY(scrollEnabled, _webView.scrollView.scrollEnabled, BOOL);
 RCT_REMAP_VIEW_PROPERTY(scalesPageToFit, _webView.scalesPageToFit, BOOL);
 RCT_EXPORT_VIEW_PROPERTY(injectedJavaScript, NSString);
 RCT_EXPORT_VIEW_PROPERTY(contentInset, UIEdgeInsets);
+RCT_EXPORT_VIEW_PROPERTY(schemes, NSDictionary);
 RCT_EXPORT_VIEW_PROPERTY(automaticallyAdjustContentInsets, BOOL);
 
 - (NSDictionary *)constantsToExport


### PR DESCRIPTION
Adds three new properties to WebViews:
- cacheEnabled: (Boolean) Specify whether or not page content should be cached
- cookiesEnabled: (Boolean) Specify whether or not cookies should be used
- schemes: (Object of shape: { String: Boolean, ... }) A black/white list of schemes that are (dis)allowed. True means allowed, false means disallowed. By default all schemes are allowed, and the wildcard `*` may be used to target all schemes.