### PR TITLE
Simplified Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,19 +30,10 @@ script:
 
     npm install github@0.2.4
     cat <(echo eslint; npm run lint --silent -- --format=json; echo flow; flow --json) | GITHUB_TOKEN="af6ef0d15709bc91d""06a6217a5a826a226fb57b7" node bots/code-analysis-bot.js
-    flow check && npm test -- '\/Libraries\/'
+    flow check
+    npm test
 
-  elif [ "$TEST_TYPE" = packager ]
-  then
-
-    npm test -- '\/packager\/'
-
-  elif [ "$TEST_TYPE" = cli ]
-  then
-
-    npm test -- '\/(local|private|react-native)-cli\/'
-
-  elif [ "$TEST_TYPE" = e2e ]
+  elif [ "$TEST_TYPE" = e2e-objc ]
   then
 
     ./scripts/e2e-test.sh
@@ -56,14 +47,7 @@ env:
   matrix:
     - TEST_TYPE=objc
     - TEST_TYPE=js
-    - TEST_TYPE=packager
-    - TEST_TYPE=cli
-    - TEST_TYPE=e2e
-  global:
-    # $APPETIZE_TOKEN
-    - secure: "egsvVSpszTzrNd6bN62DsVAzMiSZI/OHgdizfPryqvqWBf655ztE6XFQSEFNpuIAzSKDDF25ioT8iPfVsbC1iK6HDWHfmqYxML0L+OoU0gi+hV2oKUBFZDZ1fwSnFoWuBdNdMDpLlUxvJp6N1WyfNOB2dxuZUt8eTt48Hi3+Hpc="
-    # $S3_TOKEN
-    - secure: "lY8JZPA0A7zT7L5KF9BBg34XYWIeR/RJiEvE7l7oVr88KnEPtyd//79eHhhVKnUnav7zsk5QJwkcX0MxKTp/dp4G0Am+zOX+sfA8kQrJ+2/+FzFW7AEsW/kHByfaIEIly9DQvUFt4I4oMm8nQZysJLahDgNWglyI3RTuJp//hcY="
+    - TEST_TYPE=e2e-objc
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ script:
   if [ "$TEST_TYPE" = objc ]
   then
 
-    ./scripts/objc-test.sh
+    travis_retry ./scripts/objc-test.sh
 
   elif [ "$TEST_TYPE" = js ]
   then
@@ -37,7 +37,7 @@ script:
   elif [ "$TEST_TYPE" = e2e-objc ]
   then
 
-    ./scripts/e2e-test.sh
+    travis_retry ./scripts/e2e-test.sh
 
   else
     echo "Unknown test type: $TEST_TYPE"

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ install:
   - nvm install 5
   - rm -Rf "${TMPDIR}/jest_preprocess_cache"
   - npm config set spin=false
-  - npm set progress=false
+  - npm config set progress=false
   - npm install -g flow-bin@`node -p "require('fs').readFileSync('.flowconfig', 'utf8').split('[version]')[1].trim()"`
   - npm install
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ install:
   - nvm install 5
   - rm -Rf "${TMPDIR}/jest_preprocess_cache"
   - npm config set spin=false
+  - npm set progress=false
   - npm install -g flow-bin@`node -p "require('fs').readFileSync('.flowconfig', 'utf8').split('[version]')[1].trim()"`
   - npm install
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ install:
   - export NVM_DIR="$PWD/.nvm"
   - source $(brew --prefix nvm)/nvm.sh
   - nvm install 5
+  - npm install -g npm@3.7.0
   - rm -Rf "${TMPDIR}/jest_preprocess_cache"
   - npm config set spin=false
   - npm config set progress=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ install:
   - export NVM_DIR="$PWD/.nvm"
   - source $(brew --prefix nvm)/nvm.sh
   - nvm install 5
-  - npm install -g npm@3.7.0
   - rm -Rf "${TMPDIR}/jest_preprocess_cache"
   - npm config set spin=false
   - npm config set progress=false

--- a/circle.yml
+++ b/circle.yml
@@ -30,6 +30,8 @@ dependencies:
     - "buck-out/bin"
     - "website/node_modules"
   override:
+    - npm config set spin=false
+    - npm config set progress=false
     - npm install
     - cd website && npm install
 


### PR DESCRIPTION
Merged Travis js tests into one test run.

This should simplify test runs, reduce chances of external infra failures and make CI reports more focused.

**Test plan (required)**

See how travis runs it.
Need to double check that APPETIZE_TOKEN and S3_TOKEN aren't used.

