### PR TITLE
Exposes `setNativeProps` method for PullToRefreshViewAndroid

### DIFF
--- a/Libraries/PullToRefresh/PullToRefreshViewAndroid.android.js
+++ b/Libraries/PullToRefresh/PullToRefreshViewAndroid.android.js
@@ -57,6 +57,10 @@ var PullToRefreshViewAndroid = React.createClass({
     return this.refs[NATIVE_REF];
   },
 
+  setNativeProps: function(props) {
+    return this.refs[NATIVE_REF].setNativeProps(props);
+  },
+
   render: function() {
     return (
       <NativePullToRefresh


### PR DESCRIPTION
Keep `PullToRefreshViewAndroid` consistent with other components that allow optimization through `setNativeProps`.

Also updates the example to make sure it is working.