### PR TITLE
[Android] saveToCameraRoll should use DCIM folder

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/modules/camera/CameraRollManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/camera/CameraRollManager.java
@@ -113,25 +113,21 @@ public class CameraRollManager extends ReactContextBaseJavaModule {
    */
   @ReactMethod
   public void saveToCameraRoll(String uri, String type, Promise promise) {
-    MediaType parsedType = type.equals("video") ? MediaType.VIDEO : MediaType.PHOTO;
-    new SaveToCameraRoll(getReactApplicationContext(), Uri.parse(uri), parsedType, promise)
+    new SaveToCameraRoll(getReactApplicationContext(), Uri.parse(uri), promise)
         .executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
   }
 
-  private enum MediaType { PHOTO, VIDEO };
   private static class SaveToCameraRoll extends GuardedAsyncTask<Void, Void> {
 
     private final Context mContext;
     private final Uri mUri;
     private final Promise mPromise;
-    private final MediaType mType;
 
-    public SaveToCameraRoll(ReactContext context, Uri uri, MediaType type, Promise promise) {
+    public SaveToCameraRoll(ReactContext context, Uri uri, Promise promise) {
       super(context);
       mContext = context;
       mUri = uri;
       mPromise = promise;
-      mType = type;
     }
 
     @Override
@@ -139,9 +135,7 @@ public class CameraRollManager extends ReactContextBaseJavaModule {
       File source = new File(mUri.getPath());
       FileChannel input = null, output = null;
       try {
-        File exportDir = (mType == MediaType.PHOTO)
-          ? Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES)
-          : Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_MOVIES);
+        File exportDir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DCIM);
         exportDir.mkdirs();
         if (!exportDir.isDirectory()) {
           mPromise.reject(ERROR_UNABLE_TO_LOAD, "External media storage directory not available");


### PR DESCRIPTION
## Motivation
The DCIM folder is a better mapping to a "CameraRoll" than the "movies" or "pictures" directories.

https://developer.android.com/reference/android/os/Environment.html#DIRECTORY_DCIM
```
DIRECTORY_DCIM
The traditional location for pictures and videos when mounting the device as a camera. 
Note that this is primarily a convention for the top-level public directory, as this convention makes no sense elsewhere.
```

**Test plan**

- Make sure tests pass on both Travis and Circle CI.
- Test `saveToCameraRoll` in an example app, and check it is saved to the expected folder in a photos app.
