### PR TITLE
Fix build error and runtime error after proguard enabled.

### DIFF
--- a/local-cli/generator-android/templates/src/app/proguard-rules.pro
+++ b/local-cli/generator-android/templates/src/app/proguard-rules.pro
@@ -40,7 +40,7 @@
 
 -keep class * extends com.facebook.react.bridge.JavaScriptModule { *; }
 -keep class * extends com.facebook.react.bridge.NativeModule { *; }
--keepclassmembers class * { native <methods>; }
+-keepclassmembers,includedescriptorclasses class * { native <methods>; }
 -keepclassmembers class *  { @com.facebook.react.uimanager.UIProp <fields>; }
 -keepclassmembers class *  { @com.facebook.react.uimanager.ReactProp <methods>; }
 -keepclassmembers class *  { @com.facebook.react.uimanager.ReactPropGroup <methods>; }

--- a/local-cli/generator-android/templates/src/app/proguard-rules.pro
+++ b/local-cli/generator-android/templates/src/app/proguard-rules.pro
@@ -40,7 +40,7 @@
 
 -keep class * extends com.facebook.react.bridge.JavaScriptModule { *; }
 -keep class * extends com.facebook.react.bridge.NativeModule { *; }
--keep class * { native <methods>; }
+-keepclassmembers class * { native <methods>; }
 -keepclassmembers class *  { @com.facebook.react.uimanager.UIProp <fields>; }
 -keepclassmembers class *  { @com.facebook.react.uimanager.ReactProp <methods>; }
 -keepclassmembers class *  { @com.facebook.react.uimanager.ReactPropGroup <methods>; }

--- a/local-cli/generator-android/templates/src/app/proguard-rules.pro
+++ b/local-cli/generator-android/templates/src/app/proguard-rules.pro
@@ -40,6 +40,7 @@
 
 -keep class * extends com.facebook.react.bridge.JavaScriptModule { *; }
 -keep class * extends com.facebook.react.bridge.NativeModule { *; }
+-keep class * { native <methods>; }
 -keepclassmembers class *  { @com.facebook.react.uimanager.UIProp <fields>; }
 -keepclassmembers class *  { @com.facebook.react.uimanager.ReactProp <methods>; }
 -keepclassmembers class *  { @com.facebook.react.uimanager.ReactPropGroup <methods>; }

--- a/local-cli/generator-android/templates/src/app/proguard-rules.pro
+++ b/local-cli/generator-android/templates/src/app/proguard-rules.pro
@@ -45,6 +45,8 @@
 -keepclassmembers class *  { @com.facebook.react.uimanager.ReactProp <methods>; }
 -keepclassmembers class *  { @com.facebook.react.uimanager.ReactPropGroup <methods>; }
 
+-dontwarn com.facebook.react.**
+
 # okhttp
 
 -keepattributes Signature
@@ -59,3 +61,7 @@
 -dontwarn java.nio.file.*
 -dontwarn org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
 -dontwarn okio.**
+
+# stetho
+
+-dontwarn com.facebook.stetho.**


### PR DESCRIPTION
Fix: 
1. :app:packageRelease FAILED caused by proguard exception: `java.io.IOException: Please correct the above warnings first.`
2. Fix runtime exception 
```
java.lang.ExceptionInInitializerError
   at com.facebook.react.ReactInstanceManagerImpl.recreateReactContextInBackgroundFromBundleFile(ReactInstanceManagerImpl.java:308)
```
