### PR TITLE
bugfix: NavigatoriOS doesn't update any scenes when 0th scene is replaced

### DIFF
--- a/Libraries/Components/Navigation/NavigatorIOS.ios.js
+++ b/Libraries/Components/Navigation/NavigatorIOS.ios.js
@@ -639,7 +639,7 @@ var NavigatorIOS = React.createClass({
     var {component, wrapperStyle, passProps, ...route} = route;
     var {itemWrapperStyle, ...props} = this.props;
     var shouldUpdateChild =
-      this.state.updatingAllIndicesAtOrBeyond &&
+      this.state.updatingAllIndicesAtOrBeyond != null &&
       this.state.updatingAllIndicesAtOrBeyond >= i;
     var Component = component;
     return (


### PR DESCRIPTION
Calling navigator.replace(0, scene) has no effect.

This is because 0 is false in Javascript so when

    this.state.updatingAllIndicesAtOrBeyond == 0 

(meaning update all indices starting with 0)

The whole expression evaluates to 0, i.e. false ->  therefore no update
happens. 

Explicitly checking for not-equal to null (!= will convert undefined to null automatically) fixes the issue.