### PR TITLE
Add perspective transform support on Android

### DIFF
--- a/Examples/UIExplorer/js/TransformExample.js
+++ b/Examples/UIExplorer/js/TransformExample.js
@@ -211,7 +211,7 @@ exports.title = 'Transforms';
 exports.description = 'View transforms';
 exports.examples = [
   {
-    title: 'Perspective',
+    title: 'Perspective, Rotate, Animation',
     description: 'perspective: 850, rotateX: Animated.timing(0 -> 360)',
     render(): React.Element<any> { return <Flip />; }
   },


### PR DESCRIPTION
Rebased #6926 against master.

Fixes #2915

Test plan:

Check that the perspective of the flip card in UIExplorer is same on both iOS and Android

cc @kevinstumpf @brentvatne @lexs 