### PR TITLE
Move SimpleArray and SimpleMap from test to src.

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/JavaOnlyArray.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/JavaOnlyArray.java
@@ -14,29 +14,37 @@ import java.util.Arrays;
 import java.util.List;
 
 /**
- * A simple read/write array that can be used in tests in place of {@link WritableNativeArray}.
+ * Java {@link ArrayList} backed impementation of {@link ReadableArray} and {@link WritableArray}
+ * Instances of this class SHOULD NOT be used for communication between java and JS, use instances
+ * of {@link WritableNativeArray} created via {@link Arguments#createArray} or just
+ * {@link ReadableArray} interface if you want your "native" module method to take an array from JS
+ * as an argument.
+ *
+ * Main purpose for this class is to be used in java-only unit tests, but could also be used outside
+ * of tests in the code that operates only in java and needs to communicate with RN modules via
+ * their JS-exposed API.
  */
-public class SimpleArray implements ReadableArray, WritableArray {
+public class JavaOnlyArray implements ReadableArray, WritableArray {
 
   private final List mBackingList;
 
-  public static SimpleArray from(List list) {
-    return new SimpleArray(list);
+  public static JavaOnlyArray from(List list) {
+    return new JavaOnlyArray(list);
   }
 
-  public static SimpleArray of(Object... values) {
-    return new SimpleArray(values);
+  public static JavaOnlyArray of(Object... values) {
+    return new JavaOnlyArray(values);
   }
 
-  private SimpleArray(Object... values) {
+  private JavaOnlyArray(Object... values) {
     mBackingList = Arrays.asList(values);
   }
 
-  private SimpleArray(List list) {
+  private JavaOnlyArray(List list) {
     mBackingList = new ArrayList(list);
   }
 
-  public SimpleArray() {
+  public JavaOnlyArray() {
     mBackingList = new ArrayList();
   }
 
@@ -66,8 +74,8 @@ public class SimpleArray implements ReadableArray, WritableArray {
   }
 
   @Override
-  public SimpleArray getArray(int index) {
-    return (SimpleArray) mBackingList.get(index);
+  public JavaOnlyArray getArray(int index) {
+    return (JavaOnlyArray) mBackingList.get(index);
   }
 
   @Override
@@ -76,8 +84,8 @@ public class SimpleArray implements ReadableArray, WritableArray {
   }
 
   @Override
-  public SimpleMap getMap(int index) {
-    return (SimpleMap) mBackingList.get(index);
+  public JavaOnlyMap getMap(int index) {
+    return (JavaOnlyMap) mBackingList.get(index);
   }
 
   @Override
@@ -130,7 +138,7 @@ public class SimpleArray implements ReadableArray, WritableArray {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
 
-    SimpleArray that = (SimpleArray) o;
+    JavaOnlyArray that = (JavaOnlyArray) o;
 
     if (mBackingList != null ? !mBackingList.equals(that.mBackingList) : that.mBackingList != null)
       return false;

--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/JavaOnlyMap.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/JavaOnlyMap.java
@@ -14,20 +14,27 @@ import java.util.Iterator;
 import java.util.Map;
 
 /**
- * A simple read/write map that can be used in tests in place of {@link WritableNativeMap}.
+ * Java {@link HashMap} backed impementation of {@link ReadableMap} and {@link WritableMap}
+ * Instances of this class SHOULD NOT be used for communication between java and JS, use instances
+ * of {@link WritableNativeMap} created via {@link Arguments#createMap} or just {@link ReadableMap}
+ * interface if you want your "native" module method to take a map from JS as an argument.
+ *
+ * Main purpose for this class is to be used in java-only unit tests, but could also be used outside
+ * of tests in the code that operates only in java and needs to communicate with RN modules via
+ * their JS-exposed API.
  */
-public class SimpleMap implements ReadableMap, WritableMap {
+public class JavaOnlyMap implements ReadableMap, WritableMap {
 
   private final Map mBackingMap;
 
-  public static SimpleMap of(Object... keysAndValues) {
-    return new SimpleMap(keysAndValues);
+  public static JavaOnlyMap of(Object... keysAndValues) {
+    return new JavaOnlyMap(keysAndValues);
   }
 
   /**
    * @param keysAndValues keys and values, interleaved
    */
-  private SimpleMap(Object... keysAndValues) {
+  private JavaOnlyMap(Object... keysAndValues) {
     if (keysAndValues.length % 2 != 0) {
       throw new IllegalArgumentException("You must provide the same number of keys and values");
     }
@@ -37,7 +44,7 @@ public class SimpleMap implements ReadableMap, WritableMap {
     }
   }
 
-  public SimpleMap() {
+  public JavaOnlyMap() {
     mBackingMap = new HashMap();
   }
 
@@ -72,13 +79,13 @@ public class SimpleMap implements ReadableMap, WritableMap {
   }
 
   @Override
-  public SimpleMap getMap(String name) {
-    return (SimpleMap) mBackingMap.get(name);
+  public JavaOnlyMap getMap(String name) {
+    return (JavaOnlyMap) mBackingMap.get(name);
   }
 
   @Override
-  public SimpleArray getArray(String name) {
-    return (SimpleArray) mBackingMap.get(name);
+  public JavaOnlyArray getArray(String name) {
+    return (JavaOnlyArray) mBackingMap.get(name);
   }
 
   @Override
@@ -135,7 +142,7 @@ public class SimpleMap implements ReadableMap, WritableMap {
 
   @Override
   public void merge(ReadableMap source) {
-    mBackingMap.putAll(((SimpleMap) source).mBackingMap);
+    mBackingMap.putAll(((JavaOnlyMap) source).mBackingMap);
   }
 
   @Override
@@ -153,7 +160,7 @@ public class SimpleMap implements ReadableMap, WritableMap {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
 
-    SimpleMap that = (SimpleMap) o;
+    JavaOnlyMap that = (JavaOnlyMap) o;
 
     if (mBackingMap != null ? !mBackingMap.equals(that.mBackingMap) : that.mBackingMap != null)
       return false;

--- a/ReactAndroid/src/test/java/com/facebook/react/RootViewTest.java
+++ b/ReactAndroid/src/test/java/com/facebook/react/RootViewTest.java
@@ -19,8 +19,8 @@ import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.CatalystInstance;
 import com.facebook.react.bridge.ReactTestHelper;
-import com.facebook.react.bridge.SimpleArray;
-import com.facebook.react.bridge.SimpleMap;
+import com.facebook.react.bridge.JavaOnlyArray;
+import com.facebook.react.bridge.JavaOnlyMap;
 import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.uimanager.UIManagerModule;
 import com.facebook.react.uimanager.DisplayMetricsHolder;
@@ -68,13 +68,13 @@ public class RootViewTest {
     PowerMockito.when(Arguments.createArray()).thenAnswer(new Answer<Object>() {
       @Override
       public Object answer(InvocationOnMock invocation) throws Throwable {
-        return new SimpleArray();
+        return new JavaOnlyArray();
       }
     });
     PowerMockito.when(Arguments.createMap()).thenAnswer(new Answer<Object>() {
       @Override
       public Object answer(InvocationOnMock invocation) throws Throwable {
-        return new SimpleMap();
+        return new JavaOnlyMap();
       }
     });
 
@@ -120,17 +120,17 @@ public class RootViewTest {
 
     downEventCaptor.getValue().dispatch(eventEmitterModuleMock);
 
-    ArgumentCaptor<SimpleArray> downActionTouchesArgCaptor =
-        ArgumentCaptor.forClass(SimpleArray.class);
+    ArgumentCaptor<JavaOnlyArray> downActionTouchesArgCaptor =
+        ArgumentCaptor.forClass(JavaOnlyArray.class);
     verify(eventEmitterModuleMock).receiveTouches(
         eq("topTouchStart"),
         downActionTouchesArgCaptor.capture(),
-        any(SimpleArray.class));
+        any(JavaOnlyArray.class));
     verifyNoMoreInteractions(eventEmitterModuleMock);
 
     assertThat(downActionTouchesArgCaptor.getValue().size()).isEqualTo(1);
     assertThat(downActionTouchesArgCaptor.getValue().getMap(0)).isEqualTo(
-        SimpleMap.of(
+        JavaOnlyMap.of(
             "pageX",
             0.,
             "pageY",
@@ -150,8 +150,8 @@ public class RootViewTest {
     reset(eventEmitterModuleMock, eventDispatcher);
 
     ArgumentCaptor<Event> upEventCaptor = ArgumentCaptor.forClass(Event.class);
-    ArgumentCaptor<SimpleArray> upActionTouchesArgCaptor =
-        ArgumentCaptor.forClass(SimpleArray.class);
+    ArgumentCaptor<JavaOnlyArray> upActionTouchesArgCaptor =
+        ArgumentCaptor.forClass(JavaOnlyArray.class);
 
     rootView.onTouchEvent(
         MotionEvent.obtain(50, ts, MotionEvent.ACTION_UP, 0, 0, 0));
@@ -167,7 +167,7 @@ public class RootViewTest {
 
     assertThat(upActionTouchesArgCaptor.getValue().size()).isEqualTo(1);
     assertThat(upActionTouchesArgCaptor.getValue().getMap(0)).isEqualTo(
-        SimpleMap.of(
+        JavaOnlyMap.of(
             "pageX",
             0.,
             "pageY",

--- a/ReactAndroid/src/test/java/com/facebook/react/modules/dialog/DialogModuleTest.java
+++ b/ReactAndroid/src/test/java/com/facebook/react/modules/dialog/DialogModuleTest.java
@@ -15,7 +15,7 @@ import android.app.Activity;
 
 import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.ReactApplicationContext;
-import com.facebook.react.bridge.SimpleMap;
+import com.facebook.react.bridge.JavaOnlyMap;
 
 import org.junit.After;
 import org.junit.Before;
@@ -84,7 +84,7 @@ public class DialogModuleTest {
 
   @Test
   public void testAllOptions() {
-    final SimpleMap options = new SimpleMap();
+    final JavaOnlyMap options = new JavaOnlyMap();
     options.putString("title", "Title");
     options.putString("message", "Message");
     options.putString("buttonPositive", "OK");
@@ -104,7 +104,7 @@ public class DialogModuleTest {
 
   @Test
   public void testCallbackPositive() {
-    final SimpleMap options = new SimpleMap();
+    final JavaOnlyMap options = new JavaOnlyMap();
     options.putString("buttonPositive", "OK");
 
     final SimpleCallback actionCallback = new SimpleCallback();
@@ -120,7 +120,7 @@ public class DialogModuleTest {
 
   @Test
   public void testCallbackNegative() {
-    final SimpleMap options = new SimpleMap();
+    final JavaOnlyMap options = new JavaOnlyMap();
     options.putString("buttonNegative", "Cancel");
 
     final SimpleCallback actionCallback = new SimpleCallback();
@@ -136,7 +136,7 @@ public class DialogModuleTest {
 
   @Test
   public void testCallbackNeutral() {
-    final SimpleMap options = new SimpleMap();
+    final JavaOnlyMap options = new JavaOnlyMap();
     options.putString("buttonNeutral", "Later");
 
     final SimpleCallback actionCallback = new SimpleCallback();
@@ -152,7 +152,7 @@ public class DialogModuleTest {
 
   @Test
   public void testCallbackDismiss() {
-    final SimpleMap options = new SimpleMap();
+    final JavaOnlyMap options = new JavaOnlyMap();
 
     final SimpleCallback actionCallback = new SimpleCallback();
     mDialogModule.showAlert(options, null, actionCallback);

--- a/ReactAndroid/src/test/java/com/facebook/react/modules/network/NetworkingModuleTest.java
+++ b/ReactAndroid/src/test/java/com/facebook/react/modules/network/NetworkingModuleTest.java
@@ -16,8 +16,8 @@ import java.util.List;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContext;
-import com.facebook.react.bridge.SimpleArray;
-import com.facebook.react.bridge.SimpleMap;
+import com.facebook.react.bridge.JavaOnlyArray;
+import com.facebook.react.bridge.JavaOnlyMap;
 import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.modules.core.DeviceEventManagerModule.RCTDeviceEventEmitter;
@@ -91,7 +91,7 @@ public class NetworkingModuleTest {
         "GET",
         "http://somedomain/foo",
         0,
-        SimpleArray.of(),
+        JavaOnlyArray.of(),
         null,
         true,
         0);
@@ -113,7 +113,7 @@ public class NetworkingModuleTest {
     OkHttpClient httpClient = mock(OkHttpClient.class);
     NetworkingModule networkingModule = new NetworkingModule(context, "", httpClient);
 
-    List<SimpleArray> invalidHeaders = Arrays.asList(SimpleArray.of("foo"));
+    List<JavaOnlyArray> invalidHeaders = Arrays.asList(JavaOnlyArray.of("foo"));
 
     mockEvents();
 
@@ -121,7 +121,7 @@ public class NetworkingModuleTest {
         "GET",
         "http://somedoman/foo",
         0,
-        SimpleArray.from(invalidHeaders),
+        JavaOnlyArray.from(invalidHeaders),
         null,
         true,
         0);
@@ -138,7 +138,7 @@ public class NetworkingModuleTest {
     OkHttpClient httpClient = mock(OkHttpClient.class);
     NetworkingModule networkingModule = new NetworkingModule(context, "", httpClient);
 
-    SimpleMap body = new SimpleMap();
+    JavaOnlyMap body = new JavaOnlyMap();
     body.putString("string", "This is request body");
 
     mockEvents();
@@ -147,7 +147,7 @@ public class NetworkingModuleTest {
         "POST",
         "http://somedomain/bar",
         0,
-        SimpleArray.of(),
+        JavaOnlyArray.of(),
         body,
         true,
         0);
@@ -170,7 +170,7 @@ public class NetworkingModuleTest {
         new Answer<WritableArray>() {
           @Override
           public WritableArray answer(InvocationOnMock invocation) throws Throwable {
-            return new SimpleArray();
+            return new JavaOnlyArray();
           }
         });
 
@@ -178,7 +178,7 @@ public class NetworkingModuleTest {
         new Answer<WritableMap>() {
           @Override
           public WritableMap answer(InvocationOnMock invocation) throws Throwable {
-            return new SimpleMap();
+            return new JavaOnlyMap();
           }
         });
   }
@@ -196,14 +196,14 @@ public class NetworkingModuleTest {
 
     NetworkingModule networkingModule = new NetworkingModule(null, "", httpClient);
 
-    SimpleMap body = new SimpleMap();
+    JavaOnlyMap body = new JavaOnlyMap();
     body.putString("string", "This is request body");
 
     networkingModule.sendRequest(
         "POST",
         "http://somedomain/bar",
         0,
-        SimpleArray.of(SimpleArray.of("Content-Type", "text/plain")),
+        JavaOnlyArray.of(JavaOnlyArray.of("Content-Type", "text/plain")),
         body,
         true,
         0);
@@ -232,15 +232,15 @@ public class NetworkingModuleTest {
     });
     NetworkingModule networkingModule = new NetworkingModule(null, "", httpClient);
 
-    List<SimpleArray> headers = Arrays.asList(
-        SimpleArray.of("Accept", "text/plain"),
-        SimpleArray.of("User-Agent", "React test agent/1.0"));
+    List<JavaOnlyArray> headers = Arrays.asList(
+        JavaOnlyArray.of("Accept", "text/plain"),
+        JavaOnlyArray.of("User-Agent", "React test agent/1.0"));
 
     networkingModule.sendRequest(
         "GET",
         "http://someurl/baz",
         0,
-        SimpleArray.from(headers),
+        JavaOnlyArray.from(headers),
         null,
         true,
         0);
@@ -260,15 +260,15 @@ public class NetworkingModuleTest {
     when(RequestBodyUtil.create(any(MediaType.class), any(InputStream.class)))
         .thenReturn(mock(RequestBody.class));
 
-    SimpleMap body = new SimpleMap();
-    SimpleArray formData = new SimpleArray();
-    SimpleMap bodyPart = new SimpleMap();
+    JavaOnlyMap body = new JavaOnlyMap();
+    JavaOnlyArray formData = new JavaOnlyArray();
+    JavaOnlyMap bodyPart = new JavaOnlyMap();
     bodyPart.putString("string", "value");
     bodyPart.putArray(
         "headers",
-        SimpleArray.from(
+        JavaOnlyArray.from(
             Arrays.asList(
-                SimpleArray.of("content-disposition", "name"))));
+                JavaOnlyArray.of("content-disposition", "name"))));
     formData.pushMap(bodyPart);
     body.putArray("formData", formData);
 
@@ -287,7 +287,7 @@ public class NetworkingModuleTest {
         "POST",
         "http://someurl/uploadFoo",
         0,
-        new SimpleArray(),
+        new JavaOnlyArray(),
         body,
         true,
         0);
@@ -313,20 +313,20 @@ public class NetworkingModuleTest {
     when(RequestBodyUtil.create(any(MediaType.class), any(InputStream.class)))
         .thenReturn(mock(RequestBody.class));
 
-    List<SimpleArray> headers = Arrays.asList(
-            SimpleArray.of("Accept", "text/plain"),
-            SimpleArray.of("User-Agent", "React test agent/1.0"),
-            SimpleArray.of("content-type", "multipart/form-data"));
+    List<JavaOnlyArray> headers = Arrays.asList(
+            JavaOnlyArray.of("Accept", "text/plain"),
+            JavaOnlyArray.of("User-Agent", "React test agent/1.0"),
+            JavaOnlyArray.of("content-type", "multipart/form-data"));
 
-    SimpleMap body = new SimpleMap();
-    SimpleArray formData = new SimpleArray();
-    SimpleMap bodyPart = new SimpleMap();
+    JavaOnlyMap body = new JavaOnlyMap();
+    JavaOnlyArray formData = new JavaOnlyArray();
+    JavaOnlyMap bodyPart = new JavaOnlyMap();
     bodyPart.putString("string", "value");
     bodyPart.putArray(
         "headers",
-        SimpleArray.from(
+        JavaOnlyArray.from(
             Arrays.asList(
-                SimpleArray.of("content-disposition", "name"))));
+                JavaOnlyArray.of("content-disposition", "name"))));
     formData.pushMap(bodyPart);
     body.putArray("formData", formData);
 
@@ -345,7 +345,7 @@ public class NetworkingModuleTest {
         "POST",
         "http://someurl/uploadFoo",
         0,
-        SimpleArray.from(headers),
+        JavaOnlyArray.from(headers),
         body,
         true,
         0);
@@ -399,30 +399,30 @@ public class NetworkingModuleTest {
           }
         });
 
-    List<SimpleArray> headers = Arrays.asList(
-            SimpleArray.of("content-type", "multipart/form-data"));
+    List<JavaOnlyArray> headers = Arrays.asList(
+            JavaOnlyArray.of("content-type", "multipart/form-data"));
 
-    SimpleMap body = new SimpleMap();
-    SimpleArray formData = new SimpleArray();
+    JavaOnlyMap body = new JavaOnlyMap();
+    JavaOnlyArray formData = new JavaOnlyArray();
     body.putArray("formData", formData);
 
-    SimpleMap bodyPart = new SimpleMap();
+    JavaOnlyMap bodyPart = new JavaOnlyMap();
     bodyPart.putString("string", "locale");
     bodyPart.putArray(
         "headers",
-        SimpleArray.from(
+        JavaOnlyArray.from(
             Arrays.asList(
-                          SimpleArray.of("content-disposition", "user"))));
+                          JavaOnlyArray.of("content-disposition", "user"))));
     formData.pushMap(bodyPart);
 
-    SimpleMap imageBodyPart = new SimpleMap();
+    JavaOnlyMap imageBodyPart = new JavaOnlyMap();
     imageBodyPart.putString("uri", "imageUri");
     imageBodyPart.putArray(
         "headers",
-        SimpleArray.from(
+        JavaOnlyArray.from(
             Arrays.asList(
-                SimpleArray.of("content-type", "image/jpg"),
-                SimpleArray.of("content-disposition", "filename=photo.jpg"))));
+                JavaOnlyArray.of("content-type", "image/jpg"),
+                JavaOnlyArray.of("content-disposition", "filename=photo.jpg"))));
     formData.pushMap(imageBodyPart);
 
     OkHttpClient httpClient = mock(OkHttpClient.class);
@@ -440,7 +440,7 @@ public class NetworkingModuleTest {
         "POST",
         "http://someurl/uploadFoo",
         0,
-        SimpleArray.from(headers),
+        JavaOnlyArray.from(headers),
         body,
         true,
         0);

--- a/ReactAndroid/src/test/java/com/facebook/react/modules/storage/AsyncStorageModuleTest.java
+++ b/ReactAndroid/src/test/java/com/facebook/react/modules/storage/AsyncStorageModuleTest.java
@@ -21,8 +21,8 @@ import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactTestHelper;
-import com.facebook.react.bridge.SimpleArray;
-import com.facebook.react.bridge.SimpleMap;
+import com.facebook.react.bridge.JavaOnlyArray;
+import com.facebook.react.bridge.JavaOnlyMap;
 import com.facebook.react.modules.storage.AsyncStorageModule;
 import com.facebook.react.modules.storage.ReactDatabaseSupplier;
 
@@ -58,7 +58,7 @@ import static org.fest.assertions.api.Assertions.assertThat;
 public class AsyncStorageModuleTest {
 
   private AsyncStorageModule mStorage;
-  private SimpleArray mEmptyArray;
+  private JavaOnlyArray mEmptyArray;
 
   @Rule
   public PowerMockRule rule = new PowerMockRule();
@@ -70,7 +70,7 @@ public class AsyncStorageModuleTest {
         new Answer<Object>() {
      @Override
      public Object answer(InvocationOnMock invocation) throws Throwable {
-       return new SimpleArray();
+       return new JavaOnlyArray();
      }
    });
 
@@ -78,13 +78,13 @@ public class AsyncStorageModuleTest {
         new Answer<Object>() {
        @Override
        public Object answer(InvocationOnMock invocation) throws Throwable {
-         return new SimpleMap();
+         return new JavaOnlyMap();
        }
      });
 
     // don't use Robolectric before initializing mocks
     mStorage = new AsyncStorageModule(ReactTestHelper.createCatalystContextForTest());
-    mEmptyArray = new SimpleArray();
+    mEmptyArray = new JavaOnlyArray();
   }
 
   @After
@@ -100,7 +100,7 @@ public class AsyncStorageModuleTest {
     final String fakeKey = "fakeKey";
     final String value1 = "bar1";
     final String value2 = "bar2";
-    SimpleArray keyValues = new SimpleArray();
+    JavaOnlyArray keyValues = new JavaOnlyArray();
     keyValues.pushArray(getArray(key1, value1));
     keyValues.pushArray(getArray(key2, value2));
 
@@ -108,7 +108,7 @@ public class AsyncStorageModuleTest {
     mStorage.multiSet(keyValues, setCallback);
     Mockito.verify(setCallback, Mockito.times(1)).invoke();
 
-    SimpleArray keys = new SimpleArray();
+    JavaOnlyArray keys = new JavaOnlyArray();
     keys.pushString(key1);
     keys.pushString(key2);
 
@@ -117,7 +117,7 @@ public class AsyncStorageModuleTest {
     Mockito.verify(getCallback, Mockito.times(1)).invoke(null, keyValues);
 
     keys.pushString(fakeKey);
-    SimpleArray row3 = new SimpleArray();
+    JavaOnlyArray row3 = new JavaOnlyArray();
     row3.pushString(fakeKey);
     row3.pushString(null);
     keyValues.pushArray(row3);
@@ -134,12 +134,12 @@ public class AsyncStorageModuleTest {
     final String value1 = "bar1";
     final String value2 = "bar2";
 
-    SimpleArray keyValues = new SimpleArray();
+    JavaOnlyArray keyValues = new JavaOnlyArray();
     keyValues.pushArray(getArray(key1, value1));
     keyValues.pushArray(getArray(key2, value2));
     mStorage.multiSet(keyValues, mock(Callback.class));
 
-    SimpleArray keys = new SimpleArray();
+    JavaOnlyArray keys = new JavaOnlyArray();
     keys.pushString(key1);
     keys.pushString(key2);
 
@@ -173,12 +173,12 @@ public class AsyncStorageModuleTest {
     value.put("foo3", 1001);
     value.put("foo4", createJSONObject("key1", "randomValueThatWillNeverBeUsed"));
 
-    mStorage.multiSet(SimpleArray.of(getArray(mergeKey, value.toString())), mock(Callback.class));
+    mStorage.multiSet(JavaOnlyArray.of(getArray(mergeKey, value.toString())), mock(Callback.class));
     {
       Callback callback = mock(Callback.class);
       mStorage.multiGet(getArray(mergeKey), callback);
       Mockito.verify(callback, Mockito.times(1))
-          .invoke(null, SimpleArray.of(getArray(mergeKey, value.toString())));
+          .invoke(null, JavaOnlyArray.of(getArray(mergeKey, value.toString())));
     }
 
     value.put("foo1", 1001);
@@ -193,29 +193,29 @@ public class AsyncStorageModuleTest {
     newValue2.put("foo2", createJSONObject("key1", "val3"));
 
     mStorage.multiMerge(
-        SimpleArray.of(
-            SimpleArray.of(mergeKey, value.toString()),
-            SimpleArray.of(mergeKey, newValue.toString()),
-            SimpleArray.of(mergeKey, newValue2.toString())),
+        JavaOnlyArray.of(
+            JavaOnlyArray.of(mergeKey, value.toString()),
+            JavaOnlyArray.of(mergeKey, newValue.toString()),
+            JavaOnlyArray.of(mergeKey, newValue2.toString())),
         mock(Callback.class));
 
     value.put("foo2", createJSONObject("key1", "val3", "key2", "val2"));
     Callback callback = mock(Callback.class);
     mStorage.multiGet(getArray(mergeKey), callback);
     Mockito.verify(callback, Mockito.times(1))
-        .invoke(null, SimpleArray.of(getArray(mergeKey, value.toString())));
+        .invoke(null, JavaOnlyArray.of(getArray(mergeKey, value.toString())));
   }
 
   @Test
   public void testGetAllKeys() {
     final String[] keys = {"foo", "foo2"};
     final String[] values = {"bar", "bar2"};
-    SimpleArray keyValues = new SimpleArray();
+    JavaOnlyArray keyValues = new JavaOnlyArray();
     keyValues.pushArray(getArray(keys[0], values[0]));
     keyValues.pushArray(getArray(keys[1], values[1]));
     mStorage.multiSet(keyValues, mock(Callback.class));
 
-    SimpleArray storedKeys = new SimpleArray();
+    JavaOnlyArray storedKeys = new JavaOnlyArray();
     storedKeys.pushString(keys[0]);
     storedKeys.pushString(keys[1]);
 
@@ -237,7 +237,7 @@ public class AsyncStorageModuleTest {
 
   @Test
   public void testClear() {
-    SimpleArray keyValues = new SimpleArray();
+    JavaOnlyArray keyValues = new JavaOnlyArray();
     keyValues.pushArray(getArray("foo", "foo2"));
     keyValues.pushArray(getArray("bar", "bar2"));
     mStorage.multiSet(keyValues, mock(Callback.class));
@@ -259,14 +259,14 @@ public class AsyncStorageModuleTest {
     // and returns null for missing keys
     final int magicalNumber = 343;
 
-    SimpleArray keyValues = new SimpleArray();
+    JavaOnlyArray keyValues = new JavaOnlyArray();
     for (int i = 0; i < keyCount; i++) {
       if (i % magicalNumber > 0) {
         keyValues.pushArray(getArray("key" + i, "value" + i));
       }
     }
     mStorage.multiSet(keyValues, mock(Callback.class));
-    SimpleArray keys = new SimpleArray();
+    JavaOnlyArray keys = new JavaOnlyArray();
     for (int i = 0; i < keyCount; i++) {
       keys.pushString("key" + i);
     }
@@ -275,7 +275,7 @@ public class AsyncStorageModuleTest {
           @Override
           public void invoke(Object... args) {
             assertThat(args.length).isEqualTo(2);
-            SimpleArray resultArray = (SimpleArray) args[1];
+            JavaOnlyArray resultArray = (JavaOnlyArray) args[1];
 
             assertThat(resultArray.size()).isEqualTo(keyCount);
             boolean keyReceived[] = new boolean[keyCount];
@@ -297,7 +297,7 @@ public class AsyncStorageModuleTest {
 
     // Test removal in same test, since it's costly to set up the test again.
     // Remove only odd keys
-    SimpleArray keyRemoves = new SimpleArray();
+    JavaOnlyArray keyRemoves = new JavaOnlyArray();
     for (int i = 0; i < keyCount; i++) {
       if (i % 2 > 0) {
         keyRemoves.pushString("key" + i);
@@ -308,7 +308,7 @@ public class AsyncStorageModuleTest {
         new Callback() {
           @Override
           public void invoke(Object... args) {
-            SimpleArray resultArray = (SimpleArray) args[1];
+            JavaOnlyArray resultArray = (JavaOnlyArray) args[1];
             assertThat(resultArray.size()).isEqualTo(499);
             for (int i = 0; i < resultArray.size(); i++) {
               String key = resultArray.getString(i).substring(3);
@@ -334,8 +334,8 @@ public class AsyncStorageModuleTest {
     return new JSONObject(map);
   }
 
-  private SimpleArray getArray(String... values) {
-    SimpleArray array = new SimpleArray();
+  private JavaOnlyArray getArray(String... values) {
+    JavaOnlyArray array = new JavaOnlyArray();
     for (String value : values) {
       array.pushString(value);
     }

--- a/ReactAndroid/src/test/java/com/facebook/react/modules/timing/TimingModuleTest.java
+++ b/ReactAndroid/src/test/java/com/facebook/react/modules/timing/TimingModuleTest.java
@@ -14,7 +14,7 @@ import android.view.Choreographer;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.CatalystInstance;
-import com.facebook.react.bridge.SimpleArray;
+import com.facebook.react.bridge.JavaOnlyArray;
 import com.facebook.react.uimanager.ReactChoreographer;
 import com.facebook.react.common.SystemClock;
 import com.facebook.react.modules.core.JSTimersExecution;
@@ -65,7 +65,7 @@ public class TimingModuleTest {
         new Answer<Object>() {
           @Override
           public Object answer(InvocationOnMock invocation) throws Throwable {
-            return new SimpleArray();
+            return new JavaOnlyArray();
           }
         });
 
@@ -109,7 +109,7 @@ public class TimingModuleTest {
     mTiming.onHostResume();
     mTiming.createTimer(1, 0, 0, false);
     stepChoreographerFrame();
-    verify(mJSTimersMock).callTimers(SimpleArray.of(1));
+    verify(mJSTimersMock).callTimers(JavaOnlyArray.of(1));
     reset(mJSTimersMock);
     stepChoreographerFrame();
     verifyNoMoreInteractions(mJSTimersMock);
@@ -120,11 +120,11 @@ public class TimingModuleTest {
     mTiming.createTimer(100, 0, 0, true);
     mTiming.onHostResume();
     stepChoreographerFrame();
-    verify(mJSTimersMock).callTimers(SimpleArray.of(100));
+    verify(mJSTimersMock).callTimers(JavaOnlyArray.of(100));
 
     reset(mJSTimersMock);
     stepChoreographerFrame();
-    verify(mJSTimersMock).callTimers(SimpleArray.of(100));
+    verify(mJSTimersMock).callTimers(JavaOnlyArray.of(100));
   }
 
   @Test
@@ -133,7 +133,7 @@ public class TimingModuleTest {
     mTiming.createTimer(105, 0, 0, true);
 
     stepChoreographerFrame();
-    verify(mJSTimersMock).callTimers(SimpleArray.of(105));
+    verify(mJSTimersMock).callTimers(JavaOnlyArray.of(105));
 
     reset(mJSTimersMock);
     mTiming.deleteTimer(105);
@@ -147,7 +147,7 @@ public class TimingModuleTest {
     mTiming.createTimer(41, 0, 0, true);
 
     stepChoreographerFrame();
-    verify(mJSTimersMock).callTimers(SimpleArray.of(41));
+    verify(mJSTimersMock).callTimers(JavaOnlyArray.of(41));
 
     reset(mJSTimersMock);
     mTiming.onHostPause();
@@ -157,7 +157,7 @@ public class TimingModuleTest {
     reset(mJSTimersMock);
     mTiming.onHostResume();
     stepChoreographerFrame();
-    verify(mJSTimersMock).callTimers(SimpleArray.of(41));
+    verify(mJSTimersMock).callTimers(JavaOnlyArray.of(41));
   }
 
   private static class PostFrameCallbackHandler implements Answer<Void> {

--- a/ReactAndroid/src/test/java/com/facebook/react/uimanager/LayoutPropertyApplicatorTest.java
+++ b/ReactAndroid/src/test/java/com/facebook/react/uimanager/LayoutPropertyApplicatorTest.java
@@ -17,7 +17,7 @@ import com.facebook.csslayout.CSSFlexDirection;
 import com.facebook.csslayout.CSSJustify;
 import com.facebook.csslayout.CSSPositionType;
 import com.facebook.csslayout.Spacing;
-import com.facebook.react.bridge.SimpleMap;
+import com.facebook.react.bridge.JavaOnlyMap;
 
 import org.junit.After;
 import org.junit.Before;
@@ -63,7 +63,7 @@ public class LayoutPropertyApplicatorTest {
   }
 
   public ReactStylesDiffMap buildStyles(Object... keysAndValues) {
-    return new ReactStylesDiffMap(SimpleMap.of(keysAndValues));
+    return new ReactStylesDiffMap(JavaOnlyMap.of(keysAndValues));
   }
 
   @Test

--- a/ReactAndroid/src/test/java/com/facebook/react/uimanager/ReactPropAnnotationSetterTest.java
+++ b/ReactAndroid/src/test/java/com/facebook/react/uimanager/ReactPropAnnotationSetterTest.java
@@ -14,8 +14,8 @@ import android.view.View;
 import com.facebook.react.bridge.JSApplicationIllegalArgumentException;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
-import com.facebook.react.bridge.SimpleArray;
-import com.facebook.react.bridge.SimpleMap;
+import com.facebook.react.bridge.JavaOnlyArray;
+import com.facebook.react.bridge.JavaOnlyMap;
 import com.facebook.react.uimanager.annotations.ReactProp;
 import com.facebook.react.uimanager.annotations.ReactPropGroup;
 
@@ -201,7 +201,7 @@ public class ReactPropAnnotationSetterTest {
   }
 
   public static ReactStylesDiffMap buildStyles(Object... keysAndValues) {
-    return new ReactStylesDiffMap(SimpleMap.of(keysAndValues));
+    return new ReactStylesDiffMap(JavaOnlyMap.of(keysAndValues));
   }
 
   private ViewManagerUnderTest mViewManager;
@@ -356,7 +356,7 @@ public class ReactPropAnnotationSetterTest {
 
   @Test
   public void testArraySetter() {
-    ReadableArray array = new SimpleArray();
+    ReadableArray array = new JavaOnlyArray();
     mViewManager.updateProperties(null, buildStyles("arrayProp", array));
     verify(mUpdatesReceiverMock).onArraySetterCalled(array);
     verifyNoMoreInteractions(mUpdatesReceiverMock);
@@ -370,7 +370,7 @@ public class ReactPropAnnotationSetterTest {
 
   @Test
   public void testMapSetter() {
-    ReadableMap map = new SimpleMap();
+    ReadableMap map = new JavaOnlyMap();
     mViewManager.updateProperties(null, buildStyles("mapProp", map));
     verify(mUpdatesReceiverMock).onMapSetterCalled(map);
     verifyNoMoreInteractions(mUpdatesReceiverMock);
@@ -458,7 +458,7 @@ public class ReactPropAnnotationSetterTest {
 
   @Test(expected = JSApplicationIllegalArgumentException.class)
   public void testFailToUpdateBoolPropWithMap() {
-    mViewManager.updateProperties(null, buildStyles("boolProp", new SimpleMap()));
+    mViewManager.updateProperties(null, buildStyles("boolProp", new JavaOnlyMap()));
   }
 
   @Test(expected = JSApplicationIllegalArgumentException.class)
@@ -483,7 +483,7 @@ public class ReactPropAnnotationSetterTest {
 
   @Test(expected = JSApplicationIllegalArgumentException.class)
   public void testFailToUpdateMapPropWithArray() {
-    mViewManager.updateProperties(null, buildStyles("mapProp", new SimpleArray()));
+    mViewManager.updateProperties(null, buildStyles("mapProp", new JavaOnlyArray()));
   }
 
   @Test(expected = JSApplicationIllegalArgumentException.class)

--- a/ReactAndroid/src/test/java/com/facebook/react/uimanager/SimpleViewPropertyTest.java
+++ b/ReactAndroid/src/test/java/com/facebook/react/uimanager/SimpleViewPropertyTest.java
@@ -17,7 +17,7 @@ import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.touch.JSResponderHandler;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactTestHelper;
-import com.facebook.react.bridge.SimpleMap;
+import com.facebook.react.bridge.JavaOnlyMap;
 import com.facebook.react.bridge.CatalystInstance;
 import com.facebook.react.uimanager.annotations.ReactProp;
 
@@ -79,7 +79,7 @@ public class SimpleViewPropertyTest {
   }
 
   public ReactStylesDiffMap buildStyles(Object... keysAndValues) {
-    return new ReactStylesDiffMap(SimpleMap.of(keysAndValues));
+    return new ReactStylesDiffMap(JavaOnlyMap.of(keysAndValues));
   }
 
   @Test

--- a/ReactAndroid/src/test/java/com/facebook/react/uimanager/UIManagerModuleTest.java
+++ b/ReactAndroid/src/test/java/com/facebook/react/uimanager/UIManagerModuleTest.java
@@ -26,8 +26,8 @@ import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.CatalystInstance;
-import com.facebook.react.bridge.SimpleArray;
-import com.facebook.react.bridge.SimpleMap;
+import com.facebook.react.bridge.JavaOnlyArray;
+import com.facebook.react.bridge.JavaOnlyMap;
 import com.facebook.react.views.text.ReactRawTextManager;
 import com.facebook.react.views.text.ReactTextShadowNode;
 import com.facebook.react.views.text.ReactTextViewManager;
@@ -80,13 +80,13 @@ public class UIManagerModuleTest {
     PowerMockito.when(Arguments.createArray()).thenAnswer(new Answer<Object>() {
       @Override
       public Object answer(InvocationOnMock invocation) throws Throwable {
-        return new SimpleArray();
+        return new JavaOnlyArray();
       }
     });
     PowerMockito.when(Arguments.createMap()).thenAnswer(new Answer<Object>() {
       @Override
       public Object answer(InvocationOnMock invocation) throws Throwable {
-        return new SimpleMap();
+        return new JavaOnlyMap();
       }
     });
     PowerMockito.when(ReactChoreographer.getInstance()).thenReturn(choreographerMock);
@@ -136,7 +136,7 @@ public class UIManagerModuleTest {
     uiManager.updateView(
         rawTextTag,
         ReactRawTextManager.REACT_CLASS,
-        SimpleMap.of(ReactTextShadowNode.PROP_TEXT, "New text"));
+        JavaOnlyMap.of(ReactTextShadowNode.PROP_TEXT, "New text"));
 
     uiManager.onBatchComplete();
     executePendingChoreographerCallbacks();
@@ -158,27 +158,27 @@ public class UIManagerModuleTest {
         viewTag,
         ReactViewManager.REACT_CLASS,
         rootTag,
-        SimpleMap.of("collapsable", false));
+        JavaOnlyMap.of("collapsable", false));
     uiManager.createView(
         subViewTag,
         ReactViewManager.REACT_CLASS,
         rootTag,
-        SimpleMap.of("collapsable", false));
+        JavaOnlyMap.of("collapsable", false));
 
     uiManager.manageChildren(
         viewTag,
         null,
         null,
-        SimpleArray.of(subViewTag),
-        SimpleArray.of(0),
+        JavaOnlyArray.of(subViewTag),
+        JavaOnlyArray.of(0),
         null);
 
     uiManager.manageChildren(
         rootTag,
         null,
         null,
-        SimpleArray.of(viewTag),
-        SimpleArray.of(0),
+        JavaOnlyArray.of(viewTag),
+        JavaOnlyArray.of(0),
         null);
 
     uiManager.onBatchComplete();
@@ -206,8 +206,8 @@ public class UIManagerModuleTest {
 
     uiManager.manageChildren(
         hierarchy.rootView,
-        SimpleArray.of(1, 0, 2),
-        SimpleArray.of(0, 2, 1),
+        JavaOnlyArray.of(1, 0, 2),
+        JavaOnlyArray.of(0, 2, 1),
         null,
         null,
         null);
@@ -237,7 +237,7 @@ public class UIManagerModuleTest {
         null,
         null,
         null,
-        SimpleArray.of(0, 3));
+        JavaOnlyArray.of(0, 3));
 
     uiManager.onBatchComplete();
     executePendingChoreographerCallbacks();
@@ -259,11 +259,11 @@ public class UIManagerModuleTest {
 
     uiManager.manageChildren(
         hierarchy.rootView,
-        SimpleArray.of(3),
-        SimpleArray.of(1),
+        JavaOnlyArray.of(3),
+        JavaOnlyArray.of(1),
         null,
         null,
-        SimpleArray.of(1));
+        JavaOnlyArray.of(1));
 
     uiManager.onBatchComplete();
     executePendingChoreographerCallbacks();
@@ -282,11 +282,11 @@ public class UIManagerModuleTest {
 
     uiManager.manageChildren(
         hierarchy.rootView,
-        SimpleArray.of(3),
-        SimpleArray.of(1),
+        JavaOnlyArray.of(3),
+        JavaOnlyArray.of(1),
         null,
         null,
-        SimpleArray.of(3));
+        JavaOnlyArray.of(3));
 
     uiManager.onBatchComplete();
     executePendingChoreographerCallbacks();
@@ -303,7 +303,7 @@ public class UIManagerModuleTest {
         null,
         null,
         null,
-        SimpleArray.of(3, 3));
+        JavaOnlyArray.of(3, 3));
 
     uiManager.onBatchComplete();
     executePendingChoreographerCallbacks();
@@ -319,7 +319,7 @@ public class UIManagerModuleTest {
         textViewTag,
         ReactTextViewManager.REACT_CLASS,
         hierarchy.rootView,
-        SimpleMap.of("collapsable", false));
+        JavaOnlyMap.of("collapsable", false));
 
     View expectedViewAt0 = hierarchy.nativeRootView.getChildAt(0);
     View expectedViewAt1 = hierarchy.nativeRootView.getChildAt(3);
@@ -328,10 +328,10 @@ public class UIManagerModuleTest {
 
     uiManager.manageChildren(
         hierarchy.rootView,
-        SimpleArray.of(1, 2, 3),
-        SimpleArray.of(3, 4, 1),
-        SimpleArray.of(textViewTag),
-        SimpleArray.of(2),
+        JavaOnlyArray.of(1, 2, 3),
+        JavaOnlyArray.of(3, 4, 1),
+        JavaOnlyArray.of(textViewTag),
+        JavaOnlyArray.of(2),
         null);
 
     uiManager.onBatchComplete();
@@ -356,8 +356,8 @@ public class UIManagerModuleTest {
 
     uiManager.manageChildren(
         hierarchy.rootView,
-        SimpleArray.of(1, 2),
-        SimpleArray.of(2, 1),
+        JavaOnlyArray.of(1, 2),
+        JavaOnlyArray.of(2, 1),
         null,
         null,
         null);
@@ -389,7 +389,7 @@ public class UIManagerModuleTest {
         null,
         null,
         null,
-        SimpleArray.of(1));
+        JavaOnlyArray.of(1));
 
     uiManager.onBatchComplete();
     executePendingChoreographerCallbacks();
@@ -412,15 +412,15 @@ public class UIManagerModuleTest {
         newViewTag,
         ReactViewManager.REACT_CLASS,
         hierarchy.rootView,
-        SimpleMap
+        JavaOnlyMap
             .of("left", 10.0, "top", 20.0, "width", 30.0, "height", 40.0, "collapsable", false));
 
     uiManager.manageChildren(
         hierarchy.rootView,
         null,
         null,
-        SimpleArray.of(newViewTag),
-        SimpleArray.of(4),
+        JavaOnlyArray.of(newViewTag),
+        JavaOnlyArray.of(4),
         null);
 
     uiManager.onBatchComplete();
@@ -448,20 +448,20 @@ public class UIManagerModuleTest {
         newViewTag,
         ReactViewManager.REACT_CLASS,
         hierarchy.rootView,
-        SimpleMap.of("collapsable", false));
+        JavaOnlyMap.of("collapsable", false));
 
     uiManager.manageChildren(
         hierarchy.rootView,
         null,
         null,
-        SimpleArray.of(newViewTag),
-        SimpleArray.of(4),
+        JavaOnlyArray.of(newViewTag),
+        JavaOnlyArray.of(4),
         null);
 
     uiManager.updateView(
         newViewTag,
         ReactViewManager.REACT_CLASS,
-        SimpleMap.of("backgroundColor", Color.RED));
+        JavaOnlyMap.of("backgroundColor", Color.RED));
 
     uiManager.manageChildren(
         hierarchy.rootView,
@@ -469,7 +469,7 @@ public class UIManagerModuleTest {
         null,
         null,
         null,
-        SimpleArray.of(4));
+        JavaOnlyArray.of(4));
 
     uiManager.onBatchComplete();
     executePendingChoreographerCallbacks();
@@ -516,7 +516,7 @@ public class UIManagerModuleTest {
     uiManager.updateView(
         hierarchy.view0,
         ReactViewManager.REACT_CLASS,
-        SimpleMap.of("left", 10.0, "top", 20.0, "width", 30.0, "height", 40.0));
+        JavaOnlyMap.of("left", 10.0, "top", 20.0, "width", 30.0, "height", 40.0));
     uiManager.onBatchComplete();
     executePendingChoreographerCallbacks();
     assertThat(view0.getLeft()).isGreaterThan(2);
@@ -527,7 +527,7 @@ public class UIManagerModuleTest {
     uiManager.updateView(
         hierarchy.view0,
         ReactViewManager.REACT_CLASS,
-        SimpleMap.of("backgroundColor", Color.RED));
+        JavaOnlyMap.of("backgroundColor", Color.RED));
     uiManager.onBatchComplete();
     executePendingChoreographerCallbacks();
     assertThat(view0.getLeft()).isEqualTo(1);
@@ -558,7 +558,7 @@ public class UIManagerModuleTest {
         hierarchy.rootView,
         ReactViewManager.REACT_CLASS,
         rootTag,
-        SimpleMap.of("collapsable", false));
+        JavaOnlyMap.of("collapsable", false));
 
     uiManagerModule.registerAnimation(mockAnimation);
     uiManagerModule.addAnimation(hierarchy.rootView, 1000, callbackMock);
@@ -586,7 +586,7 @@ public class UIManagerModuleTest {
         newViewTag,
         ReactViewManager.REACT_CLASS,
         hierarchy.rootView,
-        SimpleMap.of("backgroundColor", Color.RED));
+        JavaOnlyMap.of("backgroundColor", Color.RED));
 
     uiManager.replaceExistingNonRootView(hierarchy.view2, newViewTag);
 
@@ -617,12 +617,12 @@ public class UIManagerModuleTest {
         containerTag,
         ReactViewManager.REACT_CLASS,
         rootTag,
-        SimpleMap.of("collapsable", false));
+        JavaOnlyMap.of("collapsable", false));
     uiManager.createView(
         containerSiblingTag,
         ReactViewManager.REACT_CLASS,
         rootTag,
-        SimpleMap.of("collapsable", false));
+        JavaOnlyMap.of("collapsable", false));
     addChild(uiManager, rootTag, containerTag, 0);
     addChild(uiManager, rootTag, containerSiblingTag, 1);
 
@@ -630,12 +630,12 @@ public class UIManagerModuleTest {
         containerTag + 2,
         ReactTextViewManager.REACT_CLASS,
         rootTag,
-        SimpleMap.of("collapsable", false));
+        JavaOnlyMap.of("collapsable", false));
     uiManager.createView(
         containerTag + 3,
         ReactTextViewManager.REACT_CLASS,
         rootTag,
-        SimpleMap.of("collapsable", false));
+        JavaOnlyMap.of("collapsable", false));
     addChild(uiManager, containerTag, containerTag + 2, 0);
     addChild(uiManager, containerTag, containerTag + 3, 1);
 
@@ -669,27 +669,27 @@ public class UIManagerModuleTest {
         textTag,
         ReactTextViewManager.REACT_CLASS,
         rootTag,
-        SimpleMap.of("collapsable", false));
+        JavaOnlyMap.of("collapsable", false));
     uiManager.createView(
         rawTextTag,
         ReactRawTextManager.REACT_CLASS,
         rootTag,
-        SimpleMap.of(ReactTextShadowNode.PROP_TEXT, text, "collapsable", false));
+        JavaOnlyMap.of(ReactTextShadowNode.PROP_TEXT, text, "collapsable", false));
 
     uiManager.manageChildren(
         textTag,
         null,
         null,
-        SimpleArray.of(rawTextTag),
-        SimpleArray.of(0),
+        JavaOnlyArray.of(rawTextTag),
+        JavaOnlyArray.of(0),
         null);
 
     uiManager.manageChildren(
         rootTag,
         null,
         null,
-        SimpleArray.of(textTag),
-        SimpleArray.of(0),
+        JavaOnlyArray.of(textTag),
+        JavaOnlyArray.of(0),
         null);
 
     uiManager.onBatchComplete();
@@ -708,32 +708,32 @@ public class UIManagerModuleTest {
         hierarchy.view0,
         ReactViewManager.REACT_CLASS,
         rootTag,
-        SimpleMap.of("collapsable", false));
+        JavaOnlyMap.of("collapsable", false));
     uiManager.createView(
         hierarchy.viewWithChildren1,
         ReactViewManager.REACT_CLASS,
         rootTag,
-        SimpleMap.of("collapsable", false));
+        JavaOnlyMap.of("collapsable", false));
     uiManager.createView(
         hierarchy.view2,
         ReactViewManager.REACT_CLASS,
         rootTag,
-        SimpleMap.of("collapsable", false));
+        JavaOnlyMap.of("collapsable", false));
     uiManager.createView(
         hierarchy.view3,
         ReactViewManager.REACT_CLASS,
         rootTag,
-        SimpleMap.of("collapsable", false));
+        JavaOnlyMap.of("collapsable", false));
     uiManager.createView(
         hierarchy.childView0,
         ReactViewManager.REACT_CLASS,
         rootTag,
-        SimpleMap.of("collapsable", false));
+        JavaOnlyMap.of("collapsable", false));
     uiManager.createView(
         hierarchy.childView1,
         ReactViewManager.REACT_CLASS,
         rootTag,
-        SimpleMap.of("collapsable", false));
+        JavaOnlyMap.of("collapsable", false));
 
     addChild(uiManager, rootTag, hierarchy.view0, 0);
     addChild(uiManager, rootTag, hierarchy.viewWithChildren1, 1);
@@ -754,8 +754,8 @@ public class UIManagerModuleTest {
         parentTag,
         null,
         null,
-        SimpleArray.of(childTag),
-        SimpleArray.of(index),
+        JavaOnlyArray.of(childTag),
+        JavaOnlyArray.of(index),
         null);
   }
 

--- a/ReactAndroid/src/test/java/com/facebook/react/views/image/ReactImagePropertyTest.java
+++ b/ReactAndroid/src/test/java/com/facebook/react/views/image/ReactImagePropertyTest.java
@@ -17,7 +17,7 @@ import com.facebook.react.bridge.CatalystInstance;
 import com.facebook.react.bridge.ReactTestHelper;
 import com.facebook.react.bridge.JSApplicationIllegalArgumentException;
 import com.facebook.react.bridge.ReactApplicationContext;
-import com.facebook.react.bridge.SimpleMap;
+import com.facebook.react.bridge.JavaOnlyMap;
 import com.facebook.react.uimanager.ReactStylesDiffMap;
 import com.facebook.react.uimanager.DisplayMetricsHolder;
 import com.facebook.react.uimanager.ThemedReactContext;
@@ -68,7 +68,7 @@ public class ReactImagePropertyTest {
   }
 
   public ReactStylesDiffMap buildStyles(Object... keysAndValues) {
-    return new ReactStylesDiffMap(SimpleMap.of(keysAndValues));
+    return new ReactStylesDiffMap(JavaOnlyMap.of(keysAndValues));
   }
 
   @Test(expected=JSApplicationIllegalArgumentException.class)

--- a/ReactAndroid/src/test/java/com/facebook/react/views/text/ReactTextTest.java
+++ b/ReactAndroid/src/test/java/com/facebook/react/views/text/ReactTextTest.java
@@ -29,8 +29,8 @@ import com.facebook.react.ReactRootView;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReactTestHelper;
 import com.facebook.react.bridge.ReactApplicationContext;
-import com.facebook.react.bridge.SimpleArray;
-import com.facebook.react.bridge.SimpleMap;
+import com.facebook.react.bridge.JavaOnlyArray;
+import com.facebook.react.bridge.JavaOnlyMap;
 import com.facebook.react.uimanager.ReactChoreographer;
 import com.facebook.react.uimanager.UIImplementation;
 import com.facebook.react.uimanager.UIManagerModule;
@@ -77,7 +77,7 @@ public class ReactTextTest {
     PowerMockito.when(Arguments.createMap()).thenAnswer(new Answer<Object>() {
       @Override
       public Object answer(InvocationOnMock invocation) throws Throwable {
-        return new SimpleMap();
+        return new JavaOnlyMap();
       }
     });
     PowerMockito.when(ReactChoreographer.getInstance()).thenReturn(choreographerMock);
@@ -101,8 +101,8 @@ public class ReactTextTest {
 
     ReactRootView rootView = createText(
         uiManager,
-        SimpleMap.of(ViewProps.FONT_SIZE, 21.0),
-        SimpleMap.of(ReactTextShadowNode.PROP_TEXT, "test text"));
+        JavaOnlyMap.of(ViewProps.FONT_SIZE, 21.0),
+        JavaOnlyMap.of(ReactTextShadowNode.PROP_TEXT, "test text"));
 
     AbsoluteSizeSpan sizeSpan = getSingleSpan(
         (TextView) rootView.getChildAt(0), AbsoluteSizeSpan.class);
@@ -115,8 +115,8 @@ public class ReactTextTest {
 
     ReactRootView rootView = createText(
         uiManager,
-        SimpleMap.of(ViewProps.FONT_WEIGHT, "bold"),
-        SimpleMap.of(ReactTextShadowNode.PROP_TEXT, "test text"));
+        JavaOnlyMap.of(ViewProps.FONT_WEIGHT, "bold"),
+        JavaOnlyMap.of(ReactTextShadowNode.PROP_TEXT, "test text"));
 
     CustomStyleSpan customStyleSpan =
         getSingleSpan((TextView)rootView.getChildAt(0), CustomStyleSpan.class);
@@ -130,8 +130,8 @@ public class ReactTextTest {
 
     ReactRootView rootView = createText(
         uiManager,
-        SimpleMap.of(ViewProps.FONT_WEIGHT, "500"),
-        SimpleMap.of(ReactTextShadowNode.PROP_TEXT, "test text"));
+        JavaOnlyMap.of(ViewProps.FONT_WEIGHT, "500"),
+        JavaOnlyMap.of(ReactTextShadowNode.PROP_TEXT, "test text"));
 
     CustomStyleSpan customStyleSpan =
         getSingleSpan((TextView) rootView.getChildAt(0), CustomStyleSpan.class);
@@ -145,8 +145,8 @@ public class ReactTextTest {
 
     ReactRootView rootView = createText(
         uiManager,
-        SimpleMap.of(ViewProps.FONT_STYLE, "italic"),
-        SimpleMap.of(ReactTextShadowNode.PROP_TEXT, "test text"));
+        JavaOnlyMap.of(ViewProps.FONT_STYLE, "italic"),
+        JavaOnlyMap.of(ReactTextShadowNode.PROP_TEXT, "test text"));
 
     CustomStyleSpan customStyleSpan =
         getSingleSpan((TextView) rootView.getChildAt(0), CustomStyleSpan.class);
@@ -160,8 +160,8 @@ public class ReactTextTest {
 
     ReactRootView rootView = createText(
         uiManager,
-        SimpleMap.of(ViewProps.FONT_WEIGHT, "bold", ViewProps.FONT_STYLE, "italic"),
-        SimpleMap.of(ReactTextShadowNode.PROP_TEXT, "test text"));
+        JavaOnlyMap.of(ViewProps.FONT_WEIGHT, "bold", ViewProps.FONT_STYLE, "italic"),
+        JavaOnlyMap.of(ReactTextShadowNode.PROP_TEXT, "test text"));
 
     CustomStyleSpan customStyleSpan =
         getSingleSpan((TextView) rootView.getChildAt(0), CustomStyleSpan.class);
@@ -175,8 +175,8 @@ public class ReactTextTest {
 
     ReactRootView rootView = createText(
         uiManager,
-        SimpleMap.of(ViewProps.FONT_WEIGHT, "normal"),
-        SimpleMap.of(ReactTextShadowNode.PROP_TEXT, "test text"));
+        JavaOnlyMap.of(ViewProps.FONT_WEIGHT, "normal"),
+        JavaOnlyMap.of(ReactTextShadowNode.PROP_TEXT, "test text"));
 
     CustomStyleSpan customStyleSpan =
         getSingleSpan((TextView) rootView.getChildAt(0), CustomStyleSpan.class);
@@ -189,8 +189,8 @@ public class ReactTextTest {
 
     ReactRootView rootView = createText(
         uiManager,
-        SimpleMap.of(ViewProps.FONT_WEIGHT, "200"),
-        SimpleMap.of(ReactTextShadowNode.PROP_TEXT, "test text"));
+        JavaOnlyMap.of(ViewProps.FONT_WEIGHT, "200"),
+        JavaOnlyMap.of(ReactTextShadowNode.PROP_TEXT, "test text"));
 
     CustomStyleSpan customStyleSpan =
         getSingleSpan((TextView) rootView.getChildAt(0), CustomStyleSpan.class);
@@ -203,8 +203,8 @@ public class ReactTextTest {
 
     ReactRootView rootView = createText(
         uiManager,
-        SimpleMap.of(ViewProps.FONT_STYLE, "normal"),
-        SimpleMap.of(ReactTextShadowNode.PROP_TEXT, "test text"));
+        JavaOnlyMap.of(ViewProps.FONT_STYLE, "normal"),
+        JavaOnlyMap.of(ReactTextShadowNode.PROP_TEXT, "test text"));
 
     CustomStyleSpan customStyleSpan =
         getSingleSpan((TextView) rootView.getChildAt(0), CustomStyleSpan.class);
@@ -217,8 +217,8 @@ public class ReactTextTest {
 
     ReactRootView rootView = createText(
         uiManager,
-        SimpleMap.of(ViewProps.FONT_FAMILY, "sans-serif"),
-        SimpleMap.of(ReactTextShadowNode.PROP_TEXT, "test text"));
+        JavaOnlyMap.of(ViewProps.FONT_FAMILY, "sans-serif"),
+        JavaOnlyMap.of(ReactTextShadowNode.PROP_TEXT, "test text"));
 
     CustomStyleSpan customStyleSpan =
         getSingleSpan((TextView) rootView.getChildAt(0), CustomStyleSpan.class);
@@ -233,8 +233,8 @@ public class ReactTextTest {
 
     ReactRootView rootView = createText(
         uiManager,
-        SimpleMap.of(ViewProps.FONT_FAMILY, "sans-serif", ViewProps.FONT_WEIGHT, "bold"),
-        SimpleMap.of(ReactTextShadowNode.PROP_TEXT, "test text"));
+        JavaOnlyMap.of(ViewProps.FONT_FAMILY, "sans-serif", ViewProps.FONT_WEIGHT, "bold"),
+        JavaOnlyMap.of(ReactTextShadowNode.PROP_TEXT, "test text"));
 
     CustomStyleSpan customStyleSpan =
         getSingleSpan((TextView) rootView.getChildAt(0), CustomStyleSpan.class);
@@ -249,8 +249,8 @@ public class ReactTextTest {
 
     ReactRootView rootView = createText(
         uiManager,
-        SimpleMap.of(ViewProps.FONT_FAMILY, "sans-serif", ViewProps.FONT_STYLE, "italic"),
-        SimpleMap.of(ReactTextShadowNode.PROP_TEXT, "test text"));
+        JavaOnlyMap.of(ViewProps.FONT_FAMILY, "sans-serif", ViewProps.FONT_STYLE, "italic"),
+        JavaOnlyMap.of(ReactTextShadowNode.PROP_TEXT, "test text"));
 
     CustomStyleSpan customStyleSpan =
         getSingleSpan((TextView) rootView.getChildAt(0), CustomStyleSpan.class);
@@ -265,11 +265,11 @@ public class ReactTextTest {
 
     ReactRootView rootView = createText(
         uiManager,
-        SimpleMap.of(
+        JavaOnlyMap.of(
             ViewProps.FONT_FAMILY, "sans-serif",
             ViewProps.FONT_WEIGHT, "500",
             ViewProps.FONT_STYLE, "italic"),
-        SimpleMap.of(ReactTextShadowNode.PROP_TEXT, "test text"));
+        JavaOnlyMap.of(ReactTextShadowNode.PROP_TEXT, "test text"));
 
     CustomStyleSpan customStyleSpan =
         getSingleSpan((TextView) rootView.getChildAt(0), CustomStyleSpan.class);
@@ -284,8 +284,8 @@ public class ReactTextTest {
 
     ReactRootView rootView = createText(
         uiManager,
-        SimpleMap.of(ViewProps.BACKGROUND_COLOR, Color.BLUE),
-        SimpleMap.of(ReactTextShadowNode.PROP_TEXT, "test text"));
+        JavaOnlyMap.of(ViewProps.BACKGROUND_COLOR, Color.BLUE),
+        JavaOnlyMap.of(ReactTextShadowNode.PROP_TEXT, "test text"));
 
     Drawable backgroundDrawable = ((TextView) rootView.getChildAt(0)).getBackground();
     assertThat(((ColorDrawable) backgroundDrawable).getColor()).isEqualTo(Color.BLUE);
@@ -300,8 +300,8 @@ public class ReactTextTest {
 
     ReactRootView rootView = createText(
         uiManager,
-        SimpleMap.of(ViewProps.NUMBER_OF_LINES, 2),
-        SimpleMap.of(ReactTextShadowNode.PROP_TEXT, "test text"));
+        JavaOnlyMap.of(ViewProps.NUMBER_OF_LINES, 2),
+        JavaOnlyMap.of(ReactTextShadowNode.PROP_TEXT, "test text"));
 
     TextView textView = (TextView) rootView.getChildAt(0);
     assertThat(textView.getText().toString()).isEqualTo("test text");
@@ -321,8 +321,8 @@ public class ReactTextTest {
 
   private ReactRootView createText(
       UIManagerModule uiManager,
-      SimpleMap textProps,
-      SimpleMap rawTextProps) {
+      JavaOnlyMap textProps,
+      JavaOnlyMap rawTextProps) {
     ReactRootView rootView = new ReactRootView(RuntimeEnvironment.application);
     int rootTag = uiManager.addMeasuredRootView(rootView);
     int textTag = rootTag + 1;
@@ -343,16 +343,16 @@ public class ReactTextTest {
         textTag,
         null,
         null,
-        SimpleArray.of(rawTextTag),
-        SimpleArray.of(0),
+        JavaOnlyArray.of(rawTextTag),
+        JavaOnlyArray.of(0),
         null);
 
     uiManager.manageChildren(
         rootTag,
         null,
         null,
-        SimpleArray.of(textTag),
-        SimpleArray.of(0),
+        JavaOnlyArray.of(textTag),
+        JavaOnlyArray.of(0),
         null);
 
     uiManager.onBatchComplete();

--- a/ReactAndroid/src/test/java/com/facebook/react/views/textinput/ReactTextInputPropertyTest.java
+++ b/ReactAndroid/src/test/java/com/facebook/react/views/textinput/ReactTextInputPropertyTest.java
@@ -20,7 +20,7 @@ import com.facebook.react.bridge.CatalystInstance;
 import com.facebook.react.bridge.ReactTestHelper;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.JSApplicationCausedNativeException;
-import com.facebook.react.bridge.SimpleMap;
+import com.facebook.react.bridge.JavaOnlyMap;
 import com.facebook.react.uimanager.ReactStylesDiffMap;
 import com.facebook.react.uimanager.DisplayMetricsHolder;
 import com.facebook.react.views.text.DefaultStyleValuesUtil;
@@ -64,7 +64,7 @@ public class ReactTextInputPropertyTest {
   }
 
   public ReactStylesDiffMap buildStyles(Object... keysAndValues) {
-    return new ReactStylesDiffMap(SimpleMap.of(keysAndValues));
+    return new ReactStylesDiffMap(JavaOnlyMap.of(keysAndValues));
   }
 
   @Test

--- a/ReactAndroid/src/test/java/com/facebook/react/views/textinput/TextInputTest.java
+++ b/ReactAndroid/src/test/java/com/facebook/react/views/textinput/TextInputTest.java
@@ -20,8 +20,8 @@ import com.facebook.react.ReactRootView;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReactTestHelper;
 import com.facebook.react.bridge.ReactApplicationContext;
-import com.facebook.react.bridge.SimpleArray;
-import com.facebook.react.bridge.SimpleMap;
+import com.facebook.react.bridge.JavaOnlyArray;
+import com.facebook.react.bridge.JavaOnlyMap;
 import com.facebook.react.uimanager.ReactChoreographer;
 import com.facebook.react.uimanager.UIImplementation;
 import com.facebook.react.uimanager.UIManagerModule;
@@ -68,7 +68,7 @@ public class TextInputTest {
     PowerMockito.when(Arguments.createMap()).thenAnswer(new Answer<Object>() {
       @Override
       public Object answer(InvocationOnMock invocation) throws Throwable {
-        return new SimpleMap();
+        return new JavaOnlyMap();
       }
     });
     PowerMockito.when(ReactChoreographer.getInstance()).thenReturn(choreographerMock);
@@ -99,15 +99,15 @@ public class TextInputTest {
         textInputTag,
         ReactTextInputManager.REACT_CLASS,
         rootTag,
-        SimpleMap.of(
+        JavaOnlyMap.of(
             ViewProps.FONT_SIZE, 13.37, ViewProps.HEIGHT, 20.0, "placeholder", hintStr));
 
     uiManager.manageChildren(
         rootTag,
         null,
         null,
-        SimpleArray.of(textInputTag),
-        SimpleArray.of(0),
+        JavaOnlyArray.of(textInputTag),
+        JavaOnlyArray.of(0),
         null);
 
     uiManager.onBatchComplete();
@@ -132,15 +132,15 @@ public class TextInputTest {
         textInputTag,
         ReactTextInputManager.REACT_CLASS,
         rootTag,
-        SimpleMap.of(
+        JavaOnlyMap.of(
             ViewProps.FONT_SIZE, 13.37, ViewProps.HEIGHT, 20.0, "placeholder", hintStr));
 
     uiManager.manageChildren(
         rootTag,
         null,
         null,
-        SimpleArray.of(textInputTag),
-        SimpleArray.of(0),
+        JavaOnlyArray.of(textInputTag),
+        JavaOnlyArray.of(0),
         null);
     uiManager.onBatchComplete();
     executePendingChoreographerCallbacks();
@@ -154,7 +154,7 @@ public class TextInputTest {
     uiManager.updateView(
         textInputTag,
         ReactTextInputManager.REACT_CLASS,
-        SimpleMap.of(
+        JavaOnlyMap.of(
             ViewProps.FONT_SIZE, 26.74, ViewProps.HEIGHT, 40.0, "placeholder", hintStr2));
 
     uiManager.onBatchComplete();


### PR DESCRIPTION
As a part of this change I'm also renaming SimpleArray to JavaOnlyArray and SimpleMap to JavaOnlyMap. The main reason for the change is to support use-cases such as driving animations form the native code. In the case of native "animated" I'd like to be able to use the same interface as JS is using for updating the View properties. As view setters can take ReadableMap and ReadableArray as an argument in some cases it is necessary to create and pass those types to the setter. Using WritableNativeArray and WritableNativeMap for this purpose seems to me like a misuse and IMO will be less performant (vs java-only map/array) as those implementations of ReadableMap and ReadableArray proxies all their methods through JNI.

I'm also adding some additional class-level comments for the moved classes to avoid confusion and hopefuly prevent people from using those classess accidentally while writing native modules or methods that calls to JS.