### PR TITLE
Update keyboard input element from `span` to `kbd`

### DIFF
--- a/local-cli/server/util/debugger.html
+++ b/local-cli/server/util/debugger.html
@@ -127,7 +127,7 @@ connectToDebuggerProxy();
     <p>
       React Native JS code runs inside this Chrome tab.
     </p>
-    <p>Press <span class="shortcut">⌘⌥J</span> to open Developer Tools. Enable <a href="http://stackoverflow.com/a/17324511/232122" target="_blank">Pause On Caught Exceptions</a> for a better debugging experience.</p>
+    <p>Press <kbd class="shortcut">⌘⌥J</kbd> to open Developer Tools. Enable <a href="http://stackoverflow.com/a/17324511/232122" target="_blank">Pause On Caught Exceptions</a> for a better debugging experience.</p>
     <p>Status: <span id="status">Loading...</span></p>
   </div>
 </body>


### PR DESCRIPTION
Updated the keyboard input element on the browser debugger page that contains "⌘⌥J" from a `span` to the more semantic `kbd`.