### PR TITLE
[feat] Add optional callback on Navigator.pop()

### DIFF
--- a/Libraries/CustomComponents/Navigator/Navigator.js
+++ b/Libraries/CustomComponents/Navigator/Navigator.js
@@ -937,7 +937,10 @@ var Navigator = React.createClass({
     });
   },
 
-  _popN: function(n) {
+  /**
+   * Pop `n` routes and optionally call `cb` when transition finished
+   */
+  _popN: function(n, cb) {
     if (n === 0) {
       return;
     }
@@ -956,14 +959,16 @@ var Navigator = React.createClass({
       null, // no spring jumping
       () => {
         this._cleanScenesPastIndex(popIndex);
+        cb && cb();
       }
     );
   },
 
   /**
    * Transition back and unmount the current scene.
+   * Optionally call `cb` when transition finished
    */
-  pop: function() {
+  pop: function(cb) {
     if (this.state.transitionQueue.length) {
       // This is the workaround to prevent user from firing multiple `pop()`
       // calls that may pop the routes beyond the limit.
@@ -975,8 +980,18 @@ var Navigator = React.createClass({
     }
 
     if (this.state.presentedIndex > 0) {
-      this._popN(1);
+      this._popN(1, cb);
     }
+  },
+
+  /**
+   * Pop current scene then, after transition, push new route
+   */
+  popAndPushToRoute(route){
+    invariant(!!route, 'Must supply route to push');
+    this.pop( () => {
+      this.push(route);
+    });
   },
 
   /**

--- a/Libraries/CustomComponents/Navigator/Navigator.js
+++ b/Libraries/CustomComponents/Navigator/Navigator.js
@@ -966,7 +966,7 @@ var Navigator = React.createClass({
 
   /**
    * Transition back and unmount the current scene.
-   * Optionally call `cb` when transition finished
+   * Optionally call `cb` when transition finished.
    */
   pop: function(cb) {
     if (this.state.transitionQueue.length) {
@@ -985,7 +985,7 @@ var Navigator = React.createClass({
   },
 
   /**
-   * Pop current scene then, after transition, push new route
+   * Pop current scene then, after transition, push new route.
    */
   popAndPushToRoute(route){
     invariant(!!route, 'Must supply route to push');


### PR DESCRIPTION
Basically I want to pop from the current scene and go to the next scene, but with the current API doing a ```navigator.pop()``` then ```navigator.push(route)``` will cause a error because the pop transition it's on course when I do a push. I could do a ```navigator.replace(route)``` but this executes without transition.

So this PR add a optional callback function to the pop method, so I can execute something after the transition end.  Something like:

```
let { navigator } = this.props;
navigator.pop( () => {
  navigator.push({ component: NextScene });
});
```

And I also add a helper method called popAndPushRoute, to the same thing above but more simply:

```
let { navigator } = this.props;
navigator.popAndPushToRoute({ component: NextScene });
```

Already tested on my app here, the code is pretty simple, if needed I can make a test repo using this method.