### PR TITLE
[Docs] Improve Modal docs describing iOS only support

### DIFF
--- a/Libraries/Modal/Modal.js
+++ b/Libraries/Modal/Modal.js
@@ -31,6 +31,8 @@ var RCTModalHostView = requireNativeComponent('RCTModalHostView', null);
  * Navigator instead of Modal. With a top-level Navigator, you have more control
  * over how to present the modal scene over the rest of your app by using the
  * configureScene property.
+ *
+ * This component is only available in iOS at this time.
  */
 class Modal extends React.Component {
   render(): ?ReactElement {


### PR DESCRIPTION
Adds a note that the `Modal` component is only available in iOS.

I hit a bit of a pickle this weekend after realizing a handful of components I built will have to be rewritten. Unfortunately there's no notes in the documentation that the support is limited. Hopefully this can contribute towards avoiding those situations.

Related to documentation request in https://github.com/facebook/react-native/issues/3004#issuecomment-152782173