### PR TITLE
Return meaningful error when no devices available

### DIFF
--- a/local-cli/runIOS/runIOS.js
+++ b/local-cli/runIOS/runIOS.js
@@ -50,7 +50,7 @@ function runIOS(argv, config, args) {
     if (selectedDevice){
       return runOnDevice(selectedDevice, scheme, xcodeProject, args.configuration, args.packager);
     } else {
-      if (devices){
+      if (devices && devices.length > 0){
         console.log('Could not find device with the name: "' + args.device + '".');
         console.log('Choose one of the following:');
         printFoundDevices(devices);
@@ -70,7 +70,7 @@ function runOnDeviceByUdid(args, scheme, xcodeProject, devices) {
   if (selectedDevice){
     return runOnDevice(selectedDevice, scheme, xcodeProject, args.configuration, args.packager);
   } else {
-    if (devices){
+    if (devices && devices.length > 0){
       console.log('Could not find device with the udid: "' + args.udid + '".');
       console.log('Choose one of the following:');
       printFoundDevices(devices);

--- a/local-cli/runIOS/runIOS.js
+++ b/local-cli/runIOS/runIOS.js
@@ -47,10 +47,10 @@ function runIOS(argv, config, args) {
   );
   if (args.device) {
     const selectedDevice = matchingDevice(devices, args.device);
-    if (selectedDevice){
+    if (selectedDevice) {
       return runOnDevice(selectedDevice, scheme, xcodeProject, args.configuration, args.packager);
     } else {
-      if (devices && devices.length > 0){
+      if (devices && devices.length > 0) {
         console.log('Could not find device with the name: "' + args.device + '".');
         console.log('Choose one of the following:');
         printFoundDevices(devices);
@@ -67,10 +67,10 @@ function runIOS(argv, config, args) {
 
 function runOnDeviceByUdid(args, scheme, xcodeProject, devices) {
   const selectedDevice = matchingDeviceByUdid(devices, args.udid);
-  if (selectedDevice){
+  if (selectedDevice) {
     return runOnDevice(selectedDevice, scheme, xcodeProject, args.configuration, args.packager);
   } else {
-    if (devices && devices.length > 0){
+    if (devices && devices.length > 0) {
       console.log('Could not find device with the udid: "' + args.udid + '".');
       console.log('Choose one of the following:');
       printFoundDevices(devices);
@@ -80,7 +80,7 @@ function runOnDeviceByUdid(args, scheme, xcodeProject, devices) {
   }
 }
 
-function runOnSimulator(xcodeProject, args, scheme){
+function runOnSimulator(xcodeProject, args, scheme) {
   return new Promise((resolve) => {
     try {
       var simulators = JSON.parse(
@@ -205,7 +205,7 @@ function formattedDeviceName(simulator) {
   return `${simulator.name} (${simulator.version})`;
 }
 
-function printFoundDevices(devices){
+function printFoundDevices(devices) {
   for (let i = devices.length - 1; i >= 0; i--) {
     console.log(devices[i].name + ' Udid: ' + devices[i].udid);
   }


### PR DESCRIPTION
`react-native run-ios --device` should report 'No iOS devices connected.' in case when no devices attached. However due to logic bug when empty array is being treatened as a boolean value, cli reports odd message, saying `Could not find device with the name: "true".`

## Test Plan

Disconnect all iOS devices from developer machine and run `react-native run-ios --device` in any project - console message should state that there are no devices available.
