### PR TITLE
Add /node_modules/react-native-desktop/ to blacklist.js

### DIFF
--- a/packager/blacklist.js
+++ b/packager/blacklist.js
@@ -20,6 +20,8 @@ var sharedBlacklist = [
   'downstream/core/invariant.js',
 
   /website\/node_modules\/.*/,
+  
+  /node_modules\/react-native-desktop\/.*/,
 
   // TODO(jkassens, #9876132): Remove this rule when it's no longer needed.
   'Libraries/Relay/relay/tools/relayUnstableBatchedUpdates.js',


### PR DESCRIPTION
Since RND basically on 98% the same project, `node-haste` fails on duplicates defined by `@providesModule`. So this would blacklist packager instances from each other. 
```
index.ios.js
index.osx.js
node_modules/
   react-native/
   react-native-desktop/
```

`react-native-web` uses [webpack alias](https://github.com/necolas/react-native-web/blob/master/examples/webpack.config.js), ReactWindows seems to be merged eventually. Can't come up with the different way. 