### PR TITLE
Added keyboardDisplayRequiresUserAction prop to WebView for iOS

### DIFF
--- a/Libraries/Components/WebView/WebView.ios.js
+++ b/Libraries/Components/WebView/WebView.ios.js
@@ -334,6 +334,12 @@ class WebView extends React.Component {
      * to tap them before they start playing. The default value is `true`.
      */
     mediaPlaybackRequiresUserAction: PropTypes.bool,
+
+    /**
+     * Boolean that determines whether keyboard display requires the user
+     * to tap on HTML input element. The default value is `true`.
+     */
+    keyboardDisplayRequiresUserAction: PropTypes.bool,
   };
 
   state = {

--- a/React/Views/RCTWebViewManager.m
+++ b/React/Views/RCTWebViewManager.m
@@ -50,6 +50,7 @@ RCT_EXPORT_VIEW_PROPERTY(onShouldStartLoadWithRequest, RCTDirectEventBlock)
 RCT_REMAP_VIEW_PROPERTY(allowsInlineMediaPlayback, _webView.allowsInlineMediaPlayback, BOOL)
 RCT_REMAP_VIEW_PROPERTY(mediaPlaybackRequiresUserAction, _webView.mediaPlaybackRequiresUserAction, BOOL)
 RCT_REMAP_VIEW_PROPERTY(dataDetectorTypes, _webView.dataDetectorTypes, UIDataDetectorTypes)
+RCT_REMAP_VIEW_PROPERTY(keyboardDisplayRequiresUserAction, _webView.keyboardDisplayRequiresUserAction, BOOL)
 
 RCT_EXPORT_METHOD(goBack:(nonnull NSNumber *)reactTag)
 {


### PR DESCRIPTION
**Motivation**

Showing keyboard when CKEditor on load in WebVIew. CKEditor provides focus api, but keyboard doesn't show itself. That's because, by default
`[_webView setKeyboardDisplayRequiresUserAction:YES];`
A Boolean value indicating whether web content can programmatically display the keyboard.
Want to make this prop configurable.

**Test plan**

After this change, set this prop to `false` in JS, then load any content in WebView. Programmatically focus on input element, keyborad should pop-up

