### PR TITLE
Change cursor color when using selectionColor on Android

### DIFF
--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -409,7 +409,7 @@ const TextInput = React.createClass({
      */
     secureTextEntry: PropTypes.bool,
     /**
-    * The highlight (and cursor on iOS) color of the text input.
+    * The highlight and cursor color of the text input.
     */
     selectionColor: ColorPropType,
     /**

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/BUCK
@@ -5,6 +5,7 @@ android_library(
   srcs = glob(['*.java']),
   deps = [
     YOGA_TARGET,
+    react_native_dep('third-party/android/support/v4:lib-support-v4'),
     react_native_dep('third-party/java/infer-annotations:infer-annotations'),
     react_native_dep('third-party/java/jsr-305:jsr-305'),
     react_native_target('java/com/facebook/react/bridge:bridge'),
@@ -22,4 +23,3 @@ android_library(
     'PUBLIC',
   ],
 )
-

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
@@ -18,6 +18,7 @@ import java.util.Map;
 import android.graphics.drawable.Drawable;
 import android.graphics.PorterDuff;
 import android.graphics.Typeface;
+import android.support.v4.content.ContextCompat;
 import android.text.Editable;
 import android.text.InputFilter;
 import android.text.InputType;
@@ -318,15 +319,15 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
 
   private void setCursorColor(ReactEditText view, @Nullable Integer color) {
     // Evil method that uses reflection because there is no public API to changes
-    // the cursor color programatically.
+    // the cursor color programmatically.
     // Based on http://stackoverflow.com/questions/25996032/how-to-change-programatically-edittext-cursor-color-in-android.
     try {
-      // Get the original cusor drawable resource.
+      // Get the original cursor drawable resource.
       Field cursorDrawableResField = TextView.class.getDeclaredField("mCursorDrawableRes");
       cursorDrawableResField.setAccessible(true);
       int drawableResId = cursorDrawableResField.getInt(view);
 
-      Drawable drawable = view.getContext().getDrawable(drawableResId);
+      Drawable drawable = ContextCompat.getDrawable(view.getContext(), drawableResId);
       if (color != null) {
         drawable.setColorFilter(color, PorterDuff.Mode.SRC_IN);
       }
@@ -339,10 +340,10 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
       Field cursorDrawableField = editor.getClass().getDeclaredField("mCursorDrawable");
       cursorDrawableField.setAccessible(true);
       cursorDrawableField.set(editor, drawables);
-    } catch (Exception ex) {
+    } catch (NoSuchFieldException ex) {
       // Ignore errors to avoid crashing if these private fields don't exist on modified
       // or future android versions.
-    }
+    } catch (IllegalAccessException ex) {}
   }
 
   @ReactProp(name = "selectTextOnFocus", defaultBoolean = false)

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
@@ -321,27 +321,24 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
     // the cursor color programatically.
     // Based on http://stackoverflow.com/questions/25996032/how-to-change-programatically-edittext-cursor-color-in-android.
     try {
-      // Get the cursor resource id.
-      Field field = TextView.class.getDeclaredField("mCursorDrawableRes");
-      field.setAccessible(true);
-      int drawableResId = field.getInt(view);
+      // Get the original cusor drawable resource.
+      Field cursorDrawableResField = TextView.class.getDeclaredField("mCursorDrawableRes");
+      cursorDrawableResField.setAccessible(true);
+      int drawableResId = cursorDrawableResField.getInt(view);
 
-      // Get the editor.
-      field = TextView.class.getDeclaredField("mEditor");
-      field.setAccessible(true);
-      Object editor = field.get(view);
-
-      // Get the drawable and set a color filter.
       Drawable drawable = view.getContext().getDrawable(drawableResId);
       if (color != null) {
         drawable.setColorFilter(color, PorterDuff.Mode.SRC_IN);
       }
       Drawable[] drawables = {drawable, drawable};
 
-      // Set the drawables.
-      field = editor.getClass().getDeclaredField("mCursorDrawable");
-      field.setAccessible(true);
-      field.set(editor, drawables);
+      // Update the current cursor drawable with the new one.
+      Field editorField = TextView.class.getDeclaredField("mEditor");
+      editorField.setAccessible(true);
+      Object editor = editorField.get(view);
+      Field cursorDrawableField = editor.getClass().getDeclaredField("mCursorDrawable");
+      cursorDrawableField.setAccessible(true);
+      cursorDrawableField.set(editor, drawables);
     } catch (Exception ex) {
       // Ignore errors to avoid crashing if these private fields don't exist on modified
       // or future android versions.


### PR DESCRIPTION
This matches the behavior on iOS, there was no way before to change the cursor color per input, it was only possible to change it globally via the theme. Ideally cursor color and selection color would be 2 different props but I think this is better than what we have (and matches iOS).

Sadly there is no api to change it pragmatically (only possible via xml) so this uses reflection and can easily break so it is wrapped in a try catch to avoid crashes. I think it is better to just silently fail in this case. Definetly not super happy about the solution but I think it's worth adding since it is possible to do it natively using xml so it would suck not to be able to do it in RN.

**Test plan**
Tested that the cursor has the same color as before the change when not setting the prop and that it gets the selectionColor color when set.