### PR TITLE
Set view id before addEventEmitters, fix #16122

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeViewHierarchyManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeViewHierarchyManager.java
@@ -229,6 +229,9 @@ public class NativeViewHierarchyManager {
       // React views from layout xmls. Thus it is easier to just reuse that field instead of
       // creating another (potentially much more expensive) mapping from view to React tag
       view.setId(tag);
+
+      // setId after event emitter may cause bugs
+      viewManager.addEventEmitters(themedContext, view);
       if (initialProps != null) {
         viewManager.updateProperties(view, initialProps);
       }

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManager.java
@@ -42,7 +42,6 @@ public abstract class ViewManager<T extends View, C extends ReactShadowNode>
       ThemedReactContext reactContext,
       JSResponderHandler jsResponderHandler) {
     T view = createViewInstance(reactContext);
-    addEventEmitters(reactContext, view);
     if (view instanceof ReactInterceptingViewGroup) {
       ((ReactInterceptingViewGroup) view).setOnInterceptTouchEventListener(jsResponderHandler);
     }


### PR DESCRIPTION


(Write your motivation here.)

1.  I built a map native UI component and want to send map loaded event to JS
2.  override addEventEmitters method and set up map loaded listener
3.  inside listener use RCTEventEmitter's receiveEvent method to send event

### Expected Behavior

In my custom map JS component will receive map loaded event.

### Actual Behavior

Custom map JS component never received the event

### Issue #16122 

## Test Plan
I built a demo to test the fix. And it works like I expected. 
https://github.com/zhgqthomas/build-react-native
