### PR TITLE
Fix StyleSheet 'textAlign' for AndroidTextInput,rename Android native props

### DIFF
--- a/Examples/UIExplorer/TextInputExample.android.js
+++ b/Examples/UIExplorer/TextInputExample.android.js
@@ -314,6 +314,46 @@ exports.examples = [
     }
   },
   {
+    title: 'Text input, Alignment (Horizontal Demo Only)',
+    render: function() {
+      return (
+        <View>
+          <TextInput
+            placeholder="StyleSheet - textAlign: 'auto'"
+            style={[styles.singleLine, {textAlign: 'auto'}]}
+          />
+          <TextInput
+            placeholder="StyleSheet - textAlign: 'left'"
+            style={[styles.singleLine, {textAlign: 'left'}]}
+          />
+          <TextInput
+            placeholder="StyleSheet - textAlign: 'center'"
+            style={[styles.singleLine, {textAlign: 'center'}]}
+          />
+          <TextInput
+            placeholder="StyleSheet - textAlign: 'right'"
+            style={[styles.singleLine, {textAlign: 'right'}]}
+          />
+          <TextInput
+            placeholder="Native - textAlignAndroid='start'"
+            textAlignAndroid="start"
+            style={[styles.singleLine]}
+          />
+          <TextInput
+            placeholder="Native - textAlignAndroid='center'"
+            textAlignAndroid="center"
+            style={[styles.singleLine]}
+          />
+          <TextInput
+            placeholder="Native - textAlignAndroid='end'"
+            textAlignAndroid="end"
+            style={[styles.singleLine]}
+          />
+        </View>
+      );
+    }
+  },
+  {
     title: 'Passwords',
     render: function() {
       return (

--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -120,7 +120,7 @@ var TextInput = React.createClass({
      * Set the position of the cursor from where editing will begin.
      * @platform android
      */
-    textAlign: PropTypes.oneOf([
+    textAlignAndroid: PropTypes.oneOf([
       'start',
       'center',
       'end',
@@ -129,7 +129,7 @@ var TextInput = React.createClass({
      * Aligns text vertically within the TextInput.
      * @platform android
      */
-    textAlignVertical: PropTypes.oneOf([
+    textAlignVerticalAndroid: PropTypes.oneOf([
       'top',
       'center',
       'bottom',
@@ -497,10 +497,10 @@ var TextInput = React.createClass({
 
   _renderAndroid: function() {
     var autoCapitalize = RCTUIManager.UIText.AutocapitalizationType[this.props.autoCapitalize];
-    var textAlign =
-      RCTUIManager.AndroidTextInput.Constants.TextAlign[this.props.textAlign];
-    var textAlignVertical =
-      RCTUIManager.AndroidTextInput.Constants.TextAlignVertical[this.props.textAlignVertical];
+    var textAlignAndroid =
+      RCTUIManager.AndroidTextInput.Constants.TextAlignAndroid[this.props.textAlignAndroid];
+    var textAlignVerticalAndroid =
+      RCTUIManager.AndroidTextInput.Constants.TextAlignVerticalAndroid[this.props.textAlignVerticalAndroid];
     var children = this.props.children;
     var childCount = 0;
     ReactChildren.forEach(children, () => ++childCount);
@@ -517,8 +517,8 @@ var TextInput = React.createClass({
         style={[this.props.style]}
         autoCapitalize={autoCapitalize}
         autoCorrect={this.props.autoCorrect}
-        textAlign={textAlign}
-        textAlignVertical={textAlignVertical}
+        textAlignAndroid={textAlignAndroid}
+        textAlignVerticalAndroid={textAlignVerticalAndroid}
         keyboardType={this.props.keyboardType}
         mostRecentEventCount={this.state.mostRecentEventCount}
         multiline={this.props.multiline}

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManagersPropertyCache.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManagersPropertyCache.java
@@ -84,7 +84,7 @@ import com.facebook.react.bridge.ReadableMap;
       } catch (Throwable t) {
         FLog.e(ViewManager.class, "Error while updating prop " + mPropName, t);
         throw new JSApplicationIllegalArgumentException("Error while updating property '" +
-            mPropName + "' of a view managed by: " + viewManager.getName(), t);
+            mPropName + "' of a view managed by: " + viewManager.getName() + " | Arguments: " + VIEW_MGR_ARGS[0] + " | " + VIEW_MGR_ARGS[1], t);
       }
     }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
@@ -29,6 +29,7 @@ import android.text.InputFilter;
 
 import com.facebook.infer.annotation.Assertions;
 import com.facebook.react.bridge.JSApplicationCausedNativeException;
+import com.facebook.react.bridge.JSApplicationIllegalArgumentException;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.common.MapBuilder;
@@ -189,12 +190,27 @@ public class ReactTextInputManager extends
     }
   }
 
-  @ReactProp(name = "textAlign")
+  @ReactProp(name = ViewProps.TEXT_ALIGN)
+  public void setTextAlign(ReactEditText view, @Nullable String textAlign) {
+    if ("auto".equals(textAlign)) {
+      view.setGravity(Gravity.NO_GRAVITY);
+    } else if ("left".equals(textAlign)) {
+      view.setGravity(Gravity.LEFT);
+    } else if ("right".equals(textAlign)) {
+      view.setGravity(Gravity.RIGHT);
+    } else if ("center".equals(textAlign)) {
+      view.setGravity(Gravity.CENTER_HORIZONTAL);
+    } else {
+      throw new JSApplicationIllegalArgumentException("Invalid textAlign: " + textAlign);
+    }
+  }
+
+  @ReactProp(name = "textAlignAndroid")
   public void setTextAlign(ReactEditText view, int gravity) {
     view.setGravityHorizontal(gravity);
   }
 
-  @ReactProp(name = "textAlignVertical")
+  @ReactProp(name = "textAlignVerticalAndroid")
   public void setTextAlignVertical(ReactEditText view, int gravity) {
     view.setGravityVertical(gravity);
   }
@@ -421,12 +437,12 @@ public class ReactTextInputManager extends
   @Override
   public @Nullable Map getExportedViewConstants() {
     return MapBuilder.of(
-        "TextAlign",
+        "TextAlignAndroid",
         MapBuilder.of(
             "start", Gravity.START,
             "center", Gravity.CENTER_HORIZONTAL,
             "end", Gravity.END),
-        "TextAlignVertical",
+        "TextAlignVerticalAndroid",
         MapBuilder.of(
             "top", Gravity.TOP,
             "center", Gravity.CENTER_VERTICAL,


### PR DESCRIPTION
- rename Android native prop 'textAlign' to 'textAlignAndroid'
- rename Android native prop 'textAlignVertical' to 'textAlignVerticalAndroid'
- add another 'setTextAlign' in ReactTextInputManager for StyleSheet prop
- add demo