### PR TITLE
feat(PushNotificationIOS): return listener when add event listener

### DIFF
--- a/Libraries/PushNotificationIOS/PushNotificationIOS.js
+++ b/Libraries/PushNotificationIOS/PushNotificationIOS.js
@@ -192,6 +192,8 @@ class PushNotificationIOS {
       );
     }
     _notifHandlers.set(handler, listener);
+
+    return listener;
   }
 
   /**


### PR DESCRIPTION
should return listener, because we can call `.remove()`

example
```
 const listener = PushNotificationIOS.addEventListener('notification', () => { do something... });
 listener.remove()
```