### PR TITLE
Allow overriding DEV in the Xcode Packager script

### DIFF
--- a/packager/react-native-xcode.sh
+++ b/packager/react-native-xcode.sh
@@ -18,15 +18,14 @@ case "$CONFIGURATION" in
       echo "Skipping bundling for Simulator platform"
       exit 0;
     fi
-
-    DEV=true
+    if [[ "$DEV" = "" ]]; then DEV=true; fi
     ;;
   "")
     echo "$0 must be invoked by Xcode"
     exit 1
     ;;
   *)
-    DEV=false
+    if [[ "$DEV" = "" ]]; then DEV=false; fi
     ;;
 esac
 


### PR DESCRIPTION
The Xcode packager script sets DEV according to the Xcode configuration it runs in (which will eventually result in the value of `__DEV__` in Javascript code). This basically means that for Debug builds, `__DEV__` is `true` and for other builds it'll be `false`.

Since we have several types of internal builds, we need `__DEV__` to be `true` even for some configurations that are not Debug.

This small change will allow you to override DEV by setting it as an environment variable. (For example - set it as part of a fastlane lane)
If you don't set a DEV environment variable, it'll continue behaving the same (Debug -> true, Other configruations -> false).

(BTW, If there is another way to achieve this, I'd love to know!)

Thanks!