### PR TITLE
Add RCTAnimation to Podspec

### DIFF
--- a/React.podspec
+++ b/React.podspec
@@ -54,6 +54,12 @@ Pod::Spec.new do |s|
     ss.preserve_paths = "Libraries/AdSupport/*.js"
   end
 
+  s.subspec 'RCTAnimation' do |ss|
+    ss.dependency       'React/Core'
+    ss.source_files   = "Libraries/NativeAnimation/{Nodes/*,*}.{h,m}"
+    ss.preserve_paths = "Libraries/NativeAnimation/*.js"
+  end
+
   s.subspec 'RCTCameraRoll' do |ss|
     ss.dependency       'React/Core'
     ss.dependency       'React/RCTImage'


### PR DESCRIPTION
**Motivation**

This PR adds a subspec for the `NativeAnimation` iOS library which so one can use it with CocoaPods. 

**Test plan (required)**

Tested with the code in `NativeAnimationsExample.js` and this:
```
pod 'React', :subspecs => ['Core', 'RCTAnimation'], :path => 'node_modules/react-native'
```