### PR TITLE
Add file input to WebView

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/ThemedReactContext.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/ThemedReactContext.java
@@ -14,6 +14,7 @@ import javax.annotation.Nullable;
 import android.app.Activity;
 import android.content.Context;
 
+import com.facebook.react.bridge.ActivityEventListener;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.LifecycleEventListener;
@@ -46,6 +47,16 @@ public class ThemedReactContext extends ReactContext {
   @Override
   public void removeLifecycleEventListener(LifecycleEventListener listener) {
     mReactApplicationContext.removeLifecycleEventListener(listener);
+  }
+
+  @Override
+  public void addActivityEventListener(ActivityEventListener listener) {
+    mReactApplicationContext.addActivityEventListener(listener);
+  }
+
+  @Override
+  public void removeActivityEventListener(ActivityEventListener listener) {
+    mReactApplicationContext.removeActivityEventListener(listener);
   }
 
   @Override

--- a/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebViewManager.java
@@ -431,7 +431,7 @@ public class ReactWebViewManager extends SimpleViewManager<WebView> {
     reactContext.addActivityEventListener(new ActivityEventListener() {
       @Override
       public void onActivityResult (Activity activity, int requestCode, int resultCode, Intent data) {
-        if(requestCode != INPUT_FILE_REQUEST_CODE) {
+        if(requestCode != INPUT_FILE_REQUEST_CODE || mFilePathCallback == null) {
           return;
         }
         Uri[] results = null;
@@ -451,7 +451,12 @@ public class ReactWebViewManager extends SimpleViewManager<WebView> {
           }
         }
 
-        if(results != null) mFilePathCallback.onReceiveValue(results);
+        if(results == null) {
+          mFilePathCallback.onReceiveValue(new Uri[]{});
+        }
+        else {
+          mFilePathCallback.onReceiveValue(results);
+        }
         mFilePathCallback = null;
         return;
       }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebViewManager.java
@@ -111,7 +111,7 @@ public class ReactWebViewManager extends SimpleViewManager<WebView> {
   // state and release page resources (including any running JavaScript).
   private static final String BLANK_URL = "about:blank";
 
-  public static final int INPUT_FILE_REQUEST_CODE = 1;
+  public static final int INPUT_FILE_REQUEST_CODE = 1001;
   public static final String EXTRA_FROM_NOTIFICATION = "EXTRA_FROM_NOTIFICATION";
 
   private WebViewConfig mWebViewConfig;
@@ -431,28 +431,29 @@ public class ReactWebViewManager extends SimpleViewManager<WebView> {
     reactContext.addActivityEventListener(new ActivityEventListener() {
       @Override
       public void onActivityResult (Activity activity, int requestCode, int resultCode, Intent data) {
-        if(requestCode == INPUT_FILE_REQUEST_CODE) {
-          Uri[] results = null;
-
-          // Check that the response is a good one
-          if(resultCode == Activity.RESULT_OK) {
-            if(data == null) {
-              // If there is not data, then we may have taken a photo
-              if(mCameraPhotoPath != null) {
-                results = new Uri[]{Uri.parse(mCameraPhotoPath)};
-              }
-            } else {
-              String dataString = data.getDataString();
-              if (dataString != null) {
-                results = new Uri[]{Uri.parse(dataString)};
-              }
-            }
-          }
-
-          mFilePathCallback.onReceiveValue(results);
-          mFilePathCallback = null;
+        if(requestCode != INPUT_FILE_REQUEST_CODE) {
           return;
         }
+        Uri[] results = null;
+
+        // Check that the response is a good one
+        if(resultCode == Activity.RESULT_OK) {
+          if(data == null) {
+            // If there is not data, then we may have taken a photo
+            if(mCameraPhotoPath != null) {
+              results = new Uri[]{Uri.parse(mCameraPhotoPath)};
+            }
+          } else {
+            String dataString = data.getDataString();
+            if (dataString != null) {
+              results = new Uri[]{Uri.parse(dataString)};
+            }
+          }
+        }
+
+        if(results != null) mFilePathCallback.onReceiveValue(results);
+        mFilePathCallback = null;
+        return;
       }
 
       @Override

--- a/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebViewManager.java
@@ -11,17 +11,24 @@ package com.facebook.react.views.webview;
 
 import javax.annotation.Nullable;
 
+import java.io.File;
+import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 
+import android.app.Activity;
 import android.content.ActivityNotFoundException;
 import android.content.Intent;
 import android.graphics.Bitmap;
 import android.graphics.Picture;
 import android.net.Uri;
 import android.os.Build;
+import android.os.Environment;
+import android.provider.MediaStore;
 import android.text.TextUtils;
 import android.view.ViewGroup.LayoutParams;
 import android.webkit.ConsoleMessage;
@@ -34,6 +41,7 @@ import android.webkit.ValueCallback;
 import android.webkit.WebSettings;
 
 import com.facebook.common.logging.FLog;
+import com.facebook.react.bridge.ActivityEventListener;
 import com.facebook.react.common.ReactConstants;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.LifecycleEventListener;
@@ -103,8 +111,13 @@ public class ReactWebViewManager extends SimpleViewManager<WebView> {
   // state and release page resources (including any running JavaScript).
   private static final String BLANK_URL = "about:blank";
 
+  public static final int INPUT_FILE_REQUEST_CODE = 1;
+  public static final String EXTRA_FROM_NOTIFICATION = "EXTRA_FROM_NOTIFICATION";
+
   private WebViewConfig mWebViewConfig;
   private @Nullable WebView.PictureListener mPictureListener;
+  private ValueCallback<Uri[]> mFilePathCallback;
+  private String mCameraPhotoPath;
 
   protected static class ReactWebViewClient extends WebViewClient {
 
@@ -330,7 +343,7 @@ public class ReactWebViewManager extends SimpleViewManager<WebView> {
   }
 
   @Override
-  protected WebView createViewInstance(ThemedReactContext reactContext) {
+  protected WebView createViewInstance(final ThemedReactContext reactContext) {
     ReactWebView webView = new ReactWebView(reactContext);
     webView.setWebChromeClient(new WebChromeClient() {
       @Override
@@ -346,8 +359,103 @@ public class ReactWebViewManager extends SimpleViewManager<WebView> {
       public void onGeolocationPermissionsShowPrompt(String origin, GeolocationPermissions.Callback callback) {
         callback.invoke(origin, true, false);
       }
+
+      private File createImageFile() throws IOException {
+        // Create an image file name
+        String timeStamp = new SimpleDateFormat("yyyyMMdd_HHmmss").format(new Date());
+        String imageFileName = "JPEG_" + timeStamp + "_";
+        File storageDir = Environment.getExternalStoragePublicDirectory(
+          Environment.DIRECTORY_PICTURES);
+        File imageFile = File.createTempFile(
+          imageFileName,  /* prefix */
+          ".jpg",         /* suffix */
+          storageDir      /* directory */
+        );
+        return imageFile;
+      }
+
+      public boolean onShowFileChooser(
+        WebView webView,
+        ValueCallback<Uri[]> filePathCallback,
+        WebChromeClient.FileChooserParams fileChooserParams) {
+        if(mFilePathCallback != null) {
+          mFilePathCallback.onReceiveValue(null);
+        }
+        mFilePathCallback = filePathCallback;
+
+        Intent takePictureIntent = new Intent(MediaStore.ACTION_IMAGE_CAPTURE);
+        if (takePictureIntent.resolveActivity(reactContext.getCurrentActivity().getPackageManager()) != null) {
+          // Create the File where the photo should go
+          File photoFile = null;
+          try {
+            photoFile = createImageFile();
+            takePictureIntent.putExtra("PhotoPath", mCameraPhotoPath);
+          } catch (IOException ex) {
+            // Error occurred while creating the File
+            FLog.e(ReactConstants.TAG, "Unable to create Image File", ex);
+          }
+
+          // Continue only if the File was successfully created
+          if (photoFile != null) {
+            mCameraPhotoPath = "file:" + photoFile.getAbsolutePath();
+            takePictureIntent.putExtra(MediaStore.EXTRA_OUTPUT,
+              Uri.fromFile(photoFile));
+          } else {
+            takePictureIntent = null;
+          }
+        }
+
+        Intent contentSelectionIntent = new Intent(Intent.ACTION_GET_CONTENT);
+        contentSelectionIntent.addCategory(Intent.CATEGORY_OPENABLE);
+        contentSelectionIntent.setType("image/*");
+
+        Intent[] intentArray;
+        if(takePictureIntent != null) {
+          intentArray = new Intent[]{takePictureIntent};
+        } else {
+          intentArray = new Intent[0];
+        }
+
+        Intent chooserIntent = new Intent(Intent.ACTION_CHOOSER);
+        chooserIntent.putExtra(Intent.EXTRA_INTENT, contentSelectionIntent);
+        chooserIntent.putExtra(Intent.EXTRA_TITLE, "Image Chooser");
+        chooserIntent.putExtra(Intent.EXTRA_INITIAL_INTENTS, intentArray);
+
+        reactContext.getCurrentActivity().startActivityForResult(chooserIntent, INPUT_FILE_REQUEST_CODE);
+
+        return true;
+      }
     });
+
     reactContext.addLifecycleEventListener(webView);
+    reactContext.addActivityEventListener(new ActivityEventListener() {
+      @Override
+      public void onActivityResult (Activity activity, int requestCode, int resultCode, Intent data) {
+        Uri[] results = null;
+
+        // Check that the response is a good one
+        if(resultCode == Activity.RESULT_OK) {
+          if(data == null) {
+            // If there is not data, then we may have taken a photo
+            if(mCameraPhotoPath != null) {
+              results = new Uri[]{Uri.parse(mCameraPhotoPath)};
+            }
+          } else {
+            String dataString = data.getDataString();
+            if (dataString != null) {
+              results = new Uri[]{Uri.parse(dataString)};
+            }
+          }
+        }
+
+        mFilePathCallback.onReceiveValue(results);
+        mFilePathCallback = null;
+        return;
+      }
+
+      @Override
+      public void onNewIntent(Intent intent) {}
+    });
     mWebViewConfig.configWebView(webView);
     webView.getSettings().setBuiltInZoomControls(true);
     webView.getSettings().setDisplayZoomControls(false);

--- a/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebViewManager.java
@@ -431,26 +431,28 @@ public class ReactWebViewManager extends SimpleViewManager<WebView> {
     reactContext.addActivityEventListener(new ActivityEventListener() {
       @Override
       public void onActivityResult (Activity activity, int requestCode, int resultCode, Intent data) {
-        Uri[] results = null;
+        if(requestCode == INPUT_FILE_REQUEST_CODE) {
+          Uri[] results = null;
 
-        // Check that the response is a good one
-        if(resultCode == Activity.RESULT_OK) {
-          if(data == null) {
-            // If there is not data, then we may have taken a photo
-            if(mCameraPhotoPath != null) {
-              results = new Uri[]{Uri.parse(mCameraPhotoPath)};
-            }
-          } else {
-            String dataString = data.getDataString();
-            if (dataString != null) {
-              results = new Uri[]{Uri.parse(dataString)};
+          // Check that the response is a good one
+          if(resultCode == Activity.RESULT_OK) {
+            if(data == null) {
+              // If there is not data, then we may have taken a photo
+              if(mCameraPhotoPath != null) {
+                results = new Uri[]{Uri.parse(mCameraPhotoPath)};
+              }
+            } else {
+              String dataString = data.getDataString();
+              if (dataString != null) {
+                results = new Uri[]{Uri.parse(dataString)};
+              }
             }
           }
-        }
 
-        mFilePathCallback.onReceiveValue(results);
-        mFilePathCallback = null;
-        return;
+          mFilePathCallback.onReceiveValue(results);
+          mFilePathCallback = null;
+          return;
+        }
       }
 
       @Override

--- a/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebViewManager.java
@@ -366,10 +366,9 @@ public class ReactWebViewManager extends SimpleViewManager<WebView> {
         String imageFileName = "JPEG_" + timeStamp + "_";
         File storageDir = Environment.getExternalStoragePublicDirectory(
           Environment.DIRECTORY_PICTURES);
-        File imageFile = File.createTempFile(
-          imageFileName,  /* prefix */
-          ".jpg",         /* suffix */
-          storageDir      /* directory */
+        File imageFile = new File(
+          storageDir,           /* directory */
+          imageFileName+".jpg"  /* filename */
         );
         return imageFile;
       }


### PR DESCRIPTION
Fixes [#5219](https://github.com/facebook/react-native/issues/5219) which was moved to [ProductPains](https://productpains.com/post/react-native/android-webview-cant-open-a-dialog-window-for-select-a-upload-file). Allows file input in a webview. Previously attempting to use file input would do nothing in the webview. Now the default dialog is shown allowing you to pick Camera to take a picture or Photos/Gallery to select an existing photo.

The problem in fixing this before was that this was accomplished by using undocumented APIs for earlier versions of Android. However, for 5.0+ there is a documented API for this. Since there is no documented way to fix this for earlier versions of Android, it seems better to have a solution for 5.0+ than no solution at all. 

Based on this example: https://github.com/GoogleChrome/chromium-webview-samples/tree/master/input-file-example/ 

The `ActivityEventListener` does not work if it is attached to the `ThemedReactContext` itself but needs to be added to the original `ReactContext` similar to how `LifecycleEventListener` is handled.