### PR TITLE
Give better error feedback and print stacktrace

### DIFF
--- a/local-cli/link/link.js
+++ b/local-cli/link/link.js
@@ -200,7 +200,8 @@ function link(args: Array<string>, config: RNConfig) {
   return promiseWaterfall(tasks).catch(err => {
     log.error(
       `Something went wrong while linking. Error: ${err.message} \n` +
-      'Please file an issue here: https://github.com/facebook/react-native/issues'
+      'Please file an issue here: https://github.com/facebook/react-native/issues' +
+      `\n ${err} \n`
     );
     throw err;
   });


### PR DESCRIPTION
Just spent way too long trying to trace a very simple problem with `react-native link`

Trying to link my project I kept getting: 

```
rnpm-install ERR! ERRPACKAGEJSON No package found. Are you sure it's a React Native project?

Cannot read property '_text' of undefined
```

Which makes it seem like its a package.json problem, which it was not at all. 

Turns out the problem was I had a comment at the end of my main AndroidManifest.xml and the XML parser was failing because of it. How could I possibly know that from this error message? I had to find this file and print the error which then gave me some hints as to what was going on... This should be the default. I don't think we should trade pretty and useless error messages for actually useful ones.

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes. 

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to React Native here: http://facebook.github.io/react-native/docs/contributing.html

Happy contributing!

-->

## Motivation

To make life easier for devs. There seem to be lots of little project tool/cli related issues with react-native that lead to very poor error messages. In my case the problem was very simple, but it was very unclear where the problem was coming from so it became frustrating to solve.

## Test Plan

Just run the cli as usual. This only adds a stack-trace print in the case of an error.

## Related PRs

...

## Release Notes

...
