### PR TITLE
[Geolocation] Provide option to request specific location permissions

### DIFF
--- a/Libraries/Geolocation/Geolocation.js
+++ b/Libraries/Geolocation/Geolocation.js
@@ -31,6 +31,7 @@ type GeoOptions = {
   maximumAge: number,
   enableHighAccuracy: bool,
   distanceFilter: number,
+  locationAuthorizationIOS: string,
 }
 
 /**
@@ -185,5 +186,9 @@ var Geolocation = {
     }
   }
 };
+
+Geolocation.IOS_AUTHORIZATIONS = {};
+Geolocation.IOS_AUTHORIZATIONS.WHEN_IN_USE = "locationAuthorizationWhenInUse";
+Geolocation.IOS_AUTHORIZATIONS.ALWAYS = "locationAuthorizationAlways";
 
 module.exports = Geolocation;

--- a/Libraries/Geolocation/Geolocation.js
+++ b/Libraries/Geolocation/Geolocation.js
@@ -74,7 +74,10 @@ type GeoOptions = {
  *
  */
 var Geolocation = {
-
+  IOS_AUTHORIZATIONS: Object = {
+    WHEN_IN_USE: 'locationAuthorizationWhenInUse',
+    ALWAYS: 'locationAuthorizationAlways',
+  },
   /*
    * Request suitable Location permission based on the key configured on pList.
    * If NSLocationAlwaysUsageDescription is set, it will request Always authorization,
@@ -186,9 +189,5 @@ var Geolocation = {
     }
   }
 };
-
-Geolocation.IOS_AUTHORIZATIONS = {};
-Geolocation.IOS_AUTHORIZATIONS.WHEN_IN_USE = "locationAuthorizationWhenInUse";
-Geolocation.IOS_AUTHORIZATIONS.ALWAYS = "locationAuthorizationAlways";
 
 module.exports = Geolocation;


### PR DESCRIPTION
# Context
On IOS, the React Native Geolocation library will make system permission requests based on the capability of the app as defined in `Info.plist`.

This PR allows the option for feature developers to specify the exact level of location permission request to make, by passing an argument in as part of the options parameter. This is important in scenarios where user privacy and permission regarding location-based features needs to be specifically scoped.

This will prevent situations where apps will ask users for background location permission, even though certain features may only require location in the foreground.

# Changes
- Add `locationAuthorizationIOS` as an option in `GeoOptions`
- Expose `Geolocation.IOS_AUTHORIZATIONS` as a String enum
- Add `locationAuthorization` as an argument for `beginLocationUpdatesWithDesiredAccuracy`
- Make location requests either based on the option, or fall back to the old Info.plist approach

# Test Plan
Tested in simulator, using an app with Background Location capability, called `beginLocationUpdatesWithDesiredAccuracy`with various authorizations requested.

