### PR TITLE
return if UIManager failed to measure node

### DIFF
--- a/Libraries/Components/Touchable/Touchable.js
+++ b/Libraries/Components/Touchable/Touchable.js
@@ -575,6 +575,10 @@ var TouchableMixin = {
   },
 
   _handleQueryLayout: function(l, t, w, h, globalX, globalY) {
+    //don't do anything UIManager failed to measure node
+    if(!l && !t && !w && !h && !globalX && !globalY){
+      return
+    }
     this.state.touchable.positionOnActivate &&
       Position.release(this.state.touchable.positionOnActivate);
     this.state.touchable.dimensionsOnActivate &&

--- a/Libraries/Components/Touchable/Touchable.js
+++ b/Libraries/Components/Touchable/Touchable.js
@@ -576,8 +576,8 @@ var TouchableMixin = {
 
   _handleQueryLayout: function(l, t, w, h, globalX, globalY) {
     //don't do anything UIManager failed to measure node
-    if(!l && !t && !w && !h && !globalX && !globalY){
-      return
+    if (!l && !t && !w && !h && !globalX && !globalY) {
+      return;
     }
     this.state.touchable.positionOnActivate &&
       Position.release(this.state.touchable.positionOnActivate);


### PR DESCRIPTION
iOS return all 0 metrics for <Text> inside <Text>, which results immediate `onPressOut` event on press in. These kind of response should be ignored

this solved issue #11462 