### PR TITLE
Fix PanResponder.onShouldBlockNativeResponder

### DIFF
--- a/Libraries/Interaction/PanResponder.js
+++ b/Libraries/Interaction/PanResponder.js
@@ -326,6 +326,10 @@ const PanResponder = {
         if (!interactionState.handle) {
           interactionState.handle = InteractionManager.createInteractionHandle();
         }
+        const shouldBlockNativeResponder =
+          config.onShouldBlockNativeResponder === undefined
+            ? true
+            : config.onShouldBlockNativeResponder(e, gestureState);
         gestureState.x0 = currentCentroidX(e.touchHistory);
         gestureState.y0 = currentCentroidY(e.touchHistory);
         gestureState.dx = 0;
@@ -334,9 +338,7 @@ const PanResponder = {
           config.onPanResponderGrant(e, gestureState);
         }
         // TODO: t7467124 investigate if this can be removed
-        return config.onShouldBlockNativeResponder === undefined ?
-          true :
-          config.onShouldBlockNativeResponder();
+        return shouldBlockNativeResponder;
       },
 
       onResponderReject: function (e) {


### PR DESCRIPTION
According to the docs, it's supposed to be called with the same arguments as other methods, but it wasn't. For the arguments to make sense, it needs to be called before the `onPanResponderGrant`, for which the state is reset. Therefore this is a breaking change.

Tested this working on iOS.

Changing the docs instead doesn't really work for my usecase, where I need the args (I am finishing my gesture async given the theft of touch can't be prevented on iOS).