### PR TITLE
Android: Expose textBreakStrategy on Text and TextInput

### DIFF
--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -335,7 +335,7 @@ const TextInput = React.createClass({
      * The default value is `simple`
      * @platform android
      */
-    textBreakStrategy: PropTypes.string,
+    textBreakStrategy: React.PropTypes.oneOf(['simple', 'highQuality', 'balanced']),
     /**
      * Callback that is called when the text input is blurred.
      */

--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -331,6 +331,12 @@ const TextInput = React.createClass({
      */
     multiline: PropTypes.bool,
     /**
+     * Set text break strategy on Android API Level 23+, possible values are `simple`, `highQuality`, `balanced`
+     * The default value is `simple`
+     * @platform android
+     */
+    textBreakStrategy: PropTypes.string,
+    /**
      * Callback that is called when the text input is blurred.
      */
     onBlur: PropTypes.func,
@@ -724,6 +730,7 @@ const TextInput = React.createClass({
         text={this._getText()}
         children={children}
         disableFullscreenUI={this.props.disableFullscreenUI}
+        textBreakStrategy={this.props.textBreakStrategy}
       />;
 
     return (

--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -332,7 +332,7 @@ const TextInput = React.createClass({
     multiline: PropTypes.bool,
     /**
      * Set text break strategy on Android API Level 23+, possible values are `simple`, `highQuality`, `balanced`
-     * The default value is `simple`
+     * The default value is `simple`.
      * @platform android
      */
     textBreakStrategy: React.PropTypes.oneOf(['simple', 'highQuality', 'balanced']),

--- a/Libraries/Text/Text.js
+++ b/Libraries/Text/Text.js
@@ -33,6 +33,7 @@ const viewConfig = {
     selectable: true,
     adjustsFontSizeToFit: true,
     minimumFontScale: true,
+    textBreakStrategy: true,
   }),
   uiViewClassName: 'RCTText',
 };
@@ -116,6 +117,12 @@ const Text = React.createClass({
      * This prop is commonly used with `ellipsizeMode`.
      */
     numberOfLines: React.PropTypes.number,
+    /**
+     * Set text break strategy on Android API Level 23+, possible values are `simple`, `highQuality`, `balanced`
+     * The default value is `highQuality`
+     * @platform android
+     */
+    textBreakStrategy: React.PropTypes.string,
     /**
      * Invoked on mount and layout changes with
      *

--- a/Libraries/Text/Text.js
+++ b/Libraries/Text/Text.js
@@ -119,7 +119,7 @@ const Text = React.createClass({
     numberOfLines: React.PropTypes.number,
     /**
      * Set text break strategy on Android API Level 23+, possible values are `simple`, `highQuality`, `balanced`
-     * The default value is `highQuality`
+     * The default value is `highQuality`.
      * @platform android
      */
     textBreakStrategy: React.PropTypes.oneOf(['simple', 'highQuality', 'balanced']),

--- a/Libraries/Text/Text.js
+++ b/Libraries/Text/Text.js
@@ -122,7 +122,7 @@ const Text = React.createClass({
      * The default value is `highQuality`
      * @platform android
      */
-    textBreakStrategy: React.PropTypes.string,
+    textBreakStrategy: React.PropTypes.oneOf(['simple', 'highQuality', 'balanced']),
     /**
      * Invoked on mount and layout changes with
      *

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewProps.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewProps.java
@@ -82,6 +82,7 @@ public class ViewProps {
   public static final String TEXT_ALIGN = "textAlign";
   public static final String TEXT_ALIGN_VERTICAL = "textAlignVertical";
   public static final String TEXT_DECORATION_LINE = "textDecorationLine";
+  public static final String TEXT_BREAK_STRATEGY = "textBreakStrategy";
 
   public static final String BORDER_WIDTH = "borderWidth";
   public static final String BORDER_LEFT_WIDTH = "borderLeftWidth";

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextShadowNode.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextShadowNode.java
@@ -264,6 +264,7 @@ public class ReactTextShadowNode extends LayoutShadowNode {
                 .setLineSpacing(0.f, 1.f)
                 .setIncludePad(true)
                 .setBreakStrategy(mTextBreakStrategy)
+                .setHyphenationFrequency(Layout.HYPHENATION_FREQUENCY_NORMAL)
                 .build();
             }
 
@@ -297,6 +298,7 @@ public class ReactTextShadowNode extends LayoutShadowNode {
                 .setLineSpacing(0.f, 1.f)
                 .setIncludePad(true)
                 .setBreakStrategy(mTextBreakStrategy)
+                .setHyphenationFrequency(Layout.HYPHENATION_FREQUENCY_NORMAL)
                 .build();
             }
           }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextShadowNode.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextShadowNode.java
@@ -337,13 +337,13 @@ public class ReactTextShadowNode extends LayoutShadowNode {
   protected int mNumberOfLines = UNSET;
   protected int mFontSize = UNSET;
   protected int mTextAlign = Gravity.NO_GRAVITY;
+  protected int mTextBreakStrategy = (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) ?
+      0 : Layout.BREAK_STRATEGY_HIGH_QUALITY;
 
   private float mTextShadowOffsetDx = 0;
   private float mTextShadowOffsetDy = 0;
   private float mTextShadowRadius = 1;
   private int mTextShadowColor = DEFAULT_TEXT_SHADOW_COLOR;
-  private int mTextBreakStrategy = (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) ?
-    0 : Layout.BREAK_STRATEGY_HIGH_QUALITY;
 
   private boolean mIsUnderlineTextDecorationSet = false;
   private boolean mIsLineThroughTextDecorationSet = false;

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextUpdate.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextUpdate.java
@@ -9,6 +9,7 @@
 
 package com.facebook.react.views.text;
 
+import android.text.Layout;
 import android.text.Spannable;
 
 /**
@@ -27,6 +28,31 @@ public class ReactTextUpdate {
   private final float mPaddingBottom;
   private final int mTextAlign;
   private final int mTextBreakStrategy;
+
+  /**
+   * @deprecated Use a non-deprecated constructor for ReactTextUpdate instead. This one remains
+   * because it's being used by a unit test that isn't currently open source.
+   */
+  @Deprecated
+  public ReactTextUpdate(
+      Spannable text,
+      int jsEventCounter,
+      boolean containsImages,
+      float paddingStart,
+      float paddingTop,
+      float paddingEnd,
+      float paddingBottom,
+      int textAlign) {
+    this(text,
+        jsEventCounter,
+        containsImages,
+        paddingStart,
+        paddingTop,
+        paddingEnd,
+        paddingBottom,
+        textAlign,
+        Layout.BREAK_STRATEGY_HIGH_QUALITY);
+  }
 
   public ReactTextUpdate(
     Spannable text,

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextUpdate.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextUpdate.java
@@ -26,6 +26,7 @@ public class ReactTextUpdate {
   private final float mPaddingRight;
   private final float mPaddingBottom;
   private final int mTextAlign;
+  private final int mTextBreakStrategy;
 
   public ReactTextUpdate(
     Spannable text,
@@ -35,7 +36,8 @@ public class ReactTextUpdate {
     float paddingTop,
     float paddingEnd,
     float paddingBottom,
-    int textAlign) {
+    int textAlign,
+    int textBreakStrategy) {
     mText = text;
     mJsEventCounter = jsEventCounter;
     mContainsImages = containsImages;
@@ -44,6 +46,7 @@ public class ReactTextUpdate {
     mPaddingRight = paddingEnd;
     mPaddingBottom = paddingBottom;
     mTextAlign = textAlign;
+    mTextBreakStrategy = textBreakStrategy;
   }
 
   public Spannable getText() {
@@ -76,5 +79,9 @@ public class ReactTextUpdate {
 
   public int getTextAlign() {
     return mTextAlign;
+  }
+
+  public int getTextBreakStrategy() {
+    return mTextBreakStrategy;
   }
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
@@ -15,6 +15,7 @@ import android.content.Context;
 import android.graphics.Color;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.LayerDrawable;
+import android.os.Build;
 import android.text.Layout;
 import android.text.Spanned;
 import android.text.TextUtils;
@@ -69,6 +70,11 @@ public class ReactTextView extends TextView implements ReactCompoundView {
       mTextAlign = nextTextAlign;
     }
     setGravityHorizontal(mTextAlign);
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+      if (getBreakStrategy() != update.getTextBreakStrategy()) {
+        setBreakStrategy(update.getTextBreakStrategy());
+      }
+    }
   }
 
   @Override

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
@@ -19,6 +19,7 @@ import android.graphics.Rect;
 import android.graphics.Typeface;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.LayerDrawable;
+import android.os.Build;
 import android.text.Editable;
 import android.text.InputType;
 import android.text.SpannableStringBuilder;
@@ -340,6 +341,11 @@ public class ReactEditText extends EditText {
     mIsSettingTextFromJS = true;
     getText().replace(0, length(), spannableStringBuilder);
     mIsSettingTextFromJS = false;
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+      if (getBreakStrategy() != reactTextUpdate.getTextBreakStrategy()) {
+        setBreakStrategy(reactTextUpdate.getTextBreakStrategy());
+      }
+    }
   }
 
   /**

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputShadowNode.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputShadowNode.java
@@ -107,8 +107,10 @@ public class ReactTextInputShadowNode extends ReactTextShadowNode implements
       editText.setLines(mNumberOfLines);
     }
 
-    if (editText.getBreakStrategy() != mTextBreakStrategy) {
-      editText.setBreakStrategy(mTextBreakStrategy);
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+      if (editText.getBreakStrategy() != mTextBreakStrategy) {
+        editText.setBreakStrategy(mTextBreakStrategy);
+      }
     }
 
     editText.measure(

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputShadowNode.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputShadowNode.java
@@ -130,7 +130,6 @@ public class ReactTextInputShadowNode extends ReactTextShadowNode implements
   }
 
   @Override
-  @ReactProp(name = ViewProps.TEXT_BREAK_STRATEGY)
   public void setTextBreakStrategy(@Nullable String textBreakStrategy) {
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
       return;

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputShadowNode.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputShadowNode.java
@@ -45,10 +45,10 @@ public class ReactTextInputShadowNode extends ReactTextShadowNode implements
   private @Nullable EditText mEditText;
   private @Nullable float[] mComputedPadding;
   private int mJsEventCount = UNSET;
-  private int mTextBreakStrategy = (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) ?
-      0 : Layout.BREAK_STRATEGY_SIMPLE;
 
   public ReactTextInputShadowNode() {
+    mTextBreakStrategy = (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) ?
+        0 : Layout.BREAK_STRATEGY_SIMPLE;
     setMeasureFunction(this);
   }
 
@@ -105,6 +105,10 @@ public class ReactTextInputShadowNode extends ReactTextShadowNode implements
 
     if (mNumberOfLines != UNSET) {
       editText.setLines(mNumberOfLines);
+    }
+
+    if (editText.getBreakStrategy() != mTextBreakStrategy) {
+      editText.setBreakStrategy(mTextBreakStrategy);
     }
 
     editText.measure(


### PR DESCRIPTION
Android has a text API called breakStrategy for controlling how paragraphs are broken up into lines. For example, some modes support automatically hyphenating words so a word can be split across lines while others do not.

One source of complexity is that Android provides different defaults for `breakStrategy` for `TextView` vs `EditText`. `TextView`'s default is `BREAK_STRATEGY_HIGH_QUALITY` while `EditText`'s default is `BREAK_STRATEGY_SIMPLE`.

In addition to exposing `textBreakStrategy`, this change also fixes a couple of rendering glitches with `Text` and `TextInput`. `TextView` and `EditText` have different default values for `breakStrategy` and `hyphenationFrequency` than `StaticLayout`. Consequently, we were using different parameters for measuring and rendering. Whenever measuring and rendering parameters are inconsistent, it can result in visual glitches such as the text taking up too much space or being clipped.

This change fixes these inconsistencies by setting `breakStrategy` and `hyphenationFrequency` to the appropriate values during measuring.

**Test plan (required)**

Verified the `textBreakStrategy` prop works in a test app. Also, my team's app uses this change.

Adam Comella
Microsoft Corp.