### PR TITLE
Resolved UIExplorer StatusBarIOS deprecation warning

### DIFF
--- a/Examples/UIExplorer/NavigatorIOSColorsExample.js
+++ b/Examples/UIExplorer/NavigatorIOSColorsExample.js
@@ -16,7 +16,7 @@
 var React = require('react-native');
 var {
   NavigatorIOS,
-  StatusBarIOS,
+  StatusBar,
   StyleSheet,
   Text,
   View
@@ -45,7 +45,7 @@ var NavigatorIOSColors = React.createClass({
 
   render: function() {
     // Set StatusBar with light contents to get better contrast
-    StatusBarIOS.setStyle('light-content');
+    StatusBar.setBarStyle('light-content');
 
     return (
       <NavigatorIOS
@@ -55,7 +55,7 @@ var NavigatorIOSColors = React.createClass({
           title: '<NavigatorIOS>',
           rightButtonTitle: 'Done',
           onRightButtonPress: () => {
-            StatusBarIOS.setStyle('default');
+            StatusBar.setBarStyle('default');
             this.props.onExampleExit();
           },
           passProps: {


### PR DESCRIPTION
UIExplorer `<NavigatorIOS> - Custom` was displaying a deprecation warning. I took the warning's advice and updated with `StatusBar.setBarStyle`.

Before:
![image](https://cloud.githubusercontent.com/assets/4726068/13193296/f5adfcbc-d72a-11e5-923f-f327382f0137.png)

After:
![image](https://cloud.githubusercontent.com/assets/4726068/13193303/0536ae4a-d72b-11e5-90ac-7338280ecac0.png)