### PR TITLE
[packager] try catch requires to check for deps

### DIFF
--- a/packager/packager.js
+++ b/packager/packager.js
@@ -8,15 +8,26 @@
  */
 'use strict';
 
-var fs = require('fs');
-var path = require('path');
-var childProcess = require('child_process');
-var http = require('http');
-var isAbsolutePath = require('absolute-path');
+try {
+  var fs = require('fs');
+  var path = require('path');
+  var childProcess = require('child_process');
+  var http = require('http');
+  var isAbsolutePath = require('absolute-path');
 
-var getFlowTypeCheckMiddleware = require('./getFlowTypeCheckMiddleware');
+  var getFlowTypeCheckMiddleware = require('./getFlowTypeCheckMiddleware');
 
-if (!fs.existsSync(path.resolve(__dirname, '..', 'node_modules'))) {
+  var chalk = require('chalk');
+  var connect = require('connect');
+  var ReactPackager = require('./react-packager');
+  var blacklist = require('./blacklist.js');
+  var checkNodeVersion = require('./checkNodeVersion');
+  var formatBanner = require('./formatBanner');
+  var launchEditor = require('./launchEditor.js');
+  var parseCommandLine = require('./parseCommandLine.js');
+  var webSocketProxy = require('./webSocketProxy.js');
+}
+catch (err) {
   console.log(
     '\n' +
     'Could not find dependencies.\n' +
@@ -25,16 +36,6 @@ if (!fs.existsSync(path.resolve(__dirname, '..', 'node_modules'))) {
   );
   process.exit();
 }
-
-var chalk = require('chalk');
-var connect = require('connect');
-var ReactPackager = require('./react-packager');
-var blacklist = require('./blacklist.js');
-var checkNodeVersion = require('./checkNodeVersion');
-var formatBanner = require('./formatBanner');
-var launchEditor = require('./launchEditor.js');
-var parseCommandLine = require('./parseCommandLine.js');
-var webSocketProxy = require('./webSocketProxy.js');
 
 var options = parseCommandLine([{
   command: 'port',


### PR DESCRIPTION
Instead of checking for `node_modules`, which can be in a different place, try `require`ing the deps and catch if they aren't available then throw the install message

Fixes #1758 hopefully