### PR TITLE
Blockable WebView

### DIFF
--- a/Examples/UIExplorer/js/WebViewExample.js
+++ b/Examples/UIExplorer/js/WebViewExample.js
@@ -247,7 +247,7 @@ class ControlledWebView extends React.Component {
         backgroundColor: BGWASH,
         height: 200,
       }}>
-        <Text>Navigation to Login blocked</Text>
+        <Text>Navigation to login url blocked</Text>
         <View style={styles.buttons}>
           <Button
             text="Click to go back"

--- a/Examples/UIExplorer/js/WebViewExample.js
+++ b/Examples/UIExplorer/js/WebViewExample.js
@@ -184,7 +184,7 @@ class Button extends React.Component {
   }
 }
 
-class ControlledWebView extends React.Component {
+class BlockableWebView extends React.Component {
   state = {
     policies: [
       {
@@ -517,7 +517,7 @@ exports.examples = [
     render(): ReactElement<any> { return <MessagingTest />; }
   },
   {
-    title: 'Controlled Navigation',
-    render(): React.Element<any> { return <ControlledWebView/>; }
+    title: 'Blockable Navigation',
+    render(): React.Element<any> { return <BlockableWebView/>; }
   }
 ];

--- a/Examples/UIExplorer/js/WebViewExample.js
+++ b/Examples/UIExplorer/js/WebViewExample.js
@@ -25,6 +25,7 @@
 var React = require('react');
 var ReactNative = require('react-native');
 var {
+  Linking,
   StyleSheet,
   Text,
   TextInput,
@@ -179,6 +180,83 @@ class Button extends React.Component {
           <Text>{this.props.text}</Text>
         </View>
       </TouchableWithoutFeedback>
+    );
+  }
+}
+
+class ControlledWebView extends React.Component {
+  state = {
+    policies: [
+      {
+        // blocks navigation to login page
+        url: 'https://github.com/login.*',
+      }, {
+        // blocks any navigation to url that doesn't contain github.com
+        url: '^((?!(github.com)).)*$',
+      }
+    ],
+    showCustomLogin: false,
+  }
+
+  constructor(props) {
+    super(props);
+
+    this.onNavigationBlocked = this.onNavigationBlocked.bind(this);
+  }
+
+  onNavigationBlocked({ nativeEvent }) {
+    const { url } = nativeEvent;
+
+    // url within the github.com domain, matched by first policy (login)
+    if (/github.com/.test(url)) {
+      this.setState({
+        showCustomLogin: true
+      });
+      return;
+    }
+
+    // url not within the github.com domain. Matches second policy
+    Linking.openURL(url);
+  }
+
+  render() {
+    const source = { uri: 'https://github.com/facebook/react-native'};
+    const { showCustomLogin, policies } = this.state;
+
+    return (
+      <View style={styles.container}>
+        {
+          showCustomLogin ?
+          this.customLoginRender() :
+          <WebView style={{
+            backgroundColor: BGWASH,
+            height: 200,
+          }}
+            source={source}
+            navigationBlockingPolicies={policies}
+            onNavigationBlocked={this.onNavigationBlocked}
+          />
+        }
+      </View>
+    );
+  }
+
+  customLoginRender() {
+    return (
+      <View style={{
+        backgroundColor: BGWASH,
+        height: 200,
+      }}>
+        <Text>Navigation to Login blocked</Text>
+        <View style={styles.buttons}>
+          <Button
+            text="Click to go back"
+            onPress={() => this.setState({
+              showCustomLogin: false
+            })}
+          />
+        </View>
+      </View>
     );
   }
 }
@@ -442,5 +520,9 @@ exports.examples = [
   {
     title: 'Mesaging Test',
     render(): ReactElement<any> { return <MessagingTest />; }
+  },
+  {
+    title: 'Controlled Navigation',
+    render(): React.Element<any> { return <ControlledWebView/>; }
   }
 ];

--- a/Examples/UIExplorer/js/WebViewExample.js
+++ b/Examples/UIExplorer/js/WebViewExample.js
@@ -198,13 +198,7 @@ class ControlledWebView extends React.Component {
     showCustomLogin: false,
   }
 
-  constructor(props) {
-    super(props);
-
-    this.onNavigationBlocked = this.onNavigationBlocked.bind(this);
-  }
-
-  onNavigationBlocked({ nativeEvent }) {
+  onNavigationBlocked = ({ nativeEvent }) => {
     const { url } = nativeEvent;
 
     // url within the github.com domain, matched by first policy (login)

--- a/Examples/UIExplorer/js/WebViewExample.js
+++ b/Examples/UIExplorer/js/WebViewExample.js
@@ -244,6 +244,7 @@ class ControlledWebView extends React.Component {
         <Text>Navigation to login url blocked</Text>
         <View style={styles.buttons}>
           <Button
+            enabled
             text="Click to go back"
             onPress={() => this.setState({
               showCustomLogin: false

--- a/Libraries/Components/WebView/WebView.android.js
+++ b/Libraries/Components/WebView/WebView.android.js
@@ -160,6 +160,20 @@ class WebView extends React.Component {
      * @platform android
      */
     allowUniversalAccessFromFileURLs: PropTypes.bool,
+
+    /**
+     * Rules that will be used to block the webview navigation
+     */
+    navigationBlockingPolicies: PropTypes.arrayOf(PropTypes.shape({
+      currentURL: PropTypes.string,
+      url: PropTypes.string,
+    })),
+
+    /**
+     * Function that is invoked when the `WebView` navigation is blocked by the
+     * `navigationBlockingPolicies`.
+     */
+    onNavigationBlocked: PropTypes.func,
   };
 
   static defaultProps = {
@@ -236,6 +250,7 @@ class WebView extends React.Component {
         testID={this.props.testID}
         mediaPlaybackRequiresUserAction={this.props.mediaPlaybackRequiresUserAction}
         allowUniversalAccessFromFileURLs={this.props.allowUniversalAccessFromFileURLs}
+        navigationBlockingPolicies={this.props.navigationBlockingPolicies}
       />;
 
     return (
@@ -333,6 +348,11 @@ class WebView extends React.Component {
     var {onMessage} = this.props;
     onMessage && onMessage(event);
   }
+
+  onNavigationBlocked = (event) => {
+    var {onNavigationBlocked} = this.props;
+    onNavigationBlocked && onNavigationBlocked(event);
+  };
 }
 
 var RCTWebView = requireNativeComponent('RCTWebView', WebView, {

--- a/Libraries/Components/WebView/WebView.android.js
+++ b/Libraries/Components/WebView/WebView.android.js
@@ -251,6 +251,7 @@ class WebView extends React.Component {
         mediaPlaybackRequiresUserAction={this.props.mediaPlaybackRequiresUserAction}
         allowUniversalAccessFromFileURLs={this.props.allowUniversalAccessFromFileURLs}
         navigationBlockingPolicies={this.props.navigationBlockingPolicies}
+        onNavigationBlocked={this.onNavigationBlocked}
       />;
 
     return (

--- a/Libraries/Components/WebView/WebView.ios.js
+++ b/Libraries/Components/WebView/WebView.ios.js
@@ -334,6 +334,21 @@ class WebView extends React.Component {
      * to tap them before they start playing. The default value is `true`.
      */
     mediaPlaybackRequiresUserAction: PropTypes.bool,
+
+    /**
+     * Rules that will be used to block the webview navigation
+     */
+    navigationBlockingPolicies: PropTypes.arrayOf(PropTypes.shape({
+      currentURL: PropTypes.string,
+      navigationType: PropTypes.string,
+      url: PropTypes.string,
+    })),
+
+    /**
+     * Function that is invoked when the `WebView` navigation is blocked by the
+     * `navigationBlockingPolicies`.
+     */
+    onNavigationBlocked: PropTypes.func,
   };
 
   state = {
@@ -416,6 +431,8 @@ class WebView extends React.Component {
         allowsInlineMediaPlayback={this.props.allowsInlineMediaPlayback}
         mediaPlaybackRequiresUserAction={this.props.mediaPlaybackRequiresUserAction}
         dataDetectorTypes={this.props.dataDetectorTypes}
+        onNavigationBlocked={this.props.onNavigationBlocked}
+        navigationBlockingPolicies={this.props.navigationBlockingPolicies}
       />;
 
     return (

--- a/React/Views/RCTWebView.m
+++ b/React/Views/RCTWebView.m
@@ -224,10 +224,8 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
   BOOL isHTTPRequest = [[request.URL scheme] isEqualToString:@"http"] || [[request.URL scheme] isEqualToString:@"https"];
 
   // skip this for the JS Navigation handler, initial load, iFrames and non-http(s) requests
-  if(!isJSNavigation && isTopFrame && !isLoadingSourceURL && isHTTPRequest) {
-    BOOL _shouldBlock = false;
-
-    if(_navigationBlockingPolicies.count > 0) {
+  if (!isJSNavigation && isTopFrame && !isLoadingSourceURL && isHTTPRequest) {
+    if (_navigationBlockingPolicies.count > 0) {
       NSDictionary *currentValues = @{
                                       @"currentURL": sourceURL,
                                       @"url": requestURL,
@@ -236,22 +234,22 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
       NSString *eventValue;
       BOOL policyFulfilled;
 
-      for(NSDictionary *policy in _navigationBlockingPolicies) {
+      for (NSDictionary *policy in _navigationBlockingPolicies) {
         // policy with no rules
-        if(policy.count < 1) {
+        if (policy.count < 1) {
           continue;
         }
 
         policyFulfilled = YES;
 
-        for(NSString *key in policy) {
+        for (NSString *key in policy) {
           // policy has failed already
-          if(!policyFulfilled) break;
+          if (!policyFulfilled) break;
 
           eventValue = [currentValues objectForKey:key];
 
           // unverifiable policy rule
-          if(!eventValue) {
+          if (!eventValue) {
             RCTLogWarn(@"Could not verify webview loading policy named %@. Failing policy with rules %@", key, policy);
             policyFulfilled = NO;
             break;
@@ -262,20 +260,12 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
           policyFulfilled = [rule evaluateWithObject: eventValue];
         }
 
-        if(policyFulfilled) {
-          _shouldBlock = !_shouldBlock;
-          break;
+        // call blocked callback
+        if (policyFulfilled && _onNavigationBlocked) {
+          _onNavigationBlocked(event);
+          return NO;
         }
       }
-    }
-
-    // call blocked callback
-    if(_shouldBlock) {
-      if(_onNavigationBlocked) {
-        _onNavigationBlocked(event);
-      }
-
-      return NO;
     }
   }
 

--- a/React/Views/RCTWebView.m
+++ b/React/Views/RCTWebView.m
@@ -221,10 +221,9 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
   BOOL isJSNavigation = [request.URL.scheme isEqualToString:RCTJSNavigationScheme];
   BOOL isTopFrame = [request.URL isEqual:request.mainDocumentURL];
   BOOL isLoadingSourceURL = ([sourceURL isEqualToString:requestURL] && !_webView.isLoading);
-  BOOL isHTTPRequest = [[request.URL scheme] isEqualToString:@"http"] || [[request.URL scheme] isEqualToString:@"https"];
-
+  
   // skip this for the JS Navigation handler, initial load, iFrames and non-http(s) requests
-  if (!isJSNavigation && isTopFrame && !isLoadingSourceURL && isHTTPRequest) {
+  if (!isJSNavigation && isTopFrame && !isLoadingSourceURL) {
     if (_navigationBlockingPolicies.count > 0) {
       NSDictionary *currentValues = @{
                                       @"currentURL": sourceURL,

--- a/React/Views/RCTWebView.m
+++ b/React/Views/RCTWebView.m
@@ -222,7 +222,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
   BOOL isTopFrame = [request.URL isEqual:request.mainDocumentURL];
   BOOL isLoadingSourceURL = ([sourceURL isEqualToString:requestURL] && !_webView.isLoading);
   
-  // skip this for the JS Navigation handler, initial load, iFrames and non-http(s) requests
+  // skip this for the JS Navigation handler, initial load, iFrames
   if (!isJSNavigation && isTopFrame && !isLoadingSourceURL) {
     if (_navigationBlockingPolicies.count > 0) {
       NSDictionary *currentValues = @{

--- a/React/Views/RCTWebView.m
+++ b/React/Views/RCTWebView.m
@@ -29,6 +29,8 @@ NSString *const RCTJSPostMessageHost = @"postMessage";
 @property (nonatomic, copy) RCTDirectEventBlock onLoadingError;
 @property (nonatomic, copy) RCTDirectEventBlock onShouldStartLoadWithRequest;
 @property (nonatomic, copy) RCTDirectEventBlock onMessage;
+@property (nonatomic, copy) RCTDirectEventBlock onNavigationBlocked;
+@property (nonatomic, copy) NSArray *navigationBlockingPolicies;
 
 @end
 
@@ -208,13 +210,79 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
     };
   });
 
+  NSString *sourceURL = (NSString *)self.source[@"uri"];
+  NSString *requestURL = (request.URL).absoluteString;
+  NSString *namedNavigationType = navigationTypes[@(navigationType)];
+
+  NSMutableDictionary<NSString *, id> *event = [self baseEvent];
+  [event addEntriesFromDictionary: @{
+                                     @"url": requestURL,
+                                     @"navigationType": namedNavigationType
+                                     }];
+
+  BOOL isJSNavigation = [request.URL.scheme isEqualToString:RCTJSNavigationScheme];
+  BOOL isTopFrame = [request.URL isEqual:request.mainDocumentURL];
+  BOOL isLoadingSourceURL = ([sourceURL isEqualToString:requestURL] && !_webView.isLoading);
+  BOOL isHTTPRequest = [[request.URL scheme] isEqualToString:@"http"] || [[request.URL scheme] isEqualToString:@"https"];
+
+  // skip this for the JS Navigation handler, initial load, iFrames and non-http(s) requests
+  if(!isJSNavigation && isTopFrame && !isLoadingSourceURL && isHTTPRequest) {
+    BOOL _shouldBlock = false;
+
+    if(_navigationBlockingPolicies.count > 0) {
+      NSDictionary *currentValues = @{
+                                      @"currentURL": sourceURL,
+                                      @"url": requestURL,
+                                      @"navigationType": namedNavigationType
+                                      };
+      NSString *eventValue;
+      BOOL policyFulfilled;
+
+      for(NSDictionary *policy in _navigationBlockingPolicies) {
+        // policy with no rules
+        if(policy.count < 1) {
+          continue;
+        }
+
+        policyFulfilled = YES;
+
+        for(NSString *key in policy) {
+          // policy has failed already
+          if(!policyFulfilled) break;
+
+          eventValue = [currentValues objectForKey:key];
+
+          // unverifiable policy rule
+          if(!eventValue) {
+            RCTLogWarn(@"Could not verify webview loading policy named %@. Failing policy with rules %@", key, policy);
+            policyFulfilled = NO;
+            break;
+          }
+
+          NSPredicate *rule = [NSPredicate predicateWithFormat:@"SELF MATCHES %@", [policy objectForKey:key]];
+
+          policyFulfilled = [rule evaluateWithObject: eventValue];
+        }
+
+        if(policyFulfilled) {
+          _shouldBlock = !_shouldBlock;
+          break;
+        }
+      }
+    }
+
+    // call blocked callback
+    if(_shouldBlock) {
+      if(_onNavigationBlocked) {
+        _onNavigationBlocked(event);
+      }
+
+      return NO;
+    }
+  }
+
   // skip this for the JS Navigation handler
   if (!isJSNavigation && _onShouldStartLoadWithRequest) {
-    NSMutableDictionary<NSString *, id> *event = [self baseEvent];
-    [event addEntriesFromDictionary: @{
-      @"url": (request.URL).absoluteString,
-      @"navigationType": navigationTypes[@(navigationType)]
-    }];
     if (![self.delegate webView:self
       shouldStartLoadForRequest:event
                    withCallback:_onShouldStartLoadWithRequest]) {
@@ -224,13 +292,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
 
   if (_onLoadingStart) {
     // We have this check to filter out iframe requests and whatnot
-    BOOL isTopFrame = [request.URL isEqual:request.mainDocumentURL];
     if (isTopFrame) {
-      NSMutableDictionary<NSString *, id> *event = [self baseEvent];
-      [event addEntriesFromDictionary: @{
-        @"url": (request.URL).absoluteString,
-        @"navigationType": navigationTypes[@(navigationType)]
-      }];
       _onLoadingStart(event);
     }
   }
@@ -240,11 +302,11 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
     data = [data stringByReplacingOccurrencesOfString:@"+" withString:@" "];
     data = [data stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
 
-    NSMutableDictionary<NSString *, id> *event = [self baseEvent];
-    [event addEntriesFromDictionary: @{
+    NSMutableDictionary<NSString *, id> *_event = [self baseEvent];
+    [_event addEntriesFromDictionary: @{
       @"data": data,
     }];
-    _onMessage(event);
+    _onMessage(_event);
   }
 
   // JS Navigation handler

--- a/React/Views/RCTWebView.m
+++ b/React/Views/RCTWebView.m
@@ -195,8 +195,6 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
 - (BOOL)webView:(__unused UIWebView *)webView shouldStartLoadWithRequest:(NSURLRequest *)request
  navigationType:(UIWebViewNavigationType)navigationType
 {
-  BOOL isJSNavigation = [request.URL.scheme isEqualToString:RCTJSNavigationScheme];
-
   static NSDictionary<NSNumber *, NSString *> *navigationTypes;
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{

--- a/React/Views/RCTWebViewManager.m
+++ b/React/Views/RCTWebViewManager.m
@@ -50,6 +50,8 @@ RCT_EXPORT_VIEW_PROPERTY(onShouldStartLoadWithRequest, RCTDirectEventBlock)
 RCT_REMAP_VIEW_PROPERTY(allowsInlineMediaPlayback, _webView.allowsInlineMediaPlayback, BOOL)
 RCT_REMAP_VIEW_PROPERTY(mediaPlaybackRequiresUserAction, _webView.mediaPlaybackRequiresUserAction, BOOL)
 RCT_REMAP_VIEW_PROPERTY(dataDetectorTypes, _webView.dataDetectorTypes, UIDataDetectorTypes)
+RCT_EXPORT_VIEW_PROPERTY(onNavigationBlocked, RCTDirectEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(navigationBlockingPolicies, NSArray)
 
 RCT_EXPORT_METHOD(goBack:(nonnull NSNumber *)reactTag)
 {

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModuleConstants.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModuleConstants.java
@@ -77,7 +77,7 @@ import com.facebook.react.uimanager.events.TouchEventType;
         .put("topLoadingFinish", MapBuilder.of("registrationName", "onLoadingFinish"))
         .put("topLoadingStart", MapBuilder.of("registrationName", "onLoadingStart"))
         .put("topSelectionChange", MapBuilder.of("registrationName", "onSelectionChange"))
-        .put("topNavigationBlocked", MapBuilder.of("registrationName", "onNavigationBlocked")))
+        .put("topNavigationBlocked", MapBuilder.of("registrationName", "onNavigationBlocked"))
         .put("topMessage", MapBuilder.of("registrationName", "onMessage"))
         .build();
   }

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModuleConstants.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModuleConstants.java
@@ -77,6 +77,7 @@ import com.facebook.react.uimanager.events.TouchEventType;
         .put("topLoadingFinish", MapBuilder.of("registrationName", "onLoadingFinish"))
         .put("topLoadingStart", MapBuilder.of("registrationName", "onLoadingStart"))
         .put("topSelectionChange", MapBuilder.of("registrationName", "onSelectionChange"))
+        .put("topNavigationBlocked", MapBuilder.of("registrationName", "onNavigationBlocked")))
         .put("topMessage", MapBuilder.of("registrationName", "onMessage"))
         .build();
   }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebViewManager.java
@@ -138,13 +138,13 @@ public class ReactWebViewManager extends SimpleViewManager<WebView> {
             url.startsWith("file://")) {
               boolean shouldBlock = false;
 
-              ReadableMap[] policies = view.getNavigationBlockingPolicies();
+              ReadableMap[] policies = ((ReactWebView) view).getNavigationBlockingPolicies();
               ReadableMap policy;
               boolean policyFulfilled = false;
 
               if (policies != null) {
-                  WritableMap currentValues = createWebViewEvent(webView, url);
-                  currentValues.putString("currentURL", webView.getUrl());
+                  WritableMap currentValues = createWebViewEvent(view, url);
+                  currentValues.putString("currentURL", view.getUrl());
 
                   for (int i = 0; i < policies.length; i++) {
                       policy = policies[i];
@@ -178,10 +178,10 @@ public class ReactWebViewManager extends SimpleViewManager<WebView> {
 
               if (shouldBlock) {
                   dispatchEvent(
-                          webView,
+                          view,
                           new TopNavigationBlockedEvent(
-                                  webView.getId(),
-                                  createWebViewEvent(webView, url)));
+                                  view.getId(),
+                                  createWebViewEvent(view, url)));
               }
 
               return shouldBlock;
@@ -534,7 +534,7 @@ public class ReactWebViewManager extends SimpleViewManager<WebView> {
 
   @ReactProp(name = "navigationBlockingPolicies")
   public void setNavigationBlockingPolicies(WebView view, @Nullable ReadableArray policies) {
-      view.setNavigationBlockingPolicies(policies);
+      ((ReactWebView) view).setNavigationBlockingPolicies(policies);
   }
 
   @Override

--- a/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebViewManager.java
@@ -134,61 +134,61 @@ public class ReactWebViewManager extends SimpleViewManager<WebView> {
 
     @Override
     public boolean shouldOverrideUrlLoading(WebView view, String url) {
-        ReadableMap[] policies = ((ReactWebView) view).getNavigationBlockingPolicies();
-        ReadableMap policy;
-        boolean policyFulfilled = false;
+      ReadableMap[] policies = ((ReactWebView) view).getNavigationBlockingPolicies();
+      ReadableMap policy;
+      boolean policyFulfilled = false;
 
-        if (policies != null) {
-            WritableMap currentValues = createWebViewEvent(view, url);
-            currentValues.putString("currentURL", view.getUrl());
+      if (policies != null) {
+        WritableMap currentValues = createWebViewEvent(view, url);
+        currentValues.putString("currentURL", view.getUrl());
 
-            for (int i = 0; i < policies.length; i++) {
-                policy = policies[i];
-                ReadableMapKeySetIterator it = policy.keySetIterator();
-                String policyKey;
+        for (int i = 0; i < policies.length; i++) {
+          policy = policies[i];
+          ReadableMapKeySetIterator it = policy.keySetIterator();
+          String policyKey;
 
-                // has at least one rule
-                if (it != null && it.hasNextKey()) {
-                    policyFulfilled = true;
+          // has at least one rule
+          if (it != null && it.hasNextKey()) {
+            policyFulfilled = true;
 
-                    // loop until there are no more rules or one has been rejected already
-                    while (it.hasNextKey() && policyFulfilled) {
-                        policyKey = it.nextKey();
+            // loop until there are no more rules or one has been rejected already
+            while (it.hasNextKey() && policyFulfilled) {
+              policyKey = it.nextKey();
 
-                        if (!currentValues.hasKey(policyKey)) {
-                            policyFulfilled = false;
-                            continue;
-                        }
+              if (!currentValues.hasKey(policyKey)) {
+                policyFulfilled = false;
+                continue;
+              }
 
-                        policyFulfilled = currentValues.getString(policyKey)
-                                .matches(policy.getString(policyKey));
-                    }
-                }
-
-                if (policyFulfilled) {
-                    dispatchEvent(
-                            view,
-                            new TopNavigationBlockedEvent(
-                                    view.getId(),
-                                    createWebViewEvent(view, url)));
-                    return true;
-                }
+              policyFulfilled = currentValues.getString(policyKey)
+                .matches(policy.getString(policyKey));
             }
-        }
-
-        if (url.startsWith("http://") || url.startsWith("https://") ||
-            url.startsWith("file://")) {
-          return false;
-        } else {
-          try {
-            Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
-            intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-            view.getContext().startActivity(intent);
-          } catch (ActivityNotFoundException e) {
-            FLog.w(ReactConstants.TAG, "activity not found to handle uri scheme for: " + url, e);
           }
-          return true;
+          
+          if (policyFulfilled) {
+            dispatchEvent(
+              view,
+              new TopNavigationBlockedEvent(
+                view.getId(),
+                createWebViewEvent(view, url)));
+            return true;
+          }
         }
+      }
+
+      if (url.startsWith("http://") || url.startsWith("https://") ||
+          url.startsWith("file://")) {
+        return false;
+      } else {
+        try {
+          Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
+          intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+          view.getContext().startActivity(intent);
+        } catch (ActivityNotFoundException e) {
+          FLog.w(ReactConstants.TAG, "activity not found to handle uri scheme for: " + url, e);
+        }
+        return true;
+      }
     }
 
     @Override

--- a/ReactAndroid/src/main/java/com/facebook/react/views/webview/events/TopNavigationBlockedEvent.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/webview/events/TopNavigationBlockedEvent.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+package com.facebook.react.views.webview.events;
+
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.uimanager.events.Event;
+import com.facebook.react.uimanager.events.RCTEventEmitter;
+
+/**
+ * Event emitted when the navigation is blocked
+ */
+public class TopNavigationBlockedEvent extends Event<TopNavigationBlockedEvent> {
+
+    public static final String EVENT_NAME = "topNavigationBlocked";
+    private WritableMap mEventData;
+
+    public TopNavigationBlockedEvent(int viewId, WritableMap eventData) {
+        super(viewId);
+        mEventData = eventData;
+    }
+
+
+    @Override
+    public String getEventName() {
+        return EVENT_NAME;
+    }
+
+    @Override
+    public boolean canCoalesce() {
+        return false;
+    }
+
+    @Override
+    public short getCoalescingKey() {
+        // All events for a given view can be coalesced.
+        return 0;
+    }
+
+    @Override
+    public void dispatch(RCTEventEmitter rctEventEmitter) {
+        rctEventEmitter.receiveEvent(getViewTag(), getEventName(), mEventData);
+    }
+}

--- a/ReactAndroid/src/main/java/com/facebook/react/views/webview/events/TopNavigationBlockedEvent.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/webview/events/TopNavigationBlockedEvent.java
@@ -1,7 +1,7 @@
 /**
  * Copyright (c) 2015-present, Facebook, Inc.
  * All rights reserved.
- *
+ * <p>
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
@@ -18,33 +18,32 @@ import com.facebook.react.uimanager.events.RCTEventEmitter;
  */
 public class TopNavigationBlockedEvent extends Event<TopNavigationBlockedEvent> {
 
-    public static final String EVENT_NAME = "topNavigationBlocked";
-    private WritableMap mEventData;
+  public static final String EVENT_NAME = "topNavigationBlocked";
+  private WritableMap mEventData;
 
-    public TopNavigationBlockedEvent(int viewId, WritableMap eventData) {
-        super(viewId);
-        mEventData = eventData;
-    }
+  public TopNavigationBlockedEvent(int viewId, WritableMap eventData) {
+    super(viewId);
+    mEventData = eventData;
+  }
 
+  @Override
+  public String getEventName() {
+    return EVENT_NAME;
+  }
 
-    @Override
-    public String getEventName() {
-        return EVENT_NAME;
-    }
+  @Override
+  public boolean canCoalesce() {
+    return false;
+  }
 
-    @Override
-    public boolean canCoalesce() {
-        return false;
-    }
+  @Override
+  public short getCoalescingKey() {
+    // All events for a given view can be coalesced.
+    return 0;
+  }
 
-    @Override
-    public short getCoalescingKey() {
-        // All events for a given view can be coalesced.
-        return 0;
-    }
-
-    @Override
-    public void dispatch(RCTEventEmitter rctEventEmitter) {
-        rctEventEmitter.receiveEvent(getViewTag(), getEventName(), mEventData);
-    }
+  @Override
+  public void dispatch(RCTEventEmitter rctEventEmitter) {
+    rctEventEmitter.receiveEvent(getViewTag(), getEventName(), mEventData);
+  }
 }


### PR DESCRIPTION
### Motivation

There isn't yet a fully reliable way to block, and handle, navigation to a specific url while using the WebViews. The current iOS method is at best (as mentioned here https://github.com/facebook/react-native/pull/6478 by @astreet) an unpredictable way of handling this. Android itself has no way of doing it at all.

### Test Plan

A usage example was built in the UIExplorer WebView section. The controlled webview renders the react-native GitHub and blocks any navigations that would take the user to a non github.com urls or /login within github.com. It handles both blockage differently, showing a different component when the login url is identified or taking the users to the browser on the non github case.
