### PR TITLE
Update Debugging.md for iOS debugging on device

### DIFF
--- a/docs/Debugging.md
+++ b/docs/Debugging.md
@@ -74,7 +74,14 @@ Select `Tools → Developer Tools` from the Chrome Menu to open the [Developer T
 
 ### Debugging on a device with Chrome Developer Tools
 
-On iOS devices, open the file [`RCTWebSocketExecutor.m`](https://github.com/facebook/react-native/blob/master/Libraries/WebSocket/RCTWebSocketExecutor.m) and change "localhost" to the IP address of your computer, then select "Debug JS Remotely" from the Developer Menu.
+On iOS devices, open the file `ios/{YourApp}/Info.plist` and add the following lines before the `<key>localhost</key>` with the IP address of your computer, then select "Debug JS Remotely" from the Developer Menu:
+```
+<key>{YOUR_IP_ADDRESS}</key>
+	<dict>
+		<key>NSExceptionAllowsInsecureHTTPLoads</key>
+	<true/>
+</dict>
+```
 
 On Android 5.0+ devices connected via USB, you can use the [`adb` command line tool](http://developer.android.com/tools/help/adb.html) to setup port forwarding from the device to your computer:
 


### PR DESCRIPTION
The former documentation was outdated, `localhost` did no longer exist in `RCTWebSocketExecutor.m`.