### PR TITLE
[TabBarIOS] Give more control over opacity level

### DIFF
--- a/Libraries/Components/TabBarIOS/TabBarIOS.ios.js
+++ b/Libraries/Components/TabBarIOS/TabBarIOS.ios.js
@@ -30,10 +30,19 @@ var TabBarIOS = React.createClass({
      */
     tintColor: React.PropTypes.string,
     /**
-     * Background color of the tab bar
+     * Background color of the tab bar.
      */
     barTintColor: React.PropTypes.string,
     /**
+     * Background opacity of the tab bar.
+     */
+    barOpacityLevel: React.PropTypes.oneOf(
+      ['opaque', 'translucent', 'transparent']
+    ),
+    /**
+     * @deprecated
+     * Use `barOpacityLevel` instead.
+     *
      * A Boolean value that indicates whether the tab bar is translucent
      */
     translucent: React.PropTypes.bool,
@@ -45,7 +54,8 @@ var TabBarIOS = React.createClass({
         style={[styles.tabGroup, this.props.style]}
         tintColor={this.props.tintColor}
         barTintColor={this.props.barTintColor}
-        translucent={this.props.translucent !== false}>
+        barOpacityLevel={this.props.barOpacityLevel || 'translucent'}
+        translucent={this.props.translucent}>
         {this.props.children}
       </RCTTabBar>
     );

--- a/React/Views/RCTTabBar.m
+++ b/React/Views/RCTTabBar.m
@@ -138,6 +138,27 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
   return _tabController.tabBar.isTranslucent;
 }
 
+- (void)setBarOpacityLevel:(NSString *)opacityLevel
+{
+  if ([opacityLevel isEqualToString:@"opaque"]) {
+    _tabController.tabBar.translucent = NO;
+    [self resetBarBackgroundImage];
+  } else if ([opacityLevel isEqualToString:@"translucent"]) {
+    _tabController.tabBar.translucent = YES;
+    [self resetBarBackgroundImage];
+  } else if ([opacityLevel isEqualToString:@"transparent"]) {
+    _tabController.tabBar.backgroundImage = [UIImage new];
+  }
+}
+
+- (void)resetBarBackgroundImage
+{
+  if (_tabController.tabBar.backgroundImage) {
+    _tabController.tabBar.backgroundImage = nil;
+  }
+}
+
+
 - (void)setTranslucent:(BOOL)translucent {
   _tabController.tabBar.translucent = translucent;
 }

--- a/React/Views/RCTTabBarManager.m
+++ b/React/Views/RCTTabBarManager.m
@@ -23,6 +23,9 @@ RCT_EXPORT_MODULE()
 
 RCT_EXPORT_VIEW_PROPERTY(tintColor, UIColor)
 RCT_EXPORT_VIEW_PROPERTY(barTintColor, UIColor)
+RCT_EXPORT_VIEW_PROPERTY(barOpacityLevel, NSString)
+
+/* @Deprecated */
 RCT_EXPORT_VIEW_PROPERTY(translucent, BOOL)
 
 @end


### PR DESCRIPTION
A friend wanted to be able to create his own background view and underlay it behind the tab bar, so I added support for making the tab bar background completely transparent. This deprecates the `translucent` prop (but still leaves it in for backwards compatibility) in favour of `barOpacityLevel` which can be either `opaque` `translucent` or `transparent`.