### PR TITLE
update android gradle plugin version to 2.2.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         mavenLocal()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.3'
+        classpath 'com.android.tools.build:gradle:2.2.2'
         classpath 'de.undercouch:gradle-download-task:2.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong


### PR DESCRIPTION
Similar to https://github.com/facebook/react-native/commit/6bfabee0f848b3126f02729a16c42e2ff0976d12 but upgrading to 2.2.2 which is the what android studio suggests using

http://tools.android.com/tech-docs/new-build-system

<img width="625" alt="screen shot 2016-12-01 at 3 06 25 pm" src="https://cloud.githubusercontent.com/assets/20404/20810456/d1e759e8-b7d7-11e6-9fa3-fc79f1112f5e.png">
