### PR TITLE
Fix the height of the app icons in showcase

### DIFF
--- a/website/src/react-native/css/react-native.css
+++ b/website/src/react-native/css/react-native.css
@@ -1413,6 +1413,7 @@ div[data-twttr-id] iframe {
 
 .showcase img {
   width: 100px;
+	height: 100px;
   border-radius: 20px;
 }
 


### PR DESCRIPTION
I have fixed the app icons height to `100px` in the showcase. So, the UI won't jump on loading.


**Motivation :** https://twitter.com/Vjeux/status/831698720055926784