### PR TITLE
Updating the usage of inquirer API

### DIFF
--- a/local-cli/link/pollParams.js
+++ b/local-cli/link/pollParams.js
@@ -5,5 +5,5 @@ module.exports = (questions) => new Promise((resolve, reject) => {
     return resolve({});
   }
 
-  inquirer.prompt(questions, resolve);
+  inquirer.prompt(questions).then(resolve, reject);
 });


### PR DESCRIPTION
Inquirer was changed to a later version in https://github.com/facebook/react-native/commit/bada25d158e070fd683a10b8ff9cdcb8d2498b14. However, the API also needed to be updated to use a promise based version.

