### PR TITLE
allow use external typeface in native code

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactFontManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactFontManager.java
@@ -72,6 +72,28 @@ public class ReactFontManager {
     return typeface;
   }
 
+  /**
+   * Add additional font family, or replace the exist one in the font memory cache.
+   * @param style
+   * @see {@link Typeface#DEFAULT}
+   * @see {@link Typeface#BOLD}
+   * @see {@link Typeface#ITALIC}
+   * @see {@link Typeface#BOLD_ITALIC}
+   */
+  public void setTypeface(
+          String fontFamilyName,
+          int style,
+          Typeface typeface){
+    if (typeface != null) {
+      FontFamily fontFamily = mFontCache.get(fontFamilyName);
+      if (fontFamily == null){
+        fontFamily = new FontFamily();
+        mFontCache.put(fontFamilyName, fontFamily);
+      }
+      fontFamily.setTypeface(style, typeface);
+    }
+  }
+
   private static
   @Nullable Typeface createTypeface(
       String fontFamilyName,


### PR DESCRIPTION
Expose method to implement changing font family cache.  Like @ide suggested in #4420 , this will helpful for using remote font file (use `Typeface#createFromFile` to load downloaded font file).   
iOS's CoreText  already allow this in native code.
