### PR TITLE
Change comments in Examples for OPTION 2 in AppDelegate.m

### DIFF
--- a/Examples/Movies/Movies/AppDelegate.m
+++ b/Examples/Movies/Movies/AppDelegate.m
@@ -44,7 +44,7 @@
    * Load from pre-bundled file on disk. To re-generate the static bundle, `cd`
    * to your Xcode project folder in the terminal, and run
    *
-   * $ curl 'http://localhost:8081/Examples/Movies/MoviesApp.includeRequire.runModule.bundle' -o main.jsbundle
+   * $ curl 'http://localhost:8081/Examples/Movies/MoviesApp.ios.includeRequire.runModule.bundle?platform=ios' -o main.jsbundle
    *
    * then add the `main.jsbundle` file to your project and uncomment this line:
    */

--- a/Examples/SampleApp/iOS/SampleApp/AppDelegate.m
+++ b/Examples/SampleApp/iOS/SampleApp/AppDelegate.m
@@ -35,12 +35,12 @@
 
   /**
    * OPTION 2
-   * Load from pre-bundled file on disk. To re-generate the static bundle
-   * from the root of your project directory, run
+   * Load from pre-bundled file on disk. To re-generate the static bundle, `cd`
+   * to your Xcode project folder and run
    *
-   * $ react-native bundle --minify
+   * $ curl 'http://localhost:8081/Examples/SampleApp/index.ios.bundle?platform=ios' -o main.jsbundle
    *
-   * see http://facebook.github.io/react-native/docs/runningondevice.html
+   * then uncomment this line:
    */
 
 //   jsCodeLocation = [[NSBundle mainBundle] URLForResource:@"main" withExtension:@"jsbundle"];

--- a/Examples/UIExplorer/UIExplorer/AppDelegate.m
+++ b/Examples/UIExplorer/UIExplorer/AppDelegate.m
@@ -66,7 +66,7 @@
      * Load from pre-bundled file on disk. To re-generate the static bundle, `cd`
      * to your Xcode project folder and run
      *
-     * $ curl 'http://localhost:8081/Examples/UIExplorer/UIExplorerApp.ios.bundle' -o main.jsbundle
+     * $ curl 'http://localhost:8081/Examples/UIExplorer/UIExplorerApp.ios.bundle?platform=ios' -o main.jsbundle
      *
      * then add the `main.jsbundle` file to your project and uncomment this line:
      */

--- a/local-cli/generator-ios/templates/app/AppDelegate.m
+++ b/local-cli/generator-ios/templates/app/AppDelegate.m
@@ -40,7 +40,7 @@
    *
    * $ react-native bundle --minify
    *
-   * see http://facebook.github.io/react-native/docs/runningondevice.html
+   * see http://facebook.github.io/react-native/docs/running-on-device-ios.html
    */
 
 //   jsCodeLocation = [[NSBundle mainBundle] URLForResource:@"main" withExtension:@"jsbundle"];


### PR DESCRIPTION
Re: [Issue 2645](https://github.com/facebook/react-native/issues/2645#issuecomment-142689573) --- the Example code in most examples doesn't work with OPTION 2 (generating a static main.jsbundle file) as directed in the comments. This changes the comments to something that works.

Notes: 
- I could not get `react-native bundle` to work on any of the Examples, so I used the curl command, adding the required `platform=ios`. 
- Although the comment in SampleApp had been changed to `react-native bundle` I could not get that to work. Changed to back to `curl` which worked.
- I could not get 2048 to run. The Run command in XCode is greyed out for some reason. I left its comment unchanged.
- in `local-cli/generator-ios/templates/app/AppDelegate.m` the URL for running on device instructions has changed, so I fixed that.
