### PR TITLE
Fix UIExplorer title for android specific components and api

### DIFF
--- a/Examples/UIExplorer/UIExplorerStateTitleMap.js
+++ b/Examples/UIExplorer/UIExplorerStateTitleMap.js
@@ -15,7 +15,7 @@
  */
 'use strict';
 
-const UIExplorerList = require('./UIExplorerList.ios');
+const UIExplorerList = require('./UIExplorerList');
 
 import type {NavigationState} from 'NavigationStateUtils';
 


### PR DESCRIPTION
Was checking out how the new navigation method works and found this small bug :smile: 
![selection_030](https://cloud.githubusercontent.com/assets/11550281/13293049/21d37a66-db44-11e5-8852-fa6162ad4ef1.png)

![selection_031](https://cloud.githubusercontent.com/assets/11550281/13293050/21d94400-db44-11e5-868b-caacb96f25e5.png)

