### PR TITLE
Add support for sending binary data in websockets

### DIFF
--- a/Examples/UIExplorer/websocket_test_server.js
+++ b/Examples/UIExplorer/websocket_test_server.js
@@ -31,7 +31,7 @@ const respondWithBinary = process.argv.indexOf('--binary') !== -1;
 const server = new WebSocket.Server({port: 5555});
 server.on('connection', (ws) => {
   ws.on('message', (message) => {
-    console.log('Received message: %s', message);
+    console.log('Received message:', message);
     if (respondWithBinary) {
       message = new Buffer(message);
     }

--- a/Libraries/WebSocket/RCTWebSocketModule.m
+++ b/Libraries/WebSocket/RCTWebSocketModule.m
@@ -67,6 +67,12 @@ RCT_EXPORT_METHOD(send:(NSString *)message socketID:(nonnull NSNumber *)socketID
   [_sockets[socketID] send:message];
 }
 
+RCT_EXPORT_METHOD(sendBinary:(NSString *)base64String socketID:(nonnull NSNumber *)socketID)
+{
+  NSData *message = [[NSData alloc] initWithBase64EncodedString:base64String options:0];
+  [_sockets[socketID] send:message];
+}
+
 RCT_EXPORT_METHOD(close:(nonnull NSNumber *)socketID)
 {
   [_sockets[socketID] close];

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/websocket/WebSocketModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/websocket/WebSocketModule.java
@@ -44,6 +44,7 @@ import java.util.concurrent.TimeUnit;
 
 import okio.Buffer;
 import okio.BufferedSource;
+import okio.ByteString;
 
 public class WebSocketModule extends ReactContextBaseJavaModule {
 
@@ -211,6 +212,22 @@ public class WebSocketModule extends ReactContextBaseJavaModule {
       client.sendMessage(
         WebSocket.PayloadType.TEXT,
         new Buffer().writeUtf8(message));
+    } catch (IOException | IllegalStateException e) {
+      notifyWebSocketFailed(id, e.getMessage());
+    }
+  }
+
+  @ReactMethod
+  public void sendBinary(String base64String, int id) {
+    WebSocket client = mWebSocketConnections.get(id);
+    if (client == null) {
+      // This is a programmer error
+      throw new RuntimeException("Cannot send a message. Unknown WebSocket id " + id);
+    }
+    try {
+      client.sendMessage(
+        WebSocket.PayloadType.BINARY,
+        new Buffer().write(ByteString.decodeBase64(base64String)));
     } catch (IOException | IllegalStateException e) {
       notifyWebSocketFailed(id, e.getMessage());
     }


### PR DESCRIPTION
This is a reprise of #6327, but with iOS 7.0 compatibility and less `package.json` changes.

**Test Plan:** Load WebSocketExample in UIExplorer app and start websocket test server script (both provided in #6889) and test sending binary data on both iOS and Android