### PR TITLE
Use UnimplementedView for CheckBox on iOS

### DIFF
--- a/Libraries/Components/CheckBox/CheckBox.android.js
+++ b/Libraries/Components/CheckBox/CheckBox.android.js
@@ -27,7 +27,7 @@ type DefaultProps = {
 };
 
 /**
- * Renders a boolean input.
+ * Renders a boolean input (Android only).
  *
  * This is a controlled component that requires an `onValueChange` callback that
  * updates the `value` prop in order for the component to reflect user actions.

--- a/Libraries/Components/CheckBox/CheckBox.ios.js
+++ b/Libraries/Components/CheckBox/CheckBox.ios.js
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule CheckBox
+ * @flow
+ * @format
+ */
+'use strict';
+
+module.exports = require('UnimplementedView');

--- a/website/server/docsList.js
+++ b/website/server/docsList.js
@@ -12,7 +12,7 @@
 const components = [
   '../Libraries/Components/ActivityIndicator/ActivityIndicator.js',
   '../Libraries/Components/Button.js',
-  '../Libraries/Components/CheckBox/CheckBox.js',
+  '../Libraries/Components/CheckBox/CheckBox.android.js',
   '../Libraries/Components/DatePicker/DatePickerIOS.ios.js',
   '../Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.android.js',
   '../Libraries/Lists/FlatList.js',


### PR DESCRIPTION
`CheckBox` component was introduced in v0.49.0 and not implemented on iOS.

Users who are trying to use `CheckBox` on iOS will get a warning that 
> Native component for "AndroidCheckBox" does not exist 

We should declare in the document that this component is Android only and use `UnimplementedView` for iOS.

## Test Plan

- Use `react-native init` new project
- Apply pull request changes
- Add `<Checkbox />` after welcome text in `App.js`
- Run the app in iOS simulator
