### PR TITLE
ListViews PropType renderScrollComponent is not required

### DIFF
--- a/Libraries/CustomComponents/ListView/ListView.js
+++ b/Libraries/CustomComponents/ListView/ListView.js
@@ -193,7 +193,7 @@ var ListView = React.createClass({
      * A function that returns the scrollable component in which the list rows
      * are rendered. Defaults to returning a ScrollView with the given props.
      */
-    renderScrollComponent: React.PropTypes.func.isRequired,
+    renderScrollComponent: React.PropTypes.func,
     /**
      * How early to start rendering rows before they come on screen, in
      * pixels.


### PR DESCRIPTION
The PropType `renderScrollComponent` in `ListView` is not required because it actually defaults to returning a ScrollView with the given props. Marking the PropType as required breaks tooling support in IntelliJ IDEA and Webstorm which check user code to assure all required props are properly set.

![bildschirmfoto 2016-05-17 um 09 57 34](https://cloud.githubusercontent.com/assets/485033/15320347/4d5f4c6e-1c30-11e6-8e89-822f417cb685.png)
