### PR TITLE
Add help option to react-native-cli

### DIFF
--- a/react-native-cli/index.js
+++ b/react-native-cli/index.js
@@ -115,9 +115,28 @@ var commands = argv._;
 if (cli) {
   cli.run();
 } else {
+  if (argv._.length === 0 && (argv.h || argv.help)) {
+    console.log([
+      '',
+      '  Usage: react-native [command] [options]',
+      '',
+      '',
+      '  Commands:',
+      '',
+      '    init <ProjectName> [options]  generates a new project and installs its dependencies',
+      '',
+      '  Options:',
+      '',
+      '    -h, --help    output usage information',
+      '    -v, --version output the version number',
+      '',
+    ].join('\n'));
+    process.exit(0);
+  }
+
   if (commands.length === 0) {
     console.error(
-      'You did not pass any commands, did you mean to run `react-native init`?'
+      'You did not pass any commands, run `react-native --help` to see a list of all available commands.'
     );
     process.exit(1);
   }


### PR DESCRIPTION
This PR fixes #10784 by adding a `--help` and a `-h` option to `react-native-cli`.

**Test plan:**
Publish to sinopia and then outside of `react-native` project:
```
$ react-native --help          #same goes for -h

  Usage: react-native [command] [options]


  Commands:

    init <ProjectName> [options]  generates a new project and installs its dependencies

  Options:

    -h, --help    output usage information
    -v, --version output the version number

```
```
$ react-native
You did not pass any commands, run `react-native --help` to see a list of all available commands.
```

**Notes:**
- There is no real consistency in the UX for `react-native-cli` and `local-cli` and even is no real consistency between the UI of `react-native [command] --help` and `react-native --help` in `local-cli` either. I tried to resemble the UX of `react-native --help` as close as possible since it's kind of the nearest neighbour.
- This *doesn't* add support for `react-native init --help` in `react-native-cli`, which means that its `--version <alternative react-native package>` option stays undocumented. I wasn't sure if this should be the scope of this PR but I think we could reuse parts of this and inject it [here](https://github.com/Fahrradflucht/react-native/blob/1b0842ba6f13b9cc37cc840c53ff4429867a258a/react-native-cli/index.js#L148). (Though this sounds like kinda reimplementing [`local-cli`'s `printHelpInformation`](https://github.com/facebook/react-native/blob/master/local-cli/cliEntry.js#L43))