### PR TITLE
Android - Fix Overlay for Marshmallow 23+

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/ReactActivityDelegate.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactActivityDelegate.java
@@ -37,28 +37,14 @@ public class ReactActivityDelegate {
   private static final String REDBOX_PERMISSION_MESSAGE =
     "Overlay permissions needs to be granted in order for react native apps to run in dev mode";
 
-  private final
-  @Nullable
-  Activity mActivity;
-  private final
-  @Nullable
-  FragmentActivity mFragmentActivity;
-  private final
-  @Nullable
-  String mMainComponentName;
+  private final @Nullable Activity mActivity;
+  private final @Nullable FragmentActivity mFragmentActivity;
+  private final @Nullable String mMainComponentName;
 
-  private
-  @Nullable
-  ReactRootView mReactRootView;
-  private
-  @Nullable
-  DoubleTapReloadRecognizer mDoubleTapReloadRecognizer;
-  private
-  @Nullable
-  PermissionListener mPermissionListener;
-  private
-  @Nullable
-  Callback mPermissionsCallback;
+  private @Nullable ReactRootView mReactRootView;
+  private @Nullable DoubleTapReloadRecognizer mDoubleTapReloadRecognizer;
+  private @Nullable PermissionListener mPermissionListener;
+  private @Nullable Callback mPermissionsCallback;
 
   public ReactActivityDelegate(Activity activity, @Nullable String mainComponentName) {
     mActivity = activity;
@@ -74,9 +60,7 @@ public class ReactActivityDelegate {
     mActivity = null;
   }
 
-  protected
-  @Nullable
-  Bundle getLaunchOptions() {
+  protected @Nullable Bundle getLaunchOptions() {
     return null;
   }
 
@@ -224,8 +208,7 @@ public class ReactActivityDelegate {
     mPermissionsCallback = new Callback() {
       @Override
       public void invoke(Object... args) {
-        if (mPermissionListener != null &&
-          mPermissionListener.onRequestPermissionsResult(requestCode, permissions, grantResults)) {
+        if (mPermissionListener != null && mPermissionListener.onRequestPermissionsResult(requestCode, permissions, grantResults)) {
           mPermissionListener = null;
         }
       }

--- a/ReactAndroid/src/main/java/com/facebook/react/ReactActivityDelegate.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactActivityDelegate.java
@@ -31,7 +31,7 @@ import javax.annotation.Nullable;
  */
 public class ReactActivityDelegate {
 
-  private final int REQUEST_OVERLAY_CODE = 1111;
+  private final int REQUEST_OVERLAY_PERMISSION_CODE = 1111;
   private static final String REDBOX_PERMISSION_GRANTED_MESSAGE =
     "Overlay permissions have been granted.";
   private static final String REDBOX_PERMISSION_MESSAGE =
@@ -85,14 +85,14 @@ public class ReactActivityDelegate {
 
   protected void onCreate(Bundle savedInstanceState) {
     boolean needsOverlayPermission = false;
-    if (getReactNativeHost().getUseDeveloperSupport() && Build.VERSION.SDK_INT >= 23) {
+    if (getReactNativeHost().getUseDeveloperSupport() && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
       // Get permission to show redbox in dev builds.
       if (!Settings.canDrawOverlays(getContext())) {
         needsOverlayPermission = true;
         Intent serviceIntent = new Intent(Settings.ACTION_MANAGE_OVERLAY_PERMISSION, Uri.parse("package:" + getContext().getPackageName()));
         FLog.w(ReactConstants.TAG, REDBOX_PERMISSION_MESSAGE);
         Toast.makeText(getContext(), REDBOX_PERMISSION_MESSAGE, Toast.LENGTH_LONG).show();
-        ((Activity) getContext()).startActivityForResult(serviceIntent, REQUEST_OVERLAY_CODE);
+        ((Activity) getContext()).startActivityForResult(serviceIntent, REQUEST_OVERLAY_PERMISSION_CODE);
       }
     }
 
@@ -149,7 +149,7 @@ public class ReactActivityDelegate {
         .onActivityResult(getPlainActivity(), requestCode, resultCode, data);
     } else {
       // Did we request overlay permissions?
-      if (requestCode == REQUEST_OVERLAY_CODE && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+      if (requestCode == REQUEST_OVERLAY_PERMISSION_CODE && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
         if (Settings.canDrawOverlays(getContext())) {
           if (mMainComponentName != null) {
             loadApp(mMainComponentName);

--- a/ReactAndroid/src/main/java/com/facebook/react/ReactActivityDelegate.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactActivityDelegate.java
@@ -6,6 +6,7 @@ import android.annotation.TargetApi;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
+import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.provider.Settings;
@@ -29,17 +30,35 @@ import javax.annotation.Nullable;
  * class doesn't implement {@link ReactApplication}.
  */
 public class ReactActivityDelegate {
+
+  private final int REQUEST_OVERLAY_CODE = 1111;
+  private static final String REDBOX_PERMISSION_GRANTED_MESSAGE =
+    "Overlay permissions have been granted.";
   private static final String REDBOX_PERMISSION_MESSAGE =
     "Overlay permissions needs to be granted in order for react native apps to run in dev mode";
 
-  private final @Nullable Activity mActivity;
-  private final @Nullable FragmentActivity mFragmentActivity;
-  private final @Nullable String mMainComponentName;
+  private final
+  @Nullable
+  Activity mActivity;
+  private final
+  @Nullable
+  FragmentActivity mFragmentActivity;
+  private final
+  @Nullable
+  String mMainComponentName;
 
-  private @Nullable ReactRootView mReactRootView;
-  private @Nullable DoubleTapReloadRecognizer mDoubleTapReloadRecognizer;
-  private @Nullable PermissionListener mPermissionListener;
-  private @Nullable Callback mPermissionsCallback;
+  private
+  @Nullable
+  ReactRootView mReactRootView;
+  private
+  @Nullable
+  DoubleTapReloadRecognizer mDoubleTapReloadRecognizer;
+  private
+  @Nullable
+  PermissionListener mPermissionListener;
+  private
+  @Nullable
+  Callback mPermissionsCallback;
 
   public ReactActivityDelegate(Activity activity, @Nullable String mainComponentName) {
     mActivity = activity;
@@ -55,7 +74,9 @@ public class ReactActivityDelegate {
     mActivity = null;
   }
 
-  protected @Nullable Bundle getLaunchOptions() {
+  protected
+  @Nullable
+  Bundle getLaunchOptions() {
     return null;
   }
 
@@ -79,17 +100,19 @@ public class ReactActivityDelegate {
   }
 
   protected void onCreate(Bundle savedInstanceState) {
+    boolean needsOverlayPermission = false;
     if (getReactNativeHost().getUseDeveloperSupport() && Build.VERSION.SDK_INT >= 23) {
       // Get permission to show redbox in dev builds.
       if (!Settings.canDrawOverlays(getContext())) {
-        Intent serviceIntent = new Intent(Settings.ACTION_MANAGE_OVERLAY_PERMISSION);
-        getContext().startActivity(serviceIntent);
+        needsOverlayPermission = true;
+        Intent serviceIntent = new Intent(Settings.ACTION_MANAGE_OVERLAY_PERMISSION, Uri.parse("package:" + getContext().getPackageName()));
         FLog.w(ReactConstants.TAG, REDBOX_PERMISSION_MESSAGE);
         Toast.makeText(getContext(), REDBOX_PERMISSION_MESSAGE, Toast.LENGTH_LONG).show();
+        ((Activity) getContext()).startActivityForResult(serviceIntent, REQUEST_OVERLAY_CODE);
       }
     }
 
-    if (mMainComponentName != null) {
+    if (mMainComponentName != null && !needsOverlayPermission) {
       loadApp(mMainComponentName);
     }
     mDoubleTapReloadRecognizer = new DoubleTapReloadRecognizer();
@@ -140,6 +163,16 @@ public class ReactActivityDelegate {
     if (getReactNativeHost().hasInstance()) {
       getReactNativeHost().getReactInstanceManager()
         .onActivityResult(getPlainActivity(), requestCode, resultCode, data);
+    } else {
+      // Did we request overlay permissions?
+      if (requestCode == REQUEST_OVERLAY_CODE && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+        if (Settings.canDrawOverlays(getContext())) {
+          if (mMainComponentName != null) {
+            loadApp(mMainComponentName);
+          }
+          Toast.makeText(getContext(), REDBOX_PERMISSION_GRANTED_MESSAGE, Toast.LENGTH_LONG).show();
+        }
+      }
     }
   }
 
@@ -192,7 +225,7 @@ public class ReactActivityDelegate {
       @Override
       public void invoke(Object... args) {
         if (mPermissionListener != null &&
-        mPermissionListener.onRequestPermissionsResult(requestCode, permissions, grantResults)) {
+          mPermissionListener.onRequestPermissionsResult(requestCode, permissions, grantResults)) {
           mPermissionListener = null;
         }
       }


### PR DESCRIPTION
## Overview

Currently any React Native apps that target API 23 or greater will crash on the first initial debug/dev build due to the overlay permission.

Sadly there isn't a concrete "request permission" baked into the Marshmallow permission system.
However, we can launch the overlay screen without starting the react app and once its turned on start the app.

## Addresses / Changes
 - https://github.com/facebook/react-native/issues/10454 - targetSdkVersion 23 lead crash / App crash for targeting 23+
 - https://github.com/facebook/react-native/pull/10479 - Add the overlay permission information / Larger discussion around targeting API 23+  
- Intent to Overlay permission goes directly to the app in question, rather then the general full listing of applications. This allows a developer who is not familiar with the system to easily toggle the overlay without getting confused.

**Test plan (required)**
* Ran UIExplorer App on fresh install with Target 23
```
cd react-native
./gradlew :Examples:UIExplorer:android:app:installDebug
./packager/packager.sh
```
* Notice the app doesn't crash as it use to
* Turn on the overlay toggle for the app
* Push the back button (this navigates back to UIExplorerApp)
* Watch the UIExplorerApp fetch the JS Bundle!

Make sure tests pass on both Travis and Circle CI.