### PR TITLE
CameraRoll - Allow PhotoKit to download photos from iCloud

### DIFF
--- a/Libraries/CameraRoll/RCTPhotoLibraryImageLoader.m
+++ b/Libraries/CameraRoll/RCTPhotoLibraryImageLoader.m
@@ -60,6 +60,9 @@ RCT_EXPORT_MODULE()
   PHAsset *asset = [results firstObject];
   PHImageRequestOptions *imageOptions = [PHImageRequestOptions new];
 
+  // Allow PhotoKit to fetch images from iCloud
+  imageOptions.networkAccessAllowed = YES;
+
   if (progressHandler) {
     imageOptions.progressHandler = ^(double progress, NSError *error, BOOL *stop, NSDictionary<NSString *, id> *info) {
       static const double multiplier = 1e6;


### PR DESCRIPTION
Resolves #7081 by allowing iCloud to download photos not stored on the device.

**Test plan (required)**

1. Verified existing photos stored on the device still display.
2. Deleted my iCloud photo library from my phone and verified the image downloads and displays.