### PR TITLE
Ignore all loopback addresses for ip detection

### DIFF
--- a/packager/react-native-xcode.sh
+++ b/packager/react-native-xcode.sh
@@ -78,7 +78,7 @@ if [[ "$CONFIGURATION" = "Debug" && ! "$PLATFORM_NAME" == *simulator ]]; then
   PLIST=$TARGET_BUILD_DIR/$INFOPLIST_PATH
   IP=$(ipconfig getifaddr en0)
   if [ -z "$IP" ]; then
-    IP=$(ifconfig | grep 'inet ' | grep -v 127.0.0.1 | cut -d\   -f2  | awk 'NR==1{print $1}')
+    IP=$(ifconfig | grep 'inet ' | grep -v ' 127.' | cut -d\   -f2  | awk 'NR==1{print $1}')
   fi
 
   if [ -z ${DISABLE_XIP+x} ]; then


### PR DESCRIPTION
## Motivation
There is a bug with IP detection on Macs that have (1) multiple ethernet interfaces, (2) are using the second or third interface as their primary connection and (3) have extra loopback IPs configured (for example when running OpenVPN, running some Docker configurations or other more exotic applications). In those cases, automatic IP detection will falsely detect the IP as something like `127.94.0.1`, which will make it impossible to run debug builds from a physical device.

## Cause
The underlying network configurations looks something similar to this (irrelevant parts omitted):
```
lo0: flags=8049<UP,LOOPBACK,RUNNING,MULTICAST> mtu 16384
	options=1203<RXCSUM,TXCSUM,TXSTATUS,SW_TIMESTAMP>
	inet 127.0.0.1 netmask 0xff000000
	inet 127.94.0.1 netmask 0xff000000
	nd6 options=201<PERFORMNUD,DAD>
en0: flags=8863<UP,BROADCAST,SMART,RUNNING,SIMPLEX,MULTICAST> mtu 1500
	options=10b<RXCSUM,TXCSUM,VLAN_HWTAGGING,AV>
	ether xx:xx:xx:xx:xx:xx
	nd6 options=201<PERFORMNUD,DAD>
	media: autoselect (none)
	status: inactive
en1: flags=8863<UP,BROADCAST,SMART,RUNNING,SIMPLEX,MULTICAST> mtu 1500
	inet 192.168.0.226 netmask 0xffffff00 broadcast 192.168.0.255
en2: flags=963<UP,BROADCAST,SMART,RUNNING,PROMISC,SIMPLEX> mtu 1500
	options=60<TSO4,TSO6>
	ether xx:xx:xx:xx:xx:xx
	media: autoselect <full-duplex>
	status: inactive
```

In this configuration the packager will currently figure out `127.94.0.1` instead of `192.168.0.226`.

## Proposed Fix
In addition to the existing filter on `127.0.0.1`, also filter out all loopback addresses by changing the grep filter on ` 127.` [with a space in front of `127` to make sure we only filter out leading `127` addresses]. This PR does exactly that.

Tested and found working on the culprit systems as well as various MacBooks.

Note: this PR replaces #12875 as it seems something went wrong with a rebase I did. Decided it was less of a risk to submit a new PR with this simple fix rather than retry the rebase.