### PR TITLE
Add dev tools version to new issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,8 +1,11 @@
-We use GitHub Issues for bugs.
+Please read the following carefully before opening a new issue.
 
-If you have a non-bug question, ask on Stack Overflow: http://stackoverflow.com/questions/tagged/react-native
+We use GitHub Issues for tracking bugs in React Native.
 
-If you have a feature request, post it on Product Pains: https://productpains.com/product/react-native/
+- If you have a non-bug question, ask on Stack Overflow: http://stackoverflow.com/questions/tagged/react-native
+- If you have a feature request, post it on Canny: https://react-native.canny.io/feature-requests
+
+Your issue may be closed without explanation if it does not provide the information required by this template.
 
 --- Please use this template, and delete everything above this line before submitting your issue --- 
 
@@ -23,3 +26,4 @@ If you have a feature request, post it on Product Pains: https://productpains.co
 * React Native version: [FILL THIS OUT: Does the bug reproduce on the latest RN release?]
 * Platform: [FILL THIS OUT: iOS, Android, or both?]
 * Operating System: [FILL THIS OUT: MacOS, Linux, or Windows?]
+* Dev tools: [FILL THIS OUT: Xcode or Android Studio version, iOS or Android SDK version, if applicable]


### PR DESCRIPTION
It's sometimes helpful to provide the Xcode version being used, as in the case of #12795.