### PR TITLE
Emit `willfocus` from immediatelyResetRouteStack

### DIFF
--- a/Libraries/CustomComponents/Navigator/Navigator.js
+++ b/Libraries/CustomComponents/Navigator/Navigator.js
@@ -484,6 +484,7 @@ var Navigator = React.createClass({
    */
   immediatelyResetRouteStack: function(nextRouteStack) {
     var destIndex = nextRouteStack.length - 1;
+    this._emitWillFocus(nextRouteStack[destIndex]);
     this.setState({
       routeStack: nextRouteStack,
       sceneConfigStack: nextRouteStack.map(


### PR DESCRIPTION
The Navigator component inconsistently emits the `willfocus` event.

While it is emitted in `Navigator#resetTo`, `Navigator#push`, `Navigator#pop` and event `Navigator#replaceAtIndex` it is not emitted from `Navigator#immediatelyResetRouteStack`. This leads to surprising inconsistencies when working with these events.

With the PR I suggest to emit the `willfocus` event before resetting the route stack.