### PR TITLE
[Android]Decouple handler for process js runtime error in native code

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/CoreModulesPackage.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/CoreModulesPackage.java
@@ -77,7 +77,7 @@ import com.facebook.systrace.Systrace;
             mReactInstanceManager.getDevSupportManager().getDevSettings()),
         new AndroidInfoModule(),
         new DeviceEventManagerModule(catalystApplicationContext, mHardwareBackBtnHandler),
-        new ExceptionsManagerModule(mReactInstanceManager.getDevSupportManager()),
+        new ExceptionsManagerModule(mReactInstanceManager.getJavascriptExceptionHandler()),
         new Timing(catalystApplicationContext),
         new SourceCodeModule(
             mReactInstanceManager.getSourceUrl(),

--- a/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
@@ -25,6 +25,7 @@ import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.common.annotations.VisibleForTesting;
 import com.facebook.react.devsupport.DevSupportManager;
 import com.facebook.react.modules.core.DefaultHardwareBackBtnHandler;
+import com.facebook.react.modules.core.JavascriptExceptionHandler;
 import com.facebook.react.uimanager.UIImplementationProvider;
 import com.facebook.react.uimanager.ViewManager;
 
@@ -61,6 +62,7 @@ public abstract class ReactInstanceManager {
 
   public abstract DevSupportManager getDevSupportManager();
 
+  public abstract JavascriptExceptionHandler getJavascriptExceptionHandler();
   /**
    * Trigger react context initialization asynchronously in a background async task. This enables
    * applications to pre-load the application JS, and execute global code before
@@ -159,6 +161,7 @@ public abstract class ReactInstanceManager {
     protected boolean mUseDeveloperSupport;
     protected @Nullable LifecycleState mInitialLifecycleState;
     protected @Nullable UIImplementationProvider mUIImplementationProvider;
+    protected @Nullable JavascriptExceptionHandler mJSExceptionHandler;
 
     protected Builder() {
     }
@@ -243,6 +246,16 @@ public abstract class ReactInstanceManager {
     }
 
     /**
+     * Sets handler for runtime javascript. The handler will called in non-dev mode (by set
+     * {@link #setUseDeveloperSupport(boolean) to false}. Default behavior is simply raising a
+     * {@link com.facebook.react.modules.core.JavascriptException}.
+     */
+    public Builder setJavascriptExceptionHandler(JavascriptExceptionHandler exceptionHandler){
+      mJSExceptionHandler = exceptionHandler;
+      return this;
+    }
+
+    /**
      * Instantiates a new {@link ReactInstanceManagerImpl}.
      * Before calling {@code build}, the following must be called:
      * <ul>
@@ -274,7 +287,8 @@ public abstract class ReactInstanceManager {
           mUseDeveloperSupport,
           mBridgeIdleDebugListener,
           Assertions.assertNotNull(mInitialLifecycleState, "Initial lifecycle state was not set"),
-          mUIImplementationProvider);
+          mUIImplementationProvider,
+              mJSExceptionHandler);
     }
   }
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManager.java
@@ -44,6 +44,7 @@ import com.facebook.react.bridge.WebsocketJavaScriptExecutor;
 import com.facebook.react.common.ReactConstants;
 import com.facebook.react.common.ShakeDetector;
 import com.facebook.react.devsupport.StackTraceHelper.StackFrame;
+import com.facebook.react.modules.core.JavascriptExceptionHandler;
 import com.facebook.react.modules.debug.DeveloperSettings;
 
 /**
@@ -72,7 +73,7 @@ import com.facebook.react.modules.debug.DeveloperSettings;
  * {@code <activity android:name="com.facebook.react.devsupport.DevSettingsActivity"/>}
  * {@code <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>}
  */
-public class DevSupportManager implements NativeModuleCallExceptionHandler {
+public class DevSupportManager implements NativeModuleCallExceptionHandler,JavascriptExceptionHandler {
 
   private static final int JAVA_ERROR_COOKIE = -1;
   private static final String JS_BUNDLE_FILE_NAME = "ReactNativeDevBundle.js";
@@ -178,8 +179,14 @@ public class DevSupportManager implements NativeModuleCallExceptionHandler {
     mCustomDevOptions.put(optionName, optionHandler);
   }
 
-  public void showNewJSError(String message, ReadableArray details, int errorCookie) {
-    showNewError(message, StackTraceHelper.convertJsStackTrace(details), errorCookie);
+  @Override
+  public void handleNewError(String title, ReadableArray details, int exceptionId, String exceptionMessage) {
+    showNewError(title, StackTraceHelper.convertJsStackTrace(details), exceptionId);
+  }
+
+  @Override
+  public void updateError(String title, ReadableArray details, int exceptionId, String exceptionMessage) {
+    updateJSError(title, details, exceptionId);
   }
 
   public void updateJSError(

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/core/ExceptionsManagerModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/core/ExceptionsManagerModule.java
@@ -16,15 +16,14 @@ import com.facebook.react.bridge.BaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
-import com.facebook.react.devsupport.DevSupportManager;
 import com.facebook.react.common.ReactConstants;
 
 public class ExceptionsManagerModule extends BaseJavaModule {
 
-  private final DevSupportManager mDevSupportManager;
+  private final JavascriptExceptionHandler mJavascriptExceptionHandler;
 
-  public ExceptionsManagerModule(DevSupportManager devSupportManager) {
-    mDevSupportManager = devSupportManager;
+  public ExceptionsManagerModule(JavascriptExceptionHandler exceptionHandler) {
+    mJavascriptExceptionHandler = exceptionHandler;
   }
 
   @Override
@@ -62,17 +61,11 @@ public class ExceptionsManagerModule extends BaseJavaModule {
   }
 
   private void showOrThrowError(String title, ReadableArray details, int exceptionId) {
-    if (mDevSupportManager.getDevSupportEnabled()) {
-      mDevSupportManager.showNewJSError(title, details, exceptionId);
-    } else {
-      throw new JavascriptException(stackTraceToString(details));
-    }
+    mJavascriptExceptionHandler.handleNewError(title, details, exceptionId, stackTraceToString(details));
   }
 
   @ReactMethod
   public void updateExceptionMessage(String title, ReadableArray details, int exceptionId) {
-    if (mDevSupportManager.getDevSupportEnabled()) {
-      mDevSupportManager.updateJSError(title, details, exceptionId);
-    }
+    mJavascriptExceptionHandler.updateError(title, details, exceptionId,stackTraceToString(details));
   }
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/core/JavascriptExceptionHandler.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/core/JavascriptExceptionHandler.java
@@ -7,12 +7,13 @@ import com.facebook.react.bridge.ReadableArray;
  */
 public interface JavascriptExceptionHandler {
   /**
-   * Javascript runtime error occurred. This is the first place a javascript
+   * Javascript runtime error occurred for the first time.
    */
   void handleNewError(String title, ReadableArray details, int exceptionId, String exceptionMessage);
 
   /**
-   * Update error detail
+   * Update detail of error which was already passed to {@link #handleNewError(String, ReadableArray, int, String)}.
+   *
    */
   void updateError(String title, ReadableArray details, int exceptionId,String exceptionMessage);
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/core/JavascriptExceptionHandler.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/core/JavascriptExceptionHandler.java
@@ -1,0 +1,18 @@
+package com.facebook.react.modules.core;
+
+import com.facebook.react.bridge.ReadableArray;
+
+/**
+ * Handler for runtime JS error.
+ */
+public interface JavascriptExceptionHandler {
+  /**
+   * Javascript runtime error occurred. This is the first place a javascript
+   */
+  void handleNewError(String title, ReadableArray details, int exceptionId, String exceptionMessage);
+
+  /**
+   * Update error detail
+   */
+  void updateError(String title, ReadableArray details, int exceptionId,String exceptionMessage);
+}


### PR DESCRIPTION
* Decouple  `JavascriptExceptionHandler` from `ExceptionsManagerModule`.
*  Allow customize error handler in production.  It will be helpful for developers to adding a ideal process when JS error happened (caused by runtime JS error ,e.g. fatal server response,not JS evaluation) in native code. They can :  
  * Let users to report these errors by email or some error-report service.
  * Restart react-native app by receate JS context.

cc @mkonicek 