### PR TITLE
Make XMLHttpRequest and XMLHttpRequest.upload proper EventTargets

### DIFF
--- a/Libraries/Network/XMLHttpRequest.android.js
+++ b/Libraries/Network/XMLHttpRequest.android.js
@@ -26,7 +26,14 @@ function convertHeadersMapToArray(headers: Object): Array<Header> {
 }
 
 class XMLHttpRequest extends XMLHttpRequestBase {
-  sendImpl(method: ?string, url: ?string, headers: Object, data: any, timeout: number): void {
+  sendImpl(
+    method: ?string,
+    url: ?string,
+    headers: Object,
+    data: any,
+    useIncrementalUpdates: boolean,
+    timeout: number,
+  ): void {
     var body;
     if (typeof data === 'string') {
       body = {string: data};
@@ -40,7 +47,6 @@ class XMLHttpRequest extends XMLHttpRequestBase {
     } else {
       body = data;
     }
-    var useIncrementalUpdates = this.onreadystatechange ? true : false;
     var requestId = RCTNetworking.sendRequest(
       method,
       url,

--- a/Libraries/Network/XMLHttpRequest.ios.js
+++ b/Libraries/Network/XMLHttpRequest.ios.js
@@ -17,13 +17,14 @@ var RCTNetworking = require('RCTNetworking');
 var XMLHttpRequestBase = require('XMLHttpRequestBase');
 
 class XMLHttpRequest extends XMLHttpRequestBase {
-  constructor() {
-    super();
-    // iOS supports upload
-    this.upload = {};
-  }
-
-  sendImpl(method: ?string, url: ?string, headers: Object, data: any, timeout: number): void {
+  sendImpl(
+    method: ?string,
+    url: ?string,
+    headers: Object,
+    data: any,
+    incrementalUpdates: boolean,
+    timeout: number,
+  ): void {
     if (typeof data === 'string') {
       data = {string: data};
     } else if (data instanceof FormData) {
@@ -35,7 +36,7 @@ class XMLHttpRequest extends XMLHttpRequestBase {
         url,
         data,
         headers,
-        incrementalUpdates: this.onreadystatechange ? true : false,
+        incrementalUpdates,
         timeout
       },
       this.didCreateRequest.bind(this)

--- a/Libraries/Network/__tests__/XMLHttpRequestBase-test.js
+++ b/Libraries/Network/__tests__/XMLHttpRequestBase-test.js
@@ -2,47 +2,118 @@
 
 jest
 	.disableAutomock()
-	.unmock('XMLHttpRequestBase');
+	.dontMock('event-target-shim')
+	.dontMock('XMLHttpRequestBase');
 
 const XMLHttpRequestBase = require('XMLHttpRequestBase');
 
+class XMLHttpRequest extends XMLHttpRequestBase {}
+
 describe('XMLHttpRequestBase', function(){
 	var xhr;
+	var handleTimeout;
+	var handleError;
+	var handleLoad;
+	var handleReadyStateChange;
 
 	beforeEach(() => {
-		xhr = new XMLHttpRequestBase();
+		xhr = new XMLHttpRequest();
+
 		xhr.ontimeout = jest.fn();
 		xhr.onerror = jest.fn();
 		xhr.onload = jest.fn();
+		xhr.onreadystatechange = jest.fn();
+
+		handleTimeout = jest.fn();
+		handleError = jest.fn();
+		handleLoad = jest.fn();
+		handleReadyStateChange = jest.fn();
+
+		xhr.addEventListener('timeout', handleTimeout);
+		xhr.addEventListener('error', handleError);
+		xhr.addEventListener('load', handleLoad);
+		xhr.addEventListener('readystatechange', handleReadyStateChange);
+
 		xhr.didCreateRequest(1);
 	});
 
 	afterEach(() => {
 		xhr = null;
+		handleTimeout = null;
+		handleError = null;
+		handleLoad = null;
 	});
+
+    it('should transition readyState correctly', function() {
+		expect(xhr.readyState).toBe(xhr.UNSENT);
+
+		xhr.open('GET', 'blabla');
+
+		expect(xhr.onreadystatechange.mock.calls.length).toBe(1);
+		expect(handleReadyStateChange.mock.calls.length).toBe(1);
+		expect(xhr.readyState).toBe(xhr.OPENED);
+    });
 
 	it('should call ontimeout function when the request times out', function(){
 		xhr._didCompleteResponse(1, 'Timeout', true);
 
-		expect(xhr.ontimeout).toBeCalledWith(null);
+		expect(xhr.readyState).toBe(xhr.DONE);
+
+		expect(xhr.ontimeout.mock.calls.length).toBe(1);
 		expect(xhr.onerror).not.toBeCalled();
 		expect(xhr.onload).not.toBeCalled();
+
+		expect(handleTimeout.mock.calls.length).toBe(1);
+		expect(handleError).not.toBeCalled();
+		expect(handleLoad).not.toBeCalled();
 	});
 
 	it('should call onerror function when the request times out', function(){
 		xhr._didCompleteResponse(1, 'Generic error');
 
-		expect(xhr.onerror).toBeCalledWith(null);
+		expect(xhr.readyState).toBe(xhr.DONE);
+
+		expect(xhr.onreadystatechange.mock.calls.length).toBe(1);
+		expect(xhr.onerror.mock.calls.length).toBe(1);
 		expect(xhr.ontimeout).not.toBeCalled();
 		expect(xhr.onload).not.toBeCalled();
+
+		expect(handleReadyStateChange.mock.calls.length).toBe(1);
+		expect(handleError.mock.calls.length).toBe(1);
+		expect(handleTimeout).not.toBeCalled();
+		expect(handleLoad).not.toBeCalled();
 	});
 
 	it('should call onload function when there is no error', function(){
 		xhr._didCompleteResponse(1, null);
 
-		expect(xhr.onload).toBeCalledWith(null);
+		expect(xhr.readyState).toBe(xhr.DONE);
+
+		expect(xhr.onreadystatechange.mock.calls.length).toBe(1);
+		expect(xhr.onload.mock.calls.length).toBe(1);
 		expect(xhr.onerror).not.toBeCalled();
 		expect(xhr.ontimeout).not.toBeCalled();
+
+		expect(handleReadyStateChange.mock.calls.length).toBe(1);
+		expect(handleLoad.mock.calls.length).toBe(1);
+		expect(handleError).not.toBeCalled();
+		expect(handleTimeout).not.toBeCalled();
+	});
+
+	it('should call onload function when there is no error', function() {
+		xhr.upload.onprogress = jest.fn();
+		var handleProgress = jest.fn();
+		xhr.upload.addEventListener('progress', handleProgress);
+
+		xhr._didUploadProgress(1, 42, 100);
+
+		expect(xhr.upload.onprogress.mock.calls.length).toBe(1);
+		expect(handleProgress.mock.calls.length).toBe(1);
+
+		expect(xhr.upload.onprogress.mock.calls[0][0].loaded).toBe(42);
+		expect(xhr.upload.onprogress.mock.calls[0][0].total).toBe(100);
+		expect(handleProgress.mock.calls[0][0].loaded).toBe(42);
+		expect(handleProgress.mock.calls[0][0].total).toBe(100);
 	});
 
 });


### PR DESCRIPTION
So far, XHR only supports a few `onfoo` event handlers, not the entier `EventTarget` interface (`addEventListener`, `removeEventListener`). It also doesn't support the `upload` object on Android -- for no good reason. Even if we don't send any events there yet, there's no reason we have to break consuming code that wants to register an event handler there. This PR rectifies all that.

Fortunately, adding proper `EventTarget` support is very easy thanks to `event-target-shim`. We already use it in our WebSocket implementation. It transparently handles the `addEventListener('foo', ...)` as well as `onfoo` APIs, so when you dispatch an event on the event target, the right handlers will be invoked. The event object is wrapped so that `event.target` is set properly. Basically, it's a super easy way to make us conform to the spec.

Also added a bit of polish here and there, using ES2015 class property goodness to consolidate a lot of Flow property definitions with the corresponding property initializers.

**Test Plan:** Ran through the XHR Example in UIExplorer on both platforms. Made sure upload progress events still work on iOS and timeouts work.