### PR TITLE
[docs] Remove deprecated push notification method info

### DIFF
--- a/Libraries/PushNotificationIOS/PushNotificationIOS.js
+++ b/Libraries/PushNotificationIOS/PushNotificationIOS.js
@@ -96,20 +96,10 @@ export type PushNotificationEventName = $Enum<{
  *    {
  *       [RCTPushNotificationManager didReceiveRemoteNotification:userInfo fetchCompletionHandler:completionHandler];
  *    }
- *    // Optionally implement this method over the previous to receive remote notifications. However
- *    // implement the application:didReceiveRemoteNotification:fetchCompletionHandler: method instead of this one whenever possible.
- *    // If your delegate implements both methods, the app object calls the `application:didReceiveRemoteNotification:fetchCompletionHandler:` method
- *    // Either this method or `application:didReceiveRemoteNotification:fetchCompletionHandler:` is required in order to receive remote notifications.
- *    //
  *    // Required for the registrationError event.
  *    - (void)application:(UIApplication *)application didFailToRegisterForRemoteNotificationsWithError:(NSError *)error
  *    {
  *     [RCTPushNotificationManager didFailToRegisterForRemoteNotificationsWithError:error];
- *    }
- *    // Required for the notification event.
- *    - (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)notification
- *    {
- *     [RCTPushNotificationManager didReceiveRemoteNotification:notification];
  *    }
  *    // Required for the localNotification event.
  *    - (void)application:(UIApplication *)application didReceiveLocalNotification:(UILocalNotification *)notification


### PR DESCRIPTION
This PR seeks to improve the documentation of PushNotificationIOS.

The method didReceiveRemoteNotification without a fetch completion handler is deprecated by Apple and they [discourage using it](https://developer.apple.com/reference/uikit/uiapplicationdelegate/1623117-application) in favor of the [version with the handler](https://developer.apple.com/reference/uikit/uiapplicationdelegate/1623013-application).

Reasons for this change:

1. Our docs say that this method is required for remote notifications, but it's not. (It's one of possibilities with a recommendation not to use it.)
2. The method is deprecated by Apple and people shouldn't use it.
3. If you use the deprecated method, in 99% of the cases it will behave in a different way from what you'd expect. In particular, you won't get remote notifications when your app is in the background.

As there's no benefit (as far as I know) of using the method, I don't think we should even mention it to the users.

This is a re-opened PR that was mistakenly closed. More context and discussion here: https://github.com/facebook/react-native/pull/11062