### PR TITLE
[RNPM] Should be R.string, not R.strings

### DIFF
--- a/local-cli/rnpm/link/__tests__/android/applyPatch.spec.js
+++ b/local-cli/rnpm/link/__tests__/android/applyPatch.spec.js
@@ -8,7 +8,7 @@ describe('applyParams', () => {
   it('apply params to the string', () => {
     expect(
       applyParams('${foo}', {foo: 'foo'}, 'react-native')
-    ).toEqual('this.getResources().getString(R.strings.reactNative_foo)');
+    ).toEqual('this.getResources().getString(R.string.reactNative_foo)');
   });
 
   it('use null if no params provided', () => {

--- a/local-cli/rnpm/link/src/android/patches/applyParams.js
+++ b/local-cli/rnpm/link/src/android/patches/applyParams.js
@@ -7,7 +7,7 @@ module.exports = function applyParams(str, params, prefix) {
       const name = toCamelCase(prefix) + '_' + param;
 
       return params[param]
-        ? `this.getResources().getString(R.strings.${name})`
+        ? `this.getResources().getString(R.string.${name})`
         : null;
     }
   );


### PR DESCRIPTION
Fix regression of https://github.com/rnpm/rnpm-plugin-link/pull/88.