### PR TITLE
Ensure correct Babel plugin locations in packager transform

### DIFF
--- a/packager/transformer.js
+++ b/packager/transformer.js
@@ -37,6 +37,21 @@ function transform(src, filename, options) {
   }
   config.plugins = extraPlugins.concat(config.plugins);
 
+  // Manually resolve all default Babel plugins. babel.transform will attempt to resolve
+  // all base plugins relative to the file it's compiling. This makes sure that we're
+  // using the plugins installed in the react-native package.
+  config.plugins = config.plugins.map(function(plugin) {
+    // Normalise plugin to an array.
+    if (!Array.isArray(plugin)) {
+      plugin = [plugin];
+    }
+    // Only resolve the plugin if it's a string reference.
+    if (typeof plugin[0] === 'string') {
+      plugin[0] = require(`babel-plugin-${plugin[0]}`);
+    }
+    return plugin;
+  });
+
   const result = babel.transform(src, Object.assign({}, babelRC, config));
 
   return {


### PR DESCRIPTION
Manually resolve all default Babel plugins. `babel.transform` will attempt to resolve all base plugins relative to the file it's compiling. This makes sure that we're using the plugins installed in the react-native package.

**NOTE:** Haven't tested this. Please don't merge until Travis has done CI.