### PR TITLE
Font Scaling Fix

### DIFF
--- a/Libraries/Text/Text.js
+++ b/Libraries/Text/Text.js
@@ -116,7 +116,7 @@ var Text = React.createClass({
   
   getDefaultProps: function(): Object {
     return {
-      allowFontScaling: true,
+      allowFontScaling: false,
     };
   },
 


### PR DESCRIPTION
Default should be `false` for `allowFontScaling` property according to this commit 53fb5b6.