### PR TITLE
Prevent hitslop crash on Android

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.java
@@ -81,10 +81,10 @@ public class ReactViewManager extends ViewGroupManager<ReactViewGroup> {
       view.setHitSlopRect(null);
     } else {
       view.setHitSlopRect(new Rect(
-          (int) PixelUtil.toPixelFromDIP(hitSlop.getDouble("left")),
-          (int) PixelUtil.toPixelFromDIP(hitSlop.getDouble("top")),
-          (int) PixelUtil.toPixelFromDIP(hitSlop.getDouble("right")),
-          (int) PixelUtil.toPixelFromDIP(hitSlop.getDouble("bottom"))
+          hitSlop.hasKey("left") ? (int) PixelUtil.toPixelFromDIP(hitSlop.getDouble("left")) : 0,
+          hitSlop.hasKey("top") ? (int) PixelUtil.toPixelFromDIP(hitSlop.getDouble("top")) : 0,
+          hitSlop.hasKey("right") ? (int) PixelUtil.toPixelFromDIP(hitSlop.getDouble("right")) : 0,
+          hitSlop.hasKey("bottom") ? (int) PixelUtil.toPixelFromDIP(hitSlop.getDouble("bottom")) : 0
       ));
     }
   }


### PR DESCRIPTION
**Motivation**
Currently to use the `hitSlop` property on Android you must define the object properties `left`, `top`, `right`, and `bottom` or it will crash. iOS allows omitting object properties from the hitSlop.

This change guards and allows the `hitSlop` object properties to be optional like iOS. 

**Test plan (required)**

Run the [example](https://github.com/facebook/react-native/blob/f930270b005953bb7083190eef60d050e4de7607/Examples/UIExplorer/js/TouchableExample.js#L318) and omit a hitslop property and check it does not crash.