### PR TITLE
Make prospective syntax compatible

### DIFF
--- a/setupBabel.js
+++ b/setupBabel.js
@@ -28,15 +28,15 @@ function buildRegExps(basePath, dirPaths) {
       folderPath instanceof RegExp
         ? new RegExp(
             `^${escapeRegExp(
-              path.resolve(basePath, '.').replace(/\\/g, '/'),
+              path.resolve(basePath, '.').replace(/\\/g, '/')
             )}/${folderPath.source}`,
-            folderPath.flags,
+            folderPath.flags
           )
         : new RegExp(
             `^${escapeRegExp(
-              path.resolve(basePath, folderPath).replace(/\\/g, '/'),
-            )}`,
-          ),
+              path.resolve(basePath, folderPath).replace(/\\/g, '/')
+            )}`
+          )
   );
 }
 


### PR DESCRIPTION
## Problem

Can't run `RNTester` app and got the error below:

![image](https://user-images.githubusercontent.com/6890034/29361000-1ae6cfce-82b8-11e7-9522-b827de2712f7.png)

## Resolution

Make prospective syntax(trailing commas in function parameter lists and calls, supported in ES8) compatible.

## Test Plan

If correct, the `RNTester` can be started.