### PR TITLE
Don't use 'vertically' when describing a ListView

### DIFF
--- a/docs/UsingAListView.md
+++ b/docs/UsingAListView.md
@@ -8,7 +8,7 @@ next: network
 previous: using-a-scrollview
 ---
 
-The `ListView` component displays a vertically scrolling list of changing, but similarly structured, data.
+The `ListView` component displays a scrolling list of changing, but similarly structured, data.
 
 `ListView` works well for long lists of data, where the number of items might change over time. Unlike the more generic [`ScrollView`](docs/using-a-scrollview.html), the `ListView` only renders elements that are currently showing on the screen, not all the elements at once.
 


### PR DESCRIPTION
it gives the wrong impression that a ListView has the restriction to only align the items vertically

The problem the PR addresses is that the documentation currently gives the initial impression that a ListView can only stack the items vertically.


