### PR TITLE
[Android] Make ReactWebView & Client protected

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebViewManager.java
@@ -89,7 +89,7 @@ public class ReactWebViewManager extends SimpleViewManager<WebView> {
   private WebViewConfig mWebViewConfig;
   private @Nullable WebView.PictureListener mPictureListener;
 
-  private static class ReactWebViewClient extends WebViewClient {
+  protected static class ReactWebViewClient extends WebViewClient {
 
     private boolean mLastLoadFailed = false;
 
@@ -187,7 +187,7 @@ public class ReactWebViewManager extends SimpleViewManager<WebView> {
    * Subclass of {@link WebView} that implements {@link LifecycleEventListener} interface in order
    * to call {@link WebView#destroy} on activty destroy event and also to clear the client
    */
-  private static class ReactWebView extends WebView implements LifecycleEventListener {
+  protected static class ReactWebView extends WebView implements LifecycleEventListener {
     private @Nullable String injectedJS;
 
     /**


### PR DESCRIPTION
I'd like to make `ReactWebView` and `ReactWebViewClient` `protected` instead of `private`, inside the `ReactWebViewManager` class. The reason being that if you extend the `ReactWebViewManager` it'll be much easier to override existing logic.  

In my specific case I'd like to be able to override [shouldOverrideUrlLoading](https://github.com/facebook/react-native/blob/master/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebViewManager.java#L120) inside `ReactWebViewClient` and handle custom URL schemes differently. See #10055.
