### PR TITLE
Fix issue #6647 : The horizontal orientation problem .

### DIFF
--- a/React/Views/RCTModalHostViewController.m
+++ b/React/Views/RCTModalHostViewController.m
@@ -26,12 +26,7 @@
 
 - (UIInterfaceOrientationMask)supportedInterfaceOrientations
 {
-  // Picking some defaults here, we should probably make this configurable
-  if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad) {
-    return UIInterfaceOrientationMaskAll;
-  } else {
-    return UIInterfaceOrientationMaskPortrait;
-  }
+  return UIInterfaceOrientationMaskAll;
 }
 
 @end


### PR DESCRIPTION
**motivation**
Fix degradation.
This issue is not able to use landscape only setting on iPhone device.
There are not any problems before upgrading to 0.22 from 0.21.

** Circle CI **
https://circleci.com/gh/tasiyo7333/react-native/6

**Test plan (required)**

1. Create a project by ‘react-native init’. 
2. Test the below cases manually  

Xcode’s Device Orientation setting.
case 1 : 
   portrait : on
   landscape left : on
   landscape right: on

case 2 : 
   portrait : off
   landscape left : on
   landscape right: on

case 2 : 
   portrait : off
   landscape left : off
   landscape right: on

case 3 : 
   portrait : off
   landscape left : on
   landscape right: off