### PR TITLE
Attach origin of a 3rd party command

### DIFF
--- a/local-cli/cliEntry.js
+++ b/local-cli/cliEntry.js
@@ -52,11 +52,19 @@ function printHelpInformation() {
     cmdName = cmdName + '|' + this._alias;
   }
 
+  const sourceInformation = this.pkg
+    ? [
+      `  ${chalk.bold('Source:')} ${this.pkg.name}@${this.pkg.version}`,
+      '',
+    ]
+    : [];
+
   let output = [
     '',
     chalk.bold(chalk.cyan((`  react-native ${cmdName} ${this.usage()}`))),
     `  ${this._description}`,
     '',
+    ...sourceInformation,
     `  ${chalk.bold('Options:')}`,
     '',
     this.optionHelp().replace(/^/gm, '    '),
@@ -114,6 +122,7 @@ const addCommand = (command: Command, config: Config) => {
 
     cmd.helpInformation = printHelpInformation.bind(cmd);
     cmd.examples = command.examples;
+    cmd.pkg = command.pkg;
 
   options
     .forEach(opt => cmd.option(

--- a/local-cli/commands.js
+++ b/local-cli/commands.js
@@ -28,6 +28,10 @@ export type Command = {
     desc: string,
     cmd: string,
   }>,
+  pkg?: {
+    version: string,
+    name: string,
+  },
 };
 
 const documentedCommands = [

--- a/local-cli/core/getCommands.js
+++ b/local-cli/core/getCommands.js
@@ -12,10 +12,14 @@ const attachPackage = (command, pkg) => Array.isArray(command)
 module.exports = function getCommands() {
   const appRoot = process.cwd();
   const plugins = findPlugins([appRoot])
-    .map(name => attachPackage(
-      require(path.join(appRoot, 'node_modules', name)),
-      require(path.join(appRoot, 'node_modules', name, 'package.json'))
-    ));
+    .map(pathToCommands => {
+      const name = pathToCommands.split('/')[0];
+
+      return attachPackage(
+        require(path.join(appRoot, 'node_modules', pathToCommands)),
+        require(path.join(appRoot, 'node_modules', name, 'package.json'))
+      ));
+    });
 
   return flatten(plugins);
 };

--- a/local-cli/core/getCommands.js
+++ b/local-cli/core/getCommands.js
@@ -2,11 +2,20 @@ const path = require('path');
 const findPlugins = require('./findPlugins');
 const flatten = require('lodash').flatten;
 
+const attachPackage = (command, pkg) => Array.isArray(command)
+  ? command.map(cmd => attachPackage(cmd, pkg))
+  : { ...command, pkg };
+
 /**
  * @return {Array} Array of commands
  */
 module.exports = function getCommands() {
   const appRoot = process.cwd();
-  const plugins = findPlugins([appRoot]).map(name => require(path.join(appRoot, 'node_modules', name)));
+  const plugins = findPlugins([appRoot])
+    .map(name => attachPackage(
+      require(path.join(appRoot, 'node_modules', name)),
+      require(path.join(appRoot, 'node_modules', name, 'package.json'))
+    ));
+
   return flatten(plugins);
 };

--- a/local-cli/core/getCommands.js
+++ b/local-cli/core/getCommands.js
@@ -18,7 +18,7 @@ module.exports = function getCommands() {
       return attachPackage(
         require(path.join(appRoot, 'node_modules', pathToCommands)),
         require(path.join(appRoot, 'node_modules', name, 'package.json'))
-      ));
+      );
     });
 
   return flatten(plugins);


### PR DESCRIPTION
Fixes #9236 as suggested.

<img width="505" alt="screen shot 2016-08-22 at 21 34 44" src="https://cloud.githubusercontent.com/assets/2464966/17868740/701a0ba0-68b0-11e6-87a5-4753d5bec688.png">

(just used dummy plugin that is actually deprecated to show the output)