### PR TITLE
Support videos in Android CameraRoll.getPhotos

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/modules/camera/CameraRollManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/camera/CameraRollManager.java
@@ -32,7 +32,6 @@ import android.os.Environment;
 import android.provider.MediaStore;
 import android.provider.MediaStore.Images;
 import android.text.TextUtils;
-import android.util.Log;
 
 import com.facebook.common.logging.FLog;
 import com.facebook.react.bridge.GuardedAsyncTask;


### PR DESCRIPTION
Support getting videos for `CameraRoll.getPhotos()` on Android. Before this PR, `assetType` is ignored in Android.