### PR TITLE
Add support for launching packager when path contains spaces

### DIFF
--- a/React/React.xcodeproj/project.pbxproj
+++ b/React/React.xcodeproj/project.pbxproj
@@ -564,7 +564,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if nc -w 5 -z localhost 8081 ; then\n  if ! curl -s \"http://localhost:8081/status\" | grep -q \"packager-status:running\" ; then\n    echo \"Port 8081 already in use, packager is either not running or not running correctly\"\n    exit 2\n  fi\nelse\n  open $SRCROOT/../packager/launchPackager.command || echo \"Can't start packager automatically\"\nfi";
+			shellScript = "if nc -w 5 -z localhost 8081 ; then\n  if ! curl -s \"http://localhost:8081/status\" | grep -q \"packager-status:running\" ; then\n    echo \"Port 8081 already in use, packager is either not running or not running correctly\"\n    exit 2\n  fi\nelse\n  open "$SRCROOT/../packager/launchPackager.command" || echo \"Can't start packager automatically\"\nfi";
 		};
 		142C4F7F1B582EA6001F0B58 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/packager/launchPackager.command
+++ b/packager/launchPackager.command
@@ -12,6 +12,6 @@ echo -en "\033]0;React Packager\a"
 clear
 
 THIS_DIR=$(dirname "$0")
-$THIS_DIR/packager.sh
+"$THIS_DIR/packager.sh"
 echo "Process terminated. Press <enter> to close the window"
 read


### PR DESCRIPTION
I moved a project I was working on to another machine and noticed that the packager wasn't automatically launching when I would build. I investigated a little and determined that it was because the directory structure on the new machine contains spaces. This patch resolves the issue for me.