### PR TITLE
Run packager.sh using '.' instead of 'source'.

### DIFF
--- a/packager/launchPackager.command
+++ b/packager/launchPackager.command
@@ -13,7 +13,7 @@ clear
 
 THIS_DIR=$(dirname "$0")
 pushd "$THIS_DIR/.."
-source packager/packager.sh
+. packager/packager.sh
 popd
 
 echo "Process terminated. Press <enter> to close the window"


### PR DESCRIPTION
'source' is not available in all shells on Linux (e.g. dash) and will silently fail launchPackager.command when called from runAndroid.js.

react-native run-android will thus silently fail to start the developement server ('JS server').


## Motivation (required)
What existing problem does the pull request solve?

When running "react-native run-android" on the below reasonably vanilla Ubuntu system, the development server / packager script fails to start. It fails because sh defaults to dash (not bash) which doesn't know the command 'source'. dot (.) does the same as source, but works in all shells.

$ uname -a
Linux dallas 4.8.0-52-generic #55~16.04.1-Ubuntu SMP Fri Apr 28 14:36:29 UTC 2017 x86_64 x86_64 x86_64 GNU/Linux

$ which sh
/bin/sh

$ readlink -f /bin/sh
/bin/dash

react-native-cli: 2.0.1
react-native: 0.44.0

##  Test Plan (required) 
### using 'source':
$ ps aux | grep packager
(nothing)

### using '.':
ps aux | grep packager
sh /home/xxx/code/react-native/AwesomeProject/node_modules/react-native/packager/launchPackager.command
node /home/xxx/code/react-native/AwesomeProject/node_modules/react-native/packager/../local-cli/cli.js start
