### PR TITLE
fix Firefox bug

### DIFF
--- a/docs/QuickStart-GettingStarted.md
+++ b/docs/QuickStart-GettingStarted.md
@@ -258,7 +258,6 @@ function display(type, value) {
   var container = document.getElementsByTagName('block')[0].parentNode;
   container.className = 'display-' + type + '-' + value + ' ' +
     container.className.replace(RegExp('display-' + type + '-[a-z]+ ?'), '');
-  event && event.preventDefault();
 }
 
 // If we are coming to the page with a hash in it (i.e. from a search, for example), try to get


### PR DESCRIPTION
The motivation is that the getting started page was not working in some cases in Firefox.

This line of code appears to be at best a no-op, at worst fails in Firefox, since "event" is undefined.