### PR TITLE
[iOS] Remove all null values for request headers

### DIFF
--- a/Libraries/Network/RCTNetworking.m
+++ b/Libraries/Network/RCTNetworking.m
@@ -190,6 +190,19 @@ RCT_EXPORT_MODULE()
   return nil;
 }
 
+- (NSDictionary<NSString *, id> *)stripNullsInRequestHeaders:(NSDictionary<NSString *, id> *)headers
+{
+  NSMutableDictionary *result = [NSMutableDictionary dictionaryWithCapacity:headers.count];
+  for (NSString *key in headers.allKeys) {
+    id val = headers[key];
+    if (val != [NSNull null]) {
+      result[key] = val;
+    }
+  }
+
+  return result;
+}
+
 - (RCTURLRequestCancellationBlock)buildRequest:(NSDictionary<NSString *, id> *)query
                                  completionBlock:(void (^)(NSURLRequest *request))block
 {
@@ -198,7 +211,7 @@ RCT_EXPORT_MODULE()
   NSURL *URL = [RCTConvert NSURL:query[@"url"]]; // this is marked as nullable in JS, but should not be null
   NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:URL];
   request.HTTPMethod = [RCTConvert NSString:RCTNilIfNull(query[@"method"])].uppercaseString ?: @"GET";
-  request.allHTTPHeaderFields = [RCTConvert NSDictionary:query[@"headers"]];
+  request.allHTTPHeaderFields = [self stripNullsInRequestHeaders:[RCTConvert NSDictionary:query[@"headers"]]];
   request.timeoutInterval = [RCTConvert NSTimeInterval:query[@"timeout"]];
   NSDictionary<NSString *, id> *data = [RCTConvert NSDictionary:RCTNilIfNull(query[@"data"])];
   return [self processDataForHTTPQuery:data callback:^(NSError *error, NSDictionary<NSString *, id> *result) {


### PR DESCRIPTION
NSMutableURLRequest appears to be running `[headerValue count]` on every value of the NSDictionary that `allHTTPHeaderFields` is set to, meaning that any `null` values passed to headers in an XHR throw an exception.  This differs from the implementation of XHR in browsers, which just ignore any `null` values for headers.

PR doesn't currently include tests, happy to add those if this is something you'd consider merging