### PR TITLE
increased stability of circleCI e2e tests

### DIFF
--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -24,6 +24,8 @@ task createNativeDepsDirectories {
 task downloadBoost(dependsOn: createNativeDepsDirectories, type: Download) {
     // Use ZIP version as it's faster this way to selectively extract some parts of the archive
     src 'https://downloads.sourceforge.net/project/boost/boost/1.57.0/boost_1_57_0.zip'
+    // alternative
+    // src 'http://mirror.nienbo.com/boost/boost_1_57_0.zip'
     onlyIfNewer true
     overwrite false
     dest new File(downloadsDir, 'boost_1_57_0.zip')

--- a/circle.yml
+++ b/circle.yml
@@ -4,33 +4,37 @@ machine:
   environment:
     PATH: "~/$CIRCLE_PROJECT_REPONAME/gradle-2.9/bin:$PATH"
     TERM: "dumb"
-    ADB_INSTALL_TIMEOUT: "10"
+    ADB_INSTALL_TIMEOUT: 10
     GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx512m -XX:+HeapDumpOnOutOfMemoryError"'
 
 dependencies:
   pre:
+  # using npm@3 because of problems with shrink-wrapped optional deps installs on linux
   - npm install -g npm@3.2
-  - wget "https://services.gradle.org/distributions/gradle-2.9-bin.zip"; unzip gradle-2.9-bin.zip
+  - source scripts/circle-ci-android-setup.sh && getAndroidSDK
+  - ./gradlew :ReactAndroid:downloadBoost :ReactAndroid:downloadDoubleConversion :ReactAndroid:downloadFolly :ReactAndroid:downloadGlog
+  cache_directories:
+  - "ReactAndroid/build/downloads"
 test:
   pre:
     # starting emulator in advance because it takes very long to boot
-    # the side effect is that we loose 1GB of RAM for all the following commands
-    # if builds are running out of memory move the emulator start right before `wait-for-boot`
-    - emulator -avd circleci-android22 -no-audio -no-window:
-              background: true
-              parallel: true
+    - $ANDROID_HOME/tools/emulator -avd testAVD -no-skin -no-audio -no-window:
+            background: true
+    # assemble done separately because it requires quite a lot of memory and also gives time for emulator to load
+    - ./gradlew :ReactAndroid:assembleDebug -PdisablePreDex -Pjobs=1:
+            timeout: 360
+    - source scripts/circle-ci-android-setup.sh && waitForAVD
   override:
-    # build ndkreactlib first because it consumes memory and downloads stuff
-    - ./gradlew :ReactAndroid:buildReactNdkLib -PdisablePreDex -Pjobs=1
     # unit tests
     - ./gradlew :ReactAndroid:testDebugUnitTest -PdisablePreDex
     # build JS bundle for instrumentation tests
     - node local-cli/cli.js bundle --platform android --dev true --entry-file ReactAndroid/src/androidTest/assets/TestBundle.js --bundle-output ReactAndroid/src/androidTest/assets/AndroidTestBundle.js
-    # run instrumentation tests on device
-    - circle-android wait-for-boot
-    - sleep 5
-    # unlock the emulator screen
-    - adb shell input keyevent 82
-    - sleep 5
     # run tests on the emulator
-    - ./gradlew :ReactAndroid:connectedAndroidTest -PdisablePreDex --stacktrace
+    - ./gradlew :ReactAndroid:connectedAndroidTest -PdisablePreDex --stacktrace --info:
+        timeout: 360
+  post:
+    # copy test report for Circle CI to display
+    - mkdir -p $CIRCLE_TEST_REPORTS/junit/
+    - find . -type f -regex ".*/build/test-results/debug/.*xml" -exec cp {} $CIRCLE_TEST_REPORTS/junit/ \;
+    - find . -type f -regex ".*/outputs/androidTest-results/connected/.*xml" -exec cp {} $CIRCLE_TEST_REPORTS/junit/ \;
+

--- a/scripts/circle-ci-android-setup.sh
+++ b/scripts/circle-ci-android-setup.sh
@@ -1,0 +1,22 @@
+# inspired by https://github.com/Originate/guide/blob/master/android/guide/Continuous%20Integration.md
+
+function getAndroidSDK {
+  export PATH="$ANDROID_HOME/platform-tools:$ANDROID_HOME/tools:$PATH"
+
+  DEPS="$ANDROID_HOME/installed-dependencies"
+
+  if [ ! -e $DEPS ]; then
+    echo no | android create avd -n testAVD -f -t android-19 --abi default/armeabi-v7a &&
+    touch $DEPS
+  fi
+}
+
+function waitForAVD {
+  local bootanim=""
+  export PATH=$(dirname $(dirname $(which android)))/platform-tools:$PATH
+  until [[ "$bootanim" =~ "stopped" ]]; do
+    sleep 5
+    bootanim=$(adb -e shell getprop init.svc.bootanim 2>&1)
+    echo "emulator status=$bootanim"
+  done
+}


### PR DESCRIPTION
Out of 57 builds in the 5 days during Christmas only 15 were successful.
15 of the failed ones were caused by `com.android.ddmlib.ShellCommandUnresponsiveException` when running unstrumentation tests.
Another 10 were because of crashes probably related to memory usage.

This PR follows ideas from https://github.com/Originate/guide/blob/master/android/guide/Continuous%20Integration.md

So far I've made 6 successful builds with this setup.
Need to run it for a few more days to get accurate stats.