### PR TITLE
Remove unused scale transform in Navigator

### DIFF
--- a/Libraries/CustomComponents/Navigator/NavigatorSceneConfigs.js
+++ b/Libraries/CustomComponents/Navigator/NavigatorSceneConfigs.js
@@ -57,14 +57,6 @@ var FadeToTheLeft = {
   //   type: 'linear',
   //   extrapolate: true
   // },
-  transformScale: {
-    from: {x: 1, y: 1, z: 1},
-    to: {x: 0.95, y: 1, z: 1},
-    min: 0,
-    max: 1,
-    type: 'linear',
-    extrapolate: true
-  },
   opacity: {
     from: 1,
     to: 0.3,

--- a/Libraries/CustomComponents/Navigator/NavigatorSceneConfigs.js
+++ b/Libraries/CustomComponents/Navigator/NavigatorSceneConfigs.js
@@ -59,7 +59,7 @@ var FadeToTheLeft = {
   // },
   transformScale: {
     from: {x: 1, y: 1, z: 1},
-    to: {x: 0.95, y: 0.95, z: 1},
+    to: {x: 0.95, y: 1, z: 1},
     min: 0,
     max: 1,
     type: 'linear',


### PR DESCRIPTION
This PR removing the scale animation in `<Navigator/>`, I think is reasonable to remove this scale because:

1. I think the scale to 0.95 while `pop`ing or `push`ing will leave some blank space and make developers annoying
2. Removing this style can make `<Navigator/>` more native. As you know, customizing the `<NavigatorIOS/>` is not as easy as `<Navigator/>`. Since `<Navigator/>` does not meet the latest Material Design guideline of Android, and preserving this is no use with Android developers.
3. I think removing a transition can improve the performance, even just a little bit.

If there still some concern about this in RN development group, I hope at least providing a public API to manually disable this feature.

___Screenshots and sample code showing the difference listed below___

# Before
[https://rnplay.org/apps/HPy6UA](https://rnplay.org/apps/HPy6UA)
![screen shot 2015-11-12 at 06 26 55](https://cloud.githubusercontent.com/assets/4535844/11116107/aac48b0c-8906-11e5-9d6f-69c56cbc6840.png)

# After
[https://rnplay.org/apps/lM4ekg](https://rnplay.org/apps/lM4ekg)
![screen shot 2015-11-12 at 06 28 15](https://cloud.githubusercontent.com/assets/4535844/11116108/aac800d4-8906-11e5-932f-1cfd024b3ccc.png)

And thank you for the excellent React Native!!