### PR TITLE
Bump the flow-bin version to ^0.44.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -221,7 +221,7 @@
     "eslint-plugin-flowtype": "^2.20.0",
     "eslint-plugin-react": "^6.4.1",
     "eslint-config-fbjs": "^1.1.1",
-    "flow-bin": "^0.44.0",
+    "flow-bin": "^0.44.2",
     "jest": "19.0.2",
     "jest-repl": "19.0.2",
     "jest-runtime": "19.0.2",


### PR DESCRIPTION
## Motivation (required)

There's something wrong with the Linux binary in Flow v0.44.1. It doesn't work. Flow v0.44.2 fixes, however CircleCI may have cached Flow v0.44.1. Putting this PR up in case it's needed.

## Test Plan (required)

yarn install
yarn run flow