### PR TITLE
Webview

### DIFF
--- a/Libraries/Components/WebView/WebView.ios.js
+++ b/Libraries/Components/WebView/WebView.ios.js
@@ -253,15 +253,34 @@ class WebView extends React.Component {
     startInLoadingState: PropTypes.bool,
 
     /**
-     * An array of string corresponding to custom actions displayed in select menu
+     * selectActions: A string containing the list of actions that will be
+     * displayed in iOS selection menu
+     *
+     * onSelectActions: The event handler that will be invoked if a custom
+     * select action is chosen. The event handler will be invoked with `event'
+     * variable. The chosen action will be available in event.nativeEvent.action.
+     *
+     * Example Usage:
+     *
+     * return ( 
+     *   <WebView
+     *
+     *      source={{uri: 'https://github.com/facebook/react-native'}}
+     *      style={{marginTop: 20}}
+     *      selectActions={['Like', 'Share', 'Save', 'Add To Notes']}
+     *      onSelectAction={this.onSelect.bind(this)}
+     *      onLoadEnd={this.onLoadEnd.bind(this)}
+     *    />
+     * )
+     * ...
+     * ...
+     * onSelect(event) {
+     *    console.log('selected action:', event.nativeEvent.action);
+     * }
+     *
      */
-    selectActions: PropTypes.arrayOf(PropTypes.string),
-
-
-    /**
-     * Event handler which will be invoked if a custom select action is chosen
-     */
-    onSelectAction: PropTypes.func,
+     selectActions: PropTypes.arrayOf(PropTypes.string),
+     onSelectAction: PropTypes.func,
 
     /**
      * The style to apply to the `WebView`.

--- a/Libraries/Components/WebView/WebView.ios.js
+++ b/Libraries/Components/WebView/WebView.ios.js
@@ -251,6 +251,18 @@ class WebView extends React.Component {
      * on the first load.
      */
     startInLoadingState: PropTypes.bool,
+
+    /**
+     * An array of string corresponding to custom actions displayed in select menu
+     */
+    selectActions: PropTypes.arrayOf(PropTypes.string),
+
+
+    /**
+     * Event handler which will be invoked if a custom select action is chosen
+     */
+    onSelectAction: PropTypes.func,
+
     /**
      * The style to apply to the `WebView`.
      */
@@ -430,6 +442,8 @@ class WebView extends React.Component {
         contentInset={this.props.contentInset}
         automaticallyAdjustContentInsets={this.props.automaticallyAdjustContentInsets}
         onLoadingStart={this._onLoadingStart}
+        selectActions= {this.props.selectActions || []}
+        onSelectAction={this._onSelectAction}
         onLoadingFinish={this._onLoadingFinish}
         onLoadingError={this._onLoadingError}
         messagingEnabled={messagingEnabled}
@@ -526,6 +540,14 @@ class WebView extends React.Component {
     );
   };
 
+  registerSelectActions = (actions) => {
+    UIManager.dispatchViewManagerCommand(
+      this.getWebViewHandle(),
+      UIManager.RCTWebView.Commands.registerSelectActions,
+      actions
+    );
+  };
+
   /**
    * We return an event with a bunch of fields including:
    *  url, title, loading, canGoBack, canGoForward
@@ -542,6 +564,11 @@ class WebView extends React.Component {
   getWebViewHandle = (): any => {
     return ReactNative.findNodeHandle(this.refs[RCT_WEBVIEW_REF]);
   };
+
+  _onSelectAction = (event: Event) => {
+    var onSelectAction = this.props.onSelectAction;
+    onSelectAction && onSelectAction(event);
+  }
 
   _onLoadingStart = (event: Event) => {
     var onLoadStart = this.props.onLoadStart;

--- a/RNTester/js/WebViewExample.js
+++ b/RNTester/js/WebViewExample.js
@@ -21,6 +21,8 @@ var {
   TouchableOpacity,
   View,
   WebView
+  Platform,
+  Alert,
 } = ReactNative;
 
 var HEADER = '#3b5998';
@@ -281,6 +283,42 @@ class InjectJS extends React.Component {
   }
 }
 
+class SelectMenu extends React.Component {
+  webview = null;
+  renderAndroid() {
+    return (
+      <View>
+        <Text>Webview Selection Not Yet Supported on Android</Text>
+      </View>
+    )
+  }
+  renderIOS() {
+    return (
+      <View>
+        <WebView
+          ref={webview => { this.webview = webview; }}
+          style={{
+            backgroundColor: BGWASH,
+            height: 300,
+          }}
+          selectActions={['Like', 'Share', 'Save', 'Add To Notes']}
+          onSelectAction={this.onSelect.bind(this)}
+          source={{uri: 'https://www.facebook.com'}}
+          scalesPageToFit={true}
+        />
+        <View style={styles.buttons}>
+          <Button text="Inject JS" enabled onPress={this.injectJS} />
+        </View>
+    </View>
+    );
+  }
+  onSelect(event) {
+    Alert('Selection', 'You chose:' + event.nativeEvent.action);
+  }
+  render() {
+    return( Platform.OS === 'ios' ? this.renderIOS() : this.renderAndroid());
+  }
+}
 
 var styles = StyleSheet.create({
   container: {
@@ -464,5 +502,9 @@ exports.examples = [
   {
     title: 'Inject JavaScript',
     render(): React.Element<any> { return <InjectJS />; }
+  },
+  {
+    title: 'Selection Menu',
+    render(): React.Element<any> { return <SelectMenu />; }
   },
 ];

--- a/RNTester/js/WebViewExample.js
+++ b/RNTester/js/WebViewExample.js
@@ -20,7 +20,7 @@ var {
   TouchableWithoutFeedback,
   TouchableOpacity,
   View,
-  WebView
+  WebView,
   Platform,
   Alert,
 } = ReactNative;

--- a/React/Views/RCTWebView.h
+++ b/React/Views/RCTWebView.h
@@ -32,6 +32,8 @@ shouldStartLoadForRequest:(NSMutableDictionary<NSString *, id> *)request
 @property (nonatomic, weak) id<RCTWebViewDelegate> delegate;
 
 @property (nonatomic, copy) NSDictionary *source;
+@property (nonatomic, copy) NSArray<NSString*> *selectActions;
+
 @property (nonatomic, assign) UIEdgeInsets contentInset;
 @property (nonatomic, assign) BOOL automaticallyAdjustContentInsets;
 @property (nonatomic, assign) BOOL messagingEnabled;
@@ -44,5 +46,6 @@ shouldStartLoadForRequest:(NSMutableDictionary<NSString *, id> *)request
 - (void)stopLoading;
 - (void)postMessage:(NSString *)message;
 - (void)injectJavaScript:(NSString *)script;
+- (void)onSelect:(NSString*)action withSelection:(NSString*)selectedText;
 
 @end

--- a/React/Views/RCTWebViewManager.m
+++ b/React/Views/RCTWebViewManager.m
@@ -33,6 +33,9 @@ RCT_EXPORT_MODULE()
   return webView;
 }
 
+RCT_EXPORT_VIEW_PROPERTY(onSelectAction, RCTDirectEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(selectActions, NSArray<NSString*>*)
+
 RCT_EXPORT_VIEW_PROPERTY(source, NSDictionary)
 RCT_REMAP_VIEW_PROPERTY(bounces, _webView.scrollView.bounces, BOOL)
 RCT_REMAP_VIEW_PROPERTY(scrollEnabled, _webView.scrollView.scrollEnabled, BOOL)


### PR DESCRIPTION
## Motivation
Adds the ability to provide a custom selection menu to iOS WebView.

## Test Plan

Added selection menu example to RNTester
RNTester/js/WebViewExample.js

## Example Usage
```javascript
class SelectMenu extends React.Component {
  webview = null;
  renderAndroid() {
    return (
      <View>
        <Text>Webview Selection Not Yet Supported on Android</Text>
      </View>
    )
  }
  renderIOS() {
    return (
      <View>
        <WebView
          ref={webview => { this.webview = webview; }}
          style={{
            backgroundColor: BGWASH,
            height: 300,
          }}
          selectActions={['Like', 'Share', 'Save', 'Add To Notes']}
          onSelectAction={this.onSelect.bind(this)}
          source={{uri: 'https://www.facebook.com'}}
          scalesPageToFit={true}
        />
        <View style={styles.buttons}>
          <Button text="Inject JS" enabled onPress={this.injectJS} />
        </View>
    </View>
    );
  }
  onSelect(event) {
    Alert('Selection', 'You chose:' + event.nativeEvent.action);
  }
  render() {
    return( Platform.OS === 'ios' ? this.renderIOS() : this.renderAndroid());
  }
}
```
