### PR TITLE
[deps] Remove react from deps (it's under devDeps and peerDeps)

### DIFF
--- a/package.json
+++ b/package.json
@@ -193,8 +193,7 @@
     "yeoman-generator": "0.21.2",
     "mime-types": "2.1.11",
     "whatwg-fetch": "^1.0.0",
-    "denodeify": "^1.2.1",
-    "react": "~15.3.0"
+    "denodeify": "^1.2.1"
   },
   "devDependencies": {
     "babel-eslint": "^6.0.0",


### PR DESCRIPTION
We don't want `npm install react-native` to install `react` hence this commit to remove it from deps.