### PR TITLE
[RFC] Only run React Native Android instrumentation tests internally

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -62,17 +62,6 @@ test:
     # unit tests
     - buck test ReactAndroid/src/test/... --config build.threads=1
 
-    # instrumentation tests
-    # compile native libs with Gradle script
-    - ./gradlew :ReactAndroid:packageReactNdkLibsForBuck -Pjobs=1 -Pcom.android.build.threadPoolSize=1:
-        timeout: 360
-    # build JS bundle for instrumentation tests
-    - REACT_NATIVE_MAX_WORKERS=1 node local-cli/cli.js bundle --platform android --dev true --entry-file ReactAndroid/src/androidTest/js/TestBundle.js --bundle-output ReactAndroid/src/androidTest/assets/AndroidTestBundle.js
-    # build test APK
-    - buck install ReactAndroid/src/androidTest/buck-runner:instrumentation-tests --config build.threads=1
-    # run installed apk with tests
-    - node ./scripts/run-android-ci-instrumentation-tests.js --retries 3 --path ./ReactAndroid/src/androidTest/java/com/facebook/react/tests --package com.facebook.react.tests
-
     # gradle may invalidate bridge build cache, so we pass single-threaded setting just in case
     - ./gradlew :ReactAndroid:testDebugUnitTest -Pjobs=1 -Pcom.android.build.threadPoolSize=1
     # Deprecated: these tests are executed using Buck above, while we support Gradle we just make sure the test code compiles


### PR DESCRIPTION
These tests take 45 minutes on every commit / pull request and very rarely fail (I don't remember seeing them catch a legit issue with the pull request).

Rather than doing an analysis of which tests are the most valuable, which are the slowest ones etc., let's stop running all of them on Circle CI.

The exact same tests still run internally and are land blocking so by removing them from CI we don't risk breakages being introduced.

All the work of open sourcing these test and making it possible to run them outside of fb infra is still valuable - when they fail internally and detect an actual problem with a pull request, we can tell the pull request author what failed exactly and they can debug the problem locally:
https://github.com/facebook/react-native/tree/master/ReactAndroid/src/androidTest/java/com/facebook/react/tests

**Test plan**

Circle CI tests on this pull request.