### PR TITLE
PushNotificationIOS.requestPermissions won't resolve if no event listeners are attached

### DIFF
--- a/Libraries/PushNotificationIOS/RCTPushNotificationManager.m
+++ b/Libraries/PushNotificationIOS/RCTPushNotificationManager.m
@@ -142,6 +142,15 @@ RCT_EXPORT_MODULE()
                                            selector:@selector(handleRemoteNotificationReceived:)
                                                name:RCTRemoteNotificationReceived
                                              object:nil];
+  [self startObservingRegistrationNotifications];
+}
+
+- (void)startObservingRegistrationNotifications
+{
+  [[NSNotificationCenter defaultCenter] addObserver:self
+                                           selector:@selector(handleRegisterUserNotificationSettings:)
+                                               name:RCTRegisterUserNotificationSettings
+                                             object:nil];
   [[NSNotificationCenter defaultCenter] addObserver:self
                                            selector:@selector(handleRemoteNotificationsRegistered:)
                                                name:RCTRemoteNotificationsRegistered
@@ -149,10 +158,6 @@ RCT_EXPORT_MODULE()
   [[NSNotificationCenter defaultCenter] addObserver:self
                                            selector:@selector(handleRemoteNotificationRegistrationError:)
                                                name:RCTErrorRemoteNotificationRegistrationFailed
-                                             object:nil];
-  [[NSNotificationCenter defaultCenter] addObserver:self
-                                           selector:@selector(handleRegisterUserNotificationSettings:)
-                                               name:RCTRegisterUserNotificationSettings
                                              object:nil];
 }
 
@@ -319,6 +324,7 @@ RCT_EXPORT_METHOD(requestPermissions:(NSDictionary *)permissions
     return;
   }
 
+  [self startObservingRegistrationNotifications];
   _requestPermissionsResolveBlock = resolve;
 
   UIUserNotificationType types = UIUserNotificationTypeNone;


### PR DESCRIPTION
## Motivation

Resolves #13012 

RCTPushNotificationManager uses startObserving to register for RCTRegisterUserNotificationSettings. According to the docs, the startObserving method won't be called until somebody subscribes to NotificationManagerIOS.

This means there is a scenario when the developer can call requestPermissions without subscribing to notifications first, but since RCTPushNotificationManager relies on NSNotificationCenter subscribtion, the result will never be returned.

## Test Plan

When requesting permissions  the promise will resolve:
`PushNotificationIOS.requestPermissions().then(console.log);` without the need for calling `PushNotificationIOS.addEventListener()` first.


