### PR TITLE
 Add support for https connections to packager. This can be toggled o…

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevInternalSettings.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevInternalSettings.java
@@ -32,6 +32,7 @@ public class DevInternalSettings implements
   private static final String PREFS_JS_DEV_MODE_DEBUG_KEY = "js_dev_mode_debug";
   private static final String PREFS_JS_MINIFY_DEBUG_KEY = "js_minify_debug";
   private static final String PREFS_DEBUG_SERVER_HOST_KEY = "debug_http_host";
+  private static final String PREFS_DEBUG_SERVER_PROTOCOL_KEY="debug_host_protocol";
   private static final String PREFS_ANIMATIONS_DEBUG_KEY = "animations_debug";
   private static final String PREFS_RELOAD_ON_JS_CHANGE_KEY = "reload_on_js_change";
   private static final String PREFS_INSPECTOR_DEBUG_KEY = "inspector_debug";
@@ -75,6 +76,10 @@ public class DevInternalSettings implements
 
   public @Nullable String getDebugServerHost() {
     return mPreferences.getString(PREFS_DEBUG_SERVER_HOST_KEY, null);
+  }
+
+  public boolean useTls() {
+    return mPreferences.getBoolean(PREFS_DEBUG_SERVER_PROTOCOL_KEY, false);
   }
 
   public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {

--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevServerHelper.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevServerHelper.java
@@ -52,19 +52,19 @@ public class DevServerHelper {
   private static final String RELOAD_APP_ACTION_SUFFIX = ".RELOAD_APP_ACTION";
 
   private static final String BUNDLE_URL_FORMAT =
-      "http://%s/%s.bundle?platform=android&dev=%s&hot=%s&minify=%s";
-  private static final String RESOURCE_URL_FORMAT = "http://%s/%s";
+      "%s://%s/%s.bundle?platform=android&dev=%s&hot=%s&minify=%s";
+  private static final String RESOURCE_URL_FORMAT = "%s://%s/%s";
   private static final String SOURCE_MAP_URL_FORMAT =
       BUNDLE_URL_FORMAT.replaceFirst("\\.bundle", ".map");
   private static final String LAUNCH_JS_DEVTOOLS_COMMAND_URL_FORMAT =
-      "http://%s/launch-js-devtools";
+      "%s://%s/launch-js-devtools";
   private static final String ONCHANGE_ENDPOINT_URL_FORMAT =
-      "http://%s/onchange";
+      "%s://%s/onchange";
   private static final String WEBSOCKET_PROXY_URL_FORMAT = "ws://%s/debugger-proxy?role=client";
   private static final String PACKAGER_CONNECTION_URL_FORMAT = "ws://%s/message?role=shell";
-  private static final String PACKAGER_STATUS_URL_FORMAT = "http://%s/status";
-  private static final String HEAP_CAPTURE_UPLOAD_URL_FORMAT = "http://%s/jscheapcaptureupload";
-  private static final String INSPECTOR_DEVICE_URL_FORMAT = "http://%s/inspector/device?name=%s";
+  private static final String PACKAGER_STATUS_URL_FORMAT = "%s://%s/status";
+  private static final String HEAP_CAPTURE_UPLOAD_URL_FORMAT = "%s://%s/jscheapcaptureupload";
+  private static final String INSPECTOR_DEVICE_URL_FORMAT = "%s://%s/inspector/device?name=%s";
 
   private static final String PACKAGER_OK_STATUS = "packager-status:running";
 
@@ -202,6 +202,7 @@ public class DevServerHelper {
     return String.format(
         Locale.US,
         INSPECTOR_DEVICE_URL_FORMAT,
+        getDebugServerProtocol(),
         getDebugServerHost(),
         AndroidInfoHelpers.getFriendlyDeviceName());
   }
@@ -235,6 +236,14 @@ public class DevServerHelper {
   }
 
   /**
+   *
+   * @return
+     */
+  private String getDebugServerProtocol() {
+    return mSettings.useTls() ? "https" : "http";
+  }
+
+  /**
    * @return the host to use when connecting to the bundle server.
    */
   private String getDebugServerHost() {
@@ -258,16 +267,17 @@ public class DevServerHelper {
     return host;
   }
 
-  private static String createBundleURL(String host, String jsModulePath, boolean devMode, boolean hmr, boolean jsMinify) {
-    return String.format(Locale.US, BUNDLE_URL_FORMAT, host, jsModulePath, devMode, hmr, jsMinify);
+  private static String createBundleURL(String protocol, String host, String jsModulePath, boolean devMode, boolean hmr, boolean jsMinify) {
+    return String.format(Locale.US, BUNDLE_URL_FORMAT, protocol, host, jsModulePath, devMode, hmr, jsMinify);
   }
 
-  private static String createResourceURL(String host, String resourcePath) {
-    return String.format(Locale.US, RESOURCE_URL_FORMAT, host, resourcePath);
+  private static String createResourceURL(String protocol, String host, String resourcePath) {
+    return String.format(Locale.US, RESOURCE_URL_FORMAT, protocol, host, resourcePath);
   }
 
   public String getDevServerBundleURL(final String jsModulePath) {
     return createBundleURL(
+      getDebugServerProtocol(),
       getDebugServerHost(),
       jsModulePath,
       getDevMode(),
@@ -347,7 +357,7 @@ public class DevServerHelper {
   }
 
   public void isPackagerRunning(final PackagerStatusCallback callback) {
-    String statusURL = createPackagerStatusURL(getDebugServerHost());
+    String statusURL = createPackagerStatusURL(getDebugServerProtocol(), getDebugServerHost());
     Request request = new Request.Builder()
         .url(statusURL)
         .build();
@@ -393,8 +403,8 @@ public class DevServerHelper {
         });
   }
 
-  private static String createPackagerStatusURL(String host) {
-    return String.format(Locale.US, PACKAGER_STATUS_URL_FORMAT, host);
+  private static String createPackagerStatusURL(String protocol, String host) {
+    return String.format(Locale.US, PACKAGER_STATUS_URL_FORMAT, protocol, host);
   }
 
   public void stopPollingOnChangeEndpoint() {
@@ -497,14 +507,14 @@ public class DevServerHelper {
   }
 
   public String getSourceUrl(String mainModuleName) {
-    return String.format(Locale.US, BUNDLE_URL_FORMAT, getDebugServerHost(), mainModuleName, getDevMode(), getHMR(), getJSMinifyMode());
+    return String.format(Locale.US, BUNDLE_URL_FORMAT, getDebugServerProtocol(), getDebugServerHost(), mainModuleName, getDevMode(), getHMR(), getJSMinifyMode());
   }
 
   public String getJSBundleURLForRemoteDebugging(String mainModuleName) {
     // The host IP we use when connecting to the JS bundle server from the emulator is not the
     // same as the one needed to connect to the same server from the JavaScript proxy running on the
     // host itself.
-    return createBundleURL(getHostForJSProxy(), mainModuleName, getDevMode(), getHMR(), getJSMinifyMode());
+    return createBundleURL(getDebugServerProtocol(), getHostForJSProxy(), mainModuleName, getDevMode(), getHMR(), getJSMinifyMode());
   }
 
   /**
@@ -516,7 +526,7 @@ public class DevServerHelper {
   public @Nullable File downloadBundleResourceFromUrlSync(
       final String resourcePath,
       final File outputFile) {
-    final String resourceURL = createResourceURL(getDebugServerHost(), resourcePath);
+    final String resourceURL = createResourceURL(getDebugServerProtocol(), getDebugServerHost(), resourcePath);
     final Request request = new Request.Builder()
         .url(resourceURL)
         .build();

--- a/ReactAndroid/src/main/res/devsupport/xml/preferences.xml
+++ b/ReactAndroid/src/main/res/devsupport/xml/preferences.xml
@@ -37,6 +37,12 @@
         android:defaultValue=""
         />
     <CheckBoxPreference
+        android:key="debug_host_protocol"
+        android:title="Use Secure Connection to Host"
+        android:summary="If true the app will use HTTPS to contact the debug server."
+        android:defaultValue="false"
+        />
+    <CheckBoxPreference
         android:key="start_sampling_profiler_on_init"
         android:title="Start Sampling Profiler on init"
         android:summary="If true the Sampling Profiler will start on initialization of JS. Useful for profiling startup of the app. Reload JS after setting."


### PR DESCRIPTION
I host the debug server offsite and want TLS-secured connections for my content. This PR adds this capability to Android, exposed as a preference in the shake menu.

Tested with HTTPS support turned on and off. Supports graceful fallback to default behavior.