### PR TITLE
 Add helpful examples to Android test env validation failure messages.

### DIFF
--- a/scripts/validate-android-test-env.sh
+++ b/scripts/validate-android-test-env.sh
@@ -90,7 +90,7 @@ if [ -n "$(which csrutil)" ]; then
       echo "See https://our.intern.facebook.com/intern/dex/installing-java-8/ for instructions on installing Java 8 on FB laptops."
     else
       echo "Check out http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html ."
-      echo $"Be sure that you set JAVA_HOME and PATH correctly in your .bashrc or equivalent. Example:"
+      echo "Be sure that you set JAVA_HOME and PATH correctly in your .bashrc or equivalent. Example:"
       echo
       echo "  export JAVA_HOME=path/to/java"
       echo "  export PATH=\$PATH:\$JAVA_HOME/bin"

--- a/scripts/validate-android-test-env.sh
+++ b/scripts/validate-android-test-env.sh
@@ -48,7 +48,7 @@ BUILD_TOOLS_VERSION=`grep buildToolsVersion $(dirname $0)/../ReactAndroid/build.
 MAJOR=`echo $BUILD_TOOLS_VERSION | sed 's/\..*//'`
 
 # Check that we have the right major version of the Android SDK.
-PLATFORM_DIR="$ANDROID_HOME/platforms/android-$MAJOR/foo"
+PLATFORM_DIR="$ANDROID_HOME/platforms/android-$MAJOR"
 if [ ! -e "$PLATFORM_DIR" ]; then
   echo "Error: could not find version $ANDROID_VERSION of the Android SDK."
   echo "Specifically, the directory $PLATFORM_DIR does not exist."
@@ -56,7 +56,7 @@ if [ ! -e "$PLATFORM_DIR" ]; then
   echo "See https://facebook.github.io/react-native/docs/getting-started.html for details."
   echo "If you are using Android SDK Tools from the command line, you may need to run:"
   echo
-  echo "  sdkmanager \"platform-tools\" \"platform-tools;android-$ANDROID_VERSION\""
+  echo "  sdkmanager \"platform-tools\" \"platform-tools;android-$MAJOR\""
   echo
   echo "Check out https://developer.android.com/studio/command-line/sdkmanager.html for details."
   exit 1

--- a/scripts/validate-android-test-env.sh
+++ b/scripts/validate-android-test-env.sh
@@ -48,12 +48,17 @@ BUILD_TOOLS_VERSION=`grep buildToolsVersion $(dirname $0)/../ReactAndroid/build.
 MAJOR=`echo $BUILD_TOOLS_VERSION | sed 's/\..*//'`
 
 # Check that we have the right major version of the Android SDK.
-PLATFORM_DIR="$ANDROID_HOME/platforms/android-$MAJOR"
+PLATFORM_DIR="$ANDROID_HOME/platforms/android-$MAJOR/foo"
 if [ ! -e "$PLATFORM_DIR" ]; then
   echo "Error: could not find version $ANDROID_VERSION of the Android SDK."
   echo "Specifically, the directory $PLATFORM_DIR does not exist."
   echo "You probably need to specify the right version using the SDK Manager from within Android Studio."
   echo "See https://facebook.github.io/react-native/docs/getting-started.html for details."
+  echo "If you are using Android SDK Tools from the command line, you may need to run:"
+  echo
+  echo "  sdkmanager \"platform-tools\" \"platform-tools;android-$ANDROID_VERSION\""
+  echo
+  echo "Check out https://developer.android.com/studio/command-line/sdkmanager.html for details."
   exit 1
 fi
 
@@ -64,6 +69,11 @@ if [ ! -e "$BT_DIR" ]; then
   echo "Specifically, the directory $BT_DIR does not exist."
   echo "You probably need to explicitly install the correct version of the Android SDK Build Tools from within Android Studio."
   echo "See https://facebook.github.io/react-native/docs/getting-started.html for details."
+  echo "If you are using Android SDK Tools from the command line, you may need to run:"
+  echo
+  echo "  sdkmanager \"platform-tools\" \"build-tools;android-$BUILD_TOOLS_VERSION\""
+  echo
+  echo "Check out https://developer.android.com/studio/command-line/sdkmanager.html for details."
   exit 1
 fi
 
@@ -80,7 +90,11 @@ if [ -n "$(which csrutil)" ]; then
       echo "See https://our.intern.facebook.com/intern/dex/installing-java-8/ for instructions on installing Java 8 on FB laptops."
     else
       echo "Check out http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html ."
-      echo "Be sure that you set JAVA_HOME and PATH correctly."
+      echo $"Be sure that you set JAVA_HOME and PATH correctly in your .bashrc or equivalent. Example:"
+      echo
+      echo "  export JAVA_HOME=path/to/java"
+      echo "  export PATH=\$PATH:\$JAVA_HOME/bin"
+      echo
     fi
     echo "After installing Java, run 'buck kill' and 'buck clean'."
     exit 1


### PR DESCRIPTION
Hi there!

I set up the repo because I want to do a little contribution to the Android side but ran into trouble [running tests](https://facebook.github.io/react-native/docs/contributing.html). The Android environment validation kept failing. While the messages were a little helpful, it would have saved me a bit of time and research if I had some helpful examples to copy-and-paste. In my case, I'm using Android SDK Tools on the command line. Hopefully, this will help others when setting up!

## Test Plan

Run `./scripts/run-android-local-unit-tests.sh` with each of the following to see the expanded help messages:

* Make sure `$ANDROID_HOME/platforms/android-$MAJOR` is _not_ present.
* Make sure `$ANDROID_HOME/build-tools/$BUILD_TOOLS_VERSION` is _not_ present.
* Make sure `JAVA_HOME` is _not_ set and/or is _not_ in `PATH`.

