### PR TITLE
Fix error in flow types

### DIFF
--- a/Libraries/Share/Share.js
+++ b/Libraries/Share/Share.js
@@ -22,7 +22,7 @@ const {
 } = require('NativeModules');
 
 type Content = { title?: string, message: string } | { title?: string, url: string };
-type Options = { dialogTitle?: string, excludeActivityTypes?: Array<string>, tintColor?: string };
+type Options = { dialogTitle?: string, excludedActivityTypes?: Array<string>, tintColor?: string };
 
 class Share {
 


### PR DESCRIPTION
Previously type Options had excludeActivityTypes property, but in RCTActionSheetManager.m and docs this property is named excludedActivityTypes.

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes. 

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to React Native here: http://facebook.github.io/react-native/docs/contributing.html

Happy contributing!

-->

Want to fix error in flow types

## Test Plan

Actually, it seems there aren't any need for test plan for this PR. Just fix a mistyping error.
