### PR TITLE
Remove setUseOldBridge from the documentation

### DIFF
--- a/docs/IntegrationWithExistingApps.md
+++ b/docs/IntegrationWithExistingApps.md
@@ -611,8 +611,6 @@ You need to add some native code in order to start the React Native runtime and 
 
 > If you are targetting Android version <5, use the `AppCompatActivity` class from the `com.android.support:appcompat` package instead of `Activity`.
 
-> If you find out later that your app crashes due to `Didn't find class "com.facebook.jni.IteratorHelper"` exception, uncomment the `setUseOldBridge` line. [See related issue on GitHub.](https://github.com/facebook/react-native/issues/8701)
-
 ```java
 public class MyReactActivity extends Activity implements DefaultHardwareBackBtnHandler {
     private ReactRootView mReactRootView;
@@ -630,7 +628,6 @@ public class MyReactActivity extends Activity implements DefaultHardwareBackBtnH
                 .addPackage(new MainReactPackage())
                 .setUseDeveloperSupport(BuildConfig.DEBUG)
                 .setInitialLifecycleState(LifecycleState.RESUMED)
-                //.setUseOldBridge(true) // uncomment this line if your app crashes
                 .build();
         mReactRootView.startReactApplication(mReactInstanceManager, "HelloWorld", null);
 


### PR DESCRIPTION
This PR removes the `.setUseOldBridge(true)` from the documentation. The method was removed from the `ReactInstanceManager` class at [this](https://github.com/facebook/react-native/commit/1a690d56748eb4b6bf3a8c525ea761d3e3c9aea6#diff-dc0f3a09c238b372cb1c27aa5f7dcbce) commit and currently it is not available.