### PR TITLE
iOS: Avoid adding extra spaces to accessibility label

### DIFF
--- a/React/Views/RCTView.m
+++ b/React/Views/RCTView.m
@@ -81,20 +81,17 @@
 
 static NSString *RCTRecursiveAccessibilityLabel(UIView *view)
 {
-  BOOL isFirstIteration = YES;
   NSMutableString *str = [NSMutableString stringWithString:@""];
   for (UIView *subview in view.subviews) {
-    if (isFirstIteration) {
-      isFirstIteration = NO;
-    } else {
-      [str appendString:@" "];
-    }
-    
     NSString *label = subview.accessibilityLabel;
-    if (label) {
+    if (!label) {
+      label = RCTRecursiveAccessibilityLabel(subview);
+    }
+    if (label && label.length > 0) {
+      if (str.length > 0) {
+        [str appendString:@" "];
+      }
       [str appendString:label];
-    } else {
-      [str appendString:RCTRecursiveAccessibilityLabel(subview)];
     }
   }
   return str;


### PR DESCRIPTION
In some cases, `RCTRecursiveAccessibilityLabel` could return an accessibility label that had leading space, trailing space, or multiple spaces between words. This is because it always added a space before adding a label even if the label turned out to be empty.

This is fixed by being stricter about adding spaces.

## Test Plan (required)

Found test cases that used to introduce leading space, trailing space, or multiple spaces between words and verified that there aren't any extra spaces after the fix.

```
{/* Used to have leading space */}
<View accessible={true}>
  <View />
  <View accessibilityLabel='Two' />
  <View accessibilityLabel='Three' />
</View>

{/* Used to have 2 spaces between "One" and "Three" */}
<View accessible={true}>
  <View accessibilityLabel='One' />
  <View />
  <View accessibilityLabel='Three' />
</View>

{/* Used to have trailing space */}
<View accessible={true}>
  <View accessibilityLabel='One' />
  <View accessibilityLabel='Two' />
  <View />
</View>
```

Additionally, my team is using this fix in our app.

Adam Comella
Microsoft Corp.
