### PR TITLE
FIXED: UIExplorer Example / ImageExample.js

### DIFF
--- a/Examples/UIExplorer/ImageExample.js
+++ b/Examples/UIExplorer/ImageExample.js
@@ -442,7 +442,8 @@ exports.examples = [
     title: 'Image Size',
     render: function() {
       return <ImageSizeExample source={fullImage} />; 
-    }
+    },
+    platform: 'ios',
   },
 ];
 


### PR DESCRIPTION
`Image Size` was incorrectly being loaded on Android.