### PR TITLE
Add `React` name mapping to the preset

### DIFF
--- a/jest-preset.json
+++ b/jest-preset.json
@@ -8,7 +8,8 @@
   },
   "moduleNameMapper": {
     "^image![a-zA-Z0-9$_-]+$": "GlobalImageStub",
-    "^[./a-zA-Z0-9$_-]+\\.(bmp|gif|jpg|jpeg|png|psd|svg|webp)$": "RelativeImageStub"
+    "^[./a-zA-Z0-9$_-]+\\.(bmp|gif|jpg|jpeg|png|psd|svg|webp)$": "RelativeImageStub",
+    "^React$": "<rootDir>node_modules/react"
   },
   "modulePathIgnorePatterns": [
     "<rootDir>/node_modules/react-native/Libraries/react-native/",


### PR DESCRIPTION
Fixes breakage on https://circleci.com/gh/facebook/react-native/12763 after the upgrade of React

Explain the **motivation** for making this change. What existing problem does the pull request solve?

Jest preset has been upgraded so that requiring `React` capitalized can be possible

**Test plan (required)**

Couldn't reproduce it locally, we need to see if Circle passes.
