### PR TITLE
Use Yarn for Install/Uninstall CLI if available

### DIFF
--- a/local-cli/install/install.js
+++ b/local-cli/install/install.js
@@ -27,7 +27,7 @@ function install(args, config) {
     process.exit(res.status);
   }
 
-  res = spawnSync('rnpm', ['link', name], spawnOpts);
+  res = spawnSync('react-native', ['link', name], spawnOpts);
 
   if (res.status) {
     process.exit(res.status);

--- a/local-cli/install/install.js
+++ b/local-cli/install/install.js
@@ -21,7 +21,7 @@ log.heading = 'rnpm-install';
 function install(args, config) {
   const name = args[0];
 
-  let res = PackageManager.add(name)
+  let res = PackageManager.add(name);
 
   if (res.status) {
     process.exit(res.status);

--- a/local-cli/install/install.js
+++ b/local-cli/install/install.js
@@ -1,5 +1,6 @@
 const spawnSync = require('child_process').spawnSync;
 const log = require('npmlog');
+const yarn = require('../util/yarn');
 const spawnOpts = {
   stdio: 'inherit',
   stdin: 'inherit',
@@ -10,7 +11,17 @@ log.heading = 'rnpm-install';
 function install(args, config) {
   const name = args[0];
 
-  var res = spawnSync('npm', ['install', name, '--save'], spawnOpts);
+  const projectDir = config.getProjectRoots()[0];
+  const isYarnAvailable =
+    yarn.getYarnVersionIfAvailable() &&
+    yarn.isGlobalCliUsingYarn(projectDir);
+
+  var res;
+  if (isYarnAvailable) {
+    res = spawnSync('yarn', ['add', name], spawnOpts);
+  } else {
+    res = spawnSync('npm', ['install', name, '--save'], spawnOpts);
+  }
 
   if (res.status) {
     process.exit(res.status);
@@ -23,7 +34,7 @@ function install(args, config) {
   }
 
   log.info(`Module ${name} has been successfully installed & linked`);
-};
+}
 
 module.exports = {
   func: install,

--- a/local-cli/install/install.js
+++ b/local-cli/install/install.js
@@ -1,3 +1,13 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+'use strict';
+
 const spawnSync = require('child_process').spawnSync;
 const log = require('npmlog');
 const yarn = require('../util/yarn');

--- a/local-cli/install/install.js
+++ b/local-cli/install/install.js
@@ -10,7 +10,7 @@
 
 const spawnSync = require('child_process').spawnSync;
 const log = require('npmlog');
-const yarn = require('../util/yarn');
+const PackageManager = require('../util/PackageManager');
 const spawnOpts = {
   stdio: 'inherit',
   stdin: 'inherit',
@@ -21,17 +21,7 @@ log.heading = 'rnpm-install';
 function install(args, config) {
   const name = args[0];
 
-  const projectDir = process.cwd();
-  const isYarnAvailable =
-    yarn.getYarnVersionIfAvailable() &&
-    yarn.isGlobalCliUsingYarn(projectDir);
-
-  let res;
-  if (isYarnAvailable) {
-    res = spawnSync('yarn', ['add', name], spawnOpts);
-  } else {
-    res = spawnSync('npm', ['install', name, '--save'], spawnOpts);
-  }
+  let res = PackageManager.add(name)
 
   if (res.status) {
     process.exit(res.status);

--- a/local-cli/install/install.js
+++ b/local-cli/install/install.js
@@ -11,12 +11,12 @@ log.heading = 'rnpm-install';
 function install(args, config) {
   const name = args[0];
 
-  const projectDir = config.getProjectRoots()[0];
+  const projectDir = process.cwd();
   const isYarnAvailable =
     yarn.getYarnVersionIfAvailable() &&
     yarn.isGlobalCliUsingYarn(projectDir);
 
-  var res;
+  let res;
   if (isYarnAvailable) {
     res = spawnSync('yarn', ['add', name], spawnOpts);
   } else {

--- a/local-cli/install/uninstall.js
+++ b/local-cli/install/uninstall.js
@@ -21,7 +21,7 @@ log.heading = 'rnpm-install';
 function uninstall(args, config) {
   const name = args[0];
 
-  var res = spawnSync('rnpm', ['unlink', name], spawnOpts);
+  var res = spawnSync('react-native', ['unlink', name], spawnOpts);
 
   if (res.status) {
     process.exit(res.status);

--- a/local-cli/install/uninstall.js
+++ b/local-cli/install/uninstall.js
@@ -11,7 +11,7 @@ log.heading = 'rnpm-install';
 function uninstall(args, config) {
   const name = args[0];
 
-  const projectDir = config.getProjectRoots()[0];
+  const projectDir = process.cwd();
   const isYarnAvailable =
     yarn.getYarnVersionIfAvailable() &&
     yarn.isGlobalCliUsingYarn(projectDir);

--- a/local-cli/install/uninstall.js
+++ b/local-cli/install/uninstall.js
@@ -27,7 +27,7 @@ function uninstall(args, config) {
     process.exit(res.status);
   }
 
-  res = PackageManager.remove(name)
+  res = PackageManager.remove(name);
 
   if (res.status) {
     process.exit(res.status);

--- a/local-cli/install/uninstall.js
+++ b/local-cli/install/uninstall.js
@@ -10,7 +10,7 @@
 
 const spawnSync = require('child_process').spawnSync;
 const log = require('npmlog');
-const yarn = require('../util/yarn');
+const PackageManager = require('../util/PackageManager');
 const spawnOpts = {
   stdio: 'inherit',
   stdin: 'inherit',
@@ -21,22 +21,13 @@ log.heading = 'rnpm-install';
 function uninstall(args, config) {
   const name = args[0];
 
-  const projectDir = process.cwd();
-  const isYarnAvailable =
-    yarn.getYarnVersionIfAvailable() &&
-    yarn.isGlobalCliUsingYarn(projectDir);
-
   var res = spawnSync('rnpm', ['unlink', name], spawnOpts);
 
   if (res.status) {
     process.exit(res.status);
   }
 
-  if (isYarnAvailable) {
-    res = spawnSync('yarn', ['remove', name], spawnOpts);
-  } else {
-    res = spawnSync('npm', ['uninstall', name], spawnOpts);
-  }
+  res = PackageManager.remove(name)
 
   if (res.status) {
     process.exit(res.status);

--- a/local-cli/install/uninstall.js
+++ b/local-cli/install/uninstall.js
@@ -1,3 +1,13 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+'use strict';
+
 const spawnSync = require('child_process').spawnSync;
 const log = require('npmlog');
 const yarn = require('../util/yarn');

--- a/local-cli/install/uninstall.js
+++ b/local-cli/install/uninstall.js
@@ -1,5 +1,6 @@
 const spawnSync = require('child_process').spawnSync;
 const log = require('npmlog');
+const yarn = require('../util/yarn');
 const spawnOpts = {
   stdio: 'inherit',
   stdin: 'inherit',
@@ -10,20 +11,29 @@ log.heading = 'rnpm-install';
 function uninstall(args, config) {
   const name = args[0];
 
+  const projectDir = config.getProjectRoots()[0];
+  const isYarnAvailable =
+    yarn.getYarnVersionIfAvailable() &&
+    yarn.isGlobalCliUsingYarn(projectDir);
+
   var res = spawnSync('rnpm', ['unlink', name], spawnOpts);
 
   if (res.status) {
     process.exit(res.status);
   }
 
-  res = spawnSync('npm', ['uninstall', name], spawnOpts);
+  if (isYarnAvailable) {
+    res = spawnSync('yarn', ['remove', name], spawnOpts);
+  } else {
+    res = spawnSync('npm', ['uninstall', name], spawnOpts);
+  }
 
   if (res.status) {
     process.exit(res.status);
   }
 
   log.info(`Module ${name} has been successfully uninstalled & unlinked`);
-};
+}
 
 module.exports = {
   func: uninstall,

--- a/local-cli/link/link.js
+++ b/local-cli/link/link.js
@@ -141,7 +141,11 @@ function link(args, config) {
     return Promise.reject(err);
   }
 
-  const packageName = args[0];
+  let packageName = args[0];
+  // Check if install package by specific version (eg. package@latest)
+  if (packageName !== undefined) {
+    packageName = packageName.split('@')[0];
+  }
 
   const dependencies = getDependencyConfig(
     config,

--- a/local-cli/util/PackageManager.js
+++ b/local-cli/util/PackageManager.js
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+'use strict';
+
+const spawnSync = require('child_process').spawnSync;
+const yarn = require('../util/yarn');
+const spawnOpts = {
+  stdio: 'inherit',
+  stdin: 'inherit',
+};
+
+const projectDir = process.cwd();
+const isYarnAvailable =
+  yarn.getYarnVersionIfAvailable() &&
+  yarn.isGlobalCliUsingYarn(projectDir);
+
+/**
+ * Execute npm or yarn command
+ *
+ * @param  {String} yarnCommand Yarn command to be executed eg. yarn add package
+ * @param  {String} npmCommand  Npm command to be executed eg. npm install package
+ * @return {object}             spawnSync's result object
+ */
+function callYarnOrNpm(yarnCommand, npmCommand) {
+  let command;
+
+  if (isYarnAvailable) {
+    command = yarnCommand;
+  } else {
+    command = npmCommand;
+  }
+
+  const args = command.split(' ');
+  const cmd = args.shift();
+
+  const res = spawnSync(cmd, args, spawnOpts);
+
+  return res;
+}
+
+/**
+ * Install package into project using npm or yarn if available
+ * @param  {[type]} packageName Package to be installed
+ * @return {[type]}             spawnSync's result object
+ */
+function add(packageName) {
+  return callYarnOrNpm(
+    `yarn add ${packageName}`,
+    `npm install ${packageName} --save`
+  );
+}
+
+/**
+ * Uninstall package from project using npm or yarn if available
+ * @param  {[type]} packageName Package to be uninstalled
+ * @return {Object}             spawnSync's result object
+ */
+function remove(packageName) {
+  return callYarnOrNpm(
+    `yarn remove ${packageName}`,
+    `npm uninstall --save ${packageName}`
+  );
+}
+
+module.exports = {
+  add: add,
+  remove: remove,
+};


### PR DESCRIPTION
Make `react-native install` and `uninstall` cli to use yarn if available (fixes #11122)

**Test plan Yarn**

1. Publish to Sinopia: https://github.com/facebook/react-native/tree/master/react-native-cli
2. react-native init AwesomeApp
3. react-native install react-native-fit-image 
4. react-native uninstall react-native-fit-image

**Test plan NPM**
1. Publish to Sinopia: https://github.com/facebook/react-native/tree/master/react-native-cli
2. react-native init AwesomeAppNPM --npm
3. react-native install react-native-fit-image
4. react-native uninstall react-native-fit-image

**output (yarn.lock)**
 
```
> react-native install react-native-fit-image 
yarn add v0.16.1
[1/4] 🔍  Resolving packages...
[2/4] 🚚  Fetching packages...
[3/4] 🔗  Linking dependencies...
[4/4] 📃  Building fresh packages...
success Saved lockfile.
success Saved 1 new dependency
└─ react-native-fit-image@1.4.6
✨  Done in 4.11s.
rnpm-install info Module react-native-fit-image has been successfully installed & linked 
```

```
> react-native uninstall react-native-fit-image
yarn remove v0.16.1
[1/2] Removing module react-native-fit-image...
[2/2] Regenerating lockfile and installing missing dependencies...
success Uninstalled packages.
✨  Done in 3.32s.
rnpm-install info Module react-native-fit-image has been successfully uninstalled & unlinked 
```

**output (without yarn.lock)**

```
› react-native install react-native-fit-image 
TestApp@0.0.1 /Users/n3tr/Code/TestApp
└── react-native-fit-image@1.4.6 

rnpm-install info Module react-native-fit-image has been successfully installed & linked 
```

```
› react-native uninstall react-native-fit-image
- react-native-fit-image@1.4.6 node_modules/react-native-fit-image
rnpm-install info Module react-native-fit-image has been successfully uninstalled & unlinked 
```

