### PR TITLE
make fsop timeout injectable

### DIFF
--- a/packager/react-packager/src/AssetServer/index.js
+++ b/packager/react-packager/src/AssetServer/index.js
@@ -28,7 +28,7 @@ function timeoutableDenodeify(fsFunc, timeout) {
   };
 }
 
-const FS_OP_TIMEOUT = 15000;
+const FS_OP_TIMEOUT = parseInt(process.env.REACT_NATIVE_FSOP_TIMEOUT, 10) || 15000;
 
 const stat = timeoutableDenodeify(fs.stat, FS_OP_TIMEOUT);
 const readDir = timeoutableDenodeify(fs.readdir, FS_OP_TIMEOUT);

--- a/packager/react-packager/src/AssetServer/index.js
+++ b/packager/react-packager/src/AssetServer/index.js
@@ -28,9 +28,11 @@ function timeoutableDenodeify(fsFunc, timeout) {
   };
 }
 
-const stat = timeoutableDenodeify(fs.stat, 15000);
-const readDir = timeoutableDenodeify(fs.readdir, 15000);
-const readFile = timeoutableDenodeify(fs.readFile, 15000);
+const FS_OP_TIMEOUT = 15000;
+
+const stat = timeoutableDenodeify(fs.stat, FS_OP_TIMEOUT);
+const readDir = timeoutableDenodeify(fs.readdir, FS_OP_TIMEOUT);
+const readFile = timeoutableDenodeify(fs.readFile, FS_OP_TIMEOUT);
 
 const validateOpts = declareOpts({
   projectRoots: {


### PR DESCRIPTION
We have a weak build machine for React Native app: a poor Mac Book Air with HDD, which is very slow.

So, fs operations sometimes fail because of timeout.

We likely don't care about build time, but it's pretty annoying to restart builds sometimes.

In this PR I make timeout injectable via environment variable.

__USAGE__:
export this variable into environment. It's measured in miliseconds.
Example, for 1 minute timeout:
`export REACT_NATIVE_FSOP_TIMEOUT=60000`

If you don't specify it, it will remain default value: `15000`

This should not break anything, but repair slow builds.

Related to : #9373 , #8794 (I think so)

This PR should handle case of issue and close #9373 