### PR TITLE
Fix e2e tests

### DIFF
--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -15,7 +15,7 @@ export REACT_PACKAGER_LOG="$TEMP/server.log"
 # To make sure we actually installed the local version
 # of react-native, we will create a temp file inside the template
 # and check that it exists after `react-native init`
-MARKER=$(mktemp $ROOT/local-cli/generator-ios/templates/main/XXXXXXXX)
+MARKER=$(mktemp $ROOT/local-cli/generator-ios/templates/app/XXXXXXXX)
 
 function cleanup {
   EXIT_CODE=$?
@@ -64,7 +64,7 @@ react-native init EndToEndTest
 cd EndToEndTest/ios
 
 # Make sure we installed local version of react-native
-ls `basename $MARKER` > /dev/null
+ls EndToEndTest/`basename $MARKER` > /dev/null
 
 flow --retries 10
 


### PR DESCRIPTION
Internally we don't mirror `scripts` folder from GitHub, which means
when importing #3523 changes to `scripts/e2e-test.sh` will not make it to
GitHub. This commit contains those changes.

I'll merge this once #3523 (D2557923) lands