### PR TITLE
Android: allow app/build.gradle to specify how node gets invoked for the packager

### DIFF
--- a/local-cli/generator-android/templates/src/app/build.gradle
+++ b/local-cli/generator-android/templates/src/app/build.gradle
@@ -57,6 +57,9 @@ import com.android.build.OutputFile
  *   // for example, you might want to remove it from here.
  *   inputExcludes: ["android/**", "ios/**"],
  *
+ *   // override which node gets called and with what additional arguments
+ *   nodeExecutableAndArgs: ["node"]
+ *
  *   // supply additional arguments to the packager
  *   extraPackagerArgs: []
  * ]

--- a/react.gradle
+++ b/react.gradle
@@ -49,7 +49,8 @@ gradle.projectsEvaluated {
             // Bundle task name for variant
             def bundleJsAndAssetsTaskName = "bundle${targetName}JsAndAssets"
 
-            // Additional packager commandline arguments
+            // Additional node and packager commandline arguments
+            def nodeExecutableAndArgs = config.nodeExecutableAndArgs ?: ["node"]
             def extraPackagerArgs = config.extraPackagerArgs ?: []
 
             def currentBundleTask = tasks.create(
@@ -75,10 +76,10 @@ gradle.projectsEvaluated {
                 // Set up dev mode
                 def devEnabled = !targetName.toLowerCase().contains("release")
                 if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-                    commandLine("cmd", "/c", "node", "node_modules/react-native/local-cli/cli.js", "bundle", "--platform", "android", "--dev", "${devEnabled}",
+                    commandLine("cmd", "/c", *nodeExecutableAndArgs, "node_modules/react-native/local-cli/cli.js", "bundle", "--platform", "android", "--dev", "${devEnabled}",
                             "--reset-cache", "true", "--entry-file", entryFile, "--bundle-output", jsBundleFile, "--assets-dest", resourcesDir, *extraPackagerArgs)
                 } else {
-                    commandLine("node", "node_modules/react-native/local-cli/cli.js", "bundle", "--platform", "android", "--dev", "${devEnabled}",
+                    commandLine(*nodeExecutableAndArgs, "node_modules/react-native/local-cli/cli.js", "bundle", "--platform", "android", "--dev", "${devEnabled}",
                             "--reset-cache", "true", "--entry-file", entryFile, "--bundle-output", jsBundleFile, "--assets-dest", resourcesDir, *extraPackagerArgs)
                 }
 


### PR DESCRIPTION
**Test plan:** With the given patch applied to `react.gradle`, I specified the following in my `android/app/build.gradle`:
```
project.ext.react = [
  nodeExecutableAndArgs: ["node", "--max_old_space_size=4096"]
]
```
and ensured in a `./gradlew installDebug --debug` run that the packager gets indeed invoked with these parameters.