### PR TITLE
Add tabindex attribute to searchbar

### DIFF
--- a/website/core/AlgoliaDocSearch.js
+++ b/website/core/AlgoliaDocSearch.js
@@ -13,7 +13,7 @@ var AlgoliaDocSearch = React.createClass({
   render: function() {
     return (
       <div className="algolia-search-wrapper">
-        <input id="algolia-doc-search" type="text" placeholder="Search docs..." />
+        <input id="algolia-doc-search" tabindex="0" type="text" placeholder="Search docs..." />
       </div>
     );
   }


### PR DESCRIPTION


Explain the **motivation** for making this change. What existing problem does the pull request solve?

This is small improvement to docs webpage.
I'm tired of clicking on searchbar with mouse/touchpad, so I've added a `tabindex` attribute to it, so it can be now focused with `Tab` key.

I think this greatly improves user experience on documentation searching.

**Test plan (required)**

??? Just click on `Tab` and it will focus. Should I test it really?

**Code formatting**

Attributes are sorted alphabetically, I've inserted new attribute in this order, after `id` and before `type` attributes.