### PR TITLE
Remove docs reference to incorrect align-items default

### DIFF
--- a/docs/LayoutWithFlexbox.md
+++ b/docs/LayoutWithFlexbox.md
@@ -12,7 +12,7 @@ A component can specify the layout of its children using the flexbox algorithm. 
 
 You will normally use a combination of `flexDirection`, `alignItems`, and `justifyContent` to achieve the right layout.
 
-> Flexbox works the same way in React Native as it does in CSS on the web, with a few exceptions. The defaults are different, with `flexDirection` defaulting to `column` instead of `row`, and `alignItems` defaulting to `stretch` instead of `flex-start`, and the `flex` parameter only supports a single number.
+> Flexbox works the same way in React Native as it does in CSS on the web, with a few exceptions. The defaults are different, with `flexDirection` defaulting to `column` instead of `row`, and the `flex` parameter only supporting a single number.
 
 #### Flex Direction
 


### PR DESCRIPTION
Per https://developer.mozilla.org/en-US/docs/Web/CSS/align-items, the default for `align-items` is stretch, so I removed the reference that suggested otherwise

Similar to https://github.com/facebook/react-native/pull/9397, but this section was not updated in that PR.