### PR TITLE
Increase timeout for JS bundle download on Travis

### DIFF
--- a/Libraries/RCTTest/RCTTestRunner.m
+++ b/Libraries/RCTTest/RCTTestRunner.m
@@ -17,6 +17,7 @@
 #import "RCTUtils.h"
 #import "RCTJSCExecutor.h"
 #import "RCTBridge+Private.h"
+#import "RCTJavascriptLoader.h"
 
 static const NSTimeInterval kTestTimeoutSeconds = 60;
 static const NSTimeInterval kTestTeardownTimeoutSeconds = 30;
@@ -51,6 +52,11 @@ static const NSTimeInterval kTestTeardownTimeoutSeconds = 30;
 #else
     _scriptURL = [NSURL URLWithString:[NSString stringWithFormat:@"http://localhost:8081/%@.bundle?platform=ios&dev=true", app]];
 #endif
+
+    // Travis can be extremely slow, configure higher timeouts
+    NSURLSessionConfiguration *sessionConfig = [NSURLSessionConfiguration defaultSessionConfiguration];
+    sessionConfig.timeoutIntervalForRequest = 120;
+    [RCTJavaScriptLoader setURLSessionConfiguration:sessionConfig];
   }
   return self;
 }

--- a/React/Base/RCTJavaScriptLoader.h
+++ b/React/Base/RCTJavaScriptLoader.h
@@ -11,14 +11,13 @@
 
 #import "RCTBridgeDelegate.h"
 
-@class RCTBridge;
-
 /**
  * Class that allows easy embedding, loading, life-cycle management of a
  * JavaScript application inside of a native application.
- * TODO: Incremental module loading. (low pri).
  */
 @interface RCTJavaScriptLoader : NSObject
+
++ (void)setURLSessionConfiguration:(NSURLSessionConfiguration *)urlSessionConfiguration;
 
 + (void)loadBundleAtURL:(NSURL *)moduleURL onComplete:(RCTSourceLoadBlock)onComplete;
 

--- a/React/Base/RCTJavaScriptLoader.m
+++ b/React/Base/RCTJavaScriptLoader.m
@@ -19,6 +19,13 @@
 
 RCT_NOT_IMPLEMENTED(- (instancetype)init)
 
+static NSURLSessionConfiguration *_urlSessionConfiguration = nil;
+
++ (void)setURLSessionConfiguration:(NSURLSessionConfiguration *)urlSessionConfiguration
+{
+  _urlSessionConfiguration = urlSessionConfiguration;
+}
+
 + (void)loadBundleAtURL:(NSURL *)scriptURL onComplete:(RCTSourceLoadBlock)onComplete
 {
   // Sanitize the script URL
@@ -46,10 +53,15 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
     return;
   }
 
-  // Load remote script file
-  NSURLSessionDataTask *task = [[NSURLSession sharedSession] dataTaskWithURL:scriptURL completionHandler:
-                                ^(NSData *data, NSURLResponse *response, NSError *error) {
+  NSURLSession *session;
+  if (_urlSessionConfiguration) {
+    session = [NSURLSession sessionWithConfiguration:_urlSessionConfiguration];
+  } else {
+    session = [NSURLSession sharedSession];
+  }
 
+  // Load remote script file
+  NSURLSessionDataTask *task = [session dataTaskWithURL:scriptURL completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
     // Handle general request errors
     if (error) {
       if ([error.domain isEqualToString:NSURLErrorDomain]) {


### PR DESCRIPTION
Looks like Travis can be incredibly slow when generating the JS bundle. This adds an optional configuration object to RCTJavascriptLoader that increases the timeout used.

    [3:53:23 PM] <END>   transform (43505ms)`