### PR TITLE
fix missing lines in the ios picker

### DIFF
--- a/React/Views/RCTPickerManager.m
+++ b/React/Views/RCTPickerManager.m
@@ -19,7 +19,9 @@ RCT_EXPORT_MODULE()
 
 - (UIView *)view
 {
-  return [RCTPicker new];
+  RCTPicker *picker = [RCTPicker new];
+  [picker selectRow:0 inComponent:0 animated:YES];
+  return picker;
 }
 
 RCT_EXPORT_VIEW_PROPERTY(items, NSArray<NSDictionary *>)


### PR DESCRIPTION
fix missing lines in the ios picker. thanks to http://stackoverflow.com/questions/39564660/uipickerview-selection-indicator-not-visible-in-ios10

## Motivation (required)

as written in http://stackoverflow.com/questions/39564660/uipickerview-selection-indicator-not-visible-in-ios10 there is a case where the picker is missing the highlight lines for the currently selected picker item. this fixes this case.

## Test Plan (required)

no tests needed other than the highlight lines appear like in the stackoverflow link. and it works every time now, instead of sometimes lines missing.
