### PR TITLE
Update hot reloading dependencies

### DIFF
--- a/babel-preset/package.json
+++ b/babel-preset/package.json
@@ -15,7 +15,7 @@
   },
   "homepage": "https://github.com/facebook/react-native/tree/master/babel-preset/README.md",
   "dependencies": {
-    "babel-plugin-react-transform": "2.0.0-beta1",
+    "babel-plugin-react-transform": "2.0.2",
     "babel-plugin-syntax-async-functions": "^6.5.0",
     "babel-plugin-syntax-class-properties": "^6.5.0",
     "babel-plugin-syntax-flow": "^6.5.0",
@@ -40,6 +40,6 @@
     "babel-plugin-transform-react-display-name": "^6.5.0",
     "babel-plugin-transform-react-jsx": "^6.5.0",
     "babel-plugin-transform-regenerator": "^6.5.0",
-    "react-transform-hmr": "^1.0.2"
+    "react-transform-hmr": "^1.0.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -161,7 +161,7 @@
     "progress": "^1.1.8",
     "promise": "^7.1.1",
     "react-timer-mixin": "^0.13.2",
-    "react-transform-hmr": "^1.0.2",
+    "react-transform-hmr": "^1.0.4",
     "rebound": "^0.0.13",
     "regenerator": "^0.8.36",
     "sane": "^1.2.0",


### PR DESCRIPTION
## Motivation

These updates include important changes to correctness in the linked and underlying packages:

* https://github.com/gaearon/babel-plugin-react-transform/releases/tag/v2.0.1
* https://github.com/gaearon/babel-plugin-react-transform/releases/tag/v2.0.2
* https://github.com/gaearon/react-proxy/releases/tag/v1.1.3
* https://github.com/gaearon/react-proxy/releases/tag/v1.1.4
* etc

We need to include these if we want to ship hot reloading.

## Test Plan

Create a new project with those versions of packages.

<img width="761" alt="screen shot 2016-03-06 at 18 49 20" src="https://cloud.githubusercontent.com/assets/810438/13556222/2d45ca62-e3cc-11e5-8a3f-a2346efe19dd.png">

Verify hot reloading still works.

![](http://cl.ly/2J150y0Y3E1z/download/Screen%20Recording%202016-03-06%20at%2018.48.gif)

## Reviewers

@martinbigio @skevy 

## Notes

I wasn’t sure whether to touch the shrinkwrap.