### PR TITLE
Allow image to be passed to NavigationHeader.BackButton

### DIFF
--- a/Libraries/CustomComponents/NavigationExperimental/NavigationHeaderBackButton.js
+++ b/Libraries/CustomComponents/NavigationExperimental/NavigationHeaderBackButton.js
@@ -40,12 +40,13 @@ type Props = {
 
 const NavigationHeaderBackButton = (props: Props) => (
   <TouchableOpacity style={styles.buttonContainer} onPress={props.onPress}>
-    <Image style={styles.button} source={require('./assets/back-icon.png')} />
+    {image ? image : <Image style={styles.button} source={require('./assets/back-icon.png')} />}
   </TouchableOpacity>
 );
 
 NavigationHeaderBackButton.propTypes = {
-  onPress: React.PropTypes.func.isRequired
+  onPress: React.PropTypes.func.isRequired,
+  image: React.PropTypes.object
 };
 
 const styles = StyleSheet.create({


### PR DESCRIPTION
Consumer should allow image to be passed when specifying `NavigationHeader.BackButton` such as the following...

```
	_renderLeftComponent(props,backAction){
		return (
			<NavigationHeader.BackButton
				onPress={backAction}
				image={this._renderBackButtonImage()}
			/>
		);
	 }

       _renderBackButtonImage(){
                return (
                         <Image source={require('./custom-back-icon.png')} />
                )
      }
```