### PR TITLE
Navigator: emit didFocus after routeStack reset

### DIFF
--- a/Libraries/CustomComponents/Navigator/Navigator.js
+++ b/Libraries/CustomComponents/Navigator/Navigator.js
@@ -376,6 +376,7 @@ var Navigator = React.createClass({
     }, () => {
       this._handleSpringUpdate();
       this._navBar && this._navBar.immediatelyRefresh();
+      this._emitDidFocus(this.state.routeStack[this.state.presentedIndex]);
     });
   },
 


### PR DESCRIPTION
Hi,

I am using https://github.com/aksonov/react-native-router-flux / https://github.com/exponentjs/ex-navigator and I needed a way to update my redux store with the current route.

I'm using the navigation context to do this:

```javascript
if (navigationContext) {
  const handler = () => {
    updateCurrentRouteState(navigationContext.currentRoute);
  };
  navigationContext.addListener('willfocus', handler);
  navigationContext.addListener('didfocus', handler);
}
```

However, when the whole stack is replaced, no event is emitted. This PR aims to fix that.