### PR TITLE
REACT_NATIVE_DIR needs quoting to retain spaces

### DIFF
--- a/packager/react-native-xcode.sh
+++ b/packager/react-native-xcode.sh
@@ -34,7 +34,7 @@ esac
 REACT_NATIVE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 # Xcode project file for React Native apps is located in ios/ subfolder
-cd ${REACT_NATIVE_DIR}/../..
+cd "${REACT_NATIVE_DIR}"/../..
 
 # Define NVM_DIR and source the nvm.sh setup script
 [ -z "$NVM_DIR" ] && export NVM_DIR="$HOME/.nvm"


### PR DESCRIPTION
${REACT_NATIVE_DIR} needs to be quoted as "${REACT_NATIVE_DIR}" otherwise projects paths with spaces in, will fail to build.

e.g. a project in `/home/me/some folder` will fail to build with:

```
../node_modules/react-native/packager/react-native-xcode.sh: line 37: cd: /home/me/some: No such file or directory
```