### PR TITLE
Remove replaceOkHttpClient method

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/modules/network/OkHttpClientProvider.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/network/OkHttpClientProvider.java
@@ -46,12 +46,6 @@ public class OkHttpClientProvider {
     }
     return sClient;
   }
-  
-  // okhttp3 OkHttpClient is immutable
-  // This allows app to init an OkHttpClient with custom settings.
-  public static void replaceOkHttpClient(OkHttpClient client) {
-    sClient = client;
-  }
 
   public static OkHttpClient createClient() {
     if (sFactory != null) {


### PR DESCRIPTION
## Motivation

This method was originally intended to replace the OkHttp client used by React Native's networking library. However it has effectively been a noop since https://github.com/facebook/react-native/commit/0a71f48b1349ed09bcb6e76ba9ff8eb388518b15#diff-177100ae5a977e4060b54cc2b34c79a7, when the Networking library was modified to create a new client rather than use the reference provided by OkHttpClientProvider.

Leaving this code in place is dangerous. There is no indication to users upgrading React Native that the method is no longer replacing the OkHttpClient used by the Networking library. Any functionality reliant on overriding the client will silently break. This caused us some problems internally.

## Related PRs

There's been a PR out for some time that seeks to reintroduce this functionality: https://github.com/facebook/react-native/pull/14068

I've also put up a new PR that adds an interface for replacing the client without introducing breaking changes: https://github.com/facebook/react-native/pull/17237

## Test Plan

Do our unit tests continue to pass? Should be safe as this method is not used anywhere inside React Native.

## Release Notes

[ANDROID] [BREAKING] [Networking] - removed replaceOkHttpClient method in OkHttpClientProvider.
