### PR TITLE
Fix adb being required in path

### DIFF
--- a/local-cli/runAndroid/adb.js
+++ b/local-cli/runAndroid/adb.js
@@ -9,7 +9,12 @@
  * @flow
  */
 
+var path = require('path');
 const child_process = require('child_process');
+
+const adbPath = process.env.ANDROID_HOME
+  ? path.join(process.env.ANDROID_HOME, '/platform-tools/adb')
+    : 'adb';
 
 /**
  * Parses the output of the 'adb devices' command
@@ -37,13 +42,11 @@ function parseDevicesResult(result: string): Array<string> {
  */
 function getDevices(): Array<string> {
   try {
-    const devicesResult = child_process.execSync('adb devices');
-    return parseDevicesResult(devicesResult.toString());
+    const devicesResult = child_process.spawnSync(adbPath, ['devices']);
+    return parseDevicesResult(devicesResult.stdout.toString());
   } catch (e) {
     return [];
   }
-
-
 }
 
 module.exports = {


### PR DESCRIPTION
Currently device detection is assuming `adb` to be located within $PATH (whereas the real run routine implements it properly via ANDROID_HOME). I also replaced execSync with spawnSync as that will properly work with adb pathes containing spaces (I am on windows and my path is `D:\Program Files (x86)\Android\android-sdk/platform-tools/adb`).