### PR TITLE
Fix message when react-native init encounters existing directory.

### DIFF
--- a/react-native-cli/index.js
+++ b/react-native-cli/index.js
@@ -138,7 +138,7 @@ function createAfterConfirmation(name, verbose) {
 
   var property = {
     name: 'yesno',
-    message: 'Directory ' + name + ' already exist. Continue?',
+    message: 'Directory ' + name + ' already exists. Continue?',
     validator: /y[es]*|n[o]?/,
     warning: 'Must respond yes or no',
     default: 'no'


### PR DESCRIPTION
`react-native init` exhibits a typo in informing the user that the directory already exists. This PR fixes that.