### PR TITLE
Tweak dev menu label: Stop Remote JS Debugging

### DIFF
--- a/React/Modules/RCTDevMenu.m
+++ b/React/Modules/RCTDevMenu.m
@@ -466,7 +466,7 @@ RCT_EXPORT_MODULE()
   } else {
     BOOL isDebuggingJS = _executorClass && _executorClass == jsDebuggingExecutorClass;
     NSString *debuggingDescription = [_defaults objectForKey:@"websocket-executor-name"] ?: @"Remote JS";
-    NSString *debugTitleJS = isDebuggingJS ? [NSString stringWithFormat:@"Disable %@ Debugging", debuggingDescription] : [NSString stringWithFormat:@"Debug %@", _webSocketExecutorName];
+    NSString *debugTitleJS = isDebuggingJS ? [NSString stringWithFormat:@"Stop %@ Debugging", debuggingDescription] : [NSString stringWithFormat:@"Debug %@", _webSocketExecutorName];
     [items addObject:[RCTDevMenuItem buttonItemWithTitle:debugTitleJS handler:^{
       weakSelf.executorClass = isDebuggingJS ? Nil : jsDebuggingExecutorClass;
     }]];

--- a/ReactAndroid/src/main/res/devsupport/values/strings.xml
+++ b/ReactAndroid/src/main/res/devsupport/values/strings.xml
@@ -2,7 +2,7 @@
 <resources>
   <string name="catalyst_reloadjs" project="catalyst" translatable="false">Reload</string>
   <string name="catalyst_debugjs" project="catalyst" translatable="false">Debug JS Remotely</string>
-  <string name="catalyst_debugjs_off" project="catalyst" translatable="false">Disable Remote JS Debugging</string>
+  <string name="catalyst_debugjs_off" project="catalyst" translatable="false">Stop Remote JS Debugging</string>
   <string name="catalyst_hot_module_replacement" project="catalyst" translatable="false">Enable Hot Reloading</string>
   <string name="catalyst_hot_module_replacement_off" project="catalyst" translatable="false">Disable Hot Reloading</string>
   <string name="catalyst_live_reload" project="catalyst" translatable="false">Enable Live Reload</string>


### PR DESCRIPTION
"Stop" is a bit clearer - the debugger is started and stopped, rather than enabled / disabled. Small difference :)

In contrast, live reloading and hot reloading are enabled and disabled.

@satya164 pointed it out in [this comment](https://github.com/facebook/react-native/commit/31eea8eee3bd904065b06c639321dbc2cea1ca55#commitcomment-17682563) and I agree.

**Test Plan**

Ran the UIExplorer:

<img width="432" alt="screen shot 2016-05-31 at 11 11 28 pm" src="https://cloud.githubusercontent.com/assets/346214/15692439/473c26b6-2786-11e6-969a-d494067cbc3b.png">

On Android the change is kind of obvious :)