### PR TITLE
add programmatic variant for permission check (Android)

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/modules/location/LocationModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/location/LocationModule.java
@@ -238,8 +238,13 @@ public class LocationModule extends ReactContextBaseJavaModule {
   private static void throwLocationPermissionMissing(SecurityException e) {
     throw new SecurityException(
       "Looks like the app doesn't have the permission to access location.\n" +
-      "Add the following line to your app's AndroidManifest.xml:\n" +
-      "<uses-permission android:name=\"android.permission.ACCESS_FINE_LOCATION\" />", e);
+      "To solve this add the following line to your app's AndroidManifest.xml:\n" +
+      "<uses-permission android:name=\"android.permission.ACCESS_FINE_LOCATION\" />\n" +
+      "Or request the permission programmatically before accessing the location using the following example:\n" +
+      "PermissionsAndroid.request(PermissionsAndroid.PERMISSIONS.ACCESS_FINE_LOCATION)\n" +
+      "  .then((result) => {\n" +
+      "    if (PermissionsAndroid.RESULTS.GRANTED === result) { ... }\n" +
+      "  })", e);
   }
 
   private static class SingleUpdateRequest {


### PR DESCRIPTION
It can happen that location access is denied by the user because of them checking the "don't show again" checkbox in the permission dialog. When this is the case, every subsequent request of accessing the location will make the app crash, even when the permission is added to the manifest.

By updating the exception message I would like it to be more clear to developers where else to look than in the `AndroidManifest.xml`. But it might be necessary to make it even more descriptive/to elaborate on the specific case described before.