### PR TITLE
Remove getDefaultProps from plain Javascript class

### DIFF
--- a/docs/UsingNavigators.md
+++ b/docs/UsingNavigators.md
@@ -31,11 +31,12 @@ import React, { Component } from 'react';
 import { View, Text } from 'react-native';
 
 export default class MyScene extends Component {
-  getDefaultProps() {
-    return {
-      title: 'MyScene'
-    };
-  }
+  static propTypes = {
+    title: React.PropTypes.string,
+  };    
+  static defaultProps = {
+    title: 'MyScene',
+  };
 
   render() {
     return (


### PR DESCRIPTION
**motivation**
`getDefaultProps` is not available in ES6 class declaration for components. Adding it here may cause confusion to new comers. 