### PR TITLE
Clarify access scope for publicly visible access token

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -49,7 +49,7 @@ test:
     - source scripts/circle-ci-android-setup.sh && waitForAVD
 
   override:
-    # eslint bot
+    # eslint bot. This GitHub token grants public_repo access scope.
     - cat <(echo eslint; npm run lint --silent -- --format=json; echo flow; npm run flow --silent -- check --json) | GITHUB_TOKEN="af6ef0d15709bc91d""06a6217a5a826a226fb57b7" CI_USER=$CIRCLE_PROJECT_USERNAME CI_REPO=$CIRCLE_PROJECT_REPONAME PULL_REQUEST_NUMBER=$CIRCLE_PR_NUMBER node bots/code-analysis-bot.js
     # JS tests for dependencies installed with npm3
     - npm run flow -- check


### PR DESCRIPTION
This token is restricted to public_repo access rights and it's alright to store in the open:

```
$ curl https://api.github.com/user?access_token={...}
X-OAuth-Scopes: public_repo
```