### PR TITLE
[Docs] Provide example of android side implementation of HeadlessJS

### DIFF
--- a/docs/HeadlessJSAndroid.md
+++ b/docs/HeadlessJSAndroid.md
@@ -58,6 +58,10 @@ Now, whenever you [start your service][0], e.g. as a periodic task or in respons
 * If you start your service from a `BroadcastReceiver`, make sure to call `HeadlessJsTaskService.acquireWakelockNow()` before returning from `onReceive()`.
 
 ## Example Usage
+
+Service can be started from Java API. First you need to decide when the service should be started and implement your solution accordingly. Here is a simple example that reacts to network connection change.
+
+Following lines shows part of Android manifest file for registering broadcast receiver.   
 ```xml
 <receiver android:name=".NetworkChangeReceiver" >
   <intent-filter>
@@ -65,6 +69,8 @@ Now, whenever you [start your service][0], e.g. as a periodic task or in respons
   </intent-filter>
 </receiver>
 ```
+
+Broadcast receiver then handles intent that was broadcasted in onReceive function. This is a great place to check whether your app is on foreground or not. If app is not on foreground we can prepare our intent to be started, with no information or additional information bundled using putExta (keep in mind bundle can handle only parcelable values). In the end service is started and wakelock is acquired.
 
 ```java
 public class NetworkChangeReceiver extends BroadcastReceiver {

--- a/docs/HeadlessJSAndroid.md
+++ b/docs/HeadlessJSAndroid.md
@@ -80,7 +80,7 @@ public class NetworkChangeReceiver extends BroadcastReceiver {
               We will start our service and send extra info about 
               network connections
             **/
-            boolean hasInternet = checkInternet(context);
+            boolean hasInternet = isNetworkAvailable(context);
             Intent serviceIntent = new Intent(context, MyTaskService.class);
             serviceIntent.putExtra("hasInternet", hasInternet);
             context.startService(serviceIntent);
@@ -108,14 +108,6 @@ public class NetworkChangeReceiver extends BroadcastReceiver {
             }
         }
         return false;
-    }
-
-    boolean checkInternet(Context context) {
-        if (isNetworkAvailable(context)) {
-            return true;
-        } else {
-            return false;
-        }
     }
 
     public static boolean isNetworkAvailable(Context context) {


### PR DESCRIPTION
Thanks for submitting a PR! Please read these instructions carefully:

- [x] Explain the **motivation** for making this change.
- [ ] Provide a **test plan** demonstrating that the code is solid.
- [ ] Match the **code formatting** of the rest of the codebase.
- [ ] Target the `master` branch, NOT a "stable" branch.

## Motivation (required)

The existing documentation on this topic doesn't provide enough of detail on where to start a headlessJS task.

## Test Plan (required)

Just docs change

This PR extends HeadlessJS documentation to show an example on how to start HeadlessJsTaskService. Sample code in example reacts to connectivity change using custom broadcast receiver logic that bundles additional information and starts the aforementioned service.
