### PR TITLE
adds sample library distinction

### DIFF
--- a/docs/LinkingLibraries.md
+++ b/docs/LinkingLibraries.md
@@ -41,7 +41,7 @@ $ npm install rnpm -g
 
 Install a library with native dependencies:
 ```bash
-$ npm install library-with-native-dependencies --save
+$ npm install <library-with-native-dependencies> --save
 ```
 
 **Note:** _`--save` or `--save-dev` flag is very important for this step. `rnpm` will link


### PR DESCRIPTION
I am not sure if this warrants a change but I had a hard time Linking my first library in my React Native project. Following the steps was pretty easy but at first glance it seems like `library-with-native-dependencies` is a real npm library.

Adding the `<>` removes any confusion and helps the reader know `<library-with-native-dependencies>` is a placeholder. 