### PR TITLE
Fix output of init script with path to xcode project

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -37,7 +37,7 @@ else
 
   puts "Next steps:"
   puts ""
-  puts "   Open #{File.join(dest, app_name)}.xcodeproj in Xcode"
+  puts "   Open #{File.join(dest, 'iOS', app_name)}.xcodeproj in Xcode"
   puts "   Hit Run button"
   puts ""
 end


### PR DESCRIPTION
Hey, all.

I've just noticed that when you run `react-native init SomeSampleApp`, you get wrong path to XCode project in the command output. `iOS` subfolder was missing for me.

So there is an original output:
```
Next Steps:
   Open /path/to/the/project/folder/SomeSampleApp/SomeSampleApp.xcodeproj in Xcode
   Hit Run button
```

But I needed to open `/path/to/the/project/folder/SomeSampleApp/iOS//path/to/the/project/folder/SomeSampleApp.xcodeproj` file.