### PR TITLE
Fix missing RCTBridgeModule.h

### DIFF
--- a/Libraries/Sample/Sample.h
+++ b/Libraries/Sample/Sample.h
@@ -1,4 +1,4 @@
-#import "RCTBridgeModule.h"
+#import <React/RCTBridgeModule.h>
 
 @interface Sample : NSObject <RCTBridgeModule>
 


### PR DESCRIPTION
`<React/RCTBridgeModule.h>`

**motivation**

iOS native headers moved in RN v0.40.0.
link: https://github.com/facebook/react-native/releases/tag/v0.40.0

So, fixed import path in `Libraries/Sample/Sample.h`.

**Test plan (required)**

- [x] Make sure tests pass on both Travis and Circle CI.

Related p-r
https://github.com/facebook/react-native/pull/11576