### PR TITLE
Fix bug on GettingStarted.md page when clicking nav buttons in FF

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -36,12 +36,12 @@ block { display: none; }
   display: block;
 }</style>
 <span>Platform:</span>
-<a href="" class="button-ios" onclick="display('platform', 'ios')">iOS</a>
-<a href="" class="button-android" onclick="display('platform', 'android')">Android</a>
+<a href="javascript:void(0);" class="button-ios" onclick="display('platform', 'ios')">iOS</a>
+<a href="javascript:void(0);" class="button-android" onclick="display('platform', 'android')">Android</a>
 <span>OS:</span>
-<a href="" class="button-mac" onclick="display('os', 'mac')">Mac</a>
-<a href="" class="button-linux" onclick="display('os', 'linux')">Linux</a>
-<a href="" class="button-windows" onclick="display('os', 'windows')">Windows</a>
+<a href="javascript:void(0);" class="button-mac" onclick="display('os', 'mac')">Mac</a>
+<a href="javascript:void(0);" class="button-linux" onclick="display('os', 'linux')">Linux</a>
+<a href="javascript:void(0);" class="button-windows" onclick="display('os', 'windows')">Windows</a>
 </div>
 
 <!-- ######### LINUX AND WINDOWS for iOS ##################### -->


### PR DESCRIPTION
Hi,
The [commit](https://github.com/facebook/react-native/commit/156d3ed7a290a7d0576c7e6d2b3fc03681d71ee9?_pjax=%23js-repo-pjax-container) by @JoelMarcey is much appreciated.  However, when you click on the nav buttons in Firefox (v46.0.1, I'm on El-Capitan), it will switch the content but also navigate you to the React-Native homepage.  This doesn't happen in Chrome, so that's how it probably slipped through.
I propose these changes to fix that.

**Test plan**
Tested locally on FF and Chrome on El-Capitan