### PR TITLE
Make run-ios --device example copy-pastable

### DIFF
--- a/local-cli/runIOS/runIOS.js
+++ b/local-cli/runIOS/runIOS.js
@@ -222,7 +222,7 @@ module.exports = {
   },
   {
     desc: "Run on a connected device, e.g. Max's iPhone",
-    cmd: "react-native run-ios --device 'Max's iPhone'",
+    cmd: 'react-native run-ios --device "Max\'s iPhone"',
   },
   ],
   options: [{


### PR DESCRIPTION
This changes the single quotes to double quotes so this command can be copy-pasted.

## Motivation (required)

If a user copy pastes the run-on-device example in bash they will be presented with a confusing prompt because bash expects another terminating single quote.

```
~ben (master *) ~/code/transit: react-native run-ios --device 'Max's iPhone'
>
>
```

It seems minor but this could be just confusing enough to frustrate a beginner or someone not familiar with bash. 

## Test Plan (required)

This can be tested by running:

```
react-native run-ios --help
```

and verifying that the "run on device" example is changed:

```diff
- react-native run-ios --device 'Max's iPhone'
+ react-native run-ios --device "Max's iPhone"
```
