### PR TITLE
[uglify-js] Lock version to 2.7.5 to avoid breakage like #12772

### DIFF
--- a/package.json
+++ b/package.json
@@ -200,7 +200,7 @@
     "stacktrace-parser": "^0.1.3",
     "temp": "0.8.3",
     "throat": "^3.0.0",
-    "uglify-js": "2.8.9",
+    "uglify-js": "2.7.5",
     "whatwg-fetch": "^1.0.0",
     "wordwrap": "^1.0.0",
     "worker-farm": "^1.3.1",

--- a/package.json
+++ b/package.json
@@ -200,7 +200,7 @@
     "stacktrace-parser": "^0.1.3",
     "temp": "0.8.3",
     "throat": "^3.0.0",
-    "uglify-js": "^2.6.2",
+    "uglify-js": "2.8.9",
     "whatwg-fetch": "^1.0.0",
     "wordwrap": "^1.0.0",
     "worker-farm": "^1.3.1",

--- a/packager/package.json
+++ b/packager/package.json
@@ -37,7 +37,7 @@
     "rimraf": "^2.5.4",
     "source-map": "^0.5.6",
     "throat": "^3.0.0",
-    "uglify-js": "2.8.9",
+    "uglify-js": "2.7.5",
     "worker-farm": "^1.3.1",
     "write-file-atomic": "^1.2.0",
     "xpipe": "^1.0.5"

--- a/packager/package.json
+++ b/packager/package.json
@@ -37,7 +37,7 @@
     "rimraf": "^2.5.4",
     "source-map": "^0.5.6",
     "throat": "^3.0.0",
-    "uglify-js": "^2.6.2",
+    "uglify-js": "2.8.9",
     "worker-farm": "^1.3.1",
     "write-file-atomic": "^1.2.0",
     "xpipe": "^1.0.5"


### PR DESCRIPTION
As per uglify-js maintainer @kzc's comment in https://github.com/mishoo/UglifyJS2/issues/1573#issuecomment-284940371 we should be locking our version to prevent issues like #12772 from happening again.

No test plan needed, people are already using this version of uglify-js (it's the latest).
