### PR TITLE
Bump babel-preset-react-native version

### DIFF
--- a/babel-preset/package.json
+++ b/babel-preset/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-preset-react-native",
-  "version": "1.5.6",
+  "version": "1.5.7",
   "description": "Babel preset for React Native applications",
   "main": "index.js",
   "repository": "https://github.com/facebook/react-native/tree/master/babel-preset",


### PR DESCRIPTION
To include a missing part of the fix to HMR on Windows that was done in 0.25rc. See https://github.com/facebook/react-native/commit/c61100d0ceb4b71c86f01f35d7464d2d8a02b342. Will need to also publish to npm.

cc @ide @grabbou 