### PR TITLE
remove busywork of upgrade docs, move to symbols

### DIFF
--- a/docs/Upgrading.md
+++ b/docs/Upgrading.md
@@ -20,10 +20,11 @@ Note the latest version of the `react-native` npm package from here (or use `npm
 
 * https://www.npmjs.com/package/react-native
 
-Now install that version of `react-native` in your project with `npm install --save`. For example, to upgrade to the version `0.34`, in a terminal run:
+Now install that version of `react-native` in your project with `npm install --save`.
 
 ```sh
-$ npm install --save react-native@0.34
+$ npm install --save react-native@X.Y 
+# where X.Y is the semantic version you are upgrading to
 ```
 
 ## 2. Upgrade your project templates


### PR DESCRIPTION
We constantly get PRs that are busywork.

_e.g._ https://github.com/facebook/react-native/pull/10555#issuecomment-256301537

This PR hopefully makes a clear doc that won't get PRs.