### PR TITLE
[NavigationTransitioner] Fix animation in fast navigation between scenes

### DIFF
--- a/Libraries/NavigationExperimental/NavigationTransitioner.js
+++ b/Libraries/NavigationExperimental/NavigationTransitioner.js
@@ -117,13 +117,15 @@ class NavigationTransitioner extends React.Component<any, Props, State> {
       scenes: nextScenes,
     };
 
-    this._prevTransitionProps = this._transitionProps;
-    this._transitionProps = buildTransitionProps(nextProps, nextState);
-
     const {
       position,
       progress,
     } = nextState;
+
+    progress.setValue(0);
+
+    this._prevTransitionProps = this._transitionProps;
+    this._transitionProps = buildTransitionProps(nextProps, nextState);
 
     // get the transition spec.
     const transitionUserSpec = nextProps.configureTransition ?
@@ -140,8 +142,6 @@ class NavigationTransitioner extends React.Component<any, Props, State> {
 
     const {timing} = transitionSpec;
     delete transitionSpec.timing;
-
-    progress.setValue(0);
 
     const animations = [
       timing(


### PR DESCRIPTION
There is a bug in navigation animation:
![-05-2016 16-04-23](https://cloud.githubusercontent.com/assets/3778452/20030228/8d93bc3e-a371-11e6-87d6-2c5c994733b5.gif)
navigation animation from route-2 was awful, route-3 scene appeared without any animation, I pushed above example to https://github.com/gitim/react-native/commit/46dd8c93b491893f1707c3db80ca39b9ac9ba59a.

This bug can be reproduced when user navigates to the next scene immediately after navigation to the current one or when navigating between scenes programmatically (e.g. between loading scene and whatever next scene). I made some investigation and It looks like that `progress` should be reseted before building the new _transitionProps.

The above example after applying this patch:
![-05-2016 16-12-16](https://cloud.githubusercontent.com/assets/3778452/20030259/a800681e-a372-11e6-847a-991d355a5940.gif)