### PR TITLE
Stop Reload Android Webview On Same URL Before

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebViewManager.java
@@ -329,6 +329,10 @@ public class ReactWebViewManager extends SimpleViewManager<WebView> {
       }
       if (source.hasKey("uri")) {
         String url = source.getString("uri");
+        String previousUrl = view.getUrl();
+        if (previousUrl != null && previousUrl.equals(url)) {
+          return;
+        }
         if (source.hasKey("method")) {
           String method = source.getString("method");
           if (method.equals(HTTP_METHOD_POST)) {


### PR DESCRIPTION
### Motivation
Because it is react, the url could be changed on redirection or some other ways.
The iOS version's WebView has controled that on [here](https://github.com/facebook/react-native/blob/master/React/Views/RCTWebView.m#L106).
But the Android's one is not.

### What this commit do
Check the url is same with privous url. If it is true, cancel loading.
This logic is same with iOS's.

### What should we know
the ```method``` hasn't compared.

### Test Plan
Test urls as we can.
The Google Map(https://map.google.com) was one of the site which has occur error before this commit.

related issue : #9121