### PR TITLE
[TextInput] corrects keyboard mapping for numeric on Android

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
@@ -64,6 +64,7 @@ public class ReactEditText extends EditText {
   private @Nullable TextWatcherDelegator mTextWatcherDelegator;
   private int mStagedInputType;
   private boolean mContainsImages;
+  private String mKeyboardType;
 
   public ReactEditText(Context context) {
     super(context);
@@ -80,6 +81,7 @@ public class ReactEditText extends EditText {
     mListeners = null;
     mTextWatcherDelegator = null;
     mStagedInputType = getInputType();
+    mKeyboardType = "default";
   }
 
   // After the text changes inside an EditText, TextView checks if a layout() has been requested.
@@ -162,6 +164,14 @@ public class ReactEditText extends EditText {
     if (getInputType() != mStagedInputType) {
       setInputType(mStagedInputType);
     }
+  }
+
+  String getKeyboardType() {
+    return mKeyboardType;
+  }
+
+  void setKeyboardType(String keyboardType) {
+    this.mKeyboardType = keyboardType;
   }
 
   @Override

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
@@ -271,23 +271,29 @@ public class ReactTextInputManager extends
 
   @ReactProp(name = "keyboardType")
   public void setKeyboardType(ReactEditText view, @Nullable String keyboardType) {
-    int flagsToUnset = 0;
-    int flagsToSet = 0;
-    if (KEYBOARD_TYPE_NUMERIC.equalsIgnoreCase(keyboardType)) {
-      flagsToUnset = InputType.TYPE_MASK_CLASS | InputType.TYPE_MASK_FLAGS;
-      flagsToSet = InputType.TYPE_CLASS_NUMBER | InputType.TYPE_NUMBER_FLAG_DECIMAL;
-    } else if (KEYBOARD_TYPE_EMAIL_ADDRESS.equalsIgnoreCase(keyboardType)) {
-      flagsToSet = InputType.TYPE_TEXT_VARIATION_EMAIL_ADDRESS;
-    }
-    updateStagedInputTypeFlag(
-        view,
-        flagsToUnset,
-        flagsToSet);
+    view.setKeyboardType(keyboardType);
   }
 
   @Override
   protected void onAfterUpdateTransaction(ReactEditText view) {
     super.onAfterUpdateTransaction(view);
+
+    if (KEYBOARD_TYPE_EMAIL_ADDRESS.equalsIgnoreCase(view.getKeyboardType())) {
+      updateStagedInputTypeFlag(
+          view,
+          0,
+          InputType.TYPE_TEXT_VARIATION_EMAIL_ADDRESS);
+
+    } else if (KEYBOARD_TYPE_NUMERIC.equalsIgnoreCase(view.getKeyboardType())) {
+      boolean pw = (view.getStagedInputType() & InputType.TYPE_TEXT_VARIATION_PASSWORD) > 0;
+
+      view.setStagedInputType(
+          InputType.TYPE_CLASS_NUMBER | InputType.TYPE_NUMBER_FLAG_DECIMAL |
+              (pw ?
+                  InputType.TYPE_NUMBER_VARIATION_PASSWORD
+                : InputType.TYPE_NUMBER_VARIATION_NORMAL));
+    }
+
     view.commitStagedInputType();
   }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
@@ -271,15 +271,17 @@ public class ReactTextInputManager extends
 
   @ReactProp(name = "keyboardType")
   public void setKeyboardType(ReactEditText view, @Nullable String keyboardType) {
+    int flagsToUnset = 0;
     int flagsToSet = 0;
     if (KEYBOARD_TYPE_NUMERIC.equalsIgnoreCase(keyboardType)) {
-      flagsToSet = InputType.TYPE_CLASS_NUMBER;
+      flagsToUnset = InputType.TYPE_MASK_CLASS | InputType.TYPE_MASK_FLAGS;
+      flagsToSet = InputType.TYPE_CLASS_NUMBER | InputType.TYPE_NUMBER_FLAG_DECIMAL;
     } else if (KEYBOARD_TYPE_EMAIL_ADDRESS.equalsIgnoreCase(keyboardType)) {
       flagsToSet = InputType.TYPE_TEXT_VARIATION_EMAIL_ADDRESS;
     }
     updateStagedInputTypeFlag(
         view,
-        InputType.TYPE_CLASS_NUMBER | InputType.TYPE_TEXT_VARIATION_EMAIL_ADDRESS,
+        flagsToUnset,
         flagsToSet);
   }
 


### PR DESCRIPTION
This should resolve issue #4260 that I opened.