### PR TITLE
Added userAgent prop type in docs for webview

### DIFF
--- a/Libraries/Components/WebView/WebView.ios.js
+++ b/Libraries/Components/WebView/WebView.ios.js
@@ -213,6 +213,13 @@ var WebView = React.createClass({
     injectedJavaScript: PropTypes.string,
 
     /**
+     * Sets the user-agent for this WebView. The user-agent can also be set in native using
+     * WebViewConfig. This prop will overwrite that config.
+     * @platform android
+     */
+    userAgent: PropTypes.string,
+
+    /**
      * Sets whether the webpage scales to fit the view and the user can change the scale.
      */
     scalesPageToFit: PropTypes.bool,


### PR DESCRIPTION
userAgent as a prop type is available in WebView for android but is not documented. This PR fixes it.

**TestPlan** : Not required as this just adds an entry in the documentation

![webview react native a framework for building native apps using react 2016-06-18 02-14-58](https://cloud.githubusercontent.com/assets/6805530/16164289/e8908526-34fa-11e6-98fe-face38ff9f51.png)
