### PR TITLE
Add missing `java` directory in ReactAndroid/build.gradle

### DIFF
--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -240,7 +240,7 @@ android {
         jniLibs.srcDir "$buildDir/react-ndk/exported"
         res.srcDirs = ['src/main/res/devsupport', 'src/main/res/shell', 'src/main/res/views/modal']
         java {
-          srcDirs = ['src/main/java', 'src/main/libraries/soloader']
+          srcDirs = ['src/main/java', 'src/main/libraries/soloader/java']
           exclude 'com/facebook/react/processing'
         }
     }


### PR DESCRIPTION
Fix Android Studio warnings for https://github.com/facebook/SoLoader package.