### PR TITLE
Remove duplicate install of nativeFlushQueueImmediate

### DIFF
--- a/ReactCommon/bridge/JSCExecutor.cpp
+++ b/ReactCommon/bridge/JSCExecutor.cpp
@@ -192,7 +192,6 @@ void JSCExecutor::initOnJSVMThread() {
   JSObjectSetPrivate(JSContextGetGlobalObject(m_context), this);
 
   installNativeHook<&JSCExecutor::nativeFlushQueueImmediate>("nativeFlushQueueImmediate");
-  installNativeHook<&JSCExecutor::nativeFlushQueueImmediate>("nativeFlushQueueImmediate");
   installNativeHook<&JSCExecutor::nativeStartWorker>("nativeStartWorker");
   installNativeHook<&JSCExecutor::nativePostMessageToWorker>("nativePostMessageToWorker");
   installNativeHook<&JSCExecutor::nativeTerminateWorker>("nativeTerminateWorker");


### PR DESCRIPTION
This was accidentally added twice.

**Test plan (required)**

CI