### PR TITLE
Added UDID to the simulator identifier in `react-native run-ios`

### DIFF
--- a/local-cli/runIOS/runIOS.js
+++ b/local-cli/runIOS/runIOS.js
@@ -52,7 +52,7 @@ function _runIOS(argv, config, resolve, reject) {
     throw new Error(`Cound't find ${args.simulator} simulator`);
   }
 
-  const simulatorFullName = `${selectedSimulator.name} (${selectedSimulator.version})`;
+  const simulatorFullName = `${selectedSimulator.name} (${selectedSimulator.version}) [${selectedSimulator.udid}]`;
   console.log(`Launching ${simulatorFullName}...`);
   try {
     child_process.spawnSync('xcrun', ['instruments', '-w', simulatorFullName]);

--- a/local-cli/runIOS/runIOS.js
+++ b/local-cli/runIOS/runIOS.js
@@ -55,7 +55,7 @@ function _runIOS(argv, config, resolve, reject) {
   const simulatorFullName = `${selectedSimulator.name} (${selectedSimulator.version}) [${selectedSimulator.udid}]`;
   console.log(`Launching ${simulatorFullName}...`);
   try {
-    child_process.spawnSync('xcrun', ['instruments', '-w', simulatorFullName]);
+    child_process.spawnSync('xcrun', ['instruments', '-w', selectedSimulator.udid]);
   } catch(e) {
     // instruments always fail with 255 because it expects more arguments,
     // but we want it to only launch the simulator


### PR DESCRIPTION
Added in the UUID to the `simulatorFullName` that is passed to `xcrun instruments -w`.

If you have an simulator setup with an Apple Watch, just trying to launch a simulator like `iPhone 6 (9.2)` will cause a `Instruments Usage Error : Ambiguous device name/identifier` error because there could another simulator called `iPhone 6 (9.2) + Apple Watch ...`

Another alternative is to _just_ pass the UUID to the `-w` flag.