### PR TITLE
Reject promise if network request failed

### DIFF
--- a/Libraries/Fetch/fetch.js
+++ b/Libraries/Fetch/fetch.js
@@ -390,8 +390,14 @@ var self = {};
       }
 
       xhr.onload = function() {
+        var status = (xhr.status === 1223) ? 204 : xhr.status
+        if (status < 100 || status > 599) {
+          reject(new TypeError('Network request failed'))
+          return
+        }
+        debugger;
         var options = {
-          status: xhr.status,
+          status: status,
           statusText: xhr.statusText,
           headers: headers(xhr),
           url: responseURL()

--- a/Libraries/Fetch/fetch.js
+++ b/Libraries/Fetch/fetch.js
@@ -395,7 +395,7 @@ var self = {};
           reject(new TypeError('Network request failed'))
           return
         }
-        debugger;
+
         var options = {
           status: status,
           statusText: xhr.statusText,


### PR DESCRIPTION
This adds missing check and promise reject for failing network requests. Which was missing in the fetch.js update. Sorry for the trouble.

cc @davidaurelio 