### PR TITLE
Match on `s.version` only

### DIFF
--- a/scripts/bump-oss-version.js
+++ b/scripts/bump-oss-version.js
@@ -55,7 +55,7 @@ if (sed(`-i`, /^VERSION_NAME=.*/, `VERSION_NAME=${version}`, `ReactAndroid/gradl
 }
 
 // - change React.podspec
-if (sed(`-i`, /s.version\s*=.*/, `s.version             = \"${version}\"`, `React.podspec`).code) {
+if (sed(`-i`, /s\.version\s*=.*/, `s.version             = \"${version}\"`, `React.podspec`).code) {
   echo(`Couldn't update version for React.podspec`);
   exit(1);
 }


### PR DESCRIPTION
Recent PR by @alloy adds `s.cocoapods_version`. That makes `release script` also modify that value. Adding `\` makes `sed` match on a dot character (I believe missing `\` was a mistake).

Used and tested here: https://github.com/facebook/react-native/commits/0.42-stable

CC @bestander 