### PR TITLE
Update docs about supported native animation props

### DIFF
--- a/docs/Animations.md
+++ b/docs/Animations.md
@@ -356,7 +356,7 @@ You can also take a look at the [source code](https://github.com/facebook/react-
 
 Not everything you can do with `Animated` is currently supported by the native driver.
 The main limitation is that you can only animate non-layout properties:
-things like `transform`, `opacity` and `backgroundColor` will work, but flexbox and position properties will not.
+things like `transform` and `opacity` will work, but flexbox and position properties will not.
 When using `Animated.event`, it will only work with direct events and not bubbling events.
 This means it does not work with `PanResponder` but does work with things like `ScrollView#onScroll`.
 


### PR DESCRIPTION

Thanks for submitting a PR! Please read these instructions carefully:

- [x] Explain the **motivation** for making this change.
- [x] Provide a **test plan** demonstrating that the code is solid.
- [x] Match the **code formatting** of the rest of the codebase.
- [x] Target the `master` branch, NOT a "stable" branch.

## Motivation (required)

The docs had `backgroundColor` listed as a supported style prop for
native animation, but only `opacity` and `transform` are supported
at this time. See https://github.com/facebook/react-native/blob/master/Libraries/Animated/src/NativeAnimatedHelper.js#L108
My motivation was that I tried to use it and it didn't work. :smile: 

## Test Plan (required)

Github appears to render the change correctly.