### PR TITLE
[Travis] Update CI to run with Xcode 6.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: objective-c
 
-osx_image: beta-xcode6.3
+osx_image: xcode6.4
 
 cache:
     directories:

--- a/scripts/objc-test.sh
+++ b/scripts/objc-test.sh
@@ -28,5 +28,5 @@ node ./packager/packager.js --nonPersistent &
 SERVER_PID=$!
 xctool \
   -project Examples/UIExplorer/UIExplorer.xcodeproj \
-  -scheme UIExplorer -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 5,OS=8.3' \
+  -scheme UIExplorer -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 5,OS=8.4' \
   test


### PR DESCRIPTION
Use Xcode 6.4 instead of Travis' beta support for 6.3.