### PR TITLE
Add Atom Beta to launchEditor

### DIFF
--- a/local-cli/server/util/launchEditor.js
+++ b/local-cli/server/util/launchEditor.js
@@ -30,6 +30,8 @@ function isTerminalEditor(editor) {
 // of the app every time
 var COMMON_EDITORS = {
   '/Applications/Atom.app/Contents/MacOS/Atom': 'atom',
+  '/Applications/Atom Beta.app/Contents/MacOS/Atom Beta':
+    '/Applications/Atom Beta.app/Contents/MacOS/Atom Beta',
   '/Applications/Sublime Text.app/Contents/MacOS/Sublime Text':
     '/Applications/Sublime Text.app/Contents/SharedSupport/bin/subl',
   '/Applications/Sublime Text 2.app/Contents/MacOS/Sublime Text 2':
@@ -57,7 +59,7 @@ function getArgumentsForLineNumber(editor, fileName, lineNumber, workspace) {
     case 'wstorm':
     case 'appcode':
     case 'charm':
-    case 'idea':  
+    case 'idea':
       return [fileName + ':' + lineNumber];
     case 'joe':
     case 'emacs':


### PR DESCRIPTION
## Motivation (required)

Support [the pre-release of Atom](https://github.com/atom/atom/releases/tag/v1.16.0-beta0) for launchEditor in RN packager.

## Test Plan (required)

Open the pre-release of Atom and use the following code: (use the built-in [openFileInEditor](https://github.com/facebook/react-native/blob/292cc82d0ebc437a6f1cdd2e972b3917b7ee05a4/Libraries/Core/Devtools/openFileInEditor.js) module)

```js
import openFileInEditor from 'openFileInEditor'

openFileInEditor(file, lineNumber)
```