### PR TITLE
Fix JSX string props quote convention

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,7 +101,7 @@ Facebook has a [bounty program](https://www.facebook.com/whitehat/) for the safe
 
 #### JSX
 
-* Prefer `'` over `"` for string literal props
+* Prefer `"` over `'` for string literal props
 * When wrapping opening tags over multiple lines, place one prop per line
 * `{}` of props should hug their values (no spaces)
 * Place the closing `>` of opening tags on the same line as the last prop


### PR DESCRIPTION
Not sure if I misunderstand the previous JSX convention. But I found that in JSX string props, double-quote is preferred instead.

https://github.com/facebook/react-native/blob/master/.eslintrc#L182

![screen shot 2016-07-21 at 5 32 04 am](https://cloud.githubusercontent.com/assets/6204776/17006166/137db7ae-4f09-11e6-871b-2cf99960e3a1.png)
