### PR TITLE
Update JavaScriptEnvironment.md to fix link

### DIFF
--- a/docs/JavaScriptEnvironment.md
+++ b/docs/JavaScriptEnvironment.md
@@ -22,7 +22,7 @@ Syntax transformers make writing code more enjoyable by allowing you to use new 
 
 As of version 0.5.0, React Native ships with the [Babel JavaScript compiler](https://babeljs.io). Check [Babel documentation](http://babeljs.io/docs/advanced/transformers/) on its supported transformations for more details.
 
-Here's a full list of React Native's [enabled transformations](https://github.com/facebook/react-native/blob/master/babel-preset/configs/main.js#L16).
+Here's a full list of React Native's [enabled transformations](https://github.com/facebook/react-native/blob/194092e7290c2a2e50e0263bac67686df418b915/babel-preset/configs/main.js#L16).
 
 ES5
 


### PR DESCRIPTION
This link is outdated, currently links to https://github.com/facebook/react-native/blob/e6cb02d61af82832016bafb259a1b0d3039a357e/packager/transformer.js#L16. Transforms moved to other package in https://github.com/facebook/react-native/commit/e6cb02d61af82832016bafb259a1b0d3039a357e