### PR TITLE
Renamed --flavor to --variant

### DIFF
--- a/local-cli/runAndroid/runAndroid.js
+++ b/local-cli/runAndroid/runAndroid.js
@@ -39,6 +39,10 @@ function _runAndroid(argv, config, resolve, reject) {
     command: 'flavor',
     type: 'string',
     required: false,
+  }, {
+    command: 'variant',
+    type: 'string',
+    required: false,
   }], argv);
 
   args.root = args.root || '';
@@ -76,7 +80,14 @@ function buildAndRun(args, reject) {
       : './gradlew';
 
     const gradleArgs = [];
-    if (args['flavor']) {
+    if (args['variant']) {
+        gradleArgs.push('install' +
+          args['variant'][0].toUpperCase() + args['variant'].slice(1)
+        );
+    } else if (args['flavor']) {
+        console.warn(chalk.yellow(
+          `--flavor has been deprecated. Use --variant instead`
+        ));
         gradleArgs.push('install' +
           args['flavor'][0].toUpperCase() + args['flavor'].slice(1)
         );


### PR DESCRIPTION
This small update to runAndroid.js which renames --flavor to --variant.
~~`react-native run-android --flavor=staging`~~

~~doesn't work as it needs build type as well~~

~~so at present it needs to be like this~~

~~`react-native run-android --flavor=stagingDebug`~~

~~it looks messy, instead if we want to use the original spec then Debug must be concatenated to the end all the time as run-android was speced to trigger only debug builds~~


