### PR TITLE
Allow loading JS bundles from the file system on Android.

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
@@ -327,12 +327,18 @@ public class ReactInstanceManager {
         return;
       }
     }
+
+    // Load from file system if bundle name is an absolute path.
+    JSBundleLoader loader = mBundleAssetName.startsWith("/")
+            ? JSBundleLoader.createFileLoader(mBundleAssetName)
+            : JSBundleLoader.createAssetLoader(
+                mApplicationContext.getAssets(),
+                mBundleAssetName);
+
     // Use JS file from assets
     recreateReactContext(
         new JSCJavaScriptExecutor(),
-        JSBundleLoader.createAssetLoader(
-            mApplicationContext.getAssets(),
-            mBundleAssetName));
+        loader);
   }
 
   private void recreateReactContext(

--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/JSBundleLoader.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/JSBundleLoader.java
@@ -34,6 +34,18 @@ public abstract class JSBundleLoader {
   }
 
   /**
+   * This loader loads a JS bundle from a location on the file system.
+   */
+  public static JSBundleLoader createFileLoader(final String fileName) {
+    return new JSBundleLoader() {
+      @Override
+      public void loadScript(ReactBridge bridge) {
+        bridge.loadScriptFromFile(fileName);
+      }
+    };
+  }
+
+  /**
    * This loader is used when bundle gets reloaded from dev server. In that case loader expect JS
    * bundle to be prefetched and stored in local file. We do that to avoid passing large strings
    * between java and native code and avoid allocating memory in java to fit whole JS bundle in it.

--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactBridge.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactBridge.java
@@ -61,6 +61,7 @@ public class ReactBridge extends Countable {
       ReactCallback callback,
       MessageQueueThread nativeModulesQueueThread);
   public native void loadScriptFromAssets(AssetManager assetManager, String assetName);
+  public native void loadScriptFromFile(String assetName);
   public native void loadScriptFromNetworkCached(String sourceURL, @Nullable String tempFileName);
   public native void callFunction(int moduleId, int methodId, NativeArray arguments);
   public native void invokeCallback(int callbackID, NativeArray arguments);

--- a/ReactAndroid/src/main/jni/react/jni/OnLoad.cpp
+++ b/ReactAndroid/src/main/jni/react/jni/OnLoad.cpp
@@ -547,6 +547,13 @@ static void loadScriptFromAssets(JNIEnv* env, jobject obj, jobject assetManager,
   bridge->executeApplicationScript(script, assetNameStr);
 }
 
+static void loadScriptFromFile(JNIEnv* env, jobject obj, jstring fileName) {
+  auto bridge = jni::extractRefPtr<Bridge>(env, obj);
+  auto fileNameStr = fromJString(env, fileName);
+  auto script = react::loadScriptFromFile(fileNameStr);
+  bridge->executeApplicationScript(script, fileNameStr);
+}
+
 static void loadScriptFromNetworkCached(JNIEnv* env, jobject obj, jstring sourceURL,
                                    jstring tempFileName) {
   auto bridge = jni::extractRefPtr<Bridge>(env, obj);
@@ -705,6 +712,7 @@ extern "C" JNIEXPORT jint JNI_OnLoad(JavaVM* vm, void* reserved) {
         makeNativeMethod(
           "loadScriptFromAssets", "(Landroid/content/res/AssetManager;Ljava/lang/String;)V",
           bridge::loadScriptFromAssets),
+        makeNativeMethod("loadScriptFromFile", bridge::loadScriptFromFile),
         makeNativeMethod("loadScriptFromNetworkCached", bridge::loadScriptFromNetworkCached),
         makeNativeMethod("callFunction", bridge::callFunction),
         makeNativeMethod("invokeCallback", bridge::invokeCallback),


### PR DESCRIPTION
This enables developers to use absolute paths to load JS bundles
from the file system. For example:

    mReactInstanceManager = ReactInstanceManager.builder()
        .setApplication(getApplication())
        .setBundleAssetName(Environment.getExternalStorageDirectory() + "/UIExplorerApp.android.bundle")
        .setJSMainModuleName("Examples/UIExplorer/UIExplorerApp.android")
        .addPackage(new MainReactPackage())
        .setInitialLifecycleState(LifecycleState.RESUMED)
        .build();

Tested manually, as there are no public Android tests right now.