### PR TITLE
Fix jest preprocessor script

### DIFF
--- a/jestSupport/preprocessor.js
+++ b/jestSupport/preprocessor.js
@@ -26,6 +26,6 @@ module.exports = {
   getCacheKey: createCacheKeyFunction([
     __filename,
     path.join(__dirname, '../packager/transformer.js'),
-    path.join(__dirname, '../node_modules/babel-core/package.json'),
+    require.resolve('babel-core/package.json'),
   ]),
 };


### PR DESCRIPTION
Related to #3999 

There is an issue with the `preprocessor` script when using node >=5 as it uses npm 3. ~~There are (at least) two solutions, (I'm submitting the first one):~~
- ~~specify min required node version to 5.x and modify [this the preprocessor script](https://github.com/facebook/react-native/blob/0.16-stable/jestSupport/preprocessor.js#L29) to match npm 3 requirements~~
- ~~specifify node version >= 4.x and < 5.x and let the preprocessor script as it is~~

**EDIT**:
Using `require.resolve` will do the trick !

--
Thank you guys for this amazing project by the way ;)
