### PR TITLE
Add env't variable to kill Xcode 8's noisy logs

### DIFF
--- a/local-cli/generator-ios/templates/xcodeproj/xcshareddata/xcschemes/_xcscheme
+++ b/local-cli/generator-ios/templates/xcodeproj/xcshareddata/xcschemes/_xcscheme
@@ -82,6 +82,13 @@
             ReferencedContainer = "container:<%= name %>.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "OS_ACTIVITY_MODE"
+            value = "disable"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>


### PR DESCRIPTION
Ever since Xcode 8's release the development console logs have started to become extremely noisy that it doesn't allow you to see your logs. You can see the outrage of this issue spring up in the web, just Google: [`xcode 8 logs`](https://www.google.com/search?q=xcode+8+logs&oq=xcode+8+logs).

Also, I'm not sure if this change automatically propagates to the `react-native-cli`, and if so, let me know how this change is made.

Test plan:

I'm not sure if there is a test that can be run on this? If so, how do we do so?

For the meantime, for those with existing projects, to manually apply this patch, simply Edit Scheme -> Run -> Arguments ->Environment Variables -> Click + to add a new one -> Name: OS_ACTIVITY_MODE -> Value: disable.