### PR TITLE
Add snapToInterval support for Android ScrollView

### DIFF
--- a/Libraries/Components/ScrollView/ScrollView.js
+++ b/Libraries/Components/ScrollView/ScrollView.js
@@ -335,8 +335,6 @@ const ScrollView = createReactClass({
      * that have lengths smaller than the scroll view. Typically used in
      * combination with `snapToAlignment` and `decelerationRate="fast"`.
      * Overrides less configurable `pagingEnabled` prop.
-     *
-     * @platform ios
      */
     snapToInterval: PropTypes.number,
     /**

--- a/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.java
@@ -22,6 +22,7 @@ import android.view.View;
 import android.widget.HorizontalScrollView;
 import com.facebook.infer.annotation.Assertions;
 import com.facebook.react.uimanager.MeasureSpecAssertions;
+import com.facebook.react.uimanager.PixelUtil;
 import com.facebook.react.uimanager.ReactClippingViewGroup;
 import com.facebook.react.uimanager.ReactClippingViewGroupHelper;
 import com.facebook.react.uimanager.events.NativeGestureUtil;
@@ -41,6 +42,7 @@ public class ReactHorizontalScrollView extends HorizontalScrollView implements
   private @Nullable Rect mClippingRect;
   private boolean mDragging;
   private boolean mPagingEnabled = false;
+  private double mSnapToInterval;
   private @Nullable Runnable mPostTouchRunnable;
   private boolean mRemoveClippedSubviews;
   private boolean mScrollEnabled = true;
@@ -92,6 +94,10 @@ public class ReactHorizontalScrollView extends HorizontalScrollView implements
 
   public void flashScrollIndicators() {
     awakenScrollBars();
+  }
+
+  public void setSnapToInterval(double snapToInterval) {
+    mSnapToInterval = snapToInterval;
   }
 
   @Override
@@ -235,6 +241,13 @@ public class ReactHorizontalScrollView extends HorizontalScrollView implements
     }
   }
 
+  private int getPageWidth() {
+    if(mSnapToInterval != 0) {
+      return (int) (PixelUtil.toPixelFromDIP(mSnapToInterval) + 0.5);
+    }
+    return getWidth();
+  }
+
   private boolean isScrollPerfLoggingEnabled() {
     return mFpsListener != null && mScrollPerfTag != null && !mScrollPerfTag.isEmpty();
   }
@@ -312,7 +325,7 @@ public class ReactHorizontalScrollView extends HorizontalScrollView implements
    * scrolling.
    */
   private void smoothScrollToPage(int velocity) {
-    int width = getWidth();
+    int width = getPageWidth();
     int currentX = getScrollX();
     // TODO (t11123799) - Should we do anything beyond linear accounting of the velocity
     int predictedX = currentX + velocity;

--- a/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollViewManager.java
@@ -105,6 +105,11 @@ public class ReactHorizontalScrollViewManager
     view.setPagingEnabled(pagingEnabled);
   }
 
+  @ReactProp(name = "snapToInterval")
+  public void setSnapToInterval(ReactHorizontalScrollView view, double snapToInterval) {
+    view.setSnapToInterval(snapToInterval);
+  }
+
   /**
    * Controls overScroll behaviour
    */


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes. 

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to React Native here: http://facebook.github.io/react-native/docs/contributing.html

Happy contributing!

-->

This pull request adds Android support for `snapToInterval` in the `ScrollView` component (it is already implemented for iOS). I need it for a project, so I will be responsive and follow up on any comments on this pull request :)

## Test Plan

The code change is pretty minimal, so it should be easy to reason about. I made a quick bare-bones test project with `react-native init ` and tested it in an android emulator. 

The test project code:
```
export default class ScrollViewTest extends Component {
  render() {
    const width = Dimensions.get('window').width - 32;
    return (
        <ScrollView
          horizontal={true}
          pagingEnabled={true}
          snapToInterval={width}
          >
          <Text style={{width, backgroundColor: 'red'}}>
            Welcome to React Native!
          </Text>
          <Text style={{width, backgroundColor: 'green'}}>
            To get started, edit index.android.js
          </Text>
          <Text style={{width, backgroundColor: 'blue'}}>
            Double tap R on your keyboard to reload,{'\n'}
            Shake or press menu button for dev menu
          </Text>
        </ScrollView>
    );
  }
}
```

A video of it running:
![snaptointerval](https://user-images.githubusercontent.com/578029/29744001-0c99593c-8a9c-11e7-9bac-eae80ad8048c.gif)
