### PR TITLE
Internal fixes for the iOS Explorer test script

### DIFF
--- a/scripts/objc-test.sh
+++ b/scripts/objc-test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -ex
 
 SCRIPTS=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 ROOT=$(dirname $SCRIPTS)
@@ -16,9 +16,17 @@ function cleanup {
     WATCHMAN_LOGS=/usr/local/Cellar/watchman/3.1/var/run/watchman/$USER.log
     [ -f $WATCHMAN_LOGS ] && cat $WATCHMAN_LOGS
   fi
+  [ $SERVER_PID ] && kill -9 $SERVER_PID
 }
 trap cleanup EXIT
 
+# Run the packager process directly
+node ./local-cli/cli.js start &
+SERVER_PID=$!
+
+XCODE_PROJECT="Examples/UIExplorer/UIExplorer.xcodeproj"
+XCODE_SCHEME="UIExplorer"
+XCODE_SDK="iphonesimulator"
 if [ -z "$XCODE_DESTINATION" ]; then
   XCODE_DESTINATION="platform=iOS Simulator,name=iPhone 5,OS=9.3"
 fi
@@ -27,17 +35,22 @@ fi
 set +e
 OUTPUT_TOOL=$(which xcpretty)
 set -e
-if [ -z "$OUTPUT_TOOL" ]; then
-  OUTPUT_TOOL="sed"
-fi
 
 # TODO: We use xcodebuild because xctool would stall when collecting info about
 # the tests before running them. Switch back when this issue with xctool has
 # been resolved.
-xcodebuild \
-  -project Examples/UIExplorer/UIExplorer.xcodeproj \
-  -scheme UIExplorer \
-  -sdk iphonesimulator \
-  -destination "$XCODE_DESTINATION" \
-  test \
-  | $OUTPUT_TOOL && exit ${PIPESTATUS[0]}
+if [ -z "$OUTPUT_TOOL" ]; then
+  xcodebuild \
+    -project $XCODE_PROJECT \
+    -scheme $XCODE_SCHEME \
+    -sdk $XCODE_SDK \
+    -destination "$XCODE_DESTINATION" \
+    test
+else
+  xcodebuild \
+    -project $XCODE_PROJECT \
+    -scheme $XCODE_SCHEME \
+    -sdk $XCODE_SDK \
+    -destination "$XCODE_DESTINATION" \
+    test | $OUTPUT_TOOL && exit ${PIPESTATUS[0]}
+fi


### PR DESCRIPTION
Some changes are required to this scripts in order to successfully run it on Sandcastle:

- the packager needs to be started before the test
- no xcpretty available, piping to anything else (e.g. `cat`) fails

Test Plan:

- Travis
- Sandcastle