### PR TITLE
Only update visible length on scroll if greater than 0

### DIFF
--- a/Libraries/Lists/VirtualizedList.js
+++ b/Libraries/Lists/VirtualizedList.js
@@ -957,7 +957,7 @@ class VirtualizedList extends React.PureComponent<OptionalProps, Props, State> {
       offset,
       timestamp,
       velocity,
-      this._scrollMetrics.visibleLength,
+      visibleLength: this._scrollMetrics.visibleLength,
     };
     if (visibleLength) {
         this._scrollMetrics.visibleLength = visibleLength;

--- a/Libraries/Lists/VirtualizedList.js
+++ b/Libraries/Lists/VirtualizedList.js
@@ -957,8 +957,11 @@ class VirtualizedList extends React.PureComponent<OptionalProps, Props, State> {
       offset,
       timestamp,
       velocity,
-      visibleLength,
+      this._scrollMetrics.visibleLength,
     };
+    if (visibleLength) {
+        this._scrollMetrics.visibleLength = visibleLength;
+    }
     this._updateViewableItems(this.props.data);
     if (!this.props) {
       return;


### PR DESCRIPTION
Observed behavior where if you set `initialScrollIndex` to some number outside the initially rendered frames (i.e. frame 11), the onScroll event (triggered by the internal call of scrollToIndex in componentDidMount) will return a layout size of 0. This causes all the content to be hidden until the point at which the user scrolls again which triggers another update with the correct length.

If you don't do this it causes problems for computeWindowedRenderLimits which believes only one cell will ever be rendered at a time.

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. In other words, a test plan is *required*. Bonus points for screenshots and videos!

Please read the Contribution Guidelines at https://github.com/facebook/react-native/blob/master/CONTRIBUTING.md to learn more about contributing to React Native.

Happy contributing!
-->
