### PR TITLE
Initial navigator.language support

### DIFF
--- a/Libraries/Intl/Intl.android.js
+++ b/Libraries/Intl/Intl.android.js
@@ -1,0 +1,5 @@
+// @todo remove this file when Android is implemented
+module.exports = {
+  language: '',
+  languages: [],
+};

--- a/Libraries/Intl/Intl.ios.js
+++ b/Libraries/Intl/Intl.ios.js
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule Intl
+ * @flow
+ */
+'use strict';
+
+const IntlManager = require('NativeModules').IntlManager;
+
+module.exports = IntlManager;

--- a/Libraries/JavaScriptAppEngine/Initialization/InitializeJavaScriptAppEngine.js
+++ b/Libraries/JavaScriptAppEngine/Initialization/InitializeJavaScriptAppEngine.js
@@ -147,13 +147,18 @@ function setUpXHR() {
   polyfillGlobal('Response', fetchPolyfill.Response);
 }
 
-function setUpGeolocation() {
+function setUpNavigator() {
   polyfillIfNeeded('navigator', {}, GLOBAL, {
     writable: true,
     enumerable: true,
     configurable: true,
   });
+
   polyfillGlobal('geolocation', require('Geolocation'), GLOBAL.navigator);
+
+  const Intl = require('Intl');
+  polyfillGlobal('language', Intl.language, GLOBAL.navigator);
+  polyfillGlobal('languages', Intl.languages, GLOBAL.navigator);
 }
 
 function setUpMapAndSet() {
@@ -207,7 +212,7 @@ setUpAlert();
 setUpPromise();
 setUpErrorHandler();
 setUpXHR();
-setUpGeolocation();
+setUpNavigator();
 setUpMapAndSet();
 setUpProduct();
 setUpWebSockets();

--- a/React/Modules/RCTIntlManager.h
+++ b/React/Modules/RCTIntlManager.h
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import "RCTBridgeModule.h"
+
+@interface RCTIntlManager : NSObject <RCTBridgeModule>
+
+@end

--- a/React/Modules/RCTIntlManager.m
+++ b/React/Modules/RCTIntlManager.m
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import "RCTIntlManager.h"
+
+@implementation RCTIntlManager
+
+RCT_EXPORT_MODULE(IntlManager)
+
+- (NSDictionary *)constantsToExport {
+  NSArray *languages = [NSLocale preferredLanguages];
+  return @{
+    @"language": [languages objectAtIndex:0],
+    @"languages": languages
+  };
+}
+
+@end

--- a/React/React.xcodeproj/project.pbxproj
+++ b/React/React.xcodeproj/project.pbxproj
@@ -92,6 +92,7 @@
 		83CBBA691A601EF300E9B192 /* RCTEventDispatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 83CBBA661A601EF300E9B192 /* RCTEventDispatcher.m */; };
 		83CBBA981A6020BB00E9B192 /* RCTTouchHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 83CBBA971A6020BB00E9B192 /* RCTTouchHandler.m */; };
 		83CBBACC1A6023D300E9B192 /* RCTConvert.m in Sources */ = {isa = PBXBuildFile; fileRef = 83CBBACB1A6023D300E9B192 /* RCTConvert.m */; };
+		AD8620EF1CCBF161006A3500 /* RCTIntlManager.m in Sources */ = {isa = PBXBuildFile; fileRef = AD8620ED1CCBF161006A3500 /* RCTIntlManager.m */; };
 		E9B20B7B1B500126007A2DA7 /* RCTAccessibilityManager.m in Sources */ = {isa = PBXBuildFile; fileRef = E9B20B7A1B500126007A2DA7 /* RCTAccessibilityManager.m */; };
 /* End PBXBuildFile section */
 
@@ -298,6 +299,8 @@
 		83CBBACB1A6023D300E9B192 /* RCTConvert.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTConvert.m; sourceTree = "<group>"; };
 		83F15A171B7CC46900F10295 /* UIView+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIView+Private.h"; sourceTree = "<group>"; };
 		ACDD3FDA1BC7430D00E7DE33 /* RCTBorderStyle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTBorderStyle.h; sourceTree = "<group>"; };
+		AD8620ED1CCBF161006A3500 /* RCTIntlManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTIntlManager.m; sourceTree = "<group>"; };
+		AD8620EE1CCBF161006A3500 /* RCTIntlManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTIntlManager.h; sourceTree = "<group>"; };
 		E3BBC8EB1ADE6F47001BBD81 /* RCTTextDecorationLineType.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RCTTextDecorationLineType.h; sourceTree = "<group>"; };
 		E9B20B791B500126007A2DA7 /* RCTAccessibilityManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTAccessibilityManager.h; sourceTree = "<group>"; };
 		E9B20B7A1B500126007A2DA7 /* RCTAccessibilityManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTAccessibilityManager.m; sourceTree = "<group>"; };
@@ -335,6 +338,8 @@
 		13B07FE01A69315300A75B9A /* Modules */ = {
 			isa = PBXGroup;
 			children = (
+				AD8620ED1CCBF161006A3500 /* RCTIntlManager.m */,
+				AD8620EE1CCBF161006A3500 /* RCTIntlManager.h */,
 				E9B20B791B500126007A2DA7 /* RCTAccessibilityManager.h */,
 				E9B20B7A1B500126007A2DA7 /* RCTAccessibilityManager.m */,
 				13B07FE71A69327A00A75B9A /* RCTAlertManager.h */,
@@ -726,6 +731,7 @@
 				13456E931ADAD2DE009F94A7 /* RCTConvert+CoreLocation.m in Sources */,
 				137327E91AA5CF210034F82E /* RCTTabBarItemManager.m in Sources */,
 				13A1F71E1A75392D00D3D453 /* RCTKeyCommands.m in Sources */,
+				AD8620EF1CCBF161006A3500 /* RCTIntlManager.m in Sources */,
 				83CBBA531A601E3B00E9B192 /* RCTUtils.m in Sources */,
 				14435CE61AAC4AE100FC20F4 /* RCTMapManager.m in Sources */,
 				191E3EC11C29DC3800C180A6 /* RCTRefreshControl.m in Sources */,


### PR DESCRIPTION
Adds `navigator.language` and `navigator.languages` as per HTML5 spec.

This is not meant to be merged just `yet` - needs rebasing & Android implementation (and making sure the languages are returned in the correct format) #2349

It does not use `[[NSBundle mainBundle] preferredLocalizations]` since we don't have any translations defined on the native side and the language logic (selecting the first matching based on an array of localisations) should be done by a library. 

However, on the other hand, w/o defining supported languages in the `Info.plist`, `CFBundleDevelopmentRegion` & `CFBundleLocalizations` it will not be displayed in the iTunes correctly if I am not wrong. Need to play around with that later as we roll out the app to see how that can be solved.

In the meantime - feedback and suggestions appreciated.