### PR TITLE
Custom font - fall back to regular variation of custom font family

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/modules/fresco/FrescoModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/fresco/FrescoModule.java
@@ -154,7 +154,7 @@ public class FrescoModule extends ReactContextBaseJavaModule implements
     HashSet<RequestListener> requestListeners = new HashSet<>();
     requestListeners.add(new SystraceRequestListener());
 
-    OkHttpClient client = OkHttpClientProvider.createClient();
+    OkHttpClient client = new OkHttpClientProvider().get();
 
     // make sure to forward cookies for any requests via the okHttpClient
     // so that image requests to endpoints that use cookies still work

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/fresco/FrescoModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/fresco/FrescoModule.java
@@ -9,8 +9,6 @@
 
 package com.facebook.react.modules.fresco;
 
-import java.util.HashSet;
-
 import android.content.Context;
 import android.support.annotation.Nullable;
 
@@ -28,9 +26,11 @@ import com.facebook.react.common.ReactConstants;
 import com.facebook.react.module.annotations.ReactModule;
 import com.facebook.react.modules.common.ModuleDataCleaner;
 import com.facebook.react.modules.network.CookieJarContainer;
+import com.facebook.react.modules.network.DefaultOkHttpProvider;
 import com.facebook.react.modules.network.ForwardingCookieHandler;
-import com.facebook.react.modules.network.OkHttpClientProvider;
 import com.facebook.soloader.SoLoader;
+
+import java.util.HashSet;
 
 import okhttp3.JavaNetCookieJar;
 import okhttp3.OkHttpClient;
@@ -154,7 +154,7 @@ public class FrescoModule extends ReactContextBaseJavaModule implements
     HashSet<RequestListener> requestListeners = new HashSet<>();
     requestListeners.add(new SystraceRequestListener());
 
-    OkHttpClient client = new OkHttpClientProvider().get();
+    OkHttpClient client = new DefaultOkHttpProvider().get();
 
     // make sure to forward cookies for any requests via the okHttpClient
     // so that image requests to endpoints that use cookies still work

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/network/DefaultOkHttpProvider.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/network/DefaultOkHttpProvider.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+package com.facebook.react.modules.network;
+
+import android.os.Build;
+
+import com.facebook.common.logging.FLog;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import okhttp3.ConnectionSpec;
+import okhttp3.OkHttpClient;
+import okhttp3.TlsVersion;
+
+public class DefaultOkHttpProvider implements OkHttpClientProvider {
+
+  public OkHttpClient get() {
+    // No timeouts by default
+    OkHttpClient.Builder client = new OkHttpClient.Builder()
+      .connectTimeout(0, TimeUnit.MILLISECONDS)
+      .readTimeout(0, TimeUnit.MILLISECONDS)
+      .writeTimeout(0, TimeUnit.MILLISECONDS)
+      .cookieJar(new ReactCookieJarContainer());
+
+    return enableTls12OnPreLollipop(client).build();
+  }
+
+  /*
+    On Android 4.1-4.4 (API level 16 to 19) TLS 1.1 and 1.2 are
+    available but not enabled by default. The following method
+    enables it.
+   */
+  public static OkHttpClient.Builder enableTls12OnPreLollipop(OkHttpClient.Builder client) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN && Build.VERSION.SDK_INT <= Build.VERSION_CODES.KITKAT) {
+      try {
+        client.sslSocketFactory(new TLSSocketFactory());
+
+        ConnectionSpec cs = new ConnectionSpec.Builder(ConnectionSpec.MODERN_TLS)
+          .tlsVersions(TlsVersion.TLS_1_2)
+          .build();
+
+        List<ConnectionSpec> specs = new ArrayList<>();
+        specs.add(cs);
+        specs.add(ConnectionSpec.COMPATIBLE_TLS);
+        specs.add(ConnectionSpec.CLEARTEXT);
+
+        client.connectionSpecs(specs);
+      } catch (Exception exc) {
+        FLog.e("OkHttpClientProvider", "Error while enabling TLS 1.2", exc);
+      }
+    }
+
+    return client;
+  }
+}

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/network/OkHttpClientProvider.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/network/OkHttpClientProvider.java
@@ -9,79 +9,11 @@
 
 package com.facebook.react.modules.network;
 
-import android.os.Build;
-
-import com.facebook.common.logging.FLog;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
-
-import javax.annotation.Nullable;
-
-import okhttp3.ConnectionSpec;
 import okhttp3.OkHttpClient;
-import okhttp3.TlsVersion;
 
 /**
- * Helper class that provides the same OkHttpClient instance that will be used for all networking
- * requests.
+ *  Interface that provides the OkHttpClient instance, that will be used for all networking requests.
  */
-public class OkHttpClientProvider {
-
-  // Centralized OkHttpClient for all networking requests.
-  private static @Nullable OkHttpClient sClient;
-
-  public static OkHttpClient getOkHttpClient() {
-    if (sClient == null) {
-      sClient = createClient();
-    }
-    return sClient;
-  }
-  
-  // okhttp3 OkHttpClient is immutable
-  // This allows app to init an OkHttpClient with custom settings.
-  public static void replaceOkHttpClient(OkHttpClient client) {
-    sClient = client;
-  }
-
-  public static OkHttpClient createClient() {
-    // No timeouts by default
-    OkHttpClient.Builder client = new OkHttpClient.Builder()
-      .connectTimeout(0, TimeUnit.MILLISECONDS)
-      .readTimeout(0, TimeUnit.MILLISECONDS)
-      .writeTimeout(0, TimeUnit.MILLISECONDS)
-      .cookieJar(new ReactCookieJarContainer());
-
-    return enableTls12OnPreLollipop(client).build();
-  }
-
-  /*
-    On Android 4.1-4.4 (API level 16 to 19) TLS 1.1 and 1.2 are
-    available but not enabled by default. The following method
-    enables it.
-   */
-  public static OkHttpClient.Builder enableTls12OnPreLollipop(OkHttpClient.Builder client) {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN && Build.VERSION.SDK_INT <= Build.VERSION_CODES.KITKAT) {
-      try {
-        client.sslSocketFactory(new TLSSocketFactory());
-
-        ConnectionSpec cs = new ConnectionSpec.Builder(ConnectionSpec.MODERN_TLS)
-                .tlsVersions(TlsVersion.TLS_1_2)
-                .build();
-
-        List<ConnectionSpec> specs = new ArrayList<>();
-        specs.add(cs);
-        specs.add(ConnectionSpec.COMPATIBLE_TLS);
-        specs.add(ConnectionSpec.CLEARTEXT);
-
-        client.connectionSpecs(specs);
-      } catch (Exception exc) {
-        FLog.e("OkHttpClientProvider", "Error while enabling TLS 1.2", exc);
-      }
-    }
-
-    return client;
-  }
-
+public interface OkHttpClientProvider {
+  OkHttpClient get();
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/shell/MainPackageConfig.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/shell/MainPackageConfig.java
@@ -10,28 +10,41 @@
 package com.facebook.react.shell;
 
 import com.facebook.imagepipeline.core.ImagePipelineConfig;
+import com.facebook.react.modules.network.OkHttpClientProvider;
 
 /**
  * Configuration for {@link MainReactPackage}
  */
 public class MainPackageConfig {
 
-  private ImagePipelineConfig mFrescoConfig;
+  private final OkHttpClientProvider okHttpClientProvider;
+  private final ImagePipelineConfig mFrescoConfig;
 
   private MainPackageConfig(Builder builder) {
     mFrescoConfig = builder.mFrescoConfig;
+    okHttpClientProvider = builder.okHttpClientProvider;
   }
 
   public ImagePipelineConfig getFrescoConfig() {
     return mFrescoConfig;
   }
 
+  public OkHttpClientProvider getOkHttpClientProvider() {
+    return okHttpClientProvider;
+  }
+
   public static class Builder {
 
     private ImagePipelineConfig mFrescoConfig;
+    private OkHttpClientProvider okHttpClientProvider;
 
     public Builder setFrescoConfig(ImagePipelineConfig frescoConfig) {
       mFrescoConfig = frescoConfig;
+      return this;
+    }
+
+    public Builder setOkHttpClientProvider(OkHttpClientProvider okHttpClientProvider) {
+      this.okHttpClientProvider = okHttpClientProvider;
       return this;
     }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/shell/MainPackageConfig.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/shell/MainPackageConfig.java
@@ -10,6 +10,7 @@
 package com.facebook.react.shell;
 
 import com.facebook.imagepipeline.core.ImagePipelineConfig;
+import com.facebook.react.modules.network.DefaultOkHttpProvider;
 import com.facebook.react.modules.network.OkHttpClientProvider;
 
 /**
@@ -30,7 +31,7 @@ public class MainPackageConfig {
   }
 
   public OkHttpClientProvider getOkHttpClientProvider() {
-    return okHttpClientProvider;
+    return okHttpClientProvider != null ? okHttpClientProvider : new DefaultOkHttpProvider();
   }
 
   public static class Builder {

--- a/ReactAndroid/src/main/java/com/facebook/react/shell/MainReactPackage.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/shell/MainReactPackage.java
@@ -194,7 +194,7 @@ public class MainReactPackage extends LazyReactPackage {
       new ModuleSpec(NetworkingModule.class, new Provider<NativeModule>() {
         @Override
         public NativeModule get() {
-          return new NetworkingModule(context);
+          return mConfig == null ? new NetworkingModule(context) : new NetworkingModule(context, mConfig.getOkHttpClientProvider());
         }
       }),
       new ModuleSpec(NetInfoModule.class, new Provider<NativeModule>() {

--- a/ReactAndroid/src/test/java/com/facebook/react/modules/network/NetworkingModuleTest.java
+++ b/ReactAndroid/src/test/java/com/facebook/react/modules/network/NetworkingModuleTest.java
@@ -9,10 +9,6 @@
 
 package com.facebook.react.modules.network;
 
-import java.io.InputStream;
-import java.util.Arrays;
-import java.util.List;
-
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.JavaOnlyArray;
 import com.facebook.react.bridge.JavaOnlyMap;
@@ -23,14 +19,6 @@ import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.common.network.OkHttpCallUtil;
 import com.facebook.react.modules.core.DeviceEventManagerModule.RCTDeviceEventEmitter;
 
-import okhttp3.Call;
-import okhttp3.Headers;
-import okhttp3.MediaType;
-import okhttp3.MultipartBody;
-import okhttp3.OkHttpClient;
-import okhttp3.Request;
-import okhttp3.RequestBody;
-import okio.Buffer;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -43,6 +31,19 @@ import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.rule.PowerMockRule;
 import org.robolectric.RobolectricTestRunner;
+
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.List;
+
+import okhttp3.Call;
+import okhttp3.Headers;
+import okhttp3.MediaType;
+import okhttp3.MultipartBody;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okio.Buffer;
 
 import static org.fest.assertions.api.Assertions.assertThat;
 import static org.mockito.Mockito.any;
@@ -77,6 +78,7 @@ public class NetworkingModuleTest {
   @Test
   public void testGetWithoutHeaders() throws Exception {
     OkHttpClient httpClient = mock(OkHttpClient.class);
+
     when(httpClient.newCall(any(Request.class))).thenAnswer(new Answer<Object>() {
       @Override
       public Object answer(InvocationOnMock invocation) throws Throwable {
@@ -87,8 +89,10 @@ public class NetworkingModuleTest {
     OkHttpClient.Builder clientBuilder = mock(OkHttpClient.Builder.class);
     when(clientBuilder.build()).thenReturn(httpClient);
     when(httpClient.newBuilder()).thenReturn(clientBuilder);
+    OkHttpClientProvider clientProvider = mock(OkHttpClientProvider.class);
+    when(clientProvider.get()).thenReturn(httpClient);
     NetworkingModule networkingModule =
-      new NetworkingModule(mock(ReactApplicationContext.class), "", httpClient);
+      new NetworkingModule(mock(ReactApplicationContext.class), "", clientProvider);
 
     networkingModule.sendRequest(
       "GET",
@@ -119,7 +123,9 @@ public class NetworkingModuleTest {
     OkHttpClient.Builder clientBuilder = mock(OkHttpClient.Builder.class);
     when(clientBuilder.build()).thenReturn(httpClient);
     when(httpClient.newBuilder()).thenReturn(clientBuilder);
-    NetworkingModule networkingModule = new NetworkingModule(context, "", httpClient);
+    OkHttpClientProvider clientProvider = mock(OkHttpClientProvider.class);
+    when(clientProvider.get()).thenReturn(httpClient);
+    NetworkingModule networkingModule = new NetworkingModule(context, "", clientProvider);
 
     List<JavaOnlyArray> invalidHeaders = Arrays.asList(JavaOnlyArray.of("foo"));
 
@@ -149,7 +155,9 @@ public class NetworkingModuleTest {
     OkHttpClient.Builder clientBuilder = mock(OkHttpClient.Builder.class);
     when(clientBuilder.build()).thenReturn(httpClient);
     when(httpClient.newBuilder()).thenReturn(clientBuilder);
-    NetworkingModule networkingModule = new NetworkingModule(context, "", httpClient);
+    OkHttpClientProvider clientProvider = mock(OkHttpClientProvider.class);
+    when(clientProvider.get()).thenReturn(httpClient);
+    NetworkingModule networkingModule = new NetworkingModule(context, "", clientProvider);
 
     JavaOnlyMap body = new JavaOnlyMap();
     body.putString("string", "This is request body");
@@ -211,8 +219,10 @@ public class NetworkingModuleTest {
     OkHttpClient.Builder clientBuilder = mock(OkHttpClient.Builder.class);
     when(clientBuilder.build()).thenReturn(httpClient);
     when(httpClient.newBuilder()).thenReturn(clientBuilder);
+    OkHttpClientProvider clientProvider = mock(OkHttpClientProvider.class);
+    when(clientProvider.get()).thenReturn(httpClient);
     NetworkingModule networkingModule =
-      new NetworkingModule(mock(ReactApplicationContext.class), "", httpClient);
+      new NetworkingModule(mock(ReactApplicationContext.class), "", clientProvider);
 
     JavaOnlyMap body = new JavaOnlyMap();
     body.putString("string", "This is request body");
@@ -253,8 +263,10 @@ public class NetworkingModuleTest {
     OkHttpClient.Builder clientBuilder = mock(OkHttpClient.Builder.class);
     when(clientBuilder.build()).thenReturn(httpClient);
     when(httpClient.newBuilder()).thenReturn(clientBuilder);
+    OkHttpClientProvider clientProvider = mock(OkHttpClientProvider.class);
+    when(clientProvider.get()).thenReturn(httpClient);
     NetworkingModule networkingModule =
-      new NetworkingModule(mock(ReactApplicationContext.class), "", httpClient);
+      new NetworkingModule(mock(ReactApplicationContext.class), "", clientProvider);
 
     List<JavaOnlyArray> headers = Arrays.asList(
         JavaOnlyArray.of("Accept", "text/plain"),
@@ -312,8 +324,10 @@ public class NetworkingModuleTest {
     OkHttpClient.Builder clientBuilder = mock(OkHttpClient.Builder.class);
     when(clientBuilder.build()).thenReturn(httpClient);
     when(httpClient.newBuilder()).thenReturn(clientBuilder);
+    OkHttpClientProvider clientProvider = mock(OkHttpClientProvider.class);
+    when(clientProvider.get()).thenReturn(httpClient);
     NetworkingModule networkingModule =
-      new NetworkingModule(mock(ReactApplicationContext.class), "", httpClient);
+      new NetworkingModule(mock(ReactApplicationContext.class), "", clientProvider);
     networkingModule.sendRequest(
       "POST",
       "http://someurl/uploadFoo",
@@ -377,8 +391,10 @@ public class NetworkingModuleTest {
     OkHttpClient.Builder clientBuilder = mock(OkHttpClient.Builder.class);
     when(clientBuilder.build()).thenReturn(httpClient);
     when(httpClient.newBuilder()).thenReturn(clientBuilder);
+    OkHttpClientProvider clientProvider = mock(OkHttpClientProvider.class);
+    when(clientProvider.get()).thenReturn(httpClient);
     NetworkingModule networkingModule =
-      new NetworkingModule(mock(ReactApplicationContext.class), "", httpClient);
+      new NetworkingModule(mock(ReactApplicationContext.class), "", clientProvider);
     networkingModule.sendRequest(
       "POST",
       "http://someurl/uploadFoo",
@@ -479,9 +495,10 @@ public class NetworkingModuleTest {
     OkHttpClient.Builder clientBuilder = mock(OkHttpClient.Builder.class);
     when(clientBuilder.build()).thenReturn(httpClient);
     when(httpClient.newBuilder()).thenReturn(clientBuilder);
-
+    OkHttpClientProvider clientProvider = mock(OkHttpClientProvider.class);
+    when(clientProvider.get()).thenReturn(httpClient);
     NetworkingModule networkingModule =
-      new NetworkingModule(mock(ReactApplicationContext.class), "", httpClient);
+      new NetworkingModule(mock(ReactApplicationContext.class), "", clientProvider);
     networkingModule.sendRequest(
       "POST",
       "http://someurl/uploadFoo",
@@ -541,8 +558,10 @@ public class NetworkingModuleTest {
     OkHttpClient.Builder clientBuilder = mock(OkHttpClient.Builder.class);
     when(clientBuilder.build()).thenReturn(httpClient);
     when(httpClient.newBuilder()).thenReturn(clientBuilder);
+    OkHttpClientProvider clientProvider = mock(OkHttpClientProvider.class);
+    when(clientProvider.get()).thenReturn(httpClient);
     NetworkingModule networkingModule =
-      new NetworkingModule(mock(ReactApplicationContext.class), "", httpClient);
+      new NetworkingModule(mock(ReactApplicationContext.class), "", clientProvider);
     networkingModule.initialize();
 
     for (int idx = 0; idx < requests; idx++) {
@@ -592,8 +611,10 @@ public class NetworkingModuleTest {
     OkHttpClient.Builder clientBuilder = mock(OkHttpClient.Builder.class);
     when(clientBuilder.build()).thenReturn(httpClient);
     when(httpClient.newBuilder()).thenReturn(clientBuilder);
+    OkHttpClientProvider clientProvider = mock(OkHttpClientProvider.class);
+    when(clientProvider.get()).thenReturn(httpClient);
     NetworkingModule networkingModule =
-      new NetworkingModule(mock(ReactApplicationContext.class), "", httpClient);
+      new NetworkingModule(mock(ReactApplicationContext.class), "", clientProvider);
 
     for (int idx = 0; idx < requests; idx++) {
       networkingModule.sendRequest(

--- a/ReactAndroid/src/test/java/com/facebook/react/shell/MainPackageConfigTest.java
+++ b/ReactAndroid/src/test/java/com/facebook/react/shell/MainPackageConfigTest.java
@@ -1,0 +1,27 @@
+package com.facebook.react.shell;
+
+import com.facebook.react.modules.network.DefaultOkHttpProvider;
+import com.facebook.react.modules.network.OkHttpClientProvider;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+
+public class MainPackageConfigTest {
+
+  OkHttpClientProvider httpProvider = mock(OkHttpClientProvider.class);
+
+  @Test
+  public void setOkHttpClientProvider() throws Exception {
+    MainPackageConfig config = new MainPackageConfig.Builder().setOkHttpClientProvider(httpProvider).build();
+    assertEquals(config.getOkHttpClientProvider(), httpProvider);
+  }
+
+  @Test
+  public void shouldReturnDefaultProviderIfNotInjected() throws Exception {
+    MainPackageConfig config = new MainPackageConfig.Builder().build();
+    assertEquals(config.getOkHttpClientProvider().getClass(), DefaultOkHttpProvider.class);
+  }
+
+}


### PR DESCRIPTION
Summary:
react-android looks for bold variation of custom font file, if fontWeight is >= 500. If that specific file is missing in assets directory, it falls back to default (roboto) bold font, instead of regular variation of custom font.

This becomes a problem with libraries like react-navigation, where header title fontWeight is set in the library. Library user will set custom font and keeps the regular variation of the font and expects it to display font correctly. But it shows up default font instead of custom font. 

**Test plan **
notoserif_bold.ttf exists
<img width="524" alt="natoserif_bold_font_exist" src="https://cloud.githubusercontent.com/assets/3292479/23543098/9dc15b5a-0016-11e7-9c6f-44e78c6d664d.png">

notoserif_bold.ttf missing, before fix
<img width="523" alt="natoserif_bold_font_is_missing_before_fix" src="https://cloud.githubusercontent.com/assets/3292479/23543121/b5bdc266-0016-11e7-8f1e-6b764e5a34e7.png">

notoserif_bold missing, after fix
<img width="518" alt="natoserif_bold_font_is_missing_after_fix" src="https://cloud.githubusercontent.com/assets/3292479/23543141/cef2bf66-0016-11e7-859c-8d2440de3585.png">




