### PR TITLE
[docs] Mention that LayoutAnimation has to be explicitly enabled on A…

### DIFF
--- a/Libraries/LayoutAnimation/LayoutAnimation.js
+++ b/Libraries/LayoutAnimation/LayoutAnimation.js
@@ -124,7 +124,7 @@ var Presets = {
  * A common way to use this API is to call it before calling `setState`.
  *
  * Note that in order to get this to work on **Android** you need to set the following flags via `UIManager`:
- * 
+ *
  *     UIManager.setLayoutAnimationEnabledExperimental && UIManager.setLayoutAnimationEnabledExperimental(true);
  */
 var LayoutAnimation = {

--- a/Libraries/LayoutAnimation/LayoutAnimation.js
+++ b/Libraries/LayoutAnimation/LayoutAnimation.js
@@ -121,8 +121,11 @@ var Presets = {
  * Automatically animates views to their new positions when the
  * next layout happens.
  *
- * A common way to use this API is to call `LayoutAnimation.configureNext`
- * before calling `setState`.
+ * A common way to use this API is to call it before calling `setState`.
+ *
+ * Note that in order to get this to work on **Android** you need to set the following flags via `UIManager`:
+ * 
+ *     UIManager.setLayoutAnimationEnabledExperimental && UIManager.setLayoutAnimationEnabledExperimental(true);
  */
 var LayoutAnimation = {
   /**


### PR DESCRIPTION
This is mentioned in a different document but we forgot to mention it in JS docs:
- Mentioned here: http://facebook.github.io/react-native/docs/animations.html#layoutanimation
- Missing here: http://facebook.github.io/react-native/docs/layoutanimation.html

**Test plan**

    cd website
    npm install
    npm start

<img width="925" alt="screenshot 2016-11-25 21 48 36" src="https://cloud.githubusercontent.com/assets/346214/20635747/68fe5f6c-b359-11e6-8e72-8f7ca04f79bd.png">
