### PR TITLE
fixed typo in "linking" docs

### DIFF
--- a/Libraries/Linking/Linking.js
+++ b/Libraries/Linking/Linking.js
@@ -58,7 +58,7 @@ const LinkingManager = Platform.OS === 'android' ?
  * NOTE: On iOS you'll need to link `RCTLinking` to your project by following
  * the steps described [here](docs/linking-libraries-ios.html#manual-linking).
  * In case you also want to listen to incoming app links during your app's
- * execution you'll need to add the following lines to you `*AppDelegate.m`:
+ * execution you'll need to add the following lines to your `*AppDelegate.m`:
  *
  * ```
  * #import <React/RCTLinkingManager.h>


### PR DESCRIPTION
## Motivation (required)

Fixing a typo found via https://facebook.github.io/react-native/docs/linking.html

## Test Plan (required)

n/a (they're docs)