### PR TITLE
[PushNotificationIOS] Rename _remoteNotificationCompleteCalllbackCalled to _remoteNotificationCompleteCallbackCalled

### DIFF
--- a/Libraries/PushNotificationIOS/PushNotificationIOS.js
+++ b/Libraries/PushNotificationIOS/PushNotificationIOS.js
@@ -128,7 +128,7 @@ class PushNotificationIOS {
   _badgeCount: number;
   _notificationId: string;
   _isRemote: boolean;
-  _remoteNotificationCompleteCalllbackCalled: boolean;
+  _remoteNotificationCompleteCallbackCalled: boolean;
 
   static FetchResult: FetchResult = {
     NewData: 'UIBackgroundFetchResultNewData',
@@ -406,7 +406,7 @@ class PushNotificationIOS {
    */
   constructor(nativeNotif: Object) {
     this._data = {};
-    this._remoteNotificationCompleteCalllbackCalled = false;
+    this._remoteNotificationCompleteCallbackCalled = false;
     this._isRemote = nativeNotif.remote;
     if (this._isRemote) {
       this._notificationId = nativeNotif.notificationId;
@@ -451,10 +451,10 @@ class PushNotificationIOS {
    * be throttled, to read more about it see the above documentation link.
    */
   finish(fetchResult: FetchResult) {
-    if (!this._isRemote || !this._notificationId || this._remoteNotificationCompleteCalllbackCalled) {
+    if (!this._isRemote || !this._notificationId || this._remoteNotificationCompleteCallbackCalled) {
       return;
     }
-    this._remoteNotificationCompleteCalllbackCalled = true;
+    this._remoteNotificationCompleteCallbackCalled = true;
 
     RCTPushNotificationManager.onFinishRemoteNotification(this._notificationId, fetchResult);
   }


### PR DESCRIPTION
Just noticed this typo
