### PR TITLE
fixes a bug where NavigationPropTypes.SceneRenderer was a plain object

### DIFF
--- a/Libraries/CustomComponents/NavigationExperimental/NavigationCard.js
+++ b/Libraries/CustomComponents/NavigationExperimental/NavigationCard.js
@@ -92,7 +92,7 @@ class NavigationCard extends React.Component<any, Props, any> {
   props: Props;
 
   static propTypes = {
-    ...NavigationPropTypes.SceneRenderer,
+    ...NavigationPropTypes.SceneRendererProps,
     onComponentRef: PropTypes.func.isRequired,
     panHandlers: NavigationPropTypes.panHandlers,
     pointerEvents: PropTypes.string.isRequired,

--- a/Libraries/NavigationExperimental/NavigationPropTypes.js
+++ b/Libraries/NavigationExperimental/NavigationPropTypes.js
@@ -65,7 +65,7 @@ const scene = PropTypes.shape({
 });
 
 /* NavigationSceneRendererProps */
-const SceneRenderer = {
+const SceneRendererProps = {
   layout: layout.isRequired,
   navigationState: navigationParentState.isRequired,
   onNavigate: PropTypes.func.isRequired,
@@ -73,6 +73,8 @@ const SceneRenderer = {
   scene: scene.isRequired,
   scenes: PropTypes.arrayOf(scene).isRequired,
 };
+
+const SceneRenderer = PropTypes.shape(SceneRendererProps);
 
 /* NavigationPanPanHandlers */
 const panHandlers = PropTypes.shape({
@@ -111,6 +113,7 @@ module.exports = {
   extractSceneRendererProps,
 
   // Bundled propTypes.
+  SceneRendererProps,
   SceneRenderer,
 
   // propTypes


### PR DESCRIPTION
... but used as a shape in `SceneView`.

make NavigationPropTypes.SceneRenderer a PropTypes shape (consistent with the rest of that file)

make NavigationPropTypes.SceneRendererProps the plain object (which is used in two places)

Please let me know if you want a separate PR for master