### PR TITLE
Add npm start to Getting Started

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -46,6 +46,7 @@ Create a React Native project:
 
 - `$ cd AwesomeProject`
 - `$ react-native run-ios` **OR** open `ios/AwesomeProject.xcodeproj` and hit "Run" button in Xcode
+- `$ npm start`
 - Open `index.ios.js` in your text editor of choice and edit some lines.
 - Hit ⌘-R in your iOS simulator to reload the app and see your change!
 


### PR DESCRIPTION
Not sure if this is supposed to be necessary but I never managed to get through Getting Started without an `npm start`. I always get this if I forget it:

<img width="487" alt="screen shot 2016-04-28 at 21 43 03" src="https://cloud.githubusercontent.com/assets/810438/14900798/37ef066c-0d8a-11e6-9aad-fd96c9271184.png">
