### PR TITLE
Fix react-native-git-upgrade cache busting

### DIFF
--- a/react-native-git-upgrade/cliEntry.js
+++ b/react-native-git-upgrade/cliEntry.js
@@ -160,7 +160,7 @@ function runCopyAndReplace(generatorDir, appName) {
    * This file could have changed between these 2 versions. When generating the new template,
    * we don't want to load the old version of the generator from the cache
    */
-  delete require.cache[copyProjectTemplateAndReplacePath];
+  delete require.cache[require.resolve(copyProjectTemplateAndReplacePath)];
   const copyProjectTemplateAndReplace = require(copyProjectTemplateAndReplacePath);
   copyProjectTemplateAndReplace(
     path.resolve(generatorDir, '..', 'templates', 'HelloWorld'),

--- a/react-native-git-upgrade/package.json
+++ b/react-native-git-upgrade/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-git-upgrade",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "license": "BSD-3-Clause",
   "description": "The React Native upgrade tool",
   "main": "cli.js",


### PR DESCRIPTION
**Motivation** 

This PR fixes #12420. 

For the first time, the version 0.41.2 includes a change in the generator (see #12162). The [require cache busting](https://github.com/facebook/react-native/blob/master/react-native-git-upgrade/cliEntry.js#L157-L163) of `react-native-git-upgrade`, designed to face this situation , was ineffective. 

The entry in `require.cache` is the file path including the `.js` extension. We have to delete this entry with the same key.

**Test plan**

- Publish `react-native-git-upgrade` to Sinopia,
- Follow the reproduction steps of #12420 
- 👉 The name of the app shouldn't be changed
