### PR TITLE
Add gif and webp support to Fresco

### DIFF
--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -264,8 +264,11 @@ dependencies {
     compile fileTree(dir: 'src/main/third-party/java/infer-annotations/', include: ['*.jar'])
     compile 'com.android.support:appcompat-v7:23.0.1'
     compile 'com.android.support:recyclerview-v7:23.0.1'
+    compile 'com.facebook.fresco:animated-gif:0.11.0'
+    compile 'com.facebook.fresco:animated-webp:0.11.0'
     compile 'com.facebook.fresco:fresco:0.11.0'
     compile 'com.facebook.fresco:imagepipeline-okhttp3:0.11.0'
+    compile 'com.facebook.fresco:webpsupport:0.11.0'
     compile 'com.fasterxml.jackson.core:jackson-core:2.2.3'
     compile 'com.google.code.findbugs:jsr305:3.0.0'
     compile 'com.squareup.okhttp3:okhttp:3.2.0'

--- a/ReactAndroid/src/main/libraries/fresco/fresco-react-native/BUCK
+++ b/ReactAndroid/src/main/libraries/fresco/fresco-react-native/BUCK
@@ -28,6 +28,9 @@ android_library(
       ':imagepipeline-base',
       ':imagepipeline-core',
       ':bolts',
+      ':fresco-animated-gif',
+      ':fresco-animated-webp',
+      ':fresco-webpsupport'
   ],
   visibility = ['//ReactAndroid/...',],
 )
@@ -90,4 +93,40 @@ remote_file(
     name = 'imagepipeline-okhttp3-binary-aar',
     url = 'mvn:com.facebook.fresco:imagepipeline-okhttp3:aar:0.11.0',
     sha1 = '3d7e6d1a2f2e973a596aae7d523667b5a3d6d8a5',
+)
+
+android_prebuilt_aar(
+    name = 'fresco-animated-gif',
+    aar = ':fresco-animated-gif-binary-aar',
+    visibility = ['//ReactAndroid/...',],
+)
+
+remote_file(
+    name = 'fresco-animated-gif-binary-aar',
+    url = 'mvn:com.facebook.fresco:animated-gif:aar:0.11.0',
+    sha1 = '5ec1cbdd5c4689c81009fae745c347982c8af71d',
+)
+
+android_prebuilt_aar(
+    name = 'fresco-animated-webp',
+    aar = ':fresco-animated-webp-binary-aar',
+    visibility = ['//ReactAndroid/...',],
+)
+
+remote_file(
+    name = 'fresco-animated-webp-binary-aar',
+    url = 'mvn:com.facebook.fresco:animated-webp:aar:0.11.0',
+    sha1 = 'ce9955c2dd7c906448ec586bb5360fe796d93667',
+)
+
+android_prebuilt_aar(
+    name = 'fresco-webpsupport',
+    aar = ':fresco-webpsupport-binary-aar',
+    visibility = ['//ReactAndroid/...',],
+)
+
+remote_file(
+    name = 'fresco-webpsupport-binary-aar',
+    url = 'mvn:com.facebook.fresco:webpsupport:aar:0.11.0',
+    sha1 = '2e1ea9a0c400f0cbe4aa1dd38d8a55dfbe51833d',
 )


### PR DESCRIPTION
Motivation #7760 

**Test plan**
Build from source with a gif image, everything works fine.

However, i'm not sure about the BUCK part. While building I saw the dependencies I added being downloaded, but the app built with BUCK doesn't support gif. Maybe someone with more experience with BUCK than me can check this?
