### PR TITLE
Make the root view background color explicit

### DIFF
--- a/local-cli/generator-ios/templates/app/AppDelegate.m
+++ b/local-cli/generator-ios/templates/app/AppDelegate.m
@@ -47,6 +47,7 @@
                                                       moduleName:@"<%= name %>"
                                                initialProperties:nil
                                                    launchOptions:launchOptions];
+  rootView.backgroundColor = [[UIColor alloc] initWithRed:1.0f green:1.0f blue:1.0f alpha:1];
 
   self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
   UIViewController *rootViewController = [UIViewController new];


### PR DESCRIPTION
The default white background for the root view causes an unattractive flash when loading any app with a non-white background.  Almost every developer has to search for how to fix it.  

This change makes the background color explicit in the file, so it can be easily change to match the color of the splash screen and the main screen without having to search for it.

**Test plan (required)**
Launched my app and it still has a white flash for the background before loading the app.  I changed the background colors to other values and the flash was that color.