### PR TITLE
support es6.constants by default. Fixes #2932

### DIFF
--- a/packager/react-packager/.babelrc
+++ b/packager/react-packager/.babelrc
@@ -6,9 +6,8 @@
   "whitelist": [
     "es6.arrowFunctions",
     "es6.blockScoping",
-    // This is the only place where we differ from transformer.js
-    "es6.constants",
     "es6.classes",
+    "es6.constants",
     "es6.destructuring",
     "es6.parameters",
     "es6.properties.computed",

--- a/packager/transformer.js
+++ b/packager/transformer.js
@@ -33,8 +33,8 @@ function transform(src, filename, options) {
     whitelist: [
       'es6.arrowFunctions',
       'es6.blockScoping',
-      'es6.constants',
       'es6.classes',
+      'es6.constants',
       'es6.destructuring',
       'es6.parameters',
       'es6.properties.computed',

--- a/packager/transformer.js
+++ b/packager/transformer.js
@@ -33,6 +33,7 @@ function transform(src, filename, options) {
     whitelist: [
       'es6.arrowFunctions',
       'es6.blockScoping',
+      'es6.constants',
       'es6.classes',
       'es6.destructuring',
       'es6.parameters',


### PR DESCRIPTION
In javascriptcore(ios9), this code will run as expected(output 0 1):

```js
for(let i=0; i<2; i++) {
  const data = i;
  console.log(data);
}
```

But when debug in chrome, the above code will fail without `use strict` prologue (if you add prologue, rn will fail with red screen `Const declarations are not supported in strict mode`): https://code.google.com/p/v8/issues/detail?id=4432.

So it's better to transpile contant by default.

