### PR TITLE
Add UIGraphicsPush/PopContext to prevent lost reference during snapshot testing

### DIFF
--- a/Libraries/RCTTest/FBSnapshotTestCase/FBSnapshotTestController.m
+++ b/Libraries/RCTTest/FBSnapshotTestCase/FBSnapshotTestController.m
@@ -371,11 +371,13 @@ typedef NS_ENUM(NSUInteger, FBTestSnapshotFileNameType) {
   CGContextRef context = UIGraphicsGetCurrentContext();
   NSAssert1(context, @"Could not generate context for layer %@", layer);
 
+  UIGraphicsPushContext(context);
   CGContextSaveGState(context);
   {
     [layer renderInContext:context];
   }
   CGContextRestoreGState(context);
+  UIGraphicsPopContext();
 
   UIImage *snapshot = UIGraphicsGetImageFromCurrentImageContext();
   UIGraphicsEndImageContext();


### PR DESCRIPTION
We're seeing sporadic "CGContext...: invalid context 0x..." error messages during snapshot runs of our product build. This also seems to happen sometimes when building RN, see for instance: https://www.google.nl/search?q=site%3Atravis-ci.org%2Ffacebook%2Freact-native%20CGContextSaveGState%20invalid%20context

Our guess is that at some point, the CGContextRef is autoreleased. We tried retaining the ref first, but eventually settled for pushing/popping the context as it never fails in our tests (retaining still causes seemingly unrelated failures).

We're not sure if we can provide a testplan for this change, as the FBSnapshotTestController is not tested separately.