### PR TITLE
Typo in NativeMethodsMixin.js

### DIFF
--- a/Libraries/ReactIOS/NativeMethodsMixin.js
+++ b/Libraries/ReactIOS/NativeMethodsMixin.js
@@ -94,7 +94,7 @@ var NativeMethodsMixin = {
    * Determines the location of the given view in the window and returns the
    * values via an async callback. If the React root view is embedded in
    * another native view, this will give you the absolute coordinates. If
-   * successful, the callback will be called be called with the following
+   * successful, the callback will be called with the following
    * arguments:
    *
    *  - x


### PR DESCRIPTION
Fixed a typo in NativeMethodsMixin.js

Before:
![before](https://cloud.githubusercontent.com/assets/6805530/13948549/a429c224-f046-11e5-903f-a04bd9eaa1b3.png)

After: 
![after](https://cloud.githubusercontent.com/assets/6805530/13948555/a9ba505a-f046-11e5-84fa-87f236aca486.png)

