### PR TITLE
Increase prepare js timeout

### DIFF
--- a/Libraries/WebSocket/RCTWebSocketExecutor.m
+++ b/Libraries/WebSocket/RCTWebSocketExecutor.m
@@ -117,7 +117,7 @@ RCT_EXPORT_MODULE()
     initError = error;
     dispatch_semaphore_signal(s);
   }];
-  long runtimeIsReady = dispatch_semaphore_wait(s, dispatch_time(DISPATCH_TIME_NOW, NSEC_PER_SEC));
+  long runtimeIsReady = dispatch_semaphore_wait(s, dispatch_time(DISPATCH_TIME_NOW, NSEC_PER_SEC * 5));
   if (initError) {
     RCTLogInfo(@"Websocket runtime setup failed: %@", initError);
   }


### PR DESCRIPTION
## Motivation

We run into this timeout virtually every live-reload now, which I believe is just a function of the size of our React Native code base. Looking at the code, right now the prepare JS call is run and retried 3 times, with a wait/timeout of 1s each. On android, it's done 3 times with a wait/timeout of 5s on each. For consistency, I've updated it to be the same timeout as on android. Trying this with our project, we no longer get red-boxes when we live-reload for the first time.

## Test Plan

I've run this on our project locally, and it fixed the issue. It's a very simple change, so I don't believe any additional testing should be needed.

## Release Notes

[IOS][BUGFIX][RCTWebsocketExecutor] - Increased timeout to prevent false-positive redbox during development of large RN code base