### PR TITLE
[DOCS] [ ENHANCEMENT][Navigation.md] - Package manager conflict on install instruction

### DIFF
--- a/docs/Navigation.md
+++ b/docs/Navigation.md
@@ -27,6 +27,13 @@ The first step is to install in your project:
 npm install --save react-navigation
 ```
 
+Or you can use yarn to install the package in your project :
+
+```
+yarn add react-navigation
+```
+Make sure to use the same package manager, when you first install the react native project to prevent lost package.
+
 Then you can quickly create an app with a home screen and a profile screen:
 
 ```


### PR DESCRIPTION

The instruction will produce error and delete some package if the user first installation of react native using YARN, and the instruction to install react-navigation library use NPM.


## Motivation

I start to learn react with zero knowledge of es6, package manager. I follow all the basic documentation. Until i come to Navigating Between Screens section. I got error after install the react-navigation package using NPM

## Test Plan
This is what happen after i use npm install --save react-navigation
![error again](https://user-images.githubusercontent.com/7543729/31598912-6825e12a-b27a-11e7-8072-e9e38aa2ad73.JPG)
After that i cant run my react native on android
![error again 2](https://user-images.githubusercontent.com/7543729/31599013-c69b5c9e-b27a-11e7-9db9-18f498860e76.JPG)
After some googling i realize the problem come from the package manager. I shouldnt use npm because my react native projects installed using yarn.
![success](https://user-images.githubusercontent.com/7543729/31599463-b587fca8-b27c-11e7-80f8-cc5822368eca.JPG)

I hope my change can save the millisecond of time for the developers who are still learning like me

## Release Notes

  CATEGORY

[DOCS] [ ENHANCEMENT] [Navigation.md] - Add package installation instruction option