### PR TITLE
[NativeAnimation] Problems & solutions

### DIFF
--- a/Examples/UIExplorer/js/NativeAnimationsProblemExample.js
+++ b/Examples/UIExplorer/js/NativeAnimationsProblemExample.js
@@ -1,0 +1,120 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * The examples provided by Facebook are for non-commercial testing and
+ * evaluation purposes only.
+ *
+ * Facebook reserves all rights not expressly granted.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON INFRINGEMENT. IN NO EVENT SHALL
+ * FACEBOOK BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * @flow
+ */
+'use strict';
+
+var React = require('react');
+var ReactNative = require('react-native');
+var {
+  View,
+  Text,
+  Animated,
+  StyleSheet,
+  TouchableWithoutFeedback,
+} = ReactNative;
+
+class Tester extends React.Component {
+
+  static title = 'Native Animated Problem';
+  static description = 'Test out Native Animations';
+
+  state = {
+    opacity: new Animated.Value(0.25, {useNativeDriver: true}),
+    showBlock2: false,
+  };
+
+  visible = false;
+
+  runAnimation = () => {
+    this.visible = !this.visible;
+    Animated.timing(this.state.opacity, {
+      toValue: this.visible ? 1 : 0.25,
+      duration: 500,
+      useNativeDriver: true,
+    }).start();
+  };
+
+  render() {
+    return (
+      <View style={styles.container}>
+        <View style={styles.section}>
+          <TouchableWithoutFeedback onPress={this.runAnimation}>
+            <View style={styles.button}>
+              <Text>{'Run animation'}</Text>
+            </View>
+          </TouchableWithoutFeedback>
+        </View>
+        <View style={styles.section}>
+          <TouchableWithoutFeedback onPress={() => {
+            this.setState({
+              showBlock2: !this.state.showBlock2,
+            });
+          }}>
+            <View style={styles.button}>
+              <Text>{'Toggle block 2'}</Text>
+            </View>
+          </TouchableWithoutFeedback>
+        </View>
+        <View style={styles.section}>
+          {this._renderBlock(1)}
+        </View>
+        <View style={styles.section}>
+          {this.state.showBlock2 && this._renderBlock(2)}
+        </View>
+      </View>
+    );
+  }
+
+  _renderBlock(key: number) {
+    return (
+      <Animated.View
+          key={key}
+          style={[
+            styles.block,
+            {
+              opacity: this.state.opacity,
+            }
+          ]}
+        />
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  container: {
+    padding: 10,
+  },
+  button: {
+    padding: 10,
+    backgroundColor: 'green',
+  },
+  section: {
+    marginBottom: 20,
+  },
+  block: {
+    width: 50,
+    height: 50,
+    backgroundColor: 'blue',
+  },
+});
+
+module.exports = Tester;

--- a/Examples/UIExplorer/js/UIExplorerList.android.js
+++ b/Examples/UIExplorer/js/UIExplorerList.android.js
@@ -180,6 +180,10 @@ const APIExamples: Array<UIExplorerExample> = [
     module: require('./NativeAnimationsExample'),
   },
   {
+    key: 'NativeAnimationsProblemExample',
+    module: require('./NativeAnimationsProblemExample'),
+  },
+  {
     key: 'NavigationExperimentalExample',
     module: require('./NavigationExperimental/NavigationExperimentalExample'),
   },

--- a/Examples/UIExplorer/js/UIExplorerList.ios.js
+++ b/Examples/UIExplorer/js/UIExplorerList.ios.js
@@ -232,6 +232,10 @@ const APIExamples: Array<UIExplorerExample> = [
     module: require('./NativeAnimationsExample'),
   },
   {
+    key: 'NativeAnimationsProblemExample',
+    module: require('./NativeAnimationsProblemExample'),
+  },
+  {
     key: 'NavigationExperimentalExample',
     module: require('./NavigationExperimental/NavigationExperimentalExample'),
   },

--- a/Libraries/Animated/src/AnimatedImplementation.js
+++ b/Libraries/Animated/src/AnimatedImplementation.js
@@ -659,6 +659,10 @@ class SpringAnimation extends Animation {
   }
 }
 
+type AnimatedValueConfig = {
+  useNativeDriver?: bool;
+};
+
 type ValueListenerCallback = (state: {value: number}) => void;
 
 var _uniqueId = 1;
@@ -678,12 +682,15 @@ class AnimatedValue extends AnimatedWithChildren {
   _listeners: {[key: string]: ValueListenerCallback};
   __nativeAnimatedValueListener: ?any;
 
-  constructor(value: number) {
+  constructor(value: number, config?: AnimatedValueConfig) {
     super();
     this._startingValue = this._value = value;
     this._offset = 0;
     this._animation = null;
     this._listeners = {};
+    if (config && config.useNativeDriver) {
+      this.__makeNative();
+    }
   }
 
   __detach() {
@@ -929,7 +936,7 @@ class AnimatedValueXY extends AnimatedWithChildren {
   y: AnimatedValue;
   _listeners: {[key: string]: {x: string, y: string}};
 
-  constructor(valueIn?: ?{x: number | AnimatedValue, y: number | AnimatedValue}) {
+  constructor(valueIn?: ?{x: number | AnimatedValue; y: number | AnimatedValue}, config?: AnimatedValueConfig) {
     super();
     var value: any = valueIn || {x: 0, y: 0};  // @flowfixme: shouldn't need `: any`
     if (typeof value.x === 'number' && typeof value.y === 'number') {
@@ -946,6 +953,9 @@ class AnimatedValueXY extends AnimatedWithChildren {
       this.y = value.y;
     }
     this._listeners = {};
+    if (config && config.useNativeDriver) {
+      this.__makeNative();
+    }
   }
 
   setValue(value: {x: number, y: number}) {

--- a/Libraries/NativeAnimation/Nodes/RCTAnimatedNode.h
+++ b/Libraries/NativeAnimation/Nodes/RCTAnimatedNode.h
@@ -21,7 +21,6 @@
 @property (nonatomic, copy, readonly) NSDictionary<NSNumber *, RCTAnimatedNode *> *parentNodes;
 
 @property (nonatomic, readonly) BOOL needsUpdate;
-@property (nonatomic, readonly) BOOL hasUpdated;
 
 /**
  * Marks a node and its children as needing update.

--- a/Libraries/NativeAnimation/Nodes/RCTAnimatedNode.m
+++ b/Libraries/NativeAnimation/Nodes/RCTAnimatedNode.m
@@ -69,6 +69,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
   if (parent) {
     _parentNodes[parent.nodeTag] = parent;
   }
+  [self setNeedsUpdate];
 }
 
 - (void)onDetachedFromNode:(RCTAnimatedNode *)parent
@@ -79,6 +80,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
   if (parent) {
     [_parentNodes removeObjectForKey:parent.nodeTag];
   }
+  [self setNeedsUpdate];
 }
 
 - (void)detachNode
@@ -93,10 +95,6 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
 
 - (void)setNeedsUpdate
 {
-  if (_needsUpdate) {
-    // Has already been marked. Stop branch.
-    return;
-  }
   _needsUpdate = YES;
   for (RCTAnimatedNode *child in _childNodes.allValues) {
     [child setNeedsUpdate];
@@ -105,9 +103,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
 
 - (void)cleanupAnimationUpdate
 {
-  if (_hasUpdated) {
-    _needsUpdate = NO;
-    _hasUpdated = NO;
+  if (!_needsUpdate) {
     for (RCTAnimatedNode *child in _childNodes.allValues) {
       [child cleanupAnimationUpdate];
     }
@@ -116,7 +112,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
 
 - (void)updateNodeIfNecessary
 {
-  if (_needsUpdate && !_hasUpdated) {
+  if (_needsUpdate) {
     for (RCTAnimatedNode *parent in _parentNodes.allValues) {
       [parent updateNodeIfNecessary];
     }
@@ -126,7 +122,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
 
 - (void)performUpdate
 {
-  _hasUpdated = YES;
+  _needsUpdate = NO;
   // To be overidden by subclasses
   // This method is called on a node only if it has been marked for update
   // during the current update loop

--- a/Libraries/NativeAnimation/Nodes/RCTStyleAnimatedNode.m
+++ b/Libraries/NativeAnimation/Nodes/RCTStyleAnimatedNode.m
@@ -38,7 +38,7 @@
   NSDictionary<NSString *, NSNumber *> *style = self.config[@"style"];
   [style enumerateKeysAndObjectsUsingBlock:^(NSString *property, NSNumber *nodeTag, __unused BOOL *stop) {
     RCTAnimatedNode *node = self.parentNodes[nodeTag];
-    if (node && node.hasUpdated) {
+    if (node) {
       if ([node isKindOfClass:[RCTValueAnimatedNode class]]) {
         RCTValueAnimatedNode *parentNode = (RCTValueAnimatedNode *)node;
         [self->_updatedPropsDictionary setObject:@(parentNode.value) forKey:property];

--- a/Libraries/NativeAnimation/Nodes/RCTTransformAnimatedNode.m
+++ b/Libraries/NativeAnimation/Nodes/RCTTransformAnimatedNode.m
@@ -46,7 +46,7 @@
     NSNumber *nodeTag = transformConfig[@"nodeTag"];
 
     RCTAnimatedNode *node = self.parentNodes[nodeTag];
-    if (node.hasUpdated && [node isKindOfClass:[RCTValueAnimatedNode class]]) {
+    if ([node isKindOfClass:[RCTValueAnimatedNode class]]) {
       RCTValueAnimatedNode *parentNode = (RCTValueAnimatedNode *)node;
 
       NSString *property = transformConfig[@"property"];

--- a/Libraries/NativeAnimation/Nodes/RCTValueAnimatedNode.m
+++ b/Libraries/NativeAnimation/Nodes/RCTValueAnimatedNode.m
@@ -27,6 +27,7 @@
     _value = [self.config[@"value"] floatValue];
   }
   return self;
+
 }
 
 - (void)flattenOffset

--- a/Libraries/NativeAnimation/RCTNativeAnimatedModule.m
+++ b/Libraries/NativeAnimation/RCTNativeAnimatedModule.m
@@ -51,7 +51,6 @@ RCT_EXPORT_MODULE()
   _propAnimationNodes = [NSMutableSet new];
 }
 
-
 - (dispatch_queue_t)methodQueue
 {
   return dispatch_get_main_queue();
@@ -218,6 +217,8 @@ RCT_EXPORT_METHOD(connectAnimatedNodeToView:(nonnull NSNumber *)nodeTag
   if (viewTag && [node isKindOfClass:[RCTPropsAnimatedNode class]]) {
     [(RCTPropsAnimatedNode *)node connectToView:viewTag animatedModule:self];
   }
+  [node setNeedsUpdate];
+  [node updateNodeIfNecessary];
 }
 
 RCT_EXPORT_METHOD(disconnectAnimatedNodeFromView:(nonnull NSNumber *)nodeTag


### PR DESCRIPTION
This PR is intended to raise a number of issues with the current implementation of native animations and propose solutions. I'm relaying my experience on iOS, although it's possible some of these problems show up on Android as well.

Native animations work great if you:
1. Set up your animated values and props
2. Drive them via a timing or spring animation
3. Tear everything down after you're done

However, I've found native animations to be fragile in other circumstances. I've created a UIExplorer example named `NativeAnimationsProblemExample` that illustrates a simple instance in which native animations break down.
# Overview

The example attempts to drive two blue blocks from opacity 0.25 to 1. Both blocks are driven by the same `Animated.Value`. The first block is created when the example is first rendered. The second is created when you press "Toggle block 2".

The easiest way to follow along is to check out your own branch, and apply this diff piece by piece. The problems follow each other logically, so you'll need to commit the proposed fix for a problem to reproduce the next.
# Problem 1: Disappearing blocks

[fixed]
# Problem 2: Values reset on re-render
### How to reproduce:
- Open the example
- Run the animation forward
- Run the animation backward
- Toggle block 2 to show it
### The problem:

You will see that the first block resets to opacity 1 unexpectedly. This is because when we originally create the block, it has a non-native opacity prop (opacity = 0.25). This value gets sent to react proper. After we mark the animated value as `__native`, however, this prop is removed from the component. When prevProps and nextProps are diffed, react notices that opacity has been removed and calls `updateView` with `opacity: null`, thereby resetting the value to 1.

In order to avoid this behavior, I propose that all native animated values be marked as `__native` when they are created. This would ensure that all its children would also be marked as `__native`, and would make the entire animation tree easier to reason about. I realize this may be controversial, so I'm open to other ideas.
### The fix:

Uncomment the code in componentWillMount.

``` js
componentWillMount() {
    this.state.animation.__makeNative();
}
```
# Problem 3: Incorrect values on initial render
### How to reproduce:
- Open the example
### The problem:

You will see that the first block is created with opacity 1, when we expect it to have an opacity of 0.25. This is due to a number of issues. First off, native values are not initialized with their value.

**Fix:** implement init in `RCTValueAnimatedNode.m`.

But it still doesn't work. This is because we are not updating any views outside the display link, i.e. not unless we have a current animation in motion. When a view is created, it should be updated with the current value of all its animated props before it is first shown. This can be solved by updating the view manually in `connectAnimatedNodeToView`.

**Fix:** Apply my changes to `RCTNativeAnimatedModule.m`.

However, it still doesn't work. Nodes are only marked as needing an update when an animated value is driven, so `performUpdate` will result in a no-op here. I believe every node should be marked as needsUpdate whenever its parents are first attached, or change. It makes sense to invalidate a node if its parents change.

**Fix:** Apply my changes to `RCTAnimatedNode`.

On to the next...
# Problem 3b:
### How to reproduce:
- Open the example
- Run the animation forward
- Run the animation backward
- Toggle block 2
### The problem:

Now, you will see that block 2 is created with opacity 1 when we expect it to have an opacity of 0.25. This is caused by a race. `RCTUIManager`'s `createView` will create a new view **after** our call to `connectAnimatedNodeToView`. You can set breakpoints to verify, or simply apply a timeout in `AnimatedComponent`'s `componentDidMount` to do so:

``` js
componentDidMount() {
      var props = this._propsAnimated;
      setTimeout(() => {
          props.setNativeView(this.refs[refName]);
      });
    }
```
### The fix:

I'm really not sure. We need to ensure that when a view is created, it is seeded with the current value for all animated props. The simplest solution would be to tightly couple UIManager and native animations: animated props could be gathered and merged with standard props when a view is created. Another solution that avoids coupling would be to allow a `ViewProperyMapper` to register a block to be executed when a view is created. Ideas?
