### PR TITLE
Expose IOS version in platform js

### DIFF
--- a/React/Modules/RCTIOSConstants.h
+++ b/React/Modules/RCTIOSConstants.h
@@ -5,17 +5,10 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
- *
- * @providesModule Platform
- * @flow
  */
 
-'use strict';
+#import <UIKit/UIKit.h>
+#import "RCTBridgeModule.h"
 
-var Platform = {
-  OS: 'ios',
-  get Version() { return require('NativeModules').IOSConstants.Version; },
-  select: (obj: Object) => obj.ios,
-};
-
-module.exports = Platform;
+@interface IOSConstants : NSObject <RCTBridgeModule>
+@end

--- a/React/Modules/RCTIOSConstants.m
+++ b/React/Modules/RCTIOSConstants.m
@@ -5,17 +5,18 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
- *
- * @providesModule Platform
- * @flow
  */
 
-'use strict';
+#import "RCTIOSConstants.h"
 
-var Platform = {
-  OS: 'ios',
-  get Version() { return require('NativeModules').IOSConstants.Version; },
-  select: (obj: Object) => obj.ios,
-};
+@implementation IOSConstants
 
-module.exports = Platform;
+RCT_EXPORT_MODULE();
+
+- (NSDictionary *)constantsToExport
+{
+  NSString *Version = [[UIDevice currentDevice] systemVersion];
+  return @{ @"Version": Version };
+}
+
+@end

--- a/React/React.xcodeproj/project.pbxproj
+++ b/React/React.xcodeproj/project.pbxproj
@@ -103,6 +103,7 @@
 		83CBBA981A6020BB00E9B192 /* RCTTouchHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 83CBBA971A6020BB00E9B192 /* RCTTouchHandler.m */; };
 		83CBBACC1A6023D300E9B192 /* RCTConvert.m in Sources */ = {isa = PBXBuildFile; fileRef = 83CBBACB1A6023D300E9B192 /* RCTConvert.m */; };
 		85C199EE1CD2407900DAD810 /* RCTJSCWrapper.mm in Sources */ = {isa = PBXBuildFile; fileRef = 85C199ED1CD2407900DAD810 /* RCTJSCWrapper.mm */; };
+		974DD8D21DA0A8A4005F11C7 /* RCTIOSConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = 974DD8D11DA0A8A4005F11C7 /* RCTIOSConstants.m */; };
 		B233E6EA1D2D845D00BC68BA /* RCTI18nManager.m in Sources */ = {isa = PBXBuildFile; fileRef = B233E6E91D2D845D00BC68BA /* RCTI18nManager.m */; };
 		B95154321D1B34B200FE7B80 /* RCTActivityIndicatorView.m in Sources */ = {isa = PBXBuildFile; fileRef = B95154311D1B34B200FE7B80 /* RCTActivityIndicatorView.m */; };
 		E9B20B7B1B500126007A2DA7 /* RCTAccessibilityManager.m in Sources */ = {isa = PBXBuildFile; fileRef = E9B20B7A1B500126007A2DA7 /* RCTAccessibilityManager.m */; };
@@ -334,6 +335,8 @@
 		83F15A171B7CC46900F10295 /* UIView+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIView+Private.h"; sourceTree = "<group>"; };
 		85C199EC1CD2407900DAD810 /* RCTJSCWrapper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTJSCWrapper.h; sourceTree = "<group>"; };
 		85C199ED1CD2407900DAD810 /* RCTJSCWrapper.mm */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.objcpp; fileEncoding = 4; path = RCTJSCWrapper.mm; sourceTree = "<group>"; };
+		974DD8D11DA0A8A4005F11C7 /* RCTIOSConstants.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTIOSConstants.m; sourceTree = "<group>"; };
+		974DD8D31DA0A8C8005F11C7 /* RCTIOSConstants.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RCTIOSConstants.h; sourceTree = "<group>"; };
 		ACDD3FDA1BC7430D00E7DE33 /* RCTBorderStyle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTBorderStyle.h; sourceTree = "<group>"; };
 		B233E6E81D2D843200BC68BA /* RCTI18nManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTI18nManager.h; sourceTree = "<group>"; };
 		B233E6E91D2D845D00BC68BA /* RCTI18nManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTI18nManager.m; sourceTree = "<group>"; };
@@ -418,6 +421,8 @@
 				13B07FEE1A69327A00A75B9A /* RCTTiming.m */,
 				13E067481A70F434002CDEE1 /* RCTUIManager.h */,
 				13E067491A70F434002CDEE1 /* RCTUIManager.m */,
+				974DD8D11DA0A8A4005F11C7 /* RCTIOSConstants.m */,
+				974DD8D31DA0A8C8005F11C7 /* RCTIOSConstants.h */,
 			);
 			path = Modules;
 			sourceTree = "<group>";
@@ -765,6 +770,7 @@
 				14F3620D1AABD06A001CE568 /* RCTSwitch.m in Sources */,
 				3D1E68DB1CABD13900DD7465 /* RCTDisplayLink.m in Sources */,
 				14F3620E1AABD06A001CE568 /* RCTSwitchManager.m in Sources */,
+				974DD8D21DA0A8A4005F11C7 /* RCTIOSConstants.m in Sources */,
 				13B080201A69489C00A75B9A /* RCTActivityIndicatorViewManager.m in Sources */,
 				13E067561A70F44B002CDEE1 /* RCTViewManager.m in Sources */,
 				13BB3D021BECD54500932C10 /* RCTImageSource.m in Sources */,


### PR DESCRIPTION
Currently for Android the version is already exposed in the platform js file.
This change will expose it for IOS in the same way and thus makes it consistent.

Related issue: #10149

**Test plan (required)**
1. Create example app
2. Print ios version using Platform.Version
3. Run app `react-native run-ios` (in this case it's IOS 10 emulator)
4. See `10.0` printed
