### PR TITLE
[npm] Move react-transform-hmr dep to "dependencies"

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "promise": "^7.0.4",
     "react": "^0.14.5",
     "react-timer-mixin": "^0.13.2",
+    "react-transform-hmr": "1.0.1",
     "rebound": "^0.0.13",
     "regenerator": "^0.8.36",
     "sane": "^1.2.0",
@@ -130,7 +131,6 @@
     "eslint-plugin-react": "3.3.1",
     "portfinder": "0.4.0",
     "temp": "0.8.3",
-    "babel-plugin-react-transform": "2.0.0-beta1",
-    "react-transform-hmr": "1.0.1"
+    "babel-plugin-react-transform": "2.0.0-beta1"
   }
 }


### PR DESCRIPTION
It is required from the RN app JS, so it needs to be in prod dependencies.

cc @martinbigio 