### PR TITLE
Fix custom native view verifyPropTypes regression on Android

### DIFF
--- a/Libraries/ReactIOS/verifyPropTypes.js
+++ b/Libraries/ReactIOS/verifyPropTypes.js
@@ -12,6 +12,7 @@
 'use strict';
 
 var ReactNativeStyleAttributes = require('ReactNativeStyleAttributes');
+var ReactNativeViewAttributes = require('ReactNativeViewAttributes');
 
 export type ComponentInterface = ReactClass<any, any, any> | {
   name?: string;
@@ -39,6 +40,7 @@ function verifyPropTypes(
   var nativeProps = viewConfig.NativeProps;
   for (var prop in nativeProps) {
     if (!componentInterface.propTypes[prop] &&
+        !ReactNativeViewAttributes.UIView[prop] &&
         !ReactNativeStyleAttributes[prop] &&
         (!nativePropsToIgnore || !nativePropsToIgnore[prop])) {
       throw new Error(


### PR DESCRIPTION
Test plan: Run the example VideoPlayer project at https://github.com/brentvatne/react-native-video/tree/feature/android-support/Examples/VideoPlayer on Android, notice it fails. Manually apply this patch to the appropriate file in your node_modules, try it again.

@mkonicek - we should publish a patch release for 0.16.1 that includes this, as people can't use 0.16.0 with native view modules on Android at the moment.

See #4605

cc @kmagiera 