### PR TITLE
[Image] Fix default Image functionality

### DIFF
--- a/Libraries/Image/Image.ios.js
+++ b/Libraries/Image/Image.ios.js
@@ -173,7 +173,7 @@ var Image = React.createClass({
         resizeMode={resizeMode}
         tintColor={tintColor}
         src={source.uri}
-        defaultSrc={defaultSource.uri}
+        defaultImageSrc={defaultSource.uri}
       />
     );
   }

--- a/Libraries/Image/RCTImageView.m
+++ b/Libraries/Image/RCTImageView.m
@@ -69,7 +69,7 @@ RCT_NOT_IMPLEMENTED(-init)
 
 - (void)setImage:(UIImage *)image
 {
-  if (image != super.image) {
+  if (image != super.image || super.image == nil) {
     super.image = image ?: _defaultImage;
     [self _updateImage];
   }


### PR DESCRIPTION
In the latest 0.9.0-rc of React Native, the default image won't load due to a typo and a missing condition in `setImage`. This PR contains fixes for both of them.