### PR TITLE
[CLI] add swift-bridge command to generate swift bridging header

### DIFF
--- a/docs/EmbeddedApp.md
+++ b/docs/EmbeddedApp.md
@@ -35,6 +35,15 @@ Then install your pods:
 $ pod install
 ```
 
+## Generate Swift Bridging Header
+**(For iOS apps written in Swift)**
+
+There is a cli command that will generate the imports you need to be able to call ReactNative from your Swift code. You can pass in all specs that you included in your project as a comma separated list. The output can be sent to a file using `--out <filename>`.
+
+```
+react-native swift-bridge --out Bridging-Header.h React,RCTText
+```
+
 ## Create Your React Native App
 
 There are two pieces you’ll need to set up:

--- a/local-cli/__tests__/swift-bridge-test.js
+++ b/local-cli/__tests__/swift-bridge-test.js
@@ -1,0 +1,87 @@
+'use strict';
+
+jest.dontMock('../swift-bridge');
+
+var swiftBridge = require('../swift-bridge');
+var path = require.requireActual('path');
+var fs = require.requireActual('fs');
+
+jest.setMock('path', {
+  join: function(path1, path2) {
+    if (path2 === 'node_modules/react-native') {
+      return path1;
+    }
+    return path.join(path1, path2);
+  }
+});
+
+describe('swift-bridge', function() {
+  var originalLog;
+  var originalExit;
+  var outFile = 'out.file';
+
+  beforeEach(function() {
+    originalLog = console.log;
+    originalExit = process.exit;
+
+    console.log = jest.genMockFunction();
+    process.exit = jest.genMockFunction();
+  });
+
+  afterEach(function() {
+    console.log = originalLog;
+    process.exit = originalExit;
+    try {
+      fs.unlinkSync(outFile);
+    } catch(e) {}
+  });
+
+  it('displays usage instructions when help flag is set', function() {
+    swiftBridge.init(['--help']);
+
+    expect(console.log).toBeCalled();
+    expect(process.exit).toBeCalled();
+    expect(console.log.mock.calls[0][0]).toContain('Usage: react-native swift-bridge');
+  });
+
+  it('displays usage instructions when project name is not passed in', function() {
+    swiftBridge.init([]);
+
+    expect(console.log).toBeCalled();
+    expect(process.exit).toBeCalled();
+    expect(console.log.mock.calls[0][0]).toContain('No project name was passed in');
+    expect(console.log.mock.calls[1][0]).toContain('Usage: react-native swift-bridge');
+  });
+
+  it('displays usage instructions when a flag but no project name is passed in', function() {
+    swiftBridge.init(['--any']);
+
+    expect(console.log).toBeCalled();
+    expect(process.exit).toBeCalled();
+    expect(console.log.mock.calls[0][0]).toContain('No project name was passed in');
+    expect(console.log.mock.calls[1][0]).toContain('Usage: react-native swift-bridge');
+  });
+
+  it('displays usage instructions --out flag but no project name is passed in', function() {
+    swiftBridge.init(['--out', outFile]);
+
+    expect(console.log).toBeCalled();
+    expect(process.exit).toBeCalled();
+    expect(console.log.mock.calls[0][0]).toContain('No project name was passed in');
+    expect(console.log.mock.calls[1][0]).toContain('Usage: react-native swift-bridge');
+  });
+
+  it('spits out output to console', function() {
+    swiftBridge.init(['RCTImage']);
+
+    expect(console.log).toBeCalled();
+    expect(console.log.mock.calls[0][0]).toContain('#import');
+  });
+
+  it('spits out output to output file', function() {
+    swiftBridge.init(['--out', outFile, 'RCTImage']);
+
+    expect(fs.readFileSync(outFile)).toContain('#import');
+    expect(console.log.mock.calls.length).toBe(0);
+  });
+});

--- a/local-cli/cli.js
+++ b/local-cli/cli.js
@@ -5,8 +5,6 @@
 'use strict';
 
 var fs = require('fs');
-var spawn = require('child_process').spawn;
-var path = require('path');
 var generateAndroid = require('./generate-android.js');
 var init = require('./init.js');
 var install = require('./install.js');
@@ -14,6 +12,7 @@ var bundle = require('./bundle.js');
 var newLibrary = require('./new-library.js');
 var runAndroid = require('./run-android.js');
 var runPackager = require('./run-packager.js');
+var swiftBridge = require('./swift-bridge.js');
 
 function printUsage() {
   console.log([
@@ -24,7 +23,8 @@ function printUsage() {
     '  install: installs npm react components',
     '  bundle: builds the javascript bundle for offline use',
     '  new-library: generates a native library bridge',
-    '  android: generates an Android project for your app'
+    '  android: generates an Android project for your app',
+    '  swift-bridge: generates import statements for swift bridging header',
   ].join('\n'));
   process.exit(1);
 }
@@ -55,6 +55,9 @@ function run() {
     break;
   case 'new-library':
     newLibrary.init(args);
+    break;
+  case 'swift-bridge':
+    swiftBridge.init(args);
     break;
   case 'init':
     printInitWarning();

--- a/local-cli/swift-bridge.js
+++ b/local-cli/swift-bridge.js
@@ -1,0 +1,71 @@
+'use strict';
+
+var path = require('path');
+var execSync = require('child_process').execSync;
+
+function generateImports(projectNames, flags) {
+  var reactNativeRoot = path.join(process.cwd(), 'node_modules/react-native');
+  var command;
+
+  if (flags.out) {
+    command = 'find %%%% -name "*.h" | awk -F\'/\' \'{print "#import \\""$NF"\\""}\' >> ' + flags.out;
+  } else {
+    command = 'find %%%% -name "*.h" | awk -F\'/\' \'{print "#import \\""$NF"\\""}\'';
+  }
+
+  for (var index = 0; index < projectNames.length; index++) {
+    var projectRelativePath = _getPath(reactNativeRoot, projectNames[index]);
+    var projectPath = path.join(reactNativeRoot, projectRelativePath);
+    if (flags.out) {
+      execSync(command.replace('%%%%', projectPath));
+    } else {
+      console.log(execSync(command.replace('%%%%', projectPath), {encoding: 'utf8'}));
+    }
+  }
+}
+
+function _getPath(reactNativeRoot, projectName) {
+  var findOutput = execSync('find ' + reactNativeRoot + ' -name ' + projectName + '.xcodeproj', {encoding: 'utf8'});
+  if (findOutput.length > 0) {
+    findOutput = findOutput.replace(reactNativeRoot + '/', '');
+    findOutput = findOutput.replace('/' + projectName + '.xcodeproj\n', '');
+  }
+  return findOutput;
+}
+
+function showHelp() {
+  console.log([
+    'Usage: react-native swift-bridge [options] <project1>[,<project2>]',
+    '',
+    'Each project name must match the xcode project name',
+    'Options:',
+    '  --out\t\tspecify the output file',
+  ].join('\n'));
+  process.exit(1);
+}
+
+module.exports = {
+  init: function(args) {
+    var projectNames = [];
+    var flags = {
+      help: args.indexOf('--help') !== -1,
+      out: args.indexOf('--out') !== -1 ? args[args.indexOf('--out') + 1] : false,
+    };
+
+    if (flags.help) {
+      showHelp();
+    } else {
+      if (args.length === 0 ||
+          args[args.length - 1].startsWith('--') ||
+          (args.length > 1 && args[args.length - 2] === '--out')
+          ) {
+        console.log('No project name was passed in');
+        showHelp();
+      } else {
+        projectNames = args[args.length - 1].split(',');
+      }
+
+      generateImports(projectNames, flags);
+    }
+  }
+};


### PR DESCRIPTION
Fixes #1669 

I added a command to the CLI to generate the import statements needed for the Swift bridging header. You pass in the comma separated list of all the ReactNative pod specs / projects you added to your app and it will spit out what you need to the console, or directly into a file with the `--out` option.

I updated the Docs website to include this step for Swift devs.

@yelled3 have a look and let me know if this solves your issue.
@brentvatne for review as well. This goes along with my other swift PR.