### PR TITLE
Add cardStyle prop to NavigationCardStack.

### DIFF
--- a/Libraries/CustomComponents/NavigationExperimental/NavigationCardStack.js
+++ b/Libraries/CustomComponents/NavigationExperimental/NavigationCardStack.js
@@ -96,6 +96,7 @@ class NavigationCardStack extends React.Component<DefaultProps, Props, void> {
     onNavigateBack: PropTypes.func,
     renderOverlay: PropTypes.func,
     renderScene: PropTypes.func.isRequired,
+    cardStyle: View.propTypes.style,
   };
 
   static defaultProps: DefaultProps = {
@@ -192,7 +193,7 @@ class NavigationCardStack extends React.Component<DefaultProps, Props, void> {
         key={'card_' + props.scene.key}
         panHandlers={panHandlers}
         renderScene={this.props.renderScene}
-        style={style}
+        style={[style, this.props.cardStyle]}
       />
     );
   }


### PR DESCRIPTION
This allows the `NavigationCard` style to be extended, the default `backgroundColor` style of the `NavigationCard` is not applicable to all apps.
Fixes issue #8116. PR #8115 was already made for this but didn't pass CI checks.

**Test plan**

When rendering a NavigationCardStack, add 

```
const { CardStack } = NavigationExperimental;
...

<CardStack cardStyle={{ backgroundColor: 'purple' }} />
```

to see that the `NavigationCard` background has changed to purple.