### PR TITLE
Adds `process.env.NODE_ENV` polyfill

### DIFF
--- a/Libraries/JavaScriptAppEngine/Initialization/InitializeJavaScriptAppEngine.js
+++ b/Libraries/JavaScriptAppEngine/Initialization/InitializeJavaScriptAppEngine.js
@@ -128,6 +128,10 @@ function setupProfile() {
   require('BridgeProfiling').swizzleReactPerf();
 }
 
+function setUpProcessEnv() {
+  GLOBAL.process = {env: {NODE_ENV: __DEV__ ? 'development' : 'production'}};
+}
+
 setUpRedBoxErrorHandler();
 setUpTimers();
 setUpAlert();
@@ -137,3 +141,4 @@ setUpRedBoxConsoleErrorHandler();
 setUpGeolocation();
 setUpWebSockets();
 setupProfile();
+setUpProcessEnv();


### PR DESCRIPTION
There are many libraries that use `NODE_ENV` to check whether the code is running in
"production" mode or not. This allows those library authors to not have to add conditionals
for React Native.

One such library is Redux: https://github.com/gaearon/react-redux/pull/40

Thanks to @brentvatne for providing the solution via this tweet (via his phone in the airport :wink:): https://twitter.com/notbrent/status/630440250951749632

/cc @vjeux @gaearon @zpao @amasad