### PR TITLE
Removes the error thrown by setting responseType after a request has …

### DIFF
--- a/Libraries/Network/XMLHttpRequest.js
+++ b/Libraries/Network/XMLHttpRequest.js
@@ -175,12 +175,6 @@ class XMLHttpRequest extends EventTarget(...XHR_EVENTS) {
   }
 
   set responseType(responseType: ResponseType): void {
-    if (this._sent) {
-      throw new Error(
-        'Failed to set the \'responseType\' property on \'XMLHttpRequest\': The ' +
-        'response type cannot be set after the request has been sent.'
-      );
-    }
     if (!SUPPORTED_RESPONSE_TYPES.hasOwnProperty(responseType)) {
       warning(
         false,

--- a/Libraries/Network/__tests__/XMLHttpRequest-test.js
+++ b/Libraries/Network/__tests__/XMLHttpRequest-test.js
@@ -94,11 +94,6 @@ describe('XMLHttpRequest', function() {
 
     xhr.responseType = 'arraybuffer';
     expect(xhr.responseType).toBe('arraybuffer');
-
-    // Can't change responseType after first data has been received.
-    xhr.open('GET', 'blabla');
-    xhr.send();
-    expect(() => { xhr.responseType = 'text'; }).toThrow();
   });
 
   it('should expose responseText correctly', function() {


### PR DESCRIPTION
Resolves Issue #13991. There are clear reproduction steps in that ticket.

Specifically, when using `socket.io-client` within `react-native`, an attempt is made to change the `responseType` after a result is received to match the `content-type`. This works fine with other implementations of `XMLHttpRequest`, but not RN's.

I simply removed the exception being thrown (and test scenario for it as it's no longer needed).

Examples of other standard impls of set responseType:
Chromium: https://chromium.googlesource.com/chromium/blink.git/+/99b8c9800ac123eddc3e199088d22569c5294b22/Source/core/xml/XMLHttpRequest.cpp#217

Mozilla: https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/responseType (no indication that an exception will be thrown if changing after response is received)