### PR TITLE
Clarify ActionSheetIOSExample.js

### DIFF
--- a/Examples/UIExplorer/js/ActionSheetIOSExample.js
+++ b/Examples/UIExplorer/js/ActionSheetIOSExample.js
@@ -131,9 +131,9 @@ class ShareActionSheetExample extends React.Component {
       ]
     },
     (error) => alert(error),
-    (success, method) => {
+    (completed, method) => {
       var text;
-      if (success) {
+      if (completed) {
         text = `Shared via ${method}`;
       } else {
         text = 'You didn\'t share';
@@ -172,9 +172,9 @@ class ShareScreenshotExample extends React.Component {
         ]
       },
       (error) => alert(error),
-      (success, method) => {
+      (completed, method) => {
         var text;
-        if (success) {
+        if (completed) {
           text = `Shared via ${method}`;
         } else {
           text = 'You didn\'t share';


### PR DESCRIPTION
The `successCallback` passed via `static showShareActionSheetWithOptions(options, failureCallback, successCallback)` has two parameters (see [native code](https://github.com/facebook/react-native/blob/e1577df1fd70049ce7f288f91f6e2b18d512ff4d/Libraries/ActionSheetIOS/RCTActionSheetManager.m#L174)), and the name used for the first parameter in the JS example is confusing. This fixes that.

The first parameter is a boolean indicating whether the user completed the sharing (when TRUE) or cancelled it (when FALSE). Instead of calling it "success" in the example, I propose using `completed`, which is more in line with what you see in the native code. 

Otherwise, we have a "successCallback" function whose first parameter tells us if we were "successful", and that's confusing (indeed, I think it already caused some confusion in the [react-native-share](https://github.com/EstebanFuentealba/react-native-share/) module: see [this issue](https://github.com/EstebanFuentealba/react-native-share/issues/48)).

