### PR TITLE
[website] Support pushing new files

### DIFF
--- a/website/publish.sh
+++ b/website/publish.sh
@@ -24,8 +24,8 @@ cp -R build/react-native/* ../../react-native-gh-pages/
 rm -Rf build/
 cd ../../react-native-gh-pages
 git status
+git add -A .
 if ! git diff-index --quiet HEAD --; then
-  git add -A .
   git commit -m "update website"
   git push origin gh-pages
 fi


### PR DESCRIPTION
In #3421 we created a new folder but it didn't get picked up by the publish script.

```
Untracked files:
  (use "git add <file>..." to include in what will be committed)
  js/
```

The reason is that `git diff-index --quiet HEAD --` returns 0 for untracked files. But, if we add before, it returns 1.

It still returns 0 if we add but there's nothing changed