### PR TITLE
Fixes EventEmitter#once arguments not getting passed to the listener

### DIFF
--- a/Libraries/EventEmitter/EventEmitter.js
+++ b/Libraries/EventEmitter/EventEmitter.js
@@ -78,9 +78,9 @@ class EventEmitter {
    *   listener
    */
   once(eventType: string, listener: Function, context: ?Object): EmitterSubscription {
-    return this.addListener(eventType, () => {
+    return this.addListener(eventType, (...args) => {
       this.removeCurrentListener();
-      listener.apply(context, arguments);
+      listener.apply(context, args);
     });
   }
 


### PR DESCRIPTION
Arrow functions do not have their own arguments. Fix EventEmitter#once to pass the correct arguments to the listener callback.