### PR TITLE
[packager]Fix _processAssetsRequest when url contains non-latin letter

### DIFF
--- a/packager/react-packager/src/Server/__tests__/Server-test.js
+++ b/packager/react-packager/src/Server/__tests__/Server-test.js
@@ -370,6 +370,18 @@ describe('processRequest', () => {
       expect(AssetServer.prototype.get).toBeCalledWith('imgs/a.png', 'ios');
       expect(res.end).toBeCalledWith(mockData.slice(0, 4));
     });
+
+    it('should serve assets files\'s name contain non-latin letter', () => {
+      const req = {url: '/assets/imgs/%E4%B8%BB%E9%A1%B5/logo.png'};
+      const res = {end: jest.fn()};
+
+      AssetServer.prototype.get.mockImpl(() => Promise.resolve('i am image'));
+
+      server.processRequest(req, res);
+      jest.runAllTimers();
+      expect(AssetServer.prototype.get).toBeCalledWith('imgs/主页/logo.png', undefined);
+      expect(res.end).toBeCalledWith('i am image');
+    });
   });
 
   describe('buildbundle(options)', () => {

--- a/packager/react-packager/src/Server/index.js
+++ b/packager/react-packager/src/Server/index.js
@@ -483,7 +483,7 @@ class Server {
   }
 
   _processAssetsRequest(req, res) {
-    const urlObj = url.parse(req.url, true);
+    const urlObj = url.parse(decodeURI(req.url), true);
     const assetPath = urlObj.pathname.match(/^\/assets\/(.+)$/);
     const assetEvent = Activity.startEvent('Processing asset request', {asset: assetPath[1]});
     this._assetServer.get(assetPath[1], urlObj.query.platform)


### PR DESCRIPTION
When I use local static files as Image resources, it will occur a 404 error if the image file's name contains some non-latin letters.
The reason is that the request's url will be encoded if it contains some non-latin letters.