### PR TITLE
CMD+R should post a refresh notification.

### DIFF
--- a/React/Base/RCTBridge.m
+++ b/React/Base/RCTBridge.m
@@ -177,14 +177,16 @@ RCT_NOT_IMPLEMENTED(-init)
 
 #if TARGET_IPHONE_SIMULATOR
 
-  __weak RCTBridge *weakSelf = self;
   RCTKeyCommands *commands = [RCTKeyCommands sharedInstance];
 
   // reload in current mode
   [commands registerKeyCommandWithInput:@"r"
                           modifierFlags:UIKeyModifierCommand
-                                 action:^(__unused UIKeyCommand *command) {
-                                   [weakSelf reload];
+                                 action:^(__unused UIKeyCommand *command) 
+                                 {
+                                    [[NSNotificationCenter defaultCenter] postNotificationName:RCTReloadNotification
+                                                                                        object:nil
+                                                                                      userInfo:nil];
                                  }];
 
 #endif


### PR DESCRIPTION
For the sake of consistency, `cmd+r` should just post a refresh notification. This way other tools can also observe and react to the refresh without ugly hacks.