### PR TITLE
Update function name removeListner

### DIFF
--- a/Libraries/Components/Keyboard/Keyboard.js
+++ b/Libraries/Components/Keyboard/Keyboard.js
@@ -59,8 +59,8 @@ type KeyboardEventListener = (e: KeyboardEventData) => void;
  *   }
  *
  *   componentWillUnmount () {
- *     this.keyboardDidShowListener.remove();
- *     this.keyboardDidHideListener.remove();
+ *     this.keyboardDidShowListener.removeListner();
+ *     this.keyboardDidHideListener.removeListner();
  *   }
  *
  *   _keyboardDidShow () {


### PR DESCRIPTION
Looks like this documentation was referring to older function declaration. Updated the same to reflect the name change.

## Motivation

Was working on UI change on change of keyboard. This was Component was of good help. But, remove function was of no help. Dug around to find it has been renamed to removeListner() to accommodate the removal of listener. 

## Test Plan

No testing needed. Just updated the documentation. 

## Release Notes
 [DOCS] [BUGFIX] [Libraries/Component/Keyboard/Keyboard.js] - Fixed a typo in function name. 