### PR TITLE
fix lint warnings

### DIFF
--- a/Libraries/Utilities/MessageQueue.js
+++ b/Libraries/Utilities/MessageQueue.js
@@ -110,7 +110,7 @@ class MessageQueue {
 
   processModuleConfig(config, moduleID) {
     const module = this._genModule(config, moduleID);
-    this._genLookup(config, moduleID, this._remoteModuleTable, this._remoteMethodTable)
+    this._genLookup(config, moduleID, this._remoteModuleTable, this._remoteMethodTable);
     return module;
   }
 

--- a/bots/code-analysis-bot.js
+++ b/bots/code-analysis-bot.js
@@ -238,5 +238,5 @@ process.stdin.on('end', function() {
   var number = process.env.TRAVIS_PULL_REQUEST;
 
   // intentional lint warning to make sure that the bot is working :)
-  main(messages, user, repo, number)
+  main(messages, user, repo, number);
 });

--- a/bots/code-analysis-bot.js
+++ b/bots/code-analysis-bot.js
@@ -238,5 +238,5 @@ process.stdin.on('end', function() {
   var number = process.env.TRAVIS_PULL_REQUEST;
 
   // intentional lint warning to make sure that the bot is working :)
-  main(messages, user, repo, number);
+  main(messages, user, repo, number)
 });


### PR DESCRIPTION
added two semi colons, separated from other lint commits to avoid potential conflicts