### PR TITLE
Add location of sdk tools on OSX in documentation ('Getting Started')

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -400,7 +400,7 @@ Add the following lines to your `$HOME/.bash_profile` config file:
 
 ```
 export ANDROID_HOME=$HOME/Library/Android/sdk
-export PATH=$PATH:$ANDROID_HOME/tools
+export PATH=$PATH:$ANDROID_HOME/tools/bin
 export PATH=$PATH:$ANDROID_HOME/platform-tools
 ```
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -400,6 +400,7 @@ Add the following lines to your `$HOME/.bash_profile` config file:
 
 ```
 export ANDROID_HOME=$HOME/Library/Android/sdk
+export PATH=$PATH:$ANDROID_HOME/tools
 export PATH=$PATH:$ANDROID_HOME/tools/bin
 export PATH=$PATH:$ANDROID_HOME/platform-tools
 ```


### PR DESCRIPTION
I added `$ANDROID_HOME/tools/bin` to the recommended `PATH` augmentation in order to include tools recommended by the latest release of android SDK.