### PR TITLE
Add get scheduled local notifications

### DIFF
--- a/Libraries/PushNotificationIOS/PushNotificationIOS.js
+++ b/Libraries/PushNotificationIOS/PushNotificationIOS.js
@@ -143,6 +143,13 @@ class PushNotificationIOS {
   }
 
   /**
+   * Gets the local notifications that are currently scheduled.
+   */
+  static scheduledLocalNotifications(callback: Function) {
+    RCTPushNotificationManager.scheduledLocalNotifications(callback);
+  }
+
+  /**
    * Attaches a listener to remote or local notification events while the app is running
    * in the foreground or the background.
    *

--- a/Libraries/PushNotificationIOS/PushNotificationIOS.js
+++ b/Libraries/PushNotificationIOS/PushNotificationIOS.js
@@ -145,8 +145,8 @@ class PushNotificationIOS {
   /**
    * Gets the local notifications that are currently scheduled.
    */
-  static scheduledLocalNotifications(callback: Function) {
-    RCTPushNotificationManager.scheduledLocalNotifications(callback);
+  static getScheduledLocalNotifications(callback: Function) {
+    RCTPushNotificationManager.getScheduledLocalNotifications(callback);
   }
 
   /**

--- a/Libraries/PushNotificationIOS/RCTPushNotificationManager.m
+++ b/Libraries/PushNotificationIOS/RCTPushNotificationManager.m
@@ -72,7 +72,7 @@ static NSDictionary *formatLocalNotification(UILocalNotification *notification)
   formattedLocalNotification[@"category"] = RCTNullIfNil(notification.category);
   formattedLocalNotification[@"soundName"] = RCTNullIfNil(notification.soundName);
   formattedLocalNotification[@"userInfo"] = RCTNullIfNil(RCTJSONClean(notification.userInfo));
-  return [NSDictionary dictionaryWithDictionary:formattedLocalNotification];
+  return formattedLocalNotification;
 }
 
 RCT_EXPORT_MODULE()
@@ -324,7 +324,6 @@ RCT_EXPORT_METHOD(getInitialNotification:(RCTPromiseResolveBlock)resolve
 }
 
 RCT_EXPORT_METHOD(getScheduledLocalNotifications:(RCTResponseSenderBlock)callback)
-
 {
   NSArray<UILocalNotification *> *scheduledLocalNotifications = [UIApplication sharedApplication].scheduledLocalNotifications;
   NSMutableArray *formattedScheduledLocalNotifications = [[NSMutableArray alloc] init];

--- a/Libraries/PushNotificationIOS/RCTPushNotificationManager.m
+++ b/Libraries/PushNotificationIOS/RCTPushNotificationManager.m
@@ -57,6 +57,28 @@ NSString *const RCTErrorUnableToRequestPermissions = @"E_UNABLE_TO_REQUEST_PERMI
 
 @implementation RCTPushNotificationManager
 
++ (NSMutableDictionary *)formatLocalNotification:(UILocalNotification *)notification
+{
+  NSMutableDictionary *formattedLocalNotification = [NSMutableDictionary dictionary];
+  
+  if (notification.fireDate) {
+    NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
+    [formatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ"];
+    NSString *fireDateString = [formatter stringFromDate:notification.fireDate];
+    
+    formattedLocalNotification[@"fireDate"] = fireDateString;
+  }
+  
+  formattedLocalNotification[@"alertAction"]                = RCTNullIfNil(notification.alertAction);
+  formattedLocalNotification[@"alertBody"]                  = RCTNullIfNil(notification.alertBody);
+  formattedLocalNotification[@"applicationIconBadgeNumber"] = RCTNullIfNil(@(notification.applicationIconBadgeNumber));
+  formattedLocalNotification[@"category"]                   = RCTNullIfNil(notification.category);
+  formattedLocalNotification[@"soundName"]                  = RCTNullIfNil(notification.soundName);
+  formattedLocalNotification[@"userInfo"]                   = RCTNullIfNil(RCTJSONClean(notification.userInfo));
+  
+  return formattedLocalNotification;
+}
+
 RCT_EXPORT_MODULE()
 
 - (void)startObserving
@@ -306,51 +328,18 @@ RCT_EXPORT_METHOD(getInitialNotification:(RCTPromiseResolveBlock)resolve
 }
 
 RCT_EXPORT_METHOD(getScheduledLocalNotifications:(RCTResponseSenderBlock)callback)
+
 {
   NSArray<UILocalNotification *> *scheduledLocalNotifications = [UIApplication sharedApplication].scheduledLocalNotifications;
-
-
+  
   NSMutableArray *formattedScheduledLocalNotifications = [[NSMutableArray alloc] init];
-
+  
   for (UILocalNotification *notification in scheduledLocalNotifications) {
-
-    NSMutableDictionary *formattedScheduledLocalNotification = [NSMutableDictionary dictionary];
-
-    if (notification.fireDate) {
-      NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
-      [formatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ"];
-      NSString *fireDateString = [formatter stringFromDate:notification.fireDate];
-
-      formattedScheduledLocalNotification[@"fireDate"] = fireDateString;
-    }
-
-    if (notification.alertBody) {
-      formattedScheduledLocalNotification[@"alertBody"] = notification.alertBody;
-    }
-
-    if (notification.alertAction) {
-      formattedScheduledLocalNotification[@"alertAction"] = notification.alertAction;
-    }
-
-    if (notification.soundName) {
-      formattedScheduledLocalNotification[@"soundName"] = notification.soundName;
-    }
-
-    if (notification.category) {
-      formattedScheduledLocalNotification[@"category"] = notification.category;
-    }
-
-    if (notification.applicationIconBadgeNumber) {
-      formattedScheduledLocalNotification[@"applicationIconBadgeNumber"] = @(notification.applicationIconBadgeNumber);
-    }
-
-    if (notification.userInfo) {
-      formattedScheduledLocalNotification[@"userInfo"] = RCTJSONClean(notification.userInfo);
-    }
-
-    [formattedScheduledLocalNotifications addObject:formattedScheduledLocalNotification];
+    
+    [formattedScheduledLocalNotifications addObject:[RCTPushNotificationManager formatLocalNotification:notification]];
+    
   }
-
+  
   callback(@[formattedScheduledLocalNotifications]);
 }
 

--- a/Libraries/PushNotificationIOS/RCTPushNotificationManager.m
+++ b/Libraries/PushNotificationIOS/RCTPushNotificationManager.m
@@ -305,4 +305,53 @@ RCT_EXPORT_METHOD(getInitialNotification:(RCTPromiseResolveBlock)resolve
   resolve(RCTNullIfNil(initialNotification));
 }
 
+RCT_EXPORT_METHOD(scheduledLocalNotifications:(RCTResponseSenderBlock)callback)
+{
+  NSArray<UILocalNotification *> *scheduledLocalNotifications = [UIApplication sharedApplication].scheduledLocalNotifications;
+
+
+  NSMutableArray *formattedScheduledLocalNotifications = [[NSMutableArray alloc] init];
+
+  for (UILocalNotification *notification in scheduledLocalNotifications) {
+
+    NSMutableDictionary* formattedScheduledLocalNotification = [NSMutableDictionary dictionary];
+
+    if (notification.fireDate) {
+      NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
+      [formatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ"];
+      NSString *fireDateString = [formatter stringFromDate:notification.fireDate];
+
+      [formattedScheduledLocalNotification setObject: fireDateString forKey:@"fireDate"];
+    }
+
+    if (notification.alertBody) {
+      [formattedScheduledLocalNotification setObject: notification.alertBody forKey:@"alertBody"];
+    }
+
+    if (notification.alertAction) {
+      [formattedScheduledLocalNotification setObject: notification.alertAction forKey:@"alertAction"];
+    }
+
+    if (notification.soundName) {
+      [formattedScheduledLocalNotification setObject: notification.soundName forKey:@"soundName"];
+    }
+
+    if (notification.category) {
+      [formattedScheduledLocalNotification setObject: notification.category forKey:@"category"];
+    }
+
+    if (notification.applicationIconBadgeNumber) {
+      [formattedScheduledLocalNotification setObject: [NSNumber numberWithInteger:notification.applicationIconBadgeNumber] forKey:@"applicationIconBadgeNumber"];
+    }
+
+    if (notification.userInfo) {
+      [formattedScheduledLocalNotification setObject: notification.userInfo forKey:@"userInfo"];
+    }
+
+    [formattedScheduledLocalNotifications addObject:formattedScheduledLocalNotification];
+  }
+
+  callback(@[formattedScheduledLocalNotifications]);
+}
+
 @end

--- a/Libraries/PushNotificationIOS/RCTPushNotificationManager.m
+++ b/Libraries/PushNotificationIOS/RCTPushNotificationManager.m
@@ -57,26 +57,22 @@ NSString *const RCTErrorUnableToRequestPermissions = @"E_UNABLE_TO_REQUEST_PERMI
 
 @implementation RCTPushNotificationManager
 
-+ (NSMutableDictionary *)formatLocalNotification:(UILocalNotification *)notification
+static NSDictionary *formatLocalNotification(UILocalNotification *notification)
 {
   NSMutableDictionary *formattedLocalNotification = [NSMutableDictionary dictionary];
-  
   if (notification.fireDate) {
     NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
     [formatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ"];
     NSString *fireDateString = [formatter stringFromDate:notification.fireDate];
-    
     formattedLocalNotification[@"fireDate"] = fireDateString;
   }
-  
-  formattedLocalNotification[@"alertAction"]                = RCTNullIfNil(notification.alertAction);
-  formattedLocalNotification[@"alertBody"]                  = RCTNullIfNil(notification.alertBody);
-  formattedLocalNotification[@"applicationIconBadgeNumber"] = RCTNullIfNil(@(notification.applicationIconBadgeNumber));
-  formattedLocalNotification[@"category"]                   = RCTNullIfNil(notification.category);
-  formattedLocalNotification[@"soundName"]                  = RCTNullIfNil(notification.soundName);
-  formattedLocalNotification[@"userInfo"]                   = RCTNullIfNil(RCTJSONClean(notification.userInfo));
-  
-  return formattedLocalNotification;
+  formattedLocalNotification[@"alertAction"] = RCTNullIfNil(notification.alertAction);
+  formattedLocalNotification[@"alertBody"] = RCTNullIfNil(notification.alertBody);
+  formattedLocalNotification[@"applicationIconBadgeNumber"] = @(notification.applicationIconBadgeNumber);
+  formattedLocalNotification[@"category"] = RCTNullIfNil(notification.category);
+  formattedLocalNotification[@"soundName"] = RCTNullIfNil(notification.soundName);
+  formattedLocalNotification[@"userInfo"] = RCTNullIfNil(RCTJSONClean(notification.userInfo));
+  return [NSDictionary dictionaryWithDictionary:formattedLocalNotification];
 }
 
 RCT_EXPORT_MODULE()
@@ -331,15 +327,10 @@ RCT_EXPORT_METHOD(getScheduledLocalNotifications:(RCTResponseSenderBlock)callbac
 
 {
   NSArray<UILocalNotification *> *scheduledLocalNotifications = [UIApplication sharedApplication].scheduledLocalNotifications;
-  
   NSMutableArray *formattedScheduledLocalNotifications = [[NSMutableArray alloc] init];
-  
   for (UILocalNotification *notification in scheduledLocalNotifications) {
-    
-    [formattedScheduledLocalNotifications addObject:[RCTPushNotificationManager formatLocalNotification:notification]];
-    
+    [formattedScheduledLocalNotifications addObject:formatLocalNotification(notification)];
   }
-  
   callback(@[formattedScheduledLocalNotifications]);
 }
 

--- a/Libraries/PushNotificationIOS/RCTPushNotificationManager.m
+++ b/Libraries/PushNotificationIOS/RCTPushNotificationManager.m
@@ -305,7 +305,7 @@ RCT_EXPORT_METHOD(getInitialNotification:(RCTPromiseResolveBlock)resolve
   resolve(RCTNullIfNil(initialNotification));
 }
 
-RCT_EXPORT_METHOD(scheduledLocalNotifications:(RCTResponseSenderBlock)callback)
+RCT_EXPORT_METHOD(getScheduledLocalNotifications:(RCTResponseSenderBlock)callback)
 {
   NSArray<UILocalNotification *> *scheduledLocalNotifications = [UIApplication sharedApplication].scheduledLocalNotifications;
 

--- a/Libraries/PushNotificationIOS/RCTPushNotificationManager.m
+++ b/Libraries/PushNotificationIOS/RCTPushNotificationManager.m
@@ -314,38 +314,38 @@ RCT_EXPORT_METHOD(getScheduledLocalNotifications:(RCTResponseSenderBlock)callbac
 
   for (UILocalNotification *notification in scheduledLocalNotifications) {
 
-    NSMutableDictionary* formattedScheduledLocalNotification = [NSMutableDictionary dictionary];
+    NSMutableDictionary *formattedScheduledLocalNotification = [NSMutableDictionary dictionary];
 
     if (notification.fireDate) {
       NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
       [formatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ"];
       NSString *fireDateString = [formatter stringFromDate:notification.fireDate];
 
-      [formattedScheduledLocalNotification setObject: fireDateString forKey:@"fireDate"];
+      formattedScheduledLocalNotification[@"fireDate"] = fireDateString;
     }
 
     if (notification.alertBody) {
-      [formattedScheduledLocalNotification setObject: notification.alertBody forKey:@"alertBody"];
+      formattedScheduledLocalNotification[@"alertBody"] = notification.alertBody;
     }
 
     if (notification.alertAction) {
-      [formattedScheduledLocalNotification setObject: notification.alertAction forKey:@"alertAction"];
+      formattedScheduledLocalNotification[@"alertAction"] = notification.alertAction;
     }
 
     if (notification.soundName) {
-      [formattedScheduledLocalNotification setObject: notification.soundName forKey:@"soundName"];
+      formattedScheduledLocalNotification[@"soundName"] = notification.soundName;
     }
 
     if (notification.category) {
-      [formattedScheduledLocalNotification setObject: notification.category forKey:@"category"];
+      formattedScheduledLocalNotification[@"category"] = notification.category;
     }
 
     if (notification.applicationIconBadgeNumber) {
-      [formattedScheduledLocalNotification setObject: [NSNumber numberWithInteger:notification.applicationIconBadgeNumber] forKey:@"applicationIconBadgeNumber"];
+      formattedScheduledLocalNotification[@"applicationIconBadgeNumber"] = @(notification.applicationIconBadgeNumber);
     }
 
     if (notification.userInfo) {
-      [formattedScheduledLocalNotification setObject: notification.userInfo forKey:@"userInfo"];
+      formattedScheduledLocalNotification[@"userInfo"] = RCTJSONClean(notification.userInfo);
     }
 
     [formattedScheduledLocalNotifications addObject:formattedScheduledLocalNotification];


### PR DESCRIPTION
_(This is a remake of #6907, which I botched pretty good with a rebase.)_

This returns an `Array` of Local Notifications that have been scheduled to be delivered.

Available attributes on return Notification object (if set in the local notification itself):

`alertAction`
`alertBody`
`applicationIconBadgeNumber`
`category`
`fireDate`
`soundName`
`userInfo`

More could be added to this but I just matched what was available in the `Object` passed to `presentLocalNotification` and `scheduleLocalNotification`.

**Motivation**

I needed to determine the number and other details about local notifications that were already scheduled. There is an API for this in iOS but one hadn't been built yet for React Native.

I created the Obj-C method and updated the documentation in `PushNotificationIOS.js` as well.

**Usage:**

```js
PushNotificationIOS.getScheduledLocalNotifications( (notifications) => {
  console.log(notifications);
});
```

**Sample Output:**

```js
[
  Object {
    alertBody: "It's about time you check in with Aaron, eh?", 
    applicationIconBadgeNumber: 2, 
    soundName: "UILocalNotificationDefaultSoundName", 
    fireDate: "2016-04-10T14:43:45.755-06:00", 
    userInfo: Object {
      id: 5 
    }
  }
]
```