### PR TITLE
[Executor] Use Obj-C API in `toggleProfilingFlag`

### DIFF
--- a/React/Executors/RCTContextExecutor.h
+++ b/React/Executors/RCTContextExecutor.h
@@ -19,10 +19,16 @@
 @interface RCTContextExecutor : NSObject <RCTJavaScriptExecutor>
 
 /**
- * Configures the executor to run JavaScript on a custom performer.
+ * Configures the executor to run JavaScript on a specific thread with a given JS context.
  * You probably don't want to use this; use -init instead.
  */
 - (instancetype)initWithJavaScriptThread:(NSThread *)javaScriptThread
-                        globalContextRef:(JSGlobalContextRef)context NS_DESIGNATED_INITIALIZER;
+                                 context:(JSContext *)context NS_DESIGNATED_INITIALIZER;
+
+/**
+ * Like -[initWithJavaScriptThread:context:] but uses JSGlobalContextRef from JavaScriptCore's C API.
+ */
+- (instancetype)initWithJavaScriptThread:(NSThread *)javaScriptThread
+                        globalContextRef:(JSGlobalContextRef)contextRef;
 
 @end

--- a/React/Executors/RCTContextExecutor.m
+++ b/React/Executors/RCTContextExecutor.m
@@ -286,6 +286,7 @@ static JSValueRef RCTNativeTraceEndSection(JSContextRef context, __unused JSObje
       JSContext *context = [[JSContext alloc] init];
       strongSelf->_context = [[RCTJavaScriptContext alloc] initWithJSContext:context];
     }
+
     [strongSelf _addNativeHook:RCTNativeLoggingHook withName:"nativeLoggingHook"];
     [strongSelf _addNativeHook:RCTNoop withName:"noop"];
 #if RCT_DEV
@@ -316,17 +317,8 @@ static JSValueRef RCTNativeTraceEndSection(JSContextRef context, __unused JSObje
 
 - (void)toggleProfilingFlag:(NSNotification *)notification
 {
-  JSObjectRef globalObject = JSContextGetGlobalObject(_context.ctx);
-
-  bool enabled = [notification.name isEqualToString:RCTProfileDidStartProfiling];
-  JSStringRef JSName = JSStringCreateWithUTF8CString("__BridgeProfilingIsProfiling");
-  JSObjectSetProperty(_context.ctx,
-                      globalObject,
-                      JSName,
-                      JSValueMakeBoolean(_context.ctx, enabled),
-                      kJSPropertyAttributeNone,
-                      NULL);
-  JSStringRelease(JSName);
+  BOOL enabled = [notification.name isEqualToString:RCTProfileDidStartProfiling];
+  _context.context[@"__BridgeProfilingIsProfiling"] = @(enabled);
 }
 
 - (void)_addNativeHook:(JSObjectCallAsFunctionCallback)hook withName:(const char *)name


### PR DESCRIPTION
Uses the Obj-C API to set a global flag for whether or not profiling is active.