### PR TITLE
endRefreshing animates scrollView to top inset instead of zero

### DIFF
--- a/React/Views/RCTRefreshControl.m
+++ b/React/Views/RCTRefreshControl.m
@@ -68,7 +68,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
   // endRefreshing otherwise the next pull to refresh will not work properly.
   UIScrollView *scrollView = (UIScrollView *)self.superview;
   if (scrollView.contentOffset.y < 0) {
-    CGPoint offset = {scrollView.contentOffset.x, 0};
+    CGPoint offset = {scrollView.contentOffset.x, -scrollView.contentInset.top};
     [UIView animateWithDuration:0.25
                           delay:0
                         options:UIViewAnimationOptionBeginFromCurrentState


### PR DESCRIPTION
To use a ScrollView and RefreshControl with a translucent navigation bar you have to set the top inset to the height of that bar, allowing the content to scroll underneath. After changes to RCTRefreshControl in  **v0.22**, `endRefreshing` always animates the offset to 0, hiding content behind the navigation bar. What you'd expect on iOS is for it to return to the bottom of the bar.

**Test plan**
To see this in action, refer to the UIExplorerApp. In RefreshControlExample.js if you set the ScrollView's `contentInset={{top: 100}}` you'll see the refresh control UI is where you'd expect, and after refresh the list returns to the correct position.
