### PR TITLE
[CLI] bundle arguments consistency / improvements

### DIFF
--- a/docs/RunningOnDeviceIOS.md
+++ b/docs/RunningOnDeviceIOS.md
@@ -34,6 +34,7 @@ The bundle script supports a couple of flags:
 
 * `--dev` - sets the value of `__DEV__` variable to true. When `true` it turns on a bunch of useful development warnings. For production it is recommended to set `__DEV__=false`.
 * `--minify` - pipe the JS code through UglifyJS.
+* `--help` - list additional flags for advanced scenarios.
 
 ## Disabling in-app developer menu
 

--- a/local-cli/__tests__/bundle-test.js
+++ b/local-cli/__tests__/bundle-test.js
@@ -1,0 +1,157 @@
+'use strict';
+
+var Promise = require('promise');
+var Bundle = require('../../packager/react-packager/src/Bundler/Bundle');
+
+jest.mock('fs');
+jest.dontMock('../bundle');
+jest.dontMock('path');
+
+jest.setMock('../../packager/react-packager', {
+  buildPackageFromUrl: jest.genMockFn().mockImplementation(function() {
+    return new Promise(function(resolve, reject) {
+      resolve(new Bundle());
+    });
+  })
+});
+
+var bundle = require('../bundle.js');
+
+describe('bundle', function() {
+
+  describe('with help argument', function() {
+    var originalLog;
+    var originalExit;
+
+    beforeEach(function() {
+      originalLog = console.log;
+      originalExit = process.exit;
+    });
+
+    afterEach(function() {
+      console.log = originalLog;
+      process.exit = originalExit;
+    });
+
+    it('shows usage and options', function() {
+      console.log = jest.genMockFn();
+      process.exit = jest.genMockFn();
+      bundle.init(['--help']);
+      expect(console.log).toBeCalled();
+      expect(console.log.mock.calls[0][0]).toContain('Usage');
+      expect(console.log.mock.calls[0][0]).toContain('Options');
+    });
+  });
+
+  describe('with deprecated arguments', function() {
+    var Packager;
+    var originalLog;
+    var originalExit;
+
+    beforeEach(function() {
+      originalLog = console.log;
+      originalExit = process.exit;
+      Packager = require('../../packager/react-packager');
+    });
+
+    afterEach(function() {
+      console.log = originalLog;
+      process.exit = originalExit;
+      Packager.buildPackageFromUrl.mockClear();
+    });
+
+    it('shows an error message when --root is used', function() {
+      console.log = jest.genMockFn();
+      process.exit = jest.genMockFn();
+      bundle.init(['--root']);
+      expect(console.log).toBeCalled();
+      expect(console.log.mock.calls[0][0]).toContain('deprecated argument. Use --roots');
+      expect(console.log.mock.calls[1][0]).toContain('Usage');
+    });
+
+    it('shows an error message when --url is used', function() {
+      console.log = jest.genMockFn();
+      process.exit = jest.genMockFn();
+      bundle.init(['--url']);
+      expect(console.log).toBeCalled();
+      expect(console.log.mock.calls[0][0]).toContain('deprecated argument. Use --appModule');
+      expect(console.log.mock.calls[1][0]).toContain('Usage');
+    });
+  });
+
+  describe('with no additional arguments', function() {
+    var Packager;
+
+    beforeEach(function() {
+      Packager = require('../../packager/react-packager');
+      bundle.init([]);
+    });
+
+    afterEach(function() {
+      Packager.buildPackageFromUrl.mockClear();
+    });
+
+    it('includes at least one default root', function() {
+      expect(Packager.buildPackageFromUrl).toBeCalled();
+      expect(Packager.buildPackageFromUrl.mock.calls[0][0].projectRoots.length).toBeGreaterThan(0);
+    });
+
+    it('includes at least one default asset root', function() {
+      expect(Packager.buildPackageFromUrl).toBeCalled();
+      expect(Packager.buildPackageFromUrl.mock.calls[0][0].assetRoots.length).toBeGreaterThan(0);
+    });
+
+    it('dev query param on url is false', function() {
+      expect(Packager.buildPackageFromUrl).toBeCalled();
+      expect(Packager.buildPackageFromUrl.mock.calls[0][1]).toContain('dev=false');
+    });
+
+    it('platform query param on url is ios', function() {
+      expect(Packager.buildPackageFromUrl).toBeCalled();
+      expect(Packager.buildPackageFromUrl.mock.calls[0][1]).toContain('platform=ios');
+    });
+  });
+
+  describe('with arguments', function() {
+    var Packager;
+
+    beforeEach(function() {
+      Packager = require('../../packager/react-packager');
+    });
+
+    afterEach(function() {
+      Packager.buildPackageFromUrl.mockClear();
+    });
+
+    it('passes additional roots to packager', function() {
+      bundle.init(['--roots', '/other_modules,/more_modules']);
+      expect(Packager.buildPackageFromUrl).toBeCalled();
+      expect(Packager.buildPackageFromUrl.mock.calls[0][0].projectRoots.indexOf('/other_modules')).toBeGreaterThan(-1);
+    });
+
+    it('passes additional asset roots to packager', function() {
+      bundle.init(['--assetRoots', '/other_modules,/more_modules']);
+      expect(Packager.buildPackageFromUrl).toBeCalled();
+      expect(Packager.buildPackageFromUrl.mock.calls[0][0].assetRoots.indexOf('/other_modules')).toBeGreaterThan(-1);
+    });
+
+    it('passes bundle url based off appModule to packager', function() {
+      bundle.init(['--appModule', 'MyApp.js']);
+      expect(Packager.buildPackageFromUrl).toBeCalled();
+      expect(Packager.buildPackageFromUrl.mock.calls[0][1]).toContain('/MyApp.bundle');
+    });
+
+    it('sets dev query param on url when dev argument set', function() {
+      bundle.init(['--dev', 'MyApp.js']);
+      expect(Packager.buildPackageFromUrl).toBeCalled();
+      expect(Packager.buildPackageFromUrl.mock.calls[0][1]).toContain('dev=true');
+    });
+
+    it('sets platform query param on url when platform argument set', function() {
+      bundle.init(['--platform', 'android']);
+      expect(Packager.buildPackageFromUrl).toBeCalled();
+      expect(Packager.buildPackageFromUrl.mock.calls[0][1]).toContain('platform=android');
+    });
+  });
+
+});

--- a/packager/README.md
+++ b/packager/README.md
@@ -97,21 +97,19 @@ var ReactPackager = require('./react-packager');
 Returns a function that can be used in a connect-like
 middleware. Takes the following options:
 
-* `projectRoots` array (required): Is the roots where your JavaScript
-  file will exist
-* `blacklistRE` regexp: Is a patter to ignore certain paths from the
-  packager
-* `polyfillModuleName` array: Paths to polyfills you want to be
-  included at the start of the bundle
-* `cacheVersion` string: used in creating the cache file
-* `resetCache` boolean, defaults to false: whether to use the cache on
+* `projectRoots` array (required): Root paths packager will look for
+  JavaScript files
+* `blacklistRE` regexp: Pattern to ignore certain paths from packager
+* `polyfillModuleName` array: Paths to polyfills will be included at
+  start of bundle
+* `cacheVersion` string: Used in creating cache file
+* `resetCache` boolean, defaults to false: Whether to use cache on
   disk
-* `transformModulePath` string: Path to the module used as a
-  JavaScript transformer
-* `nonPersistent` boolean, defaults to false: Whether the server
-  should be used as a persistent deamon to watch files and update
-  itself
-* `assetRoots` array: Where should the packager look for assets
+* `transformModulePath` string: Path to module used as a JavaScript
+  transformer
+* `nonPersistent` boolean, defaults to false: Whether server will be
+  used as a persistent deamon to watch for files and update itself
+* `assetRoots` array: Root paths packager will look for assets
 
 ### ReactPackager.buildPackageFromUrl(options, url)
 


### PR DESCRIPTION
I was digging through the CLI the other day and noticed that the bundle command arguments were not well documented on the website. I also noticed some inconsistencies and misleading argument names.

This PR tries to bring the bundle command on CLI to a better place. 

- RunningOnDevice docs now mention what the help command is to list additional options (I had to look at the code to figure out if a help command existed, and what the exact syntax was).
- Packager Readme was updated with better copy (up to your discretion if it is in fact better) for the options.
- Updated the descriptions of some of the arguments when calling `react-native bundle help` to be more clear (also up to your discretion if they are actually better)
- Replaced `--root` with `--roots` to allow a comma separated list of paths to be passed in, similar to `--assetRoots`. I saw no good reason to only allow a single additional root path but multiple asset paths.
- Replace `--url` with `--appModule`. The bundle cli code converts the specified JS file into its url representation that is passed to `ReactPackager`, but this is an implementation detail. When I was trying to figure out what I needed to pass in for the `url` argument on a project where I did not have the default file name for my root app component I had to look at the code. I think `appModule` and the new help description for this argument is much more descriptive now. 

Please review and consider my proposed changes. Thanks!