### PR TITLE
[Docs] Updates Swift @objc export for recent Swift versions

### DIFF
--- a/docs/NativeModulesIOS.md
+++ b/docs/NativeModulesIOS.md
@@ -383,7 +383,8 @@ Let's say we have the same `CalendarManager` but as a Swift class:
 @objc(CalendarManager)
 class CalendarManager: NSObject {
 
-  @objc func addEvent(name: String, location: String, date: NSNumber) -> Void {
+  @objc(addEvent:location:date:)
+  func addEvent(name: String, location: String, date: NSNumber) -> Void {
     // Date is ready to use!
   }
 


### PR DESCRIPTION
As of Swift 3, [Swift converts Objective-C API names based on parameters](https://github.com/apple/swift-evolution/blob/master/proposals/0005-objective-c-name-translation.md), so the docs should explicitly declare what the Objective-C API is (because it's also used in the JavaScript side too).

An alternative to this would be to update the Objective-C and JavaScript calls to be `addEventWithName:location:date:` / `addEventWithName()` based on the default Swift API, but I think the approach in the PR is most correct here.