### PR TITLE
[Android] ToastAndroid component is made customizable through new method 

### DIFF
--- a/Libraries/Components/ToastAndroid/ToastAndroid.android.js
+++ b/Libraries/Components/ToastAndroid/ToastAndroid.android.js
@@ -24,6 +24,9 @@ var RCTToastAndroid = require('NativeModules').ToastAndroid;
  * There is also a function `showWithGravity` to specify the layout gravity. May be
  * ToastAndroid.TOP, ToastAndroid.BOTTOM, ToastAndroid.CENTER.
  *
+ * There is also a function `showWithColor` to specify background color. May be
+ * String backgroundColor "#000000", "#ffffff".
+ *
  * The 'showWithGravityAndOffset' function adds on the ability to specify offset
  * These offset values will translate to pixels.
  *
@@ -31,6 +34,7 @@ var RCTToastAndroid = require('NativeModules').ToastAndroid;
  * ```javascript
  * ToastAndroid.show('A pikachu appeared nearby !', ToastAndroid.SHORT);
  * ToastAndroid.showWithGravity('All Your Base Are Belong To Us', ToastAndroid.SHORT, ToastAndroid.CENTER);
+ * ToastAndroid.showWithColor('Customizable Toast Message', ToastAndroid.SHORT, "#4c4cc7");
  * ToastAndroid.showWithGravityAndOffset('A wild toast appeared!', ToastAndroid.LONG, ToastAndroid.BOTTOM, 25, 50);
  * ```
  */
@@ -59,6 +63,14 @@ var ToastAndroid = {
     gravity: number,
   ): void {
     RCTToastAndroid.showWithGravity(message, duration, gravity);
+  },
+
+  showWithColor: function (
+    message: string,
+    duration: number,
+    backgroundColor: string,
+  ): void {
+    RCTToastAndroid.showWithColor(message, duration, backgroundColor);
   },
 
   showWithGravityAndOffset: function (

--- a/RNTester/js/ToastAndroidExample.android.js
+++ b/RNTester/js/ToastAndroidExample.android.js
@@ -82,6 +82,30 @@ class ToastExample extends React.Component<{}, $FlowFixMeState> {
             <Text style={styles.text}>Click me.</Text>
           </TouchableWithoutFeedback>
         </RNTesterBlock>
+        <RNTesterBlock title="Toast with red background color">
+          <TouchableWithoutFeedback
+            onPress={() =>
+              ToastAndroid.showWithColor(
+                'This is a toast with red background color',
+                ToastAndroid.SHORT,
+                "#ff0000"
+              )
+            }>
+            <Text style={styles.text}>Click me.</Text>
+          </TouchableWithoutFeedback>
+        </RNTesterBlock>
+        <RNTesterBlock title="Toast with blue background color">
+          <TouchableWithoutFeedback
+            onPress={() =>
+              ToastAndroid.showWithColor(
+                'This is a toast with blue background color',
+                ToastAndroid.SHORT,
+                "#0000ff"
+              )
+            }>
+            <Text style={styles.text}>Click me.</Text>
+          </TouchableWithoutFeedback>
+        </RNTesterBlock>
         <RNTesterBlock title="Toast with x offset">
           <TouchableWithoutFeedback
             onPress={() =>

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/toast/ToastModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/toast/ToastModule.java
@@ -10,6 +10,9 @@
 package com.facebook.react.modules.toast;
 
 import android.view.Gravity;
+import android.graphics.Color;
+import android.graphics.drawable.GradientDrawable;
+import android.view.View;
 import android.widget.Toast;
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
@@ -59,6 +62,22 @@ public class ToastModule extends ReactContextBaseJavaModule {
       @Override
       public void run() {
         Toast.makeText(getReactApplicationContext(), message, duration).show();
+      }
+    });
+  }
+
+  @ReactMethod
+  public void showWithColor(final String message, final int duration ,final String backgroundColor) {
+    UiThreadUtil.runOnUiThread(new Runnable() {
+      @Override
+      public void run() {
+        Toast toast = Toast.makeText(getReactApplicationContext(), message, duration);
+        View view = toast.getView();
+        GradientDrawable gd = new GradientDrawable();
+        gd.setColor(Color.parseColor(backgroundColor));
+        view.setBackground(gd);
+        toast.setView(view);
+        toast.show();
       }
     });
   }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes. 

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to React Native here: http://facebook.github.io/react-native/docs/contributing.html

Happy contributing!

-->

This pull request aims to customize current ToastAndroid component.I have already created new method on `ToastModule.java` called with `showWithColor`.This method change background color of toast in android platform.Also i have been used this method inside `ToastAndroid.android.js` file.I have been tested locally.And then result is here:

![colorful-toast](https://user-images.githubusercontent.com/5556159/31494993-58eb4a2a-af5e-11e7-9b72-18c8ccb50c39.png)


By the way i have just added only background color change for giving an example about customizable toast. It can be expanded with different style attributes .

## Test Plan
I have just create a new method `ToastModule.java` file.After that i have tested locally ,result is here:

![test-phase](https://user-images.githubusercontent.com/5556159/31485989-87f3f71a-af3e-11e7-9e5a-8f1d0c5d5e69.png)
