### PR TITLE
handle back button press in JS

### DIFF
--- a/local-cli/generator-android/templates/package/MainActivity.java
+++ b/local-cli/generator-android/templates/package/MainActivity.java
@@ -45,6 +45,15 @@ public class MainActivity extends Activity implements DefaultHardwareBackBtnHand
     }
 
     @Override
+    public void onBackPressed() {
+      if (mReactInstanceManager != null) {
+        mReactInstanceManager.onBackPressed();
+      } else {
+        super.onBackPressed();
+      }
+    }
+
+    @Override
     public void invokeDefaultOnBackPressed() {
       super.onBackPressed();
     }


### PR DESCRIPTION
It appears that the default Android activity generated by react-native `init` doesn't pass the `onBackPressed` event to the JS, so it can't be handled. I've added a block taken from the [Movies example](https://github.com/facebook/react-native/blob/42eb5464fd8a65ed84b799de5d4dc225349449be/Examples/Movies/android/app/src/main/java/com/facebook/react/movies/MoviesActivity.java#L76-L83) to the default template so the button press will be handled correctly.

I've tested with an app generated by `react-native init` and with the addition of this override `BackAndroid` works as expected.