### PR TITLE
Initialize RCTAnimatedNode with _needUpdate = YES

### DIFF
--- a/Libraries/NativeAnimation/Nodes/RCTAnimatedNode.m
+++ b/Libraries/NativeAnimation/Nodes/RCTAnimatedNode.m
@@ -23,6 +23,8 @@
   if ((self = [super init])) {
     _nodeTag = tag;
     _config = [config copy];
+    _hasUpdated = NO;
+    _needsUpdate = YES;
   }
   return self;
 }


### PR DESCRIPTION
I had some cases where animations would not play at all on iOS and this was due to some nodes not being marked as needing to update.

I don't have an exact repro or know 100% why it happens but this fixes the issue and makes sense to initialize node as needing to update. Also that _needsUpdate value is meant as an optimization to avoid traversing to node graph too much so it won't break anything.