### PR TITLE
Backport of redboxing isssue with PlatformConstants.

### DIFF
--- a/Libraries/Core/InitializeCore.js
+++ b/Libraries/Core/InitializeCore.js
@@ -116,21 +116,24 @@ if (!global.__fbDisableExceptionsManager) {
   ErrorUtils.setGlobalHandler(handleError);
 }
 
-const formatVersion = version =>
-  `${version.major}.${version.minor}.${version.patch}` +
-  (version.prerelease !== null ? `-${version.prerelease}` : '');
+const {PlatformConstants} = require('NativeModules');
+if (PlatformConstants) {
+  const formatVersion = version =>
+    `${version.major}.${version.minor}.${version.patch}` +
+    (version.prerelease !== null ? `-${version.prerelease}` : '');
 
-const ReactNativeVersion = require('ReactNativeVersion');
-const nativeVersion = require('NativeModules').PlatformConstants.reactNativeVersion;
-if (ReactNativeVersion.version.major !== nativeVersion.major ||
-    ReactNativeVersion.version.minor !== nativeVersion.minor) {
-  throw new Error(
-    `React Native version mismatch.\n\nJavaScript version: ${formatVersion(ReactNativeVersion.version)}\n` +
-    `Native version: ${formatVersion(nativeVersion)}\n\n` +
-    'Make sure that you have rebuilt the native code. If the problem persists ' +
-    'try clearing the watchman and packager caches with `watchman watch-del-all ' +
-    '&& react-native start --reset-cache`.'
-  );
+  const ReactNativeVersion = require('ReactNativeVersion');
+  const nativeVersion = PlatformConstants.reactNativeVersion;
+  if (ReactNativeVersion.version.major !== nativeVersion.major ||
+      ReactNativeVersion.version.minor !== nativeVersion.minor) {
+    throw new Error(
+      `React Native version mismatch.\n\nJavaScript version: ${formatVersion(ReactNativeVersion.version)}\n` +
+      `Native version: ${formatVersion(nativeVersion)}\n\n` +
+      'Make sure that you have rebuilt the native code. If the problem persists ' +
+      'try clearing the watchman and packager caches with `watchman watch-del-all ' +
+      '&& react-native start --reset-cache`.'
+    );
+  }
 }
 
 // Set up collections


### PR DESCRIPTION
I've been having issues with 0.49 and `react-native-windows` and `react-native-web` redboxing. This backports 96f23e7416f8dd86a0e6c43b4cdf959a69ea7039.