### PR TITLE
Force original ime option when using multiline with blurOnSubmit in a…

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
@@ -186,8 +186,8 @@ public class ReactEditText extends EditText {
   @Override
   public InputConnection onCreateInputConnection(EditorInfo outAttrs) {
     InputConnection connection = super.onCreateInputConnection(outAttrs);
-    if(isMultiline() && getBlurOnSubmit()) {
-      //Remove IME_FLAG_NO_ENTER_ACTION to keep the original IME_OPTION
+    if (isMultiline() && getBlurOnSubmit()) {
+      // Remove IME_FLAG_NO_ENTER_ACTION to keep the original IME_OPTION
       outAttrs.imeOptions &= ~EditorInfo.IME_FLAG_NO_ENTER_ACTION;
     }
     return connection;

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
@@ -35,6 +35,7 @@ import android.view.KeyEvent;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.inputmethod.EditorInfo;
+import android.view.inputmethod.InputConnection;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.EditText;
 
@@ -180,6 +181,16 @@ public class ReactEditText extends EditText {
     if (mScrollWatcher != null) {
       mScrollWatcher.onScrollChanged(horiz, vert, oldHoriz, oldVert);
     }
+  }
+
+  @Override
+  public InputConnection onCreateInputConnection(EditorInfo outAttrs) {
+    InputConnection connection = super.onCreateInputConnection(outAttrs);
+    if(isMultiline() && getBlurOnSubmit()) {
+      //Remove IME_FLAG_NO_ENTER_ACTION to keep the original IME_OPTION
+      outAttrs.imeOptions &= ~EditorInfo.IME_FLAG_NO_ENTER_ACTION;
+    }
+    return connection;
   }
 
   @Override

--- a/ReactAndroid/src/test/java/com/facebook/react/views/textinput/ReactTextInputPropertyTest.java
+++ b/ReactAndroid/src/test/java/com/facebook/react/views/textinput/ReactTextInputPropertyTest.java
@@ -15,6 +15,7 @@ import android.text.InputType;
 import android.text.InputFilter;
 import android.util.DisplayMetrics;
 import android.view.Gravity;
+import android.view.inputmethod.EditorInfo;
 import android.widget.EditText;
 
 import com.facebook.react.bridge.CatalystInstance;
@@ -199,6 +200,20 @@ public class ReactTextInputPropertyTest {
 
     mManager.updateProperties(view, buildStyles("multiline", null));
     assertThat(view.getInputType() & InputType.TYPE_TEXT_FLAG_MULTI_LINE).isZero();
+  }
+
+  @Test
+  public void testBlurMultiline() {
+    ReactEditText view = mManager.createViewInstance(mThemedContext);
+
+    mManager.updateProperties(view, buildStyles("multiline", true));
+    mManager.updateProperties(view, buildStyles("blurOnSubmit", true));
+
+    EditorInfo editorInfo = new EditorInfo();
+    editorInfo.imeOptions = EditorInfo.IME_ACTION_DONE | EditorInfo.IME_FLAG_NO_ENTER_ACTION;
+    view.onCreateInputConnection(editorInfo);
+
+    assertThat(editorInfo.imeOptions).isEqualTo(EditorInfo.IME_ACTION_DONE);
   }
 
   @Test


### PR DESCRIPTION
…ndroid

Android overrides the original set ime option when the EditText is a multiline one.
This change makes sure to set it back to the original one when blurOnSubmit is true,
which causes the button icon to be conforming to the set returnKeyType as well as
changing the behaviour of the button, such that it will blurOnSubmit correctly.

The reason not do it with blurOnSubmit being false is
because it then would not create new lines when pressing the submit button,
which would be inconsistent with IOS behaviour.

**Note** this change relies on this one #11006 because the app would crash if we don't expllicitly remove the focus (`editText.clearFocus();`)

Fixes #8778

**Test plan (required)**


1. Create view with TextInput with multiline and blurOnSubmit set to true
```javascript
<View>
           <TextInput
                returnKeyType='search'
                blurOnSubmit={true}
                multiline={true}
                onSubmitEditing={event => console.log('submit search')}></TextInput>
</View>
```

2. Input some text and click submit button in soft keyboard
3. See submit event fired and focus cleared / keyboard removed