### PR TITLE
iOS: Fix registration for UIContentSizeCategoryDidChangeNotification

### DIFF
--- a/React/Modules/RCTAccessibilityManager.m
+++ b/React/Modules/RCTAccessibilityManager.m
@@ -65,7 +65,7 @@ RCT_EXPORT_MODULE()
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(didReceiveNewContentSizeCategory:)
                                                  name:UIContentSizeCategoryDidChangeNotification
-                                               object:RCTSharedApplication()];
+                                               object:nil];
 
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(didReceiveNewVoiceOverStatus:)


### PR DESCRIPTION
On an iPhone running iOS 10.3.3, I'm not seeing the UIContentSizeCategoryDidChangeNotification fire when changing the system's font scale setting. Registering for the event on `nil` instead of on the application object fixes the issue.

**Test Plan**

Verified that text in an RN app changes size when you change the system's font scale setting (Settings -> General -> Accessibility -> Larger Text). By default, RN text is supposed to scale with the system setting.

Adam Comella
Microsoft Corp.