### PR TITLE
Correctly bind Touchable.js setTimeout

### DIFF
--- a/Libraries/Components/Touchable/Touchable.js
+++ b/Libraries/Components/Touchable/Touchable.js
@@ -668,10 +668,9 @@ var TouchableMixin = {
       this.touchableHandleActivePressIn && this.touchableHandleActivePressIn(e);
     } else if (!newIsHighlight && curIsHighlight && this.touchableHandleActivePressOut) {
       if (this.touchableGetPressOutDelayMS && this.touchableGetPressOutDelayMS()) {
-        this.pressOutDelayTimeout = setTimeout(
-          this.touchableHandleActivePressOut.bind(this, e),
-          this.touchableGetPressOutDelayMS()
-        );
+        this.pressOutDelayTimeout = setTimeout(() => {
+          this.touchableHandleActivePressOut(e);
+        }, this.touchableGetPressOutDelayMS());
       } else {
         this.touchableHandleActivePressOut(e);
       }

--- a/Libraries/Components/Touchable/Touchable.js
+++ b/Libraries/Components/Touchable/Touchable.js
@@ -668,9 +668,10 @@ var TouchableMixin = {
       this.touchableHandleActivePressIn && this.touchableHandleActivePressIn(e);
     } else if (!newIsHighlight && curIsHighlight && this.touchableHandleActivePressOut) {
       if (this.touchableGetPressOutDelayMS && this.touchableGetPressOutDelayMS()) {
-        this.pressOutDelayTimeout = this.setTimeout(function() {
-          this.touchableHandleActivePressOut(e);
-        }, this.touchableGetPressOutDelayMS());
+        this.pressOutDelayTimeout = setTimeout(
+          this.touchableHandleActivePressOut.bind(this, e),
+          this.touchableGetPressOutDelayMS()
+        );
       } else {
         this.touchableHandleActivePressOut(e);
       }


### PR DESCRIPTION
Fixes https://github.com/facebook/react-native/issues/5337

`this.setTimeout` is undefined and the scope wasn't being passed through causing a RedBox error.