### PR TITLE
Upgrade to React v15.3.0-rc.2

### DIFF
--- a/Libraries/StyleSheet/StyleSheetValidation.js
+++ b/Libraries/StyleSheet/StyleSheetValidation.js
@@ -13,6 +13,7 @@
 
 var ImageStylePropTypes = require('ImageStylePropTypes');
 var ReactPropTypeLocations = require('react/lib/ReactPropTypeLocations');
+var ReactPropTypesSecret = require('react/lib/ReactPropTypesSecret');
 var TextStylePropTypes = require('TextStylePropTypes');
 var ViewStylePropTypes = require('ViewStylePropTypes');
 
@@ -33,7 +34,9 @@ class StyleSheetValidation {
       style,
       prop,
       caller,
-      ReactPropTypeLocations.prop
+      ReactPropTypeLocations.prop,
+      null,
+      ReactPropTypesSecret
     );
     if (error) {
       styleError(error.message, style, caller);

--- a/Libraries/Utilities/createStrictShapeTypeChecker.js
+++ b/Libraries/Utilities/createStrictShapeTypeChecker.js
@@ -12,6 +12,7 @@
 'use strict';
 
 var ReactPropTypeLocationNames = require('react/lib/ReactPropTypeLocationNames');
+var ReactPropTypesSecret = require('react/lib/ReactPropTypesSecret');
 
 var invariant = require('fbjs/lib/invariant');
 var merge = require('merge');
@@ -54,7 +55,7 @@ function createStrictShapeTypeChecker(
             `\nValid keys: ` + JSON.stringify(Object.keys(shapeTypes), null, '  ')
         );
       }
-      var error = checker(propValue, key, componentName, location);
+      var error = checker(propValue, key, componentName, location, null, ReactPropTypesSecret);
       if (error) {
         invariant(
           false,

--- a/Libraries/Utilities/deprecatedPropType.js
+++ b/Libraries/Utilities/deprecatedPropType.js
@@ -12,6 +12,8 @@
 'use strict';
 
 const UIManager = require('UIManager');
+const ReactPropTypesSecret = require('react/lib/ReactPropTypesSecret');
+const ReactPropTypeLocations = require('react/lib/ReactPropTypeLocations');
 
 /**
  * Adds a deprecation warning when the prop is used.
@@ -26,7 +28,14 @@ function deprecatedPropType(
       console.warn(`\`${propName}\` supplied to \`${componentName}\` has been deprecated. ${explanation}`);
     }
 
-    return propType(props, propName, componentName);
+    return propType(
+      props,
+      propName,
+      componentName,
+      ReactPropTypeLocations.prop,
+      null,
+      ReactPropTypesSecret
+    );
   };
 }
 

--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "react-native": "local-cli/wrong-react-native.js"
   },
   "peerDependencies": {
-    "react": "~15.2.0"
+    "react": "~15.3.0-rc.2"
   },
   "dependencies": {
     "absolute-path": "^0.0.0",
@@ -202,7 +202,7 @@
     "jest-repl": "^13.1.0",
     "jest-runtime": "^13.1.0",
     "portfinder": "0.4.0",
-    "react": "~15.2.0",
+    "react": "~15.3.0-rc.2",
     "shelljs": "0.6.0"
   }
 }


### PR DESCRIPTION
There were several fixes to how calls to propType checkers. This is to
account for the new deprecation warning - React.PropTypes will not be
part of production builds in the future.

Note: There is still a warning about an invalid argument to `React.PropTypes.oneOf` (React is running that validation sooner now). Specifically [both of these](https://github.com/facebook/react-native/blob/b1e49832ef3f9ffb0e5da2da7f847a8fae1d9c35/Libraries/Components/Touchable/TouchableWithoutFeedback.js#L44-L45) because `View.AccessibilityTraits` is actually undefined in tests (didn't look into why you conditionally set that).

**Test plan (required)**

`npm test` & fixed all warnings due to proptype secret