### PR TITLE
RCTConverter: Add type casting to enum conversion macros.

### DIFF
--- a/React/Base/RCTConvert.h
+++ b/React/Base/RCTConvert.h
@@ -214,7 +214,7 @@ RCT_CUSTOM_CONVERTER(type, type, [RCT_DEBUG ? [self NSNumber:json] : json getter
   dispatch_once(&onceToken, ^{                            \
     mapping = values;                                     \
   });                                                     \
-  return [RCTConvertEnumValue(#type, mapping, @(default), json) getter]; \
+  return (type)[RCTConvertEnumValue(#type, mapping, @(default), json) getter]; \
 }
 
 /**
@@ -229,7 +229,7 @@ RCT_CUSTOM_CONVERTER(type, type, [RCT_DEBUG ? [self NSNumber:json] : json getter
   dispatch_once(&onceToken, ^{                            \
     mapping = values;                                     \
   });                                                     \
-  return [RCTConvertMultiEnumValue(#type, mapping, @(default), json) getter]; \
+  return (type)[RCTConvertMultiEnumValue(#type, mapping, @(default), json) getter]; \
 }
 
 /**


### PR DESCRIPTION
The explicit casting is required in order to avoid implicit casting
warnings / errors.