### PR TITLE
add multiline flag to product name regex in runIOS build project

### DIFF
--- a/local-cli/runIOS/runIOS.js
+++ b/local-cli/runIOS/runIOS.js
@@ -157,7 +157,7 @@ function buildProject(xcodeProject, udid, scheme, configuration = 'Debug', launc
     });
     buildProcess.on('close', function(code) {
       //FULL_PRODUCT_NAME is the actual file name of the app, which actually comes from the Product Name in the build config, which does not necessary match a scheme name,  example output line: export FULL_PRODUCT_NAME="Super App Dev.app"
-      let productNameMatch = /export FULL_PRODUCT_NAME="?(.+).app"?$/.exec(buildOutput);
+      let productNameMatch = /export FULL_PRODUCT_NAME="?(.+).app"?$/m.exec(buildOutput);
       if (productNameMatch && productNameMatch.length && productNameMatch.length > 1) {
         return resolve(productNameMatch[1]);//0 is the full match, 1 is the app name
       }


### PR DESCRIPTION
Maintainers - hoping theres a chance this could be cherry-picked into 0.44-stable as it's a very minor change to the local-cli.

## Motivation (required)

Our iOS app has 3 different configurations, each with a separate Product Name.  When building for debugging on the simulator with the `react-native run-ios` command, the build would complete successfully but would error in trying to install to the simulator.  I tracked the error down to the regex I've updated in this PR which was looking for the full product name in the build output, but the regex there wasn't using the multiline flag so it never matched.

## Test Plan (required)

I've tested this locally with our app and it now works as expected.  If I specify a different configuration with `react-native run-ios --configuration Beta` (for example), it properly detects the Product Name for the configuration and installs correctly as well.
