### PR TITLE
Temporarily disable Android instrumentation tests

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -73,7 +73,7 @@ test:
     # build test APK
     - buck install ReactAndroid/src/androidTest/buck-runner:instrumentation-tests --config build.threads=1
     # run installed apk with tests
-    - node ./scripts/run-android-ci-instrumentation-tests.js --retries 3 --path ./ReactAndroid/src/androidTest/java/com/facebook/react/tests --package com.facebook.react.tests
+    # - node ./scripts/run-android-ci-instrumentation-tests.js --retries 3 --path ./ReactAndroid/src/androidTest/java/com/facebook/react/tests --package com.facebook.react.tests
 
     # Android e2e test
     - source scripts/circle-ci-android-setup.sh && retry3 node ./scripts/run-ci-e2e-tests.js --android --js --retries 2


### PR DESCRIPTION
Android instrumentation tests keep failing due to `java.lang.RuntimeException: java.lang.RuntimeException: Timed out waiting for JS thread`.

An [earlier job](https://circleci.com/gh/facebook/react-native/17064) based off commit [c31a65](https://github.com/facebook/react-native/commit/c31a65669e80c455757509ab494ac3fa46e96c92) finished successfully, yet [this job](https://circleci.com/gh/facebook/react-native/17070), triggered by the very [next commit](https://github.com/facebook/react-native/commit/e82c2fbbe5ad808609e4e7f477223b655750f8d0), failed Android instrumentation tests even though that commit touches no Android code.

You can see from the [Circle history](https://circleci.com/gh/facebook/react-native/tree/master) that this test has been consistently failing for the same time out reason.

I am disabling Android instrumentation tests as they are not providing any useful signal a this point in time.

## Next Steps

Debug and fix instrumentation tests, and re-enable them.