### PR TITLE
NavigatorIOS: Expose interactivePopGestureEnabled property

### DIFF
--- a/Libraries/Components/Navigation/NavigatorIOS.ios.js
+++ b/Libraries/Components/Navigation/NavigatorIOS.ios.js
@@ -308,6 +308,15 @@ var NavigatorIOS = React.createClass({
      */
     translucent: PropTypes.bool,
 
+    /**
+     * A Boolean value that indicates whether the interactive pop gesture is enabled. Useful
+     * for enabling/disabling the back swipe navigation gesture. If this prop is not provided,
+     * the default behavior is for the back swipe gesture to be enabled when the navigation bar
+     * is shown and disabled when the navigation bar is hidden. Once you've provided
+     * the interactivePopGestureEnabled prop, you can never restore the default behavior.
+     */
+    interactivePopGestureEnabled: PropTypes.bool,
+
   },
 
   navigator: (undefined: ?Object),
@@ -686,7 +695,8 @@ var NavigatorIOS = React.createClass({
           style={styles.transitioner}
           vertical={this.props.vertical}
           requestedTopOfStack={this.state.requestedTopOfStack}
-          onNavigationComplete={this._handleNavigationComplete}>
+          onNavigationComplete={this._handleNavigationComplete}
+          interactivePopGestureEnabled={this.props.interactivePopGestureEnabled}>
           {items}
         </NavigatorTransitionerIOS>
       </StaticContainer>

--- a/React/Views/RCTNavigator.h
+++ b/React/Views/RCTNavigator.h
@@ -17,6 +17,7 @@
 
 @property (nonatomic, strong) UIView *reactNavSuperviewLink;
 @property (nonatomic, assign) NSInteger requestedTopOfStack;
+@property (nonatomic, assign) BOOL interactivePopGestureEnabled;
 
 - (instancetype)initWithBridge:(RCTBridge *)bridge NS_DESIGNATED_INITIALIZER;
 

--- a/React/Views/RCTNavigatorManager.m
+++ b/React/Views/RCTNavigatorManager.m
@@ -27,6 +27,7 @@ RCT_EXPORT_MODULE()
 RCT_EXPORT_VIEW_PROPERTY(requestedTopOfStack, NSInteger)
 RCT_EXPORT_VIEW_PROPERTY(onNavigationProgress, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onNavigationComplete, RCTBubblingEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(interactivePopGestureEnabled, BOOL)
 
 // TODO: remove error callbacks
 RCT_EXPORT_METHOD(requestSchedulingJavaScriptNavigation:(nonnull NSNumber *)reactTag


### PR DESCRIPTION
Previously, the back swipe navigation gesture would be enabled when the navigation bar is shown and disabled when the navigation bar is hidden.

This change enables developers to control the back swipe gesture independently of the visibility of the navigation bar. An example use case would be that an app wants to render a custom navigation bar so it sets `navigationBarHidden` to true and it wants to enable the back swipe gesture so it sets `interactivePopGestureEnabled` to true.

**Test plan (required)**

- Created a test app to verify setting `interactivePopGestureEnabled` to `true` and `false` with the navigation bar both hidden and shown.
- Verified prop works in a larger app.

Adam Comella
Microsoft Corp.