### PR TITLE
Docs: add warining about possible memory leaks while using native mod…

### DIFF
--- a/docs/NativeModulesIOS.md
+++ b/docs/NativeModulesIOS.md
@@ -182,6 +182,11 @@ A native module is supposed to invoke its callback only once. It can, however, s
 
 If you want to pass error-like objects to JavaScript, use `RCTMakeError` from [`RCTUtils.h`](https://github.com/facebook/react-native/blob/master/React/Base/RCTUtils.h).  Right now this just passes an Error-shaped dictionary to JavaScript, but we would like to automatically generate real JavaScript `Error` objects in the future.
 
+
+> **WARNING**
+>
+> The passed callback (or one of two, if both onSuccess and onFail callbacks were passed) must be invoked by the native module, otherwise it will lead to memory leaks.
+
 ## Promises
 
 Native modules can also fulfill a promise, which can simplify your code, especially when using ES2016's `async/await` syntax. When the last parameters of a bridged native method are an `RCTPromiseResolveBlock` and `RCTPromiseRejectBlock`, its corresponding JS method will return a JS Promise object.

--- a/docs/NativeModulesIOS.md
+++ b/docs/NativeModulesIOS.md
@@ -166,7 +166,7 @@ RCT_EXPORT_METHOD(findEvents:(RCTResponseSenderBlock)callback)
 }
 ```
 
-`RCTResponseSenderBlock` accepts only one argument - an array of parameters to pass to the JavaScript callback. In this case we use node's convention to make the first parameter an error object (usually `null` when there is no error) and the rest are the results of the function.
+`RCTResponseSenderBlock` accepts only one argument - an array of parameters to pass to the JavaScript callback. In this case we use Node's convention to make the first parameter an error object (usually `null` when there is no error) and the rest are the results of the function.
 
 ```javascript
 CalendarManager.findEvents((error, events) => {
@@ -178,14 +178,9 @@ CalendarManager.findEvents((error, events) => {
 })
 ```
 
-A native module is supposed to invoke its callback only once. It can, however, store the callback and invoke it later. This pattern is often used to wrap iOS APIs that require delegates. See [`RCTAlertManager`](https://github.com/facebook/react-native/blob/master/React/Modules/RCTAlertManager.m) for an example.
+A native module should invoke its callback exactly once. It's okay to store the callback and invoke it later. This pattern is often used to wrap iOS APIs that require delegates - see [`RCTAlertManager`](https://github.com/facebook/react-native/blob/master/React/Modules/RCTAlertManager.m) for an example. If the callback is never invoked, some memory is leaked. If both `onSuccess` and `onFail` callbacks are passed, you should only invoke one of them.
 
 If you want to pass error-like objects to JavaScript, use `RCTMakeError` from [`RCTUtils.h`](https://github.com/facebook/react-native/blob/master/React/Base/RCTUtils.h).  Right now this just passes an Error-shaped dictionary to JavaScript, but we would like to automatically generate real JavaScript `Error` objects in the future.
-
-
-> **WARNING**
->
-> The passed callback (or one of two, if both onSuccess and onFail callbacks were passed) must be invoked by the native module, otherwise it will lead to memory leaks.
 
 ## Promises
 


### PR DESCRIPTION
Currently callbacks passed to native method are stored in [MessageQueue](https://github.com/facebook/react-native/blob/master/Libraries/BatchedBridge/MessageQueue.js#L160-L162) and [will be removed after invocation](https://github.com/facebook/react-native/blob/master/Libraries/BatchedBridge/MessageQueue.js#L273-L274), so to avoid memory leak in js-side the passed callback(s) must be invoked by native method. 

Because of this significant nuance of callbacks usage, which is not (or not directly) mentioned  in docs, we have gained huge increase of ooms count in our app. So, I think this warning will help other developers to avoid this issue