### PR TITLE
Extended icon and selectedIcon propType to include scale

### DIFF
--- a/Libraries/Components/TabBarIOS/TabBarItemIOS.ios.js
+++ b/Libraries/Components/TabBarIOS/TabBarItemIOS.ios.js
@@ -51,12 +51,24 @@ var TabBarItemIOS = React.createClass({
     /**
      * A custom icon for the tab. It is ignored when a system icon is defined.
      */
-    icon: Image.propTypes.source,
+    icon: React.PropTypes.oneOfType([
+      React.PropTypes.shape({
+        uri: React.PropTypes.string,
+        scale: React.PropTypes.number,
+      }),
+      React.PropTypes.number,
+    ]),
     /**
      * A custom icon when the tab is selected. It is ignored when a system
      * icon is defined. If left empty, the icon will be tinted in blue.
      */
-    selectedIcon: Image.propTypes.source,
+    selectedIcon: React.PropTypes.oneOfType([
+      React.PropTypes.shape({
+        uri: React.PropTypes.string,
+        scale: React.PropTypes.number,
+      }),
+      React.PropTypes.number,
+    ]),
     /**
      * Callback when this tab is being selected, you should change the state of your
      * component to set selected={true}.


### PR DESCRIPTION
Resolves issue #4591 

Not sure what the best practice is with regards to de-duplication in propTypes, and if that proptype should therefore be declared as a variable and reused for icon and selectedIcon?