### PR TITLE
[Circle CI] Separate JavaScript lint/flow checks from tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,8 +96,15 @@ aliases:
   - &run-node-tests
     | 
       npm test -- --maxWorkers=2
+
+  - &run-lint-checks
+    | 
       npm run lint
+
+  - &run-flow-checks
+    | 
       npm run flow -- check
+
 
   - &filter-only-master-stable
     branches:
@@ -182,30 +189,22 @@ jobs:
       - run: *install-node-dependencies
       - save-cache: *save-node-cache
       - run: *run-node-tests
+      - run: *run-lint-checks
+      - run: *run-flow-checks
 
   # Runs JavaScript tests on Node 6
   test-js-node-6:
     <<: *defaults
     docker:
-      - image: circleci/node:6.11.0
+      - image: circleci/node:6
     steps:
       - checkout
       - restore-cache: *restore-node-cache
       - run: *install-node-dependencies
       - save-cache: *save-node-cache
       - run: *run-node-tests
-
-  # Runs JavaScript tests on Node 4
-  test-js-node-4:
-    <<: *defaults
-    docker:
-      - image: circleci/node:4.8.4
-    steps:
-      - checkout
-      - restore-cache: *restore-node-cache
-      - run: *install-node-dependencies
-      - save-cache: *save-node-cache
-      - run: *run-node-tests
+      - run: *run-lint-checks
+      - run: *run-flow-checks
 
   # Runs unit tests on iOS devices
   test-objc-ios:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -178,6 +178,19 @@ android_defaults: &android_defaults
 
 version: 2
 jobs:
+  # Runs JavaScript lint and flow checks
+  run-js-checks:
+    <<: *defaults
+    docker:
+      - image: circleci/node:8
+    steps:
+      - checkout
+      - restore-cache: *restore-node-cache
+      - run: *install-node-dependencies
+      - save-cache: *save-node-cache
+      - run: *run-lint-checks
+      - run: *run-flow-checks
+
   # Runs JavaScript tests on Node 8
   test-js-node-8:
     <<: *defaults
@@ -189,8 +202,6 @@ jobs:
       - run: *install-node-dependencies
       - save-cache: *save-node-cache
       - run: *run-node-tests
-      - run: *run-lint-checks
-      - run: *run-flow-checks
 
   # Runs JavaScript tests on Node 6
   test-js-node-6:
@@ -203,8 +214,6 @@ jobs:
       - run: *install-node-dependencies
       - save-cache: *save-node-cache
       - run: *run-node-tests
-      - run: *run-lint-checks
-      - run: *run-flow-checks
 
   # Runs unit tests on iOS devices
   test-objc-ios:
@@ -456,7 +465,11 @@ workflows:
   build:
     jobs:
 
-      # Test Javascript on Node 8 and 6
+      # Run lint and flow checks
+      - run-js-checks:
+          filters: *filter-ignore-gh-pages
+
+      # Test JavaScript on Node 8 and 6
       - test-js-node-8:
           filters: *filter-ignore-gh-pages
       - test-js-node-6:


### PR DESCRIPTION
This should help make it clearer, at a glance, which specific step is failing.

# Test Plan

Run on Circle. Workflows will now show that Node 8 JS tests are green, but Node 6 JS tests are not. Lint/flow checks are also not green. Previously, it would be necessary to open the two test-node workflows to investigate which particular test failed. Given these tests and checks tend to break often, the additional clarity would be helpful.

<img width="485" alt="screen shot 2017-12-20 at 9 40 07 am" src="https://user-images.githubusercontent.com/165856/34220526-ce3d3b26-e569-11e7-803f-0e4bf1090f2f.png">
