### PR TITLE
[ci] Upgrade the version of Yarn to 0.27.5 for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,8 @@ install:
   # Use node 6 because that is what runs on land-blocking tests
   - nvm install 6
   - rm -Rf "${TMPDIR}/jest_preprocess_cache"
-  - wget https://github.com/yarnpkg/yarn/releases/download/v0.16.0/yarn-0.16.0.js
-  - export yarn="node $(pwd)/yarn-0.16.0.js"
-  - $yarn install
+  - brew install yarn --ignore-dependencies
+  - yarn install
 
 script:
   - if [[ "$TEST_TYPE" = objc-ios ]]; then travis_retry travis_wait ./scripts/objc-test-ios.sh test; fi

--- a/ContainerShip/Dockerfile.javascript
+++ b/ContainerShip/Dockerfile.javascript
@@ -1,6 +1,6 @@
 FROM library/node:6.9.2
 
-ENV YARN_VERSION=0.19.1
+ENV YARN_VERSION=0.27.5
 
 # install dependencies
 RUN apt-get update && apt-get install ocaml libelf-dev -y


### PR DESCRIPTION
The TravisCI tests were using an especially old version of Yarn. Upgrade to 0.27.5 so we're using a version closer to the version that more people (and especially RN maintainers) would be using.

Test plan: Look at the OSS CI tests; make sure there are no Yarn / node_module errors.
