### PR TITLE
[metro] Control whether Metro tells Babel to lookup .babelrc files

### DIFF
--- a/local-cli/server/runServer.js
+++ b/local-cli/server/runServer.js
@@ -149,6 +149,7 @@ function getPackagerServer(args, config) {
     assetExts: defaultAssetExts.concat(args.assetExts),
     blacklistRE: config.getBlacklistRE(),
     cacheVersion: '3',
+    enableBabelRCLookup: config.getEnableBabelRCLookup(),
     extraNodeModules: config.extraNodeModules,
     getPolyfills: config.getPolyfills,
     getTransformOptions: config.getTransformOptions,

--- a/local-cli/util/Config.js
+++ b/local-cli/util/Config.js
@@ -51,6 +51,13 @@ export type ConfigT = {
   getBlacklistRE(): RegExp,
 
   /**
+   * Specify whether or not to enable Babel's behavior for looking up .babelrc
+   * files. If false, only the .babelrc file (if one exists) in the main project
+   * root is used.
+   */
+  getEnableBabelRCLookup(): boolean,
+
+  /**
    * Specify any additional polyfill modules that should be processed
    * before regular module loading.
    */
@@ -165,6 +172,7 @@ const Config = {
     extraNodeModules: Object.create(null),
     getAssetExts: () => [],
     getBlacklistRE: () => blacklist(),
+    getEnableBabelRCLookup: () => true,
     getPlatforms: () => [],
     getPolyfillModuleNames: () => [],
     getProjectRoots: () => {


### PR DESCRIPTION
This adds support to RN's configuration file to let people turn off Babel's behavior of looking up .babelrc files. Most of the support for this feature is in Metro (https://github.com/facebook/metro-bundler/pull/31).

Test Plan: See the Metro test plan (tested with RN).