### PR TITLE
Platform.isAndroid & Platform.isIos shortcuts

### DIFF
--- a/Libraries/Utilities/Platform.android.js
+++ b/Libraries/Utilities/Platform.android.js
@@ -14,6 +14,8 @@
 
 var Platform = {
   OS: 'android',
+  isIos: false,
+  isAndroid: true,
   get Version() { return require('NativeModules').AndroidConstants.Version; },
   select: (obj: Object) => obj.android,
 };

--- a/Libraries/Utilities/Platform.ios.js
+++ b/Libraries/Utilities/Platform.ios.js
@@ -14,6 +14,8 @@
 
 var Platform = {
   OS: 'ios',
+  isIos: true,
+  isAndroid: false,
   select: (obj: Object) => obj.ios,
 };
 


### PR DESCRIPTION
motivation: allow to turn the `Platform.OS === 'android'` and `Platform.OS === 'ios'` into `Platform.isAndroid` and `Platform.isIos` which is shorter and well readable.

**Test plan (required)**
The change is simple. I tested it by modifying the UIExplorer touchables example. I can push that too, if you like.

