### PR TITLE
Fixes podspec for master #11640

### DIFF
--- a/React.podspec
+++ b/React.podspec
@@ -34,12 +34,12 @@ Pod::Spec.new do |s|
     ss.dependency      'React/yoga'
     ss.dependency      'React/cxxreact'
     ss.source_files  = "React/**/*.{c,h,m,mm,S}"
-    ss.exclude_files = "React/**/RCTTVView.*", "**/__tests__/*", "IntegrationTests/* ReactCommon/yoga/*"
+    ss.exclude_files = "**/__tests__/*", "IntegrationTests/*", "React/**/RCTTVView.*", "ReactCommon/yoga/*"
     ss.frameworks    = "JavaScriptCore"
     ss.libraries     = "stdc++"
   end
 
-  s.subspec 'AppleTV' do |ss|
+  s.subspec 'tvOS' do |ss|
     ss.dependency       'React/Core'
     ss.source_files   = "React/**/RCTTVView.{h, m}"
   end

--- a/React.podspec
+++ b/React.podspec
@@ -34,9 +34,14 @@ Pod::Spec.new do |s|
     ss.dependency      'React/yoga'
     ss.dependency      'React/cxxreact'
     ss.source_files  = "React/**/*.{c,h,m,mm,S}"
-    ss.exclude_files = "**/__tests__/*", "IntegrationTests/*", "ReactCommon/yoga/*"
+    ss.exclude_files = "RCTTVView*", "**/__tests__/*", "IntegrationTests/* ReactCommon/yoga/*"
     ss.frameworks    = "JavaScriptCore"
     ss.libraries     = "stdc++"
+  end
+
+  s.subspec 'AppleTV' do |ss|
+    ss.dependency       'React/Core'
+    ss.source_files   = "React/**/RCTTVView.{h, m}"
   end
 
   s.subspec 'jschelpers' do |ss|

--- a/React.podspec
+++ b/React.podspec
@@ -34,7 +34,7 @@ Pod::Spec.new do |s|
     ss.dependency      'React/yoga'
     ss.dependency      'React/cxxreact'
     ss.source_files  = "React/**/*.{c,h,m,mm,S}"
-    ss.exclude_files = "RCTTVView*", "**/__tests__/*", "IntegrationTests/* ReactCommon/yoga/*"
+    ss.exclude_files = "React/**/RCTTVView.*", "**/__tests__/*", "IntegrationTests/* ReactCommon/yoga/*"
     ss.frameworks    = "JavaScriptCore"
     ss.libraries     = "stdc++"
   end


### PR DESCRIPTION
Currently the master Podspec is broken because tvOS files are being included, to avoid this compile error the file is being excluded.

https://github.com/facebook/react-native/commit/c92ad5f6ae74c1d398c7cd93d5c4c50da0ca0430

Thats the commit which introduced the breakage anything later that that will fail. Aka RN 0.41 will fail because of this.

**Test plan (required)**

Tested on new project against master

// cc @ide 