### PR TITLE
Cleanup packager dead debug endpoint

### DIFF
--- a/packager/README.md
+++ b/packager/README.md
@@ -72,12 +72,10 @@ Here are the current options the packager accepts:
 
 ### /debug
 
-This is a page used for debugging, it has links to two pages:
+This is a page used for debugging, it offers a link to a single page :
 
 * Cached Packages: which shows you the packages that's been already
   generated and cached
-* Dependency Graph: is the in-memory graph of all the modules and
-  their dependencies
 
 ## Programmatic API
 

--- a/packager/react-packager/src/Bundler/index.js
+++ b/packager/react-packager/src/Bundler/index.js
@@ -566,10 +566,6 @@ class Bundler {
     });
   }
 
-  getGraphDebugInfo() {
-    return this._resolver.getDebugInfo();
-  }
-
   _generateAssetModule_DEPRECATED(bundle, module, getModuleId) {
     return Promise.all([
       sizeOf(module.path),

--- a/packager/react-packager/src/Resolver/index.js
+++ b/packager/react-packager/src/Resolver/index.js
@@ -265,10 +265,6 @@ class Resolver {
   minifyModule({path, code, map}) {
     return this._minifyCode(path, code, map);
   }
-
-  getDebugInfo() {
-    return this._depGraph.getDebugInfo();
-  }
 }
 
 function defineModuleCode(moduleName, code, verboseName = '', dev = true) {

--- a/packager/react-packager/src/Server/index.js
+++ b/packager/react-packager/src/Server/index.js
@@ -348,7 +348,6 @@ class Server {
     const parts = pathname.split('/').filter(Boolean);
     if (parts.length === 1) {
       ret += '<div><a href="/debug/bundles">Cached Bundles</a></div>';
-      ret += '<div><a href="/debug/graph">Dependency Graph</a></div>';
       res.end(ret);
     } else if (parts[1] === 'bundles') {
       ret += '<h1> Cached Bundles </h1>';
@@ -365,10 +364,6 @@ class Server {
           console.log(e.stack); // eslint-disable-line no-console-disallow
         }
       );
-    } else if (parts[1] === 'graph'){
-      ret += '<h1> Dependency Graph </h2>';
-      ret += this._bundler.getGraphDebugInfo();
-      res.end(ret);
     } else {
       res.writeHead('404');
       res.end('Invalid debug request');


### PR DESCRIPTION
When trying to access the debug dependency graph through the `/debug/graph` endpoint of the packager server (documented in the packager README and listed as well when hitting the root `/debug` endpoint), all I am getting back is a nasty HTTP 500 error :'(

What triggers this HTTP 500 is a `TypeError` being thrown while trying to access a function that doesn't exists (anymore). Here is the error log of the packager when trying to access this endpoint :

```
TypeError: this._depGraph.getDebugInfo is not a function
    at Resolver.getDebugInfo (index.js:270:27)
    at Bundler.getGraphDebugInfo (index.js:575:27)
    at Server._processDebugRequest (index.js:369:28)
    at Server.processRequest (index.js:423:12)
    at next (/Users/blemair/Code/DependencyGraphTest/node_modules/connect/lib/proto.js:174:15)
    at Object.module.exports [as handle] (cpuProfilerMiddleware.js:17:5)
    at next (/Users/blemair/Code/DependencyGraphTest/node_modules/connect/lib/proto.js:174:15)
    at Object.module.exports [as handle] (systraceProfileMiddleware.js:17:5)
    at next (/Users/blemair/Code/DependencyGraphTest/node_modules/connect/lib/proto.js:174:15)
    at Object.module.exports [as handle] (statusPageMiddleware.js:19:5)
```

Ultimately this is due to the call to `this._depGraph.getDebugInfo()`.   
`_depGraph` here is an instance of the `DependencyGraph` class exported by `node_haste` module. After taking a look at the class from this module, there is indeed no `getDebugInfo()` method defined in this class (and it is not added to the `DependencyGraph` prototype anywhere in the packager code from what I can see).

I don't really know if this is an issue or just a dead endpoint for which documentation and code was not cleaned up. Anyway, I ultimately thought that opening a PR would be more appropriate than opening an issue as it'll help reviewer pinpoint in the code what I am talking about more precisely (by looking to the small commits). And in case this is indeed dead stuff (for now), then at least this PR is up and ready to clean things up quick and easy ;) If not, just close it and open an issue ;P