### PR TITLE
Add a `--minify` option to the `bundle` CLI command

### DIFF
--- a/local-cli/bundle/buildBundle.js
+++ b/local-cli/bundle/buildBundle.js
@@ -65,6 +65,7 @@ function buildBundle(
     assetsDest: mixed,
     entryFile: string,
     maxWorkers: number,
+    minify: ?boolean,
     resetCache: boolean,
     transformer: string,
   },
@@ -85,7 +86,7 @@ function buildBundle(
     entryFile: args.entryFile,
     sourceMapUrl,
     dev: args.dev,
-    minify: !args.dev,
+    minify: args.minify != null ? args.minify : !args.dev,
     platform: args.platform,
   };
 

--- a/local-cli/bundle/bundleCommandLineArgs.js
+++ b/local-cli/bundle/bundleCommandLineArgs.js
@@ -25,6 +25,10 @@ module.exports = [
     parse: (val) => val === 'false' ? false : true,
     default: true,
   }, {
+    command: '--minify [boolean]',
+    description: 'Enable or disables minification, overriding "--dev"',
+    parse: (val) => val === 'false' ? false : true
+  }, {
     command: '--bundle-output <string>',
     description: 'File name where to store the resulting bundle, ex. /tmp/groups.bundle',
   }, {

--- a/local-cli/bundle/bundleCommandLineArgs.js
+++ b/local-cli/bundle/bundleCommandLineArgs.js
@@ -26,7 +26,7 @@ module.exports = [
     default: true,
   }, {
     command: '--minify [boolean]',
-    description: 'Enable or disables minification, overriding "--dev"',
+    description: 'Enables or disables minification, overriding "--dev"',
     parse: (val) => val === 'false' ? false : true
   }, {
     command: '--bundle-output <string>',


### PR DESCRIPTION
If specified, this flag will override the `--dev` flag. Otherwise, the existing behavior remains the same.

## Motivation

Some of our upstream dependencies break under minification. Therefore, we need to produce release builds with minification turned off. Adding this flag allows us to manually create builds with the configuration `--dev false --minify false`, which was previously impossible from the CLI.

## Test Plan

In a fresh react-native project, just run these commands:

```sh
# existing behavior remains:
react-native bundle --entry-file index.ios.js --bundle-output dev.js --dev
react-native bundle --entry-file index.ios.js --bundle-output prod.js --dev false

# new combinations are possible:
react-native bundle --entry-file index.ios.js --bundle-output dev-min.js --dev --minify
react-native bundle --entry-file index.ios.js --bundle-output prod-non-min.js --dev false --minify false
```

If you check the output, you will see:

* dev.js - non-minified (current behavior)
* prod.js - minified (current behavior)
* dev-min.js - minified (new feature)
* prod-non-min.js - non-minified (new feature)

## Release Notes

[CLI] [FEATURE] [local-cli/bundle] - Added a `--minify` option to the `bundle` command