### PR TITLE
Added ability to specify an alternative port for the run-android command

### DIFF
--- a/local-cli/server/middleware/statusPageMiddleware.js
+++ b/local-cli/server/middleware/statusPageMiddleware.js
@@ -10,7 +10,7 @@
 
 /**
  * Status page so that anyone who needs to can verify that the packager is
- * running on 8081 and not another program / service.
+ * running on the expected port (defaults to 8081) and not another program / service.
  */
 module.exports = function(req, res, next) {
   if (req.url === '/status') {

--- a/local-cli/util/isPackagerRunning.js
+++ b/local-cli/util/isPackagerRunning.js
@@ -19,8 +19,8 @@ const fetch = require('node-fetch');
  *   - `unrecognized`: one other process is running on the port we expect the
  *                     packager to be running.
  */
-function isPackagerRunning() {
-  return fetch('http://localhost:8081/status').then(
+function isPackagerRunning(port = 8081) {
+  return fetch(`http://localhost:${port}/status`).then(
     res => res.text().then(body =>
       body === 'packager-status:running' ? 'running' : 'unrecognized'
     ),

--- a/packager/launchPackager.bat
+++ b/packager/launchPackager.bat
@@ -7,6 +7,12 @@
 
 @echo off
 title React Packager
+if "%PACKAGER_PORT%" == "" goto NOPORT
+:YESPORT
+node "%~dp0..\local-cli\cli.js" start --port "%PACKAGER_PORT%"
+goto DONE
+:NOPORT
 node "%~dp0..\local-cli\cli.js" start
+:DONE
 pause
 exit

--- a/packager/launchPackager.command
+++ b/packager/launchPackager.command
@@ -13,7 +13,7 @@ clear
 
 THIS_DIR=$(dirname "$0")
 pushd "$THIS_DIR"
-source ./packager.sh
+source ./packager.sh --port $PACKAGER_PORT
 popd
 
 echo "Process terminated. Press <enter> to close the window"


### PR DESCRIPTION
… to allow simultaneous iOS / Android hot reload connections via separate packager instances.

## Motivation (required)
When attempting to use Hot Reloading on an iOS and Android device at the same time (with the packager instance), it switches between them as you interact with the devices rather than working with both.  To resolve this, each device needs to be pointed to a separate packager instance.  The current hardcoding of port 8081 makes this difficult.  This pull request introduces a new "--port" option for the run-android command.

## Test Plan (required)
I need help here.  From what I can tell, my change is sane and is correctly propagating the port to every level.  I'm doing an adb reverse from 8081 to the specified port in order to allow the hardcoded 8081 in the native device constants to continue working.

However, I think I have something misconfigured in my environment for building React Native for Android as I am getting a javascript error in my app on master even prior to my change, and it's also looking for the bundle in the wrong location.  I don't know if I'm just experiencing a problem introduced on master, or if it's me.  🤷‍♂️ 

## Next Steps

I've signed the CLA, and I'm hoping someone can help review this change or guide me in what I've screwed up in my build environment.