### PR TITLE
Make Getting Started labels a bit more clear

### DIFF
--- a/docs/QuickStart-GettingStarted.md
+++ b/docs/QuickStart-GettingStarted.md
@@ -35,10 +35,10 @@ block { display: none; }
 .display-platform-android.display-os-windows .android.windows {
   display: block;
 }</style>
-<span>Platform:</span>
+<span>Target:</span>
 <a href="javascript:void(0);" class="button-ios" onclick="display('platform', 'ios')">iOS</a>
 <a href="javascript:void(0);" class="button-android" onclick="display('platform', 'android')">Android</a>
-<span>OS:</span>
+<span>Development OS:</span>
 <a href="javascript:void(0);" class="button-mac" onclick="display('os', 'mac')">Mac</a>
 <a href="javascript:void(0);" class="button-linux" onclick="display('os', 'linux')">Linux</a>
 <a href="javascript:void(0);" class="button-windows" onclick="display('os', 'windows')">Windows</a>


### PR DESCRIPTION
"Target" over "Platform" to represent target for your RN app
"Development OS" over "OS" to represent your RN Development environment

<img width="526" alt="screenshot 2016-05-21 09 48 47" src="https://cloud.githubusercontent.com/assets/3757713/15449679/87e1c9fa-1f39-11e6-99e9-822c2022c4db.png">
