### PR TITLE
Deleting dead code

### DIFF
--- a/packager/react-packager/src/DependencyResolver/index.js
+++ b/packager/react-packager/src/DependencyResolver/index.js
@@ -167,10 +167,6 @@ HasteDependencyResolver.prototype.wrapModule = function(module, code) {
   });
 };
 
-HasteDependencyResolver.prototype.getDebugInfo = function() {
-  return this._depGraph.getDebugInfo();
-};
-
 function defineModuleCode({moduleName, code, deps}) {
   return [
     `__d(`,

--- a/packager/react-packager/src/Packager/index.js
+++ b/packager/react-packager/src/Packager/index.js
@@ -182,10 +182,6 @@ Packager.prototype._transformModule = function(ppackage, module) {
   );
 };
 
-Packager.prototype.getGraphDebugInfo = function() {
-  return this._resolver.getDebugInfo();
-};
-
 Packager.prototype.generateAssetModule_DEPRECATED = function(ppackage, module) {
   return sizeOf(module.path).then(function(dimensions) {
     var img = {

--- a/packager/react-packager/src/Server/index.js
+++ b/packager/react-packager/src/Server/index.js
@@ -225,7 +225,6 @@ Server.prototype._processDebugRequest = function(reqUrl, res) {
   var parts = pathname.split('/').filter(Boolean);
   if (parts.length === 1) {
     ret += '<div><a href="/debug/packages">Cached Packages</a></div>';
-    ret += '<div><a href="/debug/graph">Dependency Graph</a></div>';
     res.end(ret);
   } else if (parts[1] === 'packages') {
     ret += '<h1> Cached Packages </h1>';
@@ -242,10 +241,6 @@ Server.prototype._processDebugRequest = function(reqUrl, res) {
         console.log(e.stack);
       }
     );
-  } else if (parts[1] === 'graph'){
-    ret += '<h1> Dependency Graph </h2>';
-    ret += this._packager.getGraphDebugInfo();
-    res.end(ret);
   } else {
     res.writeHead('404');
     res.end('Invalid debug request');


### PR DESCRIPTION
As part of the `DependencyGraph` rewrite in commit https://github.com/facebook/react-native/commit/0deb9d2bc5296e3c1b6e48eadd613f2efb2f955c, the `DependecyGraph.prototype.getDebugInfo` method was deleted and wasn't replaced. This resulted in some dead code that should be cleaned up.