### PR TITLE
[WebSockets] Remove guard that we used in iOS 7 to avoid a JS crash

### DIFF
--- a/Libraries/WebSocket/WebSocket.js
+++ b/Libraries/WebSocket/WebSocket.js
@@ -118,18 +118,15 @@ class WebSocket extends EventTarget(...WEBSOCKET_EVENTS) {
       return;
     }
 
-    // Maintain iOS 7 compatibility which doesn't have JS typed arrays.
-    if (typeof ArrayBuffer !== 'undefined' &&
-        typeof Uint8Array !== 'undefined') {
-      if (ArrayBuffer.isView(data)) {
-        // $FlowFixMe: no way to assert that 'data' is indeed an ArrayBufferView now
-        data = data.buffer;
-      }
-      if (data instanceof ArrayBuffer) {
-        data = base64.fromByteArray(new Uint8Array(data));
-        RCTWebSocketModule.sendBinary(data, this._socketId);
-        return;
-      }
+
+    if (ArrayBuffer.isView(data)) {
+      // $FlowFixMe: no way to assert that 'data' is indeed an ArrayBufferView now
+      data = data.buffer;
+    }
+    if (data instanceof ArrayBuffer) {
+      data = base64.fromByteArray(new Uint8Array(data));
+      RCTWebSocketModule.sendBinary(data, this._socketId);
+      return;
     }
 
     throw new Error('Unsupported data type');


### PR DESCRIPTION
JSC on iOS 8 and above includes TypedArrays so there's no need for the guard statement anymore since React Native officially does not support iOS 7 moving forward.