### PR TITLE
Correctly reference cwd instead of __dirname

### DIFF
--- a/local-cli/util/Config.js
+++ b/local-cli/util/Config.js
@@ -33,7 +33,7 @@ const Config = {
     const parentDir = findParentDirectory(cwd, RN_CLI_CONFIG);
     if (!parentDir && !defaultConfig) {
       throw new Error(
-        `Can't find "rn-cli.config.js" file in any parent folder of "${__dirname}"`
+        `Can't find "rn-cli.config.js" file in any parent folder of "${cwd}"`
       );
     }
 


### PR DESCRIPTION
This is for issue #7670.  I consider this a typo, but maybe you don't.

In order to see the problem, you need to have the packager search for the configuration in a place that doesn't have one and the default configuration can't be provided.  It's likely that no one is doing this and also why this probably wasn't seen.