### PR TITLE
Find all symlinks in (scoped) node_modules and merge `root` flag

### DIFF
--- a/local-cli/server/server.js
+++ b/local-cli/server/server.js
@@ -10,12 +10,16 @@
 
 const path = require('path');
 const runServer = require('./runServer');
+const findSymlinksPaths = require('../util/findSymlinksPaths');
 
 /**
  * Starts the React Native Packager Server.
  */
 function server(argv, config, args) {
-  args.projectRoots = args.projectRoots.concat(args.root);
+  Array.prototype.push.apply(args.projectRoots, args.root.reduce((roots, src) => roots.concat(
+    findSymlinksPaths(path.join(src, 'node_modules'), args.projectRoots),
+    src
+  ), []));
 
   const startedCallback = logReporter => {
     logReporter.update({

--- a/local-cli/util/__tests__/findSymlinksPaths.spec.js
+++ b/local-cli/util/__tests__/findSymlinksPaths.spec.js
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+'use strict';
+
+jest.autoMockOff();
+
+const log = require('npmlog');
+const fs = require('fs');
+
+describe('Utils', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    delete require.cache[require.resolve('../findSymlinksPaths')];
+    log.level = 'silent';
+  });
+
+  it('should read scoped packages', () => {
+    const readdirSync = jest.fn()
+      .mockImplementationOnce(() => [ 'module1', 'module2', '@jest', '@react' ])
+      .mockImplementationOnce(() => [ 'mocks', 'tests' ])
+      .mockImplementationOnce(() => [ 'native' ]);
+    const lstatSync = jest.fn((str) => new fs.Stats())
+
+    const mock = jest.setMock('fs', {
+      readdirSync,
+      lstatSync
+    });
+
+    const find = require('../findSymlinksPaths');
+    const links = find(__dirname, []);
+
+    expect(readdirSync.mock.calls.length).toEqual(3);
+    expect(readdirSync.mock.calls[1][0]).toContain('__tests__/@jest');
+    expect(readdirSync.mock.calls[2][0]).toContain('__tests__/@react');
+
+    expect(lstatSync.mock.calls.length).toEqual(7);
+    expect(lstatSync.mock.calls[2][0]).toContain('__tests__/@jest/mocks');
+    expect(lstatSync.mock.calls[3][0]).toContain('__tests__/@jest/tests');
+    expect(lstatSync.mock.calls[5][0]).toContain('__tests__/@react/native');
+    expect(links.length).toEqual(0);
+  });
+
+  it('should attempt to read symlinks node_modules folder for nested symlinks', function () {
+    const link = new fs.Stats(16777220, 41453);
+    const dir = new fs.Stats(16777220, 16877);
+
+    const readdirSync = jest.fn()
+      .mockImplementationOnce(() => [ 'symlink' ])
+      .mockImplementationOnce(() => [ 'deeperLink' ])
+    const lstatSync = jest.fn()
+      .mockImplementationOnce(str => link)
+      .mockImplementationOnce(str => dir) // shortcircuits while loop
+      .mockImplementationOnce(str => dir)
+      .mockImplementationOnce(str => link)
+      .mockImplementationOnce(str => dir) // shortcircuits while loop
+      .mockImplementationOnce(str => new fs.Stats());
+
+    const mock = jest.setMock('fs', {
+      readlinkSync: str => str,
+      existsSync: () => true,
+      readdirSync,
+      lstatSync
+    });
+
+    const find = require('../findSymlinksPaths');
+    const links = find(__dirname, []);
+
+    expect(links.length).toEqual(2);
+
+    expect(lstatSync.mock.calls[0][0]).toContain('__tests__/symlink');
+    expect(lstatSync.mock.calls[2][0]).toContain('__tests__/symlink/node_modules');
+    expect(lstatSync.mock.calls[3][0]).toContain('__tests__/symlink/node_modules/deeperLink');
+    expect(lstatSync.mock.calls[5][0]).toContain('__tests__/symlink/node_modules/deeperLink/node_modules');
+  });
+});

--- a/local-cli/util/findSymlinksPaths.js
+++ b/local-cli/util/findSymlinksPaths.js
@@ -7,36 +7,54 @@ const fs = require('fs');
  */
 module.exports = function findSymlinksPaths(lookupFolder, ignoredRoots) {
   const timeStart = Date.now();
-  const folders = fs.readdirSync(lookupFolder);
-
   const resolvedSymlinks = [];
-  folders.forEach(folder => {
-    const visited = [];
+  let n = 0;
 
-    let symlink = path.resolve(lookupFolder, folder);
-    while (fs.lstatSync(symlink).isSymbolicLink()) {
-      const index = visited.indexOf(symlink);
-      if (index !== -1) {
-        throw Error(
-          `Infinite symlink recursion detected:\n  ` +
-            visited.slice(index).join(`\n  `)
+  function findSymLinks(base) {
+    const folders = fs.readdirSync(base);
+    n += folders.length;
+
+    folders.forEach(folder => {
+      const visited = [];
+      let symlink = path.resolve(base, folder);
+
+      // Resolve symlinks from scoped modules.
+      if (path.basename(symlink).charAt(0) === '@') {
+        findSymLinks(symlink);
+      }
+
+      while (fs.lstatSync(symlink).isSymbolicLink()) {
+        const index = visited.indexOf(symlink);
+        if (index !== -1) {
+          throw Error(
+            `Infinite symlink recursion detected:\n  ` +
+              visited.slice(index).join(`\n  `)
+          );
+        }
+
+        visited.push(symlink);
+        symlink = path.resolve(
+          path.dirname(symlink),
+          fs.readlinkSync(symlink)
         );
       }
 
-      visited.push(symlink);
-      symlink = path.resolve(
-        path.dirname(symlink),
-        fs.readlinkSync(symlink)
-      );
-    }
+      if (visited.length && !rootExists(ignoredRoots, symlink)) {
+        resolvedSymlinks.push(symlink);
 
-    if (visited.length && !rootExists(ignoredRoots, symlink)) {
-      resolvedSymlinks.push(symlink);
-    }
-  });
+        // Also find symlinks from symlinked lookupFolder.
+        const modules = path.join(symlink, 'node_modules');
+        if (fs.existsSync(modules) && fs.lstatSync(modules).isDirectory()) {
+          findSymLinks(modules);
+        }
+      }
+    });
+  }
+
+  findSymLinks(lookupFolder);
 
   const timeEnd = Date.now();
-  console.log(`Scanning ${folders.length} folders for symlinks in ${lookupFolder} (${timeEnd - timeStart}ms)`);
+  console.log(`Scanning ${n} folders for symlinks in ${lookupFolder} (${timeEnd - timeStart}ms)`);
 
   return resolvedSymlinks;
 };

--- a/packager/src/node-haste/DependencyGraph/ResolutionRequest.js
+++ b/packager/src/node-haste/DependencyGraph/ResolutionRequest.js
@@ -15,6 +15,7 @@ const MapWithDefaults = require('../lib/MapWithDefaults');
 
 const debug = require('debug')('RNP:DependencyGraph');
 const util = require('util');
+const fs = require('fs');
 const path = require('path');
 const realPath = require('path');
 const invariant = require('fbjs/lib/invariant');
@@ -499,6 +500,13 @@ class ResolutionRequest<TModule: Moduleish, TPackage: Packageish> {
   }
 
   _loadAsDir(potentialDirPath: string, fromModule: TModule, toModule: string): TModule {
+    while (fs.existsSync(potentialDirPath) && fs.lstatSync(potentialDirPath).isSymbolicLink()) {
+      potentialDirPath = path.resolve(
+        path.dirname(potentialDirPath),
+        fs.readlinkSync(potentialDirPath)
+      );
+    }
+
     if (!this._dirExists(potentialDirPath)) {
       throw new UnableToResolveError(
         fromModule,


### PR DESCRIPTION
### Motivation

Improve DX by finding all symlinks in `node_modules`. Both @scoped modules and discovered `node_modules` from symlinks. No more than in RN can exist in the file structure, so allow discovering symlinks through the `root` flag.

### Improvements

tldr; symlinking through `yarn link` or `npm link` works for all modules and Watchman can be installed.  

#### Scoped modules

Symlinks were only discovered for a single level of `node_modules`, however scoped modules exist two level deeps, e.g `node_modules/@scoped/module`. If the first character of a module folder is `@` that folder is also read for possible symlinks. **tested with jest**

```
app
├── node_modules
│   ├── @scoped         // scoped, will be crawled
│   │   ├──  module     // if symlink will be added as source
│   ├── regular
├── lib
├── package.json
```

#### Recursive detection of symlinked modules

A symlinked module is likely to have `node_modules` installed. When developing highly modularized apps, another symlink in the symlinked module `node_modules` can exists. Whenever a symlink is found the `/resolved/path/to/symlink/node_modules/` will again be read for potential symlinks.  **tested with jest**

```
app
├── node_modules
│   ├── symlink         // symlink added to source and crawled 
│   ├── react-native 
├── lib
├── package.json
symlink
├── node_modules
│   ├── another         // will also be found and added to source
another
├── node_modules
│   ├── required
```

#### Configurable and crawled `root` flag for RN packager

Due to the nature of `@providesModule` no more than a single RN package can ever exist in the crawled and read file structure. RN is often a `devDependency` for modules, which works fine with regular installs. However, symlinking will often lead to multiple RN packages. 

Removing these packages each time you work/change symlinks is cumbersome. To work efficient and effective with symlinks, RN itself has to be symlinkable as well. `node_modules` are resolved relative to the [source of RN](https://github.com/facebook/react-native/blob/master/local-cli/core/default.config.js#L26). The `root` flag is a feature that could potentially solve this problem. However, currently it is ignored for the packager server, [see this change](https://github.com/facebook/react-native/pull/11810/files#diff-4a892a6b8856f0253e2de7094e585ae6L22).

Adding `root` back in with `args.projectRoots` and reading its `node_modules` allows RN to exists outside the app file structure and create symlinks from each linked module back to RN. 

```
app
├── node_modules
│   ├── symlink            // symlink added to source and crawled 
│   ├── react-native       // symlink added to source and crawled 
├── lib
├── package.json
symlink
├── node_modules
│   ├── react-native       // devDependency that can now be symlinked
react-native               // cloned from React-native repo or installed.
```

From the app itself the following two commands can now be run: 

```
react-native start -- --root .
react-native run-ios
```

Passing the `.` working directory allows the packager to pickup on the actual source.

#### Node-haste should resolve symlinks when reading a directory.

A required module from a symlinked folder/file will return the symlinked directory as part of its path, so node-haste should resolve symlinked directories before actually trying to require a file or module.

### Performance

Crawling additional directories in a complex setup with 4 (nested) symlinks and multiple `node_modules` directories being crawled barely changes startup time, e.g:

```
Scanning 1820 folders for symlinks in /projects/godaddy/module/node_modules (20ms)
```