### PR TITLE
[podspec] Add C++ and standard v14 settings.

### DIFF
--- a/React.podspec
+++ b/React.podspec
@@ -29,95 +29,97 @@ Pod::Spec.new do |s|
   s.preserve_paths      = "cli.js", "Libraries/**/*.js", "lint", "linter.js", "node_modules", "package.json", "packager", "PATENTS", "react-native-cli"
 
   s.subspec 'Core' do |ss|
-    ss.source_files     = "React/**/*.{c,h,m,mm,S}"
-    ss.exclude_files    = "**/__tests__/*", "IntegrationTests/*"
-    ss.frameworks       = "JavaScriptCore"
+    ss.source_files        = "React/**/*.{c,h,m,mm,S}"
+    ss.exclude_files       = "**/__tests__/*", "IntegrationTests/*"
+    ss.frameworks          = "JavaScriptCore"
+    ss.libraries           = "stdc++"
+    ss.pod_target_xcconfig = { "CLANG_CXX_LANGUAGE_STANDARD" => "c++14" }
   end
 
   s.subspec 'ART' do |ss|
-    ss.dependency         'React/Core'
-    ss.source_files     = "Libraries/ART/**/*.{h,m}"
-    ss.preserve_paths   = "Libraries/ART/**/*.js"
+    ss.dependency       'React/Core'
+    ss.source_files   = "Libraries/ART/**/*.{h,m}"
+    ss.preserve_paths = "Libraries/ART/**/*.js"
   end
 
   s.subspec 'RCTActionSheet' do |ss|
-    ss.dependency         'React/Core'
-    ss.source_files     = "Libraries/ActionSheetIOS/*.{h,m}"
-    ss.preserve_paths   = "Libraries/ActionSheetIOS/*.js"
+    ss.dependency       'React/Core'
+    ss.source_files   = "Libraries/ActionSheetIOS/*.{h,m}"
+    ss.preserve_paths = "Libraries/ActionSheetIOS/*.js"
   end
 
   s.subspec 'RCTAdSupport' do |ss|
-    ss.dependency         'React/Core'
-    ss.source_files     = "Libraries/AdSupport/*.{h,m}"
-    ss.preserve_paths   = "Libraries/AdSupport/*.js"
+    ss.dependency       'React/Core'
+    ss.source_files   = "Libraries/AdSupport/*.{h,m}"
+    ss.preserve_paths = "Libraries/AdSupport/*.js"
   end
 
   s.subspec 'RCTCameraRoll' do |ss|
-    ss.dependency         'React/Core'
-    ss.dependency         'React/RCTImage'
-    ss.source_files     = "Libraries/CameraRoll/*.{h,m}"
-    ss.preserve_paths   = "Libraries/CameraRoll/*.js"
+    ss.dependency       'React/Core'
+    ss.dependency       'React/RCTImage'
+    ss.source_files   = "Libraries/CameraRoll/*.{h,m}"
+    ss.preserve_paths = "Libraries/CameraRoll/*.js"
   end
 
   s.subspec 'RCTGeolocation' do |ss|
-    ss.dependency         'React/Core'
-    ss.source_files     = "Libraries/Geolocation/*.{h,m}"
-    ss.preserve_paths   = "Libraries/Geolocation/*.js"
+    ss.dependency       'React/Core'
+    ss.source_files   = "Libraries/Geolocation/*.{h,m}"
+    ss.preserve_paths = "Libraries/Geolocation/*.js"
   end
 
   s.subspec 'RCTImage' do |ss|
-    ss.dependency         'React/Core'
-    ss.dependency         'React/RCTNetwork'
-    ss.source_files     = "Libraries/Image/*.{h,m}"
-    ss.preserve_paths   = "Libraries/Image/*.js"
+    ss.dependency       'React/Core'
+    ss.dependency       'React/RCTNetwork'
+    ss.source_files   = "Libraries/Image/*.{h,m}"
+    ss.preserve_paths = "Libraries/Image/*.js"
   end
 
   s.subspec 'RCTNetwork' do |ss|
-    ss.dependency         'React/Core'
-    ss.source_files     = "Libraries/Network/*.{h,m}"
-    ss.preserve_paths   = "Libraries/Network/*.js"
+    ss.dependency       'React/Core'
+    ss.source_files   = "Libraries/Network/*.{h,m}"
+    ss.preserve_paths = "Libraries/Network/*.js"
   end
 
   s.subspec 'RCTPushNotification' do |ss|
-    ss.dependency         'React/Core'
-    ss.source_files     = "Libraries/PushNotificationIOS/*.{h,m}"
-    ss.preserve_paths   = "Libraries/PushNotificationIOS/*.js"
+    ss.dependency       'React/Core'
+    ss.source_files   = "Libraries/PushNotificationIOS/*.{h,m}"
+    ss.preserve_paths = "Libraries/PushNotificationIOS/*.js"
   end
 
   s.subspec 'RCTSettings' do |ss|
-    ss.dependency         'React/Core'
-    ss.source_files     = "Libraries/Settings/*.{h,m}"
-    ss.preserve_paths   = "Libraries/Settings/*.js"
+    ss.dependency       'React/Core'
+    ss.source_files   = "Libraries/Settings/*.{h,m}"
+    ss.preserve_paths = "Libraries/Settings/*.js"
   end
 
   s.subspec 'RCTText' do |ss|
-    ss.dependency         'React/Core'
-    ss.source_files     = "Libraries/Text/*.{h,m}"
-    ss.preserve_paths   = "Libraries/Text/*.js"
+    ss.dependency       'React/Core'
+    ss.source_files   = "Libraries/Text/*.{h,m}"
+    ss.preserve_paths = "Libraries/Text/*.js"
   end
 
   s.subspec 'RCTVibration' do |ss|
-    ss.dependency         'React/Core'
-    ss.source_files     = "Libraries/Vibration/*.{h,m}"
-    ss.preserve_paths   = "Libraries/Vibration/*.js"
+    ss.dependency       'React/Core'
+    ss.source_files   = "Libraries/Vibration/*.{h,m}"
+    ss.preserve_paths = "Libraries/Vibration/*.js"
   end
 
   s.subspec 'RCTWebSocket' do |ss|
-    ss.dependency         'React/Core'
-    ss.source_files     = "Libraries/WebSocket/*.{h,m}"
-    ss.preserve_paths   = "Libraries/WebSocket/*.js"
+    ss.dependency       'React/Core'
+    ss.source_files   = "Libraries/WebSocket/*.{h,m}"
+    ss.preserve_paths = "Libraries/WebSocket/*.js"
   end
 
   s.subspec 'RCTLinkingIOS' do |ss|
-    ss.dependency         'React/Core'
-    ss.source_files     = "Libraries/LinkingIOS/*.{h,m}"
-    ss.preserve_paths   = "Libraries/LinkingIOS/*.js"
+    ss.dependency       'React/Core'
+    ss.source_files   = "Libraries/LinkingIOS/*.{h,m}"
+    ss.preserve_paths = "Libraries/LinkingIOS/*.js"
   end
 
   s.subspec 'RCTTest' do |ss|
-    ss.dependency         'React/Core'
-    ss.source_files     = "Libraries/RCTTest/**/*.{h,m}"
-    ss.preserve_paths   = "Libraries/RCTTest/**/*.js"
-    ss.frameworks       = "XCTest"
+    ss.dependency       'React/Core'
+    ss.source_files   = "Libraries/RCTTest/**/*.{h,m}"
+    ss.preserve_paths = "Libraries/RCTTest/**/*.js"
+    ss.frameworks     = "XCTest"
   end
 end


### PR DESCRIPTION
This PR adds the C++ stdlib to the linker flags and sets the C++ standard that’s used to v14.

I have tested this with my app, without it any CP build would fail unless users add those flags to the generated projects themselves.

/cc @grabbou 