### PR TITLE
Update fbjs version

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "connect": "^2.8.3",
     "debug": "^2.2.0",
     "event-target-shim": "^1.0.5",
-    "fbjs": "^0.6.0",
+    "fbjs": "^0.7.0",
     "fbjs-scripts": "^0.4.0",
     "graceful-fs": "^4.1.2",
     "image-size": "^0.3.5",


### PR DESCRIPTION
`react-relay` requires fbjs@0.7 to be installed, otherwise a naming collision happens:
```bash
Error: Naming collision detected: /some/path/node_modules/fbjs/package.json collides with > /some/path/node_modules/react-relay/node_modules/fbjs/package.json
```