### PR TITLE
Fix type error of _backPressSubscriptions in BackAndroid

### DIFF
--- a/Libraries/Utilities/BackAndroid.android.js
+++ b/Libraries/Utilities/BackAndroid.android.js
@@ -26,7 +26,9 @@ var _backPressSubscriptions = new Set();
 RCTDeviceEventEmitter.addListener(DEVICE_BACK_EVENT, function() {
   var invokeDefault = true;
   _backPressSubscriptions.forEach((subscription) => {
-    if (subscription()) {
+    if (typeof subscription === 'function'
+        && Object.prototype.toString.call(subscription) === '[object Function]'
+        && subscription()) {
       invokeDefault = false;
     }
   });


### PR DESCRIPTION
Inside `BackAndroid`, by default, the last element in `_backPressSubscriptions` is a boolean. We need to check if a subscription is a function before invoking it, or else it will throw a type error:
```
Error: subscription is not a function
```