### PR TITLE
Align inline images to baseline by default on Android

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/frescosupport/FrescoBasedReactTextInlineImageSpan.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/frescosupport/FrescoBasedReactTextInlineImageSpan.java
@@ -148,6 +148,9 @@ public class FrescoBasedReactTextInlineImageSpan extends TextInlineImageSpan {
 
     int transY = bottom - mDrawable.getBounds().bottom;
 
+    // Align to baseline by default
+    transY -= paint.getFontMetricsInt().descent;
+
     canvas.translate(x, transY);
     mDrawable.draw(canvas);
     canvas.restore();


### PR DESCRIPTION
Full discussion in FB group: https://www.facebook.com/groups/reactnativeoss/permalink/1532669803696315/

**Test plan**

In the following examples I use a different image than the one built in to UIExplorer because this one better demonstrates the alignment:

#### Before

![before](https://cloud.githubusercontent.com/assets/90494/13887933/c183e60e-ecfb-11e5-98cb-9c6d0104bb23.png)

#### After

![after](https://cloud.githubusercontent.com/assets/90494/13887937/c896eb76-ecfb-11e5-88fa-979a1ba62714.png)

#### iOS

![ios](https://cloud.githubusercontent.com/assets/90494/13888029/40b1f3ee-ecfc-11e5-9d71-1cfdf8213ec8.png)

If you want to try this for yourself, you can copy this into the inline image example:

```javascript
<Text style={{fontSize: 20}}>
  This text contains an inline image, look at it! <Image source={{uri: 'https://d3fzfeknznuaac.cloudfront.net/images4/open_list_plus_grey@2x.png'}} style={{height: 15, width: 15}} />. Neat, huh?
</Text>
```