### PR TITLE
FormData can append only string or object with uri

### DIFF
--- a/Libraries/Network/FormData.js
+++ b/Libraries/Network/FormData.js
@@ -71,21 +71,22 @@ class FormData {
 
       /* $FlowIssue(>=0.20.1) #9463928 */
       var headers: Headers = {'content-disposition': contentDisposition};
-      if (typeof value === 'string') {
-        return {string: value, headers, fieldName: name};
-      }
 
       // The body part is a "blob", which in React Native just means
       // an object with a `uri` attribute. Optionally, it can also
       // have a `name` and `type` attribute to specify filename and
       // content type (cf. web Blob interface.)
-      if (typeof value.name === 'string') {
-        headers['content-disposition'] += '; filename="' + value.name + '"';
+      if (typeof value === 'object') {
+        if (typeof value.name === 'string') {
+          headers['content-disposition'] += '; filename="' + value.name + '"';
+        }
+        if (typeof value.type === 'string') {
+          headers['content-type'] = value.type;
+        }
+        return {...value, headers, fieldName: name};
       }
-      if (typeof value.type === 'string') {
-        headers['content-type'] = value.type;
-      }
-      return {...value, headers, fieldName: name};
+      // Cast to string all other values
+      return {string: String(value), headers, fieldName: name};
     });
   }
 }


### PR DESCRIPTION
I fix FormData type checking.

Simple test case:
```js
var fd = new FormData();

// JS Error.
// Because all non-string values threaded as "blob"
fd.append('number', 1);
```