### PR TITLE
[Android] Prevent destroying activity on runtime changes

### DIFF
--- a/local-cli/generator-android/templates/src/app/src/main/AndroidManifest.xml
+++ b/local-cli/generator-android/templates/src/app/src/main/AndroidManifest.xml
@@ -10,7 +10,8 @@
       android:theme="@style/AppTheme">
       <activity
         android:name=".MainActivity"
-        android:label="@string/app_name">
+        android:label="@string/app_name"
+        android:configChanges="keyboard|keyboardHidden|orientation|screenSize">
         <intent-filter>
             <action android:name="android.intent.action.MAIN" />
             <category android:name="android.intent.category.LAUNCHER" />


### PR DESCRIPTION
From http://developer.android.com/guide/topics/resources/runtime-changes.html

> Some device configurations can change during runtime (such as screen orientation, keyboard availability, and language). When such a change occurs, Android restarts the running Activity (onDestroy() is called, followed by onCreate()). The restart behavior is designed to help your application adapt to new configurations by automatically reloading your application with alternative resources that match the new device configuration.

However, in a React Native app, there is only a single activity for the entire app, unlike a single activity per screen in Android, and resources are not specific to orientation etc. Destroying activity means reloading the entire app. Most of the time, this is not the intended behaviour, and can cause data loss for the user if the developer doesn't disable it explicitly. I'm proposing to disable it by default.