### PR TITLE
Use native driver even if gestures are enabled

### DIFF
--- a/Libraries/CustomComponents/NavigationExperimental/NavigationCardStack.js
+++ b/Libraries/CustomComponents/NavigationExperimental/NavigationCardStack.js
@@ -32,7 +32,6 @@
  */
 'use strict';
 
-const NativeAnimatedModule = require('NativeModules').NativeAnimatedModule;
 const NavigationCard = require('NavigationCard');
 const NavigationCardStackPanResponder = require('NavigationCardStackPanResponder');
 const NavigationCardStackStyleInterpolator = require('NavigationCardStackStyleInterpolator');
@@ -221,16 +220,7 @@ class NavigationCardStack extends React.Component<DefaultProps, Props, void> {
   _configureTransition = () => {
     const isVertical = this.props.direction === 'vertical';
     const animationConfig = {};
-    if (
-      !!NativeAnimatedModule
-
-      // Gestures do not work with the current iteration of native animation
-      // driving. When gestures are disabled, we can drive natively.
-      && !this.props.enableGestures
-
-      // Native animation support also depends on the transforms used:
-      && NavigationCardStackStyleInterpolator.canUseNativeDriver(isVertical)
-    ) {
+    if (NavigationCardStackStyleInterpolator.canUseNativeDriver(isVertical)) {
       animationConfig.useNativeDriver = true;
     }
     return animationConfig;


### PR DESCRIPTION
Gestures now work with native animations so we can enable it, it is also not needed anymore to check if the native module exists since we print a warning in the Animated module now.

**Test plan**
Tested that animations and gesture work properly in the UIExplorer example. Also been using native animations with NavigationExperimental (ex-nav) in an app for a while.