### PR TITLE
Android: Enable views to be nested within <Text>

### DIFF
--- a/Examples/UIExplorer/js/TextExample.android.js
+++ b/Examples/UIExplorer/js/TextExample.android.js
@@ -390,9 +390,10 @@ var TextExample = React.createClass({
             This text is selectable if you click-and-hold, and will offer the native Android selection menus.
           </Text>
         </UIExplorerBlock>
-        <UIExplorerBlock title="Inline images">
+        <UIExplorerBlock title="Inline views">
           <Text>
-            This text contains an inline image <Image source={require('./flux.png')}/>. Neat, huh?
+            This text contains an inline blue view <View style={{width: 25, height: 25, backgroundColor: 'steelblue'}} /> and
+            an inline image <Image source={require('./flux.png')} style={{width: 30, height: 11, resizeMode: 'cover'}}/>. Neat, huh?
           </Text>
         </UIExplorerBlock>
         <UIExplorerBlock title="Text shadow">

--- a/ReactAndroid/src/main/java/com/facebook/csslayout/CSSNode.java
+++ b/ReactAndroid/src/main/java/com/facebook/csslayout/CSSNode.java
@@ -7,6 +7,11 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+// NOTE: this file is auto-copied from https://github.com/facebook/css-layout
+// @generated SignedSource<<da35a9f6c5a59af0d73da3e46ee60a9a>>
+
+// NOTE: Changes in this file must be imported from this css-layout PR: https://github.com/facebook/css-layout/pull/202
+
 package com.facebook.csslayout;
 
 import javax.annotation.Nullable;
@@ -24,7 +29,7 @@ import static com.facebook.csslayout.CSSLayout.POSITION_TOP;
 
 /**
  * A CSS Node. It has a style object you can manipulate at {@link #style}. After calling
- * {@link #calculateLayout()}, {@link #layout} will be filled with the results of the layout.
+ * {@link #calculateLayout(CSSLayoutContext)}, {@link #layout} will be filled with the results of the layout.
  */
 public class CSSNode {
 
@@ -71,6 +76,11 @@ public class CSSNode {
   private @Nullable MeasureFunction mMeasureFunction = null;
   private LayoutState mLayoutState = LayoutState.DIRTY;
   private boolean mIsTextNode = false;
+
+  public static final Iterable<CSSNode> NO_CSS_NODES = new ArrayList<CSSNode>(0);
+  public Iterable<CSSNode> getChildrenIterable() {
+    return mChildren == null ? NO_CSS_NODES : mChildren;
+  }
 
   public int getChildCount() {
     return mChildren == null ? 0 : mChildren.size();

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/IViewManagerWithChildren.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/IViewManagerWithChildren.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+package com.facebook.react.uimanager;
+
+public interface IViewManagerWithChildren {
+  /**
+   * Returns whether this View type needs to handle laying out its own children instead of
+   * deferring to the standard css-layout algorithm.
+   * Returns true for the layout to *not* be automatically invoked. Instead onLayout will be
+   * invoked as normal and it is the View instance's responsibility to properly call layout on its
+   * children.
+   * Returns false for the default behavior of automatically laying out children without going
+   * through the ViewGroup's onLayout method. In that case, onLayout for this View type must *not*
+   * call layout on its children.
+   */
+  public boolean needsCustomLayoutForChildren();
+}

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeKind.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeKind.java
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+package com.facebook.react.uimanager;
+
+public enum NativeKind {
+  // Node is in the native hierarchy and the HierarchyOptimizer should assume it can host children
+  // (e.g. because it's a ViewGroup). Note that it's okay if the node doesn't support children. When
+  // the HierarchyOptimizer generates children manipulation commands for that node, the
+  // HierarchyManager will catch this case and throw an exception.
+  PARENT,
+  // Node is in the native hierarchy, it may have children, but it cannot host them itself (e.g.
+  // because it isn't a ViewGroup). Consequently, its children need to be hosted by an ancestor.
+  LEAF,
+  // Node is not in the native hierarchy.
+  NONE
+}

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeViewHierarchyManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeViewHierarchyManager.java
@@ -164,16 +164,16 @@ public class NativeViewHierarchyManager {
       // Check if the parent of the view has to layout the view, or the child has to lay itself out.
       if (!mRootTags.get(parentTag)) {
         ViewManager parentViewManager = mTagsToViewManagers.get(parentTag);
-        ViewGroupManager parentViewGroupManager;
-        if (parentViewManager instanceof ViewGroupManager) {
-          parentViewGroupManager = (ViewGroupManager) parentViewManager;
+        IViewManagerWithChildren parentViewManagerWithChildren;
+        if (parentViewManager instanceof IViewManagerWithChildren) {
+          parentViewManagerWithChildren = (IViewManagerWithChildren) parentViewManager;
         } else {
           throw new IllegalViewOperationException(
-              "Trying to use view with tag " + tag +
-                  " as a parent, but its Manager doesn't extends ViewGroupManager");
+              "Trying to use view with tag " + parentTag +
+                  " as a parent, but its Manager doesn't implement IViewManagerWithChildren");
         }
-        if (parentViewGroupManager != null
-            && !parentViewGroupManager.needsCustomLayoutForChildren()) {
+        if (parentViewManagerWithChildren != null
+            && !parentViewManagerWithChildren.needsCustomLayoutForChildren()) {
           updateLayout(viewToUpdate, x, y, width, height);
         }
       } else {

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeViewHierarchyOptimizer.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeViewHierarchyOptimizer.java
@@ -68,6 +68,15 @@ public class NativeViewHierarchyOptimizer {
   private final ShadowNodeRegistry mShadowNodeRegistry;
   private final SparseBooleanArray mTagsWithLayoutVisited = new SparseBooleanArray();
 
+  public static void assertNodeSupportedWithoutOptimizer(ReactShadowNode node) {
+    // NativeKind.LEAF nodes require the optimizer. They are not ViewGroups so they cannot host
+    // their native children themselves. Their native children need to be hoisted by the optimizer
+    // to an ancestor which is a ViewGroup.
+    Assertions.assertCondition(
+        node.getNativeKind() != NativeKind.LEAF,
+        "Nodes with NativeKind.LEAF are not supported when the optimizer is disabled");
+  }
+
   public NativeViewHierarchyOptimizer(
       UIViewOperationQueue uiViewOperationQueue,
       ShadowNodeRegistry shadowNodeRegistry) {
@@ -83,6 +92,7 @@ public class NativeViewHierarchyOptimizer {
       ThemedReactContext themedContext,
       @Nullable ReactStylesDiffMap initialProps) {
     if (!ENABLED) {
+      assertNodeSupportedWithoutOptimizer(node);
       int tag = node.getReactTag();
       mUIViewOperationQueue.enqueueCreateView(
           themedContext,
@@ -96,7 +106,7 @@ public class NativeViewHierarchyOptimizer {
         isLayoutOnlyAndCollapsable(initialProps);
     node.setIsLayoutOnly(isLayoutOnly);
 
-    if (!isLayoutOnly) {
+    if (node.getNativeKind() != NativeKind.NONE) {
       mUIViewOperationQueue.enqueueCreateView(
           themedContext,
           node.getReactTag(),
@@ -122,6 +132,7 @@ public class NativeViewHierarchyOptimizer {
       String className,
       ReactStylesDiffMap props) {
     if (!ENABLED) {
+      assertNodeSupportedWithoutOptimizer(node);
       mUIViewOperationQueue.enqueueUpdateProperties(node.getReactTag(), className, props);
       return;
     }
@@ -151,6 +162,7 @@ public class NativeViewHierarchyOptimizer {
       ViewAtIndex[] viewsToAdd,
       int[] tagsToDelete) {
     if (!ENABLED) {
+      assertNodeSupportedWithoutOptimizer(nodeToManage);
       mUIViewOperationQueue.enqueueManageChildren(
           nodeToManage.getReactTag(),
           indicesToRemove,
@@ -191,6 +203,7 @@ public class NativeViewHierarchyOptimizer {
     ReadableArray childrenTags
   ) {
     if (!ENABLED) {
+      assertNodeSupportedWithoutOptimizer(nodeToManage);
       mUIViewOperationQueue.enqueueSetChildren(
         nodeToManage.getReactTag(),
         childrenTags);
@@ -210,8 +223,9 @@ public class NativeViewHierarchyOptimizer {
    */
   public void handleUpdateLayout(ReactShadowNode node) {
     if (!ENABLED) {
+      assertNodeSupportedWithoutOptimizer(node);
       mUIViewOperationQueue.enqueueUpdateLayout(
-          Assertions.assertNotNull(node.getParent()).getReactTag(),
+          Assertions.assertNotNull(node.getLayoutParent()).getReactTag(),
           node.getReactTag(),
           node.getScreenX(),
           node.getScreenY(),
@@ -223,6 +237,12 @@ public class NativeViewHierarchyOptimizer {
     applyLayoutBase(node);
   }
 
+  public void handleForceViewToBeNonLayoutOnly(ReactShadowNode node) {
+    if (node.isLayoutOnly()) {
+      transitionLayoutOnlyViewToNativeView(node, null);
+    }
+  }
+
   /**
    * Processes the shadow hierarchy to dispatch all necessary updateLayout calls to the native
    * hierarchy. Should be called after all updateLayout calls for a batch have been handled.
@@ -231,16 +251,18 @@ public class NativeViewHierarchyOptimizer {
     mTagsWithLayoutVisited.clear();
   }
 
-  private NodeIndexPair walkUpUntilNonLayoutOnly(
+  private NodeIndexPair walkUpUntilNativeKindIsParent(
       ReactShadowNode node,
       int indexInNativeChildren) {
-    while (node.isLayoutOnly()) {
+    while (node.getNativeKind() != NativeKind.PARENT) {
       ReactShadowNode parent = node.getParent();
       if (parent == null) {
         return null;
       }
 
-      indexInNativeChildren = indexInNativeChildren + parent.getNativeOffsetForChild(node);
+      indexInNativeChildren = indexInNativeChildren +
+          (node.getNativeKind() == NativeKind.LEAF ? 1 : 0) +
+          parent.getNativeOffsetForChild(node);
       node = parent;
     }
 
@@ -249,8 +271,8 @@ public class NativeViewHierarchyOptimizer {
 
   private void addNodeToNode(ReactShadowNode parent, ReactShadowNode child, int index) {
     int indexInNativeChildren = parent.getNativeOffsetForChild(parent.getChildAt(index));
-    if (parent.isLayoutOnly()) {
-      NodeIndexPair result = walkUpUntilNonLayoutOnly(parent, indexInNativeChildren);
+    if (parent.getNativeKind() != NativeKind.PARENT) {
+      NodeIndexPair result = walkUpUntilNativeKindIsParent(parent, indexInNativeChildren);
       if (result == null) {
         // If the parent hasn't been attached to its native parent yet, don't issue commands to the
         // native hierarchy. We'll do that when the parent node actually gets attached somewhere.
@@ -260,20 +282,26 @@ public class NativeViewHierarchyOptimizer {
       indexInNativeChildren = result.index;
     }
 
-    if (!child.isLayoutOnly()) {
-      addNonLayoutNode(parent, child, indexInNativeChildren);
+    if (child.getNativeKind() != NativeKind.NONE) {
+      addNativeChild(parent, child, indexInNativeChildren);
     } else {
-      addLayoutOnlyNode(parent, child, indexInNativeChildren);
+      addNonNativeChild(parent, child, indexInNativeChildren);
     }
   }
 
   /**
-   * For handling node removal from manageChildren. In the case of removing a layout-only node, we
-   * need to instead recursively remove all its children from their native parents.
+   * For handling node removal from manageChildren. In the case of removing a node which isn't
+   * hosting its own children (e.g. layout-only or NativeKind.LEAF), we need to recursively remove
+   * all its children from their native parents.
    */
   private void removeNodeFromParent(ReactShadowNode nodeToRemove, boolean shouldDelete) {
-    ReactShadowNode nativeNodeToRemoveFrom = nodeToRemove.getNativeParent();
+    if (nodeToRemove.getNativeKind() != NativeKind.PARENT) {
+      for (int i = nodeToRemove.getChildCount() - 1; i >= 0; i--) {
+        removeNodeFromParent(nodeToRemove.getChildAt(i), shouldDelete);
+      }
+    }
 
+    ReactShadowNode nativeNodeToRemoveFrom = nodeToRemove.getNativeParent();
     if (nativeNodeToRemoveFrom != null) {
       int index = nativeNodeToRemoveFrom.indexOfNativeChild(nodeToRemove);
       nativeNodeToRemoveFrom.removeNativeChildAt(index);
@@ -283,21 +311,17 @@ public class NativeViewHierarchyOptimizer {
           new int[]{index},
           null,
           shouldDelete ? new int[]{nodeToRemove.getReactTag()} : null);
-    } else {
-      for (int i = nodeToRemove.getChildCount() - 1; i >= 0; i--) {
-        removeNodeFromParent(nodeToRemove.getChildAt(i), shouldDelete);
-      }
     }
   }
 
-  private void addLayoutOnlyNode(
-      ReactShadowNode nonLayoutOnlyNode,
-      ReactShadowNode layoutOnlyNode,
+  private void addNonNativeChild(
+      ReactShadowNode nativeParent,
+      ReactShadowNode nonNativeChild,
       int index) {
-    addGrandchildren(nonLayoutOnlyNode, layoutOnlyNode, index);
+    addGrandchildren(nativeParent, nonNativeChild, index);
   }
 
-  private void addNonLayoutNode(
+  private void addNativeChild(
       ReactShadowNode parent,
       ReactShadowNode child,
       int index) {
@@ -307,13 +331,17 @@ public class NativeViewHierarchyOptimizer {
         null,
         new ViewAtIndex[]{new ViewAtIndex(child.getReactTag(), index)},
         null);
+
+    if (child.getNativeKind() != NativeKind.PARENT) {
+      addGrandchildren(parent, child, index + 1);
+    }
   }
 
   private void addGrandchildren(
       ReactShadowNode nativeParent,
       ReactShadowNode child,
       int index) {
-    Assertions.assertCondition(!nativeParent.isLayoutOnly());
+    Assertions.assertCondition(child.getNativeKind() != NativeKind.PARENT);
 
     // `child` can't hold native children. Add all of `child`'s children to `parent`.
     int currentIndex = index;
@@ -321,16 +349,15 @@ public class NativeViewHierarchyOptimizer {
       ReactShadowNode grandchild = child.getChildAt(i);
       Assertions.assertCondition(grandchild.getNativeParent() == null);
 
-      if (grandchild.isLayoutOnly()) {
-        // Adding this child could result in adding multiple native views
-        int grandchildCountBefore = nativeParent.getNativeChildCount();
-        addLayoutOnlyNode(nativeParent, grandchild, currentIndex);
-        int grandchildCountAfter = nativeParent.getNativeChildCount();
-        currentIndex += grandchildCountAfter - grandchildCountBefore;
+      // Adding this child could result in adding multiple native views
+      int grandchildCountBefore = nativeParent.getNativeChildCount();
+      if (grandchild.getNativeKind() == NativeKind.NONE) {
+        addNonNativeChild(nativeParent, grandchild, currentIndex);
       } else {
-        addNonLayoutNode(nativeParent, grandchild, currentIndex);
-        currentIndex++;
+        addNativeChild(nativeParent, grandchild, currentIndex);
       }
+      int grandchildCountAfter = nativeParent.getNativeChildCount();
+      currentIndex += grandchildCountAfter - grandchildCountBefore;
     }
   }
 
@@ -349,7 +376,7 @@ public class NativeViewHierarchyOptimizer {
     int x = node.getScreenX();
     int y = node.getScreenY();
 
-    while (parent != null && parent.isLayoutOnly()) {
+    while (parent != null && parent.getNativeKind() != NativeKind.PARENT) {
       // TODO(7854667): handle and test proper clipping
       x += Math.round(parent.getLayoutX());
       y += Math.round(parent.getLayoutY());
@@ -361,10 +388,10 @@ public class NativeViewHierarchyOptimizer {
   }
 
   private void applyLayoutRecursive(ReactShadowNode toUpdate, int x, int y) {
-    if (!toUpdate.isLayoutOnly() && toUpdate.getNativeParent() != null) {
+    if (toUpdate.getNativeKind() != NativeKind.NONE && toUpdate.getNativeParent() != null) {
       int tag = toUpdate.getReactTag();
       mUIViewOperationQueue.enqueueUpdateLayout(
-          toUpdate.getNativeParent().getReactTag(),
+          toUpdate.getLayoutParent().getReactTag(),
           tag,
           x,
           y,

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModule.java
@@ -9,6 +9,8 @@
 
 package com.facebook.react.uimanager;
 
+import android.view.View;
+
 import javax.annotation.Nullable;
 
 import java.util.List;
@@ -25,6 +27,7 @@ import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.common.ReactConstants;
+import com.facebook.react.bridge.UiThreadUtil;
 import com.facebook.react.uimanager.debug.NotThreadSafeViewHierarchyUpdateDebugListener;
 import com.facebook.react.uimanager.events.EventDispatcher;
 import com.facebook.systrace.Systrace;
@@ -515,5 +518,10 @@ public class UIManagerModule extends ReactContextBaseJavaModule implements
      */
   public void addUIBlock (UIBlock block) {
     mUIImplementation.addUIBlock(block);
+  }
+
+  public View resolveView(int tag) {
+    UiThreadUtil.assertOnUiThread();
+    return mUIImplementation.getUIViewOperationQueue().getNativeViewHierarchyManager().resolveView(tag);
   }
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewGroupManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewGroupManager.java
@@ -22,7 +22,8 @@ import java.util.WeakHashMap;
  * Class providing children management API for view managers of classes extending ViewGroup.
  */
 public abstract class ViewGroupManager <T extends ViewGroup>
-    extends BaseViewManager<T, LayoutShadowNode> {
+    extends BaseViewManager<T, LayoutShadowNode>
+    implements IViewManagerWithChildren {
 
   public static WeakHashMap<View, Integer> mZIndexHash = new WeakHashMap<>();
 
@@ -134,6 +135,7 @@ public abstract class ViewGroupManager <T extends ViewGroup>
    * through the ViewGroup's onLayout method. In that case, onLayout for this View type must *not*
    * call layout on its children.
    */
+  @Override
   public boolean needsCustomLayoutForChildren() {
     return false;
   }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextViewManager.java
@@ -18,6 +18,7 @@ import android.widget.TextView;
 
 import com.facebook.react.bridge.JSApplicationIllegalArgumentException;
 import com.facebook.react.uimanager.BaseViewManager;
+import com.facebook.react.uimanager.IViewManagerWithChildren;
 import com.facebook.react.uimanager.PixelUtil;
 import com.facebook.react.uimanager.annotations.ReactProp;
 import com.facebook.react.uimanager.ThemedReactContext;
@@ -33,7 +34,8 @@ import com.facebook.react.common.annotations.VisibleForTesting;
  * @{link ReactTextShadowNode} hierarchy to calculate a {@link Spannable} text representing the
  * whole text subtree.
  */
-public class ReactTextViewManager extends BaseViewManager<ReactTextView, ReactTextShadowNode> {
+public class ReactTextViewManager extends BaseViewManager<ReactTextView, ReactTextShadowNode>
+    implements IViewManagerWithChildren {
 
   @VisibleForTesting
   public static final String REACT_CLASS = "RCTText";
@@ -126,5 +128,10 @@ public class ReactTextViewManager extends BaseViewManager<ReactTextView, ReactTe
   @Override
   public Class<ReactTextShadowNode> getShadowNodeClass() {
     return ReactTextShadowNode.class;
+  }
+
+  @Override
+  public boolean needsCustomLayoutForChildren() {
+    return true;
   }
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/TextInlineViewPlaceholderSpan.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/TextInlineViewPlaceholderSpan.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+package com.facebook.react.views.text;
+
+import android.graphics.Canvas;
+import android.graphics.Paint;
+import android.text.style.ReplacementSpan;
+
+/**
+ * TextInlineViewPlaceholderSpan is a span for inlined views that are inside <Text/>. It computes
+ * its size based on the input size. It contains no draw logic, just positioning logic.
+ */
+public class TextInlineViewPlaceholderSpan extends ReplacementSpan {
+  private int mReactTag;
+  private int mWidth;
+  private int mHeight;
+
+  public TextInlineViewPlaceholderSpan(int reactTag, int width, int height) {
+    mReactTag = reactTag;
+    mWidth = width;
+    mHeight = height;
+  }
+
+  public int getReactTag() {
+    return mReactTag;
+  }
+
+  public int getWidth() {
+    return mWidth;
+  }
+
+  public int getHeight() {
+    return mHeight;
+  }
+
+  @Override
+  public int getSize(
+      Paint paint, CharSequence text, int start, int end, Paint.FontMetricsInt fm) {
+    // NOTE: This getSize code is copied from DynamicDrawableSpan and modified to not use a Drawable
+
+    if (fm != null) {
+      fm.ascent = -mHeight;
+      fm.descent = 0;
+
+      fm.top = fm.ascent;
+      fm.bottom = 0;
+    }
+
+    return mWidth;
+  }
+
+  @Override
+  public void draw(
+      Canvas canvas, CharSequence text, int start, int end, float x, int top, int y, int bottom, Paint paint) {
+  }
+}

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputShadowNode.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputShadowNode.java
@@ -22,6 +22,7 @@ import com.facebook.csslayout.MeasureOutput;
 import com.facebook.csslayout.Spacing;
 import com.facebook.infer.annotation.Assertions;
 import com.facebook.react.common.annotations.VisibleForTesting;
+import com.facebook.react.uimanager.NativeViewHierarchyOptimizer;
 import com.facebook.react.uimanager.PixelUtil;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.UIViewOperationQueue;
@@ -42,6 +43,11 @@ public class ReactTextInputShadowNode extends ReactTextShadowNode implements
   public ReactTextInputShadowNode() {
     super(false);
     setMeasureFunction(this);
+  }
+
+  @Override
+  public boolean supportsInlineViews() {
+    return false;
   }
 
   @Override
@@ -98,7 +104,7 @@ public class ReactTextInputShadowNode extends ReactTextShadowNode implements
   }
 
   @Override
-  public void onBeforeLayout() {
+  public void onBeforeLayout(NativeViewHierarchyOptimizer nativeViewHierarchyOptimizer) {
     // We don't have to measure the text within the text input.
     return;
   }
@@ -117,7 +123,7 @@ public class ReactTextInputShadowNode extends ReactTextShadowNode implements
     }
 
     if (mJsEventCount != UNSET) {
-      Spannable preparedSpannableText = fromTextCSSNode(this);
+      Spannable preparedSpannableText = fromTextCSSNode(this, null);
       ReactTextUpdate reactTextUpdate =
           new ReactTextUpdate(preparedSpannableText, mJsEventCount, mContainsImages, getPadding(), getEffectiveLineHeight());
       uiViewOperationQueue.enqueueUpdateExtraData(getReactTag(), reactTextUpdate);

--- a/docs/Text.md
+++ b/docs/Text.md
@@ -32,9 +32,9 @@ Behind the scenes, React Native converts this to a flat `NSAttributedString` or 
 9-17: bold, red
 ```
 
-## Nested Views (iOS Only)
+## Nested Views
 
-On iOS, you can nest views within your Text component. Here's an example:
+You can nest views within your Text component. Here's an example:
 
 ```ReactNativeWebPlayer
 import React, { Component } from 'react';


### PR DESCRIPTION
Potential breaking change: The signature of ReactShadowNode's onBeforeLayout method was changed
- Before: public void onBeforeLayout()
- After:  public void onBeforeLayout(NativeViewHierarchyOptimizer nativeViewHierarchyOptimizer)

Depends on this css-layout PR:
https://github.com/facebook/css-layout/pull/202

Implements same feature as this iOS PR:
https://github.com/facebook/react-native/pull/7304

Previously, only Text and Image could be nested within Text. Now, any view can be nested within Text. One restriction of this feature is that developers must give inline views a width and a height via the style prop. Here's a screenshot illustrating this feature:

![image](https://cloud.githubusercontent.com/assets/199935/16635219/3fd4e5b8-4386-11e6-88b0-0b771ebd3a38.png)

Note that the changes to NativeViewHierarchyOptimizer were broken up across a few commits to make the diffs easier to understand.

Previously, inline Images were supported via FrescoBasedReactTextInlineImageSpan. To get support for nesting views within Text, we create one special kind of span per inline view. This span is called TextInlineViewPlaceholderSpan. It is the same size as the inline view. Its job is just to occupy space -- it doesn't render any visual. After the text is rendered, we query the Android Layout object associated with the TextView to find out where it has positioned each TextInlineViewPlaceholderSpan. We then position the views to be at those locations.

One tricky aspect of the implementation is that the Text component needs to be able to render native children (the inline views) but the Android TextView cannot have children. This is solved by having the native parent of the ReactTextView also host the inline views. Implementation-wise, this was accomplished by extending the NativeViewHierarchyOptimizer to handle this case. The optimizer now handles these cases:
- Node is not in the native tree. An ancestor must host its children.
- Node is in the native tree and it can host its own children.
- (new) Node is in the native tree but it cannot host its own children. An ancestor must host both this node and its children.

**Limitation: Clipping**

If Text's height/width is small such that an inline view doesn't completely fit, the inline view may still be fully visible due to hoisting (the inline view isn't actually parented to the Text which has the limited size. It is parented to an ancestor which may have a different clipping rectangle.). Prior to this change, layout-only views had a similar limitation.

**Test plan (required)**

This change was tested with UIExplorer and a small test app and it's being used in my team's app.

**Outstanding Issue: Using Text and Image within an inline view**

Currently, you cannot use Text or Image components within an inline view. This is because the React context flag, `isInAParentText`, indicates that you're still inside of a Text component and these components use their virtual node representation rather than their normal representation.

The Text component sets `isInAParentText` to `true`. No components ever set `isInAParentText` to `false`.

I need some help with fixing this. One option I was considering was setting `isInAParentText` to `false` for all other native components. This could be done by editing the native component creation primitives such as `requireNativeComponent` and `createReactNativeComponentClass` to provide the appropriate context. However, when I tried this, it didn’t work and it wasn’t clear to me whether or not context works on native components. Thoughts?

Adam Comella
Microsoft Corp.
