### PR TITLE
Update AlertIOS.js

### DIFF
--- a/Libraries/Utilities/AlertIOS.js
+++ b/Libraries/Utilities/AlertIOS.js
@@ -94,7 +94,8 @@ class AlertIOS {
       onPress?: ?Function;
       style?: AlertButtonStyle;
     }>,
-    callback?: ?Function
+    callback?: ?Function,
+    type?: string
   ): void {
     if (arguments.length === 2) {
       if (typeof value === 'object') {
@@ -117,7 +118,12 @@ class AlertIOS {
     if (!buttons) {
       buttons = [{ onPress: callback }];
     }
-    this.alert(title, value, buttons, 'plain-text');
+
+    if (!type) {
+    	type = 'plain-text';
+    }
+
+    this.alert(title, value, buttons, type);
   }
 }
 


### PR DESCRIPTION
When using AlertIOS.prompt() the developer can't choose the input type, thus being forced to use 'plain-text'. This simple change allows to set input type ('secure-text' or 'login-password'), keeping as default 'plain-text'.