### PR TITLE
[Android] Enable HMR

### DIFF
--- a/Libraries/Utilities/HMRClient.js
+++ b/Libraries/Utilities/HMRClient.js
@@ -10,6 +10,7 @@
  */
 'use strict';
 
+const Platform = require('Platform');
 const invariant = require('invariant');
 const processColor = require('processColor');
 
@@ -50,7 +51,13 @@ Error: ${e.message}`
       );
     };
     activeWS.onmessage = ({data}) => {
-      const DevLoadingView = require('NativeModules').DevLoadingView;
+      let DevLoadingView = require('NativeModules').DevLoadingView;
+      if (!DevLoadingView) {
+        DevLoadingView = {
+          showMessage() {},
+          hide() {},
+        };
+      }
       data = JSON.parse(data);
 
       switch(data.type) {
@@ -67,8 +74,13 @@ Error: ${e.message}`
           const sourceMappingURLs = data.body.sourceMappingURLs;
           const sourceURLs = data.body.sourceURLs;
 
-          const RCTRedBox = require('NativeModules').RedBox;
-          RCTRedBox && RCTRedBox.dismiss && RCTRedBox.dismiss();
+          if (Platform.OS === 'ios') {
+            const RCTRedBox = require('NativeModules').RedBox;
+            RCTRedBox && RCTRedBox.dismiss && RCTRedBox.dismiss();
+          } else {
+            const RCTExceptionsManager = require('NativeModules').ExceptionsManager;
+            RCTExceptionsManager && RCTExceptionsManager.dismissRedbox && RCTExceptionsManager.dismissRedbox();
+          }
 
           modules.forEach((code, i) => {
             code = code + '\n\n' + sourceMappingURLs[i];

--- a/Libraries/Utilities/HMRClient.js
+++ b/Libraries/Utilities/HMRClient.js
@@ -94,8 +94,8 @@ Error: ${e.message}`
             // on JSC we need to inject from native for sourcemaps to work
             // (Safari doesn't support `sourceMappingURL` nor any variant when
             // evaluating code) but on Chrome we can simply use eval
-            const injectFunction = typeof __injectHMRUpdate === 'function'
-              ? __injectHMRUpdate
+            const injectFunction = typeof global.nativeInjectHMRUpdate === 'function'
+              ? global.nativeInjectHMRUpdate
               : eval;
 
             injectFunction(code, sourceURLs[i]);

--- a/React/Base/RCTBatchedBridge.m
+++ b/React/Base/RCTBatchedBridge.m
@@ -456,7 +456,9 @@ RCT_EXTERN NSArray<Class> *RCTGetModuleClasses(void);
 
   if (RCTGetURLQueryParam(self.bundleURL, @"hot")) {
     NSString *path = [self.bundleURL.path substringFromIndex:1]; // strip initial slash
-    [self enqueueJSCall:@"HMRClient.enable" args:@[@"ios", path]];
+    NSString *host = self.bundleURL.host;
+    NSNumber *port = self.bundleURL.port;
+    [self enqueueJSCall:@"HMRClient.enable" args:@[@"ios", path, host, RCTNullIfNil(port)]];
   }
 
 #endif

--- a/React/Executors/RCTJSCExecutor.m
+++ b/React/Executors/RCTJSCExecutor.m
@@ -329,7 +329,7 @@ static void RCTInstallJSCProfiler(RCTBridge *bridge, JSContextRef context)
   [self addSynchronousHookWithName:@"nativeInjectHMRUpdate" usingBlock:^(NSString *sourceCode, NSString *sourceCodeURL) {
     RCTJSCExecutor *strongSelf = weakSelf;
     if (!strongSelf.valid) {
-      return nil;
+      return;
     }
 
     JSStringRef execJSString = JSStringCreateWithUTF8CString(sourceCode.UTF8String);

--- a/React/Executors/RCTJSCExecutor.m
+++ b/React/Executors/RCTJSCExecutor.m
@@ -324,6 +324,20 @@ static void RCTInstallJSCProfiler(RCTBridge *bridge, JSContextRef context)
                                                  name:event
                                                object:nil];
   }
+
+  // Inject handler used by HMR
+  [self addSynchronousHookWithName:@"nativeInjectHMRUpdate" usingBlock:^(NSString *sourceCode, NSString *sourceCodeURL) {
+    RCTJSCExecutor *strongSelf = weakSelf;
+    if (!strongSelf.valid) {
+      return nil;
+    }
+
+    JSStringRef execJSString = JSStringCreateWithUTF8CString(sourceCode.UTF8String);
+    JSStringRef jsURL = JSStringCreateWithUTF8CString(sourceCodeURL.UTF8String);
+    JSEvaluateScript(strongSelf->_context.ctx, execJSString, NULL, jsURL, 0, NULL);
+    JSStringRelease(jsURL);
+    JSStringRelease(execJSString);
+  }];
 #endif
 }
 
@@ -496,21 +510,6 @@ static void RCTInstallJSCProfiler(RCTBridge *bridge, JSContextRef context)
   RCTAssertParam(sourceURL);
 
   __weak RCTJSCExecutor *weakSelf = self;
-#if RCT_DEV
-  _context.context[@"__injectHMRUpdate"] = ^(NSString *sourceCode, NSString *sourceCodeURL) {
-    RCTJSCExecutor *strongSelf = weakSelf;
-
-    if (!strongSelf) {
-      return;
-    }
-
-    JSStringRef execJSString = JSStringCreateWithUTF8CString(sourceCode.UTF8String);
-    JSStringRef jsURL = JSStringCreateWithUTF8CString(sourceCodeURL.UTF8String);
-    JSEvaluateScript(strongSelf->_context.ctx, execJSString, NULL, jsURL, 0, NULL);
-    JSStringRelease(jsURL);
-    JSStringRelease(execJSString);
-  };
-#endif
 
   [self executeBlockOnJavaScriptQueue:RCTProfileBlock((^{
     RCTJSCExecutor *strongSelf = weakSelf;

--- a/ReactAndroid/src/main/java/com/facebook/react/CoreModulesPackage.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/CoreModulesPackage.java
@@ -19,6 +19,7 @@ import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.modules.core.DefaultHardwareBackBtnHandler;
 import com.facebook.react.modules.core.DeviceEventManagerModule;
 import com.facebook.react.modules.core.ExceptionsManagerModule;
+import com.facebook.react.modules.core.HMRClient;
 import com.facebook.react.modules.core.JSTimersExecution;
 import com.facebook.react.modules.core.RCTNativeAppEventEmitter;
 import com.facebook.react.modules.core.Timing;
@@ -95,6 +96,7 @@ import com.facebook.systrace.Systrace;
         RCTNativeAppEventEmitter.class,
         AppRegistry.class,
         com.facebook.react.bridge.Systrace.class,
+        HMRClient.class,
         DebugComponentOwnershipModule.RCTDebugComponentOwnership.class);
   }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/CoreModulesPackage.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/CoreModulesPackage.java
@@ -19,7 +19,7 @@ import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.modules.core.DefaultHardwareBackBtnHandler;
 import com.facebook.react.modules.core.DeviceEventManagerModule;
 import com.facebook.react.modules.core.ExceptionsManagerModule;
-import com.facebook.react.modules.core.HMRClient;
+import com.facebook.react.devsupport.HMRClient;
 import com.facebook.react.modules.core.JSTimersExecution;
 import com.facebook.react.modules.core.RCTNativeAppEventEmitter;
 import com.facebook.react.modules.core.Timing;

--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManager.java
@@ -25,6 +25,7 @@ public interface DevSupportManager extends NativeModuleCallExceptionHandler {
   void addCustomDevOption(String optionName, DevOptionHandler optionHandler);
   void showNewJSError(String message, ReadableArray details, int errorCookie);
   void updateJSError(final String message, final ReadableArray details, final int errorCookie);
+  void hideRedboxDialog();
   void showDevOptionsDialog();
   void setDevSupportEnabled(boolean isDevSupportEnabled);
   boolean getDevSupportEnabled();

--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerImpl.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerImpl.java
@@ -218,6 +218,14 @@ public class DevSupportManagerImpl implements DevSupportManager {
         });
   }
 
+  @Override
+  public void hideRedboxDialog() {
+    // dismiss redbox if exists
+    if (mRedBoxDialog != null) {
+      mRedBoxDialog.dismiss();
+    }
+  }
+
   private void showNewError(
       final String message,
       final StackFrame[] stack,

--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerImpl.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerImpl.java
@@ -13,6 +13,7 @@ import javax.annotation.Nullable;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URL;
 import java.util.LinkedHashMap;
 import java.util.Locale;
 import java.util.concurrent.ExecutionException;
@@ -49,6 +50,7 @@ import com.facebook.react.common.ReactConstants;
 import com.facebook.react.common.ShakeDetector;
 import com.facebook.react.common.futures.SimpleSettableFuture;
 import com.facebook.react.devsupport.StackTraceHelper.StackFrame;
+import com.facebook.react.modules.core.HMRClient;
 import com.facebook.react.modules.debug.DeveloperSettings;
 
 /**
@@ -520,6 +522,15 @@ public class DevSupportManagerImpl implements DevSupportManager {
     }
     if (reactContext != null) {
       mDebugOverlayController = new DebugOverlayController(reactContext);
+    }
+
+    if (mDevSettings.isHotModuleReplacementEnabled() && mCurrentContext != null) {
+      try {
+        URL sourceUrl = new URL(getSourceUrl());
+        mCurrentContext.getJSModule(HMRClient.class).enable("android", sourceUrl.getPath().substring(1));
+      } catch (Exception e) {
+        e.printStackTrace();
+      }
     }
 
     reloadSettings();

--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerImpl.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerImpl.java
@@ -42,7 +42,6 @@ import com.facebook.react.R;
 import com.facebook.react.bridge.CatalystInstance;
 import com.facebook.react.bridge.DefaultNativeModuleCallExceptionHandler;
 import com.facebook.react.bridge.JavaJSExecutor;
-import com.facebook.react.bridge.NativeModuleCallExceptionHandler;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.UiThreadUtil;
@@ -51,7 +50,6 @@ import com.facebook.react.common.ReactConstants;
 import com.facebook.react.common.ShakeDetector;
 import com.facebook.react.common.futures.SimpleSettableFuture;
 import com.facebook.react.devsupport.StackTraceHelper.StackFrame;
-import com.facebook.react.modules.core.HMRClient;
 import com.facebook.react.modules.debug.DeveloperSettings;
 
 /**

--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerImpl.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerImpl.java
@@ -537,7 +537,9 @@ public class DevSupportManagerImpl implements DevSupportManager {
       try {
         URL sourceUrl = new URL(getSourceUrl());
         String path = sourceUrl.getPath().substring(1); // strip initial slash in path
-        mCurrentContext.getJSModule(HMRClient.class).enable("android", path);
+        String host = sourceUrl.getHost();
+        int port = sourceUrl.getPort();
+        mCurrentContext.getJSModule(HMRClient.class).enable("android", path, host, port);
       } catch (MalformedURLException e) {
         showNewJavaError(e.getMessage(), e);
       }

--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerImpl.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerImpl.java
@@ -13,6 +13,7 @@ import javax.annotation.Nullable;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.LinkedHashMap;
 import java.util.Locale;
@@ -535,9 +536,10 @@ public class DevSupportManagerImpl implements DevSupportManager {
     if (mDevSettings.isHotModuleReplacementEnabled() && mCurrentContext != null) {
       try {
         URL sourceUrl = new URL(getSourceUrl());
-        mCurrentContext.getJSModule(HMRClient.class).enable("android", sourceUrl.getPath().substring(1));
-      } catch (Exception e) {
-        e.printStackTrace();
+        String path = sourceUrl.getPath().substring(1); // strip initial slash in path
+        mCurrentContext.getJSModule(HMRClient.class).enable("android", path);
+      } catch (MalformedURLException e) {
+        showNewJavaError(e.getMessage(), e);
       }
     }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/DisabledDevSupportManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/DisabledDevSupportManager.java
@@ -47,6 +47,11 @@ public class DisabledDevSupportManager implements DevSupportManager {
   }
 
   @Override
+  public void hideRedboxDialog() {
+
+  }
+
+  @Override
   public void showDevOptionsDialog() {
 
   }

--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/HMRClient.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/HMRClient.java
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-package com.facebook.react.modules.core;
+package com.facebook.react.devsupport;
 
 import com.facebook.react.bridge.JavaScriptModule;
 

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/core/ExceptionsManagerModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/core/ExceptionsManagerModule.java
@@ -75,4 +75,11 @@ public class ExceptionsManagerModule extends BaseJavaModule {
       mDevSupportManager.updateJSError(title, details, exceptionId);
     }
   }
+
+  @ReactMethod
+  public void dismissRedbox() {
+    if (mDevSupportManager.getDevSupportEnabled()) {
+      mDevSupportManager.hideRedboxDialog();
+    }
+  }
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/core/HMRClient.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/core/HMRClient.java
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+package com.facebook.react.modules.core;
+
+import com.facebook.react.bridge.JavaScriptModule;
+
+/**
+ * JS module interface - allows for enabling of HMRClient
+ */
+public interface HMRClient extends JavaScriptModule {
+  void enable(String platform, String bundleEntry);
+}

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/core/HMRClient.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/core/HMRClient.java
@@ -12,8 +12,19 @@ package com.facebook.react.modules.core;
 import com.facebook.react.bridge.JavaScriptModule;
 
 /**
- * JS module interface - allows for enabling of HMRClient
+ * JS module interface for HMRClient
+ *
+ * The HMR(Hot Module Replacement)Client allows for the application to receive updates
+ * from the packager server (over a web socket), allowing for injection of JavaScript to
+ * the running application (without a refresh).
  */
 public interface HMRClient extends JavaScriptModule {
+
+  /**
+   * Enable the HMRClient so that the client will receive updates
+   * from the packager server.
+   * @param platform The platform in which HMR updates will be enabled. Should be "android".
+   * @param bundleEntry The path to the bundle entry file (e.g. index.ios.bundle)
+   */
   void enable(String platform, String bundleEntry);
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/core/HMRClient.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/core/HMRClient.java
@@ -24,7 +24,9 @@ public interface HMRClient extends JavaScriptModule {
    * Enable the HMRClient so that the client will receive updates
    * from the packager server.
    * @param platform The platform in which HMR updates will be enabled. Should be "android".
-   * @param bundleEntry The path to the bundle entry file (e.g. index.ios.bundle)
+   * @param bundleEntry The path to the bundle entry file (e.g. index.ios.bundle).
+   * @param host The host that the HMRClient should communicate with.
+   * @param port The port that the HMRClient should communicate with on the host.
    */
-  void enable(String platform, String bundleEntry);
+  void enable(String platform, String bundleEntry, String host, int port);
 }

--- a/ReactAndroid/src/main/jni/react/JSCExecutor.cpp
+++ b/ReactAndroid/src/main/jni/react/JSCExecutor.cpp
@@ -554,8 +554,8 @@ static JSValueRef nativeInjectHMRUpdate(
     JSObjectRef thisObject,
     size_t argumentCount,
     const JSValueRef arguments[], JSValueRef *exception) {
-  JSStringRef execJSString = JSValueToStringCopy(ctx, arguments[0], NULL);
-  JSStringRef jsURL = JSValueToStringCopy(ctx, arguments[1], NULL);
+  String execJSString = Value(ctx, arguments[0]).toString();
+  String jsURL = Value(ctx, arguments[1]).toString();
   evaluateScript(ctx, execJSString, jsURL);
   return JSValueMakeUndefined(ctx);
 }

--- a/ReactAndroid/src/main/jni/react/JSCExecutor.cpp
+++ b/ReactAndroid/src/main/jni/react/JSCExecutor.cpp
@@ -73,7 +73,7 @@ static JSValueRef nativePerformanceNow(
     size_t argumentCount,
     const JSValueRef arguments[],
     JSValueRef *exception);
-static JSValueRef injectHMRUpdate(
+static JSValueRef nativeInjectHMRUpdate(
     JSContextRef ctx,
     JSObjectRef function,
     JSObjectRef thisObject,
@@ -115,8 +115,7 @@ JSCExecutor::JSCExecutor(FlushImmediateCallback cb) :
   installGlobalFunction(m_context, "nativeStartWorker", nativeStartWorker);
   installGlobalFunction(m_context, "nativePostMessageToWorker", nativePostMessageToWorker);
   installGlobalFunction(m_context, "nativeTerminateWorker", nativeTerminateWorker);
-
-  installGlobalFunction(m_context, "__injectHMRUpdate", injectHMRUpdate);
+  installGlobalFunction(m_context, "nativeInjectHMRUpdate", nativeInjectHMRUpdate);
 
   #ifdef WITH_FB_JSC_TUNING
   configureJSCForAndroid();
@@ -549,7 +548,7 @@ static JSValueRef nativePerformanceNow(
   return JSValueMakeNumber(ctx, (nano / (double)NANOSECONDS_IN_MILLISECOND));
 }
 
-static JSValueRef injectHMRUpdate(
+static JSValueRef nativeInjectHMRUpdate(
     JSContextRef ctx,
     JSObjectRef function,
     JSObjectRef thisObject,


### PR DESCRIPTION
This PR does most of the final things to enable HMR on Android, including:

* Calling `HMRClient.enable` when the option is toggled in the dev menu.
* Injecting a helper function into the JSC Context to deal with SourceMaps
* Make sure RedBox dismisses appropriately when an error is fixed and HMR is enabled.