### PR TITLE
Dont call npm before node is available

### DIFF
--- a/packager/react-native-xcode.sh
+++ b/packager/react-native-xcode.sh
@@ -29,9 +29,6 @@ cd ..
 set -x
 DEST=$CONFIGURATION_BUILD_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH
 
-# npm global install path may be a non-standard location
-PATH="$(npm prefix -g)/bin:$PATH"
-
 # Define NVM_DIR and source the nvm.sh setup script
 [ -z "$NVM_DIR" ] && export NVM_DIR="$HOME/.nvm"
 
@@ -45,6 +42,9 @@ fi
 if [[ -x "$HOME/.nodenv/bin/nodenv" ]]; then
   eval "$($HOME/.nodenv/bin/nodenv init -)"
 fi
+
+# npm global install path may be a non-standard location
+PATH="$(npm prefix -g)/bin:$PATH"
 
 react-native bundle \
   --entry-file index.ios.js \


### PR DESCRIPTION
This fixes an error introduced in `0.18.0-rc`

`node` and `npm` isn't available if the developer is using `nvm` or `nodeenv`. XCode throws an error because of the call to `npm`. Simple move the line to after `node` and `npm` has been setup.
