### PR TITLE
Add missing textAlignVertical support on android textview

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
@@ -13,6 +13,7 @@ import android.content.Context;
 import android.graphics.drawable.Drawable;
 import android.text.Layout;
 import android.text.Spanned;
+import android.view.Gravity;
 import android.widget.TextView;
 
 import com.facebook.react.uimanager.ReactCompoundView;
@@ -20,9 +21,14 @@ import com.facebook.react.uimanager.ReactCompoundView;
 public class ReactTextView extends TextView implements ReactCompoundView {
 
   private boolean mContainsImages;
+  private int mDefaultGravityHorizontal;
+  private int mDefaultGravityVertical;
 
   public ReactTextView(Context context) {
     super(context);
+    mDefaultGravityHorizontal =
+      getGravity() & (Gravity.HORIZONTAL_GRAVITY_MASK | Gravity.RELATIVE_HORIZONTAL_GRAVITY_MASK);
+    mDefaultGravityVertical = getGravity() & Gravity.VERTICAL_GRAVITY_MASK;
   }
 
   public void setText(ReactTextUpdate update) {
@@ -149,5 +155,21 @@ public class ReactTextView extends TextView implements ReactCompoundView {
         span.onFinishTemporaryDetach();
       }
     }
+  }
+
+  /* package */ void setGravityHorizontal(int gravityHorizontal) {
+    if (gravityHorizontal == 0) {
+      gravityHorizontal = mDefaultGravityHorizontal;
+    }
+    setGravity(
+      (getGravity() & ~Gravity.HORIZONTAL_GRAVITY_MASK &
+        ~Gravity.RELATIVE_HORIZONTAL_GRAVITY_MASK) | gravityHorizontal);
+  }
+
+  /* package */ void setGravityVertical(int gravityVertical) {
+    if (gravityVertical == 0) {
+      gravityVertical = mDefaultGravityVertical;
+    }
+    setGravity((getGravity() & ~Gravity.VERTICAL_GRAVITY_MASK) | gravityVertical);
   }
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextViewManager.java
@@ -58,15 +58,30 @@ public class ReactTextViewManager extends BaseViewManager<ReactTextView, ReactTe
   @ReactProp(name = ViewProps.TEXT_ALIGN)
   public void setTextAlign(ReactTextView view, @Nullable String textAlign) {
     if (textAlign == null || "auto".equals(textAlign)) {
-      view.setGravity(Gravity.NO_GRAVITY);
+      view.setGravityHorizontal(Gravity.NO_GRAVITY);
     } else if ("left".equals(textAlign)) {
-      view.setGravity(Gravity.LEFT);
+      view.setGravityHorizontal(Gravity.LEFT);
     } else if ("right".equals(textAlign)) {
-      view.setGravity(Gravity.RIGHT);
+      view.setGravityHorizontal(Gravity.RIGHT);
     } else if ("center".equals(textAlign)) {
-      view.setGravity(Gravity.CENTER_HORIZONTAL);
+      view.setGravityHorizontal(Gravity.CENTER_HORIZONTAL);
     } else {
       throw new JSApplicationIllegalArgumentException("Invalid textAlign: " + textAlign);
+    }
+  }
+
+  @ReactProp(name = ViewProps.TEXT_ALIGN_VERTICAL)
+  public void setTextAlignVertical(ReactTextView view, @Nullable String textAlignVertical) {
+    if (textAlignVertical == null || "auto".equals(textAlignVertical)) {
+      view.setGravityVertical(Gravity.NO_GRAVITY);
+    } else if ("top".equals(textAlignVertical)) {
+      view.setGravityVertical(Gravity.TOP);
+    } else if ("bottom".equals(textAlignVertical)) {
+      view.setGravityVertical(Gravity.BOTTOM);
+    } else if ("center".equals(textAlignVertical)) {
+      view.setGravityVertical(Gravity.CENTER_VERTICAL);
+    } else {
+      throw new JSApplicationIllegalArgumentException("Invalid textAlignVertical: " + textAlignVertical);
     }
   }
 

--- a/ReactAndroid/src/test/java/com/facebook/react/views/text/ReactTextViewPropertyTest.java
+++ b/ReactAndroid/src/test/java/com/facebook/react/views/text/ReactTextViewPropertyTest.java
@@ -1,0 +1,109 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+package com.facebook.react.views.text;
+
+import android.util.DisplayMetrics;
+import android.view.Gravity;
+
+import com.facebook.react.bridge.CatalystInstance;
+import com.facebook.react.bridge.JavaOnlyMap;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactTestHelper;
+import com.facebook.react.uimanager.DisplayMetricsHolder;
+import com.facebook.react.uimanager.ReactStylesDiffMap;
+import com.facebook.react.uimanager.ThemedReactContext;
+import com.facebook.react.views.text.ReactTextView;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.modules.junit4.rule.PowerMockRule;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+
+import static org.fest.assertions.api.Assertions.assertThat;
+
+/**
+ * Verify {@link TextView} view property being applied properly by {@link ReactTextViewManager}
+ */
+@RunWith(RobolectricTestRunner.class)
+@PowerMockIgnore({"org.mockito.*", "org.robolectric.*", "android.*"})
+public class ReactTextViewPropertyTest {
+
+  @Rule
+  public PowerMockRule rule = new PowerMockRule();
+
+  private ReactApplicationContext mContext;
+  private CatalystInstance mCatalystInstanceMock;
+  private ThemedReactContext mThemedContext;
+  private ReactTextViewManager mManager;
+
+  @Before
+  public void setup() {
+    mContext = new ReactApplicationContext(RuntimeEnvironment.application);
+    mCatalystInstanceMock = ReactTestHelper.createMockCatalystInstance();
+    mContext.initializeWithInstance(mCatalystInstanceMock);
+    mThemedContext = new ThemedReactContext(mContext, mContext);
+    mManager = new ReactTextViewManager();
+    DisplayMetricsHolder.setWindowDisplayMetrics(new DisplayMetrics());
+  }
+
+  public ReactStylesDiffMap buildStyles(Object... keysAndValues) {
+    return new ReactStylesDiffMap(JavaOnlyMap.of(keysAndValues));
+  }
+
+  @Test
+  public void testTextAlign() {
+    ReactTextView view = mManager.createViewInstance(mThemedContext);
+    int defaultGravity = view.getGravity();
+
+    int defaultHorizontalGravity = defaultGravity & Gravity.HORIZONTAL_GRAVITY_MASK;
+    int defaultVerticalGravity = defaultGravity & Gravity.VERTICAL_GRAVITY_MASK;
+
+    // Theme
+    assertThat(view.getGravity()).isNotEqualTo(Gravity.NO_GRAVITY);
+
+    // TextAlign
+    mManager.updateProperties(view, buildStyles("textAlign", "left"));
+    assertThat(view.getGravity() & Gravity.HORIZONTAL_GRAVITY_MASK).isEqualTo(Gravity.LEFT);
+    mManager.updateProperties(view, buildStyles("textAlign", "right"));
+    assertThat(view.getGravity() & Gravity.HORIZONTAL_GRAVITY_MASK).isEqualTo(Gravity.RIGHT);
+    mManager.updateProperties(view, buildStyles("textAlign", "center"));
+    assertThat(view.getGravity() & Gravity.HORIZONTAL_GRAVITY_MASK).isEqualTo(Gravity.CENTER_HORIZONTAL);
+    mManager.updateProperties(view, buildStyles("textAlign", null));
+    assertThat(view.getGravity() & Gravity.HORIZONTAL_GRAVITY_MASK).isEqualTo(defaultHorizontalGravity);
+
+    // TextAlignVertical
+    mManager.updateProperties(view, buildStyles("textAlignVertical", "top"));
+    assertThat(view.getGravity() & Gravity.VERTICAL_GRAVITY_MASK).isEqualTo(Gravity.TOP);
+    mManager.updateProperties(view, buildStyles("textAlignVertical", "bottom"));
+    assertThat(view.getGravity() & Gravity.VERTICAL_GRAVITY_MASK).isEqualTo(Gravity.BOTTOM);
+    mManager.updateProperties(view, buildStyles("textAlignVertical", "center"));
+    assertThat(view.getGravity() & Gravity.VERTICAL_GRAVITY_MASK).isEqualTo(Gravity.CENTER_VERTICAL);
+    mManager.updateProperties(view, buildStyles("textAlignVertical", null));
+    assertThat(view.getGravity() & Gravity.VERTICAL_GRAVITY_MASK).isEqualTo(defaultVerticalGravity);
+
+    // TextAlign + TextAlignVertical
+    mManager.updateProperties(
+      view,
+      buildStyles("textAlign", "center", "textAlignVertical", "center"));
+    assertThat(view.getGravity()).isEqualTo(Gravity.CENTER);
+    mManager.updateProperties(
+      view,
+      buildStyles("textAlign", "right", "textAlignVertical", "bottom"));
+    assertThat(view.getGravity()).isEqualTo(Gravity.RIGHT | Gravity.BOTTOM);
+    mManager.updateProperties(
+      view,
+      buildStyles("textAlign", null, "textAlignVertical", null));
+    assertThat(view.getGravity()).isEqualTo(defaultGravity);
+  }
+}

--- a/ReactAndroid/src/test/java/com/facebook/react/views/textinput/ReactTextInputPropertyTest.java
+++ b/ReactAndroid/src/test/java/com/facebook/react/views/textinput/ReactTextInputPropertyTest.java
@@ -289,26 +289,45 @@ public class ReactTextInputPropertyTest {
   @Test
   public void testTextAlign() {
     ReactEditText view = mManager.createViewInstance(mThemedContext);
-    int gravity = view.getGravity();
-    assertThat(view.getGravity() & Gravity.BOTTOM).isNotEqualTo(Gravity.BOTTOM);
+    int defaultGravity = view.getGravity();
+    int defaultHorizontalGravity = defaultGravity & Gravity.HORIZONTAL_GRAVITY_MASK;
+    int defaultVerticalGravity = defaultGravity & Gravity.VERTICAL_GRAVITY_MASK;
 
-    mManager.updateProperties(view, buildStyles("textAlignVertical", "bottom"));
-    assertThat(view.getGravity() & Gravity.BOTTOM).isEqualTo(Gravity.BOTTOM);
+    // Theme
+    assertThat(view.getGravity()).isNotEqualTo(Gravity.NO_GRAVITY);
 
-    mManager.updateProperties(
-        view,
-        buildStyles("textAlign", "right", "textAlignVertical", "top"));
-    assertThat(view.getGravity() & Gravity.BOTTOM).isNotEqualTo(Gravity.BOTTOM);
-    assertThat(view.getGravity() & (Gravity.RIGHT | Gravity.TOP))
-        .isEqualTo(Gravity.RIGHT | Gravity.TOP);
-
-    mManager.updateProperties(
-        view,
-        buildStyles("textAlignVertical", null));
-    assertThat(view.getGravity() & Gravity.RIGHT).isEqualTo(Gravity.RIGHT);
-    assertThat(view.getGravity() & Gravity.TOP).isNotEqualTo(Gravity.TOP);
-
+    // TextAlign
+    mManager.updateProperties(view, buildStyles("textAlign", "left"));
+    assertThat(view.getGravity() & Gravity.HORIZONTAL_GRAVITY_MASK).isEqualTo(Gravity.LEFT);
+    mManager.updateProperties(view, buildStyles("textAlign", "right"));
+    assertThat(view.getGravity() & Gravity.HORIZONTAL_GRAVITY_MASK).isEqualTo(Gravity.RIGHT);
+    mManager.updateProperties(view, buildStyles("textAlign", "center"));
+    assertThat(view.getGravity() & Gravity.HORIZONTAL_GRAVITY_MASK).isEqualTo(Gravity.CENTER_HORIZONTAL);
     mManager.updateProperties(view, buildStyles("textAlign", null));
-    assertThat(view.getGravity()).isEqualTo(gravity);
+    assertThat(view.getGravity() & Gravity.HORIZONTAL_GRAVITY_MASK).isEqualTo(defaultHorizontalGravity);
+
+    // TextAlignVertical
+    mManager.updateProperties(view, buildStyles("textAlignVertical", "top"));
+    assertThat(view.getGravity() & Gravity.VERTICAL_GRAVITY_MASK).isEqualTo(Gravity.TOP);
+    mManager.updateProperties(view, buildStyles("textAlignVertical", "bottom"));
+    assertThat(view.getGravity() & Gravity.VERTICAL_GRAVITY_MASK).isEqualTo(Gravity.BOTTOM);
+    mManager.updateProperties(view, buildStyles("textAlignVertical", "center"));
+    assertThat(view.getGravity() & Gravity.VERTICAL_GRAVITY_MASK).isEqualTo(Gravity.CENTER_VERTICAL);
+    mManager.updateProperties(view, buildStyles("textAlignVertical", null));
+    assertThat(view.getGravity() & Gravity.VERTICAL_GRAVITY_MASK).isEqualTo(defaultVerticalGravity);
+
+    // TextAlign + TextAlignVertical
+    mManager.updateProperties(
+      view,
+      buildStyles("textAlign", "center", "textAlignVertical", "center"));
+    assertThat(view.getGravity()).isEqualTo(Gravity.CENTER);
+    mManager.updateProperties(
+      view,
+      buildStyles("textAlign", "right", "textAlignVertical", "bottom"));
+    assertThat(view.getGravity()).isEqualTo(Gravity.RIGHT | Gravity.BOTTOM);
+    mManager.updateProperties(
+      view,
+      buildStyles("textAlign", null, "textAlignVertical", null));
+    assertThat(view.getGravity()).isEqualTo(defaultGravity);
   }
 }


### PR DESCRIPTION
Add missing implementation of `textAlignVertical` style prop for `Text`-component.
According to the [docs](https://facebook.github.io/react-native/docs/text.html#style) it should be implemented but was only added for `TextInput` in https://github.com/facebook/react-native/commit/f453e14c8f91d00a8205e6bb06094c85281b38be.