### PR TITLE
Fix misleading docstring on getInitialNotification

### DIFF
--- a/Libraries/PushNotificationIOS/PushNotificationIOS.js
+++ b/Libraries/PushNotificationIOS/PushNotificationIOS.js
@@ -284,8 +284,8 @@ class PushNotificationIOS {
   }
 
   /**
-   * If the app launch was triggered by a push notification,
-   * it will give the notification object, otherwise it will give `null`
+   * This method returns a promise that resolves to either the notification
+   * object if the app was launched by a push notification, or `null` otherwise.
    */
   static getInitialNotification(): Promise<?PushNotificationIOS> {
     return RCTPushNotificationManager.getInitialNotification().then(notification => {


### PR DESCRIPTION
The docs heavily implied that this method returned a notification object or null directly, like popInitialNotification used to do. In fact, it returns a promise. This change clarifies this.

Note that:
- This is purely a comment change, so no testing required.
- I've adhered to the 80 character line limit, and can't think of any other style rules you might have that could apply here.