### PR TITLE
Android: Support setting background color on ARTSurfaceView

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/art/ARTSurfaceViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/art/ARTSurfaceViewManager.java
@@ -64,4 +64,12 @@ public class ARTSurfaceViewManager extends
   public void updateExtraData(ARTSurfaceView root, Object extraData) {
     root.setSurfaceTextureListener((ARTSurfaceViewShadowNode) extraData);
   }
+
+  @Override
+  public void setBackgroundColor(ARTSurfaceView view, int backgroundColor) {
+    // As of Android N TextureView does not support calling setBackground on it.
+    // It will also throw an exception when target SDK is set to N or higher.
+
+    // Setting the background color for this view is handled in the shadow node.
+  }
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/art/ARTSurfaceViewShadowNode.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/art/ARTSurfaceViewShadowNode.java
@@ -35,15 +35,11 @@ public class ARTSurfaceViewShadowNode extends LayoutShadowNode
 
   private @Nullable Surface mSurface;
 
-  private boolean mIsBackgroundColorSet;
-  private int mBackgroundColor;
+  private @Nullable Integer mBackgroundColor;
 
   @ReactProp(name = ViewProps.BACKGROUND_COLOR, customType = "Color")
   public void setBackgroundColor(Integer color) {
-    mIsBackgroundColorSet = (color != null);
-    if (mIsBackgroundColorSet) {
-      mBackgroundColor = color;
-    }
+    mBackgroundColor = color;
     markUpdated();
   }
 
@@ -73,7 +69,7 @@ public class ARTSurfaceViewShadowNode extends LayoutShadowNode
     try {
       Canvas canvas = mSurface.lockCanvas(null);
       canvas.drawColor(Color.TRANSPARENT, PorterDuff.Mode.CLEAR);
-      if (mIsBackgroundColorSet) {
+      if (mBackgroundColor != null) {
         canvas.drawColor(mBackgroundColor);
       }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/views/art/ARTSurfaceViewShadowNode.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/art/ARTSurfaceViewShadowNode.java
@@ -24,6 +24,8 @@ import com.facebook.react.common.ReactConstants;
 import com.facebook.react.uimanager.LayoutShadowNode;
 import com.facebook.react.uimanager.UIViewOperationQueue;
 import com.facebook.react.uimanager.ReactShadowNode;
+import com.facebook.react.uimanager.ViewProps;
+import com.facebook.react.uimanager.annotations.ReactProp;
 
 /**
  * Shadow node for ART virtual tree root - ARTSurfaceView
@@ -32,6 +34,18 @@ public class ARTSurfaceViewShadowNode extends LayoutShadowNode
   implements TextureView.SurfaceTextureListener {
 
   private @Nullable Surface mSurface;
+
+  private boolean mIsBackgroundColorSet;
+  private int mBackgroundColor;
+
+  @ReactProp(name = ViewProps.BACKGROUND_COLOR, customType = "Color")
+  public void setBackgroundColor(Integer color) {
+    mIsBackgroundColorSet = (color != null);
+    if (mIsBackgroundColorSet) {
+      mBackgroundColor = color;
+    }
+    markUpdated();
+  }
 
   @Override
   public boolean isVirtual() {
@@ -59,6 +73,9 @@ public class ARTSurfaceViewShadowNode extends LayoutShadowNode
     try {
       Canvas canvas = mSurface.lockCanvas(null);
       canvas.drawColor(Color.TRANSPARENT, PorterDuff.Mode.CLEAR);
+      if (mIsBackgroundColorSet) {
+        canvas.drawColor(mBackgroundColor);
+      }
 
       Paint paint = new Paint();
       for (int i = 0; i < getChildCount(); i++) {


### PR DESCRIPTION
This fixes support for the `backgroundColor` style prop on an `ART.Surface`.

`ARTSurfaceViewManager` inherits its `setBackgroundColor` implementation from `BaseViewManager`. This implementation broke in API 24 because API 24 removed support for `setBackgroundColor`on `TextureViews`. `ARTSurfaceView` inherits from `TextureView` so it also lost support for `setBackgroundColor`.

To fix this, the implementation of `ART.Surface's` `setBackgroundColor` was moved to the shadow node. The implementation now draws the background color on the canvas.

## Test Plan (required)

In a test app, verified that initializing and changing the background color on an `ART.Surface` works. Verified that the background renders as transparent when a background color isn't set. Also, this change is being used in my team's app.

Adam Comella
Microsoft Corp.
