### PR TITLE
Added front-matter as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -156,6 +156,7 @@
     "event-target-shim": "^1.0.5",
     "fbjs": "0.8.14",
     "fbjs-scripts": "^0.8.1",
+    "front-matter": "^2.2.0",
     "fs-extra": "^1.0.0",
     "glob": "^7.1.1",
     "graceful-fs": "^4.1.3",


### PR DESCRIPTION


<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes. 

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to React Native here: http://facebook.github.io/react-native/docs/contributing.html

Happy contributing!

-->

Running npm install and then import-existing-docs.js results in error that 'front-matter' dependency is missing. Looks like the file requires it on line 13 but it's not included in package.json.

Installed and saved the file to dependency list.

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

import docs file ran successfully and generated markdown for sidebar.
