### PR TITLE
[Animated] support plain numbers in add and multiply operators

### DIFF
--- a/Libraries/Animated/src/AnimatedImplementation.js
+++ b/Libraries/Animated/src/AnimatedImplementation.js
@@ -844,7 +844,7 @@ class AnimatedAddition extends AnimatedWithChildren {
   _a: Animated;
   _b: Animated;
 
-  constructor(a: Animated, b: Animated) {
+  constructor(a: Animated | number, b: Animated | number) {
     super();
     this._a = typeof a === 'number' ? new AnimatedValue(a) : a;
     this._b = typeof b === 'number' ? new AnimatedValue(b) : b;
@@ -873,7 +873,7 @@ class AnimatedMultiplication extends AnimatedWithChildren {
   _a: Animated;
   _b: Animated;
 
-  constructor(a: Animated, b: Animated) {
+  constructor(a: Animated | number, b: Animated | number) {
     super();
     this._a = typeof a === 'number' ? new AnimatedValue(a) : a;
     this._b = typeof b === 'number' ? new AnimatedValue(b) : b;

--- a/Libraries/Animated/src/AnimatedImplementation.js
+++ b/Libraries/Animated/src/AnimatedImplementation.js
@@ -846,8 +846,8 @@ class AnimatedAddition extends AnimatedWithChildren {
 
   constructor(a: Animated, b: Animated) {
     super();
-    this._a = a;
-    this._b = b;
+    this._a = typeof a === 'number' ? new AnimatedValue(a) : a;
+    this._b = typeof b === 'number' ? new AnimatedValue(b) : b;
   }
 
   __getValue(): number {
@@ -875,8 +875,8 @@ class AnimatedMultiplication extends AnimatedWithChildren {
 
   constructor(a: Animated, b: Animated) {
     super();
-    this._a = a;
-    this._b = b;
+    this._a = typeof a === 'number' ? new AnimatedValue(a) : a;
+    this._b = typeof b === 'number' ? new AnimatedValue(b) : b;
   }
 
   __getValue(): number {


### PR DESCRIPTION
This adds support for passing plain numbers into the add and multiply operators. This can be useful if you want to have one AnimatedValue for a component that is say a scale 0 -> 1 and then animated many style properties accordingly using derivative Animated values.

Thoughts? 

As far as implementation, there may be more performant implementations that do not require creating a whole new AnimatedValue for every static number. I am open to suggestion.