### PR TITLE
Fix build process for react-native-fbsdk libraries.

### DIFF
--- a/React.podspec
+++ b/React.podspec
@@ -24,7 +24,6 @@ Pod::Spec.new do |s|
   s.platform            = :ios, "7.0"
   s.prepare_command     = 'npm install --production'
   s.preserve_paths      = "cli.js", "Libraries/**/*.js", "lint", "linter.js", "node_modules", "package.json", "packager", "PATENTS", "react-native-cli"
-  s.header_mappings_dir = "."
 
   s.subspec 'Core' do |ss|
     ss.source_files     = "React/**/*.{c,h,m}"


### PR DESCRIPTION
I found the problem with building react-native-fbsdk (https://github.com/facebook/react-native-fbsdk) libraries when I used cocoapods.
When we use the option 'header_mappings_dir = "."' , header files of React will be copied with subfolders structures, not into one folder "${PODS_ROOT}/Headers/Public/React". And we should add recursive search and write "${PODS_ROOT}/Headers/Public/React/**". However writing code in auto-generated files is not good idea.