### PR TITLE
Remove missing link from Modal doc

### DIFF
--- a/Libraries/Modal/Modal.js
+++ b/Libraries/Modal/Modal.js
@@ -27,7 +27,7 @@ const RCTModalHostView = requireNativeComponent('RCTModalHostView', null);
  * The Modal component is a simple way to present content above an enclosing view.
  *
  * _Note: If you need more control over how to present modals over the rest of your app,
- * then consider using a top-level Navigator. Go [here](/react-native/docs/navigator-comparison.html) to compare navigation options._
+ * then consider using a top-level Navigator._
  *
  * ```javascript
  * import React, { Component } from 'react';


### PR DESCRIPTION
Is okay to remove this link? It seems that we don't have the Navigator Comparison anymore.