### PR TITLE
Add note in View.js render method that wrapper component is not used.

### DIFF
--- a/Libraries/Components/View/View.js
+++ b/Libraries/Components/View/View.js
@@ -312,6 +312,10 @@ var View = React.createClass({
   },
 
   render: function() {
+    // WARNING: This method will not be used in production mode as in that mode we
+    // replace wrapper component View with generated native wrapper RCTView. Avoid
+    // adding functionality this component that you'd want to be available in both
+    // dev and prod modes.
     return <RCTView {...this.props} />;
   },
 });


### PR DESCRIPTION
Got bitten lately by View.js returning different component based on `__DEV__`

Adding a warning in the render method that should make it cleaner in the future that this method is not actually being used in prod mode.