### PR TITLE
[BUGFIX] Requesting permission results into ArrayIndexOutOfBoundsException

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/modules/permissions/PermissionsModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/permissions/PermissionsModule.java
@@ -15,7 +15,6 @@ import android.content.pm.PackageManager;
 import android.os.Build;
 import android.os.Process;
 import android.util.SparseArray;
-
 import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
@@ -27,7 +26,6 @@ import com.facebook.react.bridge.WritableNativeMap;
 import com.facebook.react.module.annotations.ReactModule;
 import com.facebook.react.modules.core.PermissionAwareActivity;
 import com.facebook.react.modules.core.PermissionListener;
-
 import java.util.ArrayList;
 
 /**
@@ -116,7 +114,7 @@ public class PermissionsModule extends ReactContextBaseJavaModule implements Per
           @Override
           public void invoke(Object... args) {
             int[] results = (int[]) args[0];
-            if (results[0] == PackageManager.PERMISSION_GRANTED) {
+            if (results.length > 0 && results[0] == PackageManager.PERMISSION_GRANTED) {
               promise.resolve(GRANTED);
             } else {
               PermissionAwareActivity activity = (PermissionAwareActivity) args[1];
@@ -175,7 +173,8 @@ public class PermissionsModule extends ReactContextBaseJavaModule implements Per
           PermissionAwareActivity activity = (PermissionAwareActivity) args[1];
           for (int j = 0; j < permissionsToCheck.size(); j++) {
             String permission = permissionsToCheck.get(j);
-            if (results[j] == PackageManager.PERMISSION_GRANTED) {
+
+            if (results.length > 0 && results[j] == PackageManager.PERMISSION_GRANTED) {
               grantedPermissions.putString(permission, GRANTED);
             } else {
               if (activity.shouldShowRequestPermissionRationale(permission)) {

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/permissions/PermissionsModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/permissions/PermissionsModule.java
@@ -173,7 +173,6 @@ public class PermissionsModule extends ReactContextBaseJavaModule implements Per
           PermissionAwareActivity activity = (PermissionAwareActivity) args[1];
           for (int j = 0; j < permissionsToCheck.size(); j++) {
             String permission = permissionsToCheck.get(j);
-
             if (results.length > 0 && results[j] == PackageManager.PERMISSION_GRANTED) {
               grantedPermissions.putString(permission, GRANTED);
             } else {


### PR DESCRIPTION
Reported in Issue #15928

## Motivation
Fixing bug when permission showing dialog and user go to home and re-open minimized app.

## Test Plan
1. Ask for permission 
2. Minimize app (Press HomeButton)
3. Open app again via shortcut

## Release Notes
 [ANDROID] [BUGFIX] [PermissionsModule.java] - Fixed bug when asked for permission Cause: java.lang.ArrayIndexOutOfBoundsException · length=0; index=0