### PR TITLE
Add magic platform directives to packager

### DIFF
--- a/packager/react-packager/src/JSTransformer/worker.js
+++ b/packager/react-packager/src/JSTransformer/worker.js
@@ -17,12 +17,6 @@ var Transforms = require('../transforms');
 // Javascript code
 function internalTransforms(sourceCode, filename, options) {
   var plugins = resolvePlugins(Transforms.getAll(options));
-  if (plugins.length === 0) {
-    return {
-      code: sourceCode,
-      filename: filename,
-    };
-  }
 
   var result = babel.transform(sourceCode, {
     retainLines: true,

--- a/packager/react-packager/src/transforms/babel-plugin-transform-inline-platform-variables/__tests__/babel-plugin-transform-inline-platform-variables.js
+++ b/packager/react-packager/src/transforms/babel-plugin-transform-inline-platform-variables/__tests__/babel-plugin-transform-inline-platform-variables.js
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2004-present Facebook. All Rights Reserved.
+ *
+ * @emails oncall+jsinfra
+ */
+'use strict';
+
+jest.autoMockOff();
+
+const babel = require('babel-core');
+
+describe('platform directives', () => {
+  function transform(source, platform) {
+    return babel.transform(source, {
+      plugins: [
+        [require('../'), {platform}]
+      ],
+    }).code;
+  }
+
+  it('should transform __ANDROID__', () => {
+    expect(transform('__ANDROID__;', 'ios')).toEqual('false;');
+    expect(transform('__ANDROID__;', 'android')).toEqual('true;');
+    expect(transform('if (__ANDROID__) ;', 'ios')).toEqual('if (false) ;');
+    expect(transform('if (__ANDROID__) ;', 'android')).toEqual('if (true) ;');
+  });
+
+  it('should transform __IOS__', () => {
+    expect(transform('__IOS__;', 'ios')).toEqual('true;');
+    expect(transform('__IOS__;', 'android')).toEqual('false;');
+    expect(transform('if (__IOS__) ;', 'ios')).toEqual('if (true) ;');
+    expect(transform('if (__IOS__) ;', 'android')).toEqual('if (false) ;');
+  });
+});

--- a/packager/react-packager/src/transforms/babel-plugin-transform-inline-platform-variables/index.js
+++ b/packager/react-packager/src/transforms/babel-plugin-transform-inline-platform-variables/index.js
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+'use strict';
+
+// Return the list of plugins use for Whole Program Optimisations
+module.exports = require('./inline-platform-variables');

--- a/packager/react-packager/src/transforms/babel-plugin-transform-inline-platform-variables/inline-platform-variables.js
+++ b/packager/react-packager/src/transforms/babel-plugin-transform-inline-platform-variables/inline-platform-variables.js
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+'use strict';
+
+const t = require('babel-types');
+
+module.exports = function () {
+  return {
+    visitor: {
+      ReferencedIdentifier(path) {
+        let platform = this.opts.platform;
+        let name = path.node.name;
+        let is = false;
+
+        if (name === "__ANDROID") {
+          is = platform === "android";
+        } else if (name === "__IOS") {
+          is = platform === "ios";
+        } else {
+          return;
+        }
+
+        path.replaceWith(t.booleanLiteral(is));
+      }
+    }
+  };
+};

--- a/packager/react-packager/src/transforms/index.js
+++ b/packager/react-packager/src/transforms/index.js
@@ -8,6 +8,8 @@
  */
 'use strict';
 
+const inlinePlatformVariablesPlugin = require('./babel-plugin-transform-inline-platform-variables');
+
 exports.getAll = function(options) {
   var plugins = [];
   if (options.hot) {
@@ -26,8 +28,11 @@ exports.getAll = function(options) {
       'transform-es2015-constants',
       ['transform-es2015-modules-commonjs', {strict: false, allowTopLevelThis: true}],
     ]);
+  } else {
+    plugins = plugins.concat([
+      [inlinePlatformVariablePlugins, {platform: options.platform}]
+    ]);
   }
 
   return plugins;
 };
-


### PR DESCRIPTION
This adds the variables `__ANDROID__` and `__IOS__` that can be referred to in code and are transformed away in the packager. This allows the colocation of platform specific conditions within the same file which we should encourage over the use of separate files which increases repetition.

This is currently a required transform. One improvement would be to only run this transform when doing production builds and include the variables as globals in development. It wasn't clear to me how to do this but if someone can point me in the right direction to do that I'm more than happy to make changes.

Also I'm not sure if this is a controversial change but @sebmarkbage basically dared me to do it.