### PR TITLE
[DrawerLayoutAndroid] Fix broken code block and make the example nicer

### DIFF
--- a/Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.android.js
+++ b/Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.android.js
@@ -50,15 +50,19 @@ var DRAWER_STATES = [
  * ```
  * render: function() {
  *   var navigationView = (
- *     <Text style={{margin: 10, fontSize: 15, textAlign: 'left'}}>I'm in the Drawer!</Text>
+   *   <View style={{flex: 1, backgroundColor: '#fff'}}>
+   *     <Text style={{margin: 10, fontSize: 15, textAlign: 'left'}}>I'm in the Drawer!</Text>
+   *   </View>
  *   );
  *   return (
  *     <DrawerLayoutAndroid
  *       drawerWidth={300}
  *       drawerPosition={DrawerLayoutAndroid.positions.Left}
  *       renderNavigationView={() => navigationView}>
- *       <Text style={{10, fontSize: 15, textAlign: 'right'}}>Hello</Text>
- *       <Text style={{10, fontSize: 15, textAlign: 'right'}}>World!</Text>
+ *       <View style={{flex: 1, alignItems: 'center'}}>
+ *         <Text style={{margin: 10, fontSize: 15, textAlign: 'right'}}>Hello</Text>
+ *         <Text style={{margin: 10, fontSize: 15, textAlign: 'right'}}>World!</Text>
+ *       </View>
  *     </DrawerLayoutAndroid>
  *   );
  * },


### PR DESCRIPTION
@kmagiera @mkonicek - made a mistake while updating it, removed the `margin` style for some reason on the inner Text (it was 1am, ¯\_(ツ)_/¯). This also makes the example nicer looking - style the navigation with a white background, center the text in the main content view.

![](http://url.brentvatne.ca/16xXe.png)
![](http://url.brentvatne.ca/1a4Jt.png)