### PR TITLE
Add the npm global prefix to PATH.

### DIFF
--- a/packager/react-native-xcode.sh
+++ b/packager/react-native-xcode.sh
@@ -29,6 +29,9 @@ cd ..
 set -x
 DEST=$CONFIGURATION_BUILD_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH
 
+# npm global install path may be a non-standard location
+PATH="$(npm prefix -g)/bin:$PATH"
+
 # Define NVM_DIR and source the nvm.sh setup script
 [ -z "$NVM_DIR" ] && export NVM_DIR="$HOME/.nvm"
 


### PR DESCRIPTION
Related to issue https://github.com/facebook/react-native/issues/4034#issuecomment-164134543.
The npm global install path may be set to a non-standard location. `react-native` is assumed to be in `PATH` but doesn't take into account the user's environment so building in Xcode fails:
~~~
react-native bundle --entry-file index.ios.js --platform ios --dev true --bundle-output [...]

../node_modules/react-native/packager/react-native-xcode.sh: line 48: react-native: command not found
Command /bin/sh failed with exit code 127
~~~
This fix uses `npm prefix -g` to get the bin location and adds it to `PATH`.