### PR TITLE
Use uri instead of url in source property of Image

### DIFF
--- a/Examples/UIExplorer/js/ImageExample.js
+++ b/Examples/UIExplorer/js/ImageExample.js
@@ -656,7 +656,7 @@ exports.examples = [
         <View style={{flexDirection: 'row'}}>
           <Image
             source={{
-              url: 'ImageInBundle',
+              uri: 'ImageInBundle',
               bundle: 'UIExplorerBundle',
               width: 100,
               height: 100,
@@ -665,7 +665,7 @@ exports.examples = [
           />
           <Image
             source={{
-              url: 'ImageInAssetCatalog',
+              uri: 'ImageInAssetCatalog',
               bundle: 'UIExplorerBundle',
               width: 100,
               height: 100,


### PR DESCRIPTION
https://github.com/facebook/react-native/issues/13478#issuecomment-294002694

Fix incorrect usage of `url` in the `source` property of `<Image />` in the example.