### PR TITLE
[website] Fix #14566, image in second code sample not rendering

### DIFF
--- a/website/src/react-native/index.js
+++ b/website/src/react-native/index.js
@@ -95,7 +95,10 @@ class AwkwardScrollingImageWithText extends Component {
   render() {
     return (
       <ScrollView>
-        <Image source={{uri: 'https://i.chzbgr.com/full/7345954048/h7E2C65F9/'}} />
+        <Image
+          source={{uri: 'https://i.chzbgr.com/full/7345954048/h7E2C65F9/'}}
+          style={{width: 320, height:180}}
+        />
         <Text>
           On iOS, a React Native ScrollView uses a native UIScrollView.
           On Android, it uses a native ScrollView.


### PR DESCRIPTION
## Motivation
Fixes #14566, as suggested by @hramos. Only change from our convo is that I set the height to 180 in this pull request instead of 240. This to respect the aspect ratio of the source image.

## Test Plan
- run website, visit in browser, verify that second example code section renders correctly
- copy and paste example code of second example into the App.js of a freshly created react native app
- prepend "export default" to line 4 of the pasted code
- run the app for ios or android (npm start ios)
- verify that the image of that terrible high-five actually renders in the app now

## Issue
#14566