### PR TITLE
CallInfo API

### DIFF
--- a/Libraries/Utilities/CallInfo.js
+++ b/Libraries/Utilities/CallInfo.js
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule CallInfo
+ * @flow
+ */
+'use strict';
+
+const Map = require('Map');
+const NativeEventEmitter = require('NativeEventEmitter');
+const NativeModules = require('NativeModules');
+const Platform = require('Platform');
+const RCTCallInfo = NativeModules.CallInfo;
+
+const CallInfoEventEmitter = new NativeEventEmitter(RCTCallInfo);
+
+const CALL_STATE_EVENT = 'callStateDidChange';
+
+const _subscriptions = new Map();
+
+/**
+ * CallInfo exposes info about call status
+ */
+const CallInfo = {
+  /**
+   * Adds an event handler
+   */
+  addEventListener(
+    eventName: string,
+    handler: Function
+  ): {remove: () => void} {
+    let listener;
+    if (eventName === 'change') {
+      listener = CallInfoEventEmitter.addListener(
+        CALL_STATE_EVENT,
+        (appStateData) => {
+          handler(appStateData.phone_state);
+        }
+      );
+    } else {
+      console.warn('Trying to subscribe to unknown event: "' + eventName + '"');
+      return {
+        remove: () => {}
+      };
+    }
+
+    _subscriptions.set(handler, listener);
+    return {
+      remove: () => CallInfo.removeEventListener(eventName, handler)
+    };
+  },
+
+  /**
+   * Removes the listener for call status changes.
+   */
+  removeEventListener(
+    eventName: string,
+    handler: Function
+  ): void {
+    const listener = _subscriptions.get(handler);
+    if (!listener) {
+      return;
+    }
+    listener.remove();
+    _subscriptions.delete(handler);
+  }
+};
+
+module.exports = CallInfo;

--- a/Libraries/react-native/react-native-implementation.js
+++ b/Libraries/react-native/react-native-implementation.js
@@ -85,6 +85,7 @@ const ReactNative = {
   get Linking() { return require('Linking'); },
   get NativeEventEmitter() { return require('NativeEventEmitter'); },
   get NetInfo() { return require('NetInfo'); },
+  get CallInfo() { return require('CallInfo'); },
   get PanResponder() { return require('PanResponder'); },
   get PermissionsAndroid() { return require('PermissionsAndroid'); },
   get PixelRatio() { return require('PixelRatio'); },

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/callinfo/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/callinfo/BUCK
@@ -1,0 +1,21 @@
+include_defs("//ReactAndroid/DEFS")
+
+android_library(
+    name = "callinfo",
+    srcs = glob(["**/*.java"]),
+    provided_deps = [
+        react_native_dep("third-party/android/support/v4:lib-support-v4"),
+    ],
+    visibility = [
+        "PUBLIC",
+    ],
+    deps = [
+        react_native_dep("libraries/fbcore/src/main/java/com/facebook/common/logging:logging"),
+        react_native_dep("third-party/java/infer-annotations:infer-annotations"),
+        react_native_dep("third-party/java/jsr-305:jsr-305"),
+        react_native_target("java/com/facebook/react/bridge:bridge"),
+        react_native_target("java/com/facebook/react/common:common"),
+        react_native_target("java/com/facebook/react/module/annotations:annotations"),
+        react_native_target("java/com/facebook/react/modules/core:core"),
+    ],
+)

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/callinfo/CallInfoModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/callinfo/CallInfoModule.java
@@ -1,0 +1,149 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+package com.facebook.react.modules.callinfo;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.telephony.TelephonyManager;
+
+import com.facebook.react.bridge.LifecycleEventListener;
+import com.facebook.react.bridge.Promise;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContextBaseJavaModule;
+import com.facebook.react.bridge.ReactMethod;
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.bridge.WritableNativeMap;
+import com.facebook.react.module.annotations.ReactModule;
+
+import static com.facebook.react.modules.core.DeviceEventManagerModule.RCTDeviceEventEmitter;
+
+/**
+ * Module that monitors and provides information about the call state of the device.
+ */
+@ReactModule(name = "CallInfo")
+public class CallInfoModule extends ReactContextBaseJavaModule
+    implements LifecycleEventListener {
+
+  private static final String ACTION_PHONE_STATE = "android.intent.action.PHONE_STATE";
+  private static final String ACTION_NEW_OUTGOING_CALL = "android.intent.action.NEW_OUTGOING_CALL";
+
+  private static final String MISSING_PERMISSION_MESSAGE =
+      "To use CallInfo on Android, add the following to your AndroidManifest.xml:\n" +
+      "<uses-permission android:name=\"android.permission.READ_PHONE_STATE\" />\n" +
+      "<uses-permission android:name=\"android.permission.PROCESS_OUTGOING_CALLS\" />";
+
+  private static final String ERROR_MISSING_PERMISSION = "E_MISSING_PERMISSION";
+
+  private static final String CALL_DIRECTION_UNKNOWN = "unknown";
+  private static final String CALL_DIRECTION_INCOMING = "incoming";
+  private static final String CALL_DIRECTION_OUTGOING = "outgoing";
+
+  private static final String PHONE_STATE_UNKNOWN = "unknown";
+  private static final String PHONE_STATE_RINGING = "ringing";
+  private static final String PHONE_STATE_OFFHOOK = "offhook";
+  private static final String PHONE_STATE_IDLE = "idle";
+
+  private final CallBroadcastReceiver mCallBroadcastReceiver;
+  private boolean mNoCallInfoPermission = false;
+
+  private String mCallDirection = CALL_DIRECTION_UNKNOWN;
+  private String mPhoneState = PHONE_STATE_UNKNOWN;
+
+  public CallInfoModule(ReactApplicationContext reactContext) {
+    super(reactContext);
+    mCallBroadcastReceiver = new CallBroadcastReceiver();
+  }
+
+  @Override
+  public void onHostResume() {
+    registerReceiver();
+  }
+
+  @Override
+  public void onHostPause() {
+    unregisterReceiver();
+  }
+
+  @Override
+  public void onHostDestroy() {
+  }
+
+  @Override
+  public void initialize() {
+    getReactApplicationContext().addLifecycleEventListener(this);
+  }
+
+  @Override
+  public String getName() {
+    return "CallInfo";
+  }
+
+  @ReactMethod
+  public void getCurrentState(Promise promise) {
+    if (mNoCallInfoPermission) {
+      promise.reject(ERROR_MISSING_PERMISSION, MISSING_PERMISSION_MESSAGE, null);
+      return;
+    }
+    promise.resolve(createCallInfoEventMap());
+  }
+
+  private void registerReceiver() {
+    IntentFilter filter = new IntentFilter();
+    filter.addAction(ACTION_PHONE_STATE);
+    filter.addAction(ACTION_NEW_OUTGOING_CALL);
+    getReactApplicationContext().registerReceiver(mCallBroadcastReceiver, filter);
+    mCallBroadcastReceiver.setRegistered(true);
+  }
+
+  private void unregisterReceiver() {
+    if (mCallBroadcastReceiver.isRegistered()) {
+      getReactApplicationContext().unregisterReceiver(mCallBroadcastReceiver);
+      mCallBroadcastReceiver.setRegistered(false);
+    }
+  }
+
+  private void sendCallStateChangedEvent() {
+    getReactApplicationContext().getJSModule(RCTDeviceEventEmitter.class)
+        .emit("callStateDidChange", createCallInfoEventMap());
+  }
+
+  private WritableMap createCallInfoEventMap() {
+    WritableMap event = new WritableNativeMap();
+    event.putString("call_direction", mCallDirection);
+    event.putString("phone_state", mPhoneState);
+    return event;
+  }
+
+  /**
+   * Class that receives intents whenever the call state changes.
+   */
+  private class CallBroadcastReceiver extends BroadcastReceiver {
+    private boolean isRegistered = false;
+
+    public void setRegistered(boolean registered) {
+      isRegistered = registered;
+    }
+
+    public boolean isRegistered() {
+      return isRegistered;
+    }
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+      if (intent.getAction().equals(ACTION_PHONE_STATE)) {
+        updateAndSendPhoneState();
+      } else if (intent.getAction().equals(ACTION_NEW_OUTGOING_CALL)) {
+        updateAndSendCallDirection();
+      }
+    }
+  }
+}

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/callinfo/CallInfoModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/callinfo/CallInfoModule.java
@@ -33,9 +33,6 @@ import static com.facebook.react.modules.core.DeviceEventManagerModule.RCTDevice
 public class CallInfoModule extends ReactContextBaseJavaModule
     implements LifecycleEventListener {
 
-  private static final String ACTION_PHONE_STATE = "android.intent.action.PHONE_STATE";
-  private static final String ACTION_NEW_OUTGOING_CALL = "android.intent.action.NEW_OUTGOING_CALL";
-
   private static final String MISSING_PERMISSION_MESSAGE =
       "To use CallInfo on Android, add the following to your AndroidManifest.xml:\n" +
       "<uses-permission android:name=\"android.permission.READ_PHONE_STATE\" />";

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/callinfo/CallInfoModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/callinfo/CallInfoModule.java
@@ -39,6 +39,8 @@ public class CallInfoModule extends ReactContextBaseJavaModule
 
   private static final String ERROR_MISSING_PERMISSION = "E_MISSING_PERMISSION";
 
+  private static final String ACTION_PHONE_STATE = "android.intent.action.PHONE_STATE";
+
   private static final String PHONE_STATE_UNKNOWN = "unknown";
   private static final String PHONE_STATE_RINGING = "ringing";
   private static final String PHONE_STATE_OFFHOOK = "offhook";

--- a/ReactAndroid/src/main/java/com/facebook/react/shell/MainReactPackage.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/shell/MainReactPackage.java
@@ -42,6 +42,7 @@ import com.facebook.react.modules.image.ImageLoaderModule;
 import com.facebook.react.modules.intent.IntentModule;
 import com.facebook.react.modules.location.LocationModule;
 import com.facebook.react.modules.netinfo.NetInfoModule;
+import com.facebook.react.modules.callinfo.CallInfoModule;
 import com.facebook.react.modules.network.NetworkingModule;
 import com.facebook.react.modules.permissions.PermissionsModule;
 import com.facebook.react.modules.share.ShareModule;
@@ -242,6 +243,14 @@ public class MainReactPackage extends LazyReactPackage {
               @Override
               public NativeModule get() {
                 return new NetInfoModule(context);
+              }
+            }),
+        new ModuleSpec(
+            CallInfoModule.class,
+            new Provider<NativeModule>() {
+              @Override
+              public NativeModule get() {
+                return new CallInfoModule(context);
               }
             }),
         new ModuleSpec(


### PR DESCRIPTION
CallInfo is API to listen a call state like 'ringing', 'offhook', 'idle', it's supported only on Android.

```
CallInfo.addEventListener('change', state => {
   ...
})
```

Also I'm going to add 'incoming/outgoing' and 'phone number' information.

How do you think it is a good idea to continue working on this PR? Or it's better to extract it into a separate repo? I would be glad to maintain this feature in react-native.