### PR TITLE
[CLI] Updated contributing guide to deal with Sinopia publishing issue

### DIFF
--- a/react-native-cli/CONTRIBUTING.md
+++ b/react-native-cli/CONTRIBUTING.md
@@ -13,7 +13,11 @@ Because `react-native init` calls `npm install react-native`, simply linking you
 Then, open `~/.config/sinopia/config.yaml` and configure it like this (note the `max_body_size`):
 
     storage: ./storage
-    
+
+    auth:
+      htpasswd:
+        file: ./htpasswd
+
     uplinks:
       npmjs:
         url: https://registry.npmjs.org/
@@ -22,18 +26,18 @@ Then, open `~/.config/sinopia/config.yaml` and configure it like this (note the 
       'react-native':
         allow_access: $all
         allow_publish: $all
-    
+
       'react-native-cli':
         allow_access: $all
         allow_publish: $all
-    
+
       '*':
         allow_access: $all
         proxy: npmjs
 
     logs:
       - {type: stdout, format: pretty, level: http}
-    
+
     max_body_size: '50mb'
 
 Now you can run sinopia by simply doing:
@@ -45,6 +49,7 @@ Now you can run sinopia by simply doing:
 Now we need to publish the two React Native packages to our local registry. To do this, we configure npm to use the new registry, unpublish any existing packages and then publish the new ones:
 
     react-native$ npm set registry http://localhost:4873/
+    react-native$ npm adduser --registry http://localhost:4873/
     # Check that it worked:
     react-native$ npm config list
     react-native$ npm unpublish --force


### PR DESCRIPTION
I was following `CONTRIBUTING.md`, specifically the section on using Sinopia for testing local changes. The setup did not cover how to handle an error that comes up when you try to publish to your private repo for the first time:

`npm ERR! need auth auth and email required for publishing`

You need to setup Sinopia to allow adding users before being able to publish locally. I updated the doc to cover this additional bit of setup.