### PR TITLE
Fix Dynamic with reflection based prop setter

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManagersPropertyCache.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManagersPropertyCache.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import android.view.View;
 
 import com.facebook.common.logging.FLog;
+import com.facebook.react.bridge.Dynamic;
 import com.facebook.react.bridge.JSApplicationIllegalArgumentException;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
@@ -259,6 +260,22 @@ import com.facebook.react.uimanager.annotations.ReactPropGroup;
     }
   }
 
+  private static class DynamicPropSetter extends PropSetter {
+
+    public DynamicPropSetter(ReactProp prop, Method setter) {
+      super(prop, "Dynamic", setter);
+    }
+
+    public DynamicPropSetter(ReactPropGroup prop, Method setter, int index) {
+      super(prop, "Dynamic", setter, index);
+    }
+
+    @Override
+    protected @Nullable Object extractProperty(ReactStylesDiffMap props) {
+      return props.getDynamic(mPropName);
+    }
+  }
+
   /*package*/ static Map<String, String> getNativePropsForView(
       Class<? extends ViewManager> viewManagerTopClass,
       Class<? extends ReactShadowNode> shadowNodeTopClass) {
@@ -349,6 +366,8 @@ import com.facebook.react.uimanager.annotations.ReactPropGroup;
       return new ArrayPropSetter(annotation, method);
     } else if (propTypeClass == ReadableMap.class) {
       return new MapPropSetter(annotation, method);
+    } else if (propTypeClass == Dynamic.class) {
+      return new DynamicPropSetter(annotation, method);
     } else {
       throw new RuntimeException("Unrecognized type: " + propTypeClass + " for method: " +
           method.getDeclaringClass().getName() + "#" + method.getName());
@@ -384,6 +403,12 @@ import com.facebook.react.uimanager.annotations.ReactPropGroup;
         props.put(
             names[i],
             new BoxedIntPropSetter(annotation, method, i));
+      }
+    } else if (propTypeClass == Dynamic.class) {
+      for (int i = 0; i < names.length; i++) {
+        props.put(
+            names[i],
+            new DynamicPropSetter(annotation, method, i));
       }
     } else {
       throw new RuntimeException("Unrecognized type: " + propTypeClass + " for method: " +


### PR DESCRIPTION
e3c8d80b3c213711f0a13e0f40372fb7e26b5dfe added support for Dynamic props on Android but didn't add it to `ViewManagersPropertyCache` which is used by the reflection based prop setter that OSS uses when building with gradle.

**Test plan**
Tested that my app doesn't crash anymore :)