### PR TITLE
[iOS] Expose overflow prop to layout engine

### DIFF
--- a/React/Base/RCTConvert.h
+++ b/React/Base/RCTConvert.h
@@ -104,8 +104,8 @@ typedef NSArray CGColorArray;
 typedef id NSPropertyList;
 + (NSPropertyList)NSPropertyList:(id)json;
 
-typedef BOOL css_clip_t, css_backface_visibility_t;
-+ (css_clip_t)css_clip_t:(id)json;
+typedef BOOL css_backface_visibility_t;
++ (CSSOverflow)CSSOverflow:(id)json;
 + (css_backface_visibility_t)css_backface_visibility_t:(id)json;
 + (CSSFlexDirection)CSSFlexDirection:(id)json;
 + (CSSJustify)CSSJustify:(id)json;

--- a/React/Base/RCTConvert.m
+++ b/React/Base/RCTConvert.m
@@ -601,10 +601,10 @@ RCT_ENUM_CONVERTER(css_backface_visibility_t, (@{
   @"visible": @YES
 }), YES, boolValue)
 
-RCT_ENUM_CONVERTER(css_clip_t, (@{
-  @"hidden": @YES,
-  @"visible": @NO
-}), NO, boolValue)
+RCT_ENUM_CONVERTER(CSSOverflow, (@{
+  @"hidden": @(CSSOverflowHidden),
+  @"visible": @(CSSOverflowVisible)
+}), CSSOverflowVisible, intValue)
 
 RCT_ENUM_CONVERTER(CSSFlexDirection, (@{
   @"row": @(CSSFlexDirectionRow),

--- a/React/Views/RCTShadowView.h
+++ b/React/Views/RCTShadowView.h
@@ -140,6 +140,11 @@ typedef void (^RCTApplierBlock)(NSDictionary<NSNumber *, UIView *> *viewRegistry
 @property (nonatomic, assign) NSInteger zIndex;
 
 /**
+ * Clipping properties
+ */
+@property (nonatomic, assign) CSSOverflow overflow;
+
+/**
  * Calculate property changes that need to be propagated to the view.
  * The applierBlocks set contains RCTApplierBlock functions that must be applied
  * on the main thread in order to update the view.

--- a/React/Views/RCTShadowView.m
+++ b/React/Views/RCTShadowView.m
@@ -632,6 +632,7 @@ RCT_STYLE_PROPERTY(AlignSelf, alignSelf, AlignSelf, CSSAlign)
 RCT_STYLE_PROPERTY(AlignItems, alignItems, AlignItems, CSSAlign)
 RCT_STYLE_PROPERTY(Position, position, PositionType, CSSPositionType)
 RCT_STYLE_PROPERTY(FlexWrap, flexWrap, FlexWrap, CSSWrapType)
+RCT_STYLE_PROPERTY(Overflow, overflow, Overflow, CSSOverflow)
 
 - (void)setBackgroundColor:(UIColor *)color
 {

--- a/React/Views/RCTViewManager.m
+++ b/React/Views/RCTViewManager.m
@@ -119,7 +119,14 @@ RCT_REMAP_VIEW_PROPERTY(shadowColor, layer.shadowColor, CGColor)
 RCT_REMAP_VIEW_PROPERTY(shadowOffset, layer.shadowOffset, CGSize)
 RCT_REMAP_VIEW_PROPERTY(shadowOpacity, layer.shadowOpacity, float)
 RCT_REMAP_VIEW_PROPERTY(shadowRadius, layer.shadowRadius, CGFloat)
-RCT_REMAP_VIEW_PROPERTY(overflow, clipsToBounds, css_clip_t)
+RCT_CUSTOM_VIEW_PROPERTY(overflow, CSSOverflow, RCTView)
+{
+  if (json) {
+    view.clipsToBounds = [RCTConvert CSSOverflow:json] == CSSOverflowHidden;
+  } else {
+    view.clipsToBounds = defaultView.clipsToBounds;
+  }
+}
 RCT_CUSTOM_VIEW_PROPERTY(shouldRasterizeIOS, BOOL, RCTView)
 {
   view.layer.shouldRasterize = json ? [RCTConvert BOOL:json] : defaultView.layer.shouldRasterize;
@@ -294,6 +301,8 @@ RCT_EXPORT_SHADOW_PROPERTY(justifyContent, CSSJustify)
 RCT_EXPORT_SHADOW_PROPERTY(alignItems, CSSAlign)
 RCT_EXPORT_SHADOW_PROPERTY(alignSelf, CSSAlign)
 RCT_EXPORT_SHADOW_PROPERTY(position, CSSPositionType)
+
+RCT_EXPORT_SHADOW_PROPERTY(overflow, CSSOverflow)
 
 RCT_EXPORT_SHADOW_PROPERTY(onLayout, RCTDirectEventBlock)
 


### PR DESCRIPTION
The overflow prop needs to be set on the shadow view so that it can make its way into the layout engine. In some situations, the value of the overflow prop affects the calculations of the layout engine.

**Test plan (required)**

Verified in a test app that the `overflow` prop makes its way into the layout engine. Also, my team's app is currently using this change.

Adam Comella
Microsoft Corp.