### PR TITLE
fix showcase app icon scaling

### DIFF
--- a/css/react-native.css
+++ b/css/react-native.css
@@ -1685,6 +1685,7 @@ input#algolia-doc-search:focus {
   color: rgba(0, 0, 0, 0.4); }
 
 .home-showcase-section .showcase img {
+  height: 110px;
   width: 110px;
   border-radius: 20px; }
 


### PR DESCRIPTION
Thanks for submitting a PR! Please read these instructions carefully:

- [x] Explain the **motivation** for making this change.
- [x] Provide a **test plan** demonstrating that the code is solid.
- [x] Match the **code formatting** of the rest of the codebase.
- [x] Target the `master` branch, NOT a "stable" branch.

## Motivation (required)

The current web page's "Who's using React Native?" icons are awkwardly squished:

![squished icons](http://i.imgur.com/TmS4brm.png?1)

By explicitly setting the height, we can make them square again:
![fixed icons](http://i.imgur.com/mN3cR1W.png?1)

## Test Plan (required)

Since this is just a one line CSS change, it probably doesn't need tests. See above screenshot for the change it makes. The fixed CSS is available live on my own [github pages](https://veggiedefender.github.io/react-native)
