### PR TITLE
[Geolocation] Fix getCurrentPosition

### DIFF
--- a/Libraries/Geolocation/RCTLocationObserver.m
+++ b/Libraries/Geolocation/RCTLocationObserver.m
@@ -130,7 +130,6 @@ RCT_EXPORT_MODULE()
     _locationManager = [CLLocationManager new];
     _locationManager.distanceFilter = RCT_DEFAULT_LOCATION_ACCURACY;
     _locationManager.delegate = self;
-    _pendingRequests = [NSMutableArray new];
   }
 
   // Request location access permission
@@ -234,6 +233,9 @@ RCT_EXPORT_METHOD(getCurrentPosition:(RCTLocationOptions)options
                                                         selector:@selector(timeout:)
                                                         userInfo:request
                                                          repeats:NO];
+  if (!_pendingRequests) {
+    _pendingRequests = [NSMutableArray new];
+  }
   [_pendingRequests addObject:request];
 
   // Configure location manager and begin updating location


### PR DESCRIPTION
Instantiates the _pendingRequests array before trying to add to it. As it currently stands, we try to add the pending request before the array is created. getCurrentPosition always fails on the first try.