### PR TITLE
Enable ATS w/ localhost exception for generated iOS proj

### DIFF
--- a/docs/KnownIssues.md
+++ b/docs/KnownIssues.md
@@ -71,3 +71,17 @@ Try running `react-native init` with `--verbose` and see [#2797](https://github.
 ### Text Input Border
 
 The text input has by default a border at the bottom of its view. This border has its padding set by the background image provided by the system, and it cannot be changed. Solutions to avoid this is to either not set height explicitly, case in which the system will take care of displaying the border in the correct position, or to not display the border by setting underlineColorAndroid to transparent.
+
+### iOS App Transport Security and loading HTTP resources
+
+As of iOS 9, new Xcode projects enable App Transport Security by default, which rejects all HTTP requests that are not sent over HTTPS. This can result in HTTP traffic being blocked (including the developer React Native server) with the following console errors:
+
+```
+App Transport Security has blocked a cleartext HTTP (http://) resource load since it is insecure. Temporary exceptions can be configured via your app's Info.plist file.
+```
+
+```
+NSURLSession/NSURLConnection HTTP load failed (kCFStreamErrorDomainSSL, -9802)
+```
+
+See our guide for [running on an iOS device](RunningOnDeviceIOS.md) and working around the ATS issues, or [several](http://useyourloaf.com/blog/app-transport-security/) [community](https://www.hackingwithswift.com/example-code/system/how-to-handle-the-https-requirements-in-ios-9-with-app-transport-security) [posts](https://ste.vn/2015/06/10/configuring-app-transport-security-ios-9-osx-10-11/) on handling common cases like [whitelisting specific domains](http://stackoverflow.com/a/30732693) for non-HTTPS traffic.

--- a/docs/RunningOnDeviceIOS.md
+++ b/docs/RunningOnDeviceIOS.md
@@ -15,7 +15,8 @@ You can iterate quickly on device using development server. To do that, your lap
 
 1. Open `AwesomeApp/ios/AwesomeApp/AppDelegate.m`
 2. Change the IP in the URL from `localhost` to your laptop's IP. On Mac, you can find the IP address in System Preferences / Network.
-3. In Xcode select your phone as build target and press "Build and run"
+3. Replace the `localhost` entry in your `Info.plist`’s App Transport Security settings with the same IP address from above.
+4. In Xcode select your phone as build target and press "Build and run"
 
 > Hint
 >

--- a/docs/RunningOnDeviceIOS.md
+++ b/docs/RunningOnDeviceIOS.md
@@ -15,8 +15,11 @@ You can iterate quickly on device using development server. To do that, your lap
 
 1. Open `AwesomeApp/ios/AwesomeApp/AppDelegate.m`
 2. Change the IP in the URL from `localhost` to your laptop's IP. On Mac, you can find the IP address in System Preferences / Network.
-3. Replace the `localhost` entry in your `Info.plist`’s App Transport Security settings with the same IP address from above.
+3. Temporarily disable App Transport Security (ATS) by [adding the `NSAllowsArbitraryLoads` entry to your `Info.plist` file][gpl]. Since ATS does not allow insecure HTTP requests to IP addresses, you must completely disable it to run on a device. This is only a requirement for development on a device, and unless you can't workaround an issue you should leave ATS enabled for production builds. For more information, see [this post on configuring ATS][bats].
 4. In Xcode select your phone as build target and press "Build and run"
+
+[gpl]: https://gist.github.com/andrewsardone/91797ff9923b9ac6ea64
+[bats]: http://ste.vn/2015/06/10/configuring-app-transport-security-ios-9-osx-10-11/
 
 > Hint
 >

--- a/local-cli/generator-ios/templates/app/Info.plist
+++ b/local-cli/generator-ios/templates/app/Info.plist
@@ -38,11 +38,17 @@
 	<false/>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string></string>
-  <key>NSAppTransportSecurity</key>
-  <dict>
-    <!--See http://ste.vn/2015/06/10/configuring-app-transport-security-ios-9-osx-10-11/ -->
-    <key>NSAllowsArbitraryLoads</key>
-    <true/>
-  </dict>
+	<key>NSAppTransportSecurity</key>
+	<!--See http://ste.vn/2015/06/10/configuring-app-transport-security-ios-9-osx-10-11/ -->
+	<dict>
+		<key>NSExceptionDomains</key>
+		<dict>
+			<key>localhost</key>
+			<dict>
+				<key>NSTemporaryExceptionAllowsInsecureHTTPLoads</key>
+				<true/>
+			</dict>
+		</dict>
+	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
Building off of the work in https://github.com/facebook/react-native/pull/5290, this…

- Remove the total disabling of ATS from the react-native generated iOS project in favor of a localhost exception