### PR TITLE
[packager][windows] fixing packager module resolving

### DIFF
--- a/packager/react-packager/src/DependencyResolver/index.js
+++ b/packager/react-packager/src/DependencyResolver/index.js
@@ -163,6 +163,9 @@ HasteDependencyResolver.prototype.getDebugInfo = function() {
 };
 
 function defineModuleCode({moduleName, code, deps}) {
+  //change Win path like'\\' or '\' to '/'
+  deps = deps.replace(/\\+/g,'/');
+  moduleName = moduleName.replace(/\\+/g,'/');
   return [
     `__d(`,
     `'${moduleName}',`,


### PR DESCRIPTION
By using module path as module id cause issues when generate bundle code.
Such as 
```
__d('reactnativedemo\index.android.js',["react-native\\Libraries\\react-native\\react-native.js"],function(global, require, module, exports) {  'use strict';

__d('react-native\Libraries\react-native\react-native.js',[],function(global, require, module, exports) {  'use strict';
```

Replace the Win path '\\' or '\' in  module name and dependence to '/' before generating bundle code,it make sure the bundle get the same module id,and will get the same bundle code form different OS.
