### PR TITLE
[Tests] Update jest-cli to v0.11.x and fix InteractionMixin test

### DIFF
--- a/Libraries/Interaction/__tests__/InteractionMixin-test.js
+++ b/Libraries/Interaction/__tests__/InteractionMixin-test.js
@@ -3,7 +3,7 @@
  */
 'use strict';
 
-jest.dontMock('InteractionMixin');
+jest.unmock('InteractionMixin');
 
 describe('InteractionMixin', () => {
   var InteractionManager;
@@ -19,9 +19,8 @@ describe('InteractionMixin', () => {
   });
 
   it('should start interactions', () => {
-    var timeout = 123;
-    component.createInteractionHandle(timeout);
-    expect(InteractionManager.createInteractionHandle).toBeCalled(timeout);
+    component.createInteractionHandle();
+    expect(InteractionManager.createInteractionHandle).toBeCalled();
   });
 
   it('should end interactions', () => {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
       "^image![a-zA-Z0-9$_-]+$": "GlobalImageStub",
       "^[./a-zA-Z0-9$_-]+\\.png$": "RelativeImageStub"
     },
-    "testRunner": "<rootDir>/node_modules/jest-cli/src/testRunners/jasmine/jasmine2.js",
     "testPathIgnorePatterns": [
       "/node_modules/"
     ],
@@ -187,7 +186,7 @@
     "eslint-plugin-flow-vars": "^0.2.1",
     "eslint-plugin-react": "^4.2.1",
     "flow-bin": "0.23.0",
-    "jest-cli": "0.9.2",
+    "jest-cli": "^11.0.2",
     "portfinder": "0.4.0",
     "react": "15.0.2-alpha.2",
     "shelljs": "0.6.0"


### PR DESCRIPTION
Updates Jest to the latest version with all of its enhancements. I fixed up the InteractionMixin test, which was calling `createInteractionHandle` with a timeout argument that the actual method doesn't actually support, so I just removed the argument.

Test Plan: `npm test`