### PR TITLE
Update TouchableHighlight.js

### DIFF
--- a/Libraries/Components/Touchable/TouchableHighlight.js
+++ b/Libraries/Components/Touchable/TouchableHighlight.js
@@ -32,7 +32,7 @@ type Event = Object;
 
 var DEFAULT_PROPS = {
   activeOpacity: 0.8,
-  underlayColor: 'black',
+  underlayColor: 'transparent',
 };
 
 /**


### PR DESCRIPTION
changing the default underlay color to transparent, as this is the expected default functionality