### PR TITLE
Format Code in TextInput Comment

### DIFF
--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -68,8 +68,8 @@ type Event = Object;
  *   />
  * ```
  *
- * Note that some props are only available with multiline={true/false}:
- *
+ * Note that some props are only available with `multiline={true/false}`:
+ * ```
  *   var onlyMultiline = {
  *     onSelectionChange: true, // not supported in Open Source yet
  *     onTextInput: true, // not supported in Open Source yet
@@ -79,6 +79,7 @@ type Event = Object;
  *   var notMultiline = {
  *     onSubmitEditing: true,
  *   };
+ * ```
  */
 var TextInput = React.createClass({
   propTypes: {


### PR DESCRIPTION
* wrap code snippet in TextInput Comment in backticks ```
* unless there is a way to omit portions of comments from reaching the
docs this is less confusing