### PR TITLE
Update docs for creating an android native view

### DIFF
--- a/docs/NativeComponentsAndroid.md
+++ b/docs/NativeComponentsAndroid.md
@@ -106,7 +106,7 @@ The very final step is to create the JavaScript module that defines the interfac
 // ImageView.js
 
 import { PropTypes } from 'react';
-import { requireNativeComponent } from 'react-native';
+import { requireNativeComponent, View } from 'react-native';
 
 var iface = {
   name: 'ImageView',
@@ -114,6 +114,7 @@ var iface = {
     src: PropTypes.string,
     borderRadius: PropTypes.number,
     resizeMode: PropTypes.oneOf(['cover', 'contain', 'stretch']),
+    ...View.propTypes // include the default view properties
   },
 };
 


### PR DESCRIPTION
Doc changes only.  Updating example code to reflect the new requirements discussed in this [issue](https://github.com/facebook/react-native/issues/4605).

In short, in the JS code that registers your new native view, you need to explicitly include the `propTypes` that come default for views or else you get an error.