### PR TITLE
[Android] Use a CDN to download Boost

### DIFF
--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -28,7 +28,7 @@ task createNativeDepsDirectories {
 
 task downloadBoost(dependsOn: createNativeDepsDirectories, type: Download) {
     // Use ZIP version as it's faster this way to selectively extract some parts of the archive
-    src 'https://downloads.sourceforge.net/project/boost/boost/1.57.0/boost_1_57_0.zip'
+    src 'https://unpkg.com/boost-mirror@1.57.0/boost.zip'
     // alternative
     // src 'http://mirror.nienbo.com/boost/boost_1_57_0.zip'
     onlyIfNewer true


### PR DESCRIPTION
Downloading from the CDN is much faster than from SourceForge, both on my home WiFi and at the office.

I checked using the `diff` utility that both files are identical.

**Test Plan**

Circle CI build on this PR.