### PR TITLE
Set viewTag for RCTTouchEvent to avoid EventID conflict

### DIFF
--- a/React/Base/RCTTouchEvent.h
+++ b/React/Base/RCTTouchEvent.h
@@ -18,6 +18,7 @@
 @interface RCTTouchEvent : NSObject <RCTEvent>
 
 - (instancetype)initWithEventName:(NSString *)eventName
+                         reactTag:(NSNumber *)reactTag
                      reactTouches:(NSArray<NSDictionary *> *)reactTouches
                    changedIndexes:(NSArray<NSNumber *> *)changedIndexes
                     coalescingKey:(uint16_t)coalescingKey NS_DESIGNATED_INITIALIZER;

--- a/React/Base/RCTTouchEvent.m
+++ b/React/Base/RCTTouchEvent.m
@@ -21,11 +21,13 @@
 @synthesize viewTag = _viewTag;
 
 - (instancetype)initWithEventName:(NSString *)eventName
+                         reactTag:(NSNumber *)reactTag
                      reactTouches:(NSArray<NSDictionary *> *)reactTouches
                    changedIndexes:(NSArray<NSNumber *> *)changedIndexes
                     coalescingKey:(uint16_t)coalescingKey
 {
   if (self = [super init]) {
+    _viewTag = reactTag;
     _eventName = eventName;
     _reactTouches = reactTouches;
     _changedIndexes = changedIndexes;

--- a/React/Base/RCTTouchHandler.m
+++ b/React/Base/RCTTouchHandler.m
@@ -199,6 +199,7 @@ typedef NS_ENUM(NSInteger, RCTTouchEventType) {
   }
 
   RCTTouchEvent *event = [[RCTTouchEvent alloc] initWithEventName:eventName
+                                                         reactTag:self.view.reactTag
                                                      reactTouches:reactTouches
                                                    changedIndexes:changedIndexes
                                                     coalescingKey:_coalescingKey];


### PR DESCRIPTION
Using target view's reactTag as viewTag for RCTTouchEvent.

Fix issue https://github.com/facebook/react-native/issues/9503