### PR TITLE
Android: Enable apps to provide a custom configuration to Fresco

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/modules/fresco/FrescoModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/fresco/FrescoModule.java
@@ -111,14 +111,23 @@ public class FrescoModule extends ReactContextBaseJavaModule implements
   }
 
   private static ImagePipelineConfig getDefaultConfig(Context context) {
+    return getDefaultConfigBuilder(context).build();
+  }
+
+  /**
+   * Get the default Fresco configuration builder.
+   * Allows adding of configuration options in addition to the default values.
+   *
+   * @return {@link ImagePipelineConfig.Builder} that has been initialized with default values
+   */
+  public static ImagePipelineConfig.Builder getDefaultConfigBuilder(Context context) {
     HashSet<RequestListener> requestListeners = new HashSet<>();
     requestListeners.add(new SystraceRequestListener());
 
     return OkHttpImagePipelineConfigFactory
       .newBuilder(context.getApplicationContext(), OkHttpClientProvider.getOkHttpClient())
       .setDownsampleEnabled(false)
-      .setRequestListeners(requestListeners)
-      .build();
+      .setRequestListeners(requestListeners);
   }
 
   private static class FrescoHandler implements SoLoaderShim.Handler {

--- a/ReactAndroid/src/main/java/com/facebook/react/shell/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/shell/BUCK
@@ -4,6 +4,7 @@ android_library(
   name = 'shell',
   srcs = glob(['**/*.java']),
   deps = [
+    react_native_dep('libraries/fresco/fresco-react-native:imagepipeline'),
     react_native_dep('libraries/soloader/java/com/facebook/soloader:soloader'),
     react_native_dep('third-party/android/support/v4:lib-support-v4'),
     react_native_dep('third-party/java/infer-annotations:infer-annotations'),

--- a/ReactAndroid/src/main/java/com/facebook/react/shell/MainPackageConfig.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/shell/MainPackageConfig.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+package com.facebook.react.shell;
+
+import com.facebook.imagepipeline.core.ImagePipelineConfig;
+
+/**
+ * Configuration for {@link MainReactPackage}
+ */
+public class MainPackageConfig {
+
+  private ImagePipelineConfig mFrescoConfig;
+
+  private MainPackageConfig(Builder builder) {
+    mFrescoConfig = builder.mFrescoConfig;
+  }
+
+  public ImagePipelineConfig getFrescoConfig() {
+    return mFrescoConfig;
+  }
+
+  public static class Builder {
+
+    private ImagePipelineConfig mFrescoConfig;
+
+    public Builder setFrescoConfig(ImagePipelineConfig frescoConfig) {
+      mFrescoConfig = frescoConfig;
+      return this;
+    }
+
+    public MainPackageConfig build() {
+      return new MainPackageConfig(this);
+    }
+  }
+}

--- a/ReactAndroid/src/main/java/com/facebook/react/shell/MainReactPackage.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/shell/MainReactPackage.java
@@ -15,7 +15,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import com.facebook.imagepipeline.core.ImagePipelineConfig;
 import com.facebook.react.LazyReactPackage;
 import com.facebook.react.animated.NativeAnimatedModule;
 import com.facebook.react.bridge.JavaScriptModule;

--- a/ReactAndroid/src/main/java/com/facebook/react/shell/MainReactPackage.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/shell/MainReactPackage.java
@@ -15,6 +15,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import com.facebook.imagepipeline.core.ImagePipelineConfig;
 import com.facebook.react.LazyReactPackage;
 import com.facebook.react.animated.NativeAnimatedModule;
 import com.facebook.react.bridge.JavaScriptModule;
@@ -74,6 +75,18 @@ import com.facebook.react.views.webview.ReactWebViewManager;
  */
 public class MainReactPackage extends LazyReactPackage {
 
+  private MainPackageConfig mConfig;
+
+  public MainReactPackage() {
+  }
+
+  /**
+   * Create a new package with configuration
+   */
+  public MainReactPackage(MainPackageConfig config) {
+    mConfig = config;
+  }
+
   @Override
   public List<ModuleSpec> getNativeModules(final ReactApplicationContext context) {
     return Arrays.asList(
@@ -116,7 +129,7 @@ public class MainReactPackage extends LazyReactPackage {
       new ModuleSpec(FrescoModule.class, new Provider<NativeModule>() {
         @Override
         public NativeModule get() {
-          return new FrescoModule(context);
+          return new FrescoModule(context, mConfig != null ? mConfig.getFrescoConfig() : null);
         }
       }),
       new ModuleSpec(I18nManagerModule.class, new Provider<NativeModule>() {


### PR DESCRIPTION
The `FrescoModule` supports providing a custom image pipeline configuration. This module is created by `MainReactPackage` but `MainReactPackage` doesn't expose any way to customize the Fresco configuration. This change adds a parameter to `MainReactPackage`'s constructor so that the `FrescoModule`'s configuration can be customized by the app. A couple of design choices were made in this change:
  - `MainReactPackage`'s new constructor parameter is a `MainPackageConfig`. Introducing `MainPackageConfig` enables `MainReactPackage` to nicely support new optional configuration options in the future. Imagine the alternative of each optional configuration being a separate parameter to the `MainReactPackage` constructor.
  - `FrescoModule` exposes its default configuration as a builder object through the `getDefaultConfigBuilder` method. This enables app's to start with `FrescoModule`'s default configuration and then modify it.

**Test plan (required)**

Verified that passing a custom config based on React Native's default Fresco config works in a test app. Also, my team uses this change in our app.

Adam Comella
Microsoft Corp.