### PR TITLE
Use packager.bat instead of packager.sh on Windows

### DIFF
--- a/packager/packager.bat
+++ b/packager/packager.bat
@@ -1,0 +1,3 @@
+@if "%DEBUG%" == "" @echo off
+set THIS_DIR=%~dp0
+node %THIS_DIR%packager.js %*

--- a/packager/packager.bat
+++ b/packager/packager.bat
@@ -1,3 +1,5 @@
+@rem disable all output if DEBUG env variable is not set
 @if "%DEBUG%" == "" @echo off
+@rem set THIS_DIR variable to the full directory path
 set THIS_DIR=%~dp0
 node %THIS_DIR%packager.js %*

--- a/react-native-cli/index.js
+++ b/react-native-cli/index.js
@@ -156,12 +156,19 @@ function createProject(name, verbose) {
     fs.mkdirSync(root);
   }
 
+  var startScript;
+      if (/^win/.test(process.platform)) {
+		startScript = 'node_modules\\react-native\\packager\\packager.bat';
+	  }
+	  else {
+		  startScript = 'node_modules/react-native/packager/packager.sh';
+	  }
   var packageJson = {
     name: projectName,
     version: '0.0.1',
     private: true,
     scripts: {
-      start: process.platform.startsWith('win') ? 'node_modules\\react-native\\packager\\packager.bat' : 'node_modules/react-native/packager/packager.sh'
+      start: startScript
     }
   };
   fs.writeFileSync(path.join(root, 'package.json'), JSON.stringify(packageJson));

--- a/react-native-cli/index.js
+++ b/react-native-cli/index.js
@@ -157,12 +157,11 @@ function createProject(name, verbose) {
   }
 
   var startScript;
-      if (/^win/.test(process.platform)) {
-		startScript = 'node_modules\\react-native\\packager\\packager.bat';
-	  }
-	  else {
-		  startScript = 'node_modules/react-native/packager/packager.sh';
-	  }
+  if (/^win/.test(process.platform)) {
+    startScript = 'node_modules\\react-native\\packager\\packager.bat';
+  } else {
+    startScript = 'node_modules/react-native/packager/packager.sh';
+  }
   var packageJson = {
     name: projectName,
     version: '0.0.1',

--- a/react-native-cli/index.js
+++ b/react-native-cli/index.js
@@ -161,7 +161,7 @@ function createProject(name, verbose) {
     version: '0.0.1',
     private: true,
     scripts: {
-      start: 'node_modules/react-native/packager/packager.sh'
+      start: process.platform.startsWith('win') ? 'node_modules\\react-native\\packager\\packager.bat' : 'node_modules/react-native/packager/packager.sh'
     }
   };
   fs.writeFileSync(path.join(root, 'package.json'), JSON.stringify(packageJson));


### PR DESCRIPTION
If you run react-native on Windows, shell scripts do not work. This patch contains equivalent .bat file and necessary changes in executing code.