### PR TITLE
Add "npm i --save react" to Android docs

### DIFF
--- a/docs/IntegrationWithExistingApps.md
+++ b/docs/IntegrationWithExistingApps.md
@@ -526,7 +526,7 @@ You can examine the code that added the React Native screen on [GitHub](https://
 In your app's root folder, run:
 
     $ npm init
-    $ npm install --save react-native
+    $ npm install --save react react-native
     $ curl -o .flowconfig https://raw.githubusercontent.com/facebook/react-native/master/.flowconfig
 
 This creates a node module for your app and adds the `react-native` npm dependency. Now open the newly created `package.json` file and add this under `scripts`:


### PR DESCRIPTION
This PR changes the docs for Android installation. 

If you're a first time user and follow http://facebook.github.io/react-native/docs/integration-with-existing-apps.html, the react-enabled activity throws a red error screen with missing react module. `index.android.js` has `import React from 'react';`.