### PR TITLE
Remove React dev tools upsell

### DIFF
--- a/local-cli/server/util/debugger.html
+++ b/local-cli/server/util/debugger.html
@@ -27,12 +27,6 @@ window.onbeforeunload = function() {
   }
 };
 
-window.addEventListener('load', function () {
-  if (typeof window.__REACT_DEVTOOLS_GLOBAL_HOOK__ === 'undefined') {
-    document.getElementById('devtools-banner').style.display = 'block';
-  }
-});
-
 // Alias native implementations needed by the debugger before platform-specific
 // implementations are loaded into the global namespace
 var debuggerSetTimeout = window.setTimeout;
@@ -123,46 +117,12 @@ connectToDebuggerProxy();
     border-radius: 4px;
     letter-spacing: 3px;
   }
-  #devtools-banner {
-    display: none;
-    background-color: #FDFDD5;
-    padding: 10px;
-  }
-  #devtools-banner h3 {
-    margin: 0;
-    font-weight: normal;
-  }
-  #devtools-banner a {
-    display: none;
-    padding: 10px 20px 10px 20px;
-    margin-bottom: 10px;
-    color: white;
-    text-decoration: none;
-    font-size: 11px;
-    text-shadow: 0 1px 1px rgba(0,0,0,0.1);
-    text-transform: uppercase;
-    font-weight: bold;
-    background-color: #4d7bd6;
-    border-radius: 2px;
-    border: 1px solid #2d53af;
-    display: inline-block;
-  }
   .content {
     padding: 10px;
   }
 </style>
 </head>
 <body>
-  <div id="devtools-banner">
-    <h3>Install React DevTools</h3>
-    <p>
-       React Developer Tools is an extension that allows you to inspect the
-       React component hierarchies in the Chrome Developer Tools.
-    </p>
-    <a href="https://fb.me/react-devtools" target="_blank">
-      Install
-    </a>
-  </div>
   <div class="content">
     <p>
       React Native JS code runs inside this Chrome tab.


### PR DESCRIPTION
React dev tools have been broken since we moved to web worker but we had a gigantic upsell for them. This must be a very frustrating experience for people just starting to use react native to be told to use something and see that it doesn't work.

Removing that upsell until it works again

<img width="1090" alt="screen shot 2016-02-04 at 2 00 37 pm" src="https://cloud.githubusercontent.com/assets/197597/12831501/8eba3f4e-cb49-11e5-8bdc-84f902053321.png">
