### PR TITLE
Fix navigation card stack pan responder

### DIFF
--- a/Libraries/CustomComponents/NavigationExperimental/NavigationCardStack.js
+++ b/Libraries/CustomComponents/NavigationExperimental/NavigationCardStack.js
@@ -64,7 +64,7 @@ type Props = {
   renderScene: NavigationSceneRenderer,
   cardStyle?: any,
   style: any,
-  gestureResponseDistance: ?number,
+  gestureResponseDistance?: ?number,
 };
 
 type DefaultProps = {

--- a/Libraries/CustomComponents/NavigationExperimental/NavigationCardStack.js
+++ b/Libraries/CustomComponents/NavigationExperimental/NavigationCardStack.js
@@ -64,8 +64,7 @@ type Props = {
   renderScene: NavigationSceneRenderer,
   cardStyle?: any,
   style: any,
-  verticalGestureHeightDetection: ?number,
-  horizontalGestureWidthDetection: ?number,
+  gestureResponseDistance: ?number,
 };
 
 type DefaultProps = {
@@ -97,6 +96,7 @@ class NavigationCardStack extends React.Component<DefaultProps, Props, void> {
     renderOverlay: PropTypes.func,
     renderScene: PropTypes.func.isRequired,
     cardStyle: View.propTypes.style,
+    gestureResponseDistance: PropTypes.number,
   };
 
   static defaultProps: DefaultProps = {
@@ -166,8 +166,7 @@ class NavigationCardStack extends React.Component<DefaultProps, Props, void> {
     const panHandlersProps = {
       ...props,
       onNavigateBack: this.props.onNavigateBack,
-      verticalGestureHeightDetection: this.props.verticalGestureHeightDetection,
-      horizontalGestureWidthDetection: this.props.horizontalGestureWidthDetection,
+      gestureResponseDistance: this.props.gestureResponseDistance,
     };
     const panHandlers = isVertical ?
       NavigationCardStackPanResponder.forVertical(panHandlersProps) :

--- a/Libraries/CustomComponents/NavigationExperimental/NavigationCardStack.js
+++ b/Libraries/CustomComponents/NavigationExperimental/NavigationCardStack.js
@@ -64,6 +64,8 @@ type Props = {
   renderScene: NavigationSceneRenderer,
   cardStyle?: any,
   style: any,
+  verticalGestureHeightDetection: ?number,
+  horizontalGestureWidthDetection: ?number,
 };
 
 type DefaultProps = {
@@ -164,6 +166,8 @@ class NavigationCardStack extends React.Component<DefaultProps, Props, void> {
     const panHandlersProps = {
       ...props,
       onNavigateBack: this.props.onNavigateBack,
+      verticalGestureHeightDetection: this.props.verticalGestureHeightDetection,
+      horizontalGestureWidthDetection: this.props.horizontalGestureWidthDetection,
     };
     const panHandlers = isVertical ?
       NavigationCardStackPanResponder.forVertical(panHandlersProps) :

--- a/Libraries/CustomComponents/NavigationExperimental/NavigationCardStackPanResponder.js
+++ b/Libraries/CustomComponents/NavigationExperimental/NavigationCardStackPanResponder.js
@@ -40,14 +40,6 @@ const POSITION_THRESHOLD = 1 / 3;
 const RESPOND_THRESHOLD = 15;
 
 /**
- * The distance from the edge of the navigator which gesture response can start for.
- * For horizontal scroll views, a distance of 30 from the left of the screen is the
- * standard maximum position to start touch responsiveness.
- */
-const RESPOND_POSITION_MAX_HORIZONTAL = 30;
-const RESPOND_POSITION_MAX_VERTICAL = null;
-
-/**
  * The threshold (in pixels) to finish the gesture action.
  */
 const DISTANCE_THRESHOLD = 100;
@@ -64,6 +56,11 @@ export type NavigationGestureDirection =  'horizontal' | 'vertical';
 
 type Props = NavigationSceneRendererProps & {
   onNavigateBack: ?Function,
+  /**
+  * The distance from the edge of the navigator which gesture response can start for.
+  **/
+  verticalGestureHeightDetection: ?number,
+  horizontalGestureWidthDetection: ?number,
 };
 
 /**
@@ -86,6 +83,15 @@ class NavigationCardStackPanResponder extends NavigationAbstractPanResponder {
   _isVertical: boolean;
   _props: Props;
   _startValue: number;
+
+  static defaultProps: {
+    verticalGestureHeightDetection: null,
+    /**
+    * For horizontal scroll views, a distance of 30 from the left of the screen is the
+    * standard maximum position to start touch responsiveness.
+    */
+    horizontalGestureWidthDetection: 30,
+  };
 
   constructor(
     direction: NavigationGestureDirection,
@@ -115,8 +121,8 @@ class NavigationCardStackPanResponder extends NavigationAbstractPanResponder {
       layout.width.__getValue();
 
     const positionMax = isVertical ?
-      RESPOND_POSITION_MAX_VERTICAL :
-      RESPOND_POSITION_MAX_HORIZONTAL;
+      props.verticalGestureHeightDetection :
+      props.horizontalGestureWidthDetection;
 
     if (positionMax != null && currentDragPosition > positionMax) {
       return false;

--- a/Libraries/CustomComponents/NavigationExperimental/NavigationCardStackPanResponder.js
+++ b/Libraries/CustomComponents/NavigationExperimental/NavigationCardStackPanResponder.js
@@ -59,8 +59,7 @@ type Props = NavigationSceneRendererProps & {
   /**
   * The distance from the edge of the navigator which gesture response can start for.
   **/
-  verticalGestureHeightDetection: ?number,
-  horizontalGestureWidthDetection: ?number,
+  gestureResponseDistance: ?number,
 };
 
 /**
@@ -83,15 +82,6 @@ class NavigationCardStackPanResponder extends NavigationAbstractPanResponder {
   _isVertical: boolean;
   _props: Props;
   _startValue: number;
-
-  static defaultProps: {
-    verticalGestureHeightDetection: null,
-    /**
-    * For horizontal scroll views, a distance of 30 from the left of the screen is the
-    * standard maximum position to start touch responsiveness.
-    */
-    horizontalGestureWidthDetection: 30,
-  };
 
   constructor(
     direction: NavigationGestureDirection,
@@ -121,8 +111,12 @@ class NavigationCardStackPanResponder extends NavigationAbstractPanResponder {
       layout.width.__getValue();
 
     const positionMax = isVertical ?
-      props.verticalGestureHeightDetection :
-      props.horizontalGestureWidthDetection;
+      props.gestureResponseDistance :
+      /**
+      * For horizontal scroll views, a distance of 30 from the left of the screen is the
+      * standard maximum position to start touch responsiveness.
+      */
+      props.gestureResponseDistance || 30;
 
     if (positionMax != null && currentDragPosition > positionMax) {
       return false;

--- a/Libraries/NavigationExperimental/NavigationTypeDefinition.js
+++ b/Libraries/NavigationExperimental/NavigationTypeDefinition.js
@@ -70,6 +70,9 @@ export type NavigationTransitionProps = {
   // The active scene, corresponding to the route at
   // `navigationState.routes[navigationState.index]`.
   scene: NavigationScene,
+
+  // The gesture distance for `horizontal` and `vertical` transitions
+  gestureResponseDistance?: ?number,
 };
 
 // Similar to `NavigationTransitionProps`, except that the prop `scene`


### PR DESCRIPTION
Hi folks !
🔧 Fix the navigation card stack pan responder when the `vertical` direction is enabled. 

**Issue:**
When using a `ScrollView` with the `vertical` direction enabled, the pan handler catch the gesture before the `ScrollView`.

I don't know why there was no default value here for `RESPOND_POSITION_MAX_VERTICAL` 5162eb32546b42a017adac1e1bf9b4196affc7c5
@ericvicenti could you tell me what you think about setting a default value for `RESPOND_POSITION_MAX_VERTICAL` ? 😃 

Thanks !!

**EDIT June 15, 2016**
I'll update this PR this week end to provide a way to give custom values as there is no magic value for `RESPOND_POSITION_MAX_VERTICAL` 

**EDIT June 24, 2016**
I've added a props `gestureResponseDistance` to control both the `RESPOND_POSITION_MAX_VERTICAL` and `RESPOND_POSITION_MAX_HORIZONTAL`