### PR TITLE
fix the memory leaks caused by RCTTabBar

### DIFF
--- a/React/Views/RCTTabBar.m
+++ b/React/Views/RCTTabBar.m
@@ -50,6 +50,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
 - (void)dealloc
 {
   _tabController.delegate = nil;
+  [_tabController removeFromParentViewController];
 }
 
 - (NSArray *)reactSubviews


### PR DESCRIPTION
The memory leaks root from the TabBarController not removing itself
when its holder view deallocs. So to fix the issue, it’s just to remove
it from its parentViewController when the holding RCTTabBar
deallocs. This should be safe, since the RCTTabBar seems the owner
of the TabBarController.