### PR TITLE
Updated a warning string in upgrade.js

### DIFF
--- a/local-cli/upgrade/upgrade.js
+++ b/local-cli/upgrade/upgrade.js
@@ -60,7 +60,7 @@ module.exports = function upgrade(args, config) {
         } else {
           console.log(
             chalk.yellow(
-              'A valid version number for \'react-native\' is not specified your \'package.json\' file.'
+              'A valid version number for \'react-native\' is not specified in your \'package.json\' file.'
             )
           );
         }


### PR DESCRIPTION
I inserted an 'in' in the warning message that is displayed when the user's package.json file doesn't have a valid version number for react native.

Test plan
---------------
-run upgrade.js on a project with an invalid version number.