### PR TITLE
iOS: Introduce spellCheck prop to TextInput

### DIFF
--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -195,6 +195,12 @@ const TextInput = React.createClass({
      */
     autoCorrect: PropTypes.bool,
     /**
+     * If `false`, disables spell-check style (i.e. red underlines).
+     * The default value is inherited from `autoCorrect`.
+     * @platform ios
+     */
+    spellCheck: PropTypes.bool,
+    /**
      * If `true`, focuses the input on `componentDidMount`.
      * The default value is `false`.
      */

--- a/Libraries/Text/RCTConvert+Text.h
+++ b/Libraries/Text/RCTConvert+Text.h
@@ -12,5 +12,6 @@
 @interface RCTConvert (Text)
 
 + (UITextAutocorrectionType)UITextAutocorrectionType:(id)json;
++ (UITextSpellCheckingType)UITextSpellCheckingType:(id)json;
 
 @end

--- a/Libraries/Text/RCTConvert+Text.m
+++ b/Libraries/Text/RCTConvert+Text.m
@@ -19,4 +19,12 @@
     UITextAutocorrectionTypeNo;
 }
 
++ (UITextSpellCheckingType)UITextSpellCheckingType:(id)json
+{
+  return
+    json == nil ? UITextSpellCheckingTypeDefault :
+    [RCTConvert BOOL:json] ? UITextSpellCheckingTypeYes :
+    UITextSpellCheckingTypeNo;
+}
+
 @end

--- a/Libraries/Text/RCTTextFieldManager.m
+++ b/Libraries/Text/RCTTextFieldManager.m
@@ -77,13 +77,7 @@ RCT_EXPORT_MODULE()
 
 RCT_EXPORT_VIEW_PROPERTY(caretHidden, BOOL)
 RCT_REMAP_VIEW_PROPERTY(autoCorrect, autocorrectionType, UITextAutocorrectionType)
-RCT_CUSTOM_VIEW_PROPERTY(spellCheck, NSString, RCTTextField)
-{
-  view.spellCheckingType =
-    json == nil ? UITextSpellCheckingTypeDefault :
-    [RCTConvert BOOL:json] ? UITextSpellCheckingTypeYes :
-    UITextSpellCheckingTypeNo;
-}
+RCT_REMAP_VIEW_PROPERTY(spellCheck, spellCheckingType, UITextSpellCheckingType)
 RCT_REMAP_VIEW_PROPERTY(editable, enabled, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(placeholder, NSString)
 RCT_EXPORT_VIEW_PROPERTY(placeholderTextColor, UIColor)

--- a/Libraries/Text/RCTTextFieldManager.m
+++ b/Libraries/Text/RCTTextFieldManager.m
@@ -77,6 +77,13 @@ RCT_EXPORT_MODULE()
 
 RCT_EXPORT_VIEW_PROPERTY(caretHidden, BOOL)
 RCT_REMAP_VIEW_PROPERTY(autoCorrect, autocorrectionType, UITextAutocorrectionType)
+RCT_CUSTOM_VIEW_PROPERTY(spellCheck, NSString, RCTTextField)
+{
+  view.spellCheckingType =
+    json == nil ? UITextSpellCheckingTypeDefault :
+    [RCTConvert BOOL:json] ? UITextSpellCheckingTypeYes :
+    UITextSpellCheckingTypeNo;
+}
 RCT_REMAP_VIEW_PROPERTY(editable, enabled, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(placeholder, NSString)
 RCT_EXPORT_VIEW_PROPERTY(placeholderTextColor, UIColor)

--- a/Libraries/Text/RCTTextView.h
+++ b/Libraries/Text/RCTTextView.h
@@ -17,6 +17,7 @@
 @interface RCTTextView : RCTView <UITextViewDelegate>
 
 @property (nonatomic, assign) UITextAutocorrectionType autocorrectionType;
+@property (nonatomic, assign) UITextSpellCheckingType spellCheckingType;
 @property (nonatomic, assign) BOOL blurOnSubmit;
 @property (nonatomic, assign) BOOL clearTextOnFocus;
 @property (nonatomic, assign) BOOL selectTextOnFocus;

--- a/Libraries/Text/RCTTextView.m
+++ b/Libraries/Text/RCTTextView.m
@@ -529,6 +529,16 @@ static NSAttributedString *removeReactTagFromString(NSAttributedString *string)
   return _textView.autocorrectionType;
 }
 
+- (void)setSpellCheckingType:(UITextSpellCheckingType)spellCheckingType
+{
+  _textView.spellCheckingType = spellCheckingType;
+}
+
+- (UITextSpellCheckingType)spellCheckingType
+{
+  return _textView.spellCheckingType;
+}
+
 - (BOOL)textViewShouldBeginEditing:(UITextView *)textView
 {
   if (_selectTextOnFocus) {

--- a/Libraries/Text/RCTTextViewManager.m
+++ b/Libraries/Text/RCTTextViewManager.m
@@ -27,6 +27,13 @@ RCT_EXPORT_MODULE()
 
 RCT_REMAP_VIEW_PROPERTY(autoCapitalize, textView.autocapitalizationType, UITextAutocapitalizationType)
 RCT_REMAP_VIEW_PROPERTY(autoCorrect, autocorrectionType, UITextAutocorrectionType)
+RCT_CUSTOM_VIEW_PROPERTY(spellCheck, NSString, RCTTextView)
+{
+  view.spellCheckingType =
+    json == nil ? UITextSpellCheckingTypeDefault :
+    [RCTConvert BOOL:json] ? UITextSpellCheckingTypeYes :
+    UITextSpellCheckingTypeNo;
+}
 RCT_EXPORT_VIEW_PROPERTY(blurOnSubmit, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(clearTextOnFocus, BOOL)
 RCT_REMAP_VIEW_PROPERTY(color, textView.textColor, UIColor)

--- a/Libraries/Text/RCTTextViewManager.m
+++ b/Libraries/Text/RCTTextViewManager.m
@@ -27,13 +27,7 @@ RCT_EXPORT_MODULE()
 
 RCT_REMAP_VIEW_PROPERTY(autoCapitalize, textView.autocapitalizationType, UITextAutocapitalizationType)
 RCT_REMAP_VIEW_PROPERTY(autoCorrect, autocorrectionType, UITextAutocorrectionType)
-RCT_CUSTOM_VIEW_PROPERTY(spellCheck, NSString, RCTTextView)
-{
-  view.spellCheckingType =
-    json == nil ? UITextSpellCheckingTypeDefault :
-    [RCTConvert BOOL:json] ? UITextSpellCheckingTypeYes :
-    UITextSpellCheckingTypeNo;
-}
+RCT_REMAP_VIEW_PROPERTY(spellCheck, spellCheckingType, UITextSpellCheckingType)
 RCT_EXPORT_VIEW_PROPERTY(blurOnSubmit, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(clearTextOnFocus, BOOL)
 RCT_REMAP_VIEW_PROPERTY(color, textView.textColor, UIColor)


### PR DESCRIPTION
This exposes iOS's spellCheckingType functionality to JavaScript. The native functionality is a three state enum. It gets exposed to JavaScript as a boolean. The initial value and JS null map to the third state.

An alternative design for this API would have been to expose a three state enum to JavaScript:
  - "on" which maps to UITextSpellCheckingTypeYes
  - "off" which maps to UITextSpellCheckingTypeNo
  - "auto" (default) which maps to UITextSpellCheckingTypeDefault

For consistency, I decided to use the same API design as spellCheck. We don't have many options for fixing spellCheck in #11055 without introducing a breaking change.

**Test plan (required)**

Verified that switching `spellCheck` between `true`, `false`, and `null` all work correctly in single line and multiline `TextInputs`.