### PR TITLE
gradle.properties is in the root Android folder

### DIFF
--- a/docs/SignedAPKAndroid.md
+++ b/docs/SignedAPKAndroid.md
@@ -26,7 +26,7 @@ _Note: Remember to keep your keystore file private and never commit it to versio
 ### Setting up gradle variables
 
 1. Place the `my-release-key.keystore` file under the `android/app` directory in your project folder.
-2. Edit the file `~/.gradle/gradle.properties` and add the following (replace `*****` with the correct keystore password, alias and key password),
+2. Edit the file `gradle.properties` and add the following (replace `*****` with the correct keystore password, alias and key password),
 
 ```
 MYAPP_RELEASE_STORE_FILE=my-release-key.keystore


### PR DESCRIPTION
Generating .apk was failing for me, because of 
```
* What went wrong:
Execution failed for task ':app:validateSigningRelease'.
> Keystore file not set for signing config release
```
Found out that the gralde.properties file already existed in the root Android folder. Editing the settings there, made my build succeed.
