### PR TITLE
Fix crash when trying to load photo library assets with nil image url

### DIFF
--- a/Libraries/CameraRoll/RCTPhotoLibraryImageLoader.m
+++ b/Libraries/CameraRoll/RCTPhotoLibraryImageLoader.m
@@ -44,7 +44,10 @@ RCT_EXPORT_MODULE()
   // form of an, NSURL which is what assets-library uses.
   NSString *assetID = @"";
   PHFetchResult *results;
-  if ([imageURL.scheme caseInsensitiveCompare:@"assets-library"] == NSOrderedSame) {
+  if (!imageURL) {
+    completionHandler(RCTErrorWithMessage(@"Cannot load a photo library asset with no URL"), nil);
+    return ^{};
+  } else if ([imageURL.scheme caseInsensitiveCompare:@"assets-library"] == NSOrderedSame) {
     assetID = [imageURL absoluteString];
     results = [PHAsset fetchAssetsWithALAssetURLs:@[imageURL] options:nil];
   } else {


### PR DESCRIPTION
## Motivation

This avoids a crash when we try to load a PHAsset with nil image url. Specifically, the following condition evaluates to true when `imageURL` is nil:

```objc
if ([imageURL.scheme caseInsensitiveCompare:@"assets-library"] == NSOrderedSame) {
    assetID = [imageURL absoluteString];
    results = [PHAsset fetchAssetsWithALAssetURLs:@[imageURL] options:nil];
}
```

The crash will be "attempt to insert nil object from objects[0]" when we build the `@[imageURL]` array literal.

We've seen this emerge as a very common crash among Expo users, so I wanted to at least provide a clear error message instead of terminating the app.

## Test Plan

Load an image from the photo library with a nil request url.