### PR TITLE
[RCTWebView] Fix webViewDidFinishLoad is called twice in iOS

### DIFF
--- a/React/Views/RCTWebView.m
+++ b/React/Views/RCTWebView.m
@@ -282,7 +282,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
   if (_messagingEnabled && webView.loading) {
     #if RCT_DEV
     // See isNative in lodash
-    NSString *testPostMessageNative = @"String(window.postMessage) === String(Object.hasOwnProperty).replace('hasOwnProperty', 'postMessage')";
+    NSString *testPostMessageNative = @"String(window.postMessage).replace('postMessage', '') === String(Object.hasOwnProperty).replace('hasOwnProperty', '')";
     BOOL postMessageIsNative = [
       [webView stringByEvaluatingJavaScriptFromString:testPostMessageNative]
       isEqualToString:@"true"

--- a/React/Views/RCTWebView.m
+++ b/React/Views/RCTWebView.m
@@ -279,7 +279,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
 
 - (void)webViewDidFinishLoad:(UIWebView *)webView
 {
-  if (_messagingEnabled) {
+  if (_messagingEnabled && webView.loading) {
     #if RCT_DEV
     // See isNative in lodash
     NSString *testPostMessageNative = @"String(window.postMessage) === String(Object.hasOwnProperty).replace('hasOwnProperty', 'postMessage')";
@@ -299,7 +299,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
     ];
     [webView stringByEvaluatingJavaScriptFromString:source];
   }
-  if (_injectedJavaScript != nil) {
+  if (_injectedJavaScript != nil && _onLoadingFinish && webView.loading) {
     NSString *jsEvaluationValue = [webView stringByEvaluatingJavaScriptFromString:_injectedJavaScript];
 
     NSMutableDictionary<NSString *, id> *event = [self baseEvent];


### PR DESCRIPTION
```javascript
class WebViewComponent extends Component {

  onLoad(event) {
    console.log(event);
  }

  render() {
    return (
      <WebView
        injectedJavaScript="alert('hello')"
        source={{uri: 'http://testserver.com/index.html'}}
        javaScriptEnabled={true}
        domStorageEnabled={true}
        onLoad={this.onLoad}
      />
    );
  }
}
```

index.html
```html
<!doctype html>
<html>
<head>
  <meta charset="utf-8">
  <title>Test Page</title>
</head>
<body>
  <iframe src="about:blank" />
</body>
</html>
```

In the above code,  

`OnLoad` method and `alert('hello')` are called twice in iOS because `iframe` tag.  
(Possibly, if there are two `iframe`, it will be called three times.)  

Also, In the below code,

```javascript
class WebViewComponent extends Component {

  onMessage(event) {
    console.log(event);
  }

  render() {
    return (
      <WebView
        source={{uri: 'http://testserver.com/index.html'}}
        javaScriptEnabled={true}
        domStorageEnabled={true}
        onMessage={this.onMessage}
      />
    );
  }
}
```

Because webViewDidFinishLoad is called twice, if add `onMessage` on webView property it raise an error like `Setting onMessage on a WebView overrides existing values of window.postMessage, but a previous value was defined`.

So, i changed the code to called only once.

Additionally, becoase some browser(ie. Mac Chrome 56.0.2924.87) is difference like below.
```javascript
> String(window.postMessage)
< "function () { [native code] }"

> String(window.hasOwnProperty)
< "function hasOwnProperty() { [native code] }"
```
So, if want to just checking that is `native code` the `code A` better then the `code B` i think.

### code A
```javascript
String(window.postMessage) === String(Object.hasOwnProperty).replace('hasOwnProperty', 'postMessage')
```

### code B
```javascript
String(window.postMessage).replace('postMessage', '') === String(Object.hasOwnProperty).replace('hasOwnProperty', '')
```
