### PR TITLE
[Packager] global.Promise = require('promise')

### DIFF
--- a/packager/react-packager/index.js
+++ b/packager/react-packager/index.js
@@ -13,6 +13,8 @@ require('../babelRegisterOnly')([/react-packager\/src/]);
 require('./src/node-haste/fastpath').replace();
 useGracefulFs();
 
+global.Promise = require('promise');
+
 var debug = require('debug');
 var Activity = require('./src/Activity');
 

--- a/packager/react-packager/src/AssetServer/index.js
+++ b/packager/react-packager/src/AssetServer/index.js
@@ -8,8 +8,6 @@
  */
 'use strict';
 
-const Promise = require('promise');
-
 const crypto = require('crypto');
 const declareOpts = require('../lib/declareOpts');
 const fs = require('fs');

--- a/packager/react-packager/src/Bundler/index.js
+++ b/packager/react-packager/src/Bundler/index.js
@@ -11,7 +11,6 @@
 const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
-const Promise = require('promise');
 const ProgressBar = require('progress');
 const Cache = require('../node-haste').Cache;
 const Transformer = require('../JSTransformer');

--- a/packager/react-packager/src/JSTransformer/index.js
+++ b/packager/react-packager/src/JSTransformer/index.js
@@ -8,7 +8,6 @@
  */
 'use strict';
 
-const Promise = require('promise');
 const declareOpts = require('../lib/declareOpts');
 const os = require('os');
 const util = require('util');

--- a/packager/react-packager/src/Resolver/index.js
+++ b/packager/react-packager/src/Resolver/index.js
@@ -13,7 +13,6 @@ const path = require('path');
 const Activity = require('../Activity');
 const DependencyGraph = require('../node-haste');
 const declareOpts = require('../lib/declareOpts');
-const Promise = require('promise');
 
 const validateOpts = declareOpts({
   projectRoots: {

--- a/packager/react-packager/src/Server/index.js
+++ b/packager/react-packager/src/Server/index.js
@@ -13,7 +13,6 @@ const AssetServer = require('../AssetServer');
 const FileWatcher = require('../node-haste').FileWatcher;
 const getPlatformExtension = require('../node-haste').getPlatformExtension;
 const Bundler = require('../Bundler');
-const Promise = require('promise');
 const SourceMapConsumer = require('source-map').SourceMapConsumer;
 
 const declareOpts = require('../lib/declareOpts');


### PR DESCRIPTION
I noticed some modules in the Packager were importing `promise`, while other were **not**.

I think it makes sense to expose `promise` as `global.Promise` (especially since that means `denodeify` will use the same implementation as elsewhere).

LMK what you think! 🎅 