### PR TITLE
[Android] Deprecate RecyclerViewBackedScrollView

### DIFF
--- a/Libraries/Components/ScrollView/RecyclerViewBackedScrollView.android.js
+++ b/Libraries/Components/ScrollView/RecyclerViewBackedScrollView.android.js
@@ -16,7 +16,13 @@ var requireNativeComponent = require('requireNativeComponent');
 var INNERVIEW = 'InnerView';
 
 /**
- * Wrapper around android native recycler view.
+ * RecyclerViewBackedScrollView is DEPRECATED and will be removed from
+ * React Native.
+ * Please use a `ListView` which has `removeClippedSubviews` enabled by
+ * default so that rows that are out of sight are automatically
+ * detached from the view hierarchy.
+ *
+ * Wrapper around Android native recycler view.
  *
  * It simply renders rows passed as children in a separate recycler view cells
  * similarly to how `ScrollView` is doing it. Thanks to the fact that it uses
@@ -57,6 +63,14 @@ var RecyclerViewBackedScrollView = React.createClass({
   },
 
   mixins: [ScrollResponder.Mixin],
+
+  componentWillMount: function() {
+    log.warn(
+      'RecyclerViewBackedScrollView is DEPRECATED and will be removed from React Native. ' +
+      'Please use a ListView which has removeClippedSubviews enabled by default so that ' +
+      'rows that are out of sight are automatically detached from the view hierarchy.'
+    );
+  },
 
   getInitialState: function() {
     return this.scrollResponderMixinGetInitialState();


### PR DESCRIPTION
We don't use this component internally and seems like it's not needed.

From the docs of this component it looks like there's no point in its existence:

    * It simply renders rows passed as children in a separate recycler view cells
    * similarly to how `ScrollView` is doing it. Thanks to the fact that it uses
    * native `RecyclerView` though, rows that are out of sight are going to be
    * automatically detached (similarly on how this would work with
    * `removeClippedSubviews = true` on a `ScrollView.js`).

I'd like to deprecate this component we don't use it at fb and it has a maintenance cost, e.g.: https://github.com/facebook/react-native/pull/7002