### PR TITLE
Setting current working directory for dev server.

### DIFF
--- a/local-cli/runAndroid/runAndroid.js
+++ b/local-cli/runAndroid/runAndroid.js
@@ -168,32 +168,31 @@ function buildAndRun(args, reject) {
 }
 
 function startServerInNewWindow() {
-  var yargV = require('yargs').argv;
-
+  const yargV = require('yargs').argv;
   const scriptFile = /^win/.test(process.platform) ?
     'launchPackager.bat' :
     'launchPackager.command';
-
-  const launchPackagerScript = path.resolve(
-    __dirname, '..', '..', 'packager', scriptFile
-  );
+  const packagerDir = path.resolve(__dirname, '..', '..', 'packager');
+  const launchPackagerScript = path.resolve(packagerDir, scriptFile);
+  const procConfig = {cwd: packagerDir};
 
   if (process.platform === 'darwin') {
     if (yargV.open) {
-      return child_process.spawnSync('open', ['-a', yargV.open, launchPackagerScript]);
+      return child_process.spawnSync('open', ['-a', yargV.open, launchPackagerScript], procConfig);
     }
-    return child_process.spawnSync('open', [launchPackagerScript]);
+    return child_process.spawnSync('open', [launchPackagerScript], procConfig);
 
   } else if (process.platform === 'linux') {
+    procConfig.detached = true;
     if (yargV.open){
-      return child_process.spawn(yargV.open,['-e', 'sh', launchPackagerScript], {detached: true});
+      return child_process.spawn(yargV.open,['-e', 'sh', launchPackagerScript], procConfig);
     }
-    return child_process.spawn('sh', [launchPackagerScript],{detached: true});
+    return child_process.spawn('sh', [launchPackagerScript], procConfig);
 
   } else if (/^win/.test(process.platform)) {
-    return child_process.spawn(
-      'cmd.exe', ['/C', 'start', launchPackagerScript], {detached: true, stdio: 'ignore'}
-    );
+    procConfig.detached = true;
+    procConfig.stdio = 'ignore';
+    return child_process.spawn('cmd.exe', ['/C', 'start', launchPackagerScript], procConfig);
   } else {
     console.log(chalk.red(`Cannot start the packager. Unknown platform ${process.platform}`));
   }

--- a/packager/launchPackager.command
+++ b/packager/launchPackager.command
@@ -13,7 +13,7 @@ clear
 
 THIS_DIR=$(dirname "$0")
 pushd "$THIS_DIR"
-source packager.sh
+source ./packager.sh
 popd
 
 echo "Process terminated. Press <enter> to close the window"


### PR DESCRIPTION
* This allows `react-native` to work for users on fedora.
* `react-native run-android` was failing because the launch packager script was unable to find packager.sh (see `source` in `man bash`).
* This change sets cwd for the dev server when run with `run-android`.