### PR TITLE
[Animated] Use native animations in TouchableBounce and TouchableOpacity

### DIFF
--- a/Libraries/Components/Touchable/TouchableBounce.js
+++ b/Libraries/Components/Touchable/TouchableBounce.js
@@ -88,6 +88,7 @@ var TouchableBounce = React.createClass({
       toValue: value,
       velocity,
       bounciness,
+      useNativeDriver: true,
     }).start(callback);
   },
 

--- a/Libraries/Components/Touchable/TouchableOpacity.js
+++ b/Libraries/Components/Touchable/TouchableOpacity.js
@@ -87,7 +87,7 @@ var TouchableOpacity = React.createClass({
   setOpacityTo: function(value: number) {
     Animated.timing(
       this.state.anim,
-      {toValue: value, duration: 150}
+      {toValue: value, duration: 150, useNativeDriver: true}
     ).start();
   },
 


### PR DESCRIPTION
Now that native animations for opacity and springs have landed in both iOS and Android, we can enable native animations both for TouchableBounce and TouchableOpacity.

Test Plan: Open the UIExplorer's Touchable demo and tap the "Enabled TouchableOpacity" component. Then change it to be TouchableBounce and reload the app and verify that works too. Do this on iOS and Android.