### PR TITLE
Settings: watch deletion

### DIFF
--- a/Libraries/Settings/Settings.ios.js
+++ b/Libraries/Settings/Settings.ios.js
@@ -52,22 +52,18 @@ var Settings = {
   },
 
   _sendObservations(body: Object) {
-    const bodyKeys = Object.keys(body);
-    const keys = Object.keys(this._settings);
+    const watchedKeys = new Set(subscriptions.reduce((keys, subscription) => {
+      return subscription.keys.concat(subscription.keys);
+    }, []));
 
-    // Deletions
-    keys.forEach((key) => {
-      if (bodyKeys.indexOf(key) === -1) {
-        const newValue = body[key];
-        this._checkValue(key, newValue)
-      }
-    });
-
-    // Additions and modifications
-    bodyKeys.forEach((key) => {
+    watchedKeys.forEach((key) => {
       const newValue = body[key];
       this._checkValue(key, newValue);
     });
+
+    this._settings = {
+      ...body,
+    };
   },
 
   _checkValue(key: String, newValue: mixed) {


### PR DESCRIPTION
**The problem:**
When a key is deleted, the subscription handler isn't called

**First commit:** First iterate over the existing keys (before iterating over the incoming keys), and check if those keys still exist in the incoming data. If not the same logic is applied as for every incoming key.

**But then I figured**, we only notify subscribers for the keys they subscribed to, so in my second commit I simplified the logic by only comparing the values of the watched keys.


