### PR TITLE
[CI] Settle on Node 4.8.4 for both Circle and Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: objective-c
 osx_image: xcode8.3
 
 install:
-  - nvm install 7
+  - nvm install 4.8.4
   - rm -Rf "${TMPDIR}/jest_preprocess_cache"
   - brew install yarn --ignore-dependencies
   - brew install watchman

--- a/circle.yml
+++ b/circle.yml
@@ -4,7 +4,7 @@ general:
       - gh-pages # list of branches to ignore
 machine:
   node:
-    version: 6.2.0
+    version: 4.8.4
   environment:
     PATH: "~/$CIRCLE_PROJECT_REPONAME/gradle-2.9/bin:/home/ubuntu/buck/bin:$PATH"
     TERM: "dumb"


### PR DESCRIPTION
React Native should have no dependencies that require anything newer than Node 4. Let's make sure we test against Node v4 in CI then.

This PR updates both Travis and Circle to use the same Node release: 4.8.4, which is the most recent release of Node 4.x, which is currently in LTS maintenance mode.

# Test Plan

Wait for Travis and Circle to run.