### PR TITLE
Allow getters and setters in flow check

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -51,5 +51,7 @@ suppress_comment=\\(.\\|\n\\)*\\$FlowFixMe\\($\\|[^(]\\|(\\(>=0\\.\\(2[0-8]\\|1[
 suppress_comment=\\(.\\|\n\\)*\\$FlowIssue\\((\\(>=0\\.\\(2[0-8]\\|1[0-9]\\|[0-9]\\).[0-9]\\)? *\\(site=[a-z,_]*react_native[a-z,_]*\\)?)\\)?:? #[0-9]+
 suppress_comment=\\(.\\|\n\\)*\\$FlowFixedInNextDeploy
 
+unsafe.enable_getters_and_setters=true
+
 [version]
 ^0.28.0


### PR DESCRIPTION
We have static getters in [DatePickerAndroid](https://github.com/facebook/react-native/blob/master/Libraries/Components/DatePickerAndroid/DatePickerAndroid.android.js#L77) and  [TimePickerAndroid](https://github.com/facebook/react-native/blob/master/Libraries/Components/TimePickerAndroid/TimePickerAndroid.android.js#L60) already. Can we allow it in the config file?