### PR TITLE
Fix the `path.sep` replacement of node-haste for Windows

### DIFF
--- a/packager/react-packager/src/ModuleGraph/node-haste/Package.js
+++ b/packager/react-packager/src/ModuleGraph/node-haste/Package.js
@@ -77,7 +77,7 @@ module.exports = class Package {
 
       let relPath = './' + path.relative(this.root, name);
       if (path.sep !== '/') {
-        relPath = relPath.replace(path.sep, '/');
+        relPath = relPath.replace(new RegExp('\\' + path.sep, 'g'), '/');
       }
 
       let redirect = replacements[relPath];

--- a/packager/react-packager/src/node-haste/Package.js
+++ b/packager/react-packager/src/node-haste/Package.js
@@ -97,7 +97,7 @@ class Package {
 
       let relPath = './' + path.relative(this.root, name);
       if (path.sep !== '/') {
-        relPath = relPath.replace(path.sep, '/');
+        relPath = relPath.replace(new RegExp('\\' + path.sep, 'g'), '/');
       }
 
       let redirect = replacements[relPath];


### PR DESCRIPTION
Fix the `path.sep` replacement for Windows, currently it just replace one segment:

```js
// Result: './lib/random\random-byte.js'
'./lib\\random\\random-byte.js'.replace(path.sep, '/') 
```

Change to regex will work fine:

```js
// Result: './lib/random/random-byte.js' (correct)
'./lib\\random\\random-byte.js'.replace(new RegExp('\\' + path.sep, 'g'), '/') 
```