### PR TITLE
[Push notifications] Add error event

### DIFF
--- a/Libraries/PushNotificationIOS/PushNotificationIOS.js
+++ b/Libraries/PushNotificationIOS/PushNotificationIOS.js
@@ -21,6 +21,7 @@ var _initialNotification = RCTPushNotificationManager &&
 
 var DEVICE_NOTIF_EVENT = 'remoteNotificationReceived';
 var NOTIF_REGISTER_EVENT = 'remoteNotificationsRegistered';
+var NOTIF_REGISTER_ERROR_EVENT = 'remoteNotificationsRegisteredError';
 var DEVICE_LOCAL_NOTIF_EVENT = 'localNotificationReceived';
 
 /**
@@ -153,8 +154,8 @@ class PushNotificationIOS {
    */
   static addEventListener(type: string, handler: Function) {
     invariant(
-      type === 'notification' || type === 'register' || type === 'localNotification',
-      'PushNotificationIOS only supports `notification`, `register` and `localNotification` events'
+      type === 'notification' || type === 'register' || type === 'localNotification' || type === 'error',
+      'PushNotificationIOS only supports `notification`, `register`, `error` and `localNotification` events'
     );
     var listener;
     if (type === 'notification') {
@@ -176,6 +177,13 @@ class PushNotificationIOS {
         NOTIF_REGISTER_EVENT,
         (registrationInfo) => {
           handler(registrationInfo.deviceToken);
+        }
+      );
+    } else if(type === 'error'){
+      listener = RCTDeviceEventEmitter.addListener(
+        NOTIF_REGISTER_ERROR_EVENT,
+        (registrationError) => {
+          handler(registrationError);
         }
       );
     }
@@ -252,8 +260,8 @@ class PushNotificationIOS {
    */
   static removeEventListener(type: string, handler: Function) {
     invariant(
-      type === 'notification' || type === 'register' || type === 'localNotification',
-      'PushNotificationIOS only supports `notification`, `register` and `localNotification` events'
+      type === 'notification' || type === 'register' || type === 'localNotification' || type === 'error',
+      'PushNotificationIOS only supports `notification`, `register`, `error` and `localNotification` events'
     );
     var listener = _notifHandlers.get(handler);
     if (!listener) {

--- a/Libraries/PushNotificationIOS/PushNotificationIOS.js
+++ b/Libraries/PushNotificationIOS/PushNotificationIOS.js
@@ -21,7 +21,7 @@ var _initialNotification = RCTPushNotificationManager &&
 
 var DEVICE_NOTIF_EVENT = 'remoteNotificationReceived';
 var NOTIF_REGISTER_EVENT = 'remoteNotificationsRegistered';
-var NOTIF_REGISTER_ERROR_EVENT = 'remoteNotificationsRegisteredError';
+var NOTIF_REGISTER_ERROR_EVENT = 'remoteNotificationsRegistrationError';
 var DEVICE_LOCAL_NOTIF_EVENT = 'localNotificationReceived';
 
 /**
@@ -179,7 +179,7 @@ class PushNotificationIOS {
           handler(registrationInfo.deviceToken);
         }
       );
-    } else if(type === 'error'){
+    } else if (type === 'error'){
       listener = RCTDeviceEventEmitter.addListener(
         NOTIF_REGISTER_ERROR_EVENT,
         (registrationError) => {

--- a/Libraries/PushNotificationIOS/RCTPushNotificationManager.h
+++ b/Libraries/PushNotificationIOS/RCTPushNotificationManager.h
@@ -17,5 +17,6 @@
 + (void)didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken;
 + (void)didReceiveRemoteNotification:(NSDictionary *)notification;
 + (void)didReceiveLocalNotification:(UILocalNotification *)notification;
++ (void)didFailToRegisterForRemoteNotificationsWithError:(NSError *)error;
 
 @end

--- a/Libraries/PushNotificationIOS/RCTPushNotificationManager.m
+++ b/Libraries/PushNotificationIOS/RCTPushNotificationManager.m
@@ -27,6 +27,7 @@
 NSString *const RCTLocalNotificationReceived = @"LocalNotificationReceived";
 NSString *const RCTRemoteNotificationReceived = @"RemoteNotificationReceived";
 NSString *const RCTRemoteNotificationsRegistered = @"RemoteNotificationsRegistered";
+NSString *const RCTRemoteNotificationRegisteredError = @"RemoteNotificationRegisteredError";
 
 @implementation RCTConvert (UILocalNotification)
 
@@ -85,6 +86,10 @@ RCT_EXPORT_MODULE()
                                            selector:@selector(handleRemoteNotificationsRegistered:)
                                                name:RCTRemoteNotificationsRegistered
                                              object:nil];
+  [[NSNotificationCenter defaultCenter] addObserver:self
+                                           selector:@selector(handleRemoteNotificationRegisteredError:)
+                                               name:RCTRemoteNotificationRegisteredError
+                                             object:nil];
 }
 
 - (NSDictionary<NSString *, id> *)constantsToExport
@@ -135,6 +140,15 @@ RCT_EXPORT_MODULE()
                                                     userInfo:details];
 }
 
+
+
++ (void)didFailToRegisterForRemoteNotificationsWithError:(NSError *)error
+{
+  [[NSNotificationCenter defaultCenter] postNotificationName:RCTRemoteNotificationRegisteredError
+                                                      object:self
+                                                    userInfo:error.userInfo];
+}
+
 - (void)handleLocalNotificationReceived:(NSNotification *)notification
 {
   [_bridge.eventDispatcher sendDeviceEventWithName:@"localNotificationReceived"
@@ -151,6 +165,12 @@ RCT_EXPORT_MODULE()
 {
   [_bridge.eventDispatcher sendDeviceEventWithName:@"remoteNotificationsRegistered"
                                               body:notification.userInfo];
+}
+
+- (void)handleRemoteNotificationRegisteredError:(NSNotification *)notification
+{
+  [_bridge.eventDispatcher sendDeviceEventWithName:@"remoteNotificationsRegisteredError"
+                                              body:[notification userInfo]];
 }
 
 /**

--- a/Libraries/PushNotificationIOS/RCTPushNotificationManager.m
+++ b/Libraries/PushNotificationIOS/RCTPushNotificationManager.m
@@ -27,7 +27,7 @@
 NSString *const RCTLocalNotificationReceived = @"LocalNotificationReceived";
 NSString *const RCTRemoteNotificationReceived = @"RemoteNotificationReceived";
 NSString *const RCTRemoteNotificationsRegistered = @"RemoteNotificationsRegistered";
-NSString *const RCTRemoteNotificationRegisteredError = @"RemoteNotificationRegisteredError";
+NSString *const RCTRemoteNotificationsRegistrationError = @"RemoteNotificationsRegistrationError";
 
 @implementation RCTConvert (UILocalNotification)
 
@@ -87,8 +87,8 @@ RCT_EXPORT_MODULE()
                                                name:RCTRemoteNotificationsRegistered
                                              object:nil];
   [[NSNotificationCenter defaultCenter] addObserver:self
-                                           selector:@selector(handleRemoteNotificationRegisteredError:)
-                                               name:RCTRemoteNotificationRegisteredError
+                                           selector:@selector(handleRemoteNotificationsRegistrationError:)
+                                               name:RCTRemoteNotificationsRegistrationError
                                              object:nil];
 }
 
@@ -144,7 +144,7 @@ RCT_EXPORT_MODULE()
 
 + (void)didFailToRegisterForRemoteNotificationsWithError:(NSError *)error
 {
-  [[NSNotificationCenter defaultCenter] postNotificationName:RCTRemoteNotificationRegisteredError
+  [[NSNotificationCenter defaultCenter] postNotificationName:RCTRemoteNotificationsRegistrationError
                                                       object:self
                                                     userInfo:error.userInfo];
 }
@@ -167,10 +167,10 @@ RCT_EXPORT_MODULE()
                                               body:notification.userInfo];
 }
 
-- (void)handleRemoteNotificationRegisteredError:(NSNotification *)notification
+- (void)handleRemoteNotificationsRegistrationError:(NSNotification *)notification
 {
-  [_bridge.eventDispatcher sendDeviceEventWithName:@"remoteNotificationsRegisteredError"
-                                              body:[notification userInfo]];
+  [_bridge.eventDispatcher sendDeviceEventWithName:@"remoteNotificationsRegistrationError"
+                                              body:notification.userInfo];
 }
 
 /**


### PR DESCRIPTION
> This is PR is an updated version of: https://github.com/facebook/react-native/pull/2336 (closed)

This PR will add an `error` event to `PushNotificationIOS`.

**How does this work?**
The errors from `didFailToRegisterForRemoteNotificationsWithError` will be parsed to the `error` event in javascript. 

**Why is this useful?**
At the moment PushNotificationIOS fails silently and there is no way of telling if something went wrong. 
It would be very helpful to see the errors for debugging and in-app error handling. 

**How to use**
The error event can be used just like the register and the notification events.
The error callback will give the original error object from IOS. 

```js
PushNotificationIOS.addEventListener('error', function(error){
  // Example: {NSLocalizedDescription: "REMOTE_NOTIFICATION_SIMULATOR_NOT_SUPPORTED_NSERROR_DESCRIPTION"}
   console.log('An error occurred: ', error);
});
```

To use the `error` event in javascript add these line to your `AppDelegate.m`:
```objective-c
- (void)application:(UIApplication *)application didFailToRegisterForRemoteNotificationsWithError:(NSError *)error
{
  [RCTPushNotificationManager didFailToRegisterForRemoteNotificationsWithError:error];
}
```

**PR**
This is an new updated version of my 7 month closed old PR: https://github.com/facebook/react-native/pull/2336. I couldn't get the old branch updated without destroying the PR. I forked the master of react-native today and added back and updated all the code of the old PR. 

**TODO: Docs**
This event should be added to the docs and the website. Can someone tell me how I can accomplish this?

**TODO: Review**
Objective-C is not a language I use often. It would be appreciated if someone could review this PR :)