### PR TITLE
Allows a user to specify an xcode scheme name.

### DIFF
--- a/local-cli/runIOS/runIOS.js
+++ b/local-cli/runIOS/runIOS.js
@@ -33,6 +33,11 @@ function _runIOS(argv, config, resolve, reject) {
     type: 'string',
     required: false,
     default: 'iPhone 6',
+  }, {
+    command: 'scheme',
+    description: 'Explicitly set Xcode scheme to use',
+    type: 'string',
+    required: false,
   }], argv);
 
   process.chdir('ios');
@@ -42,6 +47,7 @@ function _runIOS(argv, config, resolve, reject) {
   }
 
   const inferredSchemeName = path.basename(xcodeProject.name, path.extname(xcodeProject.name));
+  const scheme = args.scheme || inferredSchemeName
   console.log(`Found Xcode ${xcodeProject.isWorkspace ? 'workspace' : 'project'} ${xcodeProject.name}`);
 
   const simulators = parseIOSSimulatorsList(
@@ -63,7 +69,7 @@ function _runIOS(argv, config, resolve, reject) {
 
   const xcodebuildArgs = [
     xcodeProject.isWorkspace ? '-workspace' : '-project', xcodeProject.name,
-    '-scheme', inferredSchemeName,
+    '-scheme', scheme,
     '-destination', `id=${selectedSimulator.udid}`,
     '-derivedDataPath', 'build',
   ];


### PR DESCRIPTION
# Motivation: 

When running `react-native run-ios`, this feature allows a user to specify which scheme to run.

My project's scheme name is not the same as the xcode project name. Running `react-native run-ios` would error with the following:

```
± |master ↓95 ✓| → react-native run-ios
Found Xcode workspace Poot.xcworkspace
Launching iPhone 6 (9.2)...
Building using "xcodebuild -workspace Poot.xcworkspace -scheme Poot -destination id=2B3E8AAC-DD61-414C-95BD-F4829A8F7CE6 -derivedDataPath build"
User defaults from command line:
    IDEDerivedDataPathOverride = /Users/mrickert/Documents/project/ios/build

xcodebuild: error: The workspace named "Poot" does not contain a scheme named "Poot". The "-list" option can be used to find the names of the schemes in the workspace.
Installing build/Build/Products/Debug-iphonesimulator/Poot.app
An error was encountered processing the command (domain=NSPOSIXErrorDomain, code=2):
Failed to install the requested application
An application bundle was not found at the provided path.
Provide a valid path to the desired application bundle.
Print: Entry, ":CFBundleIdentifier", Does Not Exist
/Users/mrickert/Documents/project/node_modules/promise/lib/done.js:10
      throw err;
      ^

Error: Command failed: /usr/libexec/PlistBuddy -c Print:CFBundleIdentifier build/Build/Products/Debug-iphonesimulator/Poot.app/Info.plist
Print: Entry, ":CFBundleIdentifier", Does Not Exist
```

Note the error: `xcodebuild: error: The workspace named "Poot" does not contain a scheme named "Poot". The "-list" option can be used to find the names of the schemes in the workspace.` yet `run-ios` can't actually run a different scheme in the project.

This pull request allows you to pass the scheme as a parameter, overcoming this issue.

# Test plan: 

1. Create a brand new react-native project. `react-native init test`.
1. Run `react-native run-ios`
1. Note that the application builds properly.
1. Delete the compiled data from the build directory - `rm -rfv ios/build`
1. Open the Xcode project for iOS
1. Click the schemes list in the upper left part of xcode and click "Manage Schemes..."
1. Click once to select your main scheme wait, and click the name again to edit the name. Name it something OTHER than your project's name. For example: `myscheme`. Close the popups.
1. (*optional*) Click on your main project name in the navigator pane and rename your main target to the new scheme name.
1. Quit Xcode
1. Run `react-native run-ios`
1. Note the error message described above.
1. Make modification in this pull request.
1. Run `react-native run-ios`
1. Note the error message described above.
1. Run `react-native run-ios --scheme myscheme`
1. Note the project builds correctly, running the proper scheme.
1. Go back into XCode and rename the scheme & target back to the original.
1. Delete the compiled data from the build directory - `rm -rfv ios/build`
1. Run `react-native run-ios --scheme myscheme`
1. Note that the command errors since the scheme doesn't exist anymore.
1. Run `react-native run-ios`
1. Note that the application launches like normal.
1. Delete the compiled data from the build directory - `rm -rfv ios/build`
1. Run `react-native run-ios --scheme test` (the correct scheme name based on the project's name)
1. Note that the application builds correctly

# Notes: 

* Defaults to previous behavior of inferring the scheme name based on the project file name if the parameter is not present.
* Parameter is not required
* Running `react-native run-ios --help` shows the parameter's description.

# Example Usage: 

```bash
react-native run-ios --scheme myDifferentScheme
```