### PR TITLE
Fix the website build

### DIFF
--- a/Libraries/AppState/AppState.js
+++ b/Libraries/AppState/AppState.js
@@ -26,9 +26,6 @@ const invariant = require('fbjs/lib/invariant');
  * AppState is frequently used to determine the intent and proper behavior when
  * handling push notifications.
  *
- * This module depends on the native RCTAppState module. If you don't include it,
- * `AppState.isAvailable` will return `false`, and any method calls will throw.
- *
  * ### App States
  *
  *  - `active` - The app is running in the foreground
@@ -90,11 +87,12 @@ class AppState extends NativeEventEmitter {
 
   _eventHandlers: Object;
   currentState: ?string;
-  isAvailable: boolean = true;
+  isAvailable: boolean;
 
   constructor() {
     super(RCTAppState);
 
+    this.isAvailable = true;
     this._eventHandlers = {
       change: new Map(),
       memoryWarning: new Map(),
@@ -213,10 +211,13 @@ class MissingNativeAppStateShim extends EventEmitter {
   }
 }
 
-// Guard against missing native module by throwing on first method call.
-// Keep the API the same so Flow doesn't complain.
-const appState = RCTAppState
-  ? new AppState()
-  : new MissingNativeAppStateShim();
+// This module depends on the native `RCTAppState` module. If you don't include it,
+// `AppState.isAvailable` will return `false`, and any method calls will throw.
+// We reassign the class variable to keep the autodoc generator happy.
+if (RCTAppState) {
+  AppState = new AppState();
+} else {
+  AppState = new MissingNativeAppStateShim();
+}
 
-module.exports = appState;
+module.exports = AppState;


### PR DESCRIPTION
118e88393e389ff70e30ada10a69b72dd31d869a broke autodoc generation because autodoc isn't smart enough to understand some patterns.

I'm working around it by using the same trick as this file was using previously: reassigning the class variable.

Similarly, using a property initializer produces bad output so I had to remove it:

<img width="146" alt="screen shot 2017-02-20 at 19 00 36" src="https://cloud.githubusercontent.com/assets/810438/23138561/09ebb476-f7a0-11e6-8fad-92c5a01503c3.png">

cc @ericnakagawa @mkonicek for review