### PR TITLE
Fix undefined var exception

### DIFF
--- a/local-cli/server/util/debuggerWorker.js
+++ b/local-cli/server/util/debuggerWorker.js
@@ -21,7 +21,7 @@ var messageHandlers = {
   'executeJSCall': function(message, sendReply) {
     var returnValue = [[], [], [], [], []];
     try {
-      if (require) {
+      if (typeof require === 'function') {
         returnValue = require(message.moduleName)[message.moduleMethod].apply(null, message.arguments);
       }
     } finally {


### PR DESCRIPTION
This check to see if `require` exists was bad as it throws an error for an
undefined reference in case it doesn't exist.