### PR TITLE
debugger-ui js does not support object spread operator  fixes #16977

### DIFF
--- a/local-cli/server/util/debugger-ui/index.html
+++ b/local-cli/server/util/debugger-ui/index.html
@@ -179,10 +179,11 @@
         shutdownJSRuntime();
         Page.setState({status: {type: 'disconnected'}});
       } else if (object.method === 'executeApplicationScript') {
-        worker.postMessage({
-          ...object,
-          url: await getBlobUrl(object.url),
-        });
+        worker.postMessage(
+          Object.assign({}, object, {
+              url: await getBlobUrl(object.url),
+            }
+        ));
       } else {
         // Otherwise, pass through to the worker.
         worker.postMessage(object);


### PR DESCRIPTION
## Motivation

debugger-ui was broken on v0.50 + 

## Test Plan

JS does not support object spread operator natively, So I simply rewrote 1 block of code to use Object.assign instead of Object spread. 

## Release Notes

[CLI][BUGFIX][local-cli/server/util/debugger-ui/index.html] - changed from object spread to Object.assign line 182

It looks like the cause of the issue stems */debugger-ui/index.html using Object Spread features

Ideally, async/await should be removed from debugger-ui as well to support further backwards compatibility.

My fix should be backwards compatible as far back as google chrome v55 and Firefox 57

The debugger should not need to rely on the newest browser versions to work properly.

