### PR TITLE
[Podspec] Make Core subspec use a Ruby string array for exclude_files

### DIFF
--- a/React.podspec
+++ b/React.podspec
@@ -34,7 +34,7 @@ Pod::Spec.new do |s|
     ss.dependency      'React/yoga'
     ss.dependency      'React/cxxreact'
     ss.source_files  = "React/**/*.{c,h,m,mm,S}"
-    ss.exclude_files = "**/__tests__/*", "IntegrationTests/* ReactCommon/yoga/*"
+    ss.exclude_files = "**/__tests__/*", "IntegrationTests/*", "ReactCommon/yoga/*"
     ss.frameworks    = "JavaScriptCore"
     ss.libraries     = "stdc++"
   end


### PR DESCRIPTION
For consistency (and maybe correctness?) use an array instead of a string with spaces in it for the `exclude_paths` value in the Podspec.
