### PR TITLE
[CI] Warn if base !== master, tag CODEOWNERS

### DIFF
--- a/danger/dangerfile.js
+++ b/danger/dangerfile.js
@@ -11,8 +11,9 @@
 
 const fs = require('fs');
 const includes = require('lodash.includes');
+const minimatch = require('minimatch');
 
-import { danger, fail, markdown, warn } from 'danger';
+// Removed import
 
 const isDocsFile = path => includes(path, 'docs/');
 const editsDocs = danger.git.modified_files.filter(isDocsFile).length > 0;
@@ -33,7 +34,6 @@ if (addsBlogPost) {
   const idea = 'This PR appears to add a new blog post, ' +
     'and may require further review from the React Native team.';
   warn(`${message} - <i>${idea}</i>`);
-  markdown(':memo: This PR requires attention from the @facebook/react-native team.');
 }
 
 // Flags edits to blog posts
@@ -43,7 +43,6 @@ if (editsBlogPost) {
   const idea = 'This PR appears to edit an existing blog post, ' +
     'and may require further review from the React Native team.';
   warn(`${message} - <i>${idea}</i>`);
-  markdown('This PR requires attention from the @facebook/react-native team.');
 }
 
 // Fails if the description is too short.
@@ -66,7 +65,6 @@ if (packageChanged) {
   const idea = 'Changes were made to package.json. ' +
     'This will require a manual import by a Facebook employee.';
   warn(`${message} - <i>${idea}</i>`);
-  markdown('This PR requires attention from the @facebook/react-native team.');
 }
 
 // Warns if a test plan is missing.
@@ -101,4 +99,38 @@ if (issueCommandsFileModified) {
   const idea = 'This PR appears to modify the list of people that may issue commands to the ' +
     'GitHub bot.';
   warn(`${message} - <i>${idea}</i>`);
+}
+
+// Warns if the PR is opened against stable, as commits need to be cherry picked and tagged by a release maintainer.
+// Fails if the PR is opened against anything other than `master` or `-stable`.
+const isMergeRefMaster = danger.github.pr.base.ref === 'master';
+const isMergeRefStable = danger.github.pr.base.ref.indexOf(`-stable`) !== -1;
+if (!isMergeRefMaster && isMergeRefStable) {
+  const message = ':grey_question: Base Branch';
+  const idea = 'The base branch for this PR is something other than `master`. Are you sure you want to merge these changes into a stable release? If you are interested in backporting updates to an older release, the suggested approach is to land those changes on `master` first and then cherry-pick the commits into the branch for that release. The [Releases Guide](https://github.com/facebook/react-native/blob/master/Releases.md) has more information.';
+  warn(`${message} - <i>${idea}</i>`);
+} else if (!isMergeRefMaster && !isMergeRefStable) {
+  const message = ':exclamation: Base Branch';
+  const idea = 'The base branch for this PR is something other than `master`. [Are you sure you want to target something other than the `master` branch?](http://facebook.github.io/react-native/docs/contributing.html#pull-requests)';
+  fail(`${message} - <i>${idea}</i>`);
+}
+
+// People can add themselves to CODEOWNERS in order to be automatically added as reviewers when a file matching a glob pattern is modified. The following will have the bot add a mention in that case.
+const codeowners = fs.readFileSync('../.github/CODEOWNERS', 'utf8').split('\n');
+let mentions = [];
+codeowners.forEach((codeowner) => {
+  const pattern = codeowner.split(' ')[0];
+  const owners = codeowner.substring(pattern.length).trim().split(' ');
+
+  const modifiedFileHasOwner = path => minimatch(path, pattern);
+  const modifiesOwnedCode = danger.git.modified_files.filter(modifiedFileHasOwner).length > 0;
+
+  if (modifiesOwnedCode) {
+    mentions = mentions.concat(owners);
+  }
+});
+const isOwnedCodeModified = mentions.length > 0;
+if (isOwnedCodeModified) {
+  const uniqueMentions = new Set(mentions);
+  markdown('Attention: ' + [...uniqueMentions].join(', '));
 }

--- a/danger/dangerfile.js
+++ b/danger/dangerfile.js
@@ -13,7 +13,7 @@ const fs = require('fs');
 const includes = require('lodash.includes');
 const minimatch = require('minimatch');
 
-// Removed import
+import { danger, fail, markdown, warn } from 'danger';
 
 const isDocsFile = path => includes(path, 'docs/');
 const editsDocs = danger.git.modified_files.filter(isDocsFile).length > 0;

--- a/danger/package.json
+++ b/danger/package.json
@@ -5,6 +5,7 @@
   },
   "devDependencies": {
     "danger": "^0.21.2",
-    "lodash.includes": "^4.3.0"
+    "lodash.includes": "^4.3.0",
+    "minimatch": "^3.0.4"
   }
 }


### PR DESCRIPTION
The following PR modifies the Danger rules in the following way:

1. Verifies if a PR is opened against master. If not, it will warn (if opened against stable) or fail (anything else).
2. No longer adds a markdown message tagging the @facebook/react-native team, as the bot does not have the necessary scope to mention the team.
3. Mentions people that have marked themselves as interested in a file, when that file is modified. This is based off CODEOWNERS. The bot should be able to use mentions here as it will act as any other regular user.

## Test Plan

Verify it tags the right people in https://github.com/facebook/react-native/pull/15139

```
$ npm run danger pr https://github.com/facebook/react-native/pull/15139

> @ danger /Users/hramos/git/react-native/danger
> node ./node_modules/.bin/danger "pr" "https://github.com/facebook/react-native/pull/15139"

{
  fails: [],
  warnings: [],
  messages: [],
  markdowns: ["Attention: @grabbou, @kureev"]
}
```

It should not tag anyone for https://github.com/facebook/react-native/pull/15175:

```
$ npm run danger pr https://github.com/facebook/react-native/pull/15175

> @ danger /Users/hramos/git/react-native/danger
> node ./node_modules/.bin/danger "pr" "https://github.com/facebook/react-native/pull/15175"

{
  fails: [],
  warnings: [],
  messages: [],
  markdowns: []
}
```

It should warn on https://github.com/facebook/react-native/pull/14640 as it targets 0.45-stable:

```
$ npm run danger pr https://github.com/facebook/react-native/pull/14640

> @ danger /Users/hramos/git/react-native/danger
> node ./node_modules/.bin/danger "pr" "https://github.com/facebook/react-native/pull/14640"

{
  fails: [],
  warnings: [
    {
      message: ":grey_question: Base Branch - <i>The base branch for this PR is something other than `master`. Are you sure you want to merge these changes into a stable release? If you are interested in backporting updates to an older release, the suggested approach is to land those changes on `master` first and then cherry-pick the commits into the branch for that release. The [Releases Guide](https://github.com/facebook/react-native/blob/master/Releases.md) has more information.</i>"
    }
  ],
  messages: [],
  markdowns: [":page_facing_up: Thanks for your contribution to the docs!"]
}
```

It should not warn on https://github.com/facebook/react-native/pull/15175 because it targets master.
```
$ npm run danger pr https://github.com/facebook/react-native/pull/15175

> @ danger /Users/hramos/git/react-native/danger
> node ./node_modules/.bin/danger "pr" "https://github.com/facebook/react-native/pull/15175"

{
  fails: [],
  warnings: [],
  messages: [],
  markdowns: []
}
```