### PR TITLE
devTools: do not reconnect in websocket.onerror

### DIFF
--- a/Libraries/Devtools/setupDevtools.js
+++ b/Libraries/Devtools/setupDevtools.js
@@ -34,10 +34,6 @@ function setupDevtools() {
     setTimeout(setupDevtools, 200);
     closeListeners.forEach(fn => fn());
   };
-  ws.onerror = error => {
-    setTimeout(setupDevtools, 200);
-    closeListeners.forEach(fn => fn());
-  };
   ws.onopen = function () {
     tryToConnect();
   };


### PR DESCRIPTION
This follows https://github.com/facebook/react-native/pull/6307 and solves https://github.com/facebook/react-native/pull/6307#issuecomment-193534660

Since the aforementioned PR now always calls `onclose` when failure occurs for a websocket, `onclose` should be sufficient for reconnecting the devtools websocket.