### PR TITLE
Android: Fix sizing of TextInput when font scale != 1

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextShadowNode.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextShadowNode.java
@@ -331,11 +331,11 @@ public class ReactTextShadowNode extends LayoutShadowNode {
 
   private float mLineHeight = Float.NaN;
   private boolean mIsColorSet = false;
-  private boolean mAllowFontScaling = true;
   private int mColor;
   private boolean mIsBackgroundColorSet = false;
   private int mBackgroundColor;
 
+  protected boolean mAllowFontScaling = true;
   protected int mNumberOfLines = UNSET;
   protected int mFontSize = UNSET;
   protected float mFontSizeInput = UNSET;

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputShadowNode.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputShadowNode.java
@@ -81,10 +81,13 @@ public class ReactTextInputShadowNode extends ReactTextShadowNode implements
     // measure() should never be called before setThemedContext()
     EditText editText = Assertions.assertNotNull(mEditText);
 
-    editText.setTextSize(
-        TypedValue.COMPLEX_UNIT_PX,
-        mFontSize == UNSET ?
-            (int) Math.ceil(PixelUtil.toPixelFromSP(ViewDefaults.FONT_SIZE_SP)) : mFontSize);
+    float textSize = mFontSize;
+    if (mFontSize == UNSET) {
+      textSize = (int) Math.ceil(mAllowFontScaling
+          ? PixelUtil.toPixelFromSP(ViewDefaults.FONT_SIZE_SP)
+          : PixelUtil.toPixelFromDIP(ViewDefaults.FONT_SIZE_SP));
+    }
+    editText.setTextSize(TypedValue.COMPLEX_UNIT_PX, textSize);
 
     if (mNumberOfLines != UNSET) {
       editText.setLines(mNumberOfLines);


### PR DESCRIPTION
Sometimes, TextInputs on Android have the wrong size. Specifically, this occurs when the user has changed the system's font scale setting, the TextInput has `allowFontScaling={false}`, and the `fontSize` prop isn't set.

To fix this, TextInput's measure function needs to take into account the value of `allowFontScaling`.

**Test Plan**

Created a test app with a multiline `TextInput` which had `numberOfLines` set to `3`. Changed the system's font scale setting and verified that the `TextInput` was tall enough to show exactly 3 lines when `allowFontScaling` was both `true` and `false`.

Here are screenshots for `allowFontScaling={false}`:

**Before**

Notice that the `TextInput` is too short and is clipping the third line.

![image](https://user-images.githubusercontent.com/199935/29646284-65367352-8837-11e7-96bb-48f34b0a2cd2.png)

**After**

Notice that the `TextInput` is tall enough to render exactly three lines of text as expected.

![image](https://user-images.githubusercontent.com/199935/29646275-591dbf30-8837-11e7-9701-f084862a462b.png)

Adam Comella
Microsoft Corp.
