### PR TITLE
Fix typo

### DIFF
--- a/docs/KnownIssues.md
+++ b/docs/KnownIssues.md
@@ -76,7 +76,7 @@ We don't support shadows on Android currently. These are notoriously hard to imp
 
 ### Layout-only nodes on Android
 
-An optimization feature of the Android version of React Native is for views which only contribute to the layout to not have a native view, only their layout properties are propagated to their children views. This optimization is to provide stability in deep view hierarchies for React Native and gis therefore enabled by default. Should you depend on a view being present or internal tests incorrectly detect a view is layout only it will be necessary to turn off this behavior. To do this, set `collapsable` to false as in this example:
+An optimization feature of the Android version of React Native is for views which only contribute to the layout to not have a native view, only their layout properties are propagated to their children views. This optimization is to provide stability in deep view hierarchies for React Native and is therefore enabled by default. Should you depend on a view being present or internal tests incorrectly detect a view is layout only it will be necessary to turn off this behavior. To do this, set `collapsable` to false as in this example:
 ```
 <View collapsable={false}>
     ...


### PR DESCRIPTION
changed
`... for React Native and gis therefore enabled by default.`

to

`... for React Native and is therefore enabled by default.`

Sorry I didn't apply the fix to the master branch originally.