### PR TITLE
Fix UIManager setFrame forView warnings

### DIFF
--- a/React/Base/RCTRootView.m
+++ b/React/Base/RCTRootView.m
@@ -411,7 +411,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder:(nonnull NSCoder *)aDecoder)
 {
   super.frame = frame;
   if (self.reactTag && _bridge.isValid) {
-    [_bridge.uiManager setFrame:frame forView:self];
+    [_bridge.uiManager setSize:frame.size forView:self];
   }
 }
 

--- a/React/Views/RCTModalHostView.m
+++ b/React/Views/RCTModalHostView.m
@@ -56,7 +56,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:coder)
 - (void)notifyForBoundsChange:(CGRect)newBounds
 {
   if (_reactSubview && _isPresented) {
-    [_bridge.uiManager setFrame:newBounds forView:_reactSubview];
+    [_bridge.uiManager setSize:newBounds.size forView:_reactSubview];
     [self notifyForOrientationChange];
   }
 }


### PR DESCRIPTION
RCTUIManager's setFrame forView is deprecated, thus there are deprecation warnings in XCode. 

Internally setFrameForView is just calling setSizeForView, so we can modify the following files to call setSizeForView directly. 

reference: setFrameForView calling setSizeForView: (https://github.com/facebook/react-native/blob/master/React/Modules/RCTUIManager.m#L1658)

This fixes another warning for: https://github.com/facebook/react-native/issues/11736