### PR TITLE
Mock requireNativeComponent so manual mocking of UIManager properties isn't needed

### DIFF
--- a/jest/setup.js
+++ b/jest/setup.js
@@ -158,3 +158,17 @@ jest
     register: id => id,
     getByID: () => mockEmptyObject,
   }));
+
+const React = require('react');
+
+jest.doMock('requireNativeComponent', () => {
+  return (viewName) => {
+    return (props) => {
+      return React.createElement(
+        viewName,
+        props,
+        props.children,
+      );
+    }
+  }
+});

--- a/jest/setup.js
+++ b/jest/setup.js
@@ -162,13 +162,9 @@ jest
 jest.doMock('requireNativeComponent', () => {
   const React = require('react');
 
-  return (viewName) => {
-    return (props) => {
-      return React.createElement(
-        viewName,
-        props,
-        props.children,
-      );
-    }
-  }
+  return viewName => props => React.createElement(
+    viewName,
+    props,
+    props.children,
+  );
 });

--- a/jest/setup.js
+++ b/jest/setup.js
@@ -159,9 +159,9 @@ jest
     getByID: () => mockEmptyObject,
   }));
 
-const React = require('react');
-
 jest.doMock('requireNativeComponent', () => {
+  const React = require('react');
+
   return (viewName) => {
     return (props) => {
       return React.createElement(


### PR DESCRIPTION
Fixes warnings such as `Warning: Native component for "RCTView" does not exist` when you don't mock the native view class on `UIManager`.

**Test plan (required)**

Run `npm test` with it and without it, notice that warnings are gone and results are the same.

cc @cpojer 