### PR TITLE
UITapGestureRecognizer added to RCTSlider

### DIFF
--- a/React/Views/RCTSliderManager.m
+++ b/React/Views/RCTSliderManager.m
@@ -27,6 +27,12 @@ RCT_EXPORT_MODULE()
    forControlEvents:(UIControlEventTouchUpInside |
                      UIControlEventTouchUpOutside |
                      UIControlEventTouchCancel)];
+  UITapGestureRecognizer *tapGestureRecognizer = [[UITapGestureRecognizer alloc]
+                                                  initWithTarget:self
+                                                  action:@selector(sliderTap:)
+                                                  ];
+  [slider addGestureRecognizer:tapGestureRecognizer];
+
   return slider;
 }
 
@@ -71,6 +77,23 @@ static void RCTSendSliderEvent(RCTSlider *sender, BOOL continuous)
 
 - (void)sliderTouchEnd:(RCTSlider *)sender
 {
+  RCTSendSliderEvent(sender, NO);
+}
+
+- (void)sliderTap:(UIGestureRecognizer *)tapGestureRecognizer
+{
+  RCTSlider *sender = (RCTSlider *)tapGestureRecognizer.view;
+  
+  if (sender.highlighted) {
+    return;
+  }
+  
+  CGPoint locationInView = [tapGestureRecognizer locationInView:sender];
+  CGFloat delta = (locationInView.x / sender.bounds.size.width) * (sender.maximumValue - sender.minimumValue);
+  CGFloat value = sender.minimumValue + delta;
+  
+  [sender setValue:value animated:YES];
+  
   RCTSendSliderEvent(sender, NO);
 }
 


### PR DESCRIPTION
Tap gesture recognizer added to iOS slider.

## Motivation

iOS slider's value can be changed by tap somewhere on the slider.
By adding a gesture recognizer for tap, it is achieved similarly user experience on both platforms. 

## Test Plan

Demo video:

![ios](https://cloud.githubusercontent.com/assets/5950722/26823043/d3662a72-4ab4-11e7-8a84-83c43972591f.gif)
