### PR TITLE
[Bugfix] Memory Leaks caused by RCTNavigator

### DIFF
--- a/React/Views/RCTNavigator.m
+++ b/React/Views/RCTNavigator.m
@@ -335,6 +335,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
 - (void)dealloc
 {
   _navigationController.delegate = nil;
+  _navigationController.viewControllers = nil;
 }
 
 - (UIViewController *)reactViewController

--- a/React/Views/RCTNavigator.m
+++ b/React/Views/RCTNavigator.m
@@ -334,8 +334,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
 
 - (void)dealloc
 {
-  _navigationController.delegate = nil;
-  _navigationController.viewControllers = nil;
+  [_navigationController removeFromParentViewController];
 }
 
 - (UIViewController *)reactViewController

--- a/React/Views/RCTNavigator.m
+++ b/React/Views/RCTNavigator.m
@@ -334,6 +334,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
 
 - (void)dealloc
 {
+  _navigationController.delegate = nil;
   [_navigationController removeFromParentViewController];
 }
 


### PR DESCRIPTION
releasing the viewControllers referred by _navigationController.viewControllers, which is also releasing the related views