### PR TITLE
Improve loading error handling on Android WebView

### DIFF
--- a/Libraries/Components/WebView/WebView.android.js
+++ b/Libraries/Components/WebView/WebView.android.js
@@ -291,7 +291,7 @@ class WebView extends React.Component {
     var {onError, onLoadEnd} = this.props;
     onError && onError(event);
     onLoadEnd && onLoadEnd(event);
-    console.error('Encountered an error loading page', event.nativeEvent);
+    console.warn('Encountered an error loading page', event.nativeEvent);
 
     this.setState({
       lastErrorEvent: event.nativeEvent,


### PR DESCRIPTION
Loading invalid urls will happen in normal use so this line should be console.warn instead.
Actually ios WebView uses console.warn for this. 
See https://github.com/facebook/react-native/issues/2904.