### PR TITLE
Tweak the rules for the showcase

### DIFF
--- a/website/src/react-native/showcase.js
+++ b/website/src/react-native/showcase.js
@@ -10,10 +10,12 @@
 /*
 Thousands of applications use React Native, so we can't list all of them
 in our showcase. To be useful to someone looking through the showcase,
-either the app must be something that most readers would recognize, or the makers of the application must have posted useful technical content about the making of the app. It also must be useful considering that the majority of readers only speak English. So, each app in the showcase should link to either:
+either the app must be something that most readers would recognize, or the makers of the application must have
+posted useful technical content about the making of the app. It also must be useful considering that the majority
+of readers only speak English. So, each app in the showcase should link to either:
 
 1/ An English-language news article discussing the app, built either by a funded startup or for a public company
-2/ An English-language technical blog post by the app creators specifically discussing React Native
+2/ An English-language technical post on a funded startup or public company blog discussing React Native
 
 For each app in the showcase, use infoLink and infoTitle to reference this content.
 */


### PR DESCRIPTION
This just slightly alters the showcase rules to say that a technical blog post should be company-branded. Better to make exceptions the other way for particularly good posts, rather than to complain to people who are following the rules that the post doesn't seem "showcaseworthy".