### PR TITLE
[CLI] Make `react-native init` check your Node version

### DIFF
--- a/react-native-cli/index.js
+++ b/react-native-cli/index.js
@@ -39,7 +39,9 @@ var fs = require('fs');
 var path = require('path');
 var exec = require('child_process').exec;
 var spawn = require('child_process').spawn;
+var chalk = require('chalk');
 var prompt = require('prompt');
+var semver = require('semver');
 
 var CLI_MODULE_PATH = function() {
   return path.resolve(
@@ -47,6 +49,15 @@ var CLI_MODULE_PATH = function() {
     'node_modules',
     'react-native',
     'cli.js'
+  );
+};
+
+var REACT_NATIVE_PACKAGE_JSON_PATH = function() {
+  return path.resolve(
+    process.cwd(),
+    'node_modules',
+    'react-native',
+    'package.json'
   );
 };
 
@@ -185,6 +196,8 @@ function run(root, projectName) {
       process.exit(1);
     }
 
+    checkNodeVersion();
+
     var cli = require(CLI_MODULE_PATH());
     cli.init(root, projectName);
   });
@@ -201,6 +214,21 @@ function runVerbose(root, projectName) {
     cli = require(CLI_MODULE_PATH());
     cli.init(root, projectName);
   });
+}
+
+function checkNodeVersion() {
+  var packageJson = require(REACT_NATIVE_PACKAGE_JSON_PATH());
+  if (!packageJson.engines || !packageJson.engines.node) {
+    return;
+  }
+  if (!semver.satisfies(process.version, packageJson.engines.node)) {
+    console.error(chalk.red(
+        'You are currently running Node %s but React Native requires %s. ' +
+        'Please use a supported version of Node.'
+      ),
+      process.version,
+      packageJson.engines.node);
+  }
 }
 
 function checkForVersionArgument() {

--- a/react-native-cli/package.json
+++ b/react-native-cli/package.json
@@ -10,6 +10,8 @@
     "react-native": "index.js"
   },
   "dependencies": {
-    "prompt": "^0.2.14"
+    "chalk": "^1.1.1",
+    "prompt": "^0.2.14",
+    "semver": "^5.0.3"
   }
 }


### PR DESCRIPTION
We get a bunch of bugs because people are running old versions of Node that don't support modern JS. We have "engines" entries in the package.json files to catch this earlier but printing an explicit error message will also make this clear.

Test Plan: Changed react-native's package.json to require Node >= 5 and got an error message when running the CLI with Node 4.

![screenshot 2015-10-21 12 44 43](https://cloud.githubusercontent.com/assets/379606/10648262/38d42fe0-77f2-11e5-805a-5355406e3d8b.png)