### PR TITLE
Native Animated - Coalesce onValueChanged events on iOS

### DIFF
--- a/Libraries/Animated/src/NativeAnimatedHelper.js
+++ b/Libraries/Animated/src/NativeAnimatedHelper.js
@@ -9,13 +9,13 @@
  */
 'use strict';
 
-import NativeEventEmitter from '../../EventEmitter/NativeEventEmitter';
 import type {
   EventMapping,
   AnimatedNodeConfig,
   AnimatingNodeConfig,
 } from './NativeAnimatedModule';
 import NativeAnimatedModule from './NativeAnimatedModule';
+import RCTDeviceEventEmitter from '../../EventEmitter/RCTDeviceEventEmitter';
 import invariant from 'invariant';
 
 import type {AnimationConfig, EndCallback} from './animations/Animation';
@@ -24,8 +24,6 @@ import type {EventConfig} from './AnimatedEvent';
 
 let __nativeAnimatedNodeTagCount = 1; /* used for animated nodes */
 let __nativeAnimationIdCount = 1; /* used for started animations */
-
-let nativeEventEmitter;
 
 let queueConnections = false;
 let queue = [];
@@ -312,9 +310,6 @@ module.exports = {
   transformDataType,
   // $FlowExpectedError - unsafe getter lint suppresion
   get nativeEventEmitter() {
-    if (!nativeEventEmitter) {
-      nativeEventEmitter = new NativeEventEmitter(NativeAnimatedModule);
-    }
-    return nativeEventEmitter;
+    return RCTDeviceEventEmitter;
   },
 };

--- a/Libraries/NativeAnimation/RCTAnimatedValueChangeEvent.h
+++ b/Libraries/NativeAnimation/RCTAnimatedValueChangeEvent.h
@@ -1,10 +1,8 @@
 /**
- * Copyright (c) 2015-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 #import <React/RCTEventDispatcher.h>

--- a/Libraries/NativeAnimation/RCTAnimatedValueChangeEvent.h
+++ b/Libraries/NativeAnimation/RCTAnimatedValueChangeEvent.h
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <React/RCTEventDispatcher.h>
+
+@interface RCTAnimatedValueChangeEvent : NSObject <RCTEvent>
+
+- (instancetype)initWithNodeTag:(NSNumber *)nodeTag
+                          value:(CGFloat)value NS_DESIGNATED_INITIALIZER;
+
+@end

--- a/Libraries/NativeAnimation/RCTAnimatedValueChangeEvent.m
+++ b/Libraries/NativeAnimation/RCTAnimatedValueChangeEvent.m
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import "RCTAnimatedValueChangeEvent.h"
+
+@implementation RCTAnimatedValueChangeEvent
+{
+  CGFloat _value;
+}
+
+@synthesize viewTag = _viewTag;
+@synthesize eventName = _eventName;
+@synthesize coalescingKey = _coalescingKey;
+
+- (instancetype)initWithNodeTag:(NSNumber *)nodeTag
+                          value:(CGFloat)value
+{
+  if ((self = [super init])) {
+    _eventName = @"onAnimatedValueUpdate";
+    _viewTag = nodeTag;
+    _coalescingKey = 0;
+    _value = value;
+  }
+  return self;
+}
+
+RCT_NOT_IMPLEMENTED(- (instancetype)init)
+
+- (BOOL)canCoalesce
+{
+  return YES;
+}
+
+- (RCTAnimatedValueChangeEvent *)coalesceWithEvent:(RCTAnimatedValueChangeEvent *)newEvent
+{
+  return newEvent;
+}
+
++ (NSString *)moduleDotMethod
+{
+  return @"RCTDeviceEventEmitter.emit";
+}
+
+- (NSArray *)arguments
+{
+  return @[_eventName, @{@"tag": _viewTag, @"value": @(_value)}];
+}
+
+@end

--- a/Libraries/NativeAnimation/RCTAnimatedValueChangeEvent.m
+++ b/Libraries/NativeAnimation/RCTAnimatedValueChangeEvent.m
@@ -19,7 +19,7 @@
 - (instancetype)initWithNodeTag:(NSNumber *)nodeTag
                           value:(CGFloat)value
 {
-  if ((self = [super init])) {
+  if (self = [super init]) {
     _eventName = @"onAnimatedValueUpdate";
     _viewTag = nodeTag;
     _coalescingKey = 0;

--- a/Libraries/NativeAnimation/RCTAnimatedValueChangeEvent.m
+++ b/Libraries/NativeAnimation/RCTAnimatedValueChangeEvent.m
@@ -1,10 +1,8 @@
 /**
- * Copyright (c) 2015-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 #import "RCTAnimatedValueChangeEvent.h"

--- a/Libraries/NativeAnimation/RCTAnimation.xcodeproj/project.pbxproj
+++ b/Libraries/NativeAnimation/RCTAnimation.xcodeproj/project.pbxproj
@@ -17,6 +17,10 @@
 		13E501EE1D07A6C9005F35D8 /* RCTStyleAnimatedNode.m in Sources */ = {isa = PBXBuildFile; fileRef = 13E501E31D07A6C9005F35D8 /* RCTStyleAnimatedNode.m */; };
 		13E501EF1D07A6C9005F35D8 /* RCTTransformAnimatedNode.m in Sources */ = {isa = PBXBuildFile; fileRef = 13E501E51D07A6C9005F35D8 /* RCTTransformAnimatedNode.m */; };
 		13E501F01D07A6C9005F35D8 /* RCTValueAnimatedNode.m in Sources */ = {isa = PBXBuildFile; fileRef = 13E501E71D07A6C9005F35D8 /* RCTValueAnimatedNode.m */; };
+		192EE0091F54CEA00003D5E2 /* RCTAnimatedValueChangeEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = 192EE0071F54CEA00003D5E2 /* RCTAnimatedValueChangeEvent.h */; };
+		192EE00A1F54CEA00003D5E2 /* RCTAnimatedValueChangeEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = 192EE0071F54CEA00003D5E2 /* RCTAnimatedValueChangeEvent.h */; };
+		192EE00B1F54CEA00003D5E2 /* RCTAnimatedValueChangeEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = 192EE0081F54CEA00003D5E2 /* RCTAnimatedValueChangeEvent.m */; };
+		192EE00C1F54CEA00003D5E2 /* RCTAnimatedValueChangeEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = 192EE0081F54CEA00003D5E2 /* RCTAnimatedValueChangeEvent.m */; };
 		192F69811E823F4A008692C7 /* RCTAnimationUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 13E501B71D07A644005F35D8 /* RCTAnimationUtils.h */; };
 		192F69821E823F4A008692C7 /* RCTNativeAnimatedModule.h in Headers */ = {isa = PBXBuildFile; fileRef = 13E501BD1D07A644005F35D8 /* RCTNativeAnimatedModule.h */; };
 		192F69831E823F4A008692C7 /* RCTNativeAnimatedNodesManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 94DA09161DC7971C00AEA8C9 /* RCTNativeAnimatedNodesManager.h */; };
@@ -208,6 +212,8 @@
 		13E501E51D07A6C9005F35D8 /* RCTTransformAnimatedNode.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTTransformAnimatedNode.m; sourceTree = "<group>"; };
 		13E501E61D07A6C9005F35D8 /* RCTValueAnimatedNode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = RCTValueAnimatedNode.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
 		13E501E71D07A6C9005F35D8 /* RCTValueAnimatedNode.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTValueAnimatedNode.m; sourceTree = "<group>"; };
+		192EE0071F54CEA00003D5E2 /* RCTAnimatedValueChangeEvent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTAnimatedValueChangeEvent.h; sourceTree = "<group>"; };
+		192EE0081F54CEA00003D5E2 /* RCTAnimatedValueChangeEvent.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTAnimatedValueChangeEvent.m; sourceTree = "<group>"; };
 		193F64F21D776EC6004D1CAA /* RCTDiffClampAnimatedNode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = RCTDiffClampAnimatedNode.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
 		193F64F31D776EC6004D1CAA /* RCTDiffClampAnimatedNode.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTDiffClampAnimatedNode.m; sourceTree = "<group>"; };
 		194804EB1E975D8E00623005 /* RCTDecayAnimation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTDecayAnimation.h; sourceTree = "<group>"; };
@@ -277,6 +283,8 @@
 		58B511D21A9E6C8500147676 = {
 			isa = PBXGroup;
 			children = (
+				192EE0071F54CEA00003D5E2 /* RCTAnimatedValueChangeEvent.h */,
+				192EE0081F54CEA00003D5E2 /* RCTAnimatedValueChangeEvent.m */,
 				13E501B71D07A644005F35D8 /* RCTAnimationUtils.h */,
 				13E501B81D07A644005F35D8 /* RCTAnimationUtils.m */,
 				13E501BD1D07A644005F35D8 /* RCTNativeAnimatedModule.h */,
@@ -333,6 +341,7 @@
 				192F698D1E823F4A008692C7 /* RCTModuloAnimatedNode.h in Headers */,
 				192F698E1E823F4A008692C7 /* RCTMultiplicationAnimatedNode.h in Headers */,
 				192F698F1E823F4A008692C7 /* RCTPropsAnimatedNode.h in Headers */,
+				192EE00A1F54CEA00003D5E2 /* RCTAnimatedValueChangeEvent.h in Headers */,
 				192F69901E823F4A008692C7 /* RCTStyleAnimatedNode.h in Headers */,
 				192F69911E823F4A008692C7 /* RCTTransformAnimatedNode.h in Headers */,
 				192F69921E823F4A008692C7 /* RCTValueAnimatedNode.h in Headers */,
@@ -360,6 +369,7 @@
 				1980B7251E80D1C4004DC789 /* RCTModuloAnimatedNode.h in Headers */,
 				1980B7271E80D1C4004DC789 /* RCTMultiplicationAnimatedNode.h in Headers */,
 				1980B7291E80D1C4004DC789 /* RCTPropsAnimatedNode.h in Headers */,
+				192EE0091F54CEA00003D5E2 /* RCTAnimatedValueChangeEvent.h in Headers */,
 				1980B72B1E80D1C4004DC789 /* RCTStyleAnimatedNode.h in Headers */,
 				1980B72D1E80D1C4004DC789 /* RCTTransformAnimatedNode.h in Headers */,
 				1980B72F1E80D1C4004DC789 /* RCTValueAnimatedNode.h in Headers */,
@@ -460,6 +470,7 @@
 				2D3B5EFC1D9B0B4800451313 /* RCTMultiplicationAnimatedNode.m in Sources */,
 				44DB7D982024F75100588FCD /* RCTTrackingAnimatedNode.m in Sources */,
 				2D3B5EFD1D9B0B4800451313 /* RCTPropsAnimatedNode.m in Sources */,
+				192EE00C1F54CEA00003D5E2 /* RCTAnimatedValueChangeEvent.m in Sources */,
 				944244D01DB962DA0032A02B /* RCTFrameAnimation.m in Sources */,
 				944244D11DB962DC0032A02B /* RCTSpringAnimation.m in Sources */,
 				9476E8EC1DC9232D005D5CD1 /* RCTNativeAnimatedNodesManager.m in Sources */,
@@ -487,6 +498,7 @@
 				13E501E91D07A6C9005F35D8 /* RCTAnimatedNode.m in Sources */,
 				44DB7D972024F75100588FCD /* RCTTrackingAnimatedNode.m in Sources */,
 				13E501EB1D07A6C9005F35D8 /* RCTInterpolationAnimatedNode.m in Sources */,
+				192EE00B1F54CEA00003D5E2 /* RCTAnimatedValueChangeEvent.m in Sources */,
 				13E501E81D07A6C9005F35D8 /* RCTAdditionAnimatedNode.m in Sources */,
 				5C9894951D999639008027DB /* RCTDivisionAnimatedNode.m in Sources */,
 				13E501EF1D07A6C9005F35D8 /* RCTTransformAnimatedNode.m in Sources */,

--- a/Libraries/NativeAnimation/RCTNativeAnimatedModule.h
+++ b/Libraries/NativeAnimation/RCTNativeAnimatedModule.h
@@ -15,6 +15,6 @@
 
 #import "RCTValueAnimatedNode.h"
 
-@interface RCTNativeAnimatedModule : RCTEventEmitter <RCTBridgeModule, RCTValueAnimatedNodeObserver, RCTEventDispatcherObserver, RCTUIManagerObserver, RCTSurfacePresenterObserver>
+@interface RCTNativeAnimatedModule : NSObject <RCTBridgeModule, RCTValueAnimatedNodeObserver, RCTEventDispatcherObserver, RCTUIManagerObserver, RCTSurfacePresenterObserver>
 
 @end

--- a/Libraries/NativeAnimation/RCTNativeAnimatedModule.m
+++ b/Libraries/NativeAnimation/RCTNativeAnimatedModule.m
@@ -6,6 +6,7 @@
  */
 #import "RCTNativeAnimatedModule.h"
 
+#import "RCTAnimatedValueChangeEvent.h"
 #import "RCTNativeAnimatedNodesManager.h"
 
 typedef void (^AnimatedOperation)(RCTNativeAnimatedNodesManager *nodesManager);
@@ -20,6 +21,8 @@ typedef void (^AnimatedOperation)(RCTNativeAnimatedNodesManager *nodesManager);
   NSMutableArray<AnimatedOperation> *_preOperations;
   NSMutableDictionary<NSNumber *, NSNumber *> *_animIdIsManagedByFabric;
 }
+
+@synthesize bridge = _bridge;
 
 RCT_EXPORT_MODULE();
 
@@ -41,7 +44,7 @@ RCT_EXPORT_MODULE();
 
 - (void)setBridge:(RCTBridge *)bridge
 {
-  [super setBridge:bridge];
+  _bridge = bridge;
 
   _nodesManager = [[RCTNativeAnimatedNodesManager alloc] initWithBridge:self.bridge];
   _operations = [NSMutableArray new];
@@ -293,15 +296,10 @@ RCT_EXPORT_METHOD(removeAnimatedEventFromView:(nonnull NSNumber *)viewTag
 
 #pragma mark -- Events
 
-- (NSArray<NSString *> *)supportedEvents
-{
-  return @[@"onAnimatedValueUpdate"];
-}
-
 - (void)animatedNode:(RCTValueAnimatedNode *)node didUpdateValue:(CGFloat)value
 {
-  [self sendEventWithName:@"onAnimatedValueUpdate"
-                     body:@{@"tag": node.nodeTag, @"value": @(value)}];
+  RCTAnimatedValueChangeEvent *event = [[RCTAnimatedValueChangeEvent alloc] initWithNodeTag:node.nodeTag value:value];
+  [self.bridge.eventDispatcher sendEvent:event];
 }
 
 - (void)eventDispatcherWillDispatchEvent:(id<RCTEvent>)event


### PR DESCRIPTION
## Summary

While playing around with the event code I figured we could leverage RCTEvent to easily coalesce onValueChanged events for Native Animated. I meant to do that for a while but didn't knew about a simple solution. This makes it so if JS lags behind we won't spam a bunch on onValueChanged events after.

## Test plan

Tested this fix by logging the number of listener calls every 16ms and make sure it is never more than one when running an animation with a listener in RNTester native animated example. Before the fix when adding some lag to JS the listener would get called 7-8 times after the JS lag ended and after this fix only once.

## Changelog

[iOS] [Changed] - Native Animated - Coalesce onValueChanged events on iOS