### PR TITLE
KeyboardAvoidingView measures frame using absolute window position

### DIFF
--- a/Libraries/Components/Keyboard/KeyboardAvoidingView.js
+++ b/Libraries/Components/Keyboard/KeyboardAvoidingView.js
@@ -13,7 +13,7 @@
 
 const Keyboard = require('Keyboard');
 const LayoutAnimation = require('LayoutAnimation');
-const NativeMethodsMixin = require('react/lib/NativeMethodsMixin');
+const NativeMethodsMixin = require('NativeMethodsMixin');
 const Platform = require('Platform');
 const React = require('React');
 const TimerMixin = require('react-timer-mixin');


### PR DESCRIPTION
Hello, friends!

I was noticing weird measurement behaviour using `KeyboardAvoidingView`.

Our setup has our `RCTRootView` within a `UINavigationController`, which we've set up to not allow content underneath. When measuring the keyboard frame, after some trial and error, the value was 64pt off - coincidentally the height of the `UINavigationBar` + status bar.

I've wrapped the calculations in a call to `measureInWindow`, which gives the expected result.

Pictures are worth a thousand words, so here's how it was before:

![screen-shot-2016-11-25-at-2 36 10-pm](https://cloud.githubusercontent.com/assets/33126/20627031/c7b8fa30-b31d-11e6-95fa-c98f21b7df3b.png)

And after:

![screen-shot-2016-11-25-at-2 36 25-pm](https://cloud.githubusercontent.com/assets/33126/20627033/c9a6897a-b31d-11e6-84d4-0f8446652be5.png)

You can see the blue container stretching under the keyboard by 64pt (!), even though it should be keyboard-avoided (with margin 10pt). The second image shows that behaviour working correctly.