### PR TITLE
[Lint] Allow bitwise operators

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -196,7 +196,7 @@
     "max-len": 0,                    // specify the maximum length of a line in your program (off by default)
     "max-params": 0,                 // limits the number of parameters that can be used in the function declaration. (off by default)
     "max-statements": 0,             // specify the maximum number of statement allowed in a function (off by default)
-    "no-bitwise": 1,                 // disallow use of bitwise operators (off by default)
+    "no-bitwise": 0,                 // disallow use of bitwise operators (off by default)
     "no-plusplus": 0,                // disallow use of unary operators, ++ and -- (off by default)
 
     "react/display-name": 0,


### PR DESCRIPTION
Bitwise operators are reasonable to use in a small number of scenarios.