### PR TITLE
Remove deprecation warning when using indeterminate and styleAttr !== 'Horizontal' in ProgressBarAndroid

### DIFF
--- a/Libraries/Components/ProgressBarAndroid/ProgressBarAndroid.android.js
+++ b/Libraries/Components/ProgressBarAndroid/ProgressBarAndroid.android.js
@@ -109,15 +109,6 @@ class ProgressBarAndroid extends ReactNative.NativeComponent {
     animating: true,
   };
 
-  componentDidMount() {
-    if (this.props.indeterminate && this.props.styleAttr !== 'Horizontal') {
-      console.warn(
-        'Circular indeterminate `ProgressBarAndroid`' +
-        'is deprecated. Use `ActivityIndicator` instead.'
-      );
-    }
-  }
-
   render() {
     return <AndroidProgressBar {...this.props} />;
   }


### PR DESCRIPTION
## Motivation

We delegate to ProgressBarAndroid in ActivityIndicator as of https://github.com/facebook/react-native/pull/16435 so this warning is thrown constantly. Eventually we will refactor ProgressBarAndroid and ProgressViewIOS under one component, but until then this gets us into a working state of the world without warnings again.

## Test Plan

Nothing needed.

## Release Notes

Not needed, other PR mentioned above captures this.
