### PR TITLE
Fixed website generation for CameraRoll.js

### DIFF
--- a/Libraries/CameraRoll/CameraRoll.js
+++ b/Libraries/CameraRoll/CameraRoll.js
@@ -116,7 +116,7 @@ class CameraRoll {
   static GroupTypesOptions: Array<string>;
   static AssetTypeOptions: Array<string>;
 
-  static saveImageWithTag(tag: string):Promise<*> {
+  static saveImageWithTag(tag: string): Promise<Object> {
     console.warn('CameraRoll.saveImageWithTag is deprecated. Use CameraRoll.saveToCameraRoll instead');
     return this.saveToCameraRoll(tag, 'photo');
   }
@@ -135,7 +135,7 @@ class CameraRoll {
    *
    * Returns a Promise which will resolve with the new URI.
    */
-  static saveToCameraRoll(tag: string, type?: 'photo' | 'video'): Promise<*> {
+  static saveToCameraRoll(tag: string, type?: 'photo' | 'video'): Promise<Object> {
     invariant(
       typeof tag === 'string',
       'CameraRoll.saveToCameraRoll must be a valid string.'


### PR DESCRIPTION
Fixes whate was broken in #7988

Website generation does not understand Promise<*>.

Test Plan:
- cd website
- node server/server.js
- navigate to http://localhost:8079/react-native/docs/cameraroll.html