### PR TITLE
Expose getNode() on component created with createAnimatedComponent

### DIFF
--- a/Libraries/Animated/src/AnimatedImplementation.js
+++ b/Libraries/Animated/src/AnimatedImplementation.js
@@ -1672,6 +1672,12 @@ function createAnimatedComponent(Component: any): any {
     _setComponentRef(c) {
       this._component = c;
     }
+
+    // A third party library can use getNode()
+    // to get the node reference of the decorated component
+    getNode () {
+      return this._component;
+    }
   }
   AnimatedComponent.propTypes = {
     style: function(props, propName, componentName) {


### PR DESCRIPTION
see also: https://github.com/facebook/react-native/commit/eb3360b02ab82d20bc3c3f38f543b0d742598346#commitcomment-19042340

commit eb3360b02ab82d20bc3c3f38f543b0d742598346 recently break some third libraries that was (weakly) relying on traversing `animatedNode.refs.node` to get the original node of the decorated (animated) component (at least 2 libs: gl-react-native and react-native-material-kit).
Instead of now doing `animatedNode._component` (that might later break again), getNode() is a more 'public' solution for these third party.

as you expose a way to create an animated component (`createAnimatedComponent`) you sometimes still want a way to get the reference.
That way, third party components can continue providing some extra native methods to the animated version.
