### PR TITLE
[showcase] Add Artsy.

### DIFF
--- a/website/src/react-native/showcase.js
+++ b/website/src/react-native/showcase.js
@@ -321,6 +321,13 @@ var featured = [
     infoLink: 'https://www.zfanw.com/blog/developing-react-native-image-viewer-library.html',
     infoTitle: 'Developing the react-native-image-viewer library',
   },
+  {
+    name: 'Artsy – Collect and Bid on Fine Art & Design',
+    icon: 'https://raw.githubusercontent.com/artsy/eigen/master/Artsy/Resources/Images.xcassets/AppIcon.appiconset/AppIcon167.png',
+    linkAppStore: 'https://itunes.apple.com/us/app/artsy-collect-bid-on-fine/id703796080?mt=8',
+    infoLink: 'https://artsy.github.io/series/react-native-at-artsy/',
+    infoTitle: 'React Native at Artsy',
+  },
 ];
 
 featured.sort(function(a, b) {


### PR DESCRIPTION
> Thousands of applications use React Native

🎉 

> To be useful to someone looking through the showcase, either the app must be something that most readers would recognise

* Artsy is known in the art world.
* Artsy is known to Apple customers as both the site and the iOS app have been featured by Apple in marketing materials and presentations various times.
* Artsy is known to developers for its many open-source contributions.

> or the makers of the application must have posted useful technical content about the making of the app

We’re writing [a series](http://artsy.github.io/series/react-native-at-artsy/) of posts related to RN on our engineering blog, of which the initial one can be found [here](http://artsy.github.io/blog/2016/08/15/React-Native-at-Artsy/). In `showcase.js` I link to the series overview, though.

> So, each app in the showcase should link to either:
>
> 1. An English-language news article discussing the app, built either by a funded startup or for a public company
> 2. An English-language technical post on a funded startup or public company blog discussing React Native

Artsy is [a funded startup](https://www.crunchbase.com/organization/art-sy#/entity).