### PR TITLE
Stop yarn error message appearing for Windows users of local-cli

### DIFF
--- a/local-cli/util/PackageManager.js
+++ b/local-cli/util/PackageManager.js
@@ -15,11 +15,6 @@ const spawnOpts = {
   stdin: 'inherit',
 };
 
-const projectDir = process.cwd();
-const isYarnAvailable =
-  yarn.getYarnVersionIfAvailable() &&
-  yarn.isGlobalCliUsingYarn(projectDir);
-
 /**
  * Execute npm or yarn command
  *
@@ -29,6 +24,11 @@ const isYarnAvailable =
  */
 function callYarnOrNpm(yarnCommand, npmCommand) {
   let command;
+
+  const projectDir = process.cwd();
+  const isYarnAvailable =
+    yarn.getYarnVersionIfAvailable() &&
+    yarn.isGlobalCliUsingYarn(projectDir);
 
   if (isYarnAvailable) {
     command = yarnCommand;

--- a/local-cli/util/yarn.js
+++ b/local-cli/util/yarn.js
@@ -21,11 +21,9 @@ function getYarnVersionIfAvailable() {
   let yarnVersion;
   try {
     // execSync returns a Buffer -> convert to string
-    if (process.platform.startsWith('win')) {
-      yarnVersion = (execSync('yarn --version').toString() || '').trim();
-    } else {
-      yarnVersion = (execSync('yarn --version 2>/dev/null').toString() || '').trim();
-    }
+    yarnVersion = (execSync('yarn --version', {
+      stdio: [ 0, 'pipe', 'ignore', ]
+    }).toString() || '').trim();
   } catch (error) {
     return null;
   }


### PR DESCRIPTION
## Motivation

On windows, recent versions of local-cli will display a yarn error to stderr when starting the packager (see https://github.com/expo/xde/issues/91, https://github.com/react-community/create-react-native-app/issues/101, https://github.com/react-community/create-react-native-app/issues/113#issuecomment-289185491 for examples of users hitting this in the wild), even though no package management action is being taken.

From what I can tell this is what happens:

* [`local-cli/util/yarn.js` does not ignore stderr on Windows](https://github.com/facebook/react-native/blob/6fa87134fc68fd447e33a01a538ae0af6710e5d2/local-cli/util/yarn.js#L25)
* [`local-cli/util/PackageManager.js` calls the above function when it's require'd](https://github.com/facebook/react-native/blob/6fa87134fc68fd447e33a01a538ae0af6710e5d2/local-cli/util/PackageManager.js#L20)

For Windows users who don't have yarn installed, this means that the 'yarn is not recognized as an internal or external command..." error displays whenever local-cli requires PackageManager.js (which appears to be most of the time?).

Further, as far as I can tell there's no need to have this shell invocation happen when the module is loaded. It can be deferred to run only when we actually need to determine whether to use npm or yarn.

## Test Plan

I've manually tested that the yarnVersion assignment behaves correctly on Mac and Windows, with yarn available and without. This doesn't seem like a clear opportunity for a regression test, as it's a small cosmetic problem.