### PR TITLE
Add missing semicolon in NativeModulesIOS.md

### DIFF
--- a/docs/NativeModulesIOS.md
+++ b/docs/NativeModulesIOS.md
@@ -329,7 +329,7 @@ You can then define methods and export your enum constants like this:
 {
   return @{ @"statusBarAnimationNone" : @(UIStatusBarAnimationNone),
             @"statusBarAnimationFade" : @(UIStatusBarAnimationFade),
-            @"statusBarAnimationSlide" : @(UIStatusBarAnimationSlide) }
+            @"statusBarAnimationSlide" : @(UIStatusBarAnimationSlide) };
 };
 
 RCT_EXPORT_METHOD(updateStatusBarAnimation:(UIStatusBarAnimation)animation


### PR DESCRIPTION
## Motivation (required)

` ConstantsconstantsToExport` in` EnumConstants` has an error. It is a missing a closing curly braces after `return`.

## Test Plan (required)

Do not need a test.