### PR TITLE
feat(bundle): allow to extend asset extensions

### DIFF
--- a/local-cli/bundle/buildBundle.js
+++ b/local-cli/bundle/buildBundle.js
@@ -37,6 +37,7 @@ function saveBundle(output, bundle, args) {
 function buildBundle(
   args: OutputOptions & {
     assetsDest: mixed,
+    assetExts: Array<string>,
     entryFile: string,
     maxWorkers: number,
     resetCache: boolean,
@@ -67,7 +68,7 @@ function buildBundle(
   // bundle command and close it down afterwards.
   var shouldClosePackager = false;
   if (!packagerInstance) {
-    const assetExts = (config.getAssetExts && config.getAssetExts()) || [];
+    const assetExts = ((config.getAssetExts && config.getAssetExts()) || []).concat(args.assetExts);
     const sourceExts = (config.getSourceExts && config.getSourceExts()) || [];
     const platforms = (config.getPlatforms && config.getPlatforms()) || [];
 

--- a/local-cli/bundle/bundleCommandLineArgs.js
+++ b/local-cli/bundle/bundleCommandLineArgs.js
@@ -51,6 +51,10 @@ module.exports = [
     command: '--assets-dest [string]',
     description: 'Directory name where to store assets referenced in the bundle',
   }, {
+    command: '--asset-exts [list]',
+    description: 'Specify any additional asset extentions to be used by the packager',
+    parse: (val) => val.split(','),
+  }, {
     command: '--verbose',
     description: 'Enables logging',
     default: false,


### PR DESCRIPTION
## Motivation
`react-native start` allows to extend the asset extensions by config file AND cli, `react-native bundle` does not (inconsistent)

## Test Plan

1. `react-native init TestApp`
1. add `require('./FontAwesome.ttf');` to `index.ios.js`
1. download and save `FontAwesome.ttf` to app directory
1. `react-native bundle --entry-file index.ios.js --bundle-output ios/main.jsbundle`
1. `react-native bundle --entry-file index.ios.js --bundle-output ios/main.jsbundle --asset-exts=ttf`

First it should fail with `Unable to resolve module`, second command should bundle. Of course you can also configure `ttf,otf,dat` as extensions to be bundled.

![screen shot 2017-04-28 at 15 00 06](https://cloud.githubusercontent.com/assets/4459348/25529709/8add5956-2c23-11e7-84c6-409e1f4da08e.png)
