### PR TITLE
[Android] Fix race condition in EventDispatcher

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/EventDispatcher.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/EventDispatcher.java
@@ -95,7 +95,7 @@ public class EventDispatcher implements LifecycleEventListener {
 
   private Event[] mEventsToDispatch = new Event[16];
   private int mEventsToDispatchSize = 0;
-  private @Nullable RCTEventEmitter mRCTEventEmitter;
+  private volatile @Nullable RCTEventEmitter mRCTEventEmitter;
   private final ScheduleDispatchFrameCallback mCurrentFrameCallback;
   private short mNextEventTypeId = 0;
   private volatile boolean mHasDispatchScheduled = false;


### PR DESCRIPTION
`mRCTEventEmitter` is used by 2 different threads. It's assigned on the UI thread and it's accessed on the JavaScript thread. Currently, it can be the case that the UI thread assigns `mRCTEventEmitter` and later the JS thread accesses it but still sees null.

This change fixes the issue by marking the `mRCTEventEmitter` variable as `volatile` to ensure that both threads see the same value for `mRCTEventEmitter`.

**Test plan (required)**

This change is currently used in my team's app. We're no longer seeing a crash in `EventDispatcher`.

Adam Comella
Microsoft Corp.