### PR TITLE
Handle spaces in $REACT_NATIVE_DIR

### DIFF
--- a/packager/react-native-xcode.sh
+++ b/packager/react-native-xcode.sh
@@ -68,7 +68,7 @@ type $NODE_BINARY >/dev/null 2>&1 || nodejs_not_found
 set -x
 DEST=$CONFIGURATION_BUILD_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH
 
-$NODE_BINARY $REACT_NATIVE_DIR/local-cli/cli.js bundle \
+$NODE_BINARY "$REACT_NATIVE_DIR/local-cli/cli.js" bundle \
   --entry-file index.ios.js \
   --platform ios \
   --dev $DEV \


### PR DESCRIPTION
`react-native-xcode.sh` can fail to execute if `$REACT_NATIVE_DIR` contains spaces.

E.g. if `$REACT_NATIVE_DIR` was `/Users/samn/src/Xcode Projects/AwesomeReact` then `react-native-xcode.sh` would fail with the following error:

```
node /Users/samn/src/Xcode Projects/ReactNativeBeaconTest/node_modules/react-native/local-cli/cli.js bundle .... (elided)

module.js:341
    throw err;
    ^

Error: Cannot find module '/Users/samn/src/Xcode'
    at Function.Module._resolveFilename (module.js:339:15)
    at Function.Module._load (module.js:290:25)
    at Function.Module.runMain (module.js:447:10)
    at startup (node.js:139:18)
    at node.js:999:3
Command /bin/sh failed with exit code 1
```

This change properly handles paths with spaces in them by quoting `$REACT_NATIVE_DIR`