### PR TITLE
Fix flow error in Flow error in NavigationError/NavigationHeaderTitle

### DIFF
--- a/Libraries/CustomComponents/NavigationExperimental/NavigationHeaderTitle.js
+++ b/Libraries/CustomComponents/NavigationExperimental/NavigationHeaderTitle.js
@@ -43,13 +43,12 @@ const {
 } = ReactNative;
 
 type Props = {
-  children: ReactElement<any>;
+  children?: ReactElement<any>;
   style?: any;
   textStyle?: any;
   viewProps?: any;
 }
 
-// $FlowIssue(>=0.26.0) #11432532
 const NavigationHeaderTitle = ({ children, style, textStyle, viewProps }: Props) => (
   <View style={[ styles.title, style ]} {...viewProps}>
     <Text style={[ styles.titleText, textStyle ]}>{children}</Text>


### PR DESCRIPTION
Summary:
Fixes the "Unused suppression" error in NavigationHeaderTitle.
This closes https://github.com/facebook/react-native/issues/9058