### PR TITLE
Extend FragmentActivity instead of Activity

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/ReactActivity.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactActivity.java
@@ -1,11 +1,11 @@
 package com.facebook.react;
 
-import android.app.Activity;
 import android.content.Intent;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.provider.Settings;
+import android.support.v4.app.FragmentActivity;
 import android.view.KeyEvent;
 import android.widget.EditText;
 import android.widget.Toast;
@@ -21,7 +21,7 @@ import javax.annotation.Nullable;
 /**
  * Base Activity for React Native applications.
  */
-public abstract class ReactActivity extends Activity implements DefaultHardwareBackBtnHandler {
+public abstract class ReactActivity extends FragmentActivity implements DefaultHardwareBackBtnHandler {
 
   private static final String REDBOX_PERMISSION_MESSAGE =
       "Overlay permissions needs to be granted in order for react native apps to run in dev mode";


### PR DESCRIPTION
If `ReactActivity` extends `Activity`, It will be difficult for third-party libs that require the use of `FragmentActivity` (refer https://github.com/facebook/react-native/pull/4827#issuecomment-169953931). It might also break the `DialogModule` as the commit message says that it requires `FragmentActivity` - https://github.com/facebook/react-native/commit/3a3af8a385583c7aabfad5f8ff5daa69aa29953f