### PR TITLE
Document how to disable YellowBox

### DIFF
--- a/docs/Debugging.md
+++ b/docs/Debugging.md
@@ -31,7 +31,16 @@ Using `console.warn` will display an on-screen log on a yellow background. Click
 
 You can use `console.error` to display a full screen error on a red background.
 
-These boxes only appear when you're running your app in dev mode.
+By default, the warning box is enabled in `__DEV__`. Set the following flag to disable it:
+```js
+console.disableYellowBox = true;
+console.warn('YellowBox is disabled.');
+```
+Warnings can be ignored programmatically by setting the array:
+```js
+console.ignoredYellowBox = ['Warning: ...'];
+```
+Strings in `console.ignoredYellowBox` can be a prefix of the warning that should be ignored.
 
 ### Chrome Developer Tools
 To debug the JavaScript code in Chrome, select `Debug JS Remotely` from the developer menu. This will open a new tab at [http://localhost:8081/debugger-ui](http://localhost:8081/debugger-ui).

--- a/docs/Debugging.md
+++ b/docs/Debugging.md
@@ -36,7 +36,7 @@ By default, the warning box is enabled in `__DEV__`. Set the following flag to d
 console.disableYellowBox = true;
 console.warn('YellowBox is disabled.');
 ```
-Warnings can be ignored programmatically by setting the array:
+Specific warnings can be ignored programmatically by setting the array:
 ```js
 console.ignoredYellowBox = ['Warning: ...'];
 ```


### PR DESCRIPTION
As mentioned in #7121 by @javache, this can already be disabled. Might be useful if users upgrade to 0.25 and want to hide warnings about wrong React imported (something they can't really control until community upgrades).

This should be mentioned in the release notes once it's merged.