### PR TITLE
Omit all line terminators for ImageStore.getBase64ForTag

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/modules/camera/ImageStoreManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/camera/ImageStoreManager.java
@@ -79,7 +79,7 @@ public class ImageStoreManager extends ReactContextBaseJavaModule {
         Uri uri = Uri.parse(mUri);
         InputStream is = contentResolver.openInputStream(uri);
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        Base64OutputStream b64os = new Base64OutputStream(baos, Base64.DEFAULT);
+        Base64OutputStream b64os = new Base64OutputStream(baos, Base64.NO_WRAP);
         byte[] buffer = new byte[BUFFER_SIZE];
         int bytesRead;
         try {


### PR DESCRIPTION
ImageStore.getBase64ForTag result should omit the line terminators, and fix #11142

**Test plan (required)**

Manually.
