### PR TITLE
iOS: Fix dequeueTasks crash in image loader

### DIFF
--- a/Libraries/Image/RCTImageLoader.m
+++ b/Libraries/Image/RCTImageLoader.m
@@ -236,10 +236,14 @@ static UIImage *RCTResizeImageIfNeeded(UIImage *image,
 {
   dispatch_async(_URLRequestQueue, ^{
     // Remove completed tasks
+    NSMutableArray *tasksToRemove = nil;
     for (RCTNetworkTask *task in self->_pendingTasks.reverseObjectEnumerator) {
       switch (task.status) {
         case RCTNetworkTaskFinished:
-          [self->_pendingTasks removeObject:task];
+          if (!tasksToRemove) {
+            tasksToRemove = [NSMutableArray new];
+          }
+          [tasksToRemove addObject:task];
           self->_activeTasks--;
           break;
         case RCTNetworkTaskPending:
@@ -248,12 +252,19 @@ static UIImage *RCTResizeImageIfNeeded(UIImage *image,
           // Check task isn't "stuck"
           if (task.requestToken == nil) {
             RCTLogWarn(@"Task orphaned for request %@", task.request);
-            [self->_pendingTasks removeObject:task];
+            if (!tasksToRemove) {
+              tasksToRemove = [NSMutableArray new];
+            }
+            [tasksToRemove addObject:task];
             self->_activeTasks--;
             [task cancel];
           }
           break;
       }
+    }
+    
+    if (tasksToRemove) {
+      [self->_pendingTasks removeObjectsInArray:tasksToRemove];
     }
 
     // Start queued decode


### PR DESCRIPTION
This fixes a crash occurring [on this line](https://github.com/facebook/react-native/blob/f9f32eb426b5385e199ef6e1d2b610dfe20e60e7/Libraries/Image/RCTImageLoader.m#L253). It was reported in a comment in #10433.

The problem is that `task` is deallocated at this point and is unsafe to use. Removing it from `_pendingTasks` dropped its ref count to 0. [The ARC docs](http://clang.llvm.org/docs/AutomaticReferenceCounting.html#fast-enumeration-iteration-variables) state that, by default, loop variables in fast enumeration loops are not retained. That's why `task`'s ref count is 0.

It's likely we ran into this bug because the code disobeyed the [reverseObjectEnumerator docs](https://developer.apple.com/reference/foundation/nsarray/1415734-reverseobjectenumerator) which state that "you must not modify the array during enumeration". The default retention policy for fast enumeration seems to assume you follow this.

To fix this bug and avoid other potential pitfalls, the code now follows the docs and `_pendingTasks` is modified after the loop rather than during it.

**Test plan (required)**

I couldn't get the reported line to crash because the code [never entered this branch](https://github.com/facebook/react-native/blob/f9f32eb426b5385e199ef6e1d2b610dfe20e60e7/Libraries/Image/RCTImageLoader.m#L250-L253) in my testing. Consequently, I made a change to RN which introduced a crash and I believe it simulates the conditions of the reported crash. Specifically, in the `RCTNetworkTaskFinished` case I introduced an access to `task` after it had been removed from `_pendingTasks` and I introduced a `sleep` to make the crash easier to hit. In other words, I changed [this code](https://github.com/facebook/react-native/blob/f9f32eb426b5385e199ef6e1d2b610dfe20e60e7/Libraries/Image/RCTImageLoader.m#L241-L244) to:

```
case RCTNetworkTaskFinished:
{
  [self->_pendingTasks removeObject:task];
  sleep(1);
  RCTNetworkTaskStatus status __attribute__ ((unused)) = task.status;
  self->_activeTasks--;
  break;
}
```

Before my fix, this crashed consistently using https://github.com/rigdern/RNImageRepro. After my fix, it did not crash.

Additionally, @SylviaRu stated [this change](https://github.com/facebook/react-native/issues/10433#issuecomment-262890305) avoids the crash. This statement is consistent with my understanding of the cause of the bug which adds confidence to this PR.