### PR TITLE
Fix property accessor warning in RCTDevSettings::websocketExecutorName

### DIFF
--- a/React/Modules/RCTDevSettings.h
+++ b/React/Modules/RCTDevSettings.h
@@ -46,7 +46,7 @@
  * Alternate name for the websocket executor, if not the generic term "remote".
  * TODO t16297016: this seems to be unused, remove?
  */
-@property (nonatomic, copy) NSString *websocketExecutorName;
+@property (nonatomic, readonly) NSString *websocketExecutorName;
 
 /*
  * Whether shaking will show RCTDevMenu. The menu is enabled by default if RCT_DEV=1, but


### PR DESCRIPTION
Motivation: Fixes Xcode warning `Ivar '_websocketExecutorName' which backs the property is not referenced in this property's accessor` which shows up because this property has no setter (and is never set anywhere).

Test plan: Build iOS.