### PR TITLE
[ios] Fix onLayout support in <TextInput>

### DIFF
--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -501,6 +501,7 @@ var TextInput = React.createClass({
 
     return (
       <TouchableWithoutFeedback
+        onLayout={props.onLayout}
         onPress={this._onPress}
         rejectResponderTermination={true}
         accessible={props.accessible}


### PR DESCRIPTION
The `onLayout` prop is overridden by `<TouchableWithoutFeedback>` and thus does not work on `<TextInput>` components. https://github.com/facebook/react-native/blob/fb0007d85323909ab652bf97166744fa7e17daab/Libraries/Components/Touchable/TouchableWithoutFeedback.js#L176

This makes it so the following works.

```javascript
<TextInput onLayout={...} />
```

I only tested on iOS but I assume a similar fix might be needed for Android. https://github.com/facebook/react-native/blob/fb0007d85323909ab652bf97166744fa7e17daab/Libraries/Components/TextInput/TextInput.js#L575

**Test Plan**

https://rnplay.org/apps/euIZtg (confirm bug)
With fix, set `onLayout` on `<TextInput>` and see it is fired correctly.

```javascript
<TextInput onLayout={function(e) { console.log(e.nativeEvent); }} />
```