### PR TITLE
imageSource should not be required

### DIFF
--- a/Libraries/Experimental/SwipeableRow/SwipeableQuickActionButton.js
+++ b/Libraries/Experimental/SwipeableRow/SwipeableQuickActionButton.js
@@ -29,7 +29,7 @@ import type {ImageSource} from 'ImageSource';
 class SwipeableQuickActionButton extends React.Component {
   props: {
     accessibilityLabel?: string,
-    imageSource: ImageSource | number,
+    imageSource?: ImageSource | number,
     imageStyle?: ?ViewPropTypes.style,
     onPress?: Function,
     style?: ?ViewPropTypes.style,


### PR DESCRIPTION
Making the imageSource required was causing prop type warnings. Using SwipeableRow without an image works fine in production. Ideally we'd additionally not render the <Image /> component. A task for another time.