### PR TITLE
flowconfig adds flow/ folder

### DIFF
--- a/local-cli/generator-utils.js
+++ b/local-cli/generator-utils.js
@@ -19,7 +19,7 @@ function copyAndReplace(src, dest, replacements) {
   } else {
     var content = fs.readFileSync(src, 'utf8');
     Object.keys(replacements).forEach(function(regex) {
-      content = content.replace(new RegExp(regex, 'g'), replacements[regex]);
+      content = content.replace(new RegExp(regex, 'gm'), replacements[regex]);
     });
     fs.writeFileSync(dest, content);
   }

--- a/local-cli/generator/index.js
+++ b/local-cli/generator/index.js
@@ -50,7 +50,10 @@ module.exports = yeoman.generators.NamedBase.extend({
     utils.copyAndReplace(
       this.templatePath('../../../.flowconfig'),
       this.destinationPath('.flowconfig'),
-      { 'Libraries\/react-native\/react-native-interface.js' : 'node_modules/react-native/Libraries/react-native/react-native-interface.js' }
+      {
+        'Libraries\/react-native\/react-native-interface.js' : 'node_modules/react-native/Libraries/react-native/react-native-interface.js',
+        '^flow/$' : 'node_modules/react-native/flow\nflow/'
+      }
     );
 
     this.fs.copy(

--- a/package.json
+++ b/package.json
@@ -112,7 +112,8 @@
     "PATENTS",
     "README.md",
     "jestSupport",
-    ".flowconfig"
+    ".flowconfig",
+    "flow"
   ],
   "scripts": {
     "test": "NODE_ENV=test jest",


### PR DESCRIPTION
This change adds the `flow/` folder to the generated `.flowconfig` in new/upgraded projects. The absence of this folder was causing flow bugs to appear in projects consuming react-native that weren't visible in react-native itself. By including the same definition in consuming projects these errors disappear. Fixes https://github.com/facebook/react-native/issues/6428.

**Test plan (required)**

Tested `react-native upgrade` with this change and ensured that the generated `.flowconfig` works and didn't throw flow errors.