### PR TITLE
[cli] Add support for passing in additional assetExts to packager

### DIFF
--- a/local-cli/bundle/buildBundle.js
+++ b/local-cli/bundle/buildBundle.js
@@ -13,6 +13,7 @@ const path = require('path');
 const Promise = require('promise');
 const saveAssets = require('./saveAssets');
 const Server = require('../../packager/react-packager/src/Server');
+const defaultAssetExts = require('../../packager/defaultAssetExts');
 
 function saveBundle(output, bundle, args) {
   return Promise.resolve(
@@ -24,17 +25,6 @@ function buildBundle(args, config, output = outputBundle, packagerInstance) {
   // This is used by a bazillion of npm modules we don't control so we don't
   // have other choice than defining it as an env variable here.
   process.env.NODE_ENV = args.dev ? 'development' : 'production';
-
-  const options = {
-    projectRoots: config.getProjectRoots(),
-    assetRoots: config.getAssetRoots(),
-    blacklistRE: config.getBlacklistRE(args.platform),
-    getTransformOptionsModulePath: config.getTransformOptionsModulePath,
-    transformModulePath: args.transformer,
-    extraNodeModules: config.extraNodeModules,
-    nonPersistent: true,
-    resetCache: args.resetCache,
-  };
 
   const requestOpts = {
     entryFile: args.entryFile,
@@ -48,6 +38,20 @@ function buildBundle(args, config, output = outputBundle, packagerInstance) {
   // bundle command and close it down afterwards.
   var shouldClosePackager = false;
   if (!packagerInstance) {
+    let assetExts = (config.getAssetExts && config.getAssetExts()) || [];
+
+    const options = {
+      projectRoots: config.getProjectRoots(),
+      assetExts: defaultAssetExts.concat(assetExts),
+      assetRoots: config.getAssetRoots(),
+      blacklistRE: config.getBlacklistRE(args.platform),
+      getTransformOptionsModulePath: config.getTransformOptionsModulePath,
+      transformModulePath: args.transformer,
+      extraNodeModules: config.extraNodeModules,
+      nonPersistent: true,
+      resetCache: args.resetCache,
+    };
+
     packagerInstance = new Server(options);
     shouldClosePackager = true;
   }

--- a/local-cli/default.config.js
+++ b/local-cli/default.config.js
@@ -29,6 +29,15 @@ var config = {
   },
 
   /**
+   * Specify any additional asset extentions to be used by the packager.
+   * For example, if you want to include a .ttf file, you would return ['ttf']
+   * from here and use `require('./fonts/example.ttf')` inside your app.
+   */
+  getAssetExts() {
+    return [];
+  },
+
+  /**
    * Returns a regular expression for modules that should be ignored by the
    * packager on a given platform.
    */

--- a/local-cli/server/runServer.js
+++ b/local-cli/server/runServer.js
@@ -23,6 +23,7 @@ const statusPageMiddleware = require('./middleware/statusPageMiddleware.js');
 const indexPageMiddleware = require('./middleware/indexPage');
 const systraceProfileMiddleware = require('./middleware/systraceProfileMiddleware.js');
 const webSocketProxy = require('./util/webSocketProxy.js');
+const defaultAssetExts = require('../../packager/defaultAssetExts');
 
 function runServer(args, config, readyCallback) {
   var wsProxy = null;
@@ -83,12 +84,7 @@ function getPackagerServer(args, config) {
     transformModulePath: transformModulePath,
     extraNodeModules: config.extraNodeModules,
     assetRoots: args.assetRoots,
-    assetExts: [
-      'bmp', 'gif', 'jpg', 'jpeg', 'png', 'psd', 'svg', 'webp', // Image formats
-      'm4v', 'mov', 'mp4', 'mpeg', 'mpg', 'webm', // Video formats
-      'aac', 'aiff', 'caf', 'm4a', 'mp3', 'wav', // Audio formats
-      'html', 'pdf', // Document formats
-    ],
+    assetExts: defaultAssetExts.concat(args.assetExts),
     resetCache: args.resetCache,
     verbose: args.verbose,
   });

--- a/local-cli/server/server.js
+++ b/local-cli/server/server.js
@@ -92,6 +92,10 @@ module.exports = {
     parse: (val) => val.split(',').map(dir => path.resolve(process.cwd(), dir)),
     default: (config) => config.getAssetRoots(),
   }, {
+    command: 'assetExts',
+    type: 'string',
+    description: 'Specify any additional asset extentions to be used by the packager',
+  }, {
     command: '--skipflow',
     description: 'Disable flow checks'
   }, {

--- a/local-cli/server/server.js
+++ b/local-cli/server/server.js
@@ -92,9 +92,10 @@ module.exports = {
     parse: (val) => val.split(',').map(dir => path.resolve(process.cwd(), dir)),
     default: (config) => config.getAssetRoots(),
   }, {
-    command: 'assetExts',
-    type: 'string',
+    command: '--assetExts [list]',
     description: 'Specify any additional asset extentions to be used by the packager',
+    parse: (val) => val.split(','),
+    default: (config) => config.getAssetExts(),
   }, {
     command: '--skipflow',
     description: 'Disable flow checks'

--- a/packager/defaultAssetExts.js
+++ b/packager/defaultAssetExts.js
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+'use strict';
+
+module.exports = [
+  'bmp', 'gif', 'jpg', 'jpeg', 'png', 'psd', 'svg', 'webp', // Image formats
+  'm4v', 'mov', 'mp4', 'mpeg', 'mpg', 'webm', // Video formats
+  'aac', 'aiff', 'caf', 'm4a', 'mp3', 'wav', // Audio formats
+  'html', 'pdf', // Document formats
+];

--- a/packager/react-packager/src/Server/index.js
+++ b/packager/react-packager/src/Server/index.js
@@ -17,9 +17,10 @@ const Promise = require('promise');
 const SourceMapConsumer = require('source-map').SourceMapConsumer;
 
 const declareOpts = require('../lib/declareOpts');
+const defaultAssetExts = require('../../../defaultAssetExts');
+const mime = require('mime-types');
 const path = require('path');
 const url = require('url');
-const mime = require('mime-types');
 
 function debounce(fn, delay) {
   var timeout;
@@ -71,12 +72,7 @@ const validateOpts = declareOpts({
   },
   assetExts: {
     type: 'array',
-    default: [
-      'bmp', 'gif', 'jpg', 'jpeg', 'png', 'psd', 'svg', 'webp', // Image formats
-      'm4v', 'mov', 'mp4', 'mpeg', 'mpg', 'webm', // Video formats
-      'aac', 'aiff', 'caf', 'm4a', 'mp3', 'wav', // Audio formats
-      'html', 'pdf', // Document formats
-    ],
+    default: defaultAssetExts,
   },
   transformTimeoutInterval: {
     type: 'number',

--- a/packager/rn-cli.config.js
+++ b/packager/rn-cli.config.js
@@ -5,7 +5,7 @@
  */
 'use strict';
 
-const blacklist = require('./blacklist.js');
+const blacklist = require('./blacklist');
 const path = require('path');
 
 module.exports = {
@@ -15,6 +15,10 @@ module.exports = {
 
   getAssetRoots() {
     return this._getRoots();
+  },
+
+  getAssetExts() {
+    return [];
   },
 
   getBlacklistRE(platform) {


### PR DESCRIPTION
Currently, the `assetExts` list is hardcoded in the packager, and so to add support for another extension for your own use case means that you need to submit a PR upstream to add the extension to the list, or just work off of a fork.

This PR adds support for passing in additional asset extensions to be recognized by the packager through `rn-cli.config.js` or as a param to the start command (eg: for UIExplorer you would do: `node local-cli/cli.js start --assetExts=ttf`)

**Test plan**

Made this change to UIExplorer:

```diff
diff --git a/Examples/UIExplorer/UIExplorerApp.ios.js b/Examples/UIExplorer/UIExplorerApp.ios.js
index cb49d2d..425433d 100644
--- a/Examples/UIExplorer/UIExplorerApp.ios.js
+++ b/Examples/UIExplorer/UIExplorerApp.ios.js
@@ -84,6 +84,9 @@ class UIExplorerApp extends React.Component {
   }
 
   componentDidMount() {
+    var ttfExample = require('./example.ttf');
+    console.log(`id for asset ./example.ttf: ${ttfExample}`);
+
     Linking.getInitialURL().then((url) => {
       AsyncStorage.getItem(APP_STATE_KEY, (err, storedString) => {
         const exampleAction = URIActionMap(this.props.exampleFromAppetizeParams);
diff --git a/Examples/UIExplorer/example.ttf b/Examples/UIExplorer/example.ttf
new file mode 100644
index 0000000..e69de29
```

And then ran `node local-cli/cli.js start --assetExts=ttf`, opened the app, it worked as expected. Then I ran it without `--assetExts=ttf` and the packager was unable to find the resource.