### PR TITLE
Fix TextInput 'defaultValue' propTypes to 'string'

### DIFF
--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -451,7 +451,7 @@ const TextInput = React.createClass({
      * Useful for simple use-cases where you do not want to deal with listening
      * to events and updating the value prop to keep the controlled state in sync.
      */
-    defaultValue: PropTypes.node,
+    defaultValue: PropTypes.string,
     /**
      * When the clear button should appear on the right side of the text view.
      * @platform ios


### PR DESCRIPTION
Because `TextInput` only render the `defaultValue` of `string`, when using other types of values, it will render empty('') without any Warnings.