### PR TITLE
Deleted unnecessary 'use strict' in new project templates

### DIFF
--- a/local-cli/generator/templates/index.android.js
+++ b/local-cli/generator/templates/index.android.js
@@ -2,7 +2,7 @@
  * Sample React Native App
  * https://github.com/facebook/react-native
  */
-'use strict';
+
 import React, {
   AppRegistry,
   Component,

--- a/local-cli/generator/templates/index.ios.js
+++ b/local-cli/generator/templates/index.ios.js
@@ -2,7 +2,7 @@
  * Sample React Native App
  * https://github.com/facebook/react-native
  */
-'use strict';
+
 import React, {
   AppRegistry,
   Component,


### PR DESCRIPTION
Hello there!

Since React Native generates `index.*.js` files with usage of ES6 modules, `'use strict'` became unnecessary.

http://www.ecma-international.org/ecma-262/6.0/#sec-strict-mode-code
> Module code is always strict mode code.