### PR TITLE
[Android] Allow PackagerConnectionSettings to be provided by ReactNativeHost

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
@@ -75,6 +75,7 @@ import com.facebook.react.modules.core.DefaultHardwareBackBtnHandler;
 import com.facebook.react.modules.core.DeviceEventManagerModule;
 import com.facebook.react.modules.core.ReactChoreographer;
 import com.facebook.react.modules.debug.interfaces.DeveloperSettings;
+import com.facebook.react.packagerconnection.PackagerConnectionSettings;
 import com.facebook.react.uimanager.DisplayMetricsHolder;
 import com.facebook.react.uimanager.UIImplementationProvider;
 import com.facebook.react.uimanager.UIManagerModule;
@@ -233,6 +234,7 @@ public class ReactInstanceManager {
       boolean lazyNativeModulesEnabled,
       boolean lazyViewManagersEnabled,
       boolean delayViewManagerClassLoadsEnabled,
+      @Nullable PackagerConnectionSettings packagerConnectionSettings,
       @Nullable DevBundleDownloadListener devBundleDownloadListener,
       boolean useSeparateUIBackgroundThread,
       int minNumShakes,
@@ -259,6 +261,7 @@ public class ReactInstanceManager {
         mJSMainModulePath,
         useDeveloperSupport,
         redBoxHandler,
+        packagerConnectionSettings,
         devBundleDownloadListener,
         minNumShakes);
     mBridgeIdleDebugListener = bridgeIdleDebugListener;

--- a/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManagerBuilder.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManagerBuilder.java
@@ -17,6 +17,7 @@ import com.facebook.react.devsupport.RedBoxHandler;
 import com.facebook.react.devsupport.interfaces.DevBundleDownloadListener;
 import com.facebook.react.devsupport.interfaces.DevSupportManager;
 import com.facebook.react.modules.core.DefaultHardwareBackBtnHandler;
+import com.facebook.react.packagerconnection.PackagerConnectionSettings;
 import com.facebook.react.uimanager.UIImplementationProvider;
 import java.util.ArrayList;
 import java.util.List;
@@ -44,6 +45,7 @@ public class ReactInstanceManagerBuilder {
   private boolean mLazyNativeModulesEnabled;
   private boolean mLazyViewManagersEnabled;
   private boolean mDelayViewManagerClassLoadsEnabled;
+  private @Nullable PackagerConnectionSettings mPackagerConnectionSettings;
   private @Nullable DevBundleDownloadListener mDevBundleDownloadListener;
   private @Nullable JavaScriptExecutorFactory mJavaScriptExecutorFactory;
   private boolean mUseSeparateUIBackgroundThread;
@@ -210,6 +212,12 @@ public class ReactInstanceManagerBuilder {
     return this;
   }
 
+  public ReactInstanceManagerBuilder setPackagerConnectionSettings(
+    @Nullable PackagerConnectionSettings packagerConnectionSettings) {
+    mPackagerConnectionSettings = packagerConnectionSettings;
+    return this;
+  }
+
   public ReactInstanceManagerBuilder setDevBundleDownloadListener(
     @Nullable DevBundleDownloadListener listener) {
     mDevBundleDownloadListener = listener;
@@ -297,6 +305,7 @@ public class ReactInstanceManagerBuilder {
         mLazyNativeModulesEnabled,
         mLazyViewManagersEnabled,
         mDelayViewManagerClassLoadsEnabled,
+        mPackagerConnectionSettings,
         mDevBundleDownloadListener,
         mUseSeparateUIBackgroundThread,
         mMinNumShakes,

--- a/ReactAndroid/src/main/java/com/facebook/react/ReactNativeHost.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactNativeHost.java
@@ -19,6 +19,7 @@ import com.facebook.infer.annotation.Assertions;
 import com.facebook.react.bridge.JavaScriptExecutorFactory;
 import com.facebook.react.common.LifecycleState;
 import com.facebook.react.devsupport.RedBoxHandler;
+import com.facebook.react.packagerconnection.PackagerConnectionSettings;
 import com.facebook.react.uimanager.UIImplementationProvider;
 
 /**
@@ -66,6 +67,7 @@ public abstract class ReactNativeHost {
   protected ReactInstanceManager createReactInstanceManager() {
     ReactInstanceManagerBuilder builder = ReactInstanceManager.builder()
       .setApplication(mApplication)
+      .setPackagerConnectionSettings(getPackagerConnectionSettings())
       .setJSMainModulePath(getJSMainModuleName())
       .setUseDeveloperSupport(getUseDeveloperSupport())
       .setRedBoxHandler(getRedBoxHandler())
@@ -103,6 +105,10 @@ public abstract class ReactNativeHost {
 
   protected final Application getApplication() {
     return mApplication;
+  }
+
+  protected PackagerConnectionSettings getPackagerConnectionSettings() {
+    return null;
   }
 
   /**

--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevInternalSettings.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevInternalSettings.java
@@ -44,11 +44,14 @@ public class DevInternalSettings implements
 
   public DevInternalSettings(
       Context applicationContext,
+      @Nullable PackagerConnectionSettings packagerConnectionSettings,
       Listener listener) {
     mListener = listener;
     mPreferences = PreferenceManager.getDefaultSharedPreferences(applicationContext);
     mPreferences.registerOnSharedPreferenceChangeListener(this);
-    mPackagerConnectionSettings = new PackagerConnectionSettings(applicationContext);
+    mPackagerConnectionSettings = packagerConnectionSettings == null
+      ? new PackagerConnectionSettings(applicationContext)
+      : packagerConnectionSettings;
   }
 
   public PackagerConnectionSettings getPackagerConnectionSettings() {

--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerFactory.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerFactory.java
@@ -17,6 +17,7 @@ import android.content.Context;
 
 import com.facebook.react.devsupport.interfaces.DevBundleDownloadListener;
 import com.facebook.react.devsupport.interfaces.DevSupportManager;
+import com.facebook.react.packagerconnection.PackagerConnectionSettings;
 
 /**
  * A simple factory that creates instances of {@link DevSupportManager} implementations. Uses
@@ -43,6 +44,7 @@ public class DevSupportManagerFactory {
       enableOnCreate,
       null,
       null,
+      null,
       minNumShakes);
   }
 
@@ -52,6 +54,7 @@ public class DevSupportManagerFactory {
     @Nullable String packagerPathForJSBundleName,
     boolean enableOnCreate,
     @Nullable RedBoxHandler redBoxHandler,
+    @Nullable PackagerConnectionSettings packagerConnectionSettings,
     @Nullable DevBundleDownloadListener devBundleDownloadListener,
     int minNumShakes) {
     if (!enableOnCreate) {
@@ -75,6 +78,7 @@ public class DevSupportManagerFactory {
           String.class,
           boolean.class,
           RedBoxHandler.class,
+          PackagerConnectionSettings.class,
           DevBundleDownloadListener.class,
           int.class);
       return (DevSupportManager) constructor.newInstance(
@@ -83,6 +87,7 @@ public class DevSupportManagerFactory {
         packagerPathForJSBundleName,
         true,
         redBoxHandler,
+        packagerConnectionSettings,
         devBundleDownloadListener,
         minNumShakes);
     } catch (Exception e) {

--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerImpl.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerImpl.java
@@ -49,6 +49,7 @@ import com.facebook.react.devsupport.interfaces.ErrorCustomizer;
 import com.facebook.react.devsupport.interfaces.PackagerStatusCallback;
 import com.facebook.react.devsupport.interfaces.StackFrame;
 import com.facebook.react.modules.debug.interfaces.DeveloperSettings;
+import com.facebook.react.packagerconnection.PackagerConnectionSettings;
 import com.facebook.react.packagerconnection.RequestHandler;
 import com.facebook.react.packagerconnection.Responder;
 import java.io.File;
@@ -185,6 +186,7 @@ public class DevSupportManagerImpl implements
       enableOnCreate,
       null,
       null,
+      null,
       minNumShakes);
   }
 
@@ -194,12 +196,13 @@ public class DevSupportManagerImpl implements
       @Nullable String packagerPathForJSBundleName,
       boolean enableOnCreate,
       @Nullable RedBoxHandler redBoxHandler,
+      @Nullable PackagerConnectionSettings packagerConnectionSettings,
       @Nullable DevBundleDownloadListener devBundleDownloadListener,
       int minNumShakes) {
     mReactInstanceCommandsHandler = reactInstanceCommandsHandler;
     mApplicationContext = applicationContext;
     mJSAppBundleName = packagerPathForJSBundleName;
-    mDevSettings = new DevInternalSettings(applicationContext, this);
+    mDevSettings = new DevInternalSettings(applicationContext, packagerConnectionSettings, this);
     mDevServerHelper = new DevServerHelper(mDevSettings, mApplicationContext.getPackageName());
     mBundleDownloadListener = devBundleDownloadListener;
 

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/systeminfo/AndroidInfoHelpers.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/systeminfo/AndroidInfoHelpers.java
@@ -12,8 +12,8 @@ public class AndroidInfoHelpers {
   public static final String GENYMOTION_LOCALHOST = "10.0.3.2";
   public static final String DEVICE_LOCALHOST = "localhost";
 
-  private static final int DEBUG_SERVER_HOST_PORT = 8081;
-  private static final int INSPECTOR_PROXY_PORT = 8082;
+  public static final int DEBUG_SERVER_HOST_PORT = 8081;
+  public static final int INSPECTOR_PROXY_PORT = 8082;
 
   private static boolean isRunningOnGenymotion() {
     return Build.FINGERPRINT.contains("vbox");
@@ -41,7 +41,7 @@ public class AndroidInfoHelpers {
     }
   }
 
-  private static String getServerIpAddress(int port) {
+  public static String getServerIpAddress(int port) {
     // Since genymotion runs in vbox it use different hostname to refer to adb host.
     // We detect whether app runs on genymotion and replace js bundle server hostname accordingly
 

--- a/ReactAndroid/src/main/java/com/facebook/react/packagerconnection/PackagerConnectionSettings.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/packagerconnection/PackagerConnectionSettings.java
@@ -26,13 +26,25 @@ public class PackagerConnectionSettings {
 
   private final SharedPreferences mPreferences;
   private final String mPackageName;
+  private final String mDebugServerHost;
+  private final String mInspectorServerHost;
 
   public PackagerConnectionSettings(Context applicationContext) {
+    this(applicationContext, null, null);
+  }
+
+  public PackagerConnectionSettings(Context applicationContext, String debugServerHost, String inspectorServerHost) {
     mPreferences = PreferenceManager.getDefaultSharedPreferences(applicationContext);
     mPackageName = applicationContext.getPackageName();
+    mDebugServerHost = debugServerHost;
+    mInspectorServerHost = inspectorServerHost;
   }
 
   public String getDebugServerHost() {
+    if (mDebugServerHost != null) {
+      return mDebugServerHost;
+    }
+
     // Check host setting first. If empty try to detect emulator type and use default
     // hostname for those
     String hostFromSettings = mPreferences.getString(PREFS_DEBUG_SERVER_HOST_KEY, null);
@@ -54,6 +66,10 @@ public class PackagerConnectionSettings {
   }
 
   public String getInspectorServerHost() {
+    if (mInspectorServerHost != null) {
+      return mInspectorServerHost;
+    }
+
     return AndroidInfoHelpers.getInspectorProxyHost();
   }
 


### PR DESCRIPTION
This PR enables a `ReactNativeHost` to customize the `PackagerConnectionSettings` supplied to the bundle loader and dev tools.

I've been working to productionize an implementation of the WebWorkers API for React Native and I've found these changes necessary to support remote debugging of each worker instance. (Each instance requires a custom bundler port, which can now be plumbed through via the `PackagerConnectionSettings`.)

This change should be a no-op for existing apps.

### Test Plan

This code is working in my local, WebWorker-enabled apps, and does not regress the ability to start and remotely debug the `react-native init` boilerplate app on Android.