### PR TITLE
Fix help information for react-native-cli commands

### DIFF
--- a/local-cli/cliEntry.js
+++ b/local-cli/cliEntry.js
@@ -53,7 +53,7 @@ function printHelpInformation() {
 
   let output = [
     '',
-    chalk.bold(chalk.cyan((`  react-native ${cmdName} [options]`))),
+    chalk.bold(chalk.cyan((`  react-native ${cmdName} ${this.usage()}`))),
     `  ${this._description}`,
     '',
     `  ${chalk.bold('Options:')}`,
@@ -61,20 +61,6 @@ function printHelpInformation() {
     this.optionHelp().replace(/^/gm, '    '),
     '',
   ];
-
-  const usage = this.usage();
-
-  if (usage !== '[options]') {
-    const formattedUsage = usage.map(
-      example => `    ${example.desc}: \n    ${chalk.cyan(example.cmd)}`,
-    ).join('\n\n');
-
-    output = output.concat([
-      chalk.bold('  Example usage:'),
-      '',
-      formattedUsage,
-    ]);
-  }
 
   return output.concat([
     '',

--- a/local-cli/cliEntry.js
+++ b/local-cli/cliEntry.js
@@ -62,6 +62,18 @@ function printHelpInformation() {
     '',
   ];
 
+  if (this.examples) {
+    const formattedExamples = this.examples.map(
+      example => `    ${example.desc}: \n    ${chalk.cyan(example.cmd)}`,
+    ).join('\n\n');
+
+    output = output.concat([
+      chalk.bold('  Example usage:'),
+      '',
+      formattedExamples,
+    ]);
+  }
+
   return output.concat([
     '',
     '',

--- a/local-cli/cliEntry.js
+++ b/local-cli/cliEntry.js
@@ -51,9 +51,13 @@ function printHelpInformation() {
     cmdName = cmdName + '|' + this._alias;
   }
 
+  const usage = this.usage();
+  const usageIsString = typeof(usage) === 'string';
+  const usageString = usageIsString ? usage : '[options]';  
+  
   let output = [
     '',
-    chalk.bold(chalk.cyan((`  react-native ${cmdName} ${this.usage()}`))),
+    chalk.bold(chalk.cyan((`  react-native ${cmdName} ${usageString}`))),
     `  ${this._description}`,
     '',
     `  ${chalk.bold('Options:')}`,
@@ -62,15 +66,15 @@ function printHelpInformation() {
     '',
   ];
 
-  if (this.examples) {
-    const formattedExamples = this.examples.map(
+  if (!usageIsString) {
+    const formattedUsage = usage.map(
       example => `    ${example.desc}: \n    ${chalk.cyan(example.cmd)}`,
     ).join('\n\n');
 
     output = output.concat([
       chalk.bold('  Example usage:'),
       '',
-      formattedExamples,
+      formattedUsage,
     ]);
   }
 


### PR DESCRIPTION
The high level `react-native --help` command works okay, but using `react-native command --help` seems to be broken. It works for some commands that have basic usage (i.e., options only, including run-android and run-ios), but it does not work for commands that have optional arguments in their usage, like `react-native link --help`.

This fixes commands like `react-native link`, although it deletes some behavior that I'm not quite sure what the original intent was (cc author @grabbou).