### PR TITLE
fix mock for AsyncLocalStorage

### DIFF
--- a/jest/setup.js
+++ b/jest/setup.js
@@ -72,10 +72,12 @@ const mockNativeModules = {
     addEventListener: jest.fn(),
   },
   AsyncLocalStorage: {
-    clear: jest.fn(),
-    getItem: jest.fn(),
-    removeItem: jest.fn(),
-    setItem: jest.fn(),
+    multiGet: jest.fn((keys, callback) => process.nextTick(() => callback(null, []))),
+    multiSet: jest.fn((entries, callback) => process.nextTick(() => callback(null))),
+    multiRemove: jest.fn((keys, callback) => process.nextTick(() => callback(null))),
+    multiMerge: jest.fn((entries, callback) => process.nextTick(() => callback(null))),
+    clear: jest.fn(callback => process.nextTick(() => callback(null))),
+    getAllKeys: jest.fn(callback => process.nextTick(() => callback(null, []))),
   },
   BuildInfo: {
     appVersion: '0',


### PR DESCRIPTION
The current mock of `AsyncLocalStorage` seems to mock parts of the
`AsyncStorage` API that can't be found on the `AsyncLocalStorage`
object itself and therefore it doesn't work as expected.

What it should do is mock the API of `AsyncLocalStorage` which is a
`NativeModule` so that the `AsyncStorage` module can be used in tests
and it will require the mocked methods.

In order to enable behaviour in unit tests it is possible to replace or
overwrite the mock implementation, see the [jest guide on mocks](https://facebook.github.io/jest/docs/mock-functions.html).
By doing something similar to:
```javascript
import { NativeModules } from 'react-native';
const { AsyncLocalStorage } = NativeModules;
// mock 'multiGet', in order to allow 'AsyncStorage.getItem('myKey')'
AsyncLocalStorage.multiGet.mockImplementationOnce((keys, callback) => {
    callback(null, [['myKey', 'myValue']]);
});
// execute unit tests for code that makes use of 'AsyncStorage'
```