### PR TITLE
Fix Buck files after removing RecyclerViewBackedScrollView

### DIFF
--- a/ReactAndroid/src/androidTest/java/com/facebook/react/tests/BUCK
+++ b/ReactAndroid/src/androidTest/java/com/facebook/react/tests/BUCK
@@ -1,7 +1,6 @@
 include_defs('//ReactAndroid/DEFS')
 
 deps = [
-  '//java/com/facebook/fbreact/views/recyclerview:recyclerview',
   react_native_dep('third-party/android/support/v4:lib-support-v4'),
   react_native_dep('third-party/java/jsr-305:jsr-305'),
   react_native_dep('third-party/java/junit:junit'),

--- a/ReactAndroid/src/main/java/com/facebook/react/shell/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/shell/BUCK
@@ -4,7 +4,6 @@ android_library(
   name = 'shell',
   srcs = glob(['**/*.java']),
   deps = [
-    '//java/com/facebook/fbreact/views/recyclerview:recyclerview',
     react_native_dep('libraries/fresco/fresco-react-native:imagepipeline'),
     react_native_dep('libraries/soloader/java/com/facebook/soloader:soloader'),
     react_native_dep('third-party/android/support/v4:lib-support-v4'),


### PR DESCRIPTION
Remove unused deps to fix broken CI: https://circleci.com/gh/facebook/react-native/15242

Missed this in https://github.com/facebook/react-native/commit/6ec5654e7a26b856dbe26b2ba74c15ec258f065e.

**Test plan (required)**

The `buck fetch ReactAndroid/src/main/java/com/facebook/react/shell` that's failing on CI worked locally.