### PR TITLE
Fixed scrollResponder's scroll to keyboard for horizontal-scroll pagination enabled scroll views

### DIFF
--- a/Libraries/Components/ScrollResponder.js
+++ b/Libraries/Components/ScrollResponder.js
@@ -461,8 +461,13 @@ var ScrollResponderMixin = {
     if (this.preventNegativeScrollOffset) {
       scrollOffsetY = Math.max(0, scrollOffsetY);
     }
-    this.scrollResponderScrollTo({x: 0, y: scrollOffsetY, animated: true});
-
+   
+    //For horizontal scrolling enabled scroll views, current x position of the scroll view needs to be taken into account to
+    // preserve the horizontal scroll offset and prevent the scroll view from scrolling back.
+    ScrollViewManager.getScrollViewOrigin(React.findNodeHandle(this), (scrollOffsetX) => {
+      this.scrollResponderScrollTo({x: scrollOffsetX, y: scrollOffsetY, animated: true});
+    });
+    
     this.additionalOffset = 0;
     this.preventNegativeScrollOffset = false;
   },

--- a/React/Views/RCTScrollView.h
+++ b/React/Views/RCTScrollView.h
@@ -50,6 +50,7 @@
 @property (nonatomic, copy) RCTDirectEventBlock onRefreshStart;
 
 - (void)endRefreshing;
+- (CGPoint) getScrollViewOrigin;
 
 @end
 

--- a/React/Views/RCTScrollView.m
+++ b/React/Views/RCTScrollView.m
@@ -911,6 +911,11 @@ RCT_SET_AND_PRESERVE_OFFSET(setScrollIndicatorInsets, scrollIndicatorInsets, UIE
   [_scrollView.refreshControl endRefreshing];
 }
 
+- (CGPoint) getScrollViewOrigin
+{
+   return [_scrollView bounds].origin;
+};
+
 @end
 
 @implementation RCTEventDispatcher (RCTScrollView)

--- a/React/Views/RCTScrollViewManager.m
+++ b/React/Views/RCTScrollViewManager.m
@@ -161,6 +161,15 @@ RCT_EXPORT_METHOD(zoomToRect:(nonnull NSNumber *)reactTag
   }];
 }
 
+RCT_EXPORT_METHOD(getScrollViewOrigin: (NSNumber *)reactTag callback: (RCTResponseSenderBlock)callback)
+{
+   [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry){
+    RCTScrollView *scrollView = ( RCTScrollView* )viewRegistry[reactTag];
+    CGPoint origin = [scrollView getScrollViewOrigin];
+    callback(@[@(origin.x), @(origin.y)]);
+    }];
+}
+
 - (NSArray<NSString *> *)customDirectEventTypes
 {
   return @[


### PR DESCRIPTION
Motivation: Current implementation always assumes the x offset of the scroll view to be 0 and calculates only the y offset to scroll the view to keyboard. However, for horizontal scroll views, this forces the scroll view to jump back to 0 coordinate in the x direction and consequently hang. The fix addresses this bug.
