### PR TITLE
upgrade image-size version fix caculate webp image size bugs

### DIFF
--- a/package.json
+++ b/package.json
@@ -165,7 +165,7 @@
     "fs-extra": "^0.26.2",
     "glob": "^5.0.15",
     "graceful-fs": "^4.1.3",
-    "image-size": "^0.3.5",
+    "image-size": "^0.5.1",
     "immutable": "~3.7.6",
     "imurmurhash": "^0.1.4",
     "inquirer": "^0.12.0",


### PR DESCRIPTION
When I try to use webp for app. But some webp images get an error message `unsupported file type` by image-size@0.3.5.

And I in image-size repo I found a issue https://github.com/image-size/image-size/issues/65.
This is the same problem.

And try image-size^0.5.1 the error fixed.

![image](https://cloud.githubusercontent.com/assets/13161470/23597366/403a3070-026d-11e7-8666-f4357f1eee73.png)