### PR TITLE
Add `textProps` prop to NavigationExperimental.Header.Title

### DIFF
--- a/Libraries/CustomComponents/NavigationExperimental/NavigationHeaderTitle.js
+++ b/Libraries/CustomComponents/NavigationExperimental/NavigationHeaderTitle.js
@@ -45,13 +45,14 @@ const {
 type Props = {
   children?: React.Element<any>,
   style?: any,
+  textProps?: any,
   textStyle?: any,
   viewProps?: any,
 }
 
-const NavigationHeaderTitle = ({ children, style, textStyle, viewProps }: Props) => (
+const NavigationHeaderTitle = ({ children, style, textProps, textStyle, viewProps }: Props) => (
   <View style={[ styles.title, style ]} {...viewProps}>
-    <Text style={[ styles.titleText, textStyle ]}>{children}</Text>
+    <Text style={[ styles.titleText, textStyle ]} {...textProps}>{children}</Text>
   </View>
 );
 


### PR DESCRIPTION
This commit adds a `textProps` prop to `NavigationExperimental.Header.Title`, which allows for usage like:

```javascript
<NavigationExperimental.Header.Title textProps={{ numberOfLines: 2 }}>
  {route.title}
</NavigationExperimental.Header.Title>
```