### PR TITLE
WebView: Allow to change textZoom on Android

### DIFF
--- a/Libraries/Components/WebView/WebView.android.js
+++ b/Libraries/Components/WebView/WebView.android.js
@@ -232,6 +232,12 @@ class WebView extends React.Component {
      * @platform android
      */
     urlPrefixesForDefaultIntent: PropTypes.arrayOf(PropTypes.string),
+
+    /**
+     * Text zoom of the page in percent, used on Android only. The default is 100.
+     * @platform android
+     */
+    textZoom: PropTypes.number,
   };
 
   static defaultProps = {
@@ -318,6 +324,7 @@ class WebView extends React.Component {
         mixedContentMode={this.props.mixedContentMode}
         saveFormDataDisabled={this.props.saveFormDataDisabled}
         urlPrefixesForDefaultIntent={this.props.urlPrefixesForDefaultIntent}
+        textZoom={this.props.textZoom}
         {...nativeConfig.props}
       />;
 

--- a/Libraries/Components/WebView/WebView.ios.js
+++ b/Libraries/Components/WebView/WebView.ios.js
@@ -377,7 +377,7 @@ class WebView extends React.Component {
       'always',
       'compatibility'
     ]),
-    
+
     /**
      * Override the native component used to render the WebView. Enables a custom native
      * WebView which uses the same JavaScript as the original WebView.
@@ -398,6 +398,12 @@ class WebView extends React.Component {
        */
       viewManager: PropTypes.object,
     }),
+
+    /**
+     * Text zoom of the page in percent, used on Android only. The default is 100.
+     * @platform android
+     */
+    textZoom: PropTypes.number,
   };
 
   static defaultProps = {

--- a/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebViewManager.java
@@ -540,6 +540,11 @@ public class ReactWebViewManager extends SimpleViewManager<WebView> {
     }
   }
 
+  @ReactProp(name = "textZoom")
+  public void setTextZoom(WebView view, int textZoom) {
+    view.getSettings().setTextZoom(textZoom);
+  }
+
   @Override
   protected void addEventEmitters(ThemedReactContext reactContext, WebView view) {
     // Do not register default touch emitter and let WebView implementation handle touches


### PR DESCRIPTION
Allow to change `textZoom` like:
```jsx
<WebView textZoom={50} />
```
[More details about `textZoom`.](https://developer.android.com/reference/android/webkit/WebSettings.html#setTextZoom(int))

[Feature request.](https://react-native.canny.io/feature-requests/p/android-allow-to-change-webview-textzoom)

Test plan:
* create `WebView` without `textZoom`;
* ensure that everything rendered same as before;
* set `textZoom={50}`;
* ensure that font size is twice smaller than before on Android;
* ensure that everything rendered same as before on iOs.

Without `textZoom`:
![without textZoom](https://user-images.githubusercontent.com/1114542/28830393-d9ef3c8c-76d6-11e7-8f57-4150182d2023.png)

With `textZoom={50}`:
![with textZoom=50](https://user-images.githubusercontent.com/1114542/28830412-ec66315e-76d6-11e7-81a8-85c0086bbb62.png)
