### PR TITLE
[NavigationExperimental] Prevent race condition on immediate transition

### DIFF
--- a/Libraries/NavigationExperimental/NavigationTransitioner.js
+++ b/Libraries/NavigationExperimental/NavigationTransitioner.js
@@ -125,9 +125,6 @@ class NavigationTransitioner extends React.Component<any, Props, State> {
       progress,
     } = nextState;
 
-    // update scenes.
-    this.setState(nextState);
-
     // get the transition spec.
     const transitionUserSpec = nextProps.configureTransition ?
       nextProps.configureTransition(
@@ -168,12 +165,14 @@ class NavigationTransitioner extends React.Component<any, Props, State> {
       );
     }
 
-    // play the transition.
-    nextProps.onTransitionStart && nextProps.onTransitionStart(
-      this._transitionProps,
-      this._prevTransitionProps,
-    );
-    Animated.parallel(animations).start(this._onTransitionEnd);
+    // update scenes and play the transition
+    this.setState(nextState, () => {
+      nextProps.onTransitionStart && nextProps.onTransitionStart(
+        this._transitionProps,
+        this._prevTransitionProps,
+      );
+      Animated.parallel(animations).start(this._onTransitionEnd);
+    });
   }
 
   render(): ReactElement<any> {


### PR DESCRIPTION
NavigationTransitioner prepares for transition within `componentWillReceiveProps`, using previously-saved state to determine how to properly handle new props. If a transition is to take place, the code saves new info in state, executes the transition, and cleans up scenes within `_onTransitionEnd`.

If the transition is a jump-to transition, or otherwise takes very little time, then it is possible for the setState call within `_onTransitionEnd` to use state which hasn't yet been set by the code within `componentWillReceiveProps`, resulting in a failed transition.

This fix ensures that the initial setState call is completed before executing the transition.