### PR TITLE
add backfaceVisibility to ImageStylePropTypes

### DIFF
--- a/Libraries/Image/ImageStylePropTypes.js
+++ b/Libraries/Image/ImageStylePropTypes.js
@@ -20,6 +20,7 @@ var ImageStylePropTypes = {
   ...LayoutPropTypes,
   ...TransformPropTypes,
   resizeMode: ReactPropTypes.oneOf(Object.keys(ImageResizeMode)),
+  backfaceVisibility: ReactPropTypes.oneOf(['visible', 'hidden']),
   backgroundColor: ReactPropTypes.string,
   borderColor: ReactPropTypes.string,
   borderWidth: ReactPropTypes.number,


### PR DESCRIPTION
to eliminate to yellow box.
ViewStylePropTypes also has this prop.
https://github.com/facebook/react-native/blob/0a3694ce48be8991839c42aab2586202a12d43aa/Libraries/Components/View/ViewStylePropTypes.js