### PR TITLE
[0.45] react@16 did away with PropTypes; require prop-types instead

### DIFF
--- a/Libraries/Components/AppleTV/TVViewPropTypes.js
+++ b/Libraries/Components/AppleTV/TVViewPropTypes.js
@@ -10,7 +10,7 @@
  * @flow
  */
 'use strict';
-var PropTypes = require('React').PropTypes;
+var PropTypes = require('prop-types');
 
 /**
  * Additional View properties for Apple TV

--- a/Libraries/Components/Picker/PickerAndroid.android.js
+++ b/Libraries/Components/Picker/PickerAndroid.android.js
@@ -14,6 +14,7 @@
 
 var ColorPropType = require('ColorPropType');
 var React = require('React');
+var ReactPropTypes = require('prop-types');
 var StyleSheet = require('StyleSheet');
 var StyleSheetPropType = require('StyleSheetPropType');
 const ViewPropTypes = require('ViewPropTypes');
@@ -21,8 +22,6 @@ var ViewStylePropTypes = require('ViewStylePropTypes');
 
 var processColor = require('processColor');
 var requireNativeComponent = require('requireNativeComponent');
-
-var ReactPropTypes = React.PropTypes;
 
 var REF_PICKER = 'picker';
 var MODE_DROPDOWN = 'dropdown';
@@ -53,7 +52,7 @@ class PickerAndroid extends React.Component {
   static propTypes = {
     ...ViewPropTypes,
     style: pickerStyleType,
-    selectedValue: React.PropTypes.any,
+    selectedValue: ReactPropTypes.any,
     enabled: ReactPropTypes.bool,
     mode: ReactPropTypes.oneOf(['dialog', 'dropdown']),
     onValueChange: ReactPropTypes.func,

--- a/Libraries/Components/View/ShadowPropTypesIOS.js
+++ b/Libraries/Components/View/ShadowPropTypesIOS.js
@@ -12,7 +12,7 @@
 'use strict';
 
 var ColorPropType = require('ColorPropType');
-var ReactPropTypes = require('React').PropTypes;
+var ReactPropTypes = require('prop-types');
 
 var ShadowPropTypesIOS = {
   /**

--- a/Libraries/Components/View/ViewStylePropTypes.js
+++ b/Libraries/Components/View/ViewStylePropTypes.js
@@ -12,7 +12,7 @@
 'use strict';
 
 var LayoutPropTypes = require('LayoutPropTypes');
-var ReactPropTypes = require('React').PropTypes;
+var ReactPropTypes = require('prop-types');
 var ColorPropType = require('ColorPropType');
 var ShadowPropTypesIOS = require('ShadowPropTypesIOS');
 var TransformPropTypes = require('TransformPropTypes');

--- a/Libraries/Image/ImageStylePropTypes.js
+++ b/Libraries/Image/ImageStylePropTypes.js
@@ -14,10 +14,10 @@
 var ImageResizeMode = require('ImageResizeMode');
 var LayoutPropTypes = require('LayoutPropTypes');
 var ColorPropType = require('ColorPropType');
+var ReactPropTypes = require('prop-types');
 var ShadowPropTypesIOS = require('ShadowPropTypesIOS');
 var TransformPropTypes = require('TransformPropTypes');
 
-var ReactPropTypes = require('React').PropTypes;
 
 var ImageStylePropTypes = {
   ...LayoutPropTypes,

--- a/Libraries/ReactNative/AppContainer.js
+++ b/Libraries/ReactNative/AppContainer.js
@@ -13,6 +13,7 @@
 'use strict';
 
 const EmitterSubscription = require('EmitterSubscription');
+const PropTypes = require('prop-types');
 const RCTDeviceEventEmitter = require('RCTDeviceEventEmitter');
 const React = require('React');
 const ReactNative = require('ReactNative');
@@ -41,7 +42,7 @@ class AppContainer extends React.Component {
   _subscription: ?EmitterSubscription = null;
 
   static childContextTypes = {
-    rootTag: React.PropTypes.number,
+    rootTag: PropTypes.number,
   };
 
   getChildContext(): Context {

--- a/Libraries/StyleSheet/LayoutPropTypes.js
+++ b/Libraries/StyleSheet/LayoutPropTypes.js
@@ -11,7 +11,7 @@
  */
 'use strict';
 
-var ReactPropTypes = require('React').PropTypes;
+var ReactPropTypes = require('prop-types');
 
 /**
  * React Native's layout system is based on Flexbox and is powered both

--- a/Libraries/StyleSheet/PointPropType.js
+++ b/Libraries/StyleSheet/PointPropType.js
@@ -11,7 +11,7 @@
  */
 'use strict';
 
-var PropTypes = require('React').PropTypes;
+var PropTypes = require('prop-types');
 
 var createStrictShapeTypeChecker = require('createStrictShapeTypeChecker');
 

--- a/Libraries/StyleSheet/TransformPropTypes.js
+++ b/Libraries/StyleSheet/TransformPropTypes.js
@@ -13,7 +13,7 @@
 
 var deprecatedPropType = require('deprecatedPropType');
 
-var ReactPropTypes = require('React').PropTypes;
+var ReactPropTypes = require('prop-types');
 
 var TransformMatrixPropType = function(
   props : Object,

--- a/Libraries/Text/TextStylePropTypes.js
+++ b/Libraries/Text/TextStylePropTypes.js
@@ -11,7 +11,7 @@
  */
 'use strict';
 
-const ReactPropTypes = require('React').PropTypes;
+const ReactPropTypes = require('prop-types');
 const ColorPropType = require('ColorPropType');
 const ViewStylePropTypes = require('ViewStylePropTypes');
 

--- a/docs/NativeComponentsAndroid.md
+++ b/docs/NativeComponentsAndroid.md
@@ -107,7 +107,7 @@ The very final step is to create the JavaScript module that defines the interfac
 ```js
 // ImageView.js
 
-import { PropTypes } from 'react';
+import PropTypes from 'prop-types';
 import { requireNativeComponent, View } from 'react-native';
 
 var iface = {
@@ -168,7 +168,7 @@ MyCustomView.propTypes = {
   /**
    * Callback that is called continuously when the user is dragging the map.
    */
-  onChangeMessage: React.PropTypes.func,
+  onChangeMessage: PropTypes.func,
   ...
 };
 

--- a/docs/NativeComponentsIOS.md
+++ b/docs/NativeComponentsIOS.md
@@ -84,6 +84,7 @@ This isn't very well documented though - in order to know what properties are av
 
 ```javascript
 // MapView.js
+import PropTypes from 'prop-types';
 import React from 'react';
 import { requireNativeComponent } from 'react-native';
 
@@ -101,7 +102,7 @@ MapView.propTypes = {
    * angle is ignored and the map is always displayed as if the user
    * is looking straight down onto it.
    */
-  pitchEnabled: React.PropTypes.bool,
+  pitchEnabled: PropTypes.bool,
 };
 
 var RNTMap = requireNativeComponent('RNTMap', MapView);
@@ -177,7 +178,7 @@ MapView.propTypes = {
    * angle is ignored and the map is always displayed as if the user
    * is looking straight down onto it.
    */
-  pitchEnabled: React.PropTypes.bool,
+  pitchEnabled: PropTypes.bool,
 
   /**
    * The region to be displayed by the map.
@@ -185,19 +186,19 @@ MapView.propTypes = {
    * The region is defined by the center coordinates and the span of
    * coordinates to display.
    */
-  region: React.PropTypes.shape({
+  region: PropTypes.shape({
     /**
      * Coordinates for the center of the map.
      */
-    latitude: React.PropTypes.number.isRequired,
-    longitude: React.PropTypes.number.isRequired,
+    latitude: PropTypes.number.isRequired,
+    longitude: PropTypes.number.isRequired,
 
     /**
      * Distance between the minimum and the maximum latitude/longitude
      * to be displayed.
      */
-    latitudeDelta: React.PropTypes.number.isRequired,
-    longitudeDelta: React.PropTypes.number.isRequired,
+    latitudeDelta: PropTypes.number.isRequired,
+    longitudeDelta: PropTypes.number.isRequired,
   }),
 };
 
@@ -323,7 +324,7 @@ MapView.propTypes = {
   /**
    * Callback that is called continuously when the user is dragging the map.
    */
-  onChange: React.PropTypes.func,
+  onChange: PropTypes.func,
   ...
 };
 


### PR DESCRIPTION
`react@16` (a `peerDependency`) did away with the `PropTypes` export in favor of the `prop-types` module.

This updates all of the remaining references to `ReactPropTypes` (and yes, targets the `0.45-stable` branch; I'll submit a PR that targets `master` as well).