### PR TITLE
Fixed an issue where the title in NavigationExperimentalHeader would block touches for the left component

### DIFF
--- a/Libraries/CustomComponents/NavigationExperimental/NavigationHeader.js
+++ b/Libraries/CustomComponents/NavigationExperimental/NavigationHeader.js
@@ -183,7 +183,7 @@ class NavigationHeader extends React.Component<DefaultProps, Props, any> {
       return null;
     }
 
-    const pointerEvents = offset !== 0 || isStale ? 'none' : 'auto';
+    const pointerEvents = offset !== 0 || isStale ? 'none' : 'box-none';
     return (
       <Animated.View
         pointerEvents={pointerEvents}


### PR DESCRIPTION
There was an issue where the title component could overlap the left component and it would block the left component from receiving touches.

I only stumbled across this because we have a default title component which stretches most of the width and it was covering the edge of the left component. I think left/right components are more likely to be actionable than the title component so they should take priority in the touch order (ie. be rendered last).