### PR TITLE
add the ability to run-android w/o starting dev server

### DIFF
--- a/local-cli/runAndroid/runAndroid.js
+++ b/local-cli/runAndroid/runAndroid.js
@@ -42,6 +42,8 @@ function _runAndroid(argv, config, resolve, reject) {
       console.log(chalk.bold('JS server already running.'));
     } else if (result === 'unrecognized') {
       console.warn(chalk.yellow('JS server not recognized, continuing with build...'));
+    } else if (argv.includes('--no-server')) {
+      console.warn(chalk.bold('--no-server argument is specified. JS server will not start.'));
     } else {
       // result == 'not_running'
       console.log(chalk.bold('Starting JS server...'));


### PR DESCRIPTION
developers can append  `--no-server` argument to `react-native run-android`, and stop development server from spawning