### PR TITLE
Update SegmentedControlIOS.ios.js

### DIFF
--- a/Libraries/Components/SegmentedControlIOS/SegmentedControlIOS.ios.js
+++ b/Libraries/Components/SegmentedControlIOS/SegmentedControlIOS.ios.js
@@ -43,7 +43,13 @@ var SegmentedControlIOS = React.createClass({
     values: PropTypes.arrayOf(PropTypes.string),
 
     /**
-     * The index in `props.values` of the segment to be pre-selected
+     * The index in `props.values` of the segment to be pre-selected.  
+     * This can also be set to a state variable in order to be able 
+     * to programmatically change the selected index. Note that the 
+     * state variable would then need to be updated using the 
+     * event.nativeEvent.selectedSegmentIndex value that is passed 
+     * to the onChange callback, in order to keep the two values
+     * synchronized.
      */
     selectedIndex: PropTypes.number,
 

--- a/Libraries/Components/SegmentedControlIOS/SegmentedControlIOS.ios.js
+++ b/Libraries/Components/SegmentedControlIOS/SegmentedControlIOS.ios.js
@@ -31,6 +31,23 @@ type Event = Object;
 
 /**
  * Use `SegmentedControlIOS` to render a UISegmentedControl iOS.
+ * 
+ * #### Programmatically changing selected index
+ * 
+ * The selected index can be changed by the fly by assigning the 
+ * selectIndex prop to a state variable, and changing that variable.  
+ * Note that the state variable would need to be updated as the user 
+ * selects a value and changes the index, as shown in the example below.
+ * 
+ * ````
+ * <SegmentedControlIOS
+ *   values={['One', 'Two']}
+ *   selectedIndex={this.state.selectedIndex}
+ *   onChange={(event) => {
+ *     this.setState({selectedIndex: event.nativeEvent.selectedSegmentIndex});
+ *   }}
+ * />
+ * ````
  */
 var SegmentedControlIOS = React.createClass({
   mixins: [NativeMethodsMixin],
@@ -43,13 +60,7 @@ var SegmentedControlIOS = React.createClass({
     values: PropTypes.arrayOf(PropTypes.string),
 
     /**
-     * The index in `props.values` of the segment to be pre-selected.  
-     * This can also be set to a state variable in order to be able 
-     * to programmatically change the selected index. Note that the 
-     * state variable would then need to be updated using the 
-     * event.nativeEvent.selectedSegmentIndex value that is passed 
-     * to the onChange callback, in order to keep the two values
-     * synchronized.
+     * The index in `props.values` of the segment to be selected.  
      */
     selectedIndex: PropTypes.number,
 

--- a/Libraries/Components/SegmentedControlIOS/SegmentedControlIOS.ios.js
+++ b/Libraries/Components/SegmentedControlIOS/SegmentedControlIOS.ios.js
@@ -60,7 +60,7 @@ var SegmentedControlIOS = React.createClass({
     values: PropTypes.arrayOf(PropTypes.string),
 
     /**
-     * The index in `props.values` of the segment to be selected.  
+     * The index in `props.values` of the segment to be (pre)selected.  
      */
     selectedIndex: PropTypes.number,
 

--- a/Libraries/Components/SegmentedControlIOS/SegmentedControlIOS.ios.js
+++ b/Libraries/Components/SegmentedControlIOS/SegmentedControlIOS.ios.js
@@ -31,14 +31,14 @@ type Event = Object;
 
 /**
  * Use `SegmentedControlIOS` to render a UISegmentedControl iOS.
- * 
+ *
  * #### Programmatically changing selected index
- * 
- * The selected index can be changed by the fly by assigning the 
- * selectIndex prop to a state variable, and changing that variable.  
- * Note that the state variable would need to be updated as the user 
+ *
+ * The selected index can be changed by the fly by assigning the
+ * selectIndex prop to a state variable, and changing that variable.
+ * Note that the state variable would need to be updated as the user
  * selects a value and changes the index, as shown in the example below.
- * 
+ *
  * ````
  * <SegmentedControlIOS
  *   values={['One', 'Two']}

--- a/Libraries/Components/SegmentedControlIOS/SegmentedControlIOS.ios.js
+++ b/Libraries/Components/SegmentedControlIOS/SegmentedControlIOS.ios.js
@@ -34,8 +34,8 @@ type Event = Object;
  *
  * #### Programmatically changing selected index
  *
- * The selected index can be changed by the fly by assigning the
- * selectIndex prop to a state variable, and changing that variable.
+ * The selected index can be changed on the fly by assigning the
+ * selectIndex prop to a state variable, then changing that variable.
  * Note that the state variable would need to be updated as the user
  * selects a value and changes the index, as shown in the example below.
  *


### PR DESCRIPTION
Updating the comments to clarify that the selectedIndex prop is not just for pre-selecting an index, but that it can also be used to programmatically change the value of the selected index.