### PR TITLE
Add git clone step to READMEs

### DIFF
--- a/Examples/Movies/README.md
+++ b/Examples/Movies/README.md
@@ -6,6 +6,7 @@ The Movies app is a demonstration of basic concepts, such as fetching data, rend
 
 Before running the app, make sure you ran:
 
+    git clone https://github.com/facebook/react-native.git
     cd react-native
     npm install
 

--- a/Examples/UIExplorer/README.md
+++ b/Examples/UIExplorer/README.md
@@ -6,6 +6,7 @@ The UIExplorer is a sample app that showcases React Native views and modules.
 
 Before running the app, make sure you ran:
 
+    git clone https://github.com/facebook/react-native.git
     cd react-native
     npm install
 


### PR DESCRIPTION
Thought this would be helpful since people can come to the Movies example page (https://github.com/facebook/react-native/tree/master/Examples/Movies) straight from the React Native tutorial (https://facebook.github.io/react-native/docs/tutorial.html) without having read the main Examples README first.

I have completed the CLA.