### PR TITLE
Added clarifying language to error for not finding development server

### DIFF
--- a/React/Base/RCTJavaScriptLoader.m
+++ b/React/Base/RCTJavaScriptLoader.m
@@ -38,7 +38,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
     // Handle general request errors
     if (error) {
       if ([error.domain isEqualToString:NSURLErrorDomain]) {
-        NSString *desc = [@"Could not connect to development server. Ensure node server is running and available on the same network - run 'npm start' from react-native root\n\nURL: " stringByAppendingString:scriptURL.absoluteString];
+        NSString *desc = [@"Could not connect to development server.\n\nEnsure the following:\n- Node server is running and available on the same network - run 'npm start' from react-native root\n- Node server URL is correctly set in AppDelegate\n\nURL: " stringByAppendingString:scriptURL.absoluteString];
         NSDictionary *userInfo = @{
           NSLocalizedDescriptionKey: desc,
           NSLocalizedFailureReasonErrorKey: error.localizedDescription,


### PR DESCRIPTION
Added additional check to make if seeing error message on not finding development server: 
Node server URL is correctly set in AppDelegate.

Should make it easier for a developer that is not running on localhost for the first time.

Screenshot of updated error message:
![img_0015 1](https://cloud.githubusercontent.com/assets/7111607/9553286/d7081c30-4d72-11e5-8c24-e3e5c83281d0.PNG)
