### PR TITLE
Android WebView: Only fire onLoadStart for toplevel page loads

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebViewManager.java
@@ -174,17 +174,6 @@ public class ReactWebViewManager extends SimpleViewManager<WebView> {
           new TopLoadingErrorEvent(webView.getId(), eventData));
     }
 
-    @Override
-    public void doUpdateVisitedHistory(WebView webView, String url, boolean isReload) {
-      super.doUpdateVisitedHistory(webView, url, isReload);
-
-      dispatchEvent(
-          webView,
-          new TopLoadingStartEvent(
-              webView.getId(),
-              createWebViewEvent(webView, url)));
-    }
-
     protected void emitFinishEvent(WebView webView, String url) {
       dispatchEvent(
           webView,


### PR DESCRIPTION
Currently, `onLoadStart` fires for a couple of cases:
  1. toplevel page loads (e.g. initial page load, clicking links)
  2. loading of pages within an iframe

The fact that `onLoadStart` fires for case (2) causes some problems. For example, it makes it difficult for the code that uses the WebView to know what URL the WebView is currently rendering. This is because the listener can't distinguish between the toplevel URL and the URL of an iframe. Additionally, this behavior is inconsistent with the behavior on iOS. On iOS, `onLoadStart` only fires for toplevel page loads.

To fix these issues, this change deletes the `doUpdateVisitedHistory` handler so that `onLoadStart` only fires for case (1).

**Test Plan**

Created a test page that has an iframe and loaded it in the WebView. Verified that `onLoadStart` only fires for toplevel page loads.

Adam Comella
Microsoft Corp.
