### PR TITLE
Fix babel only regexp on windows

### DIFF
--- a/setupBabel.js
+++ b/setupBabel.js
@@ -26,7 +26,9 @@ const BABEL_ENABLED_PATHS = [
  */
 function buildRegExps(basePath, dirPaths) {
   return dirPaths.map(folderPath =>
-    new RegExp(`^${escapeRegExp(path.resolve(basePath, folderPath))}`)
+    // Babel `only` option works with forward slashes in the RegExp so replace
+    // backslashes for Windows.
+    new RegExp(`^${escapeRegExp(path.resolve(basePath, folderPath).replace(/\\/g, '/'))}`)
   );
 }
 


### PR DESCRIPTION
cli / packager was broken on Windows after 28f1c67ced5f082d92ba674e7e8bd233f4ff29ca.

Babel `only` regexp option requires paths to use forward slashes only but `__dirname` will use backslashes on windows. This simply adds a replace to normalize to forward slashes.

cc @jeanlauliac @cpojer 