### PR TITLE
Update HeadlessJSAndroid.md explaining parameters

### DIFF
--- a/docs/HeadlessJSAndroid.md
+++ b/docs/HeadlessJSAndroid.md
@@ -43,7 +43,9 @@ public class MyTaskService extends HeadlessJsTaskService {
       return new HeadlessJsTaskConfig(
           "SomeTaskName",
           Arguments.fromBundle(extras),
-          5000);
+          5000, // timeout for the task
+          false // optional: defines whether or not  the task is allowed in foreground. Default is false
+        );
     }
     return null;
   }


### PR DESCRIPTION
HeadlessJsTaskConfig parameters can be unclear, so I added one more parameter that was left set by default and the respective comments.