### PR TITLE
Make onUnhandled safe for undefined errors

### DIFF
--- a/Libraries/Promise.js
+++ b/Libraries/Promise.js
@@ -16,8 +16,8 @@ const Promise = require('fbjs/lib/Promise.native');
 if (__DEV__) {
   require('promise/setimmediate/rejection-tracking').enable({
     allRejections: true,
-    onUnhandled: (id, error) => {
-      const {message, stack} = error;
+    onUnhandled: (id, error = {}) => {
+      const {message = null, stack = null} = error;
       const warning =
         `Possible Unhandled Promise Rejection (id: ${id}):\n` +
         (message == null ? '' : `${message}\n`) +


### PR DESCRIPTION
This pull request fixes cases where the `error` argument of the `onUnhandled` method in `Libraries/Promise.js` is undefined. Previously this would result in a redbox with the helpful message: `Cannot read property message of undefined`. With this pull request, unhandled promise rejections result in the desired yellowbox saying that a promise rejection went unhandled.

I still do not know what would cause the error argument to be undefined, but this change makes the module behave as expected in an app I am building.

cc @bestander 

Relevant issue: #8452 