### PR TITLE
Fix instructions so react-native packages are installed first

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -1,8 +1,19 @@
-# Run the website server
+# Install prerequisites
 
-The first time, get all the dependencies loaded via
+Before running the website, make sure you've run the following:
 
 ```sh
+git clone https://github.com/facebook/react-native.git
+cd react-native
+npm install
+```
+
+# Run the website server
+
+The first time, get all the website dependencies loaded via
+
+```sh
+cd website
 npm install
 ```
 
@@ -21,4 +32,3 @@ Anytime you change the contents, just refresh the page and it's going to be upda
 cd website
 npm run publish-website
 ```
-


### PR DESCRIPTION
Post React 15.x one of the files pulled in for documentation reside in that repo: NativeMethodsMixin.js

This ensures that developers install react-native packages first (which includes React) so the file can be found when it's referenced in server/extractDocs.js

**Test plan (required)**

1. Ran through the instructions.
2. Made sure http://localhost:8079/react-native/docs/nativemethodsmixin.html exists in the nav and is shows correctly.

