### PR TITLE
Fix Navigator transparent scene case

### DIFF
--- a/Libraries/CustomComponents/Navigator/Navigator.js
+++ b/Libraries/CustomComponents/Navigator/Navigator.js
@@ -648,6 +648,7 @@ var Navigator = React.createClass({
     if (this.spring.getCurrentValue() === 0) {
       // The spring is at zero, so the gesture is already complete
       this.spring.setCurrentValue(0).setAtRest();
+      this._detachGesture();
       this._completeTransition();
       return;
     }


### PR DESCRIPTION
If a 'pop' gesture is ended where it starts(edge of screen), the gesture is not detached properly. As result, the previous scene is enabled when the gesture started, but didn't hide when gesture is ended at `hideScenes`.

It is only reproduced when current view is transparent.