### PR TITLE
Adds `RCTExceptionRaised` NSNotification

### DIFF
--- a/React/Base/RCTBridge.h
+++ b/React/Base/RCTBridge.h
@@ -39,6 +39,11 @@ RCT_EXTERN NSString *const RCTJavaScriptDidFailToLoadNotification;
 RCT_EXTERN NSString *const RCTDidCreateNativeModules;
 
 /**
+ * This notification fires when the bridge raises an exception
+ */
+RCT_EXTERN NSString *const RCTExceptionRaised;
+
+/**
  * This block can be used to instantiate modules that require additional
  * init parameters, or additional configuration prior to being used.
  * The bridge will call this block to instatiate the modules, and will

--- a/React/Base/RCTBridge.m
+++ b/React/Base/RCTBridge.m
@@ -21,6 +21,7 @@ NSString *const RCTReloadNotification = @"RCTReloadNotification";
 NSString *const RCTJavaScriptDidLoadNotification = @"RCTJavaScriptDidLoadNotification";
 NSString *const RCTJavaScriptDidFailToLoadNotification = @"RCTJavaScriptDidFailToLoadNotification";
 NSString *const RCTDidCreateNativeModules = @"RCTDidCreateNativeModules";
+NSString *const RCTExceptionRaised = @"RCTExceptionRaised";
 
 @class RCTBatchedBridge;
 


### PR DESCRIPTION
This notification gets posted before both 'Soft' & 'Fatal' exceptions are reported (either as a RedBox error or an NSException)

On the React Native Playground team, we have the use case (as well as many developers that we've talked to in the community) to be able to capture errors in the bundle before loading it, and/or logging them remotely in a QA/staging environment (Debug Mode).

We feel that this small addition may be a good starting point to accomplish this. Perhaps it's not the right implementation, but we might be able to figure out what is.