### PR TITLE
Fix events to go through the navigation bar layers

### DIFF
--- a/Libraries/CustomComponents/Navigator/NavigatorNavigationBar.js
+++ b/Libraries/CustomComponents/Navigator/NavigatorNavigationBar.js
@@ -195,6 +195,7 @@ var NavigatorNavigationBar = React.createClass({
         ref={(ref) => {
           this._components[componentName] = this._components[componentName].set(route, ref);
         }}
+        pointerEvents="box-none"
         style={initialStage[componentName]}>
         {content}
       </View>


### PR DESCRIPTION
Here is a showcase of 2 bugs that are fixed with this PR: touchability of title, touchability of overlapped top-right positionned (under the navbar).

(i'm using the inspector)

![bug](https://cloud.githubusercontent.com/assets/211411/11809475/7b6ba71a-a327-11e5-90cf-cbe58637c447.gif)

I have a navbar with a back button, a Title area with a **Green Circle**, a Right area with nothing inside.
In my Screen View, I've positioned in absolute a **Red Rectangle** just on the top-right corner under the navbar.

I want my **Green Circle** and **Red Rectangle** to be touchable but in current React Native version, this is not possible: as shown in the gif, the 3 LeftButton/Title/RightButton wrapper View are **catching the touch events**. My PR allows events to go through these wrapper View.

**After the fix:**

![nobug](https://cloud.githubusercontent.com/assets/211411/11809590/3b803994-a328-11e5-81f7-c1a3bab45e1b.gif)

Complementary Notes:
- in the case of the Red Rectangle, only the lower part of it is touchable.
- For some reason the back button works though (I guess you have fixed it specifically).

