### PR TITLE
Android: Enable ad-hoc dependencies to be pre-downloaded

### DIFF
--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -16,10 +16,18 @@ import org.apache.tools.ant.filters.ReplaceTokens
 def downloadsDir = new File("$buildDir/downloads")
 def thirdPartyNdkDir = new File("$buildDir/third-party-ndk")
 
+// You need to have following folders in this directory:
+//   - boost_1_57_0
+//   - double-conversion-1.1.1
+//   - folly-deprecate-dynamic-initializer
+//   - glog-0.3.3
+//   - jsc-headers
+def dependenciesPath = System.getenv("REACT_NATIVE_DEPENDENCIES")
+
 // The Boost library is a very large download (>100MB).
 // If Boost is already present on your system, define the REACT_NATIVE_BOOST_PATH env variable
 // and the build will use that.
-def boostPath = System.getenv("REACT_NATIVE_BOOST_PATH")
+def boostPath = dependenciesPath ?: System.getenv("REACT_NATIVE_BOOST_PATH")
 
 task createNativeDepsDirectories {
     downloadsDir.mkdirs()
@@ -37,7 +45,7 @@ task downloadBoost(dependsOn: createNativeDepsDirectories, type: Download) {
 }
 
 task prepareBoost(dependsOn: boostPath ? [] : [downloadBoost], type: Copy) {
-    from boostPath ? boostPath : zipTree(downloadBoost.dest)
+    from boostPath ?: zipTree(downloadBoost.dest)
     from 'src/main/jni/third-party/boost/Android.mk'
     include 'boost_1_57_0/boost/**/*.hpp', 'Android.mk'
     into "$thirdPartyNdkDir/boost"
@@ -50,8 +58,8 @@ task downloadDoubleConversion(dependsOn: createNativeDepsDirectories, type: Down
     dest new File(downloadsDir, 'double-conversion-1.1.1.tar.gz')
 }
 
-task prepareDoubleConversion(dependsOn: downloadDoubleConversion, type: Copy) {
-    from tarTree(downloadDoubleConversion.dest)
+task prepareDoubleConversion(dependsOn: dependenciesPath ? [] : [downloadDoubleConversion], type: Copy) {
+    from dependenciesPath ?: tarTree(downloadDoubleConversion.dest)
     from 'src/main/jni/third-party/double-conversion/Android.mk'
     include 'double-conversion-1.1.1/src/**/*', 'Android.mk'
     filesMatching('*/src/**/*', {fname -> fname.path = "double-conversion/${fname.name}"})
@@ -66,8 +74,8 @@ task downloadFolly(dependsOn: createNativeDepsDirectories, type: Download) {
     dest new File(downloadsDir, 'folly-2016.09.26.00.tar.gz');
 }
 
-task prepareFolly(dependsOn: downloadFolly, type: Copy) {
-    from tarTree(downloadFolly.dest)
+task prepareFolly(dependsOn: dependenciesPath ? [] : [downloadFolly], type: Copy) {
+    from dependenciesPath ?: tarTree(downloadFolly.dest)
     from 'src/main/jni/third-party/folly/Android.mk'
     include 'folly-2016.09.26.00/folly/**/*', 'Android.mk'
     eachFile {fname -> fname.path = (fname.path - "folly-2016.09.26.00/")}
@@ -84,8 +92,8 @@ task downloadGlog(dependsOn: createNativeDepsDirectories, type: Download) {
 
 // Prepare glog sources to be compiled, this task will perform steps that normally should've been
 // executed by automake. This way we can avoid dependencies on make/automake
-task prepareGlog(dependsOn: downloadGlog, type: Copy) {
-    from tarTree(downloadGlog.dest)
+task prepareGlog(dependsOn: dependenciesPath ? [] : [downloadGlog], type: Copy) {
+    from dependenciesPath ?: tarTree(downloadGlog.dest)
     from 'src/main/jni/third-party/glog/'
     include 'glog-0.3.3/src/**/*', 'Android.mk', 'config.h'
     includeEmptyDirs = false
@@ -124,10 +132,10 @@ task downloadJSCHeaders(type: Download) {
 }
 
 // Create Android.mk library module based on so files from mvn + include headers fetched from webkit.org
-task prepareJSC(dependsOn: downloadJSCHeaders) << {
+task prepareJSC(dependsOn: dependenciesPath ? [] : [downloadJSCHeaders]) << {
     copy {
         from zipTree(configurations.compile.fileCollection { dep -> dep.name == 'android-jsc' }.singleFile)
-        from {downloadJSCHeaders.dest}
+        from dependenciesPath ? "$dependenciesPath/jsc-headers" : {downloadJSCHeaders.dest}
         from 'src/main/jni/third-party/jsc/Android.mk'
         include 'jni/**/*.so', '*.h', 'Android.mk'
         filesMatching('*.h', { fname -> fname.path = "JavaScriptCore/${fname.path}"})


### PR DESCRIPTION
ReactAndroid/build.gradle downloads a number of ad-hoc dependencies from the internet such as boost, JSC headers, and folly. Having the build depend on the internet is problematic. For example, if the site hosting the JSC headers was to go down, then CI builds would start failing.

This change introduces the environment variable REACT_NATIVE_DEPENDENCIES which refers to a path. Developers can pre-download all of the ad-hoc dependencies into that path and then the build process will grab the dependencies from that local path rather than trying to download them from the internet. This solution is in the spirit of the existing REACT_NATIVE_BOOST_PATH hook.

**Test plan (required)**

This change is used by my team's app.

Adam Comella
Microsoft Corp.