### PR TITLE
fix new-library command #9968

### DIFF
--- a/local-cli/library/library.js
+++ b/local-cli/library/library.js
@@ -44,7 +44,8 @@ function library(argv, config, args) {
       return;
     }
 
-    const dest = f.replace(/Sample/g, args.name).replace(/^_/, '.');
+    const relativePath = f.replace(source, '').replace(/^\//, './');
+    const dest = relativePath.replace(/Sample/g, args.name).replace(/^_/, '.');
     copyAndReplace(
       path.resolve(source, f),
       path.resolve(libraryDest, dest),


### PR DESCRIPTION
Fixes issue #9968.

Previously the requested library sample have been copied to `node_modules/react-native/Libraries/[libraryName]`.
But it should be copied to `[projectpath]/Libraries/[libraryName]`.

Because `dest` is already an absolute path, `path.resolve` [will ignore](https://nodejs.org/api/path.html#path_path_resolve_paths) `libraryDest`.
To fix that, I updated `dest` to an relative path by cutting off the `source`-path.

```
// Before (dest):
/Users/Patrick/Development/tmp/helloRN/node_modules/react-native/Libraries/newLib/newLib.android.js
// Libraries folder created, but empty

After (dest):
./newLib.android.js
```

**Test plan (required)**

*Inside the project directory*

#### `ls -la`
```bash
total 80
drwxr-xr-x   16 Patrick  staff    544  6 Feb 13:58 .
drwxr-xr-x    7 Patrick  staff    238  6 Feb 13:08 ..
-rw-r--r--    1 Patrick  staff     31  6 Feb 13:10 .babelrc
-rw-r--r--    1 Patrick  staff    114  6 Feb 13:10 .buckconfig
-rw-r--r--    1 Patrick  staff   1359  6 Feb 13:10 .flowconfig
-rw-r--r--    1 Patrick  staff     16  6 Feb 13:10 .gitattributes
-rw-r--r--    1 Patrick  staff    791  6 Feb 13:10 .gitignore
-rw-r--r--    1 Patrick  staff      2  6 Feb 13:10 .watchmanconfig
drwxr-xr-x    4 Patrick  staff    136  6 Feb 13:10 __tests__
drwxr-xr-x   10 Patrick  staff    340  6 Feb 13:10 android
-rw-r--r--    1 Patrick  staff     51  6 Feb 13:10 app.json
-rw-r--r--    1 Patrick  staff   1097  6 Feb 13:10 index.android.js
-rw-r--r--    1 Patrick  staff   1063  6 Feb 13:10 index.ios.js
drwxr-xr-x    7 Patrick  staff    238  6 Feb 13:10 ios
drwxr-xr-x  556 Patrick  staff  18904  6 Feb 13:10 node_modules
-rw-r--r--    1 Patrick  staff    423  6 Feb 13:10 package.json
```

#### `react-native new-library --name newLib`
```bash
// Direct output of command
Created library in /Users/Patrick/Development/tmp/helloRN/Libraries/newLib
Next Steps:
   Link your library in Xcode:
   https://facebook.github.io/react-native/docs/linking-libraries-ios.html#content

(node:52145) DeprecationWarning: Calling an asynchronous function without callback is deprecated.


// Output of ls -la Libraries/newLib
total 40
drwxr-xr-x  8 Patrick  staff  272  6 Feb 13:59 .
drwxr-xr-x  3 Patrick  staff  102  6 Feb 13:59 ..
-rw-r--r--  1 Patrick  staff  254  6 Feb 13:59 newLib.android.js
-rw-r--r--  1 Patrick  staff   82  6 Feb 13:59 newLib.h
-rw-r--r--  1 Patrick  staff  277  6 Feb 13:59 newLib.ios.js
-rw-r--r--  1 Patrick  staff  129  6 Feb 13:59 newLib.m
drwxr-xr-x  3 Patrick  staff  102  6 Feb 13:59 newLib.xcodeproj
-rw-r--r--  1 Patrick  staff   75  6 Feb 13:59 package.json
```