### PR TITLE
Set alertTitle in UILocalNotification

### DIFF
--- a/Libraries/PushNotificationIOS/PushNotificationIOS.js
+++ b/Libraries/PushNotificationIOS/PushNotificationIOS.js
@@ -159,6 +159,7 @@ class PushNotificationIOS {
    * details is an object containing:
    *
    * - `fireDate` : The date and time when the system should deliver the notification.
+   * - `alertTitle` : The text displayed as the title of the notification alert.
    * - `alertBody` : The message displayed in the notification alert.
    * - `alertAction` : The "action" displayed beneath an actionable notification. Defaults to "view";
    * - `soundName` : The sound played when the notification is fired (optional).

--- a/Libraries/PushNotificationIOS/RCTPushNotificationManager.m
+++ b/Libraries/PushNotificationIOS/RCTPushNotificationManager.m
@@ -53,6 +53,7 @@ RCT_ENUM_CONVERTER(NSCalendarUnit,
   NSDictionary<NSString *, id> *details = [self NSDictionary:json];
   BOOL isSilent = [RCTConvert BOOL:details[@"isSilent"]];
   UILocalNotification *notification = [UILocalNotification new];
+  notification.alertTitle = [RCTConvert NSString:details[@"alertTitle"]];
   notification.fireDate = [RCTConvert NSDate:details[@"fireDate"]] ?: [NSDate date];
   notification.alertBody = [RCTConvert NSString:details[@"alertBody"]];
   notification.alertAction = [RCTConvert NSString:details[@"alertAction"]];


### PR DESCRIPTION
Currently, since the alertTitle is not set in UILocalNotification, the notification displays just the notification body with no title. This commit sets the alertTitle for local notifications.

Issue: #14699 

## Test Plan

- In a sample RN app, created a component and added the following code to componentDidMount():
`PushNotificationIOS.scheduleLocalNotification({
     fireDate: new Date(Date.now() + (30 * 1000)).toISOString(),
     alertTitle: 'Incoming Message',
     alertBody: 'Test message',
     soundName: 'default'
 })`

- On running the app, the notification appears with both body and title once the component is mounted.

![settitle_fix](https://user-images.githubusercontent.com/4279549/28995873-f62c9866-7a11-11e7-9f29-95dba50ef40b.jpg)
