### PR TITLE
[iOS] Add missing platform param for the movies app

### DIFF
--- a/Examples/Movies/Movies/AppDelegate.m
+++ b/Examples/Movies/Movies/AppDelegate.m
@@ -37,7 +37,7 @@
    * on the same Wi-Fi network.
    */
 
-  jsCodeLocation = [NSURL URLWithString:@"http://localhost:8081/Examples/Movies/MoviesApp.ios.includeRequire.runModule.bundle"];
+  jsCodeLocation = [NSURL URLWithString:@"http://localhost:8081/Examples/Movies/MoviesApp.ios.bundle?platform=ios&dev=true"];
 
   /**
    * OPTION 2


### PR DESCRIPTION
Re discussion in #2705, added the missing `platform=true` for the sample movies app. Also added `dev=true` because the other sample apps included it as well.

@ide 