### PR TITLE
Allow web as a valid build platform, fixes #2895

### DIFF
--- a/packager/react-packager/src/DependencyResolver/DependencyGraph/index.js
+++ b/packager/react-packager/src/DependencyResolver/DependencyGraph/index.js
@@ -60,7 +60,7 @@ const validateOpts = declareOpts({
   },
   platforms: {
     type: 'array',
-    default: ['ios', 'android'],
+    default: ['ios', 'android', 'web'],
   },
   cache: {
     type: 'object',


### PR DESCRIPTION
There seems to be no reason why the packager can't be used with `web` as well.