### PR TITLE
Deprecate RecyclerViewBackedScrollView

### DIFF
--- a/Libraries/Components/ScrollView/RecyclerViewBackedScrollView.android.js
+++ b/Libraries/Components/ScrollView/RecyclerViewBackedScrollView.android.js
@@ -16,7 +16,13 @@ var requireNativeComponent = require('requireNativeComponent');
 var INNERVIEW = 'InnerView';
 
 /**
- * Wrapper around android native recycler view.
+ * RecyclerViewBackedScrollView is DEPRECATED and will be removed from
+ * React Native.
+ * Please use a `ListView` which has `removeClippedSubviews` enabled by
+ * default so that rows that are out of sight are automatically
+ * detached from the view hierarchy.
+ *
+ * Wrapper around Android native recycler view.
  *
  * It simply renders rows passed as children in a separate recycler view cells
  * similarly to how `ScrollView` is doing it. Thanks to the fact that it uses
@@ -57,6 +63,13 @@ var RecyclerViewBackedScrollView = React.createClass({
   },
 
   mixins: [ScrollResponder.Mixin],
+
+  componentWillMount: function() {
+    console.warn(
+      'RecyclerViewBackedScrollView is DEPRECATED and will be removed from React Native. ' +
+      'Please use a ListView which has removeClippedSubviews enabled by default so that ' +
+      'rows that are out of sight are automatically detached from the view hierarchy.')
+  },
 
   getInitialState: function() {
     return this.scrollResponderMixinGetInitialState();


### PR DESCRIPTION
cc @brentvatne 

potential reviewers @mkonicek and @kmagiera 

**Motivation for making this change.**

The previous PR was closed : #11095 but the followup actions was never done

I reopened a really similar one so it get merged
RecyclerView is no more used at Facebook (according to previous PR)

According to @brentvatne, their were two motivations for RecyclerView:
* ListView with ScrollView component used to bounce back on row insert, but this is now fixed
* This made possible to implement certain performance improvements, but the maintenance cost was not worth the risk 

With RN 0.37, the actual code in React Native make the app crash:
- see #10560

I spend one hour investigating this and did also require brent time at exponent slack. I think other people are struggling too.

**Test plan**

<img width="708" alt="screen shot 2016-12-13 at 23 42 22" src="https://cloud.githubusercontent.com/assets/13785185/21162483/dbeb642e-c18d-11e6-9c32-1fe73f1826c1.png">

**Code formatting**

The code should be formatted correctly, as it is copy and paste of a core contributor and mainly comments.

**Next steps**

This won't prevent the app from crashing though, so if you prefer, I can rename the 
`Libraries/Components/ScrollView/RecyclerViewBackedScrollView.ios.js` to `Libraries/Components/ScrollView/RecyclerViewBackedScrollView.js` and remove the android file
