### PR TITLE
Updated ScrollView's keyboardShouldPersistTaps doc

### DIFF
--- a/Libraries/Components/ScrollView/ScrollView.js
+++ b/Libraries/Components/ScrollView/ScrollView.js
@@ -178,9 +178,9 @@ const ScrollView = React.createClass({
     ]),
     /**
      * When false, tapping outside of the focused text input when the keyboard
-     * is up dismisses the keyboard. When true, the scroll view will not catch
-     * taps, and the keyboard will not dismiss automatically. The default value
-     * is false.
+     * is up dismisses the keyboard. When true, the keyboard will not dismiss 
+     * automatically, and the scroll view will not catch taps, but children of
+     * the scroll view can catch taps. The default value is false.
      */
     keyboardShouldPersistTaps: PropTypes.bool,
     /**

--- a/Libraries/Components/ScrollView/ScrollView.js
+++ b/Libraries/Components/ScrollView/ScrollView.js
@@ -178,7 +178,7 @@ const ScrollView = React.createClass({
     ]),
     /**
      * When false, tapping outside of the focused text input when the keyboard
-     * is up dismisses the keyboard. When true, the keyboard will not dismiss 
+     * is up dismisses the keyboard. When true, the keyboard will not dismiss
      * automatically, and the scroll view will not catch taps, but children of
      * the scroll view can catch taps. The default value is false.
      */


### PR DESCRIPTION
I noticed that even when a ScrollView's `keyboardShouldPersistTaps` prop is set to true, the ScrollView's children can still respond to tap events (even if the scroll view itself will not respond to tap events and the keyboard does not dismiss automatically). This is a point of ambiguity in the React Native docs; it implies that no touch events can be handled if `keyboardShouldPersistTaps` is set to true.