### PR TITLE
Update providesModuleNodeModules option to use new format.

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,10 +24,10 @@
     "haste": {
       "defaultPlatform": "ios",
       "providesModuleNodeModules": [
-        { name: "fbjs" },
-        { name: "react" },
-        { name: "react-native" },
-        { name: "parse" }
+        { "name": "fbjs" },
+        { "name": "react" },
+        { "name": "react-native" },
+        { "name": "parse" }
       ],
       "platforms": ["ios", "android"]
     },

--- a/package.json
+++ b/package.json
@@ -24,11 +24,10 @@
     "haste": {
       "defaultPlatform": "ios",
       "providesModuleNodeModules": [
-        "fbjs",
-        "react",
-        "react-native",
-        "parse",
-        "react-transform-hmr"
+        { name: "fbjs" },
+        { name: "react" },
+        { name: "react-native" },
+        { name: "parse" }
       ],
       "platforms": ["ios", "android"]
     },

--- a/packager/react-packager/src/Resolver/index.js
+++ b/packager/react-packager/src/Resolver/index.js
@@ -84,14 +84,21 @@ class Resolver {
           (opts.blacklistRE && opts.blacklistRE.test(filepath));
       },
       providesModuleNodeModules: [
-        'fbjs',
-        'react',
-        'react-native',
+        // Use the project's installed version of react-native
+        // as the "haste" version of `react-native`
+        // (and ignore any nested copies);
+        { name: 'react-native', parent: null },
+        // Use the react peerDep for the "haste"
+        // version of `react`.
+        { name: 'react', parent: null },
+        // We only want to use the fbjs underneath react-native
+        // as the "haste" version of `fbjs`.
+        { name: 'fbjs', parent: 'react-native' },
         // Parse requires AsyncStorage. They will
         // change that to require('react-native') which
         // should work after this release and we can
         // remove it from here.
-        'parse',
+        { name: 'parse', parent: null },
       ],
       platforms: ['ios', 'android'],
       preferNativePlatform: true,


### PR DESCRIPTION
Updates providesModuleNodeModules option to use new format from https://github.com/facebook/node-haste/pull/33.

Supercedes https://github.com/facebook/react-native/pull/5985.

Ok to merge when node-haste is updated.

/cc @bestander @cpojer @mkonicek 