### PR TITLE
Fix import of LinkingIOS on Android

### DIFF
--- a/Libraries/LinkingIOS/LinkingIOS.js
+++ b/Libraries/LinkingIOS/LinkingIOS.js
@@ -15,7 +15,7 @@ var Linking = require('Linking');
 var RCTLinkingManager = require('NativeModules').LinkingManager;
 var invariant = require('invariant');
 
-var _initialURL = RCTLinkingManager.initialURL;
+var _initialURL = RCTLinkingManager && RCTLinkingManager.initialURL;
 
 /**
  * NOTE: `LinkingIOS` is being deprecated. Use `Linking` instead.


### PR DESCRIPTION
We need to check the existence of RCTLinkingManager (which doesn't exist on Android) because this code is called on require.