### PR TITLE
Pinned esint and babel-eslint versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -179,8 +179,8 @@
     "yeoman-generator": "^0.20.3"
   },
   "devDependencies": {
-    "babel-eslint": "^5.0.0",
-    "eslint": "~2.2.0",
+    "babel-eslint": "5.0.0",
+    "eslint": "2.2.0",
     "eslint-plugin-flow-vars": "^0.2.1",
     "eslint-plugin-react": "^4.2.1",
     "flow-bin": "0.22.0",


### PR DESCRIPTION
Tests seem to be broken on CI due to failing dependency of `babel-eslint` on `eslint` < `2.0.0`.

cc @bestander