### PR TITLE
[SliderIOS] Add option for both min/max track image.

### DIFF
--- a/Examples/UIExplorer/SliderIOSExample.js
+++ b/Examples/UIExplorer/SliderIOSExample.js
@@ -87,7 +87,25 @@ exports.examples = [
   {
     title: 'Custom thumb image',
     render(): ReactElement {
-      return <SliderExample thumbImage={require('image!uie_thumb_big')} />;
+      return <SliderExample thumbImage={require('./uie_thumb_big.png')} />;
     }
-  }
+  },
+  {
+    title: 'Custom min/max track tint color',
+    render(): ReactElement {
+      return <SliderExample minimumTrackTintColor={'red'} maximumTrackTintColor={'green'} />;
+    }
+  },
+  {
+    title: 'Custom track image',
+    render(): ReactElement {
+      return <SliderExample trackImage={require('image!red_square')} />;
+    }
+  },
+  {
+    title: 'Custom min/max track image',
+    render(): ReactElement {
+      return <SliderExample minimumTrackImage={require('image!red_square')} maximumTrackImage={require('image!blue_square')} />;
+    }
+  },
 ];

--- a/Examples/UIExplorer/UIExplorer/Images.xcassets/Contents.json
+++ b/Examples/UIExplorer/UIExplorer/Images.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/Libraries/Components/SliderIOS/SliderIOS.ios.js
+++ b/Libraries/Components/SliderIOS/SliderIOS.ios.js
@@ -19,6 +19,7 @@ var StyleSheet = require('StyleSheet');
 var View = require('View');
 
 var requireNativeComponent = require('requireNativeComponent');
+var resolveAssetSource = require('resolveAssetSource');
 
 type Event = Object;
 
@@ -78,10 +79,20 @@ var SliderIOS = React.createClass({
      */
     disabled: PropTypes.bool,
 
-   /**
-     * Sets an image for the track. It only supports images that are included as assets
+    /**
+     * Assign a single image for both min/max tracks.
      */
     trackImage: Image.propTypes.source,
+
+    /**
+     * Assigns a minimum track image.
+     */
+    minimumTrackImage: Image.propTypes.source,
+
+    /**
+     * Assigns a maximum track image.
+     */
+    maximumTrackImage: Image.propTypes.source,
 
     /**
      * Sets an image for the thumb. It only supports static images.
@@ -121,10 +132,16 @@ var SliderIOS = React.createClass({
     let {style, ...props} = this.props;
     style = [styles.slider, style];
 
+    let {thumbImage, trackImage, minimumTrackImage, maximumTrackImage} = this.props;
+
     return (
       <RCTSlider
         {...props}
         style={style}
+        thumbImage={thumbImage && resolveAssetSource(thumbImage)}
+        trackImage={trackImage && resolveAssetSource(trackImage)}
+        minimumTrackImage={minimumTrackImage && resolveAssetSource(minimumTrackImage)}
+        maximumTrackImage={maximumTrackImage && resolveAssetSource(maximumTrackImage)}
         onValueChange={onValueChange}
         onSlidingComplete={onSlidingComplete}
       />

--- a/React/Views/RCTSlider.h
+++ b/React/Views/RCTSlider.h
@@ -20,6 +20,9 @@
 @property (nonatomic, assign) float lastValue;
 
 @property (nonatomic, strong) UIImage *trackImage;
+@property (nonatomic, strong) UIImage *minimumTrackImage;
+@property (nonatomic, strong) UIImage *maximumTrackImage;
+
 @property (nonatomic, strong) UIImage *thumbImage;
 
 

--- a/React/Views/RCTSlider.m
+++ b/React/Views/RCTSlider.m
@@ -34,17 +34,33 @@
 
 - (void)setTrackImage:(UIImage *)trackImage
 {
-  if (trackImage != _trackImage) {
-    _trackImage = trackImage;
+  [self setMinimumTrackImage:trackImage forState:UIControlStateNormal];
+  [self setMaximumTrackImage:trackImage forState:UIControlStateNormal];
+}
 
-    CGFloat width = trackImage.size.width;
+- (UIImage *)trackImage
+{
+  return [self thumbImageForState:UIControlStateNormal];
+}
 
-    UIImage *minimumTrackImage = [trackImage resizableImageWithCapInsets:(UIEdgeInsets){0, width, 0, 0}];
-    UIImage *maximumTrackImage = [trackImage resizableImageWithCapInsets:(UIEdgeInsets){0, 0, 0, width}];
+- (void)setMinimumTrackImage:(UIImage *)minimumTrackImage
+{
+  [self setMinimumTrackImage:minimumTrackImage forState:UIControlStateNormal];
+}
 
-    [super setMinimumTrackImage:minimumTrackImage forState:UIControlStateNormal];
-    [super setMaximumTrackImage:maximumTrackImage forState:UIControlStateNormal];
-  }
+- (UIImage *)minimumTrackImage
+{
+  return [self thumbImageForState:UIControlStateNormal];
+}
+
+- (void)setMaximumTrackImage:(UIImage *)maximumTrackImage
+{
+  [self setMaximumTrackImage:maximumTrackImage forState:UIControlStateNormal];
+}
+
+- (UIImage *)maximumTrackImage
+{
+  return [self thumbImageForState:UIControlStateNormal];
 }
 
 - (void)setThumbImage:(UIImage *)thumbImage

--- a/React/Views/RCTSliderManager.m
+++ b/React/Views/RCTSliderManager.m
@@ -77,6 +77,8 @@ static void RCTSendSliderEvent(RCTSlider *sender, BOOL continuous)
 RCT_EXPORT_VIEW_PROPERTY(value, float);
 RCT_EXPORT_VIEW_PROPERTY(step, float);
 RCT_EXPORT_VIEW_PROPERTY(trackImage, UIImage);
+RCT_EXPORT_VIEW_PROPERTY(minimumTrackImage, UIImage);
+RCT_EXPORT_VIEW_PROPERTY(maximumTrackImage, UIImage);
 RCT_EXPORT_VIEW_PROPERTY(minimumValue, float);
 RCT_EXPORT_VIEW_PROPERTY(maximumValue, float);
 RCT_EXPORT_VIEW_PROPERTY(minimumTrackTintColor, UIColor);


### PR DESCRIPTION
This is a followup to PR #3850 but now separates min/max track images into different properties.
Closes #4476 

Add examples for `minimumTrackTintColor`, `maximumTrackTintColor`, `minimumTrackImage`, `maximumTrackImage` to UIExplorer.