### PR TITLE
Fix two bugs with Location when not using ACCESS_FINE_LOCATION

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/modules/location/LocationModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/location/LocationModule.java
@@ -9,6 +9,7 @@ package com.facebook.react.modules.location;
 
 import android.annotation.SuppressLint;
 import android.content.Context;
+import android.content.pm.PackageManager;
 import android.location.Location;
 import android.location.LocationListener;
 import android.location.LocationManager;
@@ -16,6 +17,7 @@ import android.location.LocationProvider;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
+import android.support.v4.content.ContextCompat;
 import com.facebook.common.logging.FLog;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Callback;
@@ -192,8 +194,9 @@ public class LocationModule extends ReactContextBaseJavaModule {
     mWatchedProvider = null;
   }
 
+  // Would mark this private, but we want to make it available for testing
   @Nullable
-  private static String getValidProvider(LocationManager locationManager, boolean highAccuracy) {
+  String getValidProvider(LocationManager locationManager, boolean highAccuracy) {
     String provider =
         highAccuracy ? LocationManager.GPS_PROVIDER : LocationManager.NETWORK_PROVIDER;
     if (!locationManager.isProviderEnabled(provider)) {
@@ -203,6 +206,11 @@ public class LocationModule extends ReactContextBaseJavaModule {
       if (!locationManager.isProviderEnabled(provider)) {
         return null;
       }
+    }
+    // If it's an enabled provider, but we don't have permissions, ignore it
+    int finePermission = ContextCompat.checkSelfPermission(getReactApplicationContext(), android.Manifest.permission.ACCESS_FINE_LOCATION);
+    if (provider.equals(LocationManager.GPS_PROVIDER) && finePermission != PackageManager.PERMISSION_GRANTED) {
+      return null;
     }
     return provider;
   }

--- a/ReactAndroid/src/test/java/com/facebook/react/modules/location/LocationModuleTest.java
+++ b/ReactAndroid/src/test/java/com/facebook/react/modules/location/LocationModuleTest.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.modules.location;
+
+import android.content.Context;
+import android.content.pm.PackageManager;
+import android.location.LocationManager;
+import android.support.v4.content.ContextCompat;
+
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactTestHelper;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.rule.PowerMockRule;
+import org.robolectric.RobolectricTestRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link LocationModule}.
+ */
+@PrepareForTest({LocationManager.class, ContextCompat.class})
+@PowerMockIgnore({"org.mockito.*", "org.robolectric.*", "android.*"})
+@RunWith(RobolectricTestRunner.class)
+public class LocationModuleTest {
+
+  private ReactApplicationContext mAppContext;
+  private LocationModule mLocModule;
+  private LocationManager mLocManager;
+
+  @Rule
+  public PowerMockRule rule = new PowerMockRule();
+
+  @Before
+  public void setUp() throws Exception {
+    PowerMockito.mockStatic(ContextCompat.class);
+
+    mAppContext = ReactTestHelper.createCatalystContextForTest();
+    mLocModule = new LocationModule(mAppContext);
+    mLocManager = (LocationManager) mAppContext.getSystemService(Context.LOCATION_SERVICE);
+  }
+
+  @Test
+  public void testGpsAndNetwork() {
+    LocationManager mMockedLocManager = mock(LocationManager.class);
+    when(mMockedLocManager.isProviderEnabled(LocationManager.GPS_PROVIDER)).thenReturn(true);
+    when(mMockedLocManager.isProviderEnabled(LocationManager.NETWORK_PROVIDER)).thenReturn(true);
+
+    when(ContextCompat.checkSelfPermission(mAppContext, android.Manifest.permission.ACCESS_FINE_LOCATION)).thenReturn(PackageManager.PERMISSION_GRANTED);
+    assertEquals(LocationManager.GPS_PROVIDER, mLocModule.getValidProvider(mLocManager, true));
+    assertEquals(LocationManager.NETWORK_PROVIDER, mLocModule.getValidProvider(mLocManager, false));
+
+    when(ContextCompat.checkSelfPermission(mAppContext, android.Manifest.permission.ACCESS_FINE_LOCATION)).thenReturn(PackageManager.PERMISSION_DENIED);
+    assertEquals(null, mLocModule.getValidProvider(mLocManager, true));
+    assertEquals(LocationManager.NETWORK_PROVIDER, mLocModule.getValidProvider(mLocManager, false));
+  }
+
+  public void testGpsNoNetwork() {
+    LocationManager mMockedLocManager = mock(LocationManager.class);
+    when(mMockedLocManager.isProviderEnabled(LocationManager.GPS_PROVIDER)).thenReturn(true);
+    when(mMockedLocManager.isProviderEnabled(LocationManager.NETWORK_PROVIDER)).thenReturn(false);
+
+    when(ContextCompat.checkSelfPermission(mAppContext, android.Manifest.permission.ACCESS_FINE_LOCATION)).thenReturn(PackageManager.PERMISSION_GRANTED);
+    assertEquals(LocationManager.GPS_PROVIDER, mLocModule.getValidProvider(mLocManager, true));
+    assertEquals(null, mLocModule.getValidProvider(mLocManager, false));
+
+    when(ContextCompat.checkSelfPermission(mAppContext, android.Manifest.permission.ACCESS_FINE_LOCATION)).thenReturn(PackageManager.PERMISSION_DENIED);
+    assertEquals(LocationManager.GPS_PROVIDER, mLocModule.getValidProvider(mLocManager, true));
+    assertEquals(null, mLocModule.getValidProvider(mLocManager, false));
+  }
+}


### PR DESCRIPTION
Fix two bugs with Location when not using ACCESS_FINE_LOCATION:
- If we request highAccuracy=false, because we don't have ACCESS_FINE_LOCATION, but we don't have access to the NETWORK_PROVIDER...then the code should not trigger a SecurityException because it fell-back to using GPS_PROVIDER (which we don't have permission for)
- If the device is pre-lollipop, and doesn't have a provider, we should detect this properly instead of letting the pre-lollipop code raise a SecurityException.

Unfortunately, SecurityExceptions cannot be caught by the calling JS code. But I am not fixing that one here, instead choosing to fix/obviate the SecurityExceptions altogether.
