### PR TITLE
Update AppRegistry.registerComponent's parameter.

### DIFF
--- a/Libraries/ReactNative/AppRegistry.js
+++ b/Libraries/ReactNative/AppRegistry.js
@@ -109,7 +109,7 @@ const AppRegistry = {
 
   registerComponent(
     appKey: string,
-    component: ComponentProvider,
+    getComponentFunc: ComponentProvider,
     section?: boolean,
   ): string {
     runnables[appKey] = {


### PR DESCRIPTION

## Motivation

Update AppRegistry.registerComponent's second parameter name from "component" to "getComponentFunc". 
Because the second parameter is NOT a component , it is like ` () => ReactClass<any>;`. 

Using 'component' will mislead people who use this function.

- react-native 4.2 docs: [static registerComponent(appKey, getComponentFunc) ](http://facebook.github.io/react-native/releases/0.42/docs/appregistry.html#registercomponent)
- react-native 4.4 docs: [static registerComponent(appKey, component, section?) #](http://facebook.github.io/react-native/docs/appregistry.html#registercomponent)

## Test Plan 

No need to test. Update the parameter name will not mislead the people who use registerComponent.


