### PR TITLE
Fixed the issue that _onTransitionEnd might try to setState at unmoun…

### DIFF
--- a/Libraries/NavigationExperimental/NavigationTransitioner.js
+++ b/Libraries/NavigationExperimental/NavigationTransitioner.js
@@ -60,6 +60,7 @@ class NavigationTransitioner extends React.Component<any, Props, State> {
   _onTransitionEnd: () => void;
   _prevTransitionProps: ?NavigationTransitionProps;
   _transitionProps: NavigationTransitionProps;
+  _isMounted: boolean;
 
   props: Props;
   state: State;
@@ -94,11 +95,20 @@ class NavigationTransitioner extends React.Component<any, Props, State> {
 
     this._prevTransitionProps = null;
     this._transitionProps = buildTransitionProps(props, this.state);
+    this._isMounted = false;
   }
 
   componentWillMount(): void {
     this._onLayout = this._onLayout.bind(this);
     this._onTransitionEnd = this._onTransitionEnd.bind(this);
+  }
+
+  componentDidMount(): void {
+    this._isMounted = true;
+  }
+
+  componentWillUnmount(): void {
+    this._isMounted = false;
   }
 
   componentWillReceiveProps(nextProps: Props): void {
@@ -211,6 +221,10 @@ class NavigationTransitioner extends React.Component<any, Props, State> {
   }
 
   _onTransitionEnd(): void {
+    if (!this._isMounted) {
+      return;
+    }
+
     const prevTransitionProps = this._prevTransitionProps;
     this._prevTransitionProps = null;
 


### PR DESCRIPTION
This is to fix the issue that if `Animated.parallel`'s callback - `_onTransitionEnd` being triggered twice in a really short period(say quickly double-click the Android's hardware back button),  it might try to `setState` at unmounted stage, hence cause app crash.

This will make sure `_onTransitionEnd` only fired after mounted.