### PR TITLE
Reduced precision in bezier test

### DIFF
--- a/Libraries/Animated/src/__tests__/bezier-test.js
+++ b/Libraries/Animated/src/__tests__/bezier-test.js
@@ -81,7 +81,7 @@ describe('bezier', function(){
       repeat(10)(function () {
         var a = Math.random(), b = 2*Math.random()-0.5, c = 1-a, d = 1-b;
         var easing = bezier(a, b, c, d);
-        assertClose(easing(0.5), 0.5);
+        assertClose(easing(0.5), 0.5, 2);
       });
     });
     it('should be symetrical', function () {


### PR DESCRIPTION
This should not happen again:

Summary of all failing tests
 FAIL  Libraries/Animated/src/__tests__/bezier-test.js (0.259s)
● bezier › symetric curves › it should have a central value y~=0.5 at x=0.5
  - Error: expected '0.5015953397493733' to be close to '0.5' with 3-digit precision
        at assertClose (Libraries/Animated/src/__tests__/bezier-test.js:9:11)
        at Libraries/Animated/src/__tests__/bezier-test.js:84:1
        at Libraries/Animated/src/__tests__/bezier-test.js:28:22
        at Object.<anonymous> (Libraries/Animated/src/__tests__/bezier-test.js:81:11)