### PR TITLE
Make object properties in NativeModules configurable.

### DIFF
--- a/Libraries/BatchedBridge/BatchedBridgedModules/NativeModules.js
+++ b/Libraries/BatchedBridge/BatchedBridgedModules/NativeModules.js
@@ -41,6 +41,7 @@ Object.keys(RemoteModules).forEach((moduleName) => {
 const NativeModules = {};
 Object.keys(RemoteModules).forEach((moduleName) => {
   Object.defineProperty(NativeModules, moduleName, {
+    configurable: true,
     enumerable: true,
     get: () => {
       let module = RemoteModules[moduleName];
@@ -71,6 +72,7 @@ UIManager && Object.keys(UIManager).forEach(viewName => {
     let constants;
     /* $FlowFixMe - nice try. Flow doesn't like getters */
     Object.defineProperty(viewConfig, 'Constants', {
+      configurable: true,
       enumerable: true,
       get: () => {
         if (constants) {
@@ -90,6 +92,7 @@ UIManager && Object.keys(UIManager).forEach(viewName => {
     let commands;
     /* $FlowFixMe - nice try. Flow doesn't like getters */
     Object.defineProperty(viewConfig, 'Commands', {
+      configurable: true,
       enumerable: true,
       get: () => {
         if (commands) {


### PR DESCRIPTION
In Jest, we sometimes wipe away the (partial) state of the world. I noticed that when we run the NativeModules file twice, it throws. Because Jest implicitly throws out the state, it isn't obvious what exactly is going on.

I figured I'll fix this in react-native directly as I don't see a reason why those fields shouldn't be configurable. This shouldn't have any negative impact on react-native apps themselves.

cc @ide @bestander @tadeuzagallo @davidaurelio 