### PR TITLE
ART add fillRule prop on iOS

### DIFF
--- a/Libraries/ART/ARTCGFillRule.h
+++ b/Libraries/ART/ARTCGFillRule.h
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+typedef CF_ENUM(int32_t, ARTCGFillRule) {
+  kARTCGFillRuleEvenodd,
+  kARTCGFillRuleNonzero
+};

--- a/Libraries/ART/ARTRenderable.h
+++ b/Libraries/ART/ARTRenderable.h
@@ -11,6 +11,7 @@
 
 #import "ARTBrush.h"
 #import "ARTCGFloatArray.h"
+#import "ARTCGFillRule.h"
 #import "ARTNode.h"
 
 @interface ARTRenderable : ARTNode
@@ -20,6 +21,7 @@
 @property (nonatomic, assign) CGFloat strokeWidth;
 @property (nonatomic, assign) CGLineCap strokeCap;
 @property (nonatomic, assign) CGLineJoin strokeJoin;
+@property (nonatomic, assign) ARTCGFillRule fillRule;
 @property (nonatomic, assign) ARTCGFloatArray strokeDash;
 
 @end

--- a/Libraries/ART/ARTRenderable.m
+++ b/Libraries/ART/ARTRenderable.m
@@ -45,6 +45,12 @@
   _strokeJoin = strokeJoin;
 }
 
+- (void)setFillRule:(ARTCGFillRule)fillRule
+{
+  [self invalidate];
+  _fillRule = fillRule;
+}
+
 - (void)setStrokeDash:(ARTCGFloatArray)strokeDash
 {
   if (strokeDash.array == _strokeDash.array) {

--- a/Libraries/ART/ARTShape.m
+++ b/Libraries/ART/ARTShape.m
@@ -35,7 +35,7 @@
   CGPathDrawingMode mode = kCGPathStroke;
   if (self.fill) {
     if ([self.fill applyFillColor:context]) {
-      mode = kCGPathFill;
+      mode = self.fillRule == kARTCGFillRuleEvenodd ? kCGPathEOFill : kCGPathFill;
     } else {
       CGContextSaveGState(context);
       CGContextAddPath(context, self.d);
@@ -58,6 +58,8 @@
     }
     if (mode == kCGPathFill) {
       mode = kCGPathFillStroke;
+    } else if (mode == kCGPathEOFill) {
+      mode = kCGPathEOFillStroke;
     }
   }
 

--- a/Libraries/ART/RCTConvert+ART.h
+++ b/Libraries/ART/RCTConvert+ART.h
@@ -12,12 +12,14 @@
 #import "ARTBrush.h"
 #import "ARTCGFloatArray.h"
 #import "ARTTextFrame.h"
+#import "ARTCGFillRule.h"
 #import "RCTConvert.h"
 
 @interface RCTConvert (ART)
 
 + (CGPathRef)CGPath:(id)json;
 + (CTTextAlignment)CTTextAlignment:(id)json;
++ (ARTCGFillRule)ARTCGFillRule:(id)json;
 + (ARTTextFrame)ARTTextFrame:(id)json;
 + (ARTCGFloatArray)ARTCGFloatArray:(id)json;
 + (ARTBrush *)ARTBrush:(id)json;

--- a/Libraries/ART/RCTConvert+ART.m
+++ b/Libraries/ART/RCTConvert+ART.m
@@ -13,6 +13,7 @@
 #import "ARTPattern.h"
 #import "ARTRadialGradient.h"
 #import "ARTSolidColor.h"
+#import "ARTCGFillRule.h"
 #import "RCTLog.h"
 
 @implementation RCTConvert (ART)
@@ -71,6 +72,11 @@ RCT_ENUM_CONVERTER(CTTextAlignment, (@{
   @"right": @(kCTTextAlignmentRight),
   @"justify": @(kCTTextAlignmentJustified),
 }), kCTTextAlignmentNatural, integerValue)
+
+RCT_ENUM_CONVERTER(ARTCGFillRule, (@{
+  @"evenodd": @(kARTCGFillRuleEvenodd),
+  @"nonzero": @(kARTCGFillRuleNonzero),
+}), kARTCGFillRuleEvenodd, intValue)
 
 // This takes a tuple of text lines and a font to generate a CTLine for each text line.
 // This prepares everything for rendering a frame of text in ARTText.

--- a/Libraries/ART/ReactNativeART.js
+++ b/Libraries/ART/ReactNativeART.js
@@ -84,6 +84,7 @@ var RenderableAttributes = merge(NodeAttributes, {
   strokeWidth: true,
   strokeCap: true,
   strokeJoin: true,
+  fillRule: true,
   strokeDash: { diff: arrayDiffer },
 });
 
@@ -377,6 +378,13 @@ function extractStrokeJoin(strokeJoin) {
   }
 }
 
+function extractFillRule(fillRule) {
+  switch (fillRule) {
+    case 'evenodd': return 0;
+    default: return 1; // nonzero
+  }
+}
+
 // Shape
 
 // Note: ART has a notion of width and height on Shape but AFAIK it's a noop in
@@ -398,7 +406,7 @@ var Shape = React.createClass({
         strokeJoin={extractStrokeJoin(props.strokeJoin)}
         strokeWidth={extractNumber(props.strokeWidth, 1)}
         transform={extractTransform(props)}
-
+        fillRule={extractFillRule(props.fillRule)}
         d={d}
       />
     );
@@ -497,7 +505,7 @@ var Text = React.createClass({
         strokeJoin={extractStrokeJoin(props.strokeJoin)}
         strokeWidth={extractNumber(props.strokeWidth, 1)}
         transform={extractTransform(props)}
-
+        fillRule={extractFillRule(props.fillRule)}
         alignment={extractAlignment(props.alignment)}
         frame={textFrame}
         path={textPath}

--- a/Libraries/ART/ViewManagers/ARTRenderableManager.m
+++ b/Libraries/ART/ViewManagers/ARTRenderableManager.m
@@ -8,8 +8,17 @@
  */
 
 #import "ARTRenderableManager.h"
-
 #import "RCTConvert+ART.h"
+#import "RCTConvert.h"
+#import "ARTCGFillRule.h"
+
+@implementation RCTConvert(FillRule)
+
+RCT_ENUM_CONVERTER(ARTCGFillRule, (@{
+  @"evenodd": @(kARTCGFillRuleEvenodd),
+  @"nonzero": @(kARTCGFillRuleNonzero),
+}), kARTCGFillRuleEvenodd, intValue)
+@end
 
 @implementation ARTRenderableManager
 
@@ -26,5 +35,6 @@ RCT_EXPORT_VIEW_PROPERTY(strokeJoin, CGLineJoin)
 RCT_EXPORT_VIEW_PROPERTY(fill, ARTBrush)
 RCT_EXPORT_VIEW_PROPERTY(stroke, CGColor)
 RCT_EXPORT_VIEW_PROPERTY(strokeDash, ARTCGFloatArray)
+RCT_EXPORT_VIEW_PROPERTY(fillRule, ARTCGFillRule)
 
 @end

--- a/Libraries/ART/ViewManagers/ARTRenderableManager.m
+++ b/Libraries/ART/ViewManagers/ARTRenderableManager.m
@@ -9,16 +9,7 @@
 
 #import "ARTRenderableManager.h"
 #import "RCTConvert+ART.h"
-#import "RCTConvert.h"
 #import "ARTCGFillRule.h"
-
-@implementation RCTConvert(FillRule)
-
-RCT_ENUM_CONVERTER(ARTCGFillRule, (@{
-  @"evenodd": @(kARTCGFillRuleEvenodd),
-  @"nonzero": @(kARTCGFillRuleNonzero),
-}), kARTCGFillRuleEvenodd, intValue)
-@end
 
 @implementation ARTRenderableManager
 


### PR DESCRIPTION
ART add fileRule prop on iOS


fillRule="nonzero" // default value
```
<Surface
            height="210"
            width="210"
        >
<Shape 
    d="M100,10L40,198L190,78L10,78L160,198z"
    fill="lime"
    stroke="purple"
    strokeWidth="5"
/>
</Surface>
```
![qq 20160122134854](https://cloud.githubusercontent.com/assets/7693239/12503523/f9c66694-c10f-11e5-9e53-519d84446e7a.png)


fillRule="evenodd"

```
<Surface
            height="210"
            width="210"
        >
<Shape 
    d="M100,10L40,198L190,78L10,78L160,198z"
    fill="lime"
    stroke="purple"
    strokeWidth="5"
    fillRule="evenodd"
/>
</Surface>
```
![qq 20160122134857](https://cloud.githubusercontent.com/assets/7693239/12503525/ffe12d8e-c10f-11e5-852c-2bb47d0dc963.png)