### PR TITLE
[MERGE ONLY ONCE TESTS PASS] Re-enable Android e2e test

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -76,7 +76,7 @@ test:
     - node ./scripts/run-android-ci-instrumentation-tests.js --retries 3 --path ./ReactAndroid/src/androidTest/java/com/facebook/react/tests --package com.facebook.react.tests
 
     # Android e2e test
-    # - source scripts/circle-ci-android-setup.sh && retry3 node ./scripts/run-ci-e2e-tests.js --android --js --retries 2
+    - source scripts/circle-ci-android-setup.sh && retry3 node ./scripts/run-ci-e2e-tests.js --android --js --retries 2
 
     # testing docs generation
     - cd website && npm test


### PR DESCRIPTION
Tests were temporarily disabled in https://github.com/facebook/react-native/pull/11894

This should fix them and has landed: https://github.com/facebook/react-native/pull/11896

**Test Plan**

CircleCI tests on this PR. If they pass, merge this.