### PR TITLE
Fix for different geolocation timestamp for Android and iOS

### DIFF
--- a/Libraries/Geolocation/RCTLocationObserver.m
+++ b/Libraries/Geolocation/RCTLocationObserver.m
@@ -270,7 +270,7 @@ RCT_EXPORT_METHOD(getCurrentPosition:(RCTLocationOptions)options
       @"heading": @(location.course),
       @"speed": @(location.speed),
     },
-    @"timestamp": @(CFAbsoluteTimeGetCurrent() * 1000.0) // in ms
+    @"timestamp": @([location.timestamp timeIntervalSince1970] * 1000) // in ms
   };
 
   // Send event


### PR DESCRIPTION
Geolocation timestamp is different for Android and iOs. For Android it is returning in UTC time in milliseconds since January 1, 1970, for iOS it was returned as time interval relative to an absolute reference date (00:00:00 UTC on 1 January 2001). Also for iOS time returned was "current system absolute time" and not the time at which this location was determined.

Tested with 0.21.0-rc React Native. Init project with this additional code:
`constructor(props) {super(props);
    navigator.geolocation.getCurrentPosition( 
      (position) => { 
        let initialPosition = JSON.stringify(position); 
        console.log(position.timestamp);
      }, 
      (error) => alert(error.message), 
      {enableHighAccuracy: true, timeout: 20000, maximumAge: 1000} );
  }
`

Tested with iOs simulator (iPhone 6S plus 9.2; iPhone 5s 8.4 )

sample result with change: 1456407795021.235
sample result without change: 23478100615007.884


Explaining links for iOS: 
https://developer.apple.com/library/ios/documentation/CoreLocation/Reference/CLLocation_Class/index.html#//apple_ref/occ/instp/CLLocation/timestamp
https://developer.apple.com/library/prerelease/ios/documentation/CoreFoundation/Reference/CFTimeUtils/index.html#//apple_ref/c/func/CFAbsoluteTimeGetCurrent
https://developer.apple.com/library/ios/documentation/Cocoa/Reference/Foundation/Classes/NSDate_Class/index.html#//apple_ref/swift/cl/c:objc%28cs%29NSDate

Link for Android:
http://developer.android.com/reference/android/location/Location.html#getTime%28%29