### PR TITLE
Android material alert dialog configurations added

### DIFF
--- a/Examples/UIExplorer/js/AlertExample.js
+++ b/Examples/UIExplorer/js/AlertExample.js
@@ -121,6 +121,19 @@ class SimpleAlertExampleBlock extends React.Component {
             <Text>Alert that cannot be dismissed</Text>
           </View>
         </TouchableHighlight>
+        <TouchableHighlight style={styles.wrapper}
+          onPress={() => Alert.alert(
+            'Alert Title',
+            alertMessage,
+            null,
+            {
+              mode: 'material'
+            }
+          )}>
+          <View style={styles.button}>
+            <Text>Android material alert with message and default button</Text>
+          </View>
+        </TouchableHighlight>
       </View>
     );
   }

--- a/Libraries/Alert/Alert.js
+++ b/Libraries/Alert/Alert.js
@@ -25,6 +25,7 @@ type Buttons = Array<{
 
 type Options = {
   cancelable?: ?boolean,
+  mode?: ?string,
 };
 
 /**
@@ -55,6 +56,24 @@ type Options = {
  * Note that by default alerts on Android can be dismissed by clicking outside of their alert box.
  * To prevent this behavior, you can provide
  * an optional `options` parameter `{ cancelable: false }` to the Alert method.
+ *
+ * To support material alert dialog, pass options value with the key 'mode'
+ * `mode` (`enum('material', 'default')`) - To set the appearance of the alert dialog
+ *   - 'material': Show a material alert dialog.
+ *   - 'default': Show a default native alert dialog based on android versions.
+ *
+ * Alert.alert(
+ *   'Alert Title',
+ *   'My Alert Msg',
+ *   [
+ *     {text: 'Ask me later', onPress: () => console.log('Ask me later pressed')},
+ *     {text: 'Cancel', onPress: () => console.log('Cancel Pressed'), style: 'cancel'},
+ *     {text: 'OK', onPress: () => console.log('OK Pressed')},
+ *   ],
+ *   {
+ *    mode: 'material'
+ *   }
+ * )
  *
  * Example usage:
  * ```
@@ -110,7 +129,7 @@ class AlertAndroid {
     };
 
     if (options) {
-      config = {...config, cancelable: options.cancelable};
+      config = {...config, cancelable: options.cancelable, mode: options.mode};
     }
     // At most three buttons (neutral, negative, positive). Ignore rest.
     // The text 'OK' should be probably localized. iOS Alert does that in native.

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/dialog/AlertDialogMode.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/dialog/AlertDialogMode.java
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+package com.facebook.react.modules.dialog;
+
+/**
+ * Alert dialog modes
+ */
+
+public enum AlertDialogMode {
+  MATERIAL,
+  DEFAULT
+}

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/dialog/AlertFragment.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/dialog/AlertFragment.java
@@ -18,6 +18,8 @@ import android.content.DialogInterface;
 import android.content.Context;
 import android.os.Bundle;
 
+import java.util.Locale;
+
 /**
  * A fragment used to display the dialog.
  */
@@ -42,29 +44,59 @@ public class AlertFragment extends DialogFragment implements DialogInterface.OnC
   }
 
   public static Dialog createDialog(
-      Context activityContext, Bundle arguments, DialogInterface.OnClickListener fragment) {
-    AlertDialog.Builder builder = new AlertDialog.Builder(activityContext)
+    Context activityContext, Bundle arguments, DialogInterface.OnClickListener fragment) {
+    AlertDialogMode mode = AlertDialogMode.DEFAULT;
+    if (arguments.getString(DialogModule.KEY_MODE, null) != null) {
+      mode = AlertDialogMode.valueOf(arguments.getString(DialogModule.KEY_MODE).toUpperCase(Locale.US));
+    }
+
+    if (mode == AlertDialogMode.MATERIAL) {
+      android.support.v7.app.AlertDialog.Builder builder = new android.support.v7.app.AlertDialog.Builder(activityContext)
         .setTitle(arguments.getString(ARG_TITLE));
 
-    if (arguments.containsKey(ARG_BUTTON_POSITIVE)) {
-      builder.setPositiveButton(arguments.getString(ARG_BUTTON_POSITIVE), fragment);
-    }
-    if (arguments.containsKey(ARG_BUTTON_NEGATIVE)) {
-      builder.setNegativeButton(arguments.getString(ARG_BUTTON_NEGATIVE), fragment);
-    }
-    if (arguments.containsKey(ARG_BUTTON_NEUTRAL)) {
-      builder.setNeutralButton(arguments.getString(ARG_BUTTON_NEUTRAL), fragment);
-    }
-    // if both message and items are set, Android will only show the message
-    // and ignore the items argument entirely
-    if (arguments.containsKey(ARG_MESSAGE)) {
-      builder.setMessage(arguments.getString(ARG_MESSAGE));
-    }
-    if (arguments.containsKey(ARG_ITEMS)) {
-      builder.setItems(arguments.getCharSequenceArray(ARG_ITEMS), fragment);
-    }
+      if (arguments.containsKey(ARG_BUTTON_POSITIVE)) {
+        builder.setPositiveButton(arguments.getString(ARG_BUTTON_POSITIVE), fragment);
+      }
+      if (arguments.containsKey(ARG_BUTTON_NEGATIVE)) {
+        builder.setNegativeButton(arguments.getString(ARG_BUTTON_NEGATIVE), fragment);
+      }
+      if (arguments.containsKey(ARG_BUTTON_NEUTRAL)) {
+        builder.setNeutralButton(arguments.getString(ARG_BUTTON_NEUTRAL), fragment);
+      }
+      // if both message and items are set, Android will only show the message
+      // and ignore the items argument entirely
+      if (arguments.containsKey(ARG_MESSAGE)) {
+        builder.setMessage(arguments.getString(ARG_MESSAGE));
+      }
+      if (arguments.containsKey(ARG_ITEMS)) {
+        builder.setItems(arguments.getCharSequenceArray(ARG_ITEMS), fragment);
+      }
 
-    return builder.create();
+      return builder.create();
+    } else {
+      AlertDialog.Builder builder = new AlertDialog.Builder(activityContext)
+        .setTitle(arguments.getString(ARG_TITLE));
+
+      if (arguments.containsKey(ARG_BUTTON_POSITIVE)) {
+        builder.setPositiveButton(arguments.getString(ARG_BUTTON_POSITIVE), fragment);
+      }
+      if (arguments.containsKey(ARG_BUTTON_NEGATIVE)) {
+        builder.setNegativeButton(arguments.getString(ARG_BUTTON_NEGATIVE), fragment);
+      }
+      if (arguments.containsKey(ARG_BUTTON_NEUTRAL)) {
+        builder.setNeutralButton(arguments.getString(ARG_BUTTON_NEUTRAL), fragment);
+      }
+      // if both message and items are set, Android will only show the message
+      // and ignore the items argument entirely
+      if (arguments.containsKey(ARG_MESSAGE)) {
+        builder.setMessage(arguments.getString(ARG_MESSAGE));
+      }
+      if (arguments.containsKey(ARG_ITEMS)) {
+        builder.setItems(arguments.getCharSequenceArray(ARG_ITEMS), fragment);
+      }
+
+      return builder.create();
+    }
   }
 
   @Override

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/dialog/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/dialog/BUCK
@@ -4,6 +4,7 @@ android_library(
   name = 'dialog',
   srcs = glob(['**/*.java']),
   deps = [
+    react_native_dep('third-party/android/support/v7/appcompat-orig:appcompat'),
     react_native_dep('libraries/fbcore/src/main/java/com/facebook/common/logging:logging'),
     react_native_dep('third-party/android/support/v4:lib-support-v4'),
     react_native_dep('third-party/java/infer-annotations:infer-annotations'),

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/dialog/DialogModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/dialog/DialogModule.java
@@ -48,6 +48,7 @@ public class DialogModule extends ReactContextBaseJavaModule implements Lifecycl
   /* package */ static final String KEY_BUTTON_NEUTRAL = "buttonNeutral";
   /* package */ static final String KEY_ITEMS = "items";
   /* package */ static final String KEY_CANCELABLE = "cancelable";
+  /* package */ static final String KEY_MODE = "mode";
 
   /* package */ static final Map<String, Object> CONSTANTS = MapBuilder.<String, Object>of(
       ACTION_BUTTON_CLICKED, ACTION_BUTTON_CLICKED,
@@ -251,6 +252,9 @@ public class DialogModule extends ReactContextBaseJavaModule implements Lifecycl
     }
     if (options.hasKey(KEY_CANCELABLE)) {
       args.putBoolean(KEY_CANCELABLE, options.getBoolean(KEY_CANCELABLE));
+    }
+    if (options.hasKey(KEY_MODE) && !options.isNull(KEY_MODE)) {
+      args.putString(KEY_MODE, options.getString(KEY_MODE));
     }
 
     fragmentManagerHelper.showNewAlert(mIsInForeground, args, actionCallback);


### PR DESCRIPTION
## Motivation
To support the android material alert dialog features for all the android versions.
## Solution
Android provides the [appcompat library](https://developer.android.com/topic/libraries/support-library/features.html#v7-appcompat) which supports the material designs for the most of the android versions. With the help of [appcompat library](https://developer.android.com/topic/libraries/support-library/features.html#v7-appcompat), I have added the customization to the android alert dialog. 
## Test Plan
When opening an alert dialog on Android, We need to pass the option value(mode: 'material/default').

### Example 1
```
Alert.alert(
  'Alert Title',
  'My Alert Msg',
  null,
  {
    mode: 'material'
  }
)
```
**Android < 5.0**
![screenshot_20161201-073541](https://cloud.githubusercontent.com/assets/22169327/20784393/e9b1d142-b7bf-11e6-8af2-471ad89dad49.png)

**Android >= 5.0**
![screenshot_20161201-073541](https://cloud.githubusercontent.com/assets/22169327/20784393/e9b1d142-b7bf-11e6-8af2-471ad89dad49.png)

### Example 2
```
Alert.alert(
  'Alert Title',
  'My Alert Msg',
  null,
  {
    mode: 'default'
  }
)
(or)
Alert.alert(
  'Alert Title',
  'My Alert Msg',
  null
)
```
**Android < 5.0**
![screenshot_20161201-073518](https://cloud.githubusercontent.com/assets/22169327/20784429/40033676-b7c0-11e6-80db-53838cab0105.png)


**Android >= 5.0**
![screenshot_20161201-073541](https://cloud.githubusercontent.com/assets/22169327/20784393/e9b1d142-b7bf-11e6-8af2-471ad89dad49.png)

For real-time testing, you can run UIExplorer android project. I have added the example code.
![screenshot_20161201-073532](https://cloud.githubusercontent.com/assets/22169327/20787055/dbc17d52-b7cf-11e6-9180-049ce04cc384.png)
