### PR TITLE
Fixes type definition of StackFrame

### DIFF
--- a/Libraries/Core/Devtools/parseErrorStack.js
+++ b/Libraries/Core/Devtools/parseErrorStack.js
@@ -12,9 +12,10 @@
 'use strict';
 
 export type StackFrame = {
+  column: ?number,
   file: string,
   lineNumber: number,
-  column: number,
+  methodName: string,
 };
 
 var stacktraceParser = require('stacktrace-parser');

--- a/Libraries/Core/Timers/JSTimers.js
+++ b/Libraries/Core/Timers/JSTimers.js
@@ -40,8 +40,6 @@ function _allocateCallback(func: Function, type: JSTimerType): number {
     e.framesToPop = 1;
     const stack = parseErrorStack(e);
     if (stack) {
-      /* $FlowFixMe(>=0.32.0) - this seems to be putting something of the wrong
-       * type into identifiers */
       JSTimersExecution.identifiers[freeIndex] = stack.shift();
     }
   }


### PR DESCRIPTION
**Motivation**
This PR fixes the flow type definition of StackFrame in parseErrorStack.js. The methodName was missing and the column could be `null`. We integrate with it in our codebase and we wanted to use `methodName`, but flow complained.

Refer to this file for possible values: [github.com/errwischt/stacktrace-parser/blob/master/lib/stacktrace-parser.js](https://github.com/errwischt/stacktrace-parser/blob/master/lib/stacktrace-parser.js)

This also allowed me to remove a flow error suppression. 

**Test plan (required)**
I ran flow on the project, no errors