### PR TITLE
Fix setAnimatedNodeValue in Native Animated on iOS

### DIFF
--- a/Libraries/NativeAnimation/RCTNativeAnimatedModule.m
+++ b/Libraries/NativeAnimation/RCTNativeAnimatedModule.m
@@ -183,6 +183,10 @@ RCT_EXPORT_METHOD(setAnimatedNodeValue:(nonnull NSNumber *)nodeTag
   RCTValueAnimatedNode *valueNode = (RCTValueAnimatedNode *)node;
   valueNode.value = value.floatValue;
   [valueNode setNeedsUpdate];
+
+  [self updateViewsProps];
+
+  [valueNode cleanupAnimationUpdate];
 }
 
 RCT_EXPORT_METHOD(setAnimatedNodeOffset:(nonnull NSNumber *)nodeTag
@@ -265,6 +269,12 @@ RCT_EXPORT_METHOD(stopListeningToAnimatedNodeValue:(nonnull NSNumber *)tag)
                      body:@{@"tag": node.nodeTag, @"value": @(value)}];
 }
 
+- (void)updateViewsProps
+{
+  for (RCTPropsAnimatedNode *propsNode in _propAnimationNodes) {
+    [propsNode updateNodeIfNecessary];
+  }
+}
 
 #pragma mark -- Animation Loop
 


### PR DESCRIPTION
`setAnimatedNodeValue` currently does not update views if there is no animation currently running. This simply updates the view immediately instead of relying on the animation loop. Extracted it out in a function to be able to use it for native `Animated.event` too.

**Test plan**
Tested this in an app using native driven animations with `NavigationCardStackPanResponder` that makes use of `setValue` to update `Animated.Values` during the back gesture.