### PR TITLE
Mention double tapping R to reload in the app template

### DIFF
--- a/local-cli/generator/templates/index.android.js
+++ b/local-cli/generator/templates/index.android.js
@@ -23,6 +23,7 @@ class <%= name %> extends Component {
           To get started, edit index.android.js
         </Text>
         <Text style={styles.instructions}>
+          Double tap R on your keyboard to reload,{'\n'}
           Shake or press menu button for dev menu
         </Text>
       </View>


### PR DESCRIPTION
This is a pretty useful trick to know, let's promote it :)

The formatting is consistent with iOS: https://github.com/facebook/react-native/blob/master/local-cli/generator/templates/index.ios.js

<img width="443" alt="screen shot 2016-06-23 at 4 04 47 pm" src="https://cloud.githubusercontent.com/assets/346214/16304185/fc94f6d6-395c-11e6-9f2c-0167217d1514.png">
