### PR TITLE
Add infix feature for dynamic file selection

### DIFF
--- a/local-cli/server/runServer.js
+++ b/local-cli/server/runServer.js
@@ -89,6 +89,7 @@ function getPackagerServer(args, config) {
     extraNodeModules: config.extraNodeModules,
     assetRoots: args.assetRoots,
     assetExts: defaultAssetExts.concat(args.assetExts),
+    infixExts: args.infixExts || [],
     resetCache: args.resetCache,
     verbose: args.verbose,
   });

--- a/local-cli/server/server.js
+++ b/local-cli/server/server.js
@@ -102,6 +102,11 @@ module.exports = {
     parse: (val) => val.split(','),
     default: (config) => config.getAssetExts(),
   }, {
+    command: '--infixExts [list]',
+    description: 'Specify a list of possible custom infix extensions to be used by the packager',
+    parse: (val) => val.split(','),
+    default: () => []
+  }, {
     command: '--skipflow',
     description: 'Disable flow checks'
   }, {

--- a/packager/react-packager/src/AssetServer/__tests__/AssetServer-test.js
+++ b/packager/react-packager/src/AssetServer/__tests__/AssetServer-test.js
@@ -57,6 +57,7 @@ describe('AssetServer', () => {
       const server = new AssetServer({
         projectRoots: ['/root'],
         assetExts: ['png'],
+        infixExts: ['d', 'e']
       });
 
       fs.__setMockFilesystem({
@@ -66,13 +67,21 @@ describe('AssetServer', () => {
             'b.android.png': 'b android image',
             'c.png': 'c general image',
             'c.android.png': 'c android image',
+            'b.d.ios.png': 'b d ios image',
+            'b.d.android.png': 'b d android image',
           }
         }
       });
 
       return Promise.all([
-        server.get('imgs/b.png', 'ios').then(
-          data => expect(data).toBe('b ios image')
+        server.get('imgs/b.d.png', 'ios').then(
+          data => expect(data).toBe('b d ios image')
+        ),
+        server.get('imgs/b.d.png', 'android').then(
+          data => expect(data).toBe('b d android image')
+        ),
+        server.get('imgs/b.d.ios.png').then(
+          data => expect(data).toBe('b d ios image')
         ),
         server.get('imgs/b.png', 'android').then(
           data => expect(data).toBe('b android image')

--- a/packager/react-packager/src/Resolver/index.js
+++ b/packager/react-packager/src/Resolver/index.js
@@ -43,6 +43,10 @@ const validateOpts = declareOpts({
     type: 'array',
     required: true,
   },
+  infixExts: {
+    type: 'array',
+    required: false,
+  },
   cache: {
     type: 'object',
     required: true,
@@ -68,6 +72,10 @@ const getDependenciesValidateOpts = declareOpts({
     type: 'string',
     required: false,
   },
+  infixExt: {
+    type: 'string',
+    required: false
+  },
   unbundle: {
     type: 'boolean',
     default: false
@@ -88,6 +96,7 @@ class Resolver {
       roots: opts.projectRoots,
       assetRoots_DEPRECATED: opts.assetRoots,
       assetExts: opts.assetExts,
+      infixExts: opts.infixExts,
       ignoreFilePath: function(filepath) {
         return filepath.indexOf('__tests__') !== -1 ||
           (opts.blacklistRE && opts.blacklistRE.test(filepath));
@@ -133,10 +142,11 @@ class Resolver {
   }
 
   getDependencies(entryPath, options, transformOptions, onProgress, getModuleId) {
-    const {platform, recursive} = getDependenciesValidateOpts(options);
+    const {platform, recursive, infixExt} = getDependenciesValidateOpts(options);
     return this._depGraph.getDependencies({
       entryPath,
       platform,
+      infixExt,
       transformOptions,
       recursive,
       onProgress,

--- a/packager/react-packager/src/Server/__tests__/Server-test.js
+++ b/packager/react-packager/src/Server/__tests__/Server-test.js
@@ -160,7 +160,7 @@ describe('processRequest', () => {
   pit('passes in the platform param', function() {
     return makeRequest(
       requestHandler,
-      'index.bundle?platform=ios'
+      'index.bundle?platform=ios&infixExt=b'
     ).then(function(response) {
       expect(response.body).toEqual('this is the source');
       expect(Bundler.prototype.bundle).toBeCalledWith({
@@ -169,8 +169,9 @@ describe('processRequest', () => {
         minify: false,
         hot: false,
         runModule: true,
-        sourceMapUrl: 'index.map?platform=ios',
+        sourceMapUrl: 'index.map?platform=ios&infixExt=b',
         dev: true,
+        infixExt: 'b',
         platform: 'ios',
         runBeforeMainModule: ['InitializeJavaScriptAppEngine'],
         unbundle: false,
@@ -390,7 +391,7 @@ describe('processRequest', () => {
 
   describe('buildBundleFromUrl(options)', () => {
     pit('Calls the bundler with the correct args', () => {
-      return server.buildBundleFromUrl('/path/to/foo.bundle?dev=false&runModule=false')
+      return server.buildBundleFromUrl('/path/to/foo.bundle?dev=false&runModule=false&infixExt=b')
         .then(() =>
           expect(Bundler.prototype.bundle).toBeCalledWith({
             entryFile: 'path/to/foo.js',
@@ -398,13 +399,14 @@ describe('processRequest', () => {
             minify: false,
             hot: false,
             runModule: false,
-            sourceMapUrl: '/path/to/foo.map?dev=false&runModule=false',
+            sourceMapUrl: '/path/to/foo.map?dev=false&runModule=false&infixExt=b',
             dev: false,
             platform: undefined,
             runBeforeMainModule: ['InitializeJavaScriptAppEngine'],
             unbundle: false,
             entryModuleOnly: false,
             isolateModuleIDs: false,
+            infixExt: 'b'
           })
         );
     });

--- a/packager/react-packager/src/lib/declareOpts.js
+++ b/packager/react-packager/src/lib/declareOpts.js
@@ -37,6 +37,8 @@ module.exports = function(descriptor) {
 
     if (record.required) {
       propValidator = propValidator.required();
+    } else {
+      propValidator = propValidator.allow(null);
     }
 
     if (record.default) {

--- a/packager/react-packager/src/node-haste/AssetModule.js
+++ b/packager/react-packager/src/node-haste/AssetModule.js
@@ -4,13 +4,13 @@ const Module = require('./Module');
 const getAssetDataFromName = require('./lib/getAssetDataFromName');
 
 class AssetModule extends Module {
-  constructor(args, platforms) {
-    super(args);
-    const { resolution, name, type } = getAssetDataFromName(this.path, platforms);
+  constructor({platforms, infixExts, ...rest}) {
+    super(rest);
+    const { resolution, name, type } = getAssetDataFromName(this.path, platforms, infixExts);
     this.resolution = resolution;
     this._name = name;
     this._type = type;
-    this._dependencies = args.dependencies || [];
+    this._dependencies = rest.dependencies || [];
   }
 
   isHaste() {

--- a/packager/react-packager/src/node-haste/AssetModule_DEPRECATED.js
+++ b/packager/react-packager/src/node-haste/AssetModule_DEPRECATED.js
@@ -4,9 +4,9 @@ const Module = require('./Module');
 const getAssetDataFromName = require('./lib/getAssetDataFromName');
 
 class AssetModule_DEPRECATED extends Module {
-  constructor(args, platforms) {
+  constructor({...args, platforms, infixExts}) {
     super(args);
-    const {resolution, name} = getAssetDataFromName(this.path, platforms);
+    const {resolution, name} = getAssetDataFromName(this.path, platforms, infixExts);
     this.resolution = resolution;
     this.name = name;
     this.platforms = platforms;

--- a/packager/react-packager/src/node-haste/DependencyGraph/HasteMap.js
+++ b/packager/react-packager/src/node-haste/DependencyGraph/HasteMap.js
@@ -11,7 +11,7 @@
 const EventEmitter = require('events');
 
 const path = require('../fastpath');
-const getPlatformExtension = require('../lib/getPlatformExtension');
+const {getPlatformExtension} = require('../lib/getExtensions');
 
 const GENERIC_PLATFORM = 'generic';
 const NATIVE_PLATFORM = 'native';

--- a/packager/react-packager/src/node-haste/ModuleCache.js
+++ b/packager/react-packager/src/node-haste/ModuleCache.js
@@ -15,8 +15,10 @@ class ModuleCache {
     transformCode,
     depGraphHelpers,
     assetDependencies,
+    infixExts,
     moduleOptions,
-  }, platforms) {
+    platforms,
+  }) {
     this._moduleCache = Object.create(null);
     this._packageCache = Object.create(null);
     this._fastfs = fastfs;
@@ -25,6 +27,7 @@ class ModuleCache {
     this._transformCode = transformCode;
     this._depGraphHelpers = depGraphHelpers;
     this._platforms = platforms;
+    this._infixExts = infixExts;
     this._assetDependencies = assetDependencies;
     this._moduleOptions = moduleOptions;
     this._packageModuleMap = new WeakMap();
@@ -60,7 +63,9 @@ class ModuleCache {
         moduleCache: this,
         cache: this._cache,
         dependencies: this._assetDependencies,
-      }, this._platforms);
+        infixExts: this._infixExts,
+        platforms: this._platforms
+      });
     }
     return this._moduleCache[filePath];
   }

--- a/packager/react-packager/src/node-haste/lib/__tests__/getAssetDataFromName-test.js
+++ b/packager/react-packager/src/node-haste/lib/__tests__/getAssetDataFromName-test.js
@@ -8,8 +8,9 @@
  */
 'use strict';
 
-jest.dontMock('../getPlatformExtension')
-    .dontMock('../getAssetDataFromName');
+jest.dontMock('../getExtensions')
+  .dontMock('../getAssetDataFromName')
+  .dontMock('../permutations');
 
 var getAssetDataFromName = require('../getAssetDataFromName');
 
@@ -18,14 +19,34 @@ describe('getAssetDataFromName', () => {
     expect(getAssetDataFromName('a/b/c.png')).toEqual({
       resolution: 1,
       assetName: 'a/b/c.png',
+      infixExt: null,
       type: 'png',
       name: 'c',
       platform: null,
     });
 
+    expect(getAssetDataFromName('a.b.png', 'ios', ['b', 'c'])).toEqual({
+      resolution: 1,
+      assetName: 'a.png',
+      infixExt: 'b',
+      type: 'png',
+      name: 'a',
+      platform: null,
+    });
+
+    expect(getAssetDataFromName('a.b.ios.png', ['ios'], ['b', 'c'])).toEqual({
+      resolution: 1,
+      assetName: 'a.b.png',
+      infixExt: 'b',
+      type: 'png',
+      name: 'a.b',
+      platform: 'ios',
+    });
+
     expect(getAssetDataFromName('a/b/c@1x.png')).toEqual({
       resolution: 1,
       assetName: 'a/b/c.png',
+      infixExt: null,
       type: 'png',
       name: 'c',
       platform: null,
@@ -34,6 +55,7 @@ describe('getAssetDataFromName', () => {
     expect(getAssetDataFromName('a/b/c@2.5x.png')).toEqual({
       resolution: 2.5,
       assetName: 'a/b/c.png',
+      infixExt: null,
       type: 'png',
       name: 'c',
       platform: null,
@@ -42,6 +64,7 @@ describe('getAssetDataFromName', () => {
     expect(getAssetDataFromName('a/b/c.ios.png')).toEqual({
       resolution: 1,
       assetName: 'a/b/c.png',
+      infixExt: null,
       type: 'png',
       name: 'c',
       platform: 'ios',
@@ -50,6 +73,7 @@ describe('getAssetDataFromName', () => {
     expect(getAssetDataFromName('a/b/c@1x.ios.png')).toEqual({
       resolution: 1,
       assetName: 'a/b/c.png',
+      infixExt: null,
       type: 'png',
       name: 'c',
       platform: 'ios',
@@ -58,6 +82,7 @@ describe('getAssetDataFromName', () => {
     expect(getAssetDataFromName('a/b/c@2.5x.ios.png')).toEqual({
       resolution: 2.5,
       assetName: 'a/b/c.png',
+      infixExt: null,
       type: 'png',
       name: 'c',
       platform: 'ios',
@@ -69,6 +94,7 @@ describe('getAssetDataFromName', () => {
       var data = getAssetDataFromName('test@2x.png');
       expect(data).toEqual({
         assetName: 'test.png',
+        infixExt: null,
         resolution: 2,
         type: 'png',
         name: 'test',
@@ -80,6 +106,7 @@ describe('getAssetDataFromName', () => {
       var data = getAssetDataFromName('test.png');
       expect(data).toEqual({
         assetName: 'test.png',
+        infixExt: null,
         resolution: 1,
         type: 'png',
         name: 'test',
@@ -91,6 +118,7 @@ describe('getAssetDataFromName', () => {
       var data = getAssetDataFromName('test@1.1x.png');
       expect(data).toEqual({
         assetName: 'test.png',
+        infixExt: null,
         resolution: 1.1,
         type: 'png',
         name: 'test',
@@ -100,6 +128,7 @@ describe('getAssetDataFromName', () => {
       data = getAssetDataFromName('test@.1x.png');
       expect(data).toEqual({
         assetName: 'test.png',
+        infixExt: null,
         resolution: 0.1,
         type: 'png',
         name: 'test',
@@ -109,6 +138,7 @@ describe('getAssetDataFromName', () => {
       data = getAssetDataFromName('test@0.2x.png');
       expect(data).toEqual({
         assetName: 'test.png',
+        infixExt: null,
         resolution: 0.2,
         type: 'png',
         name: 'test',

--- a/packager/react-packager/src/node-haste/lib/__tests__/getExtensions-test.js
+++ b/packager/react-packager/src/node-haste/lib/__tests__/getExtensions-test.js
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+'use strict';
+
+jest.dontMock('../getExtensions');
+
+var getPlatformExtension = require('../getExtensions').getPlatformExtension;
+var getInfixExt = require('../getExtensions').getInfixExt;
+
+describe('getPlatformExtension', function() {
+  it('should get platform ext', function() {
+    expect(getPlatformExtension('a.ios.js')).toBe('ios');
+    expect(getPlatformExtension('a.android.js')).toBe('android');
+    expect(getPlatformExtension('/b/c/a.ios.js')).toBe('ios');
+    expect(getPlatformExtension('/b/c.android/a.ios.something.js')).toBe('ios');
+    expect(getPlatformExtension('/b/c/a@1.5x.ios.png')).toBe('ios');
+    expect(getPlatformExtension('/b/c/a@1.5x.lol.png')).toBe(null);
+    expect(getPlatformExtension('/b/c/a.lol.png')).toBe(null);
+  });
+
+  it('should optionally accept supported platforms', function() {
+    expect(getPlatformExtension('a.ios.js', new Set(['ios']))).toBe('ios');
+    expect(getPlatformExtension('a.android.js', new Set(['android']))).toBe('android');
+    expect(getPlatformExtension('/b/c/a.ios.js', new Set(['ios', 'android']))).toBe('ios');
+    expect(getPlatformExtension('a.ios.js', new Set(['ubuntu']))).toBe(null);
+    expect(getPlatformExtension('a.ios.js', new Set([null]))).toBe(null);
+    expect(getPlatformExtension('a.ubuntu.js', new Set(['ubuntu']))).toBe('ubuntu');
+  });
+
+  it('should get infixExt', function() {
+    expect(getInfixExt('a.b.js', ['b'])).toBe('b');
+    expect(getInfixExt('a.b.js', ['a', 'b'])).toBe('b');
+    expect(getInfixExt('/b/c/a.e.js', ['e'])).toBe('e');
+    expect(getInfixExt('/b/c.android/a.e.js', ['e'])).toBe('e');
+    expect(getInfixExt('/b/c/a@1.5x.e.png', ['e'])).toBe('e');
+    expect(getInfixExt('/b/c/a@1.5x.lol.png', ['e'])).toBe(null);
+    expect(getInfixExt('/b/c/a.lol.png')).toBe(null);
+  });
+});

--- a/packager/react-packager/src/node-haste/lib/__tests__/permutations-test.js
+++ b/packager/react-packager/src/node-haste/lib/__tests__/permutations-test.js
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+'use strict';
+jest.dontMock('../permutations');
+const permutate = require('../permutations');
+
+const expected = [
+  ['a', 'b', 'c'],
+  ['a', 'c', 'b'],
+  ['b', 'a', 'c'],
+  ['b', 'c', 'a'],
+  ['c', 'a', 'b'],
+  ['c', 'b', 'a'],
+  ['a', 'b'],
+  ['a', 'c'],
+  ['b', 'a'],
+  ['b', 'c'],
+  ['c', 'a'],
+  ['c', 'b'],
+  ['a'],
+  ['b'],
+  ['c']
+];
+
+describe('permutations', () => {
+  it('should preserve the incoming order', () => {
+    console.log(JSON.stringify(permutate(['a', 'b', 'c']), null, ''));
+    console.log(JSON.stringify(expected, null, ''));
+   expect(permutate(['a', 'b', 'c']))
+      .toEqual(expected)
+  });
+});

--- a/packager/react-packager/src/node-haste/lib/getExtensions.js
+++ b/packager/react-packager/src/node-haste/lib/getExtensions.js
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+'use strict';
+
+const SUPPORTED_PLATFORM_EXTS = new Set([
+  'android',
+  'ios',
+  'web',
+]);
+
+const SUPPORTED_INFIX_EXTS = new Set([]);
+
+// Extract platform extension: index.ios.js -> ios
+function getPlatformExtension(file, platforms = SUPPORTED_PLATFORM_EXTS) {
+  const fileWithoutPath = file.split('/').pop();
+  const platformsArray = [...platforms].filter(platform => platform);
+  if (platformsArray.length === 0) {
+    return null;
+  }
+  const platformRegex = new RegExp(`\.(${platformsArray.join('|')})\.`);
+  const match = platformRegex.exec(fileWithoutPath);
+  return !match ? null : match[1];
+}
+
+// Extract the infixExt extension from the file name,
+// specified by the list of possible extensions
+function getInfixExt(file, infixExts = SUPPORTED_INFIX_EXTS) {
+  if ([...infixExts].length === 0) {
+    return null;
+  }
+  const fileWithoutPath = file.split('/').pop();
+  const platformRegex = new RegExp(`\.(${[...infixExts].join('|')})\.`);
+  const match = platformRegex.exec(fileWithoutPath);
+  return !match ? null : match[1];
+}
+
+module.exports = {getInfixExt, getPlatformExtension};

--- a/packager/react-packager/src/node-haste/lib/permutations.js
+++ b/packager/react-packager/src/node-haste/lib/permutations.js
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+'use strict';
+
+function permutations(options, cutOff = 0) {
+  const results = [];
+  function permute(arr, memory) {
+    const memo = memory || [];
+    let cur;
+    for (let i = 0; i < arr.length; ++i) {
+      cur = arr.splice(i, 1);
+      if (arr.length === cutOff) {
+        results.push(memo.concat(cur));
+      }
+      permute(arr.slice(), memo.concat(cur));
+      arr.splice(i, 0, cur[0]);
+    }
+    return results;
+  }
+  return permute(options);
+}
+
+function reduce(array) {
+  let result = [];
+  for (let i = 0; i < array.length; ++i) {
+    const permutation = permutations(array, i);
+    result = result.concat(permutation);
+  }
+  return result;
+}
+
+
+
+module.exports = reduce;


### PR DESCRIPTION
iOS and Android native developers have access to features that allow them to generate multiple apps from a single code base. At build time these features can help swapping out functionality, strings, assets, etc… 

The use cases can vary; One app for each city for a bike app, different imagery and text for a festival app framework, different app for each country for a B2B app, etc…

For iOS this can be done with targets and in Android you can use gradle flavors. Up until now there is no similar facility in React Native for assets and js files. Inspired by the —platform switch, we propose —infix as the way to generate multiple apps from a single react native javascript code base.

Allowing the packager server to receive a query parameter (```&infix=chicago```), causing the selection of files to check for this infix in the file names for assets and js files;

Choosing:
``` test.chicago.js ```
over
``` test.js ```

The functionality is tested and working in combination with platform, (```platform=ios&infix=chicago```)

Choosing:
``` test.chicago.ios.js ```
over
``` test.ios.js ```

See unit tests from line 6191 at ``` packager/react-packager/src/node-haste/__tests__/DependencyGraph-test.js ``` for cases.

Main changes in node-haste:
- ResolutionRequest
- getPlatformExtension 
- getAssetDataFromName

**Test Plan:**

Unit tests added for main cases on levels of packager, DependencyGraph, Bundler, AssetServer.

Manually tested on clean project and easily repeatable at this [example project](https://github.com/immidi/infixPrClientExample)

P.S. 
There is two unit tests failing, that were already failing before this PR but skipped because of another test suite in the file having an ``` fdescribe( ``` instead of a ``` describe( ```. I raised an issue #9192 about his but I'm not sure what to do with this is in the context of this PR. Simply disabling them seemed un-prudent.

P.P.S
Where to document this feature was not immediately obvious to me. If the core functionality is something you like, some guidance on documenting would be appreciated.