### PR TITLE
Snapshot the Set of listeners when dispatching a BackAndroid event

### DIFF
--- a/Libraries/Utilities/BackAndroid.android.js
+++ b/Libraries/Utilities/BackAndroid.android.js
@@ -23,8 +23,9 @@ type BackPressEventName = $Enum<{
 var _backPressSubscriptions = new Set();
 
 RCTDeviceEventEmitter.addListener(DEVICE_BACK_EVENT, function() {
+  var backPressSubscriptions = new Set(_backPressSubscriptions);
   var invokeDefault = true;
-  _backPressSubscriptions.forEach((subscription) => {
+  backPressSubscriptions.forEach((subscription) => {
     if (subscription()) {
       invokeDefault = false;
     }


### PR DESCRIPTION
…while an event is dispatched

While it is guarded, a copy of the Set is created before listeners are added or removed. The event dispatch loop continues with the old Set of listeners.

This PR modifies `BackAndroid` to match the proposal at the end of #5781.