### PR TITLE
fixed #13445 - the Windows package launcher script can now pass all a…

### DIFF
--- a/packager/__tests__/launchPackagerCLIMock.js.mock
+++ b/packager/__tests__/launchPackagerCLIMock.js.mock
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+'use strict';
+
+// Remove the first two elements, we only want the arguments
+process.argv.splice(0, 2);
+
+// Print out the arguments to be used in the test
+console.log(process.argv.join(';;'));

--- a/packager/__tests__/launchPackagerMock.bat
+++ b/packager/__tests__/launchPackagerMock.bat
@@ -7,6 +7,6 @@
 
 @echo off
 title React Packager
-node "%~dp0..\local-cli\cli.js" start %*
+node "$THIS_DIR/launchPackagerCLIMock.js.mock" start %*
 pause
 exit

--- a/packager/__tests__/launchPackagerMock.sh
+++ b/packager/__tests__/launchPackagerMock.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2015-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+
+THIS_DIR=$(dirname "$0")
+node "$THIS_DIR/launchPackagerCLIMock.js.mock" start "$@"

--- a/packager/__tests__/packagerLauncher.spec.js
+++ b/packager/__tests__/packagerLauncher.spec.js
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+'use strict';
+
+jest.autoMockOff();
+
+const onWindows = /^win/.test(process.platform);
+const { spawnSync } = require('child_process');
+
+describe('packager launcher', () => {
+  it('should be able to pass all arguments to the command-line script', () => {
+    // Determine the appropriate script to test based on the host OS
+    const cmd = `./packager/__tests__/launchPackagerMock.${onWindows ? 'bat' : 'sh'}`;
+
+    // Let's try to pass some args
+    const args = ['--arg1', '--arg2'];
+    const proc = spawnSync(cmd, args);
+
+    // We should've gotten the args from the mock script
+    const outArgs = proc.stdout.toString().trim().split(";;");
+
+    // We account for an extra arg in the mock scripts
+    expect(outArgs[1]).toEqual(args[0]);
+    expect(outArgs[2]).toEqual(args[1]);
+  });
+});


### PR DESCRIPTION
## Motivation (required)

This pull request solves issue #13445 

## Test Plan (required)

I have added a new test spec called `packagerLauncher` which passes successfully.

<img width="567" alt="0 43 3-patch 0-packagerlaunchertest" src="https://cloud.githubusercontent.com/assets/1070218/24911414/82674816-1ed3-11e7-963c-00007d30c196.png">

