### PR TITLE
Fixed onEndReached handling for VirtualizedList

### DIFF
--- a/Libraries/CustomComponents/Lists/FlatList.js
+++ b/Libraries/CustomComponents/Lists/FlatList.js
@@ -112,6 +112,9 @@ type OptionalProps<ItemT> = {
    * content.
    */
   onEndReached?: ?(info: {distanceFromEnd: number}) => void,
+  /**
+   * Threshold in pixels (virtual, not physical) for calling onEndReached.
+   */
   onEndReachedThreshold?: ?number,
   /**
    * If provided, a standard RefreshControl will be added for "Pull to Refresh" functionality. Make

--- a/Libraries/CustomComponents/Lists/VirtualizedList.js
+++ b/Libraries/CustomComponents/Lists/VirtualizedList.js
@@ -261,7 +261,7 @@ class VirtualizedList extends React.PureComponent<OptionalProps, Props, State> {
     },
     maxToRenderPerBatch: 10,
     onEndReached: () => {},
-    onEndReachedThreshold: 2, // multiples of length
+    onEndReachedThreshold: 1000,
     removeClippedSubviews: true,
     renderScrollComponent: (props: Props) => {
       if (props.onRefresh) {
@@ -590,7 +590,7 @@ class VirtualizedList extends React.PureComponent<OptionalProps, Props, State> {
     }
     const distanceFromEnd = contentLength - visibleLength - offset;
     const itemCount = getItemCount(data);
-    if (distanceFromEnd < onEndReachedThreshold * visibleLength &&
+    if (distanceFromEnd < onEndReachedThreshold &&
         this._scrollMetrics.contentLength !== this._sentEndForContentLength &&
         this.state.last === itemCount - 1) {
       // Only call onEndReached for a given content length once.


### PR DESCRIPTION
Fix issue #12827. 
Currently `onEndReached` will be triggered when `distanceFromEnd < onEndReachedThreshold * visibleLength`, this behaviour is different with ListView implementation: `distanceFromEnd < onEndReachedThreshold`. This PR make `VirtualizedList` implement same condition and changed default `onEndReachedThreshold` to `1000` that same with `ListView`