### PR TITLE
iOS: Introduce API for making screen reader announcements

### DIFF
--- a/Libraries/Components/AccessibilityInfo/AccessibilityInfo.ios.js
+++ b/Libraries/Components/AccessibilityInfo/AccessibilityInfo.ios.js
@@ -18,9 +18,11 @@ var RCTDeviceEventEmitter = require('RCTDeviceEventEmitter');
 var AccessibilityManager = NativeModules.AccessibilityManager;
 
 var VOICE_OVER_EVENT = 'voiceOverDidChange';
+var ANNOUNCEMENT_DID_FINISH_EVENT = 'announcementDidFinish';
 
 type ChangeEventName = $Enum<{
   change: string,
+  announcementFinished: string
 }>;
 
 var _subscriptions = new Map();
@@ -97,15 +99,30 @@ var AccessibilityInfo = {
    * - `change`: Fires when the state of the screen reader changes. The argument
    *   to the event handler is a boolean. The boolean is `true` when a screen
    *   reader is enabled and `false` otherwise.
+   * - `announcementFinished`: iOS-only event. Fires when the screen reader has
+   *   finished making an announcement. The argument to the event handler is a dictionary
+   *   with these keys:
+   *     - `announcement`: The string announced by the screen reader.
+   *     - `success`: A boolean indicating whether the announcement was successfully made.
    */
   addEventListener: function (
     eventName: ChangeEventName,
     handler: Function
   ): Object {
-    var listener = RCTDeviceEventEmitter.addListener(
-      VOICE_OVER_EVENT,
-      handler
-    );
+    var listener; 
+    
+    if (eventName === 'change') {
+      listener = RCTDeviceEventEmitter.addListener(
+        VOICE_OVER_EVENT,
+        handler
+      );
+    } else if (eventName === 'announcementFinished') {
+      listener = RCTDeviceEventEmitter.addListener(
+        ANNOUNCEMENT_DID_FINISH_EVENT,
+        handler
+      );
+    }
+
     _subscriptions.set(handler, listener);
     return {
       remove: AccessibilityInfo.removeEventListener.bind(null, eventName, handler),
@@ -119,6 +136,15 @@ var AccessibilityInfo = {
     reactTag: number
   ): void {
     AccessibilityManager.setAccessibilityFocus(reactTag);
+  },
+
+  /**
+   * iOS-Only. Post a string to be announced by the screen reader. 
+   */
+  announceForAccessibility: function(
+    announcement: string
+  ): void {
+    AccessibilityManager.announceForAccessibility(announcement);
   },
 
   /**

--- a/Libraries/Components/AccessibilityInfo/AccessibilityInfo.ios.js
+++ b/Libraries/Components/AccessibilityInfo/AccessibilityInfo.ios.js
@@ -109,8 +109,8 @@ var AccessibilityInfo = {
     eventName: ChangeEventName,
     handler: Function
   ): Object {
-    var listener; 
-    
+    var listener;
+
     if (eventName === 'change') {
       listener = RCTDeviceEventEmitter.addListener(
         VOICE_OVER_EVENT,
@@ -139,7 +139,7 @@ var AccessibilityInfo = {
   },
 
   /**
-   * iOS-Only. Post a string to be announced by the screen reader. 
+   * iOS-Only. Post a string to be announced by the screen reader.
    */
   announceForAccessibility: function(
     announcement: string

--- a/React/Modules/RCTAccessibilityManager.m
+++ b/React/Modules/RCTAccessibilityManager.m
@@ -71,6 +71,11 @@ RCT_EXPORT_MODULE()
                                              selector:@selector(didReceiveNewVoiceOverStatus:)
                                                  name:UIAccessibilityVoiceOverStatusChanged
                                                object:nil];
+    
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(accessibilityAnnouncementDidFinish:)
+                                                 name:UIAccessibilityAnnouncementDidFinishNotification
+                                               object:nil];
 
     self.contentSizeCategory = RCTSharedApplication().preferredContentSizeCategory;
     _isVoiceOverEnabled = UIAccessibilityIsVoiceOverRunning();
@@ -99,6 +104,20 @@ RCT_EXPORT_MODULE()
                                                 body:@(_isVoiceOverEnabled)];
 #pragma clang diagnostic pop
   }
+}
+
+- (void)accessibilityAnnouncementDidFinish:(__unused NSNotification *)notification
+{
+  NSDictionary *userInfo = notification.userInfo;
+  // Response dictionary to populate the event with.
+  NSDictionary *response = @{@"announcement": userInfo[@"UIAccessibilityAnnouncementKeyStringValue"],
+                              @"success": userInfo[@"UIAccessibilityAnnouncementKeyWasSuccessful"]};
+    
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+  [_bridge.eventDispatcher sendDeviceEventWithName:@"announcementDidFinish"
+                                              body:response];
+#pragma clang diagnostic pop
 }
 
 - (void)setContentSizeCategory:(NSString *)contentSizeCategory
@@ -169,6 +188,11 @@ RCT_EXPORT_METHOD(setAccessibilityFocus:(nonnull NSNumber *)reactTag)
     UIView *view = [self.bridge.uiManager viewForReactTag:reactTag];
     UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, view);
   });
+}
+
+RCT_EXPORT_METHOD(announceForAccessibility:(NSString *)announcement)
+{
+  UIAccessibilityPostNotification(UIAccessibilityAnnouncementNotification, announcement);
 }
 
 RCT_EXPORT_METHOD(getMultiplier:(RCTResponseSenderBlock)callback)

--- a/React/Modules/RCTAccessibilityManager.m
+++ b/React/Modules/RCTAccessibilityManager.m
@@ -110,8 +110,8 @@ RCT_EXPORT_MODULE()
 {
   NSDictionary *userInfo = notification.userInfo;
   // Response dictionary to populate the event with.
-  NSDictionary *response = @{@"announcement": userInfo[@"UIAccessibilityAnnouncementKeyStringValue"],
-                              @"success": userInfo[@"UIAccessibilityAnnouncementKeyWasSuccessful"]};
+  NSDictionary *response = @{@"announcement": userInfo[UIAccessibilityAnnouncementKeyStringValue],
+                              @"success": userInfo[UIAccessibilityAnnouncementKeyWasSuccessful]};
     
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"


### PR DESCRIPTION
This change introduces some APIs that are useful for making announcements through the screen reader on iOS:
  - `announceForAccessibility`: The screen reader announces the string that is passed in.
  - `announcementFinished`: An event that fires when the screen reader has finished making an announcement.

You can already solve similar problems with RN Android using the `accessibilityLiveRegion` prop. Live regions are a different feature but they can be used to solve the same problem. This commit does not attempt to add live region support in RN iOS because Apple did not build live region support into iOS.

## Test Plan (required)

Verified that `announceForAccessibility` causes VoiceOver to announce the string when VoiceOver is enabled. Verified that `announcementFinished` fires with the appropriate data in the event object. Additionally, my team has been using this change in our app.

Adam Comella
Microsoft Corp.
