### PR TITLE
Fix/fix issue #5944

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
@@ -130,13 +130,28 @@ public class ReactRootView extends SizeMonitoringFrameLayout implements RootView
 
   @Override
   public boolean onInterceptTouchEvent(MotionEvent ev) {
-    dispatchJSTouchEvent(ev);
+    try {
+      dispatchJSTouchEvent(ev);
+    } catch (RuntimeException e) {
+      FLog.w(
+        ReactConstants.TAG,
+        "Unable to dispatch JSTouch Event from native event" + ev.toString()
+      );
+    }
+
     return super.onInterceptTouchEvent(ev);
   }
 
   @Override
   public boolean onTouchEvent(MotionEvent ev) {
-    dispatchJSTouchEvent(ev);
+    try {
+      dispatchJSTouchEvent(ev);
+    } catch (RuntimeException e) {
+      FLog.w(
+        ReactConstants.TAG,
+        "Unable to dispatch JSTouch Event from native event" + ev.toString()
+      );
+    }
     super.onTouchEvent(ev);
     // In case when there is no children interested in handling touch event, we return true from
     // the root view in order to receive subsequent events related to that gesture

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/TouchEventCoalescingKeyHelper.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/TouchEventCoalescingKeyHelper.java
@@ -11,6 +11,9 @@ package com.facebook.react.uimanager.events;
 
 import android.util.SparseIntArray;
 
+import com.facebook.common.logging.FLog;
+import com.facebook.react.common.ReactConstants;
+
 /**
  * Utility for determining coalescing keys for TouchEvents. To preserve proper ordering of events,
  * move events should only be coalesced if there has been no up/down event between them (this
@@ -61,7 +64,9 @@ public class TouchEventCoalescingKeyHelper {
   public void incrementCoalescingKey(long downTime) {
     int currentValue = mDownTimeToCoalescingKey.get((int) downTime, -1);
     if (currentValue == -1) {
-      throw new RuntimeException("Tried to increment non-existent cookie");
+      FLog.w(
+        ReactConstants.TAG,
+        "Unable to coalesce touch event; Tried to increment non-existent cookie");
     }
     mDownTimeToCoalescingKey.put((int) downTime, currentValue + 1);
   }
@@ -72,7 +77,9 @@ public class TouchEventCoalescingKeyHelper {
   public short getCoalescingKey(long downTime) {
     int currentValue = mDownTimeToCoalescingKey.get((int) downTime, -1);
     if (currentValue == -1) {
-      throw new RuntimeException("Tried to get non-existent cookie");
+      FLog.w(
+        ReactConstants.TAG,
+        "Unable to coalesce touch event; Tried to increment non-existent cookie");
     }
     return ((short) (0xffff & currentValue));
   }


### PR DESCRIPTION
## Motivation

#5944 has been the number one crash on Bugsnag for several of our production apps.

In Development, this crash is easily reproducible by just clicking around and others have noted that this is caused by a bug in the underlying event system in Android. Considering we do not control the version of Android our apps run on, I propose this change to prevent this issue from crashing the app but instead catching any exceptions thrown by the `dispatchJSTouchEvent`.

If this approach could cause issues I don't foresee now, let me know. I would love to collaborate on the solution that solves it in a better way.

## Test Plan (required)

Tested this against several of our apps on [0.42.2+fix](https://github.com/immidi/react-native/tree/fix/0.42.2-with-fix).
The issue was no longer causing crashes and I did not notice any other harmful side effects.

Also using the command mentioned in this [comment](https://github.com/facebook/react-native/issues/5944#issuecomment-233076292) `adb shell input swipe 360 948 30 236 89` does not cause crashes anymore, but instead prints a warning `unknown:React: Unable to coalesce touch event; Tried to increment non-existent cookie`.

