### PR TITLE
Don’t report failure to npm-start with arg support

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "scripts": {
     "test": "NODE_ENV=test jest",
     "lint": "eslint Examples/ Libraries/",
-    "start": "./packager/packager.sh || true"
+    "start": "/usr/bin/env bash -c './packager/packager.sh \"$@\" || true' --"
   },
   "bin": {
     "react-native": "local-cli/wrong-react-native.js"


### PR DESCRIPTION
This supports passing args to `npm start` as referenced in [this comment][comment] while still returning 0 on failure from an npm perspective. 

This builds off the npm change in [this commit][commit] and discussed in this [PR].

[comment]: https://github.com/facebook/react-native/pull/2415#issuecomment-141309448
[commit]: https://github.com/facebook/react-native/commit/75df3b537ae071b0b4d1b01ae75d66ec5457bb1e
[PR]: https://github.com/facebook/react-native/pull/2415