### PR TITLE
Sanitize lineNumber in launchEditor

### DIFF
--- a/local-cli/server/util/launchEditor.js
+++ b/local-cli/server/util/launchEditor.js
@@ -106,6 +106,12 @@ function launchEditor(fileName, lineNumber) {
     return;
   }
 
+  // Sanitize lineNumber to prevent malicious use on win32
+  // via: https://github.com/nodejs/node/blob/c3bb4b1aa5e907d489619fb43d233c3336bfc03d/lib/child_process.js#L333
+  if (lineNumber && isNaN(lineNumber)) {
+    return;
+  }
+
   var editor = guessEditor();
   if (!editor) {
     printInstructions('PRO TIP');


### PR DESCRIPTION
Shelling out on win32 does not properly escape the command due to https://github.com/nodejs/node/blob/c3bb4b1aa5e907d489619fb43d233c3336bfc03d/lib/child_

This patch ensures a proper lineNumber before continuing, similar to how we check that the fileName passed exists.

**Test plan**

On platform `win32` or given appropriate testing changes to `launchEditor.js`...

With the following `request-bad` file:
```
GET /open-stack-frame HTTP/1.1
Host: 127.0.0.1:8081
Proxy-Connection: keep-alive
Cache-Control: max-age=0
Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8
Upgrade-Insecure-Requests: 1
User-Agent: Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/48.0.2564.116 Safari/537.36
Accept-Encoding: gzip, deflate, sdch
Accept-Language: en-US,en;q=0.8
Content-Length: 64

{"file":"C:\\Windows\\system.ini","lineNumber":"123\" && calc"}
```

`$ nc localhost 8081 < request-bad`

Observe that before this patch `calc` would launch and after the request is no-op.