### PR TITLE
cherry-pick NavigationPropTypes.SceneRenderer bugfix

### DIFF
--- a/Libraries/CustomComponents/NavigationExperimental/NavigationCard.js
+++ b/Libraries/CustomComponents/NavigationExperimental/NavigationCard.js
@@ -92,7 +92,7 @@ class NavigationCard extends React.Component<any, Props, any> {
   props: Props;
 
   static propTypes = {
-    ...NavigationPropTypes.SceneRenderer,
+    ...NavigationPropTypes.SceneRendererProps,
     onComponentRef: PropTypes.func.isRequired,
     panHandlers: NavigationPropTypes.panHandlers,
     pointerEvents: PropTypes.string.isRequired,

--- a/Libraries/CustomComponents/NavigationExperimental/NavigationHeader.js
+++ b/Libraries/CustomComponents/NavigationExperimental/NavigationHeader.js
@@ -95,7 +95,7 @@ class NavigationHeader extends React.Component<DefaultProps, Props, any> {
   };
 
   static propTypes = {
-    ...NavigationPropTypes.SceneRenderer,
+    ...NavigationPropTypes.SceneRendererProps,
     renderLeftComponent: PropTypes.func,
     renderRightComponent: PropTypes.func,
     renderTitleComponent: PropTypes.func,

--- a/Libraries/NavigationExperimental/NavigationPropTypes.js
+++ b/Libraries/NavigationExperimental/NavigationPropTypes.js
@@ -65,7 +65,7 @@ const scene = PropTypes.shape({
 });
 
 /* NavigationSceneRendererProps */
-const SceneRenderer = {
+const SceneRendererProps = {
   layout: layout.isRequired,
   navigationState: navigationParentState.isRequired,
   onNavigate: PropTypes.func.isRequired,
@@ -73,6 +73,8 @@ const SceneRenderer = {
   scene: scene.isRequired,
   scenes: PropTypes.arrayOf(scene).isRequired,
 };
+
+const SceneRenderer = PropTypes.shape(SceneRendererProps);
 
 /* NavigationPanPanHandlers */
 const panHandlers = PropTypes.shape({
@@ -111,11 +113,12 @@ module.exports = {
   extractSceneRendererProps,
 
   // Bundled propTypes.
-  SceneRenderer,
+  SceneRendererProps,
 
   // propTypes
   action,
   navigationParentState,
   navigationState,
   panHandlers,
+  SceneRenderer,
 };


### PR DESCRIPTION
cherry-pick 0e997c6eabae79c99823459b39b885547f824955 into 0.26-stable:
  fixes a bug where NavigationPropTypes.SceneRenderer was a plain object

re https://github.com/facebook/react-native/issues/7385