### PR TITLE
Respect scale in RCTPhotoLibraryImageLoader

### DIFF
--- a/Libraries/CameraRoll/RCTPhotoLibraryImageLoader.m
+++ b/Libraries/CameraRoll/RCTPhotoLibraryImageLoader.m
@@ -66,7 +66,7 @@ RCT_EXPORT_MODULE()
     targetSize = PHImageManagerMaximumSize;
     imageOptions.resizeMode = PHImageRequestOptionsResizeModeNone;
   } else {
-    targetSize = size;
+    targetSize = CGSizeApplyAffineTransform(size, CGAffineTransformMakeScale(scale, scale));
     imageOptions.resizeMode = PHImageRequestOptionsResizeModeFast;
   }
 


### PR DESCRIPTION
RCTPhotoLibraryImageLoader was not using the scale argument so the image loaded wasn't always the right resolution.

**Test plan**

On my iPhone 6, which has `RCTScreenScale() === 2`, see that an `<Image>` rendered with a `ph://XXX` URI is rendered properly in 2x.

More thoroughly, I used `PHAsset.fetchAssetsWithMediaType(.Image, options: fetchOptions)` to fetch PHAssets to get a `asset.localIdentifier` to test. Then, I rendered a `<Image source={{uri: `ph://${localIdentifier}`}} style={{width: 375, height: 375}} />`.

