### PR TITLE
Remove exported constants from RCTTimers to allow lazy initialization

### DIFF
--- a/Libraries/JavaScriptAppEngine/System/JSTimers/JSTimers.js
+++ b/Libraries/JavaScriptAppEngine/System/JSTimers/JSTimers.js
@@ -101,11 +101,6 @@ var JSTimers = {
    * with time remaining in frame.
    */
   requestIdleCallback: function(func) {
-    if (!RCTTiming.setSendIdleEvents) {
-      console.warn('requestIdleCallback is not currently supported on this platform');
-      return requestAnimationFrame(func);
-    }
-
     if (JSTimersExecution.requestIdleCallbacks.length === 0) {
       RCTTiming.setSendIdleEvents(true);
     }

--- a/React/Modules/RCTTiming.m
+++ b/React/Modules/RCTTiming.m
@@ -16,6 +16,8 @@
 #import "RCTUtils.h"
 
 static const NSTimeInterval kMinimumSleepInterval = 1;
+
+// These timing contants should be kept in sync with the ones in `JSTimersExecution.js`.
 // The duration of a frame. This assumes that we want to run at 60 fps.
 static const NSTimeInterval kFrameDuration = 1.0 / 60.0;
 // The minimum time left in a frame to trigger the idle callback.
@@ -136,14 +138,6 @@ RCT_EXPORT_MODULE()
 - (dispatch_queue_t)methodQueue
 {
   return RCTJSThread;
-}
-
-- (NSDictionary *)constantsToExport
-{
-  return @{
-    @"frameDuration": @(kFrameDuration * 1000),
-    @"idleCallbackFrameDeadline": @(kIdleCallbackFrameDeadline * 1000),
-  };
 }
 
 - (void)invalidate

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/core/Timing.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/core/Timing.java
@@ -45,6 +45,7 @@ import javax.annotation.Nullable;
 public final class Timing extends ReactContextBaseJavaModule implements LifecycleEventListener,
   OnExecutorUnregisteredListener {
 
+  // These timing contants should be kept in sync with the ones in `JSTimersExecution.js`.
   // The minimum time in milliseconds left in the frame to call idle callbacks.
   private static final float IDLE_CALLBACK_FRAME_DEADLINE_MS = 1.f;
   // The total duration of a frame in milliseconds, this assumes that devices run at 60 fps.
@@ -307,13 +308,6 @@ public final class Timing extends ReactContextBaseJavaModule implements Lifecycl
   @Override
   public boolean supportsWebWorkers() {
     return true;
-  }
-
-  @Override
-  public Map<String, Object> getConstants() {
-    return MapBuilder.<String, Object>of(
-        "frameDuration", FRAME_DURATION_MS,
-        "idleCallbackFrameDeadline", IDLE_CALLBACK_FRAME_DEADLINE_MS);
   }
 
   @Override


### PR DESCRIPTION
As per @javache comments in #8734.

Also removes now useless feature detection check.

**Test plan**
Tested that rIC still works in UIExplorer example.