### PR TITLE
Fix the ability to disable bundling during android build

### DIFF
--- a/react.gradle
+++ b/react.gradle
@@ -85,9 +85,7 @@ gradle.projectsEvaluated {
                             "--reset-cache", "--entry-file", entryFile, "--bundle-output", jsBundleFile, "--assets-dest", resourcesDir, *extraPackagerArgs)
                 }
 
-                enabled config."bundleIn${targetName}" ||
-                    config."bundleIn${buildTypeName.capitalize()}" ?:
-                            targetName.toLowerCase().contains("release")
+                enabled config."bundleIn${targetName}" != null ? config."bundleIn${targetName}" : targetName.toLowerCase().contains("release")
             }
 
             // Hook bundle${productFlavor}${buildType}JsAndAssets into the android build process


### PR DESCRIPTION
**Motivation**: I need to execute a custom react-native bundle before running `./gradlew assembleRelease`, as the path to my local-cli is not the path hard-coded in the `react.gradle` file. In order for this to work, I must disable the bundle step during `assembleRelease`.

**Problem**: It appears that the` bundleInRelease` option does not work. If set to `true`, the task `bundleReleaseJsAndAssets` still executes when running `./gradlew assembleRelease`.

**Cause**: The `bundleIn*` condition was was being checked in a way that caused the default to be used if `false` was specified. This is because `false ?: default` returns `default` instead of `false`.

**Solution**: Drop the Elvis operator in favor of specifically checking for a `null` value. It also appears that the explicit check for the two variations of `bundleIn${targetName}` and `bundleIn${bundleTypeName.capitalize()}` are not needed, since `targetName` includes `bundleTypeName.capitalize()` already.

**Test plan**

1. Specify the following in an application's `android/app/build.gradle`:

```
project.ext.react = [
  bundleInRelease: false
]
```

2. Execute the following command in terminal:

```sh
cd android
./gradlew assembleRelease
```

3. Observe that the `bundleReleaseJsAndAssets` step is skipped in the output.