### PR TITLE
Remove String.prototype.contains polyfill

### DIFF
--- a/packager/react-packager/src/Resolver/polyfills/String.prototype.es6.js
+++ b/packager/react-packager/src/Resolver/polyfills/String.prototype.es6.js
@@ -44,19 +44,6 @@ if (!String.prototype.endsWith) {
   };
 }
 
-if (!String.prototype.contains) {
-  String.prototype.contains = function(search) {
-    'use strict';
-    if (this == null) {
-      throw TypeError();
-    }
-    var string = String(this);
-    var pos = arguments.length > 1 ?
-      (Number(arguments[1]) || 0) : 0;
-    return string.indexOf(String(search), pos) !== -1;
-  };
-}
-
 if (!String.prototype.repeat) {
   String.prototype.repeat = function(count) {
     'use strict';


### PR DESCRIPTION
Now that String.prototype.includes is there, we should remove the .contains one which has not been standardized.

For fb reviewers, this needs to land after D2910339 which updates internal callsites.