### PR TITLE
Corrected bug that put the UTI instead of mimeType in retrieved assets

### DIFF
--- a/Libraries/CameraRoll/RCTAssetsLibraryRequestHandler.m
+++ b/Libraries/CameraRoll/RCTAssetsLibraryRequestHandler.m
@@ -11,6 +11,7 @@
 
 #import <AssetsLibrary/AssetsLibrary.h>
 #import <libkern/OSAtomic.h>
+#import <MobileCoreServices/MobileCoreServices.h>
 
 #import "RCTBridge.h"
 #import "RCTUtils.h"
@@ -54,19 +55,12 @@ RCT_EXPORT_MODULE()
       ALAssetRepresentation *representation = [asset defaultRepresentation];
       NSInteger length = (NSInteger)representation.size;
       
-      NSString *mimeType = nil;
-      switch (CGImageGetAlphaInfo([representation CGImageWithOptions:nil])) {
-        case kCGImageAlphaNone:
-        case kCGImageAlphaNoneSkipLast:
-        case kCGImageAlphaNoneSkipFirst:
-          mimeType = @"image/jpeg";
-        default:
-          mimeType = @"image/png";
-      }
+        
+      CFStringRef MIMEType = UTTypeCopyPreferredTagWithClass((__bridge CFStringRef _Nonnull)(representation.UTI), kUTTagClassMIMEType);
 
       NSURLResponse *response =
       [[NSURLResponse alloc] initWithURL:request.URL
-                                MIMEType:mimeType
+                                MIMEType:(__bridge NSString *)(MIMEType)
                    expectedContentLength:length
                         textEncodingName:nil];
 

--- a/Libraries/CameraRoll/RCTAssetsLibraryRequestHandler.m
+++ b/Libraries/CameraRoll/RCTAssetsLibraryRequestHandler.m
@@ -53,10 +53,20 @@ RCT_EXPORT_MODULE()
 
       ALAssetRepresentation *representation = [asset defaultRepresentation];
       NSInteger length = (NSInteger)representation.size;
+      
+      NSString *mimeType = nil;
+      switch (CGImageGetAlphaInfo([representation CGImageWithOptions:nil])) {
+        case kCGImageAlphaNone:
+        case kCGImageAlphaNoneSkipLast:
+        case kCGImageAlphaNoneSkipFirst:
+          mimeType = @"image/jpeg";
+        default:
+          mimeType = @"image/png";
+      }
 
       NSURLResponse *response =
       [[NSURLResponse alloc] initWithURL:request.URL
-                                MIMEType:representation.UTI
+                                MIMEType:mimeType
                    expectedContentLength:length
                         textEncodingName:nil];
 


### PR DESCRIPTION
This pull request corrects a bug  found in `RCTAssetsLibraryRequestHandler` which used the asset UTI as the mimeType.

The code for finding the mimeType is based on the implementation used in `RCTImageLoader` and `RCTImageUtils`.