### PR TITLE
Make MessageQueue to emit "SPY" events in a way that can be extensible

### DIFF
--- a/Libraries/Utilities/MessageQueue.js
+++ b/Libraries/Utilities/MessageQueue.js
@@ -28,7 +28,6 @@ const MIN_TIME_BETWEEN_FLUSHES_MS = 5;
 
 const TO_NATIVE = 1;
 const TO_JS = 0;
-const defaultSpy = (info)=>console.log(`${info.type == TO_JS ? 'N->JS' : 'JS->N'} : ${info.module ? (info.module+'.') : ''}${info.method}(${JSON.stringify(info.args)})`);
 
 const TRACE_TAG_REACT_APPS = 1 << 17;
 
@@ -94,9 +93,11 @@ class MessageQueue {
    */
 
   static spy(spyOrToggle){
-    if(spyOrToggle === true){
-      MessageQueue.prototype.__spy = defaultSpy;
-    } else if(spyOrToggle === false) {
+    if (spyOrToggle === true){
+      MessageQueue.prototype.__spy = (info)=>console.log(`${info.type == TO_JS ? 'N->JS' : 'JS->N'} : ` +
+                                                        `${info.module ? (info.module+'.') : ''}${info.method}` +
+                                                        `(${JSON.stringify(info.args)})`);
+    } else if (spyOrToggle === false) {
       MessageQueue.prototype.__spy = null;
     } else {
       MessageQueue.prototype.__spy = spyOrToggle;
@@ -464,7 +465,5 @@ function lazyProperty(target: Object, name: string, f: () => any) {
     }
   });
 }
-
-
 
 module.exports = MessageQueue;

--- a/Libraries/Utilities/MessageQueue.js
+++ b/Libraries/Utilities/MessageQueue.js
@@ -26,8 +26,8 @@ const METHOD_IDS = 1;
 const PARAMS = 2;
 const MIN_TIME_BETWEEN_FLUSHES_MS = 5;
 
-const TO_NATIVE = 1
-const TO_JS = 0
+const TO_NATIVE = 1;
+const TO_JS = 0;
 
 const TRACE_TAG_REACT_APPS = 1 << 17;
 
@@ -93,7 +93,7 @@ class MessageQueue {
    */
 
   static spy(fn){
-    MessageQueue.prototype.__spy = fn
+    MessageQueue.prototype.__spy = fn;
   }
 
   callFunctionReturnFlushedQueue(module, method, args) {
@@ -194,7 +194,7 @@ class MessageQueue {
             module: this._remoteModuleTable[module],
             method: this._remoteMethodTable[module][method],
             args: params }
-        )
+        );
     }
   }
 
@@ -203,7 +203,7 @@ class MessageQueue {
     this._eventLoopStartTime = this._lastFlush;
     Systrace.beginEvent(`${module}.${method}()`);
     if (__DEV__ && this.__spy) {
-      this.__spy({ type: TO_JS, module, method, args})
+      this.__spy({ type: TO_JS, module, method, args});
     }
     const moduleMethods = this._callableModules[module];
     invariant(
@@ -238,7 +238,7 @@ class MessageQueue {
       }
       const profileName = debug ? '<callback for ' + module + '.' + method + '>' : cbID;
       if (callback && this.__spy && __DEV__) {
-        this.__spy({ type: TO_JS, module:null, method:profileName, args })
+        this.__spy({ type: TO_JS, module:null, method:profileName, args });
       }
       Systrace.beginEvent(
         `MessageQueue.invokeCallback(${profileName}, ${stringifySafe(args)})`);

--- a/Libraries/Utilities/MessageQueue.js
+++ b/Libraries/Utilities/MessageQueue.js
@@ -28,6 +28,7 @@ const MIN_TIME_BETWEEN_FLUSHES_MS = 5;
 
 const TO_NATIVE = 1;
 const TO_JS = 0;
+const defaultSpy = (info)=>console.log(`${info.type == TO_JS ? 'N->JS' : 'JS->N'} : ${info.module ? (info.module+'.') : ''}${info.method}(${JSON.stringify(info.args)})`);
 
 const TRACE_TAG_REACT_APPS = 1 << 17;
 
@@ -92,8 +93,14 @@ class MessageQueue {
    * Public APIs
    */
 
-  static spy(fn){
-    MessageQueue.prototype.__spy = fn;
+  static spy(spyOrToggle){
+    if(spyOrToggle === true){
+      MessageQueue.prototype.__spy = defaultSpy;
+    } else if(spyOrToggle === false) {
+      MessageQueue.prototype.__spy = null;
+    } else {
+      MessageQueue.prototype.__spy = spyOrToggle;
+    }
   }
 
   callFunctionReturnFlushedQueue(module, method, args) {

--- a/Libraries/Utilities/MessageQueue.js
+++ b/Libraries/Utilities/MessageQueue.js
@@ -94,9 +94,11 @@ class MessageQueue {
 
   static spy(spyOrToggle){
     if (spyOrToggle === true){
-      MessageQueue.prototype.__spy = (info)=>console.log(`${info.type == TO_JS ? 'N->JS' : 'JS->N'} : ` +
-                                                        `${info.module ? (info.module+'.') : ''}${info.method}` +
-                                                        `(${JSON.stringify(info.args)})`);
+      MessageQueue.prototype.__spy = (info)=>{
+        console.log(`${info.type == TO_JS ? 'N->JS' : 'JS->N'} : ` +
+                    `${info.module ? (info.module+'.') : ''}${info.method}` +
+                    `(${JSON.stringify(info.args)})`);
+      }
     } else if (spyOrToggle === false) {
       MessageQueue.prototype.__spy = null;
     } else {

--- a/Libraries/Utilities/MessageQueue.js
+++ b/Libraries/Utilities/MessageQueue.js
@@ -26,8 +26,8 @@ const METHOD_IDS = 1;
 const PARAMS = 2;
 const MIN_TIME_BETWEEN_FLUSHES_MS = 5;
 
-const TO_NATIVE = 0
-const TO_JS = 1
+const TO_NATIVE = 1
+const TO_JS = 0
 
 const TRACE_TAG_REACT_APPS = 1 << 17;
 


### PR DESCRIPTION

This PR adds a capability for MessageQueue to emit "SPY" events in a way that can be extensible, to later allow for a tooling ecosystem to grow, one example is the existing [Snoopy](https://github.com/jondot/rn-snoopy) tool that is, for now, forced to work with monkeypatches, and after this PR will be able to use a "formal" way to trace queue events.

After this change, we can wire a "spy" into a queue that will expose the events in different and interesting ways, see below (done with Snoopy):
  <img src="https://github.com/jondot/rn-snoopy/blob/master/media/snoopy.gif?raw=true" alt="Aggregating and Charting Events with Bar" width="400px"/>
  <img src="https://github.com/jondot/rn-snoopy/blob/master/media/snoopy-filter.gif?raw=true" alt="Aggregating and Charting Events with Bar" width="400px"/>


This removes the hardcoded `SPY_MODE` flag and instead uses a function that can be injected from outside world.

```javascript
MessageQueue.spy((info)=>console.log("event!", info)
```

It also creates a structured descriptor for an event, so in the above example, `console.log` will accept the following object shape:

```javascript
{
   type: integer, (0:TO_JS, 1:TO_NATIVE)
   module:string,
   method:string,
   args:[object]
}
```

Once a spy exists (and we're in `__DEV__` mode), the queue will start using it.

In terms of core changes - I feel this was a low-hanging-fruit, small enough to pick.



