### PR TITLE
Correcting a mistake in the minimal example in the FlatList doc

### DIFF
--- a/Libraries/Lists/FlatList.js
+++ b/Libraries/Lists/FlatList.js
@@ -246,7 +246,7 @@ type DefaultProps = typeof defaultProps;
  *         this.setState((state) => {
  *           // copy the map rather than modifying state.
  *           const selected = new Map(state.selected);
- *           selected.set(id, !state.get(id)); // toggle
+ *           selected.set(id, !selected.get(id)); // toggle
  *           return {selected};
  *         });
  *       };


### PR DESCRIPTION
The list items' selected state is inside the `selected` Map, not inside the `state`.

## Motivation (required)

This PR corrects a small mistake in the minimal example in the Documentatioin of the FlatList component.

## Test Plan (required)

1. Create a vanilla React Native project.
2. Create the components involved in the minimal example of FlatList.
3. Run to see if the `selected` property of the `MyListItem` changes as intended.

Currently the example has this mistake so an error will show up when running:
![2017-05-05 2 00 12](https://cloud.githubusercontent.com/assets/5442413/25735154/c091f11a-319b-11e7-9646-427c6a56f901.png)

