### PR TITLE
mark dirty section and rows cleaned after they are rendered

### DIFF
--- a/Libraries/CustomComponents/ListView/ListView.js
+++ b/Libraries/CustomComponents/ListView/ListView.js
@@ -445,6 +445,8 @@ var ListView = React.createClass({
         }
       }
 
+      dataSource.dirtySectionCleaned(sectionIdx);
+
       for (var rowIdx = 0; rowIdx < rowIDs.length; rowIdx++) {
         var rowID = rowIDs[rowIdx];
         var comboID = sectionID + '_' + rowID;
@@ -486,6 +488,9 @@ var ListView = React.createClass({
             totalIndex++;
           }
         }
+
+        dataSource.dirtyRowCleaned(sectionIdx, rowIdx);
+        
         if (++rowCount === this.state.curRenderedRowsCount) {
           break;
         }

--- a/Libraries/CustomComponents/ListView/ListViewDataSource.js
+++ b/Libraries/CustomComponents/ListView/ListViewDataSource.js
@@ -319,6 +319,31 @@ class ListViewDataSource {
   }
 
   /**
+    * Mark dirty section as clean.
+    * This method should be called after the listview has rendered the dirty section
+    * so it doesn't need to be rendered again unless changed.
+    */
+  dirtySectionCleaned(sectionIndex: number): void {
+    if (this._dirtySections.length > sectionIndex) {
+      this._dirtySections[sectionIndex] = false;
+    }
+  }
+
+  /**
+    * Mark dirty row as clean.
+    * This method should be called after the listview has rendered the dirty row
+    * so it doesn't need to be rendered again unless changed.
+    */
+  dirtyRowCleaned(sectionIndex: number, rowIndex: number): void {
+    if (this._dirtyRows.length > sectionIndex) {
+      var section = this._dirtyRows[sectionIndex];
+      if (section.length > rowIndex) {
+        this._dirtyRows[sectionIndex][rowIndex] = false;
+      }
+    }
+  }
+
+  /**
    * Private members and methods.
    */
 


### PR DESCRIPTION
Currently, if dataSource is changed, the dirty sections and rows will never get "cleaned", causing them to be re-rendered every frame afterwards.
After a row or section is rendered, we "clean" the corresponding item in the dataSource's _dirtySections and _dirtyRows.

Test plan:
Log to console each time a row renders
Update datasource for a single row
Check that the row only ever re-renders once

This is related to pr: https://github.com/facebook/react-native/pull/7405
but the fix is moved out of rowShouldUpdate in ListViewDataSource.