### PR TITLE
Revert strict mode in transform-es2015-modules-commonjs

### DIFF
--- a/babel-preset/configs/main.js
+++ b/babel-preset/configs/main.js
@@ -24,7 +24,7 @@ module.exports = {
     'transform-es2015-computed-properties',
     'transform-es2015-constants',
     'transform-es2015-destructuring',
-    ['transform-es2015-modules-commonjs', { allowTopLevelThis: true }],
+    ['transform-es2015-modules-commonjs', { strict: false, allowTopLevelThis: true }],
     'transform-es2015-parameters',
     'transform-es2015-shorthand-properties',
     'transform-es2015-spread',

--- a/babel-preset/package.json
+++ b/babel-preset/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-preset-react-native",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "description": "Babel preset for React Native applications",
   "main": "index.js",
   "repository": "https://github.com/facebook/react-native/tree/master/babel-preset",


### PR DESCRIPTION
See discussion here https://github.com/facebook/react-native/pull/5796#issuecomment-202002658

**Test plan (required)**
Change the babel-preset-react-native dependency to `"babel-preset-react-native": "file:./babel-preset",` so it uses the local babel-preset instead of the one from npm.
```
./packager/packager.sh --reset-cache
```
open `http://localhost:8081/Examples/UIExplorer/UIExplorerApp.android.bundle?platform=android&dev=true&hot=false&minify=false` and there should not be any added 'strict mode'.
