### PR TITLE
More flexible IP address for xcode packager script

### DIFF
--- a/packager/react-native-xcode.sh
+++ b/packager/react-native-xcode.sh
@@ -74,7 +74,7 @@ DEST=$CONFIGURATION_BUILD_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH
 if [[ "$CONFIGURATION" = "Debug" && "$PLATFORM_NAME" != "iphonesimulator" ]]; then
   PLISTBUDDY='/usr/libexec/PlistBuddy'
   PLIST=$TARGET_BUILD_DIR/$INFOPLIST_PATH
-  [[ $(ipconfig getifaddr en0) != "" ]] && IP=$(ipconfig getifaddr en0) || IP=$(ipconfig getifaddr en1)
+  IP=$(ipconfig getifaddr en0) || IP=$(ipconfig getifaddr en1)
   $PLISTBUDDY -c "Add NSAppTransportSecurity:NSExceptionDomains:localhost:NSTemporaryExceptionAllowsInsecureHTTPLoads bool true" "$PLIST"
   $PLISTBUDDY -c "Add NSAppTransportSecurity:NSExceptionDomains:$IP.xip.io:NSTemporaryExceptionAllowsInsecureHTTPLoads bool true" "$PLIST"
   echo "$IP.xip.io" > "$DEST/ip.txt"

--- a/packager/react-native-xcode.sh
+++ b/packager/react-native-xcode.sh
@@ -74,7 +74,7 @@ DEST=$CONFIGURATION_BUILD_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH
 if [[ "$CONFIGURATION" = "Debug" && "$PLATFORM_NAME" != "iphonesimulator" ]]; then
   PLISTBUDDY='/usr/libexec/PlistBuddy'
   PLIST=$TARGET_BUILD_DIR/$INFOPLIST_PATH
-  IP=$(ipconfig getifaddr en0)
+  [[ $(ipconfig getifaddr en0) != "" ]] && IP=$(ipconfig getifaddr en0) || IP=$(ipconfig getifaddr en1)
   $PLISTBUDDY -c "Add NSAppTransportSecurity:NSExceptionDomains:localhost:NSTemporaryExceptionAllowsInsecureHTTPLoads bool true" "$PLIST"
   $PLISTBUDDY -c "Add NSAppTransportSecurity:NSExceptionDomains:$IP.xip.io:NSTemporaryExceptionAllowsInsecureHTTPLoads bool true" "$PLIST"
   echo "$IP.xip.io" > "$DEST/ip.txt"


### PR DESCRIPTION
The current xcode script doesn't work when an ethernet port is present and not used (ie, when the IP address is at en1 and not at en0).

This will use an IP address at en1 if en0 is empty. There is no change if an IP address is available at en0.
