### PR TITLE
Revert "Enable JSX files extension"

### DIFF
--- a/packager/react-packager/src/DependencyResolver/DependencyGraph/ResolutionRequest.js
+++ b/packager/react-packager/src/DependencyResolver/DependencyGraph/ResolutionRequest.js
@@ -350,8 +350,6 @@ class ResolutionRequest {
         file = potentialModulePath + '.native.js';
       } else if (this._fastfs.fileExists(potentialModulePath + '.js')) {
         file = potentialModulePath + '.js';
-      } else if (this._fastfs.fileExists(potentialModulePath + '.jsx')) {
-        file = potentialModulePath + '.jsx';
       } else if (this._fastfs.fileExists(potentialModulePath + '.json')) {
         file = potentialModulePath + '.json';
       } else {

--- a/packager/react-packager/src/DependencyResolver/DependencyGraph/index.js
+++ b/packager/react-packager/src/DependencyResolver/DependencyGraph/index.js
@@ -55,7 +55,7 @@ class DependencyGraph {
       platforms: platforms || [],
       preferNativePlatform: preferNativePlatform || false,
       cache,
-      extensions: extensions || ['js', 'jsx', 'json'],
+      extensions: extensions || ['js', 'json'],
       mocksPattern,
       extractRequires,
       shouldThrowOnUnresolvedErrors,

--- a/packager/react-packager/src/Server/index.js
+++ b/packager/react-packager/src/Server/index.js
@@ -151,7 +151,6 @@ class Server {
         dir: dir,
         globs: [
           '**/*.js',
-          '**/*.jsx',
           '**/*.json',
         ].concat(assetGlobs),
       };


### PR DESCRIPTION
This reverts commit 888749220dac26382412f2c38ac5f9205cc842e5.

The original commit didn't handle cases like .(ios|android|native).js, and vjeux is in favor of standardizing on .js instead of custom extensions like .jsx or .es6 everywhere.

> Unfortunately this pull request doesn't implement with .ios.jsx. But, when/if it does, it raises more questions like what happens if you have both ios.js and ios.jsx?
> 
> Sorry to chime in super late but I actually think that this is harmful to support .jsx extension. We now live in a world where we have many transforms for es6, flow, jsx... Why would we add .jsx but not .flow or .es6. Supporting more extensions is only going to fragment tools even more.

https://github.com/facebook/react-native/pull/5233#discussion_r49682279
