### PR TITLE
[iOS] Add extensibility point on react-native-xcode.sh script

### DIFF
--- a/scripts/react-native-xcode.sh
+++ b/scripts/react-native-xcode.sh
@@ -120,7 +120,8 @@ $NODE_BINARY $CLI_PATH $BUNDLE_COMMAND \
   --dev $DEV \
   --reset-cache \
   --bundle-output "$BUNDLE_FILE" \
-  --assets-dest "$DEST"
+  --assets-dest "$DEST" \
+  $EXTRA_PACKAGER_ARGS
 
 if [[ $DEV != true && ! -f "$BUNDLE_FILE" ]]; then
   echo "error: File $BUNDLE_FILE does not exist. This must be a bug with" >&2


### PR DESCRIPTION
Original pull request: #12863

## Motivation

Useful for generating source maps, for example.

Feature parity with Android, that already have this extensibility point on `build.gradle`:
```
project.ext.react = [
    extraPackagerArgs: [...]
]
```

## Test Plan

Xcode > Build Phases > Bundle React Native code and Images
```
export NODE_BINARY=node
export EXTRA_PACKAGER_ARGS="--sourcemap-output ${SRCROOT}/build/main.jsbundle.map"
../node_modules/react-native/scripts/react-native-xcode.sh
```

## Release Notes

[IOS] [FEATURE] [./react-native-xcode.sh] - Added $EXTRA_PACKAGER_ARGS extensibility point