### PR TITLE
Fix Image.getSize() according to image orientation

### DIFF
--- a/Libraries/Image/RCTImageLoader.m
+++ b/Libraries/Image/RCTImageLoader.m
@@ -716,10 +716,30 @@ static UIImage *RCTResizeImageIfNeeded(UIImage *image,
         CGSize size;
         if ([imageOrData isKindOfClass:[NSData class]]) {
             NSDictionary *meta = RCTGetImageMetadata(imageOrData);
-            size = (CGSize){
-                [meta[(id)kCGImagePropertyPixelWidth] doubleValue],
-                [meta[(id)kCGImagePropertyPixelHeight] doubleValue],
-            };
+
+            NSInteger imageOrientation = [meta[(id)kCGImagePropertyOrientation] integerValue];
+            switch (imageOrientation) {
+                case kCGImagePropertyOrientationLeft:
+                case kCGImagePropertyOrientationRight:
+                case kCGImagePropertyOrientationLeftMirrored:
+                case kCGImagePropertyOrientationRightMirrored:
+                    // swap width and height
+                    size = (CGSize){
+                      [meta[(id)kCGImagePropertyPixelHeight] doubleValue],
+                      [meta[(id)kCGImagePropertyPixelWidth] doubleValue],
+                    };
+                    break;
+                case kCGImagePropertyOrientationUp:
+                case kCGImagePropertyOrientationDown:
+                case kCGImagePropertyOrientationUpMirrored:
+                case kCGImagePropertyOrientationDownMirrored:
+                default:
+                    size = (CGSize){
+                      [meta[(id)kCGImagePropertyPixelWidth] doubleValue],
+                      [meta[(id)kCGImagePropertyPixelHeight] doubleValue],
+                    };
+                    break;
+            }
         } else {
             UIImage *image = imageOrData;
             size = (CGSize){


### PR DESCRIPTION
This is fix for issue https://github.com/facebook/react-native/issues/14097

## Test Plan
I've prepared images with different exif orientation (https://yadi.sk/d/is_xcEEo3MRAxF)
0-4 should have size 200x100
5-8 should have size 100x200