### PR TITLE
Fix Jest mocks for NetInfo module.

### DIFF
--- a/jest/setup.js
+++ b/jest/setup.js
@@ -162,7 +162,7 @@ const mockNativeModules = {
   },
   ImageLoader: {
     getSize: jest.fn(
-      (url) => new Promise(() => ({width: 320, height: 240}))
+      (url) => Promise.resolve({width: 320, height: 240})
     ),
     prefetchImage: jest.fn(),
   },
@@ -179,11 +179,11 @@ const mockNativeModules = {
   Linking: {
     openURL: jest.fn(),
     canOpenURL: jest.fn(
-      () => new Promise((resolve) => resolve(true))
+      () => Promise.resolve(true)
     ),
     addEventListener: jest.fn(),
     getInitialURL: jest.fn(
-      () => new Promise((resolve) => resolve())
+      () => Promise.resolve()
     ),
     removeEventListener: jest.fn(),
   },
@@ -195,15 +195,23 @@ const mockNativeModules = {
   ModalFullscreenViewManager: {},
   NetInfo: {
     fetch: jest.fn(
-      () => new Promise((resolve) => resolve())
+      () => Promise.resolve()
+    ),
+    getConnectionInfo: jest.fn(
+      () => Promise.resolve()
     ),
     addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
     isConnected: {
       fetch: jest.fn(
-        () => new Promise((resolve) => resolve())
+        () => Promise.resolve()
       ),
       addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
     },
+    isConnectionExpensive: jest.fn(
+      () => Promise.resolve()
+    ),
   },
   Networking: {
     sendRequest: jest.fn(),


### PR DESCRIPTION
## Motivation

Jest mock for `NetInfo.getConnectionInfo()` is missing. Tests are fail with error message:
```
TypeError: _reactNative.NetInfo.getConnectionInfo is not a function
```
And cleaned code in this files for unified code styles.

## Test Plan

Run test with usage of `NetInfo.getConnectionInfo()`

## Release Notes

[GENERAL] [BUGFIX] [jest/setup.js] - Fix Jest mocks for NetInfo module
