### PR TITLE
Jest - Support Immutable Objects for ListViewDataSource mock

### DIFF
--- a/jest/setup.js
+++ b/jest/setup.js
@@ -8,8 +8,6 @@
  */
 'use strict';
 
-var immutable = require('immutable');
-
 const mockComponent = require.requireActual('./mockComponent');
 
 require.requireActual('../packager/react-packager/src/Resolver/polyfills/babelHelpers.js');
@@ -47,6 +45,7 @@ jest
     return ListView;
   })
   .mock('ListViewDataSource', () => {
+    var immutable = require('immutable');
     const DataSource = require.requireActual('ListViewDataSource');
     DataSource.prototype.toJSON = function() {
       function ListViewDataSource(dataBlob) {

--- a/jest/setup.js
+++ b/jest/setup.js
@@ -52,8 +52,8 @@ jest
         // Ensure this doesn't throw.
         try {
           Object.keys(dataBlob).forEach(key => {
-            this.items += object[key] && (
-              object[key].length || object[key].size || 0
+            this.items += dataBlob[key] && (
+              dataBlob[key].length || dataBlob[key].size || 0
             )
           });
         } catch (e) {

--- a/jest/setup.js
+++ b/jest/setup.js
@@ -9,7 +9,6 @@
 'use strict';
 
 var immutable = require('immutable');
-var {Map} = immutable;
 
 const mockComponent = require.requireActual('./mockComponent');
 
@@ -55,7 +54,7 @@ jest
         // Ensure this doesn't throw.
         try {
           Object.keys(dataBlob).forEach(key => {
-            const isImmutableMap = Map.isMap(dataBlob[key]);
+            const isImmutableMap = immutable.Map.isMap(dataBlob[key]);
             this.items += isImmutableMap ?
               (dataBlob[key] && !dataBlob[key].isEmpty()) : (dataBlob[key] && dataBlob[key].length);
           });

--- a/jest/setup.js
+++ b/jest/setup.js
@@ -45,7 +45,6 @@ jest
     return ListView;
   })
   .mock('ListViewDataSource', () => {
-    var immutable = require('immutable');
     const DataSource = require.requireActual('ListViewDataSource');
     DataSource.prototype.toJSON = function() {
       function ListViewDataSource(dataBlob) {
@@ -53,9 +52,9 @@ jest
         // Ensure this doesn't throw.
         try {
           Object.keys(dataBlob).forEach(key => {
-            const isImmutableMap = immutable.Map.isMap(dataBlob[key]);
-            this.items += isImmutableMap ?
-              (dataBlob[key] && !dataBlob[key].size) : (dataBlob[key] && dataBlob[key].length);
+            this.items += object[key] && (
+              object[key].length || object[key].size || 0
+            )
           });
         } catch (e) {
           this.items = 'unknown';

--- a/jest/setup.js
+++ b/jest/setup.js
@@ -56,7 +56,7 @@ jest
           Object.keys(dataBlob).forEach(key => {
             const isImmutableMap = immutable.Map.isMap(dataBlob[key]);
             this.items += isImmutableMap ?
-              (dataBlob[key] && !dataBlob[key].isEmpty()) : (dataBlob[key] && dataBlob[key].length);
+              (dataBlob[key] && !dataBlob[key].size) : (dataBlob[key] && dataBlob[key].length);
           });
         } catch (e) {
           this.items = 'unknown';

--- a/jest/setup.js
+++ b/jest/setup.js
@@ -8,6 +8,9 @@
  */
 'use strict';
 
+var immutable = require('immutable');
+var {Map} = immutable;
+
 const mockComponent = require.requireActual('./mockComponent');
 
 require.requireActual('../packager/react-packager/src/Resolver/polyfills/babelHelpers.js');
@@ -52,7 +55,9 @@ jest
         // Ensure this doesn't throw.
         try {
           Object.keys(dataBlob).forEach(key => {
-            this.items += dataBlob[key] && dataBlob[key].length;
+            const isImmutableMap = Map.isMap(dataBlob[key]);
+            this.items += isImmutableMap ?
+              (dataBlob[key] && !dataBlob[key].isEmpty()) : (dataBlob[key] && dataBlob[key].length);
           });
         } catch (e) {
           this.items = 'unknown';


### PR DESCRIPTION
Currently the jest mock for `ListViewDataSource` has a property called `items` which returns the number of items of the data source. Example from a snapshot:

    ListViewDataSource {
      "items": 6,
    }

If the datablob includes immutable Maps like:

    const dataBlob = {
      'alpha': immutable.Map({ name: 'Alpha' }),
      'beta': immutable.Map({ name: 'Beta' }),
    };

then the result is: 

    ListViewDataSource {
      "items": NaN,
    }

This PR checks if the properties of the `dataBlob` are immutable Maps and then checks whether they are empty.

The result for the above dataBlob would be:

    ListViewDataSource {
      "items": 2,
    }