### PR TITLE
[cli][upgrade] Use Yarn if available

### DIFF
--- a/react-native-git-upgrade/checks.js
+++ b/react-native-git-upgrade/checks.js
@@ -19,12 +19,14 @@ function checkDeclaredVersion(declaredVersion) {
   }
 }
 
-function checkMatchingVersions(currentVersion, declaredVersion) {
+function checkMatchingVersions(currentVersion, declaredVersion, useYarn) {
   if (!semver.satisfies(currentVersion, declaredVersion)) {
     throw new Error(
       'react-native version in "package.json" (' + declaredVersion + ') doesn\'t match ' +
       'the installed version in "node_modules" (' + currentVersion + ').\n' +
-      'Try running "npm install" to fix this.'
+      (useYarn ?
+        'Try running "yarn" to fix this.' :
+        'Try running "npm install" to fix this.')
     );
   }
 }

--- a/react-native-git-upgrade/index.js
+++ b/react-native-git-upgrade/index.js
@@ -27,7 +27,8 @@ if (argv._.length === 0 && (argv.h || argv.help)) {
     '',
     '    -h, --help    output usage information',
     '    -v, --version output the version number',
-    '    --verbose output',
+    '    --verbose output debugging info',
+    '    --npm force using the npm client even if your project uses yarn',
     '',
   ].join('\n'));
   process.exit(0);

--- a/react-native-git-upgrade/yarn.js
+++ b/react-native-git-upgrade/yarn.js
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const semver = require('semver');
+
+/**
+ * Use Yarn if available, it's much faster than the npm client.
+ * Return the version of yarn installed on the system, null if yarn is not available.
+ */
+function getYarnVersionIfAvailable() {
+  let yarnVersion;
+  try {
+    // execSync returns a Buffer -> convert to string
+    if (process.platform.startsWith('win')) {
+      yarnVersion = (execSync('yarn --version').toString() || '').trim();
+    } else {
+      yarnVersion = (execSync('yarn --version 2>/dev/null').toString() || '').trim();
+    }
+  } catch (error) {
+    return null;
+  }
+  // yarn < 0.16 has a 'missing manifest' bug
+  try {
+    if (semver.gte(yarnVersion, '0.16.0')) {
+      return yarnVersion;
+    } else {
+      return null;
+    }
+  } catch (error) {
+    console.error('Cannot parse yarn version: ' + yarnVersion);
+    return null;
+  }
+}
+
+/**
+ * Check that 'react-native init' itself used yarn to install React Native.
+ * When using an old global react-native-cli@1.0.0 (or older), we don't want
+ * to install React Native with npm, and React + Jest with yarn.
+ * Let's be safe and not mix yarn and npm in a single project.
+ * @param projectDir e.g. /Users/martin/AwesomeApp
+ */
+function isProjectUsingYarn(projectDir) {
+  return fs.existsSync(path.join(projectDir, 'yarn.lock'));
+}
+
+module.exports = {
+  getYarnVersionIfAvailable: getYarnVersionIfAvailable,
+  isProjectUsingYarn: isProjectUsingYarn,
+};


### PR DESCRIPTION
**Motivation**

If the project is using yarn to manage its dependencies, we should be running 'yarn add' to upgrade the React Native dependency, rather than 'npm install'.

**Test plan (required)**

Running in a project that's in a bad state:

    Error: react-native version in "package.json" (0.29.2) doesn't match the installed version in "node_modules" (0.38.0).
    Try running "yarn" to fix this.

Removed yarn.lock file, ran again:

    Error: react-native version in "package.json" (0.29.2) doesn't match the installed version in "node_modules" (0.38.0).
    Try running "npm install" to fix this.

Running inside a folder that doesn't contain a `package.json` file:

    Error: Unable to find "/Users/mkonicek/Zero29App/package.json" or "/Users/mkonicek/Zero29App/node_modules/react-native/package.json". Make sure you ran "yarn" and that you are inside a React Native project.

Removed yarn.lock file, ran again:

    Error: Unable to find "/Users/mkonicek/Zero29App/package.json" or "/Users/mkonicek/Zero29App/node_modules/react-native/package.json". Make sure you ran "npm install" and that you are inside a React Native project.

Success case:

Before, `package.json` contains:

    "dependencies": {
      "react": "15.2.1",
      "react-native": "0.29.2"
    }

Ran `react-native-git-upgrade` in project folder:

The app iupgr
Logs:

    git-upgrade info Check for updates
    git-upgrade info Using yarn 0.17.8
    ...
    git-upgrade info Install the new version 
    ...
    git-upgrade info Upgrade done

`package.json` contains:

    "dependencies": {
      "react": "15.2.1",
      "react-native": "^0.38.0"
    }

`node_modules/react-native/package.json` contains `"version": "0.38.0"`.

Removed `.yarn.lock` file, the react-native-git-upgrade tool worked as before (without this PR).

Ran `react-native-git-upgrade --help`:

    Usage: react-native-git-upgrade [version] [options]


    Commands:

    [Version]     upgrades React Native and app templates to the desired version
                  (latest, if not specified)

    Options:

    -h, --help    output usage information
    -v, --version output the version number
    --verbose output debugging info
    --npm force using the npm client even if your project uses yarn

The app upgraded from v0.29 to v0.38 runs:

<img width="487" alt="screenshot 2016-12-01 21 05 23" src="https://cloud.githubusercontent.com/assets/346214/20812589/047584e8-b80a-11e6-9e8b-295b791ec84c.png">
