### PR TITLE
Correct link to former react.rocks website

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Note that you'll need the Android NDK installed, see [prerequisites](https://git
 
 ## Extending React Native
 
-- Looking for a component? [react.parts](http://react.parts/)
+- Looking for a component? [JS.coach](https://js.coach)
 - Fellow developers write and publish React Native modules to npm and open source them on GitHub.
 - Making modules helps grow the React Native ecosystem and community. We recommend writing modules for your use cases and sharing them on npm.
 - Read the guides on Native Modules ([iOS](http://facebook.github.io/react-native/docs/native-modules-ios.html), [Android](http://facebook.github.io/react-native/docs/native-modules-android.html)) and Native UI Components ([iOS](http://facebook.github.io/react-native/docs/native-components-ios.html), [Android](http://facebook.github.io/react-native/docs/native-components-android.html)) if you are interested in extending native functionality.

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Note that you'll need the Android NDK installed, see [prerequisites](https://git
 
 ## Extending React Native
 
-- Looking for a component? [JS.coach](https://js.coach)
+- Looking for a component? [JS.coach](https://js.coach/react-native)
 - Fellow developers write and publish React Native modules to npm and open source them on GitHub.
 - Making modules helps grow the React Native ecosystem and community. We recommend writing modules for your use cases and sharing them on npm.
 - Read the guides on Native Modules ([iOS](http://facebook.github.io/react-native/docs/native-modules-ios.html), [Android](http://facebook.github.io/react-native/docs/native-modules-android.html)) and Native UI Components ([iOS](http://facebook.github.io/react-native/docs/native-components-ios.html), [Android](http://facebook.github.io/react-native/docs/native-components-android.html)) if you are interested in extending native functionality.


### PR DESCRIPTION
react.rocks has moved to js.coach and the packages at react.rocks aren't up to date anymore.