### PR TITLE
[ANDROID] Add snapToInterval support for horizontal ScrollView

### DIFF
--- a/Libraries/Components/ScrollView/ScrollView.js
+++ b/Libraries/Components/ScrollView/ScrollView.js
@@ -326,11 +326,9 @@ const ScrollView = createReactClass({
     /**
      * When set, causes the scroll view to stop at multiples of the value of
      * `snapToInterval`. This can be used for paginating through children
-     * that have lengths smaller than the scroll view. Typically used in
-     * combination with `snapToAlignment` and `decelerationRate="fast"`.
+     * that have lengths smaller than the scroll view. When used on iOS it is typically combined
+     * with `snapToAlignment` and `decelerationRate="fast"`.
      * Overrides less configurable `pagingEnabled` prop.
-     *
-     * @platform ios
      */
     snapToInterval: PropTypes.number,
     /**

--- a/RNTester/js/ScrollViewSimpleExample.js
+++ b/RNTester/js/ScrollViewSimpleExample.js
@@ -38,20 +38,43 @@ class ScrollViewSimpleExample extends React.Component {
     return items;
   };
 
+  getListItem = (item, index) => {
+    if (index === 4) {
+      return (
+        <ScrollView key="scrollView" horizontal>
+          {this.makeItems(NUM_ITEMS, [styles.itemWrapper, styles.horizontalItemWrapper])}
+        </ScrollView>
+      );
+    }
+    else if (index === 5) {
+      return (
+        <ScrollView
+          key="scrollViewSnap"
+          horizontal
+          snapToInterval={horizontalItemWidth + 2 * itemMargin}
+          pagingEnabled
+        >
+          {this.makeItems(NUM_ITEMS, [styles.itemWrapper, styles.horizontalItemWrapper])}
+        </ScrollView>
+      );
+    }
+
+    return item;
+  }
+
   render() {
     var items = this.makeItems(NUM_ITEMS, styles.itemWrapper);
 
     return (
       <ScrollView style={styles.verticalScrollView}>
-        {items.map((item, index) => index === 4 ? (
-          <ScrollView key="scrollView" horizontal>
-            {this.makeItems(NUM_ITEMS, [styles.itemWrapper, styles.horizontalItemWrapper])}
-          </ScrollView>
-        ) : item)}
+        {items.map(this.getListItem)}
       </ScrollView>
     );
   }
 }
+
+const horizontalItemWidth = 125;
+const itemMargin = 5;
 
 var styles = StyleSheet.create({
   verticalScrollView: {
@@ -64,10 +87,10 @@ var styles = StyleSheet.create({
     borderWidth: 5,
     borderColor: '#a52a2a',
     padding: 30,
-    margin: 5,
+    margin: itemMargin,
   },
   horizontalItemWrapper: {
-    padding: 50
+    width: horizontalItemWidth,
   }
 });
 

--- a/RNTester/js/ScrollViewSimpleExample.js
+++ b/RNTester/js/ScrollViewSimpleExample.js
@@ -17,7 +17,7 @@ var {
   ScrollView,
   StyleSheet,
   Text,
-  TouchableOpacity
+  View
 } = ReactNative;
 
 class ScrollViewSimpleExample extends React.Component {
@@ -28,9 +28,9 @@ class ScrollViewSimpleExample extends React.Component {
     var items = [];
     for (var i = 0; i < nItems; i++) {
        items[i] = (
-         <TouchableOpacity key={i} style={[styles.itemWrapper, extraStyle]}>
+         <View key={i} style={[styles.itemWrapper, extraStyle]}>
            <Text>{'Item ' + i}</Text>
-         </TouchableOpacity>
+         </View>
        );
     }
     return items;

--- a/RNTester/js/ScrollViewSimpleExample.js
+++ b/RNTester/js/ScrollViewSimpleExample.js
@@ -39,21 +39,17 @@ class ScrollViewSimpleExample extends React.Component {
   };
 
   render() {
-    // One of the items is a horizontal scroll view
     var items = this.makeItems(NUM_ITEMS, styles.itemWrapper);
-    items[4] = (
-      <ScrollView key={'scrollView'} horizontal={true}>
-        {this.makeItems(NUM_ITEMS, [styles.itemWrapper, styles.horizontalItemWrapper])}
-      </ScrollView>
-    );
 
-    var verticalScrollView = (
+    return (
       <ScrollView style={styles.verticalScrollView}>
-        {items}
+        {items.map((item, index) => index === 4 ? (
+          <ScrollView key={'scrollView'} horizontal={true}>
+            {this.makeItems(NUM_ITEMS, [styles.itemWrapper, styles.horizontalItemWrapper])}
+          </ScrollView>
+        ) : item)}
       </ScrollView>
     );
-
-    return verticalScrollView;
   }
 }
 

--- a/RNTester/js/ScrollViewSimpleExample.js
+++ b/RNTester/js/ScrollViewSimpleExample.js
@@ -42,7 +42,7 @@ class ScrollViewSimpleExample extends React.Component {
     if (index === 4) {
       return (
         <ScrollView key="scrollView" horizontal>
-          {this.makeItems(NUM_ITEMS, [styles.itemWrapper, styles.horizontalItemWrapper])}
+          {this.makeItems(10, [styles.itemWrapper, styles.horizontalItemWrapper])}
         </ScrollView>
       );
     }
@@ -52,9 +52,8 @@ class ScrollViewSimpleExample extends React.Component {
           key="scrollViewSnap"
           horizontal
           snapToInterval={horizontalItemWidth + 2 * itemMargin}
-          pagingEnabled
         >
-          {this.makeItems(NUM_ITEMS, [styles.itemWrapper, styles.horizontalItemWrapper])}
+          {this.makeItems(10, [styles.itemWrapper, styles.horizontalItemWrapper])}
         </ScrollView>
       );
     }

--- a/RNTester/js/ScrollViewSimpleExample.js
+++ b/RNTester/js/ScrollViewSimpleExample.js
@@ -20,17 +20,15 @@ var {
   TouchableOpacity
 } = ReactNative;
 
-var NUM_ITEMS = 20;
-
 class ScrollViewSimpleExample extends React.Component {
   static title = '<ScrollView>';
   static description = 'Component that enables scrolling through child components.';
 
-  makeItems = (nItems: number, styles): Array<any> => {
+  makeItems = (nItems: number, extraStyle): Array<any> => {
     var items = [];
     for (var i = 0; i < nItems; i++) {
        items[i] = (
-         <TouchableOpacity key={i} style={styles}>
+         <TouchableOpacity key={i} style={[styles.itemWrapper, extraStyle]}>
            <Text>{'Item ' + i}</Text>
          </TouchableOpacity>
        );
@@ -42,7 +40,7 @@ class ScrollViewSimpleExample extends React.Component {
     if (index === 4) {
       return (
         <ScrollView key="scrollView" horizontal>
-          {this.makeItems(10, [styles.itemWrapper, styles.horizontalItemWrapper])}
+          {this.makeItems(10, styles.horizontalItemWrapper)}
         </ScrollView>
       );
     }
@@ -53,7 +51,7 @@ class ScrollViewSimpleExample extends React.Component {
           horizontal
           snapToInterval={horizontalItemWidth + 2 * itemMargin}
         >
-          {this.makeItems(10, [styles.itemWrapper, styles.horizontalItemWrapper])}
+          {this.makeItems(10, styles.horizontalItemWrapper)}
         </ScrollView>
       );
     }
@@ -62,11 +60,9 @@ class ScrollViewSimpleExample extends React.Component {
   }
 
   render() {
-    var items = this.makeItems(NUM_ITEMS, styles.itemWrapper);
-
     return (
       <ScrollView style={styles.verticalScrollView}>
-        {items.map(this.getListItem)}
+        {this.makeItems(20).map(this.getListItem)}
       </ScrollView>
     );
   }

--- a/RNTester/js/ScrollViewSimpleExample.js
+++ b/RNTester/js/ScrollViewSimpleExample.js
@@ -72,7 +72,7 @@ class ScrollViewSimpleExample extends React.Component {
   }
 }
 
-const horizontalItemWidth = 125;
+const horizontalItemWidth = 140;
 const itemMargin = 5;
 
 var styles = StyleSheet.create({

--- a/RNTester/js/ScrollViewSimpleExample.js
+++ b/RNTester/js/ScrollViewSimpleExample.js
@@ -36,7 +36,7 @@ class ScrollViewSimpleExample extends React.Component {
     return items;
   };
 
-  getListItem = (item, index) => {
+  getListItem = (item: any, index: number) => {
     if (index === 4) {
       return (
         <ScrollView key="scrollView" horizontal>

--- a/RNTester/js/ScrollViewSimpleExample.js
+++ b/RNTester/js/ScrollViewSimpleExample.js
@@ -44,7 +44,7 @@ class ScrollViewSimpleExample extends React.Component {
     return (
       <ScrollView style={styles.verticalScrollView}>
         {items.map((item, index) => index === 4 ? (
-          <ScrollView key={'scrollView'} horizontal={true}>
+          <ScrollView key="scrollView" horizontal>
             {this.makeItems(NUM_ITEMS, [styles.itemWrapper, styles.horizontalItemWrapper])}
           </ScrollView>
         ) : item)}

--- a/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.java
@@ -308,13 +308,6 @@ public class ReactHorizontalScrollView extends HorizontalScrollView implements
     postOnAnimationDelayed(mPostTouchRunnable, ReactScrollViewHelper.MOMENTUM_DELAY);
   }
 
-  private int getSnapInterval() {
-    if (mSnapInterval != 0) {
-      return mSnapInterval;
-    }
-    return getWidth();
-  }
-
   /**
    * This will smooth scroll us to the nearest page boundary
    * It currently just looks at where the content is relative to the page and slides to the nearest
@@ -322,7 +315,7 @@ public class ReactHorizontalScrollView extends HorizontalScrollView implements
    * scrolling.
    */
   private void smoothScrollToPage(int velocity) {
-    int width = getSnapInterval();
+    int width = mSnapInterval != 0 ? mSnapInterval : getWidth();
     int currentX = getScrollX();
     // TODO (t11123799) - Should we do anything beyond linear accounting of the velocity
     int predictedX = currentX + velocity;

--- a/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.java
@@ -52,6 +52,7 @@ public class ReactHorizontalScrollView extends HorizontalScrollView implements
   private @Nullable Drawable mEndBackground;
   private int mEndFillColor = Color.TRANSPARENT;
   private @Nullable ReactViewBackgroundDrawable mReactBackgroundDrawable;
+  private int mSnapInterval = 0;
 
   public ReactHorizontalScrollView(Context context) {
     this(context, null);
@@ -90,6 +91,10 @@ public class ReactHorizontalScrollView extends HorizontalScrollView implements
 
   public void setPagingEnabled(boolean pagingEnabled) {
     mPagingEnabled = pagingEnabled;
+  }
+
+  public void setSnapInterval(int snapInterval) {
+    mSnapInterval = snapInterval;
   }
 
   @Override
@@ -303,6 +308,13 @@ public class ReactHorizontalScrollView extends HorizontalScrollView implements
     postOnAnimationDelayed(mPostTouchRunnable, ReactScrollViewHelper.MOMENTUM_DELAY);
   }
 
+  private int getSnapInterval() {
+    if (mSnapInterval != 0) {
+      return mSnapInterval;
+    }
+    return getWidth();
+  }
+
   /**
    * This will smooth scroll us to the nearest page boundary
    * It currently just looks at where the content is relative to the page and slides to the nearest
@@ -310,7 +322,7 @@ public class ReactHorizontalScrollView extends HorizontalScrollView implements
    * scrolling.
    */
   private void smoothScrollToPage(int velocity) {
-    int width = getWidth();
+    int width = getSnapInterval();
     int currentX = getScrollX();
     // TODO (t11123799) - Should we do anything beyond linear accounting of the velocity
     int predictedX = currentX + velocity;

--- a/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollViewManager.java
@@ -72,6 +72,7 @@ public class ReactHorizontalScrollViewManager
 
   @ReactProp(name = "snapToInterval")
   public void setSnapToInterval(ReactHorizontalScrollView view, int snapToInterval) {
+    view.setPagingEnabled(snapToInterval > 0);
     DisplayMetrics screenDisplayMetrics = DisplayMetricsHolder.getScreenDisplayMetrics();
     view.setSnapInterval((int)(snapToInterval * screenDisplayMetrics.density));
   }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollViewManager.java
@@ -13,8 +13,10 @@ import javax.annotation.Nullable;
 
 import android.graphics.Color;
 import android.view.View;
+import android.util.DisplayMetrics;
 
 import com.facebook.react.bridge.ReadableArray;
+import com.facebook.react.uimanager.DisplayMetricsHolder;
 import com.facebook.react.module.annotations.ReactModule;
 import com.facebook.react.uimanager.PixelUtil;
 import com.facebook.react.uimanager.Spacing;
@@ -67,6 +69,13 @@ public class ReactHorizontalScrollViewManager
   public void setScrollEnabled(ReactHorizontalScrollView view, boolean value) {
     view.setScrollEnabled(value);
   }
+
+  @ReactProp(name = "snapToInterval")
+  public void setSnapToInterval(ReactHorizontalScrollView view, int snapToInterval) {
+    DisplayMetrics screenDisplayMetrics = DisplayMetricsHolder.getScreenDisplayMetrics();
+    view.setSnapInterval((int)(snapToInterval * screenDisplayMetrics.density));
+  }
+
 
   @ReactProp(name = "showsHorizontalScrollIndicator")
   public void setShowsHorizontalScrollIndicator(ReactHorizontalScrollView view, boolean value) {


### PR DESCRIPTION
This PR is based on PR https://github.com/facebook/react-native/pull/10242

- add implementation of `snapToInterval` to Android
- modify documentation so `snapToInterval` is not only iOS prop now
- add example to RNTester

You don't have to add `pagingEnabled` to the `ScrollView` so now iOS and Android work the same way. `snapToInterval` is only added to horizontal scroll because I have not seen any use cases for snapping in vertical scroll. 

I also think that later there should be only `snapToInterval` prop so `pagingEnabled` could be deprecated. Since `pagingEnabled` is just `snapToInterval` with value `Dimensions.get('window').width`.  Any comments or thoughts?

Demo of new behaviour:
![image](https://cloud.githubusercontent.com/assets/1699429/19086983/39d3ee1c-8a25-11e6-9c84-20f25a751f32.gif)
