### PR TITLE
Fix timing issues in RCTLoggingTests.m

### DIFF
--- a/Examples/UIExplorer/UIExplorerIntegrationTests/RCTLoggingTests.m
+++ b/Examples/UIExplorer/UIExplorerIntegrationTests/RCTLoggingTests.m
@@ -51,14 +51,6 @@
   XCTAssertFalse(_bridge.loading);
 
   _logSem = dispatch_semaphore_create(0);
-  RCTSetLogFunction(^(RCTLogLevel level, RCTLogSource source, __unused NSString *fileName, __unused NSNumber *lineNumber, NSString *message) {
-    if (source == RCTLogSourceJavaScript) {
-      self->_lastLogLevel = level;
-      self->_lastLogSource = source;
-      self->_lastLogMessage = message;
-      dispatch_semaphore_signal(self->_logSem);
-    }
-  });
 }
 
 - (void)tearDown
@@ -71,7 +63,21 @@
 
 - (void)testLogging
 {
-  [_bridge enqueueJSCall:@"LoggingTestModule.logToConsole" args:@[@"Invoking console.log"]];
+  // First console log call will fire after 2.0 sec, to allow for any initial log messages
+  // that might come in (seeing this in tvOS)
+  [_bridge enqueueJSCall:@"LoggingTestModule.logToConsoleAfterWait" args:@[@"Invoking console.log",@2000]];
+  // Spin native layer for 1.9 sec
+  [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:1.9]];
+  // Now set the log function to signal the semaphore
+  RCTSetLogFunction(^(RCTLogLevel level, RCTLogSource source, __unused NSString *fileName, __unused NSNumber *lineNumber, NSString *message) {
+    if (source == RCTLogSourceJavaScript) {
+      self->_lastLogLevel = level;
+      self->_lastLogSource = source;
+      self->_lastLogMessage = message;
+      dispatch_semaphore_signal(self->_logSem);
+    }
+  });
+  // Wait for console log to signal the semaphore
   dispatch_semaphore_wait(_logSem, DISPATCH_TIME_FOREVER);
 
   XCTAssertEqual(_lastLogLevel, RCTLogLevelInfo);

--- a/IntegrationTests/LoggingTestModule.js
+++ b/IntegrationTests/LoggingTestModule.js
@@ -19,6 +19,11 @@ var LoggingTestModule = {
   logToConsole: function(str) {
     console.log(str);
   },
+  logToConsoleAfterWait: function(str,timeout_ms) {
+    setTimeout(function() {
+      console.log(str);
+    },timeout_ms);
+  },
   warning: function(str) {
     warning(false, str);
   },

--- a/IntegrationTests/LoggingTestModule.js
+++ b/IntegrationTests/LoggingTestModule.js
@@ -22,7 +22,7 @@ var LoggingTestModule = {
   logToConsoleAfterWait: function(str,timeout_ms) {
     setTimeout(function() {
       console.log(str);
-    },timeout_ms);
+    }, timeout_ms);
   },
   warning: function(str) {
     warning(false, str);


### PR DESCRIPTION
**Motivation**

If there are any console log messages that come in on initialization (as will happen right now in tvOS), the RCTLoggingTests can fail intermittently.  This change delays the start of the logging test to allow time for initial console messages to come in.

