### PR TITLE
more accurate product-name regex

### DIFF
--- a/local-cli/runIOS/runIOS.js
+++ b/local-cli/runIOS/runIOS.js
@@ -157,7 +157,7 @@ function buildProject(xcodeProject, udid, scheme, configuration = 'Debug', launc
     });
     buildProcess.on('close', function(code) {
       //FULL_PRODUCT_NAME is the actual file name of the app, which actually comes from the Product Name in the build config, which does not necessary match a scheme name,  example output line: export FULL_PRODUCT_NAME="Super App Dev.app"
-      let productNameMatch = /export FULL_PRODUCT_NAME="?(.+).app/.exec(buildOutput);
+      let productNameMatch = /export FULL_PRODUCT_NAME="?(.+).app"?$/.exec(buildOutput);
       if (productNameMatch && productNameMatch.length && productNameMatch.length > 1) {
         return resolve(productNameMatch[1]);//0 is the full match, 1 is the app name
       }


### PR DESCRIPTION
Some projects define multiple targets, including app extensions, which are built with a “.appex” extension.   This fix prevents the buildProject method from selecting any app extension (e.g. a Today.appex today-widget extension) as the product name.

Thanks for submitting a PR! Please read these instructions carefully:

- [X] Explain the **motivation** for making this change.
- [X] Provide a **test plan** demonstrating that the code is solid.
- [X] Match the **code formatting** of the rest of the codebase.
- [X] Target the `master` branch, NOT a "stable" branch.

## Motivation (required)

When building our workspace, ReactNative was failing to install the app to the simulator because it calculated an incorrect path to the app itself.   It was attempting to install "Today.app" when it should have been installing "Remitly.app".   I discovered that ReactNative parses the build output to identify the generated app name, and that this was broken when the build also generated an app extension.  The fix was to tighten the regex to not select any target that produces a ".appex" filename. 

My build output outputs the following:

```
...
export FULL_PRODUCT_NAME=Today.appex
...
```

and then later:

```
...
export FULL_PRODUCT_NAME=Remitly.app
...
```

ReactNative was choosing the first FULL_PRODUCT_NAME=Today.appex.  My change forces it to find a product that actually generates a ".app" (vs. ".appex").

## Test Plan (required)

The command I ran:

```
react-native run-ios --scheme Debug
```

Here is the tail of the output prior to the fix.   Note that the app name is incorrect - "Today.app".  "Today" is the name of the Today app extension which is built as part of the product, but is not in-fact the app itself:

```
** BUILD SUCCEEDED **


Installing build/Build/Products/Debug-iphonesimulator/Today.app
An error was encountered processing the command (domain=NSPOSIXErrorDomain, code=2):
Failed to install the requested application
An application bundle was not found at the provided path.
Provide a valid path to the desired application bundle.
Print: Entry, ":CFBundleIdentifier", Does Not Exist

Command failed: /usr/libexec/PlistBuddy -c Print:CFBundleIdentifier build/Build/Products/Debug-iphonesimulator/Today.app/Info.plist
Print: Entry, ":CFBundleIdentifier", Does Not Exist


error Command failed with exit code 1.
```

Here is the tail of the output after the fix.   Note that the app name is now correct - "Remitly.app".

```
** BUILD SUCCEEDED **


Installing build/Build/Products/Debug-iphonesimulator/Remitly.app
Launching internal.remitly.remitly
internal.remitly.remitly: 98666
✨  Done in 25.77s.
```


## Next Steps

Sign the [CLA][2], if you haven't already.

Small pull requests are much easier to review and more likely to get merged. Make sure the PR does only one thing, otherwise please split it.

Make sure all **tests pass** on both [Travis][3] and [Circle CI][4]. PRs that break tests are unlikely to be merged.

For more info, see the ["Pull Requests"][5] section of our "Contributing" guidelines.

[1]: https://medium.com/@martinkonicek/what-is-a-test-plan-8bfc840ec171#.y9lcuqqi9
[2]: https://code.facebook.com/cla
[3]: https://travis-ci.org/facebook/react-native
[4]: http://circleci.com/gh/facebook/react-native
[5]: https://github.com/facebook/react-native/blob/master/CONTRIBUTING.md#pull-requests