### PR TITLE
Delegate to ProgressBarAndroid from ActivityIndicator on Android, instead of the other way around

### DIFF
--- a/Libraries/Components/ActivityIndicator/ActivityIndicator.js
+++ b/Libraries/Components/ActivityIndicator/ActivityIndicator.js
@@ -14,8 +14,9 @@
 const ColorPropType = require('ColorPropType');
 const NativeMethodsMixin = require('NativeMethodsMixin');
 const Platform = require('Platform');
-const React = require('React');
+const ProgressBarAndroid = require('ProgressBarAndroid');
 const PropTypes = require('prop-types');
+const React = require('React');
 const StyleSheet = require('StyleSheet');
 const View = require('View');
 const ViewPropTypes = require('ViewPropTypes');
@@ -135,16 +136,20 @@ const ActivityIndicator = createReactClass({
         break;
     }
 
+    const nativeProps = {
+      ...props,
+      style: sizeStyle,
+      styleAttr: 'Normal',
+      indeterminate: true,
+    };
+
     return (
-      <View
-        onLayout={onLayout}
-        style={[styles.container, style]}>
-        <RCTActivityIndicator
-          {...props}
-          style={sizeStyle}
-          styleAttr="Normal"
-          indeterminate
-        />
+      <View onLayout={onLayout} style={[styles.container, style]}>
+        {Platform.OS === 'ios' ? (
+          <RCTActivityIndicator {...nativeProps} />
+        ) : (
+          <ProgressBarAndroid {...nativeProps} />
+        )}
       </View>
     );
   }
@@ -169,18 +174,7 @@ if (Platform.OS === 'ios') {
   var RCTActivityIndicator = requireNativeComponent(
     'RCTActivityIndicatorView',
     ActivityIndicator,
-    {nativeOnly: {activityIndicatorViewStyle: true}},
-  );
-} else if (Platform.OS === 'android') {
-  var RCTActivityIndicator = requireNativeComponent(
-    'AndroidProgressBar',
-    ActivityIndicator,
-    // Ignore props that are specific to non inderterminate ProgressBar.
-    {nativeOnly: {
-      indeterminate: true,
-      progress: true,
-      styleAttr: true,
-    }},
+    { nativeOnly: { activityIndicatorViewStyle: true } }
   );
 }
 

--- a/Libraries/Components/ProgressBarAndroid/ProgressBarAndroid.android.js
+++ b/Libraries/Components/ProgressBarAndroid/ProgressBarAndroid.android.js
@@ -17,6 +17,8 @@ const React = require('React');
 const ReactNative = require('ReactNative');
 const ViewPropTypes = require('ViewPropTypes');
 
+const requireNativeComponent = require('requireNativeComponent');
+
 const STYLE_ATTRIBUTES = [
   'Horizontal',
   'Normal',
@@ -79,6 +81,10 @@ class ProgressBarAndroid extends ReactNative.NativeComponent {
      */
     styleAttr: PropTypes.oneOf(STYLE_ATTRIBUTES),
     /**
+     * Whether to show the ProgressBar (true, the default) or hide it (false).
+     */
+    animating: PropTypes.bool,
+    /**
      * If the progress bar will show indeterminate progress. Note that this
      * can only be false if styleAttr is Horizontal.
      */
@@ -99,7 +105,8 @@ class ProgressBarAndroid extends ReactNative.NativeComponent {
 
   static defaultProps = {
     styleAttr: 'Normal',
-    indeterminate: true
+    indeterminate: true,
+    animating: true,
   };
 
   componentDidMount() {
@@ -112,8 +119,18 @@ class ProgressBarAndroid extends ReactNative.NativeComponent {
   }
 
   render() {
-    return <ActivityIndicator {...this.props} animating={true} />;
+    return <AndroidProgressBar {...this.props} />;
   }
 }
+
+const AndroidProgressBar = requireNativeComponent(
+  'AndroidProgressBar',
+  ProgressBarAndroid,
+  {
+    nativeOnly: {
+      animating: true,
+    },
+  }
+);
 
 module.exports = ProgressBarAndroid;


### PR DESCRIPTION
## Motivation

`ProgressBarAndroid` regressed after fixing a bug in https://github.com/facebook/react-native/commit/ccddbf82d79833702f19d9f6ed1ca23755655187

## Test Plan

Run this gist on a new project with this code: https://gist.github.com/brentvatne/a0b57e5bbae1bd2cf76765ea27f077af

Notice that you will see:

<img width="642" alt="screen shot 2017-10-17 at 11 06 03 am" src="https://user-images.githubusercontent.com/90494/31681142-3437a95a-b32b-11e7-85d3-c29bfbfe591e.png">

hmmm... doesn't seem right 🤔 

With the patch in this PR applied, you will see:

<img width="642" alt="screen shot 2017-10-17 at 11 01 38 am" src="https://user-images.githubusercontent.com/90494/31680950-b0c1805a-b32a-11e7-909e-42cdf478da56.png">

oh! there we go 😄 

## Release Notes

[ANDROID] [BUGFIX] [ProgressBarAndroid] - Fix regression in ProgressBarAndroid which limited `styleAttr` to only `Regular`. 