### PR TITLE
Minor bug in random generator for `selection` prop

### DIFF
--- a/RNTester/js/TextInputExample.ios.js
+++ b/RNTester/js/TextInputExample.ios.js
@@ -284,7 +284,7 @@ class SelectionExample extends React.Component<$FlowFixMeProps, SelectionExample
   }
 
   selectRandom() {
-    var positions = [this.getRandomPosition(), this.getRandomPosition()].sort();
+    var positions = [this.getRandomPosition(), this.getRandomPosition()].sort((a, b) => a - b);
     this.select(...positions);
   }
 


### PR DESCRIPTION
`.sort()` will sort on the string value by default, so if you generate [18, 8], they will stay in that order. Adding comparer to ensure values are sorted numerically.

## Motivation

Found a bug in RNTester.

## Test Plan

Ran RNTester and confirmed that bug could be reproduced.

## Release Notes

[IOS][BUGFIX][RNTester] - patch test to implement desired behavior.
