### PR TITLE
Fix require polyfill

### DIFF
--- a/packager/react-packager/src/Resolver/polyfills/__tests__/require-test.js
+++ b/packager/react-packager/src/Resolver/polyfills/__tests__/require-test.js
@@ -92,5 +92,26 @@ describe('require', () => {
         firstWas: 'first value'
       });
     });
+
+    it('should handle circular deps using module.exports', () => {
+      defineShim(51, function(global, require, module, exports) {
+        module.exports = {
+          first: 'first value'
+        };
+        var p = require(52).p;
+        module.exports.first = 'second value';
+        module.exports.firstWas = p();
+      });
+      defineShim(52, function(global, require, module, exports) {
+        var first = require(51).first;
+        exports.p = function() {
+          return first;
+        }
+      });
+      expect(requireShim(51)).toEqual({
+        first: 'second value',
+        firstWas: 'first value'
+      });
+    });
   });
 });

--- a/packager/react-packager/src/Resolver/polyfills/__tests__/require-test.js
+++ b/packager/react-packager/src/Resolver/polyfills/__tests__/require-test.js
@@ -34,6 +34,15 @@ describe('require', () => {
     });
   });
 
+  describe('module.id', () => {
+    it('should be the identifier of the module passed to require', () => {
+      defineShim(3, function(global, require, module, exports) {
+        expect(module.id).toBe(3);
+      });
+      requireShim(3);
+    });
+  });
+
   describe('module.exports', () => {
     it('should be the same as exports', () => {
       defineShim(11, function(global, require, module, exports) {

--- a/packager/react-packager/src/Resolver/polyfills/__tests__/require-test.js
+++ b/packager/react-packager/src/Resolver/polyfills/__tests__/require-test.js
@@ -1,0 +1,96 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+// TODO: figure out why jest.resetModules() doesn't reset the polyfill's module cache
+const origGlobalRequire = global.require;
+require('../require');
+const requireShim = global.require;
+const defineShim = global.__d;
+global.require = origGlobalRequire;
+
+describe('require', () => {
+  describe('exports', () => {
+    it('should be an object containing named exports', () => {
+      defineShim(1, function(global, require, module, exports) {
+        expect(exports).toEqual({});
+        exports.hello = 'world';
+      });
+      expect(requireShim(1)).toEqual({hello: 'world'});
+    });
+  });
+
+  describe('module.exports', () => {
+    it('should be the same as exports', () => {
+      defineShim(11, function(global, require, module, exports) {
+        expect(module.exports).toBe(exports);
+      });
+      requireShim(11);
+    });
+
+    describe('should support re-assignements', () => {
+      let moduleId = 21;
+      function testModuleExportsValue(value) {
+        defineShim(moduleId, function(global, require, module, exports) {
+          module.exports = value;
+        });
+        expect(requireShim(moduleId)).toBe(value);
+        moduleId++;
+      }
+
+      it('to a primitive value', () => {
+        testModuleExportsValue(123);
+      });
+
+      it('to an object', () => {
+        testModuleExportsValue({
+          hello: 'world'
+        });
+      });
+
+      it('to a function', () => {
+        testModuleExportsValue(function Test() {});
+      });
+    });
+  });
+
+  describe('dependencies', () => {
+    it('should be resolved', () => {
+      defineShim(31, function(global, require, module, exports) {
+        exports.dep2 = require(32);
+      });
+      defineShim(32, function(global, require, module, exports) {
+        exports.hello = 'world';
+      });
+      expect(requireShim(31)).toEqual({
+        dep2: {
+          hello: 'world'
+        }
+      });
+    });
+
+    it('should handle circular deps using exports', () => {
+      defineShim(41, function(global, require, module, exports) {
+        exports.first = 'first value';
+        var p = require(42).p;
+        exports.first = 'second value';
+        exports.firstWas = p();
+      });
+      defineShim(42, function(global, require, module, exports) {
+        var first = require(41).first;
+        exports.p = function() {
+          return first;
+        }
+      });
+      expect(requireShim(41)).toEqual({
+        first: 'second value',
+        firstWas: 'first value'
+      });
+    });
+  });
+});

--- a/packager/react-packager/src/Resolver/polyfills/__tests__/require-test.js
+++ b/packager/react-packager/src/Resolver/polyfills/__tests__/require-test.js
@@ -25,6 +25,15 @@ describe('require', () => {
     });
   });
 
+  describe('this', () => {
+    it('should be the exports object', () => {
+      defineShim(2, function(global, require, module, exports) {
+        expect(this).toBe(exports);
+      });
+      requireShim(2);
+    });
+  });
+
   describe('module.exports', () => {
     it('should be the same as exports', () => {
       defineShim(11, function(global, require, module, exports) {

--- a/packager/react-packager/src/Resolver/polyfills/require.js
+++ b/packager/react-packager/src/Resolver/polyfills/require.js
@@ -105,21 +105,28 @@ function loadModuleImplementation(moduleId, module) {
   // factory to keep any require cycles inside the factory from causing an
   // infinite require loop.
   module.isInitialized = true;
-  const exports = module.exports = {};
+  module.exports = {};
   const {factory} = module;
   try {
     if (__DEV__) {
       Systrace.beginEvent('JS_require_' + (module.verboseName || moduleId));
     }
 
-    const moduleObject = {exports};
+    const moduleObject = {
+      get exports() {
+        return module.exports;
+      },
+      set exports(value) {
+        module.exports = value;
+      }
+    };
     if (__DEV__ && module.hot) {
       moduleObject.hot = module.hot;
     }
 
     // keep args in sync with with defineModuleCode in
     // packager/react-packager/src/Resolver/index.js
-    factory(global, require, moduleObject, exports);
+    factory(global, require, moduleObject, module.exports);
 
     // avoid removing factory in DEV mode as it breaks HMR
     if (!__DEV__) {
@@ -129,7 +136,7 @@ function loadModuleImplementation(moduleId, module) {
     if (__DEV__) {
       Systrace.endEvent();
     }
-    return (module.exports = moduleObject.exports);
+    return module.exports;
   } catch (e) {
     module.hasError = true;
     module.isInitialized = false;

--- a/packager/react-packager/src/Resolver/polyfills/require.js
+++ b/packager/react-packager/src/Resolver/polyfills/require.js
@@ -113,6 +113,9 @@ function loadModuleImplementation(moduleId, module) {
     }
 
     const moduleObject = {
+      get id() {
+        return moduleId;
+      },
       get exports() {
         return module.exports;
       },

--- a/packager/react-packager/src/Resolver/polyfills/require.js
+++ b/packager/react-packager/src/Resolver/polyfills/require.js
@@ -126,7 +126,7 @@ function loadModuleImplementation(moduleId, module) {
 
     // keep args in sync with with defineModuleCode in
     // packager/react-packager/src/Resolver/index.js
-    factory(global, require, moduleObject, module.exports);
+    factory.call(module.exports, global, require, moduleObject, module.exports);
 
     // avoid removing factory in DEV mode as it breaks HMR
     if (!__DEV__) {


### PR DESCRIPTION
Using some 3rd party libraries with React Native is not possible due to their reliance on some CommonJS/node module behavior not implemented by the React Native require polyfill from the packager.

This PR adds some of these behaviors:
- Circular dependencies when exporting by assignment to the `module.exports` object. Should fix #3298 for good.
- Exporting by assignment to the `this` object. Fixes #2862
- The `module.id` represents a unique identifier that can be used in `require()` calls.

There were no tests for the require polyfill so I added one.