### PR TITLE
14081 mute yarn check error on Windows

### DIFF
--- a/react-native-cli/index.js
+++ b/react-native-cli/index.js
@@ -87,7 +87,7 @@ function getYarnVersionIfAvailable() {
   try {
     // execSync returns a Buffer -> convert to string
     if (process.platform.startsWith('win')) {
-      yarnVersion = (execSync('yarn --version').toString() || '').trim();
+      yarnVersion = (execSync('yarn --version 2> NUL').toString() || '').trim();
     } else {
       yarnVersion = (execSync('yarn --version 2>/dev/null').toString() || '').trim();
     }


### PR DESCRIPTION
Thanks for submitting a PR! Please read these instructions carefully:

- [x] Explain the **motivation** for making this change.
- [x] Provide a **test plan** demonstrating that the code is solid.
- [x] Match the **code formatting** of the rest of the codebase.
- [x] Target the `master` branch, NOT a "stable" branch.

## Motivation (required)

Fixes #14081. Prevents unnecessary error output on check for yarn package manager on Windows systems.

## Test Plan (required)

Can't find existing tests for the CLI and JavaScript doesn't have much knowledge about this change anyhow. 

Example behavior with and without the fix:

![image](https://cloud.githubusercontent.com/assets/4138357/26280348/2baeace0-3d95-11e7-9e5e-5042fb61203e.png)

Note that on master, the output contains the line "'yarn' is not recognized as an internal or external command, operable program or batch file." and on my branch, it does not.

## Next Steps

Sign the [CLA][2], if you haven't already.

Small pull requests are much easier to review and more likely to get merged. Make sure the PR does only one thing, otherwise please split it.

Make sure all **tests pass** on both [Travis][3] and [Circle CI][4]. PRs that break tests are unlikely to be merged.

For more info, see the ["Pull Requests"][5] section of our "Contributing" guidelines.

[1]: https://medium.com/@martinkonicek/what-is-a-test-plan-8bfc840ec171#.y9lcuqqi9
[2]: https://code.facebook.com/cla
[3]: https://travis-ci.org/facebook/react-native
[4]: http://circleci.com/gh/facebook/react-native
[5]: https://github.com/facebook/react-native/blob/master/CONTRIBUTING.md#pull-requests
