### PR TITLE
Fix issue in removing items with LayoutAnimation on Android. When LayoutAnimation is enabled, indicesToRemove are incorrect, which makes adjacent views disappear.

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeViewHierarchyManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeViewHierarchyManager.java
@@ -323,8 +323,13 @@ public class NativeViewHierarchyManager {
                 tagsToDelete));
     }
 
+    // Remove views whose indices are in indicesToRemove only when LayoutAnimation is not enabled.
+    // When LayoutAnimation is enabled, indicesToRemove are incorrect, and we should depend on
+    // tagsToDelete. The views with tags in tagsToDelete will be removed and dropped by the 'delete'
+    // layout animation.
     int lastIndexToRemove = viewManager.getChildCount(viewToManage);
-    if (indicesToRemove != null) {
+    if (!(mLayoutAnimationEnabled && mLayoutAnimator.shouldAnimateLayoutChildrenInView(viewToManage))
+            && indicesToRemove != null) {
       for (int i = indicesToRemove.length - 1; i >= 0; i--) {
         int indexToRemove = indicesToRemove[i];
         if (indexToRemove < 0) {
@@ -361,17 +366,7 @@ public class NativeViewHierarchyManager {
                       tagsToDelete));
         }
 
-        View viewToRemove = viewManager.getChildAt(viewToManage, indexToRemove);
-
-        if (mLayoutAnimationEnabled &&
-            mLayoutAnimator.shouldAnimateLayout(viewToRemove) &&
-            arrayContains(tagsToDelete, viewToRemove.getId())) {
-          // The view will be removed and dropped by the 'delete' layout animation
-          // instead, so do nothing
-        } else {
-          viewManager.removeViewAt(viewToManage, indexToRemove);
-        }
-
+        viewManager.removeViewAt(viewToManage, indexToRemove);
         lastIndexToRemove = indexToRemove;
       }
     }

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeViewHierarchyManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeViewHierarchyManager.java
@@ -328,7 +328,7 @@ public class NativeViewHierarchyManager {
     // tagsToDelete. The views with tags in tagsToDelete will be removed and dropped by the 'delete'
     // layout animation.
     int lastIndexToRemove = viewManager.getChildCount(viewToManage);
-    if (!(mLayoutAnimationEnabled && mLayoutAnimator.shouldAnimateLayoutChildrenInView(viewToManage))
+    if (!(mLayoutAnimationEnabled && mLayoutAnimator.shouldAnimateLayout(viewToManage))
             && indicesToRemove != null) {
       for (int i = indicesToRemove.length - 1; i >= 0; i--) {
         int indexToRemove = indicesToRemove[i];

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/LayoutAnimationController.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/LayoutAnimationController.java
@@ -65,6 +65,10 @@ public class LayoutAnimationController {
     mShouldAnimateLayout = false;
   }
 
+  public boolean shouldAnimateLayoutChildrenInView(View parentView) {
+    return mShouldAnimateLayout && parentView != null;
+  }
+
   public boolean shouldAnimateLayout(View viewToAnimate) {
     // if view parent is null, skip animation: view have been clipped, we don't want animation to
     // resume when view is re-attached to parent, which is the standard android animation behavior.

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/LayoutAnimationController.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/LayoutAnimationController.java
@@ -65,10 +65,6 @@ public class LayoutAnimationController {
     mShouldAnimateLayout = false;
   }
 
-  public boolean shouldAnimateLayoutChildrenInView(View parentView) {
-    return mShouldAnimateLayout && parentView != null;
-  }
-
   public boolean shouldAnimateLayout(View viewToAnimate) {
     // if view parent is null, skip animation: view have been clipped, we don't want animation to
     // resume when view is re-attached to parent, which is the standard android animation behavior.


### PR DESCRIPTION
Fix issue #11828 Removing items with LayoutAnimation causes adjacent views/texts to disappear on Android

![Screenshot](https://github.com/vinceyuan/ReactNativeOpacityBugDemo/raw/master/ReactNativeOpacityBug3.gif)

I explained my solution in https://github.com/facebook/react-native/issues/11828#issuecomment-273434006