### PR TITLE
[Documentation] Fix links from networking to navigation in The Basics.

### DIFF
--- a/docs/Networking.md
+++ b/docs/Networking.md
@@ -4,7 +4,7 @@ title: Networking
 layout: docs
 category: The Basics
 permalink: docs/network.html
-next: navigators
+next: using-navigators
 ---
 
 Many mobile apps need to load resources from a remote URL. You may want to make a POST request to a REST API, or you may simply need to fetch a chunk of static content from another server.

--- a/docs/UsingNavigators.md
+++ b/docs/UsingNavigators.md
@@ -1,5 +1,5 @@
 ---
-id: navigators
+id: using-navigators
 title: Using Navigators
 layout: docs
 category: The Basics


### PR DESCRIPTION
Fixes #8611.

Once this lands, we may want to cherry-pick it into 0.29 to fix the broken links.