### PR TITLE
Fixed ImageLoader Mock for Android

### DIFF
--- a/jest/setup.js
+++ b/jest/setup.js
@@ -117,7 +117,7 @@ const mockNativeModules = {
   },
   ImageLoader: {
     getSize: jest.fn(
-      (uri, success) => process.nextTick(() => success(320, 240))
+      (url) => new Promise(() => ({width: 320, height: 240}))
     ),
     prefetchImage: jest.fn(),
   },


### PR DESCRIPTION
## Motivation (required)

When trying to mock an Image on Android, this error occurs referencing the ImageLoader mock in setup.js:
```
/Users/.../node_modules/react-native/jest/setup.js:120
return success(320,240);
       ^

TypeError: success is not a function
    at /Users/.../node_modules/react-native/jest/setup.js:120:8
    at _combinedTickCallback (internal/process/next_tick.js:73:7)
    at process._tickCallback (internal/process/next_tick.js:104:9)
```
- Mocking Images works for iOS but not Android.
- Since Image.android.js uses ImageLoader vs ImageViewManager, the code cannot be carried over from iOS.
## Test Plan (required)

Since this is code within the testing framework, the existing tests should test this. If there is no existing test coverage, then this would need to be done.