### PR TITLE
Fix inverted FlatList for Android: add perspective transform

### DIFF
--- a/Libraries/Lists/VirtualizedList.js
+++ b/Libraries/Lists/VirtualizedList.js
@@ -22,6 +22,7 @@ const ScrollView = require('ScrollView');
 const StyleSheet = require('StyleSheet');
 const View = require('View');
 const ViewabilityHelper = require('ViewabilityHelper');
+const Platform = require('Platform');
 
 const flattenStyle = require('flattenStyle');
 const infoLog = require('infoLog');

--- a/Libraries/Lists/VirtualizedList.js
+++ b/Libraries/Lists/VirtualizedList.js
@@ -1204,7 +1204,7 @@ class CellRenderer extends React.Component {
 const verticalTransform = [{scaleY: -1}];
 const horizontalTransform = [{scaleX: -1}];
 
-if(Platform.OS === 'android') {
+if (Platform.OS === 'android') {
   verticalTransform.push({perspective: 1});
   horizontalTransform.push({perspective: 1});
 }

--- a/Libraries/Lists/VirtualizedList.js
+++ b/Libraries/Lists/VirtualizedList.js
@@ -1200,12 +1200,20 @@ class CellRenderer extends React.Component {
   }
 }
 
+const verticalTransform = [{scaleY: -1}];
+const horizontalTransform = [{scaleX: -1}];
+
+if(Platform.OS === 'android') {
+  verticalTransform.push({perspective: 1});
+  horizontalTransform.push({perspective: 1});
+}
+
 const styles = StyleSheet.create({
   verticallyInverted: {
-    transform: [{scaleY: -1}, {perspective: 1000}],
+    transform: verticalTransform,
   },
   horizontallyInverted: {
-    transform: [{scaleX: -1}, {perspective: 1000}],
+    transform: horizontalTransform,
   },
 });
 

--- a/Libraries/Lists/VirtualizedList.js
+++ b/Libraries/Lists/VirtualizedList.js
@@ -1202,10 +1202,10 @@ class CellRenderer extends React.Component {
 
 const styles = StyleSheet.create({
   verticallyInverted: {
-    transform: [{scaleY: -1}],
+    transform: [{scaleY: -1}, {perspective: 1000}],
   },
   horizontallyInverted: {
-    transform: [{scaleX: -1}],
+    transform: [{scaleX: -1}, {perspective: 1000}],
   },
 });
 


### PR DESCRIPTION
On one of our test phones, a Huawei P10 VTR-L09, running Android 7.0 any rotate or scale animations through transforms are not working, unless `{"perspective": 1}` is added in the transforms array. I found the perspective solution here https://github.com/facebook/react-native/issues/13522 .

The new `inverted` property for `FlatList` relies on a scaleX/scaleY transform. Because this transform does not work on some Android devices, the FlatList is not displayed at all on those devices. This fix just adds the extra perspective array element. The result is a correctly displayed FlatList when `inverted` is set to `true`.

## Test Plan

Tested this on inverted `FlatList` on Android and iOS, on real devices. iOS is unaffected by the addition. Android now displays the `FlatList` correctly.

Minimal gist for testing: https://gist.github.com/bartolkaruza/87ef49d1b2d0227782739584b110722b

Minimal gist showing the View transform with scaleY issue:
https://gist.github.com/bartolkaruza/42bb9f9d63baaaebb48fc493c8127e1a
