### PR TITLE
mark dirty section and rows cleaned after they are rendered

### DIFF
--- a/Libraries/Lists/ListView/ListView.js
+++ b/Libraries/Lists/ListView/ListView.js
@@ -421,6 +421,7 @@ var ListView = React.createClass({
           totalIndex++;
         }
       }
+      dataSource.dirtySectionCleaned(sectionIdx);
 
       for (var rowIdx = 0; rowIdx < rowIDs.length; rowIdx++) {
         var rowID = rowIDs[rowIdx];
@@ -463,6 +464,8 @@ var ListView = React.createClass({
             totalIndex++;
           }
         }
+        dataSource.dirtyRowCleaned(sectionIdx, rowIdx);
+
         if (++rowCount === this.state.curRenderedRowsCount) {
           break;
         }

--- a/Libraries/Lists/ListView/ListView.js
+++ b/Libraries/Lists/ListView/ListView.js
@@ -420,8 +420,8 @@ var ListView = React.createClass({
           }
           totalIndex++;
         }
+        dataSource.dirtySectionCleaned(sectionIdx);
       }
-      dataSource.dirtySectionCleaned(sectionIdx);
 
       for (var rowIdx = 0; rowIdx < rowIDs.length; rowIdx++) {
         var rowID = rowIDs[rowIdx];

--- a/Libraries/Lists/ListView/ListViewDataSource.js
+++ b/Libraries/Lists/ListView/ListViewDataSource.js
@@ -303,6 +303,27 @@ class ListViewDataSource {
   }
 
   /**
+    * Mark dirty section as clean to prevent unnecessary re-rendering.
+    */
+  dirtySectionCleaned(sectionIndex: number): void {
+    if (this._dirtySections.length > sectionIndex) {
+      this._dirtySections[sectionIndex] = false;
+    }
+  }
+
+  /**
+    * Mark dirty row as clean to prevent unnecessary re-rendering.
+    */
+  dirtyRowCleaned(sectionIndex: number, rowIndex: number): void {
+    if (this._dirtyRows.length > sectionIndex) {
+      var section = this._dirtyRows[sectionIndex];
+      if (section.length > rowIndex) {
+        this._dirtyRows[sectionIndex][rowIndex] = false;
+      }
+    }
+  }
+
+  /**
    * Private members and methods.
    */
 

--- a/Libraries/Lists/ListView/ListViewDataSource.js
+++ b/Libraries/Lists/ListView/ListViewDataSource.js
@@ -316,7 +316,7 @@ class ListViewDataSource {
     */
   dirtyRowCleaned(sectionIndex: number, rowIndex: number): void {
     if (this._dirtyRows.length > sectionIndex) {
-      var section = this._dirtyRows[sectionIndex];
+      const section = this._dirtyRows[sectionIndex];
       if (section.length > rowIndex) {
         this._dirtyRows[sectionIndex][rowIndex] = false;
       }


### PR DESCRIPTION
Currently, if dataSource is changed, the dirty sections and rows will never get "cleaned", causing them to be re-rendered every frame afterwards.
After a row or section is rendered, we "clean" the corresponding item in the dataSource's _dirtySections and _dirtyRows.

Test plan:
Log to console each time a row renders
Update datasource for a single row
Check that the row only ever re-renders once

This is related to pr: #7405
but the fix is moved out of rowShouldUpdate in ListViewDataSource.