### PR TITLE
Use //# instead of //@ for sourceMappingURL comment

### DIFF
--- a/packager/react-packager/src/Bundler/Bundle.js
+++ b/packager/react-packager/src/Bundler/Bundle.js
@@ -14,7 +14,7 @@ const UglifyJS = require('uglify-js');
 const ModuleTransport = require('../lib/ModuleTransport');
 const Activity = require('../Activity');
 
-const SOURCEMAPPING_URL = '\n\/\/@ sourceMappingURL=';
+const SOURCEMAPPING_URL = '\n\/\/# sourceMappingURL=';
 
 const minifyCode = code =>
   UglifyJS.minify(code, {fromString: true, ascii_only: true}).code;

--- a/packager/react-packager/src/Bundler/__tests__/Bundle-test.js
+++ b/packager/react-packager/src/Bundler/__tests__/Bundle-test.js
@@ -43,7 +43,7 @@ describe('Bundle', function() {
       expect(bundle.getSource({dev: true})).toBe([
         'transformed foo;',
         'transformed bar;',
-        '\/\/@ sourceMappingURL=test_url'
+        '\/\/# sourceMappingURL=test_url'
       ].join('\n'));
     });
 
@@ -90,7 +90,7 @@ describe('Bundle', function() {
         'transformed bar;',
         ';require("bar");',
         ';require("foo");',
-        '\/\/@ sourceMappingURL=test_url',
+        '\/\/# sourceMappingURL=test_url',
       ].join('\n'));
     });
 


### PR DESCRIPTION
I had an issue debugging in chrome 48 on windows where source maps didn't work. I tried changing the sourceMappingURL comment to use the //# syntax instead and it fixed the problem.

According to https://developers.google.com/web/updates/2013/06/sourceMappingURL-and-sourceURL-syntax-changed?hl=en the //@ syntax was deprecated for //#.