### PR TITLE
Fix cli config file on Windows

### DIFF
--- a/local-cli/util/Config.js
+++ b/local-cli/util/Config.js
@@ -33,8 +33,7 @@ const Config = {
     const parentDir = findParentDirectory(cwd, RN_CLI_CONFIG);
     if (!parentDir && !defaultConfig) {
       throw new Error(
-        'Can\'t find "rn-cli.config.js" file in any parent folder of "' +
-        __dirname + '"'
+        `Can't find "rn-cli.config.js" file in any parent folder of "${__dirname}"`
       );
     }
 
@@ -63,7 +62,7 @@ function findParentDirectory(currentFullPath, filename) {
     return exists ? fullPath : testDir(parts.slice(0, -1));
   };
 
-  return testDir(currentFullPath.substring(1).split(path.sep));
+  return testDir(currentFullPath.substring(root.length).split(path.sep));
 }
 
 module.exports = Config;


### PR DESCRIPTION
The local-cli didn't pickup the `rn-cli.config.js` file on Windows because the root of a path is not 1 character long since it is 'C:/' and broke the path operations. This just substrings the root length instead of hard coding 1.

Also fix a lint warning in the file about path concatenation but using string interpolation.

Fixes  #5686

**Test plan (required)**

Tested that the `findParentDirectory` function returns the path of `rn-cli.config.js` if present or null if not on both windows and mac.