### PR TITLE
(iOS) Support for DemiBold alias of SemiBold (font-weight 600)

### DIFF
--- a/React/Views/RCTFont.mm
+++ b/React/Views/RCTFont.mm
@@ -50,6 +50,7 @@ static RCTFontWeight weightOfFont(UIFont *font)
       @"regular",
       @"medium",
       @"semibold",
+      @"demibold",
       @"bold",
       @"heavy",
       @"black"
@@ -62,13 +63,14 @@ static RCTFontWeight weightOfFont(UIFont *font)
       @(UIFontWeightRegular),
       @(UIFontWeightMedium),
       @(UIFontWeightSemibold),
+      @(UIFontWeightSemibold),
       @(UIFontWeightBold),
       @(UIFontWeightHeavy),
       @(UIFontWeightBlack)
     ];
   });
 
-  for (NSInteger i = 0; i < fontNames.count; i++) {
+  for (NSUInteger i = 0; i < fontNames.count; i++) {
     if ([font.fontName.lowercaseString hasSuffix:fontNames[i]]) {
       return (RCTFontWeight)[fontWeights[i] doubleValue];
     }

--- a/React/Views/RCTFont.mm
+++ b/React/Views/RCTFont.mm
@@ -70,7 +70,7 @@ static RCTFontWeight weightOfFont(UIFont *font)
     ];
   });
 
-  for (NSUInteger i = 0; i < fontNames.count; i++) {
+  for (NSInteger i = 0; i < fontNames.count; i++) {
     if ([font.fontName.lowercaseString hasSuffix:fontNames[i]]) {
       return (RCTFontWeight)[fontWeights[i] doubleValue];
     }


### PR DESCRIPTION
For more information on font weight naming see [this post](https://www.quora.com/What-is-the-difference-between-Medium-Demi-and-Semibold-fonts).

DemiBold is fairly common in font naming. For example, iOS React Native lacks support of "AvNext-DemiBold".

Also removed warning about `NSUInteger` <=> `NSInteger` comparison, by making `i` an `NSUInteger`

Before and after screenshots:

#### Before fix
![before-fix](https://user-images.githubusercontent.com/177857/30182567-1dfebcb0-93cc-11e7-9b51-78ef6f41c447.png)

#### After
![after-fix](https://user-images.githubusercontent.com/177857/30182570-1f90ea94-93cc-11e7-8f68-008ae648ffbe.png)


## Test Plan

Add any DemiBold font to an iOS react native project.  Set fontWeight to `'600'` on a `<Text />` component. The font weight should be applied appropriately.
