### PR TITLE
Add support for elevation in DrawerLayoutAndroid

### DIFF
--- a/Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.android.js
+++ b/Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.android.js
@@ -156,7 +156,7 @@ var DrawerLayoutAndroid = React.createClass({
         drawerWidth={this.props.drawerWidth}
         drawerPosition={this.props.drawerPosition}
         drawerLockMode={this.props.drawerLockMode}
-        style={styles.base}
+        style={[styles.base, this.props.style]}
         onDrawerSlide={this._onDrawerSlide}
         onDrawerOpen={this._onDrawerOpen}
         onDrawerClose={this._onDrawerClose}
@@ -218,6 +218,7 @@ var DrawerLayoutAndroid = React.createClass({
 var styles = StyleSheet.create({
   base: {
     flex: 1,
+    elevation: 16,
   },
   mainSubview: {
     position: 'absolute',
@@ -230,6 +231,7 @@ var styles = StyleSheet.create({
     position: 'absolute',
     top: 0,
     bottom: 0,
+    backgroundColor: 'white',
   },
 });
 

--- a/ReactAndroid/src/main/java/com/facebook/react/processing/ReactPropertyProcessor.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/processing/ReactPropertyProcessor.java
@@ -578,7 +578,8 @@ public class ReactPropertyProcessor extends AbstractProcessor {
       if (checkPropertyExists(name)) {
         throw new ReactPropertyException(
             "Module " + mClassName + " has already registered a property named \"" +
-                name + '"', propertyInfo);
+                name + "\". If you want to override a property, don't add" +
+                "the @ReactProp annotation to the property in the subclass", propertyInfo);
       }
 
       mProperties.add(propertyInfo);

--- a/ReactAndroid/src/main/java/com/facebook/react/views/drawer/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/drawer/BUCK
@@ -10,6 +10,7 @@ android_library(
     react_native_target('java/com/facebook/react/uimanager:uimanager'),
     react_native_target('java/com/facebook/react/uimanager/annotations:annotations'),
     react_native_target('java/com/facebook/react/views/scroll:scroll'),
+    react_native_dep('libraries/fbcore/src/main/java/com/facebook/common/logging:logging'),
     react_native_dep('third-party/java/jsr-305:jsr-305'),
     react_native_dep('third-party/android/support/v4:lib-support-v4'),
   ],

--- a/ReactAndroid/src/main/java/com/facebook/react/views/drawer/ReactDrawerLayoutManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/drawer/ReactDrawerLayoutManager.java
@@ -13,6 +13,7 @@ import javax.annotation.Nullable;
 
 import java.util.Map;
 
+import android.os.Build;
 import android.support.v4.widget.DrawerLayout;
 import android.view.Gravity;
 import android.view.View;
@@ -86,6 +87,13 @@ public class ReactDrawerLayoutManager extends ViewGroupManager<ReactDrawerLayout
       view.setDrawerLockMode(DrawerLayout.LOCK_MODE_LOCKED_OPEN);
     } else {
       throw new JSApplicationIllegalArgumentException("Unknown drawerLockMode " + drawerLockMode);
+    }
+  }
+
+  @Override
+  public void setElevation(ReactDrawerLayout view, float elevation) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+      view.setDrawerElevation(PixelUtil.toPixelFromDIP(elevation));
     }
   }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/views/drawer/ReactDrawerLayoutManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/drawer/ReactDrawerLayoutManager.java
@@ -11,6 +11,8 @@ package com.facebook.react.views.drawer;
 
 import javax.annotation.Nullable;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.Map;
 
 import android.os.Build;
@@ -93,7 +95,15 @@ public class ReactDrawerLayoutManager extends ViewGroupManager<ReactDrawerLayout
   @Override
   public void setElevation(ReactDrawerLayout view, float elevation) {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-      view.setDrawerElevation(PixelUtil.toPixelFromDIP(elevation));
+      // Facebook is using an older version of the support lib internally that doesn't support
+      // setDrawerElevation so we invoke it using reflection.
+      // TODO: Call the method directly when this is no longer needed.
+      try {
+        Method method = ReactDrawerLayout.class.getMethod("setDrawerElevation", float.class);
+        method.invoke(view, PixelUtil.toPixelFromDIP(elevation));
+      } catch (Exception e) {
+        // Ignore errors when the method is not present in older versions of support lib.
+      }
     }
   }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/views/drawer/ReactDrawerLayoutManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/drawer/ReactDrawerLayoutManager.java
@@ -20,9 +20,12 @@ import android.support.v4.widget.DrawerLayout;
 import android.view.Gravity;
 import android.view.View;
 
+import com.facebook.common.logging.FLog;
+
 import com.facebook.react.bridge.JSApplicationIllegalArgumentException;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.common.MapBuilder;
+import com.facebook.react.common.ReactConstants;
 import com.facebook.react.common.SystemClock;
 import com.facebook.react.uimanager.PixelUtil;
 import com.facebook.react.uimanager.ThemedReactContext;
@@ -101,8 +104,11 @@ public class ReactDrawerLayoutManager extends ViewGroupManager<ReactDrawerLayout
       try {
         Method method = ReactDrawerLayout.class.getMethod("setDrawerElevation", float.class);
         method.invoke(view, PixelUtil.toPixelFromDIP(elevation));
-      } catch (Exception e) {
-        // Ignore errors when the method is not present in older versions of support lib.
+      } catch (Exception ex) {
+        FLog.w(
+            ReactConstants.TAG,
+            "setDrawerElevation is not available in this version of the support lib.",
+            ex);
       }
     }
   }


### PR DESCRIPTION
It didn't work for a few reason. First, the drawer view NEEDS to have a background color or no shadow will ever render. Second, we need to use the `setDrawerElevation` method instead of `setElevation` for DrawerLayout. Finally we need to actually pass the style value (maybe we could just pass elevation but I don't really think it can cause any issues) down to the native component as it is not the case at the moment.

I also added a default style to elevation of 16 which is the standard for material design according to https://www.google.com/design/spec/patterns/navigation-drawer.html#navigation-drawer-specs. I could also default it to 0 so it keeps the same appearance as before but I think it looks better this way.

Closes #6022
**Test plan**
Tested using the DrawerLayout in the UIExplorer app.

Before, elevation 0
<img width="420" alt="screen shot 2016-02-23 at 1 55 42 am" src="https://cloud.githubusercontent.com/assets/2677334/13244000/008afdb2-d9d1-11e5-95b8-9c345ea0ea8d.png">

After, elevation 16
<img width="422" alt="screen shot 2016-02-23 at 1 54 48 am" src="https://cloud.githubusercontent.com/assets/2677334/13243992/f8511366-d9d0-11e5-80f4-84cd58d06536.png">



