### PR TITLE
[cli][upgrade]Fix the parse error when specifying an unknown version.

### DIFF
--- a/react-native-git-upgrade/checks.js
+++ b/react-native-git-upgrade/checks.js
@@ -54,21 +54,9 @@ function checkGitAvailable() {
   }
 }
 
-function checkNewVersionValid(newVersion, requestedVersion) {
-  if (!semver.valid(newVersion) && requestedVersion) {
-    throw new Error(
-      'The specified version of React Native ' + requestedVersion + ' doesn\'t exist.\n' +
-      'Re-run the react-native-git-upgrade command with an existing version,\n' +
-      'for example: "react-native-git-upgrade 0.38.0",\n' +
-      'or without arguments to upgrade to the latest: "react-native-git-upgrade".'
-    );
-  }
-}
-
 module.exports = {
   checkDeclaredVersion,
   checkMatchingVersions,
   checkReactPeerDependency,
   checkGitAvailable,
-  checkNewVersionValid,
 };


### PR DESCRIPTION
**Motivation**

When running `react-native-git-upgrade` with an unknown version, the error message isn't very helpful

**Test Plan**

- Publish the `master` branch to Sinopia
- Run `react-native-git-upgrade 0.666.0` inside a RN project
- Error message is `SyntaxError: Unexpected end of JSON input`
- Publish this branch to Sinopia
- Run `react-native-git-upgrade 0.666.0` inside a RN project
- Error message should be `Error: The specified version of React Native 0.666.0 doesn't exist.
Re-run the react-native-git-upgrade command with an existing version,
for example: "react-native-git-upgrade 0.38.0",
or without arguments to upgrade to the latest: "react-native-git-upgrade".`