### PR TITLE
Updated Mac/Linux ANDROID_HOME path to include ${HOME}

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -224,7 +224,7 @@ The React Native command line interface requires the `ANDROID_HOME` environment 
 Add the following lines to your `~/.bashrc` (or equivalent) config file:
 
 ```
-export ANDROID_HOME=~/Library/Android/sdk
+export ANDROID_HOME=${HOME}/Library/Android/sdk
 export PATH=${PATH}:${ANDROID_HOME}/tools
 export PATH=${PATH}:${ANDROID_HOME}/platform-tools
 ```
@@ -236,7 +236,7 @@ export PATH=${PATH}:${ANDROID_HOME}/platform-tools
 Add the following lines to your `~/.bashrc` (or equivalent) config file:
 
 ```
-export ANDROID_HOME=~/Android/Sdk
+export ANDROID_HOME={$HOME}/Android/Sdk
 export PATH=${PATH}:${ANDROID_HOME}/tools
 export PATH=${PATH}:${ANDROID_HOME}/platform-tools
 ```

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -236,7 +236,7 @@ export PATH=${PATH}:${ANDROID_HOME}/platform-tools
 Add the following lines to your `~/.bashrc` (or equivalent) config file:
 
 ```
-export ANDROID_HOME={$HOME}/Android/Sdk
+export ANDROID_HOME=${HOME}/Android/Sdk
 export PATH=${PATH}:${ANDROID_HOME}/tools
 export PATH=${PATH}:${ANDROID_HOME}/platform-tools
 ```


### PR DESCRIPTION
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request:

Using `~` in the `.bashrc` or `.zshrc` fails inside of double quotes.  By changing this to `$HOME` the path is exported correctly in all instances.

Explain the **motivation** for making this change. What existing problem does the pull request solve?

It corrects the path to the Android home location if SDK is installed via Android Studio. Using `~` for the home path is failing.  By added `$HOME` you are guaranteed the correct path.

Prefer **small pull requests**. These are much easier to review and more likely to get merged. Make sure the PR does only one thing, otherwise please split it.

**Test plan (required)**

Install Android Studio & SDK. 
Set environment variable in `.bashrc` or `.zshrc` with `${HOME}/Library/Android/sdk` instead of `~/Library/Android/sdk`

Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

Make sure tests pass on both Travis and Circle CI.

**Code formatting**

Look around. Match the style of the rest of the codebase. See also the simple [style guide](https://github.com/facebook/react-native/blob/master/CONTRIBUTING.md#style-guide).

For more info, see the ["Pull Requests" section of our "Contributing" guidelines](https://github.com/facebook/react-native/blob/master/CONTRIBUTING.md#pull-requests).