### PR TITLE
Fixed bug where `run-ios` does not respect Build Scheme's specified e…

### DIFF
--- a/local-cli/runIOS/runIOS.js
+++ b/local-cli/runIOS/runIOS.js
@@ -157,9 +157,15 @@ function buildProject(xcodeProject, udid, scheme, configuration = 'Debug', launc
     });
     buildProcess.on('close', function(code) {
       //FULL_PRODUCT_NAME is the actual file name of the app, which actually comes from the Product Name in the build config, which does not necessary match a scheme name,  example output line: export FULL_PRODUCT_NAME="Super App Dev.app"
-      let productNameMatch = /export FULL_PRODUCT_NAME="?(.+).app"?$/m.exec(buildOutput);
-      if (productNameMatch && productNameMatch.length && productNameMatch.length > 1) {
-        return resolve(productNameMatch[1]);//0 is the full match, 1 is the app name
+      const fullProductNamePattern = /export FULL_PRODUCT_NAME=?(.+).app/mg;
+      const productNameMatch = [];
+      let match;
+      while((match = fullProductNamePattern.exec(buildOutput)) !== null) {
+        productNameMatch.push(match[1]);
+      }
+      if (productNameMatch && productNameMatch.length && productNameMatch.length > 0) {
+        const lastProductName = productNameMatch[productNameMatch.length - 1];
+        return resolve(lastProductName);
       }
       return buildProcess.error? reject(error) : resolve();
     });


### PR DESCRIPTION
#14907 Fixed bug where `run-ios` does not respect Build Scheme's specified executable in Xcode.

- Changed regex matcher code to exclude the apostrophes
- Changed regex matcher code to not specify `.app` as a mandatory postfix
- Made regex matcher code do a global match instead of first match
- Retrieving `productNameMatch` from last item in list of matches

Test plan: Unsure of how to do this, but a build log with more than one occurrence of `export FULL_PRODUCT_NAME=intendedAppName.app` could be passed in to check if the last specified FULL_PRODUCT_NAME is retrieved. Using existing code, nothing would be retrieved because of the apostrophes.
