### PR TITLE
Added logging to push registration failure.

### DIFF
--- a/Libraries/PushNotificationIOS/PushNotificationIOS.js
+++ b/Libraries/PushNotificationIOS/PushNotificationIOS.js
@@ -65,6 +65,10 @@ var DEVICE_LOCAL_NOTIF_EVENT = 'localNotificationReceived';
  *    {
  *     [RCTPushNotificationManager didReceiveLocalNotification:notification];
  *    }
+ *    - (void)application:(UIApplication *)application didFailToRegisterForRemoteNotificationsWithError:(NSError *)error
+ *    {
+ *      NSLog(@"%@", error);
+ *    }
  *   ```
  */
 class PushNotificationIOS {


### PR DESCRIPTION
It seems it's a common problem people trying to register for push notifications in their simulator, and not understanding why the "register" event never works.
I've wasted a few hours myself on this issue.
This commit simply logs any failures with push registration, preventing confusion.