### PR TITLE
[IOS Objective-C] Can't set webview's background color on ios

### DIFF
--- a/React/Views/RCTWebView.m
+++ b/React/Views/RCTWebView.m
@@ -134,7 +134,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
 - (void)setBackgroundColor:(UIColor *)backgroundColor
 {
   CGFloat alpha = CGColorGetAlpha(backgroundColor.CGColor);
-  self.opaque = _webView.opaque = (alpha == 1.0);
+  self.opaque = _webView.opaque = NO;
   _webView.backgroundColor = backgroundColor;
 }
 

--- a/React/Views/RCTWebView.m
+++ b/React/Views/RCTWebView.m
@@ -133,7 +133,6 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
 
 - (void)setBackgroundColor:(UIColor *)backgroundColor
 {
-  CGFloat alpha = CGColorGetAlpha(backgroundColor.CGColor);
   self.opaque = _webView.opaque = NO;
   _webView.backgroundColor = backgroundColor;
 }

--- a/React/Views/RCTWebView.m
+++ b/React/Views/RCTWebView.m
@@ -133,7 +133,8 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
 
 - (void)setBackgroundColor:(UIColor *)backgroundColor
 {
-  self.opaque = _webView.opaque = NO;
+  const CGFloat *components = CGColorGetComponents(backgroundColor.CGColor);
+  self.opaque = _webView.opaque = (components[0] == 1.0);
   _webView.backgroundColor = backgroundColor;
 }
 


### PR DESCRIPTION
I encountered a problem that i couldn't set webview's background color on ios.
Here this the example:
https://rnplay.org/apps/s9gLdw

===========================================================

I think we do need set opaque to NO in RCTWebView.m to change the BackgroundColor of webview

http://stackoverflow.com/questions/2491654/how-to-control-the-color-of-a-uiwebview-before-contents-load
http://stackoverflow.com/questions/6605140/uiwebview-background-color