### PR TITLE
Add .gitattributes file, treat .pbxproj as binary

### DIFF
--- a/local-cli/generator/index.js
+++ b/local-cli/generator/index.js
@@ -112,6 +112,10 @@ module.exports = yeoman.generators.NamedBase.extend({
       this.destinationPath('.gitignore')
     );
     this.fs.copy(
+      this.templatePath('_gitattributes'),
+      this.destinationPath('.gitattributes')
+    );
+    this.fs.copy(
       this.templatePath('_watchmanconfig'),
       this.destinationPath('.watchmanconfig')
     );

--- a/local-cli/generator/templates/_gitattributes
+++ b/local-cli/generator/templates/_gitattributes
@@ -1,0 +1,1 @@
+*.pbxproj binary


### PR DESCRIPTION
By default, the `.pbxproj` file generated by React Native should be treated as binary data to prevent Git from possibly automatically converting or fixing CRLF issues with this file, which would break it. 

See https://git-scm.com/book/en/v2/Customizing-Git-Git-Attributes#identifying-binary-files-znTLIVhvhG (where it specifically mentions `.pbxproj` files) for more information.
