### PR TITLE
Make sure xhr req header's value is String type

### DIFF
--- a/Libraries/Network/XMLHttpRequest.js
+++ b/Libraries/Network/XMLHttpRequest.js
@@ -352,7 +352,7 @@ class XMLHttpRequest extends EventTarget(...XHR_EVENTS) {
     if (this.readyState !== this.OPENED) {
       throw new Error('Request has not been opened');
     }
-    this._headers[header.toLowerCase()] = value;
+    this._headers[header.toLowerCase()] = String(value);
   }
 
   /**


### PR DESCRIPTION
In the `NetworkingModule.java`, `header.getString(1)` was
called, so the value must be String type.

FIX #10198