### PR TITLE
Implement Linking listeners on Android

### DIFF
--- a/Libraries/Linking/Linking.js
+++ b/Libraries/Linking/Linking.js
@@ -75,8 +75,8 @@ const DEVICE_NOTIF_EVENT = 'openURL';
  *
  * ```
  *
- * And then on your React component you'll be able to listen to the events on
- * `Linking` as follows
+ * You can then listen on your React Component to new `Linking` events while
+ * your app is launched as follows
  *
  * ```
  * componentDidMount() {
@@ -89,7 +89,6 @@ const DEVICE_NOTIF_EVENT = 'openURL';
  *   console.log(event.url);
  * }
  * ```
- * Note that this is only supported on iOS.
  *
  * #### Opening external links
  *
@@ -114,45 +113,33 @@ class Linking {
   /**
    * Add a handler to Linking changes by listening to the `url` event type
    * and providing the handler
-   *
-   * @platform ios
    */
   static addEventListener(type: string, handler: Function) {
-    if (Platform.OS === 'android') {
-        console.warn('Linking.addEventListener is not supported on Android');
-    } else {
-      invariant(
-        type === 'url',
-        'Linking only supports `url` events'
-      );
-      var listener = RCTDeviceEventEmitter.addListener(
-        DEVICE_NOTIF_EVENT,
-        handler
-      );
-      _notifHandlers.set(handler, listener);
-    }
+    invariant(
+      type === 'url',
+      'Linking only supports `url` events'
+    );
+    var listener = RCTDeviceEventEmitter.addListener(
+      DEVICE_NOTIF_EVENT,
+      handler
+    );
+    _notifHandlers.set(handler, listener);
   }
 
   /**
    * Remove a handler by passing the `url` event type and the handler
-   *
-   * @platform ios
    */
-  static removeEventListener(type: string, handler: Function ) {
-    if (Platform.OS === 'android') {
-        console.warn('Linking.removeEventListener is not supported on Android');
-    } else {
-      invariant(
-        type === 'url',
-        'Linking only supports `url` events'
-      );
-      var listener = _notifHandlers.get(handler);
-      if (!listener) {
-        return;
-      }
-      listener.remove();
-      _notifHandlers.delete(handler);
+  static removeEventListener(type: string, handler: Function) {
+    invariant(
+      type === 'url',
+      'Linking only supports `url` events'
+    );
+    var listener = _notifHandlers.get(handler);
+    if (!listener) {
+      return;
     }
+    listener.remove();
+    _notifHandlers.delete(handler);
   }
 
   /**

--- a/ReactAndroid/src/main/java/com/facebook/react/ReactActivity.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactActivity.java
@@ -2,6 +2,7 @@ package com.facebook.react;
 
 import android.app.Activity;
 import android.content.Intent;
+import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
@@ -11,8 +12,12 @@ import android.widget.EditText;
 import android.widget.Toast;
 
 import com.facebook.common.logging.FLog;
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.common.ReactConstants;
 import com.facebook.react.modules.core.DefaultHardwareBackBtnHandler;
+import com.facebook.react.modules.core.DeviceEventManagerModule;
+import com.facebook.react.modules.intent.IntentModule;
 
 import java.util.List;
 
@@ -226,5 +231,20 @@ public abstract class ReactActivity extends Activity implements DefaultHardwareB
   @Override
   public void invokeDefaultOnBackPressed() {
     super.onBackPressed();
+  }
+
+  @Override
+  protected void onNewIntent(Intent intent) {
+    super.onNewIntent(intent);
+    Uri uri = intent.getData();
+
+    if (IntentModule.isLinkingIntent(intent) &&
+      mReactInstanceManager != null && mReactInstanceManager.getCurrentReactContext() != null) {
+      WritableMap map = Arguments.createMap();
+
+      map.putString("url", uri.toString());
+      mReactInstanceManager.getCurrentReactContext().getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
+        .emit("openURL", map);
+    }
   }
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/intent/IntentModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/intent/IntentModule.java
@@ -47,11 +47,9 @@ public class IntentModule extends ReactContextBaseJavaModule {
 
       if (currentActivity != null) {
         Intent intent = currentActivity.getIntent();
-        String action = intent.getAction();
-        Uri uri = intent.getData();
 
-        if (Intent.ACTION_VIEW.equals(action) && uri != null) {
-          initialURL = uri.toString();
+        if (isLinkingIntent(intent)) {
+          initialURL = intent.getDataString();
         }
       }
 
@@ -130,5 +128,12 @@ public class IntentModule extends ReactContextBaseJavaModule {
       promise.reject(new JSApplicationIllegalArgumentException(
           "Could not check if URL '" + url + "' can be opened: " + e.getMessage()));
     }
+  }
+
+  public static boolean isLinkingIntent(Intent intent) {
+    String action = intent.getAction();
+    Uri uri = intent.getData();
+
+    return (Intent.ACTION_VIEW.equals(action) && uri != null);
   }
 }


### PR DESCRIPTION
This PR aims to implement [`Linking` listeners](http://facebook.github.io/react-native/releases/0.26/docs/linking.html#handling-deep-links) on Android. It's relatively easy to do by hand, but since it's present on iOS I also implemented it on Android.

I'm not sure if passing a map containing an `url` attribute to the listener is necessary since it differs from [`getInitialUrl`](http://facebook.github.io/react-native/releases/0.26/docs/linking.html#getinitialurl) which returns only an url (string).
