### PR TITLE
Correct propTypes for placeholder

### DIFF
--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -430,7 +430,7 @@ const TextInput = createReactClass({
     /**
      * The string that will be rendered before text input has been entered.
      */
-    placeholder: PropTypes.node,
+    placeholder: PropTypes.string,
     /**
      * The text color of the placeholder string.
      */


### PR DESCRIPTION
Proptype mistake, placeholder is a "string" not a "node".

## Test Plan

https://github.com/facebook/react-native/blob/1e8f3b11027fe0a7514b4fc97d0798d3c64bc895/Libraries/Text/RCTBackedTextInputViewProtocol.h#L18

https://github.com/facebook/react-native/blob/4d54b48167c99d0f3a8917e7637ffe3304c6bed6/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java#L300
