### PR TITLE
[Android] navigationBar title is not in the middle

### DIFF
--- a/Libraries/CustomComponents/Navigator/NavigatorNavigationBarStylesAndroid.js
+++ b/Libraries/CustomComponents/Navigator/NavigatorNavigationBarStylesAndroid.js
@@ -45,10 +45,9 @@ var BASE_STYLES = {
     bottom: 0,
     left: 0,
     right: 0,
-    alignItems: 'flex-start',
+    alignItems: 'center',
     height: NAV_ELEMENT_HEIGHT,
     backgroundColor: 'transparent',
-    marginLeft: TITLE_LEFT,
   },
   LeftButton: {
     position: 'absolute',


### PR DESCRIPTION
The fix https://github.com/timzaak/react-native/commit/31f3257c2ca50757596c3fd36f1fbf3d280fc7f9 was not merged properly, possibly when splitting per-platform navigation bar styles at https://github.com/facebook/react-native/commit/2c7de35dee347b5d9a40b4e87862622e60ddf7d9#diff-dd4d9e170fe2c59c308ac4f720125002.

https://github.com/facebook/react-native/issues/3142