### PR TITLE
Way to pass styles to nested view

### DIFF
--- a/Libraries/Components/Keyboard/KeyboardAvoidingView.js
+++ b/Libraries/Components/Keyboard/KeyboardAvoidingView.js
@@ -53,11 +53,12 @@ const KeyboardAvoidingView = React.createClass({
   propTypes: {
     ...View.propTypes,
     behavior: PropTypes.oneOf(['height', 'position', 'padding']),
-
+    nestedStyle: View.propTypes.style,
     /**
      * This is the distance between the top of the user screen and the react native view,
      * may be non-zero in some use cases.
      */
+
     keyboardVerticalOffset: PropTypes.number.isRequired,
   },
 
@@ -160,9 +161,11 @@ const KeyboardAvoidingView = React.createClass({
 
       case 'position':
         const positionStyle = {bottom: this.state.bottom};
+        const { nestedStyle } = this.props;
+
         return (
           <View ref={viewRef} style={style} onLayout={this.onLayout} {...props}>
-            <View style={positionStyle}>
+            <View style={[positionStyle, nestedStyle]}>
               {children}
             </View>
           </View>

--- a/Libraries/Components/Keyboard/KeyboardAvoidingView.js
+++ b/Libraries/Components/Keyboard/KeyboardAvoidingView.js
@@ -57,15 +57,7 @@ const KeyboardAvoidingView = React.createClass({
     /**
      * The style of the content container(View) when behavior is 'position'.
      */
-    contentContainerStyle (props, propName, componentName) {
-      const isStyle = View.propTypes.style;
-
-      if (props[propName] && props.behavior !== 'position') {
-        return new Error('contentContainerStyle prop only available for position behavior');
-      }
-
-      return isStyle(props, propName, componentName);
-    },
+    contentContainerStyle: View.propTypes.style,
     
     /**
      * This is the distance between the top of the user screen and the react native view,
@@ -177,7 +169,7 @@ const KeyboardAvoidingView = React.createClass({
 
         return (
           <View ref={viewRef} style={style} onLayout={this.onLayout} {...props}>
-            <View style={[positionStyle, contentContainerStyle]}>
+            <View style={[contentContainerStyle, positionStyle]}>
               {children}
             </View>
           </View>

--- a/Libraries/Components/Keyboard/KeyboardAvoidingView.js
+++ b/Libraries/Components/Keyboard/KeyboardAvoidingView.js
@@ -53,12 +53,16 @@ const KeyboardAvoidingView = React.createClass({
   propTypes: {
     ...View.propTypes,
     behavior: PropTypes.oneOf(['height', 'position', 'padding']),
+    
+    /**
+     * The style of the content container(View) when behavior is 'position'.
+     */
     contentContainerStyle: View.propTypes.style,
+    
     /**
      * This is the distance between the top of the user screen and the react native view,
      * may be non-zero in some use cases.
      */
-
     keyboardVerticalOffset: PropTypes.number.isRequired,
   },
 

--- a/Libraries/Components/Keyboard/KeyboardAvoidingView.js
+++ b/Libraries/Components/Keyboard/KeyboardAvoidingView.js
@@ -57,7 +57,15 @@ const KeyboardAvoidingView = React.createClass({
     /**
      * The style of the content container(View) when behavior is 'position'.
      */
-    contentContainerStyle: View.propTypes.style,
+    contentContainerStyle (props, propName, componentName) {
+      const isStyle = View.propTypes.style;
+
+      if (props.behavior !== 'position') {
+        return new Error('contentContainerStyle prop only available for position behavior');
+      }
+
+      return isStyle(props, propName, componentName);
+    },
     
     /**
      * This is the distance between the top of the user screen and the react native view,

--- a/Libraries/Components/Keyboard/KeyboardAvoidingView.js
+++ b/Libraries/Components/Keyboard/KeyboardAvoidingView.js
@@ -60,7 +60,7 @@ const KeyboardAvoidingView = React.createClass({
     contentContainerStyle (props, propName, componentName) {
       const isStyle = View.propTypes.style;
 
-      if (props.behavior !== 'position') {
+      if (props[propName] && props.behavior !== 'position') {
         return new Error('contentContainerStyle prop only available for position behavior');
       }
 

--- a/Libraries/Components/Keyboard/KeyboardAvoidingView.js
+++ b/Libraries/Components/Keyboard/KeyboardAvoidingView.js
@@ -53,7 +53,7 @@ const KeyboardAvoidingView = React.createClass({
   propTypes: {
     ...View.propTypes,
     behavior: PropTypes.oneOf(['height', 'position', 'padding']),
-    nestedStyle: View.propTypes.style,
+    contentContainerStyle: View.propTypes.style,
     /**
      * This is the distance between the top of the user screen and the react native view,
      * may be non-zero in some use cases.
@@ -161,11 +161,11 @@ const KeyboardAvoidingView = React.createClass({
 
       case 'position':
         const positionStyle = {bottom: this.state.bottom};
-        const { nestedStyle } = this.props;
+        const { contentContainerStyle } = this.props;
 
         return (
           <View ref={viewRef} style={style} onLayout={this.onLayout} {...props}>
-            <View style={[positionStyle, nestedStyle]}>
+            <View style={[positionStyle, contentContainerStyle]}>
               {children}
             </View>
           </View>


### PR DESCRIPTION
Ability to pass styles to nested view for _position_ behavior.

Use case:

``` jsx
<KeyboardAvoidingView
          behavior={'position'}
          style={{ flex: 1 }}
          contentContainerStyle={{ flex: 1 }}
          keyboardVerticalOffset={ - VERTICAL_OFFSET }
>
          <SomeContainer   />
</KeyboardAvoidingView>
```