### PR TITLE
Add note to networking docs about iOS ATS exceptions

### DIFF
--- a/docs/Networking.md
+++ b/docs/Networking.md
@@ -75,6 +75,8 @@ You can also use the proposed ES2017 `async`/`await` syntax in a React Native ap
 
 Don't forget to catch any errors that may be thrown by `fetch`, otherwise they will be dropped silently.
 
+> By default, iOS will block any request that's not encrypted using SSL. If you need to fetch from a cleartext URL (one that begins with `http`) you will first need to add an App Transport Security exception. If you know ahead of time what domains you will need access to, it is more secure to add exceptions just for those domains; if the domains are not known until runtime you can [disable ATS completely](/react-native/docs/integration-with-existing-apps.html#app-transport-security). [See Apple's documentation for more information](https://developer.apple.com/library/ios/documentation/General/Reference/InfoPlistKeyReference/Articles/CocoaKeys.html#//apple_ref/doc/uid/TP40009251-SW33).
+
 ### Using Other Networking Libraries
 
 The [XMLHttpRequest API](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest) is built in to React Native. This means that you can use third party libraries such as [frisbee](https://github.com/niftylettuce/frisbee) or [axios](https://github.com/mzabriskie/axios) that depend on it, or you can use the XMLHttpRequest API directly if you prefer.


### PR DESCRIPTION
@JoelMarcey requested that I make this PR based on [my comment](https://github.com/facebook/react-native/commit/7ac931ee9b5e06ef1935d18e5b6a1e282db16c56#commitcomment-18270206).

I have signed the CLA.
However I was unable to verify that the site builds with this change. It looks okay in my markdown editor, but when following the contributor docs and running `npm install && npm start`, I get the following error when hitting node in my browser:

```
error in renderAPI for ../node_modules/react/lib/NativeMethodsMixin.js
Error: ENOENT: no such file or directory, open '../node_modules/react/lib/NativeMethodsMixin.js'
    at Error (native)
    at Object.fs.openSync (fs.js:634:18)
    at Object.fs.readFileSync (fs.js:502:33)
    at renderAPI (/Users/eliot/Dev/react/react-native/website/server/extractDocs.js:439:28)
    at concat.apis.map (/Users/eliot/Dev/react/react-native/website/server/extractDocs.js:601:14)
    at Array.map (native)
    at module.exports (/Users/eliot/Dev/react/react-native/website/server/extractDocs.js:600:10)
    at execute (/Users/eliot/Dev/react/react-native/website/server/convert.js:137:3)
    at Object.handle (/Users/eliot/Dev/react/react-native/website/server/server.js:49:7)
    at next (/Users/eliot/Dev/react/react-native/website/node_modules/connect/lib/proto.js:190:15)
```

I think this is a problem with my environment but I'm not sure.