### PR TITLE
Fix crash on Android with TLSv1 disabled

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/modules/network/TLSSocketFactory.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/network/TLSSocketFactory.java
@@ -14,6 +14,7 @@ import java.net.Socket;
 import java.net.UnknownHostException;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
 
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSocket;
@@ -71,7 +72,14 @@ public class TLSSocketFactory extends SSLSocketFactory {
 
     private Socket enableTLSOnSocket(Socket socket) {
         if(socket != null && (socket instanceof SSLSocket)) {
-            ((SSLSocket)socket).setEnabledProtocols(new String[] {"TLSv1", "TLSv1.1", "TLSv1.2"});
+            SSLSocket sslSocket = ((SSLSocket)socket);
+            String[] supportedProtocols = sslSocket.getSupportedProtocols();
+
+            if (Arrays.asList(supportedProtocols).contains("TLSv1")) {
+              sslSocket.setEnabledProtocols(new String[] {"TLSv1", "TLSv1.1", "TLSv1.2"});
+            } else {
+              sslSocket.setEnabledProtocols(new String[] {"TLSv1.1", "TLSv1.2"});
+            }
         }
         return socket;
     }


### PR DESCRIPTION
## Motivation

Our application runs in an Android 4.2 environment where TLSv1 has been disabled for security compliance. The recent code change in #14245 enables TLSv1 in all environments, without first checking to see if that version of the protocol is supported. This causes an exception:

`FATAL EXCEPTION: OkHttp Dispatcher
java.lang.IllegalArgumentException: protocol TLSv1 is not supported
                                                                             at org.apache.harmony.xnet.provider.jsse.NativeCrypto.checkEnabledProtocols(NativeCrypto.java:569)
                                                                             at org.apache.harmony.xnet.provider.jsse.OpenSSLSocketImpl.setEnabledProtocols(OpenSSLSocketImpl.java:782)
                                                                             at com.facebook.react.modules.network.TLSSocketFactory.enableTLSOnSocket(TLSSocketFactory.java:74)
                                                                             at com.facebook.react.modules.network.TLSSocketFactory.createSocket(TLSSocketFactory.java:49)
<... remaining stack omitted for brevity...>`

## Test Plan

I rebuilt the app with a patched version of React Native 0.50, and it runs successfully.

## Related PRs

#14245

## Release Notes

 [ANDROID] [BUGFIX] [Network] - Enable TLSv1 only if supported by the OS