### PR TITLE
Add flexibility to the iOS UIExplorer test script

### DIFF
--- a/scripts/objc-test.sh
+++ b/scripts/objc-test.sh
@@ -5,8 +5,6 @@ set -e
 SCRIPTS=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 ROOT=$(dirname $SCRIPTS)
 
-export REACT_PACKAGER_LOG="$ROOT/server.log"
-
 cd $ROOT
 
 function cleanup {
@@ -17,17 +15,29 @@ function cleanup {
   then
     WATCHMAN_LOGS=/usr/local/Cellar/watchman/3.1/var/run/watchman/$USER.log
     [ -f $WATCHMAN_LOGS ] && cat $WATCHMAN_LOGS
-
-    [ -f $REACT_PACKAGER_LOG ] && cat $REACT_PACKAGER_LOG
   fi
 }
 trap cleanup EXIT
+
+if [ -z "$XCODE_DESTINATION" ]; then
+  XCODE_DESTINATION="platform=iOS Simulator,name=iPhone 5,OS=9.3"
+fi
+
+# Support for environments without xcpretty installed
+set +e
+OUTPUT_TOOL=$(which xcpretty)
+set -e
+if [ -z "$OUTPUT_TOOL" ]; then
+  OUTPUT_TOOL="sed"
+fi
 
 # TODO: We use xcodebuild because xctool would stall when collecting info about
 # the tests before running them. Switch back when this issue with xctool has
 # been resolved.
 xcodebuild \
   -project Examples/UIExplorer/UIExplorer.xcodeproj \
-  -scheme UIExplorer -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 5,OS=9.3' \
+  -scheme UIExplorer \
+  -sdk iphonesimulator \
+  -destination "$XCODE_DESTINATION" \
   test \
-| xcpretty && exit ${PIPESTATUS[0]}
+  | $OUTPUT_TOOL && exit ${PIPESTATUS[0]}


### PR DESCRIPTION
Add more flexibility to the iOS UIExplorer test scripts:
- support environments without `xcpretty` installed
- support custom xcode destination argument

Initial PR is based on the last git commit which passed on Travis today (2a92b52) in order to test Travis build.

I'll rebase to latest, in order to fix merge conflicts, before merging.

**Test plan (required)**

Make sure tests pass on Travis.
