### PR TITLE
[Android] Fix crash involving illegal UTF-16 symbols

### DIFF
--- a/ReactCommon/cxxreact/Value.h
+++ b/ReactCommon/cxxreact/Value.h
@@ -13,6 +13,7 @@
 #include <JavaScriptCore/JSValueRef.h>
 
 #include <folly/dynamic.h>
+#include <jni/LocalString.h>
 
 #include "noncopyable.h"
 
@@ -84,13 +85,25 @@ public:
   size_t utf8Size() const {
     return JSStringGetMaximumUTF8CStringSize(m_string);
   }
-
+  
+ /* 
+  * JavaScriptCore is built with strict utf16 -> utf8 conversion. 
+  * This means if JSC's built-in conversion function encounters a JavaScript
+  * string which contains half of a 32-bit UTF-16 symbol, it produces an error
+  * rather than returning a string.
+  *
+  * Instead of relying on this, we use our own utf16 -> utf8 conversion function
+  * which is more lenient and always returns a string. When an invalid UTF-16
+  * string is provided, it'll likely manifest as a rendering glitch in the app for
+  * the invalid symbol.
+  * 
+  * For details on JavaScript's unicode support see:
+  * https://mathiasbynens.be/notes/javascript-unicode
+  */
   std::string str() const {
-    size_t reserved = utf8Size();
-    char* bytes = new char[reserved];
-    size_t length = JSStringGetUTF8CString(m_string, bytes, reserved) - 1;
-    std::unique_ptr<char[]> retainedBytes(bytes);
-    return std::string(bytes, length);
+    const JSChar* utf16 = JSStringGetCharactersPtr(m_string);
+    int stringLength = JSStringGetLength(m_string);
+    return jni::detail::utf16toUTF8(utf16, stringLength);
   }
 
   // Assumes that utf8 is null terminated


### PR DESCRIPTION
Fixes #9301

Currently you get a red screen with an unhelpful error message
when a JavaScript string contains an invalid UTF-16 symbol.

JavaScriptCore is built with strict utf16 -> utf8 conversion.
This means if JSC's built-in conversion function encounters a JavaScript
string which contains half of a 32-bit UTF-16 symbol, it produces an error
rather than returning a string.

Instead of relying on this, we use our own utf16 -> utf8 conversion function
which is more lenient and always returns a string. When an invalid UTF-16
string is provided, it'll likely manifest as a rendering glitch in the app for
the invalid symbol.

For details on JavaScript's unicode support see:
https://mathiasbynens.be/notes/javascript-unicode

### Alternative Fix

We could also make a change in the version of JavaScriptCore React Native
consumes. Specifically, we could change JSStringGetUTF8CString to pass
false to convertUTF16ToUTF8 for the strict parameter.
https://github.com/WebKit/webkit/blob/492951f9231575b4778019a384a858a37da2bfe0/Source/JavaScriptCore/API/JSStringRef.cpp#L111

You can see the signtarue for convertUTF16ToUTF8 here:
https://github.com/WebKit/webkit/blob/66e68cd8d7bf4ea1cf52f31ed9cb242f83ea5b57/Source/WTF/wtf/unicode/UTF8.h#L74-L76

### Test plan (required)

Ran the repro steps from #9301 and, instead of a crash, saw a question mark for the invalid character:

![image](https://cloud.githubusercontent.com/assets/199935/17500584/ace49a26-5d8b-11e6-9175-cc7274383b3b.png)

This is consistent with how iOS behaves.

Adam Comella
Microsoft Corp.