### PR TITLE
Run application using package.json scripts

### DIFF
--- a/react-native-cli/index.js
+++ b/react-native-cli/index.js
@@ -240,7 +240,9 @@ function createProject(name, options) {
     version: '0.0.1',
     private: true,
     scripts: {
-      start: 'node node_modules/react-native/local-cli/cli.js start'
+      start: 'node node_modules/react-native/local-cli/cli.js start',
+      ios: 'react-native run-ios',
+      android: 'react-native run-android',
     }
   };
   fs.writeFileSync(path.join(root, 'package.json'), JSON.stringify(packageJson));


### PR DESCRIPTION
**Motivation:**
According to the meeting notes published by @mkonicek yesterday, RN should support `yarn run ios` and `yarn run android` commands.

**Test plan (required)**
- [x] Generate a new project and start scaffolded app using `yarn(npm) run ios(android)`