### PR TITLE
Don't add duplicate font entries to plist during link (iOS)

### DIFF
--- a/local-cli/link/ios/copyAssets.js
+++ b/local-cli/link/ios/copyAssets.js
@@ -29,7 +29,9 @@ module.exports = function linkAssetsIOS(files, projectConfig) {
     .filter(file => file)   // xcode returns false if file is already there
     .map(file => file.basename);
 
-  plist.UIAppFonts = Array.from(new Set([...(plist.UIAppFonts || []), ...fonts]));
+  const existingFonts = (plist.UIAppFonts || []);
+  const allFonts = [...existingFonts, ...fonts];
+  plist.UIAppFonts = Array.from(new Set(allFonts)); // use Set to dedupe w/existing
 
   fs.writeFileSync(
     projectConfig.pbxprojPath,

--- a/local-cli/link/ios/copyAssets.js
+++ b/local-cli/link/ios/copyAssets.js
@@ -29,7 +29,7 @@ module.exports = function linkAssetsIOS(files, projectConfig) {
     .filter(file => file)   // xcode returns false if file is already there
     .map(file => file.basename);
 
-  plist.UIAppFonts = (plist.UIAppFonts || []).concat(fonts);
+  plist.UIAppFonts = Array.from(new Set([...(plist.UIAppFonts || []), ...fonts]));
 
   fs.writeFileSync(
     projectConfig.pbxprojPath,


### PR DESCRIPTION
**Test plan**

1. Add fonts using `react-native link` and a `"rnpm"` config in package.json
2. Manually delete one or more fonts from Xcode's Resources folder using Remove References option
3. Run `react-native link` again

With the patch in this PR, the plist will not accidentally get populated with duplicate entries.