### PR TITLE
Correct `setState()` usage in tutorial

### DIFF
--- a/docs/State.md
+++ b/docs/State.md
@@ -25,7 +25,9 @@ class Blink extends Component {
 
     // Toggle the state every second
     setInterval(() => {
-      this.setState({ showText: !this.state.showText });
+      this.setState(previousState => {
+        return { showText: !previousState.showText };
+      });
     }, 1000);
   }
 


### PR DESCRIPTION
If the new state depends on the previous state, if I remember correctly, it’s safer to use  `setState()` with a function argument to ensure we’re not reading from an outdated `state`.

Thanks for submitting a PR! Please read these instructions carefully:

- [x] Explain the **motivation** for making this change.
- [x] Provide a **test plan** demonstrating that the code is solid.
- [x] Match the **code formatting** of the rest of the codebase.
- [x] Target the `master` branch, NOT a "stable" branch.

## Motivation (required)
The tutorial suggests to use `setState()` with an object argument when the new state depends on the previous state. In such situations, it’s preferable to use a function to ensure the previous state is up-to-date.

## Test Plan (required)
Updates documentation only, so there are no additional tests. Rendering the site.

## Next Steps

Sign the [CLA][2], if you haven't already.

Small pull requests are much easier to review and more likely to get merged. Make sure the PR does only one thing, otherwise please split it.

Make sure all **tests pass** on both [Travis][3] and [Circle CI][4]. PRs that break tests are unlikely to be merged.

For more info, see the ["Pull Requests"][5] section of our "Contributing" guidelines.

[1]: https://medium.com/@martinkonicek/what-is-a-test-plan-8bfc840ec171#.y9lcuqqi9
[2]: https://code.facebook.com/cla
[3]: https://travis-ci.org/facebook/react-native
[4]: http://circleci.com/gh/facebook/react-native
[5]: https://github.com/facebook/react-native/blob/master/CONTRIBUTING.md#pull-requests
