### PR TITLE
iOS: Fix CameraRoll to support custom user groups

### DIFF
--- a/Libraries/CameraRoll/RCTCameraRollManager.m
+++ b/Libraries/CameraRoll/RCTCameraRollManager.m
@@ -209,7 +209,9 @@ RCT_EXPORT_METHOD(getPhotos:(NSDictionary *)params
           }];
         }
       }];
-    } else {
+    } 
+  
+    if (!group) {
       // Sometimes the enumeration continues even if we set stop above, so we guard against resolving the promise
       // multiple times here.
       if (!resolvedPromise) {


### PR DESCRIPTION
on iOS, if you pull photo from one of user's custom album, the app crashes on the assertion `RCTAssert(resolvedPromise == NO, @"Resolved the promise before we finished processing the results.");` . assertion that was assumed to never been reached.

According to iOS doc, the enumerateGroupsWithTypes `usingBlock` block is called with `group=nil` when the iteration is over, but in current react-native implementation, it is stopping in other circumstance (because the `else` case) which is probably a mistake.

You have probably never seen the bug because you didn't tried to use getPhotos with something else than the pre-defined groups, but it should be possible to do so *(and it seems to work fine as soon as I included my fix. Later I should provide a PR that includes a way to list user groups :) but at least I need this to gets in, otherwise it crashes)*.

For instance, User have a Photo Folder (or "album", whatever you call it) called "Instagram", when I call `CameraRoll.getPhotos({ groupName: "Instagram", groupTypes: "All", first: 36 })`, it instantly crashes on the assert.

Thanks