### PR TITLE
[Android] Include image dimensions & url in Image's onLoad callback

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/image/ImageLoadEvent.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/image/ImageLoadEvent.java
@@ -36,18 +36,24 @@ public class ImageLoadEvent extends Event<ImageLoadEvent> {
 
   private final int mEventType;
   private final @Nullable String mImageUri;
+  private final int mWidth;
+  private final int mHeight;
 
   public ImageLoadEvent(int viewId, @ImageEventType int eventType) {
-    this(viewId, eventType, null);
+    this(viewId, eventType, null, 0, 0);
   }
 
   public ImageLoadEvent(
     int viewId,
     @ImageEventType int eventType,
-    @Nullable String imageUri) {
+    @Nullable String imageUri,
+    int width,
+    int height) {
     super(viewId);
     mEventType = eventType;
     mImageUri = imageUri;
+    mWidth = width;
+    mHeight = height;
   }
 
   public static String eventNameForType(@ImageEventType int eventType) {
@@ -82,10 +88,20 @@ public class ImageLoadEvent extends Event<ImageLoadEvent> {
   @Override
   public void dispatch(RCTEventEmitter rctEventEmitter) {
     WritableMap eventData = null;
-    if (mImageUri != null) {
+    
+    if (mImageUri != null || mEventType == ON_LOAD) {
       eventData = Arguments.createMap();
-      eventData.putString("uri", mImageUri);
+
+      if (mImageUri != null) {
+        eventData.putString("uri", mImageUri);
+      }
+      
+      if (mEventType == ON_LOAD) {
+        eventData.putDouble("width", mWidth);
+        eventData.putDouble("height", mHeight);
+      }
     }
+    
     rctEventEmitter.receiveEvent(getViewTag(), getEventName(), eventData);
   }
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/image/ImageLoadEvent.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/image/ImageLoadEvent.java
@@ -97,8 +97,10 @@ public class ImageLoadEvent extends Event<ImageLoadEvent> {
       }
       
       if (mEventType == ON_LOAD) {
-        eventData.putDouble("width", mWidth);
-        eventData.putDouble("height", mHeight);
+        WritableMap source = Arguments.createMap();
+        source.putDouble("width", mWidth);
+        source.putDouble("height", mHeight);
+        eventData.putMap("source", source);
       }
     }
     

--- a/ReactAndroid/src/main/java/com/facebook/react/views/image/ImageLoadEvent.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/image/ImageLoadEvent.java
@@ -100,6 +100,9 @@ public class ImageLoadEvent extends Event<ImageLoadEvent> {
         WritableMap source = Arguments.createMap();
         source.putDouble("width", mWidth);
         source.putDouble("height", mHeight);
+        if (mImageUri != null) {
+          source.putString("url", mImageUri);
+        }
         eventData.putMap("source", source);
       }
     }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageView.java
@@ -201,7 +201,9 @@ public class ReactImageView extends GenericDraweeView {
             @Nullable Animatable animatable) {
           if (imageInfo != null) {
             mEventDispatcher.dispatchEvent(
-              new ImageLoadEvent(getId(), ImageLoadEvent.ON_LOAD));
+              new ImageLoadEvent(getId(), ImageLoadEvent.ON_LOAD,
+                null, imageInfo.getWidth(), imageInfo.getHeight())
+            );
             mEventDispatcher.dispatchEvent(
               new ImageLoadEvent(getId(), ImageLoadEvent.ON_LOAD_END));
           }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageView.java
@@ -202,7 +202,7 @@ public class ReactImageView extends GenericDraweeView {
           if (imageInfo != null) {
             mEventDispatcher.dispatchEvent(
               new ImageLoadEvent(getId(), ImageLoadEvent.ON_LOAD,
-                null, imageInfo.getWidth(), imageInfo.getHeight())
+                mImageSource.getSource(), imageInfo.getWidth(), imageInfo.getHeight())
             );
             mEventDispatcher.dispatchEvent(
               new ImageLoadEvent(getId(), ImageLoadEvent.ON_LOAD_END));


### PR DESCRIPTION
This is similar to the iOS feature that was implemented by 84f68c338a09d6d0dc29985874b54e7d23fcc933.

**Test plan (required)**

Verified that the image dimensions are included in the `onLoad` callback in a test app. Also, this change is used in my team's app.

Adam Comella
Microsoft Corp.

