### PR TITLE
made option to ignore certificate error more obvious

### DIFF
--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -25,6 +25,7 @@ task downloadBoost(dependsOn: createNativeDepsDirectories, type: Download) {
     // Use ZIP version as it's faster this way to selectively extract some parts of the archive
     src 'https://downloads.sourceforge.net/project/boost/boost/1.57.0/boost_1_57_0.zip'
     onlyIfNewer true
+    acceptAnyCertificate false // set to true if there are temporary certificate problems
     overwrite false
     dest new File(downloadsDir, 'boost_1_57_0.zip')
 }


### PR DESCRIPTION
Today there were temporary SSL certificate errors with source forge.
Setting the added property to true could work as a temporary measure to allow users/CI to download the lib.

I could not find a more trustworthy mirror that hosts boost, maybe we should use CDN binaries like that to be less dependent on third parties?