### PR TITLE
Fix initial value of native Animated.Value

### DIFF
--- a/Libraries/Animated/src/AnimatedImplementation.js
+++ b/Libraries/Animated/src/AnimatedImplementation.js
@@ -671,7 +671,6 @@ var _uniqueId = 1;
  */
 class AnimatedValue extends AnimatedWithChildren {
   _value: number;
-  _startingValue: number;
   _offset: number;
   _animation: ?Animation;
   _tracking: ?Animated;
@@ -680,7 +679,7 @@ class AnimatedValue extends AnimatedWithChildren {
 
   constructor(value: number) {
     super();
-    this._startingValue = this._value = value;
+    this._value = value;
     this._offset = 0;
     this._animation = null;
     this._listeners = {};
@@ -879,7 +878,8 @@ class AnimatedValue extends AnimatedWithChildren {
   __getNativeConfig(): Object {
     return {
       type: 'value',
-      value: this._startingValue,
+      value: this._value,
+      offset: this._offset,
     };
   }
 }


### PR DESCRIPTION
Native Animated.Value uses the value it was created with when sending the config to native but this causes issue when the value has changed before calling `__makeNative` this happens with the `progress` value for `NavigationExperimental`. It gets initialized with value 1, then uses `setValue` to change it to 0 before starting the animation and this is when `__makeNative` is called. This simply uses the current value instead of the value passed to the constructor. Also pass offset so native implementations that support it can use it (iOS).

**Test plan**
Tested that the first transition that uses the `progress` animated value is not broken in an app that uses `NavigationExperimental` when using `useNativeDriver` for animations.