### PR TITLE
Safeguard onScroll's callback param has valid contentOffset.

### DIFF
--- a/Libraries/Components/ScrollResponder.js
+++ b/Libraries/Components/ScrollResponder.js
@@ -283,7 +283,7 @@ var ScrollResponderMixin = {
 
   scrollResponderHandleScroll: function(e: Event) {
     this.state.observedScrollSinceBecomingResponder = true;
-    this.props.onScroll && this.props.onScroll(e);
+    e.nativeEvent.contentOffset && this.props.onScroll && this.props.onScroll(e);
   },
 
   /**


### PR DESCRIPTION
See #15725

## Test Plan

Tests pass. ScrollView and FlatList in an actual app continue working normally.