### PR TITLE
Add support for delete animation in LayoutAnimation on Android

### DIFF
--- a/Examples/UIExplorer/UIExplorerApp.android.js
+++ b/Examples/UIExplorer/UIExplorerApp.android.js
@@ -37,8 +37,11 @@ const UIExplorerExampleList = require('./UIExplorerExampleList');
 const UIExplorerList = require('./UIExplorerList');
 const UIExplorerNavigationReducer = require('./UIExplorerNavigationReducer');
 const UIExplorerStateTitleMap = require('./UIExplorerStateTitleMap');
+const UIManager = require('UIManager');
 const URIActionMap = require('./URIActionMap');
 const View = require('View');
+
+UIManager.setLayoutAnimationEnabledExperimental(true);
 
 const DRAWER_WIDTH_LEFT = 56;
 

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewGroupManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewGroupManager.java
@@ -48,6 +48,10 @@ public abstract class ViewGroupManager <T extends ViewGroup>
     parent.removeViewAt(index);
   }
 
+  public void removeView(T parent, View view) {
+    parent.removeView(view);
+  }
+
   public void removeAllViews(T parent) {
     for (int i = getChildCount(parent) - 1; i >= 0; i--) {
       removeViewAt(parent, i);

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewGroupManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewGroupManager.java
@@ -49,7 +49,12 @@ public abstract class ViewGroupManager <T extends ViewGroup>
   }
 
   public void removeView(T parent, View view) {
-    parent.removeView(view);
+    for (int i = 0; i < getChildCount(parent); i++) {
+      if (getChildAt(parent, i) == view) {
+        removeViewAt(parent, i);
+        break;
+      }
+    }
   }
 
   public void removeAllViews(T parent) {

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/LayoutAnimationController.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/LayoutAnimationController.java
@@ -8,6 +8,7 @@ import javax.annotation.concurrent.NotThreadSafe;
 import android.view.View;
 import android.view.animation.Animation;
 
+import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.UiThreadUtil;
 
@@ -25,6 +26,7 @@ public class LayoutAnimationController {
 
   private final AbstractLayoutAnimation mLayoutCreateAnimation = new LayoutCreateAnimation();
   private final AbstractLayoutAnimation mLayoutUpdateAnimation = new LayoutUpdateAnimation();
+  private final AbstractLayoutAnimation mLayoutDeleteAnimation = new LayoutDeleteAnimation();
   private boolean mShouldAnimateLayout;
 
   public void initializeFromConfig(final @Nullable ReadableMap config) {
@@ -49,11 +51,17 @@ public class LayoutAnimationController {
           config.getMap(LayoutAnimationType.UPDATE.toString()), globalDuration);
       mShouldAnimateLayout = true;
     }
+    if (config.hasKey(LayoutAnimationType.DELETE.toString())) {
+      mLayoutDeleteAnimation.initializeFromConfig(
+          config.getMap(LayoutAnimationType.DELETE.toString()), globalDuration);
+      mShouldAnimateLayout = true;
+    }
   }
 
   public void reset() {
     mLayoutCreateAnimation.reset();
     mLayoutUpdateAnimation.reset();
+    mLayoutDeleteAnimation.reset();
     mShouldAnimateLayout = false;
   }
 
@@ -65,7 +73,8 @@ public class LayoutAnimationController {
 
   /**
    * Update layout of given view, via immediate update or animation depending on the current batch
-   * layout animation configuration supplied during initialization.
+   * layout animation configuration supplied during initialization. Handles create and update
+   * animations.
    *
    * @param view the view to update layout of
    * @param x the new X position for the view
@@ -76,9 +85,9 @@ public class LayoutAnimationController {
   public void applyLayoutUpdate(View view, int x, int y, int width, int height) {
     UiThreadUtil.assertOnUiThread();
 
-    // Determine which animation to use : if view is initially invisible, use create animation.
-    // If view is becoming invisible, use delete animation. Otherwise, use update animation.
-    // This approach is easier than maintaining a list of tags for recently created/deleted views.
+    // Determine which animation to use : if view is initially invisible, use create animation,
+    // otherwise use update animation. This approach is easier than maintaining a list of tags
+    // for recently created views.
     AbstractLayoutAnimation layoutAnimation = (view.getWidth() == 0 || view.getHeight() == 0) ?
         mLayoutCreateAnimation :
         mLayoutUpdateAnimation;
@@ -89,6 +98,41 @@ public class LayoutAnimationController {
     }
     if (animation != null) {
       view.startAnimation(animation);
+    }
+  }
+
+  /**
+   * Animate a view deletion using the layout animation configuration supplied during initialization.
+   *
+   * @param view     The view to animate.
+   * @param callback Called once the animation is finished, should be used to
+   *                 completely remove the view.
+   */
+  public void deleteView(final View view, final Callback callback) {
+    UiThreadUtil.assertOnUiThread();
+
+    AbstractLayoutAnimation layoutAnimation = mLayoutDeleteAnimation;
+
+    Animation animation = layoutAnimation.createAnimation(
+        view, view.getLeft(), view.getTop(), view.getWidth(), view.getHeight());
+
+    if (animation != null) {
+      animation.setAnimationListener(new Animation.AnimationListener() {
+        @Override
+        public void onAnimationStart(Animation anim) {}
+
+        @Override
+        public void onAnimationRepeat(Animation anim) {}
+
+        @Override
+        public void onAnimationEnd(Animation anim) {
+          callback.invoke();
+        }
+      });
+
+      view.startAnimation(animation);
+    } else {
+      callback.invoke();
     }
   }
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/LayoutAnimationListener.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/LayoutAnimationListener.java
@@ -1,0 +1,10 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+package com.facebook.react.uimanager.layoutanimation;
+
+/**
+ * Listener invoked when a layout animation has completed.
+ */
+public interface LayoutAnimationListener {
+  void onAnimationEnd();
+}

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/LayoutAnimationType.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/LayoutAnimationType.java
@@ -7,7 +7,8 @@ package com.facebook.react.uimanager.layoutanimation;
  */
 /* package */ enum LayoutAnimationType {
   CREATE("create"),
-  UPDATE("update");
+  UPDATE("update"),
+  DELETE("delete");
 
   private final String mName;
 

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/LayoutDeleteAnimation.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/LayoutDeleteAnimation.java
@@ -1,0 +1,15 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+package com.facebook.react.uimanager.layoutanimation;
+
+/**
+ * Class responsible for handling layout view deletion animation, applied to view whenever a
+ * valid config was supplied for the layout animation of DELETE type.
+ */
+/* package */ class LayoutDeleteAnimation extends BaseLayoutAnimation {
+
+  @Override
+  boolean isReverse() {
+    return true;
+  }
+}


### PR DESCRIPTION
Android follow up to #6779

**Test plan**
Tested add/removing views in the UIExample explorer with and without setting a LayoutAnimation. Tested that user interation during the animation is properly disabled.

![layout-anim-2](https://cloud.githubusercontent.com/assets/2677334/14760549/d60ebe2a-0914-11e6-8f17-ea04d8bf813b.gif)

