### PR TITLE
Scope RCTReloadNotification to one bridge

### DIFF
--- a/React/Base/RCTBatchedBridge.m
+++ b/React/Base/RCTBatchedBridge.m
@@ -620,6 +620,11 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithBundleURL:(__unused NSURL *)bundleUR
   [_parentBridge reload];
 }
 
+- (void)requestReload
+{
+  [_parentBridge requestReload];
+}
+
 - (Class)executorClass
 {
   return _parentBridge.executorClass ?: [RCTJSCExecutor class];

--- a/React/Base/RCTBridge.h
+++ b/React/Base/RCTBridge.h
@@ -21,8 +21,9 @@
 
 /**
  * This notification triggers a reload of all bridges currently running.
+ * Deprecated, use RCTBridge::requestReload instead.
  */
-RCT_EXTERN NSString *const RCTReloadNotification;
+RCT_EXTERN NSString *const RCTReloadNotification DEPRECATED_ATTRIBUTE;
 
 /**
  * This notification fires when the bridge starts loading the JS bundle.
@@ -182,6 +183,11 @@ RCT_EXTERN NSString *RCTBridgeModuleNameForClass(Class bridgeModuleClass);
  * Reload the bundle and reset executor & modules. Safe to call from any thread.
  */
 - (void)reload;
+
+/**
+ * Inform the bridge, and anything subscribing to it, that it should reload.
+ */
+- (void)requestReload;
 
 /**
  * Says whether bridge has started recieving calls from javascript.

--- a/React/Base/RCTBridge.m
+++ b/React/Base/RCTBridge.m
@@ -161,21 +161,15 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
 {
   RCTAssertMainQueue();
 
-  [[NSNotificationCenter defaultCenter] addObserver:self
-                                           selector:@selector(reload)
-                                               name:RCTReloadNotification
-                                             object:nil];
-
 #if TARGET_IPHONE_SIMULATOR
   RCTKeyCommands *commands = [RCTKeyCommands sharedInstance];
 
   // reload in current mode
+  __weak typeof(self) weakSelf = self;
   [commands registerKeyCommandWithInput:@"r"
                           modifierFlags:UIKeyModifierCommand
                                  action:^(__unused UIKeyCommand *command) {
-    [[NSNotificationCenter defaultCenter] postNotificationName:RCTReloadNotification
-                                                        object:nil
-                                                      userInfo:nil];
+    [weakSelf requestReload];
   }];
 #endif
 }
@@ -233,6 +227,12 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
     [self invalidate];
     [self setUp];
   });
+}
+
+- (void)requestReload
+{
+  [[NSNotificationCenter defaultCenter] postNotificationName:RCTReloadNotification object:self];
+  [self reload];
 }
 
 - (void)setUp

--- a/React/Modules/RCTDevMenu.m
+++ b/React/Modules/RCTDevMenu.m
@@ -566,9 +566,7 @@ RCT_EXPORT_METHOD(show)
 
 RCT_EXPORT_METHOD(reload)
 {
-  [[NSNotificationCenter defaultCenter] postNotificationName:RCTReloadNotification
-                                                      object:nil
-                                                    userInfo:nil];
+  [_bridge requestReload];
 }
 
 - (void)setShakeToShow:(BOOL)shakeToShow

--- a/React/Modules/RCTExceptionsManager.m
+++ b/React/Modules/RCTExceptionsManager.m
@@ -57,7 +57,7 @@ RCT_EXPORT_METHOD(reportFatalException:(NSString *)message
   static NSUInteger reloadRetries = 0;
   if (!RCT_DEBUG && reloadRetries < _maxReloadAttempts) {
     reloadRetries++;
-    [[NSNotificationCenter defaultCenter] postNotificationName:RCTReloadNotification object:nil];
+    [_bridge requestReload];
   } else {
     NSString *description = [@"Unhandled JS Exception: " stringByAppendingString:message];
     NSDictionary *errorInfo = @{ NSLocalizedDescriptionKey: description, RCTJSStackTraceKey: stack };

--- a/React/Modules/RCTRedBox.m
+++ b/React/Modules/RCTRedBox.m
@@ -450,7 +450,7 @@ RCT_EXPORT_METHOD(dismiss)
 }
 
 - (void)reloadFromRedBoxWindow:(__unused RCTRedBoxWindow *)redBoxWindow {
-  [[NSNotificationCenter defaultCenter] postNotificationName:RCTReloadNotification object:nil userInfo:nil];
+  [_bridge requestReload];
 }
 
 @end

--- a/React/Profiler/RCTProfile.m
+++ b/React/Profiler/RCTProfile.m
@@ -363,8 +363,7 @@ void RCTProfileUnhookModules(RCTBridge *bridge)
 
 + (void)reload
 {
-  [[NSNotificationCenter defaultCenter] postNotificationName:RCTReloadNotification
-                                                      object:NULL];
+  [RCTProfilingBridge() requestReload];
 }
 
 + (void)toggle:(UIButton *)target


### PR DESCRIPTION
At the moment, posting RCTReloadNotification in any circumstance causes all RCTBridge instances to reload. This change scopes the notification to the bridge for which it was intended.

Test plan: Run more than one RCTBridge and reload one of them.