### PR TITLE
[Fastfs] Protect against roots that are contained within other roots

### DIFF
--- a/packager/react-packager/src/node-haste/crawlers/watchman.js
+++ b/packager/react-packager/src/node-haste/crawlers/watchman.js
@@ -70,7 +70,7 @@ function watchmanRecReadDir(roots, {ignore, fileWatcher, exts}) {
 }
 
 function isDescendant(root, child) {
-  return child.startsWith(root);
+  return root === child || child.startsWith(root + path.sep);
 }
 
 module.exports = watchmanRecReadDir;

--- a/packager/react-packager/src/node-haste/fastfs.js
+++ b/packager/react-packager/src/node-haste/fastfs.js
@@ -362,7 +362,7 @@ function makeReadCallback(fd, predicate, callback) {
 }
 
 function isDescendant(root, child) {
-  return child.startsWith(root);
+  return root === child || child.startsWith(root + path.sep);
 }
 
 module.exports = Fastfs;


### PR DESCRIPTION
For example, I could have a root named `random` and another root named `randomColor`.
A child of `randomColor` would **incorrectly** pass as a descendant of `random`.

So this commit changes `isDescendant` to do 2 things:
- check for exact matches (eg: the path is a root)
- call `startsWith` like before, but append `path.sep` to avoid false positives
