### PR TITLE
Fixed permalink

### DIFF
--- a/docs/GettingStartedOnLinux.md
+++ b/docs/GettingStartedOnLinux.md
@@ -3,7 +3,7 @@ id: getting-started-linux
 title: Getting Started on Linux
 layout: docs
 category: Quick Start
-permalink: docs/getting-started-on-linux.html
+permalink: docs/getting-started-linux.html
 next: android-setup
 ---
 


### PR DESCRIPTION
The 'Next' link on page http://facebook.github.io/react-native/docs/getting-started.html#content points to 
'http://facebook.github.io/react-native/getting-started-linux.html#content', but the permalink doesn't exist, it would be redirected to the getting-started.html page. 

This pull request fixed the wrong permalink.

