### PR TITLE
Fix babelHelpers.typeof is not a function

### DIFF
--- a/packager/react-packager/src/Resolver/polyfills/babelHelpers.js
+++ b/packager/react-packager/src/Resolver/polyfills/babelHelpers.js
@@ -22,7 +22,7 @@ var babelHelpers = global.babelHelpers = {};
 babelHelpers.typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) {
   return typeof obj;
 } : function (obj) {
-  return obj && typeof Symbol === "function" && obj.constructor === Symbol ? "symbol" : typeof obj;
+  return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj;
 };
 
 babelHelpers.createRawReactElement = (function () {

--- a/packager/react-packager/src/Resolver/polyfills/babelHelpers.js
+++ b/packager/react-packager/src/Resolver/polyfills/babelHelpers.js
@@ -19,6 +19,12 @@
 
 var babelHelpers = global.babelHelpers = {};
 
+babelHelpers.typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) {
+  return typeof obj;
+} : function (obj) {
+  return obj && typeof Symbol === "function" && obj.constructor === Symbol ? "symbol" : typeof obj;
+};
+
 babelHelpers.createRawReactElement = (function () {
   var REACT_ELEMENT_TYPE = typeof Symbol === "function" && Symbol.for && Symbol.for("react.element") || 0xeac7;
   return function createRawReactElement(type, key, props) {


### PR DESCRIPTION
We started encountering the error described in #5747 (`babelHelpers.typeof is not a function) after switching from npm to yarn. [This comment](https://github.com/facebook/react-native/issues/5747#issuecomment-192356656) led to [this comment](https://github.com/facebook/react-native/issues/4844#issuecomment-191282653) which contains a solution we've been using successfully in our production app.

Maybe I didn't look in the right place but it doesn't seem anyone had actually PR'd this change before (if so and I didn't find it, I apologize).

An alternative solution it seems is to add a [different .babelrc](http://stackoverflow.com/questions/35563025/new-react-native-app-has-typeerror-babelhelpers-typeof-is-not-a-function-ios), but this seems easier to me.

