### PR TITLE
fix fontWeight regression

### DIFF
--- a/React/Views/RCTFont.mm
+++ b/React/Views/RCTFont.mm
@@ -33,42 +33,38 @@
 
 #endif
 
-static NSArray *fontNameOrdering = [NSArray arrayWithObjects:
-    @"normal",
-    @"ultralight",
-    @"thin",
-    @"light",
-    @"regular",
-    @"medium",
-    @"semibold",
-    @"bold",
-    @"heavy",
-    @"black",
-    nil];
-
 typedef CGFloat RCTFontWeight;
 static RCTFontWeight weightOfFont(UIFont *font)
 {
-  static NSDictionary *nameToWeight;
+  static NSArray *fontNames;
+  static NSArray *fontWeights;
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{
-    nameToWeight = @{
-       @"normal": @(UIFontWeightRegular),
-       @"ultralight": @(UIFontWeightUltraLight),
-       @"thin": @(UIFontWeightThin),
-       @"light": @(UIFontWeightLight),
-       @"regular": @(UIFontWeightRegular),
-       @"medium": @(UIFontWeightMedium),
-       @"semibold": @(UIFontWeightSemibold),
-       @"bold": @(UIFontWeightBold),
-       @"heavy": @(UIFontWeightHeavy),
-       @"black": @(UIFontWeightBlack),
-       };
+    fontNames = @[@"normal",
+                  @"ultralight",
+                  @"thin",
+                  @"light",
+                  @"regular",
+                  @"medium",
+                  @"semibold",
+                  @"bold",
+                  @"heavy",
+                  @"black"];
+    fontWeights = @[@(UIFontWeightRegular),
+                    @(UIFontWeightUltraLight),
+                    @(UIFontWeightThin),
+                    @(UIFontWeightLight),
+                    @(UIFontWeightRegular),
+                    @(UIFontWeightMedium),
+                    @(UIFontWeightSemibold),
+                    @(UIFontWeightBold),
+                    @(UIFontWeightHeavy),
+                    @(UIFontWeightBlack)];
   });
-
-  for (NSString *name in fontNameOrdering) {
-    if ([font.fontName.lowercaseString hasSuffix:name]) {
-      return [nameToWeight[name] doubleValue];
+  
+  for (NSUInteger i = 0; i < fontNames.count; i++) {
+    if ([font.fontName.lowercaseString hasSuffix:fontNames[i]]) {
+      return [fontWeights[i] doubleValue];
     }
   }
 

--- a/React/Views/RCTFont.mm
+++ b/React/Views/RCTFont.mm
@@ -61,7 +61,7 @@ static RCTFontWeight weightOfFont(UIFont *font)
                     @(UIFontWeightHeavy),
                     @(UIFontWeightBlack)];
   });
-  
+
   for (NSUInteger i = 0; i < fontNames.count; i++) {
     if ([font.fontName.lowercaseString hasSuffix:fontNames[i]]) {
       return [fontWeights[i] doubleValue];

--- a/React/Views/RCTFont.mm
+++ b/React/Views/RCTFont.mm
@@ -62,7 +62,7 @@ static RCTFontWeight weightOfFont(UIFont *font)
                     @(UIFontWeightBlack)];
   });
 
-  for (NSUInteger i = 0; i < fontNames.count; i++) {
+  for (NSInteger i = 0; i < fontNames.count; i++) {
     if ([font.fontName.lowercaseString hasSuffix:fontNames[i]]) {
       return [fontWeights[i] doubleValue];
     }

--- a/React/Views/RCTFont.mm
+++ b/React/Views/RCTFont.mm
@@ -33,6 +33,19 @@
 
 #endif
 
+static NSArray *fontNameOrdering = [NSArray arrayWithObjects:
+    @"normal",
+    @"ultralight",
+    @"thin",
+    @"light",
+    @"regular",
+    @"medium",
+    @"semibold",
+    @"bold",
+    @"heavy",
+    @"black",
+    nil];
+
 typedef CGFloat RCTFontWeight;
 static RCTFontWeight weightOfFont(UIFont *font)
 {
@@ -41,7 +54,6 @@ static RCTFontWeight weightOfFont(UIFont *font)
   dispatch_once(&onceToken, ^{
     nameToWeight = @{
        @"normal": @(UIFontWeightRegular),
-       @"bold": @(UIFontWeightBold),
        @"ultralight": @(UIFontWeightUltraLight),
        @"thin": @(UIFontWeightThin),
        @"light": @(UIFontWeightLight),
@@ -51,10 +63,10 @@ static RCTFontWeight weightOfFont(UIFont *font)
        @"bold": @(UIFontWeightBold),
        @"heavy": @(UIFontWeightHeavy),
        @"black": @(UIFontWeightBlack),
-    };
+       };
   });
 
-  for (NSString *name in nameToWeight) {
+  for (NSString *name in fontNameOrdering) {
     if ([font.fontName.lowercaseString hasSuffix:name]) {
       return [nameToWeight[name] doubleValue];
     }

--- a/React/Views/RCTFont.mm
+++ b/React/Views/RCTFont.mm
@@ -40,37 +40,42 @@ static RCTFontWeight weightOfFont(UIFont *font)
   static NSArray *fontWeights;
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{
-    fontNames = @[@"normal",
-                  @"ultralight",
-                  @"thin",
-                  @"light",
-                  @"regular",
-                  @"medium",
-                  @"semibold",
-                  @"bold",
-                  @"heavy",
-                  @"black"];
-    fontWeights = @[@(UIFontWeightRegular),
-                    @(UIFontWeightUltraLight),
-                    @(UIFontWeightThin),
-                    @(UIFontWeightLight),
-                    @(UIFontWeightRegular),
-                    @(UIFontWeightMedium),
-                    @(UIFontWeightSemibold),
-                    @(UIFontWeightBold),
-                    @(UIFontWeightHeavy),
-                    @(UIFontWeightBlack)];
+    // We use two arrays instead of one map because
+    // the order is important for suffix matching.
+    fontNames = @[
+      @"normal",
+      @"ultralight",
+      @"thin",
+      @"light",
+      @"regular",
+      @"medium",
+      @"semibold",
+      @"bold",
+      @"heavy",
+      @"black"
+    ];
+    fontWeights = @[
+      @(UIFontWeightRegular),
+      @(UIFontWeightUltraLight),
+      @(UIFontWeightThin),
+      @(UIFontWeightLight),
+      @(UIFontWeightRegular),
+      @(UIFontWeightMedium),
+      @(UIFontWeightSemibold),
+      @(UIFontWeightBold),
+      @(UIFontWeightHeavy),
+      @(UIFontWeightBlack)
+    ];
   });
 
   for (NSInteger i = 0; i < fontNames.count; i++) {
     if ([font.fontName.lowercaseString hasSuffix:fontNames[i]]) {
-      return [fontWeights[i] doubleValue];
+      return (RCTFontWeight)[fontWeights[i] doubleValue];
     }
   }
 
   NSDictionary *traits = [font.fontDescriptor objectForKey:UIFontDescriptorTraitsAttribute];
-  RCTFontWeight weight = [traits[UIFontWeightTrait] doubleValue];
-  return weight;
+  return (RCTFontWeight)[traits[UIFontWeightTrait] doubleValue];
 }
 
 static BOOL isItalicFont(UIFont *font)


### PR DESCRIPTION
fix the regression I mentioned in https://github.com/facebook/react-native/pull/15162#issuecomment-319696706

as no one is working on this, I take the step, although I know nothing about Objective C

I find the key point is that the keys in `NSDictionary` are not ordered as presented, it's a hash table, so no grantee on keys order, so I create a new array to do that, then it will check `ultralight` before `light` and `semibold` before `bold`
