### PR TITLE
Fix Android comment and docblock typos

### DIFF
--- a/ReactAndroid/src/androidTest/java/com/facebook/react/testing/network/NetworkRecordingModuleMock.java
+++ b/ReactAndroid/src/androidTest/java/com/facebook/react/testing/network/NetworkRecordingModuleMock.java
@@ -24,7 +24,7 @@ import com.facebook.react.modules.core.DeviceEventManagerModule;
 
 /**
  * Mock Networking module that records last request received by {@link #sendRequest} method and
- * returns reponse code and body that should be set with {@link #setResponse}
+ * returns response code and body that should be set with {@link #setResponse}
  */
 @ReactModule(name = "Networking", canOverrideExistingModule = true)
 public class NetworkRecordingModuleMock extends ReactContextBaseJavaModule {

--- a/ReactAndroid/src/androidTest/java/com/facebook/react/tests/CatalystMultitouchHandlingTestCase.java
+++ b/ReactAndroid/src/androidTest/java/com/facebook/react/tests/CatalystMultitouchHandlingTestCase.java
@@ -68,7 +68,7 @@ public class CatalystMultitouchHandlingTestCase extends ReactAppInstrumentationT
         assertEquals(-1, endEventIndex);
         endEventIndex = i;
       } else if (call.equals("move;2")) {
-        // this will happen more than once, let's just capture the last occurence
+        // this will happen more than once, let's just capture the last occurrence
         moveWithBothPointersEventIndex = i;
       }
     }

--- a/ReactAndroid/src/androidTest/java/com/facebook/react/tests/CatalystNativeJSToJavaParametersTestCase.java
+++ b/ReactAndroid/src/androidTest/java/com/facebook/react/tests/CatalystNativeJSToJavaParametersTestCase.java
@@ -45,7 +45,7 @@ import org.junit.Ignore;
  * Integration test to verify passing various types of parameters from JS to Java works
  *
  * TODO: we should run these tests with isBlockingSynchronousMethod = true as well,
- * since they currrently use a completely different codepath
+ * since they currently use a completely different codepath
  */
 @Ignore("Fix prop types and view managers.")
 public class CatalystNativeJSToJavaParametersTestCase extends ReactIntegrationTestCase {

--- a/ReactAndroid/src/androidTest/java/com/facebook/react/tests/CatalystTouchBubblingTestCase.java
+++ b/ReactAndroid/src/androidTest/java/com/facebook/react/tests/CatalystTouchBubblingTestCase.java
@@ -44,7 +44,7 @@ import com.facebook.react.testing.StringRecordingModule;
  * | +----------------------------------------------------------------------------------+  |
  * +---------------------------------------------------------------------------------------+
  *
- * Then in each test case we eiter tap the center of a particular view (from A to E) or we start
+ * Then in each test case we either tap the center of a particular view (from A to E) or we start
  * a gesture in one view and end it with another.
  * View with names in brackets (e.g. {D}) have touch handlers set whereas all other views are not
  * declared to handler touch events.

--- a/ReactAndroid/src/androidTest/java/com/facebook/react/tests/JSResponderTestCase.java
+++ b/ReactAndroid/src/androidTest/java/com/facebook/react/tests/JSResponderTestCase.java
@@ -18,7 +18,7 @@ import com.facebook.react.testing.SingleTouchGestureGenerator;
  * Test case to verify that JSResponder flow work correctly.
  *
  * In a single test case scenario we have a view with pan gesture recognizer containing a scrollview
- * We werify that by vertical drags affects a scrollview while horizontal drags are suppose to
+ * We verify that by vertical drags affects a scrollview while horizontal drags are suppose to
  * be recognized by pan responder and setJSResponder should be triggered resulting in scrollview
  * events being intercepted.
  */

--- a/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManagerBuilder.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManagerBuilder.java
@@ -97,7 +97,7 @@ public class ReactInstanceManagerBuilder {
 
   /**
    * Bundle loader to use when setting up JS environment. This supersedes
-   * prior invcations of {@link setJSBundleFile} and {@link setBundleAssetName}.
+   * prior invocations of {@link setJSBundleFile} and {@link setBundleAssetName}.
    *
    * Example: {@code JSBundleLoader.createFileLoader(application, bundleFile)}
    */

--- a/ReactAndroid/src/main/java/com/facebook/react/animated/NativeAnimatedModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/animated/NativeAnimatedModule.java
@@ -69,7 +69,7 @@ import com.facebook.react.uimanager.UIManagerModuleListener;
  * that coordinates all the action: {@link NativeAnimatedNodesManager}. Since all the methods from
  * {@link NativeAnimatedNodesManager} need to be called from the UI thread, we we create a queue of
  * animated graph operations that is then enqueued to be executed in the UI Thread at the end of the
- * batch of JS->native calls (similarily to how it's handled in {@link UIManagerModule}). This
+ * batch of JS->native calls (similarly to how it's handled in {@link UIManagerModule}). This
  * isolates us from the problems that may be caused by concurrent updates of animated graph while UI
  * thread is "executing" the animation loop.
  */

--- a/ReactAndroid/src/main/java/com/facebook/react/animation/AbstractFloatPairPropertyUpdater.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/animation/AbstractFloatPairPropertyUpdater.java
@@ -13,7 +13,7 @@ import android.view.View;
 
 /**
  * Base class for {@link AnimationPropertyUpdater} subclasses that updates a pair of float property
- * values. It helps to handle convertion from animation progress to the actual values as
+ * values. It helps to handle conversion from animation progress to the actual values as
  * well as the quite common case when no starting value is provided.
  */
 public abstract class AbstractFloatPairPropertyUpdater implements AnimationPropertyUpdater {

--- a/ReactAndroid/src/main/java/com/facebook/react/animation/AbstractSingleFloatProperyUpdater.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/animation/AbstractSingleFloatProperyUpdater.java
@@ -13,7 +13,7 @@ import android.view.View;
 
 /**
  * Base class for {@link AnimationPropertyUpdater} subclasses that updates a single float property
- * value. It helps to handle convertion from animation progress to the actual value as well as the
+ * value. It helps to handle conversion from animation progress to the actual value as well as the
  * quite common case when no starting value is provided.
  */
 public abstract class AbstractSingleFloatProperyUpdater implements AnimationPropertyUpdater {

--- a/ReactAndroid/src/main/java/com/facebook/react/animation/AnimationPropertyUpdater.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/animation/AnimationPropertyUpdater.java
@@ -37,7 +37,7 @@ public interface AnimationPropertyUpdater {
 
   /**
    * This method will be called at the end of animation. It should be used to set the final values
-   * for animated properties in order to avoid floating point inacurracy calculated in
+   * for animated properties in order to avoid floating point inaccuracy calculated in
    * {@link #onUpdate} by passing value close to 1.0 or in a case some frames got dropped.
    *
    * @param view view to update property

--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/BaseJavaModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/BaseJavaModule.java
@@ -29,7 +29,7 @@ import java.util.Map;
  * 3/ {@link ReadableArray} mapped from JS Array
  * 4/ {@link ReadableMap} mapped from JS Object
  * 5/ {@link Callback} mapped from js function and can be used only as a last parameter or in the
- * case when it express success & error callback pair as two last arguments respecively.
+ * case when it express success & error callback pair as two last arguments respectively.
  *
  * All methods exposed as native to JS with {@link ReactMethod} annotation must return
  * {@code void}.

--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/Dynamic.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/Dynamic.java
@@ -10,7 +10,7 @@
 package com.facebook.react.bridge;
 
 /**
- * Type representing a piece of data with unkown runtime type. Useful for allowing javascript to
+ * Type representing a piece of data with unknown runtime type. Useful for allowing javascript to
  * pass one of multiple types down to the native layer.
  */
 public interface Dynamic {

--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/JSBundleLoader.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/JSBundleLoader.java
@@ -38,7 +38,7 @@ public abstract class JSBundleLoader {
 
   /**
    * This loader loads bundle from file system. The bundle will be read in native code to save on
-   * passing large strings from java to native memorory.
+   * passing large strings from java to native memory.
    */
   public static JSBundleLoader createFileLoader(final String fileName) {
     return createFileLoader(fileName, fileName, false);

--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/JavaOnlyArray.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/JavaOnlyArray.java
@@ -14,7 +14,7 @@ import java.util.Arrays;
 import java.util.List;
 
 /**
- * Java {@link ArrayList} backed impementation of {@link ReadableArray} and {@link WritableArray}
+ * Java {@link ArrayList} backed implementation of {@link ReadableArray} and {@link WritableArray}
  * Instances of this class SHOULD NOT be used for communication between java and JS, use instances
  * of {@link WritableNativeArray} created via {@link Arguments#createArray} or just
  * {@link ReadableArray} interface if you want your "native" module method to take an array from JS

--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/JavaOnlyMap.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/JavaOnlyMap.java
@@ -14,7 +14,7 @@ import java.util.Iterator;
 import java.util.Map;
 
 /**
- * Java {@link HashMap} backed impementation of {@link ReadableMap} and {@link WritableMap}
+ * Java {@link HashMap} backed implementation of {@link ReadableMap} and {@link WritableMap}
  * Instances of this class SHOULD NOT be used for communication between java and JS, use instances
  * of {@link WritableNativeMap} created via {@link Arguments#createMap} or just {@link ReadableMap}
  * interface if you want your "native" module method to take a map from JS as an argument.

--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/NativeModuleRegistry.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/NativeModuleRegistry.java
@@ -75,7 +75,7 @@ public class NativeModuleRegistry {
   }
 
   /*
-  * Adds any new modules to the current module regsitry
+  * Adds any new modules to the current module registry
   */
   /* package */ void registerModules(NativeModuleRegistry newRegister) {
 

--- a/ReactAndroid/src/main/java/com/facebook/react/common/DebugServerException.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/common/DebugServerException.java
@@ -21,7 +21,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 /**
- * Tracks errors connecting to or received from the debug derver.
+ * Tracks errors connecting to or received from the debug server.
  * The debug server returns errors as json objects. This exception represents that error.
  */
 public class DebugServerException extends RuntimeException {

--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevServerHelper.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevServerHelper.java
@@ -54,7 +54,7 @@ import org.json.JSONObject;
  *
  * One can use 'debug_http_host' shared preferences key to provide a host name for the debug server.
  * If the setting is empty we support and detect two basic configuration that works well for android
- * emulators connectiong to debug server running on emulator's host:
+ * emulators connection to debug server running on emulator's host:
  *  - Android stock emulator with standard non-configurable local loopback alias: 10.0.2.2,
  *  - Genymotion emulator with default settings: 10.0.3.2
  */

--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerImpl.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerImpl.java
@@ -575,7 +575,7 @@ public class DevSupportManagerImpl implements
         PackageInfo thisPackage = mApplicationContext.getPackageManager()
             .getPackageInfo(packageName, 0);
         if (mJSBundleTempFile.lastModified() > thisPackage.lastUpdateTime) {
-          // Base APK has not been updated since we donwloaded JS, but if app is using exopackage
+          // Base APK has not been updated since we downloaded JS, but if app is using exopackage
           // it may only be a single dex that has been updated. We check for exopackage dir update
           // time in that case.
           File exopackageDir = new File(

--- a/ReactAndroid/src/main/java/com/facebook/react/flat/FlatUIImplementation.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/flat/FlatUIImplementation.java
@@ -53,7 +53,7 @@ public class FlatUIImplementation extends UIImplementation {
 
   /**
    * Build the map of view managers, checking that the managers FlatUI requires are correctly
-   * overriden.
+   * overridden.
    */
   private static Map<String, ViewManager> buildViewManagerMap(List<ViewManager> viewManagers) {
     Map<String, ViewManager> viewManagerMap = new HashMap<>();
@@ -149,7 +149,7 @@ public class FlatUIImplementation extends UIImplementation {
     if (mRCTImageViewManager != null) {
       // This is not the best place to initialize DraweeRequestHelper, but order of module
       // initialization is undefined, and this is pretty much the earliest when we are guarantied
-      // that Fresco is initalized and DraweeControllerBuilder can be queried. This also happens
+      // that Fresco is initialized and DraweeControllerBuilder can be queried. This also happens
       // relatively rarely to have any performance considerations.
       mReactContext.getNativeModule(FrescoModule.class); // initialize Fresco
       DraweeRequestHelper.setDraweeControllerBuilder(

--- a/ReactAndroid/src/main/java/com/facebook/react/flat/MoveProxy.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/flat/MoveProxy.java
@@ -26,7 +26,7 @@ import javax.annotation.Nullable;
   private ReactShadowNode[] mChildren = new ReactShadowNodeImpl[4];
 
   /**
-   * Retuns size of underlying moveTo/moveFrom arrays
+   * Returns size of underlying moveTo/moveFrom arrays
    */
   public int size() {
     return mSize;

--- a/ReactAndroid/src/main/java/com/facebook/react/flat/RCTImageView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/flat/RCTImageView.java
@@ -28,7 +28,7 @@ import com.facebook.react.views.image.ImageResizeMode;
   static Object sCallerContext = RCTImageView.class;
 
   /**
-   * Assignes a CallerContext to execute network requests with.
+   * Assigns a CallerContext to execute network requests with.
    */
   /* package */ static void setCallerContext(Object callerContext) {
     sCallerContext = callerContext;

--- a/ReactAndroid/src/main/java/com/facebook/react/flat/StateBuilder.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/flat/StateBuilder.java
@@ -226,7 +226,7 @@ import com.facebook.react.uimanager.events.EventDispatcher;
   }
 
   /**
-   * Enqueue dropping of the view for a node that has a backing view.  Used in conjuction with
+   * Enqueue dropping of the view for a node that has a backing view.  Used in conjunction with
    * remove the node from the shadow hierarchy.
    *
    * @param node The node to drop the backing view for.

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIViewOperationQueue.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIViewOperationQueue.java
@@ -874,7 +874,7 @@ public class UIViewOperationQueue {
       }
 
       // In the case where the frame callback isn't enqueued, the UI isn't being displayed or is being
-      // destroyed. In this case it's no longer important to align to frames, but it is imporant to make
+      // destroyed. In this case it's no longer important to align to frames, but it is important to make
       // sure any late-arriving UI commands are executed.
       if (!mIsDispatchUIFrameCallbackEnqueued) {
         UiThreadUtil.runOnUiThread(

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManager.java
@@ -57,7 +57,7 @@ public abstract class ViewManager<T extends View, C extends ReactShadowNode>
 
   /**
    * This method should return a subclass of {@link ReactShadowNode} which will be then used for
-   * measuring position and size of the view. In mose of the cases this should just return an
+   * measuring position and size of the view. In most of the cases this should just return an
    * instance of {@link ReactShadowNode}
    */
   public C createShadowNodeInstance() {

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/annotations/ReactProp.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/annotations/ReactProp.java
@@ -58,7 +58,7 @@ public @interface ReactProp {
    * set in which case default type will be send to JS based on the type of value argument from the
    * setter method (e.g. for {@code int}, {@code double} default is "number", for
    * {@code ReadableArray} it's "Array"). Custom type may be used when additional processing of the
-   * value needs to be done in JS before sending it over the brige. A good example of that would be
+   * value needs to be done in JS before sending it over the bridge. A good example of that would be
    * backgroundColor property, which is expressed as a {@code String} in JS, but we use
    * {@code processColor} JS module to convert it to {@code int} before sending over the bridge.
    */

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/AbstractLayoutAnimation.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/AbstractLayoutAnimation.java
@@ -31,7 +31,7 @@ import com.facebook.react.uimanager.IllegalViewOperationException;
 
   /**
    * Create an animation object for the current animation type, based on the view and final screen
-   * coordinates. If the application-supplied configuraiton does not specify an animation definition
+   * coordinates. If the application-supplied configuration does not specify an animation definition
    * for this types, or if the animation definition is invalid, returns null.
    */
   abstract @Nullable Animation createAnimationImpl(View view, int x, int y, int width, int height);

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextAnchorViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextAnchorViewManager.java
@@ -29,7 +29,7 @@ import javax.annotation.Nullable;
  * TextEdit}.
  *
  * <p>This is a "shadowing" view manager, which means that the {@link NativeViewHierarchyManager}
- * will NOT manage children of native {@link TextView} instances instanciated by this manager.
+ * will NOT manage children of native {@link TextView} instances instantiated by this manager.
  * Instead we use @{link ReactBaseTextShadowNode} hierarchy to calculate a {@link Spannable} text
  * represented the whole text subtree.
  */

--- a/ReactAndroid/src/main/java/com/facebook/react/views/toolbar/events/ToolbarClickEvent.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/toolbar/events/ToolbarClickEvent.java
@@ -15,7 +15,7 @@ import com.facebook.react.uimanager.events.RCTEventEmitter;
 
 /**
  * Represents a click on the toolbar.
- * Position is meaningful when the click happenned on a menu
+ * Position is meaningful when the click happened on a menu
  */
 public class ToolbarClickEvent extends Event<ToolbarClickEvent> {
 

--- a/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebViewManager.java
@@ -217,7 +217,7 @@ public class ReactWebViewManager extends SimpleViewManager<WebView> {
 
   /**
    * Subclass of {@link WebView} that implements {@link LifecycleEventListener} interface in order
-   * to call {@link WebView#destroy} on activty destroy event and also to clear the client
+   * to call {@link WebView#destroy} on activity destroy event and also to clear the client
    */
   protected static class ReactWebView extends WebView implements LifecycleEventListener {
     protected @Nullable String injectedJS;

--- a/ReactAndroid/src/main/java/com/facebook/yoga/YogaLogger.java
+++ b/ReactAndroid/src/main/java/com/facebook/yoga/YogaLogger.java
@@ -12,7 +12,7 @@ package com.facebook.yoga;
 import com.facebook.proguard.annotations.DoNotStrip;
 
 /**
- * Inteface for recieving logs from native layer. Use by setting YogaNode.setLogger(myLogger);
+ * Interface for receiving logs from native layer. Use by setting YogaNode.setLogger(myLogger);
  * See YogaLogLevel for the different log levels.
  */
 @DoNotStrip

--- a/ReactAndroid/src/main/jni/first-party/fb/include/fb/fbjni/Registration-inl.h
+++ b/ReactAndroid/src/main/jni/first-party/fb/include/fb/fbjni/Registration-inl.h
@@ -88,7 +88,7 @@ struct FunctionWrapper {
   }
 };
 
-// registration wrappers for non-static methods, with autoconvertion of arguments.
+// registration wrappers for non-static methods, with autoconversion of arguments.
 template<typename M, M method, typename C, typename R, typename... Args>
 struct MethodWrapper {
   using jhybrid = typename C::jhybridobject;

--- a/ReactAndroid/src/main/jni/first-party/fb/include/jni/LocalString.h
+++ b/ReactAndroid/src/main/jni/first-party/fb/include/jni/LocalString.h
@@ -47,7 +47,7 @@ std::string utf16toUTF8(const uint16_t* utf16Bytes, size_t len) noexcept;
 
 class FBEXPORT LocalString {
 public:
-  // Assumes UTF8 encoding and make a required convertion to modified UTF-8 when the string
+  // Assumes UTF8 encoding and make a required conversion to modified UTF-8 when the string
   // contains unicode supplementary characters.
   explicit LocalString(const std::string& str);
   explicit LocalString(const char* str);

--- a/ReactAndroid/src/test/java/com/facebook/react/uimanager/MatrixMathHelperTest.java
+++ b/ReactAndroid/src/test/java/com/facebook/react/uimanager/MatrixMathHelperTest.java
@@ -131,7 +131,7 @@ public class MatrixMathHelperTest {
   @Test
   public void testDecomposingComplex4x4MatrixToProduceAccurateAngles() {
     verifyRotatedMatrix(10, -80, 0, 10, -80, 0);
-    // x and y will filp
+    // x and y will flip
     verifyRotatedMatrix(10, -95, 0, -170, -85, -180);
   }
 

--- a/ReactAndroid/src/test/java/com/facebook/react/uimanager/ReactPropForShadowNodeSetterTest.java
+++ b/ReactAndroid/src/test/java/com/facebook/react/uimanager/ReactPropForShadowNodeSetterTest.java
@@ -29,7 +29,7 @@ import org.powermock.modules.junit4.rule.PowerMockRule;
 import org.robolectric.RobolectricTestRunner;
 
 /**
- * Test {@link ReactProp} annotation for {@link ReactShadowNode}. More comprahensive test of this
+ * Test {@link ReactProp} annotation for {@link ReactShadowNode}. More comprehensive test of this
  * annotation can be found in {@link ReactPropAnnotationSetterTest} where we test all possible types
  * of properties to be updated.
  */

--- a/scripts/run-instrumentation-tests-via-adb-shell.sh
+++ b/scripts/run-instrumentation-tests-via-adb-shell.sh
@@ -29,7 +29,7 @@ def update():
   # prevent CircleCI from killing the process for inactivity
   while not done:
     time.sleep(5)
-    print "Running in background.  Waiting for 'adb' command reponse..."
+    print "Running in background.  Waiting for 'adb' command response..."
 
 t = threading.Thread(target=update)
 t.dameon = True


### PR DESCRIPTION
## Motivation

:wave: Hello! Thanks for react-native, it’s a great project.

I was digging into the Android implementation in _ReactAndroid_ and noticed a couple typos in the documentation. I went through and tried to fix all the typos I could find using [aspell](http://aspell.net).

## Test Plan

Not applicable: these changes are only to comments, and CI should be skipped.

## Release Notes

[ANDROID][ENHANCEMENT][*] - Correct comment and docblock typos
