### PR TITLE
fix memory leak in Chrome debugging

### DIFF
--- a/Libraries/WebSocket/RCTWebSocketExecutor.m
+++ b/Libraries/WebSocket/RCTWebSocketExecutor.m
@@ -141,6 +141,7 @@ RCT_EXPORT_MODULE()
   RCTWSMessageCallback callback = _callbacks[messageID];
   if (callback) {
     callback(error, reply);
+    [_callbacks removeObjectForKey:messageID];
   }
 }
 


### PR DESCRIPTION
`RCTWebSocketExecutor` saves every WebSocket callback when sending message to chrome, but does not clear them in a debug session until the JS bridge is reloaded, and there may be thousands of blocks saved in the callback table. This PR removes them after they are called.