### PR TITLE
Make a forward declaration of RCTMethodInfo

### DIFF
--- a/React/Base/RCTBridgeModule.h
+++ b/React/Base/RCTBridgeModule.h
@@ -51,11 +51,12 @@ RCT_EXTERN dispatch_queue_t RCTJSThread;
 
 RCT_EXTERN_C_BEGIN
 
-typedef struct RCTMethodInfo {
+struct RCTMethodInfo {
   const char *const jsName;
   const char *const objcName;
   const BOOL isSync;
-} RCTMethodInfo;
+};
+typedef struct RCTMethodInfo RCTMethodInfo;
 
 RCT_EXTERN_C_END
 


### PR DESCRIPTION
> declares an anonymous structure and creates a typedef for it. Thus, with this construct, it doesn't have a name in the tag namespace, only a name in the typedef namespace. This means it also cannot be forward-declared. If you want to make a forward declaration, you have to give it a name in the tag namespace.

https://stackoverflow.com/questions/612328/difference-between-struct-and-typedef-struct-in-c

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes. 

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to React Native here: http://facebook.github.io/react-native/docs/contributing.html

Happy contributing!

-->

(Write your motivation here.)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)
