### PR TITLE
fix memory leak

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
@@ -52,7 +52,7 @@ import static com.facebook.systrace.Systrace.TRACE_TAG_REACT_JAVA_BRIDGE;
  * It delegates handling touch events for itself and child views and sending those events to JS by
  * using JSTouchDispatcher.
  * This view is overriding {@link ViewGroup#onInterceptTouchEvent} method in order to be notified
- * about the events for all of it's children and it's also overriding
+ * about the events for all of its children and it's also overriding
  * {@link ViewGroup#requestDisallowInterceptTouchEvent} to make sure that
  * {@link ViewGroup#onInterceptTouchEvent} will get events even when some child view start
  * intercepting it. In case when no child view is interested in handling some particular

--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/CatalystInstanceImpl.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/CatalystInstanceImpl.java
@@ -24,12 +24,14 @@ import com.facebook.infer.annotation.Assertions;
 import com.facebook.jni.HybridData;
 import com.facebook.proguard.annotations.DoNotStrip;
 import com.facebook.react.bridge.queue.MessageQueueThread;
+import com.facebook.react.bridge.queue.MessageQueueThreadRegistry;
 import com.facebook.react.bridge.queue.QueueThreadExceptionHandler;
 import com.facebook.react.bridge.queue.ReactQueueConfiguration;
 import com.facebook.react.bridge.queue.ReactQueueConfigurationImpl;
 import com.facebook.react.bridge.queue.ReactQueueConfigurationSpec;
 import com.facebook.react.common.ReactConstants;
 import com.facebook.react.common.annotations.VisibleForTesting;
+import com.facebook.react.uimanager.ViewManagerPropertyUpdater;
 import com.facebook.soloader.SoLoader;
 import com.facebook.systrace.Systrace;
 import com.facebook.systrace.TraceListener;
@@ -296,6 +298,9 @@ public class CatalystInstanceImpl implements CatalystInstance {
         mHybridData.resetNative();
       }
     });
+
+    MessageQueueThreadRegistry.clear();
+    ViewManagerPropertyUpdater.clear();
 
     // This is a noop if the listener was not yet registered.
     Systrace.unregisterListener(mTraceListener);

--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/queue/MessageQueueThreadRegistry.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/queue/MessageQueueThreadRegistry.java
@@ -35,5 +35,9 @@ public class MessageQueueThreadRegistry {
         sMyMessageQueueThread.get(),
         "This thread doesn't have a MessageQueueThread registered to it!");
   }
+
+  public static void clear() {
+    sMyMessageQueueThread.remove();
+  }
 }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManagerPropertyUpdater.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManagerPropertyUpdater.java
@@ -30,6 +30,12 @@ public class ViewManagerPropertyUpdater {
       new HashMap<>();
   private static final Map<Class<?>, ShadowNodeSetter<?>> SHADOW_NODE_SETTER_MAP = new HashMap<>();
 
+  public static void clear() {
+    ViewManagersPropertyCache.clear();
+    VIEW_MANAGER_SETTER_MAP.clear();
+    SHADOW_NODE_SETTER_MAP.clear();
+  }
+
   public static <T extends ViewManager, V extends View> void updateProps(
       T manager,
       V v,

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManagersPropertyCache.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManagersPropertyCache.java
@@ -28,6 +28,11 @@ import com.facebook.react.uimanager.annotations.ReactPropGroup;
   private static final Map<Class, Map<String, PropSetter>> CLASS_PROPS_CACHE = new HashMap<>();
   private static final Map<String, PropSetter> EMPTY_PROPS_MAP = new HashMap<>();
 
+  public static void clear() {
+    CLASS_PROPS_CACHE.clear();
+    EMPTY_PROPS_MAP.clear();
+  }
+
   /*package*/ static abstract class PropSetter {
 
     protected final String mPropName;


### PR DESCRIPTION
Signed-off-by: yk3372 <yk3372@gmail.com>

## Motivation (required)

What existing problem does the pull request solve?

ViewManagersPropertyCache, ViewManagerPropertyUpdater, MessageQueueThreadRegistry static field not release when ReactInstanceManager called destroy.

## Test Plan (required)

I use this url to integrate RN:
[http://facebook.github.io/react-native/docs/integration-with-existing-apps.html](http://facebook.github.io/react-native/docs/integration-with-existing-apps.html)
and in Activity's onDestroy function add the follow code to release RN:
```java
mReactInstanceManager.destroy();
mReactInstanceManager = null;
```
and then when I exit activity, find the static field not release.
the follow is screen shot:
before:
![2017-05-23 17 41 16](https://cloud.githubusercontent.com/assets/1514899/26350318/53ea250c-3fe5-11e7-8eda-a0dcc20ba4f6.jpg)
after:
![2017-05-23 17 38 49](https://cloud.githubusercontent.com/assets/1514899/26350329/5e5b273e-3fe5-11e7-9b0b-a8b0e044abf3.jpg)

