### PR TITLE
Add "npm i --save react" to Android docs

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,7 +1,7 @@
 [ignore]
 
 # We fork some components by platform.
-.*/*.android.js
+.*/*[.]android.js
 
 # Ignore templates with `@flow` in header
 .*/local-cli/generator.*

--- a/React.podspec
+++ b/React.podspec
@@ -4,7 +4,7 @@ package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
 Pod::Spec.new do |s|
   s.name                = "React"
-  s.version             = "0.32.0-rc.0"
+  s.version             = "0.32.0"
   s.summary             = package['description']
   s.description         = <<-DESC
                             React Native apps are built using the React JS

--- a/React.podspec
+++ b/React.podspec
@@ -4,7 +4,7 @@ package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
 Pod::Spec.new do |s|
   s.name                = "React"
-  s.version             = package['version']
+  s.version             = "0.32.0-rc.0"
   s.summary             = package['description']
   s.description         = <<-DESC
                             React Native apps are built using the React JS

--- a/React.podspec
+++ b/React.podspec
@@ -4,7 +4,7 @@ package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
 Pod::Spec.new do |s|
   s.name                = "React"
-  s.version             = "0.32.0"
+  s.version             = "0.32.0-rc.0"
   s.summary             = package['description']
   s.description         = <<-DESC
                             React Native apps are built using the React JS

--- a/ReactAndroid/gradle.properties
+++ b/ReactAndroid/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=1000.0.0-master
+VERSION_NAME=0.32.0-rc.0
 GROUP=com.facebook.react
 
 POM_NAME=ReactNative

--- a/ReactAndroid/gradle.properties
+++ b/ReactAndroid/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=0.32.0
+VERSION_NAME=0.32.0-rc.0
 GROUP=com.facebook.react
 
 POM_NAME=ReactNative

--- a/ReactAndroid/gradle.properties
+++ b/ReactAndroid/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=0.32.0-rc.0
+VERSION_NAME=0.32.0
 GROUP=com.facebook.react
 
 POM_NAME=ReactNative

--- a/ReactAndroid/src/main/jni/xreact/jni/ProxyExecutor.cpp
+++ b/ReactAndroid/src/main/jni/xreact/jni/ProxyExecutor.cpp
@@ -78,7 +78,8 @@ void ProxyExecutor::loadApplicationScript(
   loadApplicationScript(
     m_executor.get(),
     jni::make_jstring(sourceURL).get());
-  executeJSCallWithProxy(m_executor.get(), "flushedQueue", std::vector<folly::dynamic>());
+  // We can get pending calls here to native but the queue will be drained when
+  // we launch the application.
 }
 
 void ProxyExecutor::setJSModulesUnbundle(std::unique_ptr<JSModulesUnbundle>) {

--- a/ReactAndroid/src/main/third-party/java/robolectric3/robolectric/BUCK
+++ b/ReactAndroid/src/main/third-party/java/robolectric3/robolectric/BUCK
@@ -110,8 +110,16 @@ prebuilt_jar(
     visibility = ['//ReactAndroid/...',],
 )
 
-remote_file(
+# This new rule will make the .jar file appear in the "right" location,
+# though that may change in the future
+export_file(
     name = 'robolectric-android-all-binary-jar',
+    src = ':robolectric-android-all-binary-remote-jar',
+    out = 'android-all-4.1.2_r1-robolectric-0.jar', # name defines filename used by robolectric in runtime
+)
+
+remote_file(
+    name = 'robolectric-android-all-binary-remote-jar',
     url = 'mvn:org.robolectric:android-all:jar:4.1.2_r1-robolectric-0',
     sha1 = 'aecc8ce5119a25fcea1cdf8285469c9d1261a352',
 )
@@ -122,8 +130,14 @@ prebuilt_jar(
     visibility = ['//ReactAndroid/...',],
 )
 
-remote_file(
+export_file(
     name = 'json-jar',
+    src = ':json-remote-jar',
+    out = 'json-20080701.jar', # name defines filename used by robolectric in runtime
+)
+
+remote_file(
+    name = 'json-remote-jar',
     url = 'mvn:org.json:json:jar:20080701',
     sha1 = 'd652f102185530c93b66158b1859f35d45687258',
 )
@@ -134,8 +148,14 @@ prebuilt_jar(
     visibility = ['//ReactAndroid/...',],
 )
 
-remote_file(
+export_file(
     name = 'tagsoup-jar',
+    src = ':tagsoup-remote-jar',
+    out = 'tagsoup-1.2.jar', # name defines filename used by robolectric in runtime
+)
+
+remote_file(
+    name = 'tagsoup-remote-jar',
     url = 'mvn:org.ccil.cowan.tagsoup:tagsoup:jar:1.2',
     sha1 = '639fd364750d7363c85797dc944b4a80f78fa684',
 )
@@ -146,8 +166,14 @@ prebuilt_jar(
     visibility = ['//ReactAndroid/...',],
 )
 
-remote_file(
+export_file(
     name = 'robolectric-shadows-binary-jar',
+    src = ':robolectric-shadows-binary-remote-jar',
+    out = 'shadows-core-3.0-16.jar', # name defines filename used by robolectric in runtime
+)
+
+remote_file(
+    name = 'robolectric-shadows-binary-remote-jar',
     url = 'https://repo1.maven.org/maven2/org/robolectric/shadows-core/3.0/shadows-core-3.0-16.jar',
     sha1 = '39d7a856bf91640b1a6d044333336a2b3f3c198f',
 )

--- a/docs/IntegrationWithExistingApps.md
+++ b/docs/IntegrationWithExistingApps.md
@@ -526,7 +526,7 @@ You can examine the code that added the React Native screen on [GitHub](https://
 In your app's root folder, run:
 
     $ npm init
-    $ npm install --save react-native
+    $ npm install --save react react-native
     $ curl -o .flowconfig https://raw.githubusercontent.com/facebook/react-native/master/.flowconfig
 
 This creates a node module for your app and adds the `react-native` npm dependency. Now open the newly created `package.json` file and add this under `scripts`:

--- a/local-cli/android/android.js
+++ b/local-cli/android/android.js
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+'use strict';
+
+var generate = require('../generate/generate');
+var fs = require('fs');
+
+function android(argv, config, args) {
+  return generate([
+    '--platform', 'android',
+    '--project-path', process.cwd(),
+    '--project-name', args.projectName,
+  ], config);
+}
+
+module.exports = {
+  name: 'android',
+  description: 'creates an empty android project',
+  func: android,
+  options: [{
+    command: '--project-name [name]',
+    default: () => JSON.parse(
+      fs.readFileSync('package.json', 'utf8')
+    ).name,
+  }],
+};

--- a/local-cli/commands.js
+++ b/local-cli/commands.js
@@ -31,6 +31,7 @@ export type Command = {
 };
 
 const documentedCommands = [
+  require('./android/android'),
   require('./server/server'),
   require('./runIOS/runIOS'),
   require('./runAndroid/runAndroid'),

--- a/local-cli/rnpm/link/__tests__/android/applyPatch.spec.js
+++ b/local-cli/rnpm/link/__tests__/android/applyPatch.spec.js
@@ -8,7 +8,7 @@ describe('applyParams', () => {
   it('apply params to the string', () => {
     expect(
       applyParams('${foo}', {foo: 'foo'}, 'react-native')
-    ).toEqual('this.getResources().getString(R.strings.reactNative_foo)');
+    ).toEqual('this.getResources().getString(R.string.reactNative_foo)');
   });
 
   it('use null if no params provided', () => {

--- a/local-cli/rnpm/link/__tests__/android/applyPatch.spec.js
+++ b/local-cli/rnpm/link/__tests__/android/applyPatch.spec.js
@@ -1,3 +1,12 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
 'use strict';
 
 jest.autoMockOff();
@@ -8,7 +17,7 @@ describe('applyParams', () => {
   it('apply params to the string', () => {
     expect(
       applyParams('${foo}', {foo: 'foo'}, 'react-native')
-    ).toEqual('this.getResources().getString(R.string.reactNative_foo)');
+    ).toEqual('getResources().getString(R.string.reactNative_foo)');
   });
 
   it('use null if no params provided', () => {

--- a/local-cli/rnpm/link/src/android/patches/applyParams.js
+++ b/local-cli/rnpm/link/src/android/patches/applyParams.js
@@ -7,7 +7,7 @@ module.exports = function applyParams(str, params, prefix) {
       const name = toCamelCase(prefix) + '_' + param;
 
       return params[param]
-        ? `this.getResources().getString(R.strings.${name})`
+        ? `this.getResources().getString(R.string.${name})`
         : null;
     }
   );

--- a/local-cli/rnpm/link/src/android/patches/applyParams.js
+++ b/local-cli/rnpm/link/src/android/patches/applyParams.js
@@ -1,3 +1,12 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
 const toCamelCase = require('lodash').camelCase;
 
 module.exports = function applyParams(str, params, prefix) {
@@ -7,7 +16,7 @@ module.exports = function applyParams(str, params, prefix) {
       const name = toCamelCase(prefix) + '_' + param;
 
       return params[param]
-        ? `this.getResources().getString(R.string.${name})`
+        ? `getResources().getString(R.string.${name})`
         : null;
     }
   );

--- a/package.json
+++ b/package.json
@@ -193,8 +193,7 @@
     "yeoman-generator": "0.21.2",
     "mime-types": "2.1.11",
     "whatwg-fetch": "^1.0.0",
-    "denodeify": "^1.2.1",
-    "react": "~15.3.0"
+    "denodeify": "^1.2.1"
   },
   "devDependencies": {
     "babel-eslint": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "react-native": "local-cli/wrong-react-native.js"
   },
   "peerDependencies": {
-    "react": "~15.3.0-rc.2"
+    "react": "~15.3.0"
   },
   "dependencies": {
     "absolute-path": "^0.0.0",
@@ -207,7 +207,7 @@
     "jest-runtime": "~14.1.0",
     "mock-fs": "^3.11.0",
     "portfinder": "0.4.0",
-    "react": "~15.3.0-rc.2",
+    "react": "~15.3.0",
     "shelljs": "0.6.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -193,7 +193,8 @@
     "yeoman-generator": "0.21.2",
     "mime-types": "2.1.11",
     "whatwg-fetch": "^1.0.0",
-    "denodeify": "^1.2.1"
+    "denodeify": "^1.2.1",
+    "react": "15.3.0"
   },
   "devDependencies": {
     "babel-eslint": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -194,7 +194,7 @@
     "mime-types": "2.1.11",
     "whatwg-fetch": "^1.0.0",
     "denodeify": "^1.2.1",
-    "react": "15.3.0"
+    "react": "~15.3.0"
   },
   "devDependencies": {
     "babel-eslint": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native",
-  "version": "0.32.0-rc.0",
+  "version": "0.32.0",
   "description": "A framework for building native apps using React",
   "license": "BSD-3-Clause",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native",
-  "version": "1000.0.0",
+  "version": "0.32.0-rc.0",
   "description": "A framework for building native apps using React",
   "license": "BSD-3-Clause",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native",
-  "version": "0.32.0",
+  "version": "0.32.0-rc.0",
   "description": "A framework for building native apps using React",
   "license": "BSD-3-Clause",
   "repository": {


### PR DESCRIPTION
This PR changes the docs for Android installation. 

If you're a first time user and follow http://facebook.github.io/react-native/docs/integration-with-existing-apps.html, the react-enabled activity throws a red screen with missing module react. It works when react is also installed apart from react-native. Because `index.android.js` has `import React from 'react';` 