### PR TITLE
Changing Linked Libraries URI to point to the right page

### DIFF
--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -78,7 +78,7 @@ pod 'React', :subspecs => [
 ```
 Next, make sure you have run `pod install` and that a `Pods/` directory has been created in your project with React installed. CocoaPods will instruct you to use the generated `.xcworkspace` file henceforth to be able to use these installed dependencies.
 
-If you are adding React manually, make sure you have included all the relevant dependencies, like `RCTText.xcodeproj`, `RCTImage.xcodeproj` depending on the ones you are using. Next, the binaries built by these dependencies have to be linked to your app binary. Use the `Linked Frameworks and Binaries` section in the Xcode project settings. More detailed steps are here: [Linking Libraries](https://facebook.github.io/react-native/docs/linking-libraries.html#content).
+If you are adding React manually, make sure you have included all the relevant dependencies, like `RCTText.xcodeproj`, `RCTImage.xcodeproj` depending on the ones you are using. Next, the binaries built by these dependencies have to be linked to your app binary. Use the `Linked Frameworks and Binaries` section in the Xcode project settings. More detailed steps are here: [Linking Libraries](https://facebook.github.io/react-native/docs/linking-libraries-ios.html#content).
 
 ##### Argument list too long: recursive header expansion failed
 

--- a/local-cli/new-library.js
+++ b/local-cli/new-library.js
@@ -44,7 +44,7 @@ function newLibrary(libraryName) {
   console.log('Created library in', libraryDest);
   console.log('Next Steps:');
   console.log('   Link your library in Xcode:');
-  console.log('   https://facebook.github.io/react-native/docs/linking-libraries.html#content');
+  console.log('   https://facebook.github.io/react-native/docs/linking-libraries-ios.html#content');
   console.log('');
 }
 


### PR DESCRIPTION
https://facebook.github.io/react-native/docs/linking-libraries-ios.html is the correct page, otherwise it will just redirect to the 'Getting Started' page