### PR TITLE
TextInput should call blur and focus methods of selectionState

### DIFF
--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -549,6 +549,10 @@ var TextInput = React.createClass({
     if (this.props.onFocus) {
       this.props.onFocus(event);
     }
+
+    if (this.props.selectionState) {
+      this.props.selectionState.focus();
+    }
   },
 
   _onPress: function(event: Event) {
@@ -588,6 +592,10 @@ var TextInput = React.createClass({
     this.blur();
     if (this.props.onBlur) {
       this.props.onBlur(event);
+    }
+
+    if (this.props.selectionState) {
+      this.props.selectionState.blur();
     }
   },
 


### PR DESCRIPTION
DocumentSelectionState returns anchor and focus offsets only in focused state. So TextInput should set proper state to selectionState when blur and focus.