### PR TITLE
increased timeout for ios e2e test and fixed --js e2e after ios e2e

### DIFF
--- a/local-cli/generator-ios/templates/tests/Tests.m
+++ b/local-cli/generator-ios/templates/tests/Tests.m
@@ -13,7 +13,7 @@
 #import "RCTLog.h"
 #import "RCTRootView.h"
 
-#define TIMEOUT_SECONDS 240
+#define TIMEOUT_SECONDS 600
 #define TEXT_TO_LOOK_FOR @"Welcome to React Native!"
 
 @interface <%= name %>Tests : XCTestCase

--- a/scripts/run-ci-e2e-tests.js
+++ b/scripts/run-ci-e2e-tests.js
@@ -162,13 +162,17 @@ if (args.indexOf('--ios') !== -1) {
   if (exec('xctool -scheme EndToEndTest -sdk iphonesimulator test').code) {
     exit(cleanup(1));
   }
-  exec('cd ..');
+  cd('..');
 }
 
 if (args.indexOf('--js') !== -1) {
   // Check the packager produces a bundle (doesn't throw an error)
  if (exec('react-native bundle --platform android --dev true --entry-file index.android.js --bundle-output android-bundle.js').code) {
-   echo('Could not build package');
+   echo('Could not build android package');
+   exit(cleanup(1));
+ }
+ if (exec('react-native bundle --platform ios --dev true --entry-file index.ios.js --bundle-output ios-bundle.js').code) {
+   echo('Could not build ios package');
    exit(cleanup(1));
  }
  if (exec(`${ROOT}/node_modules/.bin/flow check`).code) {

--- a/scripts/run-ci-e2e-tests.js
+++ b/scripts/run-ci-e2e-tests.js
@@ -151,20 +151,18 @@ if (args.indexOf('--ios') !== -1) {
   // shelljs exec('', {async: true}) does not emit stdout events, so we rely on good old spawn
   let packagerEnv = Object.create(process.env);
   packagerEnv.REACT_NATIVE_MAX_WORKERS = 1;
-  const packagerProcess = spawn('npm', ['start'], 
+  const packagerProcess = spawn('npm', ['start', '--', '--non-persistent'], 
   {
     stdio: 'inherit',
     env: packagerEnv
   });
   SERVER_PID = packagerProcess.pid;
   echo(`Starting packager server, ${SERVER_PID}`);
-  exec('sleep 5s');
-  // prepare cache to reduce chances of possible red screen "Can't fibd variable __fbBatchedBridge..."
-  exec('response=$(curl --write-out %{http_code} --silent --output /dev/null localhost:8081/index.ios.bundle?platform=ios)');
   echo('Executing ios e2e test');
   if (exec('xctool -scheme EndToEndTest -sdk iphonesimulator test').code) {
     exit(cleanup(1));
   }
+  exec('cd ..');
 }
 
 if (args.indexOf('--js') !== -1) {


### PR DESCRIPTION
Packager usually builds within 250 seconds and sometimes misses test timeout.
Also added non-persistent option to make it build faster.
Should be fine because we don't test live reloading in ios