### PR TITLE
customizable thumb for the `SliderIOS` component

### DIFF
--- a/Libraries/Components/SliderIOS/SliderIOS.ios.js
+++ b/Libraries/Components/SliderIOS/SliderIOS.ios.js
@@ -16,13 +16,22 @@ var PropTypes = require('ReactPropTypes');
 var React = require('React');
 var StyleSheet = require('StyleSheet');
 var View = require('View');
+var Image = require('Image');
 
 var requireNativeComponent = require('requireNativeComponent');
 
 type Event = Object;
 
+var Constants =
+{
+  SLIDER_HEIGHT_DEFAULT: 40
+};
+Object.freeze(Constants);
+
 var SliderIOS = React.createClass({
   mixins: [NativeMethodsMixin],
+  
+  sliderHeight: Constants.SLIDER_HEIGHT_DEFAULT,
 
   propTypes: {
     /**
@@ -67,6 +76,11 @@ var SliderIOS = React.createClass({
      * Callback continuously called while the user is dragging the slider.
      */
     onValueChange: PropTypes.func,
+    
+    /**
+     * A custom thumb icon for the slider. If no icon is supplied the default thumb is used.
+     */
+    thumb: Image.propTypes.source,
 
     /**
      * Callback called when the user finishes changing the value (e.g. when
@@ -87,23 +101,34 @@ var SliderIOS = React.createClass({
   },
 
   render: function() {
+    // Check if a thumb has been overgiven via the properties and if the thumb's height exceeds the slider's height.
+    if ((this.props.thumb !== undefined) && (this.props.thumb !== null))
+    {
+      if (this.props.thumb.height > this.sliderHeight)
+      {
+        this.sliderHeight = this.props.thumb.height;
+      }
+    }
+
     return (
       <RCTSlider
-        style={[styles.slider, this.props.style]}
+        style={[{ height: this.sliderHeight }, this.props.style]}
         value={this.props.value}
         maximumValue={this.props.maximumValue}
         minimumValue={this.props.minimumValue}
         minimumTrackTintColor={this.props.minimumTrackTintColor}
         maximumTrackTintColor={this.props.maximumTrackTintColor}
+        thumb={this.props.thumb}
         onChange={this._onValueChange}
       />
     );
   }
 });
 
+// TODO: remove if not needed anymore
 var styles = StyleSheet.create({
   slider: {
-    height: 40,
+    height: this.sliderHeight,
   },
 });
 

--- a/Libraries/Components/SliderIOS/SliderIOS.ios.js
+++ b/Libraries/Components/SliderIOS/SliderIOS.ios.js
@@ -78,7 +78,7 @@ var SliderIOS = React.createClass({
     onValueChange: PropTypes.func,
     
     /**
-     * A custom thumb icon for the slider. If no icon is supplied the default thumb is used.
+     * A custom thumb icon for the slider. If no icon is supplied the default thumb is used. Please note that the used approach does not allow you to set the thumb's height and width
      */
     thumb: Image.propTypes.source,
 

--- a/React/Views/RCTSlider.m
+++ b/React/Views/RCTSlider.m
@@ -8,6 +8,7 @@
  */
 
 #import "RCTSlider.h"
+#import "RCTConvert.h"
 
 @implementation RCTSlider
 {
@@ -30,6 +31,13 @@
 {
   super.maximumValue = maximumValue;
   super.value = _unclippedValue;
+}
+
+- (void) setThumb: (id) thumbImage
+{
+  UIImage* newThumb = [RCTConvert UIImage: thumbImage];
+  [super setThumbImage: newThumb forState: UIControlStateNormal];
+  [super setThumbImage: newThumb forState: UIControlStateSelected];
 }
 
 @end

--- a/React/Views/RCTSliderManager.m
+++ b/React/Views/RCTSliderManager.m
@@ -53,5 +53,6 @@ RCT_EXPORT_VIEW_PROPERTY(minimumValue, float);
 RCT_EXPORT_VIEW_PROPERTY(maximumValue, float);
 RCT_EXPORT_VIEW_PROPERTY(minimumTrackTintColor, UIColor);
 RCT_EXPORT_VIEW_PROPERTY(maximumTrackTintColor, UIColor);
+RCT_EXPORT_VIEW_PROPERTY(thumb, id);
 
 @end


### PR DESCRIPTION
Hi,

Having worked on a project I needed a custom thumb image which is currently not supported by the `SliderIOS` component. Thus, I extended the component so that a custom thumb can be specified by using a static asset for instance.

If no height is specified in the style the slider's height is either the default height (40px) or the image's height if the latter one exceeds the default height.

However, having followed your implementation of the component `TabBarIOS.Item` my solution currently only passes the source of the image from the JavaScript code to the native code. Being willing to further optimise it I would be most grateful if you could provide some links helping me. As a workaround I have been able to circumvent this issue by using the `PixelRatio` API:

	slider:
	{
		...,
		height: 20 * PixelRatio.get(),
		...
	}