### PR TITLE
Added in missing ReactProp in TextInput for Android

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
@@ -487,7 +487,18 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
                 InputType.TYPE_TEXT_FLAG_AUTO_CORRECT : InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS)
             : 0);
   }
-
+  
+  @ReactProp(name = "autoComplete")
+  public void setAutoComplete(ReactEditText view, @Nullable Boolean autoComplete) {
+    updateStagedInputTypeFlag(
+        view,
+        InputType.TYPE_TEXT_FLAG_AUTO_CORRECT | InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS | TYPE_TEXT_VARIATION_VISIBLE_PASSWORD,
+        autoComplete != null ?
+            (autoComplete.booleanValue() ?
+                InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS : InputType.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD)
+            : 0);
+  }
+  
   @ReactProp(name = "multiline", defaultBoolean = false)
   public void setMultiline(ReactEditText view, boolean multiline) {
     updateStagedInputTypeFlag(


### PR DESCRIPTION
The missing autoComplete is the reason why some Samsung and HTC can't turn off autoSuggestion/autoCompletion successfully. 

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes. 

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to React Native here: http://facebook.github.io/react-native/docs/contributing.html

Happy contributing!

-->

While testing a mobile application that prioritizes security, it was noted that on some Samsung and HTC devices the TextInput component (username field) would still auto-suggest even with autoCorrect and autoComplete props set to false.

[Here is a link to a SO question that had the same issue.](https://stackoverflow.com/questions/37001070/how-to-avoid-the-suggestions-of-keyboard-for-android-in-react-native)

## Test Plan

This solution was tested on a Samsung phone that was previously auto-suggesting with props set.

Planning to test this on more HTC and Samsung phones.