### PR TITLE
Fix off-by-one error in range requests

### DIFF
--- a/packager/react-packager/src/Server/__tests__/Server-test.js
+++ b/packager/react-packager/src/Server/__tests__/Server-test.js
@@ -362,7 +362,7 @@ describe('processRequest', () => {
       server.processRequest(req, res);
       jest.runAllTimers();
       expect(AssetServer.prototype.get).toBeCalledWith('imgs/a.png', 'ios');
-      expect(res.end).toBeCalledWith(mockData.slice(0, 3));
+      expect(res.end).toBeCalledWith(mockData.slice(0, 4));
     });
   });
 

--- a/packager/react-packager/src/Server/index.js
+++ b/packager/react-packager/src/Server/index.js
@@ -407,7 +407,7 @@ class Server {
         'Content-Type': mime.lookup(path.basename(assetPath[1]))
       });
 
-      return data.slice(dataStart, dataEnd);
+      return data.slice(dataStart, dataEnd + 1);
     }
 
     return data;


### PR DESCRIPTION
https://github.com/facebook/react-native/pull/8219 adds range requests to the asset server, but there was an off-by-one-error that made responses end prematurely. This made (for example) react-native-video not work for video assets. This change fixes the off-by-one error and react-native-video works with assets.

**Test plan (required)**

Try the test in the original pull request for range requests: https://github.com/facebook/react-native/pull/8219

