### PR TITLE
Xcode 9 supports running multiple simulators

### DIFF
--- a/local-cli/runIOS/__tests__/findMatchingSimulator-test.js
+++ b/local-cli/runIOS/__tests__/findMatchingSimulator-test.js
@@ -446,9 +446,9 @@ describe('findMatchingSimulator', () => {
       },
       'iPhone 6s'
     )).toEqual({
-      udid: 'CBBB8FB8-77AB-49A9-8297-4CCFE3189C22',
+      udid: 'D0F29BE7-CC3C-4976-888D-C739B4F50508',
       name: 'iPhone 6s',
-      version: 'iOS 10.0'
+      version: 'iOS 9.2'
     });
   });
 

--- a/local-cli/runIOS/__tests__/findMatchingSimulator-test.js
+++ b/local-cli/runIOS/__tests__/findMatchingSimulator-test.js
@@ -55,6 +55,7 @@ describe('findMatchingSimulator', () => {
     )).toEqual({
       udid: 'BA0D93BD-07E6-4182-9B0A-F60A2474139C',
       name: 'iPhone 6',
+      booted: false,
       version: 'iOS 9.2'
     });
   });
@@ -145,6 +146,7 @@ describe('findMatchingSimulator', () => {
     )).toEqual({
       udid: '1CCBBF8B-5773-4EA6-BD6F-C308C87A1ADB',
       name: 'iPhone 5',
+      booted: false,
       version: 'iOS 9.2'
     });
   });
@@ -216,6 +218,7 @@ describe('findMatchingSimulator', () => {
     )).toEqual({
       udid: '1CCBBF8B-5773-4EA6-BD6F-C308C87A1ADB',
       name: 'iPhone 5',
+      booted: false,
       version: 'iOS 9.2'
     });
   });
@@ -261,6 +264,7 @@ describe('findMatchingSimulator', () => {
     )).toEqual({
       udid: 'D0F29BE7-CC3C-4976-888D-C739B4F50508',
       name: 'iPhone 6s',
+      booted: true,
       version: 'iOS 9.2'
     });
   });
@@ -306,6 +310,7 @@ describe('findMatchingSimulator', () => {
     )).toEqual({
       udid: 'BA0D93BD-07E6-4182-9B0A-F60A2474139C',
       name: 'iPhone 6',
+      booted: false,
       version: 'iOS 9.2'
     });
   });
@@ -377,6 +382,7 @@ describe('findMatchingSimulator', () => {
     )).toEqual({
       udid: '3A409DC5-5188-42A6-8598-3AA6F34607A5',
       name: 'iPhone 7',
+      booted: true,
       version: 'iOS 10.0'
     });
   });
@@ -448,6 +454,7 @@ describe('findMatchingSimulator', () => {
     )).toEqual({
       udid: 'D0F29BE7-CC3C-4976-888D-C739B4F50508',
       name: 'iPhone 6s',
+      booted: false,
       version: 'iOS 9.2'
     });
   });
@@ -481,6 +488,7 @@ describe('findMatchingSimulator', () => {
   )).toEqual({
     udid: '816C30EA-38EA-41AC-BFDA-96FB632D522E',
     name: 'Apple TV',
+    booted: true,
     version: 'tvOS 11.2'
   });
   });

--- a/local-cli/runIOS/__tests__/findMatchingSimulator-test.js
+++ b/local-cli/runIOS/__tests__/findMatchingSimulator-test.js
@@ -265,7 +265,7 @@ describe('findMatchingSimulator', () => {
     });
   });
 
-  it('should return the booted simulator in list even if another device is defined', () => {
+  it('should return the defined simulator in list even if another device is booted', () => {
     expect(findMatchingSimulator({
         'devices': {
           'iOS 9.2': [
@@ -304,8 +304,8 @@ describe('findMatchingSimulator', () => {
       },
       'iPhone 6'
     )).toEqual({
-      udid: 'D0F29BE7-CC3C-4976-888D-C739B4F50508',
-      name: 'iPhone 6s',
+      udid: 'BA0D93BD-07E6-4182-9B0A-F60A2474139C',
+      name: 'iPhone 6',
       version: 'iOS 9.2'
     });
   });
@@ -381,7 +381,7 @@ describe('findMatchingSimulator', () => {
     });
   });
 
-  it('should return the booted simulator in list even if another device is defined (multi ios versions)', () => {
+  it('should return the defined simulator in list even if another device is booted (multi ios versions)', () => {
     expect(findMatchingSimulator({
         'devices': {
           'iOS 9.2': [
@@ -446,8 +446,8 @@ describe('findMatchingSimulator', () => {
       },
       'iPhone 6s'
     )).toEqual({
-      udid: '3A409DC5-5188-42A6-8598-3AA6F34607A5',
-      name: 'iPhone 7',
+      udid: 'CBBB8FB8-77AB-49A9-8297-4CCFE3189C22',
+      name: 'iPhone 6s',
       version: 'iOS 10.0'
     });
   });

--- a/local-cli/runIOS/findMatchingSimulator.js
+++ b/local-cli/runIOS/findMatchingSimulator.js
@@ -34,17 +34,6 @@ function findMatchingSimulator(simulators, simulatorName) {
       if (simulator.availability !== '(available)') {
         continue;
       }
-      // If there is a booted simulator, we'll use that as instruments will not boot a second simulator
-      if (simulator.state === 'Booted') {
-        if (simulatorName !== null) {
-          console.warn("We couldn't boot your defined simulator due to an already booted simulator. We are limited to one simulator launched at a time.");
-        }
-        return {
-          udid: simulator.udid,
-          name: simulator.name,
-          version
-        };
-      }
       if (simulator.name === simulatorName && !match) {
         match = {
           udid: simulator.udid,

--- a/local-cli/runIOS/findMatchingSimulator.js
+++ b/local-cli/runIOS/findMatchingSimulator.js
@@ -34,6 +34,13 @@ function findMatchingSimulator(simulators, simulatorName) {
       if (simulator.availability !== '(available)') {
         continue;
       }
+      if (simulator.state === 'Booted' && simulatorName === null) {
+        match = {
+          udid: simulator.udid,
+          name: simulator.name,
+          version
+        };
+      }
       if (simulator.name === simulatorName && !match) {
         match = {
           udid: simulator.udid,

--- a/local-cli/runIOS/findMatchingSimulator.js
+++ b/local-cli/runIOS/findMatchingSimulator.js
@@ -35,7 +35,7 @@ function findMatchingSimulator(simulators, simulatorName) {
         continue;
       }
       if (simulator.state === 'Booted' && simulatorName === null) {
-        match = {
+        return {
           udid: simulator.udid,
           name: simulator.name,
           version

--- a/local-cli/runIOS/findMatchingSimulator.js
+++ b/local-cli/runIOS/findMatchingSimulator.js
@@ -34,10 +34,12 @@ function findMatchingSimulator(simulators, simulatorName) {
       if (simulator.availability !== '(available)') {
         continue;
       }
-      if (simulator.state === 'Booted' && simulatorName === null) {
+      let booted = simulator.state === 'Booted';
+      if (booted && simulatorName === null) {
         return {
           udid: simulator.udid,
           name: simulator.name,
+          booted,
           version
         };
       }
@@ -45,6 +47,7 @@ function findMatchingSimulator(simulators, simulatorName) {
         match = {
           udid: simulator.udid,
           name: simulator.name,
+          booted,
           version
         };
       }
@@ -53,6 +56,7 @@ function findMatchingSimulator(simulators, simulatorName) {
         match = {
           udid: simulator.udid,
           name: simulator.name,
+          booted,
           version
         };
       }

--- a/local-cli/runIOS/runIOS.js
+++ b/local-cli/runIOS/runIOS.js
@@ -115,7 +115,15 @@ function runOnSimulator(xcodeProject, args, scheme) {
 
     const simulatorFullName = formattedDeviceName(selectedSimulator);
     console.log(`Launching ${simulatorFullName}...`);
-    child_process.spawnSync('xcrun', ['simctl', 'boot', selectedSimulator.udid]);
+    try {
+      child_process.spawnSync('xcrun', ['simctl', 'boot', selectedSimulator.udid]);
+    } catch (e) {
+      throw new Error(
+        `Could not boot ${args.simulator} simulator. Is there already a simulator running? ` +
+        'Running multiple simulators is only supported from Xcode 9 and up. ' +
+        'Try closing the simulator or run the command again without specifying a simulator.'
+      );
+    }
 
     buildProject(xcodeProject, selectedSimulator.udid, scheme, args.configuration, args.packager, args.verbose)
       .then((appName) => resolve(selectedSimulator.udid, appName));

--- a/local-cli/runIOS/runIOS.js
+++ b/local-cli/runIOS/runIOS.js
@@ -113,16 +113,18 @@ function runOnSimulator(xcodeProject, args, scheme) {
       throw new Error(`Could not find ${args.simulator} simulator`);
     }
 
-    const simulatorFullName = formattedDeviceName(selectedSimulator);
-    console.log(`Launching ${simulatorFullName}...`);
-    try {
-      child_process.spawnSync('xcrun', ['simctl', 'boot', selectedSimulator.udid]);
-    } catch (e) {
-      throw new Error(
-        `Could not boot ${args.simulator} simulator. Is there already a simulator running? ` +
-        'Running multiple simulators is only supported from Xcode 9 and up. ' +
-        'Try closing the simulator or run the command again without specifying a simulator.'
-      );
+    if (!selectedSimulator.booted) {
+      const simulatorFullName = formattedDeviceName(selectedSimulator);
+      console.log(`Booting ${simulatorFullName}...`);
+      try {
+        child_process.execFileSync('xcrun', ['simctl', 'boot', selectedSimulator.udid]);
+      } catch (e) {
+        throw new Error(
+`Could not boot ${args.simulator} simulator. Is there already a simulator running?
+Running multiple simulators is only supported from Xcode 9 and up.
+Try closing the simulator or run the command again without specifying a simulator.`
+        );
+      }
     }
 
     buildProject(xcodeProject, selectedSimulator.udid, scheme, args.configuration, args.packager, args.verbose)


### PR DESCRIPTION
## Motivation

Since Xcode 9 you can run multiple simultaneously. And since I believe React Native advocates using the latest version of Xcode, we can safely remove this constraint.

## Test Plan

Updated the unit tests. Furthermore it can be found in the [Xcode release notes](https://developer.apple.com/library/content/documentation/DeveloperTools/Conceptual/WhatsNewXcode/xcode_9/xcode_9.html#//apple_ref/doc/uid/TP40004626-CH8-SW12) that multiple simulators are now supported.

This can be tested with the CLI by running `react-native run-ios` twice, but with a different `--simulator` flag, e.g.;

    react-native run-ios --simulator "iPhone SE"
    react-native run-ios --simulator "iPhone X"

## Release Notes

[IOS] [ENHANCEMENT] [local-cli/runIOS/findMatchingSimulator.js] - Allow running multiple simulators
