### PR TITLE
Adds plugin install feature to `install` and `uninstall`

### DIFF
--- a/local-cli/install/install.js
+++ b/local-cli/install/install.js
@@ -18,26 +18,41 @@ const spawnOpts = {
 
 log.heading = 'rnpm-install';
 
-function install(args, config) {
+function install(args, config, options) {
   const name = args[0];
 
-  let res = PackageManager.add(name);
+  let res;
+  if (options.plugin) {
+    res = PackageManager.addDev(name);
+  } else {
+    res = PackageManager.add(name);
+  }
 
   if (res.status) {
     process.exit(res.status);
   }
 
-  res = spawnSync('react-native', ['link', name], spawnOpts);
-
-  if (res.status) {
-    process.exit(res.status);
+  if (!options.plugin) {
+    res = spawnSync('react-native', ['link', name], spawnOpts);
+    if (res.status) {
+      process.exit(res.status);
+    }
   }
 
-  log.info(`Module ${name} has been successfully installed & linked`);
+  if (options.plugin) {
+    log.info(`Plugin ${name} has been successfully installed`);
+  } else {
+    log.info(`Module ${name} has been successfully installed & linked`);
+  }
 }
 
 module.exports = {
   func: install,
   description: 'install and link native dependencies',
   name: 'install <packageName>',
+  options: [{
+    command: '--plugin',
+    description: 'signals that the target is a plugin',
+    default: false,
+  }],
 };

--- a/local-cli/install/uninstall.js
+++ b/local-cli/install/uninstall.js
@@ -18,26 +18,42 @@ const spawnOpts = {
 
 log.heading = 'rnpm-install';
 
-function uninstall(args, config) {
+function uninstall(args, config, options) {
   const name = args[0];
 
-  var res = spawnSync('react-native', ['unlink', name], spawnOpts);
+  let res;
+  if (!options.plugin) {
+    res = spawnSync('react-native', ['unlink', name], spawnOpts);
+
+    if (res.status) {
+      process.exit(res.status);
+    }
+  }
+
+  if (options.plugin) {
+    res = PackageManager.removeDev(name);
+  } else {
+    res = PackageManager.remove(name);
+  }
 
   if (res.status) {
     process.exit(res.status);
   }
 
-  res = PackageManager.remove(name);
-
-  if (res.status) {
-    process.exit(res.status);
+  if (options.plugin) {
+    log.info(`Plugin ${name} has been successfully uninstalled`);
+  } else {
+    log.info(`Module ${name} has been successfully uninstalled & unlinked`);
   }
-
-  log.info(`Module ${name} has been successfully uninstalled & unlinked`);
 }
 
 module.exports = {
   func: uninstall,
   description: 'uninstall and unlink native dependencies',
   name: 'uninstall <packageName>',
+  options: [{
+    command: '--plugin',
+    description: 'signals that the target is a plugin',
+    default: false,
+  }],
 };

--- a/local-cli/util/PackageManager.js
+++ b/local-cli/util/PackageManager.js
@@ -38,8 +38,12 @@ function callYarnOrNpm(yarnCommand, npmCommand) {
 
   const args = command.split(' ');
   const cmd = args.shift();
+  let fixedCmd = cmd;
+  if (process.platform === 'win32') {
+    fixedCmd = `${cmd}.cmd`;
+  }
 
-  const res = spawnSync(cmd, args, spawnOpts);
+  const res = spawnSync(fixedCmd, args, spawnOpts);
 
   return res;
 }
@@ -68,7 +72,34 @@ function remove(packageName) {
   );
 }
 
+/**
+ * Install package into project using npm or yarn if available
+ * @param  {[type]} packageName Package to be installed
+ * @return {[type]}             spawnSync's result object
+ */
+function addDev(packageName) {
+  return callYarnOrNpm(
+    `yarn add ${packageName} --dev`,
+    `npm install ${packageName} --save-dev`
+  );
+}
+
+/**
+ * Uninstall package from project using npm or yarn if available
+ * @param  {[type]} packageName Package to be uninstalled
+ * @return {Object}             spawnSync's result object
+ */
+function removeDev(packageName) {
+  return callYarnOrNpm(
+    `yarn remove ${packageName} --dev`,
+    `npm uninstall --save-dev ${packageName}`
+  );
+}
+
+
 module.exports = {
   add: add,
+  addDev: addDev,
   remove: remove,
+  removeDev: removeDev,
 };


### PR DESCRIPTION


<details>
  Thanks for submitting a PR! Please read these instructions carefully:

  - [x] Explain the **motivation** for making this change.
  - [x] Provide a **test plan** demonstrating that the code is solid.
  - [x] Match the **code formatting** of the rest of the codebase.
  - [x] Target the `master` branch, NOT a "stable" branch.

  Please read the [Contribution Guidelines](https://github.com/facebook/react-native/blob/master/CONTRIBUTING.md) to learn more about contributing to React Native.
</details>

## Motivation (required)

_What existing problem does the pull request solve?_

For react-native-windows (as well as other CLI plugins for react-native), the user should not be expected to know whether they need to use yarn or NPM to install a CLI plugin. We were running into issues where users installed react-native using yarn, but when following our tutorial for adding `rnpm-plugin-windows`, the CLI would break as the instructions currently say to use NPM. These plugins will allow us to have a simple tutorial for how to install the `rnpm-plugin-windows`, as well as any other RN CLI plugin. The plugins use the existing CLI utilities to check if the project is yarn or NPM based, and then install the specified plugin accordingly.

## Test Plan (required)

_A good test plan has the exact commands you ran and their output, provides screenshots or videos if the pull request changes UI or updates the website._

I tested this CLI plugin using sinopia. I made the changes, published react-native to sinopia, generated new projects from the package in sinopia (with yarn and NPM), and verified that the correct tool was used to install plugins in each case.

cc @grabbou 
