### PR TITLE
improve TextInput docs

### DIFF
--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -190,6 +190,7 @@ const TextInput = React.createClass({
      * - `default`
      * - `numeric`
      * - `email-address`
+     * - `phone-pad`
      */
     keyboardType: PropTypes.oneOf([
       // Cross-platform


### PR DESCRIPTION
Add `phone-pad` as one of cross-platform values to `keyboardType`.