### PR TITLE
Support vscode as a React Editor

### DIFF
--- a/local-cli/server/middleware/openStackFrameInEditorMiddleware.js
+++ b/local-cli/server/middleware/openStackFrameInEditorMiddleware.js
@@ -10,12 +10,14 @@
 
 const launchEditor = require('../util/launchEditor');
 
-module.exports = function(req, res, next) {
-  if (req.url === '/open-stack-frame') {
-    var frame = JSON.parse(req.rawBody);
-    launchEditor(frame.file, frame.lineNumber);
-    res.end('OK');
-  } else {
-    next();
-  }
+module.exports = function(args) {
+  return function(req, res, next) {
+    if (req.url === '/open-stack-frame') {
+      var frame = JSON.parse(req.rawBody);
+      launchEditor(frame.file, frame.lineNumber, args['projectRoots']);
+      res.end('OK');
+    } else {
+      next();
+    }
+  };
 };

--- a/local-cli/server/runServer.js
+++ b/local-cli/server/runServer.js
@@ -32,7 +32,7 @@ function runServer(args, config, readyCallback) {
     .use(connect.compress())
     .use(getDevToolsMiddleware(args, () => wsProxy && wsProxy.isChromeConnected()))
     .use(getDevToolsMiddleware(args, () => ms && ms.isChromeConnected()))
-    .use(openStackFrameInEditorMiddleware)
+    .use(openStackFrameInEditorMiddleware(args))
     .use(statusPageMiddleware)
     .use(systraceProfileMiddleware)
     .use(cpuProfilerMiddleware)


### PR DESCRIPTION
When opening a text editor from react native there are a list of editors being supported. This PR adds `VSCode` to that.

As a difference with the current supported editors, `VSCode` has a notion of `workspace` (a directory that contains all of the project's files). The `workspace` can be passed to `VSCode` as a parameter so that if the workspace is already open we don't get new instances of `VSCode` every time a new file is open. The `workspace` is gotten by comparing the file location with the different `project roots`.

This code relies on `VSCode`'s `code` command, which it's documentation can be found at: https://code.visualstudio.com/Docs/editor/codebasics#_launching-from-the-command-line