### PR TITLE
[tests] Add scripts for running tests locally

### DIFF
--- a/ReactAndroid/README.md
+++ b/ReactAndroid/README.md
@@ -1,3 +1,7 @@
 # Building React Native for Android
 
-See [docs on the website](https://facebook.github.io/react-native/docs/android-building-from-source.html).
+See the [docs on the website](https://facebook.github.io/react-native/docs/android-building-from-source.html).
+
+# Running tests
+
+When you submit a pull request CircleCI will automatically run all tests. To run tests locally, see [Testing](https://facebook.github.io/react-native/docs/testing.html).

--- a/docs/AndroidBuildingFromSource.md
+++ b/docs/AndroidBuildingFromSource.md
@@ -129,6 +129,10 @@ gradle.projectsLoaded {
 }
 ```
 
+## Testing
+
+If you made changes to React Native and submit a pull request, all tests will run on your pull request automatically. To run the tests locally, see [Testing](/react-native/docs/testing.html).
+
 ## Troubleshooting
 
 Gradle build fails in `ndk-build`. See the section about `local.properties` file above.

--- a/docs/Testing.md
+++ b/docs/Testing.md
@@ -9,9 +9,7 @@ next: javascript-environment
 
 ## Running Tests and Contributing
 
-The React Native repo has several tests you can run to verify you haven't caused a regression with your PR.  These tests are run with the [Travis](http://docs.travis-ci.com/) continuous integration system, and will automatically post the results to your PR.
-
-
+The React Native repo has several tests you can run to verify you haven't caused a regression with your PR.  These tests are run with the [Travis](http://docs.travis-ci.com/) and [CircleCI](https://circleci.com/) continuous integration systems, and will automatically post the results to your PR.
 
 We don't have perfect test coverage of course, especially for complex end-to-end interactions with the user, so many changes will still require significant manual verification, but we would love it if you want to help us increase our test coverage and add more tests and test cases!
 
@@ -54,13 +52,32 @@ Note: In order to run your own tests, you will have to first follow the Getting 
 
 Note: you may have to install/upgrade/link Node.js and other parts of your environment in order for the tests to run correctly.  Check out the latest setup in [.travis.yml](https://github.com/facebook/react-native/blob/master/.travis.yml#L11-24)
 
-## Integration Tests (iOS only)
+## Unit tests (Android)
+
+React Native uses the [Buck build tool](https://buckbuild.com/setup/install.html) to run tests. Unit tests run locally on your machine, no emulator is needed. To run the tests:
+
+    $ cd react-native
+    $ ./scripts/run-android-local-unit-tests.sh
+
+## Integration tests (Android)
+
+React Native uses the [Buck build tool](https://buckbuild.com/setup/install.html) to run tests. Integration tests run on an emulator / device and verify that modules and components, as well as the core parts of React Native (such as the bridge) work well end-to-end.
+
+Make sure you have the path to the Android NDK set up, see [Prerequisites](/react-native/docs/android-building-from-source.html#prerequisites).
+
+To run the tests:
+
+    $ cd react-native
+    $ npm install
+    $ ./scripts/run-android-local-integration-tests.sh
+
+## Integration Tests (iOS)
 
 React Native provides facilities to make it easier to test integrated components that require both native and JS components to communicate across the bridge.  The two main components are `RCTTestRunner` and `RCTTestModule`.  `RCTTestRunner` sets up the ReactNative environment and provides facilities to run the tests as `XCTestCase`s in Xcode (`runTest:module` is the simplest method).  `RCTTestModule` is exported to JS as `NativeModules.TestModule`.  The tests themselves are written in JS, and must call `TestModule.markTestCompleted()` when they are done, otherwise the test will timeout and fail.  Test failures are primarily indicated by throwing a JS exception.  It is also possible to test error conditions with `runTest:module:initialProps:expectErrorRegex:` or `runTest:module:initialProps:expectErrorBlock:` which will expect an error to be thrown and verify the error matches the provided criteria.  See [`IntegrationTestHarnessTest.js`](https://github.com/facebook/react-native/blob/master/IntegrationTests/IntegrationTestHarnessTest.js), [`UIExplorerIntegrationTests.m`](https://github.com/facebook/react-native/blob/master/Examples/UIExplorer/UIExplorerIntegrationTests/UIExplorerIntegrationTests.m), and [IntegrationTestsApp.js](https://github.com/facebook/react-native/blob/master/IntegrationTests/IntegrationTestsApp.js) for example usage and integration points.
 
 You can run integration tests locally with cmd+U in the IntegrationTest and UIExplorer apps in Xcode.
 
-## Snapshot Tests (iOS only)
+## Snapshot Tests (iOS)
 
 A common type of integration test is the snapshot test.  These tests render a component, and verify snapshots of the screen against reference images using `TestModule.verifySnapshot()`, using the [`FBSnapshotTestCase`](https://github.com/facebook/ios-snapshot-test-case) library behind the scenes.  Reference images are recorded by setting `recordMode = YES` on the `RCTTestRunner`, then running the tests.  Snapshots will differ slightly between 32 and 64 bit, and various OS versions, so it's recommended that you enforce tests are run with the correct configuration.  It's also highly recommended that all network data be mocked out, along with other potentially troublesome dependencies.  See [`SimpleSnapshotTest`](https://github.com/facebook/react-native/blob/master/IntegrationTests/SimpleSnapshotTest.js) for a basic example.
 

--- a/scripts/run-android-local-integration-test.sh
+++ b/scripts/run-android-local-integration-test.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Runs all Android integration tests locally.
+# See http://facebook.github.io/react-native/docs/testing.html
+
+which buck > /dev/null || { 
+  echo "React Native uses the Buck build tool to run tests. Please install Buck: https://buckbuild.com/setup/install.html";
+  exit 1;
+}
+
+echo "Compiling native code..."
+./gradlew :ReactAndroid:packageReactNdkLibsForBuck
+echo "Building JS bundle..."
+node local-cli/cli.js bundle --platform android --dev true --entry-file ReactAndroid/src/androidTest/js/TestBundle.js --bundle-output ReactAndroid/src/androidTest/assets/AndroidTestBundle.js
+echo "Installing test app on the device..."
+buck install ReactAndroid/src/androidTest/buck-runner:instrumentation-tests
+echo "Running integration tests..."
+./scripts/run-android-instrumentation-tests.sh com.facebook.react.tests

--- a/scripts/run-android-local-unit-tests.sh
+++ b/scripts/run-android-local-unit-tests.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Runs all Android unit tests locally.
+# See http://facebook.github.io/react-native/docs/testing.html
+
+which buck > /dev/null || { 
+  echo "React Native uses the Buck build tool to run tests. Please install Buck: https://buckbuild.com/setup/install.html";
+  exit 1;
+}
+
+echo "Fetching dependencies..."
+buck fetch ReactAndroid/src/test/...
+echo "Running unit tests..."
+buck test ReactAndroid/src/test/...


### PR DESCRIPTION
I was going to add an integration test and realized it would be useful to have an easy way to run these test locally. Added scripts and documented how to use them.

**Test plan**

`./scripts/run-android-local-unit-tests.sh`

<img width="786" alt="screen shot 2016-05-04 at 3 55 26 pm" src="https://cloud.githubusercontent.com/assets/346214/15018667/7f4981cc-1212-11e6-9fcb-12493c29015c.png">

`./scripts/run-android-local-integration-tests.sh`

<img width="772" alt="screen shot 2016-05-04 at 3 57 23 pm" src="https://cloud.githubusercontent.com/assets/346214/15018677/90b54810-1212-11e6-83d4-58530eb41d79.png">

Buck check by replacing `which buck` by `which duck` in the scripts:

<img width="805" alt="screen shot 2016-05-04 at 4 09 37 pm" src="https://cloud.githubusercontent.com/assets/346214/15018696/aa008262-1212-11e6-9a22-173507cd771f.png">

Checked the website renders fine:

`cd website; npm install; npm start`

![screen shot 2016-05-04 at 4 05 23 pm](https://cloud.githubusercontent.com/assets/346214/15018728/c2e6f176-1212-11e6-8d85-b8214a454312.png)

![screen shot 2016-05-04 at 3 36 59 pm](https://cloud.githubusercontent.com/assets/346214/15018731/c9d86848-1212-11e6-8bbf-dff75fdc871e.png)
