### PR TITLE
Support ScrollView.scrollToEnd on Android natively

### DIFF
--- a/Examples/UIExplorer/js/ListViewExample.js
+++ b/Examples/UIExplorer/js/ListViewExample.js
@@ -61,6 +61,7 @@ var ListViewSimpleExample = React.createClass({
         noSpacer={true}
         noScroll={true}>
         <ListView
+          removeClippedSubviews={true}
           dataSource={this.state.dataSource}
           renderRow={this._renderRow}
           renderSeparator={this._renderSeparator}

--- a/Examples/UIExplorer/js/ListViewExample.js
+++ b/Examples/UIExplorer/js/ListViewExample.js
@@ -61,7 +61,6 @@ var ListViewSimpleExample = React.createClass({
         noSpacer={true}
         noScroll={true}>
         <ListView
-          removeClippedSubviews={true}
           dataSource={this.state.dataSource}
           renderRow={this._renderRow}
           renderSeparator={this._renderSeparator}

--- a/Libraries/Components/ScrollResponder.js
+++ b/Libraries/Components/ScrollResponder.js
@@ -415,12 +415,6 @@ var ScrollResponderMixin = {
   scrollResponderScrollToEnd: function(
     options?: { animated?: boolean },
   ) {
-    if (Platform.OS !== 'ios') {
-      console.warn(
-        'scrollResponderScrollToEnd is not supported on this platform'
-      );
-      return;
-    }
     // Default to true
     const animated = (options && options.animated) !== false;
     UIManager.dispatchViewManagerCommand(

--- a/Libraries/Components/ScrollView/ScrollView.js
+++ b/Libraries/Components/ScrollView/ScrollView.js
@@ -410,29 +410,15 @@ const ScrollView = React.createClass({
    * Use `scrollToEnd({animated: true})` for smooth animated scrolling,
    * `scrollToEnd({animated: false})` for immediate scrolling.
    * If no options are passed, `animated` defaults to true.
-   *
-   * See `ScrollView#scrollToEnd`.
    */
   scrollToEnd: function(
     options?: { animated?: boolean },
   ) {
     // Default to true
     const animated = (options && options.animated) !== false;
-    if (Platform.OS === 'ios') {
-      this.getScrollResponder().scrollResponderScrollToEnd({
-        animated: animated,
-      });
-    } else if (Platform.OS === 'android') {
-      // On Android scrolling past the end of the ScrollView gets clipped
-      // - scrolls to the end.
-      if (this.props.horizontal) {
-        this.scrollTo({x: 10*1000*1000, animated: animated});
-      } else {
-        this.scrollTo({y: 10*1000*1000, animated: animated});
-      }
-    } else {
-      console.warn('scrollToEnd is not supported on this platform');
-    }
+    this.getScrollResponder().scrollResponderScrollToEnd({
+      animated: animated,
+    });
   },
 
   /**

--- a/ReactAndroid/src/main/java/com/facebook/react/views/recyclerview/RecyclerViewBackedScrollViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/recyclerview/RecyclerViewBackedScrollViewManager.java
@@ -8,8 +8,10 @@ import java.util.Map;
 
 import android.view.View;
 
+import com.facebook.common.logging.FLog;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.common.MapBuilder;
+import com.facebook.react.common.ReactConstants;
 import com.facebook.react.uimanager.annotations.ReactProp;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.ViewGroupManager;
@@ -78,6 +80,17 @@ public class RecyclerViewBackedScrollViewManager extends
       RecyclerViewBackedScrollView scrollView,
       ReactScrollViewCommandHelper.ScrollToCommandData data) {
     scrollView.scrollTo(data.mDestX, data.mDestY, data.mAnimated);
+  }
+
+  @Override
+  public void scrollToEnd(
+      RecyclerViewBackedScrollView scrollView,
+      ReactScrollViewCommandHelper.ScrollToEndCommandData data) {
+    FLog.w(
+      ReactConstants.TAG,
+      "scrollToEnd is not implemented for RecyclerViewBackedScrollView." +
+      "RecyclerViewBackedScrollView is deprecated and will be removed. " +
+      "Use a standard ScrollView or ListView instead.");
   }
 
   @Override

--- a/ReactAndroid/src/main/java/com/facebook/react/views/recyclerview/RecyclerViewBackedScrollViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/recyclerview/RecyclerViewBackedScrollViewManager.java
@@ -8,10 +8,8 @@ import java.util.Map;
 
 import android.view.View;
 
-import com.facebook.common.logging.FLog;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.common.MapBuilder;
-import com.facebook.react.common.ReactConstants;
 import com.facebook.react.uimanager.annotations.ReactProp;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.ViewGroupManager;
@@ -86,11 +84,9 @@ public class RecyclerViewBackedScrollViewManager extends
   public void scrollToEnd(
       RecyclerViewBackedScrollView scrollView,
       ReactScrollViewCommandHelper.ScrollToEndCommandData data) {
-    FLog.w(
-      ReactConstants.TAG,
-      "scrollToEnd is not implemented for RecyclerViewBackedScrollView." +
-      "RecyclerViewBackedScrollView is deprecated and will be removed. " +
-      "Use a standard ScrollView or ListView instead.");
+    // Not implemented.
+    // RecyclerViewBackedScrollView is deprecated and will be removed.
+    // People should use a standard ScrollView or ListView instead.
   }
 
   @Override

--- a/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollViewManager.java
@@ -117,6 +117,20 @@ public class ReactHorizontalScrollViewManager
     }
   }
 
+  @Override
+  public void scrollToEnd(
+      ReactHorizontalScrollView scrollView,
+      ReactScrollViewCommandHelper.ScrollToEndCommandData data) {
+    // ScrollView always has one child - the scrollable area
+    int right =
+      scrollView.getChildAt(0).getWidth() + scrollView.getPaddingRight();
+    if (data.mAnimated) {
+      scrollView.smoothScrollTo(right, scrollView.getScrollY());
+    } else {
+      scrollView.scrollTo(right, scrollView.getScrollY());
+    }
+  }
+
   /**
    * When set, fills the rest of the scrollview with a color to avoid setting a background and
    * creating unnecessary overdraw.

--- a/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewCommandHelper.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewCommandHelper.java
@@ -25,9 +25,11 @@ import com.facebook.react.common.MapBuilder;
 public class ReactScrollViewCommandHelper {
 
   public static final int COMMAND_SCROLL_TO = 1;
+  public static final int COMMAND_SCROLL_TO_END = 2;
 
   public interface ScrollCommandHandler<T> {
     void scrollTo(T scrollView, ScrollToCommandData data);
+    void scrollToEnd(T scrollView, ScrollToEndCommandData data);
   }
 
   public static class ScrollToCommandData {
@@ -42,10 +44,21 @@ public class ReactScrollViewCommandHelper {
     }
   }
 
+  public static class ScrollToEndCommandData {
+
+    public final boolean mAnimated;
+
+    ScrollToEndCommandData(boolean animated) {
+      mAnimated = animated;
+    }
+  }
+
   public static Map<String,Integer> getCommandsMap() {
     return MapBuilder.of(
         "scrollTo",
-        COMMAND_SCROLL_TO);
+        COMMAND_SCROLL_TO,
+        "scrollToEnd",
+        COMMAND_SCROLL_TO_END);
   }
 
   public static <T> void receiveCommand(
@@ -62,6 +75,11 @@ public class ReactScrollViewCommandHelper {
         int destY = Math.round(PixelUtil.toPixelFromDIP(args.getDouble(1)));
         boolean animated = args.getBoolean(2);
         viewManager.scrollTo(scrollView, new ScrollToCommandData(destX, destY, animated));
+        return;
+      }
+      case COMMAND_SCROLL_TO_END: {
+        boolean animated = args.getBoolean(0);
+        viewManager.scrollToEnd(scrollView, new ScrollToEndCommandData(animated));
         return;
       }
       default:

--- a/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewCommandHelper.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewCommandHelper.java
@@ -75,12 +75,10 @@ public class ReactScrollViewCommandHelper {
         int destY = Math.round(PixelUtil.toPixelFromDIP(args.getDouble(1)));
         boolean animated = args.getBoolean(2);
         viewManager.scrollTo(scrollView, new ScrollToCommandData(destX, destY, animated));
-        return;
       }
       case COMMAND_SCROLL_TO_END: {
         boolean animated = args.getBoolean(0);
         viewManager.scrollToEnd(scrollView, new ScrollToEndCommandData(animated));
-        return;
       }
       default:
         throw new IllegalArgumentException(String.format(

--- a/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewCommandHelper.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewCommandHelper.java
@@ -75,10 +75,12 @@ public class ReactScrollViewCommandHelper {
         int destY = Math.round(PixelUtil.toPixelFromDIP(args.getDouble(1)));
         boolean animated = args.getBoolean(2);
         viewManager.scrollTo(scrollView, new ScrollToCommandData(destX, destY, animated));
+        return;
       }
       case COMMAND_SCROLL_TO_END: {
         boolean animated = args.getBoolean(0);
         viewManager.scrollToEnd(scrollView, new ScrollToEndCommandData(animated));
+        return;
       }
       default:
         throw new IllegalArgumentException(String.format(

--- a/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewManager.java
@@ -14,6 +14,7 @@ import javax.annotation.Nullable;
 import java.util.Map;
 
 import android.graphics.Color;
+import android.view.View;
 
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.common.MapBuilder;
@@ -128,6 +129,20 @@ public class ReactScrollViewManager
       scrollView.smoothScrollTo(data.mDestX, data.mDestY);
     } else {
       scrollView.scrollTo(data.mDestX, data.mDestY);
+    }
+  }
+
+  @Override
+  public void scrollToEnd(
+      ReactScrollView scrollView,
+      ReactScrollViewCommandHelper.ScrollToEndCommandData data) {
+    // ScrollView always has one child - the scrollable area
+    int bottom =
+      scrollView.getChildAt(0).getHeight() + scrollView.getPaddingBottom();
+    if (data.mAnimated) {
+      scrollView.smoothScrollTo(scrollView.getScrollX(), bottom);
+    } else {
+      scrollView.scrollTo(scrollView.getScrollX(), bottom);
     }
   }
 


### PR DESCRIPTION
This is a followup for https://github.com/facebook/react-native/pull/12088 and implements the scrolling to end on Android natively rather than sending a large scroll offset from JS.

This turned out to be an OK amount of code, and some reduction in the amount of JavaScript. The only part I'm not particularly happy about is:

```
// ScrollView always has one child - the scrollable area
int bottom = scrollView.getChildAt(0).getHeight() + scrollView.getPaddingBottom();
```

According to multiple sources (e.g. [this SO answer](http://stackoverflow.com/questions/3609297/android-total-height-of-scrollview)) it is the way to get the total size of the scrollable area, similar to`scrollView.contentSize` on iOS but more ugly and relying on the fact the ScrollView always has a single child (hopefully this won't change in future versions of Android).

An alternative is:

```
View lastChild = scrollLayout.getChildAt(scrollLayout.getChildCount() - 1);
int bottom = lastChild.getBottom() + scrollLayout.getPaddingBottom();
```

But that seems even more fragile in case we ever change how `removeClippedSubviews` work and the off-screen children are removed from the ScrollView.

I vote for the `scrollView.getChildAt(0)` approach.

**Test plan (required)**

Tried calling `scrollToEnd` in the SimpleScrollView and ListView examples in the Android UIExplorer. Tried `scrollToEnd()` (animated as expected), `scrollToEnd({animated: false})` (no animation).

Tried with `removeClippedSubviews` enabled on the ListView while some views at the bottom were off the screen - scrolled to the bottom correctly.
