### PR TITLE
[WebSocket] Add support for sending binary data (ArrayBuffer)

### DIFF
--- a/Libraries/WebSocket/RCTWebSocketModule.m
+++ b/Libraries/WebSocket/RCTWebSocketModule.m
@@ -61,6 +61,12 @@ RCT_EXPORT_METHOD(send:(NSString *)message socketID:(nonnull NSNumber *)socketID
   [_sockets[socketID] send:message];
 }
 
+RCT_EXPORT_METHOD(sendBinary:(NSString *)base64String socketID:(nonnull NSNumber *)socketID)
+{
+  NSData *message = [[NSData alloc] initWithBase64EncodedString:base64String options:0];
+  [_sockets[socketID] send:message];
+}
+
 RCT_EXPORT_METHOD(close:(nonnull NSNumber *)socketID)
 {
   [_sockets[socketID] close];

--- a/Libraries/WebSocket/WebSocket.js
+++ b/Libraries/WebSocket/WebSocket.js
@@ -53,9 +53,9 @@ class WebSocket extends WebSocketBase {
     RCTWebSocketModule.send(message, this._socketId);
   }
 
-  sendArrayBufferImpl(): void {
-    // TODO
-    console.warn('Sending ArrayBuffers is not yet supported');
+  sendArrayBufferImpl(data: ArrayBuffer): void {
+    var message = base64.fromByteArray(new Uint8Array(data));
+    RCTWebSocketModule.sendBinary(message, this._socketId);
   }
 
   _closeWebSocket(id: number, code?: number, reason?: string): void {

--- a/Libraries/WebSocket/WebSocketBase.js
+++ b/Libraries/WebSocket/WebSocketBase.js
@@ -102,7 +102,7 @@ class WebSocketBase extends EventTarget {
     throw new Error('Subclass must define sendStringImpl method');
   }
 
-  sendArrayBufferImpl(): void {
+  sendArrayBufferImpl(data: ArrayBuffer): void {
     throw new Error('Subclass must define sendArrayBufferImpl method');
   }
 }

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "babel-register": "~6.4.3",
     "babel-types": "~6.4.5",
     "babylon": "~6.4.5",
-    "base64-js": "^0.0.8",
+    "base64-js": "^1.0.4",
     "bser": "^1.0.2",
     "chalk": "^1.1.1",
     "connect": "^2.8.3",


### PR DESCRIPTION
Adding WebSocket support for sending ArrayBuffer. This was previously not implemented, just printing a warning to console.

Support for receiving ArrayBuffers was implemented in #4483.

**Test plan**
 Code was tested with [Paho MQTT Client](https://www.eclipse.org/paho/clients/js/) that requires support for sending ArrayBuffers. 

This test code roundtrips an MQTT message over websockets and writes to console:
```javascript
// Download from http://git.eclipse.org/c/paho/org.eclipse.paho.mqtt.javascript.git/plain/src/mqttws31.js
import './mqttws31'; 

window.localStorage = {
    _data       : {},
    setItem     : function(id, val) { return this._data[id] = String(val); },
    getItem     : function(id) { return this._data.hasOwnProperty(id) ? this._data[id] : undefined; },
    removeItem  : function(id) { return delete this._data[id]; },
    clear       : function() { return this._data = {}; }
  };

var client = new Paho.MQTT.Client('broker.mqttdashboard.com', 8000, 'rn-client');

client.onConnectionLost = onConnectionLost;
client.onMessageArrived = onMessageArrived;

client.connect({
  onSuccess: onConnect,
  onFailure: onFail
});

function onConnect() {
  console.log("Sending message...");
  var message = new Paho.MQTT.Message('MQTT over websockets, ' + new Date().toISOString());
  message.destinationName = 'test/websockets';
  client.subscribe('test/websockets');
  client.send(message);
}

function onMessageArrived(msg) {
  console.log(`Received from '${msg.destinationName}': ${msg.payloadString}`);
}

function onConnectionLost(r) {
  console.log('Connection lost: ' + r.errorMessage);
}

function onFail(e) {
  console.log('Failed connect', e);
}
```

CLA has been signed.
