### PR TITLE
Fix and update Android documentation (Integrating with existing app section)

### DIFF
--- a/docs/EmbeddedAppAndroid.md
+++ b/docs/EmbeddedAppAndroid.md
@@ -83,7 +83,7 @@ protected void onPause() {
     super.onPause();
 
     if (mReactInstanceManager != null) {
-        mReactInstanceManager.onPause();
+        mReactInstanceManager.onHostPause();
     }
 }
 
@@ -92,7 +92,16 @@ protected void onResume() {
     super.onResume();
 
     if (mReactInstanceManager != null) {
-        mReactInstanceManager.onResume(this, this);
+        mReactInstanceManager.onHostResume(this, this);
+    }
+}
+
+@Override
+protected void onDestroy() {
+    super.onDestroy();
+
+    if (mReactInstanceManager != null) {
+        mReactInstanceManager.onHostDestroy();
     }
 }
 ```


### PR DESCRIPTION
Android documentation was not updated accordingly following a native Android API surface modification which ended up renaming a couple of methods  (introduced in 19a1c4c22985ea6c7b475db71681bfc4dac4f1e0)

This PR is fixing the documentation while at the same time updating the documentation in the same section adding another method which was introduced in the same commit and which needs to be called as well (please see comment in [ReactInstanceManager.java](https://github.com/facebook/react-native/blob/5b871ad9d73deb50c8423d81588cb5b0331e49d5/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java#L44) : `It's required to pass owning activity's lifecycle events to the instance manager [...]`)