### PR TITLE
Add support for clamping for NativeAnimated on iOS

### DIFF
--- a/Examples/UIExplorer/js/NativeAnimationsExample.js
+++ b/Examples/UIExplorer/js/NativeAnimationsExample.js
@@ -454,6 +454,40 @@ exports.examples = [
     },
   },
   {
+    title: 'Interpolation with clamping',
+    description: 'description',
+    render: function() {
+      return (
+        <Tester
+          type="spring"
+          config={{
+            speed: 8,
+            bounciness: 12,
+          }}
+        >
+          {anim => (
+            <Animated.View
+              style={[
+                styles.block,
+                {
+                  transform: [
+                    {
+                      translateX: anim.interpolate({
+                        inputRange: [0, 1],
+                        outputRange: [0, 100],
+                        extrapolateLeft: 'clamp',
+                      })
+                    }
+                  ],
+                }
+              ]}
+            />
+          )}
+        </Tester>
+      );
+    },
+  }
+  {
     title: 'Animated value listener',
     render: function() {
       return (

--- a/Examples/UIExplorer/js/NativeAnimationsExample.js
+++ b/Examples/UIExplorer/js/NativeAnimationsExample.js
@@ -320,7 +320,7 @@ exports.examples = [
     },
   },
   {
-    title: 'Scale interpolation',
+    title: 'Scale interpolation with clamping',
     description: 'description',
     render: function() {
       return (
@@ -335,8 +335,9 @@ exports.examples = [
                   transform: [
                     {
                       scale: anim.interpolate({
-                        inputRange: [0, 1],
+                        inputRange: [0, 0.5],
                         outputRange: [1, 1.4],
+                        extrapolateRight: 'clamp',
                       })
                     }
                   ],
@@ -453,40 +454,6 @@ exports.examples = [
       );
     },
   },
-  {
-    title: 'Interpolation with clamping',
-    description: 'description',
-    render: function() {
-      return (
-        <Tester
-          type="spring"
-          config={{
-            speed: 8,
-            bounciness: 12,
-          }}
-        >
-          {anim => (
-            <Animated.View
-              style={[
-                styles.block,
-                {
-                  transform: [
-                    {
-                      translateX: anim.interpolate({
-                        inputRange: [0, 1],
-                        outputRange: [0, 100],
-                        extrapolateLeft: 'clamp',
-                      })
-                    }
-                  ],
-                }
-              ]}
-            />
-          )}
-        </Tester>
-      );
-    },
-  }
   {
     title: 'Animated value listener',
     render: function() {

--- a/Libraries/NativeAnimation/Nodes/RCTAnimationDriverNode.m
+++ b/Libraries/NativeAnimation/Nodes/RCTAnimationDriverNode.m
@@ -118,14 +118,23 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
                                             fromInterval,
                                             toInterval,
                                             fromFrameValue.doubleValue,
-                                            toFrameValue.doubleValue);
+                                            toFrameValue.doubleValue,
+                                            EXTRAPOLATE_TYPE_EXTEND,
+                                            EXTRAPOLATE_TYPE_EXTEND);
 
   [self updateOutputWithFrameOutput:frameOutput];
 }
 
 - (void)updateOutputWithFrameOutput:(CGFloat)frameOutput
 {
-  CGFloat outputValue = RCTInterpolateValue(frameOutput, 0, 1, _fromValue, _toValue);
+  CGFloat outputValue = RCTInterpolateValue(frameOutput,
+                                            0,
+                                            1,
+                                            _fromValue,
+                                            _toValue,
+                                            EXTRAPOLATE_TYPE_EXTEND,
+                                            EXTRAPOLATE_TYPE_EXTEND);
+
   _outputValue = @(outputValue);
   _valueNode.value = outputValue;
   [_valueNode setNeedsUpdate];

--- a/Libraries/NativeAnimation/Nodes/RCTInterpolationAnimatedNode.m
+++ b/Libraries/NativeAnimation/Nodes/RCTInterpolationAnimatedNode.m
@@ -15,6 +15,8 @@
   __weak RCTValueAnimatedNode *_parentNode;
   NSArray<NSNumber *> *_inputRange;
   NSArray<NSNumber *> *_outputRange;
+  BOOL _clampLeft;
+  BOOL _clampRight;
 }
 
 - (instancetype)initWithTag:(NSNumber *)tag
@@ -29,6 +31,17 @@
       }
     }
     _outputRange = [outputRange copy];
+
+    if ([config[@"extrapolate"] isEqualToString:@"clamp"]) {
+      _clampLeft = YES;
+      _clampRight = YES;
+    }
+    if ([config[@"extrapolateLeft"] isEqualToString:@"clamp"]) {
+      _clampLeft = YES;
+    }
+    if ([config[@"extrapolateRight"] isEqualToString:@"clamp"]) {
+      _clampRight = YES;
+    }
   }
   return self;
 }
@@ -70,18 +83,27 @@
     return;
   }
 
-  NSUInteger rangeIndex = [self findIndexOfNearestValue:_parentNode.value
+  CGFloat inputValue = _parentNode.value;
+  if (_clampLeft) {
+    inputValue = MAX(inputValue, _inputRange.firstObject.doubleValue);
+  }
+  if (_clampRight) {
+    inputValue = MIN(inputValue, _inputRange.lastObject.doubleValue);
+  }
+
+  NSUInteger rangeIndex = [self findIndexOfNearestValue:inputValue
                                                 inRange:_inputRange];
   NSNumber *inputMin = _inputRange[rangeIndex];
   NSNumber *inputMax = _inputRange[rangeIndex + 1];
   NSNumber *outputMin = _outputRange[rangeIndex];
   NSNumber *outputMax = _outputRange[rangeIndex + 1];
 
-  CGFloat outputValue = RCTInterpolateValue(_parentNode.value,
+  CGFloat outputValue = RCTInterpolateValue(inputValue,
                                             inputMin.doubleValue,
                                             inputMax.doubleValue,
                                             outputMin.doubleValue,
                                             outputMax.doubleValue);
+
   self.value = outputValue;
 }
 

--- a/Libraries/NativeAnimation/Nodes/RCTInterpolationAnimatedNode.m
+++ b/Libraries/NativeAnimation/Nodes/RCTInterpolationAnimatedNode.m
@@ -15,8 +15,8 @@
   __weak RCTValueAnimatedNode *_parentNode;
   NSArray<NSNumber *> *_inputRange;
   NSArray<NSNumber *> *_outputRange;
-  BOOL _clampLeft;
-  BOOL _clampRight;
+  NSString *_extrapolateLeft;
+  NSString *_extrapolateRight;
 }
 
 - (instancetype)initWithTag:(NSNumber *)tag
@@ -31,17 +31,8 @@
       }
     }
     _outputRange = [outputRange copy];
-
-    if ([config[@"extrapolate"] isEqualToString:@"clamp"]) {
-      _clampLeft = YES;
-      _clampRight = YES;
-    }
-    if ([config[@"extrapolateLeft"] isEqualToString:@"clamp"]) {
-      _clampLeft = YES;
-    }
-    if ([config[@"extrapolateRight"] isEqualToString:@"clamp"]) {
-      _clampRight = YES;
-    }
+    _extrapolateLeft = config[@"extrapolateLeft"];
+    _extrapolateRight = config[@"extrapolateRight"];
   }
   return self;
 }
@@ -84,27 +75,19 @@
   }
 
   CGFloat inputValue = _parentNode.value;
-  if (_clampLeft) {
-    inputValue = MAX(inputValue, _inputRange.firstObject.doubleValue);
-  }
-  if (_clampRight) {
-    inputValue = MIN(inputValue, _inputRange.lastObject.doubleValue);
-  }
-
-  NSUInteger rangeIndex = [self findIndexOfNearestValue:inputValue
-                                                inRange:_inputRange];
+  NSUInteger rangeIndex = [self findIndexOfNearestValue:inputValue inRange:_inputRange];
   NSNumber *inputMin = _inputRange[rangeIndex];
   NSNumber *inputMax = _inputRange[rangeIndex + 1];
   NSNumber *outputMin = _outputRange[rangeIndex];
   NSNumber *outputMax = _outputRange[rangeIndex + 1];
 
-  CGFloat outputValue = RCTInterpolateValue(inputValue,
-                                            inputMin.doubleValue,
-                                            inputMax.doubleValue,
-                                            outputMin.doubleValue,
-                                            outputMax.doubleValue);
-
-  self.value = outputValue;
+  self.value = RCTInterpolateValue(inputValue,
+                                   inputMin.doubleValue,
+                                   inputMax.doubleValue,
+                                   outputMin.doubleValue,
+                                   outputMax.doubleValue,
+                                   _extrapolateLeft,
+                                   _extrapolateRight);
 }
 
 @end

--- a/Libraries/NativeAnimation/RCTAnimationUtils.h
+++ b/Libraries/NativeAnimation/RCTAnimationUtils.h
@@ -12,11 +12,17 @@
 
 #import "RCTDefines.h"
 
+static NSString * const EXTRAPOLATE_TYPE_IDENTITY = @"identity";
+static NSString * const EXTRAPOLATE_TYPE_CLAMP = @"clamp";
+static NSString * const EXTRAPOLATE_TYPE_EXTEND = @"extend";
+
 RCT_EXTERN CGFloat RCTInterpolateValue(CGFloat value,
-                                       CGFloat fromMin,
-                                       CGFloat fromMax,
-                                       CGFloat toMin,
-                                       CGFloat toMax);
+                                       CGFloat inputMin,
+                                       CGFloat inputMax,
+                                       CGFloat outputMin,
+                                       CGFloat outputMax,
+                                       NSString *extrapolateLeft,
+                                       NSString *extrapolateRight);
 
 RCT_EXTERN CGFloat RCTRadiansToDegrees(CGFloat radians);
 RCT_EXTERN CGFloat RCTDegreesToRadians(CGFloat degrees);

--- a/Libraries/NativeAnimation/RCTAnimationUtils.m
+++ b/Libraries/NativeAnimation/RCTAnimationUtils.m
@@ -9,16 +9,44 @@
 
 #import "RCTAnimationUtils.h"
 
+#import "RCTLog.h"
+
 /**
  * Interpolates value by remapping it linearly fromMin->fromMax to toMin->toMax
  */
 CGFloat RCTInterpolateValue(CGFloat value,
-                            CGFloat fromMin,
-                            CGFloat fromMax,
-                            CGFloat toMin,
-                            CGFloat toMax)
+                            CGFloat inputMin,
+                            CGFloat inputMax,
+                            CGFloat outputMin,
+                            CGFloat outputMax,
+                            NSString *extrapolateLeft,
+                            NSString *extrapolateRight)
 {
-  return toMin + (value - fromMin) * (toMax - toMin) / (fromMax - fromMin);
+  if (value < inputMin) {
+    if ([extrapolateLeft isEqualToString:EXTRAPOLATE_TYPE_IDENTITY]) {
+      return value;
+    } else if ([extrapolateLeft isEqualToString:EXTRAPOLATE_TYPE_CLAMP]) {
+      value = inputMin;
+    } else if ([extrapolateLeft isEqualToString:EXTRAPOLATE_TYPE_EXTEND]) {
+      // noop
+    } else {
+      RCTLogError(@"Invalid extrapolation type %@ for left extrapolation", extrapolateLeft);
+    }
+  }
+
+  if (value > inputMax) {
+    if ([extrapolateRight isEqualToString:EXTRAPOLATE_TYPE_IDENTITY]) {
+      return value;
+    } else if ([extrapolateRight isEqualToString:EXTRAPOLATE_TYPE_CLAMP]) {
+      value = inputMax;
+    } else if ([extrapolateRight isEqualToString:EXTRAPOLATE_TYPE_EXTEND]) {
+      // noop
+    } else {
+      RCTLogError(@"Invalid extrapolation type %@ for right extrapolation", extrapolateRight);
+    }
+  }
+
+  return outputMin + (value - inputMin) * (outputMax - outputMin) / (inputMax - inputMin);
 }
 
 CGFloat RCTRadiansToDegrees(CGFloat radians)


### PR DESCRIPTION
This diff adds support for clamping on iOS. It separates out code originally submitted in #9048.

Test plan (required)

Run UIExplorer NativeAnimated examples before and after - compare the results. Pay special attention to the new clamped spring example.