### PR TITLE
Disable git hooks for the upgrade process

### DIFF
--- a/react-native-git-upgrade/cliEntry.js
+++ b/react-native-git-upgrade/cliEntry.js
@@ -278,7 +278,7 @@ async function run(requestedVersion, cliArgs) {
     await exec('git add .', verbose);
 
     log.info('Commit current project sources');
-    await exec('git commit -m "Project snapshot"', verbose);
+    await exec('git commit -m "Project snapshot" --no-verify', verbose);
 
     log.info('Create a tag before updating sources');
     await exec('git tag project-snapshot', verbose);
@@ -291,7 +291,7 @@ async function run(requestedVersion, cliArgs) {
     await exec('git add .', verbose);
 
     log.info('Commit old version template');
-    await exec('git commit -m "Old version" --allow-empty', verbose);
+    await exec('git commit -m "Old version" --allow-empty --no-verify', verbose);
 
     log.info('Install the new version');
     let installCommand;
@@ -314,7 +314,7 @@ async function run(requestedVersion, cliArgs) {
     await exec('git add .', verbose);
 
     log.info('Commit new version template');
-    await exec('git commit -m "New version" --allow-empty', verbose);
+    await exec('git commit -m "New version" --allow-empty --no-verify', verbose);
 
     log.info('Generate the patch between the 2 versions');
     const diffOutput = await exec('git diff --binary --no-color HEAD~1 HEAD', verbose);
@@ -345,7 +345,7 @@ async function run(requestedVersion, cliArgs) {
     log.error(err.stack);
     if (projectBackupCreated) {
       log.error('Restore initial sources');
-      await exec('git checkout project-snapshot', true);
+      await exec('git checkout project-snapshot --no-verify', true);
     }
   }
 }


### PR DESCRIPTION
## Motivation

I'm loving `react-native-git-upgrade`, such a life and time saver, but when doing the upgrade, if git hooks are defined globally to be applied, `react-native-git-upgrade` uses these git hooks, although they might not be relevant to the upgrade process (and potentially make it way longer).

Btw, thanks @ncuillery for the great tool 😄 

## Test Plan

To test, I : 
* cloned my project
* upgraded it with the npm published `react-native-git-upgrade` version : Git hooks are running during the upgrade
* cloned the `react-native` repo
* did my modifications on the `react-native-git-upgrade/cliEntry.js` file
* `npm i -g react-native-git-upgrade/` after running `yarn` in that folder
* Re-cloned my project in another folder
* Upgraded it with `react-native-git-upgrade` : The hooks are not running anymore, yay!

## Release Notes

[CLI] [ENHANCEMENT] [react-native/react-native-git-upgrade] - Do not run git hooks in the upgrade process

## Notes

I plan to add an option to the cli so you can pass `--verify` or `--use-git-hooks` if you DO want your git hooks to run, but don't have the time right now and I think the default should be to not run them.