### PR TITLE
Platform.select method

### DIFF
--- a/Libraries/Utilities/Platform.android.js
+++ b/Libraries/Utilities/Platform.android.js
@@ -12,9 +12,22 @@
 
 'use strict';
 
+var invariant = require('invariant');
+
 var Platform = {
   OS: 'android',
   get Version() { return require('NativeModules').AndroidConstants.Version; },
+  select: (obj: Object) => {
+    invariant(
+      obj && typeof obj === 'object',
+      'Platform.select: Must be called with an object'
+    );
+    invariant(
+      obj.android,
+      'Platform.select: You must provide a value for `android` to select'
+    );
+    return obj.android;
+  },
 };
 
 module.exports = Platform;

--- a/Libraries/Utilities/Platform.android.js
+++ b/Libraries/Utilities/Platform.android.js
@@ -12,18 +12,10 @@
 
 'use strict';
 
-var invariant = require('fbjs/lib/invariant');
-
 var Platform = {
   OS: 'android',
   get Version() { return require('NativeModules').AndroidConstants.Version; },
-  select: (obj: Object) => {
-    invariant(
-      obj && typeof obj === 'object',
-      'Platform.select: Must be called with an object'
-    );
-    return obj.android;
-  },
+  select: (obj: Object) => obj.android,
 };
 
 module.exports = Platform;

--- a/Libraries/Utilities/Platform.android.js
+++ b/Libraries/Utilities/Platform.android.js
@@ -12,7 +12,7 @@
 
 'use strict';
 
-var invariant = require('invariant');
+var invariant = require('fbjs/lib/invariant');
 
 var Platform = {
   OS: 'android',
@@ -21,10 +21,6 @@ var Platform = {
     invariant(
       obj && typeof obj === 'object',
       'Platform.select: Must be called with an object'
-    );
-    invariant(
-      obj.android,
-      'Platform.select: You must provide a value for `android` to select'
     );
     return obj.android;
   },

--- a/Libraries/Utilities/Platform.ios.js
+++ b/Libraries/Utilities/Platform.ios.js
@@ -12,8 +12,21 @@
 
 'use strict';
 
+var invariant = require('invariant');
+
 var Platform = {
   OS: 'ios',
+  select: (obj: Object) => {
+    invariant(
+      obj && typeof obj === 'object',
+      'Platform.select: Must be called with an object'
+    );
+    invariant(
+      obj.ios,
+      'Platform.select: You must provide a value for `ios` to select'
+    );
+    return obj.ios;
+  },
 };
 
 module.exports = Platform;

--- a/Libraries/Utilities/Platform.ios.js
+++ b/Libraries/Utilities/Platform.ios.js
@@ -12,7 +12,7 @@
 
 'use strict';
 
-var invariant = require('invariant');
+var invariant = require('fbjs/lib/invariant');
 
 var Platform = {
   OS: 'ios',
@@ -20,10 +20,6 @@ var Platform = {
     invariant(
       obj && typeof obj === 'object',
       'Platform.select: Must be called with an object'
-    );
-    invariant(
-      obj.ios,
-      'Platform.select: You must provide a value for `ios` to select'
     );
     return obj.ios;
   },

--- a/Libraries/Utilities/Platform.ios.js
+++ b/Libraries/Utilities/Platform.ios.js
@@ -12,17 +12,9 @@
 
 'use strict';
 
-var invariant = require('fbjs/lib/invariant');
-
 var Platform = {
   OS: 'ios',
-  select: (obj: Object) => {
-    invariant(
-      obj && typeof obj === 'object',
-      'Platform.select: Must be called with an object'
-    );
-    return obj.ios;
-  },
+  select: (obj: Object) => obj.ios,
 };
 
 module.exports = Platform;

--- a/Libraries/Utilities/__tests__/Platform-test.js
+++ b/Libraries/Utilities/__tests__/Platform-test.js
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+'use strict';
+
+jest.dontMock('../Platform.ios');
+jest.dontMock('../Platform.android');
+
+var PlatformIOS = require('../Platform.ios');
+var PlatformAndroid = require('../Platform.android');
+
+describe('Platform', () => {
+
+  describe('OS', () => {
+    it('should have correct value', () => {
+      expect(PlatformIOS.OS).toEqual('ios');
+      expect(PlatformAndroid.OS).toEqual('android');
+    });
+  });
+
+  describe('select', () => {
+    it('should return platform specific value', () => {
+      const obj = { ios: 'ios', android: 'android' };
+      expect(PlatformIOS.select(obj)).toEqual(obj.ios);
+      expect(PlatformAndroid.select(obj)).toEqual(obj.android);
+    });
+  });
+
+});

--- a/docs/PlatformSpecificInformation.md
+++ b/docs/PlatformSpecificInformation.md
@@ -55,6 +55,43 @@ var styles = StyleSheet.create({
 
 `Platform.OS` will be `ios` when running in iOS and `android` when running in an Android device or simulator.
 
+There is also a `Platform.select` method available, that given an object containing Platform.OS as keys,
+returns the value for the platform you are currently running on.
+
+```javascript
+var { Platform } = React;
+
+var styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    ...Platform.select({
+      ios: {
+        backgroundColor: 'red',
+      },
+      android: {
+        backgroundColor: 'blue',
+      },
+    }),
+  },
+});
+```
+
+This will result in a container having `flex: 1` on both platforms and backgroundColor - red on iOS and blue
+on Android.
+
+Since it accepts `any` value, you can also use it to return platform specific component, like below:
+
+```javascript
+module.exports = class App extends React.Component {
+  render() {
+    return Platform.select({
+      ios: <ViewIOS />,
+      android: <ViewAndroid />,
+    });
+  }
+}
+```
+
 ###Detecting Android version
 On Android, the Platform module can be also used to detect which is the version of the Android Platform in which the app is running
 

--- a/docs/PlatformSpecificInformation.md
+++ b/docs/PlatformSpecificInformation.md
@@ -82,14 +82,12 @@ on Android.
 Since it accepts `any` value, you can also use it to return platform specific component, like below:
 
 ```javascript
-module.exports = class App extends React.Component {
-  render() {
-    return Platform.select({
-      ios: <ViewIOS />,
-      android: <ViewAndroid />,
-    });
-  }
-}
+var Component = Platform.select({
+  ios: () => require('ComponentIOS'),
+  android: () => require('ComponentAndroid'),
+})();
+
+<Component />;
 ```
 
 ###Detecting Android version


### PR DESCRIPTION
Platform.select, given an object containing Platform.OS as keys, returns the value for the platform you are currently running on.

It works with styles:
```js
var styles = StyleSheet.create({
  container: {
    flex: 1,
    ...Platform.select({
      ios: {
        backgroundColor: 'red',
      },
      android: {
        backgroundColor: 'blue',
      },
    }),
  },
});
```
as well as with functions:
```js
var Component = Platform.select({
  ios: () => require('ComponentIOS'),
  android: () => require('ComponentAndroid'),
})();

<Component />;
```

The entire implementation :)

```patch
 var Platform = {
   OS: 'ios',
+  select: (obj: Object) => obj.ios,
 };
```

Kudos to @frantic for this amazing idea suggested in #7033 