### PR TITLE
update ESLint to 2.0

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,8 +1,12 @@
 {
   "parser": "babel-eslint",
 
-  "ecmaFeatures": {
-    "jsx": true
+  "parserOptions": {
+    "ecmaVersion": 6,
+    "ecmaFeatures": {
+      "jsx": true
+    },
+    "sourceType": "module"
   },
 
   "env": {


### PR DESCRIPTION
Update ESLint to 2.0, should move ecmaFeatures under parserOptions.

If want to use `import`, shoud add `sourceType: "module"`.

http://eslint.org/docs/user-guide/migrating-to-2.0.0