### PR TITLE
[website] Remove unused npm dependencies and add missing ones

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -6,11 +6,7 @@
   },
   "dependencies": {
     "babel-core": "^6.6.4",
-    "babel-plugin-external-helpers": "^6.5.0",
-    "babel-polyfill": "^6.6.1",
-    "babel-preset-react-native": "~1.6.0",
-    "babel-register": "^6.6.0",
-    "babel-types": "^6.6.4",
+    "babel-plugin-transform-flow-strip-types": "^6.21.0",
     "bluebird": "^2.9.21",
     "connect": "2.8.3",
     "deep-assign": "^2.0.0",


### PR DESCRIPTION
A couple of npm dependencies are unused (grepped for them or their variants since some are Babel presets/plugins) and there were also some missing that are listed in react-native's package.json but are directly required by the website.

Test plan: follow the steps in the website README, open the website, browse a few different types of pages