### PR TITLE
Use offset adjusted value in ModulusAnimatedNode

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/animated/ModulusAnimatedNode.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/animated/ModulusAnimatedNode.java
@@ -31,7 +31,7 @@ import com.facebook.react.bridge.ReadableMap;
   public void update() {
     AnimatedNode animatedNode = mNativeAnimatedNodesManager.getNodeById(mInputNode);
     if (animatedNode != null && animatedNode instanceof ValueAnimatedNode) {
-      mValue = ((ValueAnimatedNode) animatedNode).mValue % mModulus;
+      mValue = ((ValueAnimatedNode) animatedNode).getValue() % mModulus;
     } else {
       throw new JSApplicationCausedNativeException("Illegal node ID set as an input for " +
         "Animated.modulus node");


### PR DESCRIPTION
Modulus animation computation should use the value adjusted for offset, not the raw value.

See the JS implementation here:
https://github.com/facebook/react-native/blob/master/Libraries/Animated/src/AnimatedImplementation.js#L1338

cc @ryangomba 