### PR TITLE
Backport: Add a check in InitializeCore.js that PlatformConstants native module is present

### DIFF
--- a/Libraries/Core/InitializeCore.js
+++ b/Libraries/Core/InitializeCore.js
@@ -116,21 +116,24 @@ if (!global.__fbDisableExceptionsManager) {
   ErrorUtils.setGlobalHandler(handleError);
 }
 
-const formatVersion = version =>
-  `${version.major}.${version.minor}.${version.patch}` +
-  (version.prerelease !== null ? `-${version.prerelease}` : '');
+const {PlatformConstants} = require('NativeModules');
+if (PlatformConstants) {
+  const formatVersion = version =>
+    `${version.major}.${version.minor}.${version.patch}` +
+    (version.prerelease !== null ? `-${version.prerelease}` : '');
 
-const ReactNativeVersion = require('ReactNativeVersion');
-const nativeVersion = require('NativeModules').PlatformConstants.reactNativeVersion;
-if (ReactNativeVersion.version.major !== nativeVersion.major ||
-    ReactNativeVersion.version.minor !== nativeVersion.minor) {
-  throw new Error(
-    `React Native version mismatch.\n\nJavaScript version: ${formatVersion(ReactNativeVersion.version)}\n` +
-    `Native version: ${formatVersion(nativeVersion)}\n\n` +
-    'Make sure that you have rebuilt the native code. If the problem persists ' +
-    'try clearing the watchman and packager caches with `watchman watch-del-all ' +
-    '&& react-native start --reset-cache`.'
-  );
+  const ReactNativeVersion = require('ReactNativeVersion');
+  const nativeVersion = PlatformConstants.reactNativeVersion;
+  if (ReactNativeVersion.version.major !== nativeVersion.major ||
+      ReactNativeVersion.version.minor !== nativeVersion.minor) {
+    throw new Error(
+      `React Native version mismatch.\n\nJavaScript version: ${formatVersion(ReactNativeVersion.version)}\n` +
+      `Native version: ${formatVersion(nativeVersion)}\n\n` +
+      'Make sure that you have rebuilt the native code. If the problem persists ' +
+      'try clearing the watchman and packager caches with `watchman watch-del-all ' +
+      '&& react-native start --reset-cache`.'
+    );
+  }
 }
 
 // Set up collections


### PR DESCRIPTION
Summary: In some enviroments PlatformConstants native module may not be presented in a project, which results in a call to undefined property and a RedBox

This backports commit 96f23e7 to 0.49-stable.