### PR TITLE
Fix run-ios when specifying a scheme as cli arg

### DIFF
--- a/local-cli/runIOS/runIOS.js
+++ b/local-cli/runIOS/runIOS.js
@@ -94,7 +94,7 @@ function runOnSimulator(xcodeProject, args, inferredSchemeName, scheme){
   .then((udid) => buildProject(xcodeProject, udid, scheme, args.configuration, args.packager))
   .then((appName) => {
     if (!appName) {
-      appName = inferredSchemeName;
+      appName = scheme;
     }
     let appPath = getBuildPath(args.configuration, appName);
     console.log(`Installing ${appPath}`);

--- a/local-cli/runIOS/runIOS.js
+++ b/local-cli/runIOS/runIOS.js
@@ -47,7 +47,7 @@ function runIOS(argv, config, args) {
   } else if (args.udid) {
     return runOnDeviceByUdid(args, scheme, xcodeProject, devices);
   } else {
-    return runOnSimulator(xcodeProject, args, inferredSchemeName, scheme);
+    return runOnSimulator(xcodeProject, args, scheme);
   }
 }
 
@@ -66,7 +66,7 @@ function runOnDeviceByUdid(args, scheme, xcodeProject, devices) {
   }
 }
 
-function runOnSimulator(xcodeProject, args, inferredSchemeName, scheme){
+function runOnSimulator(xcodeProject, args, scheme){
   return new Promise((resolve) => {
     try {
       var simulators = JSON.parse(


### PR DESCRIPTION
The cli arg `--scheme` allows you to override the inferred scheme.
The runOnDevice command takes this override into account, but run-ios
doesn't. This commit fixes this discrepancy.

Thanks for submitting a PR! Please read these instructions carefully:

- [x] Explain the **motivation** for making this change.
- [x] Provide a **test plan** demonstrating that the code is solid.
- [x] Match the **code formatting** of the rest of the codebase.
- [x] Target the `master` branch, NOT a "stable" branch.

## Motivation (required)

Currently if a custom scheme is specified, `run-ios` will fail with the following message

```
Error: Command failed: /usr/libexec/PlistBuddy -c Print:CFBundleIdentifier build/Build/Products/Debug-iphonesimulator/AwesomeProject.app/Info.plist
Print: Entry, ":CFBundleIdentifier", Does Not Exist
```

This PR fixes this.

## Test Plan (required)

Tested manually from CLI.