### PR TITLE
[jest] Added mocked functions to StatusBarManager

### DIFF
--- a/jest/setup.js
+++ b/jest/setup.js
@@ -131,7 +131,13 @@ const mockNativeModules = {
   SourceCode: {
     scriptURL: null,
   },
-  StatusBarManager: {},
+  StatusBarManager: {
+    setStyle: jest.fn(),
+    setHidden: jest.fn(),
+    setNetworkActivityIndicatorVisible: jest.fn(),
+    setBackgroundColor: jest.fn(),
+    setTranslucent: jest.fn(),
+  },
   Timing: {
     createTimer: jest.fn(),
     deleteTimer: jest.fn(),


### PR DESCRIPTION
**Description:**
Jest tests that use that StatusBar failing because the status bar functions aren't mocked.
Errors I ran into:
`TypeError: StatusBarManager. setNetworkActivityIndicatorVisible is not a function`
`TypeError: StatusBarManager. setHidden is not a function`
`TypeError: StatusBarManager. setStyle is not a function`

**Fix:**
Added mocks for all the functions that the StatusBar offers according to the docs: https://facebook.github.io/react-native/docs/statusbar.html

**Test plan (required)**
Verify that the tests using StatusBar and its functions succeed.