### PR TITLE
Allow both HMR clients and live reloading clients

### DIFF
--- a/React/Modules/RCTDevMenu.m
+++ b/React/Modules/RCTDevMenu.m
@@ -653,7 +653,9 @@ RCT_EXPORT_METHOD(reload)
       if (strongSelf && strongSelf->_liveReloadEnabled) {
         NSHTTPURLResponse *HTTPResponse = (NSHTTPURLResponse *)response;
         if (!error && HTTPResponse.statusCode == 205) {
-          [strongSelf reload];
+          if (!strongSelf->_hotLoadingEnabled) {
+            [strongSelf reload];
+          }
         } else {
           strongSelf->_updateTask = nil;
           [strongSelf checkForUpdates];

--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevServerHelper.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevServerHelper.java
@@ -320,7 +320,12 @@ public class DevServerHelper {
 
   private void handleOnChangePollingResponse(boolean didServerContentChanged) {
     if (mOnChangePollingEnabled) {
-      if (didServerContentChanged) {
+      // before this commit, the package server doesn't inform changes to live reloading
+      // clients when one more HMR clients connected, this commit allow server informs
+      // both live reloading clients and HMR clients.
+      // when HMR enabled, live reload subscription doesnt't disconnect, so need disable
+      // live reloading.
+      if (didServerContentChanged && !mSettings.isHotModuleReplacementEnabled()) {
         UiThreadUtil.runOnUiThread(new Runnable() {
           @Override
           public void run() {

--- a/packager/react-packager/src/Server/index.js
+++ b/packager/react-packager/src/Server/index.js
@@ -291,7 +291,8 @@ class Server {
       // Clear cached bundles in case user reloads
       this._clearBundles();
       this._hmrFileChangeListener(absPath, this._bundler.stat(absPath));
-      return;
+      // when HMR clients connected, also allow live reloading clients
+      // return;
     }
 
     Promise.all(


### PR DESCRIPTION
In current implementation, if a HMR client conntcted, live reloading will be disabled, all other clients don't update. Sometimes we want multi clients both work, maybe some clients are live reloading and others are hot reloading, this PR allows them to work on same server.

**Test plan (required)**
In current implementation, packager server just allow one HMR client, so before every test begins, must set every clients to enable live reloading and disable live reloading and reload them. (because the last HMR client will overwrite other HMR clients notification, see: https://github.com/facebook/react-native/blob/a461d25601a3f63902a219632bdb6770993c60f0/local-cli/server/util/attachHMRServer.js#L132)

* Test 1: Connect multi clients, set an iOS client to hot reloading, update code, expect just this iOS client do hot reloading, and other clients reloaded.
* Test 2: Connect multi clients, set an Android client to hot reloading, update code, expect just this Android client do hot reloading, and other clients reloaded.
* Test 3: If also apply https://github.com/facebook/react-native/pull/6179, allow many clients work with hot reloading, and others work with live reloading.
