### PR TITLE
Add TextInput controlled selection prop on Android

### DIFF
--- a/Examples/UIExplorer/js/TextInputExample.android.js
+++ b/Examples/UIExplorer/js/TextInputExample.android.js
@@ -258,6 +258,93 @@ class ToggleDefaultPaddingExample extends React.Component {
   }
 }
 
+type SelectionExampleState = {
+  selection: {
+    start: number;
+    end: number;
+  };
+  value: string;
+};
+
+class SelectionExample extends React.Component {
+  state: SelectionExampleState;
+
+  _textInput: any;
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      selection: {start: 0, end: 0},
+      value: props.value
+    };
+  }
+
+  onSelectionChange({nativeEvent: {selection}}) {
+    this.setState({selection});
+  }
+
+  getRandomPosition() {
+    var length = this.state.value.length;
+    return Math.round(Math.random() * length);
+  }
+
+  select(start, end) {
+    this._textInput.focus();
+    this.setState({selection: {start, end}});
+  }
+
+  selectRandom() {
+    var positions = [this.getRandomPosition(), this.getRandomPosition()].sort();
+    this.select(...positions);
+  }
+
+  placeAt(position) {
+    this.select(position, position);
+  }
+
+  placeAtRandom() {
+    this.placeAt(this.getRandomPosition());
+  }
+
+  render() {
+    var length = this.state.value.length;
+
+    return (
+      <View>
+        <TextInput
+          multiline={this.props.multiline}
+          onChangeText={(value) => this.setState({value})}
+          onSelectionChange={this.onSelectionChange.bind(this)}
+          ref={textInput => (this._textInput = textInput)}
+          selection={this.state.selection}
+          style={this.props.style}
+          value={this.state.value}
+        />
+        <View>
+          <Text>
+            selection = {JSON.stringify(this.state.selection)}
+          </Text>
+          <Text onPress={this.placeAt.bind(this, 0)}>
+            Place at Start (0, 0)
+          </Text>
+          <Text onPress={this.placeAt.bind(this, length)}>
+            Place at End ({length}, {length})
+          </Text>
+          <Text onPress={this.placeAtRandom.bind(this)}>
+            Place at Random
+          </Text>
+          <Text onPress={this.select.bind(this, 0, length)}>
+            Select All
+          </Text>
+          <Text onPress={this.selectRandom.bind(this)}>
+            Select Random
+          </Text>
+        </View>
+      </View>
+    );
+  }
+}
+
 var styles = StyleSheet.create({
   multiline: {
     height: 60,
@@ -499,19 +586,19 @@ exports.examples = [
             placeholder="multiline, aligned top-left"
             placeholderTextColor="red"
             multiline={true}
-            style={[styles.multiline, {textAlign: "left", textAlignVertical: "top"}]}
+            style={[styles.multiline, {textAlign: 'left', textAlignVertical: 'top'}]}
           />
           <TextInput
             autoCorrect={true}
             placeholder="multiline, aligned center"
             placeholderTextColor="green"
             multiline={true}
-            style={[styles.multiline, {textAlign: "center", textAlignVertical: "center"}]}
+            style={[styles.multiline, {textAlign: 'center', textAlignVertical: 'center'}]}
           />
           <TextInput
             autoCorrect={true}
             multiline={true}
-            style={[styles.multiline, {color: 'blue'}, {textAlign: "right", textAlignVertical: "bottom"}]}>
+            style={[styles.multiline, {color: 'blue'}, {textAlign: 'right', textAlignVertical: 'bottom'}]}>
             <Text style={styles.multiline}>multiline with children, aligned bottom-right</Text>
           </TextInput>
         </View>
@@ -622,5 +709,23 @@ exports.examples = [
   {
     title: 'Toggle Default Padding',
     render: function(): ReactElement { return <ToggleDefaultPaddingExample />; },
+  },
+  {
+    title: 'Text selection & cursor placement',
+    render: function() {
+      return (
+        <View>
+          <SelectionExample
+            style={styles.default}
+            value="text selection can be changed"
+          />
+          <SelectionExample
+            multiline
+            style={styles.multiline}
+            value={"multiline text selection\ncan also be changed"}
+          />
+        </View>
+      );
+    }
   },
 ];

--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -674,9 +674,8 @@ const TextInput = React.createClass({
       children = <Text>{children}</Text>;
     }
 
-    let selection = this.props.selection;
-    if (selection && selection.end == null) {
-      selection = {start: selection.start, end: selection.end};
+    if (props.selection && props.selection.end == null) {
+      props.selection = {start: props.selection.start, end: props.selection.start};
     }
 
     const textContainer =
@@ -690,7 +689,6 @@ const TextInput = React.createClass({
         onSelectionChange={this._onSelectionChange}
         onTextInput={this._onTextInput}
         text={this._getText()}
-        selection={selection}
         children={children}
       />;
 

--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -393,7 +393,6 @@ const TextInput = React.createClass({
     /**
      * The start and end of the text input's selection. Set start and end to
      * the same value to position the cursor.
-     * @platform ios
      */
     selection: PropTypes.shape({
       start: PropTypes.number.isRequired,
@@ -675,6 +674,11 @@ const TextInput = React.createClass({
       children = <Text>{children}</Text>;
     }
 
+    let selection = this.props.selection;
+    if (selection && selection.end == null) {
+      selection = {start: selection.start, end: selection.end};
+    }
+
     const textContainer =
       <AndroidTextInput
         ref={this._setNativeRef}
@@ -686,6 +690,7 @@ const TextInput = React.createClass({
         onSelectionChange={this._onSelectionChange}
         onTextInput={this._onTextInput}
         text={this._getText()}
+        selection={selection}
         children={children}
       />;
 

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
@@ -32,6 +32,7 @@ import com.facebook.infer.annotation.Assertions;
 import com.facebook.react.bridge.JSApplicationIllegalArgumentException;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReadableArray;
+import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.common.MapBuilder;
 import com.facebook.react.uimanager.BaseViewManager;
 import com.facebook.react.uimanager.LayoutShadowNode;
@@ -227,6 +228,17 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
     }
     if (fontStyle != currentTypeface.getStyle()) {
       view.setTypeface(currentTypeface, fontStyle);
+    }
+  }
+
+  @ReactProp(name = "selection")
+  public void setSelection(ReactEditText view, @Nullable ReadableMap selection) {
+    if (selection == null) {
+      return;
+    }
+
+    if (selection.hasKey("start") && selection.hasKey("end")) {
+      view.setSelection(selection.getInt("start"), selection.getInt("end"));
     }
   }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputSelectionEvent.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputSelectionEvent.java
@@ -48,8 +48,8 @@ import com.facebook.react.uimanager.events.RCTEventEmitter;
     WritableMap eventData = Arguments.createMap();
 
     WritableMap selectionData = Arguments.createMap();
-    selectionData.putInt("start", mSelectionStart);
     selectionData.putInt("end", mSelectionEnd);
+    selectionData.putInt("start", mSelectionStart);
 
     eventData.putMap("selection", selectionData);
     return eventData;

--- a/ReactAndroid/src/test/java/com/facebook/react/views/textinput/ReactTextInputPropertyTest.java
+++ b/ReactAndroid/src/test/java/com/facebook/react/views/textinput/ReactTextInputPropertyTest.java
@@ -331,7 +331,7 @@ public class ReactTextInputPropertyTest {
       buildStyles("textAlign", null, "textAlignVertical", null));
     assertThat(view.getGravity()).isEqualTo(defaultGravity);
   }
-  
+
   @Test
   public void testMaxLength() {
     ReactEditText view = mManager.createViewInstance(mThemedContext);
@@ -339,5 +339,24 @@ public class ReactTextInputPropertyTest {
     view.setFilters(filters);
     mManager.setMaxLength(view, null);
     assertThat(view.getFilters()).isEqualTo(filters);
+  }
+
+  @Test
+  public void testSelection() {
+    ReactEditText view = mManager.createViewInstance(mThemedContext);
+    view.setText("Need some text to select something...");
+
+    mManager.updateProperties(view, buildStyles());
+    assertThat(view.getSelectionStart()).isEqualTo(0);
+    assertThat(view.getSelectionEnd()).isEqualTo(0);
+
+    JavaOnlyMap selection = JavaOnlyMap.of("start", 5, "end", 10);
+    mManager.updateProperties(view, buildStyles("selection", selection));
+    assertThat(view.getSelectionStart()).isEqualTo(5);
+    assertThat(view.getSelectionEnd()).isEqualTo(10);
+
+    mManager.updateProperties(view, buildStyles("selection", null));
+    assertThat(view.getSelectionStart()).isEqualTo(5);
+    assertThat(view.getSelectionEnd()).isEqualTo(10);
   }
 }


### PR DESCRIPTION
Android PR for TextInput selection, based on the iOS implementation in #8958.

** Test plan **
Tested using the text selection example in UIExplorer.