### PR TITLE
Include syntax-class-properties in packager

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,6 +127,7 @@
     "babel-core": "^6.21.0",
     "babel-generator": "^6.21.0",
     "babel-plugin-external-helpers": "^6.18.0",
+    "babel-plugin-syntax-class-properties": "^6.5.0",
     "babel-plugin-syntax-trailing-function-commas": "^6.20.0",
     "babel-plugin-transform-async-to-generator": "6.16.0",
     "babel-plugin-transform-flow-strip-types": "^6.21.0",

--- a/packager/babelRegisterOnly.js
+++ b/packager/babelRegisterOnly.js
@@ -25,6 +25,7 @@ function config(onlyList) {
     plugins: [
       'transform-flow-strip-types',
       'syntax-trailing-function-commas',
+      'syntax-class-properties',
       'transform-object-rest-spread',
       'transform-async-to-generator',
     ],


### PR DESCRIPTION
Babylon 6.16.0 fixed a problem that it was parsing class properties although the corresponding plugin was not enabled. This leas to react-native breaking with the new version of babylon as class-properties are use in [node-haste](https://github.com/facebook/react-native/blob/master/packager/src/node-haste/index.js#L323), but the plugin is not enabled in react-native.

We for the time being reverted some changes and released 6.16.1, but going to reenable them at some point.

I'm not 100% sure if it is the correct package.json file I changed, let me know if not. It would also be included due to `babel-preset-react-native`, but maybe better be explicit.

Fixes #12542 and #12545 if released as bugfix release for the latest version.


