### PR TITLE
Animated - Add missing super calls to fix native animated crash

### DIFF
--- a/Libraries/Animated/src/AnimatedImplementation.js
+++ b/Libraries/Animated/src/AnimatedImplementation.js
@@ -1328,6 +1328,7 @@ class AnimatedModulo extends AnimatedWithChildren {
 
   __detach(): void {
     this._a.__removeChild(this);
+    super.__detach();
   }
 
   __getNativeConfig(): any {
@@ -1378,6 +1379,7 @@ class AnimatedDiffClamp extends AnimatedWithChildren {
 
   __detach(): void {
     this._a.__removeChild(this);
+    super.__detach();
   }
 
   __getNativeConfig(): any {
@@ -1461,6 +1463,7 @@ class AnimatedTransform extends AnimatedWithChildren {
         }
       }
     });
+    super.__detach();
   }
 
   __getNativeConfig(): any {
@@ -1568,6 +1571,7 @@ class AnimatedStyle extends AnimatedWithChildren {
         value.__removeChild(this);
       }
     }
+    super.__detach();
   }
 
   __makeNative() {

--- a/Libraries/Animated/src/__tests__/AnimatedNative-test.js
+++ b/Libraries/Animated/src/__tests__/AnimatedNative-test.js
@@ -281,7 +281,7 @@ describe('Native Animated', () => {
       );
 
       expect(nativeAnimatedModule.disconnectAnimatedNodes).toHaveBeenCalledTimes(2);
-      expect(nativeAnimatedModule.dropAnimatedNode).toHaveBeenCalledTimes(2);
+      expect(nativeAnimatedModule.dropAnimatedNode).toHaveBeenCalledTimes(3);
     });
 
     it('sends a valid description for value, style and props nodes', () => {


### PR DESCRIPTION
There was some missing super.__detach calls in some Animated nodes, we rely on the base class being called to drop the node in the native implementation, not doing so will cause some nodes to leak. It also resulted in a crash when removing certain nodes because they would get updated after being detached.

**Test plan**
Reproduced the crash by unmounting a view that uses a DiffClamp node and made sure this fixes it. Also tested that other native animations still worked properly.

Fixes #11317