### PR TITLE
[iOS] [Text] allowFontScaling lineHeight fix

### DIFF
--- a/Libraries/Text/RCTShadowText.m
+++ b/Libraries/Text/RCTShadowText.m
@@ -268,7 +268,7 @@ static css_dim_t RCTMeasure(void *context, float width)
     NSMutableParagraphStyle *paragraphStyle = [NSMutableParagraphStyle new];
     paragraphStyle.alignment = _textAlign;
     paragraphStyle.baseWritingDirection = _writingDirection;
-    CGFloat lineHeight = round(_lineHeight * self.fontSizeMultiplier);
+    CGFloat lineHeight = round(_lineHeight * (_allowFontScaling && _fontSizeMultiplier > 0.0 ? _fontSizeMultiplier : 1.0));
     paragraphStyle.minimumLineHeight = lineHeight;
     paragraphStyle.maximumLineHeight = lineHeight;
     [attributedString addAttribute:NSParagraphStyleAttributeName


### PR DESCRIPTION
When accessibility options for larger text are enabled and a text object has a style that defines lineHeight and allowFontScaling is set to false the text size is properly set and will not increase but the line height is still getting multiplied by  "_fontSizeMultiplier"

```js 
<Text allowFontScaling={false} style={{ lineHeight: 30, fontSize: 30}}>TEST</Text>
```