### PR TITLE
[Android] Add explicit error message if e.getMessage is null

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/modules/network/NetworkingModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/network/NetworkingModule.java
@@ -332,7 +332,10 @@ public final class NetworkingModule extends ReactContextBaseJavaModule {
               return;
             }
             removeRequest(requestId);
-            ResponseUtil.onRequestError(eventEmitter, requestId, e.getMessage(), e);
+            String errorMessage = e.getMessage() != null
+                    ? e.getMessage()
+                    : "Error while executing request: " + e.getClass().getSimpleName();
+            ResponseUtil.onRequestError(eventEmitter, requestId, errorMessage, e);
           }
 
           @Override


### PR DESCRIPTION
## Motivation (required)

In the NetworkingModule, if the http request failed, we send a `didCompleteNetworkResponse` event with the error message, which is used on JS side to determine if the request was erroring. Currently we get the error message from `e.getMessage()`, however, not all exceptions have a message and it might therefore return null and thus resulting in no error on JS side. This change checks if the message is null and if so uses a default message.

## Test Plan (required)

In android send a request using XMLHttpRequest with a timeout set to a server that has a delay larger than the timeout (so we force the timeout to happen).

```
const request =  new XMLHttpRequest();
request.open('GET', "http://localhost:3000/", true);
request.timeout = 1000;
request.ontimeout = () => { console.log('ontimeout'); };
request.send();
```

See the timeout callback being called correctly.

Fixes #11666