### PR TITLE
[DOCS] Updated documentation of local notifications for PushNotificationIOS addEventListener()

### DIFF
--- a/Libraries/PushNotificationIOS/PushNotificationIOS.js
+++ b/Libraries/PushNotificationIOS/PushNotificationIOS.js
@@ -137,12 +137,14 @@ class PushNotificationIOS {
   }
 
   /**
-   * Attaches a listener to remote notification events while the app is running
+   * Attaches a listener to remote or local notification events while the app is running
    * in the foreground or the background.
    *
    * Valid events are:
    *
    * - `notification` : Fired when a remote notification is received. The
+   *   handler will be invoked with an instance of `PushNotificationIOS`.
+   * - `localNotification` : Fired when a local notification is received. The
    *   handler will be invoked with an instance of `PushNotificationIOS`.
    * - `register`: Fired when the user registers for remote notifications. The
    *   handler will be invoked with a hex string representing the deviceToken.


### PR DESCRIPTION
I've updated the documentation of addEventListener, so it mentions the use of the 'localNotification' event. Which is currently not mentioned at all.

**Test plan (required)**
<img width="1019" alt="screen shot 2016-03-22 at 08 09 15" src="https://cloud.githubusercontent.com/assets/1757473/13963693/a47c0636-f066-11e5-859c-445a0f9d823c.png">




…