### PR TITLE
Fix failure of `pod lib lint`, which will close #6448. Tested on 0.23.0.

### DIFF
--- a/React.podspec
+++ b/React.podspec
@@ -54,6 +54,7 @@ Pod::Spec.new do |s|
 
   s.subspec 'RCTCameraRoll' do |ss|
     ss.dependency         'React/Core'
+    ss.dependency         'React/RCTImage'
     ss.source_files     = "Libraries/CameraRoll/*.{h,m}"
     ss.preserve_paths   = "Libraries/CameraRoll/*.js"
   end
@@ -114,9 +115,9 @@ Pod::Spec.new do |s|
   end
 
   s.subspec 'RCTTest' do |ss|
+    ss.dependency         'React/Core'
     ss.source_files     = "Libraries/RCTTest/**/*.{h,m}"
     ss.preserve_paths   = "Libraries/RCTTest/**/*.js"
     ss.frameworks       = "XCTest"
   end
-
 end


### PR DESCRIPTION
The subspec should declare enough dependencies. Or the lint of podspec file will fail because CoaoaPods will not import necessary source on the building step.