### PR TITLE
Changes reference to RCTBridgeDelegate from weak to strong

### DIFF
--- a/React/Base/RCTBridge.h
+++ b/React/Base/RCTBridge.h
@@ -168,7 +168,7 @@ RCT_EXTERN NSString *RCTBridgeModuleNameForClass(Class bridgeModuleClass);
 /**
  * The delegate provided during the bridge initialization
  */
-@property (nonatomic, weak, readonly) id<RCTBridgeDelegate> delegate;
+@property (nonatomic, strong, readonly) id<RCTBridgeDelegate> delegate;
 
 /**
  * The launch options that were used to initialize the bridge.


### PR DESCRIPTION
This PR makes sure the bridge delegate is retained. Currently the delegate only survives the initial load. During a `[bridge reload]`, it turns out to be `nil`. 

**Context**
In my project, I provide a RCTBridgeDelegate to load the bundle in a different way:

```ObjectiveC
@implementation MyScriptLoader
  - (void)loadSourceForBridge:(RCTBridge *)bridge
                 onProgress:(RCTSourceLoadProgressBlock)onProgress
                 onComplete:(RCTSourceLoadBlock)onComplete
  {    
    // My own way of loading the bundle
  }

  - (NSURL *)sourceURLForBridge:(RCTBridge *)bridge
  {
    return nil;
  }

@end
```

In AppDelegate I use it like this: 
```ObjectiveC
MyScriptLoader *scriptLoader = [MyScriptLoader alloc];
  bridge = [[RCTBridge alloc] initWithDelegate:scriptLoader
                                         launchOptions:launchOptions];
```

**Expected behaviour**
When I call `[bridge reload]`, I expect the delegate to be used to load the bundle, but currently it is gone. 

**Proposed fix**
Change the delegate reference in `RCTBridge` from weak to strong.

**Test plan (required)**
Tested the change in my project, delegate was retained and still there when reloading. 
