### PR TITLE
updated docs with iOS 10 compatible linking code

### DIFF
--- a/Libraries/Linking/Linking.js
+++ b/Libraries/Linking/Linking.js
@@ -66,15 +66,13 @@ const LinkingManager = Platform.OS === 'android' ?
  *   android:launchMode="singleTask">
  * ```
  *
- * NOTE: On iOS you'll need to link `RCTLinking` to your project by following
+ * NOTE: On iOS, you'll need to link `RCTLinking` to your project by following
  * the steps described [here](docs/linking-libraries-ios.html#manual-linking).
- * In case you also want to listen to incoming app links during your app's
- * execution you'll need to add the following lines to your `*AppDelegate.m`:
+ * If you also want to listen to incoming app links during your app's
+ * execution, you'll need to add the following lines to your `*AppDelegate.m`:
  *
- * NOTE: openURL Deprecated in iOS10.
- *
- * IOS 10:
  * ```
+ * // iOS 10
  * #import <React/RCTLinkingManager.h>
  * - (BOOL)application:(UIApplication *)application
  *    openURL:(NSURL *)url
@@ -87,8 +85,11 @@ const LinkingManager = Platform.OS === 'android' ?
  *
  * }
  * ```
- * IOS 9 and older:
+ * 
+ * If you're targeting iOS 9 or older, you can use the following code instead:
+ *
  * ```
+ * // iOS 9 or older
  * #import <React/RCTLinkingManager.h>
  *
  * - (BOOL)application:(UIApplication *)application openURL:(NSURL *)url
@@ -98,9 +99,11 @@ const LinkingManager = Platform.OS === 'android' ?
  *          sourceApplication:sourceApplication annotation:annotation];
  * }
  * ```
- * Universal Links:
+ * 
+ * If your app is using [Universal Links](https://developer.apple.com/library/prerelease/ios/documentation/General/Conceptual/AppSearch/UniversalLinks.html),
+ * you'll need to add the following code as well:
+ * 
  * ```
- * // Only if your app is using [Universal Links](https://developer.apple.com/library/prerelease/ios/documentation/General/Conceptual/AppSearch/UniversalLinks.html).
  * - (BOOL)application:(UIApplication *)application continueUserActivity:(NSUserActivity *)userActivity
  *  restorationHandler:(void (^)(NSArray * _Nullable))restorationHandler
  * {

--- a/Libraries/Linking/Linking.js
+++ b/Libraries/Linking/Linking.js
@@ -71,6 +71,23 @@ const LinkingManager = Platform.OS === 'android' ?
  * In case you also want to listen to incoming app links during your app's
  * execution you'll need to add the following lines to your `*AppDelegate.m`:
  *
+ * NOTE: openURL Deprecated in iOS10.
+ *
+ * IOS 10:
+ * ```
+ * #import <React/RCTLinkingManager.h>
+ * - (BOOL)application:(UIApplication *)application
+ *    openURL:(NSURL *)url
+ *    options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options
+ * {
+ *
+ *  return [RCTLinkingManager application:application openURL:url
+ *  sourceApplication:options[UIApplicationOpenURLOptionsSourceApplicationKey]
+ *             annotation:options[UIApplicationOpenURLOptionsAnnotationKey]];
+ *
+ * }
+ * ```
+ * IOS 9 and older:
  * ```
  * #import <React/RCTLinkingManager.h>
  *
@@ -78,9 +95,11 @@ const LinkingManager = Platform.OS === 'android' ?
  *   sourceApplication:(NSString *)sourceApplication annotation:(id)annotation
  * {
  *   return [RCTLinkingManager application:application openURL:url
- *                       sourceApplication:sourceApplication annotation:annotation];
+ *          sourceApplication:sourceApplication annotation:annotation];
  * }
- *
+ * ```
+ * Universal Links:
+ * ```
  * // Only if your app is using [Universal Links](https://developer.apple.com/library/prerelease/ios/documentation/General/Conceptual/AppSearch/UniversalLinks.html).
  * - (BOOL)application:(UIApplication *)application continueUserActivity:(NSUserActivity *)userActivity
  *  restorationHandler:(void (^)(NSArray * _Nullable))restorationHandler


### PR DESCRIPTION
Thanks for submitting a PR! Please read these instructions carefully:

- [x] Explain the **motivation** for making this change.
- [x] Provide a **test plan** demonstrating that the code is solid.
- [x] Match the **code formatting** of the rest of the codebase.
- [x] Target the `master` branch, NOT a "stable" branch.

## Motivation (required)

The current code for IOS contains deprecated code for incoming urls.
in iOS 10 deprecated openURL. 
more details here: https://useyourloaf.com/blog/openurl-deprecated-in-ios10/

## Test Plan (required)

1. Create an RN app with iOS 10. set up linking as per instructions. 

2. Using the iOS9 code snippet, with the app is open, navigate to the apps url scheme (in safari)  appname://value1/value2, the eventListener will not trigger.  note: it will however trigger getInitialURL if app is closed. 

3. Replace the old iOS9 code with the iOS 10 and trigger an incoming url from a browser appname://
with the new code in the doc it will trigger for both open and closed apps.
