### PR TITLE
onPause -> onHostPause and onResume -> onHostResume

### DIFF
--- a/docs/EmbeddedAppAndroid.md
+++ b/docs/EmbeddedAppAndroid.md
@@ -83,7 +83,7 @@ protected void onPause() {
     super.onPause();
 
     if (mReactInstanceManager != null) {
-        mReactInstanceManager.onPause();
+        mReactInstanceManager.onHostPause();
     }
 }
 
@@ -92,7 +92,7 @@ protected void onResume() {
     super.onResume();
 
     if (mReactInstanceManager != null) {
-        mReactInstanceManager.onResume(this, this);
+        mReactInstanceManager.onHostResume(this, this);
     }
 }
 ```


### PR DESCRIPTION
```ReactInstanceManager.onPause``` and ```ReactInstanceManager.onResume``` are now replaced by ```ReactInstanceManager.onHostPause``` and ```ReactInstanceManager.onHostResume```. Following the old document will lead people to a compile error.