### PR TITLE
[Docs] Remove section on how transparent views don't receive touches on iOS

### DIFF
--- a/docs/KnownIssues.md
+++ b/docs/KnownIssues.md
@@ -58,28 +58,6 @@ There are known cases where the APIs could be made more consistent across iOS an
 
 There is currently no easy way of publishing custom native modules on Android. Smooth work flow for contributors is important and this will be looked at very closely after the initial Open Source release. Of course the aim will be to streamline and optimize the process between iOS and Android as much as possible.
 
-### Overlay view with opacity of 0 cannot be clicked through
-
-There is a noted difference in the handling of Views with an opacity of 0 between iOS and Android. While iOS will allow these views to be clicked through and the View below will receive the touch input, for Android the touch will be blocked. This can be demonstrated in this example where it will only be possible to click the touchable on iOS.
-
-```
-<View style={{flex: 1}}>
-  <TouchableOpacity onPress={() => alert('hi!')}>
-    <Text>HELLO!</Text>
-  </TouchableOpacity>
-
-  <View style={{
-    position: 'absolute',
-    top: 0,
-    left: 0,
-    bottom: 0,
-    right: 0,
-    opacity: 0}} />
-</View>
-```
-
-The behavior on Android is what you would expect from the web as well.  If you want to be able to click through an overlaying transparent view, you can set `pointerEvents='none'` on it.
-
 ### The `overflow` style property defaults to `hidden` and cannot be changed on Android
 
 This is a result of how Android rendering works. This feature is not being worked on as it would be a significant undertaking and there are many more important tasks.


### PR DESCRIPTION
After https://github.com/facebook/react-native/commit/77272d5a9193762b8668c99d54f5bb9a3e423a9e / D2574937, transparent views (managed by RN) on iOS now receive touch events. The code sample from the Known Issues section is now a UIExplorer example, and you can't tap the TouchableOpacity button because the transparent overlay is intercepting touches (which matches the behavior on other platforms).