### PR TITLE
Updated Device Specifying Command

### DIFF
--- a/docs/RunningOnSimulatorIOS.md
+++ b/docs/RunningOnSimulatorIOS.md
@@ -14,6 +14,6 @@ Once you have your React Native project initialized, you can run `react-native r
 
 ## Specifying a device
 
-You can specify the device the simulator should run with the `--simulator` flag, followed by the device name as a string. The default is `"iPhone 6"`. If you wish to run your app on an iPhone 4s, just run `react-native run-ios --simulator "iPhone 4s"`.
+You can specify the device the simulator should run with the `--simulator` flag, followed by the device name as a string. The default is `"iPhone 6"`. If you wish to run your app on an iPhone 4s, just run `react-native run-ios --simulator="iPhone 4s"`.
 
 The device names correspond to the list of devices available in Xcode. You can check your available devices by running `xcrun simctl list devices` from the console.


### PR DESCRIPTION
The command `react-native run-ios --simulator "iPhone 4s"` wasn't working, and I think it's because there needs to be an equals sign in the command. ie. `react-native run-ios --simulator="iPhone 4s"`

I ran that command again, and it worked for me.