### PR TITLE
Added openDrawer and closeDrawer methods to DrawerLayoutAndroid docs

### DIFF
--- a/Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.android.js
+++ b/Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.android.js
@@ -108,6 +108,14 @@ var DrawerLayoutAndroid = React.createClass({
      */
     onDrawerStateChanged: ReactPropTypes.func,
     /**
+     * Opens the navigation view.
+     */
+    openDrawer: ReactPropTypes.func,
+    /**
+     * Closes the navigation view.
+     */
+    closeDrawer: ReactPropTypes.func,
+    /**
      * Function called whenever the navigation view has been opened.
      */
     onDrawerOpen: ReactPropTypes.func,


### PR DESCRIPTION
Both methods were missing from the docs.