### PR TITLE
[Android] Update OkHttp to 3.4.1

### DIFF
--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -269,10 +269,10 @@ dependencies {
     compile 'com.facebook.soloader:soloader:0.1.0'
     compile 'com.fasterxml.jackson.core:jackson-core:2.2.3'
     compile 'com.google.code.findbugs:jsr305:3.0.0'
-    compile 'com.squareup.okhttp3:okhttp:3.2.0'
-    compile 'com.squareup.okhttp3:okhttp-urlconnection:3.2.0'
-    compile 'com.squareup.okhttp3:okhttp-ws:3.2.0'
-    compile 'com.squareup.okio:okio:1.8.0'
+    compile 'com.squareup.okhttp3:okhttp:3.4.1'
+    compile 'com.squareup.okhttp3:okhttp-urlconnection:3.4.1'
+    compile 'com.squareup.okhttp3:okhttp-ws:3.4.1'
+    compile 'com.squareup.okio:okio:1.9.0'
     compile 'org.webkit:android-jsc:r174650'
 
     testCompile "junit:junit:${JUNIT_VERSION}"

--- a/ReactAndroid/src/main/third-party/java/okhttp/BUCK
+++ b/ReactAndroid/src/main/third-party/java/okhttp/BUCK
@@ -6,8 +6,8 @@ prebuilt_jar(
 
 remote_file(
     name = 'okhttp3-binary-jar',
-    url = 'mvn:com.squareup.okhttp3:okhttp:jar:3.2.0',
-    sha1 = 'f7873a2ebde246a45c2a8d6f3247108b4c88a879'
+    url = 'mvn:com.squareup.okhttp3:okhttp:jar:3.4.1',
+    sha1 = 'c7c4f9e35c2fd5900da24f9872e3971801f08ce0'
 )
 
 prebuilt_jar(
@@ -18,8 +18,8 @@ prebuilt_jar(
 
 remote_file(
   name = 'okhttp3-urlconnection-binary-jar',
-  url = 'mvn:com.squareup.okhttp3:okhttp-urlconnection:jar:3.2.0',
-  sha1 = '6f8a4b1435c9e0a6f9c5fe4a1be46627b848fd0c'
+  url = 'mvn:com.squareup.okhttp3:okhttp-urlconnection:jar:3.4.1',
+  sha1 = '63994437f62bc861bc20c605d12962f7246116d1'
 )
 
 prebuilt_jar(
@@ -30,6 +30,6 @@ prebuilt_jar(
 
 remote_file(
     name = 'okhttp3-ws-binary-jar',
-    url = 'mvn:com.squareup.okhttp3:okhttp-ws:jar:3.2.0',
-    sha1 = '1ea229d6984444c8c58b8e97ba4c8429d9d135b3',
+    url = 'mvn:com.squareup.okhttp3:okhttp-ws:jar:3.4.1',
+    sha1 = '8ace66ef7002d98f633377c9e67daeeb196d8c3b',
 )

--- a/ReactAndroid/src/main/third-party/java/okio/BUCK
+++ b/ReactAndroid/src/main/third-party/java/okio/BUCK
@@ -6,6 +6,6 @@ prebuilt_jar(
 
 remote_file(
     name = 'okio-binary-jar',
-    url = 'mvn:com.squareup.okio:okio:jar:1.8.0',
-    sha1 = '05ea7af56cc7c567ed9856d99efb30740e9b17ff',
+    url = 'mvn:com.squareup.okio:okio:jar:1.9.0',
+    sha1 = 'f824591a0016efbaeddb8300bee54832a1398cfa',
 )


### PR DESCRIPTION
### Motivation

- OkHttp fix after #8672
- Fix an major bug in encoding HTTP headers. - https://github.com/square/okhttp/blob/master/CHANGELOG.md#version-341

### Test plan

- CircleCi
- Test with `/Examples` ✅ 

cc @bestander 