### PR TITLE
Refactor product name for runIOS, enable multi-line

### DIFF
--- a/local-cli/runIOS/__tests__/runIOS-test.js
+++ b/local-cli/runIOS/__tests__/runIOS-test.js
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+'use strict';
+
+jest.dontMock('../runIOS');
+
+const { getProductName } = require('../runIOS');
+
+describe('runIOS', () => {
+  it('Should get product name, single line', () => {
+    expect(getProductName('export FULL_PRODUCT_NAME="Super App Dev.app"'))
+      .toEqual('Super App Dev');
+  });
+
+  it('Should get product name, multi line', () => {
+    expect(getProductName('export FRAMEWORK_VERSION=A\nexport FULL_PRODUCT_NAME="Super App Dev.app"\nexport GCC3_VERSION=3.3'))
+      .toEqual('Super App Dev');
+  });
+
+  it('Should get the first product name if there are multiple', () => {
+    expect(getProductName('export FULL_PRODUCT_NAME="Super App Dev.app"\nexport FULL_PRODUCT_NAME="Super App Dev2.app"'))
+      .toEqual('Super App Dev');
+  });
+
+  it('Should get product name and skip app extensions (.appex)', () => {
+    expect(getProductName('export FULL_PRODUCT_NAME="Evil App Dev.appex"\nexport FULL_PRODUCT_NAME="Super App Dev.app"\nexport FULL_PRODUCT_NAME="Evil App Dev2.appex"'))
+      .toEqual('Super App Dev');
+  });
+
+  it('Should return null if no product name', () => {
+    expect(getProductName('export FRAMEWORK_VERSION=A\nexport FULL_PRODUCT_NAME="Super App Dev"\nexport GCC3_VERSION=3.3'))
+      .toEqual(null);
+  });
+});

--- a/local-cli/runIOS/runIOS.js
+++ b/local-cli/runIOS/runIOS.js
@@ -156,14 +156,23 @@ function buildProject(xcodeProject, udid, scheme, configuration = 'Debug', launc
       console.error(data.toString());
     });
     buildProcess.on('close', function(code) {
-      //FULL_PRODUCT_NAME is the actual file name of the app, which actually comes from the Product Name in the build config, which does not necessary match a scheme name,  example output line: export FULL_PRODUCT_NAME="Super App Dev.app"
-      let productNameMatch = /export FULL_PRODUCT_NAME="?(.+).app"?$/.exec(buildOutput);
-      if (productNameMatch && productNameMatch.length && productNameMatch.length > 1) {
-        return resolve(productNameMatch[1]);//0 is the full match, 1 is the app name
+      let productName = getProductName(buildOutput);
+      if (productName) {
+        return resolve(productName);
       }
       return buildProcess.error? reject(error) : resolve();
     });
   });
+}
+
+function getProductName(buildOutput) {
+  //FULL_PRODUCT_NAME is the actual file name of the app, which actually comes from the Product Name in the build config, which does not necessary match a scheme name,  example output line: export FULL_PRODUCT_NAME="Super App Dev.app"
+  let productNameMatch = /export FULL_PRODUCT_NAME="?(.+).app"?$/m.exec(buildOutput);
+  if (productNameMatch && productNameMatch.length && productNameMatch.length > 1) {
+    return productNameMatch[1]; //0 is the full match, 1 is the app name
+  }
+
+  return null;
 }
 
 function matchingDevice(devices, deviceName) {
@@ -250,4 +259,5 @@ module.exports = {
     command: '--no-packager',
     description: 'Do not launch packager while building',
   }],
+  getProductName
 };


### PR DESCRIPTION
Updated `FULL_PRODUCT_NAME` regex to match across multiple lines, which
is the case for iOS build output. Includes refactor to export
getProductName for unit testing.

## Motivation (required)

Fixes an issue introduced in https://github.com/facebook/react-native/pull/13001
where custom app names may no longer found in the iOS build output due to
change in regex, depending on `FULL_PRODUCT_NAME` print in build output.

What existing problem does the pull request solve?

## Test Plan (required)

Manually ran:

```
react-native run-ios
```

Before change:

```
** BUILD SUCCEEDED **


Installing build/Build/Products/Debug-iphonesimulator/Test.app
An error was encountered processing the command (domain=NSPOSIXErrorDomain, code=2):
Failed to install the requested application
An application bundle was not found at the provided path.
Provide a valid path to the desired application bundle.
Print: Entry, ":CFBundleIdentifier", Does Not Exist

Command failed: /usr/libexec/PlistBuddy -c Print:CFBundleIdentifier build/Build/Products/Debug-iphonesimulator/Test.app/Info.plist
Print: Entry, ":CFBundleIdentifier", Does Not Exist
```

After change:

```
** BUILD SUCCEEDED **


Installing build/Build/Products/Debug-iphonesimulator/Test Dev.app
Launching com.test.dev-ent
com.test.dev-ent: 25738
```

Additionally, added unit tests to exhaust case where:
1) .app is provided, single line
2) .app is provided, multi-line
3) .appex and .app are provided (reason #13001 was pushed)
4) Multiple .app's are provided
5) No .app is provided