### PR TITLE
Doc fix for getPackages method

### DIFF
--- a/docs/NativeModulesAndroid.md
+++ b/docs/NativeModulesAndroid.md
@@ -116,7 +116,7 @@ class AnExampleReactPackage implements ReactPackage {
   }
 ```
 
-The package needs to be provided in the `getPackages` method of the `MainActivity.java` file. This file exists under the android folder in your react-native application directory. The path to this file is: `android/app/src/main/java/com/your-app-name/MainActivity.java`.
+The package needs to be provided in the `getPackages` method of the `MainApplication.java` file. This file exists under the android folder in your react-native application directory. The path to this file is: `android/app/src/main/java/com/your-app-name/MainApplication.java`.
 
 ```java
 protected List<ReactPackage> getPackages() {


### PR DESCRIPTION
getPackages() Method has been shifted to 'MainApplication.java' and not 'MainActivity.java'.