### PR TITLE
[Docs] Remove default argument syntax on getVersionedGithubPath()

### DIFF
--- a/website/core/HeaderWithGithub.js
+++ b/website/core/HeaderWithGithub.js
@@ -12,12 +12,13 @@
 var H = require('Header');
 var React = require('React');
 
-function getVersionedGithubPath(path, version='next') {
+function getVersionedGithubPath(path, version) {
+  version = version || 'next';
   return [
     'https://github.com/facebook/react-native/blob',
     version === 'next' ? 'master' : version + '-stable',
     path
-    ].join('/')
+  ].join('/');
 }
 
 var HeaderWithGithub = React.createClass({


### PR DESCRIPTION
Removes ES6 syntax of default arguments to fix website building as per #7434. [More info](https://github.com/facebook/react-native/pull/7434).