### PR TITLE
Fixing AssetServer in the Packager so it reload the app with updated files.

### DIFF
--- a/packager/react-packager/src/AssetServer/__tests__/AssetServer-test.js
+++ b/packager/react-packager/src/AssetServer/__tests__/AssetServer-test.js
@@ -13,6 +13,7 @@ jest.disableAutomock();
 
 jest.mock('fs');
 
+const Promise = require('promise');
 const AssetServer = require('../');
 const crypto = require('crypto');
 const {EventEmitter} = require('events');
@@ -307,7 +308,7 @@ describe('AssetServer', () => {
       it('changes the hash when the passed-in file watcher emits an `all` event', () => {
         return server.getAssetData('imgs/b.jpg').then(initialData => {
           fileSystem.root.imgs['b@4x.jpg'] = 'updated data';
-          fileWatcher.emit('all', 'arbitrary', '/root', 'imgs/b@4x.jpg');
+          fileWatcher.emit('all', 'arbitrary', 'imgs/b@4x.jpg', '/root');
           return server.getAssetData('imgs/b.jpg').then(data =>
             expect(data.hash).not.toEqual(initialData.hash)
           );


### PR DESCRIPTION
Fixing #10738

**Motivation**

I am using a webview to inject a Google Places picker in my app. Whilst I was on RN 0.34.0, any changes was made to the html was reflected immediately and was reloading the app accordingly.

It stopped working since RN 0.36.0 update.

I had to reload the packager entirely. I've quickly identified that changes had been made on [AssetServer](https://github.com/facebook/react-native/blob/cacc31d7596acb5508aec617618eef432dd80595/packager/react-packager/src/AssetServer/index.js), optimising the way assets changes were identified.

The issue was taking root in the wrong expections of the `fileWatcher.emit` callback parameters.

Note: I've taken the liberty to add some logs using the ```Logger``` (as oppose to ```Activity``` module). It gives more visibility over what the AssetServer does.

**Test plan**

Run jest on impacted files:
```
node_modules/.bin/eslint packager/react-packager/src/AssetServer/__tests__/AssetServer-test.js
```
