### PR TITLE
fix CSSNodeList memory leak

### DIFF
--- a/React/CSSLayout/CSSNodeList.c
+++ b/React/CSSLayout/CSSNodeList.c
@@ -27,7 +27,10 @@ CSSNodeListRef CSSNodeListNew(uint32_t initialCapacity) {
   return list;
 }
 
-void CSSNodeListFree(CSSNodeListRef list) { free(list); }
+void CSSNodeListFree(CSSNodeListRef list) {
+  free(list->items);
+  free(list);
+}
 
 uint32_t CSSNodeListCount(CSSNodeListRef list) { return list->count; }
 


### PR DESCRIPTION
CSSNodeListFree does not free the list->items memory