### PR TITLE
[Android] use RN version from node_modules instead of jcenter

### DIFF
--- a/local-cli/generator-android/templates/src/build.gradle
+++ b/local-cli/generator-android/templates/src/build.gradle
@@ -18,7 +18,7 @@ allprojects {
         jcenter()
         maven {
             // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
-            url "$projectDir/../../node_modules/react-native/android"
+            url "$rootDir/../node_modules/react-native/android"
         }
     }
 }


### PR DESCRIPTION
the current `build.gradle` configuration make all third-party plugins to pull react native from jcenter instead of using version from `node_modules`.

For example, a newly generated project with RN 0.25 using https://github.com/ProjectSeptemberInc/gl-react-native leads to the following gradle output:

```
Download https://jcenter.bintray.com/com/facebook/stetho/stetho-okhttp/1.2.0/stetho-okhttp-1.2.0.pom
Download https://jcenter.bintray.com/com/facebook/stetho/stetho/1.2.0/stetho-1.2.0.pom
Download https://jcenter.bintray.com/com/facebook/stetho/stetho/1.2.0/stetho-1.2.0.jar
Download https://jcenter.bintray.com/com/facebook/stetho/stetho-okhttp/1.2.0/stetho-okhttp-1.2.0.jar
Download https://jcenter.bintray.com/com/facebook/react/react-native/0.20.1/react-native-0.20.1.aar
```

