### PR TITLE
Update GettingStarted.md if user using zsh filename should be .zshrc

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -138,7 +138,7 @@ The React Native command line interface requires the `ANDROID_HOME` environment 
 export ANDROID_HOME=~/Library/Android/sdk
 ```
 
-To avoid doing this every time you open a new Terminal, create (or edit) `~/.bashrc` using your favorite text editor and add the following lines:
+To avoid doing this every time you open a new Terminal, create (or edit) `~/.bashrc` (`~/.zshrc` if you using `zsh`) using your favorite text editor and add the following lines:
 
 ```
 export ANDROID_HOME=~/Library/Android/sdk

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -138,7 +138,7 @@ The React Native command line interface requires the `ANDROID_HOME` environment 
 export ANDROID_HOME=~/Library/Android/sdk
 ```
 
-To avoid doing this every time you open a new Terminal, create (or edit) `~/.bashrc` (`~/.zshrc` if you using `zsh`) using your favorite text editor and add the following lines:
+To avoid doing this every time you open a new terminal, add the following lines to your `~/.bashrc` or equivalent config file:
 
 ```
 export ANDROID_HOME=~/Library/Android/sdk


### PR DESCRIPTION
Small contribution for MacOS users: 

For those users who using zsh with their Mac OS filename to place variables should be different