### PR TITLE
Update ScrollView.js Documention

### DIFF
--- a/Libraries/Components/ScrollView/ScrollView.js
+++ b/Libraries/Components/ScrollView/ScrollView.js
@@ -169,7 +169,7 @@ var ScrollView = React.createClass({
      * When false, tapping outside of the focused text input when the keyboard
      * is up dismisses the keyboard. When true, the scroll view will not catch
      * taps, and the keyboard will not dismiss automatically. The default value
-     * is false.
+     * is true.
      */
     keyboardShouldPersistTaps: PropTypes.bool,
     /**


### PR DESCRIPTION
`keyboardShouldPersistTaps` default value is `true` but documentation mentions `false`.