### PR TITLE
Removed RCTLogWarn about "Required dispatch_sync ... that my lead to deadlocks"

### DIFF
--- a/React/Base/RCTModuleData.mm
+++ b/React/Base/RCTModuleData.mm
@@ -293,10 +293,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init);
   if (_hasConstantsToExport && !_constantsToExport) {
     RCT_PROFILE_BEGIN_EVENT(RCTProfileTagAlways, ([NSString stringWithFormat:@"[RCTModuleData gatherConstants] %@", _moduleClass]), nil);
     (void)[self instance];
-    if (!RCTIsMainQueue()) {
-      RCTLogWarn(@"Required dispatch_sync to load constants for %@. This may lead to deadlocks", _moduleClass);
-    }
-
+    
     RCTUnsafeExecuteOnMainQueueSync(^{
       self->_constantsToExport = [self->_instance constantsToExport] ?: @{};
     });


### PR DESCRIPTION
As the next line calls RCTUnsafeExecuteOnMainQueueSync which checks RCTIsMainQueue as well and calls block as is if it is on main queue.

## Motivation (required)

What existing problem does the pull request solve?

Currently in master when method gatherConstants is called we check RCTIsMainQueue and show warning about possible issues, but later we call RCTUnsafeExecuteOnMainQueueSync which in its turn check RCTIsMainQueue again can if it is true handles the case by calling block as is (without dispatch).

I found this warning useless and misleading.

## Test Plan (required)

1. This simple change that removes warning message and does not affect functionality, 
2. All tests are passed.
3. Additionally we can create Module which prepares constants and load it into ReactNative to see that it is still works and does not produce any Warnings. 

## Next Steps

Signed CLA