### PR TITLE
Update releases script

### DIFF
--- a/scripts/bump-oss-version.js
+++ b/scripts/bump-oss-version.js
@@ -88,8 +88,18 @@ if (exec(`git tag v${version}`).code) {
 let remote = argv.remote;
 exec(`git push ${remote} v${version}`);
 
+// Branch that currently has latest tag
+let latestBranch = exec(`git branch --contains latest`, {silent: true}).stdout.trim();
+
+// Minor version, e.g. `0` if `0.45.0` is released
+let versionMinor = +version.match(/\.(\d+)$/)[1];
+
+// Do not set `latest` if we are not on the latest branch
+// and not releasing a new stable (version "0")
+let shouldSkipLatest = latestBranch !== branch && versionMinor !== 0;
+
 // Tag latest if doing stable release
-if (version.indexOf(`rc`) === -1) {
+if (version.indexOf(`rc`) === -1 && !shouldSkipLatest) {
   exec(`git tag -d latest`);
   exec(`git push ${remote} :latest`);
   exec(`git tag latest`);


### PR DESCRIPTION
When releasing old stable versions, e.g. `0.43` for Microsoft, I found it to update the `latest` tag because we are technically on the stable branch.

This PR modifies this logic so that latest is not set if we are on an older than latest branch.

I will test this code when releasing new version of React Native in few days. 