### PR TITLE
[DOCS] [BUGFIX] [Keyboad.js] - Fixed link ref for NativeEventEmitter.js

### DIFF
--- a/Libraries/Components/Keyboard/Keyboard.js
+++ b/Libraries/Components/Keyboard/Keyboard.js
@@ -38,7 +38,7 @@ type KeyboardEventListener = (e: KeyboardEventData) => void;
 
 // The following object exists for documentation purposes
 // Actual work happens in
-// https://github.com/facebook/react-native/blob/master/Libraries/vendor/emitter/NativeEventEmitter.js
+// https://github.com/facebook/react-native/blob/master/Libraries/EventEmitter/NativeEventEmitter.js
 
 /**
  * `Keyboard` module to control keyboard events.


### PR DESCRIPTION
- Make it link to the right location for [NativeEventEmitter](https://github.com/facebook/react-native/blob/master/Libraries/EventEmitter/NativeEventEmitter.js)

## Motivation

The docs are wrong.

## Test Plan

Copy-paste the link. 404 === Bad, 200 === Good
