### PR TITLE
Add onBatchStarted callback to "BatchCompleteListener".

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/CatalystInstanceImpl.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/CatalystInstanceImpl.java
@@ -10,6 +10,7 @@
 package com.facebook.react.bridge;
 
 import javax.annotation.Nullable;
+import javax.annotation.OverridingMethodsMustInvokeSuper;
 
 import java.io.IOException;
 import java.io.StringWriter;
@@ -446,6 +447,15 @@ public class CatalystInstanceImpl implements CatalystInstance {
       }
 
       decrementPendingJSCalls();
+    }
+
+    @Override
+    public void onBatchStarted() {
+      mReactQueueConfiguration.getNativeModulesQueueThread().assertIsOnThread();
+
+      if (!mDestroyed) {
+        mJavaRegistry.onBatchStarted();
+      }
     }
   }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/JSBatchListener.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/JSBatchListener.java
@@ -10,9 +10,9 @@
 package com.facebook.react.bridge;
 
 /**
- * Interface for a module that will be notified when a batch of JS->Java calls has finished.
+ * Interface for a module that will be notified when a batch of JS->Java calls starts or finishes.
  */
-public interface OnBatchCompleteListener {
-
+public interface JSBatchListener {
+  void onBatchStarted();
   void onBatchComplete();
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/NativeModuleRegistry.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/NativeModuleRegistry.java
@@ -29,7 +29,7 @@ public class NativeModuleRegistry {
 
   private final List<ModuleDefinition> mModuleTable;
   private final Map<Class<? extends NativeModule>, NativeModule> mModuleInstances;
-  private final ArrayList<OnBatchCompleteListener> mBatchCompleteListenerModules;
+  private final ArrayList<JSBatchListener> mJSBatchCompleteListeners;
 
   private NativeModuleRegistry(
       List<ModuleDefinition> moduleTable,
@@ -37,11 +37,11 @@ public class NativeModuleRegistry {
     mModuleTable = moduleTable;
     mModuleInstances = moduleInstances;
 
-    mBatchCompleteListenerModules = new ArrayList<OnBatchCompleteListener>(mModuleTable.size());
+    mJSBatchCompleteListeners = new ArrayList<>(mModuleTable.size());
     for (int i = 0; i < mModuleTable.size(); i++) {
       ModuleDefinition definition = mModuleTable.get(i);
-      if (definition.target instanceof OnBatchCompleteListener) {
-        mBatchCompleteListenerModules.add((OnBatchCompleteListener) definition.target);
+      if (definition.target instanceof JSBatchListener) {
+        mJSBatchCompleteListeners.add((JSBatchListener) definition.target);
       }
     }
   }
@@ -115,8 +115,14 @@ public class NativeModuleRegistry {
   }
 
   public void onBatchComplete() {
-    for (int i = 0; i < mBatchCompleteListenerModules.size(); i++) {
-      mBatchCompleteListenerModules.get(i).onBatchComplete();
+    for (int i = 0; i < mJSBatchCompleteListeners.size(); i++) {
+      mJSBatchCompleteListeners.get(i).onBatchComplete();
+    }
+  }
+
+  public void onBatchStarted() {
+    for (int i = 0; i < mJSBatchCompleteListeners.size(); i++) {
+      mJSBatchCompleteListeners.get(i).onBatchStarted();
     }
   }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactCallback.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactCallback.java
@@ -19,4 +19,7 @@ public interface ReactCallback {
 
   @DoNotStrip
   void onBatchComplete();
+
+  @DoNotStrip
+  void onBatchStarted();
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModule.java
@@ -11,25 +11,20 @@ package com.facebook.react.uimanager;
 
 import javax.annotation.Nullable;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
 import android.util.DisplayMetrics;
 
-import com.facebook.csslayout.CSSLayoutContext;
-import com.facebook.infer.annotation.Assertions;
 import com.facebook.react.animation.Animation;
-import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.LifecycleEventListener;
-import com.facebook.react.bridge.OnBatchCompleteListener;
+import com.facebook.react.bridge.JSBatchListener;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
-import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.uimanager.debug.NotThreadSafeViewHierarchyUpdateDebugListener;
 import com.facebook.react.uimanager.events.EventDispatcher;
 import com.facebook.systrace.Systrace;
@@ -65,7 +60,7 @@ import com.facebook.systrace.SystraceMessage;
  * TODO(5483063): Don't dispatch the view hierarchy at the end of a batch if no UI changes occurred
  */
 public class UIManagerModule extends ReactContextBaseJavaModule implements
-    OnBatchCompleteListener, LifecycleEventListener {
+    JSBatchListener, LifecycleEventListener {
 
   // Keep in sync with ReactIOSTagHandles JS module - see that file for an explanation on why the
   // increment here is 10
@@ -408,6 +403,11 @@ public class UIManagerModule extends ReactContextBaseJavaModule implements
       Callback success,
       Callback error) {
     mUIImplementation.configureNextLayoutAnimation(config, success, error);
+  }
+
+  @Override
+  public void onBatchStarted() {
+    // no-op
   }
 
   /**

--- a/ReactAndroid/src/main/jni/react/Bridge.h
+++ b/ReactAndroid/src/main/jni/react/Bridge.h
@@ -24,7 +24,7 @@ namespace react {
 
 class Bridge : public Countable {
 public:
-  typedef std::function<void(std::vector<MethodCall>, bool isEndOfBatch)> Callback;
+  typedef std::function<void(std::vector<MethodCall>, bool isStartOfBatch, bool isEndOfBatch)> Callback;
 
   Bridge(const RefPtr<JSExecutorFactory>& jsExecutorFactory, Callback callback);
   virtual ~Bridge();
@@ -66,12 +66,14 @@ public:
   void handleMemoryPressureModerate();
   void handleMemoryPressureCritical();
 private:
+  void callback(std::vector<MethodCall> calls, bool isEndOfBatch);
   Callback m_callback;
   // This is used to avoid a race condition where a proxyCallback gets queued after ~Bridge(),
   // on the same thread. In that case, the callback will try to run the task on m_callback which
   // will have been destroyed within ~Bridge(), thus causing a SIGSEGV.
   std::shared_ptr<bool> m_destroyed;
   std::unique_ptr<JSExecutor> m_jsExecutor;
+  bool m_hasNotifyBatchStart;
 };
 
 } }


### PR DESCRIPTION
This change adds a way for native modules to receive "batchStarted" event (I've actually renamed OnBatchCompleteListener to JSBatchListener so that the name does no longer suggest it can be used only for getting "batchComplete" events).

I think this callback will be important for implementing features that may want to interact with native modules from inside of the native code and will allow to isolate modifications of UI that are done by JS from the ones that can be driven by purely native code. A good example would be driving animations from native code. In that case we'd like for the animation code to be able to update view properties (such as transforms) but also props that affect shadow view hierarchy (layout-related props). Since changes made to layout props have to go though the regular prop update pipeline (update shadow view -> calculate layout on batch complete -> update values in UI thread) the best way IMO is to "trigger" onBatchComplete when animation frame is requested and let UIManager start all the view updating logic. The issue is with other updates that might be coming from JS at the same time. SO the solution is to detect if JS is in a process of sending native commands and wait until the process is finished - that's where this new callback I'm adding will help a lot.

Test plan:
Add boolean "batchState" variable in UImanagerModule. Update it to tru in #onBatchStarted and to false in #onBatchComplete. Add asserts in #onBatchComplete for "batchState" to be true when entering the method -> play with some apps, test reload, asserts should always be passing