### PR TITLE
Pinned react (and co) to 16.0.0-alpha.4

### DIFF
--- a/local-cli/init/init.js
+++ b/local-cli/init/init.js
@@ -60,15 +60,24 @@ function init(projectDir, argsOrName) {
  */
 function generateProject(destinationRoot, newProjectName, options) {
   var reactNativePackageJson = require('../../package.json');
-  var { peerDependencies } = reactNativePackageJson;
+  var { devDependencies, peerDependencies } = reactNativePackageJson;
   if (!peerDependencies) {
     console.error('Missing React peer dependency in React Native\'s package.json. Aborting.');
+    return;
+  } else if (!devDependencies) {
+    console.error('Missing react-test-renderer dev dependency in React Native\'s package.json. Aborting.');
     return;
   }
 
   var reactVersion = peerDependencies.react;
   if (!reactVersion) {
     console.error('Missing React peer dependency in React Native\'s package.json. Aborting.');
+    return;
+  }
+
+  var reactTestRendererVersion = devDependencies['react-test-renderer'];
+  if (!reactTestRendererVersion) {
+    console.error('Missing react-test-renderer dev dependency in React Native\'s package.json. Aborting.');
     return;
   }
 
@@ -88,7 +97,7 @@ function generateProject(destinationRoot, newProjectName, options) {
   }
   if (!options['skip-jest']) {
     const jestDeps = (
-      `jest babel-jest babel-preset-react-native react-test-renderer@${reactVersion}`
+      `jest babel-jest babel-preset-react-native react-test-renderer@${reactTestRendererVersion}`
     );
     if (yarnVersion) {
       console.log('Adding Jest...');

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "react-native": "local-cli/wrong-react-native.js"
   },
   "peerDependencies": {
-    "react": "~16.0.0-alpha.4"
+    "react": "16.0.0-alpha.4"
   },
   "dependencies": {
     "absolute-path": "^0.0.0",
@@ -223,9 +223,9 @@
     "jest-repl": "19.0.2",
     "jest-runtime": "19.0.2",
     "mock-fs": "^3.11.0",
-    "react": "~16.0.0-alpha.4",
-    "react-dom": "~16.0.0-alpha.4",
-    "react-test-renderer": "~16.0.0-alpha.3",
+    "react": "16.0.0-alpha.4",
+    "react-dom": "16.0.0-alpha.4",
+    "react-test-renderer": "16.0.0-alpha.3",
     "shelljs": "0.6.0",
     "sinon": "^2.0.0-pre.2"
   }


### PR DESCRIPTION
Some time ago (24a7665) the version of React specified in `package.json` was relaxed (presumably unintentionally). As a result, a recent backwards-incompatible release of React 16 alpha 5 caused some breakage in OSS.

This PR pins the version of React to avoid breaking changes in subsequent alpha releases until the React team has created codemods and prepared the ReactNative codebase for this.

Since the change to `package.json` was made in February, this PR will need to go into the RC branch for the next ReactNative release in order to avoid breaking other apps in the OSS community.

cc @mkonicek, @gaearon, @javache  