### PR TITLE
Fix listView _updateVisibleRows not returning changes if scrolled to unrendered cells too quickly

### DIFF
--- a/Libraries/Lists/ListView/ListView.js
+++ b/Libraries/Lists/ListView/ListView.js
@@ -597,7 +597,11 @@ var ListView = React.createClass({
     }
     if (updatedFrames) {
       updatedFrames.forEach((newFrame) => {
-        this._childFrames[newFrame.index] = merge(newFrame);
+        // When row has not been rendered, frame is {x:0 y:0 width:0 height:0}
+        // Do not merge this or it will fail check with visibleMax and visibleMin
+        if (!(newFrame.x == 0 && newFrame.y == 0 && newFrame.width == 0 && newFrame.height == 0)) {
+          this._childFrames[newFrame.index] = merge(newFrame);
+        }
       });
     }
     var isVertical = !this.props.horizontal;

--- a/Libraries/Lists/ListView/ListView.js
+++ b/Libraries/Lists/ListView/ListView.js
@@ -599,7 +599,7 @@ var ListView = React.createClass({
       updatedFrames.forEach((newFrame) => {
         // When row has not been rendered, frame is {x:0 y:0 width:0 height:0}
         // Do not merge this or it will fail check with visibleMax and visibleMin
-        if (!(newFrame.x == 0 && newFrame.y == 0 && newFrame.width == 0 && newFrame.height == 0)) {
+        if (!(newFrame.x === 0 && newFrame.y === 0 && newFrame.width === 0 && newFrame.height === 0)) {
           this._childFrames[newFrame.index] = merge(newFrame);
         }
       });


### PR DESCRIPTION
## Motivation

On iOS device, if ListView takes more than one pass to render all the rows, and user scrolls too quickly to an un-rendered row, row may not be returned in the `onChangeVisibleRows` method.
This same issue mentioned in https://github.com/facebook/react-native/issues/12311.

## Test Plan

1. Make listView more than 20 cells.
2. Set initialListSize to 10.
3. Quickly scroll to the end of list. (works better with real device)
4. Observe in `onChangeVisibleRows` that cells towards the end are not returned.

## Cause
I think the problem is in _updateVisibleRows. When an un-rendered row is passed to this method from onScroll, frame will be {x:0, y:0, width:0, height:0}; and if this frame is merged into childFrames, the check against visibleMin and visibleMax will fail, thus not returning the row. I am not sure if this fixes the root cause of this problem.
