### PR TITLE
[NativeAnimation] Move RCTNativeAnimatedModule onto the main queue

### DIFF
--- a/Libraries/NativeAnimation/RCTNativeAnimatedModule.m
+++ b/Libraries/NativeAnimation/RCTNativeAnimatedModule.m
@@ -47,6 +47,11 @@ RCT_EXPORT_MODULE()
   _propAnimationNodes = [NSMutableSet new];
 }
 
+- (dispatch_queue_t)methodQueue
+{
+  return dispatch_get_main_queue();
+}
+
 RCT_EXPORT_METHOD(createAnimatedNode:(nonnull NSNumber *)tag
                   config:(NSDictionary<NSString *, id> *)config)
 {


### PR DESCRIPTION
We're mutating dictionaries on one thread for bookkeeping (anytime we receive a call over the bridge) and iterating over them on the main thread each frame (in `updateAnimations`). Seems like this can all happen on the main thread without issue. Am I missing something?

**Test plan (required)**

Run UIExplorer NativeAnimated examples before and after - compare the results. Nothing should have changed.