### PR TITLE
Expose category property of iOS notifications

### DIFF
--- a/Libraries/PushNotificationIOS/PushNotificationIOS.js
+++ b/Libraries/PushNotificationIOS/PushNotificationIOS.js
@@ -121,6 +121,7 @@ class PushNotificationIOS {
   _data: Object;
   _alert: string | Object;
   _sound: string;
+  _category: string;
   _badgeCount: number;
   _notificationId: string;
   _isRemote: boolean;
@@ -417,6 +418,7 @@ class PushNotificationIOS {
           this._alert = notifVal.alert;
           this._sound = notifVal.sound;
           this._badgeCount = notifVal.badge;
+          this._category = notifVal.category;
         } else {
           this._data[notifKey] = notifVal;
         }
@@ -465,6 +467,13 @@ class PushNotificationIOS {
    */
   getSound(): ?string {
     return this._sound;
+  }
+
+  /**
+   * Gets the category string from the `aps` object
+   */
+  getCategory(): ?string {
+    return this._category;
   }
 
   /**

--- a/Libraries/PushNotificationIOS/PushNotificationIOS.js
+++ b/Libraries/PushNotificationIOS/PushNotificationIOS.js
@@ -429,6 +429,7 @@ class PushNotificationIOS {
       this._sound = nativeNotif.soundName;
       this._alert = nativeNotif.alertBody;
       this._data = nativeNotif.userInfo;
+      this._category = nativeNotif.category;
     }
   }
 

--- a/Libraries/PushNotificationIOS/PushNotificationIOS.js
+++ b/Libraries/PushNotificationIOS/PushNotificationIOS.js
@@ -429,7 +429,6 @@ class PushNotificationIOS {
       this._sound = nativeNotif.soundName;
       this._alert = nativeNotif.alertBody;
       this._data = nativeNotif.userInfo;
-      this._data = nativeNotif.category;
     }
   }
 

--- a/Libraries/PushNotificationIOS/PushNotificationIOS.js
+++ b/Libraries/PushNotificationIOS/PushNotificationIOS.js
@@ -429,6 +429,7 @@ class PushNotificationIOS {
       this._sound = nativeNotif.soundName;
       this._alert = nativeNotif.alertBody;
       this._data = nativeNotif.userInfo;
+      this._data = nativeNotif.category;
     }
   }
 


### PR DESCRIPTION
Thanks for submitting a PR! Please read these instructions carefully:

- [x] Explain the **motivation** for making this change.
- [x] Provide a **test plan** demonstrating that the code is solid.
- [x] Match the **code formatting** of the rest of the codebase.
- [x] Target the `master` branch, NOT a "stable" branch.

## Motivation

This change allows app code to access the 'category' property of incoming iOS remote push notifications. Currently the property is not made available.

## Test Plan

Create a test application which:
- registers for remote notifications with APNs
- passes the returned token to your push notification service provider
- displays the contents of the notification, including the 'category'
Send a remote push notification including a value for the category property in the payload. Check that the category is displayed in the application.

I considered updating RNTester but I couldn't for the life of me figure out how to get it to compile on my machine, sorry ;-) I can confirm my change works when applied directly in the node_modules of an existing RN project.

## Next Steps

I've signed the CLA. Hope this is enough info to go on, please let me know if not!
