### PR TITLE
replace old ATS key name to new one.

### DIFF
--- a/local-cli/generator-ios/templates/app/Info.plist
+++ b/local-cli/generator-ios/templates/app/Info.plist
@@ -45,7 +45,7 @@
 		<dict>
 			<key>localhost</key>
 			<dict>
-				<key>NSTemporaryExceptionAllowsInsecureHTTPLoads</key>
+				<key>NSExceptionAllowsInsecureHTTPLoads</key>
 				<true/>
 			</dict>
 		</dict>


### PR DESCRIPTION
On iOS project, ATS is disabled for 'localhost'.  But the key for this setting is old and just for early iOS9 beta.  iOS9 release and later uses new one, so I updated it.