### PR TITLE
Navigator: null check on gesture.overswipe to prevent crash

### DIFF
--- a/Libraries/CustomComponents/Navigator/Navigator.js
+++ b/Libraries/CustomComponents/Navigator/Navigator.js
@@ -914,7 +914,7 @@ var Navigator = React.createClass({
       }
       return;
     }
-    if (this._doesGestureOverswipe(this.state.activeGesture)) {
+    if (gesture.overswipe && this._doesGestureOverswipe(this.state.activeGesture)) {
       var frictionConstant = gesture.overswipe.frictionConstant;
       var frictionByDistance = gesture.overswipe.frictionByDistance;
       var frictionRatio = 1 / ((frictionConstant) + (Math.abs(nextProgress) * frictionByDistance));


### PR DESCRIPTION
Sometimes, `gesture.overswipe` can be `null`/`undefined` in `_moveAttachedGesture` resulting in a crash. This change adds a null check to avoid the crash. `_matchGestureAction` has a similar check so it looks like this case was overlooked in `_moveAttachedGesture`.

**Test plan (required)**

My team's app is using this change.

Adam Comella
Microsoft Corp.