### PR TITLE
Invoking devMenu from RCTBridge in prod will crash

### DIFF
--- a/React/Modules/RCTDevMenu.m
+++ b/React/Modules/RCTDevMenu.m
@@ -624,7 +624,11 @@ RCT_EXPORT_METHOD(reload)
 
 - (RCTDevMenu *)devMenu
 {
+#if RCT_DEV
   return self.modules[RCTBridgeModuleNameForClass([RCTDevMenu class])];
+#else
+  return nil;
+#endif
 }
 
 @end


### PR DESCRIPTION
While we shouldn't invoke `bridge.devMenu` in production, doing it will result into a crash. 

1. `devMenu` internally calls `RCTBridgeModuleNameForClass([RCTDevMenu class])`
2. `RCTBridgeModuleNameForClass()` calls `moduleName`
3. In the release code `RCTDevMenu` doesn't export the `moduleName` class method.