### PR TITLE
Improve autogen for reference docs including jsdoc support

### DIFF
--- a/Libraries/Components/StatusBar/StatusBar.js
+++ b/Libraries/Components/StatusBar/StatusBar.js
@@ -159,8 +159,8 @@ const StatusBar = React.createClass({
 
     /**
      * Show or hide the status bar
-     * @param {boolean} hidden The dialog's title.
-     * @param {StatusBarAnimation=} animation Optional animation when
+     * @param hidden The dialog's title.
+     * @param animation Optional animation when
      *    changing the status bar hidden property.
      */
     setHidden(hidden: boolean, animation?: StatusBarAnimation) {
@@ -175,8 +175,8 @@ const StatusBar = React.createClass({
 
     /**
      * Set the status bar style
-     * @param {StatusBarStyle} style Status bar style to set
-     * @param {boolean=} animated Animate the style change.
+     * @param style Status bar style to set
+     * @param animated Animate the style change.
      */
     setBarStyle(style: StatusBarStyle, animated?: boolean) {
       if (Platform.OS !== 'ios') {
@@ -190,7 +190,7 @@ const StatusBar = React.createClass({
 
     /**
      * Control the visibility of the network activity indicator
-     * @param {boolean} visible Show the indicator.
+     * @param visible Show the indicator.
      */
     setNetworkActivityIndicatorVisible(visible: boolean) {
       if (Platform.OS !== 'ios') {
@@ -203,8 +203,8 @@ const StatusBar = React.createClass({
 
     /**
      * Set the background color for the status bar
-     * @param {string} color Background color.
-     * @param {boolean=} animated Animate the style change.
+     * @param color Background color.
+     * @param animated Animate the style change.
      */
     setBackgroundColor(color: string, animated?: boolean) {
       if (Platform.OS !== 'android') {
@@ -218,7 +218,7 @@ const StatusBar = React.createClass({
 
     /**
      * Control the translucency of the status bar
-     * @param {boolean} translucent Set as translucent.
+     * @param translucent Set as translucent.
      */
     setTranslucent(translucent: boolean) {
       if (Platform.OS !== 'android') {

--- a/Libraries/Components/StatusBar/StatusBar.js
+++ b/Libraries/Components/StatusBar/StatusBar.js
@@ -19,14 +19,35 @@ const processColor = require('processColor');
 
 const StatusBarManager = require('NativeModules').StatusBarManager;
 
+/**
+ * Status bar style
+ */
 export type StatusBarStyle = $Enum<{
+  /**
+   * Default status bar style
+   */
   'default': string,
+  /**
+   * Dark background style
+   */
   'light-content': string,
 }>;
 
+/**
+ * Status bar animation
+ */
 export type StatusBarAnimation = $Enum<{
+  /**
+   * No animation
+   */
   'none': string,
+  /**
+   * Fade animation
+   */
   'fade': string,
+  /**
+   * Slide animation
+   */
   'slide': string,
 }>;
 
@@ -135,6 +156,13 @@ const StatusBar = React.createClass({
 
     // Provide an imperative API as static functions of the component.
     // See the corresponding prop for more detail.
+
+    /**
+     * Show or hide the status bar
+     * @param {boolean} hidden The dialog's title.
+     * @param {StatusBarAnimation=} animation Optional animation when
+     *    changing the status bar hidden property.
+     */
     setHidden(hidden: boolean, animation?: StatusBarAnimation) {
       animation = animation || 'none';
       StatusBar._defaultProps.hidden.value = hidden;
@@ -145,6 +173,11 @@ const StatusBar = React.createClass({
       }
     },
 
+    /**
+     * Set the status bar style
+     * @param {StatusBarStyle} style Status bar style to set
+     * @param {boolean=} animated Animate the style change.
+     */
     setBarStyle(style: StatusBarStyle, animated?: boolean) {
       if (Platform.OS !== 'ios') {
         console.warn('`setBarStyle` is only available on iOS');
@@ -155,6 +188,10 @@ const StatusBar = React.createClass({
       StatusBarManager.setStyle(style, animated);
     },
 
+    /**
+     * Control the visibility of the network activity indicator
+     * @param {boolean} visible Show the indicator.
+     */
     setNetworkActivityIndicatorVisible(visible: boolean) {
       if (Platform.OS !== 'ios') {
         console.warn('`setNetworkActivityIndicatorVisible` is only available on iOS');
@@ -164,6 +201,11 @@ const StatusBar = React.createClass({
       StatusBarManager.setNetworkActivityIndicatorVisible(visible);
     },
 
+    /**
+     * Set the background color for the status bar
+     * @param {string} color Background color.
+     * @param {boolean=} animated Animate the style change.
+     */
     setBackgroundColor(color: string, animated?: boolean) {
       if (Platform.OS !== 'android') {
         console.warn('`setBackgroundColor` is only available on Android');
@@ -174,6 +216,10 @@ const StatusBar = React.createClass({
       StatusBarManager.setColor(processColor(color), animated);
     },
 
+    /**
+     * Control the translucency of the status bar
+     * @param {boolean} translucent Set as translucent.
+     */
     setTranslucent(translucent: boolean) {
       if (Platform.OS !== 'android') {
         console.warn('`setTranslucent` is only available on Android');

--- a/Libraries/Utilities/AlertIOS.js
+++ b/Libraries/Utilities/AlertIOS.js
@@ -109,17 +109,17 @@ class AlertIOS {
    * Create and display a popup alert.
    * @static
    * @method alert
-   * @param {string} title The dialog's title.
-   * @param {string=} message An optional message that appears below
+   * @param title The dialog's title.
+   * @param message An optional message that appears below
    *     the dialog's title.
-   * @param {(Function|ButtonsArray)=} callbackOrButtons This optional argument should
+   * @param callbackOrButtons This optional argument should
    *    be either a single-argument function or an array of buttons. If passed
    *    a function, it will be called when the user taps 'OK'.
    *
    *    If passed an array of button configurations, each button should include
    *    a `text` key, as well as optional `onPress` and `style` keys. `style`
    *    should be one of 'default', 'cancel' or 'destructive'.
-   * @param {AlertType=} type Deprecated, do not use.
+   * @param type Deprecated, do not use.
    *
    * @example <caption>Example with custom buttons</caption>
    *
@@ -150,10 +150,10 @@ class AlertIOS {
    * Create and display a prompt to enter some text.
    * @static
    * @method prompt
-   * @param {string} title The dialog's title.
-   * @param {string=} message An optional message that appears above the text
+   * @param title The dialog's title.
+   * @param message An optional message that appears above the text
    *    input.
-   * @param {(Function|ButtonsArray)=} callbackOrButtons This optional argument should
+   * @param callbackOrButtons This optional argument should
    *    be either a single-argument function or an array of buttons. If passed
    *    a function, it will be called with the prompt's value when the user
    *    taps 'OK'.
@@ -161,9 +161,9 @@ class AlertIOS {
    *    If passed an array of button configurations, each button should include
    *    a `text` key, as well as optional `onPress` and `style` keys (see
    *    example). `style` should be one of 'default', 'cancel' or 'destructive'.
-   * @param {AlertType=} type This configures the text input. One of 'plain-text',
+   * @param type This configures the text input. One of 'plain-text',
    *    'secure-text' or 'login-password'.
-   * @param {string} defaultValue The dialog's title.
+   * @param defaultValue The dialog's title.
    *
    * @example <caption>Example with custom buttons</caption>
    *

--- a/Libraries/Utilities/AlertIOS.js
+++ b/Libraries/Utilities/AlertIOS.js
@@ -8,64 +8,129 @@
  *
  * @providesModule AlertIOS
  * @flow
+ * @jsdoc
  */
 'use strict';
 
 var RCTAlertManager = require('NativeModules').AlertManager;
 
+/**
+ * An Alert button type
+ */
 export type AlertType = $Enum<{
+  /**
+   * Default alert with no inputs
+   */
   'default': string;
+  /**
+   * Plain text input alert
+   */
   'plain-text': string;
+  /**
+   * Secure text input alert
+   */
   'secure-text': string;
+  /**
+   * Login and password alert
+   */
   'login-password': string;
 }>;
 
+/**
+ * An Alert button style
+ */
 export type AlertButtonStyle = $Enum<{
+  /**
+   * Default button style
+   */
   'default': string;
+  /**
+   * Cancel button style
+   */
   'cancel': string;
+  /**
+   * Destructive button style
+   */
   'destructive': string;
 }>;
 
+/**
+ * Array or buttons
+ * @typedef {Array} ButtonsArray
+ * @property {string=} text Button label
+ * @property {Function=} onPress Callback function when button pressed
+ * @property {AlertButtonStyle=} style Button style
+ */
 type ButtonsArray = Array<{
+  /**
+   * Button label
+   */
   text?: string;
+  /**
+   * Callback function when button pressed
+   */
   onPress?: ?Function;
+  /**
+   * Button style
+   */
   style?: AlertButtonStyle;
 }>;
 
 /**
- * The AlertsIOS utility provides two functions: `alert` and `prompt`. All
- * functionality available through `AlertIOS.alert` is also available in the
- * cross-platform `Alert.alert`, which we recommend you use if you don't need
- * iOS-specific functionality.
+ * @description
+ * `AlertIOS` provides functionality to create an iOS alert dialog with a
+ * message or create a prompt for user input.
  *
- * `AlertIOS.prompt` allows you to prompt the user for input inside of an
- * alert popup.
+ * Creating an iOS alert:
+ *
+ * ```
+ * AlertIOS.alert(
+ *  'Sync Complete',
+ *  'All your data are belong to us.'
+ * );
+ * ```
+ *
+ * Creating an iOS prompt:
+ *
+ * ```
+ * AlertIOS.prompt(
+ *   'Enter a value',
+ *   null,
+ *   text => console.log("You entered "+text)
+ * );
+ * ```
+ *
+ * We recommend using the [`Alert.alert`](/docs/alert.html) method for
+ * cross-platform support if you don't need to create iOS-only prompts.
  *
  */
 class AlertIOS {
   /**
-   * Creates a popup to alert the user. See
-   * [Alert](docs/alert.html).
-   *
-   *  - title: string -- The dialog's title.
-   *  - message: string -- An optional message that appears above the text input.
-   *  - callbackOrButtons -- This optional argument should be either a
-   *    single-argument function or an array of buttons. If passed a function,
-   *    it will be called when the user taps 'OK'.
+   * Create and display a popup alert.
+   * @static
+   * @method alert
+   * @param {string} title The dialog's title.
+   * @param {string=} message An optional message that appears below
+   *     the dialog's title.
+   * @param {(Function|ButtonsArray)=} callbackOrButtons This optional argument should
+   *    be either a single-argument function or an array of buttons. If passed
+   *    a function, it will be called when the user taps 'OK'.
    *
    *    If passed an array of button configurations, each button should include
-   *    a `text` key, as well as optional `onPress` and `style` keys.
-   *    `style` should be one of 'default', 'cancel' or 'destructive'.
-   *  - type -- *deprecated, do not use*
+   *    a `text` key, as well as optional `onPress` and `style` keys. `style`
+   *    should be one of 'default', 'cancel' or 'destructive'.
+   * @param {AlertType=} type Deprecated, do not use.
    *
-   * Example:
+   * @example <caption>Example with custom buttons</caption>
    *
-   * ```
    * AlertIOS.alert(
-   *  'Sync Complete',
-   *  'All your data are belong to us.'
+   *  'Update available',
+   *  'Keep your app up to date to enjoy the latest features',
+   *  [
+   *    {text: 'Cancel', onPress: () => console.log('Cancel Pressed'), style: 'cancel'},
+   *    {text: 'Install', onPress: () => console.log('Install Pressed')},
+   *  ],
    * );
-   * ```
    */
   static alert(
     title: ?string,
@@ -82,23 +147,26 @@ class AlertIOS {
   }
 
   /**
-   * Prompt the user to enter some text.
-   *
-   *  - title: string -- The dialog's title.
-   *  - message: string -- An optional message that appears above the text input.
-   *  - callbackOrButtons -- This optional argument should be either a
-   *    single-argument function or an array of buttons. If passed a function,
-   *    it will be called with the prompt's value when the user taps 'OK'.
+   * Create and display a prompt to enter some text.
+   * @static
+   * @method prompt
+   * @param {string} title The dialog's title.
+   * @param {string=} message An optional message that appears above the text
+   *    input.
+   * @param {(Function|ButtonsArray)=} callbackOrButtons This optional argument should
+   *    be either a single-argument function or an array of buttons. If passed
+   *    a function, it will be called with the prompt's value when the user
+   *    taps 'OK'.
    *
    *    If passed an array of button configurations, each button should include
-   *    a `text` key, as well as optional `onPress` and `style` keys (see example).
-   *    `style` should be one of 'default', 'cancel' or 'destructive'.
-   *  - type: string -- This configures the text input. One of 'plain-text',
+   *    a `text` key, as well as optional `onPress` and `style` keys (see
+   *    example). `style` should be one of 'default', 'cancel' or 'destructive'.
+   * @param {AlertType=} type This configures the text input. One of 'plain-text',
    *    'secure-text' or 'login-password'.
-   *  - defaultValue: string -- the default value for the text field.
+   * @param {string} defaultValue The dialog's title.
    *
-   * Example with custom buttons:
-   * ```
+   * @example <caption>Example with custom buttons</caption>
+   *
    * AlertIOS.prompt(
    *   'Enter password',
    *   'Enter your password to claim your $1.5B in lottery winnings',
@@ -108,18 +176,16 @@ class AlertIOS {
    *   ],
    *   'secure-text'
    * );
-   * ```
    *
-   * Example with the default button and a custom callback:
-   * ```
+   * @example <caption>Example with the default button and a custom callback</caption>
+   *
    * AlertIOS.prompt(
    *   'Update username',
    *   null,
    *   text => console.log("Your username is "+text),
    *   null,
    *   'default'
-   * )
-   * ```
+   * );
    */
   static prompt(
     title: ?string,

--- a/website/jsdocs/jsdoc-conf.json
+++ b/website/jsdocs/jsdoc-conf.json
@@ -1,0 +1,15 @@
+{
+    "tags": {
+        "allowUnknownTags": true,
+        "dictionaries": ["jsdoc","closure"]
+    },
+    "source": {
+        "includePattern": ".+\\.js(doc)?$",
+        "excludePattern": "(^|\\/|\\\\)_"
+    },
+    "plugins": ["./jsdocs/jsdoc-plugin-values"],
+    "templates": {
+        "cleverLinks": true,
+        "monospaceLinks": false
+    }
+}

--- a/website/jsdocs/jsdoc-plugin-values.js
+++ b/website/jsdocs/jsdoc-plugin-values.js
@@ -1,0 +1,11 @@
+exports.defineTags = function(dictionary) {
+    dictionary.defineTag('value', {
+        mustHaveValue: true,
+        canHaveType: true,
+        canHaveName: true,
+        onTagged: function(doclet, tag) {
+            if (!doclet.values) { doclet.values = []; }
+            doclet.values.push(tag.value);
+        }
+    });
+};

--- a/website/package.json
+++ b/website/package.json
@@ -13,7 +13,7 @@
     "mkdirp": "^0.5.1",
     "optimist": "0.6.0",
     "react": "~0.13.0",
-    "react-docgen": "^2.8.0",
+    "react-docgen": "^2.9.0",
     "react-page-middleware": "git://github.com/facebook/react-page-middleware.git",
     "request": "^2.69.0",
     "semver-compare": "^1.0.0",
@@ -23,6 +23,7 @@
     "babel-preset-react-native": "~1.6.0",
     "babel-register": "^6.6.0",
     "babel-types": "^6.6.4",
-    "jsdoc-api": "^1.1.0"
+    "jsdoc-api": "^1.1.0",
+    "deep-assign": "^2.0.0"
   }
 }

--- a/website/package.json
+++ b/website/package.json
@@ -16,6 +16,13 @@
     "react-docgen": "^2.8.0",
     "react-page-middleware": "git://github.com/facebook/react-page-middleware.git",
     "request": "^2.69.0",
-    "semver-compare": "^1.0.0"
+    "semver-compare": "^1.0.0",
+    "babel-core": "^6.6.4",
+    "babel-plugin-external-helpers": "^6.5.0",
+    "babel-polyfill": "^6.6.1",
+    "babel-preset-react-native": "~1.6.0",
+    "babel-register": "^6.6.0",
+    "babel-types": "^6.6.4",
+    "jsdoc-api": "^1.1.0"
   }
 }

--- a/website/server/extractDocs.js
+++ b/website/server/extractDocs.js
@@ -15,6 +15,8 @@ const fs = require('fs');
 const jsDocs = require('../jsdocs/jsdocs.js');
 const path = require('path');
 const slugify = require('../core/slugify');
+const babel = require('babel-core');
+const jsdocApi = require('jsdoc-api');
 
 const ANDROID_SUFFIX = 'android';
 const CROSS_SUFFIX = 'cross';
@@ -58,8 +60,8 @@ function getPlatformFromPath(filepath) {
 }
 
 function getExamplePaths(componentName, componentPlatform) {
-  var componentExample = '../Examples/UIExplorer/' + componentName + 'Example.';
-  var pathsToCheck = [
+  const componentExample = '../Examples/UIExplorer/' + componentName + 'Example.';
+  let pathsToCheck = [
     componentExample + 'js',
     componentExample + componentPlatform + '.js',
   ];
@@ -69,7 +71,7 @@ function getExamplePaths(componentName, componentPlatform) {
       componentExample + ANDROID_SUFFIX + '.js'
     );
   }
-  var paths = [];
+  let paths = [];
   pathsToCheck.map((p) => {
     if (fs.existsSync(p)) {
       paths.push(p);
@@ -79,12 +81,12 @@ function getExamplePaths(componentName, componentPlatform) {
 }
 
 function getExamples(componentName, componentPlatform) {
-  var paths = getExamplePaths(componentName, componentPlatform);
+  const paths = getExamplePaths(componentName, componentPlatform);
   if (paths) {
-    var examples = [];
+    let examples = [];
     paths.map((p) => {
-      var platform = p.match(/Example\.(.*)\.js$/);
-      var title = '';
+      const platform = p.match(/Example\.(.*)\.js$/);
+      let title = '';
       if ((componentPlatform === CROSS_SUFFIX) && (platform !== null)) {
         title = platform[1].toUpperCase();
       }
@@ -128,7 +130,7 @@ function filterMethods(method) {
 // Determines whether a component should have a link to a runnable example
 
 function isRunnable(componentName, componentPlatform) {
-  var paths = getExamplePaths(componentName, componentPlatform);
+  const paths = getExamplePaths(componentName, componentPlatform);
   if (paths && paths.length > 0) {
     return true;
   } else {
@@ -206,30 +208,127 @@ function componentsToMarkdown(type, json, filepath, idx, styles) {
 
 let componentCount;
 
+function getTypedef(filepath, fileContents, json) {
+  let typedefDocgen;
+  try {
+    typedefDocgen = docgen.parse(
+      fileContents,
+      docgenHelpers.findExportedType,
+      [docgenHelpers.typedefHandler]
+    ).map((type) => type.typedef);
+  } catch (e) {
+    // Ignore errors due to missing exported type definitions
+    if (e.message.indexOf(docgen.ERROR_MISSING_DEFINITION) !== -1) {
+      console.error('Cannot parse file', filepath, e);
+    }
+  }
+  if (!json) {
+    return typedefDocgen;
+  }
+  let typedef = typedefDocgen;
+  if (json.typedef && json.typedef.length !== 0) {
+    json.typedef.forEach(def => {
+      const typedefMatch = typedefDocgen.find(t => t.name === def.name);
+      if (typedefMatch) {
+        typedef.name = Object.assign(typedefMatch, def);
+      } else {
+        typedef.push(def);
+      }
+    });
+  }
+  return typedef;
+}
+
 function renderComponent(filepath) {
+  const fileContent = fs.readFileSync(filepath);
   const json = docgen.parse(
-    fs.readFileSync(filepath),
+    fileContent,
     docgenHelpers.findExportedOrFirst,
     docgen.defaultHandlers.concat([
       docgenHelpers.stylePropTypeHandler,
       docgenHelpers.deprecatedPropTypeHandler,
+      docgenHelpers.jsDocFormatHandler,
     ])
   );
+  json.typedef = getTypedef(filepath, fileContent);
 
   return componentsToMarkdown('component', json, filepath, componentCount++, styleDocs);
 }
 
-function renderAPI(type) {
-  return function(filepath) {
-    let json;
-    try {
-      json = jsDocs(fs.readFileSync(filepath).toString());
-    } catch (e) {
-      console.error('Cannot parse file', filepath, e);
-      json = {};
-    }
-    return componentsToMarkdown(type, json, filepath, componentCount++);
+function isJsDocFormat(fileContent) {
+  const reComment = /\/\*\*[\s\S]+?\*\//g;
+  const comments = fileContent.match(reComment);
+  if (!comments) {
+    return false;
+  }
+  return !!comments[0].match(/\s*\*\s+@jsdoc/);
+}
+
+function parseAPIJsDocFormat(filepath, fileContent) {
+  const fileName = path.basename(filepath);
+  const babelRC = {
+    'filename': fileName,
+    'sourceFileName': fileName,
+    'plugins': [
+      'transform-flow-strip-types',
+      'babel-plugin-syntax-trailing-function-commas',
+    ]
   };
+  // Babel transform
+  const code = babel.transform(fileContent, babelRC).code;
+  // Parse via jsdocs
+  let jsonParsed = jsdocApi.explainSync({
+    source: code,
+    configure: './jsdocs/jsdoc-conf.json'
+  });
+  // Cleanup jsdocs return
+  jsonParsed = jsonParsed.filter(i => {
+    return !i.undocumented && !/package|file/.test(i.kind);
+  });
+  jsonParsed = jsonParsed.map((identifier) => {
+    delete identifier.comment;
+    return identifier;
+  });
+  jsonParsed.forEach((identifier, index) => {
+    identifier.order = index;
+  });
+  // Group by "kind"
+  let json = {};
+  jsonParsed.forEach((identifier, index) => {
+    let kind = identifier.kind;
+    if (kind === 'function') {
+      kind = 'methods';
+    }
+    if (!json[kind]) {
+      json[kind] = [];
+    }
+    delete identifier.kind;
+    json[kind].push(identifier);
+  });
+  json.typedef = getTypedef(filepath, fileContent, json);
+  return json;
+}
+
+function parseAPIInferred(filepath, fileContent) {
+  let json;
+  try {
+    json = jsDocs(fileContent);
+  } catch (e) {
+    console.error('Cannot parse file', filepath, e);
+    json = {};
+  }
+  return json;
+}
+
+function renderAPI(filepath, type) {
+  let json;
+  const fileContent = fs.readFileSync(filepath).toString();
+  if (isJsDocFormat(fileContent)) {
+    json = parseAPIJsDocFormat(filepath, fileContent);
+  } else {
+    json = parseAPIInferred(filepath, fileContent);
+  }
+  return componentsToMarkdown(type, json, filepath, componentCount++);
 }
 
 function renderStyle(filepath) {
@@ -355,8 +454,12 @@ module.exports = function() {
   componentCount = 0;
   return [].concat(
     components.map(renderComponent),
-    apis.map(renderAPI('api')),
+    apis.map((filepath) => {
+      return renderAPI(filepath, 'api');
+    }),
     stylesWithPermalink.map(renderStyle),
-    polyfills.map(renderAPI('Polyfill'))
+    polyfills.map((filepath) => {
+      return renderAPI(filepath, 'Polyfill');
+    })
   );
 };

--- a/website/src/react-native/css/react-native.css
+++ b/website/src/react-native/css/react-native.css
@@ -1545,3 +1545,53 @@ input#algolia-doc-search:focus {
   background-color: hsl(198, 100%, 96%);
   color: #3B3738;
 }
+
+.params, .props
+{
+    border-spacing: 0;
+    border: 0;
+    border-collapse: collapse;
+}
+
+.params .name, .props .name, .name code {
+    color: #4D4E53;
+}
+
+.params td, .params th, .props td, .props th
+{
+    border: 1px solid #ddd;
+    margin: 0px;
+    text-align: left;
+    vertical-align: top;
+    padding: 4px 6px;
+    display: table-cell;
+}
+
+.params thead tr, .props thead tr
+{
+    background-color: hsl(198, 75%, 88%);
+    font-weight: bold;
+}
+
+.params .params thead tr, .props .props thead tr
+{
+    background-color: #fff;
+    font-weight: bold;
+}
+
+.params th, .props th { border-right: 1px solid #aaa; }
+.params thead .last, .props thead .last { border-right: 1px solid #ddd; }
+
+.params td.description > div > p:first-child,
+.props td.description > div > p:first-child
+{
+    margin-top: 0;
+    padding-top: 0;
+}
+
+.params td.description > p:last-child,
+.props td.description > p:last-child
+{
+    margin-bottom: 0;
+    padding-bottom: 0;
+}


### PR DESCRIPTION
As part of improving the API and Component reference docs #8154 this pull request adds the following:

- jsdoc support for API docs. See the AlertIOS changes as an example.
- type definitions support and added to both API and Component docs. This is supported via react-docgen and jsdoc.
- better formatting of method properties (now shown in a table).

FYI, API and Component docs were previously generated in two different ways. Components were using react-docgen and that basically remains as-is. APIs were using custom parsing code and that's been switched to use a jsdoc parser + react-docgen as an option for typedefs (it could also use the jsdoc parser).

Two docs have been updated to showcase how we'd like the new docs to look:

- AlertIOS (API): showing method parameters, examples, typedefs, more details overall.
- Statusbar (Component): showing method parameters, typedefs, more details overall.

**Note**: To convert new API docs to use the new format, add `@jsdoc` to the initial file comment. Component docs will show new details as they're added.

**Test plan (required)**

    cd react-native
    npm install
    cd website
    npm install
    npm start

**Checked:** http://localhost:8079/react-native/docs/alertios.html

![api_example_alertios](https://cloud.githubusercontent.com/assets/691109/16159358/3573aef6-3477-11e6-95f5-72e66d6d145a.png)

**Checked:** http://localhost:8079/react-native/docs/statusbar.html

![component_example_statusbar](https://cloud.githubusercontent.com/assets/691109/16159369/3d4b44fe-3477-11e6-8cc9-1c8a4f48afd5.png)