### PR TITLE
Fix one docs typo

### DIFF
--- a/docs/GestureResponderSystem.md
+++ b/docs/GestureResponderSystem.md
@@ -55,7 +55,7 @@ If the view is responding, the following handlers can be called:
      + `pageX` - The X position of the touch, relative to the root element
      + `pageY` - The Y position of the touch, relative to the root element
      + `target` - The node id of the element receiving the touch event
-     + `timestamp` - A time identifier for the touch, useful for velocity calculation
+     + `timeStamp` - A time identifier for the touch, useful for velocity calculation
      + `touches` - Array of all current touches on the screen
 
 ### Capture ShouldSet Handlers


### PR DESCRIPTION
This typo was fixed in https://github.com/facebook/react-native/pull/7553 but the submitter (understandably) did not want to bother signing a CLA to fix a typo. This PR fixes that typo ;-)