### PR TITLE
update yeoman-generator to 0.21 because of RegExp DoS issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -188,7 +188,7 @@
     "xmldoc": "^0.4.0",
     "yargs": "^3.24.0",
     "yeoman-environment": "~1.2.7",
-    "yeoman-generator": "^0.20.3",
+    "yeoman-generator": "^0.21.0",
     "mime-types": "2.1.11",
     "whatwg-fetch": "^1.0.0"
   },


### PR DESCRIPTION
Installing react-native gives a warning because of outdated version of yeoman-generator. The warning is ```npm WARN deprecated minimatch@2.0.10: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue```.
This MR will update the yeoman-generator version to 0.21.0 to resolve this warning.