### PR TITLE
[Android] fix cleanReactNdkLib task failure caused by module not found 

### DIFF
--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -200,6 +200,8 @@ task buildReactNdkLib(dependsOn: [prepareJSC, prepareBoost, prepareDoubleConvers
 
 task cleanReactNdkLib(type: Exec) {
     commandLine getNdkBuildFullPath(),
+            "NDK_APPLICATION_MK=$projectDir/src/main/jni/Application.mk",
+            "THIRD_PARTY_NDK_DIR=$buildDir/third-party-ndk",
             '-C', file('src/main/jni/react/jni').absolutePath,
             'clean'
 }


### PR DESCRIPTION
The `clean` task always fail due to the failure of the `cleanReactNdkLib` task, error messages:

```
:ReactAndroid:cleanReactNdkLib
Android NDK: /my/react-native/ReactAndroid/src/main/jni/react/jni/Android.mk: Cannot find module with tag 'react' in import path
Android NDK: Are you sure your NDK_MODULE_PATH variable is properly defined ?
Android NDK: The following directories were searched:
Android NDK:
make: Entering directory `/my/react-native/ReactAndroid/src/main/jni/react/jni'
make: Leaving directory `/my/react-native/ReactAndroid/src/main/jni/react/jni'
/my/react-native/ReactAndroid/src/main/jni/react/jni/Android.mk:31: *** Android NDK: Aborting.    .  Stop.
:ReactAndroid:cleanReactNdkLib FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':ReactAndroid:cleanReactNdkLib'.
> Process 'command '/usr/local/opt/android-ndk/ndk-build'' finished with non-zero exit value 2

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output.

BUILD FAILED

Total time: 9.059 secs
```
Fixed it by specifying the location of `Application.mk` and `THIRD_PARTY_NDK_DIR`, same as the `buildReactNdkLib` task.