### PR TITLE
RCTProfile: Use C atomics instead of OSAtomic

### DIFF
--- a/React/Profiler/RCTProfile.m
+++ b/React/Profiler/RCTProfile.m
@@ -10,7 +10,7 @@
 #import "RCTProfile.h"
 
 #import <dlfcn.h>
-#import <libkern/OSAtomic.h>
+#import <stdatomic.h>
 #import <mach/mach.h>
 #import <objc/message.h>
 #import <objc/runtime.h>
@@ -42,9 +42,7 @@ static NSString *const kProfilePrefix = @"rct_profile_";
 
 #pragma mark - Variables
 
-// This is actually a BOOL - but has to be compatible with OSAtomic
-static volatile uint32_t RCTProfileProfiling;
-
+static atomic_bool RCTProfileProfiling;
 static NSDictionary *RCTProfileInfo;
 static NSMutableDictionary *RCTProfileOngoingEvents;
 static NSTimeInterval RCTProfileStartTime;
@@ -439,17 +437,16 @@ dispatch_queue_t RCTProfileGetQueue(void)
 
 BOOL RCTProfileIsProfiling(void)
 {
-  return (BOOL)RCTProfileProfiling;
+  return atomic_load(&RCTProfileProfiling);
 }
 
 void RCTProfileInit(RCTBridge *bridge)
 {
   // TODO: enable assert JS thread from any file (and assert here)
-  if (RCTProfileIsProfiling()) {
+  BOOL wasProfiling = atomic_fetch_or(&RCTProfileProfiling, 1);
+  if (wasProfiling) {
     return;
   }
-
-  OSAtomicOr32Barrier(1, &RCTProfileProfiling);
 
   if (callbacks != NULL) {
     systrace_buffer = callbacks->start();
@@ -493,12 +490,10 @@ void RCTProfileInit(RCTBridge *bridge)
 void RCTProfileEnd(RCTBridge *bridge, void (^callback)(NSString *))
 {
   // assert JavaScript thread here again
-
-  if (!RCTProfileIsProfiling()) {
+  BOOL wasProfiling = atomic_fetch_and(&RCTProfileProfiling, 0);
+  if (!wasProfiling) {
     return;
   }
-
-  OSAtomicAnd32Barrier(0, &RCTProfileProfiling);
 
   [[NSNotificationCenter defaultCenter] postNotificationName:RCTProfileDidEndProfiling
                                                       object:bridge];

--- a/React/Profiler/RCTProfile.m
+++ b/React/Profiler/RCTProfile.m
@@ -42,7 +42,8 @@ static NSString *const kProfilePrefix = @"rct_profile_";
 
 #pragma mark - Variables
 
-static atomic_bool RCTProfileProfiling;
+static atomic_bool RCTProfileProfiling = ATOMIC_VAR_INIT(NO);
+
 static NSDictionary *RCTProfileInfo;
 static NSMutableDictionary *RCTProfileOngoingEvents;
 static NSTimeInterval RCTProfileStartTime;


### PR DESCRIPTION
This will save us precious microseconds and it's prettier to look at.

Test plan: Try the profiler, rely on CI.