### PR TITLE
Fix frame calculation for natively driven animations

### DIFF
--- a/Libraries/Animated/src/AnimatedImplementation.js
+++ b/Libraries/Animated/src/AnimatedImplementation.js
@@ -255,9 +255,10 @@ class TimingAnimation extends Animation {
   _getNativeAnimationConfig(): any {
     var frameDuration = 1000.0 / 60.0;
     var frames = [];
-    for (var dt = 0.0; dt <= this._duration; dt += frameDuration) {
+    for (var dt = 0.0; dt < this._duration; dt += frameDuration) {
       frames.push(this._easing(dt / this._duration));
     }
+    frames.push(this._easing(1));
     return {
       type: 'frames',
       frames,


### PR DESCRIPTION
Currently the algorithm for calculating frames will not always have an correct value for the endframe making some natively driven animations stuck almost at the end. This PR ensures the animation ends at `1`.

**Test plan**

Tested with the code in `NativeAnimationsExample.js`.