### PR TITLE
Adopt Create React App's issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,36 +1,118 @@
-<details>
-  **Issues that do not describe a bug or do not fill out the template below will be closed**
+<!--
+  PLEASE DON'T DELETE THIS TEMPLATE UNTIL YOU HAVE READ THE FIRST SECTION.
+-->
 
-  We use GitHub Issues exclusively for tracking bugs in React Native.
+### Is this a bug report?
 
-  - If you're looking for help with your code, consider asking on Stack Overflow instead: http://stackoverflow.com/questions/tagged/react-native
-  - Want to know more about future plans? Check out the roadmap: https://github.com/facebook/react-native/wiki/Roadmap
-  - Have a feature request that is not covered in the roadmap? Submit it here: https://react-native.canny.io/feature-requests
+(write your answer here)
 
-  ## Reporting bugs
+<!--
+  If you answered "Yes":
 
-  Want to **report a bug**? Please read the bug reporting guidelines: https://github.com/facebook/react-native/blob/master/CONTRIBUTING.md#bugs
-</details>
+    We expect that it will take you about 30 minutes to produce a high-quality bug report.
+    While this may seem like a lot, putting care into issues helps us fix them faster.
+    For bug reports, it is REQUIRED to fill the rest of this template, or the issue will be closed.
 
-### Description
+  If you answered "No":
 
-Explain what you did, what you expected to happen, and what actually happens.
+    We use GitHub Issues exclusively for tracking bugs in React Native. If you're looking for help,
+    check out the How to Get Help section of this guide: 
+    https://github.com/facebook/react-native/blob/master/CONTRIBUTING.md#how-to-get-help
 
-### Reproduction Steps
+  Now scroll below!
+-->
 
-List all the steps required to reproduce the issue you're reporting. These steps should be clear and concise. Always include a sample of your code.
 
-#### Sample Code
+### Have you read the Bugs section of the Contributing to React Native Guide?
 
-An example of your code or a reproduction of the problem using Snack is **REQUIRED**.
+(Write your answer here.)
 
-### Solution
+<!--
+  Please read through the bug reporting guidelines thoroughly:
+  https://github.com/facebook/react-native/blob/master/CONTRIBUTING.md#bugs
+-->
 
-What needs to be done to address this issue? Ideally, provide a pull request with a fix.
+### Environment
 
-### Additional Information
+<!--
+  Please fill in all the relevant fields by running these commands in terminal.
+-->
 
-* React Native version: [FILL THIS OUT: Be specific, filling out "latest" here is not enough.]
-* Platform: [FILL THIS OUT: iOS, Android, or both?]
-* Development Operating System: [FILL THIS OUT: Are you developing on macOS, Linux, or Windows?]
-* Build tools: [FILL THIS OUT: Xcode or Android Studio version, iOS or Android SDK version, if applicable]
+1. `react-native -v`:
+2. `node -v`: 
+3. `npm -v`:
+4. `yarn --version` (if you use Yarn):
+
+Then, specify:
+
+1. Target Platform (e.g. iOS, Android): 
+2. Development Operating System (e.g. macOS Sierra, Windows 10): 
+3. Build tools (Xcode or Android Studio version, iOS or Android SDK version, if relevant):
+
+
+### Steps to Reproduce
+
+<!--
+  How would you describe your issue to someone who doesn’t know you or your project?
+  Try to write a sequence of steps that anybody can repeat to see the issue.
+-->
+
+(Write your steps here:)
+
+1. 
+2. 
+3. 
+
+### Expected Behavior
+
+<!--
+  How did you expect your project to behave?
+  It’s fine if you’re not sure your understanding is correct.
+  Just write down what you thought would happen.
+-->
+
+(Write what you thought would happen.)
+
+### Actual Behavior
+
+<!--
+  Did something go wrong?
+  Is something broken, or not behaving as you expected?
+  Describe this section in detail, and attach screenshots if possible.
+-->
+
+(Write what happened. Add screenshots!)
+
+### Reproducible Demo
+
+<!--
+  Please share a project that reproduces the issue.
+  There are two ways to do it:
+
+    * Create a new app using https://snack.expo.io/ and try to reproduce the issue in it.
+      This is useful if you roughly know where the problem is, or can’t share the real code.
+
+    * Or, copy your app and remove things until you’re left with the minimal reproducible demo.
+      This is useful for finding the root cause. You may then optionally create a Snack.
+
+  This is a good guide to creating bug demos: https://stackoverflow.com/help/mcve
+  Once you’re done, copy and paste the link to the Snack or a public GitHub repository below:
+-->
+
+(Paste the link to an example project and exact instructions to reproduce the issue.)
+
+<!--
+  What happens if you skip this step?
+
+  Someone will read your bug report, and maybe will be able to help you,
+  but it’s unlikely that it will get much attention from the team. Eventually,
+  the issue will likely get closed in favor of issues that have reproducible demos.
+
+  Please remember that:
+
+    * Issues without reproducible demos have a very low priority.
+    * The person fixing the bug would have to do that anyway. Please be respectful of their time.
+    * You might figure out the issues yourself as you work on extracting it.
+
+  Thanks for helping us help you!
+-->


### PR DESCRIPTION
Yet another experiment with the issue template. I've wanted to have some consistency across projects, and in this PR I am following CRA's example.