### PR TITLE
improve fresco docs so that the version is tied to RN

### DIFF
--- a/Libraries/Image/Image.ios.js
+++ b/Libraries/Image/Image.ios.js
@@ -108,19 +108,34 @@ const ImageViewManager = NativeModules.ImageViewManager;
  * You will need to add some optional modules in `android/app/build.gradle`, depending on the needs of your app.
  *
  * ```
+ * // use getFrescoComponent to lock your components to the version used by react-native
+ * def getFrescoVersion() {
+ *    String reactGradle = file('../../node_modules/react-native/ReactAndroid/build.gradle').text
+ *    // use the default of the latest version
+ *    def version = '+'
+ *    reactGradle.eachLine {
+ *        if (it =~ /'com.facebook.fresco:fresco:.*'/) {
+ *            version = it.find(/(?<='com.facebook.fresco:fresco:).*(?=')/)
+ *        }
+ *    }
+ *    return version;
+ * }
+ *
+ * def frescoVersion = getFrescoVersion()
+ *
  * dependencies {
  *   // If your app supports Android versions before Ice Cream Sandwich (API level 14)
- *   compile 'com.facebook.fresco:animated-base-support:1.3.0'
+ *   compile 'com.facebook.fresco:animated-base-support:'+frescoVersion
  *
  *   // For animated GIF support
- *   compile 'com.facebook.fresco:animated-gif:1.3.0'
+ *   compile 'com.facebook.fresco:animated-gif:'+frescoVersion
  *
  *   // For WebP support, including animated WebP
- *   compile 'com.facebook.fresco:animated-webp:1.3.0'
- *   compile 'com.facebook.fresco:webpsupport:1.3.0'
+ *   compile 'com.facebook.fresco:animated-webp:'+frescoVersion
+ *   compile 'com.facebook.fresco:webpsupport:'+frescoVersion
  *
  *   // For WebP support, without animations
- *   compile 'com.facebook.fresco:webpsupport:1.3.0'
+ *   compile 'com.facebook.fresco:webpsupport:'+frescoVersion
  * }
  * ```
  *


### PR DESCRIPTION
## Motivation

Some time ago we integrated fresco:animated-gif into our project at version 0.14.1. 
```
   compile 'com.facebook.fresco:animated-gif:0.14.1'
```
Later we upgraded react native several times, and the core library of fresco was updated automatically under ReactAndroid/build.gradle. This did not pose a problem necessarily until there was a version mismatch and the API was broken between fresco common and fresco animated-gifs. It can be an easy to miss detail, but the version of fresco really ought to be explicitly tied to react-native from the get go. This recommendation in the docs future proofs users gradle files against changes in react-native so that their fresco components match.

Furthermore it should prevent upgrades to the fresco library from having to touch Image.ios.js again.

## Test Plan

Create a test app + add the components using the recommended method. 

## Release Notes

[DOCS][ENHANCEMENT][Image.ios.js] - Recommendation to lock fresco component version to fresco version used by react native
