### PR TITLE
self -> this in ScrollResponder

### DIFF
--- a/Libraries/Components/ScrollResponder.js
+++ b/Libraries/Components/ScrollResponder.js
@@ -372,7 +372,7 @@ var ScrollResponderMixin = {
    */
   scrollResponderScrollWithoutAnimationTo: function(offsetX: number, offsetY: number) {
     console.warn('`scrollResponderScrollWithoutAnimationTo` is deprecated. Use `scrollResponderScrollTo` instead');
-    self.scrollResponderScrollTo(offsetX, offsetY, false);
+    this.scrollResponderScrollTo(offsetX, offsetY, false);
   },
 
   /**


### PR DESCRIPTION
I *think* this is causing a crash for me in a release build (curiously, not a debug build):
```
ReferenceError: Can't find variable: self
```

I saw this in 0.18.1, which I assume was renamed to v0.19.0-rc.