### PR TITLE
Fix `runAndroid` command

### DIFF
--- a/docs/SignedAPKAndroid.md
+++ b/docs/SignedAPKAndroid.md
@@ -79,6 +79,7 @@ Simply run the following in a terminal:
 ```sh
 $ cd android && ./gradlew assembleRelease
 ```
+> If you prefer, you can run `react-native run-android --configuration=release` to generate the **release** `apk` and install it onto the connected `android` device.
 
 Gradle's `assembleRelease` will bundle all the JavaScript needed to run your app into the APK. If you need to change the way the JavaScript bundle and/or drawable resources are bundled (e.g. if you changed the default file/folder names or the general structure of the project), have a look at `android/app/build.gradle` to see how you can update it to reflect these changes.
 


### PR DESCRIPTION
The `runAndroid` command in the version 0.41 of the React Native has several issues. This PR fixes them.

With 0.41 the `--configuration` flag was removed from the `runAndroid` command. It was removed probably due to a bad rebase [here](https://github.com/facebook/react-native/commit/85c8333bc87d27a7f5f31a74d62c3d0b3ad631f9). More information can be found in this [PR](https://github.com/facebook/react-native/pull/11443).

Specifying the device id, with the flag `--deviceId` also bypass all the other configurations. For instance, if a `flavor/variant` is specified with the flags `--flavor` or `--variant` and a `device id` is also included with the flag `--deviceId` the `flavor/variant` is completely ignored. 

I also included minor tweaks like always assemble the `apk`and only install it in a separated step.

With this PR, a command like `react-native run-android --configuration release` will generate an android `apk` with the release configuration, like in the version `0.40` of React Native.