### PR TITLE
Caches array length in flattenStyles methods for loop

### DIFF
--- a/Libraries/StyleSheet/flattenStyle.js
+++ b/Libraries/StyleSheet/flattenStyle.js
@@ -34,7 +34,7 @@ function flattenStyle(style: ?StyleObj): ?Object {
   }
 
   var result = {};
-  for (var i = 0; i < style.length; ++i) {
+  for (var i = 0, styleLength = style.length; i < styleLength; ++i) {
     var computedStyle = flattenStyle(style[i]);
     if (computedStyle) {
       for (var key in computedStyle) {


### PR DESCRIPTION
Gains minor perf improvement in the for loop by caching the array length

