### PR TITLE
fix(packager): support node-haste browser and react-native replacements on Windows

### DIFF
--- a/packager/react-packager/src/node-haste/Package.js
+++ b/packager/react-packager/src/node-haste/Package.js
@@ -58,7 +58,7 @@ class Package {
         return name;
       }
 
-      if (name[0] !== '/') {
+      if (!isAbsolutePath(name)) {
         const replacement = replacements[name];
         // support exclude with "someDependency": false
         return replacement === false
@@ -66,11 +66,11 @@ class Package {
           : replacement || name;
       }
 
-      if (!isAbsolutePath(name)) {
-        throw new Error(`Expected ${name} to be absolute path`);
+      const relPath = './' + path.relative(this.root, name);
+      if (path.sep !== '/') {
+        relPath.replace(path.sep, '/');
       }
 
-      const relPath = './' + path.relative(this.root, name);
       let redirect = replacements[relPath];
 
       // false is a valid value

--- a/packager/react-packager/src/node-haste/Package.js
+++ b/packager/react-packager/src/node-haste/Package.js
@@ -66,9 +66,9 @@ class Package {
           : replacement || name;
       }
 
-      const relPath = './' + path.relative(this.root, name);
+      let relPath = './' + path.relative(this.root, name);
       if (path.sep !== '/') {
-        relPath.replace(path.sep, '/');
+        relPath = relPath.replace(path.sep, '/');
       }
 
       let redirect = replacements[relPath];


### PR DESCRIPTION
Explain the **motivation** for making this change. What existing problem does the pull request solve?

Fix issue with browser and react-native module mappings in node-haste when running the packager from Windows.

**Test plan (required)**

Tested on the NPM package uuid, which has a browser mapping, and it worked.

Fixes #9570