### PR TITLE
Fix Travis podspec CI for Cxx bridge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,25 +3,21 @@ language: objective-c
 osx_image: xcode8.3
 
 install:
-  - mkdir -p /Users/travis/build/facebook/.nvm
-  - export NVM_DIR="/Users/travis/build/facebook/.nvm"
-  - brew install nvm
-  - source $(brew --prefix nvm)/nvm.sh
-  # TODO npm 2 started stalling on Travis, t11852928
-
-  # Use node 6 because that is what runs on land-blocking tests
-  - nvm install 6
+  - nvm install 7
   - rm -Rf "${TMPDIR}/jest_preprocess_cache"
   - wget https://github.com/yarnpkg/yarn/releases/download/v0.16.0/yarn-0.16.0.js
   - export yarn="node $(pwd)/yarn-0.16.0.js"
   - $yarn install
 
 script:
-  - if [[ "$TEST_TYPE" = objc-ios ]]; then travis_retry travis_wait ./scripts/objc-test-ios.sh test; fi
-  - if [[ "$TEST_TYPE" = objc-tvos ]]; then travis_retry travis_wait ./scripts/objc-test-tvos.sh; fi
+  - if [[ "$TEST_TYPE" = objc-ios ]]; then travis_retry travis_wait 30 ./scripts/objc-test-ios.sh test; fi
+  - if [[ "$TEST_TYPE" = objc-tvos ]]; then travis_retry travis_wait 30 ./scripts/objc-test-tvos.sh; fi
   - if [[ "$TEST_TYPE" = e2e-objc ]]; then node ./scripts/run-ci-e2e-tests.js --ios --js --retries 3; fi
-  - if [[ ( "$TEST_TYPE" = podspecs ) && ( "$TRAVIS_PULL_REQUEST" = "false" ) ]]; then gem install cocoapods && ./scripts/process-podspecs.sh; fi
+  - if [[ "$TEST_TYPE" = podspecs ]]; then gem install cocoapods && travis_wait 30 ./scripts/process-podspecs.sh; fi
 
+cache:
+  - cocoapods
+  - yarn
 
 matrix:
   - fast_finish: true # Fail the whole build as soon as one test type fails. Should help with Travis capacity issues (very long queues).
@@ -41,7 +37,6 @@ branches:
 notifications:
   email:
     recipients:
-      - mkonicek@fb.com
       - douglowder@mac.com # Doug Lowder built and maintains Apple TV specific code and wants to be notified about tvOS failures.
       - eloy@artsy.net # Eloy Durán maintains the podspecs test and wants to be notified about failures.
     on_failure: change

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ script:
   - if [[ "$TEST_TYPE" = objc-ios ]]; then travis_retry travis_wait 30 ./scripts/objc-test-ios.sh test; fi
   - if [[ "$TEST_TYPE" = objc-tvos ]]; then travis_retry travis_wait 30 ./scripts/objc-test-tvos.sh; fi
   - if [[ "$TEST_TYPE" = e2e-objc ]]; then node ./scripts/run-ci-e2e-tests.js --ios --js --retries 3; fi
-  - if [[ "$TEST_TYPE" = podspecs ]]; then gem install cocoapods && travis_wait 30 ./scripts/process-podspecs.sh; fi
+  - if [[ ( "$TEST_TYPE" = podspecs ) && ( "$TRAVIS_PULL_REQUEST" = "false" ) ]]; then gem install cocoapods && travis_wait 30 ./scripts/process-podspecs.sh; fi
 
 cache:
   - cocoapods

--- a/React.podspec
+++ b/React.podspec
@@ -44,7 +44,16 @@ Pod::Spec.new do |s|
   s.subspec "Core" do |ss|
     ss.dependency             "Yoga", "#{package["version"]}.React"
     ss.source_files         = "React/**/*.{c,h,m,mm,S}"
-    ss.exclude_files        = "**/__tests__/*", "IntegrationTests/*", "React/DevSupport/*", "React/**/RCTTVView.*", "ReactCommon/yoga/*", "React/Cxx*/*", "React/Base/RCTBatchedBridge.mm", "React/Executors/*"
+    ss.exclude_files        = "**/__tests__/*",
+                              "IntegrationTests/*",
+                              "React/DevSupport/*",
+                              "React/Inspector/*",
+                              "React/**/RCTTVView.*",
+                              "ReactCommon/yoga/*",
+                              "React/Cxx*/*",
+                              "React/Base/RCTBatchedBridge.mm",
+                              "React/Executors/*"
+    ss.header_dir           = "React"
     ss.framework            = "JavaScriptCore"
     ss.libraries            = "stdc++"
     ss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\"" }
@@ -68,7 +77,8 @@ Pod::Spec.new do |s|
   s.subspec "DevSupport" do |ss|
     ss.dependency             "React/Core"
     ss.dependency             "React/RCTWebSocket"
-    ss.source_files         = "React/DevSupport/*"
+    ss.source_files         = "React/DevSupport/*",
+                              "React/Inspector/*"
   end
 
   s.subspec "tvOS" do |ss|
@@ -187,5 +197,10 @@ Pod::Spec.new do |s|
     ss.dependency             "React/Core"
     ss.source_files         = "Libraries/RCTTest/**/*.{h,m}"
     ss.frameworks           = "XCTest"
+  end
+
+  s.subspec "_ignore_me_subspec_for_linting_" do |ss|
+    ss.dependency             "React/Core"
+    ss.dependency             "React/CxxBridge"
   end
 end

--- a/React/Modules/RCTDevSettings.mm
+++ b/React/Modules/RCTDevSettings.mm
@@ -18,7 +18,6 @@
 #import "RCTBridge+Private.h"
 #import "RCTBridgeModule.h"
 #import "RCTEventDispatcher.h"
-#import "RCTInspectorDevServerHelper.h"
 #import "RCTJSCSamplingProfiler.h"
 #import "RCTJSEnvironment.h"
 #import "RCTLog.h"
@@ -42,6 +41,12 @@ NSString *const kRCTDevSettingsUserDefaultsKey = @"RCTDevMenu";
 
 #if ENABLE_PACKAGER_CONNECTION
 #import "RCTPackagerConnection.h"
+#endif
+
+#define ENABLE_INSPECTOR RCT_DEV && __has_include("RCTInspectorDevServerHelper")
+
+#if ENABLE_INSPECTOR
+#import "RCTInspectorDevServerHelper.h"
 #endif
 
 #if RCT_DEV
@@ -162,7 +167,7 @@ RCT_EXPORT_MODULE()
   _bridge = bridge;
   [self _configurePackagerConnection];
 
-#if RCT_DEV
+#if ENABLE_INSPECTOR
   // we need this dispatch back to the main thread because even though this
   // is executed on the main thread, at this point the bridge is not yet
   // finished with its initialisation. But it does finish by the time it

--- a/scripts/objc-test-ios.sh
+++ b/scripts/objc-test-ios.sh
@@ -15,7 +15,7 @@ cd "$ROOT"
 
 SCHEME="RNTester"
 SDK="iphonesimulator"
-DESTINATION="platform=iOS Simulator,name=iPhone 5s,OS=10.1"
+DESTINATION="platform=iOS Simulator,name=iPhone 5s,OS=10.3.1"
 
-# If there is a "test" argument, pass it to the test script.
+# If there's a "test" argument, pass it to the test script.
 . ./scripts/objc-test.sh $1

--- a/scripts/objc-test-tvos.sh
+++ b/scripts/objc-test-tvos.sh
@@ -15,7 +15,7 @@ cd "$ROOT"
 
 SCHEME="RNTester-tvOS"
 SDK="appletvsimulator"
-DESTINATION="platform=tvOS Simulator,name=Apple TV 1080p,OS=10.1"
+DESTINATION="platform=tvOS Simulator,name=Apple TV 1080p,OS=10.2"
 
 # If there's a "test" argument, pass it to the test script.
 . ./scripts/objc-test.sh $1

--- a/scripts/process-podspecs.sh
+++ b/scripts/process-podspecs.sh
@@ -3,7 +3,6 @@ set -ex
 
 SCRIPTS=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 ROOT=$(dirname $SCRIPTS)
-YOGA_ROOT="$ROOT/ReactCommon/yoga"
 
 # Specify `SPEC_REPO` as an env variable if you want to push to a specific spec repo.
 # Defaults to `react-test`, which is meant to be a dummy repo used to test that the specs fully lint.
@@ -14,17 +13,17 @@ SPEC_REPO_DIR="$HOME/.cocoapods/repos/$SPEC_REPO"
 if ! [ -d "$SPEC_REPO_DIR" ]; then
   mkdir -p "$SPEC_REPO_DIR"
   cd "$SPEC_REPO_DIR"
-  echo "testing" > .gitkeep
+  touch .gitkeep
   git init
-  git add .gitkeep
+  git add .
   git commit -m "init"
   git remote add origin "https://example.com/$SPEC_REPO.git"
 fi
 
 cd "$SPEC_REPO_DIR"
-SPEC_REPO_REMOTE=$(git remote get-url origin)
+SPEC_REPOS="$(git remote get-url origin),https://github.com/CocoaPods/Specs.git"
 
-POD_LINT_OPT="--verbose --allow-warnings --fail-fast --private --swift-version=3.0 --sources=$SPEC_REPO_REMOTE"
+POD_LINT_OPT="--verbose --allow-warnings --fail-fast --private --swift-version=3.0 --sources=$SPEC_REPOS"
 
 # Get the version from a podspec.
 version() {
@@ -33,8 +32,12 @@ version() {
 
 # Lint both framework and static library builds.
 lint() {
-  pod lib lint $POD_LINT_OPT
-  pod lib lint $POD_LINT_OPT --use-libraries
+  local SUBSPEC=$1
+  if [ "${SUBSPEC:-}" ]; then
+    local SUBSPEC_OPT="--subspec=$SUBSPEC"
+  fi
+  pod lib lint $SUBSPEC_OPT $POD_LINT_OPT
+  pod lib lint $SUBSPEC_OPT $POD_LINT_OPT --use-libraries
 }
 
 # Push the spec in arg `$1`, which is expected to be in the cwd, to the `SPEC_REPO` in JSON format.
@@ -52,11 +55,17 @@ push() {
 process() {
   cd $1
   if [ -z "$SKIP_LINT" ]; then
-    lint
+    lint $2
   fi
   local SPEC_NAME=(*.podspec)
   push $SPEC_NAME
 }
 
-process $YOGA_ROOT
-process $ROOT
+# Make third-party deps accessible
+cd "$ROOT/third-party-podspecs"
+push Folly.podspec
+push DoubleConversion.podspec
+push GLog.podspec
+
+process "$ROOT/ReactCommon/yoga"
+process "$ROOT" _ignore_me_subspec_for_linting_


### PR DESCRIPTION
Fixed the test script to properly setup our third-party deps and tweaked the third-party specs a bit so they work correctly.

This currently works for projects using static libraries, but fails when using dynamic libraries (`--use-libraries`)

cc @mhorowitz @alloy 