### PR TITLE
Android: TextInput: Remove default underline when setting a background color

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/flat/FlatViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/flat/FlatViewManager.java
@@ -20,7 +20,7 @@ abstract class FlatViewManager extends ViewGroupManager<FlatViewGroup> {
   }
 
   @Override
-  public void setBackgroundColor(FlatViewGroup view, int backgroundColor) {
+  public void setBackgroundColor(FlatViewGroup view, Integer backgroundColor) {
     // suppress
   }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
@@ -44,9 +44,9 @@ public abstract class BaseViewManager<T extends View, C extends LayoutShadowNode
       new MatrixMathHelper.MatrixDecompositionContext();
   private static double[] sTransformDecompositionArray = new double[16];
 
-  @ReactProp(name = PROP_BACKGROUND_COLOR, defaultInt = Color.TRANSPARENT, customType = "Color")
-  public void setBackgroundColor(T view, int backgroundColor) {
-    view.setBackgroundColor(backgroundColor);
+  @ReactProp(name = PROP_BACKGROUND_COLOR, customType = "Color")
+  public void setBackgroundColor(T view, Integer backgroundColor) {
+    view.setBackgroundColor(backgroundColor == null ? Color.TRANSPARENT : backgroundColor);
   }
 
   @ReactProp(name = PROP_TRANSFORM)

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
@@ -178,6 +178,15 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
     }
   }
 
+  @Override
+  public void setBackgroundColor(ReactEditText view, Integer backgroundColor) {
+    if (backgroundColor == null) {
+      view.clearBackgroundColor();
+    } else {
+      view.setBackgroundColor(backgroundColor);
+    }
+  }
+
   @ReactProp(name = ViewProps.FONT_SIZE, defaultFloat = ViewDefaults.FONT_SIZE_SP)
   public void setFontSize(ReactEditText view, float fontSize) {
     view.setTextSize(


### PR DESCRIPTION
### Bug Description

On Android, when focused, my `TextInput` always has a bluish green underline which spans most of the width of the `TextInput`. Here's an example. I created a `TextInput` like this:

```javascript
<TextInput
  style={{
    height: 50,
    width: 200,
    color: 'white',
    backgroundColor: 'black'
  }}
/>
```

#### Expected Output

![image](https://cloud.githubusercontent.com/assets/199935/21739122/4db5fcb0-d447-11e6-9dbd-d17e33db84b6.png)

#### Actual Output

![image](https://cloud.githubusercontent.com/assets/199935/21739127/6d0e4b9e-d447-11e6-945a-96834bc9f2ce.png)

Notice the unwanted bluish green underline.

### Fix Description

The bluish green underline is a part of the Android `EditText`'s default background. As you can [see here](https://github.com/facebook/react-native/blob/3d1bdcc2e3e60cd0ac166023023e82b47643cd12/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java#L588-L589), React Native's background for `TextInput` is constructed by layering it below the `EditText`'s default background.

My fix has the following behavior:
  - When a background color **is not** specified (e.g. the `backgroundColor` prop isn't provided or its value is `null/undefined`), then you see the bluish green underline (or whatever Android `EditText`'s default background may be.)
  - When a background color **is** specified, even if that color is `'transparent'`, you do not see the bluish green underline.

One downside of my fix is that it changes the signature of `BaseViewManager`'s `setBackgroundColor` method such that it takes an `Integer` rather than an `int`. This is a breaking change that will affect anybody that overrode this method in a custom view manager. This breaking change was needed so that the `ReactTextInputManager` could identify the case where a developer provided `null/undefined` for the `backgroundColor` prop.

An alternative fix we could do is to never show Android `EditText`'s default background. This would avoid the breaking change in `BaseViewManager`'s `setBackgroundColor` method. However, it would change React Native's default appearance for `EditText`s and make it impossible to achieve the previous visual.

Each of these fixes has pros and cons. Which one should we do? Or is there another one I haven't listed that would be preferable?

### Test plan (required)

Verified in a test app that the change works as expected when providing a `backgroundColor`, when not providing a `backgroundColor`, and when providing `null/undefined` for a `backgroundColor`.

Adam Comella
Microsoft Corp.
