### PR TITLE
fixed jest tests: added /website/ folder to jest ignore list

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,8 @@
       "downstream/core/toArray.js",
       "node_modules/jest-cli",
       "node_modules/react/dist",
-      "/node_modules/fbjs/.*/__mocks__/"
+      "/node_modules/fbjs/.*/__mocks__/",
+      "<rootDir>/website/"
     ],
     "testFileExtensions": [
       "js"


### PR DESCRIPTION
If website has node_modules installed `npm tests`

**Test plan (required)**

```
cd website && npm install
cd .. && npm test
```

Before this fix we see this error:
Error: Failed to build DependencyGraph: @providesModule naming collision:
  Duplicate module name: ViewportMetrics
  Paths: react-native/node_modules/react/lib/ViewportMetrics.js collides with react-native/website/node_modules/react/lib/ViewportMetrics.js


