### PR TITLE
Provide a method to easily provide initial props to a ReactAndroid application

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/ReactActivity.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactActivity.java
@@ -61,6 +61,17 @@ public abstract class ReactActivity extends Activity implements DefaultHardwareB
   }
 
   /**
+   * Returns the launchOptions which will be passed to the {@link ReactInstanceManager}
+   * when the application is started. By default, this will return null and an empty
+   * object will be passed to your top level component as its initial props.
+   * If your React Native application requires props set outside of JS, override
+   * this method to return the Android.os.Bundle of your desired initial props.
+   */
+  protected @Nullable Bundle getLaunchOptions() {
+    return null;
+  }
+
+  /**
    * Returns the name of the main component registered from JavaScript.
    * This is used to schedule rendering of the component.
    * e.g. "MoviesApp"
@@ -128,7 +139,7 @@ public abstract class ReactActivity extends Activity implements DefaultHardwareB
 
     mReactInstanceManager = createReactInstanceManager();
     ReactRootView mReactRootView = createRootView();
-    mReactRootView.startReactApplication(mReactInstanceManager, getMainComponentName());
+    mReactRootView.startReactApplication(mReactInstanceManager, getMainComponentName(), getLaunchOptions());
     setContentView(mReactRootView);
   }
 


### PR DESCRIPTION
Adds back support for initial props in ReactAndroid while maintaining the abstraction benefits of having the details of ReactActivity abstracted from the end user's MainActivity. This does remove the need for ReactRootView's two paramater version of the overloaded startReactApplication as far as I can tell but I wasn't sure if anyone might be using that method internally.