### PR TITLE
add more infos on how to profile the javascript #10944

### DIFF
--- a/docs/AndroidUIPerformance.md
+++ b/docs/AndroidUIPerformance.md
@@ -126,26 +126,6 @@ If you identified a JS problem, look for clues in the specific JS that you're ex
 
 This doesn't seem right. Why is it being called so often? Are they actually different events? The answers to these questions will probably depend on your product code. And many times, you'll want to look into [shouldComponentUpdate](https://facebook.github.io/react/docs/component-specs.html#updating-shouldcomponentupdate).
 
-You can use `react-addons-perf` to have a first insight on wich components are the bottleneck.
-
-```js
-import Perf from 'react-addons-perf';
-
-....
-    componentDidMount() {
-        console.log('start perf tracking');
-        Perf.start();
-        setTimeout(() => {
-            console.log('stop perf tracking');
-            Perf.stop();
-            Perf.printInclusive();
-        }, 10000);
-   }
-...
-```
-
-Another way is to use the chrome profiler while debugging, this won't give you accurate results but more of a general idea of what's going on in the javascript thread.
-
 > **TODO**: Add more tools for profiling JS
 
 ## Native UI Issues

--- a/docs/AndroidUIPerformance.md
+++ b/docs/AndroidUIPerformance.md
@@ -126,6 +126,8 @@ If you identified a JS problem, look for clues in the specific JS that you're ex
 
 This doesn't seem right. Why is it being called so often? Are they actually different events? The answers to these questions will probably depend on your product code. And many times, you'll want to look into [shouldComponentUpdate](https://facebook.github.io/react/docs/component-specs.html#updating-shouldcomponentupdate).
 
+You can use `react-addons-perf` to have a first insight on wich components are the bottleneck. Another way is to use the chrome profiler while debugging, this won't give you accurate results but more of a general idea of what's going on.
+
 > **TODO**: Add more tools for profiling JS
 
 ## Native UI Issues

--- a/docs/AndroidUIPerformance.md
+++ b/docs/AndroidUIPerformance.md
@@ -126,7 +126,25 @@ If you identified a JS problem, look for clues in the specific JS that you're ex
 
 This doesn't seem right. Why is it being called so often? Are they actually different events? The answers to these questions will probably depend on your product code. And many times, you'll want to look into [shouldComponentUpdate](https://facebook.github.io/react/docs/component-specs.html#updating-shouldcomponentupdate).
 
-You can use `react-addons-perf` to have a first insight on wich components are the bottleneck. Another way is to use the chrome profiler while debugging, this won't give you accurate results but more of a general idea of what's going on.
+You can use `react-addons-perf` to have a first insight on wich components are the bottleneck.
+
+```js
+import Perf from 'react-addons-perf';
+
+....
+    componentDidMount() {
+        console.log('start perf tracking');
+        Perf.start();
+        setTimeout(() => {
+            console.log('stop perf tracking');
+            Perf.stop();
+            Perf.printInclusive();
+        }, 10000);
+   }
+...
+```
+
+Another way is to use the chrome profiler while debugging, this won't give you accurate results but more of a general idea of what's going on.
 
 > **TODO**: Add more tools for profiling JS
 

--- a/docs/AndroidUIPerformance.md
+++ b/docs/AndroidUIPerformance.md
@@ -144,7 +144,7 @@ import Perf from 'react-addons-perf';
 ...
 ```
 
-Another way is to use the chrome profiler while debugging, this won't give you accurate results but more of a general idea of what's going on.
+Another way is to use the chrome profiler while debugging, this won't give you accurate results but more of a general idea of what's going on in the javascript thread.
 
 > **TODO**: Add more tools for profiling JS
 

--- a/docs/Performance.md
+++ b/docs/Performance.md
@@ -325,22 +325,6 @@ the JavaScript thread and main thread side-by-side.
 For iOS, Instruments are an invaluable tool, and on Android you should
 learn to use systrace.
 
-You can use `react-addons-perf` to have a first insight on wich components are the bottleneck.
+You can also use [`react-addons-perf`](https://facebook.github.io/react/docs/perf.html) to get insights into where React is spending time when rendering your components.
 
-```js
-import Perf from 'react-addons-perf';
-
-....
-    componentDidMount() {
-        console.log('start perf tracking');
-        Perf.start();
-        setTimeout(() => {
-            console.log('stop perf tracking');
-            Perf.stop();
-            Perf.printInclusive();
-        }, 10000);
-   }
-...
-```
-
-Another way is to use the chrome profiler while debugging, this won't give you accurate results but more of a general idea of what's going on in the javascript thread.
+Another way to profile JavaScript is to use the Chrome profiler while debugging. This won't give you accurate results as the code is running in Chrome but will give you a general idea of where bottlenecks might be.

--- a/docs/Performance.md
+++ b/docs/Performance.md
@@ -324,3 +324,23 @@ the JavaScript thread and main thread side-by-side.
 
 For iOS, Instruments are an invaluable tool, and on Android you should
 learn to use systrace.
+
+You can use `react-addons-perf` to have a first insight on wich components are the bottleneck.
+
+```javascript
+import Perf from 'react-addons-perf';
+
+....
+    componentDidMount() {
+        console.log('start perf tracking');
+        Perf.start();
+        setTimeout(() => {
+            console.log('stop perf tracking');
+            Perf.stop();
+            Perf.printInclusive();
+        }, 10000);
+   }
+...
+```
+
+Another way is to use the chrome profiler while debugging, this won't give you accurate results but more of a general idea of what's going on.

--- a/docs/Performance.md
+++ b/docs/Performance.md
@@ -327,7 +327,7 @@ learn to use systrace.
 
 You can use `react-addons-perf` to have a first insight on wich components are the bottleneck.
 
-```javascript
+```js
 import Perf from 'react-addons-perf';
 
 ....
@@ -343,4 +343,4 @@ import Perf from 'react-addons-perf';
 ...
 ```
 
-Another way is to use the chrome profiler while debugging, this won't give you accurate results but more of a general idea of what's going on.
+Another way is to use the chrome profiler while debugging, this won't give you accurate results but more of a general idea of what's going on in the javascript thread.


### PR DESCRIPTION
As said in #10944, there's not yet some good infos on how to profile the javascript.

I'm adding a mention to two ways of doing it (`react-addons-perf` and chrome profiler), feel free to correct me on this.

I almost added an example for `react-addons-perf` but I'm not sure what's the correct way to use. Here's the way I use it:

```javascript
import Perf from 'react-addons-perf';

....
    componentDidMount() {
        console.log('start perf tracking');
        Perf.start();
        setTimeout(() => {
            console.log('stop perf tracking');
            Perf.stop();
            Perf.printExclusive();
        }, 10000);
   }
...
```