### PR TITLE
specify arguments for bundle cli parameters

### DIFF
--- a/local-cli/bundle/bundleCommandLineArgs.js
+++ b/local-cli/bundle/bundleCommandLineArgs.js
@@ -45,12 +45,14 @@ module.exports = [
     command: '--assets-dest [string]',
     description: 'Directory name where to store assets referenced in the bundle',
   }, {
-    command: '--verbose',
+    command: '--verbose [boolean]',
     description: 'Enables logging',
+    parse: (val) => val === 'false' ? false : true,
     default: false,
   }, {
-    command: '--reset-cache',
+    command: '--reset-cache [boolean]',
     description: 'Removes cached files',
+    parse: (val) => val === 'false' ? false : true,
     default: false,
   },
 ];


### PR DESCRIPTION
With the recent commander adition to the local-cli ([ref](https://github.com/facebook/react-native/commit/86cbaedb7a40a5afb105caadffdf1cea27624e31#diff-b9cfc7f2cdf78a7f4b91a753d10865a2R144)), some parameters were misconfigured.

This change makes sure that parameters like `reset-cache` are accepting a boolean argument. Without this, when running the bundle command, it wouldn't recognize the
`--reset-cache true` parameter and just show the command help.

with @fampinheiro
