### PR TITLE
Instancify some static functions in `RCTAsyncLocalStorage`

### DIFF
--- a/React/Modules/RCTAsyncLocalStorage.h
+++ b/React/Modules/RCTAsyncLocalStorage.h
@@ -30,7 +30,4 @@
 // Clear the RCTAsyncLocalStorage data from native code
 - (void)clearAllData;
 
-// For clearing data when the bridge may not exist, e.g. when logging out.
-+ (void)clearAllData;
-
 @end

--- a/React/Modules/RCTAsyncLocalStorage.m
+++ b/React/Modules/RCTAsyncLocalStorage.m
@@ -153,6 +153,23 @@ static const NSUInteger RCTInlineValueThreshold = 1024;
 }
 
 static BOOL RCTHasCreatedStorageDirectory = NO;
+
+- (NSError *)_createStorageDirectory
+{
+  if (!RCTHasCreatedStorageDirectory) {
+    NSError *error = nil;
+    [[NSFileManager defaultManager] createDirectoryAtPath:[self _storageDirectory]
+                              withIntermediateDirectories:YES
+                                               attributes:nil
+                                                    error:&error];
+    if (error) {
+      return error;
+    }
+    RCTHasCreatedStorageDirectory = YES;
+  }
+  return nil;
+}
+
 - (NSDictionary *)_deleteStorageDirectory
 {
   NSError *error;
@@ -201,16 +218,9 @@ static BOOL RCTHasCreatedStorageDirectory = NO;
 {
   RCTAssertThread([self methodQueue], @"Must be executed on storage thread");
 
-  NSError *error = nil;
-  if (!RCTHasCreatedStorageDirectory) {
-    [[NSFileManager defaultManager] createDirectoryAtPath:[self _storageDirectory]
-                              withIntermediateDirectories:YES
-                                               attributes:nil
-                                                    error:&error];
-    if (error) {
-      return RCTMakeError(@"Failed to create storage directory.", error, nil);
-    }
-    RCTHasCreatedStorageDirectory = YES;
+  NSError *error = [self _createStorageDirectory];
+  if (error) {
+    return RCTMakeError(@"Failed to create storage directory.", error, nil);
   }
   if (!_haveSetup) {
     NSDictionary *errorOut;


### PR DESCRIPTION
RCTAsyncLocalStorage.m has some static C functions such as `RCTGetStorageDirectory()` that make functionality hard to override in a subclass of `RCTAsyncLocalStorage`. This commit turns them into instance methods, but retains the same instance-shared behavior of the method queue and cache. Subclasses of `RCTAsyncLocalStorage` are free to define their own instance-specific behavior (I have a case where I need this, which motivated the change).

As part of this change the `clearAllData` class method was removed to make it easier to move to instance methods (the instance `clearAllData` method still exists and retains the same functionality). I found that the class method used to be called before but no longer is (https://github.com/facebook/react-native/commit/86639450ee0f707d414ce4b6e18c82deca168752#diff-519938f6357ccdd2e47df33e6aebeb14L135 removed two class sends of this message, and grepping finds no references to `clearAllData` in the latest code).

Test plan: Ran AsyncLocalStorage integration test from UIExplorer, works!