### PR TITLE
Fix linking manager library name in documentation

### DIFF
--- a/Libraries/Linking/Linking.js
+++ b/Libraries/Linking/Linking.js
@@ -61,7 +61,7 @@ const LinkingManager = Platform.OS === 'android' ?
  * execution you'll need to add the following lines to you `*AppDelegate.m`:
  *
  * ```
- * #import "RCTLinkingManager.h"
+ * #import <React/RCTLinkingManager.h>
  *
  * - (BOOL)application:(UIApplication *)application openURL:(NSURL *)url
  *   sourceApplication:(NSString *)sourceApplication annotation:(id)annotation


### PR DESCRIPTION
I had an issue while using 

```#import "RCTLinkingManager.h"```

![image](https://cloud.githubusercontent.com/assets/1089932/22933908/523cf910-f2cd-11e6-9c20-b3c298d5b7cc.png)

But when replaced with

```#import <React/RCTLinkingManager.h>```

the build succeeds.

Looks fine on the website:

![image](https://cloud.githubusercontent.com/assets/1089932/22934563/b1ff337a-f2cf-11e6-9109-b133aef1d69c.png)


