### PR TITLE
Deploy the website even if other tests fail

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -82,6 +82,9 @@ test:
     # testing docs generation
     - cd website && npm test
     - cd website && node ./server/generate.js
+    # if website can be built, deploy regardless of test failures
+    - if [[ ($CIRCLE_BRANCH =~ .*-stable || $CIRCLE_BRANCH == "master") && $CIRCLE_PROJECT_USERNAME == "facebook" && -z $CI_PULL_REQUEST && -z $CIRCLE_PR_USERNAME ]]; then git config --global user.email "reactjs-bot@users.noreply.github.com" && git config --global user.name "Website Deployment Script" && echo "machine github.com login reactjs-bot password $GITHUB_TOKEN" > ~/.netrc && cd website && GIT_USER=reactjs-bot npm run gh-pages; fi
+
   post:
     # copy test report for Circle CI to display
     - mkdir -p $CIRCLE_TEST_REPORTS/junit/
@@ -93,12 +96,12 @@ test:
 deployment:
   stable:
     branch: [/.*-stable/, /master/]
+    owner: facebook
     commands:
-      # generate docs website
       - git config --global user.email "reactjs-bot@users.noreply.github.com"
       - git config --global user.name "Website Deployment Script"
       - echo "machine github.com login reactjs-bot password $GITHUB_TOKEN" > ~/.netrc
-      - cd website && GIT_USER=reactjs-bot npm run gh-pages
+      # publish to npm
       - node ./scripts/publish-npm.js
 
 experimental:


### PR DESCRIPTION
Circle only runs the commands under "deployment" if all tests pass. As a result, website deploys tend to get blocked unnecessarily when Circle is red, even when the website has no issues.

As every command under "overrride" is run independently even if other commands fail, the result of this PR is that the website will be deployed on every Circle run on `master` or any of the `-stable` branches.

Note that the "deployment" section is only executed when Circle is run against the master/-stable branch, and Circle is configured to not run deployments on forks. Since "override" does not have these protections in place, I've added some guards to ensure that a web deploy only occurs on runs triggered by commits to master/-stable on the main `facebook/react-native` repo.

This PR assumes the following are correct:

- `CI_PULL_REQUEST` and `CIRCLE_PR_USERNAME` are only set when [run on a fork](https://circleci.com/docs/1.0/environment-variables/#building-pull-requests-that-come-from-forks).
- `CIRCLE_PROJECT_USERNAME ` is only set to "facebook" when the run is triggered by a commit on the main `facebook/react-native` repo, and not a fork.

## Relevant docs

* Configuring circle.yml: https://circleci.com/docs/1.0/configuration/
* Environment Variables: https://circleci.com/docs/1.0/environment-variables/

# Test Plan

None, aside from checking that bash can handle these conditionals. We need to trial this on Circle. Great attention needs to be paid to the conditionals, to ensure we do not allow forks to deploy the official website. We also need to make sure we are not leaking the GitHub access token accidentally.