### PR TITLE
Add polyline to MapView

### DIFF
--- a/Libraries/Components/MapView/MapView.js
+++ b/Libraries/Components/MapView/MapView.js
@@ -185,6 +185,31 @@ var MapView = React.createClass({
     })),
 
     /**
+     * Map polylines
+     */
+    polylines: React.PropTypes.arrayOf(React.PropTypes.shape({
+      /**
+       * Locations in sequence for polyline
+       */
+      locations: React.PropTypes.arrayOf(React.PropTypes.shape({
+        lat: React.PropTypes.number.isRequired,
+        lon: React.PropTypes.number.isRequired
+      })),
+
+      /**
+       * Polyline presentation properties
+       */
+      alpha: React.PropTypes.number,
+      lineWidth: React.PropTypes.number,
+      strokeColor: React.PropTypes.string,
+
+      /**
+       * Polyline id
+       */
+      id: React.PropTypes.string
+    })),
+
+    /**
      * Maximum size of area that can be displayed.
      */
     maxDelta: React.PropTypes.number,

--- a/Libraries/Components/WebView/WebView.ios.js
+++ b/Libraries/Components/WebView/WebView.ios.js
@@ -178,6 +178,28 @@ var WebView = React.createClass({
     );
   },
 
+  evaluateJavaScript: function(
+    script: string,
+    callback?: ?(error: ?Error, result: ?string) => void
+  ): Promise {
+    return new Promise((resolve, reject) => {
+      RCTWebViewManager.evaluateJavaScript(this.getWebViewHandle(), script, function(err, value) {
+        // iOS returns a string for the result of stringByEvaluatingJavaScriptFromString.
+        // --> attempt to JSON.parse value, if we fail, just return as a string value.
+        try {
+          value = JSON.parse(value);
+        } catch(e) { }
+
+        callback && callback(err, value);
+        if (err) {
+          reject(err);
+        } else {
+          resolve(value);
+        }
+      });
+    });
+  },
+
   goForward: function() {
     RCTWebViewManager.goForward(this.getWebViewHandle());
   },

--- a/Libraries/Components/WebView/WebView.ios.js
+++ b/Libraries/Components/WebView/WebView.ios.js
@@ -183,7 +183,10 @@ var WebView = React.createClass({
     callback?: ?(error: ?Error, result: ?string) => void
   ): Promise {
     return new Promise((resolve, reject) => {
-      RCTWebViewManager.evaluateJavaScript(this.getWebViewHandle(), script, function(err, value) {
+      // wrap script in JSON.stringify to preserve type of return result through iOS's string based interface
+      var wrappedScript = 'JSON.stringify(eval("' + script + '"))';
+
+      RCTWebViewManager.evaluateJavaScript(this.getWebViewHandle(), wrappedScript, function(err, value) {
         // iOS returns a string for the result of stringByEvaluatingJavaScriptFromString.
         // --> attempt to JSON.parse value, if we fail, just return as a string value.
         try {
@@ -191,6 +194,7 @@ var WebView = React.createClass({
         } catch(e) { }
 
         callback && callback(err, value);
+
         if (err) {
           reject(err);
         } else {

--- a/React/Modules/RCTPolyline.h
+++ b/React/Modules/RCTPolyline.h
@@ -1,0 +1,23 @@
+//
+//  RCTPolyline.h
+//  React
+//
+//  Created by Timothy Park on 11/7/15.
+//  Copyright © 2015 Facebook. All rights reserved.
+//
+
+#ifndef RCTPolyline_h
+#define RCTPolyline_h
+
+#import <MapKit/MapKit.h>
+
+@interface RCTPolyline : MKPolyline <MKAnnotation>
+
+@property (nonatomic, copy) NSString *identifier;
+@property (nonatomic, copy) UIColor* strokeColor;
+@property (nonatomic, assign) double lineWidth;
+@property (nonatomic, assign) double alpha;
+
+@end
+
+#endif /* RCTPolyline_h */

--- a/React/Modules/RCTPolyline.m
+++ b/React/Modules/RCTPolyline.m
@@ -1,0 +1,13 @@
+//
+//  RCTPolyline.m
+//  React
+//
+//  Created by Timothy Park on 11/7/15.
+//  Copyright © 2015 Facebook. All rights reserved.
+//
+
+#import "RCTPolyline.h"
+
+@implementation RCTPolyline
+
+@end

--- a/React/React.xcodeproj/project.pbxproj
+++ b/React/React.xcodeproj/project.pbxproj
@@ -60,6 +60,7 @@
 		14F3620E1AABD06A001CE568 /* RCTSwitchManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 14F3620A1AABD06A001CE568 /* RCTSwitchManager.m */; };
 		14F484561AABFCE100FDF6B9 /* RCTSliderManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 14F484551AABFCE100FDF6B9 /* RCTSliderManager.m */; };
 		14F4D38B1AE1B7E40049C042 /* RCTProfile.m in Sources */ = {isa = PBXBuildFile; fileRef = 14F4D38A1AE1B7E40049C042 /* RCTProfile.m */; };
+		229A358A1BF93BE400FC204F /* RCTPolyline.m in Sources */ = {isa = PBXBuildFile; fileRef = 229A35891BF93BE400FC204F /* RCTPolyline.m */; };
 		58114A161AAE854800E7D092 /* RCTPicker.m in Sources */ = {isa = PBXBuildFile; fileRef = 58114A131AAE854800E7D092 /* RCTPicker.m */; };
 		58114A171AAE854800E7D092 /* RCTPickerManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 58114A151AAE854800E7D092 /* RCTPickerManager.m */; };
 		58114A501AAE93D500E7D092 /* RCTAsyncLocalStorage.m in Sources */ = {isa = PBXBuildFile; fileRef = 58114A4E1AAE93D500E7D092 /* RCTAsyncLocalStorage.m */; };
@@ -205,6 +206,8 @@
 		14F484551AABFCE100FDF6B9 /* RCTSliderManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTSliderManager.m; sourceTree = "<group>"; };
 		14F4D3891AE1B7E40049C042 /* RCTProfile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTProfile.h; sourceTree = "<group>"; };
 		14F4D38A1AE1B7E40049C042 /* RCTProfile.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTProfile.m; sourceTree = "<group>"; };
+		229A35881BF93BE400FC204F /* RCTPolyline.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTPolyline.h; sourceTree = "<group>"; };
+		229A35891BF93BE400FC204F /* RCTPolyline.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTPolyline.m; sourceTree = "<group>"; };
 		58114A121AAE854800E7D092 /* RCTPicker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTPicker.h; sourceTree = "<group>"; };
 		58114A131AAE854800E7D092 /* RCTPicker.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTPicker.m; sourceTree = "<group>"; };
 		58114A141AAE854800E7D092 /* RCTPickerManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTPickerManager.h; sourceTree = "<group>"; };
@@ -286,6 +289,8 @@
 				13B07FEA1A69327A00A75B9A /* RCTExceptionsManager.m */,
 				63F014BE1B02080B003B75D2 /* RCTPointAnnotation.h */,
 				63F014BF1B02080B003B75D2 /* RCTPointAnnotation.m */,
+				229A35881BF93BE400FC204F /* RCTPolyline.h */,
+				229A35891BF93BE400FC204F /* RCTPolyline.m */,
 				000E6CE91AB0E97F000CDF4D /* RCTSourceCode.h */,
 				000E6CEA1AB0E980000CDF4D /* RCTSourceCode.m */,
 				13723B4E1A82FD3C00F88898 /* RCTStatusBarManager.h */,
@@ -570,6 +575,7 @@
 				83CBBA511A601E3B00E9B192 /* RCTAssert.m in Sources */,
 				13AF20451AE707F9005F5298 /* RCTSlider.m in Sources */,
 				58114A501AAE93D500E7D092 /* RCTAsyncLocalStorage.m in Sources */,
+				229A358A1BF93BE400FC204F /* RCTPolyline.m in Sources */,
 				832348161A77A5AA00B55238 /* Layout.c in Sources */,
 				14F4D38B1AE1B7E40049C042 /* RCTProfile.m in Sources */,
 				13513F3C1B1F43F400FCE529 /* RCTProgressViewManager.m in Sources */,

--- a/React/Views/RCTConvert+MapKit.h
+++ b/React/Views/RCTConvert+MapKit.h
@@ -10,6 +10,7 @@
 #import <MapKit/MapKit.h>
 
 #import "RCTPointAnnotation.h"
+#import "RCTPolyline.h"
 #import "RCTConvert.h"
 
 @interface RCTConvert (MapKit)
@@ -19,11 +20,15 @@
 + (MKShape *)MKShape:(id)json;
 + (MKMapType)MKMapType:(id)json;
 + (RCTPointAnnotation *)RCTPointAnnotation:(id)json;
++ (RCTPolyline *)RCTPolyline:(id)json;
 
 typedef NSArray MKShapeArray;
 + (MKShapeArray *)MKShapeArray:(id)json;
 
 typedef NSArray RCTPointAnnotationArray;
 + (RCTPointAnnotationArray *)RCTPointAnnotationArray:(id)json;
+
+typedef NSArray RCTPolylineArray;
++ (RCTPolylineArray *)RCTPolylineArray:(id)json;
 
 @end

--- a/React/Views/RCTConvert+MapKit.m
+++ b/React/Views/RCTConvert+MapKit.m
@@ -66,4 +66,42 @@ RCT_ENUM_CONVERTER(MKMapType, (@{
 
 RCT_ARRAY_CONVERTER(RCTPointAnnotation)
 
++ (RCTPolyline *)RCTPolyline:(id)json
+{
+
+  json = [self NSDictionary:json];
+  NSArray* locations = (NSArray*)json[@"locations"];
+
+
+  CLLocationCoordinate2D polylineCoordinates[locations.count];
+  NSUInteger index = 0;
+  for (NSDictionary* location in locations) {
+    CLLocationCoordinate2D coordinate;
+
+    coordinate.latitude = [location[@"lat"] doubleValue];
+    coordinate.longitude = [location[@"lon"] doubleValue];
+
+    polylineCoordinates[index++] = coordinate;
+  }
+
+  RCTPolyline *polyline = [RCTPolyline polylineWithCoordinates:polylineCoordinates count:locations.count];
+
+  unsigned rgbValue = 0;
+  NSScanner *scanner = [NSScanner scannerWithString:[RCTConvert NSString:json[@"strokeColor"]]];
+  [scanner setScanLocation:1]; // bypass '#' character
+  [scanner scanHexInt:&rgbValue];
+  polyline.strokeColor = [UIColor colorWithRed:((rgbValue & 0xFF0000) >> 16)/255.0
+                         green:((rgbValue & 0xFF00) >> 8)/255.0
+                          blue:(rgbValue & 0xFF)/255.0
+                         alpha:[RCTConvert double:json[@"alpha"]]];
+
+  polyline.identifier = [RCTConvert NSString:json[@"id"]];
+  polyline.lineWidth = [RCTConvert double:json[@"lineWidth"]];
+  polyline.alpha = [RCTConvert double:json[@"alpha"]];
+
+  return polyline;
+}
+
+RCT_ARRAY_CONVERTER(RCTPolyline)
+
 @end

--- a/React/Views/RCTMap.h
+++ b/React/Views/RCTMap.h
@@ -27,7 +27,9 @@ extern const CGFloat RCTMapZoomBoundBuffer;
 @property (nonatomic, assign) UIEdgeInsets legalLabelInsets;
 @property (nonatomic, strong) NSTimer *regionChangeObserveTimer;
 @property (nonatomic, strong) NSMutableArray *annotationIds;
+@property (nonatomic, strong) NSMutableArray *polylineIds;
 
 - (void)setAnnotations:(RCTPointAnnotationArray *)annotations;
+- (void)setPolylines:(RCTPolylineArray *)polylines;
 
 @end

--- a/React/Views/RCTMap.m
+++ b/React/Views/RCTMap.m
@@ -12,6 +12,7 @@
 #import "RCTEventDispatcher.h"
 #import "RCTLog.h"
 #import "RCTUtils.h"
+#import "RCTPolyline.h"
 
 const CLLocationDegrees RCTMapDefaultSpan = 0.005;
 const NSTimeInterval RCTMapRegionChangeObserveInterval = 0.1;
@@ -158,6 +159,47 @@ const CGFloat RCTMapZoomBoundBuffer = 0.01;
     [newIds addObject:anno.identifier];
   }
   self.annotationIds = newIds;
+}
+
+- (void)setPolylines:(RCTPolylineArray *)polylines
+{
+  NSMutableArray *newPolylineIds = [NSMutableArray new];
+  NSMutableArray *polylinesToDelete = [NSMutableArray new];
+  NSMutableArray *polylinesToAdd = [NSMutableArray new];
+
+  for (RCTPolyline* polyline in polylines) {
+    if (![polyline isKindOfClass:[RCTPolyline class]]) {
+      continue;
+    }
+
+    [newPolylineIds addObject:polyline.identifier];
+
+    // If the current set does not contain the new annotation, mark it as add
+    if (![self.annotationIds containsObject:polyline.identifier]) {
+      [polylinesToAdd addObject:polyline];
+    }
+  }
+
+  for (RCTPolyline *polyline in self.overlays) {
+    if (![polyline isKindOfClass:[RCTPolyline class]]) {
+      continue;
+    }
+
+    // If the new set does not contain an existing annotation, mark it as delete
+    if (![newPolylineIds containsObject:polyline.identifier]) {
+      [polylinesToDelete addObject:polyline];
+    }
+  }
+
+  if (polylinesToDelete.count) {
+    [self removeOverlays: polylinesToDelete];
+  }
+
+  if (polylinesToAdd.count) {
+    [self addOverlays: polylinesToAdd];
+  }
+
+  self.polylineIds = newPolylineIds;
 }
 
 @end

--- a/React/Views/RCTMapManager.m
+++ b/React/Views/RCTMapManager.m
@@ -46,6 +46,7 @@ RCT_EXPORT_VIEW_PROPERTY(minDelta, CGFloat)
 RCT_EXPORT_VIEW_PROPERTY(legalLabelInsets, UIEdgeInsets)
 RCT_EXPORT_VIEW_PROPERTY(mapType, MKMapType)
 RCT_EXPORT_VIEW_PROPERTY(annotations, RCTPointAnnotationArray)
+RCT_EXPORT_VIEW_PROPERTY(polylines, RCTPolylineArray)
 RCT_CUSTOM_VIEW_PROPERTY(region, MKCoordinateRegion, RCTMap)
 {
   [view setRegion:json ? [RCTConvert MKCoordinateRegion:json] : defaultView.region animated:YES];
@@ -76,6 +77,20 @@ RCT_CUSTOM_VIEW_PROPERTY(region, MKCoordinateRegion, RCTMap)
                             };
 
     [self.bridge.eventDispatcher sendInputEventWithName:@"topTap" body:event];
+  }
+}
+
+
+- (MKOverlayRenderer *)mapView:(__unused MKMapView *)mapView rendererForOverlay:(id)overlay {
+  if ([overlay isKindOfClass:[RCTPolyline class]]) {
+    RCTPolyline *polyline = overlay;
+    MKPolylineRenderer *polylineRenderer = [[MKPolylineRenderer alloc] initWithPolyline:polyline];
+    polylineRenderer.strokeColor = polyline.strokeColor;
+    polylineRenderer.lineWidth = polyline.lineWidth;
+    polylineRenderer.alpha = polyline.alpha;
+    return polylineRenderer;
+  } else {
+    return nil;
   }
 }
 

--- a/React/Views/RCTWebView.h
+++ b/React/Views/RCTWebView.h
@@ -25,5 +25,6 @@ extern NSString *const RCTJSNavigationScheme;
 - (void)goForward;
 - (void)goBack;
 - (void)reload;
+- (NSString *)evaluateJavaScript:(NSString *)script;
 
 @end

--- a/React/Views/RCTWebView.m
+++ b/React/Views/RCTWebView.m
@@ -75,6 +75,11 @@ RCT_NOT_IMPLEMENTED(-initWithCoder:(NSCoder *)aDecoder)
   return _webView.request.URL;
 }
 
+- (NSString *)evaluateJavaScript: (NSString*) script
+{
+  return [_webView stringByEvaluatingJavaScriptFromString: script];
+}
+
 - (void)setURL:(NSURL *)URL
 {
   // Because of the way React works, as pages redirect, we actually end up

--- a/React/Views/RCTWebViewManager.m
+++ b/React/Views/RCTWebViewManager.m
@@ -81,4 +81,15 @@ RCT_EXPORT_METHOD(reload:(NSNumber *)reactTag)
   }];
 }
 
+RCT_EXPORT_METHOD(evaluateJavaScript:(NSNumber *)reactTag script: (NSString *)script callback:(RCTResponseSenderBlock) callback)
+{
+  [self.bridge.uiManager addUIBlock:^(RCTUIManager *uiManager, RCTSparseArray *viewRegistry) {
+    RCTWebView *view = viewRegistry[reactTag];
+    if (![view isKindOfClass:[RCTWebView class]]) {
+      RCTLogError(@"Invalid view returned from registry, expecting RKWebView, got: %@", view);
+    }
+    callback(@[[NSNull null], [view evaluateJavaScript: script]]);
+  }];
+}
+
 @end


### PR DESCRIPTION
Per issue #1925, add support for Polyline to MapView.

Briefly, if you have a MapView declared as:

<MapView
                annotations={this.state.annotations}
                polylines={this.state.polylines}
                style={styles.map}
                region={this.state.region}
                showsUserLocation={true}
                rotateEnabled={true}
                ref="mapView"
/>

then setting

this.state.polylines = [
{
"locations": [
{ "lat": 35.5, "lon": -5.5 },
{ "lat": 35.6, "lon": -5.6 },
...
],
"strokeColor": "#FF0000",
"lineWidth": 3,
"alpha": 0.5
}];

will draw a red line between the points in locations with a width of 3 and equally blended with the background.