### PR TITLE
Container Testing Updates

### DIFF
--- a/ContainerShip/Dockerfile.android-base
+++ b/ContainerShip/Dockerfile.android-base
@@ -86,10 +86,16 @@ RUN echo "y" | android update sdk -u -a -t $(android list sdk -a | grep "Intel x
 RUN echo "y" | android update sdk -u -a -t $(android list sdk -a | grep "Google APIs, Android API 23, revision 1" | awk '{ print $1 }' | sed 's/.$//')
 
 # Android Support Repository, revision 45
-RUN echo "y" | android update sdk -u -a -t $(android list sdk -a | grep "Android Support Repository, revision 45" | awk '{ print $1 }' | sed 's/.$//')
+RUN echo "y" | android update sdk -u -a -t $(android list sdk -a | grep "Android Support Repository" | awk '{ print $1 }' | sed 's/.$//')
 
 # Link adb executable
 RUN ln -s /opt/android/platform-tools/adb /usr/bin/adb
+
+# Install google-chrome
+RUN curl -fsSL https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
+     && echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list \
+     && apt-get update \
+     && apt-get install -y google-chrome-stable
 
 # clean up unnecessary directories
 RUN rm -rf /opt/android/system-images/android-19/default/x86

--- a/ContainerShip/scripts/run-ci-e2e-tests.sh
+++ b/ContainerShip/scripts/run-ci-e2e-tests.sh
@@ -11,13 +11,17 @@ RUN_CLI_INSTALL=1
 RUN_IOS=0
 RUN_JS=0
 
-RETRY_COUNT=${RETRY_COUNT:-1}
+RETRY_COUNT=${RETRY_COUNT:-2}
 AVD_UUID=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 8 | head -n 1)
 
 ANDROID_NPM_DEPS="appium@1.5.1 mocha@2.4.5 wd@0.3.11 colors@1.0.3 pretty-data2@0.40.1"
 CLI_PACKAGE=$ROOT/react-native-cli/react-native-cli-*.tgz
 PACKAGE=$ROOT/react-native-*.tgz
 REACT_NATIVE_MAX_WORKERS=1
+
+# solve issue with max user watches limit
+echo 65536 | tee -a /proc/sys/fs/inotify/max_user_watches
+watchman shutdown-server
 
 # retries command on failure
 # $1 -- max attempts
@@ -177,7 +181,6 @@ function e2e_suite() {
       cd ..
       keytool -genkey -v -keystore android/keystores/debug.keystore -storepass android -alias androiddebugkey -keypass android -dname "CN=Android Debug,O=Android,C=US"
 
-      echo "Starting packager server"
       node ./node_modules/.bin/appium >> /dev/null &
       APPIUM_PID=$!
       echo "Starting appium server $APPIUM_PID"
@@ -193,6 +196,7 @@ function e2e_suite() {
         return 1
       fi
 
+      echo "Starting packager server"
       npm start >> /dev/null &
       SERVER_PID=$!
       sleep 15

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -52,11 +52,13 @@ def getParallelInstrumentationTests(testDir, parallelCount, imageName) {
     def testCount = sh(script: "ls ${testDir} | wc -l", returnStdout: true).trim().toInteger()
     def testPerParallel = testCount.intdiv(parallelCount) + 1
 
+    def ignoredTests = 'ProgressBarTestCase|LayoutEventsTestCase|CatalystNativeJavaToJSReturnValuesTestCase|CatalystUIManagerTestCase|CatalystMeasureLayoutTest|CatalystNativeJavaToJSArgumentsTestCase|CatalystNativeJSToJavaParametersTestCase|ReactScrollViewTestCase|ReactHorizontalScrollViewTestCase|ViewRenderingTestCase';
+
     for (def x = 0; (x*testPerParallel) < testCount; x++) {
         def offset = x
         integrationTests["android integration tests: ${offset}"] = {
             run: {
-                runCmdOnDockerImage(imageName, "bash /app/ContainerShip/scripts/run-android-docker-instrumentation-tests.sh --offset=${offset} --count=${testPerParallel}", '--privileged --rm')
+                runCmdOnDockerImage(imageName, "bash /app/ContainerShip/scripts/run-android-docker-instrumentation-tests.sh --offset=${offset} --count=${testPerParallel} --ignore=\"${ignoredTests}\"", '--privileged --rm')
             }
         }
     }
@@ -106,7 +108,7 @@ def runStages() {
                 jsImageName = "${buildInfo.image.name}-js:${jsTag}"
                 androidImageName = "${buildInfo.image.name}-android:${androidTag}"
 
-                parallelInstrumentationTests = getParallelInstrumentationTests('./ReactAndroid/src/androidTest/java/com/facebook/react/tests', 1, androidImageName)
+                parallelInstrumentationTests = getParallelInstrumentationTests('./ReactAndroid/src/androidTest/java/com/facebook/react/tests', 3, androidImageName)
 
                 parallel(
                     'javascript build': {
@@ -148,9 +150,7 @@ def runStages() {
                             runCmdOnDockerImage(androidImageName, 'bash /app/ContainerShip/scripts/run-android-docker-unit-tests.sh', '--privileged --rm')
                         },
                         'android e2e tests': {
-                            // temporarily disable e2e tests, they have a high transient failure rate
-                            // runCmdOnDockerImage(androidImageName, 'bash /app/ContainerShip/scripts/run-ci-e2e-tests.sh --android --js', '--rm')
-                            echo "Android E2E tests have been temporarily disabled"
+                            runCmdOnDockerImage(androidImageName, 'bash /app/ContainerShip/scripts/run-ci-e2e-tests.sh --android --js', '--privileged --rm')
                         }
                     )
                 } catch(e) {

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "test-android-build": "docker build -t react/android -f ContainerShip/Dockerfile.android .",
     "test-android-run-instrumentation": "docker run --cap-add=SYS_ADMIN -it react/android bash ContainerShip/scripts/run-android-docker-instrumentation-tests.sh",
     "test-android-run-unit": "docker run --cap-add=SYS_ADMIN -it react/android bash ContainerShip/scripts/run-android-docker-unit-tests.sh",
-    "test-android-run-e2e": "docker run -it react/android bash ContainerShip/scripts/run-ci-e2e-tests.sh --android --js",
+    "test-android-run-e2e": "docker run --cap-add=SYS_ADMIN -it react/android bash ContainerShip/scripts/run-ci-e2e-tests.sh --android --js",
     "test-android-all": "npm run test-android-build && npm run test-android-run-unit && npm run test-android-run-instrumentation && npm run test-android-run-e2e",
     "test-android-instrumentation": "npm run test-android-build && npm run test-android-run-instrumentation",
     "test-android-unit": "npm run test-android-build && npm run test-android-run-unit",


### PR DESCRIPTION
@ericvicenti Here is the latest updates and fixes for the container testing. Everything should be good to go now, the update for `inotify.max_user_watches` should fix the E2E test issues you were seeing locally.

The update to the packer prevents excessively large filename lengths due to the hash used in the name and splits them into directories instead. I was getting errors locally on the E2E because the hash filename was over 248 characters which was causing issues on the base image file system. It might not have appeared in circle due to another file system being used with different limits. I can separate it out into another PR if you want though.

* Updated packager to split hash included in filename into directories
if it was over 143 characters (max size of encrypted file on most file
    systems)
* Turned jenkins instrumentation parallelism up to 3
* Disabled various instrumentation tests that seemed to have inconsistent results from
Jenkins by default
* Install google-chrome in the android base image so the chrome debug E2E test does not fail
* Turned back on E2E tests

cc @normanjoyner