### PR TITLE
Corrected misplaced closing parenthesis

### DIFF
--- a/docs/Networking.md
+++ b/docs/Networking.md
@@ -49,11 +49,11 @@ Networking is an inherently asynchronous operation. Fetch methods will return a 
   ```js
   function getMoviesFromApiAsync() {
     return fetch('https://facebook.github.io/react-native/movies.json')
-      .then((response) => response.json())
-      .then((responseJson) => {
-        return responseJson.movies;
-      })
-      .catch((error) => {
+      .then((response) => response.json()
+        .then((responseJson) => {
+          return responseJson.movies;
+        })
+      ).catch((error) => {
         console.error(error);
       });
   }


### PR DESCRIPTION
The example shows two `then`s for the same fetch method. If run as-is, it causes a method does not exist error.
**motivation**
Well, as a beginner, I was thrown off by the example and just thought I'd share.

**Solution**
The second `then` should handle the promise given by the `.json()` method.

**Test plan **
This is a documentation problem. It does not change anything in the real codebase. 

Thanks!
