### PR TITLE
[travis] Add myself as recipient for notifications.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,5 +41,6 @@ notifications:
   email:
     recipients:
       - mkonicek@fb.com
+      - eloy@artsy.net
     on_failure: change
     on_success: change


### PR DESCRIPTION
This is simply so I will start receiving Travis CI build notifications so I can keep an eye on the CocoaPods podspecs, as discussed with @mkonicek.