### PR TITLE
Set defaults in RCTBundleURLProvider so development mode is the default

### DIFF
--- a/React/Base/RCTBundleURLProvider.m
+++ b/React/Base/RCTBundleURLProvider.m
@@ -183,6 +183,7 @@ static NSString *serverRootWithHost(NSString *host)
   static dispatch_once_t once_token;
   dispatch_once(&once_token, ^{
     sharedInstance = [RCTBundleURLProvider new];
+    [sharedInstance setDefaults];
   });
   return sharedInstance;
 }


### PR DESCRIPTION
This PR fixes a bug introduced in #8091 which turns of development mode by default when using the new RCTBundleURLProvider.

**Test Plan**

Install React Native in a fresh app from `react-native init`.

update `AppDelegate.m` to use the new default development URL generator:

`jsCodeLocation = [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index.ios" fallbackResource:nil];`

Run on iOS device or simulator, and ensure that the dev menu can be pulled up.
