### PR TITLE
[Packager] Expose the projectRoots option

### DIFF
--- a/packager/packager.js
+++ b/packager/packager.js
@@ -42,6 +42,10 @@ var options = parseCommandLine([{
   type: 'string',
   description: 'add another root(s) to be used by the packager in this project',
 }, {
+  command: 'projectRoots',
+  type: 'string',
+  description: 'override the root(s) to be used by the packager',
+}, {
   command: 'assetRoots',
   type: 'string',
   description: 'specify the root directories of app assets'


### PR DESCRIPTION
This was already implemented -- just documenting it in the CLI.

Test Plan: `packager.sh --projectRoot /my/project`