### PR TITLE
Fix native modules linking in 0.29.1

### DIFF
--- a/local-cli/rnpm/link/src/android/patches/0.20/makeImportPatch.js
+++ b/local-cli/rnpm/link/src/android/patches/0.20/makeImportPatch.js
@@ -1,6 +1,6 @@
 module.exports = function makeImportPatch(packageImportPath) {
   return {
-    pattern: 'import com.facebook.react.ReactActivity;',
+    pattern: 'import com.facebook.react.ReactApplication;',
     patch: '\n' + packageImportPath,
   };
 };

--- a/local-cli/rnpm/link/src/android/registerNativeModule.js
+++ b/local-cli/rnpm/link/src/android/registerNativeModule.js
@@ -27,12 +27,12 @@ module.exports = function registerNativeAndroidModule(
   applyPatch(projectConfig.stringsPath, makeStringsPatch(params, name));
 
   applyPatch(
-    projectConfig.mainActivityPath,
+    projectConfig.mainFilePath,
     makePackagePatch(androidConfig.packageInstance, params, name)
   );
 
   applyPatch(
-    projectConfig.mainActivityPath,
+    projectConfig.mainFilePath,
     makeImportPatch(androidConfig.packageImportPath)
   );
 };

--- a/local-cli/rnpm/link/src/android/unregisterNativeModule.js
+++ b/local-cli/rnpm/link/src/android/unregisterNativeModule.js
@@ -36,12 +36,12 @@ module.exports = function unregisterNativeAndroidModule(
   revokePatch(projectConfig.stringsPath, makeStringsPatch(params, name));
 
   revokePatch(
-    projectConfig.mainActivityPath,
+    projectConfig.mainFilePath,
     makePackagePatch(androidConfig.packageInstance, params, name)
   );
 
   revokePatch(
-    projectConfig.mainActivityPath,
+    projectConfig.mainFilePath,
     makeImportPatch(androidConfig.packageImportPath)
   );
 };

--- a/local-cli/rnpm/link/test/android/patches/0.17/makeImportPatch.js
+++ b/local-cli/rnpm/link/test/android/patches/0.17/makeImportPatch.js
@@ -7,7 +7,7 @@ const makeImportPatch = require('../../../../src/android/patches/0.17/makeImport
 const applyPatch = require('../../../../src/android/patches/applyPatch');
 
 const projectConfig = {
-  mainActivityPath: 'MainActivity.java',
+  mainFilePath: 'MainActivity.java',
 };
 
 const packageImportPath = 'import some.example.project';

--- a/local-cli/rnpm/link/test/android/patches/0.17/makePackagePatch.js
+++ b/local-cli/rnpm/link/test/android/patches/0.17/makePackagePatch.js
@@ -7,7 +7,7 @@ const makePackagePatch = require('../../../../src/android/patches/0.17/makePacka
 const applyPatch = require('../../../../src/android/patches/applyPatch');
 
 const projectConfig = {
-  mainActivityPath: 'MainActivity.java',
+  mainFilePath: 'MainActivity.java',
 };
 
 const packageInstance = 'new SomeLibrary(${foo}, ${bar}, \'something\')';

--- a/local-cli/rnpm/link/test/android/patches/0.18/makeImportPatch.js
+++ b/local-cli/rnpm/link/test/android/patches/0.18/makeImportPatch.js
@@ -7,7 +7,7 @@ const makeImportPatch = require('../../../../src/android/patches/0.18/makeImport
 const applyPatch = require('../../../../src/android/patches/applyPatch');
 
 const projectConfig = {
-  mainActivityPath: 'MainActivity.java',
+  mainFilePath: 'MainActivity.java',
 };
 
 const packageImportPath = 'import some.example.project';

--- a/local-cli/rnpm/link/test/android/patches/0.18/makePackagePatch.js
+++ b/local-cli/rnpm/link/test/android/patches/0.18/makePackagePatch.js
@@ -7,7 +7,7 @@ const makePackagePatch = require('../../../../src/android/patches/0.18/makePacka
 const applyPatch = require('../../../../src/android/patches/applyPatch');
 
 const projectConfig = {
-  mainActivityPath: 'MainActivity.java',
+  mainFilePath: 'MainActivity.java',
 };
 
 const packageInstance = 'new SomeLibrary(${foo}, ${bar}, \'something\')';

--- a/local-cli/rnpm/link/test/android/patches/0.20/makeImportPatch.js
+++ b/local-cli/rnpm/link/test/android/patches/0.20/makeImportPatch.js
@@ -7,7 +7,7 @@ const makeImportPatch = require('../../../../src/android/patches/0.20/makeImport
 const applyPatch = require('../../../../src/android/patches/applyPatch');
 
 const projectConfig = {
-  mainActivityPath: 'MainActivity.java',
+  mainFilePath: 'MainActivity.java',
 };
 
 const packageImportPath = 'import some.example.project';

--- a/local-cli/rnpm/link/test/android/patches/0.20/makePackagePatch.js
+++ b/local-cli/rnpm/link/test/android/patches/0.20/makePackagePatch.js
@@ -7,7 +7,7 @@ const makePackagePatch = require('../../../../src/android/patches/0.20/makePacka
 const applyPatch = require('../../../../src/android/patches/applyPatch');
 
 const projectConfig = {
-  mainActivityPath: 'MainActivity.java',
+  mainFilePath: 'MainActivity.java',
 };
 
 const packageInstance = 'new SomeLibrary(${foo}, ${bar}, \'something\')';


### PR DESCRIPTION
### Motivation
Attempt to fix https://github.com/facebook/react-native/pull/8612

### Description
We re-named `mainActivityPath` by `mainFilePath` in the `link` code, but we forgot to rename config parameters. Currently, link is broken.

### Test plan (required)

- [x] `react-native link` should work for react-native 0.29+