### PR TITLE
Add instructions to first start React packager

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -554,6 +554,12 @@ The above command will automatically run your app on the iOS Simulator by defaul
 
 ## Running your React Native application
 
+Before running your application, the React packager must be running:
+```
+cd AwesomeProject
+react-native start
+```
+
 Run `react-native run-android` inside your React Native project folder:
 
 ```


### PR DESCRIPTION
It seems the React Packager needs to be running before the application installed by the run-android command can actually load your JS bundle. This might also be true for run-ios.

## Motivation
Incomplete documentation