### PR TITLE
Documentation: Fix LayoutWithFlexbox.md broken example

### DIFF
--- a/docs/LayoutWithFlexbox.md
+++ b/docs/LayoutWithFlexbox.md
@@ -76,7 +76,7 @@ Adding `alignItems` to a component's style determines the **alignment** of child
 import React, { Component } from 'react';
 import { AppRegistry, View } from 'react-native';
 
-class AlignItemsBasics {
+class AlignItemsBasics extends Component {
   render() {
     return (
       // Try setting `alignItems` to 'flex-start'


### PR DESCRIPTION
This fixes the [Align Items example](http://facebook.github.io/react-native/releases/next/docs/flexbox.html#align-items) in Layout with Flexbox -documentation page by fixing a broken example.

<img width="892" alt="screen shot 2016-07-06 at 20 59 08" src="https://cloud.githubusercontent.com/assets/482561/16629040/ee0e819e-43bc-11e6-8ca1-eb9b90869b59.png">


EDIT: Seems like 34adde9e96d8949fe3a20144616aaa5e073d5e94 tried to cover all of these but missed one case :)