### PR TITLE
[WebSocket][android][ios parity] Add support for receiving binary type data (ArrayBuffer)

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/modules/websocket/WebSocketModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/websocket/WebSocketModule.java
@@ -9,6 +9,8 @@
 
 package com.facebook.react.modules.websocket;
 
+import android.util.Base64;
+
 import java.io.IOException;
 import java.lang.IllegalStateException;
 import javax.annotation.Nullable;
@@ -131,7 +133,11 @@ public class WebSocketModule extends ReactContextBaseJavaModule {
       public void onMessage(BufferedSource bufferedSource, WebSocket.PayloadType payloadType) {
         String message;
         try {
-          message = bufferedSource.readUtf8();
+          if (payloadType == WebSocket.PayloadType.BINARY) {
+            message = Base64.encodeToString(bufferedSource.readByteArray(), Base64.NO_WRAP);
+          } else {
+            message = bufferedSource.readUtf8();
+          }
         } catch (IOException e) {
           notifyWebSocketFailed(id, e.getMessage());
           return;
@@ -148,6 +154,7 @@ public class WebSocketModule extends ReactContextBaseJavaModule {
         WritableMap params = Arguments.createMap();
         params.putInt("id", id);
         params.putString("data", message);
+        params.putString("type", payloadType == WebSocket.PayloadType.BINARY ? "binary" : "text");
         sendEvent("websocketMessage", params);
       }
     });


### PR DESCRIPTION
This brings the same functionality that's already present on iOS, introduced in #4483, to Android: convert binary payloads to base64 strings and send them to JS land that way, where they'll be turned into an ArrayBuffer.

**Test Plan:** Used test server from #6889 (in `--binary` mode) to send some binary data to the Android UIExplorer example (also from #6889). Verified it's received correctly as `ArrayBuffer`.
