### PR TITLE
Fixes missleading comment on getInitialURL

### DIFF
--- a/Libraries/Linking/Linking.js
+++ b/Libraries/Linking/Linking.js
@@ -33,7 +33,7 @@ const LinkingManager = Platform.OS === 'android' ?
  *
  * ```
  * componentDidMount() {
- *   var url = Linking.getInitialURL().then((url) => {
+ *   Linking.getInitialURL().then((url) => {
  *     if (url) {
  *       console.log('Initial url is: ' + url);
  *     }


### PR DESCRIPTION
The returned value from Linking.getInitialURL is a promise that returns an url.

Can be seen here: https://github.com/facebook/react-native/blob/f126540519bd276c0048aa77b543dc863412de46/Libraries/Linking/Linking.js#L175