### PR TITLE
Enable full podspec CI build and make RCTAnimation subspec green.

### DIFF
--- a/Libraries/NativeAnimation/RCTNativeAnimatedNodesManager.h
+++ b/Libraries/NativeAnimation/RCTNativeAnimatedNodesManager.h
@@ -9,9 +9,10 @@
 
 #import <Foundation/Foundation.h>
 
-#import <RCTAnimation/RCTValueAnimatedNode.h>
 #import <React/RCTBridgeModule.h>
 #import <React/RCTUIManager.h>
+
+#import "RCTValueAnimatedNode.h"
 
 @interface RCTNativeAnimatedNodesManager : NSObject
 

--- a/scripts/process-podspecs.sh
+++ b/scripts/process-podspecs.sh
@@ -24,7 +24,7 @@ fi
 cd "$SPEC_REPO_DIR"
 SPEC_REPO_REMOTE=$(git remote get-url origin)
 
-POD_LINT_OPT="--verbose --no-subspecs --allow-warnings --fail-fast --private --swift-version=3.0 --sources=$SPEC_REPO_REMOTE"
+POD_LINT_OPT="--verbose --allow-warnings --fail-fast --private --swift-version=3.0 --sources=$SPEC_REPO_REMOTE"
 
 # Get the version from a podspec.
 version() {


### PR DESCRIPTION
Fixes #13198.

This enables all subspecs defined in the podspec to be built individually, which does take a lot longer but ensures build failures in the smaller subspecs are caught too.

Also fixes a build failure in RCTAnimation by making the import consistent with other imports in the same area of the codebase.

/cc @janicduplessis @mkonicek 