### PR TITLE
XMLHttpRequest.getAllResponseHeaders should use CRLF

### DIFF
--- a/Libraries/Network/XMLHttpRequest.js
+++ b/Libraries/Network/XMLHttpRequest.js
@@ -340,7 +340,7 @@ class XMLHttpRequest extends EventTarget(...XHR_EVENTS) {
     var headers = this.responseHeaders || {};
     return Object.keys(headers).map((headerName) => {
       return headerName + ': ' + headers[headerName];
-    }).join('\n');
+    }).join('\r\n');
   }
 
   getResponseHeader(header: string): ?string {

--- a/Libraries/Network/__tests__/XMLHttpRequest-test.js
+++ b/Libraries/Network/__tests__/XMLHttpRequest-test.js
@@ -194,4 +194,17 @@ describe('XMLHttpRequest', function() {
     expect(handleProgress.mock.calls[0][0].total).toBe(100);
   });
 
+  it('should combine response headers with CRLF', function() {
+    xhr.open('GET', 'blabla');
+    xhr.send();
+    xhr.__didReceiveResponse(1, 200, {
+      'Content-Type': 'text/plain; charset=utf-8',
+      'Content-Length': '32',
+    });
+
+    expect(xhr.getAllResponseHeaders()).toBe(
+      'Content-Type: text/plain; charset=utf-8\r\n' +
+      'Content-Length: 32');
+  });
+
 });


### PR DESCRIPTION
XMLHttpRequest.prototype.getAllResponseHeaders was previously joining
the headers with `\n`. The spec at:

https://xhr.spec.whatwg.org/#the-getallresponseheaders()-method

step 3.2, requires the headers to be joined using `\r\n`.