### PR TITLE
Fix SectionList examples in documentation

### DIFF
--- a/Libraries/Lists/SectionList.js
+++ b/Libraries/Lists/SectionList.js
@@ -220,17 +220,17 @@ type DefaultProps = typeof defaultProps;
  *       renderItem={({item}) => <ListItem title={item.title} />}
  *       renderSectionHeader={({section}) => <H1 title={section.title} />}
  *       sections={[ // homogenous rendering between sections
- *         {data: [...], title: ...},
- *         {data: [...], title: ...},
- *         {data: [...], title: ...},
+ *         {data: [...]},
+ *         {data: [...]},
+ *         {data: [...]},
  *       ]}
  *     />
  *
  *     <SectionList
  *       sections={[ // heterogeneous rendering between sections
- *         {data: [...], title: ..., renderItem: ...},
- *         {data: [...], title: ..., renderItem: ...},
- *         {data: [...], title: ..., renderItem: ...},
+ *         {data: [...], renderItem: ...},
+ *         {data: [...], renderItem: ...},
+ *         {data: [...], renderItem: ...},
  *       ]}
  *     />
  *

--- a/Libraries/Lists/SectionList.js
+++ b/Libraries/Lists/SectionList.js
@@ -217,12 +217,12 @@ type DefaultProps = typeof defaultProps;
  * Simple Examples:
  *
  *     <SectionList
- *       renderItem={({item}) => <ListItem title={item.title} />}
- *       renderSectionHeader={({section}) => <H1 title={section.title} />}
+ *       renderItem={({item}) => <ListItem title={item} />}
+ *       renderSectionHeader={({section}) => <Header title={section.title} />}
  *       sections={[ // homogenous rendering between sections
- *         {data: [...]},
- *         {data: [...]},
- *         {data: [...]},
+ *         {data: [...], title: ...},
+ *         {data: [...], title: ...},
+ *         {data: [...], title: ...},
  *       ]}
  *     />
  *


### PR DESCRIPTION
Document to change http://facebook.github.io/react-native/releases/next/docs/sectionlist.html

This example is not documented incorrectly. 

According to Flow-type in the [source code](https://github.com/facebook/react-native/blob/master/Libraries/Lists/SectionList.js#L25-L52) the `title` is not required and the `renderItem` method takes wrong `item.title` for rendering in example. See https://github.com/facebook/react-native/pull/15234#issuecomment-318555336

## Test Plan (Screenshot)
![screen shot 2017-07-28 at 12 24 03 pm](https://user-images.githubusercontent.com/8013313/28702472-b72d160a-738f-11e7-96ba-dcd7e8ce4ff2.png)

