### PR TITLE
[Pods] Set fishhook's header_dir to "fishhook"

### DIFF
--- a/React.podspec
+++ b/React.podspec
@@ -204,6 +204,7 @@ Pod::Spec.new do |s|
   end
 
   s.subspec "fishhook" do |ss|
+    ss.header_dir           = "fishhook"
     ss.source_files         = "Libraries/fishhook/*.{h,c}"
   end
 


### PR DESCRIPTION
This lets us import fishhook like `<fishhook/fishhook.h>`.

Test Plan: Used this in a CocoaPods project with RN and was able to compile without needing to edit the existing fishhook import.

Fixes: #16039
Should address #16130 without needing to modify source that affects FB 