### PR TITLE
Add disabled TouchableNativeFeedback button example

### DIFF
--- a/Examples/UIExplorer/TouchableExample.js
+++ b/Examples/UIExplorer/TouchableExample.js
@@ -24,6 +24,8 @@ var {
   TouchableHighlight,
   TouchableOpacity,
   UIManager,
+  Platform,
+  TouchableNativeFeedback,
   View,
 } = React;
 
@@ -333,6 +335,33 @@ var TouchableDisabled = React.createClass({
             Disabled TouchableHighlight
           </Text>
         </TouchableHighlight>
+
+        {Platform.OS === 'android' &&
+          <TouchableNativeFeedback
+            style={[styles.row, styles.block]}
+            onPress={() => console.log('custom TNF has been clicked')}
+            background={TouchableNativeFeedback.SelectableBackground()}>
+            <View>
+              <Text style={[styles.button, styles.nativeFeedbackButton]}>
+                Enabled TouchableNativeFeedback
+              </Text>
+            </View>
+          </TouchableNativeFeedback>
+        }
+
+        {Platform.OS === 'android' &&
+          <TouchableNativeFeedback
+            disabled={true}
+            style={[styles.row, styles.block]}
+            onPress={() => console.log('custom TNF has been clicked')}
+            background={TouchableNativeFeedback.SelectableBackground()}>
+            <View>
+              <Text style={[styles.disabledButton, styles.nativeFeedbackButton]}>
+                Disabled TouchableNativeFeedback
+              </Text>
+            </View>
+          </TouchableNativeFeedback>
+        }
       </View>
     );
   }
@@ -365,6 +394,10 @@ var styles = StyleSheet.create({
   disabledButton: {
     color: '#007AFF',
     opacity: 0.5,
+  },
+  nativeFeedbackButton: {
+    textAlign: 'center',
+    margin: 10,
   },
   hitSlopButton: {
     color: 'white',


### PR DESCRIPTION
Follow-up PR for #5931: Adding missing `TouchableNativeFeedback` example.

**Test plan**

- Run UIExplorer on iOS and Android devices

[Android]
- Go to Touchable* examples and scroll down to the `Disabled Touchable*` section. There are two new buttons there: `Enabled TouchableNativeFeedback` and `Disabled TouchableNativeFeedback`. Buttons should behave according their titles.

[iOS]
- Go to Touchable* examples and scroll down to the `Disabled Touchable*` section. As far as `TouchableNativeFeedback` is supported on Android only, you **wouldn't see** any new buttons there

**Code formatting**

This PR code style match the desired [style guide](https://github.com/facebook/react-native/blob/master/CONTRIBUTING.md#style-guide).

cc @mkonicek 