### PR TITLE
[CI] Pin Buck to commit which supports source only abi

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,11 +69,11 @@ aliases:
 
   - &restore-cache-buck
     keys:
-      - v1-buck-{{ arch }}-v2017.09.04.02
+      - v1-buck-{{ arch }}-6043596e11bee8dc5119a78c89a8c744bd9e6868
   - &save-cache-buck
     paths:
       - ~/buck
-    key: v1-buck-{{ arch }}-v2017.09.04.02
+    key: v1-buck-{{ arch }}-6043596e11bee8dc5119a78c89a8c744bd9e6868
 
   - &restore-cache-watchman
     keys:
@@ -334,7 +334,10 @@ jobs:
           name: Install Buck
           command: |
             if [[ ! -e ~/buck ]]; then
-              git clone https://github.com/facebook/buck.git ~/buck --branch v2017.09.04.02 --depth=1
+              curl -o buck.zip https://github.com/facebook/buck/archive/6043596e11bee8dc5119a78c89a8c744bd9e6868.zip
+              unzip -d ~ -o -q buck.zip
+              rm buck.zip
+              mv ~/buck-6043596e11bee8dc5119a78c89a8c744bd9e6868 ~/buck
             fi
             cd ~/buck && ant
             buck --version


### PR DESCRIPTION
Android tests on CI have been failing since late October due to dd016f334cef26f393b1a3c1e052e89a69502a56 which makes use of a new Buck feature, `required_for_source_only_abi`. Circle was using an older September release. In this PR, we pin the Buck version to match the commit where the feature was enabled.

We're not plainly installing from master in order to take advantage of caching.

## Motivation

Green is good. Red is bad.

## Test Plan

Wait for Circle to run.

## Release Notes

[INTERNAL][BUGFIX][./circleci/config.yml] - Update Buck version