### PR TITLE
BREAKING: iOS: Fix case sensitivity build warning in Xcode 8.3

### DIFF
--- a/React.podspec
+++ b/React.podspec
@@ -42,7 +42,7 @@ Pod::Spec.new do |s|
   s.cocoapods_version       = ">= 1.2.0"
 
   s.subspec "Core" do |ss|
-    ss.dependency             "Yoga", "#{package["version"]}.React"
+    ss.dependency             "yoga", "#{package["version"]}.React"
     ss.source_files         = "React/**/*.{c,h,m,mm,S}"
     ss.exclude_files        = "**/__tests__/*",
                               "IntegrationTests/*",

--- a/ReactCommon/yoga/Yoga.podspec
+++ b/ReactCommon/yoga/Yoga.podspec
@@ -10,7 +10,7 @@ else
 end
 
 Pod::Spec.new do |spec|
-  spec.name = 'Yoga'
+  spec.name = 'yoga'
   spec.version = "#{version}.React"
   spec.license =  { :type => 'BSD' }
   spec.homepage = 'https://facebook.github.io/yoga/'

--- a/docs/IntegrationWithExistingApps.md
+++ b/docs/IntegrationWithExistingApps.md
@@ -223,7 +223,7 @@ target 'NumberTileGame' do
     # Add any other subspecs you want to use in your project
   ]
   # Explicitly include Yoga if you are using RN >= 0.42.0
-  pod 'Yoga', :path => '../node_modules/react-native/ReactCommon/yoga'
+  pod 'yoga', :path => '../node_modules/react-native/ReactCommon/yoga'
 
 end
 ```
@@ -252,7 +252,7 @@ target 'swift-2048' do
     # Add any other subspecs you want to use in your project
   ]
   # Explicitly include Yoga if you are using RN >= 0.42.0
-  pod "Yoga", :path => "../node_modules/react-native/ReactCommon/yoga"
+  pod "yoga", :path => "../node_modules/react-native/ReactCommon/yoga"
 
 end
 ```


### PR DESCRIPTION
**Breaking Change Notes**

To adapt to the breaking change, app developers that are consuming React Native through CocoaPods must update their Podfile to refer to yoga with a lowercase "y". In other words:

    pod 'Yoga', :path => '../node_modules/react-native/ReactCommon/yoga'

Must be changed to (note the lowercase "y"):

    pod 'yoga', :path => '../node_modules/react-native/ReactCommon/yoga'

**Symptom**

If you consume React Native as a CocoaPod and consume a third-party React Native module not as a CocoaPod, you will receive a `nonportable-include-path` warning in Xcode >= 8.3.

**Details**

Xcode 8.3 introduced -Wnonportable-include-path which triggers if you import a header using different casing than the path to the header on disk. This triggers when consuming React Native as a CocoaPod from a library that isn't a CocoaPod. React Native imports Yoga using paths like this:

    #import <yoga/Yoga.h>

Which means Yoga's headers are expected to be located in a directory called "yoga" with a lowercase "y". However, when React Native is a CocoaPod the Yoga headers for non-CocoaPods end up in the directory "$(BUILT_PRODUCTS_DIR)/Yoga".

To fix this such that Yoga's headers end up in "$(BUILT_PRODUCTS_DIR)/yoga" (note the lowercase "y"), I've changed Yoga's podspec name to have a lowercase "y".

**Test Plan**

Created a test app where React Native is consumed as a CocoaPod. Added the react-native-maps library to the project and configured it to not be consumed through CocoaPods. Verified that the app compiles properly without the `nonportable-include-path` warnings.

Adam Comella
Microsoft Corp.
