### PR TITLE
Attempt to make RN work with npm 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,11 +24,9 @@
     "haste": {
       "defaultPlatform": "ios",
       "providesModuleNodeModules": [
-        "fbjs",
         "react",
         "react-native",
-        "parse",
-        "react-transform-hmr"
+        "parse"
       ],
       "platforms": [
         "ios",
@@ -155,7 +153,7 @@
     "mkdirp": "^0.5.1",
     "module-deps": "^3.9.1",
     "node-fetch": "^1.3.3",
-    "node-haste": "~2.4.0",
+    "node-haste": "~2.6.1",
     "opn": "^3.0.2",
     "optimist": "^0.6.1",
     "progress": "^1.1.8",

--- a/packager/react-packager/src/AssetServer/__tests__/AssetServer-test.js
+++ b/packager/react-packager/src/AssetServer/__tests__/AssetServer-test.js
@@ -3,6 +3,7 @@
 jest
   .dontMock('node-haste/lib/lib/getPlatformExtension')
   .dontMock('node-haste/node_modules/throat')
+  .dontMock('node-haste/lib/fastpath')
   .dontMock('../');
 
 jest

--- a/packager/react-packager/src/Resolver/index.js
+++ b/packager/react-packager/src/Resolver/index.js
@@ -84,13 +84,18 @@ class Resolver {
           (opts.blacklistRE && opts.blacklistRE.test(filepath));
       },
       providesModuleNodeModules: [
-        'react',
-        'react-native',
+        // Use the project's installed version of react-native
+        // as the "haste" version of `react-native`
+        // (and ignore any nested copies);
+        { name: 'react-native', parent: null },
+        // Use the react peerDep for the "haste"
+        // version of `react`.
+        { name: 'react', parent: null },
         // Parse requires AsyncStorage. They will
         // change that to require('react-native') which
         // should work after this release and we can
         // remove it from here.
-        'parse',
+        { name: 'parse', parent: null },
       ],
       platforms: ['ios', 'android'],
       preferNativePlatform: true,


### PR DESCRIPTION
This is an attempt to make https://github.com/facebook/react-native/pull/6039 work and see test results on Travis and CircleCI now both are green (tests fails on #6039):
https://travis-ci.org/facebook/react-native/builds
https://circleci.com/gh/facebook/react-native/tree/master

https://github.com/facebook/node-haste/pull/33 has been merged a 2.6.1 that contains it is in npm.