### PR TITLE
Use media url instead of reference url when picking movie types in image picker

### DIFF
--- a/Libraries/CameraRoll/RCTImagePickerManager.m
+++ b/Libraries/CameraRoll/RCTImagePickerManager.m
@@ -104,8 +104,17 @@ RCT_EXPORT_METHOD(openSelectDialog:(NSDictionary *)config
 - (void)imagePickerController:(UIImagePickerController *)picker
 didFinishPickingMediaWithInfo:(NSDictionary<NSString *, id> *)info
 {
-  // Image from PhotoLibrary
-  NSString *imageUri = [info[UIImagePickerControllerReferenceURL] absoluteString];
+  NSString *mediaType = info[UIImagePickerControllerMediaType];
+  NSString *imageUri;
+
+  if (mediaType == (NSString *)kUTTypeMovie) {
+    // Filesystem URL for the movie
+    imageUri = [info[UIImagePickerControllerMediaURL] absoluteString];
+  } else {
+    // Image from PhotoLibrary
+    imageUri = [info[UIImagePickerControllerReferenceURL] absoluteString];
+  }
+
   if (imageUri) {
     [self _dismissPicker:picker args:@[imageUri]];
 


### PR DESCRIPTION
I ran into an issue trying to upload videos selected with ImagePickerIOS to S3. The file would upload just fine but would be reduced in size and have no duration. It appears to be just a thumbnail of the video. Using the media url resolves this.