### PR TITLE
Add babelHelpers.jsx

### DIFF
--- a/packager/react-packager/src/Resolver/polyfills/babelHelpers.js
+++ b/packager/react-packager/src/Resolver/polyfills/babelHelpers.js
@@ -227,3 +227,40 @@ babelHelpers.toConsumableArray = function (arr) {
     return Array.from(arr);
   }
 };
+
+babelHelpers.jsx = (function () {
+  var REACT_ELEMENT_TYPE = (typeof Symbol === "function" && Symbol.for && Symbol.for("react.element")) || 0xeac7;
+  return function createRawReactElement (type, props, key, children) {
+    var defaultProps = type && type.defaultProps;
+    var childrenLength = arguments.length - 3;
+    if (!props && childrenLength !== 0) {
+      props = {};
+    }
+    if (props && defaultProps) {
+      for (var propName in defaultProps) {
+        if (props[propName] === void 0) {
+          props[propName] = defaultProps[propName];
+        }
+      }
+    } else if (!props) {
+      props = defaultProps || {};
+    }
+    if (childrenLength === 1) {
+      props.children = children;
+    } else if (childrenLength > 1) {
+      var childArray = Array(childrenLength);
+      for (var i = 0; i < childrenLength; i++) {
+        childArray[i] = arguments[i + 3];
+      }
+      props.children = childArray;
+    }
+    return {
+      $$typeof: REACT_ELEMENT_TYPE,
+      type: type,
+      key: key === undefined ? null : '' + key,
+      ref: null,
+      props: props,
+      _owner: null,
+    };
+  };
+})();


### PR DESCRIPTION
Currently we missing `babelHelpers.jsx` if we use `babel-plugin-transform-react-inline-elements` to make optimization. (see [this](https://github.com/babel/babel/blob/master/packages/babel-plugin-transform-react-inline-elements/src/index.js#L64))

It copy from [babel-helpers](https://github.com/babel/babel/blob/master/packages/babel-helpers/src/helpers.js#L14) package.