### PR TITLE
[RCTUtils] Don't loose NSError code in RCTJSErrorFromNSError()

### DIFF
--- a/React/Base/RCTUtils.m
+++ b/React/Base/RCTUtils.m
@@ -372,7 +372,7 @@ NSDictionary<NSString *, id> *RCTMakeAndLogError(NSString *message,
 
 NSDictionary<NSString *, id> *RCTJSErrorFromNSError(NSError *error)
 {
-  return RCTJSErrorFromCodeMessageAndNSError(RCTErrorUnspecified,
+  return RCTJSErrorFromCodeMessageAndNSError([NSString stringWithFormat:@"%ld", (long)[error code]],
                                              error.localizedDescription,
                                              error);
 }

--- a/React/Base/RCTUtils.m
+++ b/React/Base/RCTUtils.m
@@ -372,7 +372,8 @@ NSDictionary<NSString *, id> *RCTMakeAndLogError(NSString *message,
 
 NSDictionary<NSString *, id> *RCTJSErrorFromNSError(NSError *error)
 {
-  return RCTJSErrorFromCodeMessageAndNSError([NSString stringWithFormat:@"%ld", (long)[error code]],
+  NSString *codeWithDomain = [NSString stringWithFormat:@"E%@%zd", error.domain.uppercaseString, error.code];
+  return RCTJSErrorFromCodeMessageAndNSError(codeWithDomain,
                                              error.localizedDescription,
                                              error);
 }


### PR DESCRIPTION
Fixes #6171

Send original error code back to JS - this reverts old functionality according to https://github.com/facebook/react-native/issues/6171#issuecomment-189332649, that is https://github.com/facebook/react-native/blob/3c541ca54095fbf9d572362bcb661593acc1b64b/React/Base/RCTUtils.m#L299