### PR TITLE
IOS cancel local notification

### DIFF
--- a/Examples/UIExplorer/PushNotificationIOSExample.js
+++ b/Examples/UIExplorer/PushNotificationIOSExample.js
@@ -42,11 +42,11 @@ var Button = React.createClass({
 
 class NotificationExample extends React.Component {
   componentWillMount() {
-    PushNotificationIOS.addEventListener('notification', this._onNotification);
+    PushNotificationIOS.addEventListener('remoteNotificationReceived', this._onNotification);
   }
 
   componentWillUnmount() {
-    PushNotificationIOS.removeEventListener('notification', this._onNotification);
+    PushNotificationIOS.removeEventListener('remoteNotificationReceived', this._onNotification);
   }
 
   render() {

--- a/Libraries/PushNotificationIOS/PushNotificationIOS.js
+++ b/Libraries/PushNotificationIOS/PushNotificationIOS.js
@@ -20,8 +20,9 @@ var _notifHandlers = new Map();
 var _initialNotification = RCTPushNotificationManager &&
   RCTPushNotificationManager.initialNotification;
 
-var DEVICE_NOTIF_EVENT = 'remoteNotificationReceived';
-var NOTIF_REGISTER_EVENT = 'remoteNotificationsRegistered';
+var REMOTE_NOTIF_RECEIVED_EVENT = 'remoteNotificationReceived';
+var REMOTE_NOTIF_REG_EVENT = 'remoteNotificationsRegistered';
+var LOCAL_NOTIF_RECEIVED_EVENT = 'localNotificationReceived';
 
 /**
  * Handle push notifications for your app, including permission handling and
@@ -117,27 +118,36 @@ class PushNotificationIOS {
    *
    * Valid events are:
    *
-   * - `notification` : Fired when a remote notification is received. The
+   * - `remoteNotification` : Fired when a remote notification is received. The
    *   handler will be invoked with an instance of `PushNotificationIOS`.
-   * - `register`: Fired when the user registers for remote notifications. The
+   * - `remoteRegistration`: Fired when the user registers for remote notifications. The
    *   handler will be invoked with a hex string representing the deviceToken.
+   * - `localNotification` : Fired when a local notification is received. The
+   *   handler will be invoked with notification identifier.
    */
   static addEventListener(type: string, handler: Function) {
     invariant(
-      type === 'notification' || type === 'register',
-      'PushNotificationIOS only supports `notification` and `register` events'
+      type === 'remoteNotification' || type === 'remoteRegistration' || type === 'localNotification',
+      'PushNotificationIOS only supports `remoteNotification`, `remoteRegistration` and `localNotification` events'
     );
     var listener;
-    if (type === 'notification') {
+    if (type === 'remoteNotification') {
       listener =  RCTDeviceEventEmitter.addListener(
-        DEVICE_NOTIF_EVENT,
+        REMOTE_NOTIF_RECEIVED_EVENT,
         (notifData) => {
           handler(new PushNotificationIOS(notifData));
         }
       );
-    } else if (type === 'register') {
+    } else if (type === 'localNotification') {
+      listener =  RCTDeviceEventEmitter.addListener(
+        LOCAL_NOTIF_RECEIVED_EVENT,
+        (notifData) => {
+          handler(notifData.identifier);
+        }
+      );
+    } else if (type === 'remoteRegistration') {
       listener = RCTDeviceEventEmitter.addListener(
-        NOTIF_REGISTER_EVENT,
+        REMOTE_NOTIF_REG_EVENT,
         (registrationInfo) => {
           handler(registrationInfo.deviceToken);
         }

--- a/Libraries/PushNotificationIOS/PushNotificationIOS.js
+++ b/Libraries/PushNotificationIOS/PushNotificationIOS.js
@@ -77,11 +77,11 @@ class PushNotificationIOS {
    *
    * - `fireDate` : The date and time when the system should deliver the notification.
    * - `alertBody` : The message displayed in the notification alert.
-   * - `successCallback` : Optional. Invoked with a uuid identifying the notification.
+   * - `callback` : Optional. Invoked with a uuid identifying the notification.
    */
-  static scheduleLocalNotification(details: Object, successCallback?: Function) {
-    successCallback = successCallback ? successCallback : function() {};
-    RCTPushNotificationManager.scheduleLocalNotification(details, successCallback);
+  static scheduleLocalNotification(details: Object, callback?: Function) {
+    callback = callback ? callback : function() {};
+    RCTPushNotificationManager.scheduleLocalNotification(details, callback);
   }
 
   /**

--- a/Libraries/PushNotificationIOS/PushNotificationIOS.js
+++ b/Libraries/PushNotificationIOS/PushNotificationIOS.js
@@ -226,8 +226,8 @@ class PushNotificationIOS {
    */
   static removeEventListener(type: string, handler: Function) {
     invariant(
-      type === 'notification' || type === 'register',
-      'PushNotificationIOS only supports `notification` and `register` events'
+      type === 'remoteNotification' || type === 'remoteRegistration' || type === 'localNotification',
+      'PushNotificationIOS only supports `remoteNotification`, `remoteRegistration` and `localNotification` events'
     );
     var listener = _notifHandlers.get(handler);
     if (!listener) {

--- a/Libraries/PushNotificationIOS/PushNotificationIOS.js
+++ b/Libraries/PushNotificationIOS/PushNotificationIOS.js
@@ -73,10 +73,10 @@ class PushNotificationIOS {
    * Schedules the localNotification for future presentation.
    *
    * details is an object containing:
+   *
    * - `fireDate` : The date and time when the system should deliver the notification.
    * - `alertBody` : The message displayed in the notification alert.
-   *
-   * optional callback will be invoked with a uuid identifying the notification.
+   * - `successCallback` : Optional. Invoked with a uuid identifying the notification.
    */
   static scheduleLocalNotification(details: Object, successCallback?: Function) {
     successCallback = successCallback ? successCallback : function() {};

--- a/Libraries/PushNotificationIOS/PushNotificationIOS.js
+++ b/Libraries/PushNotificationIOS/PushNotificationIOS.js
@@ -73,13 +73,21 @@ class PushNotificationIOS {
    * Schedules the localNotification for future presentation.
    *
    * details is an object containing:
-   *
    * - `fireDate` : The date and time when the system should deliver the notification.
    * - `alertBody` : The message displayed in the notification alert.
    *
+   * optional callback will be invoked with a uuid identifying the notification.
    */
-  static scheduleLocalNotification(details: Object) {
-    RCTPushNotificationManager.scheduleLocalNotification(details);
+  static scheduleLocalNotification(details: Object, successCallback?: Function) {
+    successCallback = successCallback ? successCallback : function() {};
+    RCTPushNotificationManager.scheduleLocalNotification(details, successCallback);
+  }
+
+  /**
+   * Cancels the scheduled notification specified by identifier.
+   */
+  static cancelLocalNotification(identifier) {
+    RCTPushNotificationManager.cancelLocalNotification(identifier);
   }
 
   /**

--- a/Libraries/PushNotificationIOS/RCTPushNotificationManager.h
+++ b/Libraries/PushNotificationIOS/RCTPushNotificationManager.h
@@ -16,5 +16,6 @@
 + (void)application:(UIApplication *)application didRegisterUserNotificationSettings:(UIUserNotificationSettings *)notificationSettings;
 + (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken;
 + (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)notification;
++ (void)application:(UIApplication *)application didReceiveLocalNotification:(UILocalNotification *)notification;
 
 @end

--- a/Libraries/PushNotificationIOS/RCTPushNotificationManager.m
+++ b/Libraries/PushNotificationIOS/RCTPushNotificationManager.m
@@ -26,6 +26,7 @@
 
 NSString *const RCTRemoteNotificationReceived = @"RemoteNotificationReceived";
 NSString *const RCTRemoteNotificationsRegistered = @"RemoteNotificationsRegistered";
+NSString *const RCTLocalNotificationReceived = @"LocalNotificationReceived";
 
 @implementation RCTConvert (UILocalNotification)
 
@@ -43,6 +44,7 @@ NSString *const RCTRemoteNotificationsRegistered = @"RemoteNotificationsRegister
 @implementation RCTPushNotificationManager
 {
   NSDictionary *_initialNotification;
+  NSMutableDictionary *_scheduledLocalNotifications;
 }
 
 RCT_EXPORT_MODULE()
@@ -60,6 +62,15 @@ RCT_EXPORT_MODULE()
                                              selector:@selector(handleRemoteNotificationsRegistered:)
                                                  name:RCTRemoteNotificationsRegistered
                                                object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(handleLocalNotificationReceived:)
+                                                 name:RCTLocalNotificationReceived
+                                               object:nil];
+
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(handleApplicationDidBecomeActiveNotification:)
+                                                 name:UIApplicationDidBecomeActiveNotification
+                                               object:nil];
   }
   return self;
 }
@@ -73,6 +84,7 @@ RCT_EXPORT_MODULE()
 {
   _bridge = bridge;
   _initialNotification = [bridge.launchOptions[UIApplicationLaunchOptionsRemoteNotificationKey] copy];
+  _scheduledLocalNotifications = [NSMutableDictionary new];
 }
 
 + (void)application:(__unused UIApplication *)application didRegisterUserNotificationSettings:(__unused UIUserNotificationSettings *)notificationSettings
@@ -105,6 +117,16 @@ RCT_EXPORT_MODULE()
                                                     userInfo:notification];
 }
 
++ (void)application:(__unused UIApplication *)application didReceiveLocalNotification:(UILocalNotification *)notification
+{
+  NSDictionary *userInfo = @{
+    @"notification": notification
+  };
+  [[NSNotificationCenter defaultCenter] postNotificationName:RCTLocalNotificationReceived
+                                                      object:self
+                                                    userInfo:userInfo];
+}
+
 - (void)handleRemoteNotificationReceived:(NSNotification *)notification
 {
   [_bridge.eventDispatcher sendDeviceEventWithName:@"remoteNotificationReceived"
@@ -115,6 +137,33 @@ RCT_EXPORT_MODULE()
 {
   [_bridge.eventDispatcher sendDeviceEventWithName:@"remoteNotificationsRegistered"
                                               body:notification.userInfo];
+}
+
+- (void)handleLocalNotificationReceived:(NSNotification *)notification
+{
+  UILocalNotification *local = [notification.userInfo objectForKey:@"notification"];
+  NSArray *keys = [_scheduledLocalNotifications allKeysForObject:local];
+  NSString *identifier = [keys objectAtIndex:0];
+
+  [_scheduledLocalNotifications removeObjectForKey:identifier];
+
+  NSDictionary *userInfo = @{@"identifier": identifier};
+  [_bridge.eventDispatcher sendDeviceEventWithName:@"localNotificationReceived"
+                                              body:userInfo];
+}
+
+/**
+ * Remove all expired UILocalNotification instances that may still remain in _scheduledLocalNotifications
+ * since we can only explicity remove them if the app is active or the user taps the notification icon.
+ */
+- (void)handleApplicationDidBecomeActiveNotification:(__unused NSNotification *)notification
+{
+  for (NSString *identifier in [_scheduledLocalNotifications allKeys]) {
+    UILocalNotification *note = [_scheduledLocalNotifications objectForKey:identifier];
+    if([note.fireDate timeIntervalSinceReferenceDate] < [[NSDate date] timeIntervalSinceReferenceDate]) {
+      [_scheduledLocalNotifications removeObjectForKey:identifier];
+    }
+  }
 }
 
 /**
@@ -212,13 +261,27 @@ RCT_EXPORT_METHOD(presentLocalNotification:(UILocalNotification *)notification)
   [RCTSharedApplication() presentLocalNotificationNow:notification];
 }
 
-RCT_EXPORT_METHOD(scheduleLocalNotification:(UILocalNotification *)notification)
+RCT_EXPORT_METHOD(scheduleLocalNotification:(UILocalNotification *)notification successCallback:(RCTResponseSenderBlock)callback)
 {
   [RCTSharedApplication() scheduleLocalNotification:notification];
+
+  NSString *identifier = [[NSUUID UUID] UUIDString];
+  [_scheduledLocalNotifications setValue:notification forKey:identifier];
+  callback(@[identifier]);
+}
+
+RCT_EXPORT_METHOD(cancelLocalNotification:(NSString *)identifier)
+{
+  UILocalNotification *notification = [_scheduledLocalNotifications objectForKey:identifier];
+  if (notification != nil) {
+    [_scheduledLocalNotifications removeObjectForKey:identifier];
+    [RCTSharedApplication() cancelLocalNotification:notification];
+  }
 }
 
 RCT_EXPORT_METHOD(cancelAllLocalNotifications)
 {
+  [_scheduledLocalNotifications removeAllObjects];
   [RCTSharedApplication() cancelAllLocalNotifications];
 }
 

--- a/Libraries/PushNotificationIOS/RCTPushNotificationManager.m
+++ b/Libraries/PushNotificationIOS/RCTPushNotificationManager.m
@@ -261,7 +261,7 @@ RCT_EXPORT_METHOD(presentLocalNotification:(UILocalNotification *)notification)
   [RCTSharedApplication() presentLocalNotificationNow:notification];
 }
 
-RCT_EXPORT_METHOD(scheduleLocalNotification:(UILocalNotification *)notification successCallback:(RCTResponseSenderBlock)callback)
+RCT_EXPORT_METHOD(scheduleLocalNotification:(UILocalNotification *)notification callback:(RCTResponseSenderBlock)callback)
 {
   [RCTSharedApplication() scheduleLocalNotification:notification];
 


### PR DESCRIPTION
Adds support for cancelling specific UILocalNotification instances. scheduleLocalNotification now has an optional callback invoked with a uuid that can be used to identify and cancel specific notifications.

Also extends addEventListener to support local notifications.

Fixes #2185