### PR TITLE
iOS: Fix font weight resolution

### DIFF
--- a/React/Views/RCTFont.mm
+++ b/React/Views/RCTFont.mm
@@ -54,15 +54,14 @@ static RCTFontWeight weightOfFont(UIFont *font)
     };
   });
 
-  NSDictionary *traits = [font.fontDescriptor objectForKey:UIFontDescriptorTraitsAttribute];
-  RCTFontWeight weight = [traits[UIFontWeightTrait] doubleValue];
-  if (weight == 0.0) {
-    for (NSString *name in nameToWeight) {
-      if ([font.fontName.lowercaseString hasSuffix:name]) {
-        return [nameToWeight[name] doubleValue];
-      }
+  for (NSString *name in nameToWeight) {
+    if ([font.fontName.lowercaseString hasSuffix:name]) {
+      return [nameToWeight[name] doubleValue];
     }
   }
+
+  NSDictionary *traits = [font.fontDescriptor objectForKey:UIFontDescriptorTraitsAttribute];
+  RCTFontWeight weight = [traits[UIFontWeightTrait] doubleValue];
   return weight;
 }
 


### PR DESCRIPTION
**Issue:**
Some fonts are defined with weights that don't match with the UIFontWeight constants.

**Example:**
UIFontWeightTraits for Roboto font
Light: -0.230
Thin: -0.365

Currently, the UIFontWeightTrait is always used if it != 0.0, and given the UIFontWeight constants for Light and Thin:
UIFontWeightThin -0.6
UIFontWeightLight -0.4

A style font weight of "300" or "200" will both resolve to Roboto-Thin as its weight -0.365 is closer to -0.4 (UIFontWeightLight) and -0.6 (UIFontWeightThin) than -0.230 (Roboto-Light).

**Proposed fix:**
When resolving `getWeightOfFont` try to match the name of weight to the name of the font first, and guess the font with UIFontWeightTrait as the fall back.

**Test Plan:**
Attempt to display Roboto at weights "200" and "300" and Roboto-Thin and Roboto-Light should be displayed correctly.

Current:
![simulator screen shot jul 7 2017 11 44 42 am](https://user-images.githubusercontent.com/889895/28506859-31b274e8-6fe3-11e7-8f92-f41ff2183356.png)

Fixed:
![simulator screen shot jul 7 2017 11 42 25 am](https://user-images.githubusercontent.com/889895/28506861-365ea3f4-6fe3-11e7-992c-9f426785037f.png)
