### PR TITLE
Convert warning about keystore into warning block in SignedAPKAndroid.md

### DIFF
--- a/docs/SignedAPKAndroid.md
+++ b/docs/SignedAPKAndroid.md
@@ -35,9 +35,11 @@ MYAPP_RELEASE_KEY_PASSWORD=*****
 
 These are going to be global gradle variables, which we can later use in our gradle config to sign our app.
 
-_Note about saving the keystore: Once you publish the app on the Play Store, you will need to republish your app under a different package name (losing all downloads and ratings) if you want to change the signing key at any point. So backup your keystore and don't forget the passwords._
+> __Note about saving the keystore:__
 
-_Note about security: If you are not keen on storing your passwords in plaintext and you are running OSX, you can also [store your credentials in the Keychain Access app](https://pilloxa.gitlab.io/posts/safer-passwords-in-gradle/). Then you can skip the two last rows in `~/.gradle/gradle.properties`._ 
+> Once you publish the app on the Play Store, you will need to republish your app under a different package name (losing all downloads and ratings) if you want to change the signing key at any point. So backup your keystore and don't forget the passwords.
+
+_Note about security: If you are not keen on storing your passwords in plaintext and you are running OSX, you can also [store your credentials in the Keychain Access app](https://pilloxa.gitlab.io/posts/safer-passwords-in-gradle/). Then you can skip the two last rows in `~/.gradle/gradle.properties`._
 
 
 ### Adding signing config to your app's gradle config


### PR DESCRIPTION
The current docs page [Generating a Signed APK](https://facebook.github.io/react-native/docs/signed-apk-android.html) contains a note about keeping your generated keystore safe, but this isn't well highlighted.

This commit highlights the notice in a warning blockquote to ensure people following the guide don't miss the importance of keeping the keystore safe as shown below:

<img width="666" alt="screen shot 2016-06-06 at 10 01 25" src="https://cloud.githubusercontent.com/assets/1863808/15817245/10e4e6d2-2bcf-11e6-9fe8-defc8a6ec93c.png">
