### PR TITLE
[Modal] Add `visible` prop type

### DIFF
--- a/Libraries/Modal/Modal.js
+++ b/Libraries/Modal/Modal.js
@@ -45,6 +45,7 @@ class Modal extends React.Component {
 Modal.propTypes = {
   animated: PropTypes.bool,
   transparent: PropTypes.bool,
+  visible: PropTypes.bool
 };
 
 var styles = StyleSheet.create({


### PR DESCRIPTION
It is missing from the docs, but used in the example.