### PR TITLE
Update activity lifecycle callback example

### DIFF
--- a/docs/IntegrationWithExistingApps.md
+++ b/docs/IntegrationWithExistingApps.md
@@ -667,7 +667,7 @@ protected void onPause() {
     super.onPause();
 
     if (mReactInstanceManager != null) {
-        mReactInstanceManager.onPause();
+        mReactInstanceManager.onPause(this);
     }
 }
 
@@ -685,7 +685,7 @@ protected void onDestroy() {
     super.onDestroy();
 
     if (mReactInstanceManager != null) {
-        mReactInstanceManager.onDestroy();
+        mReactInstanceManager.onDestroy(this);
     }
 }
 ```


### PR DESCRIPTION
Updates the documentation for the the android life cycle methods, recent changes has deprecated

 `onHostPause()` for `onHostPause(Activity activity)`
 `onHostDestroy()` for `onHostDestroy(Activity activity)`

[deprecation commit](https://github.com/facebook/react-native/commit/0b5c61250b290e78b2c37c7c22b8146056cd30d8)
