### PR TITLE
 Inverted descent/ascent Android prioritisation to match iOS lineHeight behaviour

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/CustomLineHeightSpan.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/CustomLineHeightSpan.java
@@ -29,34 +29,25 @@ public class CustomLineHeightSpan implements LineHeightSpan {
     // The general solution is that if there's not enough height to show the full line height, we
     // will prioritize in this order: descent, ascent, bottom, top
 
-    int height = mHeight;
-    int currentHeight = -fm.top + fm.bottom;
-    int delta = currentHeight - height;
-    if (delta > 0) {
-      int bottomSpaceAvailable = fm.bottom - fm.descent;
-      int topSpaceAvailable = -fm.top - -fm.ascent;
-      if (topSpaceAvailable > 0 && delta > 0) {
-        int topSpaceTaken = topSpaceAvailable;
-        if (delta < topSpaceTaken) {
-          topSpaceTaken = delta;
-        }
-        delta -= topSpaceTaken;
-        fm.top = fm.ascent - (topSpaceAvailable - topSpaceTaken);
-      }
-      if (bottomSpaceAvailable > 0) {
-        int bottomSpaceTaken = bottomSpaceAvailable;
-        if (delta < bottomSpaceAvailable) {
-          bottomSpaceTaken = delta;
-        }
-        delta -= bottomSpaceTaken;
-        fm.bottom = fm.descent + bottomSpaceAvailable - bottomSpaceTaken;
-      }
+    if (-fm.ascent > mHeight) {
+      // Show as much descent as possible
+      fm.bottom = fm.descent = mHeight;
+      fm.top = fm.ascent = 0;
+    } else if (-fm.ascent + fm.descent > mHeight) {
+      // Show all descent, and as much ascent as possible
+      fm.bottom = fm.descent;
+      fm.top = fm.ascent = -mHeight + fm.descent;
+    } else if (-fm.ascent + fm.bottom > mHeight) {
+      // Show all ascent, descent, as much bottom as possible
+      fm.top = fm.ascent;
+      fm.bottom = fm.ascent + mHeight;
+    } else if (-fm.top + fm.bottom > mHeight) {
+      // Show all ascent, descent, bottom, as much top as possible
+      fm.top = fm.bottom - mHeight;
+    } else {
+      // Show proportionally additional top
+      final int additional = mHeight - (-fm.top + fm.bottom);
+      fm.top -= additional;
     }
-
-    fm.top += delta;
-    if(delta > 0) {
-      fm.ascent = Math.max(fm.top, fm.ascent - delta);
-    }
-
   }
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/CustomLineHeightSpan.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/CustomLineHeightSpan.java
@@ -36,12 +36,25 @@ public class CustomLineHeightSpan implements LineHeightSpan {
     // The general solution is that if there's not enough height to show the full line height, we
     // will prioritize in this order: descent, ascent, bottom, top
 
-    // Show proportionally additional ascent / top & descent / bottom
-    final int additional = mHeight - (-fm.top + fm.bottom);
-
-    fm.top -= additional / 2;
-    fm.ascent -= additional / 2;
-    fm.descent += additional / 2;
-    fm.bottom += additional / 2;
+    if (-fm.ascent > mHeight) {
+      // Show as much descent as possible
+      fm.bottom = fm.descent = mHeight;
+      fm.top = fm.ascent = 0;
+    } else if (-fm.ascent + fm.descent > mHeight) {
+      // Show all descent, and as much ascent as possible
+      fm.bottom = fm.descent;
+      fm.top = fm.ascent = -mHeight + fm.descent;
+    } else if (-fm.ascent + fm.bottom > mHeight) {
+      // Show all ascent, descent, as much bottom as possible
+      fm.top = fm.ascent;
+      fm.bottom = fm.ascent + mHeight;
+    } else if (-fm.top + fm.bottom > mHeight) {
+      // Show all ascent, descent, bottom, as much top as possible
+      fm.top = fm.bottom - mHeight;
+    } else {
+      // Show proportionally additional top
+      final int additional = mHeight - (-fm.top + fm.bottom);
+      fm.top -= additional;
+    }
   }
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/CustomLineHeightSpan.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/CustomLineHeightSpan.java
@@ -54,7 +54,9 @@ public class CustomLineHeightSpan implements LineHeightSpan {
     }
 
     fm.top += delta;
-    fm.ascent = Math.max(fm.top, fm.ascent - delta);
+    if(delta > 0) {
+      fm.ascent = Math.max(fm.top, fm.ascent - delta);
+    }
 
   }
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/CustomLineHeightSpan.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/CustomLineHeightSpan.java
@@ -27,28 +27,34 @@ public class CustomLineHeightSpan implements LineHeightSpan {
     // This is more complicated that I wanted it to be. You can find a good explanation of what the
     // FontMetrics mean here: http://stackoverflow.com/questions/27631736.
     // The general solution is that if there's not enough height to show the full line height, we
-    // will prioritize in this order: ascent, descent, bottom, top
+    // will prioritize in this order: descent, ascent, bottom, top
 
-    if (-fm.ascent > mHeight) {
-      // Show as much ascent as possible
-      fm.top = fm.ascent = -mHeight;
-      fm.bottom = fm.descent = 0;
-    } else if (-fm.ascent + fm.descent > mHeight) {
-      // Show all ascent, and as much descent as possible
-      fm.top = fm.ascent;
-      fm.bottom = fm.descent = mHeight + fm.ascent;
-    } else if (-fm.ascent + fm.bottom > mHeight) {
-      // Show all ascent, descent, as much bottom as possible
-      fm.top = fm.ascent;
-      fm.bottom = fm.ascent + mHeight;
-    } else if (-fm.top + fm.bottom > mHeight) {
-      // Show all ascent, descent, bottom, as much top as possible
-      fm.top = fm.bottom - mHeight;
-    } else {
-      // Show proportionally additional ascent and top
-      final int additional = mHeight - (-fm.top + fm.bottom);
-      fm.top -= additional;
-      fm.ascent -= additional;
+    int height = mHeight;
+    int currentHeight = -fm.top + fm.bottom;
+    int delta = currentHeight - height;
+    if (delta > 0) {
+      int bottomSpaceAvailable = fm.bottom - fm.descent;
+      int topSpaceAvailable = -fm.top - -fm.ascent;
+      if (topSpaceAvailable > 0 && delta > 0) {
+        int topSpaceTaken = topSpaceAvailable;
+        if (delta < topSpaceTaken) {
+          topSpaceTaken = delta;
+        }
+        delta -= topSpaceTaken;
+        fm.top = fm.ascent - (topSpaceAvailable - topSpaceTaken);
+      }
+      if (bottomSpaceAvailable > 0) {
+        int bottomSpaceTaken = bottomSpaceAvailable;
+        if (delta < bottomSpaceAvailable) {
+          bottomSpaceTaken = delta;
+        }
+        delta -= bottomSpaceTaken;
+        fm.bottom = fm.descent + bottomSpaceAvailable - bottomSpaceTaken;
+      }
     }
+
+    fm.top += delta;
+    fm.ascent = Math.max(fm.top, fm.ascent - delta);
+
   }
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/CustomLineHeightSpan.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/CustomLineHeightSpan.java
@@ -36,9 +36,9 @@ public class CustomLineHeightSpan implements LineHeightSpan {
     // The general solution is that if there's not enough height to show the full line height, we
     // will prioritize in this order: descent, ascent, bottom, top
 
-    if (-fm.ascent > mHeight) {
+    if (fm.descent > mHeight) {
       // Show as much descent as possible
-      fm.bottom = fm.descent = mHeight;
+      fm.bottom = fm.descent = Math.min(mHeight, fm.descent);
       fm.top = fm.ascent = 0;
     } else if (-fm.ascent + fm.descent > mHeight) {
       // Show all descent, and as much ascent as possible
@@ -52,9 +52,13 @@ public class CustomLineHeightSpan implements LineHeightSpan {
       // Show all ascent, descent, bottom, as much top as possible
       fm.top = fm.bottom - mHeight;
     } else {
-      // Show proportionally additional top
+      // Show proportionally additional ascent / top & descent / bottom
       final int additional = mHeight - (-fm.top + fm.bottom);
-      fm.top -= additional;
+
+      fm.top -= additional / 2;
+      fm.ascent -= additional / 2;
+      fm.descent += additional / 2;
+      fm.bottom += additional / 2;
     }
   }
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/CustomLineHeightSpan.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/CustomLineHeightSpan.java
@@ -1,4 +1,11 @@
-// Copyright 2004-present Facebook. All Rights Reserved.
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
 
 package com.facebook.react.views.text;
 
@@ -29,25 +36,12 @@ public class CustomLineHeightSpan implements LineHeightSpan {
     // The general solution is that if there's not enough height to show the full line height, we
     // will prioritize in this order: descent, ascent, bottom, top
 
-    if (-fm.ascent > mHeight) {
-      // Show as much descent as possible
-      fm.bottom = fm.descent = mHeight;
-      fm.top = fm.ascent = 0;
-    } else if (-fm.ascent + fm.descent > mHeight) {
-      // Show all descent, and as much ascent as possible
-      fm.bottom = fm.descent;
-      fm.top = fm.ascent = -mHeight + fm.descent;
-    } else if (-fm.ascent + fm.bottom > mHeight) {
-      // Show all ascent, descent, as much bottom as possible
-      fm.top = fm.ascent;
-      fm.bottom = fm.ascent + mHeight;
-    } else if (-fm.top + fm.bottom > mHeight) {
-      // Show all ascent, descent, bottom, as much top as possible
-      fm.top = fm.bottom - mHeight;
-    } else {
-      // Show proportionally additional top
-      final int additional = mHeight - (-fm.top + fm.bottom);
-      fm.top -= additional;
-    }
+    // Show proportionally additional ascent / top & descent / bottom
+    final int additional = mHeight - (-fm.top + fm.bottom);
+
+    fm.top -= additional / 2;
+    fm.ascent -= additional / 2;
+    fm.descent += additional / 2;
+    fm.bottom += additional / 2;
   }
 }

--- a/ReactAndroid/src/test/java/com/facebook/react/views/text/CustomLineHeightSpanTest.java
+++ b/ReactAndroid/src/test/java/com/facebook/react/views/text/CustomLineHeightSpanTest.java
@@ -13,6 +13,21 @@ import org.robolectric.RobolectricTestRunner;
 public class CustomLineHeightSpanTest {
 
   @Test
+  public void shouldIncreaseTop() {
+    CustomLineHeightSpan customLineHeightSpan = new CustomLineHeightSpan(21);
+    Paint.FontMetricsInt fm = new Paint.FontMetricsInt();
+    fm.top = -10;
+    fm.ascent = -5;
+    fm.descent = 5;
+    fm.bottom = 10;
+    customLineHeightSpan.chooseHeight("Hi", 0, 2, 0, 0, fm);
+    assertThat(fm.top).isEqualTo(-11);
+    assertThat(fm.ascent).isEqualTo(-5);
+    assertThat(fm.descent).isEqualTo(5);
+    assertThat(fm.bottom).isEqualTo(10);
+  }
+
+  @Test
   public void shouldReduceTopFirst() {
     CustomLineHeightSpan customLineHeightSpan = new CustomLineHeightSpan(19);
     Paint.FontMetricsInt fm = new Paint.FontMetricsInt();

--- a/ReactAndroid/src/test/java/com/facebook/react/views/text/CustomLineHeightSpanTest.java
+++ b/ReactAndroid/src/test/java/com/facebook/react/views/text/CustomLineHeightSpanTest.java
@@ -13,8 +13,8 @@ import org.robolectric.RobolectricTestRunner;
 public class CustomLineHeightSpanTest {
 
   @Test
-  public void shouldIncreaseTop() {
-    CustomLineHeightSpan customLineHeightSpan = new CustomLineHeightSpan(21);
+  public void shouldIncreaseAllMetricsProportionally() {
+    CustomLineHeightSpan customLineHeightSpan = new CustomLineHeightSpan(22);
     Paint.FontMetricsInt fm = new Paint.FontMetricsInt();
     fm.top = -10;
     fm.ascent = -5;
@@ -22,9 +22,9 @@ public class CustomLineHeightSpanTest {
     fm.bottom = 10;
     customLineHeightSpan.chooseHeight("Hi", 0, 2, 0, 0, fm);
     assertThat(fm.top).isEqualTo(-11);
-    assertThat(fm.ascent).isEqualTo(-5);
-    assertThat(fm.descent).isEqualTo(5);
-    assertThat(fm.bottom).isEqualTo(10);
+    assertThat(fm.ascent).isEqualTo(-6);
+    assertThat(fm.descent).isEqualTo(6);
+    assertThat(fm.bottom).isEqualTo(11);
   }
 
   @Test
@@ -70,5 +70,20 @@ public class CustomLineHeightSpanTest {
     assertThat(fm.ascent).isEqualTo(-4);
     assertThat(fm.descent).isEqualTo(5);
     assertThat(fm.bottom).isEqualTo(5);
+  }
+
+  @Test
+  public void shouldReduceDescentLast() {
+    CustomLineHeightSpan customLineHeightSpan = new CustomLineHeightSpan(4);
+    Paint.FontMetricsInt fm = new Paint.FontMetricsInt();
+    fm.top = -10;
+    fm.ascent = -5;
+    fm.descent = 5;
+    fm.bottom = 10;
+    customLineHeightSpan.chooseHeight("Hi", 0, 2, 0, 0, fm);
+    assertThat(fm.top).isEqualTo(0);
+    assertThat(fm.ascent).isEqualTo(0);
+    assertThat(fm.descent).isEqualTo(4);
+    assertThat(fm.bottom).isEqualTo(4);
   }
 }

--- a/ReactAndroid/src/test/java/com/facebook/react/views/text/CustomLineHeightSpanTest.java
+++ b/ReactAndroid/src/test/java/com/facebook/react/views/text/CustomLineHeightSpanTest.java
@@ -1,0 +1,59 @@
+package com.facebook.react.views.text;
+
+import android.graphics.Paint;
+
+import static org.fest.assertions.api.Assertions.assertThat;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.robolectric.RobolectricTestRunner;
+
+@RunWith(RobolectricTestRunner.class)
+@PowerMockIgnore({"org.mockito.*", "org.robolectric.*", "android.*"})
+public class CustomLineHeightSpanTest {
+
+  @Test
+  public void shouldReduceTopFirst() {
+    CustomLineHeightSpan customLineHeightSpan = new CustomLineHeightSpan(19);
+    Paint.FontMetricsInt fm = new Paint.FontMetricsInt();
+    fm.top = -10;
+    fm.ascent = -5;
+    fm.descent = 5;
+    fm.bottom = 10;
+    customLineHeightSpan.chooseHeight("Hi", 0, 2, 0, 0, fm);
+    assertThat(fm.top).isEqualTo(-9);
+    assertThat(fm.ascent).isEqualTo(-5);
+    assertThat(fm.descent).isEqualTo(5);
+    assertThat(fm.bottom).isEqualTo(10);
+  }
+
+  @Test
+  public void shouldReduceBottomSecond() {
+    CustomLineHeightSpan customLineHeightSpan = new CustomLineHeightSpan(14);
+    Paint.FontMetricsInt fm = new Paint.FontMetricsInt();
+    fm.top = -10;
+    fm.ascent = -5;
+    fm.descent = 5;
+    fm.bottom = 10;
+    customLineHeightSpan.chooseHeight("Hi", 0, 2, 0, 0, fm);
+    assertThat(fm.top).isEqualTo(-5);
+    assertThat(fm.ascent).isEqualTo(-5);
+    assertThat(fm.descent).isEqualTo(5);
+    assertThat(fm.bottom).isEqualTo(9);
+  }
+
+  @Test
+  public void shouldReduceAscentThird() {
+    CustomLineHeightSpan customLineHeightSpan = new CustomLineHeightSpan(9);
+    Paint.FontMetricsInt fm = new Paint.FontMetricsInt();
+    fm.top = -10;
+    fm.ascent = -5;
+    fm.descent = 5;
+    fm.bottom = 10;
+    customLineHeightSpan.chooseHeight("Hi", 0, 2, 0, 0, fm);
+    assertThat(fm.top).isEqualTo(-4);
+    assertThat(fm.ascent).isEqualTo(-4);
+    assertThat(fm.descent).isEqualTo(5);
+    assertThat(fm.bottom).isEqualTo(5);
+  }
+}


### PR DESCRIPTION
## Motivation

We noticed that on Android the lineHeight behaviour is different from iOS for built in fonts and custom fonts. The problem becomes visible when the lineHeight approaches the fontSize, showing a cut-off on the bottom of the TextView. This issue has been raised before in #10712. There is a mention of a PR with a fix in that issue, which has not been merged yet. This implementation is a less intrusive fix leaving the current lineHeight approach in place and fixing the discrepancy only.

This proposed change prioritises ascent over descent for reduction, making the lineHeight functionality behave identical to iOS.

## Test Plan

There is no existing test covering the lineHeight property and its behaviour in the CustomLineHeightSpan. This PR contains new unit tests that covers the various scenario's for the lineHeight calculations.

The original behaviour, before the change can against these unit tests. The case that fails is `shouldReduceAscentThird`, which can be made to succeed on the old code by changing the asserts to:
```
    assertThat(fm.top).isEqualTo(-5);
    assertThat(fm.ascent).isEqualTo(-5);
    assertThat(fm.descent).isEqualTo(-4);
    assertThat(fm.bottom).isEqualTo(-4);
```
The unit test succeeds for the current implementation, which has the values for ascent and descent inverted.

Below screenshots show before, after and iOS:

BEFORE
![screen shot 2017-10-18 at 15 35 41](https://user-images.githubusercontent.com/1605731/31721688-58d7086a-b41a-11e7-8186-9a201e2acb01.png)

AFTER
![screen shot 2017-10-18 at 15 37 02](https://user-images.githubusercontent.com/1605731/31721665-473cf86c-b41a-11e7-94d5-7a70eaf99889.png)

iOS
![screen shot 2017-10-18 at 15 35 22](https://user-images.githubusercontent.com/1605731/31721712-707e30a6-b41a-11e7-9baa-f886a66837e6.png)

## Release Notes

[ANDROID] [BUGFIX] [Text] - Fix the lineHeight behaviour on Android to match iOS