### PR TITLE
Update RCTNavigator.m

### DIFF
--- a/React/Views/RCTNavigator.m
+++ b/React/Views/RCTNavigator.m
@@ -361,6 +361,13 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
       (RCTWrapperViewController *)[context viewControllerForKey:UITransitionContextFromViewControllerKey];
     RCTWrapperViewController *toController =
       (RCTWrapperViewController *)[context viewControllerForKey:UITransitionContextToViewControllerKey];
+      
+    // This may be triggered by a navigation controller unrelated to me: if so, ignore.
+    if (fromController.navigationController != _navigationController ||
+        toController.navigationController != _navigationController) {
+      return;
+    }
+    
     NSUInteger indexOfFrom = [_currentViews indexOfObject:fromController.navItem];
     NSUInteger indexOfTo = [_currentViews indexOfObject:toController.navItem];
     CGFloat destination = indexOfFrom < indexOfTo ? 1.0 : -1.0;


### PR DESCRIPTION
I am using ReactNative in a hybrid App.

We have a setup like so:

Native Navigation Controller
  Native Tab Controller
    Native View Controller wrapping React
      React Navigation Controller
        React View Controller 1
          React View Controller 2
  Native View Controller 2.

When I pop Native View Controller 2 off the Navigation stack, I get a seg fault on this line:

NSUInteger indexOfFrom = [_currentViews indexOfObject:fromController.navItem];

I believe what's happening:
Your code is listening to Nav Controller transitions, assuming that they are all from React Native Nav Controllers.
You are catching this one instead, which is actually a Native Nav Controller transition.
You start trying to access the pushed/popped view controllers as if they were react native view controllers.

In this case, the view controllers are not react native -> no navItem field -> seg fault.

Solution: if we are catching this transition but it isn't from our react native nav controller, just ignore it.

This fixes my problem, things work fine.