### PR TITLE
packager: dedupe symlinks if they point to already covered paths

### DIFF
--- a/local-cli/server/findSymlinksPaths.js
+++ b/local-cli/server/findSymlinksPaths.js
@@ -1,12 +1,25 @@
 const path = require('path');
 const fs = require('fs');
 
-module.exports = function findSymlinksPaths(lookupFolder) {
+function isSubPathOfPath(parentPath, subPath) {
+  return !path.relative(parentPath, subPath).startsWith('..' + path.sep);
+}
+
+function isSubPathOfPaths(parentPaths, subPath) {
+  return parentPaths.some(parentPath => isSubPathOfPath(parentPath, subPath));
+}
+
+/**
+ * Find and resolve symlinks in `lookupFolder`, filtering out any
+ * paths that are subpaths of `existingSearchPaths`.
+ */
+module.exports = function findSymlinksPaths(lookupFolder, existingSearchPaths) {
   const timeStart = Date.now();
   const folders = fs.readdirSync(lookupFolder);
   const resolvedSymlinks = folders.map(folder => path.resolve(lookupFolder, folder))
     .filter(folderPath => fs.lstatSync(folderPath).isSymbolicLink())
-    .map(symlink => path.resolve(process.cwd(), fs.readlinkSync(symlink)));
+    .map(symlink => path.resolve(process.cwd(), fs.readlinkSync(symlink)))
+    .filter(symlinkPath => !isSubPathOfPaths(existingSearchPaths, symlinkPath));
   const timeEnd = Date.now();
 
   console.log(`Scanning ${folders.length} folders for symlinks in ${lookupFolder} (${timeEnd - timeStart}ms)`);

--- a/local-cli/server/server.js
+++ b/local-cli/server/server.js
@@ -21,7 +21,7 @@ const NODE_MODULES = path.resolve(__dirname, '..', '..', '..');
 function server(argv, config, args) {
   args.projectRoots = args.projectRoots.concat(
     args.root,
-    findSymlinksPaths(NODE_MODULES)
+    findSymlinksPaths(NODE_MODULES, args.projectRoots)
   );
 
   console.log(formatBanner(


### PR DESCRIPTION
If the packager is already watching `/path/to/MyProject`, and it finds symlinks inside `/path/to/MyProject/node_modules` that point to `/path/to/MyProject/path/to/somewhere/else`, there's no need to add the latter to the project roots.

**Test Plan:** replicate an aforementioned project set-up, and verify that only `/path/to/MyProject` is a project root for the packager, while files in `/path/to/MyProject/path/to/somewhere/else` can still be imported so long as they're part of an npm-style package (e.g. `/path/to/MyProject/path/to/somewhere/else/package.json` exists).