### PR TITLE
[Android] Improve ellipsizeMode prop

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewProps.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewProps.java
@@ -72,7 +72,7 @@ public class ViewProps {
   public static final String LINE_HEIGHT = "lineHeight";
   public static final String NEEDS_OFFSCREEN_ALPHA_COMPOSITING = "needsOffscreenAlphaCompositing";
   public static final String NUMBER_OF_LINES = "numberOfLines";
-  public static final String LINE_BREAK_MODE = "ellipsizeMode";
+  public static final String ELLIPSIZE_MODE = "ellipsizeMode";
   public static final String ON = "on";
   public static final String RESIZE_MODE = "resizeMode";
   public static final String TEXT_ALIGN = "textAlign";

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
@@ -13,12 +13,16 @@ import android.content.Context;
 import android.graphics.drawable.Drawable;
 import android.text.Layout;
 import android.text.Spanned;
+import android.text.TextUtils;
 import android.view.Gravity;
 import android.view.ViewGroup;
 import android.widget.TextView;
 
 import com.facebook.csslayout.FloatUtil;
 import com.facebook.react.uimanager.ReactCompoundView;
+import com.facebook.react.uimanager.ViewDefaults;
+
+import javax.annotation.Nullable;
 
 public class ReactTextView extends TextView implements ReactCompoundView {
 
@@ -31,6 +35,8 @@ public class ReactTextView extends TextView implements ReactCompoundView {
   private boolean mTextIsSelectable;
   private float mLineHeight = Float.NaN;
   private int mTextAlign = Gravity.NO_GRAVITY;
+  private int mNumberOfLines = ViewDefaults.NUMBER_OF_LINES;
+  private TextUtils.TruncateAt mEllipsizeLocation = TextUtils.TruncateAt.END;
 
   public ReactTextView(Context context) {
     super(context);
@@ -212,5 +218,19 @@ public class ReactTextView extends TextView implements ReactCompoundView {
       gravityVertical = mDefaultGravityVertical;
     }
     setGravity((getGravity() & ~Gravity.VERTICAL_GRAVITY_MASK) | gravityVertical);
+  }
+
+  public void setNumberOfLines(int numberOfLines) {
+    mNumberOfLines = numberOfLines == 0 ? ViewDefaults.NUMBER_OF_LINES : numberOfLines;
+    setMaxLines(mNumberOfLines);
+  }
+
+  public void setEllipsizeLocation(TextUtils.TruncateAt ellipsizeLocation) {
+    mEllipsizeLocation = ellipsizeLocation;
+  }
+
+  public void updateView() {
+    @Nullable TextUtils.TruncateAt ellipsizeLocation = mNumberOfLines == ViewDefaults.NUMBER_OF_LINES ? null : mEllipsizeLocation;
+    setEllipsize(ellipsizeLocation);
   }
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextViewManager.java
@@ -33,8 +33,6 @@ import com.facebook.react.common.annotations.VisibleForTesting;
  * whole text subtree.
  */
 public class ReactTextViewManager extends BaseViewManager<ReactTextView, ReactTextShadowNode> {
-  private int mNumberOfLines = ViewDefaults.NUMBER_OF_LINES;
-  private @Nullable TextUtils.TruncateAt mEllipsizeLocation = TextUtils.TruncateAt.END;
 
   @VisibleForTesting
   public static final String REACT_CLASS = "RCTText";
@@ -52,18 +50,17 @@ public class ReactTextViewManager extends BaseViewManager<ReactTextView, ReactTe
   // maxLines can only be set in master view (block), doesn't really make sense to set in a span
   @ReactProp(name = ViewProps.NUMBER_OF_LINES, defaultInt = ViewDefaults.NUMBER_OF_LINES)
   public void setNumberOfLines(ReactTextView view, int numberOfLines) {
-    mNumberOfLines = numberOfLines == 0 ? ViewDefaults.NUMBER_OF_LINES : numberOfLines;
-    view.setMaxLines(mNumberOfLines);
+    view.setNumberOfLines(numberOfLines);
   }
 
   @ReactProp(name = ViewProps.ELLIPSIZE_MODE)
   public void setEllipsizeMode(ReactTextView view, @Nullable String ellipsizeMode) {
     if (ellipsizeMode == null || ellipsizeMode.equals("tail")) {
-      mEllipsizeLocation = TextUtils.TruncateAt.END;
+      view.setEllipsizeLocation(TextUtils.TruncateAt.END);
     } else if (ellipsizeMode.equals("head")) {
-      mEllipsizeLocation = TextUtils.TruncateAt.START;
+      view.setEllipsizeLocation(TextUtils.TruncateAt.START);
     } else if (ellipsizeMode.equals("middle")) {
-      mEllipsizeLocation = TextUtils.TruncateAt.MIDDLE;
+      view.setEllipsizeLocation(TextUtils.TruncateAt.MIDDLE);
     } else {
       throw new JSApplicationIllegalArgumentException("Invalid ellipsizeMode: " + ellipsizeMode);
     }
@@ -111,7 +108,7 @@ public class ReactTextViewManager extends BaseViewManager<ReactTextView, ReactTe
 
   @Override
   protected void onAfterUpdateTransaction(ReactTextView view) {
-    @Nullable TextUtils.TruncateAt ellipsizeLocation = mNumberOfLines == ViewDefaults.NUMBER_OF_LINES ? null : mEllipsizeLocation;
-    view.setEllipsize(ellipsizeLocation);
+    super.onAfterUpdateTransaction(view);
+    view.updateView();
   }
 }


### PR DESCRIPTION
There are a couple of buggy behaviors in the current implementation of the `ellipsizeMode` prop on Android:
  - Setting the `numberOfLines` prop stomps on whatever value you provided for `ellipsizeMode` earlier.
  - The value you've provided for `ellipsizeMode` is used even if you've configured your view to have an unlimited size (i.e. `numberOfLines` is 0 or unspecified).

This change fixes these issues which makes Android's `ellipsizeMode` prop more consistent with iOS's. Additionally, it renames LineBreakMode to EllipsizeMode in a couple of places.

**Test plan (required)**

Verified that the `numberOfLines` and `ellipsizeMode` props work correctly in an Android test app. 

Adam Comella
Microsoft Corp.