### PR TITLE
Adds hook for platform-specific View props

### DIFF
--- a/Libraries/Components/View/PlatformViewPropTypes.android.js
+++ b/Libraries/Components/View/PlatformViewPropTypes.android.js
@@ -10,4 +10,4 @@
  * @flow
  */
 
-module.export = {}
+module.export = {};

--- a/Libraries/Components/View/PlatformViewPropTypes.android.js
+++ b/Libraries/Components/View/PlatformViewPropTypes.android.js
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule PlatformViewPropTypes
+ * @flow
+ */
+
+module.export = {}

--- a/Libraries/Components/View/PlatformViewPropTypes.ios.js
+++ b/Libraries/Components/View/PlatformViewPropTypes.ios.js
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule PlatformViewPropTypes
+ * @flow
+ */
+
+const Platform = require('Platform');
+
+var TVViewPropTypes = {};
+if (Platform.isTVOS) {
+  TVViewPropTypes = require('TVViewPropTypes');
+}
+
+module.exports = TVViewPropTypes;

--- a/Libraries/Components/View/ViewPropTypes.js
+++ b/Libraries/Components/View/ViewPropTypes.js
@@ -12,7 +12,7 @@
 'use strict';
 
 const EdgeInsetsPropType = require('EdgeInsetsPropType');
-const Platform = require('Platform');
+const PlatformViewPropTypes = require('PlatformViewPropTypes');
 const PropTypes = require('prop-types');
 const StyleSheetPropType = require('StyleSheetPropType');
 const ViewStylePropTypes = require('ViewStylePropTypes');
@@ -21,11 +21,6 @@ const {
   AccessibilityComponentTypes,
   AccessibilityTraits,
 } = require('ViewAccessibility');
-
-var TVViewPropTypes = {};
-if (Platform.isTVOS) {
-  TVViewPropTypes = require('TVViewPropTypes');
-}
 
 import type {
   AccessibilityComponentType,
@@ -85,7 +80,7 @@ export type ViewProps = {
 } & TVViewProps;
 
 module.exports = {
-  ...TVViewPropTypes,
+  ...PlatformViewPropTypes,
 
   /**
    * When `true`, indicates that the view is an accessibility element. By default,


### PR DESCRIPTION
Platforms that plug in to react-native may require additional props that are specific to those platforms. For example, already in react-native there are props that are specific to Android (`accessibilityComponentType`, `needsOffscreenAlphaCompositing`, etc.), props that are specific to iOS (`accessibilityTraits`, `shouldRasterizeIOS`, etc.) and props that are specific to tvOS (`isTVSelectable`, `tvParallaxProperties`, etc.).

I need to add properties to `react-native-windows`, and I'd prefer not to override the entire `ViewPropTypes` file as it is a risk that things in react-native-windows fall out of sync with react-native.

Fixes #15173

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. In other words, a test plan is *required*. Bonus points for screenshots and videos!

Please read the Contribution Guidelines at https://github.com/facebook/react-native/blob/master/CONTRIBUTING.md to learn more about contributing to React Native.

Happy contributing!
-->
