### PR TITLE
Fix ImageEditingManager when no external cache

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/modules/camera/ImageEditingManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/camera/ImageEditingManager.java
@@ -485,7 +485,7 @@ public class ImageEditingManager extends ReactContextBaseJavaModule {
     File externalCacheDir = context.getExternalCacheDir();
     File internalCacheDir = context.getCacheDir();
     File cacheDir;
-    if (externalCacheDir == null && externalCacheDir == null) {
+    if (externalCacheDir == null && internalCacheDir == null) {
       throw new IOException("No cache directory available");
     }
     if (externalCacheDir == null) {


### PR DESCRIPTION
`externalCacheDir == null && externalCacheDir == null` is obviously a typo in existing code.