### PR TITLE
Fix InteractionManager-test.js

### DIFF
--- a/Libraries/Interaction/__tests__/InteractionManager-test.js
+++ b/Libraries/Interaction/__tests__/InteractionManager-test.js
@@ -5,9 +5,8 @@
 'use strict';
 
 jest
-  .dontMock('InteractionManager')
-  .dontMock('TaskQueue')
-  .dontMock('invariant');
+  .autoMockOff()
+  .mock('BatchedBridge');
 
 function expectToBeCalledOnce(fn) {
   expect(fn.mock.calls.length).toBe(1);


### PR DESCRIPTION
Rather than specifying what not to mock, turn off autoMock for this test suite, and only mock BatchedBridge.

Fixes #4965 