### PR TITLE
Reference to clearText() must be bound

### DIFF
--- a/docs/DirectManipulation.md
+++ b/docs/DirectManipulation.md
@@ -189,7 +189,7 @@ class App extends React.Component {
       <View style={styles.container}>
         <TextInput ref={component => this._textInput = component}
                    style={styles.textInput} />
-        <TouchableOpacity onPress={this.clearText}>
+        <TouchableOpacity onPress={this.clearText.bind(this)}>
           <Text>Clear text</Text>
         </TouchableOpacity>
       </View>


### PR DESCRIPTION
> Explain the **motivation** for making this change. What existing problem does the pull request solve?

Error in example in docs. Let's fix that :)

onPress references directly to function without current element reference, which means `this` is not available.

`bind()` is just one method. There's no clear guideline on what way to bind. Another way would be to define the function as a class property using an arrow function. Chose `bind()` since it has less "magic" syntax.