### PR TITLE
Change the Debug Menu string from Debug/Stop JS Remotely to Debug/Stop Remote JS

### DIFF
--- a/React/Modules/RCTDevMenu.m
+++ b/React/Modules/RCTDevMenu.m
@@ -456,7 +456,8 @@ RCT_EXPORT_MODULE()
     }]];
   } else {
     BOOL isDebuggingJS = _executorClass && _executorClass == jsDebuggingExecutorClass;
-    NSString *debugTitleJS = isDebuggingJS ? [NSString stringWithFormat:@"Disable %@ Debugging", _webSocketExecutorName] : [NSString stringWithFormat:@"Debug %@", _webSocketExecutorName];
+    NSString *debuggingDescription = [_defaults objectForKey:@"websocket-executor-name"] ?: @"Remote JS";
+    NSString *debugTitleJS = isDebuggingJS ? [NSString stringWithFormat:@"Disable %@ Debugging", debuggingDescription] : [NSString stringWithFormat:@"Debug %@", _webSocketExecutorName];
     [items addObject:[RCTDevMenuItem buttonItemWithTitle:debugTitleJS handler:^{
       weakSelf.executorClass = isDebuggingJS ? Nil : jsDebuggingExecutorClass;
     }]];

--- a/ReactAndroid/src/main/res/devsupport/values/strings.xml
+++ b/ReactAndroid/src/main/res/devsupport/values/strings.xml
@@ -2,7 +2,7 @@
 <resources>
   <string name="catalyst_reloadjs" project="catalyst" translatable="false">Reload JS</string>
   <string name="catalyst_debugjs" project="catalyst" translatable="false">Debug JS Remotely</string>
-  <string name="catalyst_debugjs_off" project="catalyst" translatable="false">Stop JS Remotely Debugging</string>
+  <string name="catalyst_debugjs_off" project="catalyst" translatable="false">Stop Remote JS Debugging</string>
   <string name="catalyst_hot_module_replacement" project="catalyst" translatable="false">Enable Hot Reloading</string>
   <string name="catalyst_hot_module_replacement_off" project="catalyst" translatable="false">Disable Hot Reloading</string>
   <string name="catalyst_live_reload" project="catalyst" translatable="false">Enable Live Reload</string>


### PR DESCRIPTION
Changed debug menu string as requested in: https://github.com/facebook/react-native/pull/5683 by @ide and @matthewwithanm 

![image](https://cloud.githubusercontent.com/assets/14098140/14967128/ab9ca244-106a-11e6-9168-c8e36285dfb1.png)
