### PR TITLE
[cli] make init backwards-compatible for real

### DIFF
--- a/local-cli/init.js
+++ b/local-cli/init.js
@@ -7,7 +7,7 @@ function init(projectDir, argsOrName) {
   console.log('Setting up new React Native app in ' + projectDir);
   var env = yeoman.createEnv();
   env.register(require.resolve(path.join(__dirname, 'generator')), 'react:app');
-  var args = Array.isArray(argsOrName) ? argsOrName : [argsOrName].concat(process.args.slice(4));
+  var args = Array.isArray(argsOrName) ? argsOrName : [argsOrName].concat(process.argv.slice(4));
   var generator = env.create('react:app', {args: args});
   generator.destinationRoot(projectDir);
   generator.run();


### PR DESCRIPTION
https://github.com/facebook/react-native/commit/046d8d2dee91e11965adf084a2a41a7b9ac6213a did not do the job because `process.args` is not a thing.

Ran into this issue and manually verified that this worked.

@ide @foghina for review and quick merge please