### PR TITLE
Add evaluateJavaScript to iOS WebView

### DIFF
--- a/Libraries/Components/WebView/WebView.ios.js
+++ b/Libraries/Components/WebView/WebView.ios.js
@@ -464,33 +464,24 @@ var WebView = React.createClass({
   /**
    * Evaluate JavaScript on the current page.
    */
-  evaluateJavaScript: function(
+  evaluateJavaScript: async function(
     script: string,
     callback?: ?(error: ?Error, result: ?string) => void,
   ): Promise {
-    return new Promise((resolve, reject) => {
-      var escaped = JSON.stringify(script).replace(/\u2028/g, '\\u2028').replace(/\u2029/g, '\\u2029');
-      var wrapped = 'JSON.stringify(eval(' + escaped + '))';
+    var escaped = JSON.stringify(script).replace(/\u2028/g, '\\u2028').replace(/\u2029/g, '\\u2029');
+    var wrapped = 'JSON.stringify(eval(' + escaped + '))';
+    var result = null;
 
-      RCTWebViewManager.evaluateJavaScript(this.getWebViewHandle(), wrapped, function(error, result) {
-        if (!error) {
-          if (result === '') {
-            error = new Error("Error evaluating script.")
-            result = null;
-          } else {
-            result = JSON.parse(result);
-          }
-        }
+    try {
+      var resultString = await RCTWebViewManager.evaluateJavaScript(this.getWebViewHandle(), wrapped);
+      result = JSON.parse(resultString);
+    } catch (e) {
+      callback && callback(e, null);
+      throw e;
+    }
 
-        callback && callback(error, result);
-
-        if (error) {
-          reject(error);
-        } else {
-          resolve(result);
-        }
-      });
-    });
+    callback && callback(null, result);
+    return result;
   },
 
   /**

--- a/Libraries/Components/WebView/WebView.ios.js
+++ b/Libraries/Components/WebView/WebView.ios.js
@@ -464,24 +464,11 @@ var WebView = React.createClass({
   /**
    * Evaluate JavaScript on the current page.
    */
-  evaluateJavaScript: async function(
-    script: string,
-    callback?: ?(error: ?Error, result: ?string) => void,
-  ): Promise {
+  evaluateJavaScript: async function(script: string): Promise {
     var escaped = JSON.stringify(script).replace(/\u2028/g, '\\u2028').replace(/\u2029/g, '\\u2029');
     var wrapped = 'JSON.stringify(eval(' + escaped + '))';
-    var result = null;
-
-    try {
-      var resultString = await RCTWebViewManager.evaluateJavaScript(this.getWebViewHandle(), wrapped);
-      result = JSON.parse(resultString);
-    } catch (e) {
-      callback && callback(e, null);
-      throw e;
-    }
-
-    callback && callback(null, result);
-    return result;
+    var resultString = await RCTWebViewManager.evaluateJavaScript(this.getWebViewHandle(), wrapped);
+    return JSON.parse(resultString);
   },
 
   /**

--- a/Libraries/Components/WebView/WebView.ios.js
+++ b/Libraries/Components/WebView/WebView.ios.js
@@ -469,9 +469,8 @@ var WebView = React.createClass({
     callback?: ?(error: ?Error, result: ?string) => void,
   ): Promise {
     return new Promise((resolve, reject) => {
-      var escaped = script.replace(/\\/g, '\\\\')
-                          .replace(/"/g, '\\"');
-      var wrapped = 'JSON.stringify(eval("' + escaped + '"))';
+      var escaped = JSON.stringify(script).replace(/\u2028/g, '\\u2028').replace(/\u2029/g, '\\u2029');
+      var wrapped = 'JSON.stringify(eval(' + escaped + '))';
 
       RCTWebViewManager.evaluateJavaScript(this.getWebViewHandle(), wrapped, function(error, result) {
         if (!error) {

--- a/Libraries/Components/WebView/WebView.ios.js
+++ b/Libraries/Components/WebView/WebView.ios.js
@@ -462,6 +462,39 @@ var WebView = React.createClass({
   },
 
   /**
+   * Evaluate JavaScript on the current page.
+   */
+  evaluateJavaScript: function(
+    script: string,
+    callback?: ?(error: ?Error, result: ?string) => void,
+  ): Promise {
+    return new Promise((resolve, reject) => {
+      var escaped = script.replace(/\\/g, '\\\\')
+                          .replace(/"/g, '\\"');
+      var wrapped = 'JSON.stringify(eval("' + escaped + '"))';
+
+      RCTWebViewManager.evaluateJavaScript(this.getWebViewHandle(), wrapped, function(error, result) {
+        if (!error) {
+          if (result === '') {
+            error = new Error("Error evaluating script.")
+            result = null;
+          } else {
+            result = JSON.parse(result);
+          }
+        }
+
+        callback && callback(error, result);
+
+        if (error) {
+          reject(error);
+        } else {
+          resolve(result);
+        }
+      });
+    });
+  },
+
+  /**
    * We return an event with a bunch of fields including:
    *  url, title, loading, canGoBack, canGoForward
    */

--- a/React/Views/RCTWebView.h
+++ b/React/Views/RCTWebView.h
@@ -41,5 +41,6 @@ shouldStartLoadForRequest:(NSMutableDictionary<NSString *, id> *)request
 - (void)goBack;
 - (void)reload;
 - (void)stopLoading;
+- (NSString *)evaluateJavaScript:(NSString *)script;
 
 @end

--- a/React/Views/RCTWebView.m
+++ b/React/Views/RCTWebView.m
@@ -82,7 +82,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
   [_webView stopLoading];
 }
 
-- (NSString *)evaluateJavaScript: (NSString*) script
+- (NSString *)evaluateJavaScript:(NSString*)script
 {
   return [_webView stringByEvaluatingJavaScriptFromString: script];
 }

--- a/React/Views/RCTWebView.m
+++ b/React/Views/RCTWebView.m
@@ -82,6 +82,11 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
   [_webView stopLoading];
 }
 
+- (NSString *)evaluateJavaScript: (NSString*) script
+{
+  return [_webView stringByEvaluatingJavaScriptFromString: script];
+}
+
 - (void)setSource:(NSDictionary *)source
 {
   if (![_source isEqualToDictionary:source]) {

--- a/React/Views/RCTWebViewManager.m
+++ b/React/Views/RCTWebViewManager.m
@@ -97,6 +97,18 @@ RCT_EXPORT_METHOD(stopLoading:(nonnull NSNumber *)reactTag)
   }];
 }
 
+RCT_EXPORT_METHOD(evaluateJavaScript:(nonnull NSNumber *)reactTag script: (nonnull NSString *)script callback:(RCTResponseSenderBlock)callback)
+{
+  [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, RCTWebView *> *viewRegistry) {
+    RCTWebView *view = viewRegistry[reactTag];
+    if (![view isKindOfClass:[RCTWebView class]]) {
+      RCTLogError(@"Invalid view returned from registry, expecting RCTWebView, got: %@", view);
+    } else {
+      callback(@[[NSNull null], [view evaluateJavaScript: script]]);
+    }
+  }];
+}
+
 #pragma mark - Exported synchronous methods
 
 - (BOOL)webView:(__unused RCTWebView *)webView

--- a/React/Views/RCTWebViewManager.m
+++ b/React/Views/RCTWebViewManager.m
@@ -98,19 +98,20 @@ RCT_EXPORT_METHOD(stopLoading:(nonnull NSNumber *)reactTag)
   }];
 }
 
-RCT_REMAP_METHOD(evaluateJavaScript, evaluateJavaScript:(nonnull NSNumber *)reactTag script: (nonnull NSString *)script resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
+RCT_REMAP_METHOD(evaluateJavaScript, evaluateJavaScript:(nonnull NSNumber *)reactTag script:(nonnull NSString *)script resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 {
   [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, RCTWebView *> *viewRegistry) {
     RCTWebView *view = viewRegistry[reactTag];
     if (![view isKindOfClass:[RCTWebView class]]) {
       RCTLogError(@"Invalid view returned from registry, expecting RCTWebView, got: %@", view);
+      return;
+    }
+
+    NSString *result = [view evaluateJavaScript: script];
+    if (result && [result length] > 0) {
+      resolve(result);
     } else {
-      NSString *result = [view evaluateJavaScript: script];
-      if (result && [result length] > 0) {
-        resolve(result);
-      } else {
-        reject(RCTErrorUnspecified, @"Error evaluating script.", nil);
-      }
+      reject(RCTErrorUnspecified, @"Error evaluating script.", nil);
     }
   }];
 }


### PR DESCRIPTION
Picking this up from #1191. Adds `evaluateJavaScript` to iOS `WebView` API, enabling React -> page communication.

Verified test cases:
- `"123"` evaluates to `123`.
- `"'123'"` evaluates to the string "`123`".
- `"'foo\"bar'"` evaluates to "`foo"bar`".
- `"'foo\\'bar'"` evaluates to "`foo'bar`".
- `"'foo\\\\bar'"` evaluates to "`foo\bar`".
- `"window.location"` returns an object with `href`, `host`, and other expected properties.
- `"window"` results in an error (cyclic JSON).
