### PR TITLE
Udpate scrollTo example

### DIFF
--- a/Libraries/Components/ScrollView/ScrollView.js
+++ b/Libraries/Components/ScrollView/ScrollView.js
@@ -436,7 +436,7 @@ const ScrollView = React.createClass({
    *
    * Example:
    *
-   * `scrollTo({x: 0; y: 0; animated: true})`
+   * `scrollTo({x: 0, y: 0, animated: true})`
    *
    * Note: The weird function signature is due to the fact that, for historical reasons,
    * the function also accepts separate arguments as an alternative to the options object.


### PR DESCRIPTION
## Motivation (required)
This PR updates the example of scrollTo that uses `;` instead of `,` to separate x, y and animated values. 
