### PR TITLE
Fix documentations to build application in production

### DIFF
--- a/docs/RunningOnDeviceIOS.md
+++ b/docs/RunningOnDeviceIOS.md
@@ -24,7 +24,7 @@ In Xcode, select your phone as build target and press "Build and run"
 
 You have built a great app using React Native, and you are now itching to release it in the App Store. The process is the same as any other native iOS app, with some additional considerations to take into account.
 
-Building an app for distribution in the App Store requires using the `Release` scheme in Xcode. To do this, go to `Project -> Scheme -> Edit Scheme (cmd + <)`, make sure you're in the `Run` tab from the side, and set the Build Configuration dropdown to `release`.
+Building an app for distribution in the App Store requires using the `Release` scheme in Xcode. To do this, go to `Product -> Scheme -> Edit Scheme (cmd + <)`, make sure you're in the `Run` tab from the side, and set the Build Configuration dropdown to `release`.
 
 Apps built for `Release` will automatically disable the in-app developer menu, which will prevent your users from inadvertently accessing the menu in production. It will also load the JavaScript locally, so you can put the app on a device and test whilst not connected to the computer.
 


### PR DESCRIPTION
The Xcode menu where you can `Edit Scheme` is called `Product` and not `Project`.

![capture d ecran 2016-09-26 a 12 20 30](https://cloud.githubusercontent.com/assets/1385737/18830997/a385fbfe-83e3-11e6-9a03-ef542b3da00d.png)

