### PR TITLE
Update Networking.md

### DIFF
--- a/docs/Networking.md
+++ b/docs/Networking.md
@@ -106,6 +106,8 @@ request.send();
 React Native also supports [WebSockets](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket), a protocol which provides full-duplex communication channels over a single TCP connection.
 
 ```js
+import { WebSocketModule } from 'react-native';
+
 var ws = new WebSocket('ws://host.com/path');
 
 ws.onopen = () => {


### PR DESCRIPTION
## Motivation (required)

I ran into an `undefined is not a constructor` when I tried initiating a WebSocket connection. I imported the WebSocket module like so:`import { WebSocket } from 'react-native'`. 

When I changed it to `import { WebSocketModule } from 'react-native'` it worked. So I see two possible solutions:

1. renaming the `WebSocketModule` to `WebSocket`
2. updating the docs

This PR is for #2.

## Test Plan (required)

I have tested the code in both the iOS and Android emulators and compiled into a very simple app.

## Next Steps

I have signed the CLA.
