### PR TITLE
[UIExplorer] Add TransformExample to UIExplorerList.ios.js

### DIFF
--- a/Examples/UIExplorer/UIExplorerList.ios.js
+++ b/Examples/UIExplorer/UIExplorerList.ios.js
@@ -72,6 +72,7 @@ var APIS = [
   require('./PushNotificationIOSExample'),
   require('./StatusBarIOSExample'),
   require('./TimerExample'),
+  require('./TransformExample'),
   require('./VibrationIOSExample'),
   require('./XHRExample'),
 ];


### PR DESCRIPTION
It wasn't in UIExplorerList.ios.js (only in UIExplorerList.js) so it was not being pulled in on the iOS UIExplorer.