### PR TITLE
LocalString doesn't have a check for nullptr 

### DIFF
--- a/ReactAndroid/src/main/jni/first-party/fb/jni/LocalString.cpp
+++ b/ReactAndroid/src/main/jni/first-party/fb/jni/LocalString.cpp
@@ -82,16 +82,18 @@ size_t modifiedLength(const uint8_t* str, size_t* length) {
   // NUL-terminated: Scan for length and supplementary characters
   size_t i = 0;
   size_t j = 0;
-  while (str[i] != 0) {
-    if (str[i + 1] == 0 ||
-        str[i + 2] == 0 ||
-        str[i + 3] == 0 ||
-        !isFourByteUTF8Encoding(&(str[i]))) {
-      i += 1;
-      j += 1;
-    } else {
-      i += 4;
-      j += 6;
+  if (str != nullptr) {
+    while (str[i] != 0) {
+      if (str[i + 1] == 0 ||
+          str[i + 2] == 0 ||
+          str[i + 3] == 0 ||
+          !isFourByteUTF8Encoding(&(str[i]))) {
+        i += 1;
+        j += 1;
+      } else {
+        i += 4;
+        j += 6;
+      }
     }
   }
 


### PR DESCRIPTION
LocalString doesn't have a check for null ptr which causes a crash if the null string passed.

Test Plan:
Wrap NULL to LocalString it crashes.
If you wrap it after fix there is no crash.

You want to use LocalString to make sure that your string correctly converted from UTF-8 to jstring.
As modified UTF-8 and UTF-8 are not completely compatible and if you pass the UTF-8 string to JNI API that could cause a crash.
