### PR TITLE
Fixed manual e2e test runner script

### DIFF
--- a/scripts/test-manual-e2e.sh
+++ b/scripts/test-manual-e2e.sh
@@ -31,6 +31,7 @@ success "Preparing version $PACKAGE_VERSION"
 
 repo_root=$(pwd)
 
+rm -rf android
 ./gradlew :ReactAndroid:installArchives || error "Couldn't generate artifacts"
 
 success "Generated artifacts for Maven"


### PR DESCRIPTION

Android folder may contain versions from previous runs and it may affect e2e test execution.
This should make tests independent of cached jars.