### PR TITLE
Accept children of all types for NavigationHeaderTitle

### DIFF
--- a/Libraries/CustomComponents/NavigationExperimental/NavigationHeaderTitle.js
+++ b/Libraries/CustomComponents/NavigationExperimental/NavigationHeaderTitle.js
@@ -73,7 +73,7 @@ const styles = StyleSheet.create({
 });
 
 NavigationHeaderTitle.propTypes = {
-  children: React.PropTypes.string.isRequired,
+  children: React.PropTypes.node.isRequired,
   style: View.propTypes.style,
   textStyle: Text.propTypes.style
 };


### PR DESCRIPTION
`<Text>` accepts more than just string as its children; and it's handy to be able to style nav titles without a proptype warning throwing