### PR TITLE
Fix LayoutAnimation Android bug when adding and removing views at the same time

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/LayoutAnimationController.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/LayoutAnimationController.java
@@ -2,6 +2,9 @@
 
 package com.facebook.react.uimanager.layoutanimation;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -28,6 +31,8 @@ public class LayoutAnimationController {
   private final AbstractLayoutAnimation mLayoutUpdateAnimation = new LayoutUpdateAnimation();
   private final AbstractLayoutAnimation mLayoutDeleteAnimation = new LayoutDeleteAnimation();
   private boolean mShouldAnimateLayout;
+
+  private List<View> mDeleteAnimatedViews = new ArrayList<>();
 
   public void initializeFromConfig(final @Nullable ReadableMap config) {
     if (!ENABLED) {
@@ -136,6 +141,41 @@ public class LayoutAnimationController {
     } else {
       listener.onAnimationEnd();
     }
+  }
+
+  /**
+   * Add a view to list of views that are being deleted with an animation.
+   *
+   * @param view View to add
+   */
+  public void addViewAnimatingDeletion(View view) {
+    mDeleteAnimatedViews.add(view);
+  }
+
+  /**
+   * Remove a view to list of views that are being deleted with an animation.
+   *
+   * @param view View to remove
+   */
+  public void removeViewAnimatingDeletion(View view) {
+    mDeleteAnimatedViews.remove(view);
+  }
+
+  /**
+   * Returns if the view is being deleted with an animation.
+   *
+   * @param view View to check
+   * @return If it is being animated
+   */
+  public boolean isViewAnimatingDeletion(View view) {
+    return mDeleteAnimatedViews.contains(view);
+  }
+
+  /**
+   * Returns if there are any view being deleted with an animation.
+   */
+  public boolean isAnimatingViewDeletion() {
+    return mDeleteAnimatedViews.size() > 0;
   }
 
   /**


### PR DESCRIPTION
Similar to #7942 but for android

Fix a bug that happens when views are added during a delete layout animation. What happens is that the inserted view is not inserted at the proper index if the deleted view index is smaller than the inserted one. This is because the view is not immediately removed from the subviews array so we need to offset the insert index for each view that is going to be deleted with an animation and is before the inserted view.

Test plan (required)
Tested that this fixed the bug in an app where I noticed it, also tested the UIExplorer example to make sure LayoutAnimations still worked properly.
