### PR TITLE
Fix markdown in requiresMainQueueSetup warning

### DIFF
--- a/React/Base/RCTModuleData.mm
+++ b/React/Base/RCTModuleData.mm
@@ -65,7 +65,7 @@
         methodName = "init";
       }
       RCTLogWarn(@"Module %@ requires main queue setup since it overrides `%s` but doesn't implement "
-        "`requiresMainQueueSetup. In a future release React Native will default to initializing all native modules "
+        "`requiresMainQueueSetup`. In a future release React Native will default to initializing all native modules "
         "on a background thread unless explicitly opted-out of.", _moduleClass, methodName);
     }
   }


### PR DESCRIPTION
## Motivation

nit-picking

## Release Notes

[IOS] [MINOR] [React/Base/RCTModuleData.mm] - Fix markdown in `requiresMainQueueSetup` warning