### PR TITLE
Removed eslint rule that checks modules

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -147,11 +147,6 @@
     "wrap-iife": 0,                  // require immediate function invocation to be wrapped in parentheses (off by default)
     "yoda": 1,                       // require or disallow Yoda conditions
 
-  // Strict Mode
-  // These rules relate to using strict mode.
-
-    "strict": [2, "never"],         // require or disallow the "use strict" pragma in the global scope (off by default in the node environment)
-
   // Variables
   // These rules have to do with variable declarations.
 

--- a/.eslintrc
+++ b/.eslintrc
@@ -150,7 +150,7 @@
   // Strict Mode
   // These rules relate to using strict mode.
 
-    "strict": [2, "global"],         // require or disallow the "use strict" pragma in the global scope (off by default in the node environment)
+    "strict": [2, "never"],         // require or disallow the "use strict" pragma in the global scope (off by default in the node environment)
 
   // Variables
   // These rules have to do with variable declarations.

--- a/Examples/UIExplorer/UIExplorerList.android.js
+++ b/Examples/UIExplorer/UIExplorerList.android.js
@@ -15,6 +15,8 @@
  */
 'use strict';
 
+const React = require('react-native');
+
 export type UIExplorerExample = {
   key: string;
   module: React.Component;


### PR DESCRIPTION
Removed eslint rule that checks modules

After we updated to ESLint 2.x, ESLint started complaining `'use strict' is unnecessary inside of modules  strict`.
This is correct behaviour because according to spec modules are strict.
The problem is that our transforms don't transpile strict mode so we still need to have this pragma in all our code.

I did not find a way to make eslint require "use strict" for ES6 modules: https://github.com/eslint/eslint/issues/2785
So I am removing this.

What stops us from automatically adding strict mode with babel?

Need your feedback, @frantic @martinbigio 
David said that you Martin looked into this.