### PR TITLE
Restore platform-specific cookie behavior

### DIFF
--- a/Libraries/Network/RCTHTTPRequestHandler.mm
+++ b/Libraries/Network/RCTHTTPRequestHandler.mm
@@ -63,9 +63,6 @@ RCT_EXPORT_MODULE()
     callbackQueue.maxConcurrentOperationCount = 1;
     callbackQueue.underlyingQueue = [[_bridge networking] methodQueue];
     NSURLSessionConfiguration *configuration = [NSURLSessionConfiguration defaultSessionConfiguration];
-    [configuration setHTTPShouldSetCookies:YES];
-    [configuration setHTTPCookieAcceptPolicy:NSHTTPCookieAcceptPolicyAlways];
-    [configuration setHTTPCookieStorage:[NSHTTPCookieStorage sharedHTTPCookieStorage]];
     _session = [NSURLSession sessionWithConfiguration:configuration
                                              delegate:self
                                         delegateQueue:callbackQueue];

--- a/Libraries/Network/RCTNetworking.mm
+++ b/Libraries/Network/RCTNetworking.mm
@@ -228,19 +228,7 @@ RCT_EXPORT_MODULE()
   NSURL *URL = [RCTConvert NSURL:query[@"url"]]; // this is marked as nullable in JS, but should not be null
   NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:URL];
   request.HTTPMethod = [RCTConvert NSString:RCTNilIfNull(query[@"method"])].uppercaseString ?: @"GET";
-
-  // Load and set the cookie header.
-  NSArray<NSHTTPCookie *> *cookies = [[NSHTTPCookieStorage sharedHTTPCookieStorage] cookiesForURL:URL];
-  request.allHTTPHeaderFields = [NSHTTPCookie requestHeaderFieldsWithCookies:cookies];
-
-  // Set supplied headers.
-  NSDictionary *headers = [RCTConvert NSDictionary:query[@"headers"]];
-  [headers enumerateKeysAndObjectsUsingBlock:^(NSString *key, id value, BOOL *stop) {
-    if (value) {
-      [request addValue:[RCTConvert NSString:value] forHTTPHeaderField:key];
-    }
-  }];
-
+  request.allHTTPHeaderFields = [self stripNullsInRequestHeaders:[RCTConvert NSDictionary:query[@"headers"]]];
   request.timeoutInterval = [RCTConvert NSTimeInterval:query[@"timeout"]];
   request.HTTPShouldHandleCookies = [RCTConvert BOOL:query[@"withCredentials"]];
   NSDictionary<NSString *, id> *data = [RCTConvert NSDictionary:RCTNilIfNull(query[@"data"])];

--- a/Libraries/WebSocket/RCTWebSocketModule.m
+++ b/Libraries/WebSocket/RCTWebSocketModule.m
@@ -64,20 +64,6 @@ RCT_EXPORT_MODULE()
 RCT_EXPORT_METHOD(connect:(NSURL *)URL protocols:(NSArray *)protocols options:(NSDictionary *)options socketID:(nonnull NSNumber *)socketID)
 {
   NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:URL];
-
-  // We load cookies from sharedHTTPCookieStorage (shared with XHR and
-  // fetch). To get secure cookies for wss URLs, replace wss with https
-  // in the URL.
-  NSURLComponents *components = [NSURLComponents componentsWithURL:URL resolvingAgainstBaseURL:true];
-  if ([components.scheme.lowercaseString isEqualToString:@"wss"]) {
-    components.scheme = @"https";
-  }
-
-  // Load and set the cookie header.
-  NSArray<NSHTTPCookie *> *cookies = [[NSHTTPCookieStorage sharedHTTPCookieStorage] cookiesForURL:components.URL];
-  request.allHTTPHeaderFields = [NSHTTPCookie requestHeaderFieldsWithCookies:cookies];
-
-  // Load supplied headers
   [options[@"headers"] enumerateKeysAndObjectsUsingBlock:^(NSString *key, id value, BOOL *stop) {
     [request addValue:[RCTConvert NSString:value] forHTTPHeaderField:key];
   }];


### PR DESCRIPTION
This PR reverts commit 047961fbf77cb012b53978184102e8ca3d00c7ec, which was introduced by #10575.

The original patch was intended to make iOS behave more like a standards-compliant web browser in its handling of cookies. Specifically, it was built to seamlessly share the cookie jar between standard HTTP and WebSocket requests.

While the goals of the original patch are understandable, they contradict the outcome of a spirited debate within the community in https://github.com/facebook/react-native/issues/14063#issuecomment-303490425. The debate was whether React Native should default to platform-specific networking behavior, or whether it should try to normalize across platforms (with an eye towards behaving as close to a web browser as possible). **The community resoundingly voted for preserving platform-specific behavior, 31 to 3.**

This custom behavior arose as an issue because the patch in question breaks the semantics around `withCredentials` on `fetch`. Instead of mapping that value to `setHTTPCookieAcceptPolicy`, it pins `setHTTPCookieAcceptPolicy` to `.Always` and defines custom behavior. Naturally, the custom behavior fails to emulate the many edge-cases that exist in the system level cookie handling, which has led to a number of people complaining on #14869 and #14931.

I laid out an argument for both sides in https://github.com/facebook/react-native/pull/14931#issuecomment-318149698 and was met with mostly silence. However, stating my intention to revert the original patch garnered some support (as you'll see on that thread), and so here we are.

Hopefully this PR can provoke the conversation that needs to be had around cookie behavior, but in the absence of strong objection, I think the correct course of action is to merge this reversion and get RN a little further out of the business of abstracting the networking stack on iOS.