### PR TITLE
Add support for trackHeight to Slider on iOS

### DIFF
--- a/Libraries/Components/Slider/Slider.js
+++ b/Libraries/Components/Slider/Slider.js
@@ -115,6 +115,12 @@ var Slider = React.createClass({
     thumbImage: Image.propTypes.source,
 
     /**
+     * Sets the height for the track image.
+     * @platform ios
+     */
+    trackHeight: PropTypes.number,
+
+    /**
      * Callback continuously called while the user is dragging the slider.
      */
     onValueChange: PropTypes.func,

--- a/React/Views/RCTSlider.m
+++ b/React/Views/RCTSlider.m
@@ -88,4 +88,18 @@
   return [self thumbImageForState:UIControlStateNormal];
 }
 
+
+- (void)setTrackHeight:(NSInteger)trackHeight
+{
+  _trackHeight = trackHeight;
+}
+
+- (CGRect)trackRectForBounds:(CGRect)bounds {
+    CGRect trackBounds = [super trackRectForBounds:bounds];
+    if (_trackHeight != nil) {
+      trackBounds.size.height = _trackHeight;
+    }
+    return trackBounds;
+}
+
 @end

--- a/React/Views/RCTSliderManager.m
+++ b/React/Views/RCTSliderManager.m
@@ -86,6 +86,7 @@ RCT_EXPORT_VIEW_PROPERTY(maximumTrackTintColor, UIColor);
 RCT_EXPORT_VIEW_PROPERTY(onValueChange, RCTBubblingEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onSlidingComplete, RCTBubblingEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(thumbImage, UIImage);
+RCT_EXPORT_VIEW_PROPERTY(trackHeight, NSInteger);
 RCT_CUSTOM_VIEW_PROPERTY(disabled, BOOL, RCTSlider)
 {
   if (json) {


### PR DESCRIPTION
This pull request adds support for a `trackHeight` prop to the `Slider` component. 

It was tested by adding a `trackHeight` property to an existing `Slider` and observing the expected result (a taller track). I couldn't find unit tests for the `Slider` - if there are some that I missed I'll be happy to add a test for the new property.
