### PR TITLE
[Podspec] Fix duplicate symbols error

### DIFF
--- a/React.podspec
+++ b/React.podspec
@@ -33,7 +33,7 @@ Pod::Spec.new do |s|
   s.subspec 'Core' do |ss|
     ss.dependency      'React/CSSLayout'
     ss.source_files  = "React/**/*.{c,h,m,mm,S}"
-    ss.exclude_files = "**/__tests__/*", "IntegrationTests/* ReactCommon/CSSLayout/*"
+    ss.exclude_files = "**/__tests__/*", "IntegrationTests/* ReactCommon/CSSLayout/*", "React/CSSLayout/*"
     ss.frameworks    = "JavaScriptCore"
     ss.libraries     = "stdc++"
   end


### PR DESCRIPTION
Closes https://github.com/facebook/react-native/issues/11502. We have the same problem in our app. Could you release this patch in 0.39.3, because the react-native@0.40.0 has huge breaking changes and we won't quickly update to it?