### PR TITLE
Update watchman version in docs to latest stable release

### DIFF
--- a/docs/GettingStartedOnLinux.md
+++ b/docs/GettingStartedOnLinux.md
@@ -40,7 +40,7 @@ Paste the following into your terminal to compile watchman from source and insta
 ```sh
 git clone https://github.com/facebook/watchman.git
 cd watchman
-git checkout v4.1.0  # the latest stable release
+git checkout v4.5.0  # the latest stable release
 ./autogen.sh
 ./configure
 make


### PR DESCRIPTION
Update documentation. Per https://facebook.github.io/watchman/docs/install.html the latest stable release of watchman is now at v4.5.0

This is my first pull request and I have completed the CLA.