### PR TITLE
Docs - explain how to access the geolocation API

### DIFF
--- a/Libraries/Geolocation/Geolocation.js
+++ b/Libraries/Geolocation/Geolocation.js
@@ -33,8 +33,8 @@ type GeoOptions = {
 /**
  * The Geolocation API follows the web spec:
  * https://developer.mozilla.org/en-US/docs/Web/API/Geolocation
- * 
- * As a browser polyfill, this API is available through the `navigator.geolocation` 
+ *
+ * As a browser polyfill, this API is available through the `navigator.geolocation`
  * global - you do not need to `import` it.
  *
  * ### iOS

--- a/Libraries/Geolocation/Geolocation.js
+++ b/Libraries/Geolocation/Geolocation.js
@@ -33,6 +33,9 @@ type GeoOptions = {
 /**
  * The Geolocation API follows the web spec:
  * https://developer.mozilla.org/en-US/docs/Web/API/Geolocation
+ * 
+ * As a browser polyfill, this API is available through the `navigator.geolocation` 
+ * global - you do not need to `import` it.
  *
  * ### iOS
  * You need to include the `NSLocationWhenInUseUsageDescription` key


### PR DESCRIPTION
Explain that, unlike other APIs, geolocation follows the browser spec and is exposed through `navigator.geolocation` rather than as an `react-native` export.

This can be inferred from the example code but isn't otherwise stated in the docs. See also https://github.com/facebook/react-native/pull/9793