### PR TITLE
[docs] Fix code example: NSNumber should be marked `nonnull` for compatibility with Android

### DIFF
--- a/docs/NativeModulesIOS.md
+++ b/docs/NativeModulesIOS.md
@@ -78,7 +78,7 @@ But it also works with any type that is supported by the `RCTConvert` class (see
 In our `CalendarManager` example, we need to pass the event date to the native method. We can't send JavaScript Date objects over the bridge, so we need to convert the date to a string or number. We could write our native function like this:
 
 ```objective-c
-RCT_EXPORT_METHOD(addEvent:(NSString *)name location:(NSString *)location date:(NSNumber *)secondsSinceUnixEpoch)
+RCT_EXPORT_METHOD(addEvent:(NSString *)name location:(NSString *)location date:(nonnull NSNumber *)secondsSinceUnixEpoch)
 {
   NSDate *date = [RCTConvert NSDate:secondsSinceUnixEpoch];
 }


### PR DESCRIPTION
I was following the Native Modules guide for iOS, when I noticed this error in the example code:

> Argument 2 (NSNumber) of CalendarManager.addEvent has unspecified nullability but React requires that all NSNumber arguments are explicitly marked as `nonnull` to ensure compatibility with Android.

Marking the parameter NSNumber type as `nonnull` fixes the error in the example.