### PR TITLE
Fix tintColor prop platform in Image

### DIFF
--- a/Libraries/Image/ImageStylePropTypes.js
+++ b/Libraries/Image/ImageStylePropTypes.js
@@ -31,9 +31,7 @@ var ImageStylePropTypes = {
   overflow: ReactPropTypes.oneOf(['visible', 'hidden']),
 
   /**
-   * iOS-Specific style to "tint" an image.
    * Changes the color of all the non-transparent pixels to the tintColor.
-   * @platform ios
    */
   tintColor: ColorPropType,
   opacity: ReactPropTypes.number,


### PR DESCRIPTION
`tintColor`, even in style, works on Android; this must be some old comment but that confused me when reading the docs.

**Test plan:**
- Launched website locally 