### PR TITLE
Added support for styling the PickerIOS

### DIFF
--- a/Libraries/Picker/PickerIOS.ios.js
+++ b/Libraries/Picker/PickerIOS.ios.js
@@ -17,6 +17,7 @@ var React = require('React');
 var ReactChildren = require('ReactChildren');
 var RCTPickerIOSConsts = require('NativeModules').UIManager.RCTPicker.Constants;
 var StyleSheet = require('StyleSheet');
+var StyleSheetRegistry = require('StyleSheetRegistry');
 var View = require('View');
 
 var requireNativeComponent = require('requireNativeComponent');
@@ -53,15 +54,38 @@ var PickerIOS = React.createClass({
     return {selectedIndex, items};
   },
 
+  _getItemsStyleFromProps: function(props){    
+     var styleFromProps;    
+     var itemsStyle;    
+     if(typeof props.style === 'number') {    
+       styleFromProps = StyleSheetRegistry.getStyleByID(props.style);   
+     } else if(typeof  props.style === 'object') {    
+       styleFromProps = props.style;    
+     } else {   
+       styleFromProps = {}    
+     }    
+     //default styles for items   
+     itemsStyle = {   
+       fontSize: styleFromProps.fontSize || 20,   
+       color: styleFromProps.color || '#000000',    
+       textAlign: styleFromProps.textAlign || 'center'    
+     };   
+     return itemsStyle;   
+   },
+
   render: function() {
+    var itemsStyle = this._getItemsStyleFromProps(this.props);
     return (
-      <View style={this.props.style}>
+      <View>
         <RCTPickerIOS
           ref={PICKER}
-          style={styles.pickerIOS}
+          style={[styles.pickerIOS, this.props.style]}
           items={this.state.items}
           selectedIndex={this.state.selectedIndex}
           onChange={this._onChange}
+          fontSize={itemsStyle.fontSize}
+          color={itemsStyle.color}
+          textAlign={itemsStyle.textAlign}
         />
       </View>
     );

--- a/React/Views/RCTPicker.h
+++ b/React/Views/RCTPicker.h
@@ -16,5 +16,8 @@
 @property (nonatomic, copy) NSArray<NSDictionary *> *items;
 @property (nonatomic, assign) NSInteger selectedIndex;
 @property (nonatomic, copy) RCTBubblingEventBlock onChange;
+@property (nonatomic, assign) CGFloat fontSize;
+@property (nonatomic, copy) UIColor *color;
+@property (nonatomic, assign) NSTextAlignment textAlign;
 
 @end

--- a/React/Views/RCTPicker.h
+++ b/React/Views/RCTPicker.h
@@ -17,7 +17,7 @@
 @property (nonatomic, assign) NSInteger selectedIndex;
 @property (nonatomic, copy) RCTBubblingEventBlock onChange;
 @property (nonatomic, assign) CGFloat fontSize;
-@property (nonatomic, copy) UIColor *color;
+@property (nonatomic, strong) UIColor *color;
 @property (nonatomic, assign) NSTextAlignment textAlign;
 
 @end

--- a/React/Views/RCTPicker.m
+++ b/React/Views/RCTPicker.m
@@ -69,10 +69,20 @@ numberOfRowsInComponent:(__unused NSInteger)component
   return [self itemForRow:row][@"value"];
 }
 
-- (NSString *)pickerView:(__unused UIPickerView *)pickerView
-             titleForRow:(NSInteger)row forComponent:(__unused NSInteger)component
-{
-  return [self itemForRow:row][@"label"];
+- (UIView *)pickerView:(UIPickerView *)pickerView viewForRow:(NSInteger)row
+ forComponent:(NSInteger)component reusingView:(UIView *)view {
+
+  UILabel *retval = (UILabel*)view;
+  if (!retval) {
+      retval = [[UILabel alloc] initWithFrame:CGRectMake(0.0f, 0.0f, [pickerView rowSizeForComponent:component].width, [pickerView rowSizeForComponent:component].height)];
+  }
+
+  retval.font = [UIFont systemFontOfSize:[self fontSize]];
+  retval.textColor = [self color];
+  retval.textAlignment = [self textAlign];
+  retval.text = [self itemForRow:row][@"label"];
+
+  return retval;
 }
 
 - (void)pickerView:(__unused UIPickerView *)pickerView

--- a/React/Views/RCTPickerManager.m
+++ b/React/Views/RCTPickerManager.m
@@ -25,6 +25,9 @@ RCT_EXPORT_MODULE()
 RCT_EXPORT_VIEW_PROPERTY(items, NSDictionaryArray)
 RCT_EXPORT_VIEW_PROPERTY(selectedIndex, NSInteger)
 RCT_EXPORT_VIEW_PROPERTY(onChange, RCTBubblingEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(fontSize, CGFloat)
+RCT_EXPORT_VIEW_PROPERTY(color, UIColor)
+RCT_EXPORT_VIEW_PROPERTY(textAlign, NSTextAlignment)
 
 - (NSDictionary<NSString *, id> *)constantsToExport
 {


### PR DESCRIPTION
 - PickerIOS accepts now a new prop: style
 - this prop modifies the native style of the RCTPicker allowing to modify the font size of the items (fontSize), color of the items (color, only 6 char HEX values for now) and alignment of the items (textAlign)