### PR TITLE
Add Galarm app to showcase

### DIFF
--- a/website/showcase.json
+++ b/website/showcase.json
@@ -136,6 +136,15 @@
     "pinned": false
   },
   {
+    "name": "Galarm",
+    "icon": "https://drive.google.com/a/acintyo.com/uc?id=0B65x4eTJ8xXCWHJyV3JDRDFFMkU",
+    "linkAppStore": "https://itunes.apple.com/us/app/galarm-alarms-reminders/id1187849174?mt=8",
+    "linkPlayStore": "http://play.google.com/store/apps/details?id=com.galarmapp",
+    "infoLink": "https://www.galarmapp.com",
+    "infoTitle": "Social alarm app",
+    "pinned": false
+  },
+  {
     "name": "Gyroscope",
     "icon": "https://media.gyrosco.pe/images/magneto/180x180.png",
     "linkAppStore": "https://itunes.apple.com/app/apple-store/id1104085053?pt=117927205&ct=website&mt=8",


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes. 

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to React Native here: http://facebook.github.io/react-native/docs/contributing.html

Happy contributing!

-->

I just published my first app called Galarm built with react-native a few days ago and I wanted to add the app to the showcase of apps.

## Test Plan

I ran the website with my update and was able to successfully see my app in the showcase. Screenshot attached.
![screen shot 2017-09-08 at 11 35 34 am](https://user-images.githubusercontent.com/7475133/30198171-ecb348b0-9489-11e7-8db6-e23327715599.png)

