### PR TITLE
Bring back missing android command

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,7 +1,7 @@
 [ignore]
 
 # We fork some components by platform.
-.*/*.android.js
+.*/*[.]android.js
 
 # Ignore templates with `@flow` in header
 .*/local-cli/generator.*

--- a/local-cli/android/android.js
+++ b/local-cli/android/android.js
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+'use strict';
+
+var generate = require('../generate/generate');
+var fs = require('fs');
+
+function android(argv, config, args) {
+  return generate([
+    '--platform', 'android',
+    '--project-path', process.cwd(),
+    '--project-name', args.projectName,
+  ], config);
+}
+
+module.exports = {
+  name: 'android',
+  description: 'creates an empty android project',
+  func: android,
+  options: [{
+    command: '--project-name [name]',
+    default: () => JSON.parse(
+      fs.readFileSync('package.json', 'utf8')
+    ).name,
+  }],
+};

--- a/local-cli/commands.js
+++ b/local-cli/commands.js
@@ -31,6 +31,7 @@ export type Command = {
 };
 
 const documentedCommands = [
+  require('./android/android'),
   require('./server/server'),
   require('./runIOS/runIOS'),
   require('./runAndroid/runAndroid'),

--- a/local-cli/commands.js
+++ b/local-cli/commands.js
@@ -31,6 +31,7 @@ export type Command = {
 };
 
 const documentedCommands = [
+  // $FlowFixMe: For some reason it reports missing `android/android` module
   require('./android/android'),
   require('./server/server'),
   require('./runIOS/runIOS'),

--- a/local-cli/commands.js
+++ b/local-cli/commands.js
@@ -31,7 +31,6 @@ export type Command = {
 };
 
 const documentedCommands = [
-  // $FlowFixMe: For some reason it reports missing `android/android` module
   require('./android/android'),
   require('./server/server'),
   require('./runIOS/runIOS'),


### PR DESCRIPTION
Fixes #9312 

(Sorry for inconvenience, could've been removed by mistake!)

Bonus: projectName can be configured rather than always defaulting to package.json name, not sure if helpful, but just added it since we have a `default` function that makes sense in this case.