### PR TITLE
[Docs] Explain more about nvm in the io.js setup docs

### DIFF
--- a/docs/EmbeddedApp.md
+++ b/docs/EmbeddedApp.md
@@ -12,8 +12,9 @@ Since React makes no assumptions about the rest of your technology stack – it�
 ## Requirements
 
 - [CocoaPods](http://cocoapods.org/) – `gem install cocoapods`
-- [io.js](http://iojs.org) – `brew install iojs && brew link iojs --force` or from [nvm](https://github.com/creationix/nvm)
-  - You may have to run `brew unlink node` if you have previously installed Node
+- [io.js](http://iojs.org)
+  - **With nvm:** Install nvm with [its setup instructions here](https://github.com/creationix/nvm#installation). Then run `nvm install iojs && nvm alias default iojs`, which installs the latest version of io.js and sets up your terminal so that typing `node` runs io.js.  With nvm you can install multiple versions of Node and io.js and easily switch between them.
+  - **With Homebrew:** Run `brew install iojs && brew link iojs --force`. You may need to run `brew unlink node` if you have previously installed Node.
 
 ## Install React Native Using CocoaPods
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -11,10 +11,15 @@ next: tutorial
 
 1. OS X - This repo only contains the iOS (7+) implementation right now, and Xcode only runs on Mac.
 2. [Xcode](https://developer.apple.com/xcode/downloads/) 6.3 or higher is recommended.
-3. [Homebrew](http://brew.sh/) is the recommended way to install node, watchman, and flow.
-4. `brew install iojs && brew link iojs --force`. You may need to run `brew unlink node` if you have previously installed Node. New to [io.js](https://iojs.org/) or [npm](https://docs.npmjs.com/)?
+3. [Homebrew](http://brew.sh/) is the recommended way to install io.js, watchman, and flow.
+4. Install [io.js](https://iojs.org/) 1.0 or newer. io.js is the modern version of Node.
+  - **With nvm:** Install nvm with [its setup instructions here](https://github.com/creationix/nvm#installation). Then run `nvm install iojs && nvm alias default iojs`, which installs the latest version of io.js and sets up your terminal so that typing `node` runs io.js. With nvm you can install multiple versions of Node and io.js and easily switch between them.
+  - **With Homebrew:** Run `brew install iojs && brew link iojs --force`. You may need to run `brew unlink node` if you have previously installed Node.
+  - New to [npm](https://docs.npmjs.com/)?
 5. `brew install watchman`. We recommend installing [watchman](https://facebook.github.io/watchman/docs/install.html), otherwise you might hit a node file watching bug.
 6. `brew install flow`. If you want to use [flow](http://www.flowtype.org).
+
+We recommend periodically running `brew update && brew upgrade` to keep your programs up-to-date.
 
 ## Quick start
 


### PR DESCRIPTION
Clarify that io.js is the modern version of Node and explain a little more about how to get set up with nvm, and that it lets you switch between multiple io.js/node versions.
