### PR TITLE
Fix issues running the website locally on windows with npm3

### DIFF
--- a/packager/blacklist.js
+++ b/packager/blacklist.js
@@ -89,7 +89,7 @@ var platformBlacklists = {
 
 function escapeRegExp(pattern) {
   if (Object.prototype.toString.call(pattern) === '[object RegExp]') {
-    return pattern.source;
+    return pattern.source.replace(/\//g, path.sep);
   } else if (typeof pattern === 'string') {
     var escaped = pattern.replace(/[\-\[\]\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&');
     // convert the '/' into an escaped local file separator

--- a/website/core/H2.js
+++ b/website/core/H2.js
@@ -14,9 +14,7 @@ var Header = require('Header');
 
 var H2 = React.createClass({
   render: function() {
-    return this.transferPropsTo(
-      <Header level={2}>{this.props.children}</Header>
-    );
+    return <Header {...this.props} level={2}>{this.props.children}</Header>;
   }
 });
 

--- a/website/core/Marked.js
+++ b/website/core/Marked.js
@@ -811,13 +811,16 @@ Parser.prototype.tok = function() {
       return React.DOM.hr(null, null);
     }
     case 'heading': {
-      return Header(
-        {level: this.token.depth, toSlug: this.token.text},
-        this.inline.output(this.token.text)
+      return (
+        <Header
+          level={this.token.depth}
+          toSlug={this.token.text}>
+          {this.inline.output(this.token.text)}
+        </Header>
       );
     }
     case 'code': {
-      return Prism(null, this.token.text);
+      return <Prism>{this.token.text}</Prism>;
     }
     case 'table': {
       var table = []

--- a/website/package.json
+++ b/website/package.json
@@ -11,7 +11,7 @@
     "jstransform": "latest",
     "mkdirp": "latest",
     "optimist": "0.6.0",
-    "react": "~0.12.0",
+    "react": "~0.13.0",
     "react-docgen": "^2.0.1",
     "react-page-middleware": "git://github.com/facebook/react-page-middleware.git",
     "request": "latest"

--- a/website/server/convert.js
+++ b/website/server/convert.js
@@ -16,7 +16,7 @@ var extractDocs = require('./extractDocs');
 var argv = optimist.argv;
 
 function splitHeader(content) {
-  var lines = content.split('\n');
+  var lines = content.split(/\r?\n/);
   for (var i = 1; i < lines.length - 1; ++i) {
     if (lines[i] === '---') {
       break;
@@ -87,15 +87,16 @@ function execute() {
       ' * @jsx React.DOM\n' +
       ' */\n' +
       'var React = require("React");\n' +
-      'var layout = require("' + layout + '");\n' +
+      'var Layout = require("' + layout + '");\n' +
       'var content = ' + backtickify(both.content) + '\n' +
       'var Post = React.createClass({\n' +
+      '  statics: {\n' +
+      '    content: content\n' +
+      '  },\n' +
       '  render: function() {\n' +
-      '    return layout({metadata: ' + JSON.stringify(metadata) + '}, content);\n' +
+      '    return <Layout metadata={' + JSON.stringify(metadata) + '}>{content}</Layout>;\n' +
       '  }\n' +
       '});\n' +
-      // TODO: Use React statics after upgrading React
-      'Post.content = content;\n' +
       'module.exports = Post;\n'
     );
 


### PR DESCRIPTION
I had a few issues running the website locally on Windows with npm3.

#### Windows issues

##### packager/blacklist.js
The packager was not properly ignoring the website node_modules which caused errors with the haste modules.

##### website/server/convert.js
splitHeader didn't work properly because of \r\n

#### npm3 issues

Not 100% sure about this one but the website used react@0.12 while react-page-middleware used react-tools @0.13. Updating react to 0.13 fixed the problem. I also fixed some warning about not using factory functions by using jsx instead and remove the transferPropsTo call that doesn't exist anymore in react@0.13.
