### PR TITLE
add yarn-error.log to gitignore

### DIFF
--- a/local-cli/templates/HelloWorld/_gitignore
+++ b/local-cli/templates/HelloWorld/_gitignore
@@ -34,6 +34,7 @@ local.properties
 #
 node_modules/
 npm-debug.log
+yarn-error.log
 
 # BUCK
 buck-out/


### PR DESCRIPTION
Due to react-native-cli use yarn if yarn is available, we need to add yarn-error.log to .gitignore.