### PR TITLE
React/Base/RCTJavaScriptLoader.m imported <cxxreact/JSBundleType.h> a…

### DIFF
--- a/React.podspec
+++ b/React.podspec
@@ -43,6 +43,7 @@ Pod::Spec.new do |s|
 
   s.subspec "Core" do |ss|
     ss.dependency             "yoga", "#{package["version"]}.React"
+    ss.dependency             "React/cxxreact_legacy"
     ss.source_files         = "React/**/*.{c,h,m,mm,S}"
     ss.exclude_files        = "**/__tests__/*",
                               "IntegrationTests/*",


### PR DESCRIPTION
## Motivation
fix bugs

## Test Plan
please look at the code，u will know me.

## Release Notes
add dependency 'React/cxxreact_legacy' for subspec 'React/Core', because 'React/Base/RCTJavaScriptLoader.m' imported <cxxreact/JSBundleType.h> and <jschelpers/JavaScriptCore.h>

[CATEGORY] [TYPE] [LOCATION] - MESSAGE
 [IOS] [BUGFIX] [React.podspec] - React/Base/RCTJavaScriptLoader.m imported <cxxreact/JSBundleType.h> and <jschelpers/JavaScriptCore.h>, but no dependency in React.podspec
