### PR TITLE
Add Screen orientation lock instructions

### DIFF
--- a/docs/ImprovingUserExperience.md
+++ b/docs/ImprovingUserExperience.md
@@ -19,6 +19,7 @@ Building apps for mobile platforms is nuanced, there are many little details tha
 - [Manage layout when keyboard is visible](#manage-layout-when-keyboard-is-visible)
 - [Make tappable areas larger](#make-tappable-areas-larger)
 - [Use Android Ripple](#use-android-ripple)
+- [Screen orientation lock](#screen-orientation-lock)
 - [Learn More](#learn-more)
 
 -------------------------------------------------------------------------------
@@ -62,6 +63,10 @@ Android API 21+ uses the material design ripple to provide user with feedback wh
 <video src="img/ripple.mp4" autoplay loop width="320"></video>
 
 [Try it on your phone](https://snack.expo.io/SJywqe3rZ)
+
+## Screen orientation lock
+
+Unless supporting both, it is considered good practice to lock the screen orientation to either portrait or landscape. On iOS, in the General tab and Deployment Info section of Xcode enable the Device Orientation you want to support (ensure you have selected iPhone from the Devices menu when making the changes). For Android, open the AndroidManifest.xml file and within the activity element add android:screenOrientation=”portrait” to lock to portrait or android:screenOrientation=”landscape” to lock to landscape.
 
 # Learn more
 


### PR DESCRIPTION
Instructions to lock screen orientations to either portrait or landscape for Android and iOS

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes. 

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to React Native here: http://facebook.github.io/react-native/docs/contributing.html

Happy contributing!

-->

## Motivation

To help out with the Improving User Experience docs

## Release Notes
 [DOCS] [IOS] [ANDROID] [ENHANCEMENT] [ImprovingUserExperience.md] - Adding instructions for screen orientation locking for Android/iOS
