### PR TITLE
CLI: Add support for templates fetched from npm

### DIFF
--- a/local-cli/generator/copyProjectTemplateAndReplace.js
+++ b/local-cli/generator/copyProjectTemplateAndReplace.js
@@ -21,6 +21,12 @@ const walk = require('../util/walk');
  * @param srcPath e.g. '/Users/martin/AwesomeApp/node_modules/react-native/local-cli/templates/HelloWorld'
  * @param destPath e.g. '/Users/martin/AwesomeApp'
  * @param newProjectName e.g. 'AwesomeApp'
+ * @param options e.g. {
+ *          upgrade: true,
+ *          force: false,
+ *          displayName: 'Hello World',
+ *          ignorePaths: ['template/file/to/ignore.md'],
+ *        }
  */
 function copyProjectTemplateAndReplace(srcPath, destPath, newProjectName, options) {
   if (!srcPath) { throw new Error('Need a path to copy from'); }
@@ -44,6 +50,20 @@ function copyProjectTemplateAndReplace(srcPath, destPath, newProjectName, option
     const relativeRenamedPath = dotFilePath(relativeFilePath)
       .replace(/HelloWorld/g, newProjectName)
       .replace(/helloworld/g, newProjectName.toLowerCase());
+
+    // Templates may contain files that we don't want to copy.
+    // Examples:
+    // - Dummy package.json file included in the template only for publishing to npm
+    // - Docs specific to the template (.md files)
+    if (options.ignorePaths) {
+      if (!Array.isArray(options.ignorePaths)) {
+        throw new Error('options.ignorePaths must be an array');
+      }
+      if (options.ignorePaths.some(ignorePath => ignorePath === relativeFilePath)) {
+        // Skip copying this file
+        return;
+      }
+    }
 
     let contentChangedCallback = null;
     if (options.upgrade && (!options.force)) {

--- a/local-cli/generator/templates.js
+++ b/local-cli/generator/templates.js
@@ -13,7 +13,11 @@ const execSync = require('child_process').execSync;
 const fs = require('fs');
 const path = require('path');
 
-const availableTemplates = {
+/**
+ * Templates released as part of react-native in local-cli/templates.
+ * It's also possible to use templates from npm.
+ */
+const builtInTemplates = {
   navigation: 'HelloNavigation',
 };
 
@@ -22,9 +26,9 @@ function listTemplatesAndExit(newProjectName, options) {
     // Just listing templates using 'react-native init --template'.
     // Not creating a new app.
     // Print available templates and exit.
-    const templateKeys = Object.keys(availableTemplates);
+    const templateKeys = Object.keys(builtInTemplates);
     if (templateKeys.length === 0) {
-      // Just a guard, should never happen as long availableTemplates
+      // Just a guard, should never happen as long builtInTemplates
       // above is defined correctly :)
       console.log(
         'There are no templates available besides ' +
@@ -73,27 +77,85 @@ function createProjectFromTemplate(destPath, newProjectName, templateKey, yarnVe
   // This way we don't have to duplicate the native files in every template.
   // If we duplicated them we'd make RN larger and risk that people would
   // forget to maintain all the copies so they would go out of sync.
-  const templateName = availableTemplates[templateKey];
-  if (templateName) {
-    copyProjectTemplateAndReplace(
-      path.resolve(
-        'node_modules', 'react-native', 'local-cli', 'templates', templateName
-      ),
-      destPath,
-      newProjectName
-    );
+  const builtInTemplateName = builtInTemplates[templateKey];
+  if (builtInTemplateName) {
+    // templateKey is e.g. 'navigation',
+    // use the built-in local-cli/templates/HelloNavigation folder
+    createFromBuiltInTemplate(builtInTemplateName, destPath, newProjectName, yarnVersion);
   } else {
-    throw new Error('Uknown template: ' + templateKey);
+    // templateKey is e.g. 'ignite',
+    // use the template react-native-template-ignite from npm
+    createFromNpmTemplate(templateKey, destPath, newProjectName, yarnVersion);
   }
-
-  installTemplateDependencies(templateName, yarnVersion);
 }
 
-function installTemplateDependencies(templateName, yarnVersion) {
+// (We might want to get rid of built-in templates in the future -
+// publish them to npm and install from there.)
+function createFromBuiltInTemplate(templateName, destPath, newProjectName, yarnVersion) {
+  const templatePath = path.resolve(
+    'node_modules', 'react-native', 'local-cli', 'templates', templateName
+  );
+  copyProjectTemplateAndReplace(
+    templatePath,
+    destPath,
+    newProjectName,
+  );
+  installTemplateDependencies(templatePath, yarnVersion);
+}
+
+function createFromNpmTemplate(templateName, destPath, newProjectName, yarnVersion) {
+  const packageName = 'react-native-template-' + templateName;
+  // Check if the template exists
+  console.log(`Fetching template ${packageName} from npm...`);
+  try {
+    if (yarnVersion) {
+      execSync(`yarn info ${packageName}`);
+    } else {
+      execSync(`npm info ${packageName}`);
+    }
+  } catch (err) {
+    throw new Error(`The template ${packageName} was not found on npm:\n` + err.message);
+  }
+  const templatePath = path.resolve(
+    'node_modules', packageName
+  );
+  try {
+    if (yarnVersion) {
+      execSync(`yarn add ${packageName} --ignore-scripts`, {stdio: 'inherit'});
+    } else {
+      execSync(`npm install ${packageName} --save --save-exact --ignore-scripts`, {stdio: 'inherit'});
+    }
+    // TODO debug this, package.json is getting overwritten
+    console.log('====== installed template in ' + templatePath);
+    console.log('====== copyProjectTemplateAndReplace ', { templatePath, destPath, newProjectName });
+    copyProjectTemplateAndReplace(
+      templatePath,
+      destPath,
+      newProjectName,
+    );
+  } finally {
+    // Clean up the temp files
+    try {
+      if (yarnVersion) {
+        execSync(`yarn remove ${packageName} --ignore-scripts`);
+      } else {
+        execSync(`npm uninstall ${packageName} --ignore-scripts`);
+      }
+    } catch (err) {
+      console.warn(
+        `Failed to clean up template temp files in node_modules/${packageName}. ` +
+        'This is not a critical error, you can work on your app.'
+      );
+    }
+  }
+  installTemplateDependencies(templatePath, yarnVersion);
+}
+
+function installTemplateDependencies(templatePath, yarnVersion) {
   // dependencies.json is a special file that lists additional dependencies
   // that are required by this template
   const dependenciesJsonPath = path.resolve(
-    'node_modules', 'react-native', 'local-cli', 'templates', templateName, 'dependencies.json'
+    templatePath, 'dependencies.json'
   );
   if (!fs.existsSync(dependenciesJsonPath)) {
     return;

--- a/local-cli/generator/templates.js
+++ b/local-cli/generator/templates.js
@@ -91,7 +91,14 @@ function createProjectFromTemplate(destPath, newProjectName, templateKey, yarnVe
     );
     if (fs.existsSync(dependenciesJsonPath)) {
       console.log('Adding dependencies for the project...');
-      const dependencies = JSON.parse(fs.readFileSync(dependenciesJsonPath));
+      let dependencies;
+      try {
+        dependencies = JSON.parse(fs.readFileSync(dependenciesJsonPath));
+      } catch (err) {
+        throw new Error(
+          'Could not parse the template\'s dependencies.json: ' + err.message
+        );
+      }
       for (let depName in dependencies) {
         const depVersion = dependencies[depName];
         const depToInstall = depName + '@' + depVersion;

--- a/local-cli/link/link.js
+++ b/local-cli/link/link.js
@@ -5,6 +5,8 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
  */
 
 const log = require('npmlog');
@@ -28,6 +30,8 @@ const getDependencyConfig = require('./getDependencyConfig');
 const pollParams = require('./pollParams');
 const commandStub = require('./commandStub');
 const promisify = require('./promisify');
+
+import type {ConfigT} from '../core';
 
 log.heading = 'rnpm-link';
 
@@ -125,18 +129,20 @@ const linkAssets = (project, assets) => {
 };
 
 /**
- * Updates project and links all dependencies to it
+ * Updates project and links all dependencies to it.
  *
- * If optional argument [packageName] is provided, it's the only one that's checked
+ * @param args If optional argument [packageName] is provided,
+ *             only that package is processed.
+ * @param config CLI config, see local-cli/core/index.js
  */
-function link(args, config) {
+function link(args: Array<string>, config: ConfigT) {
   var project;
   try {
     project = config.getProjectConfig();
   } catch (err) {
     log.error(
       'ERRPACKAGEJSON',
-      'No package found. Are you sure it\'s a React Native project?'
+      'No package found. Are you sure this is a React Native project?'
     );
     return Promise.reject(err);
   }
@@ -169,8 +175,8 @@ function link(args, config) {
 
   return promiseWaterfall(tasks).catch(err => {
     log.error(
-      `It seems something went wrong while linking. Error: ${err.message} \n`
-      + 'Please file an issue here: https://github.com/facebook/react-native/issues'
+      `Something went wrong while linking. Error: ${err.message} \n` +
+      'Please file an issue here: https://github.com/facebook/react-native/issues'
     );
     throw err;
   });
@@ -178,6 +184,6 @@ function link(args, config) {
 
 module.exports = {
   func: link,
-  description: 'links all native dependencies',
+  description: 'links all native dependencies (updates native build files)',
   name: 'link [packageName]',
 };

--- a/local-cli/templates/HelloNavigation/dependencies.json
+++ b/local-cli/templates/HelloNavigation/dependencies.json
@@ -1,4 +1,3 @@
 {
-  "react-navigation": "1.0.0-beta.5",
-  "react-native-vector-icons": "4.0.0"
+  "react-navigation": "1.0.0-beta.5"
 }

--- a/local-cli/templates/HelloNavigation/dependencies.json
+++ b/local-cli/templates/HelloNavigation/dependencies.json
@@ -1,3 +1,4 @@
 {
-  "react-navigation": "1.0.0-beta.5"
+  "react-navigation": "1.0.0-beta.5",
+  "react-native-vector-icons": "4.0.0"
 }


### PR DESCRIPTION
This PR allows anyone to publish templates for React Native.

It's possible for people to publish modules for React Native, we should also support custom templates. A suggestion from a Cordova mantainer where they did the same thing suggests this is useful:
https://github.com/mkonicek/AppTemplateFeedback/issues/1

## How it works

I published a sample template [react-native-template-demo](https://www.npmjs.com/package/react-native-template-demo).

(GitHub: https://github.com/mkonicek/react-native-template-demo)

With this PR anyone can then use that template:

`react-native init MyApp --template demo`

The convention is: if someone publishes an npm package called `react-native-template-foo`, people can use it by running `react-native init MyApp --template foo`.

## What's supported

Use a template called `react-native-template-demo` from npm:

`react-native init MyApp --template demo`

Use a local template:

`react-native init MyApp --template file:///path_to/react-native-template-demo`

Use a template from a https:// or git:// URL:

`react-native init MyApp --template git://.../react-native-template-demo`

## Test plan

Published the stock 'navigation' template to npm under the name 'demo':
https://www.npmjs.com/package/react-native-template-demo

Also added a native dependency (react-native-vector-icons) to the template to test that linking native dependencies works.

Generated app works:

```
react-native init MyApp --template demo
```

- MyApp/package.json contains all the dependencies of the template (react-navigation, react-native-vector-icons)
- Xcode and Gradle build files of MyApp contain react-native-vector-icons

![screenshot 2017-02-23 13 27 03](https://cloud.githubusercontent.com/assets/346214/23265736/80e38c18-f9dd-11e6-8593-11ffdb33359f.png)

![screenshot 2017-02-23 13 36 47](https://cloud.githubusercontent.com/assets/346214/23265744/879c941e-f9dd-11e6-83f5-82937b9f41ab.png)

---

Checked that existing workflows still work:

Built-in template (local-cli/templates/HelloNavigation):

```
react-native init MyApp --template navigation
```

The app works (screenshots are the same as above).

---

Checked that existing workflows still work:

No template:

```
react-native init MyApp
```

![screenshot 2017-02-23 14 13 43](https://cloud.githubusercontent.com/assets/346214/23265808/bfd0fe60-f9dd-11e6-8ee0-6648ee58466d.png)

![screenshot 2017-02-23 14 11 55](https://cloud.githubusercontent.com/assets/346214/23265813/c4bcbc0c-f9dd-11e6-9134-81583f2f154e.png)
