### PR TITLE
Change packager project root path so RNTester can start

### DIFF
--- a/packager/launchPackager.command
+++ b/packager/launchPackager.command
@@ -12,8 +12,8 @@ echo -en "\033]0;React Packager\a"
 clear
 
 THIS_DIR=$(dirname "$0")
-pushd "$THIS_DIR"
-source ./packager.sh
+pushd "$THIS_DIR/.."
+source packager/packager.sh
 popd
 
 echo "Process terminated. Press <enter> to close the window"


### PR DESCRIPTION
A quick fix to ensure RNTest works. This PR changes the process root for where packager is run, resulting in the right `cwd` directory path when RN launches RNTester.