### PR TITLE
Open to correct line on Webstorm, IntelliJ and AppCode

### DIFF
--- a/local-cli/server/util/launchEditor.js
+++ b/local-cli/server/util/launchEditor.js
@@ -52,6 +52,9 @@ function getArgumentsForLineNumber(editor, fileName, lineNumber, workspace) {
       return addWorkspaceToArgumentsIfExists([fileName + ':' + lineNumber], workspace);
     case 'subl':
     case 'sublime':
+    case 'wstorm':
+    case 'appcode':
+    case 'idea':  
       return [fileName + ':' + lineNumber];
     case 'joe':
     case 'emacs':


### PR DESCRIPTION
A tiny PR to add support for launching IDEA editors with the cursor at the correct line. The argument syntax is the same as sublime. 

The base names `wstorm`, `idea` and `appcode` are the default names when CLI launchers are created through 'Tools'->'Create Command-Line launcher' in the respective editor's gui.

Tested through a fork of RN on Webstorm, IntelliJ and AppCode for OSX and by manual invocation from CLI on IntelliJ for windows. 