### PR TITLE
Add support for `onPermissionRequestResult` callback

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/ReactActivity.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactActivity.java
@@ -182,6 +182,13 @@ public abstract class ReactActivity extends Activity implements DefaultHardwareB
   }
 
   @Override
+  public void onRequestPermissionsResult(int requestCode, String permissions[], int[] grantResults) {
+    if (mReactInstanceManager != null) {
+      mReactInstanceManager.onRequestPermissionsResult(requestCode, permissions, grantResults);
+    }
+  }
+
+  @Override
   public boolean onKeyUp(int keyCode, KeyEvent event) {
     if (mReactInstanceManager != null &&
         mReactInstanceManager.getDevSupportManager().getDevSupportEnabled()) {

--- a/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
@@ -113,6 +113,7 @@ public abstract class ReactInstanceManager {
    */
   public abstract void onHostDestroy();
   public abstract void onActivityResult(int requestCode, int resultCode, Intent data);
+  public abstract void onRequestPermissionsResult(int requestCode, String permissions[], int[] grantResults);
   public abstract void showDevOptionsDialog();
 
   /**

--- a/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManagerImpl.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManagerImpl.java
@@ -598,6 +598,13 @@ import static com.facebook.react.bridge.ReactMarkerConstants.RUN_JS_BUNDLE_START
   }
 
   @Override
+  public void onRequestPermissionsResult(int requestCode, String permissions[], int[] grantResults) {
+    if (mCurrentReactContext != null) {
+      mCurrentReactContext.onRequestPermissionsResult(requestCode, permissions, grantResults);
+    }
+  }
+
+  @Override
   public void showDevOptionsDialog() {
     UiThreadUtil.assertOnUiThread();
     mDevSupportManager.showDevOptionsDialog();

--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/PermissionRequestListener.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/PermissionRequestListener.java
@@ -1,0 +1,16 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+package com.facebook.react.bridge;
+
+import android.content.Intent;
+
+/**
+ * Listener for receiving activity events.
+ */
+public interface PermissionRequestListener {
+
+  /**
+   * Called when host (activity/service) receives an {@link Activity#onRequestPermissionsResult} permission request.
+   */
+  void onRequestPermissionsResult(int requestCode, String permissions[], int[] grantResults);
+}

--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactContext.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactContext.java
@@ -35,6 +35,8 @@ public class ReactContext extends ContextWrapper {
       new CopyOnWriteArraySet<>();
   private final CopyOnWriteArraySet<ActivityEventListener> mActivityEventListeners =
       new CopyOnWriteArraySet<>();
+  private final CopyOnWriteArraySet<PermissionRequestListener> mPermissionRequestListeners =
+          new CopyOnWriteArraySet<>();
 
   private @Nullable CatalystInstance mCatalystInstance;
   private @Nullable LayoutInflater mInflater;
@@ -138,6 +140,14 @@ public class ReactContext extends ContextWrapper {
     mActivityEventListeners.remove(listener);
   }
 
+  public void addPermissionRequestListener(PermissionRequestListener listener) {
+    mPermissionRequestListeners.add(listener);
+  }
+
+  public void removePermissionRequestListener(PermissionRequestListener listener) {
+    mPermissionRequestListeners.remove(listener);
+  }
+
   /**
    * Should be called by the hosting Fragment in {@link Fragment#onResume}
    */
@@ -187,6 +197,15 @@ public class ReactContext extends ContextWrapper {
   public void onActivityResult(int requestCode, int resultCode, Intent data) {
     for (ActivityEventListener listener : mActivityEventListeners) {
       listener.onActivityResult(requestCode, resultCode, data);
+    }
+  }
+
+  /**
+   * Should be called by the hosting Fragment in {@link Fragment#onRequestPermissionsResult}
+   */
+  public void onRequestPermissionsResult(int requestCode, String permissions[], int[] grantResults) {
+    for (PermissionRequestListener listener : mPermissionRequestListeners) {
+      listener.onRequestPermissionsResult(requestCode, permissions, grantResults);
     }
   }
 


### PR DESCRIPTION
On lollipop, while requesting permission, we need to listen to `onPermissionRequestResult` - http://developer.android.com/training/permissions/requesting.html

I've yet to test this, but just wanted feedback on whether this approach is good or we want to use a different approach.

cc @mkonicek @kmagiera @foghina 