### PR TITLE
call bundle with reset-cache true as default from standard project

### DIFF
--- a/packager/react-native-xcode.sh
+++ b/packager/react-native-xcode.sh
@@ -72,5 +72,6 @@ $NODE_BINARY "$REACT_NATIVE_DIR/local-cli/cli.js" bundle \
   --entry-file index.ios.js \
   --platform ios \
   --dev $DEV \
+  --reset-cache true \
   --bundle-output "$DEST/main.jsbundle" \
   --assets-dest "$DEST"

--- a/react.gradle
+++ b/react.gradle
@@ -73,10 +73,10 @@ gradle.projectsEvaluated {
                 def devEnabled = !targetName.toLowerCase().contains("release")
                 if (Os.isFamily(Os.FAMILY_WINDOWS)) {
                     commandLine "cmd", "/c", "node", "node_modules/react-native/local-cli/cli.js", "bundle", "--platform", "android", "--dev", "${devEnabled}",
-                            "--entry-file", entryFile, "--bundle-output", jsBundleFile, "--assets-dest", resourcesDir
+                            "--reset-cache", "true", "--entry-file", entryFile, "--bundle-output", jsBundleFile, "--assets-dest", resourcesDir
                 } else {
                     commandLine "node", "node_modules/react-native/local-cli/cli.js", "bundle", "--platform", "android", "--dev", "${devEnabled}",
-                            "--entry-file", entryFile, "--bundle-output", jsBundleFile, "--assets-dest", resourcesDir
+                            "--reset-cache", "true", "--entry-file", entryFile, "--bundle-output", jsBundleFile, "--assets-dest", resourcesDir
                 }
 
                 enabled config."bundleIn${targetName}" ||


### PR DESCRIPTION
addition to #7297 

When called from an upstarting app, the bundling process should always be called with a cleared cache. That avoids possible problems with cached files.