### PR TITLE
Checkbox implementation for Android

### DIFF
--- a/Examples/UIExplorer/CheckBoxAndroidExample.js
+++ b/Examples/UIExplorer/CheckBoxAndroidExample.js
@@ -1,0 +1,171 @@
+/**
+ * The examples provided by Facebook are for non-commercial testing and
+ * evaluation purposes only.
+ *
+ * Facebook reserves all rights not expressly granted.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON INFRINGEMENT. IN NO EVENT SHALL
+ * FACEBOOK BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * @flow
+ */
+'use strict';
+
+var React = require('react');
+var ReactNative = require('react-native');
+var {
+  CheckBoxAndroid,
+  Text,
+  View
+} = ReactNative;
+
+var BasicCheckBoxExample = React.createClass({
+  getInitialState() {
+   return {
+     firstCheckboxChecked: true,
+     secondCheckboxChecked: false
+   };
+  },
+  render() {
+    return (
+      <View>
+        <CheckBoxAndroid
+          onValueChange={(value) => this.setState({firstCheckboxChecked: value})}
+          text="First Checkbox"
+          style={{marginBottom: 10}}
+          value={this.state.firstCheckboxChecked} />
+        <CheckBoxAndroid
+          onValueChange={(value) => this.setState({secondCheckboxChecked: value})}
+          text="Second Checkbox"
+          value={this.state.secondCheckboxChecked}/>
+      </View>
+    );
+  }
+});
+
+var DisabledCheckBoxExample = React.createClass({
+  render() {
+    return (
+      <View>
+        <CheckBoxAndroid
+          enabled={false}
+          text="First Checkbox"
+          style={{marginBottom: 10}}
+          value={true} />
+        <CheckBoxAndroid
+          enabled={false}
+          text="Second Checkbox"
+          value={false}/>
+      </View>
+    );
+  }
+});
+
+var EventCheckBoxExample = React.createClass({
+  getInitialState() {
+    return {
+      eventCheckBoxIsOn: false,
+      eventCheckBoxRegressionIsOn: true,
+    };
+  },
+  render() {
+    return (
+      <View style={{flexDirection: 'row', justifyContent: 'space-around'}}>
+        <View>
+        <CheckBoxAndroid
+           onValueChange={(value) => this.setState({eventCheckBoxIsOn: value})}
+           style={{marginBottom: 10}}
+           value={this.state.eventCheckBoxIsOn} />
+         <CheckBoxAndroid
+           onValueChange={(value) => this.setState({eventCheckBoxIsOn: value})}
+           style={{marginBottom: 10}}
+           value={this.state.eventCheckBoxIsOn} />
+         <Text>{this.state.eventCheckBoxIsOn ? 'On' : 'Off'}</Text>
+        </View>
+        <View>
+        <CheckBoxAndroid
+          onValueChange={(value) => this.setState({eventCheckBoxRegressionIsOn: value})}
+          style={{marginBottom: 10}}
+          value={this.state.eventCheckBoxRegressionIsOn} />
+        <CheckBoxAndroid
+          onValueChange={(value) => this.setState({eventCheckBoxRegressionIsOn: value})}
+          style={{marginBottom: 10}}
+          value={this.state.eventCheckBoxRegressionIsOn} />
+        <Text>{this.state.eventCheckBoxRegressionIsOn ? 'On' : 'Off'}</Text>
+        </View>
+      </View>
+    );
+  }
+});
+
+var LayoutCheckBoxExample = React.createClass({
+  render() {
+    return (
+      <View>
+        <CheckBoxAndroid
+          enabled={false}
+          text="First Checkbox"
+          style={{alignSelf: 'stretch'}}
+          value={true} />
+        <View style={{flexDirection: 'row', flexWrap: 'wrap'}}>
+          <CheckBoxAndroid
+            enabled={false}
+            text="Second Checkbox"
+            value={true} />
+          <CheckBoxAndroid
+            enabled={false}
+            text="Third Checkbox"
+            value={false}/>
+          <CheckBoxAndroid
+            enabled={false}
+            text="Fourth Checkbox"
+            value={false}/>
+          </View>
+          <View style={{flexDirection: 'row'}}>
+          <CheckBoxAndroid
+            style={{flex: 1}}
+            enabled={false}
+            text="Sixth Checkbox"
+            value={true} />
+          <CheckBoxAndroid
+            style={{flex: 1}}
+            enabled={false}
+            text="Seventh Checkbox"
+            value={false}/>
+        </View>
+      </View>
+    );
+  }
+});
+
+var examples = [
+  {
+   title: 'CheckBoxes can be checked and unchecked',
+   render(): ReactElement { return <BasicCheckBoxExample />; }
+  },
+  {
+   title: 'CheckBoxes can be disabled',
+   render(): ReactElement { return <DisabledCheckBoxExample />; }
+  },
+  {
+   title: 'Change events can be detected',
+   render(): ReactElement { return <EventCheckBoxExample />; }
+  },
+  {
+   title: 'CheckBoxes are controlled components',
+   render(): ReactElement { return <CheckBoxAndroid />; }
+  },
+  {
+   title: 'Layout Test',
+   render(): ReactElement { return <LayoutCheckBoxExample />; }
+  },
+];
+
+exports.title = '<CheckBoxAndroid>';
+exports.displayName = 'CheckBoxAndroidExample';
+exports.description = 'Native Android checkbox';
+exports.examples = examples;

--- a/Examples/UIExplorer/UIExplorerList.android.js
+++ b/Examples/UIExplorer/UIExplorerList.android.js
@@ -24,6 +24,10 @@ export type UIExplorerExample = {
 
 var ComponentExamples: Array<UIExplorerExample> = [
   {
+    key: 'CheckBoxAndroidExample',
+    module: require('./CheckBoxAndroidExample'),
+  },
+  {
     key: 'SliderExample',
     module: require('./SliderExample'),
   },

--- a/Libraries/Components/CheckBoxAndroid/CheckBoxAndroid.android.js
+++ b/Libraries/Components/CheckBoxAndroid/CheckBoxAndroid.android.js
@@ -1,0 +1,100 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule CheckBoxAndroid
+ */
+'use strict';
+
+var NativeMethodsMixin = require('NativeMethodsMixin');
+var PropTypes = require('ReactPropTypes');
+var React = require('React');
+var View = require('View');
+
+var requireNativeComponent = require('requireNativeComponent');
+
+var CHECKBOX = 'checkbox';
+
+/**
+ * Standard Android checkbox component.
+ * iOS does not have a checkbox component. You may want to use `<Switch />` instead.
+ */
+var CheckBoxAndroid = React.createClass({
+  mixins: [NativeMethodsMixin],
+
+  propTypes: {
+    ...View.propTypes,
+    /**
+     * Boolean value of the switch.
+     */
+    value: PropTypes.bool,
+    /**
+     * If `false`, this component can't be interacted with.
+     */
+    enabled: PropTypes.bool,
+    /**
+     * Invoked with the new value when the value changes.
+     */
+    onValueChange: PropTypes.func,
+
+    /**
+     * The label to be showed with the checkbox.
+     */
+    text: PropTypes.string,
+
+    /**
+     * Used to locate this view in end-to-end tests.
+     */
+    testID: PropTypes.string,
+  },
+
+  getDefaultProps: function() {
+    return {
+      value: false,
+      enabled: true,
+    };
+  },
+
+  _onChange: function(event) {
+    // The underlying checkbox might have changed, but we're controlled,
+    // and so want to ensure it represents our value.
+    this.refs[CHECKBOX].setNativeProps({on: this.props.value});
+
+    if (this.props.value === event.nativeEvent.value || !this.props.enabled) {
+      return;
+    }
+
+    this.props.onChange && this.props.onChange(event);
+    this.props.onValueChange && this.props.onValueChange(event.nativeEvent.value);
+  },
+
+  render: function() {
+    return (
+      <RCheckbox
+        ref={CHECKBOX}
+        style={this.props.style}
+        enabled={this.props.enabled}
+        on={this.props.value}
+        onChange={this._onChange}
+        text={this.props.text}
+        testID={this.props.testID}
+        onStartShouldSetResponder={() => true}
+        onResponderTerminationRequest={() => false}
+      />
+    );
+  }
+});
+
+var RCheckbox = requireNativeComponent('AndroidCheckBox', CheckBoxAndroid, {
+  nativeOnly: {
+    on: true,
+    enabled: true,
+    text: ''
+  }
+});
+
+module.exports = CheckBoxAndroid;

--- a/Libraries/Components/CheckBoxAndroid/CheckBoxAndroid.ios.js
+++ b/Libraries/Components/CheckBoxAndroid/CheckBoxAndroid.ios.js
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule CheckBoxAndroid
+ */
+'use strict';
+
+// Checkboxes are not available on iOS.
+// The recommendation is to use Switch
+module.exports = require('UnimplementedView');

--- a/Libraries/react-native/react-native.js
+++ b/Libraries/react-native/react-native.js
@@ -29,6 +29,7 @@ var ReactNative = {
   // Components
   get ActivityIndicatorIOS() { return require('ActivityIndicatorIOS'); },
   get ART() { return require('ReactNativeART'); },
+  get CheckBoxAndroid() { return require('CheckBoxAndroid'); },
   get DatePickerIOS() { return require('DatePickerIOS'); },
   get DrawerLayoutAndroid() { return require('DrawerLayoutAndroid'); },
   get Image() { return require('Image'); },

--- a/Libraries/react-native/react-native.js.flow
+++ b/Libraries/react-native/react-native.js.flow
@@ -27,6 +27,7 @@ var ReactNative = Object.assign(Object.create(require('react')), {
   // Components
   ActivityIndicatorIOS: require('ActivityIndicatorIOS'),
   ART: require('ReactNativeART'),
+  CheckBoxAndroid: require('CheckBoxAndroid'),
   DatePickerIOS: require('DatePickerIOS'),
   DrawerLayoutAndroid: require('DrawerLayoutAndroid'),
   Image: require('Image'),

--- a/ReactAndroid/src/main/java/com/facebook/react/shell/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/shell/BUCK
@@ -32,6 +32,7 @@ android_library(
     react_native_target('java/com/facebook/react/modules/websocket:websocket'),
     react_native_target('java/com/facebook/react/uimanager:uimanager'),
     react_native_target('java/com/facebook/react/views/art:art'),
+    react_native_target('java/com/facebook/react/views/checkbox:checkbox'),
     react_native_target('java/com/facebook/react/views/drawer:drawer'),
     react_native_target('java/com/facebook/react/views/image:image'),
     react_native_target('java/com/facebook/react/views/modal:modal'),

--- a/ReactAndroid/src/main/java/com/facebook/react/shell/MainReactPackage.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/shell/MainReactPackage.java
@@ -39,6 +39,7 @@ import com.facebook.react.modules.websocket.WebSocketModule;
 import com.facebook.react.uimanager.ViewManager;
 import com.facebook.react.views.art.ARTRenderableViewManager;
 import com.facebook.react.views.art.ARTSurfaceViewManager;
+import com.facebook.react.views.checkbox.ReactCheckBoxManager;
 import com.facebook.react.views.drawer.ReactDrawerLayoutManager;
 import com.facebook.react.views.image.ReactImageManager;
 import com.facebook.react.views.modal.ReactModalHostManager;
@@ -103,6 +104,7 @@ public class MainReactPackage implements ReactPackage {
       ARTRenderableViewManager.createARTShapeViewManager(),
       ARTRenderableViewManager.createARTTextViewManager(),
       new ARTSurfaceViewManager(),
+      new ReactCheckBoxManager(),
       new ReactDialogPickerManager(),
       new ReactDrawerLayoutManager(),
       new ReactDropdownPickerManager(),

--- a/ReactAndroid/src/main/java/com/facebook/react/views/checkbox/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/checkbox/BUCK
@@ -1,0 +1,24 @@
+include_defs('//ReactAndroid/DEFS')
+
+android_library(
+  name = 'checkbox',
+  srcs = glob(['*.java']),
+  deps = [
+    react_native_target('java/com/facebook/react/bridge:bridge'),
+    react_native_target('java/com/facebook/react/common:common'),
+    react_native_target('java/com/facebook/csslayout:csslayout'),
+    react_native_target('java/com/facebook/react/uimanager:uimanager'),
+    react_native_target('java/com/facebook/react/uimanager/annotations:annotations'),
+    react_native_dep('third-party/android/support-annotations:android-support-annotations'),
+    react_native_dep('third-party/android/support/v7/appcompat-orig:appcompat'),
+    react_native_dep('third-party/android/support/v4:lib-support-v4'),
+    react_native_dep('third-party/java/jsr-305:jsr-305'),
+  ],
+  visibility = [
+    'PUBLIC',
+  ],
+)
+
+project_config(
+  src_target = ':checkbox',
+)

--- a/ReactAndroid/src/main/java/com/facebook/react/views/checkbox/ReactCheckBox.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/checkbox/ReactCheckBox.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+package com.facebook.react.views.checkbox;
+
+import android.support.v7.widget.AppCompatCheckBox;
+
+import com.facebook.react.uimanager.ThemedReactContext;
+
+/**
+ * CheckBox that has its value controlled by JS. Whenever the value of the checkbox changes, we do not
+ * allow any other changes to that checkbox until JS sets a value explicitly. This stops the CheckBox
+ * from changing its value multiple times, when those changes have not been processed by JS first.
+ */
+/*package*/ class ReactCheckBox extends AppCompatCheckBox {
+
+  private boolean mAllowChange;
+  private ThemedReactContext mReactContext;
+
+  public ReactCheckBox(ThemedReactContext reactContext) {
+    super(reactContext);
+    mReactContext = reactContext;
+    mAllowChange = true;
+  }
+
+  @Override
+  public void setChecked(boolean checked) {
+    if (mAllowChange) {
+      mAllowChange = false;
+      super.setChecked(checked);
+    }
+  }
+
+  void setOn(boolean on) {
+    // If the switch has a different value than the value sent by JS, we must change it.
+    if (isChecked() != on) {
+      super.setChecked(on);
+    }
+    mAllowChange = true;
+  }
+
+  public ThemedReactContext getReactContext() {
+    return mReactContext;
+  }
+
+}

--- a/ReactAndroid/src/main/java/com/facebook/react/views/checkbox/ReactCheckBoxEvent.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/checkbox/ReactCheckBoxEvent.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+package com.facebook.react.views.checkbox;
+
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.uimanager.events.Event;
+import com.facebook.react.uimanager.events.RCTEventEmitter;
+
+/**
+ * Event emitted by a ReactCheckBoxManager once a checkbox is checked/unchecked.
+ */
+/*package*/ class ReactCheckBoxEvent extends Event<ReactCheckBoxEvent> {
+
+  public static final String EVENT_NAME = "topChange";
+  private final boolean mIsChecked;
+
+  protected ReactCheckBoxEvent(int viewTag, long timestampMs, boolean isChecked) {
+    super(viewTag, timestampMs);
+    mIsChecked = isChecked;
+  }
+
+  @Override
+  public String getEventName() {
+    return EVENT_NAME;
+  }
+
+  public boolean isChecked() {
+    return mIsChecked;
+  }
+
+  @Override
+  public short getCoalescingKey() {
+    // All checkbox events for a given view can be coalesced.
+    return 0;
+  }
+
+  private WritableMap serializeEventData() {
+    WritableMap eventData = Arguments.createMap();
+    eventData.putInt("target", getViewTag());
+    eventData.putBoolean("value", isChecked());
+    return eventData;
+  }
+
+  @Override
+  public void dispatch(RCTEventEmitter rctEventEmitter) {
+    rctEventEmitter.receiveEvent(getViewTag(), getEventName(), serializeEventData());
+  }
+}

--- a/ReactAndroid/src/main/java/com/facebook/react/views/checkbox/ReactCheckBoxManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/checkbox/ReactCheckBoxManager.java
@@ -1,0 +1,155 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+package com.facebook.react.views.checkbox;
+
+import android.support.annotation.Nullable;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.CompoundButton;
+
+import com.facebook.csslayout.CSSMeasureMode;
+import com.facebook.csslayout.CSSNode;
+import com.facebook.csslayout.MeasureOutput;
+import com.facebook.react.common.SystemClock;
+import com.facebook.react.uimanager.LayoutShadowNode;
+import com.facebook.react.uimanager.SimpleViewManager;
+import com.facebook.react.uimanager.ThemedReactContext;
+import com.facebook.react.uimanager.UIManagerModule;
+import com.facebook.react.uimanager.ViewProps;
+import com.facebook.react.uimanager.annotations.ReactProp;
+
+/**
+ * View manager for {@link ReactCheckBox} components.
+ */
+public class ReactCheckBoxManager extends SimpleViewManager<ReactCheckBox> {
+
+  private static final String REACT_CLASS = "AndroidCheckBox";
+  private static final String PROP_TEXT = "text";
+
+  static class ShadowNode extends LayoutShadowNode implements CSSNode.MeasureFunction {
+    private String mText;
+    private boolean mNeedsMeasure = true;
+    private int mWidth;
+    private int mHeight;
+
+    public ShadowNode() {
+      setMeasureFunction(this);
+    }
+
+    private boolean isSameString(@Nullable String text) {
+      return mText == null ? text == null : mText.equals(text);
+    }
+
+    private int buildMeasureSpec(float dimension, CSSMeasureMode mode) {
+      switch (mode) {
+        case EXACTLY:
+          return View.MeasureSpec.makeMeasureSpec(Math.round(dimension),
+            View.MeasureSpec.EXACTLY);
+
+        case AT_MOST:
+          return View.MeasureSpec.makeMeasureSpec(Math.round(dimension),
+            View.MeasureSpec.AT_MOST);
+
+        case UNDEFINED:
+        default:
+          return View.MeasureSpec.makeMeasureSpec(ViewGroup.LayoutParams.WRAP_CONTENT,
+            View.MeasureSpec.UNSPECIFIED);
+      }
+    }
+
+    @Override
+    public void measure(CSSNode node, float width, CSSMeasureMode widthMode, float height,
+                        CSSMeasureMode heightMode, MeasureOutput measureOutput) {
+      if (mNeedsMeasure) {
+        ReactCheckBox checkBox = new ReactCheckBox(getThemedContext());
+        checkBox.setText(mText);
+
+        final int widthSpec = buildMeasureSpec(width, widthMode);
+        final int heightSpec = buildMeasureSpec(height, heightMode);
+
+        checkBox.measure(widthSpec, heightSpec);
+        mWidth = checkBox.getMeasuredWidth();
+        mHeight = checkBox.getMeasuredHeight();
+      }
+
+      measureOutput.width = mWidth;
+      measureOutput.height = mHeight;
+    }
+
+    @ReactProp(name = PROP_TEXT)
+    public void setText(String text) {
+      if (!isSameString(text)) {
+        mText = text;
+        mNeedsMeasure = true;
+        dirty();
+      }
+    }
+  }
+
+
+  private static final CompoundButton.OnCheckedChangeListener ON_CHECKED_CHANGE_LISTENER =
+    new CompoundButton.OnCheckedChangeListener() {
+      @Override
+      public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
+        ReactCheckBox checkBox = (ReactCheckBox) buttonView;
+        checkBox.getReactContext().getNativeModule(UIManagerModule.class).getEventDispatcher().dispatchEvent(
+          new ReactCheckBoxEvent(
+            buttonView.getId(),
+            SystemClock.nanoTime(),
+            isChecked));
+      }
+    };
+
+  @Override
+  public String getName() {
+    return REACT_CLASS;
+  }
+
+  @Override
+  protected ReactCheckBox createViewInstance(ThemedReactContext reactContext) {
+    return new ReactCheckBox(reactContext);
+  }
+
+  @Override
+  public LayoutShadowNode createShadowNodeInstance() {
+    return new ShadowNode();
+  }
+
+  @Override
+  public Class getShadowNodeClass() {
+    return ShadowNode.class;
+  }
+
+  @ReactProp(name = ViewProps.ENABLED, defaultBoolean = true)
+  public void setEnabled(ReactCheckBox view, boolean enabled) {
+    view.setEnabled(enabled);
+  }
+
+  @ReactProp(name = ViewProps.ON)
+  public void setOn(ReactCheckBox view, boolean on) {
+    // we set the checked change listener to null and then restore it so that we don't fire an
+    // onChange event to JS when JS itself is updating the value of the switch
+    view.setOnCheckedChangeListener(null);
+    view.setOn(on);
+    view.setOnCheckedChangeListener(ON_CHECKED_CHANGE_LISTENER);
+  }
+
+  @ReactProp(name = PROP_TEXT)
+  public void setText(ReactCheckBox view, @Nullable String text) {
+    view.setText(text);
+  }
+
+  @Override
+  protected void addEventEmitters(final ThemedReactContext reactContext, final ReactCheckBox view) {
+    view.setOnCheckedChangeListener(ON_CHECKED_CHANGE_LISTENER);
+  }
+
+}
+

--- a/website/server/extractDocs.js
+++ b/website/server/extractDocs.js
@@ -219,6 +219,7 @@ function renderStyle(filepath) {
 
 var components = [
   '../Libraries/Components/ActivityIndicatorIOS/ActivityIndicatorIOS.ios.js',
+  '../Libraries/Components/CheckBoxAndroid/CheckBoxAndroid.android.js',
   '../Libraries/Components/DatePicker/DatePickerIOS.ios.js',
   '../Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.android.js',
   '../Libraries/Image/Image.ios.js',


### PR DESCRIPTION
This PR implements a native checkbox for Android. Currently there are some implementations that implement checkboxes purely in Javascript using `<Image />`,  `<Text />,` and the like to mimic behavior according to the Material design guidelines. The flaw with such approach is that if the design guidelines change again ( historically Android had at least three themes: the original orangish theme, Hollo, and now Material), those implementations will require some maintenance. This implementation wraps an actual Android AppCompatCheckbox view, ensuring that it match the current design and behavior of the platform.

Because there is no official checkbox component in iOS, this implementation is specific for Android.

I wrote examples for the UIExplorer to test the component. I didn't write actual UTs because I could not find similar tests for other components, specially `<Switch />`  on which based most of my implementation. I would be glad if someone could help me on that.