### PR TITLE
Update blacklist.js

### DIFF
--- a/packager/blacklist.js
+++ b/packager/blacklist.js
@@ -17,6 +17,8 @@ var sharedBlacklist = [
   'node_modules/react-tools/src/renderers/shared/event/EventPropagators.js',
   'node_modules/react-tools/src/renderers/shared/event/eventPlugins/ResponderEventPlugin.js',
   'node_modules/react-tools/src/shared/vendor/core/ExecutionEnvironment.js',
+  'node_modules/react-tools/docs/js/react.js',
+  'node_modules/react-tools/src/package.json',  
 
   // Those conflicts with the ones in react-tools/. We need to blacklist the
   // internal version otherwise they won't work in open source.


### PR DESCRIPTION
Since we rely on a non npm version of `react-tools` which includes docs and other unnecessary files we need to make sure we blacklist some of them as otherwise the packager fails