### PR TITLE
calling navigationBar's overridden ref function

### DIFF
--- a/Libraries/CustomComponents/Navigator/Navigator.js
+++ b/Libraries/CustomComponents/Navigator/Navigator.js
@@ -1073,7 +1073,10 @@ var Navigator = React.createClass({
       return null;
     }
     return React.cloneElement(this.props.navigationBar, {
-      ref: (navBar) => { this._navBar = navBar; },
+      ref: (navBar) => {
+        this.props.navigationBar.ref instanceof Function && this.props.navigationBar.ref(navBar);
+        this._navBar = navBar;
+      },
       navigator: this,
       navState: this.state,
     });


### PR DESCRIPTION
Before that it was not possible to get a ref to a navigation bar (unless using Navigator's internal `_navBar` prop)