### PR TITLE
Apple TV support 3: support for input (tvOS focus engine)

### DIFF
--- a/Examples/UIExplorer/UIExplorerUnitTests/RCTAllocationTests.m
+++ b/Examples/UIExplorer/UIExplorerUnitTests/RCTAllocationTests.m
@@ -213,7 +213,10 @@ RCT_EXPORT_METHOD(test:(__unused NSString *)a
     (void)rootView;
   }
 
+#if !TARGET_OS_TV // userInteractionEnabled is true for Apple TV views
   XCTAssertFalse(rootContentView.userInteractionEnabled, @"RCTContentView should have been invalidated");
+#endif
+
 }
 
 - (void)testUnderlyingBridgeIsDeallocated

--- a/Libraries/Components/Navigation/NavigatorIOS.ios.js
+++ b/Libraries/Components/Navigation/NavigatorIOS.ios.js
@@ -893,9 +893,15 @@ var NavigatorIOS = React.createClass({
     );
   },
 
+  _handleTVEvent(evt: Object): void {
+    if(evt && evt.nativeEvent && evt.nativeEvent.eventType === "menu") {
+      this.pop();
+    }
+  },
+  
   render: function() {
     return (
-      <View style={this.props.style}>
+      <View style={this.props.style} onTVNavEvent={(evt) => this._handleTVEvent(evt)}>
         {this._renderNavigationStackItems()}
       </View>
     );

--- a/Libraries/Components/Navigation/NavigatorIOS.ios.js
+++ b/Libraries/Components/Navigation/NavigatorIOS.ios.js
@@ -894,11 +894,11 @@ var NavigatorIOS = React.createClass({
   },
 
   _handleTVEvent(evt: Object): void {
-    if(evt && evt.nativeEvent && evt.nativeEvent.eventType === "menu") {
+    if (evt && evt.nativeEvent && evt.nativeEvent.eventType === 'menu') {
       this.pop();
     }
   },
-  
+
   render: function() {
     return (
       <View style={this.props.style} onTVNavEvent={(evt) => this._handleTVEvent(evt)}>

--- a/Libraries/Components/TabBarIOS/TabBarIOS.ios.js
+++ b/Libraries/Components/TabBarIOS/TabBarIOS.ios.js
@@ -27,6 +27,9 @@ class TabBarIOS extends React.Component {
     barTintColor?: $FlowFixMe,
     translucent?: boolean,
     itemPositioning?: 'fill' | 'center' | 'auto',
+    onTVFocus?: $FlowFixMe,
+    onTVBlur?: $FlowFixMe,
+    onTVNavEvent?: $FlowFixMe,
   };
 
   static Item = TabBarItemIOS;
@@ -60,6 +63,10 @@ class TabBarIOS extends React.Component {
      * it defaults to center.
      */
     itemPositioning: React.PropTypes.oneOf(['fill', 'center', 'auto']),
+
+    onTVFocus: React.PropTypes.func,
+    onTVBlur: React.PropTypes.func,
+    onTVNavEvent: React.PropTypes.func
   };
 
   render() {
@@ -70,7 +77,10 @@ class TabBarIOS extends React.Component {
         tintColor={this.props.tintColor}
         barTintColor={this.props.barTintColor}
         itemPositioning={this.props.itemPositioning}
-        translucent={this.props.translucent !== false}>
+        translucent={this.props.translucent !== false}
+        onTVFocus={this.props.onTVFocus}
+        onTVBlur={this.props.onTVBlur}
+        onTVNavEvent={this.props.onTVNavEvent}>
         {
           // $FlowFixMe found when converting React.createClass to ES6
           this.props.children}

--- a/Libraries/Components/TabBarIOS/TabBarItemIOS.ios.js
+++ b/Libraries/Components/TabBarIOS/TabBarItemIOS.ios.js
@@ -81,6 +81,11 @@ class TabBarItemIOS extends React.Component {
      * is defined.
      */
     title: React.PropTypes.string,
+
+    onTVSelect: React.PropTypes.func,
+    onTVFocus: React.PropTypes.func,
+    onTVBlur: React.PropTypes.func,
+    onTVNavEvent: React.PropTypes.func
   };
 
   state = {

--- a/Libraries/Components/Touchable/TouchableHighlight.js
+++ b/Libraries/Components/Touchable/TouchableHighlight.js
@@ -34,6 +34,11 @@ type Event = Object;
 var DEFAULT_PROPS = {
   activeOpacity: 0.85,
   underlayColor: 'black',
+  tvParallaxDisable: false,
+  tvParallaxShiftDistanceX: 2.0,
+  tvParallaxShiftDistanceY: 2.0,
+  tvParallaxTiltAngle: 0.05,
+  tvParallaxMagnification: 1.0
 };
 
 var PRESS_RETENTION_OFFSET = {top: 20, left: 20, right: 20, bottom: 30};
@@ -87,6 +92,37 @@ var TouchableHighlight = React.createClass({
      * Called immediately after the underlay is hidden
      */
     onHideUnderlay: React.PropTypes.func,
+    /**
+     * *(Apple TV only)* TV preferred focus (see documentation for the View component).
+     */
+    hasTVPreferredFocus: React.PropTypes.bool,
+
+    /**
+     * *(Apple TV only)* Set this to true to disable Apple TV parallax effects when this view goes in or out of focus.
+     */
+    tvParallaxDisable: React.PropTypes.bool,
+
+    /**
+     * *(Apple TV only)* May be used to change the appearance of the Apple TV parallax effect when this view goes in or out of focus.  Defaults to 2.0.
+     */
+    tvParallaxShiftDistanceX: React.PropTypes.number,
+
+    /**
+     * *(Apple TV only)* May be used to change the appearance of the Apple TV parallax effect when this view goes in or out of focus.  Defaults to 2.0.
+     */
+    tvParallaxShiftDistanceY: React.PropTypes.number,
+
+    /**
+     * *(Apple TV only)* May be used to change the appearance of the Apple TV parallax effect when this view goes in or out of focus.  Defaults to 0.05.
+     */
+    tvParallaxTiltAngle: React.PropTypes.number,
+
+    /**
+     * *(Apple TV only)* May be used to change the appearance of the Apple TV parallax effect when this view goes in or out of focus.  Defaults to 1.0.
+     */
+    tvParallaxMagnification: React.PropTypes.number,
+
+
   },
 
   mixins: [NativeMethodsMixin, TimerMixin, Touchable.Mixin],
@@ -109,7 +145,8 @@ var TouchableHighlight = React.createClass({
       underlayStyle: [
         INACTIVE_UNDERLAY_PROPS.style,
         props.style,
-      ]
+      ],
+      hasTVPreferredFocus: props.hasTVPreferredFocus
     };
   },
 
@@ -235,6 +272,15 @@ var TouchableHighlight = React.createClass({
         style={this.state.underlayStyle}
         onLayout={this.props.onLayout}
         hitSlop={this.props.hitSlop}
+        onTVSelect={this.props.onPress}
+        onTVFocus={this._showUnderlay}
+        onTVBlur={this._hideUnderlay}
+        tvParallaxDisable={this.props.tvParallaxDisable}
+        tvParallaxShiftDistanceX={this.props.tvParallaxShiftDistanceX}
+        tvParallaxShiftDistanceY={this.props.tvParallaxShiftDistanceY}
+        tvParallaxTiltAngle={this.props.tvParallaxTiltAngle}
+        tvParallaxMagnification={this.props.tvParallaxMagnification}
+        hasTVPreferredFocus={this.state.hasTVPreferredFocus}
         onStartShouldSetResponder={this.touchableHandleStartShouldSetResponder}
         onResponderTerminationRequest={this.touchableHandleResponderTerminationRequest}
         onResponderGrant={this.touchableHandleResponderGrant}

--- a/Libraries/Components/Touchable/TouchableOpacity.js
+++ b/Libraries/Components/Touchable/TouchableOpacity.js
@@ -58,11 +58,26 @@ var TouchableOpacity = React.createClass({
      * active. Defaults to 0.2.
      */
     activeOpacity: React.PropTypes.number,
+    focusedOpacity: React.PropTypes.number,
+    /**
+     * Apple TV parallax effects
+     */
+    tvParallaxDisable: React.PropTypes.bool,
+    tvParallaxShiftDistanceX: React.PropTypes.number,
+    tvParallaxShiftDistanceY: React.PropTypes.number,
+    tvParallaxTiltAngle: React.PropTypes.number,
+    tvParallaxMagnification: React.PropTypes.number,
   },
 
   getDefaultProps: function() {
     return {
       activeOpacity: 0.2,
+      focusedOpacity: 0.7,
+      tvParallaxDisable: false,
+      tvParallaxShiftDistanceX: 2.0,
+      tvParallaxShiftDistanceY: 2.0,
+      tvParallaxTiltAngle: 0.05,
+      tvParallaxMagnification: 1.0
     };
   },
 
@@ -157,6 +172,10 @@ var TouchableOpacity = React.createClass({
     );
   },
 
+  _opacityFocused: function() {
+    this.setOpacityTo(this.props.focusedOpacity);
+  },
+
   render: function() {
     return (
       <Animated.View
@@ -167,6 +186,14 @@ var TouchableOpacity = React.createClass({
         style={[this.props.style, {opacity: this.state.anim}]}
         testID={this.props.testID}
         onLayout={this.props.onLayout}
+        onTVSelect={this.props.onPress}
+        onTVFocus={this._opacityFocused}
+        onTVBlur={this._opacityInactive}
+        tvParallaxDisable={this.props.tvParallaxDisable}
+        tvParallaxShiftDistanceX={this.props.tvParallaxShiftDistanceX}
+        tvParallaxShiftDistanceY={this.props.tvParallaxShiftDistanceY}
+        tvParallaxTiltAngle={this.props.tvParallaxTiltAngle}
+        tvParallaxMagnification={this.props.tvParallaxMagnification}
         hitSlop={this.props.hitSlop}
         onStartShouldSetResponder={this.touchableHandleStartShouldSetResponder}
         onResponderTerminationRequest={this.touchableHandleResponderTerminationRequest}

--- a/Libraries/Components/Touchable/__tests__/__snapshots__/TouchableHighlight-test.js.snap
+++ b/Libraries/Components/Touchable/__tests__/__snapshots__/TouchableHighlight-test.js.snap
@@ -4,6 +4,7 @@ exports[`TouchableHighlight renders correctly 1`] = `
   accessibilityLabel={undefined}
   accessibilityTraits={undefined}
   accessible={true}
+  hasTVPreferredFocus={undefined}
   hitSlop={undefined}
   onLayout={undefined}
   onResponderGrant={[Function bound touchableHandleResponderGrant]}
@@ -12,6 +13,9 @@ exports[`TouchableHighlight renders correctly 1`] = `
   onResponderTerminate={[Function bound touchableHandleResponderTerminate]}
   onResponderTerminationRequest={[Function bound touchableHandleResponderTerminationRequest]}
   onStartShouldSetResponder={[Function bound touchableHandleStartShouldSetResponder]}
+  onTVBlur={[Function bound _hideUnderlay]}
+  onTVFocus={[Function bound _showUnderlay]}
+  onTVSelect={undefined}
   style={
     Array [
       Object {
@@ -20,7 +24,12 @@ exports[`TouchableHighlight renders correctly 1`] = `
       Object {}
     ]
   }
-  testID={undefined}>
+  testID={undefined}
+  tvParallaxDisable={false}
+  tvParallaxMagnification={1}
+  tvParallaxShiftDistanceX={2}
+  tvParallaxShiftDistanceY={2}
+  tvParallaxTiltAngle={0.05}>
   <Text>
     Touchable
   </Text>

--- a/Libraries/Components/View/ReactNativeStyleAttributes.js
+++ b/Libraries/Components/View/ReactNativeStyleAttributes.js
@@ -42,6 +42,7 @@ ReactNativeStyleAttributes.borderColor = colorAttributes;
 ReactNativeStyleAttributes.borderLeftColor = colorAttributes;
 ReactNativeStyleAttributes.borderRightColor = colorAttributes;
 ReactNativeStyleAttributes.borderTopColor = colorAttributes;
+ReactNativeStyleAttributes.tvFocusedBorderColor = colorAttributes;
 ReactNativeStyleAttributes.color = colorAttributes;
 ReactNativeStyleAttributes.shadowColor = colorAttributes;
 ReactNativeStyleAttributes.textDecorationColor = colorAttributes;

--- a/Libraries/Components/View/View.js
+++ b/Libraries/Components/View/View.js
@@ -255,6 +255,38 @@ const View = React.createClass({
     onMagicTap: PropTypes.func,
 
     /**
+     * *(Apple TV only)* Optional method.  When implemented, this view will be focusable
+     * and navigable using the Apple TV remote.
+     */
+    onTVSelect: PropTypes.func,
+
+    /**
+     * *(Apple TV only)* Optional method. Will be called if this view comes into focus 
+     * during navigation with the TV remote.  May be used to give the view a different
+     * appearance when focused.
+     */
+    onTVFocus: PropTypes.func,
+
+    /**
+     * *(Apple TV only)* Optional method.  Will be called if this view leaves focus during
+     * navigation with the TV remote.
+     */
+    onTVBlur: PropTypes.func,
+
+    /**
+     * *(Apple TV only)* Optional method.  When implemented, this method will be called when
+     * the user presses a button or makes a swipe gesture on the TV remote.  The event passed
+     * into this method will have a nativeEvent property, with a type that is one of 
+     * [left, right, up, down, playPause, menu].
+     */
+    onTVNavEvent: PropTypes.func,
+
+    /**
+     * *(Apple TV only)* May be set to true to force the Apple TV focus engine to move focus to this view.
+     */
+    hasTVPreferredFocus: PropTypes.bool,
+
+    /**
      * Used to locate this view in end-to-end tests.
      *
      * > This disables the 'layout-only view removal' optimization for this view!
@@ -430,6 +462,31 @@ const View = React.createClass({
      * (or one of its superviews).
      */
     removeClippedSubviews: PropTypes.bool,
+
+    /**
+     * *(Apple TV only)* Set this to true to disable Apple TV parallax effects when this view goes in or out of focus.
+     */
+    tvParallaxDisable: PropTypes.bool,
+
+    /**
+     * *(Apple TV only)* May be used to change the appearance of the Apple TV parallax effect when this view goes in or out of focus.  Defaults to 2.0.
+     */
+    tvParallaxShiftDistanceX: PropTypes.number,
+
+    /**
+     * *(Apple TV only)* May be used to change the appearance of the Apple TV parallax effect when this view goes in or out of focus.  Defaults to 2.0.
+     */
+    tvParallaxShiftDistanceY: PropTypes.number,
+
+    /**
+     * *(Apple TV only)* May be used to change the appearance of the Apple TV parallax effect when this view goes in or out of focus.  Defaults to 0.05.
+     */
+    tvParallaxTiltAngle: PropTypes.number,
+
+    /**
+     * *(Apple TV only)* May be used to change the appearance of the Apple TV parallax effect when this view goes in or out of focus.  Defaults to 1.0.
+     */
+    tvParallaxMagnification: PropTypes.number,
 
     /**
      * Whether this `View` should render itself (and all of its children) into a

--- a/Libraries/Components/View/View.js
+++ b/Libraries/Components/View/View.js
@@ -261,7 +261,7 @@ const View = React.createClass({
     onTVSelect: PropTypes.func,
 
     /**
-     * *(Apple TV only)* Optional method. Will be called if this view comes into focus 
+     * *(Apple TV only)* Optional method. Will be called if this view comes into focus
      * during navigation with the TV remote.  May be used to give the view a different
      * appearance when focused.
      */
@@ -276,7 +276,7 @@ const View = React.createClass({
     /**
      * *(Apple TV only)* Optional method.  When implemented, this method will be called when
      * the user presses a button or makes a swipe gesture on the TV remote.  The event passed
-     * into this method will have a nativeEvent property, with a type that is one of 
+     * into this method will have a nativeEvent property, with a type that is one of
      * [left, right, up, down, playPause, menu].
      */
     onTVNavEvent: PropTypes.func,

--- a/Libraries/Components/View/ViewStylePropTypes.js
+++ b/Libraries/Components/View/ViewStylePropTypes.js
@@ -31,6 +31,7 @@ var ViewStylePropTypes = {
   borderRightColor: ColorPropType,
   borderBottomColor: ColorPropType,
   borderLeftColor: ColorPropType,
+  tvFocusedBorderColor: ColorPropType,
   borderRadius: ReactPropTypes.number,
   borderTopLeftRadius: ReactPropTypes.number,
   borderTopRightRadius: ReactPropTypes.number,

--- a/Libraries/CustomComponents/NavigationExperimental/NavigationHeader.js
+++ b/Libraries/CustomComponents/NavigationExperimental/NavigationHeader.js
@@ -128,6 +128,12 @@ class NavigationHeader extends React.Component<DefaultProps, Props, any> {
     );
   }
 
+  _handleTVEvent(props: NavigationSceneRendererProps, evt: Object): void {
+    if(evt && evt.nativeEvent && evt.nativeEvent.eventType === "menu") {
+      props.onNavigateBack && props.onNavigateBack();
+    }
+  }
+
   render(): ReactElement<any> {
     const { scenes, style, viewProps } = this.props;
 
@@ -147,6 +153,7 @@ class NavigationHeader extends React.Component<DefaultProps, Props, any> {
           { height: barHeight },
           style
         ]}
+        onTVNavEvent={(evt) => this._handleTVEvent(this.props,evt)}
         {...viewProps}
       >
         {scenesProps.map(this._renderLeft, this)}

--- a/Libraries/CustomComponents/NavigationExperimental/NavigationHeader.js
+++ b/Libraries/CustomComponents/NavigationExperimental/NavigationHeader.js
@@ -129,7 +129,7 @@ class NavigationHeader extends React.Component<DefaultProps, Props, any> {
   }
 
   _handleTVEvent(props: NavigationSceneRendererProps, evt: Object): void {
-    if(evt && evt.nativeEvent && evt.nativeEvent.eventType === "menu") {
+    if (evt && evt.nativeEvent && evt.nativeEvent.eventType === 'menu') {
       props.onNavigateBack && props.onNavigateBack();
     }
   }

--- a/Libraries/CustomComponents/Navigator/Navigator.js
+++ b/Libraries/CustomComponents/Navigator/Navigator.js
@@ -1278,6 +1278,12 @@ var Navigator = React.createClass({
     });
   },
 
+ _handleTVEvent: function(evt: Object) {
+    if (evt && evt.nativeEvent && evt.nativeEvent.eventType === "menu") {
+      this.pop();
+    }
+  },
+
   render: function() {
     var newRenderedSceneMap = new Map();
     var scenes = this.state.routeStack.map((route, index) => {
@@ -1293,7 +1299,7 @@ var Navigator = React.createClass({
     });
     this._renderedSceneMap = newRenderedSceneMap;
     return (
-      <View style={[styles.container, this.props.style]}>
+      <View style={[styles.container, this.props.style]} onTVNavEvent={(evt) => this._handleTVEvent(evt)}>
         <View
           style={styles.transitioner}
           {...this.panGesture.panHandlers}

--- a/Libraries/CustomComponents/Navigator/Navigator.js
+++ b/Libraries/CustomComponents/Navigator/Navigator.js
@@ -1279,7 +1279,7 @@ var Navigator = React.createClass({
   },
 
  _handleTVEvent: function(evt: Object) {
-    if (evt && evt.nativeEvent && evt.nativeEvent.eventType === "menu") {
+    if (evt && evt.nativeEvent && evt.nativeEvent.eventType === 'menu') {
       this.pop();
     }
   },

--- a/Libraries/Text/RCTShadowText.m
+++ b/Libraries/Text/RCTShadowText.m
@@ -431,6 +431,7 @@ static CSSSize RCTMeasure(void *context, float width, CSSMeasureMode widthMode, 
     }
     paragraphStyle.minimumLineHeight = lineHeight;
     paragraphStyle.maximumLineHeight = lineHeight;
+
     [attributedString addAttribute:NSParagraphStyleAttributeName
                              value:paragraphStyle
                              range:(NSRange){0, attributedString.length}];

--- a/Libraries/Text/RCTTextField.m
+++ b/Libraries/Text/RCTTextField.m
@@ -56,6 +56,15 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
                                eventCount:_nativeEventCount];
 }
 
+- (void)didUpdateFocusInContext:(UIFocusUpdateContext *)context withAnimationCoordinator:(UIFocusAnimationCoordinator *)coordinator {
+  [super didUpdateFocusInContext:context withAnimationCoordinator:coordinator];
+  if(context.nextFocusedView == self) {
+    _jsRequestingFirstResponder = YES;
+  } else {
+    _jsRequestingFirstResponder = NO;
+  }
+}
+
 // This method is overridden for `onKeyPress`. The manager
 // will not send a keyPress for text that was pasted.
 - (void)paste:(id)sender

--- a/Libraries/Text/RCTTextViewManager.m
+++ b/Libraries/Text/RCTTextViewManager.m
@@ -64,7 +64,7 @@ RCT_CUSTOM_VIEW_PROPERTY(fontFamily, NSString, RCTTextView)
   view.font = [RCTFont updateFont:view.font withFamily:json ?: defaultView.font.familyName];
 }
 RCT_EXPORT_VIEW_PROPERTY(mostRecentEventCount, NSInteger)
-RCT_REMAP_VIEW_PROPERTY(dataDetectorTypes, textView.dataDetectorTypes, UIDataDetectorTypes)
+RCT_REMAP_VIEW_PROPERTY(dataDetectorTypes, textView.dataDetectorTypes, RCTDataDetectorTypes)
 
 - (RCTViewManagerUIBlock)uiBlockToAmendWithShadowView:(RCTShadowView *)shadowView
 {

--- a/React/Base/RCTRootView.h
+++ b/React/Base/RCTRootView.h
@@ -13,6 +13,10 @@
 
 @protocol RCTRootViewDelegate;
 
+#if TARGET_OS_TV
+@class RCTTVRemoteHandler;
+#endif
+
 /**
  * This enum is used to define size flexibility type of the root view.
  * If a dimension is flexible, the view will recalculate that dimension
@@ -108,6 +112,14 @@ extern NSString *const RCTContentDidAppearNotification;
  * The React-managed contents view of the root view.
  */
 @property (nonatomic, strong, readonly) UIView *contentView;
+
+/**
+ * TV remote gesture recognizers
+ */
+#if TARGET_OS_TV
+@property (nonatomic, strong, readwrite) RCTTVRemoteHandler *tvRemoteHandler;
+@property (nonatomic, strong, readwrite) UIView *reactPreferredFocusedView;
+#endif
 
 /**
  * A view to display while the JavaScript is loading, so users aren't presented

--- a/React/Base/RCTRootView.m
+++ b/React/Base/RCTRootView.m
@@ -28,6 +28,10 @@
 #import "UIView+React.h"
 #import "RCTProfile.h"
 
+#if TARGET_OS_TV
+#import "RCTTVRemoteHandler.h"
+#endif
+
 NSString *const RCTContentDidAppearNotification = @"RCTContentDidAppearNotification";
 
 @interface RCTUIManager (RCTRootView)
@@ -91,6 +95,14 @@ NSString *const RCTContentDidAppearNotification = @"RCTContentDidAppearNotificat
                                              selector:@selector(hideLoadingView)
                                                  name:RCTContentDidAppearNotification
                                                object:self];
+    
+#if TARGET_OS_TV
+    self.tvRemoteHandler = [[RCTTVRemoteHandler alloc] initWithBridge:_bridge];
+    for(UIGestureRecognizer *gr in self.tvRemoteHandler.tvRemoteGestureRecognizers) {
+      [self addGestureRecognizer:gr];
+    }
+#endif
+
 
     if (!_bridge.loading) {
       [self bundleFinishedLoading:[_bridge batchedBridge]];
@@ -118,6 +130,15 @@ NSString *const RCTContentDidAppearNotification = @"RCTContentDidAppearNotificat
 
 RCT_NOT_IMPLEMENTED(- (instancetype)initWithFrame:(CGRect)frame)
 RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
+
+#if TARGET_OS_TV
+- (UIView*)preferredFocusedView {
+  if(self.reactPreferredFocusedView) {
+    return self.reactPreferredFocusedView;
+  };
+  return [super preferredFocusedView];
+}
+#endif
 
 - (void)setBackgroundColor:(UIColor *)backgroundColor
 {

--- a/React/Base/RCTTVRemoteHandler.h
+++ b/React/Base/RCTTVRemoteHandler.h
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <UIKit/UIKit.h>
+
+#import "RCTFrameUpdate.h"
+
+@class RCTBridge;
+
+@interface RCTTVRemoteHandler : NSObject
+
+@property(nonatomic, nonnull, readwrite, strong) NSArray *tvRemoteGestureRecognizers;
+
+- (instancetype _Nullable)initWithBridge:(RCTBridge * _Nullable)bridge NS_DESIGNATED_INITIALIZER;
+- (void)cancel;
+
+@end

--- a/React/Base/RCTTVRemoteHandler.m
+++ b/React/Base/RCTTVRemoteHandler.m
@@ -1,0 +1,160 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import "RCTTVRemoteHandler.h"
+#import <UIKit/UIGestureRecognizerSubclass.h>
+
+#import "RCTAssert.h"
+#import "RCTBridge.h"
+#import "RCTEventDispatcher.h"
+#import "RCTLog.h"
+#import "RCTUIManager.h"
+#import "RCTUtils.h"
+#import "RCTRootView.h"
+#import "RCTView.h"
+#import "UIView+React.h"
+
+@implementation RCTTVRemoteHandler
+{
+  __weak RCTEventDispatcher *_eventDispatcher;
+}
+
+- (instancetype)initWithBridge:(RCTBridge *)bridge
+{
+  RCTAssertParam(bridge);
+  
+  if ((self = [super init])) {
+    _eventDispatcher = [bridge moduleForClass:[RCTEventDispatcher class]];
+    
+    self.tvRemoteGestureRecognizers = [NSMutableArray array];
+    
+    // Recognizers for Apple TV remote buttons
+    
+    // Play/Pause
+    [self addTapGestureRecognizerWithSelector:@selector(playPausePressed:)
+                                    pressType:UIPressTypePlayPause];
+    
+    // Menu
+    [self addTapGestureRecognizerWithSelector:@selector(menuPressed:)
+                                    pressType:UIPressTypeMenu];
+    
+    // Select
+    [self addTapGestureRecognizerWithSelector:@selector(selectPressed:)
+                                    pressType:UIPressTypeSelect];
+    
+    // Up
+    [self addTapGestureRecognizerWithSelector:@selector(swipedUp:)
+                                    pressType:UIPressTypeUpArrow];
+    
+    // Down
+    [self addTapGestureRecognizerWithSelector:@selector(swipedDown:)
+                                    pressType:UIPressTypeDownArrow];
+    
+    // Left
+    [self addTapGestureRecognizerWithSelector:@selector(swipedLeft:)
+                                    pressType:UIPressTypeLeftArrow];
+    
+    // Right
+    [self addTapGestureRecognizerWithSelector:@selector(swipedRight:)
+                                    pressType:UIPressTypeRightArrow];
+    
+    
+    // Recognizers for Apple TV remote trackpad swipes
+    
+    // Up
+    [self addSwipeGestureRecognizerWithSelector:@selector(swipedUp:)
+                                      direction:UISwipeGestureRecognizerDirectionUp];
+    
+    // Down
+    [self addSwipeGestureRecognizerWithSelector:@selector(swipedDown:)
+                                      direction:UISwipeGestureRecognizerDirectionDown];
+    
+    // Left
+    [self addSwipeGestureRecognizerWithSelector:@selector(swipedLeft:)
+                                      direction:UISwipeGestureRecognizerDirectionLeft];
+    
+    // Right
+    [self addSwipeGestureRecognizerWithSelector:@selector(swipedRight:)
+                                      direction:UISwipeGestureRecognizerDirectionRight];
+    
+  }
+
+  return self;
+}
+
+RCT_NOT_IMPLEMENTED(- (instancetype)init)
+
+
+- (void)playPausePressed:(UIGestureRecognizer*)r {
+  [self sendAppleTVEvent:@"playPause" toView:r.view];
+}
+
+- (void)menuPressed:(UIGestureRecognizer*)r {
+  [self sendAppleTVEvent:@"menu" toView:r.view];
+}
+
+- (void)selectPressed:(UIGestureRecognizer*)r {
+  [self sendAppleTVEvent:@"select" toView:r.view];
+}
+
+- (void)longPress:(UIGestureRecognizer*)r {
+  [self sendAppleTVEvent:@"longPress" toView:r.view];
+}
+
+- (void)swipedUp:(UIGestureRecognizer*)r {
+  [self sendAppleTVEvent:@"up" toView:r.view];
+}
+
+- (void)swipedDown:(UIGestureRecognizer*)r {
+  [self sendAppleTVEvent:@"down" toView:r.view];
+}
+
+- (void)swipedLeft:(UIGestureRecognizer*)r {
+  [self sendAppleTVEvent:@"left" toView:r.view];
+}
+
+- (void)swipedRight:(UIGestureRecognizer*)r {
+  [self sendAppleTVEvent:@"right" toView:r.view];
+}
+
+#pragma mark -
+
+- (void)addTapGestureRecognizerWithSelector:(nonnull SEL)selector pressType:(UIPressType)pressType {
+  
+  UITapGestureRecognizer *recognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:selector];
+  recognizer.allowedPressTypes = @[[NSNumber numberWithInteger:pressType]];
+  
+  
+  NSMutableArray *gestureRecognizers = (NSMutableArray*)self.tvRemoteGestureRecognizers;
+  [gestureRecognizers addObject:recognizer];
+}
+
+- (void)addSwipeGestureRecognizerWithSelector:(nonnull SEL)selector direction:(UISwipeGestureRecognizerDirection)direction {
+  
+  UISwipeGestureRecognizer *recognizer = [[UISwipeGestureRecognizer alloc] initWithTarget:self action:selector];
+  recognizer.direction = direction;
+  
+  NSMutableArray *gestureRecognizers = (NSMutableArray*)self.tvRemoteGestureRecognizers;
+  [gestureRecognizers addObject:recognizer];
+}
+
+- (void)sendAppleTVEvent:(NSString*)eventType toView:(UIView*)v {
+  if([v respondsToSelector:@selector(onTVNavEvent)]) {
+    RCTDirectEventBlock onTVNavEvent = [v performSelector:@selector(onTVNavEvent) withObject:nil];
+    if(onTVNavEvent) {
+      onTVNavEvent(@{@"eventType":eventType});
+    }
+  }
+  for(UIView *u in [v subviews]) {
+    [self sendAppleTVEvent:eventType toView:u];
+  }
+}
+
+
+@end

--- a/React/React.xcodeproj/project.pbxproj
+++ b/React/React.xcodeproj/project.pbxproj
@@ -163,6 +163,8 @@
 		2D3B5EF01D9B09E300451313 /* RCTWrapperViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B080241A694A8400A75B9A /* RCTWrapperViewController.m */; };
 		2D3B5EF11D9B09E700451313 /* UIView+React.m in Sources */ = {isa = PBXBuildFile; fileRef = 13E067541A70F44B002CDEE1 /* UIView+React.m */; };
 		2D537FD21DA4809D000F876C /* RCTMultipartDataTask.m in Sources */ = {isa = PBXBuildFile; fileRef = 006FC4131D9B20820057AAAD /* RCTMultipartDataTask.m */; };
+		2D562E431DA5976B00F962D6 /* RCTTVRemoteHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 2D562E421DA5976B00F962D6 /* RCTTVRemoteHandler.m */; };
+		2D562E441DA5979400F962D6 /* RCTTVRemoteHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 2D562E421DA5976B00F962D6 /* RCTTVRemoteHandler.m */; };
 		2D8C2E331DA40441000EE098 /* RCTMultipartStreamReader.m in Sources */ = {isa = PBXBuildFile; fileRef = 001BFCCF1D8381DE008E587E /* RCTMultipartStreamReader.m */; };
 		352DCFF01D19F4C20056D623 /* RCTI18nUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = 352DCFEF1D19F4C20056D623 /* RCTI18nUtil.m */; };
 		391E86A41C623EC800009732 /* RCTTouchEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = 391E86A21C623EC800009732 /* RCTTouchEvent.m */; };
@@ -371,6 +373,8 @@
 		191E3EBF1C29DC3800C180A6 /* RCTRefreshControl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTRefreshControl.h; sourceTree = "<group>"; };
 		191E3EC01C29DC3800C180A6 /* RCTRefreshControl.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTRefreshControl.m; sourceTree = "<group>"; };
 		2D2A28131D9B038B00D4039D /* libReact-tvOS.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libReact-tvOS.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		2D562E411DA5976B00F962D6 /* RCTTVRemoteHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTTVRemoteHandler.h; sourceTree = "<group>"; };
+		2D562E421DA5976B00F962D6 /* RCTTVRemoteHandler.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTTVRemoteHandler.m; sourceTree = "<group>"; };
 		352DCFEE1D19F4C20056D623 /* RCTI18nUtil.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTI18nUtil.h; sourceTree = "<group>"; };
 		352DCFEF1D19F4C20056D623 /* RCTI18nUtil.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTI18nUtil.m; sourceTree = "<group>"; };
 		391E86A21C623EC800009732 /* RCTTouchEvent.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTTouchEvent.m; sourceTree = "<group>"; };
@@ -735,6 +739,8 @@
 				391E86A21C623EC800009732 /* RCTTouchEvent.m */,
 				83CBBA961A6020BB00E9B192 /* RCTTouchHandler.h */,
 				83CBBA971A6020BB00E9B192 /* RCTTouchHandler.m */,
+				2D562E411DA5976B00F962D6 /* RCTTVRemoteHandler.h */,
+				2D562E421DA5976B00F962D6 /* RCTTVRemoteHandler.m */,
 				1345A83A1B265A0E00583190 /* RCTURLRequestDelegate.h */,
 				1345A83B1B265A0E00583190 /* RCTURLRequestHandler.h */,
 				83CBBA4F1A601E3B00E9B192 /* RCTUtils.h */,
@@ -934,6 +940,7 @@
 				2D3B5EAA1D9B08E600451313 /* CSSLayout.c in Sources */,
 				2D3B5ECB1D9B096200451313 /* RCTConvert+CoreLocation.m in Sources */,
 				2D3B5EEE1D9B09DA00451313 /* RCTView.m in Sources */,
+				2D562E441DA5979400F962D6 /* RCTTVRemoteHandler.m in Sources */,
 				2D3B5ECC1D9B096500451313 /* RCTConvert+MapKit.m in Sources */,
 				2D3B5E981D9B089500451313 /* RCTConvert.m in Sources */,
 				2D3B5EA71D9B08CE00451313 /* RCTTouchHandler.m in Sources */,
@@ -1055,6 +1062,7 @@
 				83A1FE8C1B62640A00BE0E65 /* RCTModalHostView.m in Sources */,
 				13E067551A70F44B002CDEE1 /* RCTShadowView.m in Sources */,
 				1450FF871BCFF28A00208362 /* RCTProfileTrampoline-arm.S in Sources */,
+				2D562E431DA5976B00F962D6 /* RCTTVRemoteHandler.m in Sources */,
 				131B6AF51AF1093D00FFC3E0 /* RCTSegmentedControlManager.m in Sources */,
 				58114A171AAE854800E7D092 /* RCTPickerManager.m in Sources */,
 				191E3EBE1C29D9AF00C180A6 /* RCTRefreshControlManager.m in Sources */,

--- a/React/Views/RCTTabBar.h
+++ b/React/Views/RCTTabBar.h
@@ -9,11 +9,22 @@
 
 #import <UIKit/UIKit.h>
 
+#import "RCTComponent.h"
+
+
 @interface RCTTabBar : UIView
 
 @property (nonatomic, strong) UIColor *unselectedTintColor;
 @property (nonatomic, strong) UIColor *tintColor;
 @property (nonatomic, strong) UIColor *barTintColor;
 @property (nonatomic, assign) BOOL translucent;
+
+/**
+ * TV event handlers
+ */
+@property (nonatomic, copy) RCTDirectEventBlock onTVFocus; // Called when this view comes into focus when navigating via TV remote swipes or arrow keys
+@property (nonatomic, copy) RCTDirectEventBlock onTVBlur; // Called when this view leaves focus when navigating via TV remote swipes or arrow keys
+@property (nonatomic, copy) RCTDirectEventBlock onTVNavEvent; // Called on any TV remote action other than select (menu, play/pause, swipes or arrow keys);
+
 
 @end

--- a/React/Views/RCTTabBar.m
+++ b/React/Views/RCTTabBar.m
@@ -175,4 +175,27 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
   return NO;
 }
 
+#if TARGET_OS_TV
+
+- (BOOL)isUserInteractionEnabled {
+  return YES;
+}
+
+- (void)didUpdateFocusInContext:(UIFocusUpdateContext *)context withAnimationCoordinator:(UIFocusAnimationCoordinator *)coordinator {
+  if(context.nextFocusedView == self) {
+    if(self.onTVFocus) {
+      self.onTVFocus(nil);
+    }
+    [self becomeFirstResponder];
+  } else {
+    if(self.onTVBlur) {
+      self.onTVBlur(nil);
+    }
+    [self resignFirstResponder];
+  }
+}
+
+#endif
+
+
 @end

--- a/React/Views/RCTTabBarItem.h
+++ b/React/Views/RCTTabBarItem.h
@@ -22,4 +22,13 @@
 @property (nonatomic, readonly) UITabBarItem *barItem;
 @property (nonatomic, copy) RCTBubblingEventBlock onPress;
 
+/**
+ * TV event handlers
+ */
+@property (nonatomic, copy) RCTDirectEventBlock onTVSelect; // Called if this view is focused and the TV remote select button is pressed
+@property (nonatomic, copy) RCTDirectEventBlock onTVFocus; // Called when this view comes into focus when navigating via TV remote swipes or arrow keys
+@property (nonatomic, copy) RCTDirectEventBlock onTVBlur; // Called when this view leaves focus when navigating via TV remote swipes or arrow keys
+@property (nonatomic, copy) RCTDirectEventBlock onTVNavEvent; // Called on any TV remote action other than select (menu, play/pause, swipes or arrow keys);
+
+
 @end

--- a/React/Views/RCTTabBarItem.m
+++ b/React/Views/RCTTabBarItem.m
@@ -110,4 +110,52 @@ RCT_ENUM_CONVERTER(UITabBarSystemItem, (@{
   return self.superview.reactViewController;
 }
 
+#if TARGET_OS_TV
+
+- (void)setOnTVSelect:(RCTDirectEventBlock)onTVSelect {
+  _onTVSelect = [onTVSelect copy];
+  if(_onTVSelect) {
+    UITapGestureRecognizer *recognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleSelect:)];
+    recognizer.allowedPressTypes = @[[NSNumber numberWithInteger:UIPressTypeSelect]];
+    _selectRecognizer = recognizer;
+    [self addGestureRecognizer:_selectRecognizer];
+  } else {
+    if(_selectRecognizer) {
+      [self removeGestureRecognizer:_selectRecognizer];
+    }
+  }
+  
+}
+
+- (void)handleSelect:(UIGestureRecognizer*)r {
+  RCTTabBarItem *v = (RCTTabBarItem*)r.view;
+  if(v.onTVSelect) {
+    v.onTVSelect(nil);
+  }
+}
+
+- (BOOL)isUserInteractionEnabled {
+  return YES;
+}
+
+- (BOOL)canBecomeFocused {
+  return (self.onTVSelect != nil);
+}
+
+- (void)didUpdateFocusInContext:(UIFocusUpdateContext *)context withAnimationCoordinator:(UIFocusAnimationCoordinator *)coordinator {
+  if(context.nextFocusedView == self && self.onTVSelect != nil) {
+    if(self.onTVFocus) {
+      self.onTVFocus(nil);
+    }
+    [self becomeFirstResponder];
+  } else {
+    if(self.onTVBlur) {
+      self.onTVBlur(nil);
+    }
+    [self resignFirstResponder];
+  }
+}
+
+#endif
+
 @end

--- a/React/Views/RCTTabBarItemManager.m
+++ b/React/Views/RCTTabBarItemManager.m
@@ -28,6 +28,12 @@ RCT_EXPORT_VIEW_PROPERTY(icon, UIImage)
 RCT_EXPORT_VIEW_PROPERTY(selectedIcon, UIImage)
 RCT_EXPORT_VIEW_PROPERTY(systemIcon, UITabBarSystemItem)
 RCT_EXPORT_VIEW_PROPERTY(onPress, RCTBubblingEventBlock)
+
+RCT_EXPORT_VIEW_PROPERTY(onTVSelect, RCTDirectEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onTVFocus, RCTDirectEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onTVBlur, RCTDirectEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onTVNavEvent, RCTDirectEventBlock)
+
 RCT_CUSTOM_VIEW_PROPERTY(title, NSString, RCTTabBarItem)
 {
   view.barItem.title = json ? [RCTConvert NSString:json] : defaultView.barItem.title;

--- a/React/Views/RCTTabBarManager.m
+++ b/React/Views/RCTTabBarManager.m
@@ -37,4 +37,8 @@ RCT_EXPORT_VIEW_PROPERTY(barTintColor, UIColor)
 RCT_EXPORT_VIEW_PROPERTY(translucent, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(itemPositioning, UITabBarItemPositioning)
 
+RCT_EXPORT_VIEW_PROPERTY(onTVFocus, RCTDirectEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onTVBlur, RCTDirectEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onTVNavEvent, RCTDirectEventBlock)
+
 @end

--- a/React/Views/RCTView.h
+++ b/React/Views/RCTView.h
@@ -28,6 +28,28 @@
 @property (nonatomic, copy) RCTDirectEventBlock onMagicTap;
 
 /**
+ * TV event handlers
+ */
+@property (nonatomic, copy) RCTDirectEventBlock onTVSelect; // Called if this view is focused and the TV remote select button is pressed
+@property (nonatomic, copy) RCTDirectEventBlock onTVFocus; // Called when this view comes into focus when navigating via TV remote swipes or arrow keys
+@property (nonatomic, copy) RCTDirectEventBlock onTVBlur; // Called when this view leaves focus when navigating via TV remote swipes or arrow keys
+@property (nonatomic, copy) RCTDirectEventBlock onTVNavEvent; // Called on any TV remote action other than select (menu, play/pause, swipes or arrow keys);
+
+/**
+ *  Properties for Apple TV focus parallax effects
+ */
+@property (nonatomic, assign) BOOL tvParallaxDisable;
+@property (nonatomic, assign) float tvParallaxShiftDistanceX;
+@property (nonatomic, assign) float tvParallaxShiftDistanceY;
+@property (nonatomic, assign) float tvParallaxTiltAngle;
+@property (nonatomic, assign) float tvParallaxMagnification;
+
+/**
+ * TV preferred focus
+ */
+@property (nonatomic, assign) BOOL hasTVPreferredFocus;
+
+/**
  * Used to control how touch events are processed.
  */
 @property (nonatomic, assign) RCTPointerEvents pointerEvents;
@@ -82,6 +104,8 @@
 @property (nonatomic, assign) CGColorRef borderBottomColor;
 @property (nonatomic, assign) CGColorRef borderLeftColor;
 @property (nonatomic, assign) CGColorRef borderColor;
+
+@property (nonatomic, strong) UIColor *tvFocusedBorderColor;
 
 /**
  * Border widths.

--- a/React/Views/RCTView.m
+++ b/React/Views/RCTView.m
@@ -16,6 +16,9 @@
 #import "RCTUtils.h"
 #import "UIView+React.h"
 
+#import "RCTBridge.h"
+#import "RCTEventDispatcher.h"
+
 @implementation UIView (RCTViewUnmounting)
 
 - (void)react_remountAllSubviews
@@ -97,6 +100,7 @@ static NSString *RCTRecursiveAccessibilityLabel(UIView *view)
 @implementation RCTView
 {
   UIColor *_backgroundColor;
+  UITapGestureRecognizer *_selectRecognizer;
 }
 
 @synthesize reactZIndex = _reactZIndex;
@@ -117,6 +121,13 @@ static NSString *RCTRecursiveAccessibilityLabel(UIView *view)
     _hitTestEdgeInsets = UIEdgeInsetsZero;
 
     _backgroundColor = super.backgroundColor;
+    
+    _tvParallaxDisable = false;
+    _tvParallaxShiftDistanceX = 2.0f;
+    _tvParallaxShiftDistanceY = 2.0f;
+    _tvParallaxTiltAngle = 0.05f;
+    _tvParallaxMagnification = 1.0f;
+
   }
 
   return self;
@@ -222,6 +233,154 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:unused)
   NSString *replacement = [NSString stringWithFormat:@"; reactTag: %@;", self.reactTag];
   return [superDescription stringByReplacingCharactersInRange:semicolonRange withString:replacement];
 }
+
+
+#pragma mark - Apple TV specific methods
+
+#if TARGET_OS_TV
+
+- (void)setOnTVSelect:(RCTDirectEventBlock)onTVSelect {
+  _onTVSelect = [onTVSelect copy];
+  if(_onTVSelect) {
+    UITapGestureRecognizer *recognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleSelect:)];
+    recognizer.allowedPressTypes = @[[NSNumber numberWithInteger:UIPressTypeSelect]];
+    _selectRecognizer = recognizer;
+    [self addGestureRecognizer:_selectRecognizer];
+  } else {
+    if(_selectRecognizer) {
+      [self removeGestureRecognizer:_selectRecognizer];
+    }
+  }
+}
+
+- (void)handleSelect:(UIGestureRecognizer*)r {
+  RCTView *v = (RCTView*)r.view;
+  if(v.onTVSelect) {
+    v.onTVSelect(nil);
+  }
+}
+
+- (BOOL)isUserInteractionEnabled {
+  return YES;
+}
+
+- (BOOL)canBecomeFocused {
+  return (self.onTVSelect != nil);
+}
+
+- (void)addParallaxMotionEffectsWithTiltValue:(CGFloat)tiltValue andPanValue:(CGFloat)panValue {
+    // Size of shift movements
+  CGFloat const shiftDistanceX = self.tvParallaxShiftDistanceX;
+  CGFloat const shiftDistanceY = self.tvParallaxShiftDistanceY;
+
+    // Make horizontal movements shift the centre left and right
+    UIInterpolatingMotionEffect *xShift = [[UIInterpolatingMotionEffect alloc]
+                                           initWithKeyPath:@"center.x"
+                                           type:UIInterpolatingMotionEffectTypeTiltAlongHorizontalAxis];
+    xShift.minimumRelativeValue = [NSNumber numberWithFloat: shiftDistanceX * -1.0f];
+    xShift.maximumRelativeValue = [NSNumber numberWithFloat: shiftDistanceX];
+
+    // Make vertical movements shift the centre up and down
+    UIInterpolatingMotionEffect *yShift = [[UIInterpolatingMotionEffect alloc]
+                                           initWithKeyPath:@"center.y"
+                                           type:UIInterpolatingMotionEffectTypeTiltAlongVerticalAxis];
+    yShift.minimumRelativeValue = [NSNumber numberWithFloat: shiftDistanceY * -1.0f];
+    yShift.maximumRelativeValue = [NSNumber numberWithFloat: shiftDistanceY];
+
+    // Size of tilt movements
+    CGFloat const tiltAngle = self.tvParallaxTiltAngle;
+
+    // Now make horizontal movements effect a rotation about the Y axis for side-to-side rotation.
+    UIInterpolatingMotionEffect *xTilt = [[UIInterpolatingMotionEffect alloc] initWithKeyPath:@"layer.transform" type:UIInterpolatingMotionEffectTypeTiltAlongHorizontalAxis];
+
+    // CATransform3D value for minimumRelativeValue
+    CATransform3D transMinimumTiltAboutY = CATransform3DIdentity;
+    transMinimumTiltAboutY.m34 = 1.0 / 500;
+    transMinimumTiltAboutY = CATransform3DRotate(transMinimumTiltAboutY, tiltAngle * -1.0, 0, 1, 0);
+
+    // CATransform3D value for minimumRelativeValue
+    CATransform3D transMaximumTiltAboutY = CATransform3DIdentity;
+    transMaximumTiltAboutY.m34 = 1.0 / 500;
+    transMaximumTiltAboutY = CATransform3DRotate(transMaximumTiltAboutY, tiltAngle, 0, 1, 0);
+
+    // Set the transform property boundaries for the interpolation
+    xTilt.minimumRelativeValue = [NSValue valueWithCATransform3D: transMinimumTiltAboutY];
+    xTilt.maximumRelativeValue = [NSValue valueWithCATransform3D: transMaximumTiltAboutY];
+
+    // Now make vertical movements effect a rotation about the X axis for up and down rotation.
+    UIInterpolatingMotionEffect *yTilt = [[UIInterpolatingMotionEffect alloc] initWithKeyPath:@"layer.transform" type:UIInterpolatingMotionEffectTypeTiltAlongVerticalAxis];
+
+    // CATransform3D value for minimumRelativeValue
+    CATransform3D transMinimumTiltAboutX = CATransform3DIdentity;
+    transMinimumTiltAboutX.m34 = 1.0 / 500;
+    transMinimumTiltAboutX = CATransform3DRotate(transMinimumTiltAboutX, tiltAngle * -1.0, 1, 0, 0);
+
+    // CATransform3D value for minimumRelativeValue
+    CATransform3D transMaximumTiltAboutX = CATransform3DIdentity;
+    transMaximumTiltAboutX.m34 = 1.0 / 500;
+    transMaximumTiltAboutX = CATransform3DRotate(transMaximumTiltAboutX, tiltAngle, 1, 0, 0);
+
+    // Set the transform property boundaries for the interpolation
+    yTilt.minimumRelativeValue = [NSValue valueWithCATransform3D: transMinimumTiltAboutX];
+    yTilt.maximumRelativeValue = [NSValue valueWithCATransform3D: transMaximumTiltAboutX];
+
+    // Add all of the motion effects to this group
+    self.motionEffects = @[xShift, yShift, xTilt, yTilt];
+
+    float magnification = self.tvParallaxMagnification;
+  
+    [UIView animateWithDuration:0.2 animations:^{
+        self.transform = CGAffineTransformMakeScale(magnification, magnification);
+    }];
+
+
+}
+
+- (void)didUpdateFocusInContext:(UIFocusUpdateContext *)context withAnimationCoordinator:(UIFocusAnimationCoordinator *)coordinator {
+  if(context.nextFocusedView == self && self.onTVSelect != nil ) {
+    [self becomeFirstResponder];
+    [coordinator addCoordinatedAnimations:^(void){
+      if(!self.tvParallaxDisable)
+        [self addParallaxMotionEffectsWithTiltValue:0.25 andPanValue:5.0];
+      if(self.onTVFocus) {
+        self.onTVFocus(nil);
+      }
+    } completion:^(void){}];
+  } else {
+    [coordinator addCoordinatedAnimations:^(void){
+      if(self.onTVBlur) {
+        self.onTVBlur(nil);
+      }
+        [UIView animateWithDuration:0.2 animations:^{
+            self.transform = CGAffineTransformMakeScale(1, 1);
+        }];
+
+        for (UIMotionEffect* effect in [self.motionEffects copy]){
+            [self removeMotionEffect:effect];
+        }
+    } completion:^(void){}];
+    [self resignFirstResponder];
+  }
+}
+
+- (void)setHasTVPreferredFocus:(BOOL)hasTVPreferredFocus {
+  self->_hasTVPreferredFocus = hasTVPreferredFocus;
+  if(hasTVPreferredFocus) {
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1.0 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+      UIView *rootview = self;
+      while(![rootview isReactRootView]) {
+        rootview = [rootview superview];
+      }
+      rootview = [rootview superview];
+
+      [rootview performSelector:@selector(setReactPreferredFocusedView:) withObject:self];
+      [rootview setNeedsFocusUpdate];
+      [rootview updateFocusIfNeeded];
+    });
+  }
+}
+
+#endif
 
 #pragma mark - Statics for dealing with layoutGuides
 

--- a/React/Views/RCTViewManager.m
+++ b/React/Views/RCTViewManager.m
@@ -172,6 +172,7 @@ RCT_CUSTOM_VIEW_PROPERTY(pointerEvents, RCTPointerEvents, RCTView)
       RCTLogError(@"UIView base class does not support pointerEvent value: %@", json);
   }
 }
+
 RCT_CUSTOM_VIEW_PROPERTY(removeClippedSubviews, BOOL, RCTView)
 {
   if ([view respondsToSelector:@selector(setRemoveClippedSubviews:)]) {
@@ -191,6 +192,12 @@ RCT_CUSTOM_VIEW_PROPERTY(borderColor, CGColor, RCTView)
     view.borderColor = json ? [RCTConvert CGColor:json] : defaultView.borderColor;
   } else {
     view.layer.borderColor = json ? [RCTConvert CGColor:json] : defaultView.layer.borderColor;
+  }
+}
+RCT_CUSTOM_VIEW_PROPERTY(tvFocusedBorderColor, CGColor, RCTView)
+{
+  if ([view respondsToSelector:@selector(setTvFocusedBorderColor:)]) {
+    view.tvFocusedBorderColor = json ? [UIColor colorWithCGColor:[RCTConvert CGColor:json]] : nil;
   }
 }
 RCT_CUSTOM_VIEW_PROPERTY(borderWidth, CGFloat, RCTView)
@@ -220,6 +227,18 @@ RCT_CUSTOM_VIEW_PROPERTY(hitSlop, UIEdgeInsets, RCTView)
 }
 RCT_EXPORT_VIEW_PROPERTY(onAccessibilityTap, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onMagicTap, RCTDirectEventBlock)
+
+// Apple TV properties
+RCT_EXPORT_VIEW_PROPERTY(onTVSelect, RCTDirectEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onTVFocus, RCTDirectEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onTVBlur, RCTDirectEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onTVNavEvent, RCTDirectEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(hasTVPreferredFocus, BOOL)
+RCT_EXPORT_VIEW_PROPERTY(tvParallaxDisable, BOOL)
+RCT_EXPORT_VIEW_PROPERTY(tvParallaxShiftDistanceX, float)
+RCT_EXPORT_VIEW_PROPERTY(tvParallaxShiftDistanceY, float)
+RCT_EXPORT_VIEW_PROPERTY(tvParallaxTiltAngle, float)
+RCT_EXPORT_VIEW_PROPERTY(tvParallaxMagnification, float)
 
 #define RCT_VIEW_BORDER_PROPERTY(SIDE)                                  \
 RCT_CUSTOM_VIEW_PROPERTY(border##SIDE##Width, CGFloat, RCTView)         \


### PR DESCRIPTION
* Motivation

Third PR for Apple TV support.  This one adds support for the tvOS focus engine, so the app is navigable with the TV remote or keyboard.  TouchableHighlight and TouchableOpacity use the new functionality, so that apps using these components will automatically be navigable on the TV.

* Test plan

All existing test automation still passes.  I plan to add snapshot tests to the CI to check that the API for programmatically changing focus works correctly.