### PR TITLE
Fixes #3846

### DIFF
--- a/Libraries/WebSocket/WebSocketBase.js
+++ b/Libraries/WebSocket/WebSocketBase.js
@@ -97,4 +97,9 @@ class WebSocketBase extends EventTarget {
   }
 }
 
+WebSocketBase.CONNECTING = 0;
+WebSocketBase.OPEN = 1;
+WebSocketBase.CLOSING = 2;
+WebSocketBase.CLOSED = 3;
+
 module.exports = WebSocketBase;

--- a/Libraries/WebSocket/WebSocketBase.js
+++ b/Libraries/WebSocket/WebSocketBase.js
@@ -44,26 +44,26 @@ class WebSocketBase extends EventTarget {
       protocols = [];
     }
 
-    this.readyState = WebSocketBase.CONNECTING;
+    this.readyState = this.CONNECTING;
     this.connectToSocketImpl(url);
   }
 
   close(): void {
-    if (this.readyState === WebSocketBase.CLOSING ||
-        this.readyState === WebSocketBase.CLOSED) {
+    if (this.readyState === this.CLOSING ||
+        this.readyState === this.CLOSED) {
       return;
     }
 
-    if (this.readyState === WebSocketBase.CONNECTING) {
+    if (this.readyState === this.CONNECTING) {
       this.cancelConnectionImpl();
     }
 
-    this.readyState = WebSocketBase.CLOSING;
+    this.readyState = this.CLOSING;
     this.closeConnectionImpl();
   }
 
   send(data: any): void {
-    if (this.readyState === WebSocketBase.CONNECTING) {
+    if (this.readyState === this.CONNECTING) {
       throw new Error('INVALID_STATE_ERR');
     }
 

--- a/Libraries/WebSocket/__tests__/WebSocket-test.js
+++ b/Libraries/WebSocket/__tests__/WebSocket-test.js
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2004-present Facebook. All Rights Reserved.
+ */
+'use strict';
+
+jest.dontMock('WebSocket');
+jest.dontMock('WebSocketBase');
+jest.setMock('NativeModules', {
+  WebSocketModule: {
+    connect: () => {}
+  }
+});
+
+var WebSocket = require('WebSocket');
+
+describe('WebSocketBase', function() {
+
+  it('should have connection lifecycle constants defined on the class', () => {
+    expect(WebSocket.CONNECTING).toEqual(0);
+  });
+
+  it('should have connection lifecycle constants defined on the instance', () => {
+    expect(new WebSocket('wss://echo.websocket.org').CONNECTING).toEqual(0);
+  });
+
+});


### PR DESCRIPTION
This fixes a  leak in regards to web sockets, detailed in #3846 . The connection state constants referenced the class rather than the instance and were coming back undefined.

cc @brentvatne @stephenelliot