### PR TITLE
Eradicate the 'unique "key" prop' warnings

### DIFF
--- a/website/core/Marked.js
+++ b/website/core/Marked.js
@@ -10,6 +10,7 @@ var React = require('React');
 var Prism = require('Prism');
 var WebPlayer = require('WebPlayer');
 var Header = require('Header');
+var randomKey = require('randomKey');
 
 /**
  * Block-Level Grammar
@@ -580,7 +581,7 @@ InlineLexer.prototype.output = function(src) {
         text = cap[1];
         href = text;
       }
-      out.push(React.DOM.a({href: this.sanitizeUrl(href)}, text));
+      out.push(React.DOM.a({key: randomKey(), href: this.sanitizeUrl(href)}, text));
       continue;
     }
 
@@ -589,7 +590,7 @@ InlineLexer.prototype.output = function(src) {
       src = src.substring(cap[0].length);
       text = cap[1];
       href = text;
-      out.push(React.DOM.a({href: this.sanitizeUrl(href)}, text));
+      out.push(React.DOM.a({key: randomKey(), href: this.sanitizeUrl(href)}, text));
       continue;
     }
 
@@ -599,7 +600,9 @@ InlineLexer.prototype.output = function(src) {
 
       var color = cap[0].match('<color ([^ ]+) />');
       if (color) {
-        out.push(React.DOM.span({className: 'color', style: {backgroundColor: color[1]}}));
+        out.push(React.DOM.span(
+          {key: randomKey(), className: 'color', style: {backgroundColor: color[1]}}
+        ));
         continue;
       }
 
@@ -636,35 +639,35 @@ InlineLexer.prototype.output = function(src) {
     // strong
     if (cap = this.rules.strong.exec(src)) {
       src = src.substring(cap[0].length);
-      out.push(React.DOM.strong(null, this.output(cap[2] || cap[1])));
+      out.push(React.DOM.strong({key: randomKey()}, this.output(cap[2] || cap[1])));
       continue;
     }
 
     // em
     if (cap = this.rules.em.exec(src)) {
       src = src.substring(cap[0].length);
-      out.push(React.DOM.em(null, this.output(cap[2] || cap[1])));
+      out.push(React.DOM.em({key: randomKey()}, this.output(cap[2] || cap[1])));
       continue;
     }
 
     // code
     if (cap = this.rules.code.exec(src)) {
       src = src.substring(cap[0].length);
-      out.push(React.DOM.code(null, cap[2]));
+      out.push(React.DOM.code({key: randomKey()}, cap[2]));
       continue;
     }
 
     // br
     if (cap = this.rules.br.exec(src)) {
       src = src.substring(cap[0].length);
-      out.push(React.DOM.br(null, null));
+      out.push(React.DOM.br({key: randomKey()}, null));
       continue;
     }
 
     // del (gfm)
     if (cap = this.rules.del.exec(src)) {
       src = src.substring(cap[0].length);
-      out.push(React.DOM.del(null, this.output(cap[1])));
+      out.push(React.DOM.del({key: randomKey()}, this.output(cap[1])));
       continue;
     }
 
@@ -715,12 +718,14 @@ InlineLexer.prototype.outputLink = function(cap, link) {
       && link.href.charAt(0) !== '#';
 
     return React.DOM.a({
+      key: randomKey(),
       href: this.sanitizeUrl(link.href),
       title: link.title,
       target: shouldOpenInNewWindow ? '_blank' : ''
     }, this.output(cap[1]));
   } else {
     return React.DOM.img({
+      key: randomKey(),
       src: this.sanitizeUrl(link.href),
       alt: cap[1],
       title: link.title
@@ -816,11 +821,12 @@ Parser.prototype.tok = function() {
       return [];
     }
     case 'hr': {
-      return React.DOM.hr(null, null);
+      return React.DOM.hr({key: randomKey()}, null);
     }
     case 'heading': {
       return (
         <Header
+          key={randomKey()}
           level={this.token.depth}
           toSlug={this.token.text}>
           {this.inline.output(this.token.text)}
@@ -833,11 +839,11 @@ Parser.prototype.tok = function() {
 
       if (lang && lang.indexOf('ReactNativeWebPlayer') === 0) {
         return (
-          <WebPlayer params={lang.split('?')[1]}>{text}</WebPlayer>
+          <WebPlayer key={randomKey()} params={lang.split('?')[1]}>{text}</WebPlayer>
         );
       }
 
-      return <Prism>{text}</Prism>;
+      return <Prism key={randomKey()}>{text}</Prism>;
     }
     case 'table': {
       var table = []
@@ -853,12 +859,12 @@ Parser.prototype.tok = function() {
         heading = this.inline.output(this.token.header[i]);
         row.push(React.DOM.th(
           this.token.align[i]
-            ? {style: {textAlign: this.token.align[i]}}
+            ? {key: randomKey(), style: {textAlign: this.token.align[i]}}
             : null,
           heading
         ));
       }
-      table.push(React.DOM.thead(null, React.DOM.tr(null, row)));
+      table.push(React.DOM.thead({key: randomKey()}, React.DOM.tr(null, row)));
 
       // body
       for (i = 0; i < this.token.cells.length; i++) {
@@ -867,16 +873,16 @@ Parser.prototype.tok = function() {
         for (j = 0; j < cells.length; j++) {
           row.push(React.DOM.td(
             this.token.align[j]
-              ? {style: {textAlign: this.token.align[j]}}
+              ? {key: randomKey(), style: {textAlign: this.token.align[j]}}
               : null,
             this.inline.output(cells[j])
           ));
         }
-        body.push(React.DOM.tr(null, row));
+        body.push(React.DOM.tr({key: randomKey()}, row));
       }
-      table.push(React.DOM.thead(null, body));
+      table.push(React.DOM.thead({key: randomKey()}, body));
 
-      return React.DOM.table(null, table);
+      return React.DOM.table({key: randomKey()}, table);
     }
     case 'blockquote_start': {
       var body = [];
@@ -885,7 +891,7 @@ Parser.prototype.tok = function() {
         body.push(this.tok());
       }
 
-      return React.DOM.blockquote(null, body);
+      return React.DOM.blockquote({key: randomKey()}, body);
     }
     case 'list_start': {
       var type = this.token.ordered ? 'ol' : 'ul'
@@ -895,7 +901,7 @@ Parser.prototype.tok = function() {
         body.push(this.tok());
       }
 
-      return React.DOM[type](null, body);
+      return React.DOM[type]({key: randomKey()}, body);
     }
     case 'list_item_start': {
       var body = [];
@@ -906,7 +912,7 @@ Parser.prototype.tok = function() {
           : this.tok());
       }
 
-      return React.DOM.li(null, body);
+      return React.DOM.li({key: randomKey()}, body);
     }
     case 'loose_item_start': {
       var body = [];
@@ -915,22 +921,22 @@ Parser.prototype.tok = function() {
         body.push(this.tok());
       }
 
-      return React.DOM.li(null, body);
+      return React.DOM.li({key: randomKey()}, body);
     }
     case 'html': {
       return !this.token.pre && !this.options.pedantic
-        ? React.DOM.span({dangerouslySetInnerHTML: {__html: this.token.text}})
+        ? React.DOM.span({key: randomKey(), dangerouslySetInnerHTML: {__html: this.token.text}})
         : this.token.text;
     }
     case 'paragraph': {
       return this.options.paragraphFn
         ? this.options.paragraphFn.call(null, this.inline.output(this.token.text))
-        : React.DOM.p(null, this.inline.output(this.token.text));
+        : React.DOM.p({key: randomKey()}, this.inline.output(this.token.text));
     }
     case 'text': {
       return this.options.paragraphFn
         ? this.options.paragraphFn.call(null, this.parseText())
-        : React.DOM.p(null, this.parseText());
+        : React.DOM.p({key: randomKey()}, this.parseText());
     }
   }
 };
@@ -1056,8 +1062,8 @@ function marked(src, opt, callback) {
   } catch (e) {
     e.message += '\nPlease report this to https://github.com/chjj/marked.';
     if ((opt || marked.defaults).silent) {
-      return [React.DOM.p(null, "An error occurred:"),
-        React.DOM.pre(null, e.message)];
+      return [React.DOM.p({key: randomKey()}, "An error occurred:"),
+        React.DOM.pre({key: randomKey()}, e.message)];
     }
     throw e;
   }
@@ -1105,7 +1111,7 @@ marked.parse = marked;
 var Marked = React.createClass({
   render: function() {
     return this.props.children ?
-      React.DOM.div(null, marked(this.props.children, this.props)) :
+      React.DOM.div({key: randomKey()}, marked(this.props.children, this.props)) :
       null;
   }
 });

--- a/website/core/Marked.js
+++ b/website/core/Marked.js
@@ -10,7 +10,7 @@ var React = require('React');
 var Prism = require('Prism');
 var WebPlayer = require('WebPlayer');
 var Header = require('Header');
-var randomKey = require('randomKey');
+var sequentialKey = require('sequentialKey');
 
 /**
  * Block-Level Grammar
@@ -581,7 +581,7 @@ InlineLexer.prototype.output = function(src) {
         text = cap[1];
         href = text;
       }
-      out.push(React.DOM.a({key: randomKey(), href: this.sanitizeUrl(href)}, text));
+      out.push(React.DOM.a({key: sequentialKey(), href: this.sanitizeUrl(href)}, text));
       continue;
     }
 
@@ -590,7 +590,7 @@ InlineLexer.prototype.output = function(src) {
       src = src.substring(cap[0].length);
       text = cap[1];
       href = text;
-      out.push(React.DOM.a({key: randomKey(), href: this.sanitizeUrl(href)}, text));
+      out.push(React.DOM.a({key: sequentialKey(), href: this.sanitizeUrl(href)}, text));
       continue;
     }
 
@@ -601,7 +601,7 @@ InlineLexer.prototype.output = function(src) {
       var color = cap[0].match('<color ([^ ]+) />');
       if (color) {
         out.push(React.DOM.span(
-          {key: randomKey(), className: 'color', style: {backgroundColor: color[1]}}
+          {key: sequentialKey(), className: 'color', style: {backgroundColor: color[1]}}
         ));
         continue;
       }
@@ -639,35 +639,35 @@ InlineLexer.prototype.output = function(src) {
     // strong
     if (cap = this.rules.strong.exec(src)) {
       src = src.substring(cap[0].length);
-      out.push(React.DOM.strong({key: randomKey()}, this.output(cap[2] || cap[1])));
+      out.push(React.DOM.strong({key: sequentialKey()}, this.output(cap[2] || cap[1])));
       continue;
     }
 
     // em
     if (cap = this.rules.em.exec(src)) {
       src = src.substring(cap[0].length);
-      out.push(React.DOM.em({key: randomKey()}, this.output(cap[2] || cap[1])));
+      out.push(React.DOM.em({key: sequentialKey()}, this.output(cap[2] || cap[1])));
       continue;
     }
 
     // code
     if (cap = this.rules.code.exec(src)) {
       src = src.substring(cap[0].length);
-      out.push(React.DOM.code({key: randomKey()}, cap[2]));
+      out.push(React.DOM.code({key: sequentialKey()}, cap[2]));
       continue;
     }
 
     // br
     if (cap = this.rules.br.exec(src)) {
       src = src.substring(cap[0].length);
-      out.push(React.DOM.br({key: randomKey()}, null));
+      out.push(React.DOM.br({key: sequentialKey()}, null));
       continue;
     }
 
     // del (gfm)
     if (cap = this.rules.del.exec(src)) {
       src = src.substring(cap[0].length);
-      out.push(React.DOM.del({key: randomKey()}, this.output(cap[1])));
+      out.push(React.DOM.del({key: sequentialKey()}, this.output(cap[1])));
       continue;
     }
 
@@ -718,14 +718,14 @@ InlineLexer.prototype.outputLink = function(cap, link) {
       && link.href.charAt(0) !== '#';
 
     return React.DOM.a({
-      key: randomKey(),
+      key: sequentialKey(),
       href: this.sanitizeUrl(link.href),
       title: link.title,
       target: shouldOpenInNewWindow ? '_blank' : ''
     }, this.output(cap[1]));
   } else {
     return React.DOM.img({
-      key: randomKey(),
+      key: sequentialKey(),
       src: this.sanitizeUrl(link.href),
       alt: cap[1],
       title: link.title
@@ -821,12 +821,12 @@ Parser.prototype.tok = function() {
       return [];
     }
     case 'hr': {
-      return React.DOM.hr({key: randomKey()}, null);
+      return React.DOM.hr({key: sequentialKey()}, null);
     }
     case 'heading': {
       return (
         <Header
-          key={randomKey()}
+          key={sequentialKey()}
           level={this.token.depth}
           toSlug={this.token.text}>
           {this.inline.output(this.token.text)}
@@ -839,11 +839,11 @@ Parser.prototype.tok = function() {
 
       if (lang && lang.indexOf('ReactNativeWebPlayer') === 0) {
         return (
-          <WebPlayer key={randomKey()} params={lang.split('?')[1]}>{text}</WebPlayer>
+          <WebPlayer key={sequentialKey()} params={lang.split('?')[1]}>{text}</WebPlayer>
         );
       }
 
-      return <Prism key={randomKey()}>{text}</Prism>;
+      return <Prism key={sequentialKey()}>{text}</Prism>;
     }
     case 'table': {
       var table = []
@@ -859,12 +859,12 @@ Parser.prototype.tok = function() {
         heading = this.inline.output(this.token.header[i]);
         row.push(React.DOM.th(
           this.token.align[i]
-            ? {key: randomKey(), style: {textAlign: this.token.align[i]}}
+            ? {key: sequentialKey(), style: {textAlign: this.token.align[i]}}
             : null,
           heading
         ));
       }
-      table.push(React.DOM.thead({key: randomKey()}, React.DOM.tr(null, row)));
+      table.push(React.DOM.thead({key: sequentialKey()}, React.DOM.tr(null, row)));
 
       // body
       for (i = 0; i < this.token.cells.length; i++) {
@@ -873,16 +873,16 @@ Parser.prototype.tok = function() {
         for (j = 0; j < cells.length; j++) {
           row.push(React.DOM.td(
             this.token.align[j]
-              ? {key: randomKey(), style: {textAlign: this.token.align[j]}}
+              ? {key: sequentialKey(), style: {textAlign: this.token.align[j]}}
               : null,
             this.inline.output(cells[j])
           ));
         }
-        body.push(React.DOM.tr({key: randomKey()}, row));
+        body.push(React.DOM.tr({key: sequentialKey()}, row));
       }
-      table.push(React.DOM.thead({key: randomKey()}, body));
+      table.push(React.DOM.thead({key: sequentialKey()}, body));
 
-      return React.DOM.table({key: randomKey()}, table);
+      return React.DOM.table({key: sequentialKey()}, table);
     }
     case 'blockquote_start': {
       var body = [];
@@ -891,7 +891,7 @@ Parser.prototype.tok = function() {
         body.push(this.tok());
       }
 
-      return React.DOM.blockquote({key: randomKey()}, body);
+      return React.DOM.blockquote({key: sequentialKey()}, body);
     }
     case 'list_start': {
       var type = this.token.ordered ? 'ol' : 'ul'
@@ -901,7 +901,7 @@ Parser.prototype.tok = function() {
         body.push(this.tok());
       }
 
-      return React.DOM[type]({key: randomKey()}, body);
+      return React.DOM[type]({key: sequentialKey()}, body);
     }
     case 'list_item_start': {
       var body = [];
@@ -912,7 +912,7 @@ Parser.prototype.tok = function() {
           : this.tok());
       }
 
-      return React.DOM.li({key: randomKey()}, body);
+      return React.DOM.li({key: sequentialKey()}, body);
     }
     case 'loose_item_start': {
       var body = [];
@@ -921,22 +921,22 @@ Parser.prototype.tok = function() {
         body.push(this.tok());
       }
 
-      return React.DOM.li({key: randomKey()}, body);
+      return React.DOM.li({key: sequentialKey()}, body);
     }
     case 'html': {
       return !this.token.pre && !this.options.pedantic
-        ? React.DOM.span({key: randomKey(), dangerouslySetInnerHTML: {__html: this.token.text}})
+        ? React.DOM.span({key: sequentialKey(), dangerouslySetInnerHTML: {__html: this.token.text}})
         : this.token.text;
     }
     case 'paragraph': {
       return this.options.paragraphFn
         ? this.options.paragraphFn.call(null, this.inline.output(this.token.text))
-        : React.DOM.p({key: randomKey()}, this.inline.output(this.token.text));
+        : React.DOM.p({key: sequentialKey()}, this.inline.output(this.token.text));
     }
     case 'text': {
       return this.options.paragraphFn
         ? this.options.paragraphFn.call(null, this.parseText())
-        : React.DOM.p({key: randomKey()}, this.parseText());
+        : React.DOM.p({key: sequentialKey()}, this.parseText());
     }
   }
 };
@@ -1062,8 +1062,8 @@ function marked(src, opt, callback) {
   } catch (e) {
     e.message += '\nPlease report this to https://github.com/chjj/marked.';
     if ((opt || marked.defaults).silent) {
-      return [React.DOM.p({key: randomKey()}, "An error occurred:"),
-        React.DOM.pre({key: randomKey()}, e.message)];
+      return [React.DOM.p({key: sequentialKey()}, "An error occurred:"),
+        React.DOM.pre({key: sequentialKey()}, e.message)];
     }
     throw e;
   }
@@ -1111,7 +1111,7 @@ marked.parse = marked;
 var Marked = React.createClass({
   render: function() {
     return this.props.children ?
-      React.DOM.div({key: randomKey()}, marked(this.props.children, this.props)) :
+      React.DOM.div({key: sequentialKey()}, marked(this.props.children, this.props)) :
       null;
   }
 });

--- a/website/core/randomKey.js
+++ b/website/core/randomKey.js
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule randomKey
+ */
+
+// Create a random key for rendered DOM elements to avoid:
+//   "Each child in an array or iterator should have a unique "key" prop.""
+// warnings.
+function randomKey() {
+  // http://stackoverflow.com/questions/10726909/random-alpha-numeric-string-in-javascript
+  return Math.random().toString(36).slice(2);
+}
+
+module.exports = randomKey;

--- a/website/core/sequentialKey.js
+++ b/website/core/sequentialKey.js
@@ -6,15 +6,18 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  *
- * @providesModule randomKey
+ * @providesModule sequentialKey
  */
 
-// Create a random key for rendered DOM elements to avoid:
+// Create a sequential key for rendered DOM elements to avoid:
 //   "Each child in an array or iterator should have a unique "key" prop.""
-// warnings.
-function randomKey() {
-  // http://stackoverflow.com/questions/10726909/random-alpha-numeric-string-in-javascript
-  return Math.random().toString(36).slice(2);
+// warnings. Given that the DOM for the docs will not have any state changes so
+// the counter will always be the same and determinisic for any component.
+
+var keyCounter = 0;
+
+function sequentialKey() {
+  return keyCounter++;
 }
 
-module.exports = randomKey;
+module.exports = sequentialKey;

--- a/website/layout/AutodocsLayout.js
+++ b/website/layout/AutodocsLayout.js
@@ -21,6 +21,7 @@ var React = require('React');
 var Site = require('Site');
 var slugify = require('slugify');
 var Metadata = require('Metadata');
+var randomKey = require('randomKey');
 
 var styleReferencePattern = /^[^.]+\.propTypes\.style$/;
 
@@ -59,7 +60,7 @@ function renderType(type) {
   }
 
   if (type.name === 'arrayOf') {
-    return <span>[{renderType(type.value)}]</span>;
+    return <span key={randomKey()}>[{renderType(type.value)}]</span>;
   }
 
   if (type.name === 'instanceOf') {
@@ -69,10 +70,10 @@ function renderType(type) {
   if (type.name === 'custom') {
     if (styleReferencePattern.test(type.raw)) {
       var name = type.raw.substring(0, type.raw.indexOf('.'));
-      return <a href={'docs/' + slugify(name) + '.html#style'}>{name}#style</a>;
+      return <a key={randomKey()} href={'docs/' + slugify(name) + '.html#style'}>{name}#style</a>;
     }
     if (type.raw === 'ColorPropType') {
-      return <a href={'docs/colors.html'}>color</a>;
+      return <a key={randomKey()} href={'docs/colors.html'}>color</a>;
     }
     if (type.raw === 'EdgeInsetsPropType') {
       return '{top: number, left: number, bottom: number, right: number}';
@@ -108,7 +109,7 @@ function renderTypeNameLink(typeName, docPath, namedTypes) {
   if (ignoreTypes.indexOf(typeNameLower) !== -1 || !namedTypes[typeNameLower]) {
     return typeName;
   }
-  return <a href={docPath + '#' + typeNameLower}>{typeName}</a>;
+  return <a key={randomKey()} href={docPath + '#' + typeNameLower}>{typeName}</a>;
 }
 
 function renderTypeWithLinks(type, docTitle, namedTypes) {
@@ -118,7 +119,7 @@ function renderTypeWithLinks(type, docTitle, namedTypes) {
 
   const docPath = docTitle ? 'docs/' + docTitle.toLowerCase() + '.html' : 'docs/';
   return (
-    <div>
+    <div key={randomKey()}>
       {
         type.names.map((typeName, index, array) => {
           let separator = index < array.length - 1 && ' | ';
@@ -190,28 +191,28 @@ var ComponentDoc = React.createClass({
   renderProp: function(name, prop) {
     return (
       <div className="prop" key={name}>
-        <Header level={4} className="propTitle" toSlug={name}>
+        <Header key={randomKey()} level={4} className="propTitle" toSlug={name}>
           {prop.platforms && prop.platforms.map(platform =>
-            <span className="platform">{platform}</span>
+            <span key={randomKey()} className="platform">{platform}</span>
           )}
           {name}
           {' '}
-          {prop.type && <span className="propType">
+          {prop.type && <span key={randomKey()} className="propType">
             {renderType(prop.type)}
           </span>}
         </Header>
-        {prop.deprecationMessage && <div className="deprecated">
-          <div className="deprecatedTitle">
-            <img className="deprecatedIcon" src="img/Warning.png" />
-            <span>Deprecated</span>
+        {prop.deprecationMessage && <div key={randomKey()} className="deprecated">
+          <div key={randomKey()} className="deprecatedTitle">
+            <img key={randomKey()} className="deprecatedIcon" src="img/Warning.png" />
+            <span key={randomKey()}>Deprecated</span>
           </div>
-          <div className="deprecatedMessage">
-            <Marked>{prop.deprecationMessage}</Marked>
+          <div key={randomKey()} className="deprecatedMessage">
+            <Marked key={randomKey()}>{prop.deprecationMessage}</Marked>
           </div>
         </div>}
         {prop.type && prop.type.name === 'stylesheet' &&
           this.renderStylesheetProps(prop.type.value)}
-        {prop.description && <Marked>{prop.description}</Marked>}
+        {prop.description && <Marked key={randomKey()}>{prop.description}</Marked>}
       </div>
     );
   },
@@ -219,8 +220,8 @@ var ComponentDoc = React.createClass({
   renderCompose: function(name) {
     return (
       <div className="prop" key={name}>
-        <Header level={4} className="propTitle" toSlug={name}>
-          <a href={'docs/' + slugify(name) + '.html#props'}>{name} props...</a>
+        <Header key={randomKey()} level={4} className="propTitle" toSlug={name}>
+          <a key={randomKey()} href={'docs/' + slugify(name) + '.html#props'}>{name} props...</a>
         </Header>
       </div>
     );
@@ -229,17 +230,17 @@ var ComponentDoc = React.createClass({
   renderStylesheetProp: function(name, prop) {
     return (
       <div className="prop" key={name}>
-        <h6 className="propTitle">
+        <h6 key={randomKey()} className="propTitle">
           {prop.platforms && prop.platforms.map(platform =>
-            <span className="platform">{platform}</span>
+            <span key={randomKey()} className="platform">{platform}</span>
           )}
           {name}
           {' '}
-          {prop.type && <span className="propType">
+          {prop.type && <span key={randomKey()} className="propType">
             {renderType(prop.type)}
           </span>}
           {' '}
-          {prop.description && <Marked>{prop.description}</Marked>}
+          {prop.description && <Marked key={randomKey()}>{prop.description}</Marked>}
         </h6>
       </div>
     );
@@ -249,25 +250,25 @@ var ComponentDoc = React.createClass({
     var style = this.props.content.styles[stylesheetName];
     this.extractPlatformFromProps(style.props);
     return (
-      <div className="compactProps">
+      <div key={randomKey()} className="compactProps">
         {(style.composes || []).map((name) => {
           var link;
           if (name === 'LayoutPropTypes') {
             name = 'Flexbox';
             link =
-              <a href={'docs/' + slugify(name) + '.html#proptypes'}>{name}...</a>;
+              <a key={randomKey()} href={'docs/' + slugify(name) + '.html#proptypes'}>{name}...</a>;
           } else if (name === 'TransformPropTypes') {
             name = 'Transforms';
             link =
-              <a href={'docs/' + slugify(name) + '.html#proptypes'}>{name}...</a>;
+              <a key={randomKey()} href={'docs/' + slugify(name) + '.html#proptypes'}>{name}...</a>;
           } else {
             name = name.replace('StylePropTypes', '');
             link =
-              <a href={'docs/' + slugify(name) + '.html#style'}>{name}#style...</a>;
+              <a key={randomKey()} href={'docs/' + slugify(name) + '.html#style'}>{name}#style...</a>;
           }
           return (
-            <div className="prop" key={name}>
-              <h6 className="propTitle">{link}</h6>
+            <div key={randomKey()} className="prop" key={name}>
+              <h6 key={randomKey()} className="propTitle">{link}</h6>
             </div>
           );
         })}
@@ -281,7 +282,7 @@ var ComponentDoc = React.createClass({
 
   renderProps: function(props, composes) {
     return (
-      <div className="props">
+      <div key={randomKey()} className="props">
         {(composes || []).map((name) =>
           this.renderCompose(name)
         )}
@@ -326,9 +327,9 @@ var ComponentDoc = React.createClass({
       return null;
     }
     return (
-      <span>
-        <H level={3}>Methods</H>
-        <div className="props">
+      <span key={randomKey()}>
+        <H key={randomKey()}level={3}>Methods</H>
+        <div key={randomKey()} className="props">
           {methods.filter((method) => {
             return method.name[0] !== '_';
           }).map(method => this.renderMethod(method, namedTypes))}
@@ -357,9 +358,9 @@ var ComponentDoc = React.createClass({
       return null;
     }
     return (
-      <span>
-        <H level={3}>Type Definitions</H>
-        <div className="props">
+      <span key={randomKey()}>
+        <H key={randomKey()} level={3}>Type Definitions</H>
+        <div key={randomKey()} className="props">
           {typedefs.map((typedef) => {
             return this.renderTypeDef(typedef, namedTypes);
           })}
@@ -373,11 +374,11 @@ var ComponentDoc = React.createClass({
     this.extractPlatformFromProps(content.props);
     const namedTypes = getNamedTypes(content.typedef);
     return (
-      <div>
-        <Marked>
+      <div key={randomKey()}>
+        <Marked key={randomKey()}>
           {content.description}
         </Marked>
-        <H level={3}>Props</H>
+        <H key={randomKey()} level={3}>Props</H>
         {this.renderProps(content.props, content.composes)}
         {this.renderMethods(content.methods, namedTypes)}
         {this.renderTypeDefs(content.typedef, namedTypes)}
@@ -408,9 +409,9 @@ var APIDoc = React.createClass({
       return null;
     }
     return (
-      <span>
-        <H level={3}>Methods</H>
-        <div className="props">
+      <span key={randomKey()}>
+        <H key={randomKey()} level={3}>Methods</H>
+        <div key={randomKey()} className="props">
           {methods.filter((method) => {
             return method.name[0] !== '_';
           }).map(method => this.renderMethod(method, namedTypes))}
@@ -421,16 +422,16 @@ var APIDoc = React.createClass({
 
   renderProperty: function(property) {
     return (
-      <div className="prop" key={property.name}>
-        <Header level={4} className="propTitle" toSlug={property.name}>
+      <div key={randomKey()} className="prop" key={property.name}>
+        <Header key={randomKey()} level={4} className="propTitle" toSlug={property.name}>
           {property.name}
           {property.type &&
-            <span className="propType">
+            <span key={randomKey()} className="propType">
               {': ' + renderType(property.type)}
             </span>
           }
         </Header>
-        {property.docblock && <Marked>
+        {property.docblock && <Marked key={randomKey()}>
           {removeCommentsFromDocblock(property.docblock)}
         </Marked>}
       </div>
@@ -442,9 +443,9 @@ var APIDoc = React.createClass({
       return null;
     }
     return (
-      <span>
-        <H level={3}>Properties</H>
-        <div className="props">
+      <span key={randomKey()}>
+        <H key={randomKey()} level={3}>Properties</H>
+        <div key={randomKey()} className="props">
           {properties.filter((property) => {
             return property.name[0] !== '_';
           }).map(this.renderProperty)}
@@ -458,18 +459,18 @@ var APIDoc = React.createClass({
       return null;
     }
     return (
-      <span>
-        <div>
+      <span key={randomKey()}>
+        <div key={randomKey()}>
           {classes.filter((cls) => {
             return cls.name[0] !== '_' && cls.ownerProperty[0] !== '_';
           }).map((cls) => {
             return (
               <span key={cls.name}>
-                <Header level={2} toSlug={cls.name}>
+                <Header key={randomKey()} level={2} toSlug={cls.name}>
                   class {cls.name}
                 </Header>
-                <ul>
-                  {cls.docblock && <Marked>
+                <ul key={randomKey()}>
+                  {cls.docblock && <Marked key={randomKey()}>
                     {removeCommentsFromDocblock(cls.docblock)}
                   </Marked>}
                   {this.renderMethods(cls.methods, namedTypes)}
@@ -503,9 +504,9 @@ var APIDoc = React.createClass({
       return null;
     }
     return (
-      <span>
-        <H level={3}>Type Definitions</H>
-        <div className="props">
+      <span key={randomKey()}>
+        <H key={randomKey()} level={3}>Type Definitions</H>
+        <div key={randomKey()} className="props">
           {typedefs.map((typedef) => {
             return this.renderTypeDef(typedef, namedTypes);
           })}
@@ -517,14 +518,14 @@ var APIDoc = React.createClass({
   renderMainDescription: function(content) {
     if (content.docblock) {
       return (
-        <Marked>
+        <Marked key={randomKey()}>
           {removeCommentsFromDocblock(content.docblock)}
         </Marked>
       );
     }
     if (content.class && content.class.length && content.class[0].description) {
       return (
-        <Marked>
+        <Marked key={randomKey()}>
           {content.class[0].description}
         </Marked>
       );
@@ -541,7 +542,7 @@ var APIDoc = React.createClass({
     }
     const namedTypes = getNamedTypes(content.typedef);
     return (
-      <div>
+      <div key={randomKey()}>
         {this.renderMainDescription(content)}
         {this.renderMethods(content.methods, namedTypes)}
         {this.renderProperties(content.properties)}
@@ -590,10 +591,10 @@ var Method = React.createClass({
       const code = example.replace(/<caption>.*?<\/caption>/ig, '')
         .replace(/^\n\n/, '');
       return (
-        <div>
-          <br/>
+        <div key={randomKey()}>
+          <br key={randomKey()} />
           {caption}
-          <Prism>
+          <Prism key={randomKey()}>
             {code}
           </Prism>
         </div>
@@ -613,25 +614,27 @@ var Method = React.createClass({
       return null;
     }
     return (
-      <div>
-        <strong>Parameters:</strong>
-          <table className="params">
-            <thead>
-              <tr>
-                <th>Name and Type</th>
-                <th>Description</th>
+      <div key={randomKey()}>
+        <strong key={randomKey()}>Parameters:</strong>
+          <table key={randomKey()} className="params">
+            <thead key={randomKey()}>
+              <tr key={randomKey()}>
+                <th key={randomKey()}>Name and Type</th>
+                <th key={randomKey()}>Description</th>
               </tr>
             </thead>
-            <tbody>
+            <tbody key={randomKey()}>
               {params.map((param) => {
                 return (
-                  <tr>
-                    <td>
+                  <tr key={randomKey()}>
+                    <td key={randomKey()}>
                       {param.optional ? '[' + param.name + ']' : param.name}
-                      <br/><br/>
+                      <br key={randomKey()} /><br key={randomKey()} />
                       {renderTypeWithLinks(param.type, this.props.apiName, this.props.namedTypes)}
                     </td>
-                    <td className="description"><Marked>{param.description}</Marked></td>
+                    <td key={randomKey()} className="description">
+                      <Marked key={randomKey()}>{param.description}</Marked>
+                    </td>
                   </tr>
                 );
               })}
@@ -643,13 +646,14 @@ var Method = React.createClass({
 
   render: function() {
     return (
-      <div className="prop">
-        <Header level={4} className="methodTitle" toSlug={this.props.name}>
-          {this.props.modifiers && this.props.modifiers.length && <span className="methodType">
+      <div key={randomKey()} className="prop">
+        <Header key={randomKey()} level={4} className="methodTitle" toSlug={this.props.name}>
+          {this.props.modifiers && this.props.modifiers.length &&
+          <span key={randomKey()} className="methodType">
             {this.props.modifiers.join(' ') + ' '}
           </span> || ''}
           {this.props.name}
-          <span className="methodType">
+          <span key={randomKey()} className="methodType">
             ({this.props.params && this.props.params.length && this.props.params
               .map((param) => {
                 var res = param.name;
@@ -660,7 +664,7 @@ var Method = React.createClass({
               {this.props.returns && ': ' + this.renderTypehint(this.props.returns.type)}
           </span>
         </Header>
-        {this.props.description && <Marked>
+        {this.props.description && <Marked key={randomKey()}>
           {this.props.description}
         </Marked>}
         {this.renderMethodParameters(this.props.params)}
@@ -679,26 +683,28 @@ var TypeDef = React.createClass({
       return null;
     }
     return (
-      <div>
-        <br/>
-        <strong>Properties:</strong>
-          <table className="params">
-            <thead>
-              <tr>
-                <th>Name and Type</th>
-                <th>Description</th>
+      <div key={randomKey()}>
+        <br key={randomKey()} />
+        <strong key={randomKey()}>Properties:</strong>
+          <table key={randomKey()} className="params">
+            <thead key={randomKey()}>
+              <tr key={randomKey()}>
+                <th key={randomKey()}>Name and Type</th>
+                <th key={randomKey()}>Description</th>
               </tr>
             </thead>
-            <tbody>
+            <tbody key={randomKey()}>
               {properties.map((property) => {
                 return (
-                  <tr>
-                    <td>
+                  <tr key={randomKey()}>
+                    <td key={randomKey()}>
                       {property.optional ? '[' + property.name + ']' : property.name}
-                      <br/><br/>
+                      <br key={randomKey()} /><br key={randomKey()} />
                       {renderTypeWithLinks(property.type, this.props.apiName, this.props.namedTypes)}
                     </td>
-                    <td className="description"><Marked>{property.description}</Marked></td>
+                    <td key={randomKey()} className="description">
+                      <Marked key={randomKey()}>{property.description}</Marked>
+                    </td>
                   </tr>
                 );
               })}
@@ -716,24 +722,26 @@ var TypeDef = React.createClass({
       return null;
     }
     return (
-      <div>
-        <br/>
-        <strong>Constants:</strong>
-        <table className="params">
-          <thead>
-            <tr>
-              <th>Value</th>
-              <th>Description</th>
+      <div key={randomKey()}>
+        <br key={randomKey()} />
+        <strong key={randomKey()}>Constants:</strong>
+        <table key={randomKey()} className="params">
+          <thead key={randomKey()}>
+            <tr key={randomKey()}>
+              <th key={randomKey()}>Value</th>
+              <th key={randomKey()}>Description</th>
             </tr>
           </thead>
-          <tbody>
+          <tbody key={randomKey()}>
             {values.map((value) => {
               return (
-                <tr>
-                  <td>
+                <tr key={randomKey()}>
+                  <td key={randomKey()}>
                     {value.name}
                   </td>
-                  <td className="description"><Marked>{value.description}</Marked></td>
+                  <td key={randomKey()} className="description">
+                    <Marked key={randomKey()}>{value.description}</Marked>
+                  </td>
                 </tr>
               );
             })}
@@ -745,15 +753,15 @@ var TypeDef = React.createClass({
 
   render: function() {
     return (
-      <div className="prop">
-        <Header level={4} className="propTitle" toSlug={this.props.name}>
+      <div key={randomKey()} className="prop">
+        <Header key={randomKey()} level={4} className="propTitle" toSlug={this.props.name}>
           {this.props.name}
         </Header>
-        {this.props.description && <Marked>
+        {this.props.description && <Marked key={randomKey()}>
           {this.props.description}
         </Marked>}
-        <strong>Type:</strong>
-        <br/>
+        <strong key={randomKey()}>Type:</strong>
+        <br key={randomKey()} />
         {this.props.type.names.join(' | ')}
         {this.renderProperties(this.props.properties)}
         {this.renderValues(this.props.values)}
@@ -771,16 +779,21 @@ var EmbeddedSimulator = React.createClass({
     var metadata = this.props.metadata;
 
     var imagePreview = metadata.platform === 'android'
-      ? <img alt="Run example in simulator" width="170" height="338" src="img/uiexplorer_main_android.png" />
-      : <img alt="Run example in simulator" width="170" height="356" src="img/uiexplorer_main_ios.png" />;
+      ? <img key={randomKey()} alt="Run example in simulator" width="170" height="338" src="img/uiexplorer_main_android.png" />
+      : <img key={randomKey()} alt="Run example in simulator" width="170"
+             height="356" src="img/uiexplorer_main_ios.png" />;
 
     return (
-      <div className="embedded-simulator">
-        <p><a className="modal-button-open"><strong>Run this example</strong></a></p>
-        <div className="modal-button-open modal-button-open-img">
+      <div key={randomKey()} className="embedded-simulator">
+        <p key={randomKey()}>
+          <a key={randomKey()}className="modal-button-open">
+            <strong key={randomKey()}>Run this example</strong>
+          </a>
+        </p>
+        <div key={randomKey()} className="modal-button-open modal-button-open-img">
           {imagePreview}
         </div>
-        <Modal metadata={metadata} />
+        <Modal key={randomKey()} metadata={metadata} />
       </div>
     );
   }
@@ -796,17 +809,19 @@ var Modal = React.createClass({
       : `https://appetize.io/embed/7vdfm9h3e6vuf4gfdm7r5rgc48?device=iphone6s&scale=60&autoplay=false&orientation=portrait&deviceColor=white&params=${encodedParams}`;
 
     return (
-      <div>
-        <div className="modal">
-          <div className="modal-content">
-            <button className="modal-button-close">&times;</button>
-            <div className="center">
-              <iframe className="simulator" src={url} width="256" height="550" frameborder="0" scrolling="no"></iframe>
-              <p>Powered by <a target="_blank" href="https://appetize.io">appetize.io</a></p>
+      <div key={randomKey()}>
+        <div key={randomKey()} className="modal">
+          <div key={randomKey()} className="modal-content">
+            <button key={randomKey()} className="modal-button-close">&times;</button>
+            <div key={randomKey()} className="center">
+              <iframe key={randomKey()} className="simulator" src={url} width="256" height="550" frameBorder="0" scrolling="no"></iframe>
+              <p key={randomKey()}>Powered by
+                <a key={randomKey()} target="_blank" href="https://appetize.io">appetize.io</a>
+              </p>
             </div>
           </div>
         </div>
-        <div className="modal-backdrop" />
+        <div key={randomKey()} className="modal-backdrop" />
       </div>
     );
   }
@@ -830,12 +845,13 @@ var Autodocs = React.createClass({
       return;
     }
     return (
-      <div>
+      <div key={randomKey()}>
         <HeaderWithGithub
+          key={randomKey()}
           title="Description"
           path={'docs/' + docs.componentName + '.md'}
         />
-        <Marked>
+        <Marked key={randomKey()}>
           {docs.fullDescription}
         </Marked>
       </div>
@@ -848,18 +864,23 @@ var Autodocs = React.createClass({
     }
 
     return (
-      <div>
+      <div key={randomKey()}>
         <HeaderWithGithub
+          key={randomKey()}
           title={example.title || 'Examples'}
           level={example.title ? 4 : 3}
           path={example.path}
           metadata={metadata}
         />
-        <div className="example-container">
-          <Prism>
+        <div key={randomKey()} className="example-container">
+          <Prism key={randomKey()}>
            {example.content.replace(/^[\s\S]*?\*\//, '').trim()}
           </Prism>
-          <EmbeddedSimulator shouldRender={metadata.runnable} metadata={metadata} />
+          <EmbeddedSimulator
+            key={randomKey()}
+            shouldRender={metadata.runnable}
+            metadata={metadata}
+          />
         </div>
       </div>
     );
@@ -871,8 +892,8 @@ var Autodocs = React.createClass({
     }
 
     return (
-      <div>
-        {(docs.examples.length > 1) ? <H level={3}>Examples</H> : null}
+      <div key={randomKey()}>
+        {(docs.examples.length > 1) ? <H key={randomKey()} level={3}>Examples</H> : null}
         {docs.examples.map(example => this.renderExample(example, metadata))}
       </div>
     );
@@ -882,16 +903,17 @@ var Autodocs = React.createClass({
     var metadata = this.props.metadata;
     var docs = JSON.parse(this.props.children);
     var content  = docs.type === 'component' || docs.type === 'style' ?
-      <ComponentDoc content={docs} /> :
-      <APIDoc content={docs} apiName={metadata.title} />;
+      <ComponentDoc key={randomKey()} content={docs} /> :
+      <APIDoc key={randomKey()} content={docs} apiName={metadata.title} />;
 
     return (
-      <Site section="docs" title={metadata.title}>
-        <section className="content wrap documentationContent">
-          <DocsSidebar metadata={metadata} />
-          <div className="inner-content">
-            <a id="content" />
+      <Site key={randomKey()} section="docs" title={metadata.title}>
+        <section key={randomKey()} className="content wrap documentationContent">
+          <DocsSidebar key={randomKey()} metadata={metadata} />
+          <div key={randomKey()} className="inner-content">
+            <a key={randomKey()} id="content" />
             <HeaderWithGithub
+              key={randomKey()}
               title={metadata.title}
               level={1}
               path={metadata.path}
@@ -899,9 +921,19 @@ var Autodocs = React.createClass({
             {content}
             {this.renderFullDescription(docs)}
             {this.renderExamples(docs, metadata)}
-            <div className="docs-prevnext">
-              {metadata.previous && <a className="docs-prev" href={'docs/' + metadata.previous + '.html#content'}>&larr; Prev</a>}
-              {metadata.next && <a className="docs-next" href={'docs/' + metadata.next + '.html#content'}>Next &rarr;</a>}
+            <div key={randomKey()} className="docs-prevnext">
+              {metadata.previous &&
+               <a
+                 key={randomKey()}
+                 className="docs-prev"
+                 href={'docs/' + metadata.previous + '.html#content'}>&larr; Prev</a>
+              }
+              {metadata.next &&
+               <a
+                 key={randomKey()}
+                 className="docs-next"
+                 href={'docs/' + metadata.next + '.html#content'}>Next &rarr;</a>
+              }
             </div>
           </div>
         </section>

--- a/website/layout/AutodocsLayout.js
+++ b/website/layout/AutodocsLayout.js
@@ -21,7 +21,7 @@ var React = require('React');
 var Site = require('Site');
 var slugify = require('slugify');
 var Metadata = require('Metadata');
-var randomKey = require('randomKey');
+var sequentialKey = require('sequentialKey');
 
 var styleReferencePattern = /^[^.]+\.propTypes\.style$/;
 
@@ -60,7 +60,7 @@ function renderType(type) {
   }
 
   if (type.name === 'arrayOf') {
-    return <span key={randomKey()}>[{renderType(type.value)}]</span>;
+    return <span key={sequentialKey()}>[{renderType(type.value)}]</span>;
   }
 
   if (type.name === 'instanceOf') {
@@ -70,10 +70,10 @@ function renderType(type) {
   if (type.name === 'custom') {
     if (styleReferencePattern.test(type.raw)) {
       var name = type.raw.substring(0, type.raw.indexOf('.'));
-      return <a key={randomKey()} href={'docs/' + slugify(name) + '.html#style'}>{name}#style</a>;
+      return <a key={sequentialKey()} href={'docs/' + slugify(name) + '.html#style'}>{name}#style</a>;
     }
     if (type.raw === 'ColorPropType') {
-      return <a key={randomKey()} href={'docs/colors.html'}>color</a>;
+      return <a key={sequentialKey()} href={'docs/colors.html'}>color</a>;
     }
     if (type.raw === 'EdgeInsetsPropType') {
       return '{top: number, left: number, bottom: number, right: number}';
@@ -109,7 +109,7 @@ function renderTypeNameLink(typeName, docPath, namedTypes) {
   if (ignoreTypes.indexOf(typeNameLower) !== -1 || !namedTypes[typeNameLower]) {
     return typeName;
   }
-  return <a key={randomKey()} href={docPath + '#' + typeNameLower}>{typeName}</a>;
+  return <a key={sequentialKey()} href={docPath + '#' + typeNameLower}>{typeName}</a>;
 }
 
 function renderTypeWithLinks(type, docTitle, namedTypes) {
@@ -119,7 +119,7 @@ function renderTypeWithLinks(type, docTitle, namedTypes) {
 
   const docPath = docTitle ? 'docs/' + docTitle.toLowerCase() + '.html' : 'docs/';
   return (
-    <div key={randomKey()}>
+    <div key={sequentialKey()}>
       {
         type.names.map((typeName, index, array) => {
           let separator = index < array.length - 1 && ' | ';
@@ -191,28 +191,28 @@ var ComponentDoc = React.createClass({
   renderProp: function(name, prop) {
     return (
       <div className="prop" key={name}>
-        <Header key={randomKey()} level={4} className="propTitle" toSlug={name}>
+        <Header key={sequentialKey()} level={4} className="propTitle" toSlug={name}>
           {prop.platforms && prop.platforms.map(platform =>
-            <span key={randomKey()} className="platform">{platform}</span>
+            <span key={sequentialKey()} className="platform">{platform}</span>
           )}
           {name}
           {' '}
-          {prop.type && <span key={randomKey()} className="propType">
+          {prop.type && <span key={sequentialKey()} className="propType">
             {renderType(prop.type)}
           </span>}
         </Header>
-        {prop.deprecationMessage && <div key={randomKey()} className="deprecated">
-          <div key={randomKey()} className="deprecatedTitle">
-            <img key={randomKey()} className="deprecatedIcon" src="img/Warning.png" />
-            <span key={randomKey()}>Deprecated</span>
+        {prop.deprecationMessage && <div key={sequentialKey()} className="deprecated">
+          <div key={sequentialKey()} className="deprecatedTitle">
+            <img key={sequentialKey()} className="deprecatedIcon" src="img/Warning.png" />
+            <span key={sequentialKey()}>Deprecated</span>
           </div>
-          <div key={randomKey()} className="deprecatedMessage">
-            <Marked key={randomKey()}>{prop.deprecationMessage}</Marked>
+          <div key={sequentialKey()} className="deprecatedMessage">
+            <Marked key={sequentialKey()}>{prop.deprecationMessage}</Marked>
           </div>
         </div>}
         {prop.type && prop.type.name === 'stylesheet' &&
           this.renderStylesheetProps(prop.type.value)}
-        {prop.description && <Marked key={randomKey()}>{prop.description}</Marked>}
+        {prop.description && <Marked key={sequentialKey()}>{prop.description}</Marked>}
       </div>
     );
   },
@@ -220,8 +220,8 @@ var ComponentDoc = React.createClass({
   renderCompose: function(name) {
     return (
       <div className="prop" key={name}>
-        <Header key={randomKey()} level={4} className="propTitle" toSlug={name}>
-          <a key={randomKey()} href={'docs/' + slugify(name) + '.html#props'}>{name} props...</a>
+        <Header key={sequentialKey()} level={4} className="propTitle" toSlug={name}>
+          <a key={sequentialKey()} href={'docs/' + slugify(name) + '.html#props'}>{name} props...</a>
         </Header>
       </div>
     );
@@ -230,17 +230,17 @@ var ComponentDoc = React.createClass({
   renderStylesheetProp: function(name, prop) {
     return (
       <div className="prop" key={name}>
-        <h6 key={randomKey()} className="propTitle">
+        <h6 key={sequentialKey()} className="propTitle">
           {prop.platforms && prop.platforms.map(platform =>
-            <span key={randomKey()} className="platform">{platform}</span>
+            <span key={sequentialKey()} className="platform">{platform}</span>
           )}
           {name}
           {' '}
-          {prop.type && <span key={randomKey()} className="propType">
+          {prop.type && <span key={sequentialKey()} className="propType">
             {renderType(prop.type)}
           </span>}
           {' '}
-          {prop.description && <Marked key={randomKey()}>{prop.description}</Marked>}
+          {prop.description && <Marked key={sequentialKey()}>{prop.description}</Marked>}
         </h6>
       </div>
     );
@@ -250,25 +250,25 @@ var ComponentDoc = React.createClass({
     var style = this.props.content.styles[stylesheetName];
     this.extractPlatformFromProps(style.props);
     return (
-      <div key={randomKey()} className="compactProps">
+      <div key={sequentialKey()} className="compactProps">
         {(style.composes || []).map((name) => {
           var link;
           if (name === 'LayoutPropTypes') {
             name = 'Flexbox';
             link =
-              <a key={randomKey()} href={'docs/' + slugify(name) + '.html#proptypes'}>{name}...</a>;
+              <a key={sequentialKey()} href={'docs/' + slugify(name) + '.html#proptypes'}>{name}...</a>;
           } else if (name === 'TransformPropTypes') {
             name = 'Transforms';
             link =
-              <a key={randomKey()} href={'docs/' + slugify(name) + '.html#proptypes'}>{name}...</a>;
+              <a key={sequentialKey()} href={'docs/' + slugify(name) + '.html#proptypes'}>{name}...</a>;
           } else {
             name = name.replace('StylePropTypes', '');
             link =
-              <a key={randomKey()} href={'docs/' + slugify(name) + '.html#style'}>{name}#style...</a>;
+              <a key={sequentialKey()} href={'docs/' + slugify(name) + '.html#style'}>{name}#style...</a>;
           }
           return (
-            <div key={randomKey()} className="prop" key={name}>
-              <h6 key={randomKey()} className="propTitle">{link}</h6>
+            <div key={sequentialKey()} className="prop" key={name}>
+              <h6 key={sequentialKey()} className="propTitle">{link}</h6>
             </div>
           );
         })}
@@ -282,7 +282,7 @@ var ComponentDoc = React.createClass({
 
   renderProps: function(props, composes) {
     return (
-      <div key={randomKey()} className="props">
+      <div key={sequentialKey()} className="props">
         {(composes || []).map((name) =>
           this.renderCompose(name)
         )}
@@ -327,9 +327,9 @@ var ComponentDoc = React.createClass({
       return null;
     }
     return (
-      <span key={randomKey()}>
-        <H key={randomKey()}level={3}>Methods</H>
-        <div key={randomKey()} className="props">
+      <span key={sequentialKey()}>
+        <H key={sequentialKey()}level={3}>Methods</H>
+        <div key={sequentialKey()} className="props">
           {methods.filter((method) => {
             return method.name[0] !== '_';
           }).map(method => this.renderMethod(method, namedTypes))}
@@ -358,9 +358,9 @@ var ComponentDoc = React.createClass({
       return null;
     }
     return (
-      <span key={randomKey()}>
-        <H key={randomKey()} level={3}>Type Definitions</H>
-        <div key={randomKey()} className="props">
+      <span key={sequentialKey()}>
+        <H key={sequentialKey()} level={3}>Type Definitions</H>
+        <div key={sequentialKey()} className="props">
           {typedefs.map((typedef) => {
             return this.renderTypeDef(typedef, namedTypes);
           })}
@@ -374,11 +374,11 @@ var ComponentDoc = React.createClass({
     this.extractPlatformFromProps(content.props);
     const namedTypes = getNamedTypes(content.typedef);
     return (
-      <div key={randomKey()}>
-        <Marked key={randomKey()}>
+      <div key={sequentialKey()}>
+        <Marked key={sequentialKey()}>
           {content.description}
         </Marked>
-        <H key={randomKey()} level={3}>Props</H>
+        <H key={sequentialKey()} level={3}>Props</H>
         {this.renderProps(content.props, content.composes)}
         {this.renderMethods(content.methods, namedTypes)}
         {this.renderTypeDefs(content.typedef, namedTypes)}
@@ -409,9 +409,9 @@ var APIDoc = React.createClass({
       return null;
     }
     return (
-      <span key={randomKey()}>
-        <H key={randomKey()} level={3}>Methods</H>
-        <div key={randomKey()} className="props">
+      <span key={sequentialKey()}>
+        <H key={sequentialKey()} level={3}>Methods</H>
+        <div key={sequentialKey()} className="props">
           {methods.filter((method) => {
             return method.name[0] !== '_';
           }).map(method => this.renderMethod(method, namedTypes))}
@@ -422,16 +422,16 @@ var APIDoc = React.createClass({
 
   renderProperty: function(property) {
     return (
-      <div key={randomKey()} className="prop" key={property.name}>
-        <Header key={randomKey()} level={4} className="propTitle" toSlug={property.name}>
+      <div key={sequentialKey()} className="prop" key={property.name}>
+        <Header key={sequentialKey()} level={4} className="propTitle" toSlug={property.name}>
           {property.name}
           {property.type &&
-            <span key={randomKey()} className="propType">
+            <span key={sequentialKey()} className="propType">
               {': ' + renderType(property.type)}
             </span>
           }
         </Header>
-        {property.docblock && <Marked key={randomKey()}>
+        {property.docblock && <Marked key={sequentialKey()}>
           {removeCommentsFromDocblock(property.docblock)}
         </Marked>}
       </div>
@@ -443,9 +443,9 @@ var APIDoc = React.createClass({
       return null;
     }
     return (
-      <span key={randomKey()}>
-        <H key={randomKey()} level={3}>Properties</H>
-        <div key={randomKey()} className="props">
+      <span key={sequentialKey()}>
+        <H key={sequentialKey()} level={3}>Properties</H>
+        <div key={sequentialKey()} className="props">
           {properties.filter((property) => {
             return property.name[0] !== '_';
           }).map(this.renderProperty)}
@@ -459,18 +459,18 @@ var APIDoc = React.createClass({
       return null;
     }
     return (
-      <span key={randomKey()}>
-        <div key={randomKey()}>
+      <span key={sequentialKey()}>
+        <div key={sequentialKey()}>
           {classes.filter((cls) => {
             return cls.name[0] !== '_' && cls.ownerProperty[0] !== '_';
           }).map((cls) => {
             return (
               <span key={cls.name}>
-                <Header key={randomKey()} level={2} toSlug={cls.name}>
+                <Header key={sequentialKey()} level={2} toSlug={cls.name}>
                   class {cls.name}
                 </Header>
-                <ul key={randomKey()}>
-                  {cls.docblock && <Marked key={randomKey()}>
+                <ul key={sequentialKey()}>
+                  {cls.docblock && <Marked key={sequentialKey()}>
                     {removeCommentsFromDocblock(cls.docblock)}
                   </Marked>}
                   {this.renderMethods(cls.methods, namedTypes)}
@@ -504,9 +504,9 @@ var APIDoc = React.createClass({
       return null;
     }
     return (
-      <span key={randomKey()}>
-        <H key={randomKey()} level={3}>Type Definitions</H>
-        <div key={randomKey()} className="props">
+      <span key={sequentialKey()}>
+        <H key={sequentialKey()} level={3}>Type Definitions</H>
+        <div key={sequentialKey()} className="props">
           {typedefs.map((typedef) => {
             return this.renderTypeDef(typedef, namedTypes);
           })}
@@ -518,14 +518,14 @@ var APIDoc = React.createClass({
   renderMainDescription: function(content) {
     if (content.docblock) {
       return (
-        <Marked key={randomKey()}>
+        <Marked key={sequentialKey()}>
           {removeCommentsFromDocblock(content.docblock)}
         </Marked>
       );
     }
     if (content.class && content.class.length && content.class[0].description) {
       return (
-        <Marked key={randomKey()}>
+        <Marked key={sequentialKey()}>
           {content.class[0].description}
         </Marked>
       );
@@ -542,7 +542,7 @@ var APIDoc = React.createClass({
     }
     const namedTypes = getNamedTypes(content.typedef);
     return (
-      <div key={randomKey()}>
+      <div key={sequentialKey()}>
         {this.renderMainDescription(content)}
         {this.renderMethods(content.methods, namedTypes)}
         {this.renderProperties(content.properties)}
@@ -591,10 +591,10 @@ var Method = React.createClass({
       const code = example.replace(/<caption>.*?<\/caption>/ig, '')
         .replace(/^\n\n/, '');
       return (
-        <div key={randomKey()}>
-          <br key={randomKey()} />
+        <div key={sequentialKey()}>
+          <br key={sequentialKey()} />
           {caption}
-          <Prism key={randomKey()}>
+          <Prism key={sequentialKey()}>
             {code}
           </Prism>
         </div>
@@ -614,26 +614,26 @@ var Method = React.createClass({
       return null;
     }
     return (
-      <div key={randomKey()}>
-        <strong key={randomKey()}>Parameters:</strong>
-          <table key={randomKey()} className="params">
-            <thead key={randomKey()}>
-              <tr key={randomKey()}>
-                <th key={randomKey()}>Name and Type</th>
-                <th key={randomKey()}>Description</th>
+      <div key={sequentialKey()}>
+        <strong key={sequentialKey()}>Parameters:</strong>
+          <table key={sequentialKey()} className="params">
+            <thead key={sequentialKey()}>
+              <tr key={sequentialKey()}>
+                <th key={sequentialKey()}>Name and Type</th>
+                <th key={sequentialKey()}>Description</th>
               </tr>
             </thead>
-            <tbody key={randomKey()}>
+            <tbody key={sequentialKey()}>
               {params.map((param) => {
                 return (
-                  <tr key={randomKey()}>
-                    <td key={randomKey()}>
+                  <tr key={sequentialKey()}>
+                    <td key={sequentialKey()}>
                       {param.optional ? '[' + param.name + ']' : param.name}
-                      <br key={randomKey()} /><br key={randomKey()} />
+                      <br key={sequentialKey()} /><br key={sequentialKey()} />
                       {renderTypeWithLinks(param.type, this.props.apiName, this.props.namedTypes)}
                     </td>
-                    <td key={randomKey()} className="description">
-                      <Marked key={randomKey()}>{param.description}</Marked>
+                    <td key={sequentialKey()} className="description">
+                      <Marked key={sequentialKey()}>{param.description}</Marked>
                     </td>
                   </tr>
                 );
@@ -646,14 +646,14 @@ var Method = React.createClass({
 
   render: function() {
     return (
-      <div key={randomKey()} className="prop">
-        <Header key={randomKey()} level={4} className="methodTitle" toSlug={this.props.name}>
+      <div key={sequentialKey()} className="prop">
+        <Header key={sequentialKey()} level={4} className="methodTitle" toSlug={this.props.name}>
           {this.props.modifiers && this.props.modifiers.length &&
-          <span key={randomKey()} className="methodType">
+          <span key={sequentialKey()} className="methodType">
             {this.props.modifiers.join(' ') + ' '}
           </span> || ''}
           {this.props.name}
-          <span key={randomKey()} className="methodType">
+          <span key={sequentialKey()} className="methodType">
             ({this.props.params && this.props.params.length && this.props.params
               .map((param) => {
                 var res = param.name;
@@ -664,7 +664,7 @@ var Method = React.createClass({
               {this.props.returns && ': ' + this.renderTypehint(this.props.returns.type)}
           </span>
         </Header>
-        {this.props.description && <Marked key={randomKey()}>
+        {this.props.description && <Marked key={sequentialKey()}>
           {this.props.description}
         </Marked>}
         {this.renderMethodParameters(this.props.params)}
@@ -683,27 +683,27 @@ var TypeDef = React.createClass({
       return null;
     }
     return (
-      <div key={randomKey()}>
-        <br key={randomKey()} />
-        <strong key={randomKey()}>Properties:</strong>
-          <table key={randomKey()} className="params">
-            <thead key={randomKey()}>
-              <tr key={randomKey()}>
-                <th key={randomKey()}>Name and Type</th>
-                <th key={randomKey()}>Description</th>
+      <div key={sequentialKey()}>
+        <br key={sequentialKey()} />
+        <strong key={sequentialKey()}>Properties:</strong>
+          <table key={sequentialKey()} className="params">
+            <thead key={sequentialKey()}>
+              <tr key={sequentialKey()}>
+                <th key={sequentialKey()}>Name and Type</th>
+                <th key={sequentialKey()}>Description</th>
               </tr>
             </thead>
-            <tbody key={randomKey()}>
+            <tbody key={sequentialKey()}>
               {properties.map((property) => {
                 return (
-                  <tr key={randomKey()}>
-                    <td key={randomKey()}>
+                  <tr key={sequentialKey()}>
+                    <td key={sequentialKey()}>
                       {property.optional ? '[' + property.name + ']' : property.name}
-                      <br key={randomKey()} /><br key={randomKey()} />
+                      <br key={sequentialKey()} /><br key={sequentialKey()} />
                       {renderTypeWithLinks(property.type, this.props.apiName, this.props.namedTypes)}
                     </td>
-                    <td key={randomKey()} className="description">
-                      <Marked key={randomKey()}>{property.description}</Marked>
+                    <td key={sequentialKey()} className="description">
+                      <Marked key={sequentialKey()}>{property.description}</Marked>
                     </td>
                   </tr>
                 );
@@ -722,25 +722,25 @@ var TypeDef = React.createClass({
       return null;
     }
     return (
-      <div key={randomKey()}>
-        <br key={randomKey()} />
-        <strong key={randomKey()}>Constants:</strong>
-        <table key={randomKey()} className="params">
-          <thead key={randomKey()}>
-            <tr key={randomKey()}>
-              <th key={randomKey()}>Value</th>
-              <th key={randomKey()}>Description</th>
+      <div key={sequentialKey()}>
+        <br key={sequentialKey()} />
+        <strong key={sequentialKey()}>Constants:</strong>
+        <table key={sequentialKey()} className="params">
+          <thead key={sequentialKey()}>
+            <tr key={sequentialKey()}>
+              <th key={sequentialKey()}>Value</th>
+              <th key={sequentialKey()}>Description</th>
             </tr>
           </thead>
-          <tbody key={randomKey()}>
+          <tbody key={sequentialKey()}>
             {values.map((value) => {
               return (
-                <tr key={randomKey()}>
-                  <td key={randomKey()}>
+                <tr key={sequentialKey()}>
+                  <td key={sequentialKey()}>
                     {value.name}
                   </td>
-                  <td key={randomKey()} className="description">
-                    <Marked key={randomKey()}>{value.description}</Marked>
+                  <td key={sequentialKey()} className="description">
+                    <Marked key={sequentialKey()}>{value.description}</Marked>
                   </td>
                 </tr>
               );
@@ -753,15 +753,15 @@ var TypeDef = React.createClass({
 
   render: function() {
     return (
-      <div key={randomKey()} className="prop">
-        <Header key={randomKey()} level={4} className="propTitle" toSlug={this.props.name}>
+      <div key={sequentialKey()} className="prop">
+        <Header key={sequentialKey()} level={4} className="propTitle" toSlug={this.props.name}>
           {this.props.name}
         </Header>
-        {this.props.description && <Marked key={randomKey()}>
+        {this.props.description && <Marked key={sequentialKey()}>
           {this.props.description}
         </Marked>}
-        <strong key={randomKey()}>Type:</strong>
-        <br key={randomKey()} />
+        <strong key={sequentialKey()}>Type:</strong>
+        <br key={sequentialKey()} />
         {this.props.type.names.join(' | ')}
         {this.renderProperties(this.props.properties)}
         {this.renderValues(this.props.values)}
@@ -779,21 +779,21 @@ var EmbeddedSimulator = React.createClass({
     var metadata = this.props.metadata;
 
     var imagePreview = metadata.platform === 'android'
-      ? <img key={randomKey()} alt="Run example in simulator" width="170" height="338" src="img/uiexplorer_main_android.png" />
-      : <img key={randomKey()} alt="Run example in simulator" width="170"
+      ? <img key={sequentialKey()} alt="Run example in simulator" width="170" height="338" src="img/uiexplorer_main_android.png" />
+      : <img key={sequentialKey()} alt="Run example in simulator" width="170"
              height="356" src="img/uiexplorer_main_ios.png" />;
 
     return (
-      <div key={randomKey()} className="embedded-simulator">
-        <p key={randomKey()}>
-          <a key={randomKey()}className="modal-button-open">
-            <strong key={randomKey()}>Run this example</strong>
+      <div key={sequentialKey()} className="embedded-simulator">
+        <p key={sequentialKey()}>
+          <a key={sequentialKey()}className="modal-button-open">
+            <strong key={sequentialKey()}>Run this example</strong>
           </a>
         </p>
-        <div key={randomKey()} className="modal-button-open modal-button-open-img">
+        <div key={sequentialKey()} className="modal-button-open modal-button-open-img">
           {imagePreview}
         </div>
-        <Modal key={randomKey()} metadata={metadata} />
+        <Modal key={sequentialKey()} metadata={metadata} />
       </div>
     );
   }
@@ -809,19 +809,19 @@ var Modal = React.createClass({
       : `https://appetize.io/embed/7vdfm9h3e6vuf4gfdm7r5rgc48?device=iphone6s&scale=60&autoplay=false&orientation=portrait&deviceColor=white&params=${encodedParams}`;
 
     return (
-      <div key={randomKey()}>
-        <div key={randomKey()} className="modal">
-          <div key={randomKey()} className="modal-content">
-            <button key={randomKey()} className="modal-button-close">&times;</button>
-            <div key={randomKey()} className="center">
-              <iframe key={randomKey()} className="simulator" src={url} width="256" height="550" frameBorder="0" scrolling="no"></iframe>
-              <p key={randomKey()}>Powered by
-                <a key={randomKey()} target="_blank" href="https://appetize.io">appetize.io</a>
+      <div key={sequentialKey()}>
+        <div key={sequentialKey()} className="modal">
+          <div key={sequentialKey()} className="modal-content">
+            <button key={sequentialKey()} className="modal-button-close">&times;</button>
+            <div key={sequentialKey()} className="center">
+              <iframe key={sequentialKey()} className="simulator" src={url} width="256" height="550" frameBorder="0" scrolling="no"></iframe>
+              <p key={sequentialKey()}>Powered by
+                <a key={sequentialKey()} target="_blank" href="https://appetize.io">appetize.io</a>
               </p>
             </div>
           </div>
         </div>
-        <div key={randomKey()} className="modal-backdrop" />
+        <div key={sequentialKey()} className="modal-backdrop" />
       </div>
     );
   }
@@ -845,13 +845,13 @@ var Autodocs = React.createClass({
       return;
     }
     return (
-      <div key={randomKey()}>
+      <div key={sequentialKey()}>
         <HeaderWithGithub
-          key={randomKey()}
+          key={sequentialKey()}
           title="Description"
           path={'docs/' + docs.componentName + '.md'}
         />
-        <Marked key={randomKey()}>
+        <Marked key={sequentialKey()}>
           {docs.fullDescription}
         </Marked>
       </div>
@@ -864,20 +864,20 @@ var Autodocs = React.createClass({
     }
 
     return (
-      <div key={randomKey()}>
+      <div key={sequentialKey()}>
         <HeaderWithGithub
-          key={randomKey()}
+          key={sequentialKey()}
           title={example.title || 'Examples'}
           level={example.title ? 4 : 3}
           path={example.path}
           metadata={metadata}
         />
-        <div key={randomKey()} className="example-container">
-          <Prism key={randomKey()}>
+        <div key={sequentialKey()} className="example-container">
+          <Prism key={sequentialKey()}>
            {example.content.replace(/^[\s\S]*?\*\//, '').trim()}
           </Prism>
           <EmbeddedSimulator
-            key={randomKey()}
+            key={sequentialKey()}
             shouldRender={metadata.runnable}
             metadata={metadata}
           />
@@ -892,8 +892,8 @@ var Autodocs = React.createClass({
     }
 
     return (
-      <div key={randomKey()}>
-        {(docs.examples.length > 1) ? <H key={randomKey()} level={3}>Examples</H> : null}
+      <div key={sequentialKey()}>
+        {(docs.examples.length > 1) ? <H key={sequentialKey()} level={3}>Examples</H> : null}
         {docs.examples.map(example => this.renderExample(example, metadata))}
       </div>
     );
@@ -903,17 +903,17 @@ var Autodocs = React.createClass({
     var metadata = this.props.metadata;
     var docs = JSON.parse(this.props.children);
     var content  = docs.type === 'component' || docs.type === 'style' ?
-      <ComponentDoc key={randomKey()} content={docs} /> :
-      <APIDoc key={randomKey()} content={docs} apiName={metadata.title} />;
+      <ComponentDoc key={sequentialKey()} content={docs} /> :
+      <APIDoc key={sequentialKey()} content={docs} apiName={metadata.title} />;
 
     return (
-      <Site key={randomKey()} section="docs" title={metadata.title}>
-        <section key={randomKey()} className="content wrap documentationContent">
-          <DocsSidebar key={randomKey()} metadata={metadata} />
-          <div key={randomKey()} className="inner-content">
-            <a key={randomKey()} id="content" />
+      <Site key={sequentialKey()} section="docs" title={metadata.title}>
+        <section key={sequentialKey()} className="content wrap documentationContent">
+          <DocsSidebar key={sequentialKey()} metadata={metadata} />
+          <div key={sequentialKey()} className="inner-content">
+            <a key={sequentialKey()} id="content" />
             <HeaderWithGithub
-              key={randomKey()}
+              key={sequentialKey()}
               title={metadata.title}
               level={1}
               path={metadata.path}
@@ -921,16 +921,16 @@ var Autodocs = React.createClass({
             {content}
             {this.renderFullDescription(docs)}
             {this.renderExamples(docs, metadata)}
-            <div key={randomKey()} className="docs-prevnext">
+            <div key={sequentialKey()} className="docs-prevnext">
               {metadata.previous &&
                <a
-                 key={randomKey()}
+                 key={sequentialKey()}
                  className="docs-prev"
                  href={'docs/' + metadata.previous + '.html#content'}>&larr; Prev</a>
               }
               {metadata.next &&
                <a
-                 key={randomKey()}
+                 key={sequentialKey()}
                  className="docs-next"
                  href={'docs/' + metadata.next + '.html#content'}>Next &rarr;</a>
               }


### PR DESCRIPTION
For the guides and Components/APIs, we would continuously get:

  `Warning: Each child in an array or iterator should have a unique "key" prop.`

when rendering them.

<img width="1254" alt="screenshot 2016-07-13 09 14 36" src="https://cloud.githubusercontent.com/assets/3757713/16807935/69f70954-48e8-11e6-8cee-3f0b950afa15.png">
<img width="1259" alt="screenshot 2016-07-13 09 14 04" src="https://cloud.githubusercontent.com/assets/3757713/16807937/6bd7aac6-48e8-11e6-8f64-7922b0477e6b.png">


This add `key` attributes to our DOM elements that did not have them in order
to remove this warning. It uses a random string generator to create unique keys.

> Should we establish the key a different or better way?

I went full hammer on this and put `key` attributes on everything. May have
been overkill, but the warnings are gone.

> Should I be more selective on what we put the `key` attribute on?

Also fixed a:

`Warning: Unknown DOM property frameborder. Did you mean frameBorder?`

issue as well.

Test Plan:

- No more warnings

<img width="1255" alt="screenshot 2016-07-13 10 57 49" src="https://cloud.githubusercontent.com/assets/3757713/16808008/b15693c8-48e8-11e6-8eb7-57be2eb7a9ea.png">


- Guides still render the same
- APIs still render the same (when applied with fix from
https://github.com/facebook/react-native/pull/8746)