### PR TITLE
Clarify language specifying array mutation is an error

### DIFF
--- a/Libraries/CustomComponents/ListView/ListViewDataSource.js
+++ b/Libraries/CustomComponents/ListView/ListViewDataSource.js
@@ -70,7 +70,7 @@ type ParamType = {
  *
  * In this example, a component receives data in chunks, handled by
  * `_onDataArrived`, which concats the new data onto the old data and updates the
- * data source.  We use `concat` to create a new array - mutating `this._data`,
+ * data source.  We use `concat` to create a new array because mutating `this._data`,
  * e.g. with `this._data.push(newRowData)`, would be an error. `_rowHasChanged`
  * understands the shape of the row data and knows how to efficiently compare
  * it.


### PR DESCRIPTION
The use of a hyphen/dash with this sentence structure makes it possible to first read the sentence as:

> _"We use `concat` to create a new array [i.e.] mutating `this._data` [...]"_.

Replacing the hyphen with "because" (or "since" or "as" or an em-dash) makes the meaning more obvious and reduces likelihood of an initial misreading.

**Test plan (required)**

Read the new sentence and notice you are less confused about its meaning.

NOTE: I'm not going to sign the CLA for this change.