### PR TITLE
Fix a crash for RCTNetwork Library in iOS7

### DIFF
--- a/Libraries/Network/RCTHTTPRequestHandler.m
+++ b/Libraries/Network/RCTHTTPRequestHandler.m
@@ -59,7 +59,11 @@ RCT_EXPORT_MODULE()
 
     NSOperationQueue *callbackQueue = [NSOperationQueue new];
     callbackQueue.maxConcurrentOperationCount = 1;
-    callbackQueue.underlyingQueue = [[_bridge networking] methodQueue];
+      
+    if ([self respondsToSelector:@selector(setUnderlyingQueue:)]) {
+        callbackQueue.underlyingQueue = [[_bridge networking] methodQueue];
+    }
+
     NSURLSessionConfiguration *configuration = [NSURLSessionConfiguration defaultSessionConfiguration];
     _session = [NSURLSession sessionWithConfiguration:configuration
                                              delegate:self


### PR DESCRIPTION
Fix a crash for RCTNetwork Library in iOS7 . This crash appears in RN v0.33