### PR TITLE
Getting MobX ObservableArrays to work in ListViews

### DIFF
--- a/Libraries/CustomComponents/ListView/ListViewDataSource.js
+++ b/Libraries/CustomComponents/ListView/ListViewDataSource.js
@@ -208,7 +208,7 @@ class ListViewDataSource {
     } else {
       newSource.rowIdentities = [];
       newSource.sectionIdentities.forEach((sectionID) => {
-        newSource.rowIdentities.push(Object.keys(dataBlob[sectionID]));
+        newSource.rowIdentities.push(Object.keys(dataBlob[sectionID].slice()));
       });
     }
     newSource._cachedRowCount = countRows(newSource.rowIdentities);


### PR DESCRIPTION
When passing in data to a listview with section headers and the datasource comes from Mobx, arrays get wrapped with Mobx ObservableArrays and Object.keys(...) doesn't return indices. Calling .slice() will fix this case.