### PR TITLE
Docs improvement

### DIFF
--- a/Libraries/CustomComponents/Navigator/Navigator.js
+++ b/Libraries/CustomComponents/Navigator/Navigator.js
@@ -141,7 +141,7 @@ var GESTURE_ACTIONS = [
  *
  * ```
  * import React, { Component } from 'react';
- * import { Text, Navigator } from 'react-native';
+ * import { Text, Navigator, TouchableHighlight } from 'react-native';
  *
  * export default class NavAllDay extends Component {
  *   render() {


### PR DESCRIPTION
In the `Additional Scenes` section, the `TouchableHighlight` component is used, but is not present in the import statement. 

This is confusing and results in a `Can't find variable: TouchableHighlight` error.

This PR attempts to correct this confusion.