### PR TITLE
Removed takeSnapshot util function from ReactNative renderer

### DIFF
--- a/Libraries/Renderer/src/renderers/native/ReactNativeFiber.js
+++ b/Libraries/Renderer/src/renderers/native/ReactNativeFiber.js
@@ -29,7 +29,6 @@ const deepFreezeAndThrowOnMutationInDev = require('deepFreezeAndThrowOnMutationI
 const emptyObject = require('fbjs/lib/emptyObject');
 const findNodeHandle = require('findNodeHandle');
 const invariant = require('fbjs/lib/invariant');
-const takeSnapshot = require('takeSnapshot');
 
 const {injectInternals} = require('ReactFiberDevToolsHook');
 
@@ -420,8 +419,6 @@ const ReactNative = {
 
     return NativeRenderer.getPublicRootInstance(root);
   },
-
-  takeSnapshot,
 
   unmountComponentAtNode(containerTag: number) {
     const root = roots.get(containerTag);

--- a/Libraries/Renderer/src/renderers/native/ReactNativeStack.js
+++ b/Libraries/Renderer/src/renderers/native/ReactNativeStack.js
@@ -18,7 +18,6 @@ var ReactNativeStackInjection = require('ReactNativeStackInjection');
 var ReactUpdates = require('ReactUpdates');
 
 var findNodeHandle = require('findNodeHandle');
-var takeSnapshot = require('takeSnapshot');
 
 ReactNativeInjection.inject();
 ReactNativeStackInjection.inject();
@@ -46,8 +45,6 @@ var ReactNative = {
   },
 
   render: render,
-
-  takeSnapshot,
 
   unmountComponentAtNode: ReactNativeMount.unmountComponentAtNode,
 


### PR DESCRIPTION
It was added to react-native-implementation in c7387fe

Relates to [this comment](https://github.com/facebook/react-native/commit/848593c0f0b75da9ff342596908c5091a2cd1430#commitcomment-21585552) and issue #13343

cc @janicduplessis 