### PR TITLE
Support copy to clipboard on Windows

### DIFF
--- a/local-cli/.eslintrc
+++ b/local-cli/.eslintrc
@@ -2,5 +2,8 @@
   "rules": {
     "extra-arrow-initializer": 0,
     "no-console-disallow": 0
+  },
+  "env": {
+    "node": true
   }
 }

--- a/local-cli/server/util/copyToClipBoard.js
+++ b/local-cli/server/util/copyToClipBoard.js
@@ -24,7 +24,7 @@ function copyToClipBoard(content) {
   case 'win32':
     var child = spawn('clip', []);
     child.stdin.end(new Buffer(content, 'utf8'));
-   return true;
+    return true;
   default:
     return false;
   }

--- a/local-cli/server/util/copyToClipBoard.js
+++ b/local-cli/server/util/copyToClipBoard.js
@@ -13,7 +13,7 @@ var spawn = child_process.spawn;
 
 /**
  * Copy the content to host system clipboard.
- * This is only supported on Mac for now.
+ * This is only supported on Mac and Windows for now.
  */
 function copyToClipBoard(content) {
   switch (process.platform) {
@@ -21,6 +21,10 @@ function copyToClipBoard(content) {
     var child = spawn('pbcopy', []);
     child.stdin.end(new Buffer(content, 'utf8'));
     return true;
+  case 'win32':
+    var child = spawn('clip', []);
+    child.stdin.end(new Buffer(content, 'utf8'));
+   return true;
   default:
     return false;
   }


### PR DESCRIPTION
Also fix lint errors about Buffer being undefined by adding env: node to the eslint config for local-cli.

Tested on windows 10.