### PR TITLE
Add support for overriding entry file in react-native-xcode.sh

### DIFF
--- a/packager/react-native-xcode.sh
+++ b/packager/react-native-xcode.sh
@@ -52,6 +52,8 @@ fi
 
 [ -z "$NODE_BINARY" ] && export NODE_BINARY="node"
 
+[ -z "$REACT_NATIVE_ENTRY_FILE" ] && export REACT_NATIVE_ENTRY_FILE="index.ios.js"
+
 nodejs_not_found()
 {
   echo "error: Can't find '$NODE_BINARY' binary to build React Native bundle" >&2
@@ -69,7 +71,7 @@ set -x
 DEST=$CONFIGURATION_BUILD_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH
 
 $NODE_BINARY "$REACT_NATIVE_DIR/local-cli/cli.js" bundle \
-  --entry-file index.ios.js \
+  --entry-file "$REACT_NATIVE_ENTRY_FILE" \
   --platform ios \
   --dev $DEV \
   --reset-cache true \


### PR DESCRIPTION
We need this as we have our codebase in typescript, and a different folder structure than the default