### PR TITLE
[iOS] Update RedBox copy error and stack to send the text to the Mac clipboard

### DIFF
--- a/React/Modules/RCTRedBox.m
+++ b/React/Modules/RCTRedBox.m
@@ -167,16 +167,9 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
     }
   }
   
-  UIPasteboard *pb = [UIPasteboard generalPasteboard];
-  [pb setString:fullStackTrace];
-  
-#if TARGET_IPHONE_SIMULATOR
-  // if running in the simulator, try to get the stack up to the hosting computer's clipboard as
-  // well as the pastboard in the simulator
   if (_actionDelegate && [_actionDelegate respondsToSelector:@selector(redBoxWindow:sendTextToPasteboard:)]) {
     [_actionDelegate redBoxWindow:self sendTextToPasteboard:fullStackTrace];
   }
-#endif
 }
 
 #pragma mark - TableView
@@ -399,6 +392,13 @@ RCT_EXPORT_METHOD(dismiss)
 
 
 - (void)redBoxWindow:(RCTRedBoxWindow *)redBoxWindow sendTextToPasteboard:(NSString *)text {
+
+  // add the text to the local pasteboard on the device.
+  UIPasteboard *pb = [UIPasteboard generalPasteboard];
+  [pb setString:text];
+  
+  // if the bridge is connected, send the text to the packager so it can be added to the desktop
+  // clipboard too
   if (![_bridge.bundleURL.scheme hasPrefix:@"http"]) {
     RCTLogWarn(@"Cannot copy text to clipboard because you're not connected to the packager.");
     return;

--- a/local-cli/server/middleware/copyToClipboard.js
+++ b/local-cli/server/middleware/copyToClipboard.js
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+'use strict';
+
+
+module.exports = function(req, res, next) {
+  if (req.url === '/copy-to-clipboard') {
+  	var copyText = req.rawBody;
+  	if (process.platform === 'darwin') {
+	  	var proc = require('child_process').spawn('pbcopy'); 
+	  	proc.stdin.write(copyText); 
+	  	proc.stdin.end(); 
+	    res.end('OK');
+	  }
+  } else {
+    next();
+  }
+};
+
+

--- a/local-cli/server/middleware/copyToClipboard.js
+++ b/local-cli/server/middleware/copyToClipboard.js
@@ -12,12 +12,10 @@
 module.exports = function(req, res, next) {
   if (req.url === '/copy-to-clipboard') {
   	var copyText = req.rawBody;
-  	if (process.platform === 'darwin') {
-	  	var proc = require('child_process').spawn('pbcopy'); 
-	  	proc.stdin.write(copyText); 
-	  	proc.stdin.end(); 
+		var cp = require('copy-paste');
+		cp.copy(copyText, function () {
 	    res.end('OK');
-	  }
+		});
   } else {
     next();
   }

--- a/local-cli/server/runServer.js
+++ b/local-cli/server/runServer.js
@@ -17,6 +17,7 @@ const isAbsolutePath = require('absolute-path');
 const loadRawBodyMiddleware = require('./middleware/loadRawBodyMiddleware');
 const messageSocket = require('./util/messageSocket.js');
 const openStackFrameInEditorMiddleware = require('./middleware/openStackFrameInEditorMiddleware');
+const copyToClipboard = require('./middleware/copyToClipboard');
 const path = require('path');
 const ReactPackager = require('../../packager/react-packager');
 const statusPageMiddleware = require('./middleware/statusPageMiddleware.js');
@@ -33,6 +34,7 @@ function runServer(args, config, readyCallback) {
     .use(getDevToolsMiddleware(args, () => wsProxy && wsProxy.isChromeConnected()))
     .use(getDevToolsMiddleware(args, () => ms && ms.isChromeConnected()))
     .use(openStackFrameInEditorMiddleware)
+    .use(copyToClipboard)
     .use(statusPageMiddleware)
     .use(systraceProfileMiddleware)
     .use(cpuProfilerMiddleware)

--- a/package.json
+++ b/package.json
@@ -182,6 +182,7 @@
   },
   "devDependencies": {
     "babel-eslint": "^6.0.0",
+    "copy-paste": "1.1.3",
     "eslint": "^2.5.3",
     "eslint-plugin-flow-vars": "^0.2.1",
     "eslint-plugin-react": "^4.2.1",


### PR DESCRIPTION
Add the ability for the Copy option in the RedBox screen on iOS to send the text all the way to the desktop clipboard when running in the iOS Simulator on a Mac. The error message and stack are sent through the action delegate method which passes the text on to the packager. If the packager is running on MacOS, it uses pbcopy to copy that text to the Mac clipboard in the copyToClipboard middleware function. copyToClipboard could be extended to other platforms and should be usable by the Android implementation if someone adds Copy to the Android RedBox.

With this change, you no longer need to hit Cmd-C on the Mac after clicking the Copy button in the RedBox error screen, the text will be sent through to the Mac clipboard as long as the packager is running.

There are no written tests for this code, but it was verified by running pbpaste on the Mac to see the current value of the clipboard, clicking the Copy option in the error screen and then running pbpaste again to see that the clipboard now contains the proper stack trace.
