### PR TITLE
Use HTTP range requests (responses) to serve mp4 from assets

### DIFF
--- a/package.json
+++ b/package.json
@@ -160,6 +160,7 @@
     "jstransform": "^11.0.3",
     "lodash": "^3.10.1",
     "mime": "^1.3.4",
+    "mime-types": "^2.1.11",
     "mkdirp": "^0.5.1",
     "module-deps": "^3.9.1",
     "node-fetch": "^1.3.3",

--- a/packager/react-packager/src/Server/__tests__/Server-test.js
+++ b/packager/react-packager/src/Server/__tests__/Server-test.js
@@ -349,6 +349,19 @@ describe('processRequest', () => {
       expect(AssetServer.prototype.get).toBeCalledWith('imgs/a.png', 'ios');
       expect(res.end).toBeCalledWith('i am image');
     });
+
+    it('should serve range request', () => {
+      const req = {url: '/assets/imgs/a.png?platform=ios', headers: {range: 'bytes=0-3'}};
+      const res = {end: jest.fn(), writeHead: jest.fn()};
+      const mockData = new Buffer('i am image');
+
+      AssetServer.prototype.get.mockImpl(() => Promise.resolve(mockData));
+
+      server.processRequest(req, res);
+      jest.runAllTimers();
+      expect(AssetServer.prototype.get).toBeCalledWith('imgs/a.png', 'ios');
+      expect(res.end).toBeCalledWith(mockData.slice(0, 3));
+    });
   });
 
   describe('buildbundle(options)', () => {


### PR DESCRIPTION
This PR solves a problem when video assets are used from third-party React Native components (e.g. [react-native-video](https://github.com/brentvatne/react-native-video). The video will not work while the assets are served from the react native packager because the used video component (iOS) relies on HTTP range requests.

I added a small fix that allows ranged requests (e.g. mp4) to be served in ranges. 

To test this:

1. make new react native project
1. add [react-native-video](https://github.com/brentvatne/react-native-video) to xcode project
1. add video component to your project
```
import Video from 'react-native-video';
var resolveAssetSource = require('react-native/Libraries/Image/resolveAssetSource');
/* ... /*
render() {
    let source = resolveAssetSource(require('./someVideoFile.mp4')) || {};
    return <Video /*....*/ source={source} />;
}
```

That should not work (if video is smaller than a few megabytes, open app a few times). Then add my fix, that should do the trick.