### PR TITLE
[Android] Removes hardcoded port `8081` from URL format strings

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevServerHelper.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevServerHelper.java
@@ -49,19 +49,19 @@ import okio.Sink;
   public static final String RELOAD_APP_EXTRA_JS_PROXY = "jsproxy";
   private static final String RELOAD_APP_ACTION_SUFFIX = ".RELOAD_APP_ACTION";
 
-  private static final String EMULATOR_LOCALHOST = "10.0.2.2";
-  private static final String GENYMOTION_LOCALHOST = "10.0.3.2";
-  private static final String DEVICE_LOCALHOST = "localhost";
+  private static final String EMULATOR_LOCALHOST = "10.0.2.2:8081";
+  private static final String GENYMOTION_LOCALHOST = "10.0.3.2:8081";
+  private static final String DEVICE_LOCALHOST = "localhost:8081";
 
   private static final String BUNDLE_URL_FORMAT =
-      "http://%s:8081/%s.bundle?platform=android&dev=%s";
+      "http://%s/%s.bundle?platform=android&dev=%s";
   private static final String SOURCE_MAP_URL_FORMAT =
       BUNDLE_URL_FORMAT.replaceFirst("\\.bundle", ".map");
   private static final String LAUNCH_CHROME_DEVTOOLS_COMMAND_URL_FORMAT =
-      "http://%s:8081/launch-chrome-devtools";
+      "http://%s/launch-chrome-devtools";
   private static final String ONCHANGE_ENDPOINT_URL_FORMAT =
-      "http://%s:8081/onchange";
-  private static final String WEBSOCKET_PROXY_URL_FORMAT = "ws://%s:8081/debugger-proxy";
+      "http://%s/onchange";
+  private static final String WEBSOCKET_PROXY_URL_FORMAT = "ws://%s/debugger-proxy";
 
   private static final int LONG_POLL_KEEP_ALIVE_DURATION_MS = 2 * 60 * 1000; // 2 mins
   private static final int LONG_POLL_FAILURE_DELAY_MS = 5000;

--- a/ReactAndroid/src/main/res/devsupport/xml/preferences.xml
+++ b/ReactAndroid/src/main/res/devsupport/xml/preferences.xml
@@ -38,8 +38,8 @@
         />
     <EditTextPreference
         android:key="debug_http_host"
-        android:title="Debug server host for device"
-        android:summary="Debug server host for downloading JS bundle or communicating with JS debugger. With this setting empty launcher should work fine when running on emulator (or genymotion) and connection to debug server running on emulator's host"
+        android:title="Debug server host &amp; port for device"
+        android:summary="Debug server host &amp; port for downloading JS bundle or communicating with JS debugger. With this setting empty launcher should work fine when running on emulator (or genymotion) and connection to debug server running on emulator's host."
         android:defaultValue=""
         />
   </PreferenceCategory>

--- a/docs/RunningOnDeviceAndroid.md
+++ b/docs/RunningOnDeviceAndroid.md
@@ -35,4 +35,4 @@ To do that, your laptop and your phone have to be on the same wifi network.
 1. Open rage shake menu (shake the device) or run `adb shell input keyevent 82`
 2. Go to `Dev Settings`
 3. Go to `Debug server host for device`
-4. Type in your machine's IP and `Reload JS`
+4. Type in your machine's IP and the port of the packager (ie. 8081) and `Reload JS`


### PR DESCRIPTION
This allows the use of different bundle URLs & ports in Dev mode. (ie. ngrok url shared with a team member)

The bundle URL can be changed via the normal Dev Menu, or programmatically by setting the `debug_http_host` shared preference key.

For example, in your apps `MainActivity.java` before creating your `ReactRootView`:
```java
SharedPreferences mPreferences = PreferenceManager.getDefaultSharedPreferences(getApplication());
SharedPreferences.Editor editor = mPreferences.edit();
editor.putString("debug_http_host", "my.customurlandport.com:8888");
editor.commit();
```

**Breaking change**: Custom bundle URLs added via the Dev Menu will need to also include the port. This has been noted in the documentation and also on the preference description in the Dev Menu.

Addresses: https://github.com/facebook/react-native/issues/2704