### PR TITLE
Remove double to string convertion in FormData

### DIFF
--- a/Libraries/Network/FormData.js
+++ b/Libraries/Network/FormData.js
@@ -64,10 +64,6 @@ class FormData {
   getParts(): Array<FormDataPart> {
     return this._parts.map(([name, value]) => {
       var contentDisposition = 'form-data; name="' + name + '"';
-      // Convert non-object values to strings as per FormData.append() spec
-      if (typeof value !== 'object') {
-        value = '' + value;
-      }
 
       /* $FlowIssue(>=0.20.1) #9463928 */
       var headers: Headers = {'content-disposition': contentDisposition};
@@ -85,7 +81,7 @@ class FormData {
         }
         return {...value, headers, fieldName: name};
       }
-      // Cast to string all other values
+      // Convert non-object values to strings as per FormData.append() spec
       return {string: String(value), headers, fieldName: name};
     });
   }


### PR DESCRIPTION
These convertions introduced by 2 different PRs
https://github.com/facebook/react-native/commit/5061fde3173e6228d544b5df1ce8ce4e2a7dd2a4
https://github.com/facebook/react-native/commit/de392b5351494675220e0ef5176d8a8f3d473477