### PR TITLE
Fixed rendering inconsistency with ListView rows

### DIFF
--- a/Libraries/CustomComponents/ListView/ListView.js
+++ b/Libraries/CustomComponents/ListView/ListView.js
@@ -320,7 +320,7 @@ var ListView = React.createClass({
       }
 
       if (this.props.renderSectionHeader) {
-        var shouldUpdateHeader = rowCount >= this.state.prevRenderedRowsCount &&
+        var shouldUpdateHeader = rowCount >= this.state.prevRenderedRowsCount ||
           dataSource.sectionHeaderShouldUpdate(sectionIdx);
         bodyComponents.push(
           <StaticRenderer


### PR DESCRIPTION
Allows for changes to ListView rows to be rendered even if new cells
are not loaded - before, re-rendering was inconsistent, even after a
significant state change