### PR TITLE
Fix description of next tutorial on "Handling Text Input" page

### DIFF
--- a/docs/HandlingTextInput.md
+++ b/docs/HandlingTextInput.md
@@ -48,4 +48,4 @@ In this example, we store `text` in the state, because it changes over time.
 
 There are a lot more things you might want to do with a text input. For example, you could validate the text inside while the user types. For more detailed examples, see the [React docs on controlled components](https://facebook.github.io/react/docs/forms.html), or the [reference docs for TextInput](docs/textinput.html).
 
-Text input is probably the simplest example of a component whose state naturally changes over time. Next, let's look at another type of component like this one that controls layout, and [learn about the ScrollView](docs/using-a-scrollview.html).
+Text input is probably the simplest example of a component whose state naturally changes over time. Next, let's look at [how to handle touches](docs/handling-touches.html).


### PR DESCRIPTION
The last sentence says that the next tutorial is the ScrollView, when the Next button actually points to "Handling Touches. (ScrollView is after Handling Touches).  Updated the sentence and link to go to Handling Touches instead.
