### PR TITLE
Replacing `react-native android` with `react-native eject`

### DIFF
--- a/local-cli/runAndroid/runAndroid.js
+++ b/local-cli/runAndroid/runAndroid.js
@@ -27,7 +27,7 @@ function checkAndroid(root) {
  */
 function runAndroid(argv, config, args) {
   if (!checkAndroid(args.root)) {
-    console.log(chalk.red('Android project not found. Maybe run react-native android first?'));
+    console.log(chalk.red('Android project not found. Maybe run react-native eject first?'));
     return;
   }
 


### PR DESCRIPTION
Just updated the documentation. To create the android directory, `react-native android` doesn't work anymore, it has been replaced by `react-native eject`.