### PR TITLE
Add more information to `__fbBatchedBridge is undefined` error

### DIFF
--- a/React/Executors/RCTJSCExecutor.mm
+++ b/React/Executors/RCTJSCExecutor.mm
@@ -596,7 +596,11 @@ RCT_EXPORT_METHOD(setContextName:(nonnull NSString *)contextName)
       }
     } else {
       if (!errorJSRef && JSC_JSValueGetType(ctx, batchedBridgeRef) == kJSTypeUndefined) {
-        error = RCTErrorWithMessage(@"Unable to execute JS call: __fbBatchedBridge is undefined");
+        error = RCTErrorWithMessage(@"Unable to execute JS call: __fbBatchedBridge is undefined. This can happen "
+                                    "if you try to execute JS and the bridge has not set up, for example if it encountered "
+                                    "an incomplete bundle or a fatal script execution error during startup. Verify that a "
+                                    "valid JS bundle is included with your app and that it loaded correctly, or try "
+                                    "reinstalling the app.");
       }
     }
 


### PR DESCRIPTION
**Motivation:**  This error can be a symptom of various other issues (see: an issue search for `__fbBatchedBridge is undefined`). I'm hoping to provide slightly more information about what might be going wrong and how to self-help.

**Test Plan:** Run some JS before the bridge has injected itself into the JS context. (sort of copping out here since the change is just to an error string literal.)