### PR TITLE
Upgrade fs-extra to 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
     "event-target-shim": "^1.0.5",
     "fbjs": "^0.8.5",
     "fbjs-scripts": "^0.7.0",
-    "fs-extra": "^0.26.2",
+    "fs-extra": "^1.0.0",
     "glob": "^5.0.15",
     "graceful-fs": "^4.1.3",
     "image-size": "^0.3.5",


### PR DESCRIPTION
fs-extra's first stable release is out since 1 of November.
I think its time to upgrade to 1.0.0. We've been running 1.0.0 locally and is having no problems with it.

**Test plan (required)**

Walked through the commits from 0.30 to 1.0.0 and no breaking changes has been made to the repository. https://github.com/jprichardson/node-fs-extra/compare/1.0.0...1.x