### PR TITLE
Proposal for Activity Indicator: Forward setNativeProps directly to native view.

### DIFF
--- a/Libraries/Components/ActivityIndicator/ActivityIndicator.js
+++ b/Libraries/Components/ActivityIndicator/ActivityIndicator.js
@@ -36,6 +36,8 @@ type DefaultProps = {
  */
 const ActivityIndicator = React.createClass({
 
+  _root: (undefined: ?any),
+
   propTypes: {
     ...View.propTypes,
     /**
@@ -71,7 +73,7 @@ const ActivityIndicator = React.createClass({
     };
   },
 
-  setNativeProps(nativeProps) {
+  setNativeProps(nativeProps: Object) {
     if (this._root) {
       this._root.setNativeProps(nativeProps);
     }

--- a/Libraries/Components/ActivityIndicator/ActivityIndicator.js
+++ b/Libraries/Components/ActivityIndicator/ActivityIndicator.js
@@ -12,7 +12,6 @@
 'use strict';
 
 const ColorPropType = require('ColorPropType');
-const NativeMethodsMixin = require('react/lib/NativeMethodsMixin');
 const Platform = require('Platform');
 const PropTypes = require('react/lib/ReactPropTypes');
 const React = require('React');
@@ -36,7 +35,6 @@ type DefaultProps = {
  * Displays a circular loading indicator.
  */
 const ActivityIndicator = React.createClass({
-  mixins: [NativeMethodsMixin],
 
   propTypes: {
     ...View.propTypes,
@@ -73,6 +71,12 @@ const ActivityIndicator = React.createClass({
     };
   },
 
+  setNativeProps(nativeProps) {
+    if (this._root) {
+      this._root.setNativeProps(nativeProps);
+    }
+  },
+
   render() {
     const {onLayout, style, ...props} = this.props;
     let sizeStyle;
@@ -95,6 +99,7 @@ const ActivityIndicator = React.createClass({
         style={[styles.container, style]}>
         <RCTActivityIndicator
           {...props}
+          ref={(ref) => { this._root = ref; }}
           style={sizeStyle}
           styleAttr="Normal"
           indeterminate


### PR DESCRIPTION
**The Problem**

Currently, calling setNativeProps on an `ActivityIndicator` will always throw an exception "Cannot read property 'validAttributes' of undefined," because React's NativeMethodsMixin's `setNativeProps` method depends on the component having a `viewConfig`  property.

This wouldn't be a major problem (i.e., just use `setState` for modifying props, like normal), except that it leads to other, less intuitive crashes, such as when an `ActivityIndicator` is wrapped in a `TouchableHighlight`. For example, see [this recent issue](https://github.com/facebook/react-native/issues/8981).

**Proposed Solution**

This PR removes the NativeMethodsMixin completely from the ActivityIndicator component, and simply forwards `setNativeProps` to the native component.  

Now, I understand that this removes some useful functions, like `measure`.  I get that that's a useful function to expose, and maybe I'm really missing something here, and we really need to keep those methods.  The trouble is, having a completely broken `setNativeProps` function for a component backed by a native view isn't intuitive at all.  Plus, the current component yields some really confusing crashes when it's wrapped in another component that uses `setNativeProps`, such as `TouchableHighlight`, as seen in the issue referenced above.
