### PR TITLE
Typo fix in Touchable example

### DIFF
--- a/Examples/UIExplorer/TouchableExample.js
+++ b/Examples/UIExplorer/TouchableExample.js
@@ -333,7 +333,7 @@ var TouchableDisabled = React.createClass({
           style={[styles.row, styles.block]}
           onPress={() => console.log('custom THW text - highlight')}>
           <Text style={styles.button}>
-            Disabled TouchableHighlight
+            Enabled TouchableHighlight
           </Text>
         </TouchableHighlight>
 


### PR DESCRIPTION
**Test plan**

Run UIExplorer example and see that enabled TouchableHighlight example has correct text.

![image](https://cloud.githubusercontent.com/assets/2266187/15682555/2117ec9a-2713-11e6-9272-b868a8d8d705.png)