### PR TITLE
[Podspec] Stop copying unused JS files into the Pods folder

### DIFF
--- a/React.podspec
+++ b/React.podspec
@@ -28,7 +28,7 @@ Pod::Spec.new do |s|
   s.platform            = :ios, "8.0"
   s.pod_target_xcconfig = { "CLANG_CXX_LANGUAGE_STANDARD" => "c++14" }
   s.header_dir          = 'React'
-  s.preserve_paths      = "cli.js", "Libraries/**/*.js", "lint", "linter.js", "node_modules", "package.json", "packager", "PATENTS", "react-native-cli"
+  s.preserve_paths      = "package.json", "LICENSE", "LICENSE-CustomComponents", "PATENTS"
 
   s.subspec 'Core' do |ss|
     ss.dependency      'React/yoga'
@@ -58,19 +58,16 @@ Pod::Spec.new do |s|
   s.subspec 'ART' do |ss|
     ss.dependency       'React/Core'
     ss.source_files   = "Libraries/ART/**/*.{h,m}"
-    ss.preserve_paths = "Libraries/ART/**/*.js"
   end
 
   s.subspec 'RCTActionSheet' do |ss|
     ss.dependency       'React/Core'
     ss.source_files   = "Libraries/ActionSheetIOS/*.{h,m}"
-    ss.preserve_paths = "Libraries/ActionSheetIOS/*.js"
   end
 
   s.subspec 'RCTAdSupport' do |ss|
     ss.dependency       'React/Core'
     ss.source_files   = "Libraries/AdSupport/*.{h,m}"
-    ss.preserve_paths = "Libraries/AdSupport/*.js"
   end
 
   s.subspec 'RCTAnimation' do |ss|
@@ -82,56 +79,47 @@ Pod::Spec.new do |s|
     ss.dependency       'React/Core'
     ss.dependency       'React/RCTImage'
     ss.source_files   = "Libraries/CameraRoll/*.{h,m}"
-    ss.preserve_paths = "Libraries/CameraRoll/*.js"
   end
 
   s.subspec 'RCTGeolocation' do |ss|
     ss.dependency       'React/Core'
     ss.source_files   = "Libraries/Geolocation/*.{h,m}"
-    ss.preserve_paths = "Libraries/Geolocation/*.js"
   end
 
   s.subspec 'RCTImage' do |ss|
     ss.dependency       'React/Core'
     ss.dependency       'React/RCTNetwork'
     ss.source_files   = "Libraries/Image/*.{h,m}"
-    ss.preserve_paths = "Libraries/Image/*.js"
   end
 
   s.subspec 'RCTNetwork' do |ss|
     ss.dependency       'React/Core'
     ss.source_files   = "Libraries/Network/*.{h,m,mm}"
-    ss.preserve_paths = "Libraries/Network/*.js"
   end
 
   s.subspec 'RCTPushNotification' do |ss|
     ss.dependency       'React/Core'
     ss.source_files   = "Libraries/PushNotificationIOS/*.{h,m}"
-    ss.preserve_paths = "Libraries/PushNotificationIOS/*.js"
   end
 
   s.subspec 'RCTSettings' do |ss|
     ss.dependency       'React/Core'
     ss.source_files   = "Libraries/Settings/*.{h,m}"
-    ss.preserve_paths = "Libraries/Settings/*.js"
   end
 
   s.subspec 'RCTText' do |ss|
     ss.dependency       'React/Core'
     ss.source_files   = "Libraries/Text/*.{h,m}"
-    ss.preserve_paths = "Libraries/Text/*.js"
   end
 
   s.subspec 'RCTVibration' do |ss|
     ss.dependency       'React/Core'
     ss.source_files   = "Libraries/Vibration/*.{h,m}"
-    ss.preserve_paths = "Libraries/Vibration/*.js"
   end
 
   s.subspec 'RCTWebSocket' do |ss|
     ss.dependency       'React/Core'
     ss.source_files   = "Libraries/WebSocket/*.{h,m}"
-    ss.preserve_paths = "Libraries/WebSocket/*.js"
   end
 
   s.subspec 'RCTLinkingIOS' do |ss|
@@ -142,7 +130,6 @@ Pod::Spec.new do |s|
   s.subspec 'RCTTest' do |ss|
     ss.dependency       'React/Core'
     ss.source_files   = "Libraries/RCTTest/**/*.{h,m}"
-    ss.preserve_paths = "Libraries/RCTTest/**/*.js"
     ss.frameworks     = "XCTest"
   end
 end


### PR DESCRIPTION
Currently the podspec copies JS files along with the associated Obj-C files (ex: PushNotifications.m and PushNotifications.js are copied together). However the packager looks at `node_modules`, not `Pods`, for the JS source files so these copied JS source files (plus JS unit tests) were always ignored and are cruft.

This is documented as a breaking change but I suspect it won't affect most (if any) configurations. For this to have been useful, you would have had to have had been running the packager under `Pods/..some path to RN../cli.js` instead of with `npm start` or `node_modules/react-native/cli.js`.

Test Plan: Set up a new iOS project with CocoaPods, npm install react-native from this branch, set up CocoaPods to read the podspec from it, verify that an iOS project works.