### PR TITLE
Fix typo in ViewabilityHelper (`itemVisiblePercentThreshold` mistyped)

### DIFF
--- a/Libraries/Experimental/ViewabilityHelper.js
+++ b/Libraries/Experimental/ViewabilityHelper.js
@@ -35,7 +35,7 @@ export type ViewabilityConfig = {
    * Similar to `viewAreaPercentThreshold`, but considers the percent of the item that is visible,
    * rather than the fraction of the viewable area it covers.
    */
-  itemVisiblePercentThreashold?: number,
+  itemVisiblePercentThreshold?: number,
 
   /**
    * Nothing is considered viewable until the user scrolls (tbd: or taps) the screen after render.
@@ -68,15 +68,15 @@ class ViewabilityHelper {
     getFrameMetrics: (index: number) => ?{length: number, offset: number},
     renderRange?: {first: number, last: number}, // Optional optimization to reduce the scan size
   ): Array<number> {
-    const {itemVisiblePercentThreashold, viewAreaCoveragePercentThreshold} = this._config;
+    const {itemVisiblePercentThreshold, viewAreaCoveragePercentThreshold} = this._config;
     const viewAreaMode = viewAreaCoveragePercentThreshold != null;
     const viewablePercentThreshold = viewAreaMode ?
       viewAreaCoveragePercentThreshold :
-      itemVisiblePercentThreashold;
+      itemVisiblePercentThreshold;
     invariant(
       viewablePercentThreshold != null &&
-      (itemVisiblePercentThreashold != null) !== (viewAreaCoveragePercentThreshold != null),
-      'Must set exactly one of itemVisiblePercentThreashold or viewAreaCoveragePercentThreshold',
+      (itemVisiblePercentThreshold != null) !== (viewAreaCoveragePercentThreshold != null),
+      'Must set exactly one of itemVisiblePercentThreshold or viewAreaCoveragePercentThreshold',
     );
     const viewableIndices = [];
     if (itemCount === 0) {

--- a/Libraries/Experimental/__tests__/ViewabilityHelper-test.js
+++ b/Libraries/Experimental/__tests__/ViewabilityHelper-test.js
@@ -118,12 +118,12 @@ describe('computeViewableItems', function() {
         d: {y: 250, height: 50},
       };
       data = [{key: 'a'}, {key: 'b'}, {key: 'c'}, {key: 'd'}];
-      let helper = new ViewabilityHelper({itemVisiblePercentThreashold: 0});
+      let helper = new ViewabilityHelper({itemVisiblePercentThreshold: 0});
       expect(helper.computeViewableItems(data.length, 0, 50, getFrameMetrics))
         .toEqual([0]);
       expect(helper.computeViewableItems(data.length, 1, 50, getFrameMetrics))
         .toEqual([0, 1]);
-      helper = new ViewabilityHelper({itemVisiblePercentThreashold: 100});
+      helper = new ViewabilityHelper({itemVisiblePercentThreshold: 100});
       expect(helper.computeViewableItems(data.length, 0, 250, getFrameMetrics))
         .toEqual([0, 1, 2]);
       expect(helper.computeViewableItems(data.length, 1, 250, getFrameMetrics))


### PR DESCRIPTION
The new `ViewabilityConfig` API has a typo:
`itemVisiblePercentThreashold` should be `itemVisiblePercentThreshold`.

Thought it would be good to fix this before people start depending on a property containing a typo :-)

Updated tests to match.
