### PR TITLE
Don't set defaultProps for default view manager values

### DIFF
--- a/Libraries/Text/Text.js
+++ b/Libraries/Text/Text.js
@@ -408,7 +408,6 @@ const Text = createReactClass({
       accessible: true,
       allowFontScaling: true,
       ellipsizeMode: 'tail',
-      disabled: false,
     };
   },
   getInitialState: function(): Object {


### PR DESCRIPTION
The Android ViewManager already has disabled set to false by default. When setting it in defaultProps we send it over for every text view, which is unnecessary.

On platforms that don't support disabled this may also cause unnecessary log noise.