### PR TITLE
Better doc for 'data:' uri scheme & mandatory size

### DIFF
--- a/Libraries/Image/Image.ios.js
+++ b/Libraries/Image/Image.ios.js
@@ -34,8 +34,10 @@ const ImageViewManager = NativeModules.ImageViewManager;
  * including network images, static resources, temporary local images, and
  * images from local disk, such as the camera roll.
  *
- * This example shows both fetching and displaying an image from local
- * storage as well as one from network.
+ * This example shows fetching and displaying an image from local storage
+ * as well as one from network and even from data provided in the `'data:'` uri scheme.
+ *
+ * > Note that for network and data images, you will need to manually specify the dimensions of your image!
  *
  * ```ReactNativeWebPlayer
  * import React, { Component } from 'react';
@@ -51,6 +53,10 @@ const ImageViewManager = NativeModules.ImageViewManager;
  *         <Image
  *           style={{width: 50, height: 50}}
  *           source={{uri: 'https://facebook.github.io/react/img/logo_og.png'}}
+ *         />
+ *         <Image
+ *           style={{width: 66, height: 58}}
+ *           source={{uri: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADMAAAAzCAYAAAA6oTAqAAAAEXRFWHRTb2Z0d2FyZQBwbmdjcnVzaEB1SfMAAABQSURBVGje7dSxCQBACARB+2/ab8BEeQNhFi6WSYzYLYudDQYGBgYGBgYGBgYGBgYGBgZmcvDqYGBgmhivGQYGBgYGBgYGBgYGBgYGBgbmQw+P/eMrC5UTVAAAAABJRU5ErkJggg=='}}
  *         />
  *       </View>
  *     );


### PR DESCRIPTION
It is quite confusing that the 'data:' uri scheme is not documented, but working. 
It is very useful when getting e.g. an icon from a REST call.

Also, the mandatory size style for network & data images should be mentioned here, not only in the image guide.

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. In other words, a test plan is *required*. Bonus points for screenshots and videos!

Please read the Contribution Guidelines at https://github.com/facebook/react-native/blob/master/CONTRIBUTING.md to learn more about contributing to React Native.

Happy contributing!
-->
