### PR TITLE
[Pushnotifications] Add error event

### DIFF
--- a/Libraries/PushNotificationIOS/PushNotificationIOS.js
+++ b/Libraries/PushNotificationIOS/PushNotificationIOS.js
@@ -112,7 +112,7 @@ class PushNotificationIOS {
         NOTIF_REGISTER_ERROR_EVENT,
         (registrationError) => {
           var key = Object.keys(registrationError)[0]; 
-          handler(key, registrationError[key]);
+          handler(registrationError[key], key);
         }
       );
     }

--- a/Libraries/PushNotificationIOS/PushNotificationIOS.js
+++ b/Libraries/PushNotificationIOS/PushNotificationIOS.js
@@ -22,6 +22,7 @@ var _initialNotification = RCTPushNotificationManager &&
 
 var DEVICE_NOTIF_EVENT = 'remoteNotificationReceived';
 var NOTIF_REGISTER_EVENT = 'remoteNotificationsRegistered';
+var NOTIF_REGISTER_ERROR_EVENT = 'remoteNotificationsRegisteredError';
 
 /**
  * Handle push notifications for your app, including permission handling and
@@ -88,8 +89,8 @@ class PushNotificationIOS {
    */
   static addEventListener(type: string, handler: Function) {
     invariant(
-      type === 'notification' || type === 'register',
-      'PushNotificationIOS only supports `notification` and `register` events'
+      type === 'notification' || type === 'register' || type === 'error',
+      'PushNotificationIOS only supports `notification`, `register` and `error` events'
     );
     var listener;
     if (type === 'notification') {
@@ -104,6 +105,14 @@ class PushNotificationIOS {
         NOTIF_REGISTER_EVENT,
         (registrationInfo) => {
           handler(registrationInfo.deviceToken);
+        }
+      );
+    } else if(type === 'error'){
+      listener = RCTDeviceEventEmitter.addListener(
+        NOTIF_REGISTER_ERROR_EVENT,
+        (registrationError) => {
+          var key = Object.keys(registrationError)[0]; 
+          handler(key, registrationError[key]);
         }
       );
     }
@@ -180,8 +189,8 @@ class PushNotificationIOS {
    */
   static removeEventListener(type: string, handler: Function) {
     invariant(
-      type === 'notification' || type === 'register',
-      'PushNotificationIOS only supports `notification` and `register` events'
+      type === 'notification' || type === 'register' || type === 'error',
+      'PushNotificationIOS only supports `notification`, `register` and `error` events'
     );
     var listener = _notifHandlers.get(handler);
     if (!listener) {

--- a/Libraries/PushNotificationIOS/PushNotificationIOS.js
+++ b/Libraries/PushNotificationIOS/PushNotificationIOS.js
@@ -111,7 +111,10 @@ class PushNotificationIOS {
       listener = RCTDeviceEventEmitter.addListener(
         NOTIF_REGISTER_ERROR_EVENT,
         (registrationError) => {
-          var key = Object.keys(registrationError)[0]; 
+          var key = Object.keys(registrationError)[0] || null;
+          if(!key){
+              return;
+          }
           handler(registrationError[key], key);
         }
       );

--- a/Libraries/PushNotificationIOS/RCTPushNotificationManager.h
+++ b/Libraries/PushNotificationIOS/RCTPushNotificationManager.h
@@ -16,5 +16,6 @@
 + (void)application:(UIApplication *)application didRegisterUserNotificationSettings:(UIUserNotificationSettings *)notificationSettings;
 + (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken;
 + (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)notification;
++ (void)application:(UIApplication *)application didFailToRegisterForRemoteNotificationsWithError:(NSError *)error;
 
 @end


### PR DESCRIPTION
This PR will add an `error` event to `PushNotificationIOS`. 

**How it works**
When something goes wrong with the Push notifications, for example running on a simulator or when the certificates aren't configured the right way, IOS will create an error and pass it to `didFailToRegisterForRemoteNotificationsWithError`. This error consists out of an key and a message. This error is passed down from IOS to Js and when there is an error event registered in JS it will pass the error. When there isn't an error event registered nothing will happen.

**Why is this useful?**
At the moment `PushNotificationIOS` fails silently and there is no way of telling if something went wrong. Therefore some people are having trouble to get push notifications working in react-native. 

**How to use**
The error event can be used just like the `register` and the `notification` event.
The error callback will give the error `message` and the error `key`. Both are the original IOS error.
```js
// Javascript:
PushNotificationIOS.addEventListener('error', function(message, key){
   console.log('An error occurred: ', message);
});
PushNotificationIOS.addEventListener('register', function(token){
   console.log('You are registered and the device token is: ',token)
});
PushNotificationIOS.requestPermissions();
```

And add this to the `AppDelegate.m` besides the normal pushnotifications code:
```objective-c
- (void)application:(UIApplication *)application didFailToRegisterForRemoteNotificationsWithError:(NSError *)error
{
  [RCTPushNotificationManager application:application didFailToRegisterForRemoteNotificationsWithError:error];
}
``` 

**Similar PR**
A similar solution PR exists: https://github.com/facebook/react-native/pull/1019
This PR uses a callback as a parameter in `requestPermissions` and it will give you a token or an error.
I prefer the solution is this PR because it is:
* more in line with the react-native Api.
* less potential spaghetti code
* I have used this in an proof of concept app and I prefer the event over the callback.

**References**
This PR was part of https://github.com/facebook/react-native/pull/1979 and it is discussed here: https://github.com/facebook/react-native/issues/1613.

This event should be added to the docs. Can anyone tell me how accomplish this?

Please let me know what you think.