### PR TITLE
Include a style in the example for AndroidToolbar

### DIFF
--- a/Libraries/Components/ToolbarAndroid/ToolbarAndroid.android.js
+++ b/Libraries/Components/ToolbarAndroid/ToolbarAndroid.android.js
@@ -51,6 +51,7 @@ var optionalImageSource = PropTypes.oneOfType([
  * render: function() {
  *   return (
  *     <ToolbarAndroid
+ *       style={{height: 56, alignSelf: 'stretch'}}
  *       logo={require('./app_logo.png')}
  *       title="AwesomeApp"
  *       actions={[{title: 'Settings', icon: require('./icon_settings.png'), show: 'always'}]}


### PR DESCRIPTION
- The toolbar does not render unless height and width are set. It may not be a priority to fix, but we should at least update the docs so the example works.
see: https://github.com/facebook/react-native/issues/5293

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. In other words, a test plan is *required*. Bonus points for screenshots and videos!

Please read the Contribution Guidelines at https://github.com/facebook/react-native/blob/master/CONTRIBUTING.md to learn more about contributing to React Native.

Happy contributing!
-->
