### PR TITLE
Use strong reference in RCTImageLoader

### DIFF
--- a/Libraries/Image/RCTImageLoader.m
+++ b/Libraries/Image/RCTImageLoader.m
@@ -553,7 +553,7 @@ static UIImage *RCTResizeImageIfNeeded(UIImage *image,
       completionBlock(error_, image);
     };
 
-    cancelLoad = [weakSelf decodeImageData:imageOrData
+    cancelLoad = [strongSelf decodeImageData:imageOrData
                                       size:size
                                      scale:scale
                                    clipped:clipped


### PR DESCRIPTION
This PR is related to the multitude of crashes (#10016, #9751, #9882).

From my understanding, we should be using a strong reference when calling `decodeImageData` or we could be calling the method on a deallocated instance.

PR #9751 have mitigated this by adding a fail-safe, but I think the culprint is the weak reference, which this PR fixes.

Tested on iOS only, since it doesn't touch Android.