### PR TITLE
[Docs] Use HTML for links including closing bracket

### DIFF
--- a/docs/IntegrationWithExistingApps.md
+++ b/docs/IntegrationWithExistingApps.md
@@ -103,11 +103,11 @@ $ sudo gem install cocoapods
 
 <block class="objc" />
 
-Assume the [app for integration](https://github.com/JoelMarcey/iOS-2048) is a [2048](https://en.wikipedia.org/wiki/2048_(video_game)) game. Here is what the main menu of the native application looks like without React Native.
+Assume the [app for integration](https://github.com/JoelMarcey/iOS-2048) is a <a href="https://en.wikipedia.org/wiki/2048_(video_game)">2048</a> game. Here is what the main menu of the native application looks like without React Native.
 
 <block class="swift" />
 
-Assume the [app for integration](https://github.com/JoelMarcey/swift-2048) is a [2048](https://en.wikipedia.org/wiki/2048_(video_game) game. Here is what the main menu of the native application looks like without React Native.
+Assume the [app for integration](https://github.com/JoelMarcey/swift-2048) is a <a href="https://en.wikipedia.org/wiki/2048_(video_game)">2048</a> game. Here is what the main menu of the native application looks like without React Native.
 
 <block class="objc swift" />
 


### PR DESCRIPTION
The markdown parser (Marked) used by the docs doesn't handle links ending with a closing bracket. The result is a broken link in the [Integration With Existing Apps](http://facebook.github.io/react-native/docs/integration-with-existing-apps.html#our-sample-app) guide.


Using HTML makes the parser ignoring these links.

Note: this is a well-known issue of Marked: https://github.com/chjj/marked/issues/690
Note bis: The fix #9429 didn't solve the problem.