### PR TITLE
[ListView] Fix RCTScrollView stickyHeader touch passing.

### DIFF
--- a/React/Views/RCTScrollView.m
+++ b/React/Views/RCTScrollView.m
@@ -339,20 +339,16 @@ RCT_NOT_IMPLEMENTED(-init)
 
 - (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event
 {
-  __block UIView *stickyHeader;
+  __block UIView *hitView;
 
   [_stickyHeaderIndices enumerateIndexesWithOptions:0 usingBlock:^(NSUInteger idx, BOOL *stop) {
-    stickyHeader = [self contentView].reactSubviews[idx];
+    UIView *stickyHeader = [self contentView].reactSubviews[idx];
     CGPoint convertedPoint = [stickyHeader convertPoint:point fromView:self];
-
-    if ([stickyHeader hitTest:convertedPoint withEvent:event]) {
-      *stop = YES;
-    } else {
-      stickyHeader = nil;
-    }
+    hitView = [stickyHeader hitTest:convertedPoint withEvent:event];
+    *stop = (hitView != nil);
   }];
 
-  return stickyHeader ?: [super hitTest:point withEvent:event];
+  return hitView ?: [super hitTest:point withEvent:event];
 }
 
 @end


### PR DESCRIPTION
Point must be converted to the stickyHeader's coordinate space and then passed to the stickyHeaders hitTest:withEvent: method in order to be correctly routed to any subviews of the stickyHeader.

This resolves this [issue](https://github.com/facebook/react-native/issues/2075).