### PR TITLE
Removing test-driver symlink in ios third party install script

### DIFF
--- a/scripts/ios-configure-glog.sh
+++ b/scripts/ios-configure-glog.sh
@@ -7,6 +7,11 @@ if [ -z "$ACTION" ] || [ -z "$BUILD_DIR" ]; then
   export CXX="$CC"
 fi
 
+# Remove automake symlink if it exists
+if [ -h "test-driver" ]; then
+    rm test-driver
+fi
+
 ./configure --host arm-apple-darwin
 
 # Fix build for tvOS

--- a/scripts/ios-install-third-party.sh
+++ b/scripts/ios-install-third-party.sh
@@ -25,6 +25,9 @@ function fetch_and_unpack () {
              exit 1
          fi
          cd "$dir"
+         if [ -h "test-driver" ]; then
+             rm test-driver
+         fi
          eval "${cmd:-true}")
     fi
 }

--- a/scripts/ios-install-third-party.sh
+++ b/scripts/ios-install-third-party.sh
@@ -25,9 +25,6 @@ function fetch_and_unpack () {
              exit 1
          fi
          cd "$dir"
-         if [ -h "test-driver" ]; then
-             rm test-driver
-         fi
          eval "${cmd:-true}")
     fi
 }


### PR DESCRIPTION
## Motivation (required)
After execution of `scripts/ios-install-third-party.sh` a symlink is created : 
`<YOUR-APP-PATH>/node_modules/react-native/third-party/glog-0.3.4/test-driver`
that is pointing to `test-driver -> /usr/share/automake-1.14/test-driver`
This can be executed indirectly by `react-native run-ios`.

This breaks the bundle process if the system don't contain a given file under the link and having this strict dependency on the system setup is not a good practice.

Once the `test-driver` symlink is created android app release is failing, for :
`./gradlew assembleRelease`
the `:app:bundleReleaseJsAndAssets` returns :
```
FAILURE: Build failed with an exception.

* What went wrong:
Could not list contents of '<YOUR-APP-PATH>/node_modules/react-native/third-party/glog-0.3.4/test-driver'. Couldn't follow symbolic link.
```
Related issues:
https://github.com/facebook/react-native/issues/14417
https://github.com/facebook/react-native/issues/14464
https://github.com/facebook/react-native/issues/14548

## Test Plan (required)

1. Create new project with `react-native init <YOUR-APP>`
2. cd `<YOUR-APP>/`
3. Run app on iOS `react-native run-ios` so `scripts/ios-install-third-party.sh` is executed.
4. cd `android/`
5. Run android app release `./gradlew assembleRelease` (it will work properly after this fix and fail if the `test-driver` symlink exists)

## Summary
IMHO we should resolve the issue with this quick fix and apply the proper fix later after the new version of `google/glog` will be released.
The proper cleanup of files generated by autotools was already applied : https://github.com/google/glog/pull/188

Please let me know if I should provide more details : @javache, @mhorowitz, @hramos 
