### PR TITLE
added support for 'row-reverse' mode of flexDirection (Android Only)

### DIFF
--- a/Libraries/StyleSheet/LayoutPropTypes.js
+++ b/Libraries/StyleSheet/LayoutPropTypes.js
@@ -60,6 +60,7 @@ var LayoutPropTypes = {
   // https://developer.mozilla.org/en-US/docs/Web/CSS/flex-direction
   flexDirection: ReactPropTypes.oneOf([
     'row',
+    'row-reverse',
     'column'
   ]),
 

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/LayoutShadowNode.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/LayoutShadowNode.java
@@ -60,7 +60,7 @@ public class LayoutShadowNode extends ReactShadowNode {
   public void setFlexDirection(@Nullable String flexDirection) {
     setFlexDirection(
         flexDirection == null ? CSSFlexDirection.COLUMN : CSSFlexDirection.valueOf(
-            flexDirection.toUpperCase(Locale.US)));
+            flexDirection.toUpperCase(Locale.US).replace("-", "_")));
   }
 
   @ReactProp(name = ViewProps.FLEX_WRAP)


### PR DESCRIPTION
The 'row-reverse' flexDirection mode was not available because it was not defined in LayoutPropTypes.js .
After adding it, I was able to configure an RTL (right-to-left) view using the style flexDirection: 'row-reverse' .
Tested only in Android but it seems that except for handling the dash to underscore issue, everything else is working well and the child views are properly reversed.