### PR TITLE
ignore all keystore files

### DIFF
--- a/local-cli/generator/templates/_gitignore
+++ b/local-cli/generator/templates/_gitignore
@@ -38,4 +38,4 @@ npm-debug.log
 buck-out/
 \.buckd/
 android/app/libs
-android/keystores/debug.keystore
+*.keystore


### PR DESCRIPTION
Ignore all keystore files as we do not want users to accidentally check in their keystore file.
