### PR TITLE
Add scrollToEnd to ScrollView and ListView

### DIFF
--- a/Examples/UIExplorer/js/ScrollViewExample.js
+++ b/Examples/UIExplorer/js/ScrollViewExample.js
@@ -59,7 +59,7 @@ exports.examples = [
         </TouchableOpacity>
         <TouchableOpacity
           style={styles.button}
-          onPress={() => { _scrollView.scrollToBottom(); }}>
+          onPress={() => { _scrollView.scrollToBottom({animated: true}); }}>
           <Text>Scroll to bottom</Text>
         </TouchableOpacity>
       </View>

--- a/Examples/UIExplorer/js/ScrollViewExample.js
+++ b/Examples/UIExplorer/js/ScrollViewExample.js
@@ -59,7 +59,7 @@ exports.examples = [
         </TouchableOpacity>
         <TouchableOpacity
           style={styles.button}
-          onPress={() => { _scrollView.scrollToBottom({animated: true}); }}>
+          onPress={() => { _scrollView.scrollToEnd({animated: true}); }}>
           <Text>Scroll to bottom</Text>
         </TouchableOpacity>
       </View>
@@ -86,7 +86,7 @@ exports.examples = [
         </TouchableOpacity>
         <TouchableOpacity
           style={styles.button}
-          onPress={() => { _scrollView.scrollToBottom(); }}>
+          onPress={() => { _scrollView.scrollToEnd({animated: true}); }}>
           <Text>Scroll to end</Text>
         </TouchableOpacity>
       </View>

--- a/Examples/UIExplorer/js/ScrollViewExample.js
+++ b/Examples/UIExplorer/js/ScrollViewExample.js
@@ -57,6 +57,11 @@ exports.examples = [
           onPress={() => { _scrollView.scrollTo({y: 0}); }}>
           <Text>Scroll to top</Text>
         </TouchableOpacity>
+        <TouchableOpacity
+          style={styles.button}
+          onPress={() => { _scrollView.scrollToBottom(); }}>
+          <Text>Scroll to bottom</Text>
+        </TouchableOpacity>
       </View>
     );
   }
@@ -78,6 +83,11 @@ exports.examples = [
           style={styles.button}
           onPress={() => { _scrollView.scrollTo({x: 0}); }}>
           <Text>Scroll to start</Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={styles.button}
+          onPress={() => { _scrollView.scrollToBottom(); }}>
+          <Text>Scroll to end</Text>
         </TouchableOpacity>
       </View>
     );

--- a/Examples/UIExplorer/js/ScrollViewExample.js
+++ b/Examples/UIExplorer/js/ScrollViewExample.js
@@ -59,7 +59,7 @@ exports.examples = [
         </TouchableOpacity>
         <TouchableOpacity
           style={styles.button}
-          onPress={() => { _scrollView.scrollToEnd({animated: true}); }}>
+          onPress={() => { _scrollView.scrollToEnd({animated: true); }}>
           <Text>Scroll to bottom</Text>
         </TouchableOpacity>
       </View>

--- a/Examples/UIExplorer/js/ScrollViewExample.js
+++ b/Examples/UIExplorer/js/ScrollViewExample.js
@@ -59,7 +59,7 @@ exports.examples = [
         </TouchableOpacity>
         <TouchableOpacity
           style={styles.button}
-          onPress={() => { _scrollView.scrollToEnd({animated: true); }}>
+          onPress={() => { _scrollView.scrollToEnd({animated: true}); }}>
           <Text>Scroll to bottom</Text>
         </TouchableOpacity>
       </View>

--- a/Examples/UIExplorer/js/ScrollViewSimpleExample.js
+++ b/Examples/UIExplorer/js/ScrollViewSimpleExample.js
@@ -63,7 +63,7 @@ class ScrollViewSimpleExample extends React.Component {
         {items}
       </ScrollView>
     );
-    
+
     return verticalScrollView;
   }
 }

--- a/Examples/UIExplorer/js/ScrollViewSimpleExample.js
+++ b/Examples/UIExplorer/js/ScrollViewSimpleExample.js
@@ -63,7 +63,7 @@ class ScrollViewSimpleExample extends React.Component {
         {items}
       </ScrollView>
     );
-
+    
     return verticalScrollView;
   }
 }

--- a/Libraries/Components/ScrollResponder.js
+++ b/Libraries/Components/ScrollResponder.js
@@ -381,7 +381,7 @@ var ScrollResponderMixin = {
    * This is currently used to help focus child TextViews, but can also
    * be used to quickly scroll to any element we want to focus. Syntax:
    *
-   * `scrollResponderScrollTo(options: {x: number = 0; y: number = 0; animated: boolean = true})``
+   * `scrollResponderScrollTo(options: {x: number = 0; y: number = 0; animated: boolean = true})`
    *
    * Note: The weird argument signature is due to the fact that, for historical reasons,
    * the function also accepts separate arguments as as alternative to the options object.
@@ -421,8 +421,8 @@ var ScrollResponderMixin = {
       );
       return;
     }
-    // The value passed to native must be a boolean
-    const animated = (options && options.animated === true) ? true : false;
+    // Default to true
+    const animated = (options && options.animated) !== false;
     UIManager.dispatchViewManagerCommand(
       this.scrollResponderGetScrollableNode(),
       UIManager.RCTScrollView.Commands.scrollToEnd,

--- a/Libraries/Components/ScrollResponder.js
+++ b/Libraries/Components/ScrollResponder.js
@@ -415,6 +415,12 @@ var ScrollResponderMixin = {
   scrollResponderScrollToEnd: function(
     options?: { animated?: boolean },
   ) {
+    if (Platform.OS !== 'ios') {
+      console.warn(
+        'scrollResponderScrollToEnd is not supported on this platform'
+      );
+      return;
+    }
     const animated = (options && options.animated === true) ? true : false;
     UIManager.dispatchViewManagerCommand(
       this.scrollResponderGetScrollableNode(),

--- a/Libraries/Components/ScrollResponder.js
+++ b/Libraries/Components/ScrollResponder.js
@@ -377,11 +377,11 @@ var ScrollResponderMixin = {
   },
 
   /**
-   * A helper function to scroll to a specific point  in the scrollview.
-   * This is currently used to help focus on child textviews, but can also
+   * A helper function to scroll to a specific point  in the ScrollView.
+   * This is currently used to help focus child TextViews, but can also
    * be used to quickly scroll to any element we want to focus. Syntax:
    *
-   * scrollResponderScrollTo(options: {x: number = 0; y: number = 0; animated: boolean = true})
+   * `scrollResponderScrollTo(options: {x: number = 0; y: number = 0; animated: boolean = true})``
    *
    * Note: The weird argument signature is due to the fact that, for historical reasons,
    * the function also accepts separate arguments as as alternative to the options object.
@@ -401,6 +401,25 @@ var ScrollResponderMixin = {
       this.scrollResponderGetScrollableNode(),
       UIManager.RCTScrollView.Commands.scrollTo,
       [x || 0, y || 0, animated !== false],
+    );
+  },
+
+  /**
+   * Scrolls to the end of the ScrollView, either immediately or with a smooth
+   * animation.
+   *
+   * Example:
+   *
+   * `scrollResponderScrollToBottom({animated: true})`
+   */
+  scrollResponderScrollToBottom: function(
+    options?: { animated?: boolean },
+  ) {
+    const animated = (options && options.animated === true) ? true : false;
+    UIManager.dispatchViewManagerCommand(
+      this.scrollResponderGetScrollableNode(),
+      UIManager.RCTScrollView.Commands.scrollTo,
+      [animated],
     );
   },
 

--- a/Libraries/Components/ScrollResponder.js
+++ b/Libraries/Components/ScrollResponder.js
@@ -377,7 +377,7 @@ var ScrollResponderMixin = {
   },
 
   /**
-   * A helper function to scroll to a specific point  in the ScrollView.
+   * A helper function to scroll to a specific point in the ScrollView.
    * This is currently used to help focus child TextViews, but can also
    * be used to quickly scroll to any element we want to focus. Syntax:
    *

--- a/Libraries/Components/ScrollResponder.js
+++ b/Libraries/Components/ScrollResponder.js
@@ -421,6 +421,7 @@ var ScrollResponderMixin = {
       );
       return;
     }
+    // The value passed to native must be a boolean
     const animated = (options && options.animated === true) ? true : false;
     UIManager.dispatchViewManagerCommand(
       this.scrollResponderGetScrollableNode(),

--- a/Libraries/Components/ScrollResponder.js
+++ b/Libraries/Components/ScrollResponder.js
@@ -418,7 +418,7 @@ var ScrollResponderMixin = {
     const animated = (options && options.animated === true) ? true : false;
     UIManager.dispatchViewManagerCommand(
       this.scrollResponderGetScrollableNode(),
-      UIManager.RCTScrollView.Commands.scrollTo,
+      UIManager.RCTScrollView.Commands.scrollToEnd,
       [animated],
     );
   },

--- a/Libraries/Components/ScrollResponder.js
+++ b/Libraries/Components/ScrollResponder.js
@@ -410,9 +410,9 @@ var ScrollResponderMixin = {
    *
    * Example:
    *
-   * `scrollResponderScrollToBottom({animated: true})`
+   * `scrollResponderScrollToEnd({animated: true})`
    */
-  scrollResponderScrollToBottom: function(
+  scrollResponderScrollToEnd: function(
     options?: { animated?: boolean },
   ) {
     const animated = (options && options.animated === true) ? true : false;

--- a/Libraries/Components/ScrollView/ScrollView.js
+++ b/Libraries/Components/ScrollView/ScrollView.js
@@ -407,23 +407,27 @@ const ScrollView = React.createClass({
    * If this is a vertical ScrollView scrolls to the bottom.
    * If this is a horizontal ScrollView scrolls to the right.
    *
-   * Use `scrollToEnd()` for immediate scrolling,
-   * `scrollToEnd({animated: true})` for animated scrolling.
+   * Use `scrollToEnd()` for smooth animated scrolling,
+   * `scrollToEnd({animated: false})` for immediate scrolling.
    *
    * See `ScrollView#scrollToEnd`.
    */
   scrollToEnd: function(
     options?: { animated?: boolean },
   ) {
+    // Default to true
+    const animated = (options && options.animated) !== false;
     if (Platform.OS === 'ios') {
-      this.getScrollResponder().scrollResponderScrollToEnd(options);
+      this.getScrollResponder().scrollResponderScrollToEnd({
+        animated: animated,
+      });
     } else if (Platform.OS === 'android') {
       // On Android scrolling past the end of the ScrollView gets clipped
       // - scrolls to the end.
       if (this.props.horizontal) {
-        this.scrollTo({x: 1000*1000, animated: options && options.animated});
+        this.scrollTo({x: 10*1000*1000, animated: animated});
       } else {
-        this.scrollTo({y: 1000*1000, animated: options && options.animated});
+        this.scrollTo({y: 10*1000*1000, animated: animated});
       }
     } else {
       console.warn('scrollToEnd is not supported on this platform');

--- a/Libraries/Components/ScrollView/ScrollView.js
+++ b/Libraries/Components/ScrollView/ScrollView.js
@@ -404,16 +404,18 @@ const ScrollView = React.createClass({
   },
 
   /**
-   * Scrolls to the end, either immediately or with a smooth animation.
+   * If this is a vertical ScrollView scrolls to the bottom.
+   * If this is a horizontal ScrollView scrolls to the right.
    *
-   * Example:
+   * Use `scrollToEnd()` for immediate scrolling,
+   * `scrollToEnd({animated: true})` for animated scrolling.
    *
-   * `scrollToBottom({animated: true})`
+   * See `ScrollView#scrollToEnd`.
    */
-  scrollToBottom: function(
+  scrollToEnd: function(
     options?: { animated?: boolean },
   ) {
-    this.getScrollResponder().scrollResponderScrollToBottom(options);
+    this.getScrollResponder().scrollResponderScrollToEnd(options);
   },
 
   /**

--- a/Libraries/Components/ScrollView/ScrollView.js
+++ b/Libraries/Components/ScrollView/ScrollView.js
@@ -415,7 +415,19 @@ const ScrollView = React.createClass({
   scrollToEnd: function(
     options?: { animated?: boolean },
   ) {
-    this.getScrollResponder().scrollResponderScrollToEnd(options);
+    if (Platform.OS === 'ios') {
+      this.getScrollResponder().scrollResponderScrollToEnd(options);
+    } else if (Platform.OS === 'android') {
+      // On Android scrolling past the end of the ScrollView gets clipped
+      // - scrolls to the end.
+      if (this.props.horizontal) {
+        this.scrollTo({x: 1000*1000, animated: options && options.animated});
+      } else {
+        this.scrollTo({y: 1000*1000, animated: options && options.animated});
+      }
+    } else {
+      console.warn('scrollToEnd is not supported on this platform');
+    }
   },
 
   /**

--- a/Libraries/Components/ScrollView/ScrollView.js
+++ b/Libraries/Components/ScrollView/ScrollView.js
@@ -382,11 +382,11 @@ const ScrollView = React.createClass({
   /**
    * Scrolls to a given x, y offset, either immediately or with a smooth animation.
    *
-   * Syntax:
+   * Example:
    *
-   * `scrollTo(options: {x: number = 0; y: number = 0; animated: boolean = true})`
+   * `scrollTo({x: 0; y: 0; animated: true})`
    *
-   * Note: The weird argument signature is due to the fact that, for historical reasons,
+   * Note: The weird function signature is due to the fact that, for historical reasons,
    * the function also accepts separate arguments as as alternative to the options object.
    * This is deprecated due to ambiguity (y before x), and SHOULD NOT BE USED.
    */
@@ -404,7 +404,20 @@ const ScrollView = React.createClass({
   },
 
   /**
-   * Deprecated, do not use.
+   * Scrolls to the end, either immediately or with a smooth animation.
+   *
+   * Example:
+   *
+   * `scrollToBottom({animated: true})`
+   */
+  scrollToBottom: function(
+    options?: { animated?: boolean },
+  ) {
+    this.getScrollResponder().scrollResponderScrollToBottom(options);
+  },
+
+  /**
+   * Deprecated, use `scrollTo` instead.
    */
   scrollWithoutAnimationTo: function(y: number = 0, x: number = 0) {
     console.warn('`scrollWithoutAnimationTo` is deprecated. Use `scrollTo` instead');

--- a/Libraries/Components/ScrollView/ScrollView.js
+++ b/Libraries/Components/ScrollView/ScrollView.js
@@ -407,8 +407,9 @@ const ScrollView = React.createClass({
    * If this is a vertical ScrollView scrolls to the bottom.
    * If this is a horizontal ScrollView scrolls to the right.
    *
-   * Use `scrollToEnd()` for smooth animated scrolling,
+   * Use `scrollToEnd({animated: true})` for smooth animated scrolling,
    * `scrollToEnd({animated: false})` for immediate scrolling.
+   * If no options are passed, `animated` defaults to true.
    *
    * See `ScrollView#scrollToEnd`.
    */

--- a/Libraries/CustomComponents/ListView/ListView.js
+++ b/Libraries/CustomComponents/ListView/ListView.js
@@ -298,8 +298,8 @@ var ListView = React.createClass({
    *
    * See `ScrollView#scrollToEnd`.
    */
-  scrollToEnd: function(options?: { animated?: boolean },) {
-    if (this._scrollComponent && this._scrollComponent.scrollTo) {
+  scrollToEnd: function(options?: { animated?: boolean }) {
+    if (this._scrollComponent && this._scrollComponent.scrollToEnd) {
       this._scrollComponent.scrollToEnd(options);
     }
   },

--- a/Libraries/CustomComponents/ListView/ListView.js
+++ b/Libraries/CustomComponents/ListView/ListView.js
@@ -293,6 +293,9 @@ var ListView = React.createClass({
    * If this is a vertical ListView scrolls to the bottom.
    * If this is a horizontal ListView scrolls to the right.
    *
+   * Use `scrollToEnd()` for immediate scrolling,
+   * `scrollToEnd({animated: true})` for animated scrolling.
+   *
    * See `ScrollView#scrollToEnd`.
    */
   scrollToEnd: function(options?: { animated?: boolean },) {

--- a/Libraries/CustomComponents/ListView/ListView.js
+++ b/Libraries/CustomComponents/ListView/ListView.js
@@ -289,6 +289,18 @@ var ListView = React.createClass({
     }
   },
 
+  /**
+   * If this is a vertical ListView scrolls to the bottom.
+   * If this is a horizontal ListView scrolls to the right.
+   *
+   * See `ScrollView#scrollToEnd`.
+   */
+  scrollToEnd: function(options?: { animated?: boolean },) {
+    if (this._scrollComponent && this._scrollComponent.scrollTo) {
+      this._scrollComponent.scrollToEnd(options);
+    }
+  },
+
   setNativeProps: function(props: Object) {
     if (this._scrollComponent) {
       this._scrollComponent.setNativeProps(props);

--- a/Libraries/CustomComponents/ListView/ListView.js
+++ b/Libraries/CustomComponents/ListView/ListView.js
@@ -293,8 +293,9 @@ var ListView = React.createClass({
    * If this is a vertical ListView scrolls to the bottom.
    * If this is a horizontal ListView scrolls to the right.
    *
-   * Use `scrollToEnd()` for smooth animated scrolling,
+   * Use `scrollToEnd({animated: true})` for smooth animated scrolling,
    * `scrollToEnd({animated: false})` for immediate scrolling.
+   * If no options are passed, `animated` defaults to true.
    *
    * See `ScrollView#scrollToEnd`.
    */

--- a/Libraries/CustomComponents/ListView/ListView.js
+++ b/Libraries/CustomComponents/ListView/ListView.js
@@ -299,8 +299,15 @@ var ListView = React.createClass({
    * See `ScrollView#scrollToEnd`.
    */
   scrollToEnd: function(options?: { animated?: boolean }) {
-    if (this._scrollComponent && this._scrollComponent.scrollToEnd) {
-      this._scrollComponent.scrollToEnd(options);
+    if (this._scrollComponent) {
+      if (this._scrollComponent.scrollToEnd) {
+        this._scrollComponent.scrollToEnd(options);
+      } else {
+        console.warn(
+          'The scroll component used by the ListView does not support ' +
+          'scrollToEnd. Check the renderScrollComponent prop of your ListView.'
+        );
+      }
     }
   },
 

--- a/Libraries/CustomComponents/ListView/ListView.js
+++ b/Libraries/CustomComponents/ListView/ListView.js
@@ -293,8 +293,8 @@ var ListView = React.createClass({
    * If this is a vertical ListView scrolls to the bottom.
    * If this is a horizontal ListView scrolls to the right.
    *
-   * Use `scrollToEnd()` for immediate scrolling,
-   * `scrollToEnd({animated: true})` for animated scrolling.
+   * Use `scrollToEnd()` for smooth animated scrolling,
+   * `scrollToEnd({animated: false})` for immediate scrolling.
    *
    * See `ScrollView#scrollToEnd`.
    */

--- a/React/Base/RCTModuleMethod.m
+++ b/React/Base/RCTModuleMethod.m
@@ -480,10 +480,10 @@ SEL RCTParseMethodSignature(NSString *methodSignature, NSArray<RCTMethodArgument
         expectedCount -= 2;
       }
 
-      RCTLogError(@"%@.%@ was called with %zd arguments, but expects %zd. \
-                  If you haven\'t changed this method yourself, this usually means that \
-                  your versions of the native code and JavaScript code are out of sync. \
-                  Updating both should make this error go away.",
+      RCTLogError(@"%@.%@ was called with %zd arguments but expects %zd arguments. "
+                  @"If you haven\'t changed this method yourself, this usually means that "
+                  @"your versions of the native code and JavaScript code are out of sync. "
+                  @"Updating both should make this error go away.",
                   RCTBridgeModuleNameForClass(_moduleClass), _JSMethodName,
                   actualCount, expectedCount);
       return nil;

--- a/React/Views/RCTScrollView.m
+++ b/React/Views/RCTScrollView.m
@@ -602,6 +602,32 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
   }
 }
 
+/**
+ * If this is a vertical scroll view, scrolls to the bottom.
+ * If this is a horizontal scroll view, scrolls to the right.
+ */
+- (void)scrollToEnd:(BOOL)animated
+{
+  BOOL isHorizontal = (_scrollView.contentSize.width > self.frame.size.width);
+  CGPoint offset;
+  if (isHorizontal) {
+    offset = (CGPoint){
+      _scrollView.contentSize.width - _scrollView.bounds.size.width,
+      0
+    };
+  } else {
+    offset = (CGPoint){
+      0,
+      _scrollView.contentSize.height - _scrollView.bounds.size.height
+    };
+  }
+  if (!CGPointEqualToPoint(_scrollView.contentOffset, offset)) {
+    // Ensure at least one scroll event will fire
+    _allowNextScrollNoMatterWhat = YES;
+    [_scrollView setContentOffset:offset animated:animated];
+  }
+}
+
 - (void)zoomToRect:(CGRect)rect animated:(BOOL)animated
 {
   [_scrollView zoomToRect:rect animated:animated];

--- a/React/Views/RCTScrollView.m
+++ b/React/Views/RCTScrollView.m
@@ -588,6 +588,11 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
   _scrollView.contentOffset = contentOffset;
 }
 
+- (BOOL)isHorizontal:(UIScrollView *)scrollView
+{
+  return (scrollView.contentSize.width > self.frame.size.width);
+}
+
 - (void)scrollToOffset:(CGPoint)offset
 {
   [self scrollToOffset:offset animated:YES];
@@ -608,18 +613,12 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
  */
 - (void)scrollToEnd:(BOOL)animated
 {
-  BOOL isHorizontal = (_scrollView.contentSize.width > self.frame.size.width);
+  BOOL isHorizontal = [self isHorizontal:_scrollView];
   CGPoint offset;
   if (isHorizontal) {
-    offset = (CGPoint){
-      _scrollView.contentSize.width - _scrollView.bounds.size.width,
-      0
-    };
+    offset = CGPointMake(_scrollView.contentSize.width - _scrollView.bounds.size.width, 0);
   } else {
-    offset = (CGPoint){
-      0,
-      _scrollView.contentSize.height - _scrollView.bounds.size.height
-    };
+    offset = CGPointMake(0, _scrollView.contentSize.height - _scrollView.bounds.size.height);
   }
   if (!CGPointEqualToPoint(_scrollView.contentOffset, offset)) {
     // Ensure at least one scroll event will fire
@@ -753,7 +752,7 @@ RCT_SCROLL_EVENT_HANDLER(scrollViewDidZoom, onScroll)
     CGFloat snapToIntervalF = (CGFloat)self.snapToInterval;
 
     // Find which axis to snap
-    BOOL isHorizontal = (scrollView.contentSize.width > self.frame.size.width);
+    BOOL isHorizontal = [self isHorizontal:scrollView];
 
     // What is the current offset?
     CGFloat targetContentOffsetAlongAxis = isHorizontal ? targetContentOffset->x : targetContentOffset->y;

--- a/React/Views/RCTScrollView.m
+++ b/React/Views/RCTScrollView.m
@@ -590,7 +590,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
 
 - (BOOL)isHorizontal:(UIScrollView *)scrollView
 {
-  return (scrollView.contentSize.width > self.frame.size.width);
+  return scrollView.contentSize.width > self.frame.size.width;
 }
 
 - (void)scrollToOffset:(CGPoint)offset

--- a/React/Views/RCTScrollViewManager.m
+++ b/React/Views/RCTScrollViewManager.m
@@ -148,6 +148,21 @@ RCT_EXPORT_METHOD(scrollTo:(nonnull NSNumber *)reactTag
   }];
 }
 
+RCT_EXPORT_METHOD(scrollToEnd:(nonnull NSNumber *)reactTag
+                  animated:(BOOL)animated)
+{
+  [self.bridge.uiManager addUIBlock:
+   ^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, RCTScrollView *> *viewRegistry) {
+     RCTScrollView *view = viewRegistry[reactTag];
+     if (!view || ![view isKindOfClass:[RCTScrollView class]]) {
+       RCTLogError(@"Cannot find RCTScrollView with tag #%@", reactTag);
+       return;
+     }
+     CGPoint bottomOffset = (CGPoint){0, view.contentSize.height - view.bounds.size.height};
+     [view scrollToOffset:bottomOffset animated:animated];
+   }];
+}
+
 RCT_EXPORT_METHOD(zoomToRect:(nonnull NSNumber *)reactTag
                   withRect:(CGRect)rect
                   animated:(BOOL)animated)

--- a/React/Views/RCTScrollViewManager.m
+++ b/React/Views/RCTScrollViewManager.m
@@ -152,14 +152,14 @@ RCT_EXPORT_METHOD(scrollToEnd:(nonnull NSNumber *)reactTag
                   animated:(BOOL)animated)
 {
   [self.bridge.uiManager addUIBlock:
-   ^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, RCTScrollView *> *viewRegistry) {
-     RCTScrollView *view = viewRegistry[reactTag];
-     if (!view || ![view isKindOfClass:[RCTScrollView class]]) {
-       RCTLogError(@"Cannot find RCTScrollView with tag #%@", reactTag);
-       return;
+   ^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry){
+     UIView *view = viewRegistry[reactTag];
+     if ([view conformsToProtocol:@protocol(RCTScrollableProtocol)]) {
+       [(id<RCTScrollableProtocol>)view scrollToEnd:animated];
+     } else {
+       RCTLogError(@"tried to scrollTo: on non-RCTScrollableProtocol view %@ "
+                   "with tag #%@", view, reactTag);
      }
-     CGPoint bottomOffset = (CGPoint){0, view.contentSize.height - view.bounds.size.height};
-     [view scrollToOffset:bottomOffset animated:animated];
    }];
 }
 

--- a/React/Views/RCTScrollableProtocol.h
+++ b/React/Views/RCTScrollableProtocol.h
@@ -19,6 +19,11 @@
 
 - (void)scrollToOffset:(CGPoint)offset;
 - (void)scrollToOffset:(CGPoint)offset animated:(BOOL)animated;
+/**
+ * If this is a vertical scroll view, scrolls to the bottom.
+ * If this is a horizontal scroll view, scrolls to the right.
+ */
+- (void)scrollToEnd:(BOOL)animated;
 - (void)zoomToRect:(CGRect)rect animated:(BOOL)animated;
 
 - (void)addScrollListener:(NSObject<UIScrollViewDelegate> *)scrollListener;


### PR DESCRIPTION
**Motivation**

A basic task of making a React Native ScrollView or ListView scroll to the bottom is currently very hard to accomplish:
- https://github.com/facebook/react-native/issues/8003
- https://github.com/facebook/react-native/issues/913
- http://stackoverflow.com/questions/29829375/how-to-scroll-to-bottom-in-react-native-listview

**NOTE:** If you're building something like a chat app where you want a ListView to keep scrolling to the bottom at all times, it's easiest to use the [react-native-invertible-scrollview](https://github.com/exponent/react-native-invertible-scroll-view) component rather calling `scrollToEnd` manually when layout changes. The invertible-scrollview uses a clever trick to invert the direction of the ScrollView.

This pull request adds a `scrollToEnd` method which scrolls to the bottom if the ScrollView is vertical, to the right if the ScrollView is horizontal.

The implementation is based on this SO answer:
http://stackoverflow.com/questions/952412/uiscrollview-scroll-to-bottom-programmatically

**Test plan (required)**

New buttons "Scroll to bottom" and "Scroll to end" in the UIExplorer work as expected. They work if tapped while the ScrollView is still decelerating, and also when `removeClippedSubviews` is enabled:

<img width="487" alt="screenshot 2017-01-27 12 21 34" src="https://cloud.githubusercontent.com/assets/346214/22361492/dee983d2-e48c-11e6-8072-afd7f9be70aa.png">

On Android added calls to `scrollToEnd` to the [ScrollViewSimpleExample](https://github.com/facebook/react-native/blob/master/Examples/UIExplorer/js/ScrollViewSimpleExample.js) in the UI Explorer and verified both the vertical and horizontal ScrollView scroll to end and the `animated` option works as expected.