### PR TITLE
[CLI] Add back projectRoots option to packager CLI command

### DIFF
--- a/local-cli/server/server.js
+++ b/local-cli/server/server.js
@@ -35,6 +35,10 @@ function _server(argv, config, resolve, reject) {
     type: 'string',
     description: 'add another root(s) to be used by the packager in this project',
   }, {
+    command: 'projectRoots',
+    type: 'string',
+    description: 'override the root(s) to be used by the packager',
+  },{
     command: 'assetRoots',
     type: 'string',
     description: 'specify the root directories of app assets'


### PR DESCRIPTION
Adding this to the CLI again (like: https://github.com/facebook/react-native/commit/8e7cfcd0537ce742618be21aa03e86aedef5f9ac#diff-75e3fc051b7c5100b4681e8a8f62615bL45)

Fix #2390