### PR TITLE
add setNativeProps to SectionList

### DIFF
--- a/Libraries/Lists/SectionList.js
+++ b/Libraries/Lists/SectionList.js
@@ -317,6 +317,13 @@ class SectionList<SectionT: SectionBase<any>> extends React.PureComponent<
     }
   }
 
+  setNativeProps(props: Object) {
+    const listRef = this._wrapperListRef && this._wrapperListRef.getListRef();
+    if (listRef) {
+      listRef.setNativeProps(props);
+    }
+  }
+
   render() {
     const List = this.props.legacyImplementation
       ? MetroListView


### PR DESCRIPTION
# Motivation

#13529 added `setNativeProps` to `FlatList`. So it would be nice to support it in `SectionList` too. Because sometime, for example, I need to disable scroll functionality when using with `SwipeableRow`.

# Test plan

```js
componentDidMount() {
  this._list.setNativeProps({scrollEnabled: false})
}

render() {
  const sections = [
    {key: 'foo', data: [{name: 'Jone Doe', key: 'a'}, {name: 'Susan Briz', key: 'b'}],
    {key: 'bar', data: [{name: 'David Mark', key: 'c'}, {name: 'Daniel Campbell', key: 'd'}]
  ]

  return (
    <SectionList
      ref={c => (this._list = c)}
      sections={sections}
      renderItem={({item}) => <Text>{item.name}<Text>}
    />
  )
}
```