### PR TITLE
[Docs] - Update remote image example

### DIFF
--- a/Libraries/Image/Image.ios.js
+++ b/Libraries/Image/Image.ios.js
@@ -49,7 +49,8 @@ const ImageViewManager = NativeModules.ImageViewManager;
  *           source={require('./img/favicon.png')}
  *         />
  *         <Image
- *           source={{uri: 'http://facebook.github.io/react/img/logo_og.png'}}
+ *           style={{width: 50, height: 50}}
+ *           source={{uri: 'https://facebook.github.io/react/img/logo_og.png'}}
  *         />
  *       </View>
  *     );


### PR DESCRIPTION
I've seen quite a few newbs trip on this, so I'm fixing it.

First - you have to set the width/height on a remote image, otherwise nothing shows.  This is [even on stack overflow](http://stackoverflow.com/questions/30091398/unable-to-display-image-with-react-native-with-uri).

Second - with the addition of ATS in iOS most people who copy/paste this example will not be able to load an insecure image, so I changed it to the `https`.   

**RESULT** this doc becomes copy/paste friendly again for beginners.