### PR TITLE
[HMR] Avoid clearing out factory on DEV mode

### DIFF
--- a/packager/react-packager/src/Resolver/polyfills/require.js
+++ b/packager/react-packager/src/Resolver/polyfills/require.js
@@ -120,7 +120,11 @@ function loadModuleImplementation(moduleId, module) {
     // keep args in sync with with defineModuleCode in
     // packager/react-packager/src/Resolver/index.js
     factory(global, require, moduleObject, exports);
-    module.factory = undefined;
+
+    // avoid removing factory in DEV mode as it breaks HMR
+    if (!__DEV__) {
+      module.factory = undefined;
+    }
 
     if (__DEV__) {
       Systrace.endEvent();


### PR DESCRIPTION
@grabbou pointed out this issue.

We recently started cleaning out the factory function after module are required to save some memory. This broke HMR on some edge cases because sometimes the factory function may need to be re-executed. This PR just wraps the optimization into `__DEV__` to make sure we don't use it while developing.