### PR TITLE
Fix Android startup exception

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManagersPropertyCache.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManagersPropertyCache.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import android.view.View;
 
 import com.facebook.common.logging.FLog;
+import com.facebook.react.bridge.Dynamic;
 import com.facebook.react.bridge.JSApplicationIllegalArgumentException;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
@@ -112,6 +113,22 @@ import com.facebook.react.uimanager.annotations.ReactPropGroup;
     }
 
     protected abstract @Nullable Object extractProperty(ReactStylesDiffMap props);
+  }
+
+  private static class DynamicPropSetter extends PropSetter {
+
+    public DynamicPropSetter(ReactProp prop, Method setter) {
+      super(prop, "mixed", setter);
+    }
+
+    public DynamicPropSetter(ReactPropGroup prop, Method setter, int index) {
+      super(prop, "mixed", setter, index);
+    }
+
+    @Override
+    protected Object extractProperty(ReactStylesDiffMap props) {
+      return props.getDynamic(mPropName);
+    }
   }
 
   private static class IntPropSetter extends PropSetter {
@@ -331,7 +348,9 @@ import com.facebook.react.uimanager.annotations.ReactPropGroup;
       ReactProp annotation,
       Method method,
       Class<?> propTypeClass) {
-    if (propTypeClass == boolean.class) {
+    if (propTypeClass == Dynamic.class) {
+      return new DynamicPropSetter(annotation, method);
+    } else if (propTypeClass == boolean.class) {
       return new BooleanPropSetter(annotation, method, annotation.defaultBoolean());
     } else if (propTypeClass == int.class) {
       return new IntPropSetter(annotation, method, annotation.defaultInt());
@@ -361,7 +380,13 @@ import com.facebook.react.uimanager.annotations.ReactPropGroup;
       Class<?> propTypeClass,
       Map<String, PropSetter> props) {
     String[] names = annotation.names();
-    if (propTypeClass == int.class) {
+    if (propTypeClass == Dynamic.class) {
+      for (int i = 0; i < names.length; i++) {
+        props.put(
+            names[i],
+            new DynamicPropSetter(annotation, method, i));
+      }
+    } else if (propTypeClass == int.class) {
       for (int i = 0; i < names.length; i++) {
         props.put(
             names[i],


### PR DESCRIPTION
This is an attempt to fix the following startup exception that I get when running any of the example apps:

> Unrecognized type: interface com.facebook.react.bridge.Dynamic for method: com.facebook.react.uimanager.LayoutShadowNode#setFlexBasis

I really have no idea what I'm doing here, just trying to get UIExplorer to compile and run so I can test my upcoming PRs. ~~Unfortunately, this doesn't actually make the apps run, but at least it does get rid of the startup exception!~~ Edit: it works now.

**Test plan:** Run Movies and UIExplorer example app