### PR TITLE
Packager: deep react-native field (also known as browser/resolve.alias) shim

### DIFF
--- a/packager/react-packager/src/node-haste/DependencyGraph/ResolutionRequest.js
+++ b/packager/react-packager/src/node-haste/DependencyGraph/ResolutionRequest.js
@@ -54,7 +54,7 @@ class ResolutionRequest {
     });
   }
 
-  resolveDependency(fromModule, toModuleName) {
+  resolveDependency(fromModule, toModuleName, rootModule) {
     const resHash = resolutionHash(fromModule.path, toModuleName);
 
     if (this._immediateResolutionCache[resHash]) {
@@ -94,14 +94,14 @@ class ResolutionRequest {
         && !(isRelativeImport(toModuleName) || isAbsolutePath(toModuleName))) {
       return this._tryResolve(
         () => this._resolveHasteDependency(fromModule, toModuleName),
-        () => this._resolveNodeDependency(fromModule, toModuleName)
+        () => this._resolveNodeDependency(fromModule, toModuleName, rootModule)
       ).then(
         cacheResult,
         forgive,
       );
     }
 
-    return this._resolveNodeDependency(fromModule, toModuleName)
+    return this._resolveNodeDependency(fromModule, toModuleName, rootModule)
       .then(
         cacheResult,
         forgive,
@@ -120,6 +120,8 @@ class ResolutionRequest {
       const mocks = Object.create(null);
 
       response.pushDependency(entry);
+      const rootModule = response.getRootDependency();
+
       let totalModules = 1;
       let finishedModules = 0;
 
@@ -127,7 +129,7 @@ class ResolutionRequest {
         module.getDependencies(transformOptions)
           .then(dependencyNames =>
             Promise.all(
-              dependencyNames.map(name => this.resolveDependency(module, name))
+              dependencyNames.map(name => this.resolveDependency(module, name, rootModule))
             ).then(dependencies => [dependencyNames, dependencies])
           );
 
@@ -305,21 +307,38 @@ class ResolutionRequest {
     });
   }
 
-  _redirectRequire(fromModule, modulePath) {
-    return Promise.resolve(fromModule.getPackage()).then(p => {
+  _redirectRequire(fromModule, modulePath, rootModule) {
+
+    const resolveRoot = (p) => {
       if (p) {
         return p.redirectRequire(modulePath);
       }
       return modulePath;
-    });
+    };
+
+    const resolveLocal = (name) => {
+      if(name === modulePath) {
+        return Promise.resolve(fromModule.getPackage()).then(p => {
+          if (p) {
+            return p.redirectRequire(modulePath);
+          }
+          return modulePath;
+        });
+      }
+      return name;
+    };
+
+    return Promise.resolve(rootModule.getPackage())
+    .then(resolveRoot)
+    .then(resolveLocal);
   }
 
-  _resolveFileOrDir(fromModule, toModuleName) {
+  _resolveFileOrDir(fromModule, toModuleName, rootModule) {
     const potentialModulePath = isAbsolutePath(toModuleName) ?
         toModuleName :
         path.join(path.dirname(fromModule.path), toModuleName);
 
-    return this._redirectRequire(fromModule, potentialModulePath).then(
+    return this._redirectRequire(fromModule, potentialModulePath, rootModule).then(
       realModuleName => {
         if (realModuleName === false) {
           return null;
@@ -333,11 +352,11 @@ class ResolutionRequest {
     );
   }
 
-  _resolveNodeDependency(fromModule, toModuleName) {
+  _resolveNodeDependency(fromModule, toModuleName, rootModule) {
     if (isRelativeImport(toModuleName) || isAbsolutePath(toModuleName)) {
-      return this._resolveFileOrDir(fromModule, toModuleName);
+      return this._resolveFileOrDir(fromModule, toModuleName, rootModule);
     } else {
-      return this._redirectRequire(fromModule, toModuleName).then(
+      return this._redirectRequire(fromModule, toModuleName, rootModule).then(
         realModuleName => {
           // exclude
           if (realModuleName === false) {
@@ -349,7 +368,7 @@ class ResolutionRequest {
             const fromModuleParentIdx = fromModule.path.lastIndexOf('node_modules/') + 13;
             const fromModuleDir = fromModule.path.slice(0, fromModule.path.indexOf('/', fromModuleParentIdx));
             const absPath = path.join(fromModuleDir, realModuleName);
-            return this._resolveFileOrDir(fromModule, absPath);
+            return this._resolveFileOrDir(fromModule, absPath, rootModule);
           }
 
           const searchQueue = [];

--- a/packager/react-packager/src/node-haste/DependencyGraph/ResolutionResponse.js
+++ b/packager/react-packager/src/node-haste/DependencyGraph/ResolutionResponse.js
@@ -96,6 +96,14 @@ class ResolutionResponse {
     this._assertFinalized();
     return this._mappings[module.hash()];
   }
+
+  getRootDependency() {
+    if (this.dependencies.length === 0) {
+      return null;
+    }
+
+    return this.dependencies[0];
+  }
 }
 
 module.exports = ResolutionResponse;


### PR DESCRIPTION
Ive been maintaining a [react native bluetooth package](https://github.com/jacobrosenthal/react-native-ble) that attempts to bring over the [extensive node bluetooth ecosystem](github.com/sandeepmistry/noble/) from node to ios and android 

Its been a longstanding request from many of us, sometimes with accompanying PR's sometimes without, to be able to use the react-native (browser elsewhere) field to shim packages. 
https://github.com/facebook/node-haste/pull/46
https://github.com/mjohnston/react-native-webpack-server/issues/75
https://github.com/facebook/react-native/issues/6253
https://productpains.com/post/react-native/packager-support-resolvealias-ala-webpack/
https://productpains.com/post/react-native/support-resolvealias-ala-webpack

Since then we got first level shims in the form of 'react-native' field in package.json. This attempts to store the root module and use its redirectRequire as a priority replacement before the current module's redirectRequire.

I know Ill need tests, and maybe even more implementation as I dont understand the cache/haste stuff yet but I haven't gotten any discussion in the discourse yet so Im hoping to spark some here.

Thanks in advance for any consideration or feedback
