### PR TITLE
Cannot assign to read only property 'product' of object '#<WorkerNavi…

### DIFF
--- a/Libraries/Core/InitializeCore.js
+++ b/Libraries/Core/InitializeCore.js
@@ -181,7 +181,7 @@ if (navigator === undefined) {
 }
 
 // see https://github.com/facebook/react-native/issues/10881
-defineProperty(navigator, 'product', () => 'ReactNative');
+defineProperty(navigator, 'product', () => 'ReactNative', true);
 defineProperty(navigator, 'geolocation', () => require('Geolocation'));
 
 // Set up collections

--- a/Libraries/Core/InitializeCore.js
+++ b/Libraries/Core/InitializeCore.js
@@ -27,6 +27,7 @@
  *   2. Bridged modules.
  *
  */
+'use strict';
 
 if (global.GLOBAL === undefined) {
   global.GLOBAL = global;
@@ -178,7 +179,9 @@ let navigator = global.navigator;
 if (navigator === undefined) {
   global.navigator = navigator = {};
 }
-navigator.product = 'ReactNative';
+
+// see https://github.com/facebook/react-native/issues/10881
+defineProperty(navigator, 'product', () => 'ReactNative');
 defineProperty(navigator, 'geolocation', () => require('Geolocation'));
 
 // Set up collections


### PR DESCRIPTION
When running in strict mode we run into the following error:
“Cannot assign to read only property 'product' of object '#<WorkerNavigator>’”

Moreover navigator.product = ‘ReactNative’; didn’t actually change the product value. Without strict mode this was silently ignored.

By using our defineProperty function we are able to run in strict mode and now navigator.product is really ReactNative.

See https://github.com/facebook/react-native/issues/10881 for more information

---------------

Long story short - if we run in strict mode, the current code throws an error :
`Cannot assign to read only property 'product' of object '#<WorkerNavigator>' initializeCore.js`
(the current version of initializeCore.js doesn't have 'use strict'; on top, but if you are unfortunate enough to have a babel module that ads this for you, you are guaranteed to run into this. Moreover our contributing guidelines say that we should have 'use strict'; https://github.com/facebook/react-native/blob/master/CONTRIBUTING.md)

If we are not running in strict mode, then we don't get any error but the value assigned to navigator.product is ignored.

**Test plan (required)**
Easiest way to replicate. Run the UIExplorer example with **"remote js debug" on**.  Then in the render function of UIExplorerApp.ios.js add a **console.log(navigator);** In your console you should see that the navigator.product is still set to "Gecko". Apply this pull request -> now navigator.product is "ReactNative".
