### PR TITLE
Add validate method to StyleSheet component

### DIFF
--- a/Libraries/StyleSheet/StyleSheet.js
+++ b/Libraries/StyleSheet/StyleSheet.js
@@ -19,6 +19,7 @@ var flatten = require('flattenStyle');
 
 export type Styles = {[key: string]: Object};
 export type StyleSheet<S: Styles> = {[key: $Keys<S>]: number};
+export type StyleObject<S: Styles> = {[key: $Keys<S>]: Object};
 
 var hairlineWidth = PixelRatio.roundToNearestPixel(0.4);
 if (hairlineWidth === 0) {
@@ -95,7 +96,7 @@ module.exports = {
    * on the underlying platform. However, you should not rely on it being a
    * constant size, because on different platforms and screen densities its
    * value may be calculated differently.
-   * 
+   *
    * A line with hairline width may not be visible if your simulator is downscaled.
    */
   hairlineWidth,
@@ -161,6 +162,50 @@ module.exports = {
    * the alternative use.
    */
   flatten,
+
+  /**
+   * Sometimes you may want to validate your style object
+   * without creating StyleSheet style object.
+   *
+   * > **NOTE**: Exercise caution as abusing this can tax you in terms of
+   * > optimizations.
+   * >
+   * > IDs enable optimizations through the bridge and memory in general. Refering
+   * > to style objects directly will deprive you of these optimizations.
+   *
+   * Example:
+   * ```
+   * var styles = StyleSheet.validate({
+   *   listItem: {
+   *     flex: 1,
+   *     color: '#eeeeee',
+   *   },
+   *   selectedListItem: {
+   *     color: '#ffffff',
+   *   },
+   * });
+   *
+   * console.log(styles);
+   * // returns {listItem: {flex: 1, color: '#eeeeee'}, selectedListItem: { color: '#ffffff'}}
+   *
+   * var styles = StyleSheet.validate({
+   *   listItem: {
+   *     invalidProperty: 1,
+   *   },
+   * });
+   * // Will throw exception: "invalidProperty" is not a valid style property.
+   * ```
+   * This method internally uses `StyleSheetValidation.validateStyle(key, obj)`
+   * to validate style objects. Returns the same object.
+   * If you need style validation use 'StyleSheet.validate' instead of creating StyleSheet style
+   * and `flatten` together.
+   */
+  validate<S: Styles>(obj: S): StyleObject<S> {
+    for (var key in obj) {
+      StyleSheetValidation.validateStyle(key, obj);
+    }
+    return obj;
+  },
 
   /**
    * Creates a StyleSheet style reference from the given object.


### PR DESCRIPTION
This PR makes it so that adding a new `validate` method to StyleSheet component.
The main motivation is so a lot of popular react-native libraries* doesn't support StyleSheet style. Sometimes I have used `flatten` method for an extracting style object.
In my opinion, it's good to have validation method for such situations.

I believe this to be the good feature for developers. Would be much appreciated if we could get this merged in.

Thanks! Let me know if you have any questions.

*For example, few libraries doesn't support StyleSheet style:
https://github.com/react-native-community/react-native-elements
https://github.com/GeekyAnts/NativeBase