### PR TITLE
Add transform-react-jsx-source to react-native preset

### DIFF
--- a/babel-preset/configs/main.js
+++ b/babel-preset/configs/main.js
@@ -39,6 +39,11 @@ module.exports = {
     ['transform-es2015-for-of', { loose: true }],
     require('../transforms/transform-symbol-member'),
   ]),
+  env: {
+    development: {
+      plugins: resolvePlugins(['transform-react-jsx-source']),
+    },
+  },
   retainLines: true,
   sourceMaps: false,
 };

--- a/babel-preset/package.json
+++ b/babel-preset/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-preset-react-native",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "Babel preset for React Native applications",
   "main": "index.js",
   "repository": "https://github.com/facebook/react-native/tree/master/babel-preset",
@@ -39,6 +39,7 @@
     "babel-plugin-transform-object-assign": "^6.5.0",
     "babel-plugin-transform-object-rest-spread": "^6.5.0",
     "babel-plugin-transform-react-display-name": "^6.5.0",
+    "babel-plugin-transform-react-jsx-source": "^6.5.0",
     "babel-plugin-transform-react-jsx": "^6.5.0",
     "babel-plugin-transform-regenerator": "^6.5.0",
     "react-transform-hmr": "^1.0.4"

--- a/babel-preset/plugins.js
+++ b/babel-preset/plugins.js
@@ -30,6 +30,7 @@ module.exports = {
   'babel-plugin-transform-object-assign': require('babel-plugin-transform-object-assign'),
   'babel-plugin-transform-object-rest-spread': require('babel-plugin-transform-object-rest-spread'),
   'babel-plugin-transform-react-display-name': require('babel-plugin-transform-react-display-name'),
+  'babel-plugin-transform-react-jsx-source': require('babel-plugin-transform-react-jsx-source'),
   'babel-plugin-transform-react-jsx': require('babel-plugin-transform-react-jsx'),
   'babel-plugin-transform-regenerator': require('babel-plugin-transform-regenerator'),
   'babel-plugin-transform-es2015-for-of': require('babel-plugin-transform-es2015-for-of'),

--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "babel-core": "^6.6.4",
     "babel-plugin-external-helpers": "^6.5.0",
     "babel-polyfill": "^6.6.1",
-    "babel-preset-react-native": "^1.7.0",
+    "babel-preset-react-native": "^1.8.0",
     "babel-register": "^6.6.0",
     "babel-types": "^6.6.4",
     "babylon": "^6.6.4",

--- a/packager/transformer.js
+++ b/packager/transformer.js
@@ -100,15 +100,22 @@ function buildBabelConfig(filename, options) {
 function transform(src, filename, options) {
   options = options || {};
 
-  const babelConfig = buildBabelConfig(filename, options);
-  const result = babel.transform(src, babelConfig);
+  const OLD_BABEL_ENV = process.env.BABEL_ENV;
+  process.env.BABEL_ENV = options.dev ? 'development' : 'production';
 
-  return {
-    ast: result.ast,
-    code: result.code,
-    map: result.map,
-    filename: filename,
-  };
+  try {
+    const babelConfig = buildBabelConfig(filename, options);
+    const result = babel.transform(src, babelConfig);
+
+    return {
+      ast: result.ast,
+      code: result.code,
+      map: result.map,
+      filename: filename,
+    };
+  } finally {
+    process.env.BABEL_ENV = OLD_BABEL_ENV;
+  }
 }
 
 module.exports = function(data, callback) {


### PR DESCRIPTION
Putting this up as request for comments.

The PR adds [transform-react-jsx-source](https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-react-jsx-source) to the list of plugins that come by default with the `react-native` preset. It will enable the use of a bunch of really cool tooling around JSX, however those are generally useful only in development mode. Is changing `react-native` preset the right thing to do in this case? Is there a way to enable this transform only in DEV? Should I add this somewhere else?