### PR TITLE
[Docs] Remove recommendation to install nvm from brew

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -10,9 +10,9 @@ next: android-setup
 ## Requirements
 
 1. OS X - Only OS X is currently supported
-2. [Homebrew](http://brew.sh/) is the recommended way to install nvm, watchman, and flow.
+2. [Homebrew](http://brew.sh/) is the recommended way to install Watchman and Flow.
 3. Install [Node.js](https://nodejs.org/) 4.0 or newer.
-  - Install **nvm** with Homebrew or [its setup instructions here](https://github.com/creationix/nvm#installation). Then run `nvm install node && nvm alias default node`, which installs the latest version of Node.js and sets up your terminal so you can run it by typing `node`. With nvm you can install multiple versions of Node.js and easily switch between them.
+  - Install **nvm** with [its setup instructions here](https://github.com/creationix/nvm#installation). Then run `nvm install node && nvm alias default node`, which installs the latest version of Node.js and sets up your terminal so you can run it by typing `node`. With nvm you can install multiple versions of Node.js and easily switch between them.
   - New to [npm](https://docs.npmjs.com/)?
 4. `brew install watchman`. We recommend installing [watchman](https://facebook.github.io/watchman/docs/install.html), otherwise you might hit a node file watching bug.
 5. `brew install flow`, if you want to use [flow](http://www.flowtype.org).


### PR DESCRIPTION
The nvm maintainers have their own recommended installation instructions (via shell script or git checkout), which are linked to from the docs.

Fixes #3037 