### PR TITLE
Check bundle file exists for release builds

### DIFF
--- a/packager/react-native-xcode.sh
+++ b/packager/react-native-xcode.sh
@@ -80,10 +80,17 @@ if [[ "$CONFIGURATION" = "Debug" && "$PLATFORM_NAME" != "iphonesimulator" ]]; th
   echo "$IP.xip.io" > "$DEST/ip.txt"
 fi
 
+BUNDLE_FILE="$DEST/main.jsbundle"
+
 $NODE_BINARY "$REACT_NATIVE_DIR/local-cli/cli.js" bundle \
   --entry-file "$ENTRY_FILE" \
   --platform ios \
   --dev $DEV \
   --reset-cache \
-  --bundle-output "$DEST/main.jsbundle" \
+  --bundle-output $BUNDLE_FILE \
   --assets-dest "$DEST"
+
+if [[ ! $DEV && ! -f $BUNDLE_FILE ]]; then
+  echo "Error: File $BUNDLE_FILE does not exist."
+  exit 2
+fi

--- a/packager/react-native-xcode.sh
+++ b/packager/react-native-xcode.sh
@@ -87,10 +87,11 @@ $NODE_BINARY "$REACT_NATIVE_DIR/local-cli/cli.js" bundle \
   --platform ios \
   --dev $DEV \
   --reset-cache \
-  --bundle-output $BUNDLE_FILE \
+  --bundle-output "$BUNDLE_FILE" \
   --assets-dest "$DEST"
 
-if [[ ! $DEV && ! -f $BUNDLE_FILE ]]; then
-  echo "Error: File $BUNDLE_FILE does not exist."
+if [[ ! $DEV && ! -f "$BUNDLE_FILE" ]]; then
+  echo "error: File $BUNDLE_FILE does not exist. This must be a bug with" >&2
+  echo "React Native, please report it here: https://github.com/facebook/react-native/issues"
   exit 2
 fi


### PR DESCRIPTION
Motivation: While testing the RC, the bundle step failed (because the reset-cache true flag was still present) for an Archive build causing an app to be distributed without the JS bundle. This was obviously not great because the app just crashed on startup.

This fix just checks that the bundle file is present and if not fails the build, as you would expect it to.