### PR TITLE
Fix broken link to PanResponderExample.js

### DIFF
--- a/Libraries/Interaction/PanResponder.js
+++ b/Libraries/Interaction/PanResponder.js
@@ -116,7 +116,7 @@ const currentCentroidY = TouchHistoryMath.currentCentroidY;
  * ### Working Example
  *
  * To see it in action, try the
- * [PanResponder example in UIExplorer](https://github.com/facebook/react-native/blob/master/Examples/UIExplorer/PanResponderExample.js)
+ * [PanResponder example in UIExplorer](https://github.com/facebook/react-native/blob/master/Examples/UIExplorer/js/PanResponderExample.js)
  */
 
 const PanResponder = {


### PR DESCRIPTION
In recent change in 2f73ca8 all javascript files under UIExplorer were moved to js subfolders but PanResponderExample link wasn't updated accordingly.