### PR TITLE
[tests] Test that Picker selection is updated correctly

### DIFF
--- a/ReactAndroid/src/androidTest/java/com/facebook/react/tests/ReactPickerTestCase.java
+++ b/ReactAndroid/src/androidTest/java/com/facebook/react/tests/ReactPickerTestCase.java
@@ -171,6 +171,36 @@ public class ReactPickerTestCase extends ReactAppInstrumentationTestCase {
     assertEquals(2, (int) selections.get(0));
   }
 
+  public void testOnSelectSequence() throws Throwable {
+    updateFirstSpinnerAndCheckLastSpinnerMatches(0);
+    updateFirstSpinnerAndCheckLastSpinnerMatches(2);
+    updateFirstSpinnerAndCheckLastSpinnerMatches(0);
+    updateFirstSpinnerAndCheckLastSpinnerMatches(2);
+  }
+
+  private void updateFirstSpinnerAndCheckLastSpinnerMatches(
+    final int indexToSelect
+  ) throws Throwable {
+    // The last spinner has the same selected value as the first one.
+    // Test that user selection is propagated correctly to JS, to setState, and to Spinners.
+    runTestOnUiThread(
+        new Runnable() {
+          @Override
+          public void run() {
+            ReactPicker spinner = getViewAtPath(0, 0);
+            spinner.setSelection(indexToSelect);
+          }
+        });
+    getInstrumentation().waitForIdleSync();
+    waitForBridgeAndUIIdle();
+
+    ReactPicker spinnerInSync = getViewAtPath(0, 3);
+    assertEquals(
+      "Picker selection was not updated correctly via setState.",
+      indexToSelect,
+      spinnerInSync.getSelectedItemPosition());
+  }
+
   private PickerAndroidTestModule getTestModule() {
     return getReactContext().getCatalystInstance().getJSModule(PickerAndroidTestModule.class);
   }

--- a/ReactAndroid/src/androidTest/js/PickerAndroidTestModule.js
+++ b/ReactAndroid/src/androidTest/js/PickerAndroidTestModule.js
@@ -52,6 +52,14 @@ var PickerAndroidTestApp = React.createClass({
           <Item label="item1" />
           <Item label="item2" />
         </Picker>
+        <Picker
+          mode="dropdown"
+          selectedValue={this.state.selected}
+          onValueChange={this.onValueChange}>
+          <Item label="item in sync 1" value={0} />
+          <Item label="item in sync 2" value={1} />
+          <Item label="item in sync 3" value={2} />
+        </Picker>
       </View>
     );
   },


### PR DESCRIPTION
A React pull request broke the Picker: https://github.com/facebook/react/pull/6572
This pull request adds a test so that we prevent breakages like this in the future.

`PickerAndroidExample` in the UIExplorer before the breakage (video): https://vid.me/h5Rg
`PickerAndroidExample` in the UIExplorer after the breakage (video): https://vid.me/atFc

**Test plan**

`./scripts/run-android-local-integration-test.sh`

The test is failing, we can only merge this once React is fixed.

<img width="837" alt="screen shot 2016-05-04 at 5 13 31 pm" src="https://cloud.githubusercontent.com/assets/346214/15020827/aca8d718-121b-11e6-91f6-a338293d7d92.png">
