### PR TITLE
Fix polyfillLazyGlobal to work with allowTopLevelThis = false

### DIFF
--- a/Libraries/JavaScriptAppEngine/Initialization/InitializeJavaScriptAppEngine.js
+++ b/Libraries/JavaScriptAppEngine/Initialization/InitializeJavaScriptAppEngine.js
@@ -20,7 +20,7 @@
  */
 
 /* eslint strict: 0 */
-/* globals GLOBAL: true, window: true */
+/* globals window: true */
 
 require('regenerator-runtime/runtime');
 

--- a/Libraries/JavaScriptAppEngine/Initialization/InitializeJavaScriptAppEngine.js
+++ b/Libraries/JavaScriptAppEngine/Initialization/InitializeJavaScriptAppEngine.js
@@ -33,10 +33,10 @@ if (typeof window === 'undefined') {
 }
 
 function setUpProcess() {
-  GLOBAL.process = GLOBAL.process || {};
-  GLOBAL.process.env = GLOBAL.process.env || {};
-  if (!GLOBAL.process.env.NODE_ENV) {
-    GLOBAL.process.env.NODE_ENV = __DEV__ ? 'development' : 'production';
+  global.process = global.process || {};
+  global.process.env = global.process.env || {};
+  if (!global.process.env.NODE_ENV) {
+    global.process.env.NODE_ENV = __DEV__ ? 'development' : 'production';
   }
 }
 
@@ -102,10 +102,10 @@ function polyfillLazyGlobal(name, valueFn, scope = global) {
     configurable: true,
     enumerable: enumerable !== false,
     get() {
-      return (this[name] = valueFn());
+      return (global[name] = valueFn());
     },
     set(value) {
-      Object.defineProperty(this, name, {
+      Object.defineProperty(global, name, {
         configurable: true,
         enumerable: enumerable !== false,
         writable: writable !== false,


### PR DESCRIPTION
`polyfillLazyGlobal` used a top level this which get stripped by babel `transform-es2015-modules-commonjs` with the default config. This is mainly an issues for people not using the react native babel preset.

This also replaces a few GLOBAL with global for consistency with the rest of the file.

**Test plan**

Tested that there was an error when using `['transform-es2015-modules-commonjs', { strict: true, allowTopLevelThis: false }]` in the babel config and that it was fixed after applying my changes.

Fixes #7700