### PR TITLE
Added documentation on string interpolation to Animations doc

### DIFF
--- a/docs/Animations.md
+++ b/docs/Animations.md
@@ -165,6 +165,15 @@ Input | Output
    101|      0
    200|      0
 
+`interpolate` also supports mapping to strings, allowing you to animate colors as well as values with units. For example, if you wanted to animate a rotation you could do:
+
+```javascript
+value.interpolate({
+  inputRange: [0, 360],
+  outputRange: ['0deg', '360deg']
+})
+```
+
 `interpolation` also supports arbitrary easing functions, many of which are
 already implemented in the
 [`Easing`](https://github.com/facebook/react-native/blob/master/Libraries/Animation/Animated/Easing.js)


### PR DESCRIPTION
**Motivation**
I saw that [Clearer documentation on how to animate string properties](https://github.com/facebook/react-native/issues/2276) had the Good First Task label so I thought I'd take a crack at it. My only change is to the Animations doc, where I added a few sentences and an example based on @JedWatson's comment in the issue.

**Test plan (required)**
I wrote a small example app that contains the code snippet from the docs and ran it in the ios simulator and on a Nexus 5X. You can see it [here](https://github.com/liamfd/react_native_examples/tree/master/TestStringInterpolation).

I also looked at the docs and the formatting seemed fine:

<img width="671" alt="screen shot 2016-10-14 at 10 43 21 am" src="https://cloud.githubusercontent.com/assets/5359538/19391550/29bd1d54-91fb-11e6-92d0-1c5b53c6f346.png">

I got the "colors as well as values with units" part from a comment [in the source](https://github.com/facebook/react-native/blob/master/Libraries/Animated/src/Interpolation.js#L178). The comment makes it sound slightly more open ended than the line I added in the docs, but wanted to avoid implying that it works for any arbitrary string values.