### PR TITLE
IntentAndroid.openChooserWithOptions implements

### DIFF
--- a/Libraries/Components/Intent/IntentAndroid.android.js
+++ b/Libraries/Components/Intent/IntentAndroid.android.js
@@ -113,10 +113,10 @@ class IntentAndroid {
    * Open a chooser dialog to send data to other apps.
    *
    * Refer http://developer.android.com/intl/ko/training/sharing/send.html
-   * 
+   *
    * @param {object} Options - the data to send
    * @param {string} Title - the title of the chooser dialog
-   * @example 
+   * @example
    *   var options = {
    *     type: 'text/plain', //default
    *     subject: 'React Native',

--- a/Libraries/Components/Intent/IntentAndroid.android.js
+++ b/Libraries/Components/Intent/IntentAndroid.android.js
@@ -109,6 +109,33 @@ class IntentAndroid {
     IntentAndroidModule.getInitialURL(callback);
   }
 
+  /**
+   * Open a chooser dialog to send data to other apps.
+   *
+   * Refer http://developer.android.com/intl/ko/training/sharing/send.html
+   * 
+   * @param {object} Options - the data to send
+   * @param {string} Title - the title of the chooser dialog
+   * @example 
+   *   var options = {
+   *     type: 'text/plain', //default
+   *     subject: 'React Native',
+   *     text: 'http://facebook.github.io/react-native/'
+   *   }
+   */
+  static openChooserWithOptions(options: Object, title: string) {
+    invariant(
+      typeof options === 'object',
+      'A valid option object is required'
+    );
+     invariant(
+      typeof title === 'string',
+      'Invalid Title: should be a string. Was: ' + title
+    );
+    IntentAndroidModule.openChooserWithOptions(options, title);
+  }
+
+
   static _validateURL(url: string) {
     invariant(
       typeof url === 'string',

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/intent/IntentModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/intent/IntentModule.java
@@ -115,5 +115,42 @@ public class IntentModule extends ReactContextBaseJavaModule {
       throw new JSApplicationIllegalArgumentException(
           "Could not check if URL '" + url + "' can be opened: " + e.getMessage());
     }
+  } 
+
+  /**
+   * Open a chooser dialog to send data to other apps.
+   *
+   * Refer http://developer.android.com/intl/ko/training/sharing/send.html
+   * 
+   * @param options the data to send
+   * @param title the title of the chooser dialog
+   */
+  @ReactMethod
+  public void openChooserWithOptions(ReadableMap options, String title) {
+    if (options == null) {
+      throw new JSApplicationIllegalArgumentException("Invalid Options");
+    }
+
+    Activity currentActivity = getCurrentActivity();
+    Intent intent = new Intent(Intent.ACTION_SEND);
+    if(options.hasKey("type")) {
+      intent.setTypeAndNormalize(options.getString("type"));
+    } else {
+      intent.setTypeAndNormalize("text/plain");
+    }
+    
+    if(options.hasKey("subject")) {
+      intent.putExtra(Intent.EXTRA_SUBJECT, options.getString("subject"));
+    }
+    if(options.hasKey("text")) {
+      intent.putExtra(Intent.EXTRA_TEXT, options.getString("text"));
+    }
+
+    if (currentActivity != null) {
+      currentActivity.startActivity(Intent.createChooser(intent, title));
+    } else {
+      intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+      getReactApplicationContext().startActivity(Intent.createChooser(intent, title));
+    }
   }
 }


### PR DESCRIPTION
This implementation of `IntentAndroid.openChooserWithOptions` is similar to `ActionSheetIOS. showShareActionSheetWithOptions`. It calls `Intent.createChooser()` and you can see how it acts at [android docs](http://developer.android.com/intl/ko/training/sharing/send.html)