### PR TITLE
Change Promise.done to Promise.then

### DIFF
--- a/Libraries/Network/NetInfo.js
+++ b/Libraries/Network/NetInfo.js
@@ -79,7 +79,7 @@ const _isConnectedSubscriptions = new Map();
  * NetInfo exposes info about online/offline status
  *
  * ```
- * NetInfo.fetch().done((reach) => {
+ * NetInfo.fetch().then((reach) => {
  *   console.log('Initial: ' + reach);
  * });
  * function handleFirstConnectivityChange(reach) {


### PR DESCRIPTION
- [X] Explain the **motivation** for making this change.
- [X] Provide a **test plan** demonstrating that the code is solid.
- [X] Match the **code formatting** of the rest of the codebase.
- [X] Target the `master` branch, NOT a "stable" branch.

## Motivation

`Promise.done` is non-standard, `Promise.then` is preferred as a standardized method. On Android, polyfill filling in `Promise.done` has been most probably taken out in newer versions of `react-native` and app crashes when it tries to query network state through `NetInfo`.

## Test Plan

No tests are required for this change.
