### PR TITLE
Fix a bug, if clipData is null we can not ask getItemCount() from it

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/modules/clipboard/ClipboardModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/clipboard/ClipboardModule.java
@@ -54,8 +54,7 @@ public class ClipboardModule extends ReactContextBaseJavaModule {
       ClipData clipData = clipboard.getPrimaryClip();
       if (clipData == null) {
         promise.resolve("");
-      }
-      if (clipData.getItemCount() >= 1) {
+      } else if (clipData.getItemCount() >= 1) {
         ClipData.Item firstItem = clipboard.getPrimaryClip().getItemAt(0);
         promise.resolve("" + firstItem.getText());
       } else {


### PR DESCRIPTION
I ran into problems when using Clipboard.getString() in Android. The method seems to work fine when there is *something* in the clipboard, but when it's empty the app crashes. I think I've tracked down the bug to ClipboardModule.java@58.

When clipData is null, the promise is resolved with an empty string. However, after that the rest of the block is executed. There should be a return or an 'else if' like in my pr.

Screenshot of the error message when clipboard is empty:

![image](https://cloud.githubusercontent.com/assets/7509183/15206922/44bd2094-182b-11e6-9400-6a59c513de24.png)
