### PR TITLE
[ios] don't limit possible orientations for <Modal>

### DIFF
--- a/React/Views/RCTModalHostViewController.m
+++ b/React/Views/RCTModalHostViewController.m
@@ -24,14 +24,4 @@
   }
 }
 
-- (UIInterfaceOrientationMask)supportedInterfaceOrientations
-{
-  // Picking some defaults here, we should probably make this configurable
-  if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad) {
-    return UIInterfaceOrientationMaskAll;
-  } else {
-    return UIInterfaceOrientationMaskPortrait;
-  }
-}
-
 @end


### PR DESCRIPTION
It's unclear why the ViewController for `<Modal>` restricts the screen orientations on iPhone, but it's also pretty clear from its comment that whoever made that choice realized that there needs to be some way for consumers to set their own preferences here. I propose that such a preference should not be baked into the ViewController but left up to the consumer using a custom mechanism or something like react-native-orientation.

**Test plan:** `<Modal>` works in non-portrait screen orientations now.