### PR TITLE
[Android] Update dev menu to keep track of element inspector.

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevInternalSettings.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevInternalSettings.java
@@ -33,6 +33,7 @@ public class DevInternalSettings implements
   private static final String PREFS_DEBUG_SERVER_HOST_KEY = "debug_http_host";
   private static final String PREFS_ANIMATIONS_DEBUG_KEY = "animations_debug";
   private static final String PREFS_RELOAD_ON_JS_CHANGE_KEY = "reload_on_js_change";
+  private static final String PREFS_INSPECTOR_DEBUG_KEY = "inspector_debug";
 
   private final SharedPreferences mPreferences;
   private final DevSupportManager mDebugManager;
@@ -82,5 +83,13 @@ public class DevInternalSettings implements
 
   public void setReloadOnJSChangeEnabled(boolean enabled) {
     mPreferences.edit().putBoolean(PREFS_RELOAD_ON_JS_CHANGE_KEY, enabled).apply();
+  }
+
+  public boolean isElementInspectorEnabled() {
+    return mPreferences.getBoolean(PREFS_INSPECTOR_DEBUG_KEY, false);
+  }
+
+  public void setElementInspectorEnabled(boolean enabled) {
+    mPreferences.edit().putBoolean(PREFS_INSPECTOR_DEBUG_KEY, enabled).apply();
   }
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManager.java
@@ -265,10 +265,13 @@ public class DevSupportManager implements NativeModuleCallExceptionHandler {
           }
         });
     options.put(
-        mApplicationContext.getString(R.string.catalyst_inspect_element),
+        mDevSettings.isElementInspectorEnabled()
+          ? mApplicationContext.getString(R.string.catalyst_element_inspector_off)
+          : mApplicationContext.getString(R.string.catalyst_element_inspector),
         new DevOptionHandler() {
           @Override
           public void onOptionSelected() {
+            mDevSettings.setElementInspectorEnabled(!mDevSettings.isElementInspectorEnabled());
             mReactInstanceCommandsHandler.toggleElementInspector();
           }
         });

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/debug/DeveloperSettings.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/debug/DeveloperSettings.java
@@ -28,4 +28,9 @@ public interface DeveloperSettings {
    * @return Whether dev mode should be enabled in JS bundles.
    */
   boolean isJSDevModeEnabled();
+
+  /**
+   * @return Whether element inspector is enabled.
+   */
+  boolean isElementInspectorEnabled();
 }

--- a/ReactAndroid/src/main/res/devsupport/values-cs/strings.xml
+++ b/ReactAndroid/src/main/res/devsupport/values-cs/strings.xml
@@ -12,5 +12,5 @@
     <string name="catalyst_jsload_title">Čekejte prosím...</string>
     <string name="catalyst_jsload_message">Fetching JS bundle</string>
     <string name="catalyst_jsload_error">Unable to download JS bundle</string>
-    <string name="catalyst_inspect_element">Prozkoumat prvek</string>
+    <string name="catalyst_element_inspector">Prozkoumat prvek</string>
 </resources>

--- a/ReactAndroid/src/main/res/devsupport/values-da/strings.xml
+++ b/ReactAndroid/src/main/res/devsupport/values-da/strings.xml
@@ -12,5 +12,5 @@
     <string name="catalyst_jsload_title">Vent venligst...</string>
     <string name="catalyst_jsload_message">Fetching JS bundle</string>
     <string name="catalyst_jsload_error">Unable to download JS bundle</string>
-    <string name="catalyst_inspect_element">Inspicer element</string>
+    <string name="catalyst_element_inspector">Inspicer element</string>
 </resources>

--- a/ReactAndroid/src/main/res/devsupport/values-de/strings.xml
+++ b/ReactAndroid/src/main/res/devsupport/values-de/strings.xml
@@ -12,5 +12,5 @@
     <string name="catalyst_jsload_title">Bitte warten Sie ...</string>
     <string name="catalyst_jsload_message">Fetching JS bundle</string>
     <string name="catalyst_jsload_error">Unable to download JS bundle</string>
-    <string name="catalyst_inspect_element">Element untersuchen</string>
+    <string name="catalyst_element_inspector">Element untersuchen</string>
 </resources>

--- a/ReactAndroid/src/main/res/devsupport/values-el/strings.xml
+++ b/ReactAndroid/src/main/res/devsupport/values-el/strings.xml
@@ -12,5 +12,5 @@
     <string name="catalyst_jsload_title">Περιμένετε...</string>
     <string name="catalyst_jsload_message">Fetching JS bundle</string>
     <string name="catalyst_jsload_error">Unable to download JS bundle</string>
-    <string name="catalyst_inspect_element">Εξέταση στοιχείου</string>
+    <string name="catalyst_element_inspector">Εξέταση στοιχείου</string>
 </resources>

--- a/ReactAndroid/src/main/res/devsupport/values-en-rGB/strings.xml
+++ b/ReactAndroid/src/main/res/devsupport/values-en-rGB/strings.xml
@@ -12,5 +12,5 @@
     <string name="catalyst_jsload_title">Please wait...</string>
     <string name="catalyst_jsload_message">Fetching JS bundle</string>
     <string name="catalyst_jsload_error">Unable to download JS bundle</string>
-    <string name="catalyst_inspect_element">Inspect Element</string>
+    <string name="catalyst_element_inspector">Show Inspector</string>
 </resources>

--- a/ReactAndroid/src/main/res/devsupport/values-es-rES/strings.xml
+++ b/ReactAndroid/src/main/res/devsupport/values-es-rES/strings.xml
@@ -12,5 +12,5 @@
     <string name="catalyst_jsload_title">Espera...</string>
     <string name="catalyst_jsload_message">Fetching JS bundle</string>
     <string name="catalyst_jsload_error">Unable to download JS bundle</string>
-    <string name="catalyst_inspect_element">Inspeccionar elemento</string>
+    <string name="catalyst_element_inspector">Inspeccionar elemento</string>
 </resources>

--- a/ReactAndroid/src/main/res/devsupport/values-es/strings.xml
+++ b/ReactAndroid/src/main/res/devsupport/values-es/strings.xml
@@ -12,5 +12,5 @@
     <string name="catalyst_jsload_title">Espera...</string>
     <string name="catalyst_jsload_message">Fetching JS bundle</string>
     <string name="catalyst_jsload_error">Unable to download JS bundle</string>
-    <string name="catalyst_inspect_element">Inspeccionar elemento</string>
+    <string name="catalyst_element_inspector">Inspeccionar elemento</string>
 </resources>

--- a/ReactAndroid/src/main/res/devsupport/values-fb-rLL/strings.xml
+++ b/ReactAndroid/src/main/res/devsupport/values-fb-rLL/strings.xml
@@ -12,5 +12,5 @@
     <string name="catalyst_jsload_title">(অনুগ্রহ করে অপেক্ষা করুন….)</string>
     <string name="catalyst_jsload_message">Fetching JS bundle</string>
     <string name="catalyst_jsload_error">Unable to download JS bundle</string>
-    <string name="catalyst_inspect_element">(तत्व निरीक्षण गर्नुहोस्)</string>
+    <string name="catalyst_element_inspector">(तत्व निरीक्षण गर्नुहोस्)</string>
 </resources>

--- a/ReactAndroid/src/main/res/devsupport/values-fb/strings.xml
+++ b/ReactAndroid/src/main/res/devsupport/values-fb/strings.xml
@@ -12,5 +12,5 @@
     <string name="catalyst_jsload_title">[Please wait...#71bad104a80f916d3bfb1ffa23a487af:1]</string>
     <string name="catalyst_jsload_message">[Fetching JS bundle#0de4127d4fc6e7d1e265e07433f26e25:1]</string>
     <string name="catalyst_jsload_error">[Unable to download JS bundle#51057ecd2555f91873cce4c452e1ea03:1]</string>
-    <string name="catalyst_inspect_element">[Inspect Element#c1b106c92869437ebd88f326d632b973:1]</string>
+    <string name="catalyst_element_inspector">[Show Inspector#c1b106c92869437ebd88f326d632b973:1]</string>
 </resources>

--- a/ReactAndroid/src/main/res/devsupport/values-fi/strings.xml
+++ b/ReactAndroid/src/main/res/devsupport/values-fi/strings.xml
@@ -12,5 +12,5 @@
     <string name="catalyst_jsload_title">Odota…</string>
     <string name="catalyst_jsload_message">Fetching JS bundle</string>
     <string name="catalyst_jsload_error">Unable to download JS bundle</string>
-    <string name="catalyst_inspect_element">Tarkista elementti</string>
+    <string name="catalyst_element_inspector">Tarkista elementti</string>
 </resources>

--- a/ReactAndroid/src/main/res/devsupport/values-fr/strings.xml
+++ b/ReactAndroid/src/main/res/devsupport/values-fr/strings.xml
@@ -12,5 +12,5 @@
     <string name="catalyst_jsload_title">Veuillez patienter...</string>
     <string name="catalyst_jsload_message">Fetching JS bundle</string>
     <string name="catalyst_jsload_error">Unable to download JS bundle</string>
-    <string name="catalyst_inspect_element">Inspecter l’élément</string>
+    <string name="catalyst_element_inspector">Inspecter l’élément</string>
 </resources>

--- a/ReactAndroid/src/main/res/devsupport/values-hu/strings.xml
+++ b/ReactAndroid/src/main/res/devsupport/values-hu/strings.xml
@@ -12,5 +12,5 @@
     <string name="catalyst_jsload_title">Kérjük, várj...</string>
     <string name="catalyst_jsload_message">Fetching JS bundle</string>
     <string name="catalyst_jsload_error">Unable to download JS bundle</string>
-    <string name="catalyst_inspect_element">Elem megtekintése</string>
+    <string name="catalyst_element_inspector">Elem megtekintése</string>
 </resources>

--- a/ReactAndroid/src/main/res/devsupport/values-in/strings.xml
+++ b/ReactAndroid/src/main/res/devsupport/values-in/strings.xml
@@ -12,5 +12,5 @@
     <string name="catalyst_jsload_title">Harap tunggu...</string>
     <string name="catalyst_jsload_message">Fetching JS bundle</string>
     <string name="catalyst_jsload_error">Unable to download JS bundle</string>
-    <string name="catalyst_inspect_element">Periksa Elemen</string>
+    <string name="catalyst_element_inspector">Periksa Elemen</string>
 </resources>

--- a/ReactAndroid/src/main/res/devsupport/values-it/strings.xml
+++ b/ReactAndroid/src/main/res/devsupport/values-it/strings.xml
@@ -12,5 +12,5 @@
     <string name="catalyst_jsload_title">Attendi...</string>
     <string name="catalyst_jsload_message">Fetching JS bundle</string>
     <string name="catalyst_jsload_error">Unable to download JS bundle</string>
-    <string name="catalyst_inspect_element">Esamina elemento</string>
+    <string name="catalyst_element_inspector">Esamina elemento</string>
 </resources>

--- a/ReactAndroid/src/main/res/devsupport/values-ja/strings.xml
+++ b/ReactAndroid/src/main/res/devsupport/values-ja/strings.xml
@@ -12,5 +12,5 @@
     <string name="catalyst_jsload_title">しばらくお待ちください</string>
     <string name="catalyst_jsload_message">Fetching JS bundle</string>
     <string name="catalyst_jsload_error">Unable to download JS bundle</string>
-    <string name="catalyst_inspect_element">要素を確認</string>
+    <string name="catalyst_element_inspector">要素を確認</string>
 </resources>

--- a/ReactAndroid/src/main/res/devsupport/values-ko/strings.xml
+++ b/ReactAndroid/src/main/res/devsupport/values-ko/strings.xml
@@ -12,5 +12,5 @@
     <string name="catalyst_jsload_title">기다려주세요...</string>
     <string name="catalyst_jsload_message">Fetching JS bundle</string>
     <string name="catalyst_jsload_error">Unable to download JS bundle</string>
-    <string name="catalyst_inspect_element">요소 검사</string>
+    <string name="catalyst_element_inspector">요소 검사</string>
 </resources>

--- a/ReactAndroid/src/main/res/devsupport/values-nb/strings.xml
+++ b/ReactAndroid/src/main/res/devsupport/values-nb/strings.xml
@@ -12,5 +12,5 @@
     <string name="catalyst_jsload_title">Vent litt ...</string>
     <string name="catalyst_jsload_message">Fetching JS bundle</string>
     <string name="catalyst_jsload_error">Unable to download JS bundle</string>
-    <string name="catalyst_inspect_element">Inspiser element</string>
+    <string name="catalyst_element_inspector">Inspiser element</string>
 </resources>

--- a/ReactAndroid/src/main/res/devsupport/values-nl/strings.xml
+++ b/ReactAndroid/src/main/res/devsupport/values-nl/strings.xml
@@ -12,5 +12,5 @@
     <string name="catalyst_jsload_title">Even geduld...</string>
     <string name="catalyst_jsload_message">Fetching JS bundle</string>
     <string name="catalyst_jsload_error">Unable to download JS bundle</string>
-    <string name="catalyst_inspect_element">Element inspecteren</string>
+    <string name="catalyst_element_inspector">Element inspecteren</string>
 </resources>

--- a/ReactAndroid/src/main/res/devsupport/values-pl/strings.xml
+++ b/ReactAndroid/src/main/res/devsupport/values-pl/strings.xml
@@ -12,5 +12,5 @@
     <string name="catalyst_jsload_title">Zaczekaj...</string>
     <string name="catalyst_jsload_message">Fetching JS bundle</string>
     <string name="catalyst_jsload_error">Unable to download JS bundle</string>
-    <string name="catalyst_inspect_element">Zbadaj element</string>
+    <string name="catalyst_element_inspector">Zbadaj element</string>
 </resources>

--- a/ReactAndroid/src/main/res/devsupport/values-pt-rPT/strings.xml
+++ b/ReactAndroid/src/main/res/devsupport/values-pt-rPT/strings.xml
@@ -12,5 +12,5 @@
     <string name="catalyst_jsload_title">Aguarda...</string>
     <string name="catalyst_jsload_message">Fetching JS bundle</string>
     <string name="catalyst_jsload_error">Unable to download JS bundle</string>
-    <string name="catalyst_inspect_element">Inspect Element</string>
+    <string name="catalyst_element_inspector">Show Inspector</string>
 </resources>

--- a/ReactAndroid/src/main/res/devsupport/values-pt/strings.xml
+++ b/ReactAndroid/src/main/res/devsupport/values-pt/strings.xml
@@ -12,5 +12,5 @@
     <string name="catalyst_jsload_title">Aguarde...</string>
     <string name="catalyst_jsload_message">Fetching JS bundle</string>
     <string name="catalyst_jsload_error">Unable to download JS bundle</string>
-    <string name="catalyst_inspect_element">Inspect Element</string>
+    <string name="catalyst_element_inspector">Show Inspector</string>
 </resources>

--- a/ReactAndroid/src/main/res/devsupport/values-ro/strings.xml
+++ b/ReactAndroid/src/main/res/devsupport/values-ro/strings.xml
@@ -12,5 +12,5 @@
     <string name="catalyst_jsload_title">Please wait...</string>
     <string name="catalyst_jsload_message">Fetching JS bundle</string>
     <string name="catalyst_jsload_error">Unable to download JS bundle</string>
-    <string name="catalyst_inspect_element">Inspect Element</string>
+    <string name="catalyst_element_inspector">Show Inspector</string>
 </resources>

--- a/ReactAndroid/src/main/res/devsupport/values-ru/strings.xml
+++ b/ReactAndroid/src/main/res/devsupport/values-ru/strings.xml
@@ -12,5 +12,5 @@
     <string name="catalyst_jsload_title">Подождите...</string>
     <string name="catalyst_jsload_message">Fetching JS bundle</string>
     <string name="catalyst_jsload_error">Unable to download JS bundle</string>
-    <string name="catalyst_inspect_element">Проверить элемент</string>
+    <string name="catalyst_element_inspector">Проверить элемент</string>
 </resources>

--- a/ReactAndroid/src/main/res/devsupport/values-sv/strings.xml
+++ b/ReactAndroid/src/main/res/devsupport/values-sv/strings.xml
@@ -12,5 +12,5 @@
     <string name="catalyst_jsload_title">Vänta ...</string>
     <string name="catalyst_jsload_message">Fetching JS bundle</string>
     <string name="catalyst_jsload_error">Unable to download JS bundle</string>
-    <string name="catalyst_inspect_element">Inspektionselement</string>
+    <string name="catalyst_element_inspector">Inspektionselement</string>
 </resources>

--- a/ReactAndroid/src/main/res/devsupport/values-th/strings.xml
+++ b/ReactAndroid/src/main/res/devsupport/values-th/strings.xml
@@ -12,5 +12,5 @@
     <string name="catalyst_jsload_title">โปรดรอ...</string>
     <string name="catalyst_jsload_message">Fetching JS bundle</string>
     <string name="catalyst_jsload_error">Unable to download JS bundle</string>
-    <string name="catalyst_inspect_element">ตรวจสอบอิลิเมนต์</string>
+    <string name="catalyst_element_inspector">ตรวจสอบอิลิเมนต์</string>
 </resources>

--- a/ReactAndroid/src/main/res/devsupport/values-tr/strings.xml
+++ b/ReactAndroid/src/main/res/devsupport/values-tr/strings.xml
@@ -12,5 +12,5 @@
     <string name="catalyst_jsload_title">Lütfen bekleyin...</string>
     <string name="catalyst_jsload_message">Fetching JS bundle</string>
     <string name="catalyst_jsload_error">Unable to download JS bundle</string>
-    <string name="catalyst_inspect_element">Öğeyi Denetle</string>
+    <string name="catalyst_element_inspector">Öğeyi Denetle</string>
 </resources>

--- a/ReactAndroid/src/main/res/devsupport/values-vi/strings.xml
+++ b/ReactAndroid/src/main/res/devsupport/values-vi/strings.xml
@@ -12,5 +12,5 @@
     <string name="catalyst_jsload_title">Vui lòng đợi...</string>
     <string name="catalyst_jsload_message">Fetching JS bundle</string>
     <string name="catalyst_jsload_error">Unable to download JS bundle</string>
-    <string name="catalyst_inspect_element">Kiểm tra phần tử</string>
+    <string name="catalyst_element_inspector">Kiểm tra phần tử</string>
 </resources>

--- a/ReactAndroid/src/main/res/devsupport/values-zh-rCN/strings.xml
+++ b/ReactAndroid/src/main/res/devsupport/values-zh-rCN/strings.xml
@@ -12,5 +12,5 @@
     <string name="catalyst_jsload_title">请稍等...</string>
     <string name="catalyst_jsload_message">Fetching JS bundle</string>
     <string name="catalyst_jsload_error">Unable to download JS bundle</string>
-    <string name="catalyst_inspect_element">检查元素</string>
+    <string name="catalyst_element_inspector">检查元素</string>
 </resources>

--- a/ReactAndroid/src/main/res/devsupport/values-zh-rHK/strings.xml
+++ b/ReactAndroid/src/main/res/devsupport/values-zh-rHK/strings.xml
@@ -12,5 +12,5 @@
     <string name="catalyst_jsload_title">請稍候……</string>
     <string name="catalyst_jsload_message">Fetching JS bundle</string>
     <string name="catalyst_jsload_error">Unable to download JS bundle</string>
-    <string name="catalyst_inspect_element">檢查項目</string>
+    <string name="catalyst_element_inspector">檢查項目</string>
 </resources>

--- a/ReactAndroid/src/main/res/devsupport/values-zh-rTW/strings.xml
+++ b/ReactAndroid/src/main/res/devsupport/values-zh-rTW/strings.xml
@@ -12,5 +12,5 @@
     <string name="catalyst_jsload_title">請稍候……</string>
     <string name="catalyst_jsload_message">Fetching JS bundle</string>
     <string name="catalyst_jsload_error">Unable to download JS bundle</string>
-    <string name="catalyst_inspect_element">檢查元素</string>
+    <string name="catalyst_element_inspector">檢查元素</string>
 </resources>

--- a/ReactAndroid/src/main/res/devsupport/values/strings.xml
+++ b/ReactAndroid/src/main/res/devsupport/values/strings.xml
@@ -14,7 +14,8 @@
   <string name="catalyst_jsload_error" project="catalyst" translatable="false">Unable to download JS bundle. Did you forget to start the development server or connect your device?</string>
   <string name="catalyst_remotedbg_message" project="catalyst" translatable="false">Connecting to remote debugger</string>
   <string name="catalyst_remotedbg_error" project="catalyst" translatable="false">Unable to connect with remote debugger</string>
-  <string name="catalyst_inspect_element" project="catalyst" translatable="false">Inspect Element</string>
+  <string name="catalyst_element_inspector" project="catalyst" translatable="false">Show Inspector</string>
+  <string name="catalyst_element_inspector_off" project="catalyst" translatable="false">Hide Inspector</string>
   <string name="catalyst_start_profile" project="catalyst" translatable="false">Start Profile</string>
   <string name="catalyst_stop_profile" project="catalyst" translatable="false">Stop Profile</string>
 </resources>


### PR DESCRIPTION
This PR makes the android dev menu consistent with iOS where toggling the inspector will update the button label accordingly.