### PR TITLE
Bring out prop descriptions, for Flexbox

### DIFF
--- a/website/server/extractDocs.js
+++ b/website/server/extractDocs.js
@@ -437,7 +437,10 @@ function renderStyle(filepath) {
   const json = docgen.parse(
     fs.readFileSync(filepath),
     docgenHelpers.findExportedObject,
-    [docgen.handlers.propTypeHandler]
+    [
+      docgen.handlers.propTypeHandler,
+      docgen.handlers.propDocBlockHandler,
+    ]
   );
 
   // Remove deprecated transform props from docs


### PR DESCRIPTION
For Flexbox API docs would like to tease out the prop descriptions. This PR makes that feasible by exposing the description for style.

**Test plan (required)**

1. Temporarily modified the flexbox source doc: Libraries/StyleSheet/LayoutPropTypes.js to add a description.
2. Checked it out on local webpage: http://localhost:8079/react-native/docs/flexbox.html

![style_prop_descriptions](https://cloud.githubusercontent.com/assets/691109/16321579/866b186e-3952-11e6-823a-2d38132bd553.png)


