### PR TITLE
Verify ref exists before calling setNativeProps

### DIFF
--- a/Libraries/Components/DatePicker/DatePickerIOS.ios.js
+++ b/Libraries/Components/DatePicker/DatePickerIOS.ios.js
@@ -108,7 +108,7 @@ var DatePickerIOS = React.createClass({
     // certain values. In other words, the embedder of this component should
     // be the source of truth, not the native component.
     var propsTimeStamp = this.props.date.getTime();
-    if (nativeTimeStamp !== propsTimeStamp) {
+    if (nativeTimeStamp !== propsTimeStamp && this.refs[DATEPICKER]) {
       this.refs[DATEPICKER].setNativeProps({
         date: propsTimeStamp,
       });

--- a/Libraries/Picker/PickerIOS.ios.js
+++ b/Libraries/Picker/PickerIOS.ios.js
@@ -83,7 +83,7 @@ var PickerIOS = React.createClass({
     // disallow/undo/mutate the selection of certain values. In other
     // words, the embedder of this component should be the source of
     // truth, not the native component.
-    if (this.state.selectedIndex !== event.nativeEvent.newIndex) {
+    if (this.state.selectedIndex !== event.nativeEvent.newIndex && this.refs[PICKER]) {
       this.refs[PICKER].setNativeProps({
         selectedIndex: this.state.selectedIndex
       });


### PR DESCRIPTION
Proposed fix for https://github.com/facebook/react-native/issues/3447

Dumb fix! Quite possibly we don't ever expect those to be null, and the proper fix is to figure out why the ref is null, and remedy that. 