### PR TITLE
Make 'onRequestClose' a required prop for Modal on Android. Fixes #6612

### DIFF
--- a/Libraries/Modal/Modal.js
+++ b/Libraries/Modal/Modal.js
@@ -11,6 +11,7 @@
  */
 'use strict';
 
+var Platform = require('Platform');
 var PropTypes = require('ReactPropTypes');
 var React = require('React');
 var StyleSheet = require('StyleSheet');
@@ -61,7 +62,7 @@ Modal.propTypes = {
   animated: PropTypes.bool,
   transparent: PropTypes.bool,
   visible: PropTypes.bool,
-  onRequestClose: PropTypes.func,
+  onRequestClose: Platform.OS === 'android' ? PropTypes.func.isRequired : PropTypes.func,
   onShow: PropTypes.func,
 };
 


### PR DESCRIPTION
The `onRequestClose` prop can be used to handle dismissing the modal by back button. It's pretty easy to miss the `onRequestClose` prop on Android. So making it a required prop makes sure that it generates a warning when not supplied.

Context #6612