### PR TITLE
[ListView] Use function refs and support composed refs

### DIFF
--- a/package.json
+++ b/package.json
@@ -160,6 +160,7 @@
     "optimist": "^0.6.1",
     "progress": "^1.1.8",
     "promise": "^7.1.1",
+    "react-clone-referenced-element": "^1.0.1",
     "react-timer-mixin": "^0.13.2",
     "react-transform-hmr": "^1.0.4",
     "rebound": "^0.0.13",


### PR DESCRIPTION
Fixes an issue where if you implement `renderScrollComponent` and have a `ref` callback on the returned element, the ref used to be clobbered by the ref that ListView adds to the element.

This is accomplished by converting the ref from a legacy string-based ref to a callback-based ref, and then using `cloneReferencedElement`, which is a simple utility to compose callback refs.

Test Plan: Open the ListView examples in UIExplorer (iOS)