### PR TITLE
Ship third-party-podspecs in the npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,8 @@
     "React",
     "ReactAndroid",
     "ReactCommon",
-    "README.md"
+    "README.md",
+    "third-party-podspecs"
   ],
   "scripts": {
     "test": "jest",


### PR DESCRIPTION
Hi,

Today I upgraded from RN 0.44 to 0.45.0-rc.0 and noticed I add to include either `CxxBridge` or `BatchedBridge` in the React subspecs in my Podfile to get my project to compile again (https://github.com/facebook/react-native/issues/13010).

Adding `BatchedBridge` works fine. However I wanted to try `CxxBridge` as described in https://github.com/facebook/react-native/commit/5aca739cc25949eebc04a0309c2944f92b5b5391 but couldn't do it since the required `third-party-podspecs` folder with `Folly.podspec`, `GLog.podspec` and `DoubleConversion.podspec` hadn't been included in the npm release.

So here is the fix for that.
It should be included in the next 0.45.0-rc release.

Let me know what you think.