### PR TITLE
use lookup folder instead of cwd for symlink path resolution. Refs #9009

### DIFF
--- a/local-cli/server/findSymlinksPaths.js
+++ b/local-cli/server/findSymlinksPaths.js
@@ -6,7 +6,7 @@ module.exports = function findSymlinksPaths(lookupFolder) {
   const folders = fs.readdirSync(lookupFolder);
   const resolvedSymlinks = folders.map(folder => path.resolve(lookupFolder, folder))
     .filter(folderPath => fs.lstatSync(folderPath).isSymbolicLink())
-    .map(symlink => path.resolve(process.cwd(), fs.readlinkSync(symlink)));
+    .map(symlink => path.resolve(lookupFolder, fs.readlinkSync(symlink)));
   const timeEnd = Date.now();
 
   console.log(`Scanning ${folders.length} folders for symlinks in ${lookupFolder} (${timeEnd - timeStart}ms)`);


### PR DESCRIPTION
Explain the **motivation** for making this change. What existing problem does the pull request solve?

Fixes the symlink path resolution. See discussion here: https://github.com/facebook/react-native/pull/9009#issuecomment-241965513

**Test plan (required)**

Symlink a required module by running `npm link` in the module directory and then `npm link <module name>` in your project  and run `npm start`. The packager and server should start properly and not throw an error about not being unable to find the symlink.

cc/ @Kureev @bestander 
