### PR TITLE
Fix description of AlertIOS.prompt()'s parameter defaultValue.

### DIFF
--- a/Libraries/Utilities/AlertIOS.js
+++ b/Libraries/Utilities/AlertIOS.js
@@ -163,7 +163,7 @@ class AlertIOS {
    *    example). `style` should be one of 'default', 'cancel' or 'destructive'.
    * @param type This configures the text input. One of 'plain-text',
    *    'secure-text' or 'login-password'.
-   * @param defaultValue The dialog's title.
+   * @param defaultValue The default text in text input.
    *
    * @example <caption>Example with custom buttons</caption>
    *


### PR DESCRIPTION
The description of `AlertIOS.prompt()` parameter `defaultValue` is wrong, correct it.