### PR TITLE
Fixed bug since Map.prototype.includes is not defined in some contexts.

### DIFF
--- a/Libraries/CustomComponents/Navigator/NavigatorNavigationBar.js
+++ b/Libraries/CustomComponents/Navigator/NavigatorNavigationBar.js
@@ -188,7 +188,7 @@ var NavigatorNavigationBar = React.createClass({
     /*object*/route,
     /*number*/index
   ) /*?Object*/ {
-    if (this._descriptors[componentName].includes(route)) {
+    if (this._descriptors[componentName].has(route)) {
       return this._descriptors[componentName].get(route);
     }
 


### PR DESCRIPTION
In NavigatorNavigationBar.js, sometimes the following lines would throw an error if the Maps for LeftButton, RightButton, and Title weren't initialized yet, but were instead empty Maps. We should be using the Map method "has" instead of the "includes" method, since this works in all cases on _descriptors regardless of its initialization state.