### PR TITLE
Pass actual loaded image size to load (iOS).

### DIFF
--- a/Libraries/Image/RCTImageView.m
+++ b/Libraries/Image/RCTImageView.m
@@ -364,7 +364,8 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
       }
     } else {
       if (self->_onLoad) {
-        self->_onLoad(onLoadParamsForSource(source));
+        RCTImageSource *sourceLoaded = [source imageSourceWithSize:image.size scale:source.scale];
+        self->_onLoad(onLoadParamsForSource(sourceLoaded));
       }
       if (self->_onLoadEnd) {
         self->_onLoadEnd(nil);


### PR DESCRIPTION
Motivation: The JavaScript image component's onLoad callback optionally
accepts dimensions width and height, allowing the parent of the image to
obtain the native size (without an extra bridge call). It was found that
the dimensions passed into this callback on iOS are frequently (0,0),
not the true native dimensions. This change ensures that the image's
dimensions are passed to the callback. (Examination of the initializer
for RCTImageSource, + (RCTImageSource *)RCTImageSource:(id)json,
indicates that not all code paths produce a size other than CGSizeZero.)

Test plan: To verify this fix, load an image (in my case, from the
network) with the onLoad callback simply logging the received
dimensions. Obeserve that without this fix, the dimensions are (0,0),
whereas this change passes the dimensions