### PR TITLE
Add replaceWithAnimation Method to Navigator component

### DIFF
--- a/Libraries/CustomComponents/Navigator/Navigator.js
+++ b/Libraries/CustomComponents/Navigator/Navigator.js
@@ -1190,6 +1190,33 @@ var Navigator = React.createClass({
   },
 
   /**
+   * Replace the previous scene with transition Animations.
+   * @param {object} route Route that replaces the previous scene.
+   */
+  replaceWithAnimation: function (route) {
+    const currentLength = this.state.presentedIndex + 1;
+    const currentRouteStack = this.state.routeStack.slice(0, currentLength);
+    const animationConfigFromSceneConfigStack = this.state.sceneConfigStack.slice(0, currentLength);
+    const nextStack = currentRouteStack.concat([route]);
+    const destIndex = nextStack.length - 1;
+    const nextSceneConfig = this.props.configureScene(route, nextStack);
+    const nextAnimationConfigStack = animationConfigFromSceneConfigStack.concat([nextSceneConfig]);
+
+    const newStack = currentRouteStack.slice(0, currentLength - 1).concat([route]);
+    this._emitWillFocus(nextStack[destIndex]);
+    this.setState({
+      routeStack: nextStack,
+      sceneConfigStack: nextAnimationConfigStack,
+    },() => {
+      this._enableScene(destIndex);
+      this._transitionTo(destIndex, nextSceneConfig.defaultTransitionVelocity, null, () => {
+        // Immediately reset the route stack after the transition is completed
+        this.immediatelyResetRouteStack(newStack);
+      });
+    });
+  },
+
+  /**
    * Replace the previous scene.
    * @param {object} route Route that replaces the previous scene.
    */


### PR DESCRIPTION
**New feature**
This commit will add replaceWithAnimation function to the Navigator component which will allow the user to replace a route while having the default transition animation of the target scene.

fixes facebook/react-native#1981

Implemented based of Stack-Overflow solution - http://stackoverflow.com/questions/40393380/react-native-transition-animation-for-navigator-replace

**Test plan**
the following repository [ReactNativeNavigationDemo (branch replaceWithAnimation)](https://github.com/DaniAkash/ReactNativeNavigationDemo/tree/replaceWithAnimation) has a page implemented using the replaceWithAnimation function in [SplashPage.js](https://github.com/DaniAkash/ReactNativeNavigationDemo/blob/replaceWithAnimation/components/splash/SplashPage.js#L22) which replaces the splash page with the homepage and it is tested with various use cases and found that the component is working as expected.