### PR TITLE
Using evaluateJavascript to fix #9749

### DIFF
--- a/Libraries/Components/WebView/WebView.android.js
+++ b/Libraries/Components/WebView/WebView.android.js
@@ -207,6 +207,14 @@ class WebView extends React.Component {
       console.warn('WebView: `source.body` is not supported when using GET.');
     }
 
+    if (__DEV__) {
+      if (this.props.injectedJavaScript
+          && this.props.injectedJavaScript.indexOf('//') !== -1) {
+        console.warn('WebView: single-line comment in `injectedJavaScript` will ' +
+          'cause inconsistent result across different devices.');
+      }
+    }
+
     var webView =
       <RCTWebView
         ref={RCT_WEBVIEW_REF}

--- a/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebViewManager.java
@@ -225,7 +225,13 @@ public class ReactWebViewManager extends SimpleViewManager<WebView> {
       if (getSettings().getJavaScriptEnabled() &&
           injectedJS != null &&
           !TextUtils.isEmpty(injectedJS)) {
-        loadUrl("javascript:(function() {\n" + injectedJS + ";\n})();");
+        String code = "(function() {\n" + injectedJS + ";\n})();";
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+          evaluateJavascript(code, null);
+        } else {
+          loadUrl("javascript:" + code);
+        }
       }
     }
 


### PR DESCRIPTION
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request:

Use `evaluateJavascript` instead of `loadUrl` if possible, which will preserve the single line comment.

**Test plan (required)**

Manually.
