### PR TITLE
[iOS build warnings] JavaScriptLoader BCBundle version check

### DIFF
--- a/React/Base/RCTJavaScriptLoader.h
+++ b/React/Base/RCTJavaScriptLoader.h
@@ -20,6 +20,7 @@ NS_ENUM(NSInteger) {
   RCTJavaScriptLoaderErrorFailedStatingFile = 3,
   RCTJavaScriptLoaderErrorURLLoadFailed = 3,
   RCTJavaScriptLoaderErrorBCVersion = 4,
+  RCTJavaScriptLoaderErrorBCNotSupported = 4,
 
   RCTJavaScriptLoaderErrorCannotBeLoadedSynchronously = 1000,
 };

--- a/React/Base/RCTJavaScriptLoader.mm
+++ b/React/Base/RCTJavaScriptLoader.mm
@@ -142,10 +142,19 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
     return nil;
 
   case facebook::react::ScriptTag::BCBundle:
-    if (header.BCVersion != runtimeBCVersion) {
+    if (runtimeBCVersion == JSNoBytecodeFileFormatVersion || runtimeBCVersion < 0) {
+      if (error) {
+        *error = [NSError errorWithDomain:RCTJavaScriptLoaderErrorDomain
+                                     code:RCTJavaScriptLoaderErrorBCNotSupported
+                                 userInfo:@{NSLocalizedDescriptionKey:
+                                              @"Bytecode bundles are not supported by this runtime."}];
+      }
+      return nil;
+    }
+    else if ((uint32_t)runtimeBCVersion != header.BCVersion) {
       if (error) {
         NSString *errDesc =
-          [NSString stringWithFormat:@"BC Version Mismatch. Expect: %d, Actual: %d",
+          [NSString stringWithFormat:@"BC Version Mismatch. Expect: %d, Actual: %u",
                     runtimeBCVersion, header.BCVersion];
 
         *error = [NSError errorWithDomain:RCTJavaScriptLoaderErrorDomain


### PR DESCRIPTION
Currently a build warning is thrown by `if (header.BCVersion != runtimeBCVersion) ...` because `runtimeBCVersion` is signed, apparently because `-1` is used to mean that the runtime has no support for bytecode bundles.

This PR splits out the error case of the runtime not supporting BC bundles from the case of a version mismatch.

Tested as much as I could by building and running `UIExplorer` - I haven't attempted to use real bytecode bundles.