### PR TITLE
[cleanup] Remove remnants of the packager

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -3,4 +3,3 @@
 **/staticBundle.js
 **/main.js
 Libraries/vendor/**/*
-packager/src/worker-farm/**/*

--- a/Libraries/Image/RelativeImageStub.js
+++ b/Libraries/Image/RelativeImageStub.js
@@ -12,7 +12,7 @@
 'use strict';
 
 // This is a stub for flow to make it understand require('./icon.png')
-// See packager/src/Bundler/index.js
+// See metro-bundler/src/Bundler/index.js
 
 var AssetRegistry = require('AssetRegistry');
 

--- a/jest-preset.json
+++ b/jest-preset.json
@@ -11,8 +11,7 @@
     "^React$": "<rootDir>/node_modules/react"
   },
   "modulePathIgnorePatterns": [
-    "<rootDir>/node_modules/react-native/Libraries/react-native/",
-    "<rootDir>/node_modules/react-native/packager/"
+    "<rootDir>/node_modules/react-native/Libraries/react-native/"
   ],
   "transformIgnorePatterns": [
     "node_modules/(?!(jest-)?react-native|react-clone-referenced-element)"

--- a/package.json
+++ b/package.json
@@ -26,8 +26,7 @@
       "Libraries/Renderer",
       "/node_modules/",
       "/website/",
-      "local-cli/templates/",
-      "packager/src/integration_tests/__tests__/basic_bundle-test.js"
+      "local-cli/templates/"
     ],
     "haste": {
       "defaultPlatform": "ios",

--- a/setupBabel.js
+++ b/setupBabel.js
@@ -14,7 +14,6 @@ const escapeRegExp = require('lodash/escapeRegExp');
 const path = require('path');
 
 const BABEL_ENABLED_PATHS = [
-  'packager/src',
   'local-cli',
 ];
 


### PR DESCRIPTION
There were still some references to "packager/" that are no longer used since the `packager` directory has been deleted after moving to Metro. Cleaned up the ones that were doing nothing and updated the references that are still meaningful.

Test plan: Ran `npm start`, CI tests
