### PR TITLE
Update TextInput placeholder to PropTypes.string

### DIFF
--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -398,7 +398,7 @@ const TextInput = React.createClass({
     /**
      * The string that will be rendered before text input has been entered.
      */
-    placeholder: PropTypes.node,
+    placeholder: PropTypes.string,
     /**
      * The text color of the placeholder string.
      */


### PR DESCRIPTION
Updates TextInput to take a string for placeholder instead of a node in the PropTypes validation.  Currently, TextInput docs indicate it can take a node, but attempts to actually pass in a Text node rather than a simple String result in an error being thrown.  When digging into the actual ios and android code backing the component, placeholder is a string in both cases.

For further detail about the problem being fixed by this, including screenshots and sample code, see https://github.com/facebook/react-native/issues/12525

**Test plan (required)**

As this code is only updating a PropType on TextInput, it is sufficient to see that a TextInput being passed a node for placeholder will fail prop type validation.  One which is passed a string for placeholder will continue to behave as normal.
