### PR TITLE
Docs fix: remove confusing typo

### DIFF
--- a/Libraries/PermissionsAndroid/PermissionsAndroid.js
+++ b/Libraries/PermissionsAndroid/PermissionsAndroid.js
@@ -39,8 +39,8 @@ type Rationale = {
  * ```
  * async function requestCameraPermission() {
  *   try {
- *     const granted = await AndroidPermissions.requestPermission(
- *       AndroidPermissions.PERMISSIONS.CAMERA,
+ *     const granted = await PermissionsAndroid.requestPermission(
+ *       PermissionsAndroid.PERMISSIONS.CAMERA,
  *       {
  *         'title': 'Cool Photo App Camera Permission',
  *         'message': 'Cool Photo App needs access to your camera ' +


### PR DESCRIPTION
Explain the **motivation** for making this change. What existing problem does the pull request solve?

Copy&paste from the example in the documentation will cause exception because there is no `AndroidPermissions` object. To avoid confusion we should refer to `PermissionsAndroid` instead since this is how this module is named in the API.