### PR TITLE
Fix: cli.js - use var instead of const

### DIFF
--- a/local-cli/cli.js
+++ b/local-cli/cli.js
@@ -71,7 +71,7 @@ function run() {
     printUsage();
   }
 
-  const setupEnvScript = /^win/.test(process.platform)
+  var setupEnvScript = /^win/.test(process.platform)
     ? 'setup_env.bat'
     : 'setup_env.sh';
   childProcess.execFileSync(path.join(__dirname, setupEnvScript));


### PR DESCRIPTION
Explain the **motivation** for making this change. What existing problem does the pull request solve?

Fixes https://github.com/facebook/react-native/issues/6203

> SyntaxError: Use of const in strict mode.

- The rest of the file isn't using es6 anyway and babel-register is run on the file it's included in

**Test plan (required)**

Shouldn't have issues replacing it since it's used right after one time.
