### PR TITLE
Fix KeyboardAvoidingView padding for android

### DIFF
--- a/Libraries/Components/Keyboard/KeyboardAvoidingView.js
+++ b/Libraries/Components/Keyboard/KeyboardAvoidingView.js
@@ -169,7 +169,7 @@ const KeyboardAvoidingView = React.createClass({
         );
 
       case 'padding':
-        const paddingStyle = {paddingBottom: this.state.bottom};
+        const paddingStyle = {paddingBottom: Platform.OS === 'android' ? 0 : this.state.bottom};
         return (
           <View ref={viewRef} style={[style, paddingStyle]} onLayout={this.onLayout} {...props}>
             {children}


### PR DESCRIPTION
On Android this:

```
<KeyboardAvoidingView behavior={'padding'} style={{ flex: 1 }}>
    <View style={{flex: 1}} />
    <TextInput style={{width, height}} />
</KeyboardAvoidingView>
```

produces incorrect result (because frame's height also changes when keyboard shows up), so `bottomPadding: 0` for container should work fine.
