### PR TITLE
Fix test suite when running on a feature branch

### DIFF
--- a/Libraries/Core/__tests__/ReactNativeVersionCheck-test.js
+++ b/Libraries/Core/__tests__/ReactNativeVersionCheck-test.js
@@ -41,7 +41,7 @@ function _defineCheckVersionTests() {
   });
 
   it('passes when all the versions are zero', () => {
-    jest.dontMock('ReactNativeVersion');
+    _mockJsVersion(0, 0, 0);
     _mockNativeVersion(0, 0, 0);
 
     const ReactNativeVersion = require('ReactNativeVersion');


### PR DESCRIPTION
Test suite for React Native version check relies on `ReactNativeVersion.js` file that is modified on a release branch (it contains values of a real version, not zeros).

That makes it impossible for the build to pass: https://circleci.com/gh/facebook/react-native/23494

This PR mocks it with zero values, just like we mock it in other suites. I am not sure if that is desired, but works for now.

CC @ide 