### PR TITLE
UIExplorer duplicate example fix

### DIFF
--- a/Examples/UIExplorer/UIExplorerList.android.js
+++ b/Examples/UIExplorer/UIExplorerList.android.js
@@ -55,7 +55,6 @@ var APIS = [
   require('./LayoutEventsExample'),
   require('./NavigationExperimental/NavigationExperimentalExample'),
   require('./LayoutExample'),
-  require('./NavigationExperimental/NavigationExperimentalExample'),
   require('./NetInfoExample'),
   require('./PanResponderExample'),
   require('./PointerEventsExample'),


### PR DESCRIPTION
It's a great example but we probably only need to show it once