### PR TITLE
[React DevTools] Move DevTools integration into its own repo

### DIFF
--- a/Libraries/Core/InitializeCore.js
+++ b/Libraries/Core/InitializeCore.js
@@ -195,8 +195,7 @@ if (__DEV__) {
   // not when debugging in chrome
   // TODO(t12832058) This check is broken
   if (!window.document) {
-    const setupDevtools = require('setupDevtools');
-    setupDevtools();
+    require('setupDevtools');
   }
 
   require('RCTDebugComponentOwnership');

--- a/local-cli/server/runServer.js
+++ b/local-cli/server/runServer.js
@@ -69,7 +69,6 @@ function runServer(args, config, readyCallback) {
 
       wsProxy = webSocketProxy.attachToServer(serverInstance, '/debugger-proxy');
       ms = messageSocket.attachToServer(serverInstance, '/message');
-      webSocketProxy.attachToServer(serverInstance, '/devtools');
       inspectorProxy.attachToServer(serverInstance, '/inspector');
       readyCallback();
     }

--- a/package.json
+++ b/package.json
@@ -171,6 +171,7 @@
     "plist": "^1.2.0",
     "promise": "^7.1.1",
     "react-clone-referenced-element": "^1.0.1",
+    "react-devtools-core": "^2.0.5",
     "react-timer-mixin": "^0.13.2",
     "react-transform-hmr": "^1.0.4",
     "rebound": "^0.0.13",


### PR DESCRIPTION
The way React DevTools integration was set up in RN was not entirely supported by the React team, and we had to disable it in c3b25c9059f57ee8df5505628ff6221f11cf9234 so that we can move forward with enabling Fiber support in React Native.

Here, I am moving the DevTools client setup from RN repo to [React DevTools repo](https://github.com/facebook/react-devtools/blob/master/packages/react-devtools-core/README.md#requirereact-devtools-coreconnecttodevtoolsoptions) so that we can keep it in sync with the rest of React DevTools. This is also a part of a larger effort to consolidate DevTools code (https://github.com/facebook/react-devtools/issues/489). It allows us to remove the double injection of the hook, an lets us replace the `eval` hack with a regular dependency. The implementation [lives here now](https://github.com/facebook/react-devtools/blob/master/packages/react-devtools-core/src/backend.js).

This change re-enables Nuclide Inspector with React Native Stack reconciler and prepares it for compatibility with React Native Fiber reconciler in the future. We will release more updates of `react-devtools-core` to improve Fiber compatibility as we are polishing it.

I am removing the packager proxying because `setupDevtools` has not been using it (for a while).

This only affects DEV codepath and has no impact on production.

## Test Plan

After also applying #12305, stable Nuclide shows React inspector again on iOS.

<img width="683" alt="screen shot 2017-02-09 at 20 14 48" src="https://cloud.githubusercontent.com/assets/810438/22801591/603ab8c0-ef05-11e6-8914-bbad1026ce69.png">

So does Nuclide master:

<img width="758" alt="screen shot 2017-02-09 at 20 23 05" src="https://cloud.githubusercontent.com/assets/810438/22801647/9b31e1c4-ef05-11e6-96bc-0b447bbf7d61.png">

I haven't tested the Android simulator.