### PR TITLE
[PickerIOS] Fix changeEvents for the Picker

### DIFF
--- a/Libraries/Picker/PickerIOS.ios.js
+++ b/Libraries/Picker/PickerIOS.ios.js
@@ -111,6 +111,8 @@ var styles = StyleSheet.create({
   },
 });
 
-var RCTPickerIOS = requireNativeComponent('RCTPicker', null);
+var RCTPickerIOS = requireNativeComponent('RCTPicker', null, {
+  nativeOnly: { onChange: true },
+});
 
 module.exports = PickerIOS;

--- a/React/Views/RCTPickerManager.m
+++ b/React/Views/RCTPickerManager.m
@@ -24,6 +24,7 @@ RCT_EXPORT_MODULE()
 
 RCT_EXPORT_VIEW_PROPERTY(items, NSDictionaryArray)
 RCT_EXPORT_VIEW_PROPERTY(selectedIndex, NSInteger)
+RCT_EXPORT_VIEW_PROPERTY(onChange, RCTBubblingEventBlock)
 
 - (NSDictionary *)constantsToExport
 {


### PR DESCRIPTION
onChange events weren't getting sent -- just needed to export the property.

Test Plan: Open the Picker example in the UIExplorer and ensure it works.

Fix #2591 