### PR TITLE
Fixed position of ripple-effect

### DIFF
--- a/Libraries/Components/Touchable/TouchableNativeFeedback.android.js
+++ b/Libraries/Components/Touchable/TouchableNativeFeedback.android.js
@@ -185,8 +185,9 @@ var TouchableNativeFeedback = React.createClass({
 
   _handleResponderMove: function(e) {
     this.touchableHandleResponderMove(e);
-    var elementHeight = this.pressInLocation.pageY - e.nativeEvent.locationY,
-        elementWidth = this.pressInLocation.pageX - e.nativeEvent.locationX
+    var [elementWidth, elementHeight] = (this.pressInLocation)
+    ? [this.pressInLocation.pageX - e.nativeEvent.locationX, this.pressInLocation.pageY - e.nativeEvent.locationY]
+    : [0, 0];
     this._dispatchHotspotUpdate(e.nativeEvent.pageX - elementWidth, e.nativeEvent.pageY - elementHeight);
   },
 

--- a/Libraries/Components/Touchable/TouchableNativeFeedback.android.js
+++ b/Libraries/Components/Touchable/TouchableNativeFeedback.android.js
@@ -185,7 +185,9 @@ var TouchableNativeFeedback = React.createClass({
 
   _handleResponderMove: function(e) {
     this.touchableHandleResponderMove(e);
-    this._dispatchHotspotUpdate(e.nativeEvent.pageX, e.nativeEvent.pageY);
+    var elementHeight = this.pressInLocation.pageY - e.nativeEvent.locationY,
+        elementWidth = this.pressInLocation.pageX - e.nativeEvent.locationX
+    this._dispatchHotspotUpdate(e.nativeEvent.pageX - elementWidth, e.nativeEvent.pageY - elementHeight);
   },
 
   _dispatchHotspotUpdate: function(destX, destY) {


### PR DESCRIPTION
I recognised that the ripple effect was always located at the bottom of my buttons. So i started to search for other ppl having the same problem. I also found this bug on the f8 app. 

The gifs show the behaviour before and after my changes:

[The ripple effect is always on the bottom of the element, because pageY is used instead of the relative pos]
![before](https://cloud.githubusercontent.com/assets/956410/16042805/df49d97e-323c-11e6-8ce2-b0658ec85b27.gif)

![after](https://cloud.githubusercontent.com/assets/956410/16042804/df483a60-323c-11e6-862f-e8c97b835339.gif)


Before, the absolute position of the touch was used to update the position during movement but it should be the relative position. Just some small calculation changes were needed to achieve the correct behaviour :)