### PR TITLE
Add a default case to `Platform.select`

### DIFF
--- a/Libraries/Utilities/Platform.android.js
+++ b/Libraries/Utilities/Platform.android.js
@@ -18,7 +18,7 @@ const Platform = {
     const AndroidConstants = require('NativeModules').AndroidConstants;
     return AndroidConstants && AndroidConstants.Version;
   },
-  select: (obj: Object) => obj.android,
+  select: (obj: Object) => 'android' in obj ? obj.android : obj.default,
 };
 
 module.exports = Platform;

--- a/Libraries/Utilities/Platform.ios.js
+++ b/Libraries/Utilities/Platform.ios.js
@@ -22,7 +22,7 @@ const Platform = {
     const constants = require('NativeModules').IOSConstants;
     return constants ? (constants.interfaceIdiom === 'tv') : false;
   },
-  select: (obj: Object) => obj.ios,
+  select: (obj: Object) => 'ios' in obj ? obj.ios : obj.default,,
 };
 
 module.exports = Platform;


### PR DESCRIPTION
You could then do this,

```js
Platform.select({
  android: require('./AndroidSpecificImpl'),
  default: require('./GenericImpl'),
})
```

It'll be useful since we've more platforms now, e.g. - windows