### PR TITLE
[Node] Add Node >= 4 requirement to package.json and packager/package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "type": "git",
     "url": "git@github.com:facebook/react-native.git"
   },
+  "engines": {
+    "node": ">=4"
+  },
   "jest": {
     "scriptPreprocessor": "jestSupport/preprocessor.js",
     "setupEnvScriptFile": "jestSupport/env.js",

--- a/packager/package.json
+++ b/packager/package.json
@@ -6,6 +6,9 @@
     "type": "git",
     "url": "git@github.com:facebook/react-native.git"
   },
+  "engines": {
+    "node": ">=4"
+  },
   "jest": {
     "setupEnvScriptFile": "jestSupport/env.js",
     "testPathIgnorePatterns": [


### PR DESCRIPTION
When you try to install these with old Node you'll now get a message from npm telling you that your version of Node is old. This makes it more obvious what's going on and hopefully reduces the number of issues we get due to people using an old version of Node.