### PR TITLE
run-android Chose your Term for OSX, and Linux

### DIFF
--- a/local-cli/runAndroid/runAndroid.js
+++ b/local-cli/runAndroid/runAndroid.js
@@ -136,24 +136,17 @@ function startServerInNewWindow() {
   );
 
   if (process.platform === 'darwin') {
-    if (!yargV.open) {
-      return child_process.spawnSync('open', [launchPackagerScript]);
+    if (yargV.open) {
+      return child_process.spawnSync('open', ['-a', yargV.open, launchPackagerScript]);
     }
-    return child_process.spawnSync('open', ['-a', yargV.open, launchPackagerScript]);
+    return child_process.spawnSync('open', [launchPackagerScript]);
 
   } else if (process.platform === 'linux') {
-    if (!yargV.open){
-      return child_process.spawn(
-        'xterm',
-        ['-e', 'sh', launchPackagerScript],
-        {detached: true}
-      );
+    if (yargV.open){
+      return child_process.spawn(yargV.open,['-e', 'sh', launchPackagerScript], {detached: true});
     }
-    return child_process.spawn(
-      yargV.open,
-      ['-e', 'sh', launchPackagerScript],
-      {detached: true}
-    );
+    return child_process.spawn('xterm',['-e', 'sh', launchPackagerScript],{detached: true});
+
   } else if (/^win/.test(process.platform)) {
     console.log(chalk.yellow('Starting the packager in a new window ' +
       'is not supported on Windows yet.\nPlease start it manually using ' +

--- a/local-cli/runAndroid/runAndroid.js
+++ b/local-cli/runAndroid/runAndroid.js
@@ -129,15 +129,28 @@ function buildAndRun(args, reject) {
 }
 
 function startServerInNewWindow() {
+  var yargV = require('yargs').argv;
+
   const launchPackagerScript = path.resolve(
     __dirname, '..', '..', 'packager', 'launchPackager.command'
   );
 
   if (process.platform === 'darwin') {
-    child_process.spawnSync('open', [launchPackagerScript]);
+    if (!yargV.open) {
+      return child_process.spawnSync('open', [launchPackagerScript]);
+    }
+    return child_process.spawnSync('open', ['-a', yargV.open, launchPackagerScript]);
+
   } else if (process.platform === 'linux') {
-    child_process.spawn(
-      'xterm',
+    if (!yargV.open){
+      return child_process.spawn(
+        'xterm',
+        ['-e', 'sh', launchPackagerScript],
+        {detached: true}
+      );
+    }
+    return child_process.spawn(
+      yargV.open,
       ['-e', 'sh', launchPackagerScript],
       {detached: true}
     );


### PR DESCRIPTION
Main goal is to get this passed for OSX. I assume this works for linux; please verify. Also if specs need to be added, please suggest
an implementation as there is no __test__ dir for andriod.

using yargs (already a dependency) to allow other terminals besides OSX crummy default terminal. Like (iterm) :)

main use case:

` react-native run-android --open iterm`

The nice thing about this in ITERM is it opens another tab by default which is way less intrusive then OSX default term.