### PR TITLE
Change attribute mentioned in alignItem

### DIFF
--- a/docs/LayoutWithFlexbox.md
+++ b/docs/LayoutWithFlexbox.md
@@ -73,7 +73,7 @@ AppRegistry.registerComponent('AwesomeProject', () => JustifyContentBasics);
 
 Adding `alignItems` to a component's style determines the **alignment** of children along the **secondary axis** (if the primary axis is `row`, then the secondary is `column`, and vice versa). Should children be aligned at the start, the center, the end, or stretched to fill? Available options are `flex-start`, `center`, `flex-end`, and `stretch`.
 
-> For `stretch` to have an effect, children must not have a fixed dimension along the secondary axis. In the following example, setting `alignItems: stretch` does nothing until the `width: 50` is removed from the children.
+> For `stretch` to have an effect, children must not have a fixed dimension along the secondary axis. In the following example, setting `alignItems: stretch` does nothing until the `height: 50` is removed from the children.
 
 ```ReactNativeWebPlayer
 import React, { Component } from 'react';


### PR DESCRIPTION
Since alignItem works on the secondary axis, in the example, the value heigth: 50 should be deleted so that alignItem: 'stretch' can work. Not width: 50. In fact, width needs to be there, or else no component will be shown at all.

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes. 

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to React Native here: http://facebook.github.io/react-native/docs/contributing.html

Happy contributing!

-->

(Write your motivation here.)

## Test Plan

I'm going through the docs, that's why I found this. It's already tested!

Apologize if I'm contributing the wrong way. I read the instructions, but this is my first time ever, and will try to do it again correctly if needed.