### PR TITLE
fix too many unused render with HeaderComponent

### DIFF
--- a/Libraries/Lists/VirtualizedList.js
+++ b/Libraries/Lists/VirtualizedList.js
@@ -977,7 +977,7 @@ class VirtualizedList extends React.PureComponent<OptionalProps, Props, State> {
     const itemCount = this.props.getItemCount(this.props.data);
     let hiPri = false;
     if (first > 0 || last < itemCount - 1) {
-      const distTop = offset - this._getFrameMetricsApprox(first).offset;
+      const distTop = offset - (this._getFrameMetricsApprox(first).offset - this._getFrameMetricsApprox(0).offset);
       const distBottom =
         this._getFrameMetricsApprox(last).offset - (offset + visibleLength);
       const scrollingThreshold =


### PR DESCRIPTION
fix #14968 , this bug happen with SectionList with HeaderComponent

the distTop is wrong because the HeaderComponent Height > 0, cause distTop < 0 and hiPri = true, then call _updateCellsToRender > render again and again
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. In other words, a test plan is *required*. Bonus points for screenshots and videos!

Please read the Contribution Guidelines at https://github.com/facebook/react-native/blob/master/CONTRIBUTING.md to learn more about contributing to React Native.

Happy contributing!
-->
