### PR TITLE
RCTHTTPRequestHandler: common operation queue

### DIFF
--- a/Libraries/Network/RCTHTTPRequestHandler.m
+++ b/Libraries/Network/RCTHTTPRequestHandler.m
@@ -17,6 +17,7 @@
 {
   NSMapTable *_delegates;
   NSURLSession *_session;
+  NSOperationQueue *_queue;
 }
 
 RCT_EXPORT_MODULE()
@@ -27,6 +28,7 @@ RCT_EXPORT_MODULE()
     _delegates = [[NSMapTable alloc] initWithKeyOptions:NSPointerFunctionsStrongMemory
                                            valueOptions:NSPointerFunctionsStrongMemory
                                                capacity:0];
+    _queue = [NSOperationQueue new];
   }
   return self;
 }
@@ -34,8 +36,10 @@ RCT_EXPORT_MODULE()
 - (void)invalidate
 {
   [_session invalidateAndCancel];
+  [_queue cancelAllOperations];
   _session = nil;
   _delegates = nil;
+  _queue = nil;
 }
 
 - (BOOL)isValid
@@ -55,7 +59,7 @@ RCT_EXPORT_MODULE()
 {
   // Lazy setup
   if (!_session && [self isValid]) {
-    NSOperationQueue *callbackQueue = [NSOperationQueue new];
+    NSOperationQueue *callbackQueue = _queue;
     NSURLSessionConfiguration *configuration = [NSURLSessionConfiguration defaultSessionConfiguration];
     _session = [NSURLSession sessionWithConfiguration:configuration
                                              delegate:self


### PR DESCRIPTION
I was sometimes getting crashing memory errors in one of the delegate methods in this class, during modification of the `_delegates` structure which is not thread safe. As far as I can tell, this change fixes it, but unfortunately I have no reliable way of proving it except by anecdote.

I am a newbie with Objective-C and its concurrency stuff especially, but as far as I can tell, creating a new `NSOperationQueue` for every request is likely to cause callbacks from different threads. Since these callbacks modify a thread-unsafe structure (`NSMapTable`), random errors can happen.

So I added a single `NSOperationQueue` to the class and reuse it for all requests. I'm guessing the performance implications shouldn't be horrible, since the callbacks don't do much work. Either way, access to the mutable data needs to be sequential.

It's unclear to me if the `invalidate` method needs to cancel all the queue operations... I figured "why not?"