### PR TITLE
Update .npmignore to include generated bundle file

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,3 @@
 # rnpm
 /local-cli/rnpm
+/local-cli/server/middleware/heapCapture/bundle.js


### PR DESCRIPTION
to: @mkonicek @grabbou 

Fixes #12183 
Fixes #12196 

This PR is a followup from #12185 which added this file to the `.gitignore`, but was still not enough because NPM will only use `.npmignore` since one is defined