### PR TITLE
Remove instructions about IP address on iOS

### DIFF
--- a/docs/RunningOnDeviceIOS.md
+++ b/docs/RunningOnDeviceIOS.md
@@ -13,9 +13,7 @@ Running an iOS app on a device requires an [Apple Developer account](https://dev
 
 You can iterate quickly on device using the development server. First, ensure that you are on the same Wi-Fi network as your computer.
 
-1. Open `ios/YourApp/AppDelegate.m`
-2. Change the host in the URL from `localhost` to your laptop's IP address. On Mac, you can find the IP address in System Preferences / Network.
-3. In Xcode, select your phone as build target and press "Build and run"
+In Xcode, select your phone as build target and press "Build and run"
 
 > Hint
 >


### PR DESCRIPTION
The documentation was not updated after this change : Implemented automatic IP detection for iOS (8c29a52) 

Fixes #8651.