### PR TITLE
Remove version from "line to delete" since we no longer use versions.

### DIFF
--- a/docs/AndroidBuildingFromSource.md
+++ b/docs/AndroidBuildingFromSource.md
@@ -97,7 +97,7 @@ project(':ReactAndroid').projectDir = new File(
 ...
 ```
 
-Modify your `android/app/build.gradle` to use the `:ReactAndroid` project instead of the pre-compiled library, e.g. - replace `compile 'com.facebook.react:react-native:0.16.+'` with `compile project(':ReactAndroid')`:
+Modify your `android/app/build.gradle` to use the `:ReactAndroid` project instead of the pre-compiled library, e.g. - replace `compile 'com.facebook.react:react-native:+'` with `compile project(':ReactAndroid')`:
 
 ```gradle
 ...


### PR DESCRIPTION
It seems everything pushes for "com.facebook.react:react-native:+" these days, so just updating the docs to match.