### PR TITLE
Add RCTRenderingPerf to performance docs

### DIFF
--- a/docs/Performance.md
+++ b/docs/Performance.md
@@ -168,7 +168,21 @@ Access it by selecting Perf Monitor from the Debug menu.
 
 For iOS, Instruments is an invaluable tool, and on Android you should learn to use [`systrace`](docs/performance.html#profiling-android-ui-performance-with-systrace).
 
-You can also use [`react-addons-perf`](https://facebook.github.io/react/docs/perf.html) to get insights into where React is spending time when rendering your components.
+You can also use `RCTRenderingPerf.js` to get insights into where React is spending time when rendering your components. Its behaviour is similar to that of react's [`react-addons-perf`](https://facebook.github.io/react/docs/perf.html)
+
+```js
+import PerfMonitor from 'react-native/Libraries/Performance/RCTRenderingPerf';
+
+componentDidMount() {
+
+  PerfMonitor.toggle();
+  PerfMonitor.start();
+  setTimeout(() => {
+      PerfMonitor.stop();
+  },5000);
+
+}
+```
 
 Another way to profile JavaScript is to use the Chrome profiler while debugging.
 This won't give you accurate results as the code is running in Chrome but will give you a general idea of where bottlenecks might be.

--- a/docs/Performance.md
+++ b/docs/Performance.md
@@ -168,7 +168,7 @@ Access it by selecting Perf Monitor from the Debug menu.
 
 For iOS, Instruments is an invaluable tool, and on Android you should learn to use [`systrace`](docs/performance.html#profiling-android-ui-performance-with-systrace).
 
-You can also use `RCTRenderingPerf.js` to get insights into where React is spending time when rendering your components. Its behaviour is similar to that of react's [`react-addons-perf`](https://facebook.github.io/react/docs/perf.html)
+You can also use `RCTRenderingPerf.js` to get insights into where React is spending time when rendering your components. Its behaviour is similar to that of react's [`react-addons-perf`](https://facebook.github.io/react/docs/perf.html):
 
 ```js
 import PerfMonitor from 'react-native/Libraries/Performance/RCTRenderingPerf';
@@ -178,8 +178,8 @@ componentDidMount() {
   PerfMonitor.toggle();
   PerfMonitor.start();
   setTimeout(() => {
-      PerfMonitor.stop();
-  },5000);
+    PerfMonitor.stop();
+  }, 5000);
 
 }
 ```


### PR DESCRIPTION
Issue https://github.com/facebook/react-native/issues/12163 shows the docs on profiling are not up to date. Here's a quick fix to at least have something in the docs that works for the latest version of React Native. 

Feel free to change / close this PR as long as the issue is addressed.