### PR TITLE
Fixed issue with install third party script in directory with spaces

### DIFF
--- a/React/React.xcodeproj/project.pbxproj
+++ b/React/React.xcodeproj/project.pbxproj
@@ -3491,7 +3491,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "cd $SRCROOT/..\nexec ./scripts/ios-install-third-party.sh";
+			shellScript = "cd \"$SRCROOT/..\"\nexec ./scripts/ios-install-third-party.sh";
 		};
 		2D6948201DA3042200B3FA97 /* Include RCTJSCProfiler */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/scripts/ios-install-third-party.sh
+++ b/scripts/ios-install-third-party.sh
@@ -33,7 +33,7 @@ mkdir -p third-party
 
 SCRIPTDIR=$(dirname "$0")
 
-fetch_and_unpack glog-0.3.4.tar.gz https://github.com/google/glog/archive/v0.3.4.tar.gz "$SCRIPTDIR/ios-configure-glog.sh"
+fetch_and_unpack glog-0.3.4.tar.gz https://github.com/google/glog/archive/v0.3.4.tar.gz "\"$SCRIPTDIR/ios-configure-glog.sh\""
 fetch_and_unpack double-conversion-1.1.5.tar.gz https://github.com/google/double-conversion/archive/v1.1.5.tar.gz
 fetch_and_unpack boost_1_63_0.tar.gz https://github.com/react-native-community/boost-for-react-native/releases/download/v1.63.0-0/boost_1_63_0.tar.gz
 fetch_and_unpack folly-2016.09.26.00.tar.gz https://github.com/facebook/folly/archive/v2016.09.26.00.tar.gz


### PR DESCRIPTION
Fixes an issue with installing third party on iOS when the project's path contains a space, no matter where the space is in the path.


__Error__
```
/Users/AwesomeUser/Library/Developer/Xcode/DerivedData/AwesomeProject-xxx/Build/Intermediates.noindex/React.build/Debug-iphoneos/double-conversion.build/Script-190EE32F1E6A43DE00A8543A.sh: line 3: /Users/AwesomeUser/path contain space/scripts/ios-install-third-party.sh: No such file or directory
/Users/AwesomeUser/Library/Developer/Xcode/DerivedData/AwesomeProject-xxx/Build/Intermediates.noindex/React.build/Debug-iphoneos/double-conversion.build/Script-190EE32F1E6A43DE00A8543A.sh: line 3: exec: /Users/AwesomeUser/path contain space/scripts/ios-install-third-party.sh: cannot execute: No such file or directory
```