### PR TITLE
Check for contentView before emitting scroll event

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewHelper.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewHelper.java
@@ -48,6 +48,11 @@ public class ReactScrollViewHelper {
 
   private static void emitScrollEvent(ViewGroup scrollView, ScrollEventType scrollEventType) {
     View contentView = scrollView.getChildAt(0);
+
+    if (contentView == null) {
+      return;
+    }
+
     ReactContext reactContext = (ReactContext) scrollView.getContext();
     reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher().dispatchEvent(
         ScrollEvent.obtain(


### PR DESCRIPTION
I've found that when switching between tabs that each have ScrollViews, sometimes `emitScrollEvent` fires without a `contentView`, which causes the following crash:

```
`D/AndroidRuntime(24496): Shutting down VM
E/AndroidRuntime(24496): FATAL EXCEPTION: main
E/AndroidRuntime(24496): Process: com.listexp, PID: 24496
E/AndroidRuntime(24496): java.lang.NullPointerException: Attempt to invoke virtual method 'int android.view.View.getWidth()' on a null object reference
E/AndroidRuntime(24496):        at com.facebook.react.views.scroll.ReactScrollViewHelper.emitScrollEvent(ReactScrollViewHelper.java:59)
E/AndroidRuntime(24496):        at com.facebook.react.views.scroll.ReactScrollViewHelper.emitScrollMomentumEndEvent(ReactScrollViewHelper.java:46)
E/AndroidRuntime(24496):        at com.facebook.react.views.scroll.ReactScrollView$1.run(ReactScrollView.java:159)
E/AndroidRuntime(24496):        at android.os.Handler.handleCallback(Handler.java:739)
E/AndroidRuntime(24496):        at android.os.Handler.dispatchMessage(Handler.java:95)
E/AndroidRuntime(24496):        at android.os.Looper.loop(Looper.java:135)
E/AndroidRuntime(24496):        at android.app.ActivityThread.main(ActivityThread.java:5254)
E/AndroidRuntime(24496):        at java.lang.reflect.Method.invoke(Native Method)
E/AndroidRuntime(24496):        at java.lang.reflect.Method.invoke(Method.java:372)
E/AndroidRuntime(24496):        at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:903)
E/AndroidRuntime(24496):        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:698)
W/ActivityManager(  747):   Force finishing activity 1 com.listexp/.MainActivity
```

There is probably a better way to resolve this than a null check, but I couldn't figure out exactly why this was happening. I tried `removeCallbacks(null)` in `onDetachedFromWindow()` on `ReactScrollView` to get rid [of this](https://github.com/facebook/react-native/blob/master/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java#L154-L166) but it didn't help. This null check fixes it though :P