### PR TITLE
Remove unused var in NativeAnimatedNodesManager

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/animated/NativeAnimatedNodesManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/animated/NativeAnimatedNodesManager.java
@@ -480,7 +480,6 @@ import javax.annotation.Nullable;
     // Cleanup finished animations. Iterate over the array of animations and override ones that has
     // finished, then resize `mActiveAnimations`.
     if (hasFinishedAnimations) {
-      int dest = 0;
       for (int i = mActiveAnimations.size() - 1; i >= 0; i--) {
         AnimationDriver animation = mActiveAnimations.valueAt(i);
         if (animation.mHasFinished) {


### PR DESCRIPTION
Should have been removed in https://github.com/facebook/react-native/commit/6f5433febe2c6dab5cc7b5799db7b95fc9992a11#commitcomment-19793695.

Simple enough fix.

cc/ @janicduplessis 