### PR TITLE
Make synchronouslyUpdateViewOnUIThread use the operations queue

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeViewHierarchyOptimizer.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeViewHierarchyOptimizer.java
@@ -122,7 +122,7 @@ public class NativeViewHierarchyOptimizer {
       String className,
       ReactStylesDiffMap props) {
     if (!ENABLED) {
-      mUIViewOperationQueue.enqueueUpdateProperties(node.getReactTag(), className, props);
+      mUIViewOperationQueue.enqueueUpdateProperties(node.getReactTag(), props);
       return;
     }
 
@@ -130,7 +130,7 @@ public class NativeViewHierarchyOptimizer {
     if (needsToLeaveLayoutOnly) {
       transitionLayoutOnlyViewToNativeView(node, props);
     } else if (!node.isLayoutOnly()) {
-      mUIViewOperationQueue.enqueueUpdateProperties(node.getReactTag(), className, props);
+      mUIViewOperationQueue.enqueueUpdateProperties(node.getReactTag(), props);
     }
   }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIImplementation.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIImplementation.java
@@ -226,8 +226,8 @@ public class UIImplementation {
    */
   public void synchronouslyUpdateViewOnUIThread(int tag, ReactStylesDiffMap props) {
     UiThreadUtil.assertOnUiThread();
-    mOperationsQueue.enqueueUpdateProperties(tag, props);
-    mOperationsQueue.synchronouslyDispatchViewUpdates();
+    mOperationsQueue.enqueueNonBatchedUpdateProperties(tag, props);
+    mOperationsQueue.dispatchNonBatchedViewUpdates();
   }
 
   protected void handleUpdateView(

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIImplementation.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIImplementation.java
@@ -226,7 +226,8 @@ public class UIImplementation {
    */
   public void synchronouslyUpdateViewOnUIThread(int tag, ReactStylesDiffMap props) {
     UiThreadUtil.assertOnUiThread();
-    mOperationsQueue.getNativeViewHierarchyManager().updateProperties(tag, props);
+    mOperationsQueue.enqueueUpdateProperties(tag, props);
+    mOperationsQueue.synchronouslyDispatchViewUpdates();
   }
 
   protected void handleUpdateView(


### PR DESCRIPTION
Alternative solution to #10907. This fixes a crash that happens because native animations tries to update a view that was not yet created because it bypasses the operation queue. This uses `enqueueUpdateProperties` and then a new method that just flushes the queue immediately. This makes sure pending view creation operations are executed before the update ones.

Decided to add a new method to flush the operation queue since the existing one did some extra dispatching / logging and assumes to be called from UIManager.

**Test plan**
Tested that native animations still work and that it happens in the same frame as they are dispatched. A good way to test this is to put a view inside a scrollview and animated it's translation to be the same as the scroll position, the view is not supposed to move at all. Pretty much made sure it behaves exactly as before this change.