### PR TITLE
Update web player in docs for custom registerComponent names

### DIFF
--- a/website/core/WebPlayer.js
+++ b/website/core/WebPlayer.js
@@ -44,7 +44,7 @@ var WebPlayer = React.createClass({
   },
 
   render: function() {
-    var hash = `#code=${encodeURIComponent(this.props.children)}&runApp=AwesomeProject`;
+    var hash = `#code=${encodeURIComponent(this.props.children)}`;
 
     if (this.props.params) {
       hash += `&${this.props.params}`;
@@ -57,7 +57,7 @@ var WebPlayer = React.createClass({
           style={{marginTop: 4}}
           width='880'
           height={this.parseParams(this.props.params).platform === 'android' ? '425' : '420'}
-          data-src={`//cdn.rawgit.com/dabbott/react-native-web-player/v0.1.2/index.html${hash}`}
+          data-src={`//cdn.rawgit.com/dabbott/react-native-web-player/v0.1.3/index.html${hash}`}
           frameBorder='0'
         />
       </div>


### PR DESCRIPTION
In the web player in the docs, allows `AppRegistry.registerComponent('name', App)` to use *anything* for `'name'`. It is ignored by the web player - last registration wins.