### PR TITLE
Mention <ImageBackground> when error is thrown

### DIFF
--- a/Libraries/Image/Image.android.js
+++ b/Libraries/Image/Image.android.js
@@ -274,7 +274,7 @@ var Image = createReactClass({
     }
 
     if (this.props.children) {
-      throw new Error('The <Image> component cannot contain children. If you want to render content on top of the image, consider using absolute positioning.');
+      throw new Error('The <Image> component cannot contain children. If you want to render content on top of the image, consider using the <ImageBackground> component or absolute positioning.');
     }
 
     if (source && (source.uri || Array.isArray(source))) {

--- a/Libraries/Image/Image.ios.js
+++ b/Libraries/Image/Image.ios.js
@@ -374,7 +374,7 @@ const Image = createReactClass({
     }
 
     if (this.props.children) {
-      throw new Error('The <Image> component cannot contain children. If you want to render content on top of the image, consider using absolute positioning.');
+      throw new Error('The <Image> component cannot contain children. If you want to render content on top of the image, consider using the <ImageBackground> component or absolute positioning.');
     }
 
     return (


### PR DESCRIPTION
Improve the error message shown when you try to nest components in an
`<Image>` component by referencing the `<ImageBackground>` component.

## Motivation

It would be helpful if the error message displayed when you try to nest components in an `<Image>` component mentioned the `<ImageBackground>` component. Especially since this component is not yet well documented.

## Release Notes

[IOS][MINOR][Libraries/Image/Image.ios.js] - Surfaced `<ImageBackground>` in error message
[ANDROID][MINOR][Libraries/Image/Image.android.js] - Surfaced `<ImageBackground>` in error message

