### PR TITLE
Android build docs should include 39.0 command

### DIFF
--- a/docs/SignedAPKAndroid.md
+++ b/docs/SignedAPKAndroid.md
@@ -90,7 +90,13 @@ Before uploading the release build to the Play Store, make sure you test it thor
 $ react-native run-android --variant=release
 ```
 
-Note that `--variant=release` is only available if you've set up signing as described above.
+Note that `--variant=release` is only available if you've set up signing as described above, and are using React Native 40.0
+
+To test the app build using React Native versions 39 and below use the command: 
+
+```sh
+$ react-native run-android --configuration=release
+```
 
 You can kill any running packager instances, all your and framework JavaScript code is bundled in the APK's assets.
 


### PR DESCRIPTION
The current public docs do not include build instructions for React Native Android version 39.

