### PR TITLE
[iOS] Add missing `toggleElementInspector` event send when `jsLoaded`

### DIFF
--- a/React/Modules/RCTDevSettings.mm
+++ b/React/Modules/RCTDevSettings.mm
@@ -454,6 +454,14 @@ RCT_EXPORT_METHOD(toggleElementInspector)
   dispatch_async(dispatch_get_main_queue(), ^{
     // update state again after the bridge has finished loading
     [self _synchronizeAllSettings];
+
+    // Inspector can only be shown after JS has loaded
+    if ([self isElementInspectorShown]) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+      [self.bridge.eventDispatcher sendDeviceEventWithName:@"toggleElementInspector" body:nil];
+#pragma clang diagnostic pop
+    }
   });
 }
 


### PR DESCRIPTION
- [x] Explain the **motivation** for making this change.
- [x] Provide a **test plan** demonstrating that the code is solid.
- [x] Match the **code formatting** of the rest of the codebase.
- [x] Target the `master` branch, NOT a "stable" branch.

## Motivation (required)

The PR #11613 (0.43) removed this missing `toggleElementInspector` event send when `jsLoaded` in DevMenu (Now is DevSettings), it should open the inspector if `isElementInspectorShown` is true when we reload JS.

The dev menu text `Show / Hide Inspector` is dependent on `isElementInspectorShown` bool value.

([This behavior in 0.42](https://github.com/facebook/react-native/blob/0.42-stable/React/Modules/RCTDevMenu.mm#L436-L442))

## Test Plan (required)

Manual testing in UIExplorer:

* Open the dev menu and click `Show Inspector`
* Open the dev menu and click `Reload JS`
* The built-in inspector should keep open (dev menu text: `Hide Inspector`)
