### PR TITLE
A semicolon is required after a class property

### DIFF
--- a/Examples/UIExplorer/TabBarIOSExample.js
+++ b/Examples/UIExplorer/TabBarIOSExample.js
@@ -29,9 +29,9 @@ var TabBarExample = React.createClass({
   statics: {
     title: '<TabBarIOS>',
     description: 'Tab-based navigation.',
-  },
+  };
 
-  displayName: 'TabBarExample',
+  displayName: 'TabBarExample';
 
   getInitialState: function() {
     return {


### PR DESCRIPTION
Terminal Message.

transforming [========================================] 100% 407/408Error while persisting cache: SyntaxError /TabBarExample/index.ios.js: **A semicolon is required after a class property** (21:13)
