### PR TITLE
[Docs] Restore proper ordering of docs in the sidebar 

### DIFF
--- a/docs/ComponentsAndAPIs.md
+++ b/docs/ComponentsAndAPIs.md
@@ -4,7 +4,7 @@ title: Components and APIs
 layout: docs
 category: Guides
 permalink: docs/components-and-apis.html
-next: handling-touches
+next: platform-specific-code
 previous: more-resources
 ---
 

--- a/docs/MoreResources.md
+++ b/docs/MoreResources.md
@@ -4,7 +4,7 @@ title: More Resources
 layout: docs
 category: The Basics
 permalink: docs/more-resources.html
-next: platform-specific-code
+next: components
 previous: network
 ---
 

--- a/docs/PlatformSpecificInformation.md
+++ b/docs/PlatformSpecificInformation.md
@@ -5,7 +5,7 @@ layout: docs
 category: Guides
 permalink: docs/platform-specific-code.html
 next: navigation
-previous: more-resources
+previous: components
 ---
 
 When building a cross-platform app, you'll want to re-use as much code as possible. Scenarios may arise where it makes sense for the code to be different, for example you may want to implement separate visual components for iOS and Android.


### PR DESCRIPTION
Quickfix: The ordering here was lost when a previous PR was merged.