### PR TITLE
Update `ScrollResponder.js` to use new `scrollTo` API

### DIFF
--- a/Libraries/Components/ScrollResponder.js
+++ b/Libraries/Components/ScrollResponder.js
@@ -461,7 +461,7 @@ var ScrollResponderMixin = {
     if (this.preventNegativeScrollOffset) {
       scrollOffsetY = Math.max(0, scrollOffsetY);
     }
-    this.scrollResponderScrollTo(0, scrollOffsetY);
+    this.scrollResponderScrollTo({x: 0, y: scrollOffsetY, animated: true});
 
     this.additionalOffset = 0;
     this.preventNegativeScrollOffset = false;


### PR DESCRIPTION
`scrollResponderInputMeasureAndScrollToKeyboard` is the only non-deprecated method in `ScrollResponder.js` that doesn't use the [new `scrollTo` API](https://github.com/facebook/react-native/commit/6941c4e027abb582d7cef0e7c3b9b7ebf51bc070). The other method that uses the deprecated API (`scrollResponderScrollWithoutAnimationTo`) is also deprecated, so it has been left unaltered.