### PR TITLE
GeoLocation timeout never called on android

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/modules/location/LocationModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/location/LocationModule.java
@@ -280,7 +280,7 @@ public class LocationModule extends ReactContextBaseJavaModule {
 
     public void invoke() {
       mLocationManager.requestSingleUpdate(mProvider, mLocationListener, null);
-      mHandler.postDelayed(mTimeoutRunnable, SystemClock.currentTimeMillis() + mTimeout);
+      mHandler.postDelayed(mTimeoutRunnable, mTimeout);
     }
   }
 }


### PR DESCRIPTION
Don't add systems current time to the `timeout` option. This is already correct on iOS.