### PR TITLE
Add `disabled` prop to Touchable components.

### DIFF
--- a/Libraries/Components/Touchable/TouchableHighlight.js
+++ b/Libraries/Components/Touchable/TouchableHighlight.js
@@ -226,6 +226,7 @@ var TouchableHighlight = React.createClass({
         onResponderMove={this.touchableHandleResponderMove}
         onResponderRelease={this.touchableHandleResponderRelease}
         onResponderTerminate={this.touchableHandleResponderTerminate}
+        pointerEvents={this.props.disabled ? 'none' : 'auto'}
         testID={this.props.testID}>
         {React.cloneElement(
           onlyChild(this.props.children),

--- a/Libraries/Components/Touchable/TouchableNativeFeedback.android.js
+++ b/Libraries/Components/Touchable/TouchableNativeFeedback.android.js
@@ -210,6 +210,7 @@ var TouchableNativeFeedback = React.createClass({
       onResponderMove: this._handleResponderMove,
       onResponderRelease: this.touchableHandleResponderRelease,
       onResponderTerminate: this.touchableHandleResponderTerminate,
+      pointerEvents: this.props.disabled ? 'none' : 'auto',
     };
     return <TouchableView {...childProps}/>;
   }

--- a/Libraries/Components/Touchable/TouchableOpacity.js
+++ b/Libraries/Components/Touchable/TouchableOpacity.js
@@ -164,7 +164,8 @@ var TouchableOpacity = React.createClass({
         onResponderGrant={this.touchableHandleResponderGrant}
         onResponderMove={this.touchableHandleResponderMove}
         onResponderRelease={this.touchableHandleResponderRelease}
-        onResponderTerminate={this.touchableHandleResponderTerminate}>
+        onResponderTerminate={this.touchableHandleResponderTerminate}
+        pointerEvents={this.props.disabled ? 'none' : 'auto'}>
         {this.props.children}
       </Animated.View>
     );

--- a/Libraries/Components/Touchable/TouchableWithoutFeedback.js
+++ b/Libraries/Components/Touchable/TouchableWithoutFeedback.js
@@ -29,7 +29,7 @@ var PRESS_RETENTION_OFFSET = {top: 20, left: 20, right: 20, bottom: 30};
  * Do not use unless you have a very good reason. All the elements that
  * respond to press should have a visual feedback when touched. This is
  * one of the primary reason a "web" app doesn't feel "native".
- * 
+ *
  * > **NOTE**: TouchableWithoutFeedback supports only one child
  * >
  * > If you wish to have several child components, wrap them in a View.
@@ -44,6 +44,11 @@ var TouchableWithoutFeedback = React.createClass({
       React.PropTypes.oneOf(View.AccessibilityTraits),
       React.PropTypes.arrayOf(React.PropTypes.oneOf(View.AccessibilityTraits)),
     ]),
+    /**
+     * When `true`, disables touches.
+     * Default is `false`.
+     */
+    disabled: React.PropTypes.bool,
     /**
      * Called when the touch is released, but not if cancelled (e.g. by a scroll
      * that steals the responder lock).
@@ -144,7 +149,8 @@ var TouchableWithoutFeedback = React.createClass({
       onResponderGrant: this.touchableHandleResponderGrant,
       onResponderMove: this.touchableHandleResponderMove,
       onResponderRelease: this.touchableHandleResponderRelease,
-      onResponderTerminate: this.touchableHandleResponderTerminate
+      onResponderTerminate: this.touchableHandleResponderTerminate,
+      pointerEvents: this.props.disabled ? 'none' : 'auto'
     });
   }
 });


### PR DESCRIPTION
Adds a `disabled` prop to `TouchableWithoutFeedback`, `TouchableOpacity`, `TouchableNativeFeedback`, and `TouchableHighlight`. Behind the scenes, it's just setting `pointerEvents` to `none` when this prop is `true`.