### PR TITLE
[RFC] Add support for missing XHR response types

### DIFF
--- a/Libraries/Network/XMLHttpRequestBase.js
+++ b/Libraries/Network/XMLHttpRequestBase.js
@@ -75,7 +75,7 @@ class XMLHttpRequestBase {
   _headers: Object;
   _lowerCaseResponseHeaders: Object;
   _method: ?string;
-  _response: void | null | string | Object;
+  _response: string | ?Object;
   _responseType: ResponseType;
   _sent: boolean;
   _url: ?string;
@@ -117,10 +117,12 @@ class XMLHttpRequestBase {
     this._clearSubscriptions();
   }
 
+  // $FlowIssue #10784535
   get responseType(): ResponseType {
     return this._responseType;
   }
 
+  // $FlowIssue #10784535
   set responseType(responseType: ResponseType): void {
     if (this.readyState > HEADERS_RECEIVED) {
       throw new Error(
@@ -134,6 +136,7 @@ class XMLHttpRequestBase {
       return;
     }
 
+    // redboxes early, e.g. for 'arraybuffer' on ios 7
     invariant(
       SUPPORTED_RESPONSE_TYPES[responseType] || responseType === 'document',
       `The provided value '${responseType}' is unsupported in this environment.`
@@ -141,6 +144,7 @@ class XMLHttpRequestBase {
     this._responseType = responseType;
   }
 
+  // $FlowIssue #10784535
   get response(): Response {
     const {responseType} = this;
     if (responseType === '' || responseType === 'text') {

--- a/Libraries/Network/XMLHttpRequestBase.js
+++ b/Libraries/Network/XMLHttpRequestBase.js
@@ -134,10 +134,10 @@ class XMLHttpRequestBase {
       return;
     }
 
-    if (!SUPPORTED_RESPONSE_TYPES[responseType]) {
-      warning(
-        `The provided value '${responseType}' is unsupported in this environment.`);
-    }
+    invariant(
+      SUPPORTED_RESPONSE_TYPES[responseType] || responseType === 'document',
+      `The provided value '${responseType}' is unsupported in this environment.`
+    );
     this._responseType = responseType;
   }
 

--- a/Libraries/Utilities/__tests__/utf8-test.js
+++ b/Libraries/Utilities/__tests__/utf8-test.js
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+ 'use strict';
+
+ jest.autoMockOff();
+
+ const {encode} = require('../utf8');
+
+ describe('UTF-8 encoding:', () => {
+    it('can encode code points < U+80', () => {
+      const arrayBuffer = encode('\u0000abcDEF\u007f');
+      expect(new Uint8Array(arrayBuffer)).toEqual(
+        new Uint8Array([0x00, 0x61, 0x62, 0x63, 0x44, 0x45, 0x46, 0x7f]));
+    });
+
+    it('can encode code points < U+800', () => {
+      const arrayBuffer = encode('\u0080\u0548\u07ff');
+      expect(new Uint8Array(arrayBuffer)).toEqual(
+        new Uint8Array([0xc2, 0x80, 0xd5, 0x88, 0xdf, 0xbf]));
+    });
+
+    it('can encode code points < U+10000', () => {
+      const arrayBuffer = encode('\u0800\uac48\uffff');
+      expect(new Uint8Array(arrayBuffer)).toEqual(
+        new Uint8Array([0xe0, 0xa0, 0x80, 0xea, 0xb1, 0x88, 0xef, 0xbf, 0xbf]));
+    });
+
+    it('can encode code points in the Supplementary Planes (surrogate pairs)', () => {
+      const arrayBuffer = encode([
+        '\ud800\udc00',
+        '\ud800\ude89',
+        '\ud83d\ude3b',
+        '\udbff\udfff'
+      ].join(''));
+      expect(new Uint8Array(arrayBuffer)).toEqual(
+        new Uint8Array([
+          0xf0, 0x90, 0x80, 0x80,
+          0xf0, 0x90, 0x8a, 0x89,
+          0xf0, 0x9f, 0x98, 0xbb,
+          0xf4, 0x8f, 0xbf, 0xbf,
+        ])
+      );
+    });
+
+    it('allows for stray high surrogates', () => {
+      const arrayBuffer = encode('a\ud8c6b');
+      expect(new Uint8Array(arrayBuffer)).toEqual(
+        new Uint8Array([0x61, 0xed, 0xa3, 0x86, 0x62]));
+    });
+
+    it('allows for stray low surrogates', () => {
+      const arrayBuffer = encode('a\ude19b');
+      expect(new Uint8Array(arrayBuffer)).toEqual(
+        new Uint8Array([0x61, 0xed, 0xb8, 0x99, 0x62]));
+    });
+ });

--- a/Libraries/Utilities/utf8.js
+++ b/Libraries/Utilities/utf8.js
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule utf8
+ * @flow
+ */
+'use strict';
+
+class ByteVector {
+  _storage: Uint8Array;
+  _sizeWritten: number;
+
+  constructor(size) {
+    this._storage = new Uint8Array(size);
+    this._sizeWritten = 0;
+  }
+
+  push(value: number): ByteVector {
+    const i = this._sizeWritten;
+    if (i === this._storage.length) {
+      this._realloc();
+    }
+    this._storage[i] = value;
+    this._sizeWritten = i + 1;
+    return this;
+  }
+
+  getBuffer(): ArrayBuffer {
+    return this._storage.buffer.slice(0, this._sizeWritten);
+  }
+
+  _realloc() {
+    const storage = this._storage;
+    this._storage = new Uint8Array(align(storage.length * 1.5));
+    this._storage.set(storage);
+  }
+}
+
+/*eslint-disable no-bitwise */
+exports.encode = (string: string): ArrayBuffer => {
+  const {length} = string;
+  const bytes = new ByteVector(length);
+
+  let nextCodePoint = string.charCodeAt(0);
+  for (let i = 0; i < length; i++) {
+    let codePoint = nextCodePoint;
+    nextCodePoint = string.charCodeAt(i + 1);
+
+    if (codePoint < 0x80) {
+      bytes.push(codePoint);
+    } else if (codePoint < 0x800) {
+      bytes
+        .push(0xc0 | codePoint >>> 6)
+        .push(0x80 | codePoint & 0x3f);
+    } else if (codePoint >>> 10 === 0x36 && nextCodePoint >>> 10 === 0x37) { // high surrogate & low surrogate
+      codePoint = 0x10000 + (((codePoint & 0x3ff) << 10) | (nextCodePoint & 0x3ff));
+      bytes
+        .push(0xf0 | codePoint >>> 18 & 0x7)
+        .push(0x80 | codePoint >>> 12 & 0x3f)
+        .push(0x80 | codePoint >>> 6  & 0x3f)
+        .push(0x80 | codePoint & 0x3f);
+
+      i += 1;
+      nextCodePoint = string.charCodeAt(i + 1);
+    } else {
+      bytes.push(0xe0 | codePoint >>> 12);
+      codePoint &= 0xfff;
+      bytes
+        .push(0x80 | codePoint >>> 6)
+        .push(0x80 | codePoint & 0x3f);
+    }
+  }
+  return bytes.getBuffer();
+};
+
+function align(size: number): number {
+  return size % 8 ? (Math.floor(size / 8) + 1) << 3 : size;
+}

--- a/Libraries/Utilities/utf8.js
+++ b/Libraries/Utilities/utf8.js
@@ -46,8 +46,8 @@ exports.encode = (string: string): ArrayBuffer => {
   const {length} = string;
   const bytes = new ByteVector(length);
 
-  // each character / char code is assumed to represent an UTF-16 wchar
-  // with the notable exception of surrogate pairs, each wchar represents the
+  // each character / char code is assumed to represent an UTF-16 wchar.
+  // With the notable exception of surrogate pairs, each wchar represents the
   // corresponding unicode code point.
   // For an explanation of UTF-8 encoding, read [1]
   // For an explanation of UTF-16 surrogate pairs, read [2]


### PR DESCRIPTION
Fixes #6679

This adds support for the missing response types to XMLHttpRequest.
Don’t ship this yet. This is completely untested. yolo and stuff.