### PR TITLE
Fix issue where xhr.upload is undefined on Android

### DIFF
--- a/Libraries/Network/XMLHttpRequest.android.js
+++ b/Libraries/Network/XMLHttpRequest.android.js
@@ -26,6 +26,11 @@ function convertHeadersMapToArray(headers: Object): Array<Header> {
 }
 
 class XMLHttpRequest extends XMLHttpRequestBase {
+  constructor() {
+    super();
+    this.upload = {};
+  }
+
   sendImpl(method: ?string, url: ?string, headers: Object, data: any, timeout: number): void {
     var body;
     if (typeof data === 'string') {


### PR DESCRIPTION
When attempting to set `xhr.upload.onprogress` on Android I get the following error:
`undefined is not an object (evaluating 'xhr.upload')`

Looking at the [iOS implementation of XMLHTTPRequest](https://github.com/facebook/react-native/blob/master/Libraries/Network/XMLHttpRequest.ios.js) I found the following code:
```
  constructor() {
    super();
    // iOS supports upload
    this.upload = {};
  }
```

Applying the same constructor to the Android implementation resolves the issue.