### PR TITLE
Return instancetype for shared RCTI18nUtil instance

### DIFF
--- a/React/Modules/RCTI18nUtil.h
+++ b/React/Modules/RCTI18nUtil.h
@@ -17,11 +17,12 @@
  */
 @interface RCTI18nUtil : NSObject
 
++ (instancetype)sharedInstance;
+
 - (BOOL)isRTL;
 - (BOOL)isRTLAllowed;
 - (void)allowRTL:(BOOL)value;
 - (BOOL)isRTLForced;
 - (void)forceRTL:(BOOL)value;
-+ (instancetype)sharedInstance;
 
 @end

--- a/React/Modules/RCTI18nUtil.h
+++ b/React/Modules/RCTI18nUtil.h
@@ -22,6 +22,6 @@
 - (void)allowRTL:(BOOL)value;
 - (BOOL)isRTLForced;
 - (void)forceRTL:(BOOL)value;
-+ (id)sharedInstance;
++ (instancetype)sharedInstance;
 
 @end

--- a/React/Modules/RCTI18nUtil.m
+++ b/React/Modules/RCTI18nUtil.m
@@ -13,13 +13,15 @@
 
 @implementation RCTI18nUtil
 
-+ (id)sharedInstance {
-   static RCTI18nUtil *sharedRCTI18nUtilInstance = nil;
-   @synchronized(self) {
-     if (sharedRCTI18nUtilInstance == nil)
-      sharedRCTI18nUtilInstance = [self new];
-   }
-   return sharedRCTI18nUtilInstance;
++ (instancetype)sharedInstance
+{
+  static RCTI18nUtil *sharedInstance;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    sharedInstance = [self new];
+  });
+  
+  return sharedInstance;
 }
 
 /**


### PR DESCRIPTION
## Motivation

In modern Objective-C you should use the `instancetype` keyword for methods which return an instance of the class they are called on. See Apple's [Adopting Modern Objective-C](https://developer.apple.com/library/content/releasenotes/ObjectiveC/ModernizationObjC/AdoptingModernObjective-C/AdoptingModernObjective-C.html) guide.

Because `sharedInstance` was returning an object of type `id`, the returned value needed to be cast before it could be used in Swift.

I also changed the implementation of `sharedInstance` to use Grand Central Dispatch, which is the generally accepted best way of creating a singleton in Objective-C.

## Test Plan

I verified my changes with the "RTLExample" app in RNTester.

| LTR | RTL |
|---|---|
|<img width="300" src="https://user-images.githubusercontent.com/1413388/31155210-6454b4d6-a87a-11e7-9dd7-9a52f3924737.png">|<img width="300" src="https://user-images.githubusercontent.com/1413388/31155233-8702aff6-a87a-11e7-8028-51cf2b3eb0c4.png">|
