### PR TITLE
Fix broken link in /docs/MoreResources.md

### DIFF
--- a/docs/MoreResources.md
+++ b/docs/MoreResources.md
@@ -4,7 +4,7 @@ title: More Resources
 layout: docs
 category: The Basics
 permalink: docs/more-resources.html
-next: components
+next: components-and-apis
 previous: network
 ---
 


### PR DESCRIPTION
## Motivation (required)

`Next →` link on `https://facebook.github.io/react-native/docs/more-resources.html` is currently broken


## Test Plan (required)

Click on `Next →` link and make sure you are not redirected to the main page
