### PR TITLE
add Navigator sceneConfig to match iOS

### DIFF
--- a/Examples/UIExplorer/Navigator/NavigatorExample.js
+++ b/Examples/UIExplorer/Navigator/NavigatorExample.js
@@ -56,6 +56,15 @@ class NavMenu extends React.Component {
         <NavButton
           onPress={() => {
             this.props.navigator.push({
+              message: 'Swipe right to dismiss',
+              sceneConfig: Navigator.SceneConfigs.PushFromRightIOS,
+            });
+          }}
+          text="Push from right (matches iOS shadow)"
+        />
+        <NavButton
+          onPress={() => {
+            this.props.navigator.push({
               message: 'Swipe down to dismiss',
               sceneConfig: Navigator.SceneConfigs.FloatFromBottom,
             });
@@ -136,6 +145,7 @@ var TabBarExample = React.createClass({
         style={styles.container}
         initialRoute={{ message: "First Scene", }}
         renderScene={this.renderScene}
+        sceneStyle={{ overflow: 'visible' }}
         configureScene={(route) => {
           if (route.sceneConfig) {
             return route.sceneConfig;

--- a/Libraries/CustomComponents/Navigator/NavigatorSceneConfigs.js
+++ b/Libraries/CustomComponents/Navigator/NavigatorSceneConfigs.js
@@ -101,6 +101,36 @@ var FadeToTheLeft = {
   },
 };
 
+var FadeToTheLeftIOS = {
+  transformTranslate: {
+    from: {x: 0, y: 0, z: 0},
+    to: {x: -Math.round(Dimensions.get('window').width * 0.3), y: 0, z: 0},
+    min: 0,
+    max: 1,
+    type: 'linear',
+    extrapolate: true,
+    round: PixelRatio.get(),
+  },
+  opacity: {
+    from: 1,
+    to: 0.3,
+    min: 0,
+    max: 1,
+    type: 'linear',
+    extrapolate: false,
+    round: 100,
+  },
+  translateX: {
+    from: 0,
+    to: -Math.round(Dimensions.get('window').width * 0.3),
+    min: 0,
+    max: 1,
+    type: 'linear',
+    extrapolate: true,
+    round: PixelRatio.get(),
+  },
+};
+
 var FadeToTheRight = {
   ...FadeToTheLeft,
   transformTranslate: {
@@ -246,6 +276,31 @@ var FromTheRight = {
   scaleY: {
     value: 1,
     type: 'constant',
+  },
+};
+
+var FromTheRightIOS = {
+  ...FromTheRight,
+  shadowColor: {
+    value: '#000000',
+    type: 'constant',
+  },
+  shadowOpacity: {
+    from: 0.1,
+    to: 0.5,
+    min: 0,
+    max: 1,
+    type: 'linear',
+    extrapolate: false,
+    round: 100,
+  },
+  shadowRadius: {
+    from: 2,
+    to: 6,
+    min: 0,
+    max: 1,
+    type: 'linear',
+    extrapolate: true,
   },
 };
 
@@ -508,6 +563,18 @@ var NavigatorSceneConfigs = {
   PushFromRight: {
     ...BaseConfig,
     // We will want to customize this soon
+  },
+  PushFromRightIOS: {
+    ...BaseConfig,
+    // We will want to customize this soon
+    gestures: {
+      jumpBack: BaseLeftToRightGesture,
+      jumpForward: BaseRightToLeftGesture,
+    },
+    animationInterpolators: {
+      into: buildStyleInterpolator(FromTheRightIOS),
+      out: buildStyleInterpolator(FadeToTheLeftIOS),
+    },
   },
   FloatFromRight: {
     ...BaseConfig,


### PR DESCRIPTION
Issue: https://github.com/facebook/react-native/issues/2301

Add `PushFromRightIOS` sceneConfig that attempts to match the native iOS shadow (and no scale as closely as possible.