### PR TITLE
update docs for Transforms

### DIFF
--- a/Libraries/StyleSheet/TransformPropTypes.js
+++ b/Libraries/StyleSheet/TransformPropTypes.js
@@ -42,6 +42,22 @@ var DecomposedMatrixPropType = function(
 };
 
 var TransformPropTypes = {
+  /**
+   * `transform` accepts an array of transformation objects. Each object specifies
+   * the property that will be transformed as the key, and the value to use in the
+   * transformation. Objects should not be combined. Use a single key/value pair
+   * per object.
+   *
+   * The rotate transformations require a string so that the transform may be
+   * expressed in degrees (deg) or radians (rad). For example:
+   *
+   * `transform([{ rotateX: '45deg' }, { rotateZ: '0.785398rad' }])`
+   *
+   * The skew transformations require a string so that the transform may be
+   * expressed in degrees (deg). For example:
+   *
+   * `transform([{ skewX: '45deg' }])`
+   */
   transform: ReactPropTypes.arrayOf(
     ReactPropTypes.oneOfType([
       ReactPropTypes.shape({perspective: ReactPropTypes.number}),
@@ -59,8 +75,13 @@ var TransformPropTypes = {
     ])
   ),
 
-  /* Deprecated */
+  /**
+   * Deprecated. Use the transform prop instead.
+   */
   transformMatrix: TransformMatrixPropType,
+  /**
+   * Deprecated. Use the transform prop instead.
+   */
   decomposedMatrix: DecomposedMatrixPropType,
 
   /* Deprecated transform props used on Android only */


### PR DESCRIPTION
Documentation change only.

Filled out the Transforms docs a little more to indicate which props are now deprecated and to provide some guidance on the transform array since some values are expected to be strings and some are numbers

http://facebook.github.io/react-native/docs/transforms.html