### PR TITLE
Android: Fix WebView crash for links of unknown schemes

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebViewManager.java
@@ -137,16 +137,14 @@ public class ReactWebViewManager extends SimpleViewManager<WebView> {
             url.startsWith("file://")) {
           return false;
         } else {
-          boolean result = true;
           try {
             Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
             intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
             view.getContext().startActivity(intent);
           } catch (ActivityNotFoundException e) {
             FLog.w(ReactConstants.TAG, "activity not found to handle uri scheme for: " + url, e);
-            result = false;
           }
-          return result;
+          return true;
         }
     }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebViewManager.java
@@ -16,6 +16,7 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 
+import android.content.ActivityNotFoundException;
 import android.content.Intent;
 import android.graphics.Bitmap;
 import android.graphics.Picture;
@@ -136,10 +137,16 @@ public class ReactWebViewManager extends SimpleViewManager<WebView> {
             url.startsWith("file://")) {
           return false;
         } else {
-          Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
-          intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-          view.getContext().startActivity(intent);
-          return true;
+          boolean result = true;
+          try {
+            Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
+            intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+            view.getContext().startActivity(intent);
+          } catch (ActivityNotFoundException e) {
+            FLog.w(ReactConstants.TAG, "activity not found to handle uri scheme for: " + url, e);
+            result = false;
+          }
+          return result;
         }
     }
 


### PR DESCRIPTION
When tapping on a link in a WebView with an unknown scheme, the app would crash. For example, if you have the link "something://example/" but your device doesn't have anything to handle the "something" scheme, the app would crash when the user clicks on the link. This change handles the exception to prevent the app from crashing. Instead, the click is a no-op and the WebView doesn't navigate anywhere.

**Test plan (required)**

Verified the app no longer crashes when clicking on unknown schemes in a test app. Also, my team uses this change in our app.

Adam Comella
Microsoft Corp.