### PR TITLE
Fix for displayName transform

### DIFF
--- a/packager/packager.js
+++ b/packager/packager.js
@@ -285,7 +285,7 @@ function getAppMiddleware(options) {
     nonPersistent: options.nonPersistent,
     projectRoots: options.projectRoots,
     blacklistRE: blacklist(),
-    cacheVersion: '2',
+    cacheVersion: '3',
     transformModulePath: transformerPath,
     assetRoots: options.assetRoots,
     assetExts: ['png', 'jpeg', 'jpg'],

--- a/packager/react-packager/.babelrc
+++ b/packager/react-packager/.babelrc
@@ -20,6 +20,7 @@
     "es7.objectRestSpread",
     "flow",
     "react",
+    "react.displayName",
     "regenerator"
   ],
   "sourceMaps": false

--- a/packager/transformer.js
+++ b/packager/transformer.js
@@ -31,6 +31,7 @@ function transform(src, filename, options) {
     comments: false,
     filename,
     whitelist: [
+      // Keep in sync with packager/react-packager/.babelrc
       'es6.arrowFunctions',
       'es6.blockScoping',
       'es6.classes',


### PR DESCRIPTION
The `react.displayName` transform was added in 93b9329b758cde3e921b26e11ba91d9700d2a06d.

That diff missed to update the `.babelrc` where the comment says it should stay
in sync (I'm not sure where it's used though). I added a comment in the other
direction so this can be prevented in the future.

I also updated the `cacheVersion` so we actually transform the code again to add
the missing displayName properties to unchanged components.