### PR TITLE
iOS: Fix an image loader crash

### DIFF
--- a/Libraries/Image/RCTImageLoader.m
+++ b/Libraries/Image/RCTImageLoader.m
@@ -382,9 +382,10 @@ static UIImage *RCTResizeImageIfNeeded(UIImage *image,
   });
 
   return ^{
-    if (cancelLoad && !cancelled) {
-      cancelLoad();
-      cancelLoad = nil;
+    dispatch_block_t cancelLoadLocal = cancelLoad;
+    cancelLoad = nil;
+    if (cancelLoadLocal && !cancelled) {
+      cancelLoadLocal();
     }
     OSAtomicOr32Barrier(1, &cancelled);
   };
@@ -516,8 +517,9 @@ static UIImage *RCTResizeImageIfNeeded(UIImage *image,
   __block volatile uint32_t cancelled = 0;
   __block dispatch_block_t cancelLoad = nil;
   dispatch_block_t cancellationBlock = ^{
-    if (cancelLoad && !cancelled) {
-      cancelLoad();
+    dispatch_block_t cancelLoadLocal = cancelLoad;
+    if (cancelLoadLocal && !cancelled) {
+      cancelLoadLocal();
     }
     OSAtomicOr32Barrier(1, &cancelled);
   };


### PR DESCRIPTION
Fixes #10433

The code didn't account for the fact that cancelLoad is set by two different threads. It gets set on the URL request queue when the request completes successfully and it gets set on the UI queue during cancelation. This oversight lead to a couple of different kinds of crashes.

1. Attempt to invoke a nil function -- We check that cancelLoad is non-nil and on the next line we call it. However, cancelLoad could have been set to nil by the other thread between the time it was verified to be non-nil and the time it was called. Consequently, the program will attempt to call nil and crash.

2. Block deallocated while it's executing -- Suppose cancelLoad points to a block, it is verified to be non-nil, and it is successfully invoked. In the middle of executing the block, cancelLoad, the last reference to the block, is set to nil. This causes the block to be deallocated and its captured values to be freed. However, the block continues executing and the next time it attempts to use a captured value, the program will crash because the captured value has already been freed. This explains how the program can crash on `OSAtomicOr32Barrier(1, &cancelled);`: `cancelled` is a captured value that may already have been freed.

**Test plan (required)**

I built a test app which consistently repros this bug: https://github.com/rigdern/RNImageRepro (see the repro steps in the README). After this change, the test app no longer repros the crash.

**Notes**

While working on this code, some of the design intentions were not clear to me.

For example, are the cancelation handlers always supposed to be run on the UI thread? If not and they can be run on multiple threads, I believe it's possible for a cancelation handler to run multiple times (it's not clear to me if that's a bad thing).

Is the scenario allowed where both a completion handler and a cancelation handler run for a singe request? I believe this is possible in the current implementation but I wasn't sure if this was intended.