### PR TITLE
Geolocation: add authorizationStatusChange event

### DIFF
--- a/Libraries/Geolocation/Geolocation.js
+++ b/Libraries/Geolocation/Geolocation.js
@@ -92,7 +92,28 @@ type LocationEventName = $Enum<{
  */
 var Geolocation = {
 
-  /*
+  STATUSES: {
+    // User has not yet made a choice with regards to this application
+    NOT_DETERMINED: 'not_determined',
+    // This application is not authorized to use location services.  Due
+    // to active restrictions on location services, the user cannot change
+    // this status, and may not have personally denied authorization
+    RESTRICTED: 'restricted',
+    // User has explicitly denied authorization for this application, or
+    // location services are disabled in Settings.
+    DENIED: 'denied',
+    // User has granted authorization to use their location at any time,
+    // including monitoring for regions, visits, or significant location
+    // changes.
+    AUTHORIZED_ALWAYS: 'authorized_always',
+    // User has granted authorization to use their location only when your app
+    // is visible to them (it will be made visible to them if you continue to
+    // receive location updates while in the background).  Authorization to use
+    // launch APIs has not been granted.
+    AUTHORIZED_WHEN_IN_USE: 'authorized_when_in_use',
+  },
+
+   /*
     * Sets configuration options that will be used in all location requests.
     *
     * ### Options

--- a/Libraries/Geolocation/Geolocation.js
+++ b/Libraries/Geolocation/Geolocation.js
@@ -41,6 +41,10 @@ type GeoOptions = {
   useSignificantChanges?: bool,
 }
 
+type LocationEventName = $Enum<{
+  authorizationStatusChange: string,
+}>;
+
 /**
  * The Geolocation API extends the web spec:
  * https://developer.mozilla.org/en-US/docs/Web/API/Geolocation
@@ -215,6 +219,28 @@ var Geolocation = {
         }
       }
       subscriptions = [];
+    }
+  },
+
+  addEventListener: function(eventName: LocationEventName, callback: Function) {
+    if (eventName === 'authorizationStatusChange') {
+      return LocationEventEmitter.addListener(
+        'locationAuthorizationStatusDidChange',
+        callback
+      );
+    } else {
+      warning(false, 'Trying to subscribe to unknown event: ' + eventName);
+    }
+  },
+
+  removeEventListener: function(eventName: LocationEventName, callback?: Function) {
+    if (eventName === 'authorizationStatusChange') {
+      return LocationEventEmitter.removeListener(
+        'locationAuthorizationStatusDidChange',
+        callback
+      );
+    } else {
+      warning(false, 'Trying to unsubscribe from unknown event: ' + eventName);
     }
   }
 };

--- a/Libraries/Geolocation/Geolocation.js
+++ b/Libraries/Geolocation/Geolocation.js
@@ -122,6 +122,17 @@ var Geolocation = {
   },
 
   /*
+   * Invokes the callback once with the current authorization status.
+   */
+  getAuthorizationStatus: function(callback: Function) {
+    invariant(
+      typeof callback === 'function',
+      'Must provide a valid callback.'
+    );
+    RCTLocationObserver.getAuthorizationStatus(callback);
+  },
+
+  /*
    * Invokes the success callback once with the latest location info.  Supported
    * options: timeout (ms), maximumAge (ms), enableHighAccuracy (bool)
    * On Android, if the location is cached this can return almost immediately,

--- a/Libraries/Geolocation/RCTLocationObserver.m
+++ b/Libraries/Geolocation/RCTLocationObserver.m
@@ -82,7 +82,7 @@ static NSString *RCTAuthorizationStatus(CLAuthorizationStatus status)
     };
   });
 
-  return statuses[status] ?: @"not_determined";
+  return statuses[@(status)] ?: @"not_determined";
 }
 
 static NSDictionary<NSString *, id> *RCTPositionError(RCTPositionErrorCode code, NSString *msg /* nil for default */)

--- a/Libraries/Geolocation/RCTLocationObserver.m
+++ b/Libraries/Geolocation/RCTLocationObserver.m
@@ -349,6 +349,11 @@ RCT_EXPORT_METHOD(getCurrentPosition:(RCTLocationOptions)options
                           useSignificantChanges:options.useSignificantChanges];
 }
 
+RCT_EXPORT_METHOD(getAuthorizationStatus:(RCTResponseSenderBlock)callback)
+{
+  callback(@[@([CLLocationManager authorizationStatus])]);
+}
+
 #pragma mark - CLLocationManagerDelegate
 
 - (void)locationManager:(CLLocationManager *)manager


### PR DESCRIPTION
## Motivation

To be able to listen for authorization changes. For example when a user previously denied authorization to their location, you can direct them to the system settings, and by using this event you can reflect the updated setting in the application.

Mostly putting this out here to see if there's any desire by others too for this functionality.

## Test Plan

Currently not sure, but if someone has an idea on how this should be tested I'm happy to hear.

## Release Notes

[IOS] [FEATURE] [Geolocation] - add `authorizationStatusChange` event

<!--
Help reviewers and the release process by writing your own release notes

**INTERNAL and MINOR tagged notes will not be included in the next version's final release notes.**

  CATEGORY
[----------]        TYPE
[ CLI      ]   [-------------]      LOCATION
[ DOCS     ]   [ BREAKING    ]   [-------------]
[ GENERAL  ]   [ BUGFIX      ]   [-{Component}-]
[ INTERNAL ]   [ ENHANCEMENT ]   [ {File}      ]
[ IOS      ]   [ FEATURE     ]   [ {Directory} ]   |-----------|
[ ANDROID  ]   [ MINOR       ]   [ {Framework} ] - | {Message} |
[----------]   [-------------]   [-------------]   |-----------|

[CATEGORY] [TYPE] [LOCATION] - MESSAGE

 EXAMPLES:

 [IOS] [BREAKING] [FlatList] - Change a thing that breaks other things
 [ANDROID] [BUGFIX] [TextInput] - Did a thing to TextInput
 [CLI] [FEATURE] [local-cli/info/info.js] - CLI easier to do things with
 [DOCS] [BUGFIX] [GettingStarted.md] - Accidentally a thing/word
 [GENERAL] [ENHANCEMENT] [Yoga] - Added new yoga thing/position
 [INTERNAL] [FEATURE] [./scripts] - Added thing to script that nobody will see
-->
