### PR TITLE
[npm] Include ReactAndroid with the npm distribution

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "files": [
     "React",
     "React.podspec",
+    "ReactAndroid",
     "Libraries",
     "packager",
     "cli.js",


### PR DESCRIPTION
Enables building RN Android from source while keeping it in sync with the iOS distribution.