### PR TITLE
Fixed new line and prioritise blurOnSubmit in multiline text input

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
@@ -725,11 +725,13 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
         new TextView.OnEditorActionListener() {
           @Override
           public boolean onEditorAction(TextView v, int actionId, KeyEvent keyEvent) {
-            // Any 'Enter' action will do, except next and previous
-            if (((actionId & EditorInfo.IME_MASK_ACTION) > 0 &&
-                actionId != EditorInfo.IME_ACTION_NEXT &&
-                actionId != EditorInfo.IME_ACTION_PREVIOUS) ||
-                actionId == EditorInfo.IME_NULL) {
+            boolean isAnyEnterActionOtherThanNextOrPrevious = (
+              (actionId & EditorInfo.IME_MASK_ACTION) > 0 &&
+              actionId != EditorInfo.IME_ACTION_NEXT &&
+              actionId != EditorInfo.IME_ACTION_PREVIOUS
+            ) || actionId == EditorInfo.IME_NULL;
+
+            if (isAnyEnterActionOtherThanNextOrPrevious) {
               boolean blurOnSubmit = editText.getBlurOnSubmit();
               boolean isMultiline = ((editText.getInputType() &
                 InputType.TYPE_TEXT_FLAG_MULTI_LINE) != 0);

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
@@ -725,7 +725,7 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
         new TextView.OnEditorActionListener() {
           @Override
           public boolean onEditorAction(TextView v, int actionId, KeyEvent keyEvent) {
-            // Any 'Enter' action will do
+            // Any 'Enter' action will do, except next and previous
             if (((actionId & EditorInfo.IME_MASK_ACTION) > 0 &&
                 actionId != EditorInfo.IME_ACTION_NEXT &&
                 actionId != EditorInfo.IME_ACTION_PREVIOUS) ||
@@ -749,7 +749,7 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
               } else {
                 returnValue = !isMultiline;
               }
-              
+
               if (shouldDispatchSubmitEvent) {
                 EventDispatcher eventDispatcher =
                     reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher();
@@ -758,11 +758,11 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
                         editText.getId(),
                         editText.getText().toString()));
               }
-              
+
               if (shouldClearFocus) {
                 editText.clearFocus();
               }
-              
+
               return returnValue;
             }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
@@ -734,6 +734,11 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
                   new ReactTextInputSubmitEditingEvent(
                       editText.getId(),
                       editText.getText().toString()));
+              // if blurOnSubmit is false, and isMultiline, go to new line
+              // if blurOnSubmit is true, prioritise blur
+              if (!editText.getBlurOnSubmit() && (editText.getInputType() & InputType.TYPE_TEXT_FLAG_MULTI_LINE) != 0) {
+                return false;
+              }
             }
 
             if (editText.getBlurOnSubmit()) {

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
@@ -726,7 +726,9 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
           @Override
           public boolean onEditorAction(TextView v, int actionId, KeyEvent keyEvent) {
             // Any 'Enter' action will do
-            if ((actionId & EditorInfo.IME_MASK_ACTION) > 0 ||
+            if (((actionId & EditorInfo.IME_MASK_ACTION) > 0 &&
+                actionId != EditorInfo.IME_ACTION_NEXT &&
+                actionId != EditorInfo.IME_ACTION_PREVIOUS) ||
                 actionId == EditorInfo.IME_NULL) {
               boolean blurOnSubmit = editText.getBlurOnSubmit();
               boolean isMultiline = ((editText.getInputType() &

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
@@ -735,21 +735,19 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
               boolean shouldClearFocus = false;
               boolean returnValue = false;
 
-              // blurOnSubmit && isMultiline => generate submit event; blur; return true;
-              // !blurOnSubmit && isMultiline => return false; (Perform default behaviour.)
-              // blurOnSubmit && !isMultiline => generate submit event; blur; return true;
-              // !blurOnSubmit && !isMultiline => return true; (Shallow <Enter>.)
+              // Motivation:
+              // * blurOnSubmit && isMultiline => Generate `submit` event; clear focus; prevent default behaviour (return true);
+              // * blurOnSubmit && !isMultiline => Generate `submit` event; clear focus; prevent default behaviour (return true);
+              // * !blurOnSubmit && isMultiline => Perform default behaviour (return false);
+              // * !blurOnSubmit && !isMultiline => Prevent default behaviour (return true).
               if (blurOnSubmit) {
                 shouldClearFocus = true;
                 shouldDispatchSubmitEvent = true;
                 returnValue = true;
               } else {
-                if (isMultiline) {
-                  returnValue = false;
-                } else {
-                  returnValue = true;
-                }
+                returnValue = !isMultiline;
               }
+              
               if (shouldDispatchSubmitEvent) {
                 EventDispatcher eventDispatcher =
                     reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher();
@@ -758,14 +756,12 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
                         editText.getId(),
                         editText.getText().toString()));
               }
+              
               if (shouldClearFocus) {
                 editText.clearFocus();
               }
+              
               return returnValue;
-            }
-
-            if (editText.getBlurOnSubmit()) {
-              editText.clearFocus();
             }
 
             return true;


### PR DESCRIPTION
## Motivation (required)

What existing problem does the pull request solve?
this fixes #13506 and #12717 where:
- there are some issues when pressing enter with some keyboard
- blurOnSubmit is not working with multiline

I think this should be in stable branch as this is pretty critical, isn't it?

## Test Plan (required)

- just create a TextInput with multiline and press enter with samsung keyboard
before, it won't create a new line, now it will.

- just create a TextInput with multiline and blurOnSubmit true and press enter
before, it won't blur, and wont create a new line (on some keyboard, it will create a new line), now it will blur only