### PR TITLE
Remove dependency on internal data structure

### DIFF
--- a/Libraries/Inspector/Inspector.js
+++ b/Libraries/Inspector/Inspector.js
@@ -169,14 +169,15 @@ class Inspector extends React.Component {
     // instance that contains it (like View)
     const {
       hierarchy,
-      instance,
       props,
       selection,
       source,
     } = renderer.getInspectorDataForViewTag(touchedViewTag);
 
     if (this.state.devtoolsAgent) {
-      this.state.devtoolsAgent.selectFromReactInstance(instance, true);
+      // Skip host leafs
+      const offsetFromLeaf = hierarchy.length - 1 - selection;
+      this.state.devtoolsAgent.selectFromDOMNode(touchedViewTag, true, offsetFromLeaf);
     }
 
     this.setState({


### PR DESCRIPTION
See context for this change in https://github.com/facebook/react-devtools/pull/770.
We'll later stop exposing `instance` (because it is a Fiber and is private to React).