### PR TITLE
Fixing CLI to pass "sourcemap-output" option to bundler.

### DIFF
--- a/local-cli/bundle/buildBundle.js
+++ b/local-cli/bundle/buildBundle.js
@@ -33,6 +33,7 @@ function buildBundle(args, config, output = outputBundle) {
 
     const requestOpts = {
       entryFile: args['entry-file'],
+      sourceMapUrl: args['sourcemap-output'],
       dev: args.dev,
       minify: !args.dev,
       platform: args.platform,


### PR DESCRIPTION
Currently, the CLI is not passing the sourceMapURL option to the bundler, so source maps are output as "null".