### PR TITLE
[Android] Added backface-visibility support for android

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.java
@@ -146,6 +146,22 @@ public class ReactViewManager extends ViewGroupManager<ReactViewGroup> {
     // handled in NativeViewHierarchyOptimizer
   }
 
+  @ReactProp(name = "backfaceVisibility")
+  public void setBackfaceVisibility(ReactViewGroup view, String backfaceVisibility) {
+    view.setBackfaceVisibility(backfaceVisibility);
+  }
+
+  @Override
+  public void setOpacity(ReactViewGroup view, float opacity) {
+    view.setOpacityIfPossible(opacity);
+  }
+
+  @Override
+  public void setDecomposedMatrix(ReactViewGroup view, ReadableMap decomposedMatrix) {
+    super.setDecomposedMatrix(view, decomposedMatrix);
+    view.rememberDecomposedMatrix(decomposedMatrix);
+  }
+
   @Override
   public String getName() {
     return REACT_CLASS;


### PR DESCRIPTION
- Motivation: Style backfaceVisibility was so far supported only on iOS
- Test: I built [react-native-flip-view](https://github.com/DispatcherInc/react-native-flip-view) and ensured that the back face of a rotated View is not visible anymore when its "backfaceVisibility" style is set to "hidden"
- Implementation Details: Out of the box, Android doesn't support hiding a view's back face. The developed solution therefore takes into account the view's rotation. If its X or Y rotation is such that the back face is visible, it checks the backfaceVisibility setting. If it's set to "hidden", it sets the view's opacity to 0 -- otherwise it is set to the user defined value. Furthermore, this check is run whenever the view's opacity, transform matrix or backfaceVisibility changes.

Before:
![y-flip-broken](https://cloud.githubusercontent.com/assets/7293984/14091268/0f011186-f4f4-11e5-8ed9-aa68456aacd7.gif)
![x-flip-broken](https://cloud.githubusercontent.com/assets/7293984/14091269/10b68a88-f4f4-11e5-806d-be5c40ae679d.gif)

After:
![y-flip-working](https://cloud.githubusercontent.com/assets/7293984/14091275/1f403202-f4f4-11e5-9920-d00d34029d1b.gif)
![x-flip-working](https://cloud.githubusercontent.com/assets/7293984/14091277/20d2d7be-f4f4-11e5-955e-1298d1c14844.gif)

