### PR TITLE
Unwrapping NativeReadableArray and NativeReadableMap

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/ReadableNativeArray.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/ReadableNativeArray.java
@@ -13,6 +13,9 @@ import com.facebook.jni.HybridData;
 import com.facebook.proguard.annotations.DoNotStrip;
 import com.facebook.soloader.SoLoader;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * Implementation of a NativeArray that allows read-only access to its members. This will generally
  * be constructed and filled in native code so you shouldn't construct one yourself.
@@ -46,4 +49,38 @@ public class ReadableNativeArray extends NativeArray implements ReadableArray {
   public native ReadableNativeMap getMap(int index);
   @Override
   public native ReadableType getType(int index);
+
+  public List<Object> toJavaArray() {
+    return ReadableNativeArray.toJavaArray(this);
+  }
+
+  public static List<Object> toJavaArray(ReadableNativeArray readableArray) {
+    List<Object> unwrappedList = new ArrayList<>(readableArray.size());
+    for (int i = 0; i < readableArray.size(); i++) {
+      ReadableType type = readableArray.getType(i);
+      switch (type) {
+        case Null:
+          unwrappedList.add(i, null);
+          break;
+        case Boolean:
+          unwrappedList.add(i, readableArray.getBoolean(i));
+          break;
+        case Number:
+          unwrappedList.add(i, readableArray.getDouble(i));
+          break;
+        case String:
+          unwrappedList.add(i, readableArray.getString(i));
+          break;
+        case Map:
+          unwrappedList.add(i, readableArray.getMap(i).toJavaMap());
+          break;
+        case Array:
+          unwrappedList.add(i, ReadableNativeArray.toJavaArray(readableArray.getArray(i)));
+          break;
+        default:
+          throw new IllegalArgumentsException("Could not convert object at index " + i + ".");
+      }
+    }
+    return unwrappedList;
+  }
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/ReadableNativeMap.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/ReadableNativeMap.java
@@ -13,6 +13,9 @@ import com.facebook.jni.Countable;
 import com.facebook.proguard.annotations.DoNotStrip;
 import com.facebook.soloader.SoLoader;
 
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * Implementation of a read-only map in native memory. This will generally be constructed and filled
  * in native code so you shouldn't construct one yourself.
@@ -46,6 +49,39 @@ public class ReadableNativeMap extends NativeMap implements ReadableMap {
   @Override
   public ReadableMapKeySetIterator keySetIterator() {
     return new ReadableNativeMapKeySetIterator(this);
+  }
+
+  public Map<String, Object> toJavaMap() {
+    return ReadableNativeMap.toJavaMap(this);
+  }
+
+  public static Map<String, Object>toJavaMap(ReadableNativeMap map) {
+    ReadableNativeMapKeySetIterator iterator = map.keySetIterator();
+    Map<String, Object> unwrappedMap = new HashMap<>();
+    while (iterator.hasNextKey()) {
+      String key = iterator.nextKey();
+      ReadableType type = map.getType(type);
+      switch (type) {
+        case Null:
+          unwrappedMap.put(key, null);
+          break;
+        case Boolean:
+          unwrappedMap.put(key, map.getBoolean(type));
+          break;
+        case Number:
+          unwrappedMap.put(key, map.getDouble(type));
+          break;
+        case Map:
+          unwrappedMap.put(key, ReadableNativeMap.toJavaMap(map.getMap(key)));
+          break;
+        case Array:
+          unwrappedMap.put(key, map.getArray(key).toJavaArray());
+          break;
+        default:
+          throw new IllegalArgumentException("Could not convert object with key: " + key + ".");
+      }
+    }
+    return unwrappedMap;
   }
 
   /**


### PR DESCRIPTION
This provides the ability to transform a `ReadableNativeArray` and a `ReadableNativeMap` into normal Java objects. 

Related issue (pending feedback): https://github.com/facebook/react-native/issues/4655

## The Problem

There's some scenarios where you can expect an arbitrary object to be sent over the bridge without any knowledge of incoming data type or keys. An example would be to pass a `Map` from JS to a native library, such as [Intercom](https://docs.intercom.io/install-on-your-mobile-product/configuring-intercom-for-android), where you forward a `Map<String, Object>` onto the library. Currently, this would require recursively unwrapping the `ReadableMap` or `ReadableArray` to infer the final map or array of their proper types.

## The Solution

Providing this functionality as part of the API of a `NativeReadableMap` and `NativeReadableArray` will allow users to transform their wrapped object into types that are more commonly usable throughout their native integrations.

## Example

```java
@ReactMethod
public void something(ReadableMap readableMap) {
  Map<String, Object> data = readableMap.toMap();
}

@ReactMethod
public void somethingElse(ReadableArray readableArray) {
  List<Object> array = readableArray.toList();
}
```


Todo:
- [ ] compile & test changes