### PR TITLE
Fix layout animations for views with a transform

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/PositionAndSizeAnimation.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/PositionAndSizeAnimation.java
@@ -21,8 +21,8 @@ import android.view.animation.Transformation;
   public PositionAndSizeAnimation(View view, int x, int y, int width, int height) {
     mView = view;
 
-    mStartX = view.getX();
-    mStartY = view.getY();
+    mStartX = view.getX() - view.getTranslationX();
+    mStartY = view.getY() - view.getTranslationY();
     mStartWidth = view.getWidth();
     mStartHeight = view.getHeight();
 


### PR DESCRIPTION
Fixes LayoutAnimation when animating the position of a view that has a transform, the animation would start at the wrong position, offset by the transform translation value. I noticed this bug while working on sticky headers using animated in the UIExplorer <ListView> - Paging example.

**Test plan**
Made a simple repro for the bug https://gist.github.com/janicduplessis/eb985dc3accfd5982c77761be692e395 and tested that it fixed it. Also tested that the UIExplorer <ListView> - Paging example with sticky headers worked properly with this fix.