### PR TITLE
[ImagePickerIOS] Fixed camera crash when video mode is on.

### DIFF
--- a/Libraries/CameraRoll/RCTImagePickerManager.m
+++ b/Libraries/CameraRoll/RCTImagePickerManager.m
@@ -65,7 +65,7 @@ RCT_EXPORT_METHOD(openCameraDialog:(NSDictionary *)config
   imagePicker.sourceType = UIImagePickerControllerSourceTypeCamera;
 
   if ([RCTConvert BOOL:config[@"videoMode"]]) {
-    imagePicker.cameraCaptureMode = UIImagePickerControllerCameraCaptureModeVideo;
+    imagePicker.mediaTypes = @[(NSString *)kUTTypeImage, (NSString *)kUTTypeMovie];
   }
 
   [self _presentPicker:imagePicker


### PR DESCRIPTION
Need to set `mediaTypes` instead of `cameraCaptureMode ` to allow video recording using `UIImagePickerController`. More details of `mediaTypes` can be found [here](https://developer.apple.com/reference/uikit/uiimagepickercontroller/1619173-mediatypes).

**Test plan**
```
      ImagePickerIOS.openCameraDialog(
        {videoMode: true},
        url => {
          console.log('call back');
        },
        () => {
          console.log('canceled');
        }
      );
```

