### PR TITLE
Add support for delete animation in LayoutAnimation on iOS

### DIFF
--- a/Examples/UIExplorer/LayoutAnimationExample.js
+++ b/Examples/UIExplorer/LayoutAnimationExample.js
@@ -32,14 +32,16 @@ const AddRemoveExample = React.createClass({
     };
   },
 
-  _onPressAddView() {
+  componentWillUpdate() {
     LayoutAnimation.easeInEaseOut();
-    this.setState({views: [...this.state.views, {}]});
+  },
+
+  _onPressAddView() {
+    this.setState((state) => ({views: [...state.views, {}]}));
   },
 
   _onPressRemoveView() {
-    LayoutAnimation.easeInEaseOut();
-    this.setState({views: this.state.views.slice(0, -1)});
+    this.setState((state) => ({views: state.views.slice(0, -1)}));
   },
 
   render() {
@@ -65,7 +67,7 @@ const AddRemoveExample = React.createClass({
         </View>
       </View>
     );
-  }
+  },
 });
 
 const GreenSquare = () =>
@@ -88,7 +90,7 @@ const CrossFadeExample = React.createClass({
 
   _onPressToggle() {
     LayoutAnimation.easeInEaseOut();
-    this.setState({toggled: !this.state.toggled});
+    this.setState((state) => ({toggled: !state.toggled}));
   },
 
   render() {
@@ -108,10 +110,10 @@ const CrossFadeExample = React.createClass({
         </View>
       </View>
     );
-  }
+  },
 });
 
-var styles = StyleSheet.create({
+const styles = StyleSheet.create({
   container: {
     flex: 1,
   },
@@ -155,8 +157,7 @@ var styles = StyleSheet.create({
 
 exports.title = 'Layout Animation';
 exports.description = 'Layout animation';
-exports.examples = [
-{
+exports.examples = [{
   title: 'Add and remove views',
   render(): ReactElement {
     return <AddRemoveExample />;
@@ -165,5 +166,5 @@ exports.examples = [
   title: 'Cross fade views',
   render(): ReactElement {
     return <CrossFadeExample />;
-  }
+  },
 }];

--- a/Examples/UIExplorer/LayoutAnimationExample.js
+++ b/Examples/UIExplorer/LayoutAnimationExample.js
@@ -68,6 +68,49 @@ const AddRemoveExample = React.createClass({
   }
 });
 
+const GreenSquare = () =>
+  <View style={styles.greenSquare}>
+    <Text>Green square</Text>
+  </View>;
+
+const BlueSquare = () =>
+  <View style={styles.blueSquare}>
+    <Text>Blue square</Text>
+  </View>;
+
+const CrossFadeExample = React.createClass({
+
+  getInitialState() {
+    return {
+      toggled: false,
+    };
+  },
+
+  _onPressToggle() {
+    LayoutAnimation.easeInEaseOut();
+    this.setState({toggled: !this.state.toggled});
+  },
+
+  render() {
+    return (
+      <View style={styles.container}>
+        <TouchableOpacity onPress={this._onPressToggle}>
+          <View style={styles.button}>
+            <Text>Toggle</Text>
+          </View>
+        </TouchableOpacity>
+        <View style={styles.viewContainer}>
+          {
+            this.state.toggled ?
+            <GreenSquare /> :
+            <BlueSquare />
+          }
+        </View>
+      </View>
+    );
+  }
+});
+
 var styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -94,6 +137,20 @@ var styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
   },
+  greenSquare: {
+    width: 150,
+    height: 150,
+    backgroundColor: 'green',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  blueSquare: {
+    width: 150,
+    height: 150,
+    backgroundColor: 'blue',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
 });
 
 exports.title = 'Layout Animation';
@@ -104,4 +161,9 @@ exports.examples = [
   render(): ReactElement {
     return <AddRemoveExample />;
   },
+}, {
+  title: 'Cross fade views',
+  render(): ReactElement {
+    return <CrossFadeExample />;
+  }
 }];

--- a/Examples/UIExplorer/LayoutAnimationExample.js
+++ b/Examples/UIExplorer/LayoutAnimationExample.js
@@ -1,0 +1,107 @@
+/**
+ * The examples provided by Facebook are for non-commercial testing and
+ * evaluation purposes only.
+ *
+ * Facebook reserves all rights not expressly granted.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON INFRINGEMENT. IN NO EVENT SHALL
+ * FACEBOOK BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * @flow
+ */
+'use strict';
+
+const React = require('react-native');
+const {
+  LayoutAnimation,
+  StyleSheet,
+  Text,
+  View,
+  TouchableOpacity,
+} = React;
+
+const AddRemoveExample = React.createClass({
+
+  getInitialState() {
+    return {
+      views: [],
+    };
+  },
+
+  _onPressAddView() {
+    LayoutAnimation.easeInEaseOut();
+    this.setState({views: [...this.state.views, {}]});
+  },
+
+  _onPressRemoveView() {
+    LayoutAnimation.easeInEaseOut();
+    this.setState({views: this.state.views.slice(0, -1)});
+  },
+
+  render() {
+    const views = this.state.views.map((view, i) =>
+      <View key={i} style={styles.view}>
+        <Text>{i}</Text>
+      </View>
+    );
+    return (
+      <View style={styles.container}>
+        <TouchableOpacity onPress={this._onPressAddView}>
+          <View style={styles.button}>
+            <Text>Add view</Text>
+          </View>
+        </TouchableOpacity>
+        <TouchableOpacity onPress={this._onPressRemoveView}>
+          <View style={styles.button}>
+            <Text>Remove view</Text>
+          </View>
+        </TouchableOpacity>
+        <View style={styles.viewContainer}>
+          {views}
+        </View>
+      </View>
+    );
+  }
+});
+
+var styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  button: {
+    borderRadius: 5,
+    backgroundColor: '#eeeeee',
+    padding: 10,
+    marginBottom: 10,
+  },
+  buttonText: {
+    fontSize: 16,
+  },
+  viewContainer: {
+    flex: 1,
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+  },
+  view: {
+    height: 54,
+    width: 54,
+    backgroundColor: 'red',
+    margin: 8,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});
+
+exports.title = 'Layout Animation';
+exports.description = 'Layout animation';
+exports.examples = [
+{
+  title: 'Add and remove views',
+  render(): ReactElement {
+    return <AddRemoveExample />;
+  },
+}];

--- a/Examples/UIExplorer/LayoutAnimationExample.js
+++ b/Examples/UIExplorer/LayoutAnimationExample.js
@@ -15,14 +15,15 @@
  */
 'use strict';
 
-const React = require('react-native');
+const React = require('react');
+const ReactNative = require('react-native');
 const {
   LayoutAnimation,
   StyleSheet,
   Text,
   View,
   TouchableOpacity,
-} = React;
+} = ReactNative;
 
 const AddRemoveExample = React.createClass({
 

--- a/Examples/UIExplorer/UIExplorerList.android.js
+++ b/Examples/UIExplorer/UIExplorerList.android.js
@@ -139,6 +139,10 @@ const APIExamples = [
     module: require('./LinkingExample'),
   },
   {
+    key: 'LayoutAnimationExample',
+    module: require('./LayoutAnimationExample'),
+  },
+  {
     key: 'LayoutExample',
     module: require('./LayoutExample'),
   },

--- a/Examples/UIExplorer/UIExplorerList.ios.js
+++ b/Examples/UIExplorer/UIExplorerList.ios.js
@@ -193,6 +193,10 @@ var APIExamples: Array<UIExplorerExample> = [
     module: require('./ImageEditingExample'),
   },
   {
+    key: 'LayoutAnimationExample',
+    module: require('./LayoutAnimationExample'),
+  },
+  {
     key: 'LayoutExample',
     module: require('./LayoutExample'),
   },

--- a/Libraries/LayoutAnimation/LayoutAnimation.js
+++ b/Libraries/LayoutAnimation/LayoutAnimation.js
@@ -74,12 +74,6 @@ function configureNext(config: Config, onAnimationDidEnd?: Function) {
   UIManager.configureNextLayoutAnimation(
     config, onAnimationDidEnd || function() {}, function() { /* unused */ }
   );
-  // Clear the layout animation configuration after the current frame.
-  requestAnimationFrame(() => {
-    UIManager.configureNextLayoutAnimation(
-      null, function() { /* unused */ }, function() { /* unused */ }
-    );
-  });
 }
 
 function create(duration: number, type, creationProp): Config {
@@ -115,6 +109,10 @@ var Presets = {
     update: {
       type: Types.spring,
       springDamping: 0.4,
+    },
+    delete: {
+      type: Types.linear,
+      property: Properties.opacity,
     },
   },
 };

--- a/Libraries/LayoutAnimation/LayoutAnimation.js
+++ b/Libraries/LayoutAnimation/LayoutAnimation.js
@@ -74,6 +74,12 @@ function configureNext(config: Config, onAnimationDidEnd?: Function) {
   UIManager.configureNextLayoutAnimation(
     config, onAnimationDidEnd || function() {}, function() { /* unused */ }
   );
+  // Clear the layout animation configuration after the current frame.
+  requestAnimationFrame(() => {
+    UIManager.configureNextLayoutAnimation(
+      null, function() { /* unused */ }, function() { /* unused */ }
+    );
+  });
 }
 
 function create(duration: number, type, creationProp): Config {
@@ -85,6 +91,10 @@ function create(duration: number, type, creationProp): Config {
     },
     update: {
       type,
+    },
+    delete: {
+      type,
+      property: creationProp,
     },
   };
 }

--- a/React/Modules/RCTUIManager.m
+++ b/React/Modules/RCTUIManager.m
@@ -755,6 +755,11 @@ RCT_EXPORT_METHOD(removeSubviewsFromContainerWithID:(nonnull NSNumber *)containe
 
     if (permanent && deleteAnimation && [removedChild isKindOfClass: [UIView class]]) {
       UIView *view = (UIView *)removedChild;
+
+      // Disable user interaction while the view is animating since JS won't receive
+      // the view events anyway.
+      view.userInteractionEnabled = NO;
+
       [deleteAnimation performAnimations:^{
         if ([deleteAnimation.property isEqual:@"scaleXY"]) {
           view.layer.transform = CATransform3DMakeScale(0, 0, 0);
@@ -884,8 +889,8 @@ RCT_EXPORT_METHOD(manageChildren:(nonnull NSNumber *)containerReactTag
     [self _childrenToRemoveFromContainer:container atIndices:removeAtIndices];
   NSArray<id<RCTComponent>> *temporarilyRemovedChildren =
     [self _childrenToRemoveFromContainer:container atIndices:moveFromIndices];
-  [self _removeChildren:permanentlyRemovedChildren fromContainer:container permanent: true];
-  [self _removeChildren:temporarilyRemovedChildren fromContainer:container permanent: false];
+  [self _removeChildren:permanentlyRemovedChildren fromContainer:container permanent:true];
+  [self _removeChildren:temporarilyRemovedChildren fromContainer:container permanent:false];
 
   [self _purgeChildren:permanentlyRemovedChildren fromRegistry:registry];
 


### PR DESCRIPTION
This adds support for delete view animations in LayoutAnimation for iOS. It supports the same properties as the create animation (alpha, scale).

This allows making simple animations when removing a view which is normally hard to do in React since we need to not remove the view node immediately.

**Test plan**
Tested add/removing views in the UIExample explorer with and without setting a LayoutAnimation. Also tested that the completion callback still works properly. Tested that user interation during the animation is properly disabled.

![layout-anim2](https://cloud.githubusercontent.com/assets/2677334/14595471/86fb1654-050d-11e6-8b38-fe45cc2dcd71.gif)

I also plan to work on improving the doc for LayoutAnimation as well as making this PR for android too.