### PR TITLE
Fix navigation links in documentation.

### DIFF
--- a/docs/ComponentsAndAPIs.md
+++ b/docs/ComponentsAndAPIs.md
@@ -1,5 +1,5 @@
 ---
-id: components
+id: components-and-apis
 title: Components and APIs
 layout: docs
 category: Guides

--- a/docs/MoreResources.md
+++ b/docs/MoreResources.md
@@ -4,7 +4,7 @@ title: More Resources
 layout: docs
 category: The Basics
 permalink: docs/more-resources.html
-next: components
+next: components-and-apis
 previous: network
 ---
 

--- a/docs/PlatformSpecificInformation.md
+++ b/docs/PlatformSpecificInformation.md
@@ -5,7 +5,7 @@ layout: docs
 category: Guides
 permalink: docs/platform-specific-code.html
 next: navigation
-previous: components
+previous: components-and-apis
 ---
 
 When building a cross-platform app, you'll want to re-use as much code as possible. Scenarios may arise where it makes sense for the code to be different, for example you may want to implement separate visual components for iOS and Android.


### PR DESCRIPTION
When navigating in the docs, these two links are broken.

The "Continue Reading" in http://facebook.github.io/react-native/docs/more-resources.html page, and "Previous" in http://facebook.github.io/react-native/docs/platform-specific-code.html.

This PR is to fix this.