### PR TITLE
[Bridge] RFC: Declare module w/out auto exporting it with RCT_DECLARE_MODULE

### DIFF
--- a/React/Base/RCTBatchedBridge.m
+++ b/React/Base/RCTBatchedBridge.m
@@ -273,7 +273,7 @@ RCT_EXTERN NSArray<Class> *RCTGetModuleClasses(void);
       {
         if (class_conformsToProtocol(superclass, @protocol(RCTBridgeModule)))
         {
-          if (![moduleClasses containsObject:cls]) {
+          if (![moduleClasses containsObject:cls] && !RCTBridgeModuleClassIsDeclared(cls)) {
             RCTLogWarn(@"Class %@ was not exported. Did you forget to use "
                        "RCT_EXPORT_MODULE()?", cls);
           }
@@ -332,7 +332,7 @@ RCT_EXTERN NSArray<Class> *RCTGetModuleClasses(void);
                     moduleClass, moduleName, moduleData.moduleClass);
       }
     }
-    
+
     // Instantiate moduleData (TODO: can we defer this until config generation?)
     moduleData = [[RCTModuleData alloc] initWithModuleClass:moduleClass
                                                      bridge:self];

--- a/React/Base/RCTBridge.m
+++ b/React/Base/RCTBridge.m
@@ -64,6 +64,26 @@ void RCTRegisterModule(Class moduleClass)
 }
 
 /**
+ * Checks if class has been declared as a bridge module that is not
+ * automatically exported to JavaScript.
+ */
+BOOL RCTBridgeModuleClassIsDeclared(Class);
+BOOL RCTBridgeModuleClassIsDeclared(Class cls)
+{
+  return [objc_getAssociatedObject(cls, &RCTBridgeModuleClassIsDeclared) boolValue];
+}
+
+/**
+ * Declares the given class as a bridge module but does not automatically
+ * export it to JavaScript.
+ */
+void RCTDeclareModule(Class);
+void RCTDeclareModule(Class cls)
+{
+  objc_setAssociatedObject(cls, &RCTBridgeModuleClassIsDeclared, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
+/**
  * This function returns the module name for a given class.
  */
 NSString *RCTBridgeModuleNameForClass(Class cls)

--- a/React/Base/RCTBridgeModule.h
+++ b/React/Base/RCTBridgeModule.h
@@ -65,7 +65,16 @@ RCT_EXTERN void RCTRegisterModule(Class); \
 + (NSString *)moduleName { return @#js_name; } \
 + (void)load { RCTRegisterModule(self); }
 
-// Implemented by RCT_EXPORT_MODULE
+/**
+ * Use this macro to declare a module without automatically exporting it. This
+ * lets you manually export modules.
+ */
+#define RCT_DECLARE_MODULE(js_name) \
+RCT_EXTERN void RCTDeclareModule(Class); \
++ (NSString *)moduleName { return @#js_name; } \
++ (void)load { RCTDeclareModule(self); }
+
+// Implemented by RCT_EXPORT_MODULE and RCT_DECLARE_MODULE
 + (NSString *)moduleName;
 
 @optional


### PR DESCRIPTION
The motivation for this is to define bridge modules that aren't automatically exported and need to be manually provided to the bridge. Usage looks like this:

```objc
@interface XXModule : NSObject <RCTBridgeModule>
@end

@implementation XXModule
RCT_DECLARE_MODULE(OptionalName)
RCT_EXPORT_METHOD(...)
@end
```

And by default it is not exported to JS and does not show up under `require('react-native').NativeModules`'.

Test Plan: Use the new macro to declare a module and see that it is not auto-exported. See that it is exported to JS when explicitly provided to the bridge.