### PR TITLE
Fixed Image#getSize not working with the same image twice

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/modules/image/ImageLoaderModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/image/ImageLoaderModule.java
@@ -83,7 +83,6 @@ public class ImageLoaderModule extends ReactContextBaseJavaModule {
               sizes.putInt("width", image.getWidth());
               sizes.putInt("height", image.getHeight());
 
-              image.close();
               promise.resolve(sizes);
             } catch (Exception e) {
               promise.reject(ERROR_GET_SIZE_FAILURE, e);


### PR DESCRIPTION
The getSize function closes the CloseableImage which is afaik not needed and results in the image not being available the second time.

**Test plan (required)**
I've tested this by adding more images to the Example. This didn't work before.

![screenshot_20160523-095707](https://cloud.githubusercontent.com/assets/570297/15463956/ccf171a0-20cc-11e6-90ca-2c206120bc5b.png)


