### PR TITLE
[podspec] Fix issue with whitespace in path to source and stabilise CI.

### DIFF
--- a/React.podspec
+++ b/React.podspec
@@ -62,7 +62,7 @@ Pod::Spec.new do |s|
   s.subspec "jschelpers" do |ss|
     ss.source_files         = "ReactCommon/jschelpers/{JavaScriptCore,JSCWrapper}.{cpp,h}", "ReactCommon/jschelpers/systemJSCWrapper.cpp"
     ss.private_header_files = "ReactCommon/jschelpers/{JavaScriptCore,JSCWrapper}.h"
-    ss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "$(PODS_TARGET_SRCROOT)/ReactCommon" }
+    ss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\"" }
     ss.framework            = "JavaScriptCore"
   end
 
@@ -70,7 +70,7 @@ Pod::Spec.new do |s|
     ss.dependency             "React/jschelpers"
     ss.source_files         = "ReactCommon/cxxreact/{JSBundleType,oss-compat-util}.{cpp,h}"
     ss.private_header_files = "ReactCommon/cxxreact/{JSBundleType,oss-compat-util}.h"
-    ss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "$(PODS_TARGET_SRCROOT)/ReactCommon" }
+    ss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\"" }
   end
 
   s.subspec "ART" do |ss|

--- a/ReactCommon/yoga/Yoga.podspec
+++ b/ReactCommon/yoga/Yoga.podspec
@@ -1,7 +1,7 @@
 package = JSON.parse(File.read(File.expand_path('../../package.json', __dir__)))
 version = package['version']
 
-source = { :git => 'https://github.com/facebook/react-native.git' }
+source = { :git => ENV['INSTALL_YOGA_FROM_LOCATION'] || 'https://github.com/facebook/react-native.git' }
 if version == '1000.0.0'
   # This is an unpublished version, use the latest commit hash of the react-native repo, which we’re presumably in.
   source[:commit] = `git rev-parse HEAD`.strip

--- a/scripts/process-podspecs.sh
+++ b/scripts/process-podspecs.sh
@@ -44,7 +44,7 @@ push() {
   local SPEC_DIR="$SPEC_REPO_DIR/$POD_NAME/$(version $SPEC_NAME)"
   local SPEC_PATH="$SPEC_DIR/$SPEC_NAME.json"
   mkdir -p $SPEC_DIR
-  env INSTALL_YOGA_WITHOUT_PATH_OPTION=1 pod ipc spec $SPEC_NAME > $SPEC_PATH
+  env INSTALL_YOGA_WITHOUT_PATH_OPTION=1 INSTALL_YOGA_FROM_LOCATION="$ROOT" pod ipc spec $SPEC_NAME > $SPEC_PATH
 }
 
 # Perform linting and publishing of podspec in cwd.


### PR DESCRIPTION
* Fixes issue where headers could not be found due to whitespace in an unquoted header search path. https://github.com/facebook/react-native/issues/11781#issuecomment-287176373
* Stabilises CI but not needing to download the source for Yoga, but use the existing cloned repo instead.

/cc @mkonicek 