### PR TITLE
Allow code to check android permissions when run from a Service as well as Activity

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/modules/permissions/PermissionsModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/permissions/PermissionsModule.java
@@ -10,6 +10,7 @@
 package com.facebook.react.modules.permissions;
 
 import android.app.Activity;
+import android.content.Context;
 import android.content.pm.PackageManager;
 import android.os.Build;
 import android.os.Process;
@@ -49,13 +50,13 @@ public class PermissionsModule extends ReactContextBaseJavaModule implements Per
    */
   @ReactMethod
   public void checkPermission(final String permission, final Promise promise) {
-    PermissionAwareActivity activity = getPermissionAwareActivity();
+    Context context = getReactApplicationContext().getBaseContext();
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
-      promise.resolve(activity.checkPermission(permission, Process.myPid(), Process.myUid()) ==
+      promise.resolve(context.checkPermission(permission, Process.myPid(), Process.myUid()) ==
         PackageManager.PERMISSION_GRANTED);
       return;
     }
-    promise.resolve(activity.checkSelfPermission(permission) == PackageManager.PERMISSION_GRANTED);
+    promise.resolve(context.checkSelfPermission(permission) == PackageManager.PERMISSION_GRANTED);
   }
 
   /**
@@ -83,13 +84,13 @@ public class PermissionsModule extends ReactContextBaseJavaModule implements Per
    */
   @ReactMethod
   public void requestPermission(final String permission, final Promise promise) {
-    PermissionAwareActivity activity = getPermissionAwareActivity();
+    Context context = getReactApplicationContext().getBaseContext();
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
-      promise.resolve(activity.checkPermission(permission, Process.myPid(), Process.myUid()) ==
+      promise.resolve(context.checkPermission(permission, Process.myPid(), Process.myUid()) ==
               PackageManager.PERMISSION_GRANTED);
       return;
     }
-    if (activity.checkSelfPermission(permission) == PackageManager.PERMISSION_GRANTED) {
+    if (context.checkSelfPermission(permission) == PackageManager.PERMISSION_GRANTED) {
       promise.resolve(true);
       return;
     }
@@ -102,6 +103,7 @@ public class PermissionsModule extends ReactContextBaseJavaModule implements Per
           }
         });
 
+    PermissionAwareActivity activity = getPermissionAwareActivity();
     activity.requestPermissions(new String[]{permission}, mRequestCode, this);
     mRequestCode++;
   }


### PR DESCRIPTION
This allows the React JS code that's running from a Service (ie GcmListenerService) to check permissions (ie check for VIBRATE permissions before delivering notifications)

**Test plan (required)**

I've run this code from a GcmListenerService subclass, and it works correctly.

