### PR TITLE
Update AnimatedExample.js

### DIFF
--- a/Examples/UIExplorer/js/AnimatedExample.js
+++ b/Examples/UIExplorer/js/AnimatedExample.js
@@ -48,7 +48,7 @@ exports.examples = [
       'mounts.',
     render: function() {
       class FadeInView extends React.Component {
-        _fadeAnim: AnimatedValue = new Animated.Value(0), // opacity 0
+        _fadeAnim: AnimatedValue = new Animated.Value(0); // opacity 0
 
         componentDidMount() {
           Animated.timing(     // Uses easing functions

--- a/Examples/UIExplorer/js/AnimatedExample.js
+++ b/Examples/UIExplorer/js/AnimatedExample.js
@@ -48,28 +48,22 @@ exports.examples = [
       'mounts.',
     render: function() {
       class FadeInView extends React.Component {
-        state: any;
+        _fadeAnim: AnimatedValue = new Animated.Value(0), // opacity 0
 
-        constructor(props) {
-          super(props);
-          this.state = {
-            fadeAnim: new Animated.Value(0), // opacity 0
-          };
-        }
         componentDidMount() {
-          Animated.timing(       // Uses easing functions
-            this.state.fadeAnim, // The value to drive
+          Animated.timing(     // Uses easing functions
+            this._fadeAnim,    // The value to drive
             {
-              toValue: 1,        // Target
-              duration: 2000,    // Configuration
+              toValue: 1,      // Target
+              duration: 2000,  // Configuration
             },
-          ).start();             // Don't forget start!
+          ).start();           // Don't forget start!
         }
         render() {
           return (
             <Animated.View   // Special animatable View
               style={{
-                opacity: this.state.fadeAnim,  // Binds
+                opacity: this._fadeAnim,  // Binds
               }}>
               {this.props.children}
             </Animated.View>


### PR DESCRIPTION
fix weird use of state to store "private" prop

## Motivation (required)

The provided example raises a question of why to use `state`, if the value is static.

## Test Plan (required)

Provided example should still work
