### PR TITLE
Improve YellowBox output format

### DIFF
--- a/Libraries/ReactNative/YellowBox.js
+++ b/Libraries/ReactNative/YellowBox.js
@@ -106,17 +106,22 @@ function sprintf(format, ...args) {
   return format.replace(/%s/g, match => args[index++]);
 }
 
-function updateWarningMap(format, ...args): void {
+function updateWarningMap(...args): void {
   if (console.disableYellowBox) {
     return;
   }
 
-  format = String(format);
-  const argCount = (format.match(/%s/g) || []).length;
-  const warning = [
-    sprintf(format, ...args.slice(0, argCount)),
-    ...args.slice(argCount).map(stringifySafe),
-  ].join(' ');
+  let warning;
+  if (typeof args[0] === 'string') {
+    const [format, ...formatArgs] = args;
+    const argCount = (format.match(/%s/g) || []).length;
+    warning = [
+      sprintf(format, ...formatArgs.slice(0, argCount).map(stringifySafe)),
+      ...formatArgs.slice(argCount).map(stringifySafe),
+    ].join(' ');
+  } else {
+    warning = args.map(stringifySafe).join(' ');
+  }
 
   if (warning.startsWith('(ADVICE)')) {
     return;


### PR DESCRIPTION
YellowBox currently assumes the first arg is a printf like format string, this adds support for any arguments so it works more like console in the browser. This also adds `stringifySafe` to format arguments when using printf style.

The main annoyance that this fixes is when trying to log a single object it will currently print [object Object] instead of the fully stringified version.

**Test plan**

Tested a bunch of different log combinations.

```js
console.warn({test: 'a'}); // {"test":"a"} (was [object Object] before this patch)
console.warn('test %s %s', 1, {}); // test 1 {}
console.warn('test %s', 1, {}); // test 1 {}
console.warn({}, {}, {}, {}); // {} {} {} {}
```