### PR TITLE
Better support for custom file extensions (and build flavours)

### DIFF
--- a/local-cli/bundle/buildBundle.js
+++ b/local-cli/bundle/buildBundle.js
@@ -117,7 +117,7 @@ async function buildBundle(
       providesModuleNodeModules: providesModuleNodeModules,
       resetCache: args.resetCache,
       reporter: new TerminalReporter(terminal),
-      sourceExts: defaultSourceExts.concat(sourceExts),
+      sourceExts: sourceExts.concat(defaultSourceExts),
       transformCache: TransformCaching.useTempDir(),
       transformModulePath: transformModulePath,
       watch: false,

--- a/local-cli/server/runServer.js
+++ b/local-cli/server/runServer.js
@@ -200,7 +200,7 @@ function getPackagerServer(args, config, reporter) {
     providesModuleNodeModules: providesModuleNodeModules,
     reporter,
     resetCache: args.resetCache,
-    sourceExts: [...args.sourceExts, ...defaultSourceExts],
+    sourceExts: args.sourceExts.concat(defaultSourceExts),
     transformModulePath: transformModulePath,
     transformCache: TransformCaching.useTempDir(),
     verbose: args.verbose,

--- a/local-cli/server/runServer.js
+++ b/local-cli/server/runServer.js
@@ -200,7 +200,7 @@ function getPackagerServer(args, config, reporter) {
     providesModuleNodeModules: providesModuleNodeModules,
     reporter,
     resetCache: args.resetCache,
-    sourceExts: defaultSourceExts.concat(args.sourceExts),
+    sourceExts: [...args.sourceExts, ...defaultSourceExts],
     transformModulePath: transformModulePath,
     transformCache: TransformCaching.useTempDir(),
     verbose: args.verbose,


### PR DESCRIPTION
## Motivation

This PR solves the following issue in the metro-bundler:
https://github.com/facebook/metro-bundler/issues/17

This PR was created to enhance support for custom file extensions - mainly, enabling it to be used for build flavouring.

In the current configuration, custom file extensions are **concatenated** to the existing ones.
This causes files which match `*.js` to always override files with custom file extensions such as `*.e2e.js`. 
This behaviour contradicts the specification of a custom file extension, which expresses a desire to use the file with the custom extension instead of the regular `.js`, when possible.

This is useful for several use cases, such as defining specialised files to be loaded in End-To-End testing or bundling different build flavours of your app (such as "Free" or "Premium" flavours).

Note:
This change is **not** a breaking change, since it alters behaviour for files matching`*.ext.js` while specifying a custom source extension `ext.js`. This is currently not supported in any way (the `*.js` will override the custom ones) , so nothing will break.

This change does not break specifying different files for different platform, because files are searched for using `${fileNamePrefix}.${platform}.${ext}`. Specifying a custom extension `e2e.js` will load `index.ios.e2e.js` and `index.android.e2e.js` for iOS and Android respectively, while `index.ios.js` and `index.android.js`, `index.native.js` (if specified), and `index.js` while be used as fallbacks as usual.

## Test Plan

At the moment, this file has no test plan, and there's no way of testing the altered logic without running an End-To-End test for the server. This will alter the test behaviour in a significant way, so was not implemented without further planning.  

## Release Notes

[CLI] [ENHANCEMENT] [local-cli/server] - Support build flavouring (Place custom source extensions in front of default ones).
