### PR TITLE
`uniq` with an iteratee is `uniqBy`

### DIFF
--- a/local-cli/link/link.js
+++ b/local-cli/link/link.js
@@ -14,7 +14,7 @@
  * run Flow. */
 const log = require('npmlog');
 const path = require('path');
-const uniq = require('lodash').uniq;
+const uniqBy = require('lodash').uniqBy;
 const flatten = require('lodash').flatten;
 /* $FlowFixMe(>=0.54.0 site=react_native_oss) This comment suppresses an error
  * found when Flow v0.54 was deployed. To see the error delete this comment and
@@ -45,7 +45,7 @@ import type {RNConfig} from '../core';
 
 log.heading = 'rnpm-link';
 
-const dedupeAssets = (assets) => uniq(assets, asset => path.basename(asset));
+const dedupeAssets = (assets) => uniqBy(assets, asset => path.basename(asset));
 
 
 const linkDependencyAndroid = (androidProject, dependency) => {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes. 

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to React Native here: http://facebook.github.io/react-native/docs/contributing.html

Happy contributing!

-->

The wrong version of the function was being used which was resulting in flow errors.

See https://lodash.com/docs/4.17.4#uniqBy for reference.

## Test Plan

There should probably be *a* test for this. According to [the lodash source](https://github.com/lodash/lodash/blob/4.17.4/lodash.js#L8407), calling `uniq` with a second argument is not supported.

Flow correctly picks up on this, and is causing errors in my project.
