### PR TITLE
Fix ViewPager being stuck in some scenarios

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/viewpager/ReactViewPager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/viewpager/ReactViewPager.java
@@ -30,6 +30,8 @@ import com.facebook.react.uimanager.events.NativeGestureUtil;
  */
 public class ReactViewPager extends ViewPager {
 
+  private boolean mHasLayout;
+
   private class Adapter extends PagerAdapter {
 
     private final List<View> mViews = new ArrayList<>();
@@ -92,6 +94,7 @@ public class ReactViewPager extends ViewPager {
     public int getCount() {
       return mViews.size();
     }
+
 
     @Override
     public int getItemPosition(Object object) {
@@ -163,7 +166,7 @@ public class ReactViewPager extends ViewPager {
     super(reactContext);
     mEventDispatcher = reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher();
     mIsCurrentItemFromJs = false;
-    setOnPageChangeListener(new PageChangeListener());
+    addOnPageChangeListener(new PageChangeListener());
     setAdapter(new Adapter());
   }
 
@@ -192,6 +195,19 @@ public class ReactViewPager extends ViewPager {
     }
 
     return super.onTouchEvent(ev);
+  }
+
+  @Override
+  protected void onLayout(boolean changed, int l, int t, int r, int b) {
+    super.onLayout(changed, l, t, r, b);
+    mHasLayout = true;
+  }
+
+  @Override
+  protected void onAttachedToWindow() {
+    if (!mHasLayout) {
+      super.onAttachedToWindow();
+    }
   }
 
   public void setCurrentItemFromJs(int item, boolean animated) {


### PR DESCRIPTION
In some scenarios, the view pager gets stuck in and it's not possible to update the pages. I did some digging and found the following.

In native `ViewPager`, the `onAttachedToWindow` method gets called on start, which sets a variable called `mFirstLayout` to `true`. Then `onLayout` method gets called, which sets `mFirstLayout` to `false`, since first layout has occurred now. But then `onAttachedToWindow` method gets called again for some reason which resets `mFirstLayout` to `true`.

This makes the `ViewPager` stuck since `mFirstLayout` variable never updates again, and to be able to animate the pager, the native component expects it to be `false`.

I also discovered that @rauliyohmc arrived at the same conclusions here, which describes it in more detail -
 https://github.com/expo/ex-navigation/issues/415#issue-207683159

This PR is a hacky attempt to prevent `onAttachedToWindow` being called again after first layout since I am unsure about the correct fix.

Fixes #13463

cc @astreet 