### PR TITLE
Allow both HMR clients and live reloading clients

### DIFF
--- a/React/Modules/RCTDevMenu.mm
+++ b/React/Modules/RCTDevMenu.mm
@@ -721,7 +721,14 @@ RCT_EXPORT_METHOD(setHotLoadingEnabled:(BOOL)enabled)
       if (strongSelf && strongSelf->_liveReloadEnabled) {
         NSHTTPURLResponse *HTTPResponse = (NSHTTPURLResponse *)response;
         if (!error && HTTPResponse.statusCode == 205) {
-          [strongSelf reload];
+          // Before this commit, the package server doesn't inform changes to live reloading
+          // clients when one more HMR clients connected, this commit allow server informs
+          // both live reloading clients and HMR clients.
+          // When HMR enabled, live reload subscription doesnt't disconnect, so need disable
+          // live reloading.
+          if (!strongSelf->_hotLoadingEnabled) {
+            [strongSelf reload];
+          }
         } else {
           if (error.code != NSURLErrorCancelled) {
             strongSelf->_updateTask = nil;

--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevServerHelper.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevServerHelper.java
@@ -432,7 +432,12 @@ public class DevServerHelper {
 
   private void handleOnChangePollingResponse(boolean didServerContentChanged) {
     if (mOnChangePollingEnabled) {
-      if (didServerContentChanged) {
+      // Before this commit, the package server doesn't inform changes to live reloading
+      // clients when one more HMR clients connected, this commit allow server informs
+      // both live reloading clients and HMR clients.
+      // When HMR enabled, live reload subscription doesnt't disconnect, so need disable
+      // live reloading.
+      if (didServerContentChanged && !mSettings.isHotModuleReplacementEnabled()) {
         UiThreadUtil.runOnUiThread(new Runnable() {
           @Override
           public void run() {

--- a/packager/react-packager/src/Server/index.js
+++ b/packager/react-packager/src/Server/index.js
@@ -391,7 +391,8 @@ class Server {
       // Clear cached bundles in case user reloads
       this._clearBundles();
       this._hmrFileChangeListener(type, filePath);
-      return;
+      // when HMR clients connected, also allow live reloading clients
+      // return;
     } else if (type !== 'change' && filePath.indexOf(NODE_MODULES) !== -1) {
       // node module resolution can be affected by added or removed files
       debug('Clearing bundles due to potential node_modules resolution change');


### PR DESCRIPTION
Explain the **motivation** for making this change. What existing problem does the pull request solve?

> I almost preview on multi devices, sometimes I switch a device to HMR mode, and others are Live Reload mode, currently only the "HMR device" can update. I already used this patch a few months, and I think I'm not the only need it.

Prefer **small pull requests**. These are much easier to review and more likely to get merged. Make sure the PR does only one thing, otherwise please split it.

> Very small :-)

**Test plan (required)**

> Test Steps:
> 1. Open multi devices or emulators, switch one to HMR mode, and others are Live Reloading mode.
> 2. Update your code.
>
> Expected result:
> 1. All devices can updated.
> 2. The "HMR device" only update with HOT RELOADING experience.
