### PR TITLE
[Websocket] Update options parameter to headers. Update to spec.

### DIFF
--- a/Libraries/WebSocket/RCTSRWebSocket.h
+++ b/Libraries/WebSocket/RCTSRWebSocket.h
@@ -61,11 +61,11 @@ extern NSString *const RCTSRHTTPResponseErrorKey;
 
 // Protocols should be an array of strings that turn into Sec-WebSocket-Protocol.
 // options can contain a custom "origin" NSString
-- (instancetype)initWithURLRequest:(NSURLRequest *)request protocols:(NSArray<NSString *> *)protocols options:(NSDictionary<NSString *, NSString *> *)options NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithURLRequest:(NSURLRequest *)request protocols:(NSArray<NSString *> *)protocols headers:(NSDictionary<NSString *, NSString *> *)headers NS_DESIGNATED_INITIALIZER;
 - (instancetype)initWithURLRequest:(NSURLRequest *)request;
 
 // Some helper constructors.
-- (instancetype)initWithURL:(NSURL *)url protocols:(NSArray<NSString *> *)protocols options:(NSDictionary<NSString *, NSString *> *)options;
+- (instancetype)initWithURL:(NSURL *)url protocols:(NSArray<NSString *> *)protocols headers:(NSDictionary<NSString *, NSString *> *)headers;
 - (instancetype)initWithURL:(NSURL *)url protocols:(NSArray<NSString *> *)protocols;
 - (instancetype)initWithURL:(NSURL *)url;
 

--- a/Libraries/WebSocket/RCTWebSocketModule.m
+++ b/Libraries/WebSocket/RCTWebSocketModule.m
@@ -44,9 +44,9 @@ RCT_EXPORT_MODULE()
   }
 }
 
-RCT_EXPORT_METHOD(connect:(NSURL *)URL protocols:(NSArray *)protocols options:(NSDictionary *)options socketID:(nonnull NSNumber *)socketID)
+RCT_EXPORT_METHOD(connect:(NSURL *)URL protocols:(NSArray *)protocols headers:(NSDictionary *)headers socketID:(nonnull NSNumber *)socketID)
 {
-  RCTSRWebSocket *webSocket = [[RCTSRWebSocket alloc] initWithURL:URL protocols:protocols options:options];
+  RCTSRWebSocket *webSocket = [[RCTSRWebSocket alloc] initWithURL:URL protocols:protocols headers:headers];
   webSocket.delegate = self;
   webSocket.reactTag = socketID;
   if (!_sockets) {

--- a/Libraries/WebSocket/WebSocket.js
+++ b/Libraries/WebSocket/WebSocket.js
@@ -33,10 +33,10 @@ class WebSocket extends WebSocketBase {
   _socketId: number;
   _subs: any;
 
-  connectToSocketImpl(url: string, protocols: ?Array<string>, options: ?{origin?: string}): void {
+  connectToSocketImpl(url: string, protocols: ?Array<string>, headers: ?Object): void {
     this._socketId = WebSocketId++;
 
-    RCTWebSocketModule.connect(url, protocols, options, this._socketId);
+    RCTWebSocketModule.connect(url, protocols, headers, this._socketId);
 
     this._registerEvents(this._socketId);
   }

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/websocket/WebSocketModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/websocket/WebSocketModule.java
@@ -34,6 +34,8 @@ import com.squareup.okhttp.ws.WebSocket;
 import com.squareup.okhttp.ws.WebSocketCall;
 import com.squareup.okhttp.ws.WebSocketListener;
 
+import java.net.URISyntaxException;
+import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -63,7 +65,7 @@ public class WebSocketModule extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
-  public void connect(final String url, @Nullable final ReadableArray protocols, @Nullable final ReadableMap options, final int id) {
+  public void connect(final String url, @Nullable final ReadableArray protocols, @Nullable final ReadableMap headers, final int id) {
     // ignoring protocols, since OKHttp overrides them.
     OkHttpClient client = new OkHttpClient();
 
@@ -76,14 +78,25 @@ public class WebSocketModule extends ReactContextBaseJavaModule {
         .tag(id)
         .url(url);
 
-    if (options != null && options.hasKey("origin")) {
-      if (ReadableType.String.equals(options.getType("origin"))) {
-        builder.addHeader("Origin", options.getString("origin"));
-      } else {
-        FLog.w(
-          ReactConstants.TAG,
-          "Ignoring: requested origin, value not a string");
+    if (headers != null) {
+      ReadableMapKeySetIterator iterator = headers.keySetIterator();
+
+      if (!headers.hasKey("origin")) {
+        builder.addHeader("origin", setDefaultOrigin(url));
       }
+
+      while (iterator.hasNextKey()) {
+        String key = iterator.nextKey();
+        if (ReadableType.String.equals(headers.getType(key))) {
+          builder.addHeader(key, headers.getString(key));
+        } else {
+          FLog.w(
+            ReactConstants.TAG,
+            "Ignoring: requested " + key + ", value not a string");
+        }
+      }
+    } else {
+      builder.addHeader("origin", setDefaultOrigin(url));
     }
 
     WebSocketCall.create(client, builder.build()).enqueue(new WebSocketListener() {
@@ -188,4 +201,37 @@ public class WebSocketModule extends ReactContextBaseJavaModule {
     params.putString("message", message);
     sendEvent("websocketFailed", params);
   }
+
+  /**
+   * Set a default origin
+   *
+   * @param Websocket connection endpoint
+   * @return A string of the endpoint converted to HTTP protocol
+   */
+
+  private static String setDefaultOrigin(String uri) {
+    try {
+      String defaultOrigin;
+      String scheme = "";
+
+      URI requestURI = new URI(uri);
+      if (requestURI.getScheme().equals("wss")) {
+        scheme += "https";
+      } else if (requestURI.getScheme().equals("ws")) {
+        scheme += "http";
+      }
+
+      if (requestURI.getPort() != -1) {
+        defaultOrigin = String.format("%s://%s:%s", scheme, requestURI.getHost(), requestURI.getPort());
+      } else {
+        defaultOrigin = String.format("%s://%s/", scheme, requestURI.getHost());
+      }
+
+      return defaultOrigin;
+
+    } catch(URISyntaxException e) {
+        throw new IllegalArgumentException("Unable to set " + uri + " as default origin header.");
+    }
+  }
+
 }


### PR DESCRIPTION
This is a follow up of https://github.com/facebook/react-native/commit/9b87e6c860a95fe3d55285314d3d56be06cb7833.

### PR Overview:
- Allows custom headers on connection request
- Adds a default `origin` header to Android, just like iOS

**Introduces no breaking changes.**

### PR Detail:

I was working on something similar and would like to propose a few changes that make the API more consistent across both iOS and Android platforms and brings this closer to [spec](https://tools.ietf.org/html/rfc6455).

I believe @aprock first implementation of adding custom `headers` was correct. It makes sense naming this argument `headers` since we have no other general options available, and the current `options` field is being used to pass in a header anyway.

My use case for custom headers was attaching a token to the `Authorization` header on the connection request. I have been testing this by passing a JWT inside the `Authorization` header and verifying it on the server before establishing a connection.

I tried to take this this abstraction further and read the response headers from the server to see if a new token was available if the connection was denied from a expired token. Unfortunately, this was only possible with Android since the third party library used by iOS (SquareRocket) does not return the server response on connection failures.
