### PR TITLE
Clearer information regarding RCT_EXPORT_MODULE

### DIFF
--- a/docs/NativeModulesIOS.md
+++ b/docs/NativeModulesIOS.md
@@ -38,6 +38,17 @@ RCT_EXPORT_MODULE();
 
 @end
 ```
+If you want to add a different name to your Module, make sure you don't use Obj-C String syntax as a parameter as the macro won't accept it. Do it like this:
+
+```objective-c
+// CalendarManager.m
+@implementation CalendarManager
+
+RCT_EXPORT_MODULE(MyAwsomeCalendarManager);
+
+@end
+```
+Notice the lack of '@' and double quotes.
 
 React Native will not expose any methods of `CalendarManager` to JavaScript unless explicitly told to. This is done using the `RCT_EXPORT_METHOD()` macro:
 

--- a/docs/NativeModulesIOS.md
+++ b/docs/NativeModulesIOS.md
@@ -34,21 +34,14 @@ In addition to implementing the `RCTBridgeModule` protocol, your class must also
 // CalendarManager.m
 @implementation CalendarManager
 
+// To export a module named CalendarManager
 RCT_EXPORT_MODULE();
 
-@end
-```
-If you want to add a different name to your Module, make sure you don't use Obj-C String syntax as a parameter as the macro won't accept it. Do it like this:
-
-```objective-c
-// CalendarManager.m
-@implementation CalendarManager
-
-RCT_EXPORT_MODULE(MyAwsomeCalendarManager);
+// This would name the module AwesomeCalendarManager instead
+// RCT_EXPORT_MODULE(AwesomeCalendarManager);
 
 @end
 ```
-Notice the lack of '@' and double quotes.
 
 React Native will not expose any methods of `CalendarManager` to JavaScript unless explicitly told to. This is done using the `RCT_EXPORT_METHOD()` macro:
 


### PR DESCRIPTION
I think this update is Critical as I wanted to add a different module name to be the same as the Android module name. I simply lost 6 hours until I found out that the Macro does not accept String syntax. Almost drove me crazy. Please, at least do something about it. Thanks.

Thanks for submitting a pull request! Please provide enough information so that others can review your pull request:

> **Unless you are a React Native release maintainer and cherry-picking an *existing* commit into a current release, ensure your pull request is targeting the `master` React Native branch.**

Explain the **motivation** for making this change. What existing problem does the pull request solve?

Prefer **small pull requests**. These are much easier to review and more likely to get merged. Make sure the PR does only one thing, otherwise please split it.

**Test plan (required)**

Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

Make sure tests pass on both Travis and Circle CI.

**Code formatting**

Look around. Match the style of the rest of the codebase. See also the simple [style guide](https://github.com/facebook/react-native/blob/master/CONTRIBUTING.md#style-guide).

For more info, see the ["Pull Requests" section of our "Contributing" guidelines](https://github.com/facebook/react-native/blob/master/CONTRIBUTING.md#pull-requests).
