### PR TITLE
Add details what to do if sourceURLForBridge return nil

### DIFF
--- a/React/Base/RCTBridgeDelegate.h
+++ b/React/Base/RCTBridgeDelegate.h
@@ -19,6 +19,8 @@
  * this should be an absolute URL, e.g. `http://localhost:8081/index.ios.bundle`.
  * When running from a locally bundled JS file, this should be a `file://` url
  * pointing to a path inside the app resources, e.g. `file://.../main.jsbundle`.
+ * If you return nil you need to implement loadSourceForBridge:onProgress:onComplete:
+ * or loadSourceForBridge:withBlock: instead
  */
 - (NSURL *)sourceURLForBridge:(RCTBridge *)bridge;
 

--- a/React/Executors/RCTJSCExecutor.mm
+++ b/React/Executors/RCTJSCExecutor.mm
@@ -668,7 +668,6 @@ RCT_EXPORT_METHOD(setContextName:(nonnull NSString *)contextName)
                       onComplete:(RCTJavaScriptCompleteBlock)onComplete
 {
   RCTAssertParam(script);
-  RCTAssertParam(sourceURL);
 
   NSError *loadError;
   TaggedScript taggedScript = loadTaggedScript(script, sourceURL,
@@ -717,6 +716,7 @@ static TaggedScript loadTaggedScript(NSData *script,
   NSData *loadedScript = NULL;
   switch (tag) {
     case facebook::react::ScriptTag::RAMBundle:
+      RCTAssertParam(sourceURL);
       [performanceLogger markStartForTag:RCTPLRAMBundleLoad];
 
       loadedScript = loadRAMBundle(sourceURL, error, randomAccessBundle);


### PR DESCRIPTION
- Add more comments to sourceURLForBridge method
- Move source URL assert on right place in RCTJSExecutor

Thanks for submitting a PR! Please read these instructions carefully:

- [x] Explain the **motivation** for making this change.
- [x] Provide a **test plan** demonstrating that the code is solid.
- [ ] Match the **code formatting** of the rest of the codebase.
- [ ] Target the `master` branch, NOT a "stable" branch.

## Motivation (required)

RCTBridgeDelegate support 2 ways of JS downloading. First you can return URL (remote or file URL) with `- (NSURL *)sourceURLForBridge:(RCTBridge *)bridge` method or download it manually with ` - (void)loadSourceForBridge:(RCTBridge *)bridge
onProgress:(RCTSourceLoadProgressBlock)onProgress onComplete:(RCTSourceLoadBlock)loadCallback;`. 
But if you return nil in `sourceURLForBridge` and download JS manually RCTJSExecutor will raise assert in `- (void)executeApplicationScript:(NSData *)script sourceURL:(NSURL *)sourceURL onComplete:(RCTJavaScriptCompleteBlock)onComplete`

With this PR  I moved asserts to place where we really need it and updated comments for `sourceURLForBridge` method

## Test Plan (required)

This can be tested with RCTBridgeDelegate that returns nil on `sourceURLForBridge` and download JS code with ` - (void)loadSourceForBridge:(RCTBridge *)bridge
onProgress:(RCTSourceLoadProgressBlock)onProgress onComplete:(RCTSourceLoadBlock)loadCallback;`
