### PR TITLE
removed flex: 1 from SwipeableRow styles to make compatible with 0.39 changes

### DIFF
--- a/Libraries/Experimental/SwipeableRow/SwipeableRow.js
+++ b/Libraries/Experimental/SwipeableRow/SwipeableRow.js
@@ -186,12 +186,7 @@ const SwipeableRow = React.createClass({
     const swipeableView = (
       <Animated.View
         onLayout={this._onSwipeableViewLayout}
-        style={[
-          styles.swipeableContainer,
-          {
-            transform: [{translateX: this.state.currentLeft}],
-          },
-        ]}>
+        style={{transform: [{translateX: this.state.currentLeft}]}}>
         {this.props.children}
       </Animated.View>
     );
@@ -389,9 +384,6 @@ const styles = StyleSheet.create({
     position: 'absolute',
     right: 0,
     top: 0,
-  },
-  swipeableContainer: {
-    flex: 1,
   },
 });
 


### PR DESCRIPTION
React Native 0.39 introduced a breaking change through a new C-based implementation of css-layout. Developers were encouraged to remove unnecessary flex: 1 styles where no longer required to address any resulting layout issues.

The SwipeableListView has not yet been updated to reflect this change. Specifically, SwipeableRow still sets flex: 1 even though it shouldn't.

This was resulting in a rendering issue for folks when they upgraded to React Native 0.39 and used SwipeableListView that caused significant initial flickering when rendering a SwipeableListView. The solution was simply to remove flex: 1 from the SwipeableRow implementation.

This small change removes flex: 1 to resolve this issue.

Suggested reviewer (initial SwipeableListView contributor): @fred2028 

See this issue for more details: https://github.com/facebook/react-native/issues/11441