### PR TITLE
reset-cache flag no longer needs boolean

### DIFF
--- a/packager/react-native-xcode.sh
+++ b/packager/react-native-xcode.sh
@@ -84,6 +84,6 @@ $NODE_BINARY "$REACT_NATIVE_DIR/local-cli/cli.js" bundle \
   --entry-file "$ENTRY_FILE" \
   --platform ios \
   --dev $DEV \
-  --reset-cache true \
+  --reset-cache \
   --bundle-output "$DEST/main.jsbundle" \
   --assets-dest "$DEST"


### PR DESCRIPTION
When compiling 0.31-rc1 was having issues with xcode running the package script and failing (ie not running and returning the --help info) Was due to this - simply changing the flag to --reset-cache instead of --reset-cache true worked miracles.

**Test plan (required)**

Ran packager without and runs but doesn't build the package, runs with small change and works now. Can copy paste output if you want but it's pretty super verbose for this small change.