### PR TITLE
Fix minor typo in documentation of bottom property - "top" => "bottom"

### DIFF
--- a/Libraries/StyleSheet/LayoutPropTypes.js
+++ b/Libraries/StyleSheet/LayoutPropTypes.js
@@ -83,7 +83,7 @@ var LayoutPropTypes = {
    *  use logical pixel units, rather than percents, ems, or any of that.
    *
    *  See https://developer.mozilla.org/en-US/docs/Web/CSS/bottom
-   *  for more details of how `top` affects layout.
+   *  for more details of how `bottom` affects layout.
    */
   bottom: ReactPropTypes.number,
 


### PR DESCRIPTION
Super minor documentation fix.