### PR TITLE
add settings to android webview to allow enabling file scheme and thi…

### DIFF
--- a/Libraries/Components/WebView/WebView.android.js
+++ b/Libraries/Components/WebView/WebView.android.js
@@ -122,6 +122,18 @@ class WebView extends React.Component {
     javaScriptEnabled: PropTypes.bool,
 
     /**
+     * Used on Android only, controls whether or not to allow cookies for file:/// urls
+     * @platform android
+     */
+    acceptFileSchemeCookies: PropTypes.bool,
+
+    /**
+     * Used on Android only, controls whether or not to allow third party cookies
+     * @platform android
+     */
+    acceptThirdPartyCookies: PropTypes.bool,
+
+    /**
      * Used on Android only, controls whether DOM Storage is enabled or not
      * @platform android
      */
@@ -217,6 +229,8 @@ class WebView extends React.Component {
         injectedJavaScript={this.props.injectedJavaScript}
         userAgent={this.props.userAgent}
         javaScriptEnabled={this.props.javaScriptEnabled}
+        acceptFileSchemeCookies={this.props.acceptFileSchemeCookies}
+        acceptThirdPartyCookies={this.props.acceptThirdPartyCookies}
         domStorageEnabled={this.props.domStorageEnabled}
         contentInset={this.props.contentInset}
         automaticallyAdjustContentInsets={this.props.automaticallyAdjustContentInsets}

--- a/Libraries/Components/WebView/WebView.ios.js
+++ b/Libraries/Components/WebView/WebView.ios.js
@@ -275,6 +275,18 @@ class WebView extends React.Component {
     javaScriptEnabled: PropTypes.bool,
 
     /**
+     * Used on Android only, controls whether or not to allow cookies for file:/// urls
+     * @platform android
+     */
+    acceptFileSchemeCookies: PropTypes.bool,
+
+    /**
+     * Used on Android only, controls whether or not to allow third party cookies
+     * @platform android
+     */
+    acceptThirdPartyCookies: PropTypes.bool,
+
+    /**
      * Boolean value to control whether DOM Storage is enabled. Used only in
      * Android.
      * @platform android

--- a/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebViewManager.java
@@ -22,6 +22,7 @@ import android.net.Uri;
 import android.os.Build;
 import android.text.TextUtils;
 import android.view.ViewGroup.LayoutParams;
+import android.webkit.CookieManager;
 import android.webkit.GeolocationPermissions;
 import android.webkit.WebChromeClient;
 import android.webkit.WebView;
@@ -279,6 +280,16 @@ public class ReactWebViewManager extends SimpleViewManager<WebView> {
   @ReactProp(name = "javaScriptEnabled")
   public void setJavaScriptEnabled(WebView view, boolean enabled) {
     view.getSettings().setJavaScriptEnabled(enabled);
+  }
+
+  @ReactProp(name = "acceptFileSchemeCookies")
+  public void setAcceptFileSchemeCookies(WebView view, boolean enabled) {
+    CookieManager.setAcceptFileSchemeCookies(enabled);
+  }
+
+  @ReactProp(name = "acceptThirdPartyCookies")
+  public void setAcceptThirdPartyCookies(WebView view, boolean enabled) {
+    CookieManager.getInstance().setAcceptThirdPartyCookies(view, enabled);
   }
 
   @ReactProp(name = "scalesPageToFit")


### PR DESCRIPTION
Add two props to android WebView:
- acceptFileSchemeCookies: controls whether or not android WebViews that load file scheme urls are allowed to used cookies
- acceptThirdPartyCookies: controls whether or not android WebViews allow third party cookies
