### PR TITLE
[react-native-gradle] Add flavor support for gradle plugin

### DIFF
--- a/react-native-gradle/build.gradle
+++ b/react-native-gradle/build.gradle
@@ -12,6 +12,7 @@ dependencies {
   compile gradleApi()
   compile 'commons-io:commons-io:2.4'
   compile 'org.apache.commons:commons-lang3:3.4'
+  compile 'com.android.tools.build:gradle:1.3.1'
 
   testCompile 'junit:junit:4.12'
   testCompile 'com.squareup.okhttp:mockwebserver:2.4.0'

--- a/react-native-gradle/src/main/java/com/facebook/react/ReactGradlePlugin.java
+++ b/react-native-gradle/src/main/java/com/facebook/react/ReactGradlePlugin.java
@@ -1,9 +1,18 @@
 package com.facebook.react;
 
+import com.android.build.gradle.AppPlugin;
+import com.android.build.gradle.LibraryPlugin;
+import com.android.build.gradle.internal.variant.BaseVariantData;
+import com.android.builder.core.VariantType;
+import com.google.common.collect.Lists;
+
 import org.gradle.api.Action;
+import org.gradle.api.GradleException;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
-import org.gradle.api.Task;
+
+import java.util.Iterator;
+import java.util.List;
 
 /**
  * Main entry point for our plugin. When applied to a project, this registers the {@code react}
@@ -15,6 +24,9 @@ import org.gradle.api.Task;
  * was applied incorrectly.
  */
 public class ReactGradlePlugin implements Plugin<Project> {
+  static final String sAndroidApplicationPluginName = "com.android.application";
+  static final String sAndroidLibraryPluginName = "com.android.library";
+
   @Override
   public void apply(Project project) {
     project.getExtensions().create("react", ReactGradleExtension.class, project);
@@ -23,17 +35,40 @@ public class ReactGradlePlugin implements Plugin<Project> {
         new Action<Project>() {
           @Override
           public void execute(Project project) {
-            PackageDebugJsTask packageDebugJsTask =
-                project.getTasks().create("packageDebugJS", PackageDebugJsTask.class);
-            PackageReleaseJsTask packageReleaseJsTask =
-                project.getTasks().create("packageReleaseJS", PackageReleaseJsTask.class);
 
-            packageDebugJsTask.dependsOn("mergeDebugAssets");
-            project.getTasks().getByName("processDebugResources").dependsOn(packageDebugJsTask);
+            final List<BaseVariantData> variantList = Lists.newArrayList();
+            if (project.getPlugins().hasPlugin(sAndroidApplicationPluginName)) {
+              AppPlugin plugin = (AppPlugin) project.getPlugins().getPlugin(sAndroidApplicationPluginName);
+              plugin.getVariantManager().getVariantDataList().stream().filter(variantData -> VariantType.DEFAULT == variantData.getType() || VariantType.LIBRARY == variantData.getType()).forEach(variantData -> {
+                variantList.add(variantData);
+              });
+            } else if (project.getPlugins().hasPlugin(sAndroidLibraryPluginName)) {
+              LibraryPlugin plugin = (LibraryPlugin) project.getPlugins().getPlugin(sAndroidLibraryPluginName);
+              plugin.getVariantManager().getVariantDataList().stream().filter(variantData -> VariantType.DEFAULT == variantData.getType() || VariantType.LIBRARY == variantData.getType()).forEach(variantData -> {
+                variantList.add(variantData);
+              });
+            } else {
+              throw new GradleException("The 'android' or 'android-library' plugin is required.");
+            }
 
-            packageReleaseJsTask.dependsOn("mergeReleaseAssets");
-            project.getTasks().getByName("processReleaseResources").dependsOn(packageReleaseJsTask);
+            Iterator<BaseVariantData> iterator = variantList.iterator();
+            while (iterator.hasNext()) {
+              BaseVariantData variantData = iterator.next();
+
+              String variantName = capitalize(variantData.getName());
+              String taskName = String.format("package%sJS", variantName);
+              Class<? extends AbstractPackageJsTask> clazz = variantData.getVariantConfiguration().getBuildType().isDebuggable() ? PackageDebugJsTask.class : PackageReleaseJsTask.class;
+
+              AbstractPackageJsTask packageJsTask = project.getTasks().create(taskName, clazz);
+
+              packageJsTask.dependsOn(String.format("merge%sAssets", variantName));
+              project.getTasks().getByName(String.format("process%sResources", variantName)).dependsOn(packageJsTask);
+            }
           }
         });
+  }
+
+  private String capitalize(final String name) {
+    return Character.toUpperCase(name.charAt(0)) + name.substring(1);
   }
 }


### PR DESCRIPTION
react-native-gradle plugin will occur errors when apply in build.gradle which contains flavor settings.

if we add flavor in our project build.gradle, and at the same time we apply 'com.facebook.react' plugin , the following error message will occur when we sync build.gradle:

"processReleaseResources Task does not existed"