### PR TITLE
Android: Add overScrollMode prop to ScrollView

### DIFF
--- a/Libraries/Components/ScrollView/ScrollView.js
+++ b/Libraries/Components/ScrollView/ScrollView.js
@@ -355,16 +355,16 @@ const ScrollView = React.createClass({
      *
      * Possible values:
      *
-     *  - `'always'` - Always allow a user to over-scroll this view.
-     *  - `'always-if-content-scrolls'` - Default value, allow a user to over-scroll
+     *  - `'auto'` - Default value, allow a user to over-scroll
      *    this view only if the content is large enough to meaningfully scroll.
+     *  - `'always'` - Always allow a user to over-scroll this view.
      *  - `'never'` - Never allow a user to over-scroll this view.
      *
      * @platform android
      */
     overScrollMode: PropTypes.oneOf([
+      'auto',
       'always',
-      'always-if-content-scrolls',
       'never',
     ]),
   },

--- a/Libraries/Components/ScrollView/ScrollView.js
+++ b/Libraries/Components/ScrollView/ScrollView.js
@@ -349,6 +349,24 @@ const ScrollView = React.createClass({
      * @platform android
      */
     scrollPerfTag: PropTypes.string,
+
+     /**
+     * Used to override default value of overScroll mode.
+     * 
+     * Possible values:
+     *
+     *  - `'always'` - Always allow a user to over-scroll this view.
+     *  - `'always-if-content-scrolls'` - Default value, allow a user to over-scroll 
+     *    this view only if the content is large enough to meaningfully scroll.
+     *  - `'never'` - Never allow a user to over-scroll this view.
+     * 
+     * @platform android
+     */
+    overScrollMode: PropTypes.oneOf([
+      'always',
+      'always-if-content-scrolls',
+      'never',
+    ]),
   },
 
   mixins: [ScrollResponder.Mixin],

--- a/Libraries/Components/ScrollView/ScrollView.js
+++ b/Libraries/Components/ScrollView/ScrollView.js
@@ -352,14 +352,14 @@ const ScrollView = React.createClass({
 
      /**
      * Used to override default value of overScroll mode.
-     * 
+     *
      * Possible values:
      *
      *  - `'always'` - Always allow a user to over-scroll this view.
-     *  - `'always-if-content-scrolls'` - Default value, allow a user to over-scroll 
+     *  - `'always-if-content-scrolls'` - Default value, allow a user to over-scroll
      *    this view only if the content is large enough to meaningfully scroll.
      *  - `'never'` - Never allow a user to over-scroll this view.
-     * 
+     *
      * @platform android
      */
     overScrollMode: PropTypes.oneOf([

--- a/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollViewManager.java
@@ -12,6 +12,7 @@ package com.facebook.react.views.scroll;
 import javax.annotation.Nullable;
 
 import android.graphics.Color;
+import android.view.View;
 
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.module.annotations.ReactModule;
@@ -96,6 +97,20 @@ public class ReactHorizontalScrollViewManager
   @ReactProp(name = "pagingEnabled")
   public void setPagingEnabled(ReactHorizontalScrollView view, boolean pagingEnabled) {
     view.setPagingEnabled(pagingEnabled);
+  }
+
+  /**
+   * Controls overScroll behaviour
+   */
+  @ReactProp(name = "overScrollMode")
+  public void setOverScrollMode(ReactScrollView view, String value) {
+    if (value == null || value.equals(ReactScrollViewHelper.OVER_SCROLL_IF_CONTENT_SCROLLS)) {
+      view.setOverScrollMode(View.OVER_SCROLL_IF_CONTENT_SCROLLS);
+    } else if (value.equals(ReactScrollViewHelper.OVER_SCROLL_ALWAYS)) {
+      view.setOverScrollMode(View.OVER_SCROLL_ALWAYS);
+    } else if (value.equals(ReactScrollViewHelper.OVER_SCROLL_NEVER)) {
+      view.setOverScrollMode(View.OVER_SCROLL_NEVER);
+    }
   }
 
   @Override

--- a/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollViewManager.java
@@ -103,8 +103,8 @@ public class ReactHorizontalScrollViewManager
    * Controls overScroll behaviour
    */
   @ReactProp(name = "overScrollMode")
-  public void setOverScrollMode(ReactScrollView view, String value) {
-    if (value == null || value.equals(ReactScrollViewHelper.OVER_SCROLL_IF_CONTENT_SCROLLS)) {
+  public void setOverScrollMode(ReactHorizontalScrollView view, String value) {
+    if (value == null || value.equals(ReactScrollViewHelper.AUTO)) {
       view.setOverScrollMode(View.OVER_SCROLL_IF_CONTENT_SCROLLS);
     } else if (value.equals(ReactScrollViewHelper.OVER_SCROLL_ALWAYS)) {
       view.setOverScrollMode(View.OVER_SCROLL_ALWAYS);

--- a/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollViewManager.java
@@ -104,13 +104,7 @@ public class ReactHorizontalScrollViewManager
    */
   @ReactProp(name = "overScrollMode")
   public void setOverScrollMode(ReactHorizontalScrollView view, String value) {
-    if (value == null || value.equals(ReactScrollViewHelper.AUTO)) {
-      view.setOverScrollMode(View.OVER_SCROLL_IF_CONTENT_SCROLLS);
-    } else if (value.equals(ReactScrollViewHelper.OVER_SCROLL_ALWAYS)) {
-      view.setOverScrollMode(View.OVER_SCROLL_ALWAYS);
-    } else if (value.equals(ReactScrollViewHelper.OVER_SCROLL_NEVER)) {
-      view.setOverScrollMode(View.OVER_SCROLL_NEVER);
-    }
+    view.setOverScrollMode(ReactScrollViewHelper.parseOverScrollMode(value));
   }
 
   @Override

--- a/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewHelper.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewHelper.java
@@ -12,6 +12,7 @@ package com.facebook.react.views.scroll;
 import android.view.View;
 import android.view.ViewGroup;
 
+import com.facebook.react.bridge.JSApplicationIllegalArgumentException;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.uimanager.UIManagerModule;
 
@@ -66,5 +67,17 @@ public class ReactScrollViewHelper {
             contentView.getHeight(),
             scrollView.getWidth(),
             scrollView.getHeight()));
+  }
+
+  public static int parseOverScrollMode(String jsOverScrollMode) {
+    if (jsOverScrollMode == null || jsOverScrollMode.equals(AUTO)) {
+      return View.OVER_SCROLL_IF_CONTENT_SCROLLS;
+    } else if (jsOverScrollMode.equals(OVER_SCROLL_ALWAYS)) {
+      return View.OVER_SCROLL_ALWAYS;
+    } else if (jsOverScrollMode.equals(OVER_SCROLL_NEVER)) {
+      return View.OVER_SCROLL_NEVER;
+    } else {
+      throw new JSApplicationIllegalArgumentException("wrong overScrollMode: " + jsOverScrollMode);
+    }
   }
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewHelper.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewHelper.java
@@ -22,7 +22,7 @@ public class ReactScrollViewHelper {
 
   public static final long MOMENTUM_DELAY = 20;
   public static final String OVER_SCROLL_ALWAYS = "always";
-  public static final String OVER_SCROLL_IF_CONTENT_SCROLLS = "always-if-content-scrolls";
+  public static final String AUTO = "auto";
   public static final String OVER_SCROLL_NEVER = "never";
 
   /**

--- a/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewHelper.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewHelper.java
@@ -21,6 +21,9 @@ import com.facebook.react.uimanager.UIManagerModule;
 public class ReactScrollViewHelper {
 
   public static final long MOMENTUM_DELAY = 20;
+  public static final String OVER_SCROLL_ALWAYS = "always";
+  public static final String OVER_SCROLL_IF_CONTENT_SCROLLS = "always-if-content-scrolls";
+  public static final String OVER_SCROLL_NEVER = "never";
 
   /**
    * Shared by {@link ReactScrollView} and {@link ReactHorizontalScrollView}.

--- a/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewManager.java
@@ -113,7 +113,7 @@ public class ReactScrollViewManager
    */
   @ReactProp(name = "overScrollMode")
   public void setOverScrollMode(ReactScrollView view, String value) {
-    if (value == null || value.equals(ReactScrollViewHelper.OVER_SCROLL_IF_CONTENT_SCROLLS)) {
+    if (value == null || value.equals(ReactScrollViewHelper.AUTO)) {
       view.setOverScrollMode(View.OVER_SCROLL_IF_CONTENT_SCROLLS);
     } else if (value.equals(ReactScrollViewHelper.OVER_SCROLL_ALWAYS)) {
       view.setOverScrollMode(View.OVER_SCROLL_ALWAYS);

--- a/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewManager.java
@@ -113,13 +113,7 @@ public class ReactScrollViewManager
    */
   @ReactProp(name = "overScrollMode")
   public void setOverScrollMode(ReactScrollView view, String value) {
-    if (value == null || value.equals(ReactScrollViewHelper.AUTO)) {
-      view.setOverScrollMode(View.OVER_SCROLL_IF_CONTENT_SCROLLS);
-    } else if (value.equals(ReactScrollViewHelper.OVER_SCROLL_ALWAYS)) {
-      view.setOverScrollMode(View.OVER_SCROLL_ALWAYS);
-    } else if (value.equals(ReactScrollViewHelper.OVER_SCROLL_NEVER)) {
-      view.setOverScrollMode(View.OVER_SCROLL_NEVER);
-    }
+    view.setOverScrollMode(ReactScrollViewHelper.parseOverScrollMode(value));
   }
 
   @Override

--- a/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewManager.java
@@ -14,6 +14,7 @@ import javax.annotation.Nullable;
 import java.util.Map;
 
 import android.graphics.Color;
+import android.view.View;
 
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.common.MapBuilder;
@@ -105,6 +106,20 @@ public class ReactScrollViewManager
   @ReactProp(name = "endFillColor", defaultInt = Color.TRANSPARENT, customType = "Color")
   public void setBottomFillColor(ReactScrollView view, int color) {
     view.setEndFillColor(color);
+  }
+
+  /**
+   * Controls overScroll behaviour
+   */
+  @ReactProp(name = "overScrollMode")
+  public void setOverScrollMode(ReactScrollView view, String value) {
+    if (value == null || value.equals(ReactScrollViewHelper.OVER_SCROLL_IF_CONTENT_SCROLLS)) {
+      view.setOverScrollMode(View.OVER_SCROLL_IF_CONTENT_SCROLLS);
+    } else if (value.equals(ReactScrollViewHelper.OVER_SCROLL_ALWAYS)) {
+      view.setOverScrollMode(View.OVER_SCROLL_ALWAYS);
+    } else if (value.equals(ReactScrollViewHelper.OVER_SCROLL_NEVER)) {
+      view.setOverScrollMode(View.OVER_SCROLL_NEVER);
+    }
   }
 
   @Override


### PR DESCRIPTION
This prop exposes the functionality provided by Android ScrollView's setOverScrollMode method.

One interesting thing to note is that, if you were to read the Android docs, you would think that the value "always" is the default over scroll mode. However, the docs are incorrect and "always-if-content-scrolls" is actually the default value (http://stackoverflow.com/a/27116306).

**Test plan (required)**

Verified this change in a test app. Also, our team uses this change in our app.

Adam Comella
Microsoft Corp.