### PR TITLE
Document AsyncStorage size on iOS and Android

### DIFF
--- a/Libraries/Storage/AsyncStorage.js
+++ b/Libraries/Storage/AsyncStorage.js
@@ -36,6 +36,24 @@ var RCTAsyncStorage = RCTAsyncRocksDBStorage || RCTAsyncSQLiteStorage || RCTAsyn
  * `AsyncStorage` will use either [RocksDB](http://rocksdb.org/) or SQLite
  * based on what is available.
  *
+ * iOS doesn't have any storage limits, but on Android the database is limited to
+ * 6 MB by default. To change the limit, you can modify the `getPackages()` method
+ * in your your project's `MainApplication.java`:
+ * ```
+ * // add the following import
+ * import com.facebook.react.modules.storage.ReactDatabaseSupplier;
+ *
+ * // modify `getPackages()` method
+ * @Override
+ * protected List<ReactPackage> getPackages() {
+ *   // Increase the maximum size of AsyncStorage
+ *   long size = 100 * 1024L * 1024L; // 100 MB
+ *   ReactDatabaseSupplier.getInstance(getApplicationContext()).setMaximumSize(size);
+ * 
+ *   // ...rest of code in `getPackages()`
+ * }
+ * ```
+ *
  * The `AsyncStorage` JavaScript code is a simple facade that provides a clear
  * JavaScript API, real `Error` objects, and simple non-multi functions. Each
  * method in the API returns a `Promise` object.

--- a/Libraries/Storage/AsyncStorage.js
+++ b/Libraries/Storage/AsyncStorage.js
@@ -37,20 +37,20 @@ var RCTAsyncStorage = RCTAsyncRocksDBStorage || RCTAsyncSQLiteStorage || RCTAsyn
  * based on what is available.
  *
  * iOS doesn't have any storage limits, but on Android the database is limited to
- * 6 MB by default. To change the limit, you can modify the `getPackages()` method
+ * 6 MB by default. To change the limit, you can modify the `onCreate()` method
  * in your your project's `MainApplication.java`:
  * ```
  * // add the following import
  * import com.facebook.react.modules.storage.ReactDatabaseSupplier;
  *
- * // modify `getPackages()` method
+ * // modify `onCreate()` method
  * @Override
- * protected List<ReactPackage> getPackages() {
+ * public void onCreate() {
+ *   // ...existing code, including `super.onCreate()` call
+ *
  *   // Increase the maximum size of AsyncStorage
  *   long size = 100 * 1024L * 1024L; // 100 MB
  *   ReactDatabaseSupplier.getInstance(getApplicationContext()).setMaximumSize(size);
- *
- *   // ...rest of code in `getPackages()`
  * }
  * ```
  *

--- a/Libraries/Storage/AsyncStorage.js
+++ b/Libraries/Storage/AsyncStorage.js
@@ -49,7 +49,7 @@ var RCTAsyncStorage = RCTAsyncRocksDBStorage || RCTAsyncSQLiteStorage || RCTAsyn
  *   // Increase the maximum size of AsyncStorage
  *   long size = 100 * 1024L * 1024L; // 100 MB
  *   ReactDatabaseSupplier.getInstance(getApplicationContext()).setMaximumSize(size);
- * 
+ *
  *   // ...rest of code in `getPackages()`
  * }
  * ```


### PR DESCRIPTION
Currently, there's no documentation on the default 6MB limit on Android for `AsyncStorage`. This pull request adds documentation for iOS and Android size limits, as well as example code for changing the default size limit on Android.

This pull request should properly resolve this issue: https://github.com/facebook/react-native/issues/3387#issuecomment-148042923