### PR TITLE
Move to{HashMap,ArrayList} up to Readable{Map,Array}

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/JavaOnlyArray.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/JavaOnlyArray.java
@@ -151,6 +151,11 @@ public class JavaOnlyArray implements ReadableArray, WritableArray {
   }
 
   @Override
+  public ArrayList<Object> toArrayList() {
+    return new ArrayList<Object>(mBackingList);
+  }
+
+  @Override
   public String toString() {
     return mBackingList.toString();
   }

--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/JavaOnlyMap.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/JavaOnlyMap.java
@@ -174,6 +174,11 @@ public class JavaOnlyMap implements ReadableMap, WritableMap {
   }
 
   @Override
+  public HashMap<String, Object> toHashMap() {
+    return new HashMap<String, Object>(mBackingMap);
+  }
+
+  @Override
   public String toString() {
     return mBackingMap.toString();
   }

--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/ReadableArray.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/ReadableArray.java
@@ -9,6 +9,8 @@
 
 package com.facebook.react.bridge;
 
+import java.util.ArrayList;
+
 /**
  * Interface for an array that allows typed access to its members. Used to pass parameters from JS
  * to Java.
@@ -25,4 +27,6 @@ public interface ReadableArray {
   ReadableMap getMap(int index);
   Dynamic getDynamic(int index);
   ReadableType getType(int index);
+  ArrayList<Object> toArrayList();
+
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/ReadableMap.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/ReadableMap.java
@@ -9,6 +9,8 @@
 
 package com.facebook.react.bridge;
 
+import java.util.HashMap;
+
 /**
  * Interface for a map that allows typed access to its members. Used to pass parameters from JS to
  * Java.
@@ -26,4 +28,6 @@ public interface ReadableMap {
   Dynamic getDynamic(String name);
   ReadableType getType(String name);
   ReadableMapKeySetIterator keySetIterator();
+  HashMap<String, Object> toHashMap();
+
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/ReadableNativeArray.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/ReadableNativeArray.java
@@ -52,6 +52,7 @@ public class ReadableNativeArray extends NativeArray implements ReadableArray {
     return DynamicFromArray.create(this, index);
   }
 
+  @Override
   public ArrayList<Object> toArrayList() {
     ArrayList<Object> arrayList = new ArrayList<>();
 

--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/ReadableNativeMap.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/ReadableNativeMap.java
@@ -57,6 +57,7 @@ public class ReadableNativeMap extends NativeMap implements ReadableMap {
     return new ReadableNativeMapKeySetIterator(this);
   }
 
+  @Override
   public HashMap<String, Object> toHashMap() {
     ReadableMapKeySetIterator iterator = keySetIterator();
     HashMap<String, Object> hashMap = new HashMap<>();


### PR DESCRIPTION
NativeReadable{Map,Array} classes have convenient to{HashMap,ArrayList}
methods that make it easier to interoperate with existing Java code
from within a ReactNative application (e.g., Native Module) ...

Thanks for submitting a PR! Please read these instructions carefully:

- [x] Explain the **motivation** for making this change.
- [x] Provide a **test plan** demonstrating that the code is solid.
- [x] Match the **code formatting** of the rest of the codebase.
- [x] Target the `master` branch, NOT a "stable" branch.

## Motivation

NativeReadable{Map,Array} classes have convenient to{HashMap,ArrayList}
methods that make it easier to interoperate with existing Java code
from within a ReactNative application (e.g., Native Module)

These changes make these same methods available to any code using
the Readable{Map,Array} interfaces, instead of forcing consumers to
cast their generic instances into the NativeReadable* equivalents

Moving this methods up to the interfaces also makes it easier to
write unit tests for Native Modules - using the JavaOnly{Map,Array}
implementations of Readable{Map,Array} - while still relying on the
to{HashMap,ArrayList} methods

## Test Plan

* Write a native module that receives a JSON object as `ReadableMap` and a JSON array `ReadableArray`.
* Print out the result of `toHashMap` and `toArrayList`.
* Make sure `NativeReadable{Map,Array}` works:
  * Call the native module's method from JavaScript, passing an `Object` and an `Array`.
  * Compare the printed values with the passed content.
* Make sure `JavaOnly{Map,Array}` works:
  * Call the native module's method from the Java code and pass a `JavaOnlyMap` and a `JavaOnlyArray`.
  * Compare the printed values with the passed content.

**Please advise if there is an automated test suite where I could add a case for this.**