### PR TITLE
Move OTHER_LDFLAGS from app target to project level for CocoaPods compat

### DIFF
--- a/local-cli/generator-ios/templates/xcodeproj/project.pbxproj
+++ b/local-cli/generator-ios/templates/xcodeproj/project.pbxproj
@@ -602,7 +602,6 @@
 				);
 				INFOPLIST_FILE = "<%= name %>/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = <%= name %>;
 			};
 			name = Debug;
@@ -618,7 +617,6 @@
 				);
 				INFOPLIST_FILE = "<%= name %>/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = <%= name %>;
 			};
 			name = Release;
@@ -665,6 +663,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
+				OTHER_LDFLAGS = "-ObjC";
 				SDKROOT = iphoneos;
 			};
 			name = Debug;
@@ -704,6 +703,7 @@
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = "-ObjC";
 				SDKROOT = iphoneos;
 				VALIDATE_PRODUCT = YES;
 			};


### PR DESCRIPTION
The extra `-ObjC` seems unnecessary at best. At worst, it makes interopability with systems that depend on setting `OTHER_LDFLAGS` (e.g. CocoaPods) annoying. Tracking down why your React Native app fails with a linker error is pretty annoying and near impossible for an Xcode novice.