### PR TITLE
Use react@15.3.1 instead of react@15.3.1-rc.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "react-native": "local-cli/wrong-react-native.js"
   },
   "peerDependencies": {
-    "react": "15.3.1-rc.2"
+    "react": "15.3.1"
   },
   "dependencies": {
     "absolute-path": "^0.0.0",
@@ -217,7 +217,7 @@
     "jest-runtime": "15.1.0",
     "mock-fs": "^3.11.0",
     "portfinder": "0.4.0",
-    "react": "15.3.1-rc.2",
+    "react": "15.3.1",
     "shelljs": "0.6.0",
     "sinon": "^2.0.0-pre.2"
   }


### PR DESCRIPTION
Use `react@15.3.1` instead of `react@15.3.1-rc.2`.  I'm trying to install `react-native@0.34.0-rc.0`, because `0.33.0` doesn't include 141d35de061287742f084eacd6a5a5665ce31f49, which is necessary for Swift projects to work.

However, because `react-native@0.34.0-rc.0` depends on `react@15.3.1-rc.2`, NPM is giving me errors about invalid peer dependencies:

```
npm ERR! peer dep missing: react@0.13.x || 0.14.x || ^15.0.0-0, required by enzyme@2.4.1
npm ERR! peer dep missing: react@^15.3.1, required by react-addons-shallow-compare@15.3.1
npm ERR! peer dep missing: react@^15.3.1, required by react-addons-test-utils@15.3.1
npm ERR! peer dep missing: react@^15.3.1, required by react-dom@15.3.1
npm ERR! peer dep missing: react@>=15.3.0, required by react-native-maps@0.8.2
npm ERR! peer dep missing: react@^0.14.0 || ^15.0.0-0, required by react-redux@4.4.5
npm ERR! peer dep missing: react-native@>=0.32.0, required by react-native-maps@0.8.2
npm ERR! peer dep missing: react@>= 0.14, required by airbnb-i18n@5.0.2
npm ERR! peer dep missing: react@^15.3.1, required by react-addons-shallow-compare@15.3.1
npm ERR! peer dep missing: react@>= 0.14, required by airbnb-i18n@5.0.2
npm ERR! peer dep missing: react@>= 0.14, required by airbnb-i18n@5.0.2
npm ERR! peer dep missing: react@^15.1.0, required by react-addons-create-fragment@15.1.0
npm ERR! peer dep missing: react@^15.1.0, required by react-addons-linked-state-mixin@15.1.0
npm ERR! peer dep missing: react@^15.1.0, required by react-addons-perf@15.1.0
npm ERR! peer dep missing: react@^15.1.0, required by react-addons-pure-render-mixin@15.1.0
npm ERR! peer dep missing: react@^15.1.0, required by react-addons-update@15.1.0
npm ERR! peer dep missing: react@^15.1.0, required by react-addons-test-utils@15.1.0
```

Apparently because the `-rc.2` suffix of `react` is not satisfying the semver ranges of the dependencies.

Now that `react@15.3.1` is open, can we just point to that instead?

to: @zpao 