### PR TITLE
Make the RCTSRWebSocketDelegate protocol part of RCTWebSocketModule public

### DIFF
--- a/Libraries/WebSocket/RCTWebSocketModule.h
+++ b/Libraries/WebSocket/RCTWebSocketModule.h
@@ -8,7 +8,8 @@
  */
 
 #import "RCTBridgeModule.h"
+#import "RCTSRWebSocket.h"
 
-@interface RCTWebSocketModule : NSObject <RCTBridgeModule>
+@interface RCTWebSocketModule : NSObject <RCTBridgeModule, RCTSRWebSocketDelegate>
 
 @end

--- a/Libraries/WebSocket/RCTWebSocketModule.m
+++ b/Libraries/WebSocket/RCTWebSocketModule.m
@@ -11,7 +11,6 @@
 
 #import "RCTBridge.h"
 #import "RCTEventDispatcher.h"
-#import "RCTSRWebSocket.h"
 #import "RCTUtils.h"
 
 @implementation RCTSRWebSocket (React)
@@ -25,10 +24,6 @@
 {
   objc_setAssociatedObject(self, @selector(reactTag), reactTag, OBJC_ASSOCIATION_COPY_NONATOMIC);
 }
-
-@end
-
-@interface RCTWebSocketModule () <RCTSRWebSocketDelegate>
 
 @end
 


### PR DESCRIPTION
This allows consumers to subclass and extend `RCTWebSocketModule` and make use of the `RCTSRWebSocketDelegate` methods.

The use case here is to do some pre-processing of WebSocket data before handing it off to JS. Consumers could that in the following way:

```
#import "RCTBridgeModule.h"
#import "RCTWebSocketModule.h"

@interface MyWebSocketModule : RCTWebSocketModule
@end

@implementation MyWebSocketModule

// Don't use RCT_EXPORT_MODULE macro for this so we replace the existing RCTWebSocketModule.
+ (NSString *)moduleName { return @"RCTWebSocketModule"; }

RCT_EXTERN_METHOD(connect:(NSURL *)URL socketID:(nonnull NSNumber *)socketID)
RCT_EXTERN_METHOD(send:(NSString *)message socketID:(nonnull NSNumber *)socketID)
RCT_EXTERN_METHOD(close:(nonnull NSNumber *)socketID)

- (void)webSocket:(RCTSRWebSocket *)webSocket didReceiveMessage:(id)message
{
  [super webSocket:webSocket didReceiveMessage:[DoSomethingWith message]];
}

@end
```

... and then returning a `MyWebSocketModule` instance from the app's `[RCTBridgeDelegate extraModulesForBridge]` method.