### PR TITLE
Expose SectionList getItem

### DIFF
--- a/Libraries/Lists/VirtualizedSectionList.js
+++ b/Libraries/Lists/VirtualizedSectionList.js
@@ -502,7 +502,7 @@ class ItemWithSeparator extends React.Component<
   }
 }
 
-function getItem(sections: ?$ReadOnlyArray<Item>, index: number): ?Item {
+export function getItem(sections: ?$ReadOnlyArray<Item>, index: number): ?Item {
   if (!sections) {
     return null;
   }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes. 

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to React Native here: http://facebook.github.io/react-native/docs/contributing.html

Happy contributing!

-->

## Motivation

Implementing `getItemLayout` for a SectionList is tricky, because the `index` provided doesn't directly map to the `data`, which is the sections (see also https://github.com/facebook/react-native/issues/14966). If we had access to the `getItem` used internally, then we could reliably map index to the actual item. Example implementation:

```
import { range } from 'lodash'
import { getItem } from 'SectionList'

const heights = {
  sectionHeader: 20,
  row: 40,
  separator: 5,
}

const getItemLayout = (data, index) => ({
  index,
  length: heights[getItem(data, index).type],
  offset: range(index).reduce((result, i) => result + heights[getItem(data, i).type], 0),
})
```
