### PR TITLE
fixed new line for SwiftKey Keyboard

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
@@ -750,6 +750,10 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
                       editText.getText().toString()));
             }
 
+            if (actionId == EditorInfo.IME_NULL) {
+              return !editText.getBlurOnSubmit();
+            }
+
             if (editText.getBlurOnSubmit()) {
               editText.clearFocus();
             }


### PR DESCRIPTION
After upgrading to ReactNative v0.42.0 return key for new line no longer worked with SwiftKey Keyboard from Samsung. The TextInput loses focus and the keyboard hides.