### PR TITLE
Update Podfile documentation for RN >= 0.42.0

### DIFF
--- a/docs/IntegrationWithExistingApps.md
+++ b/docs/IntegrationWithExistingApps.md
@@ -217,6 +217,8 @@ target 'NumberTileGame' do
     'RCTWebSocket', # needed for debugging
     # Add any other subspecs you want to use in your project
   ]
+  # Explicitly include Yoga if you are using RN >= 0.42.0
+  pod "Yoga", :path => "../node_modules/react-native/ReactCommon/yoga"
 
 end
 ```
@@ -242,35 +244,13 @@ target 'swift-2048' do
     'RCTWebSocket', # needed for debugging
     # Add any other subspecs you want to use in your project
   ]
+  # Explicitly include Yoga if you are using RN >= 0.42.0
+  pod "Yoga", :path => "../node_modules/react-native/ReactCommon/yoga"
 
 end
 ```
 
 <block class="objc swift" />
-
-> **Note:** From React Native `0.42.0` you have to explicitly include Yoga in your Podfile. Here is an example:
-
-```
-source 'https://github.com/CocoaPods/Specs.git'
-
-# Required for Swift apps
-platform :ios, '8.0'
-use_frameworks!
-
-# The target name is most likely the name of your project.
-target 'your-project' do
-
-  react_native_path = "../node_modules/react-native"
-  pod 'React', :path => react_native_path, :subspecs => [
-    'Core',
-    'RCTText',
-    'RCTNetwork',
-    'RCTWebSocket',
-  ]
-  # Explicitly include Yoga
-  pod "Yoga", :path => "#{react_native_path}/ReactCommon/yoga"
-end
-```
 
 #### Pod Installation
 

--- a/docs/IntegrationWithExistingApps.md
+++ b/docs/IntegrationWithExistingApps.md
@@ -210,15 +210,13 @@ target 'NumberTileGame' do
 
   # Your 'node_modules' directory is probably in the root of your project,
   # but if not, adjust the `:path` accordingly
-  react_native_path = "../node_modules/react-native"
-  pod 'React', :path => react_native_path, :subspecs => [
+  pod 'React', :path => '../node_modules/react-native', :subspecs => [
     'Core',
     'RCTText',
     'RCTNetwork',
     'RCTWebSocket', # needed for debugging
     # Add any other subspecs you want to use in your project
   ]
-  pod "Yoga", :path => "#{react_native_path}/ReactCommon/yoga"
 
 end
 ```
@@ -251,6 +249,30 @@ end
 ```
 
 <block class="objc swift" />
+
+> **Note:** From React Native `0.42.0` you have to include explicitly Yoga in your Podfile. Here is an exemple:
+
+```
+source 'https://github.com/CocoaPods/Specs.git'
+
+# Required for Swift apps
+platform :ios, '8.0'
+use_frameworks!
+
+# The target name is most likely the name of your project.
+target 'your-project' do
+
+  react_native_path = "../node_modules/react-native"
+  pod 'React', :path => react_native_path, :subspecs => [
+    'Core',
+    'RCTText',
+    'RCTNetwork',
+    'RCTWebSocket',
+  ]
+  # Explicitly include Yoga
+  pod "Yoga", :path => "#{react_native_path}/ReactCommon/yoga"
+end
+```
 
 #### Pod Installation
 

--- a/docs/IntegrationWithExistingApps.md
+++ b/docs/IntegrationWithExistingApps.md
@@ -248,7 +248,7 @@ end
 
 <block class="objc swift" />
 
-> **Note:** From React Native `0.42.0` you have to include explicitly Yoga in your Podfile. Here is an exemple:
+> **Note:** From React Native `0.42.0` you have to explicitly include Yoga in your Podfile. Here is an example:
 
 ```
 source 'https://github.com/CocoaPods/Specs.git'

--- a/docs/IntegrationWithExistingApps.md
+++ b/docs/IntegrationWithExistingApps.md
@@ -221,8 +221,6 @@ target 'NumberTileGame' do
 end
 ```
 
-> **Note:** From RN 0.42.0 you have to include explicitly Yoga in your Podfile.
-
 <block class="swift" />
 
 ```

--- a/docs/IntegrationWithExistingApps.md
+++ b/docs/IntegrationWithExistingApps.md
@@ -210,16 +210,20 @@ target 'NumberTileGame' do
 
   # Your 'node_modules' directory is probably in the root of your project,
   # but if not, adjust the `:path` accordingly
-  pod 'React', :path => '../node_modules/react-native', :subspecs => [
+  react_native_path = "../node_modules/react-native"
+  pod 'React', :path => react_native_path, :subspecs => [
     'Core',
     'RCTText',
     'RCTNetwork',
     'RCTWebSocket', # needed for debugging
     # Add any other subspecs you want to use in your project
   ]
+  pod "Yoga", :path => "#{react_native_path}/ReactCommon/yoga"
 
 end
 ```
+
+> **Note:** From RN 0.42.0 you have to include explicitly Yoga in your Podfile.
 
 <block class="swift" />
 


### PR DESCRIPTION
I've updated the documentation that gives an example of Podfile adding a note that from React Native 0.42.0, users have to explicitly include Yoga in their Podfile.

I didn't want to modify existing `Podfile` from this documentation because they refer to `Podfile` from existing projects that do not use RN 0.42.0. So I just added a note and an example to explain how to include Yoga.

This PR is to fix the following issue: https://github.com/facebook/react-native/issues/12670