### PR TITLE
Don't include JNI dep in OSS build

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/BUCK
@@ -34,6 +34,5 @@ android_library(
         react_native_dep("third-party/java/jsr-305:jsr-305"),
         react_native_target("java/com/facebook/react/common:common"),
         react_native_target("java/com/facebook/react/module/model:model"),
-        react_native_target("jni/react/jni:jni"),
-    ],
+    ] + ([react_native_target("jni/react/jni:jni")] if not IS_OSS_BUILD else []),
 )


### PR DESCRIPTION
When circle is using Buck, it uses prebuilt native libraries. I added this dependency internally to avoid callers having to depend on it explicitly but it looks like that broken open-source.