### PR TITLE
Fix fetching sourcemap in genymotion. Fixes #5338

### DIFF
--- a/Libraries/Utilities/HMRClient.js
+++ b/Libraries/Utilities/HMRClient.js
@@ -73,7 +73,6 @@ Error: ${e.message}`
     };
     activeWS.onmessage = ({data}) => {
       // Moving to top gives errors due to NativeModules not being initialized
-      const { AndroidConstants } = require('NativeModules');
       const HMRLoadingView = require('HMRLoadingView');
 
       data = JSON.parse(data);
@@ -99,12 +98,20 @@ Error: ${e.message}`
             RCTExceptionsManager && RCTExceptionsManager.dismissRedbox && RCTExceptionsManager.dismissRedbox();
           }
 
+          let serverHost;
+
+          if (Platform.OS === 'android') {
+            serverHost = require('NativeModules').AndroidConstants.ServerHost;
+          } else {
+            serverHost = port ? `${host}:${port}` : host;
+          }
+
           modules.forEach(({id, code}, i) => {
             code = code + '\n\n' + sourceMappingURLs[i];
 
             require('SourceMapsCache').fetch({
               text: code,
-              url: 'http://' + AndroidConstants.ServerHost + sourceURLs[i],
+              url: `http://${serverHost}${sourceURLs[i]}`,
               sourceMappingURL: sourceMappingURLs[i],
             });
 

--- a/Libraries/Utilities/HMRClient.js
+++ b/Libraries/Utilities/HMRClient.js
@@ -73,6 +73,7 @@ Error: ${e.message}`
     };
     activeWS.onmessage = ({data}) => {
       // Moving to top gives errors due to NativeModules not being initialized
+      const { AndroidConstants } = require('NativeModules');
       const HMRLoadingView = require('HMRLoadingView');
 
       data = JSON.parse(data);
@@ -103,7 +104,7 @@ Error: ${e.message}`
 
             require('SourceMapsCache').fetch({
               text: code,
-              url: sourceURLs[i],
+              url: 'http://' + AndroidConstants.ServerHost + sourceURLs[i],
               sourceMappingURL: sourceMappingURLs[i],
             });
 

--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/BUCK
@@ -9,6 +9,7 @@ android_library(
     react_native_target('java/com/facebook/react/bridge:bridge'),
     react_native_target('java/com/facebook/react/common:common'),
     react_native_target('java/com/facebook/react/modules/debug:debug'),
+    react_native_target('java/com/facebook/react/modules/systeminfo:systeminfo'),
     react_native_dep('libraries/fbcore/src/main/java/com/facebook/common/logging:logging'),
     react_native_dep('third-party/java/infer-annotations:infer-annotations'),
     react_native_dep('third-party/java/jsr-305:jsr-305'),

--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevServerHelper.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevServerHelper.java
@@ -10,7 +10,6 @@
 package com.facebook.react.devsupport;
 
 import android.content.Context;
-import android.os.Build;
 import android.os.Handler;
 import android.text.TextUtils;
 
@@ -18,6 +17,7 @@ import com.facebook.common.logging.FLog;
 import com.facebook.infer.annotation.Assertions;
 import com.facebook.react.bridge.UiThreadUtil;
 import com.facebook.react.common.ReactConstants;
+import com.facebook.react.modules.systeminfo.AndroidInfoHelpers;
 import com.squareup.okhttp.Call;
 import com.squareup.okhttp.Callback;
 import com.squareup.okhttp.ConnectionPool;
@@ -49,10 +49,6 @@ public class DevServerHelper {
 
   public static final String RELOAD_APP_EXTRA_JS_PROXY = "jsproxy";
   private static final String RELOAD_APP_ACTION_SUFFIX = ".RELOAD_APP_ACTION";
-
-  private static final String EMULATOR_LOCALHOST = "10.0.2.2:8081";
-  private static final String GENYMOTION_LOCALHOST = "10.0.3.2:8081";
-  private static final String DEVICE_LOCALHOST = "localhost:8081";
 
   private static final String BUNDLE_URL_FORMAT =
       "http://%s/%s.bundle?platform=android&dev=%s&hot=%s&minify=%s";
@@ -109,21 +105,6 @@ public class DevServerHelper {
     return context.getPackageName() + RELOAD_APP_ACTION_SUFFIX;
   }
 
-  public static String getServerHost() {
-    // Since genymotion runs in vbox it use different hostname to refer to adb host.
-    // We detect whether app runs on genymotion and replace js bundle server hostname accordingly
-
-    if (isRunningOnGenymotion()) {
-      return GENYMOTION_LOCALHOST;
-    }
-
-    if (isRunningOnStockEmulator()) {
-      return EMULATOR_LOCALHOST;
-    }
-
-    return DEVICE_LOCALHOST;
-  }
-
   public String getWebsocketProxyURL() {
     return String.format(Locale.US, WEBSOCKET_PROXY_URL_FORMAT, getDebugServerHost());
   }
@@ -132,7 +113,7 @@ public class DevServerHelper {
    * @return the host to use when connecting to the bundle server from the host itself.
    */
   private static String getHostForJSProxy() {
-    return DEVICE_LOCALHOST;
+    return AndroidInfoHelpers.DEVICE_LOCALHOST;
   }
 
   /**
@@ -168,9 +149,9 @@ public class DevServerHelper {
       return Assertions.assertNotNull(hostFromSettings);
     }
 
-    String host = DevServerHelper.getServerHost();
+    String host = AndroidInfoHelpers.getServerHost();
 
-    if (host.equals(DEVICE_LOCALHOST)) {
+    if (host.equals(AndroidInfoHelpers.DEVICE_LOCALHOST)) {
       FLog.w(
         ReactConstants.TAG,
         "You seem to be running on device. Run 'adb reverse tcp:8081 tcp:8081' " +
@@ -178,14 +159,6 @@ public class DevServerHelper {
     }
 
     return host;
-  }
-
-  private static boolean isRunningOnGenymotion() {
-    return Build.FINGERPRINT.contains("vbox");
-  }
-
-  private static boolean isRunningOnStockEmulator() {
-    return Build.FINGERPRINT.contains("generic");
   }
 
   private static String createBundleURL(String host, String jsModulePath, boolean devMode, boolean hmr, boolean jsMinify) {

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/systeminfo/AndroidInfoHelpers.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/systeminfo/AndroidInfoHelpers.java
@@ -1,0 +1,33 @@
+package com.facebook.react.modules.systeminfo;
+
+import android.os.Build;
+
+public class AndroidInfoHelpers {
+
+  public static final String EMULATOR_LOCALHOST = "10.0.2.2:8081";
+  public static final String GENYMOTION_LOCALHOST = "10.0.3.2:8081";
+  public static final String DEVICE_LOCALHOST = "localhost:8081";
+
+  private static boolean isRunningOnGenymotion() {
+    return Build.FINGERPRINT.contains("vbox");
+  }
+
+  private static boolean isRunningOnStockEmulator() {
+    return Build.FINGERPRINT.contains("generic");
+  }
+
+  public static String getServerHost() {
+    // Since genymotion runs in vbox it use different hostname to refer to adb host.
+    // We detect whether app runs on genymotion and replace js bundle server hostname accordingly
+
+    if (isRunningOnGenymotion()) {
+      return GENYMOTION_LOCALHOST;
+    }
+
+    if (isRunningOnStockEmulator()) {
+      return EMULATOR_LOCALHOST;
+    }
+
+    return DEVICE_LOCALHOST;
+  }
+}

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/systeminfo/AndroidInfoModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/systeminfo/AndroidInfoModule.java
@@ -33,7 +33,7 @@ public class AndroidInfoModule extends BaseJavaModule {
   public @Nullable Map<String, Object> getConstants() {
     HashMap<String, Object> constants = new HashMap<String, Object>();
     constants.put("Version", Build.VERSION.SDK_INT);
-    constants.put("ServerHost", DevServerHelper.getServerHost());
+    constants.put("ServerHost", AndroidInfoHelpers.getServerHost());
     return constants;
   }
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/systeminfo/AndroidInfoModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/systeminfo/AndroidInfoModule.java
@@ -12,7 +12,6 @@ package com.facebook.react.modules.systeminfo;
 import android.os.Build;
 
 import com.facebook.react.bridge.BaseJavaModule;
-import com.facebook.react.devsupport.DevServerHelper;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/systeminfo/AndroidInfoModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/systeminfo/AndroidInfoModule.java
@@ -9,14 +9,15 @@
 
 package com.facebook.react.modules.systeminfo;
 
-import javax.annotation.Nullable;
+import android.os.Build;
+
+import com.facebook.react.bridge.BaseJavaModule;
+import com.facebook.react.devsupport.DevServerHelper;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import android.os.Build;
-
-import com.facebook.react.bridge.BaseJavaModule;
+import javax.annotation.Nullable;
 
 /**
  * Module that exposes Android Constants to JS.
@@ -32,6 +33,7 @@ public class AndroidInfoModule extends BaseJavaModule {
   public @Nullable Map<String, Object> getConstants() {
     HashMap<String, Object> constants = new HashMap<String, Object>();
     constants.put("Version", Build.VERSION.SDK_INT);
+    constants.put("ServerHost", DevServerHelper.getServerHost());
     return constants;
   }
 }

--- a/packager/react-packager/src/Bundler/index.js
+++ b/packager/react-packager/src/Bundler/index.js
@@ -170,9 +170,9 @@ class Bundler {
     });
   }
 
-  _sourceHMRURL(platform, host, port, path) {
+  _sourceHMRURL(platform, path) {
     return this._hmrURL(
-      `http://${host}:${port}`,
+      '',
       platform,
       'bundle',
       path,
@@ -217,7 +217,7 @@ class Bundler {
     return this._bundle({
       ...options,
       bundle: new HMRBundle({
-        sourceURLFn: this._sourceHMRURL.bind(this, options.platform, host, port),
+        sourceURLFn: this._sourceHMRURL.bind(this, options.platform),
         sourceMappingURLFn: this._sourceMappingHMRURL.bind(
           this,
           options.platform,


### PR DESCRIPTION
Source maps are broken on Genymotion right now as they aren't being loaded from the correct URL. refer - https://github.com/facebook/react-native/issues/5338#issuecomment-188232402

**Test plan**

Build and install UIExplorer from master branch in genymotion and enable hot reload. When you change a file and save it, you'll see a Yellow box due to source map fetching failed, as per the referenced comment.

Doing the same for this branch doesn't produce any yellow boxes.