### PR TITLE
Indicate width and height params are being passed to onContentSizeChange.

### DIFF
--- a/Libraries/Components/ScrollView/ScrollView.js
+++ b/Libraries/Components/ScrollView/ScrollView.js
@@ -210,8 +210,11 @@ var ScrollView = React.createClass({
      */
     onScrollAnimationEnd: PropTypes.func,
     /**
-     * Called when scrollable content view of the ScrollView changes. It's
-     * implemented using onLayout handler attached to the content container
+     * Called when scrollable content view of the ScrollView changes. 
+     * 
+     * Handler function is passed the content width and content height as parameters: `(contentWidth, contentHeight)`
+     * 
+     * It's implemented using onLayout handler attached to the content container
      * which this ScrollView renders.
      */
     onContentSizeChange: PropTypes.func,

--- a/Libraries/Components/ScrollView/ScrollView.js
+++ b/Libraries/Components/ScrollView/ScrollView.js
@@ -210,10 +210,10 @@ var ScrollView = React.createClass({
      */
     onScrollAnimationEnd: PropTypes.func,
     /**
-     * Called when scrollable content view of the ScrollView changes. 
-     * 
+     * Called when scrollable content view of the ScrollView changes.
+     *
      * Handler function is passed the content width and content height as parameters: `(contentWidth, contentHeight)`
-     * 
+     *
      * It's implemented using onLayout handler attached to the content container
      * which this ScrollView renders.
      */


### PR DESCRIPTION
I had to do a little trial and error to find this out. Would be helpful to have it in the docs.

I'm not sure if there's a standard wording or format you prefer for indicating handler function params.