### PR TITLE
[docs][android] Fix Gradle setup in 'Integrating with existing apps'

### DIFF
--- a/docs/EmbeddedAppAndroid.md
+++ b/docs/EmbeddedAppAndroid.md
@@ -28,7 +28,7 @@ allprojects {
         ...
         maven {
             // All of React Native (JS, Android binaries) is installed from npm
-            url "$projectDir/node_modules/react-native/android"
+            url "$rootDir/node_modules/react-native/android"
         }
     }
     ...


### PR DESCRIPTION
Based on https://github.com/facebook/react-native/pull/7470, fixing the case when an existing Android app uses React Native as well as 3rd-party React Native modules.

With this PR Gradle should always pick up React Native binaries from node_modules rather than fetching old binaries from JCenter.