### PR TITLE
Update templates to ES2015

### DIFF
--- a/local-cli/generator/templates/index.android.js
+++ b/local-cli/generator/templates/index.android.js
@@ -2,6 +2,7 @@
  * Sample React Native App
  * https://github.com/facebook/react-native
  */
+'use strict';
 import React, {
   AppRegistry,
   StyleSheet,

--- a/local-cli/generator/templates/index.android.js
+++ b/local-cli/generator/templates/index.android.js
@@ -11,6 +11,24 @@ import React, {
   View
 } from 'react-native';
 
+class <%= name %> extends Component {
+  render() {
+    return (
+      <View style={styles.container}>
+        <Text style={styles.welcome}>
+          Welcome to React Native!
+        </Text>
+        <Text style={styles.instructions}>
+          To get started, edit index.android.js
+        </Text>
+        <Text style={styles.instructions}>
+          Shake or press menu button for dev menu
+        </Text>
+      </View>
+    );
+  }
+}
+
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -29,23 +47,5 @@ const styles = StyleSheet.create({
     marginBottom: 5,
   },
 });
-
-class <%= name %> extends Component {
-  render() {
-    return (
-      <View style={styles.container}>
-        <Text style={styles.welcome}>
-          Welcome to React Native!
-        </Text>
-        <Text style={styles.instructions}>
-          To get started, edit index.android.js
-        </Text>
-        <Text style={styles.instructions}>
-          Shake or press menu button for dev menu
-        </Text>
-      </View>
-    );
-  }
-}
 
 AppRegistry.registerComponent('<%= name %>', () => <%= name %>);

--- a/local-cli/generator/templates/index.android.js
+++ b/local-cli/generator/templates/index.android.js
@@ -27,7 +27,7 @@ class <%= name %> extends Component {
       </View>
     );
   }
-};
+}
 
 var styles = StyleSheet.create({
   container: {

--- a/local-cli/generator/templates/index.android.js
+++ b/local-cli/generator/templates/index.android.js
@@ -19,7 +19,7 @@ class <%= name %> extends Component {
           Welcome to React Native!
         </Text>
         <Text style={styles.instructions}>
-          To get started, edit index.ios.js
+          To get started, edit index.android.js
         </Text>
         <Text style={styles.instructions}>
           Press Cmd+R to reload,{'\n'}

--- a/local-cli/generator/templates/index.android.js
+++ b/local-cli/generator/templates/index.android.js
@@ -22,8 +22,7 @@ class <%= name %> extends Component {
           To get started, edit index.android.js
         </Text>
         <Text style={styles.instructions}>
-          Press Cmd+R to reload,{'\n'}
-          Cmd+D or shake for dev menu
+          Shake or press menu button for dev menu
         </Text>
       </View>
     );

--- a/local-cli/generator/templates/index.android.js
+++ b/local-cli/generator/templates/index.android.js
@@ -2,33 +2,33 @@
  * Sample React Native App
  * https://github.com/facebook/react-native
  */
-'use strict';
-
-var React = require('react-native');
-var {
+import React, {
   AppRegistry,
   StyleSheet,
+  Component,
   Text,
-  View,
-} = React;
+  View
+} from 'react-native';
 
-var <%= name %> = React.createClass({
-  render: function() {
+
+class <%= name %> extends Component {
+  render() {
     return (
       <View style={styles.container}>
         <Text style={styles.welcome}>
           Welcome to React Native!
         </Text>
         <Text style={styles.instructions}>
-          To get started, edit index.android.js
+          To get started, edit index.ios.js
         </Text>
         <Text style={styles.instructions}>
-          Shake or press menu button for dev menu
+          Press Cmd+R to reload,{'\n'}
+          Cmd+D or shake for dev menu
         </Text>
       </View>
     );
   }
-});
+};
 
 var styles = StyleSheet.create({
   container: {

--- a/local-cli/generator/templates/index.android.js
+++ b/local-cli/generator/templates/index.android.js
@@ -5,8 +5,8 @@
 'use strict';
 import React, {
   AppRegistry,
-  StyleSheet,
   Component,
+  StyleSheet,
   Text,
   View
 } from 'react-native';

--- a/local-cli/generator/templates/index.android.js
+++ b/local-cli/generator/templates/index.android.js
@@ -10,25 +10,6 @@ import React, {
   View
 } from 'react-native';
 
-
-class <%= name %> extends Component {
-  render() {
-    return (
-      <View style={styles.container}>
-        <Text style={styles.welcome}>
-          Welcome to React Native!
-        </Text>
-        <Text style={styles.instructions}>
-          To get started, edit index.android.js
-        </Text>
-        <Text style={styles.instructions}>
-          Shake or press menu button for dev menu
-        </Text>
-      </View>
-    );
-  }
-}
-
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -47,5 +28,23 @@ const styles = StyleSheet.create({
     marginBottom: 5,
   },
 });
+
+class <%= name %> extends Component {
+  render() {
+    return (
+      <View style={styles.container}>
+        <Text style={styles.welcome}>
+          Welcome to React Native!
+        </Text>
+        <Text style={styles.instructions}>
+          To get started, edit index.android.js
+        </Text>
+        <Text style={styles.instructions}>
+          Shake or press menu button for dev menu
+        </Text>
+      </View>
+    );
+  }
+}
 
 AppRegistry.registerComponent('<%= name %>', () => <%= name %>);

--- a/local-cli/generator/templates/index.android.js
+++ b/local-cli/generator/templates/index.android.js
@@ -29,7 +29,7 @@ class <%= name %> extends Component {
   }
 }
 
-var styles = StyleSheet.create({
+const styles = StyleSheet.create({
   container: {
     flex: 1,
     justifyContent: 'center',

--- a/local-cli/generator/templates/index.ios.js
+++ b/local-cli/generator/templates/index.ios.js
@@ -2,6 +2,7 @@
  * Sample React Native App
  * https://github.com/facebook/react-native
  */
+'use strict';
 import React, {
   AppRegistry,
   StyleSheet,

--- a/local-cli/generator/templates/index.ios.js
+++ b/local-cli/generator/templates/index.ios.js
@@ -11,25 +11,6 @@ import React, {
   View
 } from 'react-native';
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-    backgroundColor: '#F5FCFF',
-  },
-  welcome: {
-    fontSize: 20,
-    textAlign: 'center',
-    margin: 10,
-  },
-  instructions: {
-    textAlign: 'center',
-    color: '#333333',
-    marginBottom: 5,
-  },
-});
-
 class <%= name %> extends Component {
   render() {
     return (
@@ -48,5 +29,24 @@ class <%= name %> extends Component {
     );
   }
 }
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: '#F5FCFF',
+  },
+  welcome: {
+    fontSize: 20,
+    textAlign: 'center',
+    margin: 10,
+  },
+  instructions: {
+    textAlign: 'center',
+    color: '#333333',
+    marginBottom: 5,
+  },
+});
 
 AppRegistry.registerComponent('<%= name %>', () => <%= name %>);

--- a/local-cli/generator/templates/index.ios.js
+++ b/local-cli/generator/templates/index.ios.js
@@ -2,18 +2,17 @@
  * Sample React Native App
  * https://github.com/facebook/react-native
  */
-'use strict';
-
-var React = require('react-native');
-var {
+import React, {
   AppRegistry,
   StyleSheet,
+  Component,
   Text,
-  View,
-} = React;
+  View
+} from 'react-native';
 
-var <%= name %> = React.createClass({
-  render: function() {
+
+class <%= name %> extends Component {
+  render() {
     return (
       <View style={styles.container}>
         <Text style={styles.welcome}>
@@ -29,7 +28,7 @@ var <%= name %> = React.createClass({
       </View>
     );
   }
-});
+};
 
 var styles = StyleSheet.create({
   container: {

--- a/local-cli/generator/templates/index.ios.js
+++ b/local-cli/generator/templates/index.ios.js
@@ -10,6 +10,24 @@ import React, {
   View
 } from 'react-native';
 
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: '#F5FCFF',
+  },
+  welcome: {
+    fontSize: 20,
+    textAlign: 'center',
+    margin: 10,
+  },
+  instructions: {
+    textAlign: 'center',
+    color: '#333333',
+    marginBottom: 5,
+  },
+});
 
 class <%= name %> extends Component {
   render() {
@@ -29,24 +47,5 @@ class <%= name %> extends Component {
     );
   }
 }
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-    backgroundColor: '#F5FCFF',
-  },
-  welcome: {
-    fontSize: 20,
-    textAlign: 'center',
-    margin: 10,
-  },
-  instructions: {
-    textAlign: 'center',
-    color: '#333333',
-    marginBottom: 5,
-  },
-});
 
 AppRegistry.registerComponent('<%= name %>', () => <%= name %>);

--- a/local-cli/generator/templates/index.ios.js
+++ b/local-cli/generator/templates/index.ios.js
@@ -5,8 +5,8 @@
 'use strict';
 import React, {
   AppRegistry,
-  StyleSheet,
   Component,
+  StyleSheet,
   Text,
   View
 } from 'react-native';

--- a/local-cli/generator/templates/index.ios.js
+++ b/local-cli/generator/templates/index.ios.js
@@ -28,7 +28,7 @@ class <%= name %> extends Component {
       </View>
     );
   }
-};
+}
 
 var styles = StyleSheet.create({
   container: {

--- a/local-cli/generator/templates/index.ios.js
+++ b/local-cli/generator/templates/index.ios.js
@@ -30,7 +30,7 @@ class <%= name %> extends Component {
   }
 }
 
-var styles = StyleSheet.create({
+const styles = StyleSheet.create({
   container: {
     flex: 1,
     justifyContent: 'center',


### PR DESCRIPTION
I don't know the reasons, why the templates are written with the `react.createClass`method. Today I see lot's of examples using the **ES6 way**. In my own projects I'm using this way, too.

I removed `use strict`, since *Module code is always strict mode code*, according to the [spec](http://www.ecma-international.org/ecma-262/6.0/#sec-strict-mode-code).

Maybe we should **discuss** the usage of ES6 in the templates.