### PR TITLE
Document: ImageView should use https

### DIFF
--- a/Libraries/Image/Image.ios.js
+++ b/Libraries/Image/Image.ios.js
@@ -49,7 +49,7 @@ const ImageViewManager = NativeModules.ImageViewManager;
  *           source={require('./img/favicon.png')}
  *         />
  *         <Image
- *           source={{uri: 'http://facebook.github.io/react/img/logo_og.png'}}
+ *           source={{uri: 'https://facebook.github.io/react/img/logo_og.png'}}
  *         />
  *       </View>
  *     );


### PR DESCRIPTION
From this issue,
it looks like `<Image />` is now working only `https` by default.
So, it's better to correct the document.