### PR TITLE
[ToolbarAndroid] Add props for content insets

### DIFF
--- a/Libraries/Components/ToolbarAndroid/ToolbarAndroid.android.js
+++ b/Libraries/Components/ToolbarAndroid/ToolbarAndroid.android.js
@@ -127,6 +127,14 @@ var ToolbarAndroid = React.createClass({
      * Used to locate this view in end-to-end tests.
      */
     testID: ReactPropTypes.string,
+    /**
+     * Sets the content inset start
+     */
+    contentInsetStart: ReactPropTypes.number,
+    /**
+     * Sets the content inset end
+     */
+    contentInsetEnd: ReactPropTypes.number,
   },
 
   render: function() {
@@ -181,6 +189,8 @@ var toolbarAttributes = {
   subtitleColor: true,
   title: true,
   titleColor: true,
+  contentInsetStart: true,
+  contentInsetEnd: true,
 };
 
 var NativeToolbar = requireNativeComponent('ToolbarAndroid', null);

--- a/ReactAndroid/src/main/java/com/facebook/react/views/toolbar/ReactToolbarManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/toolbar/ReactToolbarManager.java
@@ -99,6 +99,16 @@ public class ReactToolbarManager extends ViewGroupManager<ReactToolbar> {
     view.setActions(actions);
   }
 
+  @ReactProp(name = "contentInsetStart")
+  public void setContentInsetStart(ReactToolbar view, int insetStart) {
+    view.setContentInsetsRelative((int) PixelUtil.toPixelFromDIP(insetStart), view.getContentInsetEnd());
+  }
+
+  @ReactProp(name = "contentInsetEnd")
+  public void setContentInsetEnd(ReactToolbar view, int insetEnd) {
+    view.setContentInsetsRelative(view.getContentInsetStart(), (int) PixelUtil.toPixelFromDIP(insetEnd));
+  }
+
   @Override
   protected void addEventEmitters(final ThemedReactContext reactContext, final ReactToolbar view) {
     final EventDispatcher mEventDispatcher = reactContext.getNativeModule(UIManagerModule.class)


### PR DESCRIPTION
This PR adds a contentInsetStart and a contentInsetEnd property to ToolbarAndroid, allowing offsetting Toolbar contents to different keylines