### PR TITLE
Document Linking

### DIFF
--- a/website/server/extractDocs.js
+++ b/website/server/extractDocs.js
@@ -236,6 +236,7 @@ var apis = [
   '../Libraries/Components/Intent/IntentAndroid.android.js',
   '../Libraries/Interaction/InteractionManager.js',
   '../Libraries/LayoutAnimation/LayoutAnimation.js',
+  '../Libraries/Linking/Linking.js',
   '../Libraries/LinkingIOS/LinkingIOS.js',
   '../Libraries/ReactIOS/NativeMethodsMixin.js',
   '../Libraries/Network/NetInfo.js',


### PR DESCRIPTION
Both LinkingIOS and IntentAndroid are deprecated in favor of Linking but it was not in the website documentation.