### PR TITLE
[NavigationExperimental] Fix the NavigationTransitioner animation bug

### DIFF
--- a/Libraries/NavigationExperimental/NavigationTransitioner.js
+++ b/Libraries/NavigationExperimental/NavigationTransitioner.js
@@ -117,13 +117,15 @@ class NavigationTransitioner extends React.Component<any, Props, State> {
       scenes: nextScenes,
     };
 
-    this._prevTransitionProps = this._transitionProps;
-    this._transitionProps = buildTransitionProps(nextProps, nextState);
-
     const {
       position,
       progress,
     } = nextState;
+
+    progress.setValue(0);
+
+    this._prevTransitionProps = this._transitionProps;
+    this._transitionProps = buildTransitionProps(nextProps, nextState);
 
     // get the transition spec.
     const transitionUserSpec = nextProps.configureTransition ?
@@ -140,8 +142,6 @@ class NavigationTransitioner extends React.Component<any, Props, State> {
 
     const {timing} = transitionSpec;
     delete transitionSpec.timing;
-
-    progress.setValue(0);
 
     const animations = [
       timing(


### PR DESCRIPTION
Hi, there is a problem in the NavigationTransitioner, if navigate to the next scene before the end of the navigation animation of the current scene, the next scene is not rendered while transitioning:

![-08-2016 13-30-16](https://cloud.githubusercontent.com/assets/3778452/17477434/5e98e102-5d76-11e6-9d97-f843f0ca0360.gif)

This is can not be reproduced manually, but it happens when navigating automatically, for example after some loading completed.

I made some investigation and found that in the [componentWillReceiveProps](https://github.com/facebook/react-native/blob/master/Libraries/NavigationExperimental/NavigationTransitioner.js#L104) of the NavigationTransitioner when execution reaches  [setValue](https://github.com/facebook/react-native/blob/master/Libraries/NavigationExperimental/NavigationTransitioner.js#L144)  [_onTransitionEnd](https://github.com/facebook/react-native/blob/master/Libraries/NavigationExperimental/NavigationTransitioner.js#L210) is called, where an old _transitionProps with previous navigationState [replaces](https://github.com/facebook/react-native/blob/master/Libraries/NavigationExperimental/NavigationTransitioner.js#L219) a new _transitionProps which was previously set in [componentWillReceiveProps](https://github.com/facebook/react-native/blob/master/Libraries/NavigationExperimental/NavigationTransitioner.js#L121). It seems that progress should be reseted before building the new _transitionProps.

**Test plan**
Here https://github.com/gitim/react-native/commit/4e49a9ffb3ddb75571c59e314c322e7857eb1e30 I modified an example from the UIExplorer to reproduce the bug, you can copy this lines and run it.