### PR TITLE
Networking Guide

### DIFF
--- a/docs/Basics-Network.md
+++ b/docs/Basics-Network.md
@@ -7,18 +7,18 @@ permalink: docs/network.html
 next: more-resources
 ---
 
-Many modern mobile apps will at some point find the need to load resources from a remote endpoint. You may want to make a POST request to a REST API, or you may simply need to fetch a chunk of static content from another server.
-
-React Native provides the [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) for your networking needs.
+Many mobile apps need to load resources from a remote URL. You may want to make a POST request to a REST API, or you may simply need to fetch a chunk of static content from another server.
 
 ## Using Fetch
 
-Fetch will seem familiar if you have used `XMLHttpRequest` or other networking APIs before. You may refer to MDN's guide on [Using Fetch](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch) for additional information.
+React Native provides the [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) for your networking needs. Fetch will seem familiar if you have used `XMLHttpRequest` or other networking APIs before. You may refer to MDN's guide on [Using Fetch](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch) for additional information.
 
-In order to fetch content from an arbitrary endpoint, just pass the URL to fetch:
+#### Making requests
+
+In order to fetch content from an arbitrary URL, just pass the URL to fetch:
 
 ```js
-fetch('https://mywebsite.com/endpoint/')
+fetch('https://mywebsite.com/mydata.json')
 ```
 
 Fetch also takes an optional second argument that allows you to customize the HTTP request. You may want to specify additional headers, or make a POST request:
@@ -39,7 +39,7 @@ fetch('https://mywebsite.com/endpoint/', {
 
 Take a look at the [Fetch Request docs](https://developer.mozilla.org/en-US/docs/Web/API/Request) for a full list of properties.
 
-### Handling the response
+#### Handling the response
 
 The above examples show how you can make a request. In many cases, you will want to do something with the response.
 
@@ -74,10 +74,54 @@ You can also use ES7's `async`/`await` syntax in React Native app:
 
 Don't forget to catch any errors that may be thrown by `fetch`, otherwise they will be dropped silently.
 
+### Using Other Networking Libraries
+
+The [XMLHttpRequest API](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest) is built in to React Native. This means that you can use third party libraries such as [frisbee](https://github.com/niftylettuce/frisbee) or [axios](https://github.com/mzabriskie/axios) that depend on it, or you can use the XMLHttpRequest API directly if you prefer.
+
+```js
+var request = new XMLHttpRequest();
+request.onreadystatechange = (e) => {
+  if (request.readyState !== 4) {
+    return;
+  }
+
+  if (request.status === 200) {
+    console.log('success', request.responseText);
+  } else {
+    console.warn('error');
+  }
+};
+
+request.open('GET', 'https://mywebsite.com/endpoint/');
+request.send();
+```
+
+> The security model for XMLHttpRequest is different than on web as there is no concept of [CORS](http://en.wikipedia.org/wiki/Cross-origin_resource_sharing) in native apps.
+
 ## WebSocket Support
 
 React Native supports [WebSocket](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket), a protocol which provides full-duplex communication channels over a single TCP connection.
 
-## Using Other Networking Libraries
+```js
+var ws = new WebSocket('ws://host.com/path');
 
-The `XMLHttpRequest` API, used by many networking libraries, is built in to React Native. This means that you can use third party libraries such as [frisbee](https://github.com/niftylettuce/frisbee) or [axios](https://github.com/mzabriskie/axios) if you prefer.
+ws.onopen = () => {
+  // connection opened
+  ws.send('something');
+};
+
+ws.onmessage = (e) => {
+  // a message was received
+  console.log(e.data);
+};
+
+ws.onerror = (e) => {
+  // an error occurred
+  console.log(e.message);
+};
+
+ws.onclose = (e) => {
+  // connection closed
+  console.log(e.code, e.reason);
+};
+```

--- a/docs/Basics-Network.md
+++ b/docs/Basics-Network.md
@@ -1,25 +1,25 @@
 ---
 id: basics-network
-title: Network
+title: Networking
 layout: docs
 category: The Basics
 permalink: docs/network.html
 next: more-resources
 ---
 
-One of React Native's goals is to be a playground where we can experiment with different architectures and crazy ideas. Since browsers are not flexible enough, we had no choice but to reimplement the entire stack. In the places that we did not intend to change anything, we tried to be as faithful as possible to the browser APIs. The networking stack is a great example.
+Many modern mobile apps will at some point find the need to load resources from a remote endpoint. You may want to integrate with a third party REST API, or you may simply need to fetch a chunk of static content from another server.
 
-## Fetch
+## Using Fetch
 
-[fetch](https://fetch.spec.whatwg.org/) is a better networking API being worked on by the standards committee and is already available in Chrome. It is available in React Native by default.
+React Native provides the [Fetch API](https://fetch.spec.whatwg.org/) for your networking needs. This standard is currently being worked on, and is not available in all web browsers yet, but you can start using it today in your React Native apps without any additional work.
 
-#### Usage
+Fetch works generally like this. In order to fetch content from an arbitrary endpoint,
 
 ```js
 fetch('https://mywebsite.com/endpoint/')
 ```
 
-Include a request object as the optional second argument to customize the HTTP request:
+Fetch also takes an optional second argument that allows you to customize the HTTP request:
 
 ```js
 fetch('https://mywebsite.com/endpoint/', {
@@ -35,9 +35,11 @@ fetch('https://mywebsite.com/endpoint/', {
 })
 ```
 
-#### Async
+### Asynchronous
 
-`fetch` returns a [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that can be processed in two ways:
+Networking is an inherently asynchronous operation. Fetch methods will return a  [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that make it straightforward to write code that works in an asynchronous manner.
+
+// clean up these examples, they should be completely identical save for await, try, catch
 
 1.  Using `then` and `catch` in synchronous code:
 
@@ -70,86 +72,12 @@ fetch('https://mywebsite.com/endpoint/', {
   }
   ```
 
-- Note: Errors thrown by rejected Promises need to be caught, or they will be swallowed silently
+Always make sure to catch any errors that may thrown by fetch. Unhandled errors will be dropped silently.
 
-## WebSocket
+## Advanced networking
 
-WebSocket is a protocol providing full-duplex communication channels over a single TCP connection.
+React Native also comes with support for [Web Sockets](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket).
 
-```js
-var ws = new WebSocket('ws://host.com/path');
+## Networking in third party libraries
 
-ws.onopen = () => {
-  // connection opened
-  ws.send('something');
-};
-
-ws.onmessage = (e) => {
-  // a message was received
-  console.log(e.data);
-};
-
-ws.onerror = (e) => {
-  // an error occurred
-  console.log(e.message);
-};
-
-ws.onclose = (e) => {
-  // connection closed
-  console.log(e.code, e.reason);
-};
-```
-
-## XMLHttpRequest
-
-XMLHttpRequest API is implemented on-top of [iOS networking apis](https://developer.apple.com/library/mac/documentation/Cocoa/Conceptual/URLLoadingSystem/URLLoadingSystem.html) and [OkHttp](http://square.github.io/okhttp/). The notable difference from web is the security model: you can read from arbitrary websites on the internet since there is no concept of [CORS](http://en.wikipedia.org/wiki/Cross-origin_resource_sharing).
-
-```js
-var request = new XMLHttpRequest();
-request.onreadystatechange = (e) => {
-  if (request.readyState !== 4) {
-    return;
-  }
-
-  if (request.status === 200) {
-    console.log('success', request.responseText);
-  } else {
-    console.warn('error');
-  }
-};
-
-request.open('GET', 'https://mywebsite.com/endpoint.php');
-request.send();
-```
-
-You can also use -
-
-```js
-var request = new XMLHttpRequest();
-
-function onLoad() {
-    console.log(request.status);
-    console.log(request.responseText);
-};
-
-function onTimeout() {
-    console.log('Timeout');
-    console.log(request.responseText);
-};
-
-function onError() {
-    console.log('General network error');
-    console.log(request.responseText);
-};
-
-request.onload = onLoad;
-request.ontimeout = onTimeout;
-request.onerror = onError;
-request.open('GET', 'https://mywebsite.com/endpoint.php');
-request.send();
-```
-
-
-Please follow the [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest) for a complete description of the API.
-
-As a developer, you're probably not going to use XMLHttpRequest directly as its API is very tedious to work with. But the fact that it is implemented and compatible with the browser API gives you the ability to use third-party libraries such as [frisbee](https://github.com/niftylettuce/frisbee) or [axios](https://github.com/mzabriskie/axios) directly from npm.
+Many third party libraries use the `XMLHttpRequest` API. This API is also built in to React Native, which means that you can use third party libraries such as [frisbee](https://github.com/niftylettuce/frisbee) or [axios](https://github.com/mzabriskie/axios) directly from NPM.

--- a/docs/Basics-Network.md
+++ b/docs/Basics-Network.md
@@ -7,19 +7,21 @@ permalink: docs/network.html
 next: more-resources
 ---
 
-Many modern mobile apps will at some point find the need to load resources from a remote endpoint. You may want to integrate with a third party REST API, or you may simply need to fetch a chunk of static content from another server.
+Many modern mobile apps will at some point find the need to load resources from a remote endpoint. You may want to make a POST request to a REST API, or you may simply need to fetch a chunk of static content from another server.
+
+React Native provides the [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) for your networking needs.
 
 ## Using Fetch
 
-React Native provides the [Fetch API](https://fetch.spec.whatwg.org/) for your networking needs. This standard is currently being worked on, and is not available in all web browsers yet, but you can start using it today in your React Native apps without any additional work.
+Fetch will seem familiar if you have used `XMLHttpRequest` or other networking APIs before. You may refer to MDN's guide on [Using Fetch](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch) for additional information.
 
-Fetch works generally like this. In order to fetch content from an arbitrary endpoint,
+In order to fetch content from an arbitrary endpoint, just pass the URL to fetch:
 
 ```js
 fetch('https://mywebsite.com/endpoint/')
 ```
 
-Fetch also takes an optional second argument that allows you to customize the HTTP request:
+Fetch also takes an optional second argument that allows you to customize the HTTP request. You may want to specify additional headers, or make a POST request:
 
 ```js
 fetch('https://mywebsite.com/endpoint/', {
@@ -35,49 +37,49 @@ fetch('https://mywebsite.com/endpoint/', {
 })
 ```
 
-### Asynchronous
+Take a look at the [Fetch Request docs](https://developer.mozilla.org/en-US/docs/Web/API/Request) for a full list of properties.
 
-Networking is an inherently asynchronous operation. Fetch methods will return a  [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that make it straightforward to write code that works in an asynchronous manner.
+### Handling the response
 
-// clean up these examples, they should be completely identical save for await, try, catch
+The above examples show how you can make a request. In many cases, you will want to do something with the response.
 
-1.  Using `then` and `catch` in synchronous code:
-
-  ```js
-  fetch('https://mywebsite.com/endpoint.php')
-    .then((response) => response.text())
-    .then((responseText) => {
-      console.log(responseText);
-    })
-    .catch((error) => {
-      console.warn(error);
-    });
-  ```
-2.  Called within an asynchronous function using ES7 `async`/`await` syntax:
+Networking is an inherently asynchronous operation. Fetch methods will return a  [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that make it straightforward to write code that works in an asynchronous manner:
 
   ```js
-  class MyComponent extends React.Component {
-    ...
-    async getUsersFromApi() {
-      try {
-        let response = await fetch('https://mywebsite.com/endpoint/');
-        let responseJson = await response.json();
-        return responseJson.users;
-      } catch(error) {
-        // Handle error
+  getMoviesFromApiAsync() {
+    return fetch('http://facebook.github.io/react-native/movies.json')
+      .then((response) => response.json())
+      .then((responseJson) => {
+        return responseJson.movies;
+      })
+      .catch((error) => {
         console.error(error);
-      }
-    }
-    ...
+      });
   }
   ```
 
-Always make sure to catch any errors that may thrown by fetch. Unhandled errors will be dropped silently.
+You can also use ES7's `async`/`await` syntax in React Native app:
 
-## Advanced networking
+  ```js
+  async getMoviesFromApi() {
+    try {
+      let response = await fetch('http://facebook.github.io/react-native/movies.json');
+      let responseJson = await response.json();
+      return responseJson.movies;
+    } catch(error) {
+      console.error(error);
+    }
+  }
+  ```
+
+Don't forget to catch any errors that may be thrown by `fetch`, otherwise they will be dropped silently.
+
+## WebSocket Support
+
+React Native supports [WebSocket]((https://developer.mozilla.org/en-US/docs/Web/API/WebSocket)), a protocol which provides full-duplex communication channels over a single TCP connection.
 
 React Native also comes with support for [Web Sockets](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket).
 
-## Networking in third party libraries
+## Using Other Networking Libraries
 
-Many third party libraries use the `XMLHttpRequest` API. This API is also built in to React Native, which means that you can use third party libraries such as [frisbee](https://github.com/niftylettuce/frisbee) or [axios](https://github.com/mzabriskie/axios) directly from NPM.
+The `XMLHttpRequest` API, used by many networking libraries, is built in to React Native. This means that you can use third party libraries such as [frisbee](https://github.com/niftylettuce/frisbee) or [axios](https://github.com/mzabriskie/axios) if you prefer.

--- a/docs/Basics-Network.md
+++ b/docs/Basics-Network.md
@@ -76,7 +76,7 @@ Don't forget to catch any errors that may be thrown by `fetch`, otherwise they w
 
 ## WebSocket Support
 
-React Native supports [WebSocket]((https://developer.mozilla.org/en-US/docs/Web/API/WebSocket)), a protocol which provides full-duplex communication channels over a single TCP connection.
+React Native supports [WebSocket](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket), a protocol which provides full-duplex communication channels over a single TCP connection.
 
 React Native also comes with support for [Web Sockets](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket).
 

--- a/docs/Basics-Network.md
+++ b/docs/Basics-Network.md
@@ -78,8 +78,6 @@ Don't forget to catch any errors that may be thrown by `fetch`, otherwise they w
 
 React Native supports [WebSocket](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket), a protocol which provides full-duplex communication channels over a single TCP connection.
 
-React Native also comes with support for [Web Sockets](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket).
-
 ## Using Other Networking Libraries
 
 The `XMLHttpRequest` API, used by many networking libraries, is built in to React Native. This means that you can use third party libraries such as [frisbee](https://github.com/niftylettuce/frisbee) or [axios](https://github.com/mzabriskie/axios) if you prefer.

--- a/website/src/react-native/movies.json
+++ b/website/src/react-native/movies.json
@@ -1,0 +1,11 @@
+{
+  "title": "The Basics - Networking",
+  "description": "Your app fetched this from a remote endpoint!",
+  "movies": [
+    { "title": "Star Wars", "releaseYear": "1977"},
+    { "title": "Back to the Future", "releaseYear": "1985"},
+    { "title": "The Matrix", "releaseYear": "1999"},
+    { "title": "Inception", "releaseYear": "2010"},
+    { "title": "Interstellar", "releaseYear": "2014"}
+  ]
+}


### PR DESCRIPTION
Simplified Networking Guide, based on the old Network polyfill doc.

This guide strongly recommends using fetch, while still informing the user about React Native's support for other libraries.

In order to provide an actual working networking example, a `movies.json` file is added at the root of the site, allowing the user to fetch a small blob of JSON:

```
fetch('http://facebook.github.io/react-native/movies.json')
```

![networking](https://cloud.githubusercontent.com/assets/165856/16321804/d2bd7c6a-3953-11e6-9fc5-30baaa38d7a4.png)