### PR TITLE
Update the documenation of ActionSheetIOS to include all possible options

### DIFF
--- a/Libraries/ActionSheetIOS/ActionSheetIOS.js
+++ b/Libraries/ActionSheetIOS/ActionSheetIOS.js
@@ -44,10 +44,13 @@ var ActionSheetIOS = {
 
   /**
    * Display the iOS share sheet. The `options` object should contain
-   * one or both of:
+   * one or both of `message` and `url` and can additionally have 
+   * a `subject` or `excludedActivityTypes`:
    *
-   * - `message` (string) - a message to share
    * - `url` (string) - a URL to share
+   * - `message` (string) - a message to share
+   * - `subject` (string) - a subject for the message
+   * - `excludedActivityTypes` (array) - the activites to exclude from the ActionSheet
    *
    * NOTE: if `url` points to a local file, or is a base64-encoded
    * uri, the file it points to will be loaded and shared directly.


### PR DESCRIPTION
As it is shown in the examples, `subject` and `excludedActivityTypes` should be part of the documentation. `excludedActivityTypes` could be completed by a list of all possible options (see [UIActivity](https://developer.apple.com/library/ios/documentation/UIKit/Reference/UIActivity_Class/#//apple_ref/doc/constant_group/Built_in_Activity_Types) documentation of Apple).

Screenshots of updated documentation:
![actionsheetios](https://cloud.githubusercontent.com/assets/12033337/15772879/0e54ca98-2974-11e6-9af5-df76c093ec5a.png)
