### PR TITLE
Website: Fix aspect ratio of icons in the showcase on homepage

### DIFF
--- a/website/styles/_showcase.scss
+++ b/website/styles/_showcase.scss
@@ -18,7 +18,8 @@
 }
 
 .home-showcase-section .showcase img {
-  width: 110px;
+  width: 100px;
+  height: 100px;
   border-radius: 20px;
 }
 


### PR DESCRIPTION
I ran the website locally and noticed the icons in the showcase on the homepage look squashed:

![screenshot 2017-03-07 22 28 23](https://cloud.githubusercontent.com/assets/346214/23681227/18fbec6e-0386-11e7-9658-93907cbb3337.png)

Made the icons consistent with /showcase.html:

https://github.com/facebook/react-native/blob/d54c7f82822f623a903858d8d686d7f14ec71aae/website/styles/_showcase.scss#L74

Test plan:

![screenshot 2017-03-07 22 28 33](https://cloud.githubusercontent.com/assets/346214/23681235/264e05a0-0386-11e7-92db-8f26cca11bf3.png)

