### PR TITLE
Support custom android buildPatch with react-native link

### DIFF
--- a/local-cli/core/android/index.js
+++ b/local-cli/core/android/index.js
@@ -124,5 +124,7 @@ exports.dependencyConfig = function dependencyConfigAndroid(folder, userConfig) 
   const packageInstance = userConfig.packageInstance ||
     `new ${packageClassName}()`;
 
-  return { sourceDir, folder, manifest, packageImportPath, packageInstance };
+  const buildPatch = userConfig.buildPatch;
+
+  return { sourceDir, folder, manifest, packageImportPath, packageInstance, buildPatch };
 };

--- a/local-cli/link/__tests__/android/makeBuildPatch.spec.js
+++ b/local-cli/link/__tests__/android/makeBuildPatch.spec.js
@@ -3,15 +3,27 @@
 const makeBuildPatch = require('../../android/patches/makeBuildPatch');
 const name = 'test';
 
+const buildPatch = 'import some.example.project';
+
 describe('makeBuildPatch', () => {
-  it('should build a patch function', () => {
+  it('should build a patch function (no custom buildPatch)', () => {
     expect(Object.prototype.toString(makeBuildPatch(name)))
       .toBe('[object Object]');
   });
 
-  it('should make a correct patch', () => {
+  it('should make a correct patch (no custom buildPatch)', () => {
     const {patch} = makeBuildPatch(name);
     expect(patch).toBe(`    compile project(':${name}')\n`);
+  });
+
+  it('should build a patch function (custom buildPatch)', () => {
+    expect(Object.prototype.toString(makeBuildPatch(name, buildPatch)))
+      .toBe('[object Object]');
+  });
+
+  it('should make a correct patch (custom buildPatch)', () => {
+    const {patch} = makeBuildPatch(name, buildPatch);
+    expect(patch).toBe(buildPatch);
   });
 
   it('should make a correct install check pattern', () => {

--- a/local-cli/link/android/patches/makeBuildPatch.js
+++ b/local-cli/link/android/patches/makeBuildPatch.js
@@ -1,4 +1,4 @@
-module.exports = function makeBuildPatch(name) {
+module.exports = function makeBuildPatch(name, buildPatch) {
   const installPattern = new RegExp(
     `\\s{4}(compile)(\\(|\\s)(project)\\(\\\':${name}\\\'\\)(\\)|\\s)`
   )
@@ -6,6 +6,6 @@ module.exports = function makeBuildPatch(name) {
   return {
     installPattern,
     pattern: /[^ \t]dependencies {\n/,
-    patch: `    compile project(':${name}')\n`
+    patch: buildPatch || `    compile project(':${name}')\n`
   };
 };

--- a/local-cli/link/android/registerNativeModule.js
+++ b/local-cli/link/android/registerNativeModule.js
@@ -11,7 +11,7 @@ module.exports = function registerNativeAndroidModule(
   params,
   projectConfig
 ) {
-  const buildPatch = makeBuildPatch(name);
+  const buildPatch = makeBuildPatch(name, androidConfig.buildPatch);
 
   applyPatch(
     projectConfig.settingsGradlePath,


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes. 

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to React Native here: http://facebook.github.io/react-native/docs/contributing.html

Happy contributing!

-->

This PR: https://github.com/invertase/react-native/commit/5f1408858abb8d8d0b6c573bdf7b8b8f1aac0986 added support for more complex compile statements in `build.gradle` such as:

```
compile(project(':example') { … }
```

However, whilst `react-native link` can now detect the presence of such a compile statement, there is no way for a library developer to specify a compile statement of this format as part of their library linking.  In our `react-native-firebase` library, we have such a requirement and need to be able to add the following:

```
    compile(project(':react-native-firebase')) {
        transitive = false
    }
```

This change adds an additional `buildPatch` option for the rnpm settings in a library's package.json file as follows:

```
  "rnpm": {
    "android": {
      "buildPatch": "    compile(project(':react-native-firebase')) {\n        transitive = false\n    }\n"
    }
  }
```

## Test Plan

This commit adds additional test cases to `makeBuildPatch.spec.js` to validate that the buildPatch is correctly built in the instance where a buildPatch is supplied and to ensure backwards compatibility when it is not supplied.

I have also manually validated that the configuration works for `react-native-firebase` by applying the patch locally and running `react-native link`.
