### PR TITLE
[jest] Fix missing mock for StatusBarManager

### DIFF
--- a/jest/setup.js
+++ b/jest/setup.js
@@ -128,6 +128,7 @@ const mockNativeModules = {
   SourceCode: {
     scriptURL: null,
   },
+  StatusBarManager: {},
   Timing: {
     createTimer: jest.fn(),
     deleteTimer: jest.fn(),


### PR DESCRIPTION
Fix an issue when running Jest unit tests due to a missing mock for StatusBarManger. 

**More info:**
In one of my files I have:
```
export const STATUS_BAR_HEIGHT = (StatusBar.currentHeight || 0);
```
When I run the tests it gives this error, which seems to be because StatusBarManager is undefined (https://github.com/facebook/react-native/blob/master/Libraries/Components/StatusBar/StatusBar.js#L20)

```
TypeError: Cannot read property 'HEIGHT' of undefined      
  at Object.<anonymous> (node_modules/react-native/Libraries/Components/StatusBar/StatusBar.js:395:1823)
  at Object.StatusBar (node_modules/react-native/Libraries/react-native/react-native.js:55:24)
```

**Test plan (required)**
Verify that with this change tests that use StatusBar pass.