### PR TITLE
Issue #16159 - RCTImageStoreManager's priority

### DIFF
--- a/Libraries/Image/RCTImageLoader.m
+++ b/Libraries/Image/RCTImageLoader.m
@@ -66,7 +66,7 @@ RCT_EXPORT_MODULE()
 
 - (float)handlerPriority
 {
-    return 1;
+    return 2;
 }
 
 - (id<RCTImageCache>)imageCache

--- a/Libraries/Image/RCTImageStoreManager.m
+++ b/Libraries/Image/RCTImageStoreManager.m
@@ -32,6 +32,11 @@ static NSString *const RCTImageStoreURLScheme = @"rct-image-store";
 
 RCT_EXPORT_MODULE()
 
+- (float)handlerPriority
+{
+    return 1;
+}
+
 - (void)removeImageForTag:(NSString *)imageTag withBlock:(void (^)())block
 {
   dispatch_async(_methodQueue, ^{


### PR DESCRIPTION
Summary: RCTImageStoreManager and RCTBlobManager have the same priority, hence in certain cases, both are able to handle the request, but this causes non-deterministic behavior. Hence increased ImageStoreManager's Priority to 1 and thereby increasing RCTImageLoader's Priority to 2 to prevent similar issue of same priorities.

Issue: #16159
