### PR TITLE
Text component: Pass event object to onPress and onLongPress handlers

### DIFF
--- a/Libraries/Text/Text.js
+++ b/Libraries/Text/Text.js
@@ -255,12 +255,12 @@ const Text = React.createClass({
                 });
               };
 
-              this.touchableHandlePress = () => {
-                this.props.onPress && this.props.onPress();
+              this.touchableHandlePress = (e: SyntheticEvent) => {
+                this.props.onPress && this.props.onPress(e);
               };
 
-              this.touchableHandleLongPress = () => {
-                this.props.onLongPress && this.props.onLongPress();
+              this.touchableHandleLongPress = (e: SyntheticEvent) => {
+                this.props.onLongPress && this.props.onLongPress(e);
               };
 
               this.touchableGetPressRectOffset = function(): RectOffset {


### PR DESCRIPTION
This makes the Text component more consistent with the contracts implemented by the Touchable* components.

**Test plan (required)**

Verified the event object gets passed to the `onPress` and `onLongPress` handlers in a test app. Also, this change is being used by my team's app.

Adam Comella
Microsoft Corp.