### PR TITLE
Add support for nodenv with xcode

### DIFF
--- a/packager/react-native-xcode.sh
+++ b/packager/react-native-xcode.sh
@@ -41,6 +41,11 @@ elif [[ -x "$(command -v brew)" && -s "$(brew --prefix nvm)/nvm.sh" ]]; then
   . "$(brew --prefix nvm)/nvm.sh"
 fi
 
+# Set up the nodenv node version manager if present
+if [[ -x "$HOME/.nodenv/bin/nodenv" ]]; then
+  eval "$($HOME/.nodenv/bin/nodenv init -)"
+fi
+
 react-native bundle \
   --entry-file index.ios.js \
   --platform ios \


### PR DESCRIPTION
Hello!

I'm a fan of the *env family of version managers over the *vm family as I find them simpler and less obtrusive, but it seems that they don't currently work so well with react-native on OSX. See #4645

I've made a small addition to the xcode script that resolves the issue for me. Hopefully others will find this useful too :)

If I've not made the right move here, what is the correct way to get react-native projects building in xcode when the binary is not in the $PATH used by the script?

Cheers,
Louis
