### PR TITLE
Add transform-es2015-function-name to the react-native babel preset. Fixes #6716

### DIFF
--- a/babel-preset/configs/main.js
+++ b/babel-preset/configs/main.js
@@ -18,6 +18,7 @@ module.exports = {
     'syntax-class-properties',
     'syntax-trailing-function-commas',
     'transform-class-properties',
+    'transform-es2015-function-name',
     'transform-es2015-arrow-functions',
     'transform-es2015-block-scoping',
     'transform-es2015-classes',

--- a/babel-preset/package.json
+++ b/babel-preset/package.json
@@ -22,6 +22,7 @@
     "babel-plugin-syntax-jsx": "^6.5.0",
     "babel-plugin-syntax-trailing-function-commas": "^6.5.0",
     "babel-plugin-transform-class-properties": "^6.5.0",
+    "babel-plugin-transform-es2015-function-name": "^6.5.0",
     "babel-plugin-transform-es2015-arrow-functions": "^6.5.0",
     "babel-plugin-transform-es2015-block-scoping": "^6.5.0",
     "babel-plugin-transform-es2015-classes": "^6.5.0",

--- a/babel-preset/plugins.js
+++ b/babel-preset/plugins.js
@@ -14,6 +14,7 @@ module.exports = {
   'babel-plugin-syntax-class-properties': require('babel-plugin-syntax-class-properties'),
   'babel-plugin-syntax-trailing-function-commas': require('babel-plugin-syntax-trailing-function-commas'),
   'babel-plugin-transform-class-properties': require('babel-plugin-transform-class-properties'),
+  'babel-plugin-transform-es2015-function-name': require('babel-plugin-transform-es2015-function-name'),
   'babel-plugin-transform-es2015-arrow-functions': require('babel-plugin-transform-es2015-arrow-functions'),
   'babel-plugin-transform-es2015-block-scoping': require('babel-plugin-transform-es2015-block-scoping'),
   'babel-plugin-transform-es2015-classes': require('babel-plugin-transform-es2015-classes'),


### PR DESCRIPTION
Stateless function components (at least those using arrow functions) are not assigned names when this transform is omitted.

Rebased against master and kept the original author from #6717 

cc @martinbigio @bestander 