### PR TITLE
Updated onValueChange to include the property.

### DIFF
--- a/Examples/UIExplorer/PickerIOSExample.js
+++ b/Examples/UIExplorer/PickerIOSExample.js
@@ -82,7 +82,7 @@ var PickerExample = React.createClass({
         <Text>Please choose a make for your car:</Text>
         <PickerIOS
           selectedValue={this.state.carMake}
-          onValueChange={(carMake) => this.setState({carMake, modelIndex: 0})}>
+          onValueChange={(carMake) => this.setState({pickerValue: carMake, modelIndex: 0})}>
           {Object.keys(CAR_MAKES_AND_MODELS).map((carMake) => (
             <PickerItemIOS
               key={carMake}


### PR DESCRIPTION
 **motivation** 
***What existing problem does the pull request solve?***
The existing problem this pull request solves is that the demo for the picker does not properly select new values. If left alone, the picker goes back to its original value and doesn't stay on the option the user selected. This addition will keep the new selection in the correct place.

**Test plan (required)**

Include a Picker in any react-native project.. If you try selecting any of its options, it always returns to its original point. With this edit, it will stay on the newly selected option/value. 

**Changes**
Updated `onValueChange={(carMake) => this.setState({carMake, modelIndex: 0})}`
to
`onValueChange={(carMake) => this.setState({pickerValue: carMake, modelIndex: 0})}`
Because the property being updated must be specified inside of the setState function. Without this property, the picker always returns to its starting index as soon as it stops being dragged.