### PR TITLE
PushNotificationIOS: Use PushNotificationEventName as the key to store in the handler map

### DIFF
--- a/Libraries/PushNotificationIOS/PushNotificationIOS.js
+++ b/Libraries/PushNotificationIOS/PushNotificationIOS.js
@@ -258,7 +258,7 @@ class PushNotificationIOS {
         }
       );
     }
-    _notifHandlers.set(handler, listener);
+    _notifHandlers.set(type, listener);
   }
 
   /**
@@ -270,12 +270,12 @@ class PushNotificationIOS {
       type === 'notification' || type === 'register' || type === 'registrationError' || type === 'localNotification',
       'PushNotificationIOS only supports `notification`, `register`, `registrationError`, and `localNotification` events'
     );
-    var listener = _notifHandlers.get(handler);
+    var listener = _notifHandlers.get(type);
     if (!listener) {
       return;
     }
     listener.remove();
-    _notifHandlers.delete(handler);
+    _notifHandlers.delete(type);
   }
 
   /**


### PR DESCRIPTION
### Motivation

If we are using the same handler for different events, e.g. both `notification` and `localNotification` use `_onNotification()` handler, the former listener stored in `_notifHandlers` would be overridden by the latter so it's impossible to remove the `notification` listener when we call `removeEventListener`.

This PR stores the listeners by using `pushNotificationEventName` (notification, localNotification, register or registrationError) as the key.

### Test plan

Use the same handler for `notification` and `localNotification`, both listeners will be removed when calling `removeEventListener`.