### PR TITLE
Defend against nil pointer in RCTImageLoader.m

### DIFF
--- a/Libraries/Image/RCTImageLoader.m
+++ b/Libraries/Image/RCTImageLoader.m
@@ -382,6 +382,9 @@ static UIImage *RCTResizeImageIfNeeded(UIImage *image,
     if (error) {
       completionHandler(error, nil);
       return;
+    } else if (!response) {
+      completionHandler(RCTErrorWithMessage(@"Response metadata error"), nil);
+      return;
     } else if (!data) {
       completionHandler(RCTErrorWithMessage(@"Unknown image download error"), nil);
       return;
@@ -435,8 +438,16 @@ static UIImage *RCTResizeImageIfNeeded(UIImage *image,
   // Download image
   __weak __typeof(self) weakSelf = self;
   RCTNetworkTask *task = [networking networkTaskWithRequest:request completionBlock:^(NSURLResponse *response, NSData *data, NSError *error) {
-    if (error) {
-      completionHandler(error, nil);
+    if (error || !response || !data) {
+      NSError *someError = nil;
+      if (error) {
+        someError = error;
+      } else if (!response) {
+        someError = RCTErrorWithMessage(@"Response metadata error");
+      } else {
+        someError = RCTErrorWithMessage(@"Unknown image download error");
+      }
+      completionHandler(someError, nil);
       [weakSelf dequeueTasks];
       return;
     }


### PR DESCRIPTION
Defend against nil pointer in RCTImageLoader.m. In some rare case, the "response" might be nil, and this would lead to crash.

This issue is related: https://github.com/facebook/react-native/issues/6952