### PR TITLE
Support native ViewManager inheritance on iOS

### DIFF
--- a/Libraries/ReactNative/requireNativeComponent.js
+++ b/Libraries/ReactNative/requireNativeComponent.js
@@ -70,13 +70,19 @@ function requireNativeComponent(
     viewConfig.propTypes = null;
   }
 
-  // The ViewConfig doesn't contain any props inherited from the view manager's
-  // superclass, so we manually merge in the RCTView ones. Other inheritance
-  // patterns are currenty not supported.
-  const nativeProps = {
-    ...UIManager.RCTView.NativeProps,
-    ...viewConfig.NativeProps,
-  };
+  let baseModuleName = viewConfig.baseModuleName;
+  let nativeProps = { ...viewConfig.NativeProps };
+  while (baseModuleName) {
+    const baseModule = UIManager[baseModuleName];
+    if (!baseModule) {
+      warning(false, 'Base module "%s" does not exist', baseModuleName);
+      baseModuleName = null;
+    } else {
+      nativeProps = { ...nativeProps, ...baseModule.NativeProps };
+      baseModuleName = baseModule.baseModuleName;
+    }
+  }
+
   for (const key in nativeProps) {
     let useAttribute = false;
     const attribute = {};

--- a/React/Modules/RCTUIManager.m
+++ b/React/Modules/RCTUIManager.m
@@ -1542,6 +1542,7 @@ RCT_EXPORT_METHOD(clearJSResponder)
      // Add native props
      NSDictionary<NSString *, id> *viewConfig = [componentData viewConfig];
      moduleConstants[@"NativeProps"] = viewConfig[@"propTypes"];
+     moduleConstants[@"baseModuleName"] = viewConfig[@"baseModuleName"];
 
      // Add direct events
      for (NSString *eventName in viewConfig[@"directEvents"]) {

--- a/React/Views/RCTComponentData.m
+++ b/React/Views/RCTComponentData.m
@@ -430,7 +430,7 @@ static RCTPropBlock createNSInvocationSetter(NSMethodSignature *typeSignature, S
     @"propTypes": propTypes,
     @"directEvents": directEvents,
     @"bubblingEvents": bubblingEvents,
-    @"baseModuleName": superClass == [NSObject class] ? (id)kCFNull : moduleNameForClass(superClass)
+    @"baseModuleName": superClass == [NSObject class] ? [NSNull null] : moduleNameForClass(superClass)
   };
 }
 

--- a/React/Views/RCTComponentData.m
+++ b/React/Views/RCTComponentData.m
@@ -41,7 +41,7 @@ typedef NSMutableDictionary<NSString *, RCTPropBlock> RCTPropBlockDictionary;
     _viewPropBlocks = [NSMutableDictionary new];
     _shadowPropBlocks = [NSMutableDictionary new];
 
-    _name = [self moduleNameForClass:managerClass];
+    _name = moduleNameForClass(managerClass);
 
     _implementsUIBlockToAmendWithShadowViewRegistry = NO;
     Class cls = _managerClass;
@@ -430,7 +430,7 @@ static RCTPropBlock createNSInvocationSetter(NSMethodSignature *typeSignature, S
     @"propTypes": propTypes,
     @"directEvents": directEvents,
     @"bubblingEvents": bubblingEvents,
-    @"baseModuleName": superClass != [NSObject class] ? [self moduleNameForClass:superClass] : [NSNull null]
+    @"baseModuleName": superClass == [NSObject class] ? (id)kCFNull : moduleNameForClass(superClass)
   };
 }
 
@@ -442,7 +442,7 @@ static RCTPropBlock createNSInvocationSetter(NSMethodSignature *typeSignature, S
   return nil;
 }
 
-- (NSString *)moduleNameForClass:(Class)managerClass
+static NSString *moduleNameForClass(Class managerClass)
 {
   // Hackety hack, this partially re-implements RCTBridgeModuleNameForClass
   // We want to get rid of RCT and RK prefixes, but a lot of JS code still references

--- a/React/Views/RCTComponentData.m
+++ b/React/Views/RCTComponentData.m
@@ -41,23 +41,7 @@ typedef NSMutableDictionary<NSString *, RCTPropBlock> RCTPropBlockDictionary;
     _viewPropBlocks = [NSMutableDictionary new];
     _shadowPropBlocks = [NSMutableDictionary new];
 
-    // Hackety hack, this partially re-implements RCTBridgeModuleNameForClass
-    // We want to get rid of RCT and RK prefixes, but a lot of JS code still references
-    // view names by prefix. So, while RCTBridgeModuleNameForClass now drops these
-    // prefixes by default, we'll still keep them around here.
-    NSString *name = [managerClass moduleName];
-    if (name.length == 0) {
-      name = NSStringFromClass(managerClass);
-    }
-    if ([name hasPrefix:@"RK"]) {
-      name = [name stringByReplacingCharactersInRange:(NSRange){0, @"RK".length} withString:@"RCT"];
-    }
-    if ([name hasSuffix:@"Manager"]) {
-      name = [name substringToIndex:name.length - @"Manager".length];
-    }
-
-    RCTAssert(name.length, @"Invalid moduleName '%@'", name);
-    _name = name;
+    _name = [self moduleNameForClass:managerClass];
 
     _implementsUIBlockToAmendWithShadowViewRegistry = NO;
     Class cls = _managerClass;
@@ -439,11 +423,14 @@ static RCTPropBlock createNSInvocationSetter(NSMethodSignature *typeSignature, S
     }
   }
 #endif
-
+  
+  Class superClass = [_managerClass superclass];
+  
   return @{
     @"propTypes": propTypes,
     @"directEvents": directEvents,
     @"bubblingEvents": bubblingEvents,
+    @"baseModuleName": superClass != [NSObject class] ? [self moduleNameForClass:superClass] : [NSNull null]
   };
 }
 
@@ -453,6 +440,28 @@ static RCTPropBlock createNSInvocationSetter(NSMethodSignature *typeSignature, S
     return [[self manager] uiBlockToAmendWithShadowViewRegistry:registry];
   }
   return nil;
+}
+
+- (NSString *)moduleNameForClass:(Class)managerClass
+{
+  // Hackety hack, this partially re-implements RCTBridgeModuleNameForClass
+  // We want to get rid of RCT and RK prefixes, but a lot of JS code still references
+  // view names by prefix. So, while RCTBridgeModuleNameForClass now drops these
+  // prefixes by default, we'll still keep them around here.
+  NSString *name = [managerClass moduleName];
+  if (name.length == 0) {
+    name = NSStringFromClass(managerClass);
+  }
+  if ([name hasPrefix:@"RK"]) {
+    name = [name stringByReplacingCharactersInRange:(NSRange){0, @"RK".length} withString:@"RCT"];
+  }
+  if ([name hasSuffix:@"Manager"]) {
+    name = [name substringToIndex:name.length - @"Manager".length];
+  }
+  
+  RCTAssert(name.length, @"Invalid moduleName '%@'", name);
+  
+  return name;
 }
 
 @end


### PR DESCRIPTION
**Motivation**
This is a re-worked version of #14260, by @shergin's suggestion.

For iOS, if you want to inherit from a native ViewManagers, your custom ViewManager will not automatically export the parents' props. So the only way to do this today, is to basically copy/paste the parent ViewManager-file, and add your own custom logic.

With this PR, this is made more extensible by exporting the `baseModuleName` (i.e. the iOS `superclass` of the ViewManager), and then using that value to re-establish the inheritance relationship in `requireNativeComponent`.

**Test plan**
I've run this with a test project, and it works fine there. But needs more testing.

Opened this PR as [per @shergin's suggestion](https://github.com/facebook/react-native/pull/10946#issuecomment-311860545) though, so we can discuss approach.

**Discussion**
* Android already supports inheritance, so this change should be compatible with that. But, not every prop available on `UIManager.RCTView.NativeProps` is actually exported by every ViewManager. So should `UIManager.RCTView.NativeProps` still be merged with `viewConfig.NativeProps`, even if the individual ViewManager does not export/use them to begin with?
* Does this break other platforms? [UWP](https://github.com/Microsoft/react-native-windows)?