### PR TITLE
Add UberEATS article to showcase

### DIFF
--- a/website/showcase.json
+++ b/website/showcase.json
@@ -190,5 +190,12 @@
     "infoLink": "http://x.co/FlareNews",
     "infoTitle": "Social network that connects entrepreneurs to fellow entrepreneurs, consumers, investors and experts",
     "pinned": false
+  },
+  {
+    "name": "UberEATS",
+    "icon": "http://is5.mzstatic.com/image/thumb/Purple111/v4/5f/e9/00/5fe90072-c9ce-87c3-bdfe-8611f9325f0e/source/175x175bb.jpg",
+    "infoLink": "https://eng.uber.com/ubereats-react-native/",
+    "infoTitle": "Powering UberEATS with React Native and Uber Engineering",
+    "pinned": false
   }
 ]


### PR DESCRIPTION
Adds UberEATS technical blog post, https://eng.uber.com/ubereats-react-native/, to the showcase.

This is not an ideal entry, as the app in question, the UberEATS Restaurant Dashboard, is not widely available in the app stores for people to download and try out. I still think it's worth adding this to the showcase as a good example of a large, known company leveraging React Native to build a new experience.

Test Plan
=======

Built website and verified everything rendered correctly in the Showcase.