### PR TITLE
remove the unnecessary 'var' in `runVerbose`

### DIFF
--- a/react-native-cli/index.js
+++ b/react-native-cli/index.js
@@ -224,7 +224,7 @@ function run(root, projectName, rnPackage) {
 
     checkNodeVersion();
 
-    var cli = require(CLI_MODULE_PATH());
+    cli = require(CLI_MODULE_PATH());
     cli.init(root, projectName);
   });
 }


### PR DESCRIPTION
[react-native-cli] Remove the unnecessary 'var' in `runVerbose`, keep pace with `run`.