### PR TITLE
FIX #9939 - Add missing options argument to Android picker example

### DIFF
--- a/Examples/UIExplorer/js/TimePickerAndroidExample.js
+++ b/Examples/UIExplorer/js/TimePickerAndroidExample.js
@@ -66,7 +66,7 @@ class TimePickerAndroidExample extends React.Component {
       <UIExplorerPage title="TimePickerAndroid">
         <UIExplorerBlock title="Simple time picker">
           <TouchableWithoutFeedback
-            onPress={this.showPicker.bind(this, 'simple')}>
+            onPress={this.showPicker.bind(this, 'simple', {})}>
             <Text style={styles.text}>{this.state.simpleText}</Text>
           </TouchableWithoutFeedback>
         </UIExplorerBlock>


### PR DESCRIPTION
`options` is required when call `TimePickerAndroid.open()`