### PR TITLE
[ScrollView] Stub out contentInset for parity with iOS

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ScrollEvent.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ScrollEvent.java
@@ -64,6 +64,12 @@ public class ScrollEvent extends Event<ScrollEvent> {
   }
 
   private WritableMap serializeEventData() {
+    WritableMap contentInset = Arguments.createMap();
+    contentInset.putDouble("top", 0);
+    contentInset.putDouble("bottom", 0);
+    contentInset.putDouble("left", 0);
+    contentInset.putDouble("right", 0);
+
     WritableMap contentOffset = Arguments.createMap();
     contentOffset.putDouble("x", PixelUtil.toDIPFromPixel(mScrollX));
     contentOffset.putDouble("y", PixelUtil.toDIPFromPixel(mScrollY));
@@ -77,6 +83,7 @@ public class ScrollEvent extends Event<ScrollEvent> {
     layoutMeasurement.putDouble("height", PixelUtil.toDIPFromPixel(mScrollViewHeight));
 
     WritableMap event = Arguments.createMap();
+    event.putMap("contentInset", contentInset);
     event.putMap("contentOffset", contentOffset);
     event.putMap("contentSize", contentSize);
     event.putMap("layoutMeasurement", layoutMeasurement);


### PR DESCRIPTION
iOS scrollviews have content insets as well (https://stackoverflow.com/questions/1983463/whats-the-uiscrollview-contentinset-property-for).

Setting them to zero is technically correct on Android because it doesn't apply any insets.

Test Plan: Components that look at contentInset.top/bottom/x/y no longer throw an error.