### PR TITLE
Fix Linking Example

### DIFF
--- a/Examples/UIExplorer/LinkingExample.js
+++ b/Examples/UIExplorer/LinkingExample.js
@@ -19,7 +19,7 @@ var {
   Linking,
   StyleSheet,
   Text,
-  TouchableNativeFeedback,
+  TouchableOpacity,
   View,
 } = ReactNative;
 var UIExplorerBlock = require('./UIExplorerBlock');
@@ -42,12 +42,12 @@ var OpenURLButton = React.createClass({
 
   render: function() {
     return (
-      <TouchableNativeFeedback
+      <TouchableOpacity
         onPress={this.handleClick}>
         <View style={styles.button}>
           <Text style={styles.text}>Open {this.props.url}</Text>
         </View>
-      </TouchableNativeFeedback>
+      </TouchableOpacity>
     );
   }
 });


### PR DESCRIPTION
It seems like the examples weren't working since the merge of `IntentAndroid` and `LinkingIOS` since they were still using `TouchableNativeFeedback` only available on Android.

The problem was also reported here : https://github.com/facebook/react-native/issues/7615