### PR TITLE
Init diffclamp node at 0 to avoid problems with NaN

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/animated/DiffClampAnimatedNode.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/animated/DiffClampAnimatedNode.java
@@ -28,7 +28,7 @@ import com.facebook.react.bridge.ReadableMap;
     mMin = config.getDouble("min");
     mMax = config.getDouble("max");
 
-    mValue = mLastValue = getInputNodeValue();
+    mValue = mLastValue = 0;
   }
 
   @Override


### PR DESCRIPTION
Some nodes have a value of NaN initially so if we assign the value of the input in the constructor it is possible we get NaN as a value and then it will break when trying to update the value. Initializing at 0 is actually fine with this node since it will get updated properly in the `update` method.

**Test plan**
Tested in an app that uses native animated diffclamp where I noticed the issue. Made sure this change fixed it.