### PR TITLE
Don't clobber user-defined environment variables

### DIFF
--- a/local-cli/bundle/buildBundle.js
+++ b/local-cli/bundle/buildBundle.js
@@ -25,7 +25,12 @@ function buildBundle(args, config, output = outputBundle, packagerInstance) {
 
     // This is used by a bazillion of npm modules we don't control so we don't
     // have other choice than defining it as an env variable here.
-    process.env.NODE_ENV = args.dev ? 'development' : 'production';
+    if (!process.env.NODE_ENV) {
+      // If you're inlining environment variables, you can use babel to remove
+      // this line:
+      // https://www.npmjs.com/package/babel-remove-process-env-assignment
+      process.env.NODE_ENV = args.dev ? 'development' : 'production';
+    }
 
     const options = {
       projectRoots: config.getProjectRoots(),


### PR DESCRIPTION
Re: @javache 's suggestions from https://github.com/facebook/react-native/pull/7878. Didn't want to deal with the merge conflict so I'm opening a separate PR. Here's the original justification:

If I want to set NODE_ENV to "baconator", I should be allowed to. Mutating global state that most devs assume to be immutable is just abysmal dev practice, especially since this mutation only happens when you're building for prod, not running on the simulator.

To test this, run env NODE_ENV=baconator ./gradlew assembleRelease with babel-plugin-transform-inline-environment-variables in your app/.babelrc. You'll see that the final app has NODE_ENV=production.

As a side note, running with babel-plugin-transform-inline-environment-variables in the top-level .babelrc crashes horribly with a compiler error.

For anybody who runs into this bug and doesn't feel like waiting for this to get merged, I wrote a quick babel plugin to remove assignments to process.env, which is sufficient to fix this issue.