### PR TITLE
[TextInput] Add __DEV__ around textInput prop check

### DIFF
--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -538,11 +538,13 @@ const TextInput = React.createClass({
     var props = Object.assign({}, this.props);
     props.style = [styles.input, this.props.style];
     if (!props.multiline) {
-      for (var propKey in onlyMultiline) {
-        if (props[propKey]) {
-          throw new Error(
-            'TextInput prop `' + propKey + '` is only supported with multiline.'
-          );
+      if (__DEV__) {
+        for (var propKey in onlyMultiline) {
+          if (props[propKey]) {
+            throw new Error(
+              'TextInput prop `' + propKey + '` is only supported with multiline.'
+            );
+          }
         }
       }
       textContainer =


### PR DESCRIPTION
**Motivation** 

The prop validation was run on every render, even in prod which seems odd to me. This adds a dev check to make sure prod build skips the validation.

**Test plan (required)**

There are no changes to the ui.