### PR TITLE
Move `getLaunchOptions` from ReactActivity to ReactActivityDelegate

### DIFF
--- a/Examples/UIExplorer/android/app/src/main/java/com/facebook/react/uiapp/UIExplorerActivity.java
+++ b/Examples/UIExplorer/android/app/src/main/java/com/facebook/react/uiapp/UIExplorerActivity.java
@@ -22,38 +22,38 @@ import com.facebook.react.ReactActivityDelegate;
 
 import javax.annotation.Nullable;
 
-class UIExplorerActivityDelegate extends ReactActivityDelegate {
-  private final String PARAM_ROUTE = "route";
-  private Bundle mInitialProps = null;
-  private final @Nullable Activity mActivity;
-
-  public UIExplorerActivityDelegate(Activity activity, String mainComponentName) {
-    super(activity, mainComponentName);
-    this.mActivity = activity;
-  }
-
-  @Override
-  protected void onCreate(Bundle savedInstanceState) {
-    // Get remote param before calling super which uses it
-    Bundle bundle = mActivity.getIntent().getExtras();
-    if (bundle != null && bundle.containsKey(PARAM_ROUTE)) {
-      String routeUri = new StringBuilder("rnuiexplorer://example/")
-        .append(bundle.getString(PARAM_ROUTE))
-        .append("Example")
-        .toString();
-      mInitialProps = new Bundle();
-      mInitialProps.putString("exampleFromAppetizeParams", routeUri);
-    }
-    super.onCreate(savedInstanceState);
-  }
-
-  @Override
-  protected Bundle getLaunchOptions() {
-    return mInitialProps;
-  }
-}
-
 public class UIExplorerActivity extends ReactActivity {
+  class UIExplorerActivityDelegate extends ReactActivityDelegate {
+    private final String PARAM_ROUTE = "route";
+    private Bundle mInitialProps = null;
+    private final @Nullable Activity mActivity;
+
+    public UIExplorerActivityDelegate(Activity activity, String mainComponentName) {
+      super(activity, mainComponentName);
+      this.mActivity = activity;
+    }
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+      // Get remote param before calling super which uses it
+      Bundle bundle = mActivity.getIntent().getExtras();
+      if (bundle != null && bundle.containsKey(PARAM_ROUTE)) {
+        String routeUri = new StringBuilder("rnuiexplorer://example/")
+          .append(bundle.getString(PARAM_ROUTE))
+          .append("Example")
+          .toString();
+        mInitialProps = new Bundle();
+        mInitialProps.putString("exampleFromAppetizeParams", routeUri);
+      }
+      super.onCreate(savedInstanceState);
+    }
+
+    @Override
+    protected Bundle getLaunchOptions() {
+      return mInitialProps;
+    }
+  }
+
   @Override
   protected ReactActivityDelegate createReactActivityDelegate() {
     return new UIExplorerActivityDelegate(this, getMainComponentName());

--- a/Examples/UIExplorer/android/app/src/main/java/com/facebook/react/uiapp/UIExplorerActivity.java
+++ b/Examples/UIExplorer/android/app/src/main/java/com/facebook/react/uiapp/UIExplorerActivity.java
@@ -23,8 +23,8 @@ import com.facebook.react.ReactActivityDelegate;
 import javax.annotation.Nullable;
 
 public class UIExplorerActivity extends ReactActivity {
-  class UIExplorerActivityDelegate extends ReactActivityDelegate {
-    private final String PARAM_ROUTE = "route";
+  public static class UIExplorerActivityDelegate extends ReactActivityDelegate {
+    private static final String PARAM_ROUTE = "route";
     private Bundle mInitialProps = null;
     private final @Nullable Activity mActivity;
 

--- a/Examples/UIExplorer/android/app/src/main/java/com/facebook/react/uiapp/UIExplorerActivity.java
+++ b/Examples/UIExplorer/android/app/src/main/java/com/facebook/react/uiapp/UIExplorerActivity.java
@@ -14,18 +14,28 @@
 
 package com.facebook.react.uiapp;
 
+import android.app.Activity;
 import android.os.Bundle;
 
 import com.facebook.react.ReactActivity;
+import com.facebook.react.ReactActivityDelegate;
 
-public class UIExplorerActivity extends ReactActivity {
+import javax.annotation.Nullable;
+
+class UIExplorerActivityDelegate extends ReactActivityDelegate {
   private final String PARAM_ROUTE = "route";
   private Bundle mInitialProps = null;
+  private final @Nullable Activity mActivity;
+
+  public UIExplorerActivityDelegate(Activity activity, String mainComponentName) {
+    super(activity, mainComponentName);
+    this.mActivity = activity;
+  }
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
     // Get remote param before calling super which uses it
-    Bundle bundle = getIntent().getExtras();
+    Bundle bundle = mActivity.getIntent().getExtras();
     if (bundle != null && bundle.containsKey(PARAM_ROUTE)) {
       String routeUri = new StringBuilder("rnuiexplorer://example/")
         .append(bundle.getString(PARAM_ROUTE))
@@ -40,6 +50,13 @@ public class UIExplorerActivity extends ReactActivity {
   @Override
   protected Bundle getLaunchOptions() {
     return mInitialProps;
+  }
+}
+
+public class UIExplorerActivity extends ReactActivity {
+  @Override
+  protected ReactActivityDelegate createReactActivityDelegate() {
+    return new UIExplorerActivityDelegate(this, getMainComponentName());
   }
 
   @Override


### PR DESCRIPTION
After https://github.com/facebook/react-native/commit/3c4fd42749e0079b0cf54e1106bf81c993f9d29a, `getLaunchOptions` no longer exists in class `ReactActivity`. 
We need refactor UIExplorerActivity to fix the build error. 