### PR TITLE
Ensure perspective value is non-zero

### DIFF
--- a/Libraries/StyleSheet/processTransform.js
+++ b/Libraries/StyleSheet/processTransform.js
@@ -174,7 +174,9 @@ function _validateTransform(key, value, transformation) {
       );
       invariant(
         value !== 0,
-        'Perspective transform must receive a non-zero value'
+        'Transform with key of "%s" cannot be zero: %s',
+        key,
+        stringifySafe(transformation),
       );
       break;
     default:

--- a/Libraries/StyleSheet/processTransform.js
+++ b/Libraries/StyleSheet/processTransform.js
@@ -168,7 +168,7 @@ function _validateTransform(key, value, transformation) {
     case 'perspective':
       invariant(
         value !== 0,
-        "Perspective transform must receive a non-zero value"
+        'Perspective transform must receive a non-zero value'
       );
     default:
       invariant(

--- a/Libraries/StyleSheet/processTransform.js
+++ b/Libraries/StyleSheet/processTransform.js
@@ -165,6 +165,11 @@ function _validateTransform(key, value, transformation) {
         stringifySafe(transformation),
       );
       break;
+    case 'perspective':
+      invariant(
+        value !== 0,
+        "Perspective transform must receive a non-zero value"
+      );
     default:
       invariant(
         typeof value === 'number',

--- a/Libraries/StyleSheet/processTransform.js
+++ b/Libraries/StyleSheet/processTransform.js
@@ -167,9 +167,16 @@ function _validateTransform(key, value, transformation) {
       break;
     case 'perspective':
       invariant(
+        typeof value === 'number',
+        'Transform with key of "%s" must be a number: %s',
+        key,
+        stringifySafe(transformation),
+      );
+      invariant(
         value !== 0,
         'Perspective transform must receive a non-zero value'
       );
+      break;
     default:
       invariant(
         typeof value === 'number',


### PR DESCRIPTION
Setting `transform: {perspective: 0}` was causing app failure due to `NaN` produced by divide by zero in [MatrixMath.js](https://github.com/facebook/react-native/blob/96553cf553e26e48a87f83030e04aef788f2dfef/Libraries/Utilities/MatrixMath.js#L118).

See issue #2616 