### PR TITLE
Fix packager asset requests on windows

### DIFF
--- a/packager/react-packager/src/node-haste/DependencyGraph/ResolutionRequest.js
+++ b/packager/react-packager/src/node-haste/DependencyGraph/ResolutionRequest.js
@@ -400,7 +400,7 @@ class ResolutionRequest {
   _loadAsFile(potentialModulePath, fromModule, toModule) {
     return Promise.resolve().then(() => {
       if (this._helpers.isAssetFile(potentialModulePath)) {
-        const dirname = path.dirname(potentialModulePath);
+        let dirname = path.dirname(potentialModulePath);
         if (!this._dirExists(dirname)) {
           throw new UnableToResolveError(
             fromModule,
@@ -416,6 +416,11 @@ class ResolutionRequest {
           pattern += '(\\.' + this._platform + ')?';
         }
         pattern += '\\.' + type;
+
+        // Escape backslashes in the path to be able to use it in the regex
+        if (path.sep === '\\') {
+          dirname = dirname.replace(/\\/g, '\\\\');
+        }
 
         // We arbitrarly grab the first one, because scale selection
         // will happen somewhere

--- a/packager/react-packager/src/node-haste/__tests__/DependencyGraph-test.js
+++ b/packager/react-packager/src/node-haste/__tests__/DependencyGraph-test.js
@@ -2541,6 +2541,81 @@ describe('DependencyGraph', function() {
           ]);
       });
     });
+
+    it('should get dependencies with assets and resolution', function() {
+      const root = 'C:\\root';
+      setMockFileSystem({
+        'root': {
+          'index.js': [
+            '/**',
+            ' * @providesModule index',
+            ' */',
+            'require("./imgs/a.png");',
+            'require("./imgs/b.png");',
+            'require("./imgs/c.png");',
+          ].join('\n'),
+          'imgs': {
+            'a@1.5x.png': '',
+            'b@.7x.png': '',
+            'c.png': '',
+            'c@2x.png': '',
+          },
+          'package.json': JSON.stringify({
+            name: 'rootPackage',
+          }),
+        },
+      });
+
+      var dgraph = new DependencyGraph({
+        ...defaults,
+        roots: [root],
+      });
+      return getOrderedDependenciesAsJSON(dgraph, 'C:\\root\\index.js').then(function(deps) {
+        expect(deps)
+          .toEqual([
+            {
+              id: 'index',
+              path: 'C:\\root\\index.js',
+              dependencies: [
+                './imgs/a.png',
+                './imgs/b.png',
+                './imgs/c.png',
+              ],
+              isAsset: false,
+              isJSON: false,
+              isPolyfill: false,
+              resolution: undefined,
+            },
+            {
+              id: 'rootPackage/imgs/a.png',
+              path: 'C:\\root\\imgs\\a@1.5x.png',
+              resolution: 1.5,
+              dependencies: [],
+              isAsset: true,
+              isJSON: false,
+              isPolyfill: false,
+            },
+            {
+              id: 'rootPackage/imgs/b.png',
+              path: 'C:\\root\\imgs\\b@.7x.png',
+              resolution: 0.7,
+              dependencies: [],
+              isAsset: true,
+              isJSON: false,
+              isPolyfill: false,
+            },
+            {
+              id: 'rootPackage/imgs/c.png',
+              path: 'C:\\root\\imgs\\c.png',
+              resolution: 1,
+              dependencies: [],
+              isAsset: true,
+              isJSON: false,
+              isPolyfill: false,
+            },
+          ]);
+      });
+    });
   });
 
   describe('node_modules (posix)', function() {


### PR DESCRIPTION
6554ad5983ae85212684a09869e2ea2e0b743dd3 broke assets on windows, this fixes it and add a test to avoid regressions.

Ideally we'd run all the Dependency graph tests on both posix and win32 filesystems but that would probably require doing some sort of factory function to create the tests because I don't think we want to duplicate every test (file is big enough already :)). So for now I just copied that one test and changed the paths manually.

**Test plan**
Run the new test without the fix -> fails
Run the new test with the fix -> succeeds