### PR TITLE
Tweaked how the TextInput works in order to fix autocorrect.

### DIFF
--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -606,21 +606,6 @@ var TextInput = React.createClass({
     var text = event.nativeEvent.text;
     this.props.onChange && this.props.onChange(event);
     this.props.onChangeText && this.props.onChangeText(text);
-
-    if (!this.refs.input) {
-      // calling `this.props.onChange` or `this.props.onChangeText`
-      // may clean up the input itself. Exits here.
-      return;
-    }
-
-    // This is necessary in case native updates the text and JS decides
-    // that the update should be ignored and we should stick with the value
-    // that we have in JS.
-    if (text !== this.props.value && typeof this.props.value === 'string') {
-      this.refs.input.setNativeProps({
-        text: this.props.value,
-      });
-    }
   },
 
   _onBlur: function(event: Event) {

--- a/Libraries/Text/RCTTextField.h
+++ b/Libraries/Text/RCTTextField.h
@@ -31,6 +31,7 @@
 
 - (void)textFieldDidChange;
 - (void)sendKeyValueForString:(NSString *)string;
+- (void)sendTextChangedForString:(NSString *)string;
 - (BOOL)textFieldShouldEndEditing:(RCTTextField *)textField;
 
 @end

--- a/Libraries/Text/RCTTextFieldManager.m
+++ b/Libraries/Text/RCTTextFieldManager.m
@@ -38,7 +38,7 @@ RCT_EXPORT_MODULE()
   }
 
   if ([string isEqualToString:@"\n"]) {  // Make sure forms can be submitted via return
-    return NO;
+    return YES;
   }
     
   if (textField.maxLength == nil) {

--- a/Libraries/Text/RCTTextFieldManager.m
+++ b/Libraries/Text/RCTTextFieldManager.m
@@ -56,7 +56,10 @@ RCT_EXPORT_MODULE()
     }
     return NO;
   } else {
-    return YES;
+    NSMutableString *newString = [textField.text stringByReplacingCharactersInRange:range withString:string];
+        
+    [textField sendTextChangedForString:newString];
+    return NO;
   }
 }
 

--- a/Libraries/Text/RCTTextFieldManager.m
+++ b/Libraries/Text/RCTTextFieldManager.m
@@ -37,7 +37,11 @@ RCT_EXPORT_MODULE()
     [textField sendKeyValueForString:string];
   }
 
-  if (textField.maxLength == nil || [string isEqualToString:@"\n"]) {  // Make sure forms can be submitted via return
+  if ([string isEqualToString:@"\n"]) {  // Make sure forms can be submitted via return
+    return NO;
+  }
+    
+  if (textField.maxLength == nil) {
     NSMutableString *newString = [textField.text stringByReplacingCharactersInRange:range withString:string];
       
     [textField sendTextChangedForString:newString];

--- a/Libraries/Text/RCTTextFieldManager.m
+++ b/Libraries/Text/RCTTextFieldManager.m
@@ -38,7 +38,10 @@ RCT_EXPORT_MODULE()
   }
 
   if (textField.maxLength == nil || [string isEqualToString:@"\n"]) {  // Make sure forms can be submitted via return
-    return YES;
+    NSMutableString *newString = [textField.text stringByReplacingCharactersInRange:range withString:string];
+      
+    [textField sendTextChangedForString:newString];
+    return NO;
   }
   NSUInteger allowedLength = textField.maxLength.integerValue - textField.text.length + range.length;
   if (string.length > allowedLength) {


### PR DESCRIPTION
This is the first attempt at resolving issue https://github.com/facebook/react-native/issues/7496 (Autocorrect basically doesn't work on iOS).

This makes a fairly drastic change to how the TextField handles input, this change makes the TextInput reject changes in native by default, the change event is sent to RN which then calls back to native and directly set's the text.

We will probably need to make similar changes on Android since it is a behavioural change but I haven't just yet as I'm not sure if this is the behaviour we want from the TextInput.

Open to input - let me know if anyone can think of alternate solutions.