### PR TITLE
[ScrollResponder] Only track keyboard events with endCoordinates

### DIFF
--- a/Libraries/Components/ScrollResponder.js
+++ b/Libraries/Components/ScrollResponder.js
@@ -476,7 +476,7 @@ var ScrollResponderMixin = {
    * you had explicitly focused a node etc).
    */
   scrollResponderKeyboardWillShow: function(e: Event) {
-    this.keyboardWillOpenTo = e;
+    if (e.endCoordinates) this.keyboardWillOpenTo = e;
     this.props.onKeyboardWillShow && this.props.onKeyboardWillShow(e);
   },
 
@@ -488,7 +488,7 @@ var ScrollResponderMixin = {
   scrollResponderKeyboardDidShow: function(e: Event) {
     // TODO(7693961): The event for DidShow is not available on iOS yet.
     // Use the one from WillShow and do not assign.
-    if (e) {
+    if (e && e.endCoordinates) {
       this.keyboardWillOpenTo = e;
     }
     this.props.onKeyboardDidShow && this.props.onKeyboardDidShow(e);


### PR DESCRIPTION
I experienced an exception when calling `ScrollResponder.scrollResponderInputMeasureAndScrollToKeyboard`, because the required `this.keyboardWillOpenTo.endCoordinates` variable was undefined. I discovered that `RCTDeviceEventEmitter` emits two types of objects, only one containing the `endCoordinates`. I edited the event handlers to only store these objects.

To reproduce the issue, take the steps described in this stack overflow answer: http://stackoverflow.com/a/32593814/1088754

resolves #355 