### PR TITLE
Update file path

### DIFF
--- a/docs/SignedAPKAndroid.md
+++ b/docs/SignedAPKAndroid.md
@@ -24,7 +24,7 @@ _Note: Remember to keep your keystore file private and never commit it to versio
 ### Setting up gradle variables
 
 1. Place the `my-release-key.keystore` file under the `android/app` directory in your project folder.
-2. Edit the file `~/.gradle/gradle.properties` and add the following (replace `*****` with the correct keystore password, alias and key password),
+2. Edit the file `android/gradle.properties` and add the following (replace `*****` with the correct keystore password, alias and key password),
 
 ```
 MYAPP_RELEASE_STORE_FILE=my-release-key.keystore


### PR DESCRIPTION
In react native 0.17.0 ~/.gradle/gradle.properties does not exist. There is a /android/gradle.properties though, and if you add lines 30-33 the build works just fine.