### PR TITLE
clean UIExplorer NavigationExperimental example code

### DIFF
--- a/Examples/UIExplorer/js/NavigationExperimental/NavigationTransitioner-AnimatedView-pager-example.js
+++ b/Examples/UIExplorer/js/NavigationExperimental/NavigationTransitioner-AnimatedView-pager-example.js
@@ -137,8 +137,6 @@ class Example extends Component {
 class ExampleNavigator extends Component {
   _render: Function;
   _renderScene: Function;
-  _back: Function;
-  _forward: Function;
 
   props: {
     navigate: Function,
@@ -154,8 +152,6 @@ class ExampleNavigator extends Component {
     super(props, context);
     this._render = this._render.bind(this);
     this._renderScene = this._renderScene.bind(this);
-    this._back = this._back.bind(this);
-    this._forward = this._forward.bind(this);
   }
 
   render(): ReactElement<any> {
@@ -194,14 +190,6 @@ class ExampleNavigator extends Component {
         navigate={this.props.navigate}
       />
     );
-  }
-
-  _back(): void {
-    this.props.navigate('back');
-  }
-
-  _forward(): void {
-    this.props.navigate('forward');
   }
 }
 
@@ -260,10 +248,6 @@ const styles = StyleSheet.create({
     position: 'absolute',
     right: 0,
     top: 0,
-  },
-  scrollView: {
-    flex: 1,
-    padding: 50,
   },
   heading: {
     alignItems : 'center',


### PR DESCRIPTION
1. Explain the **motivation** for making this change.

    Those codes cleaned are not used anywhere, remove them would make the example much more clear to users.

2. **Test plan (required)**

    ![navigationexperimental](https://cloud.githubusercontent.com/assets/1091472/17392196/4f28cba4-5a4e-11e6-9ef1-727edc784f1f.gif)

