### PR TITLE
[NavigationExperimental] Support custom card style interpolators

### DIFF
--- a/Libraries/CustomComponents/NavigationExperimental/NavigationCardStack.js
+++ b/Libraries/CustomComponents/NavigationExperimental/NavigationCardStack.js
@@ -67,15 +67,12 @@ type Props = {
   style: any,
   gestureResponseDistance?: ?number,
   enableGestures: ?boolean,
-  horizontalCardStyleInterpolator: NavigationStyleInterpolator,
-  verticalCardStyleInterpolator: NavigationStyleInterpolator
+  cardStyleInterpolator?: ?NavigationStyleInterpolator,
 };
 
 type DefaultProps = {
   direction: NavigationGestureDirection,
   enableGestures: boolean,
-  horizontalCardStyleInterpolator: NavigationStyleInterpolator,
-  verticalCardStyleInterpolator: NavigationStyleInterpolator
 };
 
 /**
@@ -153,20 +150,11 @@ class NavigationCardStack extends React.Component<DefaultProps, Props, void> {
     /**
      * An interpolator function that is passed an object parameter of type
      * NavigationSceneRendererProps and should return a style object to apply to
-     * the transitioning navigation card. Used when `direction` is `horizontal`.
+     * the transitioning navigation card.
      *
      * Default interpolator transitions translateX, scale, and opacity.
      */
-    horizontalCardStyleInterpolator: PropTypes.func,
-
-    /**
-     * An interpolator function that is passed an object parameter of type
-     * NavigationSceneRendererProps and should return a style object to apply to
-     * the transitioning navigation card. Used when `direction` is `vertical`.
-     *
-     * Default interpolator transitions translateY, scale, and opacity.
-     */
-    verticalCardStyleInterpolator: PropTypes.func,
+    cardStyleInterpolator: PropTypes.func,
 
     /**
      * Enable gestures. Default value is true.
@@ -219,10 +207,6 @@ class NavigationCardStack extends React.Component<DefaultProps, Props, void> {
   static defaultProps: DefaultProps = {
     direction: Directions.HORIZONTAL,
     enableGestures: true,
-    horizontalCardStyleInterpolator:
-      NavigationCardStackStyleInterpolator.forHorizontal,
-    verticalCardStyleInterpolator:
-      NavigationCardStackStyleInterpolator.forVertical,
   };
 
   constructor(props: Props, context: any) {
@@ -290,9 +274,12 @@ class NavigationCardStack extends React.Component<DefaultProps, Props, void> {
 
   _renderScene(props: NavigationSceneRendererProps): React.Element<any> {
     const isVertical = this.props.direction === 'vertical';
-    const style = isVertical ?
-      this.props.verticalCardStyleInterpolator(props) :
-      this.props.horizontalCardStyleInterpolator(props);
+
+    const interpolator = this.props.cardStyleInterpolator || (isVertical ?
+      NavigationCardStackStyleInterpolator.forVertical :
+      NavigationCardStackStyleInterpolator.forHorizontal);
+
+    const style = interpolator(props);
 
     let panHandlers = null;
 

--- a/Libraries/CustomComponents/NavigationExperimental/NavigationCardStack.js
+++ b/Libraries/CustomComponents/NavigationExperimental/NavigationCardStack.js
@@ -67,15 +67,15 @@ type Props = {
   style: any,
   gestureResponseDistance?: ?number,
   enableGestures: ?boolean,
-  horizontalCardStyleInterpolator: ?NavigationStyleInterpolator,
-  verticalCardStyleInterpolator: ?NavigationStyleInterpolator
+  horizontalCardStyleInterpolator: NavigationStyleInterpolator,
+  verticalCardStyleInterpolator: NavigationStyleInterpolator
 };
 
 type DefaultProps = {
   direction: NavigationGestureDirection,
   enableGestures: boolean,
-  horizontalCardStyleInterpolator: ?NavigationStyleInterpolator,
-  verticalCardStyleInterpolator: ?NavigationStyleInterpolator
+  horizontalCardStyleInterpolator: NavigationStyleInterpolator,
+  verticalCardStyleInterpolator: NavigationStyleInterpolator
 };
 
 /**

--- a/Libraries/CustomComponents/NavigationExperimental/NavigationCardStack.js
+++ b/Libraries/CustomComponents/NavigationExperimental/NavigationCardStack.js
@@ -50,6 +50,7 @@ import type {
   NavigationSceneRenderer,
   NavigationSceneRendererProps,
   NavigationTransitionProps,
+  NavigationStyleInterpolator,
 } from 'NavigationTypeDefinition';
 
 import type {
@@ -65,12 +66,16 @@ type Props = {
   cardStyle?: any,
   style: any,
   gestureResponseDistance?: ?number,
-  enableGestures: ?boolean
+  enableGestures: ?boolean,
+  horizontalCardStyleInterpolator: ?NavigationStyleInterpolator,
+  verticalCardStyleInterpolator: ?NavigationStyleInterpolator
 };
 
 type DefaultProps = {
   direction: NavigationGestureDirection,
-  enableGestures: boolean
+  enableGestures: boolean,
+  horizontalCardStyleInterpolator: ?NavigationStyleInterpolator,
+  verticalCardStyleInterpolator: ?NavigationStyleInterpolator
 };
 
 /**
@@ -141,9 +146,27 @@ class NavigationCardStack extends React.Component<DefaultProps, Props, void> {
 
     /**
      * The distance from the edge of the card which gesture response can start
-     * for. Defaults value is `30`.
+     * for. Default value is `30`.
      */
     gestureResponseDistance: PropTypes.number,
+
+    /**
+     * An interpolator function that is passed an object parameter of type
+     * NavigationSceneRendererProps and should return a style object to apply to
+     * the transitioning navigation card. Used when `direction` is `horizontal`.
+     *
+     * Default interpolator transitions translateX, scale, and opacity.
+     */
+    horizontalCardStyleInterpolator: PropTypes.func,
+
+    /**
+     * An interpolator function that is passed an object parameter of type
+     * NavigationSceneRendererProps and should return a style object to apply to
+     * the transitioning navigation card. Used when `direction` is `vertical`.
+     *
+     * Default interpolator transitions translateY, scale, and opacity.
+     */
+    verticalCardStyleInterpolator: PropTypes.func,
 
     /**
      * Enable gestures. Default value is true.
@@ -196,6 +219,10 @@ class NavigationCardStack extends React.Component<DefaultProps, Props, void> {
   static defaultProps: DefaultProps = {
     direction: Directions.HORIZONTAL,
     enableGestures: true,
+    horizontalCardStyleInterpolator:
+      NavigationCardStackStyleInterpolator.forHorizontal,
+    verticalCardStyleInterpolator:
+      NavigationCardStackStyleInterpolator.forVertical,
   };
 
   constructor(props: Props, context: any) {
@@ -263,10 +290,9 @@ class NavigationCardStack extends React.Component<DefaultProps, Props, void> {
 
   _renderScene(props: NavigationSceneRendererProps): React.Element<any> {
     const isVertical = this.props.direction === 'vertical';
-
     const style = isVertical ?
-      NavigationCardStackStyleInterpolator.forVertical(props) :
-      NavigationCardStackStyleInterpolator.forHorizontal(props);
+      this.props.verticalCardStyleInterpolator(props) :
+      this.props.horizontalCardStyleInterpolator(props);
 
     let panHandlers = null;
 


### PR DESCRIPTION
Transition animations are not very customizable right now with NavigationExperimental, unless I am missing something big. This PR allows NavigationCardStack to receive the `horizontalCardStyleInterpolator` and `verticalCardStyleInterpolator` props to override the default interpolators.

See the gif, transition animation changes from the default one (with scale) to a custom one (without scale) when passing in a custom interpolator. (The custom interpolator is an exact copy of the one in `NavigationCardStackStyleInterpolator.forHorizontal`, minus the scale transform.)

![cmz0gagoec](https://cloud.githubusercontent.com/assets/1389312/20552499/af33667c-b119-11e6-97e7-bea9986a58e0.gif)

Let me know if there's a robust way to test, but I couldn't find anything.

**To address**
The new `canUseNativeDriver` function on NavigationCardStackStyleInterpolator, which returns `true`, is dependent on the interpolator, so custom interpolators may need to falsify this. Didn't include it on the first pass since I wasn't sure, but how does moving it out of NavigationCardStackStyleInterpolator and changing it to a boolean property on NavigationCardStack which defaults to `true` sound? (The `isVertical` param passed to it won't be relevant anymore because the user of NavigationCardStack knows the direction set.)