### PR TITLE
Make CLI executable configurable

### DIFF
--- a/packager/react-native-xcode.sh
+++ b/packager/react-native-xcode.sh
@@ -55,6 +55,8 @@ fi
 
 [ -z "$NODE_BINARY" ] && export NODE_BINARY="node"
 
+[ -z "$CLI_PATH" ] && export CLI_PATH="$REACT_NATIVE_DIR/local-cli/cli.js"
+
 nodejs_not_found()
 {
   echo "error: Can't find '$NODE_BINARY' binary to build React Native bundle" >&2
@@ -85,7 +87,7 @@ fi
 
 BUNDLE_FILE="$DEST/main.jsbundle"
 
-$NODE_BINARY "$REACT_NATIVE_DIR/local-cli/cli.js" bundle \
+$NODE_BINARY $CLI_PATH bundle \
   --entry-file "$ENTRY_FILE" \
   --platform ios \
   --dev $DEV \


### PR DESCRIPTION
Follow up to #13248 for iOS.

## Motivation (required)

This pull request allows changing the default path to `cli` when running from Xcode environment. That is especially useful when debugging from a different location or... running `Haul`.

## Test Plan (required)

Set `export CLI_PATH=./node_modules/react-native/local-cli/cli.js` and run. Should use new path provided.