### PR TITLE
fix NSTimer scheduling in RCTTiming

### DIFF
--- a/React/Modules/RCTTiming.m
+++ b/React/Modules/RCTTiming.m
@@ -233,16 +233,18 @@ RCT_EXPORT_MODULE()
     _sleepTimer = [[NSTimer alloc] initWithFireDate:sleepTarget
                                            interval:0
                                              target:[_RCTTimingProxy proxyWithTarget:self]
-                                           selector:@selector(timerDidFire)
+                                           selector:@selector(sleepTimerDidFire)
                                            userInfo:nil
                                             repeats:NO];
-    [[NSRunLoop currentRunLoop] addTimer:_sleepTimer forMode:NSDefaultRunLoopMode];
+    dispatch_async(dispatch_get_main_queue(), ^{
+      [[NSRunLoop currentRunLoop] addTimer:_sleepTimer forMode:NSDefaultRunLoopMode];
+    });
   } else {
     _sleepTimer.fireDate = [_sleepTimer.fireDate earlierDate:sleepTarget];
   }
 }
 
-- (void)timerDidFire
+- (void)sleepTimerDidFire
 {
   _sleepTimer = nil;
   if (_paused) {


### PR DESCRIPTION
When debugging remotely, the NSTimer used to unpause the RCTTiming module's observation of RCTDisplayLink frame updates gets scheduled on the WebSocketExecutor queue (rather than the main queue) and fails to fire.

The result is an especially fickle bermuda triangle for calls to setTimeout/setInterval. 

The most reliable way to reproduce the issue I've found is to call setTimeout/setInterval from any component render function, with a delay > 1025.

A couple of ways you might fail to reproduce this:
- creating another timer with < 1025ms delay. RCTTiming's `kMinimumSleepInterval` is 1s, and timers beneath that threshold will unpause the module's observation of RCTDisplayLink frame updates, causing all scheduled timers to get executed properly. I'm not sure where the extra 25ms sneak in, but it smells like it's related to the distance over the bridge.
- running the debugger in a background tab

It's been a long time since I've written any objective-c, so this might not be the best solution, but it works :)
