### PR TITLE
Allow for changing the okhttpclientprovider builder

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/modules/network/OkHttpClientProvider.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/network/OkHttpClientProvider.java
@@ -31,6 +31,7 @@ public class OkHttpClientProvider {
 
   // Centralized OkHttpClient for all networking requests.
   private static @Nullable OkHttpClient sClient;
+  private static @Nullable OkHttpClient.Builder sClientBuilder;
 
   public static OkHttpClient getOkHttpClient() {
     if (sClient == null) {
@@ -38,22 +39,37 @@ public class OkHttpClientProvider {
     }
     return sClient;
   }
-  
-  // okhttp3 OkHttpClient is immutable
-  // This allows app to init an OkHttpClient with custom settings.
+
+  /**
+   * okhttp3 OkHttpClient is immutable
+   * This allows app to init an OkHttpClient with custom settings.
+   * @deprecated Use {@link #replaceOkHttpClientBuilder(OkHttpClient.Builder)} instead.
+   */
+  @Deprecated
   public static void replaceOkHttpClient(OkHttpClient client) {
     sClient = client;
   }
 
-  public static OkHttpClient createClient() {
-    // No timeouts by default
-    OkHttpClient.Builder client = new OkHttpClient.Builder()
-      .connectTimeout(0, TimeUnit.MILLISECONDS)
-      .readTimeout(0, TimeUnit.MILLISECONDS)
-      .writeTimeout(0, TimeUnit.MILLISECONDS)
-      .cookieJar(new ReactCookieJarContainer());
+  /**
+   * Replace the builder used by {@link #createClient()}
+   */
+  public static void replaceOkHttpClientBuilder(OkHttpClient.Builder builder) {
+    sClientBuilder = builder;
+  }
 
-    return enableTls12OnPreLollipop(client).build();
+  public static OkHttpClient createClient() {
+    if (sClientBuilder != null) {
+      return sClientBuilder.build();
+    } else {
+      // No timeouts by default
+      OkHttpClient.Builder client = new OkHttpClient.Builder()
+        .connectTimeout(0, TimeUnit.MILLISECONDS)
+        .readTimeout(0, TimeUnit.MILLISECONDS)
+        .writeTimeout(0, TimeUnit.MILLISECONDS)
+        .cookieJar(new ReactCookieJarContainer());
+
+      return enableTls12OnPreLollipop(client).build();
+    }
   }
 
   /*

--- a/ReactAndroid/src/test/java/com/facebook/react/modules/network/OkHttpClientProviderTest.java
+++ b/ReactAndroid/src/test/java/com/facebook/react/modules/network/OkHttpClientProviderTest.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+package com.facebook.react.modules.network;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.robolectric.RobolectricTestRunner;
+
+import okhttp3.OkHttpClient;
+
+import static org.fest.assertions.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link OkHttpClientProvider}.
+ */
+@PrepareForTest({
+    OkHttpClient.class,
+    OkHttpClient.Builder.class
+})
+@RunWith(RobolectricTestRunner.class)
+@PowerMockIgnore({"org.mockito.*", "org.robolectric.*", "android.*"})
+public class OkHttpClientProviderTest {
+
+  @Test
+  public void testReplaceOkHttpClientBuilder() throws Exception {
+    OkHttpClient httpClient = mock(OkHttpClient.class);
+    OkHttpClient.Builder clientBuilder = mock(OkHttpClient.Builder.class);
+    when(clientBuilder.build()).thenReturn(httpClient);
+    when(httpClient.newBuilder()).thenReturn(clientBuilder);
+
+    OkHttpClientProvider.replaceOkHttpClientBuilder(clientBuilder);
+    assertThat(OkHttpClientProvider.createClient()).isEqualTo(httpClient);
+
+    OkHttpClientProvider.replaceOkHttpClientBuilder(null);
+    assertThat(OkHttpClientProvider.createClient()).isNotEqualTo(httpClient);
+  }
+}


### PR DESCRIPTION
## Motivation

This is another attempt at reviving OkHttpClientProvider as a way of controlling the OkHttpClients used by react native. See previous attempts #14068 and #14675, and the original change here: https://github.com/facebook/react-native/commit/0a71f48b1349ed09bcb6e76ba9ff8eb388518b15 . 

## Test Plan
Unit test

## Release Notes
<!--
Help reviewers and the release process by writing your own release notes

**INTERNAL and MINOR tagged notes will not be included in the next version's final release notes.**

  CATEGORY
[----------]        TYPE
[ CLI      ]   [-------------]      LOCATION
[ DOCS     ]   [ BREAKING    ]   [-------------]
[ GENERAL  ]   [ BUGFIX      ]   [-{Component}-]
[ INTERNAL ]   [ ENHANCEMENT ]   [ {File}      ]
[ IOS      ]   [ FEATURE     ]   [ {Directory} ]   |-----------|
[ ANDROID  ]   [ MINOR       ]   [ {Framework} ] - | {Message} |
[----------]   [-------------]   [-------------]   |-----------|

[CATEGORY] [TYPE] [LOCATION] - MESSAGE

 EXAMPLES:

 [IOS] [BREAKING] [FlatList] - Change a thing that breaks other things
 [ANDROID] [BUGFIX] [TextInput] - Did a thing to TextInput
 [CLI] [FEATURE] [local-cli/info/info.js] - CLI easier to do things with
 [DOCS] [BUGFIX] [GettingStarted.md] - Accidentally a thing/word
 [GENERAL] [ENHANCEMENT] [Yoga] - Added new yoga thing/position
 [INTERNAL] [FEATURE] [./scripts] - Added thing to script that nobody will see
-->
[ANDROID] [ENHANCEMENT] [Networking] - Added support for swapping out OkHttpClient.Builder in OkHttpClientProvider