### PR TITLE
[ActionSheetIOS] Fixes consistent crash on iPad with iOS 8 while sharing.

### DIFF
--- a/Libraries/ActionSheetIOS/RCTActionSheetManager.m
+++ b/Libraries/ActionSheetIOS/RCTActionSheetManager.m
@@ -12,6 +12,8 @@
 #import "RCTConvert.h"
 #import "RCTLog.h"
 #import "RCTUtils.h"
+#import "RCTBridge.h"
+#import "RCTUIManager.h"
 
 @interface RCTActionSheetManager () <UIActionSheetDelegate>
 
@@ -108,6 +110,24 @@ RCT_EXPORT_METHOD(showShareActionSheetWithOptions:(NSDictionary *)options
         successCallback(@[@(completed), RCTNullIfNil(activityType)]);
       }
     };
+  }
+
+  /*
+   * The `anchor` option takes a view to set as the anchor for the share
+   * popup to point to, on iPads running iOS 8. If it is not passed, it
+   * defaults to centering the share popup on screen without any arrows.
+   */
+  if ([share respondsToSelector:@selector(popoverPresentationController)]) {
+    share.popoverPresentationController.sourceView = ctrl.view;
+    NSNumber *anchorViewTag = [RCTConvert NSNumber:options[@"anchor"]];
+    if (anchorViewTag) {
+      UIView *anchorView = [self.bridge.uiManager viewForReactTag:anchorViewTag];
+      share.popoverPresentationController.sourceRect = [anchorView convertRect:anchorView.bounds toView:ctrl.view];
+    } else {
+      CGRect sourceRect = CGRectMake(ctrl.view.center.x, ctrl.view.center.y, 1, 1);
+      share.popoverPresentationController.sourceRect = sourceRect;
+      share.popoverPresentationController.permittedArrowDirections = 0;
+    }
   }
 
   [ctrl presentViewController:share animated:YES completion:nil];


### PR DESCRIPTION
(Fixes #1890, #2395, #2604.)

Usage:
```
ActionSheetIOS.showShareActionSheetWithOptions({
  anchor: React.findNodeHandle(this.refs.share),
  message: "React Native",
  url: "https://github.com/facebook/react-native"
}, (e)=>{ console.log('shared'); }, (e)=>{console.log('dismissed'); });
```

Screenshot on iPad with iOS 8:

<img width="324" alt="screen shot 2015-09-09 at 8 50 26 am" src="https://cloud.githubusercontent.com/assets/543981/9752590/df5cd324-56cf-11e5-892b-92a6c98f3d39.png">

If the `anchor` is not specified, it will centre the popup on screen without arrows:

![centered](https://cloud.githubusercontent.com/assets/543981/9752612/10c87c6a-56d0-11e5-8c59-fcbf64a36f9c.png)
