### PR TITLE
NavigationExperimental: Correct the distance from the left of the screen to start touch responsiveness

### DIFF
--- a/Libraries/CustomComponents/NavigationExperimental/NavigationCardStackPanResponder.js
+++ b/Libraries/CustomComponents/NavigationExperimental/NavigationCardStackPanResponder.js
@@ -131,7 +131,7 @@ class NavigationCardStackPanResponder extends NavigationAbstractPanResponder {
       */
       props.gestureResponseDistance || 30;
 
-    if (positionMax != null && currentDragPosition > positionMax) {
+    if (positionMax != null && currentDragPosition - RESPOND_THRESHOLD > positionMax) {
       return false;
     }
 


### PR DESCRIPTION
There are at least 2 requirements to be met at the same time:
1. currentDragPosition <= positionMax
2. Math.abs(currentDragDistance) > RESPOND_THRESHOLD

The default positionMax = 30 and RESPOND_THRESHOLD = 15. If so, the user must begin drag at the point which is less than 15 apart from the left edge. That is unexpected.

So currentDragPosition must minus RESPOND_THRESHOLD, and then the user can start dragging at the distance of 30 from the left edge