### PR TITLE
prevent NPE when drawRoundedBackgroundWithBorders 

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewBackgroundDrawable.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewBackgroundDrawable.java
@@ -180,6 +180,11 @@ import com.facebook.csslayout.Spacing;
 
   private void drawRoundedBackgroundWithBorders(Canvas canvas) {
     updatePath();
+
+    if (mPathForBorderRadius == null) {
+      return;
+    }
+
     int useColor = ColorUtil.multiplyColorAlpha(mColor, mAlpha);
     if ((useColor >>> 24) != 0) { // color is not transparent
       mPaint.setColor(useColor);


### PR DESCRIPTION
fix #3069 

```
E/AndroidRuntime(14469): java.lang.NullPointerException: Attempt to read from field 'boolean android.graphics.Path.isSimplePath' on a null object reference
E/AndroidRuntime(14469):    at android.view.GLES20Canvas.drawPath(GLES20Canvas.java:796)
E/AndroidRuntime(14469):    at com.facebook.react.views.view.ReactViewBackgroundDrawable.drawRoundedBackgroundWithBorders(ReactViewBackgroundDrawable.java:187)
E/AndroidRuntime(14469):    at com.facebook.react.views.view.ReactViewBackgroundDrawable.draw(ReactViewBackgroundDrawable.java:91)
```