### PR TITLE
Fix typo; width and height are the wrong way around

### DIFF
--- a/Libraries/Utilities/Dimensions.js
+++ b/Libraries/Utilities/Dimensions.js
@@ -72,7 +72,7 @@ class Dimensions {
    * than caching the value (for example, using inline styles rather than
    * setting a value in a `StyleSheet`).
    *
-   * Example: `var {height, width} = Dimensions.get('window');`
+   * Example: `var {width, height} = Dimensions.get('window');`
    *
    * @param {string} dim Name of dimension as defined when calling `set`.
    * @returns {Object?} Value for the dimension.


### PR DESCRIPTION
Width and height are the wrong way around in the example. 
You can see [here](https://rnplay.org/apps/rGnaJQ) that with a portrait phone, the first argument is the smaller one (width).