### PR TITLE
Fix to make bundling available for iPhone simulators again

### DIFF
--- a/packager/react-native-xcode.sh
+++ b/packager/react-native-xcode.sh
@@ -12,13 +12,6 @@
 
 case "$CONFIGURATION" in
   Debug)
-    # Speed up build times by skipping the creation of the offline package for debug
-    # builds on the simulator since the packager is supposed to be running anyways.
-    if [[ "$PLATFORM_NAME" = "iphonesimulator" ]]; then		
-      echo "Skipping bundling for Simulator platform"		
-      exit 0;		
-    fi
-    
     DEV=true
     ;;
   "")


### PR DESCRIPTION
Motivation:-

Being a framework, other teams are not debugging RN part of code but use it as a blackbox component. It creates a lot of inconveniences for developers which use the framework in a way as many other standard frameworks, real device or simulator does not make any difference for developers who are not directly develop RN code.

For iOS projects that create the JSBundle within the DyLib framework, this condition results in the bundle being unavailable for iOS emulators and results in an infinite loop resulting in a crash saying _fbBatched bridge undefined. Removing this piece of code would make the bundle available for iOS simulators for all such projects when the JSLocation is pointing to the RN Bundle.