### PR TITLE
Update version number in repo for ecosystem compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native",
-  "version": "0.0.0-master",
+  "version": "1000.0.0",
   "description": "A framework for building native apps using React",
   "license": "BSD-3-Clause",
   "repository": {


### PR DESCRIPTION
In https://github.com/facebook/react-native/pull/5241 @ide updated the version number to be a fake one so that people wouldn't send in PRs just bumping the version.

Unfortunately, this leads to compatibility issues when developing against `master` with 3rd-party components that declare React Native as a `peerDependency`. For example, I'm using [react-native-orientation](https://github.com/yamill/react-native-orientation) which has a peerDependency of `"react-native": ">=0.5"`.

I see a few ways to deal with this:

1. Only develop against the releases on npm, not git snapshots.
2. Ask ecosystem projects to not include a minimum version of `react-native` in their peerDependencies.
3. Track the RN release numbers in the git repository (eg it would be 0.19 right now).
4. Make the release number on master huge (1000 in this PR) so it's obviously a fake number but will still comply with >= checks.

I don't think option 2 is good because it's reasonable for a package author to want to specify a minimum RN version. Option 3 would be fine, although it would take manual effort to keep the version in sync. Option 4 (this PR) is my favorite because it's obvious that the version number is fake, but it maintains ecosystem compatibility.