### PR TITLE
[docs] remove instructions to install node/io.js with brew

### DIFF
--- a/docs/EmbeddedApp.md
+++ b/docs/EmbeddedApp.md
@@ -13,8 +13,7 @@ Since React makes no assumptions about the rest of your technology stack – it�
 
 - [CocoaPods](http://cocoapods.org/) – `gem install cocoapods`
 - [io.js](http://iojs.org)
-  - **With nvm:** Install nvm with [its setup instructions here](https://github.com/creationix/nvm#installation). Then run `nvm install iojs-v2 && nvm alias default iojs-v2`, which installs the latest compatible version of io.js and sets up your terminal so that typing `node` runs io.js.  With nvm you can install multiple versions of Node and io.js and easily switch between them.
-  - **With Homebrew:** Run `brew install iojs && brew link iojs --force`. You may need to run `brew unlink node` if you have previously installed Node.
+  - Install **nvm** with [its setup instructions here](https://github.com/creationix/nvm#installation). Then run `nvm install iojs-v2 && nvm alias default iojs-v2`, which installs the latest compatible version of io.js and sets up your terminal so that typing `node` runs io.js.  With nvm you can install multiple versions of Node and io.js and easily switch between them.
 
 ## Install React Native Using CocoaPods
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -13,8 +13,7 @@ next: tutorial
 2. [Xcode](https://developer.apple.com/xcode/downloads/) 6.3 or higher is recommended.
 3. [Homebrew](http://brew.sh/) is the recommended way to install io.js, watchman, and flow.
 4. Install [io.js](https://iojs.org/) 1.0 or newer. io.js is the modern version of Node.
-  - **With nvm:** Install nvm with [its setup instructions here](https://github.com/creationix/nvm#installation). Then run `nvm install iojs-v2 && nvm alias default iojs-v2`, which installs the latest compatible version of io.js and sets up your terminal so that typing `node` runs io.js. With nvm you can install multiple versions of Node and io.js and easily switch between them.
-  - **With Homebrew:** Run `brew install iojs && brew link iojs --force`. You may need to run `brew unlink node` if you have previously installed Node.
+  - Install **nvm** with [its setup instructions here](https://github.com/creationix/nvm#installation). Then run `nvm install iojs-v2 && nvm alias default iojs-v2`, which installs the latest compatible version of io.js and sets up your terminal so that typing `node` runs io.js. With nvm you can install multiple versions of Node and io.js and easily switch between them.
   - New to [npm](https://docs.npmjs.com/)?
 5. `brew install watchman`. We recommend installing [watchman](https://facebook.github.io/watchman/docs/install.html), otherwise you might hit a node file watching bug.
 6. `brew install flow`. If you want to use [flow](http://www.flowtype.org).


### PR DESCRIPTION
nvm is way better than homebrew for managing node installations:

 - can install multiple versions
 - can choose which version of node to install
 - easy to clean up under ~/.nvm
 - there are still some rough edges with /usr/local on El Cap -- nvm avoids those altogether

cc @vjeux 