### PR TITLE
Fixes an issue when in release mode and packager can’t create a bundl…

### DIFF
--- a/packager/react-native-xcode.sh
+++ b/packager/react-native-xcode.sh
@@ -93,7 +93,7 @@ $NODE_BINARY "$REACT_NATIVE_DIR/local-cli/cli.js" bundle \
   --bundle-output "$BUNDLE_FILE" \
   --assets-dest "$DEST"
 
-if [[ ! $DEV && ! -f "$BUNDLE_FILE" ]]; then
+if [[ $DEV == false && ! -f "$BUNDLE_FILE" ]]; then
   echo "error: File $BUNDLE_FILE does not exist. This must be a bug with" >&2
   echo "React Native, please report it here: https://github.com/facebook/react-native/issues"
   exit 2


### PR DESCRIPTION
Fixes an issue when in release mode and packager can’t create a bundle file the xcode build scripts exits with exitcode 0. This still happens even after commit ea7b2ef36b1a0b141c4b64d0ab5d6d3a94be14a4 was merged.

The current condition will never resolve to true
```sh
if [[ !  $DEV && ! -f "$BUNDLE_FILE" ]]
```

This condition will resolve to true if this is a release build and there is no bundle.
```sh
if [[ $DEV == false && ! -f "$BUNDLE_FILE" ]]
```

Thanks!