### PR TITLE
Add softInputMode prop for Modal on Android

### DIFF
--- a/Libraries/Modal/Modal.js
+++ b/Libraries/Modal/Modal.js
@@ -90,6 +90,16 @@ class Modal extends React.Component {
      */
     animationType: PropTypes.oneOf(['none', 'slide', 'fade']),
     /**
+     * The `softInputMode` prop controls soft input mode for the modal window.
+     *
+     * - `unspecified` The system will try to pick a mode, `resize` or `pan`.
+     * - `resize` Window is resized when an input method is shown. This mode is ignored if the window is fullscreen.
+     * - `pan` Window is panned to ensure the current input focus is visible.
+     * - `nothing` Window is neither resized nor panned when an input method is shown.
+     * @platform android
+     */
+    softInputMode: PropTypes.oneOf(['unspecified', 'resize', 'pan', 'nothing']),
+    /**
      * The `transparent` prop determines whether your modal will fill the entire view. Setting this to `true` will render the modal over a transparent background.
      */
     transparent: PropTypes.bool,
@@ -132,6 +142,7 @@ class Modal extends React.Component {
   static defaultProps = {
     visible: true,
     hardwareAccelerated: false,
+    softInputMode: 'resize',
   };
 
   static contextTypes = {
@@ -165,6 +176,7 @@ class Modal extends React.Component {
     return (
       <RCTModalHostView
         animationType={animationType}
+        softInputMode={this.props.softInputMode}
         transparent={this.props.transparent}
         hardwareAccelerated={this.props.hardwareAccelerated}
         onRequestClose={this.props.onRequestClose}

--- a/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostManager.java
@@ -61,6 +61,11 @@ public class ReactModalHostManager extends ViewGroupManager<ReactModalHostView> 
     view.setAnimationType(animationType);
   }
 
+  @ReactProp(name = "softInputMode")
+  public void setSoftInputMode(ReactModalHostView view, String softInputMode) {
+    view.setSoftInputMode(softInputMode);
+  }
+
   @ReactProp(name = "transparent")
   public void setTransparent(ReactModalHostView view, boolean transparent) {
     view.setTransparent(transparent);

--- a/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.java
@@ -61,6 +61,7 @@ public class ReactModalHostView extends ViewGroup implements LifecycleEventListe
   private @Nullable Dialog mDialog;
   private boolean mTransparent;
   private String mAnimationType;
+  private String mSoftInputMode;
   private boolean mHardwareAccelerated;
   // Set this flag to true if changing a particular property on the view requires a new Dialog to
   // be created.  For instance, animation does since it affects Dialog creation through the theme
@@ -154,6 +155,10 @@ public class ReactModalHostView extends ViewGroup implements LifecycleEventListe
     mPropertyRequiresNewDialog = true;
   }
 
+  protected void setSoftInputMode(String softInputMode) {
+    mSoftInputMode = softInputMode;
+  }
+
   protected void setHardwareAccelerated(boolean hardwareAccelerated) {
     mHardwareAccelerated = hardwareAccelerated;
     mPropertyRequiresNewDialog = true;
@@ -242,7 +247,6 @@ public class ReactModalHostView extends ViewGroup implements LifecycleEventListe
         }
       });
 
-    mDialog.getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE);
     if (mHardwareAccelerated) {
       mDialog.getWindow().addFlags(WindowManager.LayoutParams.FLAG_HARDWARE_ACCELERATED);
     }
@@ -277,6 +281,18 @@ public class ReactModalHostView extends ViewGroup implements LifecycleEventListe
       mDialog.getWindow().setFlags(
           WindowManager.LayoutParams.FLAG_DIM_BEHIND,
           WindowManager.LayoutParams.FLAG_DIM_BEHIND);
+    }
+
+    switch (mSoftInputMode) {
+      case "resize":
+        mDialog.getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE);
+        break;
+      case "pan":
+        mDialog.getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_PAN);
+        break;
+      case "nothing":
+        mDialog.getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_NOTHING);
+        break;
     }
   }
 


### PR DESCRIPTION
On Android, currently set default `SOFT_INPUT_ADJUST_RESIZE` for modal windows is ignored if the window is fullscreen and this usually breaks apps. So, with this property, it is possible to set how the window is treated when an input method is shown on Android. The mode `nothing` works like how it is on iOS, which doesn't do any resizing and the developer has to take care of it.

The default value for the property is `resize` as it was hardcoded before.

**Test plan (required)**

Open a modal window and set `softInputMode` property. Does nothing on iOS.