### PR TITLE
Allow building UIExplorer with Buck

### DIFF
--- a/.buckconfig
+++ b/.buckconfig
@@ -7,3 +7,4 @@
 
 [alias]
   movies = //Examples/Movies/android/app:app
+  uiexplorer = //Examples/UIExplorer/android/app:app

--- a/Examples/Movies/README.md
+++ b/Examples/Movies/README.md
@@ -35,6 +35,21 @@ Open the Movies app in your emulator.
 
 See [Running on Device](https://facebook.github.io/react-native/docs/running-on-device-android.html) in case you want to use a physical device.
 
+### Running with Buck
+
+Follow the same setup as running with gradle.
+
+Install Buck from [here](https://buckbuild.com/setup/install.html).
+
+Run the following commands from the react-native folder:
+
+    ./gradlew :ReactAndroid:packageReactNdkLibsForBuck
+    buck fetch movies
+    buck install -r movies
+    ./packager/packager.sh
+
+_Note: The native libs are still built using gradle. Full build with buck is coming soon(tm)._
+
 ## Built from source
 
 Building the app on both iOS and Android means building the React Native framework from source. This way you're running the latest native and JS code the way you see it in your clone of the github repo.

--- a/Examples/Movies/android/app/src/main/AndroidManifest.xml
+++ b/Examples/Movies/android/app/src/main/AndroidManifest.xml
@@ -1,9 +1,15 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.facebook.react.movies">
+    package="com.facebook.react.movies"
+    android:versionCode="1"
+    android:versionName="1.0">
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
+
+    <uses-sdk
+      android:minSdkVersion="16"
+      android:targetSdkVersion="22" />
 
     <application
       android:allowBackup="true"

--- a/Examples/UIExplorer/README.md
+++ b/Examples/UIExplorer/README.md
@@ -35,6 +35,21 @@ Open the UIExplorer app in your emulator.
 
 See [Running on Device](https://facebook.github.io/react-native/docs/running-on-device-android.html) in case you want to use a physical device.
 
+### Running with Buck
+
+Follow the same setup as running with gradle.
+
+Install Buck from [here](https://buckbuild.com/setup/install.html).
+
+Run the following commands from the react-native folder:
+
+    ./gradlew :ReactAndroid:packageReactNdkLibsForBuck
+    buck fetch uiexplorer
+    buck install -r uiexplorer
+    ./packager/packager.sh
+
+_Note: The native libs are still built using gradle. Full build with buck is coming soon(tm)._
+
 ## Built from source
 
 Building the app on both iOS and Android means building the React Native framework from source. This way you're running the latest native and JS code the way you see it in your clone of the github repo.

--- a/Examples/UIExplorer/android/app/BUCK
+++ b/Examples/UIExplorer/android/app/BUCK
@@ -5,12 +5,12 @@ android_binary(
   manifest = 'src/main/AndroidManifest.xml',
   keystore = '//keystores:debug',
   deps = [
-    ':movies-lib',
+    ':uiexplorer-lib',
   ],
 )
 
 android_library(
-  name = 'movies-lib',
+  name = 'uiexplorer-lib',
   srcs = glob(['src/main/java/**/*.java']),
   deps = [
     react_native_target('java/com/facebook/react:react'),
@@ -27,5 +27,5 @@ android_library(
 android_resource(
   name = 'res',
   res = 'src/main/res',
-  package = 'com.facebook.react.movies',
+  package = 'com.facebook.react.uiapp',
 )

--- a/Examples/UIExplorer/android/app/src/main/AndroidManifest.xml
+++ b/Examples/UIExplorer/android/app/src/main/AndroidManifest.xml
@@ -1,12 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.facebook.react.uiapp" >
+<manifest
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  package="com.facebook.react.uiapp"
+  android:versionCode="1"
+  android:versionName="1.0">
 
   <uses-permission android:name="android.permission.INTERNET" />
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
   <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
   <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
   <uses-permission android:name="android.permission.VIBRATE"/>
+
+  <uses-sdk
+    android:minSdkVersion="16"
+    android:targetSdkVersion="22" />
 
   <application
       android:allowBackup="true"

--- a/ReactAndroid/src/main/third-party/android/support/v7/appcompat-orig/BUCK
+++ b/ReactAndroid/src/main/third-party/android/support/v7/appcompat-orig/BUCK
@@ -38,13 +38,13 @@ prebuilt_jar(
 
 genrule(
     name = 'classes-unpacker-cmd',
-    cmd = '$(exe :aar-unpacker) $(location :appcompat-binary-aar) "classes.jar" $OUT',
+    cmd = '$(exe :aar-unpacker) $(location :appcompat-binary-aar) classes.jar $OUT',
     out = 'classes.jar',
 )
 
 genrule(
     name = 'res-unpacker-cmd',
-    cmd = '$(exe :aar-unpacker) $(location :appcompat-binary-aar) "res/" $OUT',
+    cmd = '$(exe :aar-unpacker) $(location :appcompat-binary-aar) res/ $OUT',
     out = 'res',
     visibility = ['//ReactAndroid/...',],
 )


### PR DESCRIPTION
This adds a BUCK file to UIExplorer to allow building it with buck. It is based on the one in the movies app but I removed the extra deps that were not needed in both files. 

Also add build version number and target sdk version in the Android manifest so Buck can use it since it was only specified in the gradle build and caused the app to run on a super old target sdk.

@bestander @mkonicek Would it be simple to also build the ndk part with Buck? Right now it is built with gradle and packaged after. I suppose it is already being done internally at facebook. The BUCK files for building the cpp code are already there but I couldn't figure out what was missing to make it work :(

That is pretty much the only missing part to have first class support for building RN apps with Buck in OSS. We could eventually include BUCK files with the generated project.

**Test plan (required)**
Build and run UIExplorer and Movies examples using Buck.

Edited:
```
./gradlew ReactAndroid:packageReactNdkLibsForBuck

buck fetch movies
buck install -r movies

buck fetch uiexplorer
buck install -r uiexplorer
```