### PR TITLE
[Android] Implement ScrollView sticky headers on Android

### DIFF
--- a/Examples/UIExplorer/js/ListViewPagingExample.js
+++ b/Examples/UIExplorer/js/ListViewPagingExample.js
@@ -195,6 +195,7 @@ class ListViewPagingExample extends React.Component {
         initialListSize={10}
         pageSize={4}
         scrollRenderAheadDistance={500}
+        stickySectionHeaders={true}
       />
     );
   }

--- a/Examples/UIExplorer/js/UIExplorerExampleList.js
+++ b/Examples/UIExplorer/js/UIExplorerExampleList.js
@@ -85,6 +85,7 @@ class UIExplorerExampleList extends React.Component {
           keyboardShouldPersistTaps={true}
           automaticallyAdjustContentInsets={false}
           keyboardDismissMode="on-drag"
+          stickySectionHeaders={true}
         />
       </View>
     );
@@ -148,7 +149,7 @@ class UIExplorerExampleList extends React.Component {
 
   _renderRow(title: string, description: string, key: ?string, handler: ?Function): ?React.Element<any> {
     return (
-      <View key={key || title}>
+      <View key={key || title} collapsable={false}>
         <TouchableHighlight onPress={handler}>
           <View style={styles.row}>
             <Text style={styles.rowTitleText}>
@@ -185,6 +186,7 @@ const styles = StyleSheet.create({
     padding: 5,
     fontWeight: '500',
     fontSize: 11,
+    backgroundColor: '#eeeeee',
   },
   row: {
     backgroundColor: 'white',

--- a/Libraries/Components/ScrollView/ScrollView.js
+++ b/Libraries/Components/ScrollView/ScrollView.js
@@ -265,7 +265,10 @@ const ScrollView = React.createClass({
      * `stickyHeaderIndices={[0]}` will cause the first child to be fixed to the
      * top of the scroll view. This property is not supported in conjunction
      * with `horizontal={true}`.
-     * @platform ios
+     *
+     * **Note:**
+     * On Android if sticky headers are not working properly make sure the child
+     * views are not getting collapsed by adding collapsable={false} on each child.
      */
     stickyHeaderIndices: PropTypes.arrayOf(PropTypes.number),
     style: StyleSheetPropType(ViewStylePropTypes),

--- a/Libraries/CustomComponents/ListView/ListView.js
+++ b/Libraries/CustomComponents/ListView/ListView.js
@@ -33,6 +33,7 @@
 'use strict';
 
 var ListViewDataSource = require('ListViewDataSource');
+var Platform = require('Platform');
 var React = require('React');
 var ReactNative = require('ReactNative');
 var RCTScrollViewManager = require('NativeModules').ScrollViewManager;
@@ -234,9 +235,17 @@ var ListView = React.createClass({
      * `stickyHeaderIndices={[0]}` will cause the first child to be fixed to the
      * top of the scroll view. This property is not supported in conjunction
      * with `horizontal={true}`.
-     * @platform ios
+     *
+     * **Note:**
+     * On Android if sticky headers are not working properly make sure the child
+     * views are not getting collapsed by adding collapsable={false} on each child.
      */
     stickyHeaderIndices: PropTypes.arrayOf(PropTypes.number).isRequired,
+    /**
+     * If the sections headers should be sticky. Defaults to `true` on iOS and
+     * `false` on Android.
+     */
+    stickySectionHeaders: PropTypes.bool.isRequired,
     /**
      * Flag indicating whether empty section headers should be rendered. In the future release
      * empty section headers will be rendered by default, and the flag will be deprecated.
@@ -297,6 +306,7 @@ var ListView = React.createClass({
       scrollRenderAheadDistance: DEFAULT_SCROLL_RENDER_AHEAD,
       onEndReachedThreshold: DEFAULT_END_REACHED_THRESHOLD,
       stickyHeaderIndices: [],
+      stickySectionHeaders: Platform.OS === 'ios',
     };
   },
 
@@ -464,9 +474,14 @@ var ListView = React.createClass({
     if (props.removeClippedSubviews === undefined) {
       props.removeClippedSubviews = true;
     }
+
+    var stickyHeaderIndices = this.props.stickySectionHeaders ?
+      this.props.stickyHeaderIndices.concat(sectionHeaderIndices) :
+      this.props.stickyHeaderIndices;
+
     Object.assign(props, {
       onScroll: this._onScroll,
-      stickyHeaderIndices: this.props.stickyHeaderIndices.concat(sectionHeaderIndices),
+      stickyHeaderIndices,
 
       // Do not pass these events downstream to ScrollView since they will be
       // registered in ListView's own ScrollResponder.Mixin

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
@@ -5,7 +5,7 @@ package com.facebook.react.uimanager;
 import android.graphics.Color;
 import android.os.Build;
 import android.view.View;
-import android.view.ViewGroup;
+import android.view.ViewParent;
 
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.uimanager.annotations.ReactProp;
@@ -56,6 +56,8 @@ public abstract class BaseViewManager<T extends View, C extends LayoutShadowNode
     } else {
       setTransformProperty(view, matrix);
     }
+
+    updateClipping(view);
   }
 
   @ReactProp(name = PROP_OPACITY, defaultFloat = 1.f)
@@ -114,30 +116,40 @@ public abstract class BaseViewManager<T extends View, C extends LayoutShadowNode
   @ReactProp(name = PROP_ROTATION)
   public void setRotation(T view, float rotation) {
     view.setRotation(rotation);
+
+    updateClipping(view);
   }
 
   @Deprecated
   @ReactProp(name = PROP_SCALE_X, defaultFloat = 1f)
   public void setScaleX(T view, float scaleX) {
     view.setScaleX(scaleX);
+
+    updateClipping(view);
   }
 
   @Deprecated
   @ReactProp(name = PROP_SCALE_Y, defaultFloat = 1f)
   public void setScaleY(T view, float scaleY) {
     view.setScaleY(scaleY);
+
+    updateClipping(view);
   }
 
   @Deprecated
   @ReactProp(name = PROP_TRANSLATE_X, defaultFloat = 0f)
   public void setTranslateX(T view, float translateX) {
     view.setTranslationX(PixelUtil.toPixelFromDIP(translateX));
+
+    updateClipping(view);
   }
 
   @Deprecated
   @ReactProp(name = PROP_TRANSLATE_Y, defaultFloat = 0f)
   public void setTranslateY(T view, float translateY) {
     view.setTranslationY(PixelUtil.toPixelFromDIP(translateY));
+
+    updateClipping(view);
   }
 
   @ReactProp(name = PROP_ACCESSIBILITY_LIVE_REGION)
@@ -175,5 +187,12 @@ public abstract class BaseViewManager<T extends View, C extends LayoutShadowNode
     view.setRotationY(0);
     view.setScaleX(1);
     view.setScaleY(1);
+  }
+
+  private static void updateClipping(View view) {
+    ViewParent parent = view.getParent();
+    if (parent instanceof ReactClippingViewGroup) {
+      ((ReactClippingViewGroup) parent).updateClippingRect();
+    }
   }
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/DrawingOrderViewGroup.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/DrawingOrderViewGroup.java
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+package com.facebook.react.uimanager;
+
+public interface DrawingOrderViewGroup {
+  /**
+   * Returns if the ViewGroup implements custom drawing order.
+   */
+  boolean isDrawingOrderEnabled();
+
+  /**
+   * Returns which child to draw for the specified index.
+   */
+  int getDrawingOrder(int i);
+}

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactCompoundViewGroup.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactCompoundViewGroup.java
@@ -10,14 +10,14 @@
 package com.facebook.react.uimanager;
 
 /**
- * This interface should be implemented be native ViewGroup subclasses that can represent more
+ * This interface should be implemented by native ViewGroup subclasses that can represent more
  * than a single react node. In that case, virtual and non-virtual (mapping to a View) elements
  * can overlap, and TouchTargetHelper may incorrectly dispatch touch event to a wrong element
  * because it priorities children over parents.
  */
 public interface ReactCompoundViewGroup extends ReactCompoundView {
   /**
-   * Returns true if react node responsible for the touch even is flattened into this ViewGroup.
+   * Returns true if react node responsible for the touch event is flattened into this ViewGroup.
    * Use reactTagForTouch() to get its tag.
    */
   boolean interceptsTouchEvent(float touchX, float touchY);

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/TouchTargetHelper.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/TouchTargetHelper.java
@@ -124,8 +124,12 @@ public class TouchTargetHelper {
    */
   private static View findTouchTargetView(float[] eventCoords, ViewGroup viewGroup) {
     int childrenCount = viewGroup.getChildCount();
+    final boolean useCustomOrder = (viewGroup instanceof DrawingOrderViewGroup) &&
+      ((DrawingOrderViewGroup) viewGroup).isDrawingOrderEnabled();
     for (int i = childrenCount - 1; i >= 0; i--) {
-      View child = viewGroup.getChildAt(i);
+      int childIndex = useCustomOrder ?
+        ((DrawingOrderViewGroup) viewGroup).getDrawingOrder(i) : i;
+      View child = viewGroup.getChildAt(childIndex);
       PointF childPoint = mTempPoint;
       if (isTransformedTouchPointInView(eventCoords[0], eventCoords[1], viewGroup, child, childPoint)) {
         // If it is contained within the child View, the childPoint value will contain the view

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIImplementation.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIImplementation.java
@@ -835,4 +835,8 @@ public class UIImplementation {
 
     return rootTag;
   }
+
+  public ViewManager getViewManager(String name) {
+    return mViewManagers.get(name);
+  }
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/LayoutAnimationController.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/LayoutAnimationController.java
@@ -11,6 +11,7 @@ import android.view.animation.Animation;
 
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.UiThreadUtil;
+import com.facebook.react.uimanager.DrawingOrderViewGroup;
 
 /**
  * Class responsible for animation layout changes, if a valid layout animation config has been
@@ -66,6 +67,12 @@ public class LayoutAnimationController {
   }
 
   public boolean shouldAnimateLayout(View viewToAnimate) {
+    if (viewToAnimate instanceof LayoutAnimationViewGroup) {
+      if (!((LayoutAnimationViewGroup) viewToAnimate).isLayoutAnimationEnabled()) {
+        return false;
+      }
+    }
+
     // if view parent is null, skip animation: view have been clipped, we don't want animation to
     // resume when view is re-attached to parent, which is the standard android animation behavior.
     return mShouldAnimateLayout && viewToAnimate.getParent() != null;

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/LayoutAnimationViewGroup.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/LayoutAnimationViewGroup.java
@@ -1,0 +1,7 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+package com.facebook.react.uimanager.layoutanimation;
+
+public interface LayoutAnimationViewGroup {
+  boolean isLayoutAnimationEnabled();
+}

--- a/ReactAndroid/src/main/java/com/facebook/react/views/scroll/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/scroll/BUCK
@@ -14,6 +14,7 @@ android_library(
     react_native_target('java/com/facebook/react/uimanager:uimanager'),
     react_native_target('java/com/facebook/react/uimanager/annotations:annotations'),
     react_native_target('java/com/facebook/react/views/view:view'),
+    react_native_dep('libraries/fbcore/src/main/java/com/facebook/common/logging:logging'),
   ],
   visibility = [
     'PUBLIC',

--- a/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
@@ -9,10 +9,6 @@
 
 package com.facebook.react.views.scroll;
 
-import javax.annotation.Nullable;
-
-import java.lang.reflect.Field;
-
 import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.Rect;
@@ -25,13 +21,27 @@ import android.view.ViewGroup;
 import android.widget.OverScroller;
 import android.widget.ScrollView;
 
+import com.facebook.common.logging.FLog;
+import com.facebook.infer.annotation.Assertions;
 import com.facebook.react.bridge.ReactContext;
+import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.common.ReactConstants;
 import com.facebook.react.uimanager.MeasureSpecAssertions;
+import com.facebook.react.uimanager.UIManagerModule;
 import com.facebook.react.uimanager.events.NativeGestureUtil;
 import com.facebook.react.uimanager.ReactClippingViewGroup;
 import com.facebook.react.uimanager.ReactClippingViewGroupHelper;
-import com.facebook.infer.annotation.Assertions;
+import com.facebook.react.uimanager.ViewGroupManager;
+import com.facebook.react.views.view.ReactViewGroup;
+import com.facebook.react.views.view.ReactViewManager;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import javax.annotation.Nullable;
 
 /**
  * A simple subclass of ScrollView that doesn't dispatch measure and layout to its children and has
@@ -44,6 +54,7 @@ public class ReactScrollView extends ScrollView implements ReactClippingViewGrou
 
   private static Field sScrollerField;
   private static boolean sTriedToGetScrollerField = false;
+  private static boolean sHasWarnedAboutStickyHeaders = false;
 
   private final OnScrollDispatchHelper mOnScrollDispatchHelper = new OnScrollDispatchHelper();
   private final OverScroller mScroller;
@@ -60,6 +71,20 @@ public class ReactScrollView extends ScrollView implements ReactClippingViewGrou
   private @Nullable Drawable mEndBackground;
   private int mEndFillColor = Color.TRANSPARENT;
   private View mContentView;
+  private @Nullable int[] mStickyHeaderIndices;
+  private @Nullable Set<View> mStickyHeaderViews;
+  private @Nullable List<View> mOrderedChildViews;
+  private ViewGroupManager mViewManager;
+
+  private final ReactViewGroup.ChildDrawingOrderDelegate mContentDrawingOrderDelegate =
+    new ReactViewGroup.ChildDrawingOrderDelegate() {
+      @Override
+      public int getChildDrawingOrder(ReactViewGroup viewGroup, int drawingIndex) {
+        Assertions.assertNotNull(mOrderedChildViews);
+
+        return viewGroup.indexOfChild(mOrderedChildViews.get(drawingIndex));
+      }
+    };
 
   public ReactScrollView(ReactContext context) {
     this(context, null);
@@ -67,6 +92,10 @@ public class ReactScrollView extends ScrollView implements ReactClippingViewGrou
 
   public ReactScrollView(ReactContext context, @Nullable FpsListener fpsListener) {
     super(context);
+
+    UIManagerModule uiManager = context.getNativeModule(UIManagerModule.class);
+    mViewManager = (ViewGroupManager) uiManager.getUIImplementation().getViewManager(ReactViewManager.REACT_CLASS);
+
     mFpsListener = fpsListener;
 
     if (!sTriedToGetScrollerField) {
@@ -145,6 +174,14 @@ public class ReactScrollView extends ScrollView implements ReactClippingViewGrou
     if (mRemoveClippedSubviews) {
       updateClippingRect();
     }
+
+    View contentView = getChildAt(0);
+    if (contentView instanceof ReactViewGroup) {
+      ((ReactViewGroup) contentView).setChildDrawingOrderDelegate(
+        mStickyHeaderIndices != null ? mContentDrawingOrderDelegate : null);
+    }
+
+    dockClosestSectionHeader();
   }
 
   @Override
@@ -152,6 +189,8 @@ public class ReactScrollView extends ScrollView implements ReactClippingViewGrou
     super.onScrollChanged(x, y, oldX, oldY);
 
     if (mOnScrollDispatchHelper.onScrollChanged(x, y)) {
+      dockClosestSectionHeader();
+
       if (mRemoveClippedSubviews) {
         updateClippingRect();
       }
@@ -310,6 +349,13 @@ public class ReactScrollView extends ScrollView implements ReactClippingViewGrou
   }
 
   @Override
+  protected void onDraw(Canvas canvas) {
+    updateOrderedChildViews();
+
+    super.onDraw(canvas);
+  }
+
+  @Override
   public void draw(Canvas canvas) {
     if (mEndFillColor != Color.TRANSPARENT) {
       final View content = getChildAt(0);
@@ -325,6 +371,141 @@ public class ReactScrollView extends ScrollView implements ReactClippingViewGrou
     if (color != mEndFillColor) {
       mEndFillColor = color;
       mEndBackground = new ColorDrawable(mEndFillColor);
+    }
+  }
+
+  public void setStickyHeaderIndices(@Nullable ReadableArray indices) {
+    if (indices == null || indices.size() == 0) {
+      mStickyHeaderIndices = null;
+    } else {
+      int[] indicesArray = new int[indices.size()];
+      for (int i = 0; i < indices.size(); i++) {
+        indicesArray[i] = indices.getInt(i);
+      }
+
+      mStickyHeaderIndices = indicesArray;
+    }
+  }
+
+  public void onAfterUpdateTransaction() {
+    View contentView = getChildAt(0);
+    if (contentView instanceof ReactViewGroup) {
+      ((ReactViewGroup) contentView).setChildDrawingOrderDelegate(
+        mStickyHeaderIndices != null ? mContentDrawingOrderDelegate : null);
+    }
+
+    dockClosestSectionHeader();
+  }
+
+  private void dockClosestSectionHeader() {
+    if (mStickyHeaderIndices == null) {
+      return;
+    }
+
+    if (mStickyHeaderViews == null) {
+      mStickyHeaderViews = new HashSet<>();
+    }
+    mStickyHeaderViews.clear();
+
+    View previousHeader = null;
+    View currentHeader = null;
+    View nextHeader = null;
+    View firstChild = getChildAt(0);
+
+    if (firstChild != null && !(firstChild instanceof ReactViewGroup)) {
+      if (!sHasWarnedAboutStickyHeaders) {
+        FLog.w(
+          ReactConstants.TAG,
+          "'stickyHeaderIndices' isn't a supported prop type for this UIImplementation (nodes). " +
+            "It'd be awesome if you could help us support it by sending a diff or PR :)");
+        sHasWarnedAboutStickyHeaders = true;
+      }
+      return;
+    }
+
+    ReactViewGroup contentView = (ReactViewGroup) getChildAt(0);
+    if (contentView == null) {
+      return;
+    }
+
+    int scrollY = getScrollY();
+    for (int idx : mStickyHeaderIndices) {
+      // If the subviews are out of sync with the sticky header indices don't
+      // do anything.
+      if (idx >= mViewManager.getChildCount(contentView)) {
+        break;
+      }
+
+      View header = mViewManager.getChildAt(contentView, idx);
+      mStickyHeaderViews.add(header);
+
+      // If nextHeader not yet found, search for docked headers.
+      if (nextHeader == null) {
+        int top = header.getTop();
+        if (top > scrollY) {
+          nextHeader = header;
+        } else {
+          previousHeader = currentHeader;
+          currentHeader = header;
+        }
+      }
+
+      header.setTranslationY(0);
+      if (header instanceof ReactViewGroup) {
+        ((ReactViewGroup) header).setLayoutAnimationEnabled(true);
+      }
+    }
+
+    if (currentHeader == null) {
+      return;
+    }
+
+    int currentHeaderTop = currentHeader.getTop();
+    int currentHeaderHeight = currentHeader.getHeight();
+    int yOffset = scrollY - currentHeaderTop;
+
+    if (nextHeader != null) {
+      // The next header nudges the current header out of the way when it reaches
+      // the top of the screen.
+      int nextHeaderTop = nextHeader.getTop();
+      int overlap = currentHeaderHeight - (nextHeaderTop - scrollY);
+      yOffset -= Math.max(0, overlap);
+    }
+
+    currentHeader.setTranslationY(yOffset);
+    if (currentHeader instanceof ReactViewGroup) {
+      ((ReactViewGroup) currentHeader).setLayoutAnimationEnabled(false);
+    }
+
+    if (previousHeader != null) {
+      // The previous header sits right above the currentHeader's initial position
+      // so it scrolls away nicely once the currentHeader has locked into place.
+      yOffset = currentHeaderTop - previousHeader.getTop() - previousHeader.getHeight();
+      previousHeader.setTranslationY(yOffset);
+    }
+  }
+
+  private void updateOrderedChildViews() {
+    if (mStickyHeaderIndices == null || mStickyHeaderViews == null) {
+      return;
+    }
+
+    if (mOrderedChildViews == null) {
+      mOrderedChildViews = new ArrayList<>();
+    }
+    mOrderedChildViews.clear();
+
+    ReactViewGroup contentView = (ReactViewGroup) getChildAt(0);
+    int childCount = contentView.getChildCount();
+    int totalStickyHeaders = 0;
+    for (int i = 0; i < childCount; i++) {
+      View child = contentView.getChildAt(i);
+      if (mStickyHeaderViews.contains(child)) {
+        mOrderedChildViews.add(mOrderedChildViews.size(), child);
+        totalStickyHeaders++;
+      } else {
+        mOrderedChildViews.add(mOrderedChildViews.size() - totalStickyHeaders, child);
+      }
     }
   }
 
@@ -380,4 +561,3 @@ public class ReactScrollView extends ScrollView implements ReactClippingViewGrou
     }
   }
 }
-

--- a/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewManager.java
@@ -9,10 +9,6 @@
 
 package com.facebook.react.views.scroll;
 
-import javax.annotation.Nullable;
-
-import java.util.Map;
-
 import android.graphics.Color;
 
 import com.facebook.react.bridge.ReadableArray;
@@ -22,6 +18,10 @@ import com.facebook.react.uimanager.annotations.ReactProp;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.ViewGroupManager;
 import com.facebook.react.uimanager.ReactClippingViewGroupHelper;
+
+import java.util.Map;
+
+import javax.annotation.Nullable;
 
 /**
  * View manager for {@link ReactScrollView} components.
@@ -54,6 +54,13 @@ public class ReactScrollViewManager
   @Override
   public ReactScrollView createViewInstance(ThemedReactContext context) {
     return new ReactScrollView(context, mFpsListener);
+  }
+
+  @Override
+  protected void onAfterUpdateTransaction(ReactScrollView view) {
+    super.onAfterUpdateTransaction(view);
+
+    view.onAfterUpdateTransaction();
   }
 
   @ReactProp(name = "scrollEnabled", defaultBoolean = true)
@@ -105,6 +112,11 @@ public class ReactScrollViewManager
   @ReactProp(name = "endFillColor", defaultInt = Color.TRANSPARENT, customType = "Color")
   public void setBottomFillColor(ReactScrollView view, int color) {
     view.setEndFillColor(color);
+  }
+
+  @ReactProp(name = "stickyHeaderIndices")
+  public void setStickyHeaderIndices(ReactScrollView view, @Nullable ReadableArray indices) {
+    view.setStickyHeaderIndices(indices);
   }
 
   @Override

--- a/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
@@ -13,7 +13,9 @@ import javax.annotation.Nullable;
 
 import android.content.Context;
 import android.graphics.Color;
+import android.graphics.Matrix;
 import android.graphics.Rect;
+import android.graphics.RectF;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.LayerDrawable;
 import android.view.animation.Animation;
@@ -31,19 +33,25 @@ import com.facebook.react.uimanager.PointerEvents;
 import com.facebook.react.uimanager.ReactClippingViewGroup;
 import com.facebook.react.uimanager.ReactClippingViewGroupHelper;
 import com.facebook.react.uimanager.ReactPointerEventsView;
+import com.facebook.react.uimanager.layoutanimation.LayoutAnimationViewGroup;
 
 /**
  * Backing for a React View. Has support for borders, but since borders aren't common, lazy
  * initializes most of the storage needed for them.
  */
 public class ReactViewGroup extends ViewGroup implements
-    ReactInterceptingViewGroup, ReactClippingViewGroup, ReactPointerEventsView, ReactHitSlopView {
+    ReactInterceptingViewGroup, ReactClippingViewGroup, ReactPointerEventsView,
+    ReactHitSlopView, DrawingOrderViewGroup, LayoutAnimationViewGroup {
 
   private static final int ARRAY_CAPACITY_INCREMENT = 12;
   private static final int DEFAULT_BACKGROUND_COLOR = Color.TRANSPARENT;
   private static final LayoutParams sDefaultLayoutParam = new ViewGroup.LayoutParams(0, 0);
   /* should only be used in {@link #updateClippingToRect} */
-  private static final Rect sHelperRect = new Rect();
+  private static final RectF sHelperRect = new RectF();
+
+  public interface ChildDrawingOrderDelegate {
+    int getChildDrawingOrder(ReactViewGroup view, int i);
+  }
 
   /**
    * This listener will be set for child views when removeClippedSubview property is enabled. When
@@ -96,6 +104,8 @@ public class ReactViewGroup extends ViewGroup implements
   private @Nullable ReactViewBackgroundDrawable mReactBackgroundDrawable;
   private @Nullable OnInterceptTouchEventListener mOnInterceptTouchEventListener;
   private boolean mNeedsOffscreenAlphaCompositing = false;
+  private @Nullable ChildDrawingOrderDelegate mChildDrawingOrderDelegate;
+  private boolean mIsLayoutAnimationEnabled = true;
 
   public ReactViewGroup(Context context) {
     super(context);
@@ -292,8 +302,15 @@ public class ReactViewGroup extends ViewGroup implements
   private void updateSubviewClipStatus(Rect clippingRect, int idx, int clippedSoFar) {
     View child = Assertions.assertNotNull(mAllChildren)[idx];
     sHelperRect.set(child.getLeft(), child.getTop(), child.getRight(), child.getBottom());
-    boolean intersects = clippingRect
-        .intersects(sHelperRect.left, sHelperRect.top, sHelperRect.right, sHelperRect.bottom);
+    Matrix matrix = child.getMatrix();
+    if (!matrix.isIdentity()) {
+      matrix.mapRect(sHelperRect);
+    }
+    boolean intersects = clippingRect.intersects(
+      (int) sHelperRect.left,
+      (int) sHelperRect.top,
+      (int) Math.ceil(sHelperRect.right),
+      (int) Math.ceil(sHelperRect.bottom));
     boolean needUpdateClippingRecursive = false;
     // We never want to clip children that are being animated, as this can easily break layout :
     // when layout animation changes size and/or position of views contained inside a listview that
@@ -338,8 +355,15 @@ public class ReactViewGroup extends ViewGroup implements
 
     // do fast check whether intersect state changed
     sHelperRect.set(subview.getLeft(), subview.getTop(), subview.getRight(), subview.getBottom());
-    boolean intersects = mClippingRect
-        .intersects(sHelperRect.left, sHelperRect.top, sHelperRect.right, sHelperRect.bottom);
+    Matrix matrix = subview.getMatrix();
+    if (!matrix.isIdentity()) {
+      matrix.mapRect(sHelperRect);
+    }
+    boolean intersects = mClippingRect.intersects(
+      (int) sHelperRect.left,
+      (int) sHelperRect.top,
+      (int) Math.ceil(sHelperRect.right),
+      (int) Math.ceil(sHelperRect.bottom));
 
     // If it was intersecting before, should be attached to the parent
     boolean oldIntersects = (subview.getParent() != null);
@@ -532,4 +556,35 @@ public class ReactViewGroup extends ViewGroup implements
     mHitSlopRect = rect;
   }
 
+  @Override
+  public int getDrawingOrder(int i) {
+    return getChildDrawingOrder(getChildCount(), i);
+  }
+
+  @Override
+  public boolean isDrawingOrderEnabled() {
+    return isChildrenDrawingOrderEnabled();
+  }
+
+  @Override
+  protected int getChildDrawingOrder(int childCount, int i) {
+    if (mChildDrawingOrderDelegate == null) {
+      return super.getChildDrawingOrder(childCount, i);
+    } else {
+      return mChildDrawingOrderDelegate.getChildDrawingOrder(this, i);
+    }
+  }
+
+  public void setChildDrawingOrderDelegate(@Nullable ChildDrawingOrderDelegate delegate) {
+    setChildrenDrawingOrderEnabled(delegate != null);
+    mChildDrawingOrderDelegate = delegate;
+  }
+
+  public boolean isLayoutAnimationEnabled() {
+    return mIsLayoutAnimationEnabled;
+  }
+
+  public void setLayoutAnimationEnabled(boolean enabled) {
+    mIsLayoutAnimationEnabled = enabled;
+  }
 }


### PR DESCRIPTION
This adds support for sticky headers on Android. The implementation if based primarily on the iOS one (https://github.com/facebook/react-native/blob/master/React/Views/RCTScrollView.m#L272) and adds some stuff that was missing to be able to handle z-index, view clipping, view hierarchy optimization and touch handling properly.

Some notable changes:

Adds a `stickySectionHeaders` prop on `ListView` to control whether section headers are sticky. This is `true` on iOS and `false` on Android by default.

Add ChildDrawingOrderDelegate interface to allow changing the ViewGroup drawing order using ViewGroup#getChildDrawingOrder. This is used to change the content view drawing order to make sure headers are drawn over the other cells.

Add collapsableChildren prop that works like collapsable but applies to every child of the view. This is needed to be able to reference sticky headers by their indices otherwise some subviews can get optimized out and break indexes.

Make TouchTargetHelper take drawing order into consideration when finding the touch target.

Take translate into consideration when clipping subviews.

Fixes issues after the original PR (#9456) was reverted .

Test plan
Tested using the UIExplorer main menu on android.
Tested the Paging ListView example that uses LayoutAnimation to make sure it works.
Tested that touches get dispatched to the sticky header when over other touchable views.
Tested that touchables inside a sticky header work properly.
