### PR TITLE
Fix Movie Fetcher tutorial problem loading Mocked_DATA images

### DIFF
--- a/Libraries/Utilities/throwOnWrongReactAPI.js
+++ b/Libraries/Utilities/throwOnWrongReactAPI.js
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule throwOnWrongReactAPI
+ * @flow
+ */
+
+'use strict';
+
+function throwOnWrongReactAPI(key: string) {
+  throw new Error(
+`Seems you're trying to access 'ReactNative.${key}' from the 'react-native' package. Perhaps you meant to access 'React.${key}' from the 'react' package instead?
+
+For example, instead of:
+
+  import React, { Component, View } from 'react-native';
+
+You should now do:
+
+  import React, { Component } from 'react';
+  import { View } from 'react-native';
+
+Check the release notes on how to upgrade your code - https://github.com/facebook/react-native/releases/tag/v0.25.1
+`);
+}
+
+module.exports = throwOnWrongReactAPI;

--- a/Libraries/react-native/react-native.js
+++ b/Libraries/react-native/react-native.js
@@ -173,6 +173,20 @@ const ReactNative = {
   },
 };
 
+// Better error messages when accessing React APIs on ReactNative
+if (__DEV__) {
+  const throwOnWrongReactAPI = require('throwOnWrongReactAPI');
+  const reactAPIs = [ 'createClass', 'Component' ];
+
+  for (const key of reactAPIs) {
+    Object.defineProperty(ReactNative, key, {
+      get() { throwOnWrongReactAPI(key); },
+      enumerable: false,
+      configurable: false
+    });
+  }
+}
+
 // Preserve getters with warnings on the internal ReactNative copy without
 // invoking them.
 const ReactNativeInternal = require('ReactNative');

--- a/React.podspec
+++ b/React.podspec
@@ -4,7 +4,7 @@ package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
 Pod::Spec.new do |s|
   s.name                = "React"
-  s.version             = package['version']
+  s.version             = "0.28.0-rc.0"
   s.summary             = package['description']
   s.description         = <<-DESC
                             React Native apps are built using the React JS

--- a/React.podspec
+++ b/React.podspec
@@ -4,7 +4,7 @@ package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
 Pod::Spec.new do |s|
   s.name                = "React"
-  s.version             = "0.28.0-rc.0"
+  s.version             = "0.28.0"
   s.summary             = package['description']
   s.description         = <<-DESC
                             React Native apps are built using the React JS

--- a/ReactAndroid/gradle.properties
+++ b/ReactAndroid/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=0.28.0-rc.0
+VERSION_NAME=0.28.0
 GROUP=com.facebook.react
 
 POM_NAME=ReactNative

--- a/ReactAndroid/gradle.properties
+++ b/ReactAndroid/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=1000.0.0-master
+VERSION_NAME=0.28.0-rc.0
 GROUP=com.facebook.react
 
 POM_NAME=ReactNative

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/image/ImageLoaderModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/image/ImageLoaderModule.java
@@ -11,9 +11,6 @@ package com.facebook.react.modules.image;
 
 import android.net.Uri;
 
-import com.facebook.react.bridge.Arguments;
-import com.facebook.react.bridge.Callback;
-import com.facebook.react.bridge.WritableMap;
 import com.facebook.common.executors.CallerThreadExecutor;
 import com.facebook.common.references.CloseableReference;
 import com.facebook.datasource.BaseDataSubscriber;
@@ -23,10 +20,12 @@ import com.facebook.drawee.backends.pipeline.Fresco;
 import com.facebook.imagepipeline.image.CloseableImage;
 import com.facebook.imagepipeline.request.ImageRequest;
 import com.facebook.imagepipeline.request.ImageRequestBuilder;
+import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
+import com.facebook.react.bridge.WritableMap;
 
 public class ImageLoaderModule extends ReactContextBaseJavaModule {
 
@@ -83,27 +82,20 @@ public class ImageLoaderModule extends ReactContextBaseJavaModule {
               sizes.putInt("width", image.getWidth());
               sizes.putInt("height", image.getHeight());
 
-              image.close();
               promise.resolve(sizes);
             } catch (Exception e) {
               promise.reject(ERROR_GET_SIZE_FAILURE, e);
             } finally {
               CloseableReference.closeSafely(ref);
-              dataSource.close();
             }
           } else {
-            dataSource.close();
             promise.reject(ERROR_GET_SIZE_FAILURE);
           }
         }
 
         @Override
         protected void onFailureImpl(DataSource<CloseableReference<CloseableImage>> dataSource) {
-          try {
-            promise.reject(ERROR_GET_SIZE_FAILURE, dataSource.getFailureCause());
-          } finally {
-            dataSource.close();
-          }
+          promise.reject(ERROR_GET_SIZE_FAILURE, dataSource.getFailureCause());
         }
       };
     dataSource.subscribe(dataSubscriber, CallerThreadExecutor.getInstance());

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/websocket/WebSocketModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/websocket/WebSocketModule.java
@@ -223,7 +223,7 @@ public class WebSocketModule extends ReactContextBaseJavaModule {
       throw new RuntimeException("Cannot send a message. Unknown WebSocket id " + id);
     }
     try {
-      client.sendMessage(RequestBody.create(WebSocket.TEXT, ByteString.decodeBase64(base64String)));
+      client.sendMessage(RequestBody.create(WebSocket.BINARY, ByteString.decodeBase64(base64String)));
     } catch (IOException | IllegalStateException e) {
       notifyWebSocketFailed(id, e.getMessage());
     }

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeViewHierarchyManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeViewHierarchyManager.java
@@ -348,7 +348,8 @@ public class NativeViewHierarchyManager {
 
         View viewToRemove = viewToManage.getChildAt(indexToRemove);
 
-        if (mLayoutAnimator.shouldAnimateLayout(viewToRemove) &&
+        if (mLayoutAnimationEnabled &&
+            mLayoutAnimator.shouldAnimateLayout(viewToRemove) &&
             arrayContains(tagsToDelete, viewToRemove.getId())) {
           // The view will be removed and dropped by the 'delete' layout animation
           // instead, so do nothing
@@ -395,7 +396,8 @@ public class NativeViewHierarchyManager {
                       tagsToDelete));
         }
 
-        if (mLayoutAnimator.shouldAnimateLayout(viewToDestroy)) {
+        if (mLayoutAnimationEnabled &&
+            mLayoutAnimator.shouldAnimateLayout(viewToDestroy)) {
           mLayoutAnimator.deleteView(viewToDestroy, new LayoutAnimationListener() {
             @Override
             public void onAnimationEnd() {

--- a/docs/SampleApplication-Movies.md
+++ b/docs/SampleApplication-Movies.md
@@ -52,7 +52,7 @@ Before we write the code to fetch actual Rotten Tomatoes data let's mock some da
 
 ```javascript
 var MOCKED_MOVIES_DATA = [
-  {title: 'Title', year: '2015', posters: {thumbnail: 'http://i.imgur.com/UePbdph.jpg'}},
+  {title: 'Title', year: '2015', posters: {thumbnail: 'https://i.imgur.com/UePbdph.jpg'}},
 ];
 ```
 

--- a/local-cli/generator-android/templates/src/app/proguard-rules.pro
+++ b/local-cli/generator-android/templates/src/app/proguard-rules.pro
@@ -26,11 +26,14 @@
 # See http://sourceforge.net/p/proguard/bugs/466/
 -keep,allowobfuscation @interface com.facebook.proguard.annotations.DoNotStrip
 -keep,allowobfuscation @interface com.facebook.proguard.annotations.KeepGettersAndSetters
+-keep,allowobfuscation @interface com.facebook.common.internal.DoNotStrip
 
 # Do not strip any method/class that is annotated with @DoNotStrip
 -keep @com.facebook.proguard.annotations.DoNotStrip class *
+-keep @com.facebook.common.internal.DoNotStrip class *
 -keepclassmembers class * {
     @com.facebook.proguard.annotations.DoNotStrip *;
+    @com.facebook.common.internal.DoNotStrip *;
 }
 
 -keepclassmembers @com.facebook.proguard.annotations.KeepGettersAndSetters class * {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native",
-  "version": "0.28.0-rc.0",
+  "version": "0.28.0",
   "description": "A framework for building native apps using React",
   "license": "BSD-3-Clause",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native",
-  "version": "1000.0.0",
+  "version": "0.28.0-rc.0",
   "description": "A framework for building native apps using React",
   "license": "BSD-3-Clause",
   "repository": {


### PR DESCRIPTION
## Motivation (required)

_What existing problem does the pull request solve?_
When going through the Movie Fetcher tutorial images failed to load right at the beginning due to the lack of an 's' in the first 'http' requesting the thumbnail.

The fix permits the user to complete Movie Fetcher tutorial by loading the resources from mocked data as expected, while allowing user to continue and complete tutorial.

## Test Plan (required)

Minimal doc edit* No edit to codebase.
