### PR TITLE
iOS: Support corner-specific border radii on Images

### DIFF
--- a/Libraries/Image/RCTImageView.h
+++ b/Libraries/Image/RCTImageView.h
@@ -25,4 +25,13 @@
 @property (nonatomic, assign) CGFloat blurRadius;
 @property (nonatomic, assign) RCTResizeMode resizeMode;
 
+/**
+ * Border radii.
+ */
+@property (nonatomic, assign) CGFloat borderRadius;
+@property (nonatomic, assign) CGFloat borderTopLeftRadius;
+@property (nonatomic, assign) CGFloat borderTopRightRadius;
+@property (nonatomic, assign) CGFloat borderBottomLeftRadius;
+@property (nonatomic, assign) CGFloat borderBottomRightRadius;
+
 @end

--- a/docs/Images.md
+++ b/docs/Images.md
@@ -176,15 +176,6 @@ return (
 );
 ```
 
-## iOS Border Radius Styles
-
-Please note that the following corner specific, border radius style properties are currently ignored by iOS's image component:
-
-* `borderTopLeftRadius`
-* `borderTopRightRadius`
-* `borderBottomLeftRadius`
-* `borderBottomRightRadius`
-
 ## Off-thread Decoding
 
 Image decoding can take more than a frame-worth of time. This is one of the major sources of frame drops on the web because decoding is done in the main thread. In React Native, image decoding is done in a different thread. In practice, you already need to handle the case when the image is not downloaded yet, so displaying the placeholder for a few more frames while it is decoding does not require any code change.


### PR DESCRIPTION
This adds support for corner-specific radii on Images on iOS. Specifically, these props:
  - `borderTopLeftRadius`
  - `borderTopRightRadius`
  - `borderBottomLeftRadius`
  - `borderBottomRightRadius`

This feature is already supported on Android.

Most of the logic was copied from `RCTView`.

## Test Plan (required)

I made a test app where I set `borderRadius` and the corner-specific border radius props mentioned above to a variety of values including `undefined` and ensured the `Image` rendered correctly. I tested initial values as well as updates. Additionally, my team is using this change in our app.

Adam Comella
Microsoft Corp.