### PR TITLE
Removed xcpretty from running objc tests runner

### DIFF
--- a/scripts/objc-test.sh
+++ b/scripts/objc-test.sh
@@ -31,7 +31,7 @@ fi
 # TODO: We use xcodebuild because xctool would stall when collecting info about
 # the tests before running them. Switch back when this issue with xctool has
 # been resolved.
-xcodebuild \
+xctool \
   -project $XCODE_PROJECT \
   -scheme $XCODE_SCHEME \
   -sdk $XCODE_SDK \

--- a/scripts/objc-test.sh
+++ b/scripts/objc-test.sh
@@ -28,26 +28,12 @@ if [ -z "$XCODE_DESTINATION" ]; then
   XCODE_DESTINATION="platform=iOS Simulator,name=iPhone 5s,OS=9.3"
 fi
 
-# Support for environments without xcpretty installed
-set +e
-OUTPUT_TOOL=$(which xcpretty)
-set -e
-
 # TODO: We use xcodebuild because xctool would stall when collecting info about
 # the tests before running them. Switch back when this issue with xctool has
 # been resolved.
-if [ -z "$OUTPUT_TOOL" ]; then
-  xcodebuild \
-    -project $XCODE_PROJECT \
-    -scheme $XCODE_SCHEME \
-    -sdk $XCODE_SDK \
-    -destination "$XCODE_DESTINATION" \
-    test
-else
-  xcodebuild \
-    -project $XCODE_PROJECT \
-    -scheme $XCODE_SCHEME \
-    -sdk $XCODE_SDK \
-    -destination "$XCODE_DESTINATION" \
-    test | $OUTPUT_TOOL && exit ${PIPESTATUS[0]}
-fi
+xcodebuild \
+  -project $XCODE_PROJECT \
+  -scheme $XCODE_SCHEME \
+  -sdk $XCODE_SDK \
+  -destination "$XCODE_DESTINATION" \
+  test


### PR DESCRIPTION
Quite often, ~10%, Travis ObjC tests stall and fail to compile, e.g. https://travis-ci.org/facebook/react-native/jobs/144980707.
When testing locally I noticed that running tests with xcpretty may cause tests to stall and never finish.
Maybe related to https://github.com/supermarin/xcpretty/issues/227

Anyway, we don't need tests to be pretty, we need them to finish.

Test Plan:
- see Travis run results
- check uiexplorer legocastle run results