### PR TITLE
Fixing path of node_modules inside gradle.builde [Doc update]

### DIFF
--- a/docs/IntegrationWithExistingApps.md
+++ b/docs/IntegrationWithExistingApps.md
@@ -556,7 +556,7 @@ allprojects {
         ...
         maven {
             // All of React Native (JS, Android binaries) is installed from npm
-            url "$rootDir/node_modules/react-native/android"
+            url "$rootDir/../node_modules/react-native/android"
         }
     }
     ...


### PR DESCRIPTION
Node_modules path was incorrect in the integration guilde, So I fixed it in this PR
