### PR TITLE
Fix the yeoman-environment version

### DIFF
--- a/package.json
+++ b/package.json
@@ -187,7 +187,7 @@
     "xcode": "^0.8.2",
     "xmldoc": "^0.4.0",
     "yargs": "^3.24.0",
-    "yeoman-environment": "^1.2.7",
+    "yeoman-environment": "~1.2.7",
     "yeoman-generator": "^0.20.3"
   },
   "devDependencies": {


### PR DESCRIPTION
This closes #8610.
The release of 1.6.2 of yeoman-environment break react-native (since there is no lib folder)
Yeoman will be removed from RN as #8197 anyway.

Thanks @cpsubrian, @RobTS

**Test plan (required)**

I installed the 1.2.7 version and copied it in react-native nodes_modules.
Then I ran react-native upgrade

<img width="1337" alt="screen shot 2016-07-06 at 21 09 33" src="https://cloud.githubusercontent.com/assets/13785185/16631160/075fc422-43be-11e6-8625-92f03075b007.png">
