### PR TITLE
Fix key name required with accessing CameraRoll

### DIFF
--- a/Libraries/CameraRoll/CameraRoll.js
+++ b/Libraries/CameraRoll/CameraRoll.js
@@ -116,8 +116,8 @@ var getPhotosReturnChecker = createStrictShapeTypeChecker({
  *
  * ### Permissions
  * The user's permission is required in order to access the Camera Roll on devices running iOS 10 or later.
- * Fill out the `NSCameraUsageDescription` key in your `Info.plist` with a string that describes how your
- * app will use this data. This key will appear as `Privacy - Camera Usage Description` in Xcode.
+ * Add the `NSPhotoLibraryUsageDescription` key in your `Info.plist` with a string that describes how your
+ * app will use this data. This key will appear as `Privacy - Photo Library Usage Description` in Xcode.
  *
  */
 class CameraRoll {


### PR DESCRIPTION
- [x] Explain the **motivation** for making this change.
- [ ] ~Provide a **test plan** demonstrating that the code is solid.~
- [x] Match the **code formatting** of the rest of the codebase.
- [x] Target the `master` branch, NOT a "stable" branch.

## Motivation (required)

The key name required to access the CameraRoll in iOS is incorrect.