### PR TITLE
[Node 6] Run CircleCI tests on the latest version of Node

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -4,7 +4,7 @@ general:
       - gh-pages # list of branches to ignore
 machine:
   node:
-    version: 5.6.0
+    version: 6.2.0
   environment:
     PATH: "~/$CIRCLE_PROJECT_REPONAME/gradle-2.9/bin:/home/ubuntu/buck/bin:$PATH"
     TERM: "dumb"


### PR DESCRIPTION
Travis CI runs Node 4 (LTS), so make CircleCI run Node `<latest>` which is Node 6.