### PR TITLE
Adding PushNotificationIOS finish method usage

### DIFF
--- a/Examples/UIExplorer/js/PushNotificationIOSExample.js
+++ b/Examples/UIExplorer/js/PushNotificationIOSExample.js
@@ -127,6 +127,7 @@ class NotificationExample extends React.Component {
   }
 
   _onRemoteNotification(notification) {
+    notification.finish(PushNotificationIOS.FetchResult.NewData);
     AlertIOS.alert(
       'Push Notification Received',
       'Alert message: ' + notification.getMessage(),


### PR DESCRIPTION
## Motivation (required)

What existing problem does the pull request solve?
PushNotificationIOS finish method usage in case of remote notification. It was unclear from the documentation. Found the usage from  here http://stackissue.com/facebook/react-native/remote-notification-completion-handler-8040.html

## Test Plan (required)

Tested the PushNotifcationIOSExample on device.
1. It has registered and got deviceToken.
2. DeviceToken has been sent to ProviderService.
3. ProviderService sent a push notification and the device was able to get it.

Attaching the screenshots of 
1.  alert of registered deviceToken
![img_3953](https://cloud.githubusercontent.com/assets/4823891/25423747/7e5559a6-2a6e-11e7-90fd-d203a2437a05.PNG)
2. alert of received push notifcation
![img_3952](https://cloud.githubusercontent.com/assets/4823891/25423776/8ddd36b4-2a6e-11e7-9eed-497e67cd0fcf.PNG)

