### PR TITLE
Fix ENOENT when react-native init with --verbose on Windows

### DIFF
--- a/react-native-cli/index.js
+++ b/react-native-cli/index.js
@@ -230,7 +230,7 @@ function run(root, projectName, rnPackage) {
 }
 
 function runVerbose(root, projectName, rnPackage) {
-  var proc = spawn('npm', ['install', '--verbose', '--save', '--save-exact', getInstallPackage(rnPackage)], {stdio: 'inherit'});
+  var proc = spawn(/^win/.test(process.platform) ? 'npm.cmd' : 'npm', ['install', '--verbose', '--save', '--save-exact', getInstallPackage(rnPackage)], {stdio: 'inherit'});
   proc.on('close', function (code) {
     if (code !== 0) {
       console.error('`npm install --save --save-exact react-native` failed');


### PR DESCRIPTION
As PR #5171 was reverted in 521bd03f0a94df35e21d368a3416599f5f01f5dc for breaking reason, ENOENT again in issues #5169 , this commit fix it ref to https://github.com/nodejs/node-v0.x-archive/issues/2318#issuecomment-249355505 , and this is the smallest change in file to fix such Windows platform specific bug @tdzl2003 @mkonicek @snowdream @sunnylqm 