### PR TITLE
OkHttpCallUtil.cancelTag verifies tag is not null

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/common/network/OkHttpCallUtil.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/common/network/OkHttpCallUtil.java
@@ -21,6 +21,10 @@ public class OkHttpCallUtil {
   }
 
   public static void cancelTag(OkHttpClient client, Object tag) {
+    if (tag == null) {
+      return;
+    }
+
     for (Call call : client.dispatcher().queuedCalls()) {
       if (tag.equals(call.request().tag())) {
         call.cancel();


### PR DESCRIPTION
#8009 and #8175 have reported issues of request tags in OkHttp 3 being `null` when cancelling any pending requests during a catalyst teardown. 

I put a `null` check before attempting to access `tag`, since it's been coming in as `null`. Not sure if it's better to do this at the callsite though. Or tack down how it became `null` in the first place. My knowledge of the `NetworkingModule` is not too deep.

As a quick sanity check, it would appear that `tag` would be the `null` reference, and not `call.request().tag()`'s tag.

![screen shot 2016-06-24 at 2 43 03 pm](https://cloud.githubusercontent.com/assets/656630/16347568/6cc090f0-3a1b-11e6-9281-981eca0d8ac8.png)


This causes the following exception: 

```
Fatal Exception: java.lang.RuntimeException: Unable to destroy activity {com.robinpowered.rooms/com.robinrooms.MainActivity}: java.lang.NullPointerException: Attempt to invoke virtual method 'boolean java.lang.Object.equals(java.lang.Object)' on a null object reference
       at android.app.ActivityThread.performDestroyActivity(ActivityThread.java:4828)
       at android.app.ActivityThread.handleDestroyActivity(ActivityThread.java:4846)
       at android.app.ActivityThread.handleRelaunchActivity(ActivityThread.java:5105)
       at android.app.ActivityThread.access$1100(ActivityThread.java:197)
       at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1662)
       at android.os.Handler.dispatchMessage(Handler.java:102)
       at android.os.Looper.loop(Looper.java:145)
       at android.app.ActivityThread.main(ActivityThread.java:6873)
       at java.lang.reflect.Method.invoke(Method.java)
       at java.lang.reflect.Method.invoke(Method.java:372)
       at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:1404)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1199)
Caused by java.lang.NullPointerException: Attempt to invoke virtual method 'boolean java.lang.Object.equals(java.lang.Object)' on a null object reference
       at com.facebook.react.common.network.OkHttpCallUtil.cancelTag(OkHttpCallUtil.java:30)
       at com.facebook.react.modules.network.NetworkingModule.onCatalystInstanceDestroy(NetworkingModule.java:141)
       at com.facebook.react.bridge.NativeModuleRegistry.notifyCatalystInstanceDestroy(NativeModuleRegistry.java:98)
       at com.facebook.react.bridge.CatalystInstanceImpl.destroy(CatalystInstanceImpl.java:218)
       at com.facebook.react.bridge.ReactContext.destroy(ReactContext.java:193)
       at com.facebook.react.ReactInstanceManagerImpl.destroy(ReactInstanceManagerImpl.java:510)
       at com.facebook.react.ReactActivity.onDestroy(ReactActivity.java:177)
       at android.app.Activity.performDestroy(Activity.java:6784)
       at android.app.Instrumentation.callActivityOnDestroy(Instrumentation.java:1155)
       at android.app.ActivityThread.performDestroyActivity(ActivityThread.java:4806)
       at android.app.ActivityThread.handleDestroyActivity(ActivityThread.java:4846)
       at android.app.ActivityThread.handleRelaunchActivity(ActivityThread.java:5105)
       at android.app.ActivityThread.access$1100(ActivityThread.java:197)
       at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1662)
       at android.os.Handler.dispatchMessage(Handler.java:102)
       at android.os.Looper.loop(Looper.java:145)
       at android.app.ActivityThread.main(ActivityThread.java:6873)
       at java.lang.reflect.Method.invoke(Method.java)
       at java.lang.reflect.Method.invoke(Method.java:372)
       at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:1404)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1199)
```