### PR TITLE
packager: bust cached babelrc if projectRoots change

### DIFF
--- a/packager/transformer.js
+++ b/packager/transformer.js
@@ -29,12 +29,14 @@ const {compactMapping} = require('./src/Bundler/source-map');
  */
 const getBabelRC = (function() {
   let babelRC = null;
+  let pr = null;
 
   return function _getBabelRC(projectRoots) {
-    if (babelRC !== null) {
+    if (babelRC !== null && pr === projectRoots) {
       return babelRC;
     }
 
+    pr = projectRoots;
     babelRC = {plugins: []}; // empty babelrc
 
     // Let's look for the .babelrc in the first project root.


### PR DESCRIPTION
I'm using a complex project setup where I use different `.babelrc` files for different components. To make the packager behave the way I want, I implement `getTransformOptions()` in `rn-cli.config.js`, that might return a different "first projectRoot" based on the input file. `packager/transformer.js` then uses the `.babelrc` from this projectRoot. More or less like so:

```javascript
getTransformOptions(file, opts) {
    let m;
    if (m = file.match(/^(portal|app|video)\/index\.js$/)) {
        // Prefix projectRoots with the (non-build!) path of the component:
        // allows defining a .babelrc there that will be applied to all files
        // collected by this build, including files from other components.
        // Using transform-rename-import we can also use this to mock packages
        // (eg react with preact)
        // TODO: memoize the projectRoots array object to better use babelRC cache
        opts = Object.assign({}, opts, {
            projectRoots: [__dirname+'/'+m[1]].concat(opts.projectRoots)
        });
    }
    return opts;
}
```

However, `getBabelRC` is cached and does not support changing projectRoots. This patch addresses this by tracking the last used `projectRoot` variable and only using the memoized value if the projectRoot is (object-ref wise) the same.