### PR TITLE
Reset hasError flag after HMR request

### DIFF
--- a/packager/react-packager/src/Resolver/polyfills/require.js
+++ b/packager/react-packager/src/Resolver/polyfills/require.js
@@ -201,6 +201,7 @@ if (__DEV__) {
     if (factory) {
       mod.factory = factory;
     }
+    mod.hasError = false;
     mod.isInitialized = false;
     require(id);
 


### PR DESCRIPTION
This got broken recently. As a result of this, when a module throws while being required, either by regular load or hot reload, the module object is marked as `hasError`. Form that point all subsequent HMR updates will fail because it will think the module failed while executing the factory but the failure could have been on an old run of an old factory.

The fix is very simple: just reset `hasError` to false when accepting a module.