### PR TITLE
Implement TextInput.clearTextOnFocus for Android

### DIFF
--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -279,11 +279,11 @@ var TextInput = React.createClass({
     ]),
     /**
      * If true, clears the text field automatically when editing begins
-     * @platform ios
      */
     clearTextOnFocus: PropTypes.bool,
     /**
      * If true, all text will automatically be selected on focus
+     * @platform ios
      */
     selectTextOnFocus: PropTypes.bool,
     /**

--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -284,7 +284,6 @@ var TextInput = React.createClass({
     clearTextOnFocus: PropTypes.bool,
     /**
      * If true, all text will automatically be selected on focus
-     * @platform ios
      */
     selectTextOnFocus: PropTypes.bool,
     /**
@@ -524,6 +523,7 @@ var TextInput = React.createClass({
         underlineColorAndroid={this.props.underlineColorAndroid}
         children={children}
         editable={this.props.editable}
+        clearTextOnFocus={this.props.clearTextOnFocus}
       />;
 
     return (

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
@@ -68,6 +68,7 @@ public class ReactEditText extends EditText {
   private int mStagedInputType;
   private boolean mContainsImages;
   private boolean mBlurOnSubmit;
+  private boolean mClearTextOnFocus;
   private @Nullable SelectionWatcher mSelectionWatcher;
   private final InternalKeyListener mKeyListener;
 
@@ -86,6 +87,7 @@ public class ReactEditText extends EditText {
     mIsSettingTextFromJS = false;
     mIsJSSettingFocus = false;
     mBlurOnSubmit = true;
+    mClearTextOnFocus = false;
     mListeners = null;
     mTextWatcherDelegator = null;
     mStagedInputType = getInputType();
@@ -172,8 +174,12 @@ public class ReactEditText extends EditText {
   protected void onFocusChanged(
       boolean focused, int direction, Rect previouslyFocusedRect) {
     super.onFocusChanged(focused, direction, previouslyFocusedRect);
-    if (focused && mSelectionWatcher != null) {
-      mSelectionWatcher.onSelectionChanged(getSelectionStart(), getSelectionEnd());
+    if (focused) {
+      if (mClearTextOnFocus) {
+        setText("");
+      } else if (mSelectionWatcher != null) {
+        mSelectionWatcher.onSelectionChanged(getSelectionStart(), getSelectionEnd());
+      }
     }
   }
 
@@ -187,6 +193,10 @@ public class ReactEditText extends EditText {
 
   public boolean getBlurOnSubmit() {
     return mBlurOnSubmit;
+  }
+
+  public void setClearTextOnFocus(boolean clearTextOnFocus) {
+    mClearTextOnFocus = clearTextOnFocus;
   }
 
   /*protected*/ int getStagedInputType() {

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
@@ -186,6 +186,11 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
     view.setBlurOnSubmit(blurOnSubmit);
   }
 
+  @ReactProp(name = "clearTextOnFocus", defaultBoolean = false)
+  public void setClearTextOnFocus(ReactEditText view, boolean clearTextOnFocus) {
+    view.setClearTextOnFocus(clearTextOnFocus);
+  }
+
   @ReactProp(name = "placeholder")
   public void setPlaceholder(ReactEditText view, @Nullable String placeholder) {
     view.setHint(placeholder);


### PR DESCRIPTION
Does not fire onSelectionChanged when gaining focus, same as on iOS