### PR TITLE
See issue #4886

### DIFF
--- a/Libraries/Geolocation/RCTLocationObserver.m
+++ b/Libraries/Geolocation/RCTLocationObserver.m
@@ -133,7 +133,11 @@ RCT_EXPORT_MODULE()
   }
 
   // Request location access permission
-  if ([_locationManager respondsToSelector:@selector(requestWhenInUseAuthorization)]) {
+  if ([[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSLocationAlwaysUsageDescription"] &&
+    [_locationManager respondsToSelector:@selector(requestAlwaysAuthorization)]) {
+    [_locationManager requestAlwaysAuthorization];
+  } else if ([[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSLocationWhenInUseUsageDescription"] &&
+    [_locationManager respondsToSelector:@selector(requestWhenInUseAuthorization)]) {
     [_locationManager requestWhenInUseAuthorization];
   }
 
@@ -327,8 +331,9 @@ RCT_EXPORT_METHOD(getCurrentPosition:(RCTLocationOptions)options
 
 - (void)checkLocationConfig
 {
-  if (![[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSLocationWhenInUseUsageDescription"]) {
-    RCTLogError(@"NSLocationWhenInUseUsageDescription key must be present in Info.plist to use geolocation.");
+  if (!([[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSLocationWhenInUseUsageDescription"] ||
+    [[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSLocationAlwaysUsageDescription"])) {
+    RCTLogError(@"Either NSLocationWhenInUseUsageDescription or NSLocationAlwaysUsageDescription key must be present in Info.plist to use geolocation.");
   }
 }
 


### PR DESCRIPTION
@brentvatne this is the pull request you requested
See issue #4886 

On iOS the plist key NSLocationAlwaysUsageDescription was ignored and the location could not be retreived when using this key. Now both keys NSLocationWhenInUseUsageDescription and NSLocationAlwaysUsageDescription are supported. If NSLocationAlwaysUsageDescription is set, NSLocationWhenInUseUsageDescription will be simply ignored according to https://developer.apple.com/library/ios/documentation/General/Reference/InfoPlistKeyReference/Articles/CocoaKeys.html#//apple_ref/doc/uid/TP40009251-SW18

I read the contribution guidelines regarding the Objective-C coding standards. Hopefully my line length breaks are okay - otherwise just give me a shout and I will fix that. Didn't write any line of Objective-C before so^^