### PR TITLE
Use integer types in "to{HashMap,ArrayList}" when possible

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/ReadableNativeArray.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/ReadableNativeArray.java
@@ -64,7 +64,15 @@ public class ReadableNativeArray extends NativeArray implements ReadableArray {
           arrayList.add(getBoolean(i));
           break;
         case Number:
-          arrayList.add(getDouble(i));
+          Double aDouble = getDouble(i);
+          if (Math.rint(aDouble) == aDouble) {
+            // WARNING: doubles have 64-bits, but the IEEE 754 encoding
+            // means we can only store integers of up to 52-bits.
+            // (This is still better than using 32-bit integers).
+            arrayList.add(aDouble.longValue());
+          } else {
+            arrayList.add(aDouble);
+          }
           break;
         case String:
           arrayList.add(getString(i));

--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/ReadableNativeMap.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/ReadableNativeMap.java
@@ -71,7 +71,15 @@ public class ReadableNativeMap extends NativeMap implements ReadableMap {
           hashMap.put(key, getBoolean(key));
           break;
         case Number:
-          hashMap.put(key, getDouble(key));
+          Double aDouble = getDouble(key);
+          if (Math.rint(aDouble) == aDouble) {
+            // WARNING: doubles have 64-bits, but the IEEE 754 encoding
+            // means we can only store integers of up to 52-bits.
+            // (This is still better than using 32-bit integers).
+            hashMap.put(key, aDouble.longValue());
+          } else {
+            hashMap.put(key, aDouble);
+          }
           break;
         case String:
           hashMap.put(key, getString(key));


### PR DESCRIPTION
Thanks for submitting a PR! Please read these instructions carefully:

- [x] Explain the **motivation** for making this change.
- [x] Provide a **test plan** demonstrating that the code is solid.
- [x] Match the **code formatting** of the rest of the codebase.
- [x] Target the `master` branch, NOT a "stable" branch.

## Motivation

The "to{HashMap,ArrayList}" methods translate a JS object/array
into a Java Map/List. These methods, however, only translate JS
numbers into Java doubles - even if they could be represented
as longs

This change enhances this translation to use Java longs when
possible, and fall-back to doubles when the value cannot be
fully represented as a long integer

On the other hand, even though JS's number type is encoded as a
double-precision float, Java _does_ have an integral type, and
an accurate translation into Java types does not need to treat
all numbers as double

## Test Plan

* Write a native module that receives a `RenderableMap` and a `RenderableArray`.
* In the native module, print the values as Strings, using the `toString` method.
* Call the native module from JS, passing an object and an array that contain an integer number (e.g., `[2]`).
* Check that the printed value for the integer number does not include decimals (e.g., `"2"` instead of `"2.0"`).

**Please advise if there is an automated test suite where I could add a case for this.**