### PR TITLE
Implement requiresMainQueueSetup in RCTTVNavigationEventEmitter

### DIFF
--- a/React/Modules/RCTTVNavigationEventEmitter.m
+++ b/React/Modules/RCTTVNavigationEventEmitter.m
@@ -17,6 +17,11 @@ static NSString *const TVNavigationEventName = @"onTVNavEvent";
 
 RCT_EXPORT_MODULE()
 
++ (BOOL)requiresMainQueueSetup
+{
+  return NO;
+}
+
 - (instancetype)init
 {
   if (self = [super init]) {


### PR DESCRIPTION
## Motivation

Fix the following warning:

> Module RCTTVNavigationEventEmitter requires main queue setup since it overrides `init` but doesn't implement `requiresMainQueueSetup`. In a future release React Native will default to initializing all native modules on a background thread unless explicitly opted-out of.

## Test Plan

Trivial change.

## Release Notes

[IOS] [MINOR] [RCTTVNavigationEventEmitter] - Implement `requiresMainQueueSetup` in `RCTTVNavigationEventEmitter`