### PR TITLE
Fix android's image tintColor prop when used with alpha

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageManager.java
@@ -14,6 +14,7 @@ import javax.annotation.Nullable;
 import java.util.Map;
 
 import android.graphics.Color;
+import android.graphics.PorterDuff.Mode;
 
 import com.facebook.drawee.backends.pipeline.Fresco;
 import com.facebook.drawee.controller.AbstractDraweeControllerBuilder;
@@ -120,7 +121,7 @@ public class ReactImageManager extends SimpleViewManager<ReactImageView> {
     if (tintColor == null) {
       view.clearColorFilter();
     } else {
-      view.setColorFilter(tintColor);
+      view.setColorFilter(tintColor, Mode.SRC_IN);
     }
   }
 


### PR DESCRIPTION
Fixes https://github.com/facebook/react-native/issues/6075
UIExplorer example has been tested with 4 levels of opacity(100,75,50,25)

![selection_029](https://cloud.githubusercontent.com/assets/11550281/13228124/31c85dcc-d9c0-11e5-90e3-3938e155d5a2.png)
