### PR TITLE
Don't start the Chrome Debugger for a file.

### DIFF
--- a/React/Modules/RCTDevMenu.m
+++ b/React/Modules/RCTDevMenu.m
@@ -611,6 +611,9 @@ RCT_EXPORT_METHOD(reload)
   }
 
   if (_bridge.executorClass != executorClass) {
+    if ([[_bridge.bundleURL absoluteString] rangeOfString:@"file://"].location != NSNotFound) {
+        return;
+    }
 
     // TODO (6929129): we can remove this special case test once we have better
     // support for custom executors in the dev menu. But right now this is


### PR DESCRIPTION
This probably isn't great (ideally we would be able to debug everything). But the use-case I have for this is the following:
- I have a hybrid app (both RN and native code)
- I have 'common' RN code included in the project as a .jsbundle file
- I also have app-specific logic running via npm start which I want to debug

Currently when you try to run any of the code in the jsbundle, it will attempt to connect to the Chrome Debugger (if it's running) and then fail (because the Chrome Debugger doesn't currently seem to support bundled files).

This change basically stops any bundled files from connecting to the Chrome Debugger, allowing people to debug non-bundled code along side non-debugging bundled coded.