### PR TITLE
[CLI] Allow git to merge pbxproj files

### DIFF
--- a/local-cli/generator/copyProjectTemplateAndReplace.js
+++ b/local-cli/generator/copyProjectTemplateAndReplace.js
@@ -77,6 +77,7 @@ function dotFilePath(path) {
   if (!path) return path;
   return path
     .replace('_gitignore', '.gitignore')
+    .replace('_gitattributes', '.gitattributes')
     .replace('_babelrc', '.babelrc')
     .replace('_flowconfig', '.flowconfig')
     .replace('_buckconfig', '.buckconfig')

--- a/local-cli/templates/HelloWorld/.gitattributes
+++ b/local-cli/templates/HelloWorld/.gitattributes
@@ -1,1 +1,0 @@
-*.pbxproj binary

--- a/local-cli/templates/HelloWorld/_gitattributes
+++ b/local-cli/templates/HelloWorld/_gitattributes
@@ -1,0 +1,1 @@
+*.pbxproj -text


### PR DESCRIPTION
Follow on in https://github.com/facebook/react-native/pull/10864.

**Motivation**

@ncuillery Is has a lot of experience with upgrading RN projects (see his [talk](http://www.slideshare.net/ncuillery/introducing-the-new-reactnative-upgrade)) and is rewriting 'react-native upgrade' to use git.

He tells me that we actually want git to merge changes in the .pbxproj file. In his words: "Making the project.pbxproj invisible for "git diff" means that react-native-git-upgrade will never be able to upgrade the project.pbxproj."

Note the git docs explicitly recommend not to use git to merge .pbxproj files: https://git-scm.com/book/en/v2/Customizing-Git-Git-Attributes#Binary-Files

@ncuillery do we have an alternative? Some ideas:

1. Use a 3rd-party tool in 'react-native upgrade' to merge the .pbxproj file? 
2. We could always re-generate and overwrite the .pbxproj file (never merge) and then run 'react-native link' to update native 3rd-party dependencies in the Xcode project?
3. Last resort: stay away from the .pbxproj file and ask users to upgrade it manually via the Xcode UI. This is pretty bad as many users are JS developers with no experience configuring Xcode projects (I don't know how to use Xcode either :)). 

To unblock the new git-based upgrade we should probably allow git to work with this file for now, until we figure out a cleaner way.

**Test plan**

Travis and Circle e2e tests on this pull request.

