### PR TITLE
Android: Keep ScrollView content visible after edits

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
@@ -364,14 +364,10 @@ public class ReactScrollView extends ScrollView implements ReactClippingViewGrou
    */
   @Override
   public void onLayoutChange(View v, int left, int top, int right, int bottom, int oldLeft, int oldTop, int oldRight, int oldBottom) {
-    onContentLayoutChange(v, left, top, right, bottom, oldLeft, oldTop, oldRight, oldBottom);
-  }
-
-  private void onContentLayoutChange(View v, int left, int top, int right, int bottom, int oldLeft, int oldTop, int oldRight, int oldBottom) {
     if (mContentView == null) {
       FLog.w(
-              ReactConstants.TAG,
-              "mContentView is not set on call to onContentLayoutChange");
+          ReactConstants.TAG,
+          "mContentView is not set on call to onContentLayoutChange");
       return;
     }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
@@ -26,7 +26,6 @@ import android.widget.OverScroller;
 import android.widget.ScrollView;
 
 import com.facebook.react.bridge.ReactContext;
-import com.facebook.common.logging.FLog;
 import com.facebook.react.common.ReactConstants;
 import com.facebook.react.uimanager.MeasureSpecAssertions;
 import com.facebook.react.uimanager.events.NativeGestureUtil;
@@ -371,9 +370,6 @@ public class ReactScrollView extends ScrollView implements ReactClippingViewGrou
   @Override
   public void onLayoutChange(View v, int left, int top, int right, int bottom, int oldLeft, int oldTop, int oldRight, int oldBottom) {
     if (mContentView == null) {
-      FLog.w(
-          ReactConstants.TAG,
-          "mContentView is not set on call to onContentLayoutChange");
       return;
     }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
@@ -102,7 +102,7 @@ public class ReactScrollView extends ScrollView implements ReactClippingViewGrou
       mScroller = null;
     }
 
-    this.setOnHierarchyChangeListener(this);
+    setOnHierarchyChangeListener(this);
   }
 
   public void setSendMomentumEvents(boolean sendMomentumEvents) {
@@ -362,14 +362,14 @@ public class ReactScrollView extends ScrollView implements ReactClippingViewGrou
     if (mContentView != null) {
       mContentView.removeOnLayoutChangeListener(this);
     }
-    if (this.getChildCount() != expectedChildCount) {
+    if (getChildCount() != expectedChildCount) {
       FLog.w(
               ReactConstants.TAG,
-              String.format("Expected %s children for ReactScrollView, found %s.", expectedChildCount, this.getChildCount()));
+              String.format("Expected %s children for ReactScrollView, found %s.", expectedChildCount, getChildCount()));
     }
 
-    if (this.getChildCount() > 0) {
-      mContentView = this.getChildAt(0);
+    if (getChildCount() > 0) {
+      mContentView = getChildAt(0);
       mContentView.addOnLayoutChangeListener(this);
     } else { // no children
       mContentView = null;
@@ -381,7 +381,7 @@ public class ReactScrollView extends ScrollView implements ReactClippingViewGrou
    */
   @Override
   public void onLayoutChange(View v, int left, int top, int right, int bottom, int oldLeft, int oldTop, int oldRight, int oldBottom) {
-    this.onContentLayoutChange(v, left, top, right, bottom, oldLeft, oldTop, oldRight, oldBottom);
+    onContentLayoutChange(v, left, top, right, bottom, oldLeft, oldTop, oldRight, oldBottom);
   }
 
   private void onContentLayoutChange(View v, int left, int top, int right, int bottom, int oldLeft, int oldTop, int oldRight, int oldBottom) {
@@ -394,12 +394,12 @@ public class ReactScrollView extends ScrollView implements ReactClippingViewGrou
 
     int contentHeight = mContentView.getMeasuredHeight();
     int currentScrollY = getScrollY();
-    int thisHeight = this.getMeasuredHeight();
+    int thisHeight = getMeasuredHeight();
 
     int maxScrollY = Math.max(0, contentHeight - thisHeight);
 
     if (currentScrollY > maxScrollY) {
-      this.scrollTo(getScrollX(), maxScrollY);
+      scrollTo(getScrollX(), maxScrollY);
     }
   }
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
@@ -349,31 +349,14 @@ public class ReactScrollView extends ScrollView implements ReactClippingViewGrou
 
   @Override
   public void onChildViewAdded(View parent, View child) {
-    setContentView(1 /* expectedChildCount */);
+    mContentView = child;
+    mContentView.addOnLayoutChangeListener(this);
   }
 
   @Override
   public void onChildViewRemoved(View parent, View child) {
-    setContentView(0 /* expectedChildCount */);
-
-  }
-
-  private void setContentView(int expectedChildCount) {
-    if (mContentView != null) {
-      mContentView.removeOnLayoutChangeListener(this);
-    }
-    if (getChildCount() != expectedChildCount) {
-      FLog.w(
-              ReactConstants.TAG,
-              String.format("Expected %s children for ReactScrollView, found %s.", expectedChildCount, getChildCount()));
-    }
-
-    if (getChildCount() > 0) {
-      mContentView = getChildAt(0);
-      mContentView.addOnLayoutChangeListener(this);
-    } else { // no children
-      mContentView = null;
-    }
+    mContentView.removeOnLayoutChangeListener(this);
+    mContentView = null;
   }
 
   /**

--- a/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
@@ -364,7 +364,9 @@ public class ReactScrollView extends ScrollView implements ReactClippingViewGrou
   }
 
   /**
-   * Called when a mContentView's layout has changed.
+   * Called when a mContentView's layout has changed. Fixes the scroll position if it's too large
+   * after the content resizes. Without this, the user would see a blank ScrollView when the scroll
+   * position is larger than the ScrollView's max scroll position after the content shrinks.
    */
   @Override
   public void onLayoutChange(View v, int left, int top, int right, int bottom, int oldLeft, int oldTop, int oldRight, int oldBottom) {

--- a/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
@@ -304,6 +304,12 @@ public class ReactScrollView extends ScrollView implements ReactClippingViewGrou
     return mFpsListener != null && mScrollPerfTag != null && !mScrollPerfTag.isEmpty();
   }
 
+  private int getMaxScrollY() {
+    int contentHeight = mContentView.getHeight();
+    int viewportHeight = getHeight() - getPaddingBottom() - getPaddingTop();
+    return Math.max(0, contentHeight - viewportHeight);
+  }
+
   @Override
   public void draw(Canvas canvas) {
     if (mEndFillColor != Color.TRANSPARENT) {
@@ -332,10 +338,8 @@ public class ReactScrollView extends ScrollView implements ReactClippingViewGrou
       // more information.
 
       if (!mScroller.isFinished() && mScroller.getCurrY() != mScroller.getFinalY()) {
-        int scrollRange = Math.max(
-          0,
-          getChildAt(0).getHeight() - (getHeight() - getPaddingBottom() - getPaddingTop()));
-        if (scrollY >= scrollRange) {
+        int scrollRange = getMaxScrollY();
+        if (scrollY >= getMaxScrollY()) {
           mScroller.abortAnimation();
           scrollY = scrollRange;
         }
@@ -371,12 +375,8 @@ public class ReactScrollView extends ScrollView implements ReactClippingViewGrou
       return;
     }
 
-    int contentHeight = mContentView.getMeasuredHeight();
     int currentScrollY = getScrollY();
-    int thisHeight = getMeasuredHeight();
-
-    int maxScrollY = Math.max(0, contentHeight - thisHeight);
-
+    int maxScrollY = getMaxScrollY();
     if (currentScrollY > maxScrollY) {
       scrollTo(getScrollX(), maxScrollY);
     }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
@@ -339,7 +339,7 @@ public class ReactScrollView extends ScrollView implements ReactClippingViewGrou
 
       if (!mScroller.isFinished() && mScroller.getCurrY() != mScroller.getFinalY()) {
         int scrollRange = getMaxScrollY();
-        if (scrollY >= getMaxScrollY()) {
+        if (scrollY >= scrollRange) {
           mScroller.abortAnimation();
           scrollY = scrollRange;
         }


### PR DESCRIPTION
Suppose that the user is scrolled to the bottom of a ScrollView. Next, the ScrollView's content is edited such that the height of the content changes and the current scroll position is larger than the new height of the content. Consequently, the user sees a blank ScrollView. As soon as the user interacts with the ScrollView, the ScrollView will jump to its max scroll position.

This change improves this scenario by ensuring that the user is never staring at a blank ScrollView when the ScrollView has content in it. It does this by moving the ScrollView to its max scroll position when the scroll position after an edit is larger than the max scroll position of the ScrollView.

Here are some pictures to illustrate how this PR improves the scenario described above:

![image](https://cloud.githubusercontent.com/assets/199935/20408839/0e731774-accc-11e6-9f0a-3d77198645e9.png)

![image](https://cloud.githubusercontent.com/assets/199935/20408844/12877bb6-accc-11e6-8fe2-1c1bb26569cc.png)

**Test plan (required)**

Verified ScrollView keeps the content visible after an edit in a test app. Also, my team uses this change in our app.

Adam Comella
Microsoft Corp.