### PR TITLE
Fix bug where library is generated in the wrong place (node_modules)

### DIFF
--- a/local-cli/library/library.js
+++ b/local-cli/library/library.js
@@ -59,7 +59,8 @@ function _library(argv, config, resolve, reject) {
       return;
     }
 
-    const dest = f.replace(/Sample/g, args.name).replace(/^_/, '.');
+    const dest = f.replace(path.join(source, path.sep),'').replace(/Sample/g, args.name).replace(/^_/, '.');
+
     copyAndReplace(
       path.resolve(source, f),
       path.resolve(libraryDest, dest),


### PR DESCRIPTION
Currently the library is dumped at `SomeProject/node_modules/react-native/Libraries/MyLibrary` because the target path is being build from the sample path, since the code takes the template (`Sample`) from that path. However the code mistakenly assumes this is also the destination path.

The effect is that the actual library been generated sits at the project's `node_modules` which is not under source control, and the console mistakenly reports that the library sits within the project `Libraries` folder, by using the correct `libraryDest`.

This fix trims the internal path that `Sample` has so that the files are actually placed in the project's source tree and not within `node_modules`.
