### PR TITLE
Added content to docs specially the 'Register Module' section. Thus m…

### DIFF
--- a/docs/NativeModulesAndroid.md
+++ b/docs/NativeModulesAndroid.md
@@ -89,21 +89,44 @@ ReadableArray -> Array
 ### Register the Module
 
 The last step within Java is to register the Module; this happens in the `createNativeModules` of your apps package. If a module is not registered it will not be available from JavaScript.
-
+In the Module registry class it is important you override three methods `createNativeModules`, `createJSModules` and `createViewManagers`.
 ```java
-class AnExampleReactPackage implements ReactPackage {
+//AnExampleReactPackage.java
+package com.facebook.react.modules.toast;
 
-  ...
+import java.util.ArrayList;
+import java.util.List;
+
+import com.facebook.react.ReactPackage;
+import com.facebook.react.bridge.JavaScriptModule;
+import com.facebook.react.bridge.NativeModule;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.uimanager.ViewManager;
+
+
+public class AnExampleReactPackage implements ReactPackage {
 
   @Override
   public List<NativeModule> createNativeModules(
                               ReactApplicationContext reactContext) {
     List<NativeModule> modules = new ArrayList<>();
-
+    
+    //Registering the module.
     modules.add(new ToastModule(reactContext));
 
     return modules;
   }
+
+  @Override
+  public List<Class<? extends JavaScriptModule>> createJSModules() {
+      return new ArrayList();
+  }
+
+  @Override
+  public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
+      return new ArrayList();
+  }
+}
 ```
 
 The package needs to be provided to the ReactInstanceManager when it is built. See `UIExplorerActivity.java` for an example. The default package when you initialize a new project is `MainReactPackage.java`.

--- a/docs/NativeModulesAndroid.md
+++ b/docs/NativeModulesAndroid.md
@@ -90,6 +90,9 @@ ReadableArray -> Array
 
 The last step within Java is to register the Module; this happens in the `createNativeModules` of your apps package. If a module is not registered it will not be available from JavaScript.
 In the package class it is important you override three methods: `createNativeModules`, `createJSModules` and `createViewManagers`.
+
+Note : It is necessary to have same package name of `MainActivity.java` in your packaging class and module class. Only then your module will be accessible across classes. 
+
 ```java
 //AnExampleReactPackage.java
 package com.example.modules.toast;

--- a/docs/NativeModulesAndroid.md
+++ b/docs/NativeModulesAndroid.md
@@ -113,7 +113,7 @@ public class AnExampleReactPackage implements ReactPackage {
   public List<NativeModule> createNativeModules(
                               ReactApplicationContext reactContext) {
     //Registering the module.
-    return Arrays.asList(new ToastModule(reactContext));
+    return Arrays.<NativeModule>asList(new ToastModule(reactContext));
   }
 
   @Override

--- a/docs/NativeModulesAndroid.md
+++ b/docs/NativeModulesAndroid.md
@@ -103,7 +103,6 @@ import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.uimanager.ViewManager;
 
-
 public class AnExampleReactPackage implements ReactPackage {
 
   @Override
@@ -119,12 +118,12 @@ public class AnExampleReactPackage implements ReactPackage {
 
   @Override
   public List<Class<? extends JavaScriptModule>> createJSModules() {
-      return new ArrayList();
+    return new ArrayList();
   }
 
   @Override
   public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
-      return new ArrayList();
+    return new ArrayList();
   }
 }
 ```

--- a/docs/NativeModulesAndroid.md
+++ b/docs/NativeModulesAndroid.md
@@ -18,7 +18,7 @@ This guide will use the [Toast](http://developer.android.com/reference/android/w
 We start by creating a native module. A native module is a Java class that usually extends the `ReactContextBaseJavaModule` class and implements the functionality required by the JavaScript. Our goal here is to be able to write `ToastAndroid.show('Awesome', ToastAndroid.SHORT);` from JavaScript to display a short toast on the screen.
 
 ```java
-package com.facebook.react.modules.toast;
+package com.example.modules.toast;
 
 import android.widget.Toast;
 
@@ -89,12 +89,13 @@ ReadableArray -> Array
 ### Register the Module
 
 The last step within Java is to register the Module; this happens in the `createNativeModules` of your apps package. If a module is not registered it will not be available from JavaScript.
-In the Module registry class it is important you override three methods `createNativeModules`, `createJSModules` and `createViewManagers`.
+In the package class it is important you override three methods: `createNativeModules`, `createJSModules` and `createViewManagers`.
 ```java
 //AnExampleReactPackage.java
-package com.facebook.react.modules.toast;
+package com.example.modules.toast;
 
-import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import com.facebook.react.ReactPackage;
@@ -108,22 +109,18 @@ public class AnExampleReactPackage implements ReactPackage {
   @Override
   public List<NativeModule> createNativeModules(
                               ReactApplicationContext reactContext) {
-    List<NativeModule> modules = new ArrayList<>();
-    
     //Registering the module.
-    modules.add(new ToastModule(reactContext));
-
-    return modules;
+    return Arrays.asList(new ToastModule(reactContext));
   }
 
   @Override
   public List<Class<? extends JavaScriptModule>> createJSModules() {
-    return new ArrayList();
+    return Collections.emptyList();
   }
 
   @Override
   public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
-    return new ArrayList();
+    return Collections.emptyList();
   }
 }
 ```

--- a/docs/NativeModulesAndroid.md
+++ b/docs/NativeModulesAndroid.md
@@ -91,7 +91,7 @@ ReadableArray -> Array
 The last step within Java is to register the Module; this happens in the `createNativeModules` of your apps package. If a module is not registered it will not be available from JavaScript.
 In the package class it is important you override three methods: `createNativeModules`, `createJSModules` and `createViewManagers`.
 
-Note : It is necessary to have same package name of `MainActivity.java` in your packaging class and module class. Only then your module will be accessible across classes. 
+Note: It is necessary to have same package name of `MainActivity.java` in your packaging class and module class. Only then your module will be accessible across classes. 
 
 ```java
 //AnExampleReactPackage.java


### PR DESCRIPTION
Added content to docs specially the 'Register Module' section. Thus makes the example workable also clears understanding on overriding methods on AnExampleReactPackage which were not listed otherwise.

Hi, After running circles around the docs it was extremely difficult to build a simple Native module. the pieces of implementing the module registry class was missing.  I figured it out from the compile time error message. I feel this will certainly help readers.  
Thanks.