### PR TITLE
 add release notes/changelog requirement to PR Template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,14 +21,19 @@ Happy contributing!
 <!--
 Help reviewers and the release process by writing your own release notes
 
- CATEGORY
-[---------]        TYPE
-[ GENERAL ]   [-------------]       WHERE
-[ DOCS    ]   [ BREAKING    ]   [-------------]
-[ CLI     ]   [ BUGFIX      ]   [ {Framework} ]
-[ IOS     ]   [ ENHANCEMENT ]   [ {Component} ]   |-----------|
-[ ANDROID ]   [ FEATURE     ]   [ {File}      ] - | {Message} |
-[---------]   [-------------]   [-------------]   |-----------|
+**INTERNAL and MINOR tagged notes will not be included in the next version's final release notes.**
+
+  CATEGORY
+[----------]        TYPE
+[ CLI      ]   [-------------]      LOCATION
+[ DOCS     ]   [ BREAKING    ]   [-------------]
+[ GENERAl  ]   [ BUGFIX      ]   [-{Component}-]
+[ INTERNAL ]   [ ENHANCEMENT ]   [ {File}      ]
+[ IOS      ]   [ FEATURE     ]   [ {Directory} ]   |-----------|
+[ ANDROID  ]   [ MINOR       ]   [ {Framework} ] - | {Message} |
+[----------]   [-------------]   [-------------]   |-----------|
+
+[CATEGORY] [TYPE] [LOCATION] - MESSAGE
 
  EXAMPLES:
 
@@ -37,4 +42,5 @@ Help reviewers and the release process by writing your own release notes
  [CLI] [FEATURE] [local-cli/info/info.js] - CLI easier to do things with
  [DOCS] [BUGFIX] [GettingStarted.md] - Accidentally a thing/word
  [GENERAL] [ENHANCEMENT] [Yoga] - Added new yoga thing/position
+ [INTERNAL] [FEATURE] [./scripts] - Added thing to script that nobody will see
 -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,8 +9,32 @@ Happy contributing!
 
 -->
 
+## Motivation
+
 (Write your motivation here.)
 
 ## Test Plan
 
 (Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)
+
+## Release Notes
+<!--
+Help reviewers and the release process by writing your own release notes
+
+ CATEGORY
+[---------]        TYPE
+[ GENERAL ]   [-------------]       WHERE
+[ DOCS    ]   [ BREAKING    ]   [-------------]
+[ CLI     ]   [ BUGFIX      ]   [ {Framework} ]
+[ IOS     ]   [ ENHANCEMENT ]   [ {Component} ]   |-----------|
+[ ANDROID ]   [ FEATURE     ]   [ {File}      ] - | {Message} |
+[---------]   [-------------]   [-------------]   |-----------|
+
+ EXAMPLES:
+
+ [IOS] [BREAKING] [FlatList] - Change a thing that breaks other things
+ [ANDROID] [BUGFIX] [TextInput] - Did a thing to TextInput
+ [CLI] [FEATURE] [local-cli/info/info.js] - CLI easier to do things with
+ [DOCS] [BUGFIX] [GettingStarted.md] - Accidentally a thing/word
+ [GENERAL] [ENHANCEMENT] [Yoga] - Added new yoga thing/position
+-->

--- a/danger/dangerfile.js
+++ b/danger/dangerfile.js
@@ -93,6 +93,35 @@ if (!includesTestPlan && !editsDocs) {
   markdown('@facebook-github-bot label Needs more information');
 }
 
+// Regex looks for given categories, types, a file/framework/component, and a message - broken into 4 capture groups
+const releaseNotesRegex = /\[(ANDROID|CLI|DOCS|GENERAL|IOS|TVOS|WINDOWS)\]\s*?\[(BREAKING|FEATURE|ENHANCEMENT|BUGFIX)\]\s*?\[(.*)\]\s*?\-\s*?(.*)/ig;
+const includesReleaseNotes = danger.github.pr.body.toLowerCase().includes('release notes');
+const correctlyFormattedReleaseNotes = releaseNotesRegex.test(danger.github.pr.body);
+const releaseNotesCaptureGroups = releaseNotesRegex.exec(danger.github.pr.body);
+
+if (!includesReleaseNotes) {
+  const title = ':clipboard: Release Notes';
+  const idea = 'This PR appears to be missing Release Notes.';
+  warn(`${title} - <i>${idea}</i>`);
+  markdown('@facebook-github-bot label Needs more information');
+} else if (!correctlyFormattedReleaseNotes) {
+  const title = ':clipboard: Release Notes';
+  const idea = 'This PR may have incorrectly formatted Release Notes.';
+  warn(`${title} - <i>${idea}</i>`);
+  markdown('@facebook-github-bot label Needs more information');
+} else if (releaseNotesCaptureGroups) {
+  const category = releaseNotesCaptureGroups[1].toLowerCase();
+
+  // Use Release Notes to Tag PRs appropriately
+  if (category === 'ios' ){
+    markdown('@facebook-github-bot label iOS');
+  }
+
+  if (category === 'android' ){
+    markdown('@facebook-github-bot label Android');
+  }
+}
+
 // Tags PRs that have been submitted by a core contributor.
 // TODO: Switch to using an actual MAINTAINERS file.
 const taskforce = fs.readFileSync('../bots/IssueCommands.txt', 'utf8').split('\n')[0].split(':')[1];

--- a/danger/dangerfile.js
+++ b/danger/dangerfile.js
@@ -94,7 +94,7 @@ if (!includesTestPlan && !editsDocs) {
 }
 
 // Regex looks for given categories, types, a file/framework/component, and a message - broken into 4 capture groups
-const releaseNotesRegex = /\[(ANDROID|CLI|DOCS|GENERAL|IOS|TVOS|WINDOWS)\]\s*?\[(BREAKING|FEATURE|ENHANCEMENT|BUGFIX)\]\s*?\[(.*)\]\s*?\-\s*?(.*)/ig;
+const releaseNotesRegex = /\[(ANDROID|CLI|DOCS|GENERAL|INTERNAL|IOS|TVOS|WINDOWS)\]\s*?\[(BREAKING|BUGFIX|ENHANCEMENT|FEATURE|MINOR)\]\s*?\[(.*)\]\s*?\-\s*?(.*)/ig;
 const includesReleaseNotes = danger.github.pr.body.toLowerCase().includes('release notes');
 const correctlyFormattedReleaseNotes = releaseNotesRegex.test(danger.github.pr.body);
 const releaseNotesCaptureGroups = releaseNotesRegex.exec(danger.github.pr.body);


### PR DESCRIPTION
## Motivation
@grabbou has to write release notes for every release, and that's getting ridonc. Have you seen the changelog from 0.48?

PR writers need to do their own, hopefully in a standardized format so it can be scripted. 

## Test Plan

Just a PR template change, just proofreading needed. Please mention if have missed or added any extra Categories, Types, or Where columns. 

Here's a sample:

## Release Notes

[GENERAL] [ENHANCEMENT] [PULL_REQUEST_TEMPLATE.md] - added release notes/changelog requirement to PR Template