### PR TITLE
Fix iOS Picker Item Colors

### DIFF
--- a/Examples/UIExplorer/js/PickerExample.js
+++ b/Examples/UIExplorer/js/PickerExample.js
@@ -55,8 +55,8 @@ class PickerExample extends React.Component {
             style={styles.picker}
             selectedValue={this.state.selected1}
             onValueChange={this.onValueChange.bind(this, 'selected1')}>
-            <Item label="hello" value="key0" />
-            <Item label="world" value="key1" />
+            <Item label="hello" value="key0" color="#ff0000" />
+            <Item label="world" value="key1" color="00ff00" />
           </Picker>
         </UIExplorerBlock>
         <UIExplorerBlock title="Disabled picker">

--- a/Examples/UIExplorer/js/PickerExample.js
+++ b/Examples/UIExplorer/js/PickerExample.js
@@ -55,8 +55,8 @@ class PickerExample extends React.Component {
             style={styles.picker}
             selectedValue={this.state.selected1}
             onValueChange={this.onValueChange.bind(this, 'selected1')}>
-            <Item label="hello" value="key0" color="#ff0000" />
-            <Item label="world" value="key1" color="00ff00" />
+            <Item label="hello" value="key0" />
+            <Item label="world" value="key1" />
           </Picker>
         </UIExplorerBlock>
         <UIExplorerBlock title="Disabled picker">

--- a/Libraries/Components/Picker/PickerIOS.ios.js
+++ b/Libraries/Components/Picker/PickerIOS.ios.js
@@ -52,7 +52,8 @@ var PickerIOS = React.createClass({
       items.push({
         value: child.props.value,
         label: child.props.label,
-        textColor: processColor(child.props.color)});
+        textColor: processColor(child.props.color),
+      });
     });
     return {selectedIndex, items};
   },

--- a/Libraries/Components/Picker/PickerIOS.ios.js
+++ b/Libraries/Components/Picker/PickerIOS.ios.js
@@ -18,6 +18,7 @@ var StyleSheet = require('StyleSheet');
 var StyleSheetPropType = require('StyleSheetPropType');
 var TextStylePropTypes = require('TextStylePropTypes');
 var View = require('View');
+var processColor = require('processColor');
 
 var itemStylePropType = StyleSheetPropType(TextStylePropTypes);
 var requireNativeComponent = require('requireNativeComponent');
@@ -49,7 +50,10 @@ var PickerIOS = React.createClass({
       if (child.props.value === props.selectedValue) {
         selectedIndex = index;
       }
-      items.push({value: child.props.value, label: child.props.label, color: child.props.color});
+      items.push({
+        value: child.props.value,
+        label: child.props.label,
+        textColor: processColor(child.props.color)});
     });
     return {selectedIndex, items};
   },

--- a/Libraries/Components/Picker/PickerIOS.ios.js
+++ b/Libraries/Components/Picker/PickerIOS.ios.js
@@ -43,7 +43,6 @@ var PickerIOS = React.createClass({
 
   // Translate PickerIOS prop and children into stuff that RCTPickerIOS understands.
   _stateFromProps: function(props) {
-    console.log("\n------ PROPS ------\n", props);
     var selectedIndex = 0;
     var items = [];
     React.Children.toArray(props.children).forEach(function (child, index) {

--- a/Libraries/Components/Picker/PickerIOS.ios.js
+++ b/Libraries/Components/Picker/PickerIOS.ios.js
@@ -42,13 +42,14 @@ var PickerIOS = React.createClass({
 
   // Translate PickerIOS prop and children into stuff that RCTPickerIOS understands.
   _stateFromProps: function(props) {
+    console.log("\n------ PROPS ------\n", props);
     var selectedIndex = 0;
     var items = [];
     React.Children.toArray(props.children).forEach(function (child, index) {
       if (child.props.value === props.selectedValue) {
         selectedIndex = index;
       }
-      items.push({value: child.props.value, label: child.props.label});
+      items.push({value: child.props.value, label: child.props.label, color: child.props.color});
     });
     return {selectedIndex, items};
   },
@@ -95,6 +96,7 @@ PickerIOS.Item = class extends React.Component {
   static propTypes = {
     value: React.PropTypes.any, // string or integer basically
     label: React.PropTypes.string,
+    color: React.PropTypes.string,
   };
 
   render() {

--- a/React/Views/RCTPicker.m
+++ b/React/Views/RCTPicker.m
@@ -87,11 +87,9 @@ numberOfRowsInComponent:(__unused NSInteger)component
 
   label.font = _font;
 
-  if ([_items[row] objectForKey:@"textColor"] == nil) {
-    label.textColor = _color;
-  } else {
-    label.textColor = [RCTConvert UIColor:_items[row][@"textColor"]];
-  }
+  label.textColor = [_items[row] objectForKey:@"textColor"] == nil
+    ?  _color
+    : [RCTConvert UIColor:_items[row][@"textColor"]];
 
   label.textAlignment = _textAlign;
   label.text = [self pickerView:pickerView titleForRow:row forComponent:component];

--- a/React/Views/RCTPicker.m
+++ b/React/Views/RCTPicker.m
@@ -86,7 +86,13 @@ numberOfRowsInComponent:(__unused NSInteger)component
   }
 
   label.font = _font;
-  label.textColor = _color;
+
+  if ([_items[row] objectForKey:@"textColor"] == nil) {
+    label.textColor = _color;
+  } else {
+    label.textColor = [RCTConvert UIColor:_items[row][@"textColor"]];
+  }
+
   label.textAlignment = _textAlign;
   label.text = [self pickerView:pickerView titleForRow:row forComponent:component];
   return label;

--- a/React/Views/RCTPicker.m
+++ b/React/Views/RCTPicker.m
@@ -87,9 +87,7 @@ numberOfRowsInComponent:(__unused NSInteger)component
 
   label.font = _font;
 
-  label.textColor = [_items[row] objectForKey:@"textColor"] == nil
-    ?  _color
-    : [RCTConvert UIColor:_items[row][@"textColor"]];
+  label.textColor = [RCTConvert UIColor:_items[row][@"textColor"]] ?: _color;
 
   label.textAlignment = _textAlign;
   label.text = [self pickerView:pickerView titleForRow:row forComponent:component];


### PR DESCRIPTION
I want to resolve #11170 by passing the `color` prop from `PickerIOS.Item` to its implementation.

In `RCTPicker.m`, the label.textColor was already being set and used, but there was nothing referencing the past prop. I passed the prop to the implementation, checked if it exists, and if not, set the default color, like before.

## Test plan

I visually tested the **Colorful Pickers** example in UIExplorer. Those picker `Item`s pass in a `color` prop. 

![dec-01-2016 22-07-46](https://cloud.githubusercontent.com/assets/9259509/20821696/ae45d704-b812-11e6-9720-0045d6c0bcd4.gif)

The basic picker does not pass the color prop to the picker `Item`, and there are no errors. Basic functionality is still in tact:

![dec-01-2016 22-09-35](https://cloud.githubusercontent.com/assets/9259509/20821730/ee544f74-b812-11e6-9294-a1b45e78d9f7.gif)
