### PR TITLE
add reset-cache command to bundle

### DIFF
--- a/local-cli/bundle/buildBundle.js
+++ b/local-cli/bundle/buildBundle.js
@@ -34,6 +34,7 @@ function buildBundle(args, config, output = outputBundle, packagerInstance) {
       transformModulePath: args.transformer,
       extraNodeModules: config.extraNodeModules,
       nonPersistent: true,
+      resetCache: args['reset-cache'],
     };
 
     const requestOpts = {

--- a/local-cli/bundle/bundleCommandLineArgs.js
+++ b/local-cli/bundle/bundleCommandLineArgs.js
@@ -57,5 +57,9 @@ module.exports = [
     command: 'verbose',
     description: 'Enables logging',
     default: false,
+  }, {
+    command: 'reset-cache',
+    description: 'Removes cached files',
+    default: false
   }
 ];


### PR DESCRIPTION
Currently the `react-native bundle` has no option to reset the file cache. For example changing the .babelrc has no effect on the bundling process. `react-native start` has it already implemented, so this is just a small addition.

**Test plan (required)**

the issue:

- `react-native init` a new project
- run `react-native bundle` (should work as expected)
- create `.babelrc` with empty object ```{}```
- rerun `react-native bundle`
- should fail now with `Unexptected token` (no babel plugins configured)
 - if not failing, your cache already hit (clear $TMPDIR to get the error)
- delete .babelrc and rerun `bundle`
- still failing, but it should went back to normal
- delete your $TMPDIR contents
- works again

The option `--reset-cache` should fix that

