### PR TITLE
Android: fix JSC crash in dev

### DIFF
--- a/Libraries/Utilities/deepFreezeAndThrowOnMutationInDev.js
+++ b/Libraries/Utilities/deepFreezeAndThrowOnMutationInDev.js
@@ -38,7 +38,10 @@ function deepFreezeAndThrowOnMutationInDev(object: Object) {
       return;
     }
 
-    for (var key in object) {
+    var keys = Object.keys(object);
+
+    for (var i = 0; i < keys.length; i++) {
+      var key = keys[i];
       if (object.hasOwnProperty(key)) {
         object.__defineGetter__(key, identity.bind(null, object[key]));
         object.__defineSetter__(key, throwOnImmutableMutation.bind(null, key));
@@ -48,7 +51,8 @@ function deepFreezeAndThrowOnMutationInDev(object: Object) {
     Object.freeze(object);
     Object.seal(object);
 
-    for (var key in object) {
+    for (var i = 0; i < keys.length; i++) {
+      var key = keys[i];
       if (object.hasOwnProperty(key)) {
         deepFreezeAndThrowOnMutationInDev(object[key]);
       }


### PR DESCRIPTION
On Android with dev mode on, we're seeing a regular SIGSEGV when pushing a lot of animation declarations over the bridge. We tracked this down to being not specific to animations, but the crash is caused in `deepFreezeAndThrowOnMutationInDev`.

Specifically: the provided object to freeze is modified while looping, replacing the current key access to a getter/setter. After the modification, JSC crashes during retrieval of the next key - but only when there are a lot of events passing over the bridge.

We have a hunch that this is due to a bug in JSC object enumeration but did we not look into it further yet. Any help here is welcome. The JS code seems all right at first sight and shouldn't cause a segmentation crash.

The workaround in this PR is to retrieve the keys first from the object and then looping over that array. In our app and in a reduced app test case this fixes the crash.

If needed I can provide the reduced app test case. It's really tricky to make a test for this as it requires to be run on Android and causes a segmentation crash.

Crash log:
```
A/libc: Fatal signal 11 (SIGSEGV), code 2, fault addr 0xd0cd002c in tid 26981 (mqt_js)
                                                            
                                                            [ 01-10 13:10:31.704  1236: 1236 W/         ]
                                                            debuggerd: handling request: pid=26952 uid=10026 gid=10026 tid=26981
01-10 13:10:31.764 27015-27015/? A/DEBUG: *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
01-10 13:10:31.764 27015-27015/? A/DEBUG: Build fingerprint: 'Android/sdk_google_phone_x86_64/generic_x86_64:7.0/NYC/3513876:userdebug/dev-keys'
01-10 13:10:31.764 27015-27015/? A/DEBUG: Revision: '0'
01-10 13:10:31.764 27015-27015/? A/DEBUG: ABI: 'x86'
01-10 13:10:31.764 27015-27015/? A/DEBUG: pid: 26952, tid: 26981, name: mqt_js  >>> com.investigatecrash <<<
01-10 13:10:31.764 27015-27015/? A/DEBUG: signal 11 (SIGSEGV), code 2 (SEGV_ACCERR), fault addr 0xd0cd002c
01-10 13:10:31.764 27015-27015/? A/DEBUG:     eax d0c6c870  ebx d0ccff48  ecx 0000001c  edx 0000001a
01-10 13:10:31.764 27015-27015/? A/DEBUG:     esi d5e4ffe0  edi 00000003
01-10 13:10:31.764 27015-27015/? A/DEBUG:     xcs 00000023  xds 0000002b  xes 0000002b  xfs 0000006b  xss 0000002b
01-10 13:10:31.764 27015-27015/? A/DEBUG:     eip d328d235  ebp d637d7f8  esp d637d720  flags 00000293
01-10 13:10:31.764 27015-27015/? A/DEBUG: backtrace:
01-10 13:10:31.764 27015-27015/? A/DEBUG:     #00 pc 00000235  <anonymous:d328d000>
```
