### PR TITLE
Fix Incorrect Build Script Bash False-Matching

### DIFF
--- a/scripts/react-native-xcode.sh
+++ b/scripts/react-native-xcode.sh
@@ -100,7 +100,7 @@ $NODE_BINARY $CLI_PATH bundle \
   --bundle-output "$BUNDLE_FILE" \
   --assets-dest "$DEST"
 
-if [[ ! $DEV && ! -f "$BUNDLE_FILE" ]]; then
+if [[ $DEV != true && ! -f "$BUNDLE_FILE" ]]; then
   echo "error: File $BUNDLE_FILE does not exist. This must be a bug with" >&2
   echo "React Native, please report it here: https://github.com/facebook/react-native/issues"
   exit 2


### PR DESCRIPTION
When attempting to inverse a Bash boolean, the `!` character converts the meaning to become `[[ ! -n false ]]` (checking that the string "false" is empty) which never matches, and therefore this condition can never occur.

See https://stackoverflow.com/a/2953673