### PR TITLE
Fixed issue where the copy item would be added to the tooltips on the…

### DIFF
--- a/Libraries/Text/RCTText.m
+++ b/Libraries/Text/RCTText.m
@@ -236,11 +236,11 @@ static void collectNonTextDescendants(RCTText *view, NSMutableArray *nonTextDesc
 
 - (BOOL)canPerformAction:(SEL)action withSender:(id)sender
 {
-  if (action == @selector(copy:)) {
+  if (_selectable && action == @selector(copy:)) {
     return YES;
   }
-
-  return [super canPerformAction:action withSender:sender];
+  
+  return [self.nextResponder canPerformAction:action withSender:sender];
 }
 
 - (void)copy:(id)sender


### PR DESCRIPTION
## Motivation

This PR solves issue #13618.

## Test Plan

Selectable text still behaves the same way:

```jsx
<Text selectable={true}>yo yo yo</Text>
```

![capture d ecran 2017-04-21 a 17 10 51](https://cloud.githubusercontent.com/assets/671923/25296285/85eba646-26b5-11e7-8773-e5e55ee0d7bb.png)

Text that is not selectable and has a custom tooltip now do not include the copy item:

```jsx
import * as React from 'react';
import { Text } from 'react-native';
import ToolTip from 'react-native-tooltip';

const MyComponent = () => (
  <Text>
    <Text>This is my text.</Text>
    <ToolTip
      actions={[
        {text: 'My', onPress: (): any => null },
        {text: 'Context', onPress: (): any => null },
        {text: 'Menu', onPress: (): any => null },
      ]}
      underlayColor='transparent'
      longPress={true}
      arrowDirection='down'
    >
      <Text>You can long press me for a tooltip.</Text>
    </ToolTip>
    <Text>This is the rest of my text</Text>
  </Text>
);

export default MyComponent;
```

![capture d ecran 2017-04-21 a 17 10 56](https://cloud.githubusercontent.com/assets/671923/25296297/970949ba-26b5-11e7-8378-3bf0289d1a5a.png)