### PR TITLE
Fix for "var ws = new WebSocket(url);" not working

### DIFF
--- a/Libraries/WebSocket/WebSocket.js
+++ b/Libraries/WebSocket/WebSocket.js
@@ -29,6 +29,9 @@ class WebSocket extends WebSocketBase {
   _socketId: number;
   _subs: any;
 
+  constructor(url: string, protocols: ?any) {
+    super(url, protocols);
+  }
   connectToSocketImpl(url: string): void {
     this._socketId = WebSocketId++;
 


### PR DESCRIPTION
```
var ws = new WebSocket(url); 
```
This is not working, as there is no constructor in WebSocket to pass url to base class (WebSocketBase).

Adding constructor to WebSocket class