### PR TITLE
Broken link replacement

### DIFF
--- a/docs/NativeModulesIOS.md
+++ b/docs/NativeModulesIOS.md
@@ -16,7 +16,7 @@ This is a more advanced guide that shows how to build a native module. It assume
 
 ## iOS Calendar Module Example
 
-This guide will use the [iOS Calendar API](https://developer.apple.com/library/mac/documentation/DataManagement/Conceptual/EventKitProgGuide/Introduction/Introduction.html) example. Let's say we would like to be able to access the iOS calendar from JavaScript.
+This guide will use the [iOS Calendar API](https://developer.apple.com/library/prerelease/content/documentation/DataManagement/Conceptual/EventKitProgGuide/Introduction/Introduction.html) example. Let's say we would like to be able to access the iOS calendar from JavaScript.
 
 A native module is just an Objective-C class that implements the `RCTBridgeModule` protocol. If you are wondering, RCT is an abbreviation of ReaCT.
 


### PR DESCRIPTION
Link to **OS Calendar API** was broken so I've tried to find out the closest one to replace.

* Broken url 
https://developer.apple.com/library/mac/documentation/DataManagement/Conceptual/EventKitProgGuide/Introduction/Introduction.html

* Replacement
https://developer.apple.com/library/prerelease/content/documentation/DataManagement/Conceptual/EventKitProgGuide/Introduction/Introduction.html

