### PR TITLE
[cli][git_upgrade] More accurate check for latest version

### DIFF
--- a/react-native-git-upgrade/checks.js
+++ b/react-native-git-upgrade/checks.js
@@ -22,8 +22,8 @@ function checkDeclaredVersion(declaredVersion) {
 function checkMatchingVersions(currentVersion, declaredVersion) {
   if (!semver.satisfies(currentVersion, declaredVersion)) {
     throw new Error(
-      'react-native version in "package.json" doesn\'t match ' +
-      'the installed version in "node_modules".\n' +
+      'react-native version in "package.json" (' + declaredVersion + ') doesn\'t match ' +
+      'the installed version in "node_modules" (' + currentVersion + ').\n' +
       'Try running "npm install" to fix this.'
     );
   }


### PR DESCRIPTION
When testing `react-native-git-upgrade` locally I noticed a warning:

    A more recent version of "react-native-git-upgrade" has been found:
    Current: 0.1.0
    Latest: 0.0.1

See https://www.npmjs.com/package/react-native-git-upgrade

This won't happen to a lot of people but better fix the warning. Also, if the check for updates fails, don't crash - the check for updates is not critical to the tool working.

Also, slightly updated one error message.

**Test plan (required)**

Installed `react-native-git-upgrade` locally, ran it inside an app folder (RN 0.29).

Didn't see the wrong "more recent version" warning anymore.

Tried making `checkForUpdates` fail by adding some dummy code: `semver.foo()`. Saw a warning but the process continued:

    git-upgrade WARN Check for latest version failed semver.foo is not a function

Saw a more descriptive error message:

    git-upgrade ERR! Error: react-native version in "package.json" (0.29.0) doesn't match the installed version in "node_modules" (0.38.0).

