### PR TITLE
[Docs] Expand API parsing and rendering

### DIFF
--- a/website/jsdocs/jsdocs.js
+++ b/website/jsdocs/jsdocs.js
@@ -19,6 +19,7 @@ var genericTransform = require('./generic-function-visitor');
 var genericVisitor = genericTransform.visitorList[0];
 var traverseFlat = require('./traverseFlat');
 var parseTypehint = require('./TypeExpressionParser').parse;
+var util = require('util');
 
 // Don't save object properties source code that is longer than this
 var MAX_PROPERTY_SOURCE_LENGTH = 1000;
@@ -317,6 +318,7 @@ function getObjectData(node, state, source, scopeChain,
     commentsForFile, linesForFile) {
   var methods = [];
   var properties = [];
+  var classes = [];
   var superClass = null;
   node.properties.forEach(function(property) {
     if (property.type === Syntax.SpreadProperty) {
@@ -341,7 +343,8 @@ function getObjectData(node, state, source, scopeChain,
         scopeChain
       );
       if (expr) {
-        if (expr.type === Syntax.FunctionDeclaration) {
+        if (expr.type === Syntax.FunctionDeclaration ||
+            expr.type === Syntax.FunctionExpression) {
           var functionData =
             getFunctionData(expr, property, state, source, commentsForFile,
               linesForFile);
@@ -362,16 +365,24 @@ function getObjectData(node, state, source, scopeChain,
       }
       var docBlock = getDocBlock(property, commentsForFile, linesForFile);
       /* CodexVarDef: modifiers, type, name, default, docblock */
-      var propertyData = [
-        ['static'],
-        '',
+      if (property.value.type === Syntax.ClassDeclaration) {
+        var type = {name: property.value.id.name};
+        var classData = getClassData(property.value, state, source, commentsForFile, linesForFile);
+        classData.ownerProperty = property.key.name;
+        classes.push(classData);
+      } else {
+        var type = {name: property.value.type};
+      }
+      var propertyData = {
         // Cast to String because this can be a Number
         // Could also be a String literal (e.g. "key") hence the value
-        String(property.key.name || property.key.value),
+        name: String(property.key.name || property.key.value),
+        type,
+        docblock: docBlock || '',
+        source: source.substring.apply(source, property.range),
+        modifiers: ['static'],
         propertySource,
-        docBlock || '',
-        property.loc.start.line
-      ];
+      };
       properties.push(propertyData);
       break;
     }
@@ -379,6 +390,7 @@ function getObjectData(node, state, source, scopeChain,
   return {
     methods: methods,
     properties: properties,
+    classes: classes,
     superClass: superClass
   };
 }
@@ -410,6 +422,7 @@ function getClassData(node, state, source, commentsForFile, linesForFile) {
     }
   });
   var data = {
+    name: node.id.name,
     methods: methods
   };
   if (node.superClass && node.superClass.type === Syntax.Identifier) {

--- a/website/server/extractDocs.js
+++ b/website/server/extractDocs.js
@@ -134,7 +134,7 @@ function renderAPI(type) {
     try {
       json = jsDocs(fs.readFileSync(filepath).toString());
     } catch(e) {
-      console.error('Cannot parse file', filepath);
+      console.error('Cannot parse file', filepath, e);
       json = {};
     }
     return componentsToMarkdown(type, json, filepath, n++);
@@ -187,6 +187,7 @@ var components = [
 var apis = [
   '../Libraries/ActionSheetIOS/ActionSheetIOS.js',
   '../Libraries/Utilities/AlertIOS.js',
+  '../Libraries/Animated/Animated.js',
   '../Libraries/AppRegistry/AppRegistry.js',
   '../Libraries/AppStateIOS/AppStateIOS.ios.js',
   '../Libraries/Storage/AsyncStorage.ios.js',


### PR DESCRIPTION
The `Animated` module exposes a lot of functionality, including internal classes. This diff extracts properties and classes from modules and renders them recursively.

This also adds `Animated` to the autogen docs now that they more capable, although it needs way more docblocks and such which will come later.

Before:
<img width="939" alt="screen shot 2015-09-01 at 12 57 08 pm" src="https://cloud.githubusercontent.com/assets/1509831/9614821/02da5e2a-50a9-11e5-9d10-ea1b605c1362.png">

After:
<img width="727" alt="screen shot 2015-09-01 at 12 38 12 pm" src="https://cloud.githubusercontent.com/assets/1509831/9614695/282c490a-50a8-11e5-8a0f-4d1023a470c5.png">
