### PR TITLE
Red Box should open PyCharm at line number of error

### DIFF
--- a/local-cli/server/util/launchEditor.js
+++ b/local-cli/server/util/launchEditor.js
@@ -56,6 +56,7 @@ function getArgumentsForLineNumber(editor, fileName, lineNumber, workspace) {
     case 'sublime':
     case 'wstorm':
     case 'appcode':
+    case 'charm':
     case 'idea':  
       return [fileName + ':' + lineNumber];
     case 'joe':


### PR DESCRIPTION
This is a simple one line change.  When a red box is launching the editor, if `launchEditor.js` is aware of your editor it can also add a line number to open the file at.  So if the stacktrace shows an error on like 56 in `ako.js` then it'll try`wstorm /Users/somelady/src/project/ako.js:56` instead of `wstorm /Users/somelady/src/project/ako.js`.

This adds PyCharm's command line launcher, which is named `charm`.  There is existing logic to handle other JetBrains editors, so I just did a simple one line addition.

**Test plan (required)**

* Install PyCharm (if needed)
* Set environment variable `REACT_EDITOR` to `charm`
* Open PyCharm
* Add/replace the current `charm` command via `Tools -> Create Command-line launcher...` in PyCharm.
* Run a React Native project with an error in the source code.
* In the generated red box, click on one of the entries in the stack trace
* File should open in PyCharm at the correct line number.