### PR TITLE
Android package name validator consistent with docs

### DIFF
--- a/local-cli/generator-android/index.js
+++ b/local-cli/generator-android/index.js
@@ -14,7 +14,7 @@ var path = require('path');
 var yeoman = require('yeoman-generator');
 
 function validatePackageName(name) {
-  if (!name.match(/^([a-zA-Z_$][a-zA-Z\d_$]*\.)+([a-zA-Z_$][a-zA-Z\d_$]*)$/)) {
+  if (!name.match(/^([a-zA-Z][a-zA-Z\d_]*\.)+([a-zA-Z_][a-zA-Z\d_]*)$/)) {
     return false;
   }
   return true;

--- a/local-cli/generator-utils.js
+++ b/local-cli/generator-utils.js
@@ -37,19 +37,7 @@ function walk(current) {
   return [].concat.apply([current], files);
 }
 
-function validatePackageName(name) {
-  if (!name.match(/^[$A-Z_][0-9A-Z_$]*$/i)) {
-    console.error(
-      '"%s" is not a valid name for a project. Please use a valid identifier ' +
-        'name (alphanumeric).',
-      name
-    );
-    process.exit(1);
-  }
-}
-
 module.exports = {
   copyAndReplace: copyAndReplace,
-  walk: walk,
-  validatePackageName: validatePackageName
+  walk: walk
 };


### PR DESCRIPTION
I removed `$` and `_` (only from the starting substring) as they
cannot be used in creating Android package name according to official
android documentation. Also removed a duplicate function (there is the
same one in `react-native-cli/index.js`). This fixes #7115.