### PR TITLE
[tvOS] Change behavior of onPress

### DIFF
--- a/Libraries/Components/Touchable/TouchableHighlight.js
+++ b/Libraries/Components/Touchable/TouchableHighlight.js
@@ -14,6 +14,7 @@
 const ColorPropType = require('ColorPropType');
 const NativeMethodsMixin = require('NativeMethodsMixin');
 const PropTypes = require('prop-types');
+const Platform = require('Platform');
 const React = require('React');
 const ReactNativeViewAttributes = require('ReactNativeViewAttributes');
 const StyleSheet = require('StyleSheet');
@@ -190,9 +191,10 @@ var TouchableHighlight = createReactClass({
 
   touchableHandlePress: function(e: Event) {
     this.clearTimeout(this._hideTimeout);
-    this._showUnderlay();
-    this._hideTimeout = this.setTimeout(this._hideUnderlay,
-      this.props.delayPressOut || 100);
+    if (!Platform.isTVOS) {
+      this._showUnderlay();
+      this._hideTimeout = this.setTimeout(this._hideUnderlay, this.props.delayPressOut || 100);
+		}
     this.props.onPress && this.props.onPress(e);
   },
 


### PR DESCRIPTION
# Change TouchableHighlight onPress behaviour

I think default behaviour of TouchableHighlight on tvOS is not really good, it is really great for iOS / Android.

When you select and press a button on tvOS this is a bit different: 

The actual behaviour when you press a TouchableHighlight is: 
- You press the button
- You have the underlay is show
- You have a delay
- You have the underlay is hide

We have this behaviour because the focus coming and going on mobile. But on a tvOS application when have press the TouchableHighlight this is bit different, the focus rest on the TouchableHighlight

## This is a button on tvOS:

![real](https://user-images.githubusercontent.com/7658664/29193216-98520368-7e24-11e7-8160-a7918faf71da.gif)

- When you select the button he is focus
- When you press the button, there is a little animation, but after the animation, the focus is on the button 

## This is the actual behaviour: 

![actual](https://user-images.githubusercontent.com/7658664/29193194-8cbfc094-7e24-11e7-9647-6b06a777521f.gif)

- When you select the button he is focus and the underlay is show
- When you press the button, there is no animation, but after the animation, the focus is on the button and the underlay is hide

This is not logic when we have the focus we have the underlay and sometimes no because you have press the button

## The is a behaviour proposal:

![new](https://user-images.githubusercontent.com/7658664/29193233-a362c71a-7e24-11e7-9663-5ba83f9df782.gif)

- When you select the button he is focus and the underlay is show
- When you press the button, there is no animation, but after the animation, the focus is on the button and the underlay is show 


## This is a behaviour proposal with animation based on tvParallaxProperties :
This modification is not in this pull request you can see #15455 

![newChangesWithAnimation](https://user-images.githubusercontent.com/7658664/29193255-baf5bd10-7e24-11e7-9811-480ac61f031e.gif)

- When you select the button he is focus and the underlay is show
- When you press the button, there is an animation, but after the animation, the focus is on the button and the underlay is show 

## Test Plan

Play with tvParallaxProperties on tvOS, test with and without patch just to see the actual behaviour
```
			<TouchableHighlight
						tvParallaxProperties={{
							enabled: true,
							shiftDistanceX: 0,
							shiftDistanceY: 0,
							tiltAngle: 0,
							magnification: 1.1,
							pressDuration: 0.3,
						}}
						underlayColor="black"
						onShowUnderlay={() => (console.log("onShowUnderlay")}
						onHideUnderlay={() =>  (console.log("onHideUnderlay")}
						onPress={() =>  (console.log("onPress")}
					>
						<Image
							style={styles.image}
							source={ uri: 'https://www.facebook.com/images/fb_icon_325x325.png' }
						/>
					</TouchableHighlight>
```