### PR TITLE
Add ProGuard rules fixes #11891 #6624

### DIFF
--- a/local-cli/templates/HelloWorld/android/app/proguard-rules.pro
+++ b/local-cli/templates/HelloWorld/android/app/proguard-rules.pro
@@ -68,3 +68,23 @@
 -dontwarn java.nio.file.*
 -dontwarn org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
 -dontwarn okio.**
+
+# com.facebook.react.uimanager.UIProp
+
+-keep class com.facebook.react.uimanager.UIProp { *; }
+-keep class sun.misc.Unsafe { *; }
+
+# RN 0.41+
+# https://github.com/facebook/react-native/issues/11891
+# -dontwarn com.facebook.fbui.textlayoutbuilder.proxy.StaticLayoutProxy
+# This library uses a non-public Android constructor within StaticLayout.
+# See libs/proxy/src/main/java/com/facebook/fbui/textlayoutbuilder/proxy for details.
+-dontwarn android.text.StaticLayout
+
+# https://github.com/facebook/react-native/issues/6624
+-keep class com.facebook.react.cxxbridge.ModuleRegistryHolder { *; }
+-keep class com.facebook.react.cxxbridge.CatalystInstanceImpl { *; }
+-keep class com.facebook.react.cxxbridge.JavaScriptExecutor { *; }
+-keep class com.facebook.react.bridge.queue.NativeRunnable { *; }
+-keep class com.facebook.react.bridge.ExecutorToken { *; }
+-keep class com.facebook.react.bridge.ReadableType { *; }

--- a/local-cli/templates/HelloWorld/android/app/proguard-rules.pro
+++ b/local-cli/templates/HelloWorld/android/app/proguard-rules.pro
@@ -82,9 +82,9 @@
 -dontwarn android.text.StaticLayout
 
 # https://github.com/facebook/react-native/issues/6624
--keep class com.facebook.react.cxxbridge.ModuleRegistryHolder { *; }
--keep class com.facebook.react.cxxbridge.CatalystInstanceImpl { *; }
--keep class com.facebook.react.cxxbridge.JavaScriptExecutor { *; }
+-keep class com.facebook.react.bridge.ModuleRegistryHolder { *; }
+-keep class com.facebook.react.bridge.CatalystInstanceImpl { *; }
+-keep class com.facebook.react.bridge.JavaScriptExecutor { *; }
 -keep class com.facebook.react.bridge.queue.NativeRunnable { *; }
 -keep class com.facebook.react.bridge.ExecutorToken { *; }
 -keep class com.facebook.react.bridge.ReadableType { *; }


### PR DESCRIPTION
Trying to build project for Android 7 (O)

## Test Plan

RN 0.47.1

```
        classpath 'com.android.tools.build:gradle:2.3.3' // For Android 7 (O)
```

```
    compile "com.android.support:appcompat-v7:26.0.0-alpha1"
```

```
    buildTypes {
        debug {
            debuggable true
            minifyEnabled enableProguardInReleaseBuilds
            proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro", "devsupport.pro"
            applicationIdSuffix ".debug"
        }
        release {
            signingConfig signingConfigs.release
            minifyEnabled enableProguardInReleaseBuilds
            proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
            manifestPlaceholders = [excludeSystemAlertWindowPermission: "true"]
        }
    }

```


```
    supportLibVersion = '26.0.1'
...
    compileSdkVersion 26
```