### PR TITLE
No need for divider width

### DIFF
--- a/Libraries/Experimental/SwipeableRow/SwipeableQuickActions.js
+++ b/Libraries/Experimental/SwipeableRow/SwipeableQuickActions.js
@@ -68,7 +68,7 @@ const styles = StyleSheet.create({
     justifyContent: 'flex-end',
   },
   divider: {
-    width: 4,
+    width: 0,
   },
 });
 


### PR DESCRIPTION
At the moment there's an odd 4px gap between buttons. This hasn't been necessary for anything to work so I would assume this is to fix an issue that no longer exists. This amend is working in production.

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. In other words, a test plan is *required*. Bonus points for screenshots and videos!

Please read the Contribution Guidelines at https://github.com/facebook/react-native/blob/master/CONTRIBUTING.md to learn more about contributing to React Native.

Happy contributing!
-->
