### PR TITLE
UIExplorer: fix navigation animation by using props passed to renderTitleComponent

### DIFF
--- a/Examples/UIExplorer/js/NavigationExperimental/NavigationCardStack-NavigationHeader-Tabs-example.js
+++ b/Examples/UIExplorer/js/NavigationExperimental/NavigationCardStack-NavigationHeader-Tabs-example.js
@@ -333,10 +333,10 @@ const YourHeader = createAppNavigationContainer(class extends Component {
     this.props.navigate({type: 'pop'});
   }
 
-  _renderTitleComponent(): ReactElement {
+  _renderTitleComponent(props: Object): ReactElement {
     return (
       <NavigationHeader.Title>
-        {this.props.scene.route.key}
+        {props.scene.route.key}
       </NavigationHeader.Title>
     );
   }


### PR DESCRIPTION
The animation shown in the UIExplorer example for NavigationExperimental's NavigationHeader is not working correctly. Due to an incomplete use of the `renderTitleComponent()` callback, interpolation is not working correctly in this example.

Even if the animation error is subtle, since the examples are followed by developers quite closely, the bug may multiply if not corrected in the sample code. 

This is a really *tiny* modification that fixes that particular animation.
