### PR TITLE
Extract docs during static site generation

### DIFF
--- a/website/server/convert.js
+++ b/website/server/convert.js
@@ -92,6 +92,10 @@ function buildFile(layout, metadata, rawContent) {
 }
 
 function execute(options) {
+  if (options === undefined) {
+      options = {};
+  }
+
   var DOCS_MD_DIR = '../docs/';
   var BLOG_MD_DIR = '../blog/';
 

--- a/website/server/generate.js
+++ b/website/server/generate.js
@@ -16,7 +16,7 @@ var mkdirp = require('mkdirp');
 var server = require('./server.js');
 var Feed = require('feed');
 
-require('./convert.js')();
+require('./convert.js')({extractDocs: true});
 server.noconvert = true;
 
 // Sadly, our setup fatals when doing multiple concurrent requests


### PR DESCRIPTION
Addresses an issue introduced in 6a8200df95d3c5a732fc1f9f104f83556645954f. While that commit successfully avoids extracting the docs while developing locally, it neglected to handle the case when the site was being built for deployment. As a result this broke CI.

Options are now optional as they should be, and the site generation script will ensure docs are built during deployment.