### PR TITLE
Load assets from same folder as JSbundle (Android)

### DIFF
--- a/Libraries/Image/__tests__/resolveAssetSource-test.js
+++ b/Libraries/Image/__tests__/resolveAssetSource-test.js
@@ -10,7 +10,8 @@
 
 jest
   .dontMock('AssetRegistry')
-  .dontMock('../resolveAssetSource');
+  .dontMock('../resolveAssetSource')
+  .dontMock('../../../local-cli/bundle/getAssetDestPathAndroid');
 
 var AssetRegistry = require('AssetRegistry');
 var Platform = require('Platform');
@@ -182,7 +183,7 @@ describe('resolveAssetSource', () => {
         __packager_asset: true,
         width: 100,
         height: 200,
-        uri: 'file:///sdcard/Path/To/Simulator/assets/AwesomeModule/Subdir/!@Logo#1_€.png',
+        uri: 'file:///sdcard/Path/To/Simulator/drawable-mdpi/awesomemodule_subdir_logo1_.png',
         scale: 1,
       });
     });

--- a/Libraries/Image/__tests__/resolveAssetSource-test.js
+++ b/Libraries/Image/__tests__/resolveAssetSource-test.js
@@ -11,7 +11,7 @@
 jest
   .dontMock('AssetRegistry')
   .dontMock('../resolveAssetSource')
-  .dontMock('../../../local-cli/bundle/getAssetDestPathAndroid');
+  .dontMock('../../../local-cli/bundle/assetPathUtils');
 
 var AssetRegistry = require('AssetRegistry');
 var Platform = require('Platform');

--- a/Libraries/Image/__tests__/resolveAssetSource-test.js
+++ b/Libraries/Image/__tests__/resolveAssetSource-test.js
@@ -132,10 +132,10 @@ describe('resolveAssetSource', () => {
     });
   });
 
-  describe('bundle was loaded from file on Android', () => {
+  describe('bundle was loaded from assets on Android', () => {
     beforeEach(() => {
       NativeModules.SourceCode.scriptURL =
-        'file:///Path/To/Simulator/main.bundle';
+        'assets://Path/To/Simulator/main.bundle';
       Platform.OS = 'android';
     });
 
@@ -155,6 +155,34 @@ describe('resolveAssetSource', () => {
         width: 100,
         height: 200,
         uri: 'awesomemodule_subdir_logo1_',
+        scale: 1,
+      });
+    });
+  });
+  
+  describe('bundle was loaded from file on Android', () => {
+    beforeEach(() => {
+      NativeModules.SourceCode.scriptURL =
+        '/sdcard/Path/To/Simulator/main.bundle';
+      Platform.OS = 'android';
+    });
+
+    it('uses pre-packed image', () => {
+      expectResolvesAsset({
+        __packager_asset: true,
+        fileSystemLocation: '/root/app/module/a',
+        httpServerLocation: '/assets/AwesomeModule/Subdir',
+        width: 100,
+        height: 200,
+        scales: [1],
+        hash: '5b6f00f',
+        name: '!@Logo#1_€',
+        type: 'png',
+      }, {
+        __packager_asset: true,
+        width: 100,
+        height: 200,
+        uri: 'file:///sdcard/Path/To/Simulator/assets/AwesomeModule/Subdir/!@Logo#1_€.png',
         scale: 1,
       });
     });

--- a/Libraries/Image/__tests__/resolveAssetSource-test.js
+++ b/Libraries/Image/__tests__/resolveAssetSource-test.js
@@ -164,7 +164,7 @@ describe('resolveAssetSource', () => {
   describe('bundle was loaded from file on Android', () => {
     beforeEach(() => {
       NativeModules.SourceCode.scriptURL =
-        '/sdcard/Path/To/Simulator/main.bundle';
+        'file:///sdcard/Path/To/Simulator/main.bundle';
       Platform.OS = 'android';
     });
 

--- a/Libraries/Image/resolveAssetSource.js
+++ b/Libraries/Image/resolveAssetSource.js
@@ -75,11 +75,11 @@ function getResourceIdentifier(asset) {
  */
 function getPathInArchive(asset) {
   var offlinePath = getOfflinePath();
-  if (Platform.OS === 'ios' || offlinePath) {
-    return offlinePath + getScaledAssetPath(asset);
-  } else {
+  if (platform === 'android' && !offlinePath) {
     // In Android, image assets are belong to the drawables.
     return getResourceIdentifier(asset);
+  } else {
+    return offlinePath + getScaledAssetPath(asset);
   }
 }
 

--- a/Libraries/Image/resolveAssetSource.js
+++ b/Libraries/Image/resolveAssetSource.js
@@ -68,7 +68,7 @@ function getPathInArchive(asset) {
     if (match) {
       // scriptURL has no scheme, 
       // E.g. /sdcard/path/to/file.jsbundle  or /data/data/path/to/file.jsbundle
-      return 'file://' + match[0] + getBasePath(asset) + '/' + asset.name;
+      return 'file://' + match[0] + getScaledAssetPath(asset);
     } else {
       // scriptURL has a scheme, E.g. assets://file.jsbundle 
       var assetDir = getBasePath(asset);

--- a/Libraries/Image/resolveAssetSource.js
+++ b/Libraries/Image/resolveAssetSource.js
@@ -68,7 +68,7 @@ function getPathInArchive(asset) {
     if (match) {
       // scriptURL has no scheme, 
       // E.g. /sdcard/path/to/file.jsbundle  or /data/data/path/to/file.jsbundle
-      return 'file://' + match[0] + asset.name;
+      return 'file://' + match[0] + getBasePath(asset) + '/' + asset.name;
     } else {
       // scriptURL has a scheme, E.g. assets://file.jsbundle 
       var assetDir = getBasePath(asset);

--- a/Libraries/Image/resolveAssetSource.js
+++ b/Libraries/Image/resolveAssetSource.js
@@ -67,7 +67,7 @@ function getPathInArchive(asset) {
   if (Platform.OS === 'android') {
     if (offlinePath) {
       // E.g. 'file:///sdcard/AwesomeModule/drawable-mdpi/icon.png'
-      return "file://" + offlinePath + getAssetPathInDrawableFolder(asset);
+      return 'file://' + offlinePath + getAssetPathInDrawableFolder(asset);
     }
     // E.g. 'assets_awesomemodule_icon'
     // The Android resource system picks the correct scale.

--- a/Libraries/Image/resolveAssetSource.js
+++ b/Libraries/Image/resolveAssetSource.js
@@ -63,14 +63,23 @@ function getOfflinePath() {
  */
 function getPathInArchive(asset) {
   if (Platform.OS === 'android') {
-    var assetDir = getBasePath(asset);
-    // E.g. 'assets_awesomemodule_icon'
-    // The Android resource system picks the correct scale.
-    return (assetDir + '/' + asset.name)
-      .toLowerCase()
-      .replace(/\//g, '_')           // Encode folder structure in file name
-      .replace(/([^a-z0-9_])/g, '')  // Remove illegal chars
-      .replace(/^assets_/, '');      // Remove "assets_" prefix
+    var scriptURL = SourceCode.scriptURL;
+    var match = scriptURL && scriptURL.match(/^\/.*\//);
+    if (match) {
+      // scriptURL has no scheme, 
+      // E.g. /sdcard/path/to/file.jsbundle  or /data/data/path/to/file.jsbundle
+      return 'file://' + match[0] + getScaledAssetPath(asset);
+    } else {
+      // scriptURL has a scheme, E.g. assets://file.jsbundle 
+      var assetDir = getBasePath(asset);
+      // E.g. 'assets_awesomemodule_icon'
+      // The Android resource system picks the correct scale.
+      return (assetDir + '/' + asset.name)
+        .toLowerCase()
+        .replace(/\//g, '_')           // Encode folder structure in file name
+        .replace(/([^a-z0-9_])/g, '')  // Remove illegal chars
+        .replace(/^assets_/, '');      // Remove "assets_" prefix
+    }
   } else {
     // E.g. 'assets/AwesomeModule/icon@2x.png'
     return getOfflinePath() + getScaledAssetPath(asset);

--- a/Libraries/Image/resolveAssetSource.js
+++ b/Libraries/Image/resolveAssetSource.js
@@ -47,9 +47,9 @@ function getDevServerURL() {
 function getOfflinePath() {
   if (_offlinePath === undefined) {
     var scriptURL = SourceCode.scriptURL;
-    var match = scriptURL && scriptURL.match(/^file:\/\/(\/.*\/)/);
+    var match = scriptURL && scriptURL.match(/^(file:\/\/)?(\/.*\/)/);
     if (match) {
-      _offlinePath = match[1];
+      _offlinePath = (Platform.OS === 'android' ? 'file://' : '') + match[2];
     } else {
       _offlinePath = '';
     }
@@ -58,31 +58,26 @@ function getOfflinePath() {
   return _offlinePath;
 }
 
+function getResourceIdentifier(asset) {
+  var assetDir = getBasePath(asset);
+  // E.g. 'assets_awesomemodule_icon'
+  // The Android resource system picks the correct scale.
+  return (assetDir + '/' + asset.name)
+    .toLowerCase()
+    .replace(/\//g, '_')           // Encode folder structure in file name
+    .replace(/([^a-z0-9_])/g, '')  // Remove illegal chars
+    .replace(/^assets_/, '');      // Remove "assets_" prefix
+}
+
 /**
  * Returns the path at which the asset can be found in the archive
  */
 function getPathInArchive(asset) {
-  if (Platform.OS === 'android') {
-    var scriptURL = SourceCode.scriptURL;
-    var match = scriptURL && scriptURL.match(/^\/.*\//);
-    if (match) {
-      // scriptURL has no scheme, 
-      // E.g. /sdcard/path/to/file.jsbundle  or /data/data/path/to/file.jsbundle
-      return 'file://' + match[0] + getScaledAssetPath(asset);
-    } else {
-      // scriptURL has a scheme, E.g. assets://file.jsbundle 
-      var assetDir = getBasePath(asset);
-      // E.g. 'assets_awesomemodule_icon'
-      // The Android resource system picks the correct scale.
-      return (assetDir + '/' + asset.name)
-        .toLowerCase()
-        .replace(/\//g, '_')           // Encode folder structure in file name
-        .replace(/([^a-z0-9_])/g, '')  // Remove illegal chars
-        .replace(/^assets_/, '');      // Remove "assets_" prefix
-    }
+  var offlinePath = getOfflinePath();
+  if (Platform.OS === 'ios' || offlinePath) {
+    return offlinePath + getScaledAssetPath(asset);
   } else {
-    // E.g. 'assets/AwesomeModule/icon@2x.png'
-    return getOfflinePath() + getScaledAssetPath(asset);
+    return getResourceIdentifier(asset);
   }
 }
 

--- a/Libraries/Image/resolveAssetSource.js
+++ b/Libraries/Image/resolveAssetSource.js
@@ -82,7 +82,8 @@ function getPathOnDevserver(devServerUrl, asset) {
 }
 
 /**
- * Returns a path like 'assets/AwesomeModule/icon@2x.png'
+ * Returns a path like 'assets/AwesomeModule/icon@2x.png' on iOS
+ * or 'drawable_ldpi/awesomemodule_icon.png' on Android
  */
 function getScaledAssetPath(asset) {
   var scale = pickScale(asset.scales, PixelRatio.get());

--- a/Libraries/Image/resolveAssetSource.js
+++ b/Libraries/Image/resolveAssetSource.js
@@ -25,6 +25,7 @@ var AssetRegistry = require('AssetRegistry');
 var PixelRatio = require('PixelRatio');
 var Platform = require('Platform');
 var SourceCode = require('NativeModules').SourceCode;
+var getAssetDestPathAndroid = require('../../local-cli/bundle/getAssetDestPathAndroid');
 
 var _serverURL, _offlinePath;
 
@@ -77,6 +78,7 @@ function getPathInArchive(asset) {
   if (Platform.OS === 'ios' || offlinePath) {
     return offlinePath + getScaledAssetPath(asset);
   } else {
+    // In Android, image assets are belong to the drawables.
     return getResourceIdentifier(asset);
   }
 }
@@ -108,9 +110,13 @@ function getBasePath(asset) {
  */
 function getScaledAssetPath(asset) {
   var scale = pickScale(asset.scales, PixelRatio.get());
-  var scaleSuffix = scale === 1 ? '' : '@' + scale + 'x';
-  var assetDir = getBasePath(asset);
-  return assetDir + '/' + asset.name + scaleSuffix + '.' + asset.type;
+  if (Platform.OS === 'ios') {
+    var scaleSuffix = scale === 1 ? '' : '@' + scale + 'x';
+    var assetDir = getBasePath(asset);
+    return assetDir + '/' + asset.name + scaleSuffix + '.' + asset.type;
+  } else {
+    return getAssetDestPathAndroid(asset, scale);
+  }
 }
 
 function pickScale(scales: Array<number>, deviceScale: number): number {

--- a/Libraries/Image/resolveAssetSource.js
+++ b/Libraries/Image/resolveAssetSource.js
@@ -68,7 +68,7 @@ function getPathInArchive(asset) {
     if (match) {
       // scriptURL has no scheme, 
       // E.g. /sdcard/path/to/file.jsbundle  or /data/data/path/to/file.jsbundle
-      return 'file://' + match[0] + getScaledAssetPath(asset);
+      return 'file://' + match[0] + asset.name;
     } else {
       // scriptURL has a scheme, E.g. assets://file.jsbundle 
       var assetDir = getBasePath(asset);

--- a/Libraries/Image/resolveAssetSource.js
+++ b/Libraries/Image/resolveAssetSource.js
@@ -25,7 +25,7 @@ var AssetRegistry = require('AssetRegistry');
 var PixelRatio = require('PixelRatio');
 var Platform = require('Platform');
 var SourceCode = require('NativeModules').SourceCode;
-var getAssetDestPathAndroid = require('../../local-cli/bundle/getAssetDestPathAndroid');
+var assetPathUtils = require('../../local-cli/bundle/assetPathUtils');
 
 var _serverURL, _offlinePath;
 
@@ -59,25 +59,14 @@ function getOfflinePath() {
   return _offlinePath;
 }
 
-function getResourceIdentifier(asset) {
-  var assetDir = getBasePath(asset);
-  // E.g. 'assets_awesomemodule_icon'
-  // The Android resource system picks the correct scale.
-  return (assetDir + '/' + asset.name)
-    .toLowerCase()
-    .replace(/\//g, '_')           // Encode folder structure in file name
-    .replace(/([^a-z0-9_])/g, '')  // Remove illegal chars
-    .replace(/^assets_/, '');      // Remove "assets_" prefix
-}
-
 /**
  * Returns the path at which the asset can be found in the archive
  */
 function getPathInArchive(asset) {
   var offlinePath = getOfflinePath();
-  if (platform === 'android' && !offlinePath) {
+  if (Platform.OS === 'android' && !offlinePath) {
     // In Android, image assets are belong to the drawables.
-    return getResourceIdentifier(asset);
+    return assetPathUtils.getAndroidResourceIdentifier(asset);
   } else {
     return offlinePath + getScaledAssetPath(asset);
   }
@@ -93,29 +82,18 @@ function getPathOnDevserver(devServerUrl, asset) {
 }
 
 /**
- * Returns a path like 'assets/AwesomeModule'
- */
-function getBasePath(asset) {
-  // TODO(frantic): currently httpServerLocation is used both as
-  // path in http URL and path within IPA. Should we have zipArchiveLocation?
-  var path = asset.httpServerLocation;
-  if (path[0] === '/') {
-    path = path.substr(1);
-  }
-  return path;
-}
-
-/**
  * Returns a path like 'assets/AwesomeModule/icon@2x.png'
  */
 function getScaledAssetPath(asset) {
   var scale = pickScale(asset.scales, PixelRatio.get());
   if (Platform.OS === 'ios') {
     var scaleSuffix = scale === 1 ? '' : '@' + scale + 'x';
-    var assetDir = getBasePath(asset);
+    var assetDir = assetPathUtils.getBasePath(asset);
     return assetDir + '/' + asset.name + scaleSuffix + '.' + asset.type;
   } else {
-    return getAssetDestPathAndroid(asset, scale);
+    const androidFolder = assetPathUtils.getAndroidDrawableFolderName(asset, scale);
+    const fileName =  assetPathUtils.getAndroidResourceIdentifier(asset);
+    return androidFolder + '/' + fileName + '.' + asset.type;
   }
 }
 

--- a/Libraries/Image/resolveAssetSource.js
+++ b/Libraries/Image/resolveAssetSource.js
@@ -102,8 +102,8 @@ function getScaledAssetPath(asset) {
  */
 function getAssetPathInDrawableFolder(asset) {
   var scale = pickScale(asset.scales, PixelRatio.get());
-  const drawbleFolder = assetPathUtils.getAndroidDrawableFolderName(asset, scale);
-  const fileName =  assetPathUtils.getAndroidResourceIdentifier(asset);
+  var drawbleFolder = assetPathUtils.getAndroidDrawableFolderName(asset, scale);
+  var fileName =  assetPathUtils.getAndroidResourceIdentifier(asset);
   return drawbleFolder + '/' + fileName + '.' + asset.type;
 }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/JSBundleLoader.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/JSBundleLoader.java
@@ -37,7 +37,7 @@ public abstract class JSBundleLoader {
 
       @Override
       public String getSourceUrl() {
-        return fileName;
+        return (fileName.startsWith("assets://") ? "" : "file://") + fileName;
       }
     };
   }

--- a/local-cli/bundle/__tests__/getAssetDestPathAndroid-test.js
+++ b/local-cli/bundle/__tests__/getAssetDestPathAndroid-test.js
@@ -8,7 +8,9 @@
  */
 'use strict';
 
-jest.dontMock('../getAssetDestPathAndroid');
+jest
+  .dontMock('../getAssetDestPathAndroid')
+  .dontMock('../assetPathUtils');
 
 const getAssetDestPathAndroid = require('../getAssetDestPathAndroid');
 

--- a/local-cli/bundle/assetPathUtils.js
+++ b/local-cli/bundle/assetPathUtils.js
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+'use strict';
+
+function getAndroidAssetSuffix(scale) {
+  switch (scale) {
+    case 0.75: return 'ldpi';
+    case 1: return 'mdpi';
+    case 1.5: return 'hdpi';
+    case 2: return 'xhdpi';
+    case 3: return 'xxhdpi';
+    case 4: return 'xxxhdpi';
+  }
+}
+
+function getAndroidDrawableFolderName(asset, scale) {
+  var suffix = getAndroidAssetSuffix(scale);
+  if (!suffix) {
+    throw new Error(
+      'Don\'t know which android drawable suffix to use for asset: ' +
+      JSON.stringify(asset)
+    );
+  }
+  const androidFolder = 'drawable-' + suffix;
+  return androidFolder;
+}
+
+function getAndroidResourceIdentifier(asset) {
+  var folderPath = getBasePath(asset);
+  const resourceIdentifier = (folderPath + '/' + asset.name)
+    .toLowerCase()
+    .replace(/\//g, '_')           // Encode folder structure in file name
+    .replace(/([^a-z0-9_])/g, '')  // Remove illegal chars
+    .replace(/^assets_/, '');      // Remove "assets_" prefix
+  return resourceIdentifier;
+}
+
+function getBasePath(asset) {
+  var basePath = asset.httpServerLocation;
+  if (basePath[0] === '/') {
+    basePath = basePath.substr(1);
+  }
+  return basePath;
+}
+
+module.exports = {
+  getAndroidAssetSuffix: getAndroidAssetSuffix,
+  getAndroidDrawableFolderName: getAndroidDrawableFolderName,
+  getAndroidResourceIdentifier: getAndroidResourceIdentifier,
+  getBasePath: getBasePath
+};

--- a/local-cli/bundle/assetPathUtils.js
+++ b/local-cli/bundle/assetPathUtils.js
@@ -33,12 +33,11 @@ function getAndroidDrawableFolderName(asset, scale) {
 
 function getAndroidResourceIdentifier(asset) {
   var folderPath = getBasePath(asset);
-  const resourceIdentifier = (folderPath + '/' + asset.name)
+  return (folderPath + '/' + asset.name)
     .toLowerCase()
     .replace(/\//g, '_')           // Encode folder structure in file name
     .replace(/([^a-z0-9_])/g, '')  // Remove illegal chars
     .replace(/^assets_/, '');      // Remove "assets_" prefix
-  return resourceIdentifier;
 }
 
 function getBasePath(asset) {

--- a/local-cli/bundle/getAssetDestPathAndroid.js
+++ b/local-cli/bundle/getAssetDestPathAndroid.js
@@ -9,34 +9,11 @@
 'use strict';
 
 const path = require('path');
-
-function getAndroidAssetSuffix(scale) {
-  switch (scale) {
-    case 0.75: return 'ldpi';
-    case 1: return 'mdpi';
-    case 1.5: return 'hdpi';
-    case 2: return 'xhdpi';
-    case 3: return 'xxhdpi';
-    case 4: return 'xxxhdpi';
-  }
-}
+const assetPathUtils = require('./assetPathUtils');
 
 function getAssetDestPathAndroid(asset, scale) {
-  var suffix = getAndroidAssetSuffix(scale);
-  if (!suffix) {
-    throw new Error(
-      'Don\'t know which android drawable suffix to use for asset: ' +
-      JSON.stringify(asset)
-    );
-  }
-  const androidFolder = 'drawable-' + suffix;
-  // TODO: reuse this logic from https://fburl.com/151101135
-  const fileName = (asset.httpServerLocation.substr(1) + '/' + asset.name)
-    .toLowerCase()
-    .replace(/\//g, '_')           // Encode folder structure in file name
-    .replace(/([^a-z0-9_])/g, '')  // Remove illegal chars
-    .replace(/^assets_/, '');      // Remove "assets_" prefix
-
+  const androidFolder = assetPathUtils.getAndroidDrawableFolderName(asset, scale);
+  const fileName =  assetPathUtils.getAndroidResourceIdentifier(asset);
   return path.join(androidFolder, fileName + '.' + asset.type);
 }
 

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "node-fetch": "^1.3.3",
     "opn": "^3.0.2",
     "optimist": "^0.6.1",
+    "path": "^0.12.7",
     "progress": "^1.1.8",
     "promise": "^7.0.4",
     "react-haste": "^0.14.2",

--- a/package.json
+++ b/package.json
@@ -102,7 +102,6 @@
     "node-fetch": "^1.3.3",
     "opn": "^3.0.2",
     "optimist": "^0.6.1",
-    "path": "^0.12.7",
     "progress": "^1.1.8",
     "promise": "^7.0.4",
     "react-haste": "^0.14.2",


### PR DESCRIPTION
https://github.com/facebook/react-native/issues/3679 was only partially fixed as the behaviour only works on iOS. This implements the same behaviour for Android. If the JSBundle was loaded from the assets folder, this will load images from the built-in resources. Else, load the image from the same folder as the JS bundle.

EDIT: For added clarity:

On iOS,
Bundle Location: 'file:///Path/To/Sample.app/main.bundle' 
httpServerLocation: '/assets/module/a/'
Name: 'logo'
type: 'png'
**Resolved Asset location: '/Path/To/Sample.app/assets/module/a/logo.png'**

On Android,
Bundle Location: 'file:///sdcard/Path/To/main.bundle'
httpServerLocation: '/assets/module/a/',
name: 'logo'
type: 'png'
**Resolved Asset location: 'file:///sdcard/Path/To/drawable_mdpi/module_a_logo.png'**