### PR TITLE
Fix usage of react-native cli inside package.json scripts

### DIFF
--- a/local-cli/wrong-react-native.js
+++ b/local-cli/wrong-react-native.js
@@ -9,11 +9,17 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-console.error([
-  '\033[31mLooks like you installed react-native globally, maybe you meant react-native-cli?',
-  'To fix the issue, run:\033[0m',
-  'npm uninstall -g react-native',
-  'npm install -g react-native-cli'
-].join('\n'));
+var script = process.argv[1];
+var installedGlobally = script.indexOf('node_modules/.bin/react-native') === -1;
 
-process.exit(1);
+if (installedGlobally) {
+  console.error([
+    '\033[31mLooks like you installed react-native globally, maybe you meant react-native-cli?',
+    'To fix the issue, run:\033[0m',
+    'npm uninstall -g react-native',
+    'npm install -g react-native-cli'
+  ].join('\n'));
+  process.exit(1);
+} else {
+  require('./cli').run();
+}


### PR DESCRIPTION
IIRC we made `wrong-react-native` to warn people in case they installed `react-native` globally (instead of `react-native-cli` what the guide suggests). To do that we added `bin` entry to React Native's `package.json` that points to `local-cli/wrong-react-native.js`

However, this means that if we have a project that uses `react-native` package and has call to `react-native` CLI inside its package.json, npm will execute *local* override (which just prints a confusing in this context error message).

In fact, the template we generate with `react-native init` has `react-native start` as `start` script, which makes it useless. Let's fix it by making `wrong-react-native` script smarter – it can detect that it has been executed from local `node_modules` and run the actual CLI.

cc @vjeux @ide 