### PR TITLE
Prevent null header value from raising exception

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/modules/network/NetworkingModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/network/NetworkingModule.java
@@ -533,6 +533,9 @@ public final class NetworkingModule extends ReactContextBaseJavaModule {
       }
       String headerName = header.getString(0);
       String headerValue = header.getString(1);
+      if (headerName == null || headerValue == null) {
+        return null;
+      }
       headersBuilder.add(headerName, headerValue);
     }
     if (headersBuilder.get(USER_AGENT_HEADER_NAME) == null && mDefaultUserAgent != null) {


### PR DESCRIPTION
In the wild, our app will occasionally crash with:
```
Fatal Exception: java.lang.NullPointerException
value == null
```

The stack trace brings it back to `okhttp3.Headers$Builder.checkNameAndValue (Headers.java:316)`:
```
if (value == null) throw new NullPointerException("value == null");
```

In the proposed fix, we simply continue the documented functionality of the `extractHeaders` method by returning "null" for invalid data.
