### PR TITLE
[Text] Add Drop Shadow Style to Text Component

### DIFF
--- a/Libraries/Text/RCTShadowText.h
+++ b/Libraries/Text/RCTShadowText.h
@@ -32,6 +32,10 @@ extern NSString *const RCTReactTagAttributeName;
 @property (nonatomic, assign) RCTTextDecorationLineType textDecorationLine;
 @property (nonatomic, assign) CGFloat fontSizeMultiplier;
 @property (nonatomic, assign) BOOL allowFontScaling;
+@property (nonatomic, strong) UIColor *textShadowColor;
+@property (nonatomic, assign) CGFloat textShadowOpacity;
+@property (nonatomic, assign) CGSize textShadowOffset;
+@property (nonatomic, assign) CGFloat textShadowRadius;
 
 - (void)recomputeText;
 

--- a/Libraries/Text/RCTShadowText.m
+++ b/Libraries/Text/RCTShadowText.m
@@ -54,6 +54,7 @@ static css_dim_t RCTMeasure(void *context, float width)
     _letterSpacing = NAN;
     _isHighlighted = NO;
     _textDecorationStyle = NSUnderlineStyleSingle;
+    _textShadowOpacity = NAN;
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(contentSizeMultiplierDidChange:)
                                                  name:RCTUIManagerWillUpdateViewsDueToContentSizeMultiplierChangeNotification
@@ -180,7 +181,7 @@ static css_dim_t RCTMeasure(void *context, float width)
   if (!isnan(_letterSpacing)) {
     letterSpacing = @(_letterSpacing);
   }
-
+  
   _effectiveLetterSpacing = letterSpacing.doubleValue;
 
   NSMutableAttributedString *attributedString = [[NSMutableAttributedString alloc] init];
@@ -201,6 +202,22 @@ static css_dim_t RCTMeasure(void *context, float width)
   if (_color) {
     [self _addAttribute:NSForegroundColorAttributeName withValue:_color toAttributedString:attributedString];
   }
+  
+  if (!isnan(_textShadowOpacity)) {
+      NSShadow *shadow = [[NSShadow alloc] init];
+      
+      if (_textShadowColor) {
+        shadow.shadowColor = [_textShadowColor colorWithAlphaComponent:_textShadowOpacity];
+      }
+      if (!_textShadowOpacity) {
+        shadow.shadowColor = [UIColor clearColor];
+      }
+      shadow.shadowBlurRadius = _textShadowRadius;
+      shadow.shadowOffset = _textShadowOffset;
+      
+      [self _addAttribute:NSShadowAttributeName withValue:shadow toAttributedString:attributedString];
+   }
+  
   if (_isHighlighted) {
     [self _addAttribute:RCTIsHighlightedAttributeName withValue:@YES toAttributedString:attributedString];
   }
@@ -342,6 +359,10 @@ RCT_TEXT_PROPERTY(TextDecorationColor, _textDecorationColor, UIColor *);
 RCT_TEXT_PROPERTY(TextDecorationLine, _textDecorationLine, RCTTextDecorationLineType);
 RCT_TEXT_PROPERTY(TextDecorationStyle, _textDecorationStyle, NSUnderlineStyle);
 RCT_TEXT_PROPERTY(WritingDirection, _writingDirection, NSWritingDirection)
+RCT_TEXT_PROPERTY(TextShadowOpacity, _textShadowOpacity, CGFloat)
+RCT_TEXT_PROPERTY(TextShadowColor, _textShadowColor, UIColor *)
+RCT_TEXT_PROPERTY(TextShadowOffset, _textShadowOffset, CGSize)
+RCT_TEXT_PROPERTY(TextShadowRadius, _textShadowRadius, CGFloat)
 
 - (void)setAllowFontScaling:(BOOL)allowFontScaling
 {

--- a/Libraries/Text/RCTShadowText.m
+++ b/Libraries/Text/RCTShadowText.m
@@ -181,7 +181,7 @@ static css_dim_t RCTMeasure(void *context, float width)
   if (!isnan(_letterSpacing)) {
     letterSpacing = @(_letterSpacing);
   }
-  
+
   _effectiveLetterSpacing = letterSpacing.doubleValue;
 
   NSMutableAttributedString *attributedString = [[NSMutableAttributedString alloc] init];
@@ -204,7 +204,7 @@ static css_dim_t RCTMeasure(void *context, float width)
   }
   
   if (!isnan(_textShadowOpacity)) {
-      NSShadow *shadow = [[NSShadow alloc] init];
+      NSShadow *shadow = [NSShadow new];
       
       if (_textShadowColor) {
         shadow.shadowColor = [_textShadowColor colorWithAlphaComponent:_textShadowOpacity];

--- a/Libraries/Text/RCTTextManager.m
+++ b/Libraries/Text/RCTTextManager.m
@@ -51,6 +51,10 @@ RCT_EXPORT_SHADOW_PROPERTY(textDecorationColor, UIColor)
 RCT_EXPORT_SHADOW_PROPERTY(textDecorationLine, RCTTextDecorationLineType)
 RCT_EXPORT_SHADOW_PROPERTY(writingDirection, NSWritingDirection)
 RCT_EXPORT_SHADOW_PROPERTY(allowFontScaling, BOOL)
+RCT_EXPORT_SHADOW_PROPERTY(textShadowOpacity, CGFloat)
+RCT_EXPORT_SHADOW_PROPERTY(textShadowColor, UIColor *)
+RCT_EXPORT_SHADOW_PROPERTY(textShadowOffset, CGSize)
+RCT_EXPORT_SHADOW_PROPERTY(textShadowRadius, CGFloat)
 
 - (RCTViewManagerUIBlock)uiBlockToAmendWithShadowViewRegistry:(RCTSparseArray *)shadowViewRegistry
 {

--- a/Libraries/Text/TextStylePropTypes.js
+++ b/Libraries/Text/TextStylePropTypes.js
@@ -62,6 +62,24 @@ var TextStylePropTypes = Object.assign(Object.create(ViewStylePropTypes), {
   writingDirection: ReactPropTypes.oneOf(
     ['auto' /*default*/, 'ltr', 'rtl']
   ),
+  /**
+   * @platform ios
+   */
+  textShadowOpacity: ReactPropTypes.number,
+  /**
+   * @platform ios
+   */
+  textShadowColor: ReactPropTypes.string,
+  /**
+   * @platform ios
+   */
+  textShadowOffset: ReactPropTypes.shape(
+     {width: ReactPropTypes.number, height: ReactPropTypes.number}
+   ),
+  /**
+   * @platform ios
+   */
+  textShadowRadius: ReactPropTypes.number,
 });
 
 // Text doesn't support padding correctly (#4841912)


### PR DESCRIPTION
![dropshadow](https://cloud.githubusercontent.com/assets/5883925/9426444/a2f0961e-490f-11e5-89b6-65bd3f0aa342.png)

Adds four new styles to the Text component: `textShadowOpacity`,` textShadowColor`, `textShadowOffset` and `textShadowRadius`. They are nearly identical to the correspondingly named view shadow properties.
