### PR TITLE
Fix Chinese chars in children of TextInput

### DIFF
--- a/Libraries/Text/RCTTextManager.m
+++ b/Libraries/Text/RCTTextManager.m
@@ -149,7 +149,7 @@ RCT_EXPORT_SHADOW_PROPERTY(textShadowColor, UIColor)
       UIEdgeInsets padding = shadowText.paddingAsInsets;
       CGFloat width = shadowText.frame.size.width - (padding.left + padding.right);
 
-      NSTextStorage *textStorage = [shadowText buildTextStorageForWidth:width widthMode:CSS_MEASURE_MODE_EXACTLY];
+      NSTextStorage *textStorage = [shadowText buildTextStorageForWidth:width widthMode:isnan(width) ? CSS_MEASURE_MODE_UNDEFINED : CSS_MEASURE_MODE_EXACTLY];
       [uiBlocks addObject:^(RCTUIManager *uiManager, NSDictionary<NSNumber *, RCTTextView *> *viewRegistry) {
         RCTTextView *textView = viewRegistry[reactTag];
         RCTText *text;


### PR DESCRIPTION
Revert the change in the line of [362738a](https://github.com/facebook/react-native/commit/362738a776074b4d327d98650a1b85b5b534a0f1#diff-b420deaf37c44d3ff103e4aa56228bb7L96), to fix the issue #7851:

> Since v0.26, Put a code like this below:
`<TextInput multiline><Text>中文</Text></TextInput>`
The app will run into no response, cpu 100%, memory increasing 20M per second.

cc @javache