### PR TITLE
[android] Updated Elevation implementation so that it works with differents borders sizes

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewBackgroundDrawable.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewBackgroundDrawable.java
@@ -27,10 +27,10 @@ import android.graphics.RectF;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
 
-import com.facebook.react.common.annotations.VisibleForTesting;
 import com.facebook.csslayout.CSSConstants;
 import com.facebook.csslayout.FloatUtil;
 import com.facebook.csslayout.Spacing;
+import com.facebook.react.common.annotations.VisibleForTesting;
 
 /**
  * A subclass of {@link Drawable} used for background of {@link ReactViewGroup}. It supports
@@ -143,7 +143,7 @@ import com.facebook.csslayout.Spacing;
 
       outline.setConvexPath(mPathForBorderRadiusOutline);
     } else {
-      outline.setRect(getBounds());
+      outline.setConvexPath(getPathForBorderOutline());
     }
   }
 
@@ -302,6 +302,59 @@ import com.facebook.csslayout.Spacing;
     mPathEffectForBorderStyle = mBorderStyle != null
         ? mBorderStyle.getPathEffect(getFullBorderWidth())
         : null;
+  }
+
+  private Path getPathForBorderOutline() {
+    Path mPathForBorderOutline = new Path();
+
+    int borderLeft = getBorderWidth(Spacing.LEFT);
+    int borderTop = getBorderWidth(Spacing.TOP);
+    int borderRight = getBorderWidth(Spacing.RIGHT);
+    int borderBottom = getBorderWidth(Spacing.BOTTOM);
+    int colorLeft = getBorderColor(Spacing.LEFT);
+    int colorTop = getBorderColor(Spacing.TOP);
+    int colorRight = getBorderColor(Spacing.RIGHT);
+    int colorBottom = getBorderColor(Spacing.BOTTOM);
+
+    int width =  getBounds().width();
+    int height = getBounds().height();
+
+    // top left
+    if ((borderTop > 0 && colorTop != Color.TRANSPARENT) || (borderLeft > 0 && colorLeft != Color.TRANSPARENT)) {
+      mPathForBorderOutline.moveTo(0, 0);
+    } else {
+      mPathForBorderOutline.moveTo(borderLeft, borderTop);
+    }
+
+    // top right
+    if ((borderRight > 0 && colorRight != Color.TRANSPARENT) || (borderTop > 0 && colorTop != Color.TRANSPARENT)) {
+      mPathForBorderOutline.lineTo(width, 0);
+    } else {
+      mPathForBorderOutline.lineTo(width - borderRight, borderTop);
+    }
+
+    // bottom right
+    if ((borderBottom > 0 && colorBottom != Color.TRANSPARENT) || (borderRight > 0 && colorRight != Color.TRANSPARENT)) {
+      mPathForBorderOutline.lineTo(width, height);
+    } else {
+      mPathForBorderOutline.lineTo(width - borderRight, height - borderBottom);
+    }
+
+    // bottom left
+    if ((borderLeft > 0 && colorLeft != Color.TRANSPARENT) || (borderBottom > 0 && colorBottom != Color.TRANSPARENT)) {
+      mPathForBorderOutline.lineTo(0, height);
+    } else {
+      mPathForBorderOutline.lineTo(borderLeft, height - borderBottom);
+    }
+
+    // back to start
+    if ((borderTop > 0 && colorTop != Color.TRANSPARENT) || (borderLeft > 0 && colorLeft != Color.TRANSPARENT)) {
+      mPathForBorderOutline.lineTo(0, 0);
+    } else {
+      mPathForBorderOutline.lineTo(borderLeft, borderTop);
+    }
+
+    return mPathForBorderOutline;
   }
 
   /**


### PR DESCRIPTION
When using elevation while using the triangle css tricks, the shadow is not good.

before:
<img width="406" alt="capture d ecran 2016-03-31 a 12 15 57" src="https://cloud.githubusercontent.com/assets/5071029/14287012/392481ba-fb1f-11e5-954e-04a0bc5620df.png">

after:
<img width="420" alt="capture d ecran 2016-04-05 a 11 21 43" src="https://cloud.githubusercontent.com/assets/5071029/14287342/6478cf5a-fb20-11e5-9b9a-b6af904774b5.png">

