### PR TITLE
Fix typo in run-instrumentation-tests-via-adb-shell.sh

### DIFF
--- a/ContainerShip/scripts/run-instrumentation-tests-via-adb-shell.sh
+++ b/ContainerShip/scripts/run-instrumentation-tests-via-adb-shell.sh
@@ -29,7 +29,7 @@ def update():
   # prevent CircleCI from killing the process for inactivity
   while not done:
     time.sleep(5)
-    print "Running in background.  Waiting for 'adb' command reponse..."
+    print "Running in background.  Waiting for 'adb' command response..."
 
 t = threading.Thread(target=update)
 t.dameon = True


### PR DESCRIPTION
Small fix:

Fix typo in run-instrumentation-tests-via-adb-shell.sh. "reponse" is a misspelling of "response"
