### PR TITLE
Adding http as failover for react-tools git repo.

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "progress": "^1.1.8",
     "promise": "^7.0.4",
     "react-timer-mixin": "^0.13.2",
-    "react-tools": "git://github.com/facebook/react#b4e74e38e43ac53af8acd62c78c9213be0194245",
+    "react-tools": "git+http://github.com/facebook/react#b4e74e38e43ac53af8acd62c78c9213be0194245",
     "rebound": "^0.0.13",
     "regenerator": "^0.8.36",
     "sane": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "progress": "^1.1.8",
     "promise": "^7.0.4",
     "react-timer-mixin": "^0.13.2",
-    "react-tools": "git+http://github.com/facebook/react#b4e74e38e43ac53af8acd62c78c9213be0194245",
+    "react-tools": "git+https://github.com/facebook/react#b4e74e38e43ac53af8acd62c78c9213be0194245",
     "rebound": "^0.0.13",
     "regenerator": "^0.8.36",
     "sane": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "progress": "^1.1.8",
     "promise": "^7.0.4",
     "react-timer-mixin": "^0.13.2",
-    "react-tools": "git+https://github.com/facebook/react#b4e74e38e43ac53af8acd62c78c9213be0194245",
+    "react-tools": "https://api.github.com/repos/facebook/react/tarball/b4e74e38e43ac53af8acd62c78c9213be0194245",
     "rebound": "^0.0.13",
     "regenerator": "^0.8.36",
     "sane": "^1.2.0",


### PR DESCRIPTION
Fixes #2797 for me.

Most times git://github.com/facebook/react-tools times out. So adding
http as a fail-over so that if git protocol doesn't work while cloning
the react-tools repo as a dependency, http would atleast work and ensure
that a simple "react-native init myProject" doesn't fail.

Submitting a PR so that http is used as a failover when cloning. (I guess that is what git+http does in package.json)