### PR TITLE
[NavigationExperimental] Rename setTiming to applyAnimation

### DIFF
--- a/Examples/UIExplorer/NavigationExperimental/NavigationAnimatedExample.js
+++ b/Examples/UIExplorer/NavigationExperimental/NavigationAnimatedExample.js
@@ -81,7 +81,7 @@ class NavigationAnimatedExample extends React.Component {
             getTitle={state => state.key}
           />
         )}
-        setTiming={(pos, navState) => {
+        applyAnimation={(pos, navState) => {
           Animated.timing(pos, {toValue: navState.index, duration: 1000}).start();
         }}
         renderScene={(props) => (

--- a/Libraries/CustomComponents/NavigationExperimental/NavigationCardStack.js
+++ b/Libraries/CustomComponents/NavigationExperimental/NavigationCardStack.js
@@ -49,7 +49,7 @@ import type {
   NavigationStateRenderer,
   NavigationStateRendererProps,
   Position,
-  TimingSetter,
+  AnimationSetter,
 } from 'NavigationAnimatedView';
 
 type Props = {
@@ -64,12 +64,12 @@ type Props = {
  */
 class NavigationCardStack extends React.Component {
   _renderScene : NavigationStateRenderer;
-  _setTiming: TimingSetter;
+  _applyAnimation: AnimationSetter;
 
   constructor(props: Props, context: any) {
     super(props, context);
     this._renderScene = this._renderScene.bind(this);
-    this._setTiming = this._setTiming.bind(this);
+    this._applyAnimation = this._applyAnimation.bind(this);
   }
 
   shouldComponentUpdate(nextProps: Object, nextState: Object): boolean {
@@ -86,7 +86,7 @@ class NavigationCardStack extends React.Component {
         navigationState={this.props.navigationState}
         renderOverlay={this.props.renderOverlay}
         renderScene={this._renderScene}
-        setTiming={this._setTiming}
+        applyAnimation={this._applyAnimation}
         style={[styles.animatedView, this.props.style]}
       />
     );
@@ -115,7 +115,7 @@ class NavigationCardStack extends React.Component {
     );
   }
 
-  _setTiming(position: Position, navigationState: NavigationParentState): void {
+  _applyAnimation(position: Position, navigationState: NavigationParentState): void {
     Animated.timing(
       position,
       {

--- a/Libraries/NavigationExperimental/NavigationAnimatedView.js
+++ b/Libraries/NavigationExperimental/NavigationAnimatedView.js
@@ -95,7 +95,7 @@ type NavigationStateRenderer = (
   props: NavigationStateRendererProps,
 ) => ReactElement;
 
-type TimingSetter = (
+type AnimationSetter = (
   position: Animated.Value,
   newState: NavigationParentState,
   lastState: NavigationParentState,
@@ -107,7 +107,7 @@ type Props = {
   renderScene: NavigationStateRenderer,
   renderOverlay: ?NavigationStateRenderer,
   style: any,
-  setTiming: ?TimingSetter,
+  applyAnimation: ?AnimationSetter,
 };
 
 class NavigationAnimatedView extends React.Component {
@@ -144,8 +144,8 @@ class NavigationAnimatedView extends React.Component {
     }
   }
   componentDidUpdate(lastProps) {
-    if (lastProps.navigationState.index !== this.props.navigationState.index && this.props.setTiming) {
-      this.props.setTiming(this.state.position, this.props.navigationState, lastProps.navigationState);
+    if (lastProps.navigationState.index !== this.props.navigationState.index && this.props.applyAnimation) {
+      this.props.applyAnimation(this.state.position, this.props.navigationState, lastProps.navigationState);
     }
   }
   componentWillUnmount() {
@@ -251,7 +251,7 @@ class NavigationAnimatedView extends React.Component {
   }
 }
 
-function setDefaultTiming(position, navigationState) {
+function applyDefaultAnimation(position, navigationState) {
   Animated.spring(
     position,
     {
@@ -262,7 +262,7 @@ function setDefaultTiming(position, navigationState) {
 }
 
 NavigationAnimatedView.defaultProps = {
-  setTiming: setDefaultTiming,
+  applyAnimation: applyDefaultAnimation,
 };
 
 NavigationAnimatedView = NavigationContainer.create(NavigationAnimatedView);


### PR DESCRIPTION
Given that you can do all kinds of animations other than `Animated.timing`, it made no sense to have `setTiming`. In addition, you can't intuitively tell that this is the callback where you would do custom animations.

The discussion took place on Discord with @ericvicenti: https://discordapp.com/channels/102860784329052160/154015578669973504