### PR TITLE
[XMLHttpRequest] Add support for ontimeout and onerror handler when using XMLHttpRequest for Android and iOS

### DIFF
--- a/Examples/UIExplorer/XHRExample.android.js
+++ b/Examples/UIExplorer/XHRExample.android.js
@@ -29,7 +29,7 @@ var {
 var XHRExampleHeaders = require('./XHRExampleHeaders');
 var XHRExampleCookies = require('./XHRExampleCookies');
 var XHRExampleFetch = require('./XHRExampleFetch');
-
+var XHRExampleOnTimeOut = require('./XHRExampleOnTimeOut');
 
 // TODO t7093728 This is a simplified XHRExample.ios.js.
 // Once we have Camera roll, Toast, Intent (for opening URLs)
@@ -296,6 +296,11 @@ exports.examples = [{
   title: 'Cookies',
   render() {
     return <XHRExampleCookies/>;
+  }
+}, {
+  title: 'Time Out Test',
+  render() {
+    return <XHRExampleOnTimeOut/>;
   }
 }];
 

--- a/Examples/UIExplorer/XHRExample.ios.js
+++ b/Examples/UIExplorer/XHRExample.ios.js
@@ -32,6 +32,7 @@ var {
 
 var XHRExampleHeaders = require('./XHRExampleHeaders');
 var XHRExampleFetch = require('./XHRExampleFetch');
+var XHRExampleOnTimeOut = require('./XHRExampleOnTimeOut');
 
 class Downloader extends React.Component {
   state: any;
@@ -330,6 +331,11 @@ exports.examples = [{
   title: 'Headers',
   render() {
     return <XHRExampleHeaders/>;
+  }
+}, {
+  title: 'Time Out Test',
+  render() {
+    return <XHRExampleOnTimeOut/>;
   }
 }];
 

--- a/Examples/UIExplorer/XHRExampleOnTimeOut.js
+++ b/Examples/UIExplorer/XHRExampleOnTimeOut.js
@@ -1,0 +1,110 @@
+/**
+ * The examples provided by Facebook are for non-commercial testing and
+ * evaluation purposes only.
+ *
+ * Facebook reserves all rights not expressly granted.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON INFRINGEMENT. IN NO EVENT SHALL
+ * FACEBOOK BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * @flow
+ */
+'use strict';
+
+var React = require('react');
+var ReactNative = require('react-native');
+var {
+  StyleSheet,
+  Text,
+  TouchableHighlight,
+  View,
+} = ReactNative;
+
+class XHRExampleOnTimeOut extends React.Component {
+  state: any;
+  xhr: XMLHttpRequest;
+
+  constructor(props: any) {
+    super(props);
+    this.state = {
+      status: '',
+      loading: false
+    };
+  }
+
+  loadTimeOutRequest() {
+    this.xhr && this.xhr.abort();
+
+    var xhr = this.xhr || new XMLHttpRequest();
+
+    xhr.onerror = ()=> {
+      console.log('Status ', xhr.status);
+      console.log('Error ', xhr.responseText);
+    };
+
+    xhr.ontimeout = () => {
+      this.setState({
+        status: xhr.responseText,
+        loading: false
+      });
+    };
+
+    xhr.onload = () => {
+      console.log('Status ', xhr.status);
+      console.log('Response ', xhr.responseText);
+    };
+
+    xhr.open('GET', 'https://httpbin.org/delay/5'); // request to take 5 seconds to load
+    xhr.timeout = 2000; // request times out in 2 seconds
+    xhr.send();
+    this.xhr = xhr;
+
+    this.setState({loading: true});
+  }
+
+  componentWillUnmount() {
+    this.xhr && this.xhr.abort();
+  }
+
+  render() {
+    var button = this.state.loading ? (
+      <View style={styles.wrapper}>
+        <View style={styles.button}>
+          <Text>Loading...</Text>
+        </View>
+      </View>
+    ) : (
+      <TouchableHighlight
+        style={styles.wrapper}
+        onPress={this.loadTimeOutRequest.bind(this)}>
+        <View style={styles.button}>
+         <Text>Make Time Out Request</Text>
+        </View>
+      </TouchableHighlight>
+    );
+
+    return (
+      <View>
+        {button}
+        <Text>{this.state.status}</Text>
+      </View>
+    );
+  }
+}
+
+var styles = StyleSheet.create({
+  wrapper: {
+    borderRadius: 5,
+    marginBottom: 5,
+  },
+  button: {
+    backgroundColor: '#eeeeee',
+    padding: 8,
+  },
+});
+
+module.exports = XHRExampleOnTimeOut;

--- a/Libraries/Network/RCTNetworking.m
+++ b/Libraries/Network/RCTNetworking.m
@@ -385,6 +385,7 @@ RCT_EXPORT_MODULE()
       }
       NSArray *responseJSON = @[task.requestID,
                                 RCTNullIfNil(error.localizedDescription),
+                                error.code == kCFURLErrorTimedOut ? @YES : @NO
                                 ];
 
       [_bridge.eventDispatcher sendDeviceEventWithName:@"didCompleteNetworkResponse"

--- a/Libraries/Network/__tests__/XMLHttpRequestBase-test.js
+++ b/Libraries/Network/__tests__/XMLHttpRequestBase-test.js
@@ -1,0 +1,48 @@
+'use strict';
+
+jest
+	.autoMockOff()
+	.dontMock('XMLHttpRequestBase');
+
+const XMLHttpRequestBase = require('XMLHttpRequestBase');
+
+describe('XMLHttpRequestBase', function(){
+	var xhr;
+
+	beforeEach(() => {
+		xhr = new XMLHttpRequestBase();
+		xhr.ontimeout = jest.fn();
+		xhr.onerror = jest.fn();
+		xhr.onload = jest.fn();
+		xhr.didCreateRequest(1);
+	});
+
+	afterEach(() => {
+		xhr = null;
+	});
+
+	it('should call ontimeout function when the request times out', function(){
+		xhr._didCompleteResponse(1, 'Timeout', true);
+
+		expect(xhr.ontimeout).toBeCalledWith(null);
+		expect(xhr.onerror).not.toBeCalled();
+		expect(xhr.onload).not.toBeCalled();
+	});
+
+	it('should call onerror function when the request times out', function(){
+		xhr._didCompleteResponse(1, 'Generic error');
+
+		expect(xhr.onerror).toBeCalledWith(null);
+		expect(xhr.ontimeout).not.toBeCalled();
+		expect(xhr.onload).not.toBeCalled();
+	});
+
+	it('should call onload function when there is no error', function(){
+		xhr._didCompleteResponse(1, null);
+
+		expect(xhr.onload).toBeCalledWith(null);
+		expect(xhr.onerror).not.toBeCalled();
+		expect(xhr.ontimeout).not.toBeCalled();
+	});
+
+});

--- a/docs/Network.md
+++ b/docs/Network.md
@@ -122,6 +122,34 @@ request.open('GET', 'https://mywebsite.com/endpoint.php');
 request.send();
 ```
 
+You can also use - 
+
+```js
+var request = new XMLHttpRequest();
+
+function onLoad() {
+    console.log(request.status);
+    console.log(request.responseText);
+};
+
+function onTimeout() {
+    console.log('Timeout');
+    console.log(request.responseText);
+};
+
+function onError() {
+    console.log('General network error');
+    console.log(request.responseText);
+};
+
+request.onload = onLoad;
+request.ontimeout = onTimeout;
+request.onerror = onError;
+request.open('GET', 'https://mywebsite.com/endpoint.php');
+request.send();
+```
+
+
 Please follow the [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest) for a complete description of the API.
 
 As a developer, you're probably not going to use XMLHttpRequest directly as its API is very tedious to work with. But the fact that it is implemented and compatible with the browser API gives you the ability to use third-party libraries such as [frisbee](https://github.com/niftylettuce/frisbee) or [axios](https://github.com/mzabriskie/axios) directly from npm.


### PR DESCRIPTION
Currently React-Native does not have `ontimeout` and `onerror` handlers for [XMLHttpRequest](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest). This is an extension to [No timeout on XMLHttpRequest](https://github.com/facebook/react-native/issues/4648).

With addition to two handlers, both Android and iOS can now handle `ontimeout` if request times out and `onerror` when there is general network error.

**Test plan**

Code has been tested on both Android and iOS with [Charles](https://www.charlesproxy.com/) by setting a breakpoint on the request which fires `ontimeout` when the request waits beyond `timeout` time and `onerror` when there is network error.

**Usage**

JavaScript - 

```
var request = new XMLHttpRequest();

function onLoad() {
    console.log(request.status);
};

function onTimeout() {
    console.log('Timeout');
};

function onError() {
    console.log('General network error');
};

request.onload = onLoad;
request.ontimeout = onTimeout;
request.onerror = onError;
request.open('GET', 'https://mywebsite.com/endpoint.php');
request.send();
```