### PR TITLE
Force LF line endings for Bash scripts, so they work on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Force LF line endings for Bash scripts.   On Windows the rest of the source
+# files will typically have CR+LF endings (Git default on Windows), but Bash
+# scripts need to have LF endings to work (under Cygwin), thus override to force
+# that.
+gradlew text eol=lf
+*.sh text eol=lf


### PR DESCRIPTION
Added a .gitattributes file, ensuring that Bash script source files (gradlew and
*.sh) have normal Unix LF line endings even on Windows.  This change is needed
so gradlew, packager.sh, and other Bash scripts can run on Windows (under Cygwin).
On Windows the rest of the source files will typically have CR+LF endings (Git
default), but Bash scripts need to have LF endings to work, thus this override
to force that.