### PR TITLE
Add a DeviceInfo API that allows you to access device and app

### DIFF
--- a/Examples/UIExplorer/UIExplorer.xcodeproj/project.pbxproj
+++ b/Examples/UIExplorer/UIExplorer.xcodeproj/project.pbxproj
@@ -68,6 +68,7 @@
 		8385CEF51B873B5C00C6273E /* RCTImageLoaderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8385CEF41B873B5C00C6273E /* RCTImageLoaderTests.m */; };
 		8385CF041B87479200C6273E /* RCTImageLoaderHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = 8385CF031B87479200C6273E /* RCTImageLoaderHelpers.m */; };
 		D85B829E1AB6D5D7003F4FE2 /* libRCTVibration.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D85B829C1AB6D5CE003F4FE2 /* libRCTVibration.a */; };
+		DDD7B02B1CA578E000FF99CC /* libRCTDeviceInfo.a in Frameworks */ = {isa = PBXBuildFile; fileRef = DDD7B01F1CA578C300FF99CC /* libRCTDeviceInfo.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -176,6 +177,13 @@
 			remoteGlobalIDString = 832C81801AAF6DEF007FA2F7;
 			remoteInfo = RCTVibration;
 		};
+		DDD7B01E1CA578C300FF99CC /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = DDD7B0171CA578C300FF99CC /* RCTDeviceInfo.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 134814201AA4EA6300B7C361;
+			remoteInfo = RCTDeviceInfo;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
@@ -253,6 +261,7 @@
 		8385CF031B87479200C6273E /* RCTImageLoaderHelpers.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTImageLoaderHelpers.m; sourceTree = "<group>"; };
 		8385CF051B8747A000C6273E /* RCTImageLoaderHelpers.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RCTImageLoaderHelpers.h; sourceTree = "<group>"; };
 		D85B82911AB6D5CE003F4FE2 /* RCTVibration.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTVibration.xcodeproj; path = ../../Libraries/Vibration/RCTVibration.xcodeproj; sourceTree = "<group>"; };
+		DDD7B0171CA578C300FF99CC /* RCTDeviceInfo.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTDeviceInfo.xcodeproj; path = ../../Libraries/DeviceInfo/RCTDeviceInfo.xcodeproj; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -280,6 +289,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DDD7B02B1CA578E000FF99CC /* libRCTDeviceInfo.a in Frameworks */,
 				14AADF051AC3DBB1002390C9 /* libReact.a in Frameworks */,
 				147CED4C1AB3532B00DA3E4C /* libRCTActionSheet.a in Frameworks */,
 				134454601AAFCABD003F0779 /* libRCTAdSupport.a in Frameworks */,
@@ -314,6 +324,7 @@
 				14E0EEC81AB118F7000DECC3 /* RCTActionSheet.xcodeproj */,
 				134454551AAFCAAE003F0779 /* RCTAdSupport.xcodeproj */,
 				138DEE021B9EDDDB007F4EA5 /* RCTCameraRoll.xcodeproj */,
+				DDD7B0171CA578C300FF99CC /* RCTDeviceInfo.xcodeproj */,
 				134A8A201AACED6A00945AAE /* RCTGeolocation.xcodeproj */,
 				13417FE31AA91428003F314A /* RCTImage.xcodeproj */,
 				357858F81B28D2C400341EDB /* RCTLinking.xcodeproj */,
@@ -597,6 +608,14 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
+		DDD7B0181CA578C300FF99CC /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				DDD7B01F1CA578C300FF99CC /* libRCTDeviceInfo.a */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -693,6 +712,10 @@
 				{
 					ProductGroup = 138DEE031B9EDDDB007F4EA5 /* Products */;
 					ProjectRef = 138DEE021B9EDDDB007F4EA5 /* RCTCameraRoll.xcodeproj */;
+				},
+				{
+					ProductGroup = DDD7B0181CA578C300FF99CC /* Products */;
+					ProjectRef = DDD7B0171CA578C300FF99CC /* RCTDeviceInfo.xcodeproj */;
 				},
 				{
 					ProductGroup = 134A8A211AACED6A00945AAE /* Products */;
@@ -845,6 +868,13 @@
 			fileType = archive.ar;
 			path = libRCTVibration.a;
 			remoteRef = D85B829B1AB6D5CE003F4FE2 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		DDD7B01F1CA578C300FF99CC /* libRCTDeviceInfo.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libRCTDeviceInfo.a;
+			remoteRef = DDD7B01E1CA578C300FF99CC /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 /* End PBXReferenceProxy section */

--- a/Libraries/DeviceInfo/DeviceInfo.js
+++ b/Libraries/DeviceInfo/DeviceInfo.js
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule DeviceInfo
+ */
+'use strict';
+
+var RCTDeviceInfo = require('NativeModules').DeviceInfoModule;
+
+/**
+ * `DeviceInfo` gives you information about your running application and the
+ * device you are running on.
+ *
+ * #### Device Name on Android
+ *
+ * If you want to get the device name on Android then you will need to add the
+ * bluetooth permission to your application's `AndroidManifest.xml` file.
+ *
+ * ```
+ * <uses-permission android:name="android.permission.BLUETOOTH"/>
+ * ```
+ */
+var DeviceInfo = {
+  /**
+   *  Return a unique ID for the current device (this is the IDFV on iOS so it will change if all apps from the current apps vendor have been previously uninstalled)
+   */
+  UniqueID: RCTDeviceInfo.UniqueID,
+  /**
+   *  Return a system identifier for the type of device e.g. iPhone7,2 or the board on Android e.g. goldfish
+   */
+  DeviceID: RCTDeviceInfo.DeviceID,
+  /**
+   *  Return the device manufacturer e.g. Apple
+   */
+  Manufacturer: RCTDeviceInfo.Manufacturer,
+  /**
+   *  Return a user friendly device model e.g. iPad Air 2
+   */
+  Model: RCTDeviceInfo.Model,
+  /**
+   *  Return the name of the operating system running on the device e.g. iPhone OS
+   */
+  SystemName: RCTDeviceInfo.SystemName,
+  /**
+   *  Return the version of the operating system running on the device e.g. 9.0
+   */
+  SystemVersion: RCTDeviceInfo.SystemVersion,
+  /**
+   *  Return the application's bundle identifier e.g. com.facebook.internal.uiexplorer.local
+   */
+  PackageName: RCTDeviceInfo.PackageName,
+  /**
+   *  Return the build number for the running application e.g. 1
+   */
+  BuildNumber: RCTDeviceInfo.BuildNumber,
+  /**
+   *  Return the version for the running application e.g. 1.0
+   */
+  Version: RCTDeviceInfo.AppVersion,
+  /**
+   *  Return the name of the current device e.g. Becca's iPhone 6
+   */
+  DeviceName: RCTDeviceInfo.DeviceName,
+  /**
+   *  Return the current device's user agent e.g. Dalvik/2.1.0 (Linux; U; Android 5.1; Google Nexus 4 - 5.1.0 - API 22 - 768x1280 Build/LMY47D)
+   */
+  UserAgent: RCTDeviceInfo.UserAgent,
+  /**
+   *  Return the current device's locale e.g. en-US
+   */
+  DeviceLocale: RCTDeviceInfo.DeviceLocale,
+  /**
+   *  Return the current device's country as a ISO_3166-1 string e.g. US
+   */
+  DeviceCountry: RCTDeviceInfo.DeviceCountry,
+};
+
+module.exports = DeviceInfo;

--- a/Libraries/DeviceInfo/DeviceInfoModule.h
+++ b/Libraries/DeviceInfo/DeviceInfoModule.h
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <UIKit/UIKit.h>
+#import <sys/utsname.h>
+
+#import "RCTBridgeModule.h"
+
+@interface DeviceInfoModule : NSObject <RCTBridgeModule>
+
+@end

--- a/Libraries/DeviceInfo/DeviceInfoModule.m
+++ b/Libraries/DeviceInfo/DeviceInfoModule.m
@@ -1,0 +1,169 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import "DeviceInfoModule.h"
+
+@interface DeviceInfoModule()
+
+@end
+
+@implementation DeviceInfoModule
+{
+
+}
+
+RCT_EXPORT_MODULE()
+
+- (dispatch_queue_t)methodQueue
+{
+  return dispatch_get_main_queue();
+}
+
+- (NSString*) deviceId
+{
+  struct utsname systemInfo;
+
+  uname(&systemInfo);
+
+  return [NSString stringWithCString:systemInfo.machine
+                                  encoding:NSUTF8StringEncoding];
+}
+
+- (NSString*) deviceName
+{
+  static NSDictionary* deviceNamesByCode = nil;
+
+  if (!deviceNamesByCode) {
+
+    deviceNamesByCode = @{@"i386"      :@"Simulator",
+                          @"x86_64"    :@"Simulator",
+                          @"iPod1,1"   :@"iPod Touch",      // (Original)
+                          @"iPod2,1"   :@"iPod Touch",      // (Second Generation)
+                          @"iPod3,1"   :@"iPod Touch",      // (Third Generation)
+                          @"iPod4,1"   :@"iPod Touch",      // (Fourth Generation)
+                          @"iPod5,1"   :@"iPod Touch",      // (Fifth Generation)
+                          @"iPod7,1"   :@"iPod Touch",      // (Sixth Generation)
+                          @"iPhone1,1" :@"iPhone",          // (Original)
+                          @"iPhone1,2" :@"iPhone 3G",       // (3G)
+                          @"iPhone2,1" :@"iPhone 3GS",      // (3GS)
+                          @"iPad1,1"   :@"iPad",            // (Original)
+                          @"iPad2,1"   :@"iPad 2",          //
+                          @"iPad2,2"   :@"iPad 2",          //
+                          @"iPad2,3"   :@"iPad 2",          //
+                          @"iPad2,4"   :@"iPad 2",          //
+                          @"iPad3,1"   :@"iPad",            // (3rd Generation)
+                          @"iPad3,2"   :@"iPad",            // (3rd Generation)
+                          @"iPad3,3"   :@"iPad",            // (3rd Generation)
+                          @"iPhone3,1" :@"iPhone 4",        // (GSM)
+                          @"iPhone3,2" :@"iPhone 4",        // iPhone 4
+                          @"iPhone3,3" :@"iPhone 4",        // (CDMA/Verizon/Sprint)
+                          @"iPhone4,1" :@"iPhone 4S",       //
+                          @"iPhone5,1" :@"iPhone 5",        // (model A1428, AT&T/Canada)
+                          @"iPhone5,2" :@"iPhone 5",        // (model A1429, everything else)
+                          @"iPad3,4"   :@"iPad",            // (4th Generation)
+                          @"iPad3,5"   :@"iPad",            // (4th Generation)
+                          @"iPad3,6"   :@"iPad",            // (4th Generation)
+                          @"iPad2,5"   :@"iPad Mini",       // (Original)
+                          @"iPad2,6"   :@"iPad Mini",       // (Original)
+                          @"iPad2,7"   :@"iPad Mini",       // (Original)
+                          @"iPhone5,3" :@"iPhone 5c",       // (model A1456, A1532 | GSM)
+                          @"iPhone5,4" :@"iPhone 5c",       // (model A1507, A1516, A1526 (China), A1529 | Global)
+                          @"iPhone6,1" :@"iPhone 5s",       // (model A1433, A1533 | GSM)
+                          @"iPhone6,2" :@"iPhone 5s",       // (model A1457, A1518, A1528 (China), A1530 | Global)
+                          @"iPhone7,1" :@"iPhone 6 Plus",   //
+                          @"iPhone7,2" :@"iPhone 6",        //
+                          @"iPhone8,1" :@"iPhone 6s",       //
+                          @"iPhone8,2" :@"iPhone 6s Plus",  //
+                          @"iPhone8,4" :@"iPhone SE",       //
+                          @"iPad4,1"   :@"iPad Air",        // 5th Generation iPad (iPad Air) - Wifi
+                          @"iPad4,2"   :@"iPad Air",        // 5th Generation iPad (iPad Air) - Cellular
+                          @"iPad4,3"   :@"iPad Air",        // 5th Generation iPad (iPad Air)
+                          @"iPad4,4"   :@"iPad Mini 2",     // (2nd Generation iPad Mini - Wifi)
+                          @"iPad4,5"   :@"iPad Mini 2",     // (2nd Generation iPad Mini - Cellular)
+                          @"iPad4,6"   :@"iPad Mini 2",     // (2nd Generation iPad Mini)
+                          @"iPad4,7"   :@"iPad Mini 3",     // (3rd Generation iPad Mini)
+                          @"iPad4,8"   :@"iPad Mini 3",     // (3rd Generation iPad Mini)
+                          @"iPad4,9"   :@"iPad Mini 3",     // (3rd Generation iPad Mini)
+                          @"iPad5,1"   :@"iPad Mini 4",     // (4th Generation iPad Mini)
+                          @"iPad5,2"   :@"iPad Mini 4",     // (4th Generation iPad Mini)
+                          @"iPad5,3"   :@"iPad Air 2",      // 6th Generation iPad (iPad Air 2)
+                          @"iPad5,4"   :@"iPad Air 2",      // 6th Generation iPad (iPad Air 2)
+                          @"iPad6,3"   :@"iPad Pro 9.7-inch",// iPad Pro 9.7-inch
+                          @"iPad6,4"   :@"iPad Pro 9.7-inch",// iPad Pro 9.7-inch
+                          @"iPad6,7"   :@"iPad Pro 12.9-inch",// iPad Pro 12.9-inch
+                          @"iPad6,8"   :@"iPad Pro 12.9-inch",// iPad Pro 12.9-inch
+                          @"AppleTV2,1":@"Apple TV",        // Apple TV (2nd Generation)
+                          @"AppleTV3,1":@"Apple TV",        // Apple TV (3rd Generation)
+                          @"AppleTV3,2":@"Apple TV",        // Apple TV (3rd Generation - Rev A)
+                          @"AppleTV5,3":@"Apple TV",        // Apple TV (4th Generation)
+                          };
+  }
+
+  NSString* deviceName = [deviceNamesByCode objectForKey:self.deviceId];
+
+  if (!deviceName) {
+    // Not found on database. At least guess main device type from string contents:
+
+    if ([self.deviceId rangeOfString:@"iPod"].location != NSNotFound) {
+        deviceName = @"iPod Touch";
+    }
+    else if([self.deviceId rangeOfString:@"iPad"].location != NSNotFound) {
+        deviceName = @"iPad";
+    }
+    else if([self.deviceId rangeOfString:@"iPhone"].location != NSNotFound){
+        deviceName = @"iPhone";
+    }
+  }
+
+  return deviceName;
+}
+
+- (NSString*) userAgent
+{
+  UIWebView* webView = [[UIWebView alloc] initWithFrame:CGRectZero];
+  return [webView stringByEvaluatingJavaScriptFromString:@"navigator.userAgent"];
+}
+
+- (NSString*) deviceLocale
+{
+  NSString *language = [[NSLocale preferredLanguages] objectAtIndex:0];
+  return language;
+}
+
+- (NSString*) deviceCountry
+{
+  NSString *country = [[NSLocale currentLocale] objectForKey:NSLocaleCountryCode];
+  return country;
+}
+
+- (NSDictionary *)constantsToExport
+{
+  UIDevice *currentDevice = [UIDevice currentDevice];
+
+  NSUUID *identifierForVendor = [currentDevice identifierForVendor];
+  NSString *uniqueId = [identifierForVendor UUIDString];
+
+  return @{
+           @"SystemName": currentDevice.systemName,
+           @"SystemVersion": currentDevice.systemVersion,
+           @"Model": self.deviceName,
+           @"DeviceID": self.deviceId,
+           @"DeviceName": currentDevice.name,
+           @"DeviceLocale": self.deviceLocale,
+           @"DeviceCountry": self.deviceCountry,
+           @"UniqueID": uniqueId,
+           @"PackageName": [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleIdentifier"],
+           @"AppVersion": [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"],
+           @"BuildNumber": [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleVersion"],
+           @"Manufacturer": @"Apple",
+           @"UserAgent": self.userAgent,
+           };
+}
+
+@end

--- a/Libraries/DeviceInfo/RCTDeviceInfo.xcodeproj/project.pbxproj
+++ b/Libraries/DeviceInfo/RCTDeviceInfo.xcodeproj/project.pbxproj
@@ -1,0 +1,252 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		148699CF1ABD045300480536 /* DeviceInfoModule.m in Sources */ = {isa = PBXBuildFile; fileRef = 148699CE1ABD045300480536 /* DeviceInfoModule.m */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		58B511D91A9E6C8500147676 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "include/$(PRODUCT_NAME)";
+			dstSubfolderSpec = 16;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		134814201AA4EA6300B7C361 /* libRCTDeviceInfo.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libRCTDeviceInfo.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		148699CD1ABD045300480536 /* DeviceInfoModule.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DeviceInfoModule.h; sourceTree = "<group>"; };
+		148699CE1ABD045300480536 /* DeviceInfoModule.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DeviceInfoModule.m; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		58B511D81A9E6C8500147676 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		134814211AA4EA7D00B7C361 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				134814201AA4EA6300B7C361 /* libRCTDeviceInfo.a */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		58B511D21A9E6C8500147676 = {
+			isa = PBXGroup;
+			children = (
+				148699CD1ABD045300480536 /* DeviceInfoModule.h */,
+				148699CE1ABD045300480536 /* DeviceInfoModule.m */,
+				134814211AA4EA7D00B7C361 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		58B511DA1A9E6C8500147676 /* RCTDeviceInfo */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 58B511EF1A9E6C8500147676 /* Build configuration list for PBXNativeTarget "RCTDeviceInfo" */;
+			buildPhases = (
+				58B511D71A9E6C8500147676 /* Sources */,
+				58B511D81A9E6C8500147676 /* Frameworks */,
+				58B511D91A9E6C8500147676 /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = RCTDeviceInfo;
+			productName = RCTDataManager;
+			productReference = 134814201AA4EA6300B7C361 /* libRCTDeviceInfo.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		58B511D31A9E6C8500147676 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0610;
+				ORGANIZATIONNAME = Facebook;
+				TargetAttributes = {
+					58B511DA1A9E6C8500147676 = {
+						CreatedOnToolsVersion = 6.1.1;
+					};
+				};
+			};
+			buildConfigurationList = 58B511D61A9E6C8500147676 /* Build configuration list for PBXProject "RCTDeviceInfo" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = 58B511D21A9E6C8500147676;
+			productRefGroup = 58B511D21A9E6C8500147676;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				58B511DA1A9E6C8500147676 /* RCTDeviceInfo */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXSourcesBuildPhase section */
+		58B511D71A9E6C8500147676 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				148699CF1ABD045300480536 /* DeviceInfoModule.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		58B511ED1A9E6C8500147676 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_SHADOW = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		58B511EE1A9E6C8500147676 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_SHADOW = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		58B511F01A9E6C8500147676 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
+					"$(SRCROOT)/../../React/**",
+				);
+				LIBRARY_SEARCH_PATHS = "$(inherited)";
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_NAME = RCTDeviceInfo;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		58B511F11A9E6C8500147676 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
+					"$(SRCROOT)/../../React/**",
+				);
+				LIBRARY_SEARCH_PATHS = "$(inherited)";
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_NAME = RCTDeviceInfo;
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		58B511D61A9E6C8500147676 /* Build configuration list for PBXProject "RCTDeviceInfo" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				58B511ED1A9E6C8500147676 /* Debug */,
+				58B511EE1A9E6C8500147676 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		58B511EF1A9E6C8500147676 /* Build configuration list for PBXNativeTarget "RCTDeviceInfo" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				58B511F01A9E6C8500147676 /* Debug */,
+				58B511F11A9E6C8500147676 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 58B511D31A9E6C8500147676 /* Project object */;
+}

--- a/Libraries/react-native/react-native.js
+++ b/Libraries/react-native/react-native.js
@@ -68,6 +68,7 @@ var ReactNative = {
   get CameraRoll() { return require('CameraRoll'); },
   get Clipboard() { return require('Clipboard'); },
   get DatePickerAndroid() { return require('DatePickerAndroid'); },
+  get DeviceInfo() { return require('DeviceInfo'); },
   get Dimensions() { return require('Dimensions'); },
   get Easing() { return require('Easing'); },
   get ImagePickerIOS() { return require('ImagePickerIOS'); },

--- a/Libraries/react-native/react-native.js.flow
+++ b/Libraries/react-native/react-native.js.flow
@@ -80,6 +80,7 @@ var ReactNative = Object.assign(Object.create(require('react')), {
   CameraRoll: require('CameraRoll'),
   Clipboard: require('Clipboard'),
   DatePickerAndroid: require('DatePickerAndroid'),
+  DeviceInfo: require('DeviceInfo'),
   Dimensions: require('Dimensions'),
   Easing: require('Easing'),
   ImagePickerIOS: require('ImagePickerIOS'),

--- a/React.podspec
+++ b/React.podspec
@@ -109,6 +109,12 @@ Pod::Spec.new do |s|
     ss.preserve_paths   = "Libraries/LinkingIOS/*.js"
   end
 
+  s.subspec 'RCTDeviceInfo' do |ss|
+    ss.dependency         'React/Core'
+    ss.source_files     = "Libraries/DeviceInfo/*.{h,m}"
+    ss.preserve_paths   = "Libraries/DeviceInfo/*.js"
+  end
+
   s.subspec 'RCTTest' do |ss|
     ss.source_files     = "Libraries/RCTTest/**/*.{h,m}"
     ss.preserve_paths   = "Libraries/RCTTest/**/*.js"

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/deviceinfo/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/deviceinfo/BUCK
@@ -1,0 +1,20 @@
+include_defs('//ReactAndroid/DEFS')
+
+android_library(
+  name = 'deviceinfo',
+  srcs = glob(['**/*.java']),
+  deps = [
+    react_native_target('java/com/facebook/react/bridge:bridge'),
+    react_native_target('java/com/facebook/react/common:common'),
+    react_native_dep('libraries/fbcore/src/main/java/com/facebook/common/logging:logging'),
+    react_native_dep('third-party/java/infer-annotations:infer-annotations'),
+    react_native_dep('third-party/java/jsr-305:jsr-305'),
+  ],
+  visibility = [
+    'PUBLIC',
+  ],
+)
+
+project_config(
+  src_target = ':deviceinfo',
+)

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/deviceinfo/DeviceInfoModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/deviceinfo/DeviceInfoModule.java
@@ -1,0 +1,109 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+package com.facebook.react.modules.deviceinfo;
+
+import android.bluetooth.BluetoothAdapter;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
+import android.os.Build;
+import android.provider.Settings.Secure;
+
+import com.facebook.common.logging.FLog;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContextBaseJavaModule;
+import com.facebook.react.common.ReactConstants;
+
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+import javax.annotation.Nullable;
+
+/**
+ * DeviceInfo module. Get Android device information from JS.
+ */
+public class DeviceInfoModule extends ReactContextBaseJavaModule {
+
+  public DeviceInfoModule(ReactApplicationContext reactContext) {
+    super(reactContext);
+  }
+
+  @Override
+  public String getName() {
+    return "DeviceInfoModule";
+  }
+
+  /**
+   * Return the current language
+   */
+  private String getCurrentLanguage() {
+    Locale current = getReactApplicationContext().getResources().getConfiguration().locale;
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+      return current.toLanguageTag();
+    } else {
+      StringBuilder builder = new StringBuilder();
+      builder.append(current.getLanguage());
+      if (current.getCountry() != null) {
+        builder.append("-");
+        builder.append(current.getCountry());
+      }
+      return builder.toString();
+    }
+  }
+
+  /**
+   * Return the current locale
+   */
+  private String getCurrentCountry() {
+    Locale current = getReactApplicationContext().getResources().getConfiguration().locale;
+    return current.getCountry();
+  }
+
+  /**
+   * Expose constants to Javascript
+   */
+  @Override
+  public @Nullable Map<String, Object> getConstants() {
+    HashMap<String, Object> constants = new HashMap<String, Object>();
+
+    PackageManager packageManager = getReactApplicationContext().getPackageManager();
+    String packageName = getReactApplicationContext().getPackageName();
+
+    try {
+      PackageInfo info = packageManager.getPackageInfo(packageName, 0);
+      constants.put("appVersion", info.versionName);
+      constants.put("buildNumber", info.versionCode);
+    } catch (PackageManager.NameNotFoundException e) {
+      constants.put("appVersion", "Not Available");
+      constants.put("buildNumber", 0);
+      FLog.e(ReactConstants.TAG, e.getMessage(), e);
+    }
+
+    try {
+      BluetoothAdapter myDevice = BluetoothAdapter.getDefaultAdapter();
+      constants.put("deviceName", myDevice.getName());
+    } catch(Exception e) {
+      constants.put("deviceName", "Unknown");
+      FLog.e(ReactConstants.TAG, e.getMessage(), e);
+    }
+
+    constants.put("SystemName", "Android");
+    constants.put("SystemVersion", Build.VERSION.RELEASE);
+    constants.put("Model", Build.MODEL);
+    constants.put("DeviceID", Build.BOARD);
+    constants.put("DeviceLocale", this.getCurrentLanguage());
+    constants.put("DeviceCountry", this.getCurrentCountry());
+    constants.put("UniqueID", Secure.getString(getReactApplicationContext().getContentResolver(), Secure.ANDROID_ID));
+    constants.put("Manufacturer", Build.MANUFACTURER);
+    constants.put("PackageName", packageName);
+    constants.put("UserAgent", System.getProperty("http.agent"));
+    return constants;
+  }
+}

--- a/ReactAndroid/src/main/java/com/facebook/react/shell/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/shell/BUCK
@@ -33,6 +33,7 @@ android_library(
     react_native_target('java/com/facebook/react/modules/core:core'),
     react_native_target('java/com/facebook/react/modules/datepicker:datepicker'),
     react_native_target('java/com/facebook/react/modules/debug:debug'),
+    react_native_target('java/com/facebook/react/modules/deviceinfo:deviceinfo'),
     react_native_target('java/com/facebook/react/modules/dialog:dialog'),
     react_native_target('java/com/facebook/react/modules/fresco:fresco'),
     react_native_target('java/com/facebook/react/modules/intent:intent'),

--- a/ReactAndroid/src/main/java/com/facebook/react/shell/MainReactPackage.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/shell/MainReactPackage.java
@@ -23,6 +23,7 @@ import com.facebook.react.modules.camera.ImageEditingManager;
 import com.facebook.react.modules.camera.ImageStoreManager;
 import com.facebook.react.modules.clipboard.ClipboardModule;
 import com.facebook.react.modules.datepicker.DatePickerDialogModule;
+import com.facebook.react.modules.deviceinfo.DeviceInfoModule;
 import com.facebook.react.modules.dialog.DialogModule;
 import com.facebook.react.modules.fresco.FrescoModule;
 import com.facebook.react.modules.intent.IntentModule;
@@ -72,6 +73,7 @@ public class MainReactPackage implements ReactPackage {
       new CameraRollManager(reactContext),
       new ClipboardModule(reactContext),
       new DatePickerDialogModule(reactContext),
+      new DeviceInfoModule(reactContext),
       new DialogModule(reactContext),
       new FrescoModule(reactContext),
       new ImageEditingManager(reactContext),

--- a/local-cli/generator-ios/templates/xcodeproj/project.pbxproj
+++ b/local-cli/generator-ios/templates/xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
 		146834051AC3E58100842450 /* libReact.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 146834041AC3E56700842450 /* libReact.a */; };
 		832341BD1AAA6AB300B99B32 /* libRCTText.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 832341B51AAA6A8300B99B32 /* libRCTText.a */; };
+		DDD7B02B1CA578E000FF99CC /* libRCTDeviceInfo.a in Frameworks */ = {isa = PBXBuildFile; fileRef = DDD7B01F1CA578C300FF99CC /* libRCTDeviceInfo.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -102,6 +103,13 @@
 			remoteGlobalIDString = 58B5119B1A9E6C1200147676;
 			remoteInfo = RCTText;
 		};
+		DDD7B01E1CA578C300FF99CC /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = DDD7B0171CA578C300FF99CC /* RCTDeviceInfo.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 134814201AA4EA6300B7C361;
+			remoteInfo = RCTDeviceInfo;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
@@ -126,6 +134,7 @@
 		146833FF1AC3E56700842450 /* React.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = React.xcodeproj; path = ../node_modules/react-native/React/React.xcodeproj; sourceTree = "<group>"; };
 		78C398B01ACF4ADC00677621 /* RCTLinking.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTLinking.xcodeproj; path = ../node_modules/react-native/Libraries/LinkingIOS/RCTLinking.xcodeproj; sourceTree = "<group>"; };
 		832341B01AAA6A8300B99B32 /* RCTText.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTText.xcodeproj; path = ../node_modules/react-native/Libraries/Text/RCTText.xcodeproj; sourceTree = "<group>"; };
+		DDD7B0171CA578C300FF99CC /* RCTDeviceInfo.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTDeviceInfo.xcodeproj; path = ../node_modules/react-native/Libraries/DeviceInfo/RCTDeviceInfo.xcodeproj; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -140,6 +149,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DDD7B02B1CA578E000FF99CC /* libRCTDeviceInfo.a in Frameworks */,
 				146834051AC3E58100842450 /* libReact.a in Frameworks */,
 				00C302E51ABCBA2D00DB3ED1 /* libRCTActionSheet.a in Frameworks */,
 				00C302E71ABCBA2D00DB3ED1 /* libRCTGeolocation.a in Frameworks */,
@@ -264,6 +274,7 @@
 			children = (
 				146833FF1AC3E56700842450 /* React.xcodeproj */,
 				00C302A71ABCB8CE00DB3ED1 /* RCTActionSheet.xcodeproj */,
+				DDD7B0171CA578C300FF99CC /* RCTDeviceInfo.xcodeproj */,
 				00C302B51ABCB90400DB3ED1 /* RCTGeolocation.xcodeproj */,
 				00C302BB1ABCB91800DB3ED1 /* RCTImage.xcodeproj */,
 				78C398B01ACF4ADC00677621 /* RCTLinking.xcodeproj */,
@@ -301,6 +312,14 @@
 			children = (
 				13B07F961A680F5B00A75B9A /* <%= name %>.app */,
 				00E356EE1AD99517003FC87E /* <%= name %>Tests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		DDD7B0181CA578C300FF99CC /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				DDD7B01F1CA578C300FF99CC /* libRCTDeviceInfo.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -374,6 +393,10 @@
 				{
 					ProductGroup = 00C302A81ABCB8CE00DB3ED1 /* Products */;
 					ProjectRef = 00C302A71ABCB8CE00DB3ED1 /* RCTActionSheet.xcodeproj */;
+				},
+				{
+					ProductGroup = DDD7B0181CA578C300FF99CC /* Products */;
+					ProjectRef = DDD7B0171CA578C300FF99CC /* RCTDeviceInfo.xcodeproj */;
 				},
 				{
 					ProductGroup = 00C302B61ABCB90400DB3ED1 /* Products */;
@@ -489,6 +512,13 @@
 			fileType = archive.ar;
 			path = libRCTText.a;
 			remoteRef = 832341B41AAA6A8300B99B32 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		DDD7B01F1CA578C300FF99CC /* libRCTDeviceInfo.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libRCTDeviceInfo.a;
+			remoteRef = DDD7B01E1CA578C300FF99CC /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 /* End PBXReferenceProxy section */

--- a/website/server/extractDocs.js
+++ b/website/server/extractDocs.js
@@ -236,6 +236,7 @@ var apis = [
   '../Libraries/CameraRoll/CameraRoll.js',
   '../Libraries/Components/Clipboard/Clipboard.js',
   '../Libraries/Components/DatePickerAndroid/DatePickerAndroid.android.js',
+  '../Libraries/DeviceInfo/DeviceInfo.js',
   '../Libraries/Utilities/Dimensions.js',
   '../Libraries/Components/Intent/IntentAndroid.android.js',
   '../Libraries/Interaction/InteractionManager.js',


### PR DESCRIPTION
Motivation: Device and App information is something that really should be a Core API and could add real value.

**Test Plan**

```
import {DeviceInfo} from "react-native";
console.log(DeviceInfo.UniqueID);  // 599A7221-0C3F-437B-9807-8A1DF28A3F81
console.log(DeviceInfo.Manufacturer);  // Apple
console.log(DeviceInfo.Model);  // Simulator
console.log(DeviceInfo.DeviceID);  // x86_64
console.log(DeviceInfo.SystemName);  // iPhone OS
console.log(DeviceInfo.SystemVersion);  // 9.2
console.log(DeviceInfo.BundleID);  // com.facebook.internal.uiexplorer.local
console.log(DeviceInfo.BuildNumber);  // 1
console.log(DeviceInfo.Version);  // 1.0
console.log(DeviceInfo.ReadableVersion);  // 1.0.1
console.log(DeviceInfo.DeviceName);  // iPhone Simulator
console.log(DeviceInfo.UserAgent);  // Mozilla/5.0 (iPhone; CPU iPhone OS 9_2 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Mobile/13C75
console.log(DeviceInfo.DeviceLocale);  // en-US
console.log(DeviceInfo.DeviceCountry);  // US
```