### PR TITLE
[Website] Swap locations for Prev/Next links.

### DIFF
--- a/website/layout/BlogPageLayout.js
+++ b/website/layout/BlogPageLayout.js
@@ -46,10 +46,10 @@ var BlogPageLayout = React.createClass({
               })
             }
             <div className="docs-prevnext">
-              {MetadataBlog.files.length > (page + 1) * perPage &&
-                <a className="docs-next" href={this.getPageURL(page + 1)}>&larr; Older posts</a>}
               {page > 0 &&
-                <a className="docs-prev" href={this.getPageURL(page - 1)}>Newer posts &rarr;</a>}
+                <a className="docs-prev" href={this.getPageURL(page - 1)}>&larr; Newer posts</a>}
+              {MetadataBlog.files.length > (page + 1) * perPage &&
+                <a className="docs-next" href={this.getPageURL(page + 1)}>Older posts &rarr;</a>}
             </div>
         </section>
       </Site>

--- a/website/src/react-native/css/react-native.css
+++ b/website/src/react-native/css/react-native.css
@@ -745,11 +745,11 @@ h1:hover .hash-link, h2:hover .hash-link, h3:hover .hash-link, h4:hover .hash-li
 }
 
 .docs-prev {
-  float: right;
+  float: left;
 }
 
 .docs-next {
-  float: left;
+  float: right;
 }
 
 section.black content {


### PR DESCRIPTION
This reverts a change in #10660 that swapped the locations of the prev/next links across the entire site. It made sense in the blog, but not so much in the docs.