### PR TITLE
Rename devtool to hook

### DIFF
--- a/Libraries/Utilities/RCTRenderingPerf.js
+++ b/Libraries/Utilities/RCTRenderingPerf.js
@@ -54,7 +54,7 @@ var RCTRenderingPerf = {
     }
 
     ReactPerf.start();
-    ReactDebugTool.addDevtool(RCTRenderingPerfDevtool);
+    ReactDebugTool.addHook(RCTRenderingPerfDevtool);
     perfModules.forEach((module) => module.start());
   },
 
@@ -66,7 +66,7 @@ var RCTRenderingPerf = {
     ReactPerf.stop();
     ReactPerf.printInclusive();
     ReactPerf.printWasted();
-    ReactDebugTool.removeDevtool(RCTRenderingPerfDevtool);
+    ReactDebugTool.removeHook(RCTRenderingPerfDevtool);
 
     console.log(`Total time spent in render(): ${totalRenderDuration.toFixed(2)} ms`);
     lastRenderStartTime = 0;

--- a/Libraries/Utilities/Systrace.js
+++ b/Libraries/Utilities/Systrace.js
@@ -32,14 +32,14 @@ let _asyncCookie = 0;
 
 const ReactSystraceDevtool = __DEV__ ? {
   onBeginReconcilerTimer(debugID, timerType) {
-    const displayName = require('react/lib/ReactComponentTreeDevtool').getDisplayName(debugID);
+    const displayName = require('react/lib/ReactComponentTreeHook').getDisplayName(debugID);
     Systrace.beginEvent(`ReactReconciler.${timerType}(${displayName})`);
   },
   onEndReconcilerTimer(debugID, timerType) {
     Systrace.endEvent();
   },
   onBeginLifeCycleTimer(debugID, timerType) {
-    const displayName = require('react/lib/ReactComponentTreeDevtool').getDisplayName(debugID);
+    const displayName = require('react/lib/ReactComponentTreeHook').getDisplayName(debugID);
     Systrace.beginEvent(`${displayName}.${timerType}()`);
   },
   onEndLifeCycleTimer(debugID, timerType) {
@@ -53,10 +53,10 @@ const Systrace = {
       if (__DEV__) {
         if (enabled) {
           global.nativeTraceBeginLegacy && global.nativeTraceBeginLegacy(TRACE_TAG_JSC_CALLS);
-          require('react/lib/ReactDebugTool').addDevtool(ReactSystraceDevtool);
+          require('react/lib/ReactDebugTool').addHook(ReactSystraceDevtool);
         } else {
           global.nativeTraceEndLegacy && global.nativeTraceEndLegacy(TRACE_TAG_JSC_CALLS);
-          require('react/lib/ReactDebugTool').removeDevtool(ReactSystraceDevtool);
+          require('react/lib/ReactDebugTool').removeHook(ReactSystraceDevtool);
         }
       }
       _enabled = enabled;


### PR DESCRIPTION
Hey,

We recently renamed `devtool` to `hook` in React's codebase (facebook/react#7381). Now `devtool` stands for our [chrome extension](https://github.com/facebook/react-devtools/) and our internal stuff are called `hook`s.

Module name changes:
```
ReactComponentTreeDevtool -> ReactComponentTreeHook
ReactDOMNullInputValuePropDevtool -> ReactDOMNullInputValuePropHook
ReactDOMUnknownPropertyDevtool -> ReactDOMUnknownPropertyHook
ReactChildrenMutationWarningDevtool -> ReactChildrenMutationWarningHook
ReactHostOperationHistoryDevtool -> ReactHostOperationHistoryHook
ReactInvalidSetStateWarningDevTool -> ReactInvalidSetStateWarningHook
```

Internal API changes:
```
ReactDebugTool.addDevtool -> ReactDOMDebugTool.addHook
ReactDebugTool.removeDevtool -> ReactDOMDebugTool.removeHook
ReactDOMDebugTool.addDevtool -> ReactDOMDebugTool.addHook
ReactDOMDebugTool.removeDevtool -> ReactDOMDebugTool.removeHook
```

There's a temporary compatibility fix (https://github.com/facebook/react/pull/7381/commits/bba0d992d8f4ecf9cf6677817a1218e7f48a8a77) and it will be reverted when RN/www gets updated. I greped RN's codebase and only found these usages -- please let me know if I missed anything!

Test plan:
- Grep and make sure all `devtool`s are renamed to `hook`s