### PR TITLE
Support RefreshControl in RecyclerViewBackedScrollView in Android

### DIFF
--- a/Libraries/Components/ScrollView/RecyclerViewBackedScrollView.android.js
+++ b/Libraries/Components/ScrollView/RecyclerViewBackedScrollView.android.js
@@ -76,7 +76,7 @@ var RecyclerViewBackedScrollView = React.createClass({
   },
 
   render: function() {
-    var props = {
+    var recyclerProps = {
       ...this.props,
       onTouchStart: this.scrollResponderHandleTouchStart,
       onTouchMove: this.scrollResponderHandleTouchMove,
@@ -92,12 +92,11 @@ var RecyclerViewBackedScrollView = React.createClass({
       onResponderRelease: this.scrollResponderHandleResponderRelease,
       onResponderReject: this.scrollResponderHandleResponderReject,
       onScroll: this.scrollResponderHandleScroll,
-      style: ([{flex: 1}, this.props.style]: ?Array<any>),
       ref: INNERVIEW,
     };
 
     if (this.props.onContentSizeChange) {
-      props.onContentSizeChange = this._handleContentSizeChange;
+      recyclerProps.onContentSizeChange = this._handleContentSizeChange;
     }
 
     var wrappedChildren = React.Children.map(this.props.children, (child) => {
@@ -118,15 +117,15 @@ var RecyclerViewBackedScrollView = React.createClass({
       // Wrap the NativeAndroidRecyclerView with a AndroidSwipeRefreshLayout.
       return React.cloneElement(
         refreshControl,
-        {style: props.style},
-        <NativeAndroidRecyclerView {...props} style={{flex: 1}}>
+        {style: [styles.base, this.props.style]},
+        <NativeAndroidRecyclerView {...recyclerProps} style={styles.base}>
           {wrappedChildren}
         </NativeAndroidRecyclerView>
       );
     }
 
     return (
-      <NativeAndroidRecyclerView {...props}>
+      <NativeAndroidRecyclerView {...recyclerProps} style={[styles.base, this.props.style]}>
         {wrappedChildren}
       </NativeAndroidRecyclerView>
     );
@@ -139,6 +138,9 @@ var styles = StyleSheet.create({
     top: 0,
     left: 0,
     right: 0,
+  },
+  base: {
+    flex: 1,
   },
 });
 

--- a/Libraries/Components/ScrollView/RecyclerViewBackedScrollView.android.js
+++ b/Libraries/Components/ScrollView/RecyclerViewBackedScrollView.android.js
@@ -119,7 +119,7 @@ var RecyclerViewBackedScrollView = React.createClass({
       return React.cloneElement(
         refreshControl,
         {style: props.style},
-        <NativeAndroidRecyclerView {...props}>
+        <NativeAndroidRecyclerView {...props} style={{flex: 1}}>
           {wrappedChildren}
         </NativeAndroidRecyclerView>
       );

--- a/Libraries/Components/ScrollView/RecyclerViewBackedScrollView.android.js
+++ b/Libraries/Components/ScrollView/RecyclerViewBackedScrollView.android.js
@@ -113,6 +113,18 @@ var RecyclerViewBackedScrollView = React.createClass({
       );
     });
 
+    const refreshControl = this.props.refreshControl;
+    if (refreshControl) {
+      // Wrap the NativeAndroidRecyclerView with a AndroidSwipeRefreshLayout.
+      return React.cloneElement(
+        refreshControl,
+        {style: props.style},
+        <NativeAndroidRecyclerView {...props}>
+          {wrappedChildren}
+        </NativeAndroidRecyclerView>
+      );
+    }
+
     return (
       <NativeAndroidRecyclerView {...props}>
         {wrappedChildren}


### PR DESCRIPTION
In Android, `RecyclerViewBackedScrollView` wasn't using `refreshControl` prop.
If a ListView were created with `RecyclerViewBackedScrollView` as its `renderScrollComponent`, then the `refreshControl` wouldn't work.
example:
```js
        <ListView
          dataSource={this.props.dataSource}
          renderRow={this._renderRow.bind(this)}
          refreshControl={
            <RefreshControl 
              refreshing={this.props.isRefreshing} 
              onRefresh={this._onRefresh.bind(this)} 
            />
          }
          renderScrollComponent={props => <RecyclerViewBackedScrollView {...props} />}/>;
```
This works in iOS, since the `RecyclerViewBackedScrollView` just returns an `ScrollView`.

This pull request uses the `refreshControl` to decide whether it should wrap the `NativeAndroidRecyclerView` with an 
`AndroidSwipeRefreshLayout` or not.

This fixes the issue #7134.