### PR TITLE
[packager] Change `polyfills` to `getPolyfills` function for more configurability

### DIFF
--- a/local-cli/server/runServer.js
+++ b/local-cli/server/runServer.js
@@ -157,7 +157,7 @@ function getPackagerServer(args, config) {
     maxWorkers: args.maxWorkers,
     platforms: defaultPlatforms.concat(args.platforms),
     polyfillModuleNames: config.getPolyfillModuleNames(),
-    polyfills: config.polyfills,
+    getPolyfills: config.getPolyfills,
     postMinifyProcess: config.postMinifyProcess,
     postProcessModules: config.postProcessModules,
     projectRoots: args.projectRoots,

--- a/local-cli/util/Config.js
+++ b/local-cli/util/Config.js
@@ -94,7 +94,7 @@ export type ConfigT = {
    * An optional list of polyfills to include in the bundle. The list defaults
    * to a set of common polyfills for Number, String, Array, Object...
    */
-  polyfills: Array<string>,
+  getPolyfills: ({platform: string}) => Array<string>,
 
   /**
    * An optional function that can modify the code and source map of bundle
@@ -177,7 +177,7 @@ const Config = {
     getSourceExts: () => [],
     getTransformModulePath: () => require.resolve('metro-bundler/src/transformer.js'),
     getTransformOptions: async () => ({}),
-    polyfills: [
+    getPolyfills: ({platform}) => [
       require.resolve('../../Libraries/polyfills/Object.es6.js'),
       require.resolve('../../Libraries/polyfills/console.js'),
       require.resolve('../../Libraries/polyfills/error-guard.js'),
@@ -239,6 +239,7 @@ const Config = {
   },
 
   loadFileCustom<TConfig: {}>(pathToConfig: string, defaults: TConfig): TConfig {
+    // $FlowFixMe: necessary dynamic require
     const config: {} = require(pathToConfig);
     return {...defaults, ...config};
   },


### PR DESCRIPTION
Changing the `polyfills` option to `getPolyfills({platform})` will let us return a different set of polyfills for each platform. See https://github.com/facebook/metro-bundler/issues/25 for the motivation.

Test Plan: None so far, since this is an unimplemented property on Metro's side.
