### PR TITLE
Make sure to run all subspecs, to find failing cases

### DIFF
--- a/scripts/process-podspecs.sh
+++ b/scripts/process-podspecs.sh
@@ -24,7 +24,7 @@ fi
 cd "$SPEC_REPO_DIR"
 SPEC_REPO_REMOTE=$(git remote get-url origin)
 
-POD_LINT_OPT="--verbose --no-subspecs --allow-warnings --fail-fast --private --swift-version=3.0 --sources=$SPEC_REPO_REMOTE"
+POD_LINT_OPT="--verbose --allow-warnings --fail-fast --private --swift-version=3.0 --sources=$SPEC_REPO_REMOTE"
 
 # Get the version from a podspec.
 version() {


### PR DESCRIPTION
Thanks for submitting a PR! Please read these instructions carefully:

## Motivation (required)

Currently no subspecs are running on CI which causes us to find bugs in the podspec from time to time we upgrade master.

In order to highlight errors for podspecs users when changes happen we should make sure to run all subspecs even though it might take a bit longer when running the CI