### PR TITLE
[android] Enables webview debugging

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebViewManager.java
@@ -74,13 +74,6 @@ public class ReactWebViewManager extends SimpleViewManager<WebView> {
 
   private WebViewConfig mWebViewConfig;
 
-  static {
-    if (ReactBuildConfig.DEBUG && Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-      // TODO(T9455950): re-enable debugging
-      // WebView.setWebContentsDebuggingEnabled(true);
-    }
-  }
-
   private static class ReactWebViewClient extends WebViewClient {
 
     private boolean mLastLoadFailed = false;
@@ -248,6 +241,11 @@ public class ReactWebViewManager extends SimpleViewManager<WebView> {
     ReactWebView webView = new ReactWebView(reactContext);
     reactContext.addLifecycleEventListener(webView);
     mWebViewConfig.configWebView(webView);
+
+    if (ReactBuildConfig.DEBUG && Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+      WebView.setWebContentsDebuggingEnabled(true);
+    }
+
     return webView;
   }
 


### PR DESCRIPTION
2 things that I want to clarify / ask for feedback:

* do we really need to make sure we're running on the UI thread? I guess `onPageStarted` maybe already runs there? Couldnt find anything [here](http://developer.android.com/reference/android/webkit/WebView.html) though
* everytime a page starts we re-enable debugging -- it's a bit useless but I also don't think it's a huge problem, as debugging should only be enabled in dev

Relates to issue #4857, where we switched debugging off as, in some circumstances, it would crash the application as debugging was invoked outside the UI thread.