### PR TITLE
FloatFromLeft scene configuration fixed. HorizontalSwipeJumpFromRight…

### DIFF
--- a/Libraries/CustomComponents/Navigator/NavigatorSceneConfigs.js
+++ b/Libraries/CustomComponents/Navigator/NavigatorSceneConfigs.js
@@ -515,6 +515,9 @@ var NavigatorSceneConfigs = {
   },
   FloatFromLeft: {
     ...BaseConfig,
+    gestures: {
+      pop: BaseRightToLeftGesture,
+    },
     animationInterpolators: {
       into: buildStyleInterpolator(FromTheLeft),
       out: buildStyleInterpolator(FadeToTheRight),
@@ -572,6 +575,28 @@ var NavigatorSceneConfigs = {
     animationInterpolators: {
       into: buildStyleInterpolator(FromTheRight),
       out: buildStyleInterpolator(ToTheLeft),
+    },
+  },
+  HorizontalSwipeJumpFromRight: {
+    ...BaseConfig,
+    gestures: {
+      jumpBack: {
+        ...BaseRightToLeftGesture,
+        overswipe: BaseOverswipeConfig,
+        edgeHitWidth: null,
+        isDetachable: true,
+      },
+      jumpForward: {
+        ...BaseLeftToRightGesture,
+        overswipe: BaseOverswipeConfig,
+        edgeHitWidth: null,
+        isDetachable: true,
+      },
+      pop: BaseRightToLeftGesture,
+    },
+    animationInterpolators: {
+      into: buildStyleInterpolator(FromTheLeft),
+      out: buildStyleInterpolator(FadeToTheRight),
     },
   },
   VerticalUpSwipeJump: {


### PR DESCRIPTION
`FloatFromLeft` configuration was wrong. its animation was ok but the swipe back was wrong. for example you had to swipe from left to right for a `back` action which should be swipe from right to left. 


`HorizontalSwipeJumpFromRight` is the same as `HorizontalSwipeJump` but for RTL layouts.