### PR TITLE
Cast name to String to ensure .match is available

### DIFF
--- a/react-native-cli/index.js
+++ b/react-native-cli/index.js
@@ -167,7 +167,7 @@ if (cli) {
 }
 
 function validateProjectName(name) {
-  if (!name.match(/^[$A-Z_][0-9A-Z_$]*$/i)) {
+  if (!String(name).match(/^[$A-Z_][0-9A-Z_$]*$/i)) {
     console.error(
       '"%s" is not a valid name for a project. Please use a valid identifier ' +
         'name (alphanumeric).',


### PR DESCRIPTION
PR for issue #12444 

In `validateProjectName` in `react-native-cli` `name.match` is called but it's not certain that `name`is a String. This casts `name`to a String before doing the match.

I didn't find any tests for this file so I didn't add any.

Reproduce:
```
cd react-native-cli
npm install
node index.js init 123
```

Before this PR the code throws an exception, after this PR the intended `console.error` is printed.