### PR TITLE
Modal shouldn't be restricted to portrait only

### DIFF
--- a/React/Views/RCTModalHostViewController.m
+++ b/React/Views/RCTModalHostViewController.m
@@ -24,14 +24,4 @@
   }
 }
 
-- (UIInterfaceOrientationMask)supportedInterfaceOrientations
-{
-  // Picking some defaults here, we should probably make this configurable
-  if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad) {
-    return UIInterfaceOrientationMaskAll;
-  } else {
-    return UIInterfaceOrientationMaskPortrait;
-  }
-}
-
 @end


### PR DESCRIPTION
At the moment, the `Modal` component is restricted to portrait orientation only. I think there are enough use-cases for displaying a modal in landscape mode to reconsider this. My own use-case is displaying an image or video in an immersive view, where a user might rotate the phone to get a better view.