### PR TITLE
[ImagePickerIOS] Save photo to album when taking picture from camera

### DIFF
--- a/Libraries/CameraRoll/RCTImagePickerManager.m
+++ b/Libraries/CameraRoll/RCTImagePickerManager.m
@@ -12,8 +12,10 @@
 #import "RCTRootView.h"
 #import "RCTLog.h"
 #import "RCTUtils.h"
+#import "RCTAssetsLibraryImageLoader.h"
 
 #import <UIKit/UIKit.h>
+#import <AssetsLibrary/AssetsLibrary.h>
 
 #import <MobileCoreServices/UTCoreTypes.h>
 
@@ -29,6 +31,8 @@
 }
 
 RCT_EXPORT_MODULE(ImagePickerIOS);
+
+@synthesize bridge = _bridge;
 
 - (instancetype)init
 {
@@ -116,6 +120,7 @@ didFinishPickingMediaWithInfo:(NSDictionary *)info
 {
   NSUInteger index = [_pickers indexOfObject:picker];
   RCTResponseSenderBlock callback = _pickerCallbacks[index];
+  RCTResponseSenderBlock cancelCallback = _pickerCancelCallbacks[index];
 
   [_pickers removeObjectAtIndex:index];
   [_pickerCallbacks removeObjectAtIndex:index];
@@ -125,7 +130,24 @@ didFinishPickingMediaWithInfo:(NSDictionary *)info
   UIViewController *rootViewController = keyWindow.rootViewController;
   [rootViewController dismissViewControllerAnimated:YES completion:nil];
 
-  callback(@[[info[UIImagePickerControllerReferenceURL] absoluteString]]);
+  NSURL *imageUrl = info[UIImagePickerControllerReferenceURL];
+  if (imageUrl) {
+    callback(@[imageUrl.absoluteString]);
+    return;
+  }
+
+  UIImage *image = info[UIImagePickerControllerOriginalImage];
+  NSDictionary *imageMetadata = info[UIImagePickerControllerMediaMetadata];
+  [self.bridge.assetsLibrary writeImageToSavedPhotosAlbum:image.CGImage
+                                                 metadata:imageMetadata
+                                          completionBlock:^(NSURL *assetURL, NSError *error) {
+                                            if (error) {
+                                              cancelCallback(@[@"Image picker failed to save image to album"]);
+                                              return;
+                                            }
+
+                                            callback(@[assetURL.absoluteString]);
+                                          }];
 }
 
 - (void)imagePickerControllerDidCancel:(UIImagePickerController *)picker


### PR DESCRIPTION
In UIImagePicker callback, `info[UIImagePickerControllerReferenceURL]` is not exist if the photo is taken from camera, which leads to a crash.
The picture should be saved to album if the asset URL is needed for returning.