### PR TITLE
Added Subject to ActionSheetIOS share options and updated example

### DIFF
--- a/Examples/UIExplorer/ActionSheetIOSExample.js
+++ b/Examples/UIExplorer/ActionSheetIOSExample.js
@@ -88,6 +88,8 @@ var ShareActionSheetExample = React.createClass({
   showShareActionSheet() {
     ActionSheetIOS.showShareActionSheetWithOptions({
       url: 'https://code.facebook.com',
+      message: 'message to go with the shared url',
+      subject: 'a subject to go in the email heading',
     },
     (error) => {
       console.error(error);

--- a/Libraries/ActionSheetIOS/RCTActionSheetManager.m
+++ b/Libraries/ActionSheetIOS/RCTActionSheetManager.m
@@ -166,6 +166,12 @@ RCT_EXPORT_METHOD(showShareActionSheetWithOptions:(NSDictionary *)options
   }
 
   UIActivityViewController *shareController = [[UIActivityViewController alloc] initWithActivityItems:items applicationActivities:nil];
+
+  NSString *subject = [RCTConvert NSString:options[@"subject"]];
+  if (subject) {
+    [shareController setValue:subject forKey:@"subject"];
+  }
+
   UIViewController *controller = RCTKeyWindow().rootViewController;
 
 #if __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_8_0


### PR DESCRIPTION
I've added a subject property to the ActionSheetIOS.showShareActionSheetWithOptions options object. This will allow users to set a subject for things like emails when they are sharing to them through the ActionSheetIOS.
Options are now as follows:
```
{
   url: 'https://code.facebook.com',
   message: 'message to go with the shared url',
   subject: 'a subject to go in the email heading',
}
```