### PR TITLE
Make ShadowNodeRegistry thread safe

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/ShadowNodeRegistry.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/ShadowNodeRegistry.java
@@ -30,7 +30,7 @@ import com.facebook.react.common.SingleThreadAsserter;
     mThreadAsserter = new SingleThreadAsserter();
   }
 
-  public void addRootNode(ReactShadowNode node) {
+  public synchronized void addRootNode(ReactShadowNode node) {
     // TODO(6242243): This should be asserted... but UIManagerModule is
     // thread-unsafe and calls this on the wrong thread.
     //mThreadAsserter.assertNow();
@@ -39,7 +39,7 @@ import com.facebook.react.common.SingleThreadAsserter;
     mRootTags.put(tag, true);
   }
 
-  public void removeRootNode(int tag) {
+  public synchronized void removeRootNode(int tag) {
     mThreadAsserter.assertNow();
     if (!mRootTags.get(tag)) {
       throw new IllegalViewOperationException(
@@ -50,12 +50,12 @@ import com.facebook.react.common.SingleThreadAsserter;
     mRootTags.delete(tag);
   }
 
-  public void addNode(ReactShadowNode node) {
+  public synchronized void addNode(ReactShadowNode node) {
     mThreadAsserter.assertNow();
     mTagsToCSSNodes.put(node.getReactTag(), node);
   }
 
-  public void removeNode(int tag) {
+  public synchronized void removeNode(int tag) {
     mThreadAsserter.assertNow();
     if (mRootTags.get(tag)) {
       throw new IllegalViewOperationException(
@@ -64,22 +64,22 @@ import com.facebook.react.common.SingleThreadAsserter;
     mTagsToCSSNodes.remove(tag);
   }
 
-  public ReactShadowNode getNode(int tag) {
+  public synchronized ReactShadowNode getNode(int tag) {
     mThreadAsserter.assertNow();
     return mTagsToCSSNodes.get(tag);
   }
 
-  public boolean isRootNode(int tag) {
+  public synchronized boolean isRootNode(int tag) {
     mThreadAsserter.assertNow();
     return mRootTags.get(tag);
   }
 
-  public int getRootNodeCount() {
+  public synchronized int getRootNodeCount() {
     mThreadAsserter.assertNow();
     return mRootTags.size();
   }
 
-  public int getRootTag(int index) {
+  public synchronized int getRootTag(int index) {
     mThreadAsserter.assertNow();
     return mRootTags.keyAt(index);
   }


### PR DESCRIPTION
## Motivation (required)

As noted in `TODO` of `addRootNode`, ShadowNodeRegistry can be accessed by
multiple threads. Make it thread safe can avoid crashes in
`UIImplementation` module (e.g. tag cannot be found).

Fixes #11524 and #10755.

Example of crash stack (0.44.0):
```
Caused by java.lang.NullPointerException: Attempt to invoke virtual method 'void com.facebook.react.uimanager.ReactShadowNode.addChildAt(com.facebook.react.uimanager.ReactShadowNode, int)' on a null object reference
       at com.facebook.react.uimanager.UIImplementation.setChildren(UIImplementation.java:390)
       at com.facebook.react.uimanager.UIManagerModule.setChildren(UIManagerModule.java:313)
       at java.lang.reflect.Method.invoke(Method.java)
       at java.lang.reflect.Method.invoke(Method.java:372)
       at com.facebook.react.bridge.BaseJavaModule$JavaMethod.invoke(BaseJavaModule.java:368)
       at com.facebook.react.cxxbridge.JavaModuleWrapper.invoke(JavaModuleWrapper.java:138)
       at com.facebook.react.bridge.queue.NativeRunnable.run(NativeRunnable.java)
       at android.os.Handler.handleCallback(Handler.java:739)
       at android.os.Handler.dispatchMessage(Handler.java:95)
       at com.facebook.react.bridge.queue.MessageQueueThreadHandler.dispatchMessage(MessageQueueThreadHandler.java:31)
       at android.os.Looper.loop(Looper.java:145)
       at com.facebook.react.bridge.queue.MessageQueueThreadImpl$3.run(MessageQueueThreadImpl.java:208)
       at java.lang.Thread.run(Thread.java:818)
```

## Test Plan (required)

Crash can be re-produced by monkey test. After the fix applied, related crashes are never seen again.
