### PR TITLE
Cleanup stale port docs

### DIFF
--- a/docs/Debugging.md
+++ b/docs/Debugging.md
@@ -63,8 +63,6 @@ To debug the JavaScript code in Chrome, select "Debug JS Remotely" from the Deve
 
 Select `Tools → Developer Tools` from the Chrome Menu to open the [Developer Tools](https://developer.chrome.com/devtools). You may also access the DevTools using keyboard shortcuts (**`Command`**`⌘` + **`Option`**`⌥` + **`I`** on Mac, **`Ctrl`** + **`Shift`** + **`I`** on Windows). You may also want to enable [Pause On Caught Exceptions](http://stackoverflow.com/questions/2233339/javascript-is-there-a-way-to-get-chrome-to-break-on-all-errors/17324511#17324511) for a better debugging experience.
 
-> It is [currently not possible](https://github.com/facebook/react-devtools/issues/229) to use the "React" tab in the Chrome Developer Tools to inspect app widgets. You can use Nuclide's "React Native Inspector" as a workaround.
-
 ### Debugging using a custom JavaScript debugger
 
 To use a custom JavaScript debugger in place of Chrome Developer Tools, set the `REACT_DEBUGGER` environment variable to a command that will start your custom debugger. You can then select "Debug JS Remotely" from the Developer Menu to start debugging.

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -10,7 +10,7 @@ These are some common issues you may run into while setting up React Native. If 
 
 ### Port already in use
 
-The React Native packager runs on port 8081. If another process is already using that port (such as McAfee Antivirus on Windows), you can either terminate that process, or change the port that the packager uses.
+The React Native packager runs on port 8081. If another process is already using that port, you can either terminate that process, or change the port that the packager uses.
 
 #### Terminating a process on port 8081
 
@@ -36,7 +36,7 @@ You can configure the packager to use a port other than 8081 by using the `port`
 $ react-native start --port=8088
 ```
 
-You will also need to update your applications to load the JavaScript bundle from the new port. Open the in-app [Developer menu](docs/debugging.html#accessing-the-in-app-developer-menu), then go to **Dev Settings** → **Debug server host for device** and replace 8081 with your port of choice.
+You will also need to update your applications to load the JavaScript bundle from the new port.
 
 ### NPM locking error
 


### PR DESCRIPTION
The option to change a port is no longer displayed in the dev menu.
We don't need to call out specific apps that use port 8081.
People can now use React DevTools to debug on Chrome.