### PR TITLE
optimize getNativeProps method

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/processing/ReactPropertyProcessor.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/processing/ReactPropertyProcessor.java
@@ -245,7 +245,7 @@ public class ReactPropertyProcessor extends AbstractProcessor {
     MethodSpec getMethods = MethodSpec.methodBuilder("getProperties")
         .addModifiers(PUBLIC)
         .addAnnotation(Override.class)
-        .returns(PROPERTY_MAP_TYPE)
+        .returns(TypeName.VOID)
         .addCode(generateGetProperties(properties))
         .build();
 
@@ -397,19 +397,7 @@ public class ReactPropertyProcessor extends AbstractProcessor {
 
   private static CodeBlock generateGetProperties(List<PropertyInfo> properties)
       throws ReactPropertyException {
-    if (properties.isEmpty()) {
-      return CodeBlock.builder()
-          .addStatement("return $T.emptyMap()", Collections.class)
-          .build();
-    }
-
-    CodeBlock.Builder builder = CodeBlock.builder()
-        .addStatement(
-            "$T props = new $T($L)",
-            PROPERTY_MAP_TYPE,
-            CONCRETE_PROPERTY_MAP_TYPE,
-            properties.size());
-
+    CodeBlock.Builder builder = CodeBlock.builder();
     for (PropertyInfo propertyInfo : properties) {
       try {
         String typeName = getPropertypTypeName(propertyInfo.mProperty, propertyInfo.propertyType);
@@ -419,9 +407,7 @@ public class ReactPropertyProcessor extends AbstractProcessor {
       }
     }
 
-    return builder
-        .addStatement("return props")
-        .build();
+    return builder.build();
   }
 
   private static String getPropertypTypeName(Property property, TypeName propertyType) {

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManagerPropertyUpdater.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManagerPropertyUpdater.java
@@ -13,7 +13,7 @@ import com.facebook.react.bridge.ReadableMapKeySetIterator;
 
 public class ViewManagerPropertyUpdater {
   public interface Settable {
-    Map<String, String> getProperties();
+     void getProperties(Map<String, String> props);
   }
 
   public interface ViewManagerSetter<T extends ViewManager, V extends View> extends Settable {
@@ -57,8 +57,8 @@ public class ViewManagerPropertyUpdater {
       Class<? extends ViewManager> viewManagerTopClass,
       Class<? extends ReactShadowNode> shadowNodeTopClass) {
     Map<String, String> props = new HashMap<>();
-    props.putAll(findManagerSetter(viewManagerTopClass).getProperties());
-    props.putAll(findNodeSetter(shadowNodeTopClass).getProperties());
+    findManagerSetter(viewManagerTopClass).getProperties(props);
+    findNodeSetter(shadowNodeTopClass).getProperties(props);
     return props;
   }
 
@@ -125,12 +125,10 @@ public class ViewManagerPropertyUpdater {
     }
 
     @Override
-    public Map<String, String> getProperties() {
-      Map<String, String> nativeProps = new HashMap<>();
+    public void getProperties(Map<String, String> props) {
       for (ViewManagersPropertyCache.PropSetter setter : mPropSetters.values()) {
-        nativeProps.put(setter.getPropName(), setter.getPropType());
+        props.put(setter.getPropName(), setter.getPropType());
       }
-      return nativeProps;
     }
   }
 
@@ -152,12 +150,10 @@ public class ViewManagerPropertyUpdater {
     }
 
     @Override
-    public Map<String, String> getProperties() {
-      Map<String, String> nativeProps = new HashMap<>();
+    public void getProperties(Map<String, String> props) {
       for (ViewManagersPropertyCache.PropSetter setter : mPropSetters.values()) {
-        nativeProps.put(setter.getPropName(), setter.getPropType());
+        props.put(setter.getPropName(), setter.getPropType());
       }
-      return nativeProps;
     }
   }
 }


### PR DESCRIPTION
The original method getNativeProps in ViewManagerPropertyUpdater.java create more HashMaps and putAll method need to re-hash the key again to avoid conflicts. This pull request pass the map as params to avoid the problem and update ReactPropertyProcessor.java to adapt the change.