### PR TITLE
--reset-cache no longer accept a boolean parameter.

### DIFF
--- a/react.gradle
+++ b/react.gradle
@@ -79,10 +79,10 @@ gradle.projectsEvaluated {
                 def devEnabled = !targetName.toLowerCase().contains("release")
                 if (Os.isFamily(Os.FAMILY_WINDOWS)) {
                     commandLine("cmd", "/c", *nodeExecutableAndArgs, "node_modules/react-native/local-cli/cli.js", "bundle", "--platform", "android", "--dev", "${devEnabled}",
-                            "--reset-cache", "true", "--entry-file", entryFile, "--bundle-output", jsBundleFile, "--assets-dest", resourcesDir, *extraPackagerArgs)
+                            "--reset-cache", "--entry-file", entryFile, "--bundle-output", jsBundleFile, "--assets-dest", resourcesDir, *extraPackagerArgs)
                 } else {
                     commandLine(*nodeExecutableAndArgs, "node_modules/react-native/local-cli/cli.js", "bundle", "--platform", "android", "--dev", "${devEnabled}",
-                            "--reset-cache", "true", "--entry-file", entryFile, "--bundle-output", jsBundleFile, "--assets-dest", resourcesDir, *extraPackagerArgs)
+                            "--reset-cache", "--entry-file", entryFile, "--bundle-output", jsBundleFile, "--assets-dest", resourcesDir, *extraPackagerArgs)
                 }
 
                 enabled config."bundleIn${targetName}" ||


### PR DESCRIPTION
The gradle :app:bundleReleaseJsAndAssets task is currently broken on master.
Gradle attaches a boolean parameter to --reset-cache, while it no longer accepts it.

Related:
* https://github.com/facebook/react-native/blob/master/local-cli/bundle/bundleCommandLineArgs.js#L52
* #9134 
* https://github.com/facebook/react-native/blob/master/local-cli/bundle/bundleCommandLineArgs.js#L52