### PR TITLE
[Android] Call handleUpdateLayout even if the content didn't change

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactShadowNode.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactShadowNode.java
@@ -286,23 +286,10 @@ public class ReactShadowNode {
     }
 
     if (hasNewLayout()) {
-      float newLeft = Math.round(absoluteX + getLayoutX());
-      float newTop = Math.round(absoluteY + getLayoutY());
-      float newRight = Math.round(absoluteX + getLayoutX() + getLayoutWidth());
-      float newBottom = Math.round(absoluteY + getLayoutY() + getLayoutHeight());
-
-      if (newLeft == mAbsoluteLeft &&
-          newRight == mAbsoluteRight &&
-          newTop == mAbsoluteTop &&
-          newBottom == mAbsoluteBottom) {
-        return false;
-      }
-
-      mAbsoluteLeft = newLeft;
-      mAbsoluteTop = newTop;
-      mAbsoluteRight = newRight;
-      mAbsoluteBottom = newBottom;
-
+      mAbsoluteLeft = Math.round(absoluteX + getLayoutX());
+      mAbsoluteTop = Math.round(absoluteY + getLayoutY());
+      mAbsoluteRight = Math.round(absoluteX + getLayoutX() + getLayoutWidth());
+      mAbsoluteBottom = Math.round(absoluteY + getLayoutY() + getLayoutHeight());
       nativeViewHierarchyOptimizer.handleUpdateLayout(this);
       return true;
     } else {


### PR DESCRIPTION
This PR fixes #11096.

I don't know enough the ReactAndroid's source code so I don't know if this is correct but I hope it is.

In a recent commit (https://github.com/facebook/react-native/commit/d4b8ae7a8a3de314b5813e0bfcdf5fb265129d43), the `dispatchUpdates` method now returns a boolean to dispatch or not the `onLayout` event. This works well but if the content is unchanged, the line `nativeViewHierarchyOptimizer.handleUpdateLayout(this);` is never called. I don't know if it was intended but it was this which introduces my issue. I called this again even if the content didn't change. This was the behaviour before 0.38 so I guess I didn't break anything.

**Test plan (required)**

I tested my pretty big app with this fix and every screen is ok.
