### PR TITLE
[Website] Link to unversioned showcase.

### DIFF
--- a/website/src/react-native/index.js
+++ b/website/src/react-native/index.js
@@ -235,7 +235,7 @@ class SomethingFast extends Component {
               Some of these are hybrid native/React Native apps.
             </p>
             <div className="buttons-unit">
-              <a href="showcase.html" className="button">More React Native apps</a>
+              <a href="/react-native/showcase.html" className="button">More React Native apps</a>
             </div>
           </section>
         </section>


### PR DESCRIPTION
The showcase is not versioned. We need to link to `/react-native/showcase.html` to ensure the unversioned showcase is loaded instead of something like `react-native/releases/0.34/showcase.html` which does not exist.