### PR TITLE
Update of react gradle to increase node heap

### DIFF
--- a/react.gradle
+++ b/react.gradle
@@ -80,10 +80,10 @@ gradle.projectsEvaluated {
                 def devEnabled = !(config."devDisabledIn${targetName}"
                     || targetName.toLowerCase().contains("release"))
                 if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-                    commandLine("cmd", "/c", *nodeExecutableAndArgs, cliPath, "bundle", "--platform", "android", "--dev", "${devEnabled}",
+                    commandLine("cmd", "/c", *nodeExecutableAndArgs, "--expose-gc", "--max_old_space_size=4096", cliPath, "bundle", "--platform", "android", "--dev", "${devEnabled}",
                             "--reset-cache", "--entry-file", entryFile, "--bundle-output", jsBundleFile, "--assets-dest", resourcesDir, *extraPackagerArgs)
                 } else {
-                    commandLine(*nodeExecutableAndArgs, cliPath, "bundle", "--platform", "android", "--dev", "${devEnabled}",
+                    commandLine(*nodeExecutableAndArgs, "--expose-gc", "--max_old_space_size=4096", cliPath, "bundle", "--platform", "android", "--dev", "${devEnabled}",
                             "--reset-cache", "--entry-file", entryFile, "--bundle-output", jsBundleFile, "--assets-dest", resourcesDir, *extraPackagerArgs)
                 }
 


### PR DESCRIPTION
Updated gradle file, so that packager will not fail on assembling projects with big amount of assets

## Motivation (required)

When building the apps for android with more then 200mb of assets the packager will fail on JavaScript heap end. This will solve that problem.

## Test Plan (required)

Try to build application with 150 images 4-20mb each. Before now it will fail on JavaScript heap end. After this commit that error will be solved (for now only for android).
