### PR TITLE
Suggest using babel to remove `console.*` calls

### DIFF
--- a/docs/Performance.md
+++ b/docs/Performance.md
@@ -73,6 +73,17 @@ This is unavoidable: a lot more work needs to be done at runtime to provide you 
 When running a bundled app, these statements can cause a big bottleneck in the JavaScript thread.
 This includes calls from debugging libraries such as [redux-logger](https://github.com/evgenyrodionov/redux-logger),
 so make sure to remove them before bundling.
+You can also use this [babel plugin](https://babeljs.io/docs/plugins/transform-remove-console/) that removes all the `console.*` calls. You need to install it first using `yarn add babel-plugin-transform-remove-console`, and then edit the `.babelrc` file under your project directory like this:
+```json
+{
+  "env": {
+    "production": {
+      "plugins": ["transform-remove-console"]
+    }
+  }
+}
+```
+This will automatically remove all `console.*` calls in a the release (production) versions of your project.
 
 ### `ListView` initial rendering is too slow or scroll performance is bad for large lists
 

--- a/docs/Performance.md
+++ b/docs/Performance.md
@@ -73,7 +73,7 @@ This is unavoidable: a lot more work needs to be done at runtime to provide you 
 When running a bundled app, these statements can cause a big bottleneck in the JavaScript thread.
 This includes calls from debugging libraries such as [redux-logger](https://github.com/evgenyrodionov/redux-logger),
 so make sure to remove them before bundling.
-You can also use this [babel plugin](https://babeljs.io/docs/plugins/transform-remove-console/) that removes all the `console.*` calls. You need to install it first using `yarn add babel-plugin-transform-remove-console`, and then edit the `.babelrc` file under your project directory like this:
+You can also use this [babel plugin](https://babeljs.io/docs/plugins/transform-remove-console/) that removes all the `console.*` calls. You need to install it first with `npm i babel-plugin-transform-remove-console --save`, and then edit the `.babelrc` file under your project directory like this:
 ```json
 {
   "env": {
@@ -83,7 +83,7 @@ You can also use this [babel plugin](https://babeljs.io/docs/plugins/transform-r
   }
 }
 ```
-This will automatically remove all `console.*` calls in a the release (production) versions of your project.
+This will automatically remove all `console.*` calls in the release (production) versions of your project.
 
 ### `ListView` initial rendering is too slow or scroll performance is bad for large lists
 


### PR DESCRIPTION
This PR adds a suggestion to the docs to use  the `transform-remove-console` babel plugin in production to remove `console.*` calls.
This information was previously in the docs, but was [removed](https://github.com/facebook/react-native/pull/11793/commits/e759573680c0bed8845f918f9505753317ffd34d) because the babel plugin [didn't work](https://github.com/facebook/react-native/issues/10412). 
But now it's working well, as reported [here](https://github.com/facebook/react-native/issues/10412#issuecomment-281321709), so it would be helpful to add the suggestion again.
Ideally, this would be done automatically, as I suggested in #8337