### PR TITLE
websocket: throw an error rather than crash if specify invalid url

### DIFF
--- a/Libraries/WebSocket/WebSocket.js
+++ b/Libraries/WebSocket/WebSocket.js
@@ -92,6 +92,10 @@ class WebSocket extends EventTarget(...WEBSOCKET_EVENTS) {
       protocols = null;
     }
 
+    if (!/^wss?:\/\//.test(url)) {
+      throw new Error(`The URL '${url}' is invalid.`);
+    }
+
     this._eventEmitter = new NativeEventEmitter(RCTWebSocketModule);
     this._socketId = nextWebSocketId++;
     RCTWebSocketModule.connect(url, protocols, options, this._socketId);

--- a/Libraries/WebSocket/__tests__/WebSocket-test.js
+++ b/Libraries/WebSocket/__tests__/WebSocket-test.js
@@ -22,4 +22,9 @@ describe('WebSocket', function() {
     expect(new WebSocket('wss://echo.websocket.org').CONNECTING).toEqual(0);
   });
 
+  it('should throw an error if specify invalid url', () => {
+    const url = 'invalid url';
+    expect(() => new WebSocket(url)).toThrowError(`The URL '${url}' is invalid.`);
+  });
+
 });


### PR DESCRIPTION
Following code will cause app crash:

``` js
new WebSocket('an URL not startswith ws/wss/http/https');
```

The problem caused by https://github.com/facebook/react-native/blob/master/Libraries/WebSocket/RCTSRWebSocket.m#L318. There is no any checks before the native assert, will caused app crashed.
I add check on WebSocket's constructor, will throw an error if specify invalid url.

**Test plan (required)**
I've add test case.
