### PR TITLE
Link to Sketch and CRNA

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -7,7 +7,7 @@ We use GitHub Issues for tracking bugs in React Native.
 
 Your issue may be closed without explanation if it does not provide the information required by this template.
 
---- Please use this template, and delete everything above this line before submitting your issue --- 
+--- Please use this template, and delete everything above this line before submitting your issue ---
 
 ### Description
 
@@ -15,7 +15,7 @@ Your issue may be closed without explanation if it does not provide the informat
 
 ### Reproduction
 
-[FILL THIS OUT: Try to reproduce your bug on rnplay.org and provide a link. If you can't reproduce the bug on rnplay.org, provide a sample project.]
+[FILL THIS OUT: Try to reproduce your bug on https://sketch.expo.io/ and provide a link. If you can't reproduce the bug on Sketch, provide a sample project.]
 
 ### Solution
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,7 +69,7 @@ We are using GitHub Issues for our public bugs. We keep a close eye on this and 
 
 ### Reporting New Issues
 
-The best way to get your bug fixed is to provide a reduced test case. Please provide either a public repository with a runnable example or a [React Native Playground](https://rnplay.org/) snippet.
+The best way to get your bug fixed is to provide a reduced test case. Please provide either a public repository with a runnable example or a [Sketch](https://sketch.expo.io/).
 
 ### Security Bugs
 

--- a/docs/MoreResources.md
+++ b/docs/MoreResources.md
@@ -20,13 +20,15 @@ If you're looking for a library that does a specific thing, check out [Awesome R
 
 ## Example Apps
 
-There are a lot of example apps at the [React Native Playground](https://rnplay.org/apps/picks). You can see the code running on a real device, which is a neat feature.
+There are some example apps in the [`Examples/` directory](https://github.com/facebook/react-native/tree/master/Examples) on GitHub. You can run the apps on a simulator or device, and you can see the source code for these apps, which is neat.
 
 The folks who built the app for Facebook's F8 conference in 2016 also [open-sourced the code](https://github.com/fbsamples/f8app) and wrote up a [detailed series of tutorials](http://makeitopen.com/tutorials/building-the-f8-app/planning/). This is useful if you want a more in-depth example that's more realistic than most sample apps out there.
 
 ## Development Tools
 
 [Nuclide](https://nuclide.io/) is the IDE that Facebook uses internally for React Native development. The killer feature of Nuclide is its debugging ability. It also has great inline Flow support.
+
+[Create React Native App](https://github.com/react-community/create-react-native-app) makes it significantly easier to get started with a React Native project. There's no need to use Xcode or Android Studio, and you can develop for your iOS device using Linux or Windows.
 
 [Ignite](https://github.com/infinitered/ignite) is a starter kit that uses Redux and a few different common UI libraries. It has a CLI to generate apps, components, and containers. If you like all of the individual tech choices, Ignite could be perfect for you.
 


### PR DESCRIPTION
rnplay.org is shutting down on April 1st, 2017. Recommend instead using Expo's improved prototyping tool, Sketch.