### PR TITLE
add `error.userInfo` passed in `RCTJSErrorFromCodeMessageAndNSError` for error detail custom message

### DIFF
--- a/React/Base/RCTUtils.m
+++ b/React/Base/RCTUtils.m
@@ -347,7 +347,7 @@ NSDictionary<NSString *, id> *RCTJSErrorFromCodeMessageAndNSError(NSString *code
   if (error) {
     errorMessage = error.localizedDescription ?: @"Unknown error from a native module";
     errorInfo[@"domain"] = error.domain ?: RCTErrorDomain;
-    errorInfo[@"userInfo"] = error.userInfo;
+    errorInfo[@"userInfo"] = RCTNullIfNil(RCTJSONClean(error.userInfo));
   } else {
     errorMessage = @"Unknown error from a native module";
     errorInfo[@"domain"] = RCTErrorDomain;

--- a/React/Base/RCTUtils.m
+++ b/React/Base/RCTUtils.m
@@ -347,6 +347,7 @@ NSDictionary<NSString *, id> *RCTJSErrorFromCodeMessageAndNSError(NSString *code
   if (error) {
     errorMessage = error.localizedDescription ?: @"Unknown error from a native module";
     errorInfo[@"domain"] = error.domain ?: RCTErrorDomain;
+    errorInfo[@"userInfo"] = error.userInfo;
   } else {
     errorMessage = @"Unknown error from a native module";
     errorInfo[@"domain"] = RCTErrorDomain;


### PR DESCRIPTION
Currently through `rejecter:(RCTPromiseRejectBlock)reject` call `reject(error)` where error is initialized like `[NSError errorWithDomain:@"nativeError" code:-9999 userInfo:errorMsg];`, the `errorMsg` is not passed to the JavaScript side, which makes it difficult to figure out error detail. 

This commit pass the `error.userInfo` to `errorInfo`, so that in the reject block of the JavaScript side promise, the error object will contain `userInfo` detail JSON data.