### PR TITLE
[Networking] bind this in onreadystatechange call

### DIFF
--- a/Libraries/Network/XMLHttpRequestBase.js
+++ b/Libraries/Network/XMLHttpRequestBase.js
@@ -245,7 +245,7 @@ class XMLHttpRequestBase {
     if (onreadystatechange) {
       // We should send an event to handler, but since we don't process that
       // event anywhere, let's leave it empty
-      onreadystatechange(null);
+      onreadystatechange.call(this, null);
     }
     if (newState === this.DONE && !this._aborted) {
       this._sendLoad();


### PR DESCRIPTION
I ran into this problem that `this` is undefined in `onreadystatechange` function calls while using this github api library: https://github.com/michael/github/blob/master/github.js#L72 

It seems that in the browser, the `onreadystatechange` function expects `this` to be bound. This example on the xhr spec website can be seen using `this` similarly: https://xhr.spec.whatwg.org/#the-getresponseheader()-method