### PR TITLE
Add xcodePath configuration for run-ios command

### DIFF
--- a/docs/RunningOnSimulatorIOS.md
+++ b/docs/RunningOnSimulatorIOS.md
@@ -17,3 +17,24 @@ Once you have your React Native project initialized, you can run `react-native r
 You can specify the device the simulator should run with the `--simulator` flag, followed by the device name as a string. The default is `"iPhone 6"`. If you wish to run your app on an iPhone 4s, just run `react-native run-ios --simulator="iPhone 4s"`.
 
 The device names correspond to the list of devices available in Xcode. You can check your available devices by running `xcrun simctl list devices` from the console.
+
+## Troubleshooting
+
+*Install your `{ProjectName}.App` file on the simulator*.  You may drag and drop it directly on the Home screen with the latest version.  Read more about the iOS Simulator [here](https://developer.apple.com/library/content/documentation/IDEs/Conceptual/iOS_Simulator_Guide/GettingStartedwithiOSSimulator/GettingStartedwithiOSSimulator.html).
+
+*Finding your `{ProjectName}.App` file:* the default Xcode build path will be in `build/Products/Debug-iphonesimulator/{ProjectName}.app.  Otherwise if you open your Project.xcodeproject or Project.xcworkspace file with Xcode, then you can find your build path under `File > Workspace Settings` then click `Advanced`, if you haven't already select `Custom` and `Relative to Workspace`.  You should see right below it a path for Products, like `build/Products`.  
+
+If you receive this error:
+```
+An error was encountered processing the command (domain=NSPOSIXErrorDomain, code=2):
+Failed to install the requested application
+An application bundle was not found at the provided path.
+Provide a valid path to the desired application bundle.
+Print: Entry, ":CFBundleIdentifier", Does Not Exist
+```
+It is because the xcodebuild tool can not find your `{ProjectName}.App` file.  You can either set the path in two ways.
+1. In Xcode, refer to Finding your .App file.
+2. In the terminal, using the `--xcodePath` command like this
+```
+react-native run-ios --xcodePath 'build/Products'
+```

--- a/docs/RunningOnSimulatorIOS.md
+++ b/docs/RunningOnSimulatorIOS.md
@@ -25,16 +25,17 @@ The device names correspond to the list of devices available in Xcode. You can c
 *Finding your `{ProjectName}.App` file:* the default Xcode build path will be in `build/Products/Debug-iphonesimulator/{ProjectName}.app.`  Otherwise if you open your Project.xcodeproject or Project.xcworkspace file with Xcode, then you can find your build path under `File > Workspace Settings` then click `Advanced`, if you haven't already select `Custom` and `Relative to Workspace`.  You should see right below it a path for Products, like `build/Products`.  
 
 If you receive this error:
-``
+```
 An error was encountered processing the command (domain=NSPOSIXErrorDomain, code=2):
 Failed to install the requested application
 An application bundle was not found at the provided path.
 Provide a valid path to the desired application bundle.
 Print: Entry, ":CFBundleIdentifier", Does Not Exist
-``
+```
+
 It is because the xcodebuild tool can not find your `{ProjectName}.App` file.  You can either set the path in two ways.
 1. In Xcode, refer to Finding your .App file.
 2. In the terminal, using the `--xcodePath` command like this
-``
+```
 react-native run-ios --xcodePath 'build/Products'
-``
+```

--- a/docs/RunningOnSimulatorIOS.md
+++ b/docs/RunningOnSimulatorIOS.md
@@ -22,19 +22,19 @@ The device names correspond to the list of devices available in Xcode. You can c
 
 *Install your `{ProjectName}.App` file on the simulator*.  You may drag and drop it directly on the Home screen with the latest version.  Read more about the iOS Simulator [here](https://developer.apple.com/library/content/documentation/IDEs/Conceptual/iOS_Simulator_Guide/GettingStartedwithiOSSimulator/GettingStartedwithiOSSimulator.html).
 
-*Finding your `{ProjectName}.App` file:* the default Xcode build path will be in `build/Products/Debug-iphonesimulator/{ProjectName}.app.  Otherwise if you open your Project.xcodeproject or Project.xcworkspace file with Xcode, then you can find your build path under `File > Workspace Settings` then click `Advanced`, if you haven't already select `Custom` and `Relative to Workspace`.  You should see right below it a path for Products, like `build/Products`.  
+*Finding your `{ProjectName}.App` file:* the default Xcode build path will be in `build/Products/Debug-iphonesimulator/{ProjectName}.app.`  Otherwise if you open your Project.xcodeproject or Project.xcworkspace file with Xcode, then you can find your build path under `File > Workspace Settings` then click `Advanced`, if you haven't already select `Custom` and `Relative to Workspace`.  You should see right below it a path for Products, like `build/Products`.  
 
 If you receive this error:
-```
+``
 An error was encountered processing the command (domain=NSPOSIXErrorDomain, code=2):
 Failed to install the requested application
 An application bundle was not found at the provided path.
 Provide a valid path to the desired application bundle.
 Print: Entry, ":CFBundleIdentifier", Does Not Exist
-```
+``
 It is because the xcodebuild tool can not find your `{ProjectName}.App` file.  You can either set the path in two ways.
 1. In Xcode, refer to Finding your .App file.
 2. In the terminal, using the `--xcodePath` command like this
-```
+``
 react-native run-ios --xcodePath 'build/Products'
-```
+``

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -93,3 +93,20 @@ If you run into issues where running `react-native init` hangs in your system, t
 ```
 react-native init --verbose
 ```
+
+## Failed to install the requested application
+
+If you receive this error:
+```
+An error was encountered processing the command (domain=NSPOSIXErrorDomain, code=2):
+Failed to install the requested application
+An application bundle was not found at the provided path.
+Provide a valid path to the desired application bundle.
+Print: Entry, ":CFBundleIdentifier", Does Not Exist
+```
+It is because the xcodebuild tool can not find your `{ProjectName}.App` file.  You can either set the path in two ways.
+1. In Xcode, refer to Finding your .App file.
+2. In the terminal, using the `--xcodePath` command like this
+```
+react-native run-ios --xcodePath 'build/Products'
+```


### PR DESCRIPTION
Summary: 
React Native is currently hardcoding the iOS application path to `build/Build/Products`, which I believe is applicable if you have an Xcode Workspace, but a react-native init {ProjectName} will not.  The default application path for Xcode Projects is `build/Products` as of version 8.  I believe this is the cause for a lot of programmers believing the recent React Native release does not work.  Here are some reference cases:
[7308](https://github.com/facebook/react-native/issues/7308)
[1040](https://github.com/facebook/react-native/issues/10401)
[so1](http://stackoverflow.com/questions/37461703/print-entry-cfbundleidentifier-does-not-exist)
[so2](http://stackoverflow.com/questions/39339247/cfbundleidentifier-does-not-exist)

Currently the only way to resolve this issue: 
Setup Xcode to match React Native's hard coded values.
Select: `File > Workspace Settings`, Advanced, Custom, and enter `build/Build/Products`
<img width="545" alt="screen shot 2017-01-13 at 8 14 31 pm" src="https://cloud.githubusercontent.com/assets/7318558/21951260/1cb21190-d9d2-11e6-88aa-60475bee8bed.png">

This PR changes the default application path to `build/Products` and allows programmers to set a configurable `xcodePath` from the command line.
`react-native run-ios --xcodePath 'build/Products'`

This also updates the documentation:
[Troubleshooting](https://github.com/facebook/react-native/tree/master/docs/Troubleshooting.md)
[RunningOnSimulatorIOS](https://github.com/facebook/react-native/tree/master/docs/RunningOnSimulatorIOS.md)
