### PR TITLE
[Docs] Note that Android geolocation not yet open sourced

### DIFF
--- a/Libraries/Geolocation/Geolocation.js
+++ b/Libraries/Geolocation/Geolocation.js
@@ -42,6 +42,10 @@ type GeoOptions = {
  * app's `AndroidManifest.xml`:
  *
  * `<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />`
+ *
+ * Geolocation support for Android is planned but not yet open sourced. See
+ * [Known Issues](http://facebook.github.io/react-native/docs/known-issues.html#missing-modules-and-native-views).
+ *
  */
 var Geolocation = {
 


### PR DESCRIPTION
Since the `Geolocation` docs explicitly contain Android instructions for a library that is not open-sourced, there should probably a sign post to Known Issues as found in, for example, the [CameraRoll documentation](http://facebook.github.io/react-native/docs/cameraroll.html#methods).

Added to the inline Geolocation.js docs:

> Geolocation support for Android is planned but not yet open sourced. See [Known issues](http://facebook.github.io/react-native/docs/known-issues.html#missing-modules-and-native-views).