### PR TITLE
Fixed $PATH guide for Linux users

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -238,7 +238,7 @@ export PATH=${PATH}:${ANDROID_HOME}/tools
 export PATH=${PATH}:${ANDROID_HOME}/platform_tools
 ```
 
-The second line will add the `android` tool to your path, which will come in handy in the next step.
+The second line will add the `android` tool to your path, which will come in handy in the next step. The third line will add the `adb` tool to your path, which is used to communicate with your Android device / emulator.
 
 > Please make sure you export the correct path for `ANDROID_HOME` if you did not install the Android SDK using Android Studio.
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -235,6 +235,7 @@ Create or edit your `~/.bashrc` file and add the following lines:
 ```
 export ANDROID_HOME=~/Android/Sdk
 export PATH=${PATH}:${ANDROID_HOME}/tools
+export PATH=${PATH}:${ANDROID_HOME}/platform_tools
 ```
 
 The second line will add the `android` tool to your path, which will come in handy in the next step.


### PR DESCRIPTION
`react-native run-android` will need `adb` in `$PATH` as I explained in issue #10702.