### PR TITLE
Remove request dependency from core directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -178,7 +178,6 @@
     "react-devtools-core": "^2.5.0",
     "react-timer-mixin": "^0.13.2",
     "regenerator-runtime": "^0.9.5",
-    "request": "^2.79.0",
     "rimraf": "^2.5.4",
     "semver": "^5.0.3",
     "shell-quote": "1.6.1",


### PR DESCRIPTION
request is an unnecessary dependency of the core package as it is only used in the /website directory as a required primary dependency.

## Test Plan

request is only used in the /website directory. Searched entire package with regex.

`/require\(('|")request+\('|"))/gi`

All applicable local tests passed!

![image](https://user-images.githubusercontent.com/14060354/29438186-dade7ba4-8369-11e7-923b-efef0d208e53.png)
