### PR TITLE
Warning: bind(): You are binding a component method to the component

### DIFF
--- a/Libraries/Components/Touchable/Touchable.js
+++ b/Libraries/Components/Touchable/Touchable.js
@@ -571,7 +571,7 @@ var TouchableMixin = {
       return;
     }
 
-    UIManager.measure(tag, this._handleQueryLayout.bind(this));
+    UIManager.measure(tag, this._handleQueryLayout);
   },
 
   _handleQueryLayout: function(l, t, w, h, globalX, globalY) {


### PR DESCRIPTION
Warning: bind(): You are binding a component method to the component. 
React does this for you automatically in a high-performance way, so you can safely remove this call. See TouchableOpacity