### PR TITLE
[NavigatorIOS] Only retain the previousViews that need to be validated

### DIFF
--- a/React/Views/RCTNavigator.m
+++ b/React/Views/RCTNavigator.m
@@ -590,7 +590,10 @@ BOOL jsGettingtooSlow =
     return;
   }
 
-  _previousViews = [self.reactSubviews copy];
+  // Only make a copy of the subviews whose validity we expect to be able to check (in the loop, above),
+  // otherwise we would unnecessarily retain a reference to view(s) no longer on the React navigation stack:
+  NSUInteger expectedCount = MIN(currentReactCount, self.reactSubviews.count);
+  _previousViews = [[self.reactSubviews subarrayWithRange: NSMakeRange(0, expectedCount)] copy];
   _previousRequestedTopOfStack = _requestedTopOfStack;
 }
 


### PR DESCRIPTION
Fixes #4740, where views would unnecessarily be retained after performing `navigator.pop()` - this was particularly problematic for big lists and memory-intensive custom views.

This fix causes no functional change: `_previousViews` are only used in the loop starting at line 564 to ensure that the JavaScript and Native navigation stacks are equivalent at all times. As we do in this fix, that loop limits itself to only the views expected to be on the React navigation stack. So overall this change makes the code logically 'more correct'.

Tested by checking that `_previousViews.count` is always equivalent to `previousReactCount` in the loop (which means we could remove the complex `MIN(... MIN(previousReactCount, _previousViews.count)` in the loop too, but I wanted to keep the diff as small as possible for now).