### PR TITLE
Make TextInput "clear text" button accessible

### DIFF
--- a/Libraries/Text/TextInput/Singleline/RCTUITextField.m
+++ b/Libraries/Text/TextInput/Singleline/RCTUITextField.m
@@ -87,6 +87,22 @@
   self.enabled = editable;
 }
 
+#pragma mark - Accessibility
+
+- (BOOL)isAccessibilityElement
+{
+  // Always return NO to enumerate child elements. Otherwise the "clear text" button is hidden
+  // from accessibility interface.
+  return NO;
+}
+
+- (BOOL)accessibilityElementsHidden
+{
+  // If "accessible" prop is set to false on TextInput, disable all accessible children.
+  // Without this function the "clear text" UIButton is still exposed.
+  return ![super isAccessibilityElement];
+}
+
 #pragma mark - Caret Manipulation
 
 - (CGRect)caretRectForPosition:(UITextPosition *)position


### PR DESCRIPTION
## Motivation
This PR makes TextInput "clear text" button accessible. UITextField is wrapped inside a RCTUITextField control which has isAccessibleElement set to TRUE. This prevents iOS accessibility interface from enumerating child elements. This change makes the RCTextField not accessible, but allows child elements to be enumerated if the `accessible` prop is set to true.

## Issue
https://github.com/facebook/react-native/issues/16989

## Test Plan
Manually tested with RNTester sample app and accessibility explorer.

## Release Notes
[IOS] [BUGFIX] [TextInput] - Made "clear text" button accessible