### PR TITLE
Set podspec version to be greater than zero

### DIFF
--- a/React.podspec
+++ b/React.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                = "React"
-  s.version             = "0.0.0-master"
+  s.version             = "0.0.1-master"
   s.summary             = "Build high quality mobile apps using React."
   s.description         = <<-DESC
                             React Native apps are built using the React JS


### PR DESCRIPTION
Cocoapods requires that the version should be greater than zero. So if you have your react-native dependency pointing to the master repo it will fail when you pod install.