### PR TITLE
[Android] Add support for full-screen video in WebView

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebViewManager.java
@@ -9,12 +9,6 @@
 
 package com.facebook.react.views.webview;
 
-import javax.annotation.Nullable;
-
-import java.io.UnsupportedEncodingException;
-import java.util.HashMap;
-import java.util.Map;
-
 import android.content.Intent;
 import android.graphics.Bitmap;
 import android.graphics.Picture;
@@ -23,7 +17,6 @@ import android.os.Build;
 import android.text.TextUtils;
 import android.view.ViewGroup.LayoutParams;
 import android.webkit.GeolocationPermissions;
-import android.webkit.WebChromeClient;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
 
@@ -46,6 +39,12 @@ import com.facebook.react.uimanager.events.EventDispatcher;
 import com.facebook.react.views.webview.events.TopLoadingErrorEvent;
 import com.facebook.react.views.webview.events.TopLoadingFinishEvent;
 import com.facebook.react.views.webview.events.TopLoadingStartEvent;
+
+import java.io.UnsupportedEncodingException;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.annotation.Nullable;
 
 /**
  * Manages instances of {@link WebView}
@@ -253,8 +252,8 @@ public class ReactWebViewManager extends SimpleViewManager<WebView> {
 
   @Override
   protected WebView createViewInstance(ThemedReactContext reactContext) {
-    ReactWebView webView = new ReactWebView(reactContext);
-    webView.setWebChromeClient(new WebChromeClient() {
+    final ReactWebView webView = new ReactWebView(reactContext);
+    webView.setWebChromeClient(new VideoWebChromeClient(reactContext.getCurrentActivity(), webView) {
       @Override
       public void onGeolocationPermissionsShowPrompt(String origin, GeolocationPermissions.Callback callback) {
         callback.invoke(origin, true, false);

--- a/ReactAndroid/src/main/java/com/facebook/react/views/webview/VideoWebChromeClient.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/webview/VideoWebChromeClient.java
@@ -1,0 +1,70 @@
+package com.facebook.react.views.webview;
+
+import android.app.Activity;
+import android.graphics.Color;
+import android.view.Gravity;
+import android.view.View;
+import android.view.ViewGroup;
+import android.webkit.WebChromeClient;
+import android.webkit.WebView;
+import android.widget.FrameLayout;
+
+import static android.view.ViewGroup.LayoutParams;
+
+/**
+ * Provides support for full-screen video on Android
+ */
+public class VideoWebChromeClient extends WebChromeClient {
+
+  private final FrameLayout.LayoutParams FULLSCREEN_LAYOUT_PARAMS = new FrameLayout.LayoutParams(
+    LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT, Gravity.CENTER);
+
+  private WebChromeClient.CustomViewCallback mCustomViewCallback;
+
+  private Activity mActivity;
+  private View mWebView;
+  private View mVideoView;
+
+  public VideoWebChromeClient(Activity activity, WebView webView) {
+    mWebView = webView;
+    mActivity = activity;
+  }
+
+  @Override
+  public void onShowCustomView(View view, CustomViewCallback callback) {
+    if (mVideoView != null) {
+      callback.onCustomViewHidden();
+      return;
+    }
+
+    // Store the view and it's callback for later, so we can dispose of them correctly
+    mVideoView = view;
+    mCustomViewCallback = callback;
+
+    view.setBackgroundColor(Color.BLACK);
+
+    getRootView().addView(view, FULLSCREEN_LAYOUT_PARAMS);
+
+    mWebView.setVisibility(View.GONE);
+  }
+
+  @Override
+  public void onHideCustomView() {
+    if (mVideoView == null) {
+      return;
+    }
+
+    mVideoView.setVisibility(View.GONE);
+
+    // Remove the custom view from its container.
+    getRootView().removeView(mVideoView);
+    mVideoView = null;
+    mCustomViewCallback.onCustomViewHidden();
+
+    mWebView.setVisibility(View.VISIBLE);
+  }
+
+  private ViewGroup getRootView() {
+    return ((ViewGroup) mActivity.findViewById(android.R.id.content));
+  }
+}


### PR DESCRIPTION
**Motivation:** Android WebViews lack support for fullscreen videos by default (unlike iOS).  This adds support for that.  Covers https://github.com/facebook/react-native/issues/5230

**Testing The Changes:** Navigate to http://youtube.com and view any video. Previously, when tapping the full-screen icon on the bottom right of the video nothing would happen.  Now, it should enter full-screen mode.

This sort of stuff on Android is notorious for device/version-specific quirks - so I wouldn't be surprised if there are some edge cases that have yet to be handled.

I've tested on Android 4.2 & Android 6.0 - going to test on a couple more devices tomorrow.
