### PR TITLE
iOS: Fix autoCorrect doesn't revert to initial state

### DIFF
--- a/Libraries/Text/RCTConvert+Text.h
+++ b/Libraries/Text/RCTConvert+Text.h
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import "RCTConvert.h"
+
+@interface RCTConvert (Text)
+
++ (UITextAutocorrectionType)UITextAutocorrectionType:(id)json;
+
+@end

--- a/Libraries/Text/RCTConvert+Text.m
+++ b/Libraries/Text/RCTConvert+Text.m
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import "RCTConvert+Text.h"
+
+@implementation RCTConvert (Text)
+
++ (UITextAutocorrectionType)UITextAutocorrectionType:(id)json
+{
+  return
+    json == nil ? UITextAutocorrectionTypeDefault :
+    [RCTConvert BOOL:json] ? UITextAutocorrectionTypeYes :
+    UITextAutocorrectionTypeNo;
+}
+
+@end

--- a/Libraries/Text/RCTText.xcodeproj/project.pbxproj
+++ b/Libraries/Text/RCTText.xcodeproj/project.pbxproj
@@ -27,6 +27,8 @@
 		58B511D01A9E6C5C00147676 /* RCTShadowText.m in Sources */ = {isa = PBXBuildFile; fileRef = 58B511CB1A9E6C5C00147676 /* RCTShadowText.m */; };
 		58B511D11A9E6C5C00147676 /* RCTTextManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 58B511CD1A9E6C5C00147676 /* RCTTextManager.m */; };
 		58B512161A9E6EFF00147676 /* RCTText.m in Sources */ = {isa = PBXBuildFile; fileRef = 58B512141A9E6EFF00147676 /* RCTText.m */; };
+		AF3225F91DE5574F00D3E7E7 /* RCTConvert+Text.m in Sources */ = {isa = PBXBuildFile; fileRef = AF3225F81DE5574F00D3E7E7 /* RCTConvert+Text.m */; };
+		AF3225FA1DE5574F00D3E7E7 /* RCTConvert+Text.m in Sources */ = {isa = PBXBuildFile; fileRef = AF3225F81DE5574F00D3E7E7 /* RCTConvert+Text.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -73,6 +75,8 @@
 		58B511CD1A9E6C5C00147676 /* RCTTextManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTTextManager.m; sourceTree = "<group>"; };
 		58B512141A9E6EFF00147676 /* RCTText.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTText.m; sourceTree = "<group>"; };
 		58B512151A9E6EFF00147676 /* RCTText.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTText.h; sourceTree = "<group>"; };
+		AF3225F71DE5574F00D3E7E7 /* RCTConvert+Text.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "RCTConvert+Text.h"; sourceTree = "<group>"; };
+		AF3225F81DE5574F00D3E7E7 /* RCTConvert+Text.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "RCTConvert+Text.m"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -96,6 +100,8 @@
 		58B511921A9E6C1200147676 = {
 			isa = PBXGroup;
 			children = (
+				AF3225F71DE5574F00D3E7E7 /* RCTConvert+Text.h */,
+				AF3225F81DE5574F00D3E7E7 /* RCTConvert+Text.m */,
 				19FC5C861D41A4220090108F /* RCTTextSelection.h */,
 				19FC5C841D41A4120090108F /* RCTTextSelection.m */,
 				58B511C61A9E6C5C00147676 /* RCTRawTextManager.h */,
@@ -216,6 +222,7 @@
 				2D3B5F3B1D9B106F00451313 /* RCTTextView.m in Sources */,
 				2D3B5F3A1D9B106F00451313 /* RCTTextFieldManager.m in Sources */,
 				2D3B5F341D9B103100451313 /* RCTRawTextManager.m in Sources */,
+				AF3225FA1DE5574F00D3E7E7 /* RCTConvert+Text.m in Sources */,
 				2D3B5F3C1D9B106F00451313 /* RCTTextViewManager.m in Sources */,
 				2D3B5F331D9B102D00451313 /* RCTTextSelection.m in Sources */,
 				2D3B5F351D9B103300451313 /* RCTShadowRawText.m in Sources */,
@@ -233,6 +240,7 @@
 				1362F1001B4D51F400E06D8C /* RCTTextField.m in Sources */,
 				58B512161A9E6EFF00147676 /* RCTText.m in Sources */,
 				1362F1011B4D51F400E06D8C /* RCTTextFieldManager.m in Sources */,
+				AF3225F91DE5574F00D3E7E7 /* RCTConvert+Text.m in Sources */,
 				131B6AC11AF0CD0600FFC3E0 /* RCTTextViewManager.m in Sources */,
 				58B511CF1A9E6C5C00147676 /* RCTShadowRawText.m in Sources */,
 				58B511D01A9E6C5C00147676 /* RCTShadowText.m in Sources */,

--- a/Libraries/Text/RCTTextField.h
+++ b/Libraries/Text/RCTTextField.h
@@ -16,7 +16,6 @@
 @interface RCTTextField : UITextField
 
 @property (nonatomic, assign) BOOL caretHidden;
-@property (nonatomic, assign) BOOL autoCorrect;
 @property (nonatomic, assign) BOOL selectTextOnFocus;
 @property (nonatomic, assign) BOOL blurOnSubmit;
 @property (nonatomic, assign) UIEdgeInsets contentInset;

--- a/Libraries/Text/RCTTextField.m
+++ b/Libraries/Text/RCTTextField.m
@@ -149,16 +149,6 @@ static void RCTUpdatePlaceholder(RCTTextField *self)
   return [self textRectForBounds:bounds];
 }
 
-- (void)setAutoCorrect:(BOOL)autoCorrect
-{
-  self.autocorrectionType = (autoCorrect ? UITextAutocorrectionTypeYes : UITextAutocorrectionTypeNo);
-}
-
-- (BOOL)autoCorrect
-{
-  return self.autocorrectionType == UITextAutocorrectionTypeYes;
-}
-
 - (void)textFieldDidChange
 {
   _nativeEventCount++;

--- a/Libraries/Text/RCTTextFieldManager.m
+++ b/Libraries/Text/RCTTextFieldManager.m
@@ -13,6 +13,7 @@
 #import "RCTShadowView.h"
 #import "RCTTextField.h"
 #import "RCTFont.h"
+#import "RCTConvert+Text.h"
 
 @interface RCTTextFieldManager() <UITextFieldDelegate>
 
@@ -75,13 +76,7 @@ RCT_EXPORT_MODULE()
 }
 
 RCT_EXPORT_VIEW_PROPERTY(caretHidden, BOOL)
-RCT_CUSTOM_VIEW_PROPERTY(autoCorrect, NSString, RCTTextField)
-{
-  view.autocorrectionType =
-    json == nil ? UITextAutocorrectionTypeDefault :
-    [RCTConvert BOOL:json] ? UITextAutocorrectionTypeYes :
-    UITextAutocorrectionTypeNo;
-}
+RCT_REMAP_VIEW_PROPERTY(autoCorrect, autocorrectionType, UITextAutocorrectionType)
 RCT_REMAP_VIEW_PROPERTY(editable, enabled, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(placeholder, NSString)
 RCT_EXPORT_VIEW_PROPERTY(placeholderTextColor, UIColor)

--- a/Libraries/Text/RCTTextFieldManager.m
+++ b/Libraries/Text/RCTTextFieldManager.m
@@ -75,7 +75,13 @@ RCT_EXPORT_MODULE()
 }
 
 RCT_EXPORT_VIEW_PROPERTY(caretHidden, BOOL)
-RCT_EXPORT_VIEW_PROPERTY(autoCorrect, BOOL)
+RCT_CUSTOM_VIEW_PROPERTY(autoCorrect, NSString, RCTTextField)
+{
+  view.autocorrectionType =
+    json == nil ? UITextAutocorrectionTypeDefault :
+    [RCTConvert BOOL:json] ? UITextAutocorrectionTypeYes :
+    UITextAutocorrectionTypeNo;
+}
 RCT_REMAP_VIEW_PROPERTY(editable, enabled, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(placeholder, NSString)
 RCT_EXPORT_VIEW_PROPERTY(placeholderTextColor, UIColor)

--- a/Libraries/Text/RCTTextView.h
+++ b/Libraries/Text/RCTTextView.h
@@ -16,7 +16,7 @@
 
 @interface RCTTextView : RCTView <UITextViewDelegate>
 
-@property (nonatomic, assign) BOOL autoCorrect;
+@property (nonatomic, assign) UITextAutocorrectionType autocorrectionType;
 @property (nonatomic, assign) BOOL blurOnSubmit;
 @property (nonatomic, assign) BOOL clearTextOnFocus;
 @property (nonatomic, assign) BOOL selectTextOnFocus;

--- a/Libraries/Text/RCTTextView.m
+++ b/Libraries/Text/RCTTextView.m
@@ -519,14 +519,14 @@ static NSAttributedString *removeReactTagFromString(NSAttributedString *string)
   }
 }
 
-- (void)setAutoCorrect:(BOOL)autoCorrect
+- (void)setAutocorrectionType:(UITextAutocorrectionType)autocorrectionType
 {
-  _textView.autocorrectionType = (autoCorrect ? UITextAutocorrectionTypeYes : UITextAutocorrectionTypeNo);
+  _textView.autocorrectionType = autocorrectionType;
 }
 
-- (BOOL)autoCorrect
+- (UITextAutocorrectionType)autocorrectionType
 {
-  return _textView.autocorrectionType == UITextAutocorrectionTypeYes;
+  return _textView.autocorrectionType;
 }
 
 - (BOOL)textViewShouldBeginEditing:(UITextView *)textView

--- a/Libraries/Text/RCTTextViewManager.m
+++ b/Libraries/Text/RCTTextViewManager.m
@@ -25,7 +25,13 @@ RCT_EXPORT_MODULE()
 }
 
 RCT_REMAP_VIEW_PROPERTY(autoCapitalize, textView.autocapitalizationType, UITextAutocapitalizationType)
-RCT_EXPORT_VIEW_PROPERTY(autoCorrect, BOOL)
+RCT_CUSTOM_VIEW_PROPERTY(autoCorrect, NSString, RCTTextView)
+{
+  view.autocorrectionType =
+    json == nil ? UITextAutocorrectionTypeDefault :
+    [RCTConvert BOOL:json] ? UITextAutocorrectionTypeYes :
+    UITextAutocorrectionTypeNo;
+}
 RCT_EXPORT_VIEW_PROPERTY(blurOnSubmit, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(clearTextOnFocus, BOOL)
 RCT_REMAP_VIEW_PROPERTY(color, textView.textColor, UIColor)

--- a/Libraries/Text/RCTTextViewManager.m
+++ b/Libraries/Text/RCTTextViewManager.m
@@ -14,6 +14,7 @@
 #import "RCTShadowView.h"
 #import "RCTTextView.h"
 #import "RCTFont.h"
+#import "RCTConvert+Text.h"
 
 @implementation RCTTextViewManager
 
@@ -25,13 +26,7 @@ RCT_EXPORT_MODULE()
 }
 
 RCT_REMAP_VIEW_PROPERTY(autoCapitalize, textView.autocapitalizationType, UITextAutocapitalizationType)
-RCT_CUSTOM_VIEW_PROPERTY(autoCorrect, NSString, RCTTextView)
-{
-  view.autocorrectionType =
-    json == nil ? UITextAutocorrectionTypeDefault :
-    [RCTConvert BOOL:json] ? UITextAutocorrectionTypeYes :
-    UITextAutocorrectionTypeNo;
-}
+RCT_REMAP_VIEW_PROPERTY(autoCorrect, autocorrectionType, UITextAutocorrectionType)
 RCT_EXPORT_VIEW_PROPERTY(blurOnSubmit, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(clearTextOnFocus, BOOL)
 RCT_REMAP_VIEW_PROPERTY(color, textView.textColor, UIColor)


### PR DESCRIPTION
There's an inconsistency in autoCorrect's default state:
  - If you don't specify a value for autoCorrect, it defaults to on.
  - If you specify true/false for autoCorrect and later specify null, autoCorrect turns off. It should have reverted to its initial state of on.

The reason for this discrepancy is that autoCorrect is exposed to JS as a boolean but it is actually an enum with three states in native:
  - UITextAutocorrectionTypeDefault (the default value)
  - UITextAutocorrectionTypeYes
  - UITextAutocorrectionTypeNo

This is fixed by explicitly mapping JS null to UITextAutocorrectionTypeDefault.

**Test plan (required)**

Verified that switching `autoCorrect` between `true`, `false`, and `null` all work correctly in single line and multiline `TextInputs`.

Adam Comella
Microsoft Corp.