### PR TITLE
Added option to specify applicationId for Android builds

### DIFF
--- a/local-cli/runAndroid/runAndroid.js
+++ b/local-cli/runAndroid/runAndroid.js
@@ -43,6 +43,10 @@ function _runAndroid(argv, config, resolve, reject) {
     command: 'variant',
     type: 'string',
     required: false,
+  }, {
+    command: 'applicationId',
+    type: 'string',
+    required: false,
   }], argv);
 
   args.root = args.root || '';
@@ -154,6 +158,14 @@ function run(args, reject) {
       'utf8'
     ).match(/package="(.+?)"/)[1];
 
+    // Is there a different applicationId?
+    let applicationId;
+    if (args['applicationId']) {
+      applicationId = args['applicationId']
+    } else {
+      applicationId = packageName;
+    }
+
     const adbPath = getAdbPath();
 
     const devices = adb.getDevices();
@@ -161,7 +173,7 @@ function run(args, reject) {
     if (devices && devices.length > 0) {
       devices.forEach((device) => {
 
-        const adbArgs = ['-s', device, 'shell', 'am', 'start', '-n', packageName + '/.MainActivity'];
+        const adbArgs = ['-s', device, 'shell', 'am', 'start', '-n', applicationId + '/' + packageName + '.MainActivity'];
 
         console.log(chalk.bold(
           `Starting the app on ${device} (${adbPath} ${adbArgs.join(' ')})...`


### PR DESCRIPTION
Allow optional `applicationId` build parameter. eg:

```shell
 react-native run-android --variant=DevEnvDebug --applicationId=com.awesomeproject.devenv
```

It will then start the app with something like this: 
```shell
Starting the app on 192.168.59.101:5555 (/Users/wenterline/Library/Android/sdk/platform-tools/adb -s 192.168.59.101:5555 shell am start -n com.awesomeproject.devenv/com.awesomeproject.MainActivity)...

```

Many times in Android, we have the need to set a different `applicationId` for different build variants. eg:

```groovy
android {
    compileSdkVersion 23
    buildToolsVersion "23.0.1"

    defaultConfig {
        applicationId "com.awesomeproject"
        minSdkVersion 16
        targetSdkVersion 22
        versionCode 1
        versionName "1.0"
        ndk {
            abiFilters "armeabi-v7a", "x86"
        }
    }
    ...
    productFlavors {

        all {
        }

        ProdEnv {
        }

        DevEnv {
            applicationId "com.awesomeproject.devenv"
        }

    }
    ...
}
```

This should address issue #8308 

**Test plan (required)**

We have been using this modified version of runAndroid for quite some time. I have tested with and without the parameter and builds that have different application ids and builds that do not.
