### PR TITLE
Note that MapView is not yet available on Android

### DIFF
--- a/Libraries/Components/MapView/MapView.js
+++ b/Libraries/Components/MapView/MapView.js
@@ -38,7 +38,10 @@ export type AnnotationDragState = $Enum<{
 /**
  * A component for displaying embeddable maps and annotations using the native
  * iOS MKMapView class. The Android version is not currently available in the
- * open source React Native project.
+ * open source React Native project, but you can use Leland Richardson's 
+ * cross-platform and more feature-complete
+ * [react-native-maps](https://github.com/lelandrichardson/react-native-maps)
+ * instead.
  */
 
 const MapView = React.createClass({

--- a/Libraries/Components/MapView/MapView.js
+++ b/Libraries/Components/MapView/MapView.js
@@ -38,7 +38,7 @@ export type AnnotationDragState = $Enum<{
 /**
  * A component for displaying embeddable maps and annotations using the native
  * iOS MKMapView class. The Android version is not currently available in the
- * open source React Native project, but you can use Leland Richardson's 
+ * open source React Native project, but you can use Leland Richardson's
  * cross-platform and more feature-complete
  * [react-native-maps](https://github.com/lelandrichardson/react-native-maps)
  * instead.

--- a/Libraries/Components/MapView/MapView.js
+++ b/Libraries/Components/MapView/MapView.js
@@ -35,6 +35,12 @@ export type AnnotationDragState = $Enum<{
   ending: string;
 }>;
 
+/**
+ * A component for displaying embeddable maps and annotations using the native
+ * iOS MKMapView class. The Android version is not currently available in the
+ * open source React Native project.
+ */
+
 const MapView = React.createClass({
 
   mixins: [NativeMethodsMixin],
@@ -303,6 +309,7 @@ const MapView = React.createClass({
     onAnnotationPress: React.PropTypes.func,
 
     /**
+     * Unused - Android version of MapView not currently available.
      * @platform android
      */
     active: React.PropTypes.bool,

--- a/Libraries/Components/MapView/MapView.js
+++ b/Libraries/Components/MapView/MapView.js
@@ -309,7 +309,6 @@ const MapView = React.createClass({
     onAnnotationPress: React.PropTypes.func,
 
     /**
-     * Unused - Android version of MapView not currently available.
      * @platform android
      */
     active: React.PropTypes.bool,


### PR DESCRIPTION
The MapView component is not labelled as iOS-only, but it is. It took me a bit of digging to figure out that the Android source code hasn't been released. Found it in this [SO answer](http://stackoverflow.com/questions/32625259/no-view-manager-defined-for-class-rctmap) in the end, and it is documented [here](http://facebook.github.io/react-native/docs/known-issues.html#views), but it'd be nice if it said that directly in the MapView docs. (The mention of the Android-specific prop `active` put me off the trail for a bit.)