### PR TITLE
[docs] add debugging native code

### DIFF
--- a/docs/Debugging.md
+++ b/docs/Debugging.md
@@ -92,6 +92,10 @@ The debugger will receive a list of all project roots, separated by a space. For
 
 > Custom debugger commands executed this way should be short-lived processes, and they shouldn't produce more than 200 kilobytes of output.
 
+## Debugging native code
+
+When working with native code (e.g. when writing native modules) you can launch the app from Android Studio or Xcode and take advantage of the debugging features (setup breakpoints, etc.) as you would in case of building a standard native app.
+
 ## Performance Monitor
 
 You can enable a performance overlay to help you debug performance problems by selecting "Perf Monitor" in the Developer Menu.


### PR DESCRIPTION
I believe it is beneficial to explicitly state that this is possible.

