### PR TITLE
Make RefreshControl properly controlled by JS

### DIFF
--- a/Libraries/Components/RefreshControl/RefreshControl.js
+++ b/Libraries/Components/RefreshControl/RefreshControl.js
@@ -131,14 +131,14 @@ const RefreshControl = React.createClass({
     this._lastNativeRefreshing = this.props.refreshing;
   },
 
-  componentWillReceiveProps(nextProps: {refreshing: boolean}) {
-    this._lastNativeRefreshing = nextProps.refreshing;
-  },
-
-  componentDidUpdate() {
-    if (this.props.refreshing !== this._lastNativeRefreshing) {
+  componentDidUpdate(prevProps: {refreshing: boolean}) {
+    // RefreshControl is a controlled component, makes sure that the native value
+    // matches the refreshing prop.
+    if (this.props.refreshing !== prevProps.refreshing) {
       this._lastNativeRefreshing = this.props.refreshing;
+    } else if (this.props.refreshing !== this._lastNativeRefreshing) {
       this._nativeRef.setNativeProps({refreshing: this.props.refreshing});
+      this._lastNativeRefreshing = this.props.refreshing;
     }
   },
 

--- a/Libraries/Components/RefreshControl/RefreshControl.js
+++ b/Libraries/Components/RefreshControl/RefreshControl.js
@@ -86,7 +86,7 @@ const RefreshControl = React.createClass({
     /**
      * Whether the view should be indicating an active refresh.
      */
-    refreshing: React.PropTypes.bool,
+    refreshing: React.PropTypes.bool.isRequired,
     /**
      * The color of the refresh indicator.
      * @platform ios
@@ -124,7 +124,22 @@ const RefreshControl = React.createClass({
     size: React.PropTypes.oneOf(RefreshLayoutConsts.SIZE.DEFAULT, RefreshLayoutConsts.SIZE.LARGE),
   },
 
-  _nativeRef: {},
+  _nativeRef: (null: any),
+  _lastNativeRefreshing: false,
+
+  componentDidMount() {
+    this._lastNativeRefreshing = this.props.refreshing;
+  },
+
+  componentWillReceiveProps(nextProps: {refreshing: boolean}) {
+    this._lastNativeRefreshing = nextProps.refreshing;
+  },
+
+  componentDidUpdate() {
+    if (this.props.refreshing !== this._lastNativeRefreshing) {
+      this._nativeRef.setNativeProps({refreshing: this.props.refreshing});
+    }
+  },
 
   render() {
     return (
@@ -137,11 +152,11 @@ const RefreshControl = React.createClass({
   },
 
   _onRefresh() {
+    this._lastNativeRefreshing = true;
+
     this.props.onRefresh && this.props.onRefresh();
 
-    if (this._nativeRef) {
-      this._nativeRef.setNativeProps({refreshing: this.props.refreshing});
-    }
+    this.forceUpdate();
   },
 });
 

--- a/Libraries/Components/RefreshControl/RefreshControl.js
+++ b/Libraries/Components/RefreshControl/RefreshControl.js
@@ -132,8 +132,9 @@ const RefreshControl = React.createClass({
   },
 
   componentDidUpdate(prevProps: {refreshing: boolean}) {
-    // RefreshControl is a controlled component, makes sure that the native value
-    // matches the refreshing prop.
+    // RefreshControl is a controlled component so if the native refreshing
+    // value doesn't match the current js refreshing prop update it to
+    // the js value.
     if (this.props.refreshing !== prevProps.refreshing) {
       this._lastNativeRefreshing = this.props.refreshing;
     } else if (this.props.refreshing !== this._lastNativeRefreshing) {
@@ -157,6 +158,8 @@ const RefreshControl = React.createClass({
 
     this.props.onRefresh && this.props.onRefresh();
 
+    // The native component will start refreshing so force an update to
+    // make sure it stays in sync with the js component.
     this.forceUpdate();
   },
 });

--- a/Libraries/Components/RefreshControl/RefreshControl.js
+++ b/Libraries/Components/RefreshControl/RefreshControl.js
@@ -137,6 +137,7 @@ const RefreshControl = React.createClass({
 
   componentDidUpdate() {
     if (this.props.refreshing !== this._lastNativeRefreshing) {
+      this._lastNativeRefreshing = this.props.refreshing;
       this._nativeRef.setNativeProps({refreshing: this.props.refreshing});
     }
   },


### PR DESCRIPTION
There was an issue with the way we made `RefreshControl` a controlled component when react doesn't render synchronously. This fixes the issue by using the same technique used in the commit 0cd2904b235f53ed684bb9898280461e2cee0b5b for`PickerAndroid`

**Test plan (required)**

Tested normal behaviour and tested that if not setting the `refreshing` prop to `true` during the `onRefresh` callback that the `RefreshControl` stops refreshing immediately. Also made sure that `setNativeProps` is only called if needed when the native refreshing state is not in sync with JS.

Fix #7414