### PR TITLE
[Docs] Split iOS and Android docs into different categories

### DIFF
--- a/docs/Accessibility.md
+++ b/docs/Accessibility.md
@@ -4,7 +4,7 @@ title: Accessibility
 layout: docs
 category: Guides
 permalink: docs/accessibility.html
-next: native-modules-ios
+next: direct-manipulation
 ---
 
 ## iOS

--- a/docs/DirectManipulation.md
+++ b/docs/DirectManipulation.md
@@ -4,7 +4,7 @@ title: Direct Manipulation
 layout: docs
 category: Guides
 permalink: docs/direct-manipulation.html
-next: linking-libraries-ios
+next: debugging
 ---
 
 It is sometimes necessary to make changes directly to a component

--- a/docs/EmbeddedApp.md
+++ b/docs/EmbeddedApp.md
@@ -1,10 +1,10 @@
 ---
 id: embedded-app-ios
-title: Integrating with Existing Apps (iOS)
+title: Integrating with Existing Apps
 layout: docs
-category: Guides
+category: Guides (iOS)
 permalink: docs/embedded-app-ios.html
-next: javascript-environment
+next: native-modules-android
 ---
 
 Since React makes no assumptions about the rest of your technology stack – it’s commonly noted as simply the `V` in `MVC` – it’s easily embeddable within an existing non-React Native app. In fact, it integrates with other best practice community tools like [CocoaPods](http://cocoapods.org/).

--- a/docs/KnownIssues.md
+++ b/docs/KnownIssues.md
@@ -4,7 +4,7 @@ title: Known Issues
 layout: docs
 category: Guides
 permalink: docs/known-issues.html
-next: activityindicatorios
+next: native-modules-ios
 ---
 
 ### Missing Modules and Native Views

--- a/docs/LinkingLibraries.md
+++ b/docs/LinkingLibraries.md
@@ -1,10 +1,10 @@
 ---
 id: linking-libraries-ios
-title: Linking Libraries (iOS)
+title: Linking Libraries
 layout: docs
-category: Guides
+category: Guides (iOS)
 permalink: docs/linking-libraries-ios.html
-next: debugging
+next: running-on-device-ios
 ---
 
 Not every app uses all the native capabilities, and including the code to support

--- a/docs/NativeComponentsAndroid.md
+++ b/docs/NativeComponentsAndroid.md
@@ -1,10 +1,10 @@
 ---
 id: native-components-android
-title: Native UI Components (Android)
+title: Native UI Components
 layout: docs
-category: Guides
+category: Guides (Android)
 permalink: docs/native-components-android.html
-next: direct-manipulation
+next: running-on-device-android
 ---
 
 There are tons of native UI widgets out there ready to be used in the latest apps - some of them are part of the platform, others are available as third-party libraries, and still more might be in use in your very own portfolio. React Native has several of the most critical platform components already wrapped, like `ScrollView` and `TextInput`, but not all of them, and certainly not ones you might have written yourself for a previous app. Fortunately, it's quite easy to wrap up these existing components for seamless integration with your React Native application.

--- a/docs/NativeComponentsIOS.md
+++ b/docs/NativeComponentsIOS.md
@@ -1,10 +1,10 @@
 ---
 id: native-components-ios
-title: Native UI Components (iOS)
+title: Native UI Components
 layout: docs
-category: Guides
+category: Guides (iOS)
 permalink: docs/native-components-ios.html
-next: native-components-android
+next: linking-libraries-ios
 ---
 
 There are tons of native UI widgets out there ready to be used in the latest apps - some of them are part of the platform, others are available as third-party libraries, and still more might be in use in your very own portfolio.  React Native has several of the most critical platform components already wrapped, like `ScrollView` and `TextInput`, but not all of them, and certainly not ones you might have written yourself for a previous app.  Fortunately, it's quite easy to wrap up these existing components for seamless integration with your React Native application.

--- a/docs/NativeModulesAndroid.md
+++ b/docs/NativeModulesAndroid.md
@@ -1,10 +1,10 @@
 ---
 id: native-modules-android
-title: Native Modules (Android)
+title: Native Modules
 layout: docs
-category: Guides
+category: Guides (Android)
 permalink: docs/native-modules-android.html
-next: native-components-ios
+next: native-components-android
 ---
 
 Sometimes an app needs access to a platform API that React Native doesn't have a corresponding module for yet. Maybe you want to reuse some existing Java code without having to reimplement it in JavaScript, or write some high performance, multi-threaded code such as for image processing, a database, or any number of advanced extensions.

--- a/docs/NativeModulesIOS.md
+++ b/docs/NativeModulesIOS.md
@@ -1,10 +1,10 @@
 ---
 id: native-modules-ios
-title: Native Modules (iOS)
+title: Native Modules
 layout: docs
-category: Guides
+category: Guides (iOS)
 permalink: docs/native-modules-ios.html
-next: native-modules-android
+next: native-components-ios
 ---
 
 Sometimes an app needs access to platform API, and React Native doesn't have a corresponding module yet. Maybe you want to reuse some existing Objective-C, Swift or C++ code without having to reimplement it in JavaScript, or write some high performance, multi-threaded code such as for image processing, a database, or any number of advanced extensions.
@@ -264,7 +264,7 @@ You can then define methods and export your enum constants like this:
             @"statusBarAnimationFade" : @(UIStatusBarAnimationFade),
             @"statusBarAnimationSlide" : @(UIStatusBarAnimationSlide) }
 };
-    
+
 RCT_EXPORT_METHOD(updateStatusBarAnimation:(UIStatusBarAnimation)animation
                                 completion:(RCTResponseSenderBlock)callback)
 ```

--- a/docs/RunningOnDeviceAndroid.md
+++ b/docs/RunningOnDeviceAndroid.md
@@ -1,10 +1,10 @@
 ---
 id: running-on-device-android
-title: Running On Device (Android)
+title: Running On Device
 layout: docs
-category: Guides
+category: Guides (Android)
 permalink: docs/running-on-device-android.html
-next: embedded-app-ios
+next: activityindicatorios
 ---
 
 ## USB Debugging

--- a/docs/RunningOnDeviceIOS.md
+++ b/docs/RunningOnDeviceIOS.md
@@ -1,10 +1,10 @@
 ---
 id: running-on-device-ios
-title: Running On Device (iOS)
+title: Running On Device
 layout: docs
-category: Guides
+category: Guides (iOS)
 permalink: docs/running-on-device-ios.html
-next: running-on-device-android
+next: embedded-app-ios
 ---
 
 Note that running on device requires [Apple Developer account](https://developer.apple.com/register) and provisioning your iPhone. This guide covers only React Native specific topic.

--- a/docs/Testing.md
+++ b/docs/Testing.md
@@ -4,7 +4,7 @@ title: Testing
 layout: docs
 category: Guides
 permalink: docs/testing.html
-next: running-on-device-ios
+next: javascript-environment
 ---
 
 ## Running Tests and Contributing


### PR DESCRIPTION
This screenshot explains everything:
<img width="526" alt="screen shot 2015-09-18 at 20 53 05" src="https://cloud.githubusercontent.com/assets/3505878/9966810/90f6475e-5e47-11e5-8847-9c2594082e02.png">
If this would be accepted, I'll do the same with components.