### PR TITLE
Fix for flow (https://github.com/facebook/flow/tree/v0.19.0)

### DIFF
--- a/Libraries/CustomComponents/Navigator/Navigation/NavigationContext.js
+++ b/Libraries/CustomComponents/Navigator/Navigation/NavigationContext.js
@@ -36,7 +36,7 @@ var Set = require('Set');
 var emptyFunction = require('emptyFunction');
 var invariant = require('invariant');
 
-import type * as EventSubscription from 'EventSubscription';
+import type EventSubscription from 'EventSubscription';
 
 var {
   AT_TARGET,


### PR DESCRIPTION
From flow release notes (https://github.com/facebook/flow/releases),
> import type * as Foo is now disallowed in favor of import type Foo
