### PR TITLE
[jest] Update jest-cli version to 0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "yargs": "1.3.2"
   },
   "devDependencies": {
-    "jest-cli": "facebook/jest#0.5.x",
+    "jest-cli": "0.5.0",
     "babel-eslint": "3.1.5",
     "eslint": "0.21.2",
     "eslint-plugin-react": "2.3.0"


### PR DESCRIPTION
npm install will get a little nicer since it can read from npm instead of always having to redownload from github.

cc @cpojer 