### PR TITLE
UIViewManager: Add accessibilityElementsHidden

### DIFF
--- a/Libraries/Components/View/View.js
+++ b/Libraries/Components/View/View.js
@@ -190,9 +190,18 @@ const View = React.createClass({
     ]),
 
     /**
+     * Controls whether the accessibility elements contained within this view are hidden.
+     * Works for iOS Only. For Android, See  [importantForAccessibility](#importantforaccessibility)
+     *
+     * @platform ios
+     */
+
+    accessibilityElementsHidden: PropTypes.bool,
+
+    /**
      * Controls how view is important for accessibility which is if it
      * fires accessibility events and if it is reported to accessibility services
-     * that query the screen. Works for Android only.
+     * that query the screen. Works for Android only. For iOS see  [importantForAccessibility](#accessibilityElementsHidden)
      *
      * Possible values:
      *

--- a/Libraries/Components/View/View.js
+++ b/Libraries/Components/View/View.js
@@ -191,8 +191,14 @@ const View = React.createClass({
     ]),
 
     /**
-     * Controls whether the accessibility elements contained within this view are hidden.
-     * Use this property to indicate whatever the view should be reported to accessibility services that query the screen.
+     * Controls whether the accessibility elements contained within this view are hidden
+     * from accessibility services that query the screen.
+     *
+     * - If `true`, this View and all accessibility elements contained within it are hidden
+     * from accessibility services.
+     * - If `false`, this view is visible to accessibility services.
+     * - The default value is `null` which means the OS decides which elements are important
+     * for accessibility.
      */
     accessibilityElementsHidden: PropTypes.bool,
 

--- a/Libraries/Components/View/View.js
+++ b/Libraries/Components/View/View.js
@@ -26,6 +26,7 @@ if (Platform.isTVOS) {
   TVViewPropTypes = require('TVViewPropTypes');
 }
 
+const deprecatedPropType = require('deprecatedPropType');
 const requireNativeComponent = require('requireNativeComponent');
 
 const PropTypes = React.PropTypes;
@@ -191,38 +192,19 @@ const View = React.createClass({
 
     /**
      * Controls whether the accessibility elements contained within this view are hidden.
-     * Works for iOS Only. For Android, See  [importantForAccessibility](#importantforaccessibility)
-     *
-     * @platform ios
+     * Use this property to indicate whatever the view should be reported to accessibility services that query the screen.
      */
-
     accessibilityElementsHidden: PropTypes.bool,
 
-    /**
-     * Controls how view is important for accessibility which is if it
-     * fires accessibility events and if it is reported to accessibility services
-     * that query the screen. Works for Android only. For iOS see  [importantForAccessibility](#accessibilityElementsHidden)
-     *
-     * Possible values:
-     *
-     *  - `'auto'` - The system determines whether the view is important for accessibility -
-     *    default (recommended).
-     *  - `'yes'` - The view is important for accessibility.
-     *  - `'no'` - The view is not important for accessibility.
-     *  - `'no-hide-descendants'` - The view is not important for accessibility,
-     *    nor are any of its descendant views.
-     *
-     * See the [Android `importantForAccessibility` docs](http://developer.android.com/reference/android/R.attr.html#importantForAccessibility)
-     * for reference.
-     *
-     * @platform android
-     */
-    importantForAccessibility: PropTypes.oneOf([
-      'auto',
-      'yes',
-      'no',
-      'no-hide-descendants',
-    ]),
+    importantForAccessibility: deprecatedPropType(
+      PropTypes.oneOf([
+        'auto',
+        'yes',
+        'no',
+        'no-hide-descendants',
+      ]),
+      'Use the `accessibilityElementsHidden` prop instead.'
+    ),
 
     /**
      * Provides additional traits to screen reader. By default no traits are

--- a/Libraries/CustomComponents/NavigationExperimental/NavigationCard.js
+++ b/Libraries/CustomComponents/NavigationExperimental/NavigationCard.js
@@ -100,8 +100,7 @@ class NavigationCard extends React.Component<any, Props, any> {
         {...viewPanHandlers}
         pointerEvents={pointerEvents}
         ref={this.props.onComponentRef}
-        accessibilityElementsHidden={!props.scene.isActive} // iOS
-        importantForAccessibility={props.scene.isActive ? 'yes' : 'no-hide-descendants'} // Android
+        accessibilityElementsHidden={!props.scene.isActive}
         style={[styles.main, viewStyle]}>
         {renderScene(props)}
       </Animated.View>

--- a/Libraries/CustomComponents/NavigationExperimental/NavigationCard.js
+++ b/Libraries/CustomComponents/NavigationExperimental/NavigationCard.js
@@ -100,6 +100,8 @@ class NavigationCard extends React.Component<any, Props, any> {
         {...viewPanHandlers}
         pointerEvents={pointerEvents}
         ref={this.props.onComponentRef}
+        accessibilityElementsHidden={!props.scene.isActive} // iOS
+        importantForAccessibility={props.scene.isActive ? 'yes' : 'no-hide-descendants'} // Android
         style={[styles.main, viewStyle]}>
         {renderScene(props)}
       </Animated.View>

--- a/React/Views/RCTViewManager.m
+++ b/React/Views/RCTViewManager.m
@@ -20,10 +20,6 @@
 #import "RCTView.h"
 #import "UIView+React.h"
 
-#if TARGET_OS_TV
-#import "RCTTVView.h"
-#endif
-
 @implementation RCTConvert(UIAccessibilityTraits)
 
 RCT_MULTI_ENUM_CONVERTER(UIAccessibilityTraits, (@{
@@ -61,11 +57,7 @@ RCT_EXPORT_MODULE()
 
 - (UIView *)view
 {
-#if TARGET_OS_TV
-  return [RCTTVView new];
-#else
   return [RCTView new];
-#endif
 }
 
 - (RCTShadowView *)shadowView
@@ -106,13 +98,7 @@ RCT_EXPORT_MODULE()
 
 #pragma mark - View properties
 
-#if TARGET_OS_TV
-// Apple TV properties
-RCT_EXPORT_VIEW_PROPERTY(isTVSelectable, BOOL)
-RCT_EXPORT_VIEW_PROPERTY(hasTVPreferredFocus, BOOL)
-RCT_EXPORT_VIEW_PROPERTY(tvParallaxProperties, NSDictionary)
-#endif
-
+RCT_EXPORT_VIEW_PROPERTY(accessibilityElementsHidden, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(accessibilityLabel, NSString)
 RCT_EXPORT_VIEW_PROPERTY(accessibilityTraits, UIAccessibilityTraits)
 RCT_EXPORT_VIEW_PROPERTY(backgroundColor, UIColor)
@@ -124,10 +110,10 @@ RCT_REMAP_VIEW_PROPERTY(shadowColor, layer.shadowColor, CGColor)
 RCT_REMAP_VIEW_PROPERTY(shadowOffset, layer.shadowOffset, CGSize)
 RCT_REMAP_VIEW_PROPERTY(shadowOpacity, layer.shadowOpacity, float)
 RCT_REMAP_VIEW_PROPERTY(shadowRadius, layer.shadowRadius, CGFloat)
-RCT_CUSTOM_VIEW_PROPERTY(overflow, YGOverflow, RCTView)
+RCT_CUSTOM_VIEW_PROPERTY(overflow, CSSOverflow, RCTView)
 {
   if (json) {
-    view.clipsToBounds = [RCTConvert YGOverflow:json] != YGOverflowVisible;
+    view.clipsToBounds = [RCTConvert CSSOverflow:json] != CSSOverflowVisible;
   } else {
     view.clipsToBounds = defaultView.clipsToBounds;
   }
@@ -303,15 +289,15 @@ RCT_EXPORT_SHADOW_PROPERTY(flex, float)
 RCT_EXPORT_SHADOW_PROPERTY(flexGrow, float)
 RCT_EXPORT_SHADOW_PROPERTY(flexShrink, float)
 RCT_EXPORT_SHADOW_PROPERTY(flexBasis, float)
-RCT_EXPORT_SHADOW_PROPERTY(flexDirection, YGFlexDirection)
-RCT_EXPORT_SHADOW_PROPERTY(flexWrap, YGWrap)
-RCT_EXPORT_SHADOW_PROPERTY(justifyContent, YGJustify)
-RCT_EXPORT_SHADOW_PROPERTY(alignItems, YGAlign)
-RCT_EXPORT_SHADOW_PROPERTY(alignSelf, YGAlign)
-RCT_EXPORT_SHADOW_PROPERTY(position, YGPositionType)
+RCT_EXPORT_SHADOW_PROPERTY(flexDirection, CSSFlexDirection)
+RCT_EXPORT_SHADOW_PROPERTY(flexWrap, CSSWrap)
+RCT_EXPORT_SHADOW_PROPERTY(justifyContent, CSSJustify)
+RCT_EXPORT_SHADOW_PROPERTY(alignItems, CSSAlign)
+RCT_EXPORT_SHADOW_PROPERTY(alignSelf, CSSAlign)
+RCT_EXPORT_SHADOW_PROPERTY(position, CSSPositionType)
 RCT_EXPORT_SHADOW_PROPERTY(aspectRatio, float)
 
-RCT_EXPORT_SHADOW_PROPERTY(overflow, YGOverflow)
+RCT_EXPORT_SHADOW_PROPERTY(overflow, CSSOverflow)
 
 RCT_EXPORT_SHADOW_PROPERTY(onLayout, RCTDirectEventBlock)
 

--- a/React/Views/RCTViewManager.m
+++ b/React/Views/RCTViewManager.m
@@ -20,6 +20,10 @@
 #import "RCTView.h"
 #import "UIView+React.h"
 
+#if TARGET_OS_TV
+#import "RCTTVView.h"
+#endif
+
 @implementation RCTConvert(UIAccessibilityTraits)
 
 RCT_MULTI_ENUM_CONVERTER(UIAccessibilityTraits, (@{
@@ -57,7 +61,11 @@ RCT_EXPORT_MODULE()
 
 - (UIView *)view
 {
+#if TARGET_OS_TV
+  return [RCTTVView new];
+#else
   return [RCTView new];
+#endif
 }
 
 - (RCTShadowView *)shadowView
@@ -98,6 +106,13 @@ RCT_EXPORT_MODULE()
 
 #pragma mark - View properties
 
+#if TARGET_OS_TV
+// Apple TV properties
+RCT_EXPORT_VIEW_PROPERTY(isTVSelectable, BOOL)
+RCT_EXPORT_VIEW_PROPERTY(hasTVPreferredFocus, BOOL)
+RCT_EXPORT_VIEW_PROPERTY(tvParallaxProperties, NSDictionary)
+#endif
+
 RCT_EXPORT_VIEW_PROPERTY(accessibilityElementsHidden, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(accessibilityLabel, NSString)
 RCT_EXPORT_VIEW_PROPERTY(accessibilityTraits, UIAccessibilityTraits)
@@ -110,10 +125,10 @@ RCT_REMAP_VIEW_PROPERTY(shadowColor, layer.shadowColor, CGColor)
 RCT_REMAP_VIEW_PROPERTY(shadowOffset, layer.shadowOffset, CGSize)
 RCT_REMAP_VIEW_PROPERTY(shadowOpacity, layer.shadowOpacity, float)
 RCT_REMAP_VIEW_PROPERTY(shadowRadius, layer.shadowRadius, CGFloat)
-RCT_CUSTOM_VIEW_PROPERTY(overflow, CSSOverflow, RCTView)
+RCT_CUSTOM_VIEW_PROPERTY(overflow, YGOverflow, RCTView)
 {
   if (json) {
-    view.clipsToBounds = [RCTConvert CSSOverflow:json] != CSSOverflowVisible;
+    view.clipsToBounds = [RCTConvert YGOverflow:json] != YGOverflowVisible;
   } else {
     view.clipsToBounds = defaultView.clipsToBounds;
   }
@@ -289,15 +304,15 @@ RCT_EXPORT_SHADOW_PROPERTY(flex, float)
 RCT_EXPORT_SHADOW_PROPERTY(flexGrow, float)
 RCT_EXPORT_SHADOW_PROPERTY(flexShrink, float)
 RCT_EXPORT_SHADOW_PROPERTY(flexBasis, float)
-RCT_EXPORT_SHADOW_PROPERTY(flexDirection, CSSFlexDirection)
-RCT_EXPORT_SHADOW_PROPERTY(flexWrap, CSSWrap)
-RCT_EXPORT_SHADOW_PROPERTY(justifyContent, CSSJustify)
-RCT_EXPORT_SHADOW_PROPERTY(alignItems, CSSAlign)
-RCT_EXPORT_SHADOW_PROPERTY(alignSelf, CSSAlign)
-RCT_EXPORT_SHADOW_PROPERTY(position, CSSPositionType)
+RCT_EXPORT_SHADOW_PROPERTY(flexDirection, YGFlexDirection)
+RCT_EXPORT_SHADOW_PROPERTY(flexWrap, YGWrap)
+RCT_EXPORT_SHADOW_PROPERTY(justifyContent, YGJustify)
+RCT_EXPORT_SHADOW_PROPERTY(alignItems, YGAlign)
+RCT_EXPORT_SHADOW_PROPERTY(alignSelf, YGAlign)
+RCT_EXPORT_SHADOW_PROPERTY(position, YGPositionType)
 RCT_EXPORT_SHADOW_PROPERTY(aspectRatio, float)
 
-RCT_EXPORT_SHADOW_PROPERTY(overflow, CSSOverflow)
+RCT_EXPORT_SHADOW_PROPERTY(overflow, YGOverflow)
 
 RCT_EXPORT_SHADOW_PROPERTY(onLayout, RCTDirectEventBlock)
 


### PR DESCRIPTION
UIKit `accessibilityElementsHidden` property is similar to
Android's `importantForAccessibility` and very important for
creating a good accessible experience by hidding off the screen
and invisible elements/views from VoiceOver and other assistive
technologies.

This commit also improves accessibility of Navigation Experimental
CardStack by marking inactive (off screen) scenes invisible for iOS
VoiceOver and Android's Talkback.

Closes #9725