### PR TITLE
[WIP] [Not for Merge] Disable ReactPerf and Update Systrace React Integration

### DIFF
--- a/Libraries/Core/InitializeCore.js
+++ b/Libraries/Core/InitializeCore.js
@@ -99,6 +99,9 @@ if (!global.process.env.NODE_ENV) {
 // Set up profile
 const Systrace = require('Systrace');
 Systrace.setEnabled(global.__RCTProfileIsProfiling || false);
+if (__DEV__) {
+  global.performance = Systrace.getUserTimingPolyfill();
+}
 
 // Set up console
 const ExceptionsManager = require('ExceptionsManager');

--- a/Libraries/Performance/RCTRenderingPerf.js
+++ b/Libraries/Performance/RCTRenderingPerf.js
@@ -11,9 +11,6 @@
  */
 'use strict';
 
-var ReactDebugTool = require('ReactDebugTool');
-var ReactPerf = require('ReactPerf');
-
 var invariant = require('fbjs/lib/invariant');
 var performanceNow = require('fbjs/lib/performanceNow');
 
@@ -24,22 +21,6 @@ type perfModule = {
 
 var perfModules = [];
 var enabled = false;
-var lastRenderStartTime = 0;
-var totalRenderDuration = 0;
-
-var RCTRenderingPerfDevtool = {
-  onBeginLifeCycleTimer(debugID, timerType) {
-    if (timerType === 'render') {
-      lastRenderStartTime = performanceNow();
-    }
-  },
-  onEndLifeCycleTimer(debugID, timerType) {
-    if (timerType === 'render') {
-      var lastRenderDuration = performanceNow() - lastRenderStartTime;
-      totalRenderDuration += lastRenderDuration;
-    }
-  },
-};
 
 var RCTRenderingPerf = {
   // Once perf is enabled, it stays enabled
@@ -52,9 +33,6 @@ var RCTRenderingPerf = {
     if (!enabled) {
       return;
     }
-
-    ReactPerf.start();
-    ReactDebugTool.addHook(RCTRenderingPerfDevtool);
     perfModules.forEach((module) => module.start());
   },
 
@@ -62,16 +40,6 @@ var RCTRenderingPerf = {
     if (!enabled) {
       return;
     }
-
-    ReactPerf.stop();
-    ReactPerf.printInclusive();
-    ReactPerf.printWasted();
-    ReactDebugTool.removeHook(RCTRenderingPerfDevtool);
-
-    console.log(`Total time spent in render(): ${totalRenderDuration.toFixed(2)} ms`);
-    lastRenderStartTime = 0;
-    totalRenderDuration = 0;
-
     perfModules.forEach((module) => module.stop());
   },
 

--- a/Libraries/Renderer/src/renderers/native/NativeMethodsMixin.js
+++ b/Libraries/Renderer/src/renderers/native/NativeMethodsMixin.js
@@ -11,7 +11,6 @@
  */
 'use strict';
 
-var ReactNative = require('ReactNative');
 var ReactNativeAttributePayload = require('ReactNativeAttributePayload');
 var TextInputState = require('TextInputState');
 var UIManager = require('UIManager');
@@ -84,6 +83,7 @@ var NativeMethodsMixin = {
    * prop](docs/view.html#onlayout) instead.
    */
   measure: function(callback: MeasureOnSuccessCallback) {
+    var ReactNative = require('ReactNative');
     UIManager.measure(
       ReactNative.findNodeHandle(this),
       mountSafeCallback(this, callback)
@@ -106,6 +106,7 @@ var NativeMethodsMixin = {
    * has been completed in native.
    */
   measureInWindow: function(callback: MeasureInWindowOnSuccessCallback) {
+    var ReactNative = require('ReactNative');
     UIManager.measureInWindow(
       ReactNative.findNodeHandle(this),
       mountSafeCallback(this, callback)
@@ -125,6 +126,7 @@ var NativeMethodsMixin = {
     onSuccess: MeasureLayoutOnSuccessCallback,
     onFail: () => void /* currently unused */
   ) {
+    var ReactNative = require('ReactNative');
     UIManager.measureLayout(
       ReactNative.findNodeHandle(this),
       relativeToNativeNode,
@@ -149,6 +151,7 @@ var NativeMethodsMixin = {
       this.viewConfig.validAttributes
     );
 
+    var ReactNative = require('ReactNative');
     UIManager.updateView(
       (ReactNative.findNodeHandle(this) : any),
       this.viewConfig.uiViewClassName,
@@ -161,6 +164,7 @@ var NativeMethodsMixin = {
    * will depend on the platform and type of view.
    */
   focus: function() {
+    var ReactNative = require('ReactNative');
     TextInputState.focusTextInput(ReactNative.findNodeHandle(this));
   },
 
@@ -168,6 +172,7 @@ var NativeMethodsMixin = {
    * Removes focus from an input or view. This is the opposite of `focus()`.
    */
   blur: function() {
+    var ReactNative = require('ReactNative');
     TextInputState.blurTextInput(ReactNative.findNodeHandle(this));
   },
 };

--- a/Libraries/Renderer/src/renderers/native/ReactNative.js
+++ b/Libraries/Renderer/src/renderers/native/ReactNative.js
@@ -12,4 +12,4 @@
 'use strict';
 
 // TODO (bvaughn) Enable Fiber experiement via ReactNativeFeatureFlags
-module.exports = require('ReactNativeStack');
+module.exports = require('ReactNativeFiber');

--- a/Libraries/Renderer/src/renderers/native/ReactNativeFeatureFlags.js
+++ b/Libraries/Renderer/src/renderers/native/ReactNativeFeatureFlags.js
@@ -12,7 +12,7 @@
 'use strict';
 
 var ReactNativeFeatureFlags = {
-  useFiber: false,
+  useFiber: true,
 };
 
 module.exports = ReactNativeFeatureFlags;

--- a/Libraries/Renderer/src/renderers/shared/ReactFiberComponentTreeHook.js
+++ b/Libraries/Renderer/src/renderers/shared/ReactFiberComponentTreeHook.js
@@ -1,0 +1,73 @@
+/**
+ * Copyright 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ * @providesModule ReactFiberComponentTreeHook
+ */
+
+'use strict';
+
+var ReactTypeOfWork = require('ReactTypeOfWork');
+var {
+  IndeterminateComponent,
+  FunctionalComponent,
+  ClassComponent,
+  HostComponent,
+} = ReactTypeOfWork;
+var getComponentName = require('getComponentName');
+
+import type { Fiber } from 'ReactFiber';
+
+function describeComponentFrame(name, source: any, ownerName) {
+  return '\n    in ' + (name || 'Unknown') + (
+    source ?
+      ' (at ' + source.fileName.replace(/^.*[\\\/]/, '') + ':' +
+      source.lineNumber + ')' :
+    ownerName ?
+      ' (created by ' + ownerName + ')' :
+      ''
+  );
+}
+
+function describeFiber(fiber : Fiber) : string {
+  switch (fiber.tag) {
+    case IndeterminateComponent:
+    case FunctionalComponent:
+    case ClassComponent:
+    case HostComponent:
+      var owner = fiber._debugOwner;
+      var source = fiber._debugSource;
+      var name = getComponentName(fiber);
+      var ownerName = null;
+      if (owner) {
+        ownerName = getComponentName(owner);
+      }
+      return describeComponentFrame(name, source, ownerName);
+    default:
+      return '';
+  }
+}
+
+// This function can only be called with a work-in-progress fiber and
+// only during begin or complete phase. Do not call it under any other
+// circumstances.
+function getStackAddendumByWorkInProgressFiber(workInProgress : Fiber) : string {
+  var info = '';
+  var node = workInProgress;
+  do {
+    info += describeFiber(node);
+    // Otherwise this return pointer might point to the wrong tree:
+    node = node.return;
+  } while (node);
+  return info;
+}
+
+module.exports = {
+  getStackAddendumByWorkInProgressFiber,
+  describeComponentFrame,
+};

--- a/Libraries/Renderer/src/renderers/shared/fiber/ReactDebugFiberPerf.js
+++ b/Libraries/Renderer/src/renderers/shared/fiber/ReactDebugFiberPerf.js
@@ -1,0 +1,408 @@
+/**
+ * Copyright 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule ReactDebugFiberPerf
+ * @flow
+ */
+
+import type { Fiber } from 'ReactFiber';
+
+type MeasurementPhase =
+  'componentWillMount' |
+  'componentWillUnmount' |
+  'componentWillReceiveProps' |
+  'shouldComponentUpdate' |
+  'componentWillUpdate' |
+  'componentDidUpdate' |
+  'componentDidMount' |
+  'getChildContext';
+
+// Trust the developer to only use this with a __DEV__ check
+let ReactDebugFiberPerf = ((null: any): typeof ReactDebugFiberPerf);
+
+if (__DEV__) {
+  const {
+    HostRoot,
+    HostComponent,
+    HostText,
+    HostPortal,
+    YieldComponent,
+    Fragment,
+  } = require('ReactTypeOfWork');
+
+  const getComponentName = require('getComponentName');
+
+  // Prefix measurements so that it's possible to filter them.
+  // Longer prefixes are hard to read in DevTools.
+  const reactEmoji = '\u269B';
+  const warningEmoji = '\uD83D\uDED1';
+  const supportsUserTiming =
+    typeof performance !== 'undefined' &&
+    typeof performance.mark === 'function' &&
+    typeof performance.clearMarks === 'function' &&
+    typeof performance.measure === 'function' &&
+    typeof performance.clearMeasures === 'function';
+
+  // Keep track of current fiber so that we know the path to unwind on pause.
+  // TODO: this looks the same as nextUnitOfWork in scheduler. Can we unify them?
+  let currentFiber : Fiber | null = null;
+  // If we're in the middle of user code, which fiber and method is it?
+  // Reusing `currentFiber` would be confusing for this because user code fiber
+  // can change during commit phase too, but we don't need to unwind it (since
+  // lifecycles in the commit phase don't resemble a tree).
+  let currentPhase : MeasurementPhase | null = null;
+  let currentPhaseFiber : Fiber | null = null;
+  // Did lifecycle hook schedule an update? This is often a performance problem,
+  // so we will keep track of it, and include it in the report.
+  // Track commits caused by cascading updates.
+  let isCommitting : boolean = false;
+  let hasScheduledUpdateInCurrentCommit : boolean = false;
+  let hasScheduledUpdateInCurrentPhase : boolean = false;
+  let commitCountInCurrentWorkLoop : number = 0;
+  let effectCountInCurrentCommit : number = 0;
+  // During commits, we only show a measurement once per method name
+  // to avoid stretch the commit phase with measurement overhead.
+  const labelsInCurrentCommit : Set<string> = new Set();
+
+  const formatMarkName = (markName : string) => {
+    return `${reactEmoji} ${markName}`;
+  };
+
+  const formatLabel = (label : string, warning : string | null) => {
+    const prefix = warning ? `${warningEmoji} ` : `${reactEmoji} `;
+    const suffix = warning ? ` Warning: ${warning}` : '';
+    return `${prefix}${label}${suffix}`;
+  };
+
+  const beginMark = (markName : string) => {
+    performance.mark(formatMarkName(markName));
+  };
+
+  const clearMark = (markName : string) => {
+    performance.clearMarks(formatMarkName(markName));
+  };
+
+  const endMark = (label : string, markName : string, warning : string | null) => {
+    const formattedMarkName = formatMarkName(markName);
+    const formattedLabel = formatLabel(label, warning);
+    try {
+      performance.measure(formattedLabel, formattedMarkName);
+    } catch (err) {
+      // If previous mark was missing for some reason, this will throw.
+      // This could only happen if React crashed in an unexpected place earlier.
+      // Don't pile on with more errors.
+    }
+    // Clear marks immediately to avoid growing buffer.
+    performance.clearMarks(formattedMarkName);
+    performance.clearMeasures(formattedLabel);
+  };
+
+  const getFiberMarkName = (label : string, debugID : number) => {
+    return `${label} (#${debugID})`;
+  };
+
+  const getFiberLabel = (
+    componentName : string,
+    isMounted : boolean,
+    phase : MeasurementPhase | null,
+  ) => {
+    if (phase === null) {
+      // These are composite component total time measurements.
+      return `${componentName} [${isMounted ? 'update' : 'mount'}]`;
+    } else {
+      // Composite component methods.
+      return `${componentName}.${phase}`;
+    }
+  };
+
+  const beginFiberMark = (
+    fiber : Fiber,
+    phase : MeasurementPhase | null,
+  ) : boolean => {
+    const componentName = getComponentName(fiber) || 'Unknown';
+    const debugID = ((fiber._debugID : any) : number);
+    const isMounted = fiber.alternate !== null;
+    const label = getFiberLabel(componentName, isMounted, phase);
+
+    if (isCommitting && labelsInCurrentCommit.has(label)) {
+      // During the commit phase, we don't show duplicate labels because
+      // there is a fixed overhead for every measurement, and we don't
+      // want to stretch the commit phase beyond necessary.
+      return false;
+    }
+    labelsInCurrentCommit.add(label);
+
+    const markName = getFiberMarkName(label, debugID);
+    beginMark(markName);
+    return true;
+  };
+
+  const clearFiberMark = (fiber : Fiber, phase : MeasurementPhase | null) => {
+    const componentName = getComponentName(fiber) || 'Unknown';
+    const debugID = ((fiber._debugID : any) : number);
+    const isMounted = fiber.alternate !== null;
+    const label = getFiberLabel(componentName, isMounted, phase);
+    const markName = getFiberMarkName(label, debugID);
+    clearMark(markName);
+  };
+
+  const endFiberMark = (
+    fiber : Fiber,
+    phase : MeasurementPhase | null,
+    warning : string | null,
+  ) => {
+    const componentName = getComponentName(fiber) || 'Unknown';
+    const debugID = ((fiber._debugID : any) : number);
+    const isMounted = fiber.alternate !== null;
+    const label = getFiberLabel(componentName, isMounted, phase);
+    const markName = getFiberMarkName(label, debugID);
+    endMark(label, markName, warning);
+  };
+
+  const shouldIgnoreFiber = (fiber : Fiber) : boolean => {
+    // Host components should be skipped in the timeline.
+    // We could check typeof fiber.type, but does this work with RN?
+    switch (fiber.tag) {
+      case HostRoot:
+      case HostComponent:
+      case HostText:
+      case HostPortal:
+      case YieldComponent:
+      case Fragment:
+        return true;
+      default:
+        return false;
+    }
+  };
+
+  const clearPendingPhaseMeasurement = () => {
+    if (currentPhase !== null && currentPhaseFiber !== null) {
+      clearFiberMark(currentPhaseFiber, currentPhase);
+    }
+    currentPhaseFiber = null;
+    currentPhase = null;
+    hasScheduledUpdateInCurrentPhase = false;
+  };
+
+  const pauseTimers = () => {
+    // Stops all currently active measurements so that they can be resumed
+    // if we continue in a later deferred loop from the same unit of work.
+    let fiber = currentFiber;
+    while (fiber) {
+      if (fiber._debugIsCurrentlyTiming) {
+        endFiberMark(fiber, null, null);
+      }
+      fiber = fiber.return;
+    }
+  };
+
+  const resumeTimersRecursively = (fiber : Fiber) => {
+    if (fiber.return !== null) {
+      resumeTimersRecursively(fiber.return);
+    }
+    if (fiber._debugIsCurrentlyTiming) {
+      beginFiberMark(fiber, null);
+    }
+  };
+
+  const resumeTimers = () => {
+    // Resumes all measurements that were active during the last deferred loop.
+    if (currentFiber !== null) {
+      resumeTimersRecursively(currentFiber);
+    }
+  };
+
+  ReactDebugFiberPerf = {
+    recordEffect() : void {
+      effectCountInCurrentCommit++;
+    },
+
+    recordScheduleUpdate() : void {
+      if (isCommitting) {
+        hasScheduledUpdateInCurrentCommit = true;
+      }
+      if (
+        currentPhase !== null &&
+        currentPhase !== 'componentWillMount' &&
+        currentPhase !== 'componentWillReceiveProps'
+      ) {
+        hasScheduledUpdateInCurrentPhase = true;
+      }
+    },
+
+    startWorkTimer(fiber : Fiber) : void {
+      if (!supportsUserTiming || shouldIgnoreFiber(fiber)) {
+        return;
+      }
+      // If we pause, this is the fiber to unwind from.
+      currentFiber = fiber;
+      if (!beginFiberMark(fiber, null)) {
+        return;
+      }
+      fiber._debugIsCurrentlyTiming = true;
+    },
+
+    cancelWorkTimer(fiber : Fiber) : void {
+      if (!supportsUserTiming || shouldIgnoreFiber(fiber)) {
+        return;
+      }
+      // Remember we shouldn't complete measurement for this fiber.
+      // Otherwise flamechart will be deep even for small updates.
+      fiber._debugIsCurrentlyTiming = false;
+      clearFiberMark(fiber, null);
+    },
+
+    stopWorkTimer(fiber : Fiber) : void {
+      if (!supportsUserTiming || shouldIgnoreFiber(fiber)) {
+        return;
+      }
+      // If we pause, its parent is the fiber to unwind from.
+      currentFiber = fiber.return;
+      if (!fiber._debugIsCurrentlyTiming) {
+        return;
+      }
+      fiber._debugIsCurrentlyTiming = false;
+      endFiberMark(fiber, null, null);
+    },
+
+    startPhaseTimer(
+      fiber : Fiber,
+      phase : MeasurementPhase,
+    ) : void {
+      if (!supportsUserTiming) {
+        return;
+      }
+      clearPendingPhaseMeasurement();
+      if (!beginFiberMark(fiber, phase)) {
+        return;
+      }
+      currentPhaseFiber = fiber;
+      currentPhase = phase;
+    },
+
+    stopPhaseTimer() : void {
+      if (!supportsUserTiming) {
+        return;
+      }
+      if (currentPhase !== null && currentPhaseFiber !== null) {
+        const warning = hasScheduledUpdateInCurrentPhase ?
+          'Scheduled a cascading update' :
+          null;
+        endFiberMark(currentPhaseFiber, currentPhase, warning);
+      }
+      currentPhase = null;
+      currentPhaseFiber = null;
+    },
+
+    startWorkLoopTimer() : void {
+      if (!supportsUserTiming) {
+        return;
+      }
+      commitCountInCurrentWorkLoop = 0;
+      // This is top level call.
+      // Any other measurements are performed within.
+      beginMark('(React Tree Reconciliation)');
+      // Resume any measurements that were in progress during the last loop.
+      resumeTimers();
+    },
+
+    stopWorkLoopTimer() : void {
+      if (!supportsUserTiming) {
+        return;
+      }
+      const warning = commitCountInCurrentWorkLoop > 1 ?
+        'There were cascading updates' :
+        null;
+      commitCountInCurrentWorkLoop = 0;
+      // Pause any measurements until the next loop.
+      pauseTimers();
+      endMark(
+        '(React Tree Reconciliation)',
+        '(React Tree Reconciliation)',
+        warning,
+      );
+    },
+
+    startCommitTimer() : void {
+      if (!supportsUserTiming) {
+        return;
+      }
+      isCommitting = true;
+      hasScheduledUpdateInCurrentCommit = false;
+      labelsInCurrentCommit.clear();
+      beginMark('(Committing Changes)');
+    },
+
+    stopCommitTimer() : void {
+      if (!supportsUserTiming) {
+        return;
+      }
+
+      let warning = null;
+      if (hasScheduledUpdateInCurrentCommit) {
+        warning = 'Lifecycle hook scheduled a cascading update';
+      } else if (commitCountInCurrentWorkLoop > 0) {
+        warning = 'Caused by a cascading update in earlier commit';
+      }
+      hasScheduledUpdateInCurrentCommit = false;
+      commitCountInCurrentWorkLoop++;
+      isCommitting = false;
+      labelsInCurrentCommit.clear();
+
+      endMark(
+        '(Committing Changes)',
+        '(Committing Changes)',
+        warning,
+      );
+    },
+
+    startCommitHostEffectsTimer() : void {
+      if (!supportsUserTiming) {
+        return;
+      }
+      effectCountInCurrentCommit = 0;
+      beginMark('(Committing Host Effects)');
+    },
+
+    stopCommitHostEffectsTimer() : void {
+      if (!supportsUserTiming) {
+        return;
+      }
+      const count = effectCountInCurrentCommit;
+      effectCountInCurrentCommit = 0;
+      endMark(
+        `(Committing Host Effects: ${count} Total)`,
+        '(Committing Host Effects)',
+        null,
+      );
+    },
+
+    startCommitLifeCyclesTimer() : void {
+      if (!supportsUserTiming) {
+        return;
+      }
+      effectCountInCurrentCommit = 0;
+      beginMark('(Calling Lifecycle Methods)');
+    },
+
+    stopCommitLifeCyclesTimer() : void {
+      if (!supportsUserTiming) {
+        return;
+      }
+      const count = effectCountInCurrentCommit;
+      effectCountInCurrentCommit = 0;
+      endMark(
+        `(Calling Lifecycle Methods: ${count} Total)`,
+        '(Calling Lifecycle Methods)',
+        null,
+      );
+    },
+  };
+}
+
+module.exports = ReactDebugFiberPerf;

--- a/Libraries/Renderer/src/renderers/shared/fiber/ReactFiber.js
+++ b/Libraries/Renderer/src/renderers/shared/fiber/ReactFiber.js
@@ -60,6 +60,7 @@ export type Fiber = {
   _debugID ?: DebugID,
   _debugSource ?: Source | null,
   _debugOwner ?: Fiber | ReactInstance | null, // Stack compatible
+  _debugIsCurrentlyTiming ?: boolean,
 
   // These first fields are conceptually members of an Instance. This used to
   // be split into a separate type and intersected with the other Fiber fields,
@@ -223,6 +224,7 @@ var createFiber = function(tag : TypeOfWork, key : null | string) : Fiber {
     fiber._debugID = debugCounter++;
     fiber._debugSource = null;
     fiber._debugOwner = null;
+    fiber._debugIsCurrentlyTiming = false;
     if (typeof Object.preventExtensions === 'function') {
       Object.preventExtensions(fiber);
     }

--- a/Libraries/Renderer/src/renderers/shared/fiber/ReactFiberContext.js
+++ b/Libraries/Renderer/src/renderers/shared/fiber/ReactFiberContext.js
@@ -35,6 +35,11 @@ const {
 if (__DEV__) {
   var checkReactTypeSpec = require('checkReactTypeSpec');
   var ReactDebugCurrentFrame = require('react/lib/ReactDebugCurrentFrame');
+  var ReactDebugCurrentFiber = require('ReactDebugCurrentFiber');
+  var {
+    startPhaseTimer,
+    stopPhaseTimer,
+  } = require('ReactDebugFiberPerf');
   var warnedAboutMissingGetChildContext = {};
 }
 
@@ -168,7 +173,16 @@ function processChildContext(fiber : Fiber, parentContext : Object, isReconcilin
     return parentContext;
   }
 
-  const childContext = instance.getChildContext();
+  let childContext;
+  if (__DEV__) {
+    ReactDebugCurrentFiber.phase = 'getChildContext';
+    startPhaseTimer(fiber, 'getChildContext');
+    childContext = instance.getChildContext();
+    stopPhaseTimer();
+    ReactDebugCurrentFiber.phase = null;
+  } else {
+    childContext = instance.getChildContext();
+  }
   for (let contextKey in childContext) {
     invariant(
       contextKey in childContextTypes,
@@ -189,6 +203,7 @@ function processChildContext(fiber : Fiber, parentContext : Object, isReconcilin
     checkReactTypeSpec(childContextTypes, childContext, 'child context', name);
     ReactDebugCurrentFrame.current = null;
   }
+
   return {...parentContext, ...childContext};
 }
 exports.processChildContext = processChildContext;


### PR DESCRIPTION
This is a work in progress, not for merge yet.

We will likely disable ReactPerf in Fiber because it's not clear how to make it work correctly, and whether the heuristics it used even make sense in Fiber.

Instead, we are now hooking into [User Timing API](https://github.com/w3c/user-timing) API if one is available in the environment, to report the React measurements. In this PR, I applied an RN sync manually (which is necessary to test this change until we land Fiber support), and implement the necessary User Timing API subset on top of Systrace in the second commit. The corresponding React PR is at https://github.com/facebook/react/pull/9071.

* First commit: React sync + enabling Fiber (irrelevant to this PR) https://github.com/facebook/react-native/commit/666a00498ec4705f785d69b35bfac8c9a944d7c1

* Second commit: Replace React debugging code with a User Timing polyfill for Fiber https://github.com/facebook/react-native/commit/4fb86f7d5f3f9be76fec7d59de9808a0404d1821

<img width="791" alt="screen shot 2017-03-08 at 1 51 30 pm" src="https://cloud.githubusercontent.com/assets/810438/23707162/3a7f141e-0409-11e7-9f01-fa806284b5aa.png">

The result is more or less equivalent to the Systrace React integration we had before, although it also displays some Fiber-specific features (such as a separate commit phase). It also doesn't rely on private React APIs and is consistent with what we use for the browser, so we shouldn't be breaking this integration again in the future.

One unfortunate problem here is that there is no way to re-label Systrace measurements after they happened. In the browser, we are able to rename measurements to include warning messages (since by the time the measurement ends, we know if user did some bad pattern). However, `Systrace` can only include the label when starting the measurements, so the warnings are not exposed.