### PR TITLE
[Android] Randomize the downloaded bundle filename

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerImpl.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerImpl.java
@@ -101,7 +101,7 @@ public class DevSupportManagerImpl implements
 
   private static final int JAVA_ERROR_COOKIE = -1;
   private static final int JSEXCEPTION_ERROR_COOKIE = -1;
-  private static final String JS_BUNDLE_FILE_NAME = "ReactNativeDevBundle.js";
+  private static final String JS_BUNDLE_FILE_FORMAT = "ReactNativeDevBundle.%d.js";
   private static enum ErrorType {
     JS,
     NATIVE
@@ -229,11 +229,15 @@ public class DevSupportManagerImpl implements
     };
 
     // We store JS bundle loaded from dev server in a single destination in app's data dir.
+    // (We randomize the name in the event that there are multiple JS bridges running.)
     // In case when someone schedule 2 subsequent reloads it may happen that JS thread will
     // start reading first reload output while the second reload starts writing to the same
     // file. As this should only be the case in dev mode we leave it as it is.
     // TODO(6418010): Fix readers-writers problem in debug reload from HTTP server
-    mJSBundleTempFile = new File(applicationContext.getFilesDir(), JS_BUNDLE_FILE_NAME);
+    mJSBundleTempFile = new File(
+      applicationContext.getFilesDir(),
+      String.format(JS_BUNDLE_FILE_FORMAT, (int)(Math.random() * 1000000))
+    );
 
     mDefaultNativeModuleCallExceptionHandler = new DefaultNativeModuleCallExceptionHandler();
 


### PR DESCRIPTION
This PR randomizes the cached filename for JS bundle downloads. It's necessary to avoid collisions if multiple bundles are in use by the same app.

I've been working to productionize an implementation of the WebWorkers API for React Native and I've found these changes necessary to prevent a race condition in the local bundle cache.

### Test Plan

This code is working in my local, WebWorker-enabled apps, and does not regress the ability to start and remotely debug the react-native init boilerplate app on Android.