### PR TITLE
Fix TicTacToe example layout

### DIFF
--- a/Examples/TicTacToe/TicTacToeApp.js
+++ b/Examples/TicTacToe/TicTacToeApp.js
@@ -158,7 +158,7 @@ class GameEndOverlay extends React.Component {
     var tie = board.tie();
     var winner = board.winner();
     if (!winner && !tie) {
-      return <View />;
+      return null;
     }
 
     var message;


### PR DESCRIPTION
I noticed that after starting a new game the board is not correctly layouted:

![-08-2017 21-39-21](https://cloud.githubusercontent.com/assets/3778452/21752532/06afc648-d5eb-11e6-9f8a-ccdad00d3a6f.gif)

Maybe this bug was introduced after the change of flex behaviour in 0.36. 
Just replacing empty view with null fixed it. 

**Test plan (required)**

 - launch the TicTacToe app
 - complete a round
 - press on new game

 a new board should be centred both vertically and horizontally