### PR TITLE
Fix 'Can't find variable: React'

### DIFF
--- a/Examples/UIExplorer/BorderExample.js
+++ b/Examples/UIExplorer/BorderExample.js
@@ -13,6 +13,7 @@
  */
 'use strict';
 
+var React = require('react');
 var ReactNative = require('react-native');
 var {
   StyleSheet,


### PR DESCRIPTION
Border example throws "Can't find variable: React" error.

This simply includes React (using old 'require' syntax to keep syntax consistent)

