### PR TITLE
[Idea] Selectively expose native modules to different JS bridges

### DIFF
--- a/React/Base/RCTBatchedBridge.m
+++ b/React/Base/RCTBatchedBridge.m
@@ -238,6 +238,13 @@ id<RCTJavaScriptExecutor> RCTGetLatestExecutor(void)
      // Check if module instance has already been registered for this name
      id<RCTBridgeModule> module = modulesByName[moduleName];
 
+     if ([moduleClass respondsToSelector:@selector(allowedBridgeIDs)]) {
+       NSString *bridgeID = self.parentBridge.launchOptions[@"bridgeID"];
+       if (![[moduleClass allowedBridgeIDs] containsObject:bridgeID]) {
+         continue;
+       }
+     }
+      
      if (module) {
        // Preregistered instances takes precedence, no questions asked
        if (!preregisteredModules[moduleName]) {

--- a/React/Base/RCTBridgeModule.h
+++ b/React/Base/RCTBridgeModule.h
@@ -223,4 +223,10 @@ extern dispatch_queue_t RCTJSThread;
  */
 - (void)batchDidComplete;
 
+/**
+ * Array of acceptable bridgeIDs to expose this module to. Do not override to 
+ * expose module to any bridge.
+ */
++ (NSArray *)allowedBridgeIDs;
+
 @end


### PR DESCRIPTION
This is experimental. Wanted the discussion going around this - about how to selectively expose modules to JS. Think sandboxing - but for JS bundles within your app.

Each bridge gets a `bridgeID`. Native modules can opt-in to a whitelist of bridges `allowedBridgeIDs` they want to be exposed on. 

Sandboxing for JS:
1. Different parts of the app run different JS bundles and need access to a different group of native modules exposed.
2. To run code that does not belong to first party and hence not expose sensitive APIs/data from the native modules to a separate bridge dedicated to third party JS code.