### PR TITLE
[Network] Allow duplicate keys in FormData

### DIFF
--- a/Libraries/Network/FormData.js
+++ b/Libraries/Network/FormData.js
@@ -47,26 +47,18 @@ type FormDataPart = {
  */
 class FormData {
   _parts: Array<FormDataNameValuePair>;
-  _partsByKey: {[key: string]: FormDataNameValuePair};
 
   constructor() {
     this._parts = [];
-    this._partsByKey = {};
   }
 
   append(key: string, value: FormDataValue) {
-    var parts = this._partsByKey[key];
-    if (parts) {
-      // It's a bit unclear what the behaviour should be in this case.
-      // The XMLHttpRequest spec doesn't specify it, while MDN says that
-      // the any new values should appended to existing values. We're not
-      // doing that for now -- it's tedious and doesn't seem worth the effort.
-      parts[1] = value;
-      return;
-    }
-    parts = [key, value];
-    this._parts.push(parts);
-    this._partsByKey[key] = parts;
+    // The XMLHttpRequest spec doesn't specify if duplicate keys are allowed.
+    // MDN says that any new values should be appended to existing values.
+    // In any case, major browsers allow duplicate keys, so that's what we'll do
+    // too. They'll simply get appended as additional form data parts in the
+    // request body, leaving the server to deal with them.
+    this._parts.push([key, value]);
   }
 
   getParts(): Array<FormDataPart> {


### PR DESCRIPTION
Right now `FormData` doesn't allow duplicate keys and uses the last value set for a duplicate key. I tested this in Chrome:
```
var formData = new FormData();
formData.append('key', 'value1');
formData.append('key', 'value2');

var request = new XMLHttpRequest();
request.open("POST", serverUrl);
request.send(formData);
```
and the request has both 'value1' and 'value2'.

I removed the duplicate key check in `FormData`. If people want to build appending or disallow duplicate keys, they can build either on top of this.