### PR TITLE
[React Native] Use `react-native` instead of `React` on hmr config

### DIFF
--- a/babel-preset/configs/hmr.js
+++ b/babel-preset/configs/hmr.js
@@ -25,7 +25,7 @@ module.exports = function(options, filename) {
         {
           transforms: [{
             transform: transform,
-            imports: ['React'],
+            imports: ['react-native'],
             locals: ['module'],
           }]
         },


### PR DESCRIPTION
Check https://github.com/facebook/react-native/issues/6640 for details