### PR TITLE
Fix favicon location error

### DIFF
--- a/website/server/server.js
+++ b/website/server/server.js
@@ -52,7 +52,7 @@ var app = connect()
   })
   .use(reactMiddleware.provide(buildOptions))
   .use(connect['static'](FILE_SERVE_ROOT))
-  .use(connect.favicon(path.join(FILE_SERVE_ROOT, 'elements', 'favicon', 'favicon.ico')))
+  .use(connect.favicon(path.join(FILE_SERVE_ROOT, 'react-native', 'img', 'favicon.png')))
   .use(connect.logger())
   .use(connect.compress())
   .use(connect.errorHandler());


### PR DESCRIPTION
When generating the html after running `npm start`, we convert the
`.md` files. As part of this, we use the location of the favicon.
The location has been wrong for a while. This fixes it to point
to the current, correct location.

<img width="1256" alt="screenshot 2016-07-12 10 44 16" src="https://cloud.githubusercontent.com/assets/3757713/16771259/d2195bac-481d-11e6-9ee8-b537b4593c7d.png">

Test Plan:

No error in the server after the change.