### PR TITLE
Fix the Origin: header used in WebSocket requests.

### DIFF
--- a/Libraries/WebSocket/RCTSRWebSocket.m
+++ b/Libraries/WebSocket/RCTSRWebSocket.m
@@ -1565,10 +1565,14 @@ static const size_t RCTSRFrameHeaderOverhead = 32;
     scheme = @"http";
   }
 
-  if (self.port) {
-    return [NSString stringWithFormat:@"%@://%@:%@/", scheme, self.host, self.port];
+  int defaultPort = ([scheme isEqualToString:@"https"] ? 443 :
+                     [scheme isEqualToString:@"http"] ? 80 :
+                     -1);
+  int port = self.port.intValue;
+  if (port > 0 && port != defaultPort) {
+    return [NSString stringWithFormat:@"%@://%@:%d", scheme, self.host, port];
   } else {
-    return [NSString stringWithFormat:@"%@://%@/", scheme, self.host];
+    return [NSString stringWithFormat:@"%@://%@", scheme, self.host];
   }
 }
 


### PR DESCRIPTION
RFC 6454 section 7 defines the Origin: header syntax, and it's a
scheme, host, and optional port, not a URL.

Section 6 defines serialization of the header, including omission of the
port.

Therefore, we need to omit the trailing slash in all cases, and omit
the port if it matches the default port for the protocol.

Test plan: Existing WebSocket tests pass as before.  However, this is a change that is not exposed to the Javascript layer at all, so there's currently no unit test for it, and I haven't added one.
