### PR TITLE
Add RCTCameraRoll cocoapod subspec

### DIFF
--- a/React.podspec
+++ b/React.podspec
@@ -49,6 +49,12 @@ Pod::Spec.new do |s|
     ss.preserve_paths   = "Libraries/AdSupport/*.js"
   end
 
+  s.subspec 'RCTCameraRoll' do |ss|
+    ss.dependency         'React/Core'
+    ss.source_files     = "Libraries/CameraRoll/*.{h,m}"
+    ss.preserve_paths   = "Libraries/CameraRoll/*.js"
+  end
+
   s.subspec 'RCTGeolocation' do |ss|
     ss.dependency         'React/Core'
     ss.source_files     = "Libraries/Geolocation/*.{h,m}"


### PR DESCRIPTION
Struggled for some time to figure out why CameraRoll could not (anymore, upgraded from RN 0.11 iirc) be used in a cocoapods setup. This was the cleanest way to make it work, is it a bad idea for some reason?