### PR TITLE
Update SignedAPKAndroid.md

### DIFF
--- a/docs/SignedAPKAndroid.md
+++ b/docs/SignedAPKAndroid.md
@@ -7,7 +7,7 @@ permalink: docs/signed-apk-android.html
 next: android-ui-performance
 ---
 
-To distribute your Android application via [Google Play store](https://play.google.com/store), you'll need to generate a signed release APK. The [Signing Your Applications](https://developer.android.com/tools/publishing/app-signing.html) page on Android Developers documentation describes the topic in detail. This guide covers the process in brief, as well as lists the steps required to packaging the JavaScript bundle.
+Android requires that all apps be digitally signed with a certificate before they can be installed, so to distribute your Android application via [Google Play store](https://play.google.com/store), you'll need to generate a signed release APK. The [Signing Your Applications](https://developer.android.com/tools/publishing/app-signing.html) page on Android Developers documentation describes the topic in detail. This guide covers the process in brief, as well as lists the steps required to packaging the JavaScript bundle.
 
 ### Generating a signing key
 


### PR DESCRIPTION
From the documentation I thought I only had to sign an application if I intended to publish it to the Play Store. Turns out this is not true. Signing is still required if you want to install the APK on any device at all. Unsigned APK's are for simulators only.