### PR TITLE
Mark Text style fontVariant as iOS only

### DIFF
--- a/Libraries/Text/TextStylePropTypes.js
+++ b/Libraries/Text/TextStylePropTypes.js
@@ -30,14 +30,17 @@ var TextStylePropTypes = Object.assign(Object.create(ViewStylePropTypes), {
     ['normal' /*default*/, 'bold',
      '100', '200', '300', '400', '500', '600', '700', '800', '900']
   ),
- fontVariant: ReactPropTypes.arrayOf(
-   ReactPropTypes.oneOf([
-     'small-caps',
-     'oldstyle-nums',
-     'lining-nums',
-     'tabular-nums',
-     'proportional-nums',
-   ])
+  /**
+   * @platform ios
+   */
+  fontVariant: ReactPropTypes.arrayOf(
+    ReactPropTypes.oneOf([
+      'small-caps',
+      'oldstyle-nums',
+      'lining-nums',
+      'tabular-nums',
+      'proportional-nums',
+    ])
   ),
   textShadowOffset: ReactPropTypes.shape(
     {width: ReactPropTypes.number, height: ReactPropTypes.number}


### PR DESCRIPTION
fontVariant implemented in #9045. Appears to have lost platform annotation. Also fixes indentation.