### PR TITLE
Fixes command validity check for local-cli.

### DIFF
--- a/local-cli/cliEntry.js
+++ b/local-cli/cliEntry.js
@@ -137,7 +137,7 @@ function run() {
 
   commander.parse(process.argv);
 
-  const isValidCommand = commands.find(cmd => cmd.name === process.argv[2]);
+  const isValidCommand = commands.find(cmd => cmd.name.split(' ')[0] === process.argv[2]);
 
   if (!isValidCommand) {
     printUnknownCommand(process.argv[2]);


### PR DESCRIPTION
Prior to the RNPM integration, command names would match the second argument passed to the react-native-cli. Now the command names contain some usage information (such as non-flag CLI arguments). This commit splits the name of the commands and checks that against the second command line argument.