### PR TITLE
Fix variable assignment in ScrollView example

### DIFF
--- a/Examples/UIExplorer/js/ScrollViewExample.js
+++ b/Examples/UIExplorer/js/ScrollViewExample.js
@@ -41,7 +41,7 @@ exports.examples = [
   title: '<ScrollView>',
   description: 'To make content scrollable, wrap it within a <ScrollView> component',
   render: function() {
-    var _scrollView: ScrollView;
+    var _scrollView = ScrollView;
     return (
       <View>
         <ScrollView
@@ -64,7 +64,7 @@ exports.examples = [
   title: '<ScrollView> (horizontal = true)',
   description: 'You can display <ScrollView>\'s child components horizontally rather than vertically',
   render: function() {
-    var _scrollView: ScrollView;
+    var _scrollView = ScrollView;
     return (
       <View>
         <ScrollView


### PR DESCRIPTION
Pretty self explanatory.

A "class like" assignment slipped in the examples, instead of good ol' `=`
