### PR TITLE
[Push notifications] Fix for IOS 8

### DIFF
--- a/Libraries/PushNotificationIOS/RCTPushNotificationManager.m
+++ b/Libraries/PushNotificationIOS/RCTPushNotificationManager.m
@@ -157,13 +157,13 @@ RCT_EXPORT_METHOD(requestPermissions:(NSDictionary *)permissions)
   }
 
   UIApplication *app = RCTSharedApplication();
-#if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_8_0
-  id notificationSettings = [UIUserNotificationSettings settingsForTypes:types categories:nil];
-  [app registerUserNotificationSettings:notificationSettings];
-  [app registerForRemoteNotifications];
-#else
-  [app registerForRemoteNotificationTypes:types];
-#endif
+  if ([app respondsToSelector:@selector(registerUserNotificationSettings:)]) {
+    UIUserNotificationSettings *notificationSettings = [UIUserNotificationSettings settingsForTypes:(NSUInteger)types categories:nil];
+    [app registerUserNotificationSettings:notificationSettings];
+    [app registerForRemoteNotifications];
+  } else {
+    [app registerForRemoteNotificationTypes:(NSUInteger)types];
+  }
 }
 
 RCT_EXPORT_METHOD(abandonPermissions)


### PR DESCRIPTION
**Problem**
Using push notifications in IOS 8 will throw this error:
`registerForRemoteNotificationTypes: is not supported in iOS 8.0 and later.`
The problem is that the check is running on compile instead of runtime.

**Solution**
If have changed the compile if statement to a runtime if statement. The fix is tested on: IOS 7.1 and 8.* and everything is working now.
This solution is also discussed in: https://github.com/facebook/react-native/issues/1613 and it was part of  https://github.com/facebook/react-native/pull/1979. (is being separated to keep things moving)

Please let me know what you think.