### PR TITLE
Fix RCTPicker crash

### DIFF
--- a/React/Views/RCTPicker.m
+++ b/React/Views/RCTPicker.m
@@ -98,7 +98,7 @@ numberOfRowsInComponent:(__unused NSInteger)component
       didSelectRow:(NSInteger)row inComponent:(__unused NSInteger)component
 {
   _selectedIndex = row;
-  if (_onChange) {
+  if (_onChange && _items.count > row) {
     _onChange(@{
       @"newIndex": @(row),
       @"newValue": RCTNullIfNil(_items[row][@"value"]),


### PR DESCRIPTION
If user slide picker when picker item is zero, `UIPickerViewDelegate` will call `pickerView:didSelectRow:inComponent` row=0, `_items[row][@"value"]` will crash. 