### PR TITLE
Fix broken Buck installation link

### DIFF
--- a/scripts/validate-android-test-env.sh
+++ b/scripts/validate-android-test-env.sh
@@ -10,7 +10,7 @@
 # Check that Buck is working.
 if [ -z "$(which buck)" ]; then
   echo "You need to install Buck."
-  echo "See https://buckbuild.com/setup/install.htm for instructions."
+  echo "See https://buckbuild.com/setup/install.html for instructions."
   exit 1
 fi
 


### PR DESCRIPTION
Running `./scripts/run-android-local-unit-tests.sh` without having
installed Buck displays this link. Make it point to a URL that exists.