### PR TITLE
Custom titleTextAttributes on UINavigationBar

### DIFF
--- a/React/Views/RCTWrapperViewController.m
+++ b/React/Views/RCTWrapperViewController.m
@@ -117,7 +117,7 @@ static UIView *RCTFindNavBarShadowViewInView(UIView *view)
     bar.translucent = _navItem.translucent;
     bar.titleTextAttributes = _navItem.titleTextColor ? @{
       NSForegroundColorAttributeName: _navItem.titleTextColor
-    } : nil;
+    } : bar.titleTextAttributes;
 
     RCTFindNavBarShadowViewInView(bar).hidden = _navItem.shadowHidden;
 


### PR DESCRIPTION
Support using custom fonts for UINavigationBar title.

Instead of setting titleTextAttributes as nil when titleTextColor is not specified on component, fallback to use current titleTextAttributes. That makes it possible to set the appearance in AppDelegate for example.