### PR TITLE
FIX #9751 - Cancelling offscreen image loads causing crashes

### DIFF
--- a/Libraries/Image/RCTImageLoader.m
+++ b/Libraries/Image/RCTImageLoader.m
@@ -378,7 +378,7 @@ static UIImage *RCTResizeImageIfNeeded(UIImage *image,
   });
 
   return ^{
-    if (cancelLoad) {
+    if (cancelLoad && !cancelled) {
       cancelLoad();
       cancelLoad = nil;
     }


### PR DESCRIPTION
This fixes https://github.com/facebook/react-native/issues/9751

We were seeing the same issues as the original reporter.

I'm not an expert on this code, so apologies if it's naive, but we haven't seen the crash since making this change.

From my understanding of it, it seems like the `cancelLoad` block was being released before the block returned by `_loadImageOrDataWithURLRequest:` was called.
This PR checks the `cancelled` flag before calling `cancelLoad()`.