### PR TITLE
Update docs with ReactInstanceManager API change

### DIFF
--- a/docs/EmbeddedAppAndroid.md
+++ b/docs/EmbeddedAppAndroid.md
@@ -83,7 +83,7 @@ protected void onPause() {
     super.onPause();
 
     if (mReactInstanceManager != null) {
-        mReactInstanceManager.onPause();
+        mReactInstanceManager.onHostPause();
     }
 }
 
@@ -92,7 +92,7 @@ protected void onResume() {
     super.onResume();
 
     if (mReactInstanceManager != null) {
-        mReactInstanceManager.onResume(this, this);
+        mReactInstanceManager.onHostResume(this, this);
     }
 }
 ```


### PR DESCRIPTION
Documentation update for existing Android app integration due to API changes to `ReactInstanceManager`.

- `onPause` is now `onHostPause`
- `onResume` is `onHostResume`

This might be useful for other people searching it up, but when I got the error:

`Module 0 is not a registered callable module`

It was because my Gradle file accidentally was using the version of React Native from Maven Central instead of the one within my `node_modules` directory, which was a much older version (0.20.1).

However, I thought it was the right one because when I switched directories, my app was giving me errors since `mReactInstanceManager.onPause` and `mReactInstanceManager.onResume` didn't exist.

The change in the API wasn't reflected in the docs, and it took me forever to figure that out. Hope this saves some other people some time!