### PR TITLE
Fix indent of .gradle files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,3 +9,6 @@ end_of_line = lf
 insert_final_newline = true
 indent_style = space
 indent_size = 2
+
+[*.gradle]
+indent_size = 4

--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -214,8 +214,8 @@ task packageReactNdkLibs(dependsOn: buildReactNdkLib, type: Copy) {
 }
 
 task packageReactNdkLibsForBuck(dependsOn: packageReactNdkLibs, type: Copy) {
-  from "$buildDir/react-ndk/exported"
-  into "src/main/jni/prebuilt/lib"
+    from "$buildDir/react-ndk/exported"
+    into "src/main/jni/prebuilt/lib"
 }
 
 android {
@@ -243,9 +243,9 @@ android {
         jniLibs.srcDir "$buildDir/react-ndk/exported"
         res.srcDirs = ['src/main/res/devsupport', 'src/main/res/shell', 'src/main/res/views/modal']
         java {
-          srcDirs = ['src/main/java', 'src/main/libraries/soloader/java', 'src/main/jni/first-party/fb/jni/java']
-          exclude 'com/facebook/react/processing'
-          exclude 'com/facebook/react/module/processing'
+            srcDirs = ['src/main/java', 'src/main/libraries/soloader/java', 'src/main/jni/first-party/fb/jni/java']
+            exclude 'com/facebook/react/processing'
+            exclude 'com/facebook/react/module/processing'
         }
     }
 

--- a/local-cli/generator-android/templates/src/app/build.gradle
+++ b/local-cli/generator-android/templates/src/app/build.gradle
@@ -134,6 +134,6 @@ dependencies {
 // Run this once to be able to run the application with BUCK
 // puts all compile dependencies into folder libs for BUCK to use
 task copyDownloadableDepsToLibs(type: Copy) {
-  from configurations.compile
-  into 'libs'
+    from configurations.compile
+    into 'libs'
 }


### PR DESCRIPTION
In most .gradle files, lines are indented with 4 spaces, but in some places they are indented with 2 spaces. This PR fixes them and enforce it by adding .editorconfig settings.

