### PR TITLE
Update BackAndroid example

### DIFF
--- a/Libraries/Utilities/BackAndroid.android.js
+++ b/Libraries/Utilities/BackAndroid.android.js
@@ -42,6 +42,10 @@ RCTDeviceEventEmitter.addListener(DEVICE_BACK_EVENT, function() {
  * Example:
  *
  * ```js
+ * const ReactNative = require('react-native');
+ * const {
+ *   BackAndroid
+ * } = ReactNative;
  * BackAndroid.addEventListener('hardwareBackPress', function() {
  * 	 if (!this.onMainScreen()) {
  * 	   this.goBack();


### PR DESCRIPTION
Update BackAndroid example
The example was using BackAndroid from the React namespace, which is no longer correct since v0.25