### PR TITLE
Update podspec integration instructions

### DIFF
--- a/docs/IntegrationWithExistingApps.md
+++ b/docs/IntegrationWithExistingApps.md
@@ -244,6 +244,7 @@ target 'swift-2048' do
   # but if not, adjust the `:path` accordingly
   pod 'React', :path => '../node_modules/react-native', :subspecs => [
     'Core',
+    'CxxBridge', # Include this for RN >= 0.47
     'DevSupport', # Include this to enable In-App Devmenu if RN >= 0.43
     'RCTText',
     'RCTNetwork',


### PR DESCRIPTION
You need to add CxxBridge or BatchedBridge as a dependency while we have both. When we stop shipping the BatchedBridge in OSS, this requirement will disappear again.