### PR TITLE
Added BUCK to generated app with react-native-cli init

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -42,6 +42,12 @@
 # Ignore Website
 .*/website/.*
 
+# Ignore generators
+.*/local-cli/generator.*
+
+# Ignore BUCK generated folders
+.*\.buckd/
+
 .*/node_modules/is-my-json-valid/test/.*\.json
 .*/node_modules/iconv-lite/encodings/tables/.*\.json
 .*/node_modules/y18n/test/.*\.json
@@ -59,8 +65,6 @@
 .*/node_modules/isemail/.*\.json
 .*/node_modules/tr46/.*\.json
 
-# Buck folder
-.*\.buckd/
 
 [include]
 

--- a/.flowconfig
+++ b/.flowconfig
@@ -59,6 +59,9 @@
 .*/node_modules/isemail/.*\.json
 .*/node_modules/tr46/.*\.json
 
+# Buck folder
+.*\.buckd/
+
 [include]
 
 [libs]

--- a/circle.yml
+++ b/circle.yml
@@ -76,7 +76,8 @@ test:
     - ./gradlew :ReactAndroid:installDebugAndroidTest
     - source scripts/circle-ci-android-setup.sh && retry3 ./scripts/run-android-instrumentation-tests.sh com.facebook.react.tests.gradle
 
-    - ./scripts/e2e-test.sh --packager
+    # JS and Android e2e test
+    - ./scripts/e2e-test.sh --packager --android
 
     # testing docs generation is not broken
     - cd website && node ./server/generate.js

--- a/local-cli/generator-android/templates/package/MainActivity.java
+++ b/local-cli/generator-android/templates/package/MainActivity.java
@@ -24,7 +24,7 @@ public class MainActivity extends ReactActivity {
      */
     @Override
     protected boolean getUseDeveloperSupport() {
-        return BuildConfig.DEBUG;
+        return true;
     }
 
     /**

--- a/local-cli/generator-android/templates/package/MainActivity.java
+++ b/local-cli/generator-android/templates/package/MainActivity.java
@@ -24,7 +24,7 @@ public class MainActivity extends ReactActivity {
      */
     @Override
     protected boolean getUseDeveloperSupport() {
-        return true;
+        return BuildConfig.DEBUG;
     }
 
     /**

--- a/local-cli/generator-android/templates/src/app/BUCK
+++ b/local-cli/generator-android/templates/src/app/BUCK
@@ -39,7 +39,15 @@ android_library(
   ]),
   deps = [
     ':all-libs',
-    ':res'
+    ':res',
+    ':build_config',
+  ],
+)
+
+android_build_config(
+  name = 'build_config',
+  package = '<%= package %>',
+  values = [
   ],
 )
 
@@ -51,6 +59,7 @@ android_resource(
 
 android_binary(
   name = 'app',
+  package_type = 'debug',
   manifest = 'src/main/AndroidManifest.xml',
   keystore = '//android/keystores:debug',
   deps = [

--- a/local-cli/generator-android/templates/src/app/BUCK
+++ b/local-cli/generator-android/templates/src/app/BUCK
@@ -1,0 +1,59 @@
+import re
+
+# See [Docs](https://buckbuild.com/) to learn what BUCK is.
+# To run your application with BUCK you need:
+# - install BUCK
+# - `npm start` - to start the packager
+# - `cd android`
+# - `cp ~/.android/debug.keystore keystores/debug.keystore`
+# - `./gradlew :app:copyDownloadableDepsToLibs` - make all Gradle compile dependencies available to BUCK
+# - `buck install -r android-app` - compile, install and run application
+#
+
+lib_deps = []
+for jarfile in glob(['libs/*.jar']):
+  name = 'jars__' + re.sub(r'^.*/([^/]+)\.jar$', r'\1', jarfile)
+  lib_deps.append(':' + name)
+  prebuilt_jar(
+    name = name,
+    binary_jar = jarfile,
+  )
+
+for aarfile in glob(['libs/*.aar']):
+  name = 'aars__' + re.sub(r'^.*/([^/]+)\.aar$', r'\1', aarfile)
+  lib_deps.append(':' + name)
+  android_prebuilt_aar(
+    name = name,
+    aar = aarfile,
+  )
+
+android_library(
+  name = 'all-libs',
+  exported_deps = lib_deps
+)
+
+android_library(
+  name = 'app-code',
+  srcs = glob([
+    'src/main/java/**/*.java',
+  ]),
+  deps = [
+    ':all-libs',
+    ':res'
+  ],
+)
+
+android_resource(
+  name = 'res',
+  res = 'src/main/res',
+  package = '<%= package %>',
+)
+
+android_binary(
+  name = 'app',
+  manifest = 'src/main/AndroidManifest.xml',
+  keystore = '//android/keystores:debug',
+  deps = [
+    ':app-code',
+  ],
+)

--- a/local-cli/generator-android/templates/src/app/BUCK
+++ b/local-cli/generator-android/templates/src/app/BUCK
@@ -1,13 +1,13 @@
 import re
 
-# See [Docs](https://buckbuild.com/) to learn what BUCK is.
-# To run your application with BUCK you need:
-# - install BUCK
+# To learn about Buck see [Docs](https://buckbuild.com/).
+# To run your application with Buck:
+# - install Buck
 # - `npm start` - to start the packager
 # - `cd android`
 # - `cp ~/.android/debug.keystore keystores/debug.keystore`
-# - `./gradlew :app:copyDownloadableDepsToLibs` - make all Gradle compile dependencies available to BUCK
-# - `buck install -r android-app` - compile, install and run application
+# - `./gradlew :app:copyDownloadableDepsToLibs` - make all Gradle compile dependencies available to Buck
+# - `buck install -r android/app` - compile, install and run application
 #
 
 lib_deps = []
@@ -47,8 +47,6 @@ android_library(
 android_build_config(
   name = 'build_config',
   package = '<%= package %>',
-  values = [
-  ],
 )
 
 android_resource(

--- a/local-cli/generator-android/templates/src/app/build.gradle
+++ b/local-cli/generator-android/templates/src/app/build.gradle
@@ -124,3 +124,10 @@ dependencies {
     compile "com.android.support:appcompat-v7:23.0.1"
     compile "com.facebook.react:react-native:+"  // From node_modules
 }
+
+// Run this once to be able to run the application with BUCK
+// puts all compile dependencies into folder libs for BUCK to use
+task copyDownloadableDepsToLibs(type: Copy) {
+  from configurations.compile
+  into 'libs'
+}

--- a/local-cli/generator-android/templates/src/app/src/main/AndroidManifest.xml
+++ b/local-cli/generator-android/templates/src/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
     android:versionName="1.0">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
 
     <uses-sdk
         android:minSdkVersion="16"

--- a/local-cli/generator-android/templates/src/app/src/main/AndroidManifest.xml
+++ b/local-cli/generator-android/templates/src/app/src/main/AndroidManifest.xml
@@ -1,8 +1,13 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="<%= package %>">
+    package="<%= package %>"
+    android:versionCode="1"
+    android:versionName="1.0">
 
     <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
+
+    <uses-sdk
+        android:minSdkVersion="16"
+        android:targetSdkVersion="22" />
 
     <application
       android:allowBackup="true"

--- a/local-cli/generator-android/templates/src/app/src/main/AndroidManifest.xml
+++ b/local-cli/generator-android/templates/src/app/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
     package="<%= package %>">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
 
     <application
       android:allowBackup="true"

--- a/local-cli/generator-android/templates/src/keystores/BUCK
+++ b/local-cli/generator-android/templates/src/keystores/BUCK
@@ -1,0 +1,8 @@
+keystore(
+  name = 'debug',
+  store = 'debug.keystore',
+  properties = 'debug.keystore.properties',
+  visibility = [
+    'PUBLIC',
+  ],
+)

--- a/local-cli/generator-android/templates/src/keystores/debug.keystore.properties
+++ b/local-cli/generator-android/templates/src/keystores/debug.keystore.properties
@@ -1,0 +1,4 @@
+key.store=debug.keystore
+key.alias=androiddebugkey
+key.store.password=android
+key.alias.password=android

--- a/local-cli/generator/index.js
+++ b/local-cli/generator/index.js
@@ -64,6 +64,10 @@ module.exports = yeoman.generators.NamedBase.extend({
       this.templatePath('_watchmanconfig'),
       this.destinationPath('.watchmanconfig')
     );
+    this.fs.copy(
+      this.templatePath('_buckconfig'),
+      this.destinationPath('.buckconfig')
+    );
   },
 
   writing: function() {

--- a/local-cli/generator/templates/_buckconfig
+++ b/local-cli/generator/templates/_buckconfig
@@ -1,0 +1,9 @@
+
+[android]
+  target = Google Inc.:Google APIs:23
+
+[maven_repositories]
+  central = https://repo1.maven.org/maven2
+
+[alias]
+  android-app = //android/app:app

--- a/local-cli/generator/templates/_buckconfig
+++ b/local-cli/generator/templates/_buckconfig
@@ -4,6 +4,3 @@
 
 [maven_repositories]
   central = https://repo1.maven.org/maven2
-
-[alias]
-  android-app = //android/app:app

--- a/local-cli/generator/templates/_gitignore
+++ b/local-cli/generator/templates/_gitignore
@@ -32,3 +32,9 @@ local.properties
 #
 node_modules/
 npm-debug.log
+
+# BUCK
+buck-out/
+\.buckd/
+android/app/libs
+android/keystores/debug.keystore

--- a/local-cli/generator/templates/index.ios.js
+++ b/local-cli/generator/templates/index.ios.js
@@ -1,6 +1,7 @@
 /**
  * Sample React Native App
  * https://github.com/facebook/react-native
+ * @flow
  */
 
 import React, {
@@ -29,6 +30,10 @@ class <%= name %> extends Component {
     );
   }
 }
+
+// TODO testing flow
+const a: number = 2;
+a = "2";
 
 const styles = StyleSheet.create({
   container: {

--- a/local-cli/generator/templates/index.ios.js
+++ b/local-cli/generator/templates/index.ios.js
@@ -31,10 +31,6 @@ class <%= name %> extends Component {
   }
 }
 
-// TODO testing flow
-const a: number = 2;
-a = "2";
-
 const styles = StyleSheet.create({
   container: {
     flex: 1,

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -62,36 +62,44 @@ npm install -g $CLI_PACKAGE
 react-native init EndToEndTest --version $PACKAGE
 cd EndToEndTest
 
-case $1 in
-"--packager"*)
-  echo "Running a basic packager test"
-  # Check the packager produces a bundle (doesn't throw an error)
-  react-native bundle --platform android --dev true --entry-file index.android.js --bundle-output android-bundle.js
-  # TODO do flow check
-  ;;
-"--ios"*)
-  echo "Running an iOS app"
-  cd ios
-  # Make sure we installed local version of react-native
-  ls EndToEndTest/`basename $MARKER_IOS` > /dev/null
-  ../node_modules/react-native/packager/packager.sh --nonPersistent &
-  SERVER_PID=$!
-  # Start the app on the simulator
-  xctool -scheme EndToEndTest -sdk iphonesimulator test
-  ;;
-"--android"*)
-  echo "Running an Android app"
-  cd android
-  # Make sure we installed local version of react-native
-  ls `basename $MARKER_ANDROID` > /dev/null
-  ../node_modules/react-native/packager/packager.sh --nonPersistent &
-  SERVER_PID=$!
-  # TODO Start the app and check it renders "Welcome to React Native"
-  echo "The Android e2e test is not implemented yet" >&2
-  exit 1
-  ;;
-*)
-  echo "Please run the script with --ios, --android or --packager" >&2
-  exit 1
-  ;;
-esac
+while test $# -gt 0
+do
+  case $1 in
+  "--packager"*)
+    echo "Running a basic packager test"
+    # Check the packager produces a bundle (doesn't throw an error)
+    react-native bundle --platform android --dev true --entry-file index.android.js --bundle-output android-bundle.js
+    # Check that flow passes
+    $ROOT/node_modules/.bin/flow check
+    ;;
+  "--ios"*)
+    echo "Running an iOS app"
+    cd ios
+    # Make sure we installed local version of react-native
+    ls EndToEndTest/`basename $MARKER_IOS` > /dev/null
+    ../node_modules/react-native/packager/packager.sh --nonPersistent &
+    SERVER_PID=$!
+    # Start the app on the simulator
+    xctool -scheme EndToEndTest -sdk iphonesimulator test
+    ;;
+  "--android"*)
+    echo "Running an Android app"
+    cd android
+    # Make sure we installed local version of react-native
+    ls `basename $MARKER_ANDROID` > /dev/null
+    ../node_modules/react-native/packager/packager.sh --nonPersistent &
+    SERVER_PID=$!
+    cp ~/.android/debug.keystore keystores/debug.keystore
+    ./gradlew :app:copyDownloadableDepsToLibs
+    buck install -r android-app
+    # TODO t10114777 check it renders "Welcome to React Native"
+    ;;
+  *)
+    echo "Please run the script with --ios, --android or --packager" >&2
+    exit 1
+    ;;
+  esac
+  shift
+done
+
+exit 0

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -62,6 +62,8 @@ npm install -g $CLI_PACKAGE
 react-native init EndToEndTest --version $PACKAGE
 cd EndToEndTest
 
+# iterates all arguments and runs e2e tests for all of them one by one
+# e.g. ./scripts/e2e-test.sh --packager --ios --android will run all e2e tests but will install the test app once
 while test $# -gt 0
 do
   case $1 in

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -62,7 +62,7 @@ npm install -g $CLI_PACKAGE
 react-native init EndToEndTest --version $PACKAGE
 cd EndToEndTest
 
-# iterates all arguments and runs e2e tests for all of them one by one
+# Iterates through all arguments and runs e2e tests for all of them one by one
 # e.g. ./scripts/e2e-test.sh --packager --ios --android will run all e2e tests but will install the test app once
 while test $# -gt 0
 do

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -93,7 +93,7 @@ do
     SERVER_PID=$!
     cp ~/.android/debug.keystore keystores/debug.keystore
     ./gradlew :app:copyDownloadableDepsToLibs
-    buck install -r android-app
+    buck install -r android/app
     # TODO t10114777 check it renders "Welcome to React Native"
     ;;
   *)


### PR DESCRIPTION
BUCK is faster than Gradle.
For example `gradle app:installDebug` vs `buck install app` is ~7 seconds vs ~2 seconds with warm caches.
This is just the beginning to allow people to become familiar with BUCK.
It is enough for running the app locally and testing on a device.

Gradle is still used for dependency resolution.

Test Plan:
```
npm pack
cd /temp
react-native --init TestProject --version <path to RN src>/react-native-1000.0.0.tgz
```

After that:
```
cd TestProject
npm start
cd android
cp ~/.android/debug.keystore keystores/debug.keystore
./gradlew :app:copyDownloadableDepsToLibs
buck install -r android-app
```