### PR TITLE
[RCTRedBox] Don't show keyboard shortcuts with redbox on device

### DIFF
--- a/React/Modules/RCTRedBox.m
+++ b/React/Modules/RCTRedBox.m
@@ -65,11 +65,21 @@
     _stackTraceTableView.indicatorStyle = UIScrollViewIndicatorStyleWhite;
     [rootView addSubview:_stackTraceTableView];
 
+  #if TARGET_OS_SIMULATOR
+    NSString *reloadText = @"Reload JS (\u2318R)";
+    NSString *dismissText = @"Dismiss (ESC)";
+    NSString *copyText = @"Copy (\u2325\u2318C)";
+  #else
+    NSString *reloadText = @"Reload JS";
+    NSString *dismissText = @"Dismiss";
+    NSString *copyText = @"Copy";
+  #endif
+
     UIButton *dismissButton = [UIButton buttonWithType:UIButtonTypeCustom];
     dismissButton.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleRightMargin;
     dismissButton.accessibilityIdentifier = @"redbox-dismiss";
     dismissButton.titleLabel.font = [UIFont systemFontOfSize:14];
-    [dismissButton setTitle:@"Dismiss (ESC)" forState:UIControlStateNormal];
+    [dismissButton setTitle:dismissText forState:UIControlStateNormal];
     [dismissButton setTitleColor:[UIColor colorWithWhite:1 alpha:0.5] forState:UIControlStateNormal];
     [dismissButton setTitleColor:[UIColor whiteColor] forState:UIControlStateHighlighted];
     [dismissButton addTarget:self action:@selector(dismiss) forControlEvents:UIControlEventTouchUpInside];
@@ -78,7 +88,8 @@
     reloadButton.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleLeftMargin;
     reloadButton.accessibilityIdentifier = @"redbox-reload";
     reloadButton.titleLabel.font = [UIFont systemFontOfSize:14];
-    [reloadButton setTitle:@"Reload JS (\u2318R)" forState:UIControlStateNormal];
+
+    [reloadButton setTitle:reloadText forState:UIControlStateNormal];
     [reloadButton setTitleColor:[UIColor colorWithWhite:1 alpha:0.5] forState:UIControlStateNormal];
     [reloadButton setTitleColor:[UIColor whiteColor] forState:UIControlStateHighlighted];
     [reloadButton addTarget:self action:@selector(reload) forControlEvents:UIControlEventTouchUpInside];
@@ -87,7 +98,7 @@
     copyButton.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleLeftMargin;
     copyButton.accessibilityIdentifier = @"redbox-copy";
     copyButton.titleLabel.font = [UIFont systemFontOfSize:14];
-    [copyButton setTitle:@"Copy (\u2325\u2318C)" forState:UIControlStateNormal];
+    [copyButton setTitle:copyText forState:UIControlStateNormal];
     [copyButton setTitleColor:[UIColor colorWithWhite:1 alpha:0.5] forState:UIControlStateNormal];
     [copyButton setTitleColor:[UIColor whiteColor] forState:UIControlStateHighlighted];
     [copyButton addTarget:self action:@selector(copyStack) forControlEvents:UIControlEventTouchUpInside];


### PR DESCRIPTION
Unless there is some really fancy way to make pressing the keyboard shortcuts like cmd+r from your dev machine and have it reload on your device like you can in the simulator, we probably shouldn't display these when running on device.

## On device

![img_4679](https://cloud.githubusercontent.com/assets/90494/17316248/331d890a-5827-11e6-9796-0f2bf24315d7.PNG)

## In simulator

<img width="487" alt="screen shot 2016-08-01 at 8 29 41 pm" src="https://cloud.githubusercontent.com/assets/90494/17316250/3b174e5c-5827-11e6-8337-ac0c01843fae.png">

## My puppy

![img_4677](https://cloud.githubusercontent.com/assets/90494/17316257/47aebcd6-5827-11e6-8a16-b128275f73e8.JPG)
