### PR TITLE
Add distinction between iPhone and iPad in the interfaceOrientationWillChange method when export dimensions

### DIFF
--- a/React/Modules/RCTUIManager.m
+++ b/React/Modules/RCTUIManager.m
@@ -260,7 +260,7 @@ RCT_EXPORT_MODULE()
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
     [_bridge.eventDispatcher sendDeviceEventWithName:@"didUpdateDimensions"
-                                                body:RCTExportedDimensions(YES)];
+                                                body:RCTExportedDimensions((UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) ? NO : YES)];
 #pragma clang diagnostic pop
   }
 


### PR DESCRIPTION
**Motivation**

This PR is to fix Dimensions not updated on iPad (https://github.com/facebook/react-native/issues/7340)

When using `let {height, width} = Dimensions.get('window');` on iPhone it works fine but not on iPad.

More information on the bug in this comment: https://github.com/facebook/react-native/issues/7340#issuecomment-265826142