### PR TITLE
Document image blurRadius is working on Android too

### DIFF
--- a/Libraries/Image/Image.ios.js
+++ b/Libraries/Image/Image.ios.js
@@ -181,7 +181,6 @@ const Image = React.createClass({
     accessibilityLabel: PropTypes.node,
     /**
     * blurRadius: the blur radius of the blur filter added to the image
-    * @platform ios
     */
     blurRadius: PropTypes.number,
     /**


### PR DESCRIPTION
Hi,

I saw blurRadius is now working on Android. Updated the doc to show it.

It is available since 0.44, see https://github.com/facebook/react-native/commit/0b348095b687d0d6f5268ecac6dffedfcc268110

See RNTester screenshot on Android:
![blur-android](https://cloud.githubusercontent.com/assets/57791/26244353/97fa4f96-3c8f-11e7-8910-5c60f5ad93fc.png)

Also I noticed it's a bit different than on iOS:
![blur-ios](https://cloud.githubusercontent.com/assets/57791/26244396/bbaf9158-3c8f-11e7-96cc-534d8ee042fb.png)

Looking briefly at the code, it looks like it's caused by the fact that the Android version applies blur to the original image data in full size (and applies `PixelUtil.toPixelFromDIP(blurRadius)`), but the iOS version applies it to the resized version.
I'll open an issue for this.
