### PR TITLE
CI: Fast finish Travis builds, disable tvOS and JS tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ notifications:
   email:
     recipients:
       - mkonicek@fb.com
-      - eloy@artsy.net # Eloy Durán maintains the podspecs test and wants to be notified about failures
+      - eloy@artsy.net # Eloy Durán maintains the podspecs test and wants to be notified about failures.
     on_failure: change
     on_success: change
   slack:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,11 +18,7 @@ install:
 
 script:
   - if [[ "$TEST_TYPE" = objc-ios ]]; then travis_retry travis_wait ./scripts/objc-test-ios.sh; fi
-  - if [[ "$TEST_TYPE" = objc-tvos ]]; then travis_retry travis_wait ./scripts/objc-test-tvos.sh; fi
   - if [[ "$TEST_TYPE" = e2e-objc ]]; then node ./scripts/run-ci-e2e-tests.js --ios --js --retries 3; fi
-  - if [[ "$TEST_TYPE" = e2e-objc-tvos ]]; then node ./scripts/run-ci-e2e-tests.js --tvos --retries 3; fi
-  - if [[ "$TEST_TYPE" = js ]]; then npm run flow check; fi
-  - if [[ "$TEST_TYPE" = js ]]; then npm test -- --maxWorkers=1; fi
   - if [[ ( "$TEST_TYPE" = podspecs ) && ( "$TRAVIS_PULL_REQUEST" = "false" ) ]]; then gem install cocoapods && ./scripts/process-podspecs.sh; fi
 
 
@@ -31,11 +27,8 @@ matrix:
 
 # The order of these tests says which are more likely to run first and fail the whole build fast.
 env:
-  - TEST_TYPE=js
-  - TEST_TYPE=objc-tvos
   - TEST_TYPE=objc-ios
   - TEST_TYPE=podspecs
-  - TEST_TYPE=e2e-objc-tvos
   - TEST_TYPE=e2e-objc
 
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,14 +25,18 @@ script:
   - if [[ "$TEST_TYPE" = js ]]; then npm test -- --maxWorkers=1; fi
   - if [[ ( "$TEST_TYPE" = podspecs ) && ( "$TRAVIS_PULL_REQUEST" = "false" ) ]]; then gem install cocoapods && ./scripts/process-podspecs.sh; fi
 
+
+matrix:
+  - fast_finish: true # Fail the whole build as soon as one test type fails. Should help with Travis capacity issues (very long queues).
+
+# The order of these tests says which are more likely to run first and fail the whole build fast.
 env:
-  matrix:
-    - TEST_TYPE=e2e-objc-tvos
-    - TEST_TYPE=e2e-objc
-    - TEST_TYPE=objc-ios
-    - TEST_TYPE=objc-tvos
-    - TEST_TYPE=js
-    - TEST_TYPE=podspecs
+  - TEST_TYPE=js
+  - TEST_TYPE=objc-tvos
+  - TEST_TYPE=objc-ios
+  - TEST_TYPE=podspecs
+  - TEST_TYPE=e2e-objc-tvos
+  - TEST_TYPE=e2e-objc
 
 branches:
   only:
@@ -43,7 +47,7 @@ notifications:
   email:
     recipients:
       - mkonicek@fb.com
-      - eloy@artsy.net
+      - eloy@artsy.net # Eloy Durán maintains the podspecs test and wants to be notified about failures
     on_failure: change
     on_success: change
   slack:


### PR DESCRIPTION
On Travis all fb projects share the same org and wait around a day for test results.

When a test fails we're still using Travis capacity to run other tests:

![screenshot 2017-02-28 16 03 45](https://cloud.githubusercontent.com/assets/346214/23413069/8606c34a-fdcf-11e6-8f90-275ca0c01a2d.png)

https://travis-ci.org/facebook/react-native/builds/206214009

Could failing fast help? Docs: https://docs.travis-ci.com/user/customizing-the-build/#Fast-Finishing

Also disable tvOS tests. The reason is it turns out React Native builds are a major contributor to slowing down Travis on Mac for everyone int the world, and the tvOS tests take a significant portion of the work. Messaged @dlowder-salesforce about this. Sorry we have to do this for now until Travis hopefully adds lots of Mac capacity.

Also disable JS tests. We now spend around 10% of time on Travis running these. The exact same tests run on Circle CI.

**Test Plan**

This PR is based on master which is currently failing, so Travis tests will fail.

Looks like builds were canceled after some builds failed:

![screenshot 2017-03-01 13 29 48](https://cloud.githubusercontent.com/assets/346214/23461784/34dbac9c-fe83-11e6-9a50-bb4f92089160.png)
