### PR TITLE
[ios] Change intValue -> integerValue in RCTMultipartStreamReader

### DIFF
--- a/React/Base/RCTMultipartStreamReader.m
+++ b/React/Base/RCTMultipartStreamReader.m
@@ -76,7 +76,7 @@
   // Throttle progress events so we don't send more that around 60 per second.
   CFTimeInterval currentTime = CACurrentMediaTime();
 
-  NSInteger headersContentLength = headers[@"Content-Length"] != nil ? [headers[@"Content-Length"] intValue] : 0;
+  NSInteger headersContentLength = headers[@"Content-Length"] != nil ? [headers[@"Content-Length"] integerValue] : 0;
   if (callback && (currentTime - _lastDownloadProgress > 0.016 || final)) {
     _lastDownloadProgress = currentTime;
     callback(headers, @(headersContentLength), @(contentLength));


### PR DESCRIPTION
We assign the value to an NSInteger so we should convert the NSString to an NSInteger instead of an int.

## Test Plan

Build the app in Xcode and run it.
