### PR TITLE
[Image] Remove unused backgroundColor and tintColor params from downloader

### DIFF
--- a/Libraries/Image/RCTImageDownloader.h
+++ b/Libraries/Image/RCTImageDownloader.h
@@ -38,8 +38,6 @@ typedef void (^RCTImageDownloadCancellationBlock)(void);
                                                     size:(CGSize)size
                                                    scale:(CGFloat)scale
                                               resizeMode:(UIViewContentMode)resizeMode
-                                               tintColor:(UIColor *)tintColor
-                                         backgroundColor:(UIColor *)backgroundColor
                                            progressBlock:(RCTDataProgressBlock)progressBlock
                                                    block:(RCTImageDownloadBlock)block;
 

--- a/Libraries/Image/RCTImageDownloader.m
+++ b/Libraries/Image/RCTImageDownloader.m
@@ -149,8 +149,6 @@ CGRect RCTClipRect(CGSize, CGFloat, CGSize, CGFloat, UIViewContentMode);
                                                     size:(CGSize)size
                                                    scale:(CGFloat)scale
                                               resizeMode:(UIViewContentMode)resizeMode
-                                               tintColor:(UIColor *)tintColor
-                                         backgroundColor:(UIColor *)backgroundColor
                                            progressBlock:(RCTDataProgressBlock)progressBlock
                                                    block:(RCTImageDownloadBlock)block
 {
@@ -170,27 +168,10 @@ CGRect RCTClipRect(CGSize, CGFloat, CGSize, CGFloat, UIViewContentMode);
       CGSize destSize = RCTTargetSizeForClipRect(imageRect);
 
       // Opacity optimizations
-      UIColor *blendColor = nil;
       BOOL opaque = !RCTImageHasAlpha(image.CGImage);
-      if (!opaque && backgroundColor) {
-        CGFloat alpha;
-        [backgroundColor getRed:NULL green:NULL blue:NULL alpha:&alpha];
-        if (alpha > 0.999) { // no benefit to blending if background is translucent
-          opaque = YES;
-          blendColor = backgroundColor;
-        }
-      }
 
       // Decompress image at required size
       UIGraphicsBeginImageContextWithOptions(destSize, opaque, scale);
-      if (blendColor) {
-        [blendColor setFill];
-        UIRectFill((CGRect){CGPointZero, destSize});
-      }
-      if (tintColor) {
-        image = [image imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
-        [tintColor setFill];
-      }
       [image drawInRect:imageRect];
       image = UIGraphicsGetImageFromCurrentImageContext();
       UIGraphicsEndImageContext();

--- a/Libraries/Image/RCTImageLoader.m
+++ b/Libraries/Image/RCTImageLoader.m
@@ -226,7 +226,7 @@ static UIImage *RCTScaledImageForAsset(ALAssetRepresentation *representation,
         RCTDispatchCallbackOnMainQueue(completion, error, image);
       }];
     } else {
-      return [[RCTImageDownloader sharedInstance] downloadImageForURL:url size:size scale:scale resizeMode:resizeMode tintColor:nil backgroundColor:nil progressBlock:progress block:^(UIImage *image, NSError *error) {
+      return [[RCTImageDownloader sharedInstance] downloadImageForURL:url size:size scale:scale resizeMode:resizeMode progressBlock:progress block:^(UIImage *image, NSError *error) {
          RCTDispatchCallbackOnMainQueue(completion, error, image);
       }];
     }


### PR DESCRIPTION
The outer UIImageView now takes care of backgroundColor and tintColor so the image downloader no longer needs to paint them manually. Remove these unused params that were only nil.

Test Plan: View the Images demo in the UIExplorer and verify that tint colors and background colors are honored.