### PR TITLE
Update DrawerLayoutAndroid.android.js

### DIFF
--- a/Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.android.js
+++ b/Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.android.js
@@ -281,7 +281,7 @@ var DrawerLayoutAndroid = React.createClass({
   *   return (
   *     <DrawerLayoutAndroid ref={'DRAWER'}>
   *     </DrawerLayoutAndroid>
-  *   ) 
+  *   )
   * }
   */
   _getDrawerLayoutHandle: function() {

--- a/Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.android.js
+++ b/Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.android.js
@@ -268,7 +268,22 @@ var DrawerLayoutAndroid = React.createClass({
       null
     );
   },
-
+  /**
+  * Closing and opening example
+  * Note: To access the drawer you have to give it a ref. Refs do not work on stateless components
+  * render () {
+  *   this.openDrawer = () => {
+  *     this.refs.DRAWER.openDrawer()
+  *   }
+  *   this.closeDrawer = () => {
+  *     this.refs.DRAWER.closeDrawer()
+  *   }
+  *   return (
+  *     <DrawerLayoutAndroid ref={'DRAWER'}>
+  *     </DrawerLayoutAndroid>
+  *   ) 
+  * }
+  */
   _getDrawerLayoutHandle: function() {
     return ReactNative.findNodeHandle(this.refs[RK_DRAWER_REF]);
   },


### PR DESCRIPTION
Currently in the documentation is not clear on how to use the `openDrawer` and `closeDrawer` methods. There is no mention of the requirement to use refs in order to access the Drawer. This should make it clear on how to do the above.
