### PR TITLE
Support line number arguments for Emacs when using emacsclient

### DIFF
--- a/packager/launchEditor.js
+++ b/packager/launchEditor.js
@@ -33,6 +33,7 @@ function getArgumentsForLineNumber(editor, fileName, lineNumber) {
       return [fileName + ':' + lineNumber];
     case 'joe':
     case 'emacs':
+    case 'emacsclient':
       return ['+' + lineNumber, fileName];
     case 'rmate':
     case 'mate':


### PR DESCRIPTION
Many emacs users will want to use the `emacsclient` command to launch emacs. This opens the file in an existing emacs session rather than opening up a new instance.