### PR TITLE
[Versions] Set the versions in package.json and React.podspec to 0.0.0-master

### DIFF
--- a/React.podspec
+++ b/React.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                = "React"
-  s.version             = "0.15.0"
+  s.version             = "0.0.0-master"
   s.summary             = "Build high quality mobile apps using React."
   s.description         = <<-DESC
                             React Native apps are built using the React JS

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native",
-  "version": "0.12.0",
+  "version": "0.0.0-master",
   "description": "A framework for building native apps using React",
   "license": "BSD-3-Clause",
   "repository": {


### PR DESCRIPTION
The current versions in these files is 0.12.0, which is out of date. Better to claim no version than the wrong version, so this diff changes the versions to 0.0.0-master.

Release branches will still have the correct versions.