### PR TITLE
ActionSheetIOS - support share sheet on modals

### DIFF
--- a/Libraries/ActionSheetIOS/RCTActionSheetManager.m
+++ b/Libraries/ActionSheetIOS/RCTActionSheetManager.m
@@ -196,7 +196,10 @@ RCT_EXPORT_METHOD(showShareActionSheetWithOptions:(NSDictionary *)options
   }
 
   UIViewController *controller = RCTKeyWindow().rootViewController;
-
+  while (controller.presentedViewController) {
+    controller = controller.presentedViewController;
+  }
+  
 #if __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_8_0
 
   if (![UIActivityViewController instancesRespondToSelector:@selector(setCompletionWithItemsHandler:)]) {

--- a/Libraries/ActionSheetIOS/RCTActionSheetManager.m
+++ b/Libraries/ActionSheetIOS/RCTActionSheetManager.m
@@ -66,10 +66,7 @@ RCT_EXPORT_METHOD(showActionSheetWithOptions:(NSDictionary *)options
   NSInteger destructiveButtonIndex = options[@"destructiveButtonIndex"] ? [RCTConvert NSInteger:options[@"destructiveButtonIndex"]] : -1;
   NSInteger cancelButtonIndex = options[@"cancelButtonIndex"] ? [RCTConvert NSInteger:options[@"cancelButtonIndex"]] : -1;
 
-  UIViewController *controller = RCTKeyWindow().rootViewController;
-  while (controller.presentedViewController) {
-    controller = controller.presentedViewController;
-  }
+  UIViewController *controller = RCTPresentedViewController();
 
   if (controller == nil) {
     RCTLogError(@"Tried to display action sheet but there is no application window. options: %@", options);
@@ -195,11 +192,8 @@ RCT_EXPORT_METHOD(showShareActionSheetWithOptions:(NSDictionary *)options
     shareController.excludedActivityTypes = excludedActivityTypes;
   }
 
-  UIViewController *controller = RCTKeyWindow().rootViewController;
-  while (controller.presentedViewController) {
-    controller = controller.presentedViewController;
-  }
-  
+  UIViewController *controller = RCTPresentedViewController();
+
 #if __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_8_0
 
   if (![UIActivityViewController instancesRespondToSelector:@selector(setCompletionWithItemsHandler:)]) {

--- a/Libraries/CameraRoll/RCTImagePickerManager.m
+++ b/Libraries/CameraRoll/RCTImagePickerManager.m
@@ -143,7 +143,7 @@ didFinishPickingMediaWithInfo:(NSDictionary<NSString *, id> *)info
   [_pickerCallbacks addObject:callback];
   [_pickerCancelCallbacks addObject:cancelCallback];
 
-  UIViewController *rootViewController = RCTKeyWindow().rootViewController;
+  UIViewController *rootViewController = RCTPresentedViewController();
   [rootViewController presentViewController:imagePicker animated:YES completion:nil];
 }
 
@@ -157,7 +157,7 @@ didFinishPickingMediaWithInfo:(NSDictionary<NSString *, id> *)info
   [_pickerCallbacks removeObjectAtIndex:index];
   [_pickerCancelCallbacks removeObjectAtIndex:index];
 
-  UIViewController *rootViewController = RCTKeyWindow().rootViewController;
+  UIViewController *rootViewController = RCTPresentedViewController();
   [rootViewController dismissViewControllerAnimated:YES completion:nil];
 
   if (args) {

--- a/React/Base/RCTUtils.h
+++ b/React/Base/RCTUtils.h
@@ -75,8 +75,8 @@ RCT_EXTERN UIApplication *__nullable RCTSharedApplication(void);
 // or view controller
 RCT_EXTERN UIWindow *__nullable RCTKeyWindow(void);
 
-// Returns the presented view controller, useful if you need to present another view
-// controller over the top-most one.
+// Returns the presented view controller, useful if you need
+// e.g. to present a modal view controller or alert over it
 RCT_EXTERN UIViewController *__nullable RCTPresentedViewController(void);
 
 // Does this device support force touch (aka 3D Touch)?

--- a/React/Base/RCTUtils.h
+++ b/React/Base/RCTUtils.h
@@ -72,8 +72,12 @@ RCT_EXTERN BOOL RCTRunningInAppExtension(void);
 RCT_EXTERN UIApplication *__nullable RCTSharedApplication(void);
 
 // Returns the current main window, useful if you need to access the root view
-// or view controller, e.g. to present a modal view controller or alert.
+// or view controller
 RCT_EXTERN UIWindow *__nullable RCTKeyWindow(void);
+
+// Returns the presented view controller, useful if you need to present another view
+// controller over the top-most one.
+RCT_EXTERN UIViewController *__nullable RCTPresentedViewController(void);
 
 // Does this device support force touch (aka 3D Touch)?
 RCT_EXTERN BOOL RCTForceTouchAvailable(void);

--- a/React/Base/RCTUtils.m
+++ b/React/Base/RCTUtils.m
@@ -439,6 +439,21 @@ UIWindow *__nullable RCTKeyWindow(void)
   return RCTSharedApplication().keyWindow;
 }
 
+UIViewController *__nullable RCTPresentedViewController(void)
+{
+  if (RCTRunningInAppExtension()) {
+    return nil;
+  }
+
+  UIViewController *controller = RCTKeyWindow().rootViewController;
+
+  while (controller.presentedViewController) {
+    controller = controller.presentedViewController;
+  }
+
+  return controller;
+}
+
 BOOL RCTForceTouchAvailable(void)
 {
   static BOOL forceSupported;

--- a/React/Modules/RCTAlertManager.m
+++ b/React/Modules/RCTAlertManager.m
@@ -150,17 +150,10 @@ RCT_EXPORT_METHOD(alertWithArgs:(NSDictionary *)args
 #endif
 
   {
-    UIViewController *presentingController = RCTKeyWindow().rootViewController;
+    UIViewController *presentingController = RCTPresentedViewController();
     if (presentingController == nil) {
       RCTLogError(@"Tried to display alert view but there is no application window. args: %@", args);
       return;
-    }
-
-    // Walk the chain up to get the topmost modal view controller. If modals are
-    // presented the root view controller's view might not be in the window
-    // hierarchy, and presenting from it will fail.
-    while (presentingController.presentedViewController) {
-      presentingController = presentingController.presentedViewController;
     }
 
     UIAlertController *alertController =


### PR DESCRIPTION
Fixes #6913 - follow up to this commit https://github.com/facebook/react-native/commit/43dcdaffe2caa8a6a8a38932a3e97ccb172bbc13 to support this in the 2nd method as well.

Test plan:
Open share sheet from modal

CC: @christopherdro as originally involved in the issue