### PR TITLE
Integration test stability: add delay before starting TimersTest

### DIFF
--- a/IntegrationTests/TimersTest.js
+++ b/IntegrationTests/TimersTest.js
@@ -35,7 +35,7 @@ var TimersTest = React.createClass({
   },
 
   componentDidMount() {
-    this.testSetTimeout0();
+    this.setTimeout(this.testSetTimeout0, 1000);
   },
 
   testSetTimeout0() {


### PR DESCRIPTION
* Motivation

Locally I'm seeing consistent failures in IntegrationTests/TimersTest.js.  Adding a little delay before starting the first test seems to make these issues go away.