### PR TITLE
Fix maxLength of multibyte characters for TextInput

### DIFF
--- a/Examples/UIExplorer/TextInputExample.ios.js
+++ b/Examples/UIExplorer/TextInputExample.ios.js
@@ -103,7 +103,7 @@ class RewriteExample extends React.Component {
   }
   render() {
     var limit = 20;
-    var remainder = limit - this.state.text.length;
+    var remainder = limit - Array.from(this.state.text).length;
     var remainderColor = remainder > 5 ? 'blue' : 'red';
     return (
       <View style={styles.rewriteContainer}>


### PR DESCRIPTION
Fix issue [#2343](https://github.com/facebook/react-native/issues/2343).  
- Combining character sequences like ў and emoji are count as one symbol.
- Marked text are not truncate because they represent text that are not confirmed yet, and the confirmed result could be shorter than the marked text. For example, the picture shows a Chinese strokes keyboard, where 3 marked text(strokes) could be confirmed as one character "要", as shown on the candidate bar. 

<img src="https://cloud.githubusercontent.com/assets/2288732/12029188/aabf965e-ae1f-11e5-9d46-5313fa63d978.png" width="300">




