### PR TITLE
Incremental: Fix require of performanceNow

### DIFF
--- a/Libraries/Experimental/IncrementalExample.js
+++ b/Libraries/Experimental/IncrementalExample.js
@@ -34,7 +34,7 @@ const IncrementalPresenter = require('IncrementalPresenter');
 const JSEventLoopWatchdog = require('JSEventLoopWatchdog');
 const StaticContainer = require('StaticContainer.react');
 
-const performanceNow = require('performanceNow');
+const performanceNow = require('fbjs/lib/performanceNow');
 
 InteractionManager.setDeadline(1000);
 JSEventLoopWatchdog.install({thresholdMS: 200});

--- a/Libraries/Interaction/JSEventLoopWatchdog.js
+++ b/Libraries/Interaction/JSEventLoopWatchdog.js
@@ -11,7 +11,7 @@
  */
 'use strict';
 
-const performanceNow = require('performanceNow');
+const performanceNow = require('fbjs/lib/performanceNow');
 
 type Handler = {
   onIterate?: () => void,


### PR DESCRIPTION
Due to an earlier commit, we now have to use the full path for requiring `performanceNow`.

**Test plan (required)**

Verified that the IncrementalExample works when adding it to UIExplorer.