### PR TITLE
Make "nativePerformanceNow" use same clock as "SystemClock.elapsedRealtime()"

### DIFF
--- a/ReactAndroid/src/main/jni/xreact/jni/OnLoad.cpp
+++ b/ReactAndroid/src/main/jni/xreact/jni/OnLoad.cpp
@@ -107,15 +107,15 @@ static JSValueRef nativePerformanceNow(
   static const int64_t NANOSECONDS_IN_SECOND = 1000000000LL;
   static const int64_t NANOSECONDS_IN_MILLISECOND = 1000000LL;
 
-  // Since SystemClock.uptimeMillis() is commonly used for performance measurement in Java
-  // and uptimeMillis() internally uses clock_gettime(CLOCK_MONOTONIC),
+  // Since SystemClock.elapsedRealtime() is commonly used for performance measurement in Java
+  // and elapsedRealtime() internally uses clock_gettime(CLOCK_BOOTTIME),
   // we use the same API here.
   // We need that to make sure we use the same time system on both JS and Java sides.
   // Links to the source code:
   // https://android.googlesource.com/platform/frameworks/native/+/jb-mr1-release/libs/utils/SystemClock.cpp
   // https://android.googlesource.com/platform/system/core/+/master/libutils/Timers.cpp
   struct timespec now;
-  clock_gettime(CLOCK_MONOTONIC, &now);
+  clock_gettime(CLOCK_BOOTTIME, &now);
   int64_t nano = now.tv_sec * NANOSECONDS_IN_SECOND + now.tv_nsec;
   return Value::makeNumber(ctx, (nano / (double)NANOSECONDS_IN_MILLISECOND));
 }


### PR DESCRIPTION
`CLOCK_MONOTONIC` has an unspecified start time, whereas `CLOCK_BOOTTIME`
starts at boot time, same as `SystemClock.elapsedRealtime()`

By using the same start point, it's possible to record a start time in Java
and a stop time in JavaScript (or vice-versa), to measure performance across
the bridge

Moreover, Android's `SystemClock` documentation says:

- uptimeMillis() "[...]. This clock stops when the system enters deep sleep"
- elapsedRealtime() "[...] include[s] deep sleep"

"uptimeMillis" should never be used for measuring performance, instead
"elapsedRealtime" will be more accurate.

Thanks for submitting a PR! Please read these instructions carefully:

- [x] Explain the **motivation** for making this change.
- [x] Provide a **test plan** demonstrating that the code is solid.
- [x] Match the **code formatting** of the rest of the codebase.
- [x] Target the `master` branch, NOT a "stable" branch.

## Motivation

To accurately compare time metrics taken in the native code, with those gathered inside the JS side, `nativePerformanceNow` needs to use a clock that is available to Android's Java code (without having to create custom JNI modules).

The `nativePerformanceNow` method uses `CLOCK_MONOTONIC`, which is not exposed in Android's Java APIs. The alternative is using `CLOCK_BOOTTIME`, which is exposed in Android's Java API as `SystemClock.elapsedRealtime()`.

Given all the above, `nativePerformanceNow` should use `CLOCK_BOOTTIME`.

## Test Plan

Testing has been done manually:

- Print `SystemClock.elapsedRealtime()` in the activity's `onCreate`.
- Then, print `nativePerformanceNow` in the first component's `componentDidMount`. The printed values should be as far apart as the perceived latency.

**Please advise if there is an automated test suite where I could add a case for this.**