### PR TITLE
changed ReactTextViewManager.java

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextViewManager.java
@@ -178,7 +178,7 @@ public class ReactTextViewManager extends BaseViewManager<ReactTextView, ReactTe
   }
 
   @Override
-  public Class<ReactTextShadowNode> getShadowNodeClass() {
+  public Class<? extends ReactTextShadowNode> getShadowNodeClass() {
     return ReactTextShadowNode.class;
   }
 


### PR DESCRIPTION
Make getShadowNodeClass accept subtypes of ReactTextShadowNode, so users can extend both ReactTextViewManager and ReactTextShadowNode.

Test Plan:
If it compiles for Android then it is ok, I guess.