### PR TITLE
[Android] Implement letterSpacing option

### DIFF
--- a/Libraries/Text/TextStylePropTypes.js
+++ b/Libraries/Text/TextStylePropTypes.js
@@ -49,7 +49,16 @@ const TextStylePropTypes = {
   textShadowRadius: ReactPropTypes.number,
   textShadowColor: ColorPropType,
   /**
-   * @platform ios
+   * Increase or decrease the spacing between characters. Based on the platform specific
+   * rendering this style annotation will be rendered slightly differently on Android and iOS.
+   * Default is no letter spacing.
+   *
+   * Android: Only supported since Android 5+, older versions will will ignore this attribute.
+   * Please notice that additional space will be added *around* the characters and the space
+   * is calculated based on your font size and the font family. To left-align a text similar
+   * to iOS (or in different font sizes) you should add a Platform-specific negative layout attribute.
+   *
+   * iOS: The additional space will be added behind the character and is defined in points.
    */
   letterSpacing: ReactPropTypes.number,
   lineHeight: ReactPropTypes.number,

--- a/RNTester/js/TextExample.android.js
+++ b/RNTester/js/TextExample.android.js
@@ -322,6 +322,22 @@ class TextExample extends React.Component<{}> {
             Holisticly formulate inexpensive ideas before best-of-breed benefits. <Text style={{fontSize: 20}}>Continually</Text> expedite magnetic potentialities rather than client-focused interfaces.
           </Text>
         </RNTesterBlock>
+        <UIExplorerBlock title="Letter Spacing">
+          <View>
+            <Text style={{letterSpacing: 0}}>
+              letterSpacing = 0
+            </Text>
+            <Text style={{letterSpacing: 2, marginTop: 5}}>
+              letterSpacing = 2
+            </Text>
+            <Text style={{letterSpacing: 9, marginTop: 5}}>
+              letterSpacing = 9
+            </Text>
+            <Text style={{letterSpacing: -1, marginTop: 5}}>
+              letterSpacing = -1
+            </Text>
+          </View>
+        </UIExplorerBlock>
         <RNTesterBlock title="Empty Text">
           <Text />
         </RNTesterBlock>

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewProps.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewProps.java
@@ -80,6 +80,7 @@ public class ViewProps {
   public static final String FONT_STYLE = "fontStyle";
   public static final String FONT_FAMILY = "fontFamily";
   public static final String LINE_HEIGHT = "lineHeight";
+  public static final String LETTER_SPACING = "letterSpacing";
   public static final String NEEDS_OFFSCREEN_ALPHA_COMPOSITING = "needsOffscreenAlphaCompositing";
   public static final String NUMBER_OF_LINES = "numberOfLines";
   public static final String ELLIPSIZE_MODE = "ellipsizeMode";

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/CustomLetterSpacingSpan.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/CustomLetterSpacingSpan.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+package com.facebook.react.views.text;
+
+import android.annotation.TargetApi;
+import android.os.Build;
+import android.text.TextPaint;
+import android.text.style.MetricAffectingSpan;
+
+import com.facebook.infer.annotation.Assertions;
+
+/**
+ * A {@link MetricAffectingSpan} that allows to set the letter spacing
+ * on the selected text span.
+ */
+@TargetApi(Build.VERSION_CODES.LOLLIPOP)
+public class CustomLetterSpacingSpan extends MetricAffectingSpan {
+
+  private final float mLetterSpacing;
+
+  public CustomLetterSpacingSpan(float letterSpacing) {
+    Assertions.assertCondition(!Float.isNaN(letterSpacing) && letterSpacing != 0);
+    mLetterSpacing = letterSpacing;
+  }
+
+  @Override
+  public void updateDrawState(TextPaint paint) {
+    paint.setLetterSpacing(mLetterSpacing);
+  }
+
+  @Override
+  public void updateMeasureState(TextPaint paint) {
+    paint.setLetterSpacing(mLetterSpacing);
+  }
+}

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextUpdate.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextUpdate.java
@@ -28,6 +28,7 @@ public class ReactTextUpdate {
   private final float mPaddingBottom;
   private final int mTextAlign;
   private final int mTextBreakStrategy;
+  private final float mLetterSpacing;
 
   /**
    * @deprecated Use a non-deprecated constructor for ReactTextUpdate instead. This one remains
@@ -50,6 +51,7 @@ public class ReactTextUpdate {
         paddingTop,
         paddingEnd,
         paddingBottom,
+        0f,
         textAlign,
         Layout.BREAK_STRATEGY_HIGH_QUALITY);
   }
@@ -62,6 +64,7 @@ public class ReactTextUpdate {
     float paddingTop,
     float paddingEnd,
     float paddingBottom,
+    float letterSpacing,
     int textAlign,
     int textBreakStrategy) {
     mText = text;
@@ -71,6 +74,7 @@ public class ReactTextUpdate {
     mPaddingTop = paddingTop;
     mPaddingRight = paddingEnd;
     mPaddingBottom = paddingBottom;
+    mLetterSpacing = letterSpacing;
     mTextAlign = textAlign;
     mTextBreakStrategy = textBreakStrategy;
   }
@@ -101,6 +105,10 @@ public class ReactTextUpdate {
 
   public float getPaddingBottom() {
     return mPaddingBottom;
+  }
+
+  public float getLetterSpacing() {
+    return mLetterSpacing;
   }
 
   public int getTextAlign() {

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
@@ -65,6 +65,16 @@ public class ReactTextView extends TextView implements ReactCompoundView {
       (int) Math.floor(update.getPaddingRight()),
       (int) Math.floor(update.getPaddingBottom()));
 
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+      float nextLetterSpacing = update.getLetterSpacing();
+      if (Float.isNaN(nextLetterSpacing)) {
+        nextLetterSpacing = 0;
+      }
+      if (getLetterSpacing() != nextLetterSpacing) {
+        setLetterSpacing(nextLetterSpacing);
+      }
+    }
+
     int nextTextAlign = update.getTextAlign();
     if (mTextAlign != nextTextAlign) {
       mTextAlign = nextTextAlign;

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputShadowNode.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputShadowNode.java
@@ -146,6 +146,7 @@ public class ReactTextInputShadowNode extends ReactTextShadowNode implements
           getPadding(Spacing.TOP),
           getPadding(Spacing.RIGHT),
           getPadding(Spacing.BOTTOM),
+          mLetterSpacing,
           mTextAlign,
           mTextBreakStrategy
         );


### PR DESCRIPTION
## Motivation

Implement letterSpacing option on Android. This was requested multiple times. (See also #3485 #10622) - This PR is inspired by #9420 but also fixes the layout calculation which is required for multiline text with letter spacing.

The problem with letter spacing on Android is, in general, that the API TextView#setLetterSpacing expects the letter spacing value in "EM", where "1 EM" is defined by the width of the letter 'M'. From the documentation: "Typical values for slight expansion will be around 0.05. Negative values will tighten text." The react-native developer expectation was that the spacing is defined in points, similar to width, height, margin, padding, and so on.

This patch implements an "approach" and calculates the "EM" based on the font size.

I tested this with the default font and the layout was now "similar" to iOS, but doesn't match the iOS layout exactly.

## Test Plan

Screenshot on iOS (before and after):

![simulator screen shot 29 mar 2017 12 16 17](https://cloud.githubusercontent.com/assets/139310/24456920/d0c3e512-1494-11e7-83d0-769bde14c411.png)

Screenshot on Android before this patch:

![2017-03-29 13 40 13](https://cloud.githubusercontent.com/assets/139310/24457410/7795bdec-1496-11e7-8aad-7dd3e406d7f8.png)

Screenshot on Android after this patch:

![2017-03-29 13 34 09](https://cloud.githubusercontent.com/assets/139310/24457414/7c806514-1496-11e7-9af6-202c85efb419.png)

Sourcecode for this "beautiful app" is available here: https://gist.github.com/jerolimov/39e4fd29702b6f1ad55768907d92c33d

## Documentation Question

How can I update the documentation and remove the "ios" badge on the `letterSpacing` option?