### PR TITLE
Fix DEV mode override

### DIFF
--- a/React/Base/RCTBatchedBridge.m
+++ b/React/Base/RCTBatchedBridge.m
@@ -190,12 +190,12 @@ RCT_EXTERN NSArray *RCTGetModuleClasses(void);
     // Force JS __DEV__ value to match RCT_DEBUG
     if (shouldOverrideDev) {
       NSString *sourceString = [[NSString alloc] initWithData:source encoding:NSUTF8StringEncoding];
-      NSRange range = [sourceString rangeOfString:@"__DEV__="];
+      NSRange range = [sourceString rangeOfString:@"__DEV__ ="];
       RCTAssert(range.location != NSNotFound, @"It looks like the implementation"
                 "of __DEV__ has changed. Update -[RCTBatchedBridge loadSource:].");
-      NSRange valueRange = {range.location + range.length, 2};
-      if ([[sourceString substringWithRange:valueRange] isEqualToString:@"!1"]) {
-        source = [[sourceString stringByReplacingCharactersInRange:valueRange withString:@" 1"] dataUsingEncoding:NSUTF8StringEncoding];
+      NSRange valueRange = {range.location + range.length + 2, 5};
+      if ([[sourceString substringWithRange:valueRange] isEqualToString:@"false"]) {
+        source = [[sourceString stringByReplacingCharactersInRange:valueRange withString:@" true"] dataUsingEncoding:NSUTF8StringEncoding];
       }
     }
 


### PR DESCRIPTION
Local `.jsbundle` use seems to be broken on 0.14.0-stable. 

It seems like something in the bundler changed the output of `__DEV__ = X` in the packager, which made this regex break.

I'm not sure if this is the right fix, or whether to find where in the packager this changed.

Addresses https://github.com/facebook/react-native/issues/3583