### PR TITLE
Sticky headers are no longer ios-only

### DIFF
--- a/Libraries/Components/ScrollView/ScrollView.js
+++ b/Libraries/Components/ScrollView/ScrollView.js
@@ -295,7 +295,6 @@ const ScrollView = React.createClass({
      * `stickyHeaderIndices={[0]}` will cause the first child to be fixed to the
      * top of the scroll view. This property is not supported in conjunction
      * with `horizontal={true}`.
-     * @platform ios
      */
     stickyHeaderIndices: PropTypes.arrayOf(PropTypes.number),
     style: StyleSheetPropType(ViewStylePropTypes),


### PR DESCRIPTION
Should have removed this in https://github.com/facebook/react-native/commit/77b8c097277b5cf248d08e772ea8bb8d8583e9a1

cc @janicduplessis 