### PR TITLE
[Animated] `isInteraction` option to keep InteractionManager unblocked

### DIFF
--- a/Libraries/Animated/src/__tests__/Animated-test.js
+++ b/Libraries/Animated/src/__tests__/Animated-test.js
@@ -18,6 +18,7 @@ jest
 var Animated = require('Animated');
 
 describe('Animated', () => {
+
   it('works end to end', () => {
     var anim = new Animated.Value(0);
 
@@ -349,6 +350,54 @@ describe('Animated Events', () => {
     expect(value.__getValue()).toBe(42);
     expect(listener.mock.calls.length).toBe(1);
     expect(listener).toBeCalledWith({foo: 42});
+  });
+});
+
+describe('Animated Interactions', () => {
+  /*eslint-disable no-shadow*/
+  var Animated;
+  /*eslint-enable*/
+  var InteractionManager;
+
+  beforeEach(() => {
+    jest.mock('InteractionManager');
+    Animated = require('Animated');
+    InteractionManager = require('InteractionManager');
+  });
+
+  afterEach(()=> {
+    jest.dontMock('InteractionManager');
+  });
+
+  it('registers an interaction by default', () => {
+    InteractionManager.createInteractionHandle.mockReturnValue(777);
+
+    var value = new Animated.Value(0);
+    var callback = jest.genMockFunction();
+    Animated.timing(value, {
+      toValue: 100,
+      duration: 100,
+    }).start(callback);
+    jest.runAllTimers();
+
+    expect(InteractionManager.createInteractionHandle).toBeCalled();
+    expect(InteractionManager.clearInteractionHandle).toBeCalledWith(777);
+    expect(callback).toBeCalledWith({finished: true});
+  });
+
+  it('does not register an interaction when specified', () => {
+    var value = new Animated.Value(0);
+    var callback = jest.genMockFunction();
+    Animated.timing(value, {
+      toValue: 100,
+      duration: 100,
+      isInteraction: false,
+    }).start(callback);
+    jest.runAllTimers();
+
+    expect(InteractionManager.createInteractionHandle).not.toBeCalled();
+    expect(InteractionManager.clearInteractionHandle).not.toBeCalled();
+    expect(callback).toBeCalledWith({finished: true});
   });
 });
 


### PR DESCRIPTION
Adds a new option to animation configs so that animations can be marked as non-interactions. This solves the "loading indicator problem" where an animated loading screen would deadlock as it waits for all interactions to complete.

As for the API, what we really want long term is better scheduling. This needs to be built at the runtime level (into the RN bridge) and take care of things like priority donation that are probably overkill right now. Basically this API is a medium-term fix and I won't be upset if it gets replaced with a finer-grained scheduler.

Test Plan: Added unit tests. Tested in a real app.