### PR TITLE
Fix issue #6300: Improve error message for unregistered callbacks.

### DIFF
--- a/Libraries/Utilities/MessageQueue.js
+++ b/Libraries/Utilities/MessageQueue.js
@@ -192,15 +192,17 @@ class MessageQueue {
     let debug = this._debugInfo[cbID >> 1];
     let module = debug && this._remoteModuleTable[debug[0]];
     let method = debug && this._remoteMethodTable[debug[0]][debug[1]];
-    let errorMessage = `Callback with id ${cbID}: ${module}.${method}() not found`;
-    if (method !== null || method !== undefined) {
-      errorMessage = `The callback ${method}() exists in module ${module}, `
-      + `but only one callback may be registered to a function in a native module.`;
+    if (!callback) {
+      let errorMessage = `Callback with id ${cbID}: ${module}.${method}() not found`;
+      if (method) {
+        errorMessage = `The callback ${method}() exists in module ${module}, `
+        + `but only one callback may be registered to a function in a native module.`;
+      }
+      invariant(
+        callback,
+        errorMessage
+      );
     }
-    invariant(
-      callback,
-      errorMessage
-    );
     let profileName = debug ? '<callback for ' + module + '.' + method + '>' : cbID;
     if (callback && SPY_MODE && __DEV__) {
       console.log('N->JS : ' + profileName + '(' + JSON.stringify(args) + ')');

--- a/Libraries/Utilities/MessageQueue.js
+++ b/Libraries/Utilities/MessageQueue.js
@@ -193,7 +193,7 @@ class MessageQueue {
     let module = debug && this._remoteModuleTable[debug[0]];
     let method = debug && this._remoteMethodTable[debug[0]][debug[1]];
     let errorMessage = `Callback with id ${cbID}: ${module}.${method}() not found`;
-    if (method != null || method != undefined) {
+    if (method !== null || method !== undefined) {
       errorMessage = `The callback ${method}() exists in module ${module}, `
       + `but only one callback may be registered to a function in a native module.`;
     }

--- a/Libraries/Utilities/MessageQueue.js
+++ b/Libraries/Utilities/MessageQueue.js
@@ -192,9 +192,14 @@ class MessageQueue {
     let debug = this._debugInfo[cbID >> 1];
     let module = debug && this._remoteModuleTable[debug[0]];
     let method = debug && this._remoteMethodTable[debug[0]][debug[1]];
+    let errorMessage = `Callback with id ${cbID}: ${module}.${method}() not found`;
+    if (method != null || method != undefined) {
+      errorMessage = `The callback ${method}() exists in module ${module}, `
+      + `but only one callback may be registered to a function in a native module.`;
+    }
     invariant(
       callback,
-      `Callback with id ${cbID}: ${module}.${method}() not found`
+      errorMessage
     );
     let profileName = debug ? '<callback for ' + module + '.' + method + '>' : cbID;
     if (callback && SPY_MODE && __DEV__) {

--- a/local-cli/server/util/attachHMRServer.js
+++ b/local-cli/server/util/attachHMRServer.js
@@ -292,7 +292,7 @@ function attachHMRServer({httpServer, path, packagerServer}) {
             () => {
               // do nothing, file was removed
             },
-          ).finally(() => {
+          ).then(() => {
             client.ws.send(JSON.stringify({type: 'update-done'}));
           });
         });


### PR DESCRIPTION
Fix for issue #6300:
Motivation: When more than one callback is registered to a native module, the error message that a user receives is not indicative of what is really happening.

Test Plan:
MessageQueue. __invokeCallback(cbID, args) will need tests added.

Will need to add appropriate mocks for this._remoteMethodTable to return null and undefined.

Will need to test the cases when debug && this._remoteMethodTable[debug[0]][debug[1]];
returns null, undefined, and a non-null value.

Finally, will need to ensure that invariant(callback, errorMessage) function is called with the appropriate parameters.

As of right now, the code does not have unit tests attached. I can add them later if needed.

Demonstrate the code is solid:
To fix this issue, I first reproduced the conditions of the following issue:
https://github.com/facebook/react-native/issues/6286

To do so, I used the Movies sample project.
After successfully reproducing the error, I then followed the stack trace to come to the appropriate fix.
I can post the code to reproduce the issue if needed. It is essentially the same as that of issue #6286.

Let me know if you have any questions or concerns.

Commit Message:
Fix for issue #6300.
This fix adds a more descriptive error message for the error case when
more than one callback is registered to a native function.