### PR TITLE
Support non-standard path of Android Support Repository

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,5 +18,10 @@ allprojects {
     repositories {
         jcenter()
         mavenLocal()
+
+        def androidSdk = System.getenv("ANDROID_SDK")
+        maven {
+            url "$androidSdk/extras/m2repository/"
+        }
     }
 }


### PR DESCRIPTION
This is needed in cases when the Android Support Repository is on a non-standard path.

**Test plan (required)**

CircleCI tests on this pull request.

