### PR TITLE
Skip bundling for Simulator

### DIFF
--- a/packager/react-native-xcode.sh
+++ b/packager/react-native-xcode.sh
@@ -10,6 +10,13 @@
 # This script is supposed to be invoked as part of Xcode build process
 # and relies on envoronment variables (including PWD) set by Xcode
 
+# There is no point in creating an offline package for simulator builds
+# because the packager is supposed to be running during development anyways
+if [[ "$PLATFORM_NAME" = "iphonesimulator" ]]; then
+  echo "Skipping bundling for Simulator platform"
+  exit 0;
+fi
+
 case "$CONFIGURATION" in
   Debug)
     DEV=true


### PR DESCRIPTION
Following up on the conversation in https://www.prod.facebook.com/groups/reactnativeoss/permalink/1516993445263951/ I currently don't see any good reason to create an offline bundle for simulator builds.

Test Plan: forced `react-native-cli` to point to my local installation, `react-native init`, Cmd+B in Xcode for iPhone Simulator – script was skipped, Cmd+B for iOS Device – script was executed.