### PR TITLE
Add icebox command

### DIFF
--- a/bots/IssueCommands.txt
+++ b/bots/IssueCommands.txt
@@ -41,3 +41,8 @@ close
 
 @facebook-github-bot cla
 comment Hey {issue_author}! Thanks for sending this pull request! We would love to review your changes however it looks like you haven't signed the CLA yet. You can do so at https://code.facebook.com/cla.
+
+@facebook-github-bot icebox
+comment {author} tells me to close this issue because it has been inactive for a while. If you think it should still be opened let us know why.
+add-label Icebox
+close


### PR DESCRIPTION
Add icebox command to comment, label and close an issue from one command instead of ping facebook bot serveral times. The goal is to reduce ping pollution, see the [current implementation](https://github.com/facebook/react-native/issues/6752#issuecomment-260830484).

Will be used by the Iceboxer script for people who only have access to the @facebook-github-bot.

cc @mkonicek