### PR TITLE
React.podspec fix for RCTAnimation header issue

### DIFF
--- a/React.podspec
+++ b/React.podspec
@@ -127,6 +127,7 @@ Pod::Spec.new do |s|
   s.subspec "RCTAnimation" do |ss|
     ss.dependency             "React/Core"
     ss.source_files         = "Libraries/NativeAnimation/{Drivers/*,Nodes/*,*}.{h,m}"
+    ss.header_dir           = "RCTAnimation"
   end
 
   s.subspec "RCTCameraRoll" do |ss|


### PR DESCRIPTION
Fixes issue described #13198

Simpler, compared to #13217 

Build no longer fails on not being able to find `RCTAnimation/RCTValueAnimatedNode.h`.