### PR TITLE
[RFC][Rendering] Add shouldRasterizeIOS to View components

### DIFF
--- a/Libraries/Components/View/View.js
+++ b/Libraries/Components/View/View.js
@@ -205,6 +205,21 @@ var View = React.createClass({
      * interaction/animation.
      */
     renderToHardwareTextureAndroid: PropTypes.bool,
+
+    /**
+     * Whether this view should be rendered as a bitmap before compositing.
+     *
+     * On iOS, this is useful for animations and interactions that do not
+     * modify this component's dimensions nor its children; for example, when
+     * translating the position of a static view, rasterization allows the
+     * renderer to reuse a cached bitmap of a static view and quickly composite
+     * it during each frame.
+     *
+     * Rasterization incurs an off-screen drawing pass and the bitmap consumes
+     * memory. Test and measure when using this property.
+     * @platform ios
+     */
+    shouldRasterizeIOS: PropTypes.bool,
   },
 
   render: function() {

--- a/Libraries/ReactNative/ReactNativeViewAttributes.js
+++ b/Libraries/ReactNative/ReactNativeViewAttributes.js
@@ -21,6 +21,7 @@ ReactNativeViewAttributes.UIView = {
   accessibilityLabel: true,
   accessibilityTraits: true,
   testID: true,
+  shouldRasterizeIOS: true,
   onLayout: true,
   onAccessibilityTap: true,
   onMagicTap: true,

--- a/React/Views/RCTViewManager.m
+++ b/React/Views/RCTViewManager.m
@@ -103,6 +103,11 @@ RCT_REMAP_VIEW_PROPERTY(shadowOffset, layer.shadowOffset, CGSize);
 RCT_REMAP_VIEW_PROPERTY(shadowOpacity, layer.shadowOpacity, float)
 RCT_REMAP_VIEW_PROPERTY(shadowRadius, layer.shadowRadius, CGFloat)
 RCT_REMAP_VIEW_PROPERTY(overflow, clipsToBounds, css_clip_t)
+RCT_CUSTOM_VIEW_PROPERTY(shouldRasterizeIOS, BOOL, RCTView)
+{
+  view.layer.shouldRasterize = json ? [RCTConvert BOOL:json] : defaultView.layer.shouldRasterize;
+  view.layer.rasterizationScale = view.layer.shouldRasterize ? view.window.screen.scale : defaultView.layer.rasterizationScale;
+}
 RCT_CUSTOM_VIEW_PROPERTY(transformMatrix, CATransform3D, RCTView)
 {
   view.layer.transform = json ? [RCTConvert CATransform3D:json] : defaultView.layer.transform;


### PR DESCRIPTION
Exposes the `shouldRasterize` property. Fixes #1986.