### PR TITLE
Delete Codementor

### DIFF
--- a/website/src/react-native/showcase.js
+++ b/website/src/react-native/showcase.js
@@ -157,12 +157,6 @@ var featured = [
     infoTitle: 'The award winning Fantasy Football league manager.',
   },
   {
-    name: 'Codementor - Live 1:1 Expert Developer Help',
-    icon: 'http://a1.mzstatic.com/us/r30/Purple3/v4/db/cf/35/dbcf3523-bac7-0f54-c6a8-a80bf4f43c38/icon175x175.jpeg',
-    infoLink: 'https://techcrunch.com/2015/08/26/codementor-live-classes/',
-    infoTitle: 'Codementor, a Learning Platform for Developers',
-  },
-  {
     name: 'Coiney窓口',
     icon: 'http://a4.mzstatic.com/us/r30/Purple69/v4/c9/bc/3a/c9bc3a29-9c11-868f-b960-ca46d5fcd509/icon175x175.jpeg',
     linkAppStore: 'https://itunes.apple.com/jp/app/coiney-chuang-kou/id1069271336?mt=8',


### PR DESCRIPTION
There's no codementor app, neither Android nor iOS, so I believe it should not exist in the showcase. Furthermore, the article linked doesn't even mention react native. Not sure how this got added, but I think it should be removed as it undermines the credibility of the showcase page by being there.