### PR TITLE
Add support for trackHeight to Slider on iOS

### DIFF
--- a/Examples/UIExplorer/js/SliderExample.js
+++ b/Examples/UIExplorer/js/SliderExample.js
@@ -176,4 +176,15 @@ exports.examples = [
       );
     }
   },
+  {
+    title: 'Custom track height',
+    platform: 'ios',
+    render(): React.Element<any> {
+      return (
+        <SliderExample
+          trackHeight={10}
+        />
+      );
+    }
+  },
 ];

--- a/Libraries/Components/Slider/Slider.js
+++ b/Libraries/Components/Slider/Slider.js
@@ -115,6 +115,12 @@ var Slider = React.createClass({
     thumbImage: Image.propTypes.source,
 
     /**
+     * Sets the height for the track image.
+     * @platform ios
+     */
+    trackHeight: PropTypes.number,
+
+    /**
      * Color of the foreground switch grip.
      * @platform android
      */

--- a/React/Views/RCTSlider.h
+++ b/React/Views/RCTSlider.h
@@ -25,5 +25,7 @@
 
 @property (nonatomic, strong) UIImage *thumbImage;
 
+@property (nonatomic, strong) NSNumber *trackHeight;
+
 
 @end

--- a/React/Views/RCTSlider.m
+++ b/React/Views/RCTSlider.m
@@ -86,4 +86,17 @@
   return [self thumbImageForState:UIControlStateNormal];
 }
 
+- (void)setTrackHeight:(NSNumber*)trackHeight
+{
+  _trackHeight = trackHeight;
+}
+
+- (CGRect)trackRectForBounds:(CGRect)bounds {
+    CGRect trackBounds = [super trackRectForBounds:bounds];
+    if(_trackHeight != nil) {
+      trackBounds.size.height = _trackHeight.floatValue;
+    }
+    return trackBounds;
+}
+
 @end

--- a/React/Views/RCTSliderManager.m
+++ b/React/Views/RCTSliderManager.m
@@ -86,6 +86,7 @@ RCT_EXPORT_VIEW_PROPERTY(maximumTrackTintColor, UIColor);
 RCT_EXPORT_VIEW_PROPERTY(onValueChange, RCTBubblingEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onSlidingComplete, RCTBubblingEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(thumbImage, UIImage);
+RCT_EXPORT_VIEW_PROPERTY(trackHeight, NSNumber);
 RCT_CUSTOM_VIEW_PROPERTY(disabled, BOOL, RCTSlider)
 {
   if (json) {


### PR DESCRIPTION
This pull request adds support for a trackHeight prop to the Slider component.

tagging @lacker and @mkonicek because I deleted the last repo and had to create a new PR, so here we are. Old one was #11518 

Tested by confirming in UIExplorer that the change works, but I can't get figure out how to update the UIExplorer expected result screenshot / get integration tests to pass. Visually you can confirm it works:

![image](https://cloud.githubusercontent.com/assets/1130084/23929862/f603f926-08e5-11e7-997e-9d3560033503.png)