### PR TITLE
[Travis] Use Xcode 7 image, remove brew update, install nvm directly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,21 @@
 language: objective-c
 
-osx_image: xcode6.4
+osx_image: xcode7
 
 cache:
     directories:
         - node_modules
         - .nvm
 
-before_install:
-  # Update brew twice because the first run can fail: https://github.com/Homebrew/homebrew/issues/42553
-  - brew update; brew update
 install:
-  - brew reinstall xctool nvm
+  - brew reinstall nvm
   - mkdir -p .nvm
   - export NVM_DIR="$PWD/.nvm"
   - source $(brew --prefix nvm)/nvm.sh
   - nvm install 4
-  - rm -Rf `node -p "require('os').tmpDir()"`/jest_preprocess_cache
-  - npm install -g flow-bin@`node -p "require('fs').readFileSync('.flowconfig', 'utf8').split('[version]')[1].trim()"`
+  - rm -Rf "${TMPDIR}/jest_preprocess_cache"
   - npm config set spin=false
+  - npm install -g flow-bin@`node -p "require('fs').readFileSync('.flowconfig', 'utf8').split('[version]')[1].trim()"`
   - npm install
 
 script:


### PR DESCRIPTION
- Uses the Xcode 7 image
- The new image includes xctool 0.2.5 (current)
- Removes the `brew update` command, which needed to fetch a lot of data
- Disables the npm spinner before installing flow-bin
- Uses `$TMPDIR` instead of spinning up Node