### PR TITLE
Extend NavigatorIOS to support obj-c view controllers for hybrid apps

### DIFF
--- a/Libraries/Components/Navigation/NavigatorIOS.ios.js
+++ b/Libraries/Components/Navigation/NavigatorIOS.ios.js
@@ -603,6 +603,10 @@ var NavigatorIOS = React.createClass({
             this.props.itemWrapperStyle,
             route.wrapperStyle
           ]}
+          viewControllerStoryboard={route.viewControllerStoryboard}
+          viewControllerIdentifier={route.viewControllerIdentifier}
+          viewControllerProperties={route.viewControllerProperties}
+          onViewControllerEvent={route.onViewControllerEvent}
           backButtonIcon={this._imageNameFromSource(route.backButtonIcon)}
           backButtonTitle={route.backButtonTitle}
           leftButtonIcon={this._imageNameFromSource(route.leftButtonIcon)}
@@ -617,11 +621,11 @@ var NavigatorIOS = React.createClass({
           barTintColor={this.props.barTintColor}
           translucent={this.props.translucent !== false}
           titleTextColor={this.props.titleTextColor}>
-          <Component
-            navigator={this.navigator}
-            route={route}
-            {...route.passProps}
-          />
+          {Component ? <Component
+              navigator={this.navigator}
+              route={route}
+              {...route.passProps}
+            /> : null}
         </RCTNavigatorItem>
       </StaticContainer>
     );

--- a/React/Views/RCTNavItem.h
+++ b/React/Views/RCTNavItem.h
@@ -34,4 +34,13 @@
 @property (nonatomic, copy) RCTBubblingEventBlock onNavLeftButtonTap;
 @property (nonatomic, copy) RCTBubblingEventBlock onNavRightButtonTap;
 
+/*
+ * Adds the ability to use pre-written view
+ * controllers in the navigation stack created
+ * from JS and let them have full control.
+ */
+@property (nonatomic, copy) NSString *viewControllerStoryboard;
+@property (nonatomic, copy) NSString *viewControllerIdentifier;
+@property (nonatomic, copy) NSDictionary *viewControllerProperties;
+
 @end

--- a/React/Views/RCTNavItemManager.m
+++ b/React/Views/RCTNavItemManager.m
@@ -42,4 +42,8 @@ RCT_EXPORT_VIEW_PROPERTY(rightButtonTitle, NSString)
 RCT_EXPORT_VIEW_PROPERTY(onNavLeftButtonTap, RCTBubblingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onNavRightButtonTap, RCTBubblingEventBlock)
 
+RCT_EXPORT_VIEW_PROPERTY(viewControllerStoryboard, NSString)
+RCT_EXPORT_VIEW_PROPERTY(viewControllerIdentifier, NSString)
+RCT_EXPORT_VIEW_PROPERTY(viewControllerProperties, NSDictionary)
+
 @end

--- a/React/Views/RCTNavigator.m
+++ b/React/Views/RCTNavigator.m
@@ -506,8 +506,25 @@ BOOL jsGettingtooSlow =
   }
   if (jsGettingAhead) {
     if (reactPushOne) {
-      UIView *lastView = _currentViews.lastObject;
-      RCTWrapperViewController *vc = [[RCTWrapperViewController alloc] initWithNavItem:(RCTNavItem *)lastView];
+      RCTNavItem *lastNavItem = (RCTNavItem *)_currentViews.lastObject;
+      
+      RCTWrapperViewController *vc;
+      if (lastNavItem.viewControllerStoryboard) {
+        UIStoryboard *storyboard = [UIStoryboard storyboardWithName:lastNavItem.viewControllerStoryboard bundle:nil];
+        if (lastNavItem.viewControllerIdentifier) {
+          vc = [storyboard instantiateViewControllerWithIdentifier:lastNavItem.viewControllerIdentifier];
+        } else {
+          vc = [storyboard instantiateInitialViewController];
+        }
+        
+        for (NSString *propertyKey in lastNavItem.viewControllerProperties) {
+          [vc setValue:lastNavItem.viewControllerProperties[propertyKey] forKey:propertyKey];
+        }
+        vc.navItem = lastNavItem;
+        vc.eventDispatcher = _bridge.eventDispatcher;
+      } else {
+        vc = [[RCTWrapperViewController alloc] initWithNavItem:lastNavItem eventDispatcher:_bridge.eventDispatcher];
+      }
       vc.navigationListener = self;
       _numberOfViewControllerMovesToIgnore = 1;
       [_navigationController pushViewController:vc animated:(currentReactCount > 1)];

--- a/React/Views/RCTNavigatorManager.m
+++ b/React/Views/RCTNavigatorManager.m
@@ -27,6 +27,7 @@ RCT_EXPORT_MODULE()
 RCT_EXPORT_VIEW_PROPERTY(requestedTopOfStack, NSInteger)
 RCT_EXPORT_VIEW_PROPERTY(onNavigationProgress, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onNavigationComplete, RCTBubblingEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onViewControllerEvent, RCTBubblingEventBlock)
 
 // TODO: remove error callbacks
 RCT_EXPORT_METHOD(requestSchedulingJavaScriptNavigation:(nonnull NSNumber *)reactTag

--- a/React/Views/RCTWrapperViewController.h
+++ b/React/Views/RCTWrapperViewController.h
@@ -28,5 +28,6 @@ didMoveToNavigationController:(UINavigationController *)navigationController;
 
 @property (nonatomic, weak) id<RCTWrapperViewControllerNavigationListener> navigationListener;
 @property (nonatomic, strong) RCTNavItem *navItem;
+@property RCTEventDispatcher *eventDispatcher;
 
 @end

--- a/React/Views/RCTWrapperViewController.m
+++ b/React/Views/RCTWrapperViewController.m
@@ -22,7 +22,6 @@
 {
   UIView *_wrapperView;
   UIView *_contentView;
-  RCTEventDispatcher *_eventDispatcher;
   CGFloat _previousTopLayoutLength;
   CGFloat _previousBottomLayoutLength;
 }


### PR DESCRIPTION
Sharing something we are using to make the transition to React Native easier for us. We have a bunch of view controllers written in Objective-C that we would like to support while also using React Native on some of the other views in the navigation stack of `NavigatorIOS`.

This pull request shows how we are able to push the entire Objective-C view controller on `NavigatorIOS` as per the discretion of JS. From JS, we do something like this:

```
this.props.navigator.push({
  viewControllerStoryboard='SearchResults',
  viewControllerProperties={{
    title: 'Searching for Pizza around you',
    query: 'pizza'
  }}
});
```

On the Objective-C this instantiates `SearchResults.storyboard`, sets up the properties on it and pushes it onto `NavigatorIOS`. When a user taps on something, we notify JS back using the `RCTDeviceEventEmitter` with the event name `onViewControllerEvent`.

To use any existing pre-written view controller here, it simply needs to use the same methods and properties as the `RCTWrapperViewController`.

Would this be useful in the core?