### PR TITLE
Change returnKeyType in AutoExpandingTextInput example

### DIFF
--- a/Examples/UIExplorer/TextInputExample.ios.js
+++ b/Examples/UIExplorer/TextInputExample.ios.js
@@ -695,7 +695,7 @@ exports.examples = [
           <AutoExpandingTextInput
             placeholder="height increases with content"
             enablesReturnKeyAutomatically={true}
-            returnKeyType="done"
+            returnKeyType="default"
           />
         </View>
       );


### PR DESCRIPTION
This change will change the returnKeyType to be "return" instead of being "done" since this example is trying to provide a example of a auto growing text input multiple use-case. It makes that the return key says just return in order to expand the input instead of done which does not really show the use of multiline.