### PR TITLE
Add property to force HW acceleration on Android for modal windows

### DIFF
--- a/Libraries/Modal/Modal.js
+++ b/Libraries/Modal/Modal.js
@@ -94,6 +94,11 @@ class Modal extends React.Component {
      */
     transparent: PropTypes.bool,
     /**
+     * The `hardwareAccelerated` prop controls whether to force hardware acceleration for the underlying window.
+     * @platform android
+     */
+    hardwareAccelerated: PropTypes.bool,
+    /**
      * The `visible` prop determines whether your modal is visible.
      */
     visible: PropTypes.bool,
@@ -126,6 +131,7 @@ class Modal extends React.Component {
 
   static defaultProps = {
     visible: true,
+    hardwareAccelerated: false,
   };
 
   static contextTypes = {
@@ -160,6 +166,7 @@ class Modal extends React.Component {
       <RCTModalHostView
         animationType={animationType}
         transparent={this.props.transparent}
+        hardwareAccelerated={this.props.hardwareAccelerated}
         onRequestClose={this.props.onRequestClose}
         onShow={this.props.onShow}
         style={styles.modal}

--- a/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostManager.java
@@ -66,6 +66,11 @@ public class ReactModalHostManager extends ViewGroupManager<ReactModalHostView> 
     view.setTransparent(transparent);
   }
 
+  @ReactProp(name = "hardwareAccelerated")
+  public void setHardwareAccelerated(ReactModalHostView view, boolean hardwareAccelerated) {
+    view.setHardwareAccelerated(hardwareAccelerated);
+  }
+
   @Override
   protected void addEventEmitters(
       ThemedReactContext reactContext,

--- a/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.java
@@ -61,6 +61,7 @@ public class ReactModalHostView extends ViewGroup implements LifecycleEventListe
   private @Nullable Dialog mDialog;
   private boolean mTransparent;
   private String mAnimationType;
+  private boolean mHardwareAccelerated;
   // Set this flag to true if changing a particular property on the view requires a new Dialog to
   // be created.  For instance, animation does since it affects Dialog creation through the theme
   // but transparency does not since we can access the window to update the property.
@@ -153,6 +154,11 @@ public class ReactModalHostView extends ViewGroup implements LifecycleEventListe
     mPropertyRequiresNewDialog = true;
   }
 
+  protected void setHardwareAccelerated(boolean hardwareAccelerated) {
+    mHardwareAccelerated = hardwareAccelerated;
+    mPropertyRequiresNewDialog = true;
+  }
+
   @Override
   public void onHostResume() {
     // We show the dialog again when the host resumes
@@ -237,6 +243,9 @@ public class ReactModalHostView extends ViewGroup implements LifecycleEventListe
       });
 
     mDialog.getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE);
+    if (mHardwareAccelerated) {
+      mDialog.getWindow().addFlags(WindowManager.LayoutParams.FLAG_HARDWARE_ACCELERATED);
+    }
     mDialog.show();
   }
 


### PR DESCRIPTION
When using React Native on Android on top of a game as an overlay, dialog windows sometimes get created with hardware acceleration disabled. This causes the UI to be unresponsive and anything that uses a TextureView stops working. Added a property for the modal view to make sure hardware acceleration flag is enabled when it's set to true.

**Test plan (required)**

set `hardwareAccelerated` property for Modal to force hardware acceleration on dialog windows on Android. Does nothing on iOS.

