### PR TITLE
Fixed CI stability: running android tests via emulator not graddle:co…

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -40,7 +40,7 @@ test:
     # starting emulator in advance because it takes very long to boot
     - $ANDROID_HOME/tools/emulator -avd testAVD -no-skin -no-audio -no-window:
             background: true
-    - waitForAVD
+    - source scripts/circle-ci-android-setup.sh && waitForAVD
 
   override:
     # build app

--- a/circle.yml
+++ b/circle.yml
@@ -40,7 +40,7 @@ test:
     # starting emulator in advance because it takes very long to boot
     - $ANDROID_HOME/tools/emulator -avd testAVD -no-skin -no-audio -no-window:
             background: true
-    - source scripts/circle-ci-android-setup.sh && waitForAVD
+    - waitForAVD
 
   override:
     # build app
@@ -52,20 +52,19 @@ test:
 
     # instrumentation tests
     # compile native libs with Gradle script
-    - ./gradlew :ReactAndroid:packageReactNdkLibsForBuck -PdisablePreDex -Pjobs=1:
+    - ./gradlew :ReactAndroid:packageReactNdkLibsForBuck -Pjobs=1:
         timeout: 360
     # build JS bundle for instrumentation tests
     - node local-cli/cli.js bundle --platform android --dev true --entry-file ReactAndroid/src/androidTest/assets/TestBundle.js --bundle-output ReactAndroid/src/androidTest/assets/AndroidTestBundle.js
     # build test APK
     - buck/bin/buck install ReactAndroid/src/androidTest/buck-runner:instrumentation-tests --config build.threads=1
     # run installed apk with tests
-    - retry ./scripts/run-android-instrumentation-tests.sh com.facebook.react.tests
+    - source scripts/circle-ci-android-setup.sh && retry3 ./scripts/run-android-instrumentation-tests.sh com.facebook.react.tests
 
     # Deprecated: run tests with Gradle, we keep them for a while to compare performance
-    - ./gradlew :ReactAndroid:testDebugUnitTest -PdisablePreDex
-    - adb uninstall com.facebook.react.tests
-    - ./gradlew :ReactAndroid:installDebugAndroidTest -PdisablePreDex
-    - retry ./scripts/run-android-instrumentation-tests.sh com.facebook.react.tests
+    - ./gradlew :ReactAndroid:testDebugUnitTest
+    - ./gradlew :ReactAndroid:installDebugAndroidTest
+    - source scripts/circle-ci-android-setup.sh && retry3 ./scripts/run-android-instrumentation-tests.sh com.facebook.react.tests.gradle
 
     # Publish to Sinopia, create a new app using 'react-native init' and check the packager starts
     - ./scripts/e2e-test.sh --packager

--- a/circle.yml
+++ b/circle.yml
@@ -63,8 +63,9 @@ test:
 
     # Deprecated: run tests with Gradle, we keep them for a while to compare performance
     - ./gradlew :ReactAndroid:testDebugUnitTest -PdisablePreDex
-    - ./gradlew :ReactAndroid:connectedAndroidTest -PdisablePreDex --stacktrace --info:
-        timeout: 360
+    - adb uninstall com.facebook.react.tests
+    - ./gradlew :ReactAndroid:installDebugAndroidTest -PdisablePreDex
+    - ./scripts/run-android-instrumentation-tests.sh com.facebook.react.tests
 
     # Publish to Sinopia, create a new app using 'react-native init' and check the packager starts
     - ./scripts/e2e-test.sh --packager

--- a/circle.yml
+++ b/circle.yml
@@ -59,13 +59,13 @@ test:
     # build test APK
     - buck/bin/buck install ReactAndroid/src/androidTest/buck-runner:instrumentation-tests --config build.threads=1
     # run installed apk with tests
-    - ./scripts/run-android-instrumentation-tests.sh com.facebook.react.tests
+    - retry ./scripts/run-android-instrumentation-tests.sh com.facebook.react.tests
 
     # Deprecated: run tests with Gradle, we keep them for a while to compare performance
     - ./gradlew :ReactAndroid:testDebugUnitTest -PdisablePreDex
     - adb uninstall com.facebook.react.tests
     - ./gradlew :ReactAndroid:installDebugAndroidTest -PdisablePreDex
-    - ./scripts/run-android-instrumentation-tests.sh com.facebook.react.tests
+    - retry ./scripts/run-android-instrumentation-tests.sh com.facebook.react.tests
 
     # Publish to Sinopia, create a new app using 'react-native init' and check the packager starts
     - ./scripts/e2e-test.sh --packager

--- a/scripts/circle-ci-android-setup.sh
+++ b/scripts/circle-ci-android-setup.sh
@@ -21,7 +21,7 @@ function waitForAVD {
   done
 }
 
-function retry {
+function retry3 {
   local n=1
   local max=3
   local delay=1

--- a/scripts/circle-ci-android-setup.sh
+++ b/scripts/circle-ci-android-setup.sh
@@ -20,3 +20,22 @@ function waitForAVD {
     echo "emulator status=$bootanim"
   done
 }
+
+function retry {
+  local n=1
+  local max=3
+  local delay=1
+  while true; do
+    "$@" && break || {
+      if [[ $n -lt $max ]]; then
+        ((n++))
+        echo "Command failed. Attempt $n/$max:"
+        sleep $delay;
+      else
+        echo "The command has failed after $n attempts." >&2
+        return 1
+      fi
+    }
+  done
+}
+


### PR DESCRIPTION
Running CI tests with emulator, not a graddle wrapper.
This should make things faster