### PR TITLE
Fixing typo in Bundler

### DIFF
--- a/packager/react-packager/src/Bundler/index.js
+++ b/packager/react-packager/src/Bundler/index.js
@@ -258,7 +258,7 @@ class Bundler {
           : [];
 
         const modulesToProcess = modules || response.dependencies;
-        const dependencies = moduleSystemDeps.concat(modulesToProcess);
+        dependencies = moduleSystemDeps.concat(modulesToProcess);
 
         bundle.setNumPrependedModules && bundle.setNumPrependedModules(
           response.numPrependedDependencies + moduleSystemDeps.length


### PR DESCRIPTION
With an upgraded Babel dependency, failing tests correctly found this typo.

It does not currently cause a test failure in the current version of master, however,
which is concerning. I found it when testing #5214.

cc @martinbigio just because it was your code :)