### PR TITLE
Fix activity path in run-android launch command with multiple build variants

### DIFF
--- a/local-cli/runAndroid/runAndroid.js
+++ b/local-cli/runAndroid/runAndroid.js
@@ -85,10 +85,15 @@ function buildAndRun(args) {
     ? 'gradlew.bat'
     : './gradlew';
 
-  const packageName = fs.readFileSync(
+  const manifestPackage = fs.readFileSync(
       'app/src/main/AndroidManifest.xml',
       'utf8'
     ).match(/package="(.+?)"/)[1];
+
+  const packageName = args.applicationId ?
+                        `${args.applicationId}/${manifestPackage}.`
+                        :
+                        `${manifestPackage}/.`;
 
   const adbPath = getAdbPath();
   if (args.deviceId) {
@@ -152,7 +157,7 @@ function tryInstallAppOnDevice(args, device) {
 
 function tryLaunchAppOnDevice(device, packageName, adbPath, mainActivity) {
   try {
-    const adbArgs = ['-s', device, 'shell', 'am', 'start', '-n', packageName + '/.' + mainActivity];
+    const adbArgs = ['-s', device, 'shell', 'am', 'start', '-n', packageName + mainActivity];
     console.log(chalk.bold(
       `Starting the app on ${device} (${adbPath} ${adbArgs.join(' ')})...`
     ));
@@ -222,7 +227,7 @@ function runOnAllDevices(args, cmd, packageName, adbPath){
         // If we cannot execute based on adb devices output, fall back to
         // shell am start
         const fallbackAdbArgs = [
-          'shell', 'am', 'start', '-n', packageName + '/.MainActivity'
+          'shell', 'am', 'start', '-n', packageName + args.mainActivity
         ];
         console.log(chalk.bold(
           `Starting the app (${adbPath} ${fallbackAdbArgs.join(' ')}...`
@@ -294,6 +299,9 @@ module.exports = {
     command: '--deviceId [string]',
     description: 'builds your app and starts it on a specific device/simulator with the ' +
       'given device id (listed by running "adb devices" on the command line).',
+  }, {
+    command: '--applicationId [string]',
+    description: 'Application Id'
   }, {
     command: '--no-packager',
     description: 'Do not launch packager while building',

--- a/local-cli/runAndroid/runAndroid.js
+++ b/local-cli/runAndroid/runAndroid.js
@@ -319,5 +319,3 @@ module.exports = {
     description: 'Do not launch packager while building',
   }],
 };
-
-

--- a/local-cli/runAndroid/runAndroid.js
+++ b/local-cli/runAndroid/runAndroid.js
@@ -85,34 +85,49 @@ function buildAndRun(args) {
     ? 'gradlew.bat'
     : './gradlew';
 
-  const manifestPackage = fs.readFileSync(
-      'app/src/main/AndroidManifest.xml',
-      'utf8'
-    ).match(/package="(.+?)"/)[1];
-
-  const packageName = args.applicationId ?
-                        `${args.applicationId}/${manifestPackage}.`
-                        :
-                        `${manifestPackage}/.`;
-
   const adbPath = getAdbPath();
   if (args.deviceId) {
     if (isString(args.deviceId)) {
-        runOnSpecificDevice(args, cmd, packageName, adbPath);
+        runOnSpecificDevice(args, cmd, adbPath);
     } else {
       console.log(chalk.red('Argument missing for parameter --deviceId'));
     }
   } else {
-    runOnAllDevices(args, cmd, packageName, adbPath);
+    runOnAllDevices(args, cmd, adbPath);
   }
 }
 
-function runOnSpecificDevice(args, gradlew, packageName, adbPath) {
+function fullMainActivityPath(args) {
+  const packageName = fs.readFileSync(
+    'app/src/main/AndroidManifest.xml',
+    'utf8'
+  ).match(/package="(.+?)"/)[1];
+  const mainActivity = args.mainActivity || 'MainActivity';
+  const variant = args.variant
+
+  if (variant) {
+    const variantKeys = variant.replace(/([A-Z])/g, ' $1').trim().toLowerCase().split(' ');
+    const productFlavor = variantKeys[0], buildType = variantKeys[1];
+    const packagePath = packageName.replace('.', '/');
+    const applicationId = fs.readFileSync(
+      `app/build/generated/source/buildConfig/${productFlavor}/${buildType}/${packagePath}/BuildConfig.java`,
+      'utf8'
+    ).match(/APPLICATION_ID = "(.+?)"/)[1];
+
+    console.log(`${applicationId}/${packageName}.${mainActivity}`);
+    return `${applicationId}/${packageName}.${mainActivity}`;
+  } else {
+    console.log(`${packageName}/.${mainActivity}`);
+    return `${packageName}/.${mainActivity}`;
+  }
+}
+
+function runOnSpecificDevice(args, gradlew, adbPath) {
   let devices = adb.getDevices();
   if (devices && devices.length > 0) {
     if (devices.indexOf(args.deviceId) !== -1) {
       buildApk(gradlew);
-      installAndLaunchOnDevice(args, args.deviceId, packageName, adbPath);
+      installAndLaunchOnDevice(args, args.deviceId, adbPath);
     } else {
       console.log('Could not find device with the id: "' + args.deviceId + '".');
       console.log('Choose one of the following:');
@@ -155,9 +170,9 @@ function tryInstallAppOnDevice(args, device) {
   }
 }
 
-function tryLaunchAppOnDevice(device, packageName, adbPath, mainActivity) {
+function tryLaunchAppOnDevice(device, adbPath, mainActivity) {
   try {
-    const adbArgs = ['-s', device, 'shell', 'am', 'start', '-n', packageName + mainActivity];
+    const adbArgs = ['-s', device, 'shell', 'am', 'start', '-n', mainActivity];
     console.log(chalk.bold(
       `Starting the app on ${device} (${adbPath} ${adbArgs.join(' ')})...`
     ));
@@ -169,13 +184,13 @@ function tryLaunchAppOnDevice(device, packageName, adbPath, mainActivity) {
   }
 }
 
-function installAndLaunchOnDevice(args, selectedDevice, packageName, adbPath) {
+function installAndLaunchOnDevice(args, selectedDevice, adbPath) {
   tryRunAdbReverse(selectedDevice);
   tryInstallAppOnDevice(args, selectedDevice);
-  tryLaunchAppOnDevice(selectedDevice, packageName, adbPath, args.mainActivity);
+  tryLaunchAppOnDevice(selectedDevice, adbPath, fullMainActivityPath(args));
 }
 
-function runOnAllDevices(args, cmd, packageName, adbPath){
+function runOnAllDevices(args, cmd, adbPath){
   try {
     const gradleArgs = [];
     if (args.variant) {
@@ -220,14 +235,14 @@ function runOnAllDevices(args, cmd, packageName, adbPath){
     if (devices && devices.length > 0) {
       devices.forEach((device) => {
         tryRunAdbReverse(device);
-        tryLaunchAppOnDevice(device, packageName, adbPath, args.mainActivity);
+        tryLaunchAppOnDevice(device, adbPath, fullMainActivityPath(args));
       });
     } else {
       try {
         // If we cannot execute based on adb devices output, fall back to
         // shell am start
         const fallbackAdbArgs = [
-          'shell', 'am', 'start', '-n', packageName + args.mainActivity
+          'shell', 'am', 'start', '-n', fullMainActivityPath(args)
         ];
         console.log(chalk.bold(
           `Starting the app (${adbPath} ${fallbackAdbArgs.join(' ')}...`
@@ -300,10 +315,9 @@ module.exports = {
     description: 'builds your app and starts it on a specific device/simulator with the ' +
       'given device id (listed by running "adb devices" on the command line).',
   }, {
-    command: '--applicationId [string]',
-    description: 'Application Id'
-  }, {
     command: '--no-packager',
     description: 'Do not launch packager while building',
   }],
 };
+
+

--- a/local-cli/runAndroid/runAndroid.js
+++ b/local-cli/runAndroid/runAndroid.js
@@ -114,10 +114,8 @@ function fullMainActivityPath(args) {
       'utf8'
     ).match(/APPLICATION_ID = "(.+?)"/)[1];
 
-    console.log(`${applicationId}/${packageName}.${mainActivity}`);
     return `${applicationId}/${packageName}.${mainActivity}`;
   } else {
-    console.log(`${packageName}/.${mainActivity}`);
     return `${packageName}/.${mainActivity}`;
   }
 }


### PR DESCRIPTION
I use the productFlavor and buildType in the variant option to get the path to BuildConfig.java. From there I parse the APPLICATION_ID for that build variant.

We can also define and run a gradle task to generate applicationId, but it is not so nice.

I have to change the code quite a bit as it has to run after BuildConfig.java is generated (via build apk task)

**Test plan (required)**

1. Configure build.gradle

```
    signingConfigs {
        production {
            keyAlias = "release"
            storeFile = file("../keystores/release.jks")
            keyPassword = "******"
            storePassword = "******"
        }
    }

    buildTypes {
        debug {
            applicationIdSuffix ".debug"
            versionNameSuffix "-debug"
        }
        production {
            applicationIdSuffix ".production"
            versionNameSuffix ""
            signingConfig signingConfigs.production
        }
    }

    productFlavors {
        demo {
            applicationIdSuffix ".demo"
        }

        full {
            applicationIdSuffix ".full"
        }
    }
```

2. Run `react-native run-android --variant DemoDebug`