### PR TITLE
adding check for NODE_PATH env variable for node-haste

### DIFF
--- a/packager/react-packager/src/node-haste/DependencyGraph/ResolutionRequest.js
+++ b/packager/react-packager/src/node-haste/DependencyGraph/ResolutionRequest.js
@@ -375,6 +375,10 @@ class ResolutionRequest {
             }
           }
 
+          if (process.env.NODE_PATH) {
+            searchQueue.push(path.join(process.env.NODE_PATH, realModuleName));
+          }
+
           let p = Promise.reject(new UnableToResolveError(fromModule, toModuleName));
           searchQueue.forEach(potentialModulePath => {
             p = this._tryResolve(


### PR DESCRIPTION
I had this open PR at node-haste https://github.com/facebookarchive/node-haste/pull/75 but was told it's actively developed on any more and now you guys have merged it into the react-native repo (I assume this is temporary, would love to hear your future plans for this) could we get this merged in? It's a simple one that adds the NODE_PATH env variable (if it exists) to the search queue.

`From the ticket:`
Node JS allows you to specify a NODE_PATH env variable, this allows you to require things from directories that are not in the project path.

We use this in our node projects and in React Native to tell it to get the modules from our_project/third_party/js. Now that react-native has react as a peer dependency we are running into issues where node-haste will only look for react in node_modules folders and miss out third_party/js completely.
