### PR TITLE
Added option to disable xip

### DIFF
--- a/packager/react-native-xcode.sh
+++ b/packager/react-native-xcode.sh
@@ -80,9 +80,14 @@ if [[ "$CONFIGURATION" = "Debug" && ! "$PLATFORM_NAME" == *simulator ]]; then
   if [ -z "$IP" ]; then
     IP=$(ifconfig | grep 'inet ' | grep -v 127.0.0.1 | cut -d\   -f2  | awk 'NR==1{print $1}')
   fi
+
+  if [ -z ${DISABLE_XIP+x} ]; then
+    IP="$IP.xip.io"
+  fi
+
   $PLISTBUDDY -c "Add NSAppTransportSecurity:NSExceptionDomains:localhost:NSTemporaryExceptionAllowsInsecureHTTPLoads bool true" "$PLIST"
-  $PLISTBUDDY -c "Add NSAppTransportSecurity:NSExceptionDomains:$IP.xip.io:NSTemporaryExceptionAllowsInsecureHTTPLoads bool true" "$PLIST"
-  echo "$IP.xip.io" > "$DEST/ip.txt"
+  $PLISTBUDDY -c "Add NSAppTransportSecurity:NSExceptionDomains:$IP:NSTemporaryExceptionAllowsInsecureHTTPLoads bool true" "$PLIST"
+  echo "$IP" > "$DEST/ip.txt"
 fi
 
 BUNDLE_FILE="$DEST/main.jsbundle"


### PR DESCRIPTION
## Motivation (required)

When running an app on a real iPhone in debug mode, I occasionally get issues when trying to load the js bundle and I suspect the issue is with xip.io (and it doesn't look like I'm the only one: https://github.com/facebook/react-native/issues/12786 https://github.com/facebook/react-native/issues/9688#issuecomment-272591839). So I've added the ability to optionally disable the use of xip.io if an env variable `DISABLE_XIP` is set.

## Test Plan (required)

Add `export DISABLE_XIP=true` to the `Bundle React Native code and images` build phase. Run the app on a real iPhone and ensure that it can load the JS bundle from the host computers IP.
