### PR TITLE
Change Android testID prop from tag to content-description

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
@@ -85,7 +85,7 @@ public abstract class BaseViewManager<T extends View, C extends LayoutShadowNode
 
   @ReactProp(name = PROP_TEST_ID)
   public void setTestId(T view, String testId) {
-    view.setTag(testId);
+    view.setContentDescription(testId);
   }
 
   @ReactProp(name = PROP_ACCESSIBILITY_LABEL)


### PR DESCRIPTION
Fixes https://github.com/facebook/react-native/issues/7135

This will make automated tests with [Appium](http://appium.io/) possible in Android.

Test plan:

The "Touchable feedback events" section in the UIExplorer has a testID. Checked it in the Appium inspector before, no content-description. Checked it after, it was there:

<img width="887" alt="screen shot 2016-07-16 at 8 25 45 pm" src="https://cloud.githubusercontent.com/assets/4349082/16897976/85996f96-4b93-11e6-80c6-d90df38e3e40.png">

