### PR TITLE
os.tmpDir() is deprecated

### DIFF
--- a/packager/react-packager/src/node-haste/Cache/__tests__/Cache-test.js
+++ b/packager/react-packager/src/node-haste/Cache/__tests__/Cache-test.js
@@ -15,7 +15,7 @@ jest
 jest
   .mock('fs')
   .setMock('os', {
-    tmpDir() { return 'tmpDir'; },
+    tmpdir() { return 'tmpdir'; },
   });
 
 jest.useRealTimers();

--- a/packager/react-packager/src/node-haste/Cache/index.js
+++ b/packager/react-packager/src/node-haste/Cache/index.js
@@ -17,7 +17,7 @@ const fs = require('graceful-fs');
 const isAbsolutePath = require('absolute-path');
 const path = require('path');
 /* $FlowFixMe: missing function definition. */
-const tmpDir = require('os').tmpDir();
+const tmpDir = require('os').tmpdir();
 
 function getObjectValues<T>(object: {[key: string]: T}): Array<T> {
   return Object.keys(object).map(key => object[key]);

--- a/packager/react-packager/src/node-haste/Cache/index.js
+++ b/packager/react-packager/src/node-haste/Cache/index.js
@@ -16,7 +16,6 @@ const denodeify = require('denodeify');
 const fs = require('graceful-fs');
 const isAbsolutePath = require('absolute-path');
 const path = require('path');
-/* $FlowFixMe: missing function definition. */
 const tmpDir = require('os').tmpdir();
 
 function getObjectValues<T>(object: {[key: string]: T}): Array<T> {


### PR DESCRIPTION
According to [5e5ec2cd1e](https://github.com/nodejs/node/commit/5e5ec2cd1e) os.tmpDir() is now deprecated in node.js 7 and `os.tmpdir()` is preferred :)

Current status: 
Bundler shows annoying warning every time it runs :)