### PR TITLE
Add 3dTouch props to touch events

### DIFF
--- a/React/Base/RCTTouchHandler.m
+++ b/React/Base/RCTTouchHandler.m
@@ -152,7 +152,7 @@ typedef NS_ENUM(NSInteger, RCTTouchEventType) {
   reactTouch[@"timestamp"] =  @(nativeTouch.timestamp * 1000); // in ms, for JS
   
   if ([nativeTouch.view respondsToSelector:@selector(traitCollection)] &&
-      [[[nativeTouch view] traitCollection] respondsToSelector:@selector(forceTouchCapability)] {
+      [nativeTouch.view.traitCollection respondsToSelector:@selector(forceTouchCapability)] {
 
     reactTouch[@"force"] = @(nativeTouch.force);
     reactTouch[@"maxForce"] =  @(nativeTouch.maximumPossibleForce);

--- a/React/Base/RCTTouchHandler.m
+++ b/React/Base/RCTTouchHandler.m
@@ -151,7 +151,7 @@ typedef NS_ENUM(NSInteger, RCTTouchEventType) {
   reactTouch[@"locationY"] = @(touchViewLocation.y);
   reactTouch[@"timestamp"] =  @(nativeTouch.timestamp * 1000); // in ms, for JS
   
-  if([UIDevice currentDevice].systemVersion.floatValue >= 9) {
+  if ([UIDevice currentDevice].systemVersion.floatValue >= 9) {
     reactTouch[@"force"] = @(nativeTouch.force);
     reactTouch[@"maxForce"] =  @(nativeTouch.maximumPossibleForce);
   }

--- a/React/Base/RCTTouchHandler.m
+++ b/React/Base/RCTTouchHandler.m
@@ -108,7 +108,7 @@ typedef NS_ENUM(NSInteger, RCTTouchEventType) {
     }
 
     // Create touch
-    NSMutableDictionary *reactTouch = [[NSMutableDictionary alloc] initWithCapacity:9];
+    NSMutableDictionary *reactTouch = [[NSMutableDictionary alloc] initWithCapacity:11];
     reactTouch[@"target"] = reactTag;
     reactTouch[@"identifier"] = @(touchID);
     reactTouch[@"touches"] = (id)kCFNull;        // We hijack this touchObj to serve both as an event
@@ -150,6 +150,11 @@ typedef NS_ENUM(NSInteger, RCTTouchEventType) {
   reactTouch[@"locationX"] = @(touchViewLocation.x);
   reactTouch[@"locationY"] = @(touchViewLocation.y);
   reactTouch[@"timestamp"] =  @(nativeTouch.timestamp * 1000); // in ms, for JS
+  
+  if([UIDevice currentDevice].systemVersion.floatValue >= 9) {
+    reactTouch[@"force"] = @(nativeTouch.force);
+    reactTouch[@"maxForce"] =  @(nativeTouch.maximumPossibleForce);
+  }
 }
 
 /**

--- a/React/Base/RCTTouchHandler.m
+++ b/React/Base/RCTTouchHandler.m
@@ -151,7 +151,9 @@ typedef NS_ENUM(NSInteger, RCTTouchEventType) {
   reactTouch[@"locationY"] = @(touchViewLocation.y);
   reactTouch[@"timestamp"] =  @(nativeTouch.timestamp * 1000); // in ms, for JS
   
-  if ([UIDevice currentDevice].systemVersion.floatValue >= 9) {
+  if ([nativeTouch.view respondsToSelector:@selector(traitCollection)] &&
+      [[[nativeTouch view] traitCollection] respondsToSelector:@selector(forceTouchCapability)] {
+
     reactTouch[@"force"] = @(nativeTouch.force);
     reactTouch[@"maxForce"] =  @(nativeTouch.maximumPossibleForce);
   }


### PR DESCRIPTION
This adds the first of the three 3dTouch API types, that found on the touch event.

It adds the following props to touch events when running on iOS 9 devices:
- touch
- maxTouch