### PR TITLE
Decode URI in asset server

### DIFF
--- a/packager/react-packager/src/AssetServer/index.js
+++ b/packager/react-packager/src/AssetServer/index.js
@@ -140,7 +140,6 @@ class AssetServer {
         const dir = res[0];
         const files = res[1];
         const assetData = getAssetDataFromName(filename, new Set([platform]));
-        assetData.assetName = decodeURIComponent(assetData.assetName);
 
         const map = this._buildAssetMap(dir, files, platform);
 

--- a/packager/react-packager/src/AssetServer/index.js
+++ b/packager/react-packager/src/AssetServer/index.js
@@ -140,6 +140,7 @@ class AssetServer {
         const dir = res[0];
         const files = res[1];
         const assetData = getAssetDataFromName(filename, new Set([platform]));
+        assetData.assetName = decodeURIComponent(assetData.assetName);
 
         const map = this._buildAssetMap(dir, files, platform);
 

--- a/packager/react-packager/src/node-haste/lib/__tests__/getAssetDataFromName-test.js
+++ b/packager/react-packager/src/node-haste/lib/__tests__/getAssetDataFromName-test.js
@@ -62,6 +62,14 @@ describe('getAssetDataFromName', () => {
       name: 'c',
       platform: 'ios',
     });
+
+    expect(getAssetDataFromName('a/b /c.png')).toEqual({
+      resolution: 1,
+      assetName: 'a/b /c.png',
+      type: 'png',
+      name: 'c',
+      platform: null,
+    });
   });
 
   describe('resolution extraction', () => {

--- a/packager/react-packager/src/node-haste/lib/getAssetDataFromName.js
+++ b/packager/react-packager/src/node-haste/lib/getAssetDataFromName.js
@@ -42,6 +42,7 @@ function getAssetDataFromName(filename, platforms) {
   } else {
     assetName = filename;
   }
+  assetName = decodeURIComponent(assetName);
 
   return {
     resolution: resolution,


### PR DESCRIPTION
Solving this issue https://github.com/facebook/react-native/issues/10364

In development when assets are requested from AssetServer, it tries to find them with URI-friendly filenames. I added a single line to decode these filenames.

Tests are passing. Couldn't find any discussion regarding whether this is a good idea. This was causing some members of my team a bit of grief earlier.
