### PR TITLE
Subclass RCTEventEmitter in RCTUIManager

### DIFF
--- a/React/Modules/RCTUIManager.h
+++ b/React/Modules/RCTUIManager.h
@@ -14,6 +14,7 @@
 #import <React/RCTInvalidating.h>
 #import <React/RCTRootView.h>
 #import <React/RCTViewManager.h>
+#import <React/RCTEventEmitter.h>
 
 /**
  * UIManager queue
@@ -53,7 +54,7 @@ RCT_EXTERN NSString *const RCTUIManagerRootViewKey;
 /**
  * The RCTUIManager is the module responsible for updating the view hierarchy.
  */
-@interface RCTUIManager : NSObject <RCTBridgeModule, RCTInvalidating>
+@interface RCTUIManager : RCTEventEmitter <RCTBridgeModule, RCTInvalidating>
 
 /**
  * Register a root view with the RCTUIManager.

--- a/React/Modules/RCTUIManager.m
+++ b/React/Modules/RCTUIManager.m
@@ -290,7 +290,7 @@ RCT_EXPORT_MODULE()
     self->_shadowViewRegistry = nil;
     self->_viewRegistry = nil;
     self->_bridgeTransactionListeners = nil;
-    [self setBridge:nil];
+    [super setBridge:nil];
 
     [[NSNotificationCenter defaultCenter] removeObserver:self];
     RCT_PROFILE_END_EVENT(RCTProfileTagAlways, @"");


### PR DESCRIPTION
Updating RCTUIManager to use new events system and subclass RCTEventEmitter and bring it into line with other native modules; this fixes the deprecation warnings from calling [_bridge sendDeviceEventWithName...]. 

Fixes warnings in https://github.com/facebook/react-native/issues/11736

I am presuming that we would rather take this approach than explicitly use -Wdeprecated-declarations?

**Test plan (required)**
I'm not sure how to test this other than running tests and manual testing?
Can we write a test for this?