### PR TITLE
Replace "Bad: will fatal" with "Bad: will fail" in Text.md

### DIFF
--- a/docs/Text.md
+++ b/docs/Text.md
@@ -63,7 +63,7 @@ When the browser is trying to render a text node, it's going to go all the way u
 In React Native, we are more strict about it: **you must wrap all the text nodes inside of a `<Text>` component**; you cannot have a text node directly under a `<View>`.
 
 ```javascript
-// BAD: will fail, can't have a text node as child of a <View>
+// BAD: will raise exception, can't have a text node as child of a <View>
 <View>
   Some text
 </View>

--- a/docs/Text.md
+++ b/docs/Text.md
@@ -63,7 +63,7 @@ When the browser is trying to render a text node, it's going to go all the way u
 In React Native, we are more strict about it: **you must wrap all the text nodes inside of a `<Text>` component**; you cannot have a text node directly under a `<View>`.
 
 ```javascript
-// BAD: will fatal, can't have a text node as child of a <View>
+// BAD: will fail, can't have a text node as child of a <View>
 <View>
   Some text
 </View>


### PR DESCRIPTION
This commit makes a change to a comment in `Text.md` related to documenting that all text nodes must be wrapped in a `<Text />` component.

I know this is super small, but it was so easy to handle this on Github that I went ahead and did it.