### PR TITLE
Update issue template for Sketch -> Snack rename

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -14,8 +14,8 @@ Explain what you did, what you expected to happen, and what actually happens.
 
 ### Reproduction Steps and Sample Code
 
-Try to reproduce your bug on https://sketch.expo.io/ and provide a link. 
-If you can't reproduce the bug on Sketch, provide a sample project. At the very least, provide an example of your code.
+Try to reproduce your bug on https://snack.expo.io/ and provide a link. 
+If you can't reproduce the bug on Snack, provide a sample project. At the very least, provide an example of your code.
 
 ### Solution
 


### PR DESCRIPTION
## Motivation

[We changed the name from Sketch to Snack](https://blog.expo.io/expo-sketch-expo-snack-a444f8dec72b)

## Test Plan

It's just some text in the issue template :)

## Next Steps

- Make it clear on the Snack website which version of react-native you are using. Right now we make it possible to pick SDK versions but it's not at all obvious which react-native version that maps to.