### PR TITLE
Make platform name unselectable

### DIFF
--- a/website/src/react-native/css/react-native.css
+++ b/website/src/react-native/css/react-native.css
@@ -974,6 +974,9 @@ div[data-twttr-id] iframe {
   padding: 0 5px;
   font-size: 13px;
   font-weight: normal;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
 }
 
 .edit-github {


### PR DESCRIPTION
Copy method names by double clicking added platform name to clipboard. 
Annoyed me couple of times. Now double clicking on method name in documentation will only select the name of the method.