### PR TITLE
[UIManager] Only handle accessibility notifications from the correct RCTAccessibilityManager

### DIFF
--- a/React/Modules/RCTUIManager.m
+++ b/React/Modules/RCTUIManager.m
@@ -229,18 +229,8 @@ extern NSString *RCTBridgeModuleNameForClass(Class cls);
     _rootViewTags = [NSMutableSet new];
 
     _bridgeTransactionListeners = [NSMutableSet new];
-
-    [[NSNotificationCenter defaultCenter] addObserver:self
-                                             selector:@selector(didReceiveNewContentSizeMultiplier)
-                                                 name:RCTAccessibilityManagerDidUpdateMultiplierNotification
-                                               object:nil];
   }
   return self;
-}
-
-- (void)dealloc
-{
-  [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
 - (void)didReceiveNewContentSizeMultiplier
@@ -276,6 +266,8 @@ extern NSString *RCTBridgeModuleNameForClass(Class cls);
     [_pendingUIBlocksLock lock];
     _pendingUIBlocks = nil;
     [_pendingUIBlocksLock unlock];
+
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
   });
 }
 
@@ -296,6 +288,11 @@ extern NSString *RCTBridgeModuleNameForClass(Class cls);
   }
 
   _componentDataByName = [componentDataByName copy];
+
+  [[NSNotificationCenter defaultCenter] addObserver:self
+                                           selector:@selector(didReceiveNewContentSizeMultiplier)
+                                               name:RCTAccessibilityManagerDidUpdateMultiplierNotification
+                                             object:_bridge.accessibilityManager];
 }
 
 - (dispatch_queue_t)methodQueue


### PR DESCRIPTION
When you reload and create a new bridge, one of the things that happens during setup is that the RCTAccessibilityManager fires a notification. The old bridge would receive this notification from the new bridge's RCTAccessibilityManager, which we don't want, especially because the two are running on different shadow queues.

I believe this led to a gnarly crash in NSConcreteTextStorage because RCTMeasure in RCTShadowText.m was getting called for the old RCTText (getting destroyed) from a notification fired from the new shadow queue. The fix is for the UIManager to handle notifications only from its bridge's RCTAccessibilityManager. See #2001 for the kinds of crashes we were seeing.

Test Plan: Loaded a complex app. Crashes on reload seem to have gone away but this was non-deterministic so there may still be other issues.