### PR TITLE
Stop other views from stealing the responder from PickerIOS and DatePickerIOS

### DIFF
--- a/Libraries/Components/DatePicker/DatePickerIOS.ios.js
+++ b/Libraries/Components/DatePicker/DatePickerIOS.ios.js
@@ -134,6 +134,8 @@ const DatePickerIOS = React.createClass({
           minuteInterval={props.minuteInterval}
           timeZoneOffsetInMinutes={props.timeZoneOffsetInMinutes}
           onChange={this._onChange}
+          onStartShouldSetResponder={() => true}
+          onResponderTerminationRequest={() => false}
         />
       </View>
     );

--- a/Libraries/Components/Picker/PickerIOS.ios.js
+++ b/Libraries/Components/Picker/PickerIOS.ios.js
@@ -62,6 +62,8 @@ var PickerIOS = React.createClass({
           items={this.state.items}
           selectedIndex={this.state.selectedIndex}
           onChange={this._onChange}
+          onStartShouldSetResponder={() => true}
+          onResponderTerminationRequest={() => false}
         />
       </View>
     );


### PR DESCRIPTION
Similar to https://github.com/facebook/react-native/commit/52ddfd9b51cbaa05176efc8c9dfa7b581be01a97 the `DatePickerIOS` and `PickerIOS` components need to stop the propagation of swiping gestures in order to prevent other views from responding to them. 

This is most noticable when placed inside a modal in front of a scrollView.


<table>
    <tr>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td>
            <img src="https://cloud.githubusercontent.com/assets/13004162/20035981/ad8b97f6-a3b6-11e6-957c-2d3048e0e78b.gif" />
        </td>
        <td>
            <img src="https://cloud.githubusercontent.com/assets/13004162/20036025/e7206766-a3b7-11e6-8630-492f8092f3d4.gif" />
        </td>
    </tr>
</table>