### PR TITLE
Upgrade to OkHttp 3.8.0 and migrate to new websocket api

### DIFF
--- a/Libraries/WebSocket/WebSocket.js
+++ b/Libraries/WebSocket/WebSocket.js
@@ -115,7 +115,17 @@ class WebSocket extends EventTarget(...WEBSOCKET_EVENTS) {
     throw new Error('Unsupported data type');
   }
 
+  /**
+   * iOS only, Android uses OkHttp which auto pings, you will receive a callback if socket was closed
+   *
+   * @platform ios
+   */
   ping(): void {
+    if (Platform.OS === 'android') {
+      console.warn('"WebSocket.ping" is deprecated on Android. Listen for a closed event instead.');
+      return;
+    }
+
     if (this.readyState === this.CONNECTING) {
         throw new Error('INVALID_STATE_ERR');
     }

--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -283,10 +283,9 @@ dependencies {
     compile 'com.facebook.fresco:imagepipeline-okhttp3:1.0.1'
     compile 'com.facebook.soloader:soloader:0.1.0'
     compile 'com.google.code.findbugs:jsr305:3.0.0'
-    compile 'com.squareup.okhttp3:okhttp:3.4.1'
-    compile 'com.squareup.okhttp3:okhttp-urlconnection:3.4.1'
-    compile 'com.squareup.okhttp3:okhttp-ws:3.4.1'
-    compile 'com.squareup.okio:okio:1.9.0'
+    compile 'com.squareup.okhttp3:okhttp:3.8.0'
+    compile 'com.squareup.okhttp3:okhttp-urlconnection:3.8.0'
+    compile 'com.squareup.okio:okio:1.13.0'
     compile 'org.webkit:android-jsc:r174650'
 
     testCompile "junit:junit:${JUNIT_VERSION}"

--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/BUCK
@@ -12,7 +12,6 @@ android_library(
         react_native_dep("third-party/java/infer-annotations:infer-annotations"),
         react_native_dep("third-party/java/jsr-305:jsr-305"),
         react_native_dep("third-party/java/okhttp:okhttp3"),
-        react_native_dep("third-party/java/okhttp:okhttp3-ws"),
         react_native_dep("third-party/java/okio:okio"),
         react_native_target("java/com/facebook/react/bridge:bridge"),
         react_native_target("java/com/facebook/react/common:common"),

--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/InspectorPackagerConnection.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/InspectorPackagerConnection.java
@@ -2,14 +2,6 @@
 
 package com.facebook.react.devsupport;
 
-import javax.annotation.Nullable;
-
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.TimeUnit;
-
 import android.os.AsyncTask;
 import android.os.Handler;
 import android.os.Looper;
@@ -17,18 +9,23 @@ import android.os.Looper;
 import com.facebook.common.logging.FLog;
 import com.facebook.react.bridge.Inspector;
 
-import okhttp3.OkHttpClient;
-import okhttp3.Request;
-import okhttp3.RequestBody;
-import okhttp3.Response;
-import okhttp3.ResponseBody;
-import okhttp3.ws.WebSocket;
-import okhttp3.ws.WebSocketCall;
-import okhttp3.ws.WebSocketListener;
-import okio.Buffer;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import javax.annotation.Nullable;
+
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.WebSocket;
+import okhttp3.WebSocketListener;
 
 public class InspectorPackagerConnection {
   private static final String TAG = "InspectorPackagerConnection";
@@ -59,7 +56,7 @@ public class InspectorPackagerConnection {
   }
 
   void handleProxyMessage(JSONObject message)
-      throws JSONException, IOException {
+    throws JSONException, IOException {
     String event = message.getString("event");
     switch (event) {
       case "getPages":
@@ -162,7 +159,7 @@ public class InspectorPackagerConnection {
   }
 
   private void sendEvent(String name, Object payload)
-      throws JSONException {
+    throws JSONException {
     JSONObject jsonMessage = new JSONObject();
     jsonMessage.put("event", name);
     jsonMessage.put("payload", payload);
@@ -175,7 +172,7 @@ public class InspectorPackagerConnection {
     return payload;
   }
 
-  private class Connection implements WebSocketListener {
+  private class Connection extends WebSocketListener {
     private static final int RECONNECT_DELAY_MS = 2000;
 
     private final String mUrl;
@@ -196,9 +193,9 @@ public class InspectorPackagerConnection {
     }
 
     @Override
-    public void onFailure(IOException e, Response response) {
+    public void onFailure(WebSocket webSocket, Throwable t, Response response) {
       if (mWebSocket != null) {
-        abort("Websocket exception", e);
+        abort("Websocket exception", t);
       }
       if (!mClosed) {
         reconnect();
@@ -206,22 +203,16 @@ public class InspectorPackagerConnection {
     }
 
     @Override
-    public void onMessage(ResponseBody message) throws IOException {
+    public void onMessage(WebSocket webSocket, String text) {
       try {
-        handleProxyMessage(new JSONObject(message.string()));
-      } catch (JSONException e) {
-        throw new IOException(e);
-      } finally {
-        message.close();
+        handleProxyMessage(new JSONObject(text));
+      } catch (JSONException | IOException e) {
+        FLog.w(TAG, "onMessage Exception", e);
       }
     }
 
     @Override
-    public void onPong(Buffer payload) {
-    }
-
-    @Override
-    public void onClose(int code, String reason) {
+    public void onClosed(WebSocket webSocket, int code, String reason) {
       mWebSocket = null;
       closeAllConnections();
       if (!mClosed) {
@@ -234,14 +225,13 @@ public class InspectorPackagerConnection {
         throw new IllegalStateException("Can't connect closed client");
       }
       OkHttpClient httpClient = new OkHttpClient.Builder()
-          .connectTimeout(10, TimeUnit.SECONDS)
-          .writeTimeout(10, TimeUnit.SECONDS)
-          .readTimeout(0, TimeUnit.MINUTES) // Disable timeouts for read
-          .build();
+        .connectTimeout(10, TimeUnit.SECONDS)
+        .writeTimeout(10, TimeUnit.SECONDS)
+        .readTimeout(0, TimeUnit.MINUTES) // Disable timeouts for read
+        .build();
 
       Request request = new Request.Builder().url(mUrl).build();
-      WebSocketCall call = WebSocketCall.create(httpClient, request);
-      call.enqueue(this);
+      httpClient.newWebSocket(request, this);
     }
 
     private void reconnect() {
@@ -253,26 +243,22 @@ public class InspectorPackagerConnection {
         mSuppressConnectionErrors = true;
       }
       mHandler.postDelayed(
-          new Runnable() {
-            @Override
-            public void run() {
-              // check that we haven't been closed in the meantime
-              if (!mClosed) {
-                connect();
-              }
+        new Runnable() {
+          @Override
+          public void run() {
+            // check that we haven't been closed in the meantime
+            if (!mClosed) {
+              connect();
             }
-          },
-          RECONNECT_DELAY_MS);
+          }
+        },
+        RECONNECT_DELAY_MS);
     }
 
     public void close() {
       mClosed = true;
       if (mWebSocket != null) {
-        try {
-          mWebSocket.close(1000, "End of session");
-        } catch (IOException e) {
-          // swallow, no need to handle it here
-        }
+        mWebSocket.close(1000, "End of session");
         mWebSocket = null;
       }
     }
@@ -284,11 +270,7 @@ public class InspectorPackagerConnection {
           if (sockets == null || sockets.length == 0) {
             return null;
           }
-          try {
-            sockets[0].sendMessage(RequestBody.create(WebSocket.TEXT, object.toString()));
-          } catch (IOException e) {
-            FLog.w(TAG, "Couldn't send event to packager", e);
-          }
+          sockets[0].send(object.toString());
           return null;
         }
       }.execute(mWebSocket);
@@ -302,11 +284,7 @@ public class InspectorPackagerConnection {
 
     private void closeWebSocketQuietly() {
       if (mWebSocket != null) {
-        try {
-          mWebSocket.close(1000, "End of session");
-        } catch (IOException e) {
-          // swallow, no need to handle it here
-        }
+        mWebSocket.close(1000, "End of session");
         mWebSocket = null;
       }
     }

--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/JSDebuggerWebSocketClient.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/JSDebuggerWebSocketClient.java
@@ -18,6 +18,7 @@ import com.facebook.infer.annotation.Assertions;
 import com.facebook.react.common.JavascriptException;
 
 import java.io.IOException;
+import java.io.StringReader;
 import java.io.StringWriter;
 import java.util.HashMap;
 import java.util.concurrent.ConcurrentHashMap;
@@ -28,18 +29,14 @@ import javax.annotation.Nullable;
 
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
-import okhttp3.RequestBody;
 import okhttp3.Response;
-import okhttp3.ResponseBody;
-import okhttp3.ws.WebSocket;
-import okhttp3.ws.WebSocketCall;
-import okhttp3.ws.WebSocketListener;
-import okio.Buffer;
+import okhttp3.WebSocket;
+import okhttp3.WebSocketListener;
 
 /**
  * A wrapper around WebSocketClient that recognizes RN debugging message format.
  */
-public class JSDebuggerWebSocketClient implements WebSocketListener {
+public class JSDebuggerWebSocketClient extends WebSocketListener {
 
   private static final String TAG = "JSDebuggerWebSocketClient";
 
@@ -53,7 +50,7 @@ public class JSDebuggerWebSocketClient implements WebSocketListener {
   private @Nullable JSDebuggerCallback mConnectCallback;
   private final AtomicInteger mRequestID = new AtomicInteger();
   private final ConcurrentHashMap<Integer, JSDebuggerCallback> mCallbacks =
-      new ConcurrentHashMap<>();
+    new ConcurrentHashMap<>();
 
   public void connect(String url, JSDebuggerCallback callback) {
     if (mHttpClient != null) {
@@ -67,8 +64,7 @@ public class JSDebuggerWebSocketClient implements WebSocketListener {
       .build();
 
     Request request = new Request.Builder().url(url).build();
-    WebSocketCall call = WebSocketCall.create(mHttpClient, request);
-    call.enqueue(this);
+    mHttpClient.newWebSocket(request, this);
   }
 
   public void prepareJSRuntime(JSDebuggerCallback callback) {
@@ -90,20 +86,20 @@ public class JSDebuggerWebSocketClient implements WebSocketListener {
   }
 
   public void loadApplicationScript(
-      String sourceURL,
-      HashMap<String, String> injectedObjects,
-      JSDebuggerCallback callback) {
+    String sourceURL,
+    HashMap<String, String> injectedObjects,
+    JSDebuggerCallback callback) {
     int requestID = mRequestID.getAndIncrement();
     mCallbacks.put(requestID, callback);
 
     try {
       StringWriter sw = new StringWriter();
       JsonWriter js = new JsonWriter(sw)
-         .beginObject()
-         .name("id").value(requestID)
-         .name("method").value("executeApplicationScript")
-         .name("url").value(sourceURL)
-         .name("inject").beginObject();
+        .beginObject()
+        .name("id").value(requestID)
+        .name("method").value("executeApplicationScript")
+        .name("url").value(sourceURL)
+        .name("inject").beginObject();
       for (String key : injectedObjects.keySet()) {
         js.name(key).value(injectedObjects.get(key));
       }
@@ -115,9 +111,9 @@ public class JSDebuggerWebSocketClient implements WebSocketListener {
   }
 
   public void executeJSCall(
-      String methodName,
-      String jsonArgsArray,
-      JSDebuggerCallback callback) {
+    String methodName,
+    String jsonArgsArray,
+    JSDebuggerCallback callback) {
     int requestID = mRequestID.getAndIncrement();
     mCallbacks.put(requestID, callback);
 
@@ -140,11 +136,7 @@ public class JSDebuggerWebSocketClient implements WebSocketListener {
 
   public void closeQuietly() {
     if (mWebSocket != null) {
-      try {
-        mWebSocket.close(1000, "End of session");
-      } catch (IOException e) {
-        // swallow, no need to handle it here
-      }
+      mWebSocket.close(1000, "End of session");
       mWebSocket = null;
     }
   }
@@ -152,15 +144,11 @@ public class JSDebuggerWebSocketClient implements WebSocketListener {
   private void sendMessage(int requestID, String message) {
     if (mWebSocket == null) {
       triggerRequestFailure(
-          requestID,
-          new IllegalStateException("WebSocket connection no longer valid"));
+        requestID,
+        new IllegalStateException("WebSocket connection no longer valid"));
       return;
     }
-    try {
-      mWebSocket.sendMessage(RequestBody.create(WebSocket.TEXT, message));
-    } catch (IOException e) {
-      triggerRequestFailure(requestID, e);
-    }
+    mWebSocket.send(message);
   }
 
   private void triggerRequestFailure(int requestID, Throwable cause) {
@@ -180,16 +168,11 @@ public class JSDebuggerWebSocketClient implements WebSocketListener {
   }
 
   @Override
-  public void onMessage(ResponseBody response) throws IOException {
-    if (response.contentType() != WebSocket.TEXT) {
-      FLog.w(TAG, "Websocket received unexpected message with payload of type " + response.contentType());
-      return;
-    }
-
+  public void onMessage(WebSocket webSocket, String text) {
     Integer replyID = null;
 
     try {
-      JsonReader reader = new JsonReader(response.charStream());
+      JsonReader reader = new JsonReader(new StringReader(text));
       String result = null;
       reader.beginObject();
       while (reader.hasNext()) {
@@ -218,14 +201,12 @@ public class JSDebuggerWebSocketClient implements WebSocketListener {
       } else {
         abort("Parsing response message from websocket failed", e);
       }
-    } finally {
-      response.close();
     }
   }
 
   @Override
-  public void onFailure(IOException e, Response response) {
-    abort("Websocket exception", e);
+  public void onFailure(WebSocket webSocket, Throwable t, Response response) {
+    abort("Websocket exception", t);
   }
 
   @Override
@@ -236,13 +217,8 @@ public class JSDebuggerWebSocketClient implements WebSocketListener {
   }
 
   @Override
-  public void onClose(int code, String reason) {
+  public void onClosed(WebSocket webSocket, int code, String reason) {
     mWebSocket = null;
-  }
-
-  @Override
-  public void onPong(Buffer payload) {
-    // ignore
   }
 
   private void abort(String message, Throwable cause) {

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/websocket/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/websocket/BUCK
@@ -11,7 +11,6 @@ android_library(
         react_native_dep("third-party/java/infer-annotations:infer-annotations"),
         react_native_dep("third-party/java/jsr-305:jsr-305"),
         react_native_dep("third-party/java/okhttp:okhttp3"),
-        react_native_dep("third-party/java/okhttp:okhttp3-ws"),
         react_native_dep("third-party/java/okio:okio"),
         react_native_target("java/com/facebook/react/bridge:bridge"),
         react_native_target("java/com/facebook/react/common:common"),

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/websocket/WebSocketModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/websocket/WebSocketModule.java
@@ -9,12 +9,6 @@
 
 package com.facebook.react.modules.websocket;
 
-import android.util.Base64;
-
-import java.io.IOException;
-import java.lang.IllegalStateException;
-import javax.annotation.Nullable;
-
 import com.facebook.common.logging.FLog;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReactApplicationContext;
@@ -31,27 +25,28 @@ import com.facebook.react.module.annotations.ReactModule;
 import com.facebook.react.modules.core.DeviceEventManagerModule;
 import com.facebook.react.modules.network.ForwardingCookieHandler;
 
-import okhttp3.OkHttpClient;
-import okhttp3.Request;
-import okhttp3.RequestBody;
-import okhttp3.Response;
-import okhttp3.ResponseBody;
-import okhttp3.ws.WebSocket;
-import okhttp3.ws.WebSocketCall;
-import okhttp3.ws.WebSocketListener;
-
-import java.net.URISyntaxException;
+import java.io.IOException;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.HashMap;
-import java.util.Map;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import okio.Buffer;
+import javax.annotation.Nullable;
+
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.WebSocket;
+import okhttp3.WebSocketListener;
 import okio.ByteString;
 
 @ReactModule(name = "WebSocketModule", hasConstants = false)
 public class WebSocketModule extends ReactContextBaseJavaModule {
+
+  private static final String CONTENT_TYPE_BINARY = "binary";
+  private static final String CONTENT_TYPE_TEXT = "text";
 
   private final Map<Integer, WebSocket> mWebSocketConnections = new HashMap<>();
 
@@ -88,8 +83,8 @@ public class WebSocketModule extends ReactContextBaseJavaModule {
       .build();
 
     Request.Builder builder = new Request.Builder()
-        .tag(id)
-        .url(url);
+      .tag(id)
+      .url(url);
 
     String cookie = getCookie(url);
     if (cookie != null) {
@@ -132,7 +127,7 @@ public class WebSocketModule extends ReactContextBaseJavaModule {
       }
     }
 
-    WebSocketCall.create(client, builder.build()).enqueue(new WebSocketListener() {
+    client.newWebSocket(builder.build(), new WebSocketListener() {
 
       @Override
       public void onOpen(WebSocket webSocket, Response response) {
@@ -143,7 +138,7 @@ public class WebSocketModule extends ReactContextBaseJavaModule {
       }
 
       @Override
-      public void onClose(int code, String reason) {
+      public void onClosed(WebSocket webSocket, int code, String reason) {
         WritableMap params = Arguments.createMap();
         params.putInt("id", id);
         params.putInt("code", code);
@@ -152,40 +147,25 @@ public class WebSocketModule extends ReactContextBaseJavaModule {
       }
 
       @Override
-      public void onFailure(IOException e, Response response) {
-        notifyWebSocketFailed(id, e.getMessage());
+      public void onFailure(WebSocket webSocket, Throwable t, Response response) {
+        notifyWebSocketFailed(id, t.getMessage());
       }
 
       @Override
-      public void onPong(Buffer buffer) {
+      public void onMessage(WebSocket webSocket, String message) {
+        onMessage(CONTENT_TYPE_TEXT, message);
       }
 
       @Override
-      public void onMessage(ResponseBody response) throws IOException {
-        String message;
-        try {
-          if (response.contentType() == WebSocket.BINARY) {
-            message = Base64.encodeToString(response.source().readByteArray(), Base64.NO_WRAP);
-          } else {
-            message = response.source().readUtf8();
-          }
-        } catch (IOException e) {
-          notifyWebSocketFailed(id, e.getMessage());
-          return;
-        }
-        try {
-          response.source().close();
-        } catch (IOException e) {
-          FLog.e(
-            ReactConstants.TAG,
-            "Could not close BufferedSource for WebSocket id " + id,
-            e);
-        }
+      public void onMessage(WebSocket webSocket, ByteString bytes) {
+        onMessage(CONTENT_TYPE_BINARY, bytes.toString());
+      }
 
+      private void onMessage(String type, String message) {
         WritableMap params = Arguments.createMap();
         params.putInt("id", id);
         params.putString("data", message);
-        params.putString("type", response.contentType() == WebSocket.BINARY ? "binary" : "text");
+        params.putString("type", type);
         sendEvent("websocketMessage", params);
       }
     });
@@ -220,11 +200,7 @@ public class WebSocketModule extends ReactContextBaseJavaModule {
       // This is a programmer error
       throw new RuntimeException("Cannot send a message. Unknown WebSocket id " + id);
     }
-    try {
-      client.sendMessage(RequestBody.create(WebSocket.TEXT, message));
-    } catch (IOException | IllegalStateException e) {
-      notifyWebSocketFailed(id, e.getMessage());
-    }
+    client.send(message);
   }
 
   @ReactMethod
@@ -234,27 +210,7 @@ public class WebSocketModule extends ReactContextBaseJavaModule {
       // This is a programmer error
       throw new RuntimeException("Cannot send a message. Unknown WebSocket id " + id);
     }
-    try {
-      client.sendMessage(
-        RequestBody.create(WebSocket.BINARY, ByteString.decodeBase64(base64String)));
-    } catch (IOException | IllegalStateException e) {
-      notifyWebSocketFailed(id, e.getMessage());
-    }
-  }
-
-  @ReactMethod
-  public void ping(int id) {
-    WebSocket client = mWebSocketConnections.get(id);
-    if (client == null) {
-      // This is a programmer error
-      throw new RuntimeException("Cannot send a message. Unknown WebSocket id " + id);
-    }
-    try {
-      Buffer buffer = new Buffer();
-      client.sendPing(buffer);
-    } catch (IOException | IllegalStateException e) {
-      notifyWebSocketFailed(id, e.getMessage());
-    }
+    client.send(ByteString.decodeBase64(base64String));
   }
 
   private void notifyWebSocketFailed(int id, String message) {

--- a/ReactAndroid/src/main/java/com/facebook/react/packagerconnection/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/packagerconnection/BUCK
@@ -17,7 +17,6 @@ android_library(
         react_native_dep("third-party/java/infer-annotations:infer-annotations"),
         react_native_dep("third-party/java/jsr-305:jsr-305"),
         react_native_dep("third-party/java/okhttp:okhttp3"),
-        react_native_dep("third-party/java/okhttp:okhttp3-ws"),
         react_native_dep("third-party/java/okio:okio"),
         react_native_target("java/com/facebook/react/modules/systeminfo:systeminfo-moduleless"),
     ] + ([react_native_target("jni/packagerconnection:jni")] if not IS_OSS_BUILD else []),

--- a/ReactAndroid/src/main/java/com/facebook/react/packagerconnection/JSPackagerClient.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/packagerconnection/JSPackagerClient.java
@@ -15,9 +15,7 @@ import android.net.Uri;
 import com.facebook.common.logging.FLog;
 import com.facebook.react.modules.systeminfo.AndroidInfoHelpers;
 
-import okhttp3.RequestBody;
-import okhttp3.ResponseBody;
-import okhttp3.ws.WebSocket;
+import okio.ByteString;
 
 import org.json.JSONObject;
 
@@ -42,7 +40,7 @@ final public class JSPackagerClient implements ReconnectingWebSocket.MessageCall
         message.put("version", PROTOCOL_VERSION);
         message.put("id", mId);
         message.put("result", result);
-        mWebSocket.sendMessage(RequestBody.create(WebSocket.TEXT, message.toString()));
+        mWebSocket.sendMessage(message.toString());
       } catch (Exception e) {
         FLog.e(TAG, "Responding failed", e);
       }
@@ -54,7 +52,7 @@ final public class JSPackagerClient implements ReconnectingWebSocket.MessageCall
         message.put("version", PROTOCOL_VERSION);
         message.put("id", mId);
         message.put("error", error);
-        mWebSocket.sendMessage(RequestBody.create(WebSocket.TEXT, message.toString()));
+        mWebSocket.sendMessage(message.toString());
       } catch (Exception e) {
         FLog.e(TAG, "Responding with error failed", e);
       }
@@ -89,16 +87,16 @@ final public class JSPackagerClient implements ReconnectingWebSocket.MessageCall
   }
 
   @Override
-  public void onMessage(ResponseBody response) {
-    if (response.contentType() != WebSocket.TEXT) {
-      FLog.w(
-        TAG,
-        "Websocket received message with payload of unexpected type " + response.contentType());
-      return;
-    }
+  public void onMessage(ByteString bytes) {
+    FLog.w(
+      TAG,
+      "Websocket received message with payload of unexpected type ByteString");
+  }
 
+  @Override
+  public void onMessage(String text) {
     try {
-      JSONObject message = new JSONObject(response.string());
+      JSONObject message = new JSONObject(text);
 
       int version = message.optInt("version");
       String method = message.optString("method");
@@ -130,8 +128,6 @@ final public class JSPackagerClient implements ReconnectingWebSocket.MessageCall
       }
     } catch (Exception e) {
       FLog.e(TAG, "Handling the message failed", e);
-    } finally {
-      response.close();
     }
   }
 

--- a/ReactAndroid/src/main/third-party/java/okhttp/BUCK
+++ b/ReactAndroid/src/main/third-party/java/okhttp/BUCK
@@ -6,8 +6,8 @@ prebuilt_jar(
 
 remote_file(
     name = "okhttp3-binary-jar",
-    sha1 = "c7c4f9e35c2fd5900da24f9872e3971801f08ce0",
-    url = "mvn:com.squareup.okhttp3:okhttp:jar:3.4.1",
+    sha1 = "5a11f020cce2d11eb71ba916700600e18c4547e7",
+    url = "mvn:com.squareup.okhttp3:okhttp:jar:3.8.0",
 )
 
 prebuilt_jar(
@@ -18,18 +18,6 @@ prebuilt_jar(
 
 remote_file(
     name = "okhttp3-urlconnection-binary-jar",
-    sha1 = "63994437f62bc861bc20c605d12962f7246116d1",
-    url = "mvn:com.squareup.okhttp3:okhttp-urlconnection:jar:3.4.1",
-)
-
-prebuilt_jar(
-    name = "okhttp3-ws",
-    binary_jar = ":okhttp3-ws-binary-jar",
-    visibility = ["//ReactAndroid/..."],
-)
-
-remote_file(
-    name = "okhttp3-ws-binary-jar",
-    sha1 = "8ace66ef7002d98f633377c9e67daeeb196d8c3b",
-    url = "mvn:com.squareup.okhttp3:okhttp-ws:jar:3.4.1",
+    sha1 = "265257b82f20bb0371a926cc8ceb5f7bb17c0df8",
+    url = "mvn:com.squareup.okhttp3:okhttp-urlconnection:jar:3.8.0",
 )

--- a/ReactAndroid/src/main/third-party/java/okio/BUCK
+++ b/ReactAndroid/src/main/third-party/java/okio/BUCK
@@ -6,6 +6,6 @@ prebuilt_jar(
 
 remote_file(
     name = "okio-binary-jar",
-    sha1 = "f824591a0016efbaeddb8300bee54832a1398cfa",
-    url = "mvn:com.squareup.okio:okio:jar:1.9.0",
+    sha1 = "a9283170b7305c8d92d25aff02a6ab7e45d06cbe",
+    url = "mvn:com.squareup.okio:okio:jar:1.13.0",
 )

--- a/ReactAndroid/src/test/java/com/facebook/react/devsupport/BUCK
+++ b/ReactAndroid/src/test/java/com/facebook/react/devsupport/BUCK
@@ -15,7 +15,6 @@ rn_robolectric_test(
         react_native_dep("third-party/java/junit:junit"),
         react_native_dep("third-party/java/mockito:mockito"),
         react_native_dep("third-party/java/okhttp:okhttp3"),
-        react_native_dep("third-party/java/okhttp:okhttp3-ws"),
         react_native_dep("third-party/java/okio:okio"),
         react_native_dep("third-party/java/robolectric3/robolectric:robolectric"),
         react_native_target("java/com/facebook/react:react"),

--- a/ReactAndroid/src/test/java/com/facebook/react/devsupport/JSDebuggerWebSocketClientTest.java
+++ b/ReactAndroid/src/test/java/com/facebook/react/devsupport/JSDebuggerWebSocketClientTest.java
@@ -22,8 +22,7 @@ import org.robolectric.RobolectricTestRunner;
 
 import java.util.HashMap;
 
-import okhttp3.ResponseBody;
-import okhttp3.ws.WebSocket;
+import okio.ByteString;
 
 import static org.mockito.Mockito.*;
 
@@ -78,7 +77,7 @@ public class JSDebuggerWebSocketClientTest {
   public void test_onMessage_WithInvalidContentType_ShouldNotTriggerCallbacks() throws Exception {
     JSDebuggerWebSocketClient client = PowerMockito.spy(new JSDebuggerWebSocketClient());
 
-    client.onMessage(ResponseBody.create(WebSocket.BINARY, "{\"replyID\":0, \"result\":\"OK\"}"));
+    client.onMessage(null, ByteString.EMPTY);
     PowerMockito.verifyPrivate(client, never()).invoke("triggerRequestSuccess", anyInt(), anyString());
     PowerMockito.verifyPrivate(client, never()).invoke("triggerRequestFailure", anyInt(), any());
   }
@@ -87,7 +86,7 @@ public class JSDebuggerWebSocketClientTest {
   public void test_onMessage_WithoutReplyId_ShouldNotTriggerCallbacks() throws Exception {
     JSDebuggerWebSocketClient client = PowerMockito.spy(new JSDebuggerWebSocketClient());
 
-    client.onMessage(ResponseBody.create(WebSocket.TEXT, "{\"result\":\"OK\"}"));
+    client.onMessage(null, "{\"result\":\"OK\"}");
     PowerMockito.verifyPrivate(client, never()).invoke("triggerRequestSuccess", anyInt(), anyString());
     PowerMockito.verifyPrivate(client, never()).invoke("triggerRequestFailure", anyInt(), any());
   }
@@ -96,7 +95,7 @@ public class JSDebuggerWebSocketClientTest {
   public void test_onMessage_With_Null_ReplyId_ShouldNotTriggerCallbacks() throws Exception {
     JSDebuggerWebSocketClient client = PowerMockito.spy(new JSDebuggerWebSocketClient());
 
-    client.onMessage(ResponseBody.create(WebSocket.TEXT, "{\"replyID\":null, \"result\":\"OK\"}"));
+    client.onMessage(null, "{\"replyID\":null, \"result\":\"OK\"}");
     PowerMockito.verifyPrivate(client, never()).invoke("triggerRequestSuccess", anyInt(), anyString());
     PowerMockito.verifyPrivate(client, never()).invoke("triggerRequestFailure", anyInt(), any());
   }
@@ -105,7 +104,7 @@ public class JSDebuggerWebSocketClientTest {
   public void test_onMessage_WithResult_ShouldTriggerRequestSuccess() throws Exception {
     JSDebuggerWebSocketClient client = PowerMockito.spy(new JSDebuggerWebSocketClient());
 
-    client.onMessage(ResponseBody.create(WebSocket.TEXT, "{\"replyID\":0, \"result\":\"OK\"}"));
+    client.onMessage(null, "{\"replyID\":0, \"result\":\"OK\"}");
     PowerMockito.verifyPrivate(client).invoke("triggerRequestSuccess", 0, "OK");
     PowerMockito.verifyPrivate(client, never()).invoke("triggerRequestFailure", anyInt(), any());
   }
@@ -114,7 +113,7 @@ public class JSDebuggerWebSocketClientTest {
   public void test_onMessage_With_Null_Result_ShouldTriggerRequestSuccess() throws Exception {
     JSDebuggerWebSocketClient client = PowerMockito.spy(new JSDebuggerWebSocketClient());
 
-    client.onMessage(ResponseBody.create(WebSocket.TEXT, "{\"replyID\":0, \"result\":null}"));
+    client.onMessage(null, "{\"replyID\":0, \"result\":null}");
     PowerMockito.verifyPrivate(client).invoke("triggerRequestSuccess", 0, null);
     PowerMockito.verifyPrivate(client, never()).invoke("triggerRequestFailure", anyInt(), any());
   }
@@ -123,7 +122,7 @@ public class JSDebuggerWebSocketClientTest {
   public void test_onMessage_WithError_ShouldCallAbort() throws Exception {
     JSDebuggerWebSocketClient client = PowerMockito.spy(new JSDebuggerWebSocketClient());
 
-    client.onMessage(ResponseBody.create(WebSocket.TEXT, "{\"replyID\":0, \"error\":\"BOOM\"}"));
+    client.onMessage(null, "{\"replyID\":0, \"error\":\"BOOM\"}");
     PowerMockito.verifyPrivate(client).invoke("abort", eq("BOOM"), isA(JavascriptException.class));
   }
 
@@ -131,7 +130,7 @@ public class JSDebuggerWebSocketClientTest {
   public void test_onMessage_With_Null_Error_ShouldTriggerRequestSuccess() throws Exception {
     JSDebuggerWebSocketClient client = PowerMockito.spy(new JSDebuggerWebSocketClient());
 
-    client.onMessage(ResponseBody.create(WebSocket.TEXT, "{\"replyID\":0, \"error\":null}"));
+    client.onMessage(null, "{\"replyID\":0, \"error\":null}");
     PowerMockito.verifyPrivate(client).invoke("triggerRequestSuccess", anyInt(), anyString());
   }
 }

--- a/ReactAndroid/src/test/java/com/facebook/react/packagerconnection/BUCK
+++ b/ReactAndroid/src/test/java/com/facebook/react/packagerconnection/BUCK
@@ -15,7 +15,7 @@ rn_robolectric_test(
         react_native_dep("third-party/java/junit:junit"),
         react_native_dep("third-party/java/mockito:mockito"),
         react_native_dep("third-party/java/okhttp:okhttp3"),
-        react_native_dep("third-party/java/okhttp:okhttp3-ws"),
+        react_native_dep("third-party/java/okio:okio"),
         react_native_dep("third-party/java/robolectric3/robolectric:robolectric"),
         react_native_target("java/com/facebook/react/packagerconnection:packagerconnection"),
     ],

--- a/ReactAndroid/src/test/java/com/facebook/react/packagerconnection/JSPackagerClientTest.java
+++ b/ReactAndroid/src/test/java/com/facebook/react/packagerconnection/JSPackagerClientTest.java
@@ -17,8 +17,8 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-import okhttp3.ResponseBody;
-import okhttp3.ws.WebSocket;
+import okhttp3.WebSocket;
+import okio.ByteString;
 
 import static org.mockito.Mockito.*;
 import org.robolectric.RobolectricTestRunner;
@@ -47,10 +47,7 @@ public class JSPackagerClientTest {
     RequestHandler handler = mock(RequestHandler.class);
     final JSPackagerClient client = new JSPackagerClient("test_client", mSettings, createRH("methodValue", handler));
 
-    client.onMessage(
-        ResponseBody.create(
-          WebSocket.TEXT,
-          "{\"version\": 2, \"method\": \"methodValue\", \"params\": \"paramsValue\"}"));
+    client.onMessage("{\"version\": 2, \"method\": \"methodValue\", \"params\": \"paramsValue\"}");
     verify(handler).onNotification(eq("paramsValue"));
     verify(handler, never()).onRequest(any(), any(Responder.class));
   }
@@ -60,10 +57,7 @@ public class JSPackagerClientTest {
     RequestHandler handler = mock(RequestHandler.class);
     final JSPackagerClient client = new JSPackagerClient("test_client", mSettings, createRH("methodValue", handler));
 
-    client.onMessage(
-        ResponseBody.create(
-          WebSocket.TEXT,
-          "{\"version\": 2, \"id\": \"idValue\", \"method\": \"methodValue\", \"params\": \"paramsValue\"}"));
+    client.onMessage("{\"version\": 2, \"id\": \"idValue\", \"method\": \"methodValue\", \"params\": \"paramsValue\"}");
     verify(handler, never()).onNotification(any());
     verify(handler).onRequest(eq("paramsValue"), any(Responder.class));
   }
@@ -73,10 +67,7 @@ public class JSPackagerClientTest {
     RequestHandler handler = mock(RequestHandler.class);
     final JSPackagerClient client = new JSPackagerClient("test_client", mSettings, createRH("methodValue", handler));
 
-    client.onMessage(
-        ResponseBody.create(
-          WebSocket.TEXT,
-          "{\"version\": 2, \"method\": \"methodValue\"}"));
+    client.onMessage("{\"version\": 2, \"method\": \"methodValue\"}");
     verify(handler).onNotification(eq(null));
     verify(handler, never()).onRequest(any(), any(Responder.class));
   }
@@ -86,10 +77,7 @@ public class JSPackagerClientTest {
     RequestHandler handler = mock(RequestHandler.class);
     final JSPackagerClient client = new JSPackagerClient("test_client", mSettings, createRH("methodValue", handler));
 
-    client.onMessage(
-        ResponseBody.create(
-          WebSocket.BINARY,
-          "{\"version\": 2, \"method\": \"methodValue\"}"));
+    client.onMessage(ByteString.EMPTY);
     verify(handler, never()).onNotification(any());
     verify(handler, never()).onRequest(any(), any(Responder.class));
   }
@@ -99,10 +87,7 @@ public class JSPackagerClientTest {
     RequestHandler handler = mock(RequestHandler.class);
     final JSPackagerClient client = new JSPackagerClient("test_client", mSettings, createRH("methodValue", handler));
 
-    client.onMessage(
-        ResponseBody.create(
-          WebSocket.TEXT,
-          "{\"version\": 2}"));
+    client.onMessage("{\"version\": 2}");
     verify(handler, never()).onNotification(any());
     verify(handler, never()).onRequest(any(), any(Responder.class));
   }
@@ -112,10 +97,7 @@ public class JSPackagerClientTest {
     RequestHandler handler = mock(RequestHandler.class);
     final JSPackagerClient client = new JSPackagerClient("test_client", mSettings, createRH("methodValue", handler));
 
-    client.onMessage(
-        ResponseBody.create(
-          WebSocket.TEXT,
-          "{\"version\": 2, \"method\": null}"));
+    client.onMessage("{\"version\": 2, \"method\": null}");
     verify(handler, never()).onNotification(any());
     verify(handler, never()).onRequest(any(), any(Responder.class));
   }
@@ -125,10 +107,7 @@ public class JSPackagerClientTest {
     RequestHandler handler = mock(RequestHandler.class);
     final JSPackagerClient client = new JSPackagerClient("test_client", mSettings, createRH("methodValue", handler));
 
-    client.onMessage(
-        ResponseBody.create(
-          WebSocket.BINARY,
-          "{\"version\": 2, \"method\": \"methodValue2\"}"));
+    client.onMessage("{\"version\": 2, \"method\": \"methodValue2\"}");
     verify(handler, never()).onNotification(any());
     verify(handler, never()).onRequest(any(), any(Responder.class));
   }
@@ -138,10 +117,7 @@ public class JSPackagerClientTest {
     RequestHandler handler = mock(RequestHandler.class);
     final JSPackagerClient client = new JSPackagerClient("test_client", mSettings, createRH("methodValue", handler));
 
-    client.onMessage(
-        ResponseBody.create(
-          WebSocket.TEXT,
-          "{\"version\": 1, \"method\": \"methodValue\"}"));
+    client.onMessage("{\"version\": 1, \"method\": \"methodValue\"}");
     verify(handler, never()).onNotification(any());
     verify(handler, never()).onRequest(any(), any(Responder.class));
   }


### PR DESCRIPTION
## Motivation

- Keeping a core dependency up to date
- Fixes: #11680 
- Resolves dependency conflicts

[3.5.0 - Change log](https://github.com/square/okhttp/blob/master/CHANGELOG.md#version-350)
[3.6.0 - Change log](https://github.com/square/okhttp/blob/master/CHANGELOG.md#version-360)
[3.7.0 - Change log](https://github.com/square/okhttp/blob/master/CHANGELOG.md#version-370)
[3.8.0 - Change log](https://github.com/square/okhttp/blob/master/CHANGELOG.md#version-380)

## Test plan

- Tests pass on CI
- Tested with the example projects in JS remote debug mode

## iOS only ping 

The sendPing public API has been removed. In 3.5.0 OkHttp will automatically ping and send a callback to onClose if not connected.

Reference: https://github.com/square/okhttp/issues/2902#issuecomment-253106088

I guessing this PR will be dependent on Facebook upgrading OkHttp on their side?
cc @bestander 