### PR TITLE
Docs: Add example to Modal documentation

### DIFF
--- a/docs/modal.md
+++ b/docs/modal.md
@@ -7,6 +7,70 @@ permalink: docs/modal.html
 next: navigatorios
 previous: maskedviewios
 ---
+
+Minimal modal example:
+
+```
+import React, { Component } from 'react';
+import { Text, View, Button, Modal, StyleSheet } from 'react-native';
+
+export default class MyComponent extends Component {
+  state = {
+    modalVisible: false,
+  };
+
+  openModal() {
+    this.setState({modalVisible:true});
+  }
+
+  closeModal() {
+    this.setState({modalVisible:false});
+  }
+
+  render() {
+    return (
+        <View style={styles.container}>
+          <Modal
+              visible={this.state.modalVisible}
+              animationType={'slide'}
+              onRequestClose={() => this.closeModal()}
+          >
+            <View style={styles.modalContainer}>
+              <View style={styles.innerContainer}>
+                <Text>This is content inside of modal component</Text>
+                <Button
+                    onPress={() => this.closeModal()}
+                    title="Close modal"
+                >
+                </Button>
+              </View>
+            </View>
+          </Modal>
+          <Button
+              onPress={() => this.openModal()}
+              title="Open modal"
+          />
+        </View>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+  },
+  modalContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    backgroundColor: 'grey',
+  },
+  innerContainer: {
+    alignItems: 'center',
+  },
+});
+```
+
 ### Props
 
 - [`visible`](docs/modal.html#visible)


### PR DESCRIPTION
## Motivation

I find it easier to understand the behavior of a component when there is a simple example showing its usage. I recently used the Modal component and noticed that it doesn't have a code example. This PR adds an example to the Modal documentation.

## Test Plan

N/A

## Release Notes
[DOCS][ENHANCEMENT][Modal] - Added example to documentation

