### PR TITLE
packager: adds regression test to ensure arbitrary platforms are supported

### DIFF
--- a/packager/src/node-haste/__tests__/DependencyGraph-test.js
+++ b/packager/src/node-haste/__tests__/DependencyGraph-test.js
@@ -4624,6 +4624,55 @@ describe('DependencyGraph', function() {
       });
     });
 
+    it('should work with arbitrary platforms', function() {
+      var root = '/root';
+      setMockFileSystem({
+        root: {
+          'index.foo.js': `
+            /**
+             * @providesModule index
+             */
+             require('./a');
+          `,
+          'a.ios.js': '',
+          'a.android.js': '',
+          'a.foo.js': '',
+          'a.js': '',
+        },
+      });
+
+      var dgraph = DependencyGraph.load({
+        ...defaults,
+        platforms: new Set(['ios','android','foo']),
+        roots: [root],
+      });
+      return getOrderedDependenciesAsJSON(
+        dgraph,
+        '/root/index.foo.js',
+      ).then(function(deps) {
+        expect(deps).toEqual([
+          {
+            id: 'index',
+            path: 'C:\\root\\index.foo.js',
+            dependencies: ['./a'],
+            isAsset: false,
+            isJSON: false,
+            isPolyfill: false,
+            resolution: undefined,
+          },
+          {
+            id: 'C:\\root\\a.foo.js',
+            path: 'C:\\root\\a.foo.js',
+            dependencies: [],
+            isAsset: false,
+            isJSON: false,
+            isPolyfill: false,
+            resolution: undefined,
+          }
+        ]);
+      });
+    });
+
     it('should require package.json', () => {
       var root = '/root';
       setMockFileSystem({


### PR DESCRIPTION
Thanks for submitting a PR! Please read these instructions carefully:

- [x] Explain the **motivation** for making this change.
- [x] Provide a **test plan** demonstrating that the code is solid.
- [x] Match the **code formatting** of the rest of the codebase.
- [x] Target the `master` branch, NOT a "stable" branch.

## Motivation (required)

A recent upgrade of jest-haste-map caused a regression for react-native-windows.

## Test Plan (required)

This PR is just another unit test.
