### PR TITLE
[Experiment][RFC][CI] Attempt to stabilize React Native open source Android e2e test

### DIFF
--- a/scripts/android-e2e-test.js
+++ b/scripts/android-e2e-test.js
@@ -66,18 +66,17 @@ describe('Android Test App', function () {
       app: path.resolve('buck-out/gen/android/app/app.apk')
     };
 
-    // React Native in dev mode often starts with Red Box "Can't fibd variable __fbBatchedBridge..."
+    // React Native in dev mode often starts with Red Box "Can't find variable __fbBatchedBridge..."
     // This is fixed by clicking Reload JS which will trigger a request to packager server
     return driver
       .init(desired)
-      .setImplicitWaitTimeout(5000)
+      .setImplicitWaitTimeout(60000)
       .waitForElementByXPath('//android.widget.Button[@text="Reload JS"]').
       then((elem) => {
         elem.click();
       }, (err) => {
         // ignoring if Reload JS button can't be located
-      })
-      .setImplicitWaitTimeout(150000);
+      });
   });
 
   after(function () {


### PR DESCRIPTION
**DON'T MERGE THIS YET. USING THIS PR TO DEBUG E2E TESTS ON CIRCLE CI.**

The Android e2e test took one hour here: https://circleci.com/gh/facebook/react-native/13266

The whole script failed three times, retrying the Gradle and Buck build three times:
- The Gradle and Buck build always succeeded
- The Appium test always failed, with several different results

We can see Appium e2e test itself is a bit flaky. In the repetitions you see a sequence like:

- 1 passing (can load app), 1 failing (can load app with HMR)
- 0 passing, 2 failing (can load app, can load app with HMR)
And then the test fails to run:
- 0 passing, 2 failing
Error: [setImplicitWaitTimeout(150000)] Unexpected data in simpleCallback.

Watching the test as it runs, it always get stuck for a very long time when waiting for the UI to be updated:

    POST /session/:sessionID/elements {"using":"xpath","value":"//android.widget.TextView[starts-with(@text, \"Welcome to React Native!\")]"}

and here:

    POST /session/:sessionID/elements {"using":"xpath","value":"//android.widget.TextView[starts-with(@text, \"Welcome to React Native with HMR!\")]"}

Just before that, the test hit "Reload JS". Does this mean reloading JS takes an extremely long time? Is it because the packager is very slow on CI? Or does it mean the emulator is extremely slow updating the UI?

Let's try using a shorter 60s timeout to wait for the UI to update. At fb internally we often use 30-60s. 150s seems like quite a lot and it's unclear if a timeout of 150s makes the test more stable than 60s.

**Test Plan**
Will to rerun Circle CI tests on this PR a few times and observe how stable / flaky they are.