### PR TITLE
Add missing link to missing podspec

### DIFF
--- a/docs/IntegrationWithExistingApps.md
+++ b/docs/IntegrationWithExistingApps.md
@@ -226,6 +226,11 @@ target 'NumberTileGame' do
   ]
   # Explicitly include Yoga if you are using RN >= 0.42.0
   pod 'yoga', :path => '../node_modules/react-native/ReactCommon/yoga'
+  
+  # Third party deps podspec link
+  pod 'DoubleConversion', :podspec => '../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec'
+  pod 'GLog', :podspec => '../node_modules/react-native/third-party-podspecs/GLog.podspec'
+  pod 'Folly', :podspec => '../node_modules/react-native/third-party-podspecs/Folly.podspec'
 
 end
 ```
@@ -255,6 +260,11 @@ target 'swift-2048' do
   ]
   # Explicitly include Yoga if you are using RN >= 0.42.0
   pod "yoga", :path => "../node_modules/react-native/ReactCommon/yoga"
+  
+  # Third party deps podspec link
+  pod 'DoubleConversion', :podspec => '../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec'
+  pod 'GLog', :podspec => '../node_modules/react-native/third-party-podspecs/GLog.podspec'
+  pod 'Folly', :podspec => '../node_modules/react-native/third-party-podspecs/Folly.podspec'
 
 end
 ```


### PR DESCRIPTION
Update Integration with Existing Apps
Pod File missing link to podspecs that are not in the master CocoaPods spec repo

## Motivation

Be able to trust documentation when I come back to the page later.

## Release Notes
[DOCS][ENHANCEMENT][docs/IntegrationWithExistingApps.md] Add private podspec path to iOS 'Integration with Existing Apps' example.