### PR TITLE
Fix textShadowOffset error without width or height

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextShadowNode.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextShadowNode.java
@@ -67,11 +67,10 @@ public class ReactTextShadowNode extends LayoutShadowNode {
   public static final String PROP_TEXT = "text";
 
   public static final String PROP_SHADOW_OFFSET = "textShadowOffset";
+  public static final String PROP_SHADOW_OFFSET_WIDTH = "width";
+  public static final String PROP_SHADOW_OFFSET_HEIGHT = "height";
   public static final String PROP_SHADOW_RADIUS = "textShadowRadius";
   public static final String PROP_SHADOW_COLOR = "textShadowColor";
-
-  public static final String ARG_WIDTH = "width";
-  public static final String ARG_HEIGHT = "height";
 
   public static final int DEFAULT_TEXT_SHADOW_COLOR = 0x55000000;
 
@@ -471,11 +470,15 @@ public class ReactTextShadowNode extends LayoutShadowNode {
     mTextShadowOffsetDy = 0;
 
     if (offsetMap != null) {
-      if (offsetMap.hasKey(ARG_WIDTH) && !offsetMap.isNull(ARG_WIDTH)) {
-        mTextShadowOffsetDx = PixelUtil.toPixelFromDIP(offsetMap.getDouble(ARG_WIDTH));
+      if (offsetMap.hasKey(PROP_SHADOW_OFFSET_WIDTH) &&
+          !offsetMap.isNull(PROP_SHADOW_OFFSET_WIDTH)) {
+        mTextShadowOffsetDx =
+            PixelUtil.toPixelFromDIP(offsetMap.getDouble(PROP_SHADOW_OFFSET_WIDTH));
       }
-      if (offsetMap.hasKey(ARG_HEIGHT) && !offsetMap.isNull(ARG_HEIGHT)) {
-        mTextShadowOffsetDy = PixelUtil.toPixelFromDIP(offsetMap.getDouble(ARG_HEIGHT));
+      if (offsetMap.hasKey(PROP_SHADOW_OFFSET_HEIGHT) &&
+          !offsetMap.isNull(PROP_SHADOW_OFFSET_HEIGHT)) {
+        mTextShadowOffsetDy =
+            PixelUtil.toPixelFromDIP(offsetMap.getDouble(PROP_SHADOW_OFFSET_HEIGHT));
       }
     }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextShadowNode.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextShadowNode.java
@@ -69,6 +69,10 @@ public class ReactTextShadowNode extends LayoutShadowNode {
   public static final String PROP_SHADOW_OFFSET = "textShadowOffset";
   public static final String PROP_SHADOW_RADIUS = "textShadowRadius";
   public static final String PROP_SHADOW_COLOR = "textShadowColor";
+
+  public static final String ARG_WIDTH = "width";
+  public static final String ARG_HEIGHT = "height";
+
   public static final int DEFAULT_TEXT_SHADOW_COLOR = 0x55000000;
 
   private static final TextPaint sTextPaintInstance = new TextPaint();
@@ -463,13 +467,18 @@ public class ReactTextShadowNode extends LayoutShadowNode {
 
   @ReactProp(name = PROP_SHADOW_OFFSET)
   public void setTextShadowOffset(ReadableMap offsetMap) {
-    if (offsetMap == null) {
-      mTextShadowOffsetDx = 0;
-      mTextShadowOffsetDy = 0;
-    } else {
-      mTextShadowOffsetDx = PixelUtil.toPixelFromDIP(offsetMap.getDouble("width"));
-      mTextShadowOffsetDy = PixelUtil.toPixelFromDIP(offsetMap.getDouble("height"));
+    mTextShadowOffsetDx = 0;
+    mTextShadowOffsetDy = 0;
+
+    if (offsetMap != null) {
+      if (offsetMap.hasKey(ARG_WIDTH) && !offsetMap.isNull(ARG_WIDTH)) {
+        mTextShadowOffsetDx = PixelUtil.toPixelFromDIP(offsetMap.getDouble(ARG_WIDTH));
+      }
+      if (offsetMap.hasKey(ARG_HEIGHT) && !offsetMap.isNull(ARG_HEIGHT)) {
+        mTextShadowOffsetDy = PixelUtil.toPixelFromDIP(offsetMap.getDouble(ARG_HEIGHT));
+      }
     }
+
     markUpdated();
   }
 


### PR DESCRIPTION
textShadowOffset design is `ReactPropTypes.shape({width: ReactPropTypes.number, height: ReactPropTypes.number})`, so either width or height is optional.
Unfortunately, in Android implementation, it is my bad not handling optional case and lead to an exception.
Thanks @kohver for reporting [this issue](https://github.com/facebook/react-native/pull/4975#issuecomment-213006641)

**Test plan (required)**

*Before this fix*
1. Modify TextExample.android.js to `<Text style={{fontSize: 20, textShadowOffset: {height: 10}, textShadowRadius: 1, textShadowColor: '#00cccc'}}>` which really raise a redbox.

*After this fix*
1. Test original TextExample.android.js textShadowOffset works well.
2. Modify TextExample.android.js to `<Text style={{fontSize: 20, textShadowOffset: {height: 10}, textShadowRadius: 1, textShadowColor: '#00cccc'}}>` which works well without redbox.
