### PR TITLE
Ensure the main AndroidManifest.xml is used

### DIFF
--- a/local-cli/core/__fixtures__/android.js
+++ b/local-cli/core/__fixtures__/android.js
@@ -20,6 +20,25 @@ exports.valid = {
   },
 };
 
+exports.validMultipleManifests = {
+  src: {
+    main: {
+      'AndroidManifest.xml': manifest,
+      com: {
+        some: {
+          example: {
+            'Main.java': mainJavaClass,
+            'ReactPackage.java': fs.readFileSync(path.join(__dirname, './files/ReactPackage.java')),
+          },
+        },
+      },
+    },
+    debug: {
+      'AndroidManifest.xml': manifest
+    },
+  },
+};
+
 exports.corrupted = {
   src: {
     'AndroidManifest.xml': manifest,

--- a/local-cli/core/__tests__/android/findManifest.spec.js
+++ b/local-cli/core/__tests__/android/findManifest.spec.js
@@ -11,6 +11,9 @@ describe('android::findManifest', () => {
     flat: {
       android: mocks.valid,
     },
+    multipleManifests: {
+      android: mocks.validMultipleManifests,
+    },
   }));
 
   it('should return a manifest path if file exists in the folder', () => {
@@ -19,6 +22,10 @@ describe('android::findManifest', () => {
 
   it('should return `null` if there is no manifest in the folder', () => {
     expect(findManifest('empty')).toBe(null);
+  });
+
+  it('should return the main manifest before other manifests', () => {
+    expect(findManifest('multipleManifests')).toMatch(/[\/\\]src[\/\\]main/);
   });
 
   afterAll(mockFs.restore);

--- a/local-cli/core/config/android/findManifest.js
+++ b/local-cli/core/config/android/findManifest.js
@@ -2,16 +2,33 @@ const glob = require('glob');
 const path = require('path');
 
 /**
- * Find an android application path in the folder
+ * Find an AndroidManifest.xml in the folder.
  *
  * @param {String} folder Name of the folder where to seek
  * @return {String}
  */
 module.exports = function findManifest(folder) {
-  const manifestPath = glob.sync(path.join('**', 'AndroidManifest.xml'), {
+  // Android projects may contain multiple manifest files that are merged
+  // during build. Usually we should use the manifest file of the main source
+  // set at src/main/AndroidManifest.xml. If for some reason that manifest
+  // isn't available (e.g. with a highly customised build setup) we should
+  // look for the first manifest we find.
+  const globOptions = {
     cwd: folder,
-    ignore: ['node_modules/**', '**/build/**', 'Examples/**', 'examples/**'],
-  })[0];
+    ignore: ['**/build/**'],
+  };
 
-  return manifestPath ? path.join(folder, manifestPath) : null;
+  const mainPattern = path.join('**', 'main', 'AndroidManifest.xml');
+  const mainManifestPath = glob.sync(mainPattern, globOptions)[0];
+
+  if (mainManifestPath) {
+    return path.join(folder, mainManifestPath);
+  }
+
+  // Here it's possible that we might not find the manifest that contains what
+  // our caller is looking for but this should be better than returning null.
+  const anyPattern = path.join('**', 'AndroidManifest.xml');
+  const anyManifestPath = glob.sync(anyPattern, globOptions)[0];
+
+  return anyManifestPath ? path.join(folder, anyManifestPath) : null;
 };


### PR DESCRIPTION
Rationale from the commit message:

> Some Android projects might opt to use multiple manifest files, e.g. for
> choosing different permissions based on the build type. Android's build
> process merges the manifests; secondary manifests can omit everything
> present in the main manifest. We shouldn’t rely on those secondary
> manifests for information since crucial information like the package
> name might not be present.

The story is that I was using multiple manifests and trying to run `react-native link` to link some libraries, that specific command kept failing with:

```
rnpm-install ERR! ERRPACKAGEJSON No package found. Are you sure it's a React Native project?
```

Turns out it couldn’t find the package name from the manifest since it was looking into the debug build type’s manifest that didn’t have it.

Links for reference:
- [Manifest merging rules](https://developer.android.com/studio/build/manifest-merge.html)
- [Build types](https://sites.google.com/a/android.com/tools/tech-docs/new-build-system/user-guide#TOC-Build-Types)

Please let me know if you need more info or if anything needs to be changed. Thanks!
