### PR TITLE
Updating the documentation for getSize()

### DIFF
--- a/Libraries/Image/Image.ios.js
+++ b/Libraries/Image/Image.ios.js
@@ -287,6 +287,8 @@ const Image = React.createClass({
      * does not fully load/download the image data. A proper, supported way to
      * preload images will be provided as a separate API.
      *
+     * Does not work for static image resources.
+     *
      * @param uri The location of the image.
      * @param success The function that will be called if the image was sucessfully found and width
      * and height retrieved.


### PR DESCRIPTION
Clearly state that the `getSize()` does not work for static image resources because it is assumed the developer knows their static image resource size (the reason I got from a comment on a github issue by a react native contributor).

This missing documentation cost me about 30 minutes to figure out why it didn't work for my static image resource and so I decided to update the documentation 💃 