### PR TITLE
iOS: Introduce API for moving screen reader's focus

### DIFF
--- a/Libraries/Components/AccessibilityInfo/AccessibilityInfo.ios.js
+++ b/Libraries/Components/AccessibilityInfo/AccessibilityInfo.ios.js
@@ -113,6 +113,15 @@ var AccessibilityInfo = {
   },
 
   /**
+   * iOS-Only. Set accessibility focus to a react component.
+   */
+  setAccessibilityFocus: function(
+    reactTag: number
+  ): void {
+    AccessibilityManager.setAccessibilityFocus(reactTag);
+  },
+
+  /**
    * Remove an event handler.
    */
   removeEventListener: function(

--- a/React/Modules/RCTAccessibilityManager.m
+++ b/React/Modules/RCTAccessibilityManager.m
@@ -9,6 +9,7 @@
 
 #import "RCTAccessibilityManager.h"
 
+#import "RCTUIManager.h"
 #import "RCTBridge.h"
 #import "RCTConvert.h"
 #import "RCTEventDispatcher.h"
@@ -160,6 +161,16 @@ RCT_EXPORT_METHOD(setAccessibilityContentSizeMultipliers:(NSDictionary *)JSMulti
     multipliers[UIKitCategory] = m;
   }
   self.multipliers = multipliers;
+}
+
+RCT_EXPORT_METHOD(setAccessibilityFocus:(nonnull NSNumber *)reactTag)
+{
+  dispatch_async(RCTGetUIManagerQueue(), ^{
+    [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry) {
+      UIView *view = viewRegistry[reactTag];
+      UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, view);
+    }];
+  });
 }
 
 RCT_EXPORT_METHOD(getMultiplier:(RCTResponseSenderBlock)callback)

--- a/React/Modules/RCTAccessibilityManager.m
+++ b/React/Modules/RCTAccessibilityManager.m
@@ -165,11 +165,9 @@ RCT_EXPORT_METHOD(setAccessibilityContentSizeMultipliers:(NSDictionary *)JSMulti
 
 RCT_EXPORT_METHOD(setAccessibilityFocus:(nonnull NSNumber *)reactTag)
 {
-  dispatch_async(RCTGetUIManagerQueue(), ^{
-    [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry) {
-      UIView *view = viewRegistry[reactTag];
-      UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, view);
-    }];
+  dispatch_async(dispatch_get_main_queue(), ^{
+    UIView *view = [self.bridge.uiManager viewForReactTag:reactTag];
+    UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, view);
   });
 }
 


### PR DESCRIPTION
This change introduces an API, `setAccessibilityFocus`, which moves the screen reader's focus to the passed in element. This causes VoiceOver to announce the element and draw a focus rectangle around it.

Similar functionality is already available in RN Android through the `sendAccessibilityEvent` method. Here's an example of what exists today in RN Android:

```
RCTUIManager.sendAccessibilityEvent(
  node,
  8 /* TYPE_VIEW_FOCUSED */);
```

## Test Plan (required)

Called `setAccessibilityFocus` on a couple of elements to verify that focus does indeed move when VoiceOver is enabled. Additionally, my team is using this change in our app.

Adam Comella
Microsoft Corp.