### PR TITLE
Wrong location of sdk tools on OSX in documentation ('Getting Started')? 

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -400,7 +400,7 @@ Add the following lines to your `$HOME/.bash_profile` config file:
 
 ```
 export ANDROID_HOME=$HOME/Library/Android/sdk
-export PATH=$PATH:$ANDROID_HOME/tools
+export PATH=$PATH:$ANDROID_HOME/tools/bin
 export PATH=$PATH:$ANDROID_HOME/platform-tools
 ```
 


### PR DESCRIPTION
On OSX, the path to the cli tools seem to be in `$ANDROID_HOME/tools/bin`, not `$ANDROID_HOME/tools`

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. In other words, a test plan is *required*. Bonus points for screenshots and videos!

Please read the Contribution Guidelines at https://github.com/facebook/react-native/blob/master/CONTRIBUTING.md to learn more about contributing to React Native.

Happy contributing!
-->
