### PR TITLE
Fixing the packager  infinite loop on Windows

### DIFF
--- a/packager/react-packager/src/DependencyResolver/DependencyGraph/ResolutionRequest.js
+++ b/packager/react-packager/src/DependencyResolver/DependencyGraph/ResolutionRequest.js
@@ -226,7 +226,7 @@ class ResolutionRequest {
         realModuleName => {
           const searchQueue = [];
           for (let currDir = path.dirname(fromModule.path);
-               currDir !== '/';
+               currDir !== path.parse(fromModule.path).root;
                currDir = path.dirname(currDir)) {
             searchQueue.push(
               path.join(currDir, 'node_modules', realModuleName)

--- a/packager/react-packager/src/DependencyResolver/DependencyGraph/ResolutionRequest.js
+++ b/packager/react-packager/src/DependencyResolver/DependencyGraph/ResolutionRequest.js
@@ -225,8 +225,8 @@ class ResolutionRequest {
       return this._redirectRequire(fromModule, toModuleName).then(
         realModuleName => {
           const searchQueue = [];
-          for (let currDir = path.dirname(fromModule.path);
-               currDir !== path.parse(fromModule.path).root;
+          for (let currDir = path.dirname(fromModule.path),rootPath = path.parse(fromModule.path).root;
+               currDir !== rootPath;
                currDir = path.dirname(currDir)) {
             searchQueue.push(
               path.join(currDir, 'node_modules', realModuleName)


### PR DESCRIPTION
The issue here https://github.com/facebook/react-native/issues/2787

The root path '/' dosn't match windows root path