### PR TITLE
StatusBar: fix incorrect setHidden(hidden) docs description

### DIFF
--- a/Libraries/Components/StatusBar/StatusBar.js
+++ b/Libraries/Components/StatusBar/StatusBar.js
@@ -175,7 +175,7 @@ class StatusBar extends React.Component {
 
   /**
    * Show or hide the status bar
-   * @param hidden The dialog's title.
+   * @param hidden Hide the status bar.
    * @param animation Optional animation when
    *    changing the status bar hidden property.
    */


### PR DESCRIPTION
Hi!

Just noticed an incorrect description for the `hidden` argument for `StatusBar.setHidden()` on the website, this trivial change fixes that.

FYI I followed the start procedure for the website mentioned in [CONTRIBUTING.md](https://github.com/facebook/react-native/blob/master/CONTRIBUTING.md#pull-requests), and noticed one needs to run `npm install` in the project root directory as well before starting the website. Do you want me to add that instruction as part of this PR, or as a separate PR entirely?