### PR TITLE
Update Documentation for Headless JS: Fix pitfall of getTaskConfig

### DIFF
--- a/docs/HeadlessJSAndroid.md
+++ b/docs/HeadlessJSAndroid.md
@@ -38,13 +38,11 @@ public class MyTaskService extends HeadlessJsTaskService {
   @Override
   protected @Nullable HeadlessJsTaskConfig getTaskConfig(Intent intent) {
     Bundle extras = intent.getExtras();
-    if (extras != null) {
-      return new HeadlessJsTaskConfig(
-          "SomeTaskName",
-          Arguments.fromBundle(extras),
-          5000);
-    }
-    return null;
+    WritableMap data = extras != null ? Arguments.fromBundle(extras) : null;
+    return new HeadlessJsTaskConfig(
+        "SomeTaskName",
+        data,
+        5000);
   }
 }
 ```


### PR DESCRIPTION
This is just a minor change to the documentation. Setting up headless execution as currently described in the tutorial has the possibility of silently failing. My update just removes this pitfall.