### PR TITLE
bumping recycler view version to 23.2.1 for Android, definition of It…

### DIFF
--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -265,7 +265,7 @@ android {
 dependencies {
     compile fileTree(dir: 'src/main/third-party/java/infer-annotations/', include: ['*.jar'])
     compile 'com.android.support:appcompat-v7:23.0.1'
-    compile 'com.android.support:recyclerview-v7:23.2.1'
+    compile 'com.android.support:recyclerview-v7:23.1.0'
     compile 'com.facebook.fresco:fresco:0.11.0'
     compile 'com.facebook.fresco:imagepipeline-okhttp3:0.11.0'
     compile 'com.facebook.soloader:soloader:0.1.0'

--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -265,7 +265,7 @@ android {
 dependencies {
     compile fileTree(dir: 'src/main/third-party/java/infer-annotations/', include: ['*.jar'])
     compile 'com.android.support:appcompat-v7:23.0.1'
-    compile 'com.android.support:recyclerview-v7:23.0.1'
+    compile 'com.android.support:recyclerview-v7:23.2.1'
     compile 'com.facebook.fresco:fresco:0.11.0'
     compile 'com.facebook.fresco:imagepipeline-okhttp3:0.11.0'
     compile 'com.facebook.soloader:soloader:0.1.0'

--- a/ReactAndroid/src/main/java/com/facebook/react/views/recyclerview/NotAnimatedItemAnimator.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/recyclerview/NotAnimatedItemAnimator.java
@@ -2,8 +2,6 @@
 
 package com.facebook.react.views.recyclerview;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 import android.support.v7.widget.RecyclerView;
 
 /**
@@ -12,28 +10,41 @@ import android.support.v7.widget.RecyclerView;
 /*package*/ class NotAnimatedItemAnimator extends RecyclerView.ItemAnimator {
 
   @Override
-  public boolean animateDisappearance(@NonNull RecyclerView.ViewHolder viewHolder, @NonNull ItemHolderInfo preLayoutInfo, @Nullable ItemHolderInfo postLayoutInfo) {
+  public boolean animateDisappearance(
+      RecyclerView.ViewHolder viewHolder,
+      ItemHolderInfo preLayoutInfo,
+      ItemHolderInfo postLayoutInfo) {
     dispatchAnimationStarted(viewHolder);
     dispatchAnimationFinished(viewHolder);
     return true;
   }
 
   @Override
-  public boolean animateAppearance(@NonNull RecyclerView.ViewHolder viewHolder, @Nullable ItemHolderInfo preLayoutInfo, @NonNull ItemHolderInfo postLayoutInfo) {
+  public boolean animateAppearance(
+      RecyclerView.ViewHolder viewHolder,
+      ItemHolderInfo preLayoutInfo,
+      ItemHolderInfo postLayoutInfo) {
     dispatchAnimationStarted(viewHolder);
     dispatchAnimationFinished(viewHolder);
     return true;
   }
 
   @Override
-  public boolean animatePersistence(@NonNull RecyclerView.ViewHolder viewHolder, @NonNull ItemHolderInfo preLayoutInfo, @NonNull ItemHolderInfo postLayoutInfo) {
+  public boolean animatePersistence(
+      RecyclerView.ViewHolder viewHolder,
+      ItemHolderInfo preLayoutInfo,
+      ItemHolderInfo postLayoutInfo) {
     dispatchAnimationStarted(viewHolder);
     dispatchAnimationFinished(viewHolder);
     return true;
   }
 
   @Override
-  public boolean animateChange(@NonNull RecyclerView.ViewHolder oldHolder, @NonNull RecyclerView.ViewHolder newHolder, @NonNull ItemHolderInfo preLayoutInfo, @NonNull ItemHolderInfo postLayoutInfo) {
+  public boolean animateChange(
+      RecyclerView.ViewHolder oldHolder,
+      RecyclerView.ViewHolder newHolder,
+      ItemHolderInfo preLayoutInfo,
+      ItemHolderInfo postLayoutInfo) {
     dispatchAnimationStarted(oldHolder);
     dispatchAnimationFinished(oldHolder);
     dispatchAnimationStarted(newHolder);
@@ -43,7 +54,6 @@ import android.support.v7.widget.RecyclerView;
 
   @Override
   public void runPendingAnimations() {
-    // nothing
   }
 
   @Override

--- a/ReactAndroid/src/main/java/com/facebook/react/views/recyclerview/NotAnimatedItemAnimator.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/recyclerview/NotAnimatedItemAnimator.java
@@ -2,6 +2,8 @@
 
 package com.facebook.react.views.recyclerview;
 
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.support.v7.widget.RecyclerView;
 
 /**
@@ -10,49 +12,38 @@ import android.support.v7.widget.RecyclerView;
 /*package*/ class NotAnimatedItemAnimator extends RecyclerView.ItemAnimator {
 
   @Override
+  public boolean animateDisappearance(@NonNull RecyclerView.ViewHolder viewHolder, @NonNull ItemHolderInfo preLayoutInfo, @Nullable ItemHolderInfo postLayoutInfo) {
+    dispatchAnimationStarted(viewHolder);
+    dispatchAnimationFinished(viewHolder);
+    return true;
+  }
+
+  @Override
+  public boolean animateAppearance(@NonNull RecyclerView.ViewHolder viewHolder, @Nullable ItemHolderInfo preLayoutInfo, @NonNull ItemHolderInfo postLayoutInfo) {
+    dispatchAnimationStarted(viewHolder);
+    dispatchAnimationFinished(viewHolder);
+    return true;
+  }
+
+  @Override
+  public boolean animatePersistence(@NonNull RecyclerView.ViewHolder viewHolder, @NonNull ItemHolderInfo preLayoutInfo, @NonNull ItemHolderInfo postLayoutInfo) {
+    dispatchAnimationStarted(viewHolder);
+    dispatchAnimationFinished(viewHolder);
+    return true;
+  }
+
+  @Override
+  public boolean animateChange(@NonNull RecyclerView.ViewHolder oldHolder, @NonNull RecyclerView.ViewHolder newHolder, @NonNull ItemHolderInfo preLayoutInfo, @NonNull ItemHolderInfo postLayoutInfo) {
+    dispatchAnimationStarted(oldHolder);
+    dispatchAnimationFinished(oldHolder);
+    dispatchAnimationStarted(newHolder);
+    dispatchAnimationFinished(newHolder);
+    return true;
+  }
+
+  @Override
   public void runPendingAnimations() {
     // nothing
-  }
-
-  @Override
-  public boolean animateRemove(RecyclerView.ViewHolder holder) {
-    dispatchRemoveStarting(holder);
-    dispatchRemoveFinished(holder);
-    return true;
-  }
-
-  @Override
-  public boolean animateAdd(RecyclerView.ViewHolder holder) {
-    dispatchAddStarting(holder);
-    dispatchAddFinished(holder);
-    return true;
-  }
-
-  @Override
-  public boolean animateMove(
-      RecyclerView.ViewHolder holder,
-      int fromX,
-      int fromY,
-      int toX,
-      int toY) {
-    dispatchMoveStarting(holder);
-    dispatchMoveFinished(holder);
-    return true;
-  }
-
-  @Override
-  public boolean animateChange(
-      RecyclerView.ViewHolder oldHolder,
-      RecyclerView.ViewHolder newHolder,
-      int fromLeft,
-      int fromTop,
-      int toLeft,
-      int toTop) {
-    dispatchChangeStarting(oldHolder, true);
-    dispatchChangeFinished(oldHolder, true);
-    dispatchChangeStarting(newHolder, false);
-    dispatchChangeFinished(newHolder, false);
-    return true;
   }
 
   @Override

--- a/ReactAndroid/src/main/third-party/android/support/v7/recyclerview/BUCK
+++ b/ReactAndroid/src/main/third-party/android/support/v7/recyclerview/BUCK
@@ -8,6 +8,6 @@ android_prebuilt_aar(
 
 remote_file(
     name = 'recyclerview-binary-aar',
-    url = 'mvn:com.android.support:recyclerview-v7:aar:23.0.1',
-    sha1 = '94d5f16be156521e135295e2ffa70d79ef8ad9d5',
+    url = 'mvn:com.android.support:recyclerview-v7:aar:23.1.0',
+    sha1 = '9baf22ce2d5c1162365bfce00766e47ebd768fbc',
 )


### PR DESCRIPTION
Most of the existing android apps use recycler view versions **23.2.1 and above**. ReactAndroid still depends on **23.0.1**. In the new versions of recycler view the definition of **RecyclerView.ItemAnimator** abstract class has changed and since gradle would choose the latest build of recycler view the apps would start to get following unhandled exception on runtime: 

`java.lang.AbstractMethodError: abstract method "boolean android.support.v7.widget.RecyclerView$ItemAnimator.animatePersistence(android.support.v7.widget.RecyclerView$ViewHolder, android.support.v7.widget.RecyclerView$ItemAnimator$ItemHolderInfo, android.support.v7.widget.RecyclerView$ItemAnimator$ItemHolderInfo)"
                                                                          at android.support.v7.widget.RecyclerView$4.processPersistent(RecyclerView.java:464)
                                                                          at android.support.v7.widget.ViewInfoStore.process(ViewInfoStore.java:243)
                                                                          at android.support.v7.widget.RecyclerView.dispatchLayoutStep3(RecyclerView.java:3330)
                                                                          at android.support.v7.widget.RecyclerView.dispatchLayout(RecyclerView.java:3080)
                                                                          at android.support.v7.widget.RecyclerView.consumePendingUpdateOperations(RecyclerView.java:1505)
                                                                          at android.support.v7.widget.RecyclerView.access$400(RecyclerView.java:151)
                                                                          at android.support.v7.widget.RecyclerView$1.run(RecyclerView.java:305)
                                                                          at android.view.Choreographer$CallbackRecord.run(Choreographer.java:858)
                                                                          at android.view.Choreographer.doCallbacks(Choreographer.java:670)
                                                                          at android.view.Choreographer.doFrame(Choreographer.java:603)
                                                                          at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:844)
                                                                          at android.os.Handler.handleCallback(Handler.java:739)
                                                                          at android.os.Handler.dispatchMessage(Handler.java:95)
                                                                          at android.os.Looper.loop(Looper.java:148)
                                                                          at android.app.ActivityThread.main(ActivityThread.java:5417)
                                                                          at java.lang.reflect.Method.invoke(Native Method)
                                                                          at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:726)
                                                                          at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:616)
`

This is exactly what happened while I tried to do the same on one of my existing apps.

To workaround this and make integration with existing apps seamless I've upgraded recycler view version and written new implementation for **NotAnimatedItemAnimator** class.

I've tested with this change and new versions (23.2.1+) of the library work just fine now. The new implementation is almost similar to the old one. Only method names have changed in new interface.
