### PR TITLE
Prevent escaped 'a' tag html from appearing in 'Integration With Exis…

### DIFF
--- a/docs/IntegrationWithExistingApps.md
+++ b/docs/IntegrationWithExistingApps.md
@@ -107,11 +107,11 @@ $ sudo gem install cocoapods
 
 <block class="objc" />
 
-Assume the [app for integration](https://github.com/JoelMarcey/iOS-2048) is a <a href="https://en.wikipedia.org/wiki/2048_(video_game)">2048</a> game. Here is what the main menu of the native application looks like without React Native.
+Assume the [app for integration](https://github.com/JoelMarcey/iOS-2048) is a [2048](https://en.wikipedia.org/wiki/2048_%28video_game%29) game. Here is what the main menu of the native application looks like without React Native.
 
 <block class="swift" />
 
-Assume the [app for integration](https://github.com/JoelMarcey/swift-2048) is a <a href="https://en.wikipedia.org/wiki/2048_(video_game)">2048</a> game. Here is what the main menu of the native application looks like without React Native.
+Assume the [app for integration](https://github.com/JoelMarcey/swift-2048) is a [2048](https://en.wikipedia.org/wiki/2048_%28video_game%29) game. Here is what the main menu of the native application looks like without React Native.
 
 <block class="objc swift" />
 


### PR DESCRIPTION
Explain the **motivation** for making this change. What existing problem does the pull request solve?

- Prevents unclickable, escaped HTML from appearing in the docs.

[Before](https://facebook.github.io/react-native/docs/integration-with-existing-apps.html#our-sample-app):
![screen shot 2016-11-01 at 2 45 14 pm](https://cloud.githubusercontent.com/assets/3209502/19904789/263a4080-a042-11e6-8d9e-f88d3f8e5a77.png)

After:
![screen shot 2016-11-01 at 2 45 29 pm](https://cloud.githubusercontent.com/assets/3209502/19904813/39a5dcf6-a042-11e6-9dfb-766af44a246c.png)
