### PR TITLE
Updated documentation for hairlineWidth

### DIFF
--- a/Libraries/StyleSheet/StyleSheet.js
+++ b/Libraries/StyleSheet/StyleSheet.js
@@ -95,6 +95,8 @@ module.exports = {
    * on the underlying platform. However, you should not rely on it being a
    * constant size, because on different platforms and screen densities its
    * value may be calculated differently.
+   * 
+   * A line with hairline width may not be visible if your simulator is downscaled.
    */
   hairlineWidth,
 


### PR DESCRIPTION
Not seeing a hairline thick line is a common source of confusion with a simple cause. Let's warn about it.