### PR TITLE
injected javascript comments now work on android

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebViewManager.java
@@ -273,7 +273,12 @@ public class ReactWebViewManager extends SimpleViewManager<WebView> {
       if (getSettings().getJavaScriptEnabled() &&
           injectedJS != null &&
           !TextUtils.isEmpty(injectedJS)) {
-        loadUrl("javascript:(function() {\n" + injectedJS + ";\n})();");
+            String code = "(function() {\n" + injectedJS + ";\n})();";
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+              evaluateJavascript(code, null);
+            } else {
+              loadUrl("javascript:(function() {\n" + injectedJS + ";\n})();");
+            }
       }
     }
 


### PR DESCRIPTION
### Summary
When injecting a script to a WebView component via injectedJavaScript prop, if the script contains any comment then it won't work on android (issue: https://github.com/facebook/react-native/issues/9749).

### Test plan
Create a `WebView` in which we inject a script with a simple comment in it.

#### Code to reproduce
``` es6
import React from 'react';
import { AppRegistry, StyleSheet, Text, View, WebView } from 'react-native';

function SampleApp () {
  const html = `
    <html>
      <body>
        <h1 class="title"> Hello! </h1>
      </body>
    </html>
  `;
  const script = `
    var text = "Bye!"; // This comment will break the script on android
    document.querySelector(".title").textContent = text;
  `;
  return (
    <View style={styles.container}>
      <Text> WebView script comment issue </Text>
      <WebView
        source={{html: html}}
        injectedJavaScript={script}
        javaScriptEnabled
      />  
    </View>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    justifyContent: 'center',
    alignItems: 'stretch',
    backgroundColor: '#F5FCFF',
    paddingTop: 50
  }
});

AppRegistry.registerComponent('SampleApp', () => SampleApp);
```

#### Expected Results
Text on html `h1` element ("Hello!") should be replaced with "Bye!" text.

#### Actual Results
Text on `h1` html element changes on iOS but not on Android. Removing the comment on the js script will fix this issue.
