### PR TITLE
Adding 404.js to catch 404s on website

### DIFF
--- a/website/src/react-native/404.js
+++ b/website/src/react-native/404.js
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+var React = require('React');
+
+var four_oh_four = React.createClass({
+  render: function() {
+    return (
+      <html>
+        <head>
+          <meta httpEquiv="refresh" content="0; /react-native/docs/getting-started.html" />
+        </head>
+        <body></body>
+      </html>
+    );
+  }
+});
+
+module.exports = four_oh_four;

--- a/website/src/react-native/404.js
+++ b/website/src/react-native/404.js
@@ -9,7 +9,7 @@
 
 var React = require('React');
 
-var four_oh_four = React.createClass({
+var fourOhFour = React.createClass({
   render: function() {
     return (
       <html>
@@ -22,4 +22,4 @@ var four_oh_four = React.createClass({
   }
 });
 
-module.exports = four_oh_four;
+module.exports = fourOhFour;


### PR DESCRIPTION
404s on the website currently redirect to code.facebook.com because we have no root 404.html - this adds one that will be generated by the website script, that redirects all 404s to the root docs page. 