### PR TITLE
Set android:windowSoftInputMode to adjustResize on AndroidManifest.xml

### DIFF
--- a/local-cli/generator-android/templates/src/app/src/main/AndroidManifest.xml
+++ b/local-cli/generator-android/templates/src/app/src/main/AndroidManifest.xml
@@ -19,6 +19,7 @@
       <activity
         android:name=".MainActivity"
         android:label="@string/app_name"
+        android:windowSoftInputMode="adjustResize"
         android:configChanges="keyboard|keyboardHidden|orientation|screenSize">
         <intent-filter>
             <action android:name="android.intent.action.MAIN" />


### PR DESCRIPTION
It fixes layout issues when showing soft keyboard on Android
- fixes #8180, #10517
- It doesn't require using KeyboardAvoidingView on Android