### PR TITLE
Fixed Android bug causing to remove wrong view after reordering by zIndex

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeViewHierarchyManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeViewHierarchyManager.java
@@ -323,78 +323,8 @@ public class NativeViewHierarchyManager {
                 tagsToDelete));
     }
 
-    int lastIndexToRemove = viewManager.getChildCount(viewToManage);
-    if (indicesToRemove != null) {
-      for (int i = indicesToRemove.length - 1; i >= 0; i--) {
-        int indexToRemove = indicesToRemove[i];
-        if (indexToRemove < 0) {
-          throw new IllegalViewOperationException(
-              "Trying to remove a negative view index:"
-                  + indexToRemove + " view tag: " + tag + "\n detail: " +
-                  constructManageChildrenErrorMessage(
-                      viewToManage,
-                      viewManager,
-                      indicesToRemove,
-                      viewsToAdd,
-                      tagsToDelete));
-        }
-        if (indexToRemove >= viewManager.getChildCount(viewToManage)) {
-          throw new IllegalViewOperationException(
-              "Trying to remove a view index above child " +
-                  "count " + indexToRemove + " view tag: " + tag + "\n detail: " +
-                  constructManageChildrenErrorMessage(
-                      viewToManage,
-                      viewManager,
-                      indicesToRemove,
-                      viewsToAdd,
-                      tagsToDelete));
-        }
-        if (indexToRemove >= lastIndexToRemove) {
-          throw new IllegalViewOperationException(
-              "Trying to remove an out of order view index:"
-                  + indexToRemove + " view tag: " + tag + "\n detail: " +
-                  constructManageChildrenErrorMessage(
-                      viewToManage,
-                      viewManager,
-                      indicesToRemove,
-                      viewsToAdd,
-                      tagsToDelete));
-        }
-
-        View viewToRemove = viewManager.getChildAt(viewToManage, indexToRemove);
-
-        if (mLayoutAnimationEnabled &&
-            mLayoutAnimator.shouldAnimateLayout(viewToRemove) &&
-            arrayContains(tagsToDelete, viewToRemove.getId())) {
-          // The view will be removed and dropped by the 'delete' layout animation
-          // instead, so do nothing
-        } else {
-          viewManager.removeViewAt(viewToManage, indexToRemove);
-        }
-
-        lastIndexToRemove = indexToRemove;
-      }
-    }
-
-    if (viewsToAdd != null) {
-      for (int i = 0; i < viewsToAdd.length; i++) {
-        ViewAtIndex viewAtIndex = viewsToAdd[i];
-        View viewToAdd = mTagsToViews.get(viewAtIndex.mTag);
-        if (viewToAdd == null) {
-          throw new IllegalViewOperationException(
-              "Trying to add unknown view tag: "
-                  + viewAtIndex.mTag + "\n detail: " +
-                  constructManageChildrenErrorMessage(
-                      viewToManage,
-                      viewManager,
-                      indicesToRemove,
-                      viewsToAdd,
-                      tagsToDelete));
-        }
-        viewManager.addView(viewToManage, viewToAdd, viewAtIndex.mIndex);
-      }
-    }
-
+    // Operate only on tagsToDelete. indicesToRemove coming from JS is not reliable
+    // because views order might've been changed internally after zIndex sorting
     if (tagsToDelete != null) {
       for (int i = 0; i < tagsToDelete.length; i++) {
         int tagToDelete = tagsToDelete[i];
@@ -421,8 +351,28 @@ public class NativeViewHierarchyManager {
             }
           });
         } else {
+          viewManager.removeView(viewToManage, viewToDestroy);
           dropView(viewToDestroy);
         }
+      }
+    }
+
+    if (viewsToAdd != null) {
+      for (int i = 0; i < viewsToAdd.length; i++) {
+        ViewAtIndex viewAtIndex = viewsToAdd[i];
+        View viewToAdd = mTagsToViews.get(viewAtIndex.mTag);
+        if (viewToAdd == null) {
+          throw new IllegalViewOperationException(
+              "Trying to add unknown view tag: "
+                  + viewAtIndex.mTag + "\n detail: " +
+                  constructManageChildrenErrorMessage(
+                      viewToManage,
+                      viewManager,
+                      indicesToRemove,
+                      viewsToAdd,
+                      tagsToDelete));
+        }
+        viewManager.addView(viewToManage, viewToAdd, viewAtIndex.mIndex);
       }
     }
   }


### PR DESCRIPTION
Commit https://github.com/facebook/react-native/commit/3d3b067f6fc831b6b23726087fe39cf39ef86f00 implemented zIndex support for Android. However after zIndex resorting of the views, the JS doesn't know about the new order. When dynamically removing the view from an array of views, JS sends the command to remove the view at certain index, which is not the same in Java anymore since the order of items changed.
This issue is also happens when adding view after reordering - it's added in the wrong position instead, but since it gets reordered again, it doesn't have visible effect, that's why it's only spotted when removing views.

Test Plan:
Related issue and the simple empty react-native 0.37 app where it was tested: #8968 

Test app code:
```javascript
import React, { Component } from 'react';
import {
  AppRegistry,
  StyleSheet,
  Text,
  View
} from 'react-native';

export default class zindex extends Component {
  constructor(props) {
    super(props);
    this.state = {
      showGreen: true
    };
  }
  render() {
    return (
      <View style={{flex: 1}}>
        <View style={[styles.item, {zIndex: 3, backgroundColor: 'red'}]}>
          <Text>zIndex: 3</Text>
        </View>
        {this.state.showGreen ?
          <View style={[styles.item, {zIndex: 2, backgroundColor: 'green', height: 90}]}>
            <Text>zIndex: 2</Text>
          </View> : null
        }
        <View style={[styles.item, {zIndex: 1, backgroundColor: 'blue', height: 120}]}>
          <Text>zIndex: 1</Text>
        </View>
        <View style={styles.button}>
          <Text onPress={() => this.setState({ showGreen: !this.state.showGreen })}>
            Toggle green
          </Text>
        </View>
      </View>
    );
  }
}

const styles = StyleSheet.create({
  item: {
    position: 'absolute',
    left: 0,
    right: 0,
    top: 0,
    height: 60
  },
  button: {
    position: 'absolute',
    left: 0,
    right: 0,
    backgroundColor: 'gray',
    top: 150,
    height: 30
  }
});

AppRegistry.registerComponent('zindex', () => zindex);
```

Starting screen:
![screen shot 2016-11-15 at 16 15 58](https://cloud.githubusercontent.com/assets/2877657/20311224/3fdd817e-ab4f-11e6-8e34-69874dd97114.png)

Before fix, when trying to remove green, it removes blue instead:
![screen shot 2016-11-15 at 16 20 18](https://cloud.githubusercontent.com/assets/2877657/20311282/71bba61c-ab4f-11e6-991e-6bb35f813a2e.png)

After fix it removed green correctly:
![screen shot 2016-11-15 at 16 16 22](https://cloud.githubusercontent.com/assets/2877657/20311232/4cf649b8-ab4f-11e6-81ea-1058c15b5241.png)

When clicking toggle again, it adds green back, the blue is still ordered correctly by zIndex:
![screen shot 2016-11-15 at 16 16 44](https://cloud.githubusercontent.com/assets/2877657/20311238/5505267e-ab4f-11e6-98c1-d21988745bc6.png)


Initially the order of operations in `manageChildren` in `NativeViewHierarchyManager.java` was:
1) Loop by `indicesToRemove`, call `viewManager.removeViewAt(viewToManage, indexToRemove)`. However if the view is animated and it's ID in the array of `tagsToDelete`, do nothing and delegate this job of removing item to the step 3).
2) Loop by `viewsToAdd`, add the views.
3) Loop by `tagsToDelete`, perform animations on the views that are using animations, then call `viewManager.removeView(viewToManage, viewToDestroy)` and `dropView(viewToDestroy)`. But if the view is not animated, only `dropView(viewToDestroy)` is called because we assume that correct view was previously removed in step 1)

New order of operations:
1) Loop by `tagsToDelete`, perform animations if necessary, then call `viewManager.removeView(viewToManage, viewToDestroy)` and `dropView(viewToDestroy)`. If no animations, just call `viewManager.removeView(viewToManage, viewToDestroy)` and `dropView(viewToDestroy)` right away.
2) Loop by `viewsToAdd`, add the views.

The intent is to perform clean-up by only looping by `tagsToDelete` first, instead of splitting the clean-up into separate steps of removing by index, then dropping by tagToDelete. And then when all the views are properly removed, we add the new views. Since `indicesToRemove` it's not reliable anymore and we don't use it for `removeViewAt`, we can get rid of the whole 1) step and replace it by 3) step.
Also by having the old operations order we having the case that the *wrong* view is removed in step 1), but then, *correct* view is dropped in step 3). In result we have inconsistency when removing one view but dropping another. It's described in more details in mentioned above related issue comments.

Because the diff doesn't look very clear because of replacing the blocks of code, here is what's actually changed:
1. Removed the loop by `indicesToRemove` as it's not reliable anymore and causing wrong view to be removed.
2. Moved loop by `tagsToDelete` before adding new views
3. Added a call for `viewManager.removeView(viewToManage, viewToDestroy)` in `else` statement.