### PR TITLE
[Apple TV] Bug fix for nil TVView on pop

### DIFF
--- a/React/Views/RCTTVView.m
+++ b/React/Views/RCTTVView.m
@@ -173,10 +173,10 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:unused)
   if (hasTVPreferredFocus) {
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1.0 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
       UIView *rootview = self;
-      while(![rootview isReactRootView] && rootview != nil) {
+      while (![rootview isReactRootView] && rootview != nil) {
         rootview = [rootview superview];
       }
-      if(rootview == nil) return;
+      if (rootview == nil) return;
 
       rootview = [rootview superview];
 

--- a/React/Views/RCTTVView.m
+++ b/React/Views/RCTTVView.m
@@ -173,9 +173,11 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:unused)
   if (hasTVPreferredFocus) {
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1.0 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
       UIView *rootview = self;
-      while(![rootview isReactRootView]) {
+      while(![rootview isReactRootView] && rootview != nil) {
         rootview = [rootview superview];
       }
+      if(rootview == nil) return;
+
       rootview = [rootview superview];
 
       [(RCTRootView *)rootview setReactPreferredFocusedView:self];


### PR DESCRIPTION
Explain the **motivation** for making this change. What existing problem does the pull request solve?

This change is required when you try to set a focus on a view that doesn't exist and thus cannot be focused. In my specific use case, this occurred when trying to set a focus on a list item in a setInterval when the View (with the specific list item) had been popped. The while loop ran infinitely (eventually freezing the app) since the rootView doesn't exist. This adds that check and breaks out if so.

All obj-c tests ran successfully. 

@dlowder-salesforce 
