### PR TITLE
[iOS] Use mainBundle in RCTConvert to resolve asset paths

### DIFF
--- a/Examples/UIExplorer/UIExplorerUnitTests/RCTConvert_NSURLTests.m
+++ b/Examples/UIExplorer/UIExplorerUnitTests/RCTConvert_NSURLTests.m
@@ -36,7 +36,7 @@
 } \
 
 #define TEST_BUNDLE_PATH(name, _input, _expectedPath) \
-TEST_PATH(name, _input, [[[NSBundle bundleForClass:[self class]] bundlePath] stringByAppendingPathComponent:_expectedPath])
+TEST_PATH(name, _input, [[[NSBundle mainBundle] bundlePath] stringByAppendingPathComponent:_expectedPath])
 
 // Basic tests
 TEST_URL(basic, @"http://example.com", @"http://example.com")

--- a/React/Base/RCTConvert.m
+++ b/React/Base/RCTConvert.m
@@ -101,7 +101,7 @@ RCT_CUSTOM_CONVERTER(NSData *, NSData, [json dataUsingEncoding:NSUTF8StringEncod
       path = path.stringByExpandingTildeInPath;
     } else if (!path.absolutePath) {
       // Assume it's a resource path
-      path = [[NSBundle bundleForClass:[self class]].resourcePath stringByAppendingPathComponent:path];
+      path = [[NSBundle mainBundle].resourcePath stringByAppendingPathComponent:path];
     }
     if (!(URL = [NSURL fileURLWithPath:path])) {
       RCTLogConvertError(json, @"a valid URL");


### PR DESCRIPTION
See #3888 for why this is necessary. Essentially, `[NSBundle mainBundle]` loads the file path for the target app which is the only way to reference images.

Test plan: Make sure unit tests pass!

cc @javache @nicklockwood 