### PR TITLE
Fixed broken image link in example code

### DIFF
--- a/Libraries/Image/Image.ios.js
+++ b/Libraries/Image/Image.ios.js
@@ -53,7 +53,7 @@ const ImageViewManager = NativeModules.ImageViewManager;
  *         />
  *         <Image
  *           style={{width: 50, height: 50}}
- *           source={{uri: 'https://facebook.github.io/react/logo-og.png'}}
+ *           source={{uri: 'https://facebook.github.io/react-native/img/favicon.png'}}
  *         />
  *         <Image
  *           style={{width: 66, height: 58}}


### PR DESCRIPTION
## Motivation
Got frustrated for a minute trying to figure out why the code I copy pasted from the docs wasn't working

## Test Plan
The link I replaced the broken one with is the one used in the iOS device example next to the sample code. It can be found at https://facebook.github.io/react-native/img/favicon.png

## Release Notes
 [DOCS] [MINOR] [Libraries/Image/Image.ios.js] - Broken image link in the example code at 
