### PR TITLE
[gitignore] Add gradle wrapper files for example projects to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,9 @@ project.xcworkspace
 # Gradle
 /build/
 /Examples/**/android/app/build/
+/Examples/**/android/app/gradle/
+/Examples/**/android/app/gradlew
+/Examples/**/android/app/gradlew.bat
 /ReactAndroid/build/
 
 # Buck


### PR DESCRIPTION
Hide the gradle wrapper files for example projects like the UIExplorer
    
Test Plan: `git status` no longer shows gradle wrapper files for the UIExplorer