### PR TITLE
Adding mobile fallback in dependency resolution

### DIFF
--- a/packager/react-packager/src/DependencyResolver/DependencyGraph/ResolutionRequest.js
+++ b/packager/react-packager/src/DependencyResolver/DependencyGraph/ResolutionRequest.js
@@ -301,6 +301,8 @@ class ResolutionRequest {
       } else if (this._platform != null &&
                  this._fastfs.fileExists(potentialModulePath + '.' + this._platform + '.js')) {
         file = potentialModulePath + '.' + this._platform + '.js';
+      } else if (this._fastfs.fileExists(potentialModulePath + '.mobile.js')) {
+        file = potentialModulePath + '.mobile.js';
       } else if (this._fastfs.fileExists(potentialModulePath + '.js')) {
         file = potentialModulePath + '.js';
       } else if (this._fastfs.fileExists(potentialModulePath + '.json')) {

--- a/packager/react-packager/src/DependencyResolver/DependencyGraph/__tests__/DependencyGraph-test.js
+++ b/packager/react-packager/src/DependencyResolver/DependencyGraph/__tests__/DependencyGraph-test.js
@@ -2669,6 +2669,55 @@ describe('DependencyGraph', function() {
       });
     });
 
+    pit('should fallback to mobile with multiple platforms (node)', function() {
+      var root = '/root';
+      fs.__setMockFilesystem({
+        'root': {
+          'index.ios.js': `
+            /**
+             * @providesModule index
+             */
+             require('./a');
+          `,
+          'a.mobile.js': '',
+          'a.android.js': '',
+          'a.js': '',
+        }
+      });
+
+      var dgraph = new DependencyGraph({
+        roots: [root],
+        fileWatcher: fileWatcher,
+        assetExts: ['png', 'jpg'],
+        cache: cache,
+      });
+      return getOrderedDependenciesAsJSON(dgraph, '/root/index.ios.js').then(function(deps) {
+        expect(deps)
+          .toEqual([
+            {
+              id: 'index',
+              path: '/root/index.ios.js',
+              dependencies: ['./a'],
+              isAsset: false,
+              isAsset_DEPRECATED: false,
+              isJSON: false,
+              isPolyfill: false,
+              resolution: undefined,
+            },
+            {
+              id: '/root/a.mobile.js',
+              path: '/root/a.mobile.js',
+              dependencies: [],
+              isAsset: false,
+              isAsset_DEPRECATED: false,
+              isJSON: false,
+              isPolyfill: false,
+              resolution: undefined,
+            },
+          ]);
+      });
+    });
+
     pit('should require package.json', () => {
       var root = '/root';
       fs.__setMockFilesystem({


### PR DESCRIPTION
This is more of a conversation starter. In our project we're starting to mix react-native and web. We want to effectively share ios and android so it's handy to have a file.mobile.js fallback in the require resolution in the packager. This turns into a 2 liner in the packager (sans documentation). Is there a better solution?

The idea is on iOS it looks for

file.ios.js
file.mobile.js
file.js
(file.json etc)