### PR TITLE
Exported a callback for native webview delegate method shouldStartLoadWithRequest

### DIFF
--- a/Libraries/Components/WebView/WebView.ios.js
+++ b/Libraries/Components/WebView/WebView.ios.js
@@ -107,6 +107,7 @@ var WebView = React.createClass({
      * user can change the scale
      */
     scalesPageToFit: PropTypes.bool,
+    shouldStartLoadWithRequest: PropTypes.func,
   },
 
   getInitialState: function() {
@@ -167,6 +168,7 @@ var WebView = React.createClass({
         onLoadingStart={this.onLoadingStart}
         onLoadingFinish={this.onLoadingFinish}
         onLoadingError={this.onLoadingError}
+        onShouldStartLoadWithRequest={this.onShouldStartLoadWithRequest}
         scalesPageToFit={this.props.scalesPageToFit}
       />;
 
@@ -176,6 +178,10 @@ var WebView = React.createClass({
         {otherView}
       </View>
     );
+  },
+
+  startLoadWithResult: function(result, lockIdentifier) {
+    RCTWebViewManager.startLoadWithResult(result, lockIdentifier);
   },
 
   goForward: function() {
@@ -224,6 +230,12 @@ var WebView = React.createClass({
     });
     this.updateNavigationState(event);
   },
+
+  onShouldStartLoadWithRequest: function(event: Event) {
+    if (this.props.shouldStartLoadWithRequest) {
+      this.props.shouldStartLoadWithRequest(event.nativeEvent);
+    }
+  },
 });
 
 var RCTWebView = requireNativeComponent('RCTWebView', WebView, {
@@ -231,6 +243,7 @@ var RCTWebView = requireNativeComponent('RCTWebView', WebView, {
     onLoadingStart: true,
     onLoadingError: true,
     onLoadingFinish: true,
+    onShouldStartLoadWithRequest: true
   },
 });
 

--- a/React/Views/RCTWebViewManager.m
+++ b/React/Views/RCTWebViewManager.m
@@ -34,6 +34,7 @@ RCT_EXPORT_VIEW_PROPERTY(automaticallyAdjustContentInsets, BOOL);
 RCT_EXPORT_VIEW_PROPERTY(onLoadingStart, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onLoadingFinish, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onLoadingError, RCTDirectEventBlock);
+RCT_EXPORT_VIEW_PROPERTY(onShouldStartLoadWithRequest, RCTDirectEventBlock);
 
 - (NSDictionary *)constantsToExport
 {
@@ -48,6 +49,14 @@ RCT_EXPORT_VIEW_PROPERTY(onLoadingError, RCTDirectEventBlock);
       @"Other": @(UIWebViewNavigationTypeOther)
     },
   };
+}
+
+RCT_EXPORT_METHOD(startLoadWithResult:(BOOL)result lockIdentifier:(NSInteger)lockIdentifier) {
+  NSDictionary *userInfo = @{
+    @"result": @(result),
+    @"lockIdentifier": @(lockIdentifier)
+  };
+  [[NSNotificationCenter defaultCenter] postNotificationName:@"webViewStartLoadNotification" object:self userInfo:userInfo];
 }
 
 RCT_EXPORT_METHOD(goBack:(nonnull NSNumber *)reactTag)


### PR DESCRIPTION
We have a requirement in our app, to open in mobile Safari, any http:// and https:// links displayed in a web view. Our web view is not full screen and is loaded with an HTML string from the backend. Displaying external content in that web view is outside of the scope of our app, so we open them in mobile Safari.

I've forked the WebView component and added a callback property, shouldStartLoadWithRequest, and modified the RCTWebView implementation of `webView:shouldStartLoadWithRequest:navigationType:`
to check if the shouldStartLoadWithRequest property is set.

If the property is set, `webView:shouldStartLoadWithRequest:navigationType:` passes the URL & navigationType to the callback. The callback is then able to ignore the request, redirect it, open a full screen web view to display the URL content, or even deep link to another app with LinkingIOS.openURL().