### PR TITLE
make copyright render the current year

### DIFF
--- a/website/core/Site.js
+++ b/website/core/Site.js
@@ -15,6 +15,7 @@ var HeaderLinks = require('HeaderLinks');
 var Site = React.createClass({
   render: function() {
     var title = this.props.title ? this.props.title + ' – ' : '';
+    var currentYear = (new Date()).getFullYear();
     title += 'React Native | A framework for building native apps using React';
     return (
       <html>
@@ -53,7 +54,7 @@ var Site = React.createClass({
             {this.props.children}
 
             <footer className="wrap">
-              <div className="center">© 2015 Facebook Inc.</div>
+              <div className="center">© {currentYear} Facebook Inc.</div>
             </footer>
           </div>
 


### PR DESCRIPTION
As discussed here https://github.com/facebook/react-native/pull/5835 now the copyright is computed from `Date`