### PR TITLE
Implement deletion of asset-library files

### DIFF
--- a/Libraries/CameraRoll/CameraRoll.js
+++ b/Libraries/CameraRoll/CameraRoll.js
@@ -135,6 +135,10 @@ class CameraRoll {
     return this.saveToCameraRoll(tag, 'photo');
   }
 
+  static deletePhotos(photos: Array<string>) {
+    return RCTCameraRollManager.deletePhotos(photos);
+  }
+
   /**
    * Saves the photo or video to the camera roll / gallery.
    *

--- a/Libraries/CameraRoll/RCTCameraRollManager.m
+++ b/Libraries/CameraRoll/RCTCameraRollManager.m
@@ -12,6 +12,7 @@
 #import <CoreLocation/CoreLocation.h>
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
+#import <Photos/Photos.h>
 
 #import <React/RCTBridge.h>
 #import <React/RCTConvert.h>
@@ -232,6 +233,27 @@ RCT_EXPORT_METHOD(getPhotos:(NSDictionary *)params
     }
     reject(kErrorUnableToLoad, nil, error);
   }];
+}
+
+RCT_EXPORT_METHOD(deletePhotos:(NSArray<NSString *>*)assets
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject)
+{
+  NSArray<NSURL *> *assets_ = [RCTConvert NSURLArray:assets];
+  [[PHPhotoLibrary sharedPhotoLibrary] performChanges:^{
+      PHFetchResult<PHAsset *> *fetched =
+        [PHAsset fetchAssetsWithALAssetURLs:assets_ options:nil];
+      [PHAssetChangeRequest deleteAssets:fetched];
+    }
+  completionHandler:^(BOOL success, NSError *error) {
+      if (success == YES) {
+	resolve(@(success));
+      }
+      else {
+	reject(@"Couldn't delete", @"Couldn't delete assets", error);
+      }
+    }
+    ];
 }
 
 static void checkPhotoLibraryConfig()

--- a/Libraries/CameraRoll/RCTCameraRollManager.m
+++ b/Libraries/CameraRoll/RCTCameraRollManager.m
@@ -247,10 +247,10 @@ RCT_EXPORT_METHOD(deletePhotos:(NSArray<NSString *>*)assets
     }
   completionHandler:^(BOOL success, NSError *error) {
       if (success == YES) {
-	resolve(@(success));
+     	    resolve(@(success));
       }
       else {
-	reject(@"Couldn't delete", @"Couldn't delete assets", error);
+	        reject(@"Couldn't delete", @"Couldn't delete assets", error);
       }
     }
     ];


### PR DESCRIPTION
WIP: Starting point insofar as I'm not sure if there should be an Android equivalent. 

My application needs me to delete photos from the photos in iOS. 

I have tested this in my application and it works, have a screenshot from iOS asking as well and it does successfully delete the photos from the global Photos app. 

Related to https://github.com/facebook/react-native/issues/15253, it kind of continues using the deprecated assets-library framework, but that does need (and will be an bigger and bigger issue coming up) of assets-library URLs being used. 

I also assume RN prefers error handling at the JS level? Are the URLs starting with `asset-library`, etc. 