### PR TITLE
Allows RefreshControl to be mounted with refreshing = true

### DIFF
--- a/React/Views/RCTRefreshControl.m
+++ b/React/Views/RCTRefreshControl.m
@@ -46,9 +46,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
   CGPoint offset = {scrollView.contentOffset.x, scrollView.contentOffset.y - self.frame.size.height};
   // Don't animate when the prop is set initialy.
   if (_isInitialRender) {
-    // Must use `[scrollView setContentOffset:offset animated:NO]` instead of just setting
-    // `scrollview.contentOffset` or it doesn't work, don't ask me why!
-    [scrollView setContentOffset:offset animated:NO];
+    scrollView.contentOffset = offset;
     [super beginRefreshing];
   } else {
     // `beginRefreshing` must be called after the animation is done. This is why it is impossible

--- a/React/Views/RCTRefreshControl.m
+++ b/React/Views/RCTRefreshControl.m
@@ -11,17 +11,54 @@
 
 #import "RCTUtils.h"
 
-@implementation RCTRefreshControl
+@implementation RCTRefreshControl {
+  BOOL _initialRefreshingState;
+  BOOL _isInitialRender;
+}
 
 - (instancetype)init
 {
   if ((self = [super init])) {
     [self addTarget:self action:@selector(refreshControlValueChanged) forControlEvents:UIControlEventValueChanged];
+    _isInitialRender = true;
   }
   return self;
 }
 
 RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
+
+- (void)layoutSubviews
+{
+  [super layoutSubviews];
+  
+  // If the control is refreshing when mounted we need to call
+  // beginRefreshing in layoutSubview or it doesn't work.
+  if (_isInitialRender && _initialRefreshingState) {
+    [self beginRefreshing];
+  }
+  _isInitialRender = false;
+}
+
+- (void)beginRefreshing
+{
+  // When using begin refreshing we need to adjust the ScrollView content offset manually.
+  UIScrollView *scrollView = (UIScrollView *)self.superview;
+  CGPoint offset = CGPointMake(scrollView.contentOffset.x, scrollView.contentOffset.y - self.frame.size.height);
+  // Don't animate when the prop is set initialy.
+  if (_isInitialRender) {
+    [scrollView setContentOffset:offset animated:NO];
+    [super beginRefreshing];
+  } else {
+    [UIView animateWithDuration:0.25
+                          delay:0
+                        options:UIViewAnimationOptionBeginFromCurrentState
+                     animations:^(void) {
+                       [scrollView setContentOffset:offset];
+                     } completion:^(__unused BOOL finished) {
+                       [super beginRefreshing];
+                     }];
+  }
+}
 
 - (NSString *)title
 {
@@ -37,7 +74,13 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
 {
   if (super.refreshing != refreshing) {
     if (refreshing) {
-      [self beginRefreshing];
+      // If it is the initial render, beginRefreshing will get called
+      // in layoutSubviews.
+      if (_isInitialRender) {
+        _initialRefreshingState = refreshing;
+      } else {
+        [self beginRefreshing];
+      }
     } else {
       [self endRefreshing];
     }

--- a/React/Views/RCTRefreshControl.m
+++ b/React/Views/RCTRefreshControl.m
@@ -43,12 +43,16 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
 {
   // When using begin refreshing we need to adjust the ScrollView content offset manually.
   UIScrollView *scrollView = (UIScrollView *)self.superview;
-  CGPoint offset = CGPointMake(scrollView.contentOffset.x, scrollView.contentOffset.y - self.frame.size.height);
+  CGPoint offset = {scrollView.contentOffset.x, scrollView.contentOffset.y - self.frame.size.height};
   // Don't animate when the prop is set initialy.
   if (_isInitialRender) {
+    // Must use `[scrollView setContentOffset:offset animated:NO]` instead of just setting
+    // `scrollview.contentOffset` or it doesn't work, don't ask me why!
     [scrollView setContentOffset:offset animated:NO];
     [super beginRefreshing];
   } else {
+    // `beginRefreshing` must be called after the animation is done. This is why it is impossible
+    // to use `setContentOffset` with `animated:YES`.
     [UIView animateWithDuration:0.25
                           delay:0
                         options:UIViewAnimationOptionBeginFromCurrentState
@@ -72,7 +76,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
 
 - (void)setRefreshing:(BOOL)refreshing
 {
-  if (super.refreshing != refreshing) {
+  if (self.refreshing != refreshing) {
     if (refreshing) {
       // If it is the initial render, beginRefreshing will get called
       // in layoutSubviews.

--- a/ReactAndroid/src/main/java/com/facebook/react/views/swiperefresh/SwipeRefreshLayoutManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/swiperefresh/SwipeRefreshLayoutManager.java
@@ -71,8 +71,15 @@ public class SwipeRefreshLayoutManager extends ViewGroupManager<ReactSwipeRefres
   }
 
   @ReactProp(name = "refreshing")
-  public void setRefreshing(ReactSwipeRefreshLayout view, boolean refreshing) {
-    view.setRefreshing(refreshing);
+  public void setRefreshing(final ReactSwipeRefreshLayout view, final boolean refreshing) {
+    // Use `post` otherwise the control won't start refreshing if refreshing is true when
+    // the component gets mounted.
+    view.post(new Runnable() {
+      @Override
+      public void run() {
+        view.setRefreshing(refreshing);
+      }
+    });
   }
 
   @Override


### PR DESCRIPTION
RefreshControl did not start refreshing when refreshing was set to true initially. It also did not start refreshing on iOS when setting the prop from false to true without doing a pull to refresh gesture.

This was a pain in the ass to make work on iOS because UIRefreshControl seems super sensitive to when beginRefreshing can be called, for the initial render I need to call it in layoutSubviews. I also have to manually adjust the scrollview content offset when calling beginRefreshing. The code is a bit hacky but it was the only solution I found that was actually working.

Fixes #5716