### PR TITLE
Clarify documentation for ScrollView component

### DIFF
--- a/Libraries/Components/ScrollView/ScrollView.js
+++ b/Libraries/Components/ScrollView/ScrollView.js
@@ -250,8 +250,10 @@ const ScrollView = React.createClass({
      */
     pagingEnabled: PropTypes.bool,
     /**
-     * When false, the content does not scroll.
+     * When false, the view cannot be scrolled via touch interaction.
      * The default value is true.
+     *
+     * Note that the view can be always be scrolled by calling `scrollTo`.
      */
     scrollEnabled: PropTypes.bool,
     /**


### PR DESCRIPTION
The documentation for the prop `scrollEnabled` on the `ScrollView` component does not clarify that scrolling is still possible by calling `scrollTo` on the view ref.

Please see [this expo snack demo](https://snack.expo.io/BJKTVMM-Z) showing scrolling is allowed while `scrollEnabled` is `false`.

This PR makes the documentation for this prop more clear, in that setting it to false will only disable scrolling by touches, not universally.

In my opinion, this also raises the question of a need for an additional prop which would disable all scrolling, even when calling `scrollTo`.

I have attached a screenshot of what this part of the documentation looks like with my edit:

![screen shot 2017-05-23 at 3 38 59 pm](https://cloud.githubusercontent.com/assets/4976096/26374045/e73a035e-3fd1-11e7-93cd-3617c4ac4db8.png)


