### PR TITLE
[Addons] Add InteractionMixin to the set of addons

### DIFF
--- a/Libraries/react-native/react-native.js
+++ b/Libraries/react-native/react-native.js
@@ -77,6 +77,7 @@ var ReactNative = Object.assign(Object.create(require('React')), {
   PointPropType: require('PointPropType'),
 
   addons: {
+    InteractionMixin: require('InteractionMixin'),
     LinkedStateMixin: require('LinkedStateMixin'),
     Perf: undefined,
     PureRenderMixin: require('ReactComponentWithPureRenderMixin'),


### PR DESCRIPTION
Publicly expose InteractionMixin under addons until there's a better story around canceling tasks when a component is unmounted.