### PR TITLE
Fix podspec to include local-cli folder

### DIFF
--- a/React.podspec
+++ b/React.podspec
@@ -23,7 +23,7 @@ Pod::Spec.new do |s|
   s.requires_arc        = true
   s.platform            = :ios, "7.0"
   s.prepare_command     = 'npm install --production'
-  s.preserve_paths      = "cli.js", "Libraries/**/*.js", "lint", "linter.js", "node_modules", "package.json", "packager", "PATENTS", "react-native-cli"
+  s.preserve_paths      = "cli.js", "Libraries/**/*.js", "lint", "linter.js", "node_modules", "package.json", "packager", "PATENTS", "react-native-cli", "local-cli"
 
   s.subspec 'Core' do |ss|
     ss.source_files     = "React/**/*.{c,h,m,S}"


### PR DESCRIPTION
Without this, I was getting the following error while trying to run the development server:

```
> react-native@0.15.0-rc start /Users/rayll/dev/s/ios/patient/Pods/React
> ./packager/packager.sh || true "--root" "/Users/rayll/dev/s/ios/patient/ReactComponents"

module.js:339
    throw err;
    ^

Error: Cannot find module '/Users/rayll/dev/s/ios/patient/Pods/React/local-cli/cli.js'
    at Function.Module._resolveFilename (module.js:337:15)
    at Function.Module._load (module.js:287:25)
    at Function.Module.runMain (module.js:457:10)
    at startup (node.js:136:18)
    at node.js:972:3
```