### PR TITLE
fix #10747 (ScrollView rendered incorrectly with RefreshControl)

### DIFF
--- a/React/Views/RCTRefreshControl.m
+++ b/React/Views/RCTRefreshControl.m
@@ -72,7 +72,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
   // endRefreshing otherwise the next pull to refresh will not work properly.
   UIScrollView *scrollView = (UIScrollView *)self.superview;
   if (scrollView.contentOffset.y < 0) {
-    CGPoint offset = {scrollView.contentOffset.x, -scrollView.contentInset.top};
+    CGPoint offset = {scrollView.contentOffset.x, 0};
     [UIView animateWithDuration:0.25
                           delay:0
                         options:UIViewAnimationOptionBeginFromCurrentState


### PR DESCRIPTION
set the y offset to 0, since 0 offset is where we want to be after we hide the refreshControl.

Tested in emulator with ios 8, 9, 10 and also with section headers.
