### PR TITLE
return findNodeHandle to public api

### DIFF
--- a/Libraries/react-native/react-native-implementation.js
+++ b/Libraries/react-native/react-native-implementation.js
@@ -75,7 +75,7 @@ const ReactNative = {
   get DeviceInfo() { return require('DeviceInfo'); },
   get Dimensions() { return require('Dimensions'); },
   get Easing() { return require('Easing'); },
-  get findNodeHandle() { return require('findNodeHandle'); },
+  get findNodeHandle() { return require('ReactNative').findNodeHandle; },
   get I18nManager() { return require('I18nManager'); },
   get ImagePickerIOS() { return require('ImagePickerIOS'); },
   get InteractionManager() { return require('InteractionManager'); },

--- a/Libraries/react-native/react-native-implementation.js
+++ b/Libraries/react-native/react-native-implementation.js
@@ -75,6 +75,7 @@ const ReactNative = {
   get DeviceInfo() { return require('DeviceInfo'); },
   get Dimensions() { return require('Dimensions'); },
   get Easing() { return require('Easing'); },
+  get findNodeHandle() { return require('findNodeHandle'); },
   get I18nManager() { return require('I18nManager'); },
   get ImagePickerIOS() { return require('ImagePickerIOS'); },
   get InteractionManager() { return require('InteractionManager'); },


### PR DESCRIPTION
## Motivation (required)

findNodeHandle used in my app few times.
after https://github.com/facebook/react-native/commit/f3dbddcf2bdc0e4f49dd6f5220360b5ff383e16f it is not available.
cc @janicduplessis.
closes #13688 
proof of the publicity of the API https://facebook.github.io/react-native/docs/nativemethodsmixin.html#measurelayout