### PR TITLE
Added e2e tests for npm@2 and npm@3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,14 @@ script:
     npm install github@0.2.4
     cat <(echo eslint; npm run lint --silent -- --format=json; echo flow; npm run flow --silent -- --json) | GITHUB_TOKEN="af6ef0d15709bc91d""06a6217a5a826a226fb57b7" node bots/code-analysis-bot.js
     npm run flow && npm test
+    # testing js e2e with npm2
+    npm install -g npm@2
+    npm --version
+    ./scripts/e2e-test.sh --packager
+    # testing js e2e with npm3
+    npm install -g npm@3
+    npm --version
+    ./scripts/e2e-test.sh --packager
 
   elif [ "$TEST_TYPE" = e2e-objc ]
   then

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -10,7 +10,7 @@ set -e
 set -x
 
 if [ -z $1 ]; then
-  echo "Please run the script with --ios, --android or --packager"
+  echo "Please run the script with --ios, --android or --packager" >&2
   exit 1
 fi
 
@@ -68,6 +68,7 @@ SINOPIA_PID=$!
 
 # Make sure to remove old version of react-native in
 # case it was cached
+npm cache clear
 npm unpublish react-native --force
 npm unpublish react-native-cli --force
 npm publish $ROOT
@@ -104,9 +105,11 @@ case $1 in
   ../node_modules/react-native/packager/packager.sh --nonPersistent &
   SERVER_PID=$!
   # TODO Start the app and check it renders "Welcome to React Native"
-  echo "The Android e2e test is not implemented yet"
+  echo "The Android e2e test is not implemented yet" >&2
+  exit 1
   ;;
 *)
-  echo "Please run the script with --ios, --android or --packager"
+  echo "Please run the script with --ios, --android or --packager" >&2
+  exit 1
   ;;
 esac


### PR DESCRIPTION
Need to make sure we can use both versions of npm client for publishing and installing

**Test plan (required)**

Make sure tests pass on both Travis and Circle CI.

