### PR TITLE
Also call the original `console` methods if they exist

### DIFF
--- a/packager/react-packager/src/DependencyResolver/polyfills/console.js
+++ b/packager/react-packager/src/DependencyResolver/polyfills/console.js
@@ -367,6 +367,9 @@
   };
 
   function setupConsole(global) {
+
+    var originalConsole = global.console;
+
     if (!global.nativeLoggingHook) {
       return;
     }
@@ -462,6 +465,16 @@
       table: consoleTablePolyfill
     };
 
+    // If available, also call the original `console` method since that is
+    // sometimes useful. Ex: on OS X, this will let you see rich output in
+    // the Safari Web Inspector console.
+    Object.keys(global.console).forEach(methodName => {
+      var reactNativeMethod = global.console[methodName];
+      global.console[methodName] = function() {
+        originalConsole[methodName](...arguments);
+        reactNativeMethod.apply(global.console, arguments);
+      };
+    });
   }
 
   if (typeof module !== 'undefined') {


### PR DESCRIPTION
Ex. When `console.log` or similar is called, this will call
the original method, which can be quite useful.

For example, under iOS, this will log to the Safari console debugger,
which has an expandable UI for inspecting objects, etc., and is also
just useful if you are using that as a REPL.

I don't believe this incurs a meaningful performance penalty unless
the console is open, but it would be easy to stick behind a flag
if that is a problem.