### PR TITLE
FlatList export scrollTo function 

### DIFF
--- a/Libraries/Lists/FlatList.js
+++ b/Libraries/Lists/FlatList.js
@@ -173,7 +173,15 @@ class FlatList<ItemT> extends React.PureComponent<DefaultProps, Props<ItemT>, vo
   scrollToEnd(params?: ?{animated?: ?boolean}) {
     this._listRef.scrollToEnd(params);
   }
-
+ /**
+   * Scrolls to a given x, y offset, either immediately or with a smooth animation.
+   *
+   * See `ScrollView#scrollTo`.
+   */
+   scrollTo(...args: Array<mixed>) {
+     if (this._listRef && this._listRef.scrollTo) {
+         this._listRef.scrollTo(...args);
+   }
   /**
    * Scrolls to the item at a the specified index such that it is positioned in the viewable area
    * such that `viewPosition` 0 places it at the top, 1 at the bottom, and 0.5 centered in the

--- a/Libraries/Lists/VirtualizedList.js
+++ b/Libraries/Lists/VirtualizedList.js
@@ -170,7 +170,16 @@ class VirtualizedList extends React.PureComponent<OptionalProps, Props, State> {
       this.props.horizontal ? {x: offset, animated} : {y: offset, animated}
     );
   }
-
+  /**
+   * Scrolls to a given x, y offset, either immediately or with a smooth animation.
+   *
+   * See `ScrollView#scrollTo`.
+   */
+  scrollTo(...args: Array<mixed>) {
+    if (this._scrollRef && this._scrollRef.scrollTo) {
+        this._scrollRef.scrollTo(...args);
+    }
+  }
   // scrollToIndex may be janky without getItemLayout prop
   scrollToIndex(params: {animated?: ?boolean, index: number, viewPosition?: number}) {
     const {data, horizontal, getItemCount, getItemLayout} = this.props;


### PR DESCRIPTION
## Motivation (required)

When I have a View include FlatList and want to take over FlatList's scrollTo function,But I find the FlatList and VirtualizedList not export scrollTo function like ListView.

## Test Plan (required)

I think the code don't need to test plan.




