### PR TITLE
Docs: Add example to CheckBox documentation

### DIFF
--- a/Libraries/Components/CheckBox/CheckBox.android.js
+++ b/Libraries/Components/CheckBox/CheckBox.android.js
@@ -34,6 +34,50 @@ type DefaultProps = {
  * If the `value` prop is not updated, the component will continue to render
  * the supplied `value` prop instead of the expected result of any user actions.
  *
+ * ```
+ * import React from 'react';
+ * import { AppRegistry, StyleSheet, Text, View, CheckBox } from 'react-native';
+ *
+ * export default class App extends React.Component {
+ *   constructor(props) {
+ *     super(props);
+ *     this.state = {
+ *       checked: false
+ *     }
+ *   }
+ *
+ *   toggle() {
+ *     this.setState(({checked}) => {
+ *       return {
+ *         checked: !checked
+ *       };
+ *     });
+ *   }
+ *
+ *   render() {
+ *     const {checked} = this.state;
+ *     return (
+ *       <View style={styles.container}>
+ *         <Text>Checked</Text>
+ *         <CheckBox value={checked} onChange={this.toggle.bind(this)} />
+ *       </View>
+ *     );
+ *   }
+ * }
+ *
+ * const styles = StyleSheet.create({
+ *   container: {
+ *     flex: 1,
+ *     flexDirection: 'row',
+ *     alignItems: 'center',
+ *     justifyContent: 'center',
+ *   },
+ * });
+ *
+ * // skip this line if using Create React Native App
+ * AppRegistry.registerComponent('App', () => App);
+ * ```
+ *
  * @keyword checkbox
  * @keyword toggle
  */


### PR DESCRIPTION
## Motivation
I find it easier to understand the behavior of a component when there is a simple example showing its usage. I recently used the CheckBox component and noticed that it doesn't have a code example. This PR adds an example to the CheckBox documentation.

## Test Plan
N/A

## Release Notes
[DOCS][ENHANCEMENT][CheckBox] - Added example to documentation
