### PR TITLE
Incorrect import reference of emptyFunction causes error when importi…

### DIFF
--- a/Libraries/Experimental/SwipeableRow/SwipeableRow.js
+++ b/Libraries/Experimental/SwipeableRow/SwipeableRow.js
@@ -31,7 +31,7 @@ const View = require('View');
 
 const {PropTypes} = React;
 
-const emptyFunction = require('emptyFunction');
+const emptyFunction = require('fbjs/lib/emptyFunction');
 
 // Position of the left of the swipable item when closed
 const CLOSED_LEFT_POSITION = 0;


### PR DESCRIPTION
Experimental component SwipeableListView fails to import due to incorrect import reference.  Followed example use of import of emptyFunction found in https://github.com/facebook/react-native/blob/master/Libraries/Components/TextInput/TextInput.js#L31
