### PR TITLE
Fix panResponder nativeEvent.locationX and locationY values on touch move

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/JSTouchDispatcher.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/JSTouchDispatcher.java
@@ -116,14 +116,21 @@ public class JSTouchDispatcher {
       mGestureStartTime = TouchEvent.UNSET;
     } else if (action == MotionEvent.ACTION_MOVE) {
       // Update pointer position for current gesture
+      float[] moveTargetCoordinates = new float[2];
+      TouchTargetHelper.findTargetTagAndCoordinatesForTouch(
+        ev.getX(),
+        ev.getY(),
+        mRootViewGroup,
+        moveTargetCoordinates,
+        null);
       eventDispatcher.dispatchEvent(
         TouchEvent.obtain(
           mTargetTag,
           TouchEventType.MOVE,
           ev,
           mGestureStartTime,
-          mTargetCoordinates[0],
-          mTargetCoordinates[1],
+          moveTargetCoordinates[0],
+          moveTargetCoordinates[1],
           mTouchEventCoalescingKeyHelper));
     } else if (action == MotionEvent.ACTION_POINTER_DOWN) {
       // New pointer goes down, this can only happen after ACTION_DOWN is sent for the first pointer

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/JSTouchDispatcher.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/JSTouchDispatcher.java
@@ -74,12 +74,7 @@ public class JSTouchDispatcher {
       // this gesture
       mChildIsHandlingNativeGesture = false;
       mGestureStartTime = ev.getEventTime();
-      mTargetTag = TouchTargetHelper.findTargetTagAndCoordinatesForTouch(
-        ev.getX(),
-        ev.getY(),
-        mRootViewGroup,
-        mTargetCoordinates,
-        null);
+      mTargetTag = findTargetTagAndSetCoordinates(ev);
       eventDispatcher.dispatchEvent(
         TouchEvent.obtain(
           mTargetTag,
@@ -103,6 +98,7 @@ public class JSTouchDispatcher {
     } else if (action == MotionEvent.ACTION_UP) {
       // End of the gesture. We reset target tag to -1 and expect no further event associated with
       // this gesture.
+      findTargetTagAndSetCoordinates(ev);
       eventDispatcher.dispatchEvent(
         TouchEvent.obtain(
           mTargetTag,
@@ -116,21 +112,15 @@ public class JSTouchDispatcher {
       mGestureStartTime = TouchEvent.UNSET;
     } else if (action == MotionEvent.ACTION_MOVE) {
       // Update pointer position for current gesture
-      float[] moveTargetCoordinates = new float[2];
-      TouchTargetHelper.findTargetTagAndCoordinatesForTouch(
-        ev.getX(),
-        ev.getY(),
-        mRootViewGroup,
-        moveTargetCoordinates,
-        null);
+      findTargetTagAndSetCoordinates(ev);
       eventDispatcher.dispatchEvent(
         TouchEvent.obtain(
           mTargetTag,
           TouchEventType.MOVE,
           ev,
           mGestureStartTime,
-          moveTargetCoordinates[0],
-          moveTargetCoordinates[1],
+          mTargetCoordinates[0],
+          mTargetCoordinates[1],
           mTouchEventCoalescingKeyHelper));
     } else if (action == MotionEvent.ACTION_POINTER_DOWN) {
       // New pointer goes down, this can only happen after ACTION_DOWN is sent for the first pointer
@@ -170,6 +160,16 @@ public class JSTouchDispatcher {
         ReactConstants.TAG,
         "Warning : touch event was ignored. Action=" + action + " Target=" + mTargetTag);
     }
+  }
+
+  private int findTargetTagAndSetCoordinates(MotionEvent ev) {
+    // This method updates `mTargetCoordinates` with coordinates for the motion event.
+    return TouchTargetHelper.findTargetTagAndCoordinatesForTouch(
+      ev.getX(),
+      ev.getY(),
+      mRootViewGroup,
+      mTargetCoordinates,
+      null);
   }
 
   private void dispatchCancelEvent(MotionEvent androidEvent, EventDispatcher eventDispatcher) {


### PR DESCRIPTION
Fixes #12591

The Android JSTouchDispatcher was using `mTargetCoordinates` when creating the TouchEvent for a move. However, these are final values which are set when the touch down is received. When the user's finger moves, it's important to be able to track the coordinates of the touch as it moves. Thus, we need to update the x,y coordinates by calling `TouchTargetHelper` on each move event.

Test Plan:
All unit tests pass.
I tested this by validating that the `locationX` and `locationY` properties of the nativeEvent correspond to the location of the finger as it moves across the screen in our application. We use a PanResponder to move a view as the user's finger moves across the screen.

On iOS, the `locationX` and `locationY` properties already track the coordinates of the touch event.