### PR TITLE
Set allowsBackgroundLocationUpdates as necessary when using location …

### DIFF
--- a/Libraries/Geolocation/Geolocation.js
+++ b/Libraries/Geolocation/Geolocation.js
@@ -41,7 +41,7 @@ type GeoOptions = {
  *
  * In order to enable geolocation in the background, you need to include the
  * 'NSLocationAlwaysUsageDescription' key in Info.plist and add location as
- * a background mode in the 'Capabilities' tab in XCode.
+ * a background mode in the 'Capabilities' tab in Xcode.
  *
  * ### Android
  * To request access to location, you need to add the following line to your

--- a/Libraries/Geolocation/Geolocation.js
+++ b/Libraries/Geolocation/Geolocation.js
@@ -38,7 +38,7 @@ type GeoOptions = {
  * You need to include the `NSLocationWhenInUseUsageDescription` key
  * in Info.plist to enable geolocation when using the app. Geolocation is
  * enabled by default when you create a project with `react-native init`.
- * 
+ *
  * In order to enable geolocation in the background, you need to include the
  * 'NSLocationAlwaysUsageDescription' key in Info.plist and add location as
  * a background mode in the 'Capabilities' tab in XCode.

--- a/Libraries/Geolocation/Geolocation.js
+++ b/Libraries/Geolocation/Geolocation.js
@@ -36,8 +36,12 @@ type GeoOptions = {
  *
  * ### iOS
  * You need to include the `NSLocationWhenInUseUsageDescription` key
- * in Info.plist to enable geolocation. Geolocation is enabled by default
- * when you create a project with `react-native init`.
+ * in Info.plist to enable geolocation when using the app. Geolocation is
+ * enabled by default when you create a project with `react-native init`.
+ * 
+ * In order to enable geolocation in the background, you need to include the
+ * 'NSLocationAlwaysUsageDescription' key in Info.plist and add location as
+ * a background mode in the 'Capabilities' tab in XCode.
  *
  * ### Android
  * To request access to location, you need to add the following line to your

--- a/Libraries/Geolocation/RCTLocationObserver.m
+++ b/Libraries/Geolocation/RCTLocationObserver.m
@@ -144,6 +144,14 @@ RCT_EXPORT_MODULE()
   if ([[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSLocationAlwaysUsageDescription"] &&
     [_locationManager respondsToSelector:@selector(requestAlwaysAuthorization)]) {
     [_locationManager requestAlwaysAuthorization];
+
+    // On iOS 9+ we also need to enable background updates
+    NSArray* backgroundModes  = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"UIBackgroundModes"];
+    if(backgroundModes && [backgroundModes containsObject:@"location"]) {
+      if([_locationManager respondsToSelector:@selector(setAllowsBackgroundLocationUpdates:)]) {
+        [_locationManager setAllowsBackgroundLocationUpdates:YES];
+      }
+    }
   } else if ([[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSLocationWhenInUseUsageDescription"] &&
     [_locationManager respondsToSelector:@selector(requestWhenInUseAuthorization)]) {
     [_locationManager requestWhenInUseAuthorization];


### PR DESCRIPTION
Set the flag 'allowsBackgroundLocationUpdates' to YES if the location background mode is enabled and the 'Always Allow Location' key is set in the App Plist.

**motivation**

We found that on iOS 9.x, the allowsBackgroundLocationUpdates flag must be set on location manager in order to receive updates when the app is in the background (seems to affect actual device only).

**Test plan (required)**
Example app using the forked branch [here](https://github.com/briancalvium/react-native-geolocation-pr-example). Run this example through XCode on a device with 9.x, observe that location update logs continue to appear when the app is in the background. Switch to react native 0.32.0, observe that location update logs stop once the app is in the background.
