### PR TITLE
no need both iOSLink and AndroidLink

### DIFF
--- a/website/src/react-native/showcase.js
+++ b/website/src/react-native/showcase.js
@@ -1087,7 +1087,7 @@ var AppList = React.createClass({
       <div>
         <img src={app.icon} alt={app.name} />
         <h3>{app.name}</h3>
-        {app.linkAppStore && app.linkPlayStore ? this._renderLinks(app) : null}
+        {app.linkAppStore || app.linkPlayStore ? this._renderLinks(app) : null}
         <p>By {app.author}</p>
         {this._renderBlogPosts(app)}
         {this._renderSourceLink(app)}
@@ -1167,11 +1167,14 @@ var AppList = React.createClass({
   },
 
   _renderLinks: function(app) {
+    var linkAppStore = app.linkAppStore ? <a href={app.linkAppStore} target="_blank">iOS</a> : '';
+    var linkPlayStore = app.linkPlayStore ? <a href={app.linkPlayStore} target="_blank">Android</a> : '';
+
     return (
       <p>
-        <a href={app.linkAppStore} target="_blank">iOS</a>
-        {' '}&middot;{' '}
-        <a href={app.linkPlayStore} target="_blank">Android</a>
+        {linkAppStore}
+        {linkAppStore && linkPlayStore ? ' · ' : ''}
+        {linkPlayStore}
       </p>
     );
   },


### PR DESCRIPTION
**motivation** 

if users showcase data only have `linkAppStore` or `linkPlayStore` , not both. They will be render as a not link block. like `D.I.T.` or `烘焙帮`

**Test plan**

Befor:

![2016-06-07 2 03 27](https://cloud.githubusercontent.com/assets/73235/15847463/a9c5922c-2cb8-11e6-902e-32a942d4f1bd.png)

After:

![2016-06-07 2 03 15](https://cloud.githubusercontent.com/assets/73235/15847467/b039df50-2cb8-11e6-893c-7cc25d876a5c.png)
