### PR TITLE
[WebSocket] Fix race condition during initialization

### DIFF
--- a/Libraries/WebSocket/WebSocket.js
+++ b/Libraries/WebSocket/WebSocket.js
@@ -83,8 +83,8 @@ class WebSocket extends EventTarget(...WEBSOCKET_EVENTS) {
 
     this._eventEmitter = new NativeEventEmitter(RCTWebSocketModule);
     this._socketId = nextWebSocketId++;
-    RCTWebSocketModule.connect(url, protocols, options, this._socketId);
     this._registerEvents();
+    RCTWebSocketModule.connect(url, protocols, options, this._socketId);
   }
 
   close(code?: number, reason?: string): void {


### PR DESCRIPTION
I discovered this while trying to pinpoint why Nuclide Inspector integration with RN is so flaky. It turns out that, for some reason, if I create a `WebSocket` instance early enough (which I need to when setting up DevTools integration), and the connection is fast enough (which it is on localhost), the `websocketOpen` message may arrive earlier than an `onopen` event handler is registered, causing the `onopen` handler to never fire.

## Test Plan

```
mkdir ~/my-server
cd ~/my-server
npm i ws
nano index.js
```

Paste this code:

```js
const ws = require('ws');
const wss = new ws.Server({
  port: 8099
});
```

Run the server:

```js
node index.js
```

Now, inside React Native, paste right after [these lines](https://github.com/facebook/react-native/blob/57010d63b6fbe8a986cd6fe560bfd83551a4562f/Libraries/Core/InitializeCore.js#L193-L194):

```js
  const ws = new window.WebSocket('ws://localhost:8099');
  ws.onopen = function() {
    alert('open!');
  };
```

### Behavior Before the Fix

The alert never shows up (or maybe shows up in some rare cases). The console output includes a debugging message indicating the problem:

```
[warn][tid:main][RCTEventEmitter.m:54] Sending `websocketOpen` with no listeners registered.
```

### Behavior After the Fix

The alert consistently shows up.

## Reviewers

@mkonicek @javache 
