### PR TITLE
Fix Flow errors at declaration of most major library components

### DIFF
--- a/Libraries/Components/ActivityIndicator/ActivityIndicator.js
+++ b/Libraries/Components/ActivityIndicator/ActivityIndicator.js
@@ -77,9 +77,6 @@ type DefaultProps = {
  * AppRegistry.registerComponent('App', () => App)
  * ```
  */
-/* $FlowFixMe(>=0.53.0 site=react_native_fb,react_native_oss) This comment
- * suppresses an error when upgrading Flow's support for React. To see the
- * error delete this comment and run Flow. */
 const ActivityIndicator = createReactClass({
   displayName: 'ActivityIndicator',
   mixins: [NativeMethodsMixin],

--- a/Libraries/Components/CheckBox/CheckBox.android.js
+++ b/Libraries/Components/CheckBox/CheckBox.android.js
@@ -37,7 +37,6 @@ type DefaultProps = {
  * @keyword checkbox
  * @keyword toggle
  */
-// $FlowFixMe(>=0.41.0)
 let CheckBox = createReactClass({
   displayName: 'CheckBox',
   propTypes: {

--- a/Libraries/Components/DatePicker/DatePickerIOS.ios.js
+++ b/Libraries/Components/DatePicker/DatePickerIOS.ios.js
@@ -36,7 +36,6 @@ type Event = Object;
  * the user's change will be reverted immediately to reflect `props.date` as the
  * source of truth.
  */
-// $FlowFixMe(>=0.41.0)
 const DatePickerIOS = createReactClass({
   displayName: 'DatePickerIOS',
   // TOOD: Put a better type for _picker

--- a/Libraries/Components/Keyboard/KeyboardAvoidingView.js
+++ b/Libraries/Components/Keyboard/KeyboardAvoidingView.js
@@ -46,7 +46,6 @@ const viewRef = 'VIEW';
  * It is a component to solve the common problem of views that need to move out of the way of the virtual keyboard.
  * It can automatically adjust either its position or bottom padding based on the position of the keyboard.
  */
-// $FlowFixMe(>=0.41.0)
 const KeyboardAvoidingView = createReactClass({
   displayName: 'KeyboardAvoidingView',
   mixins: [TimerMixin],

--- a/Libraries/Components/ProgressViewIOS/ProgressViewIOS.ios.js
+++ b/Libraries/Components/ProgressViewIOS/ProgressViewIOS.ios.js
@@ -24,7 +24,6 @@ var requireNativeComponent = require('requireNativeComponent');
 /**
  * Use `ProgressViewIOS` to render a UIProgressView on iOS.
  */
-// $FlowFixMe(>=0.41.0)
 var ProgressViewIOS = createReactClass({
   displayName: 'ProgressViewIOS',
   mixins: [NativeMethodsMixin],

--- a/Libraries/Components/RefreshControl/RefreshControl.js
+++ b/Libraries/Components/RefreshControl/RefreshControl.js
@@ -72,7 +72,6 @@ if (Platform.OS === 'android') {
  * __Note:__ `refreshing` is a controlled prop, this is why it needs to be set to true
  * in the `onRefresh` function otherwise the refresh indicator will stop immediately.
  */
-// $FlowFixMe(>=0.41.0)
 const RefreshControl = createReactClass({
   displayName: 'RefreshControl',
   statics: {

--- a/Libraries/Components/SegmentedControlIOS/SegmentedControlIOS.ios.js
+++ b/Libraries/Components/SegmentedControlIOS/SegmentedControlIOS.ios.js
@@ -49,7 +49,6 @@ type Event = Object;
  * />
  * ````
  */
-// $FlowFixMe(>=0.41.0)
 var SegmentedControlIOS = createReactClass({
   displayName: 'SegmentedControlIOS',
   mixins: [NativeMethodsMixin],

--- a/Libraries/Components/Slider/Slider.js
+++ b/Libraries/Components/Slider/Slider.js
@@ -29,7 +29,6 @@ type Event = Object;
 /**
  * A component used to select a single value from a range of values.
  */
-// $FlowFixMe(>=0.41.0)
 var Slider = createReactClass({
   displayName: 'Slider',
   mixins: [NativeMethodsMixin],

--- a/Libraries/Components/Switch/Switch.js
+++ b/Libraries/Components/Switch/Switch.js
@@ -38,7 +38,6 @@ type DefaultProps = {
  * @keyword checkbox
  * @keyword toggle
  */
-// $FlowFixMe(>=0.41.0)
 var Switch = createReactClass({
   displayName: 'Switch',
   propTypes: {

--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -181,7 +181,6 @@ const DataDetectorTypes = [
  *
  */
 
-// $FlowFixMe(>=0.41.0)
 const TextInput = createReactClass({
   displayName: 'TextInput',
   statics: {

--- a/Libraries/Components/Touchable/TouchableBounce.js
+++ b/Libraries/Components/Touchable/TouchableBounce.js
@@ -36,7 +36,6 @@ var PRESS_RETENTION_OFFSET = {top: 20, left: 20, right: 20, bottom: 30};
  * `TouchableMixin` expects us to implement some abstract methods to handle
  * interesting interactions such as `handleTouchablePress`.
  */
-// $FlowFixMe(>=0.41.0)
 var TouchableBounce = createReactClass({
   displayName: 'TouchableBounce',
   mixins: [Touchable.Mixin, NativeMethodsMixin],

--- a/Libraries/Components/Touchable/TouchableWithoutFeedback.js
+++ b/Libraries/Components/Touchable/TouchableWithoutFeedback.js
@@ -102,7 +102,6 @@ const TouchableWithoutFeedback = createReactClass({
      * reactivated! Move it back and forth several times while the scroll view
      * is disabled. Ensure you pass in a constant to reduce memory allocations.
      */
-    // $FlowFixMe: Expected a React PropType instead
     pressRetentionOffset: EdgeInsetsPropType,
     /**
      * This defines how far your touch can start away from the button. This is
@@ -112,7 +111,6 @@ const TouchableWithoutFeedback = createReactClass({
      * of sibling views always takes precedence if a touch hits two overlapping
      * views.
      */
-    // $FlowFixMe: Expected a React PropType instead
     hitSlop: EdgeInsetsPropType,
   },
 

--- a/Libraries/Components/View/View.js
+++ b/Libraries/Components/View/View.js
@@ -73,7 +73,6 @@ export type Props = ViewProps;
  *   - `timestamp` - A time identifier for the touch, useful for velocity calculation.
  *   - `touches` - Array of all current touches on the screen.
  */
-// $FlowFixMe(>=0.41.0)
 const View = createReactClass({
   displayName: 'View',
   // TODO: We should probably expose the mixins, viewConfig, and statics publicly. For example,

--- a/Libraries/Image/Image.ios.js
+++ b/Libraries/Image/Image.ios.js
@@ -132,7 +132,6 @@ const ImageViewManager = NativeModules.ImageViewManager;
  * ```
  *
  */
-// $FlowFixMe(>=0.41.0)
 const Image = createReactClass({
   displayName: 'Image',
   propTypes: {

--- a/Libraries/StyleSheet/EdgeInsetsPropType.js
+++ b/Libraries/StyleSheet/EdgeInsetsPropType.js
@@ -15,12 +15,12 @@ const PropTypes = require('prop-types');
 
 const createStrictShapeTypeChecker = require('createStrictShapeTypeChecker');
 
-const EdgeInsetsPropType = createStrictShapeTypeChecker({
+const EdgeInsetsPropType = (createStrictShapeTypeChecker({
   top: PropTypes.number,
   left: PropTypes.number,
   bottom: PropTypes.number,
   right: PropTypes.number,
-});
+}): ReactPropsCheckType & ReactPropsChainableTypeChecker);
 
 export type EdgeInsetsProp = {
   top: number,

--- a/Libraries/Text/Text.js
+++ b/Libraries/Text/Text.js
@@ -285,7 +285,6 @@ const viewConfig = {
  *
  */
 
-// $FlowFixMe(>=0.41.0)
 const Text = createReactClass({
   displayName: 'Text',
   propTypes: {


### PR DESCRIPTION
The relevant changes in the PR are to Libraries/StyleSheet/EdgeInsetsPropType.js; the rest are just removals of FlowIgnores.

The definition of the relevant types is [here](https://github.com/facebook/flow/blob/master/lib/react.js#L262-L271).

The long and short of it is that for whatever reason, Flow is unable to realize that `ReactPropsChainableTypeChecker` is a subtype of `ReactPropsCheckType` unless we assert it. Once we explicitly hint this to the typechecker, it realizes that `EdgeInsetsPropType` is indeed a valid React PropType, and stops complaining that it isn't.