### PR TITLE
Add BlobModule native module mock to jest setup

### DIFF
--- a/jest/setup.js
+++ b/jest/setup.js
@@ -106,7 +106,7 @@ jest
     });
     return ReactNative;
   })
-  .mock('ensureComponentIsNative', () => () => true);  
+  .mock('ensureComponentIsNative', () => () => true);
 
 const mockEmptyObject = {};
 const mockNativeModules = {

--- a/jest/setup.js
+++ b/jest/setup.js
@@ -106,7 +106,7 @@ jest
     });
     return ReactNative;
   })
-  .mock('ensureComponentIsNative', () => () => true);
+  .mock('ensureComponentIsNative', () => () => true);  
 
 const mockEmptyObject = {};
 const mockNativeModules = {
@@ -275,6 +275,15 @@ const mockNativeModules = {
       Constants: {},
     },
   },
+  BlobModule: {
+    BLOB_URI_SCHEME: 'content',
+    BLOB_URI_HOST: null,
+    enableBlobSupport: jest.fn(),
+    disableBlobSupport: jest.fn(),
+    createFromParts: jest.fn(),
+    sendBlob: jest.fn(),
+    release: jest.fn(),
+  }
   WebSocketModule: {
     connect: jest.fn(),
     send: jest.fn(),

--- a/jest/setup.js
+++ b/jest/setup.js
@@ -283,7 +283,7 @@ const mockNativeModules = {
     createFromParts: jest.fn(),
     sendBlob: jest.fn(),
     release: jest.fn(),
-  }
+  },
   WebSocketModule: {
     connect: jest.fn(),
     send: jest.fn(),


### PR DESCRIPTION
React Native v0.48.0 shipped `WebSocketModule` support with `BlobModule` as dependency. But `BlobModule` is not mocked in jest which will cause render tests failed.

Reference implantation: [BlobModule.java](https://github.com/facebook/react-native/blob/ed903099b42259958d8a6eb3af1a6460c1bc8b2c/ReactAndroid/src/main/java/com/facebook/react/modules/blob/BlobModule.java)

Related PR: #11417
Related issue: #15810

## Test Plan

Passed CI tests.
Need render a component in jest with WebSocketModule as dependency.