### PR TITLE
Return empty bundle when passing an empty map to toBundle

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/Arguments.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/Arguments.java
@@ -154,9 +154,6 @@ public class Arguments {
     }
 
     ReadableMapKeySetIterator iterator = readableMap.keySetIterator();
-    if (!iterator.hasNextKey()) {
-      return null;
-    }
 
     Bundle bundle = new Bundle();
     while (iterator.hasNextKey()) {


### PR DESCRIPTION
(I swear this was working before...)

Right now, when passing an empty map to `toBundle` it returns null: 
- It feels counter-intuitive to have the data modified without any good reason;
- It is different from what iOS does

This PR fixes this behavior by returning an empty `Bundle` instead of `null`.

It is a breaking change though, and I'm not sure where it goes with the new bridge.