### PR TITLE
Pull requests should target master branch

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,7 @@
 Thanks for submitting a pull request! Please provide enough information so that others can review your pull request:
 
-> **Unless you are cherry-picking an existing commit into a current release, ensure your pull request is targeting the `master` React Native branch.**
- 
+> **Unless you are a React Native release maintainer and cherry-picking an *existing* commit into a current release, ensure your pull request is targeting the `master` React Native branch.**
+
 (You can skip this if you're fixing a typo or adding an app to the Showcase.)
 
 Explain the **motivation** for making this change. What existing problem does the pull request solve?

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,7 @@
 Thanks for submitting a pull request! Please provide enough information so that others can review your pull request:
 
+> **Unless you are cherry-picking an existing commit into a current release, ensure your pull request is targeting the `master` React Native branch.**
+ 
 (You can skip this if you're fixing a typo or adding an app to the Showcase.)
 
 Explain the **motivation** for making this change. What existing problem does the pull request solve?

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ We will do our best to keep `master` in good shape, with tests passing at all ti
 
 The core team will be monitoring for pull requests. When we get one, we'll run some Facebook-specific integration tests on it first. From here, we'll need to get another person to sign off on the changes and then merge the pull request. For API changes we may need to fix internal uses, which could cause some delay. We'll do our best to provide updates and feedback throughout the process.
 
-Please submit your pull request on the *master* branch. If the fix is critical and should be included in a stable branch please mention it and it will be cherry picked into it.
+**Please submit your pull request on the `master` branch**. If the fix is critical and should be included in a stable branch please mention it and it will be cherry picked into it.
 
 *Before* submitting a pull request, please make sure the following is done…
 


### PR DESCRIPTION
Make it more obvious that pull requests should generally target the `master` branch. Provide visible clarity in both the `CONTRIBUTING.md` and the actual pull request template.

Test Plan:

- markdown renders correctly
- eyes