### PR TITLE
Allows overriding the native webview class (RCTWebView)

### DIFF
--- a/Libraries/Components/WebView/WebView.android.js
+++ b/Libraries/Components/WebView/WebView.android.js
@@ -183,11 +183,15 @@ var WebView = React.createClass({
   },
 
   componentWillMount: function() {
+    var state = {
+      nativeWebView: requireNativeComponent(this.props.nativeWebView, WebView)
+    };
+    
     if (this.props.startInLoadingState) {
-      this.setState({viewState: WebViewState.LOADING});
+      state.viewState = WebViewState.LOADING;
     }
-
-    this.setState({nativeWebView: requireNativeComponent(this.props.nativeWebView, WebView)});
+    
+    this.setState(state);
   },
 
   render: function() {

--- a/Libraries/Components/WebView/WebView.android.js
+++ b/Libraries/Components/WebView/WebView.android.js
@@ -117,6 +117,16 @@ var WebView = React.createClass({
     ]),
 
     /**
+     * Used on Android only, defines what native class will be used
+     * by the WebView, with RCTWebView as default.
+     * This property is useful if you would like to override the behavior
+     * of the native webview, ie. by intercepting resource loading or
+     * triggering custom events.
+     * @platform android
+     */
+    nativeWebView: PropTypes.string,
+
+    /**
      * Used on Android only, JS is enabled by default for WebView on iOS
      * @platform android
      */
@@ -168,6 +178,7 @@ var WebView = React.createClass({
     return {
       javaScriptEnabled : true,
       scalesPageToFit: true,
+      nativeWebView: 'RCTWebView',
     };
   },
 
@@ -175,6 +186,8 @@ var WebView = React.createClass({
     if (this.props.startInLoadingState) {
       this.setState({viewState: WebViewState.LOADING});
     }
+
+    this.setState({nativeWebView: requireNativeComponent(this.props.nativeWebView, WebView)});
   },
 
   render: function() {
@@ -212,8 +225,10 @@ var WebView = React.createClass({
       console.warn('WebView: `source.body` is not supported when using GET.');
     }
 
+    let NativeWebView = this.state.nativeWebView;
+
     var webView =
-      <RCTWebView
+      <NativeWebView
         ref={RCT_WEBVIEW_REF}
         key="webViewKey"
         style={webViewStyles}
@@ -315,8 +330,6 @@ var WebView = React.createClass({
     this.updateNavigationState(event);
   },
 });
-
-var RCTWebView = requireNativeComponent('RCTWebView', WebView);
 
 var styles = StyleSheet.create({
   container: {


### PR DESCRIPTION
These changes allow you to supply your own native webview class to the WebView component.

``` javascript
<WebView
  nativeWebView={'MyNativeWebViewImplementation'}
  ...
/>
```

I did this since I want to be able to extend some of the functionality of the webview. To do so, I had to copypaste the entire JS component, change the `requireNativeComponent` call and then implement my own class in Java. Problem is, copypasting won't take us anywhere -- so I'm looking for a better / straightforward way to be able to extend native components without cooking so much copypasta.

I would do the same change for ios but I dont have a way to test it.

One problem with this is that I definitely think there's a reason why `requireNativeComponent` lives outside the JS components -- and right now I am missing it. I tested briefly on android and things seem to work fine, but I'd like to hear more from someone here.

