### PR TITLE
Use optional devEnabled[targetName/buildTypeName] configuration from …

### DIFF
--- a/react.gradle
+++ b/react.gradle
@@ -77,6 +77,13 @@ gradle.projectsEvaluated {
 
                 // Set up dev mode
                 def devEnabled = !targetName.toLowerCase().contains("release")
+
+                if (config."devEnabled${targetName}" instanceof Boolean) {
+                  devEnabled = config."devEnabled${targetName}" 
+                } else if (config."devEnabled${buildTypeName.capitalize()}" instanceof Boolean) {
+                  devEnabled = config."devEnabled${buildTypeName.capitalize()}"
+                }
+                
                 if (Os.isFamily(Os.FAMILY_WINDOWS)) {
                     commandLine("cmd", "/c", *nodeExecutableAndArgs, "node_modules/react-native/local-cli/cli.js", "bundle", "--platform", "android", "--dev", "${devEnabled}",
                             "--reset-cache", "--entry-file", entryFile, "--bundle-output", jsBundleFile, "--assets-dest", resourcesDir, *extraPackagerArgs)


### PR DESCRIPTION
Allow enabling/disabling development mode for custom Android build types. Useful for example when building a CI artifact which require custom build type setting differing from the release build type.

Follows the same API as `bundleIn<buildType>`, `jsBundleDir<buildType>` and `resourcesDir<buildType>`.

Backwards compatible with current implementation and behaviour (will default to false if `targetName` contains `release`).