### PR TITLE
Android: Add setLaunchOptions to ReactRootView

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/ReactActivity.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactActivity.java
@@ -112,6 +112,15 @@ public abstract class ReactActivity extends Activity
     mDoubleTapReloadRecognizer = new DoubleTapReloadRecognizer();
   }
 
+  /**
+   * Notifies the react application at this root view that initial properties has been changed and it should refresh itself.
+   */
+  protected void notifyLaunchOptionsChanged() {
+    if (mReactRootView != null) {
+      mReactRootView.setLaunchOptions(getLaunchOptions());
+    }
+  }
+
   @Override
   protected void onPause() {
     super.onPause();

--- a/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
@@ -150,6 +150,11 @@ public abstract class ReactInstanceManager {
   public abstract void detachRootView(ReactRootView rootView);
 
   /**
+   * Update given {@param rootView} from current catalyst instance.
+   */
+  public abstract void updateRootView(ReactRootView rootView);
+
+  /**
    * Destroy this React instance and the attached JS context.
    */
   public abstract void destroy();

--- a/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
@@ -244,6 +244,23 @@ public class ReactRootView extends SizeMonitoringFrameLayout implements RootView
   }
 
   /**
+   * Notifies the react application at this root view that initial properties has been changed and it
+   * should refresh itself.
+   */
+  public void setLaunchOptions(Bundle launchOptions) {
+    UiThreadUtil.assertOnUiThread();
+
+    if (mLaunchOptions == null ? launchOptions == null : mLaunchOptions.equals(launchOptions)) {
+      return;
+    }
+    mLaunchOptions = launchOptions;
+
+    if (mReactInstanceManager != null && mIsAttachedToInstance) {
+      mReactInstanceManager.updateRootView(this);
+    }
+  }
+
+  /**
    * Is used by unit test to setup mWasMeasured and mIsAttachedToWindow flags, that will let this
    * view to be properly attached to catalyst instance by startReactApplication call
    */

--- a/ReactAndroid/src/main/java/com/facebook/react/XReactInstanceManagerImpl.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/XReactInstanceManagerImpl.java
@@ -654,6 +654,19 @@ import static com.facebook.systrace.Systrace.TRACE_TAG_REACT_JAVA_BRIDGE;
   }
 
   /**
+   * Update given {@param rootView} from current catalyst instance.
+   */
+  @Override
+  public void updateRootView(ReactRootView rootView) {
+    UiThreadUtil.assertOnUiThread();
+    if (mAttachedRootViews.contains(rootView)) {
+      if (mCurrentReactContext != null && mCurrentReactContext.hasActiveCatalystInstance()) {
+        runApplication(rootView, mCurrentReactContext.getCatalystInstance());
+      }
+    }
+  }
+
+  /**
    * Uses configured {@link ReactPackage} instances to create all view managers
    */
   @Override
@@ -764,13 +777,22 @@ import static com.facebook.systrace.Systrace.TRACE_TAG_REACT_JAVA_BRIDGE;
     rootView.setId(View.NO_ID);
 
     UIManagerModule uiManagerModule = catalystInstance.getNativeModule(UIManagerModule.class);
-    int rootTag = uiManagerModule.addMeasuredRootView(rootView);
+    uiManagerModule.addMeasuredRootView(rootView);
+    runApplication(rootView, catalystInstance);
+    Systrace.endSection(TRACE_TAG_REACT_JAVA_BRIDGE);
+  }
+
+  private void runApplication(
+      ReactRootView rootView,
+      CatalystInstance catalystInstance) {
+    Systrace.beginSection(TRACE_TAG_REACT_JAVA_BRIDGE, "runApplication");
+    UiThreadUtil.assertOnUiThread();
     @Nullable Bundle launchOptions = rootView.getLaunchOptions();
     WritableMap initialProps = Arguments.makeNativeMap(launchOptions);
     String jsAppModuleName = rootView.getJSModuleName();
 
     WritableNativeMap appParams = new WritableNativeMap();
-    appParams.putDouble("rootTag", rootTag);
+    appParams.putDouble("rootTag", rootView.getId());
     appParams.putMap("initialProps", initialProps);
     catalystInstance.getJSModule(AppRegistry.class).runApplication(jsAppModuleName, appParams);
     Systrace.endSection(TRACE_TAG_REACT_JAVA_BRIDGE);


### PR DESCRIPTION
**Motivation**

When ReactRootView is used in a Android layout file, its properties is expected to be changeable at run time like other native views. iOS RCTRootView has a method named setAppProperties, but no such method found on Android.

**Test plan (required)**

Create a Android project for TicTacToe example.

Modify TicTacToeApp.js in Examples/TicTacToe:

Change from
`<Text style={styles.title}>EXTREME T3</Text>`
to
`<Text style={styles.title}>EXTREME T3 {this.props.title}</Text>`


Implement a TicTacToeActivity:
```java
public class TicTacToeActivity extends ReactActivity {
  private String mTitle;

  @Override
  protected String getMainComponentName() {
    return "TicTacToeApp";
  }

  @Nullable
  @Override
  protected Bundle getLaunchOptions() {
    Bundle args = new Bundle();
    args.putString("title", mTitle);
    return args;
  }

  @Override
  public boolean onKeyUp(int keyCode, KeyEvent event) {
    if (keyCode == KeyEvent.KEYCODE_1 || keyCode == KeyEvent.KEYCODE_2) {
      mTitle = keyCode == KeyEvent.KEYCODE_1 ? "1" : "2";
      notifyLaunchOptionsChanged();
    }
    return super.onKeyUp(keyCode, event);
  }
}
```

Launch TicTacToe app in an emulator, press 1 or 2, you can see the title is changed.
