### PR TITLE
[Xcode] Use xcodebuild and delete "Framework Search Paths" for Xcode 7.3 to un-stall the tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ install:
   - export NVM_DIR="/Users/travis/build/facebook/.nvm"
   - source $(brew --prefix nvm)/nvm.sh
   # testing with npm@2 for diversity, Circle tests with npm@3
-  - nvm install 4.4.0
+  - nvm install 4.4.3
   - rm -Rf "${TMPDIR}/jest_preprocess_cache"
   - npm config set spin=false
   - npm config set progress=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ language: objective-c
 osx_image: xcode7.3
 
 install:
-  - brew update
-  - brew reinstall nvm xctool
   - mkdir -p /Users/travis/build/facebook/.nvm
   - export NVM_DIR="/Users/travis/build/facebook/.nvm"
   - source $(brew --prefix nvm)/nvm.sh

--- a/Examples/UIExplorer/UIExplorer.xcodeproj/project.pbxproj
+++ b/Examples/UIExplorer/UIExplorer.xcodeproj/project.pbxproj
@@ -955,10 +955,6 @@
 		004D28A61AAF61C70097A701 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(inherited)",
-				);
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
@@ -980,10 +976,6 @@
 		004D28A71AAF61C70097A701 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(inherited)",
-				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)/../../React/**",
@@ -1057,10 +1049,6 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(inherited)",
-				);
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"$(inherited)",
@@ -1081,10 +1069,6 @@
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(inherited)",
-				);
 				GCC_NO_COMMON_BLOCKS = YES;
 				INFOPLIST_FILE = UIExplorerIntegrationTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.3;

--- a/local-cli/generator-ios/templates/xcodeproj/project.pbxproj
+++ b/local-cli/generator-ios/templates/xcodeproj/project.pbxproj
@@ -575,10 +575,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(inherited)",
-				);
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
 					"$(inherited)",
@@ -596,10 +592,6 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				COPY_PHASE_STRIP = NO;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(inherited)",
-				);
 				INFOPLIST_FILE = <%= name %>Tests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.2;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";

--- a/scripts/objc-test.sh
+++ b/scripts/objc-test.sh
@@ -26,7 +26,11 @@ trap cleanup EXIT
 
 ./packager/packager.sh --nonPersistent &
 SERVER_PID=$!
-xctool \
+# TODO: We use xcodebuild because xctool would stall when collecting info about
+# the tests before running them. Switch back when this issue with xctool has
+# been resolved.
+xcodebuild \
   -project Examples/UIExplorer/UIExplorer.xcodeproj \
   -scheme UIExplorer -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 5,OS=9.3' \
-  test
+  test \
+| xcpretty

--- a/scripts/run-ci-e2e-tests.js
+++ b/scripts/run-ci-e2e-tests.js
@@ -151,7 +151,7 @@ if (args.indexOf('--ios') !== -1) {
   // shelljs exec('', {async: true}) does not emit stdout events, so we rely on good old spawn
   let packagerEnv = Object.create(process.env);
   packagerEnv.REACT_NATIVE_MAX_WORKERS = 1;
-  const packagerProcess = spawn('npm', ['start', '--', '--non-persistent'], 
+  const packagerProcess = spawn('npm', ['start', '--', '--non-persistent'],
   {
     stdio: 'inherit',
     env: packagerEnv
@@ -162,7 +162,7 @@ if (args.indexOf('--ios') !== -1) {
   exec('response=$(curl --write-out %{http_code} --silent --output /dev/null localhost:8081/index.ios.bundle?platform=ios&dev=true)');
   echo(`Starting packager server, ${SERVER_PID}`);
   echo('Executing ios e2e test');
-  if (exec('xctool -scheme EndToEndTest -sdk iphonesimulator test').code) {
+  if (exec('xcodebuild -scheme EndToEndTest -sdk iphonesimulator test | xcpretty').code) {
     exit(cleanup(1));
   }
   cd('..');


### PR DESCRIPTION
The Obj-C tests were stalling when we updated TravisCI to use the OS X image with Xcode 7.3 and iOS 9.3.

On my own MBP with Xcode 7.3 the tests stall as well. Running `./scripts/objc-test.sh` prints out a warning near the end, which says `ld` couldn't find a Frameworks folder under the iPhoneSimulator9.3 SDK directory. Indeed, this directory doesn't exist on my computer. When creating a brand new project with unit tests and UI tests, both test targets don't specify "Framework Search Paths" so I don't think we need to specify it anymore.

The problem with stalling was that xctool has issues -- this is not specific to the RN project and other people are experiencing it. Switching to xcodebuild fixes things.

Test Plan: Locally tested with `scripts/objc-test.sh`. Will test on Travis CI with this PR.