### PR TITLE
Text docs - Update to improve readability for ellipsizeMode

### DIFF
--- a/Libraries/Text/Text.js
+++ b/Libraries/Text/Text.js
@@ -93,7 +93,7 @@ const viewConfig = {
 const Text = React.createClass({
   propTypes: {
     /**
-     * When `numberOfLines` is set, this prop defines how text will be truncated. 
+     * When `numberOfLines` is set, this prop defines how text will be truncated.
      * `numberOfLines` must be set in conjunction with this prop.
      *
      * This can be one of the following values:

--- a/Libraries/Text/Text.js
+++ b/Libraries/Text/Text.js
@@ -93,6 +93,9 @@ const viewConfig = {
 const Text = React.createClass({
   propTypes: {
     /**
+     * When `numberOfLines` is set, this prop defines how text will be truncated. 
+     * `numberOfLines` must be set in conjunction with this prop.
+     *
      * This can be one of the following values:
      *
      * - `head` - The line is displayed so that the end fits in the container and the missing text
@@ -104,8 +107,6 @@ const Text = React.createClass({
      * - `clip` - Lines are not drawn past the edge of the text container.
      *
      * The default is `tail`.
-     *
-     * `numberOfLines` must be set in conjunction with this prop.
      *
      * > `clip` is working only for iOS
      */


### PR DESCRIPTION
added context for easier understanding as 'ellipsizeMode' appears before 'numberOfLines' in https://facebook.github.io/react-native/docs/text.html


Explain the **motivation** for making this change. What existing problem does the pull request solve?

Upon first reading the Text docs, the ellipsizeMode function is confusing.  This update aims to remove the confusion.