### PR TITLE
[iOS] For file uploads, don't stomp on developer's Content-Type header

### DIFF
--- a/Libraries/Network/RCTNetworking.m
+++ b/Libraries/Network/RCTNetworking.m
@@ -236,9 +236,14 @@ RCT_EXPORT_MODULE()
       return (RCTURLRequestCancellationBlock)nil;
     }
     request.HTTPBody = result[@"body"];
-    NSString *contentType = result[@"contentType"];
-    if (contentType) {
-      [request setValue:contentType forHTTPHeaderField:@"Content-Type"];
+    NSString *dataContentType = result[@"contentType"];
+    NSString *requestContentType = [request valueForHTTPHeaderField:@"Content-Type"];
+    BOOL isMultipart = [dataContentType hasPrefix:@"multipart"];
+    
+    // For multipart requests we need to override caller-specified content type with one
+    // from the data object, because it contains the boundary string
+    if (dataContentType && ([requestContentType length] == 0 || isMultipart)) {
+      [request setValue:dataContentType forHTTPHeaderField:@"Content-Type"];
     }
 
     // Gzip the request body


### PR DESCRIPTION
Currently when doing a file upload, the Content-Type header gets set to whatever MIME type iOS computed for the file. The Content-Type header the developer provided never takes precedence.

For example, when uploading an image, iOS might determine that the MIME type is "image/jpeg" and so this would be the Content-Type of the HTTP request. But the developer might need the Content-Type to be "application/octet-stream". With this change, if the developer provides a Content-Type header, it will not be overriden.

There is only one exception to this rule which is for "multipart" requests. In this case, the developer's Content-Type header is always ignored. This is because the Content-Type header needs to contain the boundary string and that information is not available to the developer in JavaScript.

This change makes iOS's behavior more consistent with Android's.

**Test plan (required)**

In a small test app, verified that the developer's Content-Type header takes precedence when it's provided. Verified that the file's MIME type becomes the Content-Type header when the developer doesn't provide one. Also, this change is currently being used in my team's app.

Adam Comella
Microsoft Corp.