### PR TITLE
Update DependencyResolver

### DIFF
--- a/packager/react-packager/src/DependencyResolver/DependencyGraph/index.js
+++ b/packager/react-packager/src/DependencyResolver/DependencyGraph/index.js
@@ -57,7 +57,7 @@ class DependencyGraph {
       providesModuleNodeModules,
       platforms: platforms || [],
       preferNativePlatform: preferNativePlatform || false,
-      extensions: extensions || ['js', 'json'],
+      extensions: extensions || ['js', 'jsx', 'json'],
       mocksPattern,
       extractRequires,
       shouldThrowOnUnresolvedErrors,


### PR DESCRIPTION
Add 'jsx' to be default (?) supported extension.

This seems to fix a problem in my case for #4968 related issue.
Packager couldn't resolve .jsx file, imported relatively from index.js.