### PR TITLE
Set navigator.product to ReactNative

### DIFF
--- a/Libraries/JavaScriptAppEngine/Initialization/InitializeJavaScriptAppEngine.js
+++ b/Libraries/JavaScriptAppEngine/Initialization/InitializeJavaScriptAppEngine.js
@@ -154,6 +154,11 @@ function setUpGeolocation() {
   polyfillGlobal('geolocation', require('Geolocation'), GLOBAL.navigator);
 }
 
+function setUpProduct() {
+  Object.defineProperty(GLOBAL.navigator, 'product', {value: 'ReactNative'});
+}
+
+
 function setUpWebSockets() {
   polyfillGlobal('WebSocket', require('WebSocket'));
 }
@@ -197,6 +202,7 @@ setUpPromise();
 setUpErrorHandler();
 setUpXHR();
 setUpGeolocation();
+setUpProduct();
 setUpWebSockets();
 setUpProfile();
 setUpFlowChecker();


### PR DESCRIPTION
Fix for [Issue 1331](https://github.com/facebook/react-native/issues/1331). Sets navigator.product to ReactNative and navigator.productSub to the version string in package.json. 

Note that the code requires package.json, which works fine in the RN packager, but webpack users will probably a need to configure a json loader in their config file.

Tested using UIExplorer and console.log printout of the product variables in xcode and Chrome debugger.