### PR TITLE
Use Component name instead of project name to align with other docs

### DIFF
--- a/docs/HeightAndWidth.md
+++ b/docs/HeightAndWidth.md
@@ -31,7 +31,7 @@ export default class FixedDimensionsBasics extends Component {
 }
 
 // skip this line if using Create React Native App
-AppRegistry.registerComponent('AwesomeProject', () => FixedDimensionsBasics);
+AppRegistry.registerComponent('FixedDimensionsBasics', () => FixedDimensionsBasics);
 ```
 
 Setting dimensions this way is common for components that should always render at exactly the same size, regardless of screen dimensions.
@@ -62,7 +62,7 @@ export default class FlexDimensionsBasics extends Component {
 }
 
 // skip this line if using Create React Native App
-AppRegistry.registerComponent('AwesomeProject', () => FlexDimensionsBasics);
+AppRegistry.registerComponent('FlexDimensionsBasics', () => FlexDimensionsBasics);
 ```
 
 After you can control a component's size, the next step is to [learn how to lay it out on the screen](docs/flexbox.html).

--- a/docs/LayoutWithFlexbox.md
+++ b/docs/LayoutWithFlexbox.md
@@ -36,7 +36,7 @@ export default class FlexDirectionBasics extends Component {
 };
 
 // skip this line if using Create React Native App
-AppRegistry.registerComponent('AwesomeProject', () => FlexDirectionBasics);
+AppRegistry.registerComponent('FlexDirectionBasics', () => FlexDirectionBasics);
 ```
 
 #### Justify Content
@@ -66,7 +66,7 @@ export default class JustifyContentBasics extends Component {
 };
 
 // skip this line if using Create React Native App
-AppRegistry.registerComponent('AwesomeProject', () => JustifyContentBasics);
+AppRegistry.registerComponent('JustifyContentBasics', () => JustifyContentBasics);
 ```
 
 #### Align Items
@@ -100,7 +100,7 @@ export default class AlignItemsBasics extends Component {
 };
 
 // skip this line if using Create React Native App
-AppRegistry.registerComponent('AwesomeProject', () => AlignItemsBasics);
+AppRegistry.registerComponent('AlignItemsBasics', () => AlignItemsBasics);
 ```
 
 #### Going Deeper


### PR DESCRIPTION
Thanks for submitting a PR! Please read these instructions carefully:

- [x] Explain the **motivation** for making this change.
- [x] Provide a **test plan** demonstrating that the code is solid.
- [x] Match the **code formatting** of the rest of the codebase.
- [x] Target the `master` branch, NOT a "stable" branch.

## Motivation (required)

Dear maintainers,

I'm very new to React Native and still learning a lot with your excellent docs.
While reading the docs, I found tiny inconsistency in the sample codes.

```js
// When calling `registerComponent`, almost sample code uses component name. 
AppRegistry.registerComponent('HelloWorldApp', () => HelloWorldApp);

// But some samples don't. 
AppRegistry.registerComponent('AwesomeProject', () => FixedDimensionsBasics);
```

So I fixed them.

## Test Plan (required)

I ran the website locally and manually checked my changes.

```console
$ cd website
$ npm install && npm start
$ open http://localhost:8079/react-native/docs/height-and-width.html
$ open http://localhost:8079/react-native/docs/flexbox.html
```

<img width="669" alt="2017-05-19 1 42 36" src="https://cloud.githubusercontent.com/assets/1811616/26213911/981ed492-3c35-11e7-82f4-f2ff41eae686.png">
<img width="674" alt="2017-05-19 1 41 56" src="https://cloud.githubusercontent.com/assets/1811616/26213910/981d0a0e-3c35-11e7-9846-b6664f961f4e.png">

