### PR TITLE
use propTypes directly

### DIFF
--- a/Libraries/Components/MaskedView/MaskedViewIOS.ios.js
+++ b/Libraries/Components/MaskedView/MaskedViewIOS.ios.js
@@ -16,7 +16,6 @@ const StyleSheet = require('StyleSheet');
 const View = require('View');
 const ViewPropTypes = require('ViewPropTypes');
 const requireNativeComponent = require('requireNativeComponent');
-const ReactPropTypes = PropTypes;
 
 import type { ViewProps } from 'ViewPropTypes';
 
@@ -70,7 +69,7 @@ class MaskedViewIOS extends React.Component {
 
   static propTypes = {
     ...ViewPropTypes,
-    maskElement: ReactPropTypes.element.isRequired,
+    maskElement: PropTypes.element.isRequired,
   };
 
   _hasWarnedInvalidRenderMask = false;


### PR DESCRIPTION
Just noticed this commit creates a new variable for propTypes instead of using it directly. https://github.com/facebook/react-native/commit/c2c97ae4b10884bddb716ebfd6ebf7b2e49b2bca

Should be straighforward.

Test plan:
eslint should pass.

cc @bvaughn @hramos 