### PR TITLE
Fix sticky headers when rerendering

### DIFF
--- a/Libraries/Components/ScrollView/ScrollView.js
+++ b/Libraries/Components/ScrollView/ScrollView.js
@@ -490,18 +490,15 @@ const ScrollView = React.createClass({
   },
 
   _updateAnimatedNodeAttachment: function() {
+    if (this._scrollAnimatedValueAttachment) {
+      this._scrollAnimatedValueAttachment.detach();
+    }
     if (this.props.stickyHeaderIndices && this.props.stickyHeaderIndices.length > 0) {
-      if (!this._scrollAnimatedValueAttachment) {
-        this._scrollAnimatedValueAttachment = Animated.attachNativeEvent(
-          this._scrollViewRef,
-          'onScroll',
-          [{nativeEvent: {contentOffset: {y: this._scrollAnimatedValue}}}]
-        );
-      }
-    } else {
-      if (this._scrollAnimatedValueAttachment) {
-        this._scrollAnimatedValueAttachment.detach();
-      }
+      this._scrollAnimatedValueAttachment = Animated.attachNativeEvent(
+        this._scrollViewRef,
+        'onScroll',
+        [{nativeEvent: {contentOffset: {y: this._scrollAnimatedValue}}}]
+      );
     }
   },
 


### PR DESCRIPTION
There was an issue that sometimes sticky headers would stop moving when re-rendering because we did not reattach events properly. This makes sure that we always detach and reatach on rerender in case the scroll view ref changes.

**Test plan**
Tested that this fixes issues with sticky headers we discovered when updating Expo to RN 0.44.