### PR TITLE
Fix tests buck build when running locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ node_modules
 
 # OS X
 .DS_Store
+
+# Test generated files
+/ReactAndroid/src/androidTest/assets/AndroidTestBundle.js

--- a/ReactAndroid/src/androidTest/java/com/facebook/react/tests/BUCK
+++ b/ReactAndroid/src/androidTest/java/com/facebook/react/tests/BUCK
@@ -14,6 +14,8 @@ deps = [
   react_native_target('java/com/facebook/react/bridge:bridge'),
   react_native_target('java/com/facebook/react:react'),
   react_native_target('java/com/facebook/react/common:common'),
+  react_native_target('java/com/facebook/react/modules/core:core'),
+  react_native_target('java/com/facebook/react/touch:touch'),
   react_native_target('java/com/facebook/react/modules/timepicker:timepicker'),
   react_native_target('java/com/facebook/react/modules/datepicker:datepicker'),
   react_native_target('java/com/facebook/react/modules/systeminfo:systeminfo'),

--- a/ReactAndroid/src/androidTest/java/com/facebook/react/tests/BUCK
+++ b/ReactAndroid/src/androidTest/java/com/facebook/react/tests/BUCK
@@ -11,14 +11,14 @@ SANDCASTLE_FLAKY = [
 
 deps = [
   react_native_integration_tests_target('java/com/facebook/react/testing:testing'),
-  react_native_target('java/com/facebook/react/bridge:bridge'),
   react_native_target('java/com/facebook/react:react'),
+  react_native_target('java/com/facebook/react/bridge:bridge'),
   react_native_target('java/com/facebook/react/common:common'),
   react_native_target('java/com/facebook/react/modules/core:core'),
-  react_native_target('java/com/facebook/react/touch:touch'),
-  react_native_target('java/com/facebook/react/modules/timepicker:timepicker'),
   react_native_target('java/com/facebook/react/modules/datepicker:datepicker'),
   react_native_target('java/com/facebook/react/modules/systeminfo:systeminfo'),
+  react_native_target('java/com/facebook/react/modules/timepicker:timepicker'),
+  react_native_target('java/com/facebook/react/touch:touch'),
   react_native_target('java/com/facebook/react/uimanager:uimanager'),
   react_native_target('java/com/facebook/react/uimanager/annotations:annotations'),
   react_native_target('java/com/facebook/react/views/picker:picker'),


### PR DESCRIPTION
Got this error when trying to run instrumentation tests locally with `./scripts/run-android-local-integration-test.sh`

```
C:\Users\janic\Developer\react-native\ReactAndroid\src\androidTest\java\com\facebook\react\tests\DatePickerDialogTestCase.java:110: error: cannot access com.facebook.react.modules.core.DefaultHardwareBackBtnHandler
    return (DialogFragment) getActivity().getSupportFragmentManager()
                                         ^
  class file for com.facebook.react.modules.core.DefaultHardwareBackBtnHandler not found
C:\Users\janic\Developer\react-native\ReactAndroid\src\androidTest\java\com\facebook\react\tests\ViewRenderingTestCase.java:82: error: cannot access com.facebook.react.touch.ReactInterceptingViewGroup
    assertEquals("Incorrect (or not applied) opacity", expectedOpacity, view.getAlpha());
                                                                            ^
  class file for com.facebook.react.touch.ReactInterceptingViewGroup not found
C:\Users\janic\Developer\react-native\ReactAndroid\src\androidTest\java\com\facebook\react\tests\ViewRenderingTestCase.java:86: error: cannot access com.facebook.react.touch.ReactHitSlopView
        view.getBackgroundColor());
            ^
  class file for com.facebook.react.touch.ReactHitSlopView not found
C:\Users\janic\Developer\react-native\ReactAndroid\src\androidTest\java\com\facebook\react\tests\ReactHorizontalScrollViewTestCase.java:-1: note: Some input files use or override a deprecated API.

C:\Users\janic\Developer\react-native\ReactAndroid\src\androidTest\java\com\facebook\react\tests\ReactHorizontalScrollViewTestCase.java:-1: note: Recompile with -Xlint:deprecation for details.

Errors: 3. Warnings: 0.

BUILD FAILED: //ReactAndroid/src/androidTest/java/com/facebook/react/tests:tests failed with exit code 1:
javac
[-] BUILDING...FINISHED 52.2s [100%]
Not using buckd because NO_BUCKD is set.
```

Not sure exactly why it works on CI but adding those 2 lines to the tests BUCK file fixes the issue. Also added the generated test bundle to gitignore.

**Test plan**
Ran integration tests locally with `./scripts/run-android-local-integration-test.sh`