### PR TITLE
[Docs] What to Expect from Maintainers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,220 @@
 # Contributing to React Native
 
-Want to contribute to React Native? There are a few things you need to know.
+<!-- generated_contributing_start -->
+React Native is one of Facebook's first open source projects that is both under very active development and is also being used to ship code to everybody using Facebook's mobile apps. If you're interested in contributing to React Native, hopefully this document makes the process for contributing clear.
 
-We wrote a [contribution guide](https://facebook.github.io/react-native/docs/contributing.html) to help you get started.
+Core contributors to React Native meet monthly and post their meeting notes on the [React Native blog](https://facebook.github.io/react-native/blog). You can also find ad hoc discussions in the [React Native Core Contributors](https://www.facebook.com/groups/reactnativeoss/) Facebook group.
+
+## [Code of Conduct](https://code.facebook.com/codeofconduct)
+
+Facebook has adopted a Code of Conduct that we expect project participants to adhere to. Please read [the full text](https://code.facebook.com/codeofconduct) so that you can understand what actions will and will not be tolerated.
+
+## How to contribute
+
+There are many ways to contribute to React Native, and many of them do not involve writing any code. Here's a few ideas to get started:
+
+* Simply start using React Native. Go through the [Getting Started](http://facebook.github.io/react-native/docs/getting-started.html) guide. Does everything work as expected? If not, we're always looking for improvements. Let us know by [opening an issue](http://facebook.github.io/react-native/docs/contributing.html#reporting-new-issues).
+* Look through the [open issues](https://github.com/facebook/react-native/issues). Provide workarounds, ask for clarification, or suggest labels. Help [triage issues](http://facebook.github.io/react-native/docs/contributing.html#triaging-issues-and-pull-requests).
+* If you find an issue you would like to fix, [open a pull request](http://facebook.github.io/react-native/docs/contributing.html#your-first-pull-request). Issues tagged as [`Good First Task`](https://github.com/facebook/react-native/labels/Good%20First%20Task) are a good place to get started.
+* Read through the [React Native docs](http://facebook.github.io/react-native/docs). If you find anything that is confusing or can be improved, you can make edits by clicking "Improve this page" at the bottom of most docs.
+* Browse [Stack Overflow](https://stackoverflow.com/questions/tagged/react-native) and answer questions. This will help you get familiarized with common pitfalls or misunderstandings, which can be useful when contributing updates to the documentation.
+* Take a look at the [features requested](https://react-native.canny.io/feature-requests) by others in the community and consider opening a pull request if you see something you want to work on.
+
+Contributions are very welcome. If you think you need help planning your contribution, please hop into [#react-native](https://discord.gg/0ZcbPKXt5bZjGY5n) and let people know you're looking for a mentor.
+
+### Triaging issues and pull requests
+
+One great way you can contribute to the project without writing any code is to help triage issues and pull requests as they come in.
+
+* Ask for more information if the issue does not provide all the details required by the template.
+* Suggest [labels](https://github.com/facebook/react-native/labels) that can help categorize issues.
+* Flag issues that are stale or that should be closed.
+* Ask for test plans and review code.
+
+Adding labels, closing and reopening issues, and merging pull requests is, as you may expect, limited to a subset of contributors. Simply commenting on the issue or pull request can still go a long way towards helping us keep the number of outstanding issues under control.
+
+Once you have become an active contributor in the community, you may gain access to the Facebook GitHub Bot, allowing you to perform some of these operations yourself. You can learn more about the bot in the [maintainer's guide](docs/maintainers.html#facebook-github-bot).
+
+
+## Our development process
+
+Some of the core team will be working directly on [GitHub](https://github.com/facebook/react-native). These changes will be public from the beginning. Other changesets will come via a bridge with Facebook's internal source control. This is a necessity as it allows engineers at Facebook outside of the core team to move fast and contribute from an environment they are comfortable in.
+
+When a change made on GitHub is approved, it will first be imported into Facebook's internal source control. The change will eventually sync back to GitHub as a single commit once it has passed all internal tests.
+
+### Branch organization
+
+We will do our best to keep `master` in good shape, with tests passing at all times. But in order to move fast, we will make API changes that your application might not be compatible with. We will do our best to [communicate these changes](https://github.com/facebook/react-native/releases) and version appropriately so you can lock into a specific version if need be.
+
+To see what changes are coming and provide better feedback to React Native contributors, use the [latest release candidate](http://facebook.github.io/react-native/versions.html) when possible. By the time a release candidate is released, the changes it contains will have been shipped in production Facebook apps for over two weeks.
+
+## Bugs
+
+We use [GitHub Issues](https://github.com/facebook/react-native/issues) for our public bugs. If you would like to report a problem, take a look around and see if someone already opened an issue about it. If you a are certain this is a new, unreported bug, you can submit a [bug report](http://facebook.github.io/react-native/docs/contributing.html#reporting-new-issues).
+
+If you have questions about using React Native, the [help page](http://facebook.github.io/react-native/support.html) list various resources that should help you get started.
+
+We also have a [place where you can request features or enhancements](https://react-native.canny.io/feature-requests). If you see anything you'd like to be implemented, vote it up and explain your use case.
+
+## Reporting new issues
+
+When [opening a new issue](https://github.com/facebook/react-native/issues/new), always make sure to fill out the [issue template](https://raw.githubusercontent.com/facebook/react-native/master/.github/ISSUE_TEMPLATE.md). **This step is very important!** Not doing so may result in your issue getting closed. Don't take this personally if this happens, and feel free to open a new issue once you've gathered all the information required by the template.
+
+* **One issue, one bug:** Please report a single bug per issue.
+* **Provide a Snack:** The best way to get attention on your issue is to provide a reduced test case. You can use [Snack](https://snack.expo.io/) to demonstrate the issue.
+* **Provide reproduction steps:** List all the steps necessary to reproduce the issue. Provide a Snack or upload a sample project to GitHub. The person reading your bug report should be able to follow these steps to reproduce your issue with minimal effort.
+* **Try out the latest version:** Verify that the issue can be reproduced locally by updating your project to use [React Native from `master`](http://facebook.github.io/react-native/versions.html). The bug may have already been fixed!
+
+We're not able to provide support through GitHub Issues. If you're looking for help with your code, consider asking on [Stack Overflow](http://stackoverflow.com/questions/tagged/react-native) or reaching out to the community through [other channels](https://facebook.github.io/react-native/support.html).
+
+### Security bugs
+
+Facebook has a [bounty program](https://www.facebook.com/whitehat/) for the safe disclosure of security bugs. With that in mind, please do not file public issues; go through the process outlined on that page.
+
+## Pull requests
+
+### Your first pull request
+
+So you have decided to contribute code back to upstream by opening a pull request. You've invested a good chunk of time, and we appreciate it. We will do our best to work with you and get the PR looked at.
+
+Working on your first Pull Request? You can learn how from this free video series:
+
+[**How to Contribute to an Open Source Project on GitHub**](https://egghead.io/courses/how-to-contribute-to-an-open-source-project-on-github)
+
+We have a list of [beginner friendly issues](https://github.com/facebook/react-native/labels/Good%20First%20Task) to help you get your feet wet in the React Native codebase and familiar with our contribution process. This is a great place to get started.
+
+### Proposing a change
+
+If you would like to request a new feature or enhancement but are not yet thinking about opening a pull request, we have a [place to track feature requests](https://react-native.canny.io/feature-requests).
+
+If you intend to change the public API, or make any non-trivial changes to the implementation, we recommend [filing an issue](https://github.com/facebook/react-native/issues/new). This lets us reach an agreement on your proposal before you put significant effort into it.
+
+If you're only fixing a bug, it's fine to submit a pull request right away but we still recommend to file an issue detailing what you're fixing. This is helpful in case we don't accept that specific fix but want to keep track of the issue.
+
+### Sending a pull request
+
+Small pull requests are much easier to review and more likely to get merged. Make sure the PR does only one thing, otherwise please split it.
+
+**Before submitting a pull request**, please make sure the following is done:
+
+1. Fork [the repository](https://github.com/facebook/react-native) and create your branch from `master`.
+2. Add the copyright notice to the top of any new files you've added.
+3. Describe your [**test plan**](https://facebook.github.io/react-native/docs/contributing.html#test-plan) in your commit.
+4. Ensure [**tests pass**](https://facebook.github.io/react-native/docs/contributing.html#contrinuous-integration-tests) on both Travis and Circle CI.
+5. Make sure your code lints (`npm run lint`).
+6. If you haven't already, [sign the CLA](https://code.facebook.com/cla).
+
+All pull requests should be opened against the `master` branch.
+
+> **Note:** It is not necessary to keep clicking `Merge master to your branch` on the PR page. You would want to merge master if there are conflicts or tests are failing. The Facebook-GitHub-Bot ultimately squashes all commits to a single one before merging your PR.
+
+#### Test plan
+
+A good test plan has the exact commands you ran and their output, provides screenshots or videos if the pull request changes UI or updates the website.
+
+* If you've added code that should be tested, add tests!
+* If you've changed APIs, update the documentation.
+* If you've updated the docs, verify the website locally and submit screenshots if applicable (see [website/README.md](https://github.com/facebook/react-native/blob/master/website/README.md))
+
+See [What is a Test Plan?](https://medium.com/@martinkonicek/what-is-a-test-plan-8bfc840ec171#.y9lcuqqi9) to learn more.
+
+#### Continuous integration tests
+
+Make sure all **tests pass** on both [Travis][travis] and [Circle CI][circle]. PRs that break tests are unlikely to be merged. Learn more about [testing your changes here](https://facebook.github.io/react-native/docs/testing.html).
+
+[travis]: https://travis-ci.org/facebook/react-native
+[circle]: http://circleci.com/gh/facebook/react-native
+
+#### Breaking changes
+
+When adding a new breaking change, follow this template in your pull request:
+
+```
+### New breaking change here
+
+* **Who does this affect**:
+* **How to migrate**:
+* **Why make this breaking change**:
+* **Severity (number of people affected x effort)**:
+```
+
+If your pull request is merged, a core contributor will update the [list of breaking changes](https://github.com/facebook/react-native/wiki/Breaking-Changes) which is then used to populate the release notes.
+
+#### Copyright Notice for files
+
+Copy and paste this to the top of your new file(s):
+
+```JS
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+```
+
+If you've added a new module, add a `@providesModule <moduleName>` at the end of the comment. This will allow the haste package manager to find it.
+
+#### Contributor License Agreement (CLA)
+
+In order to accept your pull request, we need you to submit a CLA. You only need to do this once, so if you've done this for another Facebook open source project, you're good to go. If you are submitting a pull request for the first time, the Facebook GitHub Bot will reply with a link to the CLA form. You may also [complete your CLA here](https://code.facebook.com/cla).
+
+### What happens next?
+
+The core team will be monitoring for pull requests. Read [what to expect from maintainers](https://facebook.github.io/react-native/docs/maintainers.html#handling-pull-requests) to understand what may happen after you open a pull request.
+
+## Style Guide
+
+Our linter will catch most styling issues that may exist in your code. You can check the status of your code styling by simply running `npm run lint`.
+
+However, there are still some styles that the linter cannot pick up.
+
+### Code Conventions
+
+#### General
+
+* **Most important: Look around.** Match the style you see used in the rest of the project. This includes formatting, naming things in code, naming things in documentation.
+* Add trailing commas,
+* 2 spaces for indentation (no tabs)
+* "Attractive"
+
+#### JavaScript
+
+* Use semicolons;
+* `'use strict';`
+* Prefer `'` over `"`
+* Do not use the optional parameters of `setTimeout` and `setInterval`
+* 80 character line length
+
+#### JSX
+
+* Prefer `"` over `'` for string literal props
+* When wrapping opening tags over multiple lines, place one prop per line
+* `{}` of props should hug their values (no spaces)
+* Place the closing `>` of opening tags on the same line as the last prop
+* Place the closing `/>` of self-closing tags on their own line and left-align them with the opening `<`
+
+#### Objective-C
+
+* Space after `@property` declarations
+* Brackets on *every* `if`, on the *same* line
+* `- method`, `@interface`, and `@implementation` brackets on the following line
+* *Try* to keep it around 80 characters line length (sometimes it's just not possible...)
+* `*` operator goes with the variable name (e.g. `NSObject *variableName;`)
+
+#### Java
+
+* If a method call spans multiple lines closing bracket is on the same line as the last argument.
+* If a method header doesn't fit on one line each argument goes on a separate line.
+* 100 character line length
+
+### Documentation
+
+* Do not wrap lines at 80 characters - configure your editor to soft-wrap when editing documentation.
+
+## License
+
+By contributing to React Native, you agree that your contributions will be licensed under its BSD license.
+<!-- generated_contributing_end -->

--- a/bots/IssueCommands.txt
+++ b/bots/IssueCommands.txt
@@ -9,11 +9,11 @@ comment Duplicate of {match0}
 close
 
 @facebook-github-bot expected
-comment The comment above tells me this is expected behavior. If you'd like to change how this feature works, please submit a feature request on [Canny](https://react-native.canny.io/feature-requests) so that other people can vote on it.
+comment The comment above tells me this is expected behavior. If you'd like to change how this feature works, please submit a feature request on [Canny](https://react-native.canny.io/feature-requests) so that other people can vote on it. See ["How to Contribute"](https://facebook.github.io/react-native/docs/contributing.html#bugs).
 close
 
 @facebook-github-bot stack-overflow
-comment Hey {issue_author}, thanks for posting this! {author} tells me this issue looks like a question that would be best asked on [Stack Overflow](http://stackoverflow.com/questions/tagged/react-native). Stack Overflow is amazing for Q&A: it has a reputation system, voting, the ability to mark a question as answered. Because of the reputation system it is likely the community will see and answer your question there. This also helps us use the GitHub bug tracker for bugs only.
+comment Hey {issue_author}, thanks for posting this! {author} tells me this issue looks like a question that would be best asked on [Stack Overflow](http://stackoverflow.com/questions/tagged/react-native). Stack Overflow is amazing for Q&A: it has a reputation system, voting, the ability to mark a question as answered. Because of the reputation system it is likely the community will see and answer your question there. This also helps us use the GitHub bug tracker for bugs only. See ["What to Expect from Maintainers"](https://facebook.github.io/react-native/docs/maintainers.html#handling-issues).
 add-label For Stack Overflow
 close
 
@@ -21,17 +21,17 @@ close
 add-label {match0}
 
 @facebook-github-bot no-reply
-comment Closing this issue as more information is needed to debug this and we haven't heard back from the author.
+comment Closing this issue as more information is needed to debug this and we haven't heard back from the author. See ["What to Expect from Maintainers"](https://facebook.github.io/react-native/docs/maintainers.html#handling-issues).
 add-label Needs Response from Author
 close
 
 @facebook-github-bot no-template
-comment Hey, thanks for reporting this issue! It looks like your description is missing some necessary information, or the list of reproduction steps is not complete. Can you please add all the details specified in the [Issue Template](https://raw.githubusercontent.com/facebook/react-native/master/.github/ISSUE_TEMPLATE.md)? This is necessary for people to be able to understand and reproduce the issue being reported. I am going to close this, but feel free to open a new issue with the additional information provided. Thanks!
+comment Hey, thanks for reporting this issue! It looks like your description is missing some necessary information, or the list of reproduction steps is not complete. Can you please add all the details specified in the [Issue Template](https://raw.githubusercontent.com/facebook/react-native/master/.github/ISSUE_TEMPLATE.md)? This is necessary for people to be able to understand and reproduce the issue being reported. I am going to close this, but feel free to open a new issue with the additional information provided. Thanks! See ["What to Expect from Maintainers"](https://facebook.github.io/react-native/docs/maintainers.html#handling-issues) to learn more.
 add-label Needs more information
 close
 
 @facebook-github-bot close
-comment {author} has closed this issue. If you think it should remain open, let us know why.
+comment {author} has closed this issue. If you think it should remain open, let us know why. See ["What to Expect from Maintainers"](https://facebook.github.io/react-native/docs/maintainers.html#handling-issues).
 close
 
 @facebook-github-bot bugfix
@@ -39,11 +39,11 @@ comment Hey {issue_author}, if you're sure this is a bug, can you send a pull re
 add-label Help Wanted
 
 @facebook-github-bot needs-repro
-comment Can you reproduce the issue using [Snack](http://snack.expo.io)? This step is necessary for people to be able to see and debug the issue being reported.
+comment Can you reproduce the issue using [Snack](http://snack.expo.io)? This step is necessary for people to be able to see and debug the issue being reported. See ["How to Contribute"](https://facebook.github.io/react-native/docs/contributing.html#bugs).
 add-label Needs more information
 
 @facebook-github-bot cannot-repro
-comment Thanks for opening the issue! It does not appear like a community member will be able to reliably reproduce this issue. This may be for several reasons; perhaps it affects a particular app but a minimal repro has not been provided, or the issue may be sporadic. As it happens, we need a concrete set of steps that can demonstrably reproduce the issue as this will allow your fellow community members to validate a fix. We'll close the issue for now, but feel free to submit a new issue once you're able to reliably reproduce the issue locally. Thanks for your understanding!
+comment Thanks for opening the issue! It does not appear like a community member will be able to reliably reproduce this issue. This may be for several reasons; perhaps it affects a particular app but a minimal repro has not been provided, or the issue may be sporadic. As it happens, we need a concrete set of steps that can demonstrably reproduce the issue as this will allow your fellow community members to validate a fix. We'll close the issue for now, but feel free to submit a new issue once you're able to reliably reproduce the issue locally. Thanks for your understanding! See ["What to Expect from Maintainers"](https://facebook.github.io/react-native/docs/maintainers.html) to learn more.
 close
 
 @facebook-github-bot reopen
@@ -51,14 +51,14 @@ comment Okay, reopening this issue.
 reopen
 
 @facebook-github-bot feature
-comment Hey {issue_author}! Thanks for opening the issue, however it looks like a feature request. As noted in the [Issue template](https://raw.githubusercontent.com/facebook/react-native/master/.github/ISSUE_TEMPLATE.md) we'd like to use the GitHub issues to track bugs only. Can you implement the feature as a standalone npm module? If not, consider sending a pull request or a creating an entry on [Canny](https://react-native.canny.io/feature-requests/). It has a voting system and if the feature gets upvoted enough it might get implemented. Closing this now, thanks for understanding!
+comment Hey {issue_author}! Thanks for opening the issue, however it looks like a feature request. As noted in the [Issue template](https://raw.githubusercontent.com/facebook/react-native/master/.github/ISSUE_TEMPLATE.md) we'd like to use the GitHub issues to track bugs only. Can you implement the feature as a standalone npm module? If not, consider sending a pull request or a creating an entry on [Canny](https://react-native.canny.io/feature-requests/). It has a voting system and if the feature gets upvoted enough it might get implemented. Closing this now, thanks for understanding! See ["How to Contribute"](https://facebook.github.io/react-native/docs/contributing.html#bugs).
 add-label Feature Request
 close
 
 @facebook-github-bot cla
-comment Hey {issue_author}! Thanks for sending this pull request! We would love to review your changes however it looks like you haven't signed the CLA yet. You can do so at https://code.facebook.com/cla.
+comment Hey {issue_author}! Thanks for sending this pull request! We would love to review your changes however it looks like you haven't signed the CLA yet. You can do so at https://code.facebook.com/cla. See ["How to Contribute"](https://facebook.github.io/react-native/docs/contributing.html#pull-requests) to learn more.
 
 @facebook-github-bot icebox
-comment {author} tells me to close this issue because it has been inactive for a while. It's possible that the bug has been fixed since this issue was originally submitted, or perhaps it is not affecting a great amount of people, or a workaround has been provided. Either way, we're going to close this in order to allow the community to focus on more pressing issues. If you strongly believe this issue should remain open, please let us know why.
+comment {author} tells me to close this issue because it has been inactive for a while. It's possible that the bug has been fixed since this issue was originally submitted, or perhaps it is not affecting a great amount of people, or a workaround has been provided. Either way, we're going to close this in order to allow the community to focus on more pressing issues. If you strongly believe this issue should remain open, please let us know why. See ["What to Expect from Maintainers"](https://facebook.github.io/react-native/docs/maintainers.html#handling-issues) to learn more.
 add-label Icebox
 close

--- a/docs/AndroidBuildingFromSource.md
+++ b/docs/AndroidBuildingFromSource.md
@@ -5,7 +5,7 @@ layout: docs
 category: Guides (Android)
 permalink: docs/android-building-from-source.html
 banner: ejected
-next: activityindicator
+next: contributing
 previous: android-ui-performance
 ---
 

--- a/docs/Contributing.md
+++ b/docs/Contributing.md
@@ -2,79 +2,87 @@
 id: contributing
 title: How to Contribute
 layout: docs
-category: Guides
+category: Contributing
 permalink: docs/contributing.html
 next: testing
 previous: upgrading
 ---
 
-React Native is one of Facebook's first open source projects that is both under very active development and is also being used to ship code to everybody using Facebook's mobile apps. We're still working out the kinks to make contributing to this project as easy and transparent as possible, but we're not quite there yet. Hopefully this document makes the process for contributing clear and preempts some questions you may have.
+React Native is one of Facebook's first open source projects that is both under very active development and is also being used to ship code to everybody using Facebook's mobile apps. If you're interested in contributing to React Native, hopefully this document makes the process for contributing clear.
 
-- [Code of Conduct](docs/contributing.html#code-of-conduct)
-- [Development Process](docs/contributing.html#our-development-process)
-- [Branch Organization](docs/contributing.html#branch-organization)
-- [How to Get in Touch](docs/contributing.html#how-to-get-in-touch)
-- [Bugs](docs/contributing.html#bugs)
-- [Pull Requests](docs/contributing.html#pull-requests)
-- [Triaging Issues and Pull Requests](docs/contributing.html#triaging-issues-and-pull-requests)
-- [Style Guide](docs/contributing.html#style-guide)
-- [License](docs/contributing.html#license)
+Core contributors to React Native meet monthly and post their meeting notes on the [React Native blog](https://facebook.github.io/react-native/blog). You can also find ad hoc discussions in the [React Native Core Contributors](https://www.facebook.com/groups/reactnativeoss/) Facebook group.
 
 ## [Code of Conduct](https://code.facebook.com/codeofconduct)
 
 Facebook has adopted a Code of Conduct that we expect project participants to adhere to. Please read [the full text](https://code.facebook.com/codeofconduct) so that you can understand what actions will and will not be tolerated.
 
-## Our Development Process
+## How to contribute
+
+There are many ways to contribute to React Native, and many of them do not involve writing any code. Here's a few ideas to get started:
+
+* Simply start using React Native. Go through the [Getting Started](http://facebook.github.io/react-native/docs/getting-started.html) guide. Does everything work as expected? If not, we're always looking for improvements. Let us know by [opening an issue](http://facebook.github.io/react-native/docs/contributing.html#reporting-new-issues).
+* Look through the [open issues](https://github.com/facebook/react-native/issues). Provide workarounds, ask for clarification, or suggest labels. Help [triage issues](http://facebook.github.io/react-native/docs/contributing.html#triaging-issues-and-pull-requests).
+* If you find an issue you would like to fix, [open a pull request](http://facebook.github.io/react-native/docs/contributing.html#your-first-pull-request). Issues tagged as [`Good First Task`](https://github.com/facebook/react-native/labels/Good%20First%20Task) are a good place to get started.
+* Read through the [React Native docs](http://facebook.github.io/react-native/docs). If you find anything that is confusing or can be improved, you can make edits by clicking "Improve this page" at the bottom of most docs.
+* Browse [Stack Overflow](https://stackoverflow.com/questions/tagged/react-native) and answer questions. This will help you get familiarized with common pitfalls or misunderstandings, which can be useful when contributing updates to the documentation.
+* Take a look at the [features requested](https://react-native.canny.io/feature-requests) by others in the community and consider opening a pull request if you see something you want to work on.
+
+Contributions are very welcome. If you think you need help planning your contribution, please hop into [#react-native](https://discord.gg/0ZcbPKXt5bZjGY5n) and let people know you're looking for a mentor.
+
+### Triaging issues and pull requests
+
+One great way you can contribute to the project without writing any code is to help triage issues and pull requests as they come in.
+
+* Ask for more information if the issue does not provide all the details required by the template.
+* Suggest [labels](https://github.com/facebook/react-native/labels) that can help categorize issues.
+* Flag issues that are stale or that should be closed.
+* Ask for test plans and review code.
+
+Adding labels, closing and reopening issues, and merging pull requests is, as you may expect, limited to a subset of contributors. Simply commenting on the issue or pull request can still go a long way towards helping us keep the number of outstanding issues under control.
+
+Once you have become an active contributor in the community, you may gain access to the Facebook GitHub Bot, allowing you to perform some of these operations yourself. You can learn more about the bot in the [maintainer's guide](docs/maintainers.html#facebook-github-bot).
+
+
+## Our development process
 
 Some of the core team will be working directly on [GitHub](https://github.com/facebook/react-native). These changes will be public from the beginning. Other changesets will come via a bridge with Facebook's internal source control. This is a necessity as it allows engineers at Facebook outside of the core team to move fast and contribute from an environment they are comfortable in.
 
-## Branch Organization
+When a change made on GitHub is approved, it will first be imported into Facebook's internal source control. The change will eventually sync back to GitHub as a single commit once it has passed all internal tests.
+
+### Branch organization
 
 We will do our best to keep `master` in good shape, with tests passing at all times. But in order to move fast, we will make API changes that your application might not be compatible with. We will do our best to [communicate these changes](https://github.com/facebook/react-native/releases) and version appropriately so you can lock into a specific version if need be.
 
 To see what changes are coming and provide better feedback to React Native contributors, use the [latest release candidate](http://facebook.github.io/react-native/versions.html) when possible. By the time a release candidate is released, the changes it contains will have been shipped in production Facebook apps for over two weeks.
 
-## How to Get in Touch
-
-Many React Native users are active on [Stack Overflow](http://stackoverflow.com/questions/tagged/react-native). If you  want to get a general sense of what React Native folks talk about, check out the [React Native Community](https://www.facebook.com/groups/react.native.community) Facebook group. There is also [an active community of React and React Native users on the Discord chat platform](https://discord.gg/0ZcbPKXt5bZjGY5n) in case you need help.
-
-The React Native team sends out periodical updates through the following channels:
-
-* [React Native Blog](https://facebook.github.io/react-native/blog/)
-* [@ReactNative on Twitter](https://www.twitter.com/reactnative)
-
-Core contributors to React Native meet monthly and post their meeting notes on the React Native blog. You can also find ad hoc discussions in the [React Native Core Contributors](https://www.facebook.com/groups/reactnativeoss/) Facebook group.
-
 ## Bugs
 
-### Where to Find Known Issues
+We use [GitHub Issues](https://github.com/facebook/react-native/issues) for our public bugs. If you would like to report a problem, take a look around and see if someone already opened an issue about it. If you a are certain this is a new, unreported bug, you can submit a [bug report](http://facebook.github.io/react-native/docs/contributing.html#reporting-new-issues).
 
-We are using [GitHub Issues](https://github.com/facebook/react-native/issues) for our public bugs. Before filing a new task, try to make sure your problem doesn't already exist.
+If you have questions about using React Native, the [help page](http://facebook.github.io/react-native/support.html) list various resources that should help you get started.
 
-Questions and feature requests are tracked elsewhere:
+We also have a [place where you can request features or enhancements](https://react-native.canny.io/feature-requests). If you see anything you'd like to be implemented, vote it up and explain your use case.
 
-  - Have a question? [Ask on Stack Overflow](http://stackoverflow.com/questions/tagged/react-native).
-  - If you have a question regarding future plans, check out the [roadmap](https://github.com/facebook/react-native/wiki/Roadmap).
-  - Have a feature request that is not covered in the roadmap? [Add it here](https://react-native.canny.io/feature-requests).
-
-### Reporting New Issues
+## Reporting new issues
 
 When [opening a new issue](https://github.com/facebook/react-native/issues/new), always make sure to fill out the [issue template](https://raw.githubusercontent.com/facebook/react-native/master/.github/ISSUE_TEMPLATE.md). **This step is very important!** Not doing so may result in your issue getting closed. Don't take this personally if this happens, and feel free to open a new issue once you've gathered all the information required by the template.
 
-- **One issue, one bug:** Please report a single bug per issue.
-- **Provide a Snack:** The best way to get attention on your issue is to provide a reduced test case. You can use [Snack](https://snack.expo.io/) to demonstrate the issue.
-- **Provide reproduction steps:** List all the steps necessary to reproduce the issue. Provide a Snack or upload a sample project to GitHub. The person reading your bug report should be able to follow these steps to reproduce your issue with minimal effort.
-- **Try out the latest version:** Verify that the issue can be reproduced locally by updating your project to use [React Native from `master`](http://facebook.github.io/react-native/versions.html). The bug may have already been fixed!
+* **One issue, one bug:** Please report a single bug per issue.
+* **Provide a Snack:** The best way to get attention on your issue is to provide a reduced test case. You can use [Snack](https://snack.expo.io/) to demonstrate the issue.
+* **Provide reproduction steps:** List all the steps necessary to reproduce the issue. Provide a Snack or upload a sample project to GitHub. The person reading your bug report should be able to follow these steps to reproduce your issue with minimal effort.
+* **Try out the latest version:** Verify that the issue can be reproduced locally by updating your project to use [React Native from `master`](http://facebook.github.io/react-native/versions.html). The bug may have already been fixed!
 
-We're not able to provide support through GitHub Issues. If you're looking for help with your code, consider asking on [Stack Overflow](http://stackoverflow.com/questions/tagged/react-native) or reaching out to the community through [other channels](docs/contributing.html#how-to-get-in-touch).
+We're not able to provide support through GitHub Issues. If you're looking for help with your code, consider asking on [Stack Overflow](http://stackoverflow.com/questions/tagged/react-native) or reaching out to the community through [other channels](https://facebook.github.io/react-native/support.html).
 
-### Security Bugs
+### Security bugs
 
 Facebook has a [bounty program](https://www.facebook.com/whitehat/) for the safe disclosure of security bugs. With that in mind, please do not file public issues; go through the process outlined on that page.
 
-## Pull Requests
+## Pull requests
 
-### Your First Pull Request
+### Your first pull request
+
+So you have decided to contribute code back to upstream by opening a pull request. You've invested a good chunk of time, and we appreciate it. We will do our best to work with you and get the PR looked at.
 
 Working on your first Pull Request? You can learn how from this free video series:
 
@@ -82,26 +90,28 @@ Working on your first Pull Request? You can learn how from this free video serie
 
 We have a list of [beginner friendly issues](https://github.com/facebook/react-native/labels/Good%20First%20Task) to help you get your feet wet in the React Native codebase and familiar with our contribution process. This is a great place to get started.
 
-If you decide to fix an issue, please be sure to check the comment thread in case somebody is already working on a fix. If nobody is working on it at the moment, please leave a comment stating that you intend to work on it so other people don't accidentally duplicate your effort.
+### Proposing a change
 
-If somebody claims an issue but doesn't follow up for more than two weeks, it's fine to take over it but you should still leave a comment.
+If you would like to request a new feature or enhancement but are not yet thinking about opening a pull request, we have a [place to track feature requests](https://react-native.canny.io/feature-requests).
 
-### Sending a Pull Request
+If you intend to change the public API, or make any non-trivial changes to the implementation, we recommend [filing an issue](https://github.com/facebook/react-native/issues/new). This lets us reach an agreement on your proposal before you put significant effort into it.
 
-If you send a pull request, please do it against the master branch. We maintain stable branches for stable releases separately but we don't accept pull requests to them directly. Instead, we cherry-pick non-breaking changes from master to the latest stable version.
+If you're only fixing a bug, it's fine to submit a pull request right away but we still recommend to file an issue detailing what you're fixing. This is helpful in case we don't accept that specific fix but want to keep track of the issue.
 
-The core team will be monitoring for pull requests. When we get one, we'll run some Facebook-specific integration tests on it first. From here, we'll need to get another person to sign off on the changes and then merge the pull request. For API changes we may need to fix internal uses, which could cause some delay. We'll do our best to provide updates and feedback throughout the process.
+### Sending a pull request
 
 Small pull requests are much easier to review and more likely to get merged. Make sure the PR does only one thing, otherwise please split it.
 
-**Before submitting a pull request**, please make sure the following is done…
+**Before submitting a pull request**, please make sure the following is done:
 
 1. Fork [the repository](https://github.com/facebook/react-native) and create your branch from `master`.
 2. Add the copyright notice to the top of any new files you've added.
-3. Describe your **test plan** in your commit.
-4. Ensure **tests pass** on both Travis and Circle CI.
+3. Describe your [**test plan**](/react-native/docs/contributing.html#test-plan) in your commit.
+4. Ensure [**tests pass**](/react-native/docs/contributing.html#contrinuous-integration-tests) on both Travis and Circle CI.
 5. Make sure your code lints (`npm run lint`).
 6. If you haven't already, [sign the CLA](https://code.facebook.com/cla).
+
+All pull requests should be opened against the `master` branch.
 
 > **Note:** It is not necessary to keep clicking `Merge master to your branch` on the PR page. You would want to merge master if there are conflicts or tests are failing. The Facebook-GitHub-Bot ultimately squashes all commits to a single one before merging your PR.
 
@@ -109,17 +119,15 @@ Small pull requests are much easier to review and more likely to get merged. Mak
 
 A good test plan has the exact commands you ran and their output, provides screenshots or videos if the pull request changes UI or updates the website.
 
-  - If you've added code that should be tested, add tests!
-  - If you've changed APIs, update the documentation.
-  - If you've updated the docs, verify the website locally and submit screenshots if applicable (see [website/README.md](https://github.com/facebook/react-native/blob/master/website/README.md))
+* If you've added code that should be tested, add tests!
+* If you've changed APIs, update the documentation.
+* If you've updated the docs, verify the website locally and submit screenshots if applicable (see [website/README.md](https://github.com/facebook/react-native/blob/master/website/README.md))
 
 See [What is a Test Plan?](https://medium.com/@martinkonicek/what-is-a-test-plan-8bfc840ec171#.y9lcuqqi9) to learn more.
 
 #### Continuous integration tests
 
-Make sure all **tests pass** on both [Travis][travis] and [Circle CI][circle]. PRs that break tests are unlikely to be merged.
-
-You can learn more about running tests and contributing to React Native [next](docs/testing.html).
+Make sure all **tests pass** on both [Travis][travis] and [Circle CI][circle]. PRs that break tests are unlikely to be merged. Learn more about [testing your changes here](/react-native/docs/testing.html).
 
 [travis]: https://travis-ci.org/facebook/react-native
 [circle]: http://circleci.com/gh/facebook/react-native
@@ -131,10 +139,10 @@ When adding a new breaking change, follow this template in your pull request:
 ```
 ### New breaking change here
 
-- **Who does this affect**:
-- **How to migrate**:
-- **Why make this breaking change**:
-- **Severity (number of people affected x effort)**:
+* **Who does this affect**:
+* **How to migrate**:
+* **Why make this breaking change**:
+* **Severity (number of people affected x effort)**:
 ```
 
 If your pull request is merged, a core contributor will update the [list of breaking changes](https://github.com/facebook/react-native/wiki/Breaking-Changes) which is then used to populate the release notes.
@@ -156,163 +164,13 @@ Copy and paste this to the top of your new file(s):
 
 If you've added a new module, add a `@providesModule <moduleName>` at the end of the comment. This will allow the haste package manager to find it.
 
-### Contributor License Agreement (CLA)
+#### Contributor License Agreement (CLA)
 
-In order to accept your pull request, we need you to submit a CLA. You only need to do this once, so if you've done this for another Facebook open source project, you're good to go. If you are submitting a pull request for the first time, just let us know that you have completed the CLA and we can cross-check with your GitHub username.
+In order to accept your pull request, we need you to submit a CLA. You only need to do this once, so if you've done this for another Facebook open source project, you're good to go. If you are submitting a pull request for the first time, the Facebook GitHub Bot will reply with a link to the CLA form. You may also [complete your CLA here](https://code.facebook.com/cla).
 
-Complete your CLA here: https://code.facebook.com/cla
+### What happens next?
 
-### Proposing a change
-
-If you intend to change the public API, or make any non-trivial changes to the implementation, we recommend [filing an issue](https://github.com/facebook/react-native/issues/new). This lets us reach an agreement on your proposal before you put significant effort into it.
-
-If you're only fixing a bug, it's fine to submit a pull request right away but we still recommend to file an issue detailing what you're fixing. This is helpful in case we don't accept that specific fix but want to keep track of the issue.
-
-## Triaging Issues and Pull Requests
-
-One great way you can contribute to the project without writing any code is to help triage issues and pull requests as they come in. Ask for more information if the issue does not provide all the details required by the template. Suggest [labels](https://github.com/facebook/react-native/labels). Flag issues that are stale or that should be closed. Ask for test plans and review code.
-
-Adding labels, closing and reopening issues, and merging pull requests is, as you may expect, limited to a subset of contributors. Simply commenting on the issue or pull request can still go a long way towards helping us keep the number of outstanding issues under control.
-
-### Using the Facebook GitHub Bot
-
-The Facebook GitHub Bot allows certain active members of the community to perform administrative actions such as labeling and closing issues. The list of community members with this kind of access can be found at the top of [IssueCommands.txt](https://github.com/facebook/react-native/blob/master/bots/IssueCommands.txt). The bot can be triggered by adding any of the following commands as a standalone comment on an issue:
-
-<div class="props">
-  <div class="prop">
-    <h4 class="methodTitle">
-      <span class="methodType">@facebook-github-bot</span> no-template
-    </h4>
-    <div><p>
-      Use this when more information is needed, especially if the issue does not adhere to the <a href="https://raw.githubusercontent.com/facebook/react-native/master/.github/ISSUE_TEMPLATE.md">issue template</a>. The bot will <strong>close</strong> the issue after adding the "Needs more information" label.
-    </p></div>
-  </div>
-  <div class="prop">
-    <h4 class="methodTitle">
-      <span class="methodType">@facebook-github-bot</span> stack-overflow
-    </h4>
-    <div><p>
-      Mark issues that do not belong in the bug tracker, and redirect to Stack Overflow. The bot will <strong>close</strong> the issue after adding the "For Stack Overflow" label.
-    </p></div>
-  </div>
-  <div class="prop">
-    <h4 class="methodTitle">
-      <span class="methodType">@facebook-github-bot</span> needs-repro
-    </h4>
-    <div><p>
-      Prompts the author to provide a reproducible example or <a href="http://snack.expo.io">Snack</a>. The bot will apply the "Needs more information" label.
-    </p></div>
-  </div>
-  <div class="prop">
-    <h4 class="methodTitle">
-      <span class="methodType">@facebook-github-bot</span> cannot-repro
-    </h4>
-    <div><p>
-      Use this when the issue cannot be reproduced, either because it affects a particular app but no minimal repro was provided, or the issue describes something sporadic that is unlikely to be reproduced by a community member. The bot will <strong>close</strong> the issue.
-    </p></div>
-  </div>
-  <div class="prop">
-    <h4 class="methodTitle">
-      <span class="methodType">@facebook-github-bot</span> duplicate <span class="methodType">(#[0-9]+)</span>
-    </h4>
-    <div><p>
-      Marks an issue as a duplicate. Requires a issue number to be provided. The bot will <strong>close</strong> the issue.
-    </p></div>
-  </div>
-  <div class="prop">
-    <h4 class="methodTitle">
-      <span class="methodType">@facebook-github-bot</span> label <span class="methodType">(.*)</span>
-    </h4>
-    <div><p>
-      Use this command to add a <a href="https://github.com/facebook/react-native/labels">label</a>, such as "iOS" or "Android", to an issue.
-    </p></div>
-  </div>
-  <div class="prop">
-    <h4 class="methodTitle">
-      <span class="methodType">@facebook-github-bot</span> feature
-    </h4>
-    <div><p>
-      Use this when an issue describes a feature request, as opposed to a reproducible bug. The bot will point the author to the feature request tracker, add the "Feature Request" label, then <strong>close</strong> the issue.
-    </p></div>
-  </div>
-  <div class="prop">
-    <h4 class="methodTitle">
-      <span class="methodType">@facebook-github-bot</span> expected
-    </h4>
-    <div><p>
-      Use this when an issue describes a type of expected behavior. The bot will <strong>close</strong> the issue.
-    </p></div>
-  </div>
-  <div class="prop">
-    <h4 class="methodTitle">
-      <span class="methodType">@facebook-github-bot</span> answered
-    </h4>
-    <div><p>
-      Use this when an issue appears to be a question that has already been answered by someone on the thread. The bot will <strong>close</strong> the issue.
-    </p></div>
-  </div>
-  <div class="prop">
-    <h4 class="methodTitle">
-      <span class="methodType">@facebook-github-bot</span> close
-    </h4>
-    <div><p>
-      <strong>Closes</strong> an issue without providing a particular explanation.
-    </p></div>
-  </div>
-  <div class="prop">
-    <h4 class="methodTitle">
-      <span class="methodType">@facebook-github-bot</span> reopen
-    </h4>
-    <div><p>
-      <strong>Re-opens</strong> a previously closed issue.
-    </p></div>
-  </div>
-  <div class="prop">
-    <h4 class="methodTitle">
-      <span class="methodType">@facebook-github-bot</span> bugfix
-    </h4>
-    <div><p>
-      Mark issues that describe a reproducible bug and encourage the author to send a pull request. The bot will add the "Help Wanted" label.
-    </p></div>
-  </div>
-  <div class="prop">
-    <h4 class="methodTitle">
-      <span class="methodType">@facebook-github-bot</span> no-reply
-    </h4>
-    <div><p>
-      Use this when an issue requires more information from the author but they have not added a comment in a while. The bot will <strong>close</strong> the issue.
-    </p></div>
-  </div>
-  <div class="prop">
-    <h4 class="methodTitle">
-      <span class="methodType">@facebook-github-bot</span> icebox
-    </h4>
-    <div><p>
-      Use this when an issue has been open for over 30 days with no activity and no community member has volunteered to work on a fix. The bot will <strong>close</strong> the issue after adding the "Icebox" label.
-    </p></div>
-  </div>
-</div>
-
-Additionally, the following commands can be used on a pull request:
-
-<div class="props">
-  <div class="prop">
-    <h4 class="methodTitle">
-      <span class="methodType">@facebook-github-bot</span> cla
-    </h4>
-    <div><p>
-      Remind the author that the CLA needs to be signed.
-    </p></div>
-  </div>
-  <div class="prop">
-    <h4 class="methodTitle">
-      <span class="methodType">@facebook-github-bot</span> shipit
-    </h4>
-    <div><p>
-      Flag the PR for merging. If used by a core contributor, the bot will attempt to import the pull request. In general, core contributors are those who have consistently submitted high quality contributions to the project.
-    </p></div>
-  </div>
-</div>
+The core team will be monitoring for pull requests. Read [what to expect from maintainers](/react-native/docs/maintainers.html#handling-pull-requests) to understand what may happen after you open a pull request.
 
 ## Style Guide
 
@@ -366,7 +224,3 @@ However, there are still some styles that the linter cannot pick up.
 ## License
 
 By contributing to React Native, you agree that your contributions will be licensed under its BSD license.
-
-## What Next?
-
-Read the [next section](docs/testing.html) to learn how to test your changes.

--- a/docs/Maintainers.md
+++ b/docs/Maintainers.md
@@ -1,0 +1,246 @@
+---
+id: maintainers
+title: What to Expect from Maintainers
+layout: docs
+category: Contributing
+permalink: docs/maintainers.html
+next: understanding-cli
+previous: testing
+---
+
+So you have read through the [contributor's guide](docs/contributing.html) and you're getting ready to send your first pull request. Perhaps you've found an issue in React Native and want to work with the maintainers to land a fix. Here's what you can expect to happen when you open an issue or send a pull request.
+
+> The following is adapted from the excellent [Open Source Guide](https://opensource.guide/) from GitHub and reflects how the maintainers of React Native are encouraged to handle your contributions.
+
+## Handling Issues
+
+We see dozens of new issues being created every day. In order to help maintainers focus on what is actionable, maintainers ask contributors to do a bit of work prior to opening a new issue:
+
+* New issues should follow the [Issue Template](https://github.com/facebook/react-native/blob/master/.github/ISSUE_TEMPLATE.md).
+* Issues should provide clear, easy to follow steps alongside sample code to reproduce the issue. Ideally, provide a [Snack](http://snack.expo.io/).
+
+Issues that do not  meet the above criteria can be closed immediately, with a link to the [contributor's guide](docs/contributing.html).
+
+### Issues should be reproducible
+
+Issues should be relatively easy to reproduce. Sometimes the issue affects a particular app but a minimal repro is not provided, perhaps a crash is seen in the logs and the author is not sure where its coming from, maybe the issue is sporadic.
+
+As it happens, if a maintainer cannot easily reproduce the issue, one cannot reasonably expect them to be able to work on a fix. These issues can be closed with a short explanation why.
+
+Exceptions can be made if multiple people appear to be affected by the issue, especially right after a new React Native release is cut.
+
+### New issue runbook
+
+You have gathered all the information required to open a new issue, and you are confident it meets the [contributor guidelines](docs/contributing.html). Once you post an issue, this is what our maintainers will consider when deciding how to move forward:
+
+1. Is this issue a feature request? If so, they will ask you to use Canny for feature requests by issuing the `@facebook-github-bot feature` command, closing the issue.
+2. Is this issue a request for help? If so, the maintainer will encourage you to ask on Stack Overflow by issuing the `@facebook-github-bot stack-overflow` command, closing the issue.
+3. Was the [Issue Template](https://github.com/facebook/react-native/blob/master/.github/ISSUE_TEMPLATE.md) used to fill out the issue? Did the author answer Yes to both questions at the top? If not, the maintainer will ask you to provide more information by issuing the `@facebook-github-bot no-template` command, closing the issue.
+4. Does the issue include a Snack or list of steps to reproduce the issue? If not, a maintainer will ask for a repro by issuing the `@facebook-github-bot needs-repro` command.
+5. Can the issue be reliably reproduced? If not, a maintainer may issue the `@facebook-github-bot cannot-repro` command, closing the issue.
+6. Is the issue for an old release of React Native? If so, expect to be asked if the issue can be reproduced in the latest release candidate.
+
+You can learn more about how GitHub Bot commands are used [here](docs/maintainers.html#facebook-github-bot).
+
+### Triaging issues
+
+If a issue is still open after going through all of the checks above, it will move on to the triage stage. A maintainer will then do the following:
+
+1. Add relevant labels: iOS, Android, Tooling, Documentation. They will do so by issuing the `@facebook-github-bot label` command.
+2. Leave a comment saying the issue has been triaged.
+3. Tag the relevant people.
+
+For example, if a issue describes something that needs to be addressed before the next release is cut, a maintainer may tag @grabbou. If the issue concerns Animated, they may tag @janicduplessis. If this is a docs issue, they may tag @hramos. You can generally figure out who is interested in what sort of issue by looking at the [CODEOWNERS](https://github.com/facebook/react-native/blob/master/.github/CODEOWNERS) file.
+
+### Stale issues
+
+Issues that have been open for over six months and have had no activity in the last two months may be closed periodically. If your issue gets closed in this manner, it's nothing personal. If you strongly believe that the issue should remain open, just let us know why.
+
+Simply commenting that the issue still exists is not very compelling (it's rare for critical, release blocking issues to have no activity for two months!). In order to make a good case for reopening the issue, you may need to do a bit of work:
+
+* Can the issue be reproduced on the latest release candidate? Post a comment with the version you tested.
+* If so, is there any information missing from the bug report? Post a comment with all the information required by the [issue template](https://github.com/facebook/react-native/blob/master/.github/ISSUE_TEMPLATE.md).
+* Is there a pull request that addressed this issue? Post a comment with the PR number so we can follow up.
+
+A couple of contributors making a good case may be all that is needed to reopen the issue.
+
+
+## Handling pull requests
+
+The core team will be monitoring for pull requests. When we get one, we'll run some Facebook-specific integration tests on it first. From here, we'll need to get another person to sign off on the changes and then merge the pull request. For API changes we may need to fix internal uses, which could cause some delay. We'll do our best to provide updates and feedback throughout the process.
+
+### How we prioritize pull requests
+
+We use the [Contributors Chrome extension](https://github.com/hzoo/contributors-on-github) to help us understand who is sending a pull request. Pull requests opened by contributors that have a history of having their PRs merged are more likely to be looked at first. Aside from that, we try to go through pull requests on a chronological order.
+
+### How we review pull requests
+
+Reviewing a PR can sometimes require more time from a maintainer than it took you to write the code. Maintainers need to consider all the ramifications of importing your patch into the codebase. Does it potentially introduce breaking changes? What are the performance considerations of adding a new dependency? Will the docs need to be updated as well? Does this belong in core, or would it be a better fit as a third party package?
+
+Finding the right person to review a pull request can sometimes be tricky. A pull request may simultaneously touch iOS, Java, and JavaScript code. If a pull request has been waiting for review for a while, you can help out by looking at the blame history for the files you're touching. Is there anyone that appears to be knowledgeable in the part of the codebase the PR is touching?
+
+### Closing pull requests
+
+Sometimes a maintainer may decide that a pull request will not be accepted. Maybe the pull request is out of scope for the project, or the idea is good but the implementation is poor. Whatever the reason, when closing a pull request maintainers should keep the conversation friendly:
+
+* **Thank** them for their contribution.
+* **Explain why** it doesn't fit into the scope of the project.
+* **Link to relevant documentation**, if you have it.
+* **Close** the request.
+
+## Defusing situations
+
+Sometimes when a maintainer says no to a pull request or close an issue, a contributor may get upset and criticize your decision. Maintainers will take steps to defuse the situation.
+
+If a contributor becomes hostile or disrespectful, they will be referred to the [Code of Conduct](https://code.facebook.com/codeofconduct). Negative users will be blocked, and inappropriate comments will be deleted.
+
+## Facebook GitHub Bot
+
+The Facebook GitHub Bot allows certain active members of the community to perform administrative actions such as labeling and closing issues. The list of community members with this kind of access can be found at the top of the [IssueCommands.txt](https://github.com/facebook/react-native/blob/master/bots/IssueCommands.txt) file in the repository.
+
+Once you have become an active contributor in the community, you may open a pull request to add yourself to the list, making sure to list your prior contributions to the community when doing so.
+
+### Using the Facebook GitHub Bot
+
+The bot can be triggered by adding any of the following commands as a standalone comment on an issue:
+
+<div class="botActions">
+  <div class="botAction">
+    <h4 class="botCommand">
+      <span class="botMentionName">@facebook-github-bot</span> no-template
+    </h4>
+    <div><p>
+      Use this when more information is needed, especially if the issue does not adhere to the <a href="https://raw.githubusercontent.com/facebook/react-native/master/.github/ISSUE_TEMPLATE.md">issue template</a>. The bot will <strong>close</strong> the issue after adding the "Needs more information" label.
+    </p></div>
+  </div>
+  <div class="botAction">
+    <h4 class="botCommand">
+      <span class="botMentionName">@facebook-github-bot</span> stack-overflow
+    </h4>
+    <div><p>
+      Mark issues that do not belong in the bug tracker, and redirect to Stack Overflow. The bot will <strong>close</strong> the issue after adding the "For Stack Overflow" label.
+    </p></div>
+  </div>
+  <div class="botAction">
+    <h4 class="botCommand">
+      <span class="botMentionName">@facebook-github-bot</span> needs-repro
+    </h4>
+    <div><p>
+      Prompts the author to provide a reproducible example or <a href="http://snack.expo.io">Snack</a>. The bot will apply the "Needs more information" label.
+    </p></div>
+  </div>
+  <div class="botAction">
+    <h4 class="botCommand">
+      <span class="botMentionName">@facebook-github-bot</span> cannot-repro
+    </h4>
+    <div><p>
+      Use this when the issue cannot be reproduced, either because it affects a particular app but no minimal repro was provided, or the issue describes something sporadic that is unlikely to be reproduced by a community member. The bot will <strong>close</strong> the issue.
+    </p></div>
+  </div>
+  <div class="botAction">
+    <h4 class="botCommand">
+      <span class="botMentionName">@facebook-github-bot</span> duplicate (#[0-9]+)
+    </h4>
+    <div><p>
+      Marks an issue as a duplicate. Requires a issue number to be provided. The bot will <strong>close</strong> the issue.
+    </p>
+    <p>
+      Example: <code>@facebook-github-bot duplicate #42</code>
+    </p></div>
+  </div>
+  <div class="botAction">
+    <h4 class="botCommand">
+      <span class="botMentionName">@facebook-github-bot</span> label (.*)
+    </h4>
+    <div><p>
+      Use this command to add a <a href="https://github.com/facebook/react-native/labels">label</a>, such as "iOS" or "Android", to an issue.
+    </p><p>
+      Example: <code>@facebook-github-bot label Android</code>
+    </p></div>
+  </div>
+  <div class="botAction">
+    <h4 class="botCommand">
+      <span class="botMentionName">@facebook-github-bot</span> feature
+    </h4>
+    <div><p>
+      Use this when an issue describes a feature request, as opposed to a reproducible bug. The bot will point the author to the feature request tracker, add the "Feature Request" label, then <strong>close</strong> the issue.
+    </p></div>
+  </div>
+  <div class="botAction">
+    <h4 class="botCommand">
+      <span class="botMentionName">@facebook-github-bot</span> expected
+    </h4>
+    <div><p>
+      Use this when an issue describes a type of expected behavior. The bot will <strong>close</strong> the issue.
+    </p></div>
+  </div>
+  <div class="botAction">
+    <h4 class="botCommand">
+      <span class="botMentionName">@facebook-github-bot</span> answered
+    </h4>
+    <div><p>
+      Use this when an issue appears to be a question that has already been answered by someone on the thread. The bot will <strong>close</strong> the issue.
+    </p></div>
+  </div>
+  <div class="botAction">
+    <h4 class="botCommand">
+      <span class="botMentionName">@facebook-github-bot</span> close
+    </h4>
+    <div><p>
+      <strong>Closes</strong> an issue without providing a particular explanation.
+    </p></div>
+  </div>
+  <div class="botAction">
+    <h4 class="botCommand">
+      <span class="botMentionName">@facebook-github-bot</span> reopen
+    </h4>
+    <div><p>
+      <strong>Re-opens</strong> a previously closed issue.
+    </p></div>
+  </div>
+  <div class="botAction">
+    <h4 class="botCommand">
+      <span class="botMentionName">@facebook-github-bot</span> bugfix
+    </h4>
+    <div><p>
+      Mark issues that describe a reproducible bug and encourage the author to send a pull request. The bot will add the "Help Wanted" label.
+    </p></div>
+  </div>
+  <div class="botAction">
+    <h4 class="botCommand">
+      <span class="botMentionName">@facebook-github-bot</span> no-reply
+    </h4>
+    <div><p>
+      Use this when an issue requires more information from the author but they have not added a comment in a while. The bot will <strong>close</strong> the issue.
+    </p></div>
+  </div>
+  <div class="botAction">
+    <h4 class="botCommand">
+      <span class="botMentionName">@facebook-github-bot</span> icebox
+    </h4>
+    <div><p>
+      Use this when an issue has been open for over 30 days with no activity and no community member has volunteered to work on a fix. The bot will <strong>close</strong> the issue after adding the "Icebox" label.
+    </p></div>
+  </div>
+</div>
+
+Additionally, the following commands can be used on a pull request:
+
+<div class="botActions">
+  <div class="botAction">
+    <h4 class="botCommand">
+      <span class="botMentionName">@facebook-github-bot</span> cla
+    </h4>
+    <div><p>
+      Remind the author that the CLA needs to be signed.
+    </p></div>
+  </div>
+  <div class="botAction">
+    <h4 class="botCommand">
+      <span class="botMentionName">@facebook-github-bot</span> shipit
+    </h4>
+    <div><p>
+      Flag the PR for merging. If used by a core contributor, the bot will attempt to import the pull request. In general, core contributors are those who have consistently submitted high quality contributions to the project. Access control for this command is configured internally in Facebook, outside of the IssueCommands.txt file mentioned above.
+    </p></div>
+  </div>
+</div>

--- a/docs/Testing.md
+++ b/docs/Testing.md
@@ -2,9 +2,9 @@
 id: testing
 title: Testing your Changes
 layout: docs
-category: Guides
+category: Contributing
 permalink: docs/testing.html
-next: understanding-cli
+next: maintainers
 previous: contributing
 ---
 

--- a/docs/UnderstandingCLI.md
+++ b/docs/UnderstandingCLI.md
@@ -2,10 +2,10 @@
 id: understanding-cli
 title: Understanding the CLI
 layout: docs
-category: Guides
+category: Contributing
 permalink: docs/understanding-cli.html
 banner: ejected
-next: native-modules-ios
+next: activityindicator
 previous: testing
 ---
 

--- a/docs/Upgrading.md
+++ b/docs/Upgrading.md
@@ -4,7 +4,7 @@ title: Upgrading to new React Native versions
 layout: docs
 category: Guides
 permalink: docs/upgrading.html
-next: contributing
+next: native-modules-ios
 previous: running-on-device
 ---
 

--- a/website/core/Footer.js
+++ b/website/core/Footer.js
@@ -20,7 +20,7 @@ class Footer extends React.Component {
   render() {
     return (
       <p className="edit-page-block">
-        You can <a target="_blank" href={getGitHubPath(this.props.path)}>edit the content above on GitHub</a> and send us a pull request!
+        <a target="_blank" href={getGitHubPath(this.props.path)}>Improve this page</a>
       </p>
     );
   }

--- a/website/core/Footer.js
+++ b/website/core/Footer.js
@@ -20,7 +20,7 @@ class Footer extends React.Component {
   render() {
     return (
       <p className="edit-page-block">
-        <a target="_blank" href={getGitHubPath(this.props.path)}>Improve this page</a>
+        <a target="_blank" href={getGitHubPath(this.props.path)}>Improve this page</a> by sending a pull request!
       </p>
     );
   }

--- a/website/server/convert.js
+++ b/website/server/convert.js
@@ -100,6 +100,21 @@ function execute(options) {
   var BLOG_MD_DIR = '../blog/';
   var CONFIG_JSON_DIR = '../';
 
+  // Extracts the Contributor's Guide content from Contributing.md
+  // and inserts into repo's CONTRIBUTING.md
+  const contributingGuide = splitHeader(
+    fs.readFileSync(DOCS_MD_DIR + 'Contributing.md', 'utf8')
+  ).content.replace(/\(\/react-native\//g, '(https://facebook.github.io/react-native/');
+
+  let contributingReadme = fs.readFileSync('../CONTRIBUTING.md', 'utf8');
+  const guideStart = '<!-- generated_contributing_start -->';
+  const guideEnd = '<!-- generated_contributing_end -->';
+  contributingReadme =
+    contributingReadme.slice(0, contributingReadme.indexOf(guideStart) + guideStart.length) +
+    contributingGuide +
+    contributingReadme.slice(contributingReadme.indexOf(guideEnd));
+  fs.writeFileSync('../CONTRIBUTING.md', contributingReadme);
+
   glob.sync('src/react-native/docs/*.*').forEach(rmFile);
   glob.sync('src/react-native/blog/*.*').forEach(rmFile);
   glob.sync('../blog/img/*.*').forEach(file => {

--- a/website/src/react-native/css/react-native.css
+++ b/website/src/react-native/css/react-native.css
@@ -1385,6 +1385,28 @@ div[data-twttr-id] iframe {
   font-weight: normal;
   font-size: 13px; }
 
+.botActions {
+  background-color: #ebf9ff;
+}
+
+.botActions > .botAction:nth-child(2n) {
+  background-color: #e0f6ff;
+}
+
+.botCommand {
+  font-family: 'source-code-pro', Menlo, 'Courier New', Consolas, monospace;
+  font-weight: bold;
+  color: #025268;
+}
+
+.botAction {
+  padding: 5px 10px;
+}
+
+.botMentionName {
+  font-weight: normal;
+}
+
 .platform {
   background-color: #bdebff;
   border-radius: 5px;
@@ -1822,7 +1844,7 @@ input#algolia-doc-search:focus {
   font-size: 24px; }
 
 .help-row {
-  margin: 50px 0; }
+  margin: 0; }
 
 .help-row:after {
   content: "";
@@ -1855,7 +1877,7 @@ input#algolia-doc-search:focus {
   margin: 1.25em 0 1em 0; }
 
 .entry ul, li {
-  margin: 0; }
+  margin: 0 0 10px 0; }
 
 .help-list .help-list-entry {
   padding: 16px 0;

--- a/website/src/react-native/support.js
+++ b/website/src/react-native/support.js
@@ -81,7 +81,7 @@ class support extends React.Component {
                     <a
                       href="http://stackoverflow.com/questions/tagged/react-native?sort=frequent"
                     >
-                      Frequently Asked Questions
+                      Stack Overflow
                     </a>
                   </li>
                   <li className="help-list-entry">
@@ -138,7 +138,7 @@ class support extends React.Component {
               >
                 open source
               </a>
-              ! If you want to contribute, read the <a href="https://github.com/facebook/react-native/blob/master/CONTRIBUTING.md">contributor guidelines</a>, then take a look at the
+              ! If you want to contribute, read the <a href="/react-native/docs/contributing.html">Contributor's Guide</a>, then take a look at the
               {' '}
               <a
                 href="https://github.com/facebook/react-native/wiki/Roadmap"


### PR DESCRIPTION
Adds a new maintainers guide, and updates the contributor's guide to be consistent with regards to this new guide.

Some additional style changes made in order to support the display of bot commands. Changed the wording for the "Edit this page on GitHub" link.

Finally, the contributor's guide is now synced to `CONTRIBUTING.md` on the repo.

## Test Plan

```
cd website && npm start
```

Verify that `CONTRIBUTING.md` is updated whenever the website is regenerated.

Verify everything rendered correctly. Expand the details below to see screenshots.

<details>

## Contributing

![screencapture-localhost-8079-react-native-docs-contributing-html-1501016495792](https://user-images.githubusercontent.com/165856/28593706-33d1e03c-7142-11e7-9878-04ead7561abc.png)

## Maintainers

![screencapture-localhost-8079-react-native-docs-maintainers-html-1501016508744](https://user-images.githubusercontent.com/165856/28593719-3812d7fa-7142-11e7-9db2-f9599057d726.png)
</details>

