### PR TITLE
ActionSheetIOS support for presentation from modal view controller

### DIFF
--- a/Libraries/ActionSheetIOS/RCTActionSheetManager.m
+++ b/Libraries/ActionSheetIOS/RCTActionSheetManager.m
@@ -66,6 +66,10 @@ RCT_EXPORT_METHOD(showActionSheetWithOptions:(NSDictionary *)options
   NSInteger cancelButtonIndex = options[@"cancelButtonIndex"] ? [RCTConvert NSInteger:options[@"cancelButtonIndex"]] : -1;
 
   UIViewController *controller = RCTKeyWindow().rootViewController;
+  while (controller.presentedViewController) {
+    controller = controller.presentedViewController;
+  }
+    
   if (controller == nil) {
     RCTLogError(@"Tried to display action sheet but there is no application window. options: %@", options);
     return;


### PR DESCRIPTION
Currently the RCTActionSheetManager attempts to present itself from the 'rootViewController' of the key window, presenting a modal from a view controller which is already presenting a modal is not allowed on iOS and this fails with the following error appearing in the XCode debugger (but not the chrome debugger):

```
Warning: Attempt to present <UIAlertController: 0x7fca85b14f40> on <UINavigationController: 0x7fca84812000> whose view is not in the window hierarchy!
```

This change recursively looks through modally presented view controllers until it finds the top one and then uses that to present the action sheet.