### PR TITLE
Fix run-android behaviour when using both --deviceId and --variant

### DIFF
--- a/local-cli/runAndroid/runAndroid.js
+++ b/local-cli/runAndroid/runAndroid.js
@@ -118,7 +118,7 @@ function runOnSpecificDevice(args, gradlew, packageNameWithSuffix, packageName, 
   let devices = adb.getDevices();
   if (devices && devices.length > 0) {
     if (devices.indexOf(args.deviceId) !== -1) {
-      buildApk(gradlew);
+      buildApk(args, gradlew);
       installAndLaunchOnDevice(args, args.deviceId, packageNameWithSuffix, packageName, adbPath);
     } else {
       console.log('Could not find device with the id: "' + args.deviceId + '".');
@@ -130,12 +130,23 @@ function runOnSpecificDevice(args, gradlew, packageNameWithSuffix, packageName, 
   }
 }
 
-function buildApk(gradlew) {
+function buildApk(args, gradlew) {
   try {
     console.log(chalk.bold('Building the app...'));
 
+    var gradleArgs = [];
+    if (args.variant) {
+      gradleArgs.push('assemble' +
+        args.variant[0].toUpperCase() + args.variant.slice(1)
+      );
+    } else {
+      gradleArgs.push('assembleDebug');
+    }
+
     // using '-x lint' in order to ignore linting errors while building the apk
-    child_process.execFileSync(gradlew, ['build', '-x', 'lint'], {
+    gradleArgs.push('-x', 'lint');
+
+    child_process.execFileSync(gradlew, gradleArgs, {
       stdio: [process.stdin, process.stdout, process.stderr],
     });
   } catch (e) {


### PR DESCRIPTION
Use the correct assemble<variant> target (avoids building all targets); install the correct APK for the requested variant type.

## Test Plan

Test on a newly-built project, cleaning the android build between tests:

        # builds and installs app-debug.apk
        $ rm -rf android/app/build
        $ react-native run-android --deviceId <id>
    
        # builds and installs app-release.apk
        $ rm -rf android/app/buil
        $ react-native run-android --deviceId <id> --variant release
    
        # builds and installs app-debug.apk
        $ rm -rf android/app/buil
        $ react-native run-android --deviceId <id> --variant debug

Thanks!
Mattia