### PR TITLE
Fix LayoutAnimation delete scaleXY animation

### DIFF
--- a/React/Modules/RCTUIManager.m
+++ b/React/Modules/RCTUIManager.m
@@ -816,7 +816,7 @@ RCT_EXPORT_METHOD(removeSubviewsFromContainerWithID:(nonnull NSNumber *)containe
     NSString *property = deleteAnimation.property;
     [deleteAnimation performAnimations:^{
       if ([property isEqualToString:@"scaleXY"]) {
-        removedChild.layer.transform = CATransform3DMakeScale(0, 0, 0);
+        removedChild.layer.transform = CATransform3DMakeScale(0.001, 0.001, 0.001);
       } else if ([property isEqualToString:@"opacity"]) {
         removedChild.layer.opacity = 0.0;
       } else {


### PR DESCRIPTION
This fix the issue https://github.com/facebook/react-native/issues/11066.

It's more a workaround but it fixes the scaling down animation on component unmount using LayoutAnimation.

![scale_test](https://cloud.githubusercontent.com/assets/8358797/20537196/16f7ff24-b0e4-11e6-8870-6525466017f2.gif)