### PR TITLE
Fix navigation in UIExplorer. Use current index instead of fixed valu…

### DIFF
--- a/Examples/UIExplorer/UIExplorerApp.android.js
+++ b/Examples/UIExplorer/UIExplorerApp.android.js
@@ -105,8 +105,10 @@ class UIExplorerApp extends React.Component {
     }
     const {stack} = navigationState;
     const title = UIExplorerStateTitleMap(stack.children[stack.index]);
-    if (stack && stack.children[1]) {
-      const {key} = stack.children[1];
+    const index = stack.children.length <= 1 ?  1 : stack.index;
+
+    if (stack && stack.children[index]) {
+      const {key} = stack.children[index];
       const ExampleModule = UIExplorerList.Modules[key];
       const ExampleComponent = UIExplorerExampleList.makeRenderable(ExampleModule);
       return (


### PR DESCRIPTION
Motivation: After second navigation event in UIExplorer, content in main page always stayed the same. 
Fix: For second and future navigation events use stack.index to retrieve state from stack.children.
Test Plan: Navigate through all available positions (or at least first,middle, last ones).