### PR TITLE
Implement defaultSource on Image Android

### DIFF
--- a/Examples/UIExplorer/js/ImageExample.js
+++ b/Examples/UIExplorer/js/ImageExample.js
@@ -302,7 +302,6 @@ exports.examples = [
         />
       );
     },
-    platform: 'ios',
   },
   {
     title: 'Border Color',

--- a/Libraries/Image/Image.android.js
+++ b/Libraries/Image/Image.android.js
@@ -64,8 +64,8 @@ function generateRequestId() {
 
 var ImageViewAttributes = merge(ReactNativeViewAttributes.UIView, {
   src: true,
-  loadingIndicatorSrc: true,
   resizeMethod: true,
+  defaultSrc: true,
   resizeMode: true,
   progressiveRenderingEnabled: true,
   fadeDuration: true,
@@ -102,11 +102,9 @@ var Image = React.createClass({
         }))
     ]),
     /**
-     * similarly to `source`, this property represents the resource used to render
-     * the loading indicator for the image, displayed until image is ready to be
-     * displayed, typically after when it got downloaded from network.
+     * A static image to display while loading the image source.
      */
-    loadingIndicatorSource: PropTypes.oneOfType([
+    defaultSource: PropTypes.oneOfType([
       PropTypes.shape({
         uri: PropTypes.string,
       }),
@@ -259,7 +257,7 @@ var Image = React.createClass({
 
   render: function() {
     const source = resolveAssetSource(this.props.source);
-    const loadingIndicatorSource = resolveAssetSource(this.props.loadingIndicatorSource);
+    const defaultSource = resolveAssetSource(this.props.defaultSource);
 
     // As opposed to the ios version, here we render `null` when there is no source, source.uri
     // or source array.
@@ -289,7 +287,7 @@ var Image = React.createClass({
         style,
         shouldNotifyLoadEvents: !!(onLoadStart || onLoad || onLoadEnd),
         src: sources,
-        loadingIndicatorSrc: loadingIndicatorSource ? loadingIndicatorSource.uri : null,
+        defaultSrc: defaultSource ? defaultSource.uri : null,
       });
 
       if (nativeProps.children) {
@@ -335,7 +333,7 @@ var styles = StyleSheet.create({
 var cfg = {
   nativeOnly: {
     src: true,
-    loadingIndicatorSrc: true,
+    defaultSrc: true,
     shouldNotifyLoadEvents: true,
   },
 };

--- a/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageManager.java
@@ -81,8 +81,8 @@ public class ReactImageManager extends SimpleViewManager<ReactImageView> {
     view.setSource(sources);
   }
 
-  // In JS this is Image.props.loadingIndicatorSource.uri
-  @ReactProp(name = "loadingIndicatorSrc")
+  // In JS this is Image.props.defaultSource.uri
+  @ReactProp(name = "defaultSrc")
   public void setLoadingIndicatorSource(ReactImageView view, @Nullable String source) {
     view.setLoadingIndicatorSource(source);
   }


### PR DESCRIPTION
The title is kind of a lie, it was already implemented in https://github.com/facebook/react-native/commit/a38ce5c5705a18379d3f54297fad3b5b241611a0 (cc @brentvatne your comment gave me the idea to open this PR).

There are however a few issues before this can be merged:
- It doesn't work in dev mode because then the `defaultSource` is an url pointing to the dev server whereas the `defaultSource` is expected to be a local image (from the `drawable` folders).
- The drawable... rotates? Due to the [`AutoRotateDrawable`](https://github.com/facebook/react-native/blob/master/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageView.java#L284). I suppose this was code needed for the FB apps, but maybe it's still worth having available? Or maybe separate it in 2 different props to keep the behavior.
