### PR TITLE
Removed a wrong assert.

### DIFF
--- a/React/Modules/RCTUIManager.m
+++ b/React/Modules/RCTUIManager.m
@@ -376,7 +376,9 @@ static NSDictionary *deviceOrientationEventBody(UIDeviceOrientation orientation)
   NSNumber *reactTag = view.reactTag;
   dispatch_async(RCTGetUIManagerQueue(), ^{
     RCTShadowView *shadowView = self->_shadowViewRegistry[reactTag];
-    RCTAssert(shadowView != nil, @"Could not locate view with tag #%@", reactTag);
+    if (shadowView == nil) {
+      return;
+    }    
 
     if (!CGSizeEqualToSize(shadowView.intrinsicContentSize, size)) {
       shadowView.intrinsicContentSize = size;

--- a/React/Modules/RCTUIManager.m
+++ b/React/Modules/RCTUIManager.m
@@ -377,6 +377,7 @@ static NSDictionary *deviceOrientationEventBody(UIDeviceOrientation orientation)
   dispatch_async(RCTGetUIManagerQueue(), ^{
     RCTShadowView *shadowView = self->_shadowViewRegistry[reactTag];
     if (shadowView == nil) {
+      RCTLogWarn(@"Could not locate shadow view with tag #%@, this is probably caused by a temporary inconsistency between native views and shadow views.", reactTag);
       return;
     }    
 


### PR DESCRIPTION
This fixes [#15801](https://github.com/facebook/react-native/issues/15801)

We ran into a strange crash on iOS (debug only). After removing the clutter I was able to reproduce it in a tiny app. You can check it out [here.](https://github.com/simonracz/textinput_stress)

The UI in JS and native are not always in sync (which is okay). Due to this, a native view might call back into JS, which is no longer present in the shadow view hierarchy there. I think this should be also okay.

TextInput in some cases calls into [setIntrinsicContentView](https://github.com/facebook/react-native/blob/6d67e2dbbcd658b7f845ebb0d0156bd64dc68226/React/Modules/RCTUIManager.m#L382), where it triggers an overly enthusiastic `NSAssert` and crashes the app.

## Test Plan

Check out [textinput_stress](https://github.com/simonracz/textinput_stress)
Rotate the simulator a few times to see the crash or the lack of crash.