### PR TITLE
Eliminate openURL deprecated error if deployment target is 10.0 or above

### DIFF
--- a/Libraries/LinkingIOS/RCTLinkingManager.m
+++ b/Libraries/LinkingIOS/RCTLinkingManager.m
@@ -89,12 +89,13 @@ RCT_EXPORT_METHOD(openURL:(NSURL *)URL
                   resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
 {
-  BOOL opened = [RCTSharedApplication() openURL:URL];
-  if (opened) {
-    resolve(nil);
-  } else {
-    reject(RCTErrorUnspecified, [NSString stringWithFormat:@"Unable to open URL: %@", URL], nil);
-  }
+  [RCTSharedApplication() openURL:URL options:@{} completionHandler:^(BOOL success) {
+    if (success) {
+      resolve(nil);
+    } else {
+      reject(RCTErrorUnspecified, [NSString stringWithFormat:@"Unable to open URL: %@", URL], nil);
+    }
+  }];
 }
 
 RCT_EXPORT_METHOD(canOpenURL:(NSURL *)URL


### PR DESCRIPTION
## Motivation

openURL deprecated is marked as error since iOS 10.0

<img width="1055" alt="openurl" src="https://user-images.githubusercontent.com/13135825/33355339-123c3bb0-d485-11e7-9897-e1d6a7954604.png">

## Test Plan

1. Compiling RCTLinking should be no error if iOS deployment target is iOS 10.0 or above.
2. Opening web URL in iOS, its behavior should be same as previous by invoking Linking.openURL().

## Release Notes
 [IOS] [ENHANCEMENT] [Linking] - Eliminate openURL deprecated error if deployment target is 10.0 or above