### PR TITLE
Update documentation for iOS static bundle

### DIFF
--- a/docs/RunningOnDevice.md
+++ b/docs/RunningOnDevice.md
@@ -347,7 +347,34 @@ To configure your app to be built using the `Release` scheme, go to **Product** 
 
 ![](img/ConfigureReleaseScheme.png)
 
-### 3. Build app for release
+### 3. Configure app to use static bundle
+
+During the development process React Native has loaded your JavaScript code dynamically at runtime. For a production build you want to pre-package the JavaScript bundle and distribute it inside your Application. To do this requires a code change in your App so that it knows to load the static bundle.
+
+In `AppDelegate.m`, change the default `jsCodeLocation` to point to the static bundle that is built in Release.
+```
+  jsCodeLocation = [[NSBundle mainBundle] URLForResource:@"main" withExtension:@"jsbundle"];
+```
+
+This will now reference the `main.jsbundle` resource file that is created during the `Bundle React Native code and images` Build Phase in Xcode.
+
+> Note: The static bundle is built every time you target a physical device, even in Debug. If you want to save time, turn off bundle generation in Debug by adding theollowing to your shell script in Xcode Build Phase `Bundle React Native code and images`:
+```
+ if [ "${CONFIGURATION}" == "Debug" ]; then
+  export SKIP_BUNDLING=true
+ fi
+```
+
+#### Pro Tip
+As your App Bundle grows in size, you may start to see a White Screen flash between your Splash Screen and the display of your root Application view. If this is thease, you can add the following code to `AppDelegate.m` in order to keep your Splash Screen displayed during the transition.
+```
+  // Place this code after "[self.window makeKeyAndVisible]" and before "return YES;"
+  UIView* launchScreenView = [[[NSBundle mainBundle] loadNibNamed:@"LaunchScreen" owner:self options:nil] objectAtIndex:0];
+  launchScreenView.frame = self.window.bounds;
+  rootView.loadingView = launchScreenView;
+```
+
+### 4. Build app for release
 
 You can now build your app for release by tapping `⌘B` or selecting **Product** → **Build** from the menu bar. Once built for release, you'll be able to distribute the app to beta testers and submit the app to the App Store.
 


### PR DESCRIPTION

## Motivation

Include instructions on how to use the static bundle when building an iOS App for production. Also include tips to document the SKIP_BUNDLING flag that was recently added, as well as fix the white background flash when the bundle size is large.

There are a number of issues and past pull requests that tackle this same problem but no one has properly updated the documentation to reflect the conclusions that have been made:
[#240](https://github.com/facebook/react-native/issues/240)
[Updates #625](https://github.com/facebook/react-native/pull/625)
Also Refers to #1402 

## Test Plan

Build an app for production using a Release scheme in Xcode, and see that it does not require the React Native Packager to be running.

## Release Notes
[DOCS][ENHANCEMENT][docs/RunningOnDevice.md] - Document how to use a static bundle for iOS
