### PR TITLE
Escape directory path in packager.sh

### DIFF
--- a/packager/launchPackager.command
+++ b/packager/launchPackager.command
@@ -12,7 +12,7 @@ echo -en "\033]0;React Packager\a"
 clear
 
 THIS_DIR=$(dirname "$0")
-pushd $THIS_DIR
+pushd "$THIS_DIR"
 source packager.sh
 popd
 

--- a/packager/packager.sh
+++ b/packager/packager.sh
@@ -8,5 +8,4 @@
 # of patent rights can be found in the PATENTS file in the same directory.
 
 THIS_DIR=$(dirname "$0")
-THIS_DIR=$(printf "%q" "$THIS_DIR")
 node "$THIS_DIR/../local-cli/cli.js" start "$@"

--- a/packager/packager.sh
+++ b/packager/packager.sh
@@ -8,4 +8,5 @@
 # of patent rights can be found in the PATENTS file in the same directory.
 
 THIS_DIR=$(dirname "$0")
+THIS_DIR=$(printf "%q" "$THIS_DIR")
 node "$THIS_DIR/../local-cli/cli.js" start "$@"


### PR DESCRIPTION
Previously could not handle directory paths with spaces.