### PR TITLE
[docs] clarify the picker onValueChange

### DIFF
--- a/Libraries/Components/Picker/Picker.js
+++ b/Libraries/Components/Picker/Picker.js
@@ -77,7 +77,7 @@ class PickerItem extends React.Component {
  *
  *     <Picker
  *       selectedValue={this.state.language}
- *       onValueChange={(lang) => this.setState({language: lang})}>
+ *       onValueChange={(itemValue, itemIndex) => this.setState({language: itemValue})}>
  *       <Picker.Item label="Java" value="java" />
  *       <Picker.Item label="JavaScript" value="js" />
  *     </Picker>


### PR DESCRIPTION
In the current docs, it's not quite clear, at the first sight, what the `lang` parameter passed to `onValueChange` is. This makes it obvious.