### PR TITLE
Add Animated.ValueXY.extractOffset

### DIFF
--- a/Libraries/Animated/src/AnimatedImplementation.js
+++ b/Libraries/Animated/src/AnimatedImplementation.js
@@ -999,6 +999,11 @@ class AnimatedValueXY extends AnimatedWithChildren {
     this.y.flattenOffset();
   }
 
+  extractOffset(): void {
+    this.x.extractOffset();
+    this.y.extractOffset();
+  }
+
   __getValue(): {x: number, y: number} {
     return {
       x: this.x.__getValue(),


### PR DESCRIPTION
### Change

The `extractOffset` method is previously implemented on `Animated.Value`, along with `setOffset` and `flattenOffset`. Both of the latter methods are proxied on `Animated.ValueXY`, but `extractOffset` is not. This commit adds the missing method. 

### Rationale

When creating draggable elements in XY space, in order to compensate for previous gestures' offsets, we currently need to do something like the following at the beginning or end of each gesture:
```
xy.setOffset(xy.__getValue());
xy.setValue({x: 0, y: 0});
```

After this commit, the API is equivalent to using a plain `Animated.Value`:
```
xy.extractOffset();
```
