### PR TITLE
Prevent a crash when no cursor drawable is set

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
@@ -327,8 +327,7 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
       cursorDrawableResField.setAccessible(true);
       int drawableResId = cursorDrawableResField.getInt(view);
 
-      // If the view has no cursor drawable, React Native will crash when
-      // trying to load a resource of id 0.
+      // The view has no cursor drawable.
       if (drawableResId == 0) {
         return;
       }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
@@ -327,6 +327,12 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
       cursorDrawableResField.setAccessible(true);
       int drawableResId = cursorDrawableResField.getInt(view);
 
+      // If the view has no cursor drawable, React Native will crash when
+      // trying to load a resource of id 0.
+      if (drawableResId == 0) {
+        return;
+      }
+
       Drawable drawable = ContextCompat.getDrawable(view.getContext(), drawableResId);
       if (color != null) {
         drawable.setColorFilter(color, PorterDuff.Mode.SRC_IN);


### PR DESCRIPTION
## Summary
React Native 0.43 added additional functionality to setSelectionColor that also tints the cursor drawable of the View. However, some views may not have a cursor drawable set in which case, the code will crash when attempting to load a drawable with resource id 0.

We encountered this in our RN 0.45 upgrade in the Airbnb app.

@lelandrichardson 