### PR TITLE
[docs] add bundle and upgrade docs

### DIFF
--- a/docs/Performance.md
+++ b/docs/Performance.md
@@ -4,7 +4,7 @@ title: Performance
 layout: docs
 category: Guides
 permalink: docs/performance.html
-next: native-modules-ios
+next: upgrading
 ---
 
 A compelling reason for using React Native instead of WebView-based

--- a/docs/SignedAPKAndroid.md
+++ b/docs/SignedAPKAndroid.md
@@ -66,16 +66,29 @@ android {
 
 ### Generating the release APK
 
-1. Start the packager by running `npm start` in your project folder
-2. In your project folder, run the following in a Terminal,
+#### If you have a `react.gradle` file in `android/app`
+
+Simply run the following in a terminal:
 
 ```sh
-$ mkdir -p android/app/src/main/assets
-$ curl "http://localhost:8081/index.android.bundle?platform=android&dev=false&minify=true" -o "android/app/src/main/assets/index.android.bundle"
 $ cd android && ./gradlew assembleRelease
 ```
 
-The generated APK can be found under `android/app/build/outputs/apk/app-release.apk`, and is ready to be distributed.
+If you need to change the way the JavaScript bundle and/or drawable resources are bundled (e.g. if you changed the default file/folder names or the general structure of the project), have a look at `android/app/build.gradle` to see how you can update it to reflect these changes.
+
+#### If you *don't* have a `react.gradle` file:
+
+You can [upgrade](/react-native/docs/upgrading.html) to the latest version of React Native to get this file. Alternatively, you can bundle the JavaScript package and drawable resources manually by doing the following in a terminal:
+
+```sh
+$ mkdir -p android/app/src/main/assets
+$ react-native bundle --platform android --dev false --entry-file index.android.js \
+  --bundle-output android/app/src/main/assets/index.android.bundle \
+  --assets-dest android/app/src/main/res/
+$ cd android && ./gradlew assembleRelease
+```
+
+In both cases the generated APK can be found under `android/app/build/outputs/apk/app-release.apk`, and is ready to be distributed.
 
 ### Testing the release build of your app
 
@@ -87,7 +100,7 @@ $ cd android && ./gradlew installRelease
 
 Note that `installRelease` is only available if you've set up signing as described above.
 
-You can kill any running packager instances, all your and framework JavaScript code is bundled in the APK's assets. 
+You can kill any running packager instances, all your and framework JavaScript code is bundled in the APK's assets.
 
 ### Enabling Proguard to reduce the size of the APK (optional)
 

--- a/docs/Upgrading.md
+++ b/docs/Upgrading.md
@@ -1,0 +1,47 @@
+---
+id: upgrading
+title: Upgrading
+layout: docs
+category: Guides
+permalink: docs/upgrading.html
+next: native-modules-ios
+---
+
+Upgrading to new versions of React Native will give you access to more APIs, views, developer tools
+and other goodies. Because React Native projects are essentially made up of an Android project, an
+iOS project and a JavaScript project, all combined under an npm package, upgrading can be rather
+tricky. But we try to make it easy for you. Here's what you need to do to upgrade from an older
+version of React Native:
+
+## 1. Upgrade the `react-native` dependency
+
+Note the latest version of the `react-native` npm package from here:
+
+* https://www.npmjs.com/package/react-native
+
+Open your `package.json` file and update the version of `react-native` under `dependencies` to the
+latest version. Now, in a terminal run:
+
+```sh
+$ npm install
+```
+
+## 2. Upgrade your project templates
+
+> NOTE: This feature is not yet available in the stable release of React Native. Stay tuned.
+
+The new npm package will likely contain updates to the files that are normally generated when you
+run `react-native init`, like the iOS and the Android sub-projects. To get these latest changes,
+run this in a terminal:
+
+```sh
+$ react-native upgrade
+```
+
+This will check your files against the latest template and perform the following:
+
+* If there is a new file in the template, it is simply created.
+* If a file in the template is identical to your file, it is skipped.
+* If a file is different in your project than the template, you will be prompted; you have options
+  to view a diff between your file and the template file, keep your file or overwrite it with the
+  template version. If you are unsure, press `h` to get a list of possible commands.


### PR DESCRIPTION
cc @mkonicek @frantic

I added a note on the upgrading page about the `upgrade` command not being available yet. We should remove this after next week's release.