### PR TITLE
Exclude react-native from subprojects (dependencies)

### DIFF
--- a/local-cli/rnpm/link/src/android/patches/makeBuildPatch.js
+++ b/local-cli/rnpm/link/src/android/patches/makeBuildPatch.js
@@ -1,6 +1,8 @@
 module.exports = function makeBuildPatch(name) {
   return {
     pattern: /[^ \t]dependencies {\n/,
-    patch: `    compile project(':${name}')\n`,
+    patch: `    compile project(':${name}') {
+        exclude group: 'com.facebook.react', module: 'react-native'
+    }`,
   };
 };

--- a/local-cli/rnpm/link/src/android/patches/makeBuildPatch.js
+++ b/local-cli/rnpm/link/src/android/patches/makeBuildPatch.js
@@ -3,6 +3,6 @@ module.exports = function makeBuildPatch(name) {
     pattern: /[^ \t]dependencies {\n/,
     patch: `    compile project(':${name}') {
         exclude group: 'com.facebook.react', module: 'react-native'
-    }`,
+    }\n`,
   };
 };

--- a/local-cli/rnpm/link/test/android/patches/makeBuildPatch.spec.js
+++ b/local-cli/rnpm/link/test/android/patches/makeBuildPatch.spec.js
@@ -11,7 +11,8 @@ describe('makeBuildPatch', () => {
   });
 
   it('should make a correct patch', () => {
-    expect(makeBuildPatch(name).patch)
-      .to.be.equal(`    compile project(':${name}')\n`);
+    expect(makeBuildPatch(name).patch).to.be.equal(`    compile project(':${name}') {
+        exclude group: 'com.facebook.react', module: 'react-native'
+    }`);
   });
 });

--- a/local-cli/rnpm/link/test/android/patches/makeBuildPatch.spec.js
+++ b/local-cli/rnpm/link/test/android/patches/makeBuildPatch.spec.js
@@ -13,6 +13,6 @@ describe('makeBuildPatch', () => {
   it('should make a correct patch', () => {
     expect(makeBuildPatch(name).patch).to.be.equal(`    compile project(':${name}') {
         exclude group: 'com.facebook.react', module: 'react-native'
-    }`);
+    }\n`);
   });
 });

--- a/local-cli/rnpm/link/test/android/patches/makeSettingsPatch.spec.js
+++ b/local-cli/rnpm/link/test/android/patches/makeSettingsPatch.spec.js
@@ -16,7 +16,7 @@ const dependencyConfig = {
 describe('makeSettingsPatch', () => {
   it('should build a patch function', () => {
     expect(
-      makeSettingsPatch(name, dependencyConfig, {}, projectConfig)
+      makeSettingsPatch(name, dependencyConfig, projectConfig)
     ).to.be.an('object');
   });
 

--- a/local-cli/rnpm/link/test/fixtures/android/patchedBuild.gradle
+++ b/local-cli/rnpm/link/test/fixtures/android/patchedBuild.gradle
@@ -1,5 +1,7 @@
 dependencies {
-    compile project(':test')
+    compile project(':test') {
+        exclude group: 'com.facebook.react', module: 'react-native'
+    }
     compile fileTree(dir: "libs", include: ["*.jar"])
     compile "com.android.support:appcompat-v7:23.0.1"
     compile "com.facebook.react:react-native:0.18.+"


### PR DESCRIPTION
## Motivation

This thread: https://github.com/facebook/react-native/pull/7470#issuecomment-221234691.

**TL;DR:** Everybody exclude react-native from subprojects (Android) manually. We can do it automatically during the builde.gradle patch.
## Test plan (required)
- [x] Run `rnpm` from `react-native` repo - project's build.gradle file should be patched using extra directives block:
  
  ``` gradle
  compile(project(':projectname')) {
      exclude group: 'com.facebook.react', module: 'react-native'
  }
  ```
