### PR TITLE
Enable strict mode for transform-es2015-modules-commonjs

### DIFF
--- a/babel-preset/configs/main.js
+++ b/babel-preset/configs/main.js
@@ -24,7 +24,7 @@ module.exports = {
     'transform-es2015-computed-properties',
     'transform-es2015-constants',
     'transform-es2015-destructuring',
-    ['transform-es2015-modules-commonjs', { strict: false, allowTopLevelThis: true }],
+    ['transform-es2015-modules-commonjs', { allowTopLevelThis: true }],
     'transform-es2015-parameters',
     'transform-es2015-shorthand-properties',
     'transform-es2015-spread',


### PR DESCRIPTION
Since #5422 react-native works with strict mode modules but the transform was not updated since Facebook has some non strict mode compatible internal modules. Now that #5214 has landed and it is easy to change the babel config I think we should enable it by default to make es2015 modules spec compliant.

Someone at Facebook will have to make the internal changes necessary to disable strict mode modules for their projects that use non strict mode compatible modules by including a .babelrc file with 
``` json
{
  "presets": [
    "react-native"
  ],
  "plugins": [
    ["transform-es2015-modules-commonjs", { "strict": false, "allowTopLevelThis": true }]
  ]
}
``` 
before merging this.

We might also want to mention this in the breaking change section for the next release.