### PR TITLE
Bump react-native-git-upgrade to 0.2.0

### DIFF
--- a/react-native-git-upgrade/package.json
+++ b/react-native-git-upgrade/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-git-upgrade",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "BSD-3-Clause",
   "description": "The React Native upgrade tool",
   "main": "cli.js",


### PR DESCRIPTION
The version 0.1.0 has been published by mistake (and unpublished) a few days ago.

NPM doesn't allow publishing 0.1.0 again. So first version of `react-native-git-upgrade` will be [0.2.0](https://www.npmjs.com/package/react-native-git-upgrade).

CC @mkonicek 