### PR TITLE
Improve the BackAndroid example to be more clear

### DIFF
--- a/Libraries/Utilities/BackAndroid.android.js
+++ b/Libraries/Utilities/BackAndroid.android.js
@@ -44,13 +44,16 @@ RCTDeviceEventEmitter.addListener(DEVICE_BACK_EVENT, function() {
  *
  * Example:
  *
- * ```js
+ * ```javascript
  * BackAndroid.addEventListener('hardwareBackPress', function() {
- * 	 if (!this.onMainScreen()) {
- * 	   this.goBack();
- * 	   return true;
- * 	 }
- * 	 return false;
+ *  // this.onMainScreen and this.goBack are just examples, you need to use your own implementation here
+ *  // Typically you would use the navigator here to go to the last state.
+ *
+ *  if (!this.onMainScreen()) {
+ *    this.goBack();
+ *    return true;
+ *  }
+ *  return false;
  * });
  * ```
  */


### PR DESCRIPTION
The example of `BackAndroid` caused a bit of confusion for beginners (see #8822), so I thought we should clarify the functionality a bit. I added a comment indicating that a user would have to implement `this.onMainScreen` and `this.goBack` on their own, this was the original problem.