### PR TITLE
fix Navigator.jumpTo function problem

### DIFF
--- a/Libraries/CustomComponents/Navigator/Navigator.js
+++ b/Libraries/CustomComponents/Navigator/Navigator.js
@@ -1029,8 +1029,13 @@ var Navigator = React.createClass({
    * @param {object} route Route to transition to. The specified route must
    * be in the currently mounted set of routes defined in `routeStack`.
    */
-  jumpTo: function(route) {
-    var destIndex = this.state.routeStack.indexOf(route);
+  jumpTo: function(routeName) {
+    var destIndex = -1;
+    for (var i = 0; i < this.state.routeStack.length; i++){
+      if (this.state.routeStack[i].name === routeName){
+        destIndex = i;
+      }
+    }
     invariant(
       destIndex !== -1,
       'Cannot jump to route that is not in the route stack'


### PR DESCRIPTION
*I think function  `jumpTo` has some problem, just don't know why the official did not fix it.*

```javascript
const routes = [
  {name:"Home",component:Home,index:0},
  {name:"Seller",component:Seller,index:1}
]
```

```javascript
<Navigator 
  initialRoute={routes[0]}
  initialRouteStack={routes}
  configureScene={(route)=>{
    return Navigator.SceneConfigs.FadeAndroid;
  }}
  renderScene={(route,navigator)=>{
  let Component = route.component;
    return <Component {...route.params} RootNavigator={navigator} />
  }}/>
```

Now you can use jumpTo like `navigator.jumpTo("Seller")`, this way is more simple and more clear