### PR TITLE
[website] fix `for` being used instead of `htmlFor`

### DIFF
--- a/website/core/Site.js
+++ b/website/core/Site.js
@@ -169,7 +169,7 @@ var Site = React.createClass({
                 <div id="mc_embed_signup">
                   <form action="//reactnative.us10.list-manage.com/subscribe/post?u=db0dd948e2b729ee62625b1a8&amp;id=47cd41008f" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" className="validate" target="_blank" noValidate>
                     <div id="mc_embed_signup_scroll">
-                      <label for="mce-EMAIL">
+                      <label htmlFor="mce-EMAIL">
                         <h5>Get the React Native Newsletter</h5>
                       </label>
                       <input type="email" value="" name="EMAIL" className="email" id="mce-EMAIL" placeholder="email address" required />


### PR DESCRIPTION
When building the website, I saw this warning: 

`Warning: Unknown DOM property for. Did you mean htmlFor?`

So, here's the fix.


## Test plan:
   
 1. do `npm start`
 2. load the homepage (with the newsletter input)
 3. see warning: `Warning: Unknown DOM property for. Did you mean htmlFor?`
