### PR TITLE
[Android] Fix gradle clean task

### DIFF
--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -202,6 +202,7 @@ task cleanReactNdkLib(type: Exec) {
     commandLine getNdkBuildFullPath(),
             "NDK_APPLICATION_MK=$projectDir/src/main/jni/Application.mk",
             "THIRD_PARTY_NDK_DIR=$buildDir/third-party-ndk",
+            "REACT_COMMON_DIR=$projectDir/../ReactCommon",
             '-C', file('src/main/jni/react/jni').absolutePath,
             'clean'
 }


### PR DESCRIPTION
Running the command `./gradlew clean` resulted in the following error:

```
./node_modules/react-native/ReactAndroid/src/main/jni//xreact/jni/Android.mk:42: *** Android NDK: Aborting.    .  Stop.
Android NDK: ./node_modules/react-native/ReactAndroid/src/main/jni//xreact/jni/Android.mk: Cannot find module with tag 'cxxreact' in import path
Android NDK: Are you sure your NDK_MODULE_PATH variable is properly defined ?
Android NDK: The following directories were searched:
```

The problem was that `REACT_COMMON_DIR` wasn't defined.

**Test plan (required)**

Running `./gradlew clean` now works.

Adam Comella
Microsoft Corp.