### PR TITLE
Check ListView SCROLLVIEW_REF can scroll

### DIFF
--- a/Libraries/CustomComponents/ListView/ListView.js
+++ b/Libraries/CustomComponents/ListView/ListView.js
@@ -234,6 +234,7 @@ var ListView = React.createClass({
    */
   getScrollResponder: function() {
     return this.refs[SCROLLVIEW_REF] && 
+      this.refs[SCROLLVIEW_REF].hasOwnProperty('getScrollResponder') &&
       this.refs[SCROLLVIEW_REF].getScrollResponder();
   },
 


### PR DESCRIPTION
If rendering a ListView with a component that doesn't scroll - for example a standard View - the `getScrollResponder` method should return false. Otherwise a "is not a function" exception is thrown.

This was slightly addressed https://github.com/facebook/react-native/commit/4326b01181559a908740cda0a4c8459c9bdb919d but not quite fully.

The `scrollTo` method could also implement the check, but as it not called directly by the component - a developer must call it directly - it's not necessary to handle.