### PR TITLE
Preserve new lines in message when sharing to WhatsApp

### DIFF
--- a/Libraries/ActionSheetIOS/RCTActionSheet.xcodeproj/project.pbxproj
+++ b/Libraries/ActionSheetIOS/RCTActionSheet.xcodeproj/project.pbxproj
@@ -8,12 +8,15 @@
 
 /* Begin PBXBuildFile section */
 		14C644C41AB0DFC900DE3C65 /* RCTActionSheetManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 14C644C21AB0DFC900DE3C65 /* RCTActionSheetManager.m */; };
+		84BA329A1F14EACE00ADEFCA /* RCTMessageActivityItemProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 84BA32991F14EACE00ADEFCA /* RCTMessageActivityItemProvider.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
 		134814201AA4EA6300B7C361 /* libRCTActionSheet.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libRCTActionSheet.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		14C644C11AB0DFC900DE3C65 /* RCTActionSheetManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = RCTActionSheetManager.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
 		14C644C21AB0DFC900DE3C65 /* RCTActionSheetManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTActionSheetManager.m; sourceTree = "<group>"; };
+		84BA32981F14EACE00ADEFCA /* RCTMessageActivityItemProvider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTMessageActivityItemProvider.h; sourceTree = "<group>"; };
+		84BA32991F14EACE00ADEFCA /* RCTMessageActivityItemProvider.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTMessageActivityItemProvider.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXGroup section */
@@ -30,6 +33,8 @@
 			children = (
 				14C644C11AB0DFC900DE3C65 /* RCTActionSheetManager.h */,
 				14C644C21AB0DFC900DE3C65 /* RCTActionSheetManager.m */,
+				84BA32981F14EACE00ADEFCA /* RCTMessageActivityItemProvider.h */,
+				84BA32991F14EACE00ADEFCA /* RCTMessageActivityItemProvider.m */,
 				134814211AA4EA7D00B7C361 /* Products */,
 			);
 			indentWidth = 2;
@@ -90,6 +95,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				84BA329A1F14EACE00ADEFCA /* RCTMessageActivityItemProvider.m in Sources */,
 				14C644C41AB0DFC900DE3C65 /* RCTActionSheetManager.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Libraries/ActionSheetIOS/RCTActionSheetManager.m
+++ b/Libraries/ActionSheetIOS/RCTActionSheetManager.m
@@ -131,9 +131,11 @@ RCT_EXPORT_METHOD(showShareActionSheetWithOptions:(NSDictionary *)options
 
   NSMutableArray<id> *items = [NSMutableArray array];
   NSString *message = [RCTConvert NSString:options[@"message"]];
+  NSArray *messages = [RCTConvert NSArray:options[@"messages"]];
   if (message) {
     RCTMessageActivityItemProvider * messageItem = [[RCTMessageActivityItemProvider alloc] initWithPlaceholderItem:@""];
     messageItem.message = message;
+    maip.messages = messages;
     [items addObject:messageItem];
   }
   NSURL *URL = [RCTConvert NSURL:options[@"url"]];

--- a/Libraries/ActionSheetIOS/RCTActionSheetManager.m
+++ b/Libraries/ActionSheetIOS/RCTActionSheetManager.m
@@ -14,6 +14,7 @@
 #import <React/RCTLog.h>
 #import <React/RCTUIManager.h>
 #import <React/RCTUtils.h>
+#import "RCTMessageActivityItemProvider.h"
 
 @interface RCTActionSheetManager () <UIActionSheetDelegate>
 @end
@@ -131,7 +132,9 @@ RCT_EXPORT_METHOD(showShareActionSheetWithOptions:(NSDictionary *)options
   NSMutableArray<id> *items = [NSMutableArray array];
   NSString *message = [RCTConvert NSString:options[@"message"]];
   if (message) {
-    [items addObject:message];
+    RCTMessageActivityItemProvider * messageItem = [[RCTMessageActivityItemProvider alloc] initWithPlaceholderItem:@""];
+    messageItem.message = message;
+    [items addObject:messageItem];
   }
   NSURL *URL = [RCTConvert NSURL:options[@"url"]];
   if (URL) {

--- a/Libraries/ActionSheetIOS/RCTMessageActivityItemProvider.h
+++ b/Libraries/ActionSheetIOS/RCTMessageActivityItemProvider.h
@@ -1,10 +1,11 @@
-//
-//  RCTMessageActivityItemProvider.h
-//  RCTActionSheet
-//
-//  Created by Poon Kwok Cheung on 11/7/2017.
-//  Copyright © 2017 Facebook. All rights reserved.
-//
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
 
 #import <UIKit/UIKit.h>
 

--- a/Libraries/ActionSheetIOS/RCTMessageActivityItemProvider.h
+++ b/Libraries/ActionSheetIOS/RCTMessageActivityItemProvider.h
@@ -1,0 +1,15 @@
+//
+//  RCTMessageActivityItemProvider.h
+//  RCTActionSheet
+//
+//  Created by Poon Kwok Cheung on 11/7/2017.
+//  Copyright © 2017 Facebook. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface RCTMessageActivityItemProvider : UIActivityItemProvider
+
+@property (nonatomic, strong) NSString *message;
+
+@end

--- a/Libraries/ActionSheetIOS/RCTMessageActivityItemProvider.h
+++ b/Libraries/ActionSheetIOS/RCTMessageActivityItemProvider.h
@@ -12,5 +12,6 @@
 @interface RCTMessageActivityItemProvider : UIActivityItemProvider
 
 @property (nonatomic, strong) NSString *message;
+@property (nonatomic, strong) NSArray *messages;
 
 @end

--- a/Libraries/ActionSheetIOS/RCTMessageActivityItemProvider.m
+++ b/Libraries/ActionSheetIOS/RCTMessageActivityItemProvider.m
@@ -7,6 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#import <React/RCTConvert.h>
 #import "RCTMessageActivityItemProvider.h"
 
 @implementation RCTMessageActivityItemProvider
@@ -14,8 +15,24 @@
 
 - (id) activityViewController:(UIActivityViewController *)activityViewController itemForActivityType:(NSString *)activityType
 {
-  if ([activityType isEqualToString:@"net.whatsapp.WhatsApp.ShareExtension"]) {
-    return [self.message stringByReplacingOccurrencesOfString:@"\n" withString:@"<br/>"];
+  for (id customMessageObject in self.messages) {
+    NSDictionary * customMessage = [RCTConvert NSDictionary:customMessageObject];
+    NSArray * types = [RCTConvert NSArray:[customMessage objectForKey:@"types"]];
+    NSString * message = [RCTConvert NSString:[customMessage objectForKey:@"message"]];
+    for (id typeObject in types) {
+      NSString * type = [RCTConvert NSString:typeObject];
+      if ([type hasSuffix:@"*"]) {
+        // simple prefix match
+        NSString * prefix = [type substringToIndex:type.length - 1];
+        if ([activityType hasPrefix:prefix]) {
+          return message;
+        }
+      }
+      else if ([activityType isEqualToString:type]) {
+        // exact match
+        return message;
+      }
+    }
   }
   return self.message;
 }

--- a/Libraries/ActionSheetIOS/RCTMessageActivityItemProvider.m
+++ b/Libraries/ActionSheetIOS/RCTMessageActivityItemProvider.m
@@ -1,10 +1,11 @@
-//
-//  RCTMessageActivityItemProvider.m
-//  RCTActionSheet
-//
-//  Created by Poon Kwok Cheung on 11/7/2017.
-//  Copyright © 2017 Facebook. All rights reserved.
-//
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
 
 #import "RCTMessageActivityItemProvider.h"
 
@@ -13,7 +14,7 @@
 
 - (id) activityViewController:(UIActivityViewController *)activityViewController itemForActivityType:(NSString *)activityType
 {
-  if([activityType isEqualToString:@"net.whatsapp.WhatsApp.ShareExtension"]) {
+  if ([activityType isEqualToString:@"net.whatsapp.WhatsApp.ShareExtension"]) {
     return [self.message stringByReplacingOccurrencesOfString:@"\n" withString:@"<br/>"];
   }
   return self.message;

--- a/Libraries/ActionSheetIOS/RCTMessageActivityItemProvider.m
+++ b/Libraries/ActionSheetIOS/RCTMessageActivityItemProvider.m
@@ -1,0 +1,28 @@
+//
+//  RCTMessageActivityItemProvider.m
+//  RCTActionSheet
+//
+//  Created by Poon Kwok Cheung on 11/7/2017.
+//  Copyright © 2017 Facebook. All rights reserved.
+//
+
+#import "RCTMessageActivityItemProvider.h"
+
+@implementation RCTMessageActivityItemProvider
+
+
+- (id) activityViewController:(UIActivityViewController *)activityViewController itemForActivityType:(NSString *)activityType
+{
+  if([activityType isEqualToString:@"net.whatsapp.WhatsApp.ShareExtension"]) {
+    return [self.message stringByReplacingOccurrencesOfString:@"\n" withString:@"<br/>"];
+  }
+  return self.message;
+}
+
+
+- (id) activityViewControllerPlaceholderItem:(UIActivityViewController *)activityViewController
+{
+  return @"";
+}
+
+@end


### PR DESCRIPTION
When sharing to WhatsApp using Share.share in iOS, new line characters were converted to spaces.

Related SO question:
<https://stackoverflow.com/questions/30255923/uiactivityviewcontroller-not-passing-new-line-characters-to-some-activities>

By using a custom UIActivityItemProvider to convert `\n` to `<br/>` when WhatsApp was selected, we could send multi-line messages to WhatsApp.

** Test
1. Share a multi-line message:
`Share.share({ message: 'Line1\nLine2' });`

2. Select WhatsApp from the action sheet then select a recipient

3. The message should consist of two lines


