### PR TITLE
Modified buildBundle to Avoid TypeException

### DIFF
--- a/local-cli/bundle/buildBundle.js
+++ b/local-cli/bundle/buildBundle.js
@@ -18,7 +18,9 @@ function buildBundle(args, config, output = outputBundle, packagerInstance) {
 
     // This is used by a bazillion of npm modules we don't control so we don't
     // have other choice than defining it as an env variable here.
-    process.env.NODE_ENV = args.dev ? 'development' : 'production';
+    // process.env.NODE_ENV can throw "property read only" TypeException.
+    var _env = process.env;
+    _env.NODE_ENV = args.dev ? 'development' : 'production';
 
     const options = {
       projectRoots: config.getProjectRoots(),


### PR DESCRIPTION
As crazy as this may seem, the following code can throw an exception when using babel's `transform-inline-environment-variables` plugin.

```
process.env.NODE_ENV = args.dev ? 'development' : 'production';
```

The exception reads as follows:

```
TypeError: Cannot assign to read only property 'undefined' of [object Object]
    at buildBundle.js:22:5
```

Here are the steps to reproduce this problem:
.babelrc:
```
{
    "presets": [
        "react-native"
    ],
    "plugins": [
        "transform-inline-environment-variables"
    ]
}
```
node v5.0.0
react-native-cli: 0.2.0
react-native: 0.19.0
`react-native bundle --platform ios --dev false --entry-file index.ios.js --bundle-output ios/main.jsbundle`
