### PR TITLE
[Error cookie] Finish up the work to send through the error cookie

### DIFF
--- a/Libraries/JavaScriptAppEngine/Initialization/ExceptionsManager.js
+++ b/Libraries/JavaScriptAppEngine/Initialization/ExceptionsManager.js
@@ -36,7 +36,7 @@ function reportException(e: Exception, isFatal: bool, stack?: any) {
     if (isFatal) {
       RCTExceptionsManager.reportFatalException(e.message, stack, currentExceptionID);
     } else {
-      RCTExceptionsManager.reportSoftException(e.message, stack);
+      RCTExceptionsManager.reportSoftException(e.message, stack, currentExceptionID);
     }
     if (__DEV__) {
       (sourceMapPromise = sourceMapPromise || loadSourceMap())

--- a/React/Modules/RCTExceptionsManager.h
+++ b/React/Modules/RCTExceptionsManager.h
@@ -13,9 +13,15 @@
 
 @protocol RCTExceptionsManagerDelegate <NSObject>
 
+// NOTE: Remove these three methods and the @optional directive after updating the codebase to use only the three below
+@optional
 - (void)handleSoftJSExceptionWithMessage:(NSString *)message stack:(NSArray *)stack;
 - (void)handleFatalJSExceptionWithMessage:(NSString *)message stack:(NSArray *)stack;
 - (void)updateJSExceptionWithMessage:(NSString *)message stack:(NSArray *)stack;
+
+- (void)handleSoftJSExceptionWithMessage:(NSString *)message stack:(NSArray *)stack exceptionId:(NSNumber *)exceptionId;
+- (void)handleFatalJSExceptionWithMessage:(NSString *)message stack:(NSArray *)stack exceptionId:(NSNumber *)exceptionId;
+- (void)updateJSExceptionWithMessage:(NSString *)message stack:(NSArray *)stack exceptionId:(NSNumber *)exceptionId;
 
 @end
 

--- a/React/Modules/RCTExceptionsManager.m
+++ b/React/Modules/RCTExceptionsManager.m
@@ -39,11 +39,16 @@ RCT_EXPORT_MODULE()
 }
 
 RCT_EXPORT_METHOD(reportSoftException:(NSString *)message
-                  stack:(NSArray *)stack)
+                  stack:(NSArray *)stack
+                  exceptionId:(nonnull NSNumber *)exceptionId)
 {
   // TODO(#7070533): report a soft error to the server
   if (_delegate) {
-    [_delegate handleSoftJSExceptionWithMessage:message stack:stack];
+    if ([_delegate respondsToSelector:@selector(handleSoftJSExceptionWithMessage:stack:exceptionId:)]) {
+      [_delegate handleSoftJSExceptionWithMessage:message stack:stack exceptionId:exceptionId];
+    } else {
+      [_delegate handleSoftJSExceptionWithMessage:message stack:stack];
+    }
     return;
   }
   [_bridge.redBox showErrorMessage:message withStack:stack];
@@ -51,10 +56,14 @@ RCT_EXPORT_METHOD(reportSoftException:(NSString *)message
 
 RCT_EXPORT_METHOD(reportFatalException:(NSString *)message
                   stack:(NSArray *)stack
-                  exceptionId:(__unused NSNumber *)exceptionId)
+                  exceptionId:(nonnull NSNumber *)exceptionId)
 {
   if (_delegate) {
-    [_delegate handleFatalJSExceptionWithMessage:message stack:stack];
+    if ([_delegate respondsToSelector:@selector(handleFatalJSExceptionWithMessage:stack:exceptionId:)]) {
+      [_delegate handleFatalJSExceptionWithMessage:message stack:stack exceptionId:exceptionId];
+    } else {
+      [_delegate handleFatalJSExceptionWithMessage:message stack:stack];
+    }
     return;
   }
 
@@ -90,10 +99,14 @@ RCT_EXPORT_METHOD(reportFatalException:(NSString *)message
 
 RCT_EXPORT_METHOD(updateExceptionMessage:(NSString *)message
                   stack:(NSArray *)stack
-                  exceptionId:(__unused NSNumber *)exceptionId)
+                  exceptionId:(nonnull NSNumber *)exceptionId)
 {
   if (_delegate) {
-    [_delegate updateJSExceptionWithMessage:message stack:stack];
+    if ([_delegate respondsToSelector:@selector(updateJSExceptionWithMessage:stack:exceptionId:)]) {
+      [_delegate updateJSExceptionWithMessage:message stack:stack exceptionId:exceptionId];
+    } else {
+      [_delegate updateJSExceptionWithMessage:message stack:stack];
+    }
     return;
   }
 
@@ -104,6 +117,6 @@ RCT_EXPORT_METHOD(updateExceptionMessage:(NSString *)message
 RCT_EXPORT_METHOD(reportUnhandledException:(NSString *)message
                   stack:(NSArray *)stack)
 {
-  [self reportFatalException:message stack:stack exceptionId:nil];
+  [self reportFatalException:message stack:stack exceptionId:@-1];
 }
 @end

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/core/ExceptionsManagerModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/core/ExceptionsManagerModule.java
@@ -57,7 +57,7 @@ public class ExceptionsManagerModule extends BaseJavaModule {
   }
 
   @ReactMethod
-  public void reportSoftException(String title, ReadableArray details) {
+  public void reportSoftException(String title, ReadableArray details, int exceptionId) {
     FLog.e(ReactConstants.TAG, title + "\n" + stackTraceToString(details));
   }
 


### PR DESCRIPTION
- Includes the error cookie with soft exceptions as well since they too can be updated (requires tiny Android change too)
- Passes the error cookie through instead of leaving it unused