### PR TITLE
Add support for textDecorationLine to Android

### DIFF
--- a/Examples/UIExplorer/TextExample.android.js
+++ b/Examples/UIExplorer/TextExample.android.js
@@ -343,6 +343,22 @@ var TextExample = React.createClass({
             No maximum lines specified no matter now much I write here. If I keep writing it{"'"}ll just keep going and going
           </Text>
         </UIExplorerBlock>
+        <UIExplorerBlock title="Text Decoration">
+          <View>
+            <Text style={{textDecorationLine: 'underline'}}>
+              Solid underline
+            </Text>
+            <Text style={{textDecorationLine: 'none'}}>
+              None textDecoration
+            </Text>
+            <Text style={{textDecorationLine: 'line-through'}}>
+              Solid line-through
+            </Text>
+            <Text style={{textDecorationLine: 'underline line-through'}}>
+              Both underline and line-through
+            </Text>
+          </View>
+        </UIExplorerBlock>
       </UIExplorerPage>
     );
   }

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewProps.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewProps.java
@@ -70,6 +70,7 @@ public class ViewProps {
   public static final String ON = "on";
   public static final String RESIZE_MODE = "resizeMode";
   public static final String TEXT_ALIGN = "textAlign";
+  public static final String TEXT_DECORATION_LINE = "textDecorationLine";
 
   public static final String BORDER_WIDTH = "borderWidth";
   public static final String BORDER_LEFT_WIDTH = "borderLeftWidth";

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextViewManager.java
@@ -11,6 +11,7 @@ package com.facebook.react.views.text;
 
 import javax.annotation.Nullable;
 
+import android.graphics.Paint;
 import android.text.Spannable;
 import android.text.Spanned;
 import android.text.TextUtils;
@@ -77,6 +78,22 @@ public class ReactTextViewManager extends BaseViewManager<ReactTextView, ReactTe
       view.setLineSpacing(0, 1);
     } else {
       view.setLineSpacing(PixelUtil.toPixelFromSP(lineHeight), 0);
+    }
+  }
+
+  @ReactProp(name = ViewProps.TEXT_DECORATION_LINE)
+  public void setTextDecorationLine(ReactTextView view, @Nullable String textDecorationLine) {
+    int paintFlags = view.getPaintFlags();
+    if (textDecorationLine == null || "none".equals(textDecorationLine)) {
+      view.setPaintFlags(paintFlags & ~Paint.UNDERLINE_TEXT_FLAG & ~Paint.STRIKE_THRU_TEXT_FLAG);
+    } else if ("underline".equals(textDecorationLine)) {
+      view.setPaintFlags(paintFlags | Paint.UNDERLINE_TEXT_FLAG & ~Paint.STRIKE_THRU_TEXT_FLAG);
+    } else if ("line-through".equals(textDecorationLine)) {
+      view.setPaintFlags(paintFlags & ~Paint.UNDERLINE_TEXT_FLAG | Paint.STRIKE_THRU_TEXT_FLAG);
+    } else if ("underline line-through".equals(textDecorationLine)) {
+      view.setPaintFlags(paintFlags | Paint.UNDERLINE_TEXT_FLAG | Paint.STRIKE_THRU_TEXT_FLAG);
+    } else {
+      throw new JSApplicationIllegalArgumentException("Invalid textDecorationLine: " + textDecorationLine);
     }
   }
 


### PR DESCRIPTION
Attached PR adds support for the none, underline, line-through, and 'underline line-through' textDecorationLine style elements to Android, and, updates the UIExplorer to display these options.

Note that textDecorationColor and textDecorationStyle have not been added as well because there is no straight-forward way to support these options in Android.