### PR TITLE
Podspec: add required "DevSupport" dependency "InspectorInterfaces.{cpp,h}

### DIFF
--- a/React.podspec
+++ b/React.podspec
@@ -87,8 +87,8 @@ Pod::Spec.new do |s|
   end
 
   s.subspec "jschelpers_legacy" do |ss|
-    ss.source_files         = "ReactCommon/jschelpers/{JavaScriptCore,JSCWrapper}.{cpp,h}", "ReactCommon/jschelpers/systemJSCWrapper.cpp"
-    ss.private_header_files = "ReactCommon/jschelpers/{JavaScriptCore,JSCWrapper}.h"
+    ss.source_files         = "ReactCommon/jschelpers/{JavaScriptCore,JSCWrapper,InspectorInterfaces}.{cpp,h}", "ReactCommon/jschelpers/systemJSCWrapper.cpp"
+    ss.private_header_files = "ReactCommon/jschelpers/{JavaScriptCore,JSCWrapper,InspectorInterfaces}.h"
     ss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\"" }
     ss.framework            = "JavaScriptCore"
   end


### PR DESCRIPTION
This PR fixes #14975.
* Podspec: add InspectorInterfaces.h/cpp to the "jschelpers_legacy" subspec.

# Test plan
1. lint the Podspecs: `./scripts/process-podspecs.sh`
2. check that an iOS project can integrate "DevSupport" via Cocoapods again. I'll already checked it on this branch of the demo project: https://github.com/HeEAaD/Demo-ReactNative-0.47.0-rc2-Podspec-issue/tree/fix