### PR TITLE
Fix Babel environment check in the preset

### DIFF
--- a/babel-preset/configs/main.js
+++ b/babel-preset/configs/main.js
@@ -10,7 +10,7 @@
 
 var resolvePlugins = require('../lib/resolvePlugins');
 
-module.exports = {
+var preset = {
   comments: false,
   compact: true,
   plugins: resolvePlugins([
@@ -40,11 +40,13 @@ module.exports = {
     ['transform-es2015-for-of', { loose: true }],
     require('../transforms/transform-symbol-member'),
   ]),
-  env: {
-    development: {
-      plugins: resolvePlugins(['transform-react-jsx-source']),
-    },
-  },
   retainLines: true,
   sourceMaps: false,
 };
+
+var env = process.env.BABEL_ENV || process.env.NODE_ENV;
+if (!env || env === 'development') {
+  preset.plugins.push(resolvePlugins(['transform-react-jsx-source']));
+}
+
+module.exports = preset;


### PR DESCRIPTION
Note: I have not tested it yet.

The `env` option has been broken in Babel for a while (https://github.com/babel/babel/issues/4539), and will be deprecated (https://github.com/babel/babel/issues/5276).

I am changing this code to the way Babel < 6.10 interpreted the `env` option. This should fix the `__source` JSX transform which was applied in DEV in the past, but stopped getting applied because of the Babel bug.