### PR TITLE
Bugfix - Only add valid IOSPicker items.

### DIFF
--- a/Libraries/Components/Picker/PickerIOS.ios.js
+++ b/Libraries/Components/Picker/PickerIOS.ios.js
@@ -46,6 +46,11 @@ var PickerIOS = React.createClass({
     var selectedIndex = 0;
     var items = [];
     ReactChildren.forEach(props.children, function (child, index) {
+      // Only add items that are valid React elements, avoid `null`, `false`, etc
+      if (!React.isValidElement(child)) {
+        return;
+      }
+
       if (child.props.value === props.selectedValue) {
         selectedIndex = index;
       }

--- a/Libraries/Components/Picker/PickerIOS.ios.js
+++ b/Libraries/Components/Picker/PickerIOS.ios.js
@@ -45,12 +45,7 @@ var PickerIOS = React.createClass({
   _stateFromProps: function(props) {
     var selectedIndex = 0;
     var items = [];
-    ReactChildren.forEach(props.children, function (child, index) {
-      // Only add items that are valid React elements, avoid `null`, `false`, etc
-      if (!React.isValidElement(child)) {
-        return;
-      }
-
+    ReactChildren.toArray(props.children).forEach(function (child, index) {
       if (child.props.value === props.selectedValue) {
         selectedIndex = index;
       }


### PR DESCRIPTION
Fixes https://github.com/facebook/react-native/issues/9216.

As @nickzuber describes in #9216, conditional `Picker.Item` elements will lead to exceptions downstream when the `Picker` attempts to construct the collection of items.

[In the picker source](https://github.com/facebook/react-native/blob/a2fb703bbb988038323c55b29b40e8f5ff52966d/Libraries/Components/Picker/PickerIOS.ios.js#L48-L53) we can see that `child.props` is accessed when `child` has the potential to be an invalid `React` element.

```js
ReactChildren.forEach(props.children, function (child, index) {
  if (child.props.value === props.selectedValue) {
    selectedIndex = index;
  }
  items.push({value: child.props.value, label: child.props.label});
});
```

This change ensures the incoming element is valid

```diff
ReactChildren.forEach(props.children, function (child, index) {
+ if (!React.isValidElement(child)) {
+   return;
+ }
  if (child.props.value === props.selectedValue) {
    selectedIndex = index;
  }
  items.push({value: child.props.value, label: child.props.label});
});
```
