### PR TITLE
Fix format specifier used in RCTUIManager

### DIFF
--- a/React/Modules/RCTUIManager.m
+++ b/React/Modules/RCTUIManager.m
@@ -1421,7 +1421,7 @@ RCT_EXPORT_METHOD(setJSResponder:(nonnull NSNumber *)reactTag
   [self addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry) {
     _jsResponder = viewRegistry[reactTag];
     if (!_jsResponder) {
-      RCTLogError(@"Invalid view set to be the JS responder - tag %zd", reactTag);
+      RCTLogError(@"Invalid view set to be the JS responder - tag %@", reactTag);
     }
   }];
 }


### PR DESCRIPTION
Here, `reactTag` is an `NSNumber *` which uses `%@` as the format specifier. Newer versions of clang can warn or error on this. This change prevents that from happening.

See also #15402

## Test Plan

Local builds with clang 5.