### PR TITLE
fix error caused by first argument short when calling warning function

### DIFF
--- a/Libraries/Geolocation/Geolocation.js
+++ b/Libraries/Geolocation/Geolocation.js
@@ -175,7 +175,7 @@ var Geolocation = {
       for (var ii = 0; ii < subscriptions.length; ii++) {
         var sub = subscriptions[ii];
         if (sub) {
-          warning('Called stopObserving with existing subscriptions.');
+          warning(false, 'Called stopObserving with existing subscriptions.');
           sub[0].remove();
           // array element refinements not yet enabled in Flow
           var sub1 = sub[1]; sub1 && sub1.remove();


### PR DESCRIPTION
<details>
  Thanks for submitting a PR! Please read these instructions carefully:

  - [X] Explain the **motivation** for making this change.
  - [] Provide a **test plan** demonstrating that the code is solid.
  - [X] Match the **code formatting** of the rest of the codebase.
  - [X] Target the `master` branch, NOT a "stable" branch.

  Please read the [Contribution Guidelines](https://github.com/facebook/react-native/blob/master/CONTRIBUTING.md) to learn more about contributing to React Native.
</details>

## Motivation (required)

My app crashed when I call navigator.geolocation.stopObserving(). I found it is caused by the reason that one argument short. So I added false to the first argument. Then bug is fixed.

## Test Plan (required)
1. call both navigator.geolocation.watchPosition and navigator.geolocation.getCurrentPosition
2. then call navigator.geolocation.stopObserving()
3. error happened before I fixed, and correct Warning "Called stopObserving with existing subscriptions." shown after I fixed.
