### PR TITLE
remove-dimensionsInitialized

### DIFF
--- a/Libraries/Utilities/Dimensions.js
+++ b/Libraries/Utilities/Dimensions.js
@@ -19,7 +19,6 @@ var RCTDeviceEventEmitter = require('RCTDeviceEventEmitter');
 var invariant = require('fbjs/lib/invariant');
 
 var eventEmitter = new EventEmitter();
-var dimensionsInitialized = false;
 var dimensions = {};
 class Dimensions {
   /**
@@ -63,15 +62,11 @@ class Dimensions {
     }
 
     Object.assign(dimensions, dims);
-    if (dimensionsInitialized) {
-      // Don't fire 'change' the first time the dimensions are set.
-      eventEmitter.emit('change', {
-        window: dimensions.window,
-        screen: dimensions.screen
-      });
-    } else {
-      dimensionsInitialized = true;
-    }
+
+    eventEmitter.emit('change', {
+      window: dimensions.window,
+      screen: dimensions.screen
+    });
   }
 
   /**


### PR DESCRIPTION
this change removes dimensionsInitialized so that the 'change' event is emitted everytime native code calls Dimensions.set;

## Motivation (required)

 `Dimensions.addEventListener('change')` only emits after the first call to `Dimensions.set`. This seems to be a restriction that has no warrant. The 'change' event should be emitted on the first time `Dimensions.set` is called as well.

My use case: 
I want to get Dimensions data for window and screen into my redux store immediately so components can listen to changes on this data. On the first loading screen of my app, my component requires to know the initial Dimensions of the screen in order to dynamically adjust the size of an SVG logo.

## Test Plan (required)

confirm working on android and iOS without issue
