### PR TITLE
Android Oreo (8.0) Support

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/DebugOverlayController.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/DebugOverlayController.java
@@ -40,7 +40,7 @@ import com.facebook.react.bridge.ReactContext;
       WindowManager.LayoutParams params = new WindowManager.LayoutParams(
           WindowManager.LayoutParams.MATCH_PARENT,
           WindowManager.LayoutParams.MATCH_PARENT,
-          WindowManager.LayoutParams.TYPE_SYSTEM_OVERLAY,
+          WindowOverlayCompat.TYPE_SYSTEM_OVERLAY,
           WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE
               | WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE,
           PixelFormat.TRANSLUCENT);

--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevLoadingViewController.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevLoadingViewController.java
@@ -143,7 +143,7 @@ public class DevLoadingViewController {
       WindowManager.LayoutParams params = new WindowManager.LayoutParams(
         WindowManager.LayoutParams.MATCH_PARENT,
         WindowManager.LayoutParams.WRAP_CONTENT,
-        WindowManager.LayoutParams.TYPE_SYSTEM_OVERLAY,
+        WindowOverlayCompat.TYPE_SYSTEM_OVERLAY,
         WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE,
         PixelFormat.TRANSLUCENT);
       params.gravity = Gravity.TOP;

--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerImpl.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerImpl.java
@@ -36,7 +36,6 @@ import android.content.pm.PackageManager;
 import android.hardware.SensorManager;
 import android.net.Uri;
 import android.os.AsyncTask;
-import android.view.WindowManager;
 import android.widget.Toast;
 
 import com.facebook.common.logging.FLog;
@@ -337,7 +336,7 @@ public class DevSupportManagerImpl implements
           public void run() {
             if (mRedBoxDialog == null) {
               mRedBoxDialog = new RedBoxDialog(mApplicationContext, DevSupportManagerImpl.this, mRedBoxHandler);
-              mRedBoxDialog.getWindow().setType(WindowManager.LayoutParams.TYPE_SYSTEM_ALERT);
+              mRedBoxDialog.getWindow().setType(WindowOverlayCompat.TYPE_SYSTEM_ALERT);
             }
             if (mRedBoxDialog.isShowing()) {
               // Sometimes errors cause multiple errors to be thrown in JS in quick succession. Only
@@ -466,7 +465,7 @@ public class DevSupportManagerImpl implements
               }
             })
             .create();
-    mDevOptionsDialog.getWindow().setType(WindowManager.LayoutParams.TYPE_SYSTEM_ALERT);
+    mDevOptionsDialog.getWindow().setType(WindowOverlayCompat.TYPE_SYSTEM_ALERT);
     mDevOptionsDialog.show();
   }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/WindowOverlayCompat.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/WindowOverlayCompat.java
@@ -1,0 +1,18 @@
+package com.facebook.react.devsupport;
+
+import android.os.Build;
+import android.view.WindowManager;
+
+/**
+ * Compatibility wrapper for apps targeting API level 26 or later.
+ * See https://developer.android.com/about/versions/oreo/android-8.0-changes.html#cwt
+ */
+/* package */ class WindowOverlayCompat {
+
+  private static final int ANDROID_OREO = 26;
+  private static final int TYPE_APPLICATION_OVERLAY = 2038;
+
+  static final int TYPE_SYSTEM_ALERT = Build.VERSION.SDK_INT < ANDROID_OREO ? WindowManager.LayoutParams.TYPE_SYSTEM_ALERT : TYPE_APPLICATION_OVERLAY;
+  static final int TYPE_SYSTEM_OVERLAY = Build.VERSION.SDK_INT < ANDROID_OREO ? WindowManager.LayoutParams.TYPE_SYSTEM_OVERLAY : TYPE_APPLICATION_OVERLAY;
+
+}


### PR DESCRIPTION
Apps targeting Android 8.0 (API level 26) cannot use `TYPE_SYSTEM_OVERLAY ` and `TYPE_SYSTEM_OVERLAY `. Targeting 26 will cause the app to crash when in `DEV_MODE`.

https://developer.android.com/about/versions/oreo/android-8.0-changes.html#cwt

This PR replaces uses of these overlay flags with the new `TYPE_APPLICATION_OVERLAY` when running on a device with Android 8.0 or later.

When using `TYPE_APPLICATION_OVERLAY` it still requires the `SYSTEM_ALERT_WINDOW` permission, just like previous android versions.
https://developer.android.com/reference/android/view/WindowManager.LayoutParams.html#TYPE_APPLICATION_OVERLAY

## Test Plan

https://github.com/AndrewJack/react-native-android-oreo tested here
