### PR TITLE
Change RCTImageLoader's Cache System to default NSURLRequest's cache system

### DIFF
--- a/Libraries/Image/RCTImageLoader.h
+++ b/Libraries/Image/RCTImageLoader.h
@@ -75,16 +75,18 @@ typedef void (^RCTImageLoaderCancellationBlock)(void);
 
 /**
  * Finds an appropriate image decoder and passes the target `size`, `scale` and
- * `resizeMode` for optimal image decoding.  The `clipped` option controls
+ * `resizeMode` for optimal image decoding. The `clipped` option controls
  * whether the image will be clipped to fit the specified size exactly, or
- * if the original aspect ratio should be retained. Can be called from any
- * thread, will call callback on an unspecified thread.
+ * if the original aspect ratio should be retained. The decoded image will
+ * be stored on cache with 'cacheKey'. Can be called from any thread, will
+ * call callback on an unspecified thread
  */
 - (RCTImageLoaderCancellationBlock)decodeImageData:(NSData *)imageData
                                               size:(CGSize)size
                                              scale:(CGFloat)scale
                                            clipped:(BOOL)clipped
                                         resizeMode:(RCTResizeMode)resizeMode
+                                          cacheKey:(NSString *)cacheKey
                                    completionBlock:(RCTImageLoaderCompletionBlock)completionBlock;
 
 /**


### PR DESCRIPTION
### intro

Before this PR, ```RCTImageLodaer```'s Cache was too big(200MB on disk) and It doesn't work with HTTP Cache-Control header. So to provide dynamic image, the users must have to add random value on url( ex. adding current date) to avoid cache.

So I change that cache system to default ```NSURLRequest```'s cache system, which is well-working with HTTP specs. As the discussion on this issue #7571 , making custom cache policy processor is not ready yet and useless, over-tech things, I think.

Even we have no plan about image cache system(or would change plan later), before having a nice plan, I think we should let user use image module with common HTTP Specs.

### So What did I do?
So I remove custom ```NSURLCache```, and make logic like below,

1. try fetch image,

2. on response, get ```Date``` on response's header and make ```cacheKey``` with ```Date```.
> (why? because if ```NSURLRequest```'s response was cached, the response's ```Date``` header dosen't change.)

3. find decoded image on ```_decodedImageCache``` with ```cacheKey```

4. if there isn't, decode that image and store to ```_decodedImageCache``` with ```cacheKey```.

In addition, I didn't stored local image asset on ```_decodedImageCache``` because ```[UIImage imageNamed:]``` work with its own cache.

### Test Plan

just make one simple web-server which provide static images with cache-control header.
set max-old or anything else and test that image was really caching during max-old time.
I've just tested with simple nodejs express server and checked it was perfectly working.