### PR TITLE
added a little info on the --simulator parameter

### DIFF
--- a/docs/QuickStart-GettingStarted.md
+++ b/docs/QuickStart-GettingStarted.md
@@ -677,6 +677,7 @@ react-native run-ios
 > folder in [Nuclide](http://nuclide.io) and
 > [run the application](http://nuclide.io/docs/platforms/react-native/#command-line), or open
 > `ios/AwesomeProject.xcodeproj` and hit the `Run` button in Xcode.
+> If you want to open the simulator with a particular device use `react-native run-ios --simulator 'iPad 2'`.
 
 <block class="mac android" />
 


### PR DESCRIPTION
I added a bit of info on how to open a particular device from the CLI using `--simulator`.

As a beginner I spent a few hours trying to figure how to open an iPad instead of an iPhone from the CLI.

The CLI doesn't provide any info on how to do that, and I still haven't found any docs describing this.