### PR TITLE
#11587 invoke error for getCurrentLocation

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/modules/location/LocationModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/location/LocationModule.java
@@ -123,7 +123,9 @@ public class LocationModule extends ReactContextBaseJavaModule {
           (LocationManager) getReactApplicationContext().getSystemService(Context.LOCATION_SERVICE);
       String provider = getValidProvider(locationManager, locationOptions.highAccuracy);
       if (provider == null) {
-        emitError(PositionError.PERMISSION_DENIED, "No location provider available.");
+        error.invoke(PositionError.buildError(
+                PositionError.PERMISSION_DENIED,
+                "No location provider available."));
         return;
       }
       Location location = locationManager.getLastKnownLocation(provider);


### PR DESCRIPTION
## Motivation (required)

It started with https://github.com/facebook/react-native/issues/11587, which reported that the error returned by `getCurrentLocation` did not match the spec. 

This resulted in PR https://github.com/facebook/react-native/pull/11723, which did not get merged because it was said by @ide and @mkonicek that simply emitting the error will cause it to hang since the `error` callback was never invoked.

However, it seems like somewhere along the way PR https://github.com/facebook/react-native/pull/13140 got merged in which did exactly that.

## Test Plan (required)

Since it now matches the spec, turning off location services on Android then running the below example code from [Geolocation](https://developer.mozilla.org/en-US/docs/Web/API/Geolocation/getCurrentPosition) docs errors out correctly.

```javascript
var options = {
  enableHighAccuracy: true,
  timeout: 5000,
  maximumAge: 0
};

function success(pos) {
  var crd = pos.coords;

  console.log('Your current position is:');
  console.log(`Latitude : ${crd.latitude}`);
  console.log(`Longitude: ${crd.longitude}`);
  console.log(`More or less ${crd.accuracy} meters.`);
};

function error(err) {
  console.warn(`ERROR(${err.code}): ${err.message}`);
};

navigator.geolocation.getCurrentPosition(success, error, options);
```

OUTPUT:
`ERROR(1): No location provider available.`