### PR TITLE
Ignore fake keyboardWillChangeFrame events

### DIFF
--- a/Libraries/Components/Keyboard/KeyboardAvoidingView.js
+++ b/Libraries/Components/Keyboard/KeyboardAvoidingView.js
@@ -96,7 +96,7 @@ const KeyboardAvoidingView = React.createClass({
     const {duration, easing, endCoordinates} = event;
     const height = this.relativeKeyboardHeight(endCoordinates);
 
-    if (duration && easing) {
+    if (duration && easing && this.state.bottom !== height) {
       LayoutAnimation.configureNext({
         duration: duration,
         update: {


### PR DESCRIPTION
Super-minor fix for KeyboardAvoidingView to disable warning.
Test plan:
1. Run simulator with disabled software keyboard
2. Add `LayoutAnimation.spring()` on TextInput focus
3. Click on TextInput
