### PR TITLE
Fix Issue with network errors

### DIFF
--- a/Examples/Movies/SearchScreen.js
+++ b/Examples/Movies/SearchScreen.js
@@ -123,15 +123,6 @@ var SearchScreen = React.createClass({
 
     fetch(this._urlForQueryAndPage(query, 1))
       .then((response) => response.json())
-      .catch((error) => {
-        LOADING[query] = false;
-        resultsCache.dataForQuery[query] = undefined;
-
-        this.setState({
-          dataSource: this.getDataSource([]),
-          isLoading: false,
-        });
-      })
       .then((responseData) => {
         LOADING[query] = false;
         resultsCache.totalForQuery[query] = responseData.total;
@@ -146,6 +137,15 @@ var SearchScreen = React.createClass({
         this.setState({
           isLoading: false,
           dataSource: this.getDataSource(responseData.movies),
+        });
+      })
+      .catch((error) => {
+        LOADING[query] = false;
+        resultsCache.dataForQuery[query] = undefined;
+
+        this.setState({
+          dataSource: this.getDataSource([]),
+          isLoading: false,
         });
       })
       .done();


### PR DESCRIPTION
When running the Movies Example, the application displays an error message: "Cannot read property 'total' of undefined".
<img width="374" alt="capture d ecran 2017-03-01 a 21 26 50" src="https://cloud.githubusercontent.com/assets/3247607/23479864/2871c52a-fec6-11e6-9266-8a5fe44adfe4.png">

This is due to the fact that the API call raised an error, and the catch block is followed by a then block, which means that the code in the second then bloc will be executed.

The fix is to move the catch at the last position, to prevent any further execution in case of network error.
