### PR TITLE
Update travis config to test on node 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,9 @@ install:
   - brew install nvm
   - source $(brew --prefix nvm)/nvm.sh
   # TODO npm 2 started stalling on Travis, t11852928
-  - nvm install 5
+
+  # Use node 6 because that is what runs on land-blocking tests
+  - nvm install 6
   - rm -Rf "${TMPDIR}/jest_preprocess_cache"
   - wget https://github.com/yarnpkg/yarn/releases/download/v0.16.0/yarn-0.16.0.js
   - export yarn="node $(pwd)/yarn-0.16.0.js"


### PR DESCRIPTION
This should get our node environments to match between internal tests and Travis runs