### PR TITLE
[Packager] improve exception message when we can't find a file

### DIFF
--- a/packager/react-packager/src/DependencyResolver/fastfs.js
+++ b/packager/react-packager/src/DependencyResolver/fastfs.js
@@ -109,7 +109,7 @@ class Fastfs extends EventEmitter {
   readFile(filePath) {
     const file = this._getFile(filePath);
     if (!file) {
-      throw new Error(`Unable to find file with path: ${file}`);
+      throw new Error(`Unable to find file with path: ${filePath}`);
     }
     return file.read();
   }


### PR DESCRIPTION
in ```fastfs.js ``` when ```getFile()``` got a exception it will print ``` Unable to find file with path: null ``` in terminal . 

It's  confused 