### PR TITLE
avoid "white flash" after LaunchScreen

### DIFF
--- a/local-cli/generator-ios/templates/app/AppDelegate.m
+++ b/local-cli/generator-ios/templates/app/AppDelegate.m
@@ -31,6 +31,10 @@
   rootViewController.view = rootView;
   self.window.rootViewController = rootViewController;
   [self.window makeKeyAndVisible];
+
+  UIView* launchScreen = [[[NSBundle mainBundle] loadNibNamed:@"LaunchScreen" owner:self options:nil] objectAtIndex:0];
+  launchScreen.frame = [UIScreen mainScreen].bounds;
+  rootView.loadingView = launchScreen;
   return YES;
 }
 


### PR DESCRIPTION
The RCTRootView shows for at least one frame its background Color (default white) before JS/React is ready. This is annoying. Special if you want to animate the Launchscreen after its gone in ReactNative (Something like the Twitter IOS App).

I think this will help, getting ReactNative apps Start more smoothly. I use it and it works, think i will help others

Greez Christoph
