### PR TITLE
Add quality setting to cropImage

### DIFF
--- a/Libraries/Image/ImageEditor.js
+++ b/Libraries/Image/ImageEditor.js
@@ -46,6 +46,10 @@ type ImageCropData = {
     cover: string,
     stretch: string,
   }>,
+  /**
+   * (Optional, iOS-only) JPEG compression quality, defaults to 0.75.
+   */
+  quality?: number,
 };
 
 class ImageEditor {

--- a/Libraries/Image/RCTImageStoreManager.h
+++ b/Libraries/Image/RCTImageStoreManager.h
@@ -21,6 +21,8 @@
  */
 - (void)storeImage:(UIImage *)image withBlock:(void (^)(NSString *imageTag))block;
 
+- (void)storeImage:(UIImage *)image quality:(float)quality withBlock:(void (^)(NSString *imageTag))block;
+
 @end
 
 @interface RCTImageStoreManager (Deprecated)

--- a/Libraries/Image/RCTImageStoreManager.m
+++ b/Libraries/Image/RCTImageStoreManager.m
@@ -74,9 +74,14 @@ RCT_EXPORT_MODULE()
 
 - (void)storeImage:(UIImage *)image withBlock:(void (^)(NSString *imageTag))block
 {
+  [self storeImage:image quality:0.75 withBlock:block];
+}
+
+- (void)storeImage:(UIImage *)image quality:(float)quality withBlock:(void (^)(NSString *imageTag))block
+{
   RCTAssertParam(block);
   dispatch_async(_methodQueue, ^{
-    NSString *imageTag = [self _storeImageData:RCTGetImageData(image.CGImage, 0.75)];
+    NSString *imageTag = [self _storeImageData:RCTGetImageData(image.CGImage, quality)];
     dispatch_async(dispatch_get_main_queue(), ^{
       block(imageTag);
     });


### PR DESCRIPTION
Currently, `ImageEditor.cropImage` on iOS defaults to JPEG compression quality of `0.75` (specified in `RCTImageStoreManager.m`). This PR adds an optional `quality` property to `cropData`, so a custom quality setting can be used.

A few notes/remarks:
- Not implemented for Android (has been documented as iOS-only). It seems like ImageStore is not used when cropping images on Android but instead are saved to temporary file right away. Adding support for this property to the file implementation in Android should be pretty easy.
- Android file-based cropImage uses default compression of `0.9`, while the default on iOS is `0.75`, why?

**Test plan (required)**

Existing code using `cropImage` produces identical results.

Example cropped image data, `[self->_bridge.imageStoreManager getImageDataForTag:imageTag ... ]`: 
- before change/without setting `quality`: `309343` bytes
- specifying quality of `0.9`: `435607` bytes 