### PR TITLE
document that CameraRoll is not implemented on Android

### DIFF
--- a/Libraries/CameraRoll/CameraRoll.js
+++ b/Libraries/CameraRoll/CameraRoll.js
@@ -119,6 +119,8 @@ class CameraRoll {
   /**
    * Saves the image to the camera roll / gallery.
    *
+   * The CameraRoll API is not yet implemented for Android.
+   * 
    * @param {string} tag On Android, this is a local URI, such
    * as `"file:///sdcard/img.png"`.
    *


### PR DESCRIPTION
The CameraRoll API shows up "unsuffixed" in the API list in the docs, so it is confusing to find that it is unimplemented on Android.