### PR TITLE
Issue13077

### DIFF
--- a/local-cli/link/android/isInstalled.js
+++ b/local-cli/link/android/isInstalled.js
@@ -4,5 +4,5 @@ const makeBuildPatch = require('./patches/makeBuildPatch');
 module.exports = function isInstalled(config, name) {
   return fs
     .readFileSync(config.buildGradlePath)
-    .indexOf(makeBuildPatch(name).trim().patch) > -1;
+    .indexOf(makeBuildPatch(name).patch.trim()) > -1;
 };

--- a/local-cli/link/android/isInstalled.js
+++ b/local-cli/link/android/isInstalled.js
@@ -4,5 +4,5 @@ const makeBuildPatch = require('./patches/makeBuildPatch');
 module.exports = function isInstalled(config, name) {
   return fs
     .readFileSync(config.buildGradlePath)
-    .indexOf(makeBuildPatch(name).patch) > -1;
+    .indexOf(makeBuildPatch(name).trim().patch) > -1;
 };


### PR DESCRIPTION
## Motivation (required)

Fixes #13077: on Windows, when using `autocrlf=true`, then `react-native link` will fail to recognize that Android libraries have already been linked and will link them again.

Android's `isInstalled.js` now `trim`s the pattern it's looking for so that it's newline-neutral. Note that `react-native link` will still unconditionally use a `\n` when patching the file, but git will automatically adjust this according to `autocrlf` upon a push + pull.

## Test Plan (required)

Had some problems due to git newline manipulation to add separate `build.gradle` samples that will consistently have `\n` or `\r\n` on all platforms. :-/