### PR TITLE
Packager - Fix absolute imports on Windows

### DIFF
--- a/packager/src/node-haste/DependencyGraph/ResolutionRequest.js
+++ b/packager/src/node-haste/DependencyGraph/ResolutionRequest.js
@@ -278,7 +278,7 @@ class ResolutionRequest {
 
   _resolveFileOrDir(fromModule, toModuleName) {
     const potentialModulePath = isAbsolutePath(toModuleName) ?
-        normalizeWindowsPath(toModuleName) :
+        resolveWindowsPath(toModuleName) :
         path.join(path.dirname(fromModule.path), toModuleName);
 
     return this._redirectRequire(fromModule, potentialModulePath).then(
@@ -510,12 +510,13 @@ function normalizePath(modulePath) {
 }
 
 // HasteFS stores paths with backslashes on Windows, this ensures the path is
-// in the proper format. Noop on other platforms.
-function normalizeWindowsPath(modulePath) {
+// in the proper format. Will also add drive letter if not present so `/root` will
+// resolve to `C:\root`. Noop on other platforms.
+function resolveWindowsPath(modulePath) {
   if (path.sep !== '\\') {
     return modulePath;
   }
-  return modulePath.replace(/\//g, '\\');
+  return path.resolve(modulePath);
 }
 
 function resolveKeyWithPromise([key, promise]) {

--- a/packager/src/node-haste/DependencyGraph/ResolutionRequest.js
+++ b/packager/src/node-haste/DependencyGraph/ResolutionRequest.js
@@ -278,7 +278,7 @@ class ResolutionRequest {
 
   _resolveFileOrDir(fromModule, toModuleName) {
     const potentialModulePath = isAbsolutePath(toModuleName) ?
-        toModuleName :
+        normalizeWindowsPath(toModuleName) :
         path.join(path.dirname(fromModule.path), toModuleName);
 
     return this._redirectRequire(fromModule, potentialModulePath).then(
@@ -507,6 +507,15 @@ function normalizePath(modulePath) {
   }
 
   return modulePath.replace(/\/$/, '');
+}
+
+// HasteFS stores paths with backslashes on Windows, this ensures the path is
+// in the proper format. Noop on other platforms.
+function normalizeWindowsPath(modulePath) {
+  if (path.sep !== '\\') {
+    return modulePath;
+  }
+  return modulePath.replace(/\//g, '\\');
 }
 
 function resolveKeyWithPromise([key, promise]) {

--- a/packager/src/node-haste/__tests__/DependencyGraph-test.js
+++ b/packager/src/node-haste/__tests__/DependencyGraph-test.js
@@ -2533,7 +2533,7 @@ describe('DependencyGraph', function() {
       const root = 'C:\\root';
       setMockFileSystem({
         'root': {
-          'index.js': 'require("/root/apple.js");',
+          'index.js': 'require("C:/root/apple.js");',
           'apple.js': '',
         },
       });
@@ -2546,16 +2546,16 @@ describe('DependencyGraph', function() {
         expect(deps)
           .toEqual([
             {
-              id: '/root/index.js',
+              id: 'C:\\root\\index.js',
               path: 'C:\\root\\index.js',
-              dependencies: ['C:\\root\\apple.js'],
+              dependencies: ['C:/root/apple.js'],
               isAsset: false,
               isJSON: false,
               isPolyfill: false,
               resolution: undefined,
             },
             {
-              id: '/root/apple.js',
+              id: 'C:\\root\\apple.js',
               path: 'C:\\root\\apple.js',
               dependencies: [],
               isAsset: false,

--- a/packager/src/node-haste/__tests__/DependencyGraph-test.js
+++ b/packager/src/node-haste/__tests__/DependencyGraph-test.js
@@ -2533,7 +2533,7 @@ describe('DependencyGraph', function() {
       const root = 'C:\\root';
       setMockFileSystem({
         'root': {
-          'index.js': 'require("C:\\\\root\\\\apple.js");',
+          'index.js': 'require("/root/apple.js");',
           'apple.js': '',
         },
       });
@@ -2546,7 +2546,7 @@ describe('DependencyGraph', function() {
         expect(deps)
           .toEqual([
             {
-              id: 'C:\\root\\index.js',
+              id: '/root/index.js',
               path: 'C:\\root\\index.js',
               dependencies: ['C:\\root\\apple.js'],
               isAsset: false,
@@ -2555,7 +2555,7 @@ describe('DependencyGraph', function() {
               resolution: undefined,
             },
             {
-              id: 'C:\\root\\apple.js',
+              id: '/root/apple.js',
               path: 'C:\\root\\apple.js',
               dependencies: [],
               isAsset: false,


### PR DESCRIPTION
Absolute imports on Windows were broken, I'm not 100% sure when this happens but when I tested Exponent on Windows which uses `rn-cli.config.js` with
```js
getTransformOptions() {
    return {
      reactNativePath: path.resolve('./node_modules/react-native'),
      reactPath: path.resolve('./node_modules/react'),
    };
  }
```
it seemed to use absolute paths for these modules.

I also tested absolute paths in node repl and it does work for absolute paths of different formats. `C:/root/test.js`, `/root/test.js`, `C:\root\test.js` all do resolve properly to the same module.

To fix this I resolve the absolute path using `path.resolve` on Windows. Noop on other platforms to avoid the overhead since it's not necessary.

**Test plan**
- Tested that it fixed the bug I had when running Exponent on Windows.
- Updated the absolute path test to use forward slashes since this is what happens in practice when using `getTransformOptions`. We can't test all cases on linux since adding the drive letter automatically doesn't work.