### PR TITLE
Fix $FlowFixMe in docs

### DIFF
--- a/Libraries/Components/Picker/Picker.js
+++ b/Libraries/Components/Picker/Picker.js
@@ -26,6 +26,8 @@ var ViewStylePropTypes = require('ViewStylePropTypes');
 
 var itemStylePropType = StyleSheetPropType(TextStylePropTypes);
 
+const stylePropType = StyleSheetPropType(ViewStylePropTypes);
+
 var pickerStyleType = StyleSheetPropType({
   ...ViewStylePropTypes,
   color: ColorPropType,
@@ -84,12 +86,12 @@ class PickerItem extends React.Component {
  */
 class Picker extends React.Component {
  props: {
-  style?: $FlowFixMe,
+  style?: pickerStyleType,
   selectedValue?: any,
   onValueChange?: Function,
   enabled?: boolean,
   mode?: 'dialog' | 'dropdown',
-  itemStyle?: $FlowFixMe,
+  itemStyle?: stylePropType,
   prompt?: string,
   testID?: string,
  };

--- a/Libraries/Components/Picker/PickerAndroid.android.js
+++ b/Libraries/Components/Picker/PickerAndroid.android.js
@@ -38,7 +38,7 @@ type Event = Object;
  */
 class PickerAndroid extends React.Component {
   props: {
-    style?: $FlowFixMe,
+    style?: pickerStyleType,
     selectedValue?: any,
     enabled?: boolean,
     mode?: 'dialog' | 'dropdown',

--- a/Libraries/Components/TabBarIOS/TabBarIOS.ios.js
+++ b/Libraries/Components/TabBarIOS/TabBarIOS.ios.js
@@ -15,18 +15,22 @@ var ColorPropType = require('ColorPropType');
 var React = require('React');
 const PropTypes = require('prop-types');
 var StyleSheet = require('StyleSheet');
+const StyleSheetPropType = require('StyleSheetPropType');
 var TabBarItemIOS = require('TabBarItemIOS');
 const ViewPropTypes = require('ViewPropTypes');
+var ViewStylePropTypes = require('ViewStylePropTypes');
 
 var requireNativeComponent = require('requireNativeComponent');
 
+const stylePropType = StyleSheetPropType(ViewStylePropTypes);
+
 class TabBarIOS extends React.Component {
   props: {
-    style?: $FlowFixMe,
-    unselectedTintColor?: $FlowFixMe,
-    tintColor?: $FlowFixMe,
-    unselectedItemTintColor?: $FlowFixMe,
-    barTintColor?: $FlowFixMe,
+    style?: stylePropType,
+    unselectedTintColor?: ?string,
+    tintColor?: ?string,
+    unselectedItemTintColor?: ?string,
+    barTintColor?: ?string,
     translucent?: boolean,
     itemPositioning?: 'fill' | 'center' | 'auto',
   };


### PR DESCRIPTION
Previously, the type $FlowFixMe appeared on several pages in the docs (https://facebook.github.io/react-native/docs/tabbarios.html, https://facebook.github.io/react-native/docs/picker.html, https://facebook.github.io/react-native/docs/statusbar.html)

This fixes those types while maintaining consistency with the rest of the docs.

However, it would still be unclear to a user reading the docs what 'pickerStyleType' and 'stylePropType' in the following example means.

For example, this is how http://localhost:8079/react-native/docs/picker.html will look now:
![image](https://user-images.githubusercontent.com/134487/29011987-8dbf1570-7aec-11e7-8fc7-9b8684767819.png)

Fixes #15218 