### PR TITLE
Fix Analyze step on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,15 +92,19 @@ jobs:
       - checkout
       - run: npm install --no-package-lock
       - run: |
+          npm test -- --maxWorkers=2
           npm run lint
           npm run flow -- check
-          npm test -- --maxWorkers=2
-# eslint
+# eslint - doesn't run on non-PR builds
       - run:
           name: Analyze Code
           command: |
-            npm install github@0.2.4
-            cat <(echo eslint; npm run lint --silent -- --format=json; echo flow; npm run flow --silent -- check --json) | GITHUB_TOKEN="af6ef0d15709bc91d""06a6217a5a826a226fb57b7" CI_USER=$CIRCLE_PROJECT_USERNAME CI_REPO=$CIRCLE_PROJECT_REPONAME PULL_REQUEST_NUMBER=$CIRCLE_PR_NUMBER node bots/code-analysis-bot.js
+            if [ -n "$CIRCLE_PR_NUMBER" ]; then
+              npm install github@0.2.4
+              cat <(echo eslint; npm run lint --silent -- --format=json; echo flow; npm run flow --silent -- check --json) | GITHUB_TOKEN="af6ef0d15709bc91d""06a6217a5a826a226fb57b7" CI_USER=$CIRCLE_PROJECT_USERNAME CI_REPO=$CIRCLE_PROJECT_REPONAME PULL_REQUEST_NUMBER=$CIRCLE_PR_NUMBER node bots/code-analysis-bot.js
+            else 
+              echo "Skipping code analyzis."
+            fi
 
   test-node-6:
     <<: *defaults
@@ -110,9 +114,9 @@ jobs:
       - checkout
       - run: npm install
       - run: |
+          npm test -- --maxWorkers=2
           npm run lint
           npm run flow -- check
-          npm test -- --maxWorkers=2
 
   test-node-4:
     <<: *defaults
@@ -122,10 +126,10 @@ jobs:
       - checkout
       - run: npm install
       - run: |
+          npm test -- --maxWorkers=2
           npm run lint
           npm run flow -- check
-          npm test -- --maxWorkers=2
-
+          
   test-website:
     <<: *defaults
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,7 +103,7 @@ jobs:
               npm install github@0.2.4
               cat <(echo eslint; npm run lint --silent -- --format=json; echo flow; npm run flow --silent -- check --json) | GITHUB_TOKEN="af6ef0d15709bc91d""06a6217a5a826a226fb57b7" CI_USER=$CIRCLE_PROJECT_USERNAME CI_REPO=$CIRCLE_PROJECT_REPONAME PULL_REQUEST_NUMBER=$CIRCLE_PR_NUMBER node bots/code-analysis-bot.js
             else 
-              echo "Skipping code analyzis."
+              echo "Skipping code analysis."
             fi
 
   test-node-6:


### PR DESCRIPTION
Recent changes that introduced Circle 2 (thanks @ide and @hramos for work on this) include special step for analyzing code. It takes PR number and processes the build.

Unfortunately, that breaks all non-PR builds (including ones scheduled by me as a part of release step). 

This PR simply checks if such env variable is set and stops executing in case it's undefined.

Also, I have updated the order of the tests so that most important (unit tests) are no longer shadowed by temporary eslint and flow breakage. The reason for this change is that flow has been broken for ~20 days which shadowed breakage in unit tests (addressed in my other PR).

You can see build breaking before this change: https://circleci.com/gh/facebook/react-native/22391
And being green after: https://circleci.com/gh/facebook/react-native/22530