### PR TITLE
[Test Stability] Retry e2e test consistently

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ script:
   - if [[ "$TEST_TYPE" = e2e-objc ]]; then travis_retry ./scripts/e2e-test.sh --ios; fi
   - if [[ "$TEST_TYPE" = js ]]; then npm run flow check; fi
   - if [[ "$TEST_TYPE" = js ]]; then npm test -- --maxWorkers=1; fi
-  - if [[ "$TEST_TYPE" = js ]]; then ./scripts/e2e-test.sh --packager; fi
+  - if [[ "$TEST_TYPE" = js ]]; then travis_retry ./scripts/e2e-test.sh --packager; fi
 
 env:
   matrix:


### PR DESCRIPTION
Travis tests have been flaky recently:
https://travis-ci.org/facebook/react-native/builds

Clicking through the last 10 failures, 8 of them are caused by the `npm install` flakiness in the `./e2e-test.sh --packager`. This test works in a very similar way to the iOS e2e test which we retry (see line 18). Let's be consistent.

All the random errors are 404s during `npm install` through Sinopia:

![screen shot 2016-03-23 at 10 33 39 am](https://cloud.githubusercontent.com/assets/346214/13982618/07f338f2-f0e3-11e5-97ad-e887cb46bede.png)

JS tests are more stable (saw 1 random failure but likely the test can be fixed), let's not retry them just yet:

![screen shot 2016-03-23 at 10 33 27 am](https://cloud.githubusercontent.com/assets/346214/13982648/26f46820-f0e3-11e5-8d56-c770549b9275.png)

**Test plan (required)**

Travis tests on this pull request.
