### PR TITLE
Updating blog post about RTL from setAllowRTL to allowRTL (Android).

### DIFF
--- a/blog/2016-08-19-right-to-left-support-for-react-native-apps.md
+++ b/blog/2016-08-19-right-to-left-support-for-react-native-apps.md
@@ -57,7 +57,7 @@ With this update, when you allow RTL layout for your app:
     ```java
     // in MainActivity.java
   	I18nUtil sharedI18nUtilInstance = I18nUtil.getInstance();
-  	sharedI18nUtilInstance.setAllowRTL(context, true);
+  	sharedI18nUtilInstance.allowRTL(context, true);
     ```
 
 3. For Android, you need add `android:supportsRtl="true"` to the [`<application>`](http://developer.android.com/guide/topics/manifest/application-element.html) element in `AndroidManifest.xml` file.


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes. 

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to React Native here: http://facebook.github.io/react-native/docs/contributing.html

Happy contributing!

-->

Updating blog post about RTL to use updated function `sharedI18nUtilInstance.allowRTL` for Android as mentioned in [this issue](https://github.com/facebook/react-native/issues/16166)

## Test Plan

Check [this blog post](https://facebook.github.io/react-native/blog/2016/08/19/right-to-left-support-for-react-native-apps.html).
