### PR TITLE
Update ScrollView docs - Fixes #12139

### DIFF
--- a/Libraries/Components/ScrollView/ScrollView.js
+++ b/Libraries/Components/ScrollView/ScrollView.js
@@ -326,7 +326,8 @@ const ScrollView = React.createClass({
 
     /**
      * A RefreshControl component, used to provide pull-to-refresh
-     * functionality for the ScrollView.
+     * functionality for the ScrollView. Only works for vertical ScrollViews
+     * (`horizontal` prop must be `false`).
      *
      * See [RefreshControl](docs/refreshcontrol.html).
      */


### PR DESCRIPTION
Added a note to the `refreshControl` prop on ScrollView to call out that the prop only works for vertical ScrollViews.

Fixes #12139