### PR TITLE
Turned on old bridge for OSS

### DIFF
--- a/Libraries/Utilities/createStrictShapeTypeChecker.js
+++ b/Libraries/Utilities/createStrictShapeTypeChecker.js
@@ -46,15 +46,14 @@ function createStrictShapeTypeChecker(
     var allKeys = merge(props[propName], shapeTypes);
     for (var key in allKeys) {
       var checker = shapeTypes[key];
-      invariant(
-        checker,
-        'Invalid props.%s key `%s` supplied to `%s`.\nBad object: %s\nValid keys: %s',
-        propName,
-        key,
-        componentName,
-        JSON.stringify(props[propName], null, '  '),
-        JSON.stringify(Object.keys(shapeTypes).sort(), null, '  '),
-      );
+      if (!checker) {
+        invariant(
+          false,
+          `Invalid props.${propName} key \`${key}\` supplied to \`${componentName}\`.` +
+            `\nBad object: ` + JSON.stringify(props[propName], null, '  ') +
+            `\nValid keys: ` + JSON.stringify(Object.keys(shapeTypes), null, '  ')
+        );
+      }
       var error = checker(propValue, key, componentName, location);
       if (error) {
         invariant(

--- a/ReactAndroid/src/androidTest/java/com/facebook/react/testing/ReactAppTestActivity.java
+++ b/ReactAndroid/src/androidTest/java/com/facebook/react/testing/ReactAppTestActivity.java
@@ -153,6 +153,7 @@ public class ReactAppTestActivity extends FragmentActivity implements
     ReactInstanceManager.Builder builder =
       ReactTestHelper.getReactTestFactory().getReactInstanceManagerBuilder()
         .setApplication(getApplication())
+        .setUseOldBridge(true)
         .setBundleAssetName(bundleName)
         // By not setting a JS module name, we force the bundle to be always loaded from
         // assets, not the devserver, even if dev mode is enabled (such as when testing redboxes).

--- a/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
@@ -339,7 +339,7 @@ public abstract class ReactInstanceManager {
         mUIImplementationProvider = new UIImplementationProvider();
       }
 
-      if (mUseOldBridge) {
+      if (true) {
         return new ReactInstanceManagerImpl(
             Assertions.assertNotNull(
                 mApplication,

--- a/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
@@ -339,7 +339,7 @@ public abstract class ReactInstanceManager {
         mUIImplementationProvider = new UIImplementationProvider();
       }
 
-      if (true) {
+      if (mUseOldBridge) {
         return new ReactInstanceManagerImpl(
             Assertions.assertNotNull(
                 mApplication,

--- a/ReactAndroid/src/main/java/com/facebook/react/ReactNativeHost.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactNativeHost.java
@@ -61,6 +61,7 @@ public abstract class ReactNativeHost {
 
   protected ReactInstanceManager createReactInstanceManager() {
     ReactInstanceManager.Builder builder = ReactInstanceManager.builder()
+      .setUseOldBridge(true)
       .setApplication(mApplication)
       .setJSMainModuleName(getJSMainModuleName())
       .setUseDeveloperSupport(getUseDeveloperSupport())


### PR DESCRIPTION
This should revert back to using old bridge by default until we fix gradle script to build new bridge for OSS correctly

Test Plan:
- circle CI
- travis
- sandcastle