### PR TITLE
Remove duplicate module require

### DIFF
--- a/local-cli/cli.js
+++ b/local-cli/cli.js
@@ -18,7 +18,6 @@ var childProcess = require('child_process');
 var Config = require('./util/Config');
 var defaultConfig = require('./default.config');
 var dependencies = require('./dependencies/dependencies');
-var fs = require('fs');
 var generate = require('./generate/generate');
 var library = require('./library/library');
 var link = require('./library/link');


### PR DESCRIPTION
```js
var dependencies = require('./dependencies/dependencies');
var fs = require('fs');

...

var fs = require('fs');
var gracefulFs = require('graceful-fs');
```