### PR TITLE
Support RCTNetworking#clearCookies on iOS

### DIFF
--- a/Examples/UIExplorer/js/XHRExample.ios.js
+++ b/Examples/UIExplorer/js/XHRExample.ios.js
@@ -41,6 +41,7 @@ var {
 var XHRExampleHeaders = require('./XHRExampleHeaders');
 var XHRExampleFetch = require('./XHRExampleFetch');
 var XHRExampleOnTimeOut = require('./XHRExampleOnTimeOut');
+var XHRExampleCookies = require('./XHRExampleCookies');
 
 /**
  * Convert number of bytes to MB and round to the nearest 0.1 MB.
@@ -431,6 +432,11 @@ exports.examples = [{
   title: 'Time Out Test',
   render() {
     return <XHRExampleOnTimeOut/>;
+  }
+}, {
+  title: 'Cookies',
+  render() {
+    return <XHRExampleCookies />;
   }
 }];
 

--- a/Libraries/Network/RCTNetworking.ios.js
+++ b/Libraries/Network/RCTNetworking.ios.js
@@ -52,7 +52,7 @@ class RCTNetworking extends NativeEventEmitter {
   }
 
   clearCookies(callback: (result: boolean) => any) {
-    console.warn('RCTNetworking.clearCookies is not supported on iOS');
+    RCTNetworkingNative.clearCookies(callback);
   }
 }
 

--- a/Libraries/Network/RCTNetworking.m
+++ b/Libraries/Network/RCTNetworking.m
@@ -515,6 +515,20 @@ RCT_EXPORT_METHOD(abortRequest:(nonnull NSNumber *)requestID)
   [_tasksByRequestID removeObjectForKey:requestID];
 }
 
+RCT_EXPORT_METHOD(clearCookies:(RCTResponseSenderBlock)responseSender)
+{
+  NSHTTPCookieStorage* storage = [NSHTTPCookieStorage sharedHTTPCookieStorage];
+  if (!storage.cookies.count) {
+    responseSender(@[@NO]);
+    return;
+  }
+
+  for (NSHTTPCookie* cookie in storage.cookies) {
+    [storage deleteCookie:cookie];
+  }
+  responseSender(@[@YES]);
+}
+
 @end
 
 @implementation RCTBridge (RCTNetworking)

--- a/Libraries/Network/RCTNetworking.m
+++ b/Libraries/Network/RCTNetworking.m
@@ -517,13 +517,13 @@ RCT_EXPORT_METHOD(abortRequest:(nonnull NSNumber *)requestID)
 
 RCT_EXPORT_METHOD(clearCookies:(RCTResponseSenderBlock)responseSender)
 {
-  NSHTTPCookieStorage* storage = [NSHTTPCookieStorage sharedHTTPCookieStorage];
+  NSHTTPCookieStorage *storage = [NSHTTPCookieStorage sharedHTTPCookieStorage];
   if (!storage.cookies.count) {
     responseSender(@[@NO]);
     return;
   }
 
-  for (NSHTTPCookie* cookie in storage.cookies) {
+  for (NSHTTPCookie *cookie in storage.cookies) {
     [storage deleteCookie:cookie];
   }
   responseSender(@[@YES]);


### PR DESCRIPTION
This adds cookie clearing support for iOS to match the existing support on Android.  Helpful for resetting the app to a clean state (say, when logging a user out).
