### PR TITLE
Adds ability to build UIComponent modules based on existing UIViewControllers

### DIFF
--- a/Libraries/Text/RCTShadowText.m
+++ b/Libraries/Text/RCTShadowText.m
@@ -15,6 +15,7 @@
 #import "RCTConvert.h"
 #import "RCTImageComponent.h"
 #import "RCTLog.h"
+#import "RCTPair.h"
 #import "RCTShadowRawText.h"
 #import "RCTText.h"
 #import "RCTUtils.h"
@@ -90,8 +91,8 @@ static css_dim_t RCTMeasure(void *context, float width, float height)
   CGFloat width = self.frame.size.width - (padding.left + padding.right);
 
   NSTextStorage *textStorage = [self buildTextStorageForWidth:width];
-  [applierBlocks addObject:^(NSDictionary<NSNumber *, RCTText *> *viewRegistry) {
-    RCTText *view = viewRegistry[self.reactTag];
+  [applierBlocks addObject:^(NSDictionary<NSNumber *, RCTPair<RCTText *, UIViewController *> *> *viewRegistry) {
+    RCTText *view = viewRegistry[self.reactTag].first;
     view.textStorage = textStorage;
   }];
 

--- a/Libraries/Text/RCTTextFieldManager.m
+++ b/Libraries/Text/RCTTextFieldManager.m
@@ -10,6 +10,7 @@
 #import "RCTTextFieldManager.h"
 
 #import "RCTBridge.h"
+#import "RCTPair.h"
 #import "RCTShadowView.h"
 #import "RCTTextField.h"
 
@@ -117,8 +118,8 @@ RCT_EXPORT_VIEW_PROPERTY(mostRecentEventCount, NSInteger)
 {
   NSNumber *reactTag = shadowView.reactTag;
   UIEdgeInsets padding = shadowView.paddingAsInsets;
-  return ^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, RCTTextField *> *viewRegistry) {
-    viewRegistry[reactTag].contentInset = padding;
+  return ^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, RCTPair<RCTTextField *, UIViewController *> *> *viewRegistry) {
+    viewRegistry[reactTag].first.contentInset = padding;
   };
 }
 

--- a/Libraries/Text/RCTTextManager.m
+++ b/Libraries/Text/RCTTextManager.m
@@ -13,10 +13,12 @@
 #import "RCTAssert.h"
 #import "RCTConvert.h"
 #import "RCTLog.h"
+#import "RCTPair.h"
 #import "RCTShadowRawText.h"
 #import "RCTShadowText.h"
 #import "RCTText.h"
 #import "RCTTextView.h"
+#import "RCTViewRegistryPair.h"
 #import "UIView+React.h"
 
 @interface RCTShadowText (Private)
@@ -136,8 +138,8 @@ RCT_EXPORT_SHADOW_PROPERTY(textShadowColor, UIColor)
       CGFloat width = shadowText.frame.size.width - (padding.left + padding.right);
       NSTextStorage *textStorage = [shadowText buildTextStorageForWidth:width];
 
-      [uiBlocks addObject:^(RCTUIManager *uiManager, NSDictionary<NSNumber *, RCTTextView *> *viewRegistry) {
-        RCTTextView *textView = viewRegistry[reactTag];
+      [uiBlocks addObject:^(RCTUIManager *uiManager, NSDictionary<NSNumber *, RCTPair<RCTTextView *, UIViewController *> *> *viewRegistry) {
+        RCTTextView *textView = viewRegistry[reactTag].first;
         RCTText *text;
         for (RCTText *subview in textView.reactSubviews) {
           if ([subview isKindOfClass:[RCTText class]]) {
@@ -151,7 +153,7 @@ RCT_EXPORT_SHADOW_PROPERTY(textShadowColor, UIColor)
       }];
     }
 
-    return ^(RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry) {
+    return ^(RCTUIManager *uiManager, NSDictionary<NSNumber *, RCTViewRegistryPair *> *viewRegistry) {
       for (RCTViewManagerUIBlock uiBlock in uiBlocks) {
         uiBlock(uiManager, viewRegistry);
       }

--- a/Libraries/Text/RCTTextViewManager.m
+++ b/Libraries/Text/RCTTextViewManager.m
@@ -11,6 +11,7 @@
 
 #import "RCTBridge.h"
 #import "RCTConvert.h"
+#import "RCTPair.h"
 #import "RCTShadowView.h"
 #import "RCTTextView.h"
 
@@ -64,8 +65,8 @@ RCT_EXPORT_VIEW_PROPERTY(mostRecentEventCount, NSInteger)
 {
   NSNumber *reactTag = shadowView.reactTag;
   UIEdgeInsets padding = shadowView.paddingAsInsets;
-  return ^(RCTUIManager *uiManager, NSDictionary<NSNumber *, RCTTextView *> *viewRegistry) {
-    viewRegistry[reactTag].contentInset = padding;
+  return ^(RCTUIManager *uiManager, NSDictionary<NSNumber *, RCTPair<RCTTextView *, UIViewController *> *> *viewRegistry) {
+    viewRegistry[reactTag].first.contentInset = padding;
   };
 }
 

--- a/React/Base/RCTComponentRetrievable.h
+++ b/React/Base/RCTComponentRetrievable.h
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <Foundation/Foundation.h>
+
+@protocol RCTComponent;
+
+@protocol RCTComponentRetrievable <NSObject>
+
+@property (nonatomic, assign, readonly) id<RCTComponent> component;
+
+@end

--- a/React/Base/RCTPair.h
+++ b/React/Base/RCTPair.h
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <Foundation/Foundation.h>
+
+@interface RCTPair<F,S> : NSObject
+
+@property (nonatomic, strong, readonly) F first;
+@property (nonatomic, strong, readonly) S second;
+
+- (instancetype)initWithFirst:(F)first second:(S)second;
+
+@end

--- a/React/Base/RCTPair.m
+++ b/React/Base/RCTPair.m
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import "RCTPair.h"
+
+@interface RCTPair ()
+
+@property (nonatomic, strong, readwrite) id first;
+@property (nonatomic, strong, readwrite) id second;
+
+@end
+
+@implementation RCTPair
+
+- (instancetype)initWithFirst:(id)first second:(id)second {
+  self = [super init];
+  if (self) {
+    _first = first;
+    _second = second;
+  }
+  return self;
+}
+
+@end

--- a/React/Base/RCTRootView.m
+++ b/React/Base/RCTRootView.m
@@ -42,7 +42,8 @@ NSString *const RCTContentDidAppearNotification = @"RCTContentDidAppearNotificat
 
 - (instancetype)initWithFrame:(CGRect)frame
                        bridge:(RCTBridge *)bridge
-                     reactTag:(NSNumber *)reactTag NS_DESIGNATED_INITIALIZER;
+                     reactTag:(NSNumber *)reactTag
+           rootViewController:(UIViewController *)rootViewController NS_DESIGNATED_INITIALIZER;
 
 @end
 
@@ -211,7 +212,8 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
   [_contentView removeFromSuperview];
   _contentView = [[RCTRootContentView alloc] initWithFrame:self.bounds
                                                     bridge:bridge
-                                                  reactTag:self.reactTag];
+                                                  reactTag:self.reactTag
+                                        rootViewController:self.reactViewController];
   [self runApplication:bridge];
 
   _contentView.backgroundColor = self.backgroundColor;
@@ -319,13 +321,14 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
 - (instancetype)initWithFrame:(CGRect)frame
                        bridge:(RCTBridge *)bridge
                      reactTag:(NSNumber *)reactTag
+           rootViewController:(UIViewController *)rootViewController
 {
   if ((self = [super initWithFrame:frame])) {
     _bridge = bridge;
     self.reactTag = reactTag;
     _touchHandler = [[RCTTouchHandler alloc] initWithBridge:_bridge];
     [self addGestureRecognizer:_touchHandler];
-    [_bridge.uiManager registerRootView:self];
+    [_bridge.uiManager registerRootView:self rootViewController:rootViewController];
     self.layer.backgroundColor = NULL;
   }
   return self;

--- a/React/Base/RCTViewRegistryPair.h
+++ b/React/Base/RCTViewRegistryPair.h
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <UIKit/UIKit.h>
+
+#import "RCTComponentRetrievable.h"
+#import "RCTPair.h"
+
+@interface RCTViewRegistryPair<RCTComponentRetrievable> : RCTPair<UIView *, UIViewController *>
+
+@property (nonatomic, strong, readonly) UIView *view;
+@property (nonatomic, strong, readonly) UIViewController *viewController;
+
+- (instancetype)initWithView:(UIView *)view viewController:(UIViewController *)viewController;
+
+@end

--- a/React/Base/RCTViewRegistryPair.m
+++ b/React/Base/RCTViewRegistryPair.m
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import "RCTViewRegistryPair.h"
+
+@implementation RCTViewRegistryPair
+
+- (instancetype)initWithView:(UIView *)view viewController:(UIViewController *)viewController {
+  return [super initWithFirst:view second:viewController];
+}
+
+- (UIView *)view {
+  return self.first;
+}
+
+- (UIViewController *)viewController {
+  return self.second;
+}
+
+- (id<RCTComponent>)component {
+  return self.first;
+}
+
+@end

--- a/React/Modules/RCTUIManager.h
+++ b/React/Modules/RCTUIManager.h
@@ -45,9 +45,10 @@ RCT_EXTERN NSString *const RCTUIManagerRootViewKey;
 @interface RCTUIManager : NSObject <RCTBridgeModule, RCTInvalidating>
 
 /**
- * Register a root view with the RCTUIManager.
+ * Register a root view and root view controller with the RCTUIManager. View controller argument is optional.
  */
-- (void)registerRootView:(UIView *)rootView;
+- (void)registerRootView:(UIView *)rootView
+      rootViewController:(UIViewController *)rootViewController;
 
 /**
  * Gets the view associated with a reactTag.

--- a/React/Profiler/RCTPerfMonitor.m
+++ b/React/Profiler/RCTPerfMonitor.m
@@ -441,11 +441,11 @@ RCT_EXPORT_MODULE()
 
 - (void)updateStats
 {
-  NSDictionary<NSNumber *, UIView *> *views = [_bridge.uiManager valueForKey:@"viewRegistry"];
-  NSUInteger viewCount = views.count;
+  NSDictionary<NSNumber *, RCTViewRegistryPair *> *viewRegistryPairs = [_bridge.uiManager valueForKey:@"viewRegistry"];
+  NSUInteger viewCount = viewRegistryPairs.count;
   NSUInteger visibleViewCount = 0;
-  for (UIView *view in views.allValues) {
-    if (view.window || view.superview.window) {
+  for (RCTViewRegistryPair *viewRegistryPair in viewRegistryPairs.allValues) {
+    if (viewRegistryPair.view.window || viewRegistryPair.view.superview.window) {
       visibleViewCount++;
     }
   }

--- a/React/React.xcodeproj/project.pbxproj
+++ b/React/React.xcodeproj/project.pbxproj
@@ -72,6 +72,8 @@
 		14F7A0F01BDA714B003C6C10 /* RCTFPSGraph.m in Sources */ = {isa = PBXBuildFile; fileRef = 14F7A0EF1BDA714B003C6C10 /* RCTFPSGraph.m */; };
 		191E3EBE1C29D9AF00C180A6 /* RCTRefreshControlManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 191E3EBD1C29D9AF00C180A6 /* RCTRefreshControlManager.m */; };
 		191E3EC11C29DC3800C180A6 /* RCTRefreshControl.m in Sources */ = {isa = PBXBuildFile; fileRef = 191E3EC01C29DC3800C180A6 /* RCTRefreshControl.m */; };
+		28C046281C8159240005A0DE /* RCTPair.m in Sources */ = {isa = PBXBuildFile; fileRef = 28C046271C8159240005A0DE /* RCTPair.m */; };
+		28C0462C1C815EE00005A0DE /* RCTViewRegistryPair.m in Sources */ = {isa = PBXBuildFile; fileRef = 28C0462B1C815EE00005A0DE /* RCTViewRegistryPair.m */; };
 		391E86A41C623EC800009732 /* RCTTouchEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = 391E86A21C623EC800009732 /* RCTTouchEvent.m */; };
 		58114A161AAE854800E7D092 /* RCTPicker.m in Sources */ = {isa = PBXBuildFile; fileRef = 58114A131AAE854800E7D092 /* RCTPicker.m */; };
 		58114A171AAE854800E7D092 /* RCTPickerManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 58114A151AAE854800E7D092 /* RCTPickerManager.m */; };
@@ -249,6 +251,11 @@
 		191E3EBD1C29D9AF00C180A6 /* RCTRefreshControlManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTRefreshControlManager.m; sourceTree = "<group>"; };
 		191E3EBF1C29DC3800C180A6 /* RCTRefreshControl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTRefreshControl.h; sourceTree = "<group>"; };
 		191E3EC01C29DC3800C180A6 /* RCTRefreshControl.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTRefreshControl.m; sourceTree = "<group>"; };
+		28C046261C8159240005A0DE /* RCTPair.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTPair.h; sourceTree = "<group>"; };
+		28C046271C8159240005A0DE /* RCTPair.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTPair.m; sourceTree = "<group>"; };
+		28C046291C815DD30005A0DE /* RCTComponentRetrievable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTComponentRetrievable.h; sourceTree = "<group>"; };
+		28C0462A1C815EE00005A0DE /* RCTViewRegistryPair.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTViewRegistryPair.h; sourceTree = "<group>"; };
+		28C0462B1C815EE00005A0DE /* RCTViewRegistryPair.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTViewRegistryPair.m; sourceTree = "<group>"; };
 		391E86A21C623EC800009732 /* RCTTouchEvent.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTTouchEvent.m; sourceTree = "<group>"; };
 		391E86A31C623EC800009732 /* RCTTouchEvent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTTouchEvent.h; sourceTree = "<group>"; };
 		3DB910701C74B21600838BBE /* RCTWebSocketProxy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTWebSocketProxy.h; sourceTree = "<group>"; };
@@ -564,6 +571,11 @@
 				83CBBA501A601E3B00E9B192 /* RCTUtils.m */,
 				3DB910701C74B21600838BBE /* RCTWebSocketProxy.h */,
 				3DB910711C74B21600838BBE /* RCTWebSocketProxyDelegate.h */,
+				28C046261C8159240005A0DE /* RCTPair.h */,
+				28C046271C8159240005A0DE /* RCTPair.m */,
+				28C046291C815DD30005A0DE /* RCTComponentRetrievable.h */,
+				28C0462A1C815EE00005A0DE /* RCTViewRegistryPair.h */,
+				28C0462B1C815EE00005A0DE /* RCTViewRegistryPair.m */,
 			);
 			path = Base;
 			sourceTree = "<group>";
@@ -668,6 +680,7 @@
 				131B6AF41AF1093D00FFC3E0 /* RCTSegmentedControl.m in Sources */,
 				830A229E1A66C68A008503DA /* RCTRootView.m in Sources */,
 				13B07FF01A69327A00A75B9A /* RCTExceptionsManager.m in Sources */,
+				28C046281C8159240005A0DE /* RCTPair.m in Sources */,
 				13B202041BFB948C00C07393 /* RCTMapAnnotation.m in Sources */,
 				13A0C28A1B74F71200B29F6F /* RCTDevMenu.m in Sources */,
 				14C2CA711B3AC63800E6CBB2 /* RCTModuleMethod.m in Sources */,
@@ -707,6 +720,7 @@
 				142014191B32094000CC17BA /* RCTPerformanceLogger.m in Sources */,
 				83CBBA981A6020BB00E9B192 /* RCTTouchHandler.m in Sources */,
 				83CBBA521A601E3B00E9B192 /* RCTLog.m in Sources */,
+				28C0462C1C815EE00005A0DE /* RCTViewRegistryPair.m in Sources */,
 				13B0801D1A69489C00A75B9A /* RCTNavItemManager.m in Sources */,
 				13A6E20E1C19AA0C00845B82 /* RCTParserUtils.m in Sources */,
 				13E067571A70F44B002CDEE1 /* RCTView.m in Sources */,

--- a/React/Views/RCTComponentData.h
+++ b/React/Views/RCTComponentData.h
@@ -26,6 +26,7 @@
 - (instancetype)initWithManagerClass:(Class)managerClass
                               bridge:(RCTBridge *)bridge NS_DESIGNATED_INITIALIZER;
 
+- (UIViewController *)createViewControllerWithTag:(NSNumber *)tag;
 - (UIView *)createViewWithTag:(NSNumber *)tag;
 - (RCTShadowView *)createShadowViewWithTag:(NSNumber *)tag;
 - (void)setProps:(NSDictionary<NSString *, id> *)props forView:(id<RCTComponent>)view;

--- a/React/Views/RCTComponentData.m
+++ b/React/Views/RCTComponentData.m
@@ -85,11 +85,21 @@ typedef void (^RCTPropBlock)(id<RCTComponent> view, id json);
 
 RCT_NOT_IMPLEMENTED(- (instancetype)init)
 
+- (UIViewController *)createViewControllerWithTag:(NSNumber *)tag
+{
+  UIViewController *viewController = [_manager viewController];
+  [self configuredView:viewController.view withReactTag:tag];
+  return viewController;
+}
+
 - (UIView *)createViewWithTag:(NSNumber *)tag
 {
   RCTAssertMainThread();
-
   UIView *view = [_manager view];
+  return [self configuredView:view withReactTag:tag];
+}
+
+- (UIView *)configuredView:(UIView *)view withReactTag:(NSNumber *)tag {
   view.reactTag = tag;
   view.multipleTouchEnabled = YES;
   view.userInteractionEnabled = YES; // required for touch handling

--- a/React/Views/RCTNavigatorManager.m
+++ b/React/Views/RCTNavigatorManager.m
@@ -12,6 +12,7 @@
 #import "RCTBridge.h"
 #import "RCTConvert.h"
 #import "RCTNavigator.h"
+#import "RCTPair.h"
 #import "RCTUIManager.h"
 #import "UIView+React.h"
 
@@ -34,8 +35,8 @@ RCT_EXPORT_METHOD(requestSchedulingJavaScriptNavigation:(nonnull NSNumber *)reac
                   callback:(RCTResponseSenderBlock)callback)
 {
   [self.bridge.uiManager addUIBlock:
-   ^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, RCTNavigator *> *viewRegistry){
-    RCTNavigator *navigator = viewRegistry[reactTag];
+   ^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, RCTPair<RCTNavigator *, UIViewController *> *> *viewRegistry){
+    RCTNavigator *navigator = viewRegistry[reactTag].first;
     if ([navigator isKindOfClass:[RCTNavigator class]]) {
       BOOL wasAcquired = [navigator requestSchedulingJavaScriptNavigation];
       callback(@[@(wasAcquired)]);

--- a/React/Views/RCTScrollViewManager.m
+++ b/React/Views/RCTScrollViewManager.m
@@ -10,6 +10,7 @@
 #import "RCTScrollViewManager.h"
 
 #import "RCTBridge.h"
+#import "RCTPair.h"
 #import "RCTScrollView.h"
 #import "RCTUIManager.h"
 
@@ -88,9 +89,9 @@ RCT_EXPORT_METHOD(getContentSize:(nonnull NSNumber *)reactTag
                   callback:(RCTResponseSenderBlock)callback)
 {
   [self.bridge.uiManager addUIBlock:
-   ^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, RCTScrollView *> *viewRegistry) {
+   ^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, RCTPair<RCTScrollView *, UIViewController *> *> *viewRegistry) {
 
-    RCTScrollView *view = viewRegistry[reactTag];
+    RCTScrollView *view = viewRegistry[reactTag].first;
     if (!view || ![view isKindOfClass:[RCTScrollView class]]) {
       RCTLogError(@"Cannot find RCTScrollView with tag #%@", reactTag);
       return;
@@ -108,9 +109,9 @@ RCT_EXPORT_METHOD(calculateChildFrames:(nonnull NSNumber *)reactTag
                   callback:(RCTResponseSenderBlock)callback)
 {
   [self.bridge.uiManager addUIBlock:
-   ^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, RCTScrollView *> *viewRegistry) {
+   ^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, RCTPair<RCTScrollView *, UIViewController *> *> *viewRegistry) {
 
-    RCTScrollView *view = viewRegistry[reactTag];
+    RCTScrollView *view = viewRegistry[reactTag].first;
     if (!view || ![view isKindOfClass:[RCTScrollView class]]) {
       RCTLogError(@"Cannot find RCTScrollView with tag #%@", reactTag);
       return;
@@ -126,9 +127,9 @@ RCT_EXPORT_METHOD(calculateChildFrames:(nonnull NSNumber *)reactTag
 RCT_EXPORT_METHOD(endRefreshing:(nonnull NSNumber *)reactTag)
 {
   [self.bridge.uiManager addUIBlock:
-   ^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, RCTScrollView *> *viewRegistry) {
+   ^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, RCTPair<RCTScrollView *, UIViewController *> *> *viewRegistry) {
 
-    RCTScrollView *view = viewRegistry[reactTag];
+    RCTScrollView *view = viewRegistry[reactTag].first;
     if (!view || ![view isKindOfClass:[RCTScrollView class]]) {
       RCTLogError(@"Cannot find RCTScrollView with tag #%@", reactTag);
       return;
@@ -144,8 +145,8 @@ RCT_EXPORT_METHOD(scrollTo:(nonnull NSNumber *)reactTag
                   animated:(BOOL)animated)
 {
   [self.bridge.uiManager addUIBlock:
-   ^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry){
-    UIView *view = viewRegistry[reactTag];
+   ^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, RCTViewRegistryPair *> *viewRegistry){
+    UIView *view = viewRegistry[reactTag].view;
     if ([view conformsToProtocol:@protocol(RCTScrollableProtocol)]) {
       [(id<RCTScrollableProtocol>)view scrollToOffset:(CGPoint){x, y} animated:animated];
     } else {
@@ -160,8 +161,8 @@ RCT_EXPORT_METHOD(zoomToRect:(nonnull NSNumber *)reactTag
                   animated:(BOOL)animated)
 {
   [self.bridge.uiManager addUIBlock:
-   ^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry){
-    UIView *view = viewRegistry[reactTag];
+   ^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, RCTViewRegistryPair *> *viewRegistry){
+    UIView *view = viewRegistry[reactTag].view;
     if ([view conformsToProtocol:@protocol(RCTScrollableProtocol)]) {
       [(id<RCTScrollableProtocol>)view zoomToRect:rect animated:animated];
     } else {

--- a/React/Views/RCTShadowView.h
+++ b/React/Views/RCTShadowView.h
@@ -11,9 +11,11 @@
 
 #import "Layout.h"
 #import "RCTComponent.h"
+#import "RCTComponentRetrievable.h"
 #import "RCTRootView.h"
 
 @class RCTSparseArray;
+@class RCTViewRegistryPair;
 
 typedef NS_ENUM(NSUInteger, RCTUpdateLifecycle) {
   RCTUpdateLifecycleUninitialized = 0,
@@ -21,7 +23,7 @@ typedef NS_ENUM(NSUInteger, RCTUpdateLifecycle) {
   RCTUpdateLifecycleDirtied,
 };
 
-typedef void (^RCTApplierBlock)(NSDictionary<NSNumber *, UIView *> *viewRegistry);
+typedef void (^RCTApplierBlock)(NSDictionary<NSNumber *, RCTViewRegistryPair *> *viewRegistry);
 
 /**
  * ShadowView tree mirrors RCT view tree. Every node is highly stateful.
@@ -33,7 +35,7 @@ typedef void (^RCTApplierBlock)(NSDictionary<NSNumber *, UIView *> *viewRegistry
  * 3. If a node is "computed" and the constraint passed from above is identical to the constraint used to
  *    perform the last computation, we skip laying out the subtree entirely.
  */
-@interface RCTShadowView : NSObject <RCTComponent>
+@interface RCTShadowView : NSObject <RCTComponent, RCTComponentRetrievable>
 
 - (NSArray<RCTShadowView *> *)reactSubviews;
 - (RCTShadowView *)reactSuperview;

--- a/React/Views/RCTShadowView.m
+++ b/React/Views/RCTShadowView.m
@@ -12,6 +12,7 @@
 #import "RCTConvert.h"
 #import "RCTLog.h"
 #import "RCTUtils.h"
+#import "RCTViewRegistryPair.h"
 #import "UIView+React.h"
 
 typedef void (^RCTActionBlock)(RCTShadowView *shadowViewSelf, id value);
@@ -180,8 +181,8 @@ static void RCTProcessMetaProps(const float metaProps[META_PROP_COUNT], float st
   if (!_backgroundColor) {
     UIColor *parentBackgroundColor = parentProperties[RCTBackgroundColorProp];
     if (parentBackgroundColor) {
-      [applierBlocks addObject:^(NSDictionary<NSNumber *, UIView *> *viewRegistry) {
-        UIView *view = viewRegistry[_reactTag];
+      [applierBlocks addObject:^(NSDictionary<NSNumber *, RCTViewRegistryPair *> *viewRegistry) {
+        UIView *view = viewRegistry[_reactTag].view;
         [view reactSetInheritedBackgroundColor:parentBackgroundColor];
       }];
     }
@@ -594,6 +595,10 @@ RCT_STYLE_PROPERTY(FlexWrap, flexWrap, flex_wrap, css_wrap_type_t)
   _recomputeMargin = NO;
   _recomputePadding = NO;
   _recomputeBorder = NO;
+}
+
+- (id<RCTComponent>)component {
+  return self;
 }
 
 @end

--- a/React/Views/RCTViewManager.h
+++ b/React/Views/RCTViewManager.h
@@ -15,13 +15,14 @@
 #import "RCTDefines.h"
 #import "RCTEventDispatcher.h"
 #import "RCTLog.h"
+#import "RCTViewRegistryPair.h"
 
 @class RCTBridge;
 @class RCTShadowView;
 @class RCTSparseArray;
 @class RCTUIManager;
 
-typedef void (^RCTViewManagerUIBlock)(RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry);
+typedef void (^RCTViewManagerUIBlock)(RCTUIManager *uiManager, NSDictionary<NSNumber *, RCTViewRegistryPair *> *viewRegistry);
 
 @interface RCTViewManager : NSObject <RCTBridgeModule>
 
@@ -40,6 +41,16 @@ typedef void (^RCTViewManagerUIBlock)(RCTUIManager *uiManager, NSDictionary<NSNu
  * view and return the same instance for subsequent calls.
  */
 - (UIView *)view;
+
+/**
+ * This method returns nil by default. Override this intstead of -view to return a custom view controller
+ * instance, which may be preconfigured with default properties, subviews, etc. 
+ * This method will be called many times, and should  return a fresh instance each time.
+ * The view module MUST NOT cache the returned view controller and return the same instance for subsequent calls.
+ * This method is meant to be used to inject full featured view controllers among a react view hierarchy. These
+ * view controllers should behave like a black box.
+ */
+- (UIViewController *)viewController;
 
 /**
  * This method instantiates a shadow view to be managed by the module. If omitted,

--- a/React/Views/RCTViewManager.m
+++ b/React/Views/RCTViewManager.m
@@ -60,6 +60,11 @@ RCT_EXPORT_MODULE()
   return [RCTView new];
 }
 
+- (UIViewController *)viewController
+{
+  return nil;
+}
+
 - (RCTShadowView *)shadowView
 {
   return [RCTShadowView new];

--- a/React/Views/RCTWebViewManager.m
+++ b/React/Views/RCTWebViewManager.m
@@ -64,8 +64,8 @@ RCT_REMAP_VIEW_PROPERTY(allowsInlineMediaPlayback, _webView.allowsInlineMediaPla
 
 RCT_EXPORT_METHOD(goBack:(nonnull NSNumber *)reactTag)
 {
-  [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, RCTWebView *> *viewRegistry) {
-    RCTWebView *view = viewRegistry[reactTag];
+  [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, RCTPair<RCTWebView *, UIViewController *> *> *viewRegistry) {
+    RCTWebView *view = viewRegistry[reactTag].first;
     if (![view isKindOfClass:[RCTWebView class]]) {
       RCTLogError(@"Invalid view returned from registry, expecting RCTWebView, got: %@", view);
     } else {
@@ -76,8 +76,8 @@ RCT_EXPORT_METHOD(goBack:(nonnull NSNumber *)reactTag)
 
 RCT_EXPORT_METHOD(goForward:(nonnull NSNumber *)reactTag)
 {
-  [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry) {
-    id view = viewRegistry[reactTag];
+  [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, RCTViewRegistryPair *> *viewRegistry) {
+    id view = viewRegistry[reactTag].view;
     if (![view isKindOfClass:[RCTWebView class]]) {
       RCTLogError(@"Invalid view returned from registry, expecting RCTWebView, got: %@", view);
     } else {
@@ -88,8 +88,8 @@ RCT_EXPORT_METHOD(goForward:(nonnull NSNumber *)reactTag)
 
 RCT_EXPORT_METHOD(reload:(nonnull NSNumber *)reactTag)
 {
-  [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, RCTWebView *> *viewRegistry) {
-    RCTWebView *view = viewRegistry[reactTag];
+  [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, RCTPair<RCTWebView *, UIViewController *> *> *viewRegistry) {
+    RCTWebView *view = viewRegistry[reactTag].first;
     if (![view isKindOfClass:[RCTWebView class]]) {
       RCTLogError(@"Invalid view returned from registry, expecting RCTWebView, got: %@", view);
     } else {


### PR DESCRIPTION
**Motivation**

Adds ability to build UIComponent modules based on existing UIViewController implementations. This is a first pass experimental commit to see if the community is interested in adding this capability. In iOS, the UIViewController is designed to be very component-like so it's a natural fit for injecting existing native code within react native view hierarchies. An injected UIViewController is meant to behave like a black box. This will attract iOS developers because developers will be able to re-use a lot more code than before. 

Also, this is one step towards being able to generically compose view controllers based on react jsx trees. iOS developers would be able to build and release custom UIViewController containers as react components that can have child jsx nodes that are treated as child view controllers.

*This is not a complete implementation*, it handles adding the view controllers but does not handle removing them. I will complete this feature if there is a positive response.

**Usage**

Simple! Return a view controller instance from RCTViewManager subclass:

```objc
@implementation RCTContainerManager

RCT_EXPORT_MODULE()

- (UIViewController *)viewController {
  return [[CustomViewController alloc] init];
}

@end
```


**Test plan**

Test Plan: Ran UIExplorererIntegrationTests in Xcode, did not get green results, looks like other builds on Travis had the same errors. I'm interested in knowing whether this feature is worth the time for me to polish and complete.