### PR TITLE
[iOS build warnings] Replace deprecated completion block

### DIFF
--- a/React/Profiler/RCTProfile.m
+++ b/React/Profiler/RCTProfile.m
@@ -383,7 +383,10 @@ void RCTProfileUnhookModules(RCTBridge *bridge)
 #if !TARGET_OS_TV
       UIActivityViewController *activityViewController = [[UIActivityViewController alloc] initWithActivityItems:@[[NSURL fileURLWithPath:outFile]]
                                                                                            applicationActivities:nil];
-      activityViewController.completionHandler = ^(__unused NSString *activityType, __unused BOOL completed) {
+      activityViewController.completionWithItemsHandler = ^(__unused UIActivityType activityType,
+                                                            __unused BOOL completed,
+                                                            __unused NSArray *items,
+                                                            __unused NSError *error) {
         RCTProfileControlsWindow.hidden = NO;
       };
       RCTProfileControlsWindow.hidden = YES;


### PR DESCRIPTION
`UIActivityViewConroller.completionHandler` has been [deprecated](https://developer.apple.com/reference/uikit/uiactivityviewcontroller/1622010-completionhandler) since iOS 8, when it was replaced by `completionWithItemsHandler`.

Tested the build using `UIExplorer` and XCode 8.2 but I've never seen and can't work out how to activate the `UIActivityViewController` this method relates to, so I haven't tested a real run.