### PR TITLE
Fix issue #12112: patch with --reject

### DIFF
--- a/react-native-git-upgrade/cliEntry.js
+++ b/react-native-git-upgrade/cliEntry.js
@@ -334,7 +334,7 @@ async function run(requestedVersion, cliArgs) {
 
     try {
       log.info('Apply the patch');
-      await exec(`git apply --3way ${patchPath}`, true);
+      await exec(`git apply --reject ${patchPath}`, true);
     } catch (err) {
       log.warn(
         'The upgrade process succeeded but there might be conflicts to be resolved. ' +


### PR DESCRIPTION
FIX https://github.com/facebook/react-native/issues/12112

Per https://github.com/facebook/react-native/issues/12112#issuecomment-292619346 :

> As others have identified, the upgrade process creates a patch file, then tries to apply the patch. When it tries to apply a --3way patch, it will fail if it encounters any errors such as those above ☝️. Unfortunately, it reverses the whole patch when a 3-way patch fails to apply.
> 
> If you change the git strategy for applying the patch from --3way to --reject, it will allow your changes to go through, then you just have to resolve and remove the .rej files where it had errored out. You can either do this after it fails using the patch file @ajwhite found, or change the cliEntry.js directly as described in the PR description.

## Motivation

This has been an open issue since 2017-01-29 with a well-defined solution (see issue).  
