### PR TITLE
Docs component grid laid out with CSS Grid

### DIFF
--- a/website/src/react-native/css/react-native.css
+++ b/website/src/react-native/css/react-native.css
@@ -1764,6 +1764,13 @@ input#algolia-doc-search:focus {
   margin: 2px;
 }
 
+@supports (display:grid) {
+  .component-grid {
+    display: grid;
+    grid-gap: 22px;
+  }
+}
+
 @media only screen and (min-device-width: 768px) {
   .component-grid {
     width: 768px;
@@ -1776,6 +1783,17 @@ input#algolia-doc-search:focus {
     height: 150px;
     margin: 0 22px 22px auto;
     vertical-align: top;
+  }
+
+  @supports (display:grid) {
+    .component-grid {
+      grid-template-columns: 1fr 1fr 1fr;
+    }
+    .component {
+      width: auto;
+      height: auto;
+      margin: 0;
+    }
   }
 }
 

--- a/website/src/react-native/css/react-native.css
+++ b/website/src/react-native/css/react-native.css
@@ -1787,7 +1787,7 @@ input#algolia-doc-search:focus {
 
   @supports (display:grid) {
     .component-grid {
-      grid-template-columns: 1fr 1fr 1fr;
+      grid-template-columns: repeat(3, 1fr);
     }
     .component {
       width: auto;


### PR DESCRIPTION
## Summary

The component grid on Components and APIs
https://facebook.github.io/react-native/docs/components-and-apis.html
has a set height for each item. This causes content to overflow their
containers.

Before: 
![image](https://user-images.githubusercontent.com/1337003/29373309-b67c0dea-82a5-11e7-9850-003d66571df2.png)

After:
![image](https://user-images.githubusercontent.com/1337003/29373337-d32b7214-82a5-11e7-8d12-958be9ff81aa.png)

I've quickly fixed this with CSS Grid. There is much more room for
improvement, but this prevents it being visually broken.

Tested by locally rendering. Jest passes OK.

## Test Plan

Run docs website locally. Visually confirm correct rendering.