### PR TITLE
More verbose error messages for iOS

### DIFF
--- a/React/Base/RCTBatchedBridge.m
+++ b/React/Base/RCTBatchedBridge.m
@@ -210,7 +210,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithBundleURL:(__unused NSURL *)bundleUR
       if (error && [self.delegate respondsToSelector:@selector(fallbackSourceURLForBridge:)]) {
         NSURL *fallbackURL = [self.delegate fallbackSourceURLForBridge:self->_parentBridge];
         if (fallbackURL && ![fallbackURL isEqual:self.bundleURL]) {
-          RCTLogError(@"Failed to load bundle(%@) with error:(%@)", self.bundleURL, error.localizedDescription);
+          RCTLogError(@"Failed to load bundle(%@) with error:(%@ %@)", self.bundleURL, error.localizedDescription, error.localizedFailureReason);
           self.bundleURL = fallbackURL;
           [RCTJavaScriptLoader loadBundleAtURL:self.bundleURL onProgress:onProgress onComplete:onSourceLoad];
           return;
@@ -513,7 +513,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithBundleURL:(__unused NSURL *)bundleUR
     }
 
     if (loadError) {
-      RCTLogWarn(@"Failed to execute source code: %@", [loadError localizedDescription]);
+      RCTLogWarn(@"Failed to execute source code: %@ %@", [loadError localizedDescription], [loadError localizedFailureReason]);
       dispatch_async(dispatch_get_main_queue(), ^{
         [self stopLoadingWithError:loadError];
       });

--- a/React/Base/RCTJSCErrorHandling.mm
+++ b/React/Base/RCTJSCErrorHandling.mm
@@ -13,6 +13,7 @@
 
 #import "RCTAssert.h"
 #import "RCTJSStackFrame.h"
+#import "RCTLog.h"
 
 NSString *const RCTJSExceptionUnsymbolicatedStackTraceKey = @"RCTJSExceptionUnsymbolicatedStackTraceKey";
 
@@ -25,7 +26,9 @@ NSError *RCTNSErrorFromJSError(JSValue *exception)
     userInfo[NSLocalizedFailureReasonErrorKey] = exceptionMessage;
   }
   NSString *const stack = [exception[@"stack"] toString];
-  if ([stack length]) {
+  if ([@"undefined" isEqualToString:stack]) {
+    RCTLogWarn(@"Couldn't get stack trace for %@:%@", exception[@"sourceURL"], exception[@"line"]);
+  } else if ([stack length]) {
     NSArray<RCTJSStackFrame *> *const unsymbolicatedFrames = [RCTJSStackFrame stackFramesWithLines:stack];
     userInfo[RCTJSStackTraceKey] = unsymbolicatedFrames;
   }

--- a/React/CxxBridge/RCTCxxBridge.mm
+++ b/React/CxxBridge/RCTCxxBridge.mm
@@ -356,7 +356,7 @@ struct RCTInstanceCallback : public InstanceCallback {
       if (error && [self.delegate respondsToSelector:@selector(fallbackSourceURLForBridge:)]) {
         NSURL *fallbackURL = [self.delegate fallbackSourceURLForBridge:self->_parentBridge];
         if (fallbackURL && ![fallbackURL isEqual:self.bundleURL]) {
-          RCTLogError(@"Failed to load bundle(%@) with error:(%@)", self.bundleURL, error.localizedDescription);
+          RCTLogError(@"Failed to load bundle(%@) with error:(%@ %@)", self.bundleURL, error.localizedDescription, error.localizedFailureReason);
           self.bundleURL = fallbackURL;
           [RCTJavaScriptLoader loadBundleAtURL:self.bundleURL onProgress:onProgress onComplete:onSourceLoad];
           return;


### PR DESCRIPTION
Output the reason for the error when failing to load source code. This was a big help when trying to diagnose https://github.com/facebook/react-native/issues/13299.

~~Unfortunately there still seems to be no way to get the offending line number (because `loadError.userInfo[RCTJSStackTraceKey]` is empty), but this is good enough.~~

Before:

```
[warn][tid:com.facebook.react.JavaScript][RCTBatchedBridge.m:510] Failed to execute source code. Unhandled JS Exception: SyntaxError
```

After:

```
[warn][tid:com.facebook.react.JavaScript][RCTJSCErrorHandling.mm:30] Couldn't get stack trace for http://localhost:8081/index.ios.bundle?platform=ios&dev=true&minify=false:81886
[warn][tid:com.facebook.react.JavaScript][RCTBatchedBridge.m:510] Failed to execute source code. Unhandled JS Exception: SyntaxError Unexpected keyword 'var'
```
