### PR TITLE
HMR support multi clients

### DIFF
--- a/local-cli/server/util/attachHMRServer.js
+++ b/local-cli/server/util/attachHMRServer.js
@@ -115,8 +115,6 @@ function attachHMRServer({httpServer, path, packagerServer}) {
     wsList.fileChangeListener(type, filename);
   };
 
-  packagerServer.setHMRFileChangeListener(listener);
-
   wss.on('connection', ws => {
     const params = querystring.parse(url.parse(ws.upgradeReq.url).query);
     const wasEmpty = wsList.clients.length === 0;
@@ -175,6 +173,8 @@ function attachHMRServer({httpServer, path, packagerServer}) {
           shallowDependencies,
           inverseDependenciesCache,
         };
+
+        packagerServer.setHMRFileChangeListener(listener);
 
         wsList.fileChangeListener = (type, filename) => {
           if (!client) {

--- a/local-cli/server/util/attachHMRServer.js
+++ b/local-cli/server/util/attachHMRServer.js
@@ -184,7 +184,6 @@ function attachHMRServer({httpServer, path, packagerServer}) {
         inverseDependenciesCache,
       }) => {
         const client = {
-          ws,
           platform: params.platform,
           bundleEntry: params.bundleEntry,
           dependenciesCache,
@@ -194,10 +193,6 @@ function attachHMRServer({httpServer, path, packagerServer}) {
         };
 
         wsList.fileChangeListener = (type, filename) => {
-          if (!client) {
-            return;
-          }
-
           const blacklisted = blacklist.find(blacklistedPath =>
             filename.indexOf(blacklistedPath) !== -1
           );
@@ -215,10 +210,6 @@ function attachHMRServer({httpServer, path, packagerServer}) {
                 dev: true,
                 hot: true,
               }).then(deps => {
-                if (!client) {
-                  return [];
-                }
-
                 // if the file dependencies have change we need to invalidate the
                 // dependencies caches because the list of files we need to send
                 // to the client may have changed
@@ -251,10 +242,6 @@ function attachHMRServer({httpServer, path, packagerServer}) {
                     inverseDependenciesCache: inverseDepsCache,
                     resolutionResponse,
                   }) => {
-                    if (!client) {
-                      return {};
-                    }
-
                     // build list of modules for which we'll send HMR updates
                     const modulesToUpdate = [packagerServer.getModuleForPath(filename)];
                     Object.keys(depsModulesCache).forEach(module => {
@@ -285,10 +272,6 @@ function attachHMRServer({httpServer, path, packagerServer}) {
                   });
               })
               .then((resolutionResponse) => {
-                if (!client) {
-                  return;
-                }
-
                 // make sure the file was modified is part of the bundle
                 if (!client.shallowDependencies[filename]) {
                   return;
@@ -311,7 +294,7 @@ function attachHMRServer({httpServer, path, packagerServer}) {
                 }, packagerHost, httpServerAddress.port);
               })
               .then(bundle => {
-                if (!client || !bundle || bundle.isEmpty()) {
+                if (!bundle || bundle.isEmpty()) {
                   return;
                 }
 
@@ -349,7 +332,7 @@ function attachHMRServer({httpServer, path, packagerServer}) {
                 return JSON.stringify({type: 'error', body});
               })
               .then(update => {
-                if (!client || !update) {
+                if (!update) {
                   return;
                 }
 


### PR DESCRIPTION
Explain the **motivation** for making this change. What existing problem does the pull request solve?

> Likes https://github.com/facebook/react-native/pull/11875 , I also need multi devices can update in HMR mode, currently it supports only one.
> This PR can works with https://github.com/facebook/react-native/pull/11875, your devices can work with Live Reload or HMR mode.

Prefer **small pull requests**. These are much easier to review and more likely to get merged. Make sure the PR does only one thing, otherwise please split it.

> As small as possible.

**Test plan (required)**

> Test steps:
> 1. Open multi devices in HMR mode.
> 2. Update your code.
>
> Expected result:
> 1. Every device can update with HMR experience.
