### PR TITLE
Fix jni build with gradle

### DIFF
--- a/ReactAndroid/src/main/jni/react/Android.mk
+++ b/ReactAndroid/src/main/jni/react/Android.mk
@@ -9,8 +9,8 @@ LOCAL_SRC_FILES := \
   JSCExecutor.cpp \
   JSCHelpers.cpp \
   JSCWebWorker.cpp \
-  JSModulesUnbundle.cpp \
   MethodCall.cpp \
+  Platform.cpp \
   Value.cpp \
 
 LOCAL_C_INCLUDES := $(LOCAL_PATH)/..
@@ -24,7 +24,7 @@ CXX11_FLAGS := -std=c++11
 LOCAL_CFLAGS += $(CXX11_FLAGS)
 LOCAL_EXPORT_CPPFLAGS := $(CXX11_FLAGS)
 
-LOCAL_SHARED_LIBRARIES := libfb libfbjni libfolly_json libjsc
+LOCAL_SHARED_LIBRARIES := libfb libfbjni libfolly_json libjsc libglog
 
 include $(BUILD_STATIC_LIBRARY)
 
@@ -32,3 +32,4 @@ $(call import-module,fb)
 $(call import-module,jni)
 $(call import-module,folly)
 $(call import-module,jsc)
+$(call import-module,glog)

--- a/ReactAndroid/src/main/jni/react/jni/Android.mk
+++ b/ReactAndroid/src/main/jni/react/jni/Android.mk
@@ -6,7 +6,10 @@ LOCAL_MODULE := reactnativejni
 
 LOCAL_SRC_FILES := \
   JMessageQueueThread.cpp \
+  JSCPerfLogging.cpp \
   JSLoader.cpp \
+  JSLogging.cpp \
+  JniJSModulesUnbundle.cpp \
   NativeArray.cpp \
   OnLoad.cpp \
   ProxyExecutor.cpp \


### PR DESCRIPTION
fc94f1e6d0ac61e250c13d293ff76c9c5a5dbbf5 and the following commits introduced some changes to the jni build but only changed the BUCK build files and not the gradle ones. This ports the changes to the gradle build files to fix the build.