### PR TITLE
Tell template app .flowconfig to look for .native.js files

### DIFF
--- a/local-cli/templates/HelloWorld/_flowconfig
+++ b/local-cli/templates/HelloWorld/_flowconfig
@@ -31,6 +31,11 @@ munge_underscores=true
 
 module.name_mapper='^[./a-zA-Z0-9$_-]+\.\(bmp\|gif\|jpg\|jpeg\|png\|psd\|svg\|webp\|m4v\|mov\|mp4\|mpeg\|mpg\|webm\|aac\|aiff\|caf\|m4a\|mp3\|wav\|html\|pdf\)$' -> 'RelativeImageStub'
 
+module.file_ext=.js
+module.file_ext=.jsx
+module.file_ext=.json
+module.file_ext=.native.js
+
 suppress_type=$FlowIssue
 suppress_type=$FlowFixMe
 suppress_type=$FlowFixMeProps


### PR DESCRIPTION
## Motivation

`metro-bundler` looks for `.native.js` files ([see here](https://github.com/facebook/metro-bundler/blob/master/packages/metro-bundler/src/node-haste/DependencyGraph/ModuleResolution.js#L458)). Packages such as `react-navigation` rely on this functionality ([see here](https://github.com/react-community/react-navigation/blob/master/src/PlatformHelpers.native.js)). This PR makes it so you can `react-native init`, `yarn add react-navigation`, and `flow` successfully!

## Test Plan

1. `react-native init`
2. `yarn add react-navigation`
3. `flow`

## Release Notes

[CLI] [MINOR] [Flow] - Tell template app .flowconfig to look for .native.js files