### PR TITLE
Restore canvas once group has been drawn

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/art/ARTGroupShadowNode.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/art/ARTGroupShadowNode.java
@@ -32,6 +32,8 @@ public class ARTGroupShadowNode extends ARTVirtualNode {
         child.draw(canvas, paint, opacity);
         child.markUpdateSeen();
       }
+
+      restoreCanvas(canvas);
     }
   }
 }


### PR DESCRIPTION
The implementation of ARTGroupShadowNode saved the canvas and then drew the child nodes but did not reset the canvas afterwards, unlike the behaviour of the other ART shadow nodes.  Because of this the matrix operations were compounded for sibling nodes in the surface.

As an example the following code should draw a green circle in the bottom right corner of the surface and a red circle in the top left, which it does on iOS; on Android you'll find that the red circle is drawn in the bottom right corner instead.

```
'use strict';
import React, {
  AppRegistry,
  Component,
  StyleSheet,
  View,
} from 'react-native';

const { Surface, Group, Shape } = React.ART;

const styles = StyleSheet.create({
  container: {
    flex: 1,
    justifyContent: 'center',
    alignItems: 'center',
    backgroundColor: '#808080',
  },
  surface: {
    backgroundColor: '#ffffff'
  },
});

class ARTGroupBug extends Component {
  render() {
    return (
      <View style={styles.container}>
        <Surface style={styles.surface} width={64} height={64}>
          <Group>
            <Group x={32} y={32}>
              <Shape d="M16 .004 c-8.837 0 -16 7.164 -16 16 0 8.837 7.163 16 16 16 s16 -7.163 16 -16 c0 -8.836 -7.163 -16 -16 -16 z m0 29 c-7.16 0 -12.985 -5.832 -12.985 -13 s5.825 -13 12.985 -13 c7.16 0 12.985 5.832 12.985 13 s-5.825 13 -12.985 13 z" fill="#00ff00"/>
            </Group>

            <Group x={0} y={0}>
              <Shape d="M16 .004 c-8.837 0 -16 7.163 -16 16 s7.163 16 16 16 16 -7.163 16 -16 -7.163 -16 -16 -16 z m0 29 c-7.16 0 -12.985 -5.832 -12.985 -13 s5.825 -13 12.985 -13 c7.16 0 12.985 5.832 12.985 13 s-5.825 13 -12.985 13 z" fill="#ff0000"/>
            </Group>
          </Group>
        </Surface>
      </View>
    );
  }
}

AppRegistry.registerComponent('ARTGroupBug', () => ARTGroupBug);
```