### PR TITLE
[FlatList] Pass data prop instead of props to _updateViewableItems in _onScroll

### DIFF
--- a/Libraries/Lists/VirtualizedList.js
+++ b/Libraries/Lists/VirtualizedList.js
@@ -723,7 +723,7 @@ class VirtualizedList extends React.PureComponent<OptionalProps, Props, State> {
     const dOffset = offset - this._scrollMetrics.offset;
     const velocity = dOffset / dt;
     this._scrollMetrics = {contentLength, dt, dOffset, offset, timestamp, velocity, visibleLength};
-    this._updateViewableItems(this.props);
+    this._updateViewableItems(this.props.data);
     if (!this.props) {
       return;
     }


### PR DESCRIPTION
## Motivation

This is a simple bugfix. `_updateViewableItems` expects the `data` prop, as it calls `getItemCount` on it. Without this, `onViewableItemsChanged` updates twice for each scroll position, once from `_onScroll` with the incorrect results, and once from `_updateCellsToRender` with the correct results. This means the callback nigh-on unusable.

## Test Plan

I simply logged the results of `onViewableItemsChanged` and made sure they were correct.