### PR TITLE
Update incorrect WebSocket example in Network.md

### DIFF
--- a/docs/Network.md
+++ b/docs/Network.md
@@ -74,25 +74,25 @@ WebSocket is a protocol providing full-duplex communication channels over a sing
 ```js
 var ws = new WebSocket('ws://host.com/path');
 
-ws.on('open', function() {
+ws.onopen = () => {
   // connection opened
   ws.send('something');
-});
+};
 
-ws.on('message', function(e) {
+ws.onmessage = (e) => {
   // a message was received
   console.log(e.data);
-});
+};
 
-ws.on('error', function(e) {
+ws.onerror = (e) => {
   // an error occurred
   console.log(e.message);
-});
+};
 
-ws.on('close', function(e) {
+ws.onclose = (e) => {
   // connection closed
   console.log(e.code, e.reason);
-});
+};
 ```
 
 ## XMLHttpRequest


### PR DESCRIPTION
Using the provided WebSocket example under react-native 0.17, the sample code throws the following error:

"TypeError: ws.on is not a function(…)"

It's listening on ".on" which does not exist, rather than assigning a function to onopen, onmessage, onerror and onclose.

See: https://developer.mozilla.org/en-US/docs/Web/API/WebSocket