### PR TITLE
[IOS]Modify text input Chinese association limited BUG

### DIFF
--- a/Libraries/Text/RCTTextField.m
+++ b/Libraries/Text/RCTTextField.m
@@ -167,6 +167,14 @@ static void RCTUpdatePlaceholder(RCTTextField *self)
 
 - (void)textFieldDidChange
 {
+  // modify by xiaozh
+  if(_maxLength){
+    if (self.text.length > _maxLength.intValue) {
+          self.text = [self.text substringToIndex:_maxLength.intValue];
+        }
+  }
+  // end
+  
   _nativeEventCount++;
   [_eventDispatcher sendTextEventWithType:RCTTextEventTypeChange
                                  reactTag:self.reactTag

--- a/Libraries/Text/RCTTextFieldManager.m
+++ b/Libraries/Text/RCTTextFieldManager.m
@@ -42,7 +42,12 @@ RCT_EXPORT_MODULE()
   }
   NSUInteger allowedLength = textField.maxLength.integerValue - textField.text.length + range.length;
   if (string.length > allowedLength) {
-    if (string.length > 1) {
+    
+    // modify by xiaozh
+//    if (string.length > 1) {
+    if (string.length > 1 && [textField.text isEqualToString:@""]) {
+    // end
+      
       // Truncate the input string so the result is exactly maxLength
       NSString *limitedString = [string substringToIndex:allowedLength];
       NSMutableString *newString = textField.text.mutableCopy;

--- a/Libraries/Text/RCTTextView.m
+++ b/Libraries/Text/RCTTextView.m
@@ -327,12 +327,17 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
   }
   NSUInteger allowedLength = _maxLength.integerValue - textView.text.length + range.length;
   if (text.length > allowedLength) {
-    if (text.length > 1) {
+    
+    // modify by xiaozh
+    if (text.length > 1 && [text isEqualToString:@""]) {
+    // end
+      
       // Truncate the input string so the result is exactly maxLength
       NSString *limitedString = [text substringToIndex:allowedLength];
       NSMutableString *newString = textView.text.mutableCopy;
       [newString replaceCharactersInRange:range withString:limitedString];
       textView.text = newString;
+      
       // Collapse selection at end of insert to match normal paste behavior
       UITextPosition *insertEnd = [textView positionFromPosition:textView.beginningOfDocument
                                                           offset:(range.location + allowedLength)];
@@ -436,6 +441,13 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
 
 - (void)textViewDidChange:(UITextView *)textView
 {
+  
+  if(_maxLength){
+    if (textView.text.length > _maxLength.integerValue) {
+      textView.text = [textView.text substringToIndex:_maxLength.integerValue];
+    }
+  }
+  
   [self updateContentSize];
   [self _setPlaceholderVisibility];
   _nativeEventCount++;


### PR DESCRIPTION
Keyboard input text limit is no problem, but Chinese input for lenovo
function, so text limit invalid problem.Now I put it in the input
method for Chinese change into the model, more than words could not
enter