### PR TITLE
Add an 'Experiments' class to enable/disable experiments.

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/Experiments.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/Experiments.java
@@ -14,9 +14,8 @@ import java.util.Set;
 
 
 /**
- * This class exposes a way to enable/disable exprimental features in React Native.
+ * This class exposes a way to enable/disable experimental features in React Native.
  */
-
 public class Experiments {
 
   // Enables Hot Module Replacement menu item in the developer menu
@@ -37,7 +36,7 @@ public class Experiments {
   }
 
   /**
-   * Disbales an expriment
+   * Disables an experiment
    *
    * @param experiment - the experiment to disable
    */
@@ -48,7 +47,7 @@ public class Experiments {
   }
 
   /**
-   * Checks if an expriment is enabled
+   * Checks if an experiment is enabled
    *
    * @param experiment - the experiment to check for
    */

--- a/ReactAndroid/src/main/java/com/facebook/react/Experiments.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/Experiments.java
@@ -25,8 +25,6 @@ public class Experiments {
 
   /**
    * Enables an experiment
-   *
-   * @param experiment - the experiment to enable
    */
   public static void enableExperiment(String experiment) {
     if (enabledExperiments == null) {
@@ -37,8 +35,6 @@ public class Experiments {
 
   /**
    * Disables an experiment
-   *
-   * @param experiment - the experiment to disable
    */
   public static void disableExperiment(String experiment) {
     if (enabledExperiments != null) {
@@ -48,8 +44,6 @@ public class Experiments {
 
   /**
    * Checks if an experiment is enabled
-   *
-   * @param experiment - the experiment to check for
    */
   public static boolean isExperimentEnabled(String experiment) {
     return enabledExperiments != null && enabledExperiments.contains(experiment);

--- a/ReactAndroid/src/main/java/com/facebook/react/Experiments.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/Experiments.java
@@ -1,0 +1,28 @@
+package com.facebook.react;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class Experiments {
+
+  public static String HOT_MODULE_REPLACEMENT = "HOT_MODULE_REPLACEMENT";
+
+  private static Set<String> enabledExperiments;
+
+  public static void enableExperiment(String experiment) {
+    if (enabledExperiments == null) {
+      enabledExperiments = new HashSet<>();
+    }
+    enabledExperiments.add(experiment);
+  }
+
+  public static void disableExperiment(String experiment) {
+    if (enabledExperiments != null) {
+      enabledExperiments.remove(experiment);
+    }
+  }
+
+  public static boolean isExperimentEnabled(String experiment) {
+    return enabledExperiments != null && enabledExperiments.contains(experiment);
+  }
+}

--- a/ReactAndroid/src/main/java/com/facebook/react/Experiments.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/Experiments.java
@@ -1,14 +1,34 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
 package com.facebook.react;
 
 import java.util.HashSet;
 import java.util.Set;
 
+
+/**
+ * This class exposes a way to enable/disable exprimental features in React Native.
+ */
+
 public class Experiments {
 
+  // Enables Hot Module Replacement menu item in the developer menu
   public static String HOT_MODULE_REPLACEMENT = "HOT_MODULE_REPLACEMENT";
 
   private static Set<String> enabledExperiments;
 
+  /**
+   * Enables an experiment
+   *
+   * @param experiment - the experiment to enable
+   */
   public static void enableExperiment(String experiment) {
     if (enabledExperiments == null) {
       enabledExperiments = new HashSet<>();
@@ -16,12 +36,22 @@ public class Experiments {
     enabledExperiments.add(experiment);
   }
 
+  /**
+   * Disbales an expriment
+   *
+   * @param experiment - the experiment to disable
+   */
   public static void disableExperiment(String experiment) {
     if (enabledExperiments != null) {
       enabledExperiments.remove(experiment);
     }
   }
 
+  /**
+   * Checks if an expriment is enabled
+   *
+   * @param experiment - the experiment to check for
+   */
   public static boolean isExperimentEnabled(String experiment) {
     return enabledExperiments != null && enabledExperiments.contains(experiment);
   }

--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerImpl.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerImpl.java
@@ -36,6 +36,7 @@ import android.widget.Toast;
 
 import com.facebook.common.logging.FLog;
 import com.facebook.infer.annotation.Assertions;
+import com.facebook.react.Experiments;
 import com.facebook.react.R;
 import com.facebook.react.bridge.CatalystInstance;
 import com.facebook.react.bridge.DefaultNativeModuleCallExceptionHandler;
@@ -265,17 +266,21 @@ public class DevSupportManagerImpl implements DevSupportManager {
             handleReloadJS();
           }
         });
-    options.put(
-            mDevSettings.isHotModuleReplacementEnabled()
-                    ? mApplicationContext.getString(R.string.catalyst_hot_module_replacement_off)
-                    : mApplicationContext.getString(R.string.catalyst_hot_module_replacement),
-            new DevOptionHandler() {
-              @Override
-              public void onOptionSelected() {
-                mDevSettings.setHotModuleReplacementEnabled(!mDevSettings.isHotModuleReplacementEnabled());
-                handleReloadJS();
-              }
-            });
+
+    if (Experiments.isExperimentEnabled(Experiments.HOT_MODULE_REPLACEMENT)) {
+      options.put(
+        mDevSettings.isHotModuleReplacementEnabled()
+          ? mApplicationContext.getString(R.string.catalyst_hot_module_replacement_off)
+          : mApplicationContext.getString(R.string.catalyst_hot_module_replacement),
+        new DevOptionHandler() {
+          @Override
+          public void onOptionSelected() {
+            mDevSettings.setHotModuleReplacementEnabled(!mDevSettings.isHotModuleReplacementEnabled());
+            handleReloadJS();
+          }
+        });
+    }
+
     options.put(
         mDevSettings.isReloadOnJSChangeEnabled()
             ? mApplicationContext.getString(R.string.catalyst_live_reload_off)


### PR DESCRIPTION
To enable an experiment (say HMR),

```java
Experiments.enableExperiment(Experiments.HOT_MODULE_REPLACEMENT)
```

To check if an experiment is enabled,

```java
if (Experiments.isExperimentEnabled(Experiments.HOT_MODULE_REPLACEMENT) {
  // do stuff
}
```

See #5339 

Test plan - In a fresh project "Enable Hot Module Replacement" shouldn't exist in dev menu. It should appear after enabling HMR in `MainActivity`'s `onCreate`.