### PR TITLE
[cli/runAndroid] removing xterm from linux spawn

### DIFF
--- a/local-cli/runAndroid/runAndroid.js
+++ b/local-cli/runAndroid/runAndroid.js
@@ -173,7 +173,7 @@ function startServerInNewWindow() {
     if (yargV.open){
       return child_process.spawn(yargV.open,['-e', 'sh', launchPackagerScript], {detached: true});
     }
-    return child_process.spawn('xterm',['-e', 'sh', launchPackagerScript],{detached: true});
+    return child_process.spawn('sh', [launchPackagerScript],{detached: true});
 
   } else if (/^win/.test(process.platform)) {
     console.log(chalk.yellow('Starting the packager in a new window ' +


### PR DESCRIPTION
Simply removing the xterm spawn from android packager, since you can archive exactly the same results using the standard shell :smile: 