### PR TITLE
Fix a crash when logging a JS exception that has no source file

### DIFF
--- a/ReactAndroid/src/main/jni/react/JSCHelpers.cpp
+++ b/ReactAndroid/src/main/jni/react/JSCHelpers.cpp
@@ -56,7 +56,7 @@ JSValueRef evaluateScript(JSContextRef context, JSStringRef script, JSStringRef 
     auto line = exception.asObject().getProperty("line");
 
     std::ostringstream locationInfo;
-    std::string file = String::adopt(source).str();
+    std::string file = source != nullptr ? String::adopt(source).str() : "";
     locationInfo << "(" << (file.length() ? file : "<unknown file>");
     if (line != nullptr && line.isNumber()) {
       locationInfo << ":" << line.asInteger();


### PR DESCRIPTION
This error occurs primarily when starting the app and the packager is not running.

`source` can be null when the evaluated code does not come from a source file so it just crashes with a SIGSEGV when passing it to `String::adopt`. This restores the beloved 'Can't find variable __fbBatchedBridge' redbox error :)

Seems to be introduced in 17e1ceb5437049f794b74507feb6856e3450d2b2.

cc @davidaurelio