### PR TITLE
Add a new Navigator SceneConfig swipeFromLeft

### DIFF
--- a/Libraries/CustomComponents/Navigator/Navigator.js
+++ b/Libraries/CustomComponents/Navigator/Navigator.js
@@ -305,6 +305,7 @@ var Navigator = React.createClass({
      *  - Navigator.SceneConfigs.FloatFromBottom
      *  - Navigator.SceneConfigs.FloatFromBottomAndroid
      *  - Navigator.SceneConfigs.FadeAndroid
+     *  - Navigator.SceneConfigs.SwipeFromLeft
      *  - Navigator.SceneConfigs.HorizontalSwipeJump
      *  - Navigator.SceneConfigs.HorizontalSwipeJumpFromRight
      *  - Navigator.SceneConfigs.VerticalUpSwipeJump

--- a/Libraries/CustomComponents/Navigator/NavigatorSceneConfigs.js
+++ b/Libraries/CustomComponents/Navigator/NavigatorSceneConfigs.js
@@ -654,6 +654,27 @@ var NavigatorSceneConfigs = {
       out: buildStyleInterpolator(FadeOut),
     },
   },
+  SwipeFromLeft: {
+    ...BaseConfig,
+    gestures: {
+      jumpBack: {
+        ...directionMapping.BaseEndToStartGesture,
+        overswipe: BaseOverswipeConfig,
+        edgeHitWidth: null,
+        isDetachable: true,
+      },
+      jumpForward: {
+        ...directionMapping.BaseStartToEndGesture,
+        overswipe: BaseOverswipeConfig,
+        edgeHitWidth: null,
+        isDetachable: true,
+      },
+    },
+    animationInterpolators: {
+      into: buildStyleInterpolator(directionMapping.FromTheStart),
+      out: buildStyleInterpolator(directionMapping.ToTheEnd),
+    },
+  },
   HorizontalSwipeJump: {
     ...BaseConfig,
     gestures: {


### PR DESCRIPTION
Add a new `SwipeFromLeft` Navigator SceneConfig.

The animation is the opposite of `HorizontalSwipeJump`, however there's no `Jump` while animating as `HorizontalSwipeJump`.  Should `HorizontalSwipeJump` be renamed to `SwipeFromRight`?

![swipe-left-anim-2](https://cloud.githubusercontent.com/assets/8182981/18466947/8ca4dd24-79bb-11e6-8cae-8ffa34c0c7da.gif)
