### PR TITLE
Improve accessibilityLabel performance

### DIFF
--- a/React/Views/RCTView.m
+++ b/React/Views/RCTView.m
@@ -149,8 +149,9 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:unused)
 
 - (NSString *)accessibilityLabel
 {
-  if (super.accessibilityLabel) {
-    return super.accessibilityLabel;
+  NSString *label = super.accessibilityLabel;
+  if (label) {
+    return label;
   }
   return RCTRecursiveAccessibilityLabel(self);
 }


### PR DESCRIPTION
## Motivation

Integration testing with Appium on iOS is slow. Profiling with Instruments.app points to `RCTView`'s `accessibilityLabel` method being a hot point in React Native, due to the `RCTRecursiveAccessibilityLabel` function.

## Test Plan

I did a baseline benchmark by using Appium's `find_element(accessibility_id: <label>)` call on our application 10 times and got a baseline result of 0.6s for one of our primary screens.

After implementing the change and performing the same call 10 times, I got 0.48s for the same call, for a 20% performance increase in `find_element`.

## Release Notes

[iOS] [View] - Improve performance of `RCTView` `accessibilityLabel`

<!--
Help reviewers and the release process by writing your own release notes

**INTERNAL and MINOR tagged notes will not be included in the next version's final release notes.**

  CATEGORY
[----------]        TYPE
[ CLI      ]   [-------------]      LOCATION
[ DOCS     ]   [ BREAKING    ]   [-------------]
[ GENERAL  ]   [ BUGFIX      ]   [-{Component}-]
[ INTERNAL ]   [ ENHANCEMENT ]   [ {File}      ]
[ IOS      ]   [ FEATURE     ]   [ {Directory} ]   |-----------|
[ ANDROID  ]   [ MINOR       ]   [ {Framework} ] - | {Message} |
[----------]   [-------------]   [-------------]   |-----------|

[CATEGORY] [TYPE] [LOCATION] - MESSAGE

 EXAMPLES:

 [IOS] [BREAKING] [FlatList] - Change a thing that breaks other things
 [ANDROID] [BUGFIX] [TextInput] - Did a thing to TextInput
 [CLI] [FEATURE] [local-cli/info/info.js] - CLI easier to do things with
 [DOCS] [BUGFIX] [GettingStarted.md] - Accidentally a thing/word
 [GENERAL] [ENHANCEMENT] [Yoga] - Added new yoga thing/position
 [INTERNAL] [FEATURE] [./scripts] - Added thing to script that nobody will see
-->