### PR TITLE
add getter as public api for ErrorUtils._globalHandler

### DIFF
--- a/packager/react-packager/src/Resolver/polyfills/error-guard.js
+++ b/packager/react-packager/src/Resolver/polyfills/error-guard.js
@@ -20,6 +20,9 @@ var ErrorUtils = {
   setGlobalHandler: function(fun) {
     ErrorUtils._globalHandler = fun;
   },
+  getGlobalHandler: function() {
+    return ErrorUtils._globalHandler;
+  },
   reportError: function(error) {
     ErrorUtils._globalHandler && ErrorUtils._globalHandler(error);
   },


### PR DESCRIPTION
As discussed here #1194 . This add an getter the default handler, so that custom handler can be added (monkey patch?) without overwriting the default handler