### PR TITLE
Adds PrivateDatabase podspec

### DIFF
--- a/React.podspec
+++ b/React.podspec
@@ -118,7 +118,6 @@ Pod::Spec.new do |s|
   end
 
   s.subspec "PrivateDatabase" do |ss|
-    ss.source_files         = "Libraries/ART/**/*.{h,m}"
     ss.source_files         = "ReactCommon/privatedata/*.{cpp,h}"
     ss.private_header_files = "ReactCommon/privatedata/*.h"
   end

--- a/React.podspec
+++ b/React.podspec
@@ -116,6 +116,12 @@ Pod::Spec.new do |s|
     ss.framework            = "JavaScriptCore"
   end
 
+  s.subspec "PrivateDatabase" do |ss|
+    ss.source_files         = "Libraries/ART/**/*.{h,m}"
+    ss.source_files         = "ReactCommon/privatedata/*.{cpp,h}"
+    ss.private_header_files = "ReactCommon/privatedata/*.h"
+  end
+
   s.subspec "cxxreact" do |ss|
     ss.dependency             "React/jschelpers"
     ss.dependency             "boost"

--- a/React.podspec
+++ b/React.podspec
@@ -109,6 +109,7 @@ Pod::Spec.new do |s|
 
   s.subspec "jschelpers" do |ss|
     ss.dependency             "Folly", "2016.09.26.00"
+    ss.dependency             "React/PrivateDatabase"
     ss.compiler_flags       = folly_compiler_flags
     ss.source_files         = "ReactCommon/jschelpers/*.{cpp,h}"
     ss.private_header_files = "ReactCommon/jschelpers/*.h"


### PR DESCRIPTION
## Motivation

Resolves #16663.

## Test Plan

Walked through the reproduction steps in #16663, but with successful build.

We can also now see the files are included in the `Pods` project:

<img width="236" alt="screen shot 2017-11-03 at 7 43 21 pm" src="https://user-images.githubusercontent.com/33126/32390596-4a06c05c-c0cf-11e7-8616-3ae547f8cca2.png">

(I noticed a subspec called `_ignore_me_subspec_for_linting_` so do we have tests for the podspec?)

## Release Notes

[IOS] [BUGFIX] [React.podspec] - Resolves build error about missing symbols for PrivateDatabase.{cpp,h}
