### PR TITLE
[ToolbarAndroid] Add props for content insets

### DIFF
--- a/Libraries/Components/ToolbarAndroid/ToolbarAndroid.android.js
+++ b/Libraries/Components/ToolbarAndroid/ToolbarAndroid.android.js
@@ -126,6 +126,14 @@ var ToolbarAndroid = React.createClass({
      */
     titleColor: ReactPropTypes.string,
     /**
+     * Content inset for the toolbar starting edge
+     */
+    contentInsetStart: ReactPropTypes.number,
+    /**
+     * Content inset for the toolbar ending edge
+     */
+    contentInsetEnd: ReactPropTypes.number,
+    /**
      * Used to set the toolbar direction to RTL.
      * In addition to this property you need to add
      *

--- a/Libraries/Components/ToolbarAndroid/ToolbarAndroid.android.js
+++ b/Libraries/Components/ToolbarAndroid/ToolbarAndroid.android.js
@@ -126,11 +126,21 @@ var ToolbarAndroid = React.createClass({
      */
     titleColor: ReactPropTypes.string,
     /**
-     * Content inset for the toolbar starting edge
+     * Set the content inset for the toolbar starting edge
+     * 
+     * The content inset affects the valid area for Toolbar content other than
+     * the navigation button and menu. Insets define the minimum margin for
+     * these components and can be used to effectively align Toolbar content
+     * along well-known gridlines.
      */
     contentInsetStart: ReactPropTypes.number,
     /**
-     * Content inset for the toolbar ending edge
+     * Set the content inset for the toolbar ending edge
+     * 
+     * The content inset affects the valid area for Toolbar content other than
+     * the navigation button and menu. Insets define the minimum margin for
+     * these components and can be used to effectively align Toolbar content
+     * along well-known gridlines.
      */
     contentInsetEnd: ReactPropTypes.number,
     /**

--- a/Libraries/Components/ToolbarAndroid/ToolbarAndroid.android.js
+++ b/Libraries/Components/ToolbarAndroid/ToolbarAndroid.android.js
@@ -127,7 +127,7 @@ var ToolbarAndroid = React.createClass({
     titleColor: ReactPropTypes.string,
     /**
      * Set the content inset for the toolbar starting edge
-     * 
+     *
      * The content inset affects the valid area for Toolbar content other than
      * the navigation button and menu. Insets define the minimum margin for
      * these components and can be used to effectively align Toolbar content
@@ -136,7 +136,7 @@ var ToolbarAndroid = React.createClass({
     contentInsetStart: ReactPropTypes.number,
     /**
      * Set the content inset for the toolbar ending edge
-     * 
+     *
      * The content inset affects the valid area for Toolbar content other than
      * the navigation button and menu. Insets define the minimum margin for
      * these components and can be used to effectively align Toolbar content

--- a/ReactAndroid/src/main/java/com/facebook/react/views/toolbar/ReactToolbarManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/toolbar/ReactToolbarManager.java
@@ -100,14 +100,20 @@ public class ReactToolbarManager extends ViewGroupManager<ReactToolbar> {
     }
   }
 
-  @ReactProp(name = "contentInsetStart")
+  @ReactProp(name = "contentInsetStart", defaultFloat = Float.NaN)
   public void setContentInsetStart(ReactToolbar view, float insetStart) {
-    view.setContentInsetsRelative(Math.round(PixelUtil.toPixelFromDIP(insetStart)), view.getContentInsetEnd());
+    int inset = Float.isNaN(insetStart) ?
+            getDefaultContentInsets(view.getContext())[0] :
+            Math.round(PixelUtil.toPixelFromDIP(insetStart));
+    view.setContentInsetsRelative(inset, view.getContentInsetEnd());
   }
 
-  @ReactProp(name = "contentInsetEnd")
+  @ReactProp(name = "contentInsetEnd", defaultFloat = Float.NaN)
   public void setContentInsetEnd(ReactToolbar view, float insetEnd) {
-    view.setContentInsetsRelative(view.getContentInsetStart(), Math.round(PixelUtil.toPixelFromDIP(insetEnd)));
+    int inset = Float.isNaN(insetEnd) ?
+            getDefaultContentInsets(view.getContext())[1] :
+            Math.round(PixelUtil.toPixelFromDIP(insetEnd));
+    view.setContentInsetsRelative(view.getContentInsetStart(), inset);
   }
 
   @ReactProp(name = "nativeActions")
@@ -156,6 +162,34 @@ public class ReactToolbarManager extends ViewGroupManager<ReactToolbar> {
   @Override
   public boolean needsCustomLayoutForChildren() {
     return true;
+  }
+
+  private int[] getDefaultContentInsets(Context context) {
+    Resources.Theme theme = context.getTheme();
+    TypedArray toolbarStyle = null;
+    TypedArray contentInsets = null;
+
+    try {
+      toolbarStyle = theme
+              .obtainStyledAttributes(new int[]{R.attr.toolbarStyle});
+
+      int toolbarStyleResId = toolbarStyle.getResourceId(0, 0);
+
+      contentInsets = theme.obtainStyledAttributes(
+              toolbarStyleResId, new int[]{
+                      R.attr.contentInsetStart,
+                      R.attr.contentInsetEnd,
+              });
+
+      int contentInsetStart = contentInsets.getDimensionPixelSize(0, 0);
+      int contentInsetEnd = contentInsets.getDimensionPixelSize(1, 0);
+
+      return new int[] {contentInsetStart, contentInsetEnd};
+    } finally {
+      recycleQuietly(toolbarStyle);
+      recycleQuietly(contentInsets);
+    }
+
   }
 
   private static int[] getDefaultColors(Context context) {

--- a/ReactAndroid/src/main/java/com/facebook/react/views/toolbar/ReactToolbarManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/toolbar/ReactToolbarManager.java
@@ -100,6 +100,16 @@ public class ReactToolbarManager extends ViewGroupManager<ReactToolbar> {
     }
   }
 
+  @ReactProp(name = "contentInsetStart")
+  public void setContentInsetStart(ReactToolbar view, float insetStart) {
+    view.setContentInsetsRelative(Math.round(PixelUtil.toPixelFromDIP(insetStart)), view.getContentInsetEnd());
+  }
+
+  @ReactProp(name = "contentInsetEnd")
+  public void setContentInsetEnd(ReactToolbar view, float insetEnd) {
+    view.setContentInsetsRelative(view.getContentInsetStart(), Math.round(PixelUtil.toPixelFromDIP(insetEnd)));
+  }
+
   @ReactProp(name = "nativeActions")
   public void setActions(ReactToolbar view, @Nullable ReadableArray actions) {
     view.setActions(actions);


### PR DESCRIPTION
This PR adds a contentInsetStart and a contentInsetEnd property to ToolbarAndroid, allowing offsetting Toolbar contents to different keylines