### PR TITLE
[iOS] Updating AppState to support the inactive state.

### DIFF
--- a/Libraries/AppStateIOS/AppStateIOS.ios.js
+++ b/Libraries/AppStateIOS/AppStateIOS.ios.js
@@ -35,8 +35,9 @@ var _eventHandlers = {
  *  - `active` - The app is running in the foreground
  *  - `background` - The app is running in the background. The user is either
  *     in another app or on the home screen
- *  - `inactive` - This is a transition state that currently never happens for
- *     typical React Native apps.
+ *  - `inactive` - This is a state that occurs when transitioning between
+ *  	 foreground & background, and during periods of inactivity such as
+ *  	 entering the Multitasking view or in the event of an incoming call
  *
  * For more information, see
  * [Apple's documentation](https://developer.apple.com/library/ios/documentation/iPhone/Conceptual/iPhoneOSProgrammingGuide/TheAppLifeCycle/TheAppLifeCycle.html)

--- a/React/Modules/RCTAppState.m
+++ b/React/Modules/RCTAppState.m
@@ -84,15 +84,15 @@ RCT_EXPORT_MODULE()
 - (void)handleAppStateDidChange:(NSNotification *)notification
 {
   NSString *newState;
-  
-  if (notification.name == UIApplicationWillResignActiveNotification) {
+
+  if ([notification.name isEqualToString:UIApplicationWillResignActiveNotification]) {
     newState = @"inactive";
-  } else if (notification.name == UIApplicationWillEnterForegroundNotification) {
+  } else if ([notification.name isEqualToString:UIApplicationWillEnterForegroundNotification]) {
     newState = @"active";
   } else {
     newState = RCTCurrentAppBackgroundState();
   }
-  
+
   if (![newState isEqualToString:_lastKnownState]) {
     _lastKnownState = newState;
     [_bridge.eventDispatcher sendDeviceEventWithName:@"appStateDidChange"

--- a/React/Modules/RCTAppState.m
+++ b/React/Modules/RCTAppState.m
@@ -21,8 +21,7 @@ static NSString *RCTCurrentAppBackgroundState()
   dispatch_once(&onceToken, ^{
     states = @{
       @(UIApplicationStateActive): @"active",
-      @(UIApplicationStateBackground): @"background",
-      @(UIApplicationStateInactive): @"inactive"
+      @(UIApplicationStateBackground): @"background"
     };
   });
 
@@ -53,9 +52,12 @@ RCT_EXPORT_MODULE()
 
   for (NSString *name in @[UIApplicationDidBecomeActiveNotification,
                            UIApplicationDidEnterBackgroundNotification,
-                           UIApplicationDidFinishLaunchingNotification]) {
+                           UIApplicationDidFinishLaunchingNotification,
+                           UIApplicationWillResignActiveNotification,
+                           UIApplicationWillEnterForegroundNotification]) {
+
     [[NSNotificationCenter defaultCenter] addObserver:self
-                                             selector:@selector(handleAppStateDidChange)
+                                             selector:@selector(handleAppStateDidChange:)
                                                  name:name
                                                object:nil];
   }
@@ -79,9 +81,18 @@ RCT_EXPORT_MODULE()
 
 #pragma mark - App Notification Methods
 
-- (void)handleAppStateDidChange
+- (void)handleAppStateDidChange:(NSNotification *)notification
 {
-  NSString *newState = RCTCurrentAppBackgroundState();
+  NSString *newState;
+  
+  if (notification.name == UIApplicationWillResignActiveNotification) {
+    newState = @"inactive";
+  } else if (notification.name == UIApplicationWillEnterForegroundNotification) {
+    newState = @"active";
+  } else {
+    newState = RCTCurrentAppBackgroundState();
+  }
+  
   if (![newState isEqualToString:_lastKnownState]) {
     _lastKnownState = newState;
     [_bridge.eventDispatcher sendDeviceEventWithName:@"appStateDidChange"


### PR DESCRIPTION
**Motivation**

AppStateIOS never currently returns `inactive` as a possible state. I had a requirement that when inactive, certain portions of the app should be blacked out in accordance with compliance rules. This is not possible currently, due to `inactive` never being returned. This PR fixes that.

**Test plan**

All base tests are passing. Are there AppState specific tests in place at the moment that I'm missing?

**Demonstration**

![appstate](https://cloud.githubusercontent.com/assets/286616/13640546/1cb6eeb0-e5e3-11e5-8d64-332ea3383a54.gif)

