### PR TITLE
packager: upgrade jest-haste-map version

### DIFF
--- a/package.json
+++ b/package.json
@@ -170,7 +170,7 @@
     "immutable": "~3.7.6",
     "imurmurhash": "^0.1.4",
     "inquirer": "^0.12.0",
-    "jest-haste-map": "19.0.0",
+    "jest-haste-map": "^20.0.4",
     "joi": "^6.6.1",
     "json-stable-stringify": "^1.0.1",
     "json5": "^0.4.0",

--- a/packager/package.json
+++ b/packager/package.json
@@ -25,7 +25,7 @@
     "graceful-fs": "^4.1.3",
     "image-size": "^0.3.5",
     "imurmurhash": "^0.1.4",
-    "jest-haste-map": "18.0.0",
+    "jest-haste-map": "^20.0.4",
     "joi": "^6.6.1",
     "json-stable-stringify": "^1.0.1",
     "json5": "^0.4.0",

--- a/packager/src/node-haste/__tests__/DependencyGraph-test.js
+++ b/packager/src/node-haste/__tests__/DependencyGraph-test.js
@@ -5182,7 +5182,7 @@ describe('DependencyGraph', function() {
       });
     });
 
-    it('should recover from multiple modules with the same name (but this is broken right now)', async () => {
+    it('should recover from multiple modules with the same name', async () => {
       const root = '/root';
       console.warn = jest.fn();
       const filesystem = setMockFileSystem({
@@ -5231,17 +5231,11 @@ describe('DependencyGraph', function() {
         await triggerAndProcessWatchEvent(dgraph, 'change', root + '/b.js');
       }
 
-      // This verifies that it is broken right now. Instead of throwing it should
-      // return correct results. Once this is fixed in `jest-haste`, remove
-      // the whole try catch and verify results are matching a snapshot.
-      try {
-        await getOrderedDependenciesAsJSON(dgraph, root + '/index.js');
-        throw new Error('expected `getOrderedDependenciesAsJSON` to fail');
-      } catch (error) {
-        if (error.type !== 'UnableToResolveError') {
-          throw error;
-        }
-      }
+      const deps = await getOrderedDependenciesAsJSON(
+        dgraph,
+        root + '/index.js',
+      );
+      expect(deps).toMatchSnapshot();
     });
 
   });

--- a/packager/src/node-haste/__tests__/__snapshots__/DependencyGraph-test.js.snap
+++ b/packager/src/node-haste/__tests__/__snapshots__/DependencyGraph-test.js.snap
@@ -1,0 +1,36 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DependencyGraph file watch updating should recover from multiple modules with the same name 1`] = `
+Array [
+  Object {
+    "dependencies": Array [
+      "a",
+      "b",
+    ],
+    "id": "index",
+    "isAsset": false,
+    "isJSON": false,
+    "isPolyfill": false,
+    "path": "/root/index.js",
+    "resolution": undefined,
+  },
+  Object {
+    "dependencies": Array [],
+    "id": "a",
+    "isAsset": false,
+    "isJSON": false,
+    "isPolyfill": false,
+    "path": "/root/a.js",
+    "resolution": undefined,
+  },
+  Object {
+    "dependencies": Array [],
+    "id": "b",
+    "isAsset": false,
+    "isJSON": false,
+    "isPolyfill": false,
+    "path": "/root/b.js",
+    "resolution": undefined,
+  },
+]
+`;

--- a/packager/src/node-haste/index.js
+++ b/packager/src/node-haste/index.js
@@ -103,7 +103,7 @@ class DependencyGraph extends EventEmitter {
     return new JestHasteMap({
       extensions: opts.extensions.concat(opts.assetExts),
       forceNodeFilesystemAPI: opts.forceNodeFilesystemAPI,
-      ignorePattern: {test: opts.ignoreFilePath},
+      ignorePattern: opts.ignoreFilePath,
       maxWorkers: opts.maxWorkerCount,
       mocksPattern: '',
       name: 'react-native-packager-' + JEST_HASTE_MAP_CACHE_BREAKER,


### PR DESCRIPTION
Summary: This allows us to get the new fix for recovery on duplicate modules.

Reviewed By: cpojer

Differential Revision: D5128975

fbshipit-source-id: 5a2b60430bbca1806a97798c482af8522366e071

Thanks for submitting a PR! Please read these instructions carefully:

- [x] Explain the **motivation** for making this change.
- [x] Provide a **test plan** demonstrating that the code is solid.
- [x] Match the **code formatting** of the rest of the codebase.
- [x] Target the `master` branch, NOT a "stable" branch.

## Motivation (required)

What existing problem does the pull request solve?

Version 19.0.0 of jest-haste-map is incompatible with react-native-windows.

## Test Plan (required)

A good test plan has the exact commands you ran and their output, provides screenshots or videos if the pull request changes UI or updates the website. See [What is a Test Plan?][1] to learn more.  

If you have added code that should be tested, add tests.

Tests were already added, this commit is just a cherry-pick.

## Next Steps

Sign the [CLA][2], if you haven't already.

Small pull requests are much easier to review and more likely to get merged. Make sure the PR does only one thing, otherwise please split it.

Make sure all **tests pass** on both [Travis][3] and [Circle CI][4]. PRs that break tests are unlikely to be merged.

For more info, see the ["Pull Requests"][5] section of our "Contributing" guidelines.

[1]: https://medium.com/@martinkonicek/what-is-a-test-plan-8bfc840ec171#.y9lcuqqi9
[2]: https://code.facebook.com/cla
[3]: https://travis-ci.org/facebook/react-native
[4]: http://circleci.com/gh/facebook/react-native
[5]: https://github.com/facebook/react-native/blob/master/CONTRIBUTING.md#pull-requests
