### PR TITLE
Explicit parent style requirements

### DIFF
--- a/Libraries/CustomComponents/ListView/ListView.js
+++ b/Libraries/CustomComponents/ListView/ListView.js
@@ -53,7 +53,8 @@ var SCROLLVIEW_REF = 'listviewscroll';
  * `ListView.DataSource`, populate it with a simple array of data blobs, and
  * instantiate a `ListView` component with that data source and a `renderRow`
  * callback which takes a blob from the data array and returns a renderable
- * component.
+ * component. The ListView will only be able to scroll if the parent's style
+ * has 'flex: '.
  *
  * Minimal example:
  *
@@ -67,10 +68,12 @@ var SCROLLVIEW_REF = 'listviewscroll';
  *
  * render: function() {
  *   return (
- *     <ListView
- *       dataSource={this.state.dataSource}
- *       renderRow={(rowData) => <Text>{rowData}</Text>}
- *     />
+ *     <View style={{flex: 1}}>
+ *       <ListView
+ *         dataSource={this.state.dataSource}
+ *         renderRow={(rowData) => <Text>{rowData}</Text>}
+ *       />
+ *     </View>
  *   );
  * },
  * ```


### PR DESCRIPTION
ListView requires the parent's style to have the flex property to scroll through the list. That is not stated explicitly and can make it difficult for new users to understand why their listview doesn't scroll. This attempts to make that explicit.

**Test plan (required)**

This is a documentation change so I don't believe testing is needed

Make sure tests pass on Circle CI.

**Code formatting**

See the simple [style guide](https://github.com/facebook/react-native/blob/master/CONTRIBUTING.md#style-guide).