### PR TITLE
Change gesture direction strings in NavigatorSceneConfigs

### DIFF
--- a/Libraries/CustomComponents/Navigator/NavigatorSceneConfigs.js
+++ b/Libraries/CustomComponents/Navigator/NavigatorSceneConfigs.js
@@ -534,13 +534,13 @@ var BaseRightToLeftGesture = {
 var BaseDownUpGesture = {
   ...BaseLeftToRightGesture,
   fullDistance: SCREEN_HEIGHT,
-  direction: 'down-to-up',
+  direction: 'bottom-to-top',
 };
 
 var BaseUpDownGesture = {
   ...BaseLeftToRightGesture,
   fullDistance: SCREEN_HEIGHT,
-  direction: 'up-to-down',
+  direction: 'top-to-bottom',
 };
 
 // For RTL experiment, we need to swap all the Left and Right gesture and animation.


### PR DESCRIPTION
I see there is a string matching inconsistency in  `Libraries/CustomComponents/Navigator/Navigator.js` and `Libraries/CustomComponents/Navigator/NavigatorSceneConfigs.js`, which caused a bug resulting in gestures not working for vertical SceneConfigs. This PR fixes the inconsistency, and the bug. 

**Motivation for making this change**
When working with the navigator, I was using the `VerticalUpSwipeJump` Navigator SceneConfig. The gesture to pop to the previous scene (in this case `jumpBack`) was not working. 

**How I tested?**
I changed these strings (as shown in this PR) and swiped down. After these changes, everything worked as expected. 

**Example**
In `Libraries/CustomComponents/Navigator/Navigator.js`, we check for gesture direction strings `bottom-to-top` and `top-to-bottom` in multiple places, but nowhere do we ever check for `up-to-down` and `down-to-up`.

```
var isTravelVertical = gesture.direction === 'top-to-bottom' || gesture.direction === 'bottom-to-top';
var isTravelInverted = gesture.direction === 'right-to-left' || gesture.direction === 'bottom-to-top';
```

