### PR TITLE
Added FanVision Bolt to showcase

### DIFF
--- a/website/src/react-native/showcase.js
+++ b/website/src/react-native/showcase.js
@@ -56,6 +56,13 @@ var featured = [
     infoTitle: 'Building the F8 App',
   },
   {
+    name: 'FanVision Bolt',
+    icon: 'http://a4.mzstatic.com/us/r30/Purple18/v4/94/b4/6e/94b46ee5-80e3-ff6e-513d-16da926b03a3/icon175x175.jpeg',
+    linkAppStore: 'https://itunes.apple.com/us/app/fanvision-bolt/id1081891275',
+    infoLink: 'https://www.youtube.com/watch?v=oWOcAXyDf0w',
+    infoTitle: 'FanVision Bolt accessory + app provide live audio/video and stats at NASCAR events',
+  },
+  {
     name: 'Gyroscope',
     icon: 'https://media.gyrosco.pe/images/magneto/180x180.png',
     linkAppStore: 'https://itunes.apple.com/app/apple-store/id1104085053?pt=117927205&ct=website&mt=8',


### PR DESCRIPTION
Hi there,

I showed this app to a couple of FB people at the React Europe conf in June (@ndfred @tadeuzagallo @ericvicenti @astreet and others), they suggested I should submit it to be part of the showcased apps.

It's used in production since the beginning of the year and fully usable at all NASCAR events.
The external accessory receives the digital TV signal broadcasted around the track by an antenna on a FanVision truck.
People rent the accessory there at our kiosks. It also recharges your smartphone battery.

I linked to a demo video so people can actually see what it does without having the required accessory.

The app is of course powered by React Native. I've built custom modules to integrate the native code that does all the heavy work (talking to the accessory, demuxing the raw data, decoding the audio and video, processing the additional data for all stats, etc).

Let me know what you think.