### PR TITLE
[rnpm] Improve `unlink` 

### DIFF
--- a/local-cli/link/unlink.js
+++ b/local-cli/link/unlink.js
@@ -125,6 +125,8 @@ function unlink(args, config) {
 
   return promiseWaterfall(tasks)
     .then(() => {
+      // @todo move all these to `tasks` array, just like in
+      // link
       const assets = difference(
         dependency.assets,
         flatten(allDependencies, d => d.assets)

--- a/local-cli/link/unlink.js
+++ b/local-cli/link/unlink.js
@@ -113,15 +113,14 @@ function unlink(args, config) {
 
   const allDependencies = getDependencyConfig(config, getProjectDependencies());
   const otherDependencies = filter(allDependencies, d => d.name !== packageName);
-  const thisDependency = find(allDependencies, d => d.name === packageName);
   const iOSDependencies = compact(otherDependencies.map(d => d.config.ios));
 
   const tasks = [
-    () => promisify(thisDependency.config.commands.preunlink || commandStub),
+    () => promisify(dependency.commands.preunlink || commandStub),
     () => unlinkDependencyAndroid(project.android, dependency, packageName),
     () => unlinkDependencyIOS(project.ios, dependency, packageName, iOSDependencies),
     () => unlinkDependencyWindows(project.windows, dependency, packageName),
-    () => promisify(thisDependency.config.commands.postunlink || commandStub)
+    () => promisify(dependency.commands.postunlink || commandStub)
   ];
 
   return promiseWaterfall(tasks)


### PR DESCRIPTION
We don't need to look for `thisDependency` as we already have it. Small improvement as I am working on other fixes.