### PR TITLE
Option to not store credentials in file

### DIFF
--- a/docs/SignedAPKAndroid.md
+++ b/docs/SignedAPKAndroid.md
@@ -23,6 +23,8 @@ _Note: Remember to keep your keystore file private and never commit it to versio
 
 ### Setting up gradle variables
 
+_Note: This is a global way that will work for any platform, if you are not keen on storing your passwords in plaintext and you are running OSX, you can also [store your credentials in the Keychain Access app](https://pilloxa.gitlab.io/posts/safer-passwords-in-gradle/). Then you can skip the two last rows in `~/.gradle/gradle.properties`._ 
+
 1. Place the `my-release-key.keystore` file under the `android/app` directory in your project folder.
 2. Edit the file `~/.gradle/gradle.properties` and add the following (replace `*****` with the correct keystore password, alias and key password),
 

--- a/docs/SignedAPKAndroid.md
+++ b/docs/SignedAPKAndroid.md
@@ -23,8 +23,6 @@ _Note: Remember to keep your keystore file private and never commit it to versio
 
 ### Setting up gradle variables
 
-_Note: If you are not keen on storing your passwords in plaintext and you are running OSX, you can also [store your credentials in the Keychain Access app](https://pilloxa.gitlab.io/posts/safer-passwords-in-gradle/). Then you can skip the two last rows in `~/.gradle/gradle.properties`._ 
-
 1. Place the `my-release-key.keystore` file under the `android/app` directory in your project folder.
 2. Edit the file `~/.gradle/gradle.properties` and add the following (replace `*****` with the correct keystore password, alias and key password),
 
@@ -37,7 +35,10 @@ MYAPP_RELEASE_KEY_PASSWORD=*****
 
 These are going to be global gradle variables, which we can later use in our gradle config to sign our app.
 
-_Note: Once you publish the app on the Play Store, you will need to republish your app under a different package name (losing all downloads and ratings) if you want to change the signing key at any point. So backup your keystore and don't forget the passwords._
+_Note about saving the keystore: Once you publish the app on the Play Store, you will need to republish your app under a different package name (losing all downloads and ratings) if you want to change the signing key at any point. So backup your keystore and don't forget the passwords._
+
+_Note about security: If you are not keen on storing your passwords in plaintext and you are running OSX, you can also [store your credentials in the Keychain Access app](https://pilloxa.gitlab.io/posts/safer-passwords-in-gradle/). Then you can skip the two last rows in `~/.gradle/gradle.properties`._ 
+
 
 ### Adding signing config to your app's gradle config
 

--- a/docs/SignedAPKAndroid.md
+++ b/docs/SignedAPKAndroid.md
@@ -23,7 +23,7 @@ _Note: Remember to keep your keystore file private and never commit it to versio
 
 ### Setting up gradle variables
 
-_Note: This is a global way that will work for any platform, if you are not keen on storing your passwords in plaintext and you are running OSX, you can also [store your credentials in the Keychain Access app](https://pilloxa.gitlab.io/posts/safer-passwords-in-gradle/). Then you can skip the two last rows in `~/.gradle/gradle.properties`._ 
+_Note: If you are not keen on storing your passwords in plaintext and you are running OSX, you can also [store your credentials in the Keychain Access app](https://pilloxa.gitlab.io/posts/safer-passwords-in-gradle/). Then you can skip the two last rows in `~/.gradle/gradle.properties`._ 
 
 1. Place the `my-release-key.keystore` file under the `android/app` directory in your project folder.
 2. Edit the file `~/.gradle/gradle.properties` and add the following (replace `*****` with the correct keystore password, alias and key password),


### PR DESCRIPTION
**Motivation:** I don't like storing credentials in config files and a safer solution is to store them in the Keychain Access app.

Therefore I added a link that describes how one may go about to store the passwords in the Keychain Access app in OSX instead.

Found a [stackoverflow post](http://stackoverflow.com/a/24480579/1836121) but it wasn't very detailed so I decided to write it up myself. I understand if you have some policy against external links to blogs and I guess we could link to the stackoverflow explanation then instead.