### PR TITLE
Fix asset path-traversal outside of roots

### DIFF
--- a/packager/react-packager/src/AssetServer/index.js
+++ b/packager/react-packager/src/AssetServer/index.js
@@ -129,16 +129,23 @@ class AssetServer {
   _findRoot(roots, dir) {
     return Promise.all(
       roots.map(root => {
-        const absPath = path.join(root, dir);
+        // important: we want to resolve root + dir
+        // to ensure the requested path doesn't traverse beyond root
+        const absPath = path.resolve(root, dir);
         return stat(absPath).then(fstat => {
-          return {path: absPath, isDirectory: fstat.isDirectory()};
+          // keep asset requests from traversing files
+          // up from the root (e.g. ../../../etc/hosts)
+          if (absPath.indexOf(root) != 0) {
+            return {path: absPath, isValid: false};
+          }
+          return {path: absPath, isValid: fstat.isDirectory()};
         }, err => {
-          return {path: absPath, isDirectory: false};
+          return {path: absPath, isValid: false};
         });
       })
     ).then(stats => {
       for (let i = 0; i < stats.length; i++) {
-        if (stats[i].isDirectory) {
+        if (stats[i].isValid) {
           return stats[i].path;
         }
       }

--- a/packager/react-packager/src/AssetServer/index.js
+++ b/packager/react-packager/src/AssetServer/index.js
@@ -135,7 +135,7 @@ class AssetServer {
         return stat(absPath).then(fstat => {
           // keep asset requests from traversing files
           // up from the root (e.g. ../../../etc/hosts)
-          if (absPath.indexOf(root) != 0) {
+          if (absPath.startsWith(root)) {
             return {path: absPath, isValid: false};
           }
           return {path: absPath, isValid: fstat.isDirectory()};


### PR DESCRIPTION
`/assets/...` requests previously supported path-traversal potentially exposing and serving (private) files outside roots.

**Test plan**

Prior to patching perform the a path-traversal request to the server:
```
GET /assets/../../../../etc/hosts HTTP/1.1
Cache-Control: no-store
Host: 127.0.0.1:8081
Connection: close
Accept-Encoding: gzip
User-Agent: okhttp/2.5.0
```

Apply patch and verify a `404` response with body: `Asset not found`

Test normal asset requests work.