### PR TITLE
Expose shake-to-show dev menu setting via the bridge

### DIFF
--- a/React/Modules/RCTDevSettings.mm
+++ b/React/Modules/RCTDevSettings.mm
@@ -197,9 +197,9 @@ RCT_EXPORT_METHOD(reload)
   [_bridge reload];
 }
 
-- (void)setIsShakeToShowDevMenuEnabled:(BOOL)isShakeToShowDevMenuEnabled
+RCT_EXPORT_METHOD(setIsShakeToShowDevMenuEnabled:(BOOL)enabled)
 {
-  [self _updateSettingWithValue:@(isShakeToShowDevMenuEnabled) forKey:kRCTDevSettingShakeToShowDevMenu];
+  [self _updateSettingWithValue:@(enabled) forKey:kRCTDevSettingShakeToShowDevMenu];
 }
 
 - (BOOL)isShakeToShowDevMenuEnabled


### PR DESCRIPTION
Summary: Apps commonly provide their own rage-shake menus or behaviors, including in dev builds where the dev menu is enabled on shake. Rather than try to override these settings via native code, it can be helpful to let the app define when to show the menu via the bridge.

See recent discussion in https://github.com/facebook/react-native/issues/1054

Test Plan: Add the following code to `UIExplorerApp.ios.js` `componentDidMount`:

    NativeModules.DevSettings.setIsShakeToShowDevMenuEnabled(false);

And then rage shake the device (or simulator). Ensure that the menu no longer appears on shake.

Other tests:
- Ensure simulator Command-D shortcut still functions on simulator with setting enabled.
- Ensure calling `NativeModules.DevMenu.show()` still functions with setting enabled.
- Ensure calling the method with `false` and then `true` reverts the setting back to the original state.

Note that these settings are stored in user defaults, so setting this to `false` and then removing the code will not re-enable the menu; a subsequent call with `true` must occur.