### PR TITLE
Fix <React/... BC break: Add ifndef surrounds to iOS headers

### DIFF
--- a/Examples/UIExplorer/UIExplorerUnitTests/OCMock/NSNotificationCenter+OCMAdditions.h
+++ b/Examples/UIExplorer/UIExplorerUnitTests/OCMock/NSNotificationCenter+OCMAdditions.h
@@ -14,6 +14,9 @@
  *  under the License.
  */
 
+#ifndef NSNOTIFICATIONCENTER_OCMADDITIONS_H
+#define NSNOTIFICATIONCENTER_OCMADDITIONS_H
+
 #import <Foundation/Foundation.h>
 
 @class OCObserverMockObject;
@@ -24,3 +27,5 @@
 - (void)addMockObserver:(OCObserverMockObject *)notificationObserver name:(NSString *)notificationName object:(id)notificationSender;
 
 @end
+
+#endif //NSNOTIFICATIONCENTER_OCMADDITIONS_H

--- a/Examples/UIExplorer/UIExplorerUnitTests/OCMock/NSNotificationCenter+OCMAdditions.h
+++ b/Examples/UIExplorer/UIExplorerUnitTests/OCMock/NSNotificationCenter+OCMAdditions.h
@@ -14,9 +14,6 @@
  *  under the License.
  */
 
-#ifndef NSNOTIFICATIONCENTER_OCMADDITIONS_H
-#define NSNOTIFICATIONCENTER_OCMADDITIONS_H
-
 #import <Foundation/Foundation.h>
 
 @class OCObserverMockObject;
@@ -27,5 +24,3 @@
 - (void)addMockObserver:(OCObserverMockObject *)notificationObserver name:(NSString *)notificationName object:(id)notificationSender;
 
 @end
-
-#endif //NSNOTIFICATIONCENTER_OCMADDITIONS_H

--- a/Libraries/ART/ARTCGFloatArray.h
+++ b/Libraries/ART/ARTCGFloatArray.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef ARTCGFLOATARRAY_H
+#define ARTCGFLOATARRAY_H
+
 // A little helper to make sure we have the right memory allocation ready for use.
 // We assume that we will only this in one place so no reference counting is necessary.
 // Needs to be freed when dealloced.
@@ -18,3 +21,5 @@ typedef struct {
   size_t count;
   CGFloat *array;
 } ARTCGFloatArray;
+
+#endif //ARTCGFLOATARRAY_H

--- a/Libraries/ART/ARTContainer.h
+++ b/Libraries/ART/ARTContainer.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef ARTCONTAINER_H
+#define ARTCONTAINER_H
+
 #import <Foundation/Foundation.h>
 
 @protocol ARTContainer <NSObject>
@@ -16,3 +19,5 @@
 - (void)invalidate;
 
 @end
+
+#endif //ARTCONTAINER_H

--- a/Libraries/ART/ARTGroup.h
+++ b/Libraries/ART/ARTGroup.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef ARTGROUP_H
+#define ARTGROUP_H
+
 #import <Foundation/Foundation.h>
 
 #import "ARTContainer.h"
@@ -17,3 +20,5 @@
 @property (nonatomic, assign) CGRect clipping;
 
 @end
+
+#endif //ARTGROUP_H

--- a/Libraries/ART/ARTNode.h
+++ b/Libraries/ART/ARTNode.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef ARTNODE_H
+#define ARTNODE_H
+
 #import <React/UIView+React.h>
 
 /**
@@ -30,3 +33,5 @@
 - (void)renderLayerTo:(CGContextRef)context;
 
 @end
+
+#endif //ARTNODE_H

--- a/Libraries/ART/ARTRenderable.h
+++ b/Libraries/ART/ARTRenderable.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef ARTRENDERABLE_H
+#define ARTRENDERABLE_H
+
 #import <Foundation/Foundation.h>
 
 #import "ARTBrush.h"
@@ -23,3 +26,5 @@
 @property (nonatomic, assign) ARTCGFloatArray strokeDash;
 
 @end
+
+#endif //ARTRENDERABLE_H

--- a/Libraries/ART/ARTShape.h
+++ b/Libraries/ART/ARTShape.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef ARTSHAPE_H
+#define ARTSHAPE_H
+
 #import <Foundation/Foundation.h>
 
 #import "ARTRenderable.h"
@@ -16,3 +19,5 @@
 @property (nonatomic, assign) CGPathRef d;
 
 @end
+
+#endif //ARTSHAPE_H

--- a/Libraries/ART/ARTSurfaceView.h
+++ b/Libraries/ART/ARTSurfaceView.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef ARTSURFACEVIEW_H
+#define ARTSURFACEVIEW_H
+
 #import <UIKit/UIKit.h>
 
 #import "ARTContainer.h"
@@ -14,3 +17,5 @@
 @interface ARTSurfaceView : UIView <ARTContainer>
 
 @end
+
+#endif //ARTSURFACEVIEW_H

--- a/Libraries/ART/ARTText.h
+++ b/Libraries/ART/ARTText.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef ARTTEXT_H
+#define ARTTEXT_H
+
 #import <Foundation/Foundation.h>
 
 #import "ARTRenderable.h"
@@ -18,3 +21,5 @@
 @property (nonatomic, assign) ARTTextFrame textFrame;
 
 @end
+
+#endif //ARTTEXT_H

--- a/Libraries/ART/ARTTextFrame.h
+++ b/Libraries/ART/ARTTextFrame.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef ARTTEXTFRAME_H
+#define ARTTEXTFRAME_H
+
 #import <CoreText/CoreText.h>
 
 // A little helper to make sure we have a set of lines including width ready for use.
@@ -23,3 +26,5 @@ typedef struct {
   CTLineRef *lines;
   CGFloat *widths; // Width of each line
 } ARTTextFrame;
+
+#endif //ARTTEXTFRAME_H

--- a/Libraries/ART/Brushes/ARTBrush.h
+++ b/Libraries/ART/Brushes/ARTBrush.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef ARTBRUSH_H
+#define ARTBRUSH_H
+
 #import <CoreGraphics/CoreGraphics.h>
 #import <Foundation/Foundation.h>
 
@@ -33,3 +36,5 @@
 - (void)paint:(CGContextRef)context;
 
 @end
+
+#endif //ARTBRUSH_H

--- a/Libraries/ART/Brushes/ARTLinearGradient.h
+++ b/Libraries/ART/Brushes/ARTLinearGradient.h
@@ -7,8 +7,13 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef ARTLINEARGRADIENT_H
+#define ARTLINEARGRADIENT_H
+
 #import "ARTBrush.h"
 
 @interface ARTLinearGradient : ARTBrush
 
 @end
+
+#endif //ARTLINEARGRADIENT_H

--- a/Libraries/ART/Brushes/ARTPattern.h
+++ b/Libraries/ART/Brushes/ARTPattern.h
@@ -7,8 +7,13 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef ARTPATTERN_H
+#define ARTPATTERN_H
+
 #import "ARTBrush.h"
 
 @interface ARTPattern : ARTBrush
 
 @end
+
+#endif //ARTPATTERN_H

--- a/Libraries/ART/Brushes/ARTRadialGradient.h
+++ b/Libraries/ART/Brushes/ARTRadialGradient.h
@@ -7,8 +7,13 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef ARTRADIALGRADIENT_H
+#define ARTRADIALGRADIENT_H
+
 #import "ARTBrush.h"
 
 @interface ARTRadialGradient : ARTBrush
 
 @end
+
+#endif //ARTRADIALGRADIENT_H

--- a/Libraries/ART/Brushes/ARTSolidColor.h
+++ b/Libraries/ART/Brushes/ARTSolidColor.h
@@ -7,8 +7,13 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef ARTSOLIDCOLOR_H
+#define ARTSOLIDCOLOR_H
+
 #import "ARTBrush.h"
 
 @interface ARTSolidColor : ARTBrush
 
 @end
+
+#endif //ARTSOLIDCOLOR_H

--- a/Libraries/ART/RCTConvert+ART.h
+++ b/Libraries/ART/RCTConvert+ART.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTCONVERT_ART_H
+#define RCTCONVERT_ART_H
+
 #import <QuartzCore/QuartzCore.h>
 
 #import <React/RCTConvert.h>
@@ -29,3 +32,5 @@
 + (CGGradientRef)CGGradient:(id)json offset:(NSUInteger)offset;
 
 @end
+
+#endif //RCTCONVERT_ART_H

--- a/Libraries/ART/ViewManagers/ARTGroupManager.h
+++ b/Libraries/ART/ViewManagers/ARTGroupManager.h
@@ -7,8 +7,13 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef ARTGROUPMANAGER_H
+#define ARTGROUPMANAGER_H
+
 #import "ARTNodeManager.h"
 
 @interface ARTGroupManager : ARTNodeManager
 
 @end
+
+#endif //ARTGROUPMANAGER_H

--- a/Libraries/ART/ViewManagers/ARTNodeManager.h
+++ b/Libraries/ART/ViewManagers/ARTNodeManager.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef ARTNODEMANAGER_H
+#define ARTNODEMANAGER_H
+
 #import <React/RCTViewManager.h>
 
 @class ARTNode;
@@ -16,3 +19,5 @@
 - (ARTNode *)node;
 
 @end
+
+#endif //ARTNODEMANAGER_H

--- a/Libraries/ART/ViewManagers/ARTRenderableManager.h
+++ b/Libraries/ART/ViewManagers/ARTRenderableManager.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef ARTRENDERABLEMANAGER_H
+#define ARTRENDERABLEMANAGER_H
+
 #import "ARTNodeManager.h"
 #import "ARTRenderable.h"
 
@@ -15,3 +18,5 @@
 - (ARTRenderable *)node;
 
 @end
+
+#endif //ARTRENDERABLEMANAGER_H

--- a/Libraries/ART/ViewManagers/ARTShapeManager.h
+++ b/Libraries/ART/ViewManagers/ARTShapeManager.h
@@ -7,8 +7,13 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef ARTSHAPEMANAGER_H
+#define ARTSHAPEMANAGER_H
+
 #import "ARTRenderableManager.h"
 
 @interface ARTShapeManager : ARTRenderableManager
 
 @end
+
+#endif //ARTSHAPEMANAGER_H

--- a/Libraries/ART/ViewManagers/ARTSurfaceViewManager.h
+++ b/Libraries/ART/ViewManagers/ARTSurfaceViewManager.h
@@ -7,8 +7,13 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef ARTSURFACEVIEWMANAGER_H
+#define ARTSURFACEVIEWMANAGER_H
+
 #import <React/RCTViewManager.h>
 
 @interface ARTSurfaceViewManager : RCTViewManager
 
 @end
+
+#endif //ARTSURFACEVIEWMANAGER_H

--- a/Libraries/ART/ViewManagers/ARTTextManager.h
+++ b/Libraries/ART/ViewManagers/ARTTextManager.h
@@ -7,8 +7,13 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef ARTTEXTMANAGER_H
+#define ARTTEXTMANAGER_H
+
 #import "ARTRenderableManager.h"
 
 @interface ARTTextManager : ARTRenderableManager
 
 @end
+
+#endif //ARTTEXTMANAGER_H

--- a/Libraries/ActionSheetIOS/RCTActionSheetManager.h
+++ b/Libraries/ActionSheetIOS/RCTActionSheetManager.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTACTIONSHEETMANAGER_H
+#define RCTACTIONSHEETMANAGER_H
+
 #import <UIKit/UIKit.h>
 
 #import <React/RCTBridge.h>
@@ -14,3 +17,5 @@
 @interface RCTActionSheetManager : NSObject <RCTBridgeModule>
 
 @end
+
+#endif //RCTACTIONSHEETMANAGER_H

--- a/Libraries/AdSupport/RCTAdSupport.h
+++ b/Libraries/AdSupport/RCTAdSupport.h
@@ -7,8 +7,13 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTADSUPPORT_H
+#define RCTADSUPPORT_H
+
 #import <React/RCTBridgeModule.h>
 
 @interface RCTAdSupport : NSObject <RCTBridgeModule>
 
 @end
+
+#endif //RCTADSUPPORT_H

--- a/Libraries/CameraRoll/RCTAssetsLibraryRequestHandler.h
+++ b/Libraries/CameraRoll/RCTAssetsLibraryRequestHandler.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTASSETSLIBRARYREQUESTHANDLER_H
+#define RCTASSETSLIBRARYREQUESTHANDLER_H
+
 #import <React/RCTBridge.h>
 #import <React/RCTURLRequestHandler.h>
 
@@ -24,3 +27,5 @@
 @property (nonatomic, readonly) ALAssetsLibrary *assetsLibrary;
 
 @end
+
+#endif //RCTASSETSLIBRARYREQUESTHANDLER_H

--- a/Libraries/CameraRoll/RCTCameraRollManager.h
+++ b/Libraries/CameraRoll/RCTCameraRollManager.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTCAMERAROLLMANAGER_H
+#define RCTCAMERAROLLMANAGER_H
+
 #import <AssetsLibrary/AssetsLibrary.h>
 
 #import <React/RCTBridgeModule.h>
@@ -22,3 +25,5 @@
 @interface RCTCameraRollManager : NSObject <RCTBridgeModule>
 
 @end
+
+#endif //RCTCAMERAROLLMANAGER_H

--- a/Libraries/CameraRoll/RCTImagePickerManager.h
+++ b/Libraries/CameraRoll/RCTImagePickerManager.h
@@ -6,6 +6,9 @@
  *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
+
+#ifndef RCTIMAGEPICKERMANAGER_H
+#define RCTIMAGEPICKERMANAGER_H
  */
 
 #import <React/RCTBridgeModule.h>
@@ -13,3 +16,5 @@
 @interface RCTImagePickerManager : NSObject <RCTBridgeModule>
 
 @end
+
+#endif //RCTIMAGEPICKERMANAGER_H

--- a/Libraries/CameraRoll/RCTImagePickerManager.h
+++ b/Libraries/CameraRoll/RCTImagePickerManager.h
@@ -6,10 +6,10 @@
  *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
-
-#ifndef RCTIMAGEPICKERMANAGER_H
-#define RCTIMAGEPICKERMANAGER_H
  */
+
+ #ifndef RCTIMAGEPICKERMANAGER_H
+ #define RCTIMAGEPICKERMANAGER_H
 
 #import <React/RCTBridgeModule.h>
 

--- a/Libraries/CameraRoll/RCTPhotoLibraryImageLoader.h
+++ b/Libraries/CameraRoll/RCTPhotoLibraryImageLoader.h
@@ -7,8 +7,13 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTPHOTOLIBRARYIMAGELOADER_H
+#define RCTPHOTOLIBRARYIMAGELOADER_H
+
 #import <React/RCTImageLoader.h>
 
 @interface RCTPhotoLibraryImageLoader : NSObject <RCTImageURLLoader>
 
 @end
+
+#endif //RCTPHOTOLIBRARYIMAGELOADER_H

--- a/Libraries/Geolocation/RCTLocationObserver.h
+++ b/Libraries/Geolocation/RCTLocationObserver.h
@@ -7,8 +7,13 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTLOCATIONOBSERVER_H
+#define RCTLOCATIONOBSERVER_H
+
 #import <React/RCTEventEmitter.h>
 
 @interface RCTLocationObserver : RCTEventEmitter
 
 @end
+
+#endif //RCTLOCATIONOBSERVER_H

--- a/Libraries/Image/RCTGIFImageDecoder.h
+++ b/Libraries/Image/RCTGIFImageDecoder.h
@@ -7,8 +7,13 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTGIFIMAGEDECODER_H
+#define RCTGIFIMAGEDECODER_H
+
 #import <React/RCTImageLoader.h>
 
 @interface RCTGIFImageDecoder : NSObject <RCTImageDataDecoder>
 
 @end
+
+#endif //RCTGIFIMAGEDECODER_H

--- a/Libraries/Image/RCTImageBlurUtils.h
+++ b/Libraries/Image/RCTImageBlurUtils.h
@@ -8,9 +8,14 @@
  *
  */
 
+#ifndef RCTIMAGEBLURUTILS_H
+#define RCTIMAGEBLURUTILS_H
+
 #import <Accelerate/Accelerate.h>
 #import <UIKit/UIKit.h>
 
 #import <React/RCTDefines.h>
 
 RCT_EXTERN UIImage *RCTBlurredImageWithRadius(UIImage *inputImage, CGFloat radius);
+
+#endif //RCTIMAGEBLURUTILS_H

--- a/Libraries/Image/RCTImageCache.h
+++ b/Libraries/Image/RCTImageCache.h
@@ -7,9 +7,14 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTIMAGECACHE_H
+#define RCTIMAGECACHE_H
+
 #import <Foundation/Foundation.h>
 
 #import <React/RCTImageLoader.h>
 
 @interface RCTImageCache : NSObject <RCTImageCache>
 @end
+
+#endif //RCTIMAGECACHE_H

--- a/Libraries/Image/RCTImageEditingManager.h
+++ b/Libraries/Image/RCTImageEditingManager.h
@@ -7,8 +7,13 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTIMAGEEDITINGMANAGER_H
+#define RCTIMAGEEDITINGMANAGER_H
+
 #import <React/RCTBridgeModule.h>
 
 @interface RCTImageEditingManager : NSObject <RCTBridgeModule>
 
 @end
+
+#endif //RCTIMAGEEDITINGMANAGER_H

--- a/Libraries/Image/RCTImageLoader.h
+++ b/Libraries/Image/RCTImageLoader.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTIMAGELOADER_H
+#define RCTIMAGELOADER_H
+
 #import <UIKit/UIKit.h>
 
 #import <React/RCTBridge.h>
@@ -231,3 +234,5 @@ typedef dispatch_block_t RCTImageLoaderCancellationBlock;
 - (float)decoderPriority;
 
 @end
+
+#endif //RCTIMAGELOADER_H

--- a/Libraries/Image/RCTImageStoreManager.h
+++ b/Libraries/Image/RCTImageStoreManager.h
@@ -7,6 +7,9 @@
 
 @interface RCTImageStoreManager : NSObject <RCTURLRequestHandler>
 
+#ifndef RCTIMAGESTOREMANAGER_H
+#define RCTIMAGESTOREMANAGER_H
+
 /**
  * Set and get cached image data asynchronously. It is safe to call these from any
  * thread. The callbacks will be called on an unspecified thread.
@@ -39,3 +42,5 @@
 @property (nonatomic, readonly) RCTImageStoreManager *imageStoreManager;
 
 @end
+
+#endif //RCTIMAGESTOREMANAGER_H

--- a/Libraries/Image/RCTImageUtils.h
+++ b/Libraries/Image/RCTImageUtils.h
@@ -8,6 +8,9 @@
  *
  */
 
+#ifndef RCTIMAGEUTILS_H
+#define RCTIMAGEUTILS_H
+
 #import <UIKit/UIKit.h>
 
 #import <React/RCTDefines.h>
@@ -94,3 +97,5 @@ RCT_EXTERN UIImage *__nullable RCTTransformImage(UIImage *image,
 RCT_EXTERN BOOL RCTImageHasAlpha(CGImageRef image);
 
 NS_ASSUME_NONNULL_END
+
+#endif //RCTIMAGEUTILS_H

--- a/Libraries/Image/RCTImageView.h
+++ b/Libraries/Image/RCTImageView.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTIMAGEVIEW_H
+#define RCTIMAGEVIEW_H
+
 #import <UIKit/UIKit.h>
 
 #import <React/RCTResizeMode.h>
@@ -26,3 +29,5 @@
 @property (nonatomic, assign) RCTResizeMode resizeMode;
 
 @end
+
+#endif //RCTIMAGEVIEW_H

--- a/Libraries/Image/RCTImageViewManager.h
+++ b/Libraries/Image/RCTImageViewManager.h
@@ -7,8 +7,13 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTIMAGEVIEWMANAGER_H
+#define RCTIMAGEVIEWMANAGER_H
+
 #import <React/RCTViewManager.h>
 
 @interface RCTImageViewManager : RCTViewManager
 
 @end
+
+#endif //RCTIMAGEVIEWMANAGER_H

--- a/Libraries/Image/RCTLocalAssetImageLoader.h
+++ b/Libraries/Image/RCTLocalAssetImageLoader.h
@@ -7,8 +7,13 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTLOCALASSETIMAGELOADER_H
+#define RCTLOCALASSETIMAGELOADER_H
+
 #import <React/RCTImageLoader.h>
 
 @interface RCTLocalAssetImageLoader : NSObject <RCTImageURLLoader>
 
 @end
+
+#endif //RCTLOCALASSETIMAGELOADER_H

--- a/Libraries/Image/RCTResizeMode.h
+++ b/Libraries/Image/RCTResizeMode.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTRESIZEMODE_H
+#define RCTRESIZEMODE_H
+
 #import <React/RCTConvert.h>
 
 typedef NS_ENUM(NSInteger, RCTResizeMode) {
@@ -22,3 +25,5 @@ typedef NS_ENUM(NSInteger, RCTResizeMode) {
 + (RCTResizeMode)RCTResizeMode:(id)json;
 
 @end
+
+#endif //RCTRESIZEMODE_H

--- a/Libraries/LinkingIOS/RCTLinkingManager.h
+++ b/Libraries/LinkingIOS/RCTLinkingManager.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTLINKINGMANAGER_H
+#define RCTLINKINGMANAGER_H
+
 #import <UIKit/UIKit.h>
 
 #import <React/RCTEventEmitter.h>
@@ -23,3 +26,5 @@ continueUserActivity:(NSUserActivity *)userActivity
   restorationHandler:(void (^)(NSArray *))restorationHandler;
 
 @end
+
+#endif //RCTLINKINGMANAGER_H

--- a/Libraries/NativeAnimation/Drivers/RCTAnimationDriver.h
+++ b/Libraries/NativeAnimation/Drivers/RCTAnimationDriver.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTANIMATIONDRIVER_H
+#define RCTANIMATIONDRIVER_H
+
 #import <Foundation/Foundation.h>
 #import <CoreGraphics/CoreGraphics.h>
 
@@ -36,3 +39,5 @@ NS_ASSUME_NONNULL_BEGIN
 NS_ASSUME_NONNULL_END
 
 @end
+
+#endif //RCTANIMATIONDRIVER_H

--- a/Libraries/NativeAnimation/Drivers/RCTEventAnimation.h
+++ b/Libraries/NativeAnimation/Drivers/RCTEventAnimation.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTEVENTANIMATION_H
+#define RCTEVENTANIMATION_H
+
 #import <React/RCTEventDispatcher.h>
 
 #import "RCTValueAnimatedNode.h"
@@ -21,3 +24,5 @@
 - (void)updateWithEvent:(id<RCTEvent>)event;
 
 @end
+
+#endif //RCTEVENTANIMATION_H

--- a/Libraries/NativeAnimation/Drivers/RCTFrameAnimation.h
+++ b/Libraries/NativeAnimation/Drivers/RCTFrameAnimation.h
@@ -7,8 +7,13 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTFRAMEANIMATION_H
+#define RCTFRAMEANIMATION_H
+
 #import "RCTAnimationDriver.h"
 
 @interface RCTFrameAnimation : NSObject<RCTAnimationDriver>
 
 @end
+
+#endif //RCTFRAMEANIMATION_H

--- a/Libraries/NativeAnimation/Drivers/RCTSpringAnimation.h
+++ b/Libraries/NativeAnimation/Drivers/RCTSpringAnimation.h
@@ -7,8 +7,13 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTSPRINGANIMATION_H
+#define RCTSPRINGANIMATION_H
+
 #import "RCTAnimationDriver.h"
 
 @interface RCTSpringAnimation : NSObject<RCTAnimationDriver>
 
 @end
+
+#endif //RCTSPRINGANIMATION_H

--- a/Libraries/NativeAnimation/Nodes/RCTAdditionAnimatedNode.h
+++ b/Libraries/NativeAnimation/Nodes/RCTAdditionAnimatedNode.h
@@ -7,8 +7,13 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTADDITIONANIMATEDNODE_H
+#define RCTADDITIONANIMATEDNODE_H
+
 #import "RCTValueAnimatedNode.h"
 
 @interface RCTAdditionAnimatedNode : RCTValueAnimatedNode
 
 @end
+
+#endif //RCTADDITIONANIMATEDNODE_H

--- a/Libraries/NativeAnimation/Nodes/RCTAnimatedNode.h
+++ b/Libraries/NativeAnimation/Nodes/RCTAnimatedNode.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTANIMATEDNODE_H
+#define RCTANIMATEDNODE_H
+
 #import <Foundation/Foundation.h>
 
 @interface RCTAnimatedNode : NSObject
@@ -46,3 +49,5 @@
 - (void)detachNode NS_REQUIRES_SUPER;
 
 @end
+
+#endif //RCTANIMATEDNODE_H

--- a/Libraries/NativeAnimation/Nodes/RCTDiffClampAnimatedNode.h
+++ b/Libraries/NativeAnimation/Nodes/RCTDiffClampAnimatedNode.h
@@ -7,8 +7,13 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTDIFFCLAMPANIMATEDNODE_H
+#define RCTDIFFCLAMPANIMATEDNODE_H
+
 #import "RCTValueAnimatedNode.h"
 
 @interface RCTDiffClampAnimatedNode : RCTValueAnimatedNode
 
 @end
+
+#endif //RCTDIFFCLAMPANIMATEDNODE_H

--- a/Libraries/NativeAnimation/Nodes/RCTDivisionAnimatedNode.h
+++ b/Libraries/NativeAnimation/Nodes/RCTDivisionAnimatedNode.h
@@ -7,8 +7,13 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTDIVISIONANIMATEDNODE_H
+#define RCTDIVISIONANIMATEDNODE_H
+
 #import "RCTValueAnimatedNode.h"
 
 @interface RCTDivisionAnimatedNode : RCTValueAnimatedNode
 
 @end
+
+#endif //RCTDIVISIONANIMATEDNODE_H

--- a/Libraries/NativeAnimation/Nodes/RCTInterpolationAnimatedNode.h
+++ b/Libraries/NativeAnimation/Nodes/RCTInterpolationAnimatedNode.h
@@ -7,8 +7,13 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTINTERPOLATIONANIMATEDNODE_H
+#define RCTINTERPOLATIONANIMATEDNODE_H
+
 #import "RCTValueAnimatedNode.h"
 
 @interface RCTInterpolationAnimatedNode : RCTValueAnimatedNode
 
 @end
+
+#endif //RCTINTERPOLATIONANIMATEDNODE_H

--- a/Libraries/NativeAnimation/Nodes/RCTModuloAnimatedNode.h
+++ b/Libraries/NativeAnimation/Nodes/RCTModuloAnimatedNode.h
@@ -7,8 +7,13 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTMODULOANIMATEDNODE_H
+#define RCTMODULOANIMATEDNODE_H
+
 #import "RCTValueAnimatedNode.h"
 
 @interface RCTModuloAnimatedNode : RCTValueAnimatedNode
 
 @end
+
+#endif //RCTMODULOANIMATEDNODE_H

--- a/Libraries/NativeAnimation/Nodes/RCTMultiplicationAnimatedNode.h
+++ b/Libraries/NativeAnimation/Nodes/RCTMultiplicationAnimatedNode.h
@@ -7,8 +7,13 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTMULTIPLICATIONANIMATEDNODE_H
+#define RCTMULTIPLICATIONANIMATEDNODE_H
+
 #import "RCTValueAnimatedNode.h"
 
 @interface RCTMultiplicationAnimatedNode : RCTValueAnimatedNode
 
 @end
+
+#endif //RCTMULTIPLICATIONANIMATEDNODE_H

--- a/Libraries/NativeAnimation/Nodes/RCTPropsAnimatedNode.h
+++ b/Libraries/NativeAnimation/Nodes/RCTPropsAnimatedNode.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTPROPSANIMATEDNODE_H
+#define RCTPROPSANIMATEDNODE_H
+
 #import "RCTAnimatedNode.h"
 
 @class RCTUIManager;
@@ -22,3 +25,5 @@
 - (void)performViewUpdatesIfNecessary;
 
 @end
+
+#endif //RCTPROPSANIMATEDNODE_H

--- a/Libraries/NativeAnimation/Nodes/RCTStyleAnimatedNode.h
+++ b/Libraries/NativeAnimation/Nodes/RCTStyleAnimatedNode.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTSTYLEANIMATEDNODE_H
+#define RCTSTYLEANIMATEDNODE_H
+
 #import "RCTAnimatedNode.h"
 
 @interface RCTStyleAnimatedNode : RCTAnimatedNode
@@ -14,3 +17,5 @@
 - (NSDictionary<NSString *, NSObject *> *)propsDictionary;
 
 @end
+
+#endif //RCTSTYLEANIMATEDNODE_H

--- a/Libraries/NativeAnimation/Nodes/RCTTransformAnimatedNode.h
+++ b/Libraries/NativeAnimation/Nodes/RCTTransformAnimatedNode.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTTRANSFORMANIMATEDNODE_H
+#define RCTTRANSFORMANIMATEDNODE_H
+
 #import "RCTAnimatedNode.h"
 
 @interface RCTTransformAnimatedNode : RCTAnimatedNode
@@ -14,3 +17,5 @@
 - (NSDictionary<NSString *, NSObject *> *)propsDictionary;
 
 @end
+
+#endif //RCTTRANSFORMANIMATEDNODE_H

--- a/Libraries/NativeAnimation/Nodes/RCTValueAnimatedNode.h
+++ b/Libraries/NativeAnimation/Nodes/RCTValueAnimatedNode.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTVALUEANIMATEDNODE_H
+#define RCTVALUEANIMATEDNODE_H
+
 #import <UIKit/UIKit.h>
 
 #import "RCTAnimatedNode.h"
@@ -29,3 +32,5 @@
 @property (nonatomic, weak) id<RCTValueAnimatedNodeObserver> valueObserver;
 
 @end
+
+#endif //RCTVALUEANIMATEDNODE_H

--- a/Libraries/NativeAnimation/RCTAnimationUtils.h
+++ b/Libraries/NativeAnimation/RCTAnimationUtils.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTANIMATIONUTILS_H
+#define RCTANIMATIONUTILS_H
+
 #import <CoreGraphics/CoreGraphics.h>
 #import <Foundation/Foundation.h>
 
@@ -26,3 +29,5 @@ RCT_EXTERN CGFloat RCTInterpolateValue(CGFloat value,
 
 RCT_EXTERN CGFloat RCTRadiansToDegrees(CGFloat radians);
 RCT_EXTERN CGFloat RCTDegreesToRadians(CGFloat degrees);
+
+#endif //RCTANIMATIONUTILS_H

--- a/Libraries/NativeAnimation/RCTNativeAnimatedModule.h
+++ b/Libraries/NativeAnimation/RCTNativeAnimatedModule.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTNATIVEANIMATEDMODULE_H
+#define RCTNATIVEANIMATEDMODULE_H
+
 #import <React/RCTBridgeModule.h>
 #import <React/RCTEventDispatcher.h>
 #import <React/RCTEventEmitter.h>
@@ -16,3 +19,5 @@
 @interface RCTNativeAnimatedModule : RCTEventEmitter <RCTBridgeModule, RCTValueAnimatedNodeObserver, RCTEventDispatcherObserver>
 
 @end
+
+#endif //RCTNATIVEANIMATEDMODULE_H

--- a/Libraries/NativeAnimation/RCTNativeAnimatedNodesManager.h
+++ b/Libraries/NativeAnimation/RCTNativeAnimatedNodesManager.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTNATIVEANIMATEDNODESMANAGER_H
+#define RCTNATIVEANIMATEDNODESMANAGER_H
+
 #import <Foundation/Foundation.h>
 
 #import <React/RCTUIManager.h>
@@ -80,3 +83,5 @@
                            valueObserver:(nonnull id<RCTValueAnimatedNodeObserver>)valueObserver;
 
 @end
+
+#endif //RCTNATIVEANIMATEDNODESMANAGER_H

--- a/Libraries/NativeAnimation/RCTViewPropertyMapper.h
+++ b/Libraries/NativeAnimation/RCTViewPropertyMapper.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTVIEWPROPERTYMAPPER_H
+#define RCTVIEWPROPERTYMAPPER_H
+
 #import <Foundation/Foundation.h>
 
 @class RCTUIManager;
@@ -21,3 +24,5 @@
 - (void)updateViewWithDictionary:(NSDictionary<NSString *, NSObject *> *)updates;
 
 @end
+
+#endif //RCTVIEWPROPERTYMAPPER_H

--- a/Libraries/Network/RCTDataRequestHandler.h
+++ b/Libraries/Network/RCTDataRequestHandler.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTDATAREQUESTHANDLER_H
+#define RCTDATAREQUESTHANDLER_H
+
 #import <React/RCTInvalidating.h>
 #import <React/RCTURLRequestHandler.h>
 
@@ -16,3 +19,5 @@
 @interface RCTDataRequestHandler : NSObject <RCTURLRequestHandler, RCTInvalidating>
 
 @end
+
+#endif //RCTDATAREQUESTHANDLER_H

--- a/Libraries/Network/RCTFileRequestHandler.h
+++ b/Libraries/Network/RCTFileRequestHandler.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTFILEREQUESTHANDLER_H
+#define RCTFILEREQUESTHANDLER_H
+
 #import <React/RCTInvalidating.h>
 #import <React/RCTURLRequestHandler.h>
 
@@ -16,3 +19,5 @@
 @interface RCTFileRequestHandler : NSObject <RCTURLRequestHandler, RCTInvalidating>
 
 @end
+
+#endif //RCTFILEREQUESTHANDLER_H

--- a/Libraries/Network/RCTHTTPRequestHandler.h
+++ b/Libraries/Network/RCTHTTPRequestHandler.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTHTTPREQUESTHANDLER_H
+#define RCTHTTPREQUESTHANDLER_H
+
 #import <React/RCTInvalidating.h>
 #import <React/RCTURLRequestHandler.h>
 
@@ -16,3 +19,5 @@
 @interface RCTHTTPRequestHandler : NSObject <RCTURLRequestHandler, RCTInvalidating>
 
 @end
+
+#endif //RCTHTTPREQUESTHANDLER_H

--- a/Libraries/Network/RCTNetInfo.h
+++ b/Libraries/Network/RCTNetInfo.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTNETINFO_H
+#define RCTNETINFO_H
+
 #import <SystemConfiguration/SystemConfiguration.h>
 
 #import <React/RCTEventEmitter.h>
@@ -16,3 +19,5 @@
 - (instancetype)initWithHost:(NSString *)host;
 
 @end
+
+#endif //RCTNETINFO_H

--- a/Libraries/Network/RCTNetworkTask.h
+++ b/Libraries/Network/RCTNetworkTask.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTNETWORKTASK_H
+#define RCTNETWORKTASK_H
+
 #import <Foundation/Foundation.h>
 
 #import <React/RCTURLRequestDelegate.h>
@@ -47,3 +50,5 @@ typedef NS_ENUM(NSInteger, RCTNetworkTaskStatus) {
 - (void)cancel;
 
 @end
+
+#endif //RCTNETWORKTASK_H

--- a/Libraries/Network/RCTNetworking.h
+++ b/Libraries/Network/RCTNetworking.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTNETWORKING_H
+#define RCTNETWORKING_H
+
 #import <React/RCTEventEmitter.h>
 #import <React/RCTNetworkTask.h>
 
@@ -31,3 +34,5 @@
 @property (nonatomic, readonly) RCTNetworking *networking;
 
 @end
+
+#endif //RCTNETWORKING_H

--- a/Libraries/PushNotificationIOS/RCTPushNotificationManager.h
+++ b/Libraries/PushNotificationIOS/RCTPushNotificationManager.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTPUSHNOTIFICATIONMANAGER_H
+#define RCTPUSHNOTIFICATIONMANAGER_H
+
 #import <React/RCTEventEmitter.h>
 
 @interface RCTPushNotificationManager : RCTEventEmitter
@@ -23,3 +26,5 @@ typedef void (^RCTRemoteNotificationCallback)(UIBackgroundFetchResult result);
 #endif
 
 @end
+
+#endif //RCTPUSHNOTIFICATIONMANAGER_H

--- a/Libraries/RCTTest/FBSnapshotTestCase/UIImage+Compare.h
+++ b/Libraries/RCTTest/FBSnapshotTestCase/UIImage+Compare.h
@@ -28,6 +28,9 @@
 //  OTHER DEALINGS IN THE SOFTWARE.
 //
 
+#ifndef UIIMAGE_COMPARE_H
+#define UIIMAGE_COMPARE_H
+
 #import <UIKit/UIKit.h>
 
 @interface UIImage (Compare)
@@ -35,3 +38,5 @@
 - (BOOL)compareWithImage:(UIImage *)image;
 
 @end
+
+#endif //UIIMAGE_COMPARE_H

--- a/Libraries/RCTTest/FBSnapshotTestCase/UIImage+Diff.h
+++ b/Libraries/RCTTest/FBSnapshotTestCase/UIImage+Diff.h
@@ -28,6 +28,9 @@
 //  OTHER DEALINGS IN THE SOFTWARE.
 //
 
+#ifndef UIIMAGE_DIFF_H
+#define UIIMAGE_DIFF_H
+
 #import <UIKit/UIKit.h>
 
 @interface UIImage (Diff)
@@ -35,3 +38,5 @@
 - (UIImage *)diffWithImage:(UIImage *)image;
 
 @end
+
+#endif //UIIMAGE_DIFF_H

--- a/Libraries/RCTTest/RCTSnapshotManager.h
+++ b/Libraries/RCTTest/RCTSnapshotManager.h
@@ -7,8 +7,13 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTSNAPSHOTMANAGER_H
+#define RCTSNAPSHOTMANAGER_H
+
 #import <React/RCTViewManager.h>
 
 @interface RCTSnapshotManager : RCTViewManager
 
 @end
+
+#endif //RCTSNAPSHOTMANAGER_H

--- a/Libraries/RCTTest/RCTTestModule.h
+++ b/Libraries/RCTTest/RCTTestModule.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTTESTMODULE_H
+#define RCTTESTMODULE_H
+
 #import <UIKit/UIKit.h>
 
 #import <React/RCTBridgeModule.h>
@@ -45,3 +48,5 @@ typedef NS_ENUM(NSInteger, RCTTestStatus) {
 @property (nonatomic, copy) NSString *testSuffix;
 
 @end
+
+#endif //RCTTESTMODULE_H

--- a/Libraries/RCTTest/RCTTestRunner.h
+++ b/Libraries/RCTTest/RCTTestRunner.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTTESTRUNNER_H
+#define RCTTESTRUNNER_H
+
 #import <Foundation/Foundation.h>
 
 #ifndef FB_REFERENCE_IMAGE_DIR
@@ -115,3 +118,5 @@ configurationBlock:(void(^)(RCTRootView *rootView))configurationBlock
 expectErrorBlock:(BOOL(^)(NSString *error))expectErrorBlock;
 
 @end
+
+#endif //RCTTESTRUNNER_H

--- a/Libraries/Settings/RCTSettingsManager.h
+++ b/Libraries/Settings/RCTSettingsManager.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTSETTINGSMANAGER_H
+#define RCTSETTINGSMANAGER_H
+
 #import <Foundation/Foundation.h>
 
 #import <React/RCTBridgeModule.h>
@@ -16,3 +19,5 @@
 - (instancetype)initWithUserDefaults:(NSUserDefaults *)defaults;
 
 @end
+
+#endif //RCTSETTINGSMANAGER_H

--- a/Libraries/Text/RCTConvert+Text.h
+++ b/Libraries/Text/RCTConvert+Text.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTCONVERT_TEXT_H
+#define RCTCONVERT_TEXT_H
+
 #import <React/RCTConvert.h>
 
 @interface RCTConvert (Text)
@@ -15,3 +18,5 @@
 + (UITextSpellCheckingType)UITextSpellCheckingType:(id)json;
 
 @end
+
+#endif //RCTCONVERT_TEXT_H

--- a/Libraries/Text/RCTRawTextManager.h
+++ b/Libraries/Text/RCTRawTextManager.h
@@ -7,8 +7,13 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTRAWTEXTMANAGER_H
+#define RCTRAWTEXTMANAGER_H
+
 #import <React/RCTViewManager.h>
 
 @interface RCTRawTextManager : RCTViewManager
 
 @end
+
+#endif //RCTRAWTEXTMANAGER_H

--- a/Libraries/Text/RCTShadowRawText.h
+++ b/Libraries/Text/RCTShadowRawText.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTSHADOWRAWTEXT_H
+#define RCTSHADOWRAWTEXT_H
+
 #import <React/RCTShadowView.h>
 
 @interface RCTShadowRawText : RCTShadowView
@@ -14,3 +17,5 @@
 @property (nonatomic, copy) NSString *text;
 
 @end
+
+#endif //RCTSHADOWRAWTEXT_H

--- a/Libraries/Text/RCTShadowText.h
+++ b/Libraries/Text/RCTShadowText.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTSHADOWTEXT_H
+#define RCTSHADOWTEXT_H
+
 #import <React/RCTShadowView.h>
 #import <React/RCTTextDecorationLineType.h>
 
@@ -53,3 +56,5 @@ extern NSString *const RCTReactTagAttributeName;
 - (void)recomputeText;
 
 @end
+
+#endif //RCTSHADOWTEXT_H

--- a/Libraries/Text/RCTText.h
+++ b/Libraries/Text/RCTText.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTTEXT_H
+#define RCTTEXT_H
+
 #import <UIKit/UIKit.h>
 
 @interface RCTText : UIView
@@ -17,3 +20,5 @@
 @property (nonatomic, assign) BOOL selectable;
 
 @end
+
+#endif //RCTTEXT_H

--- a/Libraries/Text/RCTTextField.h
+++ b/Libraries/Text/RCTTextField.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTTEXTFIELD_H
+#define RCTTEXTFIELD_H
+
 #import <UIKit/UIKit.h>
 
 #import <React/RCTComponent.h>
@@ -33,3 +36,5 @@
 - (BOOL)textFieldShouldEndEditing:(RCTTextField *)textField;
 
 @end
+
+#endif //RCTTEXTFIELD_H

--- a/Libraries/Text/RCTTextFieldManager.h
+++ b/Libraries/Text/RCTTextFieldManager.h
@@ -7,8 +7,13 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTTEXTFIELDMANAGER_H
+#define RCTTEXTFIELDMANAGER_H
+
 #import <React/RCTViewManager.h>
 
 @interface RCTTextFieldManager : RCTViewManager
 
 @end
+
+#endif //RCTTEXTFIELDMANAGER_H

--- a/Libraries/Text/RCTTextManager.h
+++ b/Libraries/Text/RCTTextManager.h
@@ -7,8 +7,13 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTTEXTMANAGER_H
+#define RCTTEXTMANAGER_H
+
 #import <React/RCTViewManager.h>
 
 @interface RCTTextManager : RCTViewManager
 
 @end
+
+#endif //RCTTEXTMANAGER_H

--- a/Libraries/Text/RCTTextSelection.h
+++ b/Libraries/Text/RCTTextSelection.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTTEXTSELECTION_H
+#define RCTTEXTSELECTION_H
+
 #import <React/RCTConvert.h>
 
 /**
@@ -26,3 +29,5 @@
 + (RCTTextSelection *)RCTTextSelection:(id)json;
 
 @end
+
+#endif //RCTTEXTSELECTION_H

--- a/Libraries/Text/RCTTextView.h
+++ b/Libraries/Text/RCTTextView.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTTEXTVIEW_H
+#define RCTTEXTVIEW_H
+
 #import <UIKit/UIKit.h>
 
 #import <React/RCTView.h>
@@ -40,3 +43,5 @@
 - (void)performTextUpdate;
 
 @end
+
+#endif //RCTTEXTVIEW_H

--- a/Libraries/Text/RCTTextViewManager.h
+++ b/Libraries/Text/RCTTextViewManager.h
@@ -7,8 +7,13 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTTEXTVIEWMANAGER_H
+#define RCTTEXTVIEWMANAGER_H
+
 #import <React/RCTViewManager.h>
 
 @interface RCTTextViewManager : RCTViewManager
 
 @end
+
+#endif //RCTTEXTVIEWMANAGER_H

--- a/Libraries/Vibration/RCTVibration.h
+++ b/Libraries/Vibration/RCTVibration.h
@@ -7,8 +7,13 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTVIBRATION_H
+#define RCTVIBRATION_H
+
 #import <React/RCTBridgeModule.h>
 
 @interface RCTVibration : NSObject <RCTBridgeModule>
 
 @end
+
+#endif //RCTVIBRATION_H

--- a/Libraries/WebSocket/RCTSRWebSocket.h
+++ b/Libraries/WebSocket/RCTSRWebSocket.h
@@ -6,6 +6,9 @@
 //   You may obtain a copy of the License at
 //
 //       http://www.apache.org/licenses/LICENSE-2.0
+
+#ifndef RCTSRWEBSOCKET_H
+#define RCTSRWEBSOCKET_H
 //
 //   Unless required by applicable law or agreed to in writing, software
 //   distributed under the License is distributed on an "AS IS" BASIS,
@@ -130,3 +133,5 @@ extern NSString *const RCTSRHTTPResponseErrorKey;
 + (NSRunLoop *)RCTSR_networkRunLoop;
 
 @end
+
+#endif //RCTSRWEBSOCKET_H

--- a/Libraries/WebSocket/RCTWebSocketExecutor.h
+++ b/Libraries/WebSocket/RCTWebSocketExecutor.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTWEBSOCKETEXECUTOR_H
+#define RCTWEBSOCKETEXECUTOR_H
+
 #import <React/RCTDefines.h>
 #import <React/RCTJavaScriptExecutor.h>
 
@@ -19,3 +22,5 @@
 @end
 
 #endif
+
+#endif //RCTWEBSOCKETEXECUTOR_H

--- a/Libraries/WebSocket/RCTWebSocketModule.h
+++ b/Libraries/WebSocket/RCTWebSocketModule.h
@@ -7,8 +7,13 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTWEBSOCKETMODULE_H
+#define RCTWEBSOCKETMODULE_H
+
 #import <React/RCTEventEmitter.h>
 
 @interface RCTWebSocketModule : RCTEventEmitter
 
 @end
+
+#endif //RCTWEBSOCKETMODULE_H

--- a/Libraries/WebSocket/RCTWebSocketObserver.h
+++ b/Libraries/WebSocket/RCTWebSocketObserver.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTWEBSOCKETOBSERVER_H
+#define RCTWEBSOCKETOBSERVER_H
+
 #import <React/RCTDefines.h>
 #import <React/RCTWebSocketObserverProtocol.h>
 
@@ -16,3 +19,5 @@
 @end
 
 #endif
+
+#endif //RCTWEBSOCKETOBSERVER_H

--- a/React/Base/RCTAssert.h
+++ b/React/Base/RCTAssert.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTASSERT_H
+#define RCTASSERT_H
+
 #import <Foundation/Foundation.h>
 
 #import <React/RCTDefines.h>
@@ -159,3 +162,5 @@ _Pragma("clang diagnostic pop")
 #define RCTAssertThread(thread, format...) do { } while (0)
 
 #endif
+
+#endif //RCTASSERT_H

--- a/React/Base/RCTBridge+Private.h
+++ b/React/Base/RCTBridge+Private.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTBRIDGE_PRIVATE_H
+#define RCTBRIDGE_PRIVATE_H
+
 #import <React/RCTBridge.h>
 
 @class RCTModuleData;
@@ -150,3 +153,5 @@ RCT_EXTERN void RCTVerifyAllModulesExported(NSArray *extraModules);
 - (void)start;
 
 @end
+
+#endif //RCTBRIDGE_PRIVATE_H

--- a/React/Base/RCTBridge.h
+++ b/React/Base/RCTBridge.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTBRIDGE_H
+#define RCTBRIDGE_H
+
 #import <UIKit/UIKit.h>
 
 #import <React/RCTBridgeDelegate.h>
@@ -205,3 +208,5 @@ RCT_EXTERN NSString *RCTBridgeModuleNameForClass(Class bridgeModuleClass);
 - (BOOL)isBatchActive;
 
 @end
+
+#endif //RCTBRIDGE_H

--- a/React/Base/RCTBridgeDelegate.h
+++ b/React/Base/RCTBridgeDelegate.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTBRIDGEDELEGATE_H
+#define RCTBRIDGEDELEGATE_H
+
 #import <React/RCTJavaScriptLoader.h>
 
 @class RCTBridge;
@@ -108,3 +111,5 @@
                   withBlock:(RCTSourceLoadBlock)loadCallback;
 
 @end
+
+#endif //RCTBRIDGEDELEGATE_H

--- a/React/Base/RCTBridgeMethod.h
+++ b/React/Base/RCTBridgeMethod.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTBRIDGEMETHOD_H
+#define RCTBRIDGEMETHOD_H
+
 #import <Foundation/Foundation.h>
 
 @class RCTBridge;
@@ -27,3 +30,5 @@ typedef NS_ENUM(NSUInteger, RCTFunctionType) {
              arguments:(NSArray *)arguments;
 
 @end
+
+#endif //RCTBRIDGEMETHOD_H

--- a/React/Base/RCTBridgeModule.h
+++ b/React/Base/RCTBridgeModule.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTBRIDGEMODULE_H
+#define RCTBRIDGEMODULE_H
+
 #import <Foundation/Foundation.h>
 
 #import <React/RCTDefines.h>
@@ -244,3 +247,5 @@ RCT_EXTERN void RCTRegisterModule(Class); \
 - (void)partialBatchDidFlush;
 
 @end
+
+#endif //RCTBRIDGEMODULE_H

--- a/React/Base/RCTBundleURLProvider.h
+++ b/React/Base/RCTBundleURLProvider.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTBUNDLEURLPROVIDER_H
+#define RCTBUNDLEURLPROVIDER_H
+
 #import <Foundation/Foundation.h>
 
 extern NSString *const RCTBundleURLProviderUpdatedNotification;
@@ -77,3 +80,5 @@ extern const NSUInteger kRCTBundleURLProviderDefaultPort;
                                 query:(NSString *)query;
 
 @end
+
+#endif //RCTBUNDLEURLPROVIDER_H

--- a/React/Base/RCTConvert.h
+++ b/React/Base/RCTConvert.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTCONVERT_H
+#define RCTCONVERT_H
+
 #import <QuartzCore/QuartzCore.h>
 #import <UIKit/UIKit.h>
 
@@ -240,3 +243,5 @@ RCT_CUSTOM_CONVERTER(type, type, [RCT_DEBUG ? [self NSNumber:json] : json getter
 {                                                      \
   return RCTConvertArrayValue(@selector(type:), json); \
 }
+
+#endif //RCTCONVERT_H

--- a/React/Base/RCTDefines.h
+++ b/React/Base/RCTDefines.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTDEFINES_H
+#define RCTDEFINES_H
+
 #if __OBJC__
 #  import <Foundation/Foundation.h>
 #endif
@@ -79,3 +82,5 @@ _Pragma("clang diagnostic ignored \"-Wunused-parameter\"") \
 RCT_EXTERN NSException *_RCTNotImplementedException(SEL, Class); \
 method NS_UNAVAILABLE { @throw _RCTNotImplementedException(_cmd, [self class]); } \
 _Pragma("clang diagnostic pop")
+
+#endif //RCTDEFINES_H

--- a/React/Base/RCTDisplayLink.h
+++ b/React/Base/RCTDisplayLink.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTDISPLAYLINK_H
+#define RCTDISPLAYLINK_H
+
 #import <Foundation/Foundation.h>
 
 @protocol RCTBridgeModule;
@@ -21,3 +24,5 @@
 - (void)addToRunLoop:(NSRunLoop *)runLoop;
 
 @end
+
+#endif //RCTDISPLAYLINK_H

--- a/React/Base/RCTErrorCustomizer.h
+++ b/React/Base/RCTErrorCustomizer.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTERRORCUSTOMIZER_H
+#define RCTERRORCUSTOMIZER_H
+
 #import <Foundation/Foundation.h>
 
 @class RCTErrorInfo;
@@ -23,3 +26,5 @@
  */
 - (nonnull RCTErrorInfo *)customizeErrorInfo:(nonnull RCTErrorInfo *)info;
 @end
+
+#endif //RCTERRORCUSTOMIZER_H

--- a/React/Base/RCTErrorInfo.h
+++ b/React/Base/RCTErrorInfo.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTERRORINFO_H
+#define RCTERRORINFO_H
+
 #import <Foundation/Foundation.h>
 
 @class RCTJSStackFrame;
@@ -23,3 +26,5 @@
                                stack:(NSArray<RCTJSStackFrame *> *)stack;
 
 @end
+
+#endif //RCTERRORINFO_H

--- a/React/Base/RCTEventDispatcher.h
+++ b/React/Base/RCTEventDispatcher.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTEVENTDISPATCHER_H
+#define RCTEVENTDISPATCHER_H
+
 #import <UIKit/UIKit.h>
 
 #import <React/RCTBridge.h>
@@ -123,3 +126,5 @@ __deprecated_msg("Use RCTDirectEventBlock or RCTBubblingEventBlock instead");
 - (RCTEventDispatcher *)eventDispatcher;
 
 @end
+
+#endif //RCTEVENTDISPATCHER_H

--- a/React/Base/RCTFrameUpdate.h
+++ b/React/Base/RCTFrameUpdate.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTFRAMEUPDATE_H
+#define RCTFRAMEUPDATE_H
+
 #import <Foundation/Foundation.h>
 
 @class CADisplayLink;
@@ -52,3 +55,5 @@
 @property (nonatomic, copy) dispatch_block_t pauseCallback;
 
 @end
+
+#endif //RCTFRAMEUPDATE_H

--- a/React/Base/RCTImageSource.h
+++ b/React/Base/RCTImageSource.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTIMAGESOURCE_H
+#define RCTIMAGESOURCE_H
+
 #import <Foundation/Foundation.h>
 
 #import <React/RCTConvert.h>
@@ -42,3 +45,5 @@
 + (NSArray<RCTImageSource *> *)RCTImageSourceArray:(id)json;
 
 @end
+
+#endif //RCTIMAGESOURCE_H

--- a/React/Base/RCTInvalidating.h
+++ b/React/Base/RCTInvalidating.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTINVALIDATING_H
+#define RCTINVALIDATING_H
+
 #import <Foundation/Foundation.h>
 
 @protocol RCTInvalidating <NSObject>
@@ -14,3 +17,5 @@
 - (void)invalidate;
 
 @end
+
+#endif //RCTINVALIDATING_H

--- a/React/Base/RCTJSStackFrame.h
+++ b/React/Base/RCTJSStackFrame.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTJSSTACKFRAME_H
+#define RCTJSSTACKFRAME_H
+
 #import <Foundation/Foundation.h>
 
 @interface RCTJSStackFrame : NSObject
@@ -25,3 +28,5 @@
 + (NSArray<RCTJSStackFrame *> *)stackFramesWithDictionaries:(NSArray<NSDictionary *> *)dicts;
 
 @end
+
+#endif //RCTJSSTACKFRAME_H

--- a/React/Base/RCTJavaScriptExecutor.h
+++ b/React/Base/RCTJavaScriptExecutor.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTJAVASCRIPTEXECUTOR_H
+#define RCTJAVASCRIPTEXECUTOR_H
+
 #import <objc/runtime.h>
 
 #import <JavaScriptCore/JavaScriptCore.h>
@@ -84,3 +87,5 @@ typedef void (^RCTJavaScriptCallback)(id result, NSError *error);
 - (void)executeAsyncBlockOnJavaScriptQueue:(dispatch_block_t)block;
 
 @end
+
+#endif //RCTJAVASCRIPTEXECUTOR_H

--- a/React/Base/RCTJavaScriptLoader.h
+++ b/React/Base/RCTJavaScriptLoader.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTJAVASCRIPTLOADER_H
+#define RCTJAVASCRIPTLOADER_H
+
 #import <UIKit/UIKit.h>
 
 #import <React/RCTDefines.h>
@@ -53,3 +56,5 @@ typedef void (^RCTSourceLoadBlock)(NSError *error, NSData *source, int64_t sourc
                                           error:(NSError **)error;
 
 @end
+
+#endif //RCTJAVASCRIPTLOADER_H

--- a/React/Base/RCTKeyCommands.h
+++ b/React/Base/RCTKeyCommands.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTKEYCOMMANDS_H
+#define RCTKEYCOMMANDS_H
+
 #import <UIKit/UIKit.h>
 
 @interface RCTKeyCommands : NSObject
@@ -52,3 +55,5 @@
                          modifierFlags:(UIKeyModifierFlags)flags;
 
 @end
+
+#endif //RCTKEYCOMMANDS_H

--- a/React/Base/RCTLog.h
+++ b/React/Base/RCTLog.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTLOG_H
+#define RCTLOG_H
+
 #import <Foundation/Foundation.h>
 
 #import <React/RCTAssert.h>
@@ -131,3 +134,5 @@ RCT_EXTERN void RCTPerformBlockWithLogPrefix(void (^block)(void), NSString *pref
 
 RCT_EXTERN void _RCTLogNativeInternal(RCTLogLevel, const char *, int, NSString *, ...) NS_FORMAT_FUNCTION(4,5);
 RCT_EXTERN void _RCTLogJavaScriptInternal(RCTLogLevel, NSString *);
+
+#endif //RCTLOG_H

--- a/React/Base/RCTModuleData.h
+++ b/React/Base/RCTModuleData.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTMODULEDATA_H
+#define RCTMODULEDATA_H
+
 #import <Foundation/Foundation.h>
 
 #import <React/RCTInvalidating.h>
@@ -86,3 +89,5 @@
 @property (nonatomic, assign, readonly) BOOL implementsPartialBatchDidFlush;
 
 @end
+
+#endif //RCTMODULEDATA_H

--- a/React/Base/RCTModuleMethod.h
+++ b/React/Base/RCTModuleMethod.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTMODULEMETHOD_H
+#define RCTMODULEMETHOD_H
+
 #import <Foundation/Foundation.h>
 
 #import <React/RCTBridgeMethod.h>
@@ -32,3 +35,5 @@
                            moduleClass:(Class)moduleClass NS_DESIGNATED_INITIALIZER;
 
 @end
+
+#endif //RCTMODULEMETHOD_H

--- a/React/Base/RCTMultipartDataTask.h
+++ b/React/Base/RCTMultipartDataTask.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTMULTIPARTDATATASK_H
+#define RCTMULTIPARTDATATASK_H
+
 #import <Foundation/Foundation.h>
 
 #import <React/RCTMultipartStreamReader.h>
@@ -19,3 +22,5 @@ typedef void (^RCTMultipartDataTaskCallback)(NSInteger statusCode, NSDictionary 
 - (void)startTask;
 
 @end
+
+#endif //RCTMULTIPARTDATATASK_H

--- a/React/Base/RCTMultipartStreamReader.h
+++ b/React/Base/RCTMultipartStreamReader.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTMULTIPARTSTREAMREADER_H
+#define RCTMULTIPARTSTREAMREADER_H
+
 #import <Foundation/Foundation.h>
 
 typedef void (^RCTMultipartCallback)(NSDictionary *headers, NSData *content, BOOL done);
@@ -20,3 +23,5 @@ typedef void (^RCTMultipartCallback)(NSDictionary *headers, NSData *content, BOO
 - (BOOL)readAllParts:(RCTMultipartCallback)callback;
 
 @end
+
+#endif //RCTMULTIPARTSTREAMREADER_H

--- a/React/Base/RCTNullability.h
+++ b/React/Base/RCTNullability.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTNULLABILITY_H
+#define RCTNULLABILITY_H
+
 #import <Foundation/Foundation.h>
 
 typedef NS_ENUM(NSUInteger, RCTNullability) {
@@ -14,3 +17,5 @@ typedef NS_ENUM(NSUInteger, RCTNullability) {
   RCTNullable,
   RCTNonnullable,
 };
+
+#endif //RCTNULLABILITY_H

--- a/React/Base/RCTParserUtils.h
+++ b/React/Base/RCTParserUtils.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTPARSERUTILS_H
+#define RCTPARSERUTILS_H
+
 #import <Foundation/Foundation.h>
 
 #import <React/RCTDefines.h>
@@ -29,3 +32,5 @@ RCT_EXTERN BOOL RCTParseIdentifier(const char **input, NSString **string);
 RCT_EXTERN NSString *RCTParseType(const char **input);
 
 @end
+
+#endif //RCTPARSERUTILS_H

--- a/React/Base/RCTPerformanceLogger.h
+++ b/React/Base/RCTPerformanceLogger.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTPERFORMANCELOGGER_H
+#define RCTPERFORMANCELOGGER_H
+
 #import <Foundation/Foundation.h>
 
 typedef NS_ENUM(NSUInteger, RCTPLTag) {
@@ -102,3 +105,5 @@ typedef NS_ENUM(NSUInteger, RCTPLTag) {
 - (NSArray<NSString *> *)labelsForTags;
 
 @end
+
+#endif //RCTPERFORMANCELOGGER_H

--- a/React/Base/RCTPlatform.h
+++ b/React/Base/RCTPlatform.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTPLATFORM_H
+#define RCTPLATFORM_H
+
 #import <Foundation/Foundation.h>
 
 #import <React/RCTBridgeModule.h>
@@ -14,3 +17,5 @@
 @interface RCTPlatform : NSObject <RCTBridgeModule>
 
 @end
+
+#endif //RCTPLATFORM_H

--- a/React/Base/RCTReloadCommand.h
+++ b/React/Base/RCTReloadCommand.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTRELOADCOMMAND_H
+#define RCTRELOADCOMMAND_H
+
 #import <Foundation/Foundation.h>
 
 #import <React/RCTDefines.h>
@@ -17,3 +20,5 @@
 
 /** Registers a weakly-held observer of the Command+R reload key command. */
 RCT_EXTERN void RCTRegisterReloadCommandListener(id<RCTReloadListener> listener);
+
+#endif //RCTRELOADCOMMAND_H

--- a/React/Base/RCTRootView.h
+++ b/React/Base/RCTRootView.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTROOTVIEW_H
+#define RCTROOTVIEW_H
+
 #import <UIKit/UIKit.h>
 
 #import <React/RCTBridge.h>
@@ -155,3 +158,5 @@ extern NSString *const RCTContentDidAppearNotification;
 @property (nonatomic, assign) NSTimeInterval loadingViewFadeDuration;
 
 @end
+
+#endif //RCTROOTVIEW_H

--- a/React/Base/RCTRootViewDelegate.h
+++ b/React/Base/RCTRootViewDelegate.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTROOTVIEWDELEGATE_H
+#define RCTROOTVIEWDELEGATE_H
+
 #import <Foundation/Foundation.h>
 
 @class RCTRootView;
@@ -23,3 +26,5 @@
 - (void)rootViewDidChangeIntrinsicSize:(RCTRootView *)rootView;
 
 @end
+
+#endif //RCTROOTVIEWDELEGATE_H

--- a/React/Base/RCTRootViewInternal.h
+++ b/React/Base/RCTRootViewInternal.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTROOTVIEWINTERNAL_H
+#define RCTROOTVIEWINTERNAL_H
+
 #import <React/RCTRootView.h>
 
 @class RCTTVRemoteHandler;
@@ -31,3 +34,5 @@
 #endif
 
 @end
+
+#endif //RCTROOTVIEWINTERNAL_H

--- a/React/Base/RCTTVRemoteHandler.h
+++ b/React/Base/RCTTVRemoteHandler.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTTVREMOTEHANDLER_H
+#define RCTTVREMOTEHANDLER_H
+
 #import <UIKit/UIKit.h>
 
 @interface RCTTVRemoteHandler : NSObject
@@ -14,3 +17,5 @@
 @property (nonatomic, copy, readonly) NSArray *tvRemoteGestureRecognizers;
 
 @end
+
+#endif //RCTTVREMOTEHANDLER_H

--- a/React/Base/RCTTouchEvent.h
+++ b/React/Base/RCTTouchEvent.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTTOUCHEVENT_H
+#define RCTTOUCHEVENT_H
+
 #import <Foundation/Foundation.h>
 
 #import <React/RCTEventDispatcher.h>
@@ -23,3 +26,5 @@
                    changedIndexes:(NSArray<NSNumber *> *)changedIndexes
                     coalescingKey:(uint16_t)coalescingKey NS_DESIGNATED_INITIALIZER;
 @end
+
+#endif //RCTTOUCHEVENT_H

--- a/React/Base/RCTTouchHandler.h
+++ b/React/Base/RCTTouchHandler.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTTOUCHHANDLER_H
+#define RCTTOUCHHANDLER_H
+
 #import <UIKit/UIKit.h>
 
 #import <React/RCTFrameUpdate.h>
@@ -19,3 +22,5 @@
 - (void)cancel;
 
 @end
+
+#endif //RCTTOUCHHANDLER_H

--- a/React/Base/RCTURLRequestDelegate.h
+++ b/React/Base/RCTURLRequestDelegate.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTURLREQUESTDELEGATE_H
+#define RCTURLREQUESTDELEGATE_H
+
 #import <Foundation/Foundation.h>
 
 /**
@@ -40,3 +43,5 @@
 - (void)URLRequest:(id)requestToken didCompleteWithError:(NSError *)error;
 
 @end
+
+#endif //RCTURLREQUESTDELEGATE_H

--- a/React/Base/RCTURLRequestHandler.h
+++ b/React/Base/RCTURLRequestHandler.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTURLREQUESTHANDLER_H
+#define RCTURLREQUESTHANDLER_H
+
 #import <React/RCTBridgeModule.h>
 #import <React/RCTURLRequestDelegate.h>
 
@@ -52,3 +55,5 @@
 - (float)handlerPriority;
 
 @end
+
+#endif //RCTURLREQUESTHANDLER_H

--- a/React/Base/RCTUtils.h
+++ b/React/Base/RCTUtils.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTUTILS_H
+#define RCTUTILS_H
+
 #import <tgmath.h>
 
 #import <CoreGraphics/CoreGraphics.h>
@@ -129,3 +132,5 @@ RCT_EXTERN NSString *__nullable RCTGetURLQueryParam(NSURL *__nullable URL, NSStr
 RCT_EXTERN NSURL *__nullable RCTURLByReplacingQueryParam(NSURL *__nullable URL, NSString *param, NSString *__nullable value);
 
 NS_ASSUME_NONNULL_END
+
+#endif //RCTUTILS_H

--- a/React/Base/RCTWebSocketObserverProtocol.h
+++ b/React/Base/RCTWebSocketObserverProtocol.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTWEBSOCKETOBSERVERPROTOCOL_H
+#define RCTWEBSOCKETOBSERVERPROTOCOL_H
+
 #import <React/RCTDefines.h>
 
 #if RCT_DEV // Only supported in dev mode
@@ -23,3 +26,5 @@
 @end
 
 #endif
+
+#endif //RCTWEBSOCKETOBSERVERPROTOCOL_H

--- a/React/Executors/RCTJSCErrorHandling.h
+++ b/React/Executors/RCTJSCErrorHandling.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTJSCERRORHANDLING_H
+#define RCTJSCERRORHANDLING_H
+
 #import <JavaScriptCore/JavaScriptCore.h>
 
 #import <React/RCTDefines.h>
@@ -31,3 +34,5 @@ RCT_EXTERN NSError *RCTNSErrorFromJSError(JSValue *exception);
  @see RCTNSErrorFromJSError for details
  */
 RCT_EXTERN NSError *RCTNSErrorFromJSErrorRef(JSValueRef exceptionRef, JSGlobalContextRef ctx);
+
+#endif //RCTJSCERRORHANDLING_H

--- a/React/Executors/RCTJSCExecutor.h
+++ b/React/Executors/RCTJSCExecutor.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTJSCEXECUTOR_H
+#define RCTJSCEXECUTOR_H
+
 #import <JavaScriptCore/JavaScriptCore.h>
 
 #import <React/RCTJavaScriptExecutor.h>
@@ -140,3 +143,5 @@ RCT_EXTERN NSString *const RCTFBJSValueClassKey;
 - (JSContext *)jsContext;
 
 @end
+
+#endif //RCTJSCEXECUTOR_H

--- a/React/Modules/JSCSamplingProfiler.h
+++ b/React/Modules/JSCSamplingProfiler.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef JSCSAMPLINGPROFILER_H
+#define JSCSAMPLINGPROFILER_H
+
 #import <Foundation/Foundation.h>
 
 #import <React/RCTBridgeModule.h>
@@ -21,3 +24,5 @@
 - (void)operationCompletedWithResults:(NSString *)results;
 
 @end
+
+#endif //JSCSAMPLINGPROFILER_H

--- a/React/Modules/RCTAccessibilityManager.h
+++ b/React/Modules/RCTAccessibilityManager.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTACCESSIBILITYMANAGER_H
+#define RCTACCESSIBILITYMANAGER_H
+
 #import <Foundation/Foundation.h>
 
 #import <React/RCTBridge.h>
@@ -30,3 +33,5 @@ extern NSString *const RCTAccessibilityManagerDidUpdateMultiplierNotification; /
 @property (nonatomic, readonly) RCTAccessibilityManager *accessibilityManager;
 
 @end
+
+#endif //RCTACCESSIBILITYMANAGER_H

--- a/React/Modules/RCTAlertManager.h
+++ b/React/Modules/RCTAlertManager.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTALERTMANAGER_H
+#define RCTALERTMANAGER_H
+
 #import <UIKit/UIKit.h>
 
 #import <React/RCTBridgeModule.h>
@@ -23,3 +26,5 @@ typedef NS_ENUM(NSInteger, RCTAlertViewStyle) {
 @interface RCTAlertManager : NSObject <RCTBridgeModule, RCTInvalidating>
 
 @end
+
+#endif //RCTALERTMANAGER_H

--- a/React/Modules/RCTAppState.h
+++ b/React/Modules/RCTAppState.h
@@ -7,8 +7,13 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTAPPSTATE_H
+#define RCTAPPSTATE_H
+
 #import <React/RCTEventEmitter.h>
 
 @interface RCTAppState : RCTEventEmitter
 
 @end
+
+#endif //RCTAPPSTATE_H

--- a/React/Modules/RCTAsyncLocalStorage.h
+++ b/React/Modules/RCTAsyncLocalStorage.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTASYNCLOCALSTORAGE_H
+#define RCTASYNCLOCALSTORAGE_H
+
 #import <React/RCTBridgeModule.h>
 #import <React/RCTInvalidating.h>
 
@@ -34,3 +37,5 @@
 + (void)clearAllData;
 
 @end
+
+#endif //RCTASYNCLOCALSTORAGE_H

--- a/React/Modules/RCTClipboard.h
+++ b/React/Modules/RCTClipboard.h
@@ -7,8 +7,13 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTCLIPBOARD_H
+#define RCTCLIPBOARD_H
+
 #import <React/RCTBridgeModule.h>
 
 @interface RCTClipboard : NSObject <RCTBridgeModule>
 
 @end
+
+#endif //RCTCLIPBOARD_H

--- a/React/Modules/RCTDevLoadingView.h
+++ b/React/Modules/RCTDevLoadingView.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTDEVLOADINGVIEW_H
+#define RCTDEVLOADINGVIEW_H
+
 #import <React/RCTBridgeModule.h>
 
 @interface RCTDevLoadingView : NSObject <RCTBridgeModule>
@@ -15,3 +18,5 @@
 - (void)updateProgress:(RCTLoadingProgress *)progress;
 
 @end
+
+#endif //RCTDEVLOADINGVIEW_H

--- a/React/Modules/RCTDevMenu.h
+++ b/React/Modules/RCTDevMenu.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTDEVMENU_H
+#define RCTDEVMENU_H
+
 #import <UIKit/UIKit.h>
 
 #import <React/RCTBridge.h>
@@ -116,3 +119,5 @@
 @property (nonatomic, readonly) RCTDevMenu *devMenu;
 
 @end
+
+#endif //RCTDEVMENU_H

--- a/React/Modules/RCTEventEmitter.h
+++ b/React/Modules/RCTEventEmitter.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTEVENTEMITTER_H
+#define RCTEVENTEMITTER_H
+
 #import <React/RCTBridge.h>
 
 /**
@@ -39,3 +42,5 @@
 - (void)stopObserving;
 
 @end
+
+#endif //RCTEVENTEMITTER_H

--- a/React/Modules/RCTExceptionsManager.h
+++ b/React/Modules/RCTExceptionsManager.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTEXCEPTIONSMANAGER_H
+#define RCTEXCEPTIONSMANAGER_H
+
 #import <Foundation/Foundation.h>
 
 #import <React/RCTBridgeModule.h>
@@ -28,3 +31,5 @@
 @property (nonatomic, assign) NSUInteger maxReloadAttempts;
 
 @end
+
+#endif //RCTEXCEPTIONSMANAGER_H

--- a/React/Modules/RCTI18nManager.h
+++ b/React/Modules/RCTI18nManager.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTI18NMANAGER_H
+#define RCTI18NMANAGER_H
+
 #import <React/RCTBridgeModule.h>
 
 /**
@@ -17,3 +20,5 @@
 @interface RCTI18nManager : NSObject <RCTBridgeModule>
 
 @end
+
+#endif //RCTI18NMANAGER_H

--- a/React/Modules/RCTI18nUtil.h
+++ b/React/Modules/RCTI18nUtil.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTI18NUTIL_H
+#define RCTI18NUTIL_H
+
 #import <Foundation/Foundation.h>
 
 /**
@@ -25,3 +28,5 @@
 + (id)sharedInstance;
 
 @end
+
+#endif //RCTI18NUTIL_H

--- a/React/Modules/RCTKeyboardObserver.h
+++ b/React/Modules/RCTKeyboardObserver.h
@@ -7,8 +7,13 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTKEYBOARDOBSERVER_H
+#define RCTKEYBOARDOBSERVER_H
+
 #import <React/RCTEventEmitter.h>
 
 @interface RCTKeyboardObserver : RCTEventEmitter
 
 @end
+
+#endif //RCTKEYBOARDOBSERVER_H

--- a/React/Modules/RCTRedBox.h
+++ b/React/Modules/RCTRedBox.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTREDBOX_H
+#define RCTREDBOX_H
+
 #import <UIKit/UIKit.h>
 
 #import <React/RCTBridge.h>
@@ -36,3 +39,5 @@
 @property (nonatomic, readonly) RCTRedBox *redBox;
 
 @end
+
+#endif //RCTREDBOX_H

--- a/React/Modules/RCTSourceCode.h
+++ b/React/Modules/RCTSourceCode.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTSOURCECODE_H
+#define RCTSOURCECODE_H
+
 #import <Foundation/Foundation.h>
 
 #import <React/RCTBridgeModule.h>
@@ -14,3 +17,5 @@
 @interface RCTSourceCode : NSObject <RCTBridgeModule>
 
 @end
+
+#endif //RCTSOURCECODE_H

--- a/React/Modules/RCTStatusBarManager.h
+++ b/React/Modules/RCTStatusBarManager.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTSTATUSBARMANAGER_H
+#define RCTSTATUSBARMANAGER_H
+
 #import <UIKit/UIKit.h>
 
 #import <React/RCTConvert.h>
@@ -24,3 +27,5 @@
 @interface RCTStatusBarManager : RCTEventEmitter
 
 @end
+
+#endif //RCTSTATUSBARMANAGER_H

--- a/React/Modules/RCTTVNavigationEventEmitter.h
+++ b/React/Modules/RCTTVNavigationEventEmitter.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTTVNAVIGATIONEVENTEMITTER_H
+#define RCTTVNAVIGATIONEVENTEMITTER_H
+
 #import "RCTEventEmitter.h"
 
 RCT_EXTERN NSString *const RCTTVNavigationEventNotification;
@@ -14,3 +17,5 @@ RCT_EXTERN NSString *const RCTTVNavigationEventNotification;
 @interface RCTTVNavigationEventEmitter : RCTEventEmitter
 
 @end
+
+#endif //RCTTVNAVIGATIONEVENTEMITTER_H

--- a/React/Modules/RCTTiming.h
+++ b/React/Modules/RCTTiming.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTTIMING_H
+#define RCTTIMING_H
+
 #import <Foundation/Foundation.h>
 
 #import <React/RCTBridgeModule.h>
@@ -16,3 +19,5 @@
 @interface RCTTiming : NSObject <RCTBridgeModule, RCTInvalidating, RCTFrameUpdateObserver>
 
 @end
+
+#endif //RCTTIMING_H

--- a/React/Modules/RCTUIManager.h
+++ b/React/Modules/RCTUIManager.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTUIMANAGER_H
+#define RCTUIMANAGER_H
+
 #import <UIKit/UIKit.h>
 
 #import <React/RCTBridge.h>
@@ -134,3 +137,5 @@ RCT_EXTERN NSString *const RCTUIManagerRootViewKey;
 @property (nonatomic, readonly) RCTUIManager *uiManager;
 
 @end
+
+#endif //RCTUIMANAGER_H

--- a/React/Profiler/RCTFPSGraph.h
+++ b/React/Profiler/RCTFPSGraph.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTFPSGRAPH_H
+#define RCTFPSGRAPH_H
+
 #import <UIKit/UIKit.h>
 
 #import <React/RCTDefines.h>
@@ -27,3 +30,5 @@
 @end
 
 #endif
+
+#endif //RCTFPSGRAPH_H

--- a/React/Profiler/RCTJSCProfiler.h
+++ b/React/Profiler/RCTJSCProfiler.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTJSCPROFILER_H
+#define RCTJSCPROFILER_H
+
 #import <JavaScriptCore/JavaScriptCore.h>
 
 #import <React/RCTDefines.h>
@@ -20,3 +23,5 @@ RCT_EXTERN NSString *RCTJSCProfilerStop(JSContextRef ctx);
 
 RCT_EXTERN BOOL RCTJSCProfilerIsProfiling(JSContextRef ctx);
 RCT_EXTERN BOOL RCTJSCProfilerIsSupported(void);
+
+#endif //RCTJSCPROFILER_H

--- a/React/Profiler/RCTMacros.h
+++ b/React/Profiler/RCTMacros.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTMACROS_H
+#define RCTMACROS_H
+
 #define _CONCAT(A, B) A##B
 #define CONCAT(A, B) _CONCAT(A, B)
 
@@ -16,3 +19,5 @@
 
 #define SYMBOL_NAME(name) CONCAT(__USER_LABEL_PREFIX__, name)
 #define SYMBOL_NAME_PIC(name) CONCAT(SYMBOL_NAME(name), PIC_MODIFIER)
+
+#endif //RCTMACROS_H

--- a/React/Profiler/RCTProfile.h
+++ b/React/Profiler/RCTProfile.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTPROFILE_H
+#define RCTPROFILE_H
+
 #import <Foundation/Foundation.h>
 
 #import <React/RCTAssert.h>
@@ -233,3 +236,5 @@ RCT_EXTERN void RCTProfileHideControls(void);
 #define RCTProfileHideControls(...)
 
 #endif
+
+#endif //RCTPROFILE_H

--- a/React/Views/RCTActivityIndicatorView.h
+++ b/React/Views/RCTActivityIndicatorView.h
@@ -7,7 +7,12 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTACTIVITYINDICATORVIEW_H
+#define RCTACTIVITYINDICATORVIEW_H
+
 #import <UIKit/UIKit.h>
 
 @interface RCTActivityIndicatorView : UIActivityIndicatorView
 @end
+
+#endif //RCTACTIVITYINDICATORVIEW_H

--- a/React/Views/RCTActivityIndicatorViewManager.h
+++ b/React/Views/RCTActivityIndicatorViewManager.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTACTIVITYINDICATORVIEWMANAGER_H
+#define RCTACTIVITYINDICATORVIEWMANAGER_H
+
 #import <React/RCTViewManager.h>
 
 @interface RCTConvert (UIActivityIndicatorView)
@@ -18,3 +21,5 @@
 @interface RCTActivityIndicatorViewManager : RCTViewManager
 
 @end
+
+#endif //RCTACTIVITYINDICATORVIEWMANAGER_H

--- a/React/Views/RCTAnimationType.h
+++ b/React/Views/RCTAnimationType.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTANIMATIONTYPE_H
+#define RCTANIMATIONTYPE_H
+
 #import <Foundation/Foundation.h>
 
 typedef NS_ENUM(NSInteger, RCTAnimationType) {
@@ -17,3 +20,5 @@ typedef NS_ENUM(NSInteger, RCTAnimationType) {
   RCTAnimationTypeEaseInEaseOut,
   RCTAnimationTypeKeyboard,
 };
+
+#endif //RCTANIMATIONTYPE_H

--- a/React/Views/RCTAutoInsetsProtocol.h
+++ b/React/Views/RCTAutoInsetsProtocol.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTAUTOINSETSPROTOCOL_H
+#define RCTAUTOINSETSPROTOCOL_H
+
 #import <UIKit/UIKit.h>
 
 /**
@@ -27,3 +30,5 @@
 - (void)refreshContentInset;
 
 @end
+
+#endif //RCTAUTOINSETSPROTOCOL_H

--- a/React/Views/RCTBorderDrawing.h
+++ b/React/Views/RCTBorderDrawing.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTBORDERDRAWING_H
+#define RCTBORDERDRAWING_H
+
 #import <UIKit/UIKit.h>
 
 #import <React/RCTBorderStyle.h>
@@ -67,3 +70,5 @@ UIImage *RCTGetBorderImage(RCTBorderStyle borderStyle,
                            RCTBorderColors borderColors,
                            CGColorRef backgroundColor,
                            BOOL drawToEdge);
+
+#endif //RCTBORDERDRAWING_H

--- a/React/Views/RCTBorderStyle.h
+++ b/React/Views/RCTBorderStyle.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTBORDERSTYLE_H
+#define RCTBORDERSTYLE_H
+
 #import <Foundation/Foundation.h>
 
 typedef NS_ENUM(NSInteger, RCTBorderStyle) {
@@ -15,3 +18,5 @@ typedef NS_ENUM(NSInteger, RCTBorderStyle) {
   RCTBorderStyleDotted,
   RCTBorderStyleDashed,
 };
+
+#endif //RCTBORDERSTYLE_H

--- a/React/Views/RCTComponent.h
+++ b/React/Views/RCTComponent.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTCOMPONENT_H
+#define RCTCOMPONENT_H
+
 #import <CoreGraphics/CoreGraphics.h>
 
 #import <Foundation/Foundation.h>
@@ -63,3 +66,5 @@ static inline BOOL RCTIsReactRootView(NSNumber *reactTag)
 {
   return reactTag.integerValue % 10 == 1;
 }
+
+#endif //RCTCOMPONENT_H

--- a/React/Views/RCTComponentData.h
+++ b/React/Views/RCTComponentData.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTCOMPONENTDATA_H
+#define RCTCOMPONENTDATA_H
+
 #import <Foundation/Foundation.h>
 
 #import <React/RCTComponent.h>
@@ -36,3 +39,5 @@
 - (RCTViewManagerUIBlock)uiBlockToAmendWithShadowViewRegistry:(NSDictionary<NSNumber *, RCTShadowView *> *)registry;
 
 @end
+
+#endif //RCTCOMPONENTDATA_H

--- a/React/Views/RCTConvert+CoreLocation.h
+++ b/React/Views/RCTConvert+CoreLocation.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTCONVERT_CORELOCATION_H
+#define RCTCONVERT_CORELOCATION_H
+
 #import <CoreLocation/CoreLocation.h>
 
 #import <React/RCTConvert.h>
@@ -18,3 +21,5 @@
 + (CLLocationCoordinate2D)CLLocationCoordinate2D:(id)json;
 
 @end
+
+#endif //RCTCONVERT_CORELOCATION_H

--- a/React/Views/RCTConvert+MapKit.h
+++ b/React/Views/RCTConvert+MapKit.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTCONVERT+MAPKIT_H
+#define RCTCONVERT+MAPKIT_H
+
 #import <MapKit/MapKit.h>
 
 #import <React/RCTConvert.h>
@@ -27,3 +30,5 @@
 + (NSArray<RCTMapOverlay *> *)RCTMapOverlayArray:(id)json;
 
 @end
+
+#endif //RCTCONVERT+MAPKIT_H

--- a/React/Views/RCTDatePicker.h
+++ b/React/Views/RCTDatePicker.h
@@ -7,8 +7,13 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTDATEPICKER_H
+#define RCTDATEPICKER_H
+
 #import <UIKit/UIKit.h>
 
 @interface RCTDatePicker : UIDatePicker
 
 @end
+
+#endif //RCTDATEPICKER_H

--- a/React/Views/RCTDatePickerManager.h
+++ b/React/Views/RCTDatePickerManager.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTDATEPICKERMANAGER_H
+#define RCTDATEPICKERMANAGER_H
+
 #import <React/RCTConvert.h>
 #import <React/RCTViewManager.h>
 
@@ -19,3 +22,5 @@
 @interface RCTDatePickerManager : RCTViewManager
 
 @end
+
+#endif //RCTDATEPICKERMANAGER_H

--- a/React/Views/RCTFont.h
+++ b/React/Views/RCTFont.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTFONT_H
+#define RCTFONT_H
+
 #import <Foundation/Foundation.h>
 
 #import <React/RCTConvert.h>
@@ -38,3 +41,5 @@
 + (UIFont *)UIFont:(id)json;
 
 @end
+
+#endif //RCTFONT_H

--- a/React/Views/RCTMap.h
+++ b/React/Views/RCTMap.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTMAP_H
+#define RCTMAP_H
+
 #import <MapKit/MapKit.h>
 #import <UIKit/UIKit.h>
 
@@ -39,3 +42,5 @@ RCT_EXTERN const CGFloat RCTMapZoomBoundBuffer;
 - (void)setOverlays:(NSArray<RCTMapOverlay *> *)overlays;
 
 @end
+
+#endif //RCTMAP_H

--- a/React/Views/RCTMapAnnotation.h
+++ b/React/Views/RCTMapAnnotation.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTMAPANNOTATION_H
+#define RCTMAPANNOTATION_H
+
 #import <MapKit/MapKit.h>
 
 @interface RCTMapAnnotation : MKPointAnnotation <MKAnnotation>
@@ -24,3 +27,5 @@
 @property (nonatomic, assign) BOOL draggable;
 
 @end
+
+#endif //RCTMAPANNOTATION_H

--- a/React/Views/RCTMapManager.h
+++ b/React/Views/RCTMapManager.h
@@ -7,8 +7,13 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTMAPMANAGER_H
+#define RCTMAPMANAGER_H
+
 #import <React/RCTViewManager.h>
 
 @interface RCTMapManager : RCTViewManager
 
 @end
+
+#endif //RCTMAPMANAGER_H

--- a/React/Views/RCTMapOverlay.h
+++ b/React/Views/RCTMapOverlay.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTMAPOVERLAY_H
+#define RCTMAPOVERLAY_H
+
 #import <MapKit/MapKit.h>
 
 @interface RCTMapOverlay : MKPolyline <MKAnnotation>
@@ -16,3 +19,5 @@
 @property (nonatomic, assign) CGFloat lineWidth;
 
 @end
+
+#endif //RCTMAPOVERLAY_H

--- a/React/Views/RCTModalHostView.h
+++ b/React/Views/RCTModalHostView.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTMODALHOSTVIEW_H
+#define RCTMODALHOSTVIEW_H
+
 #import <UIKit/UIKit.h>
 
 #import <React/RCTInvalidating.h>
@@ -40,3 +43,5 @@
 - (void)dismissModalHostView:(RCTModalHostView *)modalHostView withViewController:(RCTModalHostViewController *)viewController animated:(BOOL)animated;
 
 @end
+
+#endif //RCTMODALHOSTVIEW_H

--- a/React/Views/RCTModalHostViewController.h
+++ b/React/Views/RCTModalHostViewController.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTMODALHOSTVIEWCONTROLLER_H
+#define RCTMODALHOSTVIEWCONTROLLER_H
+
 #import <UIKit/UIKit.h>
 
 @interface RCTModalHostViewController : UIViewController
@@ -18,3 +21,5 @@
 #endif
 
 @end
+
+#endif //RCTMODALHOSTVIEWCONTROLLER_H

--- a/React/Views/RCTModalHostViewManager.h
+++ b/React/Views/RCTModalHostViewManager.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTMODALHOSTVIEWMANAGER_H
+#define RCTMODALHOSTVIEWMANAGER_H
+
 #import <React/RCTInvalidating.h>
 #import <React/RCTViewManager.h>
 
@@ -23,3 +26,5 @@ typedef void (^RCTModalViewInteractionBlock)(UIViewController *reactViewControll
 @property (nonatomic, strong) RCTModalViewInteractionBlock dismissalBlock;
 
 @end
+
+#endif //RCTMODALHOSTVIEWMANAGER_H

--- a/React/Views/RCTNavItem.h
+++ b/React/Views/RCTNavItem.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTNAVITEM_H
+#define RCTNAVITEM_H
+
 #import <UIKit/UIKit.h>
 
 #import <React/RCTComponent.h>
@@ -39,3 +42,5 @@
 @property (nonatomic, copy) RCTBubblingEventBlock onRightButtonPress;
 
 @end
+
+#endif //RCTNAVITEM_H

--- a/React/Views/RCTNavItemManager.h
+++ b/React/Views/RCTNavItemManager.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTNAVITEMMANAGER_H
+#define RCTNAVITEMMANAGER_H
+
 #import <React/RCTConvert.h>
 #import <React/RCTViewManager.h>
 
@@ -19,3 +22,5 @@
 @interface RCTNavItemManager : RCTViewManager
 
 @end
+
+#endif //RCTNAVITEMMANAGER_H

--- a/React/Views/RCTNavigator.h
+++ b/React/Views/RCTNavigator.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTNAVIGATOR_H
+#define RCTNAVIGATOR_H
+
 #import <UIKit/UIKit.h>
 
 #import <React/RCTFrameUpdate.h>
@@ -32,3 +35,5 @@
 - (BOOL)requestSchedulingJavaScriptNavigation;
 
 @end
+
+#endif //RCTNAVIGATOR_H

--- a/React/Views/RCTNavigatorManager.h
+++ b/React/Views/RCTNavigatorManager.h
@@ -7,8 +7,13 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTNAVIGATORMANAGER_H
+#define RCTNAVIGATORMANAGER_H
+
 #import <React/RCTViewManager.h>
 
 @interface RCTNavigatorManager : RCTViewManager
 
 @end
+
+#endif //RCTNAVIGATORMANAGER_H

--- a/React/Views/RCTPicker.h
+++ b/React/Views/RCTPicker.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTPICKER_H
+#define RCTPICKER_H
+
 #import <UIKit/UIKit.h>
 
 #import <React/UIView+React.h>
@@ -23,3 +26,5 @@
 @property (nonatomic, copy) RCTBubblingEventBlock onChange;
 
 @end
+
+#endif //RCTPICKER_H

--- a/React/Views/RCTPickerManager.h
+++ b/React/Views/RCTPickerManager.h
@@ -7,8 +7,13 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTPICKERMANAGER_H
+#define RCTPICKERMANAGER_H
+
 #import <React/RCTViewManager.h>
 
 @interface RCTPickerManager : RCTViewManager
 
 @end
+
+#endif //RCTPICKERMANAGER_H

--- a/React/Views/RCTPointerEvents.h
+++ b/React/Views/RCTPointerEvents.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTPOINTEREVENTS_H
+#define RCTPOINTEREVENTS_H
+
 #import <Foundation/Foundation.h>
 
 typedef NS_ENUM(NSInteger, RCTPointerEvents) {
@@ -15,3 +18,5 @@ typedef NS_ENUM(NSInteger, RCTPointerEvents) {
   RCTPointerEventsBoxNone,
   RCTPointerEventsBoxOnly,
 };
+
+#endif //RCTPOINTEREVENTS_H

--- a/React/Views/RCTProgressViewManager.h
+++ b/React/Views/RCTProgressViewManager.h
@@ -7,8 +7,13 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTPROGRESSVIEWMANAGER_H
+#define RCTPROGRESSVIEWMANAGER_H
+
 #import <React/RCTViewManager.h>
 
 @interface RCTProgressViewManager : RCTViewManager
 
 @end
+
+#endif //RCTPROGRESSVIEWMANAGER_H

--- a/React/Views/RCTRefreshControl.h
+++ b/React/Views/RCTRefreshControl.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTREFRESHCONTROL_H
+#define RCTREFRESHCONTROL_H
+
 #import <UIKit/UIKit.h>
 
 #import <React/RCTComponent.h>
@@ -17,3 +20,5 @@
 @property (nonatomic, copy) RCTDirectEventBlock onRefresh;
 
 @end
+
+#endif //RCTREFRESHCONTROL_H

--- a/React/Views/RCTRefreshControlManager.h
+++ b/React/Views/RCTRefreshControlManager.h
@@ -7,8 +7,13 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTREFRESHCONTROLMANAGER_H
+#define RCTREFRESHCONTROLMANAGER_H
+
 #import <React/RCTViewManager.h>
 
 @interface RCTRefreshControlManager : RCTViewManager
 
 @end
+
+#endif //RCTREFRESHCONTROLMANAGER_H

--- a/React/Views/RCTRootShadowView.h
+++ b/React/Views/RCTRootShadowView.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTROOTSHADOWVIEW_H
+#define RCTROOTSHADOWVIEW_H
+
 #import <React/RCTShadowView.h>
 
 @interface RCTRootShadowView : RCTShadowView
@@ -24,3 +27,5 @@
 - (NSSet<RCTShadowView *> *)collectViewsWithUpdatedFrames;
 
 @end
+
+#endif //RCTROOTSHADOWVIEW_H

--- a/React/Views/RCTScrollView.h
+++ b/React/Views/RCTScrollView.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTSCROLLVIEW_H
+#define RCTSCROLLVIEW_H
+
 #import <UIKit/UIScrollView.h>
 
 #import <React/RCTAutoInsetsProtocol.h>
@@ -68,3 +71,5 @@
 - (void)sendFakeScrollEvent:(NSNumber *)reactTag;
 
 @end
+
+#endif //RCTSCROLLVIEW_H

--- a/React/Views/RCTScrollViewManager.h
+++ b/React/Views/RCTScrollViewManager.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTSCROLLVIEWMANAGER_H
+#define RCTSCROLLVIEWMANAGER_H
+
 #import <React/RCTConvert.h>
 #import <React/RCTViewManager.h>
 
@@ -19,3 +22,5 @@
 @interface RCTScrollViewManager : RCTViewManager
 
 @end
+
+#endif //RCTSCROLLVIEWMANAGER_H

--- a/React/Views/RCTScrollableProtocol.h
+++ b/React/Views/RCTScrollableProtocol.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTSCROLLABLEPROTOCOL_H
+#define RCTSCROLLABLEPROTOCOL_H
+
 #import <UIKit/UIKit.h>
 
 /**
@@ -25,3 +28,5 @@
 - (void)removeScrollListener:(NSObject<UIScrollViewDelegate> *)scrollListener;
 
 @end
+
+#endif //RCTSCROLLABLEPROTOCOL_H

--- a/React/Views/RCTSegmentedControl.h
+++ b/React/Views/RCTSegmentedControl.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTSEGMENTEDCONTROL_H
+#define RCTSEGMENTEDCONTROL_H
+
 #import <UIKit/UIKit.h>
 
 #import <React/RCTComponent.h>
@@ -18,3 +21,5 @@
 @property (nonatomic, copy) RCTBubblingEventBlock onChange;
 
 @end
+
+#endif //RCTSEGMENTEDCONTROL_H

--- a/React/Views/RCTSegmentedControlManager.h
+++ b/React/Views/RCTSegmentedControlManager.h
@@ -7,8 +7,13 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTSEGMENTEDCONTROLMANAGER_H
+#define RCTSEGMENTEDCONTROLMANAGER_H
+
 #import <React/RCTViewManager.h>
 
 @interface RCTSegmentedControlManager : RCTViewManager
 
 @end
+
+#endif //RCTSEGMENTEDCONTROLMANAGER_H

--- a/React/Views/RCTShadowView.h
+++ b/React/Views/RCTShadowView.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTSHADOWVIEW_H
+#define RCTSHADOWVIEW_H
+
 #import <UIKit/UIKit.h>
 
 #import <yoga/Yoga.h>
@@ -230,3 +233,5 @@ typedef void (^RCTApplierBlock)(NSDictionary<NSNumber *, UIView *> *viewRegistry
 - (BOOL)viewIsDescendantOf:(RCTShadowView *)ancestor;
 
 @end
+
+#endif //RCTSHADOWVIEW_H

--- a/React/Views/RCTSlider.h
+++ b/React/Views/RCTSlider.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTSLIDER_H
+#define RCTSLIDER_H
+
 #import <UIKit/UIKit.h>
 
 #import <React/RCTComponent.h>
@@ -27,3 +30,5 @@
 
 
 @end
+
+#endif //RCTSLIDER_H

--- a/React/Views/RCTSliderManager.h
+++ b/React/Views/RCTSliderManager.h
@@ -7,8 +7,13 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTSLIDERMANAGER_H
+#define RCTSLIDERMANAGER_H
+
 #import <React/RCTViewManager.h>
 
 @interface RCTSliderManager : RCTViewManager
 
 @end
+
+#endif //RCTSLIDERMANAGER_H

--- a/React/Views/RCTSwitch.h
+++ b/React/Views/RCTSwitch.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTSWITCH_H
+#define RCTSWITCH_H
+
 #import <UIKit/UIKit.h>
 
 #import <React/RCTComponent.h>
@@ -17,3 +20,5 @@
 @property (nonatomic, copy) RCTBubblingEventBlock onChange;
 
 @end
+
+#endif //RCTSWITCH_H

--- a/React/Views/RCTSwitchManager.h
+++ b/React/Views/RCTSwitchManager.h
@@ -7,8 +7,13 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTSWITCHMANAGER_H
+#define RCTSWITCHMANAGER_H
+
 #import <React/RCTViewManager.h>
 
 @interface RCTSwitchManager : RCTViewManager
 
 @end
+
+#endif //RCTSWITCHMANAGER_H

--- a/React/Views/RCTTVView.h
+++ b/React/Views/RCTTVView.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTTVVIEW_H
+#define RCTTVVIEW_H
+
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
@@ -31,3 +34,5 @@
 @property (nonatomic, assign) BOOL hasTVPreferredFocus;
 
 @end
+
+#endif //RCTTVVIEW_H

--- a/React/Views/RCTTabBar.h
+++ b/React/Views/RCTTabBar.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTTABBAR_H
+#define RCTTABBAR_H
+
 #import <UIKit/UIKit.h>
 
 @interface RCTTabBar : UIView
@@ -17,3 +20,5 @@
 @property (nonatomic, assign) BOOL translucent;
 
 @end
+
+#endif //RCTTABBAR_H

--- a/React/Views/RCTTabBarItem.h
+++ b/React/Views/RCTTabBarItem.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTTABBARITEM_H
+#define RCTTABBARITEM_H
+
 #import <UIKit/UIKit.h>
 
 #import <React/RCTComponent.h>
@@ -23,3 +26,5 @@
 @property (nonatomic, copy) RCTBubblingEventBlock onPress;
 
 @end
+
+#endif //RCTTABBARITEM_H

--- a/React/Views/RCTTabBarItemManager.h
+++ b/React/Views/RCTTabBarItemManager.h
@@ -7,8 +7,13 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTTABBARITEMMANAGER_H
+#define RCTTABBARITEMMANAGER_H
+
 #import <React/RCTViewManager.h>
 
 @interface RCTTabBarItemManager : RCTViewManager
 
 @end
+
+#endif //RCTTABBARITEMMANAGER_H

--- a/React/Views/RCTTabBarManager.h
+++ b/React/Views/RCTTabBarManager.h
@@ -7,8 +7,13 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTTABBARMANAGER_H
+#define RCTTABBARMANAGER_H
+
 #import <React/RCTViewManager.h>
 
 @interface RCTTabBarManager : RCTViewManager
 
 @end
+
+#endif //RCTTABBARMANAGER_H

--- a/React/Views/RCTTextDecorationLineType.h
+++ b/React/Views/RCTTextDecorationLineType.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTTEXTDECORATIONLINETYPE_H
+#define RCTTEXTDECORATIONLINETYPE_H
+
 #import <Foundation/Foundation.h>
 
 typedef NS_ENUM(NSInteger, RCTTextDecorationLineType) {
@@ -15,3 +18,5 @@ typedef NS_ENUM(NSInteger, RCTTextDecorationLineType) {
   RCTTextDecorationLineTypeStrikethrough,
   RCTTextDecorationLineTypeUnderlineStrikethrough,
 };
+
+#endif //RCTTEXTDECORATIONLINETYPE_H

--- a/React/Views/RCTView.h
+++ b/React/Views/RCTView.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTVIEW_H
+#define RCTVIEW_H
+
 #import <UIKit/UIKit.h>
 
 #import <React/RCTBorderStyle.h>
@@ -102,3 +105,5 @@
 @property (nonatomic, assign) UIEdgeInsets hitTestEdgeInsets;
 
 @end
+
+#endif //RCTVIEW_H

--- a/React/Views/RCTViewControllerProtocol.h
+++ b/React/Views/RCTViewControllerProtocol.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTVIEWCONTROLLERPROTOCOL_H
+#define RCTVIEWCONTROLLERPROTOCOL_H
+
 /**
  * A simple protocol that any React-managed ViewControllers should implement.
  * We need all of our ViewControllers to cache layoutGuide changes so any View
@@ -18,3 +21,5 @@
 @property (nonatomic, readonly, strong) id<UILayoutSupport> currentBottomLayoutGuide;
 
 @end
+
+#endif //RCTVIEWCONTROLLERPROTOCOL_H

--- a/React/Views/RCTViewManager.h
+++ b/React/Views/RCTViewManager.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTVIEWMANAGER_H
+#define RCTVIEWMANAGER_H
+
 #import <UIKit/UIKit.h>
 
 #import <React/RCTBridgeModule.h>
@@ -120,3 +123,5 @@ RCT_REMAP_SHADOW_PROPERTY(name, __custom__, type)         \
 - (void)set_##name:(id)json forShadowView:(viewClass *)view
 
 @end
+
+#endif //RCTVIEWMANAGER_H

--- a/React/Views/RCTWebView.h
+++ b/React/Views/RCTWebView.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTWEBVIEW_H
+#define RCTWEBVIEW_H
+
 #import <React/RCTView.h>
 
 @class RCTWebView;
@@ -45,3 +48,5 @@ shouldStartLoadForRequest:(NSMutableDictionary<NSString *, id> *)request
 - (void)postMessage:(NSString *)message;
 
 @end
+
+#endif //RCTWEBVIEW_H

--- a/React/Views/RCTWebViewManager.h
+++ b/React/Views/RCTWebViewManager.h
@@ -7,8 +7,13 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTWEBVIEWMANAGER_H
+#define RCTWEBVIEWMANAGER_H
+
 #import <React/RCTViewManager.h>
 
 @interface RCTWebViewManager : RCTViewManager
 
 @end
+
+#endif //RCTWEBVIEWMANAGER_H

--- a/React/Views/RCTWrapperViewController.h
+++ b/React/Views/RCTWrapperViewController.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef RCTWRAPPERVIEWCONTROLLER_H
+#define RCTWRAPPERVIEWCONTROLLER_H
+
 #import <UIKit/UIKit.h>
 
 #import <React/RCTViewControllerProtocol.h>
@@ -30,3 +33,5 @@ didMoveToNavigationController:(UINavigationController *)navigationController;
 @property (nonatomic, strong) RCTNavItem *navItem;
 
 @end
+
+#endif //RCTWRAPPERVIEWCONTROLLER_H

--- a/React/Views/UIView+Private.h
+++ b/React/Views/UIView+Private.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef UIVIEW_PRIVATE_H
+#define UIVIEW_PRIVATE_H
+
 #import <UIKit/UIKit.h>
 
 @interface UIView (Private)
@@ -20,3 +23,5 @@
 - (void)clearSortedSubviews;
 
 @end
+
+#endif //UIVIEW_PRIVATE_H

--- a/React/Views/UIView+React.h
+++ b/React/Views/UIView+React.h
@@ -7,6 +7,9 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#ifndef UIVIEW_REACT_H
+#define UIVIEW_REACT_H
+
 #import <UIKit/UIKit.h>
 
 #import <React/RCTComponent.h>
@@ -82,3 +85,5 @@
 #endif
 
 @end
+
+#endif //UIVIEW_REACT_H


### PR DESCRIPTION
### Motivation
Since https://github.com/facebook/react-native/commit/e1577df1fd70049ce7f288f91f6e2b18d512ff4d, and even after https://github.com/facebook/react-native/commit/59407f36608f52d4402d742d916f78acd3ca7152, changing header search paths and switching to `#import <React/Thing.h>` within RN means that user and third-party code has to be changed to match. As far as I understand it, that means a new BC (major) release will be required of every third party library which imports iOS headers. App devs will need to wait until third-party libs are fixed or rely on patches. Painful!

### Proposal
App and library developers are required to change because, when both `#import <React/RCTFoo.h>` and `#import "RCTFoo.h"` appear, we get redefinition issues. If we surround the headers in `#ifndef RCTFOO_H` `#define RCTFOO_H` ... `#endif` that's not an issue, and users are free to import headers by a mix of styles.

### Testing
As per motivation, this build against current master fails because the header change breaks compatibility with these two third party libs, things like `error: redefinition of 'RCTLogLevel'`: 
```
yarn cache clean
react-native init fooproj --version react-native@facebook/react-native#bc285de79975f7990d5edb365a6ef76fa337c7e1
cd fooproj
yarn add react-native-vector-icons react-native-orientation
react-native link
react-native run-ios
```

This PR builds fine:
```
yarn cache clean
react-native init barproj --version react-native@rh389/react-native#ifndef
cd barproj
yarn add react-native-vector-icons react-native-orientation
react-native link
react-native run-ios
```

I'm _fairly_ certain it's not possible for this PR to do harm, but it'd be interesting to know whether it helps those using different configurations (Swift, Pods etc).

Edit: FYI, I ran `find React Libraries -name *.h -execdir ~/addifndef.sh {} \;` with https://gist.github.com/rh389/cb882af964936ff9eb8b976620592ec1 and followed up with some manual fixing for files without the standard 10 line boilerplate header.