### PR TITLE
Harmonize native animation callback args with JS

### DIFF
--- a/Libraries/NativeAnimation/Nodes/RCTAnimationDriverNode.m
+++ b/Libraries/NativeAnimation/Nodes/RCTAnimationDriverNode.m
@@ -68,7 +68,9 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
   [self stopAnimation];
   _valueNode = nil;
   if (_callback) {
-    _callback(@[(id)kCFNull]);
+    _callback(@[@{
+      @"finished": @(_animationHasFinished)
+    }]);
   }
 }
 


### PR DESCRIPTION
`Animated.parallel` among other functions expects the `start(callback)` function to be invoked with an `endState` object. Currently natively driven animations call the handler with `null`, this PR changes that to `{ finished: true }`. 

**Test plan**

This should not throw any errors:
```js
Animated.parallel([
  Animated.timing(
    new Animated.Value(0),
    {
      toValue: 1,
      useNativeDriver: true
    }
  ),
  Animated.timing(
    new Animated.Value(0),
    {
      toValue: 1,
      useNativeDriver: true
    }
  )
]).start();
```