### PR TITLE
[build] fix resources build variable name

### DIFF
--- a/local-cli/generator-android/templates/src/app/react.gradle
+++ b/local-cli/generator-android/templates/src/app/react.gradle
@@ -41,7 +41,7 @@ gradle.projectsEvaluated {
             def jsBundleDir = elvisFile(config."$jsBundleDirConfigName") ?:
                     file("$buildDir/intermediates/assets/${targetPath}")
 
-            def resourcesDirConfigName = "jsBundleDir${targetName}"
+            def resourcesDirConfigName = "resourcesDir${targetName}"
             def resourcesDir = elvisFile(config."${resourcesDirConfigName}") ?:
                     file("$buildDir/intermediates/res/merged/${targetPath}")
             def jsBundleFile = file("$jsBundleDir/$bundleAssetName")


### PR DESCRIPTION
If jsBundleDir variable was defined, then RN image assets would be
thrown into the assets folder along with the js bundle. This is a
bug. Image assets should be published into a different folder than the
js bundle.

A new variable resourcesDir is defined where RN image assets and the
like should be published into.