### PR TITLE
Android: Expose Image's onError event to JavaScript

### DIFF
--- a/Libraries/Image/Image.android.js
+++ b/Libraries/Image/Image.android.js
@@ -120,6 +120,10 @@ var Image = React.createClass({
      */
     onLoadStart: PropTypes.func,
     /**
+     * Invoked on load error
+     */
+    onError: PropTypes.func,
+    /**
      * Invoked when load completes successfully
      */
     onLoad: PropTypes.func,
@@ -284,10 +288,10 @@ var Image = React.createClass({
         sources = source;
       }
 
-      const {onLoadStart, onLoad, onLoadEnd} = this.props;
+      const {onLoadStart, onLoad, onLoadEnd, onError} = this.props;
       const nativeProps = merge(this.props, {
         style,
-        shouldNotifyLoadEvents: !!(onLoadStart || onLoad || onLoadEnd),
+        shouldNotifyLoadEvents: !!(onLoadStart || onLoad || onLoadEnd || onError),
         src: sources,
         loadingIndicatorSrc: loadingIndicatorSource ? loadingIndicatorSource.uri : null,
       });

--- a/Libraries/Image/Image.ios.js
+++ b/Libraries/Image/Image.ios.js
@@ -255,7 +255,6 @@ const Image = React.createClass({
     onProgress: PropTypes.func,
     /**
      * Invoked on load error with `{nativeEvent: {error}}`.
-     * @platform ios
      */
     onError: PropTypes.func,
     /**

--- a/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageManager.java
@@ -178,6 +178,8 @@ public class ReactImageManager extends SimpleViewManager<ReactImageView> {
         MapBuilder.of("registrationName", "onLoadStart"),
       ImageLoadEvent.eventNameForType(ImageLoadEvent.ON_LOAD),
         MapBuilder.of("registrationName", "onLoad"),
+      ImageLoadEvent.eventNameForType(ImageLoadEvent.ON_ERROR),
+        MapBuilder.of("registrationName", "onError"),
       ImageLoadEvent.eventNameForType(ImageLoadEvent.ON_LOAD_END),
         MapBuilder.of("registrationName", "onLoadEnd"));
   }


### PR DESCRIPTION
iOS supports an Image onError event. Android was firing the event but it was never reaching JavaScript because Android didn't include this event in `getExportedCustomDirectEventTypeConstants`.

**Test plan (required)**

Verified that the `onError` event now fires in a test app.

My team uses this change in our app.

Adam Comella
Microsoft Corp.