### PR TITLE
actually return the app bundle supported orientations

### DIFF
--- a/React/Views/RCTModalHostView.h
+++ b/React/Views/RCTModalHostView.h
@@ -30,6 +30,9 @@
 
 @property (nonatomic, weak) id<RCTModalHostViewInteractor> delegate;
 
+#if !TARGET_OS_TV
+@property (nonatomic, assign) UIInterfaceOrientationMask appSupportedOrientationMask;
+#endif
 @property (nonatomic, copy) NSArray<NSString *> *supportedOrientations;
 @property (nonatomic, copy) RCTDirectEventBlock onOrientationChange;
 

--- a/React/Views/RCTModalHostView.m
+++ b/React/Views/RCTModalHostView.m
@@ -224,11 +224,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:coder)
 - (UIInterfaceOrientationMask)supportedOrientationsMask
 {
   if (_supportedOrientations.count == 0) {
-    if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad) {
-      return UIInterfaceOrientationMaskAll;
-    } else {
-      return UIInterfaceOrientationMaskPortrait;
-    }
+    return self.appSupportedOrientationMask;
   }
 
   UIInterfaceOrientationMask supportedOrientations = 0;


### PR DESCRIPTION
actually return the app bundle supported orientations, in case no `supportedOrientations` is provided

Problem:
when no `supportedOrientations` was provided, the modal would return only portrait for iphone, and all for ipad.

now is actually looks at the app bundle, and returns the supported orientations.

Test Plan:
- run `RNTester` and go to `Modal`.
- for `Supported orientations` select the last option, `Default supportedOrientations`.
- go landscape.
- press `Present`.
- watch as the modal actually works with landscape, when we provide no explicit supported orientations, and the app bundle said that landscape is supported too.

you can use the same test sequence to verify that before this PR, it was not working. the modal was opening as portrait, even though the app supports and currently is landscape.
