### PR TITLE
fix(docs): fixing wrong module name in the example of "Integration with Existing Apps" page

### DIFF
--- a/docs/IntegrationWithExistingApps.md
+++ b/docs/IntegrationWithExistingApps.md
@@ -362,7 +362,7 @@ const styles = StyleSheet.create({
 });
 
 // Module name
-AppRegistry.registerComponent('MyReactNativeApp', () => RNHighScores);
+AppRegistry.registerComponent('RNHighScores', () => RNHighScores);
 ```
 
 > `RNHighScores` is the name of your module that will be used when you add a view to React Native from within your iOS application.


### PR DESCRIPTION
## Motivation

The current example of `Objective-C/Swift` component will not work cos of wrong module name in the example. If change `MyReactNativeApp` to the `RNHighScores` everything starts working.

## Release Notes

[DOCS] [BUGFIX] [IntegrationWithExistingApps.md] - Wrong module name in the example.