### PR TITLE
Use the right appName on init

### DIFF
--- a/local-cli/init.js
+++ b/local-cli/init.js
@@ -3,11 +3,10 @@
 var path = require('path');
 var yeoman = require('yeoman-environment');
 
-function init(projectDir, appName) {
+function init(projectDir, args) {
   console.log('Setting up new React Native app in ' + projectDir);
   var env = yeoman.createEnv();
   env.register(require.resolve(path.join(__dirname, 'generator')), 'react:app');
-  var args = process.argv.slice(3);
   var generator = env.create('react:app', {args: args});
   generator.destinationRoot(projectDir);
   generator.run();

--- a/react-native-cli/index.js
+++ b/react-native-cli/index.js
@@ -144,8 +144,9 @@ function createProject(name) {
       process.exit(1);
     }
 
+    var args = [projectName].concat(process.argv.slice(4));
     cli = require(CLI_MODULE_PATH());
-    cli.init(root, projectName);
+    cli.init(root, args);
   });
 }
 


### PR DESCRIPTION
local-cli was getting the appName from process.argv instead of using appName parameter.