### PR TITLE
Use native animations if the animated value is native in NavigationCardStackPanResponder

### DIFF
--- a/Libraries/CustomComponents/NavigationExperimental/NavigationCardStackPanResponder.js
+++ b/Libraries/CustomComponents/NavigationExperimental/NavigationCardStackPanResponder.js
@@ -206,6 +206,7 @@ class NavigationCardStackPanResponder extends NavigationAbstractPanResponder {
       {
         toValue: props.navigationState.index,
         duration: ANIMATION_DURATION,
+        useNativeDriver: props.position.__isNative,
       }
     ).start();
   }


### PR DESCRIPTION
Since native and non-native animations do not work together check if the animated value is native and set useNativeDriver accordingly. So untill we move to always using the native driver this is needed. This and another fix in NativeAnimations module will allow using native animations to transitions with gestures.

**Test plan**
Tested in an app that uses native driven animations with a back gesture. This also needs #10643 and #10642 for everything to work properly.