### PR TITLE
Support line number arguments for RubyMine

### DIFF
--- a/local-cli/server/util/launchEditor.js
+++ b/local-cli/server/util/launchEditor.js
@@ -37,6 +37,7 @@ function getArgumentsForLineNumber(editor, fileName, lineNumber) {
       return ['+' + lineNumber, fileName];
     case 'rmate':
     case 'mate':
+    case 'mine':
       return ['--line', lineNumber, fileName];
   }
 


### PR DESCRIPTION
RubyMine's command line launcher `mine` supports the same syntax as `mate` for jumping to line numbers. This patch adds it to the list.