### PR TITLE
Fix more tests

### DIFF
--- a/local-cli/__mocks__/beeper.js
+++ b/local-cli/__mocks__/beeper.js
@@ -1,0 +1,5 @@
+// beeper@1.1.0 has a return statement outside of a function
+// and therefore doesn't parse. Let's mock it so that we can
+// run the tests.
+
+module.exports = function () {};


### PR DESCRIPTION
beeper node modules has a `return` statement outside of a function which doesn't parse. To fix it, we mock it. Also, setupEnvPolyfills is no longer being used.