### PR TITLE
Fix indent for .babelrc in HelloWorld template

### DIFF
--- a/local-cli/templates/HelloWorld/_babelrc
+++ b/local-cli/templates/HelloWorld/_babelrc
@@ -1,3 +1,3 @@
 {
-"presets": ["react-native"]
+  "presets": ["react-native"]
 }


### PR DESCRIPTION
Minor code formatting.
Each time I run `react-native init` I must reindent this file.