### PR TITLE
Add `checkAndroid` back

### DIFF
--- a/local-cli/runAndroid/runAndroid.js
+++ b/local-cli/runAndroid/runAndroid.js
@@ -16,6 +16,11 @@ const isPackagerRunning = require('../util/isPackagerRunning');
 const Promise = require('promise');
 const adb = require('./adb');
 
+// Verifies this is an Android project
+function checkAndroid(root) {
+  return fs.existsSync(path.join(root, 'android/gradlew'));
+}
+
 /**
  * Starts the app on a connected Android emulator or device.
  */


### PR DESCRIPTION
`checkAndroid` has been lost from my last PR. Finally...

[Reminder: https://github.com/facebook/react-native/pull/9190 and https://github.com/facebook/react-native/pull/9448]

I've created a new PR from this fresh new cloned repository. I think we're done with this one !