### PR TITLE
Fixed issue with path containing spaces

### DIFF
--- a/scripts/react-native-xcode.sh
+++ b/scripts/react-native-xcode.sh
@@ -105,7 +105,7 @@ fi
 
 BUNDLE_FILE="$DEST/main.jsbundle"
 
-$NODE_BINARY $CLI_PATH bundle \
+$NODE_BINARY "$CLI_PATH" bundle \
   --entry-file "$ENTRY_FILE" \
   --platform ios \
   --dev $DEV \


### PR DESCRIPTION
If the project is in a folder with a path containing a space, the project won't build. This fixes this issue.