### PR TITLE
Remove use of Object.assign module

### DIFF
--- a/Libraries/ReactNative/ReactNativeTextComponent.js
+++ b/Libraries/ReactNative/ReactNativeTextComponent.js
@@ -14,14 +14,13 @@
 var ReactNativeTagHandles = require('ReactNativeTagHandles');
 var UIManager = require('UIManager');
 
-var assign = require('Object.assign');
 var invariant = require('fbjs/lib/invariant');
 
 var ReactNativeTextComponent = function(props) {
   // This constructor and its argument is currently used by mocks.
 };
 
-assign(ReactNativeTextComponent.prototype, {
+Object.assign(ReactNativeTextComponent.prototype, {
 
   construct: function(text) {
     // This is really a ReactText (ReactNode), not a ReactElement


### PR DESCRIPTION
I'm [getting rid of it from React](https://github.com/facebook/react/pull/6376) and so I'd like to get this in before we accidentally break RN. There are a bunch of other uses of Object.assign directly so this should be perfectly safe.