### PR TITLE
Import PropTypes in Native UI Android Docs

### DIFF
--- a/docs/NativeComponentsAndroid.md
+++ b/docs/NativeComponentsAndroid.md
@@ -105,7 +105,7 @@ The very final step is to create the JavaScript module that defines the interfac
 ```js
 // ImageView.js
 
-var { requireNativeComponent } = require('react-native');
+var { requireNativeComponent, PropTypes } = require('react-native');
 
 var iface = {
   name: 'ImageView',


### PR DESCRIPTION
Currently there is a bug in the [Javascript Module](https://facebook.github.io/react-native/docs/native-components-android.html#5-implement-the-javascript-module) section of the "Android > Native UI Components" docs. `PropTypes` are used in the native component interface without ever being imported.

This PR updates the example in the docs to work correctly.