### PR TITLE
Fix bad link typo in View document

### DIFF
--- a/Libraries/Components/View/View.js
+++ b/Libraries/Components/View/View.js
@@ -194,7 +194,7 @@ const View = React.createClass({
      *  - `'no-hide-descendants'` - The view is not important for accessibility,
      *    nor are any of its descendant views.
      *
-     * See the [Android `importantForAccessibility` docs]( [http://developer.android.com/reference/android/R.attr.html#importantForAccessibility)
+     * See the [Android `importantForAccessibility` docs](http://developer.android.com/reference/android/R.attr.html#importantForAccessibility)
      * for reference.
      *
      * @platform android


### PR DESCRIPTION
This is trivial. 

It fixes a bad link in http://facebook.github.io/react-native/docs/view.html#importantforaccessibility (the "Android importantForAccessibility docs" link).