### PR TITLE
Inherit WebSocket protocol scheme in case of http and https

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/modules/websocket/WebSocketModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/websocket/WebSocketModule.java
@@ -281,6 +281,8 @@ public class WebSocketModule extends ReactContextBaseJavaModule {
         scheme += "https";
       } else if (requestURI.getScheme().equals("ws")) {
         scheme += "http";
+      } else if (requestURI.getScheme().equals("http") || requestURI.getScheme().equals("https")) {
+        scheme += requestURI.getScheme();
       }
 
       if (requestURI.getPort() != -1) {


### PR DESCRIPTION
**Motivation**

Currently, when supplying a URL with protocol scheme `http` or `https` to the WebSocket module:

```
new WebSocket("http://10.0.2.2:8080")
```
it will result in the following error:

![Unable to get cookie from http://10.0.2.2:8080](https://cloud.githubusercontent.com/assets/661993/23584771/f3f9573e-011f-11e7-839e-eb100c8cb5d2.png)

When a WebSocket URL with protocol scheme `http` or `https` is used the method [`getDefaultOrigin`](https://github.com/facebook/react-native/blob/be4afdde37ab6ff6ebe573821745887fd3edfb05/ReactAndroid/src/main/java/com/facebook/react/modules/websocket/WebSocketModule.java#L274-L301) will fail to substitute it and just returns a URL with empty protocol scheme leading to this opaque exception.

Thus, in case of `http` or `https` it should just inherit the protocol scheme since the WebSocket is responsible for upgrading the HTTP/HTTPS connection to the WebSocket protocol.

**Test plan**

If anything this change makes the method more robust. The WebSocket endpoint can now be used with `http`, `https`, `ws` and `wss`.