### PR TITLE
[DOCS] Add tintColor to ActionSheetIOS documentation

### DIFF
--- a/Libraries/ActionSheetIOS/ActionSheetIOS.js
+++ b/Libraries/ActionSheetIOS/ActionSheetIOS.js
@@ -26,6 +26,7 @@ var ActionSheetIOS = {
    * - `destructiveButtonIndex` (int) - index of destructive button in `options`
    * - `title` (string) - a title to show above the action sheet
    * - `message` (string) - a message to show below the title
+   * - `tintColor` (color) - tint color of the buttons
    *
    * The 'callback' function takes one parameter, the zero-based index
    * of the selected item.
@@ -68,6 +69,7 @@ var ActionSheetIOS = {
    * - `message` (string) - a message to share
    * - `subject` (string) - a subject for the message
    * - `excludedActivityTypes` (array) - the activities to exclude from the ActionSheet
+   * - `tintColor` (color) - tint color of the buttons   
    *
    * NOTE: if `url` points to a local file, or is a base64-encoded
    * uri, the file it points to will be loaded and shared directly.

--- a/Libraries/ActionSheetIOS/ActionSheetIOS.js
+++ b/Libraries/ActionSheetIOS/ActionSheetIOS.js
@@ -69,7 +69,7 @@ var ActionSheetIOS = {
    * - `message` (string) - a message to share
    * - `subject` (string) - a subject for the message
    * - `excludedActivityTypes` (array) - the activities to exclude from the ActionSheet
-   * - `tintColor` (color) - tint color of the buttons   
+   * - `tintColor` (color) - tint color of the buttons
    *
    * NOTE: if `url` points to a local file, or is a base64-encoded
    * uri, the file it points to will be loaded and shared directly.


### PR DESCRIPTION
This pr adds documentation for the tintColor addition of #4590

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes. 

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to React Native here: http://facebook.github.io/react-native/docs/contributing.html

Happy contributing!

-->

## Motivation

The tintColor was missing from the documentation but works perfectly fine.

## Test Plan

Added a tintColor to showActionSheetWithOptions and showShareActionSheetWithOptions in the app i am building right now.

## Release Notes

[DOCS][MINOR][ActionSheetIOS] - Added documentation for tintColor in ActionSheet.