### PR TITLE
fixed comment section

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/ReactActivity.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactActivity.java
@@ -55,7 +55,7 @@ public abstract class ReactActivity extends Activity implements DefaultHardwareB
    * Returns a custom path of the bundle file. This is used in cases the bundle should be loaded
    * from a custom path. By default it is loaded from Android assets, from a path specified
    * by {@link getBundleAssetName}.
-   * e.g. "file://sdcard/myapp_cache/index.android.bundle"
+   * e.g. "/sdcard/myapp_cache/index.android.bundle"
    */
   protected @Nullable String getJSBundleFile() {
     return null;


### PR DESCRIPTION
This pull request is fixed the documentation about how to use getJSBundleFile. having `file://` makes react on android crash. The path needs to be an absolute.