### PR TITLE
get the baseURL from the bundles resource directory

### DIFF
--- a/React/Views/RCTWebView.m
+++ b/React/Views/RCTWebView.m
@@ -115,7 +115,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
     // Check for a static html source first
     NSString *html = [RCTConvert NSString:source[@"html"]];
     if (html) {
-      NSURL *baseURL = [RCTConvert NSURL:source[@"baseUrl"]];
+      NSURL *baseURL = [NSURL fileURLWithPath: [[NSBundle mainBundle] resourcePath] isDirectory: YES];
       if (!baseURL) {
         baseURL = [NSURL URLWithString:@"about:blank"];
       }


### PR DESCRIPTION

## Motivation

If I load html file which wrapped and export  in *.js, I add the js file in bundles resource, but it not works in release mode. Just change the baseURL that get from  bundles resource directory, it works well now.

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Release Notes
