### PR TITLE
Remove read to allow automated usage

### DIFF
--- a/packager/launchPackager.command
+++ b/packager/launchPackager.command
@@ -16,5 +16,4 @@ pushd "$THIS_DIR"
 source packager.sh
 popd
 
-echo "Process terminated. Press <enter> to close the window"
-read
+


### PR DESCRIPTION

Using this in an automated build will cause the process to be orphaned, as there is no person to hit enter.

This commit just removes read and the echo statement