### PR TITLE
Prefix warning module with fbjs/lib/

### DIFF
--- a/Libraries/ReactNative/React.js
+++ b/Libraries/ReactNative/React.js
@@ -13,7 +13,7 @@
 
 const ReactIsomorphic = require('ReactIsomorphic');
 const ReactNativeImpl = require('ReactNativeImpl');
-const warning = require('warning');
+const warning = require('fbjs/lib/warning');
 
 const React = { ...ReactIsomorphic };
 

--- a/Libraries/ReactNative/ReactNative.js
+++ b/Libraries/ReactNative/ReactNative.js
@@ -13,7 +13,7 @@
 
 const ReactIsomorphic = require('ReactIsomorphic');
 const ReactNativeImpl = require('ReactNativeImpl');
-const warning = require('warning');
+const warning = require('fbjs/lib/warning');
 
 const ReactNative = { ...ReactNativeImpl };
 


### PR DESCRIPTION
This works internally at FB but not here because mixed mode requires are mandatory. At FB www, only the providesModule version works. In React Core, we only use the providesModule name. I have to remember to change these back again when I do the move so that we can unify. https://github.com/facebook/react/pull/6338/commits/0f3bd02d0fb1e292dc6a683261eeddbd3bfb7ed6

We really should pick a single convention per project. In React Core, we translate it in the package/build step to whatever output convention is needed.