### PR TITLE
Remove shouldComponentUpdate from NavigationCardStack

### DIFF
--- a/Libraries/CustomComponents/NavigationExperimental/NavigationCardStack.js
+++ b/Libraries/CustomComponents/NavigationExperimental/NavigationCardStack.js
@@ -108,14 +108,6 @@ class NavigationCardStack extends React.Component<DefaultProps, Props, void> {
     this._renderScene = this._renderScene.bind(this);
   }
 
-  shouldComponentUpdate(nextProps: Object, nextState: void): boolean {
-    return ReactComponentWithPureRenderMixin.shouldComponentUpdate.call(
-      this,
-      nextProps,
-      nextState
-    );
-  }
-
   render(): ReactElement<any> {
     return (
       <NavigationAnimatedView


### PR DESCRIPTION
* Means NavigationCardStack will update without checking equality of
the next and previous props
* Fixes https://github.com/facebook/react-native/issues/8084