### PR TITLE
Remove semi-colons after class definition

### DIFF
--- a/docs/HeightAndWidth.md
+++ b/docs/HeightAndWidth.md
@@ -28,7 +28,7 @@ class FixedDimensionsBasics extends Component {
       </View>
     );
   }
-};
+}
 
 AppRegistry.registerComponent('AwesomeProject', () => FixedDimensionsBasics);
 ```
@@ -58,7 +58,7 @@ class FlexDimensionsBasics extends Component {
       </View>
     );
   }
-};
+}
 
 AppRegistry.registerComponent('AwesomeProject', () => FlexDimensionsBasics);
 ```


### PR DESCRIPTION
None of the preceding code examples have semi-colons after the class definition (because they're not necessary):

- https://facebook.github.io/react-native/docs/tutorial.html
- https://facebook.github.io/react-native/docs/props.html
- https://facebook.github.io/react-native/docs/state.html
- https://facebook.github.io/react-native/docs/style.html

For consistency, I removed them :+1: