### PR TITLE
use https for bash links

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -124,7 +124,7 @@ Run the following command in a Terminal:
 npm install -g react-native-cli
 ```
 
-> If you get an error like `Cannot find module 'npmlog'`, try installing npm directly: `curl -0 -L http://npmjs.org/install.sh | sudo sh`.
+> If you get an error like `Cannot find module 'npmlog'`, try installing npm directly: `curl -0 -L https://npmjs.org/install.sh | sudo sh`.
 
 <block class="windows linux android" />
 
@@ -138,7 +138,7 @@ Run the following command in a Terminal:
 npm install -g react-native-cli
 ```
 
-> If you get an error like `Cannot find module 'npmlog'`, try installing npm directly: `curl -0 -L http://npmjs.org/install.sh | sudo sh`.
+> If you get an error like `Cannot find module 'npmlog'`, try installing npm directly: `curl -0 -L https://npmjs.org/install.sh | sudo sh`.
 
 <block class="mac ios" />
 


### PR DESCRIPTION
Never a good idea to pipe a bash file from `http` into `sudo`. Using `https` mitigates some of this risk.