### PR TITLE
add UIManagerModule.getViewByTag

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeViewHierarchyManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeViewHierarchyManager.java
@@ -555,6 +555,10 @@ import com.facebook.react.touch.JSResponderHandler;
     popupMenu.show();
   }
 
+    public View getViewByTag(int reactTag) {
+      return mTagsToViews.get(reactTag);
+    }
+
   private static class PopupMenuCallbackHandler implements PopupMenu.OnMenuItemClickListener,
       PopupMenu.OnDismissListener {
 

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeViewHierarchyOptimizer.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeViewHierarchyOptimizer.java
@@ -12,6 +12,7 @@ package com.facebook.react.uimanager;
 import javax.annotation.Nullable;
 
 import android.util.SparseBooleanArray;
+import android.view.View;
 
 import com.facebook.infer.annotation.Assertions;
 import com.facebook.react.bridge.ReadableMapKeySetIterator;
@@ -432,4 +433,8 @@ public class NativeViewHierarchyOptimizer {
     }
     return true;
   }
+
+    public View getViewByTag(int reactTag) {
+      return mUIViewOperationQueue.getViewByTag(reactTag);
+    }
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIImplementation.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIImplementation.java
@@ -627,4 +627,9 @@ public class UIImplementation {
     }
     cssNode.markUpdateSeen();
   }
+
+  public View getViewByTag(int reactTag) {
+    assertViewExists(reactTag, "getNode");
+    return mNativeViewHierarchyOptimizer.getViewByTag(reactTag);
+  }
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModule.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.Map;
 
 import android.util.DisplayMetrics;
+import android.view.View;
 
 import com.facebook.csslayout.CSSLayoutContext;
 import com.facebook.infer.annotation.Assertions;
@@ -135,6 +136,10 @@ public class UIManagerModule extends ReactContextBaseJavaModule implements
       Systrace.endSection(Systrace.TRACE_TAG_REACT_JAVA_BRIDGE);
     }
   }
+
+    public View getViewByTag (int reactTag) {
+      return mUIImplementation.getViewByTag(reactTag);
+    }
 
   /**
    * Registers a new root view. JS can use the returned tag with manageChildren to add/remove

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIViewOperationQueue.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIViewOperationQueue.java
@@ -9,6 +9,8 @@
 
 package com.facebook.react.uimanager;
 
+import android.view.View;
+
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
 
@@ -677,5 +679,10 @@ public class UIViewOperationQueue {
       ReactChoreographer.getInstance().postFrameCallback(
           ReactChoreographer.CallbackType.DISPATCH_UI, this);
     }
+  }
+
+
+  public View getViewByTag(int reactTag) {
+    return mNativeViewHierarchyManager.getViewByTag(reactTag);
   }
 }


### PR DESCRIPTION
Fixes #4429 

Usage Example:

```java
UIManagerModule uiManager = getReactApplicationContext().getNativeModule(UIManagerModule.class);
View view = uiManager.getViewByTag(tag);
```

---

myself, I need it for gl-react-native that exposes a `capture()` method. Here is some of my code:

```java
    @ReactMethod
    public void capture (int tag, Callback callback) {
        UIManagerModule uiManager = getReactApplicationContext().getNativeModule(UIManagerModule.class);
        View view = uiManager.getViewByTag(tag);
        if (view != null && view instanceof GLCanvas) {
            ((GLCanvas)view).capture(callback);
        }
        else {
            throw new Error("Expecting a GLCanvas, got: "+view);
        }
    }
```

and on JS side

```javascript
  captureFrame (cb) {
    GLCanvasManager.capture(
      React.findNodeHandle(this.refs.native),
      (error, frame) => {
        if (error) console.error(error); // eslint-disable-line no-console
        else cb(frame);
      });
  }
```