### PR TITLE
Android - Update Gradle to 2.2.3

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Sep 08 16:27:36 BST 2016
+#Mon Jan 16 11:21:59 CST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/local-cli/templates/HelloWorld/android/build.gradle
+++ b/local-cli/templates/HelloWorld/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.3.1'
+        classpath 'com.android.tools.build:gradle:2.2.3'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/local-cli/templates/HelloWorld/android/gradle/wrapper/gradle-wrapper.properties
+++ b/local-cli/templates/HelloWorld/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip


### PR DESCRIPTION
## Overview

Currently React Native's local cli is a bit behind in its android gradle plugin version. This PR is an attempt to update the local cli, to allow for better support moving forward.
* Updates the gradle plugin version to 2.2.3
* Updates the gradle wrapper to 2.14.1
* Uses the `all` for the project wrapper to include sources for API completion

**Test plan (required)**

* Perform all required steps here: https://github.com/facebook/react-native/tree/master/react-native-cli
   * Run the local npm tests and e2e tests (no longer available)
   * Test the local cli by using Sinopia

Make sure tests pass on both Travis and Circle CI.

TO NOTE: In a previous issue (https://github.com/facebook/react-native/issues/11500) I was able to update to 2.2.3 comfortably, however there may be other issue I am not aware of. This PR is intended to start discussion on what it will take to update.