### PR TITLE
[React] Update React version to ~15.4.1 instead of the RC

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "react-native": "local-cli/wrong-react-native.js"
   },
   "peerDependencies": {
-    "react": "~15.4.0-rc.4"
+    "react": "~15.4.1"
   },
   "dependencies": {
     "absolute-path": "^0.0.0",
@@ -203,9 +203,9 @@
     "jest-repl": "18.0.0",
     "jest-runtime": "18.0.0",
     "mock-fs": "^3.11.0",
-    "react": "~15.4.0-rc.4",
-    "react-dom": "~15.4.0-rc.4",
-    "react-test-renderer": "~15.4.0-rc.4",
+    "react": "~15.4.1",
+    "react-dom": "~15.4.1",
+    "react-test-renderer": "~15.4.1",
     "shelljs": "0.6.0",
     "sinon": "^2.0.0-pre.2"
   }


### PR DESCRIPTION
React 15.4.x has been out for awhile. Test Plan: open UI Explorer, go through the various screens and look for warnings or errors.
