### PR TITLE
Add a PopupMenuAndroid component

### DIFF
--- a/Libraries/Components/PopupMenuAndroid/PopupMenuAndroid.android.js
+++ b/Libraries/Components/PopupMenuAndroid/PopupMenuAndroid.android.js
@@ -1,0 +1,120 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ * @providesModule PopupMenuAndroid
+ */
+'use strict';
+
+const React = require('react');
+const ReactNative = require('ReactNative');
+const PropTypes = require('prop-types');
+const UIManager = require('UIManager');
+
+type Props = {
+  children?: any,
+  items: Array<{ value: string }>,
+  onItemSelect: ({ index: number, value: string }) => void,
+  onDismiss: Function,
+  onError: Function,
+}
+
+/**
+ * React component to show a PopupMenu on Android.
+ *
+ * Example:
+ *
+ * ```
+ * <PopupMenuAndroid
+ *   items={[
+ *     { value: 'Apples' },
+ *     { value: 'Oranges' }
+ *   ]}
+ *   onItemSelect={({ value, index }) => console.log(`Selected ${value} at ${index}`)}
+ *   onDismiss={() => console.log(`Dismissed`)}
+ * >
+ *   <Text>Press me</Text>
+ * </PopupMenuAndroid>
+ * ```
+ *
+ * If the child accepts an `onPress` prop, showing the menu is automatically handled.
+ *
+ * You can also use a ref to show the menu:
+ *
+ * ```
+ * <PopupMenuAndroid
+ *   ref={c => this._menu = c}
+ *   items={[
+ *     { value: 'Apples' },
+ *     { value: 'Oranges' }
+ *   ]}
+ *   onItemSelect={({ value, index }) => console.log(`Selected ${value} at ${index}`)}
+ *   onDismiss={() => console.log(`Dismissed`)}
+ * >
+ *   <Text onPress={() => this._menu.show()}>Press me</Text>
+ * </PopupMenuAndroid>
+ * ```
+ */
+class PopupMenuAndroid extends React.Component<void, Props, void> {
+  static propTypes = {
+    children: PropTypes.element.isRequired,
+    items: PropTypes.arrayOf(PropTypes.shape({ value: PropTypes.string })).isRequired,
+    onItemSelect: PropTypes.func.isRequired,
+    onDismiss: PropTypes.func,
+    onError: PropTypes.func,
+  };
+
+  show() {
+    UIManager.showPopupMenu(
+      ReactNative.findNodeHandle(this._anchor),
+      this.props.items.map(({ value }) => value),
+      this.props.onError,
+      this._handleClose
+    );
+  }
+
+  _handleClose = (action, index) => {
+    switch (action) {
+      case 'itemSelected': {
+        const { value } = this.props.items[index];
+        this.props.onItemSelect({ index, value });
+        break;
+      }
+      case 'dismissed': {
+        if (this.props.onDismiss) {
+          this.props.onDismiss();
+        }
+        break;
+      }
+    }
+  };
+
+  _handleAnchorPress = e => {
+    const child = React.Children.only(this.props.children);
+
+    if (child.props.onPress) {
+      child.props.onPress(e);
+    } else {
+      this.show();
+    }
+  };
+
+  _anchor: any;
+
+  _setRef = c => (this._anchor = c);
+
+  render() {
+    return React.cloneElement(React.Children.only(this.props.children), {
+      ref: this._setRef,
+      onPress: this._handleAnchorPress,
+      collapsable: false, // prevent android views from collapsing
+    });
+  }
+}
+
+module.exports = PopupMenuAndroid;

--- a/Libraries/Components/PopupMenuAndroid/PopupMenuAndroid.android.js
+++ b/Libraries/Components/PopupMenuAndroid/PopupMenuAndroid.android.js
@@ -1,14 +1,12 @@
 /**
  * Copyright (c) 2015-present, Facebook, Inc.
- * All rights reserved.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  *
  * @flow
- * @providesModule PopupMenuAndroid
  */
+
 'use strict';
 
 const React = require('react');

--- a/Libraries/Components/PopupMenuAndroid/PopupMenuAndroid.ios.js
+++ b/Libraries/Components/PopupMenuAndroid/PopupMenuAndroid.ios.js
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ * @providesModule PopupMenuAndroid
+ */
+'use strict';
+
+module.exports = require('UnimplementedView');

--- a/Libraries/Components/PopupMenuAndroid/PopupMenuAndroid.ios.js
+++ b/Libraries/Components/PopupMenuAndroid/PopupMenuAndroid.ios.js
@@ -1,14 +1,12 @@
 /**
  * Copyright (c) 2015-present, Facebook, Inc.
- * All rights reserved.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  *
  * @flow
- * @providesModule PopupMenuAndroid
  */
+
 'use strict';
 
 module.exports = require('UnimplementedView');

--- a/RNTester/js/PopupMenuAndroidExample.js
+++ b/RNTester/js/PopupMenuAndroidExample.js
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ * @providesModule PopupMenuExample
+ */
+'use strict';
+
+const React = require('react');
+const ReactNative = require('react-native');
+const StyleSheet = require('StyleSheet');
+const RNTesterBlock = require('RNTesterBlock');
+const RNTesterPage = require('RNTesterPage');
+
+const {
+  PopupMenuAndroid,
+  ToastAndroid,
+  View,
+  Text,
+} = ReactNative;
+
+class PopupMenuExample extends React.Component {
+  static title = '<PopupMenuAndroid>';
+  static description = 'Provides a popup menu with options to choose from.';
+
+  _menu: any;
+
+  render() {
+    return (
+      <RNTesterPage title="<PopupMenuAndroid>">
+        <RNTesterBlock title="Handle automatically">
+          <View style={styles.center}>
+            <PopupMenuAndroid
+              items={[
+                { value: 'Apples' },
+                { value: 'Oranges' }
+              ]}
+              onDismiss={() => ToastAndroid.show('Dismissed', ToastAndroid.SHORT)}
+              onItemSelect={({ value }) => ToastAndroid.show(`Selected ${value}`, ToastAndroid.SHORT)}
+              >
+              <Text style={styles.label} >
+                Press me
+              </Text>
+            </PopupMenuAndroid>
+          </View>
+        </RNTesterBlock>
+        <RNTesterBlock title="Show with a ref">
+          <View style={styles.right}>
+            <PopupMenuAndroid
+              items={[
+                { value: 'Apples' },
+                { value: 'Oranges' }
+              ]}
+              onDismiss={() => ToastAndroid.show('Dismissed', ToastAndroid.SHORT)}
+              onItemSelect={({ value }) => ToastAndroid.show(`Selected ${value}`, ToastAndroid.SHORT)}
+              ref={c => this._menu = c}
+              >
+              <Text style={styles.label} onPress={() => this._menu.show()}>
+                Press me
+              </Text>
+            </PopupMenuAndroid>
+          </View>
+        </RNTesterBlock>
+      </RNTesterPage>
+    );
+  }
+}
+
+var styles = StyleSheet.create({
+  center: {
+    alignItems: 'center',
+  },
+  right: {
+    alignItems: 'flex-end',
+  },
+  label: {
+    margin: 8,
+  }
+});
+
+module.exports = PopupMenuExample;

--- a/RNTester/js/PopupMenuAndroidExample.js
+++ b/RNTester/js/PopupMenuAndroidExample.js
@@ -1,14 +1,12 @@
 /**
  * Copyright (c) 2015-present, Facebook, Inc.
- * All rights reserved.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  *
  * @flow
- * @providesModule PopupMenuExample
  */
+
 'use strict';
 
 const React = require('react');

--- a/RNTester/js/RNTesterList.android.js
+++ b/RNTester/js/RNTesterList.android.js
@@ -61,6 +61,10 @@ const ComponentExamples: Array<RNTesterExample> = [
     module: require('./PickerExample'),
   },
   {
+    key: 'PopupMenuAndroidExample',
+    module: require('./PopupMenuAndroidExample'),
+  },
+  {
     key: 'ProgressBarAndroidExample',
     module: require('./ProgressBarAndroidExample'),
   },


### PR DESCRIPTION
### Motivation

On Android, a `showPopupMenu` method exists on `UIManager` which shows a popup menu. But the API is not very nice and can be hard to use due to manually handling refs etc. This PR aims to provide a simple component that can be used to render a popup menu with automatic handling of the anchor.

### API

```js
<PopupMenuAndroid
  items={[
    { value: 'Apples' },
    { value: 'Oranges' }
  ]}
  onItemSelect={({ value, index }) => console.log(`Selected ${value} at ${index}`)}
  onDismiss={() => console.log(`Dismissed`)}
>
  <Text>Press me</Text>
</PopupMenuAndroid>
```

A ref can be set on `PopupMenuAndroid` to manually show the menu with the `show` method on the ref.

### Test plan

Open `RNTester` app and switch to the `PopupMenuAndroid` screen

Screenshot:
![image](https://user-images.githubusercontent.com/1174278/27257965-855ceed4-5409-11e7-836a-651860a54a45.png)
