### PR TITLE
Remote debugging: fallback to other ethernet interfaces if the first one has no IP

### DIFF
--- a/packager/react-native-xcode.sh
+++ b/packager/react-native-xcode.sh
@@ -74,7 +74,7 @@ DEST=$CONFIGURATION_BUILD_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH
 if [[ "$CONFIGURATION" = "Debug" && ! "$PLATFORM_NAME" == *simulator ]]; then
   PLISTBUDDY='/usr/libexec/PlistBuddy'
   PLIST=$TARGET_BUILD_DIR/$INFOPLIST_PATH
-  IP=$(ipconfig getifaddr en0)
+  IP=$(ipconfig getifaddr en0 || ipconfig getifaddr en1 || ipconfig getifaddr en2)
   if [ -z "$IP" ]; then
     IP=$(ifconfig | grep 'inet ' | grep -v 127.0.0.1 | cut -d\   -f2  | awk 'NR==1{print $1}')
   fi


### PR DESCRIPTION
On some systems, debugging from the device fails because the IP cannot be guessed.

One reason for this is that RNs IP guessing in `react-native-xcode.sh` currently only checks the first network interface, and does not fall back to other interfaces when it cannot find an assigned IP on the first one. In our case, we sometimes use Macs which are connected via wifi (`en1`) but not via a wired connection (default `en0`). This causes on-device remote debugging to fail as it attempts to fall back to `localhost`, where it cannot find the debugger bundle.

This PR fixes this little issue by automatically falling back from `en0` to `en1` or `en2` if the first ones do not yield an IP.

Tested on a multi interface Mac as well as devices with only a single ethernet interface -- no issues.
