### PR TITLE
Update LayoutExample.js

### DIFF
--- a/Examples/UIExplorer/js/LayoutExample.js
+++ b/Examples/UIExplorer/js/LayoutExample.js
@@ -28,7 +28,14 @@ var {
   StyleSheet,
   Text,
   View,
+  Platform,
+  UIManager,
 } = ReactNative;
+
+if (Platform.OS === 'android') {
+  UIManager.setLayoutAnimationEnabledExperimental &&
+    UIManager.setLayoutAnimationEnabledExperimental(true);
+}
 
 var UIExplorerBlock = require('./UIExplorerBlock');
 var UIExplorerPage = require('./UIExplorerPage');


### PR DESCRIPTION
Added ```UIManager.setLayoutAnimationEnabledExperimental(true)``` if the user is on Android. 
#### Motivation
Just for the sake of clarity: the code I've added is already written atop [this official doc page](https://facebook.github.io/react-native/docs/layoutanimation.html#layoutanimation). However, it wasn't reported in the example code. Now it is.