### PR TITLE
fix required propType.

### DIFF
--- a/Libraries/Experimental/SwipeableRow/SwipeableListView.js
+++ b/Libraries/Experimental/SwipeableRow/SwipeableListView.js
@@ -75,7 +75,7 @@ const SwipeableListView = React.createClass({
      */
     dataSource: PropTypes.instanceOf(SwipeableListViewDataSource).isRequired,
     // Maximum distance to open to after a swipe
-    maxSwipeDistance: PropTypes.number,
+    maxSwipeDistance: PropTypes.number.isRequired,
     // Callback method to render the swipeable view
     renderRow: PropTypes.func.isRequired,
     // Callback method to render the view that will be unveiled on swipe


### PR DESCRIPTION
The required `maxSwipeDistance` was already defined in https://github.com/facebook/react-native/blob/master/Libraries/Experimental/SwipeableRow/SwipeableRow.js#L83, but the default value is [`0`](https://github.com/facebook/react-native/blob/master/Libraries/Experimental/SwipeableRow/SwipeableRow.js#L118), that means it just doesn't work by default.

I think it's much clearer to make it required on `SwipeableListView`. Or specify a default value larger that 0.