### PR TITLE
Add fetch's clone function to Request and Response prototypes

### DIFF
--- a/Libraries/Fetch/fetch.js
+++ b/Libraries/Fetch/fetch.js
@@ -324,6 +324,15 @@ var self = {};
     this.headers = options.headers instanceof Headers ? options.headers : new Headers(options.headers)
     this.url = options.url || ''
   }
+  
+  Response.prototype.clone = function() {
+    return new Response(this._bodyInit, {
+      status: this.status,
+      statusText: this.statusText,
+      headers: new Headers(this.headers),
+      url: this.url
+    })
+  }
 
   Body.call(Response.prototype)
 

--- a/Libraries/Fetch/fetch.js
+++ b/Libraries/Fetch/fetch.js
@@ -278,6 +278,10 @@ var self = {};
     }
     this._initBody(body)
   }
+  
+  Request.prototype.clone = function() {
+    return new Request(this)
+  }
 
   function decode(body) {
     var form = new FormData()


### PR DESCRIPTION
Fetch includes a cloning function that was not included in the React Native fetch.js. This adds it in so that cloning is available on responses from fetch calls in React Native. The code is taken directly from [fetch](https://github.com/github/fetch/blob/master/fetch.js) on Github.

<img width="601" alt="screen shot 2015-10-22 at 11 50 53 am" src="https://cloud.githubusercontent.com/assets/11564650/10675101/304ebe5a-78b3-11e5-9d6b-24ea6d9fb998.png">

<img width="596" alt="screen shot 2015-10-22 at 12 20 08 pm" src="https://cloud.githubusercontent.com/assets/11564650/10675834/4abaf4ee-78b7-11e5-9d34-436290b64b30.png">
