### PR TITLE
Move MethodDescriptor out from JavaModuleWrapper

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/JavaModuleWrapper.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/JavaModuleWrapper.java
@@ -37,17 +37,6 @@ import static com.facebook.systrace.Systrace.TRACE_TAG_REACT_JAVA_BRIDGE;
 
 @DoNotStrip
 public class JavaModuleWrapper {
-  @DoNotStrip
-  public class MethodDescriptor {
-    @DoNotStrip
-    Method method;
-    @DoNotStrip
-    String signature;
-    @DoNotStrip
-    String name;
-    @DoNotStrip
-    String type;
-  }
 
   private final JSInstance mJSInstance;
   private final ModuleHolder mModuleHolder;

--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/MethodDescriptor.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/MethodDescriptor.java
@@ -1,0 +1,21 @@
+package com.facebook.react.bridge;
+
+import com.facebook.proguard.annotations.DoNotStrip;
+
+import java.lang.reflect.Method;
+
+/**
+ * Created by ransj on 2017/8/14.
+ */
+
+@DoNotStrip
+public class MethodDescriptor {
+  @DoNotStrip
+  Method method;
+  @DoNotStrip
+  String signature;
+  @DoNotStrip
+  String name;
+  @DoNotStrip
+  String type;
+}

--- a/ReactAndroid/src/main/jni/react/jni/JavaModuleWrapper.h
+++ b/ReactAndroid/src/main/jni/react/jni/JavaModuleWrapper.h
@@ -16,7 +16,7 @@ class MessageQueueThread;
 
 struct JMethodDescriptor : public jni::JavaClass<JMethodDescriptor> {
   static constexpr auto kJavaDescriptor =
-    "Lcom/facebook/react/bridge/JavaModuleWrapper$MethodDescriptor;";
+    "Lcom/facebook/react/bridge/MethodDescriptor;";
 
   jni::local_ref<JReflectMethod::javaobject> getMethod() const;
   std::string getSignature() const;

--- a/ReactAndroid/src/test/java/com/facebook/react/bridge/BaseJavaModuleTest.java
+++ b/ReactAndroid/src/test/java/com/facebook/react/bridge/BaseJavaModuleTest.java
@@ -36,7 +36,7 @@ public class BaseJavaModuleTest {
   @Rule
   public PowerMockRule rule = new PowerMockRule();
 
-  private List<JavaModuleWrapper.MethodDescriptor> mMethods;
+  private List<MethodDescriptor> mMethods;
   private JavaModuleWrapper mWrapper;
   private ReadableNativeArray mArguments;
 
@@ -49,10 +49,10 @@ public class BaseJavaModuleTest {
     mArguments = PowerMockito.mock(ReadableNativeArray.class);
   }
 
-  private int findMethod(String mname, List<JavaModuleWrapper.MethodDescriptor> methods) {
+  private int findMethod(String mname, List<MethodDescriptor> methods) {
     int posn = -1;
     for (int i = 0; i< methods.size(); i++) {
-      JavaModuleWrapper.MethodDescriptor md = methods.get(i);
+      MethodDescriptor md = methods.get(i);
       if (md.name == mname) {
         posn = i;
         break;


### PR DESCRIPTION
Move MethodDescriptor out from JavaModuleWrapper. This pr aim to enable MethodDescriptor instance out of JavaModuleWrapper and make auto generated code more graceful.

## Test Plan

BaseJavaModuleTest.java had been changed to cover these changes
