### PR TITLE
Update Android dependencies

### DIFF
--- a/.buckconfig
+++ b/.buckconfig
@@ -1,6 +1,6 @@
 
 [android]
-  target = Google Inc.:Google APIs:23
+  target = Google Inc.:Google APIs:25
 
 [maven_repositories]
   central = https://repo1.maven.org/maven2

--- a/.buckconfig
+++ b/.buckconfig
@@ -1,6 +1,6 @@
 
 [android]
-  target = Google Inc.:Google APIs:25
+  target = Google Inc.:Google APIs:23
 
 [maven_repositories]
   central = https://repo1.maven.org/maven2

--- a/ContainerShip/Dockerfile.android-base
+++ b/ContainerShip/Dockerfile.android-base
@@ -64,14 +64,14 @@ RUN rm ndk.zip
 
 # add android SDK tools
 # 2 - Android SDK Platform-tools, revision 25.0.3
-# 12 - Android SDK Build-tools, revision 23.0.1
-# 35 - SDK Platform Android 6.0, API 23, revision 3
+# 3 - Android SDK Build-tools, revision 25.0.2
+# 33 - SDK Platform Android 7.1.1, API 25, revision 3
 # 39 - SDK Platform Android 4.4.2, API 19, revision 4
 # 102 - ARM EABI v7a System Image, Android API 19, revision 5
 # 103 - Intel x86 Atom System Image, Android API 19, revision 5
 # 131 - Google APIs, Android API 23, revision 1
-# 166 - Android Support Repository, revision 41
-RUN echo "y" | android update sdk -u -a -t 2,12,35,39,102,103,131,166
+# 162 - Android Support Repository, revision 44
+RUN echo "y" | android update sdk -u -a -t 2,3,33,39,102,103,131,162
 RUN ln -s /opt/android/platform-tools/adb /usr/bin/adb
 
 # clean up unnecessary directories

--- a/Examples/Movies/android/app/build.gradle
+++ b/Examples/Movies/android/app/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion 25
+    buildToolsVersion "25.0.2"
 
     defaultConfig {
         applicationId "com.facebook.react.movies"
         minSdkVersion 16
-        targetSdkVersion 22
+        targetSdkVersion 25
         versionCode 1
         versionName "1.0"
         ndk {
@@ -24,7 +24,7 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:23.0.1'
+    compile 'com.android.support:appcompat-v7:25.2.0'
 
     // Build React Native from source
     compile project(':ReactAndroid')

--- a/Examples/TicTacToe/android/app/build.gradle
+++ b/Examples/TicTacToe/android/app/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion 25
+    buildToolsVersion "25.0.2"
 
     defaultConfig {
         applicationId "com.facebook.react.tictactoe"
         minSdkVersion 16
-        targetSdkVersion 22
+        targetSdkVersion 25
         versionCode 1
         versionName "1.0"
         ndk {
@@ -24,7 +24,7 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:23.0.1'
+    compile 'com.android.support:appcompat-v7:25.2.0'
 
     // Build React Native from source
     compile project(':ReactAndroid')

--- a/Examples/UIExplorer/android/app/build.gradle
+++ b/Examples/UIExplorer/android/app/build.gradle
@@ -83,13 +83,13 @@ def enableSeparateBuildPerCPUArchitecture = false
 def enableProguardInReleaseBuilds = false
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion 25
+    buildToolsVersion "25.0.2"
 
     defaultConfig {
         applicationId "com.facebook.react.uiapp"
         minSdkVersion 16
-        targetSdkVersion 23
+        targetSdkVersion 25
         versionCode 1
         versionName "1.0"
         ndk {
@@ -136,7 +136,7 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:23.0.1'
+    compile 'com.android.support:appcompat-v7:25.2.0'
 
     // Build React Native from source
     compile project(':ReactAndroid')

--- a/Examples/UIExplorer/android/app/src/main/AndroidManifest.xml
+++ b/Examples/UIExplorer/android/app/src/main/AndroidManifest.xml
@@ -17,7 +17,7 @@
 
   <uses-sdk
     android:minSdkVersion="16"
-    android:targetSdkVersion="23" />
+    android:targetSdkVersion="25" />
 
   <application
       android:name=".UIExplorerApplication"

--- a/ReactAndroid/DevExperience.md
+++ b/ReactAndroid/DevExperience.md
@@ -4,8 +4,8 @@ Assuming you have the [Android SDK](https://developer.android.com/sdk/installing
 
 Make sure you have the following installed:
 
-- Android SDK version 23
-- SDK build tools version 23
+- Android SDK version 25
+- SDK build tools version 25
 - Android Support Repository 17 (for Android Support Library)
 
 Follow steps on https://github.com/facebook/react-native/blob/master/react-native-cli/CONTRIBUTING.md, but be sure to bump the version of react-native in package.json to some version > 0.9 (latest published npm version) or set up proxying properly for react-native

--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -226,12 +226,12 @@ task packageReactNdkLibsForBuck(dependsOn: packageReactNdkLibs, type: Copy) {
 }
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion 25
+    buildToolsVersion "25.0.2"
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 22
+        targetSdkVersion 25
         versionCode 1
         versionName "1.0"
 
@@ -274,7 +274,7 @@ android {
 dependencies {
     compile fileTree(dir: 'src/main/third-party/java/infer-annotations/', include: ['*.jar'])
     compile 'javax.inject:javax.inject:1'
-    compile 'com.android.support:appcompat-v7:23.0.1'
+    compile 'com.android.support:appcompat-v7:25.2.0'
     compile 'com.facebook.fbui.textlayoutbuilder:textlayoutbuilder:1.0.0'
     compile 'com.facebook.fresco:fresco:1.0.1'
     compile 'com.facebook.fresco:imagepipeline-okhttp3:1.0.1'

--- a/ReactAndroid/libs/BUCK
+++ b/ReactAndroid/libs/BUCK
@@ -6,7 +6,7 @@ android_prebuilt_aar(
 
 remote_file(
     name = "appcompat-binary-aar",
-    sha1 = "7d659f671541394a8bc2b9f909950aa2a5ec87ff",
+    sha1 = "cede75671ff307240a2ebf66c362a922e1bf2b1f",
     url = "mvn:com.android.support:appcompat-v7:aar:25.2.0",
 )
 

--- a/ReactAndroid/libs/BUCK
+++ b/ReactAndroid/libs/BUCK
@@ -7,7 +7,7 @@ android_prebuilt_aar(
 remote_file(
     name = "appcompat-binary-aar",
     sha1 = "7d659f671541394a8bc2b9f909950aa2a5ec87ff",
-    url = "mvn:com.android.support:appcompat-v7:aar:23.0.1",
+    url = "mvn:com.android.support:appcompat-v7:aar:25.2.0",
 )
 
 android_prebuilt_aar(

--- a/ReactAndroid/src/main/third-party/android/support-annotations/BUCK
+++ b/ReactAndroid/src/main/third-party/android/support-annotations/BUCK
@@ -7,5 +7,5 @@ prebuilt_jar(
 remote_file(
     name = "support-annotations-binary-aar",
     sha1 = "1fce89a6428c51467090d7f424e4c9c3dbd55f7e",
-    url = "mvn:com.android.support:support-annotations:jar:23.0.1",
+    url = "mvn:com.android.support:support-annotations:jar:25.2.0",
 )

--- a/ReactAndroid/src/main/third-party/android/support-annotations/BUCK
+++ b/ReactAndroid/src/main/third-party/android/support-annotations/BUCK
@@ -6,6 +6,6 @@ prebuilt_jar(
 
 remote_file(
     name = "support-annotations-binary-aar",
-    sha1 = "1fce89a6428c51467090d7f424e4c9c3dbd55f7e",
+    sha1 = "4a5a82a027706397fff621b22fd6fa796e91d7c5",
     url = "mvn:com.android.support:support-annotations:jar:25.2.0",
 )

--- a/ReactAndroid/src/main/third-party/android/support/v4/BUCK
+++ b/ReactAndroid/src/main/third-party/android/support/v4/BUCK
@@ -6,6 +6,6 @@ android_prebuilt_aar(
 
 remote_file(
     name = "lib-support-v4-binary-aar",
-    sha1 = "9e8da0e4ecf9f63258c7fbd273889252cba2d0c3",
+    sha1 = "3b9231d6e95d9b7286332e2fc9bab15fe47b14a5",
     url = "mvn:com.android.support:support-v4:aar:25.2.0",
 )

--- a/ReactAndroid/src/main/third-party/android/support/v4/BUCK
+++ b/ReactAndroid/src/main/third-party/android/support/v4/BUCK
@@ -7,5 +7,5 @@ android_prebuilt_aar(
 remote_file(
     name = "lib-support-v4-binary-aar",
     sha1 = "9e8da0e4ecf9f63258c7fbd273889252cba2d0c3",
-    url = "mvn:com.android.support:support-v4:aar:23.0.1",
+    url = "mvn:com.android.support:support-v4:aar:25.2.0",
 )

--- a/ReactAndroid/src/main/third-party/android/support/v7/appcompat-orig/BUCK
+++ b/ReactAndroid/src/main/third-party/android/support/v7/appcompat-orig/BUCK
@@ -56,6 +56,6 @@ python_binary(
 
 remote_file(
     name = "appcompat-binary-aar",
-    sha1 = "7d659f671541394a8bc2b9f909950aa2a5ec87ff",
+    sha1 = "cede75671ff307240a2ebf66c362a922e1bf2b1f",
     url = "mvn:com.android.support:appcompat-v7:aar:25.2.0",
 )

--- a/ReactAndroid/src/main/third-party/android/support/v7/appcompat-orig/BUCK
+++ b/ReactAndroid/src/main/third-party/android/support/v7/appcompat-orig/BUCK
@@ -57,5 +57,5 @@ python_binary(
 remote_file(
     name = "appcompat-binary-aar",
     sha1 = "7d659f671541394a8bc2b9f909950aa2a5ec87ff",
-    url = "mvn:com.android.support:appcompat-v7:aar:23.0.1",
+    url = "mvn:com.android.support:appcompat-v7:aar:25.2.0",
 )

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         mavenLocal()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.2'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'de.undercouch:gradle-download-task:3.1.2'
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/circle.yml
+++ b/circle.yml
@@ -20,6 +20,7 @@ dependencies:
     - cd /home/ubuntu/buck && ant
     - buck --version
     - source scripts/circle-ci-android-setup.sh && getAndroidSDK
+    - android list targets --compact
     - buck fetch ReactAndroid/src/test/java/com/facebook/react/modules
     - buck fetch ReactAndroid/src/main/java/com/facebook/react
     - buck fetch ReactAndroid/src/main/java/com/facebook/react/shell

--- a/docs/AndroidBuildingFromSource.md
+++ b/docs/AndroidBuildingFromSource.md
@@ -17,8 +17,8 @@ Assuming you have the Android SDK installed, run `android` to open the Android S
 
 Make sure you have the following installed:
 
-1. Android SDK version 23 (compileSdkVersion in [`build.gradle`](https://github.com/facebook/react-native/blob/master/ReactAndroid/build.gradle))
-2. SDK build tools version 23.0.1 (buildToolsVersion in [`build.gradle`](https://github.com/facebook/react-native/blob/master/ReactAndroid/build.gradle))
+1. Android SDK version 25 (compileSdkVersion in [`build.gradle`](https://github.com/facebook/react-native/blob/master/ReactAndroid/build.gradle))
+2. SDK build tools version 25.0.2 (buildToolsVersion in [`build.gradle`](https://github.com/facebook/react-native/blob/master/ReactAndroid/build.gradle))
 3. Android Support Repository >= 17 (for Android Support Library)
 4. Android NDK (download links and installation instructions below)
 
@@ -76,7 +76,7 @@ Add `gradle-download-task` as dependency in `android/build.gradle`:
 ```gradle
 ...
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.3.1'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'de.undercouch:gradle-download-task:3.1.2'
 
         // NOTE: Do not place your application dependencies here; they belong
@@ -104,7 +104,7 @@ Modify your `android/app/build.gradle` to use the `:ReactAndroid` project instea
 ...
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:23.0.1'
+    compile 'com.android.support:appcompat-v7:25.2.0'
 
     compile project(':ReactAndroid')
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -211,22 +211,22 @@ Click "Next" to install all of these components, then [configure VM acceleration
 
 <block class="mac linux windows android" />
 
-#### 3. Install the Android 6.0 (Marshmallow) SDK
+#### 3. Install the Android 7.1.1 (Nougat) SDK
 
-Android Studio installs the most recent Android SDK by default. React Native, however, requires the `Android 6.0 (Marshmallow)` SDK. To install it, launch the SDK Manager, click on "Configure" > "SDK Manager" in the "Welcome to Android Studio" screen.
+Android Studio installs the most recent Android SDK by default. React Native, however, requires the `Android 7.1.1 (Nougat)` SDK. To install it, launch the SDK Manager, click on "Configure" > "SDK Manager" in the "Welcome to Android Studio" screen.
 
 > The SDK Manager can also be found within the Android Studio "Preferences" menu, under **Appearance & Behavior** → **System Settings** → **Android SDK**.
 
-Select the "SDK Platforms" tab from within the SDK Manager, then check the box next to "Show Package Details" in the bottom right corner. Look for and expand the `Android 6.0 (Marshmallow)` entry, then make sure the following items are all checked:
+Select the "SDK Platforms" tab from within the SDK Manager, then check the box next to "Show Package Details" in the bottom right corner. Look for and expand the `Android 7.1.1 (Nougat)` entry, then make sure the following items are all checked:
 
 - `Google APIs`
-- `Android SDK Platform 23`
+- `Android SDK Platform 25`
 - `Intel x86 Atom_64 System Image`
 - `Google APIs Intel x86 Atom_64 System Image`
 
 ![Android SDK Manager](img/AndroidSDKManager.png)
 
-Next, select the "SDK Tools" tab and check the box next to "Show Package Details" here as well. Look for and expand the "Android SDK Build Tools" entry, then make sure that `Android SDK Build-Tools 23.0.1` is selected.
+Next, select the "SDK Tools" tab and check the box next to "Show Package Details" here as well. Look for and expand the "Android SDK Build Tools" entry, then make sure that `Android SDK Build-Tools 25.0.2` is selected.
 
 Finally, click "Apply" to download and install the Android SDK and related build tools.
 
@@ -296,7 +296,7 @@ You can see the list of available AVDs by opening the "AVD Manager" from within 
 android avd
 ```
 
-Once in the "AVD Manager", select your AVD and click "Edit...". Choose "Android 6.0 - API Level 23" under Device, and "Intel Atom (x86_64)" under CPU/ABI. Click OK, then select your new AVD and click "Start...", and finally, "Launch".
+Once in the "AVD Manager", select your AVD and click "Edit...". Choose "Android 7.1.1 - API Level 25" under Device, and "Intel Atom (x86_64)" under CPU/ABI. Click OK, then select your new AVD and click "Start...", and finally, "Launch".
 
 ![Android AVD Configuration](img/AndroidAVDConfiguration.png)
 

--- a/local-cli/link/__fixtures__/android/build.gradle
+++ b/local-cli/link/__fixtures__/android/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
     compile fileTree(dir: "libs", include: ["*.jar"])
-    compile "com.android.support:appcompat-v7:23.0.1"
+    compile "com.android.support:appcompat-v7:25.2.0"
     compile "com.facebook.react:react-native:0.18.+"
 }

--- a/local-cli/link/__fixtures__/android/patchedBuild.gradle
+++ b/local-cli/link/__fixtures__/android/patchedBuild.gradle
@@ -1,6 +1,6 @@
 dependencies {
     compile project(':test')
     compile fileTree(dir: "libs", include: ["*.jar"])
-    compile "com.android.support:appcompat-v7:23.0.1"
+    compile "com.android.support:appcompat-v7:25.2.0"
     compile "com.facebook.react:react-native:0.18.+"
 }

--- a/local-cli/templates/HelloWorld/_buckconfig
+++ b/local-cli/templates/HelloWorld/_buckconfig
@@ -1,6 +1,6 @@
 
 [android]
-  target = Google Inc.:Google APIs:23
+  target = Google Inc.:Google APIs:25
 
 [maven_repositories]
   central = https://repo1.maven.org/maven2

--- a/local-cli/templates/HelloWorld/android/app/build.gradle
+++ b/local-cli/templates/HelloWorld/android/app/build.gradle
@@ -83,13 +83,13 @@ def enableSeparateBuildPerCPUArchitecture = false
 def enableProguardInReleaseBuilds = false
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion 25
+    buildToolsVersion "25.0.2"
 
     defaultConfig {
         applicationId "com.helloworld"
         minSdkVersion 16
-        targetSdkVersion 22
+        targetSdkVersion 25
         versionCode 1
         versionName "1.0"
         ndk {
@@ -127,7 +127,7 @@ android {
 
 dependencies {
     compile fileTree(dir: "libs", include: ["*.jar"])
-    compile "com.android.support:appcompat-v7:23.0.1"
+    compile "com.android.support:appcompat-v7:25.2.0"
     compile "com.facebook.react:react-native:+"  // From node_modules
 }
 

--- a/scripts/circle-ci-android-setup.sh
+++ b/scripts/circle-ci-android-setup.sh
@@ -6,6 +6,8 @@ function getAndroidSDK {
   DEPS="$ANDROID_HOME/installed-dependencies"
 
   if [ ! -e $DEPS ]; then
+    echo y | android update sdk --no-ui --all --filter android-25
+    echo y | android update sdk --no-ui --all --filter build-tools-25.0.2
     echo y | android update sdk --no-ui --all --filter extra-android-m2repository
     echo no | android create avd -n testAVD -f -t android-19 --abi default/armeabi-v7a &&
     touch $DEPS

--- a/scripts/run-android-emulator.sh
+++ b/scripts/run-android-emulator.sh
@@ -15,5 +15,5 @@ if [ -n "$STATE" ]; then
 fi
 
 echo "Creating virtual device..."
-echo no | android create avd -n testAVD -f -t android-23 --abi default/x86
+echo no | android create avd -n testAVD -f -t android-25 --abi default/x86
 emulator -avd testAVD

--- a/scripts/validate-android-test-env.sh
+++ b/scripts/validate-android-test-env.sh
@@ -41,10 +41,10 @@ if [ -z "$(buck --version)" ]; then
   exit 1
 fi
 
-# BUILD_TOOLS_VERSION is in a format like "23.0.1"
+# BUILD_TOOLS_VERSION is in a format like "25.0.2"
 BUILD_TOOLS_VERSION=`grep buildToolsVersion $(dirname $0)/../ReactAndroid/build.gradle | sed 's/^[^"]*\"//' | sed 's/"//'`
 
-# MAJOR is something like "23"
+# MAJOR is something like "25"
 MAJOR=`echo $BUILD_TOOLS_VERSION | sed 's/\..*//'`
 
 # Check that we have the right major version of the Android SDK.


### PR DESCRIPTION
Fixes https://github.com/facebook/react-native/issues/12929 by using newer versions of Android dependencies:

* Updated Android SDK 23 to 25
* Updated Build Tools from 23.0.1 to 25.0.2
* Updated `compileSdkVersion` and `targetSdkVersion` to 25
* Updated AppCompat from 23.0.1 to 25.2.0

_This is a work in progress, and may require more changes to fix the issue_

This can be tested by:
* Building the Example apps and ensuring they run as expected
* Creating a new app with `react-native init` and ensuring it runs as expected