### PR TITLE
[iOS build warnings] Remove deprecation warning for RCTExecuteOnMainThread

### DIFF
--- a/React/Base/RCTUtils.h
+++ b/React/Base/RCTUtils.h
@@ -29,7 +29,7 @@ RCT_EXTERN id RCTJSONClean(id object);
 // Get MD5 hash of a string
 RCT_EXTERN NSString *RCTMD5Hash(NSString *string);
 
-// Check is we are currently on the main queue (not to be confused with
+// Check if we are currently on the main queue (not to be confused with
 // the main thread, which is not neccesarily the same thing)
 // https://twitter.com/olebegemann/status/738656134731599872
 RCT_EXTERN BOOL RCTIsMainQueue(void);
@@ -37,6 +37,10 @@ RCT_EXTERN BOOL RCTIsMainQueue(void);
 // Execute the specified block on the main queue. Unlike dispatch_async()
 // this will execute immediately if we're already on the main queue.
 RCT_EXTERN void RCTExecuteOnMainQueue(dispatch_block_t block);
+
+// Legacy function to execute the specified block on the main queue synchronously.
+// Please do not use this unless you know what you're doing.
+RCT_EXTERN void RCTUnsafeExecuteOnMainQueueSync(dispatch_block_t block);
 
 // Deprecated - do not use.
 RCT_EXTERN void RCTExecuteOnMainThread(dispatch_block_t block, BOOL sync)

--- a/React/Base/RCTUtils.m
+++ b/React/Base/RCTUtils.m
@@ -252,6 +252,19 @@ void RCTExecuteOnMainQueue(dispatch_block_t block)
   }
 }
 
+// Please do not use this method
+// unless you know what you are doing.
+void RCTUnsafeExecuteOnMainQueueSync(dispatch_block_t block)
+{
+  if (RCTIsMainQueue()) {
+    block();
+  } else {
+    dispatch_sync(dispatch_get_main_queue(), ^{
+      block();
+    });
+  }
+}
+
 void RCTExecuteOnMainThread(dispatch_block_t block, BOOL sync)
 {
   if (RCTIsMainQueue()) {
@@ -272,9 +285,9 @@ CGFloat RCTScreenScale()
   static CGFloat scale;
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{
-    RCTExecuteOnMainThread(^{
+    RCTUnsafeExecuteOnMainQueueSync(^{
       scale = [UIScreen mainScreen].scale;
-    }, YES);
+    });
   });
 
   return scale;
@@ -289,9 +302,9 @@ CGSize RCTScreenSize()
   static CGSize size;
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{
-    RCTExecuteOnMainThread(^{
+    RCTUnsafeExecuteOnMainQueueSync(^{
       size = [UIScreen mainScreen].bounds.size;
-    }, YES);
+    });
   });
 
   return size;


### PR DESCRIPTION
As per @janicduplessis recommendation, provide a new synchronous method to replace the necessary synchronous calls and use a warning in the comments (and method name).

**Motivation**

There are currently a number of XCode warnings that show up in a fresh 0.40 install of a react native project. While the project can still be run, this contributes negatively to the development experience -- valid warnings may be ignored and new ones may be added as per https://en.wikipedia.org/wiki/Broken_windows_theory

This addresses one of the warnings, by providing the functionality of a deprecated method in two specific cases where we can't avoid doing synchronous work on the main queue. See https://github.com/facebook/react-native/issues/11736 for more context.

**Test plan (required)**

I ran a project that relied on screen size and it didn't crash...happy to do more involved testing if someone can share better methodology.