### PR TITLE
Add iOS Linking location example to docs

### DIFF
--- a/Libraries/Linking/Linking.js
+++ b/Libraries/Linking/Linking.js
@@ -138,7 +138,8 @@ class Linking extends NativeEventEmitter {
   /**
    * Try to open the given `url` with any of the installed apps.
    *
-   * You can use other URLs, like a location (e.g. "geo:37.484847,-122.148386"), a contact,
+   * You can use other URLs, like a location (e.g. "geo:37.484847,-122.148386" on Android
+   * or "http://maps.apple.com/?ll=37.484847,-122.148386" on iOS), a contact,
    * or any other URL that can be opened with the installed apps.
    *
    * NOTE: This method will fail if the system doesn't know how to open the specified URL.


### PR DESCRIPTION
## Motivation (required)

Hi, the docs make it seem like `geo:${latitude},${longitude}` is the cross-platform way to link locations on Google/Apple Maps. This is Android-only though.

## Test Plan (required)

I did no changes to code.

## Other

I noticed that the Appetize.io embed tries to run the [Linking example](https://facebook.github.io/react-native/docs/linking.html) code on iOS, although the example uses Android location scheme. This results in errors. I'd like to fix this as well, but I have no idea how to tell the demo to run on Android.