### PR TITLE
react app root path can be override by env var 'react_native_app_root'

### DIFF
--- a/local-cli/default.config.js
+++ b/local-cli/default.config.js
@@ -34,7 +34,7 @@ var config = {
 };
 
 function getRoots() {
-  var root = process.env.react_native_app_root;
+  var root = process.env.REACT_NATIVE_APP_ROOT;
   if (root) {
     return [path.resolve(root)];
   }

--- a/local-cli/default.config.js
+++ b/local-cli/default.config.js
@@ -34,6 +34,10 @@ var config = {
 };
 
 function getRoots() {
+  var root = process.env.react_native_app_root;
+  if (root) {
+    return [path.resolve(root)];
+  }
   if (__dirname.match(/node_modules[\/\\]react-native[\/\\]local-cli$/)) {
     // Packager is running from node_modules.
     // This is the default case for all projects created using 'react-native init'.


### PR DESCRIPTION
This PR is to solve app build issue when node_modules is a symlink by providing an environmental variable to override the current *smart* guessing of app root path.
I met this issue when I tried to setup a shared incremental node_modules directory to speed our react-native app build speed in CI. But the build crashed in step 'bundleReleaseJsAndAssets' with error messages like:
> :app:bundleReleaseJsAndAssets
> bundle: Created ReactPackager
> uncaught error Error: NotFoundError: Cannot find entry file index.android.js in any of the roots:["/home/jenkins/shared_data"]

The build is fixed by applying this patch and adding 'export react_native_app_root=${WORKSPACE}' before './gradlew assembleRelease' in build script.

**Test plan**
1. react-native init demo # init a demo app from scratch
2. cd demo/android && ./gradlew assembleRelease # build works fine
3. mkdir ~/shared_data && mv ../node_modules ~/shared_data && cd .. && ln -s ~/shared_data/node_modules . # create symlink for node_modules in shared data directory
4.  cd demo/android && ./gradlew assembleRelease # build crashed with error message 'uncaught error Error: NotFoundError: Cannot find entry file index.android.js in any of the roots: ["..."]'
5. apply this patch to ~/shared_data/node_modules/react-native/local-cli/default.config.js
6. export react_native_app_root=${demo-app-path}
7. rebuild and it works
