### PR TITLE
added new property to mock in chalk.js

### DIFF
--- a/local-cli/__mocks__/chalk.js
+++ b/local-cli/__mocks__/chalk.js
@@ -8,26 +8,5 @@
  */
 'use strict';
 
-const mockColor = () => {
-  return {
-    bold: () => { return { }; },
-  };
-};
-
-mockColor.bold = function() {
-  return {};
-};
-
-module.exports = {
-  dim: s =>  s,
-  magenta: mockColor,
-  white: mockColor,
-  blue: mockColor,
-  yellow: mockColor,
-  green: mockColor,
-  bold: mockColor,
-  red: mockColor,
-  cyan: mockColor,
-  gray: mockColor,
-  black: mockColor,
-};
+module.exports =
+  require('../../packager/react-packager/src/Activity/__mocks__/chalk.js');

--- a/packager/react-packager/src/Activity/__mocks__/chalk.js
+++ b/packager/react-packager/src/Activity/__mocks__/chalk.js
@@ -18,6 +18,10 @@ mockColor.bold = function() {
   return {};
 };
 
+mockColor.bgRed = function() {
+  return {};
+};
+
 module.exports = {
   dim: s =>  s,
   magenta: mockColor,


### PR DESCRIPTION
Tests started [failing](https://travis-ci.org/facebook/react-native/jobs/163517412) with release of new  babel that uses chalk.white.bgRed in code.
Jest does not like chalk and needs it mocked.
Removed code duplication and patched the mock.

Test Plan:
npm run test