### PR TITLE
Properly validate layout animation config

### DIFF
--- a/Libraries/LayoutAnimation/LayoutAnimation.js
+++ b/Libraries/LayoutAnimation/LayoutAnimation.js
@@ -40,7 +40,7 @@ var animChecker = createStrictShapeTypeChecker({
   initialVelocity: PropTypes.number,
   type: PropTypes.oneOf(
     Object.keys(Types)
-  ),
+  ).isRequired,
   property: PropTypes.oneOf( // Only applies to create/delete
     Object.keys(Properties)
   ),

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/AbstractLayoutAnimation.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/AbstractLayoutAnimation.java
@@ -61,8 +61,10 @@ import com.facebook.react.uimanager.IllegalViewOperationException;
         AnimatedPropertyType.fromString(data.getString("property")) : null;
     mDurationMs = data.hasKey("duration") ? data.getInt("duration") : globalDuration;
     mDelayMs = data.hasKey("delay") ? data.getInt("delay") : 0;
-    mInterpolator = data.hasKey("type") ?
-        getInterpolator(InterpolatorType.fromString(data.getString("type"))) : null;
+    if (!data.hasKey("type")) {
+      throw new IllegalArgumentException("Missing interpolation type.");
+    }
+    mInterpolator = getInterpolator(InterpolatorType.fromString(data.getString("type")));
 
     if (!isValid()) {
       throw new IllegalViewOperationException("Invalid layout animation : " + data);


### PR DESCRIPTION
The type key for a layout animation config must be supplied otherwise the app crashes (on Android). I added a isRequired check in JS as well as an explicit exception in java otherwise it crashed at a very hard to debug place. The crash happens when passing null to `Animation.setInterpolator` so this makes sure it never happens.

**Test plan (required)**

Tested that the error is caught properly in JS when passing an invalid animation config like

```
LayoutAnimation.configureNext({
  duration: 250,
   update: { type: undefined }, // or LayoutAnimation.Types.easeInEastOut in my case haha :)
});
```

Also tested the java exception.
