### PR TITLE
Update node-haste and replace fast-path with node-haste's version to fix Windows compatibility

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -112,20 +112,15 @@
       "from": "https://registry.npmjs.org/babel/-/babel-5.8.29.tgz",
       "resolved": "https://registry.npmjs.org/babel/-/babel-5.8.29.tgz",
       "dependencies": {
-        "babel-core": {
-          "version": "5.8.33",
-          "from": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.33.tgz",
-          "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.33.tgz"
-        },
-        "source-map": {
-          "version": "0.5.3",
-          "from": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
-        },
         "ast-types": {
           "version": "0.8.12",
           "from": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.12.tgz",
           "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.12.tgz"
+        },
+        "babel-core": {
+          "version": "5.8.33",
+          "from": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.33.tgz",
+          "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.33.tgz"
         },
         "babylon": {
           "version": "5.8.29",
@@ -151,6 +146,11 @@
           "version": "0.8.40",
           "from": "https://registry.npmjs.org/regenerator/-/regenerator-0.8.40.tgz",
           "resolved": "https://registry.npmjs.org/regenerator/-/regenerator-0.8.40.tgz"
+        },
+        "source-map": {
+          "version": "0.5.3",
+          "from": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
         }
       }
     },
@@ -179,16 +179,6 @@
           "from": "babel-messages@>=6.6.0 <7.0.0",
           "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.6.0.tgz"
         },
-        "babel-template": {
-          "version": "6.6.4",
-          "from": "babel-template@>=6.6.4 <7.0.0",
-          "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.6.4.tgz"
-        },
-        "babel-runtime": {
-          "version": "5.8.35",
-          "from": "babel-runtime@>=5.0.0 <6.0.0",
-          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz"
-        },
         "babel-register": {
           "version": "6.6.0",
           "from": "babel-register@>=6.6.0 <7.0.0",
@@ -200,6 +190,16 @@
               "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.1.3.tgz"
             }
           }
+        },
+        "babel-runtime": {
+          "version": "5.8.35",
+          "from": "babel-runtime@>=5.0.0 <6.0.0",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz"
+        },
+        "babel-template": {
+          "version": "6.6.4",
+          "from": "babel-template@>=6.6.4 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.6.4.tgz"
         },
         "babel-traverse": {
           "version": "6.6.4",
@@ -381,11 +381,6 @@
       "from": "babel-polyfill@>=6.5.0 <7.0.0",
       "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.6.1.tgz",
       "dependencies": {
-        "core-js": {
-          "version": "2.1.3",
-          "from": "core-js@>=2.1.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.1.3.tgz"
-        },
         "babel-regenerator-runtime": {
           "version": "6.5.0",
           "from": "babel-regenerator-runtime@>=6.3.13 <7.0.0",
@@ -402,6 +397,11 @@
               "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
             }
           }
+        },
+        "core-js": {
+          "version": "2.1.3",
+          "from": "core-js@>=2.1.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.1.3.tgz"
         }
       }
     },
@@ -511,6 +511,23 @@
           "from": "babel-plugin-transform-es2015-block-scoping@>=6.5.0 <7.0.0",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.6.4.tgz",
           "dependencies": {
+            "babel-runtime": {
+              "version": "5.8.35",
+              "from": "babel-runtime@>=5.0.0 <6.0.0",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz"
+            },
+            "babel-template": {
+              "version": "6.6.4",
+              "from": "babel-template@>=6.6.4 <7.0.0",
+              "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.6.4.tgz",
+              "dependencies": {
+                "babylon": {
+                  "version": "6.6.4",
+                  "from": "babylon@>=6.6.4 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.6.4.tgz"
+                }
+              }
+            },
             "babel-traverse": {
               "version": "6.6.4",
               "from": "babel-traverse@>=6.6.4 <7.0.0",
@@ -547,23 +564,6 @@
               "version": "6.6.4",
               "from": "babel-types@>=6.3.13 <7.0.0",
               "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.6.4.tgz"
-            },
-            "babel-template": {
-              "version": "6.6.4",
-              "from": "babel-template@>=6.6.4 <7.0.0",
-              "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.6.4.tgz",
-              "dependencies": {
-                "babylon": {
-                  "version": "6.6.4",
-                  "from": "babylon@>=6.6.4 <7.0.0",
-                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.6.4.tgz"
-                }
-              }
-            },
-            "babel-runtime": {
-              "version": "5.8.35",
-              "from": "babel-runtime@>=5.0.0 <6.0.0",
-              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz"
             }
           }
         },
@@ -572,10 +572,10 @@
           "from": "babel-plugin-transform-es2015-classes@>=6.5.0 <7.0.0",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.6.4.tgz",
           "dependencies": {
-            "babel-helper-optimise-call-expression": {
-              "version": "6.6.0",
-              "from": "babel-helper-optimise-call-expression@>=6.6.0 <7.0.0",
-              "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.6.0.tgz"
+            "babel-helper-define-map": {
+              "version": "6.6.4",
+              "from": "babel-helper-define-map@>=6.6.4 <7.0.0",
+              "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.6.4.tgz"
             },
             "babel-helper-function-name": {
               "version": "6.6.0",
@@ -589,10 +589,25 @@
                 }
               }
             },
+            "babel-helper-optimise-call-expression": {
+              "version": "6.6.0",
+              "from": "babel-helper-optimise-call-expression@>=6.6.0 <7.0.0",
+              "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.6.0.tgz"
+            },
             "babel-helper-replace-supers": {
               "version": "6.6.4",
               "from": "babel-helper-replace-supers@>=6.6.4 <7.0.0",
               "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.6.4.tgz"
+            },
+            "babel-messages": {
+              "version": "6.6.0",
+              "from": "babel-messages@>=6.6.0 <7.0.0",
+              "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.6.0.tgz"
+            },
+            "babel-runtime": {
+              "version": "5.8.35",
+              "from": "babel-runtime@>=5.0.0 <6.0.0",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz"
             },
             "babel-template": {
               "version": "6.6.4",
@@ -633,21 +648,6 @@
                 }
               }
             },
-            "babel-helper-define-map": {
-              "version": "6.6.4",
-              "from": "babel-helper-define-map@>=6.6.4 <7.0.0",
-              "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.6.4.tgz"
-            },
-            "babel-messages": {
-              "version": "6.6.0",
-              "from": "babel-messages@>=6.6.0 <7.0.0",
-              "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.6.0.tgz"
-            },
-            "babel-runtime": {
-              "version": "5.8.35",
-              "from": "babel-runtime@>=5.0.0 <6.0.0",
-              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz"
-            },
             "babel-types": {
               "version": "6.6.4",
               "from": "babel-types@>=6.3.13 <7.0.0",
@@ -665,6 +665,50 @@
               "from": "babel-helper-define-map@>=6.6.4 <7.0.0",
               "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.6.4.tgz",
               "dependencies": {
+                "babel-helper-function-name": {
+                  "version": "6.6.0",
+                  "from": "babel-helper-function-name@>=6.6.0 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.6.0.tgz",
+                  "dependencies": {
+                    "babel-helper-get-function-arity": {
+                      "version": "6.6.4",
+                      "from": "babel-helper-get-function-arity@>=6.3.13 <7.0.0",
+                      "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.6.4.tgz"
+                    },
+                    "babel-traverse": {
+                      "version": "6.6.4",
+                      "from": "babel-traverse@>=6.6.0 <7.0.0",
+                      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.6.4.tgz",
+                      "dependencies": {
+                        "babel-code-frame": {
+                          "version": "6.6.0",
+                          "from": "babel-code-frame@>=6.6.0 <7.0.0",
+                          "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.6.0.tgz"
+                        },
+                        "babel-messages": {
+                          "version": "6.6.0",
+                          "from": "babel-messages@>=6.6.0 <7.0.0",
+                          "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.6.0.tgz"
+                        },
+                        "babylon": {
+                          "version": "6.6.4",
+                          "from": "babylon@>=6.6.4 <7.0.0",
+                          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.6.4.tgz"
+                        },
+                        "globals": {
+                          "version": "8.18.0",
+                          "from": "globals@>=8.3.0 <9.0.0",
+                          "resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz"
+                        },
+                        "invariant": {
+                          "version": "2.2.0",
+                          "from": "invariant@>=2.2.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
                 "babel-types": {
                   "version": "6.6.4",
                   "from": "babel-types@>=6.6.4 <7.0.0",
@@ -703,63 +747,19 @@
                       }
                     }
                   }
-                },
-                "babel-helper-function-name": {
-                  "version": "6.6.0",
-                  "from": "babel-helper-function-name@>=6.6.0 <7.0.0",
-                  "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.6.0.tgz",
-                  "dependencies": {
-                    "babel-traverse": {
-                      "version": "6.6.4",
-                      "from": "babel-traverse@>=6.6.0 <7.0.0",
-                      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.6.4.tgz",
-                      "dependencies": {
-                        "babel-code-frame": {
-                          "version": "6.6.0",
-                          "from": "babel-code-frame@>=6.6.0 <7.0.0",
-                          "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.6.0.tgz"
-                        },
-                        "babel-messages": {
-                          "version": "6.6.0",
-                          "from": "babel-messages@>=6.6.0 <7.0.0",
-                          "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.6.0.tgz"
-                        },
-                        "babylon": {
-                          "version": "6.6.4",
-                          "from": "babylon@>=6.6.4 <7.0.0",
-                          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.6.4.tgz"
-                        },
-                        "globals": {
-                          "version": "8.18.0",
-                          "from": "globals@>=8.3.0 <9.0.0",
-                          "resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz"
-                        },
-                        "invariant": {
-                          "version": "2.2.0",
-                          "from": "invariant@>=2.2.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz"
-                        }
-                      }
-                    },
-                    "babel-helper-get-function-arity": {
-                      "version": "6.6.4",
-                      "from": "babel-helper-get-function-arity@>=6.3.13 <7.0.0",
-                      "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.6.4.tgz"
-                    }
-                  }
                 }
               }
+            },
+            "babel-runtime": {
+              "version": "5.8.35",
+              "from": "babel-runtime@>=5.0.0 <6.0.0",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz"
             },
             "babel-template": {
               "version": "6.6.4",
               "from": "babel-template@>=6.6.4 <7.0.0",
               "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.6.4.tgz",
               "dependencies": {
-                "babylon": {
-                  "version": "6.6.4",
-                  "from": "babylon@>=6.6.4 <7.0.0",
-                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.6.4.tgz"
-                },
                 "babel-traverse": {
                   "version": "6.6.4",
                   "from": "babel-traverse@>=6.6.4 <7.0.0",
@@ -791,13 +791,13 @@
                   "version": "6.6.4",
                   "from": "babel-types@>=6.6.4 <7.0.0",
                   "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.6.4.tgz"
+                },
+                "babylon": {
+                  "version": "6.6.4",
+                  "from": "babylon@>=6.6.4 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.6.4.tgz"
                 }
               }
-            },
-            "babel-runtime": {
-              "version": "5.8.35",
-              "from": "babel-runtime@>=5.0.0 <6.0.0",
-              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz"
             }
           }
         },
@@ -842,6 +842,55 @@
           "from": "babel-plugin-transform-es2015-modules-commonjs@>=6.5.0 <7.0.0",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.6.4.tgz",
           "dependencies": {
+            "babel-plugin-transform-strict-mode": {
+              "version": "6.6.4",
+              "from": "babel-plugin-transform-strict-mode@>=6.6.4 <7.0.0",
+              "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.6.4.tgz"
+            },
+            "babel-runtime": {
+              "version": "5.8.35",
+              "from": "babel-runtime@>=5.0.0 <6.0.0",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz"
+            },
+            "babel-template": {
+              "version": "6.6.4",
+              "from": "babel-template@>=6.6.4 <7.0.0",
+              "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.6.4.tgz",
+              "dependencies": {
+                "babel-traverse": {
+                  "version": "6.6.4",
+                  "from": "babel-traverse@>=6.6.4 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.6.4.tgz",
+                  "dependencies": {
+                    "babel-code-frame": {
+                      "version": "6.6.0",
+                      "from": "babel-code-frame@>=6.6.0 <7.0.0",
+                      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.6.0.tgz"
+                    },
+                    "babel-messages": {
+                      "version": "6.6.0",
+                      "from": "babel-messages@>=6.6.0 <7.0.0",
+                      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.6.0.tgz"
+                    },
+                    "globals": {
+                      "version": "8.18.0",
+                      "from": "globals@>=8.3.0 <9.0.0",
+                      "resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz"
+                    },
+                    "invariant": {
+                      "version": "2.2.0",
+                      "from": "invariant@>=2.2.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz"
+                    }
+                  }
+                },
+                "babylon": {
+                  "version": "6.6.4",
+                  "from": "babylon@>=6.6.0 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.6.4.tgz"
+                }
+              }
+            },
             "babel-types": {
               "version": "6.6.4",
               "from": "babel-types@>=6.3.13 <7.0.0",
@@ -880,6 +929,30 @@
                   }
                 }
               }
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-parameters": {
+          "version": "6.6.4",
+          "from": "babel-plugin-transform-es2015-parameters@>=6.5.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.6.4.tgz",
+          "dependencies": {
+            "babel-helper-call-delegate": {
+              "version": "6.6.4",
+              "from": "babel-helper-call-delegate@>=6.6.4 <7.0.0",
+              "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.6.4.tgz",
+              "dependencies": {
+                "babel-helper-hoist-variables": {
+                  "version": "6.6.4",
+                  "from": "babel-helper-hoist-variables@>=6.6.4 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.6.4.tgz"
+                }
+              }
+            },
+            "babel-helper-get-function-arity": {
+              "version": "6.6.4",
+              "from": "babel-helper-get-function-arity@>=6.6.4 <7.0.0",
+              "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.6.4.tgz"
             },
             "babel-runtime": {
               "version": "5.8.35",
@@ -893,50 +966,11 @@
               "dependencies": {
                 "babylon": {
                   "version": "6.6.4",
-                  "from": "babylon@>=6.6.0 <7.0.0",
+                  "from": "babylon@>=6.6.4 <7.0.0",
                   "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.6.4.tgz"
-                },
-                "babel-traverse": {
-                  "version": "6.6.4",
-                  "from": "babel-traverse@>=6.6.4 <7.0.0",
-                  "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.6.4.tgz",
-                  "dependencies": {
-                    "babel-code-frame": {
-                      "version": "6.6.0",
-                      "from": "babel-code-frame@>=6.6.0 <7.0.0",
-                      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.6.0.tgz"
-                    },
-                    "babel-messages": {
-                      "version": "6.6.0",
-                      "from": "babel-messages@>=6.6.0 <7.0.0",
-                      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.6.0.tgz"
-                    },
-                    "globals": {
-                      "version": "8.18.0",
-                      "from": "globals@>=8.3.0 <9.0.0",
-                      "resolved": "https://registry.npmjs.org/globals/-/globals-8.18.0.tgz"
-                    },
-                    "invariant": {
-                      "version": "2.2.0",
-                      "from": "invariant@>=2.2.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz"
-                    }
-                  }
                 }
               }
             },
-            "babel-plugin-transform-strict-mode": {
-              "version": "6.6.4",
-              "from": "babel-plugin-transform-strict-mode@>=6.6.4 <7.0.0",
-              "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.6.4.tgz"
-            }
-          }
-        },
-        "babel-plugin-transform-es2015-parameters": {
-          "version": "6.6.4",
-          "from": "babel-plugin-transform-es2015-parameters@>=6.5.0 <7.0.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.6.4.tgz",
-          "dependencies": {
             "babel-traverse": {
               "version": "6.6.4",
               "from": "babel-traverse@>=6.6.4 <7.0.0",
@@ -969,44 +1003,10 @@
                 }
               }
             },
-            "babel-helper-call-delegate": {
-              "version": "6.6.4",
-              "from": "babel-helper-call-delegate@>=6.6.4 <7.0.0",
-              "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.6.4.tgz",
-              "dependencies": {
-                "babel-helper-hoist-variables": {
-                  "version": "6.6.4",
-                  "from": "babel-helper-hoist-variables@>=6.6.4 <7.0.0",
-                  "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.6.4.tgz"
-                }
-              }
-            },
-            "babel-helper-get-function-arity": {
-              "version": "6.6.4",
-              "from": "babel-helper-get-function-arity@>=6.6.4 <7.0.0",
-              "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.6.4.tgz"
-            },
-            "babel-template": {
-              "version": "6.6.4",
-              "from": "babel-template@>=6.6.4 <7.0.0",
-              "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.6.4.tgz",
-              "dependencies": {
-                "babylon": {
-                  "version": "6.6.4",
-                  "from": "babylon@>=6.6.4 <7.0.0",
-                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.6.4.tgz"
-                }
-              }
-            },
             "babel-types": {
               "version": "6.6.4",
               "from": "babel-types@>=6.3.13 <7.0.0",
               "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.6.4.tgz"
-            },
-            "babel-runtime": {
-              "version": "5.8.35",
-              "from": "babel-runtime@>=5.0.0 <6.0.0",
-              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz"
             }
           }
         },
@@ -1015,6 +1015,11 @@
           "from": "babel-plugin-transform-es2015-shorthand-properties@>=6.5.0 <7.0.0",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.5.0.tgz",
           "dependencies": {
+            "babel-runtime": {
+              "version": "5.8.35",
+              "from": "babel-runtime@>=5.0.0 <6.0.0",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz"
+            },
             "babel-types": {
               "version": "6.6.4",
               "from": "babel-types@>=6.3.13 <7.0.0",
@@ -1053,11 +1058,6 @@
                   }
                 }
               }
-            },
-            "babel-runtime": {
-              "version": "5.8.35",
-              "from": "babel-runtime@>=5.0.0 <6.0.0",
-              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz"
             }
           }
         },
@@ -1143,11 +1143,6 @@
           "from": "babel-plugin-transform-react-jsx@>=6.5.0 <7.0.0",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx/-/babel-plugin-transform-react-jsx-6.6.4.tgz",
           "dependencies": {
-            "babel-runtime": {
-              "version": "5.8.35",
-              "from": "babel-runtime@>=5.0.0 <6.0.0",
-              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz"
-            },
             "babel-helper-builder-react-jsx": {
               "version": "6.6.4",
               "from": "babel-helper-builder-react-jsx@>=6.6.4 <7.0.0",
@@ -1193,6 +1188,11 @@
                   }
                 }
               }
+            },
+            "babel-runtime": {
+              "version": "5.8.35",
+              "from": "babel-runtime@>=5.0.0 <6.0.0",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz"
             }
           }
         },
@@ -1451,30 +1451,50 @@
       "from": "https://registry.npmjs.org/connect/-/connect-2.8.3.tgz",
       "resolved": "https://registry.npmjs.org/connect/-/connect-2.8.3.tgz",
       "dependencies": {
-        "qs": {
-          "version": "0.6.5",
-          "from": "https://registry.npmjs.org/qs/-/qs-0.6.5.tgz",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.5.tgz"
+        "buffer-crc32": {
+          "version": "0.2.1",
+          "from": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.1.tgz"
         },
-        "formidable": {
-          "version": "1.0.14",
-          "from": "https://registry.npmjs.org/formidable/-/formidable-1.0.14.tgz",
-          "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.14.tgz"
+        "bytes": {
+          "version": "0.2.0",
+          "from": "https://registry.npmjs.org/bytes/-/bytes-0.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/bytes/-/bytes-0.2.0.tgz"
+        },
+        "cookie": {
+          "version": "0.1.0",
+          "from": "https://registry.npmjs.org/cookie/-/cookie-0.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.0.tgz"
         },
         "cookie-signature": {
           "version": "1.0.1",
           "from": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.1.tgz",
           "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.1.tgz"
         },
-        "buffer-crc32": {
-          "version": "0.2.1",
-          "from": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.1.tgz",
-          "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.1.tgz"
+        "formidable": {
+          "version": "1.0.14",
+          "from": "https://registry.npmjs.org/formidable/-/formidable-1.0.14.tgz",
+          "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.14.tgz"
         },
-        "cookie": {
+        "fresh": {
           "version": "0.1.0",
-          "from": "https://registry.npmjs.org/cookie/-/cookie-0.1.0.tgz",
-          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.0.tgz"
+          "from": "https://registry.npmjs.org/fresh/-/fresh-0.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.1.0.tgz"
+        },
+        "methods": {
+          "version": "0.0.1",
+          "from": "https://registry.npmjs.org/methods/-/methods-0.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/methods/-/methods-0.0.1.tgz"
+        },
+        "pause": {
+          "version": "0.0.1",
+          "from": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz"
+        },
+        "qs": {
+          "version": "0.6.5",
+          "from": "https://registry.npmjs.org/qs/-/qs-0.6.5.tgz",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.5.tgz"
         },
         "send": {
           "version": "0.1.2",
@@ -1493,30 +1513,10 @@
             }
           }
         },
-        "bytes": {
-          "version": "0.2.0",
-          "from": "https://registry.npmjs.org/bytes/-/bytes-0.2.0.tgz",
-          "resolved": "https://registry.npmjs.org/bytes/-/bytes-0.2.0.tgz"
-        },
-        "fresh": {
-          "version": "0.1.0",
-          "from": "https://registry.npmjs.org/fresh/-/fresh-0.1.0.tgz",
-          "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.1.0.tgz"
-        },
-        "pause": {
-          "version": "0.0.1",
-          "from": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
-          "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz"
-        },
         "uid2": {
           "version": "0.0.2",
           "from": "https://registry.npmjs.org/uid2/-/uid2-0.0.2.tgz",
           "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.2.tgz"
-        },
-        "methods": {
-          "version": "0.0.1",
-          "from": "https://registry.npmjs.org/methods/-/methods-0.0.1.tgz",
-          "resolved": "https://registry.npmjs.org/methods/-/methods-0.0.1.tgz"
         }
       }
     },
@@ -1566,6 +1566,11 @@
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.27.0.tgz"
         }
       }
+    },
+    "denodeify": {
+      "version": "1.2.1",
+      "from": "denodeify@>=1.2.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/denodeify/-/denodeify-1.2.1.tgz"
     },
     "detect-indent": {
       "version": "3.0.1",
@@ -2012,30 +2017,30 @@
           "from": "optionator@>=0.8.1 <0.9.0",
           "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.1.tgz",
           "dependencies": {
-            "prelude-ls": {
-              "version": "1.1.2",
-              "from": "prelude-ls@>=1.1.2 <1.2.0",
-              "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
-            },
             "deep-is": {
               "version": "0.1.3",
               "from": "deep-is@>=0.1.3 <0.2.0",
               "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
             },
-            "type-check": {
-              "version": "0.3.2",
-              "from": "type-check@>=0.3.2 <0.4.0",
-              "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz"
+            "fast-levenshtein": {
+              "version": "1.1.3",
+              "from": "fast-levenshtein@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.1.3.tgz"
             },
             "levn": {
               "version": "0.3.0",
               "from": "levn@>=0.3.0 <0.4.0",
               "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz"
             },
-            "fast-levenshtein": {
-              "version": "1.1.3",
-              "from": "fast-levenshtein@>=1.1.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.1.3.tgz"
+            "prelude-ls": {
+              "version": "1.1.2",
+              "from": "prelude-ls@>=1.1.2 <1.2.0",
+              "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
+            },
+            "type-check": {
+              "version": "0.3.2",
+              "from": "type-check@>=0.3.2 <0.4.0",
+              "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz"
             }
           }
         },
@@ -2171,6 +2176,11 @@
       "from": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-1.0.5.tgz",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-1.0.5.tgz"
     },
+    "exec-sh": {
+      "version": "0.2.0",
+      "from": "exec-sh@>=0.2.0 <0.3.0",
+      "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.0.tgz"
+    },
     "expand-brackets": {
       "version": "0.1.4",
       "from": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.4.tgz",
@@ -2195,6 +2205,11 @@
       "version": "1.1.0",
       "from": "fast-path@*",
       "resolved": "https://registry.npmjs.org/fast-path/-/fast-path-1.1.0.tgz"
+    },
+    "fb-watchman": {
+      "version": "1.9.0",
+      "from": "fb-watchman@>=1.8.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-1.9.0.tgz"
     },
     "fbjs": {
       "version": "0.7.2",
@@ -2760,25 +2775,25 @@
                   "from": "rc@>=0.5.1 <0.6.0",
                   "resolved": "https://registry.npmjs.org/rc/-/rc-0.5.5.tgz",
                   "dependencies": {
-                    "minimist": {
-                      "version": "0.0.10",
-                      "from": "minimist@>=0.0.7 <0.1.0",
-                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
-                    },
                     "deep-extend": {
                       "version": "0.2.11",
                       "from": "deep-extend@>=0.2.5 <0.3.0",
                       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz"
                     },
-                    "strip-json-comments": {
-                      "version": "0.1.3",
-                      "from": "strip-json-comments@>=0.1.0 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz"
-                    },
                     "ini": {
                       "version": "1.3.4",
                       "from": "ini@>=1.3.0 <1.4.0",
                       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
+                    },
+                    "minimist": {
+                      "version": "0.0.10",
+                      "from": "minimist@>=0.0.7 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                    },
+                    "strip-json-comments": {
+                      "version": "0.1.3",
+                      "from": "strip-json-comments@>=0.1.0 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz"
                     }
                   }
                 },
@@ -2927,11 +2942,6 @@
                       "from": "hawk@>=3.1.0 <3.2.0",
                       "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
                       "dependencies": {
-                        "hoek": {
-                          "version": "2.16.3",
-                          "from": "hoek@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
-                        },
                         "boom": {
                           "version": "2.10.1",
                           "from": "boom@>=2.0.0 <3.0.0",
@@ -2941,6 +2951,11 @@
                           "version": "2.0.5",
                           "from": "cryptiles@>=2.0.0 <3.0.0",
                           "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
+                        },
+                        "hoek": {
+                          "version": "2.16.3",
+                          "from": "hoek@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
                         },
                         "sntp": {
                           "version": "1.0.9",
@@ -3003,6 +3018,16 @@
                                 }
                               }
                             },
+                            "ecc-jsbn": {
+                              "version": "0.1.1",
+                              "from": "ecc-jsbn@>=0.0.1 <1.0.0",
+                              "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
+                            },
+                            "jodid25519": {
+                              "version": "1.0.2",
+                              "from": "jodid25519@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
+                            },
                             "jsbn": {
                               "version": "0.1.0",
                               "from": "jsbn@>=0.1.0 <0.2.0",
@@ -3012,16 +3037,6 @@
                               "version": "0.14.1",
                               "from": "tweetnacl@>=0.13.0 <1.0.0",
                               "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.1.tgz"
-                            },
-                            "jodid25519": {
-                              "version": "1.0.2",
-                              "from": "jodid25519@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
-                            },
-                            "ecc-jsbn": {
-                              "version": "0.1.1",
-                              "from": "ecc-jsbn@>=0.0.1 <1.0.0",
-                              "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
                             }
                           }
                         }
@@ -3154,11 +3169,6 @@
                           "from": "glob@>=4.3.1 <5.0.0",
                           "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz"
                         },
-                        "ordered-read-streams": {
-                          "version": "0.1.0",
-                          "from": "ordered-read-streams@>=0.1.0 <0.2.0",
-                          "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz"
-                        },
                         "glob2base": {
                           "version": "0.0.12",
                           "from": "glob2base@>=0.0.12 <0.0.13",
@@ -3170,6 +3180,11 @@
                               "resolved": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz"
                             }
                           }
+                        },
+                        "ordered-read-streams": {
+                          "version": "0.1.0",
+                          "from": "ordered-read-streams@>=0.1.0 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz"
                         },
                         "unique-stream": {
                           "version": "1.0.0",
@@ -3193,11 +3208,6 @@
                               "from": "globule@>=0.1.0 <0.2.0",
                               "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
                               "dependencies": {
-                                "lodash": {
-                                  "version": "1.0.2",
-                                  "from": "lodash@>=1.0.1 <1.1.0",
-                                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz"
-                                },
                                 "glob": {
                                   "version": "3.1.21",
                                   "from": "glob@>=3.1.21 <3.2.0",
@@ -3214,6 +3224,11 @@
                                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz"
                                     }
                                   }
+                                },
+                                "lodash": {
+                                  "version": "1.0.2",
+                                  "from": "lodash@>=1.0.1 <1.1.0",
+                                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz"
                                 },
                                 "minimatch": {
                                   "version": "0.2.14",
@@ -3454,25 +3469,25 @@
                   "from": "rc@>=0.5.1 <0.6.0",
                   "resolved": "https://registry.npmjs.org/rc/-/rc-0.5.5.tgz",
                   "dependencies": {
-                    "minimist": {
-                      "version": "0.0.10",
-                      "from": "minimist@>=0.0.7 <0.1.0",
-                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
-                    },
                     "deep-extend": {
                       "version": "0.2.11",
                       "from": "deep-extend@>=0.2.5 <0.3.0",
                       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz"
                     },
-                    "strip-json-comments": {
-                      "version": "0.1.3",
-                      "from": "strip-json-comments@>=0.1.0 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz"
-                    },
                     "ini": {
                       "version": "1.3.4",
                       "from": "ini@>=1.3.0 <1.4.0",
                       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
+                    },
+                    "minimist": {
+                      "version": "0.0.10",
+                      "from": "minimist@>=0.0.7 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                    },
+                    "strip-json-comments": {
+                      "version": "0.1.3",
+                      "from": "strip-json-comments@>=0.1.0 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz"
                     }
                   }
                 }
@@ -3537,574 +3552,6 @@
       "version": "0.1.2",
       "from": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-0.1.2.tgz",
       "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-0.1.2.tgz"
-    },
-    "fsevents": {
-      "version": "1.0.5",
-      "from": "https://registry.npmjs.org/fsevents/-/fsevents-1.0.5.tgz",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.0.5.tgz",
-      "dependencies": {
-        "node-pre-gyp": {
-          "version": "0.6.15",
-          "from": "node-pre-gyp@latest",
-          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.15.tgz",
-          "dependencies": {
-            "nopt": {
-              "version": "3.0.4",
-              "from": "nopt@>=3.0.1 <3.1.0",
-              "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.4.tgz"
-            }
-          }
-        },
-        "abbrev": {
-          "version": "1.0.7",
-          "from": "abbrev@1",
-          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
-        },
-        "ansi": {
-          "version": "0.3.0",
-          "from": "ansi@~0.3.0",
-          "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.0.tgz"
-        },
-        "ansi-regex": {
-          "version": "2.0.0",
-          "from": "ansi-regex@^2.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-        },
-        "ansi-styles": {
-          "version": "2.1.0",
-          "from": "ansi-styles@^2.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
-        },
-        "are-we-there-yet": {
-          "version": "1.0.4",
-          "from": "are-we-there-yet@~1.0.0",
-          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.4.tgz"
-        },
-        "asn1": {
-          "version": "0.1.11",
-          "from": "asn1@0.1.11",
-          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
-        },
-        "assert-plus": {
-          "version": "0.1.5",
-          "from": "assert-plus@^0.1.5",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
-        },
-        "async": {
-          "version": "1.5.0",
-          "from": "async@^1.4.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.0.tgz"
-        },
-        "aws-sign2": {
-          "version": "0.6.0",
-          "from": "aws-sign2@~0.6.0",
-          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
-        },
-        "balanced-match": {
-          "version": "0.2.1",
-          "from": "balanced-match@>=0.2.0 <0.3.0",
-          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.1.tgz"
-        },
-        "boom": {
-          "version": "2.10.1",
-          "from": "boom@^2.8.x",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
-        },
-        "block-stream": {
-          "version": "0.0.8",
-          "from": "block-stream@*",
-          "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.8.tgz"
-        },
-        "brace-expansion": {
-          "version": "1.1.1",
-          "from": "brace-expansion@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz"
-        },
-        "caseless": {
-          "version": "0.11.0",
-          "from": "caseless@~0.11.0",
-          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
-        },
-        "chalk": {
-          "version": "1.1.1",
-          "from": "chalk@^1.1.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz"
-        },
-        "combined-stream": {
-          "version": "1.0.5",
-          "from": "combined-stream@~1.0.5",
-          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
-        },
-        "commander": {
-          "version": "2.9.0",
-          "from": "commander@^2.8.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz"
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "from": "concat-map@0.0.1",
-          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-        },
-        "core-util-is": {
-          "version": "1.0.1",
-          "from": "core-util-is@~1.0.0",
-          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-        },
-        "cryptiles": {
-          "version": "2.0.5",
-          "from": "cryptiles@2.x.x",
-          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
-        },
-        "ctype": {
-          "version": "0.5.3",
-          "from": "ctype@0.5.3",
-          "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
-        },
-        "delayed-stream": {
-          "version": "1.0.0",
-          "from": "delayed-stream@~1.0.0",
-          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
-        },
-        "deep-extend": {
-          "version": "0.2.11",
-          "from": "deep-extend@~0.2.5",
-          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz"
-        },
-        "delegates": {
-          "version": "0.1.0",
-          "from": "delegates@^0.1.0",
-          "resolved": "https://registry.npmjs.org/delegates/-/delegates-0.1.0.tgz"
-        },
-        "debug": {
-          "version": "0.7.4",
-          "from": "debug@~0.7.2",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
-        },
-        "escape-string-regexp": {
-          "version": "1.0.3",
-          "from": "escape-string-regexp@^1.0.2",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
-        },
-        "extend": {
-          "version": "3.0.0",
-          "from": "extend@~3.0.0",
-          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
-        },
-        "forever-agent": {
-          "version": "0.6.1",
-          "from": "forever-agent@~0.6.1",
-          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
-        },
-        "form-data": {
-          "version": "1.0.0-rc3",
-          "from": "form-data@~1.0.0-rc3",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz"
-        },
-        "fstream": {
-          "version": "1.0.8",
-          "from": "fstream@^1.0.2",
-          "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.8.tgz"
-        },
-        "gauge": {
-          "version": "1.2.2",
-          "from": "gauge@~1.2.0",
-          "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.2.tgz"
-        },
-        "generate-object-property": {
-          "version": "1.2.0",
-          "from": "generate-object-property@^1.1.0",
-          "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz"
-        },
-        "graceful-fs": {
-          "version": "4.1.2",
-          "from": "graceful-fs@4.1",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
-        },
-        "generate-function": {
-          "version": "2.0.0",
-          "from": "generate-function@^2.0.0",
-          "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
-        },
-        "graceful-readlink": {
-          "version": "1.0.1",
-          "from": "graceful-readlink@>= 1.0.0",
-          "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
-        },
-        "har-validator": {
-          "version": "2.0.2",
-          "from": "har-validator@~2.0.2",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.2.tgz"
-        },
-        "has-ansi": {
-          "version": "2.0.0",
-          "from": "has-ansi@^2.0.0",
-          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
-        },
-        "has-unicode": {
-          "version": "1.0.1",
-          "from": "has-unicode@^1.0.0",
-          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-1.0.1.tgz"
-        },
-        "hoek": {
-          "version": "2.16.3",
-          "from": "hoek@2.x.x",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
-        },
-        "hawk": {
-          "version": "3.1.0",
-          "from": "hawk@~3.1.0",
-          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.0.tgz"
-        },
-        "http-signature": {
-          "version": "0.11.0",
-          "from": "http-signature@~0.11.0",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz"
-        },
-        "inherits": {
-          "version": "2.0.1",
-          "from": "inherits@*",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-        },
-        "ini": {
-          "version": "1.3.4",
-          "from": "ini@~1.3.0",
-          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
-        },
-        "is-my-json-valid": {
-          "version": "2.12.2",
-          "from": "is-my-json-valid@^2.12.2",
-          "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.2.tgz"
-        },
-        "is-property": {
-          "version": "1.0.2",
-          "from": "is-property@^1.0.0",
-          "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
-        },
-        "isarray": {
-          "version": "0.0.1",
-          "from": "isarray@0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-        },
-        "isstream": {
-          "version": "0.1.2",
-          "from": "isstream@~0.1.2",
-          "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
-        },
-        "json-stringify-safe": {
-          "version": "5.0.1",
-          "from": "json-stringify-safe@~5.0.1",
-          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
-        },
-        "jsonpointer": {
-          "version": "2.0.0",
-          "from": "jsonpointer@2.0.0",
-          "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
-        },
-        "lodash._basetostring": {
-          "version": "3.0.1",
-          "from": "lodash._basetostring@^3.0.0",
-          "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
-        },
-        "lodash._createpadding": {
-          "version": "3.6.1",
-          "from": "lodash._createpadding@^3.0.0",
-          "resolved": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz"
-        },
-        "lodash.pad": {
-          "version": "3.1.1",
-          "from": "lodash.pad@^3.0.0",
-          "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-3.1.1.tgz"
-        },
-        "lodash.padleft": {
-          "version": "3.1.1",
-          "from": "lodash.padleft@^3.0.0",
-          "resolved": "https://registry.npmjs.org/lodash.padleft/-/lodash.padleft-3.1.1.tgz"
-        },
-        "lodash.padright": {
-          "version": "3.1.1",
-          "from": "lodash.padright@^3.0.0",
-          "resolved": "https://registry.npmjs.org/lodash.padright/-/lodash.padright-3.1.1.tgz"
-        },
-        "lodash.repeat": {
-          "version": "3.0.1",
-          "from": "lodash.repeat@^3.0.0",
-          "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.0.1.tgz"
-        },
-        "mime-db": {
-          "version": "1.19.0",
-          "from": "mime-db@~1.19.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.19.0.tgz"
-        },
-        "mime-types": {
-          "version": "2.1.7",
-          "from": "mime-types@~2.1.7",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.7.tgz"
-        },
-        "minimist": {
-          "version": "0.0.8",
-          "from": "minimist@0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "from": "mkdirp@>=0.3.0 <0.4.0||>=0.4.0 <0.5.0||>=0.5.0 <0.6.0",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
-        },
-        "node-uuid": {
-          "version": "1.4.3",
-          "from": "node-uuid@~1.4.3",
-          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
-        },
-        "npmlog": {
-          "version": "1.2.1",
-          "from": "npmlog@~1.2.0",
-          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-1.2.1.tgz"
-        },
-        "oauth-sign": {
-          "version": "0.8.0",
-          "from": "oauth-sign@~0.8.0",
-          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz"
-        },
-        "once": {
-          "version": "1.1.1",
-          "from": "once@~1.1.1",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.1.1.tgz"
-        },
-        "path-is-absolute": {
-          "version": "1.0.0",
-          "from": "path-is-absolute@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
-        },
-        "pinkie": {
-          "version": "1.0.0",
-          "from": "pinkie@^1.0.0",
-          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz"
-        },
-        "pinkie-promise": {
-          "version": "1.0.0",
-          "from": "pinkie-promise@^1.0.0",
-          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz"
-        },
-        "qs": {
-          "version": "5.2.0",
-          "from": "qs@~5.2.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz"
-        },
-        "request": {
-          "version": "2.65.0",
-          "from": "request@2.x",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.65.0.tgz"
-        },
-        "readable-stream": {
-          "version": "1.1.13",
-          "from": "readable-stream@^1.1.13",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz"
-        },
-        "semver": {
-          "version": "5.0.3",
-          "from": "semver@~5.0.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz"
-        },
-        "sntp": {
-          "version": "1.0.9",
-          "from": "sntp@1.x.x",
-          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "from": "string_decoder@~0.10.x",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-        },
-        "stringstream": {
-          "version": "0.0.5",
-          "from": "stringstream@~0.0.4",
-          "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
-        },
-        "strip-ansi": {
-          "version": "3.0.0",
-          "from": "strip-ansi@^3.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz"
-        },
-        "strip-json-comments": {
-          "version": "0.1.3",
-          "from": "strip-json-comments@0.1.x",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz"
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "from": "supports-color@^2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-        },
-        "tar": {
-          "version": "2.2.1",
-          "from": "tar@~2.2.0",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz"
-        },
-        "tough-cookie": {
-          "version": "2.2.0",
-          "from": "tough-cookie@~2.2.0",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.0.tgz"
-        },
-        "tunnel-agent": {
-          "version": "0.4.1",
-          "from": "tunnel-agent@~0.4.1",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
-        },
-        "uid-number": {
-          "version": "0.0.3",
-          "from": "uid-number@0.0.3",
-          "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.3.tgz"
-        },
-        "wrappy": {
-          "version": "1.0.1",
-          "from": "wrappy@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-        },
-        "xtend": {
-          "version": "4.0.1",
-          "from": "xtend@^4.0.0",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-        },
-        "fstream-ignore": {
-          "version": "1.0.3",
-          "from": "fstream-ignore@~1.0.3",
-          "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.3.tgz",
-          "dependencies": {
-            "minimatch": {
-              "version": "3.0.0",
-              "from": "minimatch@>=3.0.0 <4.0.0"
-            }
-          }
-        },
-        "inflight": {
-          "version": "1.0.4",
-          "from": "inflight@>=1.0.4 <2.0.0",
-          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-          "dependencies": {
-            "once": {
-              "version": "1.3.2",
-              "from": "once@>=1.3.0 <2.0.0"
-            }
-          }
-        },
-        "rc": {
-          "version": "1.1.2",
-          "from": "rc@~1.1.0",
-          "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.2.tgz",
-          "dependencies": {
-            "minimist": {
-              "version": "1.2.0",
-              "from": "minimist@^1.1.2",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
-            }
-          }
-        },
-        "rimraf": {
-          "version": "2.4.3",
-          "from": "rimraf@~2.4.0",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.3.tgz",
-          "dependencies": {
-            "glob": {
-              "version": "5.0.15",
-              "from": "glob@>=5.0.14 <6.0.0",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz"
-            },
-            "minimatch": {
-              "version": "3.0.0",
-              "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz"
-            },
-            "once": {
-              "version": "1.3.2",
-              "from": "once@>=1.3.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz"
-            }
-          }
-        },
-        "bl": {
-          "version": "1.0.0",
-          "from": "bl@~1.0.0",
-          "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz",
-          "dependencies": {
-            "readable-stream": {
-              "version": "2.0.4",
-              "from": "readable-stream@~2.0.0",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.4.tgz",
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.1",
-                  "from": "core-util-is@~1.0.0",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@~2.0.1",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                },
-                "isarray": {
-                  "version": "0.0.1",
-                  "from": "isarray@0.0.1",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                },
-                "process-nextick-args": {
-                  "version": "1.0.3",
-                  "from": "process-nextick-args@~1.0.0",
-                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz"
-                },
-                "string_decoder": {
-                  "version": "0.10.31",
-                  "from": "string_decoder@~0.10.x",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                },
-                "util-deprecate": {
-                  "version": "1.0.2",
-                  "from": "util-deprecate@~1.0.1",
-                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-                }
-              }
-            }
-          }
-        },
-        "tar-pack": {
-          "version": "3.1.0",
-          "from": "tar-pack@~3.1.0",
-          "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.1.0.tgz",
-          "dependencies": {
-            "readable-stream": {
-              "version": "1.0.33",
-              "from": "readable-stream@~1.0.2",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.1",
-                  "from": "core-util-is@~1.0.0",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@~2.0.1",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                },
-                "isarray": {
-                  "version": "0.0.1",
-                  "from": "isarray@0.0.1",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                },
-                "string_decoder": {
-                  "version": "0.10.31",
-                  "from": "string_decoder@~0.10.x",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                }
-              }
-            },
-            "rimraf": {
-              "version": "2.2.8",
-              "from": "rimraf@~2.2.0",
-              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
-            }
-          }
-        }
-      }
     },
     "get-stdin": {
       "version": "4.0.1",
@@ -4302,7 +3749,8 @@
     },
     "jest-cli": {
       "version": "0.9.0-fb2",
-      "from": "jest-cli@next",
+      "from": "jest-cli@0.9.0-fb2",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-0.9.0-fb2.tgz",
       "dependencies": {
         "cover": {
           "version": "0.2.9",
@@ -4368,50 +3816,50 @@
               "from": "escodegen@>=1.7.0 <1.8.0",
               "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.7.1.tgz",
               "dependencies": {
-                "estraverse": {
-                  "version": "1.9.3",
-                  "from": "estraverse@>=1.9.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz"
-                },
                 "esprima": {
                   "version": "1.2.5",
                   "from": "esprima@>=1.2.2 <2.0.0",
                   "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz"
+                },
+                "estraverse": {
+                  "version": "1.9.3",
+                  "from": "estraverse@>=1.9.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz"
                 },
                 "optionator": {
                   "version": "0.5.0",
                   "from": "optionator@>=0.5.0 <0.6.0",
                   "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
                   "dependencies": {
-                    "prelude-ls": {
-                      "version": "1.1.2",
-                      "from": "prelude-ls@>=1.1.1 <1.2.0",
-                      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
-                    },
                     "deep-is": {
                       "version": "0.1.3",
                       "from": "deep-is@>=0.1.3 <0.2.0",
                       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
                     },
-                    "wordwrap": {
-                      "version": "0.0.3",
-                      "from": "wordwrap@>=0.0.2 <0.1.0",
-                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
-                    },
-                    "type-check": {
-                      "version": "0.3.2",
-                      "from": "type-check@>=0.3.1 <0.4.0",
-                      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz"
+                    "fast-levenshtein": {
+                      "version": "1.0.7",
+                      "from": "fast-levenshtein@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz"
                     },
                     "levn": {
                       "version": "0.2.5",
                       "from": "levn@>=0.2.5 <0.3.0",
                       "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz"
                     },
-                    "fast-levenshtein": {
-                      "version": "1.0.7",
-                      "from": "fast-levenshtein@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz"
+                    "prelude-ls": {
+                      "version": "1.1.2",
+                      "from": "prelude-ls@>=1.1.1 <1.2.0",
+                      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
+                    },
+                    "type-check": {
+                      "version": "0.3.2",
+                      "from": "type-check@>=0.3.1 <0.4.0",
+                      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz"
+                    },
+                    "wordwrap": {
+                      "version": "0.0.3",
+                      "from": "wordwrap@>=0.0.2 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
                     }
                   }
                 },
@@ -4422,7 +3870,8 @@
                   "dependencies": {
                     "amdefine": {
                       "version": "1.0.0",
-                      "from": "amdefine@>=0.0.4"
+                      "from": "amdefine@1.0.0",
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
                     }
                   }
                 }
@@ -4552,45 +4001,45 @@
               "from": "escodegen@>=1.6.1 <2.0.0",
               "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.0.tgz",
               "dependencies": {
-                "estraverse": {
-                  "version": "1.9.3",
-                  "from": "estraverse@>=1.9.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz"
-                },
                 "esprima": {
                   "version": "2.7.2",
                   "from": "esprima@>=2.7.1 <3.0.0",
                   "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz"
+                },
+                "estraverse": {
+                  "version": "1.9.3",
+                  "from": "estraverse@>=1.9.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz"
                 },
                 "optionator": {
                   "version": "0.8.1",
                   "from": "optionator@>=0.8.1 <0.9.0",
                   "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.1.tgz",
                   "dependencies": {
-                    "prelude-ls": {
-                      "version": "1.1.2",
-                      "from": "prelude-ls@>=1.1.1 <1.2.0",
-                      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
-                    },
                     "deep-is": {
                       "version": "0.1.3",
                       "from": "deep-is@>=0.1.3 <0.2.0",
                       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
                     },
-                    "type-check": {
-                      "version": "0.3.2",
-                      "from": "type-check@>=0.3.1 <0.4.0",
-                      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz"
+                    "fast-levenshtein": {
+                      "version": "1.1.3",
+                      "from": "fast-levenshtein@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.1.3.tgz"
                     },
                     "levn": {
                       "version": "0.3.0",
                       "from": "levn@>=0.3.0 <0.4.0",
                       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz"
                     },
-                    "fast-levenshtein": {
-                      "version": "1.1.3",
-                      "from": "fast-levenshtein@>=1.1.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.1.3.tgz"
+                    "prelude-ls": {
+                      "version": "1.1.2",
+                      "from": "prelude-ls@>=1.1.1 <1.2.0",
+                      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
+                    },
+                    "type-check": {
+                      "version": "0.3.2",
+                      "from": "type-check@>=0.3.1 <0.4.0",
+                      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz"
                     }
                   }
                 },
@@ -4744,11 +4193,6 @@
                   "from": "hawk@>=3.1.0 <3.2.0",
                   "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
                   "dependencies": {
-                    "hoek": {
-                      "version": "2.16.3",
-                      "from": "hoek@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
-                    },
                     "boom": {
                       "version": "2.10.1",
                       "from": "boom@>=2.0.0 <3.0.0",
@@ -4758,6 +4202,11 @@
                       "version": "2.0.5",
                       "from": "cryptiles@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
+                    },
+                    "hoek": {
+                      "version": "2.16.3",
+                      "from": "hoek@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
                     },
                     "sntp": {
                       "version": "1.0.9",
@@ -4820,6 +4269,16 @@
                             }
                           }
                         },
+                        "ecc-jsbn": {
+                          "version": "0.1.1",
+                          "from": "ecc-jsbn@>=0.0.1 <1.0.0",
+                          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
+                        },
+                        "jodid25519": {
+                          "version": "1.0.2",
+                          "from": "jodid25519@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
+                        },
                         "jsbn": {
                           "version": "0.1.0",
                           "from": "jsbn@>=0.1.0 <0.2.0",
@@ -4829,16 +4288,6 @@
                           "version": "0.13.3",
                           "from": "tweetnacl@>=0.13.0 <1.0.0",
                           "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz"
-                        },
-                        "jodid25519": {
-                          "version": "1.0.2",
-                          "from": "jodid25519@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
-                        },
-                        "ecc-jsbn": {
-                          "version": "0.1.1",
-                          "from": "ecc-jsbn@>=0.0.1 <1.0.0",
-                          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
                         }
                       }
                     }
@@ -4939,7 +4388,8 @@
         },
         "node-haste": {
           "version": "2.2.0",
-          "from": "node-haste@>=2.2.0 <3.0.0",
+          "from": "node-haste@2.2.0",
+          "resolved": "https://registry.npmjs.org/node-haste/-/node-haste-2.2.0.tgz",
           "dependencies": {
             "sane": {
               "version": "1.3.1",
@@ -5049,11 +4499,6 @@
           "from": "https://registry.npmjs.org/hoek/-/hoek-2.14.0.tgz",
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.14.0.tgz"
         },
-        "topo": {
-          "version": "1.0.3",
-          "from": "https://registry.npmjs.org/topo/-/topo-1.0.3.tgz",
-          "resolved": "https://registry.npmjs.org/topo/-/topo-1.0.3.tgz"
-        },
         "isemail": {
           "version": "1.1.1",
           "from": "https://registry.npmjs.org/isemail/-/isemail-1.1.1.tgz",
@@ -5063,6 +4508,11 @@
           "version": "2.10.6",
           "from": "https://registry.npmjs.org/moment/-/moment-2.10.6.tgz",
           "resolved": "https://registry.npmjs.org/moment/-/moment-2.10.6.tgz"
+        },
+        "topo": {
+          "version": "1.0.3",
+          "from": "https://registry.npmjs.org/topo/-/topo-1.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/topo/-/topo-1.0.3.tgz"
         }
       }
     },
@@ -5106,37 +4556,10 @@
           "from": "https://registry.npmjs.org/commoner/-/commoner-0.10.3.tgz",
           "resolved": "https://registry.npmjs.org/commoner/-/commoner-0.10.3.tgz",
           "dependencies": {
-            "q": {
-              "version": "1.1.2",
-              "from": "https://registry.npmjs.org/q/-/q-1.1.2.tgz",
-              "resolved": "https://registry.npmjs.org/q/-/q-1.1.2.tgz"
-            },
-            "recast": {
-              "version": "0.10.32",
-              "from": "https://registry.npmjs.org/recast/-/recast-0.10.32.tgz",
-              "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.32.tgz",
-              "dependencies": {
-                "esprima-fb": {
-                  "version": "15001.1001.0-dev-harmony-fb",
-                  "from": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz",
-                  "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz"
-                },
-                "ast-types": {
-                  "version": "0.8.11",
-                  "from": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.11.tgz",
-                  "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.11.tgz"
-                }
-              }
-            },
             "commander": {
               "version": "2.5.1",
               "from": "https://registry.npmjs.org/commander/-/commander-2.5.1.tgz",
               "resolved": "https://registry.npmjs.org/commander/-/commander-2.5.1.tgz"
-            },
-            "graceful-fs": {
-              "version": "3.0.8",
-              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
             },
             "glob": {
               "version": "4.2.2",
@@ -5162,15 +4585,42 @@
                 }
               }
             },
-            "install": {
-              "version": "0.1.8",
-              "from": "https://registry.npmjs.org/install/-/install-0.1.8.tgz",
-              "resolved": "https://registry.npmjs.org/install/-/install-0.1.8.tgz"
+            "graceful-fs": {
+              "version": "3.0.8",
+              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
             },
             "iconv-lite": {
               "version": "0.4.11",
               "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.11.tgz",
               "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.11.tgz"
+            },
+            "install": {
+              "version": "0.1.8",
+              "from": "https://registry.npmjs.org/install/-/install-0.1.8.tgz",
+              "resolved": "https://registry.npmjs.org/install/-/install-0.1.8.tgz"
+            },
+            "q": {
+              "version": "1.1.2",
+              "from": "https://registry.npmjs.org/q/-/q-1.1.2.tgz",
+              "resolved": "https://registry.npmjs.org/q/-/q-1.1.2.tgz"
+            },
+            "recast": {
+              "version": "0.10.32",
+              "from": "https://registry.npmjs.org/recast/-/recast-0.10.32.tgz",
+              "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.32.tgz",
+              "dependencies": {
+                "ast-types": {
+                  "version": "0.8.11",
+                  "from": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.11.tgz",
+                  "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.11.tgz"
+                },
+                "esprima-fb": {
+                  "version": "15001.1001.0-dev-harmony-fb",
+                  "from": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz",
+                  "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz"
+                }
+              }
             }
           }
         },
@@ -5371,6 +4821,16 @@
       "from": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.0.0.tgz"
     },
+    "lru-cache": {
+      "version": "2.7.3",
+      "from": "lru-cache@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
+    },
+    "makeerror": {
+      "version": "1.0.11",
+      "from": "makeerror@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz"
+    },
     "map-obj": {
       "version": "1.0.1",
       "from": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
@@ -5380,6 +4840,11 @@
       "version": "3.5.0",
       "from": "https://registry.npmjs.org/meow/-/meow-3.5.0.tgz",
       "resolved": "https://registry.npmjs.org/meow/-/meow-3.5.0.tgz"
+    },
+    "merge": {
+      "version": "1.2.0",
+      "from": "merge@>=1.1.3 <2.0.0",
+      "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz"
     },
     "micromatch": {
       "version": "2.3.0",
@@ -5413,18 +4878,6 @@
       "from": "https://registry.npmjs.org/module-deps/-/module-deps-3.9.1.tgz",
       "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-3.9.1.tgz",
       "dependencies": {
-        "JSONStream": {
-          "version": "1.0.4",
-          "from": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.4.tgz",
-          "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.4.tgz",
-          "dependencies": {
-            "jsonparse": {
-              "version": "1.0.0",
-              "from": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.0.0.tgz"
-            }
-          }
-        },
         "browser-resolve": {
           "version": "1.9.1",
           "from": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.9.1.tgz",
@@ -5452,6 +4905,11 @@
               "from": "https://registry.npmjs.org/escodegen/-/escodegen-1.6.1.tgz",
               "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.6.1.tgz",
               "dependencies": {
+                "esprima": {
+                  "version": "1.2.5",
+                  "from": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz",
+                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz"
+                },
                 "estraverse": {
                   "version": "1.9.3",
                   "from": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
@@ -5462,45 +4920,40 @@
                   "from": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz",
                   "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz"
                 },
-                "esprima": {
-                  "version": "1.2.5",
-                  "from": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz",
-                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz"
-                },
                 "optionator": {
                   "version": "0.5.0",
                   "from": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
                   "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
                   "dependencies": {
-                    "prelude-ls": {
-                      "version": "1.1.2",
-                      "from": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-                      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
-                    },
                     "deep-is": {
                       "version": "0.1.3",
                       "from": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
                       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
                     },
-                    "wordwrap": {
-                      "version": "0.0.3",
-                      "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
-                    },
-                    "type-check": {
-                      "version": "0.3.1",
-                      "from": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz",
-                      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz"
+                    "fast-levenshtein": {
+                      "version": "1.0.7",
+                      "from": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz",
+                      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz"
                     },
                     "levn": {
                       "version": "0.2.5",
                       "from": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz",
                       "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz"
                     },
-                    "fast-levenshtein": {
-                      "version": "1.0.7",
-                      "from": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz",
-                      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz"
+                    "prelude-ls": {
+                      "version": "1.1.2",
+                      "from": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+                      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
+                    },
+                    "type-check": {
+                      "version": "0.3.1",
+                      "from": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz",
+                      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz"
+                    },
+                    "wordwrap": {
+                      "version": "0.0.3",
+                      "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
                     }
                   }
                 },
@@ -5510,6 +4963,18 @@
                   "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz"
                 }
               }
+            }
+          }
+        },
+        "JSONStream": {
+          "version": "1.0.4",
+          "from": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.4.tgz",
+          "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.4.tgz",
+          "dependencies": {
+            "jsonparse": {
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.0.0.tgz"
             }
           }
         },
@@ -5581,11 +5046,6 @@
       "from": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
       "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz"
     },
-    "nan": {
-      "version": "2.1.0",
-      "from": "https://registry.npmjs.org/nan/-/nan-2.1.0.tgz",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.1.0.tgz"
-    },
     "node-fetch": {
       "version": "1.3.3",
       "from": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.3.3.tgz",
@@ -5599,84 +5059,24 @@
       }
     },
     "node-haste": {
-      "version": "2.4.0",
-      "from": "node-haste@2.4.0",
-      "resolved": "https://registry.npmjs.org/node-haste/-/node-haste-2.4.0.tgz",
+      "version": "2.7.0",
+      "from": "node-haste@2.7.0",
+      "resolved": "https://registry.npmjs.org/node-haste/-/node-haste-2.7.0.tgz",
       "dependencies": {
         "graceful-fs": {
           "version": "4.1.3",
           "from": "graceful-fs@>=4.1.3 <5.0.0",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
         },
+        "minimatch": {
+          "version": "0.2.14",
+          "from": "minimatch@>=0.2.14 <0.3.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz"
+        },
         "sane": {
           "version": "1.3.3",
           "from": "sane@>=1.3.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/sane/-/sane-1.3.3.tgz",
-          "dependencies": {
-            "exec-sh": {
-              "version": "0.2.0",
-              "from": "exec-sh@>=0.2.0 <0.3.0",
-              "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.0.tgz",
-              "dependencies": {
-                "merge": {
-                  "version": "1.2.0",
-                  "from": "merge@>=1.1.3 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz"
-                }
-              }
-            },
-            "fb-watchman": {
-              "version": "1.9.0",
-              "from": "fb-watchman@>=1.8.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-1.9.0.tgz"
-            },
-            "minimatch": {
-              "version": "0.2.14",
-              "from": "minimatch@>=0.2.14 <0.3.0",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-              "dependencies": {
-                "lru-cache": {
-                  "version": "2.7.3",
-                  "from": "lru-cache@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
-                },
-                "sigmund": {
-                  "version": "1.0.1",
-                  "from": "sigmund@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
-                }
-              }
-            },
-            "walker": {
-              "version": "1.0.7",
-              "from": "walker@>=1.0.5 <1.1.0",
-              "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
-              "dependencies": {
-                "makeerror": {
-                  "version": "1.0.11",
-                  "from": "makeerror@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
-                  "dependencies": {
-                    "tmpl": {
-                      "version": "1.0.4",
-                      "from": "tmpl@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "watch": {
-              "version": "0.10.0",
-              "from": "watch@>=0.10.0 <0.11.0",
-              "resolved": "https://registry.npmjs.org/watch/-/watch-0.10.0.tgz"
-            }
-          }
-        },
-        "throat": {
-          "version": "2.0.2",
-          "from": "throat@>=2.0.2 <3.0.0",
-          "resolved": "https://registry.npmjs.org/throat/-/throat-2.0.2.tgz"
+          "resolved": "https://registry.npmjs.org/sane/-/sane-1.3.3.tgz"
         }
       }
     },
@@ -5727,15 +5127,15 @@
       "from": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "dependencies": {
-        "wordwrap": {
-          "version": "0.0.3",
-          "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
-        },
         "minimist": {
           "version": "0.0.10",
           "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+        },
+        "wordwrap": {
+          "version": "0.0.3",
+          "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
         }
       }
     },
@@ -5981,15 +5381,15 @@
       "from": "https://registry.npmjs.org/recast/-/recast-0.10.37.tgz",
       "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.37.tgz",
       "dependencies": {
-        "source-map": {
-          "version": "0.5.3",
-          "from": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
-        },
         "ast-types": {
           "version": "0.8.12",
           "from": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.12.tgz",
           "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.12.tgz"
+        },
+        "source-map": {
+          "version": "0.5.3",
+          "from": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
         }
       }
     },
@@ -6013,20 +5413,10 @@
           "from": "https://registry.npmjs.org/commoner/-/commoner-0.10.3.tgz",
           "resolved": "https://registry.npmjs.org/commoner/-/commoner-0.10.3.tgz",
           "dependencies": {
-            "q": {
-              "version": "1.1.2",
-              "from": "https://registry.npmjs.org/q/-/q-1.1.2.tgz",
-              "resolved": "https://registry.npmjs.org/q/-/q-1.1.2.tgz"
-            },
             "commander": {
               "version": "2.5.1",
               "from": "https://registry.npmjs.org/commander/-/commander-2.5.1.tgz",
               "resolved": "https://registry.npmjs.org/commander/-/commander-2.5.1.tgz"
-            },
-            "graceful-fs": {
-              "version": "3.0.8",
-              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
             },
             "glob": {
               "version": "4.2.2",
@@ -6052,15 +5442,25 @@
                 }
               }
             },
-            "install": {
-              "version": "0.1.8",
-              "from": "https://registry.npmjs.org/install/-/install-0.1.8.tgz",
-              "resolved": "https://registry.npmjs.org/install/-/install-0.1.8.tgz"
+            "graceful-fs": {
+              "version": "3.0.8",
+              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
             },
             "iconv-lite": {
               "version": "0.4.11",
               "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.11.tgz",
               "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.11.tgz"
+            },
+            "install": {
+              "version": "0.1.8",
+              "from": "https://registry.npmjs.org/install/-/install-0.1.8.tgz",
+              "resolved": "https://registry.npmjs.org/install/-/install-0.1.8.tgz"
+            },
+            "q": {
+              "version": "1.1.2",
+              "from": "https://registry.npmjs.org/q/-/q-1.1.2.tgz",
+              "resolved": "https://registry.npmjs.org/q/-/q-1.1.2.tgz"
             }
           }
         },
@@ -6232,6 +5632,11 @@
       "from": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz"
     },
+    "sigmund": {
+      "version": "1.0.1",
+      "from": "sigmund@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+    },
     "simple-fmt": {
       "version": "0.1.0",
       "from": "https://registry.npmjs.org/simple-fmt/-/simple-fmt-0.1.0.tgz",
@@ -6358,6 +5763,11 @@
         }
       }
     },
+    "throat": {
+      "version": "2.0.2",
+      "from": "throat@>=2.0.2 <3.0.0",
+      "resolved": "https://registry.npmjs.org/throat/-/throat-2.0.2.tgz"
+    },
     "through": {
       "version": "2.3.8",
       "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -6367,6 +5777,11 @@
       "version": "2.0.0",
       "from": "https://registry.npmjs.org/through2/-/through2-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.0.tgz"
+    },
+    "tmpl": {
+      "version": "1.0.4",
+      "from": "tmpl@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz"
     },
     "to-fast-properties": {
       "version": "1.0.1",
@@ -6408,15 +5823,15 @@
           "from": "source-map@>=0.5.1 <0.6.0",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
         },
-        "yargs": {
-          "version": "3.10.0",
-          "from": "yargs@>=3.10.0 <3.11.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz"
-        },
         "window-size": {
           "version": "0.1.0",
           "from": "window-size@0.1.0",
           "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
+        },
+        "yargs": {
+          "version": "3.10.0",
+          "from": "yargs@>=3.10.0 <3.11.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz"
         }
       }
     },
@@ -6444,6 +5859,16 @@
       "version": "0.5.3",
       "from": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
       "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz"
+    },
+    "walker": {
+      "version": "1.0.7",
+      "from": "walker@>=1.0.5 <1.1.0",
+      "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz"
+    },
+    "watch": {
+      "version": "0.10.0",
+      "from": "watch@>=0.10.0 <0.11.0",
+      "resolved": "https://registry.npmjs.org/watch/-/watch-0.10.0.tgz"
     },
     "window-size": {
       "version": "0.1.2",
@@ -6489,16 +5914,6 @@
       "from": "https://registry.npmjs.org/ws/-/ws-0.8.0.tgz",
       "resolved": "https://registry.npmjs.org/ws/-/ws-0.8.0.tgz",
       "dependencies": {
-        "options": {
-          "version": "0.0.6",
-          "from": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
-          "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz"
-        },
-        "ultron": {
-          "version": "1.0.2",
-          "from": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
-          "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz"
-        },
         "bufferutil": {
           "version": "1.2.1",
           "from": "https://registry.npmjs.org/bufferutil/-/bufferutil-1.2.1.tgz",
@@ -6515,6 +5930,16 @@
               "resolved": "https://registry.npmjs.org/nan/-/nan-2.0.8.tgz"
             }
           }
+        },
+        "options": {
+          "version": "0.0.6",
+          "from": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
+          "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz"
+        },
+        "ultron": {
+          "version": "1.0.2",
+          "from": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz"
         },
         "utf-8-validate": {
           "version": "1.2.1",
@@ -6829,15 +6254,15 @@
                   "from": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.0.tgz",
                   "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.0.tgz",
                   "dependencies": {
-                    "typedarray": {
-                      "version": "0.0.6",
-                      "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-                      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
-                    },
                     "readable-stream": {
                       "version": "2.0.2",
                       "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz"
+                    },
+                    "typedarray": {
+                      "version": "0.0.6",
+                      "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+                      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
                     }
                   }
                 },
@@ -6885,25 +6310,25 @@
                       "from": "https://registry.npmjs.org/rc/-/rc-0.5.5.tgz",
                       "resolved": "https://registry.npmjs.org/rc/-/rc-0.5.5.tgz",
                       "dependencies": {
-                        "minimist": {
-                          "version": "0.0.10",
-                          "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
-                        },
                         "deep-extend": {
                           "version": "0.2.11",
                           "from": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz",
                           "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz"
                         },
-                        "strip-json-comments": {
-                          "version": "0.1.3",
-                          "from": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz",
-                          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz"
-                        },
                         "ini": {
                           "version": "1.3.4",
                           "from": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
                           "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
+                        },
+                        "minimist": {
+                          "version": "0.0.10",
+                          "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                        },
+                        "strip-json-comments": {
+                          "version": "0.1.3",
+                          "from": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz",
+                          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz"
                         }
                       }
                     }
@@ -6931,15 +6356,15 @@
               "from": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.0.tgz",
               "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.0.tgz",
               "dependencies": {
-                "typedarray": {
-                  "version": "0.0.6",
-                  "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-                  "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
-                },
                 "readable-stream": {
                   "version": "2.0.4",
                   "from": "readable-stream@2.0.4",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.4.tgz"
+                },
+                "typedarray": {
+                  "version": "0.0.6",
+                  "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+                  "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
                 }
               }
             },
@@ -7625,11 +7050,6 @@
                       "from": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
                       "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz"
                     },
-                    "ordered-read-streams": {
-                      "version": "0.1.0",
-                      "from": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz",
-                      "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz"
-                    },
                     "glob2base": {
                       "version": "0.0.12",
                       "from": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
@@ -7641,6 +7061,11 @@
                           "resolved": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz"
                         }
                       }
+                    },
+                    "ordered-read-streams": {
+                      "version": "0.1.0",
+                      "from": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz",
+                      "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz"
                     },
                     "unique-stream": {
                       "version": "2.2.0",
@@ -7690,11 +7115,6 @@
                           "from": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
                           "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
                           "dependencies": {
-                            "lodash": {
-                              "version": "1.0.2",
-                              "from": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
-                              "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz"
-                            },
                             "glob": {
                               "version": "3.1.21",
                               "from": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
@@ -7711,6 +7131,11 @@
                                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz"
                                 }
                               }
+                            },
+                            "lodash": {
+                              "version": "1.0.2",
+                              "from": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
+                              "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz"
                             },
                             "minimatch": {
                               "version": "0.2.14",
@@ -7948,50 +7373,50 @@
                   "from": "https://registry.npmjs.org/escodegen/-/escodegen-1.7.0.tgz",
                   "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.7.0.tgz",
                   "dependencies": {
-                    "estraverse": {
-                      "version": "1.9.3",
-                      "from": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
-                      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz"
-                    },
                     "esprima": {
                       "version": "1.2.5",
                       "from": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz",
                       "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz"
+                    },
+                    "estraverse": {
+                      "version": "1.9.3",
+                      "from": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
+                      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz"
                     },
                     "optionator": {
                       "version": "0.5.0",
                       "from": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
                       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
                       "dependencies": {
-                        "prelude-ls": {
-                          "version": "1.1.2",
-                          "from": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-                          "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
-                        },
                         "deep-is": {
                           "version": "0.1.3",
                           "from": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
                           "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
                         },
-                        "wordwrap": {
-                          "version": "0.0.3",
-                          "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-                          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
-                        },
-                        "type-check": {
-                          "version": "0.3.1",
-                          "from": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz",
-                          "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz"
+                        "fast-levenshtein": {
+                          "version": "1.0.7",
+                          "from": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz",
+                          "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz"
                         },
                         "levn": {
                           "version": "0.2.5",
                           "from": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz",
                           "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz"
                         },
-                        "fast-levenshtein": {
-                          "version": "1.0.7",
-                          "from": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz",
-                          "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz"
+                        "prelude-ls": {
+                          "version": "1.1.2",
+                          "from": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+                          "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
+                        },
+                        "type-check": {
+                          "version": "0.3.1",
+                          "from": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz",
+                          "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz"
+                        },
+                        "wordwrap": {
+                          "version": "0.0.3",
+                          "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+                          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
                         }
                       }
                     },
@@ -8031,6 +7456,11 @@
                   "from": "https://registry.npmjs.org/css-select/-/css-select-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.0.0.tgz",
                   "dependencies": {
+                    "boolbase": {
+                      "version": "1.0.0",
+                      "from": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz"
+                    },
                     "css-what": {
                       "version": "1.0.0",
                       "from": "https://registry.npmjs.org/css-what/-/css-what-1.0.0.tgz",
@@ -8048,15 +7478,22 @@
                         }
                       }
                     },
-                    "boolbase": {
-                      "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz"
-                    },
                     "nth-check": {
                       "version": "1.0.1",
                       "from": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz"
+                    }
+                  }
+                },
+                "dom-serializer": {
+                  "version": "0.1.0",
+                  "from": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+                  "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+                  "dependencies": {
+                    "domelementtype": {
+                      "version": "1.1.3",
+                      "from": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+                      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
                     }
                   }
                 },
@@ -8070,6 +7507,11 @@
                   "from": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
                   "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
                   "dependencies": {
+                    "domelementtype": {
+                      "version": "1.3.0",
+                      "from": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
+                      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
+                    },
                     "domhandler": {
                       "version": "2.3.0",
                       "from": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
@@ -8080,32 +7522,15 @@
                       "from": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
                       "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz"
                     },
-                    "domelementtype": {
-                      "version": "1.3.0",
-                      "from": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
-                      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
+                    "entities": {
+                      "version": "1.0.0",
+                      "from": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz"
                     },
                     "readable-stream": {
                       "version": "1.1.13",
                       "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz"
-                    },
-                    "entities": {
-                      "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz"
-                    }
-                  }
-                },
-                "dom-serializer": {
-                  "version": "0.1.0",
-                  "from": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
-                  "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
-                  "dependencies": {
-                    "domelementtype": {
-                      "version": "1.1.3",
-                      "from": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
-                      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
                     }
                   }
                 }
@@ -8167,15 +7592,15 @@
           "from": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-1.0.2.tgz",
           "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-1.0.2.tgz",
           "dependencies": {
-            "textextensions": {
-              "version": "1.0.1",
-              "from": "https://registry.npmjs.org/textextensions/-/textextensions-1.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/textextensions/-/textextensions-1.0.1.tgz"
-            },
             "binaryextensions": {
               "version": "1.0.0",
               "from": "https://registry.npmjs.org/binaryextensions/-/binaryextensions-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/binaryextensions/-/binaryextensions-1.0.0.tgz"
+            },
+            "textextensions": {
+              "version": "1.0.1",
+              "from": "https://registry.npmjs.org/textextensions/-/textextensions-1.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/textextensions/-/textextensions-1.0.1.tgz"
             }
           }
         },
@@ -8291,11 +7716,6 @@
               "from": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz",
               "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz"
             },
-            "util": {
-              "version": "0.10.3",
-              "from": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
-              "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz"
-            },
             "lolex": {
               "version": "1.3.2",
               "from": "https://registry.npmjs.org/lolex/-/lolex-1.3.2.tgz",
@@ -8305,6 +7725,11 @@
               "version": "1.1.2",
               "from": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz",
               "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz"
+            },
+            "util": {
+              "version": "0.10.3",
+              "from": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+              "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz"
             }
           }
         },

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "unmockedModulePathPatterns": [
       "promise",
       "source-map",
-      "fast-path",
+      "node-haste/lib/fastpath",
       "fbjs"
     ]
   },
@@ -142,7 +142,6 @@
     "connect": "^2.8.3",
     "debug": "^2.2.0",
     "event-target-shim": "^1.0.5",
-    "fast-path": "^1.1.0",
     "fbjs": "^0.7.2",
     "fbjs-scripts": "^0.4.0",
     "graceful-fs": "^4.1.2",
@@ -156,7 +155,7 @@
     "mkdirp": "^0.5.1",
     "module-deps": "^3.9.1",
     "node-fetch": "^1.3.3",
-    "node-haste": "~2.4.0",
+    "node-haste": "~2.7.0",
     "opn": "^3.0.2",
     "optimist": "^0.6.1",
     "progress": "^1.1.8",

--- a/packager/react-packager/index.js
+++ b/packager/react-packager/index.js
@@ -10,7 +10,7 @@
 
 require('../babelRegisterOnly')([/react-packager\/src/]);
 
-require('fast-path').replace();
+require('node-haste/lib/fastpath').replace();
 useGracefulFs();
 
 var debug = require('debug');


### PR DESCRIPTION
This is the last bits needed to fix Windows compatibility on master, most of the work was done in node-haste.

**Test plan**
Run npm test
Run the packager using Windows and Mac

cc @cpojer @davidaurelio 