### PR TITLE
[docs] Rename Application Support Repository

### DIFF
--- a/docs/DevelopmentSetupAndroid.md
+++ b/docs/DevelopmentSetupAndroid.md
@@ -52,7 +52,7 @@ React Native Android use [gradle](https://docs.gradle.org) as a build system. We
 1. Open the Android SDK Manager (**on Mac** start a new shell and run `android`); in the window that appears make sure you check:
   * Android SDK Build-tools version 23.0.**1**
   * Android 6.0 (API 23)
-  * Android Support Repository
+  * Android Support Repository (**Local Maven repository for Support Libraries**)
 2. Click "Install Packages"
 
 ![SDK Manager window](img/AndroidSDK1.png) ![SDK Manager window](img/AndroidSDK2.png)


### PR DESCRIPTION
# Updated Support Repository Name #

`Android Support Repository` was renamed to be `Local Maven repository for Support Libraries`. This is an important coherency issue IMO. I would suggest editing the photo as well to be matching the new update.

Moreover, this issue has brought to my attention, in respect to Android Gradle, another possible documentation fix. It should be pointed out that `local.properties` file needs to be `created` before `editing`; I have found that exporting `ANDROID_HOME` is not very reliable and should be suggested that `sdk.dir=/path/to/android-sdk` be added to the new `local.properties` file in the `/android` project directory as well.