### PR TITLE
Don't rely on global/$PATH react-native-cli

### DIFF
--- a/packager/react-native-xcode.sh
+++ b/packager/react-native-xcode.sh
@@ -46,7 +46,14 @@ fi
 # npm global install path may be a non-standard location
 PATH="$(npm prefix -g)/bin:$PATH"
 
-react-native bundle \
+# check for NPM-installed react-native-cli
+if [[ -d ./node_modules/react-native-cli ]] && [ -z "$REACT_NATIVE_PATH" ]; then
+  REACT_NATIVE_PATH=./node_modules/.bin/react-native
+fi
+# fall back to global/$PATH
+[ -z "$REACT_NATIVE_PATH" ] && REACT_NATIVE_PATH=react-native
+
+$REACT_NATIVE_PATH bundle \
   --entry-file index.ios.js \
   --platform ios \
   --dev $DEV \


### PR DESCRIPTION
I ([and others](https://twitter.com/dan_abramov/status/684553093409861632)) dislike installing dependencies globally. My workflow with react-native is to add the cli to the package.json so that the versions are locked for each project, etc - general reasons why global dependencies are avoided

The current Xcode build script expects `react-native` to be on the Xcode shell's $PATH, which can be troublesome (lots of issues related to this, i.e. #3948). This PR adds support for two things:

1. Automatically detects `react-native-cli` installed via `package.json` instead of globally
2. Allows a `REACT_NATIVE_PATH` variable that can be set via Xcode if your package exists elsewhere (not sure how helpful this would be for other folks, but hey)

Happy to explore other implementations, but the gist here is that generated react-native projects _should_ be able to work with a project-specific version of react-native-cli