### PR TITLE
Fix `fetch` imports

### DIFF
--- a/Libraries/Fetch/fetch.js
+++ b/Libraries/Fetch/fetch.js
@@ -12,6 +12,6 @@
  */
 'use strict';
 
-import 'whatwg-fetch';
+import { fetch, Headers, Request, Response } from 'whatwg-fetch';
 
 module.exports = {fetch, Headers, Request, Response};

--- a/Libraries/Fetch/fetch.js
+++ b/Libraries/Fetch/fetch.js
@@ -12,6 +12,6 @@
  */
 'use strict';
 
-import { fetch, Headers, Request, Response } from 'whatwg-fetch';
+const {fetch, Headers, Request, Response} = require('whatwg-fetch');
 
 module.exports = {fetch, Headers, Request, Response};


### PR DESCRIPTION
Current syntax trips `jest`'s build script and results in all tests failing with:

```
● Runtime Error
  - ReferenceError: fetch is not defined
        at Object.<anonymous> (node_modules/react-native/Libraries/Fetch/fetch.js:17:23)
```