### PR TITLE
Don't dismiss keyboard when tapping another text input

### DIFF
--- a/Libraries/Components/ScrollResponder.js
+++ b/Libraries/Components/ScrollResponder.js
@@ -114,25 +114,13 @@ type State = {
 };
 type Event = Object;
 
-if (Platform.OS === 'android') {
-  var AndroidTextInput = requireNativeComponent('AndroidTextInput', null);
-} else if (Platform.OS === 'ios') {
-  var RCTTextView = requireNativeComponent('RCTTextView', null);
-  var RCTTextField = requireNativeComponent('RCTTextField', null);
-}
-
 function isTagInstanceOfTextInput(tag) {
   var instance = getInstanceFromNode(tag);
-  if (instance) {
-    if (Platform.OS === 'android') {
-      return instance._currentElement.type === AndroidTextInput;
-    } else if (Platform.OS === 'ios') {
-      return instance._currentElement.type === RCTTextView ||
-        instance._currentElement.type === RCTTextField;
-    }
-  }
-
-  return false;
+  return instance && instance.viewConfig && (
+    instance.viewConfig.uiViewClassName === 'AndroidTextInput' ||
+    instance.viewConfig.uiViewClassName === 'RCTTextView' ||
+    instance.viewConfig.uiViewClassName === 'RCTTextField'
+  );
 }
 
 var ScrollResponderMixin = {

--- a/Libraries/Components/ScrollResponder.js
+++ b/Libraries/Components/ScrollResponder.js
@@ -19,6 +19,7 @@ var Subscribable = require('Subscribable');
 var TextInputState = require('TextInputState');
 var UIManager = require('UIManager');
 
+var { getInstanceFromNode } = require('ReactNativeComponentTree');
 var { ScrollViewManager } = require('NativeModules');
 
 var invariant = require('fbjs/lib/invariant');
@@ -112,6 +113,15 @@ type State = {
 };
 type Event = Object;
 
+function isTagInstanceOfTextInput(tag) {
+  var instance = getInstanceFromNode(tag);
+  return instance && (
+    instance.constructor.displayName === 'AndroidTextInput' ||
+    instance.constructor.displayName === 'RCTTextView' ||
+    instance.constructor.displayName === 'RCTTextField'
+  );
+}
+
 var ScrollResponderMixin = {
   mixins: [Subscribable.Mixin],
   scrollResponderMixinGetInitialState: function(): State {
@@ -172,7 +182,7 @@ var ScrollResponderMixin = {
    * that *doesn't* give priority to nested views (hence the capture phase):
    *
    * - Currently animating.
-   * - Tapping anywhere that is not the focused input, while the keyboard is
+   * - Tapping anywhere that is not a text input, while the keyboard is
    *   up (which should dismiss the keyboard).
    *
    * Invoke this from an `onStartShouldSetResponderCapture` event.
@@ -182,7 +192,7 @@ var ScrollResponderMixin = {
     var currentlyFocusedTextInput = TextInputState.currentlyFocusedField();
     if (!this.props.keyboardShouldPersistTaps &&
       currentlyFocusedTextInput != null &&
-      e.target !== currentlyFocusedTextInput) {
+      !isTagInstanceOfTextInput(e.target)) {
       return true;
     }
     return this.scrollResponderIsAnimating();

--- a/Libraries/Components/ScrollResponder.js
+++ b/Libraries/Components/ScrollResponder.js
@@ -23,7 +23,6 @@ var { getInstanceFromNode } = require('ReactNativeComponentTree');
 var { ScrollViewManager } = require('NativeModules');
 
 var invariant = require('fbjs/lib/invariant');
-var requireNativeComponent = require('requireNativeComponent');
 
 /**
  * Mixin that can be integrated in order to handle scrolling that plays well

--- a/Libraries/Components/ScrollResponder.js
+++ b/Libraries/Components/ScrollResponder.js
@@ -23,6 +23,7 @@ var { getInstanceFromNode } = require('ReactNativeComponentTree');
 var { ScrollViewManager } = require('NativeModules');
 
 var invariant = require('fbjs/lib/invariant');
+var requireNativeComponent = require('requireNativeComponent');
 
 /**
  * Mixin that can be integrated in order to handle scrolling that plays well
@@ -113,13 +114,25 @@ type State = {
 };
 type Event = Object;
 
+if (Platform.OS === 'android') {
+  var AndroidTextInput = requireNativeComponent('AndroidTextInput', null);
+} else if (Platform.OS === 'ios') {
+  var RCTTextView = requireNativeComponent('RCTTextView', null);
+  var RCTTextField = requireNativeComponent('RCTTextField', null);
+}
+
 function isTagInstanceOfTextInput(tag) {
   var instance = getInstanceFromNode(tag);
-  return instance && (
-    instance.constructor.displayName === 'AndroidTextInput' ||
-    instance.constructor.displayName === 'RCTTextView' ||
-    instance.constructor.displayName === 'RCTTextField'
-  );
+  if (instance) {
+    if (Platform.OS === 'android') {
+      return instance._currentElement.type === AndroidTextInput;
+    } else if (Platform.OS === 'ios') {
+      return instance._currentElement.type === RCTTextView ||
+        instance._currentElement.type === RCTTextField;
+    }
+  }
+
+  return false;
 }
 
 var ScrollResponderMixin = {

--- a/Libraries/ReactNative/requireNativeComponent.js
+++ b/Libraries/ReactNative/requireNativeComponent.js
@@ -47,11 +47,6 @@ function requireNativeComponent(
   componentInterface?: ?ComponentInterface,
   extraConfig?: ?{nativeOnly?: Object},
 ): Function {
-  const cachedComponent = nativeComponentsCacheMap.get(viewName);
-  if (cachedComponent) {
-    return cachedComponent;
-  }
-
   const viewConfig = UIManager[viewName];
   if (!viewConfig || !viewConfig.NativeProps) {
     warning(false, 'Native component for "%s" does not exist', viewName);
@@ -103,9 +98,7 @@ function requireNativeComponent(
     );
   }
 
-  const component = createReactNativeComponentClass(viewConfig);
-  nativeComponentsCacheMap.set(viewName, component);
-  return component;
+  return createReactNativeComponentClass(viewConfig);
 }
 
 const TypeToDifferMap = {
@@ -135,7 +128,5 @@ const TypeToProcessorMap = {
   Color: processColor,
   ColorArray: processColorArray,
 };
-
-const nativeComponentsCacheMap = new Map();
 
 module.exports = requireNativeComponent;

--- a/Libraries/ReactNative/requireNativeComponent.js
+++ b/Libraries/ReactNative/requireNativeComponent.js
@@ -47,6 +47,11 @@ function requireNativeComponent(
   componentInterface?: ?ComponentInterface,
   extraConfig?: ?{nativeOnly?: Object},
 ): Function {
+  const cachedComponent = nativeComponentsCacheMap.get(viewName);
+  if (cachedComponent) {
+    return cachedComponent;
+  }
+
   const viewConfig = UIManager[viewName];
   if (!viewConfig || !viewConfig.NativeProps) {
     warning(false, 'Native component for "%s" does not exist', viewName);
@@ -98,10 +103,12 @@ function requireNativeComponent(
     );
   }
 
-  return createReactNativeComponentClass(viewConfig);
+  const component = createReactNativeComponentClass(viewConfig);
+  nativeComponentsCacheMap.set(viewName, component);
+  return component;
 }
 
-var TypeToDifferMap = {
+const TypeToDifferMap = {
   // iOS Types
   CATransform3D: matricesDiffer,
   CGPoint: pointsDiffer,
@@ -115,7 +122,7 @@ function processColorArray(colors: []): [] {
   return colors && colors.map(processColor);
 }
 
-var TypeToProcessorMap = {
+const TypeToProcessorMap = {
   // iOS Types
   CGColor: processColor,
   CGColorArray: processColorArray,
@@ -128,5 +135,7 @@ var TypeToProcessorMap = {
   Color: processColor,
   ColorArray: processColorArray,
 };
+
+const nativeComponentsCacheMap = new Map();
 
 module.exports = requireNativeComponent;

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/TouchTargetHelper.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/TouchTargetHelper.java
@@ -200,10 +200,28 @@ public class TouchTargetHelper {
       float eventCoords[], View view) {
     PointerEvents pointerEvents = view instanceof ReactPointerEventsView ?
         ((ReactPointerEventsView) view).getPointerEvents() : PointerEvents.AUTO;
-    if (!view.isEnabled() || pointerEvents == PointerEvents.BOX_NONE) {
-      // This view can't be the target, but its children might. Views that are disabled should
-      // never be the target of pointer events. However, their children can be because some views
-      // (SwipeRefreshLayout) use enabled but still have children that can be valid targets.
+
+    // Views that are disabled should never be the target of pointer events. However, their children
+    // can be because some views (SwipeRefreshLayout) use enabled but still have children that can
+    // be valid targets.
+    if (!view.isEnabled()) {
+      if (pointerEvents == PointerEvents.AUTO) {
+        pointerEvents = PointerEvents.BOX_NONE;
+      } else if (pointerEvents == PointerEvents.BOX_ONLY) {
+        pointerEvents = PointerEvents.NONE;
+      }
+    }
+
+    if (pointerEvents == PointerEvents.NONE) {
+      // This view and its children can't be the target
+      return null;
+
+    } else if (pointerEvents == PointerEvents.BOX_ONLY) {
+      // This view is the target, its children don't matter
+      return view;
+
+    } else if (pointerEvents == PointerEvents.BOX_NONE) {
+      // This view can't be the target, but its children might.
       if (view instanceof ViewGroup) {
         View targetView = findTouchTargetView(eventCoords, (ViewGroup) view);
         if (targetView != view) {
@@ -225,14 +243,6 @@ public class TouchTargetHelper {
         }
       }
       return null;
-
-    } else if (pointerEvents == PointerEvents.NONE) {
-      // This view and its children can't be the target
-      return null;
-
-    } else if (pointerEvents == PointerEvents.BOX_ONLY) {
-      // This view is the target, its children don't matter
-      return view;
 
     } else if (pointerEvents == PointerEvents.AUTO) {
       // Either this view or one of its children is the target

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/TouchTargetHelper.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/TouchTargetHelper.java
@@ -200,16 +200,10 @@ public class TouchTargetHelper {
       float eventCoords[], View view) {
     PointerEvents pointerEvents = view instanceof ReactPointerEventsView ?
         ((ReactPointerEventsView) view).getPointerEvents() : PointerEvents.AUTO;
-    if (pointerEvents == PointerEvents.NONE) {
-      // This view and its children can't be the target
-      return null;
-
-    } else if (pointerEvents == PointerEvents.BOX_ONLY) {
-      // This view is the target, its children don't matter
-      return view;
-
-    } else if (pointerEvents == PointerEvents.BOX_NONE) {
-      // This view can't be the target, but its children might
+    if (!view.isEnabled() || pointerEvents == PointerEvents.BOX_NONE) {
+      // This view can't be the target, but its children might. Views that are disabled should
+      // never be the target of pointer events. However, their children can be because some views
+      // (SwipeRefreshLayout) use enabled but still have children that can be valid targets.
       if (view instanceof ViewGroup) {
         View targetView = findTouchTargetView(eventCoords, (ViewGroup) view);
         if (targetView != view) {
@@ -231,6 +225,14 @@ public class TouchTargetHelper {
         }
       }
       return null;
+
+    } else if (pointerEvents == PointerEvents.NONE) {
+      // This view and its children can't be the target
+      return null;
+
+    } else if (pointerEvents == PointerEvents.BOX_ONLY) {
+      // This view is the target, its children don't matter
+      return view;
 
     } else if (pointerEvents == PointerEvents.AUTO) {
       // Either this view or one of its children is the target


### PR DESCRIPTION
When using text inputs inside a ScrollView with `keyboardShouldPersistTaps=false` (default behavior) tapping another text input dismisses the keyboard instead of keeping it open and focusing the new text input which I think is the better and expected behavior.

See #10628 for more discussion about that. Note that this affects nothing but the behavior with text inputs unlike #10628.

cc @satya164 @MaxLap @ericvicenti 