### PR TITLE
fix modal covering element inspector

### DIFF
--- a/Libraries/Modal/Modal.js
+++ b/Libraries/Modal/Modal.js
@@ -11,6 +11,7 @@
  */
 'use strict';
 
+const AppContainer = require('AppContainer')
 const I18nManager = require('I18nManager');
 const Platform = require('Platform');
 const PropTypes = require('react/lib/ReactPropTypes');
@@ -146,7 +147,10 @@ class Modal extends React.Component {
         onStartShouldSetResponder={this._shouldSetResponder}
         >
         <View style={[styles.container, containerStyles]}>
-          {this.props.children}
+          {/* rendering childern inside AppContainer, so it does not cover element inspector */}
+          <AppContainer>
+            {this.props.children}
+          </AppContainer>
         </View>
       </RCTModalHostView>
     );

--- a/Libraries/Modal/Modal.js
+++ b/Libraries/Modal/Modal.js
@@ -11,7 +11,7 @@
  */
 'use strict';
 
-const AppContainer = require('AppContainer')
+const AppContainer = require('AppContainer');
 const I18nManager = require('I18nManager');
 const Platform = require('Platform');
 const PropTypes = require('react/lib/ReactPropTypes');


### PR DESCRIPTION
It fixes #8193 . 
## Motivaiton:

The Modal covers the inspector, so the elements inside the modal cannot be inspected. 
In this PR, the `this.props.children` of Modal is render inside a AppContainer with this PR as suggested by @frantic so the modal no longer covers the inspector.
## Test Plan: 

I tested it manually
![screen shot 2016-08-26 at 12 45 00 pm](https://cloud.githubusercontent.com/assets/4772643/17998026/ee2f0624-6b91-11e6-955f-0be0e69b1de8.png)
