### PR TITLE
Update ProgressBar website docs to use <ProgressBarAndroid>

### DIFF
--- a/docs/progressbarandroid.html
+++ b/docs/progressbarandroid.html
@@ -2,7 +2,7 @@
 that the app is loading or there is some activity in the app.</p><p>Example:</p><div class="prism language-javascript">render<span class="token punctuation">:</span> <span class="token keyword">function</span><span class="token punctuation">(</span><span class="token punctuation">)</span> <span class="token punctuation">{</span>
   <span class="token keyword">var</span> progressBar <span class="token operator">=</span>
     &lt;View style<span class="token operator">=</span><span class="token punctuation">{</span>styles<span class="token punctuation">.</span>container<span class="token punctuation">}</span><span class="token operator">&gt;</span>
-      &lt;ProgressBar styleAttr<span class="token operator">=</span><span class="token string">&quot;Inverse&quot;</span> <span class="token operator">/</span><span class="token operator">&gt;</span>
+      &lt;ProgressBarAndroid styleAttr<span class="token operator">=</span><span class="token string">&quot;Inverse&quot;</span> <span class="token operator">/</span><span class="token operator">&gt;</span>
     &lt;<span class="token operator">/</span>View<span class="token operator">&gt;</span><span class="token punctuation">;</span>
 
   <span class="token keyword">return</span> <span class="token punctuation">(</span>
@@ -31,27 +31,27 @@ that the app is loading or there is some activity in the app.</p><p>Example:</p>
     <span class="token keyword">return</span> <span class="token punctuation">(</span>
       &lt;UIExplorerPage title<span class="token operator">=</span><span class="token string">&quot;ProgressBar Examples&quot;</span><span class="token operator">&gt;</span>
         &lt;UIExplorerBlock title<span class="token operator">=</span><span class="token string">&quot;Default ProgressBar&quot;</span><span class="token operator">&gt;</span>
-          &lt;ProgressBar <span class="token operator">/</span><span class="token operator">&gt;</span>
+          &lt;ProgressBarAndroid <span class="token operator">/</span><span class="token operator">&gt;</span>
         &lt;<span class="token operator">/</span>UIExplorerBlock<span class="token operator">&gt;</span>
 
         &lt;UIExplorerBlock title<span class="token operator">=</span><span class="token string">&quot;Small ProgressBar&quot;</span><span class="token operator">&gt;</span>
-          &lt;ProgressBar styleAttr<span class="token operator">=</span><span class="token string">&quot;Small&quot;</span> <span class="token operator">/</span><span class="token operator">&gt;</span>
+          &lt;ProgressBarAndroid styleAttr<span class="token operator">=</span><span class="token string">&quot;Small&quot;</span> <span class="token operator">/</span><span class="token operator">&gt;</span>
         &lt;<span class="token operator">/</span>UIExplorerBlock<span class="token operator">&gt;</span>
 
         &lt;UIExplorerBlock title<span class="token operator">=</span><span class="token string">&quot;Large ProgressBar&quot;</span><span class="token operator">&gt;</span>
-          &lt;ProgressBar styleAttr<span class="token operator">=</span><span class="token string">&quot;Large&quot;</span> <span class="token operator">/</span><span class="token operator">&gt;</span>
+          &lt;ProgressBarAndroid styleAttr<span class="token operator">=</span><span class="token string">&quot;Large&quot;</span> <span class="token operator">/</span><span class="token operator">&gt;</span>
         &lt;<span class="token operator">/</span>UIExplorerBlock<span class="token operator">&gt;</span>
 
         &lt;UIExplorerBlock title<span class="token operator">=</span><span class="token string">&quot;Inverse ProgressBar&quot;</span><span class="token operator">&gt;</span>
-          &lt;ProgressBar styleAttr<span class="token operator">=</span><span class="token string">&quot;Inverse&quot;</span> <span class="token operator">/</span><span class="token operator">&gt;</span>
+          &lt;ProgressBarAndroid styleAttr<span class="token operator">=</span><span class="token string">&quot;Inverse&quot;</span> <span class="token operator">/</span><span class="token operator">&gt;</span>
         &lt;<span class="token operator">/</span>UIExplorerBlock<span class="token operator">&gt;</span>
 
         &lt;UIExplorerBlock title<span class="token operator">=</span><span class="token string">&quot;Small Inverse ProgressBar&quot;</span><span class="token operator">&gt;</span>
-          &lt;ProgressBar styleAttr<span class="token operator">=</span><span class="token string">&quot;SmallInverse&quot;</span> <span class="token operator">/</span><span class="token operator">&gt;</span>
+          &lt;ProgressBarAndroid styleAttr<span class="token operator">=</span><span class="token string">&quot;SmallInverse&quot;</span> <span class="token operator">/</span><span class="token operator">&gt;</span>
         &lt;<span class="token operator">/</span>UIExplorerBlock<span class="token operator">&gt;</span>
 
         &lt;UIExplorerBlock title<span class="token operator">=</span><span class="token string">&quot;Large Inverse ProgressBar&quot;</span><span class="token operator">&gt;</span>
-          &lt;ProgressBar styleAttr<span class="token operator">=</span><span class="token string">&quot;LargeInverse&quot;</span> <span class="token operator">/</span><span class="token operator">&gt;</span>
+          &lt;ProgressBarAndroid styleAttr<span class="token operator">=</span><span class="token string">&quot;LargeInverse&quot;</span> <span class="token operator">/</span><span class="token operator">&gt;</span>
         &lt;<span class="token operator">/</span>UIExplorerBlock<span class="token operator">&gt;</span>
       &lt;<span class="token operator">/</span>UIExplorerPage<span class="token operator">&gt;</span>
     <span class="token punctuation">)</span><span class="token punctuation">;</span>


### PR DESCRIPTION
Docs currently use <ProgressBar>, should be <ProgressBarAndroid> per what currently works. Not sure if you have plans to rename the component to ProgressBar down the road.