### PR TITLE
Initialize ImagePipelineFactory in ImageLoadedModule

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/modules/image/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/image/BUCK
@@ -12,7 +12,9 @@ android_library(
     react_native_dep('third-party/java/jsr-305:jsr-305'),
     react_native_target('java/com/facebook/react/bridge:bridge'),
     react_native_target('java/com/facebook/react/common:common'),
+    react_native_target('java/com/facebook/react/modules/common:common'),
     react_native_target('java/com/facebook/react/module/annotations:annotations'),
+    react_native_target('java/com/facebook/react/modules/fresco:fresco'),
   ],
   visibility = [
     'PUBLIC',

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/image/ImageLoaderModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/image/ImageLoaderModule.java
@@ -34,6 +34,7 @@ import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.module.annotations.ReactModule;
+import com.facebook.react.modules.fresco.FrescoModule;
 
 @ReactModule(name = "ImageLoader")
 public class ImageLoaderModule extends ReactContextBaseJavaModule implements
@@ -58,6 +59,19 @@ public class ImageLoaderModule extends ReactContextBaseJavaModule implements
   }
 
   @Override
+  public void initialize() {
+    super.initialize();
+    initializeFresco();
+  }
+
+  private void initializeFresco() {
+    if (!FrescoModule.hasBeenInitialized()) {
+      ReactApplicationContext reactContext = this.getReactApplicationContext();
+      reactContext.getNativeModule(FrescoModule.class).initializeFresco();
+    }
+  }
+
+  @Override
   public String getName() {
     return "ImageLoader";
   }
@@ -77,6 +91,8 @@ public class ImageLoaderModule extends ReactContextBaseJavaModule implements
       promise.reject(ERROR_INVALID_URI, "Cannot get the size of an image for an empty URI");
       return;
     }
+
+    this.initializeFresco();
 
     Uri uri = Uri.parse(uriString);
     ImageRequest request = ImageRequestBuilder.newBuilderWithSource(uri).build();
@@ -138,6 +154,9 @@ public class ImageLoaderModule extends ReactContextBaseJavaModule implements
       promise.reject(ERROR_INVALID_URI, "Cannot prefetch an image for an empty URI");
       return;
     }
+
+    // TODO(xxx) find out why ImageLoader.prefetchImage can be called before ImageLoader.initialize
+    this.initializeFresco();
 
     Uri uri = Uri.parse(uriString);
     ImageRequest request = ImageRequestBuilder.newBuilderWithSource(uri).build();


### PR DESCRIPTION
FIX #8397 #8114 

In the Examples/UIExplorer/ImageExample.js, Image.prefetch was called,
but ImagePipelineFactory was not initialized.
We should make ImagePipelineFactory available before use it.
