### PR TITLE
small hack to have circle.yml in gh-pages generated branch

### DIFF
--- a/website/publish.sh
+++ b/website/publish.sh
@@ -21,6 +21,7 @@ rm -Rf *
 cd ../react-native/website
 node server/generate.js
 cp -R build/react-native/* ../../react-native-gh-pages/
+cp ../circle.yml ../../react-native-gh-pages/
 rm -Rf build/
 cd ../../react-native-gh-pages
 git status


### PR DESCRIPTION
Ideally we would generate/prepare circle.yml specifically for gh-pages branch but for now this one is good enough.
Having this file in circle.yml will order circleCI to ignore the branch