### PR TITLE
add accessibilityLabel to TouchableOpacity

### DIFF
--- a/Libraries/Components/Touchable/TouchableOpacity.js
+++ b/Libraries/Components/Touchable/TouchableOpacity.js
@@ -156,6 +156,7 @@ var TouchableOpacity = React.createClass({
         accessible={true}
         accessibilityComponentType={this.props.accessibilityComponentType}
         accessibilityTraits={this.props.accessibilityTraits}
+        accessibilityLabel={this.props.accessibilityLabel}
         style={[this.props.style, {opacity: this.state.anim}]}
         testID={this.props.testID}
         onLayout={this.props.onLayout}

--- a/Libraries/Components/Touchable/TouchableWithoutFeedback.js
+++ b/Libraries/Components/Touchable/TouchableWithoutFeedback.js
@@ -137,6 +137,7 @@ var TouchableWithoutFeedback = React.createClass({
       accessible: this.props.accessible !== false,
       accessibilityComponentType: this.props.accessibilityComponentType,
       accessibilityTraits: this.props.accessibilityTraits,
+      accessibilityLabel: this.props.accessibilityLabel,
       testID: this.props.testID,
       onLayout: this.props.onLayout,
       onStartShouldSetResponder: this.touchableHandleStartShouldSetResponder,


### PR DESCRIPTION
According to https://facebook.github.io/react-native/docs/accessibility.html accessibilityLabel param should be supported, but it doesn't. 