### PR TITLE
Export Geolocation API

### DIFF
--- a/Libraries/react-native/react-native.js
+++ b/Libraries/react-native/react-native.js
@@ -87,6 +87,7 @@ const ReactNative = {
   get DatePickerAndroid() { return require('DatePickerAndroid'); },
   get Dimensions() { return require('Dimensions'); },
   get Easing() { return require('Easing'); },
+  get Geolocation() { return require('Geolocation'); },
   get I18nManager() { return require('I18nManager'); },
   get ImagePickerIOS() { return require('ImagePickerIOS'); },
   get IntentAndroid() { return require('IntentAndroid'); },


### PR DESCRIPTION
Currently the `Geolocation` API is only exposed via the `navigator.geolocation` global - browser style. It'd be less surprising to also be able to `import { Geolocation } from 'react-native'` in the same way as we can with other documented APIs. This PR adds it to the `react-native` module's exports.