### PR TITLE
Point to airbnb/react-native-maps

### DIFF
--- a/Libraries/Components/MapView/MapView.js
+++ b/Libraries/Components/MapView/MapView.js
@@ -60,8 +60,8 @@ export type AnnotationDragState = $Enum<{
  * `MKMapView`.
  *
  * For a cross-platform solution, check out
- * [react-native-maps](https://github.com/lelandrichardson/react-native-maps)
- * by Leland Richardson.
+ * [react-native-maps](https://github.com/airbnb/react-native-maps)
+ * by Airbnb.
  *
  * ```
  * import React, { Component } from 'react';


### PR DESCRIPTION
We've moved https://github.com/lelandrichardson/react-native-maps to
https://github.com/airbnb/react-native-maps. Update the docs to reflect
the change.

to: @lelandrichardson 