### PR TITLE
Add subviewStyle prop to NavigationHeader

### DIFF
--- a/Libraries/CustomComponents/NavigationExperimental/NavigationHeader.js
+++ b/Libraries/CustomComponents/NavigationExperimental/NavigationHeader.js
@@ -65,6 +65,7 @@ type Props = NavigationSceneRendererProps & {
   renderRightComponent: NavigationSceneRenderer,
   renderTitleComponent: NavigationSceneRenderer,
   style?: any;
+  subviewStyle: any;
   viewProps?: any;
 };
 
@@ -100,6 +101,7 @@ class NavigationHeader extends React.Component<DefaultProps, Props, any> {
     renderRightComponent: PropTypes.func,
     renderTitleComponent: PropTypes.func,
     style: View.propTypes.style,
+    subviewStyle: View.propTypes.style,
     viewProps: PropTypes.shape(View.propTypes),
   };
 
@@ -186,6 +188,7 @@ class NavigationHeader extends React.Component<DefaultProps, Props, any> {
       return null;
     }
 
+    const {subviewStyle = {} } = this.props;
     const pointerEvents = offset !== 0 || isStale ? 'none' : 'box-none';
     return (
       <Animated.View
@@ -194,6 +197,7 @@ class NavigationHeader extends React.Component<DefaultProps, Props, any> {
         style={[
           styles[name],
           styleInterpolator(props),
+          subviewStyle[name],
         ]}>
         {subView}
       </Animated.View>


### PR DESCRIPTION
This implements properly #7204 this time.. (Sorry about that @ericvicenti )

#### Test Plan:

I have only introduced a single style prop that is used in a single place:
```
<Animated.View
        pointerEvents={pointerEvents}
        key={name + '_' + key}
        style={[
          styles[name],
          styleInterpolator(props),
          subviewStyle[name],
        ]}>
```
Given that it's expected that this prop will have some properties on its own which are directly lookup using the `[]` syntax, a default value of `{}` is assigned to it in its destructuring assignment:

```
const {subviewStyle = {} } = this.props;
```