### PR TITLE
Fix crash in `RCTRedBox::formatFrameSource:`

### DIFF
--- a/React/Modules/RCTRedBox.m
+++ b/React/Modules/RCTRedBox.m
@@ -185,8 +185,9 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
 
 - (NSString *)formatFrameSource:(RCTJSStackFrame *)stackFrame
 {
+  NSString *fileName = RCTNilIfNull(stackFrame.file) ? [stackFrame.file lastPathComponent] : @"<unknown file>";
   NSString *lineInfo = [NSString stringWithFormat:@"%@:%zd",
-                        [stackFrame.file lastPathComponent],
+                        fileName,
                         stackFrame.lineNumber];
 
   if (stackFrame.column != 0) {


### PR DESCRIPTION
Motivation: Similar to https://github.com/facebook/react-native/pull/13242 - the application will crash with `[NSNull lastPathComponent]: unrecognized selector sent to instance` if a stack frame with no filename makes it to RCTRedBox.

Test plan: Send a crash to RCTRedBox with no filename in the stack frame.