### PR TITLE
Update FlatList optional props with intialNumberToRender

### DIFF
--- a/Libraries/Lists/FlatList.js
+++ b/Libraries/Lists/FlatList.js
@@ -76,6 +76,11 @@ type OptionalProps<ItemT> = {
    */
   horizontal?: ?boolean,
   /**
+   * How many items to render in the initial batch. This should be enough to fill the screen but not
+   * much more.
+   */
+  initialNumToRender: number,
+  /**
    * Used to extract a unique key for a given item at the specified index. Key is used for caching
    * and as the react key to track item re-ordering. The default extractor checks `item.key`, then
    * falls back to using the index, like React does.


### PR DESCRIPTION
Include initialNumberToRender in FlatList optional props from VirtualizedList. 
This is quite an important prop that users of FlatList may not be aware of unless looking at VirtualizedList props.

## Motivation

initialNumberToRender is an important prop from the underlying VirtualizedList that users of FlatList may not be aware of unless looking at the VirualizedList props. 

## Test Plan

Check prop definition is valid. 