### PR TITLE
CLI: Assign project root concat back to project roots.

### DIFF
--- a/local-cli/server/server.js
+++ b/local-cli/server/server.js
@@ -17,7 +17,7 @@ const runServer = require('./runServer');
  * Starts the React Native Packager Server.
  */
 function server(argv, config, args) {
-  args.projectRoots.concat(args.root);
+  args.projectRoots = args.projectRoots.concat(args.root);
 
   console.log(formatBanner(
     'Running packager on port ' + args.port + '.\n\n' +


### PR DESCRIPTION
With the latest version of React Native I noted my setup with React Native Storybook stopped working because it stopped searching all the right project roots. I found that it had to do with the change here https://github.com/facebook/react-native/commit/bce6ece5f6927bcc06252dc2368840aa0c6fa30e

**Test plan (required)**

Run the CLI with a project root other then the root directory and ensure that it displays both the specified project root and the actual root directory.