### PR TITLE
Add missing subspec part

### DIFF
--- a/docs/IntegrationWithExistingApps.md
+++ b/docs/IntegrationWithExistingApps.md
@@ -220,6 +220,7 @@ target 'NumberTileGame' do
     'RCTText',
     'RCTNetwork',
     'RCTWebSocket', # needed for debugging
+    'BatchedBridge', # needed as of (0.46)
     # Add any other subspecs you want to use in your project
   ]
   # Explicitly include Yoga if you are using RN >= 0.42.0


### PR DESCRIPTION
Though missing `BatchedBridge` works in dev, the archive will fail with a linking error that is very difficult to understand/research.  Fortunately @javache identifies this in https://github.com/facebook/react-native/issues/14925 and this seems to be working for many of us.

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. In other words, a test plan is *required*. Bonus points for screenshots and videos!

Please read the Contribution Guidelines at https://github.com/facebook/react-native/blob/master/CONTRIBUTING.md to learn more about contributing to React Native.

Happy contributing!
-->
