### PR TITLE
iOS: Fix Image source={{ uri: null }} to crash

### DIFF
--- a/React/Base/RCTImageSource.m
+++ b/React/Base/RCTImageSource.m
@@ -8,6 +8,7 @@
  */
 
 #import "RCTImageSource.h"
+#import "RCTUtils.h"
 
 @interface RCTImageSource ()
 
@@ -60,8 +61,7 @@
   CGFloat scale = 1.0;
   BOOL packagerAsset = NO;
   if ([json isKindOfClass:[NSDictionary class]]) {
-    id uri = json[@"uri"];
-    if (!([uri isKindOfClass:[NSString class]]) || !(imageURL = [self NSURL:uri])) {
+    if (!(imageURL = [self NSURL:RCTNilIfNull(json[@"uri"])])) {
       return nil;
     }
     size = [self CGSize:json];

--- a/React/Base/RCTImageSource.m
+++ b/React/Base/RCTImageSource.m
@@ -60,7 +60,8 @@
   CGFloat scale = 1.0;
   BOOL packagerAsset = NO;
   if ([json isKindOfClass:[NSDictionary class]]) {
-    if (!(imageURL = [self NSURL:json[@"uri"]])) {
+    id uri = json[@"uri"];
+    if (!([uri isKindOfClass:[NSString class]]) || !(imageURL = [self NSURL:uri])) {
       return nil;
     }
     size = [self CGSize:json];


### PR DESCRIPTION
this is a recent regression because the error appeared in my app (from 0.16 to 0.17).

```
<Image source={{ uri: null }} />
```

will make an error:

```
[RCTConvert.m:55] Error setting property 'source' of RCTImageView with tag #317: JSON value '<null>' of type NSNull cannot be converted to NSString
```


The solution attached is to check that uri is a NSString and return nil if not (the same way nil is returned in case of invalid url).