### PR TITLE
Fix RefreshControl race condition

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/swiperefresh/ReactSwipeRefreshLayout.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/swiperefresh/ReactSwipeRefreshLayout.java
@@ -20,8 +20,25 @@ import com.facebook.react.uimanager.events.NativeGestureUtil;
  */
 public class ReactSwipeRefreshLayout extends SwipeRefreshLayout {
 
+  private boolean mRefreshing = false;
+
   public ReactSwipeRefreshLayout(ReactContext reactContext) {
     super(reactContext);
+  }
+
+  @Override
+  public void setRefreshing(boolean refreshing) {
+    if (mRefreshing != refreshing) {
+      mRefreshing = refreshing;
+      // Use `post` otherwise the control won't start refreshing if refreshing is true when
+      // the component gets mounted.
+      post(new Runnable() {
+        @Override
+        public void run() {
+          ReactSwipeRefreshLayout.super.setRefreshing(mRefreshing);
+        }
+      });
+    }
   }
 
   @Override

--- a/ReactAndroid/src/main/java/com/facebook/react/views/swiperefresh/ReactSwipeRefreshLayout.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/swiperefresh/ReactSwipeRefreshLayout.java
@@ -28,17 +28,15 @@ public class ReactSwipeRefreshLayout extends SwipeRefreshLayout {
 
   @Override
   public void setRefreshing(boolean refreshing) {
-    if (mRefreshing != refreshing) {
-      mRefreshing = refreshing;
-      // Use `post` otherwise the control won't start refreshing if refreshing is true when
-      // the component gets mounted.
-      post(new Runnable() {
-        @Override
-        public void run() {
-          ReactSwipeRefreshLayout.super.setRefreshing(mRefreshing);
-        }
-      });
-    }
+    mRefreshing = refreshing;
+    // Use `post` otherwise the control won't start refreshing if refreshing is true when
+    // the component gets mounted.
+    post(new Runnable() {
+      @Override
+      public void run() {
+        ReactSwipeRefreshLayout.super.setRefreshing(mRefreshing);
+      }
+    });
   }
 
   @Override

--- a/ReactAndroid/src/main/java/com/facebook/react/views/swiperefresh/SwipeRefreshLayoutManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/swiperefresh/SwipeRefreshLayoutManager.java
@@ -74,15 +74,8 @@ public class SwipeRefreshLayoutManager extends ViewGroupManager<ReactSwipeRefres
   }
 
   @ReactProp(name = "refreshing")
-  public void setRefreshing(final ReactSwipeRefreshLayout view, final boolean refreshing) {
-    // Use `post` otherwise the control won't start refreshing if refreshing is true when
-    // the component gets mounted.
-    view.post(new Runnable() {
-      @Override
-      public void run() {
-        view.setRefreshing(refreshing);
-      }
-    });
+  public void setRefreshing(ReactSwipeRefreshLayout view, boolean refreshing) {
+    view.setRefreshing(refreshing);
   }
 
   @ReactProp(name = "progressViewOffset", defaultFloat = 0)


### PR DESCRIPTION
There was a race condition with `SwipeRefreshLayout` that cause the `RefreshControl` to keep refreshing when it shouldn't.

It was caused because we have to use `post` to set the refreshing state otherwise it doesn't work when setting `refreshing=true` on initial mount. What happened is that `post` doesn't guarantee the order the runnables will be called so calling post with `refreshing=true` followed by `refreshing=false` caused the `resfreshing=false` runnable to be called before the `resfreshing=true` one. This made it stay in refreshing state when it should not.

```
D/test    ( 6171): setRefreshing true
W/ReactNativeJS( 6171): false
D/test    ( 6171): setRefreshing false
D/test    ( 6171): setRefreshing post false
D/test    ( 6171): setRefreshing post true
```

This change adds an instance variable and uses it in the `post` runnable to make sure the last set value is always used.

**Test plan (required)**
Tested that it fixed the issue in the [original issue app](https://github.com/digisquare/mobile) and did some additional tests in UIExplorer example to make sure everything still worked properly.

Fixes #7313