### PR TITLE
[nvm] Source nvm.sh (best effort) when running react-native-xcode.sh

### DIFF
--- a/packager/react-native-xcode.sh
+++ b/packager/react-native-xcode.sh
@@ -33,6 +33,15 @@ cd ..
 set -x
 DEST=$CONFIGURATION_BUILD_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH
 
+# Define NVM_DIR and source the nvm.sh setup script
+[ -z "$NVM_DIR" ] && export NVM_DIR="$HOME/.nvm"
+
+if [[ -s "$HOME/.nvm/nvm.sh" ]]; then
+  . "$HOME/.nvm/nvm.sh"
+elif [[ -x "$(command -v brew)" && -s "$(brew --prefix nvm)/nvm.sh" ]]; then
+  . "$(brew --prefix nvm)/nvm.sh"
+fi
+
 react-native bundle \
   --entry-file index.ios.js \
   --platform ios \


### PR DESCRIPTION
When Node is installed with nvm, scripts invoked from Xcode need to set up nvm. This can be done either by sourcing .profile/.bash_profile/.bashrc/etc... or by sourcing nvm.sh directly -- this diff does the latter and handles the case where nvm may have been installed the official way (under ~/.nvm/nvm.sh AFAIK) or via homebrew.

Test Plan: Building a demo project set up with react-native init succeeds.

Fix #3974, fix #3948, fix #3966