### PR TITLE
Android WebSockets: include cookie in request

### DIFF
--- a/Examples/UIExplorer/WebSocketExample.js
+++ b/Examples/UIExplorer/WebSocketExample.js
@@ -25,10 +25,12 @@ const {
   Text,
   TextInput,
   TouchableOpacity,
+  ScrollView,
   View,
 } = ReactNative;
 
 const DEFAULT_WS_URL = 'ws://localhost:5555/';
+const DEFAULT_HTTP_URL = 'http://localhost:5556/';
 const WS_EVENTS = [
   'close',
   'error',
@@ -88,11 +90,13 @@ function showValue(value) {
 
 type State = {
   url: string;
+  httpServerUrl: string;
   socket: ?WebSocket;
   socketState: ?number;
   lastSocketEvent: ?string;
   lastMessage: ?string | ?ArrayBuffer;
   outgoingMessage: string;
+  fetchStatus: ?string;
 };
 
 class WebSocketExample extends React.Component<any, any, State> {
@@ -102,11 +106,13 @@ class WebSocketExample extends React.Component<any, any, State> {
 
   state: State = {
     url: DEFAULT_WS_URL,
+    httpServerUrl: DEFAULT_HTTP_URL,
     socket: null,
     socketState: null,
     lastSocketEvent: null,
     lastMessage: null,
     outgoingMessage: '',
+    fetchStatus: null,
   };
 
   _connect = () => {
@@ -162,6 +168,19 @@ class WebSocketExample extends React.Component<any, any, State> {
     this.setState({outgoingMessage: ''});
   };
 
+  _sendHttp = () => {
+    this.setState({
+      fetchStatus: 'fetching',
+    });
+    fetch(this.state.httpServerUrl).then((response) => {
+      if (response.status >= 200 && response.status < 400) {
+        this.setState({
+          fetchStatus: 'OK',
+        });
+      }
+    });
+  };
+
   render(): ReactElement<any> {
     const socketState = WS_STATES[this.state.socketState || -1];
     const canConnect =
@@ -169,16 +188,11 @@ class WebSocketExample extends React.Component<any, any, State> {
       this.state.socket.readyState >= WebSocket.CLOSING;
     const canSend = !!this.state.socket;
     return (
-      <View style={styles.container}>
+      <ScrollView style={styles.container}>
         <View style={styles.note}>
-          <Text>Pro tip:</Text>
+          <Text>To start the WS test server:</Text>
           <Text style={styles.monospace}>
-            node Examples/UIExplorer/websocket_test_server.js
-          </Text>
-          <Text>
-            {' in the '}
-            <Text style={styles.monospace}>react-native</Text>
-            {' directory starts a test server.'}
+            ./Examples/UIExplorer/websocket_test_server.js
           </Text>
         </View>
         <Row
@@ -200,16 +214,18 @@ class WebSocketExample extends React.Component<any, any, State> {
           onChangeText={(url) => this.setState({url})}
           value={this.state.url}
         />
-        <Button
-          onPress={this._connect}
-          label="Connect"
-          disabled={!canConnect}
-        />
-        <Button
-          onPress={this._disconnect}
-          label="Disconnect"
-          disabled={canConnect}
-        />
+        <View style={styles.buttonRow}>
+          <Button
+            onPress={this._connect}
+            label="Connect"
+            disabled={!canConnect}
+          />
+          <Button
+            onPress={this._disconnect}
+            label="Disconnect"
+            disabled={canConnect}
+          />
+        </View>
         <TextInput
           style={styles.textInput}
           autoCorrect={false}
@@ -229,7 +245,32 @@ class WebSocketExample extends React.Component<any, any, State> {
             disabled={!canSend}
           />
         </View>
-      </View>
+        <View style={styles.note}>
+          <Text>To start the HTTP test server:</Text>
+          <Text style={styles.monospace}>
+            ./Examples/UIExplorer/http_test_server.js
+          </Text>
+        </View>
+        <TextInput
+          style={styles.textInput}
+          autoCorrect={false}
+          placeholder="HTTP URL..."
+          onChangeText={(httpServerUrl) => this.setState({httpServerUrl})}
+          value={this.state.httpServerUrl}
+        />
+        <View style={styles.buttonRow}>
+          <Button
+            onPress={this._sendHttp}
+            label="Send HTTP request to set cookie"
+            disabled={this.state.fetchStatus === 'fetching'}
+          />
+        </View>
+        <View style={styles.note}>
+          <Text>
+            {this.state.fetchStatus === 'OK' ? 'Done. Check your WS server console to see if the next WS requests include the cookie (should be "wstest=OK")' : '-'}
+          </Text>
+        </View>
+      </ScrollView>
     );
   }
 

--- a/Examples/UIExplorer/http_test_server.js
+++ b/Examples/UIExplorer/http_test_server.js
@@ -19,28 +19,25 @@
 
 /* eslint-env node */
 
-const WebSocket = require('ws');
-
 console.log(`\
 Test server for WebSocketExample
 
-This will send each incoming message right back to the other side.
-Restart with the '--binary' command line flag to have it respond with an
-ArrayBuffer instead of a string.
+This will set a cookie named "wstest" on the response of any incoming request.
 `);
 
-const respondWithBinary = process.argv.indexOf('--binary') !== -1;
-const server = new WebSocket.Server({port: 5555});
-server.on('connection', (ws) => {
-  ws.on('message', (message) => {
-    console.log('Received message:', message);
-    console.log('Cookie:', ws.upgradeReq.headers.cookie);
-    if (respondWithBinary) {
-      message = new Buffer(message);
-    }
-    ws.send(message);
-  });
+const connect = require('connect');
+const http = require('http');
 
-  console.log('Incoming connection!');
-  ws.send('Why hello there!');
+const app = connect();
+
+app.use(function(req, res) {
+  console.log('received request');
+  const cookieOptions = {
+    //httpOnly: true, // the cookie is not accessible by the user (javascript,...)
+    secure: false, // allow HTTP
+  };
+  res.cookie('wstest', 'OK', cookieOptions);
+  res.end('Cookie has been set!\n');
 });
+
+http.createServer(app).listen(5556);

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/websocket/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/websocket/BUCK
@@ -13,6 +13,7 @@ android_library(
     react_native_target('java/com/facebook/react/bridge:bridge'),
     react_native_target('java/com/facebook/react/common:common'),
     react_native_target('java/com/facebook/react/modules/core:core'),
+    react_native_target('java/com/facebook/react/modules/network:network'),
   ],
   visibility = [
     'PUBLIC',

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/websocket/WebSocketModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/websocket/WebSocketModule.java
@@ -28,6 +28,7 @@ import com.facebook.react.bridge.ReadableType;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.common.ReactConstants;
 import com.facebook.react.modules.core.DeviceEventManagerModule;
+import com.facebook.react.modules.network.ForwardingCookieHandler;
 
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
@@ -41,6 +42,7 @@ import okhttp3.ws.WebSocketListener;
 import java.net.URISyntaxException;
 import java.net.URI;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
@@ -51,10 +53,12 @@ public class WebSocketModule extends ReactContextBaseJavaModule {
 
   private Map<Integer, WebSocket> mWebSocketConnections = new HashMap<>();
   private ReactContext mReactContext;
+  private ForwardingCookieHandler cookieHandler;
 
   public WebSocketModule(ReactApplicationContext context) {
     super(context);
     mReactContext = context;
+    cookieHandler = new ForwardingCookieHandler(context);
   }
 
   private void sendEvent(String eventName, WritableMap params) {
@@ -80,6 +84,11 @@ public class WebSocketModule extends ReactContextBaseJavaModule {
         .tag(id)
         .url(url);
 
+    String cookie = getCookie(url);
+    if (cookie != null) {
+      builder.addHeader("Cookie", getCookie(url));
+    }
+    
     if (headers != null) {
       ReadableMapKeySetIterator iterator = headers.keySetIterator();
 
@@ -265,6 +274,27 @@ public class WebSocketModule extends ReactContextBaseJavaModule {
 
     } catch(URISyntaxException e) {
         throw new IllegalArgumentException("Unable to set " + uri + " as default origin header.");
+    }
+  }
+
+  /**
+   * Get cookie if exists
+   *
+   * @param websocket uri
+   * @return A cookie / null
+   */
+
+  private String getCookie(String uri){
+    try {
+      Map<String, List<String>> cookieMap = cookieHandler.get(new URI(setDefaultOrigin(uri)), new HashMap());
+      List<String> cookieList = cookieMap.get("Cookie");
+      if (cookieList != null) {
+        return cookieList.get(0);
+      } else {
+        return null;
+      }
+    } catch(URISyntaxException | IOException  e) {
+      throw new IllegalArgumentException("Unable to get cookie from the " + uri);
     }
   }
 


### PR DESCRIPTION
This PR updates #6851 from @srikanthkh, fixing coding conventions and javadoc, and adding a test plan.

## Test plan
Added testing functions into the WebSocketExample page of the UIExplorer, including a tiny http server to set a cookie on demand. Just open the app page and read the instructions :)