### PR TITLE
suggestion for #2271 with support for Build Configuration Release

### DIFF
--- a/Libraries/Sample/Sample.xcodeproj/project.pbxproj
+++ b/Libraries/Sample/Sample.xcodeproj/project.pbxproj
@@ -200,6 +200,7 @@
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)/../../React/**",
+					"$(SRCROOT)/../../react-native/React/**",
 					"$(SRCROOT)/../../node_modules/react-native/React/**",
 				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
@@ -216,6 +217,8 @@
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)/../../React/**",
+					"$(SRCROOT)/../../react-native/React/**",
+					"$(SRCROOT)/../../node_modules/react-native/React/**",
 				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = "-ObjC";


### PR DESCRIPTION
Suggestion for #2271: Extend the header search paths. Supports the build configuration `Release`, too.

What are your opinions? Would a hint in the docs be a better solution?
The only argument for updating `new-library` is, that the file structure, which is described in #2271, is fairly common.