### PR TITLE
adb remote host support

### DIFF
--- a/local-cli/runAndroid/adb.js
+++ b/local-cli/runAndroid/adb.js
@@ -35,7 +35,7 @@ function parseDevicesResult(result: string): Array<string> {
 /**
  * Executes the commands needed to get a list of devices from ADB
  */
-function getDevices(): Array<string> {
+function getDevices(extraParams): Array<string> {
   const cmd = ['adb', extraParams, 'devices'].join(' ');
   try {
     const devicesResult = child_process.execSync(cmd);

--- a/local-cli/runAndroid/adb.js
+++ b/local-cli/runAndroid/adb.js
@@ -35,8 +35,9 @@ function parseDevicesResult(result: string): Array<string> {
 /**
  * Executes the commands needed to get a list of devices from ADB
  */
-function getDevices(extraParams): Array<string> {
-  const cmd = ['adb', extraParams, 'devices'].join(' ');
+function getDevices(extraParams: Array<string>): Array<string> {
+  extraParams = extraParams || [];
+  const cmd = ['adb', extraParams.join(' '), 'devices'].join(' ');
   try {
     const devicesResult = child_process.execSync(cmd);
     return parseDevicesResult(devicesResult.toString());

--- a/local-cli/runAndroid/adb.js
+++ b/local-cli/runAndroid/adb.js
@@ -10,6 +10,13 @@
  */
 
 const child_process = require('child_process');
+const chalk = require('chalk');
+
+function getAdbPath() {
+  return process.env.ANDROID_HOME
+    ? process.env.ANDROID_HOME + '/platform-tools/adb'
+    : 'adb';
+}
 
 /**
  * Parses the output of the 'adb devices' command
@@ -37,10 +44,21 @@ function parseDevicesResult(result: string): Array<string> {
  */
 function getDevices(extraParams: Array<string>): Array<string> {
   extraParams = extraParams || [];
-  const cmd = ['adb', extraParams.join(' '), 'devices'].join(' ');
+  const cmd = [getAdbPath(), ...extraParams, 'devices'].join(' ');
+
+  console.log(chalk.bold(
+    `Getting devices (${cmd})...`
+  ));
+
   try {
     const devicesResult = child_process.execSync(cmd);
-    return parseDevicesResult(devicesResult.toString());
+    const result = parseDevicesResult(devicesResult.toString());
+
+    console.log(chalk.bold(
+      `Found devices (${result.join(', ')})...`
+    ));
+
+    return result;
   } catch (e) {
     return [];
   }
@@ -50,5 +68,6 @@ function getDevices(extraParams: Array<string>): Array<string> {
 
 module.exports = {
   parseDevicesResult: parseDevicesResult,
-  getDevices: getDevices
+  getDevices: getDevices,
+  getAdbPath: getAdbPath
 };

--- a/local-cli/runAndroid/adb.js
+++ b/local-cli/runAndroid/adb.js
@@ -36,8 +36,9 @@ function parseDevicesResult(result: string): Array<string> {
  * Executes the commands needed to get a list of devices from ADB
  */
 function getDevices(): Array<string> {
+  const cmd = ['adb', extraParams, 'devices'].join(' ');
   try {
-    const devicesResult = child_process.execSync('adb devices');
+    const devicesResult = child_process.execSync(cmd);
     return parseDevicesResult(devicesResult.toString());
   } catch (e) {
     return [];

--- a/local-cli/runAndroid/runAndroid.js
+++ b/local-cli/runAndroid/runAndroid.js
@@ -68,16 +68,17 @@ function tryRunAdbReverse(device, adbAddrArg) {
       stdio: [process.stdin, process.stdout, process.stderr],
     });
   } catch (e) {
+    const emsg = e ? e.message : e;
     console.log(chalk.yellow(
-      `Could not run adb reverse: ${e.message}`
+      `Could not run adb reverse: ${emsg}`
     ));
   }
 }
 
 // Builds the app and runs it on a connected emulator / device.
 function buildAndRun(args) {
-  const adbHost = args.adbHost || process.env.ADB_HOST || 'localhost';
-  const adbPort = args.adbPort || process.env.ADB_PORT || '5037';
+  const adbHost = args.adbhost || process.env.ADB_HOST || 'localhost';
+  const adbPort = args.adbport || process.env.ADB_PORT || '5037';
   const adbAddrArg = ['-H', adbHost, '-P', adbPort].join(' ');
   try {
     adb.getDevices(adbAddrArg).map((device) => tryRunAdbReverse(device, adbAddrArg));
@@ -255,11 +256,11 @@ module.exports = {
   }, {
     command: '--variant [string]',
   }, {
-    command: '--adb-host [string]',
+    command: '--adbhost [string]',
     description: 'Name of adb server host (default: localhost)',
     default: ''
   }, {
-    command: '--adb-port [string]',
+    command: '--adbport [string]',
     description: 'Port of adb server (default: 5037)',
     default: ''
   }],

--- a/local-cli/runAndroid/runAndroid.js
+++ b/local-cli/runAndroid/runAndroid.js
@@ -43,16 +43,10 @@ function runAndroid(argv, config, args) {
   });
 }
 
-function getAdbPath() {
-  return process.env.ANDROID_HOME
-    ? process.env.ANDROID_HOME + '/platform-tools/adb'
-    : 'adb';
-}
-
 // Runs ADB reverse tcp:8081 tcp:8081 to allow loading the jsbundle from the packager
 function tryRunAdbReverse(device, adbAddrArg) {
   try {
-    const adbPath = getAdbPath();
+    const adbPath = adb.getAdbPath();
     const adbArgs = ['reverse', 'tcp:8081', 'tcp:8081'];
 
     // If a device is specified then tell adb to use it
@@ -84,8 +78,9 @@ function buildAndRun(args) {
   const adbHost = args.adbhost || process.env.ADB_HOST || 'localhost';
   const adbPort = args.adbport || process.env.ADB_PORT || '5037';
   const adbAddrArg = ['-H', adbHost, '-P', adbPort];
+  const devices = adb.getDevices(adbAddrArg);
   try {
-    adb.getDevices(adbAddrArg).map((device) => tryRunAdbReverse(device, adbAddrArg));
+    devices.forEach((device) => tryRunAdbReverse(device, adbAddrArg));
 
     const gradleArgs = [];
     if (args.variant) {
@@ -164,14 +159,12 @@ function buildAndRun(args) {
       'utf8'
     ).match(/package="(.+?)"/)[1];
 
-    const adbPath = getAdbPath();
-
-    const devices = adb.getDevices(adbAddrArg);
+    const adbPath = adb.getAdbPath();
 
     if (devices && devices.length > 0) {
       devices.forEach((device) => {
 
-        const adbArgs =
+        const  =
           ['-s', device, 'shell', 'am', 'start', '-n', packageName + '/.MainActivity'];
 
         adbArgs.unshift(...adbAddrArg)

--- a/local-cli/runAndroid/runAndroid.js
+++ b/local-cli/runAndroid/runAndroid.js
@@ -53,11 +53,15 @@ function getAdbPath() {
 function tryRunAdbReverse(device, adbAddrArg) {
   try {
     const adbPath = getAdbPath();
-    const adbArgs = [adbAddrArg, 'reverse', 'tcp:8081', 'tcp:8081'];
+    const adbArgs = ['reverse', 'tcp:8081', 'tcp:8081'];
 
     // If a device is specified then tell adb to use it
     if (device) {
       adbArgs.unshift('-s', device);
+    }
+
+    if (adbAddrArg) {
+      adbArgs.unshift(...adbAddrArg);
     }
 
     console.log(chalk.bold(
@@ -79,7 +83,7 @@ function tryRunAdbReverse(device, adbAddrArg) {
 function buildAndRun(args) {
   const adbHost = args.adbhost || process.env.ADB_HOST || 'localhost';
   const adbPort = args.adbport || process.env.ADB_PORT || '5037';
-  const adbAddrArg = ['-H', adbHost, '-P', adbPort].join(' ');
+  const adbAddrArg = ['-H', adbHost, '-P', adbPort];
   try {
     adb.getDevices(adbAddrArg).map((device) => tryRunAdbReverse(device, adbAddrArg));
 
@@ -168,7 +172,9 @@ function buildAndRun(args) {
       devices.forEach((device) => {
 
         const adbArgs =
-          [adbAddrArg, '-s', device, 'shell', 'am', 'start', '-n', packageName + '/.MainActivity'];
+          ['-s', device, 'shell', 'am', 'start', '-n', packageName + '/.MainActivity'];
+
+        adbArgs.unshift(...adbAddrArg)
 
         console.log(chalk.bold(
           `Starting the app on ${device} (${adbPath} ${adbArgs.join(' ')})...`
@@ -180,8 +186,9 @@ function buildAndRun(args) {
       // If we cannot execute based on adb devices output, fall back to
       // shell am start
       const fallbackAdbArgs = [
-        adbAddrArg, 'shell', 'am', 'start', '-n', packageName + '/.MainActivity'
+        'shell', 'am', 'start', '-n', packageName + '/.MainActivity'
       ];
+      fallbackAdbArgs.unshift(...adbAddrArg)
       console.log(chalk.bold(
         `Starting the app (${adbPath} ${fallbackAdbArgs.join(' ')}...`
       ));

--- a/local-cli/runAndroid/runAndroid.js
+++ b/local-cli/runAndroid/runAndroid.js
@@ -76,8 +76,11 @@ function tryRunAdbReverse(device) {
 
 // Builds the app and runs it on a connected emulator / device.
 function buildAndRun(args) {
+  const adbHost = args.adbHost || process.env.ADB_HOST || 'localhost';
+  const adbPort = args.adbPort || process.env.ADB_PORT || '5037';
+  const adbAddrArg = ['-H', adbHost, '-P', adbPort].join(' ');
   try {
-    adb.getDevices().map((device) => tryRunAdbReverse(device));
+    adb.getDevices(adbAddrArg).map((device) => tryRunAdbReverse(device));
 
     const gradleArgs = [];
     if (args.variant) {
@@ -158,13 +161,13 @@ function buildAndRun(args) {
 
     const adbPath = getAdbPath();
 
-    const devices = adb.getDevices();
+    const devices = adb.getDevices(adbAddrArg);
 
     if (devices && devices.length > 0) {
       devices.forEach((device) => {
 
         const adbArgs =
-          ['-s', device, 'shell', 'am', 'start', '-n', packageName + '/.MainActivity'];
+          [adbAddrArg, '-s', device, 'shell', 'am', 'start', '-n', packageName + '/.MainActivity'];
 
         console.log(chalk.bold(
           `Starting the app on ${device} (${adbPath} ${adbArgs.join(' ')})...`
@@ -176,7 +179,7 @@ function buildAndRun(args) {
       // If we cannot execute based on adb devices output, fall back to
       // shell am start
       const fallbackAdbArgs = [
-        'shell', 'am', 'start', '-n', packageName + '/.MainActivity'
+        adbAddrArg, 'shell', 'am', 'start', '-n', packageName + '/.MainActivity'
       ];
       console.log(chalk.bold(
         `Starting the app (${adbPath} ${fallbackAdbArgs.join(' ')}...`
@@ -251,5 +254,13 @@ module.exports = {
     default: 'Debug'
   }, {
     command: '--variant [string]',
+  }, {
+    command: '--adb-host [string]',
+    description: 'Name of adb server host (default: localhost)',
+    default: ''
+  }, {
+    command: '--adb-port [string]',
+    description: 'Port of adb server (default: 5037)',
+    default: ''
   }],
 };

--- a/local-cli/runAndroid/runAndroid.js
+++ b/local-cli/runAndroid/runAndroid.js
@@ -50,10 +50,10 @@ function getAdbPath() {
 }
 
 // Runs ADB reverse tcp:8081 tcp:8081 to allow loading the jsbundle from the packager
-function tryRunAdbReverse(device) {
+function tryRunAdbReverse(device, adbAddrArg) {
   try {
     const adbPath = getAdbPath();
-    const adbArgs = ['reverse', 'tcp:8081', 'tcp:8081'];
+    const adbArgs = [adbAddrArg, 'reverse', 'tcp:8081', 'tcp:8081'];
 
     // If a device is specified then tell adb to use it
     if (device) {
@@ -80,7 +80,7 @@ function buildAndRun(args) {
   const adbPort = args.adbPort || process.env.ADB_PORT || '5037';
   const adbAddrArg = ['-H', adbHost, '-P', adbPort].join(' ');
   try {
-    adb.getDevices(adbAddrArg).map((device) => tryRunAdbReverse(device));
+    adb.getDevices(adbAddrArg).map((device) => tryRunAdbReverse(device, adbAddrArg));
 
     const gradleArgs = [];
     if (args.variant) {


### PR DESCRIPTION
This adds a new CLI option to specify a remote adb host to use. This is useful if your adb server is on another machine on a network and you want to use your local adb as a proxy. The adb client supports this via additional command line parameters to specify the port and host of the host adb instance. This PR gives `react-native run-android` command another two pa maters to specify the remote host and port.

You can see below `adb` parameters to specify a remote host to use when giving an action (like `devices` or `shell`):

```
 -H                            - Name of adb server host (default: localhost)
 -P                            - Port of adb server (default: 5037)
```

I've added these new parameters to `run-android`:
```
{
    command: '--adbhost [string]',
    description: 'Name of adb server host (default: localhost)',
    default: ''
  }, {
    command: '--adbport [string]',
    description: 'Port of adb server (default: 5037)',
    default: ''
  }
```

Solves #11617