### PR TITLE
Fix TextInput autocorrect (#7496)

### DIFF
--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -368,6 +368,7 @@ var TextInput = React.createClass({
   _focusSubscription: (undefined: ?Function),
 
   componentDidMount: function() {
+    this._lastNativeText = this.props.value;
     if (!this.context.focusEmitter) {
       if (this.props.autoFocus) {
         this.requestAnimationFrame(this.focus);
@@ -613,10 +614,15 @@ var TextInput = React.createClass({
       return;
     }
 
+    this._lastNativeText = text;
+    this.forceUpdate();
+  },
+
+  componentDidUpdate: function () {
     // This is necessary in case native updates the text and JS decides
     // that the update should be ignored and we should stick with the value
     // that we have in JS.
-    if (text !== this.props.value && typeof this.props.value === 'string') {
+    if (this._lastNativeText !== this.props.value && typeof this.props.value === 'string') {
       this.refs.input.setNativeProps({
         text: this.props.value,
       });


### PR DESCRIPTION
Autocorrect was broken for controlled TextInput components by a change to batch event handling in React Native:
https://github.com/facebook/react/commit/9f11f8c2634921e657df2691e6bfda18fead5bcc

For example, a TextInput like this would be affected by this bug:

```javascript
<TextInput
  autoCorrect={true}
  style={{height: 26, width: 100}}
  onChangeText={(text) => this.setState({ text })}
  value={this.state.text}
/>
```
This fix uses the same approach as
https://github.com/facebook/react-native/commit/0cd2904b235f53ed684bb9898280461e2cee0b5b

The problem is that TextInput's _onChange handler relied on this.props.value being updated synchronously when calling this.props.onChangeText(text). However, this assumption was broken when React Native event handling started being batched.

The fix is to move the code that relies on this.props.value being up-to-date to componentDidUpdate.

**Test plan (required)**

Tested autocorrect now works on iOS in a small app and a large app. Also tested that autocorrect works on Android in a small app (I'm not sure whether or not it was broken before this).

@spicyj, thanks for the tip about how to fix this bug. Here's my attempt at fixing it.

Adam Comella
Microsoft Corp