### PR TITLE
[Android] Fixed reverse logic in ReactToolbarManager setRtl.

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/toolbar/ReactToolbarManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/toolbar/ReactToolbarManager.java
@@ -67,7 +67,7 @@ public class ReactToolbarManager extends ViewGroupManager<ReactToolbar> {
 
   @ReactProp(name = "rtl")
   public void setRtl(ReactToolbar view, boolean rtl) {
-    view.setLayoutDirection(rtl ? LayoutDirection.LTR : LayoutDirection.RTL);
+    view.setLayoutDirection(rtl ? LayoutDirection.RTL : LayoutDirection.LTR);
   }
 
   @ReactProp(name = "subtitle")


### PR DESCRIPTION
The logic in `setRtl` is wrong. You would expect that `{rtl: true}` would set the layout direction to RTL, instead it currently does the opposite.
This commit fixes the issue.