### PR TITLE
[ReactNative][oss] Skeleton for running Android e2e or a separate packager e2e test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ script:
   elif [ "$TEST_TYPE" = e2e-objc ]
   then
 
-    travis_retry ./scripts/e2e-test.sh
+    travis_retry ./scripts/e2e-test.sh --ios
 
   else
     echo "Unknown test type: $TEST_TYPE"

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -1,8 +1,18 @@
 #!/bin/bash
 
+# The script has one required argument:
+# --packager: react-native init, make sure the packager starts
+# --ios: react-native init, start the packager and run the iOS app
+# --android: same but run the Android app
+
 # Abort the mission if any command fails
 set -e
 set -x
+
+if [ -z $1 ]; then
+  echo "Please run the script with --ios, --android or --packager"
+  exit 1
+fi
 
 SCRIPTS=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 ROOT=$(dirname $SCRIPTS)
@@ -16,7 +26,8 @@ export REACT_PACKAGER_LOG="$TEMP/server.log"
 # To make sure we actually installed the local version
 # of react-native, we will create a temp file inside the template
 # and check that it exists after `react-native init`
-MARKER=$(mktemp $ROOT/local-cli/generator-ios/templates/app/XXXXXXXX)
+MARKER_IOS=$(mktemp $ROOT/local-cli/generator-ios/templates/app/XXXXXXXX)
+MARKER_ANDROID=$(mktemp $ROOT/local-cli/generator-android/templates/src/XXXXXXXX)
 
 function cleanup {
   EXIT_CODE=$?
@@ -30,7 +41,8 @@ function cleanup {
     [ -f $REACT_PACKAGER_LOG ] && cat $REACT_PACKAGER_LOG
   fi
 
-  rm $MARKER
+  rm $MARKER_IOS
+  rm $MARKER_ANDROID
   [ $SINOPIA_PID ] && kill -9 $SINOPIA_PID
   [ $SERVER_PID ] && kill -9 $SERVER_PID
   [ -f ~/.npmrc.bak ] && mv ~/.npmrc.bak ~/.npmrc
@@ -63,14 +75,38 @@ npm publish $ROOT/react-native-cli
 
 npm install -g react-native-cli
 react-native init EndToEndTest
-cd EndToEndTest/ios
-
-# Make sure we installed local version of react-native
-ls EndToEndTest/`basename $MARKER` > /dev/null
+cd EndToEndTest
 
 npm install --g flow-bin@0.21.0
 flow --retries 10
 
-../node_modules/react-native/packager/packager.sh --nonPersistent &
-SERVER_PID=$!
-xctool -scheme EndToEndTest -sdk iphonesimulator test
+case $1 in
+"--packager"*)
+  echo "Running a basic packager test"
+  # Check the packager produces a bundle (doesn't throw an error)
+  react-native bundle --platform android --dev true --entry-file index.android.js --bundle-output android-bundle.js
+  ;;
+"--ios"*)
+  echo "Running an iOS app"
+  cd ios
+  # Make sure we installed local version of react-native
+  ls EndToEndTest/`basename $MARKER_IOS` > /dev/null
+  ../node_modules/react-native/packager/packager.sh --nonPersistent &
+  SERVER_PID=$!
+  # Start the app on the simulator
+  xctool -scheme EndToEndTest -sdk iphonesimulator test
+  ;;
+"--android"*)
+  echo "Running an Android app"
+  cd android
+  # Make sure we installed local version of react-native
+  ls `basename $MARKER_ANDROID` > /dev/null
+  ../node_modules/react-native/packager/packager.sh --nonPersistent &
+  SERVER_PID=$!
+  # TODO Start the app and check it renders "Welcome to React Native"
+  echo "The Android e2e test is not implemented yet"
+  ;;
+*)
+  echo "Please run the script with --ios, --android or --packager"
+  ;;
+esac


### PR DESCRIPTION
The e2e-test.sh currently only supports iOS. Most of the script will be identical for Android,
let's therefore reuse it. This diff adds one argument: --ios, --android or --packager.

`--packager` starts the packager and checks it produces a bundle. The idea is to run this
on CircleCI even before we implement the actual Android e2e test in order to reliably catch
breakages to package.json quickly.

We should only land this once Travis is green again.

**Test plan**

Ran:

    git checkout master   
    ./scripts/e2e-test.sh  # Error message about required argument was printed
    ./scripts/e2e-test.sh --ios       # Ran the test as before (all the way up to xctool which I don't have locally)
    ./scripts/e2e-test.sh --android   # Message was printed
    ./scripts/e2e-test.sh --packager  # The packager created the bundle, exit code was 0
    # Made the packager fails on bad JS
    ./scripts/e2e-test.sh --packager  # Exit code was 1