### PR TITLE
add path to error message when parsing invalid package.json

### DIFF
--- a/packager/react-packager/src/DependencyResolver/Package.js
+++ b/packager/react-packager/src/DependencyResolver/Package.js
@@ -73,8 +73,16 @@ class Package {
 
   _read() {
     if (!this._reading) {
+      var path = this.path;
       this._reading = this._fastfs.readFile(this.path)
-        .then(jsonStr => JSON.parse(jsonStr));
+        .then(jsonStr => {
+          try {
+            return JSON.parse(jsonStr);
+          } catch (e) {
+            e.message = 'Error while parsing ' + path + ': ' + e.message;
+            throw e;
+          }
+        });
     }
 
     return this._reading;


### PR DESCRIPTION
Previously, the error message was just 

    SyntaxError: Unexpected token <
        at Object.parse (native)
        ...

It wasn't clear that it was an invalid package.json file causing the SyntaxError.

This change makes it give the input file location with the error message

    SyntaxError: Error while parsing /path/to/package.json: Unexpected token <
        at Object.parse (native)
        ...