### PR TITLE
Fix Platform.Version documentation

### DIFF
--- a/docs/PlatformSpecificInformation.md
+++ b/docs/PlatformSpecificInformation.md
@@ -61,7 +61,7 @@ On Android, the Platform module can be also used to detect which is the version 
 ```javascript
 var {Platform} = React;
 
-if(Platform.Version === '5.0'){
+if(Platform.Version === 21){
   console.log('Running on Lollipop!');
 }
 ```


### PR DESCRIPTION
Version exposes the sdk level (which TBH is more useful anyways), not a version string.