### PR TITLE
[Android] [Crash] Check if fresco is initialised before clearing memory caches

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/modules/fresco/FrescoModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/fresco/FrescoModule.java
@@ -182,7 +182,7 @@ public class FrescoModule extends ReactContextBaseJavaModule implements
     // According to the javadoc for LifecycleEventListener#onHostDestroy, this is only called when
     // the 'last' ReactActivity is being destroyed, which effectively means the app is being
     // backgrounded.
-    if (mClearOnDestroy) {
+    if (hasBeenInitialized() && mClearOnDestroy) {
       Fresco.getImagePipeline().clearMemoryCaches();
     }
   }


### PR DESCRIPTION
## Motivation

Fixes the following crash:
```
Fatal Exception: java.lang.RuntimeException: Unable to destroy activity {com.example/com.example.MainActivity}: java.lang.NullPointerException: ImagePipelineFactory was not initialized!
       at android.app.ActivityThread.performDestroyActivity(ActivityThread.java:3831)
       at android.app.ActivityThread.handleDestroyActivity(ActivityThread.java:3849)
       at android.app.ActivityThread.access$1500(ActivityThread.java:150)
       at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1398)
       at android.os.Handler.dispatchMessage(Handler.java:102)
       at android.os.Looper.loop(Looper.java:148)
       at android.app.ActivityThread.main(ActivityThread.java:5417)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:764)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:626)
Caused by java.lang.NullPointerException: ImagePipelineFactory was not initialized!
       at com.facebook.common.internal.Preconditions.checkNotNull(Preconditions.java:226)
       at com.facebook.imagepipeline.core.ImagePipelineFactory.getInstance(ImagePipelineFactory.java:74)
       at com.facebook.drawee.backends.pipeline.Fresco.getImagePipelineFactory(Fresco.java:92)
       at com.facebook.drawee.backends.pipeline.Fresco.getImagePipeline(Fresco.java:97)
       at com.facebook.react.modules.fresco.FrescoModule.onHostDestroy(FrescoModule.java:186)
       at com.facebook.react.bridge.ReactContext.onHostDestroy(ReactContext.java:240)
       at com.facebook.react.ReactInstanceManager.moveToBeforeCreateLifecycleState(ReactInstanceManager.java:667)
       at com.facebook.react.ReactInstanceManager.onHostDestroy(ReactInstanceManager.java:586)
       at com.facebook.react.ReactInstanceManager.onHostDestroy(ReactInstanceManager.java:599)
       at com.facebook.react.ReactActivityDelegate.onDestroy(ReactActivityDelegate.java:142)
       at com.facebook.react.ReactActivity.onDestroy(ReactActivity.java:72)
       at android.app.Activity.performDestroy(Activity.java:6456)
       at android.app.Instrumentation.callActivityOnDestroy(Instrumentation.java:1143)
       at android.app.ActivityThread.performDestroyActivity(ActivityThread.java:3818)
       at android.app.ActivityThread.handleDestroyActivity(ActivityThread.java:3849)
       at android.app.ActivityThread.access$1500(ActivityThread.java:150)
       at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1398)
       at android.os.Handler.dispatchMessage(Handler.java:102)
       at android.os.Looper.loop(Looper.java:148)
       at android.app.ActivityThread.main(ActivityThread.java:5417)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:764)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:626)
```

This was introduced by https://github.com/facebook/react-native/commit/d9ae27ba89c0beda0c76d3a227c2a453948db1a2

## Test Plan

1. Create app with an image to be loaded
2. Background app before fresco has been initialised. (Very tight window to do this)
3. Should not crash

cc @foghina 