### PR TITLE
[Blog] Fix broken link in blog page links.

### DIFF
--- a/website/core/BlogSidebar.js
+++ b/website/core/BlogSidebar.js
@@ -21,7 +21,7 @@ var BlogSidebar = React.createClass({
         <div className="nav-docs-section">
           <h3>Recent Posts</h3>
           <ul>
-            {MetadataBlog.files.map(function(post) {
+            {MetadataBlog.files.slice(0,10).map(function(post) {
               return (
                 <li key={post.path}>
                   <a

--- a/website/layout/BlogPageLayout.js
+++ b/website/layout/BlogPageLayout.js
@@ -19,7 +19,7 @@ var Site = require('Site');
 
 var BlogPageLayout = React.createClass({
   getPageURL: function(page) {
-    var url = '/jest/blog/';
+    var url = '/react-native/blog/';
     if (page > 0) {
       url += 'page' + (page + 1) + '/';
     }


### PR DESCRIPTION
This fixes an issue that would have arised once our number of blog posts passed 10, as the prev/next links in the footer were using the wrong path ("jest/", instead of "react-native/").

I also capped the number of recent blog posts to 10 in the sidebar.