### PR TITLE
[CI] Use Node 8 instead of 7 in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: objective-c
 osx_image: xcode8.3
 
 install:
-  - nvm install 7
+  - nvm install 8
   - rm -Rf "${TMPDIR}/jest_preprocess_cache"
   - brew install yarn --ignore-dependencies
   - brew install watchman


### PR DESCRIPTION
Node 8 is stable and newer and also gives us test coverage for npm 5, which is probably better to use for the E2E tests.

Test Plan: Let Travis tests run, ensure that all but the e2e-objc one (currently broken) pass.
