### PR TITLE
Documentation about ABI split in Android Release

### DIFF
--- a/docs/SignedAPKAndroid.md
+++ b/docs/SignedAPKAndroid.md
@@ -97,6 +97,23 @@ Note that `--variant=release` is only available if you've set up signing as desc
 
 You can kill any running packager instances, all your framework and JavaScript code is bundled in the APK's assets.
 
+### Split APKs by ABI to reduce file size
+
+By default, the generated APK has the native code for both x86 and ARMv7a CPU architectures. This makes it easier to share APKs that run on almost all Android devices. However, this has the downside that there will be some unused native code on any device, leading to unnecessarily bigger APKs.
+
+You can create an APK for each CPU by changing the following line in android/app/build.gradle:
+``` diff
+- def enableSeparateBuildPerCPUArchitecture = false
++ def enableSeparateBuildPerCPUArchitecture = true
+```
+
+Upload both these files to markets which support device targetting, such as [Google Play](https://developer.android.com/google/play/publishing/multiple-apks.html) and [Amazon AppStore](https://developer.amazon.com/docs/app-submission/getting-started-with-device-targeting.html) and the users will automatically get the appropriate APK. If you want to upload to other markets such as [APKFiles](https://www.apkfiles.com/), which do not support multiple APKs for a single app, change the following line as well to create the default universal APK with binaries for both CPUs.
+
+``` diff
+- universalApk false  // If true, also generate a universal APK
++ universalApk true  // If true, also generate a universal APK
+```
+
 ### Enabling Proguard to reduce the size of the APK (optional)
 
 Proguard is a tool that can slightly reduce the size of the APK. It does this by stripping parts of the React Native Java bytecode (and its dependencies) that your app is not using.


### PR DESCRIPTION
It leads to a reduction of 5-7MB for an app, which is a considerable saving when it comes to emerging markets. Also, I had written a [comment](https://github.com/facebook/react-native/issues/5037#issuecomment-223758335) on an issue which seems to have helped at least 26 people.