### PR TITLE
CLI: Update Navigation app template

### DIFF
--- a/local-cli/templates/HelloNavigation/lib/Backend.js
+++ b/local-cli/templates/HelloNavigation/lib/Backend.js
@@ -1,0 +1,116 @@
+
+// This file just a dummy example of a HTTP API to talk to the backend.
+// The state of the "database" that would normally live on the server
+// is simply held here in memory.
+
+const backendStateForLoggedInPerson = {
+  chats: [
+    {
+      name: 'Claire',
+      messages: [
+        {
+          name: 'Claire',
+          text: 'I ❤️ React Native!',
+        },
+      ],
+    },
+    {
+      name: 'John',
+      messages: [
+        {
+          name: 'John',
+          text: 'I ❤️ React Native!',
+        },
+      ],
+    }
+  ],
+};
+
+/**
+ * Randomly simulate network failures.
+ * It is useful to enable this during development to make sure our app works
+ * in real-world conditions.
+ */
+function isNetworkFailure() {
+  const chanceOfFailure = 0;  // 0..1
+  return Math.random() < chanceOfFailure;
+}
+
+/**
+ * Helper for the other functions in this file.
+ * Simulates a short delay and then returns a provided value or failure.
+ * This is just a dummy example. Normally we'd make a HTTP request,
+ * see http://facebook.github.io/react-native/docs/network.html
+ */
+function _makeSimulatedNetworkRequest(getValue) {
+  const durationMs = 400;
+  return new Promise(function (resolve, reject) {
+    setTimeout(function () {
+      if (isNetworkFailure()) {
+        reject(new Error('Network failure'));
+      } else {
+        getValue(resolve, reject);
+      }
+    }, durationMs);
+  });
+}
+
+/**
+ * Fetch a list of all chats for the logged in person.
+ */
+async function fetchChatList() {
+  return _makeSimulatedNetworkRequest((resolve, reject) => {
+    resolve(backendStateForLoggedInPerson.chats.map(chat => chat.name))
+  });
+}
+
+/**
+ * Fetch a single chat.
+ */
+async function fetchChat(name) {
+  return _makeSimulatedNetworkRequest((resolve, reject) => {
+    resolve(
+      backendStateForLoggedInPerson.chats.find(
+        chat => chat.name === name
+      )
+    )
+  });
+}
+
+/**
+ * Send given message to given person.
+ */
+async function sendMessage({name, message}) {
+  return _makeSimulatedNetworkRequest((resolve, reject) => {
+    const chat = backendStateForLoggedInPerson.chats.find(
+      chat => chat.name === name
+    );
+    if (chat) {
+      chat.messages.push({
+        name: 'Me',
+        text: message,
+      });
+      resolve();
+    } else {
+      reject(new Error('Uknown person: ' + name));
+    }
+  });
+}
+
+const Backend = {
+  fetchChatList,
+  fetchChat,
+  sendMessage,
+};
+
+export default Backend;
+
+// In case you are looking into using Redux for state management,
+// this is how network requests are done in the f8 app which uses Redux:
+// - To load some data, a Component fires a Redux action, such as loadSession()
+// - That action makes the HTTP requests and then dispatches a redux action
+//   {type: 'LOADED_SESSIONS', results}
+// - Then all reducers get called and one of them updates a part of the application
+//   state by storing the results
+// - Redux re-renders the connected Components
+// See https://github.com/fbsamples/f8app/search?utf8=%E2%9C%93&q=loaded_sessions

--- a/local-cli/templates/HelloNavigation/views/HomeScreenTabNavigator.js
+++ b/local-cli/templates/HelloNavigation/views/HomeScreenTabNavigator.js
@@ -1,9 +1,4 @@
 import React, { Component } from 'react';
-import {
-  ListView,
-  Platform,
-  Text,
-} from 'react-native';
 import { TabNavigator } from 'react-navigation';
 
 import ChatListScreen from './chat/ChatListScreen';

--- a/local-cli/templates/HelloNavigation/views/welcome/WelcomeScreen.js
+++ b/local-cli/templates/HelloNavigation/views/welcome/WelcomeScreen.js
@@ -4,7 +4,6 @@ import {
   Platform,
   StyleSheet,
   Text,
-  View,
 } from 'react-native';
 
 import ListItem from '../../components/ListItem';

--- a/local-cli/templates/HelloNavigation/views/welcome/WelcomeText.android.js
+++ b/local-cli/templates/HelloNavigation/views/welcome/WelcomeText.android.js
@@ -1,9 +1,8 @@
 import React, { Component } from 'react';
 import {
-  AppRegistry,
   StyleSheet,
   Text,
-  View
+  View,
 } from 'react-native';
 
 export default class WelcomeText extends Component {
@@ -22,8 +21,8 @@ export default class WelcomeText extends Component {
           file views/welcome/WelcomeText.android.js.
         </Text>
         <Text style={styles.instructions}>
-          Press Cmd+R to reload,{'\n'}
-          Cmd+D or shake for dev menu.
+          Double tap R on your keyboard to reload,{'\n'}
+          Shake or press menu button for dev menu.
         </Text>
       </View>
     );

--- a/local-cli/templates/HelloNavigation/views/welcome/WelcomeText.ios.js
+++ b/local-cli/templates/HelloNavigation/views/welcome/WelcomeText.ios.js
@@ -1,9 +1,8 @@
 import React, { Component } from 'react';
 import {
-  AppRegistry,
   StyleSheet,
   Text,
-  View
+  View,
 } from 'react-native';
 
 export default class WelcomeText extends Component {


### PR DESCRIPTION
Update the template that will be used by `react-native init --template navigation`. The goal is to make it easier for people to get started by demonstrating a few very basic concepts such as navigation, lists and text input.

**Test plan (required)**

<img src="https://cloud.githubusercontent.com/assets/346214/22697898/ced66f52-ed4a-11e6-9b90-df6daef43199.gif" alt="Android Example" height="800" style="float: left"/>

<img src="https://cloud.githubusercontent.com/assets/346214/22697901/cfeab3e4-ed4a-11e6-8552-d76585317ac2.gif" alt="iOS Example" height="800"/>




