### PR TITLE
Remove Warning

### DIFF
--- a/Libraries/PushNotificationIOS/RCTPushNotificationManager.m
+++ b/Libraries/PushNotificationIOS/RCTPushNotificationManager.m
@@ -299,7 +299,7 @@ RCT_EXPORT_METHOD(onFinishRemoteNotification:(NSString *)notificationId fetchRes
  */
 RCT_EXPORT_METHOD(setApplicationIconBadgeNumber:(NSInteger)number)
 {
-  RCTSharedApplication().applicationIconBadgeNumber = number;
+  RCTSharedApplication().applicationIconBadgeNumber = *(number);
 }
 
 /**


### PR DESCRIPTION
Got this warning 
Incompatible pointer to integer conversion assigning to 'NSInteger' (aka 'long') from 'NSInteger *' (aka 'long *'); dereference with * in my editor,.

This was the proposed fix
