### PR TITLE
Fix rest operator syntax errors

### DIFF
--- a/Libraries/BatchedBridge/BatchedBridgedModules/NativeModules.js
+++ b/Libraries/BatchedBridge/BatchedBridgedModules/NativeModules.js
@@ -108,7 +108,7 @@ function arrayContains<T>(array: Array<T>, value: T): boolean {
 function createErrorFromErrorData(errorData: {message: string}): Error {
   const {
     message,
-    ...extraErrorInfo,
+    ...extraErrorInfo
   } = errorData;
   const error = new Error(message);
   (error:any).framesToPop = 1;

--- a/Libraries/CustomComponents/ListView/ListView.js
+++ b/Libraries/CustomComponents/ListView/ListView.js
@@ -454,7 +454,7 @@ var ListView = React.createClass({
 
     var {
       renderScrollComponent,
-      ...props,
+      ...props
     } = this.props;
     if (!props.scrollEventThrottle) {
       props.scrollEventThrottle = DEFAULT_SCROLL_CALLBACK_THROTTLE;

--- a/Libraries/CustomComponents/NavigationExperimental/NavigationCard.js
+++ b/Libraries/CustomComponents/NavigationExperimental/NavigationCard.js
@@ -82,7 +82,7 @@ class NavigationCard extends React.Component<any, Props, any> {
       pointerEvents,
       renderScene,
       style,
-      ...props, /* NavigationSceneRendererProps */
+      ...props /* NavigationSceneRendererProps */
     } = this.props;
 
     const viewStyle = style === undefined ?


### PR DESCRIPTION
These are caused by new [syntax checking](https://github.com/babel/babylon/blob/1285131e3eb28ab6f5f62a7c5fd3ffd7ce1e5eb8/CHANGELOG.md#v6113-2016-10-01) introduced by babylon.

"The single rest at the end only applies to binding `let { x, ...y } = obj;` and assignment `({ x, ...y } = obj).`"

I'd say this really should be cherry picked into the stable branch.

**Test plan**
1. install babylon@6.11.3
2. see that things break
3. apply patch
4. things work
5. make sure all instances were fixed (I used `\.\.\..*,.*\n.*=` in IntelliJ regex format—find all ... followed by newline followed by =)


Issue #10199