### PR TITLE
Fix Circle CI build for Ubuntu 14.04 image

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -10,6 +10,9 @@ machine:
     TERM: "dumb"
     ADB_INSTALL_TIMEOUT: 10
     GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx512m -XX:+HeapDumpOnOutOfMemoryError"'
+    NDK_VERSION: "10e"
+    NDK_PATH: "/opt/ndk"
+    ANDROID_NDK: "/opt/ndk/android-ndk-r$NDK_VERSION"
   java:
     version: 'oraclejdk8'
 
@@ -19,7 +22,7 @@ dependencies:
     - if [[ ! -e /home/ubuntu/buck ]]; then git clone https://github.com/facebook/buck.git /home/ubuntu/buck; fi
     - cd /home/ubuntu/buck && ant
     - buck --version
-    - source scripts/circle-ci-android-setup.sh && getAndroidSDK
+    - source scripts/circle-ci-android-setup.sh && getAndroidSDKandNDK
     - buck fetch ReactAndroid/src/test/java/com/facebook/react/modules
     - buck fetch ReactAndroid/src/main/java/com/facebook/react
     - buck fetch ReactAndroid/src/main/java/com/facebook/react/shell
@@ -47,7 +50,7 @@ dependencies:
 test:
   pre:
     # starting emulator in advance because it takes very long to boot
-    - $ANDROID_HOME/tools/emulator -avd testAVD -no-skin -no-audio -no-window:
+    - $ANDROID_HOME/emulator/emulator -avd testAVD -no-skin -no-audio -no-window:
             background: true
     - source scripts/circle-ci-android-setup.sh && waitForAVD
 

--- a/scripts/circle-ci-android-setup.sh
+++ b/scripts/circle-ci-android-setup.sh
@@ -1,13 +1,31 @@
 # inspired by https://github.com/Originate/guide/blob/master/android/guide/Continuous%20Integration.md
 
-function getAndroidSDK {
-  export PATH="$ANDROID_HOME/platform-tools:$ANDROID_HOME/tools:$PATH"
+function getAndroidSDKandNDK {
+  export PATH="$ANDROID_HOME/platform-tools:$ANDROID_HOME/tools:$ANDROID_HOME/tools/bin:$PATH"
 
   DEPS="$ANDROID_HOME/installed-dependencies"
 
   if [ ! -e $DEPS ]; then
-    echo y | android update sdk --no-ui --all --filter extra-android-m2repository
-    echo no | android create avd -n testAVD -f -t android-19 --abi default/armeabi-v7a &&
+    # Update Android tools to make sdkmanager and avdmanager available
+    echo y | android update sdk --no-ui --filter tools
+
+    # Update SDK and create AVD
+    yes | sdkmanager --update --verbose
+    yes | sdkmanager "platforms;android-19" "system-images;android-19;default;armeabi-v7a" "extras;google;m2repository" --verbose
+    echo no | avdmanager create avd -f -k 'system-images;android-19;default;armeabi-v7a' -n testAVD
+
+    # Install NDK
+    local ndk_zip=ndk.zip
+    sudo mkdir -p $NDK_PATH
+    sudo chown -R ${USER}:${USER} $NDK_PATH
+    cd $NDK_PATH
+    curl --silent https://dl.google.com/android/repository/android-ndk-r$NDK_VERSION-linux-x86_64.zip > $ndk_zip
+    unzip -q $ndk_zip
+    rm $ndk_zip
+
+    # Accept licenses
+    yes | sdkmanager --licenses
+
     touch $DEPS
   fi
 }


### PR DESCRIPTION
## Motivation

I set up my own Circle CI build because I was going to contribute https://github.com/facebook/react-native/pull/13319 and noticed
that the `getAndroidSDK` action failed with:

```
Error: Target id is not valid. Use 'android list targets' to get the target ids.

source scripts/circle-ci-android-setup.sh && getAndroidSDK returned exit code 1

https://circleci.com/gh/myrjola/react-native/5
```

[Here's a link to the failing build](https://circleci.com/gh/myrjola/react-native/5).
The failing command is:

```
echo no | android create avd -n testAVD -f -t android-19 --abi default/armeabi-v7a &&
```

I now install `android-19` and `default/armeabi-v7a` manually.

The next problem was that
the [NDK was missing](https://circleci.com/gh/myrjola/react-native/10) according
to `gradlew`. I renamed getAndroidSDK to getAndroidSDKandNDK and configured it
to install the Android NDK version 10e as well.

After that there were [Android SDK licenses that were not accepted](https://circleci.com/gh/myrjola/react-native/13). Those can be accepted with `yes | sdkmanager --licenses`.

Another error was that running the emulator errored with:

```
PANIC: Missing emulator engine program for 'arm' CPU.
```

The fix was to change to `$ANDROID_HOME/emulator/emulator` instead.

## Test Plan (required)

The whole Circle CI build should complete.