### PR TITLE
Pass navigationProps={props} instead of ...props 🐿

### DIFF
--- a/Examples/UIExplorer/NavigationExperimental/NavigationAnimatedExample.js
+++ b/Examples/UIExplorer/NavigationExperimental/NavigationAnimatedExample.js
@@ -101,7 +101,7 @@ class NavigationAnimatedExample extends React.Component {
   _renderHeader(/*NavigationSceneRendererProps*/ props) {
     return (
       <NavigationHeader
-        {...props}
+        navigationProps={props}
         renderTitleComponent={this._renderTitleComponent}
       />
     );


### PR DESCRIPTION
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request:

[👉 Updated example due to: undefined is not an object (evaluating 'this.props.navigationProps.scene')](https://github.com/facebook/react-native/issues/6902)
