### PR TITLE
[iOS build warnings] Mark params __unused or #pragma unused

### DIFF
--- a/React/Modules/JSCSamplingProfiler.m
+++ b/React/Modules/JSCSamplingProfiler.m
@@ -20,7 +20,7 @@
 RCT_EXPORT_MODULE(JSCSamplingProfiler);
 
 #ifdef RCT_PROFILE
-RCT_EXPORT_METHOD(operationComplete:(int)token result:(id)profileData error:(id)error)
+RCT_EXPORT_METHOD(operationComplete:(__unused int)token result:(id)profileData error:(id)error)
 {
   if (error) {
     RCTLogError(@"JSC Sampling profiler ended with error: %@", error);

--- a/React/Views/RCTMapManager.m
+++ b/React/Views/RCTMapManager.m
@@ -104,7 +104,7 @@ RCT_EXPORT_VIEW_PROPERTY(onChange, RCTBubblingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onPress, RCTBubblingEventBlock)
 RCT_CUSTOM_VIEW_PROPERTY(region, MKCoordinateRegion, RCTMap)
 {
-  #pragma unused (defaultView)
+#pragma unused (defaultView)
   if (json) {
     [view setRegion:[RCTConvert MKCoordinateRegion:json] animated:YES];
   }

--- a/React/Views/RCTMapManager.m
+++ b/React/Views/RCTMapManager.m
@@ -104,6 +104,7 @@ RCT_EXPORT_VIEW_PROPERTY(onChange, RCTBubblingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onPress, RCTBubblingEventBlock)
 RCT_CUSTOM_VIEW_PROPERTY(region, MKCoordinateRegion, RCTMap)
 {
+  #pragma unused (defaultView)
   if (json) {
     [view setRegion:[RCTConvert MKCoordinateRegion:json] animated:YES];
   }
@@ -290,7 +291,7 @@ RCT_CUSTOM_VIEW_PROPERTY(region, MKCoordinateRegion, RCTMap)
   return annotationView;
 }
 
-- (void)mapView:(RCTMap *)mapView didAddAnnotationViews:(NSArray *)views {
+- (void)mapView:(RCTMap *)mapView didAddAnnotationViews:(__unused NSArray *)views {
   if (mapView.showsAnnotationCallouts) {
     for (id<MKAnnotation> annotation in mapView.annotations) {
       [mapView selectAnnotation:annotation animated:YES];
@@ -298,7 +299,7 @@ RCT_CUSTOM_VIEW_PROPERTY(region, MKCoordinateRegion, RCTMap)
   }
 }
 
-- (MKOverlayRenderer *)mapView:(MKMapView *)mapView rendererForOverlay:(id<MKOverlay>)overlay
+- (MKOverlayRenderer *)mapView:(__unused MKMapView *)mapView rendererForOverlay:(id<MKOverlay>)overlay
 {
   RCTAssert([overlay isKindOfClass:[RCTMapOverlay class]], @"Overlay must be of type RCTMapOverlay");
   MKPolylineRenderer *polylineRenderer = [[MKPolylineRenderer alloc] initWithPolyline:overlay];

--- a/React/Views/RCTScrollViewManager.m
+++ b/React/Views/RCTScrollViewManager.m
@@ -88,7 +88,7 @@ RCT_EXPORT_VIEW_PROPERTY(onScrollAnimationEnd, RCTDirectEventBlock)
 // that css-layout is always treating the contents of a scroll container as
 // overflow: 'scroll'.
 RCT_CUSTOM_SHADOW_PROPERTY(overflow, YGOverflow, RCTShadowView) {
-  #pragma unused (json)
+#pragma unused (json)
   view.overflow = YGOverflowScroll;
 }
 

--- a/React/Views/RCTScrollViewManager.m
+++ b/React/Views/RCTScrollViewManager.m
@@ -88,6 +88,7 @@ RCT_EXPORT_VIEW_PROPERTY(onScrollAnimationEnd, RCTDirectEventBlock)
 // that css-layout is always treating the contents of a scroll container as
 // overflow: 'scroll'.
 RCT_CUSTOM_SHADOW_PROPERTY(overflow, YGOverflow, RCTShadowView) {
+  #pragma unused (json)
   view.overflow = YGOverflowScroll;
 }
 


### PR DESCRIPTION
Motivation: reduce build noise that might worry new users or hide real problems.

This deals with four of the warnings currently in the iOS build. The `__unused` additions are standard and self-explanatory, following the style used elsewhere in RN. I've used `#pragma unused` to deal with parameters named by macros.

Tested by building and running the `UIExplorer` example app in XCode 8.2