### PR TITLE
Add app to showcase with source link

### DIFF
--- a/website/src/react-native/showcase.js
+++ b/website/src/react-native/showcase.js
@@ -457,6 +457,13 @@ var apps = [
     link: 'https://play.google.com/store/apps/details?id=com.rhyble.nalathekerala',
     author: 'Rhyble',
   },
+	{
+    name: 'No Fluff: Hiragana',
+    icon: 'https://lh3.googleusercontent.com/kStXwjpbPsu27E1nIEU1gfG0I8j9t5bAR_20OMhGZvu0j2vab3EbBV7O_KNZChjflZ_O',
+    link: 'https://play.google.com/store/apps/details?id=com.hiragana',
+    author: 'Matthias Sieber',
+    source: 'https://github.com/manonthemat/no-fluff-hiragana'
+  },
   {
     name: 'Night Light',
     icon: 'http://is3.mzstatic.com/image/pf/us/r30/Purple7/v4/5f/50/5f/5f505fe5-0a30-6bbf-6ed9-81ef09351aba/mzl.lkeqxyeo.png',
@@ -683,6 +690,7 @@ var AppList = React.createClass({
         {app.linkAppStore && app.linkPlayStore ? this._renderLinks(app) : null}
         <p>By {app.author}</p>
         {this._renderBlogPosts(app)}
+				{this._renderSourceLink(app)}
         {this._renderVideos(app)}
       </div>
     );
@@ -693,7 +701,7 @@ var AppList = React.createClass({
 
     return (
       <div className="showcase" key={i}>
-        <a href={app.link} target="blank">
+        <a href={app.link} target="_blank">
           {inner}
         </a>
       </div>
@@ -707,7 +715,7 @@ var AppList = React.createClass({
 
     if (app.blogs.length === 1) {
       return (
-        <p><a href={app.blogs[0]} target="blank">Blog post</a></p>
+        <p><a href={app.blogs[0]} target="_blank">Blog post</a></p>
       );
     } else if (app.blogs.length > 1) {
       return (
@@ -718,9 +726,19 @@ var AppList = React.createClass({
 
   _renderBlogPost: function(url, i) {
     return (
-      <a href={url} target="blank">
+      <a href={url} target="_blank">
         {i + 1}&nbsp;
       </a>
+    );
+  },
+
+	_renderSourceLink: function(app) {
+    if (!app.source) {
+      return;
+    }
+
+    return (
+      <p><a href={app.source} target="_blank">Source</a></p>
     );
   },
 
@@ -731,7 +749,7 @@ var AppList = React.createClass({
 
     if (app.videos.length === 1) {
       return (
-        <p><a href={app.videos[0]} target="blank">Video</a></p>
+        <p><a href={app.videos[0]} target="_blank">Video</a></p>
       );
     } else if (app.videos.length > 1) {
       return (
@@ -742,7 +760,7 @@ var AppList = React.createClass({
 
   _renderVideo: function(url, i) {
     return (
-      <a href={url} target="blank">
+      <a href={url} target="_blank">
         {i + 1}&nbsp;
       </a>
     );
@@ -751,9 +769,8 @@ var AppList = React.createClass({
   _renderLinks: function(app) {
     return (
       <p>
-        <a href={app.linkAppStore} target="blank">iOS</a>
-        {" - "}
-        <a href={app.linkPlayStore} target="blank">Android</a>
+        <a href={app.linkAppStore} target="_blank">iOS</a> -
+        <a href={app.linkPlayStore} target="_blank">Android</a>
       </p>
     );
   },


### PR DESCRIPTION
3 small changes

Added a published android app to the showcase.

Modified the rendering of the apps.
When there's a _source_ property on the app object, the link will show up as shown in this screenshot.
![screen shot 2016-02-04 at 9 13 31 am](https://cloud.githubusercontent.com/assets/5065940/12823220/a79bafcc-cb1f-11e5-8cf5-03b03ecadc45.png)

Also, external links have the _blank target and not just blank (without the underscore), so a new tab/window will always be opened.