### PR TITLE
Fixed Android bug causing to remove wrong view after reordering by zIndex

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeViewHierarchyOptimizer.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeViewHierarchyOptimizer.java
@@ -154,6 +154,7 @@ public class NativeViewHierarchyOptimizer {
       mUIViewOperationQueue.enqueueManageChildren(
           nodeToManage.getReactTag(),
           indicesToRemove,
+          tagsToRemove,
           viewsToAdd,
           tagsToDelete);
       return;
@@ -281,6 +282,7 @@ public class NativeViewHierarchyOptimizer {
       mUIViewOperationQueue.enqueueManageChildren(
           nativeNodeToRemoveFrom.getReactTag(),
           new int[]{index},
+          new int[]{nodeToRemove.getReactTag()},
           null,
           shouldDelete ? new int[]{nodeToRemove.getReactTag()} : null);
     } else {
@@ -304,6 +306,7 @@ public class NativeViewHierarchyOptimizer {
     parent.addNativeChildAt(child, index);
     mUIViewOperationQueue.enqueueManageChildren(
         parent.getReactTag(),
+        null,
         null,
         new ViewAtIndex[]{new ViewAtIndex(child.getReactTag(), index)},
         null);

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIViewOperationQueue.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIViewOperationQueue.java
@@ -156,16 +156,19 @@ public class UIViewOperationQueue {
   private final class ManageChildrenOperation extends ViewOperation {
 
     private final @Nullable int[] mIndicesToRemove;
+    private final @Nullable int[] mTagsToRemove;
     private final @Nullable ViewAtIndex[] mViewsToAdd;
     private final @Nullable int[] mTagsToDelete;
 
     public ManageChildrenOperation(
         int tag,
         @Nullable int[] indicesToRemove,
+        @Nullable int[] tagsToRemove,
         @Nullable ViewAtIndex[] viewsToAdd,
         @Nullable int[] tagsToDelete) {
       super(tag);
       mIndicesToRemove = indicesToRemove;
+      mTagsToRemove = tagsToRemove;
       mViewsToAdd = viewsToAdd;
       mTagsToDelete = tagsToDelete;
     }
@@ -175,6 +178,7 @@ public class UIViewOperationQueue {
       mNativeViewHierarchyManager.manageChildren(
           mTag,
           mIndicesToRemove,
+          mTagsToRemove,
           mViewsToAdd,
           mTagsToDelete);
     }
@@ -665,10 +669,11 @@ public class UIViewOperationQueue {
   public void enqueueManageChildren(
       int reactTag,
       @Nullable int[] indicesToRemove,
+      @Nullable int[] tagsToRemove,
       @Nullable ViewAtIndex[] viewsToAdd,
       @Nullable int[] tagsToDelete) {
     mOperations.add(
-        new ManageChildrenOperation(reactTag, indicesToRemove, viewsToAdd, tagsToDelete));
+        new ManageChildrenOperation(reactTag, indicesToRemove, tagsToRemove, viewsToAdd, tagsToDelete));
   }
 
   public void enqueueSetChildren(


### PR DESCRIPTION
Commit https://github.com/facebook/react-native/commit/3d3b067f6fc831b6b23726087fe39cf39ef86f00 implemented zIndex support for Android. However after zIndex resorting of the views, the JS doesn't know about the new order. When dynamically removing the view from an array of views, JS sends the command to remove the view at certain index, which is not the same in Java since the order of items changed.

Test Plan:
Related issue and the simple empty react-native 0.37 app where it was tested:
https://github.com/facebook/react-native/issues/8968

Test app code:
```javascript
import React, { Component } from 'react';
import {
  AppRegistry,
  StyleSheet,
  Text,
  View
} from 'react-native';

export default class zindex extends Component {
  constructor(props) {
    super(props);
    this.state = {
      showGreen: true
    };
  }
  render() {
    return (
      <View style={{flex: 1}}>
        <View style={[styles.item, {zIndex: 3, backgroundColor: 'red'}]}>
          <Text>zIndex: 3</Text>
        </View>
        {this.state.showGreen ?
          <View style={[styles.item, {zIndex: 2, backgroundColor: 'green', height: 90}]}>
            <Text>zIndex: 2</Text>
          </View> : null
        }
        <View style={[styles.item, {zIndex: 1, backgroundColor: 'blue', height: 120}]}>
          <Text>zIndex: 1</Text>
        </View>
        <View style={styles.button}>
          <Text onPress={() => this.setState({ showGreen: !this.state.showGreen })}>
            Toggle green
          </Text>
        </View>
      </View>
    );
  }
}

const styles = StyleSheet.create({
  item: {
    position: 'absolute',
    left: 0,
    right: 0,
    top: 0,
    height: 60
  },
  button: {
    position: 'absolute',
    left: 0,
    right: 0,
    backgroundColor: 'gray',
    top: 150,
    height: 30
  }
});

AppRegistry.registerComponent('zindex', () => zindex);
```

Starting screen:
![screen shot 2016-11-15 at 16 15 58](https://cloud.githubusercontent.com/assets/2877657/20311224/3fdd817e-ab4f-11e6-8e34-69874dd97114.png)

Before fix, when trying to remove green, it removes blue instead:
![screen shot 2016-11-15 at 16 20 18](https://cloud.githubusercontent.com/assets/2877657/20311282/71bba61c-ab4f-11e6-991e-6bb35f813a2e.png)

After fix it removed green correctly:
![screen shot 2016-11-15 at 16 16 22](https://cloud.githubusercontent.com/assets/2877657/20311232/4cf649b8-ab4f-11e6-81ea-1058c15b5241.png)

When clicking toggle again, it adds green back, the blue is still ordered correctly by zIndex:
![screen shot 2016-11-15 at 16 16 44](https://cloud.githubusercontent.com/assets/2877657/20311238/5505267e-ab4f-11e6-98c1-d21988745bc6.png)

Description:
In `manageChildren` in `NativeViewHierarchyManager.java` there was a loop by [`indicesToRemove`](https://github.com/facebook/react-native/blob/master/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeViewHierarchyManager.java#L326) and a call `viewManager.removeViewAt(viewToManage, indexToRemove)`. However if the view is animated and it's ID in the array of `tagsToDelete`, do nothing and delegate this job of removing item to the loop by `tagsToDelete` later.

Now we propagate `tagsToRemove` from `UIImplementation` to `NativeViewHierarchyOptimizer` to `NativeViewHierarchyManager` and using it instead of `indicesToRemove`, because the `tag` is reliable way of identifying the node, and the index is not reliable anymore because of internal reordering of the views.

Also by having the old `indicesToRemove` loop we having the case that the *wrong* view is removed, but then, *correct* view is dropped in `tagsToDelete` loop. In result we have inconsistency when removing one view but dropping another. It's described in more details in mentioned above related issue comments.