### PR TITLE
Add Safety Wizard to showcase

### DIFF
--- a/website/src/react-native/showcase.js
+++ b/website/src/react-native/showcase.js
@@ -313,7 +313,7 @@ var featured = [
   },
   {
     name: 'Safety Wizard',
-    icon: 'https://itunes.apple.com/gb/app/sme-safety-wizard/id957810075?mt=8',
+    icon: 'http://a4.mzstatic.com/eu/r30/Purple71/v4/1d/af/53/1daf5343-eeca-bec0-5c4f-09247845bb8e/icon175x175.png',
     linkAppStore: 'https://itunes.apple.com/gb/app/sme-safety-wizard/id957810075',
     linkPlayStore: 'https://play.google.com/store/apps/details?id=com.rnfdigital.safetywizard',
     infoLink: 'http://rnfdigital.com/safety-wizard-app-now-available-on-android/',

--- a/website/src/react-native/showcase.js
+++ b/website/src/react-native/showcase.js
@@ -310,7 +310,16 @@ var featured = [
     linkAppStore: 'http://apple.co/2dfkYH9',
     infoLink: 'https://blog.getchop.io/how-we-built-chop-bae3d8acd131#.7y8buamrq',
     infoTitle: 'How we built Chop',
-  }  
+  },
+  {
+    name: 'Safety Wizard',
+    icon: 'https://itunes.apple.com/gb/app/sme-safety-wizard/id957810075?mt=8',
+    linkAppStore: 'https://itunes.apple.com/gb/app/sme-safety-wizard/id957810075',
+    linkPlayStore: 'https://play.google.com/store/apps/details?id=com.rnfdigital.safetywizard',
+    infoLink: 'http://rnfdigital.com/safety-wizard-app-now-available-on-android/',
+    infoTitle: 'Safety Wizard App now available on Android',
+    defaultLink: 'https://itunes.apple.com/gb/app/sme-safety-wizard/id957810075',
+  }
 ];
 
 /*

--- a/website/src/react-native/showcase.js
+++ b/website/src/react-native/showcase.js
@@ -317,7 +317,7 @@ var featured = [
     linkAppStore: 'https://itunes.apple.com/gb/app/sme-safety-wizard/id957810075',
     linkPlayStore: 'https://play.google.com/store/apps/details?id=com.rnfdigital.safetywizard',
     infoLink: 'http://rnfdigital.com/safety-wizard-app-now-available-on-android/',
-    infoTitle: 'Safety Wizard App now available on Android',
+    infoTitle: 'React Native enables android version of safety app',
     defaultLink: 'https://itunes.apple.com/gb/app/sme-safety-wizard/id957810075',
   }
 ];


### PR DESCRIPTION
Safety Wizard started as an Objective-C iOS application and was recently migrated to React Native to have a single codebase across our iOS and Android apps.

This PR has been updated to reflect the guidelines as per @hramos in the previous PR #10679