### PR TITLE
Added the ability to set the storage location

### DIFF
--- a/Libraries/Storage/AsyncStorage.js
+++ b/Libraries/Storage/AsyncStorage.js
@@ -490,10 +490,11 @@ var AsyncStorage = {
    *
    * @platform ios
    */
-  setStorageLocation: function(storageLocation: string) {
+  setStorageLocationIOS: function(storageLocation: string) {
     RCTAsyncStorage.setStorageLocation(storageLocation);
   },
-  StorageLocation: {
+
+  StorageLocationIOS: {
     documents: RCTAsyncStorage.documents,
     applicationSupport: RCTAsyncStorage.applicationSupport
   }

--- a/Libraries/Storage/AsyncStorage.js
+++ b/Libraries/Storage/AsyncStorage.js
@@ -487,12 +487,16 @@ var AsyncStorage = {
    *
    * **Note**: changing this only sets the location for future actions and does not migrate
    * the store from the previous location.
+   *
+   * @platform ios
    */
   setStorageLocation: function(storageLocation: string) {
     RCTAsyncStorage.setStorageLocation(storageLocation);
   },
-  documents: RCTAsyncStorage.documents,
-  applicationSupport: RCTAsyncStorage.applicationSupport
+  StorageLocation: {
+    documents: RCTAsyncStorage.documents,
+    applicationSupport: RCTAsyncStorage.applicationSupport
+  }
 };
 
 // Not all native implementations support merge.

--- a/Libraries/Storage/AsyncStorage.js
+++ b/Libraries/Storage/AsyncStorage.js
@@ -480,6 +480,19 @@ var AsyncStorage = {
       });
     });
   },
+
+  /**
+   * Call this set the storage location.
+   * @param storageLocation The storage location. Can be 'documents' or 'applicationSupport'.
+   *
+   * **Note**: changing this only sets the location for future actions and does not migrate
+   * the store from the previous location.
+   */
+  setStorageLocation: function(storageLocation: string) {
+    RCTAsyncStorage.setStorageLocation(storageLocation);
+  },
+  documents: RCTAsyncStorage.documents,
+  applicationSupport: RCTAsyncStorage.applicationSupport
 };
 
 // Not all native implementations support merge.

--- a/React/Modules/RCTAsyncLocalStorage.m
+++ b/React/Modules/RCTAsyncLocalStorage.m
@@ -19,15 +19,17 @@
 #import "RCTUtils.h"
 
 typedef NS_ENUM(NSInteger, StorageLocation) {
-    Documents,
-    ApplicationSupport
+  Documents,
+  ApplicationSupport
 };
 
 @implementation RCTConvert (StorageLocation)
-  RCT_ENUM_CONVERTER(StorageLocation, (@{
-    @"documents" : @(Documents),
-    @"applicationSupport" : @(ApplicationSupport)
-  }), Documents, integerValue)
+
+RCT_ENUM_CONVERTER(StorageLocation, (@{
+  @"documents": @(Documents),
+  @"applicationSupport": @(ApplicationSupport),
+}), Documents, integerValue)
+
 @end
 
 static NSString *const RCTStorageDirectory = @"RCTAsyncLocalStorage_V1";
@@ -81,7 +83,7 @@ static NSString *RCTGetStorageDirectory()
   static dispatch_once_t onceToken;
 
   NSSearchPathDirectory searchDir = NSDocumentDirectory;
-  if(storageLocation == ApplicationSupport)
+  if (storageLocation == ApplicationSupport)
     searchDir = NSApplicationSupportDirectory;
 
   dispatch_once(&onceToken, ^{
@@ -190,8 +192,10 @@ RCT_EXPORT_MODULE()
 
 - (NSDictionary *)constantsToExport
 {
-  return @{ @"documents" : @(Documents),
-            @"applicationSupport" : @(ApplicationSupport) };
+  return @{
+    @"documents": @(Documents),
+    @"applicationSupport": @(ApplicationSupport)
+  };
 };
 
 - (void)clearAllData

--- a/React/Modules/RCTAsyncLocalStorage.m
+++ b/React/Modules/RCTAsyncLocalStorage.m
@@ -18,9 +18,22 @@
 #import "RCTLog.h"
 #import "RCTUtils.h"
 
+typedef NS_ENUM(NSInteger, StorageLocation) {
+    Documents,
+    ApplicationSupport
+};
+
+@implementation RCTConvert (StorageLocation)
+  RCT_ENUM_CONVERTER(StorageLocation, (@{
+    @"documents" : @(Documents),
+    @"applicationSupport" : @(ApplicationSupport)
+  }), Documents, integerValue)
+@end
+
 static NSString *const RCTStorageDirectory = @"RCTAsyncLocalStorage_V1";
 static NSString *const RCTManifestFileName = @"manifest.json";
 static const NSUInteger RCTInlineValueThreshold = 1024;
+static StorageLocation storageLocation = Documents;
 
 #pragma mark - Static helper functions
 
@@ -66,11 +79,16 @@ static NSString *RCTGetStorageDirectory()
 {
   static NSString *storageDirectory = nil;
   static dispatch_once_t onceToken;
+
+  NSSearchPathDirectory searchDir = NSDocumentDirectory;
+  if(storageLocation == ApplicationSupport)
+    searchDir = NSApplicationSupportDirectory;
+
   dispatch_once(&onceToken, ^{
 #if TARGET_OS_TV
     storageDirectory = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES).firstObject;
 #else
-    storageDirectory = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES).firstObject;
+    storageDirectory = NSSearchPathForDirectoriesInDomains(searchDir, NSUserDomainMask, YES).firstObject;
 #endif
     storageDirectory = [storageDirectory stringByAppendingPathComponent:RCTStorageDirectory];
   });
@@ -169,6 +187,12 @@ RCT_EXPORT_MODULE()
 {
   return RCTGetMethodQueue();
 }
+
+- (NSDictionary *)constantsToExport
+{
+  return @{ @"documents" : @(Documents),
+            @"applicationSupport" : @(ApplicationSupport) };
+};
 
 - (void)clearAllData
 {
@@ -451,6 +475,11 @@ RCT_EXPORT_METHOD(getAllKeys:(RCTResponseSenderBlock)callback)
   } else {
     callback(@[(id)kCFNull, _manifest.allKeys]);
   }
+}
+
+RCT_EXPORT_METHOD(setStorageLocation:(StorageLocation)location)
+{
+  storageLocation = location;
 }
 
 @end


### PR DESCRIPTION
AsyncStorage shouldn't store in the Documents folder because that is accessible via iTunes. A good place for settings for example is Application Support. I've added the ability to set the storage location to Application Support. However the default is still Documents, so the change isn't breaking. Unlike [PR #4561](https://github.com/facebook/react-native/pull/4561) I make no attempt to migrate the old location to the new.
Store migration could be added in a later PR.