### PR TITLE
Fix local cached file loaded error

### DIFF
--- a/Libraries/Network/RCTNetworkTask.m
+++ b/Libraries/Network/RCTNetworkTask.m
@@ -75,7 +75,9 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
     id token = [_handler sendRequest:_request withDelegate:self];
     if ([self validateRequestToken:token]) {
       _selfReference = self;
-      _status = RCTNetworkTaskInProgress;
+      if (_status == RCTNetworkTaskPending) {
+        _status = RCTNetworkTaskInProgress;
+      }
     }
   }
 }


### PR DESCRIPTION
 #15492 

When using `RCTURLRequestHandler` to load images from local cached files, unexpected loading error may happened. 
When using local cached image, we will use `dispatch_async` for `RCTURLRequestDelegate` callbacks,like this:

```
- (id)sendRequest:(NSURLRequest *)request
     withDelegate:(id<RCTURLRequestDelegate>)delegate {
  dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
    NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:request.URL
                                                             statusCode:200
                                                            HTTPVersion:@"HTTP/1.1"
                                                           headerFields:nil];
    [delegate URLRequest:request didReceiveResponse:response];
    static dispatch_once_t onceToken;
    dispatch_once(&onceToken, ^{
      cachedData = [NSData dataWithContentsOfFile:[[NSBundle mainBundle] pathForResource:@"react" ofType:@"png"]];
    });
    [delegate URLRequest:request didReceiveData:cachedData];
    [delegate URLRequest:request didCompleteWithError:nil];
  });
  return request;
}

```

But sometimes the `dispatch_async` function was excuted much faster than current thread. Then the `URLRequest: didCompleteWithError` callback  will be called before `_status = RCTNetworkTaskInProgress` excution in `[RCTNetworkTask start]`. So this `RCTNetworkTask` will be RCTNetworkTaskInProgress forever. After this kind  of error happened more than the `maxConcurrentLoadingTasks` of `RCTImageLoader` , no more `RCTNetworkTask` will start in `dequeueTasks`. Then the last images will never be loaded.

So I just add a simple judge to avoid this problem.


