### PR TITLE
[Android]Read applicationId from build.gradle instead of AndroidManifest.xml

### DIFF
--- a/local-cli/runAndroid/runAndroid.js
+++ b/local-cli/runAndroid/runAndroid.js
@@ -111,9 +111,9 @@ function buildAndRun(args, reject) {
 
   try {
     const packageName = fs.readFileSync(
-      'app/src/main/AndroidManifest.xml',
+      'app/build.gradle',
       'utf8'
-    ).match(/package="(.+?)"/)[1];
+    ).match(/applicationId "(.+?)"/)[1];
 
     const adbPath = process.env.ANDROID_HOME
       ? process.env.ANDROID_HOME + '/platform-tools/adb'


### PR DESCRIPTION
The package name of a android app is actually defined in `build.gradle` as `applicationId`. Currently `runAndroid.js` read package name from `AndroidManifest.xml`. After applicationId changed, `react-native run-android` will fail to start(or start wrong application).
