### PR TITLE
Gradle - Added Config for Dev Mode Flag in Bundles

### DIFF
--- a/react.gradle
+++ b/react.gradle
@@ -76,7 +76,9 @@ gradle.projectsEvaluated {
                 workingDir reactRoot
 
                 // Set up dev mode
-                def devEnabled = !targetName.toLowerCase().contains("release")
+                def devEnabled = config."devIn${targetName}" != null ? config."devIn${targetName}" : 
+                  (config."devIn${buildTypeName.capitalize()}" != null ? config."devIn${buildTypeName.capitalize()}" :
+                  !targetName.toLowerCase().contains("release"))
                 if (Os.isFamily(Os.FAMILY_WINDOWS)) {
                     commandLine("cmd", "/c", *nodeExecutableAndArgs, "node_modules/react-native/local-cli/cli.js", "bundle", "--platform", "android", "--dev", "${devEnabled}",
                             "--reset-cache", "--entry-file", entryFile, "--bundle-output", jsBundleFile, "--assets-dest", resourcesDir, *extraPackagerArgs)


### PR DESCRIPTION
Motivation:
We ship beta releases that are almost identical to release.  We do not want warning windows to pop up.  That is only possible by setting the bundler --dev flag to false.  Unfortunately, the current react.gradle only does this when the build type (or flavor) is called "release".

This single-line PR allows you to customize the --dev value per build type or flavor.  Keeping with the "bundleIn{config}" config, there is a "devIn{config}".  If you define that, it will take your value from config.  For example, if you want to turn dev off in 'beta', add this to your app's build.gradle:
```
project.ext.react = [
    bundleInBeta: true,
    devInbeta: false
]
```

That will bundle the non-dev js with the app, which is perfect for distributions like a beta.

This addition is backwards compatible.