### PR TITLE
UIRefreshControl added to scroll view

### DIFF
--- a/Libraries/Components/ScrollView/ScrollView.js
+++ b/Libraries/Components/ScrollView/ScrollView.js
@@ -418,11 +418,12 @@ var ScrollView = React.createClass({
       onResponderReject: this.scrollResponderHandleResponderReject,
     };
 
+    var onRefreshStart = this.props.onRefreshStart;
     // this is necessary because if we set it on props, even when empty,
     // it'll trigger the default pull-to-refresh behaviour on native.
-    if (this.props.onRefreshStart) {
-      props.onRefreshStart = () => this.props.onRefreshStart(this.endRefreshing);
-    }
+    props.onRefreshStart = onRefreshStart
+      ? function() { onRefreshStart && onRefreshStart(this.endRefreshing); }
+      : null;
 
     var ScrollViewClass;
     if (Platform.OS === 'ios') {

--- a/Libraries/Components/ScrollView/ScrollView.js
+++ b/Libraries/Components/ScrollView/ScrollView.js
@@ -283,7 +283,7 @@ var ScrollView = React.createClass({
 
     /**
      * When defined, displays a UIRefreshControl.
-     * Invoked with a function to stop refreshing when then UIRefreshControl is animating.
+     * Invoked with a function to stop refreshing when the UIRefreshControl is animating.
      *
      * ```
      * (endRefreshing) => {

--- a/Libraries/Components/ScrollView/ScrollView.js
+++ b/Libraries/Components/ScrollView/ScrollView.js
@@ -422,7 +422,7 @@ var ScrollView = React.createClass({
     // this is necessary because if we set it on props, even when empty,
     // it'll trigger the default pull-to-refresh behaviour on native.
     props.onRefreshStart = onRefreshStart
-      ? function() { onRefreshStart && onRefreshStart(this.endRefreshing); }
+      ? function() { onRefreshStart && onRefreshStart(this.endRefreshing); }.bind(this)
       : null;
 
     var ScrollViewClass;

--- a/Libraries/Components/ScrollView/ScrollView.js
+++ b/Libraries/Components/ScrollView/ScrollView.js
@@ -15,6 +15,7 @@ var EdgeInsetsPropType = require('EdgeInsetsPropType');
 var Platform = require('Platform');
 var PointPropType = require('PointPropType');
 var RCTScrollView = require('NativeModules').UIManager.RCTScrollView;
+var RCTScrollViewManager = require('NativeModules').ScrollViewManager;
 var React = require('React');
 var ReactNativeViewAttributes = require('ReactNativeViewAttributes');
 var RCTUIManager = require('NativeModules').UIManager;
@@ -279,6 +280,21 @@ var ScrollView = React.createClass({
      * @platform ios
      */
     zoomScale: PropTypes.number,
+
+    /**
+     * When defined, displays a UIRefreshControl.
+     * Invoked with a function to stop refreshing when then UIRefreshControl is animating.
+     *
+     * ```
+     * (endRefreshing) => {
+     *      endRefreshing();
+     * }
+     * ```
+     *
+     * @platform ios
+     */
+    onRefreshStart: PropTypes.func,
+
   },
 
   mixins: [ScrollResponder.Mixin],
@@ -289,6 +305,12 @@ var ScrollView = React.createClass({
 
   setNativeProps: function(props: Object) {
     this.refs[SCROLLVIEW].setNativeProps(props);
+  },
+
+  endRefreshing: function() {
+    RCTScrollViewManager.endRefreshing(
+      React.findNodeHandle(this)
+    );
   },
 
   /**
@@ -395,6 +417,12 @@ var ScrollView = React.createClass({
       onResponderRelease: this.scrollResponderHandleResponderRelease,
       onResponderReject: this.scrollResponderHandleResponderReject,
     };
+
+    // this is necessary because if we set it on props, even when empty,
+    // it'll trigger the default pull-to-refresh behaviour on native.
+    if (this.props.onRefreshStart) {
+      props.onRefreshStart = () => this.props.onRefreshStart(this.endRefreshing);
+    }
 
     var ScrollViewClass;
     if (Platform.OS === 'ios') {

--- a/React/Views/RCTScrollView.h
+++ b/React/Views/RCTScrollView.h
@@ -47,6 +47,9 @@
 @property (nonatomic, assign) int snapToInterval;
 @property (nonatomic, copy) NSString *snapToAlignment;
 @property (nonatomic, copy) NSIndexSet *stickyHeaderIndices;
+@property (nonatomic, copy) RCTDirectEventBlock onRefreshStart;
+
+- (void)endRefreshing;
 
 @end
 

--- a/React/Views/RCTScrollView.m
+++ b/React/Views/RCTScrollView.m
@@ -144,6 +144,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
 
 @property (nonatomic, copy) NSIndexSet *stickyHeaderIndices;
 @property (nonatomic, assign) BOOL centerContent;
+@property (nonatomic, strong) UIRefreshControl *refreshControl;
 
 @end
 
@@ -350,6 +351,12 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
   }];
 
   return hitView ?: [super hitTest:point withEvent:event];
+}
+
+- (void)setRefreshControl:(UIRefreshControl *)refreshControl
+{
+  _refreshControl = refreshControl;
+  [self addSubview:_refreshControl];
 }
 
 @end
@@ -842,6 +849,26 @@ RCT_SET_AND_PRESERVE_OFFSET(setScrollIndicatorInsets, UIEdgeInsets);
 - (id)valueForUndefinedKey:(NSString *)key
 {
   return [_scrollView valueForKey:key];
+}
+
+- (void)setOnRefreshStart:(RCTDirectEventBlock)onRefreshStart
+{
+  _onRefreshStart = [onRefreshStart copy];
+  UIRefreshControl *refreshControl = [[UIRefreshControl alloc] init];
+  [refreshControl addTarget:self action:@selector(refreshControlValueChanged) forControlEvents:UIControlEventValueChanged];
+  _scrollView.refreshControl = refreshControl;
+}
+
+- (void)refreshControlValueChanged
+{
+  if (self.onRefreshStart) {
+    self.onRefreshStart(nil);
+  }
+}
+
+- (void)endRefreshing
+{
+  [_scrollView.refreshControl endRefreshing];
 }
 
 @end

--- a/React/Views/RCTScrollView.m
+++ b/React/Views/RCTScrollView.m
@@ -355,6 +355,11 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
 
 - (void)setRefreshControl:(UIRefreshControl *)refreshControl
 {
+  if (!refreshControl) {
+    [_refreshControl removeFromSuperview];
+    _refreshControl = nil;
+    return;
+  }
   _refreshControl = refreshControl;
   [self addSubview:_refreshControl];
 }
@@ -853,6 +858,16 @@ RCT_SET_AND_PRESERVE_OFFSET(setScrollIndicatorInsets, UIEdgeInsets);
 
 - (void)setOnRefreshStart:(RCTDirectEventBlock)onRefreshStart
 {
+  if (!onRefreshStart) {
+    _onRefreshStart = nil;
+    _scrollView.refreshControl = nil;
+    return;
+  }
+  
+  if (_scrollView.refreshControl) {
+    return;
+  }
+  
   _onRefreshStart = [onRefreshStart copy];
   UIRefreshControl *refreshControl = [[UIRefreshControl alloc] init];
   [refreshControl addTarget:self action:@selector(refreshControlValueChanged) forControlEvents:UIControlEventValueChanged];

--- a/React/Views/RCTScrollView.m
+++ b/React/Views/RCTScrollView.m
@@ -355,10 +355,8 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
 
 - (void)setRefreshControl:(UIRefreshControl *)refreshControl
 {
-  if (!refreshControl) {
+  if (_refreshControl) {
     [_refreshControl removeFromSuperview];
-    _refreshControl = nil;
-    return;
   }
   _refreshControl = refreshControl;
   [self addSubview:_refreshControl];
@@ -863,15 +861,13 @@ RCT_SET_AND_PRESERVE_OFFSET(setScrollIndicatorInsets, UIEdgeInsets);
     _scrollView.refreshControl = nil;
     return;
   }
-  
-  if (_scrollView.refreshControl) {
-    return;
-  }
-  
   _onRefreshStart = [onRefreshStart copy];
-  UIRefreshControl *refreshControl = [[UIRefreshControl alloc] init];
-  [refreshControl addTarget:self action:@selector(refreshControlValueChanged) forControlEvents:UIControlEventValueChanged];
-  _scrollView.refreshControl = refreshControl;
+
+  if (!_scrollView.refreshControl) {
+    UIRefreshControl *refreshControl = [[UIRefreshControl alloc] init];
+    [refreshControl addTarget:self action:@selector(refreshControlValueChanged) forControlEvents:UIControlEventValueChanged];
+    _scrollView.refreshControl = refreshControl;
+  }
 }
 
 - (void)refreshControlValueChanged

--- a/React/Views/RCTScrollViewManager.m
+++ b/React/Views/RCTScrollViewManager.m
@@ -65,6 +65,7 @@ RCT_EXPORT_VIEW_PROPERTY(scrollIndicatorInsets, UIEdgeInsets)
 RCT_EXPORT_VIEW_PROPERTY(snapToInterval, int)
 RCT_EXPORT_VIEW_PROPERTY(snapToAlignment, NSString)
 RCT_REMAP_VIEW_PROPERTY(contentOffset, scrollView.contentOffset, CGPoint)
+RCT_EXPORT_VIEW_PROPERTY(onRefreshStart, RCTDirectEventBlock)
 
 - (NSDictionary<NSString *, id> *)constantsToExport
 {
@@ -114,6 +115,22 @@ RCT_EXPORT_METHOD(calculateChildFrames:(nonnull NSNumber *)reactTag
   }];
 }
 
+RCT_EXPORT_METHOD(endRefreshing:(nonnull NSNumber *)reactTag)
+{
+  [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, RCTScrollView *> *viewRegistry) {
+    
+    RCTScrollView *view = viewRegistry[reactTag];
+    if (!view || ![view isKindOfClass:[RCTScrollView class]]) {
+      RCTLogError(@"Cannot find RCTScrollView with tag #%@", reactTag);
+      return;
+    }
+
+    [view endRefreshing];
+    
+  }];
+}
+
+
 - (NSArray<NSString *> *)customDirectEventTypes
 {
   return @[
@@ -127,3 +144,4 @@ RCT_EXPORT_METHOD(calculateChildFrames:(nonnull NSNumber *)reactTag
 }
 
 @end
+


### PR DESCRIPTION
**What:**

adds `onRefreshStart` property to `ScrollView.js` for displaying and activating pull to refresh.

**Why:**

Javascript implementations seemed a little flakey and inconsistent.  As you can see in the issues below:

https://github.com/facebook/react-native/issues/2356
https://github.com/facebook/react-native/issues/745

So this is an attempt a completely native implementation.

What do you think?

![Image of dog](http://i.imgur.com/HcTQnzJ.gif)