### PR TITLE
`onAnimatedValueUpdate` should also include offset

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/animated/ValueAnimatedNode.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/animated/ValueAnimatedNode.java
@@ -49,7 +49,7 @@ import javax.annotation.Nullable;
     if (mValueListener == null) {
       return;
     }
-    mValueListener.onValueUpdate(mValue);
+    mValueListener.onValueUpdate(getValue());
   }
 
   public void setValueListener(@Nullable AnimatedNodeValueListener listener) {


### PR DESCRIPTION
Native Android implementation of animation listeners reports value only, and does not include offset. For non-native animation, the JavaScript listeners receive the animated node value + the animated node offset. Here's where the JavaScript node calls the listeners:
https://github.com/facebook/react-native/blob/046f600cc23ff2d4aeb57be8e5606347f19b76d2/Libraries/Animated/src/AnimatedImplementation.js#L942
 and here's how `__getValue()` is calculated:
 https://github.com/facebook/react-native/blob/046f600cc23ff2d4aeb57be8e5606347f19b76d2/Libraries/Animated/src/AnimatedImplementation.js#L741-L743

cc @janicduplessis @kmagiera 