### PR TITLE
[CLI] Support node_modules/react-native as a symlink

### DIFF
--- a/local-cli/server/server.js
+++ b/local-cli/server/server.js
@@ -13,7 +13,11 @@ const formatBanner = require('./formatBanner');
 const path = require('path');
 const runServer = require('./runServer');
 const findSymlinksPaths = require('./findSymlinksPaths');
-const NODE_MODULES = path.resolve(__dirname, '..', '..', '..');
+
+const NODE_MODULES =
+  /node_modules/.test(__dirname) ?
+    path.resolve(__dirname, '..', '..', '..') :
+    path.resolve('node_modules');
 
 /**
  * Starts the React Native Packager Server.

--- a/react-native-cli/index.js
+++ b/react-native-cli/index.js
@@ -42,6 +42,7 @@ var spawn = require('child_process').spawn;
 var chalk = require('chalk');
 var prompt = require('prompt');
 var semver = require('semver');
+var resolveSymlink = require('./resolveSymlink');
 /**
  * Used arguments:
  *   -v --version - to print current version of react-native-cli and react-native dependency
@@ -56,22 +57,16 @@ var semver = require('semver');
  */
 var argv = require('minimist')(process.argv.slice(2));
 
+var REACT_NATIVE_DIR = resolveSymlink(
+  path.resolve('node_modules', 'react-native')
+);
+
 var CLI_MODULE_PATH = function() {
-  return path.resolve(
-    process.cwd(),
-    'node_modules',
-    'react-native',
-    'cli.js'
-  );
+  return path.join(REACT_NATIVE_DIR, 'cli.js');
 };
 
 var REACT_NATIVE_PACKAGE_JSON_PATH = function() {
-  return path.resolve(
-    process.cwd(),
-    'node_modules',
-    'react-native',
-    'package.json'
-  );
+  return path.join(REACT_NATIVE_DIR, 'package.json');
 };
 
 checkForVersionArgument();

--- a/react-native-cli/resolveSymlink.js
+++ b/react-native-cli/resolveSymlink.js
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+'use strict';
+
+var path = require('path');
+var fs = require('fs');
+
+module.exports = function resolveSymlink(symlink) {
+  var visited = [];
+
+  var linkedPath = symlink;
+  while (fs.existsSync(linkedPath) && fs.lstatSync(linkedPath).isSymbolicLink()) {
+    var index = visited.indexOf(linkedPath);
+    if (index !== -1) {
+      throw Error(
+        'Infinite symlink recursion detected:\n  ' +
+          visited.slice(index).join('\n  ')
+      );
+    }
+
+    visited.push(linkedPath);
+    linkedPath = path.resolve(
+      path.dirname(linkedPath),
+      fs.readlinkSync(linkedPath)
+    );
+  }
+
+  return linkedPath;
+};


### PR DESCRIPTION
If `react-native` is not installed in `node_modules`,
the wrong directory is crawled when searching for symlinks.

For example, my React project has a symlink in its `node_modules`
pointing to my fork of `react-native`.

**Note:** Before starting the packager, switch to the root directory of your React project.
Otherwise it will still search the wrong directory.
