### PR TITLE
Add .iml to ignore target.

### DIFF
--- a/local-cli/generator/templates/_gitignore
+++ b/local-cli/generator/templates/_gitignore
@@ -24,6 +24,7 @@ project.xcworkspace
 
 # Android/IJ
 #
+*.iml
 .idea
 .gradle
 local.properties


### PR DESCRIPTION
Sorry for trivial one, but I feel no need to share '.iml' in a project, so it should be ignored.