### PR TITLE
Warn about long run time of init.

### DIFF
--- a/react-native-cli/index.js
+++ b/react-native-cli/index.js
@@ -102,6 +102,7 @@ if (cli) {
       );
       process.exit(1);
     } else {
+      if(!argv.verbose) console.log('This may take some time...');
       init(commands[1], argv.verbose, argv.version);
     }
     break;


### PR DESCRIPTION
I, like many before me, had to Google why react-native init appeared to hang the first time I tried it.

It turns out it can just take a really long time, but does not give any warning of this fact.

This patch provides such a warning.