### PR TITLE
give more warning context

### DIFF
--- a/Libraries/JavaScriptAppEngine/Initialization/parseErrorStack.js
+++ b/Libraries/JavaScriptAppEngine/Initialization/parseErrorStack.js
@@ -12,6 +12,8 @@
 'use strict';
 
 export type StackFrame = {
+  filePath: string,
+  fileName: string,
   file: string,
   lineNumber: number,
   column: number,

--- a/Libraries/ReactIOS/YellowBox.js
+++ b/Libraries/ReactIOS/YellowBox.js
@@ -177,10 +177,9 @@ const WarningRow = ({count, warning, onPress}) => {
 type StackRowProps = { frame: StackFrame };
 const StackRow = ({frame}: StackRowProps) => {
   const Text = require('Text');
+  const View = require('View');
   const TouchableHighlight = require('TouchableHighlight');
-  const {file, lineNumber} = frame;
-  const fileParts = file.split('/');
-  const fileName = fileParts[fileParts.length - 1];
+  const {file, lineNumber, fileName, filePath} = frame;
 
   return (
     <TouchableHighlight
@@ -188,9 +187,14 @@ const StackRow = ({frame}: StackRowProps) => {
       style={styles.openInEditorButton}
       underlayColor="transparent"
       onPress={openFileInEditor.bind(null, file, lineNumber)}>
-      <Text style={styles.inspectorCountText}>
-        {fileName}:{lineNumber}
-      </Text>
+      <View>
+        <Text style={styles.stackFile}>
+          {fileName}:{lineNumber}
+        </Text>
+        <Text style={styles.stackPath}>
+          {filePath}
+        </Text>
+      </View>
     </TouchableHighlight>
   );
 };
@@ -409,7 +413,7 @@ var styles = StyleSheet.create({
     backgroundColor: backgroundColor(1),
   },
   toggleStacktraceButton: {
-    flex: 1,
+    height: 30,
     padding: 5,
   },
   stacktraceList: {
@@ -469,6 +473,14 @@ var styles = StyleSheet.create({
     top: Platform.OS === 'android' ? 5 : 7,
     marginLeft: 15,
     marginRight: 15,
+  },
+  stackFile: {
+    color: textColor,
+    fontSize: 16,
+  },
+  stackPath: {
+    color: textColor,
+    fontSize: 10,
   },
 });
 

--- a/packager/react-packager/src/Server/__tests__/Server-test.js
+++ b/packager/react-packager/src/Server/__tests__/Server-test.js
@@ -493,6 +493,8 @@ describe('processRequest', () => {
       ).then(response => {
         expect(JSON.parse(response.body)).toEqual({
           stack: [{
+            fileName: 'foo.js',
+            filePath: '.',
             file: 'foo.js',
             lineNumber: 21,
             column: 4,

--- a/packager/react-packager/src/Server/index.js
+++ b/packager/react-packager/src/Server/index.js
@@ -701,6 +701,8 @@ class Server {
         telemetric: true,
       },
     );
+    const appRoot = process.cwd() + path.sep;
+
     new Promise.resolve(req.rawBody).then(body => {
       const stack = JSON.parse(body).stack;
 
@@ -739,7 +741,10 @@ class Server {
           if (!original) {
             return frame;
           }
+          const relativePath = original.source.replace(appRoot, '');
           return Object.assign({}, frame, {
+            fileName: path.basename(relativePath),
+            filePath: path.dirname(relativePath),
             file: original.source,
             lineNumber: original.line,
             column: original.column,


### PR DESCRIPTION
**motivation**: often is not enough to show only file names because could be few files with same name

**before**:

<img src="https://cloud.githubusercontent.com/assets/1488195/17305085/e39bc4f6-5839-11e6-9e23-8731460ae034.png" width="200" />

**after**:

<img src="https://cloud.githubusercontent.com/assets/1488195/17305128/1ef07c86-583a-11e6-9cdb-b07719b31767.png" width="200" />
