### PR TITLE
Fix tutorial hello world so it can run on recently generated project

### DIFF
--- a/docs/Tutorial.md
+++ b/docs/Tutorial.md
@@ -29,7 +29,7 @@ class HelloWorldApp extends Component {
   }
 }
 
-AppRegistry.registerComponent('HelloWorldApp', () => HelloWorldApp);
+AppRegistry.registerComponent('AwesomeProject', () => HelloWorldApp);
 ```
 
 If you are feeling curious, you can play around with sample code directly in the web simulators. You can also paste it into your `index.ios.js` or `index.android.js` file to create a real app on your local machine.


### PR DESCRIPTION
This is a near clone of https://github.com/facebook/react-native/pull/12086, which was closed I guess because there was no test plan.

**Problem**: The very first hello world example, right after creating a new project, is broken. It runs in react web simulator but not in the recently created project as the text below it suggests

**Solution**: example should do `AppRegistry.registerComponent('AwesomeProject', () => HelloWorldApp);` instead of `AppRegistry.registerComponent('HelloWorldApp', () => HelloWorldApp);`

**Test plan should be simple enough to understand with a dry-run:**


create project as told in http://facebook.github.io/react-native/docs/getting-started.html
`react-native init AwesomeProject`
run project as told in http://facebook.github.io/react-native/docs/getting-started.html
`cd AwesomeProject`
`react-native run-android`

edit index.android.js as told in http://facebook.github.io/react-native/docs/tutorial.html#content and replace with this content

```
import React, { Component } from 'react';
import { AppRegistry, Text } from 'react-native';

class HelloWorldApp extends Component {
  render() {
    return (
      <Text>Hello world!</Text>
    );
  }
}

AppRegistry.registerComponent('HelloWorldApp', () => HelloWorldApp);
```

Reload. See a nice red error screen. Open android/app/src/main/java/com/awesomeproject/MainActivity.java and notice it’s still looking for something called AwesomeProject

```
public class MainActivity extends ReactActivity {

    /**
     * Returns the name of the main component registered from JavaScript.
     * This is used to schedule rendering of the component.
     */
    @Override
    protected String getMainComponentName() {
        return "AwesomeProject";
    }
}
```

Change last line in index.android.js to 

`AppRegistry.registerComponent('AwesomeProject', () => HelloWorldApp);`

Reload. It works.

