### PR TITLE
Update Android compileSdkVersion and Build Tools

### DIFF
--- a/ContainerShip/Dockerfile.android-base
+++ b/ContainerShip/Dockerfile.android-base
@@ -64,14 +64,14 @@ RUN rm ndk.zip
 
 # add android SDK tools
 # 2 - Android SDK Platform-tools, revision 25.0.3
-# 12 - Android SDK Build-tools, revision 23.0.1
 # 35 - SDK Platform Android 6.0, API 23, revision 3
+# 3 - Android SDK Build-tools, revision 25.0.2
 # 39 - SDK Platform Android 4.4.2, API 19, revision 4
 # 102 - ARM EABI v7a System Image, Android API 19, revision 5
 # 103 - Intel x86 Atom System Image, Android API 19, revision 5
 # 131 - Google APIs, Android API 23, revision 1
 # 166 - Android Support Repository, revision 41
-RUN echo "y" | android update sdk -u -a -t 2,12,35,39,102,103,131,166
+RUN echo "y" | android update sdk -u -a -t 2,3,35,39,102,103,131,166
 RUN ln -s /opt/android/platform-tools/adb /usr/bin/adb
 
 # clean up unnecessary directories

--- a/Examples/Movies/android/app/build.gradle
+++ b/Examples/Movies/android/app/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion 25
+    buildToolsVersion "25.0.2"
 
     defaultConfig {
         applicationId "com.facebook.react.movies"

--- a/Examples/TicTacToe/android/app/build.gradle
+++ b/Examples/TicTacToe/android/app/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion 25
+    buildToolsVersion "25.0.2"
 
     defaultConfig {
         applicationId "com.facebook.react.tictactoe"

--- a/Examples/UIExplorer/android/app/build.gradle
+++ b/Examples/UIExplorer/android/app/build.gradle
@@ -83,8 +83,8 @@ def enableSeparateBuildPerCPUArchitecture = false
 def enableProguardInReleaseBuilds = false
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion 25
+    buildToolsVersion "25.0.2"
 
     defaultConfig {
         applicationId "com.facebook.react.uiapp"

--- a/ReactAndroid/DevExperience.md
+++ b/ReactAndroid/DevExperience.md
@@ -5,7 +5,7 @@ Assuming you have the [Android SDK](https://developer.android.com/sdk/installing
 Make sure you have the following installed:
 
 - Android SDK version 23
-- SDK build tools version 23
+- SDK build tools version 25
 - Android Support Repository 17 (for Android Support Library)
 
 Follow steps on https://github.com/facebook/react-native/blob/master/react-native-cli/CONTRIBUTING.md, but be sure to bump the version of react-native in package.json to some version > 0.9 (latest published npm version) or set up proxying properly for react-native

--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -226,8 +226,8 @@ task packageReactNdkLibsForBuck(dependsOn: packageReactNdkLibs, type: Copy) {
 }
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion 25
+    buildToolsVersion "25.0.2"
 
     defaultConfig {
         minSdkVersion 16

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         mavenLocal()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.2'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'de.undercouch:gradle-download-task:3.1.2'
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/docs/AndroidBuildingFromSource.md
+++ b/docs/AndroidBuildingFromSource.md
@@ -18,7 +18,7 @@ Assuming you have the Android SDK installed, run `android` to open the Android S
 Make sure you have the following installed:
 
 1. Android SDK version 23 (compileSdkVersion in [`build.gradle`](https://github.com/facebook/react-native/blob/master/ReactAndroid/build.gradle))
-2. SDK build tools version 23.0.1 (buildToolsVersion in [`build.gradle`](https://github.com/facebook/react-native/blob/master/ReactAndroid/build.gradle))
+2. SDK build tools version 25.0.2 (buildToolsVersion in [`build.gradle`](https://github.com/facebook/react-native/blob/master/ReactAndroid/build.gradle))
 3. Android Support Repository >= 17 (for Android Support Library)
 4. Android NDK (download links and installation instructions below)
 
@@ -76,7 +76,7 @@ Add `gradle-download-task` as dependency in `android/build.gradle`:
 ```gradle
 ...
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.3.1'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'de.undercouch:gradle-download-task:3.1.2'
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -226,7 +226,7 @@ Select the "SDK Platforms" tab from within the SDK Manager, then check the box n
 
 ![Android SDK Manager](img/AndroidSDKManager.png)
 
-Next, select the "SDK Tools" tab and check the box next to "Show Package Details" here as well. Look for and expand the "Android SDK Build Tools" entry, then make sure that `Android SDK Build-Tools 23.0.1` is selected.
+Next, select the "SDK Tools" tab and check the box next to "Show Package Details" here as well. Look for and expand the "Android SDK Build Tools" entry, then make sure that `Android SDK Build-Tools 25.0.2` is selected.
 
 Finally, click "Apply" to download and install the Android SDK and related build tools.
 

--- a/local-cli/templates/HelloWorld/android/app/build.gradle
+++ b/local-cli/templates/HelloWorld/android/app/build.gradle
@@ -83,8 +83,8 @@ def enableSeparateBuildPerCPUArchitecture = false
 def enableProguardInReleaseBuilds = false
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion 25
+    buildToolsVersion "25.0.2"
 
     defaultConfig {
         applicationId "com.helloworld"

--- a/scripts/circle-ci-android-setup.sh
+++ b/scripts/circle-ci-android-setup.sh
@@ -6,6 +6,7 @@ function getAndroidSDK {
   DEPS="$ANDROID_HOME/installed-dependencies"
 
   if [ ! -e $DEPS ]; then
+    echo y | android update sdk --no-ui --all --filter build-tools-25.0.2
     echo y | android update sdk --no-ui --all --filter extra-android-m2repository
     echo no | android create avd -n testAVD -f -t android-19 --abi default/armeabi-v7a &&
     touch $DEPS

--- a/scripts/validate-android-test-env.sh
+++ b/scripts/validate-android-test-env.sh
@@ -41,7 +41,7 @@ if [ -z "$(buck --version)" ]; then
   exit 1
 fi
 
-# BUILD_TOOLS_VERSION is in a format like "23.0.1"
+# BUILD_TOOLS_VERSION is in a format like "25.0.2"
 BUILD_TOOLS_VERSION=`grep buildToolsVersion $(dirname $0)/../ReactAndroid/build.gradle | sed 's/^[^"]*\"//' | sed 's/"//'`
 
 # MAJOR is something like "23"


### PR DESCRIPTION
Fixes https://github.com/facebook/react-native/issues/12929 by using a newer `compileSdkVersion` and Build Tools version:

* Updated Build Tools from 23.0.1 to 25.0.2
* Updated `compileSdkVersion` and `targetSdkVersion` to 25

This can be tested by:
* Building the Example apps and ensuring they run as expected
* Creating a new app with `react-native init` and ensuring it runs as expected