### PR TITLE
Add Geolocation API Jest mock

### DIFF
--- a/jest/setup.js
+++ b/jest/setup.js
@@ -129,6 +129,11 @@ const mockNativeModules = {
     addListener: jest.fn(),
     removeListeners: jest.fn(),
   },
+  LocationObserver: {
+    getCurrentPosition: jest.fn(),
+    startObserving: jest.fn(),
+    stopObserving: jest.fn(),
+  },
   ModalFullscreenViewManager: {},
   Networking: {
     sendRequest: jest.fn(),


### PR DESCRIPTION
Hello!

## Motivation (required)

The [Geolocation API](https://facebook.github.io/react-native/docs/geolocation.html) is currently not mocked in Jest, which often leads to an `Invariant Violation: Native module cannot be null` error. This patch adds a basic Jest configuration similar to the existing ones for the other modules.

## Test Plan (required)

None unfortunately, but this patch makes my test suite all green 😉 

Thanks,
William