### PR TITLE
Update xcode dependency from 0.8.9 -> 0.9.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -211,7 +211,7 @@
     "worker-farm": "^1.3.1",
     "write-file-atomic": "^1.2.0",
     "ws": "^1.1.0",
-    "xcode": "^0.8.9",
+    "xcode": "^0.9.1",
     "xmldoc": "^0.4.0",
     "xpipe": "^1.0.5",
     "yargs": "^6.4.0"


### PR DESCRIPTION
## Motivation (required)

This should resolve the following npm deprecation warning:
```
 WARN deprecated node-uuid@1.4.7: Use uuid module instead
```

## Test Plan (required)

Existing tests should cover this already.