### PR TITLE
[Docs] Added flow to Getting Started guide again

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -93,6 +93,14 @@ npm install -g react-native-cli
 
 If you get a permission error, try with sudo: `sudo npm install -g react-native-cli`.
 
+If you want to use [Flow](https://flowtype.org/):
+
+```
+npm install --global flow-bin
+```
+
+If you get a permission error, try with sudo: `sudo npm install -g react-native-cli`.
+
 <block class="mac ios" />
 
 The easiest way to install Xcode is via the [Mac App Store](https://itunes.apple.com/us/app/xcode/id497799835?mt=12).


### PR DESCRIPTION
Flow installation was part of the docs before version 0.29.0 [(see here)](http://facebook.github.io/react-native/releases/0.24/docs/getting-started.html#requirements) through `brew install flow`, which will only install version `0.24.1` (which doesn't work with the current version of React Native, because it requires `^0.27.0`). Using npm instead of brew will guarantee installing the latest version of flow. 

