### PR TITLE
[Animated] Export Animated.Interpolation

### DIFF
--- a/Libraries/Animated/src/AnimatedImplementation.js
+++ b/Libraries/Animated/src/AnimatedImplementation.js
@@ -2379,12 +2379,6 @@ module.exports = {
   ValueXY: AnimatedValueXY,
 
   /**
-   * Provides access to the AnimatedInterpolation type returned by calling
-   * interpolate on a value.
-   */
-  Interpolation: AnimatedInterpolation,
-
-  /**
    * Animates a value from an initial velocity to zero based on a decay
    * coefficient.
    */
@@ -2482,3 +2476,5 @@ module.exports = {
 
   __PropsOnlyForTests: AnimatedProps,
 };
+
+export type AnimatedInterpolation = AnimatedInterpolation;

--- a/Libraries/Animated/src/AnimatedImplementation.js
+++ b/Libraries/Animated/src/AnimatedImplementation.js
@@ -1109,7 +1109,7 @@ class AnimatedInterpolation extends AnimatedWithChildren {
     super.__detach();
   }
 
-  __transformDataType(range) {
+  __transformDataType(range: Array<any>) {
     // Change the string array type to number array
     // So we can reuse the same logic in iOS and Android platform
     return range.map(function (value) {

--- a/Libraries/Animated/src/AnimatedImplementation.js
+++ b/Libraries/Animated/src/AnimatedImplementation.js
@@ -1090,9 +1090,6 @@ class AnimatedInterpolation extends AnimatedWithChildren {
       typeof parentValue === 'number',
       'Cannot interpolate an input which is not a number.'
     );
-    /* $FlowFixMe(>=0.36.0 site=react_native_fb,react_native_oss) Flow error
-     * detected during the deploy of Flow v0.36.0. To see the error, remove
-     * this comment and run Flow */
     return this._interpolation(parentValue);
   }
 
@@ -2377,6 +2374,10 @@ module.exports = {
    * 2D value class for driving 2D animations, such as pan gestures.
    */
   ValueXY: AnimatedValueXY,
+  /**
+   * exported to use the Interpolation type in flow
+   */
+  Interpolation: AnimatedInterpolation,
 
   /**
    * Animates a value from an initial velocity to zero based on a decay
@@ -2476,5 +2477,3 @@ module.exports = {
 
   __PropsOnlyForTests: AnimatedProps,
 };
-
-export type AnimatedInterpolation = AnimatedInterpolation;

--- a/Libraries/Animated/src/AnimatedImplementation.js
+++ b/Libraries/Animated/src/AnimatedImplementation.js
@@ -2379,6 +2379,12 @@ module.exports = {
   ValueXY: AnimatedValueXY,
 
   /**
+   * Provides access to the AnimatedInterpolation type returned by calling
+   * interpolate on a value.
+   */
+  Interpolation: AnimatedInterpolation,
+
+  /**
    * Animates a value from an initial velocity to zero based on a decay
    * coefficient.
    */


### PR DESCRIPTION
Flow was complaining about an interpolated value I created in a class constructor, and I realized there was no way to properly import the `AnimatedInterpolation` class type. This allows for using `Animated.Interpolation` as a type to match `Animated.Value`
