### PR TITLE
Remove rnpm references in favour of react-native

### DIFF
--- a/docs/LinkingLibraries.md
+++ b/docs/LinkingLibraries.md
@@ -27,32 +27,21 @@ error as soon as you try to use the library._
 
 ### Automatic linking
 
-"[rnpm](http://github.com/rnpm/rnpm)" is a community project that allows linking of native dependencies automatically:
-
 #### Step 1
-
-Install `rnpm`:
-```bash
-$ npm install rnpm -g
-```
-
-**Note:** _`rnpm` requires `node` version 4.1 or higher_
-
-#### Step 2
 
 Install a library with native dependencies:
 ```bash
 $ npm install <library-with-native-dependencies> --save
 ```
 
-**Note:** _`--save` or `--save-dev` flag is very important for this step. `rnpm` will link
+**Note:** _`--save` or `--save-dev` flag is very important for this step. React Native will link
 your libs based on `dependencies` and `devDependencies` in your `package.json` file._
 
-#### Step 3
+#### Step 2
 
 Link your native dependencies:
 ```bash
-$ rnpm link
+$ react-native link
 ```
 
 Done! All libraries with a native dependencies should be successfully linked to your iOS/Android project.


### PR DESCRIPTION
No need for the references now that rnpm is baked into core.