### PR TITLE
[podspec] Fixes current CI failures and allows tree shaking of native dev support code.

### DIFF
--- a/React.podspec
+++ b/React.podspec
@@ -43,9 +43,15 @@ Pod::Spec.new do |s|
     ss.dependency             "Yoga", "#{package["version"]}.React"
     ss.dependency             "React/cxxreact"
     ss.source_files         = "React/**/*.{c,h,m,mm,S}"
-    ss.exclude_files        = "**/__tests__/*", "IntegrationTests/*", "React/**/RCTTVView.*", "ReactCommon/yoga/*", "React/Cxx*/*"
+    ss.exclude_files        = "**/__tests__/*", "IntegrationTests/*", "React/DevSupport/*", "React/Modules/RCTDev{LoadingView,Menu}.*", "React/**/RCTTVView.*", "ReactCommon/yoga/*", "React/Cxx*/*"
     ss.framework            = "JavaScriptCore"
     ss.libraries            = "stdc++"
+  end
+
+  s.subspec "DevSupport" do |ss|
+    ss.dependency             "React/Core"
+    ss.dependency             "React/RCTWebSocket"
+    ss.source_files         = "React/DevSupport/*", "React/Modules/RCTDev{LoadingView,Menu}.*"
   end
 
   s.subspec "tvOS" do |ss|

--- a/React.podspec
+++ b/React.podspec
@@ -1,10 +1,19 @@
 require "json"
 
 package = JSON.parse(File.read(File.join(__dir__, "package.json")))
+version = package['version']
+
+source = { :git => 'https://github.com/facebook/react-native.git' }
+if version == '1000.0.0'
+  # This is an unpublished version, use the latest commit hash of the react-native repo, which we’re presumably in.
+  source[:commit] = `git rev-parse HEAD`.strip
+else
+  source[:tag] = "v#{version}"
+end
 
 Pod::Spec.new do |s|
   s.name                    = "React"
-  s.version                 = package["version"]
+  s.version                 = version
   s.summary                 = package["description"]
   s.description             = <<-DESC
                                 React Native apps are built using the React JS
@@ -22,7 +31,7 @@ Pod::Spec.new do |s|
   s.homepage                = "http://facebook.github.io/react-native/"
   s.license                 = package["license"]
   s.author                  = "Facebook"
-  s.source                  = { :git => "https://github.com/facebook/react-native.git", :tag => "v#{s.version}" }
+  s.source                  = source
   s.default_subspec         = "Core"
   s.requires_arc            = true
   s.platform                = :ios, "8.0"

--- a/React/Base/RCTBatchedBridge.m
+++ b/React/Base/RCTBatchedBridge.m
@@ -14,7 +14,6 @@
 #import "RCTBridge.h"
 #import "RCTBridgeMethod.h"
 #import "RCTConvert.h"
-#import "RCTDevLoadingView.h"
 #import "RCTDisplayLink.h"
 #import "RCTJSCExecutor.h"
 #import "RCTJavaScriptLoader.h"
@@ -24,6 +23,10 @@
 #import "RCTProfile.h"
 #import "RCTRedBox.h"
 #import "RCTUtils.h"
+
+#if RCT_DEV && __has_include("RCTDevLoadingView.h")
+#import "RCTDevLoadingView.h"
+#endif
 
 #define RCTAssertJSThread() \
   RCTAssert(![NSStringFromClass([self->_javaScriptExecutor class]) isEqualToString:@"RCTJSCExecutor"] || \
@@ -116,7 +119,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithDelegate:(id<RCTBridgeDelegate>)dele
     sourceCode = source;
     dispatch_group_leave(initModulesAndLoadSource);
   } onProgress:^(RCTLoadingProgress *progressData) {
-#ifdef RCT_DEV
+#if RCT_DEV && __has_include("RCTDevLoadingView.h")
     RCTDevLoadingView *loadingView = [weakSelf moduleForClass:[RCTDevLoadingView class]];
     [loadingView updateProgress:progressData];
 #endif

--- a/React/Profiler/RCTPerfMonitor.m
+++ b/React/Profiler/RCTPerfMonitor.m
@@ -16,7 +16,6 @@
 #import <mach/mach.h>
 
 #import "RCTBridge.h"
-#import "RCTDevMenu.h"
 #import "RCTDevSettings.h"
 #import "RCTFPSGraph.h"
 #import "RCTInvalidating.h"
@@ -26,6 +25,10 @@
 #import "RCTRootView.h"
 #import "RCTUIManager.h"
 #import "RCTBridge+Private.h"
+
+#if __has_include("RCTDevMenu.h")
+#import "RCTDevMenu.h"
+#endif
 
 static NSString *const RCTPerfMonitorCellIdentifier = @"RCTPerfMonitorCellIdentifier";
 
@@ -74,11 +77,11 @@ static vm_size_t RCTGetResidentMemorySize(void)
   return info.resident_size;
 }
 
-@class RCTDevMenuItem;
-
 @interface RCTPerfMonitor : NSObject <RCTBridgeModule, RCTInvalidating, UITableViewDataSource, UITableViewDelegate>
 
+#if __has_include("RCTDevMenu.h")
 @property (nonatomic, strong, readonly) RCTDevMenuItem *devMenuItem;
+#endif
 @property (nonatomic, strong, readonly) UIPanGestureRecognizer *gestureRecognizer;
 @property (nonatomic, strong, readonly) UIView *container;
 @property (nonatomic, strong, readonly) UILabel *memory;
@@ -93,7 +96,9 @@ static vm_size_t RCTGetResidentMemorySize(void)
 @end
 
 @implementation RCTPerfMonitor {
+#if __has_include("RCTDevMenu.h")
   RCTDevMenuItem *_devMenuItem;
+#endif
   UIPanGestureRecognizer *_gestureRecognizer;
   UIView *_container;
   UILabel *_memory;
@@ -142,7 +147,9 @@ RCT_EXPORT_MODULE()
 {
   _bridge = bridge;
 
+#if __has_include("RCTDevMenu.h")
   [_bridge.devMenu addItem:self.devMenuItem];
+#endif
 }
 
 - (void)invalidate
@@ -150,6 +157,7 @@ RCT_EXPORT_MODULE()
   [self hide];
 }
 
+#if __has_include("RCTDevMenu.h")
 - (RCTDevMenuItem *)devMenuItem
 {
   if (!_devMenuItem) {
@@ -173,6 +181,7 @@ RCT_EXPORT_MODULE()
 
   return _devMenuItem;
 }
+#endif
 
 - (UIPanGestureRecognizer *)gestureRecognizer
 {

--- a/scripts/bump-oss-version.js
+++ b/scripts/bump-oss-version.js
@@ -11,7 +11,7 @@
 
 /**
  * This script bumps a new version for open source releases.
- * It updates the version in podspec/json/gradle files and makes sure they are consistent between each other
+ * It updates the version in json/gradle files and makes sure they are consistent between each other
  * After changing the files it makes a commit and tags it.
  * All you have to do is push changes to remote and CI will make a new build.
  */
@@ -54,17 +54,11 @@ if (sed(`-i`, /^VERSION_NAME=.*/, `VERSION_NAME=${version}`, `ReactAndroid/gradl
   exit(1);
 }
 
-// - change React.podspec
-if (sed(`-i`, /s\.version\s*=.*/, `s.version             = \"${version}\"`, `React.podspec`).code) {
-  echo(`Couldn't update version for React.podspec`);
-  exit(1);
-}
-
 // verify that files changed, we just do a git diff and check how many times version is added across files
 let numberOfChangedLinesWithNewVersion = exec(`git diff -U0 | grep '^[+]' | grep -c ${version} `, {silent: true})
   .stdout.trim();
-if (+numberOfChangedLinesWithNewVersion !== 3) {
-  echo(`Failed to update all the files. React.podspec, package.json and gradle.properties must have versions in them`);
+if (+numberOfChangedLinesWithNewVersion !== 2) {
+  echo(`Failed to update all the files. package.json and gradle.properties must have versions in them`);
   echo(`Fix the issue, revert and try again`);
   exec(`git diff`);
   exit(1);


### PR DESCRIPTION
* The dev support code moved into a `DevSupport` subspec, meaning that only if the subspec is specified in the user’s Podfile will the packager client, dev menu, etc be included. This is mainly done through checks for header availability.

  It also improves the weird situation where you had to specify the `RCTWebSocket` subspec if you wanted to be able to use the packager client during development.

* I removed hardcoding the release version in the podspec on release, because the podspec still relies on `package.json` when evaluating, so there’s no real point in not also getting the version number from there. This should remove any requirement to perform maintenance of the OSS release script regarding the podspec.