### PR TITLE
[iOS] Prevent loading message from resetting simulator orientation on every reload.

### DIFF
--- a/React/Modules/RCTDevLoadingView.m
+++ b/React/Modules/RCTDevLoadingView.m
@@ -70,7 +70,7 @@ RCT_EXPORT_METHOD(showMessage:(NSString *)message color:(UIColor *)color backgro
       _window.windowLevel = UIWindowLevelStatusBar + 1;
 
       // set a root VC so rotation is supported
-      _window.rootViewController = [RCTModalHostViewController new];
+      _window.rootViewController = [UIViewController new];
 
       _label = [[UILabel alloc] initWithFrame:_window.bounds];
       _label.font = [UIFont systemFontOfSize:12.0];


### PR DESCRIPTION
If you're working on an app that needs to support landscape, reloading the app causes the iPhone simulator to reset its orientation to portrait every time the `RCTDevLoadingView` shows up. This is because it sets the root VC to `RCTModalHostViewController`, which currently supports only portrait orientations on iPhone. Changing the root view to a vanilla `UIViewController` fixes the issue.

**Steps to Reproduce**

1. Create a blank RN project: `react-native init RNTest`
2. Open it up and run it.
3. Rotate to landscape `Cmd+Right Arrow`.
4. Reload by pressing `Cmd+R`.

**Expected**

The simulator stays in landscape mode.

**Actual**

The simulator goes back to portrait.