### PR TITLE
Allow apps to manually control when the dev support tools are enabled

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
@@ -151,6 +151,7 @@ public class ReactInstanceManager {
   private final boolean mSetupReactContextInBackgroundEnabled;
   private final boolean mUseSeparateUIBackgroundThread;
   private final int mMinNumShakes;
+  private final boolean mManuallyEnableDevSupport;
 
   private final ReactInstanceDevCommandsHandler mDevInterface =
       new ReactInstanceDevCommandsHandler() {
@@ -225,7 +226,8 @@ public class ReactInstanceManager {
     @Nullable DevBundleDownloadListener devBundleDownloadListener,
     boolean setupReactContextInBackgroundEnabled,
     boolean useSeparateUIBackgroundThread,
-    int minNumShakes) {
+    int minNumShakes,
+    boolean manuallyEnableDevSupport) {
     Log.d(ReactConstants.TAG, "ReactInstanceManager.ctor()");
     initializeSoLoaderIfNecessary(applicationContext);
 
@@ -257,6 +259,7 @@ public class ReactInstanceManager {
     mSetupReactContextInBackgroundEnabled = setupReactContextInBackgroundEnabled;
     mUseSeparateUIBackgroundThread = useSeparateUIBackgroundThread;
     mMinNumShakes = minNumShakes;
+    mManuallyEnableDevSupport = manuallyEnableDevSupport;
 
     CoreModulesPackage coreModulesPackage =
       new CoreModulesPackage(
@@ -483,7 +486,7 @@ public class ReactInstanceManager {
     UiThreadUtil.assertOnUiThread();
 
     mDefaultBackButtonImpl = null;
-    if (mUseDeveloperSupport) {
+    if (mUseDeveloperSupport && !mManuallyEnableDevSupport) {
       mDevSupportManager.setDevSupportEnabled(false);
     }
 
@@ -525,7 +528,7 @@ public class ReactInstanceManager {
     UiThreadUtil.assertOnUiThread();
 
     mDefaultBackButtonImpl = defaultBackButtonImpl;
-    if (mUseDeveloperSupport) {
+    if (mUseDeveloperSupport && !mManuallyEnableDevSupport) {
       mDevSupportManager.setDevSupportEnabled(true);
     }
 
@@ -543,7 +546,7 @@ public class ReactInstanceManager {
   public void onHostDestroy() {
     UiThreadUtil.assertOnUiThread();
 
-    if (mUseDeveloperSupport) {
+    if (mUseDeveloperSupport && !mManuallyEnableDevSupport) {
       mDevSupportManager.setDevSupportEnabled(false);
     }
 
@@ -572,7 +575,7 @@ public class ReactInstanceManager {
   public void destroy() {
     UiThreadUtil.assertOnUiThread();
 
-    if (mUseDeveloperSupport) {
+    if (mUseDeveloperSupport && !mManuallyEnableDevSupport) {
       mDevSupportManager.setDevSupportEnabled(false);
     }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManagerBuilder.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManagerBuilder.java
@@ -47,6 +47,7 @@ public class ReactInstanceManagerBuilder {
   protected boolean mSetupReactContextInBackground;
   protected boolean mUseSeparateUIBackgroundThread;
   protected int mMinNumShakes = 1;
+  protected boolean mManuallyEnableDevSupport;
 
   /* package protected */ ReactInstanceManagerBuilder() {
   }
@@ -214,6 +215,17 @@ public class ReactInstanceManagerBuilder {
   }
 
   /**
+   * By default, the developer support tools will be enabled and disabled in {@link #onHostPause()}
+   * and {@link #onHostResume(Activity, DefaultHardwareBackBtnHandler)}. This may not be ideal for
+   * multi-activity applications that often switch between native and react native screens or
+   * apps that want tighter control over when the dev tools should be enabled.
+   */
+  public ReactInstanceManagerBuilder manuallyEnableDevSupport() {
+    mManuallyEnableDevSupport = true;
+    return this;
+  }
+
+  /**
    * Instantiates a new {@link ReactInstanceManager}.
    * Before calling {@code build}, the following must be called:
    * <ul>
@@ -262,6 +274,7 @@ public class ReactInstanceManagerBuilder {
       mDevBundleDownloadListener,
       mSetupReactContextInBackground,
       mUseSeparateUIBackgroundThread,
-      mMinNumShakes);
+      mMinNumShakes,
+      mManuallyEnableDevSupport);
   }
 }


### PR DESCRIPTION
## Motivation
For multi-activity apps, apps that want fine grained control over when the dev support tools are enabled, or apps that frequently switch between native and react native, it isn't ideal to automatically enable and disable the dev tools in onHostPause and onHostResume. This allows apps to manually control when the dev tools are enabled. For example, in the Airbnb app, we enable and disable dev tools in our base Activity so the menu is available in native screens as well as React Native screens.

## Test Plan
This has been running on the Airbnb fork for several months (https://github.com/airbnb/react-native/commit/50325eae895112eef903fde5b92c566c8d392efa and https://github.com/airbnb/react-native/commit/404b1030ead595e60a1d4c79e1732a8bfc8aeb1a)

Fixes #13135
