### PR TITLE
Make react-native work with react v15 rc

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "react-native": "local-cli/wrong-react-native.js"
   },
   "peerDependencies": {
-    "react": "^0.14.5"
+    "react": "^0.14.5 || ^15.0.0-rc.1"
   },
   "dependencies": {
     "absolute-path": "^0.0.0",


### PR DESCRIPTION
React v15 rc is out. It's worth to provide early access for testing on v15.