### PR TITLE
[ReactNative][oss] Run an e2e packager test on CircleCI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -66,6 +66,9 @@ test:
     - ./gradlew :ReactAndroid:connectedAndroidTest -PdisablePreDex --stacktrace --info:
         timeout: 360
 
+    # Publish to Sinopia, create a new app using 'react-native init' and check the packager starts
+    - ./scripts/e2e-test.sh --packager
+
     # testing docs generation is not broken
     - cd website && node ./server/generate.js
   post:


### PR DESCRIPTION
Motivation: Catch packager breakages (such as bad shrinkwrap, package.json) quickly and reliably. This is also done as part of the e2e test on Travis. Having an isolated packager test as well makes it easier to see there's a problem with the packager, running in on CircleCI helps detect issues even if the Travis e2e test gets ever broken (have some redundancy, these breakages are pretty painful to fix so we want to detect them as reliably as possible).

**Test plan (required)**

Ran this locally:

    git checkout master
    ./scripts/e2e-test.sh --packager  # The packager created the bundle, exit code was 0
    # Made the packager fail on bad JS
    ./scripts/e2e-test.sh --packager  # Exit code was 1

