### PR TITLE
Fix red screen due to ref being undefined in PullRefreshViewAndroid

### DIFF
--- a/Libraries/PullToRefresh/PullToRefreshViewAndroid.android.js
+++ b/Libraries/PullToRefresh/PullToRefreshViewAndroid.android.js
@@ -67,7 +67,7 @@ var PullToRefreshViewAndroid = React.createClass({
   },
 
   setNativeProps: function(props) {
-    return this.refs[NATIVE_REF].setNativeProps(props);
+    return this.getInnerViewNode().setNativeProps(props);
   },
 
   render: function() {
@@ -88,7 +88,7 @@ var PullToRefreshViewAndroid = React.createClass({
 
   _onRefresh: function() {
     this.props.onRefresh && this.props.onRefresh();
-    this.refs[NATIVE_REF].setNativeProps({refreshing: !!this.props.refreshing});
+    this.getInnerViewNode() && this.setNativeProps({refreshing: !!this.props.refreshing});
   }
 });
 

--- a/Libraries/PullToRefresh/PullToRefreshViewAndroid.android.js
+++ b/Libraries/PullToRefresh/PullToRefreshViewAndroid.android.js
@@ -67,7 +67,8 @@ var PullToRefreshViewAndroid = React.createClass({
   },
 
   setNativeProps: function(props) {
-    return this.getInnerViewNode().setNativeProps(props);
+    let innerViewNode = this.getInnerViewNode();
+    return innerViewNode && innerViewNode.setNativeProps(props);
   },
 
   render: function() {
@@ -88,7 +89,7 @@ var PullToRefreshViewAndroid = React.createClass({
 
   _onRefresh: function() {
     this.props.onRefresh && this.props.onRefresh();
-    this.getInnerViewNode() && this.setNativeProps({refreshing: !!this.props.refreshing});
+    this.setNativeProps({refreshing: !!this.props.refreshing});
   }
 });
 


### PR DESCRIPTION
This fixes the error
`undefined is not an object (evaluating 'this.refs[NATIVE_REF].setNativeProps')`, which seems to occur when the refresh fails (in our case due to CORS).

![screen shot 2016-03-16 at 12 23 52](https://cloud.githubusercontent.com/assets/461514/13826121/1f8b0aaa-eb73-11e5-81e3-b2c60e536bf0.png)
