### PR TITLE
reenable circle e2e tests

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -76,8 +76,7 @@ test:
     - node ./scripts/run-android-ci-instrumentation-tests.js --retries 3 --path ./ReactAndroid/src/androidTest/java/com/facebook/react/tests --package com.facebook.react.tests
 
     # Android e2e test
-    # Commented out because of odd breaks. TODO: re-enable this
-    # - source scripts/circle-ci-android-setup.sh && retry3 node ./scripts/run-ci-e2e-tests.js --android --js --retries 2
+    - source scripts/circle-ci-android-setup.sh && retry3 node ./scripts/run-ci-e2e-tests.js --android --js --retries 2
 
     # testing docs generation
     - cd website && npm test


### PR DESCRIPTION
We turned them off on Wednesday Dec 14 when both CIs were busted. Once Circle runs on this PR it'll demonstrate they are functional again.