### PR TITLE
NavigationHeader - Support custom title interpolators

### DIFF
--- a/Libraries/CustomComponents/NavigationExperimental/NavigationHeader.js
+++ b/Libraries/CustomComponents/NavigationExperimental/NavigationHeader.js
@@ -74,6 +74,7 @@ type Props = NavigationSceneRendererProps & {
   style?: any,
   viewProps?: any,
   statusBarHeight: number | Animated.Value,
+  titleStyleInterpolator?: NavigationStyleInterpolator,
 };
 
 type SubViewName = 'left' | 'title' | 'right';
@@ -118,6 +119,7 @@ class NavigationHeader extends React.Component<DefaultProps, Props, any> {
     renderTitleComponent: PropTypes.func,
     style: View.propTypes.style,
     statusBarHeight: PropTypes.number,
+    titleStyleInterpolator: PropTypes.func,
     viewProps: PropTypes.shape(View.propTypes),
   };
 
@@ -189,7 +191,7 @@ class NavigationHeader extends React.Component<DefaultProps, Props, any> {
       props,
       'title',
       this.props.renderTitleComponent,
-      NavigationHeaderStyleInterpolator.forCenter,
+      this.props.titleStyleInterpolator || NavigationHeaderStyleInterpolator.forCenter,
     );
   };
 


### PR DESCRIPTION
This pull request is a follow up of [#11082](https://github.com/facebook/react-native/pull/11082) and allows a `NavigationHeader` to receive a `titleStyleInterpolator` prop to override the default `_forCenter` interpolator.

In the first gif you'll see that [#11082](https://github.com/facebook/react-native/pull/11082) allows us to provide a custom interpolator for the scene. However the title animation is inconsistent in terms of direction with the scene.

![BEFORE_PROP_DEMO](https://thumbs.gfycat.com/GlaringWarpedEsok-size_restricted.gif)

Adding a `titleStyleInyterpolator` to the `NavigationHeader` corrects this:

![AFTER_PROP_DEMO](https://thumbs.gfycat.com/UnderstatedBiodegradableInchworm-size_restricted.gif)
