### PR TITLE
call onMomentumScrollEnd when we tap to status bar

### DIFF
--- a/React/Views/RCTScrollView.m
+++ b/React/Views/RCTScrollView.m
@@ -746,6 +746,12 @@ RCT_SCROLL_EVENT_HANDLER(scrollViewDidZoom, onScroll)
   RCT_FORWARD_SCROLL_EVENT(scrollViewDidEndScrollingAnimation:scrollView);
 }
 
+- (void)scrollViewDidScrollToTop:(UIScrollView *)scrollView
+{
+  RCT_SEND_SCROLL_EVENT(onMomentumScrollEnd, nil); //TODO: shouldn't this be onScrollAnimationEnd?
+  RCT_FORWARD_SCROLL_EVENT(scrollViewDidEndScrollingAnimation:scrollView);
+}
+
 - (BOOL)scrollViewShouldScrollToTop:(UIScrollView *)scrollView
 {
   for (NSObject<UIScrollViewDelegate> *scrollListener in _scrollListeners) {


### PR DESCRIPTION
## Motivation (required)

`onMomentumScrollEnd` is called when we stop scrolling manually or programmatically but doesn't when we tap status bar (behaviour specific to iOS and controlled by https://facebook.github.io/react-native/docs/scrollview.html#scrollstotop).

## Test Plan (required)

In UIExplorer add this lines
`onMomentumScrollEnd={(e) => { console.log(e.nativeEvent.contentOffset); }}`
here
https://github.com/facebook/react-native/blob/master/Examples/UIExplorer/js/ScrollViewExample.js#L51

If my explanation doesn't make sense or if you need additional information I would love to provide more information. 