### PR TITLE
Fix z-index of YellowBox

### DIFF
--- a/Libraries/ReactNative/YellowBox.js
+++ b/Libraries/ReactNative/YellowBox.js
@@ -394,11 +394,13 @@ var styles = StyleSheet.create({
     right: 0,
     top: 0,
     bottom: 0,
+    elevation: Number.MAX_VALUE
   },
   inspector: {
     backgroundColor: backgroundColor(0.95),
     flex: 1,
     paddingTop: 5,
+    elevation: Number.MAX_VALUE
   },
   inspectorButtons: {
     flexDirection: 'row',
@@ -448,6 +450,7 @@ var styles = StyleSheet.create({
     left: 0,
     right: 0,
     bottom: 0,
+    elevation: Number.MAX_VALUE
   },
   listRow: {
     position: 'relative',


### PR DESCRIPTION
In Android, components using an elevation > 0 are able to hide the YellowBox. Especially bad when they happen to hide the dismiss button of the inspector.
