### PR TITLE
Android: Fix clipping of text which contains unicode emoticons on Android 4.4.2

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextShadowNode.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextShadowNode.java
@@ -81,11 +81,10 @@ public class ReactTextShadowNode extends LayoutShadowNode {
 
   public static final int DEFAULT_TEXT_SHADOW_COLOR = 0x55000000;
 
-  private static final TextPaint sTextPaintInstance = new TextPaint();
-
-  static {
-    sTextPaintInstance.setFlags(TextPaint.ANTI_ALIAS_FLAG);
-  }
+  // It's important to pass the ANTI_ALIAS_FLAG flag to the constructor rather than setting it
+  // later by calling setFlags. This is because the latter approach triggers a bug on Android 4.4.2.
+  // The bug is that unicode emoticons aren't measured properly which causes text to be clipped.
+  private static final TextPaint sTextPaintInstance = new TextPaint(TextPaint.ANTI_ALIAS_FLAG);
 
   private static class SetSpanOperation {
     protected int start, end;


### PR DESCRIPTION
Fixes #11592

This bug was seen on a Galaxy S4 running Android 4.4.2. On this device, Android's `Layout.getDesiredWidth` method doesn't correctly measure text that contains unicode emoticons. It appears to think the emoticons take up 0 space.

Setting ANTI_ALIAS_FLAG in the TextPaint's constructor instead of setting it later with setFlags works around the Android bug.

**Test plan (required)**

My team uses this fix in our app.

Adam Comella
Microsoft Corp.