### PR TITLE
Make `providesModuleNodeModules` behavior to be more deterministic.

### DIFF
--- a/packager/react-packager/src/Resolver/index.js
+++ b/packager/react-packager/src/Resolver/index.js
@@ -85,14 +85,21 @@ class Resolver {
           (opts.blacklistRE && opts.blacklistRE.test(filepath));
       },
       providesModuleNodeModules: [
-        'fbjs',
-        'react',
-        'react-native',
+        // Use the project's installed version of react-native
+        // as the "haste" version of `react-native`
+        // (and ignore any nested copies);
+        { name: 'react-native', parent: null },
+        // Use the react peerDep for the "haste"
+        // version of `react`.
+        { name: 'react', parent: null },
+        // We only want to use the fbjs underneath react-native
+        // as the "haste" version of `fbjs`.
+        { name: 'fbjs', parent: 'react-native' },
         // Parse requires AsyncStorage. They will
         // change that to require('react-native') which
         // should work after this release and we can
         // remove it from here.
-        'parse',
+        { name: 'parse', parent: null },
       ],
       platforms: ['ios', 'android'],
       preferNativePlatform: true,


### PR DESCRIPTION
Currently, the `providesModuleNodeModules` option allows for specifying an array of package names, that the packager will look for within node_modules, no matter how deep they're nested, and treat them as packages that use the `@providesModule` pragma.

In reality, this is not actually the behavior we want.

NPM, because of how it handles dependencies, can do all kinds of arbitrary nesting of packages when `npm install` is run. This causes a problem for how we deal with `providesModuleNodeModules`. Specifically...take `fbjs`. Currently, React Native relies on using the Haste version of `fbjs` (will be resolved in #5084). Thus if npm installs multiple copies of fbjs...which is a very common thing for it to do (as can be seen by this list of issues: https://github.com/facebook/react-native/issues?utf8=%E2%9C%93&q=naming+collision+detected), we get into a state where the packager fails and says that we have a naming collision.

Really, the behavior we want is for the packager to treat only a *single* copy of a given package, that we specify in the `Resolver` in the `providesModuleNodeModules` option, as the package that it uses when trying to resolve Haste modules.

This PR provides that behavior, by changing `providesModuleNodeModules` from a list of strings to a list of objects that have a `name` key, specifying the package name, as well as a `parent` key. If `parent` is null, it will look for the package at the top level (directly under `node_modules`). If `parent` is specified, it will use the package that is nested under that parent as the Haste module.

To anyone who reads this PR and is familiar with the differences between npm2 and npm3 -- this solution works under both, given the fact that we are now shipping the NPM Shrinkwrap file with React Native when it's installed through `npm`. In both the npm2 and npm3 case, node_modules specified by RN's package.json are nested underneath `react-native` in node_modules, thus allowing us to specify, for example, that we want to use React Native's copy of `fbjs` (not any other copy that may be installed) as the module used by the packager to resolve any `requires` that reference a module in `fbjs`.

Test Plan:

##### npm 2
1) `react-native init` a new project
2) Using npm@2, `npm install --save skevy/react-native#fix-providesModuleNodeModules react@0.14.5`
3) Observe the project compiling correctly, despite multiple copies of `react` and `fbjs` being installed.

##### npm 3
1) `react-native init` a new project
2) Using npm@3, `npm install --save skevy/react-native#fix-providesModuleNodeModules react@0.14.5`
3) Observe the project compiling correctly, despite multiple copies of `react` and `fbjs` being installed.

/cc @martinbigio @mkonicek @bestander @davidaurelio @ide