### PR TITLE
Return non-zero exit code from wrong-react-native

### DIFF
--- a/local-cli/wrong-react-native.js
+++ b/local-cli/wrong-react-native.js
@@ -15,3 +15,5 @@ console.error([
   'npm uninstall -g react-native',
   'npm install -g react-native-cli'
 ].join('\n'));
+
+process.exit(1);


### PR DESCRIPTION
When used in automation, `wrong-react-native` can cause problems because it does not
report the issue via exit code.

Test plan:
```
# node local-cli/wrong-react-native.js
...
# echo $?
1
```