### PR TITLE
[Docs] Maintain whitespace in propType documentation

### DIFF
--- a/website/src/react-native/css/react-native.css
+++ b/website/src/react-native/css/react-native.css
@@ -1262,6 +1262,7 @@ div[data-twttr-id] iframe {
 .propType {
   font-weight: normal;
   font-size: 15px;
+  white-space: pre;
 }
 
 .compactProps .propType {


### PR DESCRIPTION
When looking at PropType information for certain props the formatting puts everything on one line which makes it quite hard to read. This PR ensures that the whitespace extracted from react-docgen is preserved.

For example the documentation for [Transforms](http://facebook.github.io/react-native/releases/0.34/docs/transforms.html#transform) goes from:

<img width="717" alt="screenshot 2016-10-01 17 32 23" src="https://cloud.githubusercontent.com/assets/691952/19015498/74aaa5c8-87fd-11e6-922d-3eef38cc6452.png">

to:

<img width="707" alt="screenshot 2016-10-01 17 32 30" src="https://cloud.githubusercontent.com/assets/691952/19015500/784521a4-87fd-11e6-9c23-717d1ee31921.png">

**Test plan:**

Check PropType documentation is being rendered correctly on other components. 

**N.B.** more style tweaks could be made here to make things more readable (e.g. reducing line height, monospace font) but I'll refrain from making them here in case there are explicit designs for the docs.
