### PR TITLE
Allow rn-cli.config.js to specify the default transformer, again

### DIFF
--- a/local-cli/bundle/buildBundle.js
+++ b/local-cli/bundle/buildBundle.js
@@ -40,13 +40,18 @@ function buildBundle(args, config, output = outputBundle, packagerInstance) {
   if (!packagerInstance) {
     let assetExts = (config.getAssetExts && config.getAssetExts()) || [];
 
+    const transformModulePath =
+      args.transformer ? path.resolve(args.transformer) :
+      typeof config.getTransformModulePath === 'function' ? config.getTransformModulePath() :
+      undefined;
+
     const options = {
       projectRoots: config.getProjectRoots(),
       assetExts: defaultAssetExts.concat(assetExts),
       assetRoots: config.getAssetRoots(),
       blacklistRE: config.getBlacklistRE(args.platform),
       getTransformOptionsModulePath: config.getTransformOptionsModulePath,
-      transformModulePath: args.transformer,
+      transformModulePath: transformModulePath,
       extraNodeModules: config.extraNodeModules,
       nonPersistent: true,
       resetCache: args.resetCache,

--- a/local-cli/bundle/bundleCommandLineArgs.js
+++ b/local-cli/bundle/bundleCommandLineArgs.js
@@ -18,8 +18,7 @@ module.exports = [
     default: 'ios',
   }, {
     command: '--transformer [string]',
-    description: 'Specify a custom transformer to be used (absolute path)',
-    default: require.resolve('../../packager/transformer'),
+    description: 'Specify a custom transformer to be used',
   }, {
     command: '--dev [boolean]',
     description: 'If false, warnings are disabled and the bundle is minified',

--- a/local-cli/dependencies/dependencies.js
+++ b/local-cli/dependencies/dependencies.js
@@ -89,7 +89,6 @@ module.exports = {
       description: 'The platform extension used for selecting modules',
     }, {
       command: '--transformer [path]',
-      default: null,
       description: 'Specify a custom transformer to be used'
     }, {
       command: '--verbose',

--- a/local-cli/server/server.js
+++ b/local-cli/server/server.js
@@ -109,8 +109,7 @@ module.exports = {
     description: 'Disable file watcher'
   }, {
     command: '--transformer [string]',
-    default: require.resolve('../../packager/transformer'),
-    description: 'Specify a custom transformer to be used (absolute path)'
+    description: 'Specify a custom transformer to be used'
   }, {
     command: '--reset-cache, --resetCache',
     description: 'Removes cached files',


### PR DESCRIPTION
Restores feature introduced in #7961 after it's been paved partially by #7899

**Test Plan:** ran example in https://github.com/philikon/ReactNativify against a React Native with and without this patch