### PR TITLE
[Geolocation] Use Apple's significant-change API (for iOS 11 UX)

### DIFF
--- a/Libraries/Geolocation/Geolocation.js
+++ b/Libraries/Geolocation/Geolocation.js
@@ -31,6 +31,7 @@ type GeoOptions = {
   maximumAge: number,
   enableHighAccuracy: bool,
   distanceFilter: number,
+  useSignificantChanges: bool,
 }
 
 /**
@@ -124,7 +125,7 @@ var Geolocation = {
 
   /*
    * Invokes the success callback whenever the location changes.  Supported
-   * options: timeout (ms), maximumAge (ms), enableHighAccuracy (bool), distanceFilter(m)
+   * options: timeout (ms), maximumAge (ms), enableHighAccuracy (bool), distanceFilter(m), useSignificantChanges (bool)
    */
   watchPosition: function(success: Function, error?: Function, options?: GeoOptions): number {
     if (!updatesEnabled) {

--- a/Libraries/Geolocation/RCTLocationObserver.m
+++ b/Libraries/Geolocation/RCTLocationObserver.m
@@ -32,7 +32,7 @@ typedef struct {
   double maximumAge;
   double accuracy;
   double distanceFilter;
-  bool useSignificantChanges;
+  BOOL useSignificantChanges;
 } RCTLocationOptions;
 
 @implementation RCTConvert (RCTLocationOptions)
@@ -125,7 +125,6 @@ RCT_EXPORT_MODULE()
     [_locationManager stopUpdatingLocation];
 
   _locationManager.delegate = nil;
-  _usingSignificantChanges = NO;
 }
 
 - (dispatch_queue_t)methodQueue
@@ -146,14 +145,12 @@ RCT_EXPORT_MODULE()
 
   _locationManager.distanceFilter  = distanceFilter;
   _locationManager.desiredAccuracy = desiredAccuracy;
+  _usingSignificantChanges = useSignificantChanges;
+  
   // Start observing location
-  if (useSignificantChanges) {
-    [_locationManager startMonitoringSignificantLocationChanges];
-    _usingSignificantChanges = YES;
-  } else {
+  _usingSignificantChanges ?
+    [_locationManager startMonitoringSignificantLocationChanges] :
     [_locationManager startUpdatingLocation];
-    _usingSignificantChanges = NO;
-  }
 }
 
 #pragma mark - Timeout handler


### PR DESCRIPTION
## Context: 
In the yet-to-be-released iOS 11, Apple has changed the way they notify the user of location services. (You can watch their session from WWDC about all the changes [here](https://developer.apple.com/videos/play/wwdc2017/713/).)

The current implementation of `RCTLocationObserver` uses the standard location services from Apple. When the user has granted `Always` location permission and the application uses the background location service, the user is presented with the *_Blue Bar of Shame_* (for more information check out [this blog post](https://blog.set.gl/ios-11-location-permissions-and-avoiding-the-blue-bar-of-shame-1cee6cd93bbe)):

![image](https://user-images.githubusercontent.com/15896334/28285133-281e425c-6af9-11e7-9177-61b879ab593c.png)

## Changes:
### navigator.geolocation.watchPosition(success, error?, options?):
* Added `useSignificantChanges` boolean to the options passed.

### RCTLocationObserver.m
* Added `_usingSignificantChanges` boolean based on user options. If `true`, then the CLLocationManager will use functions `startMonitoringSignificantLocationChanges`/ `stopMonitoringSignificantLocationChanges` rather than the standard location services.
* Changed method signature of `beginLocationUpdatesWithDesiredAccuracy` to include `useSignificantChanges` flag
* Added check for new `NSLocationAlwaysAndWhenInUseUsageDescription`

## Test Plan:
All unit tests passed.

Tested in simulator and on device, toggling `useSignificantChanges` option when calling `watchPosition`. Results were as expected. **When `TRUE`, the _Blue Bar of Shame_ was not present.**

Changes do not affect Android and location services still work as expected on Android.

## Caveats:
* Change is for iOS only
* Using a different API will have different accuracy results. Adding `useSignificantChanges` as an option was by design so apps that want to have most accurate and most frequent update can still use standard location services. 
