### PR TITLE
removed 'src' prop warning if a valid 'source' prop exists

### DIFF
--- a/Libraries/Image/Image.android.js
+++ b/Libraries/Image/Image.android.js
@@ -171,10 +171,6 @@ var Image = React.createClass({
       console.warn('source.uri should not be an empty string');
     }
 
-    if (this.props.src) {
-      console.warn('The <Image> component requires a `source` property rather than `src`.');
-    }
-
     if (source && source.uri) {
       var {width, height} = source;
       var style = flattenStyle([{width, height}, styles.base, this.props.style]);
@@ -206,6 +202,8 @@ var Image = React.createClass({
           return <RKImage {...nativeProps}/>;
         }
       }
+    } else if (this.props.src) {
+      console.warn('The <Image> component requires a `source` property rather than `src`.');
     }
     return null;
   }

--- a/Libraries/Image/Image.ios.js
+++ b/Libraries/Image/Image.ios.js
@@ -221,7 +221,7 @@ var Image = React.createClass({
       RawImage = RCTImageView;
     }
 
-    if (this.props.src) {
+    if (!this.props.source && this.props.src) {
       console.warn('The <Image> component requires a `source` property rather than `src`.');
     }
 


### PR DESCRIPTION
https://github.com/facebook/react-native/issues/7106

Moved the android warning to a place where it makes more sense.

Added a `no source` check in the iOS version.