### PR TITLE
replace lineBreakMode with ellipsizeMode

### DIFF
--- a/RNTester/js/TextExample.ios.js
+++ b/RNTester/js/TextExample.ios.js
@@ -106,7 +106,7 @@ var AdjustingFontSize = React.createClass({
     }
     return (
       <View>
-        <Text lineBreakMode="tail" numberOfLines={1} style={{fontSize: 36, marginVertical:6}}>
+        <Text ellipsizeMode="tail" numberOfLines={1} style={{fontSize: 36, marginVertical:6}}>
           Truncated text is baaaaad.
         </Text>
         <Text numberOfLines={1} adjustsFontSizeToFit={true} style={{fontSize: 40, marginVertical:6}}>

--- a/RNTester/js/TextExample.ios.js
+++ b/RNTester/js/TextExample.ios.js
@@ -106,7 +106,7 @@ var AdjustingFontSize = React.createClass({
     }
     return (
       <View>
-        <Text ellipsizeMode="tail" numberOfLines={1} style={{fontSize: 36, marginVertical:6}}>
+        <Text ellipsizeMode="tail" numberOfLines={1} style={{fontSize: 36, marginVertical: 6}}>
           Truncated text is baaaaad.
         </Text>
         <Text numberOfLines={1} adjustsFontSizeToFit={true} style={{fontSize: 40, marginVertical:6}}>


### PR DESCRIPTION
lineBreakMode is a non-existing property (or maybe legacy?)

While reading the docs I encountered this prop being used in the example, but it doesn't exist in the codebase anymore.