### PR TITLE
Fix header paths in Sample/template Xcode project to make a fresh project build again

### DIFF
--- a/Examples/SampleApp/iOS/SampleApp.xcodeproj/project.pbxproj
+++ b/Examples/SampleApp/iOS/SampleApp.xcodeproj/project.pbxproj
@@ -659,7 +659,7 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
-					"$(SRCROOT)/../../React/**",
+					"$(SRCROOT)/../../../React/**",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
@@ -699,7 +699,7 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
-					"$(SRCROOT)/../../React/**",
+					"$(SRCROOT)/../../../React/**",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				MTL_ENABLE_DEBUG_INFO = NO;

--- a/local-cli/init.js
+++ b/local-cli/init.js
@@ -29,7 +29,7 @@ function init(projectDir, appName) {
   });
 
   console.log('Next Steps:');
-  console.log('   Open ' + path.resolve(projectDir, appName) + '.xcodeproj in Xcode');
+  console.log('   Open iOS/' + path.resolve(projectDir, appName) + '.xcodeproj in Xcode');
   console.log('   Hit Run button');
   console.log('');
 }


### PR DESCRIPTION
Fixed #2454. Verified by patching in the GitHub `react-native` into a new project's `node_modules`, deleting all other project artifacts except for `package.json`, and then re-generating the project artifacts using
```
node -e "var cli = require('./node_modules/react-native/cli'); cli.init('.', 'BlablaApp');"
```