### PR TITLE
[Packager] add host argument for packager.

### DIFF
--- a/local-cli/server/runServer.js
+++ b/local-cli/server/runServer.js
@@ -44,7 +44,7 @@ function runServer(args, config, readyCallback) {
 
   const serverInstance = http.createServer(app).listen(
     args.port,
-    '::',
+    args.host,
     function() {
       attachHMRServer({
         httpServer: serverInstance,

--- a/local-cli/server/server.js
+++ b/local-cli/server/server.js
@@ -31,6 +31,10 @@ function _server(argv, config, resolve, reject) {
     default: 8081,
     type: 'string',
   }, {
+    command: 'host',
+    default: '',
+    type: 'string',
+  }, {
     command: 'root',
     type: 'string',
     description: 'add another root(s) to be used by the packager in this project',


### PR DESCRIPTION
Now packager only listen to "::", which is IPv6 "Any address".
It failed to run in IPv4 Environment.

defaults to undefined or empty string will fix this.

And I think it's necessary to let user define host by cli argument.

It's also for security reason. When working on a public network, it's much safer to listen with localhost instead of ::, which may let everyone in same network be able to get your code from debugger-ui.

recommit for #1918, fixes #2441 