### PR TITLE
Update includes of folly shim headers

### DIFF
--- a/ReactCommon/cxxreact/oss-compat-util.h
+++ b/ReactCommon/cxxreact/oss-compat-util.h
@@ -8,7 +8,7 @@
   #define USE_FOLLY_FOR_ENDIAN_SWAP 1
   #define USE_FOLLY_FOR_TO_STRING 1
 #elif defined(__has_include)
-  #define USE_FOLLY_FOR_ENDIAN_SWAP __has_include(<folly/Bits.h>)
+  #define USE_FOLLY_FOR_ENDIAN_SWAP __has_include(<folly/lang/Bits.h>)
   #define USE_FOLLY_FOR_TO_STRING __has_include(<folly/Conv.h>)
 #else
   #define USE_FOLLY_FOR_ENDIAN_SWAP 0
@@ -16,7 +16,7 @@
 #endif
 
 #if USE_FOLLY_FOR_ENDIAN_SWAP
-#include <folly/Bits.h>
+#include <folly/lang/Bits.h>
 #elif defined(__APPLE__)
 #include <cstdint>
 #include <CoreFoundation/CFByteOrder.h>

--- a/third-party-podspecs/Folly.podspec
+++ b/third-party-podspecs/Folly.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name = 'Folly'
-  spec.version = '2016.09.26.00'
+  spec.version = '2017.12.11.00'
   spec.license = { :type => 'Apache License, Version 2.0' }
   spec.homepage = 'https://github.com/facebook/folly'
   spec.summary = 'An open-source C++ library developed and used at Facebook.'
@@ -12,8 +12,7 @@ Pod::Spec.new do |spec|
   spec.dependency 'DoubleConversion'
   spec.dependency 'GLog'
   spec.compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1'
-  spec.source_files = 'folly/Bits.cpp',
-                      'folly/Conv.cpp',
+  spec.source_files = 'folly/Conv.cpp',
                       'folly/Demangle.cpp',
                       'folly/StringBase.cpp',
                       'folly/Unicode.cpp',


### PR DESCRIPTION
## Motivation

Some headers in folly have moved. Relevant to react-native, `folly/Bits.h` has moved to `folly/lang/Bits.h`. A temporary shim has been left at `folly/Bits.h`, but it is slated for removal.

Also updates folly dep to `v2017.12.11.00`.

## Test Plan

CI.

## Related PRs

N/A.

## Release Notes
