### PR TITLE
Include props in new ListView and ScrollView mocks

### DIFF
--- a/Libraries/Components/ScrollView/__mocks__/ScrollViewMock.js
+++ b/Libraries/Components/ScrollView/__mocks__/ScrollViewMock.js
@@ -20,7 +20,7 @@ const RCTScrollView = requireNativeComponent('RCTScrollView');
 class ScrollViewMock extends React.Component {
   render() {
     return (
-      <RCTScrollView>
+      <RCTScrollView {...this.props}>
         {this.props.refreshControl}
         <View>
           {this.props.children}

--- a/Libraries/CustomComponents/ListView/__mocks__/ListViewMock.js
+++ b/Libraries/CustomComponents/ListView/__mocks__/ListViewMock.js
@@ -48,11 +48,7 @@ class ListViewMock extends React.Component {
       }
     }
     renderFooter && rows.push(renderFooter());
-    return (
-      <View>
-        {this.props.renderScrollComponent({children: rows})}
-      </View>
-    );
+    return this.props.renderScrollComponent({...this.props, children: rows});
   }
   static DataSource = ListViewDataSource;
 }


### PR DESCRIPTION
Hi,

The (as of yet unreleased) commit https://github.com/facebook/react-native/commit/5537055bf87c8b19e9fa8413486eef6a7ac5017f added some ListView and ScrollView mocks, but they leave out the original properties passed into them, which broke some of my tests (e.g. by excluding some properties like `testID`, for example, from the render tree) and I assume might break others' as well.

This PR makes it so the ListView mock directly returns the scroll component (instead of wrapping it in a View), and has ListViewMock and ScrollViewMock pass their given properties through.