### PR TITLE
Fix refreshing state

### DIFF
--- a/React/Views/RCTRefreshControl.m
+++ b/React/Views/RCTRefreshControl.m
@@ -14,6 +14,7 @@
 @implementation RCTRefreshControl {
   BOOL _initialRefreshingState;
   BOOL _isInitialRender;
+  BOOL _currentRefreshingState;
 }
 
 - (instancetype)init
@@ -21,6 +22,7 @@
   if ((self = [super init])) {
     [self addTarget:self action:@selector(refreshControlValueChanged) forControlEvents:UIControlEventValueChanged];
     _isInitialRender = true;
+    _currentRefreshingState = false;
   }
   return self;
 }
@@ -94,7 +96,9 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
 
 - (void)setRefreshing:(BOOL)refreshing
 {
-  if (self.refreshing != refreshing) {
+  if (_currentRefreshingState != refreshing) {
+    _currentRefreshingState = refreshing;
+
     if (refreshing) {
       // If it is the initial render, beginRefreshing will get called
       // in layoutSubviews.
@@ -111,6 +115,8 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
 
 - (void)refreshControlValueChanged
 {
+  _currentRefreshingState = super.refreshing;
+
   if (_onRefresh) {
     _onRefresh(nil);
   }


### PR DESCRIPTION
When RefreshControl.refreshing change twice within 250ms, it ignores the second changing.

**Test plan (required)**

```
refresh () {
  this.setState({
    refreshing: true
  })

  fetch('/api')
  .then(() => {
    this.setState({
      refreshing: false
    })
  })
  .catch((error) => {
    this.setState({
      refreshing: false
    })
  })
}

render() {
  return (
    <ScrollView
      refreshControl={
        <RefreshControl
          refreshing={this.state.refreshing}
          onRefresh={this.refresh.bind(this)}
        />
      }>
      <TouchableHighlight onPress={this.refresh.bind(this)}>
        <View>
          <Text>Touch Me!</Text>
        </View>
      </TouchableHighlight>
    </ScrollView>
  )
}
```

* Test Case 1: Touch "Touch Me!", if get response less than 250ms, the state is always refreshing.

* Test Case 2: Close network, Touch "Touch Me!", the state is always refreshing.