### PR TITLE
Updated method signature for ListView#scrollTo

### DIFF
--- a/Libraries/Components/ScrollView/ScrollView.js
+++ b/Libraries/Components/ScrollView/ScrollView.js
@@ -442,14 +442,14 @@ const ScrollView = React.createClass({
    * the function also accepts separate arguments as an alternative to the options object.
    * This is deprecated due to ambiguity (y before x), and SHOULD NOT BE USED.
    */
-  scrollTo: function(
-    y?: number | { x?: number, y?: number, animated?: boolean },
-    x?: number,
-    animated?: boolean
-  ) {
+scrollTo: function(
+  y?: number | { x?: number, y?: number, animated?: boolean },
+  x?: number,
+  animated?: boolean
+) {
     if (typeof y === 'number') {
-      console.warn('`scrollTo(y, x, animated)` is deprecated. Use `scrollTo({x: 5, y: 5, ' +
-        'animated: true})` instead.');
+      console.warn('`scrollTo(y, x, animated)` method signature is deprecated. Example of correct signature: ' +
+        '`scrollTo({x: 5, y: 5, animated: true})`');
     } else {
       ({x, y, animated} = y || {});
     }

--- a/Libraries/Lists/ListView/ListView.js
+++ b/Libraries/Lists/ListView/ListView.js
@@ -277,6 +277,8 @@ var ListView = React.createClass({
   ) {
     if (this._scrollComponent && this._scrollComponent.scrollTo) {
       var scrollToProps = {};
+
+      // The correct params were passed so use them
       if (typeof y === 'object') {
         scrollToProps = y;
       } else {

--- a/Libraries/Lists/ListView/ListView.js
+++ b/Libraries/Lists/ListView/ListView.js
@@ -259,13 +259,44 @@ var ListView = React.createClass({
   },
 
   /**
+   * This function is a pass through for the ScrollView#scrollTo
    * Scrolls to a given x, y offset, either immediately or with a smooth animation.
    *
-   * See `ScrollView#scrollTo`.
+   * DEPRECATED PARAMS:
+   * This function can take the arguments (x:number, y:number, animated:boolean)
+   * but it is deprecated, so please use an object {x:number, y:number, animated:boolean}
+   *
+   * Example:
+   *
+   * `scrollTo({x: 0, y: 0, animated: true})`
    */
-  scrollTo: function(...args: Array<mixed>) {
+  scrollTo: function(
+    y?: number | { x?: number, y?: number, animated?: boolean },
+    x?: number,
+    animated?: boolean
+  ) {
     if (this._scrollComponent && this._scrollComponent.scrollTo) {
-      this._scrollComponent.scrollTo(...args);
+      var scrollToProps = {};
+      if (typeof y === 'object') {
+        scrollToProps = y;
+      } else {
+        // Map deprecated params to correct format and warn developer
+        console.warn('`scrollTo(y, x, animated)` method signature is deprecated. Example of correct signature: ' +
+          '`scrollTo({x: 5, y: 5, animated: true})`');
+        if (y) {
+          scrollToProps.y = y;
+        }
+
+        if (x) {
+          scrollToProps.x = x;
+        }
+
+        if (animated) {
+          scrollToProps.animated = animated;
+        }
+      }
+
+      this._scrollComponent.scrollTo(scrollToProps);
     }
   },
 

--- a/Libraries/Lists/ListView/__tests__/ListView-tests.js
+++ b/Libraries/Lists/ListView/__tests__/ListView-tests.js
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+'use strict';
+
+jest.disableAutomock();
+
+const React = require('React');
+const ReactTestRenderer = require('react-test-renderer');
+const ListView = require('ListView');
+const Text = require('Text');
+
+describe('ListView', () => {
+  var ds = new ListView.DataSource({rowHasChanged: (r1, r2) => r1 !== r2});
+  var datasource = ds.cloneWithRows(['John', 'Joel', 'James', 'Jimmy', 'Jackson', 'Jillian', 'Julie', 'Devin']);
+
+  it('should render a ListView', () => {
+    const component = ReactTestRenderer.create(
+      <ListView
+        dataSource={datasource}
+        renderRow={rowData => <Text>{rowData}</Text>}
+      />
+    );
+
+    expect(component).toMatchSnapshot();
+  });
+
+  xit('should be able to scroll', () => {
+    // Not sure how to test this
+    let ref;
+    const component = ReactTestRenderer.create(
+      <ListView
+        ref={el => { ref = el; }}
+        dataSource={datasource}
+        renderRow={rowData => <Text>{rowData}</Text>}
+      />
+    );
+
+    ref.scrollTo(4, 3, true);
+  });
+});

--- a/Libraries/Lists/ListView/__tests__/__snapshots__/ListView-tests.js.snap
+++ b/Libraries/Lists/ListView/__tests__/__snapshots__/ListView-tests.js.snap
@@ -1,0 +1,80 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ListView should render a ListView 1`] = `
+<RCTScrollView
+  dataSource={
+    ListViewDataSource {
+      "items": 8,
+    }
+  }
+  renderRow={[Function]}
+  renderScrollComponent={[Function]}
+>
+  <View>
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      disabled={false}
+      ellipsizeMode="tail"
+    >
+      John
+    </Text>
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      disabled={false}
+      ellipsizeMode="tail"
+    >
+      Joel
+    </Text>
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      disabled={false}
+      ellipsizeMode="tail"
+    >
+      James
+    </Text>
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      disabled={false}
+      ellipsizeMode="tail"
+    >
+      Jimmy
+    </Text>
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      disabled={false}
+      ellipsizeMode="tail"
+    >
+      Jackson
+    </Text>
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      disabled={false}
+      ellipsizeMode="tail"
+    >
+      Jillian
+    </Text>
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      disabled={false}
+      ellipsizeMode="tail"
+    >
+      Julie
+    </Text>
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      disabled={false}
+      ellipsizeMode="tail"
+    >
+      Devin
+    </Text>
+  </View>
+</RCTScrollView>
+`;


### PR DESCRIPTION
 **Note: The test suite is throwing errors after a fresh fork and clone**

## Motivation

### ListView

- The method signature in ListView.scrollTo was not helpful and basically acted as a passthrough to ScrollView#scrollTo.  I thought it would be helpful to define the args here instead of having an array of any.
- I also thought it would be helpful to fix deprecated arguments before passing them to ScrollView#scrollTo.
- Since I fix the arguments here, the warning message in scrollTo will never be called, so I added a warning message here.
- Additionally I used a params object to be passed to ScrollView#scrollTo in order have a single exit point from the function instead of returning in each bool case.
- Lastly I updated the comments for this function

### ScrollView

- I updated the warning message for the deprecated args in ScrollView#scrollTo to clarify the method signature as the issue.  This message also matches the logging I added to ListView#scrollTo


## Test Plan (required)

Create a basic list ViewComponent with a touchable highlight to used to scroll the list.  Call the scroll to function with the deprecated params (y, x, animated) and with the current params ({x, y: animated})

There was not a unit test for ListView so I added one but I am not sure how to test the scrolling of it.

I hope this is good enough to get in :)

Please let me know if there is anything I can do to make it better.


