### PR TITLE
Replace the outdated flag

### DIFF
--- a/docs/SignedAPKAndroid.md
+++ b/docs/SignedAPKAndroid.md
@@ -89,10 +89,10 @@ The generated APK can be found under `android/app/build/outputs/apk/app-release.
 Before uploading the release build to the Play Store, make sure you test it thoroughly. Install it on the device using:
 
 ```sh
-$ react-native run-android --configuration=release
+$ react-native run-android --variant=release
 ```
 
-Note that `--configuration=release` is only available if you've set up signing as described above.
+Note that `--variant=release` is only available if you've set up signing as described above.
 
 You can kill any running packager instances, all your and framework JavaScript code is bundled in the APK's assets.
 


### PR DESCRIPTION
**Motivation**

Documentation was referring to an outdated command line flag for building a signed APK. https://github.com/facebook/react-native/issues/12698

**Test plan**

This PR does not contain any code changes.

**Screenshot**

![generating_signed_apk](https://cloud.githubusercontent.com/assets/8265228/23576976/5f3f76b8-0107-11e7-820e-2cd801e32dfd.png)

