### PR TITLE
[CI] Updated extra-android-m2repository to get android support v4 23.4.0

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -19,12 +19,12 @@ dependencies:
     - if [[ ! -e /home/ubuntu/buck ]]; then git clone https://github.com/facebook/buck.git /home/ubuntu/buck; fi
     - cd /home/ubuntu/buck && ant
     - buck --version
+    - source scripts/circle-ci-android-setup.sh && getAndroidSDK
     - buck fetch ReactAndroid/src/test/java/com/facebook/react/modules
     - buck fetch ReactAndroid/src/main/java/com/facebook/react
     - buck fetch ReactAndroid/src/main/java/com/facebook/react/shell
     - buck fetch ReactAndroid/src/test/...
     - buck fetch ReactAndroid/src/androidTest/...
-    - source scripts/circle-ci-android-setup.sh && getAndroidSDK
     - ./gradlew :ReactAndroid:downloadBoost :ReactAndroid:downloadDoubleConversion :ReactAndroid:downloadFolly :ReactAndroid:downloadGlog
     # CIRCLE_NPM_TOKEN is in React Native project settings in Circle CI.
     # It was generated for bestander user, easy to replace with anyone's else

--- a/scripts/circle-ci-android-setup.sh
+++ b/scripts/circle-ci-android-setup.sh
@@ -6,6 +6,7 @@ function getAndroidSDK {
   DEPS="$ANDROID_HOME/installed-dependencies"
 
   if [ ! -e $DEPS ]; then
+    echo y | android update sdk --no-ui --all --filter extra-android-m2repository
     echo no | android create avd -n testAVD -f -t android-19 --abi default/armeabi-v7a &&
     touch $DEPS
   fi


### PR DESCRIPTION
Circle CI has an older m2repository version by default