### PR TITLE
[Android] Fix bug in timer clean up

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/modules/core/Timing.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/core/Timing.java
@@ -107,6 +107,9 @@ public final class Timing extends ReactContextBaseJavaModule implements Lifecycl
             SparseArray<Timer> timers = mTimerIdsToTimers.get(timer.mExecutorToken);
             if (timers != null) {
               timers.remove(timer.mCallbackID);
+              if (timers.size() == 0) {
+                mTimerIdsToTimers.remove(timer.mExecutorToken);
+              }
             }
           }
         }
@@ -389,6 +392,9 @@ public final class Timing extends ReactContextBaseJavaModule implements Lifecycl
       }
       // We may have already called/removed it
       timersForContext.remove(timerId);
+      if (timersForContext.size() == 0) {
+        mTimerIdsToTimers.remove(executorToken);
+      }
       mTimers.remove(timer);
     }
   }

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/core/Timing.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/core/Timing.java
@@ -104,7 +104,10 @@ public final class Timing extends ReactContextBaseJavaModule implements Lifecycl
             timer.mTargetTime = frameTimeMillis + timer.mInterval;
             mTimers.add(timer);
           } else {
-            mTimerIdsToTimers.remove(timer.mExecutorToken);
+            SparseArray<Timer> timers = mTimerIdsToTimers.get(timer.mExecutorToken);
+            if (timers != null) {
+              timers.remove(timer.mCallbackID);
+            }
           }
         }
       }
@@ -385,7 +388,7 @@ public final class Timing extends ReactContextBaseJavaModule implements Lifecycl
         return;
       }
       // We may have already called/removed it
-      mTimerIdsToTimers.remove(executorToken);
+      timersForContext.remove(timerId);
       mTimers.remove(timer);
     }
   }


### PR DESCRIPTION
One of the impacts of this bug is that Java is firing timer
completion events into JavaScript for timers that should have
been deleted. JavaScript filters these out so it doesn't impact
the app developer. However, Java is completing more timers
than necessary.

When cleaning up a timer, we were accidentally deleting the
whole set of timers for that context. Instead, we should
just delete that timer from its context.

Adam Comella
Microsoft Corp.