### PR TITLE
[Tests] Increase yeoman generator timeout

### DIFF
--- a/local-cli/__tests__/generator-android-test.js
+++ b/local-cli/__tests__/generator-android-test.js
@@ -5,10 +5,21 @@ jest.autoMockOff();
 var path = require('path');
 
 describe('react:android', function () {
-  var assert = require('yeoman-generator').assert;
+  var assert;
 
   beforeEach(function (done) {
+    // A deep dependency of yeoman spams console.log with giant json objects.
+    // yeoman-generator/node_modules/
+    //   download/node_modules/
+    //     caw/node_modules/
+    //       get-proxy/node_modules/
+    //         rc/index.js
+    var log = console.log;
+    console.log = function() {};
+    assert = require('yeoman-generator').assert;
     var helpers = require('yeoman-generator').test;
+    console.log = log;
+
     var generated = false;
 
     runs(function() {
@@ -26,7 +37,7 @@ describe('react:android', function () {
       jest.runAllTicks();
       jest.runOnlyPendingTimers();
       return generated;
-    }, "generation", 750);
+    }, 'Timed out generating TestApp Android project', 5000);
   });
 
   it('creates files', function () {

--- a/local-cli/__tests__/generator-ios-test.js
+++ b/local-cli/__tests__/generator-ios-test.js
@@ -34,7 +34,7 @@ describe('react:ios', function() {
       jest.runAllTicks();
       jest.runOnlyPendingTimers();
       return generated;
-    }, "generation", 750);
+    }, 'Timed out generating TestApp iOS project', 5000);
   });
 
   it('creates files', function() {

--- a/local-cli/__tests__/generator-test.js
+++ b/local-cli/__tests__/generator-test.js
@@ -9,6 +9,7 @@ describe('react:react', function() {
   var assert;
 
   beforeEach(function() {
+    console.log('generating....');
     // A deep dependency of yeoman spams console.log with giant json objects.
     // yeoman-generator/node_modules/
     //   download/node_modules/
@@ -35,10 +36,11 @@ describe('react:react', function() {
       jest.runAllTicks();
       jest.runOnlyPendingTimers();
       return generated;
-    }, "generation", 750);
+    }, 'Timed out generating TestApp project', 5000);
   });
 
   it('creates files', function() {
+    console.log('testing creates files');
     assert.file([
       '.flowconfig',
       '.gitignore',
@@ -49,6 +51,7 @@ describe('react:react', function() {
   });
 
   it('replaces vars in index.ios.js', function() {
+    console.log('testing replaces vars in index.ios.js');
     assert.fileContent('index.ios.js', 'var TestApp = React.createClass({');
     assert.fileContent(
       'index.ios.js',
@@ -78,5 +81,5 @@ describe('react:react', function() {
     var stat = fs.statSync('android');
 
     expect(stat.isDirectory()).toBe(true);
-  })
+  });
 });


### PR DESCRIPTION
The tests were failing on my MBP till I increased the timeout... this should help Travis without making the tests too slow in case there is a real issue. The timeout is now 5 seconds (15sec for Android). If the generator completes before then, the test will proceed. Otherwise the tests will just move on and probably fail (which is what's currently happening).