### PR TITLE
[local-cli][packager] Move packager initialization events to reporter

### DIFF
--- a/local-cli/server/runServer.js
+++ b/local-cli/server/runServer.js
@@ -10,7 +10,6 @@
 
 const InspectorProxy = require('./util/inspectorProxy.js');
 const ReactPackager = require('../../packager/react-packager');
-const TerminalReporter = require('../../packager/src/lib/TerminalReporter');
 
 const attachHMRServer = require('./util/attachHMRServer');
 const connect = require('connect');
@@ -86,6 +85,21 @@ function getPackagerServer(args, config) {
   const providesModuleNodeModules =
     args.providesModuleNodeModules || defaultProvidesModuleNodeModules;
 
+  let LogReporter;
+  if (args.customLogReporterPath) {
+    try {
+      // First we let require resolve it, so we can require packages in node_modules
+      // as expected. eg: require('my-package/reporter');
+      LogReporter = require(args.customLogReporterPath);
+    } catch(e) {
+      // If that doesn't work, then we next try relative to the cwd, eg:
+      // require('./reporter');
+      LogReporter = require(path.resolve(args.customLogReporterPath));
+    }
+  } else {
+    LogReporter = require('../../packager/src/lib/TerminalReporter');
+  }
+
   return ReactPackager.createServer({
     assetExts: defaultAssetExts.concat(args.assetExts),
     blacklistRE: config.getBlacklistRE(),
@@ -96,7 +110,7 @@ function getPackagerServer(args, config) {
     platforms: defaultPlatforms.concat(args.platforms),
     projectRoots: args.projectRoots,
     providesModuleNodeModules: providesModuleNodeModules,
-    reporter: new TerminalReporter(),
+    reporter: new LogReporter(),
     resetCache: args.resetCache,
     transformModulePath: transformModulePath,
     verbose: args.verbose,

--- a/local-cli/server/runServer.js
+++ b/local-cli/server/runServer.js
@@ -30,10 +30,12 @@ const systraceProfileMiddleware = require('./middleware/systraceProfileMiddlewar
 const unless = require('./middleware/unless');
 const webSocketProxy = require('./util/webSocketProxy.js');
 
-function runServer(args, config, readyCallback) {
+function runServer(args, config, startedCallback, readyCallback) {
   var wsProxy = null;
   var ms = null;
   const packagerServer = getPackagerServer(args, config);
+  startedCallback(packagerServer._reporter);
+
   const inspectorProxy = new InspectorProxy();
   const app = connect()
     .use(loadRawBodyMiddleware)
@@ -67,7 +69,7 @@ function runServer(args, config, readyCallback) {
       wsProxy = webSocketProxy.attachToServer(serverInstance, '/debugger-proxy');
       ms = messageSocket.attachToServer(serverInstance, '/message');
       inspectorProxy.attachToServer(serverInstance, '/inspector');
-      readyCallback();
+      readyCallback(packagerServer._reporter);
     }
   );
   // Disable any kind of automatic timeout behavior for incoming

--- a/local-cli/server/server.js
+++ b/local-cli/server/server.js
@@ -119,6 +119,9 @@ module.exports = {
     command: '--reset-cache, --resetCache',
     description: 'Removes cached files',
   }, {
+    command: '--custom-log-reporter-path, --customLogReporterPath [string]',
+    description: 'Path to a JavaScript file that exports a log reporter as a replacement for TerminalReporter',
+  }, {
     command: '--verbose',
     description: 'Enables logging',
   }],

--- a/local-cli/server/server.js
+++ b/local-cli/server/server.js
@@ -8,8 +8,6 @@
  */
 'use strict';
 
-const chalk = require('chalk');
-const formatBanner = require('./formatBanner');
 const path = require('path');
 const runServer = require('./runServer');
 
@@ -19,50 +17,31 @@ const runServer = require('./runServer');
 function server(argv, config, args) {
   args.projectRoots = args.projectRoots.concat(args.root);
 
-  console.log(formatBanner(
-    'Running packager on port ' + args.port + '.\n\n' +
-    'Keep this packager running while developing on any JS projects. ' +
-    'Feel free to close this tab and run your own packager instance if you ' +
-    'prefer.\n\n' +
-    'https://github.com/facebook/react-native', {
-      marginLeft: 1,
-      marginRight: 1,
-      paddingBottom: 1,
-    })
-  );
+  const startedCallback = logReporter => {
+    logReporter.update({
+      type: 'initialize_packager_started',
+      port: args.port,
+      projectRoots: args.projectRoots,
+    });
 
-  console.log(
-    'Looking for JS files in\n  ',
-    chalk.dim(args.projectRoots.join('\n   ')),
-    '\n'
-  );
+    process.on('uncaughtException', error => {
+      logReporter.update({
+        type: 'initialize_packager_failed',
+        port: args.port,
+        error,
+      });
 
-  process.on('uncaughtException', error => {
-    if (error.code === 'EADDRINUSE') {
-      console.log(
-        chalk.bgRed.bold(' ERROR '),
-        chalk.red('Packager can\'t listen on port', chalk.bold(args.port))
-      );
-      console.log('Most likely another process is already using this port');
-      console.log('Run the following command to find out which process:');
-      console.log('\n  ', chalk.bold('lsof -i :' + args.port), '\n');
-      console.log('Then, you can either shut down the other process:');
-      console.log('\n  ', chalk.bold('kill -9 <PID>'), '\n');
-      console.log('or run packager on different port.');
-    } else {
-      console.log(chalk.bgRed.bold(' ERROR '), chalk.red(error.message));
-      const errorAttributes = JSON.stringify(error);
-      if (errorAttributes !== '{}') {
-        console.error(chalk.red(errorAttributes));
-      }
-      console.error(chalk.red(error.stack));
-    }
-    console.log('\nSee', chalk.underline('http://facebook.github.io/react-native/docs/troubleshooting.html'));
-    console.log('for common problems and solutions.');
-    process.exit(11);
-  });
+      process.exit(11);
+    });
+  };
 
-  runServer(args, config, () => console.log('\nReact packager ready.\n'));
+  const readyCallback = logReporter => {
+    logReporter.update({
+      type: 'initialize_packager_done',
+    });
+  };
+
+  runServer(args, config, startedCallback, readyCallback);
 }
 
 module.exports = {

--- a/packager/src/lib/TerminalReporter.js
+++ b/packager/src/lib/TerminalReporter.js
@@ -11,11 +11,13 @@
 
 'use strict';
 
+const chalk = require('chalk');
 const path = require('path');
 const reporting = require('./reporting');
 const terminal = require('./terminal');
 const throttle = require('lodash/throttle');
 const util = require('util');
+const formatBanner = require('../../../local-cli/server/formatBanner');
 
 import type {ReportableEvent, GlobalCacheDisabledReason} from './reporting';
 
@@ -133,12 +135,70 @@ class TerminalReporter {
     }
   }
 
+
+  _logPackagerInitializing(port: number, projectRoots: Array<string>) {
+    terminal.log(
+      formatBanner(
+        'Running packager on port ' +
+          port +
+          '.\n\n' +
+          'Keep this packager running while developing on any JS projects. ' +
+          'Feel free to close this tab and run your own packager instance if you ' +
+          'prefer.\n\n' +
+          'https://github.com/facebook/react-native',
+        {
+          marginLeft: 1,
+          marginRight: 1,
+          paddingBottom: 1,
+        }
+      )
+    );
+
+    terminal.log(
+      'Looking for JS files in\n  ',
+      chalk.dim(projectRoots.join('\n   ')),
+      '\n'
+    );
+  }
+
+  _logPackagerInitializingFailed(port: number, error: Error) {
+    if (error.code === 'EADDRINUSE') {
+      terminal.log(
+        chalk.bgRed.bold(' ERROR '),
+        chalk.red("Packager can't listen on port", chalk.bold(port))
+      );
+      terminal.log('Most likely another process is already using this port');
+      terminal.log('Run the following command to find out which process:');
+      terminal.log('\n  ', chalk.bold('lsof -i :' + port), '\n');
+      terminal.log('Then, you can either shut down the other process:');
+      terminal.log('\n  ', chalk.bold('kill -9 <PID>'), '\n');
+      terminal.log('or run packager on different port.');
+    } else {
+      terminal.log(chalk.bgRed.bold(' ERROR '), chalk.red(error.message));
+      const errorAttributes = JSON.stringify(error);
+      if (errorAttributes !== '{}') {
+        terminal.log(chalk.red(errorAttributes));
+      }
+      terminal.log(chalk.red(error.stack));
+    }
+  }
+
+
   /**
    * This function is only concerned with logging and should not do state
    * or terminal status updates.
    */
   _log(event: TerminalReportableEvent): void {
     switch (event.type) {
+      case 'initialize_packager_started':
+        this._logPackagerInitializing(event.port, event.projectRoots);
+        break;
+      case 'initialize_packager_done':
+        terminal.log('\nReact packager ready.\n');
+        break;
+      case 'initialize_packager_failed':
+        this._logPackagerInitializingFailed(event.port, event.error);
+        break;
       case 'bundle_build_done':
         this._logBundleBuildDone(event.entryFilePath);
         break;

--- a/packager/src/lib/reporting.js
+++ b/packager/src/lib/reporting.js
@@ -23,6 +23,16 @@ export type GlobalCacheDisabledReason = 'too_many_errors' | 'too_many_misses';
  * report to the tool user.
  */
 export type ReportableEvent = {
+  port: number,
+  projectRoots: Array<string>,
+  type: 'initialize_packager_started',
+} | {
+  type: 'initialize_packager_done',
+} | {
+  type: 'initialize_packager_failed',
+  port: number,
+  error: Error,
+} | {
   entryFilePath: string,
   type: 'bundle_build_done',
 } | {


### PR DESCRIPTION
This PR depends on #13172

## Motivation

Packager events are mostly logged through the TerminalReporter by default (#13172 makes this configurable). But there are a few things that aren't passed through TerminalReporter.

- We [log a banner with some information about the port and what's going on](https://github.com/facebook/react-native/blob/8c7b32d5f1da34613628b4b8e0474bc1e185a618/local-cli/server/server.js#L22-L32)
- Also [a message about looking for JS files](https://github.com/facebook/react-native/blob/8c7b32d5f1da34613628b4b8e0474bc1e185a618/local-cli/server/server.js#L34-L38) (not sure what that is for / if it is useful beyond telling the user what directory root they started the packager in, but that's another thing). 
- If the packager fails to start, then [we log an error message](https://github.com/facebook/react-native/blob/8c7b32d5f1da34613628b4b8e0474bc1e185a618/local-cli/server/server.js#L41-L61).

This pull request changes those log messages to be handled by TerminalReporter. I tried to pick good names for the events based on existing names as defined in [reporting](https://github.com/facebook/react-native/blob/8c7b32d5f1da34613628b4b8e0474bc1e185a618/packager/src/lib/reporting.js#L25-L52).

## Test Plan

Pull this, run `npm start` in root and open up UIExplorer. Works as expected, but somehow it just feels better, right?

## Next Steps

- I'm not very happy about having to include `formatBanner` from `local-cli` in `packager/src/lib/TerminalReporter`, given that packager may split off at some point. I would have just moved it into the packager, but it's a dependency of [checkNodeVersion](https://github.com/facebook/react-native/blob/9ee815f6b52e0c2417c04e5a05e1e31df26daed2/local-cli/server/checkNodeVersion.js).
- Not a huge fan of accessing a private-by-naming-convention property on `packagerServer` to get the reporter ([here](https://github.com/facebook/react-native/pull/13209/files#diff-33a4be2928925650375f54b552cb956fR37)). Maybe we should expose a getter for it, or a `logEvent` function on the packager server instance?
- Are there more events that we can send to the TerminalReporter? For example, we internally track the URL of a bundle request, it might be useful to send that along somewhere as well.
