### PR TITLE
Add accessibilityElementsHidden Prop To View Comp.

### DIFF
--- a/Libraries/Components/View/View.js
+++ b/Libraries/Components/View/View.js
@@ -26,6 +26,7 @@ if (Platform.isTVOS) {
   TVViewPropTypes = require('TVViewPropTypes');
 }
 
+const deprecatedPropType = require('deprecatedPropType');
 const requireNativeComponent = require('requireNativeComponent');
 
 const PropTypes = React.PropTypes;
@@ -190,30 +191,26 @@ const View = React.createClass({
     ]),
 
     /**
-     * Controls how view is important for accessibility which is if it
-     * fires accessibility events and if it is reported to accessibility services
-     * that query the screen. Works for Android only.
+     * Controls whether the accessibility elements contained within this view are hidden
+     * from accessibility services that query the screen.
      *
-     * Possible values:
-     *
-     *  - `'auto'` - The system determines whether the view is important for accessibility -
-     *    default (recommended).
-     *  - `'yes'` - The view is important for accessibility.
-     *  - `'no'` - The view is not important for accessibility.
-     *  - `'no-hide-descendants'` - The view is not important for accessibility,
-     *    nor are any of its descendant views.
-     *
-     * See the [Android `importantForAccessibility` docs](http://developer.android.com/reference/android/R.attr.html#importantForAccessibility)
-     * for reference.
-     *
-     * @platform android
+     * - If `true`, this View and all accessibility elements contained within it are hidden
+     * from accessibility services.
+     * - If `false`, this view is visible to accessibility services.
+     * - The default value is `null` which means the OS decides which elements are important
+     * for accessibility.
      */
-    importantForAccessibility: PropTypes.oneOf([
-      'auto',
-      'yes',
-      'no',
-      'no-hide-descendants',
-    ]),
+    accessibilityElementsHidden: PropTypes.bool,
+
+    importantForAccessibility: deprecatedPropType(
+      PropTypes.oneOf([
+        'auto',
+        'yes',
+        'no',
+        'no-hide-descendants',
+      ]),
+      'Use the `accessibilityElementsHidden` prop instead.'
+    ),
 
     /**
      * Provides additional traits to screen reader. By default no traits are

--- a/Libraries/CustomComponents/NavigationExperimental/NavigationCard.js
+++ b/Libraries/CustomComponents/NavigationExperimental/NavigationCard.js
@@ -100,6 +100,7 @@ class NavigationCard extends React.Component<any, Props, any> {
         {...viewPanHandlers}
         pointerEvents={pointerEvents}
         ref={this.props.onComponentRef}
+        accessibilityElementsHidden={!props.scene.isActive}
         style={[styles.main, viewStyle]}>
         {renderScene(props)}
       </Animated.View>

--- a/React/Views/RCTViewManager.m
+++ b/React/Views/RCTViewManager.m
@@ -113,6 +113,7 @@ RCT_EXPORT_VIEW_PROPERTY(hasTVPreferredFocus, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(tvParallaxProperties, NSDictionary)
 #endif
 
+RCT_EXPORT_VIEW_PROPERTY(accessibilityElementsHidden, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(accessibilityLabel, NSString)
 RCT_EXPORT_VIEW_PROPERTY(accessibilityTraits, UIAccessibilityTraits)
 RCT_EXPORT_VIEW_PROPERTY(backgroundColor, UIColor)

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
@@ -2,6 +2,8 @@
 
 package com.facebook.react.uimanager;
 
+import javax.annotation.Nullable;
+
 import android.graphics.Color;
 import android.os.Build;
 import android.view.View;
@@ -24,6 +26,7 @@ public abstract class BaseViewManager<T extends View, C extends LayoutShadowNode
   private static final String PROP_Z_INDEX = "zIndex";
   private static final String PROP_RENDER_TO_HARDWARE_TEXTURE = "renderToHardwareTextureAndroid";
   private static final String PROP_ACCESSIBILITY_LABEL = "accessibilityLabel";
+  private static final String PROP_ACCESSIBILITY_ELEMENTS_HIDDEN = "accessibilityElementsHidden";
   private static final String PROP_ACCESSIBILITY_COMPONENT_TYPE = "accessibilityComponentType";
   private static final String PROP_ACCESSIBILITY_LIVE_REGION = "accessibilityLiveRegion";
   private static final String PROP_IMPORTANT_FOR_ACCESSIBILITY = "importantForAccessibility";
@@ -92,11 +95,26 @@ public abstract class BaseViewManager<T extends View, C extends LayoutShadowNode
     view.setContentDescription(accessibilityLabel);
   }
 
+  @ReactProp(name = PROP_ACCESSIBILITY_ELEMENTS_HIDDEN)
+  public void setAccessibilityElementsHidden(T view, @Nullable Boolean accessibilityElementsHidden) {
+    if (accessibilityElementsHidden == null) {
+      view.setImportantForAccessibility(View.IMPORTANT_FOR_ACCESSIBILITY_AUTO);
+    } else {
+
+      view.setImportantForAccessibility(
+          accessibilityElementsHidden.booleanValue()
+          ? View.IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS
+          : View.IMPORTANT_FOR_ACCESSIBILITY_YES
+          );
+    }
+  }
+
   @ReactProp(name = PROP_ACCESSIBILITY_COMPONENT_TYPE)
   public void setAccessibilityComponentType(T view, String accessibilityComponentType) {
     AccessibilityHelper.updateAccessibilityComponentType(view, accessibilityComponentType);
   }
 
+  @Deprecated
   @ReactProp(name = PROP_IMPORTANT_FOR_ACCESSIBILITY)
   public void setImportantForAccessibility(T view, String importantForAccessibility) {
     if (importantForAccessibility == null || importantForAccessibility.equals("auto")) {


### PR DESCRIPTION
accessibilityElementsHidden is used to control wheter elemetns contained
within a view are hidden from accessiblity services that query the
screen.

On iOS, it simply reflects UIKit's accessibilityElementsHidden, on
Android it is implemented with importantForAccessibility.

This commit also improves accessiblity of Navigation Experimental
CardStack by marking inactive (off screen) scenes invsible.

Closes #9725
