### PR TITLE
[Webview]: set mediaPlaybackRequiresUserAction as true by default (io…

### DIFF
--- a/Libraries/Components/WebView/WebView.android.js
+++ b/Libraries/Components/WebView/WebView.android.js
@@ -149,7 +149,7 @@ class WebView extends React.Component {
 
     /**
      * Determines whether HTML5 audio & videos require the user to tap before they can
-     * start playing. The default value is `false`.
+     * start playing. The default value is `true`.
      */
     mediaPlaybackRequiresUserAction: PropTypes.bool,
 
@@ -165,6 +165,7 @@ class WebView extends React.Component {
   static defaultProps = {
     javaScriptEnabled : true,
     scalesPageToFit: true,
+    mediaPlaybackRequiresUserAction: true,
   };
 
   state = {

--- a/Libraries/Components/WebView/WebView.ios.js
+++ b/Libraries/Components/WebView/WebView.ios.js
@@ -336,6 +336,10 @@ class WebView extends React.Component {
     mediaPlaybackRequiresUserAction: PropTypes.bool,
   };
 
+  static defaultProps = {
+    mediaPlaybackRequiresUserAction: true,
+  };
+
   state = {
     viewState: WebViewState.IDLE,
     lastErrorEvent: (null: ?ErrorEvent),


### PR DESCRIPTION
In documentation, the default value of mediaPlaybackRequiresUserAction is true. But in reality, on ios and android, this value is false.
So to fix it, i update default value for android webview and define default props for ios with mediaPlaybackRequiresUserAction to true.