### PR TITLE
Fixed FlatList._getItemCount returning NaN

### DIFF
--- a/Libraries/Lists/FlatList.js
+++ b/Libraries/Lists/FlatList.js
@@ -467,7 +467,7 @@ class FlatList<ItemT>
   };
 
   _getItemCount = (data: ?Array<ItemT>): number => {
-    return data ? Math.ceil(data.length / this.props.numColumns) : 0;
+    return (data && data.length) ? Math.ceil(data.length / this.props.numColumns) : 0;
   };
 
   _keyExtractor = (items: ItemT | Array<ItemT>, index: number) => {


### PR DESCRIPTION
If FlatList data prop is set to a non-array object, this method return `NaN` causing a infinite loop down the road

<details>
  Thanks for submitting a PR! Please read these instructions carefully:

  - [ ] Explain the **motivation** for making this change.
  - [ ] Provide a **test plan** demonstrating that the code is solid.
  - [ ] Match the **code formatting** of the rest of the codebase.
  - [ ] Target the `master` branch, NOT a "stable" branch.

  Please read the [Contribution Guidelines](https://github.com/facebook/react-native/blob/master/CONTRIBUTING.md) to learn more about contributing to React Native.
</details>

## Motivation (required)

https://github.com/facebook/react-native/issues/14707

## Test Plan (required)

See the Issue above.