### PR TITLE
[android] add gradle tasks for bundling js and assets in template

### DIFF
--- a/local-cli/generator-android/templates/src/app/build.gradle
+++ b/local-cli/generator-android/templates/src/app/build.gradle
@@ -1,4 +1,53 @@
-apply plugin: 'com.android.application'
+apply plugin: "com.android.application"
+
+/**
+ * The react.gradle file registers two tasks: bundleDebugJsAndAssets and bundleReleaseJsAndAssets.
+ * These basically call `react-native bundle` with the correct arguments during the Android build
+ * cycle. By default, bundleDebugJsAndAssets is skipped, as in debug/dev mode we prefer to load the
+ * bundle directly from the development server. Below you can see all the possible configurations
+ * and their defaults. If you decide to add a configuration block, make sure to add it before the
+ * `apply from: "react.gradle"` line.
+ *
+ * project.ext.react = [
+ *   // the name of the generated asset file containing your JS bundle
+ *   bundleAssetName: "index.android.bundle",
+ *
+ *   // the entry file for bundle generation
+ *   entryFile: "index.android.js",
+ *
+ *   // whether to bundle JS and assets in debug mode
+ *   bundleInDebug: false,
+ *
+ *   // whether to bundle JS and assets in release mode
+ *   bundleInRelease: true,
+ *
+ *   // the root of your project, i.e. where "package.json" lives
+ *   root: "../../",
+ *
+ *   // where to put the JS bundle asset in debug mode
+ *   jsBundleDirDebug: "$buildDir/intermediates/assets/debug",
+ *
+ *   // where to put the JS bundle asset in release mode
+ *   jsBundleDirRelease: "$buildDir/intermediates/assets/release",
+ *
+ *   // where to put drawable resources / React Native assets, e.g. the ones you use via
+ *   // require('./image.png')), in debug mode
+ *   resourcesDirDebug: "$buildDir/intermediates/res/merged/debug",
+ *
+ *   // where to put drawable resources / React Native assets, e.g. the ones you use via
+ *   // require('./image.png')), in release mode
+ *   resourcesDirRelease: "$buildDir/intermediates/res/merged/release",
+ *
+ *   // by default the gradle tasks are skipped if none of the JS files or assets change; this means
+ *   // that we don't look at files in android/ or ios/ to determine whether the tasks are up to
+ *   // date; if you have any other folders that you want to ignore for performance reasons (gradle
+ *   // indexes the entire tree), add them here. Alternatively, if you have JS files in android/
+ *   // for example, you might want to remove it from here.
+ *   inputExcludes: ["android/**", "ios/**"]
+ * ]
+ */
+
+apply from: "react.gradle"
 
 android {
     compileSdkVersion 23
@@ -17,13 +66,13 @@ android {
     buildTypes {
         release {
             minifyEnabled false  // Set this to true to enable Proguard
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
         }
     }
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:23.0.1'
-    compile 'com.facebook.react:react-native:0.11.+'
+    compile fileTree(dir: "libs", include: ["*.jar"])
+    compile "com.android.support:appcompat-v7:23.0.1"
+    compile "com.facebook.react:react-native:0.13.0"
 }

--- a/local-cli/generator-android/templates/src/app/react.gradle
+++ b/local-cli/generator-android/templates/src/app/react.gradle
@@ -1,0 +1,75 @@
+def config = project.hasProperty("react") ? project.react : [];
+
+def bundleAssetName = config.bundleAssetName ?: "index.android.bundle"
+def entryFile = config.entryFile ?: "index.android.js"
+
+// because elvis operator
+def elvisFile(thing) {
+    return thing ? file(thing) : null;
+}
+
+def reactRoot = elvisFile(config.root) ?: file("../../")
+def jsBundleDirDebug = elvisFile(config.jsBundleDirDebug) ?:
+        file("$buildDir/intermediates/assets/debug")
+def jsBundleDirRelease = elvisFile(config.jsBundleDirRelease) ?:
+        file("$buildDir/intermediates/assets/release")
+def resourcesDirDebug = elvisFile(config.resourcesDirDebug) ?:
+        file("$buildDir/intermediates/res/merged/debug")
+def resourcesDirRelease = elvisFile(config.resourcesDirRelease) ?:
+        file("$buildDir/intermediates/res/merged/release")
+def inputExcludes = config.inputExcludes ?: ["android/**", "ios/**"]
+
+def jsBundleFileDebug = file("$jsBundleDirDebug/$bundleAssetName")
+def jsBundleFileRelease = file("$jsBundleDirRelease/$bundleAssetName")
+
+task bundleDebugJsAndAssets(type: Exec) {
+    // create dirs if they are not there (e.g. the "clean" task just ran)
+    doFirst {
+        jsBundleDirDebug.mkdirs()
+        resourcesDirDebug.mkdirs()
+    }
+
+    // set up inputs and outputs so gradle can cache the result
+    inputs.files fileTree(dir: reactRoot, excludes: inputExcludes)
+    outputs.dir jsBundleDirDebug
+    outputs.dir resourcesDirDebug
+
+    // set up the call to the react-native cli
+    workingDir reactRoot
+    commandLine "react-native", "bundle", "--platform", "android", "--dev", "true", "--entry-file",
+            entryFile, "--bundle-output", jsBundleFileDebug, "--assets-dest", resourcesDirDebug
+
+    enabled config.bundleInDebug ?: false
+}
+
+task bundleReleaseJsAndAssets(type: Exec) {
+    // create dirs if they are not there (e.g. the "clean" task just ran)
+    doFirst {
+        jsBundleDirRelease.mkdirs()
+        resourcesDirRelease.mkdirs()
+    }
+
+    // set up inputs and outputs so gradle can cache the result
+    inputs.files fileTree(dir: reactRoot, excludes: inputExcludes)
+    outputs.dir jsBundleDirRelease
+    outputs.dir resourcesDirRelease
+
+    // set up the call to the react-native cli
+    workingDir reactRoot
+    commandLine "react-native", "bundle", "--platform", "android", "--dev", "false", "--entry-file",
+            entryFile, "--bundle-output", jsBundleFileRelease, "--assets-dest", resourcesDirRelease
+
+    enabled config.bundleInRelease ?: true
+}
+
+gradle.projectsEvaluated {
+    // hook bundleDebugJsAndAssets into the android build process
+    bundleDebugJsAndAssets.dependsOn mergeDebugResources
+    bundleDebugJsAndAssets.dependsOn mergeDebugAssets
+    processDebugResources.dependsOn bundleDebugJsAndAssets
+
+    // hook bundleReleaseJsAndAssets into the android build process
+    bundleReleaseJsAndAssets.dependsOn mergeReleaseResources
+    bundleReleaseJsAndAssets.dependsOn mergeReleaseAssets
+    processReleaseResources.dependsOn bundleReleaseJsAndAssets
+}


### PR DESCRIPTION
This adds gradle tasks that call `react-native bundle` with the correct args to bundle dev/release JS and assets. The dev task is disabled by default, as in dev mode people only use reload JS in most cases.

Submitting this as a pull request to have community visibility, although we have this code internally as well now and this will require an import.

## Test Plan

* generate a project with `react-native init`, add some assets, run `./gradlew assembleRelease`, sign & zipalign generated APK, run it -> works
* enable dev bundling task, run `./gradlew installDebug` (not `react-native run-android` so as to not start the packager) -> works

CC:

* @martinbigio please approve of my use of `react-native bundle`  
* @mkonicek for gradle tasks / config api  
* @kmagiera I think you worked more extensively with gradle before  
* @frantic for visibility