### PR TITLE
Getter added for ReactInstanceManager

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/ReactActivity.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactActivity.java
@@ -106,6 +106,13 @@ public abstract class ReactActivity extends Activity implements DefaultHardwareB
   }
 
   /**
+   * Returns the ReactInstanceManager. A subclass may want to use it to get the current ReactContext.
+   */
+  protected ReactInstanceManager getReactInstanceManager() {
+    return mReactInstanceManager;
+  }
+
+  /**
    * A subclass may override this method if it needs to use a custom {@link ReactRootView}.
    */
   protected ReactRootView createRootView() {


### PR DESCRIPTION
Currently, there is no way for the subclassed Activity to get the ReactInstanceManager. This is generally useful to get the current ReactContext to send events to javascript, and was possible in previous releases because there was no ReactActivity.