### PR TITLE
[local-cli] Remove trailing space in template file

### DIFF
--- a/local-cli/templates/HelloWorld/_gitignore
+++ b/local-cli/templates/HelloWorld/_gitignore
@@ -43,7 +43,7 @@ android/app/libs
 
 # fastlane
 #
-# It is recommended to not store the screenshots in the git repo. Instead, use fastlane to re-generate the 
+# It is recommended to not store the screenshots in the git repo. Instead, use fastlane to re-generate the
 # screenshots whenever they are needed.
 # For more information about the recommended setup visit:
 # https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Gitignore.md


### PR DESCRIPTION
Simple removal of a trailing space in a template file which leads to a warning when using `react-native-gitupgrade`:
<img width="1187" alt="capture d ecran 2016-12-02 a 12 44 26" src="https://cloud.githubusercontent.com/assets/4425455/20832904/2c039f80-b88d-11e6-855a-78287d29585f.png">

**Test plan**
To repro:
- Install the `react-native-git-upgrade` package (see #11110)
- Upgrade from 0.39.0 to 0.40.0-rc.0

Ping @mkonicek 