### PR TITLE
Switched to npm hosted boost lib

### DIFF
--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -35,17 +35,31 @@ task createNativeDepsDirectories {
 }
 
 task downloadBoost(dependsOn: createNativeDepsDirectories, type: Download) {
-    // Use ZIP version as it's faster this way to selectively extract some parts of the archive
-    src 'https://downloads.sourceforge.net/project/boost/boost/1.57.0/boost_1_57_0.zip'
-    // alternative
-    // src 'http://mirror.nienbo.com/boost/boost_1_57_0.zip'
+    src 'https://registry.yarnpkg.com/boost-react-native-bundle/-/boost-react-native-bundle-1.57.0.tgz'
     onlyIfNewer true
     overwrite false
-    dest new File(downloadsDir, 'boost_1_57_0.zip')
+    dest new File(downloadsDir, 'boost-react-native-bundle-1.57.0.tgz')
 }
 
-task prepareBoost(dependsOn: boostPath ? [] : [downloadBoost], type: Copy) {
-    from boostPath ?: zipTree(downloadBoost.dest)
+task unpackBoost(dependsOn: downloadBoost, type: Copy) {
+    from tarTree(resources.gzip(downloadBoost.dest))
+    include 'package/boost_1_57_0/boost/**/*.hpp'
+    into "$thirdPartyNdkDir/boost"
+    // npm packages are unpacked into folder "package" that we want to strip
+    eachFile { FileCopyDetails fcp ->
+        if (fcp.relativePath.pathString.startsWith("package")) {
+            // remap the file to the root
+            def segments = fcp.relativePath.segments
+            def pathsegments = segments[1..-1] as String[]
+            fcp.relativePath = new RelativePath(!fcp.file.isDirectory(), pathsegments)
+        } else {
+            fcp.exclude()
+        }
+    }
+}
+
+task prepareBoost(dependsOn: boostPath ? [] : [unpackBoost], type: Copy) {
+    from boostPath ?: []
     from 'src/main/jni/third-party/boost/Android.mk'
     include 'boost_1_57_0/boost/**/*.hpp', 'Android.mk'
     into "$thirdPartyNdkDir/boost"

--- a/circle.yml
+++ b/circle.yml
@@ -59,13 +59,15 @@ test:
     - buck build ReactAndroid/src/main/java/com/facebook/react
     - buck build ReactAndroid/src/main/java/com/facebook/react/shell
 
+    # compile native libs with Gradle script, we need bridge for unit and
+    # integration tests
+    - ./gradlew :ReactAndroid:packageReactNdkLibsForBuck -Pjobs=1 -Pcom.android.build.threadPoolSize=1:
+        timeout: 360
+
     # unit tests
     - buck test ReactAndroid/src/test/... --config build.threads=1
 
-    # instrumentation tests
-    # compile native libs with Gradle script
-    - ./gradlew :ReactAndroid:packageReactNdkLibsForBuck -Pjobs=1 -Pcom.android.build.threadPoolSize=1:
-        timeout: 360
+    # integration tests
     # build JS bundle for instrumentation tests
     - REACT_NATIVE_MAX_WORKERS=1 node local-cli/cli.js bundle --platform android --dev true --entry-file ReactAndroid/src/androidTest/js/TestBundle.js --bundle-output ReactAndroid/src/androidTest/assets/AndroidTestBundle.js
     # build test APK


### PR DESCRIPTION
Boost is officially hosted on SourceForge which has ab SSL problem that Gradle complains about and also it is sometimes unavailable.
I switched to using npm hosted (yarnpkg mirrored for performance) boost lib exactly the same as from Source Forge.

Other alternatives considered:
- CDN e.g. mirror.nienbo.com started responding with 4XX code when requested by Gradle
- File sharing like DropBox are not for mass anonymous downloads
- Github is not good for binary files and is throttled for anonymous raw file downloads
- S3 or similar. Requires amazon account for maintenance and does not expose semver API and other nice features that npm has

In the future I'd like to try Yarn as dependency management tool for bridge builds, this could be the first step.

**Test plan (required)**

- Circle (testing with caches cleaned)
- `./gradlew ReactAndroid:packageReactNdkLibsForBuck` (check twice to make sure caches work)
- `REACT_NATIVE_BOOST_PATH=./bridge-dependencies/node_modules/boost-react-native-bundle ./gradlew ReactAndroid:packageReactNdkLibsForBuck` (check twice to make sure caches work)