### PR TITLE
Fixed anchor links in Markdown documentation

### DIFF
--- a/website/core/Header.js
+++ b/website/core/Header.js
@@ -20,7 +20,7 @@ var Header = React.createClass({
       <H {...this.props}>
         <a className="anchor" name={slug}></a>
         {this.props.children}
-        {' '}<a className="hash-link" href={'#' + slug}>#</a>
+        {' '}<a className="hash-link" href={this.props.path + '#' + slug}>#</a>
       </H>
     );
   }

--- a/website/core/Marked.js
+++ b/website/core/Marked.js
@@ -821,6 +821,7 @@ Parser.prototype.tok = function() {
       return (
         <Header
           level={this.token.depth}
+          path={this.options.path}
           toSlug={this.token.text}>
           {this.inline.output(this.token.text)}
         </Header>

--- a/website/layout/DocsLayout.js
+++ b/website/layout/DocsLayout.js
@@ -30,7 +30,7 @@ var DocsLayout = React.createClass({
               level={1}
               path={'docs/' + metadata.filename}
             />
-            <Marked>{content}</Marked>
+            <Marked path={metadata.permalink}>{content}</Marked>
             <div className="docs-prevnext">
               {metadata.previous && <a className="docs-prev" href={'docs/' + metadata.previous + '.html#content'}>&larr; Prev</a>}
               {metadata.next && <a className="docs-next" href={'docs/' + metadata.next + '.html#content'}>Next &rarr;</a>}


### PR DESCRIPTION
Anchor links on page like `https://facebook.github.io/react-native/docs/known-issues.html#content` don't work with <base> tag in HTML.
It is a very common issue https://www.google.co.uk/?gws_rd=ssl#q=anchor+links+base+tag.

This PR fixes the problem by passing permalink DocsLayout->Marked->Header.
Tested on local server.
I'll cherry-pick this commit into 0.21-stable to make sure it works for releases/xx websites