### PR TITLE
FIX: Call all android back key handlers before invoking default

### DIFF
--- a/Libraries/Utilities/BackAndroid.android.js
+++ b/Libraries/Utilities/BackAndroid.android.js
@@ -41,6 +41,8 @@ RCTDeviceEventEmitter.addListener(DEVICE_BACK_EVENT, function() {
 /**
  * Detect hardware back button presses, and programmatically invoke the default back button
  * functionality to exit the app if there are no listeners or if none of the listeners return true.
+ * The event subscriptions are called in reverse order (i.e. last registered subscription first),
+ * and if one subscription returns true then subscriptions registered earlier will not be called.
  *
  * Example:
  *

--- a/Libraries/Utilities/BackAndroid.android.js
+++ b/Libraries/Utilities/BackAndroid.android.js
@@ -29,7 +29,6 @@ RCTDeviceEventEmitter.addListener(DEVICE_BACK_EVENT, function() {
   for (var i = 0; i < subscriptions.length; ++i) {
     if (subscriptions[i]()) {
       invokeDefault = false;
-      break;
     }
   }
 

--- a/Libraries/Utilities/BackAndroid.android.js
+++ b/Libraries/Utilities/BackAndroid.android.js
@@ -29,6 +29,7 @@ RCTDeviceEventEmitter.addListener(DEVICE_BACK_EVENT, function() {
   for (var i = 0; i < subscriptions.length; ++i) {
     if (subscriptions[i]()) {
       invokeDefault = false;
+      break;
     }
   }
 


### PR DESCRIPTION
Fixes issue #9736
