### PR TITLE
iOS: Geolocation: Allow skipping of permission prompts

### DIFF
--- a/Libraries/Geolocation/Geolocation.js
+++ b/Libraries/Geolocation/Geolocation.js
@@ -26,6 +26,10 @@ const PermissionsAndroid = require('PermissionsAndroid');
 var subscriptions = [];
 var updatesEnabled = false;
 
+type GeoConfiguration = {
+  skipPermissionRequests: bool;
+}
+
 type GeoOptions = {
   timeout?: number,
   maximumAge?: number,
@@ -74,6 +78,23 @@ type GeoOptions = {
  *
  */
 var Geolocation = {
+
+  /*
+    * Sets configuration options that will be used in all location requests.
+    *
+    * ### Options
+    *
+    * #### iOS
+    *
+    * - `skipPermissionRequests` - defaults to `false`, if `true` you must request permissions
+    * before using Geolocation APIs.
+    *
+    */
+  setRNConfiguration: function(
+    geo_config: GeoConfiguration
+  ) {
+    RCTLocationObserver.setRNConfiguration(geo_config);
+  },
 
   /*
    * Request suitable Location permission based on the key configured on pList.

--- a/Libraries/Geolocation/Geolocation.js
+++ b/Libraries/Geolocation/Geolocation.js
@@ -93,8 +93,8 @@ var Geolocation = {
   setRNConfiguration: function(
     config: GeoConfiguration
   ) {
-    if (RCTLocationObserver.setRNConfiguration) {
-      RCTLocationObserver.setRNConfiguration(config);
+    if (RCTLocationObserver.setConfiguration) {
+      RCTLocationObserver.setConfiguration(config);
     }
   },
 

--- a/Libraries/Geolocation/Geolocation.js
+++ b/Libraries/Geolocation/Geolocation.js
@@ -91,9 +91,11 @@ var Geolocation = {
     *
     */
   setRNConfiguration: function(
-    geo_config: GeoConfiguration
+    config: GeoConfiguration
   ) {
-    RCTLocationObserver.setRNConfiguration(geo_config);
+    if (RCTLocationObserver.setRNConfiguration) {
+      RCTLocationObserver.setRNConfiguration(config);
+    }
   },
 
   /*

--- a/Libraries/Geolocation/RCTLocationObserver.m
+++ b/Libraries/Geolocation/RCTLocationObserver.m
@@ -188,7 +188,7 @@ RCT_EXPORT_MODULE()
 
 #pragma mark - Public API
 
-RCT_EXPORT_METHOD(setRNConfiguration:(RCTLocationConfiguration)config)
+RCT_EXPORT_METHOD(setConfiguration:(RCTLocationConfiguration)config)
 {
   _locationConfiguration = config;
 }

--- a/Libraries/Geolocation/RCTLocationObserver.m
+++ b/Libraries/Geolocation/RCTLocationObserver.m
@@ -28,6 +28,10 @@ typedef NS_ENUM(NSInteger, RCTPositionErrorCode) {
 #define RCT_DEFAULT_LOCATION_ACCURACY kCLLocationAccuracyHundredMeters
 
 typedef struct {
+  BOOL skipPermissionRequests;
+} RCTLocationConfiguration;
+
+typedef struct {
   double timeout;
   double maximumAge;
   double accuracy;
@@ -36,6 +40,15 @@ typedef struct {
 } RCTLocationOptions;
 
 @implementation RCTConvert (RCTLocationOptions)
+
++ (RCTLocationConfiguration)RCTLocationConfiguration:(id)json
+{
+  NSDictionary<NSString *, id> *options = [RCTConvert NSDictionary:json];
+
+  return (RCTLocationConfiguration) {
+    .skipPermissionRequests = [RCTConvert BOOL:options[@"skipPermissionRequests"]]
+  };
+}
 
 + (RCTLocationOptions)RCTLocationOptions:(id)json
 {
@@ -111,6 +124,7 @@ static NSDictionary<NSString *, id> *RCTPositionError(RCTPositionErrorCode code,
   NSMutableArray<RCTLocationRequest *> *_pendingRequests;
   BOOL _observingLocation;
   BOOL _usingSignificantChanges;
+  RCTLocationConfiguration _locationConfiguration;
   RCTLocationOptions _observerOptions;
 }
 
@@ -141,7 +155,9 @@ RCT_EXPORT_MODULE()
 
 - (void)beginLocationUpdatesWithDesiredAccuracy:(CLLocationAccuracy)desiredAccuracy distanceFilter:(CLLocationDistance)distanceFilter useSignificantChanges:(BOOL)useSignificantChanges
 {
-  [self requestAuthorization];
+  if (!_locationConfiguration.skipPermissionRequests) {
+    [self requestAuthorization];
+  }
 
   _locationManager.distanceFilter  = distanceFilter;
   _locationManager.desiredAccuracy = desiredAccuracy;
@@ -171,6 +187,11 @@ RCT_EXPORT_MODULE()
 }
 
 #pragma mark - Public API
+
+RCT_EXPORT_METHOD(setRNConfiguration:(RCTLocationConfiguration)config)
+{
+  _locationConfiguration = config;
+}
 
 RCT_EXPORT_METHOD(requestAuthorization)
 {

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/location/LocationModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/location/LocationModule.java
@@ -104,6 +104,11 @@ public class LocationModule extends ReactContextBaseJavaModule {
     }
   }
 
+  @ReactMethod
+  public void setRNConfiguration(ReadableMap config) {
+    // No supported configuration options on Android.
+  }
+
   /**
    * Get the current position. This can return almost immediately if the location is cached or
    * request an update, which might take a while.

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/location/LocationModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/location/LocationModule.java
@@ -104,11 +104,6 @@ public class LocationModule extends ReactContextBaseJavaModule {
     }
   }
 
-  @ReactMethod
-  public void setRNConfiguration(ReadableMap config) {
-    // No supported configuration options on Android.
-  }
-
   /**
    * Get the current position. This can return almost immediately if the location is cached or
    * request an update, which might take a while.


### PR DESCRIPTION
This change enables developers to tell the Geolocation module to skip its permissions requests so the app can manage the permissions requests on its own. React Native Android's Geolocation module already requires apps to request permissions on their own.

Currently, the Geolocation module automatically makes permissions requests for you based on what you've specified in your property list file. However, the property list file doesn't always represent what permissions the app wants right now. For example, suppose an app sometimes wants location when "in use" and sometimes wants location "always" depending on what app features the user has engaged with. The Geolocation API will request the "always" location permission even if that's not what the app wants for the current scenario.

This change enables developers to tell the Geolocation module to skip permission requests so that the app can explicitly ask for the appropriate permissions. By default, Geolocation will still ask for permissions so this is not a breaking change.

This change adds a method to Geolocation that is not supported by the web spec for geolocation (`setRNConfiguration`). This method includes `RN` in the name to minimize the chances that the web spec will introduce an API with the same name.

**Test plan (required)**

Verified that Geolocation requests permissions by default and when `skipPermissionRequests` is `false`. Verified the permission requests are skipped when `skipPermissionRequests` is `true`. Also, my team is using this change in our app.

Adam Comella
Microsoft Corp.