### PR TITLE
Add rejectResponderTermination prop to TextInput

### DIFF
--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -783,6 +783,12 @@ const TextInput = createReactClass({
     inlineImagePadding: PropTypes.number,
 
     /**
+     * Allow TextInput to pass touch event to parent.
+     * @platform ios
+     */
+    rejectResponderTermination: PropTypes.bool,
+
+    /**
      * Determines the types of data converted to clickable URLs in the text input.
      * Only valid if `multiline={true}` and `editable={false}`.
      * By default no data types are detected.
@@ -859,6 +865,7 @@ const TextInput = createReactClass({
   getDefaultProps() {
     return {
       allowFontScaling: true,
+      rejectResponderTermination: true,
       underlineColorAndroid: 'transparent',
     };
   },
@@ -1079,7 +1086,7 @@ const TextInput = createReactClass({
       <TouchableWithoutFeedback
         onLayout={props.onLayout}
         onPress={this._onPress}
-        rejectResponderTermination={true}
+        rejectResponderTermination={props.rejectResponderTermination}
         accessible={props.accessible}
         accessibilityLabel={props.accessibilityLabel}
         accessibilityRole={props.accessibilityRole}

--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -783,7 +783,10 @@ const TextInput = createReactClass({
     inlineImagePadding: PropTypes.number,
 
     /**
-     * Allow TextInput to pass touch event to parent.
+     * If `true`, allows TextInput to pass touch events to the parent component. 
+     * This allows components such as SwipeableListView to be swipeable from the TextInput on iOS, 
+     * as is the case on Android by default.
+     * If `false`, TextInput always asks to handle the input (except when disabled).
      * @platform ios
      */
     rejectResponderTermination: PropTypes.bool,

--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -783,8 +783,8 @@ const TextInput = createReactClass({
     inlineImagePadding: PropTypes.number,
 
     /**
-     * If `true`, allows TextInput to pass touch events to the parent component. 
-     * This allows components such as SwipeableListView to be swipeable from the TextInput on iOS, 
+     * If `true`, allows TextInput to pass touch events to the parent component.
+     * This allows components such as SwipeableListView to be swipeable from the TextInput on iOS,
      * as is the case on Android by default.
      * If `false`, TextInput always asks to handle the input (except when disabled).
      * @platform ios


### PR DESCRIPTION
## Motivation

This is a new attempt to get #11251 merged. I just cherry-picked the relevant commits. TextInputs are set to always ignore responder termination requests, which is not desirable when they are enclosed inside a swipeable area like a ListView

## Test Plan

Create a TextInput inside a ListView and set the `rejectResponderTermination` prop to false. Otherwise, all TextInputs should have the same behavior they do now.

## Release Notes

[IOS] [ENHANCEMENT] [TextInput] - Add `rejectResponderTermination` prop to to TextInput. This enables TextInputs inside Swipeables to function properly.
