### PR TITLE
Add the configuration option to the run-android command

### DIFF
--- a/docs/RunningOnDevice.md
+++ b/docs/RunningOnDevice.md
@@ -148,6 +148,10 @@ $ react-native run-android
 
 > If you get a "bridge configuration isn't available" error, see [Using adb reverse](#using-adb-reverse).
 
+> Hint
+>
+> You can also use the `React Native CLI` to generate and run a `Release` build (e.g. `react-native run-android --configuration Release`).
+
 <block class="mac windows linux android ios" />
 
 ## Connecting to the development server


### PR DESCRIPTION
Currently, to generate a `Release` build in `Android` it is required to get into the `android` directory and run the `react native bundle`with a lot of options and after that run the `gradle` to assemble or install the application with the build type `Release`. 

This PR improves the process adding that feature to the `React Native CLI`.

To generate a release build is only required to use the parameter `--configuration` with the value `Release`.

**Examples**

To generate a release build:
```sh
react-native run-android --configuration release
```

To generate a release build for the product flavors staging:
```sh
react-native run-android --configuration release --flavor staging
```

To generate a debug build:
```sh
react-native run-android
```

To generate a debug build for the product flavors staging:
```sh
react-native run-android --flavor staging
```

This PR also removes the option `--install-debug` from the `react-native run-android` because that is always the default value, so it is useless.

**Test plan**

To generate a release build:
```sh
> react-native run-android --configuration release
```

The output:
```
Starting JS server...
Running /Users/xxxxxxxxxx/Library/Android/sdk/platform-tools/adb -s d2951c5 reverse tcp:8081 tcp:8081
Generating the bundle for the release build...
[11/11/2016, 1:11:48 AM] <START> Initializing Packager
[11/11/2016, 1:11:48 AM] <START> Building in-memory fs for JavaScript
[11/11/2016, 1:11:49 AM] <END>   Building in-memory fs for JavaScript (433ms)
[11/11/2016, 1:11:49 AM] <START> Building Haste Map
[11/11/2016, 1:11:49 AM] <END>   Building Haste Map (385ms)
[11/11/2016, 1:11:49 AM] <END>   Initializing Packager (1076ms)
[11/11/2016, 1:11:49 AM] <START> Transforming modules
[11/11/2016, 1:11:50 AM] <END>   Transforming modules (429ms)
bundle: start
bundle: finish
bundle: Writing bundle output to: android/app/src/main/assets/index.android.bundle
bundle: Done writing bundle output
bundle: Copying 12 asset files
bundle: Done copying assets
Building and installing the app on the device (cd android && ./gradlew installRelease...
Incremental java compilation is an incubating feature.
:app:preBuild UP-TO-DATE
:app:preReleaseBuild UP-TO-DATE
:app:checkReleaseManifest
:app:preDebugBuild UP-TO-DATE
:react-native-vector-icons:preBuild UP-TO-DATE
....
:app:transformResourcesWithMergeJavaResForRelease UP-TO-DATE
:app:validateSigningRelease
:app:packageRelease
:app:assembleRelease
:app:installRelease
Installing APK 'app-release.apk' on 'A0001 - 6.0.1' for app:release
Installed on 1 device.

BUILD SUCCESSFUL

Total time: 1 mins 53.928 secs

This build could be faster, please consider using the Gradle Daemon: https://docs.gradle.org/2.14.1/userguide/gradle_daemon.html
Starting the app on d2951c5 (/Users/xxxxxxxx/Library/Android/sdk/platform-tools/adb -s d2951c5 shell am start -n com.xxxxx.xxxxxx/.MainActivity)...
Starting: Intent { cmp=com.xxxxx.xxxxxx/.MainActivity }
```

To generate a release build for a specific product flavor:
```sh
> react-native run-android --configuration release
```

The output:
```
JS server already running.
Running /Users/*****/Library/Android/sdk/platform-tools/adb -s d2951c5 reverse tcp:8081 tcp:8081
--flavor has been deprecated. Use --variant instead
Generating the bundle for the release build...
[11/11/2016, 1:16:33 AM] <START> Initializing Packager
[11/11/2016, 1:16:33 AM] <START> Building in-memory fs for JavaScript
[11/11/2016, 1:16:33 AM] <END>   Building in-memory fs for JavaScript (110ms)
[11/11/2016, 1:16:33 AM] <START> Building Haste Map
[11/11/2016, 1:16:34 AM] <END>   Building Haste Map (221ms)
[11/11/2016, 1:16:34 AM] <END>   Initializing Packager (392ms)
[11/11/2016, 1:16:34 AM] <START> Transforming modules
[11/11/2016, 1:16:34 AM] <END>   Transforming modules (391ms)
bundle: start
bundle: finish
bundle: Writing bundle output to: android/app/src/main/assets/index.android.bundle
bundle: Done writing bundle output
bundle: Copying 12 asset files
bundle: Done copying assets
Building and installing the app on the device (cd android && ./gradlew installStagingRelease...
...
:app:validateSigningStagingRelease
:app:packageStagingRelease
:app:assembleStagingRelease
:app:installStagingRelease
Installing APK 'app-staging-release.apk' on 'A0001 - 6.0.1' for app:stagingRelease
Installed on 1 device.

BUILD SUCCESSFUL
```

To check the list of options available:
```sh
 react-native run-android --help
````

The output:
```
react-native run-android [options]
  builds your app and starts it on a connected Android emulator or device

  Options:

    -h, --help            output usage information
    --root [string]       Override the root directory for the android build (which contains the android directory)
    --flavor [string]     --flavor has been deprecated. Use --variant instead
    --configuration [string]  You can use `Release` or `Debug`. This creates a build based on the selected build type. If you want to use the `Release` build type make sure you have the `signingConfig` configurated at `app/build.gradle`. The default value is `Debug`.
    --variant [string]
    --config [string]     Path to the CLI configuration file
```