### PR TITLE
Fixed to use ; instead of : as the path delimiter on Windows, for NDK_MODULE_PATH

### DIFF
--- a/ReactAndroid/src/main/jni/Application.mk
+++ b/ReactAndroid/src/main/jni/Application.mk
@@ -4,7 +4,8 @@ APP_ABI := armeabi-v7a x86
 APP_PLATFORM := android-9
 
 APP_MK_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
-NDK_MODULE_PATH := $(APP_MK_DIR):$(THIRD_PARTY_NDK_DIR):$(APP_MK_DIR)/first-party
+
+NDK_MODULE_PATH := $(APP_MK_DIR)$(HOST_DIRSEP)$(THIRD_PARTY_NDK_DIR)$(HOST_DIRSEP)$(APP_MK_DIR)first-party
 
 APP_STL := gnustl_shared
 


### PR DESCRIPTION
Also fixed the extra slash before first-party in that path (it was ...//first-party
and is now .../first-party).  The $dir funct always produces a result that ends with
a /, so APP_MK_DIR always ends in a / and no extra / is needed when appending to it.
With these two changes all of React Native for Android, including C++, seems to
build OK on Windows :smile: 