### PR TITLE
Added REACT_EDITOR_LINEFORMAT support to allow jumping to correct line with more editors

### DIFF
--- a/local-cli/server/util/launchEditor.js
+++ b/local-cli/server/util/launchEditor.js
@@ -35,28 +35,43 @@ var COMMON_EDITORS = {
 };
 
 function getArgumentsForLineNumber(editor, fileName, lineNumber) {
-  switch (path.basename(editor)) {
-    case 'vim':
-    case 'mvim':
-      return [fileName, '+' + lineNumber];
-    case 'atom':
-    case 'subl':
-    case 'sublime':
-      return [fileName + ':' + lineNumber];
-    case 'joe':
-    case 'emacs':
-    case 'emacsclient':
-      return ['+' + lineNumber, fileName];
-    case 'rmate':
-    case 'mate':
-    case 'mine':
-      return ['--line', lineNumber, fileName];
-  }
-
-  // For all others, drop the lineNumber until we have
-  // a mapping above, since providing the lineNumber incorrectly
+  // For all unknown situations, drop the lineNumber until we have
+  // a mapping, since providing the lineNumber incorrectly
   // can result in errors or confusing behavior.
-  return [fileName];
+	var lineFormat = "%f";
+
+	// Syntax for lineFormat:
+	// %f gets replaced with file name
+	// %l gets replaced with line number
+	// | splits arguments
+
+  if (process.env.REACT_EDITOR_LINEFORMAT) {
+    lineFormat = process.env.REACT_EDITOR_LINEFORMAT;
+  } else {
+		switch (path.basename(editor)) {
+			case 'vim':
+			case 'mvim':
+				lineFormat = "%f|+%l";
+				break;
+			case 'atom':
+			case 'subl':
+			case 'sublime':
+				lineFormat = "%f:%l";
+				break;
+			case 'joe':
+			case 'emacs':
+			case 'emacsclient':
+				lineFormat = "+%l|%f";
+				break;
+			case 'rmate':
+			case 'mate':
+			case 'mine':
+				lineFormat = "--line|%l|%f";
+				break;
+		}
+	}
+
+  return lineFormat.replace( /%f/g, fileName ).replace( /%l/g, lineNumber ).split( "|" );
 }
 
 function guessEditor() {

--- a/local-cli/server/util/launchEditor.js
+++ b/local-cli/server/util/launchEditor.js
@@ -110,7 +110,10 @@ function printInstructions(title) {
     '  editor of choice. It will first look at REACT_EDITOR environment ',
     '  variable, then at EDITOR. To set it up, you can add something like ',
     '  export REACT_EDITOR=atom to your ~/.bashrc or ~/.zshrc depending on ',
-    '  which shell you use.',
+    '  which shell you use. You can also define REACT_EDITOR_LINEFORMAT env',
+		'  variable to define how line number should be passed to your editor.',
+		'  Use %f for filename, %l for line number and | for splitting args, e.g.',
+		'  REACT_EDITOR_LINEFORMAT="--line|%l|%f"',
     ''
   ].join('\n'));
 }


### PR DESCRIPTION
When setting REACT_EDITOR to an editor which isn't recognized by RN, RN refuses to provide line number to the child spawn. So, opening correct file + correct line when clicking on red box is impossible. This change adds support for REACT_EDITOR_LINEFORMAT env variable which allows to guide RN how to pass the line number to user's editor.

The env var has following syntax:
- `%f` gets replaced with file name
- `%l` gets replaced with line number
- arguments are split by `|`

So, e.g. IntelliJ Idea might get `%f:%l` (resulting in args like `[ "foo.js:42" ]`), while other editor might get `--line|%l|%f` resulting in `[ "--line", "42", "foo.js" ]`.