### PR TITLE
Add null check before accessing the refresh control ref

### DIFF
--- a/Libraries/Components/RefreshControl/RefreshControl.js
+++ b/Libraries/Components/RefreshControl/RefreshControl.js
@@ -133,7 +133,10 @@ const RefreshControl = React.createClass({
 
   _onRefresh() {
     this.props.onRefresh && this.props.onRefresh();
-    this._nativeRef.setNativeProps({refreshing: this.props.refreshing});
+
+    if (this._nativeRef) {
+      this._nativeRef.setNativeProps({refreshing: this.props.refreshing});
+    }
   },
 });
 


### PR DESCRIPTION
Unmounting the RefreshControl during onRefresh callback causes the native ref to become null, this simply adds a null check to prevent the crash.

Test plan:
Reproduced the bug by unmounting the ListView in the RefreshControl UIExplorer example during the onRefresh callback.

Fixes #6929

cc @ide