### PR TITLE
Add versions to GitHub source links in documentation. #7428

### DIFF
--- a/website/core/HeaderWithGithub.js
+++ b/website/core/HeaderWithGithub.js
@@ -12,7 +12,20 @@
 var H = require('Header');
 var React = require('React');
 
+function getVersionedGithubPath(path, version='next') {
+  return [
+    'https://github.com/facebook/react-native/blob',
+    version === 'next' ? 'master' : version + '-stable',
+    path
+    ].join('/')
+}
+
 var HeaderWithGithub = React.createClass({
+
+  contextTypes: {
+    version: React.PropTypes.string
+  },
+
   render: function() {
     return (
       <table width="100%">
@@ -26,7 +39,7 @@ var HeaderWithGithub = React.createClass({
             <td style={{textAlign: 'right'}}>
               <a
                 target="_blank"
-                href={'https://github.com/facebook/react-native/blob/master/' + this.props.path}>
+                href={getVersionedGithubPath(this.props.path, this.context.version)}>
                 Edit on GitHub
               </a>
             </td>

--- a/website/layout/AutodocsLayout.js
+++ b/website/layout/AutodocsLayout.js
@@ -18,6 +18,7 @@ var Prism = require('Prism');
 var React = require('React');
 var Site = require('Site');
 var slugify = require('slugify');
+var Metadata = require('Metadata');
 
 var styleReferencePattern = /^[^.]+\.propTypes\.style$/;
 
@@ -520,11 +521,15 @@ var Modal = React.createClass({
 
 var Autodocs = React.createClass({
   childContextTypes: {
-    permalink: React.PropTypes.string
+    permalink: React.PropTypes.string,
+    version: React.PropTypes.string
   },
 
   getChildContext: function() {
-    return {permalink: this.props.metadata.permalink};
+    return {
+      permalink: this.props.metadata.permalink,
+      version: Metadata.config.RN_VERSION || 'next'
+    };
   },
 
   renderFullDescription: function(docs) {

--- a/website/layout/DocsLayout.js
+++ b/website/layout/DocsLayout.js
@@ -14,14 +14,19 @@ var HeaderWithGithub = require('HeaderWithGithub');
 var Marked = require('Marked');
 var React = require('React');
 var Site = require('Site');
+var Metadata = require('Metadata');
 
 var DocsLayout = React.createClass({
   childContextTypes: {
-    permalink: React.PropTypes.string
+    permalink: React.PropTypes.string,
+    version: React.PropTypes.string
   },
 
   getChildContext: function() {
-    return {permalink: this.props.metadata.permalink};
+    return {
+      permalink: this.props.metadata.permalink,
+      version: Metadata.config.RN_VERSION || 'next'
+    };
   },
 
   render: function() {


### PR DESCRIPTION
### Motivation 
Documentation references to source code on GitHub should point to their respective versions in order to avoid confusion and prevent broken links when the master branch differs from the currently viewed version. [More details](https://github.com/facebook/react-native/issues/7428)

Originally links pointed to a hardcoded master branch on GitHub. The change augments the GitHub url to point to a respective branch of the code. The new urls are as follows:

next: `https://github.com/facebook/react-native/blob/master/<path>`
stable: `https://github.com/facebook/react-native/blob/0.25-stable/<path>`


### Test Plan
The website module currently does not have a unit test setup. As a result, I performed the following tests:

1. Start the server with `RN_VERSION=next` and verified all links point to _master_
<img width="945" alt="screen shot 2016-05-07 at 14 10 58" src="https://cloud.githubusercontent.com/assets/1419286/15092307/ee66fb32-145d-11e6-92a0-d03169e517c2.png">
2. Start the server with `RN_VERSION=0.24` and verified all links point to the _0.24-stable_ branch
<img width="941" alt="screen shot 2016-05-07 at 14 10 28" src="https://cloud.githubusercontent.com/assets/1419286/15092306/ecb0e05a-145d-11e6-91ac-fecd5136a159.png">

I've gone through the pages and verified the links are correct and unbroken.

