### PR TITLE
fix runIOS: appPath is hardcoded, read from log

### DIFF
--- a/local-cli/runIOS/runIOS.js
+++ b/local-cli/runIOS/runIOS.js
@@ -83,20 +83,18 @@ function _runIOS(argv, config, resolve, reject) {
   console.log(`Building using "xcodebuild ${xcodebuildArgs.join(' ')}"`);
 
   let appPath = `build/Build/Products/Debug-iphonesimulator/${inferredSchemeName}.app`;
-  const xcodeBuildProcess = child_process.spawn('xcodebuild', xcodebuildArgs);
+  const xcodeBuildProcess = child_process.spawn('xcodebuild', xcodebuildArgs, {
+    stdio: [process.stdin, 'pipe', process.stderr]
+  });
 
   xcodeBuildProcess.stdout.on('data', (data) => {
-    console.log(data.toString().replace(/\s+$/g, ''));
+    process.stdout.write(data);
 
     // search this part of the process output for a path to the generated app and replace default
     const appPathFromLog = data.toString().match(/Touch (build\/Build\/Products\/.*\/.*\.app)/);
     if (appPathFromLog) {
       appPath = appPathFromLog[1];
     }
-  });
-
-  xcodeBuildProcess.stderr.on('data', (data) => {
-    console.log(`stderr: ${data}`);
   });
 
   xcodeBuildProcess.on('close', (code) => {

--- a/local-cli/runIOS/runIOS.js
+++ b/local-cli/runIOS/runIOS.js
@@ -82,9 +82,11 @@ function _runIOS(argv, config, resolve, reject) {
     '-derivedDataPath', 'build',
   ];
   console.log(`Building using "xcodebuild ${xcodebuildArgs.join(' ')}"`);
-  child_process.spawnSync('xcodebuild', xcodebuildArgs, {stdio: 'inherit'});
+  const xcodeBuildProcess = child_process.spawnSync('xcodebuild', xcodebuildArgs, {stdio: 'pipe'});
+  console.log(xcodeBuildProcess.output[1].toString());
 
-  const appPath = `build/Build/Products/Debug-iphonesimulator/${inferredSchemeName}.app`;
+  const productName = xcodeBuildProcess.output[1].toString().match(/Touch (build\/Build\/Products\/.*\/.*\.app)/);
+  const appPath = productName ? productName[1] : `build/Build/Products/Debug-iphonesimulator/${inferredSchemeName}.app`;
   console.log(`Installing ${appPath}`);
   child_process.spawnSync('xcrun', ['simctl', 'install', 'booted', appPath], {stdio: 'inherit'});
 

--- a/local-cli/runIOS/runIOS.js
+++ b/local-cli/runIOS/runIOS.js
@@ -82,14 +82,14 @@ function _runIOS(argv, config, resolve, reject) {
   ];
   console.log(`Building using "xcodebuild ${xcodebuildArgs.join(' ')}"`);
 
-  var appPath = `build/Build/Products/Debug-iphonesimulator/${inferredSchemeName}.app`;
+  let appPath = `build/Build/Products/Debug-iphonesimulator/${inferredSchemeName}.app`;
   const xcodeBuildProcess = child_process.spawn('xcodebuild', xcodebuildArgs);
 
   xcodeBuildProcess.stdout.on('data', (data) => {
-    console.log(data.toString());
+    console.log(data.toString().replace(/\s+$/g, ''));
 
     // search this part of the process output for a path to the generated app and replace default
-    var appPathFromLog = data.toString().match(/Touch (build\/Build\/Products\/.*\/.*\.app)/);
+    const appPathFromLog = data.toString().match(/Touch (build\/Build\/Products\/.*\/.*\.app)/);
     if (appPathFromLog) {
       appPath = appPathFromLog[1];
     }

--- a/local-cli/runIOS/runIOS.js
+++ b/local-cli/runIOS/runIOS.js
@@ -20,105 +20,104 @@ const Promise = require('promise');
  * Starts the app on iOS simulator
  */
 function runIOS(argv, config) {
-  return _runIOS(argv, config);
+  return new Promise((resolve, reject) => {
+    _runIOS(argv, config, resolve, reject);
+  });
 }
 
-function _runIOS(argv, config,) {
-  return new Promise((resolve, reject) => {
-    const args = parseCommandLine([
-      {
-        command: 'simulator',
-        description: 'Explicitly set simulator to use',
-        type: 'string',
-        required: false,
-        default: 'iPhone 6',
-      }, {
-        command: 'scheme',
-        description: 'Explicitly set Xcode scheme to use',
-        type: 'string',
-        required: false,
-      }, {
-        command: 'project-path',
-        description: 'Path relative to project root where the Xcode project (.xcodeproj) lives. The default is \'ios\'.',
-        type: 'string',
-        required: false,
-        default: 'ios',
-      }
-    ], argv);
+function _runIOS(argv, config, resolve, reject) {
+  const args = parseCommandLine([
+    {
+      command: 'simulator',
+      description: 'Explicitly set simulator to use',
+      type: 'string',
+      required: false,
+      default: 'iPhone 6',
+    }, {
+      command: 'scheme',
+      description: 'Explicitly set Xcode scheme to use',
+      type: 'string',
+      required: false,
+    }, {
+      command: 'project-path',
+      description: 'Path relative to project root where the Xcode project (.xcodeproj) lives. The default is \'ios\'.',
+      type: 'string',
+      required: false,
+      default: 'ios',
+    }
+  ], argv);
 
-    process.chdir(args['project-path']);
-    const xcodeProject = findXcodeProject(fs.readdirSync('.'));
-    if (!xcodeProject) {
-      reject(new Error(`Could not find Xcode project files in ios folder`));
+  process.chdir(args['project-path']);
+  const xcodeProject = findXcodeProject(fs.readdirSync('.'));
+  if (!xcodeProject) {
+    reject(new Error(`Could not find Xcode project files in ios folder`));
+  }
+
+  const inferredSchemeName = path.basename(xcodeProject.name, path.extname(xcodeProject.name));
+  const scheme = args.scheme || inferredSchemeName;
+  console.log(`Found Xcode ${xcodeProject.isWorkspace ? 'workspace' : 'project'} ${xcodeProject.name}`);
+
+  const simulators = parseIOSSimulatorsList(
+    child_process.execFileSync('xcrun', ['simctl', 'list', 'devices'], {encoding: 'utf8'})
+  );
+  const selectedSimulator = matchingSimulator(simulators, args.simulator);
+  if (!selectedSimulator) {
+    reject(new Error(`Cound't find ${args.simulator} simulator`));
+  }
+
+  const simulatorFullName = `${selectedSimulator.name} (${selectedSimulator.version})`;
+  console.log(`Launching ${simulatorFullName}...`);
+  try {
+    child_process.spawnSync('xcrun', ['instruments', '-w', simulatorFullName]);
+  } catch(e) {
+    // instruments always fail with 255 because it expects more arguments,
+    // but we want it to only launch the simulator
+  }
+
+  const xcodebuildArgs = [
+    xcodeProject.isWorkspace ? '-workspace' : '-project', xcodeProject.name,
+    '-scheme', scheme,
+    '-destination', `id=${selectedSimulator.udid}`,
+    '-derivedDataPath', 'build',
+  ];
+  console.log(`Building using "xcodebuild ${xcodebuildArgs.join(' ')}"`);
+
+  var appPath = `build/Build/Products/Debug-iphonesimulator/${inferredSchemeName}.app`;
+  const xcodeBuildProcess = child_process.spawn('xcodebuild', xcodebuildArgs);
+
+  xcodeBuildProcess.stdout.on('data', (data) => {
+    console.log(data.toString());
+
+    // search this part of the process output for a path to the generated app and replace default
+    var appPathFromLog = data.toString().match(/Touch (build\/Build\/Products\/.*\/.*\.app)/);
+    if (appPathFromLog) {
+      appPath = appPathFromLog[1];
+    }
+  });
+
+  xcodeBuildProcess.stderr.on('data', (data) => {
+    console.log(`stderr: ${data}`);
+  });
+
+  xcodeBuildProcess.on('close', (code) => {
+    if (code !== 0) {
+      reject(new Error(`xcodebuild process exited with code ${code}`));
+      return;
     }
 
-    const inferredSchemeName = path.basename(xcodeProject.name, path.extname(xcodeProject.name));
-    const scheme = args.scheme || inferredSchemeName;
-    console.log(`Found Xcode ${xcodeProject.isWorkspace ? 'workspace' : 'project'} ${xcodeProject.name}`);
+    console.log(`Installing ${appPath}`);
+    child_process.spawnSync('xcrun', ['simctl', 'install', 'booted', appPath], {stdio: 'inherit'});
 
-    const simulators = parseIOSSimulatorsList(
-        child_process.execFileSync('xcrun', ['simctl', 'list', 'devices'], {encoding: 'utf8'})
-    );
-    const selectedSimulator = matchingSimulator(simulators, args.simulator);
-    if (!selectedSimulator) {
-      reject(new Error(`Cound't find ${args.simulator} simulator`));
-    }
+    const bundleID = child_process.execFileSync(
+        '/usr/libexec/PlistBuddy',
+        ['-c', 'Print:CFBundleIdentifier', path.join(appPath, 'Info.plist')],
+        {encoding: 'utf8'}
+    ).trim();
 
-    const simulatorFullName = `${selectedSimulator.name} (${selectedSimulator.version})`;
-    console.log(`Launching ${simulatorFullName}...`);
-    try {
-      child_process.spawnSync('xcrun', ['instruments', '-w', simulatorFullName]);
-    } catch (e) {
-      // instruments always fail with 255 because it expects more arguments,
-      // but we want it to only launch the simulator
-    }
+    console.log(`Launching ${bundleID}`);
+    child_process.spawnSync('xcrun', ['simctl', 'launch', 'booted', bundleID], {stdio: 'inherit'});
 
-    const xcodebuildArgs = [
-      xcodeProject.isWorkspace ? '-workspace' : '-project', xcodeProject.name,
-      '-scheme', scheme,
-      '-destination', `id=${selectedSimulator.udid}`,
-      '-derivedDataPath', 'build',
-    ];
-    console.log(`Building using "xcodebuild ${xcodebuildArgs.join(' ')}"`);
-
-    const xcodeBuildProcess = child_process.spawn('xcodebuild', xcodebuildArgs);
-    var appPath = `build/Build/Products/Debug-iphonesimulator/${inferredSchemeName}.app`;
-
-    xcodeBuildProcess.stdout.on('data', (data) => {
-      console.log(data.toString());
-
-      // search this part of the process output for a path to the generated app and replace default
-      var appPathFromLog = data.toString().match(/Touch (build\/Build\/Products\/.*\/.*\.app)/);
-      if (appPathFromLog) {
-        appPath = appPathFromLog[1];
-      }
-    });
-
-    xcodeBuildProcess.stderr.on('data', (data) => {
-      console.log(`stderr: ${data}`);
-    });
-
-    xcodeBuildProcess.on('close', (code) => {
-      if (code !== 0) {
-        reject(new Error(`xcodebuild process exited with code ${code}`));
-        return;
-      }
-
-      console.log(`Installing ${appPath}`);
-      child_process.spawnSync('xcrun', ['simctl', 'install', 'booted', appPath], {stdio: 'inherit'});
-
-      const bundleID = child_process.execFileSync(
-          '/usr/libexec/PlistBuddy',
-          ['-c', 'Print:CFBundleIdentifier', path.join(appPath, 'Info.plist')],
-          {encoding: 'utf8'}
-      ).trim();
-
-      console.log(`Launching ${bundleID}`);
-      child_process.spawnSync('xcrun', ['simctl', 'launch', 'booted', bundleID], {stdio: 'inherit'});
-
-      resolve();
-    });
-
+    resolve();
   });
 }
 


### PR DESCRIPTION
The runIOS command currently assumes the path to the `xcodebuild` product - it's hardcoded

```
  const appPath = `build/Build/Products/Debug-iphonesimulator/${inferredSchemeName}.app`;
```
https://github.com/facebook/react-native/blob/master/local-cli/runIOS/runIOS.js#L87

This can be a problem, when you e.g. install a release version of the app to the simulator using the cli. We use a separate schema for that, which can be selected with `--scheme`.

This fix reads the output of the `xcodebuild` call and searches for the path and the name of the *.app file. If it's found, then it will be used to spawn in the simulator. If not, the default (as before) is used.