### PR TITLE
Mention in the docs how to install JS dependencies

### DIFF
--- a/docs/MoreResources.md
+++ b/docs/MoreResources.md
@@ -18,6 +18,10 @@ One common question is how to handle the "state" of your React Native applicatio
 
 If you're looking for a library that does a specific thing, check out [Awesome React Native](https://github.com/jondot/awesome-react-native), a curated list of components that also has demos, articles, and other stuff.
 
+## Installing dependencies
+
+You can simply run `npm install library`, then use `import moment from 'moment';` in your code to import a JS Node library.
+
 ## Example Apps
 
 There are a lot of example apps at the [React Native Playground](https://rnplay.org/apps/picks). You can see the code running on a real device, which is a neat feature.


### PR DESCRIPTION
I don't think this is the right place, but either I have completely missed it, or there is no mention of installing JS libraries anywhere in the docs. It works perfectly out of the box, but I think it deserves a concrete mention (along the lines of what I added). Perhaps it should be a separate page under "Guides"? I don't have a good solution, just wanted to raise this omission (the closest is mention of `import` in "Using Navigators").