### PR TITLE
Fix invalid package name and Remove unsupported prop in Image.android.js

### DIFF
--- a/Libraries/Image/Image.android.js
+++ b/Libraries/Image/Image.android.js
@@ -336,9 +336,6 @@ var cfg = {
   nativeOnly: {
     src: true,
     loadingIndicatorSrc: true,
-    defaultImageSrc: true,
-    imageTag: true,
-    progressHandlerRegistered: true,
     shouldNotifyLoadEvents: true,
   },
 };

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/frescosupport/FrescoBasedReactTextInlineImageShadowNode.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/frescosupport/FrescoBasedReactTextInlineImageShadowNode.java
@@ -24,7 +24,7 @@ import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.uimanager.annotations.ReactProp;
 import com.facebook.react.views.text.ReactTextInlineImageShadowNode;
 import com.facebook.react.views.text.TextInlineImageSpan;
-import com.facebook.react.views.textfrescosupport.FrescoBasedReactTextInlineImageSpan;
+import com.facebook.react.views.text.frescosupport.FrescoBasedReactTextInlineImageSpan;
 
 /**
  * {@link CSSNode} that represents an inline image. Loading is done using Fresco.

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/frescosupport/FrescoBasedReactTextInlineImageSpan.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/frescosupport/FrescoBasedReactTextInlineImageSpan.java
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-package com.facebook.react.views.textfrescosupport;
+package com.facebook.react.views.text.frescosupport;
 
 import javax.annotation.Nullable;
 


### PR DESCRIPTION
1. `textfrescosupport` -> `text.frescosupport`
2. `defaultImageSrc`, `imageTag` and `progressHandlerRegistered` looks like never exists in `ReactImageManager.java`