### PR TITLE
Modification of the method "replaceAtIndex" in Navigator.js to allow adding new routes to the end and creation of new method "removeAtIndex"

### DIFF
--- a/Libraries/CustomComponents/Navigator/Navigator.js
+++ b/Libraries/CustomComponents/Navigator/Navigator.js
@@ -971,6 +971,40 @@ var Navigator = React.createClass({
   },
 
   /**
+   * Removes a scene from the stack
+   */
+  removeAtIndex: function(index, cb) {
+    if (index < 0) {
+      index += this.state.routeStack.length;
+    }
+
+    if (index >= this.state.routeStack.length) {
+      return;
+    }
+
+    var nextRouteStack = this.state.routeStack.slice();
+    var nextAnimationModeStack = this.state.sceneConfigStack.slice();
+
+    nextRouteStack.splice(index, 1);
+    nextAnimationModeStack.splice(index, 1);
+
+    if (index < this.state.presentedIndex) {
+      // remove a route which is before the currently active route
+      this.state.presentedIndex = this.state.presentedIndex - 1;
+    } else if (index == this.state.presentedIndex) {
+      // return if trying to remove currently active route
+      return;
+    }
+
+    this.setState({
+      routeStack: nextRouteStack,
+      sceneConfigStack: nextAnimationModeStack,
+    }, () => {
+      cb && cb();
+    });
+  },
+
+  /**
    * Replaces the current scene in the stack.
    */
   replace: function(route) {

--- a/Libraries/CustomComponents/Navigator/Navigator.js
+++ b/Libraries/CustomComponents/Navigator/Navigator.js
@@ -937,14 +937,24 @@ var Navigator = React.createClass({
       index += this.state.routeStack.length;
     }
 
-    if (this.state.routeStack.length <= index) {
+    if (index > this.state.routeStack.length) {
       return;
     }
 
     var nextRouteStack = this.state.routeStack.slice();
     var nextAnimationModeStack = this.state.sceneConfigStack.slice();
-    nextRouteStack[index] = route;
-    nextAnimationModeStack[index] = this.props.configureScene(route);
+
+    // replacing an existing route in the routeStack
+    if (index < this.state.routeStack.length) {
+      nextRouteStack[index] = route;
+      nextAnimationModeStack[index] = this.props.configureScene(route);
+    } else {
+    // adding a new route to the very end of the current routeStack
+      nextRouteStack = nextRouteStack.concat([route]);
+      nextAnimationModeStack = nextAnimationModeStack.concat([
+        this.props.configureScene(route),
+      ]);
+    }
 
     if (index === this.state.presentedIndex) {
       this._emitWillFocus(route);


### PR DESCRIPTION
# replaceAtIndex
### Old behavior:
* if specified index is smaller than currentRouteStack.length, it will replace existing route
* if specified index is equal to currentRouteStack.length, it will return
* if index is larger than currentRouteStack.length, it will return

### New behaior:
* if specified index is smaller than currentRouteStack.length, it will replace existing route
* **if specified index is equal to currentRouteStack.length, it will add a new route to the end of the routeStack**
* if index is larger than currentRouteStack.length, it will return

### Test:
* Used the following app for testing: https://rnplay.org/apps/cm53mA/

# removeAtIndex
* added new method "removeAtIndex" which deletes a route from the routeStack specified by its current index