### PR TITLE
Fix webview crash when trying to display local html files

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebViewManager.java
@@ -118,7 +118,8 @@ public class ReactWebViewManager extends SimpleViewManager<WebView> {
 
     @Override
     public boolean shouldOverrideUrlLoading(WebView view, String url) {
-        if (url.startsWith("http://") || url.startsWith("https://")) {
+        if (url.startsWith("http://") || url.startsWith("https://") ||
+            url.startsWith("file://")) {
           return false;
         } else {
           Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));


### PR DESCRIPTION
When using webview on android and trying to link to an html file located on device (using `file://`), the application would crash with an error specifying that nothing handles the fired intent. This is due to [`33a1f28`](https://github.com/facebook/react-native/commit/33a1f28654e24a47d80f6ffc75072d0158085a09) which attempts to intercept all non `http(s)` links.

This is a simple fix so hopefully it can make it into the next stable release.