### PR TITLE
Improving the way of how we register the device for push notifications

### DIFF
--- a/Libraries/PushNotificationIOS/PushNotificationIOS.js
+++ b/Libraries/PushNotificationIOS/PushNotificationIOS.js
@@ -142,8 +142,7 @@ class PushNotificationIOS {
       listener = RCTDeviceEventEmitter.addListener(
         NOTIF_REGISTER_EVENT,
         (registrationInfo) => {
-          handler(registrationInfo.error ? registrationInfo : 
-            registrationInfo.deviceToken);
+          handler(registrationInfo.deviceToken || registrationInfo);
         }
       );
     }

--- a/Libraries/PushNotificationIOS/PushNotificationIOS.js
+++ b/Libraries/PushNotificationIOS/PushNotificationIOS.js
@@ -39,18 +39,17 @@ var NOTIF_REGISTER_EVENT = 'remoteNotificationsRegistered';
  * And then in your AppDelegate implementation add the following:
  *
  *   ```
- *   // Required to invoke register notifications
- *
- *      - (void)application:(UIApplication *)application didRegisterUserNotificationSettings:(UIUserNotificationSettings *)notificationSettings
- *      {
- *       [RCTPushNotificationManager application:application didRegisterUserNotificationSettings:notificationSettings];
- *      }
- *    // Required for error detection
- *      -(void)application:(UIApplication *)application didFailToRegisterForRemoteNotificationsWithError:(NSError *)error 
- *      {
- *       [RCTPushNotificationManager application:application didFailToRegisterForRemoteNotificationsWithError:error];
- *      }
- *   // Required for the register event.
+ *    // Required to invoke register notifications
+ *    - (void)application:(UIApplication *)application didRegisterUserNotificationSettings:(UIUserNotificationSettings *)notificationSettings
+ *    {
+ *     [RCTPushNotificationManager application:application didRegisterUserNotificationSettings:notificationSettings];
+ *    }
+ *    // Required for any errors during the registration
+ *    - (void)application:(UIApplication *)application didFailToRegisterForRemoteNotificationsWithError:(NSError *)error 
+ *    {
+ *     [RCTPushNotificationManager application:application didFailToRegisterForRemoteNotificationsWithError:error];
+ *    }
+ *    // Required for the register event.
  *    - (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken
  *    {
  *     [RCTPushNotificationManager application:application didRegisterForRemoteNotificationsWithDeviceToken:deviceToken];

--- a/Libraries/PushNotificationIOS/PushNotificationIOS.js
+++ b/Libraries/PushNotificationIOS/PushNotificationIOS.js
@@ -39,6 +39,17 @@ var NOTIF_REGISTER_EVENT = 'remoteNotificationsRegistered';
  * And then in your AppDelegate implementation add the following:
  *
  *   ```
+ *   // Required to invoke register notifications
+ *
+ *      - (void)application:(UIApplication *)application didRegisterUserNotificationSettings:(UIUserNotificationSettings *)notificationSettings
+ *      {
+ *       [RCTPushNotificationManager application:application didRegisterUserNotificationSettings:notificationSettings];
+ *      }
+ *    // Required for error detection
+ *      -(void)application:(UIApplication *)application didFailToRegisterForRemoteNotificationsWithError:(NSError *)error 
+ *      {
+ *       [RCTPushNotificationManager application:application didFailToRegisterForRemoteNotificationsWithError:error];
+ *      }
  *   // Required for the register event.
  *    - (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken
  *    {
@@ -112,7 +123,8 @@ class PushNotificationIOS {
    * - `notification` : Fired when a remote notification is received. The
    *   handler will be invoked with an instance of `PushNotificationIOS`.
    * - `register`: Fired when the user registers for remote notifications. The
-   *   handler will be invoked with a hex string representing the deviceToken.
+   *   handler will be invoked with a hex string representing the deviceToken. 
+   *   If any error occurs then a JSON with error key `true`
    */
   static addEventListener(type: string, handler: Function) {
     invariant(
@@ -131,7 +143,8 @@ class PushNotificationIOS {
       listener = RCTDeviceEventEmitter.addListener(
         NOTIF_REGISTER_EVENT,
         (registrationInfo) => {
-          handler(registrationInfo.deviceToken);
+          handler(registrationInfo.error ? registrationInfo : 
+            registrationInfo.deviceToken);
         }
       );
     }

--- a/Libraries/PushNotificationIOS/RCTPushNotificationManager.h
+++ b/Libraries/PushNotificationIOS/RCTPushNotificationManager.h
@@ -15,6 +15,7 @@
 
 + (void)application:(UIApplication *)application didRegisterUserNotificationSettings:(UIUserNotificationSettings *)notificationSettings;
 + (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken;
++ (void)application:(UIApplication *)application didFailToRegisterForRemoteNotificationsWithError:(NSError *)error;
 + (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)notification;
 
 @end

--- a/Libraries/PushNotificationIOS/RCTPushNotificationManager.m
+++ b/Libraries/PushNotificationIOS/RCTPushNotificationManager.m
@@ -172,7 +172,6 @@ RCT_EXPORT_METHOD(requestPermissions:(NSDictionary *)permissions)
   if ([app respondsToSelector:@selector(registerUserNotificationSettings:)]) {
     UIUserNotificationSettings *notificationSettings = [UIUserNotificationSettings settingsForTypes:(NSUInteger)types categories:nil];
     [app registerUserNotificationSettings:notificationSettings];
-    [app registerForRemoteNotifications];
   } else {
     [app registerForRemoteNotificationTypes:(NSUInteger)types];
   }

--- a/Libraries/PushNotificationIOS/RCTPushNotificationManager.m
+++ b/Libraries/PushNotificationIOS/RCTPushNotificationManager.m
@@ -108,10 +108,9 @@ RCT_EXPORT_MODULE()
 + (void)application:(__unused UIApplication *)application didFailToRegisterForRemoteNotificationsWithError:(NSError *)error
 {
   NSDictionary *errorInfo = @{
-                              @"error" : @TRUE,
-                              @"description" : [error localizedDescription],
-                              @"reason" : [error localizedFailureReason]
-                              };
+    @"error" : @YES,
+    @"info": RCTJSErrorFromNSError(error)
+  };
   [[NSNotificationCenter defaultCenter] postNotificationName:RCTRemoteNotificationsRegistered
                                                       object:self
                                                     userInfo:errorInfo];

--- a/Libraries/PushNotificationIOS/RCTPushNotificationManager.m
+++ b/Libraries/PushNotificationIOS/RCTPushNotificationManager.m
@@ -105,6 +105,18 @@ RCT_EXPORT_MODULE()
                                                     userInfo:notification];
 }
 
++ (void)application:(__unused UIApplication *)application didFailToRegisterForRemoteNotificationsWithError:(NSError *)error
+{
+  NSDictionary *errorInfo = @{
+                              @"error" : @TRUE,
+                              @"description" : [error localizedDescription],
+                              @"reason" : [error localizedFailureReason]
+                              };
+  [[NSNotificationCenter defaultCenter] postNotificationName:RCTRemoteNotificationsRegistered
+                                                      object:self
+                                                    userInfo:errorInfo];
+}
+
 - (void)handleRemoteNotificationReceived:(NSNotification *)notification
 {
   [_bridge.eventDispatcher sendDeviceEventWithName:@"remoteNotificationReceived"


### PR DESCRIPTION
As for now, when requestPermissions is triggered, there is no way of knowing whether the user pressed "Allow" or "Don't Allow" on the push notification dialogue. Earlier the device token was available even if the user disallowed the permissions. Which actually caused ambiguity.
With the current change didRegisterUserNotificationSettings triggers the dialogue and after user allows to register the notification settings(i.e allowing for push notifications) the registerForRemoteNotifications method is invoked which will generate a device token.

In some cases the registration can fail. Such cases are when the user has not network connection (airplane mode). In that case the new Error method will create the error response to easily handle the situation.

I hope this will be helpful. I had hard time with this, and this solution helped me on DareU. If any questions, please let me know.