### PR TITLE
Ios: complete iOS vibration pattern supports

### DIFF
--- a/Examples/UIExplorer/js/VibrationExample.js
+++ b/Examples/UIExplorer/js/VibrationExample.js
@@ -30,12 +30,45 @@ var {
   Text,
   TouchableHighlight,
   Vibration,
+  Platform,
 } = ReactNative;
 
 exports.framework = 'React';
 exports.title = 'Vibration';
 exports.description = 'Vibration API';
+
+var pattern, patternLiteral, patternDescription;
+if (Platform.OS === 'android') {
+  pattern = [0, 500, 200, 500];
+  patternLiteral = '[0, 500, 200, 500]';
+  patternDescription = `${patternLiteral}
+arg 0: duration to wait before turning the vibrator on.
+arg with odd: vibration length.
+arg with even: duration to wait before next vibration.
+`;
+} else {
+  pattern = [0, 1000, 2000, 3000];
+  patternLiteral = '[0, 1000, 2000, 3000]';
+  patternDescription = `${patternLiteral}
+vibration length on iOS is fixed.
+pattern controls durations BETWEEN each vibration only.
+
+arg 0: duration to wait before turning the vibrator on.
+subsequent args: duration to wait before next vibrattion.
+`;
+}
+
 exports.examples = [
+  {
+    title: 'Pattern Descriptions',
+    render() {
+      return (
+        <View style={styles.wrapper}>
+          <Text>{patternDescription}</Text>
+        </View>
+      );
+    },
+  },
   {
     title: 'Vibration.vibrate()',
     render() {
@@ -51,12 +84,12 @@ exports.examples = [
     },
   },
   {
-    title: 'Vibration.vibrate([0, 500, 200, 500])',
+    title: `Vibration.vibrate(${patternLiteral})`,
     render() {
       return (
         <TouchableHighlight
           style={styles.wrapper}
-          onPress={() => Vibration.vibrate([0, 500, 200, 500])}>
+          onPress={() => Vibration.vibrate(pattern)}>
           <View style={styles.button}>
             <Text>Vibrate once</Text>
           </View>
@@ -65,12 +98,12 @@ exports.examples = [
     },
   },
   {
-    title: 'Vibration.vibrate([0, 500, 200, 500], true)',
+    title: `Vibration.vibrate(${patternLiteral}, true)`,
     render() {
       return (
         <TouchableHighlight
           style={styles.wrapper}
-          onPress={() => Vibration.vibrate([0, 500, 200, 500], true)}>
+          onPress={() => Vibration.vibrate(pattern, true)}>
           <View style={styles.button}>
             <Text>Vibrate until cancel</Text>
           </View>

--- a/Libraries/Vibration/RCTVibration.m
+++ b/Libraries/Vibration/RCTVibration.m
@@ -7,17 +7,97 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#import "RCTConvert.h"
 #import "RCTVibration.h"
 
 #import <AudioToolbox/AudioToolbox.h>
 
-@implementation RCTVibration
+@implementation RCTVibration {
+  NSTimer *_timer;
+  NSArray *_pattern;
+  BOOL _repeat;
+  BOOL _vibrating;
+  NSUInteger _index;
+}
 
 RCT_EXPORT_MODULE()
 
 RCT_EXPORT_METHOD(vibrate)
 {
   AudioServicesPlaySystemSound(kSystemSoundID_Vibrate);
+}
+
+RCT_EXPORT_METHOD(vibrateByPattern:(NSArray *)pattern
+                  repeat:(BOOL)repeat
+                  initialVibrate:(BOOL)initialVibrate)
+{
+  if (_vibrating) {
+    return;
+  }
+  _vibrating = YES;
+  _pattern = pattern;
+  _repeat = repeat;
+  _index = 0;
+  if (initialVibrate) {
+    [self vibrate];
+  }
+  [self vibrateDelayedWithInterval:
+        [RCTConvert NSTimeInterval:_pattern[_index]] ?: 1.0];
+}
+
+RCT_EXPORT_METHOD(cancel)
+{
+  _vibrating = NO;
+  [self deleteTimer];
+}
+
+- (void)vibrateDelayedWithInterval:(NSTimeInterval)interval
+{
+  if (_timer) {
+    [self deleteTimer];
+  }
+  _timer =
+    [NSTimer timerWithTimeInterval:interval
+                                     target:self
+                                   selector:@selector(_onTick:)
+                                   userInfo:nil
+                                    repeats:NO];
+  [[NSRunLoop mainRunLoop] addTimer:_timer
+                            forMode:NSRunLoopCommonModes];
+}
+
+- (void)_onTick:(NSTimer *)timer
+{
+  if (!_vibrating) {
+    return;
+  }
+
+  [self vibrate];
+  _index = _index + 1;
+
+  if (_index >= [_pattern count]) {
+    if (_repeat) {
+      _index = 0;
+    } else {
+      [self cancel];
+      return;
+    }
+  }
+  [self vibrateDelayedWithInterval:
+        [RCTConvert NSTimeInterval:_pattern[_index]] ?: 1.0];
+}
+
+- (void)deleteTimer
+{
+  if (_timer && _timer.valid) {
+    [_timer invalidate];
+  }
+  _timer = nil;
+}
+
+- (void)dealloc
+{
+  [self deleteTimer];
 }
 
 @end

--- a/Libraries/Vibration/Vibration.js
+++ b/Libraries/Vibration/Vibration.js
@@ -40,7 +40,16 @@ var Vibration = {
       if (typeof pattern === 'number') {
         RCTVibration.vibrate();
       } else if (Array.isArray(pattern)) {
-        console.warn('Vibration patterns are not supported on iOS');
+        let initialVibrate = false;
+        if (pattern[0] === 0) {
+          if (pattern.length === 1) {
+            RCTVibration.vibrate();
+            return;
+          }
+          initialVibrate = true;
+          pattern = pattern.slice(1);
+        }
+        RCTVibration.vibrateByPattern(pattern, repeat, initialVibrate);
       } else {
         throw new Error('Vibration pattern should be a number or array');
       }
@@ -52,11 +61,7 @@ var Vibration = {
    * @platform android
    */
   cancel: function() {
-    if (Platform.OS === 'ios') {
-      console.warn('Vibration.cancel is not supported on iOS');
-    } else {
-      RCTVibration.cancel();
-    }
+    RCTVibration.cancel();
   }
 };
 

--- a/Libraries/Vibration/Vibration.js
+++ b/Libraries/Vibration/Vibration.js
@@ -20,10 +20,23 @@ var Platform = require('Platform');
  *
  * There will be no effect on devices that do not support Vibration, eg. the simulator.
  *
- * Note for android
+ * **Note for android**
  * add `<uses-permission android:name="android.permission.VIBRATE"/>` to `AndroidManifest.xml`
  *
- * Vibration patterns are currently unsupported.
+ * **Android Usage:**
+ *
+ * [0, 500, 200, 500]
+ * V(0.5s) --wait(0.2s)--> V(0.5s)
+ *
+ * [300, 500, 200, 500]
+ * --wait(0.3s)--> V(0.5s) --wait(0.2s)--> V(0.5s)
+ *
+ * **iOS Usage:**
+ * if first argument is 0, it will not be included in pattern array.
+ *
+ * [0, 1000, 2000, 3000]
+ * V(fixed) --wait(1s)--> V(fixed) --wait(2s)--> V(fixed) --wait(3s)--> V(fixed)
+ *
  */
 
 var Vibration = {


### PR DESCRIPTION
**motivation**

To supports vibration pattern like android.

The [iOS vibration implementation link](http://stackoverflow.com/questions/12966467/are-there-apis-for-custom-vibrations-in-ios/13047464#13047464) mentioned by @skv-headless at https://github.com/facebook/react-native/pull/6061#discussion_r54062592, which will not be accepted by apple since that implementation uses a private API. Thus, I use pure public API `NSTimer` to implement it.

**Note**

Since vibration time on iOS is not configurable, there are slightly differences with android.
for example:

**Android Usage:**
`Vibration.vibrate([0, 500, 200, 500])`
==> V(0.5s) --wait(0.2s)--> V(0.5s)

`Vibration.vibrate([300, 500, 200, 500])`
==> --wait(0.3s)--> V(0.5s) --wait(0.2s)--> V(0.5s)

**iOS Usage:**
if first argument is 0, it will not be included in pattern array.
( vibration length on iOS is about 500ms )
 
`Vibration.vibrate([0, 1000, 2000, 3000])`
==> V(fixed) --wait(1s)--> V(fixed) --wait(2s)--> V(fixed) --wait(3s)--> V(fixed)

`Vibration.vibrate([0, 1000, 2000, 3000], true)`
==> V(fixed) --wait(1s)--> V(fixed) --wait(2s)--> V(fixed) --wait(3s)--> V(fixed) --wait(1s)--> V(fixed) --wait(2s)--> V(fixed) --wait(3s)--> V(fixed)

`Vibration.vibrate([1000, 2000], true)`
==> --wait(1s)--> V(fixed) --wait(2s)--> V(fixed) --wait(1s)--> V(fixed) --wait(2s)--> V(fixed)

`Vibration.vibrate([0, 1000], true)`
==> V(fixed) --wait(1s)--> V(fixed) --wait(1s)--> V(fixed) 

**Test plan (required)**

I also added examples in `UIExplorer`.
Open `UIExplorer` on iOS, and plays it around.

