### PR TITLE
Ignore "Frame load interrupted" errors in UIWebView

### DIFF
--- a/React/Views/RCTWebView.m
+++ b/React/Views/RCTWebView.m
@@ -267,6 +267,14 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
       return;
     }
 
+    if ([error.domain isEqualToString:@"WebKitErrorDomain"] && error.code == 102) {
+      // Error code 102 "Frame load interrupted" is raised by the UIWebView if
+      // its delegate returns FALSE from webView:shouldStartLoadWithRequest:navigationType
+      // when the URL is from an http redirect. This is a common pattern when
+      // implementing OAuth with a WebView.
+      return;
+    }
+
     NSMutableDictionary<NSString *, id> *event = [self baseEvent];
     [event addEntriesFromDictionary:@{
       @"domain": error.domain,


### PR DESCRIPTION
Am writing an OAuth flow using `WebView`, when the OAuth provider redirects back to the [redirect_uri](https://developers.facebook.com/docs/facebook-login/manually-build-a-login-flow#logindialog) I intercept the request using `onShouldStartLoadWithRequest`, get the access token from the url and close the `WebView`.

The problem I see is that when the OAuth provider redirects to the `redirect_uri` and I intercept it by returning false from `onShouldStartLoadWithRequest`, I get a WebKitErrorDomain error code 102 ("Frame load interrupted").

Looking at some other iOS libraries that implement OAuth with a WebView - it seems that the error can be ignored. eg.

https://github.com/facebook/facebook-ios-sdk/blob/master/FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/FBSDKWebDialogView.m#L146

https://github.com/evernote/evernote-sdk-ios/blob/master/evernote-sdk-ios/internal/ENOAuthViewController.m#L147

You can recreate the error using a url that automatically redirects, eg http://www.facebook.com -> https://www.facebook.com

```js
<WebView
  source={{ uri: 'http://www.facebook.com' }}
  onShouldStartLoadWithRequest={(event) => {
    if (event.url.startsWith('https://www.facebook.com')) {
      return false;
    }
    return true;
  }}
/>
```
