### PR TITLE
[NavigationExperimental] Add `timing` to `NavigationTransitionConfigurator`

### DIFF
--- a/Libraries/NavigationExperimental/NavigationTransitioner.js
+++ b/Libraries/NavigationExperimental/NavigationTransitioner.js
@@ -51,6 +51,7 @@ const {PropTypes} = React;
 const DefaultTransitionSpec = {
   duration: 250,
   easing: Easing.inOut(Easing.ease),
+  timing: Animated.timing,
 };
 
 function isSceneNotStale(scene: NavigationScene): boolean {
@@ -132,7 +133,10 @@ class NavigationTransitioner extends React.Component<any, Props, State> {
 
     // get the transition spec.
     const transitionUserSpec = nextProps.configureTransition ?
-      nextProps.configureTransition() :
+      nextProps.configureTransition(
+        this._transitionProps,
+        this._prevTransitionProps
+      ) :
       null;
 
     const transitionSpec = {
@@ -142,11 +146,16 @@ class NavigationTransitioner extends React.Component<any, Props, State> {
 
     progress.setValue(0);
 
+    const {
+      timing,
+      ...animationConfig
+    } = transitionSpec;
+
     const animations = [
-      Animated.timing(
+      timing(
         progress,
         {
-          ...transitionSpec,
+          ...animationConfig,
           toValue: 1,
         },
       ),
@@ -154,10 +163,10 @@ class NavigationTransitioner extends React.Component<any, Props, State> {
 
     if (nextProps.navigationState.index !== this.props.navigationState.index) {
       animations.push(
-        Animated.timing(
+        timing(
           position,
           {
-            ...transitionSpec,
+            ...animationConfig,
             toValue: nextProps.navigationState.index,
           },
         ),

--- a/Libraries/NavigationExperimental/NavigationTypeDefinition.js
+++ b/Libraries/NavigationExperimental/NavigationTypeDefinition.js
@@ -93,6 +93,8 @@ export type NavigationTransitionSpec = {
   duration?: number,
   // An easing function from `Easing`.
   easing?: () => any,
+  // An animation function from `Animated` e.g. Animated.timing
+  timing?: NavigationTransitionTiming,
 };
 
 // Functions.
@@ -111,4 +113,12 @@ export type NavigationStyleInterpolator = (
   props: NavigationSceneRendererProps,
 ) => Object;
 
-export type NavigationTransitionConfigurator = () => NavigationTransitionSpec;
+export type NavigationTransitionConfigurator = (
+  transitionProps: NavigationTransitionProps,
+  prevTransitionProps: ?NavigationTransitionProps,
+) => NavigationTransitionSpec;
+
+export type NavigationTransitionTiming = (
+  value: NavigationAnimatedValue,
+  config: Object,
+) => Object;


### PR DESCRIPTION
NavigationTransitioner abstracts away how animations are applied internally by replacing `applyAnimation` prop with `configureTransition`, and uses `Animated.timing` over `Animated.spring`. Unlike `applyAnimation`, `configureTransition` has a different signature and removes direct access to the `Animated.Value` used by `NavigationTransitioner` to shuffle the scenes, thus removing the ability to customize the animation function used.

This PR reintroduces aforementioned feature by adding a new prop, `transitionRunner`, to `NavigationTransitioner`.

For example, to use `Animated.spring`:

```js
<NavigationTransitioner
  transitionRunner={Animated.spring}
  configureTransition={()=>({bounciness: 0})}
/>
```

Or, to completely "turn off" animations (useful for tabs):

```js
function noAnimation(
  value: NavigationAnimatedValue,
  config: NavigationAnimationConfig
): CompositeAnimation {
  return {
    start(callback) {
      value.setValue(config.toValue);
      callback({
        finished: true,
      });
    },
    stop: () => {},
  };
}

<NavigationTransitioner
  transitionRunner={noAnimation}
/>
```

Obviously, it can also be used with `Animated.decay`, or any other function that produces a `CompositeAnimation`.

This also addresses a huge degradation (at least temporarily until facebook/react-native#7884 lands) in [performance](https://github.com/facebook/react-native/commit/7db7f78dc7d2b85843707f75565bcfcb538e8e51#commitcomment-17575647) when`NavigationTransitioner`'s are nested, e.g. `NavigationTransitioner` nested inside another `NavigationTransitioner` used for tabs (by setting `configureTransition={{duration=0}}` to disable animations).

🍺 