### PR TITLE
VirtualizedList - trigger this.props.onContentSizeChange

### DIFF
--- a/Libraries/CustomComponents/Lists/VirtualizedList.js
+++ b/Libraries/CustomComponents/Lists/VirtualizedList.js
@@ -539,6 +539,9 @@ class VirtualizedList extends React.PureComponent<OptionalProps, Props, State> {
   }
 
   _onContentSizeChange = (width: number, height: number) => {
+    if (this.props.onContentSizeChange) {
+      this.props.onContentSizeChange(width, height);
+    }
     this._scrollMetrics.contentLength = this._selectLength({height, width});
     this._updateCellsToRenderBatcher.schedule();
   };


### PR DESCRIPTION
Have tested this and works fine 
```
<SectionList 
    onLayout={this.onLayout}
    ref={thisRef => this.listView = thisRef}
    ListFooterComponent={this.renderFooter}
    renderItem={this._renderRow}
    onScroll={this._onScroll}
    onContentSizeChange={this.contentSizeChanged}
    renderSectionHeader={this._renderSectionHeader}
    sections={this.props.data} 
/>