### PR TITLE
Fix empty ScrollView warnings

### DIFF
--- a/React/Views/RCTScrollView.m
+++ b/React/Views/RCTScrollView.m
@@ -838,7 +838,10 @@ RCT_SCROLL_EVENT_HANDLER(scrollViewDidZoom, RCTScrollEventTypeMove)
   if (RCT_DEBUG) {
     // Validate that sticky headers are not out of range.
     NSUInteger subviewCount = _scrollView.contentView.reactSubviews.count;
-    NSUInteger lastIndex = _scrollView.stickyHeaderIndices.lastIndex;
+    NSUInteger lastIndex = NSNotFound;
+    if (_scrollView.stickyHeaderIndices != nil) {
+      lastIndex = _scrollView.stickyHeaderIndices.lastIndex;
+    }
     if (lastIndex != NSNotFound && lastIndex >= subviewCount) {
       RCTLogWarn(@"Sticky header index %zd was outside the range {0, %zd}",
                  lastIndex, subviewCount);


### PR DESCRIPTION
Currently, an empty `<ScrollView />` on iOS always throws the warning "Sticky header index 0 was outside the range {0, 0}".

This is because the error-reporting code relies on the assumption that `stickyHeaderIndices` exists, and when it doesn't the error check thinks there's an index when there really isn't.

Note that this only changes error reporting and won't affect apps out of debug mode.

**Test plan**
I created a sample app and included an empty `<ScrollView />`. Without this change the "Sticky header..." warning was displayed on every run through. With this change implemented, the warning went away.