### PR TITLE
Load local assets synchronously to prevent image flicker

### DIFF
--- a/Libraries/Image/RCTImage.xcodeproj/project.pbxproj
+++ b/Libraries/Image/RCTImage.xcodeproj/project.pbxproj
@@ -12,9 +12,7 @@
 		1304D5B21AA8C50D0002E2BE /* RCTGIFImageDecoder.m in Sources */ = {isa = PBXBuildFile; fileRef = 1304D5B11AA8C50D0002E2BE /* RCTGIFImageDecoder.m */; };
 		134B00A21B54232B00EC8DFB /* RCTImageUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 134B00A11B54232B00EC8DFB /* RCTImageUtils.m */; };
 		139A38841C4D587C00862840 /* RCTResizeMode.m in Sources */ = {isa = PBXBuildFile; fileRef = 139A38831C4D587C00862840 /* RCTResizeMode.m */; };
-		13EF7F0B1BC42D4E003F47DD /* RCTShadowVirtualImage.m in Sources */ = {isa = PBXBuildFile; fileRef = 13EF7F081BC42D4E003F47DD /* RCTShadowVirtualImage.m */; };
-		13EF7F0C1BC42D4E003F47DD /* RCTVirtualImageManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 13EF7F0A1BC42D4E003F47DD /* RCTVirtualImageManager.m */; };
-		13EF7F7F1BC825B1003F47DD /* RCTXCAssetImageLoader.m in Sources */ = {isa = PBXBuildFile; fileRef = 13EF7F7E1BC825B1003F47DD /* RCTXCAssetImageLoader.m */; };
+		13EF7F7F1BC825B1003F47DD /* RCTLocalAssetImageLoader.m in Sources */ = {isa = PBXBuildFile; fileRef = 13EF7F7E1BC825B1003F47DD /* RCTLocalAssetImageLoader.m */; };
 		143879381AAD32A300F088A5 /* RCTImageLoader.m in Sources */ = {isa = PBXBuildFile; fileRef = 143879371AAD32A300F088A5 /* RCTImageLoader.m */; };
 		35123E6B1B59C99D00EBAD80 /* RCTImageStoreManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 35123E6A1B59C99D00EBAD80 /* RCTImageStoreManager.m */; };
 		354631681B69857700AA0B86 /* RCTImageEditingManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 354631671B69857700AA0B86 /* RCTImageEditingManager.m */; };
@@ -44,8 +42,8 @@
 		134B00A11B54232B00EC8DFB /* RCTImageUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTImageUtils.m; sourceTree = "<group>"; };
 		139A38821C4D57AD00862840 /* RCTResizeMode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTResizeMode.h; sourceTree = "<group>"; };
 		139A38831C4D587C00862840 /* RCTResizeMode.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTResizeMode.m; sourceTree = "<group>"; };
-		13EF7F7D1BC825B1003F47DD /* RCTXCAssetImageLoader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTXCAssetImageLoader.h; sourceTree = "<group>"; };
-		13EF7F7E1BC825B1003F47DD /* RCTXCAssetImageLoader.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTXCAssetImageLoader.m; sourceTree = "<group>"; };
+		13EF7F7D1BC825B1003F47DD /* RCTLocalAssetImageLoader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTLocalAssetImageLoader.h; sourceTree = "<group>"; };
+		13EF7F7E1BC825B1003F47DD /* RCTLocalAssetImageLoader.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTLocalAssetImageLoader.m; sourceTree = "<group>"; };
 		143879361AAD32A300F088A5 /* RCTImageLoader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTImageLoader.h; sourceTree = "<group>"; };
 		143879371AAD32A300F088A5 /* RCTImageLoader.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTImageLoader.m; sourceTree = "<group>"; };
 		35123E691B59C99D00EBAD80 /* RCTImageStoreManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTImageStoreManager.h; sourceTree = "<group>"; };
@@ -75,8 +73,8 @@
 				EEF314711C9B0DD30049118E /* RCTImageBlurUtils.m */,
 				139A38821C4D57AD00862840 /* RCTResizeMode.h */,
 				139A38831C4D587C00862840 /* RCTResizeMode.m */,
-				13EF7F7D1BC825B1003F47DD /* RCTXCAssetImageLoader.h */,
-				13EF7F7E1BC825B1003F47DD /* RCTXCAssetImageLoader.m */,
+				13EF7F7D1BC825B1003F47DD /* RCTLocalAssetImageLoader.h */,
+				13EF7F7E1BC825B1003F47DD /* RCTLocalAssetImageLoader.m */,
 				1304D5B01AA8C50D0002E2BE /* RCTGIFImageDecoder.h */,
 				1304D5B11AA8C50D0002E2BE /* RCTGIFImageDecoder.m */,
 				354631661B69857700AA0B86 /* RCTImageEditingManager.h */,
@@ -169,7 +167,7 @@
 				139A38841C4D587C00862840 /* RCTResizeMode.m in Sources */,
 				1304D5AB1AA8C4A30002E2BE /* RCTImageView.m in Sources */,
 				EEF314721C9B0DD30049118E /* RCTImageBlurUtils.m in Sources */,
-				13EF7F7F1BC825B1003F47DD /* RCTXCAssetImageLoader.m in Sources */,
+				13EF7F7F1BC825B1003F47DD /* RCTLocalAssetImageLoader.m in Sources */,
 				134B00A21B54232B00EC8DFB /* RCTImageUtils.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Libraries/Image/RCTImageLoader.h
+++ b/Libraries/Image/RCTImageLoader.h
@@ -185,6 +185,18 @@ __deprecated_msg("Use getImageSizeWithURLRequest:block: instead");
  */
 - (float)loaderPriority;
 
+/**
+ * If the loader must be called on the serial url cache queue. If this is NO,
+ * the loader will be called from the main queue. Defaults to YES.
+ */
+- (BOOL)requiresScheduling;
+
+/**
+ * If images loaded by the loader should be cached in the decoded image cache.
+ * Defaults to YES.
+ */
+- (BOOL)shouldCacheLoadedImages;
+
 @end
 
 /**

--- a/Libraries/Image/RCTImageLoader.m
+++ b/Libraries/Image/RCTImageLoader.m
@@ -296,8 +296,8 @@ static UIImage *RCTResizeImageIfNeeded(UIImage *image,
   __block void(^cancelLoad)(void) = nil;
   __weak RCTImageLoader *weakSelf = self;
   // Find suitable image URL loader
-  __block id<RCTImageURLLoader> loadHandler = [self imageURLLoaderForURL:imageURLRequest.URL];
-  __block BOOL cacheResult = [loadHandler respondsToSelector:@selector(shouldCacheLoadedImages)] ?
+  id<RCTImageURLLoader> loadHandler = [self imageURLLoaderForURL:imageURLRequest.URL];
+  BOOL cacheResult = [loadHandler respondsToSelector:@selector(shouldCacheLoadedImages)] ?
       [loadHandler shouldCacheLoadedImages] : YES;
   BOOL requiresScheduling = [loadHandler respondsToSelector:@selector(requiresScheduling)] ?
       [loadHandler requiresScheduling] : YES;

--- a/Libraries/Image/RCTLocalAssetImageLoader.h
+++ b/Libraries/Image/RCTLocalAssetImageLoader.h
@@ -9,6 +9,6 @@
 
 #import "RCTImageLoader.h"
 
-@interface RCTXCAssetImageLoader : NSObject <RCTImageURLLoader>
+@interface RCTLocalAssetImageLoader : NSObject <RCTImageURLLoader>
 
 @end

--- a/Libraries/Image/RCTLocalAssetImageLoader.m
+++ b/Libraries/Image/RCTLocalAssetImageLoader.m
@@ -22,6 +22,20 @@ RCT_EXPORT_MODULE()
   return RCTIsLocalAssetURL(requestURL);
 }
 
+- (BOOL)requiresScheduling
+{
+  // Don't schedule this loader on the URL queue so we can load the
+  // local assets synchronously to avoid flickers.
+  return NO;
+}
+
+- (BOOL)shouldCacheLoadedImages
+{
+  // UIImage imageNamed handles the caching automatically so we don't want
+  // to add it to the image cache.
+  return NO;
+}
+
  - (RCTImageLoaderCancellationBlock)loadImageForURL:(NSURL *)imageURL
                                                size:(CGSize)size
                                               scale:(CGFloat)scale
@@ -37,9 +51,6 @@ RCT_EXPORT_MODULE()
     }
 
     NSString *imageName = RCTBundlePathForURL(imageURL);
-
-    // imageNamed handles the caching automatically so there is no
-    // need to do any manual caching.
     UIImage *image = [UIImage imageNamed:imageName];
     if (image) {
       if (progressHandler) {

--- a/Libraries/Image/RCTLocalAssetImageLoader.m
+++ b/Libraries/Image/RCTLocalAssetImageLoader.m
@@ -7,19 +7,19 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import "RCTXCAssetImageLoader.h"
+#import "RCTLocalAssetImageLoader.h"
 
 #import <libkern/OSAtomic.h>
 
 #import "RCTUtils.h"
 
-@implementation RCTXCAssetImageLoader
+@implementation RCTLocalAssetImageLoader
 
 RCT_EXPORT_MODULE()
 
 - (BOOL)canLoadImageURL:(NSURL *)requestURL
 {
-  return RCTIsXCAssetURL(requestURL);
+  return RCTIsLocalAssetURL(requestURL);
 }
 
  - (RCTImageLoaderCancellationBlock)loadImageForURL:(NSURL *)imageURL
@@ -30,12 +30,16 @@ RCT_EXPORT_MODULE()
                                   completionHandler:(RCTImageLoaderCompletionBlock)completionHandler
 {
   __block volatile uint32_t cancelled = 0;
-  dispatch_async(dispatch_get_main_queue(), ^{
 
+  RCTExecuteOnMainQueue(^{
     if (cancelled) {
       return;
     }
+
     NSString *imageName = RCTBundlePathForURL(imageURL);
+
+    // imageNamed handles the caching automatically so there is no
+    // need to do any manual caching.
     UIImage *image = [UIImage imageNamed:imageName];
     if (image) {
       if (progressHandler) {

--- a/Libraries/Network/RCTFileRequestHandler.m
+++ b/Libraries/Network/RCTFileRequestHandler.m
@@ -30,7 +30,7 @@ RCT_EXPORT_MODULE()
 {
   return
   [request.URL.scheme caseInsensitiveCompare:@"file"] == NSOrderedSame
-  && !RCTIsXCAssetURL(request.URL);
+  && !RCTIsLocalAssetURL(request.URL);
 }
 
 - (NSOperation *)sendRequest:(NSURLRequest *)request

--- a/React/Base/RCTUtils.h
+++ b/React/Base/RCTUtils.h
@@ -120,8 +120,8 @@ RCT_EXTERN NSData *__nullable RCTGzipData(NSData *__nullable data, float level);
 // (or nil, if the URL does not specify a path within the main bundle)
 RCT_EXTERN NSString *__nullable RCTBundlePathForURL(NSURL *__nullable URL);
 
-// Determines if a given image URL actually refers to an XCAsset
-RCT_EXTERN BOOL RCTIsXCAssetURL(NSURL *__nullable imageURL);
+// Determines if a given image URL refers to a local image
+RCT_EXTERN BOOL RCTIsLocalAssetURL(NSURL *__nullable imageURL);
 
 // Creates a new, unique temporary file path with the specified extension
 RCT_EXTERN NSString *__nullable RCTTempFilePath(NSString *__nullable extension, NSError **error);

--- a/React/Base/RCTUtils.m
+++ b/React/Base/RCTUtils.m
@@ -612,21 +612,17 @@ NSString *__nullable  RCTBundlePathForURL(NSURL *__nullable URL)
   return path;
 }
 
-BOOL RCTIsXCAssetURL(NSURL *__nullable imageURL)
+BOOL RCTIsLocalAssetURL(NSURL *__nullable imageURL)
 {
   NSString *name = RCTBundlePathForURL(imageURL);
-  if (name.pathComponents.count != 1) {
-    // URL is invalid, or is a file path, not an XCAsset identifier
+  if (name == nil) {
     return NO;
   }
   NSString *extension = [name pathExtension];
-  if (extension.length && ![extension isEqualToString:@"png"]) {
-    // Not a png
-    return NO;
-  }
-  extension = extension.length ? nil : @"png";
-  if ([[NSBundle mainBundle] pathForResource:name ofType:extension]) {
-    // File actually exists in bundle, so is not an XCAsset
+  if (extension.length &&
+      ![extension isEqualToString:@"png"] &&
+      ![extension isEqualToString:@"jpg"]) {
+    // Not a supported image.
     return NO;
   }
   return YES;


### PR DESCRIPTION
This uses `[UIImage imageNamed:]` to load local assets that are bundled using `require('../image/path.png')` and makes sure it is done synchronously on the main queue to prevent images from flickering. This improves user experience a lot when using large local images and prevents icon flickers to match the behaviour of most native apps.

This adds to methods to the ImageLoader protocol, one to tell if the image loader must be executed on the url cache queue and one to tell if the result of the image loader should be cached. I then use these to make the LocalImageLoader bypass the url cache queue and avoid caching images twice.

Note that this doesn't affect debug builds since images are loaded from the packager.

I'm not sure if we want to still support async loading of local images as I'm not sure how much of a perf difference this will make. Maybe someone at fb can benchmark this see how it affects your apps but there wasn't a noticeable one in mine. Also I only enabled this for loading png and jpg images, not sure if we want to add more there.

**Test plan**
Tested my branch on an app that makes heavy use of local images and made sure there is no flicker and that the code is executed synchronously. Also did some testing in UIExplorer to make sure everything still looked fine.