### PR TITLE
[IOS] [BUGFIX] [React.podspec] - Added missing privatedata subspec

### DIFF
--- a/React.podspec
+++ b/React.podspec
@@ -109,9 +109,17 @@ Pod::Spec.new do |s|
 
   s.subspec "jschelpers" do |ss|
     ss.dependency             "Folly", "2016.09.26.00"
+    ss.dependency             "React/privatedata"
     ss.compiler_flags       = folly_compiler_flags
     ss.source_files         = "ReactCommon/jschelpers/*.{cpp,h}"
     ss.private_header_files = "ReactCommon/jschelpers/*.h"
+    ss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\"" }
+    ss.framework            = "JavaScriptCore"
+  end
+
+  s.subspec "privatedata" do |ss|
+    ss.source_files         = "ReactCommon/privatedata/*.{cpp,h}"
+    ss.private_header_files = "ReactCommon/privatedata/*.h"
     ss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\"" }
     ss.framework            = "JavaScriptCore"
   end


### PR DESCRIPTION
## Motivation

React.podspec is missing a privatedata subspect. It means when trying to build and iOS app with cocoapods and react-native 0.50.0-rc.2 it doesn't work

## Test Plan

Change React.podspec and run pod install, follow this guide https://facebook.github.io/react-native/releases/0.23/docs/embedded-app-ios.html#install-react-native-using-cocoapods

## Release Notes
[IOS] [BUGFIX] [React.podspec] - Added missing privatedata subspec
