### PR TITLE
Sync with Resolver/polyfills/require.js

### DIFF
--- a/packager/react-packager/src/ModuleGraph/worker/__tests__/optimize-module-test.js
+++ b/packager/react-packager/src/ModuleGraph/worker/__tests__/optimize-module-test.js
@@ -54,7 +54,7 @@ describe('optimizing JS modules', () => {
       const result = optimizeModule(transformResult, optimizationOptions);
       optimized = result.transformed.default;
       injectedVars = optimized.code.match(/function\(([^)]*)/)[1].split(',');
-      [requireName,,,, dependencyMapName] = injectedVars;
+      [,requireName,,, dependencyMapName] = injectedVars;
     });
 
     it('optimizes code', () => {

--- a/packager/react-packager/src/ModuleGraph/worker/__tests__/transform-module-test.js
+++ b/packager/react-packager/src/ModuleGraph/worker/__tests__/transform-module-test.js
@@ -105,7 +105,7 @@ describe('transforming JS modules:', () => {
       const {code, dependencyMapName} = result.transformed.default;
       expect(code.replace(/\s+/g, ''))
         .toEqual(
-          `__d(function(require,module,global,exports,${
+          `__d(function(global,require,module,exports,${
           dependencyMapName}){${transformedCode}});`
         );
       done();
@@ -159,12 +159,12 @@ describe('transforming JS modules:', () => {
       const {dev, prod} = result.transformed;
       expect(dev.code.replace(/\s+/g, ''))
         .toEqual(
-          `__d(function(require,module,global,exports,${
+          `__d(function(global,require,module,exports,${
           dev.dependencyMapName}){arbitrary(code);});`
         );
       expect(prod.code.replace(/\s+/g, ''))
         .toEqual(
-          `__d(function(require,module,global,exports,${
+          `__d(function(global,require,module,exports,${
           prod.dependencyMapName}){arbitrary(code);});`
         );
       done();
@@ -178,7 +178,7 @@ describe('transforming JS modules:', () => {
       const {code} = result.transformed.default;
       expect(code.replace(/\s+/g, ''))
         .toEqual(
-          '__d(function(require,module,global,exports){' +
+          '__d(function(global,require,module,exports){' +
           `module.exports=${json}});`
         );
       done();

--- a/packager/react-packager/src/ModuleGraph/worker/transform-module.js
+++ b/packager/react-packager/src/ModuleGraph/worker/transform-module.js
@@ -35,7 +35,7 @@ export type TransformOptions = {|
 |};
 
 const defaultVariants = {default: {}};
-const moduleFactoryParameters = ['require', 'module', 'global', 'exports'];
+const moduleFactoryParameters = ['global', 'require', 'module', 'exports'];
 const polyfillFactoryParameters = ['global'];
 
 function transformModule(


### PR DESCRIPTION
I don't know which version is better, but it should sync with `Resolver/polyfills/require.js: 168`
```js
    // keep args in sync with with defineModuleCode in
    // packager/react-packager/src/Resolver/index.js
    // and packager/react-packager/src/ModuleGraph/worker.js
    factory(global, require, moduleObject, exports, dependencyMap);
```