### PR TITLE
Remove unnecessary permissions, fixes #5886

### DIFF
--- a/local-cli/templates/HelloWorld/android/app/src/main/AndroidManifest.xml
+++ b/local-cli/templates/HelloWorld/android/app/src/main/AndroidManifest.xml
@@ -1,10 +1,17 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     package="com.helloworld"
     android:versionCode="1"
     android:versionName="1.0">
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
+
+    <!-- These permissions are added implicitly by android-jsc, see https://github.com/facebook/android-jsc/pull/12 -->
+    <!-- The following lines can be removed after android-jsc is updated in react-native -->
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" tools:node="remove" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" tools:node="remove" />
+    <uses-permission android:name="android.permission.READ_PHONE_STATE" tools:node="remove"/>
 
     <uses-sdk
         android:minSdkVersion="16"

--- a/local-cli/templates/HelloWorld/android/app/src/release/AndroidManifest.xml
+++ b/local-cli/templates/HelloWorld/android/app/src/release/AndroidManifest.xml
@@ -1,0 +1,8 @@
+<manifest
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    >
+
+    <!-- These are added by React Native for debug mode, but aren't needed in release mode -->
+    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" tools:node="remove" />
+</manifest>


### PR DESCRIPTION
## Motivation

The current `react-native init` generates a project with unreasonable default permissions:

- `SYSTEM_ALERT_WINDOW` is used for debugging, but should be removed for release in almost all cases
- `WRITE_EXTERNAL_STORAGE`, `READ_EXTERNAL_STORAGE`, and `READ_PHONE_STATE` are implicitly [added due to android-jsc](https://github.com/facebook/react-native/issues/5886#issuecomment-200862582) (see https://github.com/facebook/android-jsc/pull/12, which has not been pulled into React Native proper yet)

See #5886 for more details - this is one implementation of a proposed solution, the only one I could get working, happy to adjust with feedback though

## Test Plan

Tried to get `init` working locally but rather tough - any thoughts?