### PR TITLE
Remove duplicate register call

### DIFF
--- a/Libraries/PushNotificationIOS/RCTPushNotificationManager.m
+++ b/Libraries/PushNotificationIOS/RCTPushNotificationManager.m
@@ -182,7 +182,6 @@ RCT_EXPORT_METHOD(requestPermissions:(NSDictionary *)permissions)
     UIUserNotificationSettings *notificationSettings =
       [UIUserNotificationSettings settingsForTypes:(NSUInteger)types categories:nil];
     [app registerUserNotificationSettings:notificationSettings];
-    [app registerForRemoteNotifications];
   } else {
     [app registerForRemoteNotificationTypes:(NSUInteger)types];
   }


### PR DESCRIPTION
Hello!

As described in #3288, the `PushNotificationsIOS` `register` callback fires twice.  See that issue for discussion.

There wasn't any feedback on a proposed PR, so this is the first effort.  This change does make the register callback act as expected on my device.  I can make any changes necessary.

Thanks!