### PR TITLE
Fixes XMLHttpRequest progress not having loaded mentioned, Fix Issue #3181

### DIFF
--- a/Libraries/Network/XMLHttpRequest.js
+++ b/Libraries/Network/XMLHttpRequest.js
@@ -341,6 +341,8 @@ class XMLHttpRequest extends EventTarget(...XHR_EVENTS) {
     } else {
       this._response += responseText;
     }
+    // fixing progress always being 0
+    progress = (progress === 0)? this._response.length : progress;
 
     XMLHttpRequest._interceptor && XMLHttpRequest._interceptor.dataReceived(
       requestId,


### PR DESCRIPTION
Gives loaded progress back to XMLHttpRequest

## Motivation

I want to know how far along my XMLHttpRequests are to completing.

## Test Plan

Ensure that XMLHttpRequest progress events loaded increments and reaches the total.

## Release Notes

  CATEGORY

[ANDROID] [BUGFIX] [XMLHttpRequest] - Fixed XMLHttpRequests progress event to include loaded that is not 0
