### PR TITLE
Improve react-native-xcode.sh integration

### DIFF
--- a/local-cli/generator-ios/templates/xcodeproj/project.pbxproj
+++ b/local-cli/generator-ios/templates/xcodeproj/project.pbxproj
@@ -525,7 +525,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "../node_modules/react-native/packager/react-native-xcode.sh";
+			shellScript = "export NODE_BINARY=node\n../node_modules/react-native/packager/react-native-xcode.sh";
 			showEnvVarsInLog = 1;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/packager/react-native-xcode.sh
+++ b/packager/react-native-xcode.sh
@@ -23,11 +23,11 @@ case "$CONFIGURATION" in
     ;;
 esac
 
+# Path to react-native folder inside node_modules
+REACT_NATIVE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
 # Xcode project file for React Native apps is located in ios/ subfolder
 cd ..
-
-set -x
-DEST=$CONFIGURATION_BUILD_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH
 
 # Define NVM_DIR and source the nvm.sh setup script
 [ -z "$NVM_DIR" ] && export NVM_DIR="$HOME/.nvm"
@@ -43,10 +43,25 @@ if [[ -x "$HOME/.nodenv/bin/nodenv" ]]; then
   eval "$($HOME/.nodenv/bin/nodenv init -)"
 fi
 
-# npm global install path may be a non-standard location
-PATH="$(npm prefix -g)/bin:$PATH"
+[ -z "$NODE_BINARY" ] && export NODE_BINARY="node"
 
-react-native bundle \
+nodejs_not_found()
+{
+  echo "error: Can't find '$NODE_BINARY' binary to build React Native bundle" >&2
+  echo "If you have non-standard nodejs installation, select your project in Xcode," >&2
+  echo "find 'Build Phases' - 'Bundle React Native code and images'" >&2
+  echo "and change NODE_BINARY to absolute path to your node executable" >&2
+  echo "(you can find it by invoking 'which node' in the terminal)" >&2
+  exit 2
+}
+
+type $NODE_BINARY >/dev/null 2>&1 || nodejs_not_found
+
+# Print commands before executing them (useful for troubleshooting)
+set -x
+DEST=$CONFIGURATION_BUILD_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH
+
+$NODE_BINARY $REACT_NATIVE_DIR/local-cli/cli.js bundle \
   --entry-file index.ios.js \
   --platform ios \
   --dev $DEV \


### PR DESCRIPTION
Inspired by conversation in https://github.com/facebook/react-native/pull/5374, this PR improves `react-native-xcode.sh`:

* No longer depends on global `react-native` binary
* Gracefully handles missing `node` dependency and adds a new way to configure the path to `node` in non-standard installation environments


This is how the error looks like:
![image](https://cloud.githubusercontent.com/assets/192222/12538882/3f9b5c3e-c29a-11e5-84fc-c7ccedf1c46a.png)
