### PR TITLE
disable Circle e2e tests

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -76,7 +76,8 @@ test:
     # - node ./scripts/run-android-ci-instrumentation-tests.js --retries 3 --path ./ReactAndroid/src/androidTest/java/com/facebook/react/tests --package com.facebook.react.tests
 
     # Android e2e test
-    - source scripts/circle-ci-android-setup.sh && retry3 node ./scripts/run-ci-e2e-tests.js --android --js --retries 2
+    # disabled pending on https://our.intern.facebook.com/intern/tasks?t=16912142
+    # - source scripts/circle-ci-android-setup.sh && retry3 node ./scripts/run-ci-e2e-tests.js --android --js --retries 2
 
     # testing docs generation
     - cd website && npm test


### PR DESCRIPTION
Motivation is that Circle e2e tests have been broken for a few days, it appears to be flaky and an ongoing problem. @AaaChiuuu & Andrew Chen are taking a look, but for now let's turn this off so that Circle can be useful for other things.