### PR TITLE
[CocoaPods] Create a CSSLayout subspec that preserves the header directories

### DIFF
--- a/React.podspec
+++ b/React.podspec
@@ -29,8 +29,9 @@ Pod::Spec.new do |s|
   s.preserve_paths      = "cli.js", "Libraries/**/*.js", "lint", "linter.js", "node_modules", "package.json", "packager", "PATENTS", "react-native-cli"
 
   s.subspec 'Core' do |ss|
+    ss.dependency            'React/CSSLayout'
     ss.source_files        = "React/**/*.{c,h,m,mm,S}"
-    ss.exclude_files       = "**/__tests__/*", "IntegrationTests/*"
+    ss.exclude_files       = "**/__tests__/*", "IntegrationTests/*", "React/CSSLayout/*"
     ss.frameworks          = "JavaScriptCore"
     ss.libraries           = "stdc++"
     ss.pod_target_xcconfig = { "CLANG_CXX_LANGUAGE_STANDARD" => "c++14" }
@@ -40,6 +41,11 @@ Pod::Spec.new do |s|
     ss.dependency       'React/Core'
     ss.source_files   = "Libraries/ART/**/*.{h,m}"
     ss.preserve_paths = "Libraries/ART/**/*.js"
+  end
+
+  s.subspec 'CSSLayout' do |ss|
+    ss.source_files        = "React/CSSLayout/**/*.{c,h}"
+    ss.header_mappings_dir = "React"
   end
 
   s.subspec 'RCTActionSheet' do |ss|


### PR DESCRIPTION
RN imports CSSLayout files like so: `#import <CSSLayout/CSSLayout.h>`, so we need to tell CocoaPods to preserve the directory structure for CSSLayout files. This is done with the header_mappings_dir, but we want it to apply just to CSSLayout's files, hence the subspec.

Test Plan: `pod install` works