### PR TITLE
don't render stale scenes that have the same index than current navigationState

### DIFF
--- a/Libraries/CustomComponents/NavigationExperimental/NavigationCardStack.js
+++ b/Libraries/CustomComponents/NavigationExperimental/NavigationCardStack.js
@@ -128,6 +128,15 @@ class NavigationCardStack extends React.Component<DefaultProps, Props, void> {
 
   _renderScene(props: NavigationSceneRendererProps): ReactElement {
     const isVertical = this.props.direction === 'vertical';
+    const { navigationState } = this.props;
+
+    // if the scene is stale and has the same index than
+    // current navigation state index, the navigation card
+    // shouldn't be rendered
+    if(props.scene.isStale && props.scene.index === navigationState.index)
+    {
+      return null;
+    }
 
     const style = isVertical ?
       NavigationCardStackStyleInterpolator.forVertical(props) :

--- a/Libraries/CustomComponents/NavigationExperimental/NavigationCardStack.js
+++ b/Libraries/CustomComponents/NavigationExperimental/NavigationCardStack.js
@@ -133,9 +133,9 @@ class NavigationCardStack extends React.Component<DefaultProps, Props, void> {
     // if the scene is stale and has the same index than
     // current navigation state index, the navigation card
     // shouldn't be rendered
-    if(props.scene.isStale && props.scene.index === navigationState.index)
+    if (props.scene.isStale && props.scene.index === navigationState.index)
     {
-      return null;
+      return;
     }
 
     const style = isVertical ?


### PR DESCRIPTION
NavigationCardStack renders the NavigationCard for the current scene even if the scene is stale and has the same index than current navigationState. 

In practice that means that when resetting the navigationState to a previous state, it renders the stale NavigationCard above the actual NavigationCard. 

Example: 

```javascript
// initial navigationState
navState = {
	index: 0,
	children: [
		{ key: 'First'}
	]
}

// reset
navState = {
	index: 0,
	children: [
		{ key: 'Second' }
	]
}

// reset

navState = {
	index: 0,
	children: [
		{ key: 'First'}
	]
}

```