### PR TITLE
When some row's height is 0,should compute next row

### DIFF
--- a/Libraries/CustomComponents/ListView/ListView.js
+++ b/Libraries/CustomComponents/ListView/ListView.js
@@ -615,7 +615,7 @@ var ListView = React.createClass({
         var min = isVertical ? frame.y : frame.x;
         var max = min + (isVertical ? frame.height : frame.width);
         if ((!min && !max) || (min === max)) {
-          break;
+          continue;
         }
         if (min > visibleMax || max < visibleMin) {
           if (rowVisible) {


### PR DESCRIPTION
When some row's height is 0,should compute next row, not break the loop.
If 'break', when scroll to below the height is 0 row, `onChangeVisibleRows` will not work.