### PR TITLE
[WIP] Use SnackPlayer for API/Component examples

### DIFF
--- a/website/layout/AutodocsLayout.js
+++ b/website/layout/AutodocsLayout.js
@@ -23,6 +23,7 @@ const PropTypes = require('prop-types');
 var Site = require('Site');
 
 var slugify = require('slugify');
+var SnackPlayer = require('SnackPlayer');
 
 var styleReferencePattern = /^[^.]+\.propTypes\.style$/;
 
@@ -785,56 +786,6 @@ var TypeDef = React.createClass({
   },
 });
 
-var EmbeddedSimulator = React.createClass({
-  render: function() {
-    if (!this.props.shouldRender) {
-      return null;
-    }
-
-    var metadata = this.props.metadata;
-
-    var imagePreview = metadata.platform === 'android'
-      ? <img alt="Run example in simulator" width="170" height="338" src="img/uiexplorer_main_android.png" />
-      : <img alt="Run example in simulator" width="170" height="356" src="img/uiexplorer_main_ios.png" />;
-
-    return (
-      <div className="embedded-simulator">
-        <p><a className="modal-button-open"><strong>Run this example</strong></a></p>
-        <div className="modal-button-open modal-button-open-img">
-          {imagePreview}
-        </div>
-        <Modal metadata={metadata} />
-      </div>
-    );
-  }
-});
-
-var Modal = React.createClass({
-  render: function() {
-    var metadata = this.props.metadata;
-    var appParams = {route: metadata.title};
-    var encodedParams = encodeURIComponent(JSON.stringify(appParams));
-    var url = metadata.platform === 'android'
-      ? `https://appetize.io/embed/q7wkvt42v6bkr0pzt1n0gmbwfr?device=nexus5&scale=65&autoplay=false&orientation=portrait&deviceColor=white&params=${encodedParams}`
-      : `https://appetize.io/embed/7vdfm9h3e6vuf4gfdm7r5rgc48?device=iphone6s&scale=60&autoplay=false&orientation=portrait&deviceColor=white&params=${encodedParams}`;
-
-    return (
-      <div>
-        <div className="modal">
-          <div className="modal-content">
-            <button className="modal-button-close">&times;</button>
-            <div className="center">
-              <iframe className="simulator" src={url} width="256" height="550" frameborder="0" scrolling="no" />
-              <p>Powered by <a target="_blank" href="https://appetize.io">appetize.io</a></p>
-            </div>
-          </div>
-        </div>
-        <div className="modal-backdrop" />
-      </div>
-    );
-  }
-});
-
 var Autodocs = React.createClass({
   childContextTypes: {
     permalink: PropTypes.string,
@@ -868,20 +819,19 @@ var Autodocs = React.createClass({
       return;
     }
 
+    let title = 'Example';
+    if (example.title) {
+      title = example.title + ' Example';
+    }
+
     return (
       <div>
-        <HeaderWithGithub
-          title={example.title || 'Examples'}
-          level={example.title ? 4 : 3}
-          path={example.path}
-          metadata={metadata}
-        />
         <div className="example-container">
-          <Prism>
-           {example.content.replace(/^[\s\S]*?\*\//, '').trim()}
-          </Prism>
-          <EmbeddedSimulator shouldRender={metadata.runnable} metadata={metadata} />
+          <SnackPlayer params={`name=${title}&platform=${example.platform}`}>{example.content.replace(/^[\s\S]*?\*\//, '').trim()}</SnackPlayer>
         </div>
+        <p className="edit-page-block">
+          You can <a target="_blank" href={'https://github.com/facebook/react-native/blob/master/' + example.path}>edit the example above on GitHub</a> and send us a pull request!
+        </p>
       </div>
     );
   },
@@ -893,7 +843,7 @@ var Autodocs = React.createClass({
 
     return (
       <div>
-        {(docs.examples.length > 1) ? <Header level={3}>Examples</Header> : null}
+        <Header level={3}>Examples</Header>
         {docs.examples.map(example => this.renderExample(example, metadata))}
       </div>
     );

--- a/website/server/extractDocs.js
+++ b/website/server/extractDocs.js
@@ -90,15 +90,13 @@ function getExamples(componentName, componentPlatform) {
   if (paths) {
     const examples = [];
     paths.map((p) => {
+      const title = p.match(/(\w+)Example\./)[1];
       const platform = p.match(/Example\.(.*)\.js$/);
-      let title = '';
-      if ((componentPlatform === CROSS_SUFFIX) && (platform !== null)) {
-        title = platform[1].toUpperCase();
-      }
       examples.push(
         {
           path: p.replace(/^\.\.\//, ''),
           title: title,
+          platform: componentPlatform === CROSS_SUFFIX ? null : componentPlatform,
           content: fs.readFileSync(p).toString(),
         }
       );


### PR DESCRIPTION
Exploring the possibility of rendering embedded Snack players for each of the examples in the API/Components docs. It works for some components such as `ViewPagerAndroid` (with warnings), but many other examples fail to load due to the expectation these will be running inside the `UIExplorer` app.

## `ViewPagerAndroid`

This example works pretty well inside the Snack Player:

<img width="1238" alt="screen shot 2017-04-24 at 1 38 22 pm" src="https://cloud.githubusercontent.com/assets/165856/25350654/d9657668-28f3-11e7-86c7-aeb101807421.png">

### Warnings

These can be solved by updating all of our examples to use imports.

<img width="624" alt="screen shot 2017-04-24 at 1 40 25 pm" src="https://cloud.githubusercontent.com/assets/165856/25350664/e49417ce-28f3-11e7-939b-4a6f8587c6d5.png">

...but we will also need to update the examples to export a class by default:

<img width="430" alt="screen shot 2017-04-24 at 1 43 26 pm" src="https://cloud.githubusercontent.com/assets/165856/25350730/13d13f08-28f4-11e7-8c88-6126c4bd4ca3.png">


## `StatusBar`

Some examples such as `StatusBarExample.js` won't load due to the way they export multiple possible examples for use in the `UIExplorer` app.

<img width="928" alt="screen shot 2017-04-24 at 1 40 10 pm" src="https://cloud.githubusercontent.com/assets/165856/25350746/222db388-28f4-11e7-80f3-26a3979975dd.png">

## `AlertIOS`

These `require()`s break the example in Snack:

<img width="938" alt="screen shot 2017-04-24 at 1 38 54 pm" src="https://cloud.githubusercontent.com/assets/165856/25350789/4370e614-28f4-11e7-8675-765704aea1a5.png">

See also export warnings.

# Next Steps

- Should we update all examples so that they both work in the `UIExplorer` app as well as in the Snack Player? Or should we decouple these examples from the `UIExplorer`?
