### PR TITLE
Fixed path to regenerator-runtime

### DIFF
--- a/IntegrationTests/RCTRootViewIntegrationTestApp.js
+++ b/IntegrationTests/RCTRootViewIntegrationTestApp.js
@@ -10,7 +10,7 @@
  */
 'use strict';
 
-require('regenerator/node_modules/regenerator-runtime/runtime');
+require('regenerator-runtime/runtime');
 
 var React = require('react');
 var ReactNative = require('react-native');

--- a/IntegrationTests/RCTRootViewIntegrationTestApp.js
+++ b/IntegrationTests/RCTRootViewIntegrationTestApp.js
@@ -10,7 +10,7 @@
  */
 'use strict';
 
-require('regenerator/runtime');
+require('regenerator/node_modules/regenerator-runtime/runtime');
 
 var React = require('react');
 var ReactNative = require('react-native');

--- a/Libraries/JavaScriptAppEngine/Initialization/InitializeJavaScriptAppEngine.js
+++ b/Libraries/JavaScriptAppEngine/Initialization/InitializeJavaScriptAppEngine.js
@@ -22,7 +22,7 @@
 /* eslint strict: 0 */
 /* globals GLOBAL: true, window: true */
 
-require('regenerator/runtime');
+require('regenerator/node_modules/regenerator-runtime/runtime');
 
 if (typeof GLOBAL === 'undefined') {
   global.GLOBAL = global;

--- a/Libraries/JavaScriptAppEngine/Initialization/InitializeJavaScriptAppEngine.js
+++ b/Libraries/JavaScriptAppEngine/Initialization/InitializeJavaScriptAppEngine.js
@@ -22,7 +22,7 @@
 /* eslint strict: 0 */
 /* globals GLOBAL: true, window: true */
 
-require('regenerator/node_modules/regenerator-runtime/runtime');
+require('regenerator-runtime/runtime');
 
 if (typeof GLOBAL === 'undefined') {
   global.GLOBAL = global;

--- a/jestSupport/env.js
+++ b/jestSupport/env.js
@@ -17,6 +17,6 @@ global.__fbBatchedBridgeConfig = {
 };
 
 global.Promise = require('promise');
-global.regeneratorRuntime = require.requireActual('regenerator/node_modules/regenerator-runtime/runtime');
+global.regeneratorRuntime = require.requireActual('regenerator-runtime/runtime');
 
 jest.setMock('ErrorUtils', require('ErrorUtils'));

--- a/jestSupport/env.js
+++ b/jestSupport/env.js
@@ -17,6 +17,6 @@ global.__fbBatchedBridgeConfig = {
 };
 
 global.Promise = require('promise');
-global.regeneratorRuntime = require.requireActual('regenerator/runtime');
+global.regeneratorRuntime = require.requireActual('regenerator/node_modules/regenerator-runtime/runtime');
 
 jest.setMock('ErrorUtils', require('ErrorUtils'));

--- a/package.json
+++ b/package.json
@@ -165,7 +165,7 @@
     "react-timer-mixin": "^0.13.2",
     "react-transform-hmr": "^1.0.4",
     "rebound": "^0.0.13",
-    "regenerator": "^0.8.36",
+    "regenerator": "^0.8.43",
     "sane": "^1.2.0",
     "semver": "^5.0.3",
     "source-map": "^0.4.4",

--- a/package.json
+++ b/package.json
@@ -166,6 +166,7 @@
     "react-transform-hmr": "^1.0.4",
     "rebound": "^0.0.13",
     "regenerator": "^0.8.43",
+    "regenerator-runtime": "^0.9.5",
     "sane": "^1.2.0",
     "semver": "^5.0.3",
     "source-map": "^0.4.4",

--- a/package.json
+++ b/package.json
@@ -165,7 +165,6 @@
     "react-timer-mixin": "^0.13.2",
     "react-transform-hmr": "^1.0.4",
     "rebound": "^0.0.13",
-    "regenerator": "^0.8.43",
     "regenerator-runtime": "^0.9.5",
     "sane": "^1.2.0",
     "semver": "^5.0.3",


### PR DESCRIPTION
Since 0.8.43 regenerator has regenerator-runtime dependency.
Fixes one js test in trunk

Test Plan:
See CI/Travis results