### PR TITLE
Correctly test for HMR parameter in the bundle URL

### DIFF
--- a/React/Base/RCTBatchedBridge.m
+++ b/React/Base/RCTBatchedBridge.m
@@ -474,7 +474,7 @@ RCT_EXTERN NSArray<Class> *RCTGetModuleClasses(void);
 
 #if RCT_DEV
 
-  if (RCTGetURLQueryParam(self.bundleURL, @"hot")) {
+  if ([RCTGetURLQueryParam(self.bundleURL, @"hot") boolValue]) {
     NSString *path = [self.bundleURL.path substringFromIndex:1]; // strip initial slash
     NSString *host = self.bundleURL.host;
     NSNumber *port = self.bundleURL.port;


### PR DESCRIPTION
Test plan: Load a bundle with hot=false in the query parameters. RCTBatchedBridge should not enable HMR. This is consistent with the behavior in RCTDevMenu.