### PR TITLE
[ListView] render empty section headers

### DIFF
--- a/Libraries/CustomComponents/ListView/ListViewDataSource.js
+++ b/Libraries/CustomComponents/ListView/ListViewDataSource.js
@@ -186,6 +186,11 @@ class ListViewDataSource {
       typeof this._sectionHeaderHasChanged === 'function',
       'Must provide a sectionHeaderHasChanged function with section data.'
     );
+    invariant(
+      !sectionIdentities || !rowIdentities || sectionIdentities.length === rowIdentities.length,
+      'row and section ids lengths must be the same'
+    );
+
     var newSource = new ListViewDataSource({
       getRowData: this._getRowData,
       getSectionHeaderData: this._getSectionHeaderData,
@@ -219,6 +224,10 @@ class ListViewDataSource {
 
   getRowCount(): number {
     return this._cachedRowCount;
+  }
+
+  getRowAndSectionCount(): number {
+   return (this._cachedRowCount + this.sectionIdentities.length);
   }
 
   /**


### PR DESCRIPTION
Changed behavior so that empty section headers are rendered, fixes this [issue](https://github.com/facebook/react-native/issues/5639).