### PR TITLE
_getText defaults to blank string when no default value set

### DIFF
--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -560,7 +560,11 @@ const TextInput = React.createClass({
   _getText: function(): ?string {
     return typeof this.props.value === 'string' ?
       this.props.value :
-      this.props.defaultValue;
+      (
+        this.props.defaultValue ? 
+        this.props.defaultValue : 
+        ''
+      );
   },
 
   _renderIOS: function() {

--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -561,8 +561,8 @@ const TextInput = React.createClass({
     return typeof this.props.value === 'string' ?
       this.props.value :
       (
-        this.props.defaultValue ? 
-        this.props.defaultValue : 
+        this.props.defaultValue ?
+        this.props.defaultValue :
         ''
       );
   },

--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -561,7 +561,7 @@ const TextInput = React.createClass({
     return typeof this.props.value === 'string' ?
       this.props.value :
       (
-        this.props.defaultValue ?
+        typeof this.props.defaultValue === 'string' ?
         this.props.defaultValue :
         ''
       );


### PR DESCRIPTION
#6936 reports a problem with the implementation of TextInput. On iOS clearing a TextInput with no default value set would preserve the first portion of the text being cleared. 

One of the potential fixes that @grabbou suggested was to make _getText return an empty string in the worst case of null value and null defaultValue. 



