### PR TITLE
Display a warning when using src property for an Image rather than source.

### DIFF
--- a/Libraries/Image/Image.android.js
+++ b/Libraries/Image/Image.android.js
@@ -161,6 +161,10 @@ var Image = React.createClass({
       console.warn('source.uri should not be an empty string');
     }
 
+    if (this.props.src) {
+      console.warn('The <Image> component requires a `source` property rather than `src`.');
+    }
+
     if (source && source.uri) {
       var {width, height} = source;
       var style = flattenStyle([{width, height}, styles.base, this.props.style]);

--- a/Libraries/Image/Image.ios.js
+++ b/Libraries/Image/Image.ios.js
@@ -210,6 +210,10 @@ var Image = React.createClass({
       RawImage = RCTImageView;
     }
 
+    if (this.props.src) {
+      console.warn('The <Image> component requires a `source` property rather than `src`.');
+    }
+
     if (this.context.isInAParentText) {
       RawImage = RCTVirtualImage;
       if (!width || !height) {


### PR DESCRIPTION
When using the `Image` component with a `src` property instead of `source` the component fails silently. @vjeux suggested to add a warning (https://twitter.com/Vjeux/status/704509214937317378).

Tested with the UIExplorer example on iOS and Android simulators. 