### PR TITLE
Android: Fix inconsistency with fractional TextInput padding

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
@@ -164,10 +164,10 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
       float[] padding = (float[]) extraData;
 
       view.setPadding(
-          (int) Math.ceil(padding[0]),
-          (int) Math.ceil(padding[1]),
-          (int) Math.ceil(padding[2]),
-          (int) Math.ceil(padding[3]));
+          (int) Math.floor(padding[0]),
+          (int) Math.floor(padding[1]),
+          (int) Math.floor(padding[2]),
+          (int) Math.floor(padding[3]));
     } else if (extraData instanceof ReactTextUpdate) {
       ReactTextUpdate update = (ReactTextUpdate) extraData;
       if (update.containsImages()) {


### PR DESCRIPTION
TextInput rounds padding down with `floor` when measuring. However, it rounds padding up with `ceil` when rendering.

This change makes things consistent by moving TextInput's rendering code to use `floor` as well. It looks like this is the intended behavior because commit bdff10b moved measuring from `ceil` to `floor`. It looks like TextInput's rendering code was just overlooked in that commit.

**Test plan (required)**

Verified TextInput padding works in a test app. Also, my team uses this change in our app.

Adam Comella
Microsoft Corp.