### PR TITLE
Revert to pre-0.44 XHR default credentials for iOS

### DIFF
--- a/Libraries/Network/fetch.js
+++ b/Libraries/Network/fetch.js
@@ -13,5 +13,20 @@
 'use strict';
 
 import 'whatwg-fetch';
+const Platform = require('Platform');
 
-module.exports = {fetch, Headers, Request, Response};
+const DEFAULT_CREDENTIALS = Platform.OS === 'ios' ? 'include' : 'omit';
+
+const fetchWithCredentialsDefault = (input, init) => {
+  if (input.credentials == null) {
+    return fetch({ ...input, credentials: DEFAULT_CREDENTIALS }, init);
+  }
+  return fetch(input, init);
+}
+
+module.exports = {
+  fetch: fetchWithCredentialsDefault,
+  Headers,
+  Request,
+  Response
+};


### PR DESCRIPTION
Addresses https://github.com/facebook/react-native/issues/14063

([454ab8](https://github.com/facebook/react-native/commit/454ab8fc238da16f9c3986d9a64ea8e716ac0bac#diff-10faae6fe100efe7101c16fe93478084R122)) in RN 0.44 changed the default XHR credentials behavior on iOS. This change reverts the default behavior on iOS while still retaining the ability to manually provide credentials. On Android the withCredentials were always properly handled, which is why it defaults to 'omit'

Another question: does it really make sense to fork based on the platform here? The only reason we're doing this is to retain the pre-0.44 behavior.