### PR TITLE
[Packager] Compress HTTP responses from the packager

### DIFF
--- a/local-cli/server/runServer.js
+++ b/local-cli/server/runServer.js
@@ -25,6 +25,7 @@ function runServer(args, config, readyCallback) {
   var wsProxy = null;
   const app = connect()
     .use(loadRawBodyMiddleware)
+    .use(connect.compress())
     .use(getDevToolsMiddleware(args, () => wsProxy && wsProxy.isChromeConnected()))
     .use(openStackFrameInEditorMiddleware)
     .use(statusPageMiddleware)
@@ -37,7 +38,6 @@ function runServer(args, config, readyCallback) {
   args.projectRoots.forEach(root => app.use(connect.static(root)));
 
   app.use(connect.logger())
-    .use(connect.compress())
     .use(connect.errorHandler());
 
   const serverInstance = http.createServer(app).listen(


### PR DESCRIPTION
The packager was adding compression middleware too late in the stack. This makes things a little faster especially if you're loading through dynamic DNS for example.

Test Plan: Response are compressed.