### PR TITLE
Use Walmart's App Store icon.

### DIFF
--- a/website/src/react-native/index.js
+++ b/website/src/react-native/index.js
@@ -76,7 +76,7 @@ var apps = [
   },
   {
     name: 'Walmart',
-    icon: 'http://facebook.github.io/react-native/img/showcase/wmt_spark.png',
+    icon: 'http://is2.mzstatic.com/image/thumb/Purple111/v4/64/9f/20/649f2026-e968-0417-660c-e5ee6d7977ff/source/350x350bb.jpg',
     infoLink: 'https://itunes.apple.com/us/app/walmart-app-shopping-savings/id338137227?mt=8',
   },
 ];

--- a/website/src/react-native/showcase.js
+++ b/website/src/react-native/showcase.js
@@ -430,7 +430,7 @@ var pinned = [
   },
   {
     name: 'Walmart',
-    icon: 'http://facebook.github.io/react-native/img/showcase/wmt_spark.png',
+    icon: 'http://is2.mzstatic.com/image/thumb/Purple111/v4/64/9f/20/649f2026-e968-0417-660c-e5ee6d7977ff/source/350x350bb.jpg',
     linkAppStore: 'https://itunes.apple.com/us/app/walmart-app-shopping-savings/id338137227?mt=8',
     linkPlayStore: 'https://play.google.com/store/apps/details?id=com.walmart.android&hl=en',
     infoLink: ' https://medium.com/walmartlabs/react-native-at-walmartlabs-cdd140589560#.ueonqqloc',


### PR DESCRIPTION
This fixes an issue where Walmart's icon is not showing up in production. I added the icon to the RN website, but this goes against convention which is to use an externally hosted image for the showcase.

The reason this image is not showing up in production is because while the Showcase is unversioned, the images folder is versioned and the image is [only available in the `next` release](https://github.com/facebook/react-native/blob/gh-pages/releases/next/img/showcase/wmt_spark.png), e.g. https://facebook.github.io/react-native/releases/next/img/showcase/wmt_spark.png instead of https://facebook.github.io/react-native/img/showcase/wmt_spark.png.

This PR uses the App Store icon for the app.

Before:

<img width="1069" alt="unknown" src="https://cloud.githubusercontent.com/assets/165856/21729495/3bb95990-d400-11e6-98b9-9ffd86a1b3b6.png">

After:
![screen shot 2017-01-06 at 11 01 31 am](https://cloud.githubusercontent.com/assets/165856/21729508/44d049bc-d400-11e6-81ff-87c9550a8ea6.png)
