### PR TITLE
[Website] Load React Native Web Player from MaxCDN.

### DIFF
--- a/website/core/WebPlayer.js
+++ b/website/core/WebPlayer.js
@@ -12,7 +12,7 @@
 var React = require('React');
 var Prism = require('Prism');
 
-var WEB_PLAYER_VERSION = '1.1.0';
+var WEB_PLAYER_VERSION = '1.2.4';
 
 /**
  * Use the WebPlayer by including a ```ReactNativeWebPlayer``` block in markdown.
@@ -59,7 +59,7 @@ var WebPlayer = React.createClass({
           style={{marginTop: 4}}
           width='880'
           height={this.parseParams(this.props.params).platform === 'android' ? '425' : '420'}
-          data-src={`//npmcdn.com/react-native-web-player@${WEB_PLAYER_VERSION}/index.html${hash}`}
+          data-src={`//cdn.rawgit.com/dabbott/react-native-web-player/gh-v${WEB_PLAYER_VERSION}/index.html${hash}`}
           frameBorder='0'
         />
       </div>


### PR DESCRIPTION
unpkg (nee npmcdn) will [no longer serve HTML content with the text/html Content-Type](https://twitter.com/mjackson/status/779147399528718336). We need to switch to another provider to continue supporting the RN Web Player.