### PR TITLE
StatusBar imperative API: honor animation defaults for optionals

### DIFF
--- a/Libraries/Components/StatusBar/StatusBar.js
+++ b/Libraries/Components/StatusBar/StatusBar.js
@@ -155,7 +155,7 @@ const StatusBar = React.createClass({
       }
       StatusBar._defaultProps.barStyle = style;
       if (animated === undefined) {
-        animated = mergePropsStack(StatusBar._propsStack, StatusBar._defaultProps).animated
+        animated = mergePropsStack(StatusBar._propsStack, StatusBar._defaultProps).animated;
       }
       StatusBarManager.setStyle(style, animated);
     },
@@ -176,7 +176,7 @@ const StatusBar = React.createClass({
       }
       StatusBar._defaultProps.backgroundColor = color;
       if (animated === undefined) {
-        animated = mergePropsStack(StatusBar._propsStack, StatusBar._defaultProps).animated
+        animated = mergePropsStack(StatusBar._propsStack, StatusBar._defaultProps).animated;
       }
       StatusBarManager.setColor(processColor(color), animated);
     },

--- a/Libraries/Components/StatusBar/StatusBar.js
+++ b/Libraries/Components/StatusBar/StatusBar.js
@@ -136,8 +136,11 @@ const StatusBar = React.createClass({
     // Provide an imperative API as static functions of the component.
     // See the corresponding prop for more detail.
     setHidden(hidden: boolean, animation?: StatusBarAnimation) {
-      animation = animation || 'none';
-      StatusBar._defaultProps.hidden.value = hidden;
+      StatusBar._defaultProps.hidden = hidden;
+      if (!animation) {
+        const mergedProps = mergePropsStack(StatusBar._propsStack, StatusBar._defaultProps);
+        animation = mergedProps.animated ? mergedProps.showHideTransition : 'none';
+      }
       if (Platform.OS === 'ios') {
         StatusBarManager.setHidden(hidden, animation);
       } else if (Platform.OS === 'android') {
@@ -150,8 +153,10 @@ const StatusBar = React.createClass({
         console.warn('`setBarStyle` is only available on iOS');
         return;
       }
-      animated = animated || false;
-      StatusBar._defaultProps.barStyle.value = style;
+      StatusBar._defaultProps.barStyle = style;
+      if (animated === undefined) {
+        animated = mergePropsStack(StatusBar._propsStack, StatusBar._defaultProps).animated
+      }
       StatusBarManager.setStyle(style, animated);
     },
 
@@ -169,8 +174,10 @@ const StatusBar = React.createClass({
         console.warn('`setBackgroundColor` is only available on Android');
         return;
       }
-      animated = animated || false;
-      StatusBar._defaultProps.backgroundColor.value = color;
+      StatusBar._defaultProps.backgroundColor = color;
+      if (animated === undefined) {
+        animated = mergePropsStack(StatusBar._propsStack, StatusBar._defaultProps).animated
+      }
       StatusBarManager.setColor(processColor(color), animated);
     },
 


### PR DESCRIPTION
StatusBar's imperative API contains optional animation inputs in the 
methods `setHidden`, `setBarStyle` and `setBackgroundColor`, but not 
passing values currently defaults to no animation, even when a 
StatusBar instance at the top of the app declares animation props. 

Since these animation inputs are declared as optional and no method 
for setting up global defaults is provided, from a developer 
perspective, it makes sense to honor the current props stack’s 
animation settings.

For example if this is included at the top of the app,

`<StatusBar animated={true} showHideTransition='slide' />`

it intuitively makes most sense that calling `StatusBar.setHidden(true)` 
would still show a slide animation, instead of needing to pass `'slide'`.

A slightly more architecture-correct way to fix this would be to add a 
`StatusBar.setDefaultProps(props:Object)` method, but that would 
require changing the API and docs. The current docs seem to hint that 
it is possible to set defaults on a top-level StatusBar instance, so it 
feels simplest to just honor those animation defaults when defined.
