### PR TITLE
Documentation Update

### DIFF
--- a/Libraries/Modal/Modal.js
+++ b/Libraries/Modal/Modal.js
@@ -23,13 +23,14 @@ var RCTModalHostView = requireNativeComponent('RCTModalHostView', null);
  * A Modal component covers the native view (e.g. UIViewController, Activity)
  * that contains the React Native root.
  *
- * Use Modal in hybrid apps that embed React Native; Modal allows the portion of
+ * Use Modal in existing apps that embed React Native; Modal allows the portion of
  * your app written in React Native to present content above the enclosing
  * native view hierarchy.
  *
  * In apps written with React Native from the root view down, you should use
  * Navigator instead of Modal. With a top-level Navigator, you have more control
- * over how to present the modal scene over the rest of your app.
+ * over how to present the modal scene over the rest of your app by using the
+ * configureScene property.
  */
 class Modal extends React.Component {
   render(): ?ReactElement {

--- a/Libraries/Modal/Modal.js
+++ b/Libraries/Modal/Modal.js
@@ -23,7 +23,7 @@ var RCTModalHostView = requireNativeComponent('RCTModalHostView', null);
  * A Modal component covers the native view (e.g. UIViewController, Activity)
  * that contains the React Native root.
  *
- * Use Modal in existing apps that embed React Native; Modal allows the portion of
+ * Use Modal in hybrid apps that embed React Native; Modal allows the portion of
  * your app written in React Native to present content above the enclosing
  * native view hierarchy.
  *


### PR DESCRIPTION
The first change is to remove the word 'Hybrid' to a lot of javascript developers the word Hybrid is normally referred to as a webview app (such as Cordova) and this may cause confusion.

The second change is to refer to the property within Navigator that allows a scene to be presented from the bottom of the screen (like a modal).