### PR TITLE
Add `style` and `imageStyle` props to Navigation.Header.BackButton

### DIFF
--- a/Libraries/CustomComponents/NavigationExperimental/NavigationHeaderBackButton.js
+++ b/Libraries/CustomComponents/NavigationExperimental/NavigationHeaderBackButton.js
@@ -35,12 +35,14 @@ const {
 } = ReactNative;
 
 type Props = {
+  imageStyle?: any,
   onPress: Function,
+  style?: any,
 };
 
 const NavigationHeaderBackButton = (props: Props) => (
-  <TouchableOpacity style={styles.buttonContainer} onPress={props.onPress}>
-    <Image style={styles.button} source={require('./assets/back-icon.png')} />
+  <TouchableOpacity style={[styles.buttonContainer, props.style]} onPress={props.onPress}>
+    <Image style={[styles.button, styles.imageStyle]} source={require('./assets/back-icon.png')} />
   </TouchableOpacity>
 );
 

--- a/Libraries/CustomComponents/NavigationExperimental/NavigationHeaderBackButton.js
+++ b/Libraries/CustomComponents/NavigationExperimental/NavigationHeaderBackButton.js
@@ -42,7 +42,7 @@ type Props = {
 
 const NavigationHeaderBackButton = (props: Props) => (
   <TouchableOpacity style={[styles.buttonContainer, props.style]} onPress={props.onPress}>
-    <Image style={[styles.button, styles.imageStyle]} source={require('./assets/back-icon.png')} />
+    <Image style={[styles.button, props.imageStyle]} source={require('./assets/back-icon.png')} />
   </TouchableOpacity>
 );
 

--- a/ReactAndroid/src/main/java/com/facebook/react/flat/README.md
+++ b/ReactAndroid/src/main/java/com/facebook/react/flat/README.md
@@ -1,0 +1,49 @@
+# Nodes
+
+Nodes is an experimental, alternate version of
+[UIImplementation](https://github.com/facebook/react-native/blob/master/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIImplementation.java) for ReactNative on Android. It has two main advantages over the existing `UIImplementation`:
+
+1. Support for `overflow:visible` on Android.
+2. More efficient generation of view hierarchies.
+
+The intention is to ultimately replace the existing `UIImplementation` on
+Android with Nodes (after all the issues are ironed out).
+
+## How to test
+
+In a subclass of `ReactNativeHost`, add this:
+
+```java
+@Override
+protected UIImplementationProvider getUIImplementationProvider() {
+  return new FlatUIImplementationProvider();
+}
+```
+
+## How it Works
+
+The existing
+[UIImplementation](https://github.com/facebook/react-native/blob/master/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIImplementation.java) maps all non-layout tags to `View`s (resulting in an almost 1:1 mapping of tags
+to Views, with the exception of some optimizations for layout only tags that
+don't draw content). Nodes, on the other hand, maps react tags to a set of
+`DrawCommand`s. In other words, an `<image>` tag will often be mapped to a
+`Drawable` instead of an `ImageView` and a `<text>` tag will be mapped to a
+`Layout` instead of a `TextView`. This helps flatten the resulting `View`
+hierarchy.
+
+There are situations where `DrawCommand`s are promoted to `View`s:
+
+1. Existing Android components that are wrapped by React Native (for example, 
+`ViewPager`, `ScrollView`, etc).
+2. When using a `View` is more optimal (for example, `opacity`, to avoid
+unnecessary invalidations).
+3. To facilitate the implementation of certain features (accessibility,
+transforms, etc).
+
+This means that existing custom `ViewManager`s should continue to work as they
+did with the existing `UIImplementation`.
+
+## Limitations and Known Issues
+
+- `LayoutAnimation`s are not yet supported
+- `zIndex` is not yet supported


### PR DESCRIPTION
This PR adds`style` and `imageStyle` props to `Navigation.Header.BackButton` which allows for usage like:

```javascript
<NavigationExperimental.Header.BackButton
  imageStyle={{ tintColor: 'white' }}
  onPress={props.onNavigateBack}
/>
```