### PR TITLE
Remove immutable-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -167,7 +167,6 @@
     "glob": "^7.1.1",
     "graceful-fs": "^4.1.3",
     "image-size": "^0.3.5",
-    "immutable": "~3.7.6",
     "imurmurhash": "^0.1.4",
     "inquirer": "^0.12.0",
     "jest-haste-map": "19.0.0",


### PR DESCRIPTION
## Motivation (required)

Immutable doesn't seem to be used in react-native anymore so I've removed it as a dependency.

## Test Plan (required)

Ensure that all tests pass.