### PR TITLE
Remove deprecated method 'RCTExecuteOnMainThread'

### DIFF
--- a/React/Base/RCTModuleData.mm
+++ b/React/Base/RCTModuleData.mm
@@ -219,12 +219,10 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init);
       if (!RCTIsMainQueue()) {
         RCTLogWarn(@"RCTBridge required dispatch_sync to load %@. This may lead to deadlocks", _moduleClass);
       }
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-      RCTExecuteOnMainThread(^{
+
+      RCTUnsafeExecuteOnMainQueueSync(^{
         [self setUpInstanceAndBridge];
-      }, YES);
-#pragma clang diagnostic pop
+      });
       RCT_PROFILE_END_EVENT(RCTProfileTagAlways, @"");
     } else {
       [self setUpInstanceAndBridge];
@@ -286,12 +284,10 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init);
     if (!RCTIsMainQueue()) {
       RCTLogWarn(@"Required dispatch_sync to load constants for %@. This may lead to deadlocks", _moduleClass);
     }
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    RCTExecuteOnMainThread(^{
+
+    RCTUnsafeExecuteOnMainQueueSync(^{
       self->_constantsToExport = [self->_instance constantsToExport] ?: @{};
-    }, YES);
-#pragma clang diagnostic pop
+    });
     RCT_PROFILE_END_EVENT(RCTProfileTagAlways, @"");
   }
 }

--- a/React/Base/RCTUtils.h
+++ b/React/Base/RCTUtils.h
@@ -42,11 +42,6 @@ RCT_EXTERN void RCTExecuteOnMainQueue(dispatch_block_t block);
 // Please do not use this unless you know what you're doing.
 RCT_EXTERN void RCTUnsafeExecuteOnMainQueueSync(dispatch_block_t block);
 
-// Deprecated - do not use.
-RCT_EXTERN void RCTExecuteOnMainThread(dispatch_block_t block, BOOL sync)
-__deprecated_msg("Use RCTExecuteOnMainQueue instead. RCTExecuteOnMainQueue is "
-                 "async. If you need to use the `sync` option... please don't.");
-
 // Get screen metrics in a thread-safe way
 RCT_EXTERN CGFloat RCTScreenScale(void);
 RCT_EXTERN CGSize RCTScreenSize(void);

--- a/React/Base/RCTUtils.m
+++ b/React/Base/RCTUtils.m
@@ -265,21 +265,6 @@ void RCTUnsafeExecuteOnMainQueueSync(dispatch_block_t block)
   }
 }
 
-void RCTExecuteOnMainThread(dispatch_block_t block, BOOL sync)
-{
-  if (RCTIsMainQueue()) {
-    block();
-  } else if (sync) {
-    dispatch_sync(dispatch_get_main_queue(), ^{
-      block();
-    });
-  } else {
-    dispatch_async(dispatch_get_main_queue(), ^{
-      block();
-    });
-  }
-}
-
 CGFloat RCTScreenScale()
 {
   static CGFloat scale;


### PR DESCRIPTION
**Motivation**

This finishes the job of #11817, removing the previously deprecated method. See https://github.com/facebook/react-native/issues/11736 for more context.

**Test plan**

There were no tests for this method, and I searched the whole project to make sure we weren't relying on it anywhere.