### PR TITLE
Set minHeight instead of minWidth for calculating the layout in RCTSurfaceRootShadowView

### DIFF
--- a/React/Base/Surface/RCTSurfaceRootShadowView.m
+++ b/React/Base/Surface/RCTSurfaceRootShadowView.m
@@ -50,7 +50,7 @@
   float availableHeight = isinf(maximimSize.height) ? YGUndefined : maximimSize.height;
 
   self.minWidth = (YGValue){isinf(minimumSize.width) ? YGUndefined : minimumSize.width, YGUnitPoint};
-  self.minWidth = (YGValue){isinf(minimumSize.height) ? YGUndefined : minimumSize.height, YGUnitPoint};
+  self.minHeight = (YGValue){isinf(minimumSize.height) ? YGUndefined : minimumSize.height, YGUnitPoint};
 
   YGNodeCalculateLayout(self.yogaNode, availableWidth, availableHeight, _baseDirection);
 }


### PR DESCRIPTION
## Motivation

Fix calculating layout in `RCTSurfaceRootShadowView` as the `minWidth` is set doubled in `calculateLayoutWithMinimumSize:maximumSize:`.

cc @shergin 