### PR TITLE
RCTLocationObserver: Fix reporting of timeout error

### DIFF
--- a/Libraries/Geolocation/RCTLocationObserver.m
+++ b/Libraries/Geolocation/RCTLocationObserver.m
@@ -160,7 +160,7 @@ RCT_EXPORT_MODULE()
 - (void)timeout:(NSTimer *)timer
 {
   RCTLocationRequest *request = timer.userInfo;
-  NSString *message = [NSString stringWithFormat: @"Unable to fetch location within %zds.", (NSInteger)(timer.timeInterval * 1000.0)];
+  NSString *message = [NSString stringWithFormat: @"Unable to fetch location within %.1fs.", request.options.timeout];
   request.errorBlock(@[RCTPositionError(RCTPositionErrorTimeout, message)]);
   [_pendingRequests removeObject:request];
 


### PR DESCRIPTION
Fixes an issue where location request timeout errors always reported "Unable to fetch location within **0s**".

Previously we had `@"Unable to fetch location within %zds.", (NSInteger)(timer.timeInterval * 1000.0)` but from the [NSTimer.timeInterval docs](https://developer.apple.com/library/mac/documentation/Cocoa/Reference/Foundation/Classes/NSTimer_Class/#//apple_ref/occ/instp/NSTimer/timeInterval) "If the receiver is a non-repeating timer, returns 0 even if a time interval was set.".

Change to use `request.options.timeout` instead, which is a `Double` defaulting to `INFINITY`. Tested on an iOS simulator.