### PR TITLE
Fix the wrong offline bundle link in Movie example

### DIFF
--- a/Examples/Movies/Movies/AppDelegate.m
+++ b/Examples/Movies/Movies/AppDelegate.m
@@ -44,7 +44,7 @@
    * Load from pre-bundled file on disk. To re-generate the static bundle, `cd`
    * to your Xcode project folder in the terminal, and run
    *
-   * $ curl 'http://localhost:8081/Examples/Movies/MoviesApp.includeRequire.runModule.bundle' -o main.jsbundle
+   * $ curl 'http://localhost:8081/Examples/Movies/MoviesApp.ios.bundle?platform=ios&dev=true' -o main.jsbundle
    *
    * then add the `main.jsbundle` file to your project and uncomment this line:
    */


### PR DESCRIPTION
When I am trying to figure out if there are several js files, there is only one bundle file. I am trying to use the command line in the comment which is
<code>curl 'http://localhost:8081/Examples/Movies/MoviesApp.includeRequire.runModule.bundle' -o main.jsbundle</code>
But after react native has upgraded to 0.12, this command line didn't work. You need to use:
<code>curl 'http://localhost:8081/Examples/Movies/MoviesApp.ios.bundle?platform=ios&dev=true' -o main.jsbundle</code>
And then it will work