### PR TITLE
Update Animated docs to mention potential issues with VirtualizedList

### DIFF
--- a/Libraries/Animated/src/AnimatedImplementation.js
+++ b/Libraries/Animated/src/AnimatedImplementation.js
@@ -827,8 +827,11 @@ module.exports = {
   /**
   * Loops a given animation continuously, so that each time it reaches the
   * end, it resets and begins again from the start. Can specify number of
-  * times to loop using the key 'iterations' in the config. Will loop without
-  * blocking the UI thread if the child animation is set to 'useNativeDriver'.
+  * times to loop using the key `iterations` in the config. Will loop without
+  * blocking the UI thread if the child animation is set to `useNativeDriver: true`.
+  * In addition, loops can prevent `VirtualizedList`-based components from rendering
+  * more rows while the animation is running. You can pass `isInteraction: false` in the
+  * child animation config to fix this.
   */
   loop,
 

--- a/docs/Animations.md
+++ b/docs/Animations.md
@@ -360,6 +360,8 @@ things like `transform` and `opacity` will work, but flexbox and position proper
 When using `Animated.event`, it will only work with direct events and not bubbling events.
 This means it does not work with `PanResponder` but does work with things like `ScrollView#onScroll`.
 
+When an animation is running, it can prevent `VirtualizedList` components from rendering more rows. If you need to run a long or looping animation while the user is scrolling through a list, you can use `isInteraction: false` in your animation's config to prevent this issue.
+
 ### Bear in mind
 
 While using transform styles such as `rotateY`, `rotateX`, and others ensure the transform style `perspective` is in place.


### PR DESCRIPTION
Doc update to clarify how to prevent `Animated.loop` and other animations from pre-empting `VirtualizedList` rendering as discussed in #16092.