### PR TITLE
Adds support for platform specific styles in StyleSheet

### DIFF
--- a/Libraries/StyleSheet/StyleSheet.js
+++ b/Libraries/StyleSheet/StyleSheet.js
@@ -14,6 +14,7 @@
 var PixelRatio = require('PixelRatio');
 var StyleSheetRegistry = require('StyleSheetRegistry');
 var StyleSheetValidation = require('StyleSheetValidation');
+var Platform = require('Platform');
 
 var flatten = require('flattenStyle');
 
@@ -93,9 +94,19 @@ module.exports = {
    */
   create(obj: {[key: string]: any}): {[key: string]: number} {
     var result = {};
+
     for (var key in obj) {
-      StyleSheetValidation.validateStyle(key, obj);
-      result[key] = StyleSheetRegistry.registerStyle(obj[key]);
+
+      let {ios, android, ...style} = obj[key];
+      if (ios && Platform.OS === 'ios') {
+        style = {...style, ...ios};
+      }
+      if (android && Platform.OS === 'android') {
+        style = {...style, ...android};
+      }
+
+      StyleSheetValidation.validateStyle(key, style);
+      result[key] = StyleSheetRegistry.registerStyle(style);
     }
     return result;
   }


### PR DESCRIPTION
I was reading this blog post http://makeitopen.com/tutorials/building-the-f8-app/design/ and I saw a neat technique by the team for implementing platform specific styles in Stylesheet module. 

```javascript
var styles = F8StyleSheet.create({
  container: {
    flexDirection: 'row',
    backgroundColor: 'transparent',
    ios: {
      paddingBottom: 6,
      justifyContent: 'center',
      alignItems: 'center',
    },
    android: {
      paddingLeft: 60,
    },
  },
});
```
I really like this pattern. It helps to keep the code clean and simple to deal with. I feel this should be a part of StyleSheet core module. I believe this pattern has a potential to create an impact on larger level. 

I tried implementing this feature from my level of understanding. I would love to receive feedbacks and thoughts on this from the community. 