### PR TITLE
[ScrollView] Shouldn't become responder if scrollEnabled is false

### DIFF
--- a/Libraries/Components/ScrollResponder.js
+++ b/Libraries/Components/ScrollResponder.js
@@ -135,7 +135,7 @@ var ScrollResponderMixin = {
    * Invoke this from an `onScroll` event.
    */
   scrollResponderHandleScrollShouldSetResponder: function(): boolean {
-    return this.state.isTouching;
+    return this.state.isTouching && this.props.scrollEnabled;
   },
 
   /**
@@ -200,7 +200,10 @@ var ScrollResponderMixin = {
    * a touch has already started.
    */
   scrollResponderHandleResponderReject: function() {
-    warning(false, "ScrollView doesn't take rejection well - scrolls anyway");
+    if(this.props.scrollEnabled) {
+      warning(false, "ScrollView doesn't take rejection well - scrolls anyway");
+    }
+
   },
 
   /**
@@ -219,7 +222,7 @@ var ScrollResponderMixin = {
    *   rejected.
    */
   scrollResponderHandleTerminationRequest: function(): boolean {
-    return !this.state.observedScrollSinceBecomingResponder;
+    return !this.state.observedScrollSinceBecomingResponder || !this.props.scrollEnabled;
   },
 
   /**


### PR DESCRIPTION
Addresses: #2411

Using the scrollTo method to programmatically scroll a scrollView causes
it to mistakenly think a user-initiated scroll event occurred, so it
tries to steal the responder status from another active responder.