### PR TITLE
add instructions for testing website locally

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,11 +19,17 @@ The core team will be monitoring for pull requests. When we get one, we'll run s
 1. Fork the repo and create your branch from `master`.
 2. **Describe your test plan in your commit.** If you've added code that should be tested, add tests!
 3. If you've changed APIs, update the documentation.
-4. Add the copyright notice to the top of any new files you've added.
-5. Ensure tests pass on Travis and Circle CI.
-6. Make sure your code lints (`node linter.js <files touched>`).
-7. Squash your commits (`git rebase -i`).
-8. If you haven't already, sign the [CLA](https://code.facebook.com/cla).
+4. If you've updated the docs, verify the website locally and submit screenshots if applicable
+```
+$ cd website
+$ npm install && npm start
+go to: http://localhost:8079/react-native/index.html
+```
+5. Add the copyright notice to the top of any new files you've added.
+6. Ensure tests pass on Travis and Circle CI.
+7. Make sure your code lints (`node linter.js <files touched>`).
+8. Squash your commits (`git rebase -i`).
+9. If you haven't already, sign the [CLA](https://code.facebook.com/cla).
 
 #### Copyright Notice for files
 


### PR DESCRIPTION
Explain the **motivation** for making this change. What existing problem does the pull request solve?

> When @vjeux [asked me how the documentation changes looked](https://github.com/facebook/react-native/pull/6423#issuecomment-195608638), it wasn't obvious to me how to build and view them locally. So, I thought it might be a good idea to add instructions to the contributing document.

## Error Running Website Locally
I was able to run the website locally when working on PR #6423 but am no longer able to now. I have since updated my local repo with a `git pull`. I've deleted the node_modules directories in both the root and website folders, rebuilding both. Still, I get the following error when I run `npm start` within the website directory (problem with the ES2015 compiling?)...

```bash
**/react-native/website/server/convert.js:134
    .filter(key => key.startsWith('RN_'))
                ^^
SyntaxError: Unexpected token =>
    at exports.runInThisContext (vm.js:73:16)
    at Module._compile (module.js:443:25)
    at Object.Module._extensions..js (module.js:478:10)
    at Module.load (module.js:355:32)
    at Function.Module._load (module.js:310:12)
    at Module.require (module.js:365:17)
    at require (module.js:384:17)
    at Object.<anonymous> (/Users/ChrisGeirman/Dropbox/www/react-native-apps/production/react-native/website/server/server.js:16:15)
    at Module._compile (module.js:460:26)
    at Object.Module._extensions..js (module.js:478:10)**
```

## Side Note
I don't think the line about running linter.js is accurate anymore either. Looks like the signature should be `lint [flags] <project directories>` but I'm not absolutely sure, so I've not made that change. Please advise. 


