### PR TITLE
Add ping to WebSocket

### DIFF
--- a/Libraries/WebSocket/RCTWebSocketModule.m
+++ b/Libraries/WebSocket/RCTWebSocketModule.m
@@ -77,6 +77,11 @@ RCT_EXPORT_METHOD(sendBinary:(NSString *)base64String socketID:(nonnull NSNumber
   [_sockets[socketID] send:message];
 }
 
+RCT_EXPORT_METHOD(sendPing:(nonnull NSNumber *)socketID)
+{
+  [_sockets[socketID] sendPing:NULL];
+}
+
 RCT_EXPORT_METHOD(close:(nonnull NSNumber *)socketID)
 {
   [_sockets[socketID] close];

--- a/Libraries/WebSocket/RCTWebSocketModule.m
+++ b/Libraries/WebSocket/RCTWebSocketModule.m
@@ -77,7 +77,7 @@ RCT_EXPORT_METHOD(sendBinary:(NSString *)base64String socketID:(nonnull NSNumber
   [_sockets[socketID] send:message];
 }
 
-RCT_EXPORT_METHOD(sendPing:(nonnull NSNumber *)socketID)
+RCT_EXPORT_METHOD(ping:(nonnull NSNumber *)socketID)
 {
   [_sockets[socketID] sendPing:NULL];
 }

--- a/Libraries/WebSocket/WebSocket.js
+++ b/Libraries/WebSocket/WebSocket.js
@@ -135,6 +135,14 @@ class WebSocket extends EventTarget(...WEBSOCKET_EVENTS) {
     throw new Error('Unsupported data type');
   }
 
+  sendPing(): void {
+    if (this.readyState === this.CONNECTING) {
+        throw new Error('INVALID_STATE_ERR');
+    }
+
+    RCTWebSocketModule.sendPing(this._socketId);
+  }
+
   _close(code?: number, reason?: string): void {
     if (Platform.OS === 'android') {
       // See https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent

--- a/Libraries/WebSocket/WebSocket.js
+++ b/Libraries/WebSocket/WebSocket.js
@@ -135,7 +135,7 @@ class WebSocket extends EventTarget(...WEBSOCKET_EVENTS) {
     throw new Error('Unsupported data type');
   }
 
-  sendPing(): void {
+  ping(): void {
     if (this.readyState === this.CONNECTING) {
         throw new Error('INVALID_STATE_ERR');
     }

--- a/Libraries/WebSocket/WebSocket.js
+++ b/Libraries/WebSocket/WebSocket.js
@@ -140,7 +140,7 @@ class WebSocket extends EventTarget(...WEBSOCKET_EVENTS) {
         throw new Error('INVALID_STATE_ERR');
     }
 
-    RCTWebSocketModule.sendPing(this._socketId);
+    RCTWebSocketModule.ping(this._socketId);
   }
 
   _close(code?: number, reason?: string): void {

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/websocket/WebSocketModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/websocket/WebSocketModule.java
@@ -229,6 +229,21 @@ public class WebSocketModule extends ReactContextBaseJavaModule {
     }
   }
 
+  @ReactMethod
+  public void sendPing(int id) {
+    WebSocket client = mWebSocketConnections.get(id);
+    if (client == null) {
+      // This is a programmer error
+      throw new RuntimeException("Cannot send a message. Unknown WebSocket id " + id);
+    }
+    try {
+      Buffer buffer = new Buffer();
+      client.sendPing(buffer);
+    } catch (IOException | IllegalStateException e) {
+      notifyWebSocketFailed(id, e.getMessage());
+    }
+  }
+
   private void notifyWebSocketFailed(int id, String message) {
     WritableMap params = Arguments.createMap();
     params.putInt("id", id);

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/websocket/WebSocketModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/websocket/WebSocketModule.java
@@ -230,7 +230,7 @@ public class WebSocketModule extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
-  public void sendPing(int id) {
+  public void ping(int id) {
     WebSocket client = mWebSocketConnections.get(id);
     if (client == null) {
       // This is a programmer error


### PR DESCRIPTION
Idle WebSocket connections get reset after a few minutes of inactivity. To prevent this, most WebSocket implementations offer sending special ping messages. This PR adds a method `sendPing()` to  WebSocket. Ping payloads are not supported.

Manual testing can be done by adding `connection.on('ping', _ => console.log('Received ping'));` to a ws connection or using a packet sniffer while sending pings.