### PR TITLE
Allow rn-cli.config.js to specify the default transformer

### DIFF
--- a/local-cli/bundle/buildBundle.js
+++ b/local-cli/bundle/buildBundle.js
@@ -32,12 +32,16 @@ function buildBundle(args, config, output = outputBundle, packagerInstance) {
       process.env.NODE_ENV = args.dev ? 'development' : 'production';
     }
 
+    const transformModulePath = args.transformer ?
+      path.resolve(args.transformer) :
+      config.getTransformModulePath();
+
     const options = {
       projectRoots: config.getProjectRoots(),
       assetRoots: config.getAssetRoots(),
       blacklistRE: config.getBlacklistRE(args.platform),
       getTransformOptionsModulePath: config.getTransformOptionsModulePath,
-      transformModulePath: path.resolve(args.transformer),
+      transformModulePath: transformModulePath,
       extraNodeModules: config.extraNodeModules,
       nonPersistent: true,
       resetCache: args['reset-cache'],

--- a/local-cli/bundle/bundleCommandLineArgs.js
+++ b/local-cli/bundle/bundleCommandLineArgs.js
@@ -22,7 +22,7 @@ module.exports = [
     command: 'transformer',
     description: 'Specify a custom transformer to be used',
     type: 'string',
-    default: require.resolve('../../packager/transformer'),
+    default: null,
   }, {
     command: 'dev',
     description: 'If false, warnings are disabled and the bundle is minified',

--- a/local-cli/default.config.js
+++ b/local-cli/default.config.js
@@ -30,7 +30,15 @@ var config = {
    */
   getBlacklistRE(platform) {
     return blacklist(platform);
-  }
+  },
+
+  /**
+   * Returns the path to a custom transformer. This can also be overridden
+   * with the --transformer commandline argument.
+   */
+  getTransformModulePath() {
+    return require.resolve('../packager/transformer');
+  },
 };
 
 function getRoots() {

--- a/local-cli/dependencies/dependencies.js
+++ b/local-cli/dependencies/dependencies.js
@@ -40,7 +40,7 @@ function _dependencies(argv, config, resolve, reject, packagerInstance) {
     }, {
       command: 'transformer',
       type: 'string',
-      default: require.resolve('../../packager/transformer'),
+      default: null,
       description: 'Specify a custom transformer to be used'
     }, {
       command: 'verbose',
@@ -54,12 +54,16 @@ function _dependencies(argv, config, resolve, reject, packagerInstance) {
     reject(`File ${rootModuleAbsolutePath} does not exist`);
   }
 
+  const transformModulePath = args.transformer ?
+    path.resolve(args.transformer) :
+    config.getTransformModulePath();
+
   const packageOpts = {
     projectRoots: config.getProjectRoots(),
     assetRoots: config.getAssetRoots(),
     blacklistRE: config.getBlacklistRE(args.platform),
     getTransformOptionsModulePath: config.getTransformOptionsModulePath,
-    transformModulePath: path.resolve(args.transformer),
+    transformModulePath: transformModulePath,
     extraNodeModules: config.extraNodeModules,
     verbose: config.verbose,
   };

--- a/local-cli/server/runServer.js
+++ b/local-cli/server/runServer.js
@@ -67,13 +67,17 @@ function runServer(args, config, readyCallback) {
 }
 
 function getPackagerServer(args, config) {
+  const transformModulePath = args.transformer ?
+    path.resolve(args.transformer) :
+    config.getTransformModulePath();
+
   return ReactPackager.createServer({
     nonPersistent: args.nonPersistent,
     projectRoots: args.projectRoots,
     blacklistRE: config.getBlacklistRE(),
     cacheVersion: '3',
     getTransformOptionsModulePath: config.getTransformOptionsModulePath,
-    transformModulePath: path.resolve(args.transformer),
+    transformModulePath: transformModulePath,
     extraNodeModules: config.extraNodeModules,
     assetRoots: args.assetRoots,
     assetExts: [

--- a/local-cli/server/server.js
+++ b/local-cli/server/server.js
@@ -54,7 +54,7 @@ function _server(argv, config, resolve, reject) {
   }, {
     command: 'transformer',
     type: 'string',
-    default: require.resolve('../../packager/transformer'),
+    default: null,
     description: 'Specify a custom transformer to be used'
   }, {
     command: 'resetCache',

--- a/packager/rn-cli.config.js
+++ b/packager/rn-cli.config.js
@@ -33,4 +33,9 @@ module.exports = {
       return [path.resolve(__dirname, '..')];
     }
   },
+
+  getTransformModulePath() {
+    return require.resolve('./transformer');
+  },
+
 };


### PR DESCRIPTION
This will allow consumers to supply their own transformer to all `react-native` cli commands by simply implementing `rn-cli.config.js` and overriding `getTransformModulePath()`. That way they don't have to fork various parts of the iOS and Android build system that React Native already provides just to add a `--transformer` command line argument.

**Test plan:** Applied this patch to the React Native version in my app, implemented `getTransformModulePath()` in my `rn-cli.config.js`, and verified that my custom transformer is invoked.