### PR TITLE
[TextInput] Implements 'onKeyPress' for Android

### DIFF
--- a/Examples/UIExplorer/js/TextInputExample.android.js
+++ b/Examples/UIExplorer/js/TextInputExample.android.js
@@ -36,6 +36,7 @@ class TextEventsExample extends React.Component {
     curText: '<No Event>',
     prevText: '<No Event>',
     prev2Text: '<No Event>',
+    prev3Text: '<No Event>',
   };
 
   updateText = (text) => {
@@ -44,6 +45,7 @@ class TextEventsExample extends React.Component {
         curText: text,
         prevText: state.curText,
         prev2Text: state.prevText,
+        prev3Text: state.prev2Text,
       };
     });
   };
@@ -66,12 +68,16 @@ class TextEventsExample extends React.Component {
           onSubmitEditing={(event) => this.updateText(
             'onSubmitEditing text: ' + event.nativeEvent.text
           )}
+          onKeyPress={(event) => this.updateText(
+            'onKeyPress key: ' + event.nativeEvent.key
+          )}
           style={styles.singleLine}
         />
         <Text style={styles.eventLabel}>
           {this.state.curText}{'\n'}
           (prev: {this.state.prevText}){'\n'}
           (prev2: {this.state.prev2Text})
+          (prev3: {this.state.prev3Text})
         </Text>
       </View>
     );

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactKeyDownEvent.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactKeyDownEvent.java
@@ -1,0 +1,48 @@
+package com.facebook.react.views.textinput;
+
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.uimanager.events.Event;
+import com.facebook.react.uimanager.events.RCTEventEmitter;
+
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+public class ReactKeyDownEvent extends Event<ReactKeyDownEvent> {
+
+    private static final String EVENT_NAME = "topKeyDown";
+
+    private String mKey;
+
+    public ReactKeyDownEvent(
+            int viewId,
+            String key) {
+        super(viewId);
+        mKey = key;
+    }
+
+    @Override
+    public String getEventName() {
+        return EVENT_NAME;
+    }
+
+    @Override
+    public void dispatch(RCTEventEmitter rctEventEmitter) {
+        rctEventEmitter.receiveEvent(getViewTag(), getEventName(), serializeEventData());
+    }
+
+    private WritableMap serializeEventData() {
+        WritableMap eventData = Arguments.createMap();
+
+        //WritableMap selectionData = Arguments.createMap();
+        eventData.putString("key", mKey);
+
+        //eventData.putMap("selection", selectionData);
+        return eventData;
+    }
+}


### PR DESCRIPTION
An attempt at the Android implementation. Attempted to mirror the iOS implementation by supporting 'Enter' and 'Backspace'.

The implementation utilises the TextWatcher, because the [documentation](https://developer.android.com/reference/android/view/View.OnKeyListener.html#onKey(android.view.View, int, android.view.KeyEvent)) for OnKeyListener->onKey states:

> Key presses in software keyboards will generally NOT trigger this method, although some may elect to do so in some situations. Do not assume a software input method has to be key-based; even if it is, it may use key presses in a different way than you expect, **so there is no way to reliably catch soft input key presses.**

Because of this, in my implementation pressing backspace in an empty text field will not trigger onKeyPress. Using cut on selected text and pasting a single character will be interpreted as key presses.