### PR TITLE
Don't report failures to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "scripts": {
     "test": "jest",
     "lint": "node linter.js Examples/ Libraries/",
-    "start": "./packager/packager.sh"
+    "start": "./packager/packager.sh || true"
   },
   "bin": {
     "react-native-start": "packager/packager.sh"


### PR DESCRIPTION
This suppresses this output from npm:

```
npm ERR! Failed at the react-native@0.9.0 start script './packager/packager.sh'.
npm ERR! This is most likely a problem with the react-native package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     ./packager/packager.sh
npm ERR! You can get their info via:
npm ERR!     npm owner ls react-native
```

We don't seem to have any automated scripts that rely on the exit code of npm start (or even call it at all).