### PR TITLE
[CLI] Add Node >= 4 requirement to CLI tools

### DIFF
--- a/react-native-cli/package.json
+++ b/react-native-cli/package.json
@@ -1,8 +1,11 @@
 {
   "name": "react-native-cli",
-  "version": "0.1.4",
-  "description": "The ReactNative cli tools",
+  "version": "0.1.6",
+  "description": "The React Native CLI tools",
   "main": "index.js",
+  "engines": {
+    "node": ">=4"
+  },
   "scripts": {
     "test": "mocha"
   },


### PR DESCRIPTION
React Native's packager now relies on modern V8 so it depends on modern Node. The CLI tools actually run with older versions of Node but the version constraint in the CLI's package.json accomplishes two things:

- Lets us rely on modern V8 in the CLI so we don't have to think about which JS features we can use
- Fails faster up front. So if someone has Node 0.10 for example they will get an error when setting up the CLI tools instead of later on in the process.