### PR TITLE
babel-preset - transform-es2015-constants was replaced by check-es2015-constants.

### DIFF
--- a/babel-preset/configs/main.js
+++ b/babel-preset/configs/main.js
@@ -22,7 +22,7 @@ module.exports = {
     'transform-es2015-block-scoping',
     'transform-es2015-classes',
     'transform-es2015-computed-properties',
-    'transform-es2015-constants',
+    'check-es2015-constants',
     'transform-es2015-destructuring',
     ['transform-es2015-modules-commonjs', { strict: false, allowTopLevelThis: true }],
     'transform-es2015-parameters',

--- a/babel-preset/package.json
+++ b/babel-preset/package.json
@@ -15,6 +15,7 @@
   },
   "homepage": "https://github.com/facebook/react-native/tree/master/babel-preset/README.md",
   "dependencies": {
+    "babel-plugin-check-es2015-constants": "^6.5.0",
     "babel-plugin-react-transform": "2.0.2",
     "babel-plugin-syntax-async-functions": "^6.5.0",
     "babel-plugin-syntax-class-properties": "^6.5.0",
@@ -26,7 +27,6 @@
     "babel-plugin-transform-es2015-block-scoping": "^6.5.0",
     "babel-plugin-transform-es2015-classes": "^6.5.0",
     "babel-plugin-transform-es2015-computed-properties": "^6.5.0",
-    "babel-plugin-transform-es2015-constants": "^6.1.4",
     "babel-plugin-transform-es2015-destructuring": "^6.5.0",
     "babel-plugin-transform-es2015-for-of": "^6.5.0",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.5.0",

--- a/babel-preset/plugins.js
+++ b/babel-preset/plugins.js
@@ -18,7 +18,7 @@ module.exports = {
   'babel-plugin-transform-es2015-block-scoping': require('babel-plugin-transform-es2015-block-scoping'),
   'babel-plugin-transform-es2015-classes': require('babel-plugin-transform-es2015-classes'),
   'babel-plugin-transform-es2015-computed-properties': require('babel-plugin-transform-es2015-computed-properties'),
-  'babel-plugin-transform-es2015-constants': require('babel-plugin-transform-es2015-constants'),
+  'babel-plugin-check-es2015-constants': require('babel-plugin-check-es2015-constants'),
   'babel-plugin-transform-es2015-destructuring': require('babel-plugin-transform-es2015-destructuring'),
   'babel-plugin-transform-es2015-modules-commonjs': require('babel-plugin-transform-es2015-modules-commonjs'),
   'babel-plugin-transform-es2015-parameters': require('babel-plugin-transform-es2015-parameters'),


### PR DESCRIPTION
The babel plugin transform-es2015-constants was replaced by check-es2015-constants.

References:

https://phabricator.babeljs.io/T2970
https://phabricator.babeljs.io/rBW0a3b3b03dbcfc8d1e809a0eaf6270eec8de80763
https://phabricator.babeljs.io/T3053

This patch updates the babel preset to use check-es2015-constants which should be more future-proof and will receive bug fixes.

