### PR TITLE
[CI] Update Dangerfile, fix flagging IssueCommands.txt changes

### DIFF
--- a/danger/dangerfile.js
+++ b/danger/dangerfile.js
@@ -95,8 +95,8 @@ if (isSubmittedByTaskforce) {
 }
 
 // Warns if the bots whitelist file is updated.
-const isBotsCommandsFile = path => includes(path, 'bots/IssueCommands.txt');
-if (isBotsCommandsFile) {
+const issueCommandsFileModified = includes(danger.git.modified_files, 'bots/IssueCommands.txt');
+if (issueCommandsFileModified) {
   const message = ':exclamation: Bots';
   const idea = 'This PR appears to modify the list of people that may issue commands to the ' +
     'GitHub bot.';


### PR DESCRIPTION
The bot was incorrectly flagging PRs that do not touch IssueCommands.txt. This PR fixes the Dangerfile rule.

## Test Plan

Verify the warning is generated on a PR that touches IssuesCommands.txt:

```
$ DANGER_GITHUB_API_TOKEN="e622517d9f1136ea8900""07c6373666312cdfaa69" npm run danger pr https://github.com/facebook/react-native/pull/15087

> @ danger /Users/hramos/git/react-native/danger
> node ./node_modules/.bin/danger "pr" "https://github.com/facebook/react-native/pull/15087"

{
  fails: [],
  warnings: [
    {
      message: ":clipboard: Test Plan - <i>This PR appears to be missing a Test Plan.</i>"
    }, 
    {
      message: ":exclamation: Bots - <i>This PR appears to modify the list of people that may issue commands to the GitHub bot.</i>"
    }
  ],
  messages: [],
  markdowns: []
}

```

Verify it does not warn on a PR that does not modify IssueCommands.txt:

```
$ DANGER_GITHUB_API_TOKEN="e622517d9f1136ea8900""07c6373666312cdfaa69" npm run danger pr https://github.com/facebook/react-native/pull/15089

> @ danger /Users/hramos/git/react-native/danger
> node ./node_modules/.bin/danger "pr" "https://github.com/facebook/react-native/pull/15089"

{
  fails: [],
  warnings: [],
  messages: [],
  markdowns: []
}
```