### PR TITLE
Do not ping Slack on PR builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,3 +46,6 @@ notifications:
     on_success: change
   slack:
     secure: oQL2C966v7/DtxNqfM7WowjY0R5mgLHR2qHkoucwK5iVrmaptnHr8fq01xlj7VT0kDwNLqT3n4+gtCviGw89lq71m3W76c8Pms/10jpjw+LwAfQPVizNw/Bx8MFNNmjDauK/auFxaybiLZupi7zd4xFGOZvScmFdfD4CAAp2OOA=
+    on_pull_requests: false
+    on_failure: change
+    on_success: change


### PR DESCRIPTION
This will limit Slack's notifications to the #ci channel to whenever the build goes from green to red and vice versa on the default branch (master).

