### PR TITLE
platform.is()

### DIFF
--- a/Libraries/Utilities/Platform.android.js
+++ b/Libraries/Utilities/Platform.android.js
@@ -18,6 +18,7 @@ var Platform = {
     return require('NativeModules').AndroidConstants.Version;
   },
   select: (obj: Object) => obj.android,
+  is: (osString: string): boolean => { return osString === 'android'},
 };
 
 module.exports = Platform;

--- a/Libraries/Utilities/Platform.ios.js
+++ b/Libraries/Utilities/Platform.ios.js
@@ -18,6 +18,7 @@ var Platform = {
     return require('NativeModules').IOSConstants.osVersion;
   },
   select: (obj: Object) => obj.ios,
+  is: (osString: string): boolean => { return osString === 'ios'},
 };
 
 module.exports = Platform;


### PR DESCRIPTION
hi! This PR contains what basically is a equivalent for `Platform.OS === 'ios' / 'android'` but written as `Platform.is('ios' / 'android')`. I found it neater than the former way when using in a project, though I understand it may be found redundant. Your call :)