### PR TITLE
Use new DisplayMetrics object in `getDisplayMetrics` as to not overwrite Android global state

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModule.java
@@ -464,7 +464,8 @@ public class UIManagerModule extends ReactContextBaseJavaModule implements
   private DisplayMetrics getDisplayMetrics() {
     Context context = getReactApplicationContext();
 
-    DisplayMetrics displayMetrics = context.getResources().getDisplayMetrics();
+    DisplayMetrics displayMetrics = new DisplayMetrics();
+    displayMetrics.setTo(context.getResources().getDisplayMetrics());
     WindowManager wm = (WindowManager) context.getSystemService(Context.WINDOW_SERVICE);
     Display display = wm.getDefaultDisplay();
 


### PR DESCRIPTION
The change in https://github.com/facebook/react-native/commit/8e603940e3fca4ed2fe420c02a66d860b53f3076 actually causes a super bad bug when `context.getResources().getDisplayMetrics()` is accessed in other parts of the application.

It turns out that when you dive into the impl of `getRealMetrics`, it mutates whatever `DisplayMetrics` object is passed to it. In this case, `getDisplayMetrics` ends up mutating the `DisplayMetrics` object that sits on the application context's `Resources` instance.

This PR makes that not so.

#sharedmutablestateistherootofallevil

/cc @jesseruder @ide @jaysoo @bestander @astreet 