### PR TITLE
Temporarily allow decimals on rgb() and rgba()

### DIFF
--- a/Libraries/StyleSheet/__tests__/normalizeColor-test.js
+++ b/Libraries/StyleSheet/__tests__/normalizeColor-test.js
@@ -25,6 +25,11 @@ describe('normalizeColor', function() {
     expect(normalizeColor('rgba(0, 0, 0, 1)')).not.toBe(null);
   });
 
+  it('should temporarly accept floating point values for rgb', function() {
+    expect(normalizeColor('rgb(1.1, 2.1, 3.1)')).toBe(0xff010203);
+    expect(normalizeColor('rgba(1.1, 2.1, 3.1, 1.0)')).toBe(0xff010203);
+  });
+
   it('should refuse non spec compliant colors', function() {
     expect(normalizeColor('#00gg00')).toBe(null);
     expect(normalizeColor('rgb(1, 2, 3,)')).toBe(null);
@@ -40,7 +45,6 @@ describe('normalizeColor', function() {
     expect(normalizeColor('hsv(0, 1, 2)')).toBe(null);
     expect(normalizeColor({r: 10, g: 10, b: 10})).toBe(null);
     expect(normalizeColor('hsl(1%, 2, 3)')).toBe(null);
-    expect(normalizeColor('rgb(1.0, 2.0, 3.0)')).toBe(null);
     expect(normalizeColor('rgb(1%, 2%, 3%)')).toBe(null);
   });
 

--- a/Libraries/StyleSheet/normalizeColor.js
+++ b/Libraries/StyleSheet/normalizeColor.js
@@ -131,7 +131,7 @@ function hslToRgb(h: number, s: number, l: number): number {
   );
 }
 
-var INTEGER = '[-+]?\\d+';
+// var INTEGER = '[-+]?\\d+';
 var NUMBER = '[-+]?\\d*\\.?\\d+';
 var PERCENTAGE = NUMBER + '%';
 
@@ -140,8 +140,8 @@ function call(...args) {
 }
 
 var matchers = {
-  rgb: new RegExp('rgb' + call(INTEGER, INTEGER, INTEGER)),
-  rgba: new RegExp('rgba' + call(INTEGER, INTEGER, INTEGER, NUMBER)),
+  rgb: new RegExp('rgb' + call(NUMBER, NUMBER, NUMBER)),
+  rgba: new RegExp('rgba' + call(NUMBER, NUMBER, NUMBER, NUMBER)),
   hsl: new RegExp('hsl' + call(NUMBER, PERCENTAGE, PERCENTAGE)),
   hsla: new RegExp('hsla' + call(NUMBER, PERCENTAGE, PERCENTAGE, NUMBER)),
   hex3: /^#([0-9a-fA-F]{1})([0-9a-fA-F]{1})([0-9a-fA-F]{1})$/,


### PR DESCRIPTION
Animating colors using Animated is currently interpolating rgb and rgba and doesn't round the intermediate values. We need to fix it there but it's not a straightforward change so reverting to the lax version here until we fix it inside of Animated (which is needed to work on web anyway).