### PR TITLE
CLI errors if no package.json is found

### DIFF
--- a/local-cli/android/android.js
+++ b/local-cli/android/android.js
@@ -25,8 +25,14 @@ module.exports = {
   func: android,
   options: [{
     command: '--project-name [name]',
-    default: () => JSON.parse(
-      fs.readFileSync('package.json', 'utf8')
-    ).name,
+    default: () => {
+      try {
+        return JSON.parse(
+          fs.readFileSync('package.json', 'utf8')
+        ).name
+      } catch (e) {
+        return 'my-react-native-app'
+      }
+    },
   }],
 };

--- a/local-cli/android/android.js
+++ b/local-cli/android/android.js
@@ -31,7 +31,7 @@ module.exports = {
           fs.readFileSync('package.json', 'utf8')
         ).name
       } catch (e) {
-        return 'my-react-native-app'
+        return 'unknown-app-name'
       }
     },
   }],


### PR DESCRIPTION
If you don't have a `package.json` in your project you can't do anything with the cli as it errors. This fixes that by wrapping the reading of the `package.json` file and returns `my-react-native-app` if an error is caught.