### PR TITLE
[packager][breaking-change] Default enableBabelRCLookup (recursive) to false

### DIFF
--- a/local-cli/util/Config.js
+++ b/local-cli/util/Config.js
@@ -189,7 +189,7 @@ const Config = {
     extraNodeModules: Object.create(null),
     getAssetExts: () => [],
     getBlacklistRE: () => blacklist(),
-    getEnableBabelRCLookup: () => true,
+    getEnableBabelRCLookup: () => false,
     getPlatforms: () => [],
     getPolyfillModuleNames: () => [],
     getProjectRoots: () => {


### PR DESCRIPTION
This is a breaking change that tells Metro to look at only the project's .babelrc file. Previously it would look at .babelrc files under node_modules and would run into issues because it didn't have the version of Babel nor the plugins/presets that `node_modules/randompackage/.babelrc` wanted. So as a workaround, people would write a postinstall step that deletes `node_modules/**/.babelrc`, which worked well. This flag (`getEnableBabelRCLookup = false`) has the same effect and hopefully fixes one source of cryptic bugs people run into.

## Opt-in old behavior

To use the old behavior, create a config file named `rn-cli.config.js` with:
```js
module.exports = {
  getEnableBabelRCLookup() {
    return true;
  },
};
```

## Test plan

Go under node_modules, modify a used module to have a dummy .babelrc (`{"plugins": ["dummy"]}`) and ensure the JS bundle still loads.

# Release Notes 
(edit by @hramos)

Previously, the React Native packager would try to apply .babelrc files under `node_modules`. This sometimes would cause issues because it didn't have the version of Babel nor the plugins/presets that `node_modules/<dep>/.babelrc` wanted. So as a workaround, people would write a postinstall step that deletes `node_modules/**/.babelrc`, which worked well. This flag (getEnableBabelRCLookup = false) has the same effect.

Note that React Native still applies its default Babel configuration (or the one you've specified in your project's .babelrc file) to all source files, so you can keep using packages written with modern JavaScript. We expect this change will not affect most developers, or will improve their development experience.

To opt into the old behavior, create a config file named `rn-cli.config.js` with:
```js
module.exports = {
  getEnableBabelRCLookup() {
    return true;
  },
};
```