### PR TITLE
Remove unused imports in Android template

### DIFF
--- a/local-cli/templates/HelloWorld/android/app/src/main/java/com/helloworld/MainApplication.java
+++ b/local-cli/templates/HelloWorld/android/app/src/main/java/com/helloworld/MainApplication.java
@@ -1,10 +1,8 @@
 package com.helloworld;
 
 import android.app.Application;
-import android.util.Log;
 
 import com.facebook.react.ReactApplication;
-import com.facebook.react.ReactInstanceManager;
 import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactPackage;
 import com.facebook.react.shell.MainReactPackage;


### PR DESCRIPTION
When installing template by `react-native init AwesomeProject` and adding checkstyle to the Gradle setup, it will complain about unused imports