### PR TITLE
Best effort selection of target platform and dev environment

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -816,7 +816,7 @@ if (window.location.hash !== '' && window.location.hash !== 'content') { // cont
   for (var i = 0; i < hashLinks.length && !foundHash; ++i) {
     if (hashLinks[i].hash === window.location.hash) {
       var parent = hashLinks[i].parentElement;
-      while (parent !== null) {
+      while (parent) {
         if (parent.tagName === 'BLOCK') {
           var devOS = null;
           var targetPlatform = null;

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -807,8 +807,57 @@ function display(type, value) {
     container.className.replace(RegExp('display-' + type + '-[a-z]+ ?'), '');
   event && event.preventDefault();
 }
-var isMac = navigator.platform === 'MacIntel';
-var isWindows = navigator.platform === 'Win32';
-display('os', isMac ? 'mac' : (isWindows ? 'windows' : 'linux'));
-display('platform', isMac ? 'ios' : 'android');
+
+// If we are coming to the page with a hash in it (i.e. from a search, for example), try to get
+// us as close as possible to the correct platform and dev os using the hashtag and block walk up.
+var foundHash = false;
+if (window.location.hash !== '' && window.location.hash !== 'content') { // content is default
+  var hashLinks = document.querySelectorAll('a.hash-link');
+  for (var i = 0; i < hashLinks.length && !foundHash; ++i) {
+    if (hashLinks[i].hash === window.location.hash) {
+      var parent = hashLinks[i].parentElement;
+      while (parent !== null) {
+        if (parent.tagName === 'BLOCK') {
+          var devOS = null;
+          var targetPlatform = null;
+          // Could be more than one target os and dev platform, but just choose some sort of order
+          // of priority here.
+
+          // Dev OS
+          if (parent.className.indexOf('mac') > -1) {
+            devOS = 'mac';
+          } else if (parent.className.indexOf('linux') > -1) {
+            devOS = 'linux';
+          } else if (parent.className.indexOf('windows') > -1) {
+            devOS = 'windows';
+          } else {
+            break; // assume we don't have anything.
+          }
+
+          // Target Platform
+          if (parent.className.indexOf('ios') > -1) {
+            targetPlatform = 'ios';
+          } else if (parent.className.indexOf('android') > -1) {
+            targetPlatform = 'android';
+          } else {
+            break; // assume we don't have anything.
+          }
+          // We would have broken out if both targetPlatform and devOS hadn't been filled.
+          display('os', devOS);
+          display('platform', targetPlatform);      
+          foundHash = true;
+          break;
+        }
+        parent = parent.parentElement;
+      }
+    }
+  }
+}
+// Do the default if there is no matching hash
+if (!foundHash) {
+  var isMac = navigator.platform === 'MacIntel';
+  var isWindows = navigator.platform === 'Win32';
+  display('os', isMac ? 'mac' : (isWindows ? 'windows' : 'linux'));
+  display('platform', isMac ? 'ios' : 'android');
+}
 </script>


### PR DESCRIPTION
Right now, if you do a search and select a document in Getting Started, it will
always default to iOS/Mac. This adds a bit of JavaScript to do a best effort
selection based on the hashtags of the headers.

If a header is associated with multiple environments (e.g., Android Studio), we
just choose the first one. So it is not 100% perfect, but it is decent.

ref: https://github.com/facebook/react-native/issues/7574

** Test Plan **

Test locally by adding hash tags to the end of a doc URL and ensured that the toggler had the right
selection.

e.g., `http://localhost:8079/react-native/docs/getting-started.html#chocolatey` had `Android` and `Windows` chosen.