### PR TITLE
[CI] [Fix] Exclude the dangerfile from eslint.

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -12,3 +12,4 @@ website/core/metadata.js
 website/core/metadata-blog.js
 website/src/react-native/docs/
 website/src/react-native/blog/
+danger/


### PR DESCRIPTION
Before:

```
$ npm run lint

> react-native@1000.0.0 lint /Users/hramos/git/react-native
> eslint .

Cannot find module '@ljharb/eslint-config'
Referenced from: /Users/hramos/git/react-native/danger/node_modules/extend/.eslintrc
Error: Cannot find module '@ljharb/eslint-config'
Referenced from: /Users/hramos/git/react-native/danger/node_modules/extend/.eslintrc
    at ModuleResolver.resolve (/Users/hramos/git/react-native/node_modules/eslint/lib/util/module-resolver.js:74:19)
    at resolve (/Users/hramos/git/react-native/node_modules/eslint/lib/config/config-file.js:515:25)
    at load (/Users/hramos/git/react-native/node_modules/eslint/lib/config/config-file.js:532:26)
    at configExtends.reduceRight (/Users/hramos/git/react-native/node_modules/eslint/lib/config/config-file.js:424:36)
    at Array.reduceRight (native)
    at applyExtends (/Users/hramos/git/react-native/node_modules/eslint/lib/config/config-file.js:408:28)
    at Object.load (/Users/hramos/git/react-native/node_modules/eslint/lib/config/config-file.js:566:22)
    at loadConfig (/Users/hramos/git/react-native/node_modules/eslint/lib/config.js:63:33)
    at getLocalConfig (/Users/hramos/git/react-native/node_modules/eslint/lib/config.js:130:29)
    at Config.getConfig (/Users/hramos/git/react-native/node_modules/eslint/lib/config.js:260:26)


```

After:


```
$ npm run lint

> react-native@1000.0.0 lint /Users/hramos/git/react-native
> eslint .


/Users/hramos/git/react-native/babel-preset/configs/internal.js
  11:5  warning  'resolvePlugins' is assigned a value but never used  no-unused-vars
  16:2  warning  Missing semicolon               
...
✖ 5047 problems (1001 errors, 4046 warnings)
```