### PR TITLE
Don't strip NativeRunnable constructor. Fixes #6624

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/queue/NativeRunnable.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/queue/NativeRunnable.java
@@ -20,6 +20,7 @@ public class NativeRunnable implements Runnable {
 
   private final HybridData mHybridData;
 
+  @DoNotStrip
   private NativeRunnable(HybridData hybridData) {
     mHybridData = hybridData;
   }


### PR DESCRIPTION
Fixes proguard in RN 0.22.+. Closes #6624