### PR TITLE
react-native-git-upgrade signal termination

### DIFF
--- a/react-native-git-upgrade/cliEntry.js
+++ b/react-native-git-upgrade/cliEntry.js
@@ -52,12 +52,18 @@ function exec(command, logOutput) {
       process.stderr.write(data);
     });
 
-    child.on('exit', code => {
-      (code === 0)
-        ? resolve(stdout)
-        : reject(new Error(`Command '${command}' exited with code ${code}:
+    child.on('exit', (code, signal) => {
+      if (code === 0) {
+        resolve(stdout);
+      } else if (code) {
+        reject(new Error(`Command '${command}' exited with code ${code}:
 stderr: ${stderr}
 stdout: ${stdout}`));
+      } else {
+        reject(new Error(`Command '${command}' terminated with signal '${signal}':
+stderr: ${stderr}
+stdout: ${stdout}`));
+      }
     });
   });
 }


### PR DESCRIPTION
## Motivation

When performing an upgrade using react-native-git-upgrade git can fail with a signal, however, only exit codes are accounted for.

Related issue: #12336

## Test Plan

In my case, Git fails with a `SIGPIPE` signal - have not figured out why yet, but that's a separate issue. Before, since exit code was not zero, the console would default to the error case, but since no exit code was supplied, the error message was meaningless - `exited with code null`. Now, it errors out with `terminated with signal 'SIGPIPE'`, while still taking account of exit codes. Quoting [nodejs docs](https://nodejs.org/api/child_process.html#child_process_event_exit):

> The 'exit' event is emitted after the child process ends. If the process exited, code is the final exit code of the process, otherwise null. If the process terminated due to receipt of a signal, signal is the string name of the signal, otherwise null. One of the two will always be non-null.

I would be happy to write a test case for this but I haven't seen any react-native-git-upgrade ones?

## Release Notes
[CLI] [ENHANCEMENT] [react-native/react-native-git-upgrade] - Git terminated by signal error message
