### PR TITLE
[Babel] Support plugins that conform to ES6 modules

### DIFF
--- a/packager/transformer.js
+++ b/packager/transformer.js
@@ -48,6 +48,7 @@ function transform(src, filename, options) {
     // Only resolve the plugin if it's a string reference.
     if (typeof plugin[0] === 'string') {
       plugin[0] = require(`babel-plugin-${plugin[0]}`);
+      plugin[0] = plugin[0].__esModule ? plugin[0].default : plugin[0];
     }
     return plugin;
   });


### PR DESCRIPTION
ES6 modules export an object with a property called `default`. See Babel itself for how this is handled: https://github.com/babel/babel/commit/b5b7e346a04c99da8793e2c65cc3b3c7c720253d

Test Plan: Used a Babel 6 plugin that is implemented as an ES6 module.