### PR TITLE
Fix android letter spacing

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewProps.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewProps.java
@@ -70,6 +70,7 @@ public class ViewProps {
   public static final String FONT_STYLE = "fontStyle";
   public static final String FONT_FAMILY = "fontFamily";
   public static final String LINE_HEIGHT = "lineHeight";
+  public static final String LETTER_SPACING = "letterSpacing";
   public static final String NEEDS_OFFSCREEN_ALPHA_COMPOSITING = "needsOffscreenAlphaCompositing";
   public static final String NUMBER_OF_LINES = "numberOfLines";
   public static final String LINE_BREAK_MODE = "ellipsizeMode";

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextShadowNode.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextShadowNode.java
@@ -304,6 +304,7 @@ public class ReactTextShadowNode extends LayoutShadowNode {
   }
 
   private float mLineHeight = Float.NaN;
+  private float mLetterSpacing = Float.NaN;
   private boolean mIsColorSet = false;
   private int mColor;
   private boolean mIsBackgroundColorSet = false;
@@ -360,6 +361,15 @@ public class ReactTextShadowNode extends LayoutShadowNode {
     }
   }
 
+  public float getLetterSpacing() {
+    return mLetterSpacing;
+  }
+
+  public int getFontSize() {
+    return mFontSize;
+  }
+
+
   // Returns a line height which takes into account the requested line height
   // and the height of the inline images.
   public float getEffectiveLineHeight() {
@@ -415,6 +425,12 @@ public class ReactTextShadowNode extends LayoutShadowNode {
   @ReactProp(name = ViewProps.LINE_HEIGHT, defaultInt = UNSET)
   public void setLineHeight(int lineHeight) {
     mLineHeight = lineHeight == UNSET ? Float.NaN : PixelUtil.toPixelFromSP(lineHeight);
+    markUpdated();
+  }
+
+  @ReactProp(name = ViewProps.LETTER_SPACING, defaultFloat = UNSET)
+  public void setLetterSpacing(float letterSpacing) {
+    mLetterSpacing = letterSpacing == UNSET ? Float.NaN : letterSpacing;
     markUpdated();
   }
 
@@ -588,6 +604,8 @@ public class ReactTextShadowNode extends LayoutShadowNode {
           UNSET,
           mContainsImages,
           getPadding(),
+          getLetterSpacing(),
+          getFontSize(),
           getEffectiveLineHeight(),
           getTextAlign()
         );

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextUpdate.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextUpdate.java
@@ -29,6 +29,8 @@ public class ReactTextUpdate {
   private final float mPaddingRight;
   private final float mPaddingBottom;
   private final float mLineHeight;
+  private final float mLetterSpacing;
+  private final int mFontSize;
   private final int mTextAlign;
 
   public ReactTextUpdate(
@@ -36,6 +38,8 @@ public class ReactTextUpdate {
     int jsEventCounter,
     boolean containsImages,
     Spacing padding,
+    float letterSpacing,
+    int fontSize,
     float lineHeight,
     int textAlign) {
     mText = text;
@@ -45,6 +49,8 @@ public class ReactTextUpdate {
     mPaddingTop = padding.get(Spacing.TOP);
     mPaddingRight = padding.get(Spacing.END);
     mPaddingBottom = padding.get(Spacing.BOTTOM);
+    mLetterSpacing = letterSpacing;
+    mFontSize = fontSize;
     mLineHeight = lineHeight;
     mTextAlign = textAlign;
   }
@@ -75,6 +81,14 @@ public class ReactTextUpdate {
 
   public float getPaddingBottom() {
     return mPaddingBottom;
+  }
+
+  public float getLetterSpacing() {
+    return mLetterSpacing;
+  }
+
+  public int getFontSize() {
+    return mFontSize;
   }
 
   public float getLineHeight() {

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
@@ -18,6 +18,7 @@ import android.view.ViewGroup;
 import android.widget.TextView;
 
 import com.facebook.csslayout.FloatUtil;
+import com.facebook.react.uimanager.PixelUtil;
 import com.facebook.react.uimanager.ReactCompoundView;
 
 public class ReactTextView extends TextView implements ReactCompoundView {
@@ -30,6 +31,7 @@ public class ReactTextView extends TextView implements ReactCompoundView {
   private int mDefaultGravityVertical;
   private boolean mTextIsSelectable;
   private float mLineHeight = Float.NaN;
+  private float mLetterSpacing = Float.NaN;
   private int mTextAlign = Gravity.NO_GRAVITY;
 
   public ReactTextView(Context context) {
@@ -53,6 +55,19 @@ public class ReactTextView extends TextView implements ReactCompoundView {
       (int) Math.ceil(update.getPaddingTop()),
       (int) Math.ceil(update.getPaddingRight()),
       (int) Math.ceil(update.getPaddingBottom()));
+
+    float nextLetterSpacing = update.getLetterSpacing();
+    int fontSize = update.getFontSize();
+    if (!FloatUtil.floatsEqual(mLetterSpacing, nextLetterSpacing)) {
+      mLetterSpacing = nextLetterSpacing;
+      if(Float.isNaN(mLetterSpacing)) {
+        setLetterSpacing((float)0.0);
+      } else {
+        //calculate EM from proper font pixels
+        setLetterSpacing(1+(mLetterSpacing-PixelUtil.toDIPFromPixel(fontSize))/PixelUtil.toDIPFromPixel(fontSize));
+      }
+    }
+
 
     float nextLineHeight = update.getLineHeight();
     if (!FloatUtil.floatsEqual(mLineHeight, nextLineHeight)) {

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputShadowNode.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputShadowNode.java
@@ -87,6 +87,9 @@ public class ReactTextInputShadowNode extends ReactTextShadowNode implements
         (int) Math.ceil(getPadding().get(Spacing.END)),
         (int) Math.ceil(getPadding().get(Spacing.BOTTOM)));
 
+    editText.setLetterSpacing(getLetterSpacing());
+
+
     if (mNumberOfLines != UNSET) {
       editText.setLines(mNumberOfLines);
     }
@@ -129,6 +132,8 @@ public class ReactTextInputShadowNode extends ReactTextShadowNode implements
           mJsEventCount,
           mContainsImages,
           getPadding(),
+          getLetterSpacing(),
+          getFontSize(),
           getEffectiveLineHeight(),
           mTextAlign
         );


### PR DESCRIPTION
Motivation for this fix is to get "letterSpacing" property in styles to work on Android (for the most part - there are non working edge cases potentially - primary use case seems fine)

**Test plan (required)**
Tested using:
  letterSpacing: -6,
  fontSize:24,
  fontFamily:'ionicons',

Good Stars
<img width="56" alt="goodstars" src="https://cloud.githubusercontent.com/assets/1660092/17684769/70dda8ac-6334-11e6-911f-274dfb5a9c79.png">

Bad Stars
<img width="59" alt="badstars" src="https://cloud.githubusercontent.com/assets/1660092/17684821/ed4f881a-6334-11e6-8c01-3772fc351b1c.png">
