### PR TITLE
Add html content to WebView event callback

### DIFF
--- a/React/Views/RCTWebView.m
+++ b/React/Views/RCTWebView.m
@@ -126,6 +126,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
     @"title": [_webView stringByEvaluatingJavaScriptFromString:@"document.title"],
     @"canGoBack": @(_webView.canGoBack),
     @"canGoForward" : @(_webView.canGoForward),
+    @"html": [_webView stringByEvaluatingJavaScriptFromString:@"document.body.innerHTML"],
   }];
 
   return event;


### PR DESCRIPTION
I needed a way to get the html body from a `WebView` in my app.
It's accessible in the `onNavigationStateChange` callback. 
```
   onNavigationStateChange(navState) {

     // get html content
     var html = navState.html;
   }
```

I'm using this in my own branch. I figured I'd submit a pull request in case this might be helpful to others. 

Thoughts?

Also: This is my first PR to a Facebook repo. I've filled out the CLA for my Github email jpoliachik@gmail.com 