### PR TITLE
Add support for scoped npm package linking in local-cli

### DIFF
--- a/local-cli/link/__tests__/link.spec.js
+++ b/local-cli/link/__tests__/link.spec.js
@@ -205,4 +205,42 @@ describe('link', () => {
       done();
     });
   });
+
+  it('should replace forward slashes in scoped package names for android', () => {
+    const isInstalledAndroid = jest.fn(() => false);
+    const registerNativeModule = sinon.stub();
+    const registerDependencyAndroid = jest.fn();
+    const config = {
+      getProjectConfig: () => ({ ios: {}, android: {}, assets: [] }),
+      getDependencyConfig: sinon.stub(),
+    };
+
+    const  mockDependencyConfig = [{
+      config: { ios: {}, android: {}, windows: null, assets: [], commands: {}, params: [], },
+      name: '@scope/react-native-package',
+    }];
+
+    jest.setMock('../ios/isInstalled.js', sinon.stub().returns(true));
+
+    jest.mock('../getDependencyConfig.js', () => () => mockDependencyConfig);
+
+    jest.mock(
+      '../android/isInstalled.js',
+      () => isInstalledAndroid,
+    );
+
+    jest.setMock(
+      '../ios/registerNativeModule.js',
+      registerNativeModule,
+    );
+
+    jest.mock('../android/registerNativeModule.js', () => registerDependencyAndroid);
+
+    const link = require('../link').func;
+
+    return link(['react-native-test'], config).then(() => {
+      expect(isInstalledAndroid).toHaveBeenCalledWith({}, '@scope_react-native-package');
+      expect(registerDependencyAndroid).toHaveBeenCalledWith('@scope_react-native-package', {}, {}, {});
+    });
+  });
 });

--- a/local-cli/link/link.js
+++ b/local-cli/link/link.js
@@ -51,6 +51,8 @@ const dedupeAssets = (assets) => uniqBy(assets, asset => path.basename(asset));
 
 
 const linkDependencyAndroid = (androidProject, dependency) => {
+  dependency.name = dependency.name.replace(/\//g, '_');
+
   if (!androidProject || !dependency.config.android) {
     return null;
   }


### PR DESCRIPTION
## Motivation

Linking scoped npm packages breaks the android build using the local cli.

I found no documentation for this, but Android Studio correctly replaces the `/` in the npm package name with `_` in the gradle include statement.

## Test Plan

The test included with this PR verifies, that scoped dependencies, are linked with this replacement.
 
## Release Notes
 [CLI] [BUGFIX] [local-cli/link/link.js] - Change link function for scoped npm packages to link as expected on Android
