### PR TITLE
Docs: fix typo in deeplinking docs

### DIFF
--- a/Libraries/Linking/Linking.js
+++ b/Libraries/Linking/Linking.js
@@ -79,7 +79,7 @@ const LinkingManager = Platform.OS === 'android' ?
  *    openURL:(NSURL *)url
  *    options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options
  * {
- *   return [RCTLinkingManager application:app openURL:url options:options];
+ *   return [RCTLinkingManager application:application openURL:url options:options];
  * }
  * ```
  * 


### PR DESCRIPTION
Just a small typo in the docs, the suggested code uses a variable that doesn't exist and leads to a compile error.