### PR TITLE
call out that /img/favicon.png must be added

### DIFF
--- a/docs/UsingAScrollView.md
+++ b/docs/UsingAScrollView.md
@@ -10,7 +10,7 @@ previous: handling-touches
 
 The [ScrollView](docs/scrollview.html) is a generic scrolling container that can host multiple components and views. The scrollable items need not be homogenous, and you can scroll both vertically and horizontally (by setting the `horizontal` property).
 
-This example creates a vertical `ScrollView` with both images and text mixed together.
+This example creates a vertical `ScrollView` with both images and text mixed together. Before running this code, you must have a folder called "img" with an image called "favicon.png" inside your app's main folder, or change the url to point to an image in your directory.
 
 ```ReactNativeWebPlayer
 import React, { Component } from 'react';


### PR DESCRIPTION
Users who start with Create React Native App will not have an img folder or favicon.png in their app folder structure. These users may not immediately understand how to overcome the error that they will get. Added text clarifies that an image file is needed.

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes. 

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to React Native here: http://facebook.github.io/react-native/docs/contributing.html

Happy contributing!

-->

(Write your motivation here.)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)
