### PR TITLE
added new sizes to ActivityIndicator

### DIFF
--- a/Libraries/Components/ActivityIndicator/ActivityIndicator.js
+++ b/Libraries/Components/ActivityIndicator/ActivityIndicator.js
@@ -40,12 +40,14 @@ const ActivityIndicator = React.createClass({
      */
     color: ColorPropType,
     /**
-     * Size of the indicator. Small has a height of 20, large has a height of 36.
+     * Size of the indicator. Small has a height of 20, medium has a height of 28, large has a height of 36, extralarge has a height of 50.
      * Other sizes can be obtained using a scale transform.
      */
     size: PropTypes.oneOf([
       'small',
+      'medium',
       'large',
+      'extralarge'
     ]),
     /**
      * Whether the indicator should hide when not animating (true by default).
@@ -71,8 +73,14 @@ const ActivityIndicator = React.createClass({
       case 'small':
         sizeStyle = styles.sizeSmall;
         break;
+      case 'medium':
+        sizeStyle = styles.sizeMedium;
+        break;
       case 'large':
         sizeStyle = styles.sizeLarge;
+        break;
+      case 'extralarge':
+        sizeStyle = styles.sizeExtraLarge;
         break;
     }
     return (
@@ -99,9 +107,17 @@ const styles = StyleSheet.create({
     width: 20,
     height: 20,
   },
+  sizeMedium: {
+    width: 28,
+    height: 28,
+  },
   sizeLarge: {
     width: 36,
     height: 36,
+  },
+  sizeExtraLarge: {
+    width: 50,
+    height: 50,
   },
 });
 

--- a/Libraries/Components/ActivityIndicator/ActivityIndicatorIOS.ios.js
+++ b/Libraries/Components/ActivityIndicator/ActivityIndicatorIOS.ios.js
@@ -41,7 +41,9 @@ var ActivityIndicatorIOS = React.createClass({
      */
     size: PropTypes.oneOf([
       'small',
+      'medium',
       'large',
+      'extralarge',
     ]),
     /**
      * Invoked on mount and layout changes with


### PR DESCRIPTION
**Motivation**
The [docs](https://facebook.github.io/react-native/docs/activityindicator.html) on ActivityIndicator say that:

> Size of the indicator. Small has a height of 20, large has a height of 36. Other sizes can be obtained using a scale transform.

But when using scale transform the pixels are blown out in iOS (haven't tested on Android).

For example when using this:
```jsx
<ActivityIndicator style={{transform: [{scale: 2}]}} size="large" />
```

This is the zoomed result where you can clearly see the aliasing on the spinner is the result of an interpolation compared to the pixels of the text.

![image](https://cloud.githubusercontent.com/assets/226483/16666140/e341d164-444b-11e6-9123-889fe4f43d55.png)

**Solution**
To remedy this, I've created two new sizes `medium` and `extralarge` so that these new sizes can be used without having to resort to using `transform: [{scale: 2}]` which I presume is causing the interpolation problem.