### PR TITLE
Documented CameraRoll.getPhotos() param and return values

### DIFF
--- a/Libraries/CameraRoll/CameraRoll.js
+++ b/Libraries/CameraRoll/CameraRoll.js
@@ -169,9 +169,47 @@ class CameraRoll {
    * Returns a Promise with photo identifier objects from the local camera
    * roll of the device matching shape defined by `getPhotosReturnChecker`.
    *
-   * @param {object} params See `getPhotosParamChecker`.
+   * Expects a params object of the following shape:
    *
-   * Returns a Promise which when resolved will be of shape `getPhotosReturnChecker`.
+   * - `first` : {number} : The number of photos wanted in reverse order of the photo application (i.e. most recent first for SavedPhotos).
+   * - `after` : {string} : A cursor that matches `page_info { end_cursor }` returned from a previous call to `getPhotos`.
+   * - `groupTypes` : {string} : Specifies which group types to filter the results to. Valid values are:
+   *      - `Album`
+   *      - `All`
+   *      - `Event`
+   *      - `Faces`
+   *      - `Library`
+   *      - `PhotoStream`
+   *      - `SavedPhotos` // default
+   * - `groupName` : {string} : Specifies filter on group names, like 'Recent Photos' or custom album titles.
+   * - `assetType` : {string} : Specifies filter on asset type. Valid values are:
+   *      - `All`
+   *      - `Videos`
+   *      - `Photos` // default
+   * - `mimeTypes` : {string} : Filter by mimetype (e.g. image/jpeg).
+   *
+   * Returns a Promise which when resolved will be of the following shape:
+   *
+   * - `edges` : {Array<node>} An array of node objects
+   *      - `node`: {object} An object with the following shape:
+   *          - `type`: {string}
+   *          - `group_name`: {string}
+   *          - `image`: {object} : An object with the following shape:
+   *              - `uri`: {string}
+   *              - `height`: {number}
+   *              - `width`: {number}
+   *              - `isStored`: {boolean}
+   *          - `timestamp`: {number}
+   *          - `location`: {object} : An object with the following shape:
+   *              - `latitude`: {number}
+   *              - `longitude`: {number}
+   *              - `altitude`: {number}
+   *              - `heading`: {number}
+   *              - `speed`: {number}
+   * - `page_info` : {object} : An object with the following shape:
+   *      - `has_next_page`: {boolean}
+   *      - `start_cursor`: {boolean}
+   *      - `end_cursor`: {boolean}
    */
   static getPhotos(params) {
     if (__DEV__) {


### PR DESCRIPTION
**Motivation**:

The `CameraRoll.getPhotos()` documentation is lacking, I've simply exposed the shapes of the params object and returned object, as defined and documented in `getPhotosParamChecker` and `getPhotosReturnChecker`.

**Test plan**:

Built the website and checked the documentation.