### PR TITLE
[Bugfix] Add controller to closest parent on time so as to fix the automaticallyAdjustContentInsets feature.

### DIFF
--- a/React/Views/RCTNavigator.m
+++ b/React/Views/RCTNavigator.m
@@ -417,6 +417,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
 - (void)layoutSubviews
 {
   [super layoutSubviews];
+  [self reactAddControllerToClosestParent:_navigationController];
   _navigationController.view.frame = self.bounds;
 }
 

--- a/React/Views/RCTTabBar.m
+++ b/React/Views/RCTTabBar.m
@@ -80,6 +80,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
 - (void)layoutSubviews
 {
   [super layoutSubviews];
+  [self reactAddControllerToClosestParent:_tabController];
   _tabController.view.frame = self.bounds;
 }
 


### PR DESCRIPTION
Here's the bug to fix:
https://github.com/facebook/react-native/issues/898