### PR TITLE
Updated integration with existing apps for Android

### DIFF
--- a/docs/IntegrationWithExistingApps.md
+++ b/docs/IntegrationWithExistingApps.md
@@ -643,7 +643,7 @@ public class MyReactActivity extends Activity implements DefaultHardwareBackBtnH
     }
 }
 ```
-If you are using a starter kit for React Native, replace the "HelloWorld" string with the one in your index.android.js file (it’s the first argument to the `AppRegistry.registerComponent()` method).
+> If you are using a starter kit for React Native, replace the "HelloWorld" string with the one in your index.android.js file (it’s the first argument to the `AppRegistry.registerComponent()` method).
 
 If you are using Android Studio, use `Alt + Enter` to add all missing imports in your MyReactActivity class. Be careful to use your package’s `BuildConfig` and not the one from the `...facebook...` package.
 

--- a/docs/IntegrationWithExistingApps.md
+++ b/docs/IntegrationWithExistingApps.md
@@ -605,10 +605,12 @@ This is only really used in dev mode when reloading JavaScript from the developm
 
 ## Add native code
 
-You need to add some native code in order to start the React Native runtime and get it to render something. To do this, we're going to create an `AppCompatActivity` that creates a `ReactRootView`, starts a React application inside it and sets it as the main content view.
+You need to add some native code in order to start the React Native runtime and get it to render something. To do this, we're going to create an `Activity` that creates a `ReactRootView`, starts a React application inside it and sets it as the main content view.
+
+> If you are targetting Android version <5, use the `AppCompatActivity` class from the `com.android.support:appcompat` package instead of `Activity`.
 
 ```java
-public class MyReactActivity extends AppCompatActivity implements DefaultHardwareBackBtnHandler {
+public class MyReactActivity extends Activity implements DefaultHardwareBackBtnHandler {
     private ReactRootView mReactRootView;
     private ReactInstanceManager mReactInstanceManager;
 

--- a/docs/IntegrationWithExistingApps.md
+++ b/docs/IntegrationWithExistingApps.md
@@ -576,9 +576,11 @@ In your app's `build.gradle` file add the React Native dependency:
 ```
 dependencies {
     ...
-    compile "com.facebook.react:react-native:+" // From node_modules. Replace + with actual React Native version.
+    compile "com.facebook.react:react-native:+" // From node_modules.
 }
 ```
+
+> If you want to ensure that you are always using a specific React Native version in your native build, replace `+` with an actual React Native version you've downloaded from `npm`.
 
 In your project's `build.gradle` file add an entry for the local React Native maven directory:
 

--- a/docs/IntegrationWithExistingApps.md
+++ b/docs/IntegrationWithExistingApps.md
@@ -595,7 +595,7 @@ allprojects {
 }
 ```
 
-Make sure that the path is correct! You shouldn’t run into any “Failed to resolve: com.facebook.react:react-native:0.x.x" errors after running Gradle sync in Android Studio.
+> Make sure that the path is correct! You shouldn’t run into any “Failed to resolve: com.facebook.react:react-native:0.x.x" errors after running Gradle sync in Android Studio.
 
 Next, make sure you have the Internet permission in your `AndroidManifest.xml`:
 
@@ -637,7 +637,7 @@ public class MyReactActivity extends AppCompatActivity implements DefaultHardwar
     }
 }
 ```
-If you are using a starter kit for React Native, replace the "HelloWorld" string with the one in your index.android.js file (it’s the first argument to the AppRegistry.registerComponent() method).
+If you are using a starter kit for React Native, replace the "HelloWorld" string with the one in your index.android.js file (it’s the first argument to the `AppRegistry.registerComponent()` method).
 
 If you are using Android Studio, use `Alt + Enter` to add all missing imports in your MyReactActivity class. Be careful to use your package’s `BuildConfig` and not the one from the `...facebook...` package.
 
@@ -723,7 +723,7 @@ To run your app, you need to first start the development server. To do this, sim
 
 Now build and run your Android app as normal (`./gradlew installDebug` from command-line; in Android Studio just create debug build as usual).
 
-*Note: If you are using Android Studio for your builds and not the Gradle Wrapper directly, make sure you install [watchman](https://facebook.github.io/watchman/) before running `npm start`. It will prevent the packager from crashing due to conflicts between Android Studio and the React Native packager.*
+> If you are using Android Studio for your builds and not the Gradle Wrapper directly, make sure you install [watchman](https://facebook.github.io/watchman/) before running `npm start`. It will prevent the packager from crashing due to conflicts between Android Studio and the React Native packager.
 
 Once you reach your React-powered activity inside the app, it should load the JavaScript code from the development server and display:
 
@@ -798,7 +798,7 @@ if (!foundHash) {
 }
 </script>
 
-## Creating production build in Android Studio
+## Creating a release build in Android Studio
 
 You can use Android Studio to create your release builds too! It’s as easy as creating release builds of your previously-existing native Android app. There’s just one additional step, which you’ll have to do before every release build. You need to execute the following to create a React Native bundle, which’ll be included with your native Android app:
 

--- a/docs/IntegrationWithExistingApps.md
+++ b/docs/IntegrationWithExistingApps.md
@@ -609,6 +609,8 @@ You need to add some native code in order to start the React Native runtime and 
 
 > If you are targetting Android version <5, use the `AppCompatActivity` class from the `com.android.support:appcompat` package instead of `Activity`.
 
+> If you find out later that your app crashes due to `Didn't find class "com.facebook.jni.IteratorHelper"` exception, uncomment the `setUseOldBridge` line. [See related issue on GitHub.](https://github.com/facebook/react-native/issues/8701)
+
 ```java
 public class MyReactActivity extends Activity implements DefaultHardwareBackBtnHandler {
     private ReactRootView mReactRootView;


### PR DESCRIPTION
I updated the integration with existing apps guide for Android with more recent info based on my article: https://medium.com/@jankalfus/how-to-integrate-react-native-into-an-existing-android-app-c8b93b881632#.1o1vouxbn

Somebody please check the grammar etc., I'm not a native speaker.

Ping @satya164.