### PR TITLE
Fix bug related to removeClippedSubviews and view collapsing.

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.java
@@ -147,6 +147,14 @@ public class ReactHorizontalScrollView extends HorizontalScrollView implements
   }
 
   @Override
+  protected void onAttachedToWindow() {
+    super.onAttachedToWindow();
+    if (mRemoveClippedSubviews) {
+      updateClippingRect();
+    }
+  }
+
+  @Override
   public void updateClippingRect() {
     if (!mRemoveClippedSubviews) {
       return;

--- a/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
@@ -73,6 +73,14 @@ public class ReactScrollView extends ScrollView implements ReactClippingViewGrou
   }
 
   @Override
+  protected void onAttachedToWindow() {
+    super.onAttachedToWindow();
+    if (mRemoveClippedSubviews) {
+      updateClippingRect();
+    }
+  }
+
+  @Override
   protected void onScrollChanged(int x, int y, int oldX, int oldY) {
     super.onScrollChanged(x, y, oldX, oldY);
 

--- a/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
@@ -353,7 +353,17 @@ public class ReactViewGroup extends ViewGroup implements
   @Override
   protected void onSizeChanged(int w, int h, int oldw, int oldh) {
     super.onSizeChanged(w, h, oldw, oldh);
-    updateClippingRect();
+    if (mRemoveClippedSubviews) {
+      updateClippingRect();
+    }
+  }
+
+  @Override
+  protected void onAttachedToWindow() {
+    super.onAttachedToWindow();
+    if (mRemoveClippedSubviews) {
+      updateClippingRect();
+    }
   }
 
   @Override


### PR DESCRIPTION
The bug occurs for the cases when there is a nested view structure of at least two views with removeClippedSubvews enabled and with a "collapsable" view in between them that migrates from the collapsed state to non-collapsed state.

What happens in that case is that the "inner" view with "removeClippsedSubviews" gets reattached to a new parent, but we never update it's clipping rect because the update is currently only triggered for the size change (and for scroll change in case of scrollview). In the case when the view was doing some "clipping" when attached to its previous parent it needs to update its "clipping" status because the parent has change and clipping rect is calculated based on the parent clipping rect (see `ReactClippingViewGroupHelper#calculateClippingRect`).

This change triggers `updateClippingRect` when the view is attached to the window, which covers the case when it's reattached from one parent to the other.

Test plan:
Here is a simple app that illustrates the issue: https://gist.github.com/kmagiera/f2af6d6b9217fcacfea6
Without this change the "black" square won't be visible after tapping "yellow" button twice
Although it will appear when we turn off "clipping" or "collapsing":
`REMOVE_CLIPPED=false` or `REMOVE_CLIPPED=true`