### PR TITLE
Add manual instructions on upgrading 0.13 -> 0.14

### DIFF
--- a/docs/Images.md
+++ b/docs/Images.md
@@ -60,7 +60,7 @@ var icon = this.props.active ? require('./my-icon-active.png') : require('./my-i
 <Image source={icon} />
 ```
 
-NOTE: This system relies on build hooks for [Xcode](https://github.com/facebook/react-native/pull/3523) and [Gradle](https://github.com/facebook/react-native/commit/9dc036d2b99e6233297c55a3490bfc308e34e75f) that are included in new projects generated with `react-native init`. If you generated your projects before that, you'll have to manually add them to your projects to use the new images asset system.
+**Available React Native 0.14+**. If you've generated your project with 0.13 or earlier, read this. The new asset system relies on build hooks for [Xcode](https://github.com/facebook/react-native/pull/3523) and [Gradle](https://github.com/facebook/react-native/commit/9dc036d2b99e6233297c55a3490bfc308e34e75f) that are included in new projects generated with `react-native init`. If you generated your projects before that, you'll have to manually add them to your projects to use the new images asset system. See [Upgrading](/react-native/docs/upgrading.html) for instructions on how to do this.
 
 ## Images From Hybrid App's Resources
 

--- a/docs/Upgrading.md
+++ b/docs/Upgrading.md
@@ -43,3 +43,29 @@ This will check your files against the latest template and perform the following
 * If a file is different in your project than the template, you will be prompted; you have options
   to view a diff between your file and the template file, keep your file or overwrite it with the
   template version. If you are unsure, press `h` to get a list of possible commands.
+
+
+# Manual Upgrades
+
+Xcode project format is pretty complex and sometimes it's tricky to upgrade and merge new changes.
+
+### From 0.13 to 0.14
+
+The major change in this version happened to the CLI ([see changelog](https://github.com/facebook/react-native/releases/tag/v0.14.0-rc)) and static images ([see docs](http://facebook.github.io/react-native/docs/images.html)). To use the new asset system in existing Xcode project, do the following:
+
+Add new "Run Script" step to your project's build phases:
+
+![](https://cloud.githubusercontent.com/assets/192222/11050044/871bf926-86f7-11e5-8908-736106457bcb.png)
+
+Set the script to
+```sh
+../node_modules/react-native/packager/react-native-xcode.sh
+```
+
+![](https://cloud.githubusercontent.com/assets/192222/11050052/8f098252-86f7-11e5-994a-364aabbaa7d1.png)
+
+Move main.jsbundle to Trash (it will be generated automatically by Xcode using the script above)
+
+![](https://cloud.githubusercontent.com/assets/192222/11050104/f3d025e2-86f7-11e5-9101-a4622236338d.png)
+
+If you installed Node via nvm, you might experience "react-native: command not found". See [issues/3974](https://github.com/facebook/react-native/issues/3974) for workaround and [pull/4015](https://github.com/facebook/react-native/pull/4015) for the fix.


### PR DESCRIPTION
We changed the Xcode integration a bit. Instead of running `react-native bundle` manually there is now a script that runs as Xcode build phase. Upgrading can be tricky, I've added some docs on how to do this manually.


![image](https://cloud.githubusercontent.com/assets/192222/11050428/9b0076bc-86fa-11e5-88e4-1f75291253cd.png)
