### PR TITLE
[ART] Mark `-[init]` w RCT_NOT_IMPLEMENTED

### DIFF
--- a/Libraries/ART/Brushes/ARTBrush.m
+++ b/Libraries/ART/Brushes/ARTBrush.m
@@ -9,12 +9,16 @@
 
 #import "ARTBrush.h"
 
+#import "RCTDefines.h"
+
 @implementation ARTBrush
 
 - (instancetype)initWithArray:(NSArray *)data
 {
   return [super init];
 }
+
+RCT_NOT_IMPLEMENTED(- (instancetype)init)
 
 - (BOOL)applyFillColor:(CGContextRef)context
 {


### PR DESCRIPTION
ARTBrush.m doesn't defined init but Clang wants it.

Fix #2590

Test Plan: Build a project linked with ReactART. No more build warnings.