### PR TITLE
Prop routeMapper of Navigator.NavigationBar is required

### DIFF
--- a/Libraries/CustomComponents/Navigator/NavigatorNavigationBar.js
+++ b/Libraries/CustomComponents/Navigator/NavigatorNavigationBar.js
@@ -52,7 +52,7 @@ var NavigatorNavigationBar = React.createClass({
       Title: React.PropTypes.func.isRequired,
       LeftButton: React.PropTypes.func.isRequired,
       RightButton: React.PropTypes.func.isRequired,
-    }),
+    }).isRequired,
     navState: React.PropTypes.shape({
       routeStack: React.PropTypes.arrayOf(React.PropTypes.object),
       presentedIndex: React.PropTypes.number,


### PR DESCRIPTION
The component will crash if the prop is not provided. This helps with a better
error message in the console output.