### PR TITLE
[Android] Fix missing static images when using data binding 

### DIFF
--- a/react.gradle
+++ b/react.gradle
@@ -98,6 +98,7 @@ gradle.projectsEvaluated {
             runBefore("process${flavorNameCapitalized}X86${buildNameCapitalized}Resources", currentBundleTask)
             runBefore("processUniversal${targetName}Resources", currentBundleTask)
             runBefore("process${targetName}Resources", currentBundleTask)
+            runBefore("dataBindingProcessLayouts${targetName}", currentBundleTask)
         }
     }
 }


### PR DESCRIPTION
**Motivation**
Images not getting bundled when data binding is enabled in gradle in Android projects.
So to fix it running the bundle task before ```dataBindingProcessLayouts``` gradle task

**Test plan**

Example project with data binding enabled

https://github.com/jaggs6/rn_data_binding (master)

note in ```app/build.gradle```
```
dataBinding {
   enabled = true
}
```
when the app is running in debug you will see the following
![screenshot_1474456348](https://cloud.githubusercontent.com/assets/1941517/18708823/b11e306c-7ff4-11e6-89c9-5b74f0f5d1c6.png)

and when installing and running a release variant (```./gradlew uninstallAll clean installRelease```) you will see this

![screenshot_1474456603](https://cloud.githubusercontent.com/assets/1941517/18708926/4658991a-7ff5-11e6-9a29-78333504b20f.png)
(note the missing image)

to fix this problem I added the fix in react.gradle file and moved it into the project (branch master_working)

here is the compare https://github.com/jaggs6/rn_data_binding/compare/master_working

and now when u run the release variant (```./gradlew uninstallAll clean installRelease```) you will see the image asset in the app

Hence this fixes an issue caused when data binding is enabled and the image assets are missing in the release apk