### PR TITLE
Adds video support to react-native link

### DIFF
--- a/local-cli/link/android/copyAssets.js
+++ b/local-cli/link/android/copyAssets.js
@@ -6,12 +6,17 @@ const groupFilesByType = require('../groupFilesByType');
  * Copies each file from an array of assets provided to targetPath directory
  *
  * For now, the only types of files that are handled are:
- * - Fonts (otf, ttf) - copied to targetPath/fonts under original name
+ * - Fonts (otf, ttf) - copied to targetPath/fonts
+ * - Videos (mp4, 3gp, etc.) - copied to targetPath/videos
  */
 module.exports = function copyAssetsAndroid(files, targetPath) {
   const assets = groupFilesByType(files);
 
   (assets.font || []).forEach(asset =>
     fs.copySync(asset, path.join(targetPath, 'fonts', path.basename(asset)))
+  );
+
+  (assets.video || []).forEach(asset =>
+    fs.copySync(asset, path.join(targetPath, 'videos', path.basename(asset)))
   );
 };

--- a/local-cli/link/ios/copyAssets.js
+++ b/local-cli/link/ios/copyAssets.js
@@ -9,8 +9,8 @@ const getPlist = require('./getPlist');
 const getPlistPath = require('./getPlistPath');
 
 /**
- * This function works in a similar manner to its Android version,
- * except it does not copy fonts but creates XCode Group references
+ * Creates XCode Group references and plist entries for custom fonts
+ * and links video files in Resources.
  */
 module.exports = function linkAssetsIOS(files, projectConfig) {
   const project = xcode.project(projectConfig.pbxprojPath).parseSync();
@@ -19,15 +19,20 @@ module.exports = function linkAssetsIOS(files, projectConfig) {
 
   createGroupWithMessage(project, 'Resources');
 
-  const fonts = (assets.font || [])
-    .map(asset =>
-      project.addResourceFile(
-        path.relative(projectConfig.sourceDir, asset),
-        { target: project.getFirstTarget().uuid }
+  const addResourcesOfType = (type) => {
+    return (assets[type] || [])
+      .map(asset =>
+        project.addResourceFile(
+          path.relative(projectConfig.sourceDir, asset),
+          { target: project.getFirstTarget().uuid }
+        )
       )
-    )
-    .filter(file => file)   // xcode returns false if file is already there
-    .map(file => file.basename);
+      .filter(file => file)   // xcode returns false if file is already there
+      .map(file => file.basename);
+  };
+
+  addResourcesOfType('video')
+  const fonts = addResourcesOfType('font')
 
   plist.UIAppFonts = (plist.UIAppFonts || []).concat(fonts);
 

--- a/local-cli/link/ios/copyAssets.js
+++ b/local-cli/link/ios/copyAssets.js
@@ -31,8 +31,8 @@ module.exports = function linkAssetsIOS(files, projectConfig) {
       .map(file => file.basename);
   };
 
-  addResourcesOfType('video')
-  const fonts = addResourcesOfType('font')
+  addResourcesOfType('video');
+  const fonts = addResourcesOfType('font');
 
   plist.UIAppFonts = (plist.UIAppFonts || []).concat(fonts);
 


### PR DESCRIPTION
The React Native packager doesn't support static videos. (Could it? that would be a better solution than this if so...) This PR adds support for videos in `react-native link` for iOS when configured in the package.json like this,

```
  "rnpm": {
    "assets": [
      "assets/fonts",
      "assets/videos"
    ]
  },
```

The files are copied into the `Resources` folder in the Xcode project for iOS, similarly to fonts but without the plist step. For Android the files are copied into `Assets/videos`.

**Test plan**

The file `local-cli/link/__tests__/link.spec.js` should be updated to include a mock MP4 file. I haven't done that here as it is unclear to me how the mock files are handled (e.g. https://github.com/facebook/react-native/blob/master/local-cli/link/__tests__/link.spec.js#L183-L186).

I've tested manually with fonts and videos in Xcode.

I have not manually tested Android.

Would love some help with testing to improve this PR!

CC @Kureev @grabbou 