### PR TITLE
Dispatch native handled events to JS

### DIFF
--- a/Libraries/NativeAnimation/RCTNativeAnimatedModule.m
+++ b/Libraries/NativeAnimation/RCTNativeAnimatedModule.m
@@ -322,11 +322,11 @@ RCT_EXPORT_METHOD(removeAnimatedEventFromView:(nonnull NSNumber *)viewTag
                      body:@{@"tag": node.nodeTag, @"value": @(value)}];
 }
 
-- (BOOL)eventDispatcherWillDispatchEvent:(id<RCTEvent>)event
+- (void)eventDispatcherWillDispatchEvent:(id<RCTEvent>)event
 {
   // Native animated events only work for events dispatched from the main queue.
   if (!RCTIsMainQueue() || _eventAnimationDrivers.count == 0) {
-    return NO;
+    return;
   }
 
   NSString *key = [NSString stringWithFormat:@"%@%@", event.viewTag, event.eventName];
@@ -336,11 +336,7 @@ RCT_EXPORT_METHOD(removeAnimatedEventFromView:(nonnull NSNumber *)viewTag
     [driver updateWithEvent:event];
     [self updateViewsProps];
     [driver.valueNode cleanupAnimationUpdate];
-
-    return YES;
   }
-
-  return NO;
 }
 
 - (void)updateViewsProps

--- a/React/Base/RCTEventDispatcher.h
+++ b/React/Base/RCTEventDispatcher.h
@@ -58,10 +58,9 @@ RCT_EXTERN NSString *RCTNormalizeInputEventName(NSString *eventName);
 
 /**
  * Called before dispatching an event, on the same thread the event was
- * dispatched from. Return YES if the event was handled and must not be
- * sent to JS.
+ * dispatched from.
  */
-- (BOOL)eventDispatcherWillDispatchEvent:(id<RCTEvent>)event;
+- (void)eventDispatcherWillDispatchEvent:(id<RCTEvent>)event;
 
 @end
 

--- a/React/Base/RCTEventDispatcher.m
+++ b/React/Base/RCTEventDispatcher.m
@@ -146,18 +146,11 @@ RCT_EXPORT_MODULE()
 {
   [_observersLock lock];
 
-  BOOL eventHandled = NO;
   for (id<RCTEventDispatcherObserver> observer in _observers) {
-    if ([observer eventDispatcherWillDispatchEvent:event]) {
-      eventHandled = YES;
-    }
+    [observer eventDispatcherWillDispatchEvent:event];
   }
 
   [_observersLock unlock];
-
-  if (eventHandled) {
-    return;
-  }
 
   [_eventQueueLock lock];
 

--- a/ReactAndroid/src/main/java/com/facebook/react/animated/NativeAnimatedNodesManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/animated/NativeAnimatedNodesManager.java
@@ -314,10 +314,10 @@ import javax.annotation.Nullable;
   }
 
   @Override
-  public boolean onEventDispatch(Event event) {
+  public void onEventDispatch(Event event) {
     // Only support events dispatched from the UI thread.
     if (!UiThreadUtil.isOnUiThread()) {
-      return false;
+      return;
     }
 
     if (!mEventDrivers.isEmpty()) {
@@ -332,11 +332,8 @@ import javax.annotation.Nullable;
       if (eventDriver != null) {
         event.dispatch(eventDriver);
         mUpdatedNodes.put(eventDriver.mValueNode.mTag, eventDriver.mValueNode);
-        return true;
       }
     }
-
-    return false;
   }
 
   /**

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/EventDispatcher.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/EventDispatcher.java
@@ -114,16 +114,8 @@ public class EventDispatcher implements LifecycleEventListener {
   public void dispatchEvent(Event event) {
     Assertions.assertCondition(event.isInitialized(), "Dispatched event hasn't been initialized");
 
-    boolean eventHandled = false;
     for (EventDispatcherListener listener : mListeners) {
-      if (listener.onEventDispatch(event)) {
-        eventHandled = true;
-      }
-    }
-
-    // If the event was handled by one of the event listener don't send it to JS.
-    if (eventHandled) {
-      return;
+      listener.onEventDispatch(event);
     }
 
     synchronized (mEventsStagingLock) {

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/EventDispatcherListener.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/EventDispatcherListener.java
@@ -10,7 +10,6 @@ public interface EventDispatcherListener {
    * Called on every time an event is dispatched using {#link EventDispatcher#dispatchEvent}. Will be
    * called from the same thread that the event is being dispatched from.
    * @param event Event that was dispatched
-   * @return If the event was handled. If true the event won't be sent to JS.
    */
-  boolean onEventDispatch(Event event);
+  void onEventDispatch(Event event);
 }


### PR DESCRIPTION
When native events where handled they were not sent to JS as an optimization but this caused some issues. One of the major one is touches are not handled properly inside a ScrollView with an Animated.event because it doesn't receive scroll events so it can't cancel the touch if the user scrolled.