### PR TITLE
Fix launchChrome for chromium on Ubuntu

### DIFF
--- a/local-cli/server/util/launchChrome.js
+++ b/local-cli/server/util/launchChrome.js
@@ -36,6 +36,8 @@ function getChromeAppName(): string {
   case 'linux':
     if (commandExistsUnixSync('google-chrome')) {
       return 'google-chrome';
+    } else if (commandExistsUnixSync('chromium-browser')) {
+      return 'chromium-browser';
     } else {
       return 'chromium';
     }


### PR DESCRIPTION
## Motivation

On Ubuntu (and maybe other distros), the executable for the chromium browser is 'chromium-browser' instead of 'chromium'.
This commit calls 'chromium-browser' before calling 'chromium' if it exists.

## Test Plan

Start an example app on Android with "react-native init project && react-native run-android". Open DevTools: it opens chromium correctly.

## Release Notes

[CLI] [BUGFIX] [local-cli/server/utils/launchChrome.js] - Fix launchChrome for chromium on Ubuntu