### PR TITLE
Documentation update: GettingStarted.md

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -207,7 +207,6 @@ Select "SDK Platforms" from within the SDK Manager, then check the box next to "
 - `Google APIs`
 - `Intel x86 Atom System Image`
 - `Intel x86 Atom_64 System Image`
-- `Google APIs Intel x86 Atom_64 System Image`
 
 Next, select "SDK Tools" and check the box next to "Show Package Details" here as well. Look for and expand the "Android SDK Build Tools" entry, then make sure that `Android SDK Build-Tools 23.0.1` is selected.
 


### PR DESCRIPTION
Duplicate entry: `Google APIs Intel x86 Atom_64 System Image` under *3. Install the Android 6.0 (Marshmallow) SDK*

Correct entries in the SDK Manager are: http://i.imgur.com/C8eY046.png