### PR TITLE
[fastfs] Check if node_modules dir exists before adding to search queue

### DIFF
--- a/packager/react-packager/src/node-haste/DependencyGraph/ResolutionRequest.js
+++ b/packager/react-packager/src/node-haste/DependencyGraph/ResolutionRequest.js
@@ -358,9 +358,12 @@ class ResolutionRequest {
           for (let currDir = path.dirname(fromModule.path);
                currDir !== realPath.parse(fromModule.path).root;
                currDir = path.dirname(currDir)) {
-            searchQueue.push(
-              path.join(currDir, 'node_modules', realModuleName)
-            );
+            let searchPath = path.join(currDir, 'node_modules');
+            if (this._fastfs.dirExists(searchPath)) {
+              searchQueue.push(
+                path.join(searchPath, realModuleName)
+              );
+            }
           }
 
           if (this._extraNodeModules) {


### PR DESCRIPTION
We can keep the `searchQueue` cleaner by using `this._fastfs.dirExists` on the potential `node_modules` directory. In addition to avoiding useless lookups, this also makes the error message provided by #9832 much more understandable.

/cc @davidaurelio 