### PR TITLE
[Bugfix][FlatList] Objects as props trigger invariant errors

### DIFF
--- a/Libraries/Lists/FlatList.js
+++ b/Libraries/Lists/FlatList.js
@@ -17,7 +17,8 @@ const React = require('React');
 const View = require('View');
 const VirtualizedList = require('VirtualizedList');
 
-const invariant = require('fbjs/lib/invariant'), areEqual = require('fbjs/lib/areEqual');
+const invariant = require('fbjs/lib/invariant');
+const areEqual = require('fbjs/lib/areEqual');
 
 import type {StyleObj} from 'StyleSheetTypes';
 import type {
@@ -419,7 +420,10 @@ class FlatList<ItemT> extends React.PureComponent<Props<ItemT>, void> {
         'changing the number of columns to force a fresh render of the component.',
     );
     invariant(
-      areEqual(nextProps.onViewableItemsChanged, this.props.onViewableItemsChanged),
+      areEqual(
+        nextProps.onViewableItemsChanged, 
+        this.props.onViewableItemsChanged
+      ),
       'Changing onViewableItemsChanged on the fly is not supported',
     );
     invariant(
@@ -427,7 +431,10 @@ class FlatList<ItemT> extends React.PureComponent<Props<ItemT>, void> {
       'Changing viewabilityConfig on the fly is not supported',
     );
     invariant(
-      areEqual(nextProps.viewabilityConfigCallbackPairs, this.props.viewabilityConfigCallbackPairs),
+      areEqual(
+        nextProps.viewabilityConfigCallbackPairs, 
+        this.props.viewabilityConfigCallbackPairs
+      ),
       'Changing viewabilityConfigCallbackPairs on the fly is not supported',
     );
 

--- a/Libraries/Lists/FlatList.js
+++ b/Libraries/Lists/FlatList.js
@@ -421,7 +421,7 @@ class FlatList<ItemT> extends React.PureComponent<Props<ItemT>, void> {
     );
     invariant(
       areEqual(
-        nextProps.onViewableItemsChanged, 
+        nextProps.onViewableItemsChanged,
         this.props.onViewableItemsChanged
       ),
       'Changing onViewableItemsChanged on the fly is not supported',
@@ -432,7 +432,7 @@ class FlatList<ItemT> extends React.PureComponent<Props<ItemT>, void> {
     );
     invariant(
       areEqual(
-        nextProps.viewabilityConfigCallbackPairs, 
+        nextProps.viewabilityConfigCallbackPairs,
         this.props.viewabilityConfigCallbackPairs
       ),
       'Changing viewabilityConfigCallbackPairs on the fly is not supported',

--- a/Libraries/Lists/FlatList.js
+++ b/Libraries/Lists/FlatList.js
@@ -17,7 +17,7 @@ const React = require('React');
 const View = require('View');
 const VirtualizedList = require('VirtualizedList');
 
-const invariant = require('fbjs/lib/invariant');
+const invariant = require('fbjs/lib/invariant'), areEqual = require('fbjs/lib/areEqual');
 
 import type {StyleObj} from 'StyleSheetTypes';
 import type {
@@ -419,16 +419,15 @@ class FlatList<ItemT> extends React.PureComponent<Props<ItemT>, void> {
         'changing the number of columns to force a fresh render of the component.',
     );
     invariant(
-      nextProps.onViewableItemsChanged === this.props.onViewableItemsChanged,
+      areEqual(nextProps.onViewableItemsChanged, this.props.onViewableItemsChanged),
       'Changing onViewableItemsChanged on the fly is not supported',
     );
     invariant(
-      nextProps.viewabilityConfig === this.props.viewabilityConfig,
+      areEqual(nextProps.viewabilityConfig, this.props.viewabilityConfig),
       'Changing viewabilityConfig on the fly is not supported',
     );
     invariant(
-      nextProps.viewabilityConfigCallbackPairs ===
-        this.props.viewabilityConfigCallbackPairs,
+      areEqual(nextProps.viewabilityConfigCallbackPairs, this.props.viewabilityConfigCallbackPairs),
       'Changing viewabilityConfigCallbackPairs on the fly is not supported',
     );
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes. 

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to React Native here: http://facebook.github.io/react-native/docs/contributing.html

Happy contributing!

-->

## Motivation

Fixes invariant errors introduced in https://github.com/facebook/react-native/commit/ad733ad430a4b1d69b89041be8b227e2dfdb5501 triggered when using objects for certain FlatList props, leverages fbjs `areEqual` to test for equality.

**Original Issue**:
https://github.com/facebook/react-native/issues/16710

## Test Plan
Setting a value to `viewAreaCoveragePercentThreshold` key of `viewabilityConfig` prop should no longer trigger invariant error. 

    <FlatList
        ItemSeparatorComponent={() => <separator />}
        ListEmptyComponent={() => <empty />}
        ListFooterComponent={() => <footer />}
        ListHeaderComponent={() => <header />}
        data={new Array(5).fill().map((_, ii) => ({id: String(ii)}))}
        keyExtractor={(item, index) => item.id}
        getItemLayout={({index}) => ({length: 50, offset: index * 50})}
        numColumns={2}
        refreshing={false}
        onRefresh={jest.fn()}
        renderItem={({item}) => <item value={item.id} />}
        viewabilityConfig={{ viewAreaCoveragePercentThreshold: 50 }}
      />,

## Release Notes
<!--
Help reviewers and the release process by writing your own release notes

**INTERNAL and MINOR tagged notes will not be included in the next version's final release notes.**

  CATEGORY
[----------]        TYPE
[ CLI      ]   [-------------]      LOCATION
[ DOCS     ]   [ BREAKING    ]   [-------------]
[ GENERAL  ]   [ BUGFIX      ]   [-{Component}-]
[ INTERNAL ]   [ ENHANCEMENT ]   [ {File}      ]
[ IOS      ]   [ FEATURE     ]   [ {Directory} ]   |-----------|
[ ANDROID  ]   [ MINOR       ]   [ {Framework} ] - | {Message} |
[----------]   [-------------]   [-------------]   |-----------|

[CATEGORY] [TYPE] [LOCATION] - MESSAGE

 EXAMPLES:

 [IOS] [BREAKING] [FlatList] - Change a thing that breaks other things
 [ANDROID] [BUGFIX] [TextInput] - Did a thing to TextInput
 [CLI] [FEATURE] [local-cli/info/info.js] - CLI easier to do things with
 [DOCS] [BUGFIX] [GettingStarted.md] - Accidentally a thing/word
 [GENERAL] [ENHANCEMENT] [Yoga] - Added new yoga thing/position
 [INTERNAL] [FEATURE] [./scripts] - Added thing to script that nobody will see
-->
