### PR TITLE
[ScrollView] Add scrollWithoutAnimationTo to Android

### DIFF
--- a/Libraries/Components/ScrollResponder.js
+++ b/Libraries/Components/ScrollResponder.js
@@ -367,6 +367,26 @@ var ScrollResponderMixin = {
   },
 
   /**
+   * Like `scrollResponderScrollTo` but immediately scrolls to the given
+   * position
+   */
+  scrollResponderScrollWithouthAnimationTo: function(offsetX: number, offsetY: number) {
+    if (Platform.OS === 'android') {
+      RCTUIManager.dispatchViewManagerCommand(
+        React.findNodeHandle(this),
+        RCTUIManager.RCTScrollView.Commands.scrollWithoutAnimationTo,
+        [offsetX, offsetY],
+      );
+    } else {
+      RCTUIManager.scrollWithoutAnimationTo(
+        React.findNodeHandle(this),
+        offsetX,
+        offsetY
+      );
+    }
+  },
+
+  /**
    * A helper function to zoom to a specific rect in the scrollview.
    * @param {object} rect Should have shape {x, y, width, height}
    */

--- a/Libraries/Components/ScrollView/ScrollView.js
+++ b/Libraries/Components/ScrollView/ScrollView.js
@@ -290,10 +290,10 @@ var ScrollView = React.createClass({
   },
 
   scrollWithoutAnimationTo: function(destY?: number, destX?: number) {
-    RCTUIManager.scrollWithoutAnimationTo(
-      React.findNodeHandle(this),
+    // $FlowFixMe - Don't know how to pass Mixin correctly. Postpone for now
+    this.getScrollResponder().scrollResponderScrollWithouthAnimationTo(
       destX || 0,
-      destY || 0
+      destY || 0,
     );
   },
 

--- a/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollViewManager.java
@@ -51,4 +51,11 @@ public class ReactHorizontalScrollViewManager
       ReactScrollViewCommandHelper.ScrollToCommandData data) {
     scrollView.smoothScrollTo(data.mDestX, data.mDestY);
   }
+
+  @Override
+  public void scrollWithoutAnimationTo(
+      ReactHorizontalScrollView scrollView,
+      ReactScrollViewCommandHelper.ScrollToCommandData data) {
+    scrollView.scrollTo(data.mDestX, data.mDestY);
+  }
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewCommandHelper.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewCommandHelper.java
@@ -25,9 +25,11 @@ import com.facebook.react.common.MapBuilder;
 public class ReactScrollViewCommandHelper {
 
   public static final int COMMAND_SCROLL_TO = 1;
+  public static final int COMMAND_SCROLL_WITHOUT_ANIMATION_TO = 2;
 
   public interface ScrollCommandHandler<T> {
     void scrollTo(T scrollView, ScrollToCommandData data);
+    void scrollWithoutAnimationTo(T scrollView, ScrollToCommandData data);
   }
 
   public static class ScrollToCommandData {
@@ -41,7 +43,11 @@ public class ReactScrollViewCommandHelper {
   }
 
   public static Map<String,Integer> getCommandsMap() {
-    return MapBuilder.of("scrollTo", COMMAND_SCROLL_TO);
+    return MapBuilder.of(
+        "scrollTo",
+        COMMAND_SCROLL_TO,
+        "scrollWithoutAnimationTo",
+        COMMAND_SCROLL_WITHOUT_ANIMATION_TO);
   }
 
   public static <T> void receiveCommand(
@@ -53,11 +59,18 @@ public class ReactScrollViewCommandHelper {
     Assertions.assertNotNull(scrollView);
     Assertions.assertNotNull(args);
     switch (commandType) {
-      case COMMAND_SCROLL_TO:
+      case COMMAND_SCROLL_TO: {
         int destX = Math.round(PixelUtil.toPixelFromDIP(args.getInt(0)));
         int destY = Math.round(PixelUtil.toPixelFromDIP(args.getInt(1)));
         viewManager.scrollTo(scrollView, new ScrollToCommandData(destX, destY));
         return;
+      }
+      case COMMAND_SCROLL_WITHOUT_ANIMATION_TO: {
+        int destX = Math.round(PixelUtil.toPixelFromDIP(args.getInt(0)));
+        int destY = Math.round(PixelUtil.toPixelFromDIP(args.getInt(1)));
+        viewManager.scrollWithoutAnimationTo(scrollView, new ScrollToCommandData(destX, destY));
+        return;
+      }
       default:
         throw new IllegalArgumentException(String.format(
             "Unsupported command %d received by %s.",

--- a/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewManager.java
@@ -85,6 +85,13 @@ public class ReactScrollViewManager
   }
 
   @Override
+  public void scrollWithoutAnimationTo(
+      ReactScrollView scrollView,
+      ReactScrollViewCommandHelper.ScrollToCommandData data) {
+    scrollView.scrollTo(data.mDestX, data.mDestY);
+  }
+
+  @Override
   public @Nullable Map getExportedCustomDirectEventTypeConstants() {
     return MapBuilder.builder()
         .put(ScrollEvent.EVENT_NAME, MapBuilder.of("registrationName", "onScroll"))


### PR DESCRIPTION
`ScrollView.scrollWithoutAnimationTo` is supported on iOS but not Android. This is an existing API, and this diff adds Android support.

Test Plan: Create a small demo app that has a scroll view that has sufficiently large content so as to be scrollable. Add a button that calls `scrollWithoutAnimationTo(100)` when tapped, and verify that the scroll view immediately jumps to the desired position.