### PR TITLE
Update docs for textDecorationStyle

### DIFF
--- a/Libraries/Text/TextStylePropTypes.js
+++ b/Libraries/Text/TextStylePropTypes.js
@@ -56,9 +56,6 @@ var TextStylePropTypes = Object.assign(Object.create(ViewStylePropTypes), {
   textDecorationLine: ReactPropTypes.oneOf(
     ['none' /*default*/, 'underline', 'line-through', 'underline line-through']
   ),
-  /**
-   * @platform ios
-   */
   textDecorationStyle: ReactPropTypes.oneOf(
     ['solid' /*default*/, 'double', 'dotted','dashed']
   ),


### PR DESCRIPTION
This PR fixes the documentation for the `textDecorationStyle` prop in the Text component documentation.

`textDecorationLine` and `textDecorationStyle` were added for Android in https://github.com/facebook/react-native/releases/tag/v0.25.1

Only `textDecorationLine` was updated at the time https://github.com/facebook/react-native/commit/2039be9d32a52552db02239040bd8e7257bb80f0#diff-8d238dc2c74635b2aaca431551873addL55

