### PR TITLE
RFC, WIP: Refactor Text into platform-specific files

### DIFF
--- a/Libraries/Text/Text.android.js
+++ b/Libraries/Text/Text.android.js
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule Text
+ * @flow
+ */
+'use strict';
+
+const React = require('React');
+const ReactNativeViewAttributes = require('ReactNativeViewAttributes');
+const TextBaseMixin = require('./TextBaseMixin.js');
+
+const createReactNativeComponentClass =
+  require('createReactNativeComponentClass');
+ const merge = require('merge');
+
+const Text = React.createClass({
+  mixins: [TextBaseMixin],
+  render(): ReactElement {
+    const newProps = this.getNewProps();
+    if (this.context.isInAParentText) {
+      return <RCTVirtualText {...newProps} />;
+    } else {
+      return <RCTText {...newProps} />;
+    }
+  },
+});
+
+const RCTText = createReactNativeComponentClass(TextBaseMixin.viewConfig);
+const RCTVirtualText = createReactNativeComponentClass({
+  validAttributes: merge(ReactNativeViewAttributes.UIView, {
+    isHighlighted: true,
+  }),
+  uiViewClassName: 'RCTVirtualText',
+});
+
+module.exports = Text;

--- a/Libraries/Text/Text.ios.js
+++ b/Libraries/Text/Text.ios.js
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule Text
+ * @flow
+ */
+'use strict';
+
+const React = require('React');
+const TextBaseMixin = require('./TextBaseMixin.js');
+
+const createReactNativeComponentClass =
+  require('createReactNativeComponentClass');
+
+/**
+ * A React component for displaying text which supports nesting,
+ * styling, and touch handling.  In the following example, the nested title and
+ * body text will inherit the `fontFamily` from `styles.baseText`, but the title
+ * provides its own additional styles.  The title and body will stack on top of
+ * each other on account of the literal newlines:
+ *
+ * ```
+ * renderText: function() {
+ *   return (
+ *     <Text style={styles.baseText}>
+ *       <Text style={styles.titleText} onPress={this.onPressTitle}>
+ *         {this.state.titleText + '\n\n'}
+ *       </Text>
+ *       <Text numberOfLines={5}>
+ *         {this.state.bodyText}
+ *       </Text>
+ *     </Text>
+ *   );
+ * },
+ * ...
+ * var styles = StyleSheet.create({
+ *   baseText: {
+ *     fontFamily: 'Cochin',
+ *   },
+ *   titleText: {
+ *     fontSize: 20,
+ *     fontWeight: 'bold',
+ *   },
+ * };
+ * ```
+ */
+const Text = React.createClass({
+  mixins: [TextBaseMixin],
+  render(): ReactElement {
+    const newProps = this.getNewProps();
+    return <RCTText {...newProps} />;
+  },
+});
+
+const RCTText = createReactNativeComponentClass(TextBaseMixin.viewConfig);
+
+module.exports = Text;

--- a/Libraries/Text/TextBaseMixin.js
+++ b/Libraries/Text/TextBaseMixin.js
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  *
- * @providesModule Text
  * @flow
  */
 'use strict';
@@ -35,40 +34,17 @@ const viewConfig = {
 };
 
 /**
- * A React component for displaying text which supports nesting,
- * styling, and touch handling.  In the following example, the nested title and
- * body text will inherit the `fontFamily` from `styles.baseText`, but the title
- * provides its own additional styles.  The title and body will stack on top of
- * each other on account of the literal newlines:
- *
- * ```
- * renderText: function() {
- *   return (
- *     <Text style={styles.baseText}>
- *       <Text style={styles.titleText} onPress={this.onPressTitle}>
- *         {this.state.titleText + '\n\n'}
- *       </Text>
- *       <Text numberOfLines={5}>
- *         {this.state.bodyText}
- *       </Text>
- *     </Text>
- *   );
- * },
- * ...
- * var styles = StyleSheet.create({
- *   baseText: {
- *     fontFamily: 'Cochin',
- *   },
- *   titleText: {
- *     fontSize: 20,
- *     fontWeight: 'bold',
- *   },
- * };
- * ```
+ * Shared code for the <Text> component.
+ * See Text.ios.js for documentation.
  */
-
-const Text = React.createClass({
+const TextBaseMixin = {
   propTypes: {
+    /**
+     * Specifies whether fonts should scale to respect the Text Size
+     * accessibility setting on iOS.
+     * @platform ios
+     */
+    allowFontScaling: React.PropTypes.bool,
     /**
      * Used to truncate the text with an ellipsis after computing the text
      * layout, including line wrapping, such that the total number of lines
@@ -100,11 +76,6 @@ const Text = React.createClass({
      * Used to locate this view in end-to-end tests.
      */
     testID: React.PropTypes.string,
-    /**
-     * Specifies should fonts scale to respect Text Size accessibility setting on iOS.
-     * @platform ios
-     */
-    allowFontScaling: React.PropTypes.bool,
   },
   getDefaultProps(): Object {
     return {
@@ -144,7 +115,7 @@ const Text = React.createClass({
   touchableHandlePress: (null: ?Function),
   touchableHandleLongPress: (null: ?Function),
   touchableGetPressRectOffset: (null: ?Function),
-  render(): ReactElement {
+  getNewProps(): Object {
     let newProps = this.props;
     if (this.props.onStartShouldSetResponder || this._hasPressHandler()) {
       if (!this._handlers) {
@@ -236,13 +207,9 @@ const Text = React.createClass({
         style: [this.props.style, {color: 'magenta'}],
       };
     }
-    if (this.context.isInAParentText) {
-      return <RCTVirtualText {...newProps} />;
-    } else {
-      return <RCTText {...newProps} />;
-    }
+    return newProps;
   },
-});
+};
 
 type RectOffset = {
   top: number;
@@ -253,16 +220,4 @@ type RectOffset = {
 
 var PRESS_RECT_OFFSET = {top: 20, left: 20, right: 20, bottom: 30};
 
-var RCTText = createReactNativeComponentClass(viewConfig);
-var RCTVirtualText = RCTText;
-
-if (Platform.OS === 'android') {
-  RCTVirtualText = createReactNativeComponentClass({
-    validAttributes: merge(ReactNativeViewAttributes.UIView, {
-      isHighlighted: true,
-    }),
-    uiViewClassName: 'RCTVirtualText',
-  });
-}
-
-module.exports = Text;
+module.exports = TextBaseMixin;

--- a/website/server/extractDocs.js
+++ b/website/server/extractDocs.js
@@ -272,7 +272,7 @@ const components = [
   '../Libraries/Components/Switch/Switch.js',
   '../Libraries/Components/TabBarIOS/TabBarIOS.ios.js',
   '../Libraries/Components/TabBarIOS/TabBarItemIOS.ios.js',
-  '../Libraries/Text/Text.js',
+  '../Libraries/Text/Text.ios.js',
   '../Libraries/Components/TextInput/TextInput.js',
   '../Libraries/Components/ToolbarAndroid/ToolbarAndroid.android.js',
   '../Libraries/Components/Touchable/TouchableHighlight.js',


### PR DESCRIPTION
Do not review yet.

React Native for Windows is going to be released as a separate npm module. Since the Windows versions of components will have platform-specific prop types and logic, we (Eric Rozell, Nick Lockwood, Konstantin Raev, David Aurelio) decided to split the cross-platform components into:
- a file with code shared by all platforms
- one file per platform with platform-specific code

The approach I'm trying out here is to move the shared code into a mixin. It defines the current `propTypes`, in `Text.windows.js` it will be possible to do the following:

    const Text = React.createClass({
      mixins: [TextBaseMixin],
      propTypes: {
        ...TextBaseMixin.propTypes,
        /**
         * Button on the Xbox controller that can be used
         * to trigger the onPress handler.
         */
        xBoxButton: React.PropTypes.string,
      },
      render(): ReactElement {
        const newProps = this.getNewProps();
        ...
      },
    });

**Test plan**

- propTypes validation works - `<Text style={'foo'} />` produces a warning both on iOS and Android:
<img width="445" alt="screen shot 2016-05-12 at 2 15 31 pm" src="https://cloud.githubusercontent.com/assets/346214/15215760/092efb12-184c-11e6-8a9e-a9c174ba6641.png">


- Mixins work, tried adding `TimerMixin` to `TextBaseMixin`'s mixins, `Text.ios.js` can use `this.setTimeout` and `componentWillUnmount` fires correctly when `<Text>` is unmounted.
- `onPress` handlers work - tried `<Text onPress={() => alert('press')} />`
- **TODO: The code that renders `propTypes` on the website will need changes**. It can't see the `propTypes` inherited from the mixin.
- Ran the UIExplorer:

<img width="432" alt="screen shot 2016-05-12 at 1 07 51 pm" src="https://cloud.githubusercontent.com/assets/346214/15215633/53f5e832-184b-11e6-9a1e-2f7411ecd913.png">

<img width="432" alt="screen shot 2016-05-12 at 1 10 51 pm" src="https://cloud.githubusercontent.com/assets/346214/15215642/5fd97f10-184b-11e6-96cd-b0f5f366bcb2.png">

<img width="445" alt="screen shot 2016-05-12 at 1 44 25 pm" src="https://cloud.githubusercontent.com/assets/346214/15215648/6ad1cfa8-184b-11e6-820a-927fc65975c6.png">

<img width="444" alt="screen shot 2016-05-12 at 1 45 47 pm" src="https://cloud.githubusercontent.com/assets/346214/15215651/6ee46aec-184b-11e6-901b-5d62a4f90157.png">


