### PR TITLE
Add custom header support for Android WebViews

### DIFF
--- a/Examples/UIExplorer/ListViewExample.js
+++ b/Examples/UIExplorer/ListViewExample.js
@@ -57,6 +57,7 @@ var ListViewSimpleExample = React.createClass({
           dataSource={this.state.dataSource}
           renderRow={this._renderRow}
           renderScrollComponent={props => <RecyclerViewBackedScrollView {...props} />}
+          renderSeparator={(sectionID, rowID) => <View key={`${sectionID}-${rowID}`} style={styles.separator} />}
         />
       </UIExplorerPage>
     );
@@ -74,7 +75,6 @@ var ListViewSimpleExample = React.createClass({
               {rowData + ' - ' + LOREM_IPSUM.substr(0, rowHash % 301 + 10)}
             </Text>
           </View>
-          <View style={styles.separator} />
         </View>
       </TouchableHighlight>
     );

--- a/Libraries/Components/WebView/WebView.android.js
+++ b/Libraries/Components/WebView/WebView.android.js
@@ -133,13 +133,23 @@ var WebView = React.createClass({
       domStorageEnabled = this.props.domStorageEnabledAndroid;
     }
 
+    var urlProp, urlWithHeaders;
+    if(this.props.headers == null) {
+      urlProp = this.props.url;
+    } else {
+      urlWithHeaders = {
+        url: this.props.url,
+        headers: this.props.headers,
+      }
+    }
+
     var webView =
       <RCTWebView
         ref={RCT_WEBVIEW_REF}
         key="webViewKey"
         style={webViewStyles}
-        url={this.props.url}
-        headers={this.props.headers}
+        url={urlProp}
+        headers={urlWithHeaders}
         html={this.props.html}
         injectedJavaScript={this.props.injectedJavaScript}
         userAgent={this.props.userAgent}

--- a/Libraries/Components/WebView/WebView.android.js
+++ b/Libraries/Components/WebView/WebView.android.js
@@ -53,6 +53,12 @@ var WebView = React.createClass({
     style: View.propTypes.style,
 
     /**
+     * Used on Android only, custom headers to be used when loading a URL in the WebView
+     * @platform android
+     */
+    headers: PropTypes.object,
+
+    /**
      * Used on Android only, JS is enabled by default for WebView on iOS
      * @platform android
      */
@@ -133,6 +139,7 @@ var WebView = React.createClass({
         key="webViewKey"
         style={webViewStyles}
         url={this.props.url}
+        headers={this.props.headers}
         html={this.props.html}
         injectedJavaScript={this.props.injectedJavaScript}
         userAgent={this.props.userAgent}

--- a/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebViewManager.java
@@ -9,11 +9,6 @@
 
 package com.facebook.react.views.webview;
 
-import javax.annotation.Nullable;
-
-import java.util.HashMap;
-import java.util.Map;
-
 import android.graphics.Bitmap;
 import android.os.Build;
 import android.os.SystemClock;
@@ -39,6 +34,11 @@ import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.UIManagerModule;
 import com.facebook.react.uimanager.events.Event;
 import com.facebook.react.uimanager.events.EventDispatcher;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.annotation.Nullable;
 
 /**
  * Manages instances of {@link WebView}
@@ -176,8 +176,6 @@ public class ReactWebViewManager extends SimpleViewManager<WebView> {
    */
   private static class ReactWebView extends WebView implements LifecycleEventListener {
     private @Nullable String injectedJS;
-    private @Nullable String url;
-    private @Nullable HashMap<String, String> headers;
 
     /**
      * WebView must be created with an context of the current activity
@@ -207,28 +205,6 @@ public class ReactWebViewManager extends SimpleViewManager<WebView> {
 
     public void setInjectedJavaScript(@Nullable String js) {
       injectedJS = js;
-    }
-
-    public String getUrl() {
-      return url;
-    }
-
-    public HashMap<String, String> getHeaders() {
-      return headers;
-    }
-
-    public void setUrl(@Nullable String url) {
-      this.url = url;
-    }
-
-    public void setHeaders(@Nullable HashMap<String, String> headers) {
-      this.headers = headers;
-    }
-
-    public void load() {
-      if (url != null && headers != null) {
-        loadUrl(url, headers);
-      }
     }
 
     public void callInjectedJavaScript() {
@@ -308,15 +284,16 @@ public class ReactWebViewManager extends SimpleViewManager<WebView> {
   }
 
   @ReactProp(name = "headers")
-  public void setHeaders(ReactWebView view, @Nullable ReadableMap headers) {
-    HashMap<String, String> headerMap = new HashMap<>();
-    ReadableMapKeySetIterator iter = headers.keySetIterator();
+  public void setUrlWithHeaders(ReactWebView view, @Nullable ReadableMap urlWithHeaders) {
+    String url = urlWithHeaders.getString("url");
+    ReadableMap headerMap = urlWithHeaders.getMap("headers");
+    ReadableMapKeySetIterator iter = headerMap.keySetIterator();
+    HashMap<String, String> headers = new HashMap<>();
     while (iter.hasNextKey()) {
       String key = iter.nextKey();
-      headerMap.put(key, headers.getString(key));
+      headers.put(key, headerMap.getString(key));
     }
-    view.setHeaders(headerMap);
-    view.load();
+    view.loadUrl(url, headers);
   }
 
   @ReactProp(name = "url")
@@ -331,10 +308,9 @@ public class ReactWebViewManager extends SimpleViewManager<WebView> {
       return;
     }
     if (url != null) {
-      view.setUrl(url);
-      view.load();
+      view.loadUrl("http://www.cnn.com");
     } else {
-      view.loadUrl(BLANK_URL);
+      view.loadUrl("http://www.reddit.com");
     }
   }
 
@@ -374,3 +350,4 @@ public class ReactWebViewManager extends SimpleViewManager<WebView> {
     ((ReactWebView) webView).cleanupCallbacksAndDestroy();
   }
 }
+

--- a/packager/react-packager/src/Bundler/index.js
+++ b/packager/react-packager/src/Bundler/index.js
@@ -190,6 +190,7 @@ class Bundler {
     return this.getDependencies(entryFile, isDev, platform).then((response) => {
       Activity.endEvent(findEventId);
       bundle.setMainModuleId(response.mainModuleId);
+      bundle.setMainModuleName(response.mainModuleId);
       transformEventId = Activity.startEvent('transform');
 
       const moduleSystemDeps = includeSystemDependencies
@@ -396,7 +397,7 @@ class Bundler {
       return this._transformer.loadFileAndTransform(
         path.resolve(module.path),
         this._getTransformOptions(
-          {bundleEntry: bundle.getMainModuleId(), modulePath: module.path},
+          {bundleEntry: bundle.getMainModuleName(), modulePath: module.path},
           {hot: hot},
         ),
       );


### PR DESCRIPTION
Related to [issue #5418](https://github.com/facebook/react-native/issues/5418)

Adds a new ReactProp 'urlWithHeaders' to Android WebViews that takes an object with a 'url' string and a 'headers' map.