### PR TITLE
IOS TextInput bug when input Chinese Pinyin

### DIFF
--- a/Libraries/Text/RCTTextField.m
+++ b/Libraries/Text/RCTTextField.m
@@ -142,6 +142,9 @@ static void RCTUpdatePlaceholder(RCTTextField *self)
 - (void)textFieldDidChange
 {
   _nativeEventCount++;
+  UITextRange *selectedRange = [self markedTextRange];
+  NSString * newText = [self textInRange:selectedRange];
+  if(newText.length>0) return;
   [_eventDispatcher sendTextEventWithType:RCTTextEventTypeChange
                                  reactTag:self.reactTag
                                      text:self.text

--- a/Libraries/Text/RCTTextView.m
+++ b/Libraries/Text/RCTTextView.m
@@ -477,7 +477,9 @@ static NSAttributedString *removeReactTagFromString(NSAttributedString *string)
   if (!self.reactTag || !_onChange) {
     return;
   }
-
+  UITextRange *selectedRange = [textView markedTextRange];
+  NSString * newText = [textView textInRange:selectedRange];
+  if(newText.length>0) return;
   // When the context size increases, iOS updates the contentSize twice; once
   // with a lower height, then again with the correct height. To prevent a
   // spurious event from being sent, we track the previous, and only send the


### PR DESCRIPTION
I'm experiencing a issue about input Chinese Pinyin.
I'm using 0.27.2,
I have the following codes:
```
render(){
    return <TextInput value={this.state.value} onChangeText={(text) => this._onChangeText(text)}/>
}
_onChangeText(text){
    this.setState({value: text});
}
```
Under the Chinese Pinyin input mode, when i input the first letter, then _onChangeText function invoked,
and then the TextInput value property  changed, this lead to a "can't input Chinese" bug.
After seaching about Chinese Piyin input on ios, i fixed this issue in this patch, that is when textinput exist selected text, don't send onChange event.
But i' m not sure if i'm doing the correct thing, as in my another project using 0.25.1 does not produce this issue.
