### PR TITLE
Bad Merge Into Master: Instantiate local notifications different than remote notifications

### DIFF
--- a/Libraries/PushNotificationIOS/RCTPushNotificationManager.m
+++ b/Libraries/PushNotificationIOS/RCTPushNotificationManager.m
@@ -164,9 +164,25 @@ RCT_EXPORT_MODULE()
 
 + (void)didReceiveLocalNotification:(UILocalNotification *)notification
 {
+  NSMutableDictionary *details = [NSMutableDictionary new];
+  if (notification.alertBody) {
+    details[@"alertBody"] = notification.alertBody;
+  }
+
+  if (notification.applicationIconBadgeNumber) {
+    details[@"applicationIconBadgeNumber"] = [NSNumber numberWithInteger:notification.applicationIconBadgeNumber];
+  }
+
+  if (notification.soundName) {
+    details[@"soundName"] = notification.soundName;
+  }
+
+  if (notification.userInfo) {
+    details[@"userInfo"] = RCTJSONClean(notification.userInfo);
+  }
   [[NSNotificationCenter defaultCenter] postNotificationName:RCTLocalNotificationReceived
                                                       object:self
-                                                    userInfo:RCTFormatLocalNotification(notification)];
+                                                    userInfo:details];
 }
 
 - (void)handleLocalNotificationReceived:(NSNotification *)notification


### PR DESCRIPTION
This PR was partially merged: https://github.com/facebook/react-native/pull/8029 

some of the changes made from the [[pr]](https://github.com/facebook/react-native/pull/8029/files#diff-c4441933746f851b6a89a445751b812cR321) to [[master]](https://github.com/facebook/react-native/blob/master/Libraries/PushNotificationIOS/PushNotificationIOS.js#L325-L345)

But not all of the changes made it from the [[pr]](https://github.com/facebook/react-native/pull/8029/files#diff-2809d4592d87587e30e146d50d49188dR167) to [[master]](https://github.com/facebook/react-native/blob/master/Libraries/PushNotificationIOS/RCTPushNotificationManager.m#L165-L170)

This fixes the bad merge.