### PR TITLE
fix error handling in packager

### DIFF
--- a/local-cli/server/server.js
+++ b/local-cli/server/server.js
@@ -122,7 +122,7 @@ function _server(argv, config, resolve, reject) {
     }
     console.log('\nSee', chalk.underline('http://facebook.github.io/react-native/docs/troubleshooting.html'));
     console.log('for common problems and solutions.');
-    reject();
+    process.exit(1);
   });
 
   // TODO: remove once we deprecate this arg


### PR DESCRIPTION
Currently on error I have following output:
```
 ERROR  Packager can't listen on port 8081
Most likely another process is already using this port
Run the following command to find out which process:

   lsof -n -i4TCP:8081 

You can either shut down the other process:

   kill -9 <PID> 

or run packager on different port.

See http://facebook.github.io/react-native/docs/troubleshooting.html
for common problems and solutions.
/Users/nucleartux/Work/projects/react-native/local-cli/server/server.js:90
    if (error.code === 'EADDRINUSE') {
             ^

TypeError: Cannot read property 'code' of undefined
    at process.<anonymous> (/Users/nucleartux/Work/projects/react-native/local-cli/server/server.js:104:14)
    at emitOne (events.js:77:13)
    at process.emit (events.js:169:7)
    at process._fatalException (node.js:211:26)
```
