### PR TITLE
Android home path reminder visible twice on linux

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -252,8 +252,6 @@ Go to **Control Panel** → **System and Security** → **System** → **Change 
 
 Restart the Command Prompt to apply the new environment variable.
 
-<block class="linux windows android" />
-
 > Please make sure you export the correct path for `ANDROID_HOME` if you did not install the Android SDK using Android Studio.
 
 <block class="linux android" />


### PR DESCRIPTION
The line 
`Please make sure you export the correct path for 'ANDROID_HOME' if you did not install the Android SDK using Android Studio.`
was visible twice (one on top of another) in the docs when viewing linux instructions. I removed the block that set it visible on both linux and windows and incorporated it into the existing windows block.