### PR TITLE
Fix react-native -v

### DIFF
--- a/react-native-cli/index.js
+++ b/react-native-cli/index.js
@@ -56,7 +56,6 @@ var semver = require('semver');
  */
 
 var options = require('minimist')(process.argv.slice(2));
-checkForVersionArgument(options);
 
 var CLI_MODULE_PATH = function() {
   return path.resolve(
@@ -75,6 +74,7 @@ var REACT_NATIVE_PACKAGE_JSON_PATH = function() {
     'package.json'
   );
 };
+checkForVersionArgument(options);
 
 // Use Yarn if available, it's much faster than the npm client.
 // Return the version of yarn installed on the system, null if yarn is not available.


### PR DESCRIPTION
The `checkForVersionArgument` function tries to call `REACT_NATIVE_PACKAGE_JSON_PATH` which isn't defined yet prior to this change. This means that `react-native -v` never reports the version of react-native used in the current project, and in fact never detects the current project.

Fixes #11463 