### PR TITLE
Add the RCTNetwork to the podfile

### DIFF
--- a/docs/IntegrationWithExistingApps.md
+++ b/docs/IntegrationWithExistingApps.md
@@ -209,6 +209,7 @@ target 'NumberTileGame' do
   pod 'React', :path => '../node_modules/react-native', :subspecs => [
     'Core',
     'RCTText',
+    'RCTNetwork',
     'RCTWebSocket', # needed for debugging
     # Add any other subspecs you want to use in your project
   ]
@@ -233,6 +234,7 @@ target 'swift-2048' do
   pod 'React', :path => '../node_modules/react-native', :subspecs => [
     'Core',
     'RCTText',
+    'RCTNetwork',
     'RCTWebSocket', # needed for debugging
     # Add any other subspecs you want to use in your project
   ]


### PR DESCRIPTION
The pod `RCTNetwork` is missing from the `Podfile` documentation. Without it the view controller does not run.

This probably also closes #8449.