### PR TITLE
Fix react-native-git-upgrade by get package.json instead of selective field

### DIFF
--- a/react-native-git-upgrade/cliEntry.js
+++ b/react-native-git-upgrade/cliEntry.js
@@ -100,7 +100,8 @@ function parseInformationJsonOutput(jsonOutput, requestedVersion) {
   try {
     const output = JSON.parse(jsonOutput);
     const newVersion = output.version;
-    const newReactVersionRange = output['peerDependencies.react'];
+    const peerDependencies = output.peerDependencies;
+    const newReactVersionRange = peerDependencies.react;
 
     assert(semver.valid(newVersion));
 
@@ -258,7 +259,7 @@ async function run(requestedVersion, cliArgs) {
     checkGitAvailable();
 
     log.info('Get information from NPM registry');
-    const viewCommand = 'npm view react-native@' + (requestedVersion || 'latest') + ' peerDependencies.react version --json';
+    const viewCommand = 'npm view react-native@' + (requestedVersion || 'latest') + ' --json';
     const jsonOutput = await exec(viewCommand, verbose);
     const {newVersion, newReactVersionRange} = parseInformationJsonOutput(jsonOutput, requestedVersion);
     // Print which versions we're upgrading to

--- a/react-native-git-upgrade/package.json
+++ b/react-native-git-upgrade/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-git-upgrade",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "license": "BSD-3-Clause",
   "description": "The React Native upgrade tool",
   "main": "cli.js",

--- a/react-native-git-upgrade/package.json
+++ b/react-native-git-upgrade/package.json
@@ -19,6 +19,7 @@
     "babel-preset-es2015-node": "^6.1.1",
     "babel-preset-stage-3": "^6.17.0",
     "babel-register": "^6.18.0",
+    "minimist": "^1.2.0",
     "npmlog": "^4.0.0",
     "promise": "^7.1.1",
     "rimraf": "^2.5.4",


### PR DESCRIPTION
Explain the **motivation** for making this change. What existing problem does the pull request solve?

To fixes #11330 and fixes #11334 

Regarding to this command (using in `react-native-git-upgrade` - [cliEntry.js#L261](https://github.com/facebook/react-native/blob/master/react-native-git-upgrade/cliEntry.js#L261))
```bash
npm view react-native@latest peerDependencies.react version --json
```
The result from this command are not consistent across a different npm versions.

We better get a whole `package.json` file by calling (remove field and subfield option)

```
npm view react-native@latest  --json
``` 

**Test plan (required)**

**Setup**
- Publish `react-native-git-upgrade` to `sinopia`
- `npm install -g react-native-git-upgrade`
- Test against multiple npm versions (`2.15.8` or `3.7.5` or `3.10.10` or ` 4.0.3`)
- `react-native init AwesomeApp  --version 0.38.0 && cd AwesomeApp`
- `react-native-git-upgrade` and `react-native-git-upgrade 0.39.0` should be working properly


---

~~Regarding to this command (using in react-native-git-upgrade - cliEntry.js#L261)~~
~~doesn't produce a json output in some versions of `npm` (we expect it to be a json). I've tested on `3.7.5` and `2.15.8` and the output was~~

```
peerDependencies.react = "~15.4.0-rc.4"
version = "0.39.0"
```

~~This causes `react-native-git-upgrade` failed to parse json and throws an error to the users. (as #11330 and #11334)~~

~~I've also tested on node 7.2.1 + npm 3.10.10 which works fine with current `react-native-git-upgrade` script and the output from `npm view` was~~
```
{
  "peerDependencies.react": "~15.4.0-rc.4",
  "version": "0.39.0"
}
```
 

