### PR TITLE
Expose NavigatorIOS::replaceAtIndex

### DIFF
--- a/Libraries/Components/Navigation/NavigatorIOS.ios.js
+++ b/Libraries/Components/Navigation/NavigatorIOS.ios.js
@@ -512,6 +512,7 @@ var NavigatorIOS = React.createClass({
       pop: this.pop,
       popN: this.popN,
       replace: this.replace,
+      replaceAtIndex: this.replaceAtIndex,
       replacePrevious: this.replacePrevious,
       replacePreviousAndPop: this.replacePreviousAndPop,
       resetTo: this.resetTo,


### PR DESCRIPTION
The React Native docs list `replaceAtIndex` as a public method of the **NavigatorIOS** component but it is never exposed.
