### PR TITLE
Modernize docs: remove 'use strict' from docs -- es6 has 'use strict' by default

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -180,7 +180,7 @@ However, there are still some styles that the linter cannot pick up.
 #### JavaScript
 
 * Use semicolons;
-* `'use strict';`
+* ES6 standards
 * Prefer `'` over `"`
 * Do not use the optional parameters of `setTimeout` and `setInterval`
 * 80 character line length

--- a/docs/CommunicationAndroid.md
+++ b/docs/CommunicationAndroid.md
@@ -46,7 +46,6 @@ public class MainActivity extends ReactActivity {
 ```
 
 ```
-'use strict';
 
 import React from 'react';
 import {

--- a/docs/CommunicationIOS.md
+++ b/docs/CommunicationIOS.md
@@ -39,7 +39,6 @@ RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:bridge
 ```
 
 ```
-'use strict';
 
 import React from 'react';
 import {

--- a/docs/Contributing.md
+++ b/docs/Contributing.md
@@ -187,7 +187,7 @@ However, there are still some styles that the linter cannot pick up.
 #### JavaScript
 
 * Use semicolons;
-* `;`
+* ES6 standards
 * Prefer `'` over `"`
 * Do not use the optional parameters of `setTimeout` and `setInterval`
 * 80 character line length

--- a/docs/Contributing.md
+++ b/docs/Contributing.md
@@ -187,7 +187,7 @@ However, there are still some styles that the linter cannot pick up.
 #### JavaScript
 
 * Use semicolons;
-* `'use strict';`
+* `;`
 * Prefer `'` over `"`
 * Do not use the optional parameters of `setTimeout` and `setInterval`
 * 80 character line length

--- a/docs/CustomWebViewIOS.md
+++ b/docs/CustomWebViewIOS.md
@@ -151,6 +151,7 @@ To use your custom web view, you'll need to create a class for it. Your class mu
 To get your native component, you must use `requireNativeComponent`: the same as for regular custom components. However, you must pass in an extra third argument, `WebView.extraNativeComponentConfig`. This third argument contains prop types that are only required for native code.
 
 ```js
+
 import React, { Component, PropTypes } from 'react';
 import { WebView, requireNativeComponent, NativeModules } from 'react-native';
 const { CustomWebViewManager } = NativeModules; 
@@ -176,6 +177,7 @@ const RCTCustomWebView = requireNativeComponent(
   CustomWebView,
   WebView.extraNativeComponentConfig
 );
+
 ```
 
 If you want to add custom props to your native component, you can use `nativeConfig.props` on the web view. For iOS, you should also set the `nativeConfig.viewManager` prop with your custom WebView ViewManager as in the example above.

--- a/docs/IntegrationWithExistingApps.md
+++ b/docs/IntegrationWithExistingApps.md
@@ -599,7 +599,6 @@ First, create an empty `index.js` file in the root of your React Native project.
 In your `index.js`, create your component. In our sample here, we will add simple `<Text>` component within a styled `<View>`:
 
 ```javascript
-;
 
 import React from 'react';
 import {

--- a/docs/IntegrationWithExistingApps.md
+++ b/docs/IntegrationWithExistingApps.md
@@ -305,7 +305,6 @@ First, create an empty `index.js` file in the root of your React Native project.
 In your `index.js`, create your component. In our sample here, we will add simple `<Text>` component within a styled `<View>`
 
 ```javascript
-'use strict';
 
 import React from 'react';
 import {
@@ -600,7 +599,7 @@ First, create an empty `index.js` file in the root of your React Native project.
 In your `index.js`, create your component. In our sample here, we will add simple `<Text>` component within a styled `<View>`:
 
 ```javascript
-'use strict';
+;
 
 import React from 'react';
 import {

--- a/docs/NativeModulesAndroid.md
+++ b/docs/NativeModulesAndroid.md
@@ -144,7 +144,7 @@ protected List<ReactPackage> getPackages() {
 To make it simpler to access your new functionality from JavaScript, it is common to wrap the native module in a JavaScript module. This is not necessary but saves the consumers of your library the need to pull it off of `NativeModules` each time. This JavaScript file also becomes a good location for you to add any JavaScript side functionality.
 
 ```js
-'use strict';
+;
 /**
  * This exposes the native ToastExample module as a JS module. This has a
  * function 'show' which takes the following parameters:

--- a/docs/NativeModulesAndroid.md
+++ b/docs/NativeModulesAndroid.md
@@ -144,7 +144,6 @@ protected List<ReactPackage> getPackages() {
 To make it simpler to access your new functionality from JavaScript, it is common to wrap the native module in a JavaScript module. This is not necessary but saves the consumers of your library the need to pull it off of `NativeModules` each time. This JavaScript file also becomes a good location for you to add any JavaScript side functionality.
 
 ```js
-;
 /**
  * This exposes the native ToastExample module as a JS module. This has a
  * function 'show' which takes the following parameters:


### PR DESCRIPTION
Removed <b>'use strict'</b> from docs since ES6 Modules already use <b>'use strict'</b>  by default.

https://stackoverflow.com/questions/31685262/not-recommended-to-use-use-strict-in-es6



> 10.2.1 Strict Mode Code

> An ECMAScript Script syntactic unit may be processed using either unrestricted or strict mode syntax and semantics. Code is interpreted as strict mode code in the following situations:

> Global code is strict mode code if it begins with a Directive Prologue that contains a Use Strict Directive (see 14.1.1).
Module code is always strict mode code.
All parts of a ClassDeclaration or a ClassExpression are strict mode code.
Eval code is strict mode code if it begins with a Directive Prologue that contains a Use Strict Directive or if the call to eval is a direct eval (see 12.3.4.1) that is contained in strict mode code.
Function code is strict mode code if the associated FunctionDeclaration, FunctionExpression, GeneratorDeclaration, GeneratorExpression, MethodDefinition, or ArrowFunction is contained in strict mode code or if the code that produces the value of the function’s [[ECMAScriptCode]] internal slot begins with a Directive Prologue that contains a Use Strict Directive.
Function code that is supplied as the arguments to the built-in Function and Generator constructors is strict mode code if the last argument is a String that when processed is a FunctionBody that begins with a Directive Prologue that contains a Use Strict Directive.

Spec: http://www.ecma-international.org/ecma-262/6.0/#sec-strict-mode-code
