### PR TITLE
Allow subclassing ListViewDataSource

### DIFF
--- a/Libraries/CustomComponents/ListView/ListViewDataSource.js
+++ b/Libraries/CustomComponents/ListView/ListViewDataSource.js
@@ -186,7 +186,7 @@ class ListViewDataSource {
       typeof this._sectionHeaderHasChanged === 'function',
       'Must provide a sectionHeaderHasChanged function with section data.'
     );
-    var newSource = new ListViewDataSource({
+    var newSource = new this.constructor({
       getRowData: this._getRowData,
       getSectionHeaderData: this._getSectionHeaderData,
       rowHasChanged: this._rowHasChanged,


### PR DESCRIPTION
I use immutable JS throughout my codebase and created an Immutable ListViewDataSource by subclassing ListViewDataSource. Currently cloneWithRowsAndSections creates a new instance of ListViewDataSource instead of cloning my subclass.

This pull request changes the hard coded ListViewDataSource to this.constructor.

https://www.npmjs.com/package/react-native-immutable-listview-datasource