### PR TITLE
Added npm react-native-cli command to windows and linux

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -118,6 +118,12 @@ choco install python2
 
 Node.js comes with npm, which lets you install the React Native command line interface.
 
+Run the following command in a Terminal:
+
+```
+npm install -g react-native-cli
+```
+
 <block class="windows linux android" />
 
 ### The React Native CLI


### PR DESCRIPTION
The windows and linux block didn't have the command to install react-native-cli. 

The command is the exact same as it is on macOS. It makes the guide a little confusing because it leaves out this critical step and it's difficult to understand whether or not this needed component was already indirectly installed in one of the other steps.