### PR TITLE
Note proper 0.22.0 release version in podspec

### DIFF
--- a/React.podspec
+++ b/React.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                = "React"
-  s.version             = "0.22.0-rc"
+  s.version             = "0.22.0"
   s.summary             = "Build high quality mobile apps using React."
   s.description         = <<-DESC
                             React Native apps are built using the React JS


### PR DESCRIPTION
With [the release of v0.22.0](https://github.com/facebook/react-native/releases/tag/v0.22.0), the [podspec was still pointed to a release candidate version](https://github.com/facebook/react-native/blob/2360c99d993578ac7124933a1553a75da0db5e42/React.podspec#L3). This should be updated to reflect the proper version number so people's `Podfile.lock` file pins to the stable release.