### PR TITLE
Add params Object to SwipeableListView.getNewDataSource()

### DIFF
--- a/Libraries/Experimental/SwipeableRow/SwipeableListView.js
+++ b/Libraries/Experimental/SwipeableRow/SwipeableListView.js
@@ -61,7 +61,7 @@ class SwipeableListView extends React.Component<DefaultProps, Props, State> {
   _listViewRef: ?React.Element<any> = null;
   _shouldBounceFirstRowOnMount: boolean = false;
 
-  static getNewDataSource(params: Object): Object {
+  static getNewDataSource(params: ?Object): Object {
     return new SwipeableListViewDataSource({
       getRowData: (
         params && params.getRowData

--- a/Libraries/Experimental/SwipeableRow/SwipeableListView.js
+++ b/Libraries/Experimental/SwipeableRow/SwipeableListView.js
@@ -61,12 +61,28 @@ class SwipeableListView extends React.Component<DefaultProps, Props, State> {
   _listViewRef: ?React.Element<any> = null;
   _shouldBounceFirstRowOnMount: boolean = false;
 
-  static getNewDataSource(): Object {
+  static getNewDataSource(params: Object): Object {
     return new SwipeableListViewDataSource({
-      getRowData: (data, sectionID, rowID) => data[sectionID][rowID],
-      getSectionHeaderData: (data, sectionID) => data[sectionID],
-      rowHasChanged: (row1, row2) => row1 !== row2,
-      sectionHeaderHasChanged: (s1, s2) => s1 !== s2,
+      getRowData: (
+        params && params.getRowData
+          ? params.getRowData
+          : (data, sectionID, rowID) => data[sectionID][rowID]
+      ),
+      getSectionHeaderData: (
+        params && params.getSectionHeaderData
+          ? params.getSectionHeaderData
+          : (data, sectionID) => data[sectionID]
+      ),
+      rowHasChanged: (
+        params && params.rowHasChanged
+          ? params.rowHasChanged
+          : (row1, row2) => row1 !== row2
+        ),
+      sectionHeaderHasChanged: (
+        params && params.sectionHeaderHasChanged
+          ? params.sectionHeaderHasChanged
+          : (s1, s2) => s1 !== s2
+      ),
     });
   }
 


### PR DESCRIPTION
## Motivation

This change allows custom `rowHasChanged`, `sectionHeaderHasChanged`, `getRowData` and `getSectionHeaderData` functions to the `SwipeableListViewDataSource` through the helper function `SwipeableListView.getNewDataSource()`.

The need to override at least the `rowHasChanged` function is a reasonably common (see #11533).

## Test Plan

I've noticed no Jest tests for the Experimental `SwipeableListView`, so I haven't included them in this PR.

## Comments

I assume long-term `SwipeableListView` will be updated or removed due to recent addition of `VirtualizedList`?
