### PR TITLE
Allow binary files to be upgraded

### DIFF
--- a/react-native-git-upgrade/cliEntry.js
+++ b/react-native-git-upgrade/cliEntry.js
@@ -317,7 +317,7 @@ async function run(requestedVersion, cliArgs) {
     await exec('git commit -m "New version" --allow-empty', verbose);
 
     log.info('Generate the patch between the 2 versions');
-    const diffOutput = await exec('git diff HEAD~1 HEAD --no-color', verbose);
+    const diffOutput = await exec('git diff --binary --no-color HEAD~1 HEAD', verbose);
 
     log.info('Save the patch in temp directory');
     const patchPath = path.resolve(tmpDir, `upgrade_${currentVersion}_${newVersion}.patch`);

--- a/react-native-git-upgrade/package.json
+++ b/react-native-git-upgrade/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-git-upgrade",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "license": "BSD-3-Clause",
   "description": "The React Native upgrade tool",
   "main": "cli.js",

--- a/react-native-git-upgrade/package.json
+++ b/react-native-git-upgrade/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-git-upgrade",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "license": "BSD-3-Clause",
   "description": "The React Native upgrade tool",
   "main": "cli.js",


### PR DESCRIPTION
### Motivation

`react-native-git-upgrade` doesn't handle the binary files. An error is thrown if the user has changed the default Android icons. See #11402 

With this PR, the upgrader would also be ready for the assets optimization: #10408 by @GantMan 

### Test plan

- Publish `react-native-git-upgrade` to sinopia
- `npm install -g react-native-git-upgrade`

#### Scenario 1: user binary file changed

- Init a new project with an old version: `react-native init MyApp --version=0.40.0`
- Replace an Android icon (i.e. `MyApp/android/app/src/main/res/mipmap-hdpi/ic_launcher.png`) by any other image file.
- Change the content of a text file.
- Run `react-native-git-upgrade`

👉 The project is upgraded successfully.
👉 The replaced image file is still here.
👉 The text change is still here.

#### Scenario 2: RN binary file changed

- Replace an Android icon in the RN sources (i.e. https://github.com/facebook/react-native/blob/master/local-cli/templates/HelloWorld/android/app/src/main/res/mipmap-hdpi/ic_launcher.png)
- Publish `react-native` to sinopia
- Run `react-native-git-upgrade 1000.0.0` over any project using RN <= 0.40

👉 The project is upgraded successfully.
👉 The icon has been replaced.

#### Credits

Thanks to @gullitmiranda for his work on the problem (#12087), that has leads me to this solution.

Closes: #11402, #12087 
