### PR TITLE
iOS: Support HTTP headers for source prop on <Image> components

### DIFF
--- a/Examples/UIExplorer/UIExplorerUnitTests/RCTImageLoaderTests.m
+++ b/Examples/UIExplorer/UIExplorerUnitTests/RCTImageLoaderTests.m
@@ -49,7 +49,8 @@ RCTDefineImageDecoder(RCTImageLoaderTestsDecoder2)
 
   NS_VALID_UNTIL_END_OF_SCOPE RCTBridge *bridge = [[RCTBridge alloc] initWithBundleURL:nil moduleProvider:^{ return @[loader]; } launchOptions:nil];
 
-  [bridge.imageLoader loadImageWithTag:@"http://facebook.github.io/react/img/logo_og.png" size:CGSizeMake(100, 100) scale:1.0 resizeMode:RCTResizeModeContain progressBlock:^(int64_t progress, int64_t total) {
+  NSURLRequest *urlRequest = [NSURLRequest requestWithURL:[NSURL URLWithString:@"http://facebook.github.io/react/img/logo_og.png"]];
+  [bridge.imageLoader loadImageWithURLRequest:urlRequest size:CGSizeMake(100, 100) scale:1.0 resizeMode:RCTResizeModeContain progressBlock:^(int64_t progress, int64_t total) {
     XCTAssertEqual(progress, 1);
     XCTAssertEqual(total, 1);
   } completionBlock:^(NSError *loadError, id loadedImage) {
@@ -78,8 +79,9 @@ RCTDefineImageDecoder(RCTImageLoaderTestsDecoder2)
   }];
 
   NS_VALID_UNTIL_END_OF_SCOPE RCTBridge *bridge = [[RCTBridge alloc] initWithBundleURL:nil moduleProvider:^{ return @[loader1, loader2]; } launchOptions:nil];
-
-  [bridge.imageLoader loadImageWithTag:@"http://facebook.github.io/react/img/logo_og.png" size:CGSizeMake(100, 100) scale:1.0 resizeMode:RCTResizeModeContain progressBlock:^(int64_t progress, int64_t total) {
+  
+  NSURLRequest *urlRequest = [NSURLRequest requestWithURL:[NSURL URLWithString:@"http://facebook.github.io/react/img/logo_og.png"]];
+  [bridge.imageLoader loadImageWithURLRequest:urlRequest size:CGSizeMake(100, 100) scale:1.0 resizeMode:RCTResizeModeContain progressBlock:^(int64_t progress, int64_t total) {
     XCTAssertEqual(progress, 1);
     XCTAssertEqual(total, 1);
   } completionBlock:^(NSError *loadError, id loadedImage) {

--- a/Libraries/CameraRoll/RCTCameraRollManager.m
+++ b/Libraries/CameraRoll/RCTCameraRollManager.m
@@ -86,7 +86,8 @@ RCT_EXPORT_METHOD(saveImageWithTag:(NSString *)imageTag
                   resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
 {
-  [_bridge.imageLoader loadImageWithTag:imageTag callback:^(NSError *loadError, UIImage *loadedImage) {
+  [_bridge.imageLoader loadImageWithURLRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:imageTag]]
+                                      callback:^(NSError *loadError, UIImage *loadedImage) {
     if (loadError) {
       reject(RCTErrorUnableToLoad, nil, loadError);
       return;

--- a/Libraries/Image/Image.ios.js
+++ b/Libraries/Image/Image.ios.js
@@ -63,10 +63,22 @@ var Image = React.createClass({
      * `uri` is a string representing the resource identifier for the image, which
      * could be an http address, a local file path, or the name of a static image
      * resource (which should be wrapped in the `require('./path/to/image.png')` function).
+     *
+     * `method` is the HTTP Method to use. Defaults to GET if not specified.
+     * 
+     * `headers` is an object representing the HTTP headers to send along with the request
+     * for a remote image.
+     * 
+     * `body` is the HTTP body to send with the request. This must be a valid
+     * UTF-8 string, and will be sent exactly as specified, with no
+     * additional encoding (e.g. URL-escaping or base64) applied.
      */
     source: PropTypes.oneOfType([
       PropTypes.shape({
         uri: PropTypes.string,
+        method: PropTypes.string,
+        headers: PropTypes.objectOf(PropTypes.string),
+        body: PropTypes.string,
       }),
       // Opaque type returned by require('./image.jpg')
       PropTypes.number,
@@ -216,7 +228,11 @@ var Image = React.createClass({
     if (isNetwork && (tintColor || this.props.blurRadius)) {
       RawImage = RCTImageView;
     }
-
+    
+    if (source && source.uri === '') {
+      console.warn('source.uri should not be an empty string');
+    }
+    
     if (this.props.src) {
       console.warn('The <Image> component requires a `source` property rather than `src`.');
     }

--- a/Libraries/Image/RCTImageEditingManager.m
+++ b/Libraries/Image/RCTImageEditingManager.m
@@ -45,7 +45,7 @@ RCT_EXPORT_METHOD(cropImage:(NSString *)imageTag
     [RCTConvert CGSize:cropData[@"size"]]
   };
 
-  [_bridge.imageLoader loadImageWithTag:imageTag callback:^(NSError *error, UIImage *image) {
+  [_bridge.imageLoader loadImageWithURLRequest:[RCTConvert NSURLRequest:imageTag] callback:^(NSError *error, UIImage *image) {
     if (error) {
       errorCallback(error);
       return;

--- a/Libraries/Image/RCTImageLoader.h
+++ b/Libraries/Image/RCTImageLoader.h
@@ -56,14 +56,14 @@ typedef void (^RCTImageLoaderCancellationBlock)(void);
  * Loads the specified image at the highest available resolution.
  * Can be called from any thread, will call back on an unspecified thread.
  */
-- (RCTImageLoaderCancellationBlock)loadImageWithTag:(NSString *)imageTag
+- (RCTImageLoaderCancellationBlock)loadImageWithURLRequest:(NSURLRequest *)imageURLRequest
                                            callback:(RCTImageLoaderCompletionBlock)callback;
 
 /**
  * As above, but includes target size, scale and resizeMode, which are used to
  * select the optimal dimensions for the loaded image.
  */
-- (RCTImageLoaderCancellationBlock)loadImageWithTag:(NSString *)imageTag
+- (RCTImageLoaderCancellationBlock)loadImageWithURLRequest:(NSURLRequest *)imageURLRequest
                                                size:(CGSize)size
                                               scale:(CGFloat)scale
                                          resizeMode:(RCTResizeMode)resizeMode
@@ -73,7 +73,7 @@ typedef void (^RCTImageLoaderCancellationBlock)(void);
 /**
  * Loads an image without clipping the result to fit - used by RCTImageView.
  */
-- (RCTImageLoaderCancellationBlock)loadImageWithoutClipping:(NSString *)imageTag
+- (RCTImageLoaderCancellationBlock)loadImageWithURLRequestWithoutClipping:(NSURLRequest *)imageURLRequest
                                                        size:(CGSize)size
                                                       scale:(CGFloat)scale
                                                  resizeMode:(RCTResizeMode)resizeMode
@@ -104,8 +104,32 @@ typedef void (^RCTImageLoaderCancellationBlock)(void);
  * Get image size, in pixels. This method will do the least work possible to get
  * the information, and won't decode the image if it doesn't have to.
  */
-- (RCTImageLoaderCancellationBlock)getImageSize:(NSString *)imageTag
+- (RCTImageLoaderCancellationBlock)getImageSizeForURLRequest:(NSURLRequest *)imageURLRequest
                                           block:(void(^)(NSError *error, CGSize size))completionBlock;
+
+@end
+
+@interface RCTImageLoader (Deprecated)
+
+- (RCTImageLoaderCancellationBlock)loadImageWithTag:(NSString *)imageTag
+                                           callback:(RCTImageLoaderCompletionBlock)callback __deprecated;
+
+- (RCTImageLoaderCancellationBlock)loadImageWithTag:(NSString *)imageTag
+                                               size:(CGSize)size
+                                              scale:(CGFloat)scale
+                                         resizeMode:(RCTResizeMode)resizeMode
+                                      progressBlock:(RCTImageLoaderProgressBlock)progressBlock
+                                    completionBlock:(RCTImageLoaderCompletionBlock)completionBlock __deprecated;
+
+- (RCTImageLoaderCancellationBlock)loadImageWithoutClipping:(NSString *)imageTag
+                                                       size:(CGSize)size
+                                                      scale:(CGFloat)scale
+                                                 resizeMode:(RCTResizeMode)resizeMode
+                                              progressBlock:(RCTImageLoaderProgressBlock)progressBlock
+                                            completionBlock:(RCTImageLoaderCompletionBlock)completionBlock __deprecated;
+
+- (RCTImageLoaderCancellationBlock)getImageSize:(NSString *)imageTag
+                                          block:(void(^)(NSError *error, CGSize size))completionBlock __deprecated;
 
 @end
 

--- a/Libraries/Image/RCTImageView.m
+++ b/Libraries/Image/RCTImageView.m
@@ -224,12 +224,12 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
     RCTImageSource *source = _source;
     CGFloat blurRadius = _blurRadius;
     __weak RCTImageView *weakSelf = self;
-    _reloadImageCancellationBlock = [_bridge.imageLoader loadImageWithoutClipping:_source.imageURL.absoluteString
-                                                                             size:imageSize
-                                                                            scale:imageScale
-                                                                       resizeMode:(RCTResizeMode)self.contentMode
-                                                                    progressBlock:progressHandler
-                                                                  completionBlock:^(NSError *error, UIImage *loadedImage) {
+    _reloadImageCancellationBlock = [_bridge.imageLoader loadImageWithURLRequestWithoutClipping:_source.imageURLRequest
+                                                                                           size:imageSize
+                                                                                          scale:imageScale
+                                                                                     resizeMode:(RCTResizeMode)self.contentMode
+                                                                                  progressBlock:progressHandler
+                                                                                completionBlock:^(NSError *error, UIImage *loadedImage) {
       RCTImageView *strongSelf = weakSelf;
       void (^setImageBlock)(UIImage *) = ^(UIImage *image) {
         if (![source isEqual:strongSelf.source]) {
@@ -297,7 +297,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
 
     if (RCTShouldReloadImageForSizeChange(imageSize, idealSize)) {
       if (RCTShouldReloadImageForSizeChange(_targetSize, idealSize)) {
-        RCTLogInfo(@"[PERF IMAGEVIEW] Reloading image %@ as size %@", _source.imageURL, NSStringFromCGSize(idealSize));
+        RCTLogInfo(@"[PERF IMAGEVIEW] Reloading image %@ as size %@", _source.imageURLRequest.URL.absoluteString, NSStringFromCGSize(idealSize));
 
         // If the existing image or an image being loaded are not the right
         // size, reload the asset in case there is a better size available.

--- a/Libraries/Image/RCTImageViewManager.m
+++ b/Libraries/Image/RCTImageViewManager.m
@@ -48,7 +48,7 @@ RCT_EXPORT_METHOD(getSize:(NSURL *)imageURL
                   successBlock:(RCTResponseSenderBlock)successBlock
                   errorBlock:(RCTResponseErrorBlock)errorBlock)
 {
-  [self.bridge.imageLoader getImageSize:imageURL.absoluteString
+  [self.bridge.imageLoader getImageSizeForURLRequest:[NSURLRequest requestWithURL:imageURL]
                                   block:^(NSError *error, CGSize size) {
                                     if (error) {
                                       errorBlock(error);

--- a/React/Base/RCTConvert.m
+++ b/React/Base/RCTConvert.m
@@ -133,6 +133,22 @@ RCT_CUSTOM_CONVERTER(NSData *, NSData, [json dataUsingEncoding:NSUTF8StringEncod
     if ([method isEqualToString:@"GET"] && headers == nil && body == nil) {
       return [NSURLRequest requestWithURL:URL];
     }
+    
+    if (headers) {
+      BOOL allHeadersAreStrings = YES;
+      for (NSString *key in headers) {
+        if (![[headers objectForKey:key] isKindOfClass:[NSString class]]) {
+          RCTLogError(@"Values of HTTP headers passed must be"
+                      " of type string. Value of header '%@' is not a string.", key);
+          allHeadersAreStrings = NO;
+        }
+      }
+      if (!allHeadersAreStrings) {
+        // Set headers to nil here to avoid crashing later.
+        headers = nil;
+      }
+    }
+    
     NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:URL];
     request.HTTPBody = body;
     request.HTTPMethod = method;
@@ -878,7 +894,7 @@ RCT_ENUM_CONVERTER(RCTAnimationType, (@{
     return image;
   }
 
-  NSURL *URL = imageSource.imageURL;
+  NSURL *URL = imageSource.imageURLRequest.URL;
   NSString *scheme = URL.scheme.lowercaseString;
   if ([scheme isEqualToString:@"file"]) {
     NSString *assetName = RCTBundlePathForURL(URL);

--- a/React/Base/RCTImageSource.h
+++ b/React/Base/RCTImageSource.h
@@ -16,7 +16,7 @@
  */
 @interface RCTImageSource : NSObject
 
-@property (nonatomic, strong, readonly) NSURL *imageURL;
+@property (nonatomic, strong, readonly) NSURLRequest *imageURLRequest;
 @property (nonatomic, assign, readonly) CGSize size;
 @property (nonatomic, assign, readonly) CGFloat scale;
 
@@ -25,9 +25,9 @@
  * Pass a size of CGSizeZero if you do not know or wish to specify the image
  * size. Pass a scale of zero if you do not know or wish to specify the scale.
  */
-- (instancetype)initWithURL:(NSURL *)url
-                       size:(CGSize)size
-                      scale:(CGFloat)scale;
+- (instancetype)initWithURLRequest:(NSURLRequest *)urlRequest
+                              size:(CGSize)size
+                             scale:(CGFloat)scale;
 
 /**
  * Create a copy of the image source with the specified size and scale.

--- a/React/Base/RCTImageSource.m
+++ b/React/Base/RCTImageSource.m
@@ -18,10 +18,10 @@
 
 @implementation RCTImageSource
 
-- (instancetype)initWithURL:(NSURL *)url size:(CGSize)size scale:(CGFloat)scale
+- (instancetype)initWithURLRequest:(NSURLRequest *)imageURLRequest size:(CGSize)size scale:(CGFloat)scale
 {
   if ((self = [super init])) {
-    _imageURL  = url;
+    _imageURLRequest = imageURLRequest;
     _size = size;
     _scale = scale;
   }
@@ -30,9 +30,9 @@
 
 - (instancetype)imageSourceWithSize:(CGSize)size scale:(CGFloat)scale
 {
-  RCTImageSource *imageSource = [[RCTImageSource alloc] initWithURL:_imageURL
-                                                               size:size
-                                                              scale:scale];
+  RCTImageSource *imageSource = [[RCTImageSource alloc] initWithURLRequest:_imageURLRequest
+                                                                      size:size
+                                                                     scale:scale];
   imageSource.packagerAsset = _packagerAsset;
   return imageSource;
 }
@@ -42,7 +42,7 @@
   if (![object isKindOfClass:[RCTImageSource class]]) {
     return NO;
   }
-  return [_imageURL isEqual:object.imageURL] && _scale == object.scale &&
+  return [_imageURLRequest isEqual:object.imageURLRequest] && _scale == object.scale &&
   (CGSizeEqualToSize(_size, object.size) || CGSizeEqualToSize(object.size, CGSizeZero));
 }
 
@@ -56,25 +56,25 @@
     return nil;
   }
 
-  NSURL *imageURL;
+  NSURLRequest *imageURLRequest;
   CGSize size = CGSizeZero;
   CGFloat scale = 1.0;
   BOOL packagerAsset = NO;
   if ([json isKindOfClass:[NSDictionary class]]) {
-    if (!(imageURL = [self NSURL:RCTNilIfNull(json[@"uri"])])) {
+    if (!(imageURLRequest = [self NSURLRequest:json])) {
       return nil;
     }
     size = [self CGSize:json];
     scale = [self CGFloat:json[@"scale"]] ?: [self BOOL:json[@"deprecated"]] ? 0.0 : 1.0;
     packagerAsset = [self BOOL:json[@"__packager_asset"]];
   } else if ([json isKindOfClass:[NSString class]]) {
-    imageURL = [self NSURL:json];
+    imageURLRequest = [self NSURLRequest:json];
   } else {
     RCTLogConvertError(json, @"an image. Did you forget to call resolveAssetSource() on the JS side?");
     return nil;
   }
 
-  RCTImageSource *imageSource = [[RCTImageSource alloc] initWithURL:imageURL
+  RCTImageSource *imageSource = [[RCTImageSource alloc] initWithURLRequest:imageURLRequest
                                                                size:size
                                                               scale:scale];
   imageSource.packagerAsset = packagerAsset;


### PR DESCRIPTION
Allows developers to specify headers to include in the HTTP request
when fetching a remote image. For example, one might leverage this
when fetching an image from an endpoint that requires authentication:

```
<Image
  style={styles.logo}
  source={{
    uri: 'http://facebook.github.io/react/img/logo_og.png',
    headers: {
      Authorization: 'someAuthToken'
    }
  }}
/>
```

Note that the header values must be strings.

Works on iOS and Android.

**Test plan (required)**

- Ran a small example like the one above on iOS and Android and ensured the headers were sent to the server.
- Ran a small example to ensure that \<Image\> components without headers still work.
- Currently using this code in our app.

Adam Comella
Microsoft Corp.