### PR TITLE
Clarify the way of classifying metered connection

### DIFF
--- a/Libraries/Network/NetInfo.js
+++ b/Libraries/Network/NetInfo.js
@@ -131,8 +131,8 @@ const _isConnectedSubscriptions = new Map();
  * ### isConnectionExpensive
  *
  * Available on Android. Detect if the current active connection is metered or not. A network is
- * classified as metered when the user is sensitive to heavy data usage on that connection due to
- * monetary costs, data limitations or battery/performance issues.
+ * classified as metered when the user is on a cellular network or a wifi hotspot based on a 
+ * cellular network.
  *
  * ```
  * NetInfo.isConnectionExpensive((isConnectionExpensive) => {


### PR DESCRIPTION
The original explanation is all about `user`, but not `the API's behaviour`, which is uncertain and not helpful.  
According to [this post](http://stackoverflow.com/questions/23877476/android-why-connectivitymanager-isactivenetworkmetered-always-returning-true) on SO, `cellular network` and `hotspot based on cellular network` are explicitly metered.