### PR TITLE
Added reference to Frappé (for OS X Android)

### DIFF
--- a/docs/Debugging.md
+++ b/docs/Debugging.md
@@ -11,7 +11,7 @@ next: testing
 To access the in-app developer menu:
 
 1. On iOS shake the device or press `control + ⌘ + z` in the simulator.
-2. On Android shake the device or press hardware menu button (available on older devices and in most of the emulators, e.g. in [genymotion](https://www.genymotion.com) you can press `⌘ + m` to simulate hardware menu button click)
+2. On Android shake the device or press hardware menu button (available on older devices and in most of the emulators, e.g. in [genymotion](https://www.genymotion.com) you can press `⌘ + m` to simulate hardware menu button click). You can also install [Frappé](http://getfrappe.com), a tool for OS X, which allows you to emulate shaking of devices remotely. You can use `⌘ + Shift + R` as a shortcut to trigger a **shake** from Frappé.
 
 > Hint
 

--- a/docs/DevelopmentSetupAndroid.md
+++ b/docs/DevelopmentSetupAndroid.md
@@ -7,7 +7,7 @@ permalink: docs/android-setup.html
 next: linux-windows-support
 ---
 
-This guide describes basic steps of the Android development environment setup that are required to run React Native android apps on an android emulator. We don't discuss developer tool configuration such as IDEs here.  
+This guide describes basic steps of the Android development environment setup that are required to run React Native android apps on an android emulator. We don't discuss developer tool configuration such as IDEs here.
 
 ### Install Git
 
@@ -17,8 +17,8 @@ This guide describes basic steps of the Android development environment setup th
 
   - **On Linux**, install Git [via your package manager](https://git-scm.com/download/linux).
 
-  - **On Windows**, download and install [Git for Windows](https://git-for-windows.github.io/). During the setup process, choose "Run Git from Windows Command Prompt", which will add Git to your `PATH` environment variable.  
-  
+  - **On Windows**, download and install [Git for Windows](https://git-for-windows.github.io/). During the setup process, choose "Run Git from Windows Command Prompt", which will add Git to your `PATH` environment variable.
+
 ### Install the Android SDK (unless you have it)
 
 1. [Install the latest JDK](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html)
@@ -35,11 +35,11 @@ __IMPORTANT__: Make sure the `ANDROID_HOME` environment variable points to your 
         # If you installed the SDK via Homebrew, otherwise ~/Library/Android/sdk
         export ANDROID_HOME=/usr/local/opt/android-sdk
   - **On Linux**, add this to your `~/.bashrc`, `~/.bash_profile` or whatever your shell uses:
-        
+
         export ANDROID_HOME=<path_where_you_unpacked_android_sdk>
 
-  - **On Windows**, go to `Control Panel` -> `System and Security` -> `System` -> `Change settings` -> `Advanced` -> `Environment variables` -> `New`   
-   
+  - **On Windows**, go to `Control Panel` -> `System and Security` -> `System` -> `Change settings` -> `Advanced` -> `Environment variables` -> `New`
+
 __NOTE__: You need to restart the Command Prompt (Windows) / Terminal Emulator (Mac OS X, Linux) to apply the new Environment variables.
 
 
@@ -77,4 +77,4 @@ Genymotion is much easier to set up than stock Google emulators. However, it's o
   1. Run `android avd` and click on **Create...**
   ![Create AVD dialog](/react-native/img/CreateAVD.png)
   2. With the new AVD selected, click `Start...`
-5. To bring up the developer menu press F2
+5. To bring up the developer menu press F2 (or install [Frappé](http://getfrappe.com))


### PR DESCRIPTION
It's a tool for OS X that easily lets you reload developer tools menu with menubar/tray and hotkey.

It'd be great if someone forked my project and added iOS support (not sure if this is possible).