### PR TITLE
Improve e2e tests on Android

### DIFF
--- a/scripts/android-e2e-test.js
+++ b/scripts/android-e2e-test.js
@@ -165,7 +165,6 @@ const selectDeveloperOption = (driver, xPath) => driver
 const performFileChange = (func) => {
   let iteration = 0;
   return setInterval(() => {
-    console.log('called');
     func(iteration++);
   }, 3000);
 };

--- a/scripts/test-manual-e2e.sh
+++ b/scripts/test-manual-e2e.sh
@@ -53,15 +53,6 @@ grep -E "com.facebook.react:react-native:\\+" "${project_name}/android/app/build
 
 success "New sample project generated at /tmp/${project_name}"
 
-info "Test the following on Android:"
-info "   - Disable Hot Reloading. It might be enabled from last time (the setting is stored on the device)"
-info "   - Verify 'Reload JS' works"
-info ""
-info "Press any key to run the sample in Android emulator/device"
-info ""
-read -n 1
-cd "/tmp/${project_name}" && react-native run-android
-
 info "Test the following on iOS:"
 info "   - Disable Hot Reloading. It might be enabled from last time (the setting is stored on the device)"
 info "   - Verify 'Reload JS' works"


### PR DESCRIPTION
This PR adds `Live Reload` tests to our e2e-tests on Android which makes the process of releasing Android fully automatic w/o a need of any manual actions.

That's a part of the bigger process that I am working on (automating iOS tests as well) and so I've added few helpers / utils to see how the suite could be improved.

@bestander 
