### PR TITLE
[TextInput] Fix multiline TextInput so text and cursor stay in bounds

### DIFF
--- a/Libraries/Text/RCTTextView.m
+++ b/Libraries/Text/RCTTextView.m
@@ -47,14 +47,25 @@ RCT_NOT_IMPLEMENTED(-initWithCoder:(NSCoder *)aDecoder)
 - (void)updateFrames
 {
   // Adjust the insets so that they are as close as possible to single-line
-  // RCTTextField defaults
-  UIEdgeInsets adjustedInset = (UIEdgeInsets){
-    _contentInset.top - 5, _contentInset.left - 4,
-    _contentInset.bottom, _contentInset.right
-  };
-
-  [_textView setFrame:UIEdgeInsetsInsetRect(self.bounds, adjustedInset)];
-  [_placeholderView setFrame:UIEdgeInsetsInsetRect(self.bounds, adjustedInset)];
+  // RCTTextField defaults, using the system defaults of font size 17 and a
+  // height of 31 points.
+  //
+  // We apply the left inset to the frame since a negative left text-container
+  // inset mysteriously causes the text to be hidden until the text view is
+  // first focused.
+  UIEdgeInsets adjustedFrameInset = UIEdgeInsetsZero;
+  adjustedFrameInset.left = _contentInset.left - 5;
+  
+  UIEdgeInsets adjustedTextContainerInset = _contentInset;
+  adjustedTextContainerInset.top += 5;
+  adjustedTextContainerInset.left = 0;
+  
+  CGRect frame = UIEdgeInsetsInsetRect(self.bounds, adjustedFrameInset);
+  _textView.frame = frame;
+  _placeholderView.frame = frame;
+  
+  _textView.textContainerInset = adjustedTextContainerInset;
+  _placeholderView.textContainerInset = adjustedTextContainerInset;
 }
 
 - (void)updatePlaceholder


### PR DESCRIPTION
With a multiline TextInput, the text is initially rendered correctly but once you try to edit it, the cursor slides off the top of the view and out of its bounds. Also if the TextInput is scrollable, you can scroll the text out of the bounds of the view, which looks buggy unless you clip the overflow. This occurs because the top content inset is applied to the RCTTextView instead of the UITextView's text container.

This diff fixes both bugs by applying the vertical insets to the UITextView's textContainerInset instead of the RCTTextView's frame (which is a wrapper around a real UITextView).

The left inset is still applied to the frame because there is a bug with the text rendering when the left textContainerInset is negative: the initial text doesn't show up until you focus the text view. The bug doesn't occur when setting the right textContainerInset, so I apply this workaround to only the left inset.

Test Plan: Enter multiple lines of text in the text view and see that vertically scrolling it doesn't scroll the text out of bounds at the top. Also check that focusing the text view doesn't cause the cursor to slide up anymore.

Rendering matches a single-line text field by default (`{fontSize: 17, height: 31}`). One is a text field and the other is a text view; they should look the same:

![comparison](https://cloud.githubusercontent.com/assets/379606/9193493/b0837724-3fc8-11e5-8034-c3ac8ef491d7.png)
