### PR TITLE
[RCTTabBar] Fix syntax error

### DIFF
--- a/React/Views/RCTTabBar.m
+++ b/React/Views/RCTTabBar.m
@@ -157,7 +157,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
 #endif
 }
 
-- (UITabBarItemPositioning)itemPositoning
+- (UITabBarItemPositioning)itemPositioning
 {
 #if TARGET_OS_TV
   return 0;


### PR DESCRIPTION
It is not itemPositoning it is itemPositioning

I have test it on iOS and tvOS