### PR TITLE
Tvos cocoapods support

### DIFF
--- a/Libraries/NativeAnimation/RCTNativeAnimatedNodesManager.h
+++ b/Libraries/NativeAnimation/RCTNativeAnimatedNodesManager.h
@@ -9,9 +9,10 @@
 
 #import <Foundation/Foundation.h>
 
-#import <RCTAnimation/RCTValueAnimatedNode.h>
 #import <React/RCTBridgeModule.h>
 #import <React/RCTUIManager.h>
+
+ #import "RCTValueAnimatedNode.h"
 
 @interface RCTNativeAnimatedNodesManager : NSObject
 

--- a/React.podspec
+++ b/React.podspec
@@ -36,7 +36,8 @@ Pod::Spec.new do |s|
   s.source                  = source
   s.default_subspec         = "Core"
   s.requires_arc            = true
-  s.platform                = :ios, "8.0"
+  s.ios.deployment_target   = "8.0"
+  s.tvos.deployment_target  = "9.0"
   s.pod_target_xcconfig     = { "CLANG_CXX_LANGUAGE_STANDARD" => "c++14" }
   s.preserve_paths          = "package.json", "LICENSE", "LICENSE-docs", "PATENTS"
   s.cocoapods_version       = ">= 1.2.0"
@@ -45,6 +46,7 @@ Pod::Spec.new do |s|
     ss.dependency             "Yoga", "#{package["version"]}.React"
     ss.source_files         = "React/**/*.{c,h,m,mm,S}"
     ss.exclude_files        = "**/__tests__/*", "IntegrationTests/*", "React/DevSupport/*", "React/**/RCTTVView.*", "ReactCommon/yoga/*", "React/Cxx*/*", "React/Base/RCTBatchedBridge.mm", "React/Executors/*"
+    ss.tvos.exclude_files   = "React/**/RCTClipboard.*", "React/**/RCTDatePicker.*", "React/**/RCTDatePickerManager.*", "React/**/RCTPicker.*", "React/**/RCTPickerManager.*", "React/**/RCTRefreshControl.*", "React/**/RCTRefreshControlManager.*", "React/**/RCTSlider.*", "React/**/RCTSliderManager.*", "React/**/RCTRefreshControlManager.*", "React/**/RCTSwitch.*", "React/**/RCTSwitchManager.*", "React/**/RCTWebView.*", "React/**/RCTWebViewManager.*"
     ss.framework            = "JavaScriptCore"
     ss.libraries            = "stdc++"
     ss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\"" }
@@ -73,7 +75,7 @@ Pod::Spec.new do |s|
 
   s.subspec "tvOS" do |ss|
     ss.dependency             "React/Core"
-    ss.source_files         = "React/**/RCTTVView.{h, m}"
+    ss.source_files         = "React/**/RCTTVView.{h,m}"
   end
 
   s.subspec "jschelpers_legacy" do |ss|

--- a/ReactCommon/yoga/Yoga.podspec
+++ b/ReactCommon/yoga/Yoga.podspec
@@ -34,7 +34,8 @@ Pod::Spec.new do |spec|
   ]
 
   # Pinning to the same version as React.podspec.
-  spec.platform = :ios, "8.0"
+  spec.ios.deployment_target   = "8.0"
+  spec.tvos.deployment_target  = "9.0"
 
   # Set this environment variable when not using the `:path` option to install the pod.
   # E.g. when publishing this spec to a spec repo.

--- a/third-party-podspecs/DoubleConversion.podspec
+++ b/third-party-podspecs/DoubleConversion.podspec
@@ -12,6 +12,7 @@ Pod::Spec.new do |spec|
   spec.source_files = 'double-conversion/*.{h,cc}'
 
   # Pinning to the same version as React.podspec.
-  spec.platform = :ios, '8.0'
+  spec.ios.deployment_target   = "8.0"
+  spec.tvos.deployment_target  = "9.0"
 
 end

--- a/third-party-podspecs/Folly.podspec
+++ b/third-party-podspecs/Folly.podspec
@@ -27,7 +27,8 @@ Pod::Spec.new do |spec|
                                "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)\" \"$(PODS_ROOT)/boost\" \"$(PODS_ROOT)/DoubleConversion\"" }
 
   # Pinning to the same version as React.podspec.
-  spec.platform = :ios, '8.0'
+  spec.ios.deployment_target   = "8.0"
+  spec.tvos.deployment_target  = "9.0"
 
   spec.subspec "detail" do |ss|
     ss.header_dir = 'folly/detail'

--- a/third-party-podspecs/GLog.podspec
+++ b/third-party-podspecs/GLog.podspec
@@ -25,6 +25,7 @@ Pod::Spec.new do |spec|
                                "HEADER_SEARCH_PATHS" => "$(PODS_TARGET_SRCROOT)/src" }
 
   # Pinning to the same version as React.podspec.
-  spec.platform = :ios, "8.0"
+  spec.ios.deployment_target   = "8.0"
+  spec.tvos.deployment_target  = "9.0"
 
 end


### PR DESCRIPTION
Thanks for submitting a PR! Please read these instructions carefully:

- [x] Explain the **motivation** for making this change.
- [x] Provide a **test plan** demonstrating that the code is solid.
- [x] Match the **code formatting** of the rest of the codebase.
- [x] Target the `master` branch, NOT a "stable" branch.

## Motivation (required)

Making work **cocoapods** react-native dependecy on tvOS. This patch excludes files, which are not supported by tvOS, adding support of deployment platform and make it possible to use cocoapods integration into tvOS project. 

## Test Plan (required)

No tests are needed, there are no changes in code. Changes are made just in podpsecs (React.podspec and Yoga.podspec).

Working of this code can be test by adding cocoapods integration into tvOS project, where tvOS subspec has to be added as well. After "pod install" it is possible to build react-native in tvOS project.

Everything works and was tested on 0.45-stable
