### PR TITLE
fix incorrect count for layoutAnimation callback

### DIFF
--- a/React/Modules/RCTUIManager.m
+++ b/React/Modules/RCTUIManager.m
@@ -506,7 +506,7 @@ extern NSString *RCTBridgeModuleNameForClass(Class cls);
 
       void (^completion)(BOOL) = ^(BOOL finished) {
         completionsCalled++;
-        if (callback && completionsCalled == frames.count - 1) {
+        if (callback && completionsCalled == frames.count) {
           callback(@[@(finished)]);
         }
       };


### PR DESCRIPTION
fixes #3106
Having -1 would trigger callback one frame early causing it to be ignored on the next frame.