### PR TITLE
Fix ImagePicker crashed when it works with keyboard

### DIFF
--- a/Libraries/CameraRoll/RCTImagePickerManager.m
+++ b/Libraries/CameraRoll/RCTImagePickerManager.m
@@ -80,8 +80,9 @@ RCT_EXPORT_METHOD(openCameraDialog:(NSDictionary *)config
   [_pickers addObject:imagePicker];
   [_pickerCallbacks addObject:callback];
   [_pickerCancelCallbacks addObject:cancelCallback];
-
-  [rootViewController presentViewController:imagePicker animated:YES completion:nil];
+  dispatch_async(dispatch_get_main_queue(), ^{
+    [rootViewController presentViewController:imagePicker animated:YES completion:nil];
+  });
 }
 
 RCT_EXPORT_METHOD(openSelectDialog:(NSDictionary *)config
@@ -112,8 +113,9 @@ RCT_EXPORT_METHOD(openSelectDialog:(NSDictionary *)config
   [_pickers addObject:imagePicker];
   [_pickerCallbacks addObject:callback];
   [_pickerCancelCallbacks addObject:cancelCallback];
-
-  [rootViewController presentViewController:imagePicker animated:YES completion:nil];
+  dispatch_async(dispatch_get_main_queue(), ^{
+    [rootViewController presentViewController:imagePicker animated:YES completion:nil];
+  });
 }
 
 - (void)imagePickerController:(UIImagePickerController *)picker


### PR DESCRIPTION
I want to pop-up the image picker when I press a button. But if the keyboard is active and displayed on the screen, I will get a 

> -[UIKeyboardTaskQueue waitUntilAllTasksAreFinished] may only be called from the main thread.

crash error. Move present image picker view code to main thread queue is able to fix the problem.