### PR TITLE
Update maven path and warning

### DIFF
--- a/docs/IntegrationWithExistingApps.md
+++ b/docs/IntegrationWithExistingApps.md
@@ -556,14 +556,14 @@ allprojects {
         ...
         maven {
             // All of React Native (JS, Android binaries) is installed from npm
-            url "$rootDir/node_modules/react-native/android"
+            url "$rootDir/../node_modules/react-native/android"
         }
     }
     ...
 }
 ```
 
-> Make sure that the path is correct! You shouldn’t run into any “Failed to resolve: com.facebook.react:react-native:0.x.x" errors after running Gradle sync in Android Studio.
+> Make sure that the path is correct! You shouldn’t run into any “Failed to resolve: com.facebook.react:react-native:0.x.x" errors after running Gradle sync in Android Studio. **Even if the sync runs succesfully gradle may still have found an incorrect version of react-native somewhere else, this will lead to all sorts of compatibility problems when trying to build or run your app.**
 
 ### Configuring permissions
 


### PR DESCRIPTION
The path for node_modules should be "$rootDir/.." (because $rootDir is the RN home with /android at the end as well) not $rootDir

With latest RN (0.45.x) and gradle (2.3.3) does not fail on sync, yet an older version of RN is somewhat found which causes runtime problems only (very difficult to debug, took us a full day)
We tried this on two different machines, same result on both of them - however I still don't know *where* exactly the other version of RN has been found.

---
  
## Motivation (required)
A fresh install of RN to integrate in an existing android app will fail - and do so without any useful error message.


## Test Plan (required)
Try running the instructions as they currently are (with the wrong path to node-modules/react-native) and you'll see that gradle doesn't fail on sync, but instead you'll get a crash when first loading the app.

Try running the guide with the correctly updated path, and everything should go smoothly (and if not, a bigger warning is present to warn you of what could possibly be happening)

