### PR TITLE
Remove unused variable in HelloNavigation example

### DIFF
--- a/local-cli/templates/HelloNavigation/components/KeyboardSpacer.js
+++ b/local-cli/templates/HelloNavigation/components/KeyboardSpacer.js
@@ -9,7 +9,6 @@ import {
   View,
   Keyboard,
   LayoutAnimation,
-  UIManager,
 } from 'react-native';
 
 type Props = {


### PR DESCRIPTION
Because it's just unused :)
