### PR TITLE
Don't build js bundles for debug simulator build configurations

### DIFF
--- a/packager/react-native-xcode.sh
+++ b/packager/react-native-xcode.sh
@@ -11,7 +11,7 @@
 # and relies on environment variables (including PWD) set by Xcode
 
 case "$CONFIGURATION" in
-  Debug)
+  *Debug*)
     # Speed up build times by skipping the creation of the offline package for debug
     # builds on the simulator since the packager is supposed to be running anyways.
     if [[ "$PLATFORM_NAME" == *simulator ]]; then


### PR DESCRIPTION
Don't build js bundles for debug simulator build configurations

Motivation:
We have more than one debug build configuration that we run in the simulator, and none of them are exactly named 'Debug'. We want to establish the convention that any simulator build configuration containing the word 'Debug' will not build the react js bundles. We believe this is less intrusive to the developer.

Test Plan:
1.) build the app with two different build configurations, both containing the word Debug. And build the app with a build configurationg not containing the word debug. 2.) verify, in the buld log output, that the react native packager executes, when a build configuration contains the 'Debug' string


