### PR TITLE
[Release] Support the --remote option in bump-oss-version.js script

### DIFF
--- a/Releases.md
+++ b/Releases.md
@@ -44,8 +44,9 @@ Run:
 git checkout -b <version_you_are_releasing>-stable
 # e.g. git checkout -b 0.22-stable
 
-node ./scripts/bump-oss-version.js <exact-version_you_are_releasing>
-# e.g. node ./scripts/bump-oss-version.js 0.22.0-rc
+./scripts/bump-oss-version.js <exact-version_you_are_releasing>
+# e.g. ./scripts/bump-oss-version.js 0.22.0-rc
+# You can use the --remote option to specify a Git remote other than the default "origin"
 ```
 
 Circle CI will automatically run the tests and publish to npm with the version you have specified (e.g `0.22.0-rc`) and tag `next` meaning that this version will not be installed for users by default.
@@ -112,8 +113,8 @@ git cherry-pick commitHash1
 If everything worked:
 
 ```bash
-node ./scripts/bump-oss-version.js <exact_version_you_are_releasing>
-# e.g. node ./scripts/bump-oss-version.js 0.28.0-rc.1
+./scripts/bump-oss-version.js <exact_version_you_are_releasing>
+# e.g. ./scripts/bump-oss-version.js 0.28.0-rc.1
 ````
 
 -------------------
@@ -141,8 +142,8 @@ git cherry-pick commitHash1
 If everything worked:
 
 ```bash
-node ./scripts/bump-oss-version.js <exact_version_you_are_releasing>
-# e.g. node ./scripts/bump-oss-version.js 0.22.0
+./scripts/bump-oss-version.js <exact_version_you_are_releasing>
+# e.g. ./scripts/bump-oss-version.js 0.22.0
 ```
 
 #### Update the release notes

--- a/scripts/bump-oss-version.js
+++ b/scripts/bump-oss-version.js
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 /**
  * Copyright (c) 2015-present, Facebook, Inc.
  * All rights reserved.
@@ -17,6 +18,13 @@
 /*eslint-disable no-undef */
 require(`shelljs/global`);
 
+const minimist = require('minimist');
+
+let argv = minimist(process.argv.slice(2), {
+  alias: {remote: 'r'},
+  default: {remote: 'origin'},
+});
+
 // - check we are in release branch, e.g. 0.33-stable
 let branch = exec(`git symbolic-ref --short HEAD`, {silent: true}).stdout.trim();
 
@@ -30,7 +38,7 @@ let versionMajor = branch.slice(0, branch.indexOf(`-stable`));
 
 // - check that argument version matches branch
 // e.g. 0.33.1 or 0.33.0-rc4
-let version = process.argv[2];
+let version = argv._[0];
 if (!version || version.indexOf(versionMajor) !== 0) {
   echo(`You must pass a tag like ${versionMajor}.[X]-rc[Y] to bump a version`);
   exit(1);
@@ -77,17 +85,18 @@ if (exec(`git tag v${version}`).code) {
 }
 
 // Push newly created tag
-exec(`git push origin v${version}`);
+let remote = argv.remote;
+exec(`git push ${remote} v${version}`);
 
 // Tag latest if doing stable release
 if (version.indexOf(`rc`) === -1) {
   exec(`git tag -d latest`);
-  exec(`git push origin :latest`);
+  exec(`git push ${remote} :latest`);
   exec(`git tag latest`);
-  exec(`git push origin latest`);
+  exec(`git push ${remote} latest`);
 }
 
-exec(`git push origin ${branch} --follow-tags`);
+exec(`git push ${remote} ${branch} --follow-tags`);
 
 exit(0);
 /*eslint-enable no-undef */


### PR DESCRIPTION
In my RN checkout, I use "upstream" as my remote instead of "origin" -> this lets me run `scripts/bump-oss-version.js --remote upstream 0.41.1` for example.

Also made the script executable so we don't need to put `node` in front of it, and updated the Releases.md doc.

Test Plan: Did a dry run, saw that without the `--remote` flag the default remote is still `origin` and that specifying the flag let me override the origin.
