### PR TITLE
Add onabort to XHR classes

### DIFF
--- a/Libraries/Network/XMLHttpRequest.js
+++ b/Libraries/Network/XMLHttpRequest.js
@@ -81,6 +81,7 @@ class XMLHttpRequestEventTarget extends EventTarget(...REQUEST_EVENTS) {
   onprogress: ?Function;
   ontimeout: ?Function;
   onerror: ?Function;
+  onabort: ?Function;
   onloadend: ?Function;
 }
 
@@ -109,6 +110,7 @@ class XMLHttpRequest extends EventTarget(...XHR_EVENTS) {
   onprogress: ?Function;
   ontimeout: ?Function;
   onerror: ?Function;
+  onabort: ?Function;
   onloadend: ?Function;
   onreadystatechange: ?Function;
 


### PR DESCRIPTION
04d870b added support for onabort in XHRs. The other on* events are declared on XMLHttpRequest and XMLHttpRequestEventTarget. This adds onabort there as well.

Adam Comella
Microsoft Corp.