### PR TITLE
Android event documentation - Adding part about mapping event names.

### DIFF
--- a/docs/NativeComponentsAndroid.md
+++ b/docs/NativeComponentsAndroid.md
@@ -144,7 +144,24 @@ class MyCustomView extends View {
 }
 ```
 
-The event name `topChange` maps to the `onChange` callback prop in JavaScript (mappings are in `UIManagerModuleConstants.java`). This callback is invoked with the raw event, which we typically process in the wrapper component to make a simpler API:
+To map the `topChange` event name to the `onChange` callback prop in JavaScript, register it by overriding the `getExportedCustomBubblingEventTypeConstants` method in your `ViewManager`:
+
+```java
+public class ReactImageManager extends SimpleViewManager<MyCustomView> {
+    ...
+    public Map getExportedCustomBubblingEventTypeConstants() {
+        return MapBuilder.builder()
+            .put(
+                "topChange",
+                MapBuilder.of(
+                    "phasedRegistrationNames",
+                    MapBuilder.of("bubbled", "onChange")))
+                    .build();
+    }
+}
+```
+
+This callback is invoked with the raw event, which we typically process in the wrapper component to make a simpler API:
 
 ```js
 // MyCustomView.js


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes. 

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to React Native here: http://facebook.github.io/react-native/docs/contributing.html

Happy contributing!

-->

I was quite lost when the documentation told me to go figure the event mapping out myself. It took me quite a while to figure out that i needed to register the names in the `ViewManager`.

This code snippet just makes it way easier to figure out what you need to do to add events.