### PR TITLE
update the condition for minimal version requirement to allow ios 9.x…

### DIFF
--- a/Examples/UIExplorer/UIExplorerIntegrationTests/UIExplorerIntegrationTests.m
+++ b/Examples/UIExplorer/UIExplorerIntegrationTests/UIExplorerIntegrationTests.m
@@ -20,6 +20,8 @@
   [_runner runTest:_cmd module:@#name]; \
 }
 
+#define MIN_VERSION 8.3
+
 @interface UIExplorerIntegrationTests : XCTestCase
 
 @end
@@ -36,7 +38,8 @@
 #endif
 
   NSOperatingSystemVersion version = [NSProcessInfo processInfo].operatingSystemVersion;
-  RCTAssert(version.majorVersion == 8 || version.minorVersion >= 3, @"Tests should be run on iOS 8.3+, found %zd.%zd.%zd", version.majorVersion, version.minorVersion, version.patchVersion);
+  float versionToCompare = [[NSNumber numberWithFloat:version.majorVersion + version.minorVersion / 10.0] floatValue];
+  RCTAssert(versionToCompare >= MIN_VERSION, @"Tests should be run on iOS 8.3+, found %zd.%zd.%zd", version.majorVersion, version.minorVersion, version.patchVersion);
   _runner = RCTInitRunnerForApp(@"Examples/UIExplorer/UIExplorerIntegrationTests/js/IntegrationTestsApp", nil);
 }
 

--- a/Examples/UIExplorer/UIExplorerIntegrationTests/UIExplorerSnapshotTests.m
+++ b/Examples/UIExplorer/UIExplorerIntegrationTests/UIExplorerSnapshotTests.m
@@ -35,9 +35,12 @@
 #if __LP64__
   RCTAssert(NO, @"Tests should be run on 32-bit device simulators (e.g. iPhone 5)");
 #endif
+  
+#define MIN_VERSION 8.3
 
   NSOperatingSystemVersion version = [NSProcessInfo processInfo].operatingSystemVersion;
-  RCTAssert(version.majorVersion == 8 || version.minorVersion >= 3, @"Snapshot tests should be run on iOS 8.3+, found %zd.%zd.%zd", version.majorVersion, version.minorVersion, version.patchVersion);
+  float versionToCompare = [[NSNumber numberWithFloat:version.majorVersion + version.minorVersion / 10.0] floatValue];
+  RCTAssert(versionToCompare >= MIN_VERSION, @"Snapshot tests should be run on iOS 8.3+, found %zd.%zd.%zd", version.majorVersion, version.minorVersion, version.patchVersion);
   _runner = RCTInitRunnerForApp(@"Examples/UIExplorer/UIExplorerApp.ios", nil);
   _runner.recordMode = NO;
 }


### PR DESCRIPTION
… and disallow <8.3

with previous condition 
````version.majorVersion == 8 || version.minorVersion >= 3````
ios 9 does not start test while 8.1 starts.
Updated the logic to allow ios 9.x and block <8.3 (assuming that is what is wanted based on the Assert message. 
Also define const so min version can be changed easily.
