### PR TITLE
Fix typo in ResolutionRequest.js

### DIFF
--- a/packager/react-packager/src/node-haste/DependencyGraph/ResolutionRequest.js
+++ b/packager/react-packager/src/node-haste/DependencyGraph/ResolutionRequest.js
@@ -372,7 +372,7 @@ class ResolutionRequest {
               `To resolve try the following:\n` +
               `  1. Clear watchman watches: \`watchman watch-del-all\`.\n` +
               `  2. Delete the \`node_modules\` folder: \`rm -rf node_modules && npm install\`.\n` +
-              '  3. Reset packager cache: `rm -fr $TMPDIR/react-*` or `npm start -- --reset-cache`.'
+              '  3. Reset packager cache: `rm -fr $TMPDIR/react-*` or `npm start --reset-cache`.'
             );
           });
         });


### PR DESCRIPTION
Small fix:
Fix typo in error message - should be `npm start --reset-cache`
