### PR TITLE
[RecyclerViewBackedScrollView] Fix content offset calculations when scrolling up

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/recyclerview/RecyclerViewBackedScrollView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/recyclerview/RecyclerViewBackedScrollView.java
@@ -117,16 +117,17 @@ public class RecyclerViewBackedScrollView extends RecyclerView {
       if (mLastRequestedPosition != index) {
         int sum = 0;
         int startIndex = 0;
+
+        if (mLastRequestedPosition != -1) {
+          sum = mOffsetForLastPosition;
+          startIndex = mLastRequestedPosition;
+        }
+
         if (mLastRequestedPosition < index) {
-          if (mLastRequestedPosition != -1) {
-            sum = mOffsetForLastPosition;
-            startIndex = mLastRequestedPosition;
-          }
           for (int i = startIndex; i < index; i++) {
             sum += mReactListAdapter.mViews.get(i).getMeasuredHeight();
           }
-        }
-        else {
+        } else {
           if (index < (mLastRequestedPosition - index)) {
             for (int i = 0; i < index; i++) {
               sum += mReactListAdapter.mViews.get(i).getMeasuredHeight();


### PR DESCRIPTION
The offset is cached so it doesn't need to calculate the entire height on each scroll, but the cached value was being thrown away when you scroll up -- this fixes that. Found this because it was breaking an infinite scroll view that depended on the contentOffset.y value reported from onScroll.

Test plan: Add an `onScroll` event to a RecyclerViewBackedScrollView that just logs the `contentOffset`, scroll down for a couple of screens (without scrolling up at all!) and look at your logs, you will see contentOffset.y is a big number as it should be. Now scroll up, a bit, then look at your logs again, you will see the contentOffset.y is totally wrong (probably negative). Apply this patch and it should be what you expect.

cc @kmagiera 