### PR TITLE
Adjust row height by font size in PickerIOS

### DIFF
--- a/React/Views/RCTPicker.m
+++ b/React/Views/RCTPicker.m
@@ -70,6 +70,10 @@ numberOfRowsInComponent:(__unused NSInteger)component
   return [RCTConvert NSString:_items[row][@"label"]];
 }
 
+- (CGFloat)pickerView:(UIPickerView *)pickerView rowHeightForComponent:(NSInteger)component {
+  return _font.pointSize + 19;
+}
+
 - (UIView *)pickerView:(UIPickerView *)pickerView
             viewForRow:(NSInteger)row
           forComponent:(NSInteger)component


### PR DESCRIPTION
- [x] Explain the **motivation** for making this change.
- [x] Provide a **test plan** demonstrating that the code is solid.
- [x] Match the **code formatting** of the rest of the codebase.
- [x] Target the `master` branch, NOT a "stable" branch.

## Motivation (required)

There is a problem where setting a bigger fontSize in PickerItem style
clips the top and bottom of the text.
This solves that problem by computing the row height using the font
size.

## Test Plan (required)

Create a PickerIOS component and set a larger font size (e.g. 50). The row height will grow accordingly.

Example with `fontSize=50`: [Screenshot](http://i.imgur.com/YwK5fOc.png)