### PR TITLE
Update documentation for Modal's prop animationType

### DIFF
--- a/Libraries/Modal/Modal.js
+++ b/Libraries/Modal/Modal.js
@@ -87,6 +87,8 @@ class Modal extends React.Component {
      * - `slide` slides in from the bottom
      * - `fade` fades into view
      * - `none` appears without an animation
+     * 
+     * Default is set to `none`.
      */
     animationType: PropTypes.oneOf(['none', 'slide', 'fade']),
     /**

--- a/Libraries/Modal/Modal.js
+++ b/Libraries/Modal/Modal.js
@@ -87,7 +87,7 @@ class Modal extends React.Component {
      * - `slide` slides in from the bottom
      * - `fade` fades into view
      * - `none` appears without an animation
-     * 
+     *
      * Default is set to `none`.
      */
     animationType: PropTypes.oneOf(['none', 'slide', 'fade']),


### PR DESCRIPTION
I was using Modal component and I didn't knew what was the default for animationType prop. After reading the code, I saw that it was `none`.

I did not tell that the "default" is `slide` if animated is set to `true`, because it is not a default but an implementation of `animated` prop effect and because of the deprecation of `animated`.

Thanks.