### PR TITLE
Add position to Picker onValueChange's call

### DIFF
--- a/Libraries/Components/Picker/PickerAndroid.android.js
+++ b/Libraries/Components/Picker/PickerAndroid.android.js
@@ -100,9 +100,9 @@ var PickerAndroid = React.createClass({
       var position = event.nativeEvent.position;
       if (position >= 0) {
         var value = this.props.children[position].props.value;
-        this.props.onValueChange(value);
+        this.props.onValueChange(value, position);
       } else {
-        this.props.onValueChange(null);
+        this.props.onValueChange(null, position);
       }
     }
 

--- a/Libraries/Picker/PickerIOS.ios.js
+++ b/Libraries/Picker/PickerIOS.ios.js
@@ -54,7 +54,7 @@ var PickerIOS = React.createClass({
     });
     return {selectedIndex, items};
   },
-  
+
   render: function() {
     return (
       <View style={this.props.style}>
@@ -74,7 +74,7 @@ var PickerIOS = React.createClass({
       this.props.onChange(event);
     }
     if (this.props.onValueChange) {
-      this.props.onValueChange(event.nativeEvent.newValue);
+      this.props.onValueChange(event.nativeEvent.newValue, event.nativeEvent.newIndex);
     }
 
     // The picker is a controlled component. This means we expect the


### PR DESCRIPTION
According to the [docs](http://facebook.github.io/react-native/releases/0.20/docs/picker.html#onvaluechange), `Picker`'s `onValueChange` should be called with `itemValue` and `itemPosition` but currently only `itemValue` is passed. This PR fixes that.
The position is passed as the 2nd parameter to not introduce any breaking change, and also to respect the current documentation.
The documentation doesn't need to be changed as it will be correct with this PR, but maybe it needs to be updated until this is merged?