### PR TITLE
Allow bundling in Simulator

### DIFF
--- a/packager/react-native-xcode.sh
+++ b/packager/react-native-xcode.sh
@@ -10,13 +10,6 @@
 # This script is supposed to be invoked as part of Xcode build process
 # and relies on environment variables (including PWD) set by Xcode
 
-# There is no point in creating an offline package for simulator builds
-# because the packager is supposed to be running during development anyways
-if [[ "$PLATFORM_NAME" = "iphonesimulator" ]]; then
-  echo "Skipping bundling for Simulator platform"
-  exit 0;
-fi
-
 case "$CONFIGURATION" in
   Debug)
     DEV=true


### PR DESCRIPTION
Feel free to reject this PR, though I'm removing this because it causes a total failing state without any clue to the developer as to what's going on. It just yields a cryptic error message:

```
2016-02-04 18:59:17.582 [error][tid:com.facebook.React.JavaScript] Unable to execute JS call: __fbBatchedBridge is undefined
2016-02-04 18:59:17.585 SydTechEco[76215:10166934] *** Terminating app due to uncaught exception 'RCTFatalException: Unable to execute JS call: __fbBatchedBridge is undefined', reason: 'Unable to execute JS call: __fbBatchedBridge is undefined'
```

I ran into this when I set my project to Release instead of Debug, and tried to test in Simulator. This held me up and prevented me from meeting a launch goal, which was really frustrating. As developers, we should have the choice of running a release copy on Simulator or a device, as a final check before publishing to the AppStore.