### PR TITLE
[podspec] Define `pod_target_xcconfig` for PrivateDatabase

### DIFF
--- a/React.podspec
+++ b/React.podspec
@@ -120,6 +120,7 @@ Pod::Spec.new do |s|
   s.subspec "PrivateDatabase" do |ss|
     ss.source_files         = "ReactCommon/privatedata/*.{cpp,h}"
     ss.private_header_files = "ReactCommon/privatedata/*.h"
+    ss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\"" }
   end
 
   s.subspec "cxxreact" do |ss|


### PR DESCRIPTION
We don't strictly need this since all the other subspecs that use this set up the header search path for ReactCommon anyway but do it just for correctness.

Test Plan: install iOS pods

## Release Notes

[podspec] Define `pod_target_xcconfig` for PrivateDatabase