### PR TITLE
TextStorage in RCTText is now only set when it differs from old value.

### DIFF
--- a/Libraries/Text/RCTText.m
+++ b/Libraries/Text/RCTText.m
@@ -74,8 +74,10 @@
 
 - (void)setTextStorage:(NSTextStorage *)textStorage
 {
-  _textStorage = textStorage;
-  [self setNeedsDisplay];
+  if (_textStorage != textStorage) {
+    _textStorage = textStorage;
+    [self setNeedsDisplay];
+  }
 }
 
 - (void)drawRect:(CGRect)rect


### PR DESCRIPTION
**Motivation**
Multiple instances of `Text` inside a `ListView` is a bad idea for the performance of the app.
When you create 1000 elements and you scroll through the list it is really slow and laggy because the `NSTextStorage`, which is the backbone of the `RCTText` element, will set more than 1,000 times and also the method `setNeedsDisplay` is called multiple times. This will causes huge memory problems and the app crashes.

With this commit I check in `RCTText` if the `NSTextStorage` differs from the old value. If yes then set it otherwise don't set the `NSTextStorage`. This will prevent to call `setNeedsDisplay` when not really needed.

Gist with sample app to show behavior can be found here: https://gist.github.com/bpoetzschke/28a17969c6aa54219e18