### PR TITLE
Android WebSocket: include cookies in request

### DIFF
--- a/Examples/UIExplorer/js/http_test_server.js
+++ b/Examples/UIExplorer/js/http_test_server.js
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+
+/**
+ * The examples provided by Facebook are for non-commercial testing and
+ * evaluation purposes only.
+ *
+ * Facebook reserves all rights not expressly granted.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON INFRINGEMENT. IN NO EVENT SHALL
+ * FACEBOOK BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * @flow
+ */
+'use strict';
+
+/* eslint-env node */
+
+console.log(`\
+Test server for WebSocketExample
+
+This will set a cookie named "wstest" on the response of any incoming request.
+`);
+
+const connect = require('connect');
+const http = require('http');
+
+const app = connect();
+
+app.use(function(req, res) {
+  console.log('received request');
+  const cookieOptions = {
+    //httpOnly: true, // the cookie is not accessible by the user (javascript,...)
+    secure: false, // allow HTTP
+  };
+  res.cookie('wstest', 'OK', cookieOptions);
+  res.end('Cookie has been set!\n');
+});
+
+http.createServer(app).listen(5556);

--- a/Examples/UIExplorer/js/websocket_test_server.js
+++ b/Examples/UIExplorer/js/websocket_test_server.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
  * All rights reserved.
@@ -29,7 +31,7 @@ const WebSocket = require('ws');
 console.log(`\
 Test server for WebSocketExample
 
-This will send each incoming message right back to the other side.a
+This will send each incoming message right back to the other side.
 Restart with the '--binary' command line flag to have it respond with an
 ArrayBuffer instead of a string.
 `);
@@ -39,6 +41,7 @@ const server = new WebSocket.Server({port: 5555});
 server.on('connection', (ws) => {
   ws.on('message', (message) => {
     console.log('Received message:', message);
+    console.log('Cookie:', ws.upgradeReq.headers.cookie);
     if (respondWithBinary) {
       message = new Buffer(message);
     }

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/websocket/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/websocket/BUCK
@@ -14,6 +14,7 @@ android_library(
     react_native_target('java/com/facebook/react/common:common'),
     react_native_target('java/com/facebook/react/module/annotations:annotations'),
     react_native_target('java/com/facebook/react/modules/core:core'),
+    react_native_target('java/com/facebook/react/modules/network:network'),
   ],
   visibility = [
     'PUBLIC',

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/websocket/WebSocketModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/websocket/WebSocketModule.java
@@ -29,6 +29,7 @@ import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.common.ReactConstants;
 import com.facebook.react.module.annotations.ReactModule;
 import com.facebook.react.modules.core.DeviceEventManagerModule;
+import com.facebook.react.modules.network.ForwardingCookieHandler;
 
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
@@ -43,6 +44,7 @@ import java.net.URISyntaxException;
 import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import okio.Buffer;
@@ -54,10 +56,12 @@ public class WebSocketModule extends ReactContextBaseJavaModule {
   private final Map<Integer, WebSocket> mWebSocketConnections = new HashMap<>();
 
   private ReactContext mReactContext;
+  private ForwardingCookieHandler mCookieHandler;
 
   public WebSocketModule(ReactApplicationContext context) {
     super(context);
     mReactContext = context;
+    mCookieHandler = new ForwardingCookieHandler(context);
   }
 
   private void sendEvent(String eventName, WritableMap params) {
@@ -87,11 +91,16 @@ public class WebSocketModule extends ReactContextBaseJavaModule {
         .tag(id)
         .url(url);
 
+    String cookie = getCookie(url);
+    if (cookie != null) {
+      builder.addHeader("Cookie", cookie);
+    }
+
     if (headers != null) {
       ReadableMapKeySetIterator iterator = headers.keySetIterator();
 
       if (!headers.hasKey("origin")) {
-        builder.addHeader("origin", setDefaultOrigin(url));
+        builder.addHeader("origin", getDefaultOrigin(url));
       }
 
       while (iterator.hasNextKey()) {
@@ -105,7 +114,7 @@ public class WebSocketModule extends ReactContextBaseJavaModule {
         }
       }
     } else {
-      builder.addHeader("origin", setDefaultOrigin(url));
+      builder.addHeader("origin", getDefaultOrigin(url));
     }
 
     if (protocols != null && protocols.size() > 0) {
@@ -256,13 +265,13 @@ public class WebSocketModule extends ReactContextBaseJavaModule {
   }
 
   /**
-   * Set a default origin
+   * Get the default HTTP(S) origin for a specific WebSocket URI
    *
-   * @param Websocket connection endpoint
-   * @return A string of the endpoint converted to HTTP protocol
+   * @param String uri
+   * @return A string of the endpoint converted to HTTP protocol (http[s]://host[:port])
    */
 
-  private static String setDefaultOrigin(String uri) {
+  private static String getDefaultOrigin(String uri) {
     try {
       String defaultOrigin;
       String scheme = "";
@@ -285,8 +294,31 @@ public class WebSocketModule extends ReactContextBaseJavaModule {
       }
 
       return defaultOrigin;
+
     } catch (URISyntaxException e) {
-        throw new IllegalArgumentException("Unable to set " + uri + " as default origin header.");
+      throw new IllegalArgumentException("Unable to set " + uri + " as default origin header");
+    }
+  }
+
+  /**
+   * Get the cookie for a specific domain
+   *
+   * @param String uri
+   * @return The cookie header or null if none is set
+   */
+  private String getCookie(String uri) {
+    try {
+      URI origin = new URI(getDefaultOrigin(uri));
+      Map<String, List<String>> cookieMap = mCookieHandler.get(origin, new HashMap());
+      List<String> cookieList = cookieMap.get("Cookie");
+
+      if (cookieList == null || cookieList.isEmpty()) {
+        return null;
+      }
+
+      return cookieList.get(0);
+    } catch (URISyntaxException | IOException e) {
+      throw new IllegalArgumentException("Unable to get cookie from " + uri);
     }
   }
 }


### PR DESCRIPTION
This PR updates #6851 from @srikanthkh, fixing coding conventions and javadoc, and adding a test plan.
## Test plan

Added testing functions into the WebSocketExample page of the UIExplorer, including a tiny http server to set a cookie on demand. Instructions included in the UIExplorer app.
