### PR TITLE
Update sectionList keyExtractor docs

### DIFF
--- a/Libraries/Lists/SectionList.js
+++ b/Libraries/Lists/SectionList.js
@@ -129,7 +129,8 @@ type OptionalProps<SectionT: SectionBase<any>> = {
   /**
    * Used to extract a unique key for a given item at the specified index. Key is used for caching
    * and as the react key to track item re-ordering. The default extractor checks item.key, then
-   * falls back to using the index, like react does.
+   * falls back to using the index, like react does. Note that this sets keys for each item, but 
+   * each overall section still needs its own key.
    */
   keyExtractor: (item: Item, index: number) => string,
   /**


### PR DESCRIPTION
Added language to explain that you still need to add keys for each section even if you use a keyExtractor method.

No code changed; just clarified documentation.
