### PR TITLE
Add '--ignore-babelrc' option to the packager

### DIFF
--- a/local-cli/server/runServer.js
+++ b/local-cli/server/runServer.js
@@ -85,6 +85,7 @@ function getPackagerServer(args, config) {
       'aac', 'aiff', 'caf', 'm4a', 'mp3', 'wav', // Audio formats
       'html', // Document formats
     ],
+    ignoreBabelRC: args['ignore-babelrc'],
     resetCache: args.resetCache || args['reset-cache'],
     verbose: args.verbose,
   });

--- a/local-cli/server/server.js
+++ b/local-cli/server/server.js
@@ -66,6 +66,10 @@ function _server(argv, config, resolve, reject) {
     description: 'Removes cached files',
     default: false,
   }, {
+    command: 'ignore-babelrc',
+    description: 'Ignores the .babelrc in project root',
+    default: false,
+  }, {
     command: 'verbose',
     description: 'Enables logging',
     default: false,

--- a/packager/react-packager/src/Bundler/index.js
+++ b/packager/react-packager/src/Bundler/index.js
@@ -38,6 +38,9 @@ const validateOpts = declareOpts({
   blacklistRE: {
     type: 'object', // typeof regex is object
   },
+  ignoreBabelRC: {
+    type: 'boolean',
+  },
   moduleFormat: {
     type: 'string',
     default: 'haste',
@@ -450,7 +453,10 @@ class Bundler {
           dev: dev,
           modulePath: module.path,
         },
-        {hot},
+        {
+          hot,
+          ignoreBabelRC: this._opts.ignoreBabelRC
+        },
       ).then(options => {
         return this._transformer.loadFileAndTransform(
           path.resolve(module.path),

--- a/packager/react-packager/src/Server/index.js
+++ b/packager/react-packager/src/Server/index.js
@@ -28,6 +28,10 @@ const validateOpts = declareOpts({
   blacklistRE: {
     type: 'object', // typeof regex is object
   },
+  ignoreBabelRC: {
+    type: 'boolean',
+    required: false
+  },
   moduleFormat: {
     type: 'string',
     default: 'haste',
@@ -126,6 +130,10 @@ const bundleOpts = declareOpts({
   entryModuleOnly: {
     type: 'boolean',
     default: false,
+  },
+  ignoreBabelRC: {
+    type: 'boolean',
+    required: false
   },
 });
 

--- a/packager/transformer.js
+++ b/packager/transformer.js
@@ -27,7 +27,7 @@ const path = require('path');
 const getBabelRC = (function() {
   let babelRC = null;
 
-  return function _getBabelRC(projectRoots) {
+  return function _getBabelRC(projectRoots, ignoreBabelRC) {
     if (babelRC !== null) {
       return babelRC;
     }
@@ -43,7 +43,7 @@ const getBabelRC = (function() {
     // (which works because we pass in `filename` and `sourceFilename` to
     // Babel when we transform).
     let projectBabelRCPath;
-    if (projectRoots && projectRoots.length > 0) {
+    if (!ignoreBabelRC && projectRoots && projectRoots.length > 0) {
       projectBabelRCPath = path.resolve(projectRoots[0], '.babelrc');
     }
 
@@ -61,7 +61,7 @@ const getBabelRC = (function() {
     }
 
     return babelRC;
-  }
+  };
 })();
 
 /**
@@ -69,7 +69,7 @@ const getBabelRC = (function() {
  * config object with the appropriate plugins.
  */
 function buildBabelConfig(filename, options) {
-  const babelRC = getBabelRC(options.projectRoots);
+  const babelRC = getBabelRC(options.projectRoots, options.ignoreBabelRC);
 
   const extraConfig = {
     filename,


### PR DESCRIPTION
In many projects, lots of different environments co-exist in one repository, and they should play nice with each other. For example, in our case, we have the server, web, and React Native code in one repo, and everything uses Babel.

Though the React Native packager doesn't work with the project's babel configuration. In our case, we use a pretty standard babel configuration with `stage-1` and `react` presets.

I would love to fix the actual issue, that is, both projects should be able to run with a single config. But due to the differences between how the library code is written, it's sometimes pretty difficult. So it's convenient to be able to ignore the Babel configuration in the project root.

Other solution would be to manually specify the babel config for each of the other codebase at their entry points, e.g. - babel-node, build script for server, build script for web. But it's very inconvenient.

**Test plan (required)**

Create a `.babelrc` in the project root with just the `es2015` preset and run `./packager/packager.sh`, and it'll fail to properly transpile code for the examples. Run with the `--ignore-babelrc` option and it should work.

In a later PR I'll add the option to `rn-cli.config`.

This is the first time I'm diving into the packager code. So please let me know if I had made any mistakes.

On another note, I'm not even sure that this is the correct way to do this, coz seems that the packager allows you to swap the transformer, and this is a transformer specific options. Another way would be to add `getTransformerOptions` to `rn-cli.config`.

cc @martinbigio 