### PR TITLE
Alert - allow for hiding alert title on iOS

### DIFF
--- a/Libraries/Alert/AlertIOS.js
+++ b/Libraries/Alert/AlertIOS.js
@@ -209,7 +209,7 @@ class AlertIOS {
       var callback = type;
       var defaultValue = message;
       RCTAlertManager.alertWithArgs({
-        title: title || undefined,
+        title: title,
         type: 'plain-text',
         defaultValue,
       }, (id, value) => {
@@ -242,7 +242,7 @@ class AlertIOS {
     }
 
     RCTAlertManager.alertWithArgs({
-      title: title || undefined,
+      title: title,
       message: message || undefined,
       buttons,
       type: type || undefined,

--- a/Libraries/Alert/AlertIOS.js
+++ b/Libraries/Alert/AlertIOS.js
@@ -110,6 +110,8 @@ class AlertIOS {
    * @static
    * @method alert
    * @param title The dialog's title.
+   *
+   *    An empty string hides the title.
    * @param message An optional message that appears below
    *     the dialog's title.
    * @param callbackOrButtons This optional argument should

--- a/RNTester/js/AlertExample.js
+++ b/RNTester/js/AlertExample.js
@@ -110,6 +110,18 @@ class SimpleAlertExampleBlock extends React.Component {
             <Text>Alert that cannot be dismissed</Text>
           </View>
         </TouchableHighlight>
+        <TouchableHighlight style={styles.wrapper}
+          onPress={() => Alert.alert(
+            '',
+            alertMessage,
+            [
+              {text: 'OK', onPress: () => console.log('OK Pressed!')},
+            ]
+          )}>
+          <View style={styles.button}>
+            <Text>Alert without title</Text>
+          </View>
+        </TouchableHighlight>
       </View>
     );
   }


### PR DESCRIPTION
## Why
Wanted a "message-only" alert on iOS that doesn't lead to the message being large & bolded via the title field (current state).

Before:

![screen shot 2017-08-28 at 9 22 04 pm](https://user-images.githubusercontent.com/1047502/29801514-fc3629d2-8c3d-11e7-86d5-f0a866301814.png)

After:

![screen shot 2017-08-28 at 9 26 56 pm](https://user-images.githubusercontent.com/1047502/29801521-071aa1ca-8c3e-11e7-9bd0-0a4682d81979.png)

It also aligns iOS with Android's current behaviour.

The above screenhots were generated from the `RNTester` example added herein.

## What Changed
Allowed for passing an empty string through to `UIAlertController.alertControllerWithTitle` so that the message could be rendered in its expected place on iOS (not as the title).

## Test Plan
* Ran RNTester & compared example alerts before & after (below default with titles, for example)
* Ran end-to-end manual test suite (it's the only one I could get through without unrelated failures)

Before

![screen shot 2017-08-28 at 9 21 53 pm](https://user-images.githubusercontent.com/1047502/29801775-6e249ff0-8c3f-11e7-888b-2c4d5177a7d7.png)

After

![screen shot 2017-08-28 at 9 26 40 pm](https://user-images.githubusercontent.com/1047502/29801781-7270c4a8-8c3f-11e7-8b9b-59b2649646f2.png)
