### PR TITLE
Fix scale transform on Android

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/TransformHelper.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/TransformHelper.java
@@ -65,7 +65,9 @@ public class TransformHelper {
           helperMatrix,
           convertToRadians(transform, transformType));
       } else if ("scale".equals(transformType)) {
-        MatrixMathHelper.applyScaleZ(helperMatrix, transform.getDouble(transformType));
+        double scale = transform.getDouble(transformType);
+        MatrixMathHelper.applyScaleX(helperMatrix, scale);
+        MatrixMathHelper.applyScaleY(helperMatrix, scale);
       } else if ("scaleX".equals(transformType)) {
         MatrixMathHelper.applyScaleX(helperMatrix, transform.getDouble(transformType));
       } else if ("scaleY".equals(transformType)) {


### PR DESCRIPTION
#8892 broke scale transforms on Android as the new implementation did a Z scale for the `scale` transform instead of a XY scale.

cc @kmagiera @astreet 