### PR TITLE
[NavigationExperimental] Allow route to specify the animation direction in NavigationCardStack

### DIFF
--- a/Libraries/CustomComponents/NavigationExperimental/NavigationCardStack.js
+++ b/Libraries/CustomComponents/NavigationExperimental/NavigationCardStack.js
@@ -161,7 +161,9 @@ class NavigationCardStack extends React.Component<DefaultProps, Props, void> {
   }
 
   _renderScene(props: NavigationSceneRendererProps): ReactElement<any> {
-    const isVertical = this.props.direction === 'vertical';
+    const isVertical = (this.props.direction === 'vertical' &&
+      props.scene.route.direction !== 'horizontal') ||
+      props.scene.route.direction === 'vertical';
 
     const style = isVertical ?
       NavigationCardStackStyleInterpolator.forVertical(props) :

--- a/Libraries/NavigationExperimental/NavigationPropTypes.js
+++ b/Libraries/NavigationExperimental/NavigationPropTypes.js
@@ -38,6 +38,7 @@ const animatedValue = PropTypes.instanceOf(Animated.Value);
 /* NavigationRoute  */
 const navigationRoute = PropTypes.shape({
   key: PropTypes.string.isRequired,
+  direction: PropTypes.string,
 });
 
 /* navigationRoute  */

--- a/Libraries/NavigationExperimental/NavigationTypeDefinition.js
+++ b/Libraries/NavigationExperimental/NavigationTypeDefinition.js
@@ -23,7 +23,8 @@ export type NavigationGestureDirection = 'horizontal' | 'vertical';
 
 export type NavigationRoute = {
   key: string,
-  title?: string
+  title?: string,
+  direction?: NavigationGestureDirection,
 };
 
 export type NavigationState = {


### PR DESCRIPTION
Explain the **motivation** for making this change. What existing problem does the pull request solve?

In using `NavigationCardStack`, there are some screens that I want to animate in from the side (viewing details on a piece of content), and some that I want to push from the bottom (like drafting a new piece of content). This provides a means of specifying the animation direction on a per route basis while still falling back to the overall default.

**Test plan (required)**

Create a NavigationCardStack and create routes with the `direction` property - see that the animation direction matches the specified direction.
