### PR TITLE
[CI infra] added JSC headers download to prepare stage on Circle CI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -25,7 +25,7 @@ dependencies:
     - buck fetch ReactAndroid/src/main/java/com/facebook/react/shell
     - buck fetch ReactAndroid/src/test/...
     - buck fetch ReactAndroid/src/androidTest/...
-    - ./gradlew :ReactAndroid:downloadBoost :ReactAndroid:downloadDoubleConversion :ReactAndroid:downloadFolly :ReactAndroid:downloadGlog
+    - ./gradlew :ReactAndroid:downloadBoost :ReactAndroid:downloadDoubleConversion :ReactAndroid:downloadFolly :ReactAndroid:downloadGlog :ReactAndroid:downloadJSCHeaders
     # CIRCLE_NPM_TOKEN is in React Native project settings in Circle CI.
     # It was generated for bestander user, easy to replace with anyone's else
     - echo "//registry.npmjs.org/:_authToken=${CIRCLE_NPM_TOKEN}" > ~/.npmrc


### PR DESCRIPTION
So that Circle CI builds don't stress github API too much