### PR TITLE
Update to PullToRefreshViewAndroid docs

### DIFF
--- a/Libraries/PullToRefresh/PullToRefreshViewAndroid.android.js
+++ b/Libraries/PullToRefresh/PullToRefreshViewAndroid.android.js
@@ -23,6 +23,9 @@ var NATIVE_REF = 'native_swiperefreshlayout';
 /**
  * React view that supports a single scrollable child view (e.g. `ScrollView`). When this child
  * view is at `scrollY: 0`, swiping down triggers an `onRefresh` event.
+ * 
+ * The style `{flex: 1}` might be required to ensure the expected behavior of the child component
+ * (e.g. when the child is expected to scroll with `ScrollView` or `ListView`).
  */
 var PullToRefreshViewAndroid = React.createClass({
   statics: {


### PR DESCRIPTION
As mentioned in https://github.com/facebook/react-native/issues/4793 it is not initially clear that the PullToRefreshViewAndroid component needs the `{flex: 1}` style in order for it's child component to function correctly (without examining the example). This will hopefully clear that up.