### PR TITLE
Docs: Fixed Getting Started, Missing step.

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -358,11 +358,17 @@ react-native run-android
 
 ## Testing your React Native Installation
 
-Use the React Native command line interface to generate a new React Native project called "AwesomeProject", then run `react-native run-android` inside the newly created folder.
+Use the React Native command line interface to generate a new React Native project called "AwesomeProject", then run `react-native start` inside the newly created folder to start the packager.
 
 ```
 react-native init AwesomeProject
 cd AwesomeProject
+react-native start
+```
+
+Open a new terminal and run `react-native run-android` inside the same folder to launch the app on your AVD.
+
+```
 react-native run-android
 ```
 


### PR DESCRIPTION
Fixed Walkthrough for setting up the first project.
- Fixed Missing command ```react-native start``` to start the packager in the Linux-Android section.

The page at [Getting Started](https://facebook.github.io/react-native/docs/getting-started.html) for Linux Android has a step missing. i.e ```react-native start``` without which the bundler won't start.

This step is mentioned in Windows sections but not in Linux Section.