### PR TITLE
RFC: Allow native code to define global JS functions

### DIFF
--- a/React/Base/RCTJavaScriptExecutor.h
+++ b/React/Base/RCTJavaScriptExecutor.h
@@ -85,4 +85,7 @@ typedef void (^RCTJavaScriptCallback)(id json, NSError *error);
  */
 - (void)executeAsyncBlockOnJavaScriptQueue:(dispatch_block_t)block;
 
+- (void)injectGlobal:(NSString *)name
+               value:(id)value;
+
 @end


### PR DESCRIPTION
In some cases, it is necessary to replace a slow JS implementation with a faster native one, without the burden of an async API which would require large structural changes to existing code. A good example is cryptography, whose overhead can easily be negligible when implemented in native, but can be one or two orders of magnitude slower in un-JIT-ed JS.

This change provides a simple way for JS modules to inject global functions into the JS context. These functions will be executed synchronously on the JS thread. Here's an example of how one might use this hook to provide a native SHA256 implementation with just a few lines of code:

```objc
#import <CommonCrypto/CommonDigest.h>

#import "RCTBridge.h"
#import "RCTBridgeModule.h"
#import "RCTJSCExecutor.h"

@interface NativeSHA : NSObject<RCTBridgeModule>
@end

@implementation NativeSHA

@synthesize bridge = _bridge;

RCT_EXPORT_MODULE()

- (void)setBridge:(RCTBridge *)bridge
{
  _bridge = bridge;

  id<RCTJavaScriptExecutor> executor = [bridge valueForKey:@"javaScriptExecutor"];
  if ([executor isKindOfClass:[RCTJSCExecutor class]]) {

    [executor injectGlobal:@"_sha256_hex" value: ^NSString *(NSString *value) {
      const char *inputBytes = [value UTF8String];
      unsigned char resultBytes[CC_SHA256_DIGEST_LENGTH];
      CC_SHA256(inputBytes, (CC_LONG)strlen(inputBytes), resultBytes);

      char resultHex[CC_SHA256_DIGEST_LENGTH * 2 + 1];
      bin2hex(resultHex, CC_SHA256_DIGEST_LENGTH * 2 + 1,
              resultBytes, CC_SHA256_DIGEST_LENGTH);

      return [NSString stringWithUTF8String:resultHex];
    }];
  }
}
```

This could then be used from JS as follows:
```js
var hash = global._sha256_hex(input);
```