### PR TITLE
Get server host in setupDevtools for Android

### DIFF
--- a/Libraries/Devtools/setupDevtools.js
+++ b/Libraries/Devtools/setupDevtools.js
@@ -11,10 +11,17 @@
  */
 'use strict';
 
+var Platform = require('Platform');
+var NativeModules = require('NativeModules');
+
 function setupDevtools() {
   var messageListeners = [];
   var closeListeners = [];
-  var ws = new window.WebSocket('ws://localhost:8097/devtools');
+  var hostname = 'localhost';
+  if (Platform.OS === 'android' && NativeModules.AndroidConstants) {
+    hostname = NativeModules.AndroidConstants.ServerHost.split(':')[0];
+  }
+  var ws = new window.WebSocket('ws://' + hostname + ':8097/devtools');
   // this is accessed by the eval'd backend code
   var FOR_BACKEND = { // eslint-disable-line no-unused-vars
     resolveRNStyle: require('flattenStyle'),


### PR DESCRIPTION
The `setupDevtools` for Android looks coming on [v0.30](https://github.com/facebook/react-native/commit/22fbb6d46d4b91bfe08b83aaba46ad92a32bf984), currently we need to run `adb reverse tcp:8097 tcp:8097`, I think get host IP (`10.0.2.2`, Genymotion: `10.0.3.2`) for Android will be better. (it can be found in `AndroidConstants` native module)