### PR TITLE
fix FPSGraph label setText not execute on main thread

### DIFF
--- a/React/Profiler/RCTFPSGraph.m
+++ b/React/Profiler/RCTFPSGraph.m
@@ -96,7 +96,9 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
     _minFPS = MIN(_minFPS, _FPS);
     _maxFPS = MAX(_maxFPS, _FPS);
 
-    _label.text = [NSString stringWithFormat:@"%lu", (unsigned long)_FPS];
+    dispatch_async(dispatch_get_main_queue(), ^{
+      _label.text = [NSString stringWithFormat:@"%lu", (unsigned long)_FPS];
+    });
 
     CGFloat scale = 60.0 / _height;
     for (NSUInteger i = 0; i < _length - 1; i++) {


### PR DESCRIPTION
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request:

(You can skip this if you're fixing a typo or adding an app to the Showcase.)

Explain the **motivation** for making this change. What existing problem does the pull request solve?
as apple states, all UIKit methods should execute on main thread, while FPSGraph is not.


Prefer **small pull requests**. These are much easier to review and more likely to get merged. Make sure the PR does only one thing, otherwise please split it.

**Test plan (required)**

Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

Make sure tests pass on both Travis and Circle CI.

**Code formatting**

Look around. Match the style of the rest of the codebase. See also the simple [style guide](https://github.com/facebook/react-native/blob/master/CONTRIBUTING.md#style-guide).

For more info, see the ["Pull Requests" section of our "Contributing" guidelines](https://github.com/facebook/react-native/blob/master/CONTRIBUTING.md#pull-requests).

