### PR TITLE
Fixing typo in Accessibility documentation

### DIFF
--- a/docs/Accessibility.md
+++ b/docs/Accessibility.md
@@ -127,7 +127,7 @@ In the case of two overlapping UI components with the same parent, default acces
     <Text> First layout </Text>
   </View>
   <View style={{position: 'absolute', left: 10, top: 10, right: 10, height: 100,
-    backgroundColor: 'yellow'}} importantForAccessibility=”no-hide-descendant”>
+    backgroundColor: 'yellow'}} importantForAccessibility=”no-hide-descendants”>
     <Text> Second layout </Text>
   </View>
 </View>


### PR DESCRIPTION
Currently there is a typo in Accessibility.md which will result in an invalid prop type warning if directly adhered to.  The instance of `no-hide-descendant` should instead be updated to `no-hide-descendants` (plural) in the documentation.