### PR TITLE
Fixed crash when polyfillGlobal attempts to polyfill a property with a getter

### DIFF
--- a/Libraries/JavaScriptAppEngine/Initialization/GLOBAL.js
+++ b/Libraries/JavaScriptAppEngine/Initialization/GLOBAL.js
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule GLOBAL
+ */
+
+/* eslint strict: 0 */
+/* globals GLOBAL: true, window: true */
+
+if (typeof GLOBAL === 'undefined') {
+  GLOBAL = this;
+}
+
+if (typeof window === 'undefined') {
+  window = GLOBAL;
+}
+
+module.exports = GLOBAL;

--- a/Libraries/JavaScriptAppEngine/Initialization/InitializeJavaScriptAppEngine.js
+++ b/Libraries/JavaScriptAppEngine/Initialization/InitializeJavaScriptAppEngine.js
@@ -19,55 +19,19 @@
  * @providesModule InitializeJavaScriptAppEngine
  */
 
-/* eslint strict: 0 */
-/* globals GLOBAL: true, window: true */
+/* globals window: true */
+
+'use strict';
 
 require('regenerator/runtime');
 
-if (typeof GLOBAL === 'undefined') {
-  GLOBAL = this;
-}
-
-if (typeof window === 'undefined') {
-  window = GLOBAL;
-}
+var GLOBAL = require('GLOBAL');
+var polyfillGlobal = require('polyfillGlobal');
 
 function setUpConsole() {
   // ExceptionsManager transitively requires Promise so we install it after
   var ExceptionsManager = require('ExceptionsManager');
   ExceptionsManager.installConsoleErrorReporter();
-}
-
-/**
- * Assigns a new global property, replacing the existing one if there is one.
- *
- * Existing properties are preserved as `originalPropertyName`. Both properties
- * will maintain the same enumerability & configurability.
- *
- * This allows you to undo the more aggressive polyfills, should you need to.
- * For example, if you want to route network requests through DevTools (to trace
- * them):
- *
- *     global.XMLHttpRequest = global.originalXMLHttpRequest;
- *
- * For more info on that particular case, see:
- * https://github.com/facebook/react-native/issues/934
- */
-function polyfillGlobal(name, newValue, scope = GLOBAL) {
-  var descriptor = Object.getOwnPropertyDescriptor(scope, name) || {
-    // jest for some bad reasons runs the polyfill code multiple times. In jest
-    // environment, XmlHttpRequest doesn't exist so getOwnPropertyDescriptor
-    // returns undefined and defineProperty default for writable is false.
-    // Therefore, the second time it runs, defineProperty will fatal :(
-    writable: true,
-  };
-
-  if (scope[name] !== undefined) {
-    var backupName = `original${name[0].toUpperCase()}${name.substr(1)}`;
-    Object.defineProperty(scope, backupName, {...descriptor, value: scope[name]});
-  }
-
-  Object.defineProperty(scope, name, {...descriptor, value: newValue});
 }
 
 function setUpErrorHandler() {

--- a/Libraries/JavaScriptAppEngine/Initialization/InitializeJavaScriptAppEngine.js
+++ b/Libraries/JavaScriptAppEngine/Initialization/InitializeJavaScriptAppEngine.js
@@ -143,9 +143,9 @@ function setUpProcessEnv() {
 }
 
 function setUpNumber() {
-  Number.EPSILON = Number.EPSILON || Math.pow(2, -52);
-  Number.MAX_SAFE_INTEGER = Number.MAX_SAFE_INTEGER || Math.pow(2, 53) - 1;
-  Number.MIN_SAFE_INTEGER = Number.MIN_SAFE_INTEGER || -(Math.pow(2, 53) - 1);
+  if (isNaN(Number.EPSILON)) Number.EPSILON = Math.pow(2, -52);
+  if (isNaN(Number.MAX_SAFE_INTEGER)) Number.MAX_SAFE_INTEGER = Math.pow(2, 53) - 1;
+  if (isNaN(Number.MIN_SAFE_INTEGER)) Number.MIN_SAFE_INTEGER = -(Math.pow(2, 53) - 1);
 }
 
 function setUpDevTools() {

--- a/Libraries/JavaScriptAppEngine/Initialization/__tests__/polyfillGlobal-test.js
+++ b/Libraries/JavaScriptAppEngine/Initialization/__tests__/polyfillGlobal-test.js
@@ -15,7 +15,50 @@ var polyfillGlobal = require('polyfillGlobal');
 
 describe('polyfillGlobal', function() {
 
-	it('supports polyfilling objects with a getter', function() {
+	it('supports polyfilling vanilla properties', function() {
+		var scope = {
+			obj: {
+				method: function() {
+					return 'a';
+				}
+			}
+		};
+
+		var polyfill = {
+			method: function() {
+				return 'b';
+			}
+		};
+
+		polyfillGlobal('obj', polyfill, scope);
+		expect(scope.obj.method()).toEqual('b');
+		expect(scope.originalObj.method()).toEqual('a');
+	});
+
+	it('supports polyfilling data properties', function() {
+		var scope = {};
+		Object.defineProperty(scope, 'obj', {
+			configurable: true,
+			writable: true,
+			value: {
+				method: function() {
+					return 'a';
+				}
+			}
+		});
+
+		var polyfill = {
+			method: function() {
+				return 'b';
+			}
+		};
+
+		polyfillGlobal('obj', polyfill, scope);
+		expect(scope.obj.method()).toEqual('b');
+		expect(scope.originalObj.method()).toEqual('a');
+	});
+
+	it('supports polyfilling accessors', function() {
 		var scope = {};
 		Object.defineProperty(scope, 'obj', {
 			configurable: true,
@@ -28,7 +71,29 @@ describe('polyfillGlobal', function() {
 			}
 		});
 
-		expect(scope.obj.method()).toEqual('a');
+		var polyfill = {
+			method: function() {
+				return 'b';
+			}
+		};
+
+		polyfillGlobal('obj', polyfill, scope);
+		expect(scope.obj.method()).toEqual('b');
+		expect(scope.originalObj.method()).toEqual('a');
+	});
+
+	it('should not throw when polyfilling nonconfigurable properties', function() {
+		var scope = {};
+		Object.defineProperty(scope, 'obj', {
+			configurable: false,
+			get: function() {
+				return {
+					method: function() {
+						return 'a';
+					}
+				};
+			}
+		});
 
 		var polyfill = {
 			method: function() {
@@ -37,8 +102,7 @@ describe('polyfillGlobal', function() {
 		};
 
 		polyfillGlobal('obj', polyfill, scope);
-
-		expect(scope.obj.method()).toEqual('b');
+		expect(scope.obj.method()).toEqual('a');
 	});
 
 });

--- a/Libraries/JavaScriptAppEngine/Initialization/__tests__/polyfillGlobal-test.js
+++ b/Libraries/JavaScriptAppEngine/Initialization/__tests__/polyfillGlobal-test.js
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+'use strict';
+
+
+jest.autoMockOff();
+
+var polyfillGlobal = require('polyfillGlobal');
+
+describe('polyfillGlobal', function() {
+
+	it('supports polyfilling objects with a getter', function() {
+		var scope = {};
+		Object.defineProperty(scope, 'obj', {
+			configurable: true,
+			get: function() {
+				return {
+					method: function() {
+						return 'a';
+					}
+				};
+			}
+		});
+
+		expect(scope.obj.method()).toEqual('a');
+
+		var polyfill = {
+			method: function() {
+				return 'b';
+			}
+		};
+
+		polyfillGlobal('obj', polyfill, scope);
+
+		expect(scope.obj.method()).toEqual('b');
+	});
+
+});

--- a/Libraries/JavaScriptAppEngine/Initialization/polyfillGlobal.js
+++ b/Libraries/JavaScriptAppEngine/Initialization/polyfillGlobal.js
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule polyfillGlobal
+ */
+
+'use strict';
+
+var GLOBAL = require('GLOBAL');
+
+/**
+ * Assigns a new global property, replacing the existing one if there is one.
+ *
+ * Existing properties are preserved as `originalPropertyName`. Both properties
+ * will maintain the same enumerability & configurability.
+ *
+ * This allows you to undo the more aggressive polyfills, should you need to.
+ * For example, if you want to route network requests through DevTools (to trace
+ * them):
+ *
+ *     global.XMLHttpRequest = global.originalXMLHttpRequest;
+ *
+ * For more info on that particular case, see:
+ * https://github.com/facebook/react-native/issues/934
+ */
+function polyfillGlobal(name, newValue, scope=GLOBAL) {
+	var descriptor = Object.getOwnPropertyDescriptor(scope, name) || {
+		// jest for some bad reasons runs the polyfill code multiple times. In jest
+		// environment, XmlHttpRequest doesn't exist so getOwnPropertyDescriptor
+		// returns undefined and defineProperty default for writable is false.
+		// Therefore, the second time it runs, defineProperty will fatal :(
+		writable: true,
+	};
+
+	// Properties cannot have both a getter and value. The guards against the exception:
+	// "Invalid property. 'value' present on property with getter or setter."
+	delete descriptor.get;
+	delete descriptor.set;
+
+	if (scope[name] !== undefined) {
+		var backupName = `original${name[0].toUpperCase()}${name.substr(1)}`;
+		Object.defineProperty(scope, backupName, {...descriptor, value: scope[name]});
+	}
+
+	Object.defineProperty(scope, name, {...descriptor, value: newValue});
+}
+
+module.exports = polyfillGlobal;


### PR DESCRIPTION
This PR fixes an exception that occurs when `polyfillGlobal()` attempts to polyfill a property that has a getter defined instead of a value. This seems to affect `geolocation` in `setUpGeolocation()` on device. My app was working last night... then I woke up to it not working (screenshot below). Maybe the OS updated overnight? Who knows... regardless, this should be safer.

```
Invalid property. 'value' present on property with getter or setter.
```

The fix boils down to these lines:
https://github.com/facebook/react-native/pull/4287/files#diff-5fb096262c3668e49ebaf855d35cdd49R40

<img src="https://cloud.githubusercontent.com/assets/118480/11326173/7c2fd564-911f-11e5-9ad8-df27a74ac04f.PNG" width="300" />