### PR TITLE
Add example of getting window dimensions to Dimensions docs.

### DIFF
--- a/Libraries/Utilities/Dimensions.js
+++ b/Libraries/Utilities/Dimensions.js
@@ -57,6 +57,8 @@ class Dimensions {
    * than caching the value (for example, using inline styles rather than
    * setting a value in a `StyleSheet`).
    *
+   * Example: `var {height, width} = Dimensions.get('window');`
+   *
    * @param {string} dim Name of dimension as defined when calling `set`.
    * @returns {Object?} Value for the dimension.
    */


### PR DESCRIPTION
This pull request adds an example to the Dimensions documentations.  Specifically, it gives an example of how to get the height and width from the window.

I'm submitting this documentation because discovering this information cost me some time and my hope is to save other folks time by having this info right in the docs generated from the comments in this file.

Let me know if you need anything else.