### PR TITLE
[docs] Update Android support URL

### DIFF
--- a/local-cli/runAndroid/runAndroid.js
+++ b/local-cli/runAndroid/runAndroid.js
@@ -116,7 +116,7 @@ function buildAndRun(args) {
     console.log(chalk.red(
       'Could not install the app on the device, read the error above for details.\n' +
       'Make sure you have an Android emulator running or a device connected and have\n' +
-      'set up your Android development environment:\n' +
+      'set up your Android development environment.\n' +
       'Go to https://facebook.github.io/react-native/docs/getting-started.html\n' +
       'and check the Android tab for setup instructions.'
     ));

--- a/local-cli/runAndroid/runAndroid.js
+++ b/local-cli/runAndroid/runAndroid.js
@@ -117,7 +117,8 @@ function buildAndRun(args) {
       'Could not install the app on the device, read the error above for details.\n' +
       'Make sure you have an Android emulator running or a device connected and have\n' +
       'set up your Android development environment:\n' +
-      'https://facebook.github.io/react-native/docs/android-setup.html'
+      'Go to https://facebook.github.io/react-native/docs/getting-started.html\n' +
+      'and check the Android tab for setup instructions.'
     ));
     // stderr is automatically piped from the gradle process, so the user
     // should see the error already, there is no need to do


### PR DESCRIPTION
> Explain the **motivation** for making this change. What existing problem does the pull request solve?

There's no longer a seaprate page for Android setup instructions, it just redirects to the getting started page, where you have to navigate futher.

**Test plan (required)**

None.
