### PR TITLE
Switch to `declare module.exports` syntax

### DIFF
--- a/Libraries/react-native/react-native-interface.js
+++ b/Libraries/react-native/react-native-interface.js
@@ -24,5 +24,5 @@ declare var Headers: any;
 declare var Request: any;
 declare var Response: any;
 declare module requestAnimationFrame {
-  declare var exports: (callback: any) => any;
+  declare module.exports: (callback: any) => any;
 }

--- a/flow/Map.js
+++ b/flow/Map.js
@@ -32,7 +32,5 @@ declare module "Map" {
     values(): Iterator<V>;
   }
 
-  // Don't "declare class exports" directly, otherwise in error messages our
-  // show up as "exports" instead of "Map" or "MapPolyfill".
-  declare var exports: typeof MapPolyfill;
+  declare module.exports: typeof MapPolyfill;
 }

--- a/flow/Set.js
+++ b/flow/Set.js
@@ -30,7 +30,5 @@ declare module "Set" {
     values(): Iterator<T>;
   }
 
-  // Don't "declare class exports" directly, otherwise in error messages our
-  // show up as "exports" instead of "Set" or "SetPolyfill".
-  declare var exports: typeof SetPolyfill;
+  declare module.exports: typeof SetPolyfill;
 }

--- a/flow/create-react-class.js
+++ b/flow/create-react-class.js
@@ -13,5 +13,5 @@
 // TODO (acdlite) Remove this file once flowtype/flow-typed/pull/773 is merged
 
 declare module 'create-react-class' {
-  declare var exports: React$CreateClass;
+  declare module.exports: React$CreateClass;
 }

--- a/flow/fbjs.js
+++ b/flow/fbjs.js
@@ -8,9 +8,9 @@
  */
 
 declare module 'fbjs/lib/invariant' {
-  declare function exports<T>(condition: any, message: string, ...args: Array<any>): void;
+  declare module.exports: <T>(condition: any, message: string, ...args: Array<any>) => void;
 }
 
 declare module 'fbjs/lib/nullthrows' {
-  declare function exports<T>(value: ?T): T;
+  declare module.exports: <T>(value: ?T) => T;
 }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes. 

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to React Native here: http://facebook.github.io/react-native/docs/contributing.html

Happy contributing!

-->

## Motivation

In [this commit](https://github.com/facebook/flow/commit/1c91714e54893ab610ab02c45220e73376df90f4), Flow added a new syntax to define a CommonJS modules module.exports type. Instead of writing `declare var exports: T`, you can write `declare module.exports: T`.

This new syntax was released in Flow v0.25, nearly 2 years ago. Our intention was to eventually remove the special-case-y support for declare var exports within a few versions, but late is better than never.

## Test Plan

`flow` -- there were some errors before this change, but the errors are unchanged.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/react-native-website, and link to your PR here.)

## Release Notes
<!--
Help reviewers and the release process by writing your own release notes

**INTERNAL and MINOR tagged notes will not be included in the next version's final release notes.**

  CATEGORY
[----------]        TYPE
[ CLI      ]   [-------------]      LOCATION
[ DOCS     ]   [ BREAKING    ]   [-------------]
[ GENERAL  ]   [ BUGFIX      ]   [-{Component}-]
[ INTERNAL ]   [ ENHANCEMENT ]   [ {File}      ]
[ IOS      ]   [ FEATURE     ]   [ {Directory} ]   |-----------|
[ ANDROID  ]   [ MINOR       ]   [ {Framework} ] - | {Message} |
[----------]   [-------------]   [-------------]   |-----------|

[CATEGORY] [TYPE] [LOCATION] - MESSAGE

 EXAMPLES:

 [IOS] [BREAKING] [FlatList] - Change a thing that breaks other things
 [ANDROID] [BUGFIX] [TextInput] - Did a thing to TextInput
 [CLI] [FEATURE] [local-cli/info/info.js] - CLI easier to do things with
 [DOCS] [BUGFIX] [GettingStarted.md] - Accidentally a thing/word
 [GENERAL] [ENHANCEMENT] [Yoga] - Added new yoga thing/position
 [INTERNAL] [FEATURE] [./scripts] - Added thing to script that nobody will see
-->

 [INTERNAL] [MINOR] [Flow] - Switch to `declare module.exports` syntax

