### PR TITLE
fix sample code error by removing the extra chars

### DIFF
--- a/docs/NativeModulesIOS.md
+++ b/docs/NativeModulesIOS.md
@@ -181,8 +181,8 @@ Refactoring the above code to use a promise instead of callbacks looks like this
 
 ```objective-c
 RCT_REMAP_METHOD(findEvents,
-                 resolver:(RCTPromiseResolveBlock)resolve,
-                 rejecter:(RCTPromiseRejectBlock)reject))
+                 resolver:(RCTPromiseResolveBlock)resolve
+                 rejecter:(RCTPromiseRejectBlock)reject)
 {
   NSArray *events = ...
   if (events) {


### PR DESCRIPTION
fix sample code error by removing the extra ',' and ')'