### PR TITLE
[Inspector]Fix inspector for displaying styles' value

### DIFF
--- a/Libraries/Inspector/StyleInspector.js
+++ b/Libraries/Inspector/StyleInspector.js
@@ -27,8 +27,12 @@ class StyleInspector extends React.Component {
         <View>
           {names.map(name => <Text style={styles.attr}>{name}:</Text>)}
         </View>
+
         <View>
-          {names.map(name => <Text style={styles.value}>{this.props.style[name]}</Text>)}
+          {names.map(name => {
+            var value = typeof this.props.style[name] === 'object' ? JSON.stringify(this.props.style[name]) : this.props.style[name];
+            return <Text style={styles.value}>{value}</Text>;
+          } ) }
         </View>
       </View>
     );


### PR DESCRIPTION
StyleInspector will occur a error if a style's value is an object, such as transform. Now it converts the value to string before display.

fix issue #5774 .

Now it can display okay.

![simulator screen shot feb 6 2016 12 32 24 am](https://cloud.githubusercontent.com/assets/1478284/12852296/36736966-cc69-11e5-8f28-9e4681585bcb.png)


