### PR TITLE
Remove 'box-only' as a layoutOnlyProp

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewProps.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewProps.java
@@ -168,7 +168,7 @@ public class ViewProps {
       return true;
     } else if (POINTER_EVENTS.equals(prop)) {
       String value = map.getString(prop);
-      return "auto".equals(value) || "box-none".equals(value);
+      return "auto".equals(value);
     } else {
       return false;
     }


### PR DESCRIPTION
Currently, having the property `pointerEvents={'box-only'}` marks a view as layoutOnly. For optimization reasons, layoutOnly nodes are [not added to the node hierarchy](https://github.com/facebook/react-native/blob/b103903ec869bc48dfcaf001dc926957d0b5200a/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeViewHierarchyOptimizer.java#L99) The problem is that should this box ever need to be [transitioned to not-layout-only](https://github.com/facebook/react-native/blob/b103903ec869bc48dfcaf001dc926957d0b5200a/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeViewHierarchyOptimizer.java#L394) (for example, because you add the a CSS transform property),  it must be added to the hierarchy. To add it to the hierarchy the [React Styles Diff Map](https://github.com/facebook/react-native/blob/b103903ec869bc48dfcaf001dc926957d0b5200a/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeViewHierarchyOptimizer.java#L396) is passed along with the backing shadowNode to create the node. The problem is that at no point were the original `pointerEvents` and so the new node will be created with `pointerEvents =  'auto'`.

A more correct fix to this problem might be to have shadowNodes carry around their pointerEvents, although this is likely a greater design decision which is why am I proposing the quick fix now.

Will also resolve: https://github.com/react-native-community/react-native-modal/issues/11
