### PR TITLE
Add Show / Hide button for the built-in inspector

### DIFF
--- a/Libraries/Inspector/InspectorPanel.js
+++ b/Libraries/Inspector/InspectorPanel.js
@@ -24,6 +24,17 @@ const View = require('View');
 const PropTypes = React.PropTypes;
 
 class InspectorPanel extends React.Component {
+  state: {
+    devtoolsIsOpen: ?bool,
+  };
+
+  constructor(props: Object) {
+    super(props);
+    this.state = {
+      devtoolsIsOpen: null
+    };
+  }
+
   renderWaiting() {
     if (this.props.inspecting) {
       return (
@@ -33,6 +44,16 @@ class InspectorPanel extends React.Component {
       );
     }
     return <Text style={styles.waitingText}>Nothing is inspected</Text>;
+  }
+
+  devtoolsIsOpen(): ?bool {
+    return this.state.devtoolsIsOpen === null ?
+      this.props.devtoolsIsOpen :
+      this.state.devtoolsIsOpen;
+  }
+
+  toggleContents = () => {
+    this.setState({ devtoolsIsOpen: !this.devtoolsIsOpen() });
   }
 
   render() {
@@ -65,9 +86,10 @@ class InspectorPanel extends React.Component {
         </View>
       );
     }
+    var devtoolsIsOpen = this.devtoolsIsOpen();
     return (
       <View style={styles.container}>
-        {!this.props.devtoolsIsOpen && contents}
+        {!devtoolsIsOpen && contents}
         <View style={styles.buttonRow}>
           <Button
             title={'Inspect'}
@@ -85,6 +107,10 @@ class InspectorPanel extends React.Component {
           <Button title={'Touchables'}
             pressed={this.props.touchTargetting}
             onClick={this.props.setTouchTargetting}
+          />
+          <Button title={devtoolsIsOpen ? 'Show' : 'Hide'}
+            pressed={!devtoolsIsOpen}
+            onClick={this.toggleContents}
           />
         </View>
       </View>


### PR DESCRIPTION
Currently when we use [`react-devtools`](https://github.com/facebook/react-devtools/tree/master/packages/react-devtools) or react inspector of Nuclide for RN, it will hide the built-in inspector contents.

The built-in inspector have some features different from `react-devtools`, like computed styles, this PR make the two can be used together.

**Test plan (required)**

Manual testing:

* Open react-devtools and open the built-in inspector (Dev menu: Toggle Inspector)
* First inspector contents is hidden, we can click `Show` / `Hide` for toggle the inspector contents

Screenshot:

![Screenshot](https://cloud.githubusercontent.com/assets/3001525/23743578/1ce993b4-04ec-11e7-86b4-d14fb88a713b.gif)