### PR TITLE
[NativeAnimation] Maintain transform order

### DIFF
--- a/Libraries/Animated/src/AnimatedImplementation.js
+++ b/Libraries/Animated/src/AnimatedImplementation.js
@@ -1160,21 +1160,24 @@ class AnimatedTransform extends AnimatedWithChildren {
   }
 
   __getNativeConfig(): any {
-    var transConfig = {};
+    var transConfigs = [];
 
     this._transforms.forEach(transform => {
       for (var key in transform) {
         var value = transform[key];
         if (value instanceof Animated) {
-          transConfig[key] = value.__getNativeTag();
+          transConfigs.push({
+            property: key,
+            nodeTag: value.__getNativeTag(),
+          });
         }
       }
     });
 
-    NativeAnimatedHelper.validateTransform(transConfig);
+    NativeAnimatedHelper.validateTransform(transConfigs);
     return {
       type: 'transform',
-      transform: transConfig,
+      transforms: transConfigs,
     };
   }
 }

--- a/Libraries/Animated/src/NativeAnimatedHelper.js
+++ b/Libraries/Animated/src/NativeAnimatedHelper.js
@@ -87,7 +87,12 @@ var TRANSFORM_WHITELIST = {
   translateX: true,
   translateY: true,
   scale: true,
+  scaleX: true,
+  scaleY: true,
   rotate: true,
+  rotateX: true,
+  rotateY: true,
+  perspective: true,
 };
 
 function validateProps(params: Object): void {
@@ -98,12 +103,12 @@ function validateProps(params: Object): void {
   }
 }
 
-function validateTransform(config: Object): void {
-  for (var key in config) {
-    if (!TRANSFORM_WHITELIST.hasOwnProperty(key)) {
-      throw new Error(`Property '${key}' is not supported by native animated module`);
+function validateTransform(configs: Array<Object>): void {
+  configs.forEach((config) => {
+    if (!TRANSFORM_WHITELIST.hasOwnProperty(config.property)) {
+      throw new Error(`Property '${config.property}' is not supported by native animated module`);
     }
-  }
+  });
 }
 
 function validateStyles(styles: Object): void {

--- a/Libraries/NativeAnimation/Nodes/RCTPropsAnimatedNode.m
+++ b/Libraries/NativeAnimation/Nodes/RCTPropsAnimatedNode.m
@@ -10,7 +10,6 @@
 #import "RCTPropsAnimatedNode.h"
 #import "RCTAnimationUtils.h"
 #import "RCTNativeAnimatedModule.h"
-#import "RCTValueAnimatedNode.h"
 #import "RCTStyleAnimatedNode.h"
 #import "RCTViewPropertyMapper.h"
 
@@ -53,21 +52,10 @@
 
 - (void)performViewUpdatesIfNecessary
 {
-  NSMutableDictionary<NSString *, NSNumber *> *propsDictionary = [NSMutableDictionary dictionary];
-  NSDictionary<NSString *, NSNumber *> *props = self.config[@"props"];
-  [props enumerateKeysAndObjectsUsingBlock:^(NSString *property, NSNumber *nodeTag, __unused BOOL *stop) {
-    RCTAnimatedNode *node = self.parentNodes[nodeTag];
-    if (node) {
-      if ([node isKindOfClass:[RCTValueAnimatedNode class]]) {
-        RCTValueAnimatedNode *parentNode = (RCTValueAnimatedNode *)node;
-        [propsDictionary setObject:@(parentNode.value) forKey:property];
-      }
-    }
-  }];
-
-  [_propertyMapper updateViewWithProps:propsDictionary
-                                styles:_parentNode.stylesDictionary
-                             transform:_parentNode.transform];
+  NSDictionary *updates = [_parentNode updatedPropsDictionary];
+  if (updates.count) {
+    [_propertyMapper updateViewWithDictionary:updates];
+  }
 }
 
 @end

--- a/Libraries/NativeAnimation/Nodes/RCTPropsAnimatedNode.m
+++ b/Libraries/NativeAnimation/Nodes/RCTPropsAnimatedNode.m
@@ -10,6 +10,7 @@
 #import "RCTPropsAnimatedNode.h"
 #import "RCTAnimationUtils.h"
 #import "RCTNativeAnimatedModule.h"
+#import "RCTValueAnimatedNode.h"
 #import "RCTStyleAnimatedNode.h"
 #import "RCTViewPropertyMapper.h"
 
@@ -52,10 +53,21 @@
 
 - (void)performViewUpdatesIfNecessary
 {
-  NSDictionary *updates = [_parentNode updatedPropsDictionary];
-  if (updates.count) {
-    [_propertyMapper updateViewWithDictionary:updates];
-  }
+  NSMutableDictionary<NSString *, NSNumber *> *propsDictionary = [NSMutableDictionary dictionary];
+  NSDictionary<NSString *, NSNumber *> *props = self.config[@"props"];
+  [props enumerateKeysAndObjectsUsingBlock:^(NSString *property, NSNumber *nodeTag, __unused BOOL *stop) {
+    RCTAnimatedNode *node = self.parentNodes[nodeTag];
+    if (node) {
+      if ([node isKindOfClass:[RCTValueAnimatedNode class]]) {
+        RCTValueAnimatedNode *parentNode = (RCTValueAnimatedNode *)node;
+        [propsDictionary setObject:@(parentNode.value) forKey:property];
+      }
+    }
+  }];
+
+  [_propertyMapper updateViewWithProps:propsDictionary
+                                styles:_parentNode.stylesDictionary
+                             transform:_parentNode.transform];
 }
 
 @end

--- a/Libraries/NativeAnimation/Nodes/RCTStyleAnimatedNode.h
+++ b/Libraries/NativeAnimation/Nodes/RCTStyleAnimatedNode.h
@@ -7,10 +7,12 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#import <QuartzCore/QuartzCore.h>
 #import "RCTAnimatedNode.h"
 
 @interface RCTStyleAnimatedNode : RCTAnimatedNode
 
-- (NSDictionary<NSString *, NSNumber *> *)updatedPropsDictionary;
+@property (nonatomic, readonly) NSDictionary<NSString *, NSNumber *> *stylesDictionary;
+@property (nonatomic, readonly) CATransform3D transform;
 
 @end

--- a/Libraries/NativeAnimation/Nodes/RCTStyleAnimatedNode.h
+++ b/Libraries/NativeAnimation/Nodes/RCTStyleAnimatedNode.h
@@ -7,12 +7,10 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import <QuartzCore/QuartzCore.h>
 #import "RCTAnimatedNode.h"
 
 @interface RCTStyleAnimatedNode : RCTAnimatedNode
 
-@property (nonatomic, readonly) NSDictionary<NSString *, NSNumber *> *stylesDictionary;
-@property (nonatomic, readonly) CATransform3D transform;
+- (NSDictionary<NSString *, NSObject *> *)updatedPropsDictionary;
 
 @end

--- a/Libraries/NativeAnimation/Nodes/RCTTransformAnimatedNode.h
+++ b/Libraries/NativeAnimation/Nodes/RCTTransformAnimatedNode.h
@@ -7,10 +7,11 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#import <QuartzCore/QuartzCore.h>
 #import "RCTAnimatedNode.h"
 
 @interface RCTTransformAnimatedNode : RCTAnimatedNode
 
-- (NSDictionary<NSString *, NSNumber *> *)updatedPropsDictionary;
+@property (nonatomic, readonly) CATransform3D transform;
 
 @end

--- a/Libraries/NativeAnimation/Nodes/RCTTransformAnimatedNode.h
+++ b/Libraries/NativeAnimation/Nodes/RCTTransformAnimatedNode.h
@@ -7,11 +7,10 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import <QuartzCore/QuartzCore.h>
 #import "RCTAnimatedNode.h"
 
 @interface RCTTransformAnimatedNode : RCTAnimatedNode
 
-@property (nonatomic, readonly) CATransform3D transform;
+- (NSDictionary<NSString *, NSObject *> *)updatedPropsDictionary;
 
 @end

--- a/Libraries/NativeAnimation/Nodes/RCTTransformAnimatedNode.m
+++ b/Libraries/NativeAnimation/Nodes/RCTTransformAnimatedNode.m
@@ -11,6 +11,23 @@
 #import "RCTValueAnimatedNode.h"
 
 @implementation RCTTransformAnimatedNode
+{
+  NSMutableDictionary<NSString *, NSObject *> *_updatedPropsDictionary;
+}
+
+- (instancetype)initWithTag:(NSNumber *)tag
+                     config:(NSDictionary<NSString *, id> *)config;
+{
+  if ((self = [super initWithTag:tag config:config])) {
+    _updatedPropsDictionary = [NSMutableDictionary new];
+  }
+  return self;
+}
+
+- (NSDictionary *)updatedPropsDictionary
+{
+  return _updatedPropsDictionary;
+}
 
 - (void)performUpdate
 {
@@ -23,7 +40,7 @@
     NSNumber *nodeTag = transformConfig[@"nodeTag"];
 
     RCTAnimatedNode *node = self.parentNodes[nodeTag];
-    if ([node isKindOfClass:[RCTValueAnimatedNode class]]) {
+    if (node.hasUpdated && [node isKindOfClass:[RCTValueAnimatedNode class]]) {
       RCTValueAnimatedNode *parentNode = (RCTValueAnimatedNode *)node;
 
       NSString *property = transformConfig[@"property"];
@@ -59,7 +76,13 @@
     }
   }
 
-  _transform = transform;
+  _updatedPropsDictionary[@"transform"] = [NSValue valueWithCATransform3D:transform];
+}
+
+- (void)cleanupAnimationUpdate
+{
+  [super cleanupAnimationUpdate];
+  [_updatedPropsDictionary removeAllObjects];
 }
 
 @end

--- a/Libraries/NativeAnimation/RCTViewPropertyMapper.h
+++ b/Libraries/NativeAnimation/RCTViewPropertyMapper.h
@@ -6,7 +6,9 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
+
 #import <Foundation/Foundation.h>
+#import <QuartzCore/QuartzCore.h>
 
 @class RCTNativeAnimatedModule;
 
@@ -17,6 +19,8 @@
 - (instancetype)initWithViewTag:(NSNumber *)viewTag
                 animationModule:(RCTNativeAnimatedModule *)animationModule NS_DESIGNATED_INITIALIZER;
 
-- (void)updateViewWithDictionary:(NSDictionary<NSString *, NSNumber *> *)updates;
+- (void)updateViewWithProps:(NSDictionary<NSString *, NSNumber *> *)props
+                     styles:(NSDictionary<NSString *, NSNumber *> *)styles
+                  transform:(CATransform3D)transform;
 
 @end

--- a/Libraries/NativeAnimation/RCTViewPropertyMapper.h
+++ b/Libraries/NativeAnimation/RCTViewPropertyMapper.h
@@ -8,7 +8,6 @@
  */
 
 #import <Foundation/Foundation.h>
-#import <QuartzCore/QuartzCore.h>
 
 @class RCTNativeAnimatedModule;
 
@@ -19,8 +18,6 @@
 - (instancetype)initWithViewTag:(NSNumber *)viewTag
                 animationModule:(RCTNativeAnimatedModule *)animationModule NS_DESIGNATED_INITIALIZER;
 
-- (void)updateViewWithProps:(NSDictionary<NSString *, NSNumber *> *)props
-                     styles:(NSDictionary<NSString *, NSNumber *> *)styles
-                  transform:(CATransform3D)transform;
+- (void)updateViewWithDictionary:(NSDictionary<NSString *, NSObject *> *)updates;
 
 @end

--- a/Libraries/NativeAnimation/RCTViewPropertyMapper.m
+++ b/Libraries/NativeAnimation/RCTViewPropertyMapper.m
@@ -14,80 +14,53 @@
 #import "RCTBridge.h"
 #import "RCTUIManager.h"
 #import "RCTNativeAnimatedModule.h"
+#import "RCTTransformAnimatedNode.h"
 
 @implementation RCTViewPropertyMapper
 {
-  CGFloat _translateX;
-  CGFloat _translateY;
-  CGFloat _scaleX;
-  CGFloat _scaleY;
-  CGFloat _rotation;
   RCTNativeAnimatedModule *_animationModule;
+  CATransform3D _lastTransform;
+  CGFloat _lastOpacity;
 }
 
 - (instancetype)initWithViewTag:(NSNumber *)viewTag
                 animationModule:(RCTNativeAnimatedModule *)animationModule
 {
   if ((self = [super init])) {
-    _animationModule = animationModule;
     _viewTag = viewTag;
-    _translateX = 0;
-    _translateY = 0;
-    _scaleX = 1;
-    _scaleY = 1;
-    _rotation = 0;
+    _animationModule = animationModule;
+    _lastTransform = CATransform3DIdentity;
+    _lastOpacity = 1.0;
   }
   return self;
 }
 
 RCT_NOT_IMPLEMENTED(- (instancetype)init)
 
-- (void)updateViewWithDictionary:(NSDictionary<NSString *, NSNumber *> *)updates
+- (void)updateViewWithProps:(NSDictionary<NSString *,NSNumber *> *)props
+                     styles:(NSDictionary<NSString *,NSNumber *> *)styles
+                  transform:(CATransform3D)transform
 {
-  if (updates.count) {
-    UIView *view = [_animationModule.bridge.uiManager viewForReactTag:_viewTag];
-    if (!view) {
-      return;
-    }
+  UIView *view = [_animationModule.bridge.uiManager viewForReactTag:_viewTag];
+  if (!view) {
+    return;
+  }
 
-    NSNumber *opacity = updates[@"opacity"];
-    if (opacity) {
-      view.alpha = opacity.doubleValue;
+  if (styles.count) {
+    NSNumber *opacityUpdate = styles[@"opacity"];
+    if (opacityUpdate) {
+      CGFloat opacity = opacityUpdate.floatValue;
+      if (opacity != _lastOpacity) {
+        view.alpha = opacity;
+        _lastOpacity = opacity;
+      }
     }
+  }
 
-    NSNumber *scale = updates[@"scale"];
-    if (scale) {
-      _scaleX = scale.doubleValue;
-      _scaleY = scale.doubleValue;
-    }
-    NSNumber *scaleX = updates[@"scaleX"];
-    if (scaleX) {
-      _scaleX = scaleX.doubleValue;
-    }
-    NSNumber *scaleY = updates[@"scaleY"];
-    if (scaleY) {
-      _scaleY = scaleY.doubleValue;
-    }
-    NSNumber *translateX = updates[@"translateX"];
-    if (translateX) {
-      _translateX = translateX.doubleValue;
-    }
-    NSNumber *translateY = updates[@"translateY"];
-    if (translateY) {
-      _translateY = translateY.doubleValue;
-    }
-    NSNumber *rotation = updates[@"rotate"];
-    if (rotation) {
-      _rotation = rotation.doubleValue;
-    }
-
-    if (translateX || translateY || scale || scaleX || scaleY || rotation) {
-      CATransform3D xform = CATransform3DMakeScale(_scaleX, _scaleY, 0);
-      xform = CATransform3DTranslate(xform, _translateX, _translateY, 0);
-      xform = CATransform3DRotate(xform, _rotation, 0, 0, 1);
-      view.layer.allowsEdgeAntialiasing = YES;
-      view.layer.transform = xform;
-    }
+  if (!CATransform3DEqualToTransform(transform, _lastTransform)) {
+    view.layer.allowsEdgeAntialiasing = YES;
+    view.layer.transform = transform;
+    _lastTransform = transform;
   }
 }
 


### PR DESCRIPTION
This diff addresses the issues raised by @kmagiera in https://github.com/facebook/react-native/pull/7884. Transforms should be applied in the order they are defined, just like in `processTransform.js`. A scale applied before a translation, for instance, should give a different result than a translation applied before a scale.

We leverage CATransform3D to do the heavy lifting. A concatenated transform is passed all the way to `RCTViewPropertyMapper`. It is compared with the transform currently applied to the view, and if different, applied. The same approach is used for opacity.

I think it makes the most sense to do this diffing in `RCTViewPropertyMapper`, as opposed to creating and cleaning up an `_updatedPropsDictionary` each frame in `RCTTransformAnimatedNode` and `RCTStyleAnimatedNode`. The node should keep its full value; applying a minimal set of altered props is an optimization.  The higher up this optimization is implemented, the more assumptions it makes. e.g. that there will only ever be a single Style parent, that the view props cannot be altered outside the display link, etc. Happy to discuss.

**Test plan (required)**

Run UIExplorer NativeAnimated examples before and after - compare the results. Nothing should have changed.