### PR TITLE
Remove -Wall custom WARNING_CFLAGS

### DIFF
--- a/Libraries/WebSocket/RCTWebSocket.xcodeproj/project.pbxproj
+++ b/Libraries/WebSocket/RCTWebSocket.xcodeproj/project.pbxproj
@@ -271,7 +271,6 @@
 				SDKROOT = iphoneos;
 				WARNING_CFLAGS = (
 					"-Werror",
-					"-Wall",
 				);
 			};
 			name = Debug;
@@ -313,7 +312,6 @@
 				VALIDATE_PRODUCT = YES;
 				WARNING_CFLAGS = (
 					"-Werror",
-					"-Wall",
 				);
 			};
 			name = Release;


### PR DESCRIPTION
Remove -Wall flag from WARNING_CFLAGS in order to apply https://github.com/facebook/react-native/issues/8584#issuecomment-236366222 fix (there is no reason to remove -Werror flag).

**Test plan (required)**

- [x] Check if blank project compiles without [error](https://gist.github.com/andresn/1f35d718da9fc57542bb399460f2efd0#file-gistfile1-txt-L109)

cc @javache 