### PR TITLE
ignore InvalidPackage lint error in MoviesAndroid example

### DIFF
--- a/Examples/Movies/android/app/build.gradle
+++ b/Examples/Movies/android/app/build.gradle
@@ -20,6 +20,13 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+
+    lintOptions {
+        // okio-1.6.0 will cause an error like
+        // "Invalid package reference in library; not included in Android: java.nio.file. Referenced from okio.Okio."
+        // (See also: https://github.com/square/okio/issues/58 )
+        ignore 'InvalidPackage'
+    }
 }
 
 dependencies {


### PR DESCRIPTION
Disable `InvalidPackage` lint checking on building MoviesAndroid example.

It is caused by okio-1.6.0 jar file.
Please see also https://github.com/square/okio/issues/58

By the way, `intOptions { abortOnError false }` is set on ReactAndroid project.
I don't know which way is better.