### PR TITLE
FIX #9617 - Correct find local IP address when running on iOS device

### DIFF
--- a/packager/react-native-xcode.sh
+++ b/packager/react-native-xcode.sh
@@ -75,6 +75,9 @@ if [[ "$CONFIGURATION" = "Debug" && "$PLATFORM_NAME" != "iphonesimulator" ]]; th
   PLISTBUDDY='/usr/libexec/PlistBuddy'
   PLIST=$TARGET_BUILD_DIR/$INFOPLIST_PATH
   IP=$(ipconfig getifaddr en0)
+  if [ -z "$IP" ]; then
+    IP=$(ifconfig | grep 'inet ' | grep -v 127.0.0.1 | cut -d\   -f2  | awk 'NR==1{print $1}')
+  fi
   $PLISTBUDDY -c "Add NSAppTransportSecurity:NSExceptionDomains:localhost:NSTemporaryExceptionAllowsInsecureHTTPLoads bool true" "$PLIST"
   $PLISTBUDDY -c "Add NSAppTransportSecurity:NSExceptionDomains:$IP.xip.io:NSTemporaryExceptionAllowsInsecureHTTPLoads bool true" "$PLIST"
   echo "$IP.xip.io" > "$DEST/ip.txt"


### PR DESCRIPTION
React native's reload javascript option doesn't always work on iOS devices since version 0.29, as described in https://github.com/facebook/react-native/issues/9617

It only doesn't work when you have a mac on a wireless connection, because react-native-xcode.sh can't find your IP address correctly in this case and will just fallback to use the pre-bundling option on your app.

This small change in react-native-xcode.sh fixed this issue for our project and should fix this issue for all mac users that use wireless connection and that will run a debug version of the app on a real iOS device.