### PR TITLE
[local-cli] Support symlinks-to-symlinks

### DIFF
--- a/local-cli/server/server.js
+++ b/local-cli/server/server.js
@@ -19,9 +19,9 @@ const NODE_MODULES = path.resolve(__dirname, '..', '..', '..');
  * Starts the React Native Packager Server.
  */
 function server(argv, config, args) {
-  args.projectRoots = args.projectRoots.concat(
-    args.root,
-    findSymlinksPaths(NODE_MODULES, args.projectRoots)
+  const roots = args.projectRoots.concat(args.root);
+  args.projectRoots = roots.concat(
+    findSymlinksPaths(NODE_MODULES, roots)
   );
 
   console.log(formatBanner(


### PR DESCRIPTION
In response to [this comment](https://github.com/facebook/react-native/pull/9009#issuecomment-245322397).

I could be wrong here, but I think Watchman can't handle symlinks, so we need to make sure symlinks-to-symlinks are handled up front.