### PR TITLE
PickerIOS: Add possibility to wrap items around. Fix row height at large font sizes

### DIFF
--- a/Libraries/Components/Picker/Picker.js
+++ b/Libraries/Components/Picker/Picker.js
@@ -52,6 +52,7 @@ class Picker extends React.Component {
   enabled?: boolean,
   mode?: 'dialog' | 'dropdown',
   itemStyle?: $FlowFixMe,
+  loop?: boolean,
   prompt?: string,
   testID?: string,
  };
@@ -103,6 +104,11 @@ class Picker extends React.Component {
     * @platform ios
     */
    itemStyle: itemStylePropType,
+     /**
+     * Wrap the items around.
+     * @platform ios
+     */
+    loop: React.PropTypes.bool,
    /**
     * Prompt string for this picker, used on Android in dialog mode as the title of the dialog.
     * @platform android

--- a/Libraries/Components/Picker/PickerIOS.ios.js
+++ b/Libraries/Components/Picker/PickerIOS.ios.js
@@ -42,6 +42,12 @@ var PickerIOS = React.createClass({
     this.setState(this._stateFromProps(nextProps));
   },
 
+  _getLoopMiddle: function(itemCount) {
+    var maxItems = Math.max(itemCount, 10000);
+    var itemCountMultiplier = Math.round((1 - itemCount / maxItems) * 100);
+    return Math.round((itemCountMultiplier / 2));
+  },
+
   // Translate PickerIOS prop and children into stuff that RCTPickerIOS understands.
   _stateFromProps: function(props) {
     var selectedIndex = 0;
@@ -54,7 +60,7 @@ var PickerIOS = React.createClass({
     });
 
     if (props.loop) {
-      selectedIndex += items.length * 50;
+      selectedIndex += items.length * this._getLoopMiddle(items.length);
     }
 
     return {selectedIndex, items};

--- a/Libraries/Components/Picker/PickerIOS.ios.js
+++ b/Libraries/Components/Picker/PickerIOS.ios.js
@@ -44,7 +44,9 @@ var PickerIOS = React.createClass({
 
   _getLoopMiddle: function(itemCount) {
     var maxItems = Math.max(itemCount, 10000);
+    var minItemCountMultiplier = 3;
     var itemCountMultiplier = Math.round((1 - itemCount / maxItems) * 100);
+    itemCountMultiplier = Math.max(minItemCountMultiplier, itemCountMultiplier);
     return Math.round((itemCountMultiplier / 2));
   },
 

--- a/Libraries/Components/Picker/PickerIOS.ios.js
+++ b/Libraries/Components/Picker/PickerIOS.ios.js
@@ -29,6 +29,7 @@ var PickerIOS = React.createClass({
   propTypes: {
     ...View.propTypes,
     itemStyle: itemStylePropType,
+    loop: React.PropTypes.bool,
     onValueChange: React.PropTypes.func,
     selectedValue: React.PropTypes.any, // string or integer basically
   },
@@ -51,6 +52,11 @@ var PickerIOS = React.createClass({
       }
       items.push({value: child.props.value, label: child.props.label});
     });
+
+    if (props.loop) {
+      selectedIndex += items.length * 50;
+    }
+
     return {selectedIndex, items};
   },
 
@@ -61,6 +67,7 @@ var PickerIOS = React.createClass({
           ref={picker => this._picker = picker}
           style={[styles.pickerIOS, this.props.itemStyle]}
           items={this.state.items}
+          loop={this.props.loop}
           selectedIndex={this.state.selectedIndex}
           onChange={this._onChange}
         />
@@ -117,6 +124,7 @@ var RCTPickerIOS = requireNativeComponent('RCTPicker', {
   },
 }, {
   nativeOnly: {
+    loop: true,
     items: true,
     onChange: true,
     selectedIndex: true,

--- a/React/Views/RCTPicker.h
+++ b/React/Views/RCTPicker.h
@@ -19,6 +19,7 @@
 @property (nonatomic, strong) UIColor *color;
 @property (nonatomic, strong) UIFont *font;
 @property (nonatomic, assign) NSTextAlignment textAlign;
+@property (nonatomic, assign) BOOL loop;
 
 @property (nonatomic, copy) RCTBubblingEventBlock onChange;
 

--- a/React/Views/RCTPicker.m
+++ b/React/Views/RCTPicker.m
@@ -82,10 +82,6 @@ numberOfRowsInComponent:(__unused NSInteger)component
   return [RCTConvert NSString:_items[row][@"label"]];
 }
 
-- (CGFloat)pickerView:(UIPickerView *)pickerView rowHeightForComponent:(NSInteger)component {
-    return _font.pointSize + 8;
-}
-
 - (UIView *)pickerView:(UIPickerView *)pickerView
             viewForRow:(NSInteger)row
           forComponent:(NSInteger)component

--- a/React/Views/RCTPicker.m
+++ b/React/Views/RCTPicker.m
@@ -24,6 +24,7 @@
     _font = [UIFont systemFontOfSize:21]; // TODO: selected title default should be 23.5
     _selectedIndex = NSNotFound;
     _textAlign = NSTextAlignmentCenter;
+    _loop = false;
     self.delegate = self;
   }
   return self;
@@ -40,7 +41,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
 - (void)setSelectedIndex:(NSInteger)selectedIndex
 {
   if (_selectedIndex != selectedIndex) {
-    BOOL animated = _selectedIndex != NSNotFound; // Don't animate the initial value
+    BOOL animated = _selectedIndex != NSNotFound && !_loop; // Don't animate the initial value
     _selectedIndex = selectedIndex;
     dispatch_async(dispatch_get_main_queue(), ^{
       [self selectRow:selectedIndex inComponent:0 animated:animated];
@@ -58,7 +59,11 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
 - (NSInteger)pickerView:(__unused UIPickerView *)pickerView
 numberOfRowsInComponent:(__unused NSInteger)component
 {
-  return _items.count;
+  NSInteger itemCount = _items.count;
+  if (_loop) {
+    itemCount *= 100;
+  }
+  return itemCount;
 }
 
 #pragma mark - UIPickerViewDelegate methods
@@ -67,6 +72,9 @@ numberOfRowsInComponent:(__unused NSInteger)component
              titleForRow:(NSInteger)row
             forComponent:(__unused NSInteger)component
 {
+  if (_loop) {
+    row %= _items.count;
+  }
   return [RCTConvert NSString:_items[row][@"label"]];
 }
 
@@ -95,7 +103,12 @@ numberOfRowsInComponent:(__unused NSInteger)component
 - (void)pickerView:(__unused UIPickerView *)pickerView
       didSelectRow:(NSInteger)row inComponent:(__unused NSInteger)component
 {
-  _selectedIndex = row;
+  if (_loop) {
+    row %= _items.count;
+    _selectedIndex = row + _items.count * 50;
+  } else {
+    _selectedIndex = row;
+  }
   if (_onChange) {
     _onChange(@{
       @"newIndex": @(row),

--- a/React/Views/RCTPicker.m
+++ b/React/Views/RCTPicker.m
@@ -18,7 +18,8 @@
 @implementation RCTPicker
 
 #define maxItems MAX(_items.count, 10000)
-#define itemCountMultiplier ((1 - _items.count / maxItems) * 100)
+#define minItemCountMultiplier 3
+#define itemCountMultiplier MAX(minItemCountMultiplier, ((1 - _items.count / maxItems) * 100))
 #define loopMiddle (_items.count * (itemCountMultiplier / 2))
 
 - (instancetype)initWithFrame:(CGRect)frame

--- a/React/Views/RCTPicker.m
+++ b/React/Views/RCTPicker.m
@@ -17,6 +17,10 @@
 
 @implementation RCTPicker
 
+#define maxItems MAX(_items.count, 10000)
+#define itemCountMultiplier ((1 - _items.count / maxItems) * 100)
+#define loopMiddle (_items.count * (itemCountMultiplier / 2))
+
 - (instancetype)initWithFrame:(CGRect)frame
 {
   if ((self = [super initWithFrame:frame])) {
@@ -61,7 +65,7 @@ numberOfRowsInComponent:(__unused NSInteger)component
 {
   NSInteger itemCount = _items.count;
   if (_loop) {
-    itemCount *= 100;
+    itemCount *= itemCountMultiplier;
   }
   return itemCount;
 }
@@ -109,7 +113,7 @@ numberOfRowsInComponent:(__unused NSInteger)component
 {
   if (_loop) {
     row %= _items.count;
-    _selectedIndex = row + _items.count * 50;
+    _selectedIndex = row + loopMiddle;
   } else {
     _selectedIndex = row;
   }

--- a/React/Views/RCTPicker.m
+++ b/React/Views/RCTPicker.m
@@ -78,6 +78,10 @@ numberOfRowsInComponent:(__unused NSInteger)component
   return [RCTConvert NSString:_items[row][@"label"]];
 }
 
+- (CGFloat)pickerView:(UIPickerView *)pickerView rowHeightForComponent:(NSInteger)component {
+    return _font.pointSize + 8;
+}
+
 - (UIView *)pickerView:(UIPickerView *)pickerView
             viewForRow:(NSInteger)row
           forComponent:(NSInteger)component

--- a/React/Views/RCTPickerManager.m
+++ b/React/Views/RCTPickerManager.m
@@ -26,6 +26,7 @@ RCT_EXPORT_VIEW_PROPERTY(selectedIndex, NSInteger)
 RCT_EXPORT_VIEW_PROPERTY(onChange, RCTBubblingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(color, UIColor)
 RCT_EXPORT_VIEW_PROPERTY(textAlign, NSTextAlignment)
+RCT_EXPORT_VIEW_PROPERTY(loop, BOOL)
 RCT_CUSTOM_VIEW_PROPERTY(fontSize, CGFloat, RCTPicker)
 {
   view.font = [RCTConvert UIFont:view.font withSize:json ?: @(defaultView.font.pointSize)];


### PR DESCRIPTION
## Motivation

I needed a styleable time picker for my app, and DatePicker was not a good choice. So I tried to create my own by using the PickerIOS component. 

But there were two small inconveniences that didn't give me the needed result:
- bigger font size makes the text clip at the top and bottom -  [Screenshot](http://i.imgur.com/PYDv5oO.png)
- there is no way to make the items wrap around like in the native DatePicker

This patch adds these features.
## Test Plan

Tested in my own app. 

Example code:

``` jsx
<Picker
  loop
  style={{ width: 100 }}
  itemStyle={{ color: 'white', fontFamily: 'Montserrat-Regular', fontSize: 50 }}
  selectedValue={this.state.minuteValue}
  onValueChange={this.state.onMinuteChange}>
  {[...Array(60)].map((_, i) => (
   <Picker.Item
     key={i}
     label={i < 10 ? `0${i.toString()}` : i.toString()}
     value={i} />
   ))}
</Picker>
```

Yields the following result: [Screenshot](http://i.imgur.com/YwK5fOc.png)

Final result: [Screenshot](http://i.imgur.com/1XShdID.png)
