### PR TITLE
check if remote notification via aps property

### DIFF
--- a/Libraries/PushNotificationIOS/PushNotificationIOS.js
+++ b/Libraries/PushNotificationIOS/PushNotificationIOS.js
@@ -301,7 +301,7 @@ class PushNotificationIOS {
   constructor(nativeNotif: Object) {
     this._data = {};
 
-    if (nativeNotif.remote) {
+    if (nativeNotif['aps']) {
       // Extract data from Apple's `aps` dict as defined:
       // https://developer.apple.com/library/ios/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/Chapters/ApplePushService.html
       Object.keys(nativeNotif).forEach((notifKey) => {


### PR DESCRIPTION
This PR fixes https://github.com/facebook/react-native/issues/8874

It checks if the initial notification is remote by looking for the `aps` property, rather than the "remote" property (which is not present in native notifications).
