### PR TITLE
Bridge JNI method executeJSCall params should be moduleName/methodName

### DIFF
--- a/ReactAndroid/src/main/jni/react/Bridge.cpp
+++ b/ReactAndroid/src/main/jni/react/Bridge.cpp
@@ -81,8 +81,8 @@ void Bridge::executeApplicationScript(const std::string& script, const std::stri
 }
 
 void Bridge::executeJSCall(
-    const std::string& script,
-    const std::string& sourceURL,
+    const std::string& moduleName,
+    const std::string& methodName,
     const std::vector<folly::dynamic>& arguments) {
   if (*m_destroyed) {
     return;
@@ -90,7 +90,7 @@ void Bridge::executeJSCall(
   #ifdef WITH_FBSYSTRACE
   FbSystraceSection s(TRACE_TAG_REACT_CXX_BRIDGE, "Bridge.executeJSCall");
   #endif
-  m_threadState->executeJSCall(script, sourceURL, arguments);
+  m_threadState->executeJSCall(moduleName, methodName, arguments);
 }
 
 void Bridge::setGlobalVariable(const std::string& propName, const std::string& jsonValue) {


### PR DESCRIPTION
I think that these were named incorrectly, if you look [above to the function that is called by this one](https://github.com/facebook/react-native/blob/master/ReactAndroid/src/main/jni/react/Bridge.cpp#L30-L36) the names are what I would expect. These params must have been copy+pasted [from the function above](https://github.com/facebook/react-native/blob/master/ReactAndroid/src/main/jni/react/Bridge.cpp#L79-L81)