### PR TITLE
Add 'file://' prefix to sourceURL when loading a script from a file.

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/JSBundleLoader.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/JSBundleLoader.java
@@ -29,9 +29,9 @@ public abstract class JSBundleLoader {
       @Override
       public void loadScript(ReactBridge bridge) {
         if (fileName.startsWith("assets://")) {
-          bridge.loadScriptFromAssets(context.getAssets(), fileName.replaceFirst("assets://", ""));
+          bridge.loadScriptFromAssets(context.getAssets(), fileName.replaceFirst("assets://", "file://"));
         } else {
-          bridge.loadScriptFromFile(fileName, fileName);
+          bridge.loadScriptFromFile(fileName, "file://" + fileName);
         }
       }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/JSBundleLoader.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/JSBundleLoader.java
@@ -29,7 +29,7 @@ public abstract class JSBundleLoader {
       @Override
       public void loadScript(ReactBridge bridge) {
         if (fileName.startsWith("assets://")) {
-          bridge.loadScriptFromAssets(context.getAssets(), fileName.replaceFirst("assets://", "file://"));
+          bridge.loadScriptFromAssets(context.getAssets(), fileName.replaceFirst("assets://", ""));
         } else {
           bridge.loadScriptFromFile(fileName, "file://" + fileName);
         }

--- a/ReactAndroid/src/main/jni/react/jni/OnLoad.cpp
+++ b/ReactAndroid/src/main/jni/react/jni/OnLoad.cpp
@@ -696,9 +696,9 @@ static void loadScriptFromAssets(JNIEnv* env, jobject obj, jobject assetManager,
 
   env->CallStaticVoidMethod(markerClass, gLogMarkerMethod, env->NewStringUTF("loadScriptFromAssets_read"));
   if (JniJSModulesUnbundle::isUnbundle(manager, assetNameStr)) {
-    loadApplicationUnbundle(bridge, manager, script, assetNameStr);
+    loadApplicationUnbundle(bridge, manager, script, "file://" + assetNameStr);
   } else {
-    executeApplicationScript(bridge, script, assetNameStr);
+    executeApplicationScript(bridge, script, "file://" + assetNameStr);
   }
   if (env->ExceptionCheck()) {
     return;


### PR DESCRIPTION
When loading a bundle from a file (usually in the case of the release version of the application), we should prepend "file://" to the file path when passing a "sourceURL" to the JSC bridge.

This 1) unifies iOS and Android when it comes to style in which they show the file name of the script in a traceback, and 2) making this URL and _actual_ URL allows it to be parsed by something like TraceKit (https://github.com/csnover/TraceKit), which is used by Sentry, for instance, to be able to easily log tracebacks.