### PR TITLE
[Do Not Merge] Bump Travis and Circle to Node 8.2.0.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: objective-c
 osx_image: xcode8.3
 
 install:
-  - nvm install 7
+  - nvm install 8.2.0
   - rm -Rf "${TMPDIR}/jest_preprocess_cache"
   - brew install yarn --ignore-dependencies
   - brew install watchman

--- a/circle.yml
+++ b/circle.yml
@@ -4,7 +4,7 @@ general:
       - gh-pages # list of branches to ignore
 machine:
   node:
-    version: 6.2.0
+    version: 8.2.0
   environment:
     PATH: "~/$CIRCLE_PROJECT_REPONAME/gradle-2.9/bin:/home/ubuntu/buck/bin:$PATH"
     TERM: "dumb"


### PR DESCRIPTION
Circle is currently failing due to use of trailing commas in a function's argument list in metro-bundler 0.12.0. Prior to this PR, Circle used Node 6 which does not support this ECMAScript 2017 feature.
Node 8 adds support for this feature.

Circle's Ubuntu 14.04 image supports up to Node 8.2.0, so we're using that here. If we want to use a newer image, we can always use nvm to install a particular version on Circle.

Travis was using Node 7 prior to this PR, and we already use nvm to manage Node in Travis. I'm choosing 8.2.0 in Travis as well in order to keep things similar across environemnts.

We should not merge this PR yet as Node v8 is not LTS and is not widely used by our audience.


Test Plan:

This PR is the test! Let's see how Travis and Circle fare.
Note that both are red prior to this PR getting opened. There are other issues affecting CI, and I don't expect tests to go green on this PR, but we can at least see if the particular failure we're fixing is addressed with this PR.

Prior to this PR, for example, Circle fails with this error:


```
/home/ubuntu/react-native/node_modules/metro-bundler/src/lib/formatBanner.js:89
  );
  ^
SyntaxError: Unexpected token )
    at Object.exports.runInThisContext (vm.js:53:16)
    at Module._compile (module.js:513:28)
    at Object.Module._extensions..js (module.js:550:10)
    at Module.load (module.js:458:32)
    at tryModuleLoad (module.js:417:12)
    at Function.Module._load (module.js:409:3)
    at Module.require (module.js:468:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (/home/ubuntu/react-native/local-cli/server/checkNodeVersion.js:12:20)
    at Module._compile (module.js:541:32)

node local-cli/cli.js bundle --max-workers 1 --platform android --dev true --entry-file ReactAndroid/src/androidTest/js/TestBundle.js --bundle-output ReactAndroid/src/androidTest/assets/AndroidTestBundle.js returned exit code 1
```