### PR TITLE
Make iOS project path configurable by parameter in run-ios cli command

### DIFF
--- a/local-cli/runIOS/runIOS.js
+++ b/local-cli/runIOS/runIOS.js
@@ -40,15 +40,15 @@ function _runIOS(argv, config, resolve, reject) {
       type: 'string',
       required: false,
     }, {
-      command: 'ios-project-path',
-      description: 'Set XCode project path',
+      command: 'project-path',
+      description: 'Path relative to project root where the Xcode project (.xcodeproj) lives. The default is \'ios\'.',
       type: 'string',
       required: false,
       default: 'ios',
     }
   ], argv);
 
-  process.chdir(args['ios-project-path']);
+  process.chdir(args['project-path']);
   const xcodeProject = findXcodeProject(fs.readdirSync('.'));
   if (!xcodeProject) {
     throw new Error(`Could not find Xcode project files in ios folder`);

--- a/local-cli/runIOS/runIOS.js
+++ b/local-cli/runIOS/runIOS.js
@@ -27,27 +27,35 @@ function runIOS(argv, config) {
 }
 
 function _runIOS(argv, config, resolve, reject) {
-  const args = parseCommandLine([{
-    command: 'simulator',
-    description: 'Explicitly set simulator to use',
-    type: 'string',
-    required: false,
-    default: 'iPhone 6',
-  }, {
-    command: 'scheme',
-    description: 'Explicitly set Xcode scheme to use',
-    type: 'string',
-    required: false,
-  }], argv);
+  const args = parseCommandLine([
+    {
+      command: 'simulator',
+      description: 'Explicitly set simulator to use',
+      type: 'string',
+      required: false,
+      default: 'iPhone 6',
+    }, {
+      command: 'scheme',
+      description: 'Explicitly set Xcode scheme to use',
+      type: 'string',
+      required: false,
+    }, {
+      command: 'ios-project-path',
+      description: 'Set XCode project path',
+      type: 'string',
+      required: false,
+      default: 'ios',
+    }
+  ], argv);
 
-  process.chdir('ios');
+  process.chdir(args['ios-project-path']);
   const xcodeProject = findXcodeProject(fs.readdirSync('.'));
   if (!xcodeProject) {
     throw new Error(`Could not find Xcode project files in ios folder`);
   }
 
   const inferredSchemeName = path.basename(xcodeProject.name, path.extname(xcodeProject.name));
-  const scheme = args.scheme || inferredSchemeName
+  const scheme = args.scheme || inferredSchemeName;
   console.log(`Found Xcode ${xcodeProject.isWorkspace ? 'workspace' : 'project'} ${xcodeProject.name}`);
 
   const simulators = parseIOSSimulatorsList(


### PR DESCRIPTION
In projects where you have multiple apps or a different structure (ios is not the directory containing the xcode project) it would be helpful to have the option to configure the directory containing the xcode project when doing "react-native run-ios"

As my PR does not change and does not affect UI it's hard to show a video ;-) Steps to reproduce are:

1. checkout facebook/react-native
2. run 'react-native run-ios' (it will fail)
3. npm link react-native (with my PR)
4. re-run 'react-native run-ios --ios-project-path Examples/Movies/

Now the simulator should open the Movies example app