### PR TITLE
Relax error conditions for InitializeCore

### DIFF
--- a/Libraries/Core/InitializeCore.js
+++ b/Libraries/Core/InitializeCore.js
@@ -150,7 +150,7 @@ if (PlatformConstants) {
   console.warn(
     'React Native `PlatformConstants` not defined.\n\n' +
     `${PlatformMissingModuleMessage} ${PlatformProblemPersistsMessage}`
-  )
+  );
 }
 
 

--- a/Libraries/Core/InitializeCore.js
+++ b/Libraries/Core/InitializeCore.js
@@ -117,6 +117,14 @@ if (!global.__fbDisableExceptionsManager) {
 }
 
 const {PlatformConstants} = require('NativeModules');
+const PlatformMissingModuleMessage =
+  'Check the documentation for your platform and ensure it supports the ' +
+  'the version of React Native defined in your `package.json`.';
+const PlatformProblemPersistsMessage =
+  'If the problem persists try clearing the watchman and packager caches with ' +
+  '`watchman watch-del-all && react-native start --reset-cache`.';
+
+
 if (PlatformConstants) {
   const formatVersion = version =>
     `${version.major}.${version.minor}.${version.patch}` +
@@ -124,17 +132,27 @@ if (PlatformConstants) {
 
   const ReactNativeVersion = require('ReactNativeVersion');
   const nativeVersion = PlatformConstants.reactNativeVersion;
-  if (ReactNativeVersion.version.major !== nativeVersion.major ||
+  if (nativeVersion === undefined) {
+    console.warn(
+      `React Native version mismatch.\n\nJavaScript version: ${formatVersion(ReactNativeVersion.version)}\n` +
+      'Native version: undefined\n\n' +
+      `${PlatformMissingModuleMessage} ${PlatformProblemPersistsMessage}`
+    );
+  } else if (ReactNativeVersion.version.major !== nativeVersion.major ||
       ReactNativeVersion.version.minor !== nativeVersion.minor) {
     throw new Error(
       `React Native version mismatch.\n\nJavaScript version: ${formatVersion(ReactNativeVersion.version)}\n` +
       `Native version: ${formatVersion(nativeVersion)}\n\n` +
-      'Make sure that you have rebuilt the native code. If the problem persists ' +
-      'try clearing the watchman and packager caches with `watchman watch-del-all ' +
-      '&& react-native start --reset-cache`.'
+      `Make sure that you have rebuilt the native code. ${PlatformProblemPersistsMessage}`
     );
   }
+} else {
+  console.warn(
+    'React Native `PlatformConstants` not defined.\n\n' +
+    `${PlatformMissingModuleMessage} ${PlatformProblemPersistsMessage}`
+  )
 }
+
 
 // Set up collections
 const _shouldPolyfillCollection = require('_shouldPolyfillES6Collection');


### PR DESCRIPTION
## Motivation

This patch addresses an issue with non-native platforms using `expo` and `react-native-windows` with React Native 0.49 and 0.50, and conveniently also ensures `react-native-web` does not error either, if that has not been updated.

## Test Plan

I tested using an Android build, `expo`, `react-native-windows`, and `react-native-web`. For the supported platforms (`android`, `ios`), the control flow should be unchanged. This should only affect third party platforms, e.g.: `expo` on Android/iOS, Windows, and web.

## Release Notes

[INTERNAL] [ENHANCEMENT] [InitializeCore] Relax version constraints for 3rd party platforms.

## Did I do this right?

I don't know if I made this pull request correctly but I sure tried to.

If this PR is accepted, I would like it to be backported to 0.49.
