### PR TITLE
Promisify ActionSheetIOS

### DIFF
--- a/Examples/UIExplorer/ActionSheetIOSExample.js
+++ b/Examples/UIExplorer/ActionSheetIOSExample.js
@@ -60,8 +60,7 @@ var ActionSheetExample = React.createClass({
       options: BUTTONS,
       cancelButtonIndex: CANCEL_INDEX,
       destructiveButtonIndex: DESTRUCTIVE_INDEX,
-    },
-    (buttonIndex) => {
+    }).then(buttonIndex => {
       this.setState({ clicked: BUTTONS[buttonIndex] });
     });
   }
@@ -93,8 +92,7 @@ var ActionSheetTintExample = React.createClass({
       cancelButtonIndex: CANCEL_INDEX,
       destructiveButtonIndex: DESTRUCTIVE_INDEX,
       tintColor: 'green',
-    },
-    (buttonIndex) => {
+    }).then(buttonIndex => {
       this.setState({ clicked: BUTTONS[buttonIndex] });
     });
   }
@@ -121,24 +119,25 @@ var ShareActionSheetExample = React.createClass({
   },
 
   showShareActionSheet() {
-    ActionSheetIOS.showShareActionSheetWithOptions({
-      url: this.props.url,
-      message: 'message to go with the shared url',
-      subject: 'a subject to go in the email heading',
-      excludedActivityTypes: [
-        'com.apple.UIKit.activity.PostToTwitter'
-      ]
-    },
-    (error) => alert(error),
-    (success, method) => {
-      var text;
-      if (success) {
-        text = `Shared via ${method}`;
-      } else {
-        text = 'You didn\'t share';
-      }
-      this.setState({text});
-    });
+    ActionSheetIOS
+      .showShareActionSheetWithOptions({
+        url: this.props.url,
+        message: 'message to go with the shared url',
+        subject: 'a subject to go in the email heading',
+        excludedActivityTypes: [
+          'com.apple.UIKit.activity.PostToTwitter'
+        ]
+      })
+      .then(res => {
+        var text;
+        if (res.completed) {
+          text = `Shared via ${res.method}`;
+        } else {
+          text = 'You didn\'t share';
+        }
+        this.setState({text});
+      })
+      .catch(error => alert(error));
   }
 });
 
@@ -166,23 +165,24 @@ var ShareScreenshotExample = React.createClass({
     // Take the snapshot (returns a temp file uri)
     UIManager.takeSnapshot('window').then((uri) => {
       // Share image data
-      ActionSheetIOS.showShareActionSheetWithOptions({
-        url: uri,
-        excludedActivityTypes: [
-          'com.apple.UIKit.activity.PostToTwitter'
-        ]
-      },
-      (error) => alert(error),
-      (success, method) => {
-        var text;
-        if (success) {
-          text = `Shared via ${method}`;
-        } else {
-          text = 'You didn\'t share';
-        }
-        this.setState({text});
+      ActionSheetIOS
+        .showShareActionSheetWithOptions({
+          url: uri,
+          excludedActivityTypes: [
+            'com.apple.UIKit.activity.PostToTwitter'
+          ]
+        })
+        .then(res => {
+          var text;
+          if (res.completed) {
+            text = `Shared via ${res.method}`;
+          } else {
+            text = 'You didn\'t share';
+          }
+          this.setState({text});
+        })
+        .catch(error => alert(error));
       });
-    }).catch((error) => alert(error));
   }
 });
 

--- a/Libraries/ActionSheetIOS/ActionSheetIOS.js
+++ b/Libraries/ActionSheetIOS/ActionSheetIOS.js
@@ -33,8 +33,10 @@ var ActionSheetIOS = {
    * - `message` (string) - a message to show below the title
    *
    * Promise is resolved with a index of button in `options` that was selected
+   *
+   * NOTE: `callback` is now deprecated in favour of a promise
    */
-  showActionSheetWithOptions(options: Object, callback?: Function): Promise<number> {
+  showActionSheetWithOptions(options: Object, callback?: Function): ?Promise<number> {
     invariant(
       typeof options === 'object' && options !== null,
       'Options must be a valid object'
@@ -65,6 +67,14 @@ var ActionSheetIOS = {
    * - `message` (string) - a message to share
    * - `url` (string) - a URL to share
    *
+   * Returns a Promise that is resolved with an object:
+   *
+   * - `completed` (boolean) - true if share action was completed
+   * - `activityType` (?string) - type of share activity user selected
+   *
+   * NOTE: `failureCallback` and `successCallback` are now deprecated in favour
+   * of promise
+   *
    * NOTE: if `url` points to a local file, or is a base64-encoded
    * uri, the file it points to will be loaded and shared directly.
    * In this way, you can share images, videos, PDF files, etc.
@@ -73,7 +83,7 @@ var ActionSheetIOS = {
     options: Object,
     failureCallback?: Function,
     successCallback?: Function
-  ): Promise<ShareSheetResponse> {
+  ): ?Promise<ShareSheetResponse> {
     invariant(
       typeof options === 'object' && options !== null,
       'Options must be a valid object'
@@ -99,6 +109,7 @@ var ActionSheetIOS = {
         'Use showShareActionSheetWithOptions(opts).then().catch() instead.'
       );
       promise
+        // $FlowFixMe: Ignores invariants and reports possible undefined value
         .then((res: ShareSheetResponse) => successCallback(res.completed, res.activityType))
         .catch(failureCallback);
       return;

--- a/Libraries/ActionSheetIOS/ActionSheetIOS.js
+++ b/Libraries/ActionSheetIOS/ActionSheetIOS.js
@@ -49,9 +49,8 @@ var ActionSheetIOS = {
 
     if (typeof callback === 'function') {
       console.warn(
-        'ActionSheetIOS.showActionSheetWithOptions returns a Promise ' +
-        'and callback function has been deprecated. ' +
-        'Use showActionSheetWithOptions(opts).then() instead.'
+        'ActionSheetIOS.showActionSheetWithOptions(options, cb) is deprecated. ' +
+        'Use the returned Promise instead.'
       );
       promise.then(callback);
     }
@@ -103,9 +102,8 @@ var ActionSheetIOS = {
         'Must provide a valid successCallback'
       );
       console.warn(
-        'ActionSheetIOS.showShareActionSheetWithOptions returns a Promise ' +
-        'and successCallback function and failureCallback function have been deprecated. ' +
-        'Use showShareActionSheetWithOptions(opts).then().catch() instead.'
+        'ActionSheetIOS.showShareActionSheetWithOptions(opts, cb, cb) is deprecated. ' +
+        'Use the returned Promise instead.'
       );
       promise
         // $FlowFixMe: Ignores invariants and reports possible undefined value

--- a/Libraries/ActionSheetIOS/ActionSheetIOS.js
+++ b/Libraries/ActionSheetIOS/ActionSheetIOS.js
@@ -36,7 +36,7 @@ var ActionSheetIOS = {
    *
    * NOTE: `callback` is now deprecated in favour of a promise
    */
-  showActionSheetWithOptions(options: Object, callback?: Function): ?Promise<number> {
+  showActionSheetWithOptions(options: Object, callback?: Function): Promise<number> {
     invariant(
       typeof options === 'object' && options !== null,
       'Options must be a valid object'
@@ -54,7 +54,6 @@ var ActionSheetIOS = {
         'Use showActionSheetWithOptions(opts).then() instead.'
       );
       promise.then(callback);
-      return;
     }
 
     return promise;
@@ -83,7 +82,7 @@ var ActionSheetIOS = {
     options: Object,
     failureCallback?: Function,
     successCallback?: Function
-  ): ?Promise<ShareSheetResponse> {
+  ): Promise<ShareSheetResponse> {
     invariant(
       typeof options === 'object' && options !== null,
       'Options must be a valid object'
@@ -112,7 +111,6 @@ var ActionSheetIOS = {
         // $FlowFixMe: Ignores invariants and reports possible undefined value
         .then((res: ShareSheetResponse) => successCallback(res.completed, res.activityType))
         .catch(failureCallback);
-      return;
     }
 
     return promise;


### PR DESCRIPTION
Currently it has two different signatures for each method. This PR unifies that by adding support for Promises and graceful deprecation warnings to be removed in next release.

Migration time: small

How to test: Open up `UIExplorer` and play around.

Note: To test deprecation warnings, you can just copy & paste UIExplorer from master (takes few seconds). As far as I am concerned, they all show well.