### PR TITLE
Use setState rather than directly setting state in Navigator

### DIFF
--- a/Libraries/CustomComponents/Navigator/Navigator.js
+++ b/Libraries/CustomComponents/Navigator/Navigator.js
@@ -386,9 +386,11 @@ var Navigator = React.createClass({
       });
       return;
     }
-    this.state.transitionFromIndex = this.state.presentedIndex;
-    this.state.presentedIndex = destIndex;
-    this.state.transitionCb = cb;
+    this.setState({
+      transitionFromIndex: this.state.presentedIndex,
+      presentedIndex: destIndex,
+      transitionCb: cb,
+    });
     this._onAnimationStart();
     if (AnimationsDebugModule) {
       AnimationsDebugModule.startRecordingFps();


### PR DESCRIPTION
/CC @chirag04 

Otherwise code like this in NavigationBars sees stale values:

```js
    let { navState } = this.props;
    const route = navState.routeStack[navState.presentedIndex];
```