### PR TITLE
Change DomStorageEnabled default value to true

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebViewManager.java
@@ -339,6 +339,7 @@ public class ReactWebViewManager extends SimpleViewManager<WebView> {
     mWebViewConfig.configWebView(webView);
     webView.getSettings().setBuiltInZoomControls(true);
     webView.getSettings().setDisplayZoomControls(false);
+    webView.getSettings().setDomStorageEnabled(true);
 
     // Fixes broken full-screen modals/galleries due to body height being 0.
     webView.setLayoutParams(


### PR DESCRIPTION
Many websites use domstorage and never think of its unavailability, which usually leads to a blank page on android and hard for developers to debug. I think it's better to enable domstorage by default, for convenience and consistency to iOS and PC.