### PR TITLE
Add Polyline support to MapView

### DIFF
--- a/Libraries/Components/MapView/MapView.js
+++ b/Libraries/Components/MapView/MapView.js
@@ -192,6 +192,32 @@ var MapView = React.createClass({
     })),
 
     /**
+     * Map polylines
+     */
+    polylines: React.PropTypes.arrayOf(React.PropTypes.shape({
+      /**
+       * Coordinates of polyline
+       */
+
+      locations: React.PropTypes.arrayOf(React.PropTypes.shape({
+        lat: React.PropTypes.number.isRequired,
+        lon: React.PropTypes.number.isRequired
+      })),
+
+      /**
+       * Polyline presentation attributes
+       */
+      alpha: React.PropTypes.number,
+      lineWidth: React.PropTypes.number,
+      strokeColor: React.PropTypes.string,
+
+      /**
+       * Polyline id
+       */
+      id: React.PropTypes.string
+    })),
+
+    /**
      * Maximum size of area that can be displayed.
      */
     maxDelta: React.PropTypes.number,

--- a/React/Modules/RCTPolyline.h
+++ b/React/Modules/RCTPolyline.h
@@ -1,0 +1,23 @@
+//
+//  RCTPolyline.h
+//  React
+//
+//  Created by Timothy Park on 11/7/15.
+//  Copyright © 2015 Facebook. All rights reserved.
+//
+
+#ifndef RCTPolyline_h
+#define RCTPolyline_h
+
+#import <MapKit/MapKit.h>
+
+@interface RCTPolyline : MKPolyline <MKAnnotation>
+
+@property (nonatomic, copy) NSString *identifier;
+@property (nonatomic, copy) UIColor* strokeColor;
+@property (nonatomic, assign) double lineWidth;
+@property (nonatomic, assign) double alpha;
+
+@end
+
+#endif /* RCTPolyline_h */

--- a/React/Modules/RCTPolyline.m
+++ b/React/Modules/RCTPolyline.m
@@ -1,0 +1,13 @@
+//
+//  RCTPolyline.m
+//  React
+//
+//  Created by Timothy Park on 11/7/15.
+//  Copyright © 2015 Facebook. All rights reserved.
+//
+
+#import "RCTPolyline.h"
+
+@implementation RCTPolyline
+
+@end

--- a/React/React.xcodeproj/project.pbxproj
+++ b/React/React.xcodeproj/project.pbxproj
@@ -65,6 +65,7 @@
 		14F484561AABFCE100FDF6B9 /* RCTSliderManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 14F484551AABFCE100FDF6B9 /* RCTSliderManager.m */; };
 		14F7A0EC1BDA3B3C003C6C10 /* RCTPerfMonitor.m in Sources */ = {isa = PBXBuildFile; fileRef = 14F7A0EB1BDA3B3C003C6C10 /* RCTPerfMonitor.m */; };
 		14F7A0F01BDA714B003C6C10 /* RCTFPSGraph.m in Sources */ = {isa = PBXBuildFile; fileRef = 14F7A0EF1BDA714B003C6C10 /* RCTFPSGraph.m */; };
+		229A358D1BF9C9BD00FC204F /* RCTPolyline.m in Sources */ = {isa = PBXBuildFile; fileRef = 229A358C1BF9C9BD00FC204F /* RCTPolyline.m */; };
 		58114A161AAE854800E7D092 /* RCTPicker.m in Sources */ = {isa = PBXBuildFile; fileRef = 58114A131AAE854800E7D092 /* RCTPicker.m */; };
 		58114A171AAE854800E7D092 /* RCTPickerManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 58114A151AAE854800E7D092 /* RCTPickerManager.m */; };
 		58114A501AAE93D500E7D092 /* RCTAsyncLocalStorage.m in Sources */ = {isa = PBXBuildFile; fileRef = 58114A4E1AAE93D500E7D092 /* RCTAsyncLocalStorage.m */; };
@@ -223,6 +224,8 @@
 		14F7A0EB1BDA3B3C003C6C10 /* RCTPerfMonitor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTPerfMonitor.m; sourceTree = "<group>"; };
 		14F7A0EE1BDA714B003C6C10 /* RCTFPSGraph.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTFPSGraph.h; sourceTree = "<group>"; };
 		14F7A0EF1BDA714B003C6C10 /* RCTFPSGraph.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTFPSGraph.m; sourceTree = "<group>"; };
+		229A358B1BF9C9BD00FC204F /* RCTPolyline.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTPolyline.h; sourceTree = "<group>"; };
+		229A358C1BF9C9BD00FC204F /* RCTPolyline.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTPolyline.m; sourceTree = "<group>"; };
 		58114A121AAE854800E7D092 /* RCTPicker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTPicker.h; sourceTree = "<group>"; };
 		58114A131AAE854800E7D092 /* RCTPicker.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTPicker.m; sourceTree = "<group>"; };
 		58114A141AAE854800E7D092 /* RCTPickerManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTPickerManager.h; sourceTree = "<group>"; };
@@ -316,6 +319,8 @@
 				13B07FEA1A69327A00A75B9A /* RCTExceptionsManager.m */,
 				63F014BE1B02080B003B75D2 /* RCTPointAnnotation.h */,
 				63F014BF1B02080B003B75D2 /* RCTPointAnnotation.m */,
+				229A358B1BF9C9BD00FC204F /* RCTPolyline.h */,
+				229A358C1BF9C9BD00FC204F /* RCTPolyline.m */,
 				13F17A831B8493E5007D4C75 /* RCTRedBox.h */,
 				13F17A841B8493E5007D4C75 /* RCTRedBox.m */,
 				000E6CE91AB0E97F000CDF4D /* RCTSourceCode.h */,
@@ -609,6 +614,7 @@
 				13456E961ADAD482009F94A7 /* RCTConvert+MapKit.m in Sources */,
 				13723B501A82FD3C00F88898 /* RCTStatusBarManager.m in Sources */,
 				000E6CEB1AB0E980000CDF4D /* RCTSourceCode.m in Sources */,
+				229A358D1BF9C9BD00FC204F /* RCTPolyline.m in Sources */,
 				133CAE8E1B8E5CFD00F6AD92 /* RCTDatePicker.m in Sources */,
 				14C2CA761B3AC64F00E6CBB2 /* RCTFrameUpdate.m in Sources */,
 				13B07FEF1A69327A00A75B9A /* RCTAlertManager.m in Sources */,

--- a/React/Views/RCTConvert+MapKit.h
+++ b/React/Views/RCTConvert+MapKit.h
@@ -10,6 +10,7 @@
 #import <MapKit/MapKit.h>
 
 #import "RCTPointAnnotation.h"
+#import "RCTPolyline.h"
 #import "RCTConvert.h"
 
 @interface RCTConvert (MapKit)
@@ -19,11 +20,15 @@
 + (MKShape *)MKShape:(id)json;
 + (MKMapType)MKMapType:(id)json;
 + (RCTPointAnnotation *)RCTPointAnnotation:(id)json;
++ (RCTPolyline *)RCTPolyline:(id)json;
 
 typedef NSArray MKShapeArray;
 + (MKShapeArray *)MKShapeArray:(id)json;
 
 typedef NSArray RCTPointAnnotationArray;
 + (RCTPointAnnotationArray *)RCTPointAnnotationArray:(id)json;
+
+typedef NSArray RCTPolylineArray;
++ (RCTPolylineArray *)RCTPolylineArray:(id)json;
 
 @end

--- a/React/Views/RCTConvert+MapKit.m
+++ b/React/Views/RCTConvert+MapKit.m
@@ -66,4 +66,42 @@ RCT_ENUM_CONVERTER(MKMapType, (@{
 
 RCT_ARRAY_CONVERTER(RCTPointAnnotation)
 
++ (RCTPolyline *)RCTPolyline:(id)json
+{
+
+  json = [self NSDictionary:json];
+  NSArray* locations = (NSArray*)json[@"locations"];
+
+
+  CLLocationCoordinate2D polylineCoordinates[locations.count];
+  NSUInteger index = 0;
+  for (NSDictionary* location in locations) {
+    CLLocationCoordinate2D coordinate;
+
+    coordinate.latitude = [location[@"lat"] doubleValue];
+    coordinate.longitude = [location[@"lon"] doubleValue];
+
+    polylineCoordinates[index++] = coordinate;
+  }
+
+  RCTPolyline *polyline = [RCTPolyline polylineWithCoordinates:polylineCoordinates count:locations.count];
+
+  unsigned rgbValue = 0;
+  NSScanner *scanner = [NSScanner scannerWithString:[RCTConvert NSString:json[@"strokeColor"]]];
+  [scanner setScanLocation:1]; // bypass '#' character
+  [scanner scanHexInt:&rgbValue];
+  polyline.strokeColor = [UIColor colorWithRed:((rgbValue & 0xFF0000) >> 16)/255.0
+                         green:((rgbValue & 0xFF00) >> 8)/255.0
+                          blue:(rgbValue & 0xFF)/255.0
+                         alpha:[RCTConvert double:json[@"alpha"]]];
+
+  polyline.identifier = [RCTConvert NSString:json[@"id"]];
+  polyline.lineWidth = [RCTConvert double:json[@"lineWidth"]];
+  polyline.alpha = [RCTConvert double:json[@"alpha"]];
+
+  return polyline;
+}
+
+RCT_ARRAY_CONVERTER(RCTPolyline)
+
 @end

--- a/React/Views/RCTMap.h
+++ b/React/Views/RCTMap.h
@@ -26,10 +26,12 @@ extern const CGFloat RCTMapZoomBoundBuffer;
 @property (nonatomic, assign) UIEdgeInsets legalLabelInsets;
 @property (nonatomic, strong) NSTimer *regionChangeObserveTimer;
 @property (nonatomic, copy) NSArray<NSString *> *annotationIds;
+@property (nonatomic, strong) NSMutableArray *polylineIds;
 
 @property (nonatomic, copy) RCTBubblingEventBlock onChange;
 @property (nonatomic, copy) RCTBubblingEventBlock onPress;
 
 - (void)setAnnotations:(RCTPointAnnotationArray *)annotations;
+- (void)setPolylines:(RCTPolylineArray *)polylines;
 
 @end

--- a/React/Views/RCTMap.m
+++ b/React/Views/RCTMap.m
@@ -11,6 +11,7 @@
 
 #import "RCTEventDispatcher.h"
 #import "RCTLog.h"
+#import "RCTPolyline.h"
 #import "RCTUtils.h"
 
 const CLLocationDegrees RCTMapDefaultSpan = 0.005;
@@ -153,6 +154,47 @@ const CGFloat RCTMapZoomBoundBuffer = 0.01;
     [newIds addObject:annotation.identifier];
   }
   self.annotationIds = newIds;
+}
+
+- (void)setPolylines:(RCTPolylineArray *)polylines
+{
+  NSMutableArray *newPolylineIds = [NSMutableArray new];
+  NSMutableArray *polylinesToDelete = [NSMutableArray new];
+  NSMutableArray *polylinesToAdd = [NSMutableArray new];
+
+  for (RCTPolyline* polyline in polylines) {
+    if (![polyline isKindOfClass:[RCTPolyline class]]) {
+      continue;
+    }
+
+    [newPolylineIds addObject:polyline.identifier];
+
+    // If the current set does not contain the new annotation, mark it as add
+    if (![self.annotationIds containsObject:polyline.identifier]) {
+      [polylinesToAdd addObject:polyline];
+    }
+  }
+
+  for (RCTPolyline *polyline in self.overlays) {
+    if (![polyline isKindOfClass:[RCTPolyline class]]) {
+      continue;
+    }
+
+    // If the new set does not contain an existing annotation, mark it as delete
+    if (![newPolylineIds containsObject:polyline.identifier]) {
+      [polylinesToDelete addObject:polyline];
+    }
+  }
+
+  if (polylinesToDelete.count) {
+    [self removeOverlays: polylinesToDelete];
+  }
+
+  if (polylinesToAdd.count) {
+    [self addOverlays: polylinesToAdd];
+  }
+
+  self.polylineIds = newPolylineIds;
 }
 
 @end

--- a/React/Views/RCTMapManager.m
+++ b/React/Views/RCTMapManager.m
@@ -98,6 +98,19 @@ RCT_CUSTOM_VIEW_PROPERTY(region, MKCoordinateRegion, RCTMap)
   return annotationView;
 }
 
+- (MKOverlayRenderer *)mapView:(__unused MKMapView *)mapView rendererForOverlay:(id)overlay {
+  if ([overlay isKindOfClass:[RCTPolyline class]]) {
+    RCTPolyline *polyline = overlay;
+    MKPolylineRenderer *polylineRenderer = [[MKPolylineRenderer alloc] initWithPolyline:polyline];
+    polylineRenderer.strokeColor = polyline.strokeColor;
+    polylineRenderer.lineWidth = polyline.lineWidth;
+    polylineRenderer.alpha = polyline.alpha;
+    return polylineRenderer;
+  } else {
+    return nil;
+  }
+}
+
 - (void)mapView:(RCTMap *)mapView annotationView:(MKAnnotationView *)view calloutAccessoryControlTapped:(UIControl *)control
 {
   if (mapView.onPress) {


### PR DESCRIPTION
Per issue #1925, add support for Polyline to MapView.

Briefly, if you have a MapView declared as:

    <MapView
        annotations={this.state.annotations}
        overlays={this.state.overlays}
        style={styles.map}
        region={this.state.region}
        ref="mapView"
    />

then setting

    this.state.overlays = [
        {
            "type": "polyline",
            "coordinates": [
            { "lat": 35.5, "lon": -5.5 },
            { "lat": 35.6, "lon": -5.6 },
            ...
        ],
        "strokeColor": "#FF0000",
        "lineWidth": 3,
        "alpha": 0.5
    }];

will draw a red line between the points in locations with a width of 3 and equally blended with the background.