### PR TITLE
change native-modules link to work on gh-pages

### DIFF
--- a/docs/NativeComponentsAndroid.md
+++ b/docs/NativeComponentsAndroid.md
@@ -96,7 +96,7 @@ Setting properties on a view is not handled by automatically calling setter meth
 
 ## 5. Register the `ViewManager`
 
-The final Java step is to register the ViewManager to the application, this happens in a similar way to [Native Modules](NativeModulesAndroid.md), via the applications package member function `createViewManagers.`
+The final Java step is to register the ViewManager to the application, this happens in a similar way to [Native Modules](native-modules-android.html), via the applications package member function `createViewManagers.`
 
 ```java
   @Override


### PR DESCRIPTION
The link from [native components](http://facebook.github.io/react-native/docs/native-components-android.html#5-register-the-viewmanager) to [native modules](https://facebook.github.io/react-native/docs/native-modules-android.html#content) is broken in the gh-pages docs. This PR points it to the right address in pages (note that this will break the link in the GitHub markdown view, but I think the number of people that will view the page through the docs site dwarf those who view it in the repository).