### PR TITLE
Added a more explicit error message when ndk.dir / ANDROID_NDK is set,

### DIFF
--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -160,11 +160,18 @@ def findNdkBuildFullPath() {
 
 def getNdkBuildFullPath() {
     def ndkBuildFullPath = findNdkBuildFullPath()
-    if (ndkBuildFullPath == null || !new File(ndkBuildFullPath).canExecute()) {
+    if (ndkBuildFullPath == null) {
         throw new GradleScriptException(
             "ndk-build binary cannot be found, check if you've set " +
             "\$ANDROID_NDK environment variable correctly or if ndk.dir is " +
             "setup in local.properties",
+            null)
+    }
+    if (!new File(ndkBuildFullPath).canExecute()) {
+        throw new GradleScriptException(
+            "ndk-build binary " + ndkBuildFullPath + " doesn't exist or isn't executable.\n" +
+            "Check that the \$ANDROID_NDK environment variable, or ndk.dir in local.proerties, is set correctly.\n" +
+            "(On Windows, make sure you escape backslashes in local.properties or use forward slashes, e.g. C:\\\\ndk or C:/ndk rather than C:\\ndk)",
             null)
     }
     return ndkBuildFullPath


### PR DESCRIPTION
but the NDK build command can't be found in that directory.   This
more explicit error now shows the full NDK path where it's looking
and (importantly) includes a hint that backslashes need to be escaped
on Windows for ndk.dir.   When I built on Windows the first time,
I didn't realize ndk.dir backslashes needed to be escaped and the
generic "not found" error made the root cause harder to track
down.   This change should help others that build on Windows & run into
the same.