### PR TITLE
Capitalize Y in Yoga for pod file.

### DIFF
--- a/docs/IntegrationWithExistingApps.md
+++ b/docs/IntegrationWithExistingApps.md
@@ -225,7 +225,7 @@ target 'NumberTileGame' do
     # Add any other subspecs you want to use in your project
   ]
   # Explicitly include Yoga if you are using RN >= 0.42.0
-  pod 'yoga', :path => '../node_modules/react-native/ReactCommon/yoga'
+  pod 'Yoga', :path => '../node_modules/react-native/ReactCommon/yoga'
 
 end
 ```


### PR DESCRIPTION
If I don't capitalize the Y in "yoga" in the Podfile I receive these warnings:
```shell
Fetching podspec for `yoga` from `../node_modules/react-native/ReactCommon/yoga`
[!] The name of the given podspec `Yoga` doesn't match the expected one `yoga`
```

I know that in the past the "Y" was capitalized, but somewhere along the way it looks like it got upcased. Ignore this if it is meant to be upcased moving forward.
