### PR TITLE
Fix HMR after adding RA-Bundle groups

### DIFF
--- a/packager/react-packager/src/Bundler/BundleBase.js
+++ b/packager/react-packager/src/Bundler/BundleBase.js
@@ -88,6 +88,8 @@ class BundleBase {
     }
   }
 
+  setRamGroups() {}
+
   toJSON() {
     return {
       modules: this._modules,


### PR DESCRIPTION
The introduction of groups for random access bundles broke hot module reloading, because HMR uses a different Bundle class. And that didn’t have the `setRamGroups()` method.

This just adds an empty method on the base class.

**Test plan (required)**

I ran `node scripts/run-ci-e2e-tests.js --android`