### PR TITLE
Do not make RCTDevLoadingView a keyWindow

### DIFF
--- a/React/Modules/RCTDevLoadingView.m
+++ b/React/Modules/RCTDevLoadingView.m
@@ -77,7 +77,6 @@ RCT_EXPORT_METHOD(showMessage:(NSString *)message color:(UIColor *)color backgro
       _label.textAlignment = NSTextAlignmentCenter;
 
       [_window addSubview:_label];
-      [_window makeKeyAndVisible];
     }
 
     _label.text = message;


### PR DESCRIPTION
Hey,

I have been going through some UIAlert related issues in the repo trying to fix them, and one of the steps to start reproducing them was to put `Alert.alert()` call right inside `componentDidMount`.

However, I've started noticing strange bugs as long as I didn't set 1second timeout.

Started digging in deeper, and I've noticed the `UIAlert` gets attached to the `RCTWindow()` mainViewController.

However - since RCTDevLoadingView adds a `keyWindow`, that is the window that will be returned at the time of the call and the window `UIAlert` will be attached to.

To visualise that better - you can take a look at these two frames when app is being loaded:
<img width="371" alt="screen shot 2016-04-20 at 22 02 45" src="https://cloud.githubusercontent.com/assets/2464966/14688596/ae8d292c-0743-11e6-8aeb-e45da391b5b5.png">
<img width="371" alt="screen shot 2016-04-20 at 22 02 58" src="https://cloud.githubusercontent.com/assets/2464966/14688599/b30798e8-0743-11e6-951a-463fe7324c56.png">

AFAIK we do not need to call a `setKeyAndVisible` as that's equivalent to:
```obj-c
[_window setKeyWindow]
_window.hidden = NO
```
Since we already set hidden to `NO` few lines below, I just removed that line.

From the Apple docs, a window should be a keyWindow only if it wants to receive touches and keyboard events which in case of a small loading message does not make really sense.

Here's the post-commit screen:
<img width="370" alt="screen shot 2016-04-20 at 22 05 41" src="https://cloud.githubusercontent.com/assets/2464966/14688663/0f222206-0744-11e6-9877-000f77aa5bab.png">

PS. Also tested with `HMR` messages, seems to be displaying `just fine`.
