### PR TITLE
[Travis] Put $PWD in front of nvm  (fixes npm install)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,7 @@ install:
   - rm -Rf `node -p "require('os').tmpDir()"`/jest_preprocess_cache
   - npm install -g flow-bin@`node -p "require('fs').readFileSync('.flowconfig', 'utf8').split('[version]')[1].trim()"`
   - mkdir -p .nvm
-  - cp $(brew --prefix nvm)/nvm-exec .nvm/
-  - export NVM_DIR=.nvm
+  - export NVM_DIR="$PWD/.nvm"
   - source $(brew --prefix nvm)/nvm.sh
   - nvm install iojs-v2
   - nvm use iojs-v2


### PR DESCRIPTION
There was a problem where NVM_DIR wasn't correctly configured, which meant that `npm install` was using whatever version of Node was on the system (0.12 in this case) despite having run `nvm use iojs-v2`. Fixing up NVM_DIR fixes the `npm install` errors and builds the native npm packages for the right version of Node.