### PR TITLE
Cicle CI fix: limit predex threads

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -62,7 +62,7 @@ test:
 
     # instrumentation tests
     # compile native libs with Gradle script
-    - ./gradlew :ReactAndroid:packageReactNdkLibsForBuck -Pjobs=1:
+    - ./gradlew :ReactAndroid:packageReactNdkLibsForBuck -Pjobs=1 -Pcom.android.build.threadPoolSize=1:
         timeout: 360
     # build JS bundle for instrumentation tests
     - node local-cli/cli.js bundle --platform android --dev true --entry-file ReactAndroid/src/androidTest/js/TestBundle.js --bundle-output ReactAndroid/src/androidTest/assets/AndroidTestBundle.js
@@ -72,9 +72,9 @@ test:
     - node ./scripts/run-android-ci-instrumentation-tests.js --retries 3 --path ./ReactAndroid/src/androidTest/java/com/facebook/react/tests --package com.facebook.react.tests
 
     # gradle may invalidate bridge build cache, so we pass single-threaded setting just in case
-    - ./gradlew :ReactAndroid:testDebugUnitTest -Pjobs=1
+    - ./gradlew :ReactAndroid:testDebugUnitTest -Pjobs=1 -Pcom.android.build.threadPoolSize=1
     # Deprecated: these tests are executed using Buck above, while we support Gradle we just make sure the test code compiles
-    - ./gradlew :ReactAndroid:assembleDebugAndroidTest -Pjobs=1
+    - ./gradlew :ReactAndroid:assembleDebugAndroidTest -Pjobs=1 -Pcom.android.build.threadPoolSize=1
 
     # Android e2e test
     - node ./scripts/run-ci-e2e-tests.js --android --js --retries 3


### PR DESCRIPTION


Limited nubmer of threads Gradle may spawn when generating dex files