### PR TITLE
Fixed incorrect style props passed to Android Image when using children

### DIFF
--- a/Libraries/Image/Image.android.js
+++ b/Libraries/Image/Image.android.js
@@ -15,6 +15,7 @@ var NativeMethodsMixin = require('NativeMethodsMixin');
 var NativeModules = require('NativeModules');
 var ImageResizeMode = require('ImageResizeMode');
 var ImageStylePropTypes = require('ImageStylePropTypes');
+var ViewStylePropTypes = require('ViewStylePropTypes');
 var PropTypes = require('ReactPropTypes');
 var React = require('React');
 var ReactNativeViewAttributes = require('ReactNativeViewAttributes');
@@ -26,6 +27,8 @@ var flattenStyle = require('flattenStyle');
 var merge = require('merge');
 var requireNativeComponent = require('requireNativeComponent');
 var resolveAssetSource = require('resolveAssetSource');
+var Set = require('Set');
+var filterObject = require('fbjs/lib/filterObject');
 
 var {
   ImageLoader,
@@ -62,6 +65,9 @@ var ImageViewAttributes = merge(ReactNativeViewAttributes.UIView, {
   fadeDuration: true,
   shouldNotifyLoadEvents: true,
 });
+
+var ViewStyleKeys = new Set(Object.keys(ViewStylePropTypes));
+var ImageSpecificStyleKeys = new Set(Object.keys(ImageStylePropTypes).filter(x => !ViewStyleKeys.has(x)));
 
 var Image = React.createClass({
   propTypes: {
@@ -222,12 +228,15 @@ var Image = React.createClass({
 
       if (nativeProps.children) {
         // TODO(6033040): Consider implementing this as a separate native component
+        const containerStyle = filterObject(style, (val, key) => !ImageSpecificStyleKeys.has(key));
+        const imageStyle = filterObject(style, (val, key) => ImageSpecificStyleKeys.has(key));
         const imageProps = merge(nativeProps, {
-          style: styles.absoluteImage,
+          style: [imageStyle, styles.absoluteImage],
           children: undefined,
         });
+
         return (
-          <View style={nativeProps.style}>
+          <View style={containerStyle}>
             <RKImage {...imageProps}/>
             {this.props.children}
           </View>


### PR DESCRIPTION
Hi there,

Here is a fix for #7538 (and #5085).

I had originally discovered this issue when using `resizeMode` through the style props. Although this might arguably be an incorrect usage (see https://github.com/facebook/react-native/issues/4759#issuecomment-164301166) the same issue would happen with the `tintColor` and `overlayColor` style props.

To  test this, you can render the following:

```jsx
const imageContainerStyle = {width: 100, height: 100, backgroundColor: 'green', marginLeft: 10, marginTop: 10, };
const imageStyle = {flex: 1, width: undefined, height: undefined, resizeMode: 'contain', };

return (
  <View style={styles.container}>
    <View style={imageContainerStyle}>
      <Image style={imageStyle} source={
        {uri:'http://resizing.flixster.com/DeLpPTAwX3O2LszOpeaMHjbzuAw=/53x77/dkpu1ddg7pbsk.cloudfront.net/movie/11/16/47/11164719_ori.jpg'} 
      }>
      </Image>
    </View>
    <View style={imageContainerStyle}>
      <Image style={imageStyle} source={
        {uri:'http://resizing.flixster.com/DeLpPTAwX3O2LszOpeaMHjbzuAw=/53x77/dkpu1ddg7pbsk.cloudfront.net/movie/11/16/47/11164719_ori.jpg'}  
      }>
        <View style={{width: 20, height: 20, backgroundColor: 'blue'}} />
      </Image>
    </View>
  </View>
);
```

And verify that the second image (with the blue square) `resizeMode` is still correct and displays exactly as in the first image.
You can also substitute `resizeMode` with `tintColor` or `overlayColor`.

I tried to make the fix robust so it wouldn't introduce new issues if new style props were added to the `Image` component.
When the `Image` module is loaded, it intersects the `View` style props with the `Image` style props to extract the style props that are specific to the `Image` style. Right now the props are: `resizeMode`, `tintColor` and `overlayColor` (this one is Android only).

Let me know what you think.