### PR TITLE
[iOS build warnings] Prevent compiler inferring incorrect type

### DIFF
--- a/React/Modules/RCTRedBox.m
+++ b/React/Modules/RCTRedBox.m
@@ -400,7 +400,7 @@ RCT_EXPORT_MODULE()
   [self showErrorMessage:message withStack:stack isUpdate:YES];
 }
 
-- (void)showErrorMessage:(NSString *)message withStack:(NSArray *)stack isUpdate:(BOOL)isUpdate
+- (void)showErrorMessage:(NSString *)message withStack:(NSArray<id> *)stack isUpdate:(BOOL)isUpdate
 {
   if (![[stack firstObject] isKindOfClass:[RCTJSStackFrame class]]) {
     stack = [RCTJSStackFrame stackFramesWithDictionaries:stack];


### PR DESCRIPTION
Fixes the build warning: 

```react-native/React/Modules/RCTRedBox.m:406:58: Conversion from value of type 'NSArray<RCTJSStackFrame *> *' to incompatible type 'NSArray<NSDictionary *> *```

This appears because the compiler is left to infer the type of `stack`, and it does so as `NSArray<RCTJSStackFrame *>` based on [RCTRedBox.m#L390](https://github.com/facebook/react-native/blob/master/React/Modules/RCTRedBox.m#L390). In reality `stack` may be either of two types and the function body deals with normalisation.

Mark the stack as explicitly `NSArray<id>` to prevent inference so we're free to make the decision to cast to more specific types.