### PR TITLE
Update upgrade command with 0.26 breaking changes

### DIFF
--- a/local-cli/upgrade/upgrade.js
+++ b/local-cli/upgrade/upgrade.js
@@ -57,6 +57,17 @@ module.exports = function upgrade(args, config) {
             );
             return Promise.resolve();
           }
+          
+          if (semver.satisfies(v, '~0.26.0')) {
+            console.log(
+              chalk.yellow(
+                'React Native 0.26 introduced some breaking changes to the native files. You can\n' +
+                'perform them manually by checking the release notes or use \'rnpm\' to do it automatically.\n' +
+                'Just run:\n' +
+                '\'npm install -g rnpm && npm install rnpm-plugin-upgrade@0.26 --save-dev\', then run \'rnpm upgrade\''
+              )
+            );
+          }
         } else {
           console.log(
             chalk.yellow(

--- a/local-cli/upgrade/upgrade.js
+++ b/local-cli/upgrade/upgrade.js
@@ -61,7 +61,7 @@ module.exports = function upgrade(args, config) {
           if (semver.satisfies(v, '~0.26.0')) {
             console.log(
               chalk.yellow(
-                'React Native 0.26 introduced some breaking changes to the native files. You can\n' +
+                'React Native 0.26 introduced some breaking changes to the native files on iOS. You can\n' +
                 'perform them manually by checking the release notes or use \'rnpm\' to do it automatically.\n' +
                 'Just run:\n' +
                 '\'npm install -g rnpm && npm install rnpm-plugin-upgrade@0.26 --save-dev\', then run \'rnpm upgrade\''


### PR DESCRIPTION
Generally it feels that at some point we will just integrate `rnpm upgrade` directly here, but this is a super temporary quick workaround for the people upgrading to 0.26. We might want to change it later to 0.27 and update this message in case we have any other stuff to upgrade.

![screen shot 2016-05-18 at 14 28 47](https://cloud.githubusercontent.com/assets/2464966/15358460/df3b1b66-1d04-11e6-825c-fa18fa96ee6e.png)

It is supposed to work for 0.26.0, 0.26.1 and all the others up to 0.27.