### PR TITLE
changed param of setSrc() method

### DIFF
--- a/docs/NativeComponentsAndroid.md
+++ b/docs/NativeComponentsAndroid.md
@@ -71,8 +71,8 @@ Setter declaration requirements for methods annotated with `@ReactPropGroup` are
 
 ```java
   @ReactProp(name = "src")
-  public void setSrc(ReactImageView view, @Nullable String src) {
-    view.setSource(src);
+  public void setSrc(ReactImageView view, @Nullable ReadableArray sources) {
+    view.setSource(sources);
   }
 
   @ReactProp(name = "borderRadius", defaultFloat = 0f)


### PR DESCRIPTION
setSource() method of ReactImageView class accepts a ReadableArray and not a plain String.

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. In other words, a test plan is *required*. Bonus points for screenshots and videos!

Please read the Contribution Guidelines at https://github.com/facebook/react-native/blob/master/CONTRIBUTING.md to learn more about contributing to React Native.

Happy contributing!
-->
