### PR TITLE
Fix the ability to disable bundling during android build

### DIFF
--- a/react.gradle
+++ b/react.gradle
@@ -84,11 +84,11 @@ gradle.projectsEvaluated {
                     commandLine(*nodeExecutableAndArgs, "node_modules/react-native/local-cli/cli.js", "bundle", "--platform", "android", "--dev", "${devEnabled}",
                             "--reset-cache", "--entry-file", entryFile, "--bundle-output", jsBundleFile, "--assets-dest", resourcesDir, *extraPackagerArgs)
                 }
-
-                enabled config."bundleIn${targetName}" ||
-                    config."bundleIn${buildTypeName.capitalize()}" ?:
-                            targetName.toLowerCase().contains("release")
             }
+
+            currentBundleTask.enabled = config."bundleIn${targetName}" ||
+                config."bundleIn${buildTypeName.capitalize()}" ?:
+                        targetName.toLowerCase().contains("release")
 
             // Hook bundle${productFlavor}${buildType}JsAndAssets into the android build process
             currentBundleTask.dependsOn("merge${targetName}Resources")


### PR DESCRIPTION
**Motivation**: I need to execute a custom `react-native bundle` before running `./gradlew assembleRelease`, as the path to my `local-cli` is not the path hard-coded in the `react.gradle` file. In order for this to work, I must disable the bundle step during `assembleRelease`.

**Problem**: It appears that the `bundleInRelease` option does not work. If set to `true`, the task `bundleReleaseJsAndAssets` still executes when running `./gradlew assembleRelease`.

**Solution**: Specify the `enabled` flag using the same syntax used in the [Gradle documentation](https://docs.gradle.org/current/userguide/more_about_tasks.html#sec:enabling_and_disabling_tasks).

**Test plan**

1. Specify the following in an application's `android/app/build.gradle`:

```
project.ext.react = [
  bundleInRelease: false
]
```

2. Execute the following command in terminal:

```sh
cd android
./gradlew assembleRelease
```

3. Observe that the `bundleReleaseJsAndAssets` step is skipped in the output.