### PR TITLE
added branch to ignore for CI tests

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,7 @@
+general:
+  branches:
+    ignore:
+      - gh-pages # list of branches to ignore
 machine:
   node:
     version: 5.1.0


### PR DESCRIPTION
every push to gh-pages renders an error in tests https://circleci.com/gh/facebook/react-native/995?utm_campaign=build-failed&utm_medium=email&utm_source=notification