### PR TITLE
Change TextInput prop check to print instead of throw

### DIFF
--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -27,6 +27,7 @@ const TimerMixin = require('react-timer-mixin');
 const TouchableWithoutFeedback = require('TouchableWithoutFeedback');
 const UIManager = require('UIManager');
 const View = require('View');
+const warning = require('fbjs/lib/warning');
 
 const emptyFunction = require('fbjs/lib/emptyFunction');
 const invariant = require('fbjs/lib/invariant');
@@ -550,9 +551,10 @@ const TextInput = React.createClass({
       if (__DEV__) {
         for (var propKey in onlyMultiline) {
           if (props[propKey]) {
-            throw new Error(
+            const error = new Error(
               'TextInput prop `' + propKey + '` is only supported with multiline.'
             );
+            warning(false, '%s', error.stack);
           }
         }
       }


### PR DESCRIPTION
Follow up of https://github.com/facebook/react-native/pull/8499! Open to discussion

Motivation: 

See https://github.com/facebook/react-native/pull/8499#issuecomment-230004068

Goal is to have the same failure mode in dev and prod.

/cc @ide 