### PR TITLE
Upgrade ndk-build to use gcc 4.9

### DIFF
--- a/ReactAndroid/src/main/jni/Application.mk
+++ b/ReactAndroid/src/main/jni/Application.mk
@@ -12,4 +12,4 @@ APP_STL := gnustl_shared
 # Make sure every shared lib includes a .note.gnu.build-id header
 APP_LDFLAGS := -Wl,--build-id
 
-NDK_TOOLCHAIN_VERSION := 4.8
+NDK_TOOLCHAIN_VERSION := 4.9

--- a/ReactAndroid/src/main/jni/react/Android.mk
+++ b/ReactAndroid/src/main/jni/react/Android.mk
@@ -20,9 +20,8 @@ LOCAL_CFLAGS := \
 
 LOCAL_LDLIBS += -landroid
 LOCAL_CFLAGS += -Wall -Werror -fexceptions -frtti
-CXX11_FLAGS := -std=c++11
-LOCAL_CFLAGS += $(CXX11_FLAGS)
-LOCAL_EXPORT_CPPFLAGS := $(CXX11_FLAGS)
+LOCAL_CPPFLAGS := -std=c++1y
+LOCAL_EXPORT_CPPFLAGS := $(LOCAL_CPPFLAGS)
 
 LOCAL_SHARED_LIBRARIES := libfb libfbjni libfolly_json libjsc libglog
 

--- a/ReactAndroid/src/main/jni/react/jni/Android.mk
+++ b/ReactAndroid/src/main/jni/react/jni/Android.mk
@@ -17,10 +17,9 @@ LOCAL_SRC_FILES := \
 
 LOCAL_C_INCLUDES := $(LOCAL_PATH)
 
-LOCAL_CFLAGS += -Wall -Werror -fvisibility=hidden -fexceptions -frtti
-CXX11_FLAGS := -std=c++11
-LOCAL_CFLAGS += $(CXX11_FLAGS)
-LOCAL_EXPORT_CPPFLAGS := $(CXX11_FLAGS)
+LOCAL_CFLAGS := -Wall -Werror -fvisibility=hidden -fexceptions -frtti
+LOCAL_CPPFLAGS := -std=c++1y
+LOCAL_EXPORT_CPPFLAGS := $(LOCAL_CPPFLAGS)
 
 LOCAL_LDLIBS += -landroid
 LOCAL_SHARED_LIBRARIES := libfolly_json libfbjni libjsc libglog_init


### PR DESCRIPTION
Recently released ndk-11b does no longer have gcc 4.8. In addition google does not provide links for older NDK version (one need to copy a link address to the most recent version and swap version part in the URL).

In order for the native code to work after upgrading to 4.9 I had to update c++ flags so that the sources are now compiled in c++1y standard - this is required as 4.9 doesn't allow 'lambda capture initializers' in c++11 standard (added recently to OnLoad.cpp and JSCExecutor.cpp).

**Test plan (required)**
Build all the stuff using gradle