### PR TITLE
Added ability to switch version in documentation website

### DIFF
--- a/website/core/Site.js
+++ b/website/core/Site.js
@@ -16,6 +16,7 @@ var Metadata = require('Metadata');
 var Site = React.createClass({
   render: function() {
     const path = Metadata.config.RN_DEPLOYMENT_PATH;
+    const version = Metadata.config.RN_VERSION;
     var basePath = '/react-native/' + (path ? path + '/' : '');
     var title = this.props.title ? this.props.title + ' – ' : '';
     var currentYear = (new Date()).getFullYear();
@@ -51,6 +52,9 @@ var Site = React.createClass({
                 <a className="nav-home" href="">
                   <img src="img/header_logo.png" />
                   React Native
+                </a>
+                <a className="nav-version" href="/react-native/versions.html">
+                  {version}
                 </a>
                 <HeaderLinks section={this.props.section} />
               </div>

--- a/website/package.json
+++ b/website/package.json
@@ -1,21 +1,22 @@
 {
   "scripts": {
-    "start": "node server/server.js",
+    "start": "RN_VERSION=next node server/server.js",
     "gh-pages": "node publish-gh-pages.js"
   },
   "dependencies": {
     "bluebird": "^2.9.21",
     "connect": "2.8.3",
-    "esprima-fb": "latest",
-    "fs.extra": "latest",
-    "glob": "latest",
-    "jstransform": "latest",
-    "mkdirp": "latest",
+    "esprima-fb": "15001.1001.0-dev-harmony-fb",
+    "fs.extra": "1.3.2",
+    "glob": "6.0.4",
+    "jstransform": "11.0.3",
+    "mkdirp": "^0.5.1",
     "optimist": "0.6.0",
     "react": "~0.13.0",
     "react-docgen": "^2.0.1",
     "react-page-middleware": "git://github.com/facebook/react-page-middleware.git",
-    "request": "latest",
+    "request": "^2.69.0",
+    "semver-compare": "^1.0.0",
     "shelljs": "^0.6.0"
   }
 }

--- a/website/src/react-native/css/react-native.css
+++ b/website/src/react-native/css/react-native.css
@@ -312,6 +312,14 @@ h1:hover .hash-link, h2:hover .hash-link, h3:hover .hash-link, h4:hover .hash-li
   display: inline;
 }
 
+.nav-main a.nav-version {
+  font-size: 16px;
+  font-weight: 800;
+  color: #05A5D1;
+  margin-left: 5px;
+  text-decoration: underline;
+}
+
 .hero {
   background: #05A5D1;
   padding: 50px 0;
@@ -476,6 +484,15 @@ h1:hover .hash-link, h2:hover .hash-link, h3:hover .hash-link, h4:hover .hash-li
 .tutorial-mock img {
   border: 1px solid #ccc;
   box-shadow: 5px 5px 5px #888888;
+}
+
+.versions ul {
+  list-style: none;
+}
+
+.versions li {
+  font-size: 16px;
+  padding-top: 10px;
 }
 
 #examples h3, .home-presentation h3 {

--- a/website/src/react-native/versions.js
+++ b/website/src/react-native/versions.js
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+var React = require('React');
+var Site = require('Site');
+var Metadata = require('Metadata');
+
+var versions = React.createClass({
+  render: function() {
+
+    var availableDocs = (Metadata.config.RN_AVAILABLE_DOCS_VERSIONS || '').split(',');
+    var versions = [
+      {
+        title: 'next',
+        path: '/react-native/releases/next',
+      },
+      {
+        title: 'stable',
+        path: '/react-native',
+      },
+    ].concat(availableDocs.map((version) => {
+      return {
+        title: version,
+        path: '/react-native/releases/' + version
+      }
+    }));
+    var versionsLi = versions.map((version) =>
+      <li><a href={version.path}>{version.title}</a></li>
+    );
+    return (
+      <Site section="versions" title="Documentation archive">
+        <section className="content wrap versions documentationContent">
+          <h1>Documentation archive</h1>
+          <ul>
+            {versionsLi}
+          </ul>
+        </section>
+      </Site>
+    );
+  }
+});
+
+module.exports = versions;


### PR DESCRIPTION
Website header now contains version number which is a link.
Clicking the link redirects you to a page that lists all the previous versions of the website.

Considering that we do a branch cut every 2 weeks a solution with dropdown did not feel right because it would grow fast.
As an improvement for the future - we could link change docs in the versions.html