### PR TITLE
Disable packager tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "setupEnvScriptFile": "jestSupport/env.js",
     "testPathIgnorePatterns": [
       "/node_modules/",
-      "packager/react-packager/src/Activity/"
+      "packager/react-packager/"
     ],
     "testFileExtensions": [
       "js"


### PR DESCRIPTION
The packager is soon going to be on its own npm repo. The reason tests fail most of the time on open source is because of configurations that are different, but it actually runs properly. Disabling the tests on open source is going to make for less flaky tests.