### PR TITLE
Improve display of error in debugger console

### DIFF
--- a/Libraries/JavaScriptAppEngine/Initialization/ExceptionsManager.js
+++ b/Libraries/JavaScriptAppEngine/Initialization/ExceptionsManager.js
@@ -14,6 +14,16 @@
 let exceptionID = 0;
 
 /**
+ * Creates a error stack from the prettyStack array
+ */
+function generateStackTrace(prettyStack) {
+  return prettyStack.map(line => (
+    '    at ' + line.methodName +
+    ' (http://localhost:8081' + line.file + ':' + line.lineNumber + ':' + line.column + ')'
+  )).join('\n');
+}
+
+/**
  * Handles the developer-visible aspect of errors and exceptions
  */
 function reportException(e: Error, isFatal: bool) {
@@ -29,13 +39,16 @@ function reportException(e: Error, isFatal: bool) {
       RCTExceptionsManager.reportSoftException(e.message, stack, currentExceptionID);
     }
     if (__DEV__) {
-      require('SourceMapsCache').getSourceMaps().then(sourceMaps => {
+      require('SourceMapsCache').getSourceMaps()
+      .then(sourceMaps => {
         const prettyStack = parseErrorStack(e, sourceMaps);
         RCTExceptionsManager.updateExceptionMessage(
           e.message,
           prettyStack,
           currentExceptionID,
         );
+
+        e.stack = generateStackTrace(prettyStack);
       })
       .catch(error => {
         // This can happen in a variety of normal situations, such as
@@ -58,8 +71,9 @@ function handleException(e: Error, isFatal: boolean) {
     e = new Error(e);
   }
 
-  (console._errorOriginal || console.error)(e.message);
   reportException(e, isFatal);
+
+  (console._errorOriginal || console.error)(e);
 }
 
 /**

--- a/Libraries/JavaScriptAppEngine/Initialization/ExceptionsManager.js
+++ b/Libraries/JavaScriptAppEngine/Initialization/ExceptionsManager.js
@@ -54,7 +54,8 @@ function reportException(e: Error, isFatal: bool) {
         // This can happen in a variety of normal situations, such as
         // Network module not being available, or when running locally
         console.warn('Unable to load source map: ' + error.message);
-      });
+      })
+      .then(() => (console._errorOriginal || console.error)(e));
     }
   }
 }
@@ -71,9 +72,8 @@ function handleException(e: Error, isFatal: boolean) {
     e = new Error(e);
   }
 
+  console.log('%cError: ' + e.message + '%c (Loading sourcemaps…)', 'color: #F00;', 'color: #000');
   reportException(e, isFatal);
-
-  (console._errorOriginal || console.error)(e);
 }
 
 /**

--- a/Libraries/JavaScriptAppEngine/Initialization/SourceMapsUtils.js
+++ b/Libraries/JavaScriptAppEngine/Initialization/SourceMapsUtils.js
@@ -72,9 +72,9 @@ var SourceMapsUtils = {
       .then(SourceMapsUtils.extractSourceMapURL)
       .then((url) => {
         if (url === null) {
-          return Promise.reject(new Error('No source map URL found. May be running from bundled file.'));
+          throw new Error('No source map URL found. May be running from bundled file.');
         }
-        return Promise.resolve(url);
+        return url;
       });
   },
 };


### PR DESCRIPTION
The error message in chrome debugger are useless right now. As you cannot get any useful info from them except the error message. Ideally it should contain the proper stack trace with source maps to actually be useful.

Currently, the only alternative is, find the file name and line number on phone, and then open the corresponding file in the sources panel, then scroll to the lines number, as opposed to clicking a link on the console and directly going to the file.

I've been looking into how to do it. And would really like your thoughts on how to achieve it.

1. We can forget sourcemaps, and just log the error object with `console.error(e)` instead of how we're doing it right now, i.e. - `console.error(e.message)`. Doing this will help in jumping to the line in the bundle much easier. Even if sourcemaps are not there, you quickly get the idea of where the error came from, and adding breakpoints in the transformed source. Even if it's worse than sourcemaps, it's pretty convenient.

2. We can compromise a bit, and show a `console.log` instead of actual error (the stack trace is not useful anyways), and then log the actual error as soon as source maps arrive. This PR implements that currently.

![react native debugger google chrome today at 2 42 13 am](https://cloud.githubusercontent.com/assets/1174278/14001108/75695b0a-f16a-11e5-9dbd-3c272ce51100.png)

This is how it looks in the console, which I think is eons better than what we currently have.

**Caveats:** Currently there seems to be bug in master where the sourcemap is not loaded until you  interact with app. Also the parser we're using for getting the stacktraces from sourcemaps right now doesn't seem to give column numbers.

Would love your thoughts and ideas on how to improve this. I believe debugging should be as easy as possible.
