### PR TITLE
Fix documentation inconsistancy with flexbox alignItems default value

### DIFF
--- a/Libraries/StyleSheet/LayoutPropTypes.js
+++ b/Libraries/StyleSheet/LayoutPropTypes.js
@@ -303,8 +303,7 @@ var LayoutPropTypes = {
   /** `alignItems` aligns children in the cross direction.
    *  For example, if children are flowing vertically, `alignItems`
    *  controls how they align horizontally.
-   *  It works like `align-items` in CSS, except the default value
-   *  is `stretch` instead of `flex-start`.
+   *  It works like `align-items` in CSS.
    *  See https://developer.mozilla.org/en-US/docs/Web/CSS/align-items
    *  for more details.
    */

--- a/Libraries/StyleSheet/LayoutPropTypes.js
+++ b/Libraries/StyleSheet/LayoutPropTypes.js
@@ -276,7 +276,7 @@ var LayoutPropTypes = {
 
   /** `flexWrap` controls whether children can wrap around after they
    *  hit the end of a flex container.
-   *  It works like `flex-wrap` in CSS.
+   *  It works like `flex-wrap` in CSS (default: nowrap).
    *  See https://developer.mozilla.org/en-US/docs/Web/CSS/flex-wrap
    *  for more details.
    */
@@ -288,7 +288,7 @@ var LayoutPropTypes = {
   /** `justifyContent` aligns children in the main direction.
    *  For example, if children are flowing vertically, `justifyContent`
    *  controls how they align vertically.
-   *  It works like `justify-content` in CSS.
+   *  It works like `justify-content` in CSS (default: flex-start).
    *  See https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content
    *  for more details.
    */
@@ -303,7 +303,7 @@ var LayoutPropTypes = {
   /** `alignItems` aligns children in the cross direction.
    *  For example, if children are flowing vertically, `alignItems`
    *  controls how they align horizontally.
-   *  It works like `align-items` in CSS.
+   *  It works like `align-items` in CSS (default: stretch).
    *  See https://developer.mozilla.org/en-US/docs/Web/CSS/align-items
    *  for more details.
    */
@@ -316,7 +316,7 @@ var LayoutPropTypes = {
 
   /** `alignSelf` controls how a child aligns in the cross direction,
    *  overriding the `alignItems` of the parent. It works like `align-self`
-   *  in CSS.
+   *  in CSS (default: auto).
    *  See https://developer.mozilla.org/en-US/docs/Web/CSS/align-self
    *  for more details.
    */


### PR DESCRIPTION
As per mozilla docs alignItems already has made `stretch` as default
value

https://developer.mozilla.org/en-US/docs/Web/CSS/align-items. 

This resolves issue https://github.com/facebook/react-native/issues/8920