### PR TITLE
Add npm-shrinkwrap.json to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,8 @@
     "PATENTS",
     "README.md",
     "jestSupport",
-    ".flowconfig"
+    ".flowconfig",
+    "npm-shrinkwrap.json"
   ],
   "scripts": {
     "test": "NODE_ENV=test jest",


### PR DESCRIPTION
This probably should have been done a long time ago, but alas, here we are.

This adds the shrinkwrap file to be included when `react-native` is npm installed.

Previously this wasn't possible due to how we were resolving Babel plugins in the transformer in the packager, but now that we've simplified that and added the preset, this should work fine.

This will be even better when we're able to add `react` as a peer dependency, rather than a normal dependency.

**NOTE: DO NOT MERGE until `react` is a peer dependency. It will break things for people who use things like Relay/Redux/etc. that depend on React. (#5813 addresses this)**