### PR TITLE
Add $(inherited) to OTHER_LDFLAGS in xcodeproj template

### DIFF
--- a/local-cli/generator-ios/templates/xcodeproj/project.pbxproj
+++ b/local-cli/generator-ios/templates/xcodeproj/project.pbxproj
@@ -615,6 +615,7 @@
 				INFOPLIST_FILE = "<%= name %>/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
         OTHER_LDFLAGS = (
+					"$(inherited)",
           "-ObjC",
           "-lc++",
         );
@@ -634,6 +635,7 @@
 				INFOPLIST_FILE = "<%= name %>/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
         OTHER_LDFLAGS = (
+					"$(inherited)",
           "-ObjC",
           "-lc++",
         );


### PR DESCRIPTION
This is particularly important when using generated xcode project together with cocoapods (or anything that leverages a custom xcconfig)

If we do not set `$(inherited)`, then user will get cryptic "Symbol(s) not found for architecture ..." errors that will be really difficult to track down, especially for beginners. This happens because without setting `$(inherited)` we are essentially overriding settings provided on project level (rather than target level) as well as `.xcconfig` level.

**Test plan (required)**

```bash
react-native init MyProject
cd ios
pod init
```
Now go and add a pod to the `Podfile`, say
```ruby
pod 'HockeySDK'
```
And try to use it in `AppDelegate.m`
```objc
#import <HockeySDK/HockeySDK.h>
...
[[BITHockeyManager sharedHockeyManager] configureWithIdentifier:@"APP_IDENTIFIER"];
[[BITHockeyManager sharedHockeyManager] startManager];
```

Before this change, you'll get errors like this
![image](https://cloud.githubusercontent.com/assets/696842/15801450/feb3c036-2a49-11e6-9174-b4e73c8fbf74.png)

After this change, the build will succeed.