### PR TITLE
Fix crash in `RCTJSStackFrame::stackFrameWithDictionary:`

### DIFF
--- a/React/Base/RCTJSStackFrame.m
+++ b/React/Base/RCTJSStackFrame.m
@@ -70,8 +70,8 @@ static NSRegularExpression *RCTJSStackFrameRegex()
 {
   return [[self alloc] initWithMethodName:dict[@"methodName"]
                                      file:dict[@"file"]
-                               lineNumber:[dict[@"lineNumber"] integerValue]
-                                   column:[dict[@"column"] integerValue]];
+                               lineNumber:[RCTNilIfNull(dict[@"lineNumber"]) integerValue]
+                                   column:[RCTNilIfNull(dict[@"column"]) integerValue]];
 }
 
 + (NSArray<RCTJSStackFrame *> *)stackFramesWithLines:(NSString *)lines


### PR DESCRIPTION
Motivation: When logging to RCTRedBox, if any of the stack frames lacks a line number or a column, the application will crash with `[NSNull integerValue]: unrecognized selector sent to instance`.

Test plan: Send a crash to RCTRedBox with incomplete stack frames.