### PR TITLE
[Android] Check that WS connection is open before closing it on failed. Fixes #3346

### DIFF
--- a/Libraries/WebSocket/WebSocket.js
+++ b/Libraries/WebSocket/WebSocket.js
@@ -115,7 +115,7 @@ class WebSocket extends WebSocketBase {
         this.onerror && this.onerror(event);
         this.dispatchEvent(event);
         this._unregisterEvents();
-        this._closeWebSocket(id);
+        this.readyState === this.OPEN && this._closeWebSocket(id);
       })
     ];
   }


### PR DESCRIPTION
Check that the WS state is set to OPEN before trying to close it when the ```websocketFailed``` event fires. Otherwise the app throws an error at the Android level.

Fixes #3346