### PR TITLE
Add finally method to Promise flow definition

### DIFF
--- a/flow/Promise.js
+++ b/flow/Promise.js
@@ -33,6 +33,12 @@ declare class Promise<+R> {
   static race<T>(promises: Array<Promise<T>>): Promise<T>;
 
   // Non-standard APIs
+
+  // See https://github.com/facebook/fbjs/blob/master/packages/fbjs/src/__forks__/Promise.native.js#L21
+  finally<U>(
+    onFinally?: ?(value: any) => Promise<U> | U
+  ): Promise<U>;
+
   done<U>(
     onFulfill?: ?(value: R) => mixed,
     onReject?: ?(error: any) => mixed


### PR DESCRIPTION
The `finally` method definition was missing, while it really exists causing a flow error when using it.

## Test Plan

Added the method definition and make sure flow doesn't throw any error anymore on a real-life example.

