### PR TITLE
[NavigationExperimental] Abort onTransitionEnd if the transition was …

### DIFF
--- a/Libraries/NavigationExperimental/NavigationTransitioner.js
+++ b/Libraries/NavigationExperimental/NavigationTransitioner.js
@@ -210,7 +210,15 @@ class NavigationTransitioner extends React.Component<any, Props, State> {
     this.setState(nextState);
   }
 
-  _onTransitionEnd(): void {
+  _onTransitionEnd({finished}): void {
+    // It is possible to cancel the transition, for example by pushing another
+    // and this._transitionProps are not what they are expected to be anymore.
+    // onTransitionEnd callback after cancellation, because this._prevTransitionProps
+    // route. This can lead to awkward behaviour if we don't bail out the
+    if (!finished) {
+      return;
+    }
+
     const prevTransitionProps = this._prevTransitionProps;
     this._prevTransitionProps = null;
 


### PR DESCRIPTION
I noticed that when pushing a route, then popping, then pushing again before the transition completed that the push transition was totally weird.

![](http://i.giphy.com/3oz8xBUYRSlIfdnzYQ.gif)

After looking into this for far too long, I realized that the problem seemed to be that in the transitioner we are clobbering the values of `this._transitionProps` and `this._prevTransitionProps` that are set in `componentWillReceiveProps` when the transition completes. So I bailed out when the animation is cancelled and that appears to fix the problem.