### PR TITLE
Updated documentation of local notifications for PushNotificationIOS::addEventListener

### DIFF
--- a/Libraries/PushNotificationIOS/PushNotificationIOS.js
+++ b/Libraries/PushNotificationIOS/PushNotificationIOS.js
@@ -137,12 +137,14 @@ class PushNotificationIOS {
   }
 
   /**
-   * Attaches a listener to remote notification events while the app is running
+   * Attaches a listener to remote or local notification events while the app is running
    * in the foreground or the background.
    *
    * Valid events are:
    *
    * - `notification` : Fired when a remote notification is received. The
+   *   handler will be invoked with an instance of `PushNotificationIOS`.
+   * - `localNotification` : Fired when a local notification is received. The
    *   handler will be invoked with an instance of `PushNotificationIOS`.
    * - `register`: Fired when the user registers for remote notifications. The
    *   handler will be invoked with a hex string representing the deviceToken.

--- a/React/Base/RCTBatchedBridge.m
+++ b/React/Base/RCTBatchedBridge.m
@@ -162,7 +162,7 @@ RCT_EXTERN NSArray<Class> *RCTGetModuleClasses(void);
     });
   });
 
-  dispatch_group_notify(initModulesAndLoadSource, dispatch_get_main_queue(), ^{
+  dispatch_group_notify(initModulesAndLoadSource, bridgeQueue, ^{
     RCTBatchedBridge *strongSelf = weakSelf;
     if (sourceCode && strongSelf.loading) {
       [strongSelf executeSourceCode:sourceCode];

--- a/React/Views/UIView+React.m
+++ b/React/Views/UIView+React.m
@@ -27,7 +27,7 @@
   objc_setAssociatedObject(self, @selector(reactTag), reactTag, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }
 
-#if RCT_DEBUG
+#if RCT_DEV
 
 - (RCTShadowView *)_DEBUG_reactShadowView
 {

--- a/babel-preset/package.json
+++ b/babel-preset/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-preset-react-native",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "Babel preset for React Native applications",
   "main": "index.js",
   "repository": "https://github.com/facebook/react-native/tree/master/babel-preset",


### PR DESCRIPTION
I've updated the documentation of addEventListener, so it mentions the use of the 'localNotification' event.

<img width="1019" alt="screen shot 2016-03-22 at 08 09 15" src="https://cloud.githubusercontent.com/assets/1757473/13944408/6f85b3e8-f005-11e5-8ff7-5ee1e04761df.png">

**Test plan (required)**

See screenshot.
