### PR TITLE
Fix hidden StatusBar reappearing after exiting app on Android

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/modules/statusbar/StatusBarModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/statusbar/StatusBarModule.java
@@ -19,7 +19,6 @@ import android.support.v4.view.ViewCompat;
 import android.view.View;
 import android.view.WindowManager;
 
-import com.facebook.react.bridge.LifecycleEventListener;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;


### PR DESCRIPTION
I changed the technique used to hide the status bar and now it works properly. Also changed the way flags are set on the decorView to make sure it doesn't cause issues with other flags already set and fix deprecated Promise.reject

**Test plan**
Test using the UIExplorer StatusBar example, change the `hidden` prop value and go in and out of the app making sure the status bar has the right visibility.

Fixes #5991

