### PR TITLE
[AssetServer] Remove 'new' keyword before Promise.race()

### DIFF
--- a/packager/react-packager/src/AssetServer/index.js
+++ b/packager/react-packager/src/AssetServer/index.js
@@ -21,7 +21,7 @@ const createTimeoutPromise = (timeout) => new Promise((resolve, reject) => {
 });
 function timeoutableDenodeify(fsFunc, timeout) {
   return function raceWrapper(...args) {
-    return new Promise.race([
+    return Promise.race([
       createTimeoutPromise(timeout),
       Promise.denodeify(fsFunc).apply(this, args)
     ]);


### PR DESCRIPTION
I'm not sure if this was actually breaking anything, but I don't think `new` before `Promise.race()` is conventional.