### PR TITLE
Protect against fatal YellowBox error when stack frame has no file

### DIFF
--- a/Libraries/ReactNative/YellowBox.js
+++ b/Libraries/ReactNative/YellowBox.js
@@ -191,8 +191,13 @@ const StackRow = ({frame}: StackRowProps) => {
   const Text = require('Text');
   const TouchableHighlight = require('TouchableHighlight');
   const {file, lineNumber} = frame;
-  const fileParts = file.split('/');
-  const fileName = fileParts[fileParts.length - 1];
+  let fileName;
+  if (file) {
+    const fileParts = file.split('/');
+    fileName = fileParts[fileParts.length - 1];
+  } else {
+    fileName = '<unknown file>';
+  }
 
   return (
     <TouchableHighlight


### PR DESCRIPTION
Motivation: When viewing a stack trace in YellowBox where one or more of the stack frames has no `file`, JS will encounter the fatal error `null is not an object (evaluating 'file.split')`. This can happen, for example, when running a bundle for which no source maps were generated.

Test plan: Send a stack trace with empty stack frames to `console.warn`, for example by turning off source maps.