### PR TITLE
Added support for opening http:// and https:// links in Mobile Safari.

### DIFF
--- a/Libraries/Components/WebView/WebView.ios.js
+++ b/Libraries/Components/WebView/WebView.ios.js
@@ -107,6 +107,7 @@ var WebView = React.createClass({
      * user can change the scale
      */
     scalesPageToFit: PropTypes.bool,
+    externalHTTPEnabled: PropTypes.bool
   },
 
   getInitialState: function() {
@@ -168,6 +169,7 @@ var WebView = React.createClass({
         onLoadingFinish={this.onLoadingFinish}
         onLoadingError={this.onLoadingError}
         scalesPageToFit={this.props.scalesPageToFit}
+        externalHTTPEnabled={this.props.externalHTTPEnabled}
       />;
 
     return (

--- a/React/Views/RCTWebView.h
+++ b/React/Views/RCTWebView.h
@@ -23,6 +23,7 @@ extern NSString *const RCTJSNavigationScheme;
 @property (nonatomic, assign) UIEdgeInsets contentInset;
 @property (nonatomic, assign) BOOL automaticallyAdjustContentInsets;
 @property (nonatomic, copy) NSString *injectedJavaScript;
+@property (nonatomic, assign) BOOL externalHTTPEnabled;
 
 - (void)goForward;
 - (void)goBack;

--- a/React/Views/RCTWebView.m
+++ b/React/Views/RCTWebView.m
@@ -142,6 +142,11 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
 - (BOOL)webView:(__unused UIWebView *)webView shouldStartLoadWithRequest:(NSURLRequest *)request
  navigationType:(UIWebViewNavigationType)navigationType
 {
+  if ( _externalHTTPEnabled && navigationType == UIWebViewNavigationTypeLinkClicked &&
+      [request.URL.scheme hasPrefix:@"http"]) {
+    [[UIApplication sharedApplication] openURL:[request URL]];
+    return NO;
+  }
   if (_onLoadingStart) {
     // We have this check to filter out iframe requests and whatnot
     BOOL isTopFrame = [request.URL isEqual:request.mainDocumentURL];

--- a/React/Views/RCTWebViewManager.m
+++ b/React/Views/RCTWebViewManager.m
@@ -34,6 +34,7 @@ RCT_EXPORT_VIEW_PROPERTY(automaticallyAdjustContentInsets, BOOL);
 RCT_EXPORT_VIEW_PROPERTY(onLoadingStart, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onLoadingFinish, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onLoadingError, RCTDirectEventBlock);
+RCT_EXPORT_VIEW_PROPERTY(externalHTTPEnabled, BOOL);
 
 - (NSDictionary *)constantsToExport
 {


### PR DESCRIPTION
We have a requirement in our app, to open in mobile Safari, any http:// and https:// links displayed in a web view. Our web view is not full screen, and displaying external content in that web view is outside of the scope of our app, so we open them in mobile Safari.

I've forked the WebView component and added a property, externalHTTPEnabled, and modified the RCTWebView implementation of

```- (BOOL)webView:(__unused UIWebView *)webView shouldStartLoadWithRequest:(NSURLRequest *)request
 navigationType:(UIWebViewNavigationType)navigationType```

to check if the user has tapped a link and that the URL has a prefix of 'http' (this matches 'http://' and 'https://' URLs).

By adding a property and defaulting to false, this added functionality doesn't break existing behavior.