### PR TITLE
Fix `background` warning in TouchableNativeFeedback

### DIFF
--- a/Libraries/Components/Touchable/TouchableNativeFeedback.android.js
+++ b/Libraries/Components/Touchable/TouchableNativeFeedback.android.js
@@ -17,19 +17,18 @@ var Touchable = require('Touchable');
 var TouchableWithoutFeedback = require('TouchableWithoutFeedback');
 var UIManager = require('UIManager');
 
-var createStrictShapeTypeChecker = require('createStrictShapeTypeChecker');
 var ensurePositiveDelayProps = require('ensurePositiveDelayProps');
 var onlyChild = require('onlyChild');
 var processColor = require('processColor');
 var requireNativeComponent = require('requireNativeComponent');
 
-var rippleBackgroundPropType = createStrictShapeTypeChecker({
+var rippleBackgroundPropType = PropTypes.shape({
   type: React.PropTypes.oneOf(['RippleAndroid']),
   color: PropTypes.number,
   borderless: PropTypes.bool,
 });
 
-var themeAttributeBackgroundPropType = createStrictShapeTypeChecker({
+var themeAttributeBackgroundPropType = PropTypes.shape({
   type: React.PropTypes.oneOf(['ThemeAttrAndroid']),
   attribute: PropTypes.string.isRequired,
 });


### PR DESCRIPTION
The problem: no matter what value `background` prop has, it always triggers a warning

![screen shot 2016-01-05 at 1 20 35 pm](https://cloud.githubusercontent.com/assets/192222/12128053/c0a8754a-b3af-11e5-92c6-921e2e0c7cc4.png)

Looks like this happens because we use `createStrictShapeTypeChecker` prop types inside `PropTypes.oneOfType` instead of `PropTypes.shape`.