### PR TITLE
Allow devDependencies in dependencies.json

### DIFF
--- a/local-cli/generator/templates.js
+++ b/local-cli/generator/templates.js
@@ -182,16 +182,42 @@ function installTemplateDependencies(templatePath, yarnVersion) {
       'Could not parse the template\'s dependencies.json: ' + err.message
     );
   }
-  for (let depName in dependencies) {
-    const depVersion = dependencies[depName];
-    const depToInstall = depName + '@' + depVersion;
-    console.log('Adding ' + depToInstall + '...');
-    if (yarnVersion) {
-      execSync(`yarn add ${depToInstall}`, {stdio: 'inherit'});
-    } else {
-      execSync(`npm install ${depToInstall} --save --save-exact`, {stdio: 'inherit'});
+
+  if (dependencies.dependencies) {
+    for (let depName in dependencies.dependencies) {
+      const depVersion = dependencies.dependencies[depName];
+      const depToInstall = depName + '@' + depVersion;
+      console.log('Adding ' + depToInstall + '...');
+      if (yarnVersion) {
+        execSync(`yarn add ${depToInstall}`, {stdio: 'inherit'});
+      } else {
+        execSync(`npm install ${depToInstall} --save --save-exact`, {stdio: 'inherit'});
+      }
+    }
+
+    for (let depName in dependencies.devDependencies) {
+      const depVersion = dependencies.devDependencies[depName];
+      const depToInstall = depName + '@' + depVersion;
+      console.log('Adding ' + depToInstall + 'to devDependencies ...');
+      if (yarnVersion) {
+        execSync(`yarn add --dev ${depToInstall}`, {stdio: 'inherit'});
+      } else {
+        execSync(`npm install ${depToInstall} --save-dev --save-exact`, {stdio: 'inherit'});
+      }
+    }
+  } else { // For backward compability
+    for (let depName in dependencies) {
+      const depVersion = dependencies[depName];
+      const depToInstall = depName + '@' + depVersion;
+      console.log('Adding ' + depToInstall + '...');
+      if (yarnVersion) {
+        execSync(`yarn add ${depToInstall}`, {stdio: 'inherit'});
+      } else {
+        execSync(`npm install ${depToInstall} --save --save-exact`, {stdio: 'inherit'});
+      }
     }
   }
+
   console.log('Linking native dependencies into the project\'s build files...');
   execSync('react-native link', {stdio: 'inherit'});
 }


### PR DESCRIPTION
## Motivation

The current react-native-template is not able to install devDependencies. With this change, `dependencies.json` can be in the following example to allow devDependencies installation

```json
{
    "dependencies": {
        "react-navigation": "^1.0.0-beta.15"
    },
    "devDependencies": {
        "eslint-config-airbnb": "latest"
    }
}
```

This change does not alter the original behaviour, so it will be backward-compatible.

Related issue #13954

## Test Plan

1. Pack RN local repo into a tarball
1. Run `react-native init` with version set to the tarball location, and template to https://github.com/alvinthen/react-native-template-geirman
1. Verify the new project's `package.json` has the dependencies listed in https://github.com/alvinthen/react-native-template-geirman/blob/master/dependencies.json

I'm willing to write a automated test if anyone pointed me to the right direction.

## Release Notes
 [CLI] [FEATURE] [local-cli/generator/templates.js] - Allow devDependencies to be installed when using `react-native init --template`
