### PR TITLE
Fix crash when passing null to clearImmediate

### DIFF
--- a/Libraries/JavaScriptAppEngine/System/JSTimers/JSTimers.js
+++ b/Libraries/JavaScriptAppEngine/System/JSTimers/JSTimers.js
@@ -106,11 +106,9 @@ var JSTimers = {
 
   clearImmediate: function(timerID) {
     JSTimers._clearTimerID(timerID);
-    if (timerID != null) {
-      JSTimersExecution.immediates.splice(
-        JSTimersExecution.immediates.indexOf(timerID),
-        1
-      );
+    var index = JSTimersExecution.immediates.indexOf(timerID);
+    if (timerID != null && index !== -1) {
+      JSTimersExecution.immediates.splice(index, 1);
     }
   },
 

--- a/Libraries/JavaScriptAppEngine/System/JSTimers/JSTimers.js
+++ b/Libraries/JavaScriptAppEngine/System/JSTimers/JSTimers.js
@@ -106,10 +106,12 @@ var JSTimers = {
 
   clearImmediate: function(timerID) {
     JSTimers._clearTimerID(timerID);
-    JSTimersExecution.immediates.splice(
-      JSTimersExecution.immediates.indexOf(timerID),
-      1
-    );
+    if (timerID != null) {
+      JSTimersExecution.immediates.splice(
+        JSTimersExecution.immediates.indexOf(timerID),
+        1
+      );
+    }
   },
 
   cancelAnimationFrame: function(timerID) {

--- a/Libraries/JavaScriptAppEngine/System/JSTimers/JSTimers.js
+++ b/Libraries/JavaScriptAppEngine/System/JSTimers/JSTimers.js
@@ -107,7 +107,7 @@ var JSTimers = {
   clearImmediate: function(timerID) {
     JSTimers._clearTimerID(timerID);
     var index = JSTimersExecution.immediates.indexOf(timerID);
-    if (timerID != null && index !== -1) {
+    if (index !== -1) {
       JSTimersExecution.immediates.splice(index, 1);
     }
   },


### PR DESCRIPTION
Passing `undefined` or `null` to `clearImmediate` caused apps to crash. It it caused because we try to find the index of the null/undefined timer when we should just do nothing when passed these values.

It is already handled properly in the other Timer functions.

**Test plan**
Calling `clearImmediate` with `undefined` or `null` should do nothing.


