### PR TITLE
Fix asset httpServerLocation on Windows.

### DIFF
--- a/packager/react-packager/src/Bundler/index.js
+++ b/packager/react-packager/src/Bundler/index.js
@@ -360,6 +360,12 @@ class Bundler {
 
   generateAssetModule(bundle, module, platform = null) {
     const relPath = getPathRelativeToRoot(this._projectRoots, module.path);
+    var assetUrlPath = path.join('/assets', path.dirname(relPath));
+    
+    // On Windows, change backslashes to slashes to get proper URL path from file path.
+    if (path.sep === '\\') {
+      assetUrlPath = assetUrlPath.replace(/\\/g, '/');
+    }
 
     return Promise.all([
       sizeOf(module.path),
@@ -370,7 +376,7 @@ class Bundler {
       const img = {
         __packager_asset: true,
         fileSystemLocation: path.dirname(module.path),
-        httpServerLocation: path.join('/assets', path.dirname(relPath)),
+        httpServerLocation: assetUrlPath,
         width: dimensions.width / module.resolution,
         height: dimensions.height / module.resolution,
         scales: assetData.scales,


### PR DESCRIPTION
Functions from the path module return paths with the native file system path separator. generateAssetModule is using path.join and path.dirname to generate httpServerLocation.  That means that on Windows systems, the generated URL path has backslashes rather than forward slashes which breaks the app's ability to retrieve image assets using require('./image.png').  This change fixes this by checking path.sep and replacing backslashes with slashes on systems that require it.