### PR TITLE
Remove the need for allowTopLevelThis in transform-es2015-modules-commonjs

### DIFF
--- a/Libraries/JavaScriptAppEngine/Initialization/InitializeJavaScriptAppEngine.js
+++ b/Libraries/JavaScriptAppEngine/Initialization/InitializeJavaScriptAppEngine.js
@@ -25,11 +25,11 @@
 require('regenerator/runtime');
 
 if (typeof GLOBAL === 'undefined') {
-  global.GLOBAL = this;
+  global.GLOBAL = global;
 }
 
 if (typeof window === 'undefined') {
-  global.window = GLOBAL;
+  global.window = global;
 }
 
 function setUpConsole() {
@@ -53,7 +53,7 @@ function setUpConsole() {
  * For more info on that particular case, see:
  * https://github.com/facebook/react-native/issues/934
  */
-function polyfillGlobal(name, newValue, scope = GLOBAL) {
+function polyfillGlobal(name, newValue, scope = global) {
   var descriptor = Object.getOwnPropertyDescriptor(scope, name) || {
     // jest for some bad reasons runs the polyfill code multiple times. In jest
     // environment, XmlHttpRequest doesn't exist so getOwnPropertyDescriptor
@@ -96,7 +96,7 @@ function polyfillLazyGlobal(name, valueFn, scope = GLOBAL) {
 /**
  * Polyfill a module if it is not already defined in `scope`.
  */
-function polyfillIfNeeded(name, polyfill, scope = GLOBAL, descriptor = {}) {
+function polyfillIfNeeded(name, polyfill, scope = global, descriptor = {}) {
   if (scope[name] === undefined) {
     Object.defineProperty(scope, name, {...descriptor, value: polyfill});
   }
@@ -141,8 +141,8 @@ function setUpTimers() {
 }
 
 function setUpAlert() {
-  if (!GLOBAL.alert) {
-    GLOBAL.alert = function(text) {
+  if (!global.alert) {
+    global.alert = function(text) {
       // Require Alert on demand. Requiring it too early can lead to issues
       // with things like Platform not being fully initialized.
       require('Alert').alert('Alert', '' + text);
@@ -169,12 +169,12 @@ function setUpXHR() {
 }
 
 function setUpGeolocation() {
-  polyfillIfNeeded('navigator', {}, GLOBAL, {
+  polyfillIfNeeded('navigator', {}, global, {
     writable: true,
     enumerable: true,
     configurable: true,
   });
-  polyfillLazyGlobal('geolocation', () => require('Geolocation'), GLOBAL.navigator);
+  polyfillLazyGlobal('geolocation', () => require('Geolocation'), global.navigator);
 }
 
 function setUpMapAndSet() {
@@ -185,7 +185,7 @@ function setUpMapAndSet() {
 }
 
 function setUpProduct() {
-  Object.defineProperty(GLOBAL.navigator, 'product', {value: 'ReactNative'});
+  Object.defineProperty(global.navigator, 'product', {value: 'ReactNative'});
 }
 
 function setUpWebSockets() {
@@ -200,13 +200,13 @@ function setUpProfile() {
 }
 
 function setUpProcess() {
-  GLOBAL.process = GLOBAL.process || {};
-  GLOBAL.process.env = GLOBAL.process.env || {};
-  if (!GLOBAL.process.env.NODE_ENV) {
-    GLOBAL.process.env.NODE_ENV = __DEV__ ? 'development' : 'production';
+  global.process = global.process || {};
+  global.process.env = global.process.env || {};
+  if (!global.process.env.NODE_ENV) {
+    global.process.env.NODE_ENV = __DEV__ ? 'development' : 'production';
   }
 
-  polyfillLazyGlobal('platform', () => require('Platform').OS, GLOBAL.process);
+  polyfillLazyGlobal('platform', () => require('Platform').OS, global.process);
 }
 
 function setUpDevTools() {

--- a/Libraries/JavaScriptAppEngine/Initialization/InitializeJavaScriptAppEngine.js
+++ b/Libraries/JavaScriptAppEngine/Initialization/InitializeJavaScriptAppEngine.js
@@ -70,7 +70,7 @@ function polyfillGlobal(name, newValue, scope = global) {
   Object.defineProperty(scope, name, {...descriptor, value: newValue});
 }
 
-function polyfillLazyGlobal(name, valueFn, scope = GLOBAL) {
+function polyfillLazyGlobal(name, valueFn, scope = global) {
   if (scope[name] !== undefined) {
     const descriptor = Object.getOwnPropertyDescriptor(scope, name);
     const backupName = `original${name[0].toUpperCase()}${name.substr(1)}`;

--- a/Libraries/Utilities/ErrorUtils.js
+++ b/Libraries/Utilities/ErrorUtils.js
@@ -8,9 +8,7 @@
  *
  * @providesModule ErrorUtils
  */
-/* eslint-disable consistent-this, global-strict */
-
-var GLOBAL = this;
+/* eslint-disable strict */
 
 /**
  * The particular require runtime that we are using looks for a global
@@ -24,4 +22,4 @@ var GLOBAL = this;
  * that use it aren't just using a global variable, so simply export the global
  * variable here. ErrorUtils is originally defined in a file named error-guard.js.
  */
-module.exports = GLOBAL.ErrorUtils;
+module.exports = global.ErrorUtils;

--- a/Libraries/Utilities/Systrace.js
+++ b/Libraries/Utilities/Systrace.js
@@ -23,7 +23,6 @@ type RelayProfiler = {
   ): void,
 };
 
-var GLOBAL = GLOBAL || this;
 var TRACE_TAG_REACT_APPS = 1 << 17;
 var TRACE_TAG_JSC_CALLS = 1 << 27;
 

--- a/babel-preset/configs/main.js
+++ b/babel-preset/configs/main.js
@@ -25,7 +25,7 @@ module.exports = {
     'transform-es2015-computed-properties',
     'transform-es2015-constants',
     'transform-es2015-destructuring',
-    ['transform-es2015-modules-commonjs', { strict: false, allowTopLevelThis: true }],
+    ['transform-es2015-modules-commonjs', { strict: false }],
     'transform-es2015-parameters',
     'transform-es2015-shorthand-properties',
     'transform-es2015-spread',

--- a/babel-preset/configs/main.js
+++ b/babel-preset/configs/main.js
@@ -25,7 +25,7 @@ module.exports = {
     'transform-es2015-computed-properties',
     'transform-es2015-constants',
     'transform-es2015-destructuring',
-    ['transform-es2015-modules-commonjs', { strict: false }],
+    ['transform-es2015-modules-commonjs', { strict: false, allowTopLevelThis: true }],
     'transform-es2015-parameters',
     'transform-es2015-shorthand-properties',
     'transform-es2015-spread',


### PR DESCRIPTION
This make the transform behave closer to the standard for modules.

This removes the few places that a top level this was used to refer to the global space. It also clean up the usage of `GLOBAL` to use `global` instead as this is what is used everywhere else in the code base. We still define `GLOBAL` for compatibility with other modules.

**Test plan**
Clear the packager cache to make sure the transforms run again. (node ./local-cli/cli.js start --reset-cache).
Run the Movies example (UIExplorer is broken atm) and make sure there are no errors.
