### PR TITLE
Use right API for websocket event subscribing

### DIFF
--- a/docs/Network.md
+++ b/docs/Network.md
@@ -79,25 +79,25 @@ WebSocket is a protocol providing full-duplex communication channels over a sing
 ```js
 var ws = new WebSocket('ws://host.com/path');
 
-ws.onopen = () => {
+ws.addEventListener('open',() => {
   // connection opened
   ws.send('something');
-};
+});
 
-ws.onmessage = (e) => {
+ws.addEventListener('message',(e) => {
   // a message was received
   console.log(e.data);
-};
+});
 
-ws.onerror = (e) => {
+ws.addEventListener('error',(e) => {
   // an error occurred
   console.log(e.message);
-};
+});
 
-ws.onclose = (e) => {
+ws.addEventListener('close',(e) => {
   // connection closed
   console.log(e.code, e.reason);
-};
+});
 ```
 
 ## XMLHttpRequest


### PR DESCRIPTION
This only a documentation change.

`onmessage`,`onerror`,`onopen`,`onclose` doesn't exists anymore and according to this example https://github.com/facebook/react-native/blob/master/Examples/UIExplorer/WebSocketExample.js#L114 `addEventListener` should be used instead