### PR TITLE
Fix failing flow tests due to metro-bundler ignore comment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,6 +167,8 @@ jobs:
 
               echo "Deploying website..."
               cd website && GIT_USER=reactjs-bot npm run gh-pages
+
+              node ./scripts/publish-npm.js
             else
               echo "Skipping deploy."
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,7 +146,7 @@ jobs:
           name: Test Build Static Website
           command: cd website && node ./server/generate.js
 
-  deploy-website:
+  deploy:
     <<: *defaults
     docker:
       - image: circleci/node:8
@@ -167,11 +167,17 @@ jobs:
 
               echo "Deploying website..."
               cd website && GIT_USER=reactjs-bot npm run gh-pages
-
-              node ./scripts/publish-npm.js
             else
               echo "Skipping deploy."
             fi
+      - run:
+          name: Publish React Native to npm
+          command: |
+            git config --global user.email "reactjs-bot@users.noreply.github.com"
+            git config --global user.name "Website Deployment Script"
+            echo "machine github.com login reactjs-bot password $GITHUB_TOKEN" > ~/.netrc
+
+            node ./scripts/publish-npm.js
 
   build-js-bundle:
     <<: *defaults


### PR DESCRIPTION
Metro Bundler ships with `react_native_fb` flow annotations whereas our repo is set to ignore `react_native_oss` flow issues.

For now, a hot fix is to make our repo ignore both. 

Detailed discussion happens here: https://github.com/facebook/metro-bundler/commit/87cfc05ea67e19c367e24e644915b49024ce3f2a#commitcomment-24884835

Those changes have been applied to `0.50.0-rc.0` in order to make it green.