### PR TITLE
Add currentHeight constant to status bar docs

### DIFF
--- a/Examples/UIExplorer/js/StatusBarExample.js
+++ b/Examples/UIExplorer/js/StatusBarExample.js
@@ -438,7 +438,7 @@ const examples = [{
   render() {
     return (
       <View>
-        <Text>Height: {StatusBar.currentHeight} pts</Text>
+        <Text>Height (Android only): {StatusBar.currentHeight} pts</Text>
       </View>
     );
   },

--- a/Libraries/Components/StatusBar/StatusBar.js
+++ b/Libraries/Components/StatusBar/StatusBar.js
@@ -131,6 +131,10 @@ function createStackEntry(props: any): any {
  * to use the static API and the component for the same prop because any value
  * set by the static API will get overriden by the one set by the component in
  * the next render.
+ *
+ * ### Constants
+ *
+ * `currentHeight` (Android only) The height of the status bar.
  */
 class StatusBar extends React.Component {
   props: {


### PR DESCRIPTION
This PR is to fix #10561 by adding `currentHeight` to a list of constants for the `StatusBar` component. It also makes it clear that this constant is Android only by also adding a further note to the example use.

Closes #10561

![screen shot 2016-11-01 at 12 37 06](https://cloud.githubusercontent.com/assets/2854338/19889978/f453d43a-a02f-11e6-859e-5a9ebeba9d44.png)
