### PR TITLE
[Android] Implement addUIBlock to allow third party to resolve a view

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeViewHierarchyManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeViewHierarchyManager.java
@@ -83,7 +83,7 @@ public class NativeViewHierarchyManager {
     mRootTags = new SparseBooleanArray();
   }
 
-  protected final View resolveView(int tag) {
+  public final View resolveView(int tag) {
     View view = mTagsToViews.get(tag);
     if (view == null) {
       throw new IllegalViewOperationException("Trying to resolve view with tag " + tag
@@ -92,7 +92,7 @@ public class NativeViewHierarchyManager {
     return view;
   }
 
-  protected final ViewManager resolveViewManager(int tag) {
+  public final ViewManager resolveViewManager(int tag) {
     ViewManager viewManager = mTagsToViewManagers.get(tag);
     if (viewManager == null) {
       throw new IllegalViewOperationException("ViewManager for tag " + tag + " could not be found");

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIBlock.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIBlock.java
@@ -1,0 +1,10 @@
+package com.facebook.react.uimanager;
+
+import android.view.View;
+
+/**
+ * A task to execute on the UI View for third party libraries.
+ */
+public interface UIBlock {
+  public void execute(NativeViewHierarchyManager nativeViewHierarchyManager);
+}

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIImplementation.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIImplementation.java
@@ -774,4 +774,8 @@ public class UIImplementation {
     }
     cssNode.markUpdateSeen();
   }
+
+  public void addUIBlock(UIBlock block) {
+    mOperationsQueue.enqueueUIBlock(block);
+  }
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModule.java
@@ -473,4 +473,8 @@ public class UIManagerModule extends ReactContextBaseJavaModule implements
   public void sendAccessibilityEvent(int tag, int eventType) {
     mUIImplementation.sendAccessibilityEvent(tag, eventType);
   }
+
+  public void addUIBlock (UIBlock block) {
+    mUIImplementation.addUIBlock(block);
+  }
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModule.java
@@ -474,6 +474,22 @@ public class UIManagerModule extends ReactContextBaseJavaModule implements
     mUIImplementation.sendAccessibilityEvent(tag, eventType);
   }
 
+  /**
+   * Schedule a block to be executed on the UI thread. Useful if you need to execute
+   * view logic after all currently queued view updates have completed.
+   *
+   * @param block that contains UI logic you want to execute.
+   *
+   * Usage Example:
+
+   UIManagerModule uiManager = reactContext.getNativeModule(UIManagerModule.class);
+   uiManager.addUIBlock(new UIBlock() {
+     public void execute (NativeViewHierarchyManager nvhm) {
+       View view = nvhm.resolveView(tag);
+       // ...execute your code on View (e.g. snapshot the view)
+     }
+   });
+     */
   public void addUIBlock (UIBlock block) {
     mUIImplementation.addUIBlock(block);
   }

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIViewOperationQueue.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIViewOperationQueue.java
@@ -494,6 +494,18 @@ public class UIViewOperationQueue {
     }
   }
 
+  private class UIBlockOperation implements UIOperation {
+    private final UIBlock mBlock;
+    public UIBlockOperation (UIBlock block) {
+      mBlock = block;
+    }
+
+    @Override
+    public void execute() {
+      mBlock.execute(mNativeViewHierarchyManager);
+    }
+  }
+
   private final class SendAccessibilityEvent extends ViewOperation {
 
     private final int mEventType;
@@ -719,6 +731,10 @@ public class UIViewOperationQueue {
 
   public void enqueueSendAccessibilityEvent(int tag, int eventType) {
     mOperations.add(new SendAccessibilityEvent(tag, eventType));
+  }
+
+  public void enqueueUIBlock(UIBlock block) {
+    mOperations.add(new UIBlockOperation(block));
   }
 
   /* package */ void dispatchViewUpdates(final int batchId) {


### PR DESCRIPTION
This PR follows the work started in #6431 but instead of implementing the snapshot for Android, will just allow that feature to be implemented by a third party library.

The missing feature is the ability to resolve a View for a given tag integer. which is now possible with a `addUIBlock` on the `UIManagerModule` method where you give a `UIBlock` instance (a new class) that implements a `execute(NativeViewHierarchyManager)` function.

This is already possible in iOS API. a third party can use the `addUIBlock` too.
I have kept the name `addUIBlock` so it's the same as in the [iOS' API](https://github.com/facebook/react-native/search?q=addUIBlock&type=Code&utf8=%E2%9C%93).

---

With this PR a third party lib can now do...

```java
UIManagerModule uiManager = reactContext.getNativeModule(UIManagerModule.class);
uiManager.addUIBlock(new UIBlock() {
  public void execute (NativeViewHierarchyManager nvhm) {
    View view = nvhm.resolveView(tag);
    ...do something with view... like... screenshot the view!
  }
});
```

...and we can finally implement that generic view screenshot in a third party library... [**-> this is a gist implementing it! <-**](https://gist.github.com/gre/c466944b8ee7c1b1f17ba79f145d0664)

> NB: this gist will turn into a PR for @jsierles' [react-native-view-snapshot](https://github.com/jsierles/react-native-view-snapshot) library, when this gets into React Native.