### PR TITLE
[HMR] Multiple HMR clients

### DIFF
--- a/local-cli/server/util/attachHMRServer.js
+++ b/local-cli/server/util/attachHMRServer.js
@@ -26,7 +26,6 @@ function attachHMRServer({httpServer, path, packagerServer}) {
   };
 
   function addClient (client) {
-
     client.ws.on('error', e => {
       console.error('[Hot Module Replacement] Unexpected error', e);
       disconnect(client);
@@ -96,7 +95,6 @@ function attachHMRServer({httpServer, path, packagerServer}) {
 
   // Runs whenever a file changes
   function onHMRChange (filename, stat)  {
-
     if (clients.length === 0) {
       return;
     }
@@ -133,7 +131,6 @@ function attachHMRServer({httpServer, path, packagerServer}) {
                 return response.copy({dependencies: [module]});
               });
             }
-            console.log(bundleEntry, platform, "WASNT SAME")
 
             // if there're new dependencies compare the full list of
             // dependencies we used to have with the one we now have
@@ -171,7 +168,6 @@ function attachHMRServer({httpServer, path, packagerServer}) {
           }
 
           return forEachBundleEntry((bundleEntry, platform) => {
-
             if (!resolutionResponses[platform] || !resolutionResponses[platform][bundleEntry]) {
               return;
             }
@@ -206,7 +202,6 @@ function attachHMRServer({httpServer, path, packagerServer}) {
           }
 
           return forEachBundleEntry((bundleEntry, platform) => {
-
             if (!bundles[platform]) {
               return;
             }

--- a/local-cli/server/util/attachHMRServer.js
+++ b/local-cli/server/util/attachHMRServer.js
@@ -16,11 +16,259 @@ const url = require('url');
  * Hot Module Replacement updates to the simulator.
  */
 function attachHMRServer({httpServer, path, packagerServer}) {
-  let client = null;
 
-  function disconnect() {
-    client = null;
-    packagerServer.setHMRFileChangeListener(null);
+  let clients = [];
+  let clientsPerBundleEntry = {};
+
+  let platformCache = {
+    android: {},
+    ios: {},
+  };
+
+  function addClient (client) {
+
+    client.ws.on('error', e => {
+      console.error('[Hot Module Replacement] Unexpected error', e);
+      disconnect(client);
+    });
+
+    client.ws.on('close', () => disconnect(client));
+    clients.push(client);
+
+    clientsPerBundleEntry[client.bundleEntry] = [...(
+      clientsPerBundleEntry[client.bundleEntry] ? clientsPerBundleEntry[client.bundleEntry] : []
+    ), client];
+
+    // Only register callback if it's the first client
+    if (clients.length === 1) {
+      packagerServer.setHMRFileChangeListener(onHMRChange);
+    }
+
+  }
+
+  function disconnect (disconnectedClient) {
+    clients = clients.filter(client => client !== disconnectedClient);
+    clientsPerBundleEntry[disconnectedClient.bundleEntry] = clientsPerBundleEntry[disconnectedClient.bundleEntry].filter(client => client !== disconnectedClient);
+    //Only clear change listener if there are no more listening clients
+    if (clients.length === 0) {
+      packagerServer.setHMRFileChangeListener(null);
+    }
+  }
+
+  function connectedPlatformClients () {
+    return {
+      android: clients.filter(client => client.platform === "android"),
+      ios: clients.filter(client => client.platform === "ios"),
+    }
+  }
+
+  function forEachPlatform (callback) {
+    const platformClients = connectedPlatformClients();
+    return Promise.all([
+      wrapPotentialPromise(platformClients.android.length > 0 ? callback("android", platformClients.android) : null),
+      wrapPotentialPromise(platformClients.ios.length > 0 ? callback("ios", platformClients.ios) : null),
+    ]).then(results => ({
+       android: results[0],
+       ios: results[1],
+    }));
+  }
+
+  function forEachBundleEntry (callback) {
+    return forEachPlatform(platform =>
+      forEachKey(platformCache[platform], bundleEntry =>
+        callback(bundleEntry, platform)
+      )
+    )
+  }
+
+  function sendToClients (message, platform, bundleEntry) {
+    if (platform && bundleEntry) {
+      clientsPerBundleEntry[bundleEntry].map(client => {
+        if (client.platform === platform) {
+          client.ws.send(JSON.stringify(message))
+        }
+      })
+    }
+    else {
+      clients.forEach(client => client.ws.send(JSON.stringify(message)));
+    }
+  }
+
+  // Runs whenever a file changes
+  function onHMRChange (filename, stat)  {
+
+    if (clients.length === 0) {
+      return;
+    }
+
+    console.log(`[Hot Module Replacement] File change detected (${time()})`);
+    sendToClients({type: 'update-start'});
+
+    stat.then(() => {
+      return packagerServer.getShallowDependencies(filename)
+        .then(deps => {
+          if (clients.length === 0) {
+            return;
+          }
+
+          //Check the depedencies for each bundle entry
+          return forEachBundleEntry((bundleEntry, platform) => {
+            // if the file dependencies have change we need to invalidate the
+            // dependencies caches because the list of files we need to send
+            // to the client may have changed
+            const oldDependencies = platformCache[platform][bundleEntry].shallowDependencies[filename];
+            if (arrayEquals(deps, oldDependencies)) {
+              // Need to create a resolution response to pass to the bundler
+              // to process requires after transform. By providing a
+              // specific response we can compute a non recursive one which
+              // is the least we need and improve performance.
+              return packagerServer.getDependencies({
+                platform,
+                dev: true,
+                entryFile: filename,
+                recursive: true,
+              }).then(response => {
+                const module = packagerServer.getModuleForPath(filename);
+
+                return response.copy({dependencies: [module]});
+              });
+            }
+            console.log(bundleEntry, platform, "WASNT SAME")
+
+            // if there're new dependencies compare the full list of
+            // dependencies we used to have with the one we now have
+            return getDependencies(platform, bundleEntry)
+              .then(({
+                dependenciesCache,
+                dependenciesModulesCache,
+                shallowDependencies,
+                resolutionResponse,
+              }) => {
+
+                // build list of modules for which we'll send HMR updates
+                const modulesToUpdate = [packagerServer.getModuleForPath(filename)];
+                Object.keys(dependenciesModulesCache).forEach(module => {
+                  if (!platformCache[platform][bundleEntry].dependenciesModulesCache[module]) {
+                    modulesToUpdate.push(dependenciesModulesCache[module]);
+                  }
+                });
+
+                // invalidate caches
+                platformCache[platform][bundleEntry].dependenciesCache = dependenciesCache;
+                platformCache[platform][bundleEntry].dependenciesModulesCache = dependenciesModulesCache;
+                platformCache[platform][bundleEntry].shallowDependencies = shallowDependencies;
+
+                return resolutionResponse.copy({
+                  dependencies: modulesToUpdate,
+                });
+              });
+
+          });
+        })
+        .then((resolutionResponses) => {
+          if (clients.length === 0 || !resolutionResponses) {
+            return;
+          }
+
+          return forEachBundleEntry((bundleEntry, platform) => {
+
+            if (!resolutionResponses[platform] || !resolutionResponses[platform][bundleEntry]) {
+              return;
+            }
+
+            if (!platformCache[platform][bundleEntry].shallowDependencies[filename]){
+              return;
+            }
+
+            const resolutionResponse = resolutionResponses[platform][bundleEntry];
+
+            const httpServerAddress = httpServer.address();
+
+            // Sanitize the value from the HTTP server
+            let packagerHost = 'localhost';
+            if (httpServerAddress.address &&
+                httpServerAddress.address !== '::' &&
+                httpServerAddress.address !== '') {
+              packagerHost = httpServerAddress.address;
+            }
+
+            let packagerPort = httpServerAddress.port;
+            return packagerServer.buildBundleForHMR({
+              entryFile: bundleEntry,
+              platform,
+              resolutionResponse,
+            }, packagerHost, packagerPort);
+          });
+        })
+        .then(bundles => {
+          if (clients.length === 0 || !bundles) {
+            return;
+          }
+
+          return forEachBundleEntry((bundleEntry, platform) => {
+
+            if (!bundles[platform]) {
+              return;
+            }
+
+            const bundle = bundles[platform][bundleEntry];
+
+            if (!bundle || bundle.isEmpty()) {
+              return;
+            }
+            return {
+              type: 'update',
+              body: {
+                modules: bundle.getModulesCode(),
+                sourceURLs: bundle.getSourceURLs(),
+                sourceMappingURLs: bundle.getSourceMappingURLs(),
+              },
+            };
+          });
+        })
+        .catch(error => {
+          // send errors to the client instead of killing packager server
+          let body;
+          if (error.type === 'TransformError' ||
+              error.type === 'NotFoundError' ||
+              error.type === 'UnableToResolveError') {
+            body = {
+              type: error.type,
+              description: error.description,
+              filename: error.filename,
+              lineNumber: error.lineNumber,
+            };
+          } else {
+            console.error(error.stack || error);
+            body = {
+              type: 'InternalError',
+              description: 'react-packager has encountered an internal error, ' +
+                'please check your terminal error output for more details',
+            };
+          }
+
+          return forEachBundleEntry((bundleEntry, platform) => ({type: 'error', body}));
+        })
+        .then(update => {
+          if (clients.length === 0 || !update) {
+            return;
+          }
+
+          forEachBundleEntry((bundleEntry, platform) => {
+            if (!update[platform] || !update[platform][bundleEntry]) {
+              return;
+            }
+            console.log(`[Hot Module Replacement] Sending HMR update to client (${time()})`);
+            sendToClients(update[platform][bundleEntry], platform, bundleEntry);
+          });
+        })
+      },
+      () => {
+        // do nothing, file was removed
+      }
+    ).finally(() => {
+      sendToClients({type: 'update-done'});
+    });
   }
 
   // Returns a promise with the full list of dependencies and the shallow
@@ -28,7 +276,7 @@ function attachHMRServer({httpServer, path, packagerServer}) {
   // and entry file.
   function getDependencies(platform, bundleEntry) {
     return packagerServer.getDependencies({
-      platform: platform,
+      platform,
       dev: true,
       entryFile: bundleEntry,
     }).then(response => {
@@ -98,174 +346,21 @@ function attachHMRServer({httpServer, path, packagerServer}) {
         dependenciesModulesCache,
         shallowDependencies,
       }) => {
-        client = {
+
+        const client = {
           ws,
           platform: params.platform,
           bundleEntry: params.bundleEntry,
+        };
+
+        //Set the platform dependency cache when a new client connects
+        platformCache[params.platform][params.bundleEntry] = {
           dependenciesCache,
           dependenciesModulesCache,
           shallowDependencies,
         };
 
-        packagerServer.setHMRFileChangeListener((filename, stat) => {
-          if (!client) {
-            return;
-          }
-          console.log(
-            `[Hot Module Replacement] File change detected (${time()})`
-          );
-
-          client.ws.send(JSON.stringify({type: 'update-start'}));
-          stat.then(() => {
-            return packagerServer.getShallowDependencies(filename)
-              .then(deps => {
-                if (!client) {
-                  return [];
-                }
-
-                // if the file dependencies have change we need to invalidate the
-                // dependencies caches because the list of files we need to send
-                // to the client may have changed
-                const oldDependencies = client.shallowDependencies[filename];
-                if (arrayEquals(deps, oldDependencies)) {
-                  // Need to create a resolution response to pass to the bundler
-                  // to process requires after transform. By providing a
-                  // specific response we can compute a non recursive one which
-                  // is the least we need and improve performance.
-                  return packagerServer.getDependencies({
-                    platform: client.platform,
-                    dev: true,
-                    entryFile: filename,
-                    recursive: true,
-                  }).then(response => {
-                    const module = packagerServer.getModuleForPath(filename);
-
-                    return response.copy({dependencies: [module]});
-                  });
-                }
-
-                // if there're new dependencies compare the full list of
-                // dependencies we used to have with the one we now have
-                return getDependencies(client.platform, client.bundleEntry)
-                  .then(({
-                    dependenciesCache,
-                    dependenciesModulesCache,
-                    shallowDependencies,
-                    resolutionResponse,
-                  }) => {
-                    if (!client) {
-                      return {};
-                    }
-
-                    // build list of modules for which we'll send HMR updates
-                    const modulesToUpdate = [packagerServer.getModuleForPath(filename)];
-                    Object.keys(dependenciesModulesCache).forEach(module => {
-                      if (!client.dependenciesModulesCache[module]) {
-                        modulesToUpdate.push(dependenciesModulesCache[module]);
-                      }
-                    });
-
-                    // invalidate caches
-                    client.dependenciesCache = dependenciesCache;
-                    client.dependenciesModulesCache = dependenciesModulesCache;
-                    client.shallowDependencies = shallowDependencies;
-
-                    return resolutionResponse.copy({
-                      dependencies: modulesToUpdate
-                    });
-                  });
-              })
-              .then((resolutionResponse) => {
-                if (!client) {
-                  return;
-                }
-
-                // make sure the file was modified is part of the bundle
-                if (!client.shallowDependencies[filename]) {
-                  return;
-                }
-
-                const httpServerAddress = httpServer.address();
-
-                // Sanitize the value from the HTTP server
-                let packagerHost = 'localhost';
-                if (httpServer.address().address &&
-                    httpServer.address().address !== '::' &&
-                    httpServer.address().address !== '') {
-                  packagerHost = httpServerAddress.address;
-                }
-
-                let packagerPort = httpServerAddress.port;
-
-                return packagerServer.buildBundleForHMR({
-                  entryFile: client.bundleEntry,
-                  platform: client.platform,
-                  resolutionResponse,
-                }, packagerHost, packagerPort);
-              })
-              .then(bundle => {
-                if (!client || !bundle || bundle.isEmpty()) {
-                  return;
-                }
-
-                return JSON.stringify({
-                  type: 'update',
-                  body: {
-                    modules: bundle.getModulesCode(),
-                    sourceURLs: bundle.getSourceURLs(),
-                    sourceMappingURLs: bundle.getSourceMappingURLs(),
-                  },
-                });
-              })
-              .catch(error => {
-                // send errors to the client instead of killing packager server
-                let body;
-                if (error.type === 'TransformError' ||
-                    error.type === 'NotFoundError' ||
-                    error.type === 'UnableToResolveError') {
-                  body = {
-                    type: error.type,
-                    description: error.description,
-                    filename: error.filename,
-                    lineNumber: error.lineNumber,
-                  };
-                } else {
-                  console.error(error.stack || error);
-                  body = {
-                    type: 'InternalError',
-                    description: 'react-packager has encountered an internal error, ' +
-                      'please check your terminal error output for more details',
-                  };
-                }
-
-                return JSON.stringify({type: 'error', body});
-              })
-              .then(update => {
-                if (!client || !update) {
-                  return;
-                }
-
-                console.log(
-                  '[Hot Module Replacement] Sending HMR update to client (' +
-                  time() + ')'
-                );
-                client.ws.send(update);
-              });
-            },
-            () => {
-              // do nothing, file was removed
-            },
-          ).finally(() => {
-            client.ws.send(JSON.stringify({type: 'update-done'}));
-          });
-        });
-
-        client.ws.on('error', e => {
-          console.error('[Hot Module Replacement] Unexpected error', e);
-          disconnect();
-        });
-
-        client.ws.on('close', () => disconnect());
+        addClient(client);
       })
     .done();
   });
@@ -285,6 +380,30 @@ function arrayEquals(arrayA, arrayB) {
 function time() {
   const date = new Date();
   return `${date.getHours()}:${date.getMinutes()}:${date.getSeconds()}:${date.getMilliseconds()}`;
+}
+
+
+function wrapPotentialPromise (valueOrPromise) {
+  if (valueOrPromise == null) {
+    return Promise.resolve(valueOrPromise)
+  }
+  else if (valueOrPromise.then && typeof valueOrPromise === "function") {
+    return valueOrPromise
+  }
+  else {
+    return Promise.resolve(valueOrPromise)
+  }
+}
+
+function forEachKey (object, callback) {
+  const keys = Object.keys(object);
+  return Promise.all(
+    keys.map(key => wrapPotentialPromise(callback(key, object[key])))
+  ).then(results => {
+    const newObject = {};
+    keys.forEach((key, index) => newObject[key] = results[index]);
+    return newObject;
+  })
 }
 
 module.exports = attachHMRServer;


### PR DESCRIPTION
# Multiple HMR clients

This pull request adds support for multiple HMR clients :balloon: :birthday:  :balloon: (as per discussed in #5338 and e018aa3100d93abf0e222cd70bbcbb6ab248eced)

### How it works

Dependency caches are being kept per unique bundle/platform combination in a structure such as 
```javascript
{
  ios: {
    'path/to/index.ios.bundle': [/* this bundle's dependencies */],
  },
  android: {
    'path/to/index.android.bundle': [/* this bundle's dependencies */],
  },
}
```

Upon receiving a connection request, it's added to a similar structure per bundle 
```javascript 
{ 
  [bundle]: [/*connected clients for this bundle*/] 
}
```
The HMR bundle changes are then forwarded to each device when their bundle's/platform dependencies are invalid/changed.

EDIT: Quick demo :smile: https://www.youtube.com/watch?v=etk3Bb7z1eQ

### Test Plan

I did some manual tests using 2 emulators and 2 real devices, all connected at the same time, hot reloading successfully! (1 android emulator, 1 android devices, 1 iOS emulator and 1 iOS device).

Is there any way I can automate this? Not familiar with the testing practices for similar features on the project.

@martinbigio You seem like the guy to ask for code review :smile: (EDIT: Oh that's an helpful bot)
