### PR TITLE
Android - Fix Drawable v4 paths in Android Artifact Resources (Libraries)

### DIFF
--- a/local-cli/bundle/assetPathUtils.js
+++ b/local-cli/bundle/assetPathUtils.js
@@ -10,12 +10,12 @@
 
 function getAndroidAssetSuffix(scale) {
   switch (scale) {
-    case 0.75: return 'ldpi';
-    case 1: return 'mdpi';
-    case 1.5: return 'hdpi';
-    case 2: return 'xhdpi';
-    case 3: return 'xxhdpi';
-    case 4: return 'xxxhdpi';
+    case 0.75: return 'ldpi-v4';
+    case 1: return 'mdpi-v4';
+    case 1.5: return 'hdpi-v4';
+    case 2: return 'xhdpi-v4';
+    case 3: return 'xxhdpi-v4';
+    case 4: return 'xxxhdpi-v4';
   }
 }
 

--- a/local-cli/bundle/assetPathUtils.js
+++ b/local-cli/bundle/assetPathUtils.js
@@ -10,12 +10,12 @@
 
 function getAndroidAssetSuffix(scale) {
   switch (scale) {
-    case 0.75: return 'ldpi-v4';
-    case 1: return 'mdpi-v4';
-    case 1.5: return 'hdpi-v4';
-    case 2: return 'xhdpi-v4';
-    case 3: return 'xxhdpi-v4';
-    case 4: return 'xxxhdpi-v4';
+    case 0.75: return 'ldpi';
+    case 1: return 'mdpi';
+    case 1.5: return 'hdpi';
+    case 2: return 'xhdpi';
+    case 3: return 'xxhdpi';
+    case 4: return 'xxxhdpi';
   }
 }
 

--- a/react.gradle
+++ b/react.gradle
@@ -21,6 +21,7 @@ void runBefore(String dependentTaskName, Task task) {
 }
 
 gradle.projectsEvaluated {
+    def isAndroidLibrary = plugins.hasPlugin("com.android.library")
     // Grab all build types and product flavors
     def buildTypes = android.buildTypes.collect { type -> type.name }
     def productFlavors = android.productFlavors.collect { flavor -> flavor.name }
@@ -88,6 +89,24 @@ gradle.projectsEvaluated {
                 enabled config."bundleIn${targetName}" ||
                     config."bundleIn${buildTypeName.capitalize()}" ?:
                             targetName.toLowerCase().contains("release")
+
+                if (isAndroidLibrary) {
+                    doLast {
+                        def moveFunc = { resSuffix ->
+                            File originalDir = file("${resourcesDir}/drawable-${resSuffix}")
+                            if (originalDir.exists()) {
+                                File destDir = file("${resourcesDir}/drawable-${resSuffix}-v4")
+                                ant.move(file: originalDir, tofile: destDir)
+                            }
+                        }
+                        moveFunc.curry("ldpi").call()
+                        moveFunc.curry("mdpi").call()
+                        moveFunc.curry("hdpi").call()
+                        moveFunc.curry("xhdpi").call()
+                        moveFunc.curry("xxhdpi").call()
+                        moveFunc.curry("xxxhdpi").call()
+                    }
+                }
             }
 
             // Hook bundle${productFlavor}${buildType}JsAndAssets into the android build process


### PR DESCRIPTION
_Quick apologies for the lengthiness of this description. Want to make sure I'm clear and understood what is being altered._ 

Thanks for submitting a PR! Please read these instructions carefully:

- [ ] Explain the **motivation** for making this change.
- [ ] Provide a **test plan** demonstrating that the code is solid.
- [ ] Match the **code formatting** of the rest of the codebase.
- [ ] Target the `master` branch, NOT a "stable" branch.

## Motivation (required)
https://github.com/facebook/react-native/issues/5787
```
Unknown source file : /home/tom/projects/blueprint-native/android/app/build/intermediates/res/merged/release/drawable-mdpi-v4/images_google.png: error: Duplicate file.

Unknown source file : /home/tom/projects/blueprint-native/android/app/build/intermediates/res/merged/release/drawable-mdpi/images_google.png: Original is here. The version qualifier may be implied.
```

At Hudl, we've been attempting to package our React Native code into Library Dependencies _(Cocoapods / Android Artifact Resource (aar))_. Recently in React Native 0.42.0, there was an upgrade to the Android Project's gradle plugin from 1.3.1 to 2.2.3. This update drastically affected the outcome of drawable resources in Android without any noticing.

**There are 4 outcomes to consider with this change:**
1. You are developing in an Android Application using Gradle 1.3.1 or lower
2. You are developing in an Android Application using Gradle 2.2.3 or higher
3. You are developing in an Android Library Module using Gradle 1.3.1 or lower
4. You are developing in an Android Library Module using Gradle 2.2.3 or higher

With the upgrade to 2.2.3, Android changed the way aapt builds its resources. Any Library created with 2.2.3, has its resources ending with a `v4` suffix. The reasoning behind this I'm not sure of but assume it deals with Vector support that was added around that time.

The change I've added checks if React Native is being ran in an Android Library vs an Application, and appends the v4 suffix to the merged asset folders.

## Test Plan (required)

Multiple test were performed.

1. I first started out validating my assumption about the asset merger.
   1. I create a new Android Project to verify my assumption above.
   2. [Application +  >= 2.2.3](https://github.com/jpshelley/TestAndroidLibraryDrawables/tree/master/app/build/intermediates/res/merged/debug) -- `hdpi` contains my drawable. `hdpi-v4` contains dependency's drawables.
   3. [Application + <= 1.3.1](https://github.com/jpshelley/TestAndroidLibraryDrawables/tree/Android-LegacyVersion/app/build/intermediates/res/merged/debug) -- Same as above (I expect because deps are compiled against gradle 2.2.3+ themselves.
   4. [Library + >= 2.2.3](https://github.com/jpshelley/TestAndroidLibraryDrawables/tree/Android-UsingAndroidLibrary/library/build/intermediates/res/merged/debug) -- Only `-v4` folders found! Resources from the library are packages in the app's build output in similar `-v4` folder too.
   5. [Library + <= 1.3.1](https://github.com/jpshelley/TestAndroidLibraryDrawables/tree/Android-UsingAndroidLibraryLegacyVersion/library/build/intermediates/res/merged/debug) -- Same as ii. & iii. `-v4` contains other resources, but my resources are located in non -v4 folder.

2. I then wanted to validate against React Native itself. So I updated my react native code using this PR/Branch, and tested against my project locally. Unfortunately I cannot share that code as it is private, but before this change I was getting the same error as mentioned in #5787 and now my build runs as intended with the assets being placed where they should be.

Additional resources:
* https://github.com/facebook/react-native/issues/5787
* http://stackoverflow.com/questions/35700272/android-build-tool-adds-v4-qualifier-to-drawable-folders-by-default-in-generated
* https://github.com/facebook/react-native/issues/12710

Please let me know if more information is needed, further test plans, etc. With this change we should be able to upgrade to Gradle 2.3.0 as well to support the latest version of Android Studio.