### PR TITLE
Don't merge before Circle CI tests pass: Re-enable Android e2e test

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -76,9 +76,7 @@ test:
     - node ./scripts/run-android-ci-instrumentation-tests.js --retries 3 --path ./ReactAndroid/src/androidTest/java/com/facebook/react/tests --package com.facebook.react.tests
 
     # Android e2e test
-    # Temp disabled to debug an ongoing issue (so far we think it's packager related).
-    # Re-enable this ASAP once the issue is fixed.
-    #- source scripts/circle-ci-android-setup.sh && retry3 node ./scripts/run-ci-e2e-tests.js --android --js --retries 2
+    - source scripts/circle-ci-android-setup.sh && retry3 node ./scripts/run-ci-e2e-tests.js --android --js --retries 2
 
     # testing docs generation
     - cd website && npm test

--- a/scripts/run-ci-e2e-tests.js
+++ b/scripts/run-ci-e2e-tests.js
@@ -12,10 +12,10 @@
 /**
  * This script tests that React Native end to end installation/bootstrap works for different platforms
  * Available arguments:
- * --ios - to test only ios application end to end
- * --tvos - to test only tvOS application end to end
- * --android - to test only android application end to end
- * --js - to test that JS in the application is compilable
+ * --ios - 'react-native init' and check iOS app doesn't redbox
+ * --tvos - 'react-native init' and check tvOS app doesn't redbox
+ * --android - 'react-native init' and check Android app doesn't redbox
+ * --js - 'react-native init' and only check the packager returns a bundle
  * --skip-cli-install - to skip react-native-cli global installation (for local debugging)
  * --retries [num] - how many times to retry possible flaky commands: npm install and running tests, default 1
  */
@@ -113,16 +113,18 @@ try {
     cd('..');
     exec('keytool -genkey -v -keystore android/keystores/debug.keystore -storepass android -alias androiddebugkey -keypass android -dname "CN=Android Debug,O=Android,C=US"');
 
-    echo(`Starting packager server, ${SERVER_PID}`);
+    echo(`Starting appium server, ${APPIUM_PID}`);
     const appiumProcess = spawn('node', ['./node_modules/.bin/appium']);
     APPIUM_PID = appiumProcess.pid;
-    echo(`Starting appium server, ${APPIUM_PID}`);
-    echo('Building app');
+
+    echo('Building the app');
     if (exec('buck build android/app').code) {
       echo('could not execute Buck build, is it installed and in PATH?');
       exitCode = 1;
       throw Error(exitCode);
     }
+
+    echo(`Starting packager server, ${SERVER_PID}`);
     const packagerEnv = Object.create(process.env);
     packagerEnv.REACT_NATIVE_MAX_WORKERS = 1;
     // shelljs exec('', {async: true}) does not emit stdout events, so we rely on good old spawn


### PR DESCRIPTION
Disabled earlier today, a fix for HMR landed so let's test it works.

Test plan: Circle CI tests pass on this PR.