### PR TITLE
[Docs] Add a sample to clarify animation callback

### DIFF
--- a/docs/animated.md
+++ b/docs/animated.md
@@ -66,6 +66,16 @@ invoked with `{finished: true}`. If the animation is done because `stop()`
 was called on it before it could finish (e.g. because it was interrupted by a
 gesture or another animation), then it will receive `{finished: false}`.
 
+```javascript
+this.animateValue.spring({}).start(function onComplete({finished}) {
+  if (finished === true) {
+    console.log('Animation was stopped')
+  } else {
+    console.log('Animation was aborted')
+  }
+})
+```
+
 ### Using the native driver
 
 By using the native driver, we send everything about the animation to native

--- a/docs/animated.md
+++ b/docs/animated.md
@@ -67,9 +67,9 @@ was called on it before it could finish (e.g. because it was interrupted by a
 gesture or another animation), then it will receive `{finished: false}`.
 
 ```javascript
-this.animateValue.spring({}).start(function onComplete({finished}) {
-  if (finished === true) {
-    console.log('Animation was stopped')
+this.animateValue.spring({}).start(({finished}) => {
+  if (finished) {
+    console.log('Animation was completed')
   } else {
     console.log('Animation was aborted')
   }


### PR DESCRIPTION
## Motivation

Even having worked long with React Native, I am pretty new to animations, so it took me a while to figure out how to trigger some code after an animation had finished. After some investigation, it
was evident I did not ready as in depth as I am supposed to, but this can be a problem for many
who, like me, try to search quick through docs and other resources.

Here more cases:
https://stackoverflow.com/questions/38053071/react-native-animated-complete-event
https://github.com/facebook/react-native/issues/3212

## Test Plan
Read the proposed sample, and see if it is adequate.

## Release Notes
 [DOCS] [ENHANCEMENT] [AnimatedImplementation.js] - Adds a sample for animation callbacks
