### PR TITLE
Fix .gitignore of HelloWorld template to commit third party JARs

### DIFF
--- a/local-cli/templates/HelloWorld/_gitignore
+++ b/local-cli/templates/HelloWorld/_gitignore
@@ -39,7 +39,6 @@ yarn-error.log
 # BUCK
 buck-out/
 \.buckd/
-android/app/libs
 *.keystore
 
 # fastlane


### PR DESCRIPTION
Hi RN team! Thanks for all that you do. 🎉 

**Motivation:**
I noticed in the [Buck docs](https://buckbuild.com/article/exopackage.html) (scroll down to Step 2) that it expects third party JARs to live in version control. Currently, the HelloWorld template ignores these dependencies from version control, which is a bit confusing.