### PR TITLE
Add some documentation about cookie handling.

### DIFF
--- a/Libraries/Components/WebView/WebView.ios.js
+++ b/Libraries/Components/WebView/WebView.ios.js
@@ -111,7 +111,9 @@ var defaultRenderError = (errorDomain, errorCode, errorDesc) => (
  *```
  *
  * You can use this component to navigate back and forth in the web view's
- * history and configure various properties for the web content.
+ * history and configure various properties for the web content. Cookies are
+ * synchronized between React Native and the WebView with the [exception of
+ * cookies marked `SameSite` on Android](https://bugs.chromium.org/p/chromium/issues/detail?id=780491&can=2&start=0&num=100&q=samesite&colspec=ID%20Pri%20M%20Stars%20ReleaseBlock%20Component%20Status%20Owner%20Summary%20OS%20Modified&groupby=&sort=).
  */
 class WebView extends React.Component {
   static JSNavigationScheme = JSNavigationScheme;


### PR DESCRIPTION

## Motivation

I'm not sure this is the best place for the note, but I've not be able to find any documentation—on Chromium, on Android's CookieManager class, or elsewhere—that the SameSite cookies are not synced. I expect some further documentation on limitations of syncing cookies would be valuable, but I don't have the expertise to flesh that out at the moment.

## Test Plan

Documentation.

## Release Notes
[DOCS][MINOR][WebView] - Note about cookie syncing in WebView.