### PR TITLE
fix init

### DIFF
--- a/local-cli/bundle/buildBundle.js
+++ b/local-cli/bundle/buildBundle.js
@@ -13,7 +13,7 @@
 
 const log = require('../util/log').out('bundle');
 const Server = require('metro-bundler/build/Server');
-const Terminal = require('metro-bundler/build/lib/TerminalClass');
+const Terminal = require('metro-bundler/build/lib/Terminal');
 const TerminalReporter = require('metro-bundler/build/lib/TerminalReporter');
 const TransformCaching = require('metro-bundler/build/lib/TransformCaching');
 

--- a/local-cli/server/runServer.js
+++ b/local-cli/server/runServer.js
@@ -15,7 +15,7 @@
 require('../../setupBabel')();
 const InspectorProxy = require('./util/inspectorProxy.js');
 const ReactPackager = require('metro-bundler');
-const Terminal = require('metro-bundler/build/lib/TerminalClass');
+const Terminal = require('metro-bundler/build/lib/Terminal');
 
 const attachHMRServer = require('./util/attachHMRServer');
 const connect = require('connect');


### PR DESCRIPTION
Close #14476 
`TerminalClass` was renamed to `Terminal` by https://github.com/facebook/metro-bundler/commit/c1ff8b5b81f53d359abee0696ba9468d4fae9b85, this sync the changes