### PR TITLE
Fix configure glog script when building from xcodebuild

### DIFF
--- a/scripts/ios-configure-glog.sh
+++ b/scripts/ios-configure-glog.sh
@@ -1,11 +1,8 @@
 #!/bin/bash
 set -e
 
-# Only set when not running in an Xcode context
-if [ -z "$ACTION" ] || [ -z "$BUILD_DIR" ]; then
-  export CC="$(xcrun -find -sdk iphoneos cc) -arch armv7 -isysroot $(xcrun -sdk iphoneos --show-sdk-path)"
-  export CXX="$CC"
-fi
+export CC="$(xcrun -find -sdk iphoneos cc) -arch armv7 -isysroot $(xcrun -sdk iphoneos --show-sdk-path)"
+export CXX="$CC"
 
 ./configure --host arm-apple-darwin
 

--- a/scripts/ios-configure-glog.sh
+++ b/scripts/ios-configure-glog.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -e
 
+PLATFORM_NAME="${PLATFORM_NAME:-iphoneos}"
+CURRENT_ARCH="${CURRENT_ARCH:-armv7}"
+
 export CC="$(xcrun -find -sdk $PLATFORM_NAME cc) -arch $CURRENT_ARCH -isysroot $(xcrun -sdk $PLATFORM_NAME --show-sdk-path)"
 export CXX="$CC"
 

--- a/scripts/ios-configure-glog.sh
+++ b/scripts/ios-configure-glog.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-export CC="$(xcrun -find -sdk iphoneos cc) -arch armv7 -isysroot $(xcrun -sdk iphoneos --show-sdk-path)"
+export CC="$(xcrun -find -sdk $PLATFORM_NAME cc) -arch $CURRENT_ARCH -isysroot $(xcrun -sdk $PLATFORM_NAME --show-sdk-path)"
 export CXX="$CC"
 
 ./configure --host arm-apple-darwin


### PR DESCRIPTION
I encountered an issue when building with fastlane gym / xcodebuild where glog would not build because of missing config.h header file. I tracked it down to the ios-configure-glog.sh script that ended up error-ing because of missing valid c compiler. I guess it didn't enter the if to set c compiler env in xcodebuild and that env doesn't have proper values set like it does in xcode so just removing this check fixed it. Also tested that it still works properly in xcode.