### PR TITLE
[LinkingIOS] Improve deep linking payload sent to JS on openURL

### DIFF
--- a/website/src/react-native/feedback.js
+++ b/website/src/react-native/feedback.js
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+var React = require('React');
+var Site = require('Site');
+var center = require('center');
+
+var support = React.createClass({
+  childContextTypes: {
+    permalink: React.PropTypes.string
+  },
+
+  getChildContext: function() {
+    return {permalink: 'support.html'};
+  },
+
+  render: function() {
+    return (
+      <Site section="feedback" title="Feedback">
+        <section className="content wrap documentationContent nosidebar">
+          <div className="inner-content">
+            <h1>Feedback</h1>
+            <div className="subHeader"></div>
+            <p><strong>React Native</strong> uses <a href="https://productpains.com/product/react-native/">Product Pains</a> for feature requests. It has a voting system to surface which issues are most important to the community. GitHub issues should only be used for bugs.</p>
+            <iframe
+              width="100%"
+              height="360px"
+              scrolling="no"
+              src="https://productpains.com/widget.html?token=3b929306-e0f7-5c94-7d7c-ecc05d059748"
+            />
+            <script
+              type="text/javascript"
+              src="https://productpains.com/js/lib/iframeResizer.min.js"
+            />
+          </div>
+        </section>
+      </Site>
+    );
+  },
+});
+
+module.exports = support;

--- a/website/src/react-native/support.js
+++ b/website/src/react-native/support.js
@@ -40,9 +40,13 @@ var support = React.createClass({
             <ul>
               <li><a href="http://reactnative.cn">Chinese</a> (<a href="https://github.com/reactnativecn/react-native-docs-cn">source</a>)</li>
             </ul>
-            
+
             <H2>Stack Overflow</H2>
             <p>Many members of the community use Stack Overflow to ask questions. Read through the <a href="http://stackoverflow.com/questions/tagged/react-native">existing questions</a> tagged with <strong>react-native</strong> or <a href="http://stackoverflow.com/questions/ask">ask your own</a>!</p>
+
+            <H2>Feedback</H2>
+            <p>React Native uses <a href="https://productpains.com/product/react-native/">Product Pains</a> for feature requests. It has a voting system to surface which issues are most important to the community. GitHub issues should only be used for bugs.</p>
+            <p>You can search for existing requests to vote on, or write your own <a href="feedback.html">on this page</a>.</p>
 
             <H2>Chat</H2>
             <p>Join us in <strong><a href="irc://chat.freenode.net/reactnative">#reactnative on Reactiflux</a></strong>.</p>


### PR DESCRIPTION
**Prior to this commit, just the URL string is sent to JS.**

```javascript
_handleOpenURL(event) {}
```

where

```javascript
event = {
  url: 'Scheme://Host/Path?Query=Parameters',
}
```

This leaves JS to parse the URL when we already have a great parsing
tool (`NSURLComponents`) in iOS from Apple.

**Test Plan - tested the following URLs**
1) `url = 'reactnative://foo.bar/baz?a=b&c=d'`

```javascript
event = {
  host: 'foo.bar',
  parameters: {
    a: 'b',
    c: 'd',
  },
  path: '/baz',
  scheme: 'reactnative',
  url: 'reactnative://foo.bar/baz?a=b&c=d',
}
```

2) `url = 'reactnative://'`

```javascript
event = {
  host: '',
  parameters: {},
  path: '',
  scheme: 'reactnative',
  url: 'reactnative://',
}
```