### PR TITLE
Stop spamming the logs

### DIFF
--- a/React/Profiler/RCTJSCProfiler.m
+++ b/React/Profiler/RCTJSCProfiler.m
@@ -56,11 +56,9 @@ static void RCTJSCProfilerStateInit()
 
     if (RCTNativeProfilerStart && RCTNativeProfilerEnd && enableBytecode) {
       enableBytecode();
-      RCTLogInfo(@"JSC profiler is available.");
     } else {
       RCTNativeProfilerStart = NULL;
       RCTNativeProfilerEnd = NULL;
-      RCTLogInfo(@"JSC profiler is not supported.");
     }
   });
 }


### PR DESCRIPTION
We should have 0 logs at startup. In theory it could be useful to know if the profiler is enabled, but in practice 99% of the time you don't care and it ends up spamming you for no good reason. Then more people add logs and not only do the logs are not useful, they prevent people from actually using them when debugging.