### PR TITLE
Made react installed via reac-native init strict to unbreak 15.1.0

### DIFF
--- a/local-cli/generator/index.js
+++ b/local-cli/generator/index.js
@@ -107,6 +107,6 @@ module.exports = yeoman.generators.NamedBase.extend({
       return;
     }
 
-    this.npmInstall(`react@${reactVersion}`, { '--save': true });
+    this.npmInstall(`react@${reactVersion}`, { '--save': true, '--save-exact': true });
   }
 });

--- a/react-native-cli/index.js
+++ b/react-native-cli/index.js
@@ -213,11 +213,11 @@ function getInstallPackage(rnPackage) {
 }
 
 function run(root, projectName, rnPackage) {
-  exec('npm install --save ' + getInstallPackage(rnPackage), function(e, stdout, stderr) {
+  exec('npm install --save --save-exact ' + getInstallPackage(rnPackage), function(e, stdout, stderr) {
     if (e) {
       console.log(stdout);
       console.error(stderr);
-      console.error('`npm install --save react-native` failed');
+      console.error('`npm install --save --save-exact react-native` failed');
       process.exit(1);
     }
 
@@ -229,10 +229,10 @@ function run(root, projectName, rnPackage) {
 }
 
 function runVerbose(root, projectName, rnPackage) {
-  var proc = spawn('npm', ['install', '--verbose', '--save', getInstallPackage(rnPackage)], {stdio: 'inherit'});
+  var proc = spawn('npm', ['install', '--verbose', '--save', '--save-exact', getInstallPackage(rnPackage)], {stdio: 'inherit'});
   proc.on('close', function (code) {
     if (code !== 0) {
-      console.error('`npm install --save react-native` failed');
+      console.error('`npm install --save --save-exact react-native` failed');
       return;
     }
 

--- a/react-native-cli/package.json
+++ b/react-native-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-cli",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "license": "BSD-3-Clause",
   "description": "The React Native CLI tools",
   "main": "index.js",


### PR DESCRIPTION
React@15.1.0 is incompatible with React-Native@0.26.
This PR was cherry-picked to 0.26-stable branch now.

What this change does:
- react-native-cli (major release bump) saves exact versions of react-native and react (only in npm2) dependencies into package.json
- local-cli saves exact version of react (only npm3) dependency into package.json 

Test Plan:
- both npm2 and npm 3
- react-native init TestApp
- verify that TestApp/package.json has strict "react": "15.0.2" and "react-native": "0.26.3"