### PR TITLE
Add note about 12key input to TextInput

### DIFF
--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -218,6 +218,8 @@ const TextInput = React.createClass({
      * - `numeric`
      * - `email-address`
      * - `phone-pad`
+     *
+     * A 12-key numeric keyboard will be opened if `keyboardType` is `numeric` and `secureTextEntry` is `true`.
      */
     keyboardType: PropTypes.oneOf([
       // Cross-platform


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/794237/21822755/c8b41b40-d735-11e6-8e5e-4fe8d686b355.png)
Had to dig through the source to see that this was possible. Adding a note to the docs for any future people. 
Let me know if there's a better place to put the note. I felt in `keyboardType` was more appropriate than `secureTextEntry` since it relates to the keyboard that is displayed.