### PR TITLE
Fix warning on SectionList's tutorial

### DIFF
--- a/docs/UsingAListView.md
+++ b/docs/UsingAListView.md
@@ -75,6 +75,7 @@ export default class SectionListBasics extends Component {
           ]}
           renderItem={({item}) => <Text style={styles.item}>{item}</Text>}
           renderSectionHeader={({section}) => <Text style={styles.sectionHeader}>{section.title}</Text>}
+          keyExtractor={(item, index) => index}
         />
       </View>
     );


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes. 

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to React Native here: http://facebook.github.io/react-native/docs/contributing.html

Happy contributing!

-->

I wanted to fix issue #16231 - the warning is not displayed anymore:

![image](https://user-images.githubusercontent.com/2101647/31268083-7e2e0ddc-aac6-11e7-966b-b1e9ffa6cfa8.png)
