### PR TITLE
Work around a false positive warning

### DIFF
--- a/Libraries/Renderer/src/renderers/native/NativeMethodsMixinUtils.js
+++ b/Libraries/Renderer/src/renderers/native/NativeMethodsMixinUtils.js
@@ -57,11 +57,23 @@ export interface NativeMethodsInterface {
  */
 function mountSafeCallback(context: any, callback: ?Function): any {
   return function() {
-    if (
-      !callback ||
-      (typeof context.isMounted === 'function' && !context.isMounted())
-    ) {
+    if (!callback) {
       return undefined;
+    }
+    if (typeof context.__isMounted === 'boolean') {
+      // TODO(gaearon): this is gross and should be removed.
+      // It is currently necessary because View uses createClass,
+      // and so any measure() calls on View (which are done by React
+      // DevTools) trigger the isMounted() deprecation warning.
+      if (!context.__isMounted) {
+        return undefined;
+      }
+      // The else branch is important so that we don't
+      // trigger the deprecation warning by calling isMounted.
+    } else if (typeof context.isMounted === 'function') {
+      if (!context.isMounted()) {
+        return undefined;
+      }
     }
     return callback.apply(context, arguments);
   };


### PR DESCRIPTION
This works around a false positive `isMounted()` deprecation warning when using latest React DevTools and selecting components in the hierarchy.

Before:

![screen shot 2017-05-09 at 7 03 39 pm 1](https://cloud.githubusercontent.com/assets/810438/25865249/3a5cc9e2-34ea-11e7-9930-6d0d8436b390.png)


After:

![screen shot 2017-05-09 at 7 02 54 pm](https://cloud.githubusercontent.com/assets/810438/25865274/4d2d573a-34ea-11e7-8bdd-807e32c54594.png)

Test plan: careful inspection.

This hack will have to go anyway because we need to migrate `View` from `createClass` at which point we can delete this.