### PR TITLE
[Packager] Fixes typo in error message

### DIFF
--- a/packager/react-packager/src/JSTransformer/index.js
+++ b/packager/react-packager/src/JSTransformer/index.js
@@ -87,7 +87,7 @@ class Transformer {
 
   transformFile(fileName, code, options) {
     if (!this._transform) {
-      return Promise.reject(new Error('No transfrom module'));
+      return Promise.reject(new Error('No transform module'));
     }
     debug('transforming file', fileName);
     return this


### PR DESCRIPTION
This pull request fixes a small typo when a module fails being transformed through the React Packager.