### PR TITLE
Adding supported formats to Image component docs

### DIFF
--- a/Libraries/Image/Image.ios.js
+++ b/Libraries/Image/Image.ios.js
@@ -142,6 +142,9 @@ const Image = React.createClass({
      * The native side will then choose the best `uri` to display based on the
      * measured size of the image container. A `cache` property can be added to
      * control how networked request interacts with the local cache.
+     *
+     * The currently supported formats are `png`, `jpg`, `jpeg`, `bmp`, `gif`,
+     * `webp`, `psd`, `tiff`.
      */
     source: ImageSourcePropType,
     /**

--- a/Libraries/Image/Image.ios.js
+++ b/Libraries/Image/Image.ios.js
@@ -144,7 +144,7 @@ const Image = React.createClass({
      * control how networked request interacts with the local cache.
      *
      * The currently supported formats are `png`, `jpg`, `jpeg`, `bmp`, `gif`,
-     * `webp`, `psd`, `tiff`.
+     * `webp` (Android only), `psd` (iOS only).
      */
     source: ImageSourcePropType,
     /**


### PR DESCRIPTION
## Motivation

The lack of very clear docs on supported image formats is causing unnecessary issues (#13806).
This should mitigate and keep the issue list cleaner.


## Test Plan

Its only a documentation change. No code changes made.
