### PR TITLE
[Fetch] - Adds PATCH to the list of normalized method names

### DIFF
--- a/Libraries/Fetch/fetch.js
+++ b/Libraries/Fetch/fetch.js
@@ -236,7 +236,7 @@ var self = {};
   }
 
   // HTTP methods whose capitalization should be normalized
-  var methods = ['DELETE', 'GET', 'HEAD', 'OPTIONS', 'POST', 'PUT']
+  var methods = ['DELETE', 'GET', 'HEAD', 'OPTIONS', 'POST', 'PUT', 'PATCH']
 
   function normalizeMethod(method) {
     var upcased = method.toUpperCase()


### PR DESCRIPTION
I encountered a problem described in #4594 where `fetch` would fail if called with lowercase `patch` as the method name with a request body.

It turns out that the [list of normalized method names](https://github.com/facebook/react-native/blob/ca9f0adee22280f20ba96563be1553b7a975923f/Libraries/Fetch/fetch.js#L237-L244) didn't include `PATCH`. This should now contain the complete list of supported request methods.