### PR TITLE
[jest] Add missing mock for AppState

### DIFF
--- a/jest/setup.js
+++ b/jest/setup.js
@@ -70,6 +70,9 @@ const mockNativeModules = {
   AlertManager: {
     alertWithArgs: jest.fn(),
   },
+  AppState: {
+    addEventListener: jest.fn(),
+  },
   AsyncLocalStorage: {
     clear: jest.fn(),
     getItem: jest.fn(),


### PR DESCRIPTION
**Description**

In the same vein as https://github.com/facebook/react-native/pull/11198, this adds a mock for the native module `AppState`.

**Test plan**

Create a component that uses `AppState`, e.g.

```jsx
import React, { Component } from 'react';
import { AppState } from 'react-native';

class TestComponent extends Component {
  componentDidMount() {
    AppState.addEventListener('change', this.stateChangeListener);
  }
}
```