### PR TITLE
Don't block scroll when using non-touchable visible row for SwipeableRow

### DIFF
--- a/Libraries/Experimental/SwipeableRow/SwipeableRow.js
+++ b/Libraries/Experimental/SwipeableRow/SwipeableRow.js
@@ -125,10 +125,6 @@ const SwipeableRow = React.createClass({
 
   componentWillMount(): void {
     this._panResponder = PanResponder.create({
-      onStartShouldSetPanResponder: (event, gestureState) => true,
-      // Don't capture child's start events
-      onStartShouldSetPanResponderCapture: (event, gestureState) => false,
-      onMoveShouldSetPanResponder: (event, gestureState) => false,
       onMoveShouldSetPanResponderCapture: this._handleMoveShouldSetPanResponderCapture,
       onPanResponderGrant: this._handlePanResponderGrant,
       onPanResponderMove: this._handlePanResponderMove,


### PR DESCRIPTION
**motivation**
Currently when using a non-touchable visible row for a SwipeableRow, the scroll on list view is blocked.

**Test Plan**
```
<SwipeableListView
   dataSource={dataSource}
   renderRow={() => <View style={styles.row}/>}
   renderQuickActions={() => <View style={styles.hiddenrow}/>}
/>
```

* Tested that when using non-touchable for renderRow allows scrolling on list view.
* Tested that when using touchable for renderRow allows scrolling on list view.


cc @fred2028 