### PR TITLE
Don't add the tab character to the text of an iOS text field when the tab key is pressed

### DIFF
--- a/Libraries/Text/RCTTextFieldManager.m
+++ b/Libraries/Text/RCTTextFieldManager.m
@@ -37,7 +37,9 @@ RCT_EXPORT_MODULE()
     [textField sendKeyValueForString:string];
   }
 
-  if (textField.maxLength == nil || [string isEqualToString:@"\n"]) {  // Make sure forms can be submitted via return
+  if ([string isEqualToString:@"\t"]) { // Don't write the tab character into the text field value
+    return NO;
+  } else if (textField.maxLength == nil || [string isEqualToString:@"\n"]) {  // Make sure forms can be submitted via return
     return YES;
   }
   NSUInteger allowedLength = textField.maxLength.integerValue - textField.text.length + range.length;


### PR DESCRIPTION
This change is for platform parity in TextInput. Fixes an inconsistency where Android text fields ignore the tab key, while iOS text fields add the tab character to their value and dispatch a Text Change event.

Test Plan: In a TextInput running on an iOS device, press the tab key from an external keyboard (e.g. simulator's soft keyboard). Observe that no tab character is added to the value of the text field.

This is my first pull to this repository. Completed a CLA for username terribleben.