### PR TITLE
WebSocket: call onclose before closing in event of error

### DIFF
--- a/Libraries/WebSocket/WebSocket.js
+++ b/Libraries/WebSocket/WebSocket.js
@@ -117,6 +117,7 @@ class WebSocket extends WebSocketBase {
         var event = new WebSocketEvent('error');
         event.message = ev.message;
         this.onerror && this.onerror(event);
+        this.onclose && this.onclose(event);
         this.dispatchEvent(event);
         this._unregisterEvents();
         this.close();


### PR DESCRIPTION
Motivation: Developer expects `onclose` to be called before/during close of the websocket. The `websocketFailed` event triggers a close but does not invoke onclose.

Testplan: Connect to a websocket server from android, terminate the server, observe that onerror is called, the websocket is closed, but onclose is not called.

Note: the observed bug is in android only because in iOS the underlying websocket implementation fires the `websocketClosed` rather than `websocketFailed` event when the server terminates. Nevertheless, the justification for this change stands that regardless of the cause of the close, if `this.close` is called it is expected this.onclose should be called as well.