### PR TITLE
[Android] Convert event to local coordinates inside the target view.

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/TouchTargetHelper.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/TouchTargetHelper.java
@@ -53,6 +53,18 @@ public class TouchTargetHelper {
     return targetTag;
   }
 
+  public static View findTargetViewForTouch(
+      float eventY,
+      float eventX,
+      ViewGroup viewGroup) {
+    UiThreadUtil.assertOnUiThread();
+    View nativeTargetView = findTouchTargetView(eventX, eventY, viewGroup);
+    if (nativeTargetView != null) {
+      return findClosestReactAncestor(nativeTargetView);
+    }
+    return viewGroup;
+  }
+
   private static View findClosestReactAncestor(View view) {
     while (view != null && view.getId() <= 0) {
       view = (View) view.getParent();


### PR DESCRIPTION
This change makes sure `nativeEvent.locationX` and `.locationY `are coordinates *relative* to the element, as described in the documentation. And as is current behavior on iOS. Should fix #3201.