### PR TITLE
Added perspective transform support for Android

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
@@ -6,8 +6,10 @@ import android.graphics.Color;
 import android.os.Build;
 import android.view.View;
 
+import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.uimanager.annotations.ReactProp;
+import com.facebook.react.uimanager.DisplayMetricsHolder;
 
 /**
  * Base class that should be suitable for the majority of subclasses of {@link ViewManager}.
@@ -25,6 +27,7 @@ public abstract class BaseViewManager<T extends View, C extends LayoutShadowNode
   private static final String PROP_DECOMPOSED_MATRIX_SCALE_Y = "scaleY";
   private static final String PROP_DECOMPOSED_MATRIX_TRANSLATE_X = "translateX";
   private static final String PROP_DECOMPOSED_MATRIX_TRANSLATE_Y = "translateY";
+  private static final String PROP_DECOMPOSED_MATRIX_PERSPECTIVE = "perspective";
   private static final String PROP_OPACITY = "opacity";
   private static final String PROP_ELEVATION = "elevation";
   private static final String PROP_RENDER_TO_HARDWARE_TEXTURE = "renderToHardwareTextureAndroid";
@@ -32,6 +35,8 @@ public abstract class BaseViewManager<T extends View, C extends LayoutShadowNode
   private static final String PROP_ACCESSIBILITY_COMPONENT_TYPE = "accessibilityComponentType";
   private static final String PROP_ACCESSIBILITY_LIVE_REGION = "accessibilityLiveRegion";
   private static final String PROP_IMPORTANT_FOR_ACCESSIBILITY = "importantForAccessibility";
+  private static final int PERSPECTIVE_ARRAY_INVERTED_CAMERA_DISTANCE_INDEX = 2;
+  private static final float CAMERA_DISTANCE_NORMALIZATION_MULTIPLIER = 5;
 
   // DEPRECATED
   private static final String PROP_ROTATION = "rotation";
@@ -64,7 +69,7 @@ public abstract class BaseViewManager<T extends View, C extends LayoutShadowNode
   public void setOpacity(T view, float opacity) {
     view.setAlpha(opacity);
   }
-
+  
   @ReactProp(name = PROP_ELEVATION)
   public void setElevation(T view, float elevation) {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
@@ -164,6 +169,23 @@ public abstract class BaseViewManager<T extends View, C extends LayoutShadowNode
         (float) matrix.getDouble(PROP_DECOMPOSED_MATRIX_SCALE_X));
     view.setScaleY(
         (float) matrix.getDouble(PROP_DECOMPOSED_MATRIX_SCALE_Y));
+        
+    if (matrix.hasKey(PROP_DECOMPOSED_MATRIX_PERSPECTIVE)) {
+      ReadableArray perspectiveArray = matrix.getArray(PROP_DECOMPOSED_MATRIX_PERSPECTIVE);
+      if (perspectiveArray.size() > PERSPECTIVE_ARRAY_INVERTED_CAMERA_DISTANCE_INDEX) {
+        float invertedCameraDistance = (float)perspectiveArray.getDouble(PERSPECTIVE_ARRAY_INVERTED_CAMERA_DISTANCE_INDEX);
+        if (invertedCameraDistance < 0) {
+          float cameraDistance = -1 / invertedCameraDistance;
+          float scale = DisplayMetricsHolder.getScreenDisplayMetrics().density;
+
+          // The following converts the matrix's perspective to a camera distance
+          // such that the camera perspective looks the same on Android and iOS        
+          float normalizedCameraDistance = scale * cameraDistance * CAMERA_DISTANCE_NORMALIZATION_MULTIPLIER;
+
+          view.setCameraDistance(normalizedCameraDistance);
+        }        
+      }
+    }
   }
 
   private static void resetTransformMatrix(View view) {


### PR DESCRIPTION
Note: This is an update to the original PR #6159, which got reverted with ae3dad86c5f10d454884ed041c0a6539f34441cd after Issue #6622 arose. The old implementation didn't handle the case in which no perspective was set but negative scale or rotationX/Y transforms were applied ([See here](https://github.com/facebook/react-native/blob/235b16d93287061a09c4624e612b5dc4f960ce47/Libraries/Utilities/MatrixMath.js#L485)). This led in the old implementation to an infinite camera distance, resulting in the aforementioned issue #6622. That case is now [handled](https://github.com/kevinstumpf/react-native/blob/9121ed705900c3ff56f717dfca884b7342ede19d/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java#L177) -- I tested all cases described in #6622 to ensure that the Android behavior matches iOS.

Details of the original PR, which still apply:
- Motivation: ["Perspective" Transform](https://facebook.github.io/react-native/docs/transforms.html#proptypes) was so far supported only on iOS
- Closes #2915
- Test Plan: I built a [react-native-flip-view](https://github.com/DispatcherInc/react-native-flip-view) and ensured that the same perspective transform results in the same camera perspective on both iOS and Android:

![image](https://cloud.githubusercontent.com/assets/7293984/13342624/6556cfe0-dbf8-11e5-8fb2-05554a5081b7.png)

![image](https://cloud.githubusercontent.com/assets/7293984/13342677/daf90560-dbf8-11e5-9941-2ae0f9f9d99b.png)