### PR TITLE
Add a type cast to RCT_ENUM_CONVERTER for C++ compatibility

### DIFF
--- a/React/Base/RCTConvert.h
+++ b/React/Base/RCTConvert.h
@@ -218,7 +218,7 @@ RCT_CUSTOM_CONVERTER(type, type, [RCT_DEBUG ? [self NSNumber:json] : json getter
   dispatch_once(&onceToken, ^{                            \
     mapping = values;                                     \
   });                                                     \
-  return [RCTConvertEnumValue(#type, mapping, @(default), json) getter]; \
+  return (type)[RCTConvertEnumValue(#type, mapping, @(default), json) getter]; \
 }
 
 /**
@@ -233,7 +233,7 @@ RCT_CUSTOM_CONVERTER(type, type, [RCT_DEBUG ? [self NSNumber:json] : json getter
   dispatch_once(&onceToken, ^{                            \
     mapping = values;                                     \
   });                                                     \
-  return [RCTConvertMultiEnumValue(#type, mapping, @(default), json) getter]; \
+  return (type)[RCTConvertMultiEnumValue(#type, mapping, @(default), json) getter]; \
 }
 
 /**


### PR DESCRIPTION
## Motivation

C++ doesn't provide an implicit cast to an enum value from the enum's backing type. When a `.mm` file calls `RCT_ENUM_CONVERTER`, we end up with the following compiler error:
> Error: cannot initialize return object of type `<TypeName>` with an rvalue of type `NSInteger`

Since `RCT_ENUM_CONVERTER` is a macro, this error will appear whenever we try to expand the macro in a C++ context.

## Test Plan

The project compiles and runs as expected when this additional cast is added 😃 