### PR TITLE
Added ability to set optional mimeType for Android WebView source

### DIFF
--- a/Libraries/Components/WebView/WebView.android.js
+++ b/Libraries/Components/WebView/WebView.android.js
@@ -108,6 +108,11 @@ var WebView = React.createClass({
          * The base URL to be used for any relative links in the HTML.
          */
         baseUrl: PropTypes.string,
+        /*
+         * Used to override the default mime type ("text/html; charset=utf-8")
+         * @platform android
+         */
+        mimeType: PropTypes.string
       }),
       /*
        * Used internally by packager.

--- a/Libraries/Components/WebView/WebView.ios.js
+++ b/Libraries/Components/WebView/WebView.ios.js
@@ -167,6 +167,11 @@ var WebView = React.createClass({
          * The base URL to be used for any relative links in the HTML.
          */
         baseUrl: PropTypes.string,
+        /*
+         * Used to override the default mime type ("text/html; charset=utf-8")
+         * @platform android
+         */
+        mimeType: PropTypes.string
       }),
       /*
        * Used internally by packager.

--- a/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebView.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ * <p/>
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+package com.facebook.react.views.webview;
+
+import android.annotation.SuppressLint;
+import android.text.TextUtils;
+import android.webkit.WebView;
+
+import com.facebook.react.bridge.LifecycleEventListener;
+import com.facebook.react.uimanager.ThemedReactContext;
+
+import javax.annotation.Nullable;
+
+/**
+ * Subclass of {@link WebView} that implements {@link LifecycleEventListener} interface in order
+ * to call {@link WebView#destroy} on activity destroy event and also to clear the client
+ */
+@SuppressLint("ViewConstructor")
+public class ReactWebView extends WebView implements LifecycleEventListener {
+  private
+  @Nullable
+  String injectedJS;
+
+  /**
+   * WebView must be created with an context of the current activity
+   * <p/>
+   * Activity Context is required for creation of dialogs internally by WebView
+   * Reactive Native needed for access to ReactNative internal system functionality
+   */
+  public ReactWebView(ThemedReactContext reactContext) {
+    super(reactContext);
+  }
+
+  @Override
+  public void onHostResume() {
+    // do nothing
+  }
+
+  @Override
+  public void onHostPause() {
+    // do nothing
+  }
+
+  @Override
+  public void onHostDestroy() {
+    cleanupCallbacksAndDestroy();
+  }
+
+  public void setInjectedJavaScript(@Nullable String js) {
+    injectedJS = js;
+  }
+
+  public void callInjectedJavaScript() {
+    if (getSettings().getJavaScriptEnabled() &&
+            injectedJS != null &&
+            !TextUtils.isEmpty(injectedJS)) {
+      loadUrl("javascript:(function() {\n" + injectedJS + ";\n})();");
+    }
+  }
+
+  public void cleanupCallbacksAndDestroy() {
+    setWebViewClient(null);
+    destroy();
+  }
+}

--- a/ReactAndroid/src/test/java/com/facebook/react/views/BUCK
+++ b/ReactAndroid/src/test/java/com/facebook/react/views/BUCK
@@ -27,6 +27,7 @@ robolectric3_test(
     react_native_target('java/com/facebook/react/views/text:text'),
     react_native_target('java/com/facebook/react/views/textinput:textinput'),
     react_native_target('java/com/facebook/react/views/view:view'),
+    react_native_target('java/com/facebook/react/views/webview:webview'),
     react_native_target('java/com/facebook/react:react'),
     react_native_tests_target('java/com/facebook/react/bridge:testhelpers'),
   ],

--- a/ReactAndroid/src/test/java/com/facebook/react/views/webview/ReactWebViewManagerTest.java
+++ b/ReactAndroid/src/test/java/com/facebook/react/views/webview/ReactWebViewManagerTest.java
@@ -1,0 +1,157 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ * <p/>
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+package com.facebook.react.views.webview;
+
+import android.webkit.WebView;
+
+import com.facebook.react.bridge.CatalystInstance;
+import com.facebook.react.bridge.JavaOnlyMap;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactTestHelper;
+import com.facebook.react.uimanager.ReactStylesDiffMap;
+import com.facebook.react.uimanager.ThemedReactContext;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.modules.junit4.rule.PowerMockRule;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(RobolectricTestRunner.class)
+@PowerMockIgnore({"org.mockito.*", "org.robolectric.*", "android.*"})
+public class ReactWebViewManagerTest {
+
+  @Rule
+  public PowerMockRule rule = new PowerMockRule();
+
+  private ThemedReactContext mThemeContext;
+  private static final String HTML = "<html/>";
+  private static final String CUSTOM_MIME_TYPE = "text/html";
+  private static final String BASE_URL = "base url";
+
+  @Before
+  public void setup() {
+    ReactApplicationContext mContext = new ReactApplicationContext(RuntimeEnvironment.application);
+    CatalystInstance mCatalystInstanceMock = ReactTestHelper.createMockCatalystInstance();
+    mContext.initializeWithInstance(mCatalystInstanceMock);
+    mThemeContext = new ThemedReactContext(mContext, mContext);
+  }
+
+  public ReactStylesDiffMap buildStyles(Object... keysAndValues) {
+    return new ReactStylesDiffMap(JavaOnlyMap.of(keysAndValues));
+  }
+
+  @Test
+  public void testSetSourceWithHtml() {
+    ReactWebViewManager viewManager = new ReactWebViewManager();
+    WebView view = viewManager.createViewInstance(mThemeContext);
+    view = Mockito.spy(view);
+    Mockito.doNothing().when(view).loadData(
+            Mockito.anyString(),
+            Mockito.anyString(),
+            Mockito.anyString());
+    JavaOnlyMap javaOnlyMap = JavaOnlyMap.of("html", HTML);
+    viewManager.updateProperties(view, buildStyles("source", javaOnlyMap));
+
+    Mockito.verify(view).loadData(
+            Mockito.eq(HTML),
+            Mockito.eq(ReactWebViewManager.HTML_MIME_TYPE),
+            Mockito.anyString());
+  }
+
+  @Test
+  public void testSetSourceWithHtmlAndMimeType() {
+    ReactWebViewManager viewManager = new ReactWebViewManager();
+    WebView view = viewManager.createViewInstance(mThemeContext);
+    view = Mockito.spy(view);
+    Mockito.doNothing().when(view).loadData(
+            Mockito.anyString(),
+            Mockito.anyString(),
+            Mockito.anyString());
+    JavaOnlyMap javaOnlyMap = JavaOnlyMap.of("html", HTML, "mimeType", CUSTOM_MIME_TYPE);
+    viewManager.updateProperties(view, buildStyles("source", javaOnlyMap));
+
+    Mockito.verify(view).loadData(
+            Mockito.eq(HTML),
+            Mockito.eq(CUSTOM_MIME_TYPE),
+            Mockito.anyString());
+  }
+
+  @Test
+  public void testSetSourceWithHtmlAndBaseUrl() {
+    ReactWebViewManager viewManager = new ReactWebViewManager();
+    WebView view = viewManager.createViewInstance(mThemeContext);
+    view = Mockito.spy(view);
+    Mockito.doNothing().when(view).loadDataWithBaseURL(
+            Mockito.anyString(),
+            Mockito.anyString(),
+            Mockito.anyString(),
+            Mockito.anyString(),
+            Mockito.anyString());
+    JavaOnlyMap javaOnlyMap = JavaOnlyMap.of("html", HTML, "baseUrl", BASE_URL);
+    viewManager.updateProperties(view, buildStyles("source", javaOnlyMap));
+
+    Mockito.verify(view).loadDataWithBaseURL(
+            Mockito.eq(BASE_URL),
+            Mockito.eq(HTML),
+            Mockito.eq(ReactWebViewManager.HTML_MIME_TYPE),
+            Mockito.anyString(),
+            Mockito.anyString());
+  }
+
+  @Test
+  public void testSetSourceWithHtmlAndBaseUrlAndMimeType() {
+    ReactWebViewManager viewManager = new ReactWebViewManager();
+    WebView view = viewManager.createViewInstance(mThemeContext);
+    view = Mockito.spy(view);
+    Mockito.doNothing().when(view).loadDataWithBaseURL(
+            Mockito.anyString(),
+            Mockito.anyString(),
+            Mockito.anyString(),
+            Mockito.anyString(),
+            Mockito.anyString());
+    JavaOnlyMap javaOnlyMap = JavaOnlyMap.of(
+            "html", HTML, "baseUrl", BASE_URL, "mimeType", CUSTOM_MIME_TYPE);
+    viewManager.updateProperties(view, buildStyles("source", javaOnlyMap));
+
+    Mockito.verify(view).loadDataWithBaseURL(
+            Mockito.eq(BASE_URL),
+            Mockito.eq(HTML),
+            Mockito.eq(CUSTOM_MIME_TYPE),
+            Mockito.anyString(),
+            Mockito.anyString());
+  }
+
+  @Test
+  public void testSetJavaScriptEnabled() {
+    ReactWebViewManager viewManager = new ReactWebViewManager();
+    WebView view = viewManager.createViewInstance(mThemeContext);
+    viewManager.updateProperties(view, buildStyles("javaScriptEnabled", true));
+
+    assertTrue(view.getSettings().getJavaScriptEnabled());
+  }
+
+  @Test
+  public void testSetScalesPageToFit() {
+    ReactWebViewManager viewManager = new ReactWebViewManager();
+    WebView view = viewManager.createViewInstance(mThemeContext);
+    viewManager.updateProperties(view, buildStyles("setScalesPageToFit", true));
+
+    assertFalse(view.getSettings().getUseWideViewPort());
+  }
+
+}


### PR DESCRIPTION
Using a WebView to render HTML on Android versions < 19 using the default mime type `text/html; charset=utf-8` does not work properly. It will render the html string instead:
<img width="362" alt="screen shot 2016-07-14 at 12 50 54 pm" src="https://cloud.githubusercontent.com/assets/2219308/16855097/a9252210-49c8-11e6-9506-fbd3206b85f1.png">

I have added an optional `mimeType` property to the `source` property for the WebView so you can override the default mime type. If I set this to `text/html` on older versions of Android like so:

``` javascript
<WebView
            style={ styles.chart }
            automaticallyAdjustContentInsets={ this.shouldScalePage() }
            source={ { html: ChartHtmlFactory.chart(this.props.type,
                                                    this.props.labels,
                                                    this.props.series,
                                                    options),
                      baseUrl: this.getBaseUrl(), 
                      mimeType: 'text/html' } }
            javaScriptEnabled={ true }
            domStorageEnabled={ true }
            decelerationRate='normal'
            startInLoadingState={ false }
            scalesPageToFit={ this.shouldScalePage() }
 />
```

Using the above code, the html renders correctly: 
<img width="377" alt="screen shot 2016-07-14 at 12 51 34 pm" src="https://cloud.githubusercontent.com/assets/2219308/16855130/d4314236-49c8-11e6-8c42-c17fcd9cf47a.png">

I have done a minor refactor to move `ReactWebView` to a separate class so it can be tested/mocked.

**Test plan**

I have added unit tests for this new property and a few others. I also confirmed it is working on older versions of Android (see above screenshots). 
