### PR TITLE
[Android] Add TextLayoutBuilder proguard rule

### DIFF
--- a/local-cli/templates/HelloWorld/android/app/proguard-rules.pro
+++ b/local-cli/templates/HelloWorld/android/app/proguard-rules.pro
@@ -50,6 +50,10 @@
 
 -dontwarn com.facebook.react.**
 
+# TextLayoutBuilder uses a non-public Android constructor within StaticLayout.
+# See libs/proxy/src/main/java/com/facebook/fbui/textlayoutbuilder/proxy for details.
+-dontwarn android.text.StaticLayout
+
 # okhttp
 
 -keepattributes Signature


### PR DESCRIPTION
### Motivation
To enable users to use run proguard in their Android applications.

Fixes: #11891 

### The fix
[TextLayoutBuilder](https://github.com/facebookincubator/TextLayoutBuilder) is built as a Jar rather than an AAR so the proguard rules cannot be provided with the binary.

This PR adds the rules that are included in TextLayoutBuilder https://github.com/facebookincubator/TextLayoutBuilder/blob/master/proguard-android.txt

### Test plan

- Created an `react-native init ProguardTest` project with proguard turned on for v0.41.0
- Make sure tests pass on both Travis and Circle CI.