### PR TITLE
Add FORCE/SKIP_BUNDLING flags for iOS builds

### DIFF
--- a/scripts/react-native-xcode.sh
+++ b/scripts/react-native-xcode.sh
@@ -17,11 +17,15 @@ fi
 
 case "$CONFIGURATION" in
   *Debug*)
-    if [[ "$FORCE_BUNDLING" ]]; then
-      echo "FORCE_BUNDLING enabled; bundling even in Debug."
+    if [[ "$PLATFORM_NAME" == *simulator ]]; then
+      if [[ "$FORCE_BUNDLING" ]]; then
+        echo "FORCE_BUNDLING enabled; continuing to bundle."
+      else
+        echo "Skipping bundling in Debug for the Simulator (since the packager bundles for you). Use the FORCE_BUNDLING flag to change this behavior."
+        exit 0;
+      fi
     else
-      echo "Skipping bundling in Debug (since the packager bundles for you). Use the FORCE_BUNDLING flag if you want to change this behavior."
-      exit 0;
+      echo "Bundling for physical device. Use the SKIP_BUNDLING flag to change this behavior."
     fi
 
     DEV=true

--- a/scripts/react-native-xcode.sh
+++ b/scripts/react-native-xcode.sh
@@ -10,11 +10,21 @@
 # This script is supposed to be invoked as part of Xcode build process
 # and relies on environment variables (including PWD) set by Xcode
 
+if [[ "$SKIP_BUNDLING" ]]; then
+  echo "SKIP_BUNDLING enabled; skipping."
+  exit 0;
+fi
+
 case "$CONFIGURATION" in
   *Debug*)
-    # Speed up build times by skipping the creation of the offline package.
-    echo "Skipping bundling for Debug (since the packager is supposed to be running)"
-    exit 0;
+    if [[ "$FORCE_BUNDLING" ]]; then
+      echo "FORCE_BUNDLING enabled; bundling even in Debug."
+    else
+      echo "Skipping bundling in Debug (since the packager bundles for you). Use the FORCE_BUNDLING flag if you want to change this behavior."
+      exit 0;
+    fi
+
+    DEV=true
     ;;
   "")
     echo "$0 must be invoked by Xcode"

--- a/scripts/react-native-xcode.sh
+++ b/scripts/react-native-xcode.sh
@@ -12,14 +12,9 @@
 
 case "$CONFIGURATION" in
   *Debug*)
-    # Speed up build times by skipping the creation of the offline package for debug
-    # builds on the simulator since the packager is supposed to be running anyways.
-    if [[ "$PLATFORM_NAME" == *simulator ]]; then
-      echo "Skipping bundling for Simulator platform"
-      exit 0;
-    fi
-
-    DEV=true
+    # Speed up build times by skipping the creation of the offline package.
+    echo "Skipping bundling for Debug (since the packager is supposed to be running)"
+    exit 0;
     ;;
   "")
     echo "$0 must be invoked by Xcode"


### PR DESCRIPTION
### Motivation

*See discussion below for updated motivation.*

Anything running in Debug should use the packager anyway; no need to bundle. This saves a **huge amount of time** during development when testing things like push notifications that require a real device.

The code being modified was originally moved here in https://github.com/facebook/react-native/commit/9ae3714f4bebdd2bcab4d7fdbf23acebdc5ed2ba to make sure bundles are always created in `Release`, but the change can be applied to real devices, too. Ideally there should be very little difference in how a simulator is treated compared to a physical device.

### Test Plan

Run a Debug build in Xcode targeting a physical device before and after this commit.

You can use the `FORCE_BUNDLING` and `SKIP_BUNDLING` flags to manually change the default behavior. For example, under **Build Phases** > **Bundle React Native code and images**:

```bash
export SKIP_BUNDLING=true
../node_modules/react-native/packager/react-native-xcode.sh
```