### PR TITLE
Support show a progress indicator for Image while loading from URL (both Android and iOS)

### DIFF
--- a/Libraries/Image/Image.android.js
+++ b/Libraries/Image/Image.android.js
@@ -34,7 +34,6 @@ var {
   ImageLoader,
 } = NativeModules;
 var ColorPropType = require('ColorPropType');
-var ImageSourcePropType = require('ImageSourcePropType');
 
 let _requestId = 1;
 function generateRequestId() {

--- a/Libraries/Image/Image.android.js
+++ b/Libraries/Image/Image.android.js
@@ -117,13 +117,23 @@ var Image = React.createClass({
       PropTypes.number,
     ]),
 
-
-    // 2017/01/10 QuangCM added -->
+    /**
+     * Show a circle loading indicator while loading image from url
+     */
     showLoadingIndicator: PropTypes.bool,
-    loadingIndicatorSize: PropTypes.oneOf(['small', 'large']),      // default is small
-    loadingIndicatorColor: ColorPropType,                           // default is gray
-    failureImageSource: PropTypes.number,                           // only accept local image require('./image.jpg')
-    // <-- 2017/01/10 QuangCM added
+    /**
+     * Determines the size of loading indicator
+     */
+    loadingIndicatorSize: PropTypes.oneOf(['small', 'large']),
+    /**
+     * Determines color of loading indicator
+     */
+    loadingIndicatorColor: ColorPropType,
+    /**
+     * A static image to display in case of loading image from url is failed (not a placeholder).
+     * only accept local image, for example require('./image.jpg')
+     */
+    failureImageSource: PropTypes.number,
 
     progressiveRenderingEnabled: PropTypes.bool,
     fadeDuration: PropTypes.number,

--- a/Libraries/Image/Image.android.js
+++ b/Libraries/Image/Image.android.js
@@ -33,6 +33,8 @@ var PropTypes = React.PropTypes;
 var {
   ImageLoader,
 } = NativeModules;
+var ColorPropType = require('ColorPropType');
+var ImageSourcePropType = require('ImageSourcePropType');
 
 let _requestId = 1;
 function generateRequestId() {
@@ -70,6 +72,7 @@ var ImageViewAttributes = merge(ReactNativeViewAttributes.UIView, {
   progressiveRenderingEnabled: true,
   fadeDuration: true,
   shouldNotifyLoadEvents: true,
+  failureImageSrc: true,
 });
 
 var ViewStyleKeys = new Set(Object.keys(ViewStylePropTypes));
@@ -113,6 +116,15 @@ var Image = React.createClass({
       // Opaque type returned by require('./image.jpg')
       PropTypes.number,
     ]),
+
+
+    // 2017/01/10 QuangCM added -->
+    showLoadingIndicator: PropTypes.bool,
+    loadingIndicatorSize: PropTypes.oneOf(['small', 'large']),      // default is small
+    loadingIndicatorColor: ColorPropType,                           // default is gray
+    failureImageSource: PropTypes.number,                           // only accept local image require('./image.jpg')
+    // <-- 2017/01/10 QuangCM added
+
     progressiveRenderingEnabled: PropTypes.bool,
     fadeDuration: PropTypes.number,
     /**
@@ -271,6 +283,7 @@ var Image = React.createClass({
   render: function() {
     const source = resolveAssetSource(this.props.source);
     const loadingIndicatorSource = resolveAssetSource(this.props.loadingIndicatorSource);
+    const failureImageSource = resolveAssetSource(this.props.failureImageSource);
 
     // As opposed to the ios version, here we render `null` when there is no source, source.uri
     // or source array.
@@ -301,6 +314,7 @@ var Image = React.createClass({
         shouldNotifyLoadEvents: !!(onLoadStart || onLoad || onLoadEnd || onError),
         src: sources,
         loadingIndicatorSrc: loadingIndicatorSource ? loadingIndicatorSource.uri : null,
+        failureImageSrc: failureImageSource ? failureImageSource.uri : null,
       });
 
       if (nativeProps.children) {
@@ -348,6 +362,7 @@ var cfg = {
     src: true,
     loadingIndicatorSrc: true,
     shouldNotifyLoadEvents: true,
+    failureImageSrc: true,
   },
 };
 var RKImage = requireNativeComponent('RCTImageView', Image, cfg);

--- a/Libraries/Image/Image.ios.js
+++ b/Libraries/Image/Image.ios.js
@@ -21,6 +21,7 @@ const React = require('React');
 const ReactNativeViewAttributes = require('ReactNativeViewAttributes');
 const StyleSheet = require('StyleSheet');
 const StyleSheetPropType = require('StyleSheetPropType');
+const ColorPropType = require('ColorPropType');
 
 const flattenStyle = require('flattenStyle');
 const requireNativeComponent = require('requireNativeComponent');
@@ -167,6 +168,16 @@ const Image = React.createClass({
       }),
       PropTypes.number,
     ]),
+
+
+    // 2017/01/10 QuangCM added -->
+    showLoadingIndicator: PropTypes.bool,
+    loadingIndicatorSize: PropTypes.oneOf(['small', 'large']),      // default is small
+    loadingIndicatorColor: ColorPropType,                           // default is gray
+    failureImageSource: PropTypes.number,                           // only accept local image require('./image.jpg')
+    // <-- 2017/01/10 QuangCM added
+
+
     /**
      * When true, indicates the image is an accessibility element.
      * @platform ios

--- a/Libraries/Image/Image.ios.js
+++ b/Libraries/Image/Image.ios.js
@@ -176,7 +176,7 @@ const Image = React.createClass({
     /**
      * Determines the size of loading indicator
      */
-    loadingIndicatorSize: PropTypes.oneOf(['small', 'large']), 
+    loadingIndicatorSize: PropTypes.oneOf(['small', 'large']),
     /**
      * Determines color of loading indicator
      */

--- a/Libraries/Image/Image.ios.js
+++ b/Libraries/Image/Image.ios.js
@@ -169,14 +169,23 @@ const Image = React.createClass({
       PropTypes.number,
     ]),
 
-
-    // 2017/01/10 QuangCM added -->
+    /**
+     * Show a circle loading indicator while loading image from url
+     */
     showLoadingIndicator: PropTypes.bool,
-    loadingIndicatorSize: PropTypes.oneOf(['small', 'large']),      // default is small
-    loadingIndicatorColor: ColorPropType,                           // default is gray
-    failureImageSource: PropTypes.number,                           // only accept local image require('./image.jpg')
-    // <-- 2017/01/10 QuangCM added
-
+    /**
+     * Determines the size of loading indicator
+     */
+    loadingIndicatorSize: PropTypes.oneOf(['small', 'large']), 
+    /**
+     * Determines color of loading indicator
+     */
+    loadingIndicatorColor: ColorPropType,
+    /**
+     * A static image to display in case of loading image from url is failed (not a placeholder).
+     * only accept local image, for example require('./image.jpg')
+     */
+    failureImageSource: PropTypes.number,
 
     /**
      * When true, indicates the image is an accessibility element.

--- a/Libraries/Image/RCTImage.xcodeproj/project.pbxproj
+++ b/Libraries/Image/RCTImage.xcodeproj/project.pbxproj
@@ -51,6 +51,8 @@
 		3DED3A9E1DE6F7A400336DD7 /* RCTImageViewManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 1304D5A91AA8C4A30002E2BE /* RCTImageViewManager.h */; };
 		3DED3A9F1DE6F7A400336DD7 /* RCTLocalAssetImageLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 13EF7F7D1BC825B1003F47DD /* RCTLocalAssetImageLoader.h */; };
 		3DED3AA01DE6F7A400336DD7 /* RCTResizeMode.h in Headers */ = {isa = PBXBuildFile; fileRef = 3D5FA63E1DE4B44A0058FD77 /* RCTResizeMode.h */; };
+		7467AFD51E24D24A000D2D4C /* RCTLoadingIndicatorSize.h in Headers */ = {isa = PBXBuildFile; fileRef = 7467AFD31E24D24A000D2D4C /* RCTLoadingIndicatorSize.h */; };
+		7467AFD61E24D24A000D2D4C /* RCTLoadingIndicatorSize.m in Sources */ = {isa = PBXBuildFile; fileRef = 7467AFD41E24D24A000D2D4C /* RCTLoadingIndicatorSize.m */; };
 		CCD34C271D4B8FE900268922 /* RCTImageCache.m in Sources */ = {isa = PBXBuildFile; fileRef = CCD34C261D4B8FE900268922 /* RCTImageCache.m */; };
 		EEF314721C9B0DD30049118E /* RCTImageBlurUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = EEF314711C9B0DD30049118E /* RCTImageBlurUtils.m */; };
 /* End PBXBuildFile section */
@@ -102,6 +104,8 @@
 		3D5FA63E1DE4B44A0058FD77 /* RCTResizeMode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTResizeMode.h; sourceTree = "<group>"; };
 		3D5FA68C1DE4BA290058FD77 /* libRCTNetwork.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libRCTNetwork.a; path = "../Network/build/Debug-iphoneos/libRCTNetwork.a"; sourceTree = "<group>"; };
 		58B5115D1A9E6B3D00147676 /* libRCTImage.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libRCTImage.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		7467AFD31E24D24A000D2D4C /* RCTLoadingIndicatorSize.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTLoadingIndicatorSize.h; sourceTree = "<group>"; };
+		7467AFD41E24D24A000D2D4C /* RCTLoadingIndicatorSize.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTLoadingIndicatorSize.m; sourceTree = "<group>"; };
 		CCD34C251D4B8FE900268922 /* RCTImageCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = RCTImageCache.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
 		CCD34C261D4B8FE900268922 /* RCTImageCache.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTImageCache.m; sourceTree = "<group>"; };
 		EEF314701C9B0DD30049118E /* RCTImageBlurUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = RCTImageBlurUtils.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
@@ -120,6 +124,8 @@
 		58B511541A9E6B3D00147676 = {
 			isa = PBXGroup;
 			children = (
+				7467AFD31E24D24A000D2D4C /* RCTLoadingIndicatorSize.h */,
+				7467AFD41E24D24A000D2D4C /* RCTLoadingIndicatorSize.m */,
 				1304D5B01AA8C50D0002E2BE /* RCTGIFImageDecoder.h */,
 				1304D5B11AA8C50D0002E2BE /* RCTGIFImageDecoder.m */,
 				EEF314701C9B0DD30049118E /* RCTImageBlurUtils.h */,
@@ -165,6 +171,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7467AFD51E24D24A000D2D4C /* RCTLoadingIndicatorSize.h in Headers */,
 				3DED3A8A1DE6F79800336DD7 /* RCTGIFImageDecoder.h in Headers */,
 				3DED3A901DE6F79800336DD7 /* RCTImageUtils.h in Headers */,
 				3DED3A8B1DE6F79800336DD7 /* RCTImageBlurUtils.h in Headers */,
@@ -295,6 +302,7 @@
 			files = (
 				35123E6B1B59C99D00EBAD80 /* RCTImageStoreManager.m in Sources */,
 				1304D5AC1AA8C4A30002E2BE /* RCTImageViewManager.m in Sources */,
+				7467AFD61E24D24A000D2D4C /* RCTLoadingIndicatorSize.m in Sources */,
 				1304D5B21AA8C50D0002E2BE /* RCTGIFImageDecoder.m in Sources */,
 				143879381AAD32A300F088A5 /* RCTImageLoader.m in Sources */,
 				354631681B69857700AA0B86 /* RCTImageEditingManager.m in Sources */,

--- a/Libraries/Image/RCTImage.xcodeproj/project.pbxproj
+++ b/Libraries/Image/RCTImage.xcodeproj/project.pbxproj
@@ -53,6 +53,8 @@
 		3DED3AA01DE6F7A400336DD7 /* RCTResizeMode.h in Headers */ = {isa = PBXBuildFile; fileRef = 3D5FA63E1DE4B44A0058FD77 /* RCTResizeMode.h */; };
 		7467AFD51E24D24A000D2D4C /* RCTLoadingIndicatorSize.h in Headers */ = {isa = PBXBuildFile; fileRef = 7467AFD31E24D24A000D2D4C /* RCTLoadingIndicatorSize.h */; };
 		7467AFD61E24D24A000D2D4C /* RCTLoadingIndicatorSize.m in Sources */ = {isa = PBXBuildFile; fileRef = 7467AFD41E24D24A000D2D4C /* RCTLoadingIndicatorSize.m */; };
+		74A5A0581E2B15C8003FA06B /* RCTLoadingIndicatorSize.h in Headers */ = {isa = PBXBuildFile; fileRef = 7467AFD31E24D24A000D2D4C /* RCTLoadingIndicatorSize.h */; };
+		74A5A0591E2B15CC003FA06B /* RCTLoadingIndicatorSize.m in Sources */ = {isa = PBXBuildFile; fileRef = 7467AFD41E24D24A000D2D4C /* RCTLoadingIndicatorSize.m */; };
 		CCD34C271D4B8FE900268922 /* RCTImageCache.m in Sources */ = {isa = PBXBuildFile; fileRef = CCD34C261D4B8FE900268922 /* RCTImageCache.m */; };
 		EEF314721C9B0DD30049118E /* RCTImageBlurUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = EEF314711C9B0DD30049118E /* RCTImageBlurUtils.m */; };
 /* End PBXBuildFile section */
@@ -196,6 +198,7 @@
 				3DED3A991DE6F7A400336DD7 /* RCTImageEditingManager.h in Headers */,
 				3DED3A9A1DE6F7A400336DD7 /* RCTImageLoader.h in Headers */,
 				3DED3A9B1DE6F7A400336DD7 /* RCTImageStoreManager.h in Headers */,
+				74A5A0581E2B15C8003FA06B /* RCTLoadingIndicatorSize.h in Headers */,
 				3DED3A9C1DE6F7A400336DD7 /* RCTImageUtils.h in Headers */,
 				3DED3A9D1DE6F7A400336DD7 /* RCTImageView.h in Headers */,
 				3DED3A9E1DE6F7A400336DD7 /* RCTImageViewManager.h in Headers */,
@@ -285,6 +288,7 @@
 				2D3B5F231D9B0D1300451313 /* RCTImageStoreManager.m in Sources */,
 				2D3B5F1A1D9B0D0400451313 /* RCTImageCache.m in Sources */,
 				2D3B5F1D1D9B0D1300451313 /* RCTLocalAssetImageLoader.m in Sources */,
+				74A5A0591E2B15CC003FA06B /* RCTLoadingIndicatorSize.m in Sources */,
 				2D3B5F1F1D9B0D1300451313 /* RCTImageEditingManager.m in Sources */,
 				2D3B5F1E1D9B0D1300451313 /* RCTGIFImageDecoder.m in Sources */,
 				2D3B5F1C1D9B0D1300451313 /* RCTResizeMode.m in Sources */,

--- a/Libraries/Image/RCTImageView.h
+++ b/Libraries/Image/RCTImageView.h
@@ -10,6 +10,7 @@
 #import <UIKit/UIKit.h>
 
 #import <React/RCTResizeMode.h>
+#import <React/RCTLoadingIndicatorSize.h>
 
 @class RCTBridge;
 @class RCTImageSource;
@@ -24,5 +25,9 @@
 @property (nonatomic, copy) NSArray<RCTImageSource *> *imageSources;
 @property (nonatomic, assign) CGFloat blurRadius;
 @property (nonatomic, assign) RCTResizeMode resizeMode;
+@property (nonatomic, assign) BOOL showLoadingIndicator;
+@property (nonatomic, strong) UIColor *loadingIndicatorColor;
+@property (nonatomic, assign) RCTLoadingIndicatorSize loadingIndicatorSize;
+@property (nonatomic, strong) UIImage *failureImage;
 
 @end

--- a/Libraries/Image/RCTImageViewManager.m
+++ b/Libraries/Image/RCTImageViewManager.m
@@ -29,6 +29,10 @@ RCT_EXPORT_MODULE()
 RCT_EXPORT_VIEW_PROPERTY(blurRadius, CGFloat)
 RCT_EXPORT_VIEW_PROPERTY(capInsets, UIEdgeInsets)
 RCT_REMAP_VIEW_PROPERTY(defaultSource, defaultImage, UIImage)
+RCT_EXPORT_VIEW_PROPERTY(showLoadingIndicator, BOOL)
+RCT_EXPORT_VIEW_PROPERTY(loadingIndicatorSize, RCTLoadingIndicatorSize)
+RCT_EXPORT_VIEW_PROPERTY(loadingIndicatorColor, UIColor)
+RCT_REMAP_VIEW_PROPERTY(failureImageSource, failureImage, UIImage)
 RCT_EXPORT_VIEW_PROPERTY(onLoadStart, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onProgress, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onError, RCTDirectEventBlock)
@@ -38,6 +42,7 @@ RCT_EXPORT_VIEW_PROPERTY(onLoadEnd, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(resizeMode, RCTResizeMode)
 RCT_REMAP_VIEW_PROPERTY(source, imageSources, NSArray<RCTImageSource *>);
 RCT_CUSTOM_VIEW_PROPERTY(tintColor, UIColor, RCTImageView)
+
 {
   // Default tintColor isn't nil - it's inherited from the superView - but we
   // want to treat a null json value for `tintColor` as meaning 'disable tint',

--- a/Libraries/Image/RCTLoadingIndicatorSize.h
+++ b/Libraries/Image/RCTLoadingIndicatorSize.h
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <React/RCTConvert.h>
+
+typedef NS_ENUM(NSInteger, RCTLoadingIndicatorSize) {
+  RCTLoadingIndicatorSizeSmall = 1,
+  RCTLoadingIndicatorSizeLarge = 2
+};
+
+@interface RCTConvert(RCTLoadingIndicatorSize)
+
++ (RCTLoadingIndicatorSize)RCTLoadingIndicatorSize:(id)json;
+
+@end

--- a/Libraries/Image/RCTLoadingIndicatorSize.m
+++ b/Libraries/Image/RCTLoadingIndicatorSize.m
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import "RCTLoadingIndicatorSize.h"
+
+@implementation RCTConvert(RCTLoadingIndicatorSize)
+
+RCT_ENUM_CONVERTER(RCTLoadingIndicatorSize, (@{
+  @"small": @(RCTLoadingIndicatorSizeSmall),
+  @"large": @(RCTLoadingIndicatorSizeLarge),
+}), RCTLoadingIndicatorSizeSmall, integerValue)
+
+@end

--- a/React/React.xcodeproj/project.pbxproj
+++ b/React/React.xcodeproj/project.pbxproj
@@ -706,6 +706,8 @@
 		58114A501AAE93D500E7D092 /* RCTAsyncLocalStorage.m in Sources */ = {isa = PBXBuildFile; fileRef = 58114A4E1AAE93D500E7D092 /* RCTAsyncLocalStorage.m */; };
 		58C571C11AA56C1900CDF9C8 /* RCTDatePickerManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 58C571BF1AA56C1900CDF9C8 /* RCTDatePickerManager.m */; };
 		68EFE4EE1CF6EB3900A1DE13 /* RCTBundleURLProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 68EFE4ED1CF6EB3900A1DE13 /* RCTBundleURLProvider.m */; };
+		7467AFD11E249590000D2D4C /* RCTLoadingIndicatorSize.h in Headers */ = {isa = PBXBuildFile; fileRef = 7467AFD01E249590000D2D4C /* RCTLoadingIndicatorSize.h */; };
+		7467AFD21E2495BA000D2D4C /* RCTLoadingIndicatorSize.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = 7467AFD01E249590000D2D4C /* RCTLoadingIndicatorSize.h */; };
 		830A229E1A66C68A008503DA /* RCTRootView.m in Sources */ = {isa = PBXBuildFile; fileRef = 830A229D1A66C68A008503DA /* RCTRootView.m */; };
 		83392EB31B6634E10013B15F /* RCTModalHostViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 83392EB21B6634E10013B15F /* RCTModalHostViewController.m */; };
 		83A1FE8C1B62640A00BE0E65 /* RCTModalHostView.m in Sources */ = {isa = PBXBuildFile; fileRef = 83A1FE8B1B62640A00BE0E65 /* RCTModalHostView.m */; };
@@ -950,6 +952,7 @@
 			dstPath = include/React;
 			dstSubfolderSpec = 16;
 			files = (
+				7467AFD21E2495BA000D2D4C /* RCTLoadingIndicatorSize.h in Copy Headers */,
 				3D80D91F1DF6FA890028D040 /* RCTImageLoader.h in Copy Headers */,
 				3D80D9201DF6FA890028D040 /* RCTImageStoreManager.h in Copy Headers */,
 				3D80D9211DF6FA890028D040 /* RCTResizeMode.h in Copy Headers */,
@@ -1324,6 +1327,7 @@
 		68EFE4EC1CF6EB3000A1DE13 /* RCTBundleURLProvider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTBundleURLProvider.h; sourceTree = "<group>"; };
 		68EFE4ED1CF6EB3900A1DE13 /* RCTBundleURLProvider.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTBundleURLProvider.m; sourceTree = "<group>"; };
 		6A15FB0C1BDF663500531DFB /* RCTRootViewInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTRootViewInternal.h; sourceTree = "<group>"; };
+		7467AFD01E249590000D2D4C /* RCTLoadingIndicatorSize.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTLoadingIndicatorSize.h; sourceTree = "<group>"; };
 		830213F31A654E0800B993E6 /* RCTBridgeModule.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RCTBridgeModule.h; sourceTree = "<group>"; };
 		830A229C1A66C68A008503DA /* RCTRootView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTRootView.h; sourceTree = "<group>"; };
 		830A229D1A66C68A008503DA /* RCTRootView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTRootView.m; sourceTree = "<group>"; };
@@ -1622,6 +1626,7 @@
 		3D1FA0821DE4F36600E03CC6 /* Image */ = {
 			isa = PBXGroup;
 			children = (
+				7467AFD01E249590000D2D4C /* RCTLoadingIndicatorSize.h */,
 				3D1FA0831DE4F3A000E03CC6 /* RCTImageLoader.h */,
 				3D1FA0841DE4F3A000E03CC6 /* RCTImageStoreManager.h */,
 				3D1FA0851DE4F3A000E03CC6 /* RCTResizeMode.h */,
@@ -1973,6 +1978,7 @@
 			files = (
 				3D80DA191DF820620028D040 /* RCTImageLoader.h in Headers */,
 				3D80DA1A1DF820620028D040 /* RCTImageStoreManager.h in Headers */,
+				7467AFD11E249590000D2D4C /* RCTLoadingIndicatorSize.h in Headers */,
 				3D80DA1B1DF820620028D040 /* RCTResizeMode.h in Headers */,
 				3D80DA1C1DF820620028D040 /* RCTLinkingManager.h in Headers */,
 				3D80DA1D1DF820620028D040 /* RCTNetworking.h in Headers */,

--- a/React/React.xcodeproj/project.pbxproj
+++ b/React/React.xcodeproj/project.pbxproj
@@ -708,6 +708,7 @@
 		68EFE4EE1CF6EB3900A1DE13 /* RCTBundleURLProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 68EFE4ED1CF6EB3900A1DE13 /* RCTBundleURLProvider.m */; };
 		7467AFD11E249590000D2D4C /* RCTLoadingIndicatorSize.h in Headers */ = {isa = PBXBuildFile; fileRef = 7467AFD01E249590000D2D4C /* RCTLoadingIndicatorSize.h */; };
 		7467AFD21E2495BA000D2D4C /* RCTLoadingIndicatorSize.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = 7467AFD01E249590000D2D4C /* RCTLoadingIndicatorSize.h */; };
+		74A5A0D51E2B45DD003FA06B /* RCTLoadingIndicatorSize.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = 7467AFD01E249590000D2D4C /* RCTLoadingIndicatorSize.h */; };
 		830A229E1A66C68A008503DA /* RCTRootView.m in Sources */ = {isa = PBXBuildFile; fileRef = 830A229D1A66C68A008503DA /* RCTRootView.m */; };
 		83392EB31B6634E10013B15F /* RCTModalHostViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 83392EB21B6634E10013B15F /* RCTModalHostViewController.m */; };
 		83A1FE8C1B62640A00BE0E65 /* RCTModalHostView.m in Sources */ = {isa = PBXBuildFile; fileRef = 83A1FE8B1B62640A00BE0E65 /* RCTModalHostView.m */; };
@@ -787,6 +788,7 @@
 			dstPath = include/React;
 			dstSubfolderSpec = 16;
 			files = (
+				74A5A0D51E2B45DD003FA06B /* RCTLoadingIndicatorSize.h in Copy Headers */,
 				3D5AC71D1E00572F000F9153 /* RCTTVView.h in Copy Headers */,
 				3D5AC71B1E005723000F9153 /* RCTReloadCommand.h in Copy Headers */,
 				3D5AC71C1E005723000F9153 /* RCTTVNavigationEventEmitter.h in Copy Headers */,

--- a/ReactAndroid/src/main/java/com/facebook/react/views/image/CircleLoadingIndicatorDrawable.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/image/CircleLoadingIndicatorDrawable.java
@@ -1,0 +1,134 @@
+package com.facebook.react.views.image;
+
+import android.graphics.Canvas;
+import android.graphics.ColorFilter;
+import android.graphics.Paint;
+import android.graphics.PixelFormat;
+import android.graphics.Rect;
+import android.graphics.RectF;
+import android.graphics.drawable.Drawable;
+import android.os.Handler;
+
+/**
+ * Created by quang on 12/22/16.
+ */
+public class CircleLoadingIndicatorDrawable extends Drawable {
+    public static final int DEFAULT_COLOR = 0x800080FF;
+    private static final int RADIUS_SMALL = 25;
+    private static final int RADIUS_LARGE = 50;
+    private static final float STROKE_SMALL = 5f;
+    private static final float STROKE_LARGE = 8f;
+
+    private final Paint mPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
+    private int mColor = DEFAULT_COLOR;
+    private int radius = RADIUS_SMALL;
+
+    private float FROM = 270;                   // any value from 0 -> 360
+    private static final long INTERVAL = 30;    // millisecond
+    private static final float STEP = 360/INTERVAL;
+    private float start = FROM, sweep;
+    private Handler handler = new Handler();
+    private boolean increase = true;
+
+    public CircleLoadingIndicatorDrawable() {
+        mPaint.setStyle(Paint.Style.STROKE);
+        mPaint.setStrokeWidth(STROKE_SMALL);
+    }
+
+    public void setRadius(int radius) {
+        this.radius = radius;
+    }
+
+    public void setSize(ImageLoadingIndicatorSize size) {
+        if (size == ImageLoadingIndicatorSize.LARGE) {
+            radius = RADIUS_LARGE;
+            mPaint.setStrokeWidth(STROKE_LARGE);
+        } else {
+            radius = RADIUS_SMALL;
+            mPaint.setStrokeWidth(STROKE_SMALL);
+        }
+    }
+
+    public void setColor(int color) {
+        if (mColor != color) {
+            mColor = color;
+            invalidateSelf();
+        }
+    }
+
+    public int getColor() {
+        return mColor;
+    }
+
+    @Override
+    public void setAlpha(int alpha) {
+        mPaint.setAlpha(alpha);
+    }
+
+    @Override
+    public void setColorFilter(ColorFilter cf) {
+        mPaint.setColorFilter(cf);
+    }
+
+    @Override
+    public int getOpacity() {
+        return getOpacityFromColor(mPaint.getColor());
+    }
+
+    @Override
+    public void draw(Canvas canvas) {
+        drawArc(canvas, mColor);
+        handler.postDelayed(new Runnable() {
+            @Override
+            public void run() {
+                drawStyle1();
+                invalidateSelf();
+            }
+        }, INTERVAL);
+    }
+
+    private void drawStyle1() {
+        sweep = 320;
+        start += STEP;
+        if (start >= 360) start = 0;
+    }
+
+    private void drawStyle2() {
+        if (increase) {
+            sweep += STEP;
+            if (sweep == 360) {
+                increase = false;
+            }
+        } else {
+            sweep -= STEP;
+            start += STEP;
+            if (sweep == 0) {
+                increase = true;
+                FROM += STEP;
+                if (FROM >= 360) FROM = 0;
+                start = FROM;
+            }
+        }
+    }
+
+    private void drawArc(Canvas canvas, int color) {
+        mPaint.setColor(color);
+        Rect bounds = getBounds();
+        int xpos = bounds.left + bounds.width() / 2;
+        int ypos = bounds.bottom - bounds.height() / 2;
+        RectF rectF = new RectF(xpos - radius, ypos - radius, xpos + radius, ypos + radius);
+        canvas.drawArc(rectF, start, sweep, false, mPaint);
+    }
+
+    // reuse code from com.facebook.drawee.drawable.DrawableUtils.getOpacityFromColor(color)
+    public static int getOpacityFromColor(int color) {
+        int colorAlpha = color >>> 24;
+        if (colorAlpha == 255) {
+            return PixelFormat.OPAQUE;
+        } else if (colorAlpha == 0) {
+            return PixelFormat.TRANSPARENT;
+        } else {
+            return PixelFormat.TRANSLUCENT;
+        }
+    }
+}

--- a/ReactAndroid/src/main/java/com/facebook/react/views/image/CircleLoadingIndicatorDrawable.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/image/CircleLoadingIndicatorDrawable.java
@@ -1,3 +1,12 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
 package com.facebook.react.views.image;
 
 import android.graphics.Canvas;
@@ -9,9 +18,6 @@ import android.graphics.RectF;
 import android.graphics.drawable.Drawable;
 import android.os.Handler;
 
-/**
- * Created by quang on 12/22/16.
- */
 public class CircleLoadingIndicatorDrawable extends Drawable {
     public static final int DEFAULT_COLOR = 0x800080FF;
     private static final int RADIUS_SMALL = 25;

--- a/ReactAndroid/src/main/java/com/facebook/react/views/image/ImageLoadingIndicatorSize.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/image/ImageLoadingIndicatorSize.java
@@ -1,8 +1,14 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
 package com.facebook.react.views.image;
 
-/**
- * Created by quang on 1/11/17.
- */
 public enum ImageLoadingIndicatorSize {
     SMALL("small"),
     LARGE("large");

--- a/ReactAndroid/src/main/java/com/facebook/react/views/image/ImageLoadingIndicatorSize.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/image/ImageLoadingIndicatorSize.java
@@ -1,0 +1,31 @@
+package com.facebook.react.views.image;
+
+/**
+ * Created by quang on 1/11/17.
+ */
+public enum ImageLoadingIndicatorSize {
+    SMALL("small"),
+    LARGE("large");
+
+    private static final ImageLoadingIndicatorSize DEFAULT = SMALL;
+
+    private String value;
+    ImageLoadingIndicatorSize(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return this.value;
+    }
+
+    public static ImageLoadingIndicatorSize from(String value) {
+        if (value == null) {
+            return DEFAULT;
+        }
+        switch (value) {
+            case "small": return SMALL;
+            case "large": return LARGE;
+            default: return DEFAULT;
+        }
+    }
+}

--- a/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageManager.java
@@ -87,6 +87,30 @@ public class ReactImageManager extends SimpleViewManager<ReactImageView> {
     view.setLoadingIndicatorSource(source);
   }
 
+  // 2017/01/11 QuangCM added -->
+  @ReactProp(name = "showLoadingIndicator")
+  public void setShowLoadingIndicator(ReactImageView view, boolean show) {
+    view.setShowLoadingIndicator(show);
+  }
+
+  @ReactProp(name = "loadingIndicatorSize")
+  public void setLoadingIndicatorSize(ReactImageView view, @Nullable String size) {
+    view.setLoadingIndicatorSize(ImageLoadingIndicatorSize.from(size));
+  }
+
+  @ReactProp(name = "loadingIndicatorColor", customType = "Color")
+  public void setLoadingIndicatorColor(ReactImageView view, @Nullable Integer color) {
+    if (color != null) {
+      view.setLoadingIndicatorColor(color);
+    }
+  }
+
+  @ReactProp(name = "failureImageSrc")
+  public void setFailureImageSource(ReactImageView view, @Nullable String source) {
+    view.setFailureImageSource(source);
+  }
+  // <-- 2017/01/11 QuangCM added
+
   @ReactProp(name = "borderColor", customType = "Color")
   public void setBorderColor(ReactImageView view, @Nullable Integer borderColor) {
     if (borderColor == null) {

--- a/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageView.java
@@ -169,7 +169,6 @@ public class ReactImageView extends GenericDraweeView {
   private ImageLoadingIndicatorSize mLoadingIndicatorSize;
   private int mLoadingIndicatorColor = CircleLoadingIndicatorDrawable.DEFAULT_COLOR;
   private @Nullable Drawable mFailureImageDrawable;
-  private @Nullable Drawable mLoadingIndicatorDrawable;
   // <-- 2017/01/11 QuangCM added
 
   // We can't specify rounding in XML, so have to do so here

--- a/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageView.java
@@ -164,6 +164,14 @@ public class ReactImageView extends GenericDraweeView {
   private int mFadeDurationMs = -1;
   private boolean mProgressiveRenderingEnabled;
 
+  // 2017/01/11 QuangCM added -->
+  private boolean mShowLoadingIndicator;
+  private ImageLoadingIndicatorSize mLoadingIndicatorSize;
+  private int mLoadingIndicatorColor = CircleLoadingIndicatorDrawable.DEFAULT_COLOR;
+  private @Nullable Drawable mFailureImageDrawable;
+  private @Nullable Drawable mLoadingIndicatorDrawable;
+  // <-- 2017/01/11 QuangCM added
+
   // We can't specify rounding in XML, so have to do so here
   private static GenericDraweeHierarchy buildHierarchy(Context context) {
     return new GenericDraweeHierarchyBuilder(context.getResources())
@@ -306,6 +314,24 @@ public class ReactImageView extends GenericDraweeView {
     mIsDirty = true;
   }
 
+  public void setShowLoadingIndicator(boolean show) {
+    mShowLoadingIndicator = show;
+  }
+
+  public void setLoadingIndicatorSize(ImageLoadingIndicatorSize size) {
+    mLoadingIndicatorSize = size;
+  }
+
+  public void setLoadingIndicatorColor(int color) {
+    mLoadingIndicatorColor = color;
+  }
+
+  public void setFailureImageSource(@Nullable String name) {
+    if (name != null && name.length() > 0) {
+      mFailureImageDrawable = ResourceDrawableIdHelper.getInstance().getResourceDrawable(getContext(), name);
+    }
+  }
+
   public void setProgressiveRenderingEnabled(boolean enabled) {
     mProgressiveRenderingEnabled = enabled;
     // no worth marking as dirty if it already rendered..
@@ -349,9 +375,23 @@ public class ReactImageView extends GenericDraweeView {
     GenericDraweeHierarchy hierarchy = getHierarchy();
     hierarchy.setActualImageScaleType(mScaleType);
 
-    if (mLoadingImageDrawable != null) {
-      hierarchy.setPlaceholderImage(mLoadingImageDrawable, ScalingUtils.ScaleType.CENTER);
+    // 2017/01/11 QuangCM updated -->
+    if (mShowLoadingIndicator) {
+      CircleLoadingIndicatorDrawable clid = new CircleLoadingIndicatorDrawable();
+      clid.setSize(mLoadingIndicatorSize);
+      clid.setColor(mLoadingIndicatorColor);
+      hierarchy.setProgressBarImage(clid);
+    } else {
+      // keep previous logic of loadingIndicatorSource
+      if (mLoadingImageDrawable != null) {
+        hierarchy.setPlaceholderImage(mLoadingImageDrawable, ScalingUtils.ScaleType.CENTER);
+      }
     }
+
+    if (mFailureImageDrawable != null) {
+      hierarchy.setFailureImage(mFailureImageDrawable, ScalingUtils.ScaleType.CENTER_CROP);
+    }
+    // <-- 2017/01/11 QuangCM updated
 
     boolean usePostprocessorScaling =
         mScaleType != ScalingUtils.ScaleType.CENTER_CROP &&


### PR DESCRIPTION
Added some more props for Image component (includes `Image.ios.js` and `Image.android.js`) to show a progress indicator while loading image from URL

- `showLoadingIndicator` - by default, nothing changes if this flag is not used.
- `loadingIndicatorSize` - supports `small` and `large` (similar to `UIActivityIndicatorViewStyleWhite` and `UIActivityIndicatorViewStyleWhiteLarge` of iOS).
- `loadingIndicatorColor` - allows change to any color
- `failureImageSource` - if image loading is failed, then a static local image will be displayed

```javascript
<Image style = {styles.image}
                  source = {{ uri: image_url }}
                  showLoadingIndicator = {true}
                  loadingIndicatorSize = 'large' 
                  loadingIndicatorColor = 'blue'
                  failureImageSource = {require('./noimage.png')}
                  resizeMethod = 'resize'
                  resizeMode = 'cover' />
```