### PR TITLE
[packager] breaking test and fix for browser field mapping from package to file

### DIFF
--- a/packager/react-packager/src/DependencyResolver/DependencyGraph/ResolutionRequest.js
+++ b/packager/react-packager/src/DependencyResolver/DependencyGraph/ResolutionRequest.js
@@ -264,20 +264,33 @@ class ResolutionRequest {
     });
   }
 
+  _resolveFileOrDir(fromModule, toModuleName) {
+    const potentialModulePath = isAbsolutePath(toModuleName) ?
+        toModuleName :
+        path.join(path.dirname(fromModule.path), toModuleName);
+
+    return this._redirectRequire(fromModule, potentialModulePath).then(
+      realModuleName => this._tryResolve(
+        () => this._loadAsFile(realModuleName, fromModule, toModuleName),
+        () => this._loadAsDir(realModuleName, fromModule, toModuleName)
+      )
+    );
+  }
+
   _resolveNodeDependency(fromModule, toModuleName) {
     if (toModuleName[0] === '.' || toModuleName[1] === '/') {
-      const potentialModulePath = isAbsolutePath(toModuleName) ?
-              toModuleName :
-              path.join(path.dirname(fromModule.path), toModuleName);
-      return this._redirectRequire(fromModule, potentialModulePath).then(
-        realModuleName => this._tryResolve(
-          () => this._loadAsFile(realModuleName, fromModule, toModuleName),
-          () => this._loadAsDir(realModuleName, fromModule, toModuleName)
-        )
-      );
+      return this._resolveFileOrDir(fromModule, toModuleName)
     } else {
       return this._redirectRequire(fromModule, toModuleName).then(
         realModuleName => {
+          if (realModuleName[0] === '.' || realModuleName[1] === '/') {
+            // derive absolute path /.../node_modules/fromModuleDir/realModuleName
+            let fromModuleParentIdx = fromModule.path.lastIndexOf('node_modules/') + 13
+            let fromModuleDir = fromModule.path.slice(0, fromModule.path.indexOf('/', fromModuleParentIdx))
+            let absPath = path.join(fromModuleDir, realModuleName)
+            return this._resolveFileOrDir(fromModule, absPath)
+          }
+
           const searchQueue = [];
           for (let currDir = path.dirname(fromModule.path);
                currDir !== path.parse(fromModule.path).root;


### PR DESCRIPTION
breaks on mappings like:

```json
"browser": {
  "node-package": "./dir/browser.js"
}
```