### PR TITLE
RCTBorderDrawing: Cache results to save resources

### DIFF
--- a/React/Base/RCTUtils.h
+++ b/React/Base/RCTUtils.h
@@ -127,6 +127,9 @@ RCT_EXTERN NSString *__nullable RCTTempFilePath(NSString *__nullable extension, 
 // Converts a CGColor to a hex string
 RCT_EXTERN NSString *RCTColorToHexString(CGColorRef color);
 
+// Gets the RGBA components of a color
+RCT_EXTERN void RCTGetRGBAColorComponents(CGColorRef color, CGFloat rgba[__nonnull 4]);
+
 // Get standard localized string (if it exists)
 RCT_EXTERN NSString *RCTUIKitLocalizedString(NSString *string);
 

--- a/React/Base/RCTUtils.m
+++ b/React/Base/RCTUtils.m
@@ -733,8 +733,13 @@ RCT_EXTERN NSString *__nullable RCTTempFilePath(NSString *extension, NSError **e
   return [directory stringByAppendingPathComponent:filename];
 }
 
-static void RCTGetRGBAColorComponents(CGColorRef color, CGFloat rgba[4])
+void RCTGetRGBAColorComponents(CGColorRef color, CGFloat rgba[4])
 {
+  if (!color) {
+    rgba = (CGFloat[4]){0, 0, 0, 0};
+    return;
+  }
+  
   CGColorSpaceModel model = CGColorSpaceGetModel(CGColorGetColorSpace(color));
   const CGFloat *components = CGColorGetComponents(color);
   switch (model)

--- a/React/Views/RCTBorderDrawing.m
+++ b/React/Views/RCTBorderDrawing.m
@@ -573,7 +573,11 @@ UIImage *RCTGetBorderImage(RCTBorderStyle borderStyle,
         // We already checked this above.
         return nil;
     }
-    [borderImageCache setObject:image forKey:key];
+
+    // Handle cases where the above functions return nil.
+    if (image != nil) {
+      [borderImageCache setObject:image forKey:key];
+    }
   }
   
   return image;

--- a/React/Views/RCTBorderDrawing.m
+++ b/React/Views/RCTBorderDrawing.m
@@ -505,14 +505,16 @@ static id RCTGetBorderImageKey(RCTBorderStyle borderStyle,
                                CGColorRef backgroundColor,
                                BOOL drawToEdge)
 {
-  // Important that this struct is aligned on all architectures, else
-  // the compiler can insert garbage into the padding and corrupt our hash.
+  // Important that this struct is not padded on any architecture, else
+  // there can be garbage in the padding that corrupts our hash.
+#pragma clang diagnostic push
+#pragma clang diagnostic error "-Wpadded"
   struct {
     RCTBorderStyle borderStyle;
     CGSize viewSize;
     RCTCornerRadii cornerRadii;
     UIEdgeInsets borderInsets;
-    NSUInteger drawToEdge; // BOOL would be misaligned, not good.
+    NSUInteger drawToEdge; // BOOL would be padded.
     CGFloat topColors[4];
     CGFloat rightColors[4];
     CGFloat bottomColors[4];
@@ -530,6 +532,7 @@ static id RCTGetBorderImageKey(RCTBorderStyle borderStyle,
     {0,0,0,0},
     {0,0,0,0},
   };
+#pragma clang diagnostic pop
   RCTGetRGBAColorComponents(borderColors.top, borderParams.topColors);
   RCTGetRGBAColorComponents(borderColors.bottom, borderParams.bottomColors);
   RCTGetRGBAColorComponents(borderColors.left, borderParams.leftColors);


### PR DESCRIPTION
Hi folks. When profiling RNTester on master (688c74) on my iPhone 6 10.3.3 scrolling up and down the grid view example for 10 seconds, average of 3 runs, this patch reduced `RCTGetBorderImage` from 34ms to 4ms. I didn't look at memory consumption but presumably it lowered that as well.

This is a pretty strong effect but the grid view example is pretty border-heavy so you may get less on other screens. Your call. Love your work!