### PR TITLE
fix prop error on DatePickerIOS

### DIFF
--- a/Libraries/Components/DatePicker/DatePickerIOS.ios.js
+++ b/Libraries/Components/DatePicker/DatePickerIOS.ios.js
@@ -122,7 +122,7 @@ var DatePickerIOS = React.createClass({
         <RCTDatePickerIOS
           ref={ picker => this._picker = picker }
           style={styles.datePickerIOS}
-          date={props.date.getTime()}
+          date={props.date}
           maximumDate={
             props.maximumDate ? props.maximumDate.getTime() : undefined
           }
@@ -132,7 +132,7 @@ var DatePickerIOS = React.createClass({
           mode={props.mode}
           minuteInterval={props.minuteInterval}
           timeZoneOffsetInMinutes={props.timeZoneOffsetInMinutes}
-          onChange={this._onChange}
+          onDateChange={this._onChange}
         />
       </View>
     );


### PR DESCRIPTION
Fixed error like:
```
Warning: Failed propType: Invalid prop `date` supplied to `RCTDatePicker`, expected instance of `Date`. Check the render method of `DatePickerIOS`.

Warning: Failed propType: Required prop `onDateChange` was not specified in `RCTDatePicker`. Check the render method of `DatePickerIOS`.
```

![e7aa612e-47f0-11e5-93af-b7166971f200](https://cloud.githubusercontent.com/assets/10336620/15116290/3d20d436-1635-11e6-982a-ff3d9291bc87.png)

Code:
```
<DatePickerIOS
  style={styles.button}
  date={new Date(this.state.date)}
  mode="date"
  onDateChange={this.onDateChange}
/>
```

As you can see at https://github.com/facebook/react-native/blob/master/Libraries/Components/DatePicker/DatePickerIOS.ios.js#L135, prop onDateChange does not emit correctly to the inner RCTDatePickerIOS element.
Also the [date prop on RCTDatePickerIOS](https://github.com/facebook/react-native/blob/master/Libraries/Components/DatePicker/DatePickerIOS.ios.js#L125) expected a Date Object but got a number by invoke the getTime method.


Thanks @kevinold to mention this problem at https://github.com/facebook/react-native/issues/2397.