### PR TITLE
Add support for nested AnimatedValues in AnimatedStyle (like shadowOffset)

### DIFF
--- a/Libraries/Animated/src/__tests__/Animated-test.js
+++ b/Libraries/Animated/src/__tests__/Animated-test.js
@@ -33,7 +33,11 @@ describe('Animated tests', () => {
               outputRange: [100, 200],
             })},
             {scale: anim},
-          ]
+          ],
+          shadowOffset: {
+            width: anim,
+            height: anim,
+          }
         }
       }, callback);
 
@@ -47,6 +51,10 @@ describe('Animated tests', () => {
             {translateX: 100},
             {scale: 0},
           ],
+          shadowOffset: {
+            width: 0,
+            height: 0,
+          }
         },
       });
 
@@ -62,6 +70,10 @@ describe('Animated tests', () => {
             {translateX: 150},
             {scale: 0.5},
           ],
+          shadowOffset: {
+            width: 0.5,
+            height: 0.5,
+          }
         },
       });
 


### PR DESCRIPTION
**Motiviation**

Wanted to animate iOS's `shadowOffset`, which is an object, but `AnimatedStyle` only ran `__getValue` one-level deep.

Created a recursive function that walked all the styles and evaluated them.

**Test plan**

Added `shadowOffset` to the style props in the end-to-end `Animated` test