### PR TITLE
rm react-dom to see if tests fail

### DIFF
--- a/package.json
+++ b/package.json
@@ -229,7 +229,6 @@
     "jest-runtime": "19.0.2",
     "mock-fs": "^3.11.0",
     "react": "16.0.0-alpha.6",
-    "react-dom": "16.0.0-alpha.6",
     "react-test-renderer": "16.0.0-alpha.6",
     "shelljs": "0.6.0",
     "sinon": "^2.0.0-pre.2"


### PR DESCRIPTION
I'm not sure why we rely on react-dom, so this is an attempt to remove it.

Wait for tests to fail or succeed.