### PR TITLE
Fix XMLHttpRequest.abort() not functional due to incorrect lazy loading in RCTNetworking ObjC module

### DIFF
--- a/Libraries/Network/RCTNetworking.m
+++ b/Libraries/Network/RCTNetworking.m
@@ -411,7 +411,7 @@ RCT_EXPORT_MODULE()
   task.uploadProgressBlock = uploadProgressBlock;
 
   if (task.requestID) {
-    if (_tasksByRequestID) {
+    if (!_tasksByRequestID) {
       _tasksByRequestID = [NSMutableDictionary new];
     }
     _tasksByRequestID[task.requestID] = task;


### PR DESCRIPTION
Introduced in a major lazy loading refactoring: 060664fd3d9331f062696e68179bac9cd4544a06.

This is especially an issue when aborting a long-lived HTTP connection used as a notification channel, as it will use 1 of the maximum 4 connections per host (default limit defined by iOS' NSURLSession).