### PR TITLE
Fix scoped modules

### DIFF
--- a/local-cli/rnpm/core/src/config/index.js
+++ b/local-cli/rnpm/core/src/config/index.js
@@ -31,7 +31,7 @@ exports.getProjectConfig = function getProjectConfig() {
 exports.getDependencyConfig = function getDependencyConfig(packageName) {
   const folder = path.join(process.cwd(), 'node_modules', packageName);
   const rnpm = getRNPMConfig(
-    path.join(process.cwd(), 'node_modules', packageName.split('/')[0])
+    path.join(process.cwd(), 'node_modules', packageName)
   );
 
   return Object.assign({}, rnpm, {


### PR DESCRIPTION
see https://github.com/facebook/react-native/issues/8623

**Background:**
Back in a days, one buggy patch sneaked into rnpm master. It was intended to fix `react-native-fbsdk` installation for version 0.1.0 (not required in version 0.3.0). Nowadays, we see that this patch break scoped modules `@like/this`, so this PR fixes it (basically, reverting the patch).

**Test plan (required)**
- [x] Try to link unscoped react-native package
- [x] Try to link scoped react-native package
**Code formatting**

Look around. Match the style of the rest of the codebase. See also the simple [style guide](https://github.com/facebook/react-native/blob/master/CONTRIBUTING.md#style-guide).

For more info, see the ["Pull Requests" section of our "Contributing" guidelines](https://github.com/facebook/react-native/blob/master/CONTRIBUTING.md#pull-requests).

