### PR TITLE
typo alertIOS Docs

### DIFF
--- a/Libraries/Alert/AlertIOS.js
+++ b/Libraries/Alert/AlertIOS.js
@@ -86,7 +86,7 @@ export type ButtonsArray = Array<{
  * ```
  * AlertIOS.alert(
  *  'Sync Complete',
- *  'All your data are belong to us.'
+ *  'All your data belongs to us.'
  * );
  * ```
  *


### PR DESCRIPTION
'All your data belongs to us.' instead of 'All your data are belong to us.'

no code was changed