### PR TITLE
fix Touchables inspector

### DIFF
--- a/Libraries/Components/Touchable/TouchableWithoutFeedback.js
+++ b/Libraries/Components/Touchable/TouchableWithoutFeedback.js
@@ -157,9 +157,7 @@ const TouchableWithoutFeedback = React.createClass({
         ((child._owner && child._owner.getName && child._owner.getName()) || '<unknown>')
     );
     if (Touchable.TOUCH_TARGET_DEBUG && child.type && child.type.displayName === 'View') {
-      if (!Array.isArray(children)) {
-        children = [children];
-      }
+      children = React.Children.toArray(children);
       children.push(Touchable.renderDebugView({color: 'red', hitSlop: this.props.hitSlop}));
     }
     const style = (Touchable.TOUCH_TARGET_DEBUG && child.type && child.type.displayName === 'Text') ?


### PR DESCRIPTION
Fix TouchableWithoutFeedback throw error when touchables inspector is shown in react@15.4.0:
`Attempted to assign to readonly property`
![image](https://cloud.githubusercontent.com/assets/7693239/20824463/14f7bfc8-b898-11e6-9bc3-50434492ee40.png)


Convert children into an array by using React.Children.toArray.