### PR TITLE
[Android] support api 15 (use Handler-backed ui driven).

### DIFF
--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -230,7 +230,7 @@ android {
     buildToolsVersion "23.0.1"
 
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion 15
         targetSdkVersion 22
         versionCode 1
         versionName "1.0"

--- a/ReactAndroid/src/androidTest/java/com/facebook/react/testing/ReactIdleDetectionUtil.java
+++ b/ReactAndroid/src/androidTest/java/com/facebook/react/testing/ReactIdleDetectionUtil.java
@@ -14,10 +14,10 @@ import java.util.concurrent.TimeUnit;
 import android.app.Instrumentation;
 import android.os.SystemClock;
 import android.support.test.InstrumentationRegistry;
-import android.view.Choreographer;
 
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.UiThreadUtil;
+import com.facebook.react.modules.core.ChoreographerCompat;
 
 public class ReactIdleDetectionUtil {
 
@@ -56,8 +56,8 @@ public class ReactIdleDetectionUtil {
         new Runnable() {
           @Override
           public void run() {
-            Choreographer.getInstance().postFrameCallback(
-                new Choreographer.FrameCallback() {
+            ChoreographerCompat.getInstance().postFrameCallback(
+                new ChoreographerCompat.FrameCallback() {
 
                   private int frameCount = 0;
 
@@ -67,7 +67,7 @@ public class ReactIdleDetectionUtil {
                     if (frameCount == waitFrameCount) {
                       latch.countDown();
                     } else {
-                      Choreographer.getInstance().postFrameCallback(this);
+                      ChoreographerCompat.getInstance().postFrameCallback(this);
                     }
                   }
                 });

--- a/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
@@ -15,7 +15,6 @@ import android.content.Context;
 import android.graphics.Rect;
 import android.os.Bundle;
 import android.util.AttributeSet;
-import android.util.DisplayMetrics;
 import android.view.MotionEvent;
 import android.view.Surface;
 import android.view.View;
@@ -39,6 +38,7 @@ import com.facebook.react.uimanager.RootView;
 import com.facebook.react.uimanager.SizeMonitoringFrameLayout;
 import com.facebook.react.uimanager.UIManagerModule;
 import com.facebook.react.uimanager.events.EventDispatcher;
+import com.facebook.react.common.ApiCompatUtils;
 
 /**
  * Default root view for catalyst apps. Provides the ability to listen for size changes so that a UI
@@ -177,7 +177,8 @@ public class ReactRootView extends SizeMonitoringFrameLayout implements RootView
   protected void onDetachedFromWindow() {
     super.onDetachedFromWindow();
     if (mIsAttachedToInstance) {
-      getViewTreeObserver().removeOnGlobalLayoutListener(getCustomGlobalLayoutListener());
+      CustomGlobalLayoutListener listener = getCustomGlobalLayoutListener();
+      ApiCompatUtils.removeOnGlobalLayoutListener(getViewTreeObserver(), listener);
     }
   }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/animated/NativeAnimatedModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/animated/NativeAnimatedModule.java
@@ -23,8 +23,8 @@ import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.module.annotations.ReactModule;
 import com.facebook.react.modules.core.DeviceEventManagerModule;
-import com.facebook.react.uimanager.GuardedChoreographerFrameCallback;
 import com.facebook.react.modules.core.ReactChoreographer;
+import com.facebook.react.uimanager.GuardedFrameCallback;
 import com.facebook.react.uimanager.UIManagerModule;
 
 import java.util.ArrayList;
@@ -79,7 +79,7 @@ public class NativeAnimatedModule extends ReactContextBaseJavaModule implements
   }
 
   private final Object mOperationsCopyLock = new Object();
-  private @Nullable GuardedChoreographerFrameCallback mAnimatedFrameCallback;
+  private @Nullable GuardedFrameCallback mAnimatedFrameCallback;
   private @Nullable ReactChoreographer mReactChoreographer;
   private ArrayList<UIThreadOperation> mOperations = new ArrayList<>();
   private volatile @Nullable ArrayList<UIThreadOperation> mReadyOperations = null;
@@ -97,7 +97,7 @@ public class NativeAnimatedModule extends ReactContextBaseJavaModule implements
     UIManagerModule uiManager = reactCtx.getNativeModule(UIManagerModule.class);
 
     final NativeAnimatedNodesManager nodesManager = new NativeAnimatedNodesManager(uiManager);
-    mAnimatedFrameCallback = new GuardedChoreographerFrameCallback(reactCtx) {
+    mAnimatedFrameCallback = new GuardedFrameCallback(reactCtx) {
       @Override
       protected void doFrameGuarded(final long frameTimeNanos) {
 

--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactContext.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactContext.java
@@ -26,6 +26,7 @@ import android.view.LayoutInflater;
 import com.facebook.infer.annotation.Assertions;
 import com.facebook.react.bridge.queue.MessageQueueThread;
 import com.facebook.react.bridge.queue.ReactQueueConfiguration;
+import com.facebook.react.common.ApiCompatUtils;
 import com.facebook.react.common.LifecycleState;
 
 import static com.facebook.react.common.LifecycleState.BEFORE_CREATE;
@@ -348,8 +349,7 @@ public class ReactContext extends ContextWrapper {
   public boolean startActivityForResult(Intent intent, int code, Bundle bundle) {
     Activity activity = getCurrentActivity();
     Assertions.assertNotNull(activity);
-    activity.startActivityForResult(intent, code, bundle);
-    return true;
+    return ApiCompatUtils.startActivityForResult(activity, intent, code, bundle);
   }
 
   /**

--- a/ReactAndroid/src/main/java/com/facebook/react/common/ApiCompatUtils.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/common/ApiCompatUtils.java
@@ -1,0 +1,95 @@
+package com.facebook.react.common;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.graphics.drawable.Drawable;
+import android.os.Build;
+import android.os.Bundle;
+import android.view.View;
+import android.view.ViewTreeObserver;
+
+import com.facebook.common.logging.FLog;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Utility class for do some android API level compat stuff.
+ */
+public class ApiCompatUtils {
+
+  private static final String TAG = "ApiCompatUtils";
+
+  /**
+   * We may remove this compat strategy and make minSdkVersion 16 after
+   * ICS distribution below 0.1%.
+   */
+  public static boolean isJellyBeanOrHigher() {
+    return Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN;
+  }
+
+  public static boolean isJellyBeanMR1OrHigher() {
+    return Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1;
+  }
+
+  public static boolean isKitkatOrHigher() {
+    return Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT;
+  }
+
+  public static boolean isLollipopOrHigher() {
+    return Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP;
+  }
+
+  // ------- Compat functions for API 16 ------- //
+  public static void removeOnGlobalLayoutListener(ViewTreeObserver observer,
+                                                  ViewTreeObserver.OnGlobalLayoutListener listener) {
+    if (isJellyBeanOrHigher()) {
+      observer.removeOnGlobalLayoutListener(listener);
+    } else {
+      observer.removeGlobalOnLayoutListener(listener);
+    }
+  }
+
+  public static void setBackground(View view, Drawable drawable) {
+    if (isJellyBeanOrHigher()) {
+      view.setBackground(drawable);
+    } else {
+      view.setBackgroundDrawable(drawable);
+    }
+  }
+
+  public static boolean startActivityForResult(@Nonnull Activity activity, Intent intent,
+                                               int code, Bundle bundle) {
+    if (isJellyBeanOrHigher()) {
+      activity.startActivityForResult(intent, code, bundle);
+    } else {
+      if (bundle != null) {
+        FLog.w(TAG, "Cannot add bundle on startActivityForResult in android API 15!");
+      }
+      activity.startActivityForResult(intent, code);
+    }
+    return true;
+  }
+
+  // ------- Compat functions for API 17 ------- //
+  public static void setRtl(View view, boolean rtl) {
+    if (isJellyBeanMR1OrHigher()) {
+      view.setLayoutDirection(rtl ? View.LAYOUT_DIRECTION_RTL : View.LAYOUT_DIRECTION_LTR);
+    }
+  }
+
+  public static int getPaddingStart(View view) {
+    if (isJellyBeanMR1OrHigher()) {
+      return view.getPaddingStart();
+    } else {
+      return view.getPaddingLeft();
+    }
+  }
+
+  public static int getPaddingEnd(View view) {
+    if (isJellyBeanMR1OrHigher()) {
+      return view.getPaddingEnd();
+    } else {
+      return view.getPaddingRight();
+    }
+  }
+}

--- a/ReactAndroid/src/main/java/com/facebook/react/common/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/common/BUCK
@@ -12,6 +12,7 @@ android_library(
   ],
   deps = [
     ':build_config',
+    react_native_dep('libraries/fbcore/src/main/java/com/facebook/common/logging:logging'),
     react_native_dep('third-party/android/support/v4:lib-support-v4'),
     react_native_dep('third-party/java/infer-annotations:infer-annotations'),
     react_native_dep('third-party/java/jsr-305:jsr-305'),

--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/BUCK
@@ -20,6 +20,7 @@ android_library(
     react_native_target('java/com/facebook/react/modules/debug:interfaces'),
     react_native_target('java/com/facebook/react/modules/systeminfo:systeminfo'),
     react_native_target('java/com/facebook/react/packagerconnection:packagerconnection'),
+    react_native_target('java/com/facebook/react/modules/core:core'),
     react_native_target('res:devsupport'),
   ],
   visibility = [

--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/FpsView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/FpsView.java
@@ -12,7 +12,6 @@ package com.facebook.react.devsupport;
 import java.util.Locale;
 
 import android.annotation.TargetApi;
-import android.view.Choreographer;
 import android.widget.FrameLayout;
 import android.widget.TextView;
 
@@ -20,6 +19,7 @@ import com.facebook.common.logging.FLog;
 import com.facebook.react.R;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.common.ReactConstants;
+import com.facebook.react.modules.core.ChoreographerCompat;
 import com.facebook.react.modules.debug.FpsDebugFrameCallback;
 
 /**
@@ -41,7 +41,7 @@ public class FpsView extends FrameLayout {
     super(reactContext);
     inflate(reactContext, R.layout.fps_view, this);
     mTextView = (TextView) findViewById(R.id.fps_text);
-    mFrameCallback = new FpsDebugFrameCallback(Choreographer.getInstance(), reactContext);
+    mFrameCallback = new FpsDebugFrameCallback(ChoreographerCompat.getInstance(), reactContext);
     mFPSMonitorRunnable = new FPSMonitorRunnable();
     setCurrentFPS(0, 0, 0, 0);
   }

--- a/ReactAndroid/src/main/java/com/facebook/react/flat/FlatViewGroup.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/flat/FlatViewGroup.java
@@ -32,6 +32,7 @@ import android.view.ViewParent;
 import com.facebook.infer.annotation.Assertions;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.SoftAssertions;
+import com.facebook.react.common.ApiCompatUtils;
 import com.facebook.react.touch.OnInterceptTouchEventListener;
 import com.facebook.react.touch.ReactHitSlopView;
 import com.facebook.react.touch.ReactInterceptingViewGroup;
@@ -565,9 +566,11 @@ import com.facebook.react.uimanager.ReactClippingViewGroup;
 
   @Override
   public void dispatchDrawableHotspotChanged(float x, float y) {
-    if (mHotspot != null) {
-      mHotspot.setHotspot(x, y);
-      invalidate();
+    if (ApiCompatUtils.isLollipopOrHigher()) {
+      if (mHotspot != null) {
+        mHotspot.setHotspot(x, y);
+        invalidate();
+      }
     }
   }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/camera/CameraRollManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/camera/CameraRollManager.java
@@ -27,7 +27,6 @@ import android.graphics.BitmapFactory;
 import android.media.MediaScannerConnection;
 import android.net.Uri;
 import android.os.AsyncTask;
-import android.os.Build;
 import android.os.Environment;
 import android.provider.MediaStore;
 import android.provider.MediaStore.Images;
@@ -48,6 +47,7 @@ import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.bridge.WritableNativeArray;
 import com.facebook.react.bridge.WritableNativeMap;
+import com.facebook.react.common.ApiCompatUtils;
 import com.facebook.react.common.ReactConstants;
 import com.facebook.react.module.annotations.ReactModule;
 
@@ -65,8 +65,7 @@ public class CameraRollManager extends ReactContextBaseJavaModule {
   private static final String ERROR_UNABLE_TO_LOAD_PERMISSION = "E_UNABLE_TO_LOAD_PERMISSION";
   private static final String ERROR_UNABLE_TO_SAVE = "E_UNABLE_TO_SAVE";
 
-  public static final boolean IS_JELLY_BEAN_OR_LATER =
-      Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN;
+  public static final boolean IS_JELLY_BEAN_OR_LATER = ApiCompatUtils.isJellyBeanOrHigher();
 
   private static final String[] PROJECTION;
   static {

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/core/ChoreographerCompat.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/core/ChoreographerCompat.java
@@ -1,0 +1,131 @@
+/*
+ *  Copyright (c) 2013, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+package com.facebook.react.modules.core;
+
+import android.annotation.TargetApi;
+import android.os.Build;
+import android.os.Handler;
+import android.os.Looper;
+import android.view.Choreographer;
+
+/**
+ * Wrapper class for abstracting away availability of the JellyBean Choreographer. If Choreographer
+ * is unavailable we fallback to using a normal Handler.
+ */
+public class ChoreographerCompat {
+
+  private static final long ONE_FRAME_MILLIS = 17;
+  private static final boolean IS_JELLYBEAN_OR_HIGHER =
+    Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN;
+  private static final ChoreographerCompat INSTANCE = new ChoreographerCompat();
+
+  private Handler mHandler;
+  private Choreographer mChoreographer;
+
+  public static ChoreographerCompat getInstance() {
+    return INSTANCE;
+  }
+
+  private ChoreographerCompat() {
+    if (IS_JELLYBEAN_OR_HIGHER) {
+      mChoreographer = getChoreographer();
+    } else {
+      mHandler = new Handler(Looper.getMainLooper());
+    }
+  }
+
+  public void postFrameCallback(FrameCallback callbackWrapper) {
+    if (IS_JELLYBEAN_OR_HIGHER) {
+      choreographerPostFrameCallback(callbackWrapper.getFrameCallback());
+    } else {
+      mHandler.postDelayed(callbackWrapper.getRunnable(), 0);
+    }
+  }
+
+  public void postFrameCallbackDelayed(FrameCallback callbackWrapper, long delayMillis) {
+    if (IS_JELLYBEAN_OR_HIGHER) {
+      choreographerPostFrameCallbackDelayed(callbackWrapper.getFrameCallback(), delayMillis);
+    } else {
+      mHandler.postDelayed(callbackWrapper.getRunnable(), delayMillis + ONE_FRAME_MILLIS);
+    }
+  }
+
+  public void removeFrameCallback(FrameCallback callbackWrapper) {
+    if (IS_JELLYBEAN_OR_HIGHER) {
+      choreographerRemoveFrameCallback(callbackWrapper.getFrameCallback());
+    } else {
+      mHandler.removeCallbacks(callbackWrapper.getRunnable());
+    }
+  }
+
+  @TargetApi(Build.VERSION_CODES.JELLY_BEAN)
+  private Choreographer getChoreographer() {
+    return Choreographer.getInstance();
+  }
+
+  @TargetApi(Build.VERSION_CODES.JELLY_BEAN)
+  private void choreographerPostFrameCallback(Choreographer.FrameCallback frameCallback) {
+    mChoreographer.postFrameCallback(frameCallback);
+  }
+
+  @TargetApi(Build.VERSION_CODES.JELLY_BEAN)
+  private void choreographerPostFrameCallbackDelayed(
+    Choreographer.FrameCallback frameCallback,
+    long delayMillis) {
+    mChoreographer.postFrameCallbackDelayed(frameCallback, delayMillis);
+  }
+
+  @TargetApi(Build.VERSION_CODES.JELLY_BEAN)
+  private void choreographerRemoveFrameCallback(Choreographer.FrameCallback frameCallback) {
+    mChoreographer.removeFrameCallback(frameCallback);
+  }
+
+
+  /**
+   * This class provides a compatibility wrapper around the JellyBean FrameCallback with methods
+   * to access cached wrappers for submitting a real FrameCallback to a Choreographer or a Runnable
+   * to a Handler.
+   */
+  public static abstract class FrameCallback {
+
+    private Runnable mRunnable;
+    private Choreographer.FrameCallback mFrameCallback;
+
+    @TargetApi(Build.VERSION_CODES.JELLY_BEAN)
+    Choreographer.FrameCallback getFrameCallback() {
+      if (mFrameCallback == null) {
+        mFrameCallback = new Choreographer.FrameCallback() {
+          @Override
+          public void doFrame(long frameTimeNanos) {
+            FrameCallback.this.doFrame(frameTimeNanos);
+          }
+        };
+      }
+      return mFrameCallback;
+    }
+
+    Runnable getRunnable() {
+      if (mRunnable == null) {
+        mRunnable = new Runnable() {
+          @Override
+          public void run() {
+            doFrame(System.nanoTime());
+          }
+        };
+      }
+      return mRunnable;
+    }
+
+    /**
+     * Just a wrapper for frame callback, see {@link android.view.Choreographer.FrameCallback#doFrame(long)}.
+     */
+    public abstract void doFrame(long frameTimeNanos);
+  }
+}

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/core/ChoreographerCompat.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/core/ChoreographerCompat.java
@@ -15,15 +15,16 @@ import android.os.Handler;
 import android.os.Looper;
 import android.view.Choreographer;
 
+import com.facebook.react.common.ApiCompatUtils;
+
 /**
  * Wrapper class for abstracting away availability of the JellyBean Choreographer. If Choreographer
  * is unavailable we fallback to using a normal Handler.
  */
 public class ChoreographerCompat {
 
-  private static final long ONE_FRAME_MILLIS = 17;
-  private static final boolean IS_JELLYBEAN_OR_HIGHER =
-    Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN;
+  public static final long ONE_FRAME_MILLIS = 17;
+  private static final boolean IS_JELLYBEAN_OR_HIGHER = ApiCompatUtils.isJellyBeanOrHigher();
   private static final ChoreographerCompat INSTANCE = new ChoreographerCompat();
 
   private Handler mHandler;

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/core/ReactChoreographer.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/core/ReactChoreographer.java
@@ -11,8 +11,6 @@ package com.facebook.react.modules.core;
 
 import java.util.ArrayDeque;
 
-import android.view.Choreographer;
-
 import com.facebook.common.logging.FLog;
 import com.facebook.react.bridge.UiThreadUtil;
 import com.facebook.infer.annotation.Assertions;
@@ -25,7 +23,7 @@ import com.facebook.react.common.ReactConstants;
  */
 public class ReactChoreographer {
 
-  public static enum CallbackType {
+  public enum CallbackType {
 
     /**
      * For use by perf markers that need to happen immediately after draw
@@ -75,15 +73,15 @@ public class ReactChoreographer {
     return sInstance;
   }
 
-  private final Choreographer mChoreographer;
+  private final ChoreographerCompat mChoreographer;
   private final ReactChoreographerDispatcher mReactChoreographerDispatcher;
-  private final ArrayDeque<Choreographer.FrameCallback>[] mCallbackQueues;
+  private final ArrayDeque<ChoreographerCompat.FrameCallback>[] mCallbackQueues;
 
   private int mTotalCallbacks = 0;
   private boolean mHasPostedCallback = false;
 
   private ReactChoreographer() {
-    mChoreographer = Choreographer.getInstance();
+    mChoreographer = ChoreographerCompat.getInstance();
     mReactChoreographerDispatcher = new ReactChoreographerDispatcher();
     mCallbackQueues = new ArrayDeque[CallbackType.values().length];
     for (int i = 0; i < mCallbackQueues.length; i++) {
@@ -91,7 +89,7 @@ public class ReactChoreographer {
     }
   }
 
-  public void postFrameCallback(CallbackType type, Choreographer.FrameCallback frameCallback) {
+  public void postFrameCallback(CallbackType type, ChoreographerCompat.FrameCallback frameCallback) {
     UiThreadUtil.assertOnUiThread();
     mCallbackQueues[type.getOrder()].addLast(frameCallback);
     mTotalCallbacks++;
@@ -102,7 +100,7 @@ public class ReactChoreographer {
     }
   }
 
-  public void removeFrameCallback(CallbackType type, Choreographer.FrameCallback frameCallback) {
+  public void removeFrameCallback(CallbackType type, ChoreographerCompat.FrameCallback frameCallback) {
     UiThreadUtil.assertOnUiThread();
     if (mCallbackQueues[type.getOrder()].removeFirstOccurrence(frameCallback)) {
       mTotalCallbacks--;
@@ -120,7 +118,7 @@ public class ReactChoreographer {
     }
   }
 
-  private class ReactChoreographerDispatcher implements Choreographer.FrameCallback {
+  private class ReactChoreographerDispatcher extends ChoreographerCompat.FrameCallback {
 
     @Override
     public void doFrame(long frameTimeNanos) {

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/core/Timing.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/core/Timing.java
@@ -22,7 +22,6 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import android.util.SparseArray;
-import android.view.Choreographer;
 
 import com.facebook.infer.annotation.Assertions;
 import com.facebook.react.bridge.Arguments;
@@ -81,7 +80,7 @@ public final class Timing extends ReactContextBaseJavaModule implements Lifecycl
     }
   }
 
-  private class TimerFrameCallback implements Choreographer.FrameCallback {
+  private class TimerFrameCallback extends ChoreographerCompat.FrameCallback {
 
     // Temporary map for constructing the individual arrays of timers per ExecutorToken
     private final HashMap<ExecutorToken, WritableArray> mTimersToCall = new HashMap<>();
@@ -131,7 +130,7 @@ public final class Timing extends ReactContextBaseJavaModule implements Lifecycl
     }
   }
 
-  private class IdleFrameCallback implements Choreographer.FrameCallback {
+  private class IdleFrameCallback extends ChoreographerCompat.FrameCallback {
 
     @Override
     public void doFrame(long frameTimeNanos) {
@@ -248,14 +247,14 @@ public final class Timing extends ReactContextBaseJavaModule implements Lifecycl
   @Override
   public void onHostPause() {
     isPaused.set(true);
-    clearChoreographerCallback();
-    maybeClearChoreographerIdleCallback();
+    clearFrameCallback();
+    maybeIdleCallback();
   }
 
   @Override
   public void onHostDestroy() {
-    clearChoreographerCallback();
-    maybeClearChoreographerIdleCallback();
+    clearFrameCallback();
+    maybeIdleCallback();
   }
 
   @Override
@@ -281,14 +280,14 @@ public final class Timing extends ReactContextBaseJavaModule implements Lifecycl
       HeadlessJsTaskContext.getInstance(getReactApplicationContext());
     if (!headlessJsTaskContext.hasActiveTasks()) {
       isRunningTasks.set(false);
-      clearChoreographerCallback();
-      maybeClearChoreographerIdleCallback();
+      clearFrameCallback();
+      maybeIdleCallback();
     }
   }
 
   @Override
   public void onCatalystInstanceDestroy() {
-    clearChoreographerCallback();
+    clearFrameCallback();
     clearChoreographerIdleCallback();
     HeadlessJsTaskContext headlessJsTaskContext =
       HeadlessJsTaskContext.getInstance(getReactApplicationContext());
@@ -303,9 +302,9 @@ public final class Timing extends ReactContextBaseJavaModule implements Lifecycl
     }
   }
 
-  private void maybeClearChoreographerIdleCallback() {
+  private void maybeIdleCallback() {
     if (isPaused.get() && !isRunningTasks.get()) {
-      clearChoreographerCallback();
+      clearFrameCallback();
     }
   }
 
@@ -318,7 +317,7 @@ public final class Timing extends ReactContextBaseJavaModule implements Lifecycl
     }
   }
 
-  private void clearChoreographerCallback() {
+  private void clearFrameCallback() {
     HeadlessJsTaskContext headlessJsTaskContext =
       HeadlessJsTaskContext.getInstance(getReactApplicationContext());
     if (mFrameCallbackPosted && isPaused.get() &&

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/debug/AnimationsDebugModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/debug/AnimationsDebugModule.java
@@ -13,8 +13,6 @@ import javax.annotation.Nullable;
 
 import java.util.Locale;
 
-import android.os.Build;
-import android.view.Choreographer;
 import android.widget.Toast;
 
 import com.facebook.common.logging.FLog;
@@ -24,6 +22,7 @@ import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.common.ReactConstants;
 import com.facebook.react.module.annotations.ReactModule;
+import com.facebook.react.modules.core.ChoreographerCompat;
 import com.facebook.react.modules.debug.interfaces.DeveloperSettings;
 
 /**
@@ -45,6 +44,7 @@ public class AnimationsDebugModule extends ReactContextBaseJavaModule {
     mCatalystSettings = catalystSettings;
   }
 
+
   @Override
   public String getName() {
     return NAME;
@@ -60,10 +60,9 @@ public class AnimationsDebugModule extends ReactContextBaseJavaModule {
     if (mFrameCallback != null) {
       throw new JSApplicationCausedNativeException("Already recording FPS!");
     }
-    checkAPILevel();
 
     mFrameCallback = new FpsDebugFrameCallback(
-                          Choreographer.getInstance(),
+                          ChoreographerCompat.getInstance(),
                           getReactApplicationContext());
     mFrameCallback.startAndRecordFpsAtEachFrame();
   }
@@ -78,7 +77,6 @@ public class AnimationsDebugModule extends ReactContextBaseJavaModule {
     if (mFrameCallback == null) {
       return;
     }
-    checkAPILevel();
 
     mFrameCallback.stop();
 
@@ -114,13 +112,6 @@ public class AnimationsDebugModule extends ReactContextBaseJavaModule {
     if (mFrameCallback != null) {
       mFrameCallback.stop();
       mFrameCallback = null;
-    }
-  }
-
-  private static void checkAPILevel() {
-    if (Build.VERSION.SDK_INT < 16) {
-      throw new JSApplicationCausedNativeException(
-          "Animation debugging is not supported in API <16");
     }
   }
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/debug/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/debug/BUCK
@@ -12,6 +12,7 @@ android_library(
     react_native_target('java/com/facebook/react/module/annotations:annotations'),
     react_native_target('java/com/facebook/react/modules/debug:interfaces'),
     react_native_target('java/com/facebook/react/uimanager:uimanager'),
+    react_native_target('java/com/facebook/react/modules/core:core')
   ],
   visibility = [
     'PUBLIC',

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/debug/DidJSUpdateUiDuringFrameDetector.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/debug/DidJSUpdateUiDuringFrameDetector.java
@@ -9,11 +9,10 @@
 
 package com.facebook.react.modules.debug;
 
-import android.view.Choreographer;
-
 import com.facebook.react.bridge.ReactBridge;
 import com.facebook.react.bridge.NotThreadSafeBridgeIdleDebugListener;
 import com.facebook.react.common.LongArray;
+import com.facebook.react.modules.core.ChoreographerCompat;
 import com.facebook.react.uimanager.UIManagerModule;
 import com.facebook.react.uimanager.debug.NotThreadSafeViewHierarchyUpdateDebugListener;
 
@@ -22,7 +21,7 @@ import com.facebook.react.uimanager.debug.NotThreadSafeViewHierarchyUpdateDebugL
  * to calculate whether JS was able to update the UI during a given frame. After being installed
  * on a {@link ReactBridge} and a {@link UIManagerModule},
  * {@link #getDidJSHitFrameAndCleanup} should be called once per frame via a
- * {@link Choreographer.FrameCallback}.
+ * {@link ChoreographerCompat.FrameCallback}.
  */
 public class DidJSUpdateUiDuringFrameDetector implements NotThreadSafeBridgeIdleDebugListener,
     NotThreadSafeViewHierarchyUpdateDebugListener {
@@ -56,7 +55,7 @@ public class DidJSUpdateUiDuringFrameDetector implements NotThreadSafeBridgeIdle
   }
 
   /**
-   * Designed to be called from a {@link Choreographer.FrameCallback#doFrame} call.
+   * Designed to be called from a {@link ChoreographerCompat.FrameCallback#doFrame} call.
    *
    * There are two 'success' cases that will cause {@link #getDidJSHitFrameAndCleanup} to
    * return true for a given frame:

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/debug/FpsDebugFrameCallback.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/debug/FpsDebugFrameCallback.java
@@ -14,10 +14,8 @@ import javax.annotation.Nullable;
 import java.util.Map;
 import java.util.TreeMap;
 
-import android.annotation.TargetApi;
-import android.view.Choreographer;
-
 import com.facebook.react.bridge.ReactContext;
+import com.facebook.react.modules.core.ChoreographerCompat;
 import com.facebook.react.uimanager.UIManagerModule;
 import com.facebook.infer.annotation.Assertions;
 
@@ -30,11 +28,8 @@ import com.facebook.infer.annotation.Assertions;
  * Also records the JS FPS, i.e. the frames per second with which either JS updated the UI or was
  * idle and not trying to update the UI. This is different from the FPS above since JS rendering is
  * async.
- *
- * TargetApi 16 for use of Choreographer.
  */
-@TargetApi(16)
-public class FpsDebugFrameCallback implements Choreographer.FrameCallback {
+public class FpsDebugFrameCallback extends ChoreographerCompat.FrameCallback {
 
   public static class FpsInfo {
 
@@ -66,7 +61,7 @@ public class FpsDebugFrameCallback implements Choreographer.FrameCallback {
 
   private static final double EXPECTED_FRAME_TIME = 16.9;
 
-  private final Choreographer mChoreographer;
+  private final ChoreographerCompat mChoreographer;
   private final ReactContext mReactContext;
   private final UIManagerModule mUIManagerModule;
   private final DidJSUpdateUiDuringFrameDetector mDidJSUpdateUiDuringFrameDetector;
@@ -81,7 +76,7 @@ public class FpsDebugFrameCallback implements Choreographer.FrameCallback {
   private boolean mIsRecordingFpsInfoAtEachFrame = false;
   private @Nullable TreeMap<Long, FpsInfo> mTimeToFps;
 
-  public FpsDebugFrameCallback(Choreographer choreographer, ReactContext reactContext) {
+  public FpsDebugFrameCallback(ChoreographerCompat choreographer, ReactContext reactContext) {
     mChoreographer = choreographer;
     mReactContext = reactContext;
     mUIManagerModule = reactContext.getNativeModule(UIManagerModule.class);

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/network/ForwardingCookieHandler.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/network/ForwardingCookieHandler.java
@@ -26,6 +26,7 @@ import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.GuardedAsyncTask;
 import com.facebook.react.bridge.GuardedResultAsyncTask;
 import com.facebook.react.bridge.ReactContext;
+import com.facebook.react.common.ApiCompatUtils;
 
 /**
  * Cookie handler that forwards all cookies to the WebView CookieManager.
@@ -39,7 +40,7 @@ public class ForwardingCookieHandler extends CookieHandler {
   private static final String COOKIE_HEADER = "Cookie";
 
   // As CookieManager was synchronous before API 21 this class emulates the async behavior on <21.
-  private static final boolean USES_LEGACY_STORE = Build.VERSION.SDK_INT < 21;
+  private static final boolean USES_LEGACY_STORE = !ApiCompatUtils.isLollipopOrHigher();
 
   private final CookieSaver mCookieSaver;
   private final ReactContext mContext;
@@ -92,6 +93,7 @@ public class ForwardingCookieHandler extends CookieHandler {
     }
   }
 
+  @TargetApi(Build.VERSION_CODES.LOLLIPOP)
   private void clearCookiesAsync(final Callback callback) {
     getCookieManager().removeAllCookies(
         new ValueCallback<Boolean>() {

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
@@ -6,6 +6,7 @@ import android.graphics.Color;
 import android.os.Build;
 import android.view.View;
 import com.facebook.react.bridge.ReadableArray;
+import com.facebook.react.common.ApiCompatUtils;
 import com.facebook.react.uimanager.annotations.ReactProp;
 
 /**
@@ -66,7 +67,7 @@ public abstract class BaseViewManager<T extends View, C extends LayoutShadowNode
 
   @ReactProp(name = PROP_ELEVATION)
   public void setElevation(T view, float elevation) {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+    if (ApiCompatUtils.isLollipopOrHigher()) {
       view.setElevation(PixelUtil.toPixelFromDIP(elevation));
     }
     // Do nothing on API < 21
@@ -100,14 +101,18 @@ public abstract class BaseViewManager<T extends View, C extends LayoutShadowNode
 
   @ReactProp(name = PROP_IMPORTANT_FOR_ACCESSIBILITY)
   public void setImportantForAccessibility(T view, String importantForAccessibility) {
-    if (importantForAccessibility == null || importantForAccessibility.equals("auto")) {
-      view.setImportantForAccessibility(View.IMPORTANT_FOR_ACCESSIBILITY_AUTO);
-    } else if (importantForAccessibility.equals("yes")) {
-      view.setImportantForAccessibility(View.IMPORTANT_FOR_ACCESSIBILITY_YES);
-    } else if (importantForAccessibility.equals("no")) {
-      view.setImportantForAccessibility(View.IMPORTANT_FOR_ACCESSIBILITY_NO);
-    } else if (importantForAccessibility.equals("no-hide-descendants")) {
-      view.setImportantForAccessibility(View.IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS);
+    if (ApiCompatUtils.isJellyBeanOrHigher()) {
+      if (importantForAccessibility == null || importantForAccessibility.equals("auto")) {
+        view.setImportantForAccessibility(View.IMPORTANT_FOR_ACCESSIBILITY_AUTO);
+      } else if (importantForAccessibility.equals("yes")) {
+        view.setImportantForAccessibility(View.IMPORTANT_FOR_ACCESSIBILITY_YES);
+      } else if (importantForAccessibility.equals("no")) {
+        view.setImportantForAccessibility(View.IMPORTANT_FOR_ACCESSIBILITY_NO);
+      } else if (importantForAccessibility.equals("no-hide-descendants")) {
+        if (ApiCompatUtils.isKitkatOrHigher()) {
+          view.setImportantForAccessibility(View.IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS);
+        }
+      }
     }
   }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/DisplayMetricsHolder.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/DisplayMetricsHolder.java
@@ -27,7 +27,7 @@ import com.facebook.infer.annotation.Assertions;
  * classes that need it.
  * Note: windowDisplayMetrics are deprecated in favor of ScreenDisplayMetrics: window metrics
  * are supposed to return the drawable area but there's no guarantee that they correspond to the
- * actual size of the {@link ReactRootView}. Moreover, they are not consistent with what iOS
+ * actual size of the {@link com.facebook.react.ReactRootView}. Moreover, they are not consistent with what iOS
  * returns. Screen metrics returns the metrics of the entire screen, is consistent with iOS and
  * should be used instead.
  */
@@ -81,8 +81,14 @@ public class DisplayMetricsHolder {
         Method mGetRawW = Display.class.getMethod("getRawWidth");
         screenDisplayMetrics.widthPixels = (Integer) mGetRawW.invoke(display);
         screenDisplayMetrics.heightPixels = (Integer) mGetRawH.invoke(display);
-      } catch (InvocationTargetException | IllegalAccessException | NoSuchMethodException e) {
-        throw new RuntimeException("Error getting real dimensions for API level < 17", e);
+
+      // Multi-catch with these reflection exceptions requires API level 19 (current min is 15)
+      } catch (InvocationTargetException e) {
+        throw new RuntimeException("Invocation error in getting Display Dimension!", e);
+      } catch (IllegalAccessException e) {
+        throw new RuntimeException("Unable to access method for Display Dimension!", e);
+      } catch (NoSuchMethodException e) {
+        throw new RuntimeException("Unable to find method for Display Dimension!", e);
       }
     }
     DisplayMetricsHolder.setScreenDisplayMetrics(screenDisplayMetrics);

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/GuardedFrameCallback.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/GuardedFrameCallback.java
@@ -9,20 +9,19 @@
 
 package com.facebook.react.uimanager;
 
-import android.view.Choreographer;
-
 import com.facebook.react.bridge.ReactContext;
+import com.facebook.react.modules.core.ChoreographerCompat;
 
 /**
  * Abstract base for a Choreographer FrameCallback that should have any RuntimeExceptions it throws
  * handled by the {@link com.facebook.react.bridge.NativeModuleCallExceptionHandler} registered if
  * the app is in dev mode.
  */
-public abstract class GuardedChoreographerFrameCallback implements Choreographer.FrameCallback {
+public abstract class GuardedFrameCallback extends ChoreographerCompat.FrameCallback {
 
   private final ReactContext mReactContext;
 
-  protected GuardedChoreographerFrameCallback(ReactContext reactContext) {
+  protected GuardedFrameCallback(ReactContext reactContext) {
     mReactContext = reactContext;
   }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIViewOperationQueue.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIViewOperationQueue.java
@@ -862,7 +862,7 @@ public class UIViewOperationQueue {
    * Using a Choreographer callback (which runs immediately before traversals), we guarantee we run
    * before the next traversal.
    */
-  private class DispatchUIFrameCallback extends GuardedChoreographerFrameCallback {
+  private class DispatchUIFrameCallback extends GuardedFrameCallback {
 
     private static final int MIN_TIME_LEFT_IN_FRAME_TO_SCHEDULE_MORE_WORK_MS = 8;
     private static final int FRAME_TIME_MS = 16;

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManagerPropertyUpdater.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManagerPropertyUpdater.java
@@ -102,8 +102,10 @@ public class ViewManagerPropertyUpdater {
     } catch (ClassNotFoundException e) {
       FLog.w(TAG, "Could not find generated setter for " + cls);
       return null;
-    } catch (InstantiationException | IllegalAccessException e) {
+    } catch (InstantiationException e) {
       throw new RuntimeException("Unable to instantiate methods getter for " + clsName, e);
+    } catch (IllegalAccessException e) {
+      throw new RuntimeException("Unable to access methods getter for " + clsName, e);
     }
   }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/EventDispatcher.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/EventDispatcher.java
@@ -17,13 +17,13 @@ import java.util.Comparator;
 import java.util.Map;
 
 import android.util.LongSparseArray;
-import android.view.Choreographer;
 
 import com.facebook.infer.annotation.Assertions;
 import com.facebook.react.bridge.LifecycleEventListener;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.UiThreadUtil;
 import com.facebook.react.common.MapBuilder;
+import com.facebook.react.modules.core.ChoreographerCompat;
 import com.facebook.react.modules.core.ReactChoreographer;
 import com.facebook.systrace.Systrace;
 
@@ -251,7 +251,7 @@ public class EventDispatcher implements LifecycleEventListener {
         (((long) coalescingKey) & 0xffff) << 48;
   }
 
-  private class ScheduleDispatchFrameCallback implements Choreographer.FrameCallback {
+  private class ScheduleDispatchFrameCallback extends ChoreographerCompat.FrameCallback {
     private volatile boolean mIsPosted = false;
     private boolean mShouldStop = false;
 

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/EventDispatcher.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/EventDispatcher.java
@@ -9,14 +9,14 @@
 
 package com.facebook.react.uimanager.events;
 
+import android.support.v4.util.LongSparseArray;
+
 import javax.annotation.Nullable;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Map;
-
-import android.util.LongSparseArray;
 
 import com.facebook.infer.annotation.Assertions;
 import com.facebook.react.bridge.LifecycleEventListener;

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/OpacityAnimation.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/OpacityAnimation.java
@@ -2,9 +2,13 @@
 
 package com.facebook.react.uimanager.layoutanimation;
 
+import android.annotation.TargetApi;
+import android.os.Build;
 import android.view.View;
 import android.view.animation.Animation;
 import android.view.animation.Transformation;
+
+import com.facebook.react.common.ApiCompatUtils;
 
 /**
  * Animation responsible for updating opacity of a view. It should ideally use hardware texture
@@ -12,6 +16,7 @@ import android.view.animation.Transformation;
  */
 /* package */ class OpacityAnimation extends Animation {
 
+  @TargetApi(Build.VERSION_CODES.JELLY_BEAN)
   static class OpacityAnimationListener implements AnimationListener {
 
     private final View mView;
@@ -51,7 +56,10 @@ import android.view.animation.Transformation;
     mStartOpacity = startOpacity;
     mDeltaOpacity = endOpacity - startOpacity;
 
-    setAnimationListener(new OpacityAnimationListener(view));
+    // Only add layer type change listener after API 16.
+    if (ApiCompatUtils.isJellyBeanOrHigher()) {
+      setAnimationListener(new OpacityAnimationListener(view));
+    }
   }
 
   @Override

--- a/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
@@ -27,6 +27,7 @@ import android.widget.OverScroller;
 import android.widget.ScrollView;
 
 import com.facebook.react.bridge.ReactContext;
+import com.facebook.react.common.ApiCompatUtils;
 import com.facebook.react.common.ReactConstants;
 import com.facebook.react.uimanager.MeasureSpecAssertions;
 import com.facebook.react.uimanager.events.NativeGestureUtil;
@@ -259,7 +260,7 @@ public class ReactScrollView extends ScrollView implements ReactClippingViewGrou
         0,
         scrollWindowHeight / 2);
 
-      postInvalidateOnAnimation();
+      postInvalidateOnAnimationCompat();
 
       // END FB SCROLLVIEW CHANGE
     } else {
@@ -279,11 +280,27 @@ public class ReactScrollView extends ScrollView implements ReactClippingViewGrou
             ReactScrollViewHelper.emitScrollMomentumEndEvent(ReactScrollView.this);
           } else {
             mDoneFlinging = true;
-            ReactScrollView.this.postOnAnimationDelayed(this, ReactScrollViewHelper.MOMENTUM_DELAY);
+            postOnAnimationDelayedCompat(this, ReactScrollViewHelper.MOMENTUM_DELAY);
           }
         }
       };
-      postOnAnimationDelayed(r, ReactScrollViewHelper.MOMENTUM_DELAY);
+      postOnAnimationDelayedCompat(r, ReactScrollViewHelper.MOMENTUM_DELAY);
+    }
+  }
+
+  public void postInvalidateOnAnimationCompat() {
+    if (ApiCompatUtils.isJellyBeanOrHigher()) {
+      ReactScrollView.this.postInvalidateOnAnimation();
+    } else {
+      ReactScrollView.this.postInvalidateDelayed(ReactScrollViewHelper.MOMENTUM_DELAY);
+    }
+  }
+
+  public void postOnAnimationDelayedCompat(Runnable runnable, long delayMillis) {
+    if (ApiCompatUtils.isJellyBeanOrHigher()) {
+      ReactScrollView.this.postOnAnimationDelayed(runnable, delayMillis);
+    } else {
+      ReactScrollView.this.postDelayed(runnable, delayMillis);
     }
   }
 
@@ -416,14 +433,14 @@ public class ReactScrollView extends ScrollView implements ReactClippingViewGrou
     if (mReactBackgroundDrawable == null) {
       mReactBackgroundDrawable = new ReactViewBackgroundDrawable();
       Drawable backgroundDrawable = getBackground();
-      super.setBackground(null);  // required so that drawable callback is cleared before we add the
+      ApiCompatUtils.setBackground(this, null);  // required so that drawable callback is cleared before we add the
       // drawable back as a part of LayerDrawable
       if (backgroundDrawable == null) {
-        super.setBackground(mReactBackgroundDrawable);
+        ApiCompatUtils.setBackground(this, mReactBackgroundDrawable);
       } else {
         LayerDrawable layerDrawable =
             new LayerDrawable(new Drawable[]{mReactBackgroundDrawable, backgroundDrawable});
-        super.setBackground(layerDrawable);
+        ApiCompatUtils.setBackground(this, layerDrawable);
       }
     }
     return mReactBackgroundDrawable;

--- a/ReactAndroid/src/main/java/com/facebook/react/views/slider/ReactSliderManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/slider/ReactSliderManager.java
@@ -9,17 +9,15 @@
 
 package com.facebook.react.views.slider;
 
-import android.graphics.Color;
 import android.graphics.PorterDuff;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.LayerDrawable;
-import android.util.TypedValue;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.SeekBar;
 
-import com.facebook.react.R;
 import com.facebook.react.bridge.ReactContext;
+import com.facebook.react.common.ApiCompatUtils;
 import com.facebook.react.common.MapBuilder;
 import com.facebook.react.uimanager.LayoutShadowNode;
 import com.facebook.react.uimanager.SimpleViewManager;
@@ -153,10 +151,12 @@ public class ReactSliderManager extends SimpleViewManager<ReactSlider> {
 
   @ReactProp(name = "thumbTintColor", customType = "Color")
   public void setThumbTintColor(ReactSlider view, Integer color) {
-    if (color == null) {
-      view.getThumb().clearColorFilter();
-    } else {
-      view.getThumb().setColorFilter(color, PorterDuff.Mode.SRC_IN);
+    if (ApiCompatUtils.isJellyBeanOrHigher()) {
+      if (color == null) {
+        view.getThumb().clearColorFilter();
+      } else {
+        view.getThumb().setColorFilter(color, PorterDuff.Mode.SRC_IN);
+      }
     }
   }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
@@ -23,6 +23,7 @@ import android.view.Gravity;
 import android.view.ViewGroup;
 import android.widget.TextView;
 
+import com.facebook.react.common.ApiCompatUtils;
 import com.facebook.react.uimanager.ReactCompoundView;
 import com.facebook.react.uimanager.ViewDefaults;
 import com.facebook.react.views.view.ReactViewBackgroundDrawable;
@@ -267,14 +268,14 @@ public class ReactTextView extends TextView implements ReactCompoundView {
     if (mReactBackgroundDrawable == null) {
       mReactBackgroundDrawable = new ReactViewBackgroundDrawable();
       Drawable backgroundDrawable = getBackground();
-      super.setBackground(null);  // required so that drawable callback is cleared before we add the
+      ApiCompatUtils.setBackground(this, null);  // required so that drawable callback is cleared before we add the
       // drawable back as a part of LayerDrawable
       if (backgroundDrawable == null) {
-        super.setBackground(mReactBackgroundDrawable);
+        ApiCompatUtils.setBackground(this, mReactBackgroundDrawable);
       } else {
         LayerDrawable layerDrawable =
                 new LayerDrawable(new Drawable[]{mReactBackgroundDrawable, backgroundDrawable});
-        super.setBackground(layerDrawable);
+        ApiCompatUtils.setBackground(this, layerDrawable);
       }
     }
     return mReactBackgroundDrawable;

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
@@ -39,6 +39,7 @@ import android.view.inputmethod.InputMethodManager;
 import android.widget.EditText;
 
 import com.facebook.infer.annotation.Assertions;
+import com.facebook.react.common.ApiCompatUtils;
 import com.facebook.react.views.text.CustomStyleSpan;
 import com.facebook.react.views.text.ReactTagSpan;
 import com.facebook.react.views.text.ReactTextUpdate;
@@ -364,7 +365,7 @@ public class ReactEditText extends EditText {
   }
 
   /**
-   * Remove and/or add {@link Spanned.SPAN_EXCLUSIVE_EXCLUSIVE} spans, since they should only exist
+   * Remove and/or add {@link Spanned#SPAN_EXCLUSIVE_EXCLUSIVE} spans, since they should only exist
    * as long as the text they cover is the same. All other spans will remain the same, since they
    * will adapt to the new text, hence why {@link SpannableStringBuilder#replace} never removes
    * them.
@@ -595,14 +596,14 @@ public class ReactEditText extends EditText {
     if (mReactBackgroundDrawable == null) {
       mReactBackgroundDrawable = new ReactViewBackgroundDrawable();
       Drawable backgroundDrawable = getBackground();
-      super.setBackground(null);  // required so that drawable callback is cleared before we add the
+      ApiCompatUtils.setBackground(this, null);  // required so that drawable callback is cleared before we add the
       // drawable back as a part of LayerDrawable
       if (backgroundDrawable == null) {
-        super.setBackground(mReactBackgroundDrawable);
+        ApiCompatUtils.setBackground(this, mReactBackgroundDrawable);
       } else {
         LayerDrawable layerDrawable =
             new LayerDrawable(new Drawable[]{mReactBackgroundDrawable, backgroundDrawable});
-        super.setBackground(layerDrawable);
+        ApiCompatUtils.setBackground(this, layerDrawable);
       }
     }
     return mReactBackgroundDrawable;

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputShadowNode.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputShadowNode.java
@@ -10,7 +10,6 @@
 package com.facebook.react.views.textinput;
 
 import javax.annotation.Nullable;
-import javax.annotation.OverridingMethodsMustInvokeSuper;
 
 import android.os.Build;
 import android.text.Layout;
@@ -19,7 +18,7 @@ import android.util.TypedValue;
 import android.view.ViewGroup;
 import android.widget.EditText;
 
-import com.facebook.yoga.YogaDirection;
+import com.facebook.react.common.ApiCompatUtils;
 import com.facebook.yoga.YogaMeasureMode;
 import com.facebook.yoga.YogaMeasureFunction;
 import com.facebook.yoga.YogaNodeAPI;
@@ -32,7 +31,6 @@ import com.facebook.react.uimanager.Spacing;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.UIViewOperationQueue;
 import com.facebook.react.uimanager.ViewDefaults;
-import com.facebook.react.uimanager.ViewProps;
 import com.facebook.react.uimanager.annotations.ReactProp;
 import com.facebook.react.views.view.MeasureUtil;
 import com.facebook.react.views.text.ReactTextShadowNode;
@@ -64,9 +62,9 @@ public class ReactTextInputShadowNode extends ReactTextShadowNode implements
             ViewGroup.LayoutParams.WRAP_CONTENT,
             ViewGroup.LayoutParams.WRAP_CONTENT));
 
-    setDefaultPadding(Spacing.START, mEditText.getPaddingStart());
+    setDefaultPadding(Spacing.START, ApiCompatUtils.getPaddingStart(mEditText));
     setDefaultPadding(Spacing.TOP, mEditText.getPaddingTop());
-    setDefaultPadding(Spacing.END, mEditText.getPaddingEnd());
+    setDefaultPadding(Spacing.END, ApiCompatUtils.getPaddingEnd(mEditText));
     setDefaultPadding(Spacing.BOTTOM, mEditText.getPaddingBottom());
     mEditText.setPadding(0, 0, 0, 0);
   }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/toolbar/ReactToolbarManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/toolbar/ReactToolbarManager.java
@@ -17,13 +17,13 @@ import android.content.Context;
 import android.content.res.Resources;
 import android.content.res.TypedArray;
 import android.graphics.Color;
-import android.util.LayoutDirection;
 import android.view.MenuItem;
 import android.view.View;
 
 import com.facebook.react.R;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.common.ApiCompatUtils;
 import com.facebook.react.common.MapBuilder;
 import com.facebook.react.uimanager.PixelUtil;
 import com.facebook.react.uimanager.ThemedReactContext;
@@ -67,7 +67,7 @@ public class ReactToolbarManager extends ViewGroupManager<ReactToolbar> {
 
   @ReactProp(name = "rtl")
   public void setRtl(ReactToolbar view, boolean rtl) {
-    view.setLayoutDirection(rtl ? LayoutDirection.RTL : LayoutDirection.LTR);
+    ApiCompatUtils.setRtl(view, rtl);
   }
 
   @ReactProp(name = "subtitle")

--- a/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactDrawableHelper.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactDrawableHelper.java
@@ -15,12 +15,12 @@ import android.graphics.Color;
 import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.RippleDrawable;
-import android.os.Build;
 import android.util.TypedValue;
 
 import com.facebook.react.bridge.JSApplicationIllegalArgumentException;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.SoftAssertions;
+import com.facebook.react.common.ApiCompatUtils;
 import com.facebook.react.uimanager.ViewProps;
 
 /**
@@ -44,8 +44,7 @@ public class ReactDrawableHelper {
             " couldn't be found in the resource list");
       }
       if (context.getTheme().resolveAttribute(attrID, sResolveOutValue, true)) {
-        final int version = Build.VERSION.SDK_INT;
-        if (version >= 21) {
+        if (ApiCompatUtils.isLollipopOrHigher()) {
           return context.getResources()
               .getDrawable(sResolveOutValue.resourceId, context.getTheme());
         } else {
@@ -56,9 +55,9 @@ public class ReactDrawableHelper {
             " couldn't be resolved into a drawable");
       }
     } else if ("RippleAndroid".equals(type)) {
-      if (Build.VERSION.SDK_INT < 21) {
+      if (ApiCompatUtils.isLollipopOrHigher()) {
         throw new JSApplicationIllegalArgumentException("Ripple drawable is not available on " +
-            "android API <21");
+            "android API < 21");
       }
       int color;
       if (drawableDescriptionDict.hasKey(ViewProps.COLOR) &&

--- a/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
@@ -22,6 +22,7 @@ import android.view.View;
 import android.view.ViewGroup;
 
 import com.facebook.infer.annotation.Assertions;
+import com.facebook.react.common.ApiCompatUtils;
 import com.facebook.react.common.annotations.VisibleForTesting;
 import com.facebook.react.touch.ReactHitSlopView;
 import com.facebook.react.touch.ReactInterceptingViewGroup;
@@ -141,13 +142,13 @@ public class ReactViewGroup extends ViewGroup implements
     // background to be a layer drawable that contains a drawable that has been previously setup
     // as a background previously. This will not work correctly as the drawable callback logic is
     // messed up in AOSP
-    super.setBackground(null);
+    ApiCompatUtils.setBackground(this, null);
     if (mReactBackgroundDrawable != null && background != null) {
       LayerDrawable layerDrawable =
           new LayerDrawable(new Drawable[] {mReactBackgroundDrawable, background});
-      super.setBackground(layerDrawable);
+      ApiCompatUtils.setBackground(this, layerDrawable);
     } else if (background != null) {
-      super.setBackground(background);
+      ApiCompatUtils.setBackground(this, background);
     }
   }
 
@@ -510,14 +511,14 @@ public class ReactViewGroup extends ViewGroup implements
     if (mReactBackgroundDrawable == null) {
       mReactBackgroundDrawable = new ReactViewBackgroundDrawable();
       Drawable backgroundDrawable = getBackground();
-      super.setBackground(null);  // required so that drawable callback is cleared before we add the
+      ApiCompatUtils.setBackground(this, null);  // required so that drawable callback is cleared before we add the
                                   // drawable back as a part of LayerDrawable
       if (backgroundDrawable == null) {
-        super.setBackground(mReactBackgroundDrawable);
+        ApiCompatUtils.setBackground(this, mReactBackgroundDrawable);
       } else {
         LayerDrawable layerDrawable =
             new LayerDrawable(new Drawable[] {mReactBackgroundDrawable, backgroundDrawable});
-        super.setBackground(layerDrawable);
+        ApiCompatUtils.setBackground(this, layerDrawable);
       }
     }
     return mReactBackgroundDrawable;

--- a/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebViewManager.java
@@ -33,6 +33,7 @@ import android.webkit.JavascriptInterface;
 import android.webkit.ValueCallback;
 
 import com.facebook.common.logging.FLog;
+import com.facebook.react.common.ApiCompatUtils;
 import com.facebook.react.common.ReactConstants;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.LifecycleEventListener;
@@ -389,12 +390,16 @@ public class ReactWebViewManager extends SimpleViewManager<WebView> {
 
   @ReactProp(name = "mediaPlaybackRequiresUserAction")
   public void setMediaPlaybackRequiresUserAction(WebView view, boolean requires) {
-    view.getSettings().setMediaPlaybackRequiresUserGesture(requires);
+    if (ApiCompatUtils.isJellyBeanMR1OrHigher()) {
+      view.getSettings().setMediaPlaybackRequiresUserGesture(requires);
+    }
   }
 
   @ReactProp(name = "allowUniversalAccessFromFileURLs")
   public void setAllowUniversalAccessFromFileURLs(WebView view, boolean allow) {
-    view.getSettings().setAllowUniversalAccessFromFileURLs(allow);
+    if (ApiCompatUtils.isJellyBeanMR1OrHigher()) {
+      view.getSettings().setAllowUniversalAccessFromFileURLs(allow);
+    }
   }
 
   @ReactProp(name = "injectedJavaScript")

--- a/ReactAndroid/src/main/res/views/modal/values-v19/themes.xml
+++ b/ReactAndroid/src/main/res/views/modal/values-v19/themes.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+  <style name="Theme.FullScreenDialog" parent="Theme.FullScreenDialog.Base">
+    <item name="android:windowTranslucentStatus">true</item>
+  </style>
+
+</resources>

--- a/ReactAndroid/src/main/res/views/modal/values/themes.xml
+++ b/ReactAndroid/src/main/res/views/modal/values/themes.xml
@@ -2,12 +2,13 @@
 
 <resources>
 
-  <style name="Theme.FullScreenDialog">
+  <style name="Theme.FullScreenDialog.Base">
     <item name="android:windowNoTitle">true</item>
     <item name="android:windowIsFloating">false</item>
     <item name="android:windowBackground">@android:color/transparent</item>
-    <item name="android:windowTranslucentStatus">true</item>
   </style>
+
+  <style name="Theme.FullScreenDialog" parent="Theme.FullScreenDialog.Base"/>
 
   <style name="Theme.FullScreenDialogAnimatedSlide" parent="Theme.FullScreenDialog">
     <item name="android:windowAnimationStyle">@style/DialogAnimationSlide</item>

--- a/ReactAndroid/src/test/java/com/facebook/react/modules/timing/TimingModuleTest.java
+++ b/ReactAndroid/src/test/java/com/facebook/react/modules/timing/TimingModuleTest.java
@@ -9,8 +9,6 @@
 
 package com.facebook.react.modules.timing;
 
-import android.view.Choreographer;
-
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ExecutorToken;
 import com.facebook.react.bridge.ReactApplicationContext;
@@ -18,6 +16,7 @@ import com.facebook.react.bridge.CatalystInstance;
 import com.facebook.react.bridge.JavaOnlyArray;
 import com.facebook.react.devsupport.interfaces.DevSupportManager;
 import com.facebook.react.common.SystemClock;
+import com.facebook.react.modules.core.ChoreographerCompat;
 import com.facebook.react.modules.core.JSTimersExecution;
 import com.facebook.react.modules.core.ReactChoreographer;
 import com.facebook.react.modules.core.Timing;
@@ -39,8 +38,8 @@ import static org.mockito.Mockito.*;
 /**
  * Tests for {@link Timing}.
  */
- // DISABLED, BROKEN https://circleci.com/gh/facebook/react-native/12068
- // t=13905097
+// DISABLED, BROKEN https://circleci.com/gh/facebook/react-native/12068
+// t=13905097
 @PrepareForTest({Arguments.class, SystemClock.class, ReactChoreographer.class})
 @PowerMockIgnore({"org.mockito.*", "org.robolectric.*", "android.*"})
 @RunWith(RobolectricTestRunner.class)
@@ -63,12 +62,12 @@ public class TimingModuleTest {
   public void prepareModules() {
     PowerMockito.mockStatic(Arguments.class);
     when(Arguments.createArray()).thenAnswer(
-        new Answer<Object>() {
-          @Override
-          public Object answer(InvocationOnMock invocation) throws Throwable {
-            return new JavaOnlyArray();
-          }
-        });
+      new Answer<Object>() {
+        @Override
+        public Object answer(InvocationOnMock invocation) throws Throwable {
+          return new JavaOnlyArray();
+        }
+      });
 
     PowerMockito.mockStatic(SystemClock.class);
     when(SystemClock.uptimeMillis()).thenReturn(mCurrentTimeNs / 1000000);
@@ -88,16 +87,16 @@ public class TimingModuleTest {
     mIdlePostFrameCallbackHandler = new PostFrameIdleCallbackHandler();
 
     doAnswer(mPostFrameCallbackHandler)
-        .when(mReactChoreographerMock)
-        .postFrameCallback(
-            eq(ReactChoreographer.CallbackType.TIMERS_EVENTS),
-            any(Choreographer.FrameCallback.class));
+      .when(mReactChoreographerMock)
+      .postFrameCallback(
+        eq(ReactChoreographer.CallbackType.TIMERS_EVENTS),
+        any(ChoreographerCompat.FrameCallback.class));
 
     doAnswer(mIdlePostFrameCallbackHandler)
-        .when(mReactChoreographerMock)
-        .postFrameCallback(
-            eq(ReactChoreographer.CallbackType.IDLE_EVENT),
-            any(Choreographer.FrameCallback.class));
+      .when(mReactChoreographerMock)
+      .postFrameCallback(
+        eq(ReactChoreographer.CallbackType.IDLE_EVENT),
+        any(ChoreographerCompat.FrameCallback.class));
 
     mTiming = new Timing(reactContext, mock(DevSupportManager.class));
     mJSTimersMock = mock(JSTimersExecution.class);
@@ -116,8 +115,8 @@ public class TimingModuleTest {
   }
 
   private void stepChoreographerFrame() {
-    Choreographer.FrameCallback callback = mPostFrameCallbackHandler.getAndResetFrameCallback();
-    Choreographer.FrameCallback idleCallback = mIdlePostFrameCallbackHandler.getAndResetFrameCallback();
+    ChoreographerCompat.FrameCallback callback = mPostFrameCallbackHandler.getAndResetFrameCallback();
+    ChoreographerCompat.FrameCallback idleCallback = mIdlePostFrameCallbackHandler.getAndResetFrameCallback();
 
     mCurrentTimeNs += FRAME_TIME_NS;
     when(SystemClock.uptimeMillis()).thenReturn(mCurrentTimeNs / 1000000);
@@ -259,17 +258,17 @@ public class TimingModuleTest {
 
   private static class PostFrameIdleCallbackHandler implements Answer<Void> {
 
-    private Choreographer.FrameCallback mFrameCallback;
+    private ChoreographerCompat.FrameCallback mFrameCallback;
 
     @Override
     public Void answer(InvocationOnMock invocation) throws Throwable {
       Object[] args = invocation.getArguments();
-      mFrameCallback = (Choreographer.FrameCallback) args[1];
+      mFrameCallback = (ChoreographerCompat.FrameCallback) args[1];
       return null;
     }
 
-    public Choreographer.FrameCallback getAndResetFrameCallback() {
-      Choreographer.FrameCallback callback = mFrameCallback;
+    public ChoreographerCompat.FrameCallback getAndResetFrameCallback() {
+      ChoreographerCompat.FrameCallback callback = mFrameCallback;
       mFrameCallback = null;
       return callback;
     }
@@ -277,17 +276,17 @@ public class TimingModuleTest {
 
   private static class PostFrameCallbackHandler implements Answer<Void> {
 
-    private Choreographer.FrameCallback mFrameCallback;
+    private ChoreographerCompat.FrameCallback mFrameCallback;
 
     @Override
     public Void answer(InvocationOnMock invocation) throws Throwable {
       Object[] args = invocation.getArguments();
-      mFrameCallback = (Choreographer.FrameCallback) args[1];
+      mFrameCallback = (ChoreographerCompat.FrameCallback) args[1];
       return null;
     }
 
-    public Choreographer.FrameCallback getAndResetFrameCallback() {
-      Choreographer.FrameCallback callback = mFrameCallback;
+    public ChoreographerCompat.FrameCallback getAndResetFrameCallback() {
+      ChoreographerCompat.FrameCallback callback = mFrameCallback;
       mFrameCallback = null;
       return callback;
     }

--- a/ReactAndroid/src/test/java/com/facebook/react/uimanager/UIManagerModuleTest.java
+++ b/ReactAndroid/src/test/java/com/facebook/react/uimanager/UIManagerModuleTest.java
@@ -14,7 +14,6 @@ import java.util.Arrays;
 import java.util.List;
 
 import android.graphics.Color;
-import android.view.Choreographer;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
@@ -29,6 +28,8 @@ import com.facebook.react.bridge.JavaOnlyArray;
 import com.facebook.react.bridge.JavaOnlyMap;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactTestHelper;
+import com.facebook.react.modules.core.ChoreographerCompat;
+import com.facebook.react.modules.core.ReactChoreographer;
 import com.facebook.react.views.text.ReactRawTextManager;
 import com.facebook.react.views.text.ReactTextShadowNode;
 import com.facebook.react.views.text.ReactTextViewManager;
@@ -70,7 +71,7 @@ public class UIManagerModuleTest {
 
   private ReactApplicationContext mReactContext;
   private CatalystInstance mCatalystInstanceMock;
-  private ArrayList<Choreographer.FrameCallback> mPendingChoreographerCallbacks;
+  private ArrayList<ChoreographerCompat.FrameCallback> mPendingFrameCallbacks;
 
   @Before
   public void setUp() {
@@ -91,17 +92,17 @@ public class UIManagerModuleTest {
     });
     PowerMockito.when(ReactChoreographer.getInstance()).thenReturn(choreographerMock);
 
-    mPendingChoreographerCallbacks = new ArrayList<>();
+    mPendingFrameCallbacks = new ArrayList<>();
     doAnswer(new Answer() {
       @Override
       public Object answer(InvocationOnMock invocation) throws Throwable {
-        mPendingChoreographerCallbacks
-            .add((Choreographer.FrameCallback) invocation.getArguments()[1]);
+        mPendingFrameCallbacks
+            .add((ChoreographerCompat.FrameCallback) invocation.getArguments()[1]);
         return null;
       }
     }).when(choreographerMock).postFrameCallback(
         any(ReactChoreographer.CallbackType.class),
-        any(Choreographer.FrameCallback.class));
+        any(ChoreographerCompat.FrameCallback.class));
 
     mCatalystInstanceMock = ReactTestHelper.createMockCatalystInstance();
     mReactContext = new ReactApplicationContext(RuntimeEnvironment.application);
@@ -139,7 +140,7 @@ public class UIManagerModuleTest {
         JavaOnlyMap.of(ReactTextShadowNode.PROP_TEXT, "New text"));
 
     uiManager.onBatchComplete();
-    executePendingChoreographerCallbacks();
+    executePendingFrameCallbacks();
 
     assertThat(textView.getText().toString()).isEqualTo("New text");
   }
@@ -182,7 +183,7 @@ public class UIManagerModuleTest {
         null);
 
     uiManager.onBatchComplete();
-    executePendingChoreographerCallbacks();
+    executePendingFrameCallbacks();
 
     assertThat(rootView.getChildCount()).isEqualTo(1);
 
@@ -213,7 +214,7 @@ public class UIManagerModuleTest {
         null);
 
     uiManager.onBatchComplete();
-    executePendingChoreographerCallbacks();
+    executePendingFrameCallbacks();
 
     assertChildrenAreExactly(
         hierarchy.nativeRootView,
@@ -240,7 +241,7 @@ public class UIManagerModuleTest {
         JavaOnlyArray.of(0, 3));
 
     uiManager.onBatchComplete();
-    executePendingChoreographerCallbacks();
+    executePendingFrameCallbacks();
 
     assertChildrenAreExactly(
         hierarchy.nativeRootView,
@@ -266,7 +267,7 @@ public class UIManagerModuleTest {
         JavaOnlyArray.of(1));
 
     uiManager.onBatchComplete();
-    executePendingChoreographerCallbacks();
+    executePendingFrameCallbacks();
 
     assertChildrenAreExactly(
         hierarchy.nativeRootView,
@@ -289,7 +290,7 @@ public class UIManagerModuleTest {
         JavaOnlyArray.of(3));
 
     uiManager.onBatchComplete();
-    executePendingChoreographerCallbacks();
+    executePendingFrameCallbacks();
   }
 
   @Test(expected = IllegalViewOperationException.class)
@@ -306,7 +307,7 @@ public class UIManagerModuleTest {
         JavaOnlyArray.of(3, 3));
 
     uiManager.onBatchComplete();
-    executePendingChoreographerCallbacks();
+    executePendingFrameCallbacks();
   }
 
   @Test
@@ -335,7 +336,7 @@ public class UIManagerModuleTest {
         null);
 
     uiManager.onBatchComplete();
-    executePendingChoreographerCallbacks();
+    executePendingFrameCallbacks();
 
     assertThat(hierarchy.nativeRootView.getChildCount()).isEqualTo(5);
     assertThat(hierarchy.nativeRootView.getChildAt(0)).isEqualTo(expectedViewAt0);
@@ -363,7 +364,7 @@ public class UIManagerModuleTest {
         null);
 
     uiManager.onBatchComplete();
-    executePendingChoreographerCallbacks();
+    executePendingFrameCallbacks();
 
     assertChildrenAreExactly(
         hierarchy.nativeRootView,
@@ -392,7 +393,7 @@ public class UIManagerModuleTest {
         JavaOnlyArray.of(1));
 
     uiManager.onBatchComplete();
-    executePendingChoreographerCallbacks();
+    executePendingFrameCallbacks();
 
     assertChildrenAreExactly(
         hierarchy.nativeRootView,
@@ -424,7 +425,7 @@ public class UIManagerModuleTest {
         null);
 
     uiManager.onBatchComplete();
-    executePendingChoreographerCallbacks();
+    executePendingFrameCallbacks();
 
     View newView = hierarchy.nativeRootView.getChildAt(4);
     assertThat(newView.getLeft()).isEqualTo(10);
@@ -472,7 +473,7 @@ public class UIManagerModuleTest {
         JavaOnlyArray.of(4));
 
     uiManager.onBatchComplete();
-    executePendingChoreographerCallbacks();
+    executePendingFrameCallbacks();
 
     assertThat(hierarchy.nativeRootView.getChildCount()).isEqualTo(4);
   }
@@ -518,7 +519,7 @@ public class UIManagerModuleTest {
         ReactViewManager.REACT_CLASS,
         JavaOnlyMap.of("left", 10.0, "top", 20.0, "width", 30.0, "height", 40.0));
     uiManager.onBatchComplete();
-    executePendingChoreographerCallbacks();
+    executePendingFrameCallbacks();
     assertThat(view0.getLeft()).isGreaterThan(2);
 
     // verify that the layout doesn't get updated when we update style property not affecting the
@@ -529,7 +530,7 @@ public class UIManagerModuleTest {
         ReactViewManager.REACT_CLASS,
         JavaOnlyMap.of("backgroundColor", Color.RED));
     uiManager.onBatchComplete();
-    executePendingChoreographerCallbacks();
+    executePendingFrameCallbacks();
     assertThat(view0.getLeft()).isEqualTo(1);
   }
 
@@ -565,7 +566,7 @@ public class UIManagerModuleTest {
     uiManagerModule.removeAnimation(hierarchy.rootView, 1000);
 
     uiManagerModule.onBatchComplete();
-    executePendingChoreographerCallbacks();
+    executePendingFrameCallbacks();
 
     verify(callbackMock, times(1)).invoke(false);
     verify(mockAnimation).run();
@@ -591,7 +592,7 @@ public class UIManagerModuleTest {
     uiManager.replaceExistingNonRootView(hierarchy.view2, newViewTag);
 
     uiManager.onBatchComplete();
-    executePendingChoreographerCallbacks();
+    executePendingFrameCallbacks();
 
     assertThat(hierarchy.nativeRootView.getChildCount()).isEqualTo(4);
     assertThat(hierarchy.nativeRootView.getChildAt(2)).isInstanceOf(ReactViewGroup.class);
@@ -640,7 +641,7 @@ public class UIManagerModuleTest {
     addChild(uiManager, containerTag, containerTag + 3, 1);
 
     uiManager.onBatchComplete();
-    executePendingChoreographerCallbacks();
+    executePendingFrameCallbacks();
 
     assertThat(rootView.getChildCount()).isEqualTo(2);
     assertThat(((ViewGroup) rootView.getChildAt(0)).getChildCount()).isEqualTo(2);
@@ -648,7 +649,7 @@ public class UIManagerModuleTest {
     uiManager.removeSubviewsFromContainerWithID(containerTag);
 
     uiManager.onBatchComplete();
-    executePendingChoreographerCallbacks();
+    executePendingFrameCallbacks();
 
     assertThat(rootView.getChildCount()).isEqualTo(2);
     assertThat(((ViewGroup) rootView.getChildAt(0)).getChildCount()).isEqualTo(0);
@@ -693,7 +694,7 @@ public class UIManagerModuleTest {
         null);
 
     uiManager.onBatchComplete();
-    executePendingChoreographerCallbacks();
+    executePendingFrameCallbacks();
 
     return rootView;
   }
@@ -744,7 +745,7 @@ public class UIManagerModuleTest {
     addChild(uiManager, hierarchy.viewWithChildren1, hierarchy.childView1, 1);
 
     uiManager.onBatchComplete();
-    executePendingChoreographerCallbacks();
+    executePendingFrameCallbacks();
 
     return hierarchy;
   }
@@ -803,11 +804,11 @@ public class UIManagerModuleTest {
     }
   }
 
-  private void executePendingChoreographerCallbacks() {
-    ArrayList<Choreographer.FrameCallback> callbacks =
-        new ArrayList<>(mPendingChoreographerCallbacks);
-    mPendingChoreographerCallbacks.clear();
-    for (Choreographer.FrameCallback frameCallback : callbacks) {
+  private void executePendingFrameCallbacks() {
+    ArrayList<ChoreographerCompat.FrameCallback> callbacks =
+        new ArrayList<>(mPendingFrameCallbacks);
+    mPendingFrameCallbacks.clear();
+    for (ChoreographerCompat.FrameCallback frameCallback : callbacks) {
       frameCallback.doFrame(0);
     }
   }

--- a/ReactAndroid/src/test/java/com/facebook/react/views/text/ReactTextTest.java
+++ b/ReactAndroid/src/test/java/com/facebook/react/views/text/ReactTextTest.java
@@ -23,7 +23,6 @@ import android.text.TextUtils;
 import android.text.style.AbsoluteSizeSpan;
 import android.text.style.StrikethroughSpan;
 import android.text.style.UnderlineSpan;
-import android.view.Choreographer;
 import android.widget.TextView;
 
 import com.facebook.react.ReactRootView;
@@ -32,7 +31,8 @@ import com.facebook.react.bridge.JavaOnlyArray;
 import com.facebook.react.bridge.JavaOnlyMap;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactTestHelper;
-import com.facebook.react.uimanager.ReactChoreographer;
+import com.facebook.react.modules.core.ChoreographerCompat;
+import com.facebook.react.modules.core.ReactChoreographer;
 import com.facebook.react.uimanager.UIImplementationProvider;
 import com.facebook.react.uimanager.UIManagerModule;
 import com.facebook.react.uimanager.ViewManager;
@@ -68,32 +68,32 @@ public class ReactTextTest {
   @Rule
   public PowerMockRule rule = new PowerMockRule();
 
-  private ArrayList<Choreographer.FrameCallback> mPendingChoreographerCallbacks;
+  private ArrayList<ChoreographerCompat.FrameCallback> mPendingFrameCallbacks;
 
   @Before
   public void setUp() {
     PowerMockito.mockStatic(Arguments.class, ReactChoreographer.class);
 
-    ReactChoreographer choreographerMock = mock(ReactChoreographer.class);
+    ReactChoreographer uiDriverMock = mock(ReactChoreographer.class);
     PowerMockito.when(Arguments.createMap()).thenAnswer(new Answer<Object>() {
       @Override
       public Object answer(InvocationOnMock invocation) throws Throwable {
         return new JavaOnlyMap();
       }
     });
-    PowerMockito.when(ReactChoreographer.getInstance()).thenReturn(choreographerMock);
+    PowerMockito.when(ReactChoreographer.getInstance()).thenReturn(uiDriverMock);
 
-    mPendingChoreographerCallbacks = new ArrayList<>();
+    mPendingFrameCallbacks = new ArrayList<>();
     doAnswer(new Answer() {
       @Override
       public Object answer(InvocationOnMock invocation) throws Throwable {
-        mPendingChoreographerCallbacks
-            .add((Choreographer.FrameCallback) invocation.getArguments()[1]);
+        mPendingFrameCallbacks
+            .add((ChoreographerCompat.FrameCallback) invocation.getArguments()[1]);
         return null;
       }
-    }).when(choreographerMock).postFrameCallback(
+    }).when(uiDriverMock).postFrameCallback(
         any(ReactChoreographer.CallbackType.class),
-        any(Choreographer.FrameCallback.class));
+        any(ChoreographerCompat.FrameCallback.class));
   }
 
   @Test
@@ -411,15 +411,15 @@ public class ReactTextTest {
         null);
 
     uiManager.onBatchComplete();
-    executePendingChoreographerCallbacks();
+    executePendingFrameCallbacks();
     return rootView;
   }
 
-  private void executePendingChoreographerCallbacks() {
-    ArrayList<Choreographer.FrameCallback> callbacks =
-        new ArrayList<>(mPendingChoreographerCallbacks);
-    mPendingChoreographerCallbacks.clear();
-    for (Choreographer.FrameCallback frameCallback : callbacks) {
+  private void executePendingFrameCallbacks() {
+    ArrayList<ChoreographerCompat.FrameCallback> callbacks =
+        new ArrayList<>(mPendingFrameCallbacks);
+    mPendingFrameCallbacks.clear();
+    for (ChoreographerCompat.FrameCallback frameCallback : callbacks) {
       frameCallback.doFrame(0);
     }
   }

--- a/ReactAndroid/src/test/java/com/facebook/react/views/textinput/TextInputTest.java
+++ b/ReactAndroid/src/test/java/com/facebook/react/views/textinput/TextInputTest.java
@@ -13,7 +13,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import android.view.Choreographer;
 import android.widget.EditText;
 
 import com.facebook.react.ReactRootView;
@@ -22,8 +21,8 @@ import com.facebook.react.bridge.JavaOnlyArray;
 import com.facebook.react.bridge.JavaOnlyMap;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactTestHelper;
-import com.facebook.react.uimanager.ReactChoreographer;
-import com.facebook.react.uimanager.UIImplementation;
+import com.facebook.react.modules.core.ChoreographerCompat;
+import com.facebook.react.modules.core.ReactChoreographer;
 import com.facebook.react.uimanager.UIImplementationProvider;
 import com.facebook.react.uimanager.UIManagerModule;
 import com.facebook.react.uimanager.ViewManager;
@@ -58,7 +57,7 @@ public class TextInputTest {
   @Rule
   public PowerMockRule rule = new PowerMockRule();
 
-  private ArrayList<Choreographer.FrameCallback> mPendingChoreographerCallbacks;
+  private ArrayList<ChoreographerCompat.FrameCallback> mPendingChoreographerCallbacks;
 
   @Before
   public void setUp() {
@@ -78,12 +77,12 @@ public class TextInputTest {
       @Override
       public Object answer(InvocationOnMock invocation) throws Throwable {
         mPendingChoreographerCallbacks
-            .add((Choreographer.FrameCallback) invocation.getArguments()[1]);
+            .add((ChoreographerCompat.FrameCallback) invocation.getArguments()[1]);
         return null;
       }
     }).when(choreographerMock).postFrameCallback(
         any(ReactChoreographer.CallbackType.class),
-        any(Choreographer.FrameCallback.class));
+        any(ChoreographerCompat.FrameCallback.class));
   }
 
   @Test
@@ -169,10 +168,10 @@ public class TextInputTest {
   }
 
   private void executePendingChoreographerCallbacks() {
-    ArrayList<Choreographer.FrameCallback> callbacks =
+    ArrayList<ChoreographerCompat.FrameCallback> callbacks =
         new ArrayList<>(mPendingChoreographerCallbacks);
     mPendingChoreographerCallbacks.clear();
-    for (Choreographer.FrameCallback frameCallback : callbacks) {
+    for (ChoreographerCompat.FrameCallback frameCallback : callbacks) {
       frameCallback.doFrame(0);
     }
   }


### PR DESCRIPTION
Android API 15 still have 1.5~2.0% distribution (refer: [Dashboard - Android Developer](https://developer.android.com/ndk/guides/standalone_toolchain.html#creating_the_toolchain)).

React Native is a good tec but many companies cannot endure loose their consumer. [Choreographer](https://developer.android.com/reference/android/view/Choreographer.html) triggered UI operation is the only reason that React Native Android sdk use minSdkVersion 16, so we can use a backward solution **only in API 15**: [Handler](https://developer.android.com/reference/android/os/Handler.html).

In this PR, the biggest change is : 

- Make core operation of ReactChoreographer to an interface: ReactUIDriver;
- Impl ReactUIDriver by Handler => UIDriverHandlerImpl, refactor ReactChoreographer to UIDriverChoreographerImpl;
- Let UIDriverFactory to choose which one impl would be in use. (Only use handler in api 15).