### PR TITLE
Document URI for Android asset folder images

### DIFF
--- a/docs/Images.md
+++ b/docs/Images.md
@@ -75,14 +75,21 @@ A caveat is that videos must use absolute positioning instead of `flexGrow`, sin
 
 ## Images From Hybrid App's Resources
 
-If you are building a hybrid app (some UIs in React Native, some UIs in platform code) you can still use images that are already bundled into the app (via Xcode asset catalogs or Android drawable folder):
+If you are building a hybrid app (some UIs in React Native, some UIs in platform code) you can still use images that are already bundled into the app.
+
+For images included via Xcode asset catalogs or in the Android drawable folder, use the image name without the extension:
 
 ```javascript
 <Image source={{uri: 'app_icon'}} style={{width: 40, height: 40}} />
 ```
 
-This approach provides no safety checks. It's up to you to guarantee that those images are available in the application. Also you have to specify image dimensions manually.
+For images in the Android assets folder, use the `asset:/` scheme:
 
+```javascript
+<Image source={{uri: 'asset:/app_icon'}} style={{width: 40, height: 40}} />
+```
+
+These approaches provide no safety checks. It's up to you to guarantee that those images are available in the application. Also you have to specify image dimensions manually.
 
 ## Network Images
 

--- a/docs/Images.md
+++ b/docs/Images.md
@@ -86,7 +86,7 @@ For images included via Xcode asset catalogs or in the Android drawable folder, 
 For images in the Android assets folder, use the `asset:/` scheme:
 
 ```javascript
-<Image source={{uri: 'asset:/app_icon'}} style={{width: 40, height: 40}} />
+<Image source={{uri: 'asset:/app_icon.png'}} style={{width: 40, height: 40}} />
 ```
 
 These approaches provide no safety checks. It's up to you to guarantee that those images are available in the application. Also you have to specify image dimensions manually.


### PR DESCRIPTION
## Motivation (required)

How to load images from the Android assets folder was undocumented, and took us a little while to find out how to do it.

## Test Plan (required)

This is a documentation-only change. 

To confirm the syntax works create a sample app with an image at `android/app/src/main/assets/foo.png`.

Then add JSX `<Image style={{width:100, height:100}} source={{uri: 'asset:/foo.png'}} />`.

See that the image is rendered (Android only).
