### PR TITLE
Fix memory leak bug in RCTModalHost

### DIFF
--- a/React/Views/RCTModalHostViewManager.m
+++ b/React/Views/RCTModalHostViewManager.m
@@ -42,7 +42,7 @@ RCT_EXPORT_MODULE()
 - (UIView *)view
 {
   UIView *view = [[RCTModalHostView alloc] initWithBridge:self.bridge];
-  if (_hostViews) {
+  if (!_hostViews) {
     _hostViews = [NSHashTable weakObjectsHashTable];
   }
   [_hostViews addObject:view];


### PR DESCRIPTION
This PR addresses issue #9265.

Negated the condition that checks if `_hostViews` exists so that `_hostViews` will be allocated only if it doesn't exist