### PR TITLE
add zIndex property to view based on iOS native layer.zPosition

### DIFF
--- a/Examples/UIExplorer/ViewExample.js
+++ b/Examples/UIExplorer/ViewExample.js
@@ -84,6 +84,35 @@ var ViewBorderStyleExample = React.createClass({
   }
 });
 
+var ZIndexViewExample = React.createClass({
+  getInitialState() {
+    return {
+      supportzIndex: true
+    };
+  },
+  render() {
+    if (Platform.OS !== 'ios') {
+       return (
+          <View style={{backgroundColor: 'red'}}>
+            <Text style={{color: 'white'}}>
+              zIndex is only supported on iOS for now.
+            </Text>
+          </View>
+        );
+    }
+    return (
+      <View style={{height : 100}}>
+        <View style={{backgroundColor : "#000000",  height : 100, width : 100, zIndex : 1, position : "absolute", top : 0}}>
+          <Text style={{color : "#FFFFFF"}}>foreground</Text>
+        </View>
+        <View style={{backgroundColor : "#FFFFFF",  height : 100, width : 100,  position : "absolute", top : 0}}>
+          <Text style={{color : "#000000"}}>background</Text>
+        </View>
+      </View>
+    )
+  }
+});
+
 exports.title = '<View>';
 exports.description = 'Basic building block of all UI, examples that ' +
   'demonstrate some of the many styles available.';
@@ -198,5 +227,10 @@ exports.examples = [
         </View>
       );
     },
-  },
+  },{
+    title : 'zIndex', 
+    render(){
+      return <ZIndexViewExample />
+    }
+  }
 ];

--- a/Libraries/Components/View/ViewStylePropTypes.js
+++ b/Libraries/Components/View/ViewStylePropTypes.js
@@ -47,6 +47,7 @@ var ViewStylePropTypes = {
   ),
   shadowOpacity: ReactPropTypes.number,
   shadowRadius: ReactPropTypes.number,
+  zIndex: ReactPropTypes.number,
 };
 
 module.exports = ViewStylePropTypes;

--- a/React/Views/RCTViewManager.m
+++ b/React/Views/RCTViewManager.m
@@ -122,6 +122,7 @@ RCT_REMAP_VIEW_PROPERTY(shadowColor, layer.shadowColor, CGColor);
 RCT_REMAP_VIEW_PROPERTY(shadowOffset, layer.shadowOffset, CGSize);
 RCT_REMAP_VIEW_PROPERTY(shadowOpacity, layer.shadowOpacity, float)
 RCT_REMAP_VIEW_PROPERTY(shadowRadius, layer.shadowRadius, CGFloat)
+RCT_REMAP_VIEW_PROPERTY(zIndex, layer.zPosition, CGFloat)
 RCT_REMAP_VIEW_PROPERTY(overflow, clipsToBounds, css_clip_t)
 RCT_CUSTOM_VIEW_PROPERTY(shouldRasterizeIOS, BOOL, RCTView)
 {


### PR DESCRIPTION
I needed to be able to put a view above an another one without reordering them. 

I called that zIndex, but not sure if it has the same behavior than on the web. 

https://developer.apple.com/library/ios/documentation/GraphicsImaging/Reference/CALayer_class/#//apple_ref/occ/instp/CALayer/zPosition