### PR TITLE
Add back ability to customise OkHttp client

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/modules/network/OkHttpClientFactory.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/network/OkHttpClientFactory.java
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+package com.facebook.react.modules.network;
+
+import okhttp3.OkHttpClient;
+
+public interface OkHttpClientFactory {
+    OkHttpClient createNewNetworkModuleClient();
+};

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/network/OkHttpClientProvider.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/network/OkHttpClientProvider.java
@@ -32,6 +32,13 @@ public class OkHttpClientProvider {
   // Centralized OkHttpClient for all networking requests.
   private static @Nullable OkHttpClient sClient;
 
+  // User-provided OkHttpClient factory
+  private static @Nullable OkHttpClientFactory sFactory;
+
+  public static void setOkHttpClientFactory(OkHttpClientFactory factory) {
+    sFactory = factory;
+  }
+
   public static OkHttpClient getOkHttpClient() {
     if (sClient == null) {
       sClient = createClient();
@@ -46,6 +53,10 @@ public class OkHttpClientProvider {
   }
 
   public static OkHttpClient createClient() {
+    if (sFactory != null) {
+      return sFactory.createNewNetworkModuleClient();
+    }
+
     // No timeouts by default
     OkHttpClient.Builder client = new OkHttpClient.Builder()
       .connectTimeout(0, TimeUnit.MILLISECONDS)


### PR DESCRIPTION
## Motivation

Prior to 0a71f48b1349ed09bcb6e76ba9ff8eb388518b15, users could customise the OkHttp client used by React Native on Android by calling replaceOkHttpClient in OkHttpClientProvider.

This functionality has a variety of legitimate applications from changing connection timeouts or pool size to Stetho integration. The challenge is to add back support for replacing the client without causing a breaking change or reintroducing the problems @olegbl sought to address in his original commit.

Introducing a client factory archives these aims, it adds a new, backwards compatible interface and is called each time a client is requested rather than re-using the same instance (unless you explicitly want this behaviour, in which case you could replicate it using a static class property inside your custom factory). 

A number of PRs have been opened to add this functionality: https://github.com/facebook/react-native/pull/14675, https://github.com/facebook/react-native/pull/14068.

I don't have a lot of Java experience so I'm open to better/more idiomatic ways to achieve this :)

## Test Plan

Create React Native application and set a custom factory in the constructor, e.g.  `OkHttpClientProvider.setOkHttpClientFactory(new CustomNetworkModule());`

Where a custom factory would look like:

```
class CustomNetworkModule implements OkHttpClientFactory {
    public OkHttpClient createNewNetworkModuleClient() {
        return new OkHttpClient.Builder().build();
    }
}
```

## Related PRs

Remove the existing replace client method to prevent accident use and alert existing users that its functionality has changed: https://github.com/facebook/react-native/pull/16972

## Release Notes

[Android] [Minor] [Networking] - | Provide interface for customising the OkHttp client used by React Native |
