### PR TITLE
default value for javaScriptEnabled is false

### DIFF
--- a/Libraries/Components/WebView/WebView.ios.js
+++ b/Libraries/Components/WebView/WebView.ios.js
@@ -280,7 +280,7 @@ class WebView extends React.Component {
 
     /**
      * Boolean value to enable JavaScript in the `WebView`. Used on Android only
-     * as JavaScript is enabled by default on iOS. The default value is `true`.
+     * as JavaScript is enabled by default on iOS. The default value is `false`.
      * @platform android
      */
     javaScriptEnabled: PropTypes.bool,


### PR DESCRIPTION
This did cost me quite some time, but it turns out the default value for `javaScriptEnabled` isn't `true`, but `false`. So without it, any JavaScript injected through `injectJavaScript`/`injectedJavaScript` won't ever make it to the webview.

Ref: https://developer.android.com/reference/android/webkit/WebSettings.html#setJavaScriptEnabled(boolean)