### PR TITLE
Fix release Github link on website for latest RC version

### DIFF
--- a/website/src/react-native/versions.js
+++ b/website/src/react-native/versions.js
@@ -36,7 +36,7 @@ var versions = React.createClass({
       return {
         title: title,
         path: isLatest ? '/react-native' : '/react-native/releases/' + version,
-        release: 'https://github.com/facebook/react-native/releases/tag/v' + version + '.0' + (isRC ? '-rc' : '')
+        release: 'https://github.com/facebook/react-native/releases/tag/v' + version + '.0' + (isRC ? '-rc.0' : '')
       }
     }));
 


### PR DESCRIPTION
Each RC created ends with `rc.0` so the link on the website is broken. This PR fix this.

https://facebook.github.io/react-native/versions.html

But maybe it's the RC tag that is wrong and should be fixed instead of the website link.