### PR TITLE
[packager] comment out required flowcheck

### DIFF
--- a/packager/packager.js
+++ b/packager/packager.js
@@ -14,7 +14,8 @@ var childProcess = require('child_process');
 var http = require('http');
 var isAbsolutePath = require('absolute-path');
 
-var getFlowTypeCheckMiddleware = require('./getFlowTypeCheckMiddleware');
+// Temporarily disable flow check until it's more stable
+// var getFlowTypeCheckMiddleware = require('./getFlowTypeCheckMiddleware');
 
 if (!fs.existsSync(path.resolve(__dirname, '..', 'node_modules'))) {
   console.log(


### PR DESCRIPTION
The use of `getFlowTypeCheckMiddleWare` was commentd out in
b94610887c76f7e37406abbf2ffbd5103906284d but the require was left in.
Left lint warnings about unused variable.