### PR TITLE
add textProps to NavigationHeaderTitle

### DIFF
--- a/Libraries/CustomComponents/NavigationExperimental/NavigationHeaderTitle.js
+++ b/Libraries/CustomComponents/NavigationExperimental/NavigationHeaderTitle.js
@@ -47,11 +47,12 @@ type Props = {
   style?: any,
   textStyle?: any,
   viewProps?: any,
+  textProps?: any,
 }
 
-const NavigationHeaderTitle = ({ children, style, textStyle, viewProps }: Props) => (
+const NavigationHeaderTitle = ({ children, style, textStyle, viewProps, textProps }: Props) => (
   <View style={[ styles.title, style ]} {...viewProps}>
-    <Text style={[ styles.titleText, textStyle ]}>{children}</Text>
+    <Text style={[ styles.titleText, textStyle ]} {...textProps}>{children}</Text>
   </View>
 );
 


### PR DESCRIPTION
I want to add option to set props (eg: numberOfLines to truncate long titles) for the internal `<Text/>` in header titles.
