### PR TITLE
Use tabIndex instead of tabindex

### DIFF
--- a/website/core/AlgoliaDocSearch.js
+++ b/website/core/AlgoliaDocSearch.js
@@ -13,7 +13,7 @@ var AlgoliaDocSearch = React.createClass({
   render: function() {
     return (
       <div className="algolia-search-wrapper">
-        <input id="algolia-doc-search" tabindex="0" type="text" placeholder="Search docs..." />
+        <input id="algolia-doc-search" tabIndex="0" type="text" placeholder="Search docs..." />
       </div>
     );
   }


### PR DESCRIPTION
There is a little bit of dogscience here, but I believe JSX is wanting
`tabIndex` instead of `tabindex`. We have `tabindex` as an attribute in
our Algolia search; changing it to `tabIndex` removes the warning.

**Before**

<img width="1262" alt="screenshot 2016-07-12 11 05 47" src="https://cloud.githubusercontent.com/assets/3757713/16772199/4bff2d0e-4821-11e6-822f-a729656fec53.png">

**After**

<img width="1254" alt="screenshot 2016-07-12 11 09 47" src="https://cloud.githubusercontent.com/assets/3757713/16772201/4e09eb34-4821-11e6-9c5e-5e3d7e21c4bd.png">

Test Plan:

Warning before the change.
No warning after the change.