### PR TITLE
Run install third party script as part of the xcode build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,5 @@ node_modules
 # Test generated files
 /ReactAndroid/src/androidTest/assets/AndroidTestBundle.js
 *.js.meta
+
+/third-party

--- a/React/ReactCxx.xcodeproj/project.pbxproj
+++ b/React/ReactCxx.xcodeproj/project.pbxproj
@@ -2976,6 +2976,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 139D7E8E1E25C6D100323FB7 /* Build configuration list for PBXNativeTarget "double-conversion" */;
 			buildPhases = (
+				190EE32F1E6A43DE00A8543A /* Install Third Party */,
 				139D7E841E25C6D100323FB7 /* Sources */,
 				139D7E851E25C6D100323FB7 /* Frameworks */,
 				139D7E861E25C6D100323FB7 /* CopyFiles */,
@@ -3242,6 +3243,20 @@
 			shellPath = /bin/sh;
 			shellScript = "if [[ \"$CONFIGURATION\" == \"Debug\" ]] && [[ -d \"/tmp/RCTJSCProfiler\" ]]; then\n   find \"${CONFIGURATION_BUILD_DIR}\" -name '*.app' | xargs -I{} sh -c 'cp -r /tmp/RCTJSCProfiler \"$1\"' -- {}\nfi";
 			showEnvVarsInLog = 0;
+		};
+		190EE32F1E6A43DE00A8543A /* Install Third Party */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Install Third Party";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "cd $SRCROOT/..\n./ios-install-third-party.sh";
 		};
 		2D6948201DA3042200B3FA97 /* Include RCTJSCProfiler */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION
Runs the `./ios-install-third-party.sh` script as part of the build process to avoid having to do it manually when building the cxx bridge with xcode. Also added the third-party dir to gitignore.

**Test plan**
Tested that just building works when the third-party dir is missing.