### PR TITLE
Fix permissions on Android 6.0

### DIFF
--- a/ReactAndroid/src/main/AndroidManifest.xml
+++ b/ReactAndroid/src/main/AndroidManifest.xml
@@ -1,7 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.facebook.react">
 
-    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
-
     <application />
 
 </manifest>

--- a/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManagerImpl.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManagerImpl.java
@@ -209,6 +209,7 @@ import com.facebook.systrace.Systrace;
     // TODO(6803830): Don't instantiate devsupport manager when useDeveloperSupport is false
     mDevSupportManager = new DevSupportManager(
         applicationContext,
+        mCurrentActivity,
         mDevInterface,
         mJSMainModuleName,
         useDeveloperSupport);
@@ -394,6 +395,9 @@ import com.facebook.systrace.Systrace;
     mCurrentActivity = activity;
     if (mCurrentReactContext != null) {
       mCurrentReactContext.onResume(activity);
+    }
+    if (mDevSupportManager != null) {
+      mDevSupportManager.setActivityContext(mCurrentActivity);
     }
   }
 


### PR DESCRIPTION
The only thing blocking React Native from working on Android 6.0's
permissions model is the use of the SYSTEM_ALERT Dialog type, but
we don't necessarily need to use this. Instead, we need a
reference to the current Activity to use as the Dialog's context.
There may be a better way to do this, but simply setting a field
on the DevSupportManager is the easiest and simplest way to do it.