### PR TITLE
Cleaned up versions.html naming

### DIFF
--- a/website/src/react-native/versions.js
+++ b/website/src/react-native/versions.js
@@ -15,21 +15,29 @@ var versions = React.createClass({
   render: function() {
 
     var availableDocs = (Metadata.config.RN_AVAILABLE_DOCS_VERSIONS || '').split(',');
+
     var versions = [
       {
-        title: 'next',
+        title: 'master',
         path: '/react-native/releases/next',
       },
-      {
-        title: 'stable',
-        path: '/react-native',
-      },
     ].concat(availableDocs.map((version) => {
+      const isLatest =  Metadata.config.RN_LATEST_VERSION === version;
       return {
-        title: version,
-        path: '/react-native/releases/' + version
+        title: isLatest ? `${version} + (current)` : version,
+        path: isLatest ? '/react-native' : '/react-native/releases/' + version
       }
     }));
+
+    if (!Metadata.config.RN_LATEST_VERSION) {
+      versions = [
+        {
+          title: 'current',
+          path: '/react-native',
+        },
+      ].concat(versions);
+    }
+
     var versionsLi = versions.map((version) =>
       <li><a href={version.path}>{version.title}</a></li>
     );


### PR DESCRIPTION
- latest is now displayed as current to reflect that this is what you get with `npm install`
- if branch is current then in versions.html the link will lead to website root
- renamed next into master to reflect that this version is built from master branch