### PR TITLE
Remove og:url to improve links preview on Facebook

### DIFF
--- a/website/core/Site.js
+++ b/website/core/Site.js
@@ -47,10 +47,6 @@ var Site = React.createClass({
         content: title,
       },
       {
-        property: 'og:url',
-        content: 'https://facebook.github.io/react-native/' + (this.props.path ? this.props.path : 'index.html'),
-      },
-      {
         property: 'og:image',
         content: this.props.image ? this.props.image : 'https://facebook.github.io/react-native/img/opengraph.png',
       },


### PR DESCRIPTION
I noticed that any link pointing to React Native website has a very generic title:
"React Native | A framework for building native apps using React". Using the Sharing Debugger
https://developers.facebook.com/tools/debug/sharing/ I found that we are setting `og:url` which
acts as redirect for Facebook crawlers. However, `path` is never set for `<Site>` element, which
means we always get a URL to the index page with the generic title mentioned above.

Before:
<img width="732" alt="screen shot 2017-01-05 at 4 57 38 pm" src="https://cloud.githubusercontent.com/assets/192222/21703719/ff851e4c-d368-11e6-8003-568878898c6b.png">

After:
<img width="725" alt="screen shot 2017-01-05 at 5 02 11 pm" src="https://cloud.githubusercontent.com/assets/192222/21703722/0334815e-d369-11e6-97cf-b873121fb97e.png">

