### PR TITLE
Fix #6410: Destroy reactInstanceManager only when no activity is usin…

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/ReactActivity.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactActivity.java
@@ -11,6 +11,7 @@ import android.widget.EditText;
 import android.widget.Toast;
 
 import com.facebook.common.logging.FLog;
+import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.common.ReactConstants;
 import com.facebook.react.modules.core.DefaultHardwareBackBtnHandler;
 
@@ -170,6 +171,14 @@ public abstract class ReactActivity extends Activity implements DefaultHardwareB
     super.onDestroy();
 
     if (mReactInstanceManager != null) {
+      // Destroy react instance manager only if the current activity is finishing or undefined
+      ReactContext currentReactContext = mReactInstanceManager.getCurrentReactContext();
+      if (currentReactContext != null &&
+          currentReactContext.hasCurrentActivity() &&
+          !currentReactContext.isCurrentActivityFinishing()) {
+        return;
+      }
+
       mReactInstanceManager.destroy();
     }
   }

--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactContext.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactContext.java
@@ -245,6 +245,12 @@ public class ReactContext extends ContextWrapper {
     return mCurrentActivity != null && mCurrentActivity.get() != null;
   }
 
+  public boolean isCurrentActivityFinishing() {
+    return mCurrentActivity != null &&
+           mCurrentActivity.get() != null &&
+           mCurrentActivity.get().isFinishing();
+  }
+
   /**
    * Same as {@link Activity#startActivityForResult(Intent, int)}, this just redirects the call to
    * the current activity. Returns whether the activity was started, as this might fail if this


### PR DESCRIPTION
It's possible to share a single instance of ReactInstanceManager across multiple activities where each activity extends the base ReactActivity. When a new react activity (`SecondActivity`) is launched, we use our singleton ReactInstanceManager to instantiate our react views and all is well. 
But, once the user navigates back to the previous activity (`MainActivity`) the second activity's `onDestroy` function is called **after** the first activity's `onResume`, thus our ReactInstanceManager is actually destroyed when we have running activities which require it.

```
03-10 10:46:10.043 10740-10740/com.awesomeproject V/RctActivity[MainActivity]: onCreate
03-10 10:46:10.101 10740-10740/com.awesomeproject V/RctActivity[MainActivity]: onStart
03-10 10:46:10.101 10740-10740/com.awesomeproject V/RctActivity[MainActivity]: onResume
// Opening second activity
03-10 10:46:48.320 10740-10740/com.awesomeproject V/RctActivity[MainActivity]: onPause
03-10 10:46:48.325 10740-10740/com.awesomeproject V/RctActivity[SecondActivity]: onCreate
03-10 10:46:48.328 10740-10740/com.awesomeproject V/RctActivity[SecondActivity]: onStart
03-10 10:46:48.328 10740-10740/com.awesomeproject V/RctActivity[SecondActivity]: onResume
03-10 10:46:48.771 10740-10740/com.awesomeproject V/RctActivity[MainActivity]: onStop
// Back button clicked
03-10 10:47:29.772 10740-10740/com.awesomeproject V/RctActivity[SecondActivity]: onPause
03-10 10:47:29.775 10740-10740/com.awesomeproject V/RctActivity[MainActivity]: onStart
03-10 10:47:29.775 10740-10740/com.awesomeproject V/RctActivity[MainActivity]: onResume
03-10 10:47:30.105 10740-10740/com.awesomeproject V/RctActivity[SecondActivity]: onStop
03-10 10:47:30.105 10740-10740/com.awesomeproject V/RctActivity[SecondActivity]: onDestroy
```

This PR simply adds a check to the `onDestroy` call of `ReactActivity` to see if the current react activity is finishing. If the activity is set and not finishing then don't destroy `mReactInstanceManager`




