### PR TITLE
add UIExplorer example of SwipeableListView

### DIFF
--- a/Examples/UIExplorer/js/SwipeableListViewExample.js
+++ b/Examples/UIExplorer/js/SwipeableListViewExample.js
@@ -1,0 +1,184 @@
+/**
+ * The examples provided by Facebook are for non-commercial testing and
+ * evaluation purposes only.
+ *
+ * Facebook reserves all rights not expressly granted.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON INFRINGEMENT. IN NO EVENT SHALL
+ * FACEBOOK BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * @flow
+ */
+'use strict';
+
+var React = require('react');
+var ReactNative = require('react-native');
+var {
+  Image,
+  SwipeableListView,
+  TouchableHighlight,
+  StyleSheet,
+  RecyclerViewBackedScrollView,
+  Text,
+  View,
+  Alert,
+} = ReactNative;
+
+var UIExplorerPage = require('./UIExplorerPage');
+
+var SwipeableListViewSimpleExample = React.createClass({
+  statics: {
+    title: '<SwipeableListView>',
+    description: 'Performant, scrollable, swipeable list of data.'
+  },
+
+  getInitialState: function() {
+    var ds = SwipeableListView.getNewDataSource();
+    return {
+      dataSource: ds.cloneWithRowsAndSections(...this._genDataSource({})),
+    };
+  },
+
+  _pressData: ({}: {[key: number]: boolean}),
+
+  componentWillMount: function() {
+    this._pressData = {};
+  },
+
+  render: function() {
+    return (
+      <UIExplorerPage
+        title={this.props.navigator ? null : '<SwipeableListView>'}
+        noSpacer={true}
+        noScroll={true}>
+        <SwipeableListView
+          dataSource={this.state.dataSource}
+          maxSwipeDistance={100}
+          renderQuickActions={(rowData: Object, sectionID: string, rowID: string) => {
+            return (<View style={styles.actionsContainer}>
+              <TouchableHighlight onPress={() => {
+                Alert.alert('Tips', 'You could do something with this row: ' + rowData.text);
+              }}>
+                <Text>Remove</Text>
+              </TouchableHighlight>
+            </View>);
+          }}
+          renderRow={this._renderRow}
+          renderScrollComponent={props => <RecyclerViewBackedScrollView {...props} />}
+          renderSeparator={this._renderSeperator}
+        />
+      </UIExplorerPage>
+    );
+  },
+
+  _renderRow: function(rowData: Object, sectionID: number, rowID: number, highlightRow: (sectionID: number, rowID: number) => void) {
+    var rowHash = Math.abs(hashCode(rowData.id));
+    var imgSource = THUMB_URLS[rowHash % THUMB_URLS.length];
+    return (
+      <TouchableHighlight onPress={() => {}}>
+        <View>
+          <View style={styles.row}>
+            <Image style={styles.thumb} source={imgSource} />
+            <Text style={styles.text}>
+              {rowData.id + ' - ' + LOREM_IPSUM.substr(0, rowHash % 301 + 10)}
+            </Text>
+          </View>
+        </View>
+      </TouchableHighlight>
+    );
+  },
+
+  _genDataSource: function(pressData: {[key: number]: boolean}): Array<any> {
+    var dataBlob = {};
+    var sectionIDs = ['Section 0'];
+    var rowIDs = [[]];
+    /**
+     * dataBlob example below:
+      {
+        'Section 0': {
+          'Row 0': {
+            id: '0',
+            text: 'row 0 text'
+          },
+          'Row 1': {
+            id: '1',
+            text: 'row 1 text'
+          }
+        }
+      }
+    */
+    // only one section in this example
+    dataBlob['Section 0'] = {};
+    for (var ii = 0; ii < 100; ii++) {
+      var pressedText = pressData[ii] ? ' (pressed)' : '';
+      dataBlob[sectionIDs[0]]['Row ' + ii] = {id: 'Row ' + ii, text: 'Row ' + ii + pressedText};
+      rowIDs[0].push('Row ' + ii);
+    }
+    return [dataBlob, sectionIDs, rowIDs];
+  },
+
+  _renderSeperator: function(sectionID: number, rowID: number, adjacentRowHighlighted: bool) {
+    return (
+      <View
+        key={`${sectionID}-${rowID}`}
+        style={{
+          height: adjacentRowHighlighted ? 4 : 1,
+          backgroundColor: adjacentRowHighlighted ? '#3B5998' : '#CCCCCC',
+        }}
+      />
+    );
+  }
+});
+
+var THUMB_URLS = [
+  require('./Thumbnails/like.png'),
+  require('./Thumbnails/dislike.png'),
+  require('./Thumbnails/call.png'),
+  require('./Thumbnails/fist.png'),
+  require('./Thumbnails/bandaged.png'),
+  require('./Thumbnails/flowers.png'),
+  require('./Thumbnails/heart.png'),
+  require('./Thumbnails/liking.png'),
+  require('./Thumbnails/party.png'),
+  require('./Thumbnails/poke.png'),
+  require('./Thumbnails/superlike.png'),
+  require('./Thumbnails/victory.png'),
+  ];
+var LOREM_IPSUM = 'Lorem ipsum dolor sit amet, ius ad pertinax oportere accommodare, an vix civibus corrumpit referrentur. Te nam case ludus inciderint, te mea facilisi adipiscing. Sea id integre luptatum. In tota sale consequuntur nec. Erat ocurreret mei ei. Eu paulo sapientem vulputate est, vel an accusam intellegam interesset. Nam eu stet pericula reprimique, ea vim illud modus, putant invidunt reprehendunt ne qui.';
+
+/* eslint no-bitwise: 0 */
+var hashCode = function(str) {
+  var hash = 15;
+  for (var ii = str.length - 1; ii >= 0; ii--) {
+    hash = ((hash << 5) - hash) + str.charCodeAt(ii);
+  }
+  return hash;
+};
+
+var styles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    padding: 10,
+    backgroundColor: '#F6F6F6',
+  },
+  thumb: {
+    width: 64,
+    height: 64,
+  },
+  text: {
+    flex: 1,
+  },
+  actionsContainer: {
+    flex: 1,
+    flexDirection: 'row',
+    justifyContent: 'flex-end',
+    alignItems: 'center',
+  },
+});
+
+module.exports = SwipeableListViewSimpleExample;

--- a/Examples/UIExplorer/js/UIExplorerList.android.js
+++ b/Examples/UIExplorer/js/UIExplorerList.android.js
@@ -75,6 +75,10 @@ var ComponentExamples: Array<UIExplorerExample> = [
     module: require('./StatusBarExample'),
   },
   {
+    key: 'SwipeableListViewExample',
+    module: require('./SwipeableListViewExample')
+  },
+  {
     key: 'SwitchExample',
     module: require('./SwitchExample'),
   },

--- a/Examples/UIExplorer/js/UIExplorerList.ios.js
+++ b/Examples/UIExplorer/js/UIExplorerList.ios.js
@@ -117,6 +117,10 @@ const ComponentExamples: Array<UIExplorerExample> = [
     module: require('./StatusBarExample'),
   },
   {
+    key: 'SwipeableListViewExample',
+    module: require('./SwipeableListViewExample')
+  },
+  {
     key: 'SwitchExample',
     module: require('./SwitchExample'),
   },


### PR DESCRIPTION
Q: Explain the **motivation** for making this change. What existing problem does the pull request solve?

A: There is no example for [`SwipeableListView`](https://github.com/facebook/react-native/tree/master/Libraries/Experimental/SwipeableRow) component, it would be helpful to add one.

**Test plan (required)**

Some screenshots here:

<img width="377" alt="screen shot 2016-07-14 at 21 47 50" src="https://cloud.githubusercontent.com/assets/1091472/16841629/af8392c4-4a0c-11e6-9f92-208aba514f36.png">

Tested on:

1. Simulators

    iPhone 4s, 5, 5s, 6, 6 Plus

