### PR TITLE
Fix 'Error: spawn npm ENOENT' on Windows

### DIFF
--- a/react-native-cli/index.js
+++ b/react-native-cli/index.js
@@ -42,6 +42,7 @@ var spawn = require('child_process').spawn;
 var chalk = require('chalk');
 var prompt = require('prompt');
 var semver = require('semver');
+var os = require('os');
 
 var CLI_MODULE_PATH = function() {
   return path.resolve(
@@ -198,7 +199,14 @@ function run(root, projectName, logLevel) {
   if (logLevel === 'debug' || logLevel === 'verbose') {
     spawnArgs = {stdio: 'inherit'};
   }
-  var proc = spawn('npm', args, spawnArgs);
+  var proc;
+  if (os.platform() === 'win32'){
+    args.unshift('npm');
+    args.unshift('/c');
+    proc = spawn('cmd', args, spawnArgs);
+  } else {
+    proc = spawn('npm', args, spawnArgs);
+  }
   proc.on('close', function (code) {
     if (code !== 0) {
       console.error('`npm install --save react-native` failed');


### PR DESCRIPTION
A better solution for #5169 

launch npm with spawn('cmd') on windows. @mkonicek 