### PR TITLE
Jest Mocks for NetInfo and Linking

### DIFF
--- a/jest/setup.js
+++ b/jest/setup.js
@@ -143,6 +143,11 @@ const mockNativeModules = {
     canOpenURL: jest.fn(
       () => new Promise((resolve) => resolve(true))
     ),
+    addEventListener: jest.fn(),
+    getInitialURL: jest.fn(
+      () => new Promise((resolve) => resolve())
+    ),
+    removeEventListener: jest.fn()
   },
   LocationObserver: {
     getCurrentPosition: jest.fn(),
@@ -150,6 +155,18 @@ const mockNativeModules = {
     stopObserving: jest.fn(),
   },
   ModalFullscreenViewManager: {},
+  NetInfo: {
+    fetch: jest.fn(
+      () => new Promise((resolve) => resolve())
+    ),
+    addEventListener: jest.fn(),
+    isConnected: {
+      fetch: jest.fn(
+        () => new Promise((resolve) => resolve())
+      ),
+      addEventListener: jest.fn()
+    }
+  },
   Networking: {
     sendRequest: jest.fn(),
     abortRequest: jest.fn(),

--- a/jest/setup.js
+++ b/jest/setup.js
@@ -147,7 +147,7 @@ const mockNativeModules = {
     getInitialURL: jest.fn(
       () => new Promise((resolve) => resolve())
     ),
-    removeEventListener: jest.fn()
+    removeEventListener: jest.fn(),
   },
   LocationObserver: {
     getCurrentPosition: jest.fn(),
@@ -164,8 +164,8 @@ const mockNativeModules = {
       fetch: jest.fn(
         () => new Promise((resolve) => resolve())
       ),
-      addEventListener: jest.fn()
-    }
+      addEventListener: jest.fn(),
+    },
   },
   Networking: {
     sendRequest: jest.fn(),


### PR DESCRIPTION
This isn't exhaustive, but it's a few more functions that these modules normally export which need to be stubbed.