### PR TITLE
Account for header, footer, and content container padding in VirtualizedList

### DIFF
--- a/Libraries/Lists/VirtualizedList.js
+++ b/Libraries/Lists/VirtualizedList.js
@@ -213,7 +213,8 @@ class VirtualizedList extends React.PureComponent<OptionalProps, Props, State> {
       0,
       frame.offset +
         frame.length +
-        this._footerLength -
+        this._footerLength +
+        this._paddingBottom -
         this._scrollMetrics.visibleLength,
     );
     this._scrollRef.scrollTo(
@@ -503,8 +504,13 @@ class VirtualizedList extends React.PureComponent<OptionalProps, Props, State> {
   }
 
   render() {
+    const flatStyles = flattenStyle(this.props.contentContainerStyle);
+    if (flatStyles) {
+      this._paddingTop = flatStyles.paddingTop || 0;
+      this._paddingBottom = flatStyles.paddingBottom || 0;
+    }
+
     if (__DEV__) {
-      const flatStyles = flattenStyle(this.props.contentContainerStyle);
       warning(
         flatStyles == null || flatStyles.flexWrap !== 'wrap',
         '`flexWrap: `wrap`` is not supported with the `VirtualizedList` components.' +
@@ -703,10 +709,12 @@ class VirtualizedList extends React.PureComponent<OptionalProps, Props, State> {
   _hasWarned = {};
   _highestMeasuredFrameIndex = 0;
   _headerLength = 0;
+  _paddingTop = 0;
   _initialScrollIndexTimeout = 0;
   _fillRateHelper: FillRateHelper;
   _frames = {};
   _footerLength = 0;
+  _paddingBottom = 0;
   _scrollMetrics = {
     contentLength: 0,
     dOffset: 0,
@@ -977,9 +985,14 @@ class VirtualizedList extends React.PureComponent<OptionalProps, Props, State> {
     const itemCount = this.props.getItemCount(this.props.data);
     let hiPri = false;
     if (first > 0 || last < itemCount - 1) {
-      const distTop = offset - this._getFrameMetricsApprox(first).offset;
+      const distTop =
+        offset +
+        this._headerLength +
+        this._paddingTop -
+        this._getFrameMetricsApprox(first).offset;
       const distBottom =
-        this._getFrameMetricsApprox(last).offset - (offset + visibleLength);
+        this._getFrameMetricsApprox(last).offset -
+        (offset + visibleLength);
       const scrollingThreshold =
         this.props.onEndReachedThreshold * visibleLength / 2;
       hiPri =
@@ -1089,7 +1102,10 @@ class VirtualizedList extends React.PureComponent<OptionalProps, Props, State> {
       );
       return {
         length: this._averageCellLength,
-        offset: this._averageCellLength * index,
+        offset:
+          this._averageCellLength * index +
+          this._headerLength +
+          this._paddingTop,
       };
     }
   };


### PR DESCRIPTION
### Overview

`VirtualizedList` leans heavily upon frame estimates to power its heuristics. Despite explicit support for headers and footers (and implicit support for top and bottom padding via `contentContainerStyle`), the estimates fail to account for the heights of these additions to the top and bottom of the scrollable content area.

This commit addresses some of the inconsistencies, though I'm certain that I missed some calculations. Notably, it fails to address horizontal `VirtualizedLists`, and it doesn't address any of the sticky header logic, which may or may not be wrong (it was too difficult to tell).

### Test plan

Like most things with RN, these behaviors are difficult to capture with automated tests. However, I put together a repro that demonstrates the original calculation issues and can prove the fix. Code for the repro is [here](https://gist.github.com/jamesreggio/47904fb20b3a142172ef701113abbc4e).

The repro fills a `FlatList` with 100 items, each of height `100px`. It also adds `150px` of `paddingTop` and `paddingBottom` to the `contentContainerStyle` for the list. In the videos below, you'll see the list load. After a second, I invoke `scrollToEnd()`, and a second after that, I invoke `scrollToIndex({index: 50, viewPosition: 0})`.

Note that in the **before** video, `scrollToEnd` scrolls to the edge of the last item, but not to the end of the content area — it omits the dark gray `paddingBottom`. Likewise, its heuristic miscalculates the offset of the item at index 50 because it fails to account for the `paddingTop`. The **after** video shows the correct behavior after applying this patch.

#### Before

![repro-before](https://user-images.githubusercontent.com/822205/28719498-23d49e6c-7378-11e7-9cb5-aba2f90dd473.gif)

#### After

![repro-after](https://user-images.githubusercontent.com/822205/28719504-27572fc8-7378-11e7-9cd3-8fd88f1ad8f1.gif)