### PR TITLE
Code analysis bot does not need to comment on merge commits

### DIFF
--- a/bots/code-analysis-bot.js
+++ b/bots/code-analysis-bot.js
@@ -111,6 +111,11 @@ function getFilesFromCommit(user, repo, sha, callback) {
       console.log(error);
       return;
     }
+    // A merge commit should not have any new changes to report
+    if (res.parents && res.parents.length > 1) {
+      return;
+    }
+
     callback(res.files);
   });
 }
@@ -181,6 +186,10 @@ function main(messages, user, repo, number) {
       files
         .filter((file) => messages[file.filename])
         .forEach((file) => {
+          // github api sometimes does not return a patch on large commits
+          if (!file.patch) {
+            return;
+          }
           var lineMap = getLineMapFromPatch(file.patch);
           messages[file.filename].forEach((message) => {
             sendComment(user, repo, number, sha, file.filename, lineMap, message);


### PR DESCRIPTION
This PR fixes a CI issue that came up on #11304 after merging master into the pr branch. 

That created a merge commit with over 1000 changed files. That might have created irrelevant comments, but the github commit api is limited to 300 files, with only the first 294 having the expected diffs included.

I can't think of any reasonable scenario where a merge would have changes that aren't either on master or another commit in the PR, so I've updated it to treat merge commits as having no changes.