### PR TITLE
Added media queries for Showcase page in docs

### DIFF
--- a/website/src/react-native/css/react-native.css
+++ b/website/src/react-native/css/react-native.css
@@ -1091,11 +1091,26 @@ div[data-twttr-id] iframe {
 
 .showcase {
   margin: 30px auto;
-  width: 25%;
+  width: 100%;
   display: inline-block;
   text-align: center;
   vertical-align: top;
   transition: 0.2s opacity ease-in;
+}
+
+@media only screen
+  and (min-device-width: 768px)
+  and (max-device-width: 1024px) {
+  .showcase {
+    width: 50%;
+  }
+}
+
+@media only screen
+  and (min-device-width: 1024px) {
+  .showcase {
+    width: 25%;
+  }
 }
 
 .showcase:hover {
@@ -1124,7 +1139,8 @@ div[data-twttr-id] iframe {
   border-radius: 20px;
 }
 
-@media only screen and (max-device-width : 1024px) {
+@media only screen
+  and (max-device-width: 1024px) {
   #content {
     display: inline;
   }


### PR DESCRIPTION
Summary: The showcase page is where you go to see examples of RN projects deployed in the wild. Chances are you're going to want to hit that page on your mobile device to view and install them from the App Store / Google Play. Four columns looks great on a large screen. But four columns is difficult to read/browse on small screens. So I created a single-column layout for small screens and a two-column layout for tablet screens. Still four columns on large screens. Cheers!