### PR TITLE
[Env] Set up the RN JS environment before requiring other modules

### DIFF
--- a/Libraries/JavaScriptAppEngine/Initialization/InitializeJavaScriptAppEngine.js
+++ b/Libraries/JavaScriptAppEngine/Initialization/InitializeJavaScriptAppEngine.js
@@ -22,10 +22,6 @@
 /* eslint strict: 0 */
 /* globals GLOBAL: true, window: true */
 
-// Just to make sure the JS gets packaged up.
-require('RCTDebugComponentOwnership');
-require('RCTDeviceEventEmitter');
-require('PerformanceLogger');
 require('regenerator/runtime');
 
 if (typeof GLOBAL === 'undefined') {
@@ -184,6 +180,7 @@ function setUpNumber() {
   Number.MIN_SAFE_INTEGER = Number.MIN_SAFE_INTEGER || -(Math.pow(2, 53) - 1);
 }
 
+setUpProcessEnv();
 setUpRedBoxErrorHandler();
 setUpTimers();
 setUpAlert();
@@ -193,6 +190,11 @@ setUpRedBoxConsoleErrorHandler();
 setUpGeolocation();
 setUpWebSockets();
 setUpProfile();
-setUpProcessEnv();
 setUpFlowChecker();
 setUpNumber();
+
+// Just to make sure the JS gets packaged up. Wait until the JS environment has
+// been initialized before requiring them.
+require('RCTDebugComponentOwnership');
+require('RCTDeviceEventEmitter');
+require('PerformanceLogger');

--- a/Libraries/ReactNative/ReactNative.js
+++ b/Libraries/ReactNative/ReactNative.js
@@ -11,6 +11,10 @@
  */
 'use strict';
 
+// Require ReactNativeDefaultInjection first for its side effects of setting up
+// the JS environment
+var ReactNativeDefaultInjection = require('ReactNativeDefaultInjection');
+
 var ReactChildren = require('ReactChildren');
 var ReactClass = require('ReactClass');
 var ReactComponent = require('ReactComponent');
@@ -18,7 +22,6 @@ var ReactCurrentOwner = require('ReactCurrentOwner');
 var ReactElement = require('ReactElement');
 var ReactElementValidator = require('ReactElementValidator');
 var ReactInstanceHandles = require('ReactInstanceHandles');
-var ReactNativeDefaultInjection = require('ReactNativeDefaultInjection');
 var ReactNativeMount = require('ReactNativeMount');
 var ReactPropTypes = require('ReactPropTypes');
 var ReactUpdates = require('ReactUpdates');


### PR DESCRIPTION
Set up the polyfills for console and process before initializing other modules. Some modules do work (e.g. call `invariant`) when they are first required, so requiring the DefaultInjection module at the beginning ensures we have a consistent JS environment.

Test Plan: There is a packager bug that bundles a copy of `invariant` from npm under the name "invariant", which conflicts with RN's copy of `invariant`. That bug should be fixed, but it revealed another bug in which the JS environment doesn't get set up until a couple modules have already been required.

With this diff, the npm copy of `invariant`, which relies on process.env`, no longer fatals.