### PR TITLE
Fix errors related to typehint when generating docs

### DIFF
--- a/website/server/extractDocs.js
+++ b/website/server/extractDocs.js
@@ -377,7 +377,7 @@ function getTypehint(typehint) {
   try {
     var typehint = JSON.parse(typehint);
   } catch (e) {
-    return typehint.split('|').map(type => type.trim());
+    return typehint.toString().split('|').map(type => type.trim());
   }
   return getTypehintRec(typehint);
 }


### PR DESCRIPTION
After pulling in AsyncStorage doc changes, getting typehint errors when running docs. This fixes that issue.

**Test plan (required)**

Opened http://localhost:8079/react-native/index.html

Clicked around. No errors. Also successfully ran:

```
node server/generate.js
```

