### PR TITLE
Android: allow app/build.gradle to specify additional packager arguments

### DIFF
--- a/local-cli/generator-android/templates/src/app/build.gradle
+++ b/local-cli/generator-android/templates/src/app/build.gradle
@@ -55,7 +55,10 @@ import com.android.build.OutputFile
  *   // date; if you have any other folders that you want to ignore for performance reasons (gradle
  *   // indexes the entire tree), add them here. Alternatively, if you have JS files in android/
  *   // for example, you might want to remove it from here.
- *   inputExcludes: ["android/**", "ios/**"]
+ *   inputExcludes: ["android/**", "ios/**"],
+ *
+ *   // supply additional arguments to the packager
+ *   extraPackagerArgs: []
  * ]
  */
 

--- a/react.gradle
+++ b/react.gradle
@@ -49,6 +49,9 @@ gradle.projectsEvaluated {
             // Bundle task name for variant
             def bundleJsAndAssetsTaskName = "bundle${targetName}JsAndAssets"
 
+            // Additional packager commandline arguments
+            def extraPackagerArgs = config.extraPackagerArgs ?: []
+
             def currentBundleTask = tasks.create(
                     name: bundleJsAndAssetsTaskName,
                     type: Exec) {
@@ -72,11 +75,11 @@ gradle.projectsEvaluated {
                 // Set up dev mode
                 def devEnabled = !targetName.toLowerCase().contains("release")
                 if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-                    commandLine "cmd", "/c", "node", "node_modules/react-native/local-cli/cli.js", "bundle", "--platform", "android", "--dev", "${devEnabled}",
-                            "--reset-cache", "true", "--entry-file", entryFile, "--bundle-output", jsBundleFile, "--assets-dest", resourcesDir
+                    commandLine("cmd", "/c", "node", "node_modules/react-native/local-cli/cli.js", "bundle", "--platform", "android", "--dev", "${devEnabled}",
+                            "--reset-cache", "true", "--entry-file", entryFile, "--bundle-output", jsBundleFile, "--assets-dest", resourcesDir, *extraPackagerArgs)
                 } else {
-                    commandLine "node", "node_modules/react-native/local-cli/cli.js", "bundle", "--platform", "android", "--dev", "${devEnabled}",
-                            "--reset-cache", "true", "--entry-file", entryFile, "--bundle-output", jsBundleFile, "--assets-dest", resourcesDir
+                    commandLine("node", "node_modules/react-native/local-cli/cli.js", "bundle", "--platform", "android", "--dev", "${devEnabled}",
+                            "--reset-cache", "true", "--entry-file", entryFile, "--bundle-output", jsBundleFile, "--assets-dest", resourcesDir, *extraPackagerArgs)
                 }
 
                 enabled config."bundleIn${targetName}" ||


### PR DESCRIPTION
If for instance you're using a custom transformer, having this hook will let you specify it without forking all of react.gradle

**Test plan:** Specified some additional packager args in my app's `android/app/build.gradle`:
```groovy
project.ext.react = [
  bundleInDebug: true,
  extraPackagerArgs: ["--transformer", "path/to/my/transformer.js"]
]
```
and ensured they show up when gradle invokes the bundler.