### PR TITLE
don't clobber user-defined environment variables

### DIFF
--- a/local-cli/bundle/buildBundle.js
+++ b/local-cli/bundle/buildBundle.js
@@ -22,10 +22,6 @@ function saveBundle(output, bundle, args) {
 function buildBundle(args, config, output = outputBundle, packagerInstance) {
   return new Promise((resolve, reject) => {
 
-    // This is used by a bazillion of npm modules we don't control so we don't
-    // have other choice than defining it as an env variable here.
-    process.env.NODE_ENV = args.dev ? 'development' : 'production';
-
     const options = {
       projectRoots: config.getProjectRoots(),
       assetRoots: config.getAssetRoots(),


### PR DESCRIPTION
If I want to set `NODE_ENV` to "baconator", I should be allowed to. Mutating global state that most devs assume to be immutable is just abysmal dev practice, especially since this mutation only happens when you're building for prod, not running on the simulator.

To test this, run `env NODE_ENV=baconator ./gradlew assembleRelease` with [babel-plugin-transform-inline-environment-variables](https://www.npmjs.com/package/babel-plugin-transform-inline-environment-variables) in your `app/.babelrc`. You'll see that the final app has `NODE_ENV=production`.

As a side note, running with babel-plugin-transform-inline-environment-variables in the top-level `.babelrc` crashes horribly with a compiler error.

For anybody who runs into this bug and doesn't feel like waiting for this to get merged, I wrote a quick [babel plugin](https://www.npmjs.com/package/babel-remove-process-env-assignment) to remove assignments to `process.env`, which is sufficient to fix this issue.