### PR TITLE
PositionError must be an object, not string

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/modules/location/LocationModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/location/LocationModule.java
@@ -123,7 +123,7 @@ public class LocationModule extends ReactContextBaseJavaModule {
           (LocationManager) getReactApplicationContext().getSystemService(Context.LOCATION_SERVICE);
       String provider = getValidProvider(locationManager, locationOptions.highAccuracy);
       if (provider == null) {
-        error.invoke("No available location provider.");
+        emitError(PositionError.PERMISSION_DENIED, "No location provider available.");
         return;
       }
       Location location = locationManager.getLastKnownLocation(provider);


### PR DESCRIPTION
As specifications says, the Position error must be an object with code and message attributes. Right now it is a string. If not, we can't know what kind of error is. Another issue is that the message must be exactly "No available location provider."

Specifications:
https://developer.mozilla.org/en/docs/Web/API/PositionError