### PR TITLE
Expose StatusBar height on iOS

### DIFF
--- a/Examples/UIExplorer/js/StatusBarExample.js
+++ b/Examples/UIExplorer/js/StatusBarExample.js
@@ -438,11 +438,10 @@ const examples = [{
   render() {
     return (
       <View>
-        <Text>Height (Android only): {StatusBar.currentHeight} pts</Text>
+        <Text>Height: {StatusBar.currentHeight} pts</Text>
       </View>
     );
   },
-  platform: 'android',
 }];
 
 exports.examples = examples;

--- a/Libraries/Components/StatusBar/StatusBar.js
+++ b/Libraries/Components/StatusBar/StatusBar.js
@@ -134,7 +134,7 @@ function createStackEntry(props: any): any {
  *
  * ### Constants
  *
- * `currentHeight` (Android only) The height of the status bar.
+ * `currentHeight` The height of the status bar.
  */
 class StatusBar extends React.Component {
   props: {
@@ -169,8 +169,6 @@ class StatusBar extends React.Component {
   // discussion in #6195.
   /**
    * The current height of the status bar on the device.
-   *
-   * @platform android
    */
   static currentHeight = StatusBarManager.HEIGHT;
 

--- a/React/Modules/RCTStatusBarManager.m
+++ b/React/Modules/RCTStatusBarManager.m
@@ -132,6 +132,13 @@ RCT_EXPORT_METHOD(setNetworkActivityIndicatorVisible:(BOOL)visible)
   RCTSharedApplication().networkActivityIndicatorVisible = visible;
 }
 
+- (NSDictionary *)constantsToExport
+{
+  return @{
+    @"HEIGHT": @([UIApplication sharedApplication].statusBarFrame.size.height)
+  };
+}
+
 #endif //TARGET_OS_TV
 
 @end


### PR DESCRIPTION
Following the PR https://github.com/facebook/react-native/pull/6195, this adds a `HEIGHT` constant on `StatusBar` for iOS.

Combined with `statusBarFrameDidChange` and `statusBarFrameWillChange` StatusBar native events, it solves various problems with In-Call cellar bar / Location bar / others 40pt status bars, and offers a correct `keyboardVerticalOffset` value for the KeyboardAvoidingView component.