### PR TITLE
Remove iOS platform check for running devtools

### DIFF
--- a/Libraries/JavaScriptAppEngine/Initialization/InitializeJavaScriptAppEngine.js
+++ b/Libraries/JavaScriptAppEngine/Initialization/InitializeJavaScriptAppEngine.js
@@ -213,7 +213,7 @@ function setUpMapAndSet() {
 function setUpDevTools() {
   if (__DEV__) {
     // not when debugging in chrome
-    if (!window.document && require('Platform').OS === 'ios') {
+    if (!window.document) {
       const setupDevtools = require('setupDevtools');
       setupDevtools();
     }


### PR DESCRIPTION
Currently, DevTools only work under ios (although this is undocumented!), because the JavaScriptEngine initialization process skips setupDevTools() on android.

DevTools work fine with Android, as tested on 0.26, 0.27, and 0.28 using Nuclide's inspector. 

For reference, [the relevant issue on react-devtools](https://github.com/facebook/react-devtools/issues/229). 