### PR TITLE
Updated TouchableHighlight docs

### DIFF
--- a/Libraries/Components/Touchable/TouchableHighlight.js
+++ b/Libraries/Components/Touchable/TouchableHighlight.js
@@ -57,6 +57,9 @@ var DEFAULT_PROPS = {
  *   );
  * },
  * ```
+ * > **NOTE**: TouchableHighlight supports only one child
+ * >
+ * > If you wish to have to have several child components, wrap them in a View.
  */
 
 var TouchableHighlight = React.createClass({

--- a/Libraries/Components/Touchable/TouchableOpacity.js
+++ b/Libraries/Components/Touchable/TouchableOpacity.js
@@ -45,9 +45,6 @@ type Event = Object;
  *   );
  * },
  * ```
- * > **NOTE**: TouchableOpacity supports only one child
- * >
- * > If you wish to have to have several child components, wrap them in a View.
  */
 
 var TouchableOpacity = React.createClass({


### PR DESCRIPTION
``onlyChild`` restriction is implemented in ``TouchableHighlight``, not ``TouchableOpacity``.