### PR TITLE
remove prepare_command in podspec file

### DIFF
--- a/React.podspec
+++ b/React.podspec
@@ -22,7 +22,6 @@ Pod::Spec.new do |s|
   s.default_subspec     = 'Core'
   s.requires_arc        = true
   s.platform            = :ios, "7.0"
-  s.prepare_command     = 'npm install --production'
   s.preserve_paths      = "cli.js", "Libraries/**/*.js", "lint", "linter.js", "node_modules", "package.json", "packager", "PATENTS", "react-native-cli"
 
   s.subspec 'Core' do |ss|


### PR DESCRIPTION
since 0.13.2 , prepare_command in podspec would download the dependencies of react-native again when you install react-native via cocoapods with local path.