### PR TITLE
Use mergeFast in a hotspot

### DIFF
--- a/Libraries/Text/Text.js
+++ b/Libraries/Text/Text.js
@@ -22,11 +22,12 @@ const Touchable = require('Touchable');
 const createReactNativeComponentClass =
   require('react/lib/createReactNativeComponentClass');
 const merge = require('merge');
+const mergeFast = require('mergeFast');
 
 const stylePropType = StyleSheetPropType(TextStylePropTypes);
 
 const viewConfig = {
-  validAttributes: merge(ReactNativeViewAttributes.UIView, {
+  validAttributes: mergeFast(ReactNativeViewAttributes.UIView, {
     isHighlighted: true,
     numberOfLines: true,
     ellipsizeMode: true,
@@ -189,7 +190,7 @@ const Text = React.createClass({
     };
   },
   getInitialState: function(): Object {
-    return merge(Touchable.Mixin.touchableGetInitialState(), {
+    return mergeFast(Touchable.Mixin.touchableGetInitialState(), {
       isHighlighted: false,
     });
   },
@@ -334,7 +335,7 @@ var RCTVirtualText = RCTText;
 
 if (Platform.OS === 'android') {
   RCTVirtualText = createReactNativeComponentClass({
-    validAttributes: merge(ReactNativeViewAttributes.UIView, {
+    validAttributes: mergeFast(ReactNativeViewAttributes.UIView, {
       isHighlighted: true,
     }),
     uiViewClassName: 'RCTVirtualText',

--- a/Libraries/Utilities/mergeFast.js
+++ b/Libraries/Utilities/mergeFast.js
@@ -11,8 +11,6 @@
  */
 'use strict';
 
-var merge = require('merge');
-
 /**
  * Faster version of `merge` that doesn't check its arguments and
  * also merges prototype inherited properties.
@@ -23,18 +21,14 @@ var merge = require('merge');
  * inherited properties.
  */
 var mergeFast = function(one: Object, two: Object): Object {
-  if (__DEV__) {
-    return merge(one, two);
-  } else {
-    var ret = {};
-    for (var keyOne in one) {
-      ret[keyOne] = one[keyOne];
-    }
-    for (var keyTwo in two) {
-      ret[keyTwo] = two[keyTwo];
-    }
-    return ret;
+  var ret = {};
+  for (var keyOne in one) {
+    ret[keyOne] = one[keyOne];
   }
+  for (var keyTwo in two) {
+    ret[keyTwo] = two[keyTwo];
+  }
+  return ret;
 };
 
 module.exports = mergeFast;

--- a/Libraries/Utilities/mergeFast.js
+++ b/Libraries/Utilities/mergeFast.js
@@ -11,6 +11,8 @@
  */
 'use strict';
 
+var merge = require('merge');
+
 /**
  * Faster version of `merge` that doesn't check its arguments and
  * also merges prototype inherited properties.
@@ -21,14 +23,18 @@
  * inherited properties.
  */
 var mergeFast = function(one: Object, two: Object): Object {
-  var ret = {};
-  for (var keyOne in one) {
-    ret[keyOne] = one[keyOne];
+  if (__DEV__) {
+    return merge(one, two);
+  } else {
+    var ret = {};
+    for (var keyOne in one) {
+      ret[keyOne] = one[keyOne];
+    }
+    for (var keyTwo in two) {
+      ret[keyTwo] = two[keyTwo];
+    }
+    return ret;
   }
-  for (var keyTwo in two) {
-    ret[keyTwo] = two[keyTwo];
-  }
-  return ret;
 };
 
 module.exports = mergeFast;


### PR DESCRIPTION
In profiling our app, we found that the usage
of `merge` in `Text.js` was showing up as a
hotspot. We've replaced this usage of `merge`
with `mergeFast`.

**Test plan (required)**

This change is used in my team's app.

Adam Comella
Microsoft Corp.