### PR TITLE
Retry for #14830 - Fix "Handling Text Input" tutorial's "next" within text

### DIFF
--- a/docs/HandlingTextInput.md
+++ b/docs/HandlingTextInput.md
@@ -48,4 +48,4 @@ In this example, we store `text` in the state, because it changes over time.
 
 There are a lot more things you might want to do with a text input. For example, you could validate the text inside while the user types. For more detailed examples, see the [React docs on controlled components](https://facebook.github.io/react/docs/forms.html), or the [reference docs for TextInput](docs/textinput.html).
 
-Text input is probably the simplest example of a component whose state naturally changes over time. Next, let's look at another type of component like this one that controls layout, and [learn about the ScrollView](docs/using-a-scrollview.html).
+Text input is one of the ways the user interacts with the app. Next, let's look at another type of input and [learn how to handle touches](docs/handling-touches.html).


### PR DESCRIPTION
Retry for https://github.com/facebook/react-native/pull/14830.

There was some problem with the import and @hramos instructed to open a new PR with the same changes. See https://github.com/facebook/react-native/pull/14830#issuecomment-315146320 for more details.

-----

The tutorial pages tend to have a "follow to the next topic" section at the end of the text.

HandlingTextInput.md has handling-touches in the "next" in metadata, but the "follow to the next topic" section linked to ScrollView tutorial page. Thus, the "follow to the next topic" section in the text is updated also to point to handling-touches.