### PR TITLE
Fix CLI Error when there is no windows project

### DIFF
--- a/local-cli/core/config/windows/index.js
+++ b/local-cli/core/config/windows/index.js
@@ -34,13 +34,13 @@ const getProjectName = (fullProjPath) => {
 exports.projectConfig = function projectConfigWindows(folder, userConfig) {
 
   const csSolution = userConfig.csSolution || findWindowsSolution(folder);
-  const solutionPath = path.join(folder, csSolution);
 
   if (!csSolution) {
     return null;
   }
 
   // expects solutions to be named the same as project folders
+  const solutionPath = path.join(folder, csSolution);
   const windowsAppFolder = csSolution.substring(0, csSolution.lastIndexOf(".sln"));
   const src = userConfig.sourceDir || windowsAppFolder;
   const sourceDir = path.join(folder, src);


### PR DESCRIPTION
Running `master` (at https://github.com/facebook/react-native/commit/260d68bf8b39cf0fda71fd76490dd86a3373d8ea) I noticed `react-native link` fails when there is no windows project due to a bug in the code that fetches windows project configs (introduced https://github.com/facebook/react-native/commit/445182c7076593863bcf7dd191d2c4285d6c4b22). 

There's a guard to return early if `csSolution` (the relative path of the windows solution) is null but it needs to be a line earlier, because `path.join` errors when passed a non-string. 

Tested locally on a non-windows project, `react-native link` errored previously and now succeeds.
