### PR TITLE
Update RunningOnDeviceAndroid.md

### DIFF
--- a/docs/RunningOnDeviceAndroid.md
+++ b/docs/RunningOnDeviceAndroid.md
@@ -20,7 +20,7 @@ Check that your device has been **successfully connected** by running `adb devic
 
 Seeing **device** in the right column means the device is connected. Android - go figure :) You must have **only one device connected**.
 
-Now you can use `react-native run-android` to install and launch your app on the device.
+Now you can use `react-native run-android` to install and launch your app on the device. If you get a "bridge configuration isn't available" error, see the `Using adb reverse` section below.
 
 ## Setting up an Android Device
 


### PR DESCRIPTION
Add note associating error message to "adb reverse" command. When I first ran a React Native app on my Android phone, I received a cryptic "bridge configuration isn't available" error. After some research, I discovered that the "adb reverse" command mentioned further down on the page resolved the problem.