### PR TITLE
Fixes error when navigationBar is set back to null

### DIFF
--- a/Libraries/CustomComponents/Navigator/Navigator.js
+++ b/Libraries/CustomComponents/Navigator/Navigator.js
@@ -1089,7 +1089,7 @@ var Navigator = React.createClass({
     return React.cloneElement(this.props.navigationBar, {
       ref: (navBar) => {
         var navigationBar = this.props.navigationBar;
-        if (navigationBar && typeof navigationBar.ref === "function") {
+        if (navigationBar && typeof navigationBar.ref === 'function') {
           navigationBar.ref(navBar);
         }
         this._navBar = navBar;

--- a/Libraries/CustomComponents/Navigator/Navigator.js
+++ b/Libraries/CustomComponents/Navigator/Navigator.js
@@ -1083,16 +1083,16 @@ var Navigator = React.createClass({
   },
 
   _renderNavigationBar: function() {
-    if (!this.props.navigationBar) {
+    let { navigationBar } = this.props;
+    if (!navigationBar) {
       return null;
     }
-    return React.cloneElement(this.props.navigationBar, {
+    return React.cloneElement(navigationBar, {
       ref: (navBar) => {
-        var navigationBar = this.props.navigationBar;
+        this._navBar = navBar;
         if (navigationBar && typeof navigationBar.ref === 'function') {
           navigationBar.ref(navBar);
         }
-        this._navBar = navBar;
       },
       navigator: this._navigationBarNavigator,
       navState: this.state,

--- a/Libraries/CustomComponents/Navigator/Navigator.js
+++ b/Libraries/CustomComponents/Navigator/Navigator.js
@@ -1089,7 +1089,7 @@ var Navigator = React.createClass({
     return React.cloneElement(this.props.navigationBar, {
       ref: (navBar) => {
         var navigationBar = this.props.navigationBar;
-        if (navigationBar && navigationBar.ref instanceof Function) {
+        if (navigationBar && typeof navigationBar.ref === "function") {
           navigationBar.ref(navBar);
         }
         this._navBar = navBar;

--- a/Libraries/CustomComponents/Navigator/Navigator.js
+++ b/Libraries/CustomComponents/Navigator/Navigator.js
@@ -1088,7 +1088,10 @@ var Navigator = React.createClass({
     }
     return React.cloneElement(this.props.navigationBar, {
       ref: (navBar) => {
-        this.props.navigationBar.ref instanceof Function && this.props.navigationBar.ref(navBar);
+        var navigationBar = this.props.navigationBar;
+        if (navigationBar && navigationBar.ref instanceof Function) {
+          navigationBar.ref(navBar);
+        }
         this._navBar = navBar;
       },
       navigator: this._navigationBarNavigator,


### PR DESCRIPTION
This fixes a regression introduced in https://github.com/facebook/react-native/commit/df70005c12e3be14bfbdf0b32f9ea0a5c052deba

If you set navigationBar props (on Navigator) and then later set it back to null, it will crashes.
(N.B. this should be possible as navigationBar is optional)


cc @satya164 