### PR TITLE
Add default render loading on Android WebView

### DIFF
--- a/Libraries/Components/WebView/WebView.android.js
+++ b/Libraries/Components/WebView/WebView.android.js
@@ -11,6 +11,7 @@
 'use strict';
 
 var EdgeInsetsPropType = require('EdgeInsetsPropType');
+var ProgressBarAndroid = require('ProgressBarAndroid');
 var React = require('React');
 var ReactNativeViewAttributes = require('ReactNativeViewAttributes');
 var StyleSheet = require('StyleSheet');
@@ -32,6 +33,15 @@ var WebViewState = keyMirror({
   LOADING: null,
   ERROR: null,
 });
+
+var defaultRenderLoading = () => (
+  <View style={styles.loadingView}>
+    <ProgressBarAndroid
+      style={styles.loadingProgressBar}
+      styleAttr="Inverse"
+    />
+  </View>
+);
 
 /**
  * Renders a native WebView.
@@ -170,7 +180,7 @@ var WebView = React.createClass({
     var otherView = null;
 
    if (this.state.viewState === WebViewState.LOADING) {
-      otherView = this.props.renderLoading && this.props.renderLoading();
+      otherView = (this.props.renderLoading || defaultRenderLoading)();
     } else if (this.state.viewState === WebViewState.ERROR) {
       var errorEvent = this.state.lastErrorEvent;
       otherView = this.props.renderError && this.props.renderError(
@@ -306,6 +316,14 @@ var styles = StyleSheet.create({
   hidden: {
     height: 0,
     flex: 0, // disable 'flex:1' when hiding a View
+  },
+  loadingView: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  loadingProgressBar: {
+    height: 20,
   },
 });
 


### PR DESCRIPTION
I just noticed that Android WebView do not have a render loading default like iOS, so I added one.

**Test plan**

I used WebView without renderLoading on Android.

![image](https://cloud.githubusercontent.com/assets/7189823/14028408/bd94c83e-f1d2-11e5-8791-3372684b429e.png)

