### PR TITLE
Updated yeoman from 0.21.2 to 0.24.1

### DIFF
--- a/local-cli/__tests__/generators-test.js
+++ b/local-cli/__tests__/generators-test.js
@@ -26,8 +26,8 @@ xdescribe('React Yeoman Generators', function() {
       //         rc/index.js
       var log = console.log;
       console.log = function() {};
-      assert = require('yeoman-generator').assert;
-      var helpers = require('yeoman-generator').test;
+      assert = require('yeoman-assert');
+      var helpers = require('yeoman-test');
       console.log = log;
 
       var generated = false;
@@ -102,8 +102,8 @@ xdescribe('React Yeoman Generators', function() {
       //         rc/index.js
       var log = console.log;
       console.log = function() {};
-      assert = require('yeoman-generator').assert;
-      var helpers = require('yeoman-generator').test;
+      assert = require('yeoman-assert');
+      var helpers = require('yeoman-test');
       console.log = log;
 
       var generated = false;
@@ -185,8 +185,8 @@ xdescribe('React Yeoman Generators', function() {
       //         rc/index.js
       var log = console.log;
       console.log = function() {};
-      assert = require('yeoman-generator').assert;
-      var helpers = require('yeoman-generator').test;
+      assert = require('yeoman-assert');
+      var helpers = require('yeoman-test');
       console.log = log;
 
       var generated = false;

--- a/local-cli/generator-android/index.js
+++ b/local-cli/generator-android/index.js
@@ -20,9 +20,12 @@ function validatePackageName(name) {
   return true;
 }
 
-module.exports = yeoman.generators.NamedBase.extend({
-  constructor: function() {
-    yeoman.generators.NamedBase.apply(this, arguments);
+module.exports = yeoman.Base.extend({
+  constructor: function(args, options) {
+    yeoman.Base.apply(this, arguments);
+
+    this.name = args[0];
+    this.options = options;
 
     this.option('package', {
       desc: 'Package name for the application (com.example.app)',

--- a/local-cli/generator-ios/index.js
+++ b/local-cli/generator-ios/index.js
@@ -12,7 +12,13 @@ var chalk = require('chalk');
 var path = require('path');
 var yeoman = require('yeoman-generator');
 
-module.exports = yeoman.generators.NamedBase.extend({
+module.exports = yeoman.Base.extend({
+  constructor: function(args) {
+    yeoman.Base.apply(this, arguments);
+
+    this.name = args[0];
+  },
+
   writing: function() {
     var templateVars = {name: this.name};
     // SomeApp/ios/SomeApp

--- a/local-cli/generator/index.js
+++ b/local-cli/generator/index.js
@@ -12,9 +12,9 @@ var path = require('path');
 var yeoman = require('yeoman-generator');
 var utils = require('../generator-utils');
 
-module.exports = yeoman.generators.NamedBase.extend({
+module.exports = yeoman.Base.extend({
   constructor: function() {
-    yeoman.generators.NamedBase.apply(this, arguments);
+    yeoman.Base.apply(this, arguments);
 
     this.option('skip-ios', {
       desc: 'Skip generating iOS files',

--- a/package.json
+++ b/package.json
@@ -199,7 +199,7 @@
     "xmldoc": "^0.4.0",
     "yargs": "^3.24.0",
     "yeoman-environment": "1.5.3",
-    "yeoman-generator": "0.21.2"
+    "yeoman-generator": "0.24.1"
   },
   "devDependencies": {
     "babel-eslint": "^6.0.0",
@@ -214,6 +214,9 @@
     "mock-fs": "^3.11.0",
     "portfinder": "0.4.0",
     "react": "15.3.1-rc.2",
-    "shelljs": "0.6.0"
+    "shelljs": "0.6.0",
+    "sinon": "^1.17.5",
+    "yeoman-assert": "^2.2.1",
+    "yeoman-test": "^1.4.0"
   }
 }


### PR DESCRIPTION
Hi there,

First of all thanks for open sourcing react native, it really has become a passion of mine.
I saw #9728 earlier today decided to update the yeoman dependency. They split the test and assertion package from the main one, so that means we don't get a deprecation warning anymore, and we have a slightly smaller package size. This is what I did in detail:

- Moved from deprecated `NamedBase` to `Base`
- Moved imports as test and assert are now in separated packages
- Added sinon for tests to pass

With the last one, I was unsure why it passed before, sinon was required but not in the `package.json`. This is why I added it; the tests passed then.

Hope this PR works for you. If you encounter any problems with it, please don't hesitate to tell me,I will fix them as fast as I can.

Have a nice day!