### PR TITLE
Resize text in multiline TextInput if text is set programmatically

### DIFF
--- a/Libraries/Text/RCTTextView.m
+++ b/Libraries/Text/RCTTextView.m
@@ -212,6 +212,7 @@ static NSAttributedString *removeReactTagFromString(NSAttributedString *string)
     _textView.selectedTextRange = [_textView textRangeFromPosition:position toPosition:position];
   }
 
+  [self updateContentSize];
   [_textView layoutIfNeeded];
 
   [self _setPlaceholderVisibility];


### PR DESCRIPTION
Setting the value (or children) in a multiline TextInput won't cause the text to wrap.  The issue is first documented in https://github.com/facebook/react-native/issues/5786

Test plan:
Created multiline text input, along with button which sets the text input child to a long Text string.  Saw the text wrap.

