### PR TITLE
Preserve sourceMap if configured during minify

### DIFF
--- a/packager/react-packager/src/Bundler/Bundle.js
+++ b/packager/react-packager/src/Bundler/Bundle.js
@@ -101,7 +101,7 @@ class Bundle {
       let minifiedSourceAndMap = this.getMinifiedSourceAndMap();
       var minifiedSource = minifiedSourceAndMap.code;
       if (options.inlineSourceMap) {
-        const encoded = new Buffer(JSON.stringify(minifiedSourceAndMap.map)).toString('base64');
+        const encoded = new Buffer(minifiedSourceAndMap.map).toString('base64');
         const inlineSourceMap = 'data:application/json;base64,' + encoded;
         minifiedSource += SOURCEMAPPING_URL + inlineSourceMap;
       }

--- a/packager/react-packager/src/Bundler/Bundle.js
+++ b/packager/react-packager/src/Bundler/Bundle.js
@@ -98,7 +98,14 @@ class Bundle {
     options = options || {};
 
     if (options.minify) {
-      return this.getMinifiedSourceAndMap().code;
+      let minifiedSourceAndMap = this.getMinifiedSourceAndMap();
+      var minifiedSource = minifiedSourceAndMap.code;
+      if (options.inlineSourceMap) {
+        const encoded = new Buffer(JSON.stringify(minifiedSourceAndMap.map)).toString('base64');
+        const inlineSourceMap = 'data:application/json;base64,' + encoded;
+        minifiedSource += SOURCEMAPPING_URL + inlineSourceMap;
+      }
+      return minifiedSource;
     }
 
     let source = this._getSource();


### PR DESCRIPTION
TLDR: I enabled source maps in `node_modules/react-native/local-cli/bundle.js` by explicitly setting `inlineSourceMap: true,` in the code. Then running `react-native bundle --out js.bundle` works, but `react-native bundle --minify --out js.bundle` loses the source maps. I am looking to generate a source map between the original files and the minified bundle.

This solves the problem, but is generating duplicate entries, please do help out:
````
//# sourceMappingURL=bundle.js
//@ sourceMappingURL=data:application/json;base64,IntcInZlcnNpb25cIjozLFwiZmlsZVwiOlwiYnV
```

(fixes #3527)