### PR TITLE
[typo] Fix typo when running an unknown simulator

### DIFF
--- a/local-cli/runIOS/runIOS.js
+++ b/local-cli/runIOS/runIOS.js
@@ -78,7 +78,7 @@ function runOnSimulator(xcodeProject, args, inferredSchemeName, scheme){
 
     const selectedSimulator = findMatchingSimulator(simulators, args.simulator);
     if (!selectedSimulator) {
-      throw new Error(`Cound't find ${args.simulator} simulator`);
+      throw new Error(`Could not find ${args.simulator} simulator`);
     }
 
     const simulatorFullName = formattedDeviceName(selectedSimulator);


### PR DESCRIPTION
Just fixes a typo in an error message when running a simulator that XCode doesn't recognise.