### PR TITLE
Removing Rotten Tomatoes API Info

### DIFF
--- a/docs/Tutorial.md
+++ b/docs/Tutorial.md
@@ -409,11 +409,7 @@ import {
   View,
 } from 'react-native';
 
-var API_KEY = '7waqfqbprs7pajbz28mqf6vz';
-var API_URL = 'http://api.rottentomatoes.com/api/public/v1.0/lists/movies/in_theaters.json';
-var PAGE_SIZE = 25;
-var PARAMS = '?apikey=' + API_KEY + '&page_limit=' + PAGE_SIZE;
-var REQUEST_URL = API_URL + PARAMS;
+var REQUEST_URL = 'https://raw.githubusercontent.com/facebook/react-native/master/docs/MoviesExample.json';
 
 class AwesomeProject extends Component {
   constructor(props) {


### PR DESCRIPTION
Earlier on in the tutorial it was recommended to pull in mock data from Github instead of making Rotten Tomato API calls, this change will update the final code to match the rest of the tutorial. 