### PR TITLE
[docs] document how to export consts from a swift native module

### DIFF
--- a/docs/NativeModulesIOS.md
+++ b/docs/NativeModulesIOS.md
@@ -438,6 +438,10 @@ class CalendarManager: NSObject {
   func addEvent(name: String, location: String, date: NSNumber) -> Void {
     // Date is ready to use!
   }
+  
+  override func constantsToExport() -> [String: Any]! {
+    return ["someKey": "someValue"]
+  }
 
 }
 ```


### PR DESCRIPTION
I documented how to export consts from a swift native module.

