### PR TITLE
Android support for style backfaceVisibility

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.java
@@ -147,6 +147,24 @@ public class ReactViewManager extends ViewGroupManager<ReactViewGroup> {
   }
 
   @Override
+  @ReactProp(name = "opacity")
+  public void setOpacity(ReactViewGroup view, float opacity) {
+    view.setOpacityIfPossible(opacity);
+  }
+
+  @ReactProp(name = "backfaceVisibility")
+  public void setBackfaceVisibility(ReactViewGroup view, String backfaceVisibility) {
+    view.setBackfaceVisibility(backfaceVisibility);
+  }
+
+  @Override
+  @ReactProp(name = "decomposedMatrix") 
+  public void setDecomposedMatrix(ReactViewGroup view, ReadableMap decomposedMatrix) {
+    super.setDecomposedMatrix(view, decomposedMatrix);
+    view.rememberDecomposedMatrix(decomposedMatrix);
+  }
+
+  @Override
   public String getName() {
     return REACT_CLASS;
   }


### PR DESCRIPTION
- Motivation: Style backfaceVisibility was so far supported only on iOS
- Test: I built [react-native-flip-view](https://github.com/DispatcherInc/react-native-flip-view) and ensured that the back face of a rotated View is not visible anymore when its "backfaceVisibility" style is set to "hidden"
- Implementation Details: Out of the box, Android doesn't support hiding a view's back face. The developed solution therefore takes into account the view's rotation. If its X or Y rotation is such that the back face is visible, I check the backfaceVisibility setting. If it's set to "hidden", I set the view's opacity to 0 -- otherwise I set it to the user defined value. Furthermore, I run this check whenever the view's opacity, transform matrix or backfaceVisibility changes.
