### PR TITLE
Fix flowtype errors for PushNotificationIOS

### DIFF
--- a/Libraries/PushNotificationIOS/PushNotificationIOS.js
+++ b/Libraries/PushNotificationIOS/PushNotificationIOS.js
@@ -201,7 +201,7 @@ class PushNotificationIOS {
    * - `userInfo`  : An optional object containing additional notification data.
    * - `thread-id`  : The thread identifier of this notification, if has one.
    */
-  static getDeliveredNotifications(callback: (notifications: [Object]) => void): void {
+  static getDeliveredNotifications(callback: (notifications: Array<Object>) => void): void {
     RCTPushNotificationManager.getDeliveredNotifications(callback);
   }
 
@@ -210,7 +210,7 @@ class PushNotificationIOS {
    *
    * @param identifiers Array of notification identifiers
    */
-  static removeDeliveredNotifications(identifiers: [string]): void {
+  static removeDeliveredNotifications(identifiers: Array<string>): void {
     RCTPushNotificationManager.removeDeliveredNotifications(identifiers);
   }
 


### PR DESCRIPTION
Flow syntax is wrong, instead of using `Array` author used syntax for [tuples](https://flow.org/en/docs/types/tuples/). Tested with flow 0.49.1.
## Test Plan
1. Import `removeDeliveredNotifications` in your code and pass an array with more than one element.
2. Test with flow.
