### PR TITLE
[iOS] Fix TextInput numeric keyboard submit

### DIFF
--- a/Libraries/Text/RCTTextInput.m
+++ b/Libraries/Text/RCTTextInput.m
@@ -316,7 +316,9 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithFrame:(CGRect)frame)
 
 - (void)handleInputAccessoryDoneButton
 {
-  [self.backedTextInputView endEditing:YES];
+  if ([self textInputShouldReturn]) {
+    [self.backedTextInputView endEditing:YES];
+  }
 }
 
 @end


### PR DESCRIPTION
When you have a numeric non-multiline `TextInput` and a `returnKeyType` is `done` we automatically add an input accessory view ([implementation](https://github.com/facebook/react-native/blob/603cc48ceba001827d10231d51b4031c7768eef8/Libraries/Text/RCTTextInput.m#L269#L315)).

That view has a done button which triggers [handleInputAccessoryDoneButton](https://github.com/facebook/react-native/blob/603cc48ceba001827d10231d51b4031c7768eef8/Libraries/Text/RCTTextInput.m#L317...L320) which currently directly sends `endEditing:` to the text field / text view. As a consequence, the [textInputShouldReturn](https://github.com/facebook/react-native/blob/603cc48ceba001827d10231d51b4031c7768eef8/Libraries/Text/RCTTextInput.m#L118...L121) is not called and we dismiss the keyboard even if the `blurOnSubmit` value is `false`.

## Test Plan

Confirm that the keyboard is not dismissed when you tap on Done button on this `TextInput`:
```
<TextInput
  keyboardType={'numeric'}
  returnKeyType={'done'}
  blurOnSubmit={false}
/>
```

and that the keyboard is dismissed for this `TextInput`:
```
<TextInput
  keyboardType={'numeric'}
  returnKeyType={'done'}
  blurOnSubmit
/>
```