### PR TITLE
Correct the file name to preprocessor

### DIFF
--- a/docs/Testing.md
+++ b/docs/Testing.md
@@ -35,7 +35,7 @@ Note: In order to run your own tests, you will have to first follow the Getting 
 },
 ...
 "jest": {
-  "scriptPreprocessor": "node_modules/react-native/jestSupport/scriptPreprocess.js",
+  "scriptPreprocessor": "node_modules/react-native/jestSupport/preprocessor.js",
   "setupEnvScriptFile": "node_modules/react-native/jestSupport/env.js",
   "testPathIgnorePatterns": [
     "/node_modules/",


### PR DESCRIPTION
Since the `scriptPreprocessor.js` is removed since 14.0,
we use `preprocessor.js` instead, 
but the doc doesn't update yet.
So I do it :)