### PR TITLE
Update CameraRoll examples to use promises

### DIFF
--- a/Examples/UIExplorer/CameraRollView.js
+++ b/Examples/UIExplorer/CameraRollView.js
@@ -148,7 +148,8 @@ var CameraRollView = React.createClass({
       fetchParams.after = this.state.lastCursor;
     }
 
-    CameraRoll.getPhotos(fetchParams, this._appendAssets, logError);
+    CameraRoll.getPhotos(fetchParams)
+      .then((data) => this._appendAssets(data), (e) => logError(e));
   },
 
   /**

--- a/Examples/UIExplorer/XHRExample.ios.js
+++ b/Examples/UIExplorer/XHRExample.ios.js
@@ -146,7 +146,8 @@ class FormUploader extends React.Component {
 
   _fetchRandomPhoto() {
     CameraRoll.getPhotos(
-      {first: PAGE_SIZE},
+      {first: PAGE_SIZE}
+    ).then(
       (data) => {
         if (!this._isMounted) {
           return;


### PR DESCRIPTION
Update CameraRoll examples to use promises because callbacks are deprecated.