### PR TITLE
Fix memory leak in MessageQueue

### DIFF
--- a/Libraries/Utilities/MessageQueue.js
+++ b/Libraries/Utilities/MessageQueue.js
@@ -31,6 +31,8 @@ const TO_JS = 0;
 
 const TRACE_TAG_REACT_APPS = 1 << 17;
 
+const DEBUG_INFO_LIMIT = 32;
+
 const MethodTypes = keyMirror({
   remote: null,
   remoteAsync: null,
@@ -168,10 +170,11 @@ class MessageQueue {
   __nativeCall(module, method, params, onFail, onSucc) {
     if (onFail || onSucc) {
       if (__DEV__) {
-        // eventually delete old debug info
-        (this._callbackID > (1 << 5)) &&
-          (this._debugInfo[this._callbackID >> 5] = null);
-        this._debugInfo[this._callbackID >> 1] = [module, method];
+        let debugId = this._callbackID >> 1;
+        this._debugInfo[debugId] = [module, method];
+        if (debugId > DEBUG_INFO_LIMIT) {
+          delete this._debugInfo[debugId - DEBUG_INFO_LIMIT];
+        }
       }
       onFail && params.push(this._callbackID);
       this._callbacks[this._callbackID++] = onFail;

--- a/Libraries/Utilities/MessageQueue.js
+++ b/Libraries/Utilities/MessageQueue.js
@@ -170,10 +170,10 @@ class MessageQueue {
   __nativeCall(module, method, params, onFail, onSucc) {
     if (onFail || onSucc) {
       if (__DEV__) {
-        let debugId = this._callbackID >> 1;
-        this._debugInfo[debugId] = [module, method];
-        if (debugId > DEBUG_INFO_LIMIT) {
-          delete this._debugInfo[debugId - DEBUG_INFO_LIMIT];
+        let callId = this._callbackID >> 1;
+        this._debugInfo[callId] = [module, method];
+        if (callId > DEBUG_INFO_LIMIT) {
+          delete this._debugInfo[callId - DEBUG_INFO_LIMIT];
         }
       }
       onFail && params.push(this._callbackID);


### PR DESCRIPTION
The MessageQueue has a _debugInfo object where it stores debug information associated with each callback. The size of this structure is currently unbounded.

It looks like the code attempted to restrict _debugInfo to a fixed number of entries but due to a logic bug, it leaked around 30 entries for every 1 entry it cleaned up.

This change limits the _debugInfo object to around 30 entries.

**Test plan (required)**

This change is currently being used in my team's app.

Adam Comella
Microsoft Corp.