### PR TITLE
BREAKING: Android: Correct value of Dimensions.get('screen').fontScale

### DIFF
--- a/Libraries/Utilities/Dimensions.js
+++ b/Libraries/Utilities/Dimensions.js
@@ -130,7 +130,7 @@ class Dimensions {
 
 Dimensions.set(UIManager.Dimensions);
 RCTDeviceEventEmitter.addListener('didUpdateDimensions', function(update) {
-  Dimensions.set(update);  
+  Dimensions.set(update);
 });
 
 module.exports = Dimensions;

--- a/Libraries/Utilities/Dimensions.js
+++ b/Libraries/Utilities/Dimensions.js
@@ -11,12 +11,15 @@
  */
 'use strict';
 
+var EventEmitter = require('EventEmitter');
 var Platform = require('Platform');
 var UIManager = require('UIManager');
 var RCTDeviceEventEmitter = require('RCTDeviceEventEmitter');
 
 var invariant = require('fbjs/lib/invariant');
 
+var eventEmitter = new EventEmitter();
+var dimensionsInitialized = false;
 var dimensions = {};
 class Dimensions {
   /**
@@ -60,6 +63,15 @@ class Dimensions {
     }
 
     Object.assign(dimensions, dims);
+    if (dimensionsInitialized) {
+      // Don't fire 'change' the first time the dimensions are set.
+      eventEmitter.emit('change', {
+        window: dimensions.window,
+        screen: dimensions.screen
+      });
+    } else {
+      dimensionsInitialized = true;
+    }
   }
 
   /**
@@ -81,11 +93,44 @@ class Dimensions {
     invariant(dimensions[dim], 'No dimension set for key ' + dim);
     return dimensions[dim];
   }
+
+  /**
+   * Add an event handler. Supported events:
+   *
+   * - `change`: Fires when a property within the `Dimensions` object changes. The argument
+   *   to the event handler is an object with `window` and `screen` properties whose values
+   *   are the same as the return values of `Dimensions.get('window')` and
+   *   `Dimensions.get('screen')`, respectively.
+   */
+  static addEventListener(
+    type: string,
+    handler: Function
+  ) {
+    invariant(
+      'change' === type,
+      'Trying to subscribe to unknown event: "%s"', type
+    );
+    eventEmitter.addListener(type, handler);
+  }
+
+  /**
+   * Remove an event handler.
+   */
+  static removeEventListener(
+    type: string,
+    handler: Function
+  ) {
+    invariant(
+      'change' === type,
+      'Trying to remove listener for unknown event: "%s"', type
+    );
+    eventEmitter.removeListener(type, handler);
+  }
 }
 
 Dimensions.set(UIManager.Dimensions);
 RCTDeviceEventEmitter.addListener('didUpdateDimensions', function(update) {
-  Dimensions.set(update);
+  Dimensions.set(update);  
 });
 
 module.exports = Dimensions;

--- a/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
@@ -394,27 +394,10 @@ public class ReactRootView extends SizeMonitoringFrameLayout implements RootView
     }
 
     private void emitUpdateDimensionsEvent() {
-      DisplayMetrics windowDisplayMetrics = DisplayMetricsHolder.getWindowDisplayMetrics();
-      DisplayMetrics screenDisplayMetrics = DisplayMetricsHolder.getScreenDisplayMetrics();
-
-      WritableMap windowDisplayMetricsMap = Arguments.createMap();
-      windowDisplayMetricsMap.putInt("width", windowDisplayMetrics.widthPixels);
-      windowDisplayMetricsMap.putInt("height", windowDisplayMetrics.heightPixels);
-      windowDisplayMetricsMap.putDouble("scale", windowDisplayMetrics.density);
-      windowDisplayMetricsMap.putDouble("fontScale", windowDisplayMetrics.scaledDensity);
-      windowDisplayMetricsMap.putDouble("densityDpi", windowDisplayMetrics.densityDpi);
-
-      WritableMap screenDisplayMetricsMap = Arguments.createMap();
-      screenDisplayMetricsMap.putInt("width", screenDisplayMetrics.widthPixels);
-      screenDisplayMetricsMap.putInt("height", screenDisplayMetrics.heightPixels);
-      screenDisplayMetricsMap.putDouble("scale", screenDisplayMetrics.density);
-      screenDisplayMetricsMap.putDouble("fontScale", screenDisplayMetrics.scaledDensity);
-      screenDisplayMetricsMap.putDouble("densityDpi", screenDisplayMetrics.densityDpi);
-
-      WritableMap dimensionsMap = Arguments.createMap();
-      dimensionsMap.putMap("windowPhysicalPixels", windowDisplayMetricsMap);
-      dimensionsMap.putMap("screenPhysicalPixels", screenDisplayMetricsMap);
-      sendEvent("didUpdateDimensions", dimensionsMap);
+      mReactInstanceManager
+          .getCurrentReactContext()
+          .getNativeModule(UIManagerModule.class)
+          .emitUpdateDimensionsEvent();
     }
 
     private void sendEvent(String eventName, @Nullable WritableMap params) {

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModule.java
@@ -498,6 +498,12 @@ public class UIManagerModule extends ReactContextBaseJavaModule implements
     mUIImplementation.configureNextLayoutAnimation(config, success, error);
   }
 
+  @ReactMethod
+  public void getContentSizeMultiplier(Callback callback) {
+    float scale = getReactApplicationContext().getResources().getConfiguration().fontScale;
+    callback.invoke(scale);
+  }
+
   /**
    * To implement the transactional requirement mentioned in the class javadoc, we only commit
    * UI changes to the actual view hierarchy once a batch of JS->Java calls have been completed.

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModule.java
@@ -498,12 +498,6 @@ public class UIManagerModule extends ReactContextBaseJavaModule implements
     mUIImplementation.configureNextLayoutAnimation(config, success, error);
   }
 
-  @ReactMethod
-  public void getContentSizeMultiplier(Callback callback) {
-    float scale = getReactApplicationContext().getResources().getConfiguration().fontScale;
-    callback.invoke(scale);
-  }
-
   /**
    * To implement the transactional requirement mentioned in the class javadoc, we only commit
    * UI changes to the actual view hierarchy once a batch of JS->Java calls have been completed.

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModule.java
@@ -553,7 +553,7 @@ public class UIManagerModule extends ReactContextBaseJavaModule implements
     mUIImplementation.sendAccessibilityEvent(tag, eventType);
   }
 
-public void emitUpdateDimensionsEvent() {
+  public void emitUpdateDimensionsEvent() {
     sendEvent("didUpdateDimensions", UIManagerModuleConstants.getDimensionsConstants(mFontScale));
   }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModule.java
@@ -140,7 +140,9 @@ public class UIManagerModule extends ReactContextBaseJavaModule implements
   public void onHostResume() {
     mUIImplementation.onHostResume();
 
-    if (mFontScale != getReactApplicationContext().getResources().getConfiguration().fontScale) {
+    float fontScale = getReactApplicationContext().getResources().getConfiguration().fontScale;
+    if (mFontScale != fontScale) {
+      mFontScale = fontScale;
       emitUpdateDimensionsEvent();
     }
   }
@@ -554,7 +556,6 @@ public class UIManagerModule extends ReactContextBaseJavaModule implements
   }
 
   public void emitUpdateDimensionsEvent() {
-    mFontScale = getReactApplicationContext().getResources().getConfiguration().fontScale;
     DisplayMetrics windowDisplayMetrics = DisplayMetricsHolder.getWindowDisplayMetrics();
     DisplayMetrics screenDisplayMetrics = DisplayMetricsHolder.getScreenDisplayMetrics();
 

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModule.java
@@ -17,11 +17,9 @@ import java.util.Map;
 
 import android.content.ComponentCallbacks2;
 import android.content.res.Configuration;
-import android.util.DisplayMetrics;
 
 import com.facebook.common.logging.FLog;
 import com.facebook.react.animation.Animation;
-import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.GuardedRunnable;
 import com.facebook.react.bridge.LifecycleEventListener;
@@ -555,28 +553,8 @@ public class UIManagerModule extends ReactContextBaseJavaModule implements
     mUIImplementation.sendAccessibilityEvent(tag, eventType);
   }
 
-  public void emitUpdateDimensionsEvent() {
-    DisplayMetrics windowDisplayMetrics = DisplayMetricsHolder.getWindowDisplayMetrics();
-    DisplayMetrics screenDisplayMetrics = DisplayMetricsHolder.getScreenDisplayMetrics();
-
-    WritableMap windowDisplayMetricsMap = Arguments.createMap();
-    windowDisplayMetricsMap.putInt("width", windowDisplayMetrics.widthPixels);
-    windowDisplayMetricsMap.putInt("height", windowDisplayMetrics.heightPixels);
-    windowDisplayMetricsMap.putDouble("scale", windowDisplayMetrics.density);
-    windowDisplayMetricsMap.putDouble("fontScale", mFontScale);
-    windowDisplayMetricsMap.putDouble("densityDpi", windowDisplayMetrics.densityDpi);
-
-    WritableMap screenDisplayMetricsMap = Arguments.createMap();
-    screenDisplayMetricsMap.putInt("width", screenDisplayMetrics.widthPixels);
-    screenDisplayMetricsMap.putInt("height", screenDisplayMetrics.heightPixels);
-    screenDisplayMetricsMap.putDouble("scale", screenDisplayMetrics.density);
-    screenDisplayMetricsMap.putDouble("fontScale", mFontScale);
-    screenDisplayMetricsMap.putDouble("densityDpi", screenDisplayMetrics.densityDpi);
-
-    WritableMap dimensionsMap = Arguments.createMap();
-    dimensionsMap.putMap("windowPhysicalPixels", windowDisplayMetricsMap);
-    dimensionsMap.putMap("screenPhysicalPixels", screenDisplayMetricsMap);
-    sendEvent("didUpdateDimensions", dimensionsMap);
+public void emitUpdateDimensionsEvent() {
+    sendEvent("didUpdateDimensions", UIManagerModuleConstants.getDimensionsConstants(mFontScale));
   }
 
   private void sendEvent(String eventName, @Nullable WritableMap params) {

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModule.java
@@ -20,7 +20,6 @@ import android.content.res.Configuration;
 import android.util.DisplayMetrics;
 
 import com.facebook.common.logging.FLog;
-import com.facebook.react.ReactApplication;
 import com.facebook.react.animation.Animation;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Callback;

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModuleConstants.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModuleConstants.java
@@ -16,6 +16,8 @@ import android.util.DisplayMetrics;
 import android.view.accessibility.AccessibilityEvent;
 import android.widget.ImageView;
 
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.common.MapBuilder;
 import com.facebook.react.uimanager.events.TouchEventType;
 
@@ -95,35 +97,9 @@ import com.facebook.react.uimanager.events.TouchEventType;
                 "ScaleAspectCenter",
                 ImageView.ScaleType.CENTER_INSIDE.ordinal())));
 
-    DisplayMetrics displayMetrics = DisplayMetricsHolder.getWindowDisplayMetrics();
-    DisplayMetrics screenDisplayMetrics = DisplayMetricsHolder.getScreenDisplayMetrics();
     constants.put(
         "Dimensions",
-        MapBuilder.of(
-            "windowPhysicalPixels",
-            MapBuilder.of(
-                "width",
-                displayMetrics.widthPixels,
-                "height",
-                displayMetrics.heightPixels,
-                "scale",
-                displayMetrics.density,
-                "fontScale",
-                fontScale,
-                "densityDpi",
-                displayMetrics.densityDpi),
-        "screenPhysicalPixels",
-        MapBuilder.of(
-            "width",
-            screenDisplayMetrics.widthPixels,
-            "height",
-            screenDisplayMetrics.heightPixels,
-            "scale",
-            screenDisplayMetrics.density,
-            "fontScale",
-            fontScale,
-            "densityDpi",
-            screenDisplayMetrics.densityDpi)));
+        getDimensionsConstants(fontScale));
 
     constants.put(
         "StyleConstants",
@@ -156,5 +132,30 @@ import com.facebook.react.uimanager.events.TouchEventType;
           AccessibilityEvent.TYPE_VIEW_CLICKED));
 
     return constants;
+  }
+
+  public static WritableMap getDimensionsConstants(float fontScale) {
+    DisplayMetrics windowDisplayMetrics = DisplayMetricsHolder.getWindowDisplayMetrics();
+    DisplayMetrics screenDisplayMetrics = DisplayMetricsHolder.getScreenDisplayMetrics();
+
+    WritableMap windowDisplayMetricsMap = Arguments.createMap();
+    windowDisplayMetricsMap.putInt("width", windowDisplayMetrics.widthPixels);
+    windowDisplayMetricsMap.putInt("height", windowDisplayMetrics.heightPixels);
+    windowDisplayMetricsMap.putDouble("scale", windowDisplayMetrics.density);
+    windowDisplayMetricsMap.putDouble("fontScale", fontScale);
+    windowDisplayMetricsMap.putDouble("densityDpi", windowDisplayMetrics.densityDpi);
+
+    WritableMap screenDisplayMetricsMap = Arguments.createMap();
+    screenDisplayMetricsMap.putInt("width", screenDisplayMetrics.widthPixels);
+    screenDisplayMetricsMap.putInt("height", screenDisplayMetrics.heightPixels);
+    screenDisplayMetricsMap.putDouble("scale", screenDisplayMetrics.density);
+    screenDisplayMetricsMap.putDouble("fontScale", fontScale);
+    screenDisplayMetricsMap.putDouble("densityDpi", screenDisplayMetrics.densityDpi);
+
+    WritableMap dimensionsMap = Arguments.createMap();
+    dimensionsMap.putMap("windowPhysicalPixels", windowDisplayMetricsMap);
+    dimensionsMap.putMap("screenPhysicalPixels", screenDisplayMetricsMap);
+    
+    return dimensionsMap;
   }
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModuleConstants.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModuleConstants.java
@@ -16,8 +16,6 @@ import android.util.DisplayMetrics;
 import android.view.accessibility.AccessibilityEvent;
 import android.widget.ImageView;
 
-import com.facebook.react.ReactApplication;
-import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.common.MapBuilder;
 import com.facebook.react.uimanager.events.TouchEventType;
 

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModuleConstants.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModuleConstants.java
@@ -16,6 +16,8 @@ import android.util.DisplayMetrics;
 import android.view.accessibility.AccessibilityEvent;
 import android.widget.ImageView;
 
+import com.facebook.react.ReactApplication;
+import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.common.MapBuilder;
 import com.facebook.react.uimanager.events.TouchEventType;
 
@@ -81,7 +83,7 @@ import com.facebook.react.uimanager.events.TouchEventType;
         .build();
   }
 
-  public static Map<String, Object> getConstants() {
+  public static Map<String, Object> getConstants(float fontScale) {
     HashMap<String, Object> constants = new HashMap<String, Object>();
     constants.put(
         "UIView",
@@ -109,7 +111,7 @@ import com.facebook.react.uimanager.events.TouchEventType;
                 "scale",
                 displayMetrics.density,
                 "fontScale",
-                displayMetrics.scaledDensity,
+                fontScale,
                 "densityDpi",
                 displayMetrics.densityDpi),
         "screenPhysicalPixels",
@@ -121,7 +123,7 @@ import com.facebook.react.uimanager.events.TouchEventType;
             "scale",
             screenDisplayMetrics.density,
             "fontScale",
-            screenDisplayMetrics.scaledDensity,
+            fontScale,
             "densityDpi",
             screenDisplayMetrics.densityDpi)));
 

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModuleConstantsHelper.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModuleConstantsHelper.java
@@ -12,6 +12,7 @@ package com.facebook.react.uimanager;
 import java.util.List;
 import java.util.Map;
 
+import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.common.MapBuilder;
 import com.facebook.systrace.Systrace;
 import com.facebook.systrace.SystraceMessage;
@@ -42,8 +43,9 @@ import static com.facebook.systrace.Systrace.TRACE_TAG_REACT_JAVA_BRIDGE;
    */
   /* package */ static Map<String, Object> createConstants(
     List<ViewManager> viewManagers,
-    boolean lazyViewManagersEnabled) {
-    Map<String, Object> constants = UIManagerModuleConstants.getConstants();
+    boolean lazyViewManagersEnabled,
+    float fontScale) {
+    Map<String, Object> constants = UIManagerModuleConstants.getConstants(fontScale);
     Map bubblingEventTypesConstants = UIManagerModuleConstants.getBubblingEventTypeConstants();
     Map directEventTypesConstants = UIManagerModuleConstants.getDirectEventTypeConstants();
 


### PR DESCRIPTION
The PR description has been updated to reflect the new approach.

**Breaking Change Summary**

On Android, the following properties now return a different number:
  - `Dimensions.get('window').fontScale`
  - `Dimensions.get('screen').fontScale`
  - `PixelRatio.getFontScale()`

This is a breaking change to anyone who was using these properties because the meaning of these properties has now changed.

These properties used to return a value representing font scale times density ([`DisplayMetrics.scaledDensity`](https://developer.android.com/reference/android/util/DisplayMetrics.html#scaledDensity)). Now they return a value representing just font scale ([`Configuration.fontScale`](https://developer.android.com/reference/android/content/res/Configuration.html#fontScale)).

**PR Description**

This PR changes a few things:
  - Correctly exposes the font scale to JavaScript as `Dimensions.get('screen').fontScale`. UIManager was exporting `DisplayMetrics.scaledDensity` under the name `fontScale`. However, this isn't correct because `scaledDensity` is actually `density * fontScale`. We now correctly export just `fontScale` under the name `fontScale`.
  - `didUpdateDimensions` now fires whenever `fontScale` changes.
  - `Dimensions` now fires a `change` event whenever a property within the `Dimensions` object changes. The primary benefit of this event over `didUpdateDimensions` is that this event provides an event object which has the same shape on iOS and Android. The event object for `didUpdateDimensions` uses different properties names on iOS than it does on Android.

**Test plan (required)**

Verified that the API works for different font settings in a test app. Also, verified that the `didUpdateDimensions` and `change` events fire with the proper information when changing the font settings and when rotating the device.

Adam Comella
Microsoft Corp.