### PR TITLE
[WIP] Add onClose props to the Modal component

### DIFF
--- a/Libraries/Modal/Modal.js
+++ b/Libraries/Modal/Modal.js
@@ -108,6 +108,10 @@ class Modal extends React.Component {
      */
     onRequestClose: Platform.OS === 'android' ? PropTypes.func.isRequired : PropTypes.func,
     /**
+     * The `onClose` prop allows passing a function that will be called once the modal has been closed.
+     */
+    onClose: PropTypes.func,
+    /**
      * The `onShow` prop allows passing a function that will be called once the modal has been shown.
      */
     onShow: PropTypes.func,
@@ -168,6 +172,7 @@ class Modal extends React.Component {
         transparent={this.props.transparent}
         hardwareAccelerated={this.props.hardwareAccelerated}
         onRequestClose={this.props.onRequestClose}
+        onClose={this.props.onClose}
         onShow={this.props.onShow}
         style={styles.modal}
         onStartShouldSetResponder={this._shouldSetResponder}

--- a/React/Views/RCTModalHostView.h
+++ b/React/Views/RCTModalHostView.h
@@ -23,6 +23,7 @@
 @property (nonatomic, copy) NSString *animationType;
 @property (nonatomic, assign, getter=isTransparent) BOOL transparent;
 
+@property (nonatomic, copy) RCTDirectEventBlock onClose;
 @property (nonatomic, copy) RCTDirectEventBlock onShow;
 
 @property (nonatomic, weak) id<RCTModalHostViewInteractor> delegate;

--- a/React/Views/RCTModalHostViewManager.m
+++ b/React/Views/RCTModalHostViewManager.m
@@ -69,10 +69,15 @@ RCT_EXPORT_MODULE()
 
 - (void)dismissModalHostView:(RCTModalHostView *)modalHostView withViewController:(RCTModalHostViewController *)viewController animated:(BOOL)animated
 {
+  dispatch_block_t completionBlock = ^{
+    if (modalHostView.onClose) {
+      modalHostView.onClose(nil);
+    }
+  };
   if (_dismissalBlock) {
-    _dismissalBlock([modalHostView reactViewController], viewController, animated, nil);
+    _dismissalBlock([modalHostView reactViewController], viewController, animated, completionBlock);
   } else {
-    [viewController dismissViewControllerAnimated:animated completion:nil];
+    [viewController dismissViewControllerAnimated:animated completion:completionBlock];
   }
 }
 
@@ -92,6 +97,7 @@ RCT_EXPORT_MODULE()
 
 RCT_EXPORT_VIEW_PROPERTY(animationType, NSString)
 RCT_EXPORT_VIEW_PROPERTY(transparent, BOOL)
+RCT_EXPORT_VIEW_PROPERTY(onClose, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onShow, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(supportedOrientations, NSArray)
 RCT_EXPORT_VIEW_PROPERTY(onOrientationChange, RCTDirectEventBlock)

--- a/ReactAndroid/src/main/java/com/facebook/react/views/modal/CloseEvent.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/modal/CloseEvent.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+package com.facebook.react.views.modal;
+
+import com.facebook.react.uimanager.events.Event;
+import com.facebook.react.uimanager.events.RCTEventEmitter;
+
+/**
+ * {@link Event} for showing a Dialog.
+ */
+/* package */ class CloseEvent extends Event<CloseEvent> {
+
+  public static final String EVENT_NAME = "topClose";
+
+  protected CloseEvent(int viewTag) {
+    super(viewTag);
+  }
+
+  @Override
+  public String getEventName() {
+    return EVENT_NAME;
+  }
+
+  @Override
+  public void dispatch(RCTEventEmitter rctEventEmitter) {
+    rctEventEmitter.receiveEvent(getViewTag(), getEventName(), null);
+  }
+}

--- a/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostManager.java
@@ -84,6 +84,13 @@ public class ReactModalHostManager extends ViewGroupManager<ReactModalHostView> 
           dispatcher.dispatchEvent(new RequestCloseEvent(view.getId()));
         }
       });
+    view.setOnCloseListener(
+      new DialogInterface.OnDismissListener() {
+        @Override
+        public void onDismiss(DialogInterface dialog) {
+          dispatcher.dispatchEvent(new CloseEvent(view.getId()));
+        }
+    });
     view.setOnShowListener(
       new DialogInterface.OnShowListener() {
         @Override

--- a/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.java
@@ -67,6 +67,7 @@ public class ReactModalHostView extends ViewGroup implements LifecycleEventListe
   // be created.  For instance, animation does since it affects Dialog creation through the theme
   // but transparency does not since we can access the window to update the property.
   private boolean mPropertyRequiresNewDialog;
+  private @Nullable DialogInterface.OnDismissListener mOnDismissListener;
   private @Nullable DialogInterface.OnShowListener mOnShowListener;
   private @Nullable OnRequestCloseListener mOnRequestCloseListener;
 
@@ -142,6 +143,10 @@ public class ReactModalHostView extends ViewGroup implements LifecycleEventListe
     mOnRequestCloseListener = listener;
   }
 
+  protected void setOnCloseListener(DialogInterface.OnDismissListener listener) {
+    mOnDismissListener = listener;
+  }
+
   protected void setOnShowListener(DialogInterface.OnShowListener listener) {
     mOnShowListener = listener;
   }
@@ -214,6 +219,7 @@ public class ReactModalHostView extends ViewGroup implements LifecycleEventListe
     mDialog.setContentView(getContentView());
     updateProperties();
 
+    mDialog.setOnDismissListener(mOnDismissListener);
     mDialog.setOnShowListener(mOnShowListener);
     mDialog.setOnKeyListener(
       new DialogInterface.OnKeyListener() {


### PR DESCRIPTION
This PR adds a new prop (`onClose`) to the `Modal` component. This prop will provide a way to be possible to detect when the modal is dismissed.
Prefer **small pull requests**. These are much easier to review and more likely to get merged. Make sure the PR does only one thing, otherwise please split it.

```
<Modal
  ...
  onClose={() => console.log('closed');}
>
```

**I am having some problems, the event is not getting propagated to the JS layer (in iOS I added some breakpoints and the callbacks are being called...). Any tips to fix this?**

@satya164 sorry to bother you, but do you have any insights about the PR? Am I missing something?