### PR TITLE
Make a section on keyboard shortcuts more prominent

### DIFF
--- a/docs/Debugging.md
+++ b/docs/Debugging.md
@@ -8,6 +8,10 @@ next: accessibility
 previous: platform-specific-code
 ---
 
+## Enabling Keyboard Shortcuts
+
+React Native supports a few keyboard shortcuts in the iOS Simulator. They are described below. To enable them, open the Hardware menu, select Keyboard, and make sure that "Connect Hardware Keyboard" is checked.
+
 ## Accessing the In-App Developer Menu
 
 You can access the developer menu by shaking your device or by selecting "Shake Gesture" inside the Hardware menu in the iOS Simulator. You can also use the **`Command`**`⌘` + **`D`** keyboard shortcut when your app is running in the iPhone Simulator, or **`Command`**`⌘` + **`M`** when running in an Android emulator.
@@ -19,8 +23,6 @@ You can access the developer menu by shaking your device or by selecting "Shake 
 ## Reloading JavaScript
 
 Instead of recompiling your app every time you make a change, you can reload your app's JavaScript code instantly. To do so, select "Reload" from the Developer Menu. You can also press **`Command`**`⌘` + **`R`** in the iOS Simulator, or press **`R`** twice on Android emulators.
-
-> If the **`Command`**`⌘` + **`R`** keyboard shortcut does not seem to reload the iOS Simulator, go to the Hardware menu, select Keyboard, and make sure that "Connect Hardware Keyboard" is checked.
 
 ### Automatic reloading
 


### PR DESCRIPTION
The note is currently in "Reloading JavaScript". However I was struggling with the first step ("Accessing the In-App Developer Menu") so didn't read down to that section.

I think it makes sense to make this the very first thing the reader sees when visiting the page.