### PR TITLE
Fix redundant styles on RefreshControl for Android

### DIFF
--- a/Libraries/Components/ScrollView/ScrollView.js
+++ b/Libraries/Components/ScrollView/ScrollView.js
@@ -532,13 +532,12 @@ const ScrollView = React.createClass({
         // Since the ScrollView is wrapped add the style props to the
         // AndroidSwipeRefreshLayout and use flex: 1 for the ScrollView.
         // Note: we should only apply prop.style on the wrapper
-        // but the ScrollView still needs the baseStyle to be scrollable
-        const scrollViewProps = { ...props, style: baseStyle };
+        // however, the ScrollView still needs the baseStyle to be scrollable
 
         return React.cloneElement(
           refreshControl,
           {style: props.style},
-          <ScrollViewClass {...scrollViewProps} ref={this._setScrollViewRef}>
+          <ScrollViewClass {...scrollViewProps} style={baseStyle} ref={this._setScrollViewRef}>
             {contentContainer}
           </ScrollViewClass>
         );

--- a/Libraries/Components/ScrollView/ScrollView.js
+++ b/Libraries/Components/ScrollView/ScrollView.js
@@ -531,7 +531,7 @@ const ScrollView = React.createClass({
         // On Android wrap the ScrollView with a AndroidSwipeRefreshLayout.
         // Since the ScrollView is wrapped add the style props to the
         // AndroidSwipeRefreshLayout and use flex: 1 for the ScrollView.
-        // Note: we should only apply prop.style on the wrapper
+        // Note: we should only apply props.style on the wrapper
         // however, the ScrollView still needs the baseStyle to be scrollable
 
         return React.cloneElement(

--- a/Libraries/Components/ScrollView/ScrollView.js
+++ b/Libraries/Components/ScrollView/ScrollView.js
@@ -11,6 +11,8 @@
  */
 'use strict';
 
+const omit = require('lodash').omit;
+
 const ColorPropType = require('ColorPropType');
 const EdgeInsetsPropType = require('EdgeInsetsPropType');
 const Platform = require('Platform');
@@ -532,12 +534,12 @@ const ScrollView = React.createClass({
         // Since the ScrollView is wrapped add the style props to the
         // AndroidSwipeRefreshLayout and use flex: 1 for the ScrollView.
         // Note: we should only apply prop.style on the wrapper
-        const { style, ...restProps } = props;
+        const propsWithoutStyle = omit(props, 'style');
 
         return React.cloneElement(
           refreshControl,
           {style: props.style},
-          <ScrollViewClass {...restProps} ref={this._setScrollViewRef}>
+          <ScrollViewClass {...propsWithoutStyle} ref={this._setScrollViewRef}>
             {contentContainer}
           </ScrollViewClass>
         );

--- a/Libraries/Components/ScrollView/ScrollView.js
+++ b/Libraries/Components/ScrollView/ScrollView.js
@@ -531,10 +531,13 @@ const ScrollView = React.createClass({
         // On Android wrap the ScrollView with a AndroidSwipeRefreshLayout.
         // Since the ScrollView is wrapped add the style props to the
         // AndroidSwipeRefreshLayout and use flex: 1 for the ScrollView.
+        // Note: we should only apply prop.style on the wrapper
+        const { style, ...restProps } = props;
+
         return React.cloneElement(
           refreshControl,
           {style: props.style},
-          <ScrollViewClass {...props} ref={this._setScrollViewRef}>
+          <ScrollViewClass {...restProps} ref={this._setScrollViewRef}>
             {contentContainer}
           </ScrollViewClass>
         );

--- a/Libraries/Components/ScrollView/ScrollView.js
+++ b/Libraries/Components/ScrollView/ScrollView.js
@@ -11,8 +11,6 @@
  */
 'use strict';
 
-const omit = require('lodash').omit;
-
 const ColorPropType = require('ColorPropType');
 const EdgeInsetsPropType = require('EdgeInsetsPropType');
 const Platform = require('Platform');
@@ -534,12 +532,13 @@ const ScrollView = React.createClass({
         // Since the ScrollView is wrapped add the style props to the
         // AndroidSwipeRefreshLayout and use flex: 1 for the ScrollView.
         // Note: we should only apply prop.style on the wrapper
-        const propsWithoutStyle = omit(props, 'style');
+        // but the ScrollView still needs the baseStyle to be scrollable
+        const scrollViewProps = { ...props, style: baseStyle };
 
         return React.cloneElement(
           refreshControl,
           {style: props.style},
-          <ScrollViewClass {...propsWithoutStyle} ref={this._setScrollViewRef}>
+          <ScrollViewClass {...scrollViewProps} ref={this._setScrollViewRef}>
             {contentContainer}
           </ScrollViewClass>
         );

--- a/Libraries/Components/ScrollView/ScrollView.js
+++ b/Libraries/Components/ScrollView/ScrollView.js
@@ -537,7 +537,7 @@ const ScrollView = React.createClass({
         return React.cloneElement(
           refreshControl,
           {style: props.style},
-          <ScrollViewClass {...scrollViewProps} style={baseStyle} ref={this._setScrollViewRef}>
+          <ScrollViewClass {...props} style={baseStyle} ref={this._setScrollViewRef}>
             {contentContainer}
           </ScrollViewClass>
         );


### PR DESCRIPTION
Fixed a bug that RefreshControl wrongly apply redundant styles on Android, this solves #10742 