### PR TITLE
[Android] Fix for REFUSED_STREAM with Okhttp

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/modules/network/OkHttpClientProvider.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/network/OkHttpClientProvider.java
@@ -38,12 +38,23 @@ public class OkHttpClientProvider {
   }
 
   private static OkHttpClient createClient() {
+
+    // create a list of protocols the client will use to communicate
+    // by default, it will use the most efficient one, falling back to 
+    // more ubiquitous ones
+    // above as per okhttp javadocs
+    List<Protocol> protocolList = new ArrayList<>();
+    protocolList.add(Protocol.HTTP_2);
+    protocolList.add(Protocol.SPDY_3);
+    protocolList.add(Protocol.HTTP_1_1);
+
     // No timeouts by default
     return new OkHttpClient.Builder()
       .connectTimeout(0, TimeUnit.MILLISECONDS)
       .readTimeout(0, TimeUnit.MILLISECONDS)
       .writeTimeout(0, TimeUnit.MILLISECONDS)
       .cookieJar(new ReactCookieJarContainer())
+      .setProtocols(protocolList)
       .build();
   }
 }


### PR DESCRIPTION
Okhttp fails when there is `REFUSED_STREAM` in HTTP/2. This happens with newer versions of nginx that use HTTP/2. GET requests get processed correctly, however, for POST, it fails with nginx complaining that the client prematurely closed the stream.

`client sent stream with data before settings were acknowledged while processing HTTP/2 connection`

More info here - https://github.com/square/okhttp/issues/2543 and https://github.com/square/okhttp/issues/2506

Because of this, okhttp does not work with some of the newer nginx servers. 

The fix is to configure `OkHttpClient` with other protocols for it to use. Here's the fix -- https://github.com/wallabag/android-app/pull/256.

As per OkHttp's javadocs, 
> The client will prefer the most efficient transport available, falling back to more ubiquitous protocols.
>
> If multiple protocols are specified, <a href="http://tools.ietf.org/html/draft-ietf-tls-applayerprotoneg">ALPN</a> will be used to negotiate a transport.

This should make it work with them all nginx servers.