### PR TITLE
Native Animated - Override __makeNative in AnimatedInterpolation

### DIFF
--- a/Libraries/Animated/src/AnimatedImplementation.js
+++ b/Libraries/Animated/src/AnimatedImplementation.js
@@ -1124,6 +1124,11 @@ class AnimatedInterpolation extends AnimatedWithChildren {
     this._interpolation = Interpolation.create(config);
   }
 
+  __makeNative() {
+    this._parent.__makeNative();
+    super.__makeNative();
+  }
+
   __getValue(): number | string {
     var parentValue: number = this._parent.__getValue();
     invariant(


### PR DESCRIPTION
Summary:
Fixes the error `Trying to update interpolation node that has not been
attached to the parent` in android which occurs when using multiple
Animated.Values along with interpolation and an animation is run before
another one that uses interpolation. On ios, no error is thrown in such
case but the animation also doesn't work as expected.

You can check the snack code here which works properly without
useNativeDriver: true. But fails on android and skips the first stage
of animation on ios.
  https://snack.expo.io/HyD3zdjSZ

**Test Plan**
The animations worked properly after the __makeNative override made
the parent node native as well.

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. In other words, a test plan is *required*. Bonus points for screenshots and videos!

Please read the Contribution Guidelines at https://github.com/facebook/react-native/blob/master/CONTRIBUTING.md to learn more about contributing to React Native.

Happy contributing!
-->
