### PR TITLE
Added ability to build website per pull request

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -79,8 +79,6 @@ test:
     # Android e2e test
     - node ./scripts/run-ci-e2e-tests.js --android --js --retries 3
 
-    # testing docs generation is not broken
-    - cd website && node ./server/generate.js
   post:
     # copy test report for Circle CI to display
     - mkdir -p $CIRCLE_TEST_REPORTS/junit/

--- a/scripts/publish-npm.js
+++ b/scripts/publish-npm.js
@@ -50,10 +50,12 @@
 require(`shelljs/global`);
 
 const buildBranch = process.env.CIRCLE_BRANCH;
+const userName = process.env.CIRCLE_PROJECT_USERNAME;
+
 const requiredJavaVersion = `1.7`;
 
 let branchVersion;
-if (buildBranch.indexOf(`-stable`) !== -1) {
+if (buildBranch.indexOf(`-stable`) !== -1 && userName === `facebook`) {
   branchVersion = buildBranch.slice(0, buildBranch.indexOf(`-stable`));
 } else {
   echo(`Error: We publish only from stable branches`);

--- a/website/core/Site.js
+++ b/website/core/Site.js
@@ -15,10 +15,9 @@ var Metadata = require('Metadata');
 
 var Site = React.createClass({
   render: function() {
-    const path = Metadata.config.RN_DEPLOYMENT_PATH;
     const version = Metadata.config.RN_VERSION;
     const algoliaVersion = version === 'next' ? 'master' : version;
-    var basePath = '/react-native/' + (path ? path + '/' : '');
+    var basePath = Metadata.config.RN_DEPLOYMENT_PATH;
     var title = this.props.title ? this.props.title + ' – ' : '';
     var currentYear = (new Date()).getFullYear();
     title += 'React Native | A framework for building native apps using React';


### PR DESCRIPTION
This change allows building docs website for every pull request and deploys it to github.com/facebook/react-native-pr-docs gh-pages branch.

After CI runs all tests, it builds the website and pushes it to `facebook.github.io/react-native-pr-docs/releases/<pr-number>`.

Required for this to work:
- create repo github.com/facebook/react-native-pr-docs and allow reactjs-bot to push to it
- enable gh-pages feature for that repo

Further improvements:
- build a sciprt similar to bots/code-analysis-bot.js that posts a comment with link to website generated for this PR
- deploy website only if there are any changes compared to master branch