### PR TITLE
[init] Honor the version of "react" under peerDeps when setting up a new project

### DIFF
--- a/local-cli/generator/index.js
+++ b/local-cli/generator/index.js
@@ -96,6 +96,17 @@ module.exports = yeoman.generators.NamedBase.extend({
       return;
     }
 
-    this.npmInstall('react', { '--save': true });
+    var reactNativePackageJson = require('../../package.json');
+    var { peerDependencies } = reactNativePackageJson;
+    if (!peerDependencies) {
+      return;
+    }
+
+    var reactVersion = peerDependencies.react;
+    if (!reactVersion) {
+      return;
+    }
+
+    this.npmInstall(`react@${reactVersion}`, { '--save': true });
   }
 });


### PR DESCRIPTION
We need this since React 15.0.0 is coming and will break `react-native init`, which currently installs the latest version of React. We'll need some changes to React Native to support 15 that Sebastian is actively working on, but till that lands we want `react-native init` to continue working.

Test Plan: Run `scripts/test-manual-e2e.sh` and verify that it ran `npm install react@^0.14.5 --save` instead of `npm install react --save`.