### PR TITLE
add JS Air and PermisPts to showcase

### DIFF
--- a/website/src/react-native/showcase.js
+++ b/website/src/react-native/showcase.js
@@ -542,6 +542,13 @@ var apps = [
     author: 'The Beat Drop Inc'
   },
   {
+    name: 'JS Air',
+    icon: '',
+    linkAppStore: 'https://itunes.apple.com/fr/app/js-air/id1112141070?mt=8',
+    linkPlayStore: 'https://play.google.com/store/apps/details?id=com.jsair',
+    author: 'Erwan DATIN',
+  },
+  {
     name: 'Kakapo',
     icon: 'http://a2.mzstatic.com/eu/r30/Purple3/v4/12/ab/2a/12ab2a01-3a3c-9482-b8df-ab38ad281165/icon175x175.png',
     linkAppStore: 'https://itunes.apple.com/gb/app/kakapo/id1046673139?ls=1&mt=8',
@@ -703,6 +710,12 @@ var apps = [
     linkAppStore: 'https://itunes.apple.com/app/passpoints/id930988932',
     linkPlayStore: 'https://play.google.com/store/apps/details?id=com.passpointsreactnative',
     author: 'passpoints.de',
+  },
+  {
+    name: 'PermisPts',
+    icon: '',
+    link: 'https://itunes.apple.com/fr/app/permispts/id950595671?mt=8',
+    author: 'Erwan DATIN',
   },
   {
     name: 'Pimmr',


### PR DESCRIPTION
Add My 2 React Native Applications to showcase:

- JS Air 
 - iOS and android
 - [javascriptair podcast](https://javascriptair.com) related
 - [open source](https://github.com/MacKentoch/jsair-mobile)
- PermisPts 
  - iOS only but working on Android version
  - french driving license related
