### PR TITLE
Allow flow to see index.android.js

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,7 +1,7 @@
 [ignore]
 
 # We fork some components by platform.
-.*/*[.]android.js
+.*/node_modules/.*[.]android.js
 
 # Ignore templates with `@flow` in header
 .*/local-cli/generator.*


### PR DESCRIPTION
Flow wasn't able to see `index.android.js` until the following change was made. Tried to work around this issue without modifying `.flowconfig` with symlinks which also failed, but that's another issue.

Please accept this PR if this problem wasn't intentional.
