### PR TITLE
[iOS] Setting UIRefreshControl state for ScrollView

### DIFF
--- a/Examples/UIExplorer/ScrollViewExample.js
+++ b/Examples/UIExplorer/ScrollViewExample.js
@@ -20,8 +20,40 @@ var {
   ScrollView,
   StyleSheet,
   View,
-  Image
+  Image,
+  Text
 } = React;
+
+var RefreshScrollView = React.createClass({
+  getInitialState: function() {
+    return {
+      refreshing:false,
+    };
+  },
+
+  render: function() {
+    return (
+      <View>
+        <ScrollView
+          refreshing={this.state.refreshing}
+          onRefreshStart={(endRefreshing) => {
+            this.setState({refreshing: true});
+          }}
+          automaticallyAdjustContentInsets={false}
+          onScroll={() => { console.log('onScroll!'); }}
+          scrollEventThrottle={200}
+          style={styles.scrollView}>
+          {THUMBS.map(createThumbRow)}
+        </ScrollView>
+        <Text style={styles.trigger} onPress={()=>{
+          this.setState({refreshing: !this.state.refreshing});
+        }}>
+          {this.state.refreshing ? 'Tap to End Refreshing' : 'Tap to Begin Refreshing'}
+        </Text>
+      </View>
+    );
+  }
+});
 
 exports.displayName = (undefined: ?string);
 exports.title = '<ScrollView>';
@@ -31,15 +63,7 @@ exports.examples = [
   title: '<ScrollView>',
   description: 'To make content scrollable, wrap it within a <ScrollView> component',
   render: function() {
-    return (
-      <ScrollView
-        automaticallyAdjustContentInsets={false}
-        onScroll={() => { console.log('onScroll!'); }}
-        scrollEventThrottle={200}
-        style={styles.scrollView}>
-        {THUMBS.map(createThumbRow)}
-      </ScrollView>
-    );
+    return (<RefreshScrollView/>);
   }
 }, {
   title: '<ScrollView> (horizontal = true)',
@@ -109,5 +133,9 @@ var styles = StyleSheet.create({
   img: {
     width: 64,
     height: 64,
-  }
+  },
+  trigger: {
+    height: 20,
+    textAlign: 'center',
+  },
 });

--- a/Libraries/Components/ScrollView/ScrollView.js
+++ b/Libraries/Components/ScrollView/ScrollView.js
@@ -307,6 +307,12 @@ var ScrollView = React.createClass({
      */
     onRefreshStart: PropTypes.func,
 
+    /**
+     * Whether a UIRefreshControl should be displayed and indicating an active refresh.
+     *
+     * @platform ios
+     */
+    refreshing: React.PropTypes.bool,
   },
 
   mixins: [ScrollResponder.Mixin],

--- a/React/Views/RCTScrollView.h
+++ b/React/Views/RCTScrollView.h
@@ -48,6 +48,7 @@
 @property (nonatomic, copy) NSString *snapToAlignment;
 @property (nonatomic, copy) NSIndexSet *stickyHeaderIndices;
 @property (nonatomic, copy) RCTDirectEventBlock onRefreshStart;
+@property (nonatomic, assign) BOOL refreshing;
 
 - (void)endRefreshing;
 

--- a/React/Views/RCTScrollView.m
+++ b/React/Views/RCTScrollView.m
@@ -863,11 +863,7 @@ RCT_SET_AND_PRESERVE_OFFSET(setScrollIndicatorInsets, UIEdgeInsets);
   }
   _onRefreshStart = [onRefreshStart copy];
 
-  if (!_scrollView.refreshControl) {
-    UIRefreshControl *refreshControl = [[UIRefreshControl alloc] init];
-    [refreshControl addTarget:self action:@selector(refreshControlValueChanged) forControlEvents:UIControlEventValueChanged];
-    _scrollView.refreshControl = refreshControl;
-  }
+  [self setupRefreshControl];
 }
 
 - (void)refreshControlValueChanged
@@ -880,6 +876,35 @@ RCT_SET_AND_PRESERVE_OFFSET(setScrollIndicatorInsets, UIEdgeInsets);
 - (void)endRefreshing
 {
   [_scrollView.refreshControl endRefreshing];
+}
+
+- (void)setupRefreshControl {
+  if (!_scrollView.refreshControl) {
+    UIRefreshControl *refreshControl = [[UIRefreshControl alloc] init];
+    [refreshControl addTarget:self action:@selector(refreshControlValueChanged) forControlEvents:UIControlEventValueChanged];
+    _scrollView.refreshControl = refreshControl;
+  }
+}
+
+- (void)setRefreshing:(BOOL)refreshing {
+  if (refreshing) {
+    [self setupRefreshControl];
+    
+    if (!_scrollView.refreshControl.isRefreshing) {
+      [self scrollToOffset:CGPointMake(0, -_scrollView.refreshControl.frame.size.height) animated:YES];
+      [_scrollView.refreshControl beginRefreshing];
+    }
+  } else if (_scrollView.refreshControl) {
+    [_scrollView.refreshControl endRefreshing];
+  }
+}
+
+- (BOOL)refreshing {
+  if (!_scrollView.refreshControl) {
+    return NO;
+  }
+  
+  return _scrollView.refreshControl.isRefreshing;
 }
 
 @end

--- a/React/Views/RCTScrollViewManager.m
+++ b/React/Views/RCTScrollViewManager.m
@@ -66,6 +66,7 @@ RCT_EXPORT_VIEW_PROPERTY(snapToInterval, int)
 RCT_EXPORT_VIEW_PROPERTY(snapToAlignment, NSString)
 RCT_REMAP_VIEW_PROPERTY(contentOffset, scrollView.contentOffset, CGPoint)
 RCT_EXPORT_VIEW_PROPERTY(onRefreshStart, RCTDirectEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(refreshing, BOOL)
 
 - (NSDictionary<NSString *, id> *)constantsToExport
 {


### PR DESCRIPTION
Currently by setting onRefreshStart callback prop on ScrollView, the user can pull to trigger the refreshing state of the UIRefreshControl, but there's no way to do this programmatically.

This PR add a prop **refreshing** like PullToRefreshViewAndroid to control the refreshing state. In addition, the endRefreshing callback passed to onRefreshStart is no longer necessary 
since it could be stopped by setting refreshing={false}.

I am also wondering if it's possible to provide a unified API to control the refreshing state of ScrollView on both iOS and Android, i.e. by using prop **refreshing** and callback prop **onRefreshStart**. The implementation on Android could be wrapping the ScrollView automatically into a SwipeRefreshLayout thus developers don't need to use or care about PullToRefreshViewAndroid (and its underlying SwipeRefreshLayout) in most cases.