### PR TITLE
[WebView iOS] add allowsInlineMediaPlayback prop to play inline html5 video

### DIFF
--- a/Libraries/Components/WebView/WebView.ios.js
+++ b/Libraries/Components/WebView/WebView.ios.js
@@ -107,6 +107,17 @@ var WebView = React.createClass({
      * user can change the scale
      */
     scalesPageToFit: PropTypes.bool,
+    /**
+    * Determines whether HTML5 videos play inline or use the native full-screen 
+    * controller.
+    * default value `false`
+    * **NOTE** : "In order for video to play inline, not only does this 
+    * property need to be set to true, but the video element in the HTML 
+    * document must also include the webkit-playsinline attribute."
+    * @platform ios
+    */
+    allowsInlineMediaPlayback: PropTypes.bool,
+
   },
 
   getInitialState: function() {
@@ -168,6 +179,7 @@ var WebView = React.createClass({
         onLoadingFinish={this.onLoadingFinish}
         onLoadingError={this.onLoadingError}
         scalesPageToFit={this.props.scalesPageToFit}
+        allowsInlineMediaPlayback={this.props.allowsInlineMediaPlayback}
       />;
 
     return (

--- a/React/Views/RCTWebViewManager.m
+++ b/React/Views/RCTWebViewManager.m
@@ -34,6 +34,7 @@ RCT_EXPORT_VIEW_PROPERTY(automaticallyAdjustContentInsets, BOOL);
 RCT_EXPORT_VIEW_PROPERTY(onLoadingStart, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onLoadingFinish, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onLoadingError, RCTDirectEventBlock);
+RCT_REMAP_VIEW_PROPERTY(allowsInlineMediaPlayback, _webView.allowsInlineMediaPlayback, BOOL);
 
 - (NSDictionary *)constantsToExport
 {


### PR DESCRIPTION
Allow an html5 video to be played inline. (see #3112) 