### PR TITLE
[Android] Fix IllegalStateException crash in WebSocketModule.java

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/modules/websocket/WebSocketModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/websocket/WebSocketModule.java
@@ -10,6 +10,7 @@
 package com.facebook.react.modules.websocket;
 
 import java.io.IOException;
+import java.lang.IllegalStateException;
 import javax.annotation.Nullable;
 
 import com.facebook.common.logging.FLog;
@@ -176,7 +177,7 @@ public class WebSocketModule extends ReactContextBaseJavaModule {
       client.sendMessage(
         WebSocket.PayloadType.TEXT,
         new Buffer().writeUtf8(message));
-    } catch (IOException e) {
+    } catch (IOException | IllegalStateException e) {
       notifyWebSocketFailed(id, e.getMessage());
     }
   }


### PR DESCRIPTION
- Motivation: The WebSocket implementation on Android crashes the app when an attempt is made to write on a web socket that was closed due to a spotty connection. We found this issue by using Pusher, which is built on WebSockets. The following stack trace reveals that the WebSocketModule doesn't catch the case of a closed connection, when a consumer attempts to write:
```sh
Fatal Exception: java.lang.IllegalStateException: closed
       at com.squareup.okhttp.internal.ws.RealWebSocket.sendMessage(RealWebSocket.java:109)
       at com.facebook.react.modules.websocket.WebSocketModule.send(WebSocketModule.java:176)
       at java.lang.reflect.Method.invoke(Method.java)
       at java.lang.reflect.Method.invoke(Method.java:372)
       at com.facebook.react.bridge.BaseJavaModule$JavaMethod.invoke(BaseJavaModule.java:249)
       at com.facebook.react.bridge.NativeModuleRegistry$ModuleDefinition.call(NativeModuleRegistry.java:158)
       at com.facebook.react.bridge.NativeModuleRegistry.call(NativeModuleRegistry.java:58)
       at com.facebook.react.bridge.CatalystInstanceImpl$NativeModulesReactCallback.call(CatalystInstanceImpl.java:428)
       at com.facebook.react.bridge.queue.NativeRunnableDeprecated.run(NativeRunnableDeprecated.java)
       at android.os.Handler.handleCallback(Handler.java:739)
       at android.os.Handler.dispatchMessage(Handler.java:95)
       at com.facebook.react.bridge.queue.MessageQueueThreadHandler.dispatchMessage(MessageQueueThreadHandler.java:31)
       at android.os.Looper.loop(Looper.java:145)
       at com.facebook.react.bridge.queue.MessageQueueThreadImpl$3.run(MessageQueueThreadImpl.java:184)
       at java.lang.Thread.run(Thread.java:818)
```

- Test Plan: Create a WebSocket connection and attempt to write after the connection became unavailable due to a spotty connection. An easy way to do this is to establish a Pusher connection with [pusher-websocket-iso/react-native](https://github.com/pusher-community/pusher-websocket-js-iso#react-native) and fake or force a spotty connection.
