### PR TITLE
Update RCTUIManager.m

### DIFF
--- a/React/Modules/RCTUIManager.m
+++ b/React/Modules/RCTUIManager.m
@@ -7,39 +7,39 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import "RCTUIManager.h"
+#import <React/RCTUIManager.h>
 
 #import <AVFoundation/AVFoundation.h>
 
 #import <yoga/Yoga.h>
 
-#import "RCTAccessibilityManager.h"
-#import "RCTAnimationType.h"
-#import "RCTAssert.h"
-#import "RCTBridge+Private.h"
-#import "RCTBridge.h"
-#import "RCTComponent.h"
-#import "RCTComponentData.h"
-#import "RCTConvert.h"
-#import "RCTDefines.h"
-#import "RCTEventDispatcher.h"
-#import "RCTLayoutAnimation.h"
-#import "RCTLayoutAnimationGroup.h"
-#import "RCTLog.h"
-#import "RCTModuleData.h"
-#import "RCTModuleMethod.h"
-#import "RCTProfile.h"
-#import "RCTRootContentView.h"
-#import "RCTRootShadowView.h"
-#import "RCTRootViewInternal.h"
-#import "RCTScrollableProtocol.h"
-#import "RCTShadowView+Internal.h"
-#import "RCTShadowView.h"
-#import "RCTUIManagerObserverCoordinator.h"
-#import "RCTUtils.h"
-#import "RCTView.h"
-#import "RCTViewManager.h"
-#import "UIView+React.h"
+#import <React/RCTAccessibilityManager.h>
+#import <React/RCTAnimationType.h>
+#import <React/RCTAssert.h>
+#import <React/RCTBridge+Private.h>
+#import <React/RCTBridge.h>
+#import <React/RCTComponent.h>
+#import <React/RCTComponentData.h>
+#import <React/RCTConvert.h>
+#import <React/RCTDefines.h>
+#import <React/RCTEventDispatcher.h>
+#import <React/RCTLayoutAnimation.h>
+#import <React/RCTLayoutAnimationGroup.h>
+#import <React/RCTLog.h>
+#import <React/RCTModuleData.h>
+#import <React/RCTModuleMethod.h>
+#import <React/RCTProfile.h>
+#import <React/RCTRootContentView.h>
+#import <React/RCTRootShadowView.h>
+#import <React/RCTRootViewInternal.h>
+#import <React/RCTScrollableProtocol.h>
+#import <React/RCTShadowView+Internal.h>
+#import <React/RCTShadowView.h>
+#import <React/RCTUIManagerObserverCoordinator.h>
+#import <React/RCTUtils.h>
+#import <React/RCTView.h>
+#import <React/RCTViewManager.h>
+#import <React/UIView+React.h>
 
 static void RCTTraverseViewNodes(id<RCTComponent> view, void (^block)(id<RCTComponent>))
 {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes. 

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to React Native here: http://facebook.github.io/react-native/docs/contributing.html

Happy contributing!

-->

To make React Native play nicely with our internal build infrastructure we need to properly namespace all of our header includes.

Where previously you could do `#import "RCTBridge.h"`, you must now write this as `#import <React/RCTBridge.h>`. If your xcode project still has a custom header include path, both variants will likely continue to work, but for new projects, we're defaulting the header include path to `$(BUILT_PRODUCTS_DIR)/usr/local/include`, where the React and CSSLayout targets will copy a subset of headers too. To make Xcode copy headers phase work properly, you may need to add React as an explicit dependency to your app's scheme and disable "parallelize build".

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)
