### PR TITLE
Fix WebSocket compatibility with event-target-shim ^1.0.5

### DIFF
--- a/Libraries/WebSocket/WebSocket.js
+++ b/Libraries/WebSocket/WebSocket.js
@@ -55,7 +55,7 @@ let nextWebSocketId = 0;
  * See https://developer.mozilla.org/en-US/docs/Web/API/WebSocket
  * See https://github.com/websockets/ws
  */
-class WebSocket extends EventTarget(WEBSOCKET_EVENTS) {
+class WebSocket extends EventTarget(...WEBSOCKET_EVENTS) {
   static CONNECTING = CONNECTING;
   static OPEN = OPEN;
   static CLOSING = CLOSING;

--- a/Libraries/WebSocket/__mocks__/event-target-shim.js
+++ b/Libraries/WebSocket/__mocks__/event-target-shim.js
@@ -8,9 +8,9 @@
 'use strict';
 
 function EventTarget() {
-  // Support both EventTarget and EventTarget([list, of, events])
+  // Support both EventTarget and EventTarget(...)
   // as a super class, just like the original module does.
-  if (arguments.length === 1 && Array.isArray(arguments[0])) {
+  if (arguments.length > 0) {
     return EventTarget;
   }
 }


### PR DESCRIPTION
event-target-shim versions before 1.1.0 do not support taking an array for `EventTarget`. react-native requires `^1.0.5`, so this fixes compatibility with those earlier versions.

**Test Plan:** ran WebSocket UIExplorer example with earlier version of event-target-shim.