### PR TITLE
[Animated] Animated.multiply and Animated.add to combine animated values

### DIFF
--- a/Libraries/Animated/src/AnimatedImplementation.js
+++ b/Libraries/Animated/src/AnimatedImplementation.js
@@ -840,6 +840,64 @@ class AnimatedInterpolation extends AnimatedWithChildren {
   }
 }
 
+class AnimatedAddition extends AnimatedWithChildren {
+  _a: Animated;
+  _b: Animated;
+
+  constructor(a: Animated, b: Animated) {
+    super();
+    this._a = a;
+    this._b = b;
+  }
+
+  __getValue(): number {
+    return this._a.__getValue() + this._b.__getValue();
+  }
+
+  interpolate(config: InterpolationConfigType): AnimatedInterpolation {
+    return new AnimatedInterpolation(this, Interpolation.create(config));
+  }
+
+  __attach(): void {
+    this._a.__addChild(this);
+    this._b.__addChild(this);
+  }
+
+  __detach(): void {
+    this._a.__removeChild(this);
+    this._b.__removeChild(this);
+  }
+}
+
+class AnimatedMultiplication extends AnimatedWithChildren {
+  _a: Animated;
+  _b: Animated;
+
+  constructor(a: Animated, b: Animated) {
+    super();
+    this._a = a;
+    this._b = b;
+  }
+
+  __getValue(): number {
+    return this._a.__getValue() * this._b.__getValue();
+  }
+
+  interpolate(config: InterpolationConfigType): AnimatedInterpolation {
+    return new AnimatedInterpolation(this, Interpolation.create(config));
+  }
+
+  __attach(): void {
+    this._a.__addChild(this);
+    this._b.__addChild(this);
+  }
+
+  __detach(): void {
+    this._a.__removeChild(this);
+    this._b.__removeChild(this);
+  }
+}
+
 class AnimatedTransform extends AnimatedWithChildren {
   _transforms: Array<Object>;
 
@@ -1155,6 +1213,20 @@ class AnimatedTracking extends Animated {
 type CompositeAnimation = {
   start: (callback?: ?EndCallback) => void;
   stop: () => void;
+};
+
+var add = function(
+  a: Animated,
+  b: Animated
+): AnimatedAddition {
+  return new AnimatedAddition(a, b);
+};
+
+var multiply = function(
+  a: Animated,
+  b: Animated
+): AnimatedMultiplication {
+  return new AnimatedMultiplication(a, b);
 };
 
 var maybeVectorAnim = function(
@@ -1516,6 +1588,17 @@ module.exports = {
    * create fluid motions as the `toValue` updates, and can be chained together.
    */
   spring,
+
+  /**
+   * Creates a new Animated value composed from two Animated values added
+   * together.
+   */
+  add,
+  /**
+   * Creates a new Animated value composed from two Animated values multiplied
+   * together.
+   */
+  multiply,
 
   /**
    * Starts an animation after the given delay.


### PR DESCRIPTION
This PR was created in response to feedback from an older PR: https://github.com/facebook/react-native/pull/2045

The `.interpolate()` API of Animated values is quite effective to accomplish transformations based on a single animated value, but currently there is a class of animations that is impossible: animations being driven by more than one value.

Usage would be like the following:

```js
getInitialState: function() {
  return {
    panY: new Animated.Value(0),
    offset: new Animated.Value(0),
  };
}
```

```js
var scale = Animated.add(panY, offset).interpolate({
  inputRange: [...],
  outputRange: [...],
});
```


I have a real use case for this, and I cannot think of any way to accomplish what I need without an API like this.

The animation I am trying to accomplish is I have a PanResponder being used to detect both x and y panning. The y-axis panning drives a 3d sroll-like animation (which we can call `panY`), and the x-axis panning is driving a "swipe-to-remove" animation (which we can call `panX`).

![](http://i.giphy.com/3o85xvIXjOMXbfoTzq.gif)

The problem comes in to play when we try to implement the "swipe to remove" functionality. We need to smoothly transition from a list of N elements to a list of N-1 elements. Right now the position and scale of an item in the list is determined by the `panY` and `panX` animation values. Once someone "swipes" an item off the list, I want to initialize a sequence of animations based on the index (which we will call `i`) of the card. Ideally, every card with `index > i` has it's position animate smoothly (probably using `Animated.spring` from it's current position to the position of the previous card. At the end of this animation, the card at index `i` will actually be removed from the list.

Currently, I cannot see this being implemented any other way other than having a separate `Animated.Value` from `panY` that is added to only the cards with `index > i`.

The implementation of this PR is to add two more subclasses that are similar to `AnimatedInterpolation`, one  for adding two animated values together, and the other for multiplying. I believe this is done in a way which could later still be compatible with bringing animations over to a higher-priority or native thread, which I know is a concern when adding animated APIs.

I'm also totally open to alternative implementations or thoughts on how this could be done differently/better!