### PR TITLE
Pass transformOptions to getShallowDependencies.

### DIFF
--- a/local-cli/server/util/attachHMRServer.js
+++ b/local-cli/server/util/attachHMRServer.js
@@ -48,7 +48,12 @@ function attachHMRServer({httpServer, path, packagerServer}) {
           if (dep.isAsset() || dep.isAsset_DEPRECATED() || dep.isJSON()) {
             return Promise.resolve({path: dep.path, deps: []});
           }
-          return packagerServer.getShallowDependencies(dep.path)
+          return packagerServer.getShallowDependencies({
+            platform: platform,
+            dev: true,
+            hot: true,
+            entryFile: dep.path
+          })
             .then(deps => {
               return {
                 path: dep.path,
@@ -147,7 +152,12 @@ function attachHMRServer({httpServer, path, packagerServer}) {
 
           client.ws.send(JSON.stringify({type: 'update-start'}));
           stat.then(() => {
-            return packagerServer.getShallowDependencies(filename)
+            return packagerServer.getShallowDependencies({
+              entryFile: filename,
+              platform: client.platform,
+              dev: true,
+              hot: true,
+            })
               .then(deps => {
                 if (!client) {
                   return [];

--- a/packager/react-packager/src/Bundler/index.js
+++ b/packager/react-packager/src/Bundler/index.js
@@ -426,8 +426,33 @@ class Bundler {
     this._cache.invalidate(filePath);
   }
 
-  getShallowDependencies(entryFile) {
-    return this._resolver.getShallowDependencies(entryFile);
+  getShallowDependencies({
+    entryFile,
+    platform,
+    dev = true,
+    minify = !dev,
+    hot = false,
+    generateSourceMaps = false,
+  }) {
+    return this.getTransformOptions(
+      entryFile,
+      {
+        dev,
+        platform,
+        hot,
+        generateSourceMaps,
+        projectRoots: this._projectRoots,
+      },
+    ).then(transformSpecificOptions => {
+      const transformOptions = {
+        minify,
+        dev,
+        platform,
+        transform: transformSpecificOptions,
+      };
+
+      return this._resolver.getShallowDependencies(entryFile, transformOptions);
+    });
   }
 
   stat(filePath) {

--- a/packager/react-packager/src/Resolver/index.js
+++ b/packager/react-packager/src/Resolver/index.js
@@ -120,8 +120,8 @@ class Resolver {
     });
   }
 
-  getShallowDependencies(entryFile) {
-    return this._depGraph.getShallowDependencies(entryFile);
+  getShallowDependencies(entryFile, transformOptions) {
+    return this._depGraph.getShallowDependencies(entryFile, transformOptions);
   }
 
   stat(filePath) {

--- a/packager/react-packager/src/Server/index.js
+++ b/packager/react-packager/src/Server/index.js
@@ -254,8 +254,15 @@ class Server {
     return this._bundler.hmrBundle(modules, host, port);
   }
 
-  getShallowDependencies(entryFile) {
-    return this._bundler.getShallowDependencies(entryFile);
+  getShallowDependencies(options) {
+    return Promise.resolve().then(() => {
+      if (!options.platform) {
+        options.platform = getPlatformExtension(options.entryFile);
+      }
+
+      const opts = dependencyOpts(options);
+      return this._bundler.getShallowDependencies(opts);
+    });
   }
 
   getModuleForPath(entryFile) {


### PR DESCRIPTION
We weren't passing `transformOptions` to `getShallowDependencies`, and therefore, when this method was called on a module, it would bust the cache and cause a retransform of the file. This was resulting in a complete retransforming of all files when the HMR Client connected to the packager.

Test Plan:
Put a `console.log` statement in `transformer.js`. Run the packager with `--reset-cache`, and open an app with HMR enabled. You will see the transformer log during the initial bundle request, but after the "[HMR Client] Client Connected" message, you will not see any logs.