### PR TITLE
BREAKING: [CLI] New app template: Resize UI when keyboard is shown on Android

### DIFF
--- a/local-cli/templates/HelloWorld/android/app/src/main/AndroidManifest.xml
+++ b/local-cli/templates/HelloWorld/android/app/src/main/AndroidManifest.xml
@@ -19,7 +19,8 @@
       <activity
         android:name=".MainActivity"
         android:label="@string/app_name"
-        android:configChanges="keyboard|keyboardHidden|orientation|screenSize">
+        android:configChanges="keyboard|keyboardHidden|orientation|screenSize"
+        android:windowSoftInputMode="adjustResize">
         <intent-filter>
             <action android:name="android.intent.action.MAIN" />
             <category android:name="android.intent.category.LAUNCHER" />


### PR DESCRIPTION
When building the Chat example for react-navigation, I realized the default Android behavior doesn't actually work:

<img width="868" alt="screenshot 2017-02-01 15 15 25" src="https://cloud.githubusercontent.com/assets/346214/22512559/518e3bf0-e891-11e6-9a86-2dafac5b250f.png">

(From https://developer.android.com/guide/topics/manifest/activity-element.html)

In my app there's a `<ListView>` and a `<TextInput>` below it. Without this PR the UI pans which is a very bad user experience.

Keyboard is hidden:

<img width="437" alt="screenshot 2017-02-01 15 21 15" src="https://cloud.githubusercontent.com/assets/346214/22512814/23fc93d4-e892-11e6-9e45-94041dbe8eba.png">

Keyboard is shown:

<img width="439" alt="screenshot 2017-02-01 15 26 56" src="https://cloud.githubusercontent.com/assets/346214/22513062/e4e1835c-e892-11e6-93b7-fe5616135b91.png">

---

Let's use "adjustResize", it seems to be a reasonable default in most cases and people can always change the constant in their AndroidManifest.xml if needed. Definitely better than the default "adjustUnspecified" we've been using until now.

This is a BREAKING change because some libraries like [react-native-keyboard-spacer](https://github.com/Andr3wHur5t/react-native-keyboard-spacer) might be making assumptions about the constant being set to "adjustUnspecified" and therefore might not work correctly in new apps. Will create an issue on that repo, tweet about this change and add it to the breaking changes doc.

**Test plan (required)**

Soft keyboard is handled correctly without the use of `KeyboardAvoidingView` or any `KeyboardSpacer` - no need to hack around the keyboard in JS, Android resizes the UI for us:

<img width="603" alt="screenshot 2017-02-01 15 24 47" src="https://cloud.githubusercontent.com/assets/346214/22512999/b761bcee-e892-11e6-902c-a21e558562aa.png">
