### PR TITLE
Fix use of uninitialized memory when unsetting `flex` property

### DIFF
--- a/React/Views/RCTComponentData.m
+++ b/React/Views/RCTComponentData.m
@@ -234,9 +234,8 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
             setterBlock = ^(id target, id json) { \
               if (json) { \
                 if (!setDefaultValue && target) { \
-                  if ([target respondsToSelector:getter]) { \
-                    defaultValue = get(target, getter); \
-                  } \
+                  RCTAssert([target respondsToSelector:getter], @"prop getter does not exist: %@", NSStringFromSelector(getter)); \
+                  defaultValue = get(target, getter); \
                   setDefaultValue = YES; \
                 } \
                 set(target, setter, convert([RCTConvert class], type, json)); \

--- a/React/Views/RCTShadowView.m
+++ b/React/Views/RCTShadowView.m
@@ -636,6 +636,11 @@ static inline YGSize RCTShadowViewMeasure(YGNodeRef node, float width, YGMeasure
   YGNodeStyleSetFlex(_cssNode, value);
 }
 
+- (float)flex
+{
+  return YGNodeStyleGetFlex(_cssNode);
+}
+
 - (void)setFlexBasis:(YGValue)value
 {
   RCT_SET_YGVALUE(value, YGNodeStyleSetFlexBasis, _cssNode);

--- a/React/Views/RCTSwitch.m
+++ b/React/Views/RCTSwitch.m
@@ -14,6 +14,12 @@
 
 @implementation RCTSwitch
 
+// `on` is a component prop, so we must expose symmetrical `on` and `setOn` methods.
+// UIView breaks convention with the name `isOn`, so we simply forward.
+- (BOOL)on {
+  return [self isOn];
+}
+
 - (void)setOn:(BOOL)on animated:(BOOL)animated {
   _wasOn = on;
   [super setOn:on animated:animated];

--- a/React/Views/RCTTabBar.m
+++ b/React/Views/RCTTabBar.m
@@ -149,6 +149,15 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
   _tabController.tabBar.translucent = translucent;
 }
 
+- (UIColor *)unselectedItemTintColor {
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_10_0
+  if ([_tabController.tabBar respondsToSelector:@selector(unselectedItemTintColor)]) {
+    return _tabController.tabBar.unselectedItemTintColor;
+  }
+#endif
+  return nil;
+}
+
 - (void)setUnselectedItemTintColor:(UIColor *)unselectedItemTintColor {
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_10_0
   if ([_tabController.tabBar respondsToSelector:@selector(unselectedItemTintColor)]) {

--- a/ReactCommon/yoga/yoga/Yoga.c
+++ b/ReactCommon/yoga/yoga/Yoga.c
@@ -442,6 +442,10 @@ void YGNodeStyleSetFlex(const YGNodeRef node, const float flex) {
   }
 }
 
+float YGNodeStyleGetFlex(const YGNodeRef node) {
+  return node->style.flex;
+}
+
 #define YG_NODE_PROPERTY_IMPL(type, name, paramName, instanceName) \
   void YGNodeSet##name(const YGNodeRef node, type paramName) {     \
     node->instanceName = paramName;                                \

--- a/ReactCommon/yoga/yoga/Yoga.h
+++ b/ReactCommon/yoga/yoga/Yoga.h
@@ -160,6 +160,7 @@ YG_NODE_STYLE_PROPERTY(YGOverflow, Overflow, overflow);
 YG_NODE_STYLE_PROPERTY(YGDisplay, Display, display);
 
 WIN_EXPORT void YGNodeStyleSetFlex(const YGNodeRef node, const float flex);
+WIN_EXPORT float YGNodeStyleGetFlex(const YGNodeRef node);
 YG_NODE_STYLE_PROPERTY(float, FlexGrow, flexGrow);
 YG_NODE_STYLE_PROPERTY(float, FlexShrink, flexShrink);
 YG_NODE_STYLE_PROPERTY_UNIT(YGValue, FlexBasis, flexBasis);


### PR DESCRIPTION
This PR fixes a bug that can be reproduced on iOS 9.3 with v0.41.1 using [this simple app](https://gist.github.com/jamesreggio/0d9896836cdee3fbbba7ac53ef77021a). It's important to note that the bug pertains to uninitialized memory and is therefore not guaranteed to reproduce at all.

## Description of the issue and fix

When a property on a node is set for the first time, we [read and store](https://github.com/facebook/react-native/blob/61ae070444d2bcda182bc2dbabb266f38a37c78d/React/Views/RCTComponentData.m#L236-L241) the property's initial value before updating it. Later, if the property is nullified in JavaScript, we'll [write the earlier-obtained initial value](https://github.com/facebook/react-native/blob/61ae070444d2bcda182bc2dbabb266f38a37c78d/React/Views/RCTComponentData.m#L244) to the native representation.

In order to obtain the initial value, there must be a property getter that corresponds to the setter. If no getter exists, [the slot to store the initial value](https://github.com/facebook/react-native/blob/61ae070444d2bcda182bc2dbabb266f38a37c78d/React/Views/RCTComponentData.m#L230) will remain silently uninitialized. If the property is
nullified from JavaScript, we'll write the garbage value of that uninitialized variable into the native representation, and chaos will ensue.

This commit makes three changes to resolve this issue:

1. It [adds an assertion](https://github.com/jamesreggio/react-native/commit/85828306f92ec841883f7fa1f63e3984b0a51864#diff-b9fc78351b7b976a36356ef6f08c1f79R237) that a getter exists every time a property is written. It would be better to enforce this statically, but I'm not aware of a means to accomplish this.

1. It [adds a getter](https://github.com/jamesreggio/react-native/commit/85828306f92ec841883f7fa1f63e3984b0a51864#diff-ab880099e5dcdec7edae37723f513885R639) for the `flex` property, which previously lacked one. Prior to this change, setting then removing the `flex` property on a view would result in layout glitches and redboxes about `NaN` and `Infinity` in the bound and offset of a view.

1. It adds a getter for the `on` property for RCTSwitch, which can never be undefined, but is triggering the newly-added assertion.

There have been a number of complaints (#2616, #3406, to name a few) about transient redboxes with messages about illegal `NaN`s and `Infinity`s. Because this bug pertains to uninitialized memory which non-deterministic by nature, it's possible that a number of these difficult-to-repro issues will be resolved by this bugfix.

## Test plan

Use the [simple repro app](https://gist.github.com/jamesreggio/0d9896836cdee3fbbba7ac53ef77021a) to confirm that the issue has been resolved.

## Concerns

I'm not in love with the idea of adding a dynamic assertion for asymmetrical (setter-only) properties. I would appreciate any suggestions of alternatives.

---

I discovered this issue when I was trying to figure out why [`react-native-foldview`](https://github.com/jmurzy/react-native-foldview) was repeatedly redboxing on iOS 9.3. It looks like other people [have reported this, too](https://github.com/jmurzy/react-native-foldview/issues/11). (cc: @jmurzy)

I believe that this regression pertains to commit 62177dbb3b4d4bdedf0c7a6fe9140ce049743fbf by @nicklockwood (reviewed by @javache), so it would be great to have either of your eyes on it.