### PR TITLE
Expose Systrace from the 'react-native' package

### DIFF
--- a/Libraries/react-native/react-native.js
+++ b/Libraries/react-native/react-native.js
@@ -98,6 +98,7 @@ var ReactNative = {
   get Settings() { return require('Settings'); },
   get StatusBarIOS() { return require('StatusBarIOS'); },
   get StyleSheet() { return require('StyleSheet'); },
+  get Systrace() { return require('Systrace'); },
   get TimePickerAndroid() { return require('TimePickerAndroid'); },
   get UIManager() { return require('UIManager'); },
   get Vibration() { return require('Vibration'); },

--- a/Libraries/react-native/react-native.js.flow
+++ b/Libraries/react-native/react-native.js.flow
@@ -96,6 +96,7 @@ var ReactNative = Object.assign(Object.create(require('ReactNative')), {
   Settings: require('Settings'),
   StatusBarIOS: require('StatusBarIOS'),
   StyleSheet: require('StyleSheet'),
+  Systrace: require('Systrace'),
   TimePickerAndroid: require('TimePickerAndroid'),
   UIManager: require('UIManager'),
   Vibration: require('Vibration'),


### PR DESCRIPTION
This allows React Native apps to instrument their own code via Systrace.measureMethod() and the like.

**Test Plan:** Used require('react-native').Systrace in my own app successfully to instrument my own code.