### PR TITLE
Fixed ListViewMock unique key error when many sections

### DIFF
--- a/Libraries/Lists/ListView/__mocks__/ListViewMock.js
+++ b/Libraries/Lists/ListView/__mocks__/ListViewMock.js
@@ -32,9 +32,10 @@ class ListViewMock extends React.Component {
       const rowIDs = allRowIDs[sectionIdx];
       for (let rowIdx = 0; rowIdx < rowIDs.length; rowIdx++) {
         const rowID = rowIDs[rowIdx];
+        // Row IDs are only unique in a section
         rows.push(
           <StaticRenderer
-            key={'r_' + sectionID + '_' + rowID}
+            key={'section_' + sectionID + '_row_' + rowID}
             shouldUpdate={true}
             render={this.props.renderRow.bind(
               null,

--- a/Libraries/Lists/ListView/__mocks__/ListViewMock.js
+++ b/Libraries/Lists/ListView/__mocks__/ListViewMock.js
@@ -34,7 +34,7 @@ class ListViewMock extends React.Component {
         const rowID = rowIDs[rowIdx];
         rows.push(
           <StaticRenderer
-            key={rowID}
+            key={'r_' + sectionID + '_' + rowID}
             shouldUpdate={true}
             render={this.props.renderRow.bind(
               null,


### PR DESCRIPTION
When ListViews has multiple sections, then rowIDs are required to be unique per section.
However the ListViewMock required rowIDs to be unique per whole list.
This change fixes the limitation of ListViewMock.