### PR TITLE
added support for overlayColor property for image

### DIFF
--- a/Libraries/Components/View/ReactNativeStyleAttributes.js
+++ b/Libraries/Components/View/ReactNativeStyleAttributes.js
@@ -47,5 +47,6 @@ ReactNativeStyleAttributes.shadowColor = colorAttributes;
 ReactNativeStyleAttributes.textDecorationColor = colorAttributes;
 ReactNativeStyleAttributes.tintColor = colorAttributes;
 ReactNativeStyleAttributes.textShadowColor = colorAttributes;
+ReactNativeStyleAttributes.overlayColor = colorAttributes;
 
 module.exports = ReactNativeStyleAttributes;

--- a/Libraries/Image/ImageStylePropTypes.js
+++ b/Libraries/Image/ImageStylePropTypes.js
@@ -34,6 +34,14 @@ var ImageStylePropTypes = {
   // It changes the color of all the non-transparent pixels to the tintColor
   tintColor: ColorPropType,
   opacity: ReactPropTypes.number,
+  
+  /**
+  * Android-Specific style to allow rounded corners based on a solid color.
+  * Specifying an overlayColor will cause Fresco to switch to its other rounding 
+  * corners rendering mode, OVERLAY_COLOR, and will draw rounded corners (configured using borderRadius) 
+  * by overlaying the solid color specified.
+  * a null or transparent overlayColor will default back to BITMAP_ONLY.
+  */  
   overlayColor: ReactPropTypes.string,
 };
 

--- a/Libraries/Image/ImageStylePropTypes.js
+++ b/Libraries/Image/ImageStylePropTypes.js
@@ -34,6 +34,7 @@ var ImageStylePropTypes = {
   // It changes the color of all the non-transparent pixels to the tintColor
   tintColor: ColorPropType,
   opacity: ReactPropTypes.number,
+  overlayColor: ReactPropTypes.string,
 };
 
 module.exports = ImageStylePropTypes;

--- a/Libraries/Image/ImageStylePropTypes.js
+++ b/Libraries/Image/ImageStylePropTypes.js
@@ -33,15 +33,15 @@ var ImageStylePropTypes = {
   // iOS-Specific style to "tint" an image.
   // It changes the color of all the non-transparent pixels to the tintColor
   tintColor: ColorPropType,
-  opacity: ReactPropTypes.number,
-  
+  opacity: ReactPropTypes.number,  
   /**
   * Android-Specific style to allow rounded corners based on a solid color.
-  * Specifying an overlayColor will cause Fresco to switch to its other rounding 
-  * corners rendering mode, OVERLAY_COLOR, and will draw rounded corners (configured using borderRadius) 
+  * Specifying an overlayColor will cause Fresco to switch to its other rounding
+  * corners rendering mode, OVERLAY_COLOR, and will draw rounded corners (configured using borderRadius)
   * by overlaying the solid color specified.
   * a null or transparent overlayColor will default back to BITMAP_ONLY.
-  */  
+  * @platform android
+  */
   overlayColor: ReactPropTypes.string,
 };
 

--- a/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageManager.java
@@ -88,6 +88,15 @@ public class ReactImageManager extends SimpleViewManager<ReactImageView> {
     }
   }
 
+  @ReactProp(name = "overlayColor")
+  public void setOverlayColor(ReactImageView view, @Nullable Integer overlayColor) {
+    if (overlayColor == null) {
+      view.setOverlayColor(Color.TRANSPARENT);
+    } else {
+      view.setOverlayColor(overlayColor);
+    }
+  }
+
   @ReactProp(name = "borderWidth")
   public void setBorderWidth(ReactImageView view, float borderWidth) {
     view.setBorderWidth(borderWidth);

--- a/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageView.java
@@ -16,6 +16,7 @@ import android.graphics.Bitmap;
 import android.graphics.BitmapShader;
 import android.graphics.Canvas;
 import android.graphics.drawable.Drawable;
+import android.graphics.Color;
 import android.graphics.Matrix;
 import android.graphics.Paint;
 import android.graphics.Rect;
@@ -108,6 +109,7 @@ public class ReactImageView extends GenericDraweeView {
   private @Nullable Uri mUri;
   private @Nullable Drawable mLoadingImageDrawable;
   private int mBorderColor;
+  private int mOverlayColor;
   private float mBorderWidth;
   private float mBorderRadius;
   private ScalingUtils.ScaleType mScaleType;
@@ -183,6 +185,11 @@ public class ReactImageView extends GenericDraweeView {
 
   public void setBorderColor(int borderColor) {
     mBorderColor = borderColor;
+    mIsDirty = true;
+  }
+
+  public void setOverlayColor(int overlayColor) {
+    mOverlayColor = overlayColor;
     mIsDirty = true;
   }
 
@@ -266,6 +273,9 @@ public class ReactImageView extends GenericDraweeView {
     RoundingParams roundingParams = hierarchy.getRoundingParams();
     roundingParams.setCornersRadius(hierarchyRadius);
     roundingParams.setBorder(mBorderColor, mBorderWidth);
+    if (mOverlayColor != Color.TRANSPARENT) {
+        roundingParams.setOverlayColor(mOverlayColor);
+    }
     hierarchy.setRoundingParams(roundingParams);
     hierarchy.setFadeDuration(
         mFadeDurationMs >= 0

--- a/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageView.java
@@ -275,6 +275,9 @@ public class ReactImageView extends GenericDraweeView {
     roundingParams.setBorder(mBorderColor, mBorderWidth);
     if (mOverlayColor != Color.TRANSPARENT) {
         roundingParams.setOverlayColor(mOverlayColor);
+    } else {
+        // make sure the default rounding method is used.
+        roundingParams.setRoundingMethod(RoundingParams.RoundingMethod.BITMAP_ONLY);
     }
     hierarchy.setRoundingParams(roundingParams);
     hierarchy.setFadeDuration(


### PR DESCRIPTION
In Android, Fresco's default rounding corners support mode is BITMAP_ONLY which doesn't work in all cases (such as animated GIF's, some scale types, etc.).
Specifying the new "overlayColor" property on an Image will cause Fresco to switch to the other rounding corners mode, OVERLAY_COLOR, and will draw rounded corners by overlaying the solid color specified.

Fresco's behaviour is explained here: http://frescolib.org/docs/rounded-corners-and-circles.html