### PR TITLE
Allow View containers to specify custom measure functions

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/RootViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/RootViewManager.java
@@ -14,7 +14,7 @@ import android.view.ViewGroup;
 /**
  * View manager for ReactRootView components.
  */
-public class RootViewManager extends ViewGroupManager<ViewGroup> {
+public class RootViewManager extends SimpleViewGroupManager<ViewGroup> {
 
   public static final String REACT_CLASS = "RootView";
 

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/SimpleViewGroupManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/SimpleViewGroupManager.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+package com.facebook.react.uimanager;
+
+import android.view.ViewGroup;
+
+/**
+ * Common base class for providing children management API for view managers of classes extending ViewGroup.
+ */
+public abstract class SimpleViewGroupManager<T extends ViewGroup> extends ViewGroupManager<T, LayoutShadowNode>{
+    @Override
+    public LayoutShadowNode createShadowNodeInstance() {
+        return new LayoutShadowNode();
+    }
+
+    @Override
+    public Class<LayoutShadowNode> getShadowNodeClass() {
+        return LayoutShadowNode.class;
+    }
+}

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewGroupManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewGroupManager.java
@@ -15,18 +15,9 @@ import android.view.ViewGroup;
 /**
  * Class providing children management API for view managers of classes extending ViewGroup.
  */
-public abstract class ViewGroupManager <T extends ViewGroup>
-    extends BaseViewManager<T, LayoutShadowNode> {
 
-  @Override
-  public LayoutShadowNode createShadowNodeInstance() {
-    return new LayoutShadowNode();
-  }
-
-  @Override
-  public Class<? extends LayoutShadowNode> getShadowNodeClass() {
-    return LayoutShadowNode.class;
-  }
+public abstract class ViewGroupManager <T extends ViewGroup, C extends LayoutShadowNode>
+    extends BaseViewManager<T, C> {
 
   @Override
   public void updateExtraData(T root, Object extraData) {

--- a/ReactAndroid/src/main/java/com/facebook/react/views/drawer/ReactDrawerLayoutManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/drawer/ReactDrawerLayoutManager.java
@@ -23,9 +23,9 @@ import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.common.MapBuilder;
 import com.facebook.react.uimanager.PixelUtil;
 import com.facebook.react.uimanager.ReactProp;
+import com.facebook.react.uimanager.SimpleViewGroupManager;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.UIManagerModule;
-import com.facebook.react.uimanager.ViewGroupManager;
 import com.facebook.react.uimanager.events.EventDispatcher;
 import com.facebook.react.views.drawer.events.DrawerClosedEvent;
 import com.facebook.react.views.drawer.events.DrawerOpenedEvent;
@@ -35,7 +35,7 @@ import com.facebook.react.views.drawer.events.DrawerStateChangedEvent;
 /**
  * View Manager for {@link ReactDrawerLayout} components.
  */
-public class ReactDrawerLayoutManager extends ViewGroupManager<ReactDrawerLayout> {
+public class ReactDrawerLayoutManager extends SimpleViewGroupManager<ReactDrawerLayout> {
 
   private static final String REACT_CLASS = "AndroidDrawerLayout";
 

--- a/ReactAndroid/src/main/java/com/facebook/react/views/recyclerview/RecyclerViewBackedScrollViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/recyclerview/RecyclerViewBackedScrollViewManager.java
@@ -11,8 +11,8 @@ import android.view.View;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.common.MapBuilder;
 import com.facebook.react.uimanager.ReactProp;
+import com.facebook.react.uimanager.SimpleViewGroupManager;
 import com.facebook.react.uimanager.ThemedReactContext;
-import com.facebook.react.uimanager.ViewGroupManager;
 import com.facebook.react.views.scroll.ReactScrollViewCommandHelper;
 import com.facebook.react.views.scroll.ScrollEventType;
 
@@ -20,7 +20,7 @@ import com.facebook.react.views.scroll.ScrollEventType;
  * View manager for {@link RecyclerViewBackedScrollView}.
  */
 public class RecyclerViewBackedScrollViewManager extends
-    ViewGroupManager<RecyclerViewBackedScrollView>
+        SimpleViewGroupManager<RecyclerViewBackedScrollView>
     implements ReactScrollViewCommandHelper.ScrollCommandHandler<RecyclerViewBackedScrollView> {
 
   private static final String REACT_CLASS = "AndroidRecyclerViewBackedScrollView";

--- a/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollViewManager.java
@@ -9,12 +9,12 @@
 
 package com.facebook.react.views.scroll;
 
-import javax.annotation.Nullable;
-
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.uimanager.ReactProp;
+import com.facebook.react.uimanager.SimpleViewGroupManager;
 import com.facebook.react.uimanager.ThemedReactContext;
-import com.facebook.react.uimanager.ViewGroupManager;
+
+import javax.annotation.Nullable;
 
 /**
  * View manager for {@link ReactHorizontalScrollView} components.
@@ -23,7 +23,7 @@ import com.facebook.react.uimanager.ViewGroupManager;
  * as a single ScrollView component, configured via the {@code horizontal} boolean property.
  */
 public class ReactHorizontalScrollViewManager
-    extends ViewGroupManager<ReactHorizontalScrollView>
+    extends SimpleViewGroupManager<ReactHorizontalScrollView>
     implements ReactScrollViewCommandHelper.ScrollCommandHandler<ReactHorizontalScrollView> {
 
   private static final String REACT_CLASS = "AndroidHorizontalScrollView";

--- a/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewManager.java
@@ -16,8 +16,8 @@ import java.util.Map;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.common.MapBuilder;
 import com.facebook.react.uimanager.ReactProp;
+import com.facebook.react.uimanager.SimpleViewGroupManager;
 import com.facebook.react.uimanager.ThemedReactContext;
-import com.facebook.react.uimanager.ViewGroupManager;
 import com.facebook.react.views.view.ReactClippingViewGroupHelper;
 
 /**
@@ -27,7 +27,7 @@ import com.facebook.react.views.view.ReactClippingViewGroupHelper;
  * as a single ScrollView component, configured via the {@code horizontal} boolean property.
  */
 public class ReactScrollViewManager
-    extends ViewGroupManager<ReactScrollView>
+    extends SimpleViewGroupManager<ReactScrollView>
     implements ReactScrollViewCommandHelper.ScrollCommandHandler<ReactScrollView> {
 
   private static final String REACT_CLASS = "RCTScrollView";

--- a/ReactAndroid/src/main/java/com/facebook/react/views/swiperefresh/SwipeRefreshLayoutManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/swiperefresh/SwipeRefreshLayoutManager.java
@@ -21,16 +21,16 @@ import android.support.v4.widget.SwipeRefreshLayout.OnRefreshListener;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.common.MapBuilder;
 import com.facebook.react.uimanager.ReactProp;
+import com.facebook.react.uimanager.SimpleViewGroupManager;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.UIManagerModule;
-import com.facebook.react.uimanager.ViewGroupManager;
 import com.facebook.react.uimanager.ViewProps;
 
 /**
  * ViewManager for {@link ReactSwipeRefreshLayout} which allows the user to "pull to refresh" a
  * child view. Emits an {@code onRefresh} event when this happens.
  */
-public class SwipeRefreshLayoutManager extends ViewGroupManager<ReactSwipeRefreshLayout> {
+public class SwipeRefreshLayoutManager extends SimpleViewGroupManager<ReactSwipeRefreshLayout> {
 
   @Override
   protected ReactSwipeRefreshLayout createViewInstance(ThemedReactContext reactContext) {

--- a/ReactAndroid/src/main/java/com/facebook/react/views/toolbar/ReactToolbarManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/toolbar/ReactToolbarManager.java
@@ -28,16 +28,16 @@ import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.common.MapBuilder;
 import com.facebook.react.uimanager.PixelUtil;
 import com.facebook.react.uimanager.ReactProp;
+import com.facebook.react.uimanager.SimpleViewGroupManager;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.UIManagerModule;
-import com.facebook.react.uimanager.ViewGroupManager;
 import com.facebook.react.uimanager.events.EventDispatcher;
 import com.facebook.react.views.toolbar.events.ToolbarClickEvent;
 
 /**
  * Manages instances of ReactToolbar.
  */
-public class ReactToolbarManager extends ViewGroupManager<ReactToolbar> {
+public class ReactToolbarManager extends SimpleViewGroupManager<ReactToolbar> {
 
   private static final String REACT_CLASS = "ToolbarAndroid";
 

--- a/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.java
@@ -9,12 +9,6 @@
 
 package com.facebook.react.views.view;
 
-import javax.annotation.Nullable;
-
-import java.util.Locale;
-import java.util.Map;
-
-import android.graphics.Color;
 import android.os.Build;
 import android.view.View;
 
@@ -25,19 +19,23 @@ import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.common.MapBuilder;
 import com.facebook.react.common.annotations.VisibleForTesting;
-import com.facebook.react.uimanager.CatalystStylesDiffMap;
 import com.facebook.react.uimanager.PixelUtil;
 import com.facebook.react.uimanager.PointerEvents;
 import com.facebook.react.uimanager.ReactProp;
 import com.facebook.react.uimanager.ReactPropGroup;
+import com.facebook.react.uimanager.SimpleViewGroupManager;
 import com.facebook.react.uimanager.ThemedReactContext;
-import com.facebook.react.uimanager.ViewGroupManager;
 import com.facebook.react.uimanager.ViewProps;
+
+import java.util.Locale;
+import java.util.Map;
+
+import javax.annotation.Nullable;
 
 /**
  * View manager for AndroidViews (plain React Views).
  */
-public class ReactViewManager extends ViewGroupManager<ReactViewGroup> {
+public class ReactViewManager extends SimpleViewGroupManager<ReactViewGroup> {
 
   @VisibleForTesting
   public static final String REACT_CLASS = ViewProps.VIEW_CLASS_NAME;

--- a/ReactAndroid/src/main/java/com/facebook/react/views/viewpager/ReactViewPagerManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/viewpager/ReactViewPagerManager.java
@@ -11,20 +11,22 @@ package com.facebook.react.views.viewpager;
 
 import java.util.Map;
 
+import android.support.v4.view.ViewPager;
 import android.view.View;
 
 import com.facebook.infer.annotation.Assertions;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.common.MapBuilder;
+import com.facebook.react.uimanager.SimpleViewGroupManager;
 import com.facebook.react.uimanager.ThemedReactContext;
-import com.facebook.react.uimanager.ViewGroupManager;
+import com.facebook.react.uimanager.ViewManager;
 
 import javax.annotation.Nullable;
 
 /**
  * Instance of {@link ViewManager} that provides native {@link ViewPager} view.
  */
-public class ReactViewPagerManager extends ViewGroupManager<ReactViewPager> {
+public class ReactViewPagerManager extends SimpleViewGroupManager<ReactViewPager> {
 
   private static final String REACT_CLASS = "AndroidViewPager";
 


### PR DESCRIPTION
This PR allows `ViewManagers` that are containers (extending `ViewGroupManager`) to specify it's custom `CSSNode.MeasureFunction`.
`ViewManagers` that don't need to specify this can extend `SimpleViewGroupManager` instead