### PR TITLE
Fix multiple rendering of same route

### DIFF
--- a/Libraries/CustomComponents/Navigator/Navigator.js
+++ b/Libraries/CustomComponents/Navigator/Navigator.js
@@ -1097,17 +1097,16 @@ var Navigator = React.createClass({
 
   render: function() {
     var newRenderedSceneMap = new Map();
-    var scenes = this.state.routeStack.map((route, index) => {
+    var scenes = this.state.routeStack.map(((route, index) => {
       var renderedScene;
-      if (this._renderedSceneMap.has(route) &&
-          index !== this.state.presentedIndex) {
+      if (this._renderedSceneMap.has(route)) {
         renderedScene = this._renderedSceneMap.get(route);
       } else {
         renderedScene = this._renderScene(route, index);
       }
       newRenderedSceneMap.set(route, renderedScene);
       return renderedScene;
-    });
+    }).bind(this));
     this._renderedSceneMap = newRenderedSceneMap;
     return (
       <View style={[styles.container, this.props.style]}>


### PR DESCRIPTION
**Motivation**

my renderScene method is called several times on one navigator.push call. Once with old route and once with new one.

**Problem**

 When I was investigating issue I found that in one anonymous function "this" is undefined, so I call .bind(this) on this function. As far as I am able to understand this piece of code, it should not depend on condition:
index !== this.state.presentedIndex
with this condition in place it renders scene I am transitioning FROM, even if it is rendered in this._renderedSceneMap