### PR TITLE
Add context to async example function in Network docs

### DIFF
--- a/docs/Network.md
+++ b/docs/Network.md
@@ -54,14 +54,19 @@ fetch('https://mywebsite.com/endpoint/', {
 2.  Called within an asynchronous function using ES7 `async`/`await` syntax:
   
   ```js
-  async getUsersFromApi() {
-    try {
-      let response = await fetch('https://mywebsite.com/endpoint/');
-      return response.users;
-    } catch(error) {
-      throw error;
+  var MyComponent = React.createClass({
+    ...
+    async getUsersFromApi() {
+      try {
+        let response = await fetch('https://mywebsite.com/endpoint/');
+        let responseJson = await response.json();
+        return responseJson.users;
+      } catch(error) {
+        throw error;
+      }
     }
-  }
+    ...
+  })
   ```
 
 - Note: Errors thrown by rejected Promises need to be caught, or they will be swallowed silently

--- a/docs/Network.md
+++ b/docs/Network.md
@@ -41,29 +41,28 @@ fetch('https://mywebsite.com/endpoint/', {
 
 1.  Using `then` and `catch` in synchronous code:
 
-```js
-fetch('https://mywebsite.com/endpoint.php')
-  .then((response) => response.text())
-  .then((responseText) => {
-    console.log(responseText);
-  })
-  .catch((error) => {
-    console.warn(error);
-  });
-```
-
+  ```js
+  fetch('https://mywebsite.com/endpoint.php')
+    .then((response) => response.text())
+    .then((responseText) => {
+      console.log(responseText);
+    })
+    .catch((error) => {
+      console.warn(error);
+    });
+  ```
 2.  Called within an asynchronous function using ES7 `async`/`await` syntax:
-
-```js
-async getUsersFromApi() {
-  try {
-    let response = await fetch('https://mywebsite.com/endpoint/');
-    return response.users;
-  } catch(error) {
-    throw error;
+  
+  ```js
+  async getUsersFromApi() {
+    try {
+      let response = await fetch('https://mywebsite.com/endpoint/');
+      return response.users;
+    } catch(error) {
+      throw error;
+    }
   }
-}
-```
+  ```
 
 - Note: Errors thrown by rejected Promises need to be caught, or they will be swallowed silently
 

--- a/docs/Network.md
+++ b/docs/Network.md
@@ -54,7 +54,7 @@ fetch('https://mywebsite.com/endpoint/', {
 2.  Called within an asynchronous function using ES7 `async`/`await` syntax:
   
   ```js
-  var MyComponent = React.createClass({
+  class MyComponent extends React.Component {
     ...
     async getUsersFromApi() {
       try {
@@ -62,11 +62,12 @@ fetch('https://mywebsite.com/endpoint/', {
         let responseJson = await response.json();
         return responseJson.users;
       } catch(error) {
-        throw error;
+        // Handle error
+        console.error(error);
       }
     }
     ...
-  })
+  }
   ```
 
 - Note: Errors thrown by rejected Promises need to be caught, or they will be swallowed silently


### PR DESCRIPTION
Context of example was not clear, standalone async function vs object literal have different syntax
See #5869, #5885 