### PR TITLE
[JSContext] Define `ContextExecutor.setContextName` for debugging

### DIFF
--- a/React/Executors/RCTContextExecutor.m
+++ b/React/Executors/RCTContextExecutor.m
@@ -557,4 +557,13 @@ static NSError *RCTNSErrorFromJSError(JSContextRef context, JSValueRef jsError)
   }), @"js_call,json_call", (@{@"objectName": objectName}))];
 }
 
+RCT_EXPORT_METHOD(setContextName:(NSString *)name)
+{
+  if (JSGlobalContextSetName) {
+    JSStringRef JSName = JSStringCreateWithCFString((__bridge CFStringRef)name);
+    JSGlobalContextSetName(_context.ctx, JSName);
+    JSStringRelease(JSName);
+  }
+}
+
 @end


### PR DESCRIPTION
Add a method that lets JS set the name of the JSContext for debugging purposes. I check `JSGlobalContextSetName` since it is not available on iOS 7.

Test Plan: Run `NativeModules.ContextExecutor.setContextName('x')` with the default executor active, and find it from the Safari develop menu with the correct name. Changed the name when the debugger was connected and saw that its name was updated the next time I opened the menu.

<img width="476" alt="screenshot 2015-07-27 23 13 11" src="https://cloud.githubusercontent.com/assets/379606/8924729/6dbecf38-34b5-11e5-9178-5034005df985.png">