### PR TITLE
Change name of the file to edit

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -583,12 +583,12 @@ Now that you have successfully run the app, let's modify it.
 
 <block class="native mac ios" />
 
-- Open `index.js` in your text editor of choice and edit some lines.
+- Open `App.js` in your text editor of choice and edit some lines.
 - Hit `⌘R` in your iOS Simulator to reload the app and see your changes!
 
 <block class="native mac android" />
 
-- Open `index.js` in your text editor of choice and edit some lines.
+- Open `App.js` in your text editor of choice and edit some lines.
 - Press the `R` key twice or select `Reload` from the Developer Menu (`⌘M`) to see your changes!
 
 <block class="native windows linux android" />
@@ -597,7 +597,7 @@ Now that you have successfully run the app, let's modify it.
 
 Now that you have successfully run the app, let's modify it.
 
-- Open `index.js` in your text editor of choice and edit some lines.
+- Open `App.js` in your text editor of choice and edit some lines.
 - Press the `R` key twice or select `Reload` from the Developer Menu (`Ctrl + M`) to see your changes!
 
 <block class="native mac ios android" />


### PR DESCRIPTION
The text that appears on screen is in App.js component.


## Motivation
The project that is being generated using react-native shows `To get started, edit App.js` text when run, but the documentation says to edit index.js file. The text is actually present in App.js, therefore the app is correct, but the documentation is not.

[DOCS] [ENHANCEMENT] [GettingStarted.md] - Wrong name of the file to edit

