### PR TITLE
Android WebSocket: include cookies with request

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/modules/websocket/WebSocketModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/websocket/WebSocketModule.java
@@ -15,6 +15,9 @@ import java.io.IOException;
 import java.lang.IllegalStateException;
 import javax.annotation.Nullable;
 
+import android.net.Uri;
+import android.webkit.CookieManager;
+
 import com.facebook.common.logging.FLog;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReactApplicationContext;
@@ -86,6 +89,27 @@ public class WebSocketModule extends ReactContextBaseJavaModule {
     Request.Builder builder = new Request.Builder()
         .tag(id)
         .url(url);
+
+    if (url != null) {
+      // Use the shared CookieManager to access the cookies
+      // set by WebViews inside the same app
+      CookieManager cookieManager = CookieManager.getInstance();
+
+      Uri parsedUrl = Uri.parse(url);
+      Uri.Builder builtUrl = parsedUrl.buildUpon();
+
+      // To get HTTPS-only cookies for wss URLs,
+      // replace wss with http in the URL.
+      if (parsedUrl.getScheme().equals("wss")) {
+        builtUrl.scheme("https");
+      }
+
+      String cookie = cookieManager.getCookie(builtUrl.build().toString());
+
+      if (cookie != null) {
+        builder.addHeader("Cookie", cookie);
+      }
+    }
 
     if (headers != null) {
       ReadableMapKeySetIterator iterator = headers.keySetIterator();


### PR DESCRIPTION
This commit brings Android in line with iOS WebSockets by sending along cookies from the shared CookieManager. See: https://github.com/facebook/react-native/pull/5630