### PR TITLE
Add compatibility with nodenv to the ios packager

### DIFF
--- a/packager/react-native-xcode.sh
+++ b/packager/react-native-xcode.sh
@@ -41,8 +41,11 @@ elif [[ -x "$(command -v brew)" && -s "$(brew --prefix nvm)/nvm.sh" ]]; then
   . "$(brew --prefix nvm)/nvm.sh"
 fi
 
-# Initialize nodenv if it exists
-export PATH="$HOME/.nodenv/bin:$PATH"
+# Initialize nodenv if it exists, if installed via git we must modify path
+if [[ -d "$HOME/.nodenv/bin" ]]; then
+  export PATH="$HOME/.nodenv/bin:$PATH"
+fi
+
 if which nodenv > /dev/null; then eval "$(nodenv init -)"; fi
 
 react-native bundle \

--- a/packager/react-native-xcode.sh
+++ b/packager/react-native-xcode.sh
@@ -41,6 +41,10 @@ elif [[ -x "$(command -v brew)" && -s "$(brew --prefix nvm)/nvm.sh" ]]; then
   . "$(brew --prefix nvm)/nvm.sh"
 fi
 
+# Initialize nodenv if it exists
+export PATH="$HOME/.nodenv/bin:$PATH"
+if which nodenv > /dev/null; then eval "$(nodenv init -)"; fi
+
 react-native bundle \
   --entry-file index.ios.js \
   --platform ios \

--- a/packager/react-native-xcode.sh
+++ b/packager/react-native-xcode.sh
@@ -46,7 +46,9 @@ if [[ -d "$HOME/.nodenv/bin" ]]; then
   export PATH="$HOME/.nodenv/bin:$PATH"
 fi
 
-if which nodenv > /dev/null; then eval "$(nodenv init -)"; fi
+if [[ -x "$(command -v nodenv)" ]]; then
+  eval "$(nodenv init -)"
+fi
 
 react-native bundle \
   --entry-file index.ios.js \


### PR DESCRIPTION
nodenv is an alternative to nvm that I prefer to manage node verisons.

This PR adds nodenv initialization to the `react-native-xcode.sh` file in the packager, this allows the script to be run with the proper node shims in place.

This pull request should solve issue #4645 