### PR TITLE
Copy over code from RCTView to allow individual image border radii

### DIFF
--- a/Examples/UIExplorer/js/ImageExample.js
+++ b/Examples/UIExplorer/js/ImageExample.js
@@ -351,6 +351,10 @@ exports.examples = [
             style={[styles.base, styles.leftMargin, {borderRadius: 19}]}
             source={fullImage}
           />
+          <Image
+            style={[styles.base, styles.leftMargin, {borderTopLeftRadius: 10}]}
+            source={fullImage}
+          />
         </View>
       );
     },

--- a/Libraries/Image/RCTImageView.h
+++ b/Libraries/Image/RCTImageView.h
@@ -25,4 +25,36 @@
 @property (nonatomic, assign) CGFloat blurRadius;
 @property (nonatomic, assign) RCTResizeMode resizeMode;
 
+/**
+ * Border radii.
+ */
+@property (nonatomic, assign) CGFloat borderRadius;
+@property (nonatomic, assign) CGFloat borderTopLeftRadius;
+@property (nonatomic, assign) CGFloat borderTopRightRadius;
+@property (nonatomic, assign) CGFloat borderBottomLeftRadius;
+@property (nonatomic, assign) CGFloat borderBottomRightRadius;
+
+/**
+ * Border colors (actually retained).
+ */
+@property (nonatomic, assign) CGColorRef borderTopColor;
+@property (nonatomic, assign) CGColorRef borderRightColor;
+@property (nonatomic, assign) CGColorRef borderBottomColor;
+@property (nonatomic, assign) CGColorRef borderLeftColor;
+@property (nonatomic, assign) CGColorRef borderColor;
+
+/**
+ * Border widths.
+ */
+@property (nonatomic, assign) CGFloat borderTopWidth;
+@property (nonatomic, assign) CGFloat borderRightWidth;
+@property (nonatomic, assign) CGFloat borderBottomWidth;
+@property (nonatomic, assign) CGFloat borderLeftWidth;
+@property (nonatomic, assign) CGFloat borderWidth;
+
+/**
+ * Border styles.
+ */
+@property (nonatomic, assign) RCTBorderStyle borderStyle;
+
 @end

--- a/Libraries/Image/RCTImageView.m
+++ b/Libraries/Image/RCTImageView.m
@@ -534,8 +534,6 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
     return;
   }
 
-//  RCTUpdateShadowPathForView(self);
-
   const RCTCornerRadii cornerRadii = [self cornerRadii];
   const UIEdgeInsets borderInsets = [self bordersAsInsets];
   const RCTBorderColors borderColors = [self borderColors];
@@ -561,7 +559,6 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
     layer.cornerRadius = cornerRadii.topLeft;
     layer.borderColor = borderColors.left;
     layer.borderWidth = borderInsets.left;
-//    layer.backgroundColor = _backgroundColor.CGColor;
     layer.contents = nil;
     layer.needsDisplayOnBoundsChange = NO;
     layer.mask = nil;
@@ -631,31 +628,6 @@ static BOOL RCTLayerHasShadow(CALayer *layer)
     self.backgroundColor = inheritedBackgroundColor;
   }
 }
-
-//static void RCTUpdateShadowPathForView(RCTView *view)
-//{
-//  if (RCTLayerHasShadow(view.layer)) {
-//    if (CGColorGetAlpha(view.backgroundColor.CGColor) > 0.999) {
-//
-//      // If view has a solid background color, calculate shadow path from border
-//      const RCTCornerRadii cornerRadii = [view cornerRadii];
-//      const RCTCornerInsets cornerInsets = RCTGetCornerInsets(cornerRadii, UIEdgeInsetsZero);
-//      CGPathRef shadowPath = RCTPathCreateWithRoundedRect(view.bounds, cornerInsets, NULL);
-//      view.layer.shadowPath = shadowPath;
-//      CGPathRelease(shadowPath);
-//
-//    } else {
-//
-//      // Can't accurately calculate box shadow, so fall back to pixel-based shadow
-//      view.layer.shadowPath = nil;
-//
-//      RCTLogWarn(@"View #%@ of type %@ has a shadow set but cannot calculate "
-//                 "shadow efficiently. Consider setting a background color to "
-//                 "fix this, or apply the shadow to a more specific component.",
-//                 view.reactTag, [view class]);
-//    }
-//  }
-//}
 
 - (void)updateClippingForLayer:(CALayer *)layer
 {

--- a/Libraries/Image/RCTImageViewManager.m
+++ b/Libraries/Image/RCTImageViewManager.m
@@ -101,7 +101,6 @@ RCT_VIEW_BORDER_PROPERTY(Left)
 #define RCT_VIEW_BORDER_RADIUS_PROPERTY(SIDE)                           \
 RCT_CUSTOM_VIEW_PROPERTY(border##SIDE##Radius, CGFloat, RCTImageView)   \
 {                                                                       \
-  NSLog(@"SET ##SIDE## RADIUS: %@", json); \
   if ([view respondsToSelector:@selector(setBorder##SIDE##Radius:)]) {  \
     view.border##SIDE##Radius = json ? [RCTConvert CGFloat:json] : defaultView.border##SIDE##Radius; \
   }                                                                     \

--- a/Libraries/Image/RCTImageViewManager.m
+++ b/Libraries/Image/RCTImageViewManager.m
@@ -79,4 +79,43 @@ RCT_EXPORT_METHOD(prefetchImage:(NSURLRequest *)request
                                           }];
 }
 
+#define RCT_VIEW_BORDER_PROPERTY(SIDE)                                  \
+RCT_CUSTOM_VIEW_PROPERTY(border##SIDE##Width, float, RCTImageView)      \
+{                                                                       \
+  if ([view respondsToSelector:@selector(setBorder##SIDE##Width:)]) {   \
+    view.border##SIDE##Width = json ? [RCTConvert CGFloat:json] : defaultView.border##SIDE##Width; \
+  }                                                                     \
+}                                                                       \
+RCT_CUSTOM_VIEW_PROPERTY(border##SIDE##Color, UIColor, RCTImageView)    \
+{                                                                       \
+  if ([view respondsToSelector:@selector(setBorder##SIDE##Color:)]) {   \
+    view.border##SIDE##Color = json ? [RCTConvert CGColor:json] : defaultView.border##SIDE##Color; \
+  }                                                                     \
+}
+
+RCT_VIEW_BORDER_PROPERTY(Top)
+RCT_VIEW_BORDER_PROPERTY(Right)
+RCT_VIEW_BORDER_PROPERTY(Bottom)
+RCT_VIEW_BORDER_PROPERTY(Left)
+
+#define RCT_VIEW_BORDER_RADIUS_PROPERTY(SIDE)                           \
+RCT_CUSTOM_VIEW_PROPERTY(border##SIDE##Radius, CGFloat, RCTImageView)   \
+{                                                                       \
+  NSLog(@"SET ##SIDE## RADIUS: %@", json); \
+  if ([view respondsToSelector:@selector(setBorder##SIDE##Radius:)]) {  \
+    view.border##SIDE##Radius = json ? [RCTConvert CGFloat:json] : defaultView.border##SIDE##Radius; \
+  }                                                                     \
+}                                                                       \
+
+RCT_VIEW_BORDER_RADIUS_PROPERTY(TopLeft)
+RCT_VIEW_BORDER_RADIUS_PROPERTY(TopRight)
+RCT_VIEW_BORDER_RADIUS_PROPERTY(BottomLeft)
+RCT_VIEW_BORDER_RADIUS_PROPERTY(BottomRight)
+
+RCT_EXPORT_SHADOW_PROPERTY(borderTopWidth, float)
+RCT_EXPORT_SHADOW_PROPERTY(borderRightWidth, float)
+RCT_EXPORT_SHADOW_PROPERTY(borderBottomWidth, float)
+RCT_EXPORT_SHADOW_PROPERTY(borderLeftWidth, float)
+RCT_EXPORT_SHADOW_PROPERTY(borderWidth, float)
+
 @end


### PR DESCRIPTION
This *works*. It’s not the best solution for this, and I think we need to consider how we handle UIView superclasses. This is mostly a demonstration to show what I want to achieve, but I will need guidance on how this should best be implemented.

This implementation is just copying over the code from UIView.m.

![screen shot 2016-11-28 at 20 30 17](https://cloud.githubusercontent.com/assets/7275322/20684829/a4c89092-b5a9-11e6-925b-d54f5b10de06.png)