### PR TITLE
[React] Change React version to 15.3.1 (no more RC)

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "react-native": "local-cli/wrong-react-native.js"
   },
   "peerDependencies": {
-    "react": "15.3.1-rc.2"
+    "react": "~15.3.1"
   },
   "dependencies": {
     "absolute-path": "^0.0.0",
@@ -213,7 +213,7 @@
     "jest-runtime": "15.1.0",
     "mock-fs": "^3.11.0",
     "portfinder": "0.4.0",
-    "react": "15.3.1-rc.2",
+    "react": "~15.3.1",
     "shelljs": "0.6.0"
   }
 }


### PR DESCRIPTION
React 15.3.1 has been published; stop using the RC.