### PR TITLE
Enable dev menu in tvOS simulator

### DIFF
--- a/React/Modules/RCTDevMenu.m
+++ b/React/Modules/RCTDevMenu.m
@@ -108,7 +108,7 @@ RCT_EXPORT_MODULE()
                                                object:nil];
     _extraMenuItems = [NSMutableArray new];
 
-#if TARGET_IPHONE_SIMULATOR
+#if TARGET_OS_SIMULATOR
     RCTKeyCommands *commands = [RCTKeyCommands sharedInstance];
     __weak __typeof(self) weakSelf = self;
 


### PR DESCRIPTION
## Motivation (required)

There was no easy way to pull up the dev menu in the tvOS simulator

## Test Plan (required)

Run the UIExplorer demo and press cmd+d to bring up the menu
