### PR TITLE
Fix comparison between NSNumber* and int

### DIFF
--- a/React/Base/RCTJavaScriptLoader.mm
+++ b/React/Base/RCTJavaScriptLoader.mm
@@ -29,7 +29,7 @@ NSString *const RCTJavaScriptLoaderErrorDomain = @"RCTJavaScriptLoaderErrorDomai
   NSMutableString *desc = [NSMutableString new];
   [desc appendString:_status ?: @"Loading"];
 
-  if (_total > 0) {
+  if ([_total integerValue] > 0) {
     [desc appendFormat:@" %ld%% (%@/%@)", (long)(100 * [_done integerValue] / [_total integerValue]), _done, _total];
   }
   [desc appendString:@"\u2026"];


### PR DESCRIPTION
Strangely comparing a pointer with zero will only be a clang warning when compiling with `-Wpedantic`, so this incorrect comparison is silently allowed.

**Test plan**

Compiles with `-Wpedantic`.
