### PR TITLE
fix problem: RCTImageLoader cannot load image file without a extension.

### DIFF
--- a/Libraries/Image/RCTImageLoader.m
+++ b/Libraries/Image/RCTImageLoader.m
@@ -296,10 +296,6 @@ static UIImage *RCTResizeImageIfNeeded(UIImage *image,
                         forKey:@"trackingName"
                      inRequest:mutableRequest];
 
-    // Add missing png extension
-    if (request.URL.fileURL && request.URL.pathExtension.length == 0) {
-      mutableRequest.URL = [NSURL fileURLWithPath:[request.URL.path stringByAppendingPathExtension:@"png"]];
-    }
     request = mutableRequest;
   }
 

--- a/React/Base/RCTUtils.m
+++ b/React/Base/RCTUtils.m
@@ -618,9 +618,7 @@ BOOL RCTIsLocalAssetURL(NSURL *__nullable imageURL)
   if (!name) {
     return NO;
   }
-
-  NSString *extension = [name pathExtension];
-  return [extension isEqualToString:@"png"] || [extension isEqualToString:@"jpg"];
+  return YES;
 }
 
 RCT_EXTERN NSString *__nullable RCTTempFilePath(NSString *extension, NSError **error)


### PR DESCRIPTION
These lines causes RCTImageLoader failed to load image file without extension. I met this problem when use react-native together with a third-party module. These lines add '.png' extension after file URI which indicate a file that doesn't exists.

What are these lines for? Are they important for something? Should we only do this on some special situation?
