### PR TITLE
[TextInput] Implements 'onKeyPress' for Android - PR fixes

### DIFF
--- a/Examples/UIExplorer/js/TextInputExample.android.js
+++ b/Examples/UIExplorer/js/TextInputExample.android.js
@@ -36,6 +36,7 @@ class TextEventsExample extends React.Component {
     curText: '<No Event>',
     prevText: '<No Event>',
     prev2Text: '<No Event>',
+    prev3Text: '<No Event>',
   };
 
   updateText = (text) => {
@@ -44,6 +45,7 @@ class TextEventsExample extends React.Component {
         curText: text,
         prevText: state.curText,
         prev2Text: state.prevText,
+        prev3Text: state.prev2Text,
       };
     });
   };
@@ -66,12 +68,16 @@ class TextEventsExample extends React.Component {
           onSubmitEditing={(event) => this.updateText(
             'onSubmitEditing text: ' + event.nativeEvent.text
           )}
+          onKeyPress={(event) => this.updateText(
+            'onKeyPress key: ' + event.nativeEvent.key
+          )}
           style={styles.singleLine}
         />
         <Text style={styles.eventLabel}>
           {this.state.curText}{'\n'}
           (prev: {this.state.prevText}){'\n'}
           (prev2: {this.state.prev2Text})
+          (prev3: {this.state.prev3Text})
         </Text>
       </View>
     );

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactKeyDownEvent.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactKeyDownEvent.java
@@ -1,0 +1,48 @@
+package com.facebook.react.views.textinput;
+
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.uimanager.events.Event;
+import com.facebook.react.uimanager.events.RCTEventEmitter;
+
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+public class ReactKeyDownEvent extends Event<ReactKeyDownEvent> {
+
+    private static final String EVENT_NAME = "topKeyDown";
+
+    private String mKey;
+
+    public ReactKeyDownEvent(
+            int viewId,
+            String key) {
+        super(viewId);
+        mKey = key;
+    }
+
+    @Override
+    public String getEventName() {
+        return EVENT_NAME;
+    }
+
+    @Override
+    public void dispatch(RCTEventEmitter rctEventEmitter) {
+        rctEventEmitter.receiveEvent(getViewTag(), getEventName(), serializeEventData());
+    }
+
+    private WritableMap serializeEventData() {
+        WritableMap eventData = Arguments.createMap();
+
+        //WritableMap selectionData = Arguments.createMap();
+        eventData.putString("key", mKey);
+
+        //eventData.putMap("selection", selectionData);
+        return eventData;
+    }
+}

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactKeyDownEvent.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactKeyDownEvent.java
@@ -1,10 +1,3 @@
-package com.facebook.react.views.textinput;
-
-import com.facebook.react.bridge.Arguments;
-import com.facebook.react.bridge.WritableMap;
-import com.facebook.react.uimanager.events.Event;
-import com.facebook.react.uimanager.events.RCTEventEmitter;
-
 /**
  * Copyright (c) 2015-present, Facebook, Inc.
  * All rights reserved.
@@ -13,15 +6,21 @@ import com.facebook.react.uimanager.events.RCTEventEmitter;
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
+
+package com.facebook.react.views.textinput;
+
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.uimanager.events.Event;
+import com.facebook.react.uimanager.events.RCTEventEmitter;
+
 public class ReactKeyDownEvent extends Event<ReactKeyDownEvent> {
 
     private static final String EVENT_NAME = "topKeyDown";
 
     private String mKey;
 
-    public ReactKeyDownEvent(
-            int viewId,
-            String key) {
+    public ReactKeyDownEvent(int viewId, String key) {
         super(viewId);
         mKey = key;
     }
@@ -39,10 +38,10 @@ public class ReactKeyDownEvent extends Event<ReactKeyDownEvent> {
     private WritableMap serializeEventData() {
         WritableMap eventData = Arguments.createMap();
 
-        //WritableMap selectionData = Arguments.createMap();
+        // WritableMap selectionData = Arguments.createMap();
         eventData.putString("key", mKey);
 
-        //eventData.putMap("selection", selectionData);
+        // eventData.putMap("selection", selectionData);
         return eventData;
     }
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
@@ -625,9 +625,9 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
       // If the string is only 1 character longer, we interpret it as a key press. It also triggers
       // if only 1 character was pasted, but there is no way to monitor soft/virtual key presses
       int diff = count - before;
-      if(diff == 1) {
+      if (diff == 1) {
         // Mirrors behaviour of iOS
-        String key = ""+s.charAt(start+count-1);
+        String key = "" + s.charAt(start+count-1);
         key = key.equals("\n") ? "Enter" : key;
         mEventDispatcher.dispatchEvent(
                 new ReactKeyDownEvent(
@@ -636,7 +636,7 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
       }
       // If the text is shorter we interpret as a backspace press (could also be a Cut from a
       // selection)
-      if(diff < 0) {
+      if (diff < 0) {
         mEventDispatcher.dispatchEvent(
                 new ReactKeyDownEvent(
                         mEditText.getId(),

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
@@ -138,6 +138,11 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
             MapBuilder.of(
                 "phasedRegistrationNames",
                 MapBuilder.of("bubbled", "onBlur", "captured", "onBlurCapture")))
+        .put(
+            "topKeyDown",
+            MapBuilder.of(
+                "phasedRegistrationNames",
+                MapBuilder.of("bubbled", "onKeyPress", "captured", "onKeyDownCapture")))
         .build();
   }
 
@@ -617,7 +622,26 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
       if (count == 0 && before == 0) {
         return;
       }
-
+      // If the string is only 1 character longer, we interpret it as a key press. It also triggers
+      // if only 1 character was pasted, but there is no way to monitor soft/virtual key presses
+      int diff = count - before;
+      if(diff == 1) {
+        // Mirrors behaviour of iOS
+        String key = ""+s.charAt(start+count-1);
+        key = key.equals("\n") ? "Enter" : key;
+        mEventDispatcher.dispatchEvent(
+                new ReactKeyDownEvent(
+                        mEditText.getId(),
+                        key));
+      }
+      // If the text is shorter we interpret as a backspace press (could also be a Cut from a
+      // selection)
+      if(diff < 0) {
+        mEventDispatcher.dispatchEvent(
+                new ReactKeyDownEvent(
+                        mEditText.getId(),
+                        "Backspace"));
+      }
       Assertions.assertNotNull(mPreviousText);
       String newText = s.toString().substring(start, start + count);
       String oldText = mPreviousText.substring(start, start + before);
@@ -698,6 +722,10 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
                 actionId == EditorInfo.IME_NULL) {
               EventDispatcher eventDispatcher =
                   reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher();
+              eventDispatcher.dispatchEvent(
+                      new ReactKeyDownEvent(
+                              editText.getId(),
+                              "Enter"));
               eventDispatcher.dispatchEvent(
                   new ReactTextInputSubmitEditingEvent(
                       editText.getId(),


### PR DESCRIPTION
Link to original PR : https://github.com/facebook/react-native/pull/10665

It seems that author of the pull request from the link above has finished work on his PR, so I did a fork of his repository and I applied requested changes.

An attempt at the Android implementation. Attempted to mirror the iOS implementation by supporting 'Enter' and 'Backspace'.
