### PR TITLE
Initial implementation of requestIdleCallback on iOS

### DIFF
--- a/Examples/UIExplorer/js/TimerExample.js
+++ b/Examples/UIExplorer/js/TimerExample.js
@@ -57,20 +57,6 @@ var RequestIdleCallbackTester = React.createClass({
   render() {
     return (
       <View>
-        {Platform.OS === 'ios' ? this._renderIOS() : this._renderAndroid()}
-      </View>
-    );
-  },
-
-  _renderIOS() {
-    return (
-      <Text>Not implemented on iOS, falls back to requestAnimationFrame</Text>
-    );
-  },
-
-  _renderAndroid() {
-    return (
-      <View>
         <UIExplorerButton onPress={this._run.bind(this, false)}>
           Run requestIdleCallback
         </UIExplorerButton>


### PR DESCRIPTION
iOS follow up to #8569. This currently depends on the Android PR since it contains the JS implementation, only review the last commit. Just putting this out here for visibility, don't merge this before the Android PR.

**Test plan**
Tested by running a background task that burns all remaining idle time (see UIExplorer example).

Tested that native only calls into JS when there are pending idle callbacks.

Tested that timers are executed before idle callback.
