### PR TITLE
More helpful description for native-js prop mismatch

### DIFF
--- a/Libraries/ReactIOS/verifyPropTypes.js
+++ b/Libraries/ReactIOS/verifyPropTypes.js
@@ -50,6 +50,9 @@ function verifyPropTypes(
         viewConfig.uiViewClassName + '.' + prop + '` of native type `' +
         nativeProps[prop] + '`';
       };
+      message += '\nIf you haven\'t changed this prop yourself, this usually means that ' +
+        'your versions of the native code and JavaScript code are out of sync. Updating both ' +
+        'should make this error go away.';
       throw new Error(message);
     }
   }


### PR DESCRIPTION
A lot of people see this error and end up posting in our support group. The root cause is that their js and native versions are out of sync. Adding a helpful description here will unblock them on their own.