### PR TITLE
Add headers prop to Android WebViews

### DIFF
--- a/Libraries/Components/WebView/WebView.android.js
+++ b/Libraries/Components/WebView/WebView.android.js
@@ -53,6 +53,12 @@ var WebView = React.createClass({
     style: View.propTypes.style,
 
     /**
+     * Used on Android only, custom headers to be used when loading a URL in the WebView
+     * @platform android
+     */
+    headers: PropTypes.object,
+
+    /**
      * Used on Android only, JS is enabled by default for WebView on iOS
      * @platform android
      */
@@ -127,12 +133,23 @@ var WebView = React.createClass({
       domStorageEnabled = this.props.domStorageEnabledAndroid;
     }
 
+    var urlProp, urlWithHeaders;
+    if(this.props.headers == null) {
+      urlProp = this.props.url;
+    } else {
+      urlWithHeaders = {
+        url: this.props.url,
+        headers: this.props.headers,
+      }
+    }
+
     var webView =
       <RCTWebView
         ref={RCT_WEBVIEW_REF}
         key="webViewKey"
         style={webViewStyles}
-        url={this.props.url}
+        url={urlProp}
+        headers={urlWithHeaders}
         html={this.props.html}
         injectedJavaScript={this.props.injectedJavaScript}
         userAgent={this.props.userAgent}

--- a/Libraries/Components/WebView/WebView.android.js
+++ b/Libraries/Components/WebView/WebView.android.js
@@ -134,15 +134,13 @@ var WebView = React.createClass({
       domStorageEnabled = this.props.domStorageEnabledAndroid;
     }
 
-    var htmlProp, urlProp, sourceProp;
-    if(this.props.html) {
-      console.warn('html is deprecated. Use source instead.');
-      htmlProp = this.props.html;
-    } else if(this.props.url) {
-      console.warn('url is deprecated. Use source instead.');
-      urlProp = this.props.url;
-    } else {
-      sourceProp = this.props.source;
+    var source = this.props.source || {};
+    if (this.props.html) {
+      console.warn('WebView: html is deprecated. Use source prop instead.');
+      source.html = this.props.html;
+    } else if (this.props.url) {
+      console.warn('WebView: url is deprecated. Use source prop instead.');
+      source.url = this.props.url;
     }
 
     var webView =
@@ -150,9 +148,7 @@ var WebView = React.createClass({
         ref={RCT_WEBVIEW_REF}
         key="webViewKey"
         style={webViewStyles}
-        html={htmlProp}
-        url={urlProp}
-        source={sourceProp}
+        source={source}
         injectedJavaScript={this.props.injectedJavaScript}
         userAgent={this.props.userAgent}
         javaScriptEnabled={javaScriptEnabled}

--- a/Libraries/Components/WebView/WebView.android.js
+++ b/Libraries/Components/WebView/WebView.android.js
@@ -53,10 +53,11 @@ var WebView = React.createClass({
     style: View.propTypes.style,
 
     /**
-     * Used on Android only, custom headers to be used when loading a URL in the WebView
+     * Used on Android only, provides html or url with optional headers to the WebView.
+     * `{ html: string, url: string, headers: map<string, string> }`
      * @platform android
      */
-    headers: PropTypes.object,
+    source: PropTypes.object,
 
     /**
      * Used on Android only, JS is enabled by default for WebView on iOS
@@ -133,14 +134,15 @@ var WebView = React.createClass({
       domStorageEnabled = this.props.domStorageEnabledAndroid;
     }
 
-    var urlProp, urlWithHeaders;
-    if (this.props.headers == null) {
+    var htmlProp, urlProp, sourceProp;
+    if(this.props.html) {
+      console.warn('html is deprecated. Use source instead.');
+      htmlProp = this.props.html;
+    } else if(this.props.url) {
+      console.warn('url is deprecated. Use source instead.');
       urlProp = this.props.url;
     } else {
-      urlWithHeaders = {
-        url: this.props.url,
-        headers: this.props.headers,
-      };
+      sourceProp = this.props.source;
     }
 
     var webView =
@@ -148,9 +150,9 @@ var WebView = React.createClass({
         ref={RCT_WEBVIEW_REF}
         key="webViewKey"
         style={webViewStyles}
+        html={htmlProp}
         url={urlProp}
-        headers={urlWithHeaders}
-        html={this.props.html}
+        source={sourceProp}
         injectedJavaScript={this.props.injectedJavaScript}
         userAgent={this.props.userAgent}
         javaScriptEnabled={javaScriptEnabled}

--- a/Libraries/Components/WebView/WebView.android.js
+++ b/Libraries/Components/WebView/WebView.android.js
@@ -134,13 +134,13 @@ var WebView = React.createClass({
     }
 
     var urlProp, urlWithHeaders;
-    if(this.props.headers == null) {
+    if (this.props.headers == null) {
       urlProp = this.props.url;
     } else {
       urlWithHeaders = {
         url: this.props.url,
         headers: this.props.headers,
-      }
+      };
     }
 
     var webView =

--- a/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebViewManager.java
@@ -274,6 +274,7 @@ public class ReactWebViewManager extends SimpleViewManager<WebView> {
     ((ReactWebView) view).setInjectedJavaScript(injectedJavaScript);
   }
 
+  @Deprecated
   @ReactProp(name = "html")
   public void setHtml(WebView view, @Nullable String html) {
     if (html != null) {
@@ -283,19 +284,7 @@ public class ReactWebViewManager extends SimpleViewManager<WebView> {
     }
   }
 
-  @ReactProp(name = "headers")
-  public void setUrlWithHeaders(WebView view, @Nullable ReadableMap urlWithHeaders) {
-    String url = urlWithHeaders.getString("url");
-    ReadableMap headerMap = urlWithHeaders.getMap("headers");
-    ReadableMapKeySetIterator iter = headerMap.keySetIterator();
-    HashMap<String, String> headers = new HashMap<>();
-    while (iter.hasNextKey()) {
-      String key = iter.nextKey();
-      headers.put(key, headerMap.getString(key));
-    }
-    view.loadUrl(url, headers);
-  }
-
+  @Deprecated
   @ReactProp(name = "url")
   public void setUrl(WebView view, @Nullable String url) {
     // TODO(8495359): url and html are coupled as they both call loadUrl, therefore in case when
@@ -309,6 +298,26 @@ public class ReactWebViewManager extends SimpleViewManager<WebView> {
     }
     if (url != null) {
       view.loadUrl(url);
+    } else {
+      view.loadUrl(BLANK_URL);
+    }
+  }
+
+  @ReactProp(name = "source")
+  public void setSource(WebView view, @Nullable ReadableMap source) {
+    if (source.hasKey("html")) {
+      view.loadData(source.getString("html"), HTML_MIME_TYPE, HTML_ENCODING);
+    } else if(source.hasKey("url")) {
+      HashMap<String, String> headerMap = new HashMap<>();
+      if (source.hasKey("headers")) {
+        ReadableMap headers = source.getMap("headers");
+        ReadableMapKeySetIterator iter = headers.keySetIterator();
+        while (iter.hasNextKey()) {
+          String key = iter.nextKey();
+          headerMap.put(key, headers.getString(key));
+        }
+      }
+      view.loadUrl(source.getString("url"), headerMap);
     } else {
       view.loadUrl(BLANK_URL);
     }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebViewManager.java
@@ -9,10 +9,6 @@
 
 package com.facebook.react.views.webview;
 
-import javax.annotation.Nullable;
-
-import java.util.Map;
-
 import android.graphics.Bitmap;
 import android.os.Build;
 import android.os.SystemClock;
@@ -27,15 +23,22 @@ import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.LifecycleEventListener;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReadableArray;
+import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.bridge.ReadableMapKeySetIterator;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.common.MapBuilder;
 import com.facebook.react.common.build.ReactBuildConfig;
-import com.facebook.react.uimanager.annotations.ReactProp;
 import com.facebook.react.uimanager.SimpleViewManager;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.UIManagerModule;
+import com.facebook.react.uimanager.annotations.ReactProp;
 import com.facebook.react.uimanager.events.Event;
 import com.facebook.react.uimanager.events.EventDispatcher;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.annotation.Nullable;
 
 /**
  * Manages instances of {@link WebView}
@@ -278,6 +281,19 @@ public class ReactWebViewManager extends SimpleViewManager<WebView> {
     } else {
       view.loadUrl(BLANK_URL);
     }
+  }
+
+  @ReactProp(name = "headers")
+  public void setUrlWithHeaders(WebView view, @Nullable ReadableMap urlWithHeaders) {
+    String url = urlWithHeaders.getString("url");
+    ReadableMap headerMap = urlWithHeaders.getMap("headers");
+    ReadableMapKeySetIterator iter = headerMap.keySetIterator();
+    HashMap<String, String> headers = new HashMap<>();
+    while (iter.hasNextKey()) {
+      String key = iter.nextKey();
+      headers.put(key, headerMap.getString(key));
+    }
+    view.loadUrl(url, headers);
   }
 
   @ReactProp(name = "url")

--- a/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebViewManager.java
@@ -274,35 +274,6 @@ public class ReactWebViewManager extends SimpleViewManager<WebView> {
     ((ReactWebView) view).setInjectedJavaScript(injectedJavaScript);
   }
 
-  @Deprecated
-  @ReactProp(name = "html")
-  public void setHtml(WebView view, @Nullable String html) {
-    if (html != null) {
-      view.loadData(html, HTML_MIME_TYPE, HTML_ENCODING);
-    } else {
-      view.loadUrl(BLANK_URL);
-    }
-  }
-
-  @Deprecated
-  @ReactProp(name = "url")
-  public void setUrl(WebView view, @Nullable String url) {
-    // TODO(8495359): url and html are coupled as they both call loadUrl, therefore in case when
-    // property url is removed in favor of property html being added in single transaction we may
-    // end up in a state when blank url is loaded as it depends on the order of update operations!
-
-    String currentUrl = view.getUrl();
-    if (currentUrl != null && currentUrl.equals(url)) {
-      // We are already loading it so no need to stomp over it and start again
-      return;
-    }
-    if (url != null) {
-      view.loadUrl(url);
-    } else {
-      view.loadUrl(BLANK_URL);
-    }
-  }
-
   @ReactProp(name = "source")
   public void setSource(WebView view, @Nullable ReadableMap source) {
     if (source.hasKey("html")) {


### PR DESCRIPTION
Related to [issue #5418](https://github.com/facebook/react-native/issues/5418)

This is a follow-up to [this previous pull request.](https://github.com/facebook/react-native/pull/5419)

~~Adds a new ReactProp 'urlWithHeaders' to Android WebViews that takes an object with a 'url' string and a 'headers' map.~~

[Update] Adds a new prop 'source' to Android WebViews
```
{
   html: string,
   url: string,
   headers: map<string, string>,
}
```

Update: resolves TODO 8495359