### PR TITLE
Adapt require regex to allow bracket access

### DIFF
--- a/packager/react-packager/src/DependencyResolver/lib/replacePatterns.js
+++ b/packager/react-packager/src/DependencyResolver/lib/replacePatterns.js
@@ -11,5 +11,5 @@
 
 exports.IMPORT_RE = /(\bimport\s+(?:[^'"]+\s+from\s+)??)(['"])([^'"]+)(\2)/g;
 exports.EXPORT_RE = /(\bexport\s+(?:[^'"]+\s+from\s+)??)(['"])([^'"]+)(\2)/g;
-exports.REQUIRE_RE = /(\brequire\s*?\(\s*?)(['"])([^'"]+)(\2\s*?\))/g;
+exports.REQUIRE_RE = /(\b\[?(?:['"])?require(?:['"])?\]?\s*?\(\s*?)(['"])([^'"]+)(\2\s*?\))/g;
 exports.SYSTEM_IMPORT_RE = /(\bSystem\.import\s*?\(\s*?)(['"])([^'"]+)(\2\s*?\))/g;

--- a/packager/react-packager/src/Resolver/__tests__/Resolver-test.js
+++ b/packager/react-packager/src/Resolver/__tests__/Resolver-test.js
@@ -604,10 +604,12 @@ describe('Resolver', function() {
         'require( \'z\' )',
         'require( "a")',
         'require("b" )',
+        '["require"]("c")',
+        '["require"]("d")',
       ].join('\n');
       /*eslint-disable */
 
-      const module = createModule('test module', ['x', 'y']);
+      const module = createModule('test module', ['x', 'y', 'd']);
 
       const resolutionResponse = new ResolutionResponseMock({
         dependencies: [module],
@@ -619,6 +621,7 @@ describe('Resolver', function() {
         return [
           ['x', createModule('changed')],
           ['y', createModule('Y')],
+          ['d', createModule('D')],
         ];
       }
 
@@ -1015,6 +1018,8 @@ describe('Resolver', function() {
           'require( \'z\' )',
           'require( "a")',
           'require("b" )',
+          '["require"]("c")',
+          '["require"]("D")',
           '});',
         ].join('\n'));
       });


### PR DESCRIPTION
Re: #465 - this adds a simple regex (http://regexr.com/3ce5f) to allow bracket requires. 

The regex is not super-complicated in order to avoid touching the packager codebase. Different matching groups would be a pain to implement.
