### PR TITLE
Added 'react-native start' command, which was missing

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -347,6 +347,7 @@ Use the React Native command line interface to generate a new React Native proje
 # skip this first command if you ejected from Create React Native App
 react-native init AwesomeProject
 cd AwesomeProject
+react-native start
 react-native run-ios
 ```
 
@@ -364,6 +365,7 @@ Use the React Native command line interface to generate a new React Native proje
 # skip this first command if you ejected from Create React Native App
 react-native init AwesomeProject
 cd AwesomeProject
+react-native start
 react-native run-android
 ```
 
@@ -407,6 +409,7 @@ Use the React Native command line interface to generate a new React Native proje
 # skip this first command if you ejected from Create React Native App
 react-native init AwesomeProject
 cd AwesomeProject
+react-native start
 react-native run-android
 ```
 
@@ -420,6 +423,7 @@ Use the React Native command line interface to generate a new React Native proje
 # skip this first command if you ejected from Create React Native App
 react-native init AwesomeProject
 cd AwesomeProject
+react-native start
 react-native run-android
 ```
 


### PR DESCRIPTION
Thanks for submitting a PR! Please read these instructions carefully:

- [ ] Explain the **motivation** for making this change.
- [ ] Provide a **test plan** demonstrating that the code is solid.
- [ ] Match the **code formatting** of the rest of the codebase.
- [ ] Target the `master` branch, NOT a "stable" branch.

## Motivation (required)

Getting started page located here https://facebook.github.io/react-native/docs/getting-started.html
was not enough to actually perform a 'hello world' app.

## Test Plan (required)

Perform exactly what is written in the page with a noob developer and an android emulator, and you'll see he'll get an "Error calling Appregistry.runApplication".

## Next Steps

Sign the [CLA][2], if you haven't already.

Small pull requests are much easier to review and more likely to get merged. Make sure the PR does only one thing, otherwise please split it.

Make sure all **tests pass** on both [Travis][3] and [Circle CI][4]. PRs that break tests are unlikely to be merged.

For more info, see the ["Pull Requests"][5] section of our "Contributing" guidelines.

[1]: https://medium.com/@martinkonicek/what-is-a-test-plan-8bfc840ec171#.y9lcuqqi9
[2]: https://code.facebook.com/cla
[3]: https://travis-ci.org/facebook/react-native
[4]: http://circleci.com/gh/facebook/react-native
[5]: https://github.com/facebook/react-native/blob/master/CONTRIBUTING.md#pull-requests
