### PR TITLE
[NavigationExperimental] Use active scene passed in `props` by `NavigationTransitioner`

### DIFF
--- a/Libraries/CustomComponents/NavigationExperimental/NavigationCardStack.js
+++ b/Libraries/CustomComponents/NavigationExperimental/NavigationCardStack.js
@@ -42,8 +42,6 @@ const ReactComponentWithPureRenderMixin = require('ReactComponentWithPureRenderM
 const StyleSheet = require('StyleSheet');
 const View = require('View');
 
-const emptyFunction = require('fbjs/lib/emptyFunction');
-
 const {PropTypes} = React;
 const {Directions} = NavigationCardStackPanResponder;
 
@@ -69,7 +67,6 @@ type Props = {
 
 type DefaultProps = {
   direction: NavigationGestureDirection,
-  renderOverlay: ?NavigationSceneRenderer,
 };
 
 /**
@@ -100,7 +97,6 @@ class NavigationCardStack extends React.Component<DefaultProps, Props, void> {
 
   static defaultProps: DefaultProps = {
     direction: Directions.HORIZONTAL,
-    renderOverlay: emptyFunction.thatReturnsNull,
   };
 
   constructor(props: Props, context: any) {
@@ -132,22 +128,14 @@ class NavigationCardStack extends React.Component<DefaultProps, Props, void> {
 
   _render(props: NavigationTransitionProps): ReactElement<any> {
     const {
-       navigationState,
-     } = props;
+      renderOverlay
+    } = this.props;
 
     let overlay = null;
-    const renderOverlay = this.props.renderOverlay;
-
     if (renderOverlay) {
-      const route = navigationState.routes[navigationState.index];
-
-      const activeScene = props.scenes.find(
-       scene => !scene.isStale && scene.route === route ? scene : undefined
-      );
-
       overlay = renderOverlay({
        ...props,
-       scene: activeScene
+       scene: props.scene,
       });
     }
 
@@ -155,8 +143,7 @@ class NavigationCardStack extends React.Component<DefaultProps, Props, void> {
      scene => this._renderScene({
        ...props,
        scene,
-     }),
-     this
+     })
     );
 
     return (


### PR DESCRIPTION
With facebook/react-native@c57bac4, `NavigationTransitioner` passes the currently active `scene` in transition `props`. This simplifies the handling of transition changes when rendering overlay.

🍺 