### PR TITLE
Identify autoCapitalize default

### DIFF
--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -186,7 +186,7 @@ const TextInput = React.createClass({
      */
     autoCapitalize: PropTypes.oneOf([
       'none',
-      'sentences',
+      'sentences', // default
       'words',
       'characters',
     ]),


### PR DESCRIPTION
Same as `ScrollView`'s default `keyboardDismissMode` is commented, allows seeing the default at a quick glance of the code.

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. In other words, a test plan is *required*. Bonus points for screenshots and videos!

Please read the Contribution Guidelines at https://github.com/facebook/react-native/blob/master/CONTRIBUTING.md to learn more about contributing to React Native.

Happy contributing!
-->
