### PR TITLE
Better release script

### DIFF
--- a/Releases.md
+++ b/Releases.md
@@ -48,9 +48,6 @@ git checkout -b <version_you_are_releasing>-stable
 
 node ./scripts/bump-oss-version.js <exact-version_you_are_releasing>
 # e.g. node ./scripts/bump-oss-version.js 0.22.0-rc
-
-git push origin <version_you_are_releasing>-stable --follow-tags
-# e.g. git push origin 0.22-stable --follow-tags
 ```
 
 Circle CI will automatically run the tests and publish to npm with the version you have specified (e.g `0.22.0-rc`) and tag `next` meaning that this version will not be installed for users by default.
@@ -113,9 +110,6 @@ If everything worked:
 ```bash
 node ./scripts/bump-oss-version.js <exact_version_you_are_releasing>
 # e.g. node ./scripts/bump-oss-version.js 0.28.0-rc.1
-
-git push origin version_you_are_releasing-stable --follow-tags
-# e.g. git push origin 0.22-stable --follow-tags
 ````
 
 -------------------
@@ -145,15 +139,6 @@ If everything worked:
 ```bash
 node ./scripts/bump-oss-version.js <exact_version_you_are_releasing>
 # e.g. node ./scripts/bump-oss-version.js 0.22.0
-
-git tag -d latest
-git push origin :latest
-
-git tag latest
-# The latest tag marks when to regenerate the website.
-
-git push origin version_you_are_releasing-stable --follow-tags
-# e.g. git push origin 0.22-stable --follow-tags
 ```
 
 #### Update the release notes

--- a/scripts/bump-oss-version.js
+++ b/scripts/bump-oss-version.js
@@ -76,5 +76,17 @@ if (exec(`git tag v${version}`).code) {
   exit(1);
 }
 
+// Push newly created tag
+exec(`git push origin v${version}`);
+
+// Tag latest if doing stable release
+if (version.indexOf('rc') === -1) {
+  exec(`git tag -d latest`);
+  exec(`git push origin :latest`);
+  exec(`git tag latest`);
+}
+
+exec(`git push origin ${branch} --follow-tags`);
+
 exit(0);
 /*eslint-enable no-undef */

--- a/scripts/bump-oss-version.js
+++ b/scripts/bump-oss-version.js
@@ -80,7 +80,7 @@ if (exec(`git tag v${version}`).code) {
 exec(`git push origin v${version}`);
 
 // Tag latest if doing stable release
-if (version.indexOf('rc') === -1) {
+if (version.indexOf(`rc`) === -1) {
   exec(`git tag -d latest`);
   exec(`git push origin :latest`);
   exec(`git tag latest`);

--- a/scripts/bump-oss-version.js
+++ b/scripts/bump-oss-version.js
@@ -84,6 +84,7 @@ if (version.indexOf('rc') === -1) {
   exec(`git tag -d latest`);
   exec(`git push origin :latest`);
   exec(`git tag latest`);
+  exec(`git push origin latest`);
 }
 
 exec(`git push origin ${branch} --follow-tags`);


### PR DESCRIPTION
Automatically tags and publish them upstream, less steps required in order to do the release rather than just `bump-oss-version.js`

CC: @bestander 