### PR TITLE
[CLI] Add version argument

### DIFF
--- a/react-native-cli/index.js
+++ b/react-native-cli/index.js
@@ -4,10 +4,12 @@
  * Copyright 2004-present Facebook. All Rights Reserved.
  */
 
+'use strict';
+
 var fs = require('fs');
 var path = require('path');
 var exec = require('child_process').exec;
-var prompt = require("prompt");
+var prompt = require('prompt');
 
 var CLI_MODULE_PATH = function() {
   return path.resolve(
@@ -17,6 +19,8 @@ var CLI_MODULE_PATH = function() {
     'cli'
   );
 };
+
+checkForVersionArgument();
 
 var cli;
 try {
@@ -80,7 +84,7 @@ function init(name) {
   validatePackageName(name);
 
   if (fs.existsSync(name)) {
-    createAfterConfirmation(name)
+    createAfterConfirmation(name);
   } else {
     createProject(name);
   }
@@ -140,7 +144,15 @@ function createProject(name) {
       process.exit(1);
     }
 
-    var cli = require(CLI_MODULE_PATH());
+    cli = require(CLI_MODULE_PATH());
     cli.init(root, projectName);
   });
+}
+
+function checkForVersionArgument() {
+  if (process.argv.indexOf('-v') >= 0 || process.argv.indexOf('--version') >= 0) {
+    var pjson = require('./package.json');
+    console.log(pjson.version);
+    process.exit();
+  }
 }


### PR DESCRIPTION
Fixes #2225

Adds support for returning current version number:

`react-native -v`
OR
`react-native --version`

The version number returned is pulled from `package.json`