### PR TITLE
Support CSS direction, flexDirection: *-reverse properties

### DIFF
--- a/Libraries/StyleSheet/LayoutPropTypes.js
+++ b/Libraries/StyleSheet/LayoutPropTypes.js
@@ -52,6 +52,11 @@ var LayoutPropTypes = {
   borderBottomWidth: ReactPropTypes.number,
   borderLeftWidth: ReactPropTypes.number,
 
+  direction: ReactPropTypes.oneOf([
+    'ltr',
+    'rtl'
+  ]),
+
   position: ReactPropTypes.oneOf([
     'absolute',
     'relative'
@@ -60,7 +65,9 @@ var LayoutPropTypes = {
   // https://developer.mozilla.org/en-US/docs/Web/CSS/flex-direction
   flexDirection: ReactPropTypes.oneOf([
     'row',
-    'column'
+    'row-reverse',
+    'column',
+    'column-reverse'
   ]),
 
   // https://developer.mozilla.org/en-US/docs/Web/CSS/flex-wrap

--- a/React/Base/RCTConvert.h
+++ b/React/Base/RCTConvert.h
@@ -116,6 +116,7 @@ typedef BOOL css_clip_t, css_backface_visibility_t;
 + (css_clip_t)css_clip_t:(id)json;
 + (css_backface_visibility_t)css_backface_visibility_t:(id)json;
 + (css_flex_direction_t)css_flex_direction_t:(id)json;
++ (css_direction_t)css_direction_t:(id)json;
 + (css_justify_t)css_justify_t:(id)json;
 + (css_align_t)css_align_t:(id)json;
 + (css_position_type_t)css_position_type_t:(id)json;

--- a/React/Base/RCTConvert.m
+++ b/React/Base/RCTConvert.m
@@ -797,9 +797,16 @@ RCT_ENUM_CONVERTER(css_clip_t, (@{
   @"visible": @NO
 }), NO, boolValue)
 
+RCT_ENUM_CONVERTER(css_direction_t, (@{
+  @"ltr": @(CSS_DIRECTION_LTR),
+  @"rtl": @(CSS_DIRECTION_RTL)
+}), CSS_DIRECTION_LTR, intValue)
+
 RCT_ENUM_CONVERTER(css_flex_direction_t, (@{
   @"row": @(CSS_FLEX_DIRECTION_ROW),
-  @"column": @(CSS_FLEX_DIRECTION_COLUMN)
+  @"row-reverse": @(CSS_FLEX_DIRECTION_ROW_REVERSE),
+  @"column": @(CSS_FLEX_DIRECTION_COLUMN),
+  @"column-reverse": @(CSS_FLEX_DIRECTION_COLUMN_REVERSE),
 }), CSS_FLEX_DIRECTION_COLUMN, intValue)
 
 RCT_ENUM_CONVERTER(css_justify_t, (@{

--- a/React/Views/RCTShadowView.h
+++ b/React/Views/RCTShadowView.h
@@ -124,6 +124,8 @@ typedef void (^RCTApplierBlock)(NSDictionary<NSNumber *, UIView *> *viewRegistry
 @property (nonatomic, assign) css_wrap_type_t flexWrap;
 @property (nonatomic, assign) CGFloat flex;
 
+@property (nonatomic, assign) css_direction_t direction;
+
 /**
  * Calculate property changes that need to be propagated to the view.
  * The applierBlocks set contains RCTApplierBlock functions that must be applied

--- a/React/Views/RCTShadowView.m
+++ b/React/Views/RCTShadowView.m
@@ -592,6 +592,7 @@ RCT_STYLE_PROPERTY(AlignSelf, alignSelf, align_self, css_align_t)
 RCT_STYLE_PROPERTY(AlignItems, alignItems, align_items, css_align_t)
 RCT_STYLE_PROPERTY(Position, position, position_type, css_position_type_t)
 RCT_STYLE_PROPERTY(FlexWrap, flexWrap, flex_wrap, css_wrap_type_t)
+RCT_STYLE_PROPERTY(Direction, direction, direction, css_direction_t)
 
 - (void)setBackgroundColor:(UIColor *)color
 {

--- a/React/Views/RCTViewManager.m
+++ b/React/Views/RCTViewManager.m
@@ -283,6 +283,7 @@ RCT_EXPORT_SHADOW_PROPERTY(justifyContent, css_justify_t)
 RCT_EXPORT_SHADOW_PROPERTY(alignItems, css_align_t)
 RCT_EXPORT_SHADOW_PROPERTY(alignSelf, css_align_t)
 RCT_EXPORT_SHADOW_PROPERTY(position, css_position_type_t)
+RCT_EXPORT_SHADOW_PROPERTY(direction, css_direction_t)
 
 RCT_EXPORT_SHADOW_PROPERTY(onLayout, RCTDirectEventBlock)
 


### PR DESCRIPTION
I was quite disappointed when I noticed that ``flexDirection: row-reversed`` is not supported. While a lot can be done to improve support for localizing an app into a RTL language (see also https://github.com/facebook/react-native/issues/2349), I consider "row-reversed" to be the minimum. Without it, the actual order of the elements returned from render() needs to be reversed, and that is messy and verbose.

I noticed css-layout already supports these properties. I also noticed it supports "direction", which would be even more helpful here.

``flex-direction: row-reversed`` works great. ``direction`` works well on the first render, but subsequent updates go astray. I tried hard to find the source of the issue, but I think I'm stuck. I was hoping someone could guide me along.

