### PR TITLE
React.xcodeproj build phase run script edit

### DIFF
--- a/React/React.xcodeproj/project.pbxproj
+++ b/React/React.xcodeproj/project.pbxproj
@@ -657,7 +657,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if nc -w 5 -z localhost 8081 ; then\n  if ! curl -s \"http://localhost:8081/status\" | grep -q \"packager-status:running\" ; then\n    echo \"Port 8081 already in use, packager is either not running or not running correctly\"\n    exit 2\n  fi\nelse\n  open \"$SRCROOT/../packager/launchPackager.command\" || echo \"Can't start packager automatically\"\nfi";
+			shellScript = "if ! \"$REACT_NATIVE_DISABLE_PACKAGER\" ; then\n  if nc -w 5 -z localhost 8081 ; then\n    if ! curl -s \"http://localhost:8081/status\" | grep -q \"packager-status:running\" ; then\n    echo \"Port 8081 already in use, packager is either not running or not running correctly\"\n    exit 2\n  fi\n  else\n    open \"$SRCROOT/../packager/launchPackager.command\" || echo \"Can't start packager automatically\"\n  fi\nfi";
 		};
 		142C4F7F1B582EA6001F0B58 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION
I got extremely tired of the `React.xcodeproj` build phase script launching the packager instance when I wanted to run my own.

My development experience would be as follows:

`react-native run-ios` in iTerm2
-> Terminal launches with packager command
`Cmd+q` hopefully in time before the script launches, otherwise I would have to press `enter` as well, to exit the terminal with the "Are you sure message"
`npm run start`
-> launches dev server so the app can run locally

With this change, my dev experience can be as follows:

`npm run dev` -> `export REACT_NATIVE_DISABLE_PACKAGER=true && react-native run-ios && unset REACT_NATIVE_DISABLE_PACKAGER && npm run start`

Of course, I can edit that in to a bash script and point my `npm run dev` to that as well.

I'm assuming that eventually this build phase script will be removed, and I can definitely understand its current implementation with regards to ease-of-use and learning react-native, but it's a real pain in the backside for those of us who want to customize our environments a little more.

While this script is in place, this little change at least gives us the option to disable it.

I tested all of the commands above and made sure `React` built as expected, with and without the exported variable.

