### PR TITLE
Make the load-script-error less misleading

### DIFF
--- a/ReactAndroid/src/main/jni/react/jni/JSLoader.cpp
+++ b/ReactAndroid/src/main/jni/react/jni/JSLoader.cpp
@@ -56,8 +56,10 @@ std::unique_ptr<const JSBigString> loadScriptFromAssets(
     }
   }
 
-  throw std::runtime_error(folly::to<std::string>("Unable to load script from assets '", assetName,
-    "'. Make sure your bundle is packaged correctly or you're running a packager server."));
+  throw std::runtime_error(folly::to<std::string>("Unable to load script. Make sure you're "
+    "running a metro server (run 'react-native start' under your project directory) for "
+    "debug and connect to it correctly or your bundle '", assetName, 
+    "' is packaged correctly for release. ");
 }
 
 }}


### PR DESCRIPTION
For most cases, people saw this error when they are running a debug version. So they should check metro server first. However, they were misled to search for "bundle" keywords and finally they executed "react-native bundle" command and got an app that can never reload.

