### PR TITLE
Allow a trailing slash on template path in 'react-native init'

### DIFF
--- a/local-cli/generator/templates.js
+++ b/local-cli/generator/templates.js
@@ -113,6 +113,10 @@ function createFromRemoteTemplate(template, destPath, newProjectName, yarnVersio
   let templateName;
   if (template.includes('://')) {
      // URL, e.g. git://, file://
+     if (template.lastIndexOf('/')===template.length-1) {
+       // template ends with '/'. Remove it because on might use to tab to complete template path
+       template = template.substr(0, template.length-1)
+     }
      installPackage = template;
      templateName = template.substr(template.lastIndexOf('/') + 1);
   } else {


### PR DESCRIPTION
## Motivation

When using react-native init project --template file://../ I used tab completion on template file path.
But then bash completion add a trailing slash on path name.

When there is a trailing slash on template's pathname, there is this error on react-native init :

> error Not enough arguments, expected at least 1.
> Failed to clean up template temp files in node_modules/. This is not a critical error, you can work on your app.

It's false that it is not critical : the template had not been used and I have in mu resulting prohect all the content of node_module/. What happened is that the template name is empty because the name is the word after the last slash :
`templateName = template.substr(template.lastIndexOf('/') + 1);`
So template path used is node_modules/ and everithing is copied to the root of the generated project.

The other option would have been to raise a clear error if template is empty.
But it might be better to make developpers life easier :)

## Test Plan

Not sure to see too much tests to adapt.
It seems there are no tests on templates in the original commit 
https://github.com/facebook/react-native/commit/a54d449e947afc609a404a699494902823fbbf5e


