### PR TITLE
Remove hasPressHandler function and it's uses because it's not used…

### DIFF
--- a/Libraries/Components/Touchable/TouchableHighlight.js
+++ b/Libraries/Components/Touchable/TouchableHighlight.js
@@ -221,7 +221,7 @@ var TouchableHighlight = createReactClass({
   },
 
   _showUnderlay: function() {
-    if (!this._isMounted || !this._hasPressHandler()) {
+    if (!this._isMounted) {
       return;
     }
 
@@ -233,7 +233,7 @@ var TouchableHighlight = createReactClass({
   _hideUnderlay: function() {
     this.clearTimeout(this._hideTimeout);
     this._hideTimeout = null;
-    if (this._hasPressHandler() && this.refs[UNDERLAY_REF]) {
+    if (this.refs[UNDERLAY_REF]) {
       this.refs[CHILD_REF].setNativeProps(INACTIVE_CHILD_PROPS);
       this.refs[UNDERLAY_REF].setNativeProps({
         ...INACTIVE_UNDERLAY_PROPS,
@@ -241,15 +241,6 @@ var TouchableHighlight = createReactClass({
       });
       this.props.onHideUnderlay && this.props.onHideUnderlay();
     }
-  },
-
-  _hasPressHandler: function() {
-    return !!(
-      this.props.onPress ||
-      this.props.onPressIn ||
-      this.props.onPressOut ||
-      this.props.onLongPress
-    );
   },
 
   render: function() {


### PR DESCRIPTION
…  used in other touchable components also it's not necessary.

By default TouchableHighlight component needs to have a press handler funciton to show and hide underlay color which is not appropriate.

Test Plan : create a TouchableHighlight component and it won't show underlay on press if no press handler function is assigned

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. In other words, a test plan is *required*. Bonus points for screenshots and videos!

Please read the Contribution Guidelines at https://github.com/facebook/react-native/blob/master/CONTRIBUTING.md to learn more about contributing to React Native.

Happy contributing!
-->
