### PR TITLE
Fixed ImageBackground could't be wrapped by Touchable* component

### DIFF
--- a/Libraries/Image/ImageBackground.js
+++ b/Libraries/Image/ImageBackground.js
@@ -16,6 +16,7 @@ const Image = require('Image');
 const React = require('React');
 const StyleSheet = require('StyleSheet');
 const View = require('View');
+const ensureComponentIsNative = require('ensureComponentIsNative');
 
 /**
  * Very simple drop-in replacement for <Image> which supports nesting views.
@@ -42,11 +43,24 @@ const View = require('View');
  * ```
  */
 class ImageBackground extends React.Component {
+  setNativeProps(props: Object) {
+    if (this._viewRef) {
+      ensureComponentIsNative(this._viewRef);
+      this._viewRef.setNativeProps(props);
+    }
+  }
+
+  _viewRef: View;
+
+  _captureRef = ref => {
+    this._viewRef = ref;
+  };
+
   render() {
     const {children, style, imageStyle, imageRef, ...props} = this.props;
 
     return (
-      <View style={style}>
+      <View style={style} ref={this._captureRef}>
         <Image
           {...props}
           style={[


### PR DESCRIPTION
In 0.46, as warning's advice, I use `ImageBackground` to replace `Image`s which used as background image wrapper, and in some cases, I also wrap `ImageBackground` with `TouchableHighlight` to make it clickable.

But here comes an error:

> Touchable child must either be native or forward setNativeProps to a native component

![2017-07-07 3 25 19](https://user-images.githubusercontent.com/3055294/27948869-f7c5832c-632d-11e7-97ba-5074cca82961.png)

So I pick some code from `Image.ios.js` into `ImageBackground.js` to solve it.

Please help to review, thanks!