### PR TITLE
[RCTEventEmitter] log info instead of warn for no listeners registered

### DIFF
--- a/React/Modules/RCTEventEmitter.m
+++ b/React/Modules/RCTEventEmitter.m
@@ -49,7 +49,7 @@
     [_bridge enqueueJSCall:@"RCTDeviceEventEmitter.emit"
                       args:body ? @[eventName, body] : @[eventName]];
   } else {
-    RCTLogWarn(@"Sending `%@` with no listeners registered.", eventName);
+    RCTLogInfo(@"Sending `%@` with no listeners registered.", eventName);
   }
 }
 


### PR DESCRIPTION
#### Explain the **motivation** for making this change. What existing problem does the pull request solve?
We have an async native request that fires an event via RCTEventEmitter when complete. We register an event listener in JS at runtime, but this is often *after* the event has fired from the native side. The problem is that RCTEventEmitter warns every time the native block finishes before JS init.

#### Test plan (required)
None (change is cosmetic)

#### Solution
The proposed and simplest solution is to log instead of warn. Other options might be:
1. expose a `getListenerCount` method in addition to `sendEventWithName` method for classes which implement RCTEventEmitter
2. remove the log entirely

Thoughts?