### PR TITLE
Fixes babel-register for Windows paths

### DIFF
--- a/local-cli/cli.js
+++ b/local-cli/cli.js
@@ -13,9 +13,9 @@
 require('./server/checkNodeVersion')();
 
 require('../packager/babelRegisterOnly')([
-  /private-cli\/src/,
+  /private-cli[\/\\]src/,
   /local-cli/,
-  /react-packager\/src/
+  /react-packager[\/\\]src/
 ]);
 
 var cliEntry = require('./cliEntry');


### PR DESCRIPTION
Babel was not compiling anything from react-packager/src when run from Windows, including the recently added node-haste stuff, which has been causing problems for some people. This change fixes that.

Fixes #10033
Fixes #8899
