### PR TITLE
[CI] Exit with the error status code from xcodebuild

### DIFF
--- a/scripts/objc-test.sh
+++ b/scripts/objc-test.sh
@@ -33,4 +33,4 @@ xcodebuild \
   -project Examples/UIExplorer/UIExplorer.xcodeproj \
   -scheme UIExplorer -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 5,OS=9.3' \
   test \
-| xcpretty
+| xcpretty && exit ${PIPESTATUS[0]}

--- a/scripts/run-ci-e2e-tests.js
+++ b/scripts/run-ci-e2e-tests.js
@@ -162,7 +162,7 @@ if (args.indexOf('--ios') !== -1) {
   exec('response=$(curl --write-out %{http_code} --silent --output /dev/null localhost:8081/index.ios.bundle?platform=ios&dev=true)');
   echo(`Starting packager server, ${SERVER_PID}`);
   echo('Executing ios e2e test');
-  if (exec('xcodebuild -scheme EndToEndTest -sdk iphonesimulator test | xcpretty').code) {
+  if (exec('xcodebuild -scheme EndToEndTest -sdk iphonesimulator test | xcpretty && exit ${PIPESTATUS[0]}').code) {
     exit(cleanup(1));
   }
   cd('..');


### PR DESCRIPTION
See https://github.com/supermarin/xcpretty#usage -- xcpretty will suppress xcodebuild's status code so we need to add `&& exit ${PIPESTATUS[0]}`.

Test Plan: Look at Travis CI results and see that an error with the Obj-C tests is properly reported as a CI error.