### PR TITLE
Added a `root` option to the `run-android` command

### DIFF
--- a/local-cli/runAndroid/runAndroid.js
+++ b/local-cli/runAndroid/runAndroid.js
@@ -33,7 +33,7 @@ function _runAndroid(argv, config, resolve, reject) {
   }, {
     command: 'root',
     type: 'string',
-    description: 'Override the root directory to be used to start the packager',
+    description: 'Override the root directory for the android build (which contains the android directory)',
   }], argv);
 
   args.root = args.root || '';

--- a/local-cli/runAndroid/runAndroid.js
+++ b/local-cli/runAndroid/runAndroid.js
@@ -33,7 +33,7 @@ function _runAndroid(argv, config, resolve, reject) {
   }, {
     command: 'root',
     type: 'string',
-    description: 'override the root to be used to run the android packaging',
+    description: 'Override the root directory to be used to start the packager',
   }], argv);
 
   args.root = args.root || '';

--- a/local-cli/runAndroid/runAndroid.js
+++ b/local-cli/runAndroid/runAndroid.js
@@ -30,9 +30,15 @@ function _runAndroid(argv, config, resolve, reject) {
     command: 'install-debug',
     type: 'string',
     required: false,
+  }, {
+    command: 'root',
+    type: 'string',
+    description: 'override the root to be used to run the android packaging',
   }], argv);
 
-  if (!checkAndroid()) {
+  args.root = args.root || '';
+
+  if (!checkAndroid(args)) {
     console.log(chalk.red('Android project not found. Maybe run react-native android first?'));
     return;
   }
@@ -52,13 +58,13 @@ function _runAndroid(argv, config, resolve, reject) {
 }
 
 // Verifies this is an Android project
-function checkAndroid() {
-  return fs.existsSync('android/gradlew');
+function checkAndroid(args) {
+  return fs.existsSync(path.join(args.root, 'android/gradlew'));
 }
 
 // Builds the app and runs it on a connected emulator / device.
 function buildAndRun(args, reject) {
-  process.chdir('android');
+  process.chdir(path.join(args.root, 'android'));
   try {
     const cmd = process.platform.startsWith('win')
       ? 'gradlew.bat'


### PR DESCRIPTION
Added a `root` option to the `run-android` command allowing to run it from a parent directory.

Use case: project is organized like this
```
- api
- apps
---- web
---- react-native
- package.json
```
You can use the root option on `react-native start` but not on `run-android`. This pr fixes that.