### PR TITLE
fix babel 'strict mode' error

### DIFF
--- a/Libraries/Core/InitializeCore.js
+++ b/Libraries/Core/InitializeCore.js
@@ -109,7 +109,7 @@ require('RCTLog');
 
 // Set up error handler
 if (!global.__fbDisableExceptionsManager) {
-  var handleError = function(e, isFatal) {
+  const handleError = (e, isFatal) => {
     try {
       ExceptionsManager.handleException(e, isFatal);
     } catch (ee) {
@@ -118,7 +118,7 @@ if (!global.__fbDisableExceptionsManager) {
       /* eslint-enable no-console-disallow */
       throw e;
     }
-  }
+  };
 
   const ErrorUtils = require('ErrorUtils');
   ErrorUtils.setGlobalHandler(handleError);

--- a/Libraries/Core/InitializeCore.js
+++ b/Libraries/Core/InitializeCore.js
@@ -109,7 +109,7 @@ require('RCTLog');
 
 // Set up error handler
 if (!global.__fbDisableExceptionsManager) {
-  function handleError(e, isFatal) {
+  var handleError = function(e, isFatal) {
     try {
       ExceptionsManager.handleException(e, isFatal);
     } catch (ee) {


### PR DESCRIPTION
need to remove function declaration in a lexically nested statement
because babel uses 'use strict' by default now