### PR TITLE
Sample code closer to tutorial

### DIFF
--- a/docs/EmbeddedAppIOS.md
+++ b/docs/EmbeddedAppIOS.md
@@ -159,7 +159,7 @@ In root directory, we need to start React Native development server.
 (JS_DIR=`pwd`/ReactComponent; cd node_modules/react-native; npm run start -- --root $JS_DIR)
 ```
 
-This command will start up a React Native development server within our CocoaPods dependency to build our bundled script. The `--root` option indicates the root of your React Native apps – this will be our `ReactComponents` directory containing the single `index.ios.js` file. This running server will package up the `index.ios.bundle` file accessible via `http://localhost:8081/index.ios.bundle`.
+This command will start up a React Native development server within our CocoaPods dependency to build our bundled script. The `--root` option indicates the root of your React Native apps – this will be our `ReactComponent` directory containing the single `index.ios.js` file. This running server will package up the `index.ios.bundle` file accessible via `http://localhost:8081/index.ios.bundle`.
 
 ## Compile And Run
 
@@ -173,4 +173,4 @@ Live reload and all of the debugging tools will work from the simulator (make su
 
 So under the hood, when `RCTRootView` is initialized, it will try to download, parse and run the bundle file from React Native development server. This means all you need to do is to implement your own container view or view controller for the `RCTRootView` – the `RCTRootView` ingests your bundled JS and renders your React components. Bravo!
 
-You can checkout full source code of a sample application [here](https://github.com/tjwudi/EmbededReactNativeExample).
+You can checkout full source code of a sample application [here](https://github.com/hfossli/ReactNativeIntegration).


### PR DESCRIPTION
I found several inconcistencies with the repo and the tutorial. 

- No app transport security policy was set in `Info.plist`
- `Pods` folder was ignored / missing
- `node_modules` was ignored / missing
- In the tutorial the folder was named `ReactComponents`, but in source it was `ReactComponents`
- link to tutorial from readme doesn't work

I think the repo should have all these problems fixed. I found it simpler to start from scratch and figure what's wrong that way than adjusting https://github.com/tjwudi/EmbededReactNativeExample