### PR TITLE
Add default .babelrc

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -98,6 +98,14 @@ Node.js comes with npm, which lets you install the React Native command line int
 npm install -g react-native-cli
 ```
 
+Ensure your version of npm is greater than 3:
+```
+npm --version
+```
+If it is not you can update npm:
+```
+npm install npm@latest -gs
+```
 > If you get a *permission error*, try using sudo: `sudo npm install -g react-native-cli`.
 
 > If you get an error like `Cannot find module 'npmlog'`, try installing npm directly: `curl -0 -L http://npmjs.org/install.sh | sudo sh`.

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -104,7 +104,7 @@ npm --version
 ```
 If it is not you can update npm:
 ```
-npm install npm@latest -gs
+npm install npm@latest -g
 ```
 > If you get a *permission error*, try using sudo: `sudo npm install -g react-native-cli`.
 

--- a/local-cli/__tests__/generators-test.js
+++ b/local-cli/__tests__/generators-test.js
@@ -52,6 +52,7 @@ xdescribe('React Yeoman Generators', function() {
         '.flowconfig',
         '.gitignore',
         '.watchmanconfig',
+        '.babelrc',
         'index.ios.js',
         'index.android.js'
       ]);

--- a/local-cli/generator/index.js
+++ b/local-cli/generator/index.js
@@ -73,6 +73,10 @@ module.exports = yeoman.generators.NamedBase.extend({
       this.templatePath('_buckconfig'),
       this.destinationPath('.buckconfig')
     );
+    this.fs.copy(
+      this.templatePath('_babelrc'),
+      this.destinationPath('.babelrc')
+    );
   },
 
   writing: function() {

--- a/local-cli/generator/templates/_babelrc
+++ b/local-cli/generator/templates/_babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["react-native"]
+}


### PR DESCRIPTION
This PR addresses issue #7821, where the app crashes due to a parent-directory `.babelrc` file.

Previously, a [PR](https://github.com/namuol/react-native-explicit-default-babelrc/commit/59e872101329a7004359827065e307498ca92e20) tried to submit a fix by adding a default `.babelrc` file in new React Native projects, but was rejected so as not to add a peer dependency to react native.

In this PR, a default .babelrc is created with standard presets `{ "presets": ["react-native"] }`. The docs are modified to recommend using a version of NPM greater than 3. This would ensure that the default `.babelrc` does not cause any complications, as was noted by @janicduplessis for npm2. 

As for tests, the `.babelrc` is tested for in the `local-cli/__tests__/generator-tests.js` file. I also ran all the internal tests with `npm test` and there was no difference in output after the specified changes.