### PR TITLE
Handle missing font families consistently across platforms

### DIFF
--- a/React/Views/RCTFont.mm
+++ b/React/Views/RCTFont.mm
@@ -276,7 +276,7 @@ RCT_ARRAY_CONVERTER(RCTFontVariantDescriptor)
       isCondensed = isCondensedFont(font);
     } else {
       // Not a valid font or family
-      RCTLogError(@"Unrecognized font family '%@'", familyName);
+      RCTLogWarn(@"Unrecognized font family '%@'", familyName);
       if ([UIFont respondsToSelector:@selector(systemFontOfSize:weight:)]) {
         font = [UIFont systemFontOfSize:fontSize weight:fontWeight];
       } else if (fontWeight > UIFontWeightRegular) {


### PR DESCRIPTION
At present if you provide a missing font family to a stylesheet the outcome on iOS and Android is different. For example...

```js
StyleSheet.create({
  myStyle: {
    fontFamily: 'Not a real font'
  }
})
```

* **Android** silently continues and picks a default font for this style
* **iOS** throws a redbox error

I believe the android behaviour is more desirable as providing an unknown font is a recoverable state and on the iOS side there is already code in `RCTFont.mm` that picks the default system font. This default behaviour is currently defunct as the RedBox is shown.

This pull request simply changes `RCTLogError` to `RCTLogWarn` so execution continues and selects the default system font. This soft failure is especially helpful if the fonts are chosen by some user inputted data, yet if the developer is hard-coding fonts into the application they can visually check that they have loaded correctly in the same way they currently would for android.