### PR TITLE
Fix type of StatusBar backgroundColor so it is displayed correctly in docs

### DIFF
--- a/Libraries/Components/StatusBar/StatusBar.js
+++ b/Libraries/Components/StatusBar/StatusBar.js
@@ -63,7 +63,10 @@ type DefaultProps = {
 /**
  * Merges the prop stack with the default values.
  */
-function mergePropsStack(propsStack: Array<Object>, defaultValues: Object): Object {
+function mergePropsStack(
+  propsStack: Array<Object>,
+  defaultValues: Object
+): Object {
   return propsStack.reduce((prev, cur) => {
     for (const prop in cur) {
       if (cur[prop] != null) {
@@ -80,20 +83,29 @@ function mergePropsStack(propsStack: Array<Object>, defaultValues: Object): Obje
  */
 function createStackEntry(props: any): any {
   return {
-    backgroundColor: props.backgroundColor != null ? {
-      value: props.backgroundColor,
-      animated: props.animated,
-    } : null,
-    barStyle: props.barStyle != null ? {
-      value: props.barStyle,
-      animated: props.animated,
-    } : null,
+    backgroundColor:
+      props.backgroundColor != null
+        ? {
+            value: props.backgroundColor,
+            animated: props.animated,
+          }
+        : null,
+    barStyle:
+      props.barStyle != null
+        ? {
+            value: props.barStyle,
+            animated: props.animated,
+          }
+        : null,
     translucent: props.translucent,
-    hidden: props.hidden != null ? {
-      value: props.hidden,
-      animated: props.animated,
-      transition: props.showHideTransition,
-    } : null,
+    hidden:
+      props.hidden != null
+        ? {
+            value: props.hidden,
+            animated: props.animated,
+            transition: props.showHideTransition,
+          }
+        : null,
     networkActivityIndicatorVisible: props.networkActivityIndicatorVisible,
   };
 }
@@ -141,7 +153,7 @@ class StatusBar extends React.Component {
   props: {
     hidden?: boolean,
     animated?: boolean,
-    backgroundColor?: $FlowFixMe,
+    backgroundColor?: string,
     translucent?: boolean,
     barStyle?: 'default' | 'light-content' | 'dark-content',
     networkActivityIndicatorVisible?: boolean,
@@ -215,7 +227,9 @@ class StatusBar extends React.Component {
    */
   static setNetworkActivityIndicatorVisible(visible: boolean) {
     if (Platform.OS !== 'ios') {
-      console.warn('`setNetworkActivityIndicatorVisible` is only available on iOS');
+      console.warn(
+        '`setNetworkActivityIndicatorVisible` is only available on iOS'
+      );
       return;
     }
     StatusBar._defaultProps.networkActivityIndicatorVisible = visible;
@@ -276,11 +290,7 @@ class StatusBar extends React.Component {
     /**
      * Sets the color of the status bar text.
      */
-    barStyle: PropTypes.oneOf([
-      'default',
-      'light-content',
-      'dark-content',
-    ]),
+    barStyle: PropTypes.oneOf(['default', 'light-content', 'dark-content']),
     /**
      * If the network activity indicator should be visible.
      *
@@ -293,10 +303,7 @@ class StatusBar extends React.Component {
      *
      * @platform ios
      */
-    showHideTransition: PropTypes.oneOf([
-      'fade',
-      'slide',
-    ]),
+    showHideTransition: PropTypes.oneOf(['fade', 'slide']),
   };
 
   static defaultProps = {
@@ -343,38 +350,52 @@ class StatusBar extends React.Component {
     clearImmediate(StatusBar._updateImmediate);
     StatusBar._updateImmediate = setImmediate(() => {
       const oldProps = StatusBar._currentValues;
-      const mergedProps = mergePropsStack(StatusBar._propsStack, StatusBar._defaultProps);
+      const mergedProps = mergePropsStack(
+        StatusBar._propsStack,
+        StatusBar._defaultProps
+      );
 
       // Update the props that have changed using the merged values from the props stack.
       if (Platform.OS === 'ios') {
-        if (!oldProps || oldProps.barStyle.value !== mergedProps.barStyle.value) {
+        if (
+          !oldProps ||
+          oldProps.barStyle.value !== mergedProps.barStyle.value
+        ) {
           StatusBarManager.setStyle(
             mergedProps.barStyle.value,
-            mergedProps.barStyle.animated,
+            mergedProps.barStyle.animated
           );
         }
         if (!oldProps || oldProps.hidden.value !== mergedProps.hidden.value) {
           StatusBarManager.setHidden(
             mergedProps.hidden.value,
-            mergedProps.hidden.animated ?
-              mergedProps.hidden.transition :
-              'none',
+            mergedProps.hidden.animated ? mergedProps.hidden.transition : 'none'
           );
         }
 
-        if (!oldProps || oldProps.networkActivityIndicatorVisible !== mergedProps.networkActivityIndicatorVisible) {
+        if (
+          !oldProps ||
+          oldProps.networkActivityIndicatorVisible !==
+            mergedProps.networkActivityIndicatorVisible
+        ) {
           StatusBarManager.setNetworkActivityIndicatorVisible(
             mergedProps.networkActivityIndicatorVisible
           );
         }
       } else if (Platform.OS === 'android') {
-        if (!oldProps || oldProps.barStyle.value !== mergedProps.barStyle.value) {
+        if (
+          !oldProps ||
+          oldProps.barStyle.value !== mergedProps.barStyle.value
+        ) {
           StatusBarManager.setStyle(mergedProps.barStyle.value);
         }
-        if (!oldProps || oldProps.backgroundColor.value !== mergedProps.backgroundColor.value) {
+        if (
+          !oldProps ||
+          oldProps.backgroundColor.value !== mergedProps.backgroundColor.value
+        ) {
           StatusBarManager.setColor(
             processColor(mergedProps.backgroundColor.value),
-            mergedProps.backgroundColor.animated,
+            mergedProps.backgroundColor.animated
           );
         }
         if (!oldProps || oldProps.hidden.value !== mergedProps.hidden.value) {


### PR DESCRIPTION
# Before

![screen shot 2017-07-07 at 2 54 01 pm](https://user-images.githubusercontent.com/90494/27978425-3d4c7702-6324-11e7-8cea-0f1e121e84d6.png)

# After

![screen shot 2017-07-07 at 2 55 08 pm](https://user-images.githubusercontent.com/90494/27978437-4943df46-6324-11e7-9a64-ad30599811f2.png)

# Notes

The change that set this type to $FlowFixMe was a [massive one-year-old old commit](https://github.com/facebook/react-native/commit/a2fb703bbb988038323c55b29b40e8f5ff52966d) and I don't think it is necessary anymore (flow passes with this change). If it does, it must be something internal to Facebook, maybe we should $FlowFixIt somehow? 