### PR TITLE
Pin down React version on v26

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "react-native": "local-cli/wrong-react-native.js"
   },
   "peerDependencies": {
-    "react": "15.0.2"
+    "react": "~15.0.2"
   },
   "dependencies": {
     "absolute-path": "^0.0.0",


### PR DESCRIPTION
React 15.1 is not compatible with v26, so prevent people from getting a bad experience on a fresh react-native install.