### PR TITLE
Caching assets only for production environment

### DIFF
--- a/packager/react-packager/src/Server/__tests__/Server-test.js
+++ b/packager/react-packager/src/Server/__tests__/Server-test.js
@@ -379,7 +379,6 @@ describe('processRequest', () => {
 
       server.processRequest(req, res);
       jest.runAllTimers();
-      expect(res.setHeader).toBeCalledWith('Cache-Control', 'max-age=31536000');
       expect(res.end).toBeCalledWith('i am image');
     });
 
@@ -392,7 +391,6 @@ describe('processRequest', () => {
       server.processRequest(req, res);
       jest.runAllTimers();
       expect(AssetServer.prototype.get).toBeCalledWith('imgs/a.png', 'ios');
-      expect(res.setHeader).toBeCalledWith('Cache-Control', 'max-age=31536000');
       expect(res.end).toBeCalledWith('i am image');
     });
 
@@ -406,7 +404,6 @@ describe('processRequest', () => {
       server.processRequest(req, res);
       jest.runAllTimers();
       expect(AssetServer.prototype.get).toBeCalledWith('imgs/a.png', 'ios');
-      expect(res.setHeader).toBeCalledWith('Cache-Control', 'max-age=31536000');
       expect(res.end).toBeCalledWith(mockData.slice(0, 4));
     });
 
@@ -422,7 +419,6 @@ describe('processRequest', () => {
         'imgs/\u{4E3B}\u{9875}/logo.png',
         undefined
       );
-      expect(res.setHeader).toBeCalledWith('Cache-Control', 'max-age=31536000');
       expect(res.end).toBeCalledWith('i am image');
     });
   });

--- a/packager/react-packager/src/Server/index.js
+++ b/packager/react-packager/src/Server/index.js
@@ -502,7 +502,9 @@ class Server {
         data => {
           // Tell clients to cache this for 1 year.
           // This is safe as the asset url contains a hash of the asset.
-          res.setHeader('Cache-Control', 'max-age=31536000');
+          if (process.env.REACT_NATIVE_ENABLE_ASSET_CACHING === true) {
+            res.setHeader('Cache-Control', 'max-age=31536000');
+          }
           res.end(this._rangeRequestMiddleware(req, res, data, assetPath));
           print(log(createActionEndEntry(processingAssetRequestLogEntry)), ['asset']);
         },


### PR DESCRIPTION
**Motivation**

In the context of a webview, one may extract assets (javascript or any types really), and relates to them through the html.

The packager `Server` serves this files correctly but also applies a cache based on time (a year). During development, this cache is actually bad as we need to re-iterate the process of editing/testing quickly.

I don't believe it is necessary to cache, and still wanted to make sure we would if process.env.NODE_ENV is 'production'.

**Test plan**

Run jest on impacted files:
```
node_modules/.bin/jest packager/react-packager/src/Server/__tests__/Server-test.js
```
