### PR TITLE
Fix run-android --root option behavior.

### DIFF
--- a/local-cli/runAndroid/runAndroid.js
+++ b/local-cli/runAndroid/runAndroid.js
@@ -20,7 +20,8 @@ const Promise = require('promise');
 
 // Verifies this is an Android project
 function checkAndroid(root) {
-  return fs.existsSync(path.join(root, 'android/gradlew'));
+  const androidProjectPath = root ? root : 'android';
+  return fs.existsSync(path.join(androidProjectPath, 'gradlew'));
 }
 
 /**
@@ -90,7 +91,8 @@ function tryRunAdbReverse(packagerPort, device) {
 
 // Builds the app and runs it on a connected emulator / device.
 function buildAndRun(args) {
-  process.chdir(path.join(args.root, 'android'));
+  const androidProjectPath = args.root ? args.root : 'android';
+  process.chdir(path.join(androidProjectPath));
   const cmd = process.platform.startsWith('win')
     ? 'gradlew.bat'
     : './gradlew';
@@ -291,7 +293,7 @@ module.exports = {
     command: '--install-debug',
   }, {
     command: '--root [string]',
-    description: 'Override the root directory for the android build (which contains the android directory)',
+    description: 'Path relative to project root directory where the Android project lives. The default is \'android\'.',
     default: '',
   }, {
     command: '--flavor [string]',


### PR DESCRIPTION
Make it not to require to store project inside `%root%/android`, use `%root%` itself.
If no `root` provided, use 'android' as default.

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes. 

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to React Native here: http://facebook.github.io/react-native/docs/contributing.html

Happy contributing!

-->
I have an existing android project and want to integrate react-native with it. My project is NOT stored inside `android` directory. Current behavior of `--root` option for `react-native run-android` requires to store project inside `%root%/android`. I think it would be more flexible to just use `%root%` and not to require `android` folder inside it.

## Test Plan
1. react-native init AwesomeApp
2. cd AwesomeApp
2. react-native run-android
  Should run Android app as usual.
3. Move ./android folder contents to ./myAndroidApp/internalAppFolder:
  mkdir -R myAndroidApp/internalAppFolder
  mv -v android/* myAndroidApp/internalAppFolder/
4. react-native run-android --root=myAndroidApp/internalAppFolder
  Should also run Android app.