### PR TITLE
Android - Update Image.getSize to use encoded image

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/modules/image/ImageLoaderModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/image/ImageLoaderModule.java
@@ -21,7 +21,8 @@ import com.facebook.datasource.DataSource;
 import com.facebook.datasource.DataSubscriber;
 import com.facebook.drawee.backends.pipeline.Fresco;
 import com.facebook.imagepipeline.core.ImagePipeline;
-import com.facebook.imagepipeline.image.CloseableImage;
+import com.facebook.imagepipeline.image.EncodedImage;
+import com.facebook.imagepipeline.memory.PooledByteBuffer;
 import com.facebook.imagepipeline.request.ImageRequest;
 import com.facebook.imagepipeline.request.ImageRequestBuilder;
 import com.facebook.react.bridge.Arguments;
@@ -81,22 +82,23 @@ public class ImageLoaderModule extends ReactContextBaseJavaModule implements
     Uri uri = Uri.parse(uriString);
     ImageRequest request = ImageRequestBuilder.newBuilderWithSource(uri).build();
 
-    DataSource<CloseableReference<CloseableImage>> dataSource =
-      Fresco.getImagePipeline().fetchDecodedImage(request, mCallerContext);
+    DataSource<CloseableReference<PooledByteBuffer>> dataSource =
+      Fresco.getImagePipeline().fetchEncodedImage(request, mCallerContext);
 
-    DataSubscriber<CloseableReference<CloseableImage>> dataSubscriber =
-      new BaseDataSubscriber<CloseableReference<CloseableImage>>() {
+    DataSubscriber<CloseableReference<PooledByteBuffer>> dataSubscriber =
+      new BaseDataSubscriber<CloseableReference<PooledByteBuffer>>() {
         @Override
         protected void onNewResultImpl(
-            DataSource<CloseableReference<CloseableImage>> dataSource) {
+            DataSource<CloseableReference<PooledByteBuffer>> dataSource) {
           if (!dataSource.isFinished()) {
             return;
           }
-          CloseableReference<CloseableImage> ref = dataSource.getResult();
+          CloseableReference<PooledByteBuffer> ref = dataSource.getResult();
           if (ref != null) {
+            EncodedImage image = ref.get();
             try {
-              CloseableImage image = ref.get();
-
+              image.parseMetaData();
+              
               WritableMap sizes = Arguments.createMap();
               sizes.putInt("width", image.getWidth());
               sizes.putInt("height", image.getHeight());
@@ -106,6 +108,7 @@ public class ImageLoaderModule extends ReactContextBaseJavaModule implements
               promise.reject(ERROR_GET_SIZE_FAILURE, e);
             } finally {
               CloseableReference.closeSafely(ref);
+              image.close();
             }
           } else {
             promise.reject(ERROR_GET_SIZE_FAILURE);
@@ -113,7 +116,7 @@ public class ImageLoaderModule extends ReactContextBaseJavaModule implements
         }
 
         @Override
-        protected void onFailureImpl(DataSource<CloseableReference<CloseableImage>> dataSource) {
+        protected void onFailureImpl(DataSource<CloseableReference<PooledByteBuffer>> dataSource) {
           promise.reject(ERROR_GET_SIZE_FAILURE, dataSource.getFailureCause());
         }
       };

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/image/ImageLoaderModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/image/ImageLoaderModule.java
@@ -95,7 +95,7 @@ public class ImageLoaderModule extends ReactContextBaseJavaModule implements
           }
           CloseableReference<PooledByteBuffer> ref = dataSource.getResult();
           if (ref != null) {
-            EncodedImage image = ref.get();
+            EncodedImage image = new EncodedImage(ref);
             try {
               image.parseMetaData();
               


### PR DESCRIPTION
Regarding issue #14357

Manually tested it on remote URLs of png, jpeg and bmp formats.

Additional notes:
1. It is possible to add support for static images in the future.
2. parseMetaData function is also extracting image format which is unnecessary - thus, it can be replaced with the code from parseMetaData that only gets width & height.

(Might be low-level breaking change (?) - Changing from fetchDecodedImage to fetchEncodedImage probably means that the decoded image will not be cached as it used to be [apparently, regarding fresco documentation, the encoded image will be cached])