### PR TITLE
Enables communication between the webview and RN

### DIFF
--- a/Libraries/Components/WebView/WebView.android.js
+++ b/Libraries/Components/WebView/WebView.android.js
@@ -129,6 +129,21 @@ var WebView = React.createClass({
     domStorageEnabled: PropTypes.bool,
 
     /**
+     * A callback that will be executed once the webview
+     * sends a message to RN.
+     * @platform android
+     */
+     onMessage: PropTypes.func,
+
+     /**
+      * A protocol that the webview can use to communicate with RN.
+      * When the WebView triggers requests to myProtocol://something
+      * the 'onMessage' callback passed to the webview will be called.
+      * @platform android
+      */
+     messageProtocol: PropTypes.string,
+
+    /**
      * Sets the JS to be injected when the webpage loads.
      */
     injectedJavaScript: PropTypes.string,
@@ -226,6 +241,8 @@ var WebView = React.createClass({
         contentInset={this.props.contentInset}
         automaticallyAdjustContentInsets={this.props.automaticallyAdjustContentInsets}
         onLoadingStart={this.onLoadingStart}
+        onMessage={this.props.onMessage}
+        messageProtocol={this.props.messageProtocol}
         onLoadingFinish={this.onLoadingFinish}
         onLoadingError={this.onLoadingError}
         testID={this.props.testID}

--- a/ReactAndroid/src/main/java/com/facebook/react/views/webview/events/MessageEvent.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/webview/events/MessageEvent.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+package com.facebook.react.views.webview.events;
+
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.uimanager.events.Event;
+import com.facebook.react.uimanager.events.RCTEventEmitter;
+
+/**
+ * Event emitted when there is an error in loading.
+ */
+public class MessageEvent extends Event<MessageEvent> {
+
+  public static final String EVENT_NAME = "message";
+  private WritableMap mEventData;
+
+  public MessageEvent(int viewId, long timestampMs, WritableMap eventData) {
+    super(viewId, timestampMs);
+    mEventData = eventData;
+  }
+
+  @Override
+  public String getEventName() {
+    return EVENT_NAME;
+  }
+
+  @Override
+  public boolean canCoalesce() {
+    return false;
+  }
+
+  @Override
+  public short getCoalescingKey() {
+    // All events for a given view can be coalesced.
+    return 0;
+  }
+
+  @Override
+  public void dispatch(RCTEventEmitter rctEventEmitter) {
+    rctEventEmitter.receiveEvent(getViewTag(), getEventName(), mEventData);
+  }
+}


### PR DESCRIPTION
Android devs have been relying for ages on intercepting custom HTTP
calls made by the webview, to map them to native actions,
[like here](https://www.caphal.com/android/communication-between-application-and-webview/).

Say that we have a "close" button in our web interface. We first detect
if we're running on web or within a webview -- if on web, we simply call `window.close()`.
If we're running within the app things get a bit more complicated, but we can
simply call `app://exit` and the app will be able to intercept this call and
close the webview for us.

Now, this PR adds the ability of doing it on RN. You basically specify a
protocol for messages that should be forwarded to RN (ie. `rn`) and then,
when your webview loads a resource from `rn://xyz` the `onMessage` callback
will be called. You can access the URL etc etc through `event.nativeEvent.url`.

Example:

``` javascript
let onMessage = (event) => {
  let {url} = event.nativeEvent;

  if (url.endsWith('exit')) {
    BackAndroid.exitApp(); // just sayin'...
  }
}

return <Webview
  source={...}
  messageProtocol={'myApp'}
  onMessage={onMessage}
>
```

Or something of that sort. Communicating between the webview and RN / the ability
to intercept resources loaded within the webview has been already discussed but I
feel we need a very simple implementation rather than creating a full-blown
messaging pattern which will just hurt (maintainability, complexity) in the long run.

Also, my Java is pretty rusty ;-)