### PR TITLE
Warning about failure to build an APK due to poor formatting

### DIFF
--- a/docs/SignedAPKAndroid.md
+++ b/docs/SignedAPKAndroid.md
@@ -35,6 +35,8 @@ MYAPP_RELEASE_STORE_PASSWORD=*****
 MYAPP_RELEASE_KEY_PASSWORD=*****
 ```
 
+> If you copy and paste the lines above into your editor, make sure you reformat it so each variable is in a separate line, and remove all trailing spaces as well, or else the process to generate the release APK will fail during signing.
+
 These are going to be global gradle variables, which we can later use in our gradle config to sign our app.
 
 > __Note about saving the keystore:__


### PR DESCRIPTION
If you copy and paste the lines gradle.properties into your editor trailing spaces will cause the process to generate the release APK to fail during signing. This warning will help people avoid this problem.

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. In other words, a test plan is *required*. Bonus points for screenshots and videos!

Please read the Contribution Guidelines at https://github.com/facebook/react-native/blob/master/CONTRIBUTING.md to learn more about contributing to React Native.

Happy contributing!
-->
