### PR TITLE
[CI] Re-order the TravisCI test matrix based on historical run times

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,9 @@ script:
 
 env:
   matrix:
-    - TEST_TYPE=objc
-    - TEST_TYPE=js
     - TEST_TYPE=e2e-objc
+    - TEST_TYPE=js
+    - TEST_TYPE=objc
 
 branches:
   only:


### PR DESCRIPTION
Travis CI runs the test matrix in the order specified in the YAML file. When there are enough available test VMs this doesn't matter since all matrix entries run in parallel, but we often don't have enough free VMs. So when there's a free VM, start running the slowest tests first. This way as more VMs become free, they will run the faster tests and can catch up. This should minimize the time required for a PR to turn green.

Test Plan: Run Travis CI tests.