### PR TITLE
[Docs] Update RN website docs to mention Node 4+ instead of io.js

### DIFF
--- a/docs/EmbeddedApp.md
+++ b/docs/EmbeddedApp.md
@@ -12,8 +12,8 @@ Since React makes no assumptions about the rest of your technology stack – it�
 ## Requirements
 
 - [CocoaPods](http://cocoapods.org/) – `gem install cocoapods`
-- [io.js](http://iojs.org)
-  - Install **nvm** with [its setup instructions here](https://github.com/creationix/nvm#installation). Then run `nvm install iojs-v2 && nvm alias default iojs-v2`, which installs the latest compatible version of io.js and sets up your terminal so that typing `node` runs io.js.  With nvm you can install multiple versions of Node and io.js and easily switch between them.
+- [Node.js](http://nodejs.org)
+  - Install **nvm** with [its setup instructions here](https://github.com/creationix/nvm#installation). Then run `nvm install node && nvm alias default node`, which installs the latest version of Node.js and sets up your terminal so you can run it by typing `node`.  With nvm you can install multiple versions of Node.js and easily switch between them.
 
 ## Install React Native Using CocoaPods
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -10,9 +10,9 @@ next: android-setup
 ## Requirements
 
 1. OS X - Only OS X is currently supported
-2. [Homebrew](http://brew.sh/) is the recommended way to install io.js, watchman, and flow.
-3. Install [io.js](https://iojs.org/) 1.0 or newer. io.js is the modern version of Node.
-  - Install **nvm** with [its setup instructions here](https://github.com/creationix/nvm#installation). Then run `nvm install iojs-v2 && nvm alias default iojs-v2`, which installs the latest compatible version of io.js and sets up your terminal so that typing `node` runs io.js. With nvm you can install multiple versions of Node and io.js and easily switch between them.
+2. [Homebrew](http://brew.sh/) is the recommended way to install nvm, watchman, and flow.
+3. Install [Node.js](https://nodejs.org/) 4.0 or newer.
+  - Install **nvm** with Homebrew or [its setup instructions here](https://github.com/creationix/nvm#installation). Then run `nvm install node && nvm alias default node`, which installs the latest version of Node.js and sets up your terminal so you can run it by typing `node`. With nvm you can install multiple versions of Node.js and easily switch between them.
   - New to [npm](https://docs.npmjs.com/)?
 4. `brew install watchman`. We recommend installing [watchman](https://facebook.github.io/watchman/docs/install.html), otherwise you might hit a node file watching bug.
 5. `brew install flow`. If you want to use [flow](http://www.flowtype.org).

--- a/docs/Testing.md
+++ b/docs/Testing.md
@@ -52,7 +52,7 @@ Note: In order to run your own tests, you will have to first follow the Getting 
 ...
 ```
 
-Note: you may have to install/upgrade/link io.js and other parts of your environment in order for the tests to run correctly.  Check out the latest setup in [.travis.yml](https://github.com/facebook/react-native/blob/master/.travis.yml#L11-24)
+Note: you may have to install/upgrade/link Node.js and other parts of your environment in order for the tests to run correctly.  Check out the latest setup in [.travis.yml](https://github.com/facebook/react-native/blob/master/.travis.yml#L11-24)
 
 ## Integration Tests (iOS only)
 


### PR DESCRIPTION
The io.js codebase has been rebranded as "Node.js", so moving forward everyone should install the latest version of Node. The name "io.js" is no longer.