### PR TITLE
Fix a bug in asset server when using relative project roots

### DIFF
--- a/packager/react-packager/src/AssetServer/index.js
+++ b/packager/react-packager/src/AssetServer/index.js
@@ -129,7 +129,7 @@ class AssetServer {
   _findRoot(roots, dir) {
     return Promise.all(
       roots.map(root => {
-        const absRoot = fs.resolve(root);
+        const absRoot = path.resolve(root);
         // important: we want to resolve root + dir
         // to ensure the requested path doesn't traverse beyond root
         const absPath = path.resolve(root, dir);

--- a/packager/react-packager/src/AssetServer/index.js
+++ b/packager/react-packager/src/AssetServer/index.js
@@ -129,13 +129,14 @@ class AssetServer {
   _findRoot(roots, dir) {
     return Promise.all(
       roots.map(root => {
+        const absRoot = fs.resolve(root);
         // important: we want to resolve root + dir
         // to ensure the requested path doesn't traverse beyond root
         const absPath = path.resolve(root, dir);
         return stat(absPath).then(fstat => {
           // keep asset requests from traversing files
           // up from the root (e.g. ../../../etc/hosts)
-          if (!absPath.startsWith(root)) {
+          if (!absPath.startsWith(absRoot)) {
             return {path: absPath, isValid: false};
           }
           return {path: absPath, isValid: fstat.isDirectory()};


### PR DESCRIPTION
This PR fixes a bug where when using relative roots for the packager server, asset paths would be deemed invalid by the recently introduced security check. Resolving the root to an absolute path fixes that problem.

I'd be happy to write a regression test for this but I had a hard time setting up a mock file system with relative paths. If it is required, some help would be appreciated...
