### PR TITLE
remove unneeded preserve_paths declaration

### DIFF
--- a/React.podspec
+++ b/React.podspec
@@ -57,7 +57,6 @@ Pod::Spec.new do |s|
   s.subspec 'RCTAnimation' do |ss|
     ss.dependency       'React/Core'
     ss.source_files   = "Libraries/NativeAnimation/{Nodes/*,*}.{h,m}"
-    ss.preserve_paths = "Libraries/NativeAnimation/*.js"
   end
 
   s.subspec 'RCTCameraRoll' do |ss|


### PR DESCRIPTION
The subspec for `RTCAnimation` defines a `preserve_paths` attribute of `Libraries/NativeAnimation/*.js` (https://github.com/facebook/react-native/blob/master/React.podspec#L60) but there is no JavaScript file in that repository. Linting the podspec therefore fails. The fix was to simply remove `preserve_paths` for this subspec.