### PR TITLE
[Executor] Suppress warning when checking for `JSGlobalContextSetName`

### DIFF
--- a/React/Executors/RCTContextExecutor.m
+++ b/React/Executors/RCTContextExecutor.m
@@ -587,7 +587,10 @@ static void RCTInstallJSCProfiler(RCTBridge *bridge, JSContextRef context)
 
 RCT_EXPORT_METHOD(setContextName:(nonnull NSString *)name)
 {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-pointer-compare"
   if (JSGlobalContextSetName != NULL) {
+#pragma clang diagnostic pop
     JSStringRef JSName = JSStringCreateWithCFString((__bridge CFStringRef)name);
     JSGlobalContextSetName(_context.ctx, JSName);
     JSStringRelease(JSName);


### PR DESCRIPTION
This API is defined only on iOS 8 and newer. There is a warning that the function is defined when checking if it exists since it is always defined in the iOS 8 SDK but not necessarily on iOS 7 phones. Use pragmas to silence the warning.