### PR TITLE
Respect original enumerability/writability when polyfilling globals

### DIFF
--- a/Libraries/JavaScriptAppEngine/Initialization/InitializeJavaScriptAppEngine.js
+++ b/Libraries/JavaScriptAppEngine/Initialization/InitializeJavaScriptAppEngine.js
@@ -81,23 +81,25 @@ function polyfillGlobal(name, newValue, scope = global) {
 }
 
 function polyfillLazyGlobal(name, valueFn, scope = global) {
+  const descriptor = Object.getOwnPropertyDescriptor(scope, name);
   if (scope[name] !== undefined) {
-    const descriptor = Object.getOwnPropertyDescriptor(scope, name);
     const backupName = `original${name[0].toUpperCase()}${name.substr(1)}`;
     Object.defineProperty(scope, backupName, {...descriptor, value: scope[name]});
   }
 
+  const {enumerable, writable} = descriptor;
   Object.defineProperty(scope, name, {
     configurable: true,
-    enumerable: true,
+    enumerable !== false,
     get() {
       return (this[name] = valueFn());
     },
     set(value) {
       Object.defineProperty(this, name, {
         configurable: true,
-        enumerable: true,
-        value
+        enumerable !== false,
+        writable !== false,
+        value,
       });
     }
   });

--- a/Libraries/JavaScriptAppEngine/Initialization/InitializeJavaScriptAppEngine.js
+++ b/Libraries/JavaScriptAppEngine/Initialization/InitializeJavaScriptAppEngine.js
@@ -90,15 +90,15 @@ function polyfillLazyGlobal(name, valueFn, scope = global) {
   const {enumerable, writable} = descriptor;
   Object.defineProperty(scope, name, {
     configurable: true,
-    enumerable !== false,
+    enumerable: enumerable !== false,
     get() {
       return (this[name] = valueFn());
     },
     set(value) {
       Object.defineProperty(this, name, {
         configurable: true,
-        enumerable !== false,
-        writable !== false,
+        enumerable: enumerable !== false,
+        writable: writable !== false,
         value,
       });
     }

--- a/Libraries/JavaScriptAppEngine/Initialization/InitializeJavaScriptAppEngine.js
+++ b/Libraries/JavaScriptAppEngine/Initialization/InitializeJavaScriptAppEngine.js
@@ -81,7 +81,7 @@ function polyfillGlobal(name, newValue, scope = global) {
 }
 
 function polyfillLazyGlobal(name, valueFn, scope = global) {
-  const descriptor = Object.getOwnPropertyDescriptor(scope, name);
+  const descriptor = Object.getOwnPropertyDescriptor(scope, name) || {};
   if (scope[name] !== undefined) {
     const backupName = `original${name[0].toUpperCase()}${name.substr(1)}`;
     Object.defineProperty(scope, backupName, {...descriptor, value: scope[name]});


### PR DESCRIPTION
Reuses the original property descriptor when overwriting / polyfilling globals to ensure enumerability and writability are the same