### PR TITLE
Add the scheme configuration option to the run-ios command

### DIFF
--- a/docs/RunningOnDevice.md
+++ b/docs/RunningOnDevice.md
@@ -206,6 +206,10 @@ Building an app for distribution in the App Store requires using the `Release` s
 
 Apps built for `Release` will automatically disable the in-app Developer menu, which will prevent your users from inadvertently accessing the menu in production. It will also load the JavaScript locally, so you can put the app on a device and test whilst not connected to the computer.
 
+> Hint
+>
+> You can also use the `React Native CLI` to perform this operation using the option `--configuration` with the value `Release` (e.g. `react-native run-ios --configuration Release`).
+
 Once built for release, you'll be able to distribute the app to beta testers and submit the app to the App Store.
 
 ### App Transport Security


### PR DESCRIPTION
With the current `run-ios` script it is not possible to create/run iOS release builds or any other kind of scheme configuration from the terminal (we need to use `Xcode`). The reason for this is that the `run-ios` script does not expose the scheme configuration option for the `xcodebuild` command. This PR exposes that property and allows the developers to directly create/run release builds from the terminal.

This PR also closes [this](https://productpains.com/post/react-native/create-ios-release-builds-from-terminal) request at `productpains`.

And answers to [this](http://stackoverflow.com/questions/40303229/run-a-react-native-ios-release-build-from-terminal) question at the `stackoverflow`.

**Test plan (required)**

To generate a release build just run:

``` sh
react-native run-ios --configuration Release
```

The output

``` sh
Found Xcode project App.xcodeproj
Launching iPhone 6 (iOS 9.3)...
Building using "xcodebuild -project App.xcodeproj -scheme App -destination id=B0738993-CE4A-4D5A-B2A1-34C0DCEDED2E -derivedDataPath build -configuration Release"
User defaults from command line:

    IDEDerivedDataPathOverride = /Users/****/Desktop/****/app/ios/build


=== BUILD TARGET RCTImage OF PROJECT RCTImage WITH CONFIGURATION Release ===

......

** BUILD SUCCEEDED **


Installing build/Build/Products/Release-iphonesimulator/App.app
Launching com.App
com.App: 10339
```

Check the list of options available

``` sh
react-native run-ios --help
```

The output

``` sh
react-native run-ios [options]
  builds your app and starts it on iOS simulator

  Options:

    -h, --help                output usage information
    --simulator [string]      Explicitly set simulator to use
    --configuration [string]  Explicitly set the scheme configuration to use
    --scheme [string]         Explicitly set Xcode scheme to use
    --project-path [string]   Path relative to project root where the Xcode project (.xcodeproj) lives. The default is 'ios'.
    --device [string]         Explicitly set device to use by name.  The value is not required if you have a single device connected.
    --udid [string]           Explicitly set device to use by udid
    --config [string]         Path to the CLI configuration file

  Example usage:

    Run on a different simulator, e.g. iPhone 5:
    react-native run-ios --simulator "iPhone 5"

    Pass a non-standard location of iOS directory:
    react-native run-ios --project-path "./app/ios"

    Run on a connected device, e.g. Max's iPhone:
    react-native run-ios --device 'Max's iPhone'
```
