### PR TITLE
Update default .gitignore to work with fastlane setups in sub-folders

### DIFF
--- a/local-cli/templates/HelloWorld/_gitignore
+++ b/local-cli/templates/HelloWorld/_gitignore
@@ -46,8 +46,8 @@ buck-out/
 # It is recommended to not store the screenshots in the git repo. Instead, use fastlane to re-generate the
 # screenshots whenever they are needed.
 # For more information about the recommended setup visit:
-# https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Gitignore.md
+# https://docs.fastlane.tools/best-practices/source-control/
 
-fastlane/report.xml
-fastlane/Preview.html
-fastlane/screenshots
+*/fastlane/report.xml
+*/fastlane/Preview.html
+*/fastlane/screenshots


### PR DESCRIPTION
Currently the default way to setup _fastlane_ for ReactNative projects is to set it up in the `ios` or `android` subfolder. This PR updates the path and also the URL to the new fastlane docs page.