### PR TITLE
Flattens RNPM user commands from plugin modules

### DIFF
--- a/local-cli/rnpm/core/src/getCommands.js
+++ b/local-cli/rnpm/core/src/getCommands.js
@@ -1,11 +1,12 @@
 const path = require('path');
 const findPlugins = require('./findPlugins');
+const flatten = require('lodash').flatten;
 
 /**
  * @return {Array} Array of commands
  */
 module.exports = function getCommands() {
   const appRoot = process.cwd();
-
-  return findPlugins([appRoot]).map(name => require(path.join(appRoot, 'node_modules', name)));
+  const plugins = findPlugins([appRoot]).map(name => require(path.join(appRoot, 'node_modules', name)));
+  return flatten(plugins);
 };


### PR DESCRIPTION
RNPM plugins may have ship multiple commands as extensions (e.g., https://github.com/rnpm/rnpm-plugin-link/blob/master/index.js#L1)

The consumer of the user commands (https://github.com/facebook/react-native/blob/master/local-cli/commands.js#L67) expects a flat list of commands, which used to be flattened here https://github.com/rnpm/rnpm/blob/master/bin/cli#L35 in RNPM.

This commit simply flattens the (possible) set of commands coming out of a user plugin.