### PR TITLE
Fix local-cli's installedGlobally check to work on Windows platforms

### DIFF
--- a/local-cli/wrong-react-native.js
+++ b/local-cli/wrong-react-native.js
@@ -16,8 +16,10 @@ const isWindows = process.platform === 'win32';
 
 var installedGlobally;
 if (isWindows) {
+  // On Windows, assume we are installed globally if we can't find a package.json above node_modules.
   installedGlobally = !(fs.existsSync(path.join(__dirname, '../../../package.json')));
 } else {
+  // On non-windows, assume we are installed globally if we are called from outside of the node_mobules/.bin/react-native executable.
   var script = process.argv[1];
   installedGlobally = script.indexOf('node_modules/.bin/react-native') === -1;
 }

--- a/local-cli/wrong-react-native.js
+++ b/local-cli/wrong-react-native.js
@@ -9,13 +9,12 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-const fs = require('fs');
-const path = require('path');
-
 const isWindows = process.platform === 'win32';
 
 var installedGlobally;
 if (isWindows) {
+  const fs = require('fs');
+  const path = require('path');
   // On Windows, assume we are installed globally if we can't find a package.json above node_modules.
   installedGlobally = !(fs.existsSync(path.join(__dirname, '../../../package.json')));
 } else {

--- a/local-cli/wrong-react-native.js
+++ b/local-cli/wrong-react-native.js
@@ -9,8 +9,19 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-var script = process.argv[1];
-var installedGlobally = script.indexOf('node_modules/.bin/react-native') === -1;
+const fs = require('fs');
+const path = require('path');
+
+const isWindows = process.platform === 'win32';
+
+var installedGlobally;
+if (isWindows) {
+  installedGlobally = !(fs.existsSync(path.join(__dirname, '../../../package.json')));
+} else {
+  var script = process.argv[1];
+  installedGlobally = script.indexOf('node_modules/.bin/react-native') === -1;
+}
+
 
 if (installedGlobally) {
   const chalk = require('chalk');


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes. 

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to React Native here: http://facebook.github.io/react-native/docs/contributing.html

Happy contributing!

-->

## Motivation

The react-native local-cli does a check to see if it is being run from a global install or not. If running from a global install, an error is printed and the CLI exits.

This check for a global install does not work on Windows. The check of `process.argv` does not contain the expected `node_modules/.bin/react-native`. It instead contains a direct path to the `wrong-react-native.js` file, as determined by the `node_modules/.bin/react-native.cmd` entry point.

This update will, on Windows platforms, do a global check by instead looking for the existence of a package.json above the node_modules. If not found, we assume a global install and print the error.

## Test Plan

In a react-native project, I originally tried running the local react-native cli:

```
> yarn react-native --version
yarn run v1.3.2
$ E:\myproject\node_modules\.bin\react-native --version
Looks like you installed react-native globally, maybe you meant react-native-cli?
To fix the issue, run:
npm uninstall -g react-native
npm install -g react-native-cli
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

I replaced the `wrong-react-native.js` with the modified version and reran the command:

```
> yarn react-native --version
yarn run v1.3.2
$ E:\myproject\node_modules\.bin\react-native --version
Scanning folders for symlinks in E:\myproject\node_modules (93ms)
0.50.3
Done in 1.86s.
```

## Release Notes
<!--
Help reviewers and the release process by writing your own release notes

**INTERNAL and MINOR tagged notes will not be included in the next version's final release notes.**

  CATEGORY
[----------]        TYPE
[ CLI      ]   [-------------]      LOCATION
[ DOCS     ]   [ BREAKING    ]   [-------------]
[ GENERAL  ]   [ BUGFIX      ]   [-{Component}-]
[ INTERNAL ]   [ ENHANCEMENT ]   [ {File}      ]
[ IOS      ]   [ FEATURE     ]   [ {Directory} ]   |-----------|
[ ANDROID  ]   [ MINOR       ]   [ {Framework} ] - | {Message} |
[----------]   [-------------]   [-------------]   |-----------|

[CATEGORY] [TYPE] [LOCATION] - MESSAGE

 EXAMPLES:

 [IOS] [BREAKING] [FlatList] - Change a thing that breaks other things
 [ANDROID] [BUGFIX] [TextInput] - Did a thing to TextInput
 [CLI] [FEATURE] [local-cli/info/info.js] - CLI easier to do things with
 [DOCS] [BUGFIX] [GettingStarted.md] - Accidentally a thing/word
 [GENERAL] [ENHANCEMENT] [Yoga] - Added new yoga thing/position
 [INTERNAL] [FEATURE] [./scripts] - Added thing to script that nobody will see
-->

[CLI] [BUGFIX] [local-cli/wrong-react-native.js] - Updated local-cli on Windows to check for the absence of a package.json file to determine if being run from a global installation or not.
