### PR TITLE
add --port options to run-android, defaults to 8081

### DIFF
--- a/local-cli/runAndroid/runAndroid.js
+++ b/local-cli/runAndroid/runAndroid.js
@@ -56,10 +56,10 @@ function getAdbPath() {
 }
 
 // Runs ADB reverse tcp:8081 tcp:8081 to allow loading the jsbundle from the packager
-function tryRunAdbReverse(device) {
+function tryRunAdbReverse(args, device) {
   try {
     const adbPath = getAdbPath();
-    const adbArgs = ['reverse', 'tcp:8081', 'tcp:8081'];
+    const adbArgs = ['reverse', `tcp:${args.port}`, `tcp:${args.port}`];
 
     // If a device is specified then tell adb to use it
     if (device) {
@@ -167,7 +167,7 @@ function tryLaunchAppOnDevice(device, packageNameWithSuffix, packageName, adbPat
 }
 
 function installAndLaunchOnDevice(args, selectedDevice, packageNameWithSuffix, packageName, adbPath) {
-  tryRunAdbReverse(selectedDevice);
+  tryRunAdbReverse(args, selectedDevice);
   tryInstallAppOnDevice(args, selectedDevice);
   tryLaunchAppOnDevice(selectedDevice, packageNameWithSuffix, packageName, adbPath, args.mainActivity);
 }
@@ -216,7 +216,7 @@ function runOnAllDevices(args, cmd, packageNameWithSuffix, packageName, adbPath)
     const devices = adb.getDevices();
     if (devices && devices.length > 0) {
       devices.forEach((device) => {
-        tryRunAdbReverse(device);
+        tryRunAdbReverse(args, device);
         tryLaunchAppOnDevice(device, packageNameWithSuffix, packageName, adbPath, args.mainActivity);
       });
     } else {
@@ -307,5 +307,9 @@ module.exports = {
   }, {
     command: '--no-packager',
     description: 'Do not launch packager while building',
+  }, {
+    command: '--port [number]',
+    default: 8081,
+    parse: (val: string) => Number(val),
   }],
 };

--- a/local-cli/runAndroid/runAndroid.js
+++ b/local-cli/runAndroid/runAndroid.js
@@ -56,10 +56,10 @@ function getAdbPath() {
 }
 
 // Runs ADB reverse tcp:8081 tcp:8081 to allow loading the jsbundle from the packager
-function tryRunAdbReverse(args, device) {
+function tryRunAdbReverse(packagerPort, device) {
   try {
     const adbPath = getAdbPath();
-    const adbArgs = ['reverse', `tcp:${args.port}`, `tcp:${args.port}`];
+    const adbArgs = ['reverse', `tcp:${packagerPort}`, `tcp:${packagerPort}`];
 
     // If a device is specified then tell adb to use it
     if (device) {
@@ -167,7 +167,7 @@ function tryLaunchAppOnDevice(device, packageNameWithSuffix, packageName, adbPat
 }
 
 function installAndLaunchOnDevice(args, selectedDevice, packageNameWithSuffix, packageName, adbPath) {
-  tryRunAdbReverse(args, selectedDevice);
+  tryRunAdbReverse(args.port, selectedDevice);
   tryInstallAppOnDevice(args, selectedDevice);
   tryLaunchAppOnDevice(selectedDevice, packageNameWithSuffix, packageName, adbPath, args.mainActivity);
 }
@@ -216,7 +216,7 @@ function runOnAllDevices(args, cmd, packageNameWithSuffix, packageName, adbPath)
     const devices = adb.getDevices();
     if (devices && devices.length > 0) {
       devices.forEach((device) => {
-        tryRunAdbReverse(args, device);
+        tryRunAdbReverse(args.port, device);
         tryLaunchAppOnDevice(device, packageNameWithSuffix, packageName, adbPath, args.mainActivity);
       });
     } else {


### PR DESCRIPTION
Test:
* I couldn't get `npm link` to work correctly with my existing project, so this is a roundabout way of testing it. 

In this repo:
Run `react-native init fakeProject && cd fakeProject`
Run `node '../local-cli/cli.js' run-android --help`, list help and noticed port is present.
Run `node '../local-cli/cli.js' run-android --port=8088`, run command noticed adb is set correctly to 8088

In android emulator open debug tools (command+M) goto `Debug server host & port for device`
and change it to `localhost:8088`.
Run `react-native start --port=8088`, in a different shell.
Reload. 
Profit.

Suggestion welcome, if anyone knows a better way to test `runAndroid`command. 


