### PR TITLE
Update proguard-rules to fix build issues after cxxbridge and bridge …

### DIFF
--- a/local-cli/templates/HelloWorld/android/app/proguard-rules.pro
+++ b/local-cli/templates/HelloWorld/android/app/proguard-rules.pro
@@ -41,6 +41,13 @@
   *** get*();
 }
 
+-keep class com.facebook.react.uimanager.UIProp { *; }
+-keep class com.facebook.react.bridge.CatalystInstanceImpl { *; }
+-keep class com.facebook.react.bridge.JavaScriptExecutor { *; }
+-keep class com.facebook.react.bridge.queue.NativeRunnable { *; }
+-keep class com.facebook.react.bridge.ExecutorToken { *; }
+-keep class com.facebook.react.bridge.ReadableType { *; }
+
 -keep class * extends com.facebook.react.bridge.JavaScriptModule { *; }
 -keep class * extends com.facebook.react.bridge.NativeModule { *; }
 -keepclassmembers,includedescriptorclasses class * { native <methods>; }


### PR DESCRIPTION
…packages were merged

Rebased changes from #15619 and removed extra/duplicate rules.

## Motivation

Fix proguard enabled builds

## Test Plan
```gradle
    buildTypes {
        release {
            signingConfig signingConfigs.release
            minifyEnabled true
            proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
        }
    }
```

`./gradlew assembleRelease`

## Release Notes
[ANDROID] [BUGFIX] [Proguard] - Proguard enabled builds should now build correctly using the included proguard-rules file.
