### PR TITLE
Make InteractionManager.runAfterInteractions() return a Promise

### DIFF
--- a/Libraries/Interaction/InteractionManager.js
+++ b/Libraries/Interaction/InteractionManager.js
@@ -73,13 +73,14 @@ var InteractionManager = {
   /**
    * Schedule a function to run after all interactions have completed.
    */
-  runAfterInteractions(callback: Function) {
-    invariant(
-      typeof callback === 'function',
-      'Must specify a function to schedule.'
-    );
-    scheduleUpdate();
-    _queue.push(callback);
+  runAfterInteractions(callback: ?Function): Promise {
+    return new Promise((resolve, reject) => {
+      scheduleUpdate();
+      if (callback) {
+        _queue.push(callback);
+      }
+      _queue.push(resolve);
+    });
   },
 
   /**


### PR DESCRIPTION
In accordance with the unwritten rule that any API that takes a callback should also return a promise, I've changed `InteractionManager.runAfterInteractions()` to do just that.

```js
  InteractionManager.runAfterInteractions(() => {
    ...
  });
```
can become
```js
  InteractionManager.runAfterInteractions().then(() => {
    ...
  });
```
(but doesn't have to). Most importantly, though, this change enables code like
```js
  doSomeUIStuff();
  await InteractionManager.runAfterInteractions();
  doSomeNonUIStuff();
```
which is nice.

Note: Because returning a `Promise` means the callback argument is now optional, the behaviour of the API is slightly changed, though not in a backwards-incompatible way (unless a consumer is in some way relying on the exception, but that would be insane).