### PR TITLE
Correct scrollEventThrottle docs

### DIFF
--- a/Libraries/Components/ScrollView/ScrollView.js
+++ b/Libraries/Components/ScrollView/ScrollView.js
@@ -210,9 +210,11 @@ var ScrollView = React.createClass({
      * (as a time interval in ms). A lower number yields better accuracy for code
      * that is tracking the scroll position, but can lead to scroll performance
      * problems due to the volume of information being send over the bridge.
-     * You should NOT set this value below 16ms as you will be wasting frames.
-     * The default value is zero, which means the scroll event will be sent
-     * only once each time the view is scrolled.
+     * You will not notice a difference between values set between 1-16 as the
+     * JS run loop is synced to the screen refresh rate. If you do not need precise
+     * scroll position tracking, set this value higher to limit the information
+     * being sent across the bridge. The default value is zero, which results in
+     * the scroll event being sent only once each time the view is scrolled.
      * @platform ios
      */
     scrollEventThrottle: PropTypes.number,

--- a/Libraries/Components/ScrollView/ScrollView.js
+++ b/Libraries/Components/ScrollView/ScrollView.js
@@ -207,9 +207,10 @@ var ScrollView = React.createClass({
     scrollEnabled: PropTypes.bool,
     /**
      * This controls how often the scroll event will be fired while scrolling
-     * (in events per seconds). A higher number yields better accuracy for code
+     * (as a time interval in ms). A lower number yields better accuracy for code
      * that is tracking the scroll position, but can lead to scroll performance
      * problems due to the volume of information being send over the bridge.
+     * You should NOT set this value below 16ms as you will be wasting frames.
      * The default value is zero, which means the scroll event will be sent
      * only once each time the view is scrolled.
      * @platform ios


### PR DESCRIPTION
The docs indicated that a higher number was more accurate, however based on the implementation:

```
  /**
   * TODO: this logic looks wrong, and it may be because it is. Currently, if _scrollEventThrottle
   * is set to zero (the default), the "didScroll" event is only sent once per scroll, instead of repeatedly
   * while scrolling as expected. However, if you "fix" that bug, ScrollView will generate repeated
   * warnings, and behave strangely (ListView works fine however), so don't fix it unless you fix that too!
   */
  if (_allowNextScrollNoMatterWhat ||
      (_scrollEventThrottle > 0 && _scrollEventThrottle < (now - _lastScrollDispatchTime)))
```
https://github.com/facebook/react-native/blob/master/React/Views/RCTScrollView.m#L564

It appears that only 0 is a special case here, and perhaps a known issue ;)