### PR TITLE
Fix bug in Android elevation implementation

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewBackgroundDrawable.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewBackgroundDrawable.java
@@ -138,7 +138,7 @@ import com.facebook.csslayout.Spacing;
               : 0;
       outline.setRoundRect(getBounds(), mBorderRadius + extraRadiusFromBorderWidth);
     } else {
-      super.getOutline(outline);
+      outline.setRect(getBounds());
     }
   }
 


### PR DESCRIPTION
If border radius is not set or is zero, then elevation will not
work properly. This bug seems to have been introduced when the
style in facebook/react-native#4180 was modified slightly to
produce commit b65f1f223488b52963f80a67bb41956103263d27.