### PR TITLE
If no match return at least the first font in the family.

### DIFF
--- a/React/Views/RCTFont.mm
+++ b/React/Views/RCTFont.mm
@@ -301,6 +301,15 @@ RCT_ARRAY_CONVERTER(RCTFontVariantDescriptor)
     }
   }
 
+  // If we still don't have a match at least return the first font in the fontFamily
+  // This is to support built-in font Zapfino and other custom single font families like Impact
+  if (!font) {
+    NSArray *names = [UIFont fontNamesForFamilyName:familyName];
+    if (names.count > 0) {
+      font = [UIFont fontWithName:names[0] size:fontSize];
+    }
+  }
+
   // Apply font variants to font object
   if (variant) {
     NSArray *fontFeatures = [RCTConvert RCTFontVariantDescriptorArray:variant];


### PR DESCRIPTION
Solves issue #7632 where fonts with only a single font weight/type would not render.

Example of a built-in font that would not render is `Zapfino` and other custom fonts like `Impact` would not render.
