### PR TITLE
Include CSSLayout.h consistently with other project includes

### DIFF
--- a/Libraries/Text/RCTTextManager.m
+++ b/Libraries/Text/RCTTextManager.m
@@ -9,7 +9,13 @@
 
 #import "RCTTextManager.h"
 
+//Internally we reference a separate library. See https://github.com/facebook/react-native/pull/9544
+#if __has_include(<CSSLayout/CSSLayout.h>)
 #import <CSSLayout/CSSLayout.h>
+#else
+#import "CSSLayout.h"
+#endif
+
 #import "RCTAccessibilityManager.h"
 #import "RCTAssert.h"
 #import "RCTConvert.h"

--- a/React.podspec
+++ b/React.podspec
@@ -29,9 +29,8 @@ Pod::Spec.new do |s|
   s.preserve_paths      = "cli.js", "Libraries/**/*.js", "lint", "linter.js", "node_modules", "package.json", "packager", "PATENTS", "react-native-cli"
 
   s.subspec 'Core' do |ss|
-    ss.dependency            'React/CSSLayout'
     ss.source_files        = "React/**/*.{c,h,m,mm,S}"
-    ss.exclude_files       = "**/__tests__/*", "IntegrationTests/*", "React/CSSLayout/*"
+    ss.exclude_files       = "**/__tests__/*", "IntegrationTests/*"
     ss.frameworks          = "JavaScriptCore"
     ss.libraries           = "stdc++"
     ss.pod_target_xcconfig = { "CLANG_CXX_LANGUAGE_STANDARD" => "c++14" }
@@ -41,11 +40,6 @@ Pod::Spec.new do |s|
     ss.dependency       'React/Core'
     ss.source_files   = "Libraries/ART/**/*.{h,m}"
     ss.preserve_paths = "Libraries/ART/**/*.js"
-  end
-
-  s.subspec 'CSSLayout' do |ss|
-    ss.source_files        = "React/CSSLayout/**/*.{c,h}"
-    ss.header_mappings_dir = "React"
   end
 
   s.subspec 'RCTActionSheet' do |ss|

--- a/React/Base/RCTConvert.h
+++ b/React/Base/RCTConvert.h
@@ -10,7 +10,13 @@
 #import <QuartzCore/QuartzCore.h>
 #import <UIKit/UIKit.h>
 
+//Internally we reference a separate library. See https://github.com/facebook/react-native/pull/9544
+#if __has_include(<CSSLayout/CSSLayout.h>)
 #import <CSSLayout/CSSLayout.h>
+#else
+#import "CSSLayout.h"
+#endif
+
 #import "RCTAnimationType.h"
 #import "RCTBorderStyle.h"
 #import "RCTTextDecorationLineType.h"

--- a/React/Modules/RCTUIManager.m
+++ b/React/Modules/RCTUIManager.m
@@ -11,7 +11,13 @@
 
 #import <AVFoundation/AVFoundation.h>
 
+//Internally we reference a separate library. See https://github.com/facebook/react-native/pull/9544
+#if __has_include(<CSSLayout/CSSLayout.h>)
 #import <CSSLayout/CSSLayout.h>
+#else
+#import "CSSLayout.h"
+#endif
+
 #import "RCTAccessibilityManager.h"
 #import "RCTAnimationType.h"
 #import "RCTAssert.h"

--- a/React/Views/RCTShadowView.h
+++ b/React/Views/RCTShadowView.h
@@ -9,7 +9,13 @@
 
 #import <UIKit/UIKit.h>
 
+//Internally we reference a separate library. See https://github.com/facebook/react-native/pull/9544
+#if __has_include(<CSSLayout/CSSLayout.h>)
 #import <CSSLayout/CSSLayout.h>
+#else
+#import "CSSLayout.h"
+#endif
+
 #import "RCTComponent.h"
 #import "RCTRootView.h"
 


### PR DESCRIPTION
Include CSSLayout headers in the same way as other project headers, ie `#import <CSSLayout/CSSLayout.h>` becomes `#import "CSSLayout.h"`. CSSLayout is not a framework or system dependency, so shouldn't (AFAIK) be included with angle brackets. Doing so breaks framework builds, such as when RN is used as a pod in a swift project.

In combination with https://github.com/facebook/css-layout/pull/217 this fixes https://github.com/facebook/react-native/issues/9014 (specifically swift cocoapods projects). There is then no need for a separate CSSLayout pod subspec.

Tests run on the RN project in isolation (with changes inside `CSSLayout` itself also applied) and against a dummy swift project with RN included as a pod.

NB: This effectively reverts https://github.com/facebook/react-native/pull/9015 and may break non-swift cocoapods projects unless https://github.com/facebook/css-layout/pull/217 is merged and synced first.

Update: As discussed with @alloy and @emilsjolander, wrap these imports in a preprocessor macro so that `#import <CSSLayout/CSSLayout.h>` is used wherever it exists - needed for FB internal use as a library import.