### PR TITLE
Added nav item observer to RCTWrapperViewController

### DIFF
--- a/React/Views/RCTNavItem.h
+++ b/React/Views/RCTNavItem.h
@@ -38,4 +38,6 @@
 @property (nonatomic, copy) RCTBubblingEventBlock onLeftButtonPress;
 @property (nonatomic, copy) RCTBubblingEventBlock onRightButtonPress;
 
+@property (nonatomic, strong, readonly) id propertiesChanged;
+
 @end

--- a/React/Views/RCTNavItem.m
+++ b/React/Views/RCTNavItem.m
@@ -173,4 +173,37 @@
   }
 }
 
+- (id)propertiesChanged {
+  return nil;
+}
+
++ (NSSet *)keyPathsForValuesAffectingPropertiesChanged {
+  // all properties that effects the navigation bar
+  NSString * const properties[] = {
+   @"title",
+   @"titleImage",
+   @"leftButtonIcon",
+   @"leftButtonTitle",
+   @"rightButtonIcon",
+   @"rightButtonTitle",
+   @"backButtonIcon",
+   @"backButtonTitle",
+   @"navigationBarHidden",
+   @"shadowHidden",
+   @"tintColor",
+   @"barTintColor",
+   @"titleTextColor",
+   @"translucent",
+   @"titleImageView",
+   @"backButtonItem",
+   @"leftButtonItem",
+   @"rightButtonItem",
+   @"onLeftButtonPress",
+   @"onRightButtonPress",
+  };
+
+  NSUInteger numProps = (NSUInteger) (sizeof(properties) / sizeof(NSString*));
+  return [NSSet setWithObjects:properties count:numProps];
+}
+
 @end

--- a/React/Views/RCTWrapperViewController.h
+++ b/React/Views/RCTWrapperViewController.h
@@ -28,5 +28,6 @@ didMoveToNavigationController:(UINavigationController *)navigationController;
 
 @property (nonatomic, weak) id<RCTWrapperViewControllerNavigationListener> navigationListener;
 @property (nonatomic, strong) RCTNavItem *navItem;
+@property (nonatomic, assign) BOOL navItemObserving;
 
 @end


### PR DESCRIPTION
This pull request will fix the problem that the **NavigatorIOS** wont adjust its navigation bar when replacing the current route with new navigation bar properties.

Within a component that is rendered by the NavigatorIOS the following lines of code should update the navigation bar (e.g. with a new title) but it won't.

```
// somewhere within a react component
var route = this.props.navigator.navigationContext.currentRoute;
route.title = 'newTitle';
this.props.navigator.replace(route);
```

As a result of debugging the **RCTNavigator** is recognizing the call but `reactBridgeDidFinishTransaction` method doesn't detect any changes because the navigation stack hasn't changed (`jsMakingNoProgressAndDoesntNeedTo` is `true`). So far so good.

The **problem** is that the **RTCNavItem** of the instantiated **RCTWrapperViewController** will have the updated properties (like title) but the controller doesn't know about it or even handles these changes. The current implementation only extracts the RTCNavItem information once in `viewWillAppear` method.

**To accomplish a dynamic updatable navigation bar** with the official api mentioned above I implemented an observer on the *RCTWrapperViewController* that watches for property changes on the RTCNavItem. Once a property has changed the navigation bar of the controller gets updated.

The following few screenshots show a simple demo of what is possible with these changes. The "Change Navigaton Bar" button updates randomly the `title`, `leftButtonTitle`, `rightButtonTitle`and the `tintColor` on the current `route`. For sure all properties will work like defined in the react native api.

![bildschirmfoto 2016-11-11 um 14 58 02](https://cloud.githubusercontent.com/assets/813760/20217457/4ed7b7d0-a820-11e6-854b-079d73c37aeb.png)
![bildschirmfoto 2016-11-11 um 14 58 29](https://cloud.githubusercontent.com/assets/813760/20217466/53e17fa4-a820-11e6-84cf-b1fa5db286b7.png)
![bildschirmfoto 2016-11-11 um 14 58 52](https://cloud.githubusercontent.com/assets/813760/20217469/57f53054-a820-11e6-8665-640181971dab.png)

I know that the NavigatorIOS is kind of deprecated but I hope this pull request will be accepted because there are a lot of people out there who want this feature.

Cheers.

