### PR TITLE
[Blur & Focus] Support relinquishing focus from multiple views via co…

### DIFF
--- a/Libraries/Components/TextInput/TextInputState.js
+++ b/Libraries/Components/TextInput/TextInputState.js
@@ -52,6 +52,8 @@ var TextInputState = {
     if (this._currentlyFocusedID === textFieldID && textFieldID !== null) {
       this._currentlyFocusedID = null;
       RCTUIManager.blur(textFieldID);
+    } else {
+      RCTUIManager.blurView(textFieldID);
     }
   }
 };

--- a/React/Modules/RCTUIManager.m
+++ b/React/Modules/RCTUIManager.m
@@ -757,6 +757,20 @@ RCT_EXPORT_METHOD(manageChildren:(NSNumber *)containerReactTag
   }
 }
 
+- (void)endEditingForShadowView:(NSNumber *)reactTag manager:(RCTUIManager *)uiManager viewRegistry:(RCTSparseArray *)viewRegistry
+{
+  RCTShadowView *shadowView = uiManager.shadowViewRegistry[reactTag];
+
+  for(RCTShadowView *subview in [shadowView reactSubviews]) {
+    if([[subview reactSubviews] count] > 0) {
+      [uiManager endEditingForShadowView:subview.reactTag manager:uiManager viewRegistry:viewRegistry];
+    } else {
+      UIView *view = viewRegistry[subview.reactTag];
+      [view resignFirstResponder];
+    }
+  }
+}
+
 static BOOL RCTCallPropertySetter(NSString *key, SEL setter, id value, id view, id defaultView, RCTViewManager *manager)
 {
   // TODO: cache respondsToSelector tests
@@ -911,6 +925,14 @@ RCT_EXPORT_METHOD(blur:(NSNumber *)reactTag)
   [self addUIBlock:^(__unused RCTUIManager *uiManager, RCTSparseArray *viewRegistry){
     UIView *currentResponder = viewRegistry[reactTag];
     [currentResponder resignFirstResponder];
+  }];
+}
+
+RCT_EXPORT_METHOD(blurView:(NSNumber *)reactTag)
+{
+  if (!reactTag) return;
+  [self addUIBlock:^(__unused RCTUIManager *uiManager, RCTSparseArray *viewRegistry){
+      [uiManager endEditingForShadowView:reactTag manager:uiManager viewRegistry:viewRegistry];
   }];
 }
 

--- a/React/Modules/RCTUIManager.m
+++ b/React/Modules/RCTUIManager.m
@@ -757,16 +757,16 @@ RCT_EXPORT_METHOD(manageChildren:(NSNumber *)containerReactTag
   }
 }
 
-- (void)endEditingForShadowView:(NSNumber *)reactTag manager:(RCTUIManager *)uiManager viewRegistry:(RCTSparseArray *)viewRegistry
+- (void)endEditingForShadowView:(NSNumber *)reactTag
 {
-  RCTShadowView *shadowView = uiManager.shadowViewRegistry[reactTag];
-
-  for(RCTShadowView *subview in [shadowView reactSubviews]) {
-    if([[subview reactSubviews] count] > 0) {
-      [uiManager endEditingForShadowView:subview.reactTag manager:uiManager viewRegistry:viewRegistry];
-    } else {
-      UIView *view = viewRegistry[subview.reactTag];
-      [view resignFirstResponder];
+  UIView *view = self.viewRegistry[reactTag];
+  if (view) {
+    [view endEditing:YES];
+  } else {
+    RCTShadowView *shadowView = self.shadowViewRegistry[reactTag];
+    // Recurse through the shadow hierarchy when the shadow view has no backing UIView
+    for (RCTShadowView *subview in [shadowView reactSubviews]) {
+      [self endEditingForShadowView:subview.reactTag];
     }
   }
 }
@@ -932,7 +932,7 @@ RCT_EXPORT_METHOD(blurView:(NSNumber *)reactTag)
 {
   if (!reactTag) return;
   [self addUIBlock:^(__unused RCTUIManager *uiManager, RCTSparseArray *viewRegistry){
-      [uiManager endEditingForShadowView:reactTag manager:uiManager viewRegistry:viewRegistry];
+    [uiManager endEditingForShadowView:reactTag];
   }];
 }
 


### PR DESCRIPTION
…ntainer - #113 

This adds the ability to call `this.refs.parentView.blur()` and blur any active text fields inside the view. It will first try to blur the field (already supported) and if the field is not found as an "active" text field, it will transverse the view and `resignFirstResponder` for each of them.

I am currently using it in my app and works well.