### PR TITLE
Properly clear openRowID when a row is swiped to closed position.

### DIFF
--- a/Libraries/Experimental/SwipeableRow/SwipeableListView.js
+++ b/Libraries/Experimental/SwipeableRow/SwipeableListView.js
@@ -196,6 +196,7 @@ class SwipeableListView extends React.Component {
         maxSwipeDistance={this._getMaxSwipeDistance(rowData, sectionID, rowID)}
         key={rowID}
         onOpen={() => this._onOpen(rowData.id)}
+        onClose={() => this._onClose(rowData.id)}
         onSwipeEnd={() => this._setListViewScrollable(true)}
         onSwipeStart={() => this._setListViewScrollable(false)}
         shouldBounceOnMount={shouldBounceOnMount}>
@@ -207,6 +208,12 @@ class SwipeableListView extends React.Component {
   _onOpen(rowID: string): void {
     this.setState({
       dataSource: this.state.dataSource.setOpenRowID(rowID),
+    });
+  }
+
+  _onClose(rowID: string): void {
+    this.setState({
+      dataSource: this.state.dataSource.setOpenRowID(null),
     });
   }
 }

--- a/Libraries/Experimental/SwipeableRow/SwipeableRow.js
+++ b/Libraries/Experimental/SwipeableRow/SwipeableRow.js
@@ -85,6 +85,7 @@ const SwipeableRow = React.createClass({
     isOpen: PropTypes.bool,
     maxSwipeDistance: PropTypes.number.isRequired,
     onOpen: PropTypes.func.isRequired,
+    onClose: PropTypes.func.isRequired,
     onSwipeEnd: PropTypes.func.isRequired,
     onSwipeStart: PropTypes.func.isRequired,
     // Should bounce the row on mount
@@ -120,6 +121,7 @@ const SwipeableRow = React.createClass({
       isOpen: false,
       maxSwipeDistance: 0,
       onOpen: emptyFunction,
+      onClose: emptyFunction,
       onSwipeEnd: emptyFunction,
       onSwipeStart: emptyFunction,
       swipeThreshold: 30,
@@ -368,6 +370,7 @@ const SwipeableRow = React.createClass({
         this._animateToOpenPositionWith(gestureState.vx, horizontalDistance);
       } else {
         // Swiped right
+        this.props.onClose();
         this._animateToClosedPosition();
       }
     } else {


### PR DESCRIPTION
If a SwipeableRow does not have background color defined, QuickAction is rendered below the row. In such case, you can leverage openRowID defined in dataSource. For instance, one can render quickAction only for the open row. The openRowID, however, does not clear when the row is closed. It only clears when the ListView is scrolled. This is s small PR to fix address it. 