### PR TITLE
[KeyboardAvoidingView] Don't configure the next layout animation if the height hasn't changed

### DIFF
--- a/Libraries/Components/Keyboard/KeyboardAvoidingView.js
+++ b/Libraries/Components/Keyboard/KeyboardAvoidingView.js
@@ -104,13 +104,19 @@ const KeyboardAvoidingView = React.createClass({
     }
 
     const {duration, easing, endCoordinates} = event;
+    const {bottom} = this.state;
     const height = this.relativeKeyboardHeight(endCoordinates);
+
+    if (bottom === height) {
+      // If the keyboard height didn't change, there's no need to update the layout.
+      return;
+    }
 
     if (duration && easing) {
       LayoutAnimation.configureNext({
-        duration: duration,
+        duration,
         update: {
-          duration: duration,
+          duration,
           type: LayoutAnimation.Types[easing] || 'keyboard',
         },
       });
@@ -170,7 +176,7 @@ const KeyboardAvoidingView = React.createClass({
 
       case 'position':
         const positionStyle = {bottom: this.state.bottom};
-        const { contentContainerStyle } = this.props;
+        const {contentContainerStyle} = this.props;
 
         return (
           <View ref={viewRef} style={style} onLayout={this.onLayout} {...props}>


### PR DESCRIPTION
### Problem

Scenario: a view wrapped with a KeyboardAvoidingView that contains multiple TextInput components as children.

Right now, when you tap between the TextInputs, you queue up a bunch of LayoutAnimations that aren't executed because the state on the KeyboardAvoidingView does not update and thus does not change it's layout.

This means that any other action (such as navigating back on the Navigator) would receive this queued LayoutAnimation sometimes causing views to move in unexpected ways.
### Test plan (required)

Unfortunately, I can't send a video of the app we're building, but if necessary, I can put together a small example to show the issue.

Make sure tests pass on both Travis and Circle CI.
### Code formatting

I made a few small style changes to be consistent with the rest of the codebase:
1. remove spaces around destructuring
2. variables with the same name as the key inside objects
