### PR TITLE
Return statement missing for renderScene

### DIFF
--- a/docs/UsingNavigators.md
+++ b/docs/UsingNavigators.md
@@ -105,7 +105,7 @@ A more complete example that demonstrates the pushing and popping of routes coul
 ```javascript
 import React, { Component, PropTypes } from 'react';
 import { Navigator, Text, TouchableHighlight, View } from 'react-native';
-r
+
 export default class SimpleNavigationApp extends Component {
   render() {
     return (

--- a/docs/UsingNavigators.md
+++ b/docs/UsingNavigators.md
@@ -78,7 +78,7 @@ render() {
     <Navigator
       initialRoute={{ title: 'My Initial Scene', index: 0 }}
       renderScene={(route, navigator) => {
-        <MyScene title={route.title} />
+        return <MyScene title={route.title} />
       }}
     />
   );
@@ -105,32 +105,34 @@ A more complete example that demonstrates the pushing and popping of routes coul
 ```javascript
 import React, { Component, PropTypes } from 'react';
 import { Navigator, Text, TouchableHighlight, View } from 'react-native';
-
+r
 export default class SimpleNavigationApp extends Component {
   render() {
     return (
       <Navigator
         initialRoute={{ title: 'My Initial Scene', index: 0 }}
         renderScene={(route, navigator) =>
-          <MyScene
-            title={route.title}
-
-            // Function to call when a new scene should be displayed           
-            onForward={ () => {    
-              const nextIndex = route.index + 1;
-              navigator.push({
-                title: 'Scene ' + nextIndex,
-                index: nextIndex,
-              });
-            }}
-
-            // Function to call to go back to the previous scene
-            onBack={() => {
-              if (route.index > 0) {
-                navigator.pop();
-              }
-            }}
-          />
+          return (
+            <MyScene
+              title={route.title}
+  
+              // Function to call when a new scene should be displayed           
+              onForward={ () => {    
+                const nextIndex = route.index + 1;
+                navigator.push({
+                  title: 'Scene ' + nextIndex,
+                  index: nextIndex,
+                });
+              }}
+  
+              // Function to call to go back to the previous scene
+              onBack={() => {
+                if (route.index > 0) {
+                  navigator.pop();
+                }
+              }}
+            />
+          )
         }
       />
     )


### PR DESCRIPTION
Explain the **motivation** for making this change. What existing problem does the pull request solve?
Example code for "Using Navigators" under "THE BASICS" does not work. renderScene needs to return the components, not just instantiate them.

**Test plan (required)**

I copy-paste and ran the code but did not get anything rendered. I added a return statement before the component which made it work.

Arrow functions need a return statement when supplying a { block of code }.