### PR TITLE
[NativeAnimated][iOS] Value offsets

### DIFF
--- a/Libraries/Animated/src/AnimatedImplementation.js
+++ b/Libraries/Animated/src/AnimatedImplementation.js
@@ -726,10 +726,9 @@ class AnimatedValue extends AnimatedWithChildren {
    * things like the start of a pan gesture.
    */
   setOffset(offset: number): void {
+    this._offset = offset;
     if (this.__isNative) {
       NativeAnimatedAPI.setAnimatedNodeOffset(this.__getNativeTag(), offset);
-    } else {
-      this._offset = offset;
     }
   }
 
@@ -738,11 +737,10 @@ class AnimatedValue extends AnimatedWithChildren {
    * The final output of the value is unchanged.
    */
   flattenOffset(): void {
+    this._value += this._offset;
+    this._offset = 0;
     if (this.__isNative) {
       NativeAnimatedAPI.flattenAnimatedNodeOffset(this.__getNativeTag());
-    } else {
-      this._value += this._offset;
-      this._offset = 0;
     }
   }
 

--- a/Libraries/Animated/src/AnimatedImplementation.js
+++ b/Libraries/Animated/src/AnimatedImplementation.js
@@ -726,7 +726,11 @@ class AnimatedValue extends AnimatedWithChildren {
    * things like the start of a pan gesture.
    */
   setOffset(offset: number): void {
-    this._offset = offset;
+    if (this.__isNative) {
+      NativeAnimatedAPI.setAnimatedNodeOffset(this.__getNativeTag(), offset);
+    } else {
+      this._offset = offset;
+    }
   }
 
   /**
@@ -734,8 +738,12 @@ class AnimatedValue extends AnimatedWithChildren {
    * The final output of the value is unchanged.
    */
   flattenOffset(): void {
-    this._value += this._offset;
-    this._offset = 0;
+    if (this.__isNative) {
+      NativeAnimatedAPI.flattenAnimatedNodeOffset(this.__getNativeTag());
+    } else {
+      this._value += this._offset;
+      this._offset = 0;
+    }
   }
 
   /**

--- a/Libraries/Animated/src/NativeAnimatedHelper.js
+++ b/Libraries/Animated/src/NativeAnimatedHelper.js
@@ -65,6 +65,14 @@ const API = {
     assertNativeAnimatedModule();
     NativeAnimatedModule.setAnimatedNodeValue(nodeTag, value);
   },
+  setAnimatedNodeOffset: function(nodeTag: number, offset: number): void {
+    assertNativeAnimatedModule();
+    NativeAnimatedModule.setAnimatedNodeOffset(nodeTag, offset);
+  },
+  flattenAnimatedNodeOffset: function(nodeTag: number): void {
+    assertNativeAnimatedModule();
+    NativeAnimatedModule.flattenAnimatedNodeOffset(nodeTag);
+  },
   connectAnimatedNodeToView: function(nodeTag: number, viewTag: number): void {
     assertNativeAnimatedModule();
     NativeAnimatedModule.connectAnimatedNodeToView(nodeTag, viewTag);

--- a/Libraries/NativeAnimation/Nodes/RCTValueAnimatedNode.h
+++ b/Libraries/NativeAnimation/Nodes/RCTValueAnimatedNode.h
@@ -20,6 +20,9 @@
 
 @interface RCTValueAnimatedNode : RCTAnimatedNode
 
+- (void)setOffset:(CGFloat)offset;
+- (void)flattenOffset;
+
 @property (nonatomic, assign) CGFloat value;
 @property (nonatomic, weak) id<RCTValueAnimatedNodeObserver> valueObserver;
 

--- a/Libraries/NativeAnimation/Nodes/RCTValueAnimatedNode.m
+++ b/Libraries/NativeAnimation/Nodes/RCTValueAnimatedNode.m
@@ -9,7 +9,34 @@
 
 #import "RCTValueAnimatedNode.h"
 
+@interface RCTValueAnimatedNode ()
+
+@property (nonatomic, assign) CGFloat offset;
+
+@end
+
 @implementation RCTValueAnimatedNode
+
+@synthesize value = _value;
+
+- (instancetype)initWithTag:(NSNumber *)tag
+                     config:(NSDictionary<NSString *, id> *)config
+{
+  if (self = [super initWithTag:tag config:config]) {
+    _offset = [self.config[@"offset"] floatValue];
+    _value = [self.config[@"value"] floatValue];
+  }
+  return self;
+}
+
+- (void)flattenOffset {
+  _value += _offset;
+  _offset = 0;
+}
+
+- (CGFloat)value {
+  return _value + _offset;
+}
 
 - (void)setValue:(CGFloat)value
 {

--- a/Libraries/NativeAnimation/Nodes/RCTValueAnimatedNode.m
+++ b/Libraries/NativeAnimation/Nodes/RCTValueAnimatedNode.m
@@ -29,12 +29,14 @@
   return self;
 }
 
-- (void)flattenOffset {
+- (void)flattenOffset
+{
   _value += _offset;
   _offset = 0;
 }
 
-- (CGFloat)value {
+- (CGFloat)value
+{
   return _value + _offset;
 }
 

--- a/Libraries/NativeAnimation/RCTNativeAnimatedModule.m
+++ b/Libraries/NativeAnimation/RCTNativeAnimatedModule.m
@@ -175,6 +175,32 @@ RCT_EXPORT_METHOD(setAnimatedNodeValue:(nonnull NSNumber *)nodeTag
   [valueNode setNeedsUpdate];
 }
 
+RCT_EXPORT_METHOD(setAnimatedNodeOffset:(nonnull NSNumber *)nodeTag
+                  offset:(nonnull NSNumber *)offset)
+{
+  RCTAnimatedNode *node = _animationNodes[nodeTag];
+  if (![node isKindOfClass:[RCTValueAnimatedNode class]]) {
+    RCTLogError(@"Not a value node.");
+    return;
+  }
+
+  RCTValueAnimatedNode *valueNode = (RCTValueAnimatedNode *)node;
+  [valueNode setOffset:offset.floatValue];
+  [_updatedValueNodes addObject:valueNode];
+}
+
+RCT_EXPORT_METHOD(flattenAnimatedNodeOffset:(nonnull NSNumber *)nodeTag)
+{
+  RCTAnimatedNode *node = _animationNodes[nodeTag];
+  if (![node isKindOfClass:[RCTValueAnimatedNode class]]) {
+    RCTLogError(@"Not a value node.");
+    return;
+  }
+
+  RCTValueAnimatedNode *valueNode = (RCTValueAnimatedNode *)node;
+  [valueNode flattenOffset];
+}
+
 RCT_EXPORT_METHOD(connectAnimatedNodeToView:(nonnull NSNumber *)nodeTag
                   viewTag:(nonnull NSNumber *)viewTag)
 {


### PR DESCRIPTION
This diff adds support for value offsets on iOS. It separates out code originally submitted in #9048.

Test plan (required)

Set up an animation with an offset, and `useNativeModule: true`. Compare results with `useNativeModule: false`.