### PR TITLE
Properly handle babel ignored files, returning only the contents

### DIFF
--- a/packager/transformer.js
+++ b/packager/transformer.js
@@ -106,21 +106,31 @@ function transform(src, filename, options) {
 
   try {
     const babelConfig = buildBabelConfig(filename, options);
-    const {ast} = babel.transform(src, babelConfig);
-    const result = generate(ast, {
-      comments: false,
-      compact: false,
-      filename,
-      sourceFileName: filename,
-      sourceMaps: true,
-    }, src);
+    const {ast, ignored} = babel.transform(src, babelConfig);
 
-    return {
-      ast,
-      code: result.code,
-      filename,
-      map: options.generateSourceMaps ? result.map : result.rawMappings.map(compactMapping),
-    };
+    if (ignored) {
+      return {
+        ast: null,
+        code: src,
+        filename,
+        map: null
+      };
+    } else {
+      const result = generate(ast, {
+        comments: false,
+        compact: false,
+        filename,
+        sourceFileName: filename,
+        sourceMaps: true,
+      }, src);
+
+      return {
+        ast,
+        code: result.code,
+        filename,
+        map: options.generateSourceMaps ? result.map : result.rawMappings.map(compactMapping),
+      };
+    }
   } finally {
     process.env.BABEL_ENV = OLD_BABEL_ENV;
   }


### PR DESCRIPTION
- [x] Explain the **motivation** for making this change.
- [x] Provide a **test plan** demonstrating that the code is solid.
- [x] Match the **code formatting** of the rest of the codebase.
- [x] Target the `master` branch, NOT a "stable" branch.

## Motivation (required)

I have a need to bundle a pre-optimized external lib with my RN application. Until RN 0.42 I had been using a .babelignore to prevent the packager from trying to optimize this file and choke.

It seems in 0.42 and higher I'm no longer allowed to ignore the file.

This issue has also been reported as #12071

Details on the reasoning for this patch can be found in the issue I originally filed: https://github.com/facebook/react-native/issues/13168

What existing problem does the pull request solve?

This PR restores the functionality with babel ignoring files that existed in 0.41 before this patch:

https://github.com/facebook/react-native/commit/0849f84df26e4c56f5763375363bae90d94015fe#diff-4676ea0b3c55c65c3929aa993144f07f

## Test Plan (required)

Here's a screenshot of this patch properly ignoring the file I referenced in https://github.com/facebook/react-native/issues/13168 to be ignored.

![screen shot 2017-04-27 at 12 48 32 am](https://cloud.githubusercontent.com/assets/21967/25469653/524dbc0c-2ae3-11e7-81a6-faca2f4d21fe.png)

The patch relies on the `ignored` value of the call to `babel.transform` and if true returns the src in a object per instruction from @loganfsmyth from BabelJS core team.

To test, add a file to the `ignore` array of a `.babelrc` file in a React Native project with this fork.

I was unable to locate a test file for the transformer.js

Fixes #12071, #13168