### PR TITLE
Removing --reset-cache from bundle generation scripts

### DIFF
--- a/packager/react-native-xcode.sh
+++ b/packager/react-native-xcode.sh
@@ -72,6 +72,5 @@ $NODE_BINARY "$REACT_NATIVE_DIR/local-cli/cli.js" bundle \
   --entry-file index.ios.js \
   --platform ios \
   --dev $DEV \
-  --reset-cache true \
   --bundle-output "$DEST/main.jsbundle" \
   --assets-dest "$DEST"

--- a/react.gradle
+++ b/react.gradle
@@ -73,10 +73,10 @@ gradle.projectsEvaluated {
                 def devEnabled = !targetName.toLowerCase().contains("release")
                 if (Os.isFamily(Os.FAMILY_WINDOWS)) {
                     commandLine "cmd", "/c", "node", "node_modules/react-native/local-cli/cli.js", "bundle", "--platform", "android", "--dev", "${devEnabled}",
-                            "--reset-cache", "true", "--entry-file", entryFile, "--bundle-output", jsBundleFile, "--assets-dest", resourcesDir
+                            "--entry-file", entryFile, "--bundle-output", jsBundleFile, "--assets-dest", resourcesDir
                 } else {
                     commandLine "node", "node_modules/react-native/local-cli/cli.js", "bundle", "--platform", "android", "--dev", "${devEnabled}",
-                            "--reset-cache", "true", "--entry-file", entryFile, "--bundle-output", jsBundleFile, "--assets-dest", resourcesDir
+                            "--entry-file", entryFile, "--bundle-output", jsBundleFile, "--assets-dest", resourcesDir
                 }
 
                 enabled config."bundleIn${targetName}" ||


### PR DESCRIPTION
This PR proposes reverting the change made in https://github.com/facebook/react-native/commit/bb0653661637e907c13c4352d657974c5daf1513.

The problem I have observed with `--reset-cache` is that it generates a slightly different JS bundle each time you run `react-native bundle` with that flag, even though the JS code and other app assets have not been changed at all. Specifically, it appears that the module IDs are randomized each time.

![image](https://cloud.githubusercontent.com/assets/8598682/15551672/ef454f24-226b-11e6-9f61-bb0347fd9918.png)

If the `--reset-cache` is omitted, the generated JS bundle is always the same as long as the JS code files and assets are not updated. If they are updated, the JS bundle would be different, which is expected behaviour. I have seen on some occasions that a stale JS bundle might still get generated, however the workaround I have observed to always work in practice is running `rm -rf $TMPDIR/react-*` as recommended in https://github.com/facebook/react-native/issues/4289.

The reason why this behaviour is a problem is because in the CodePush plugin, we hash the contents of the JS bundle and assets and send the hash to the backend server to prevent the app from having to download an identical update from CodePush. Hashing also helps us to provide only the changed files to the app, so that the app doesn't have to always download a full version when only a subset of the files are changed, hence saving network resources. See https://github.com/Microsoft/react-native-code-push/issues/345 for more information. We rely on the behaviour that if the code files and assets are not changed, the exact same JS bundle should be deterministically generated every time. 

I don't have enough knowledge about the inner workings of `node-haste` to know why `--reset-cache` has this behaviour of randomizing module IDs (i'm guessing its something to do with parallel processing), so more information would be appreciated. However, since it seems to be causing problems such as this, I propose reverting https://github.com/facebook/react-native/commit/bb0653661637e907c13c4352d657974c5daf1513 and using a different workaround to the original problem it was trying to solve (such as using `rm -rf $TMPDIR/react-*` in the bundle generation scripts).