### PR TITLE
Fix `InspectorPackagerConnection` creates too many Threads when WebSo…

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/InspectorPackagerConnection.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/InspectorPackagerConnection.java
@@ -176,6 +176,7 @@ public class InspectorPackagerConnection {
 
     private final String mUrl;
 
+    private OkHttpClient mHttpClient;
     private @Nullable WebSocket mWebSocket;
     private final Handler mHandler;
     private boolean mClosed;
@@ -223,14 +224,16 @@ public class InspectorPackagerConnection {
       if (mClosed) {
         throw new IllegalStateException("Can't connect closed client");
       }
-      OkHttpClient httpClient = new OkHttpClient.Builder()
-          .connectTimeout(10, TimeUnit.SECONDS)
-          .writeTimeout(10, TimeUnit.SECONDS)
-          .readTimeout(0, TimeUnit.MINUTES) // Disable timeouts for read
-          .build();
+      if (mHttpClient == null) {
+        mHttpClient = new OkHttpClient.Builder()
+            .connectTimeout(10, TimeUnit.SECONDS)
+            .writeTimeout(10, TimeUnit.SECONDS)
+            .readTimeout(0, TimeUnit.MINUTES) // Disable timeouts for read
+            .build();
+      }
 
       Request request = new Request.Builder().url(mUrl).build();
-      httpClient.newWebSocket(request, this);
+      mHttpClient.newWebSocket(request, this);
     }
 
     private void reconnect() {


### PR DESCRIPTION
Thanks for submitting a PR! Please read these instructions carefully:

- [x] Explain the **motivation** for making this change.
- [x] Provide a **test plan** demonstrating that the code is solid.
- [ ] Match the **code formatting** of the rest of the codebase.
- [ ] Target the `master` branch, NOT a "stable" branch.

## Motivation (required)

InspectorPackagerConnection now creates a new OkHttpClient when previous connection fails. If the failures occur frequently, many Threads are created in `WebSocketCall.enqueue()`. On my Pixel phone, I have seen up to 260 Threads named "OkHttp ConnectionPool" alive at the same time. So, why don't we consider reusing the existing OkHttpClient instance ?

## Test Plan (required)

N/A

## Next Steps

Sign the [CLA][2], if you haven't already.

Small pull requests are much easier to review and more likely to get merged. Make sure the PR does only one thing, otherwise please split it.

Make sure all **tests pass** on both [Travis][3] and [Circle CI][4]. PRs that break tests are unlikely to be merged.

For more info, see the ["Pull Requests"][5] section of our "Contributing" guidelines.

[1]: https://medium.com/@martinkonicek/what-is-a-test-plan-8bfc840ec171#.y9lcuqqi9
[2]: https://code.facebook.com/cla
[3]: https://travis-ci.org/facebook/react-native
[4]: http://circleci.com/gh/facebook/react-native
[5]: https://github.com/facebook/react-native/blob/master/CONTRIBUTING.md#pull-requests
