### PR TITLE
[Text] Set LayoutParams in ReactTextView to fix crash

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
@@ -14,11 +14,15 @@ import android.graphics.drawable.Drawable;
 import android.text.Layout;
 import android.text.Spanned;
 import android.view.Gravity;
+import android.view.ViewGroup;
 import android.widget.TextView;
 
 import com.facebook.react.uimanager.ReactCompoundView;
 
 public class ReactTextView extends TextView implements ReactCompoundView {
+
+  private static final ViewGroup.LayoutParams EMPTY_LAYOUT_PARAMS =
+    new ViewGroup.LayoutParams(0, 0);
 
   private boolean mContainsImages;
   private int mDefaultGravityHorizontal;
@@ -34,6 +38,12 @@ public class ReactTextView extends TextView implements ReactCompoundView {
 
   public void setText(ReactTextUpdate update) {
     mContainsImages = update.containsImages();
+    // Android's TextView crashes when it tries to relayout if LayoutParams are
+    // null; explicitly set the LayoutParams to prevent this crash. See:
+    // https://github.com/facebook/react-native/pull/7011
+    if (getLayoutParams() == null) {
+      setLayoutParams(EMPTY_LAYOUT_PARAMS);
+    }
     setText(update.getText());
   }
 


### PR DESCRIPTION
ReactTextView occasionally crashes when `setText` is called. Doing some cursory research, it looks like this could be a bug in Android. We also suspect it might be related to removeClippedSubviews though.

The LayoutParams don't actually matter because RN controls layout, but on occasion (haven't narrowed down what this is...) `mLayout` is non-null and triggers relayout during `setText`, which fails because the LayoutParams are null. @jesseruder came up with this fix and it appears to be working well.

Stack trace: http://pastebin.com/P8VbxvPz

Test Plan: Run an Android app that was sporadically crashing with the stack trace linked above. With this patch the crashes appear to have disappeared and the app is performing fine.