### PR TITLE
Fix image orientation on Android for local uris

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageView.java
@@ -279,6 +279,7 @@ public class ReactImageView extends GenericDraweeView {
     ImageRequest imageRequest = ImageRequestBuilder.newBuilderWithSource(mUri)
         .setPostprocessor(postprocessor)
         .setResizeOptions(resizeOptions)
+        .setAutoRotateEnabled(true)
         .setProgressiveRenderingEnabled(mProgressiveRenderingEnabled)
         .build();
 


### PR DESCRIPTION
In Android, when displaying an image with local uri, react-native seems to fail to rotate it according to Exif. 
Images on iOS seem like they are being rotated, so this does not seem like a consistent behaviour.

For instance, when taking a picture on a Samsung Galaxy S6, and displaying it with code like below, image does not have a correct orientation.
```javascript
<Image source={{uri: "file:/storage/emulated/0/DCIM/Camera/20160106_171628.jpg"}} />
```
<img src="https://cloud.githubusercontent.com/assets/4534323/12403776/aa5075cc-be36-11e5-885a-7be8236a7fdd.jpg" width=200 />

As seen [here](http://frescolib.org/docs/resizing-rotating.html#auto-rotation), Fresco can do all the work for us (hence this very simple PR).
I tested it on Samsung Galaxy S6 (lollipop), Galaxy S4 (kitkat) and Moto X Style (marshmallow).


I have written an example that fetches images uri from the Java side and then display them in a list view.
[Here](https://github.com/Almouro/rn-camera-roll/tree/use-react-native-master/example) is the code with react-native from master (with probably not the best way to compile `react-native` from the `node_modules`).
[Here](https://github.com/Almouro/rn-camera-roll/tree/use-react-from-pr/example) is the code with react-native from this PR.