### PR TITLE
Add altitudeAccuracy attribute on Position object (Android)

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/modules/location/LocationModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/location/LocationModule.java
@@ -212,6 +212,7 @@ public class LocationModule extends ReactContextBaseJavaModule {
     coords.putDouble("longitude", location.getLongitude());
     coords.putDouble("altitude", location.getAltitude());
     coords.putDouble("accuracy", location.getAccuracy());
+    coords.putDouble("altitudeAccuracy", location.getVerticalAccuracyMeters());
     coords.putDouble("heading", location.getBearing());
     coords.putDouble("speed", location.getSpeed());
     map.putMap("coords", coords);


### PR DESCRIPTION
As the standard says, the Position object must have "altitudeAccuracy" property.

https://developer.mozilla.org/en-US/docs/Web/API/Coordinates

