### PR TITLE
Fixed an issue where the modal would reappear immediately after disapearing

### DIFF
--- a/React/Views/RCTModalHostView.m
+++ b/React/Views/RCTModalHostView.m
@@ -82,8 +82,9 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:coder)
 - (void)dismissModalViewController
 {
   if (_isPresented) {
-    [_modalViewController dismissViewControllerAnimated:[self hasAnimationType] completion:nil];
-    _isPresented = NO;
+    [_modalViewController dismissViewControllerAnimated:[self hasAnimationType] completion:^{
+        _isPresented = NO;
+    }];
   }
 }
 


### PR DESCRIPTION
After dismissing the modal 'didMoveToWindow' was getting called but the dismiss animation hadn't completed so _isPresented would be false and self.window wouldn't be nil. This would mean that it calls presentViewController, which throws a warning then re-presents the dismissed modal.