### PR TITLE
Updated Systrace and RCTRenderingPerf to sync w/ React changes

### DIFF
--- a/Libraries/Performance/RCTRenderingPerf.js
+++ b/Libraries/Performance/RCTRenderingPerf.js
@@ -54,7 +54,7 @@ var RCTRenderingPerf = {
     }
 
     ReactPerf.start();
-    ReactDebugTool.addDevtool(RCTRenderingPerfDevtool);
+    ReactDebugTool.addHook(RCTRenderingPerfDevtool);
     perfModules.forEach((module) => module.start());
   },
 
@@ -66,7 +66,7 @@ var RCTRenderingPerf = {
     ReactPerf.stop();
     ReactPerf.printInclusive();
     ReactPerf.printWasted();
-    ReactDebugTool.removeDevtool(RCTRenderingPerfDevtool);
+    ReactDebugTool.removeHook(RCTRenderingPerfDevtool);
 
     console.log(`Total time spent in render(): ${totalRenderDuration.toFixed(2)} ms`);
     lastRenderStartTime = 0;

--- a/Libraries/Performance/Systrace.js
+++ b/Libraries/Performance/Systrace.js
@@ -32,28 +32,28 @@ let _asyncCookie = 0;
 
 const ReactSystraceDevtool = __DEV__ ? {
   onBeforeMountComponent(debugID) {
-    const displayName = require('react/lib/ReactComponentTreeDevtool').getDisplayName(debugID);
+    const displayName = require('react/lib/ReactComponentTreeHook').getDisplayName(debugID);
     Systrace.beginEvent(`ReactReconciler.mountComponent(${displayName})`);
   },
   onMountComponent(debugID) {
     Systrace.endEvent();
   },
   onBeforeUpdateComponent(debugID) {
-    const displayName = require('react/lib/ReactComponentTreeDevtool').getDisplayName(debugID);
+    const displayName = require('react/lib/ReactComponentTreeHook').getDisplayName(debugID);
     Systrace.beginEvent(`ReactReconciler.updateComponent(${displayName})`);
   },
   onUpdateComponent(debugID) {
     Systrace.endEvent();
   },
   onBeforeUnmountComponent(debugID) {
-    const displayName = require('react/lib/ReactComponentTreeDevtool').getDisplayName(debugID);
+    const displayName = require('react/lib/ReactComponentTreeHook').getDisplayName(debugID);
     Systrace.beginEvent(`ReactReconciler.unmountComponent(${displayName})`);
   },
   onUnmountComponent(debugID) {
     Systrace.endEvent();
   },
   onBeginLifeCycleTimer(debugID, timerType) {
-    const displayName = require('react/lib/ReactComponentTreeDevtool').getDisplayName(debugID);
+    const displayName = require('react/lib/ReactComponentTreeHook').getDisplayName(debugID);
     Systrace.beginEvent(`${displayName}.${timerType}()`);
   },
   onEndLifeCycleTimer(debugID, timerType) {
@@ -67,10 +67,10 @@ const Systrace = {
       if (__DEV__) {
         if (enabled) {
           global.nativeTraceBeginLegacy && global.nativeTraceBeginLegacy(TRACE_TAG_JSC_CALLS);
-          require('ReactDebugTool').addDevtool(ReactSystraceDevtool);
+          require('ReactDebugTool').addHook(ReactSystraceDevtool);
         } else {
           global.nativeTraceEndLegacy && global.nativeTraceEndLegacy(TRACE_TAG_JSC_CALLS);
-          require('ReactDebugTool').removeDevtool(ReactSystraceDevtool);
+          require('ReactDebugTool').removeHook(ReactSystraceDevtool);
         }
       }
       _enabled = enabled;

--- a/Libraries/Renderer/src/renderers/shared/ReactDebugTool.js
+++ b/Libraries/Renderer/src/renderers/shared/ReactDebugTool.js
@@ -409,10 +409,6 @@ var ReactDebugTool = {
   },
 };
 
-// TODO remove these when RN/www gets updated
-(ReactDebugTool: any).addDevtool = ReactDebugTool.addHook;
-(ReactDebugTool: any).removeDevtool = ReactDebugTool.removeHook;
-
 ReactDebugTool.addHook(ReactInvalidSetStateWarningHook);
 ReactDebugTool.addHook(ReactComponentTreeHook);
 var url = (ExecutionEnvironment.canUseDOM && window.location.href) || '';


### PR DESCRIPTION
A temporary React Native compatibility fix was added to React in commit [bba0d99](https://github.com/facebook/react/commit/bba0d992d8f4ecf9cf6677817a1218e7f48a8a77) and subsequently removed in commit [e612826](https://github.com/facebook/react/commit/e612826650ff68e73bff4d71db01fea8147ee1fd). I noticed this while testing the React Native fiber renderer and attempting to use `Systrace`.

This commit updates React Native to no longer rely on the deprecated method and module.

PS I'm not sure if I should also update `ReactDebugTool` with this commit or wait for a subsequent sync script to update it. I haven't committed to this repo before. Please advise. 😄 
