### PR TITLE
[PushNotification] Add soundName config for UILocalNotification

### DIFF
--- a/Libraries/PushNotificationIOS/PushNotificationIOS.js
+++ b/Libraries/PushNotificationIOS/PushNotificationIOS.js
@@ -63,6 +63,7 @@ class PushNotificationIOS {
    * details is an object containing:
    *
    * - `alertBody` : The message displayed in the notification alert.
+   * - `soundName` : The sound played when the notification is fired (optional).
    *
    */
   static presentLocalNotification(details: Object) {
@@ -76,6 +77,7 @@ class PushNotificationIOS {
    *
    * - `fireDate` : The date and time when the system should deliver the notification.
    * - `alertBody` : The message displayed in the notification alert.
+   * - `soundName` : The sound played when the notification is fired (optional).
    *
    */
   static scheduleLocalNotification(details: Object) {

--- a/Libraries/PushNotificationIOS/RCTPushNotificationManager.m
+++ b/Libraries/PushNotificationIOS/RCTPushNotificationManager.m
@@ -35,6 +35,7 @@ NSString *const RCTRemoteNotificationsRegistered = @"RemoteNotificationsRegister
   UILocalNotification *notification = [UILocalNotification new];
   notification.fireDate = [RCTConvert NSDate:details[@"fireDate"]] ?: [NSDate date];
   notification.alertBody = [RCTConvert NSString:details[@"alertBody"]];
+  notification.soundName = [RCTConvert NSString:details[@"soundName"]] ?: UILocalNotificationDefaultSoundName;
   return notification;
 }
 


### PR DESCRIPTION
Current version wasn't triggering any sound when a local notification was fired. I added the possibility to provide a custom sound and fallback to the default iOS sound if not provided.