### PR TITLE
[Fetch]self should point to the global object instead of empty object

### DIFF
--- a/Libraries/Fetch/fetch.js
+++ b/Libraries/Fetch/fetch.js
@@ -17,13 +17,13 @@
 
 if(typeof self === 'undefined'){
   if(typeof global !== 'undefined'){
-    self = global;
+    global.self = global;
   }
   else if(typeof window !== 'undefined'){
-    self = window;
+    window.self = window;
   }
   else{
-    self = {};
+    var self = {};
   }
 }
 

--- a/Libraries/Fetch/fetch.js
+++ b/Libraries/Fetch/fetch.js
@@ -15,7 +15,17 @@
 /* eslint-disable */
 'use strict';
 
-var self = {};
+if(typeof self === 'undefined'){
+  if(typeof global !== 'undefined'){
+    self = global;
+  }
+  else if(typeof window !== 'undefined'){
+    self = window;
+  }
+  else{
+    self = {};
+  }
+}
 
 /**
  * Copyright (c) 2014 GitHub, Inc.


### PR DESCRIPTION
with the original empty object assigned to self, the native fetch api implemented by V8 runtime can never be detected, and support for formdata and blob will always return false.