### PR TITLE
iOS: Remove leading space from accessibilityLabel

### DIFF
--- a/React/Views/RCTView.m
+++ b/React/Views/RCTView.m
@@ -81,11 +81,17 @@
 
 static NSString *RCTRecursiveAccessibilityLabel(UIView *view)
 {
+  BOOL isFirstIteration = YES;
   NSMutableString *str = [NSMutableString stringWithString:@""];
   for (UIView *subview in view.subviews) {
+    if (isFirstIteration) {
+      isFirstIteration = NO;
+    } else {
+      [str appendString:@" "];
+    }
+    
     NSString *label = subview.accessibilityLabel;
     if (label) {
-      [str appendString:@" "];
       [str appendString:label];
     } else {
       [str appendString:RCTRecursiveAccessibilityLabel(subview)];

--- a/React/Views/RCTView.m
+++ b/React/Views/RCTView.m
@@ -141,8 +141,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:unused)
   if (super.accessibilityLabel) {
     return super.accessibilityLabel;
   }
-  NSString *str = RCTRecursiveAccessibilityLabel(self);
-  return [str stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+  return RCTRecursiveAccessibilityLabel(self);
 }
 
 - (void)setPointerEvents:(RCTPointerEvents)pointerEvents

--- a/React/Views/RCTView.m
+++ b/React/Views/RCTView.m
@@ -141,7 +141,8 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:unused)
   if (super.accessibilityLabel) {
     return super.accessibilityLabel;
   }
-  return RCTRecursiveAccessibilityLabel(self);
+  NSString *str = RCTRecursiveAccessibilityLabel(self);
+  return [str stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
 }
 
 - (void)setPointerEvents:(RCTPointerEvents)pointerEvents


### PR DESCRIPTION
In some cases, the accessibilityLabel contains a leading space. This is because `RCTRecursiveAccessibilityLabel` adds a space before every iteration of the loop including the first.

After this change, the contract is that:
  - `RCTRecursiveAccessibilityLabel` always returns a string with a leading space.
  - `accessibilityLabel` never returns a string with a leading space.

**Test plan**

I created a test app with the following code:

```
<View style={{height: 100, width: 100, backgroundColor: 'steelblue'}} accessible={true}>
  <View style={{height: 20, width: 20, backgroundColor: 'red'}} accessibilityLabel='One' />
  <View style={{height: 20, width: 20, backgroundColor: 'yellow'}} accessibilityLabel='Two' />
  <View style={{height: 20, width: 20, backgroundColor: 'green'}} accessibilityLabel='Three' />
</View>
```

Before this change, the accessibilityLabel of the outermost View was " One Two Three" (notice the leading space).

After this change, it is "One Two Three" as desired.

Adam Comella
Microsoft Corp.
