### PR TITLE
[docs] Remove deprecated push notification method info

### DIFF
--- a/Libraries/PushNotificationIOS/PushNotificationIOS.js
+++ b/Libraries/PushNotificationIOS/PushNotificationIOS.js
@@ -106,11 +106,6 @@ export type PushNotificationEventName = $Enum<{
  *    {
  *     [RCTPushNotificationManager didFailToRegisterForRemoteNotificationsWithError:error];
  *    }
- *    // Required for the notification event.
- *    - (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)notification
- *    {
- *     [RCTPushNotificationManager didReceiveRemoteNotification:notification];
- *    }
  *    // Required for the localNotification event.
  *    - (void)application:(UIApplication *)application didReceiveLocalNotification:(UILocalNotification *)notification
  *    {


### PR DESCRIPTION
> Explain the **motivation** for making this change. What existing problem does the pull request solve?

This PR seeks to improve the documentation of PushNotificationIOS. 

The method didReceiveRemoteNotification without a fetch completion handler is deprecated by Apple and they [discourage using it](https://developer.apple.com/reference/uikit/uiapplicationdelegate/1623117-application) in favor of the [version with the handler](https://developer.apple.com/reference/uikit/uiapplicationdelegate/1623013-application).

There's also a practical consideration for it. The deprecated method **only works when application is in the foreground** which is not what most of the people expect from their remote notification handlers. I don't think we should encourage people to use it at all.
