### PR TITLE
[Flow] Use semver in the .flowconfig version number

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -92,4 +92,4 @@ suppress_comment=\\(.\\|\n\\)*\\$FlowIssue\\((\\(>=0\\.\\(2[0-2]\\|1[0-9]\\|[0-9
 suppress_comment=\\(.\\|\n\\)*\\$FlowFixedInNextDeploy
 
 [version]
-0.22.0
+^0.22.0


### PR DESCRIPTION
Flow 0.22.1 is the latest release, but RN asks for 0.22.0 in the .flowconfig file. This commit makes use of Flow's support for semver matching (https://github.com/facebook/flow/issues/592) so that the latest version of Flow can be used as long as it's semver-compatible.
    
Test Plan: Use Flow 0.22.1 on the code base. CI tests to make sure Flow 0.22.0 still works.