### PR TITLE
Added additional predefined easing options to Easings.js

### DIFF
--- a/Libraries/Animated/src/Easing.js
+++ b/Libraries/Animated/src/Easing.js
@@ -139,8 +139,30 @@ class Easing {
   }
 }
 
-var ease = Easing.bezier(0.42, 0, 1, 1);
-
-
+var ease             = Easing.bezier(0.420, 0, 1, 1);
+var easeInQuad       = Easing.bezier(0.550,  0.085, 0.680, 0.530);
+var easeInCubic      = Easing.bezier(0.550,  0.055, 0.675, 0.190);
+var easeInQuart      = Easing.bezier(0.895,  0.030, 0.685, 0.220);
+var easeInQuint      = Easing.bezier(0.755,  0.050, 0.855, 0.060);
+var easeInSine       = Easing.bezier(0.470,  0.000, 0.745, 0.715);
+var easeInExpo       = Easing.bezier(0.950,  0.050, 0.795, 0.035);
+var easeInCirc       = Easing.bezier(0.600,  0.040, 0.980, 0.335);
+var easeInBack       = Easing.bezier(0.600, -0.280, 0.735, 0.045);
+var easeOutQuad      = Easing.bezier(0.250,  0.460, 0.450, 0.940);
+var easeOutCubic     = Easing.bezier(0.215,  0.610, 0.355, 1.000);
+var easeOutQuart     = Easing.bezier(0.165,  0.840, 0.440, 1.000);
+var easeOutQuint     = Easing.bezier(0.230,  1.000, 0.320, 1.000);
+var easeOutSine      = Easing.bezier(0.390,  0.575, 0.565, 1.000);
+var easeOutExpo      = Easing.bezier(0.190,  1.000, 0.220, 1.000);
+var easeOutCirc      = Easing.bezier(0.075,  0.820, 0.165, 1.000);
+var easeOutBack      = Easing.bezier(0.175,  0.885, 0.320, 1.275);
+var easeInOutQuad    = Easing.bezier(0.455,  0.030, 0.515, 0.955);
+var easeInOutCubic   = Easing.bezier(0.645,  0.045, 0.355, 1.000);
+var easeInOutQuart   = Easing.bezier(0.770,  0.000, 0.175, 1.000);
+var easeInOutQuint   = Easing.bezier(0.860,  0.000, 0.070, 1.000);
+var easeInOutSine    = Easing.bezier(0.445,  0.050, 0.550, 0.950);
+var easeInOutExpo    = Easing.bezier(1.000,  0.000, 0.000, 1.000);
+var easeInOutCirc    = Easing.bezier(0.785,  0.135, 0.150, 0.860);
+var easeInOutBack    = Easing.bezier(0.680, -0.550, 0.265, 1.550);
 
 module.exports = Easing;


### PR DESCRIPTION
Mapped the first 24 predefined Easing curves on http://easings.net/ for quick use. There are 6 more easing curves on that website, however they don't supply a bezier curve for them so we should probably leave those up to developers. Usually I would wrap all these in an object called easingTypes or something and set them to be const however based on how the first type, ease, was set I decided to follow the standard. Let me know if I should wrap/export these cleaner. Also I would like to update the Animated docs page with this information, would you like me to do that in this PR? Or is that something that you guys usually handle.

The reason why I am doing this is to 
1. Learn the open contribution process through something simple and easy to review.
2. Further enhance the core Animated library. When I started using it I found it difficult to figure out how and where to find Easing curves. After going through the code I realized that there was only one easing curve while the competing react-native animated library, react-tween-state, has a more encompassing predefined Easing library. 

Looking forward to working with the react native community,
Cheers!