### PR TITLE
Improve consistency of NavigationCardStack animations.

### DIFF
--- a/Libraries/CustomComponents/NavigationExperimental/NavigationCardStack.js
+++ b/Libraries/CustomComponents/NavigationExperimental/NavigationCardStack.js
@@ -50,7 +50,6 @@ const {Directions} = NavigationCardStackPanResponder;
 
 import type {
   NavigationAnimatedValue,
-  NavigationAnimationSetter,
   NavigationParentState,
   NavigationSceneRenderer,
   NavigationSceneRendererProps,

--- a/Libraries/CustomComponents/NavigationExperimental/NavigationCardStack.js
+++ b/Libraries/CustomComponents/NavigationExperimental/NavigationCardStack.js
@@ -94,7 +94,6 @@ const defaultProps = {
  *     +------------+
  */
 class NavigationCardStack extends React.Component {
-  _applyAnimation: NavigationAnimationSetter;
   _renderScene : NavigationSceneRenderer;
 
   constructor(props: Props, context: any) {
@@ -102,7 +101,6 @@ class NavigationCardStack extends React.Component {
   }
 
   componentWillMount(): void {
-    this._applyAnimation = this._applyAnimation.bind(this);
     this._renderScene = this._renderScene.bind(this);
   }
 
@@ -120,7 +118,6 @@ class NavigationCardStack extends React.Component {
         navigationState={this.props.navigationState}
         renderOverlay={this.props.renderOverlay}
         renderScene={this._renderScene}
-        applyAnimation={this._applyAnimation}
         style={[styles.animatedView, this.props.style]}
       />
     );
@@ -146,19 +143,6 @@ class NavigationCardStack extends React.Component {
         style={style}
       />
     );
-  }
-
-  _applyAnimation(
-    position: NavigationAnimatedValue,
-    navigationState: NavigationParentState,
-  ): void {
-    Animated.timing(
-      position,
-      {
-        duration: 500,
-        toValue: navigationState.index,
-      }
-    ).start();
   }
 }
 


### PR DESCRIPTION
Currently there’s an inconsistency between the animations used in `NavigationAnimatedView` (`spring`) and those in `NavigationCardStack` (`timing`), which is noticeable when switching between the two implementations.

By removing the `_applyAnimation` method, the `NavigationAnimatedView` will simply use its [default `applyAnimation`](https://github.com/facebook/react-native/blob/6c22a2174e733d536a12f47a2da4f84329ac3023/Libraries/NavigationExperimental/NavigationAnimatedView.js#L56-L67), making the animation styles the same.

**Before** (with `Animated.timing`)
Video: http://quick.as/Yexku8DdJ

**After** (with the default `NavigationAnimatedView` animations)
Video: http://quick.as/qrqbsnj8n
