### PR TITLE
be more explicit on what's ImageEditor defaults

### DIFF
--- a/Libraries/Image/ImageEditor.js
+++ b/Libraries/Image/ImageEditor.js
@@ -32,14 +32,15 @@ type ImageCropData = {
   },
   /**
    * (Optional) size to scale the cropped image to.
+   * defaults to size. (no scale)
    */
   displaySize?: ?{
     width: number,
     height: number,
   },
   /**
-   * (Optional) the resizing mode to use when scaling the image. If the
-   * `displaySize` param is not specified, this has no effect.
+   * (Optional) the resizing mode to use when scaling the image. 
+   * defaults to "contain".
    */
   resizeMode?: ?$Enum<{
     contain: string,


### PR DESCRIPTION
The comment

> If the `displaySize` param is not specified, this has no effect.

is not true, it's actually fallbacking to "contain" as shown in the implementation: https://github.com/facebook/react-native/blob/9ee815f6b52e0c2417c04e5a05e1e31df26daed2/Libraries/Image/RCTImageEditingManager.m#L63
