### PR TITLE
Add dep for android local unit tests

### DIFF
--- a/ReactAndroid/src/test/java/com/facebook/react/cxxbridge/BUCK
+++ b/ReactAndroid/src/test/java/com/facebook/react/cxxbridge/BUCK
@@ -28,6 +28,7 @@ robolectric3_test(
     react_native_dep('third-party/java/junit:junit'),
     react_native_dep('third-party/java/mockito:mockito'),
     react_native_dep('third-party/java/robolectric3/robolectric:robolectric'),
+    react_native_target('java/com/facebook/react/bridge:bridge'),
     react_native_target('java/com/facebook/react/cxxbridge:bridge'),
   ],
   visibility = [


### PR DESCRIPTION
`./scripts/run-android-local-unit-tests.sh` raise error
```
05: error: cannot access com.facebook.react.bridge.CatalystInstance
    verify(mCatalystInstanceImpl).loadScriptFromOptimizedBundle(
                                 ^
  class file for com.facebook.react.bridge.CatalystInstance not found
```
and this PR fix it.