### PR TITLE
fix NativeAnimated event listener bug

### DIFF
--- a/Libraries/Animated/src/AnimatedImplementation.js
+++ b/Libraries/Animated/src/AnimatedImplementation.js
@@ -788,6 +788,7 @@ class AnimatedValue extends AnimatedWithChildren {
     }
 
     this.__nativeAnimatedValueListener.remove();
+    this.__nativeAnimatedValueListener = null;
     NativeAnimatedAPI.stopListeningToAnimatedNodeValue(this.__getNativeTag());
   }
 


### PR DESCRIPTION
This bugfix cleans up reference to value listener upon unsubscribing to native events ultimately preventing RCTEventEmitter from throwing a [listener count error](https://github.com/facebook/react-native/blob/v0.33.0-rc.0/React/Modules/RCTEventEmitter.m#L90):

`Attempted to remove more RCTNativeAnimatedModule listeners than added`

/cc @janicduplessis @sahrens 

🍺 