### PR TITLE
Validate the content type of the bundle returned by the packager

### DIFF
--- a/React/Base/RCTJavaScriptLoader.mm
+++ b/React/Base/RCTJavaScriptLoader.mm
@@ -243,6 +243,21 @@ static void attemptAsynchronousLoadOfBundleAtURL(NSURL *scriptURL, RCTSourceLoad
       onComplete(error, nil, 0);
       return;
     }
+
+    // Validate that the packager actually returned javascript.
+    NSString *contentType = headers[@"Content-Type"];
+    if (![contentType isEqualToString:@"application/javascript"]) {
+      error = [NSError errorWithDomain:@"JSServer"
+                                  code:NSURLErrorCannotParseResponse
+                              userInfo:@{
+                                         NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Expected JavaScript, but got content type '%@'.", contentType],
+                                         @"headers": headers,
+                                         @"data": data
+                                         }];
+      onComplete(error, nil, 0);
+      return;
+    }
+
     onComplete(nil, data, data.length);
   }];
 


### PR DESCRIPTION
When using the packager behind something like an http tunnel it is possible something else than JS is returned, in that case throw an error instead of trying to parse it.

This is useful for Expo since the packager runs behind ngrok. This allows to intercept that error and show a more meaningful error message based on the ngrok response.

**Test plan**
Tested by changing the packager to return text/html content type and validate that the error shows up properly.
Also tested that it works when multipart response is disabled.

<img width="354" alt="screen shot 2017-07-19 at 8 01 58 pm" src="https://user-images.githubusercontent.com/2677334/28394905-39e86d52-6cbe-11e7-9059-13a85816a57e.png">
