### PR TITLE
Don't set height to avoid clipping textinput for XHRExample on android

### DIFF
--- a/Examples/UIExplorer/XHRExample.android.js
+++ b/Examples/UIExplorer/XHRExample.android.js
@@ -302,7 +302,6 @@ var styles = StyleSheet.create({
     borderRadius: 3,
     borderColor: 'grey',
     borderWidth: 1,
-    height: 30,
     paddingLeft: 8,
   },
   equalSign: {


### PR DESCRIPTION
When adding fields to the multipart/form-data Upload section the two `TextInput` fields have a height set that is causing them to be clipped on my Nexus 5 (5.1.1) like so: 

![screenshot_2015-09-15-16-50-41](https://cloud.githubusercontent.com/assets/362769/9889808/485a080c-5bca-11e5-9858-6aa51823928b.png)

I've removed the height property, so now it looks like:

![screenshot_2015-09-15-16-50-22](https://cloud.githubusercontent.com/assets/362769/9889806/484f416a-5bca-11e5-9a54-255f0cfc1051.png)


