### PR TITLE
Explaining how to package ReactNative for Nexus/Maven deployment.

### DIFF
--- a/docs/AndroidBuildingFromSource.md
+++ b/docs/AndroidBuildingFromSource.md
@@ -143,6 +143,18 @@ gradle.projectsLoaded {
 }
 ```
 
+## Building for Maven/Nexus deployment
+
+If you find that you need to push up a locally compiled React Native .aar and related files to a remote Nexus repository, you can.
+
+Start by following the `Point Gradle to your Android SDK` section of this page. Once you do this, assuming you have Gradle configured properly, you can then run the following command from the root of your React Native checkout to build and package all required files:
+
+```
+./gradlew ReactAndroid:installArchives
+```
+
+This will package everything that would typically be included in the `android` directory of your `node_modules/react-native/` installation in the root directory of your React Native checkout. 
+
 ## Testing
 
 If you made changes to React Native and submit a pull request, all tests will run on your pull request automatically. To run the tests locally, see [Testing](docs/testing.html).


### PR DESCRIPTION
**Motivation**

I needed to do this today. It's explained in code in the repository, but not included in the actual documentation. As React Native continues to grow, this is something that will be used more and more by the community.

**Test plan (required)**

No test plan required, this is simply a documentation change to add things that are only explained in code comments currently.
