### PR TITLE
Speeds up Android by avoiding event loop cycling with TextInput usage.

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
@@ -315,7 +315,7 @@ public class ReactEditText extends EditText {
         new SpannableStringBuilder(reactTextUpdate.getText());
     manageSpans(spannableStringBuilder);
     mContainsImages = reactTextUpdate.containsImages();
-    mIsSettingTextFromJS = true;
+    //mIsSettingTextFromJS = true;
     getText().replace(0, length(), spannableStringBuilder);
     mIsSettingTextFromJS = false;
   }


### PR DESCRIPTION
This is obviously a bit of a strawman to start a discussion.

With this change, `TextInput._onChange` can be called and update `_lastNativeText` properly.

Without this change, it doesn't get updated. Which leaves the next `componentDidUpdate` to call `setNativeProps({text:...})` again unnecessarily, which (I believe) is triggering a re-layout, and triggering `componentDidUpdate`, leading to this cycling in the event loop that makes the Android app slower for me.

The question is, why don't we want the callbacks called when we update the text from JS? Because that's exactly what `TextInput._onChange` is expecting.

I'm a bit unclear why calling `setNativeProps({text:...})` triggers another call to `componentDidUpdate`. I did a bunch of tracing and debugging and have a skeleton of who-calls-what I can share, if you're interested. But I'm pretty clueless on the layout logic stuff and suspect it's related to that somehow.
