### PR TITLE
Add no-packager option to run-android and run-ios commands

### DIFF
--- a/local-cli/runAndroid/runAndroid.js
+++ b/local-cli/runAndroid/runAndroid.js
@@ -31,6 +31,10 @@ function runAndroid(argv, config, args) {
     return;
   }
 
+  if (!args.packager) {
+    return buildAndRun(args);
+  }
+
   return isPackagerRunning().then(result => {
     if (result === 'running') {
       console.log(chalk.bold('JS server already running.'));
@@ -286,5 +290,8 @@ module.exports = {
     command: '--deviceId [string]',
     description: 'builds your app and starts it on a specific device/simulator with the ' +
       'given device id (listed by running "adb devices" on the command line).',
+  }, {
+    command: '--no-packager',
+    description: 'Do not launch packager while building',
   }],
 };


### PR DESCRIPTION
## Motivation
Currently, while running `react-native run-android` command, React Native's packager is launched, and there is not any way to disable the current behaviour. This is handled somehow on iOS by adding an environment variable `RCT_NO_LAUNCH_PACKAGER` (see #6180).

This is a cross-platform solution that adds the `--no-packager` option both to `run-ios` and `run-android`, which prevents the packager from being launched.

## Testing
This was tested by building with and without the option, on both environments (Android and iOS) using the device and simulator, working as expected.