### PR TITLE
Update gradle version and android gradle plugin version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         mavenLocal()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.5.0'
+        classpath 'com.android.tools.build:gradle:2.1.3'
         classpath 'de.undercouch:gradle-download-task:2.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https://services.gradle.org/distributions/gradle-2.11-all.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-2.14.1-all.zip


### PR DESCRIPTION
I wasn't able to run Android instrumentation tests locally from Android Studio without bumping the gradle plugin version and gradle version. 
I know that Facebook is planning to move away from Gradle into BUCK only, but this is a pretty straightforward change that seemed to fix it for me.