### PR TITLE
Update doc IntegrationWithExistingApps doc: Add activity theme

### DIFF
--- a/docs/IntegrationWithExistingApps.md
+++ b/docs/IntegrationWithExistingApps.md
@@ -630,6 +630,16 @@ public class MyReactActivity extends Activity implements DefaultHardwareBackBtnH
     }
 }
 ```
+We need set the theme of `MyReactActivity` to `Theme.AppCompat.Light.NoActionBar` beause some components rely on this theme.
+```xml
+<activity
+  android:name=".MyReactActivity"
+  android:label="@string/app_name"
+  android:theme="@style/Theme.AppCompat.Light.NoActionBar">
+</activity>
+```
+
+
 
 > A `ReactInstanceManager` can be shared amongst multiple activities and/or fragments. You will want to make your own `ReactFragment` or `ReactActivity` and have a singleton *holder* that holds a `ReactInstanceManager`. When you need the `ReactInstanceManager` (e.g., to hook up the `ReactInstanceManager` to the lifecycle of those Activities or Fragments) use the one provided by the singleton.
 


### PR DESCRIPTION
Beause I found `Switch`  can't work beause the app theme set `showText` to true. It works when the theme is sett to `Theme.AppCompat.Light.NoActionBar`.
Maybe it is necessary to let users knows this and set the default theme to `Theme.AppCompat.Light.NoActionBar`.