### PR TITLE
Fixed peer dependencies in package.json for npm@2

### DIFF
--- a/package.json
+++ b/package.json
@@ -191,7 +191,7 @@
     "flow-bin": "^0.25.0",
     "jest": "12.1.1",
     "portfinder": "0.4.0",
-    "react": "^15.1.0-alpha.1",
+    "react": "15.1.0-alpha.1",
     "shelljs": "0.6.0"
   }
 }


### PR DESCRIPTION
^ in react version caused npm installation errors in npm@2 https://travis-ci.org/facebook/react-native/builds/132153309

Test Plan:
- see Travis logs