### PR TITLE
[TextInput] Set scrollsToTop = NO for UITextViews

### DIFF
--- a/Libraries/Text/RCTTextView.m
+++ b/Libraries/Text/RCTTextView.m
@@ -35,6 +35,7 @@
 
     _textView = [[UITextView alloc] initWithFrame:self.bounds];
     _textView.backgroundColor = [UIColor clearColor];
+    _textView.scrollsToTop = NO;
     _textView.delegate = self;
     [self addSubview:_textView];
   }


### PR DESCRIPTION
Now that UITextViews have a delegate, they consume the "tap to scroll to top" gesture. This diff restores the original behavior of letting the top-level scroll view (if any) scroll to top instead.

I tried exposing scrollsToTop as a prop and was semi-successful in that I could turn scroll-to-top on and off for the top-level scroll view scroll, but the text view itself would never scroll to top. So instead of exposing it as a prop, this diff sets scrollsToTop always to NO, which is how TextInput behaved previously.

Test Plan: In the UIExplorer go to the TextInput demo. Scroll down a bit and tap the status bar to verify that scroll-to-top is working again.