### PR TITLE
CLI: Only use yarn if global CLI uses it

### DIFF
--- a/local-cli/generator/index.js
+++ b/local-cli/generator/index.js
@@ -42,6 +42,17 @@ function getYarnVersionIfAvailable() {
   }
 }
 
+/**
+ * Check that 'react-native init' itself used yarn to install React Native.
+ * When using an old global react-native-cli@1.0.0 (or older), we don't want
+ * to install React Native with npm, and React + Jest with yarn.
+ * Let's be safe and not mix yarn and npm in a single project.
+ * @param projectDir e.g. /Users/martin/AwesomeApp
+ */
+function isGlobalCliUsingYarn(projectDir) {
+  return fs.existsSync(path.join(projectDir, 'yarn.lock'));
+}
+
 module.exports = yeoman.generators.NamedBase.extend({
   constructor: function() {
     yeoman.generators.NamedBase.apply(this, arguments);
@@ -147,7 +158,7 @@ module.exports = yeoman.generators.NamedBase.extend({
       return;
     }
 
-    const yarnVersion = (!this.options['npm']) && getYarnVersionIfAvailable();
+    const yarnVersion = (!this.options['npm']) && getYarnVersionIfAvailable() && isGlobalCliUsingYarn(this.destinationRoot());
 
     console.log('Installing React...');
     if (yarnVersion) {


### PR DESCRIPTION
Check that 'react-native init' itself used yarn to install React Native.
When using an old global react-native-cli@1.0.0 (or older), we don't want to install React Native with npm, and React + Jest with yarn. Let's be safe and not mix yarn and npm in a single project.

**Test plan**

Publish the code in this PR to Sinopia, use that when creating a new project.

Using old CLI:

    npm install -g react-native-cli@1.0.0
    react-native init AwesomeApp

The generated project doesn't contain `yarn.lock` (everything was installed with the npm client).

---

Using new CLI:

    npm install -g react-native-cli@1.2.0
    react-native init AwesomeApp

The generated project contains `yarn.lock`, output shows that yarn is used to install React Native, React, Jest.

---

In both cases the project runs and Reload JS works:

![screenshot 2016-11-04 17 20 50](https://cloud.githubusercontent.com/assets/346214/20015719/719effb0-a2b4-11e6-84a0-43474314009b.png)
