### PR TITLE
Update Switch.js

### DIFF
--- a/Libraries/Components/Switch/Switch.js
+++ b/Libraries/Components/Switch/Switch.js
@@ -86,16 +86,14 @@ var Switch = React.createClass({
 
   _rctSwitch: {},
   _onChange: function(event: Object) {
-    this.props.onChange && this.props.onChange(event);
-    this.props.onValueChange && this.props.onValueChange(event.nativeEvent.value);
-
-    // The underlying switch might have changed, but we're controlled,
-    // and so want to ensure it represents our value.
     if (Platform.OS === 'android') {
       this._rctSwitch.setNativeProps({on: this.props.value});
     } else {
       this._rctSwitch.setNativeProps({value: this.props.value});
     }
+    //Change the props after the native props are set in case the props change removes the component
+    this.props.onChange && this.props.onChange(event);
+    this.props.onValueChange && this.props.onValueChange(event.nativeEvent.value);
   },
 
   render: function() {


### PR DESCRIPTION
Hi there,

This PR reorganises the flow for updating native props so that if you have a switch that's replaced with a spinner to handle a network action, you don't get a crash trying to update native props when an item may be moved out from underneath you. This was previously accepted but I had to rebase it so I just recreated it given it was a two line fix