### PR TITLE
Provide `options` argument for `global.registerDevtoolsPlugin`

### DIFF
--- a/Libraries/Core/Devtools/setupDevtools.js
+++ b/Libraries/Core/Devtools/setupDevtools.js
@@ -34,7 +34,7 @@ if (__DEV__) {
    * comment and run Flow. */
   const reactDevTools = require('react-devtools-core');
 
-  register = function (plugin: DevToolsPlugin) {
+  register = function (plugin: DevToolsPlugin, options: DevToolsPluginConnection) {
     // Initialize dev tools only if the native module for WebSocket is available
     if (WebSocket.isAvailable) {
       // Don't steal the DevTools from currently active app.
@@ -55,6 +55,7 @@ if (__DEV__) {
         // It was added in https://github.com/facebook/react-native/commit/bf2b435322e89d0aeee8792b1c6e04656c2719a0.
         port: window.__REACT_DEVTOOLS_PORT__,
         resolveRNStyle: require('flattenStyle'),
+        ...options,
       });
     }
   };

--- a/Libraries/Core/Devtools/setupDevtools.js
+++ b/Libraries/Core/Devtools/setupDevtools.js
@@ -51,16 +51,17 @@ if (__DEV__) {
       plugin.connectToDevTools({
         isAppActive,
         host,
-        // Read the optional global variable for backward compatibility.
-        // It was added in https://github.com/facebook/react-native/commit/bf2b435322e89d0aeee8792b1c6e04656c2719a0.
-        port: window.__REACT_DEVTOOLS_PORT__,
         resolveRNStyle: require('flattenStyle'),
         ...options,
       });
     }
   };
 
-  register(reactDevTools);
+  register(reactDevTools, {
+    // Read the optional global variable for backward compatibility.
+    // It was added in https://github.com/facebook/react-native/commit/bf2b435322e89d0aeee8792b1c6e04656c2719a0.
+    port: window.__REACT_DEVTOOLS_PORT__,
+  });
   global.registerDevtoolsPlugin = register;
 }
 


### PR DESCRIPTION
Currently if `__REACT_DEVTOOLS_PORT__` are set, the [relay-runtime](https://github.com/facebook/relay/blob/1ce348a5bc472a58607279c08e2236b8459b5877/packages/relay-runtime/store/RelayModernEnvironment.js#L95-L97) register will use the same port to connect devtools server. I think need to provide an another global variable (like `__RELAY_DEBUGGER_PORT__`), and it should provide an options argument here.

## Test Plan

Tested on RNTester, doesn't affect current `react-devtools` usage.
