### PR TITLE
Android O Support [DON'T MERGE]

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerImpl.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerImpl.java
@@ -21,6 +21,7 @@ import android.content.pm.PackageManager;
 import android.hardware.SensorManager;
 import android.net.Uri;
 import android.os.AsyncTask;
+import android.os.Build;
 import android.view.WindowManager;
 import android.widget.Toast;
 
@@ -93,6 +94,12 @@ public class DevSupportManagerImpl implements
     DevSupportManager,
     PackagerCommandListener,
     DevInternalSettings.Listener {
+
+  /*
+   * Adds support for Android O. See https://developer.android.com/preview/behavior-changes.html#cwt for more info
+   */
+  private static final int O_TYPE_APPLICATION_OVERLAY = 2038;
+  private static final int WINDOW_TYPE = "O".equals(Build.VERSION.CODENAME) ? O_TYPE_APPLICATION_OVERLAY : WindowManager.LayoutParams.TYPE_SYSTEM_ALERT;
 
   private static final int JAVA_ERROR_COOKIE = -1;
   private static final int JSEXCEPTION_ERROR_COOKIE = -1;
@@ -322,7 +329,7 @@ public class DevSupportManagerImpl implements
           public void run() {
             if (mRedBoxDialog == null) {
               mRedBoxDialog = new RedBoxDialog(mApplicationContext, DevSupportManagerImpl.this, mRedBoxHandler);
-              mRedBoxDialog.getWindow().setType(WindowManager.LayoutParams.TYPE_SYSTEM_ALERT);
+              mRedBoxDialog.getWindow().setType(WINDOW_TYPE);
             }
             if (mRedBoxDialog.isShowing()) {
               // Sometimes errors cause multiple errors to be thrown in JS in quick succession. Only
@@ -464,7 +471,7 @@ public class DevSupportManagerImpl implements
               }
             })
             .create();
-    mDevOptionsDialog.getWindow().setType(WindowManager.LayoutParams.TYPE_SYSTEM_ALERT);
+    mDevOptionsDialog.getWindow().setType(WINDOW_TYPE);
     mDevOptionsDialog.show();
   }
 


### PR DESCRIPTION
## Motivation
Add support for apps targeting Android O. 

**Note: I am not expecting this to be merged into a release. This is just to provide visibility, and to inform people what they need to change to test Android O.**

### What's changed?
In upcoming Android O the window type has changed from [TYPE_SYSTEM_ALERT](https://developer.android.com/reference/android/view/WindowManager.LayoutParams.html#TYPE_SYSTEM_ALERT) to [TYPE_APPLICATION_OVERLAY](https://developer.android.com/reference/android/view/WindowManager.LayoutParams.html#TYPE_APPLICATION_OVERLAY).
https://developer.android.com/preview/behavior-changes.html#cwt

To check if we are using the O preview I am using this check `"O".equals(Build.VERSION.CODENAME)` 
As suggested here https://commonsware.com/blog/2015/06/05/supporting-m-developer-preview-previous-versions.html

## Test Plan (required)

Try my sample project https://github.com/AndrewJack/react-native-android-o
