### PR TITLE
More information about boilerplate `ios`ing

### DIFF
--- a/Libraries/Components/Navigation/NavigatorIOS.ios.js
+++ b/Libraries/Components/Navigation/NavigatorIOS.ios.js
@@ -110,6 +110,7 @@ type Event = Object;
  * render: function() {
  *   return (
  *     <NavigatorIOS
+ *       style={{flex: 1}}
  *       initialRoute={{
  *         component: MyView,
  *         title: 'My View Title',
@@ -125,6 +126,8 @@ type Event = Object;
  * `passProps`.
  *
  * See the initialRoute propType for a complete definition of a route.
+ * 
+ * > It may seem like your component isn't working if you don't have `flex: 1` on the NavigatorIOS
  *
  * #### Navigator
  *


### PR DESCRIPTION
Hello wonderful React Native people!

I am proposing this change because it took me a frustratingly long time to see why my `component` wasn't rendering any children.
I feel like something like this would have helped me.

However, I may be an edge case as my first attempt at any React Native was doing a Navigator...

Your call! This is my feedback!