### PR TITLE
<br /> doesn't exist in React Native

### DIFF
--- a/Libraries/Text/Text.js
+++ b/Libraries/Text/Text.js
@@ -65,7 +65,7 @@ const viewConfig = {
  *     return (
  *       <Text style={styles.baseText}>
  *         <Text style={styles.titleText} onPress={this.onPressTitle}>
- *           {this.state.titleText}<br /><br />
+ *           {this.state.titleText}{'\n'}{'\n'}
  *         </Text>
  *         <Text numberOfLines={5}>
  *           {this.state.bodyText}


### PR DESCRIPTION
Replace `<br />` with `{'\n'}` in order to provide an example of working line breaks in React Native.