### PR TITLE
`Image.getMetadata` and tweaks to `prefetch`

### DIFF
--- a/Libraries/Image/Image.ios.js
+++ b/Libraries/Image/Image.ios.js
@@ -182,7 +182,7 @@ var Image = React.createClass({
         });
     },
     /**
-     * Retrieve the ImageMetadata of an image prior to displaying it.
+     * Retrieve the metadata of an image prior to displaying it.
      * This method can fail if the image cannot be found, or fails to download.
      *
      * In order to retrieve the image metadata, the image may first need to be
@@ -198,7 +198,7 @@ var Image = React.createClass({
     },
     /**
      * Prefetches a remote image for later use by downloading it to the disk
-     * cache
+     * cache and returns image metadata.
      */
     prefetch(url: string): Promise<ImageMetadata> {
       return ImageLoader.prefetchImage(url);

--- a/Libraries/Image/Image.ios.js
+++ b/Libraries/Image/Image.ios.js
@@ -32,6 +32,11 @@ var {
   NetworkImageViewManager,
 } = NativeModules;
 
+type ImageMetadata = {
+  width: number,
+  height: number,
+};
+
 /**
  * A React component for displaying different types of images,
  * including network images, static resources, temporary local images, and
@@ -160,16 +165,7 @@ var Image = React.createClass({
   statics: {
     resizeMode: ImageResizeMode,
     /**
-     * Retrieve the width and height (in pixels) of an image prior to displaying it.
-     * This method can fail if the image cannot be found, or fails to download.
-     *
-     * In order to retrieve the image dimensions, the image may first need to be
-     * loaded or downloaded, after which it will be cached. This means that in
-     * principle you could use this method to preload images, however it is not
-     * optimized for that purpose, and may in future be implemented in a way that
-     * does not fully load/download the image data. A proper, supported way to
-     * preload images will be provided as a separate API.
-     *
+     * @deprecated Use `Image.getMetadata` instead
      * @platform ios
      */
     getSize: function(
@@ -177,15 +173,34 @@ var Image = React.createClass({
       success: (width: number, height: number) => void,
       failure: (error: any) => void,
     ) {
-      ImageViewManager.getSize(uri, success, failure || function() {
-        console.warn('Failed to get size for image: ' + uri);
-      });
+      console.warn('Image.getSize is deprecated. Use Image.getMetadata instead');
+
+      Image.getMetadata(uri)
+        .then(meta => success(meta.width, meta.height))
+        .catch(failure || function () {
+          console.warn('Failed to get size for image: ' + uri);
+        });
+    },
+    /**
+     * Retrieve the ImageMetadata of an image prior to displaying it.
+     * This method can fail if the image cannot be found, or fails to download.
+     *
+     * In order to retrieve the image metadata, the image may first need to be
+     * loaded or downloaded, after which it will be cached. This means that in
+     * principle you could use this method to preload images, however it is not
+     * optimized for that purpose, and may in future be implemented in a way that
+     * does not fully load/download the image data. Use `Image.prefetch` instead.
+     *
+     * @platform ios
+     */
+    getMetadata(uri: string): Promise<ImageMetadata> {
+      return ImageLoader.getMetadata(uri);
     },
     /**
      * Prefetches a remote image for later use by downloading it to the disk
      * cache
      */
-    prefetch(url: string) {
+    prefetch(url: string): Promise<ImageMetadata> {
       return ImageLoader.prefetchImage(url);
     },
   },

--- a/Libraries/Image/RCTImageLoader.h
+++ b/Libraries/Image/RCTImageLoader.h
@@ -100,13 +100,6 @@ typedef void (^RCTImageLoaderCancellationBlock)(void);
                                                        resizeMode:(RCTResizeMode)resizeMode
                                                   completionBlock:(RCTImageLoaderCompletionBlock)completionBlock;
 
-/**
- * Get image size, in pixels. This method will do the least work possible to get
- * the information, and won't decode the image if it doesn't have to.
- */
-- (RCTImageLoaderCancellationBlock)getImageSize:(NSString *)imageTag
-                                          block:(void(^)(NSError *error, CGSize size))completionBlock;
-
 @end
 
 @interface RCTBridge (RCTImageLoader)

--- a/Libraries/Image/RCTImageLoader.m
+++ b/Libraries/Image/RCTImageLoader.m
@@ -659,7 +659,7 @@ RCT_EXPORT_METHOD(getMetadata:(NSString *)uri
                        reject:(RCTPromiseRejectBlock)reject)
 {
   if (!uri.length) {
-    reject(RCTErrorInvalidURI, @"Cannot prefetch an image for an empty URI", nil);
+    reject(RCTErrorInvalidURI, @"Cannot get metadata for an empty URI", nil);
     return;
   }
 

--- a/Libraries/Image/RCTImageViewManager.m
+++ b/Libraries/Image/RCTImageViewManager.m
@@ -44,18 +44,4 @@ RCT_CUSTOM_VIEW_PROPERTY(tintColor, UIColor, RCTImageView)
   view.renderingMode = json ? UIImageRenderingModeAlwaysTemplate : defaultView.renderingMode;
 }
 
-RCT_EXPORT_METHOD(getSize:(NSURL *)imageURL
-                  successBlock:(RCTResponseSenderBlock)successBlock
-                  errorBlock:(RCTResponseErrorBlock)errorBlock)
-{
-  [self.bridge.imageLoader getImageSize:imageURL.absoluteString
-                                  block:^(NSError *error, CGSize size) {
-                                    if (error) {
-                                      errorBlock(error);
-                                    } else {
-                                      successBlock(@[@(size.width), @(size.height)]);
-                                    }
-                                  }];
-}
-
 @end


### PR DESCRIPTION
This is iOS only for now implementation (Android will be provided in next commit once we agree all is good here). 

Introduces an `ImageMetadata` object which allows us adding more properties in the future (total size for instance?) If there are any other things you'd like to have returned, comments welcome.

Also it cleans up few things, mainly removes method for getting size from view manager to `ImageLoader` which should help us keeping all the things in one place.

Follow up to #7050 