### PR TITLE
Add drawerGestureLock to DrawerLayoutAndroid

### DIFF
--- a/Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.android.js
+++ b/Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.android.js
@@ -28,6 +28,7 @@ var INNERVIEW_REF = 'innerView';
 var DrawerLayoutValidAttributes = {
   drawerWidth: true,
   drawerPosition: true,
+  drawerGestureLock: true
 };
 
 var DRAWER_STATES = [
@@ -41,8 +42,9 @@ var DRAWER_STATES = [
  * Drawer (typically used for navigation) is rendered with `renderNavigationView`
  * and direct children are the main view (where your content goes). The navigation
  * view is initially not visible on the screen, but can be pulled in from the
- * side of the window specified by the `drawerPosition` prop and its width can
- * be set by the `drawerWidth` prop.
+ * side of the window specified by the `drawerPosition` prop, its width can
+ * be set by the `drawerWidth` prop, and it's locking state can be set by the
+ * `drawerGestureLock` prop.
  *
  * Example:
  *
@@ -57,6 +59,7 @@ var DRAWER_STATES = [
  *     <DrawerLayoutAndroid
  *       drawerWidth={300}
  *       drawerPosition={DrawerLayoutAndroid.positions.Left}
+ *       drawerGestureLock={DrawerLayoutAndroid.gestures.Unlocked} 
  *       renderNavigationView={() => navigationView}>
  *       <View style={{flex: 1, alignItems: 'center'}}>
  *         <Text style={{margin: 10, fontSize: 15, textAlign: 'right'}}>Hello</Text>
@@ -70,6 +73,7 @@ var DRAWER_STATES = [
 var DrawerLayoutAndroid = React.createClass({
   statics: {
     positions: DrawerConsts.DrawerPosition,
+    gestures: DrawerConsts.DrawerGestureLock
   },
 
   propTypes: {
@@ -89,6 +93,17 @@ var DrawerLayoutAndroid = React.createClass({
     drawerPosition: ReactPropTypes.oneOf([
       DrawerConsts.DrawerPosition.Left,
       DrawerConsts.DrawerPosition.Right
+    ]),
+    /**
+     * Specifies if the drawer gestures would be locked.
+     *   - 'DrawerConsts.DrawerGestureLock.Unlocked' (the default), gestures will be enabled and the drawer will respond to both gestures and drawer commands.
+     *   - 'DrawerConsts.DrawerGestureLock.LockedOpen', the drawer will be locked opened, gestures will be disabled and the drawer respond only to drawer commands.
+     *   - 'DrawerConsts.DrawerGestureLock.LockedClosed', the drawer will be locked closed, gestures will be disabled and the drawer respond only to drawer commands.
+     */
+    drawerGestureLock: ReactPropTypes.oneOf([
+      DrawerConsts.DrawerGestureLock.Unlocked,
+      DrawerConsts.DrawerGestureLock.LockedOpen,
+      DrawerConsts.DrawerGestureLock.LockedClosed
     ]),
     /**
      * Specifies the width of the drawer, more precisely the width of the view that be pulled in
@@ -142,6 +157,7 @@ var DrawerLayoutAndroid = React.createClass({
         ref={RK_DRAWER_REF}
         drawerWidth={this.props.drawerWidth}
         drawerPosition={this.props.drawerPosition}
+        drawerGestureLock={this.props.drawerGestureLock}
         style={styles.base}
         onDrawerSlide={this._onDrawerSlide}
         onDrawerOpen={this._onDrawerOpen}

--- a/ReactAndroid/src/main/java/com/facebook/react/views/drawer/ReactDrawerLayout.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/drawer/ReactDrawerLayout.java
@@ -27,6 +27,7 @@ import com.facebook.react.uimanager.events.NativeGestureUtil;
   public static final int DEFAULT_DRAWER_WIDTH = LayoutParams.MATCH_PARENT;
   private int mDrawerPosition = Gravity.START;
   private int mDrawerWidth = DEFAULT_DRAWER_WIDTH;
+  private int mDrawerGestureLock = DrawerLayout.LOCK_MODE_UNLOCKED;
 
   public ReactDrawerLayout(ReactContext reactContext) {
     super(reactContext);
@@ -59,6 +60,10 @@ import com.facebook.react.uimanager.events.NativeGestureUtil;
     setDrawerProperties();
   }
 
+    /* package */ void setDrawerGestureLock(int drawerGestureLock) {
+    mDrawerGestureLock = drawerGestureLock;
+  }
+
   // Sets the properties of the drawer, after the navigationView has been set.
   /* package */ void setDrawerProperties() {
     if (this.getChildCount() == 2) {
@@ -68,6 +73,7 @@ import com.facebook.react.uimanager.events.NativeGestureUtil;
       layoutParams.width = mDrawerWidth;
       drawerView.setLayoutParams(layoutParams);
       drawerView.setClickable(true);
+      this.setDrawerLockMode(mDrawerGestureLock);
     }
   }
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/drawer/ReactDrawerLayoutManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/drawer/ReactDrawerLayoutManager.java
@@ -76,6 +76,11 @@ public class ReactDrawerLayoutManager extends ViewGroupManager<ReactDrawerLayout
     view.setDrawerWidth(widthInPx);
   }
 
+  @ReactProp(name = "drawerGestureLock", defaultInt = DrawerLayout.LOCK_MODE_UNLOCKED)
+  public void setDrawerGestureLock(ReactDrawerLayout view, int drawerGestureLock) {
+    view.setDrawerGestureLock(drawerGestureLock);
+  }
+
   @Override
   public boolean needsCustomLayoutForChildren() {
     // Return true, since DrawerLayout will lay out it's own children.
@@ -105,8 +110,11 @@ public class ReactDrawerLayoutManager extends ViewGroupManager<ReactDrawerLayout
   @Override
   public @Nullable Map getExportedViewConstants() {
     return MapBuilder.of(
-        "DrawerPosition",
-        MapBuilder.of("Left", Gravity.START, "Right", Gravity.END));
+          "DrawerPosition",
+          MapBuilder.of("Left", Gravity.START, "Right", Gravity.END),
+          "DrawerGestureLock",
+          MapBuilder.of("Unlocked", DrawerLayout.LOCK_MODE_UNLOCKED, "LockedOpen", DrawerLayout.LOCK_MODE_LOCKED_OPEN, "LockedClosed", DrawerLayout.LOCK_MODE_LOCKED_CLOSED)
+        );
   }
 
   @Override


### PR DESCRIPTION
Useful for developers that would like to lock the drawer, closed or
opened (or unlocked by default) until drawer command is executed.