### PR TITLE
Adds additional help when a module is missing.

### DIFF
--- a/packager/react-packager/src/Resolver/polyfills/require-unbundle.js
+++ b/packager/react-packager/src/Resolver/polyfills/require-unbundle.js
@@ -80,7 +80,7 @@ function unknownModuleError(id) {
   let message = 'Requiring unknown module "' + id + '".';
   if (__DEV__) {
     message +=
-      'If you are sure the module is there, try restarting the packager.';
+      'If you are sure the module is there, try restarting the packager or running "npm install".';
   }
   return Error(message);
 }

--- a/packager/react-packager/src/Resolver/polyfills/require.js
+++ b/packager/react-packager/src/Resolver/polyfills/require.js
@@ -48,7 +48,7 @@ function requireImpl(id) {
   if (!mod) {
     var msg = 'Requiring unknown module "' + id + '"';
     if (__DEV__) {
-      msg += '. If you are sure the module is there, try restarting the packager.';
+      msg += '. If you are sure the module is there, try restarting the packager or running "npm install".';
     }
     throw new Error(msg);
   }


### PR DESCRIPTION
Hey.  Long time fan, first time forker.

You know when you're working on a project with someone and they bring in a new dependency?

When you first pull their code and you haven't also installed that dependency, the error that is shown is this:

#### Current Message

![image](https://cloud.githubusercontent.com/assets/68273/13145164/d8748b3e-d61c-11e5-9df9-3e47edf3fcfb.png)

This PR simply adds  `or running "npm install"` to the end of that message.

Just adds a little clarity to newcomers.  Hell knows I was lost for a while when I was starting.

#### New Message

![image](https://cloud.githubusercontent.com/assets/68273/13145253/65e8f31a-d61d-11e5-99ac-2d79d8e37123.png)
