### PR TITLE
Fix #14542, Text with adjustsFontSizeToFit turned on will lose fontVariant issue

### DIFF
--- a/Libraries/Text/RCTShadowText.m
+++ b/Libraries/Text/RCTShadowText.m
@@ -559,7 +559,23 @@ static YGSize RCTMeasure(YGNodeRef node, float width, YGMeasureMode widthMode, f
        UIFont *originalFont = [self.attributedString attribute:NSFontAttributeName
                                                        atIndex:range.location
                                                 effectiveRange:&range];
-       UIFont *newFont = [font fontWithSize:originalFont.pointSize * scale];
+       UIFont *newFont;
+       CGFloat newSize = originalFont.pointSize * scale;
+       // Notice: it seems that there is a bug in UIFont:fontWithSize or what,
+       // the font it retuns doesn't come with the font descriptor we set to it
+       // before. As a result, fontVariant will be lost if the font is set by
+       // just result of UIFont:fontWithSize. To solve the problem, we create
+       // the new font with UIFont:fontWithDescriptor:size here to keep our
+       // fontVariant around.
+       if (self.fontVariant) {
+         NSArray *fontFeatures = [RCTConvert RCTFontVariantDescriptorArray:self.fontVariant];
+         UIFontDescriptor *fontDescriptor = [font.fontDescriptor fontDescriptorByAddingAttributes:@{
+           UIFontDescriptorFeatureSettingsAttribute: fontFeatures
+         }];
+         newFont = [UIFont fontWithDescriptor:fontDescriptor size:newSize];
+       } else {
+         newFont = [font fontWithSize:newSize];
+       }
        [textStorage removeAttribute:NSFontAttributeName range:range];
        [textStorage addAttribute:NSFontAttributeName value:newFont range:range];
      }

--- a/React/Views/RCTFont.h
+++ b/React/Views/RCTFont.h
@@ -11,6 +11,8 @@
 
 #import <React/RCTConvert.h>
 
+typedef NSDictionary RCTFontVariantDescriptor;
+
 @interface RCTFont : NSObject
 
 /**

--- a/React/Views/RCTFont.h
+++ b/React/Views/RCTFont.h
@@ -36,5 +36,6 @@
 @interface RCTConvert (RCTFont)
 
 + (UIFont *)UIFont:(id)json;
++ (NSArray<RCTFontVariantDescriptor *> *)RCTFontVariantDescriptorArray:(id)json;
 
 @end


### PR DESCRIPTION
<details>
  Thanks for submitting a PR! Please read these instructions carefully:

  - [ ] Explain the **motivation** for making this change.
  - [ ] Provide a **test plan** demonstrating that the code is solid.
  - [ ] Match the **code formatting** of the rest of the codebase.
  - [ ] Target the `master` branch, NOT a "stable" branch.

  Please read the [Contribution Guidelines](https://github.com/facebook/react-native/blob/master/CONTRIBUTING.md) to learn more about contributing to React Native.
</details>

## Motivation (required)

Fix #14542

## Test Plan (required)

Screenshot after fixed

![img_0037](https://user-images.githubusercontent.com/201615/27206067-a4fafb40-51e9-11e7-9540-86f38205edf7.PNG)

Compare side by side with the screenshot before bugfix applied

![img_0036](https://user-images.githubusercontent.com/201615/27205523-32ec8a8a-51e6-11e7-8847-fa9a07134b19.PNG)

the same result should be easily reproduced with the sample code in #14542