### PR TITLE
Force CircleCI to use JDK 8

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -10,6 +10,8 @@ machine:
     TERM: "dumb"
     ADB_INSTALL_TIMEOUT: 10
     GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx512m -XX:+HeapDumpOnOutOfMemoryError"'
+  java:
+    version: 'oraclejdk8'
 
 dependencies:
   override:


### PR DESCRIPTION
Circle CI is failing sometimes on the `buck && ant` task with a `Require JDK 8 or higher` error.

**Test plan (required)**
Make sure tests pass on Circle CI.
