### PR TITLE
Make resolveAssetSource public

### DIFF
--- a/Libraries/Image/Image.android.js
+++ b/Libraries/Image/Image.android.js
@@ -216,7 +216,14 @@ var Image = React.createClass({
      */
     async queryCache(urls: Array<string>): Promise<Map<string, 'memory' | 'disk'>> {
       return await ImageLoader.queryCache(urls);
-    }
+    },
+
+    /**
+     * Resolves an asset reference into an object which has the properties `uri`, `width`, 
+     * and `height`. The input may either be a number (opaque type returned by 
+     * require('./foo.png')) or an `ImageSource` like { uri: '<http location || file path>' }
+     */
+    resolveAssetSource: resolveAssetSource,
   },
 
   mixins: [NativeMethodsMixin],

--- a/Libraries/Image/Image.android.js
+++ b/Libraries/Image/Image.android.js
@@ -219,8 +219,8 @@ var Image = React.createClass({
     },
 
     /**
-     * Resolves an asset reference into an object which has the properties `uri`, `width`, 
-     * and `height`. The input may either be a number (opaque type returned by 
+     * Resolves an asset reference into an object which has the properties `uri`, `width`,
+     * and `height`. The input may either be a number (opaque type returned by
      * require('./foo.png')) or an `ImageSource` like { uri: '<http location || file path>' }
      */
     resolveAssetSource: resolveAssetSource,

--- a/Libraries/Image/Image.ios.js
+++ b/Libraries/Image/Image.ios.js
@@ -318,6 +318,12 @@ const Image = React.createClass({
     prefetch(url: string) {
       return ImageViewManager.prefetchImage(url);
     },
+    /**
+     * Resolves an asset reference into an object which has the properties `uri`, `width`, 
+     * and `height`. The input may either be a number (opaque type returned by 
+     * require('./foo.png')) or an `ImageSource` like { uri: '<http location || file path>' }
+     */
+    resolveAssetSource: resolveAssetSource,
   },
 
   mixins: [NativeMethodsMixin],

--- a/Libraries/Image/Image.ios.js
+++ b/Libraries/Image/Image.ios.js
@@ -319,8 +319,8 @@ const Image = React.createClass({
       return ImageViewManager.prefetchImage(url);
     },
     /**
-     * Resolves an asset reference into an object which has the properties `uri`, `width`, 
-     * and `height`. The input may either be a number (opaque type returned by 
+     * Resolves an asset reference into an object which has the properties `uri`, `width`,
+     * and `height`. The input may either be a number (opaque type returned by
      * require('./foo.png')) or an `ImageSource` like { uri: '<http location || file path>' }
      */
     resolveAssetSource: resolveAssetSource,


### PR DESCRIPTION
When building a native component which takes an image reference as a prop, `resolveAssetSource` needs to be called on the image reference. If this isn't done, the native component may receive the opaque type returned by `require` (e.g. `require('./foo.png')`) which is useless to the native component. `resolveAssetSource` is used by builtin components that take image references such as `Image`, `WebView` and `MapView`.

This change makes `resolveAssetSource` public so that third-party native components can correctly handle image references.

**Test plan (required)**

Verified that `Image.resolveAssetSource` works in a test app. Also, my team is using this change in our app.

Adam Comella
Microsoft Corp.