### PR TITLE
Unbreak custom animated components

### DIFF
--- a/Libraries/Animated/src/AnimatedImplementation.js
+++ b/Libraries/Animated/src/AnimatedImplementation.js
@@ -1747,12 +1747,6 @@ function createAnimatedComponent(Component: any): any {
       var callback = () => {
         if (this._component.setNativeProps) {
           if (!this._propsAnimated.__isNative) {
-            if (this._component.viewConfig == null) {
-              var ctor = this._component.constructor;
-              var componentName = ctor.displayName || ctor.name || '<Unknown Component>';
-              throw new Error(componentName + ' "viewConfig" is not defined.');
-            }
-
             this._component.setNativeProps(
               this._propsAnimated.__getAnimatedValue()
             );

--- a/Libraries/Renderer/src/renderers/native/NativeMethodsMixin.js
+++ b/Libraries/Renderer/src/renderers/native/NativeMethodsMixin.js
@@ -142,7 +142,7 @@ var NativeMethodsMixin = {
     if (!this.viewConfig) {
       var ctor = this.constructor;
       var componentName = ctor.displayName || ctor.name || '<Unknown Component>';
-      throw new Error(componentName + ' "viewConfig" is not defined.');
+      invariant(false, componentName + ' "viewConfig" is not defined.');
     }
 
     if (__DEV__) {

--- a/Libraries/Renderer/src/renderers/native/NativeMethodsMixin.js
+++ b/Libraries/Renderer/src/renderers/native/NativeMethodsMixin.js
@@ -139,6 +139,12 @@ var NativeMethodsMixin = {
    * Manipulation](docs/direct-manipulation.html)).
    */
   setNativeProps: function(nativeProps: Object) {
+    if (!this.viewConfig) {
+      var ctor = this.constructor;
+      var componentName = ctor.displayName || ctor.name || '<Unknown Component>';
+      throw new Error(componentName + ' "viewConfig" is not defined.');
+    }
+
     if (__DEV__) {
       warnForStyleProps(nativeProps, this.viewConfig.validAttributes);
     }


### PR DESCRIPTION
Commit https://github.com/facebook/react-native/commit/c9960817eea008b2703657066212002557e0d939 broke `Animated.createAnimatedComponent()` for most components outside of the standard ones. This is because it will throw an exception for any component without a `viewConfig` defined, which basically no composition style component has AFAIK. 

Related issues: https://github.com/facebook/react-native/issues/10825, https://github.com/oblador/react-native-vector-icons/issues/337, https://github.com/oblador/react-native-animatable/issues/70

This PR removes the check which is more treating the symptoms really – but shouldn't `setNativeProps` duck typing be enough?