### PR TITLE
Expose StyleSheetPropType and ViewStylePropTypes

### DIFF
--- a/Libraries/react-native/react-native.js
+++ b/Libraries/react-native/react-native.js
@@ -101,6 +101,8 @@ var ReactNative = {
   get ColorPropType() { return require('ColorPropType'); },
   get EdgeInsetsPropType() { return require('EdgeInsetsPropType'); },
   get PointPropType() { return require('PointPropType'); },
+  get StyleSheetPropType() { return require('StyleSheetPropType'); },
+  get ViewStylePropTypes() { return require('ViewStylePropTypes'); },
 
   // See http://facebook.github.io/react/docs/addons.html
   addons: {


### PR DESCRIPTION
This exposes `StyleSheetPropType` and `ViewStylePropTypes` as part of the `react-native` exports.

This allows components to define `style` `propTypes` that they may require. It would also creating custom style rules that will allow granularity in what styles are permissible on the custom component.

```jsx
class CustomView extends React.Component {
  static propTypes = {
    style: StyleSheetPropType(ViewStylePropTypes)
  };
  render() {
    return (
      <View style={this.props.style}>..</View>
    );
  }
}
```

Inspiration has been taken from how prop types are defined in [View](https://github.com/facebook/react-native/blob/56c40baa06fc98a69e5193022310072b7a842416/Libraries/Components/View/View.js#L26) and [ScrollView](https://github.com/facebook/react-native/blob/56c40baa06fc98a69e5193022310072b7a842416/Libraries/Components/ScrollView/ScrollView.js#L126). Theoretically more style related prop types can be exposed, but first I'd like to see how this is received.


Current workaround:
```jsx
class CustomView extends React.Component {
  static propTypes = {
    style: View.propTypes.style
  };
  render() {
    return (
      <View style={this.props.style}>..</View>
    );
  }
}
```