### PR TITLE
Revert faulty change to HelloWorld demo in docs

### DIFF
--- a/docs/Tutorial.md
+++ b/docs/Tutorial.md
@@ -19,7 +19,7 @@ In accordance with the ancient traditions of our people, we must first build an 
 
 ```ReactNativeWebPlayer
 import React, { Component } from 'react';
-import { Text } from 'react-native';
+import { AppRegistry, Text } from 'react-native';
 
 export default class HelloWorldApp extends Component {
   render() {
@@ -28,6 +28,9 @@ export default class HelloWorldApp extends Component {
     );
   }
 }
+
+// skip this line if using Create React Native App
+AppRegistry.registerComponent('AwesomeProject', () => HelloWorldApp);
 ```
 
 If you are feeling curious, you can play around with sample code directly in the web simulators. You can also paste it into your `App.js` file to create a real app on your local machine.


### PR DESCRIPTION
Related to commit/diff:
https://github.com/facebook/react-native/commit/6e99e314b232c315628c31f97a865c17c071ad23#diff-692279cda23c48738b9688454811448a

The above change breaks "HelloWorld" demo in docs, as you can see at the bottom of the below screenshot:
![image](https://user-images.githubusercontent.com/5363847/30427914-9477d4ee-9949-11e7-8be6-3d6990d6e267.png)

This pull request reverts things just enough to get the demo working correctly again.

I'm new to react-native so I'm not sure if there is another (read: better) solution but by accepting this pull request it would prevent noobs like myself from falling at the first hurdle!

