### PR TITLE
Fixes react-native link for apps with extra xcode projects in the root folder

### DIFF
--- a/local-cli/core/config/ios/findProject.js
+++ b/local-cli/core/config/ios/findProject.js
@@ -37,6 +37,9 @@ module.exports = function findProject(folder) {
     })
     .filter(project => {
       return path.dirname(project) === IOS_BASE || !TEST_PROJECTS.test(project);
+    })
+    .sort((projectA, projectB) => {
+      return path.dirname(projectA) === IOS_BASE? -1 : 1;
     });
 
   if (projects.length === 0) {


### PR DESCRIPTION
Adds a ```sort``` to ```findProject(folder)``` to boost ones in IOS_BASE to the top. Otherwise, if for example there is a git submodule project in the root app folder, the method will pick that one instead and linking will fail. 
Fixes issue #10494

