### PR TITLE
Support for defineEnumerableProperties

### DIFF
--- a/packager/src/Resolver/polyfills/babelHelpers.js
+++ b/packager/src/Resolver/polyfills/babelHelpers.js
@@ -63,6 +63,16 @@ babelHelpers.createClass = (function () {
   };
 })();
 
+babelHelpers.defineEnumerableProperties = function(obj, descs) {
+  for (var key in descs) {
+    var desc = descs[key];
+    desc.configurable = (desc.enumerable = true);
+    if ('value' in desc) desc.writable = true;
+    Object.defineProperty(obj, key, desc);
+  }
+  return obj;
+};
+
 babelHelpers.defineProperty = function (obj, key, value) {
   if (key in obj) {
     Object.defineProperty(obj, key, {


### PR DESCRIPTION
**Motivation**
detailed in #12702.

**Test plan**
1) running [a piece of code](https://github.com/mobxjs/mobx/issues/839#issuecomment-284153126) that utilizes the helper without any modifications on the react native package results an error being thrown.

![b589a71c-0041-11e7-9d47-cb79efff3ba5](https://cloud.githubusercontent.com/assets/23000873/23579517/3c8fe992-0100-11e7-9eb5-93c47f3df3e0.png)

2) updating the list of helpers available by adding the definition of `defineEnumerableProperties` as provided by babel [babel/babel/packages/babel-helpers/src/helpers.js](https://github.com/babel/babel/blob/master/packages/babel-helpers/src/helpers.js#L275-L285) results no errors.

![kapture 2017-03-04 at 16 48 35](https://cloud.githubusercontent.com/assets/23000873/23579520/457b8ca0-0100-11e7-8ca4-c704c6e9631f.gif)