### PR TITLE
fix?

### DIFF
--- a/Libraries/Text/RCTTextInput.m
+++ b/Libraries/Text/RCTTextInput.m
@@ -65,7 +65,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithFrame:(CGRect)frame)
 - (CGSize)contentSize
 {
   CGSize contentSize = self.intrinsicContentSize;
-  UIEdgeInsets compoundInsets = self.reactCompoundInsets;
+  UIEdgeInsetsInsetRect compoundInsets = self.reactCompoundInsets;
   contentSize.width -= compoundInsets.left + compoundInsets.right;
   contentSize.height -= compoundInsets.top + compoundInsets.bottom;
   // Returning value does NOT include border and padding insets.


### PR DESCRIPTION
While debugging in XCode, I fixed that. I do not know exactly what am I doing. Please, check.

```
    "react": "^16.0.0-alpha.12",
    "react-native": "0.47.1",
```

```
node_modules/react-native/Libraries/Text/RCTTextInput.m:68:38: Property 'reactCompoundInsets' not found on object of type 'RCTTextInput *'

node_modules/react-native/Libraries/Text/RCTTextInput.m:145:29: No visible @interface for 'UIView<RCTBackedTextInputViewProtocol>' declares the selector 'reactFocus'

node_modules/react-native/Libraries/Text/RCTTextInput.m:150:29: No visible @interface for 'UIView<RCTBackedTextInputViewProtocol>' declares the selector 'reactBlur'

node_modules/react-native/Libraries/Text/RCTTextInput.m:155:29: No visible @interface for 'UIView<RCTBackedTextInputViewProtocol>' declares the selector 'reactFocusIfNeeded'
```
