### PR TITLE
Update documentation to use newer version of fresco - fixes #13345

### DIFF
--- a/Libraries/Image/Image.ios.js
+++ b/Libraries/Image/Image.ios.js
@@ -104,17 +104,17 @@ const ImageViewManager = NativeModules.ImageViewManager;
  * ```
  * dependencies {
  *   // If your app supports Android versions before Ice Cream Sandwich (API level 14)
- *   compile 'com.facebook.fresco:animated-base-support:0.11.0'
+ *   compile 'com.facebook.fresco:animated-base-support:0.14.1'
  *
  *   // For animated GIF support
- *   compile 'com.facebook.fresco:animated-gif:0.11.0'
+ *   compile 'com.facebook.fresco:animated-gif:0.14.1'
  *
  *   // For WebP support, including animated WebP
- *   compile 'com.facebook.fresco:animated-webp:0.11.0'
- *   compile 'com.facebook.fresco:webpsupport:0.11.0'
+ *   compile 'com.facebook.fresco:animated-webp:0.14.1'
+ *   compile 'com.facebook.fresco:webpsupport:0.14.1'
  *
  *   // For WebP support, without animations
- *   compile 'com.facebook.fresco:webpsupport:0.11.0'
+ *   compile 'com.facebook.fresco:webpsupport:0.14.1'
  * }
  * ```
  *

--- a/Libraries/Image/Image.ios.js
+++ b/Libraries/Image/Image.ios.js
@@ -104,17 +104,17 @@ const ImageViewManager = NativeModules.ImageViewManager;
  * ```
  * dependencies {
  *   // If your app supports Android versions before Ice Cream Sandwich (API level 14)
- *   compile 'com.facebook.fresco:animated-base-support:0.14.1'
+ *   compile 'com.facebook.fresco:animated-base-support:1.0.1'
  *
  *   // For animated GIF support
- *   compile 'com.facebook.fresco:animated-gif:0.14.1'
+ *   compile 'com.facebook.fresco:animated-gif:1.0.1'
  *
  *   // For WebP support, including animated WebP
- *   compile 'com.facebook.fresco:animated-webp:0.14.1'
- *   compile 'com.facebook.fresco:webpsupport:0.14.1'
+ *   compile 'com.facebook.fresco:animated-webp:1.0.1'
+ *   compile 'com.facebook.fresco:webpsupport:1.0.1'
  *
  *   // For WebP support, without animations
- *   compile 'com.facebook.fresco:webpsupport:0.14.1'
+ *   compile 'com.facebook.fresco:webpsupport:1.0.1'
  * }
  * ```
  *


### PR DESCRIPTION
Thanks for submitting a PR! Please read these instructions carefully:

## Motivation (required)

React Native crashes hard on fresco 0.11.0 - see #13345

## Test Plan (required)

Repro case in #13345