### PR TITLE
Update IntegrationWithExistingApps.md

### DIFF
--- a/docs/IntegrationWithExistingApps.md
+++ b/docs/IntegrationWithExistingApps.md
@@ -555,7 +555,7 @@ Add the React Native dependency to your app's `build.gradle` file:
 dependencies {
     compile 'com.android.support:appcompat-v7:23.0.1'
     ...
-    compile "com.facebook.react:react-native:+" // From node_modules.
+    compile "com.facebook.react:react-native:0.49+" // From node_modules.
 }
 ```
 

--- a/docs/IntegrationWithExistingApps.md
+++ b/docs/IntegrationWithExistingApps.md
@@ -555,7 +555,7 @@ Add the React Native dependency to your app's `build.gradle` file:
 dependencies {
     compile 'com.android.support:appcompat-v7:23.0.1'
     ...
-    compile "com.facebook.react:react-native:0.49+" // From node_modules.
+    compile "com.facebook.react:react-native:+" // From node_modules.
 }
 ```
 
@@ -566,11 +566,11 @@ Add an entry for the local React Native maven directory to `build.gradle`. Be su
 ```
 allprojects {
     repositories {
-        ...
         maven {
             // All of React Native (JS, Android binaries) is installed from npm
             url "$rootDir/../node_modules/react-native/android"
         }
+        ... // Other maven repostories such as jcenter() goes here
     }
     ...
 }


### PR DESCRIPTION
Makes sure a recent version of react native is used by specifying that at least version 0.49 should be used for Android. Otherwise an old 0.20.1 version hosted in [jcenter](https://bintray.com/bintray/jcenter/com.facebook.react%3Areact-native) might override the version included from `node_modules`.

## Motivation

Ending up with an ancient version of react native might be confusing to new users trying out react native for the first time.

## Test Plan

NA

## Release Notes
 [DOCS] [MINOR] [IntegrationWithExistingApps.md] - Make sure a `node_modules` version of react native is used
