### PR TITLE
Add missing license to UnimplementedView.js

### DIFF
--- a/Libraries/Components/UnimplementedViews/UnimplementedView.js
+++ b/Libraries/Components/UnimplementedViews/UnimplementedView.js
@@ -9,7 +9,6 @@
  * @providesModule UnimplementedView
  * @flow
  */
-
 'use strict';
 
 var React = require('React');

--- a/Libraries/Components/UnimplementedViews/UnimplementedView.js
+++ b/Libraries/Components/UnimplementedViews/UnimplementedView.js
@@ -1,8 +1,13 @@
 /**
- * Common implementation for a simple stubbed view. Simply applies the view's styles to the inner
- * View component and renders its children.
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
  *
  * @providesModule UnimplementedView
+ * @flow
  */
 
 'use strict';
@@ -10,6 +15,10 @@
 var React = require('React');
 var StyleSheet = require('StyleSheet');
 
+/**
+ * Common implementation for a simple stubbed view. Simply applies the view's styles to the inner
+ * View component and renders its children.
+ */
 class UnimplementedView extends React.Component {
   setNativeProps = () => {
     // Do nothing.


### PR DESCRIPTION
Added a missing license header to UnimplementedView.js

## Test Plan
No code logic got changed, just added a comment. So the regular CircleCI tests should be fine.