### PR TITLE
Document adb shell input keyevent 82

### DIFF
--- a/docs/Debugging.md
+++ b/docs/Debugging.md
@@ -14,7 +14,7 @@ React Native supports a few keyboard shortcuts in the iOS Simulator. They are de
 
 ## Accessing the In-App Developer Menu
 
-You can access the developer menu by shaking your device or by selecting "Shake Gesture" inside the Hardware menu in the iOS Simulator. You can also use the `⌘D` keyboard shortcut when your app is running in the iOS Simulator, or `⌘M` when running in an Android emulator.
+You can access the developer menu by shaking your device or by selecting "Shake Gesture" inside the Hardware menu in the iOS Simulator. You can also use the `⌘D` keyboard shortcut when your app is running in the iOS Simulator, or `⌘M` when running in an Android emulator. Alternatively for Android, you can run the command `adb shell input keyevent 82` to open the dev menu (82 being the Menu key code).
 
 ![](img/DeveloperMenu.png)
 


### PR DESCRIPTION
This information could be found already in older docs see https://facebook.github.io/react-native/releases/0.21/docs/running-on-device-android.html#accessing-development-server-from-device. It is missing from latest.

I think it's important alternative since shaking my device all the time borked my USB port