### PR TITLE
Added ReactCommon to package.json to allow for building locally

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "React",
     "React.podspec",
     "ReactAndroid",
+    "ReactCommon",
     "react.gradle",
     "android",
     "Libraries",


### PR DESCRIPTION
This pull request solves an error building from source as noted in https://github.com/facebook/react-native/issues/7911 and https://github.com/facebook/react-native/pull/7118. The error says BUILD FAILED due to cxxreact module not found. Previously the ReactCommon folder was excluded when installed from npm. There may be a better way to include this folder, but I'm unfamiliar with FB's build process.  

**Test plan (required)**

Create a new sample project by npm init, npm install --save https://github.com/opensports/react-native.git. Then run react-native run-android and the project should build successfully.