### PR TITLE
[ANDROID] Fix DeviceInfoModule LifecycleEventListener

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/modules/deviceinfo/DeviceInfoModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/deviceinfo/DeviceInfoModule.java
@@ -39,6 +39,7 @@ public class DeviceInfoModule extends BaseJavaModule implements
   public DeviceInfoModule(ReactApplicationContext reactContext) {
     this((Context) reactContext);
     mReactApplicationContext = reactContext;
+    mReactApplicationContext.addLifecycleEventListener(this);
   }
 
   public DeviceInfoModule(Context context) {


### PR DESCRIPTION
## Motivation

Fixes one of the two parts of [issue posted here](https://github.com/facebook/react-native/issues/17209).  Motivation is that we wanted our app to be able to handle user changing font size while the app is running.  Yes, we know that changing font size doesn't inherently trigger a re-render, but at the minimum it should cause `PixelRatio.getFontScale()` to return an updated value.

## Test Plan

1. Render an interface and invoke `PixelRatio.getFontScale()`
2. Change the font scale in Settings > Accessibility > Font Size
3. Return to the React Native app (without reloading Javascript) and invoke `PixelRatio.getFontScale()` again.
4. Verify that the result of `PixelRatio.getFontScale()` has changed to reflect the new font size.

For a video of the problem, see the linked issue under the Motivation heading.  In this fixed version, the number actually does update as expected.

## Related PRs

None.  This should require no documentation change, as it is behavior that the docs seem to indicate should be happening already.
In fact, [the documentation at the bottom of this page](https://facebook.github.io/react-native/docs/native-modules-android.html) appears to already indicate that this should be done for anything implementing LifecycleEventListener.

## Release Notes

[ANDROID] [BUGFIX] [DeviceInfo] - Fix the DeviceInfoModule to properly respond to LifecycleEvents
