### PR TITLE
Keyboard input accessory ios

### DIFF
--- a/Libraries/Text/RCTTextField.h
+++ b/Libraries/Text/RCTTextField.h
@@ -12,6 +12,10 @@
 #import "RCTComponent.h"
 
 @class RCTEventDispatcher;
+@class  RCTTextField;
+
+// input View Accessory Handle definition
+typedef UIView * (^RCTTextFieldKeyboardAccessory)(RCTTextField *);
 
 @interface RCTTextField : UITextField
 
@@ -33,4 +37,19 @@
 - (void)sendKeyValueForString:(NSString *)string;
 - (BOOL)textFieldShouldEndEditing:(RCTTextField *)textField;
 
+/*
+ * This method was exposed as public to enable accessory handle to submit changes to JS code
+ */
+- (void)textFieldSubmitEditing;
+
+
+/**
+ * The method to allow application register handle to produce inputAccessoryView for particular keyboard type
+ * handler presents instancdispatch_oncee of KeyboardAccessory type
+ */
+
++(void) registerKeyboardTypeAccessoryHandler:(UIKeyboardType)type handler:(RCTTextFieldKeyboardAccessory)handler;
+
+
 @end
+

--- a/Libraries/Text/RCTTextField.m
+++ b/Libraries/Text/RCTTextField.m
@@ -20,9 +20,7 @@
 
 static NSMutableDictionary *textFieldAccessoryMapping;
 
-// input View Accessory Handle definition
 
-typedef UIView * (^KeyboardAccessory)(UITextField *);
 
 @implementation RCTTextField
 {
@@ -270,7 +268,7 @@ static void RCTUpdatePlaceholder(RCTTextField *self)
   
   // This fragment was added to let application inject input accessory view if needed
   //
-  KeyboardAccessory handler = [RCTTextField getAcessoryMapping][[NSNumber numberWithInt:self.keyboardType]];
+  RCTTextFieldKeyboardAccessory handler = [RCTTextField accessoryMapping][[NSNumber numberWithInt:self.keyboardType]];
   if (handler) {
     self.inputAccessoryView = handler(self);
   }
@@ -297,10 +295,10 @@ static void RCTUpdatePlaceholder(RCTTextField *self)
 }
 
 
-+(NSMutableDictionary*)getAcessoryMapping {
-  static dispatch_once_t onceToken = 0;
++(NSMutableDictionary*)accessoryMapping {
+  static dispatch_once_t onceAccessoryToken = 0;
   
-  dispatch_once(&onceToken, ^{
+  dispatch_once(&onceAccessoryToken, ^{
     textFieldAccessoryMapping = [[NSMutableDictionary alloc] init];
   });
   
@@ -312,9 +310,9 @@ static void RCTUpdatePlaceholder(RCTTextField *self)
  * handler presents instancdispatch_oncee of KeyboardAccessory type
  */
 
-+(void) registerForKeyboardType:(NSNumber *)type handler:(KeyboardAccessory)handler{
++(void) registerKeyboardTypeAccessoryHandler:(UIKeyboardType)type handler:(RCTTextFieldKeyboardAccessory)handler{
   
-  [RCTTextField getAcessoryMapping][type] = handler;
+  [RCTTextField accessoryMapping][[NSNumber numberWithInt:type]] = handler;
   
 
 }

--- a/Libraries/Text/RCTTextField.m
+++ b/Libraries/Text/RCTTextField.m
@@ -302,21 +302,20 @@ static void RCTUpdatePlaceholder(RCTTextField *self)
   
   dispatch_once(&onceToken, ^{
     textFieldAccessoryMapping = [[NSMutableDictionary alloc] init];
-    // Do any other initialisation stuff here
   });
   
   return textFieldAccessoryMapping;
 }
 
 /**
- * The method to allow application register for injecting inputAccessoryView for particular keyboard type
+ * The method to allow application register handle to produce inputAccessoryView for particular keyboard type
  * handler presents instancdispatch_oncee of KeyboardAccessory type
  */
 
 +(void) registerForKeyboardType:(NSNumber *)type handler:(KeyboardAccessory)handler{
   
-  NSMutableDictionary *dct = [RCTTextField getAcessoryMapping];
-  dct[type] = handler;
+  [RCTTextField getAcessoryMapping][type] = handler;
+  
 
 }
 

--- a/Libraries/Text/RCTTextField.m
+++ b/Libraries/Text/RCTTextField.m
@@ -14,6 +14,16 @@
 #import "RCTUtils.h"
 #import "UIView+React.h"
 
+//
+// Repository of accessory Handles
+//
+
+static NSMutableDictionary *textFieldAccessoryMapping;
+
+// input View Accessory Handle definition
+
+typedef UIView * (^KeyboardAccessory)(UITextField *);
+
 @implementation RCTTextField
 {
   RCTEventDispatcher *_eventDispatcher;
@@ -257,6 +267,13 @@ static void RCTUpdatePlaceholder(RCTTextField *self)
 
 - (void)reactWillMakeFirstResponder
 {
+  
+  // This fragment was added to let application inject input accessory view if needed
+  //
+  KeyboardAccessory handler = [RCTTextField getAcessoryMapping][[NSNumber numberWithInt:self.keyboardType]];
+  if (handler) {
+    self.inputAccessoryView = handler(self);
+  }
   _jsRequestingFirstResponder = YES;
 }
 
@@ -277,6 +294,30 @@ static void RCTUpdatePlaceholder(RCTTextField *self)
                                  eventCount:_nativeEventCount];
   }
   return result;
+}
+
+
++(NSMutableDictionary*)getAcessoryMapping {
+  static dispatch_once_t onceToken = 0;
+  
+  dispatch_once(&onceToken, ^{
+    textFieldAccessoryMapping = [[NSMutableDictionary alloc] init];
+    // Do any other initialisation stuff here
+  });
+  
+  return textFieldAccessoryMapping;
+}
+
+/**
+ * The method to allow application register for injecting inputAccessoryView for particular keyboard type
+ * handler presents instancdispatch_oncee of KeyboardAccessory type
+ */
+
++(void) registerForKeyboardType:(NSNumber *)type handler:(KeyboardAccessory)handler{
+  
+  NSMutableDictionary *dct = [RCTTextField getAcessoryMapping];
+  dct[type] = handler;
+
 }
 
 @end


### PR DESCRIPTION
Intuit uses React Native in presenting Tax interview process, one of the essential problems we found that not all IOS keyboard provides a place for "Next", "Done" buttons even when keyReturnType is set to Next or Done. As a result we could not traverse an interview form while keyboardType is "number" or "number" pad or should avoid few useful keyboard types. This is IOS issue not ReactNative, however in previous native implementation we were able to add inputAccessoryView to UITextField and put there Next/Done buttons. The proposed solution enable inputAccessoryView to be added to RCTTextField.

We debated two possible solution - one with exposing RCTText include files to the project and second without exposing, this solution does not require RCTTextField to be exposed to a ReactApplication and uses selectors instead if explicit RCTTextField methods.

**Test plan (required)**

Here is "number" keyboard appearance with requested returnKeyType = Done
![image](https://cloud.githubusercontent.com/assets/2754159/14055143/8b540f22-f29c-11e5-907f-6df2865c8e52.png)

Here how it looks after improvement, note that inputViewAccessory is formed by application and is not related to this commit.
![image](https://cloud.githubusercontent.com/assets/2754159/14055178/e8029fae-f29c-11e5-92ff-39c75e09d780.png)


Here is an application code which presents a test case.

### 1. Keyboard registration

```objc
 Class clz = NSClassFromString(@"RCTTextField");

  KeyboardAccessory keyboardHandler = ^UIView *(UITextField *textField) {
    ReactTextAdapter *kAdapter = [[ReactTextAdapter alloc] init:textField];
    return [kAdapter getInputAccessory];
  };
  

  SEL selector = NSSelectorFromString(@"registerForKeyboardType:handler:");
  if ([clz respondsToSelector:selector]) {
    [ clz performSelector:selector withObject:[NSNumber numberWithInt:UIKeyboardTypeNumberPad] withObject:keyboardHandler];
  }
```

### 2. Implementation for React TextAdapter  

```objc
@interface ReactTextAdapter :UIToolbar

-(instancetype) init:(UITextField *)textField;
-(UIView *)getInputAccessory;

@end

//
//  ReactTextAdapter.m
//  KeyboardTest
//
//  Created by Krivopaltsev, Eugene on 3/11/16.
//  Copyright © 2016 Facebook. All rights reserved.
//

#import "ReactTextAdapter.h"


@interface ReactTextAdapter()

@property (nonatomic) UITextField *textField;

//@property (nonatomic)UIToolbar *toolBar;
@property (nonatomic)UIBarButtonItem *flexible;

@end

@implementation ReactTextAdapter


-(instancetype) init:(UITextField *)textField {
  self = [super init];
  if (self) {
    self.textField = textField;
    
    [self setBarStyle:UIBarStyleDefault];
    self.translatesAutoresizingMaskIntoConstraints = NO;
    self.flexible = [[UIBarButtonItem alloc]
                     initWithBarButtonSystemItem:UIBarButtonSystemItemFlexibleSpace
                     target:self action:nil];
   
    
    
    // since there is a next field, add a NEXT button to the picker
    if (self. textField. returnKeyType == UIReturnKeyNext) {
      NSString *nextText = @"Next";
      UIBarButtonItem *nextButton = [[UIBarButtonItem alloc] initWithTitle:nextText
                                                                   style:UIBarButtonItemStyleDone
                                                                  target:self
                                                                  action:@selector(next)];
      
    
      self.items = [[NSArray alloc] initWithObjects: self.flexible, nextButton, nil];
    }else if (self.textField. returnKeyType == UIReturnKeyContinue) {
    
      NSString *continueText = @"Continue";
      UIBarButtonItem *contButton = [[UIBarButtonItem alloc] initWithTitle:continueText
                                                                     style:UIBarButtonItemStyleDone
                                                                    target:self
                                                                    action:@selector(next)];
      
      self.items = [[NSArray alloc] initWithObjects: self.flexible, contButton, nil];
    }
    else if (self. textField.returnKeyType == UIReturnKeyDone) {
    
      NSString *doneText = @"Done";
      UIBarButtonItem *doneButton = [[UIBarButtonItem alloc] initWithTitle:doneText
                                                                     style:UIBarButtonItemStyleDone
                                                                    target:self
                                                                    action:@selector(done)];
      doneButton.enabled = YES;
      
      self.items = [[NSArray alloc] initWithObjects: self.flexible, doneButton, nil];
    }
    
  }
  return self;
}
-(void) done {
  [self passToReactNative];
  [self.textField resignFirstResponder];
}

-(void) next {
  [self passToReactNative];
}

-(void) passToReactNative {
  SEL selector = @selector(textFieldSubmitEditing);
  if ([self.textField respondsToSelector:selector]) {
    [self.textField performSelector:selector withObject:nil];
  }
}



-(UIView *)getInputAccessory {
  return self;
}
```

Test Project (without node_modules)
[KeyboardTest.zip](https://github.com/facebook/react-native/files/190206/KeyboardTest.zip)
