### PR TITLE
Move `react` to peerDependencies

### DIFF
--- a/local-cli/generator/index.js
+++ b/local-cli/generator/index.js
@@ -82,5 +82,13 @@ module.exports = yeoman.generators.NamedBase.extend({
         {name: this.name}
       );
     }
+  },
+
+  install: function() {
+    if (this.options.upgrade) {
+      return;
+    }
+
+    this.npmInstall('react', { '--save': true });
   }
 });

--- a/local-cli/upgrade/upgrade.js
+++ b/local-cli/upgrade/upgrade.js
@@ -44,6 +44,19 @@ module.exports = function upgrade(args, config) {
               'https://github.com/facebook/react-native/releases/tag/v' + semver.major(v) + '.' + semver.minor(v) + '.0'
             )
           );
+
+          // >= v0.21.0, we require react to be a peer depdendency
+          if (semver.gte(v, '0.21.0') && !pak.dependencies['react']) {
+            console.log(
+              chalk.yellow(
+                '\nYour \'package.json\' file doesn\'t seem to have \'react\' as a dependency.\n' +
+                '\'react\' was changed from a dependency to a peer dependency in react-native v0.21.0.\n' +
+                'Therefore, it\'s necessary to include \'react\' in your project\'s dependencies.\n' +
+                'Just run \'npm install --save react\', then re-run \'react-native upgrade\'.\n'
+              )
+            );
+            return Promise.resolve();
+          }
         } else {
           console.log(
             chalk.yellow(

--- a/package.json
+++ b/package.json
@@ -102,6 +102,9 @@
   "bin": {
     "react-native": "local-cli/wrong-react-native.js"
   },
+  "peerDependencies": {
+    "react": "^0.14.5"
+  },
   "dependencies": {
     "absolute-path": "^0.0.0",
     "art": "^0.10.0",
@@ -133,7 +136,6 @@
     "optimist": "^0.6.1",
     "progress": "^1.1.8",
     "promise": "^7.1.1",
-    "react": "^0.14.5",
     "react-timer-mixin": "^0.13.2",
     "react-transform-hmr": "^1.0.2",
     "rebound": "^0.0.13",


### PR DESCRIPTION
This PR moves `react` from dependencies to peerDependencies.

In general, this would have only been important for those people using packages that depend on `react` and were using npm@2...npm@3 would automatically de-dupe.

However, when #5812 gets merged, dependencies will be scoped to react-native (on both npm@2 & npm@3), thus breaking projects that are using a package like `react-redux` for example, which depends on `react`. There would be two copies of React installed, and due to the use of haste modules in `react`, this would break the packager and cause naming collisions.

This PR does three things -

1. Moves the dependency from dependencies to peerDependencies
2. Updates the local-cli to run `npm install react --save` when a new project is initialized.
3. Updates `react-native upgrade` to warn if `react` is not listed in the package.json's dependencies.

**Note: This will require a shrinkwrap update.**