### PR TITLE
Ensure that existing properties are configurable before redefining

### DIFF
--- a/Libraries/JavaScriptAppEngine/Initialization/InitializeJavaScriptAppEngine.js
+++ b/Libraries/JavaScriptAppEngine/Initialization/InitializeJavaScriptAppEngine.js
@@ -70,8 +70,6 @@ function setUpConsole(): void {
  */
 function defineProperty(object: Object, name: string, newValue: mixed): void {
   const descriptor = Object.getOwnPropertyDescriptor(object, name);
-  const {enumerable, writable, configurable} = descriptor || {};
-
   if (descriptor) {
     const backupName = `original${name[0].toUpperCase()}${name.substr(1)}`;
     Object.defineProperty(object, backupName, {
@@ -80,6 +78,7 @@ function defineProperty(object: Object, name: string, newValue: mixed): void {
     });
   }
 
+  const {enumerable, writable, configurable} = descriptor || {};
   if (!descriptor || configurable) {
     Object.defineProperty(object, name, {
       configurable: true,
@@ -98,13 +97,12 @@ function defineLazyProperty<T>(
   const defineLazyObjectProperty = require('defineLazyObjectProperty');
 
   const descriptor = getPropertyDescriptor(object, name);
-  const {configurable} = descriptor || {};
-
   if (descriptor) {
     const backupName = `original${name[0].toUpperCase()}${name.substr(1)}`;
     Object.defineProperty(object, backupName, descriptor);
   }
 
+  const {configurable} = descriptor || {};
   if (!descriptor || configurable) {
     defineLazyObjectProperty(object, name, {
       get: getNewValue,

--- a/Libraries/JavaScriptAppEngine/Initialization/InitializeJavaScriptAppEngine.js
+++ b/Libraries/JavaScriptAppEngine/Initialization/InitializeJavaScriptAppEngine.js
@@ -72,7 +72,7 @@ function defineProperty(object: Object, name: string, newValue: mixed): void {
   const descriptor = Object.getOwnPropertyDescriptor(object, name);
   const {enumerable, writable, configurable} = descriptor || {};
 
-  if (descriptor && configurable) {
+  if (descriptor) {
     const backupName = `original${name[0].toUpperCase()}${name.substr(1)}`;
     Object.defineProperty(object, backupName, {
       ...descriptor,
@@ -100,7 +100,7 @@ function defineLazyProperty<T>(
   const descriptor = getPropertyDescriptor(object, name);
   const {configurable} = descriptor || {};
 
-  if (descriptor && configurable) {
+  if (descriptor) {
     const backupName = `original${name[0].toUpperCase()}${name.substr(1)}`;
     Object.defineProperty(object, backupName, descriptor);
   }

--- a/Libraries/JavaScriptAppEngine/Initialization/InitializeJavaScriptAppEngine.js
+++ b/Libraries/JavaScriptAppEngine/Initialization/InitializeJavaScriptAppEngine.js
@@ -70,20 +70,24 @@ function setUpConsole(): void {
  */
 function defineProperty(object: Object, name: string, newValue: mixed): void {
   const descriptor = Object.getOwnPropertyDescriptor(object, name);
-  if (descriptor) {
+  const {enumerable, writable, configurable} = descriptor || {};
+
+  if (descriptor && configurable) {
     const backupName = `original${name[0].toUpperCase()}${name.substr(1)}`;
     Object.defineProperty(object, backupName, {
       ...descriptor,
       value: object[name],
     });
   }
-  const {enumerable, writable} = descriptor || {};
-  Object.defineProperty(object, name, {
-    configurable: true,
-    enumerable: enumerable !== false,
-    writable: writable !== false,
-    value: newValue,
-  });
+
+  if (!descriptor || configurable) {
+    Object.defineProperty(object, name, {
+      configurable: true,
+      enumerable: enumerable !== false,
+      writable: writable !== false,
+      value: newValue,
+    });
+  }
 }
 
 function defineLazyProperty<T>(
@@ -94,15 +98,20 @@ function defineLazyProperty<T>(
   const defineLazyObjectProperty = require('defineLazyObjectProperty');
 
   const descriptor = getPropertyDescriptor(object, name);
-  if (descriptor) {
+  const {configurable} = descriptor || {};
+
+  if (descriptor && configurable) {
     const backupName = `original${name[0].toUpperCase()}${name.substr(1)}`;
     Object.defineProperty(object, backupName, descriptor);
   }
-  defineLazyObjectProperty(object, name, {
-    get: getNewValue,
-    enumerable: descriptor ? descriptor.enumerable !== false : true,
-    writable: descriptor ? descriptor.writable !== false : true,
-  });
+
+  if (!descriptor || configurable) {
+    defineLazyObjectProperty(object, name, {
+      get: getNewValue,
+      enumerable: descriptor ? descriptor.enumerable !== false : true,
+      writable: descriptor ? descriptor.writable !== false : true,
+    });
+  }
 }
 
 function setUpErrorHandler(): void {


### PR DESCRIPTION
# Context
`Libraries/JavaScriptAppEngine/Initialization/InitializeJavaScriptAppEngine.js` attempts to setup global variables typical in most JavaScript environments. It finds the previous property value using `Object.getOwnPropertyDescriptor` and preserves it as `original[PropertyName]` (if it existed), it then redefines the property using `Object.defineProperty`.

# Problem
Properties may only be redefined if the property descriptor specifies that it is configurable ([MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyDescriptor)). Attempting to redefine an non-configurable property will result in an error: `TypeError: Cannot redefine property: [PropertyName]`.

Not all properties being setup in `InitializeJavaScriptAppEngine.js` are necessarily configurable in the target environment.