### PR TITLE
[docs] Upgrading - mention peerDependency on React

### DIFF
--- a/docs/Upgrading.md
+++ b/docs/Upgrading.md
@@ -20,7 +20,7 @@ Note the latest version of the `react-native` npm package from here (or use `npm
 
 * https://www.npmjs.com/package/react-native
 
-Now install that version of `react-native` in your project with `npm install --save`.
+Now install that version of `react-native` in your project with `npm install --save`:
 
 ```sh
 $ npm install --save react-native@X.Y 
@@ -28,7 +28,7 @@ $ npm install --save react-native@X.Y
 npm WARN peerDependencies The peer dependency react@~R included from react-native...
 ```
 
-If you saw a warning about the peerDependency, also install `react`:
+If you saw a warning about the peerDependency, also upgrade `react` by running:
 ```sh
 $ npm install --save react@R
 # where R is the new version of react from the peerDependency warning you saw

--- a/docs/Upgrading.md
+++ b/docs/Upgrading.md
@@ -25,6 +25,13 @@ Now install that version of `react-native` in your project with `npm install --s
 ```sh
 $ npm install --save react-native@X.Y 
 # where X.Y is the semantic version you are upgrading to
+npm WARN peerDependencies The peer dependency react@~R included from react-native...
+```
+
+If you saw a warning about the peerDependency, also install `react`:
+```sh
+$ npm install --save react@R
+# where R is the new version of react from the peerDependency warning you saw
 ```
 
 ## 2. Upgrade your project templates


### PR DESCRIPTION
Fixes issues with docs from https://github.com/facebook/react-native/issues/11104.

We should document people should update both `react` and `react-native` until we switch to the new upgrades.