### PR TITLE
[XMLHttpRequest] Uppercases the `method` variable to sanitize the string

### DIFF
--- a/Libraries/Network/XMLHttpRequestBase.js
+++ b/Libraries/Network/XMLHttpRequestBase.js
@@ -304,7 +304,7 @@ class XMLHttpRequestBase {
       throw new Error('Cannot load an empty url');
     }
     this._reset();
-    this._method = method;
+    this._method = method.toUpperCase();
     this._url = url;
     this._aborted = false;
     this.setReadyState(this.OPENED);


### PR DESCRIPTION
This prevents possible developer errors when using 'post' or 'put' instead of 'POST' and 'PUT'.

Fixes: https://github.com/facebook/react-native/issues/6855

**Test plan:**

Previously, a `method put must not have a request body` error would be thrown when the method was in lowercase and a request body was indeed included.

With this fix and the following code (note the method name in all lowercase), the request is properly completed.

```javascript
const url = 'http://myurl.com';
const request = new XMLHttpRequest();

request.open('put', url);
request.setRequestHeader("Content-type","application/json");

request.onload = function() {
    console.log('onload');
};

request.onerror = function() {
    console.log('error');
};

request.send(JSON.stringify({ something: 'here' }));
```