### PR TITLE
Fix symbolication failure caused by attempt to modify frozen frame

### DIFF
--- a/Libraries/Core/Devtools/symbolicateStackTrace.js
+++ b/Libraries/Core/Devtools/symbolicateStackTrace.js
@@ -18,27 +18,38 @@ const {fetch} = require('fetch');
 
 import type {StackFrame} from 'parseErrorStack';
 
+function isSourcedFromDisk(sourcePath: string): boolean {
+  return !/^http/.test(sourcePath) && /[\\/]/.test(sourcePath);
+}
+
 async function symbolicateStackTrace(stack: Array<StackFrame>): Promise<Array<StackFrame>> {
   const devServer = getDevServer();
   if (!devServer.bundleLoadedFromServer) {
     throw new Error('Bundle was not loaded from the packager');
   }
-  if (SourceCode.scriptURL) {
-    for (let i = 0; i < stack.length; ++i) {
+
+  let stackCopy = stack;
+
+  if (SourceCode.scriptURL && stack.length > 0 && isSourcedFromDisk(stack[0].file)) {
+    let foundInternalSource: boolean = false;
+    stackCopy = stack.map((frame: StackFrame) => {
       // If the sources exist on disk rather than appearing to come from the packager,
       // replace the location with the packager URL until we reach an internal source
       // which does not have a path (no slashes), indicating a switch from within
       // the application to a surrounding debugging environment.
-      if (/^http/.test(stack[i].file) || !/[\\/]/.test(stack[i].file)) {
-        break;
+      if (!foundInternalSource && isSourcedFromDisk(frame.file)) {
+        // Copy frame into new object and replace 'file' property
+        return Object.assign({}, frame, {file: SourceCode.scriptURL});
       }
-      stack[i].file = SourceCode.scriptURL;
-    }
+
+      foundInternalSource = true;
+      return frame;
+    })
   }
 
   const response = await fetch(devServer.url + 'symbolicate', {
     method: 'POST',
-    body: JSON.stringify({stack}),
+    body: JSON.stringify({stack: stackCopy}),
   });
   const json = await response.json();
   return json.stack;

--- a/Libraries/Core/Devtools/symbolicateStackTrace.js
+++ b/Libraries/Core/Devtools/symbolicateStackTrace.js
@@ -39,12 +39,12 @@ async function symbolicateStackTrace(stack: Array<StackFrame>): Promise<Array<St
       // the application to a surrounding debugging environment.
       if (!foundInternalSource && isSourcedFromDisk(frame.file)) {
         // Copy frame into new object and replace 'file' property
-        return Object.assign({}, frame, {file: SourceCode.scriptURL});
+        return {...frame, file: SourceCode.scriptURL};
       }
 
       foundInternalSource = true;
       return frame;
-    })
+    });
   }
 
   const response = await fetch(devServer.url + 'symbolicate', {

--- a/Libraries/Core/Devtools/symbolicateStackTrace.js
+++ b/Libraries/Core/Devtools/symbolicateStackTrace.js
@@ -30,7 +30,7 @@ async function symbolicateStackTrace(stack: Array<StackFrame>): Promise<Array<St
 
   let stackCopy = stack;
 
-  if (SourceCode.scriptURL && stack.length > 0 && isSourcedFromDisk(stack[0].file)) {
+  if (SourceCode.scriptURL) {
     let foundInternalSource: boolean = false;
     stackCopy = stack.map((frame: StackFrame) => {
       // If the sources exist on disk rather than appearing to come from the packager,


### PR DESCRIPTION
This change makes so that processing stack trace before sending it to packager (see 7dbc805)
doesn't modify original frames but creates a copies instead.

This is required because after some changes that also have been landed in 0.35, frames that arrive to
'symbolicateStackTrace' are already frozen, so changing 'file' property of the original frame causes
symbolication to fail.