### PR TITLE
Fix suggestion to "npm start -- --reset-cache"

### DIFF
--- a/packager/src/node-haste/DependencyGraph/ResolutionRequest.js
+++ b/packager/src/node-haste/DependencyGraph/ResolutionRequest.js
@@ -391,7 +391,7 @@ class ResolutionRequest {
               `To resolve try the following:\n` +
               `  1. Clear watchman watches: \`watchman watch-del-all\`.\n` +
               `  2. Delete the \`node_modules\` folder: \`rm -rf node_modules && npm install\`.\n` +
-              '  3. Reset packager cache: `rm -fr $TMPDIR/react-*` or `npm start --reset-cache`.'
+              '  3. Reset packager cache: `rm -fr $TMPDIR/react-*` or `npm start -- --reset-cache`.'
             );
           });
         });


### PR DESCRIPTION
As discussed in https://github.com/facebook/react-native/pull/11983. The double dash is necessary to pass through the argument to node. Based on the comments [here](https://github.com/facebook/react-native/issues/1924#issuecomment-249861004), it looks like most people use the double dash; it's unclear whether it would do anything at all if the dashes were omitted. If anyone else has better insight, let me know!

Test plan:

- Run `npm start -- --reset-cache` and load your app
  - You should see the following message (at least on RN v0.42): `warning: the transform cache was reset.`
- Run `npm start --reset-cache` (without the double dash) and load your app
   - The warning should not appear, because the cache was not reset

@hramos please review, thank you.

This reverts commit f521e992ccbcf684f88dcf6b3de25edc3df7cbfe.