### PR TITLE
Update docs to clarify `RCT_REMAP_METHOD` usage.

### DIFF
--- a/docs/NativeModulesIOS.md
+++ b/docs/NativeModulesIOS.md
@@ -195,7 +195,7 @@ Refactoring the above code to use a promise instead of callbacks looks like this
 
 ```objective-c
 RCT_REMAP_METHOD(findEvents,
-                 resolver:(RCTPromiseResolveBlock)resolve
+                 findEventsWithResolver:(RCTPromiseResolveBlock)resolve
                  rejecter:(RCTPromiseRejectBlock)reject)
 {
   NSArray *events = ...


### PR DESCRIPTION
## Motivation (required)

The current docs (iOS) for promises make use of the `RCT_REMAP_METHOD` macro but it's not clear about the proper usage for the macro. Specifically, it points to a selector of `resolver:rejector:` and makes it seem like `findEvents` is assumed as both the alias and method name.

This has led to some confusion (#9070) on how to use `RCT_REMAP_METHOD`.

## Test Plan (required)

No tests needed since this is just a small docs update.