### PR TITLE
[WebSocket][Android] make protocols argument work fixes #5810 fix #6137

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/modules/websocket/WebSocketModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/websocket/WebSocketModule.java
@@ -66,7 +66,6 @@ public class WebSocketModule extends ReactContextBaseJavaModule {
 
   @ReactMethod
   public void connect(final String url, @Nullable final ReadableArray protocols, @Nullable final ReadableMap headers, final int id) {
-    // ignoring protocols, since OKHttp overrides them.
     OkHttpClient client = new OkHttpClient();
 
     client.setConnectTimeout(10, TimeUnit.SECONDS);
@@ -97,6 +96,21 @@ public class WebSocketModule extends ReactContextBaseJavaModule {
       }
     } else {
       builder.addHeader("origin", setDefaultOrigin(url));
+    }
+
+    if (protocols != null && protocols.size() > 0) {
+      StringBuilder protocolsValue = new StringBuilder("");
+      for (int i = 0; i < protocols.size(); i++) {
+        String v = protocols.getString(i).trim();
+        if (!v.isEmpty() && !v.contains(",")) {
+          protocolsValue.append(v);
+          protocolsValue.append(",");
+        }
+      }
+      if (protocolsValue.length() > 0) {
+        protocolsValue.replace(protocolsValue.length() - 1, protocolsValue.length(), "");
+        builder.addHeader("Sec-WebSocket-Protocol", protocolsValue.toString());
+      }
     }
 
     WebSocketCall.create(client, builder.build()).enqueue(new WebSocketListener() {


### PR DESCRIPTION
Hey there and thanks for submitting a pull request! Please have a look at the following checklist so that others have enough information to review your pull request:

**motivation**

WebSocket spec supports [Sec-WebSocket-Protocol](https://tools.ietf.org/html/rfc6455#section-11.3.4) as a standard way for negotiate a sub protocol between client and server.

* ios WebSocket implementation supports it.
* android WebSocket implementation ignores this header, leave a comment syas: "OkHttp will overrides it", so it did not implement.
* after some test, OkHttp doesn't override the header we add.

**Test plan (required)**

1. run and react-native app on android
2. at the main page, invoke: `var ws = new WebSocket('ws://example.ws-service.fakedomain.com', 'my-sub-protocol');`
3. see the header if it send the correct header, ex, use ngrep: `sudo ngrep -t -Wbyline -deth0 host example.ws-service.fakedomain.com and port 80`

you should see the WebSocket initial GET handshake includes header:
`Sec-WebSocket-Protocol: my-sub-protocol`
and the value should equals to the value you provided in js.

Closes #5810
Closes #6137