### PR TITLE
[RN Debugger] Don't try to handle messages without a method

### DIFF
--- a/packager/debugger.html
+++ b/packager/debugger.html
@@ -85,6 +85,10 @@ function connectToDebuggerProxy() {
 
   ws.onmessage = function(message) {
     var object = JSON.parse(message.data);
+    if (!object.method) {
+      return;
+    }
+
     var sendReply = function(result) {
       ws.send(JSON.stringify({replyID: object.id, result: result}));
     };


### PR DESCRIPTION
Some messages are special and are intended for the devtools, like `{$open: id}` and `{$error: id}`. The main debugger-ui page can't handle these and thinks something is wrong when `object.method` is undefined. This diff handles messages only if they specify a method.

Fixes #2377

Test Plan: Run UIExplorer with the Chrome debugger and reload the app. See no more warning about "Unknown method: undefined".