### PR TITLE
[Docs] Add dynamic page title

### DIFF
--- a/website/core/Site.js
+++ b/website/core/Site.js
@@ -14,14 +14,16 @@ var HeaderLinks = require('HeaderLinks');
 
 var Site = React.createClass({
   render: function() {
+    var title = this.props.title ? this.props.title + ' – ' : '';
+    title += 'React Native | A framework for building native apps using React';
     return (
       <html>
         <head>
           <meta charSet="utf-8" />
           <meta httpEquiv="X-UA-Compatible" content="IE=edge,chrome=1" />
-          <title>React Native | A framework for building native apps using React</title>
+          <title>{title}</title>
           <meta name="viewport" content="width=device-width" />
-          <meta property="og:title" content="React Native | A framework for building native apps using React" />
+          <meta property="og:title" content={title} />
           <meta property="og:type" content="website" />
           <meta property="og:url" content="http://facebook.github.io/react-native/index.html" />
           <meta property="og:image" content="http://facebook.github.io/react-native/img/opengraph.png?2" />

--- a/website/layout/AutodocsLayout.js
+++ b/website/layout/AutodocsLayout.js
@@ -338,7 +338,7 @@ var Autodocs = React.createClass({
       <APIDoc content={docs} />;
 
     return (
-      <Site section="docs">
+      <Site section="docs" title={metadata.title}>
         <section className="content wrap documentationContent">
           <DocsSidebar metadata={metadata} />
           <div className="inner-content">

--- a/website/layout/DocsLayout.js
+++ b/website/layout/DocsLayout.js
@@ -18,7 +18,7 @@ var DocsLayout = React.createClass({
     var metadata = this.props.metadata;
     var content = this.props.children;
     return (
-      <Site section="docs">
+      <Site section="docs" title={metadata.title}>
         <section className="content wrap documentationContent">
           <DocsSidebar metadata={metadata} />
           <div className="inner-content">

--- a/website/layout/PageLayout.js
+++ b/website/layout/PageLayout.js
@@ -18,7 +18,7 @@ var support = React.createClass({
     var metadata = this.props.metadata;
     var content = this.props.children;
     return (
-      <Site section={metadata.section}>
+      <Site section={metadata.section} title={metadata.title}>
         <section className="content wrap documentationContent nosidebar">
           <div className="inner-content">
             <Marked>{content}</Marked>

--- a/website/src/react-native/support.js
+++ b/website/src/react-native/support.js
@@ -15,7 +15,7 @@ var H2 = require('H2');
 var support = React.createClass({
   render: function() {
     return (
-      <Site section="support">
+      <Site section="support" title="Support">
 
         <section className="content wrap documentationContent nosidebar">
           <div className="inner-content">


### PR DESCRIPTION
This adds `title` to `Site` so a page title can be passed in and prepended to the default title (also applies to `og:title`.)

Before

![image](https://cloud.githubusercontent.com/assets/1153134/9026080/ea6a959c-3953-11e5-852c-a1b8c093962d.png)

After

![image](https://cloud.githubusercontent.com/assets/1153134/9026082/f9fb22a6-3953-11e5-9226-61aff224603a.png)