### PR TITLE
disable symink finder to fix tests

### DIFF
--- a/local-cli/server/server.js
+++ b/local-cli/server/server.js
@@ -18,10 +18,11 @@ const findSymlinksPaths = require('./findSymlinksPaths');
  * Starts the React Native Packager Server.
  */
 function server(argv, config, args) {
-  args.projectRoots = args.projectRoots.concat(
-    args.root,
-    findSymlinksPaths(path.resolve(process.cwd(), 'node_modules'))
-  );
+  // Disabled temporarily to fix trunk
+  // args.projectRoots = args.projectRoots.concat(
+  //   args.root,
+  //   findSymlinksPaths(path.resolve(process.cwd(), 'node_modules'))
+  // );
 
   console.log(formatBanner(
     'Running packager on port ' + args.port + '.\n\n' +


### PR DESCRIPTION
cc @Kureev 

Disabling symlink resolver temporarily because it breaks launchPackager.command.
Waiting for a PR with a fix to enable both