### PR TITLE
Remove extraneous check in deploy script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -476,6 +476,7 @@ jobs:
               echo "Skipping code analysis."            
             fi
 
+# Publishes new version to npm. This is "hold" type of job and has to be run manually  
   publish-npm:
     <<: *defaults
     docker:
@@ -486,15 +487,11 @@ jobs:
       - run:
         name: Publish React Native Package
         command: |
-            if [ -z "$CIRCLE_PULL_REQUEST" ]; then
-              echo "//registry.npmjs.org/:_authToken=${CIRCLE_NPM_TOKEN}" > ~/.npmrc
-              git config --global user.email "reactjs-bot@users.noreply.github.com"
-              git config --global user.name "Website Deployment Script"
-              echo "machine github.com login reactjs-bot password $GITHUB_TOKEN" > ~/.netrc
-              node ./scripts/publish-npm.js
-            else
-              echo "Skipping publication."            
-            fi
+          echo "//registry.npmjs.org/:_authToken=${CIRCLE_NPM_TOKEN}" > ~/.npmrc
+          git config --global user.email "reactjs-bot@users.noreply.github.com"
+          git config --global user.name "Website Deployment Script"
+          echo "machine github.com login reactjs-bot password $GITHUB_TOKEN" > ~/.netrc
+          node ./scripts/publish-npm.js
 
 # Workflows enables us to run multiple jobs in parallel
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,6 +99,11 @@ aliases:
         - /.*-stable/
         - master
 
+  - &filter-only-stable
+    branches:
+      only:
+        - /.*-stable/
+
   - &filter-ignore-gh-pages
     branches:
       ignore: gh-pages
@@ -550,4 +555,4 @@ workflows:
       - publish-npm:
           requires: 
             - hold
-          filters: *filter-only-master-stable
+          filters: *filter-only-stable


### PR DESCRIPTION
We don't have to check for pull request number, because we use new `filter` feature of Circle where we specify jobs that makes this run only on stable branches. Also, in its existing form, it doesn't work at all and makes all deploy jobs to be skipped.

CC: @hramos 