### PR TITLE
Add props to Button to get basic styles seen across iOS/Android platforms

### DIFF
--- a/Libraries/Components/Button.js
+++ b/Libraries/Components/Button.js
@@ -11,6 +11,7 @@
  */
 'use strict';
 
+const Animated = require('Animated');
 const ColorPropType = require('ColorPropType');
 const Platform = require('Platform');
 const React = require('React');
@@ -153,9 +154,13 @@ class Button extends React.Component<{
       accessibilityTraits.push('disabled');
       buttonStyles.push(styles.buttonDisabled);
       textStyles.push(styles.textDisabled);
-      if (bordered) buttonStyles.push(styles.buttonBordered, styles.buttonBorderedDisabled);
+      if (bordered) {
+        buttonStyles.push(styles.buttonBordered, styles.buttonBorderedDisabled);
+      }
       if (isAndroid) {
-        if (transparent) buttonStyles.push(styles.buttonTransparentDisabledAndroid);
+        if (transparent) {
+          buttonStyles.push(styles.buttonTransparentDisabledAndroid);
+        }
       }
     } else {
       if (transparent && isAndroid) {
@@ -165,11 +170,18 @@ class Button extends React.Component<{
         buttonStyles.push(styles.buttonBordered);
       }
       if (color) {
-        if (bordered) buttonStyles.push({ borderColor: color });
-        if (isIOS || (isAndroid && (transparent || bordered))) textStyles.push({ color });
-        else if (!transparent) buttonStyles.push({ backgroundColor: color }); // isAndroid on this line
+        if (bordered) {
+          buttonStyles.push({ borderColor: color });
+        }
+        if (isIOS || (isAndroid && (transparent || bordered))) {
+          textStyles.push({ color });
+        } else if (!transparent) {
+          buttonStyles.push({ backgroundColor: color }); // isAndroid on this line
+        }
       } else {
-        if (isAndroid && (transparent || bordered)) textStyles.push(styles.textBorderedAndroid);
+        if (isAndroid && (transparent || bordered)) {
+          textStyles.push(styles.textBorderedAndroid);
+        }
       }
       if (noShadow && isAndroid && !bordered && !transparent) {
         buttonStyles.push(styles.buttonUnelevatedAndroid);
@@ -195,7 +207,7 @@ class Button extends React.Component<{
             </Animated.View>
           </TouchableWithoutFeedback>
         </View>
-      )
+      );
     } else {
       return (
         <Touchable accessibilityComponentType="button" accessibilityLabel={accessibilityLabel} accessibilityTraits={accessibilityTraits} disabled={disabled} hasTVPreferredFocus={hasTVPreferredFocus} onPress={onPress} testID={testID}>
@@ -203,7 +215,7 @@ class Button extends React.Component<{
             <Text style={textStyles} disabled={disabled}>{formattedTitle}</Text>
           </View>
         </Touchable>
-      )
+      );
     }
   }
 


### PR DESCRIPTION
Android: noShadow, transparent
iOS: bold
Both: bordered

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes. 

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to React Native here: http://facebook.github.io/react-native/docs/contributing.html

Happy contributing!

-->

## Motivation

Can be summed up here - https://medium.com/as-a-product-designer/android-vs-ios-compare-20-ui-components-patterns-feaf94533568 - this article compares equivalent components on iOS and Android.

On Android we have some basic style options we are missing.

Android - as seen in the Google Play store we have "no shadow", "bordered", and in dialogs everywhere we see a transparent background and the color affects the title.

No shadow and bordered examples in Play store - https://i.imgur.com/Q4qWbNF.png

Dialogs across Android platform - https://i.imgur.com/JdZmwGK.png

iOS - we see in App Store that buttons can be "bold" and can also be "bordered". When "bordered" it no longer behaves as a `<TouchableOpacity>` but the color in the background fades from transparent to color defined by "color" prop, and the title color goes to white.

system/rectRounded UIButton type seen in App Store:

  * depressed state - https://i.imgur.com/fEcSMED.png
  * default state - https://i.imgur.com/BY4Hdh3.png

Bolded labels in share dialogs:

  * notice the "Post" button is bolded while the "Cancel" button is not - https://raw.githubusercontent.com/EddyVerbruggen/SocialSharing-PhoneGap-Plugin/master/screenshots/screenshot-ios7-share.png


We can see a demonstration of this in the code here:

### Here is link to Expo snakc - https://snack.expo.io/@noitsnack/react-native-buttonex

```
import React, { Component } from 'react'
import { Text, View, StyleSheet } from 'react-native'

import Button from 'react-native-buttonex' // 1.0.2

export default class App extends Component {
    render() {
        return (
            <View style={styles.column}>
                <Text>Current/default implementation of react-native/Button</Text>
                <View style={styles.row}>
                    <Button title="Cancel" color="red" />
                    <Button title="Cancel" color="red" disabled />
                </View>
                <Text>`bordered` - makes `color` affect font and border. The background is always white on Android and always transparent on iOS. (Android - do not set `transparent` prop as this will override `bordered`)</Text>
                <View style={styles.row}>
                    <Button title="Cancel" color="red" bordered />
                    <Button title="Cancel" color="red" bordered disabled />
                </View>
                <Text>(Android only)`transparent` - makes `color` affect font and removes background</Text>
                <View style={styles.row}>
                    <Button title="Cancel" color="red" transparent />
                    <Button title="Cancel" color="red" transparent disabled />
                </View>
                <Text>(Android only) `noShadow` - default &lt;Button&gt; on Anroid has a shadow, this removes it. </Text>
                <View style={styles.row}>
                    <Button title="Cancel" color="red" noShadow />
                    <Button title="Cancel" color="red" noShadow disabled />
                </View>
                <Text>(iOS only) `bold` - Makes the title font thicker</Text>
                <View style={styles.row}>
                    <Button title="Cancel" color="red" bold />
                    <Button title="Cancel" color="red" bold disabled />
                </View>
            </View>
        )
    }
}

const styles = StyleSheet.create({
    row: {
        justifyContent: 'space-around',
        flexDirection: 'row',
        alignItems: 'center'
    },
    column: {
        flex: 1,
        backgroundColor: 'white',
        padding: 50,
        justifyContent: 'space-between'
    }
})
```

## Screenshot on Android:

![](https://i.imgur.com/VgLAa46.png)

## Screenshot on iOS:

![](https://i.imgur.com/AtBFtED.jpg)

## Test Plan

I'm not sure how to test

## Release Notes
<!--
Help reviewers and the release process by writing your own release notes

**INTERNAL and MINOR tagged notes will not be included in the next version's final release notes.**

  CATEGORY
[----------]        TYPE
[ CLI      ]   [-------------]      LOCATION
[ DOCS     ]   [ BREAKING    ]   [-------------]
[ GENERAL  ]   [ BUGFIX      ]   [-{Component}-]
[ INTERNAL ]   [ ENHANCEMENT ]   [ {File}      ]
[ IOS      ]   [ FEATURE     ]   [ {Directory} ]   |-----------|
[ ANDROID  ]   [ MINOR       ]   [ {Framework} ] - | {Message} |
[----------]   [-------------]   [-------------]   |-----------|

[CATEGORY] [TYPE] [LOCATION] - MESSAGE

 EXAMPLES:

 [IOS] [BREAKING] [FlatList] - Change a thing that breaks other things
 [ANDROID] [BUGFIX] [TextInput] - Did a thing to TextInput
 [CLI] [FEATURE] [local-cli/info/info.js] - CLI easier to do things with
 [DOCS] [BUGFIX] [GettingStarted.md] - Accidentally a thing/word
 [GENERAL] [ENHANCEMENT] [Yoga] - Added new yoga thing/position
 [INTERNAL] [FEATURE] [./scripts] - Added thing to script that nobody will see
-->

[IOS] [FEATURE] [Button] - Can get a bordered look, as seen with `roundedRect`/`system` `UIButtonType` - https://developer.apple.com/documentation/uikit/uibuttontype/
[IOS] [FEATURE] [Button] - Can make title thick with `bold` prop (as seen in app store)

[ANDROID] [FEATURE] [Button] - Can remove shadow with `noShadow` prop (as seen in Google Play store)
[ANDROID] [FEATURE] [Button] - Can give buttons a border with `bordered` prop (as seen in Google Play store)
[ANDROID] [FEATURE] [Button] - Can give buttons a transparent look with `transparent` prop, this was previously accomplished by setting `color` to "transparent" however with this change, the `color` prop rightfully affects the title color (as seen in dialogs across Android platform)