### PR TITLE
[Android] .gitignore entries for generator template (previously SampleApp)

### DIFF
--- a/local-cli/generator/templates/_gitignore
+++ b/local-cli/generator/templates/_gitignore
@@ -22,6 +22,12 @@ DerivedData
 *.xcuserstate
 project.xcworkspace
 
+# Android/IJ
+#
+.idea
+.gradle
+local.properties
+
 # node.js
 #
 node_modules/


### PR DESCRIPTION
Adds `.gitignore` entires for the Android environment. When running `react-native run-android`, the build will generate `android/build` and `android/.gradle`. This will exclude the generated files from VC.