### PR TITLE
[Docs] fix wrong script name 'publish-website' to 'gh-pages'

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -30,5 +30,5 @@ Anytime you change the contents, just refresh the page and it's going to be upda
 
 ```sh
 cd website
-npm run gh-pages
+npm run publish-gh-pages
 ```

--- a/website/README.md
+++ b/website/README.md
@@ -30,5 +30,5 @@ Anytime you change the contents, just refresh the page and it's going to be upda
 
 ```sh
 cd website
-npm run publish-website
+npm run gh-pages
 ```


### PR DESCRIPTION
There was wrong script name in Docs