### PR TITLE
Tighten blog typography

### DIFF
--- a/website/src/react-native/css/react-native.css
+++ b/website/src/react-native/css/react-native.css
@@ -10,7 +10,8 @@ body {
 }
 
 p {
-  margin: 0 0 10px;
+  margin: 0 0 16px;
+  line-height: 1.4;
 }
 
 .subHeader {
@@ -1660,7 +1661,7 @@ input#algolia-doc-search:focus {
 .entry-header h1 {
   margin: 0;
   font-size: 33px;
-  line-height: 36px;
+  line-height: 1;
 }
 
 .entry-header h4 {
@@ -1708,7 +1709,7 @@ input#algolia-doc-search:focus {
   letter-spacing: .4rem;
   text-transform: uppercase;
   font-weight: 400;
-  line-height: 12px;
+  line-height: 1;
 }
 
 .entry-share .small-title {
@@ -1724,12 +1725,11 @@ input#algolia-doc-search:focus {
 
 article {
   margin: 0 0 40px 0;
-  line-height: 1.7;
 }
 
 article h2 {
   font-size: 26px;
-  line-height: 30px;
+  line-height: 1;
 }
 
 article li {


### PR DESCRIPTION
The blog header/body line-height is a bit loose. Also generally the font-height is a good distance for in-between paragraph spacing. Right now is a bit hard to tell where a paragraph starts and ends.

Before:
<img width="666" alt="screen shot 2017-02-10 at 6 43 24 pm" src="https://cloud.githubusercontent.com/assets/71047/22850589/fab283b8-efc0-11e6-9613-3f359ccaeffd.png">

After:
<img width="671" alt="screen shot 2017-02-10 at 6 43 14 pm" src="https://cloud.githubusercontent.com/assets/71047/22850592/ff277a8e-efc0-11e6-8858-c95cb83595f6.png">
