### PR TITLE
re #15915 HeadlessJsTaskService is expected to run on UI thread

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/HeadlessJsTaskService.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/HeadlessJsTaskService.java
@@ -120,15 +120,15 @@ public abstract class HeadlessJsTaskService extends Service implements HeadlessJ
     final HeadlessJsTaskContext headlessJsTaskContext = HeadlessJsTaskContext.getInstance(reactContext);
     headlessJsTaskContext.addTaskEventListener(this);
 
-    Runnable myRunnable = new Runnable() {
-      @Override
-      public void run() {
-        int taskId = headlessJsTaskContext.startTask(taskConfig);
-        mActiveTasks.add(taskId);
+    UiThreadUtil.runOnUiThread(
+      new Runnable() {
+        @Override
+        public void run() {
+          int taskId = headlessJsTaskContext.startTask(taskConfig);
+          mActiveTasks.add(taskId);
+        }
       }
-    };
-
-    UiThreadUtil.runOnUiThread(myRunnable);
+    );
   }
 
   @Override

--- a/ReactAndroid/src/main/java/com/facebook/react/HeadlessJsTaskService.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/HeadlessJsTaskService.java
@@ -116,11 +116,19 @@ public abstract class HeadlessJsTaskService extends Service implements HeadlessJ
     }
   }
 
-  private void invokeStartTask(ReactContext reactContext, HeadlessJsTaskConfig taskConfig) {
-    HeadlessJsTaskContext headlessJsTaskContext = HeadlessJsTaskContext.getInstance(reactContext);
+  private void invokeStartTask(ReactContext reactContext, final HeadlessJsTaskConfig taskConfig) {
+    final HeadlessJsTaskContext headlessJsTaskContext = HeadlessJsTaskContext.getInstance(reactContext);
     headlessJsTaskContext.addTaskEventListener(this);
-    int taskId = headlessJsTaskContext.startTask(taskConfig);
-    mActiveTasks.add(taskId);
+
+    Runnable myRunnable = new Runnable() {
+      @Override
+      public void run() {
+        int taskId = headlessJsTaskContext.startTask(taskConfig);
+        mActiveTasks.add(taskId);
+      }
+    };
+
+    UiThreadUtil.runOnUiThread(myRunnable);
   }
 
   @Override


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes. 

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to React Native here: http://facebook.github.io/react-native/docs/contributing.html

Happy contributing!

-->

Headless tasks are required to run in the main thread, however due to the nature of the React context creation flow, the handler may be returned outside of the main thread, causing the HeadlessJsTaskContext to throw an exception.

## Test Plan

Swipe out the app. send push notification from a server that starts a HeadlessJsTaskService
