### PR TITLE
Remove 'displayName' prop from 'PickerExample' component

### DIFF
--- a/Examples/UIExplorer/PickerAndroidExample.js
+++ b/Examples/UIExplorer/PickerAndroidExample.js
@@ -44,8 +44,6 @@ const PickerExample = React.createClass({
     };
   },
 
-  displayName: 'Android Picker',
-
   render: function() {
     return (
       <UIExplorerPage title="<Picker>">


### PR DESCRIPTION
The value of the displayName was wrong (had space in it). Also the babel plugin for display name already adds display names. So we shouldn't need to do it manually.

As a side effect, it breaks the UIExplorer app when HMR is enabled (that's how I found it).