### PR TITLE
debuggerWorker.js contains code incompatible with node 5

### DIFF
--- a/local-cli/server/util/debuggerWorker.js
+++ b/local-cli/server/util/debuggerWorker.js
@@ -15,7 +15,7 @@ var messageHandlers = {
     for (var key in message.inject) {
       self[key] = JSON.parse(message.inject[key]);
     }
-    let error;
+    var error;
     try {
       importScripts(message.url);
     } catch (err) {


### PR DESCRIPTION
Hi,

This is a small fix for issue #10564.