### PR TITLE
Improve android generator

### DIFF
--- a/local-cli/generator-android/templates/src/app/src/main/AndroidManifest.xml
+++ b/local-cli/generator-android/templates/src/app/src/main/AndroidManifest.xml
@@ -19,6 +19,7 @@
       <activity
         android:name=".MainActivity"
         android:label="@string/app_name"
+		android:screenOrientation="portrait"
         android:configChanges="keyboard|keyboardHidden|orientation|screenSize">
         <intent-filter>
             <action android:name="android.intent.action.MAIN" />


### PR DESCRIPTION
~~This PR improves the Android template to generate a more cleaner `manifest` file to the Android application. All of the removed properties from the `manifest` are defined and overridden in the `build.gradle` file, so they are useless and should not be in the `manifest` of the Android application.~~

In this PR locks the orientation of the application to portrait to match the `iOS` project generator behaviour.