### PR TITLE
Requires Xcode 7 or higher to run 0.15.0-rc

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -22,7 +22,7 @@ We recommend periodically running `brew update && brew upgrade` to keep your pro
 
 ## iOS Setup
 
-[Xcode](https://developer.apple.com/xcode/downloads/) 6.3 or higher is required. It can be installed from the App Store.
+[Xcode](https://developer.apple.com/xcode/downloads/) 7.0 or higher is required. It can be installed from the App Store.
 
 ## Android Setup
 


### PR DESCRIPTION
Xcode 6 doesn't understand the annotations c5b990f65f0791041378a61cd503ccf686b00bb1 added to 0.15.0-rc. So requires Xcode 7 to build successfully.