### PR TITLE
Changed normalizePrefix function for Strict mode complaince

### DIFF
--- a/Libraries/Utilities/UIManager.js
+++ b/Libraries/Utilities/UIManager.js
@@ -65,7 +65,7 @@ UIManager.takeSnapshot = async function(
  */
 if (Platform.OS === 'ios') {
   // Copied from NativeModules
-  function normalizePrefix(moduleName: string): string {
+  var normalizePrefix = function(moduleName: string): string {
     return moduleName.replace(/^(RCT|RK)/, '');
   }
 


### PR DESCRIPTION
I was facing an issue in my project where in Android I was facing a error "strict mode does not allow function declarations in a lexically nested statement" on app start up. The reason was because babel was adding 'use strict' on top the module. Making this change fixed my error