### PR TITLE
Update hook event names

### DIFF
--- a/Libraries/Utilities/Systrace.js
+++ b/Libraries/Utilities/Systrace.js
@@ -31,11 +31,25 @@ let _enabled = false;
 let _asyncCookie = 0;
 
 const ReactSystraceDevtool = __DEV__ ? {
-  onBeginReconcilerTimer(debugID, timerType) {
+  onBeforeMountComponent(debugID) {
     const displayName = require('react/lib/ReactComponentTreeDevtool').getDisplayName(debugID);
-    Systrace.beginEvent(`ReactReconciler.${timerType}(${displayName})`);
+    Systrace.beginEvent(`ReactReconciler.mountComponent(${displayName})`);
   },
-  onEndReconcilerTimer(debugID, timerType) {
+  onMountComponent(debugID) {
+    Systrace.endEvent();
+  },
+  onBeforeUpdateComponent(debugID) {
+    const displayName = require('react/lib/ReactComponentTreeDevtool').getDisplayName(debugID);
+    Systrace.beginEvent(`ReactReconciler.updateComponent(${displayName})`);
+  },
+  onUpdateComponent(debugID) {
+    Systrace.endEvent();
+  },
+  onBeforeUnmountComponent(debugID) {
+    const displayName = require('react/lib/ReactComponentTreeDevtool').getDisplayName(debugID);
+    Systrace.beginEvent(`ReactReconciler.unmountComponent(${displayName})`);
+  },
+  onUnmountComponent(debugID) {
     Systrace.endEvent();
   },
   onBeginLifeCycleTimer(debugID, timerType) {


### PR DESCRIPTION
This brings RN up to date with https://github.com/facebook/react/pull/7472 (scheduled for React 15.3.1).
If you use React 15.3.1 with RN without this patch, Systrace output will lack the reconciler events.

(Since it’s a niche feature it didn’t seem to me that full backward compat is necessary so I just removed old hooks. This won’t cause crashes—it’s just you won’t get events in Systrace if you use new React but old RN.)

Test plan: careful examination. I haven’t actually tested this.
I can test it next week unless somebody beats me to it.