### PR TITLE
Left nav shouldn't visible when moved to left

### DIFF
--- a/Libraries/CustomComponents/Navigator/NavigatorNavigationBarStylesIOS.js
+++ b/Libraries/CustomComponents/Navigator/NavigatorNavigationBarStylesIOS.js
@@ -77,7 +77,7 @@ var BASE_STYLES = {
 var Stages = {
   Left: {
     Title: merge(BASE_STYLES.Title, { left: - SCREEN_WIDTH / 2, opacity: 0 }),
-    LeftButton: merge(BASE_STYLES.LeftButton, { left: - SCREEN_WIDTH / 3, opacity: 1 }),
+    LeftButton: merge(BASE_STYLES.LeftButton, { left: - SCREEN_WIDTH / 3, opacity: 0 }),
     RightButton: merge(BASE_STYLES.RightButton, { left: SCREEN_WIDTH / 3, opacity: 0 }),
   },
   Center: {


### PR DESCRIPTION
This issue shows up if you have a really long left nav item. When the navigator is pushed in iOS, the long nav item will be visible alongside the new nav item.

Steps to repro:
1/ Modify Examples/UIExplorer/Navigator/NavigationBarSample.js
2/ In NavigationBarRouteMapper.LeftButton, make the following change

    <Text style={[styles.navBarText, styles.navBarButtonText]}>
      Very Long Title {previousRoute.title}
    </Text>

3/ On iOS, get the UIExplorer project up and navigate to Navigator > Navbar Example > Next (top-right nav item) > Next

You should see the overlap.

<img width="592" alt="leftnavitem_issue" src="https://cloud.githubusercontent.com/assets/691109/11086934/b5b82e26-880a-11e5-9945-13901346a5c5.png">

With these changes the overlap is gone.