### PR TITLE
Add focus() and blur() to TextInput documentation

### DIFF
--- a/docs/textinput.md
+++ b/docs/textinput.md
@@ -174,7 +174,8 @@ or control this param programmatically with native code.
 
 - [`isFocused`](docs/textinput.html#isfocused)
 - [`clear`](docs/textinput.html#clear)
-
+- [`focus`](docs/textinput.html#focus)
+- [`blur`](docus/textinput.html#blur)
 
 
 
@@ -981,6 +982,31 @@ clear()
 ```
 
 Removes all text from the `TextInput`.
+
+
+
+---
+
+### `focus()`
+
+```javascript
+focus()
+```
+
+Focuses the `TextInput`.
+
+
+
+---
+
+### `blur()`
+
+```javascript
+blur()
+```
+
+Removes focus from the `TextInput`.
+
 
 
 


### PR DESCRIPTION
I needed the focus function to handle a submit on a previous TextInput in a form and realized that even though it and blur() exist on TextInputs they are not documented.
