### PR TITLE
fix RefreshControl not showing up

### DIFF
--- a/React/Views/RCTRefreshControl.m
+++ b/React/Views/RCTRefreshControl.m
@@ -18,12 +18,17 @@
   UIColor *_titleColor;
 }
 
+static unsigned short defaultHeight;
++(unsigned short) defaultHeight {return defaultHeight; }
++(void) setDefaultHeight:(unsigned short) val { defaultHeight = val; }
+
 - (instancetype)init
 {
   if ((self = [super init])) {
     [self addTarget:self action:@selector(refreshControlValueChanged) forControlEvents:UIControlEventValueChanged];
     _isInitialRender = true;
     _currentRefreshingState = false;
+    RCTRefreshControl.defaultHeight = self.frame.size.height;
   }
   return self;
 }
@@ -52,18 +57,9 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
 {
   // When using begin refreshing we need to adjust the ScrollView content offset manually.
   UIScrollView *scrollView = (UIScrollView *)self.superview;
-  CGPoint offset = {scrollView.contentOffset.x, scrollView.contentOffset.y - self.frame.size.height};
-
-  // `beginRefreshing` must be called after the animation is done. This is why it is impossible
-  // to use `setContentOffset` with `animated:YES`.
-  [UIView animateWithDuration:0.25
-                          delay:0
-                        options:UIViewAnimationOptionBeginFromCurrentState
-                     animations:^(void) {
-                       [scrollView setContentOffset:offset];
-                     } completion:^(__unused BOOL finished) {
-                       [super beginRefreshing];
-                     }];
+  CGPoint offset = {scrollView.contentOffset.x, scrollView.contentOffset.y - RCTRefreshControl.defaultHeight};
+  [scrollView setContentOffset:offset animated:YES];
+  [super beginRefreshing];
 }
 
 - (void)endRefreshing

--- a/React/Views/RCTRefreshControl.m
+++ b/React/Views/RCTRefreshControl.m
@@ -16,11 +16,8 @@
   BOOL _currentRefreshingState;
   NSString *_title;
   UIColor *_titleColor;
+  unsigned short _initialHeight;
 }
-
-static unsigned short defaultHeight;
-+(unsigned short) defaultHeight {return defaultHeight; }
-+(void) setDefaultHeight:(unsigned short) val { defaultHeight = val; }
 
 - (instancetype)init
 {
@@ -28,7 +25,7 @@ static unsigned short defaultHeight;
     [self addTarget:self action:@selector(refreshControlValueChanged) forControlEvents:UIControlEventValueChanged];
     _isInitialRender = true;
     _currentRefreshingState = false;
-    RCTRefreshControl.defaultHeight = self.frame.size.height;
+    _initialHeight = self.frame.size.height;
   }
   return self;
 }
@@ -55,9 +52,10 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
 
 - (void)beginRefreshing
 {
-  // When using begin refreshing we need to adjust the ScrollView content offset manually.
   UIScrollView *scrollView = (UIScrollView *)self.superview;
-  CGPoint offset = {scrollView.contentOffset.x, scrollView.contentOffset.y - RCTRefreshControl.defaultHeight};
+  // When using begin refreshing we need to adjust the ScrollView content offset manually.
+  // the need for _initialHeight is explained in PR #14259
+  CGPoint offset = {scrollView.contentOffset.x, scrollView.contentOffset.y - _initialHeight};
   [scrollView setContentOffset:offset animated:YES];
   [super beginRefreshing];
 }
@@ -68,18 +66,10 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
   // endRefreshing otherwise the next pull to refresh will not work properly.
   UIScrollView *scrollView = (UIScrollView *)self.superview;
   if (scrollView.contentOffset.y < 0) {
-    CGPoint offset = {scrollView.contentOffset.x, -scrollView.contentInset.top};
-    [UIView animateWithDuration:0.25
-                          delay:0
-                        options:UIViewAnimationOptionBeginFromCurrentState
-                     animations:^(void) {
-                       [scrollView setContentOffset:offset];
-                     } completion:^(__unused BOOL finished) {
-                       [super endRefreshing];
-                     }];
-  } else {
-    [super endRefreshing];
+    CGPoint offset = {scrollView.contentOffset.x, 0};
+    [scrollView setContentOffset:offset animated:YES];
   }
+  [super endRefreshing];
 }
 
 - (NSString *)title


### PR DESCRIPTION
### Motivation
There is a bug in the ios implementation of RefreshControl, described in #14056 and #13554. Essentially, it is not possible to programmatically show the refreshControl, because its `self.frame.size.height` starts with a default value of 60, but as the refreshControl hides, the value approaches zero (0.5). The next time we want to show the control, it will not be visible because the scrollView will only move by 0.5 which is not enough for the refreshControl to show up.

### Test plan 
I have built a small demo app to debug the issue. I have tested that the refreshControl works in different situations (start with scrolling, start not scrolling, trigger scroll by pull down gesture repeatedly and also programatically via the prop.)


I have noticed that at the time when `endRefreshing` is called, the `self.frame` dimensions are correct. The next time `beginRefreshing` is called the height is completely off though - it is somehow modified in the meantime. That's why I have added another static variable which preserves the value. Let me know what you think of this approach.
I have also modified the way the offset is set and the refreshControl gets displayed and it doesn't seem to affect the behavior on ios 9 and 10 emulators. In fact, it looks even better because the refreshControl is displayed without delay.