### PR TITLE
more detailed CxxModule logging

### DIFF
--- a/ReactCommon/cxxreact/CxxNativeModule.cpp
+++ b/ReactCommon/cxxreact/CxxNativeModule.cpp
@@ -4,7 +4,7 @@
 #include "Instance.h"
 
 #include <iterator>
-
+#include <glog/logging.h>
 #include <folly/json.h>
 
 #include "JsArgumentHelpers.h"
@@ -12,7 +12,6 @@
 #include "MessageQueueThread.h"
 
 using facebook::xplat::module::CxxModule;
-
 namespace facebook {
 namespace react {
 
@@ -140,9 +139,14 @@ void CxxNativeModule::invoke(unsigned int reactMethodId, folly::dynamic&& params
       method.func(std::move(params), first, second);
     } catch (const facebook::xplat::JsArgumentException& ex) {
       throw;
+    } catch (std::exception& e) {
+      LOG(ERROR) << "std::exception. Method call " << method.name.c_str() << " failed: " << e.what();
+      std::terminate();
+    } catch (std::string& error) {
+      LOG(ERROR) << "std::string. Method call " << method.name.c_str() << " failed: " << error.c_str();
+      std::terminate();
     } catch (...) {
-      // This means some C++ code is buggy.  As above, we fail hard so the C++
-      // developer can debug and fix it.
+      LOG(ERROR) << "Method call " << method.name.c_str() << " failed. unknown error";
       std::terminate();
     }
   });


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes. 

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to React Native here: http://facebook.github.io/react-native/docs/contributing.html

Happy contributing!

-->

Cxx module code swallows c++ exception details with sarcastic comment let native developer figure it out.

Now instead of swallowing it, we print as much information as we can for different exception types.
Still not ideal but way more informative.

## Test Plan
Have a crash in your c++ module and try to figure it out without this change.
