### PR TITLE
* Reduce emit overhead to ~50% of prior, by caching class-name of java-script module/interface.

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/JavaScriptModuleRegistration.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/JavaScriptModuleRegistration.java
@@ -26,6 +26,7 @@ import com.facebook.react.common.build.ReactBuildConfig;
 public class JavaScriptModuleRegistration {
 
   private final Class<? extends JavaScriptModule> mModuleInterface;
+  private String mName;
 
   public JavaScriptModuleRegistration(Class<? extends JavaScriptModule> moduleInterface) {
     mModuleInterface = moduleInterface;
@@ -45,10 +46,9 @@ public class JavaScriptModuleRegistration {
   public Class<? extends JavaScriptModule> getModuleInterface() {
     return mModuleInterface;
   }
-
-  private String name_cached;
+  
   public String getName() {
-    if (name_cached == null) {
+    if (mName == null) {
       // With proguard obfuscation turned on, proguard apparently (poorly) emulates inner classes or
       // something because Class#getSimpleName() no longer strips the outer class name. We manually
       // strip it here if necessary.
@@ -59,9 +59,9 @@ public class JavaScriptModuleRegistration {
       }
       
       // getting the class name every call is expensive, so cache it
-      name_cached = name;
+      mName = name;
     }
-    return name_cached;
+    return mName;
   }
 
   public List<Method> getMethods() {

--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/JavaScriptModuleRegistration.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/JavaScriptModuleRegistration.java
@@ -26,7 +26,7 @@ import com.facebook.react.common.build.ReactBuildConfig;
 public class JavaScriptModuleRegistration {
 
   private final Class<? extends JavaScriptModule> mModuleInterface;
-  private String mName;
+  private @Nullable String mName;
 
   public JavaScriptModuleRegistration(Class<? extends JavaScriptModule> moduleInterface) {
     mModuleInterface = moduleInterface;

--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/JavaScriptModuleRegistration.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/JavaScriptModuleRegistration.java
@@ -46,16 +46,22 @@ public class JavaScriptModuleRegistration {
     return mModuleInterface;
   }
 
+  private String name_cached;
   public String getName() {
-    // With proguard obfuscation turned on, proguard apparently (poorly) emulates inner classes or
-    // something because Class#getSimpleName() no longer strips the outer class name. We manually
-    // strip it here if necessary.
-    String name = mModuleInterface.getSimpleName();
-    int dollarSignIndex = name.lastIndexOf('$');
-    if (dollarSignIndex != -1) {
-      name = name.substring(dollarSignIndex + 1);
+    if (name_cached == null) {
+      // With proguard obfuscation turned on, proguard apparently (poorly) emulates inner classes or
+      // something because Class#getSimpleName() no longer strips the outer class name. We manually
+      // strip it here if necessary.
+      String name = mModuleInterface.getSimpleName();
+      int dollarSignIndex = name.lastIndexOf('$');
+      if (dollarSignIndex != -1) {
+        name = name.substring(dollarSignIndex + 1);
+      }
+      
+      // getting the class name every call is expensive, so cache it
+      name_cached = name;
     }
-    return name;
+    return name_cached;
   }
 
   public List<Method> getMethods() {

--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/JavaScriptModuleRegistration.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/JavaScriptModuleRegistration.java
@@ -10,6 +10,7 @@
 package com.facebook.react.bridge;
 
 import javax.annotation.concurrent.Immutable;
+import javax.annotation.Nullable;
 
 import java.lang.reflect.Method;
 import java.util.Arrays;


### PR DESCRIPTION
Made modification to react-native code that reduces the communication channel overhead to ~50% of prior, in some cases, by caching the class-name of the java-script module/interface.

For me it reduced the run-time of the RCTDeviceEventEmitter.emit function from 1438ms to 715ms, over a period of 8 seconds in my Android app. My project requires many emit calls, as I'm transferring real-time EEG data from a Muse headband to my react-native UI to be graphed, so this optimization was very helpful in my case.