### PR TITLE
Fixed link command to return a promise

### DIFF
--- a/local-cli/link/pollParams.js
+++ b/local-cli/link/pollParams.js
@@ -5,5 +5,5 @@ module.exports = (questions) => new Promise((resolve, reject) => {
     return resolve({});
   }
 
-  inquirer.prompt(questions, resolve);
+  inquirer.prompt(questions).then(resolve, reject);
 });


### PR DESCRIPTION
Update to use the promises based API that inquirer uses

As a part of #https://github.com/facebook/react-native/commit/bada25d158e070fd683a10b8ff9cdcb8d2498b14 , a newer version of inquirer was added.

The signature for inquirer@0.12 used to be inquirer.prompt(questions, callback). This has changed to a promised based signature. However the link commands in this line has not been updated to pick up this change.

This PR fixes that. 