### PR TITLE
Fix global.__RCTProfileIsProfiling flag typo

### DIFF
--- a/Libraries/ReactNative/AppContainer.js
+++ b/Libraries/ReactNative/AppContainer.js
@@ -52,7 +52,7 @@ class AppContainer extends React.Component {
 
   componentDidMount(): void {
     if (__DEV__) {
-      if (global.__RCTProfileIsProfiling) {
+      if (!global.__RCTProfileIsProfiling) {
         this._subscription = RCTDeviceEventEmitter.addListener(
           'toggleElementInspector',
           () => {

--- a/packager/launchPackager.command
+++ b/packager/launchPackager.command
@@ -12,8 +12,8 @@ echo -en "\033]0;React Packager\a"
 clear
 
 THIS_DIR=$(dirname "$0")
-pushd "$THIS_DIR/.."
-source ./packager/packager.sh
+pushd "$THIS_DIR"
+source ./packager.sh
 popd
 
 echo "Process terminated. Press <enter> to close the window"

--- a/packager/launchPackager.command
+++ b/packager/launchPackager.command
@@ -12,8 +12,8 @@ echo -en "\033]0;React Packager\a"
 clear
 
 THIS_DIR=$(dirname "$0")
-pushd "$THIS_DIR"
-source ./packager.sh
+pushd "$THIS_DIR/.."
+source ./packager/packager.sh
 popd
 
 echo "Process terminated. Press <enter> to close the window"


### PR DESCRIPTION
The Inspector tool is currently broken due to `global.__RCTProfileIsProfiling` being `false` and a typo in the statement resulting in the inspector never being initalized. This PR fixes the typo.