### PR TITLE
ViewPagerAndroid: FIX folly::toJson: JSON object value was a NaN or INF

### DIFF
--- a/Libraries/Components/ViewPager/ViewPagerAndroid.android.js
+++ b/Libraries/Components/ViewPager/ViewPagerAndroid.android.js
@@ -141,7 +141,7 @@ class ViewPagerAndroid extends React.Component {
   };
 
   componentDidMount() {
-    if (this.props.initialPage) {
+    if (this.props.initialPage != null) {
       this.setPageWithoutAnimation(this.props.initialPage);
     }
   }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/viewpager/PageScrollEvent.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/viewpager/PageScrollEvent.java
@@ -34,7 +34,10 @@ import com.facebook.react.uimanager.events.RCTEventEmitter;
   protected PageScrollEvent(int viewTag, int position, float offset) {
     super(viewTag);
     mPosition = position;
-    mOffset = offset;
+
+    // folly::toJson default options don't support serialize NaN or Infinite value
+    mOffset = (Float.isInfinite(offset) || Float.isNaN(offset))
+      ? 0.0f : offset;
   }
 
   @Override


### PR DESCRIPTION
Explain the **motivation** for making this change. What existing problem does the pull request solve?

Under certain scenario, `PageScrollEvent.offset` was initialized to `NaN`, which cause `folly::toJson` failed, and FIX #9750 

<https://github.com/android/platform_frameworks_base/blob/e71ecb2c4df15f727f51a0e1b65459f071853e35/core/java/com/android/internal/widget/ViewPager.java#L1689>

![image](https://cloud.githubusercontent.com/assets/104052/18266416/2a01f882-744d-11e6-86c4-3a2de3a1ca25.png)

**Test plan (required)**

<http://stackoverflow.com/questions/39327429/reactnative-viewpagerandroid-rcteventemitter>