### PR TITLE
Add missing licence to findSymlinksPaths

### DIFF
--- a/local-cli/util/findSymlinksPaths.js
+++ b/local-cli/util/findSymlinksPaths.js
@@ -1,3 +1,12 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
 const path = require('path');
 const fs = require('fs');
 


### PR DESCRIPTION
Missing licence added. Fixes #15759.