### PR TITLE
Add the `message:ready` event for the React Native WebView `window.postMessage` injection

### DIFF
--- a/Examples/UIExplorer/js/WebViewExample.js
+++ b/Examples/UIExplorer/js/WebViewExample.js
@@ -225,10 +225,15 @@ class MessagingTest extends React.Component {
     message: '',
   }
 
-  onMessage = e => this.setState({
-    messagesReceivedFromWebView: this.state.messagesReceivedFromWebView + 1,
-    message: e.nativeEvent.data,
-  })
+  onMessage = e => {
+    this.setState({
+      messagesReceivedFromWebView: this.state.messagesReceivedFromWebView + 1,
+      message: e.nativeEvent.data,
+    })
+    if (this.webview) {
+      this.webview.postMessage('React Native has received!');
+    }
+  }
 
   postMessage = () => {
     if (this.webview) {

--- a/Examples/UIExplorer/js/messagingtest.html
+++ b/Examples/UIExplorer/js/messagingtest.html
@@ -21,6 +21,11 @@
       document.getElementsByTagName('p')[1].innerHTML = e.data;
     });
 
+    document.addEventListener('message:ready', function() {
+      document.getElementsByTagName('p')[1].innerHTML = 'ready for postMessage';
+      window.postMessage('web view is ready');
+    })
+
     document.getElementsByTagName('button')[0].addEventListener('click', function() {
       window.postMessage('"Hello" from the web view');
     });

--- a/React/Views/RCTWebView.m
+++ b/React/Views/RCTWebView.m
@@ -290,7 +290,8 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
       @"window.originalPostMessage = window.postMessage;"
       "window.postMessage = function(data) {"
         "window.location = '%@://%@?' + encodeURIComponent(String(data));"
-      "};", RCTJSNavigationScheme, RCTJSPostMessageHost
+      "};"
+      "document.dispatchEvent(new MessageEvent('message:ready'));", RCTJSNavigationScheme, RCTJSPostMessageHost
     ];
     [webView stringByEvaluatingJavaScriptFromString:source];
   }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebViewManager.java
@@ -296,6 +296,7 @@ public class ReactWebViewManager extends SimpleViewManager<WebView> {
           "window.postMessage = function(data) {" +
             BRIDGE_NAME + ".postMessage(String(data));" +
           "}" +
+          "document.dispatchEvent(new MessageEvent('message:ready'));" +
         ")");
       }
     }


### PR DESCRIPTION
React Native injects the `window.postMessage` method when the web page finishes loading. Before that, if we send a message to React Native will not work and throw an error: `2 arguments required, but only 1 present.`. But there is no way to know when it has been injected. So I added the `message:ready` event.

Without this event, I had to hack like [this](https://github.com/pinqy520/react-native-webview-invoke/blob/b96c032353b35609668e200d7f3bf209b82441f3/src/browser.js#L11-L26). :(  

![work](https://cloud.githubusercontent.com/assets/5719833/20801992/8c278da8-b825-11e6-9ea2-7324d704f115.png)

