### PR TITLE
Fixed CircleCi script to make gradle builds more stable

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -74,7 +74,7 @@ test:
     # gradle may invalidate bridge build cache, so we pass single-threaded setting just in case
     - ./gradlew :ReactAndroid:testDebugUnitTest -Pjobs=1
     # Deprecated: these tests are executed using Buck above, while we support Gradle we just make sure the test code compiles
-    - ./gradlew :ReactAndroid:assembleDebugAndroidTest
+    - ./gradlew :ReactAndroid:assembleDebugAndroidTest -Pjobs=1
 
     # Android e2e test
     - node ./scripts/run-ci-e2e-tests.js --android --js --retries 3


### PR DESCRIPTION

This is a temporary patch because gradle builds are not properly cached