### PR TITLE
Update iOS run script to fix the build launch in the simulator

### DIFF
--- a/local-cli/runIOS/runIOS.js
+++ b/local-cli/runIOS/runIOS.js
@@ -44,7 +44,7 @@ function runIOS(argv, config, args) {
   } else if (args.udid) {
     runOnDeviceByUdid(args.udid, scheme, xcodeProject, devices);
   } else {
-    runOnSimulator(xcodeProject, args, inferredSchemeName, scheme);
+    runOnSimulator(xcodeProject, args, scheme);
   }
 }
 
@@ -63,7 +63,7 @@ function runOnDeviceByUdid(udid, scheme, xcodeProject, devices) {
   }
 }
 
-function runOnSimulator(xcodeProject, args, inferredSchemeName, scheme){
+function runOnSimulator(xcodeProject, args, scheme){
   try {
     var simulators = JSON.parse(
     child_process.execFileSync('xcrun', ['simctl', 'list', '--json', 'devices'], {encoding: 'utf8'})
@@ -88,7 +88,7 @@ function runOnSimulator(xcodeProject, args, inferredSchemeName, scheme){
 
   buildProject(xcodeProject, selectedSimulator.udid, scheme);
 
-  const appPath = `build/Build/Products/Debug-iphonesimulator/${inferredSchemeName}.app`;
+  const appPath = `build/Build/Products/Debug-iphonesimulator/${scheme}.app`;
   console.log(`Installing ${appPath}`);
   child_process.spawnSync('xcrun', ['simctl', 'install', 'booted', appPath], {stdio: 'inherit'});
 


### PR DESCRIPTION
If the `scheme` of the project is different from the `project name` the iOS run script will not work for the `iOS Simulator`, since to launch the app the script is looking for `..\${inferredSchemeName}` that can be different from the real scheme name that can be passed by argument.

For this sample, **if the name of the project is different from the name of the scheme**, this will not work, this PR will fix that issue.

```
react-native run-ios --scheme Sandbox
```