### PR TITLE
packager: make jest/preprocessor use the correct list of node files

### DIFF
--- a/jest/preprocessor.js
+++ b/jest/preprocessor.js
@@ -12,12 +12,10 @@ const babel = require('babel-core');
 const babelRegisterOnly = require('../packager/babelRegisterOnly');
 const createCacheKeyFunction = require('fbjs-scripts/jest/createCacheKeyFunction');
 const path = require('path');
+const setupBabel = require('../setupBabel');
 
-const nodeFiles = RegExp([
-  '/local-cli/',
-  '/packager/(?!src/Resolver/polyfills/)',
-].join('|'));
-const nodeOptions = babelRegisterOnly.config([nodeFiles]);
+const nodeFiles = setupBabel.getOnlyList();
+const nodeOptions = babelRegisterOnly.config(nodeFiles);
 
 babelRegisterOnly([]);
 // has to be required after setting up babelRegisterOnly
@@ -25,7 +23,7 @@ const transformer = require('../packager/transformer.js');
 
 module.exports = {
   process(src, file) {
-    if (nodeFiles.test(file)) { // node specific transforms only
+    if (nodeFiles.some(regExp => regExp.test(file))) { // node specific transforms only
       return babel.transform(
         src,
         Object.assign({filename: file}, nodeOptions)


### PR DESCRIPTION
Many tests were failing when running `npm run test` because jest wasn't applying the transformations for all the relevant files. With this change we use the same sets of file for `jest` as we use when running `packager` & `local-cli` themselves, that makes more sense.

**Test plan (required)**

`npm run test` now works, except 2 tests. However, these errors are not related to transform errors anymore, so this PR is not in cause. Moreover, I do plan to fix the `DependencyGraph-test` in a follow-up PR.
