### PR TITLE
Fixes #5934

### DIFF
--- a/Libraries/CustomComponents/ListView/ListView.js
+++ b/Libraries/CustomComponents/ListView/ListView.js
@@ -203,7 +203,8 @@ var ListView = React.createClass({
     /**
      * A performance optimization for improving scroll perf of
      * large lists, used in conjunction with overflow: 'hidden' on the row
-     * containers.  This is enabled by default.
+     * containers.  This is disabled by default.  If this option is enabled,
+     * ensure that views returned by renderRow have {{overflow:hidden}} set on them.
      */
     removeClippedSubviews: React.PropTypes.bool,
     /**
@@ -416,7 +417,7 @@ var ListView = React.createClass({
       props.scrollEventThrottle = DEFAULT_SCROLL_CALLBACK_THROTTLE;
     }
     if (props.removeClippedSubviews === undefined) {
-      props.removeClippedSubviews = true;
+      props.removeClippedSubviews = false;
     }
     Object.assign(props, {
       onScroll: this._onScroll,


### PR DESCRIPTION
This fixes the issue at https://github.com/facebook/react-native/issues/5934; basically ListView on Android may crash when adding elements that are rendered off-screen.

As the default settings for ListView was requiring action to be taken on the result returned by renderRow to avoid a crash, I've changed the default to false in the hopes that users changing the prop will read the docs first.

**Test plan (required)**

See failure at https://github.com/npomfret/react-native-bug-reports/tree/master/ListViewUpdatingBug