### PR TITLE
Fix UIExplorer search bar look on Android

### DIFF
--- a/Examples/UIExplorer/js/UIExplorerApp.android.js
+++ b/Examples/UIExplorer/js/UIExplorerApp.android.js
@@ -42,6 +42,8 @@ const UIManager = require('UIManager');
 const URIActionMap = require('./URIActionMap');
 const View = require('View');
 
+import type {UIExplorerNavigationState} from './UIExplorerNavigationReducer';
+
 UIManager.setLayoutAnimationEnabledExperimental(true);
 
 const DRAWER_WIDTH_LEFT = 56;

--- a/Examples/UIExplorer/js/UIExplorerExampleList.js
+++ b/Examples/UIExplorer/js/UIExplorerExampleList.js
@@ -120,6 +120,7 @@ class UIExplorerExampleList extends React.Component {
             this.props.persister.setState(() => ({filter: text}));
           }}
           placeholder="Search..."
+          underlineColorAndroid="transparent"
           style={[styles.searchTextInput, this.props.searchTextInputStyle]}
           testID="explorer_search"
           value={this.props.persister.state.filter}
@@ -215,6 +216,7 @@ const styles = StyleSheet.create({
     borderRadius: 3,
     borderWidth: 1,
     paddingLeft: 8,
+    paddingVertical: 0,
     height: 35,
   },
 });


### PR DESCRIPTION
Remove the underline color of the TextInput so the search input looks the same as iOS. Also add a missing type import.

Before
![image](https://cloud.githubusercontent.com/assets/2677334/18487095/e91b8066-79c1-11e6-82c8-adb3f86bc278.png)

After:
![image](https://cloud.githubusercontent.com/assets/2677334/18487043/b457987e-79c1-11e6-9393-e98d78556ef2.png)
