### PR TITLE
Fix PushNotificationIOS requestPermissions promise bug (Cannot call requestPermissions twice before the first has returned.)

### DIFF
--- a/Libraries/PushNotificationIOS/RCTPushNotificationManager.m
+++ b/Libraries/PushNotificationIOS/RCTPushNotificationManager.m
@@ -76,6 +76,18 @@ static NSDictionary *RCTFormatLocalNotification(UILocalNotification *notificatio
 
 RCT_EXPORT_MODULE()
 
+- (instancetype)init
+{
+  self = [super init];
+  if (self) {
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(handleRegisterUserNotificationSettings:)
+                                                 name:RCTRegisterUserNotificationSettings
+                                               object:nil];
+  }
+  return self;
+}
+
 - (dispatch_queue_t)methodQueue
 {
   return dispatch_get_main_queue();
@@ -94,10 +106,6 @@ RCT_EXPORT_MODULE()
   [[NSNotificationCenter defaultCenter] addObserver:self
                                            selector:@selector(handleRemoteNotificationsRegistered:)
                                                name:RCTRemoteNotificationsRegistered
-                                             object:nil];
-  [[NSNotificationCenter defaultCenter] addObserver:self
-                                           selector:@selector(handleRegisterUserNotificationSettings:)
-                                               name:RCTRegisterUserNotificationSettings
                                              object:nil];
 }
 


### PR DESCRIPTION
PushNotificationIOS [requestPermissions](http://facebook.github.io/react-native/releases/0.29/docs/pushnotificationios.html#requestpermissions) method has been enhanced to support Promise  f4dbf37ba85acb988bbb26e339ea7f7536b1f931. but It does not work before calling the [addEventListener](http://facebook.github.io/react-native/releases/0.29/docs/pushnotificationios.html#addeventlistener) method.

startObserving method that is need for adding RCTRegisterUserNotificationSettings event observer is only called at least one of the event listner is added. (See code below)

``` objectivec
@implementation RCTEventEmitter
...
RCT_EXPORT_METHOD(addListener:(NSString *)eventName)
{
  if (RCT_DEBUG && ![[self supportedEvents] containsObject:eventName]) {
    RCTLogError(@"`%@` is not a supported event type for %@. Supported events are: `%@`",
                eventName, [self class], [[self supportedEvents] componentsJoinedByString:@"`, `"]);
  }
  if (_listenerCount == 0) {
    [self startObserving];
  }
  _listenerCount++;
}
...
```

but i think requestPermissions method must be fulfilled a Promise at anytime without any dependency like addEventListener method. 
## Test plan (required)
1. Call **_PushNotificationIOS.requestPermissions()**_ twice without addEventListener method call
2. You can see error message "Cannot call requestPermissions twice before the first has returned"
## Screen Capture

![twicebug](https://cloud.githubusercontent.com/assets/5635513/16641625/d5011250-442c-11e6-89eb-a0390ff8f23e.gif)
## Demonstrate Code

``` javascript
/**
 * Sample React Native App
 * https://github.com/facebook/react-native
 * @flow
 */

import React, { Component } from 'react';
import {
  AppRegistry,
  StyleSheet,
  Text,
  View,
  PushNotificationIOS,
  TouchableHighlight
} from 'react-native';


var Button = React.createClass({
  render: function() {
    return (
      <TouchableHighlight
        underlayColor={'white'}
        style={styles.button}
        onPress={this.props.onPress}>
        <Text style={styles.buttonLabel}>
          {this.props.label}
        </Text>
      </TouchableHighlight>
    );
  }
});


class twiceBug extends Component {

  onClickButton() {
    PushNotificationIOS.requestPermissions();
  }

  render() {
    return (
      <View style={styles.container}>
        <Button label='request permission' onPress={this.onClickButton.bind(this)} />
      </View>
    );
  }
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    justifyContent: 'center',
    alignItems: 'center',
    backgroundColor: '#F5FCFF',
  },
  button: {
    padding: 10,
    alignItems: 'center',
    justifyContent: 'center',
  },
  buttonLabel: {
    color: 'blue',
  },

});

AppRegistry.registerComponent('twiceBug', () => twiceBug);
```
