### PR TITLE
Update JDK download link for Mac OS Android set up

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -160,7 +160,7 @@ Setting up your development environment can be somewhat tedious if you're new to
 
 <block class="mac android" />
 
-> Android Studio requires the [Java Development Kit (JDK)](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html), version 1.8 or higher. You can type `javac -version` in a terminal to see what version you have, if any.
+> Android Studio requires the [Java Development Kit (JDK)](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html), version 8 or higher. You can type `javac -version` in a terminal to see what version you have, if any.
 
 <block class="mac windows android" />
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -160,7 +160,14 @@ Setting up your development environment can be somewhat tedious if you're new to
 
 <block class="mac android" />
 
-> Android Studio requires the [Java Development Kit (JDK)](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html), version 8 or higher. You can type `javac -version` in a terminal to see what version you have, if any.
+> Android Studio requires the [Java SE Development Kit(JDK)](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html), version 8. You can type `javac -version` in a terminal to see what version you have, if any.
+
+```
+$ javac -version
+javac 1.8.0_111
+```
+
+> The version string `1.8.x_xxx` corresponds to JDK 8.
 
 <block class="mac windows android" />
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -160,7 +160,7 @@ Setting up your development environment can be somewhat tedious if you're new to
 
 <block class="mac android" />
 
-> Android Studio requires the [Java Development Kit (JDK)](https://www.java.com/en/download/mac_download.jsp), version 1.8 or higher. You can type `javac -version` in a terminal to see what version you have, if any.
+> Android Studio requires the [Java Development Kit (JDK)](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html), version 1.8 or higher. You can type `javac -version` in a terminal to see what version you have, if any.
 
 <block class="mac windows android" />
 


### PR DESCRIPTION
*First PR to React Native.*

After performing a clean install of macOS Sierra on my machine I tried to get RN set up again and noticed that the link provided for installing Java (required by Android Studio) pointed to the [wrong location](https://www.java.com/en/download/mac_download.jsp). After some time researching I found the right package required by Android Studio [here](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html).

I tried looking for a more general link (as this points to the JDK version 8 and has a weird path: _jdk8-downloads-2133151.html_ - Sadly this was the best I could find.

I also looked through listed issues to try and find a previous attempt to fix this error but couldn't find any references, sorry if I missed anything.

**TL;DR:** JDK download link is incorrect, PR updates it to the correct one.