### PR TITLE
[ios] Add documentation for making PushNotificationIOS events work,

### DIFF
--- a/Libraries/PushNotificationIOS/PushNotificationIOS.js
+++ b/Libraries/PushNotificationIOS/PushNotificationIOS.js
@@ -29,6 +29,27 @@ var NOTIF_REGISTER_EVENT = 'remoteNotificationsRegistered';
  *
  * To get up and running, [configure your notifications with Apple](https://developer.apple.com/library/ios/documentation/IDEs/Conceptual/AppDistributionGuide/AddingCapabilities/AddingCapabilities.html#//apple_ref/doc/uid/TP40012582-CH26-SW6)
  * and your server-side system. To get an idea, [this is the Parse guide](https://parse.com/tutorials/ios-push-notifications).
+ *
+ * To enable support for `notification` and `register` events you need to augment your AppDelegate.
+ *
+ * At the top of your `AppDelegate.m`:
+ *
+ *   `#import "RCTPushNotificationManager.h"`
+ *
+ * And then in your AppDelegate implementation add the following:
+ *
+ *   ```
+ *   // Required for the register event.
+ *    - (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken
+ *    {
+ *     [RCTPushNotificationManager application:application didRegisterForRemoteNotificationsWithDeviceToken:deviceToken];
+ *    }
+ *    // Required for the notification event.
+ *    - (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)notification
+ *    {
+ *     [RCTPushNotificationManager application:application didReceiveRemoteNotification:notification];
+ *    }
+ *   ```
  */
 class PushNotificationIOS {
   _data: Object;


### PR DESCRIPTION
I was just implementing push notifications for my iOS app and was very confused why the `register` event wasn't working.

[Eventually I ran across this tutorial](https://medium.com/@DannyvanderJagt/how-to-use-push-notifications-in-react-native-41e8b14aadae) that explained that I needed to update my AppDelegate to make that event work.

I've updated the documentation to include that note within the actual file. 