### PR TITLE
[Website] Single quotes in enum values

### DIFF
--- a/website/layout/AutodocsLayout.js
+++ b/website/layout/AutodocsLayout.js
@@ -20,12 +20,20 @@ var slugify = require('slugify');
 
 var styleReferencePattern = /^[^.]+\.propTypes\.style$/;
 
+function renderEnumValue(value) {
+  // Use single quote strings even when we are given double quotes
+  if (value.match(/^"(.+)"$/)) {
+    return "'" + value.slice(1, -1) + "'";
+  }
+  return value;
+}
+
 function renderType(type) {
   if (type.name === 'enum') {
     if (typeof type.value === 'string') {
       return type.value;
     }
-    return 'enum(' + type.value.map((v) => v.value).join(', ') + ')';
+    return 'enum(' + type.value.map((v) => renderEnumValue(v.value)).join(', ') + ')';
   }
 
   if (type.name === 'shape') {


### PR DESCRIPTION
This was driving me crazy :p Turns out that if the value is `'auto' /* default */`, then the docparser will not only trim the comment but also normalize the quote to double quote.

This is not pretty but does the job.

Test Plan:
<img width="528" alt="screen shot 2016-01-23 at 8 06 30 pm" src="https://cloud.githubusercontent.com/assets/197597/12534403/e13fb4f6-c20c-11e5-8f26-0c11d5a6ac99.png">


http://localhost:8079/react-native/docs/text.html#content