### PR TITLE
Update the `NetInfo.isConnected` example code so that it uses the new `connectionChange` event

### DIFF
--- a/Libraries/Network/NetInfo.js
+++ b/Libraries/Network/NetInfo.js
@@ -158,12 +158,12 @@ const _isConnectedSubscriptions = new Map();
  * function handleFirstConnectivityChange(isConnected) {
  *   console.log('Then, is ' + (isConnected ? 'online' : 'offline'));
  *   NetInfo.isConnected.removeEventListener(
- *     'change',
+ *     'connectionChange',
  *     handleFirstConnectivityChange
  *   );
  * }
  * NetInfo.isConnected.addEventListener(
- *   'change',
+ *   'connectionChange',
  *   handleFirstConnectivityChange
  * );
  * ```


### PR DESCRIPTION
The first code block already uses the new `connectionChange` event instead of
the deprecated `change` event, so change this example code block as well to use
the new event.

I came across this while upgrading my RN version. In the debug-console I saw a deprecation warning, despite I was using the example-code. Looking at the source, I saw the example code block still used the deprecated event, so update it to use the new one.