### PR TITLE
Conditionally allowing showCompass view property

### DIFF
--- a/React/Views/RCTMap.m
+++ b/React/Views/RCTMap.m
@@ -209,4 +209,17 @@ const CGFloat RCTMapZoomBoundBuffer = 0.01;
   self.overlayIDs = newOverlayIDs;
 }
 
+- (BOOL)showsCompass {
+  if ([MKMapView instancesRespondToSelector:@selector(showsCompass)]) {
+    return super. showsCompass;
+  }
+  return NO;
+}
+
+- (void)setShowsCompass:(BOOL)showsCompass {
+  if ([MKMapView instancesRespondToSelector:@selector(setShowsCompass:)]) {
+    super.showsCompass = showsCompass;
+  }
+}
+
 @end


### PR DESCRIPTION
Only allow the showsCompass view property when iOS 9+ is used.  Fixes #5706.