### PR TITLE
iOS ScrollView: Add scrollBy method

### DIFF
--- a/Libraries/Components/ScrollResponder.js
+++ b/Libraries/Components/ScrollResponder.js
@@ -439,6 +439,21 @@ var ScrollResponderMixin = {
   },
 
   /**
+   * A helper function to scroll by a specific offset in the ScrollView.
+   * This is useful when you want to change the size of the content view and scroll 
+   * position at the same time. Syntax:
+   *
+   * scrollResponderScrollBy(options: {deltaX: number = 0; deltaY: number = 0; animated: boolean = true})
+   */
+  scrollResponderScrollBy: function(options : {deltaX?: number, deltaY?: number, animated?: boolean}) {
+    UIManager.dispatchViewManagerCommand(
+      this.scrollResponderGetScrollableNode(),
+      UIManager.RCTScrollView.Commands.scrollBy,
+      [options.deltaX || 0, options.deltaY || 0, options.animated !== false],
+    );
+  },
+
+  /**
    * Deprecated, do not use.
    */
   scrollResponderScrollWithoutAnimationTo: function(offsetX: number, offsetY: number) {

--- a/Libraries/Components/ScrollResponder.js
+++ b/Libraries/Components/ScrollResponder.js
@@ -440,7 +440,7 @@ var ScrollResponderMixin = {
 
   /**
    * A helper function to scroll by a specific offset in the ScrollView.
-   * This is useful when you want to change the size of the content view and scroll 
+   * This is useful when you want to change the size of the content view and scroll
    * position at the same time. Syntax:
    *
    * scrollResponderScrollBy(options: {deltaX: number = 0; deltaY: number = 0; animated: boolean = true})

--- a/Libraries/Components/ScrollView/ScrollView.js
+++ b/Libraries/Components/ScrollView/ScrollView.js
@@ -531,6 +531,19 @@ const ScrollView = createReactClass({
   },
 
   /**
+   * Scrolls by a given offset, either immediately or with a smooth animation.
+   *
+   * Syntax:
+   *
+   * `scrollBy(options: {deltaX: number = 0; deltaY: number = 0; animated: boolean = true})`
+   */
+  scrollBy: function(options: { deltaX?: number, deltaY?: number, animated?: boolean } ) {
+    const data = {deltaX: options.deltaX || 0, deltaY: options.deltaY || 0, 
+      animated: options.animated !== false};
+    this.getScrollResponder().scrollResponderScrollBy(data);
+  },
+
+  /**
    * Deprecated, use `scrollTo` instead.
    */
   scrollWithoutAnimationTo: function(y: number = 0, x: number = 0) {

--- a/Libraries/Components/ScrollView/ScrollView.js
+++ b/Libraries/Components/ScrollView/ScrollView.js
@@ -538,7 +538,7 @@ const ScrollView = createReactClass({
    * `scrollBy(options: {deltaX: number = 0; deltaY: number = 0; animated: boolean = true})`
    */
   scrollBy: function(options: { deltaX?: number, deltaY?: number, animated?: boolean } ) {
-    const data = {deltaX: options.deltaX || 0, deltaY: options.deltaY || 0, 
+    const data = {deltaX: options.deltaX || 0, deltaY: options.deltaY || 0,
       animated: options.animated !== false};
     this.getScrollResponder().scrollResponderScrollBy(data);
   },

--- a/React/Views/RCTScrollView.m
+++ b/React/Views/RCTScrollView.m
@@ -587,6 +587,17 @@ static inline void RCTApplyTranformationAccordingLayoutDirection(UIView *view, U
   }
 }
 
+- (void)scrollByOffset:(CGPoint)offset animated:(BOOL)animated
+{
+  if (offset.x != 0 || offset.y != 0) {
+    // Ensure at least one scroll event will fire
+    _allowNextScrollNoMatterWhat = YES;
+    CGPoint oldOffset = _scrollView.contentOffset;
+    CGPoint newOffset = (CGPoint){oldOffset.x + offset.x, oldOffset.y + offset.y};
+    [_scrollView setContentOffset:newOffset animated:animated];
+  }
+}
+
 - (void)zoomToRect:(CGRect)rect animated:(BOOL)animated
 {
   [_scrollView zoomToRect:rect animated:animated];

--- a/React/Views/RCTScrollViewManager.m
+++ b/React/Views/RCTScrollViewManager.m
@@ -175,6 +175,23 @@ RCT_EXPORT_METHOD(scrollToEnd:(nonnull NSNumber *)reactTag
    }];
 }
 
+RCT_EXPORT_METHOD(scrollBy:(nonnull NSNumber *)reactTag
+                  deltaX:(CGFloat)deltaX
+                  deltaY:(CGFloat)deltaY
+                  animated:(BOOL)animated)
+{
+  [self.bridge.uiManager addUIBlock:
+   ^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry){
+     UIView *view = viewRegistry[reactTag];
+     if ([view conformsToProtocol:@protocol(RCTScrollableProtocol)]) {
+       [(id<RCTScrollableProtocol>)view scrollByOffset:(CGPoint){deltaX, deltaY} animated:animated];
+     } else {
+       RCTLogError(@"tried to scrollBy: on non-RCTScrollableProtocol view %@ "
+                   "with tag #%@", view, reactTag);
+     }
+   }];
+}
+
 RCT_EXPORT_METHOD(zoomToRect:(nonnull NSNumber *)reactTag
                   withRect:(CGRect)rect
                   animated:(BOOL)animated)

--- a/React/Views/RCTScrollableProtocol.h
+++ b/React/Views/RCTScrollableProtocol.h
@@ -19,6 +19,7 @@
 
 - (void)scrollToOffset:(CGPoint)offset;
 - (void)scrollToOffset:(CGPoint)offset animated:(BOOL)animated;
+- (void)scrollByOffset:(CGPoint)offset animated:(BOOL)animated;
 /**
  * If this is a vertical scroll view, scrolls to the bottom.
  * If this is a horizontal scroll view, scrolls to the right.


### PR DESCRIPTION
Android PR: facebook/react-native#15610

**General Motivation**

Currently, React Native allows you to scroll a ScrollView to a particular position using `scrollTo`. If instead you want to scroll by a delta, you could try to do this using `scrollTo` (add the delta to the current scroll position) but this doesn't always work out as intended due to the async nature of React Native (what you think is the current scroll position might be a stale value). This change introduces a `scrollBy` API to solve this problem. `scrollBy` takes a delta to scroll by and native takes care of doing the arithmetic because it knows the latest scroll position.

**Example**

We have a vertical virtualized list view where all of the items are absolutely positioned. The item positions are controlled by `AnimatedValues` because we want to avoid having to go through the diffing process to move them.

A scenario where `scrollBy` is useful is when we load items above the user's viewport which causes the `y` position of items in the viewport to change. If we didn't do anything additional, this would cause the items the user is looking at to fly off of the screen. To avoid this, we update the scroll position (by the amount the `y` coordinate of the viewport items changed) and update the `y` coordinates at the same time.

We initially tried to do this with `scrollTo` by adding the current scroll position to the `y` coordinate delta. However, sometimes the current scroll position value was stale by the time `scrollTo` ran which caused us to scroll to the wrong position and for the user to perceive a jumpiness. Consequently, we've introduced a native `scrollBy` implementation so we don't have to worry about using a stale value for current scroll position.

**Test Plan**

In a test app, verified that `scrollBy` works properly with and without animation and for both horizontal and vertical `ScrollViews`. Also, my team is using this change in our app.

Adam Comella
Microsoft Corp.
