### PR TITLE
Flexible parsing of textDecorationLine

### DIFF
--- a/Examples/UIExplorer/TextExample.android.js
+++ b/Examples/UIExplorer/TextExample.android.js
@@ -370,6 +370,22 @@ var TextExample = React.createClass({
             Demo text shadow
           </Text>
         </UIExplorerBlock>
+        <UIExplorerBlock title="Text Decoration">
+          <View>
+            <Text style={{textDecorationLine: 'underline'}}>
+              Solid underline
+            </Text>
+            <Text style={{textDecorationLine: 'none'}}>
+              None textDecoration
+            </Text>
+            <Text style={{textDecorationLine: 'line-through'}}>
+              Solid line-through
+            </Text>
+            <Text style={{textDecorationLine: 'underline line-through'}}>
+              Both underline and line-through
+            </Text>
+          </View>
+        </UIExplorerBlock>
       </UIExplorerPage>
     );
   }

--- a/Libraries/Components/View/ReactNativeStyleAttributes.js
+++ b/Libraries/Components/View/ReactNativeStyleAttributes.js
@@ -13,6 +13,7 @@
 'use strict';
 
 var ImageStylePropTypes = require('ImageStylePropTypes');
+var Platform = require('Platform');
 var TextStylePropTypes = require('TextStylePropTypes');
 var ViewStylePropTypes = require('ViewStylePropTypes');
 
@@ -48,5 +49,17 @@ ReactNativeStyleAttributes.textDecorationColor = colorAttributes;
 ReactNativeStyleAttributes.tintColor = colorAttributes;
 ReactNativeStyleAttributes.textShadowColor = colorAttributes;
 ReactNativeStyleAttributes.overlayColor = colorAttributes;
+
+if (Platform.OS === 'android') {
+  // ReactAndroid doesn't currently have the capability to have variable typing
+  // (eg. string or array) of a native attribute.  To work around that, we can
+  // transform variable types into one standard type, as done here with
+  // textDecorationLine which can be an array of enum values or a space-separated
+  // string containing the same values.
+  var processTextDecorationLine = require('processTextDecorationLine');
+  ReactNativeStyleAttributes.textDecorationLine = {
+    process: processTextDecorationLine
+  };
+}
 
 module.exports = ReactNativeStyleAttributes;

--- a/Libraries/StyleSheet/processTextDecorationLine.android.js
+++ b/Libraries/StyleSheet/processTextDecorationLine.android.js
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule processTextDecorationLine
+ */
+
+/* eslint no-bitwise: 0 */
+
+'use strict';
+
+const textDecorationLineBitFlags = {
+  'none': 0,
+  'underline': 1 << 0,
+  'line-through': 1 << 1,
+};
+
+// textDecorationLine can be a string with a single enum value, a string with
+// space-separated enum values, or an array of enum values.  Because ReactAndroid
+// doesn't currently support an @ReactProp with multiple potential types, we convert
+// it to an integer here in JS.
+function processTextDecorationLine(value) {
+  var array;
+  if (Array.isArray(value)) {
+    array = value;
+  } else if (typeof value === 'string') {
+    array = value.split(' ').filter((x) => x.length > 0);
+  } else {
+    throw new Error('Invalid type of textDecorationLine');
+  }
+  var bitField = 0;
+  array.forEach((singleValueString) => {
+    var singleValue = textDecorationLineBitFlags[singleValueString];
+    if (singleValue === undefined) {
+      throw new Error('Invalid value for textDecorationLine: ' + singleValueString);
+    }
+    bitField |= singleValue;
+  });
+  return bitField;
+}
+
+module.exports = processTextDecorationLine;

--- a/Libraries/StyleSheet/processTextDecorationLine.ios.js
+++ b/Libraries/StyleSheet/processTextDecorationLine.ios.js
@@ -5,12 +5,13 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule processTextDecorationLine
  */
+'use strict';
 
-#import <Foundation/Foundation.h>
+function processTextDecorationLine(value) {
+  throw new Error('not required on iOS');
+}
 
-typedef NS_OPTIONS(NSInteger, RCTTextDecorationLineType) {
-  RCTTextDecorationLineTypeNone = 0,
-  RCTTextDecorationLineTypeUnderline = 1 << 0,
-  RCTTextDecorationLineTypeStrikethrough = 1 << 1,
-};
+module.exports = processTextDecorationLine;

--- a/Libraries/Text/RCTShadowText.m
+++ b/Libraries/Text/RCTShadowText.m
@@ -303,13 +303,11 @@ static css_dim_t RCTMeasure(void *context, float width, float height)
   }
 
   // Text decoration
-  if (_textDecorationLine == RCTTextDecorationLineTypeUnderline ||
-      _textDecorationLine == RCTTextDecorationLineTypeUnderlineStrikethrough) {
+  if(_textDecorationLine & RCTTextDecorationLineTypeUnderline) {
     [self _addAttribute:NSUnderlineStyleAttributeName withValue:@(_textDecorationStyle)
      toAttributedString:attributedString];
   }
-  if (_textDecorationLine == RCTTextDecorationLineTypeStrikethrough ||
-      _textDecorationLine == RCTTextDecorationLineTypeUnderlineStrikethrough){
+  if(_textDecorationLine & RCTTextDecorationLineTypeStrikethrough) {
     [self _addAttribute:NSStrikethroughStyleAttributeName withValue:@(_textDecorationStyle)
      toAttributedString:attributedString];
   }

--- a/Libraries/Text/TextStylePropTypes.js
+++ b/Libraries/Text/TextStylePropTypes.js
@@ -53,11 +53,14 @@ var TextStylePropTypes = Object.assign(Object.create(ViewStylePropTypes), {
     ['auto' /*default*/, 'top', 'bottom', 'center']
   ),
   /**
-   * @platform ios
+   * Specifies the style of text decoration line; an underline, a line-through
+   * (often referred to as a strike-through), or both.  Can be specified as either a
+   * space-separated string of underline and line-through, or an array of the same.
    */
-  textDecorationLine: ReactPropTypes.oneOf(
-    ['none' /*default*/, 'underline', 'line-through', 'underline line-through']
-  ),
+  textDecorationLine: ReactPropTypes.oneOfType([
+    ReactPropTypes.oneOf(['none' /*default*/, 'underline', 'line-through', 'underline line-through']),
+    ReactPropTypes.arrayOf(ReactPropTypes.oneOf(['none', 'underline', 'line-through']))
+  ]),
   /**
    * @platform ios
    */

--- a/React/Base/RCTConvert.m
+++ b/React/Base/RCTConvert.m
@@ -216,12 +216,21 @@ NSNumber *RCTConvertEnumValue(const char *typeName, NSDictionary *mapping, NSNum
 
 NSNumber *RCTConvertMultiEnumValue(const char *typeName, NSDictionary *mapping, NSNumber *defaultValue, id json)
 {
+  NSArray *array = nil;
   if ([json isKindOfClass:[NSArray class]]) {
-    if ([json count] == 0) {
+    array = json;
+  } else if ([json isKindOfClass:[NSString class]]) {
+    // support space-separated enum values in a string
+    array = [json componentsSeparatedByString:@" "];
+    // prevent errors from extra whitespace causing blank strings
+    array = [array filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"length > 0"]];
+  }
+  if (array) {
+    if ([array count] == 0) {
       return defaultValue;
     }
     long long result = 0;
-    for (id arrayElement in json) {
+    for (id arrayElement in array) {
       NSNumber *value = RCTConvertEnumValue(typeName, mapping, defaultValue, arrayElement);
       result |= value.longLongValue;
     }
@@ -260,11 +269,10 @@ RCT_ENUM_CONVERTER(RCTBorderStyle, (@{
   @"dashed": @(RCTBorderStyleDashed),
 }), RCTBorderStyleSolid, integerValue)
 
-RCT_ENUM_CONVERTER(RCTTextDecorationLineType, (@{
+RCT_MULTI_ENUM_CONVERTER(RCTTextDecorationLineType, (@{
   @"none": @(RCTTextDecorationLineTypeNone),
   @"underline": @(RCTTextDecorationLineTypeUnderline),
   @"line-through": @(RCTTextDecorationLineTypeStrikethrough),
-  @"underline line-through": @(RCTTextDecorationLineTypeUnderlineStrikethrough),
 }), RCTTextDecorationLineTypeNone, integerValue)
 
 RCT_ENUM_CONVERTER(NSWritingDirection, (@{

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewProps.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewProps.java
@@ -71,6 +71,7 @@ public class ViewProps {
   public static final String RESIZE_MODE = "resizeMode";
   public static final String TEXT_ALIGN = "textAlign";
   public static final String TEXT_ALIGN_VERTICAL = "textAlignVertical";
+  public static final String TEXT_DECORATION_LINE = "textDecorationLine";
 
   public static final String BORDER_WIDTH = "borderWidth";
   public static final String BORDER_LEFT_WIDTH = "borderLeftWidth";

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextViewManager.java
@@ -80,20 +80,21 @@ public class ReactTextViewManager extends BaseViewManager<ReactTextView, ReactTe
     }
   }
 
-  @ReactProp(name = ViewProps.TEXT_DECORATION_LINE)
-  public void setTextDecorationLine(ReactTextView view, @Nullable String textDecorationLine) {
+  // These values should match the values in ReactNativeStyleAttributes.js, where they're converted
+  // from JS values into the integer used in setTextDecorationLine.
+  private static final int UNDERLINE = 1 << 0;
+  private static final int LINE_THROUGH = 1 << 1;
+
+  @ReactProp(name = ViewProps.TEXT_DECORATION_LINE, customType = "TextDecorationLine")
+  public void setTextDecorationLine(ReactTextView view, int textDecorationLine) {
     int paintFlags = view.getPaintFlags();
-    if (textDecorationLine == null || "none".equals(textDecorationLine)) {
-      view.setPaintFlags(paintFlags & ~Paint.UNDERLINE_TEXT_FLAG & ~Paint.STRIKE_THRU_TEXT_FLAG);
-    } else if ("underline".equals(textDecorationLine)) {
-      view.setPaintFlags(paintFlags | Paint.UNDERLINE_TEXT_FLAG & ~Paint.STRIKE_THRU_TEXT_FLAG);
-    } else if ("line-through".equals(textDecorationLine)) {
-      view.setPaintFlags(paintFlags & ~Paint.UNDERLINE_TEXT_FLAG | Paint.STRIKE_THRU_TEXT_FLAG);
-    } else if ("underline line-through".equals(textDecorationLine)) {
-      view.setPaintFlags(paintFlags | Paint.UNDERLINE_TEXT_FLAG | Paint.STRIKE_THRU_TEXT_FLAG);
-    } else {
-      throw new JSApplicationIllegalArgumentException("Invalid textDecorationLine: " + textDecorationLine);
+    if ((textDecorationLine & UNDERLINE) == UNDERLINE) {
+      paintFlags |= Paint.UNDERLINE_TEXT_FLAG;
     }
+    if ((textDecorationLine & LINE_THROUGH) == LINE_THROUGH) {
+      paintFlags |= Paint.STRIKE_THRU_TEXT_FLAG;
+    }
+    view.setPaintFlags(paintFlags);
   }
 
   @Override

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextViewManager.java
@@ -11,6 +11,7 @@ package com.facebook.react.views.text;
 
 import javax.annotation.Nullable;
 
+import android.graphics.Paint;
 import android.text.Spannable;
 import android.text.TextUtils;
 import android.view.Gravity;
@@ -76,6 +77,22 @@ public class ReactTextViewManager extends BaseViewManager<ReactTextView, ReactTe
       view.setLineSpacing(0, 1);
     } else {
       view.setLineSpacing(PixelUtil.toPixelFromSP(lineHeight), 0);
+    }
+  }
+
+  @ReactProp(name = ViewProps.TEXT_DECORATION_LINE)
+  public void setTextDecorationLine(ReactTextView view, @Nullable String textDecorationLine) {
+    int paintFlags = view.getPaintFlags();
+    if (textDecorationLine == null || "none".equals(textDecorationLine)) {
+      view.setPaintFlags(paintFlags & ~Paint.UNDERLINE_TEXT_FLAG & ~Paint.STRIKE_THRU_TEXT_FLAG);
+    } else if ("underline".equals(textDecorationLine)) {
+      view.setPaintFlags(paintFlags | Paint.UNDERLINE_TEXT_FLAG & ~Paint.STRIKE_THRU_TEXT_FLAG);
+    } else if ("line-through".equals(textDecorationLine)) {
+      view.setPaintFlags(paintFlags & ~Paint.UNDERLINE_TEXT_FLAG | Paint.STRIKE_THRU_TEXT_FLAG);
+    } else if ("underline line-through".equals(textDecorationLine)) {
+      view.setPaintFlags(paintFlags | Paint.UNDERLINE_TEXT_FLAG | Paint.STRIKE_THRU_TEXT_FLAG);
+    } else {
+      throw new JSApplicationIllegalArgumentException("Invalid textDecorationLine: " + textDecorationLine);
     }
   }
 


### PR DESCRIPTION
As suggested by @ide in #3816, this PR adds flexible parsing of the textDecorationLine style so that it can be expanded upon easily in the future, and the logically equivalent "line-through underline" and "underline line-through" styles both function correctly.

This amendment went a bit off the rails from the initial plan -- I ended up using RCT_MULTI_ENUM_CONVERTER in iOS to support the multiple value enum, which also smartly supports using an array for the enum values.  That seemed like a great idea, better than space-separated enum values.  So, I added support for both approaches (space-separated OR array) because that seemed reasonable; it's backwards compatible and yet takes a smarter approach.  (Note: a side-effect of this is that UIAccessibilityTraits now supports a space-separated string of accessibility traits; doesn't seem horrible to allow this, probably wouldn't recommend documenting it.)

However, adding support like that for the Android side became trickier, as @ReactProp can't be used on a property that doesn't have a specific supported type, and this property would support two value types.  I resolved this by converting the value in JS to an integer before passing it to the Android backend.

This PR subsumes PR #3816.