### PR TITLE
Quit early if node < 4

### DIFF
--- a/local-cli/server/checkNodeVersion.js
+++ b/local-cli/server/checkNodeVersion.js
@@ -36,5 +36,6 @@ module.exports = function() {
       marginRight: 1,
       paddingBottom: 1,
     }));
+    process.exit(1);
   }
 };


### PR DESCRIPTION
Before we would display this warning at the top and have the packager throw thousands of lines of errors because of es6 syntax.

Before:

<img width="602" alt="screen shot 2016-02-04 at 1 49 27 pm" src="https://cloud.githubusercontent.com/assets/197597/12831357/a72bdc0a-cb48-11e5-9b81-dde895eaf113.png">


After:

<img width="1440" alt="screen shot 2016-02-04 at 2 04 50 pm" src="https://cloud.githubusercontent.com/assets/197597/12831364/af1c16a0-cb48-11e5-949c-c470938f8b49.png">
