### PR TITLE
Upgrade metro-bundler to 0.9 and rename refs from build to src dir

### DIFF
--- a/jest/preprocessor.js
+++ b/jest/preprocessor.js
@@ -11,9 +11,9 @@
 'use strict';
 
 const babel = require('babel-core');
-const babelRegisterOnly = require('metro-bundler/build/babelRegisterOnly');
+const babelRegisterOnly = require('metro-bundler/src/babelRegisterOnly');
 const createCacheKeyFunction = require('fbjs-scripts/jest/createCacheKeyFunction');
-const transformer = require('metro-bundler/build/transformer.js');
+const transformer = require('metro-bundler/src/transformer.js');
 
 const nodeFiles = RegExp([
   '/local-cli/',
@@ -47,7 +47,7 @@ module.exports = {
 
   getCacheKey: createCacheKeyFunction([
     __filename,
-    require.resolve('metro-bundler/build/transformer.js'),
+    require.resolve('metro-bundler/src/transformer.js'),
     require.resolve('babel-core/package.json'),
   ]),
 };

--- a/jest/setup.js
+++ b/jest/setup.js
@@ -10,9 +10,9 @@
 
 const mockComponent = require.requireActual('./mockComponent');
 
-require.requireActual('metro-bundler/build/Resolver/polyfills/babelHelpers.js');
-require.requireActual('metro-bundler/build/Resolver/polyfills/Object.es7.js');
-require.requireActual('metro-bundler/build/Resolver/polyfills/error-guard');
+require.requireActual('metro-bundler/src/Resolver/polyfills/babelHelpers.js');
+require.requireActual('metro-bundler/src/Resolver/polyfills/Object.es7.js');
+require.requireActual('metro-bundler/src/Resolver/polyfills/error-guard');
 
 global.__DEV__ = true;
 

--- a/local-cli/bundle/buildBundle.js
+++ b/local-cli/bundle/buildBundle.js
@@ -12,18 +12,18 @@
 'use strict';
 
 const log = require('../util/log').out('bundle');
-const Server = require('metro-bundler/build/Server');
-const Terminal = require('metro-bundler/build/lib/Terminal');
-const TerminalReporter = require('metro-bundler/build/lib/TerminalReporter');
-const TransformCaching = require('metro-bundler/build/lib/TransformCaching');
+const Server = require('metro-bundler/src/Server');
+const Terminal = require('metro-bundler/src/lib/Terminal');
+const TerminalReporter = require('metro-bundler/src/lib/TerminalReporter');
+const TransformCaching = require('metro-bundler/src/lib/TransformCaching');
 
-const outputBundle = require('metro-bundler/build/shared/output/bundle');
+const outputBundle = require('metro-bundler/src/shared/output/bundle');
 const path = require('path');
 const saveAssets = require('./saveAssets');
-const defaultAssetExts = require('metro-bundler/build/defaults').assetExts;
-const defaultSourceExts = require('metro-bundler/build/defaults').sourceExts;
-const defaultPlatforms = require('metro-bundler/build/defaults').platforms;
-const defaultProvidesModuleNodeModules = require('metro-bundler/build/defaults').providesModuleNodeModules;
+const defaultAssetExts = require('metro-bundler/src/defaults').assetExts;
+const defaultSourceExts = require('metro-bundler/src/defaults').sourceExts;
+const defaultPlatforms = require('metro-bundler/src/defaults').platforms;
+const defaultProvidesModuleNodeModules = require('metro-bundler/src/defaults').providesModuleNodeModules;
 
 import type {RequestOptions, OutputOptions} from './types.flow';
 import type {ConfigT} from '../util/Config';

--- a/local-cli/bundle/bundle.js
+++ b/local-cli/bundle/bundle.js
@@ -10,7 +10,7 @@
 
 const buildBundle = require('./buildBundle');
 const bundleCommandLineArgs = require('./bundleCommandLineArgs');
-const outputBundle = require('metro-bundler/build/shared/output/bundle');
+const outputBundle = require('metro-bundler/src/shared/output/bundle');
 
 /**
  * Builds the bundle starting to look for dependencies at the given entry path.

--- a/local-cli/bundle/types.flow.js
+++ b/local-cli/bundle/types.flow.js
@@ -10,4 +10,4 @@
  */
 'use strict';
 
-export type {OutputOptions, RequestOptions} from 'metro-bundler/build/shared/types.flow';
+export type {OutputOptions, RequestOptions} from 'metro-bundler/src/shared/types.flow';

--- a/local-cli/bundle/unbundle.js
+++ b/local-cli/bundle/unbundle.js
@@ -10,7 +10,7 @@
 
 const bundleWithOutput = require('./bundle').withOutput;
 const bundleCommandLineArgs = require('./bundleCommandLineArgs');
-const outputUnbundle = require('metro-bundler/build/shared/output/unbundle');
+const outputUnbundle = require('metro-bundler/src/shared/output/unbundle');
 
 /**
  * Builds the bundle starting to look for dependencies at the given entry path.

--- a/local-cli/server/checkNodeVersion.js
+++ b/local-cli/server/checkNodeVersion.js
@@ -9,7 +9,7 @@
 'use strict';
 
 var chalk = require('chalk');
-var formatBanner = require('metro-bundler/build/lib/formatBanner');
+var formatBanner = require('metro-bundler/src/lib/formatBanner');
 var semver = require('semver');
 
 module.exports = function() {

--- a/local-cli/server/runServer.js
+++ b/local-cli/server/runServer.js
@@ -15,16 +15,16 @@
 require('../../setupBabel')();
 const InspectorProxy = require('./util/inspectorProxy.js');
 const ReactPackager = require('metro-bundler');
-const Terminal = require('metro-bundler/build/lib/Terminal');
+const Terminal = require('metro-bundler/src/lib/Terminal');
 
 const attachHMRServer = require('./util/attachHMRServer');
 const connect = require('connect');
 const copyToClipBoardMiddleware = require('./middleware/copyToClipBoardMiddleware');
 const cpuProfilerMiddleware = require('./middleware/cpuProfilerMiddleware');
-const defaultAssetExts = require('metro-bundler/build/defaults').assetExts;
-const defaultSourceExts = require('metro-bundler/build/defaults').sourceExts;
-const defaultPlatforms = require('metro-bundler/build/defaults').platforms;
-const defaultProvidesModuleNodeModules = require('metro-bundler/build/defaults')
+const defaultAssetExts = require('metro-bundler/src/defaults').assetExts;
+const defaultSourceExts = require('metro-bundler/src/defaults').sourceExts;
+const defaultPlatforms = require('metro-bundler/src/defaults').platforms;
+const defaultProvidesModuleNodeModules = require('metro-bundler/src/defaults')
   .providesModuleNodeModules;
 const fs = require('fs');
 const getDevToolsMiddleware = require('./middleware/getDevToolsMiddleware');
@@ -41,7 +41,7 @@ const unless = require('./middleware/unless');
 const webSocketProxy = require('./util/webSocketProxy.js');
 
 import type {ConfigT} from '../util/Config';
-import type {Reporter} from 'metro-bundler/build/lib/reporting';
+import type {Reporter} from 'metro-bundler/src/lib/reporting';
 
 export type Args = {|
   +assetExts: $ReadOnlyArray<string>,
@@ -148,7 +148,7 @@ function getPackagerServer(args, config) {
       LogReporter = require(path.resolve(args.customLogReporterPath));
     }
   } else {
-    LogReporter = require('metro-bundler/build/lib/TerminalReporter');
+    LogReporter = require('metro-bundler/src/lib/TerminalReporter');
   }
 
   /* $FlowFixMe: Flow is wrong, Node.js docs specify that process.stdout is an

--- a/local-cli/util/Config.js
+++ b/local-cli/util/Config.js
@@ -10,20 +10,20 @@
  */
 'use strict';
 
-const blacklist = require('metro-bundler/build/blacklist');
+const blacklist = require('metro-bundler/src/blacklist');
 const findSymlinksPaths = require('./findSymlinksPaths');
 const fs = require('fs');
 const invariant = require('fbjs/lib/invariant');
 const path = require('path');
 
-const {providesModuleNodeModules} = require('metro-bundler/build/defaults');
+const {providesModuleNodeModules} = require('metro-bundler/src/defaults');
 
 const RN_CLI_CONFIG = 'rn-cli.config.js';
 
-import type {GetTransformOptions, PostMinifyProcess, PostProcessModules} from 'metro-bundler/build/Bundler';
-import type {HasteImpl} from 'metro-bundler/build/node-haste/Module';
-import type {TransformVariants} from 'metro-bundler/build/ModuleGraph/types.flow';
-import type {PostProcessModules as PostProcessModulesForBuck} from 'metro-bundler/build/ModuleGraph/types.flow.js';
+import type {GetTransformOptions, PostMinifyProcess, PostProcessModules} from 'metro-bundler/src/Bundler';
+import type {HasteImpl} from 'metro-bundler/src/node-haste/Module';
+import type {TransformVariants} from 'metro-bundler/src/ModuleGraph/types.flow';
+import type {PostProcessModules as PostProcessModulesForBuck} from 'metro-bundler/src/ModuleGraph/types.flow.js';
 
 /**
  * Configuration file of the CLI.
@@ -156,7 +156,7 @@ const Config = {
     },
     getProvidesModuleNodeModules: () => providesModuleNodeModules.slice(),
     getSourceExts: () => [],
-    getTransformModulePath: () => require.resolve('metro-bundler/build/transformer.js'),
+    getTransformModulePath: () => require.resolve('metro-bundler/src/transformer.js'),
     getTransformOptions: async () => ({}),
     postMinifyProcess: x => x,
     postProcessModules: modules => modules,

--- a/package.json
+++ b/package.json
@@ -180,7 +180,7 @@
     "left-pad": "^1.1.3",
     "lodash": "^4.16.6",
     "merge-stream": "^1.0.1",
-    "metro-bundler": "^0.8.1",
+    "metro-bundler": "^0.9.0",
     "mime": "^1.3.4",
     "mime-types": "2.1.11",
     "minimist": "^1.2.0",

--- a/setupBabel.js
+++ b/setupBabel.js
@@ -9,7 +9,7 @@
 
 'use strict';
 
-const babelRegisterOnly = require('metro-bundler/build/babelRegisterOnly');
+const babelRegisterOnly = require('metro-bundler/src/babelRegisterOnly');
 const escapeRegExp = require('lodash/escapeRegExp');
 const path = require('path');
 


### PR DESCRIPTION
## Motivation (required)

Makes RN compatible with the new bundler version 0.9

