### PR TITLE
added chromium support for devTools on linux

### DIFF
--- a/local-cli/server/util/launchChrome.js
+++ b/local-cli/server/util/launchChrome.js
@@ -11,13 +11,13 @@
 'use strict';
 
 const opn = require('opn');
-const execSync = require('child_process').execSync
+const execSync = require('child_process').execSync;
 
 function commandExistsUnixSync (commandName, callback) {
   try {
     var stdout = execSync('command -v ' + commandName +
           ' 2>/dev/null' +
-          ' && { echo >&1 \'' + commandName + ' found\'; exit 0; }')
+          ' && { echo >&1 \'' + commandName + ' found\'; exit 0; }');
     return !!stdout;
   } catch (error) {
     return false;
@@ -32,9 +32,9 @@ function getChromeAppName(): string {
     return 'chrome';
   case 'linux':
     if (commandExistsUnixSync('google-chrome')) {
-      return 'google-chrome'
+      return 'google-chrome';
     } else {
-      return 'chromium'
+      return 'chromium';
     }
   default:
     return 'google-chrome';

--- a/local-cli/server/util/launchChrome.js
+++ b/local-cli/server/util/launchChrome.js
@@ -18,6 +18,8 @@ function getChromeAppName(): string {
     return 'google chrome';
   case 'win32':
     return 'chrome';
+  case 'linux':
+    return 'chromium';
   default:
     return 'google-chrome';
   }

--- a/local-cli/server/util/launchChrome.js
+++ b/local-cli/server/util/launchChrome.js
@@ -11,6 +11,18 @@
 'use strict';
 
 const opn = require('opn');
+const execSync = require('child_process').execSync
+
+function commandExistsUnixSync (commandName, callback) {
+  try {
+    var stdout = execSync('command -v ' + commandName +
+          ' 2>/dev/null' +
+          ' && { echo >&1 \'' + commandName + ' found\'; exit 0; }')
+    return !!stdout;
+  } catch (error) {
+    return false;
+  }
+}
 
 function getChromeAppName(): string {
   switch (process.platform) {
@@ -19,7 +31,11 @@ function getChromeAppName(): string {
   case 'win32':
     return 'chrome';
   case 'linux':
-    return 'chromium';
+    if (commandExistsUnixSync('google-chrome')) {
+      return 'google-chrome'
+    } else {
+      return 'chromium'
+    }
   default:
     return 'google-chrome';
   }


### PR DESCRIPTION
<details>
  Thanks for submitting a PR! Please read these instructions carefully:

  - [ ] Explain the **motivation** for making this change.
  - [ ] Provide a **test plan** demonstrating that the code is solid.
  - [ ] Match the **code formatting** of the rest of the codebase.
  - [ ] Target the `master` branch, NOT a "stable" branch.

  Please read the [Contribution Guidelines](https://github.com/facebook/react-native/blob/master/CONTRIBUTING.md) to learn more about contributing to React Native.
</details>

## Motivation (required)

_What existing problem does the pull request solve?_

On Linux, the packager caught an "Google Chrome exited with error: { Error: spawn google-chrome ENOENT}" when trying to launch the devTools because google-chrome is not installed but chromium is.
Thus, this pull request maps the platform Linux with chromium for launching the debugger automatically in the packager


## Test Plan (required)

_A good test plan has the exact commands you ran and their output, provides screenshots or videos if the pull request changes UI or updates the website._

- enter on terminal
    > react-native start
- launch the app in dev mode with "Debug JS remotely" enabled
- the packager prints "Launching Dev Tools..." and launch chromium with the debugger
![screenshot](https://user-images.githubusercontent.com/13065528/27481217-ceaf5e58-581b-11e7-976f-75c107596ad3.png)


