### PR TITLE
Fix Jest mocks for Dimensions module

### DIFF
--- a/jest/setup.js
+++ b/jest/setup.js
@@ -142,6 +142,12 @@ const mockNativeModules = {
         scale: 2,
         width: 750,
       },
+      screen: {
+        fontScale: 2,
+        height: 1334,
+        scale: 2,
+        width: 750,
+      },
     },
   },
   FacebookSDK: {


### PR DESCRIPTION

## Motivation

Jest mock for Dimensions.get("screen") is missing. Tests fail with error message:

    Invariant Violation: No dimension set for key screen

## Test Plan

Run test with usage of Dimensions.get("screen")

## Release Notes

[GENERAL] [BUGFIX] [jest/setup.js] - Fix Jest mocks for Dimensions module
