### PR TITLE
Do not use Node 8.x specific Stream.final

### DIFF
--- a/local-cli/__mocks__/fs.js
+++ b/local-cli/__mocks__/fs.js
@@ -347,9 +347,6 @@ fs.createWriteStream.mockImplementation(filePath => {
   const writeStream = new stream.Writable({
     write(chunk, encoding, callback) {
       this.__chunks.push(chunk);
-      callback();
-    },
-    final(callback) {
       node[path.basename(filePath)] = this.__chunks.join('');
       callback();
     },


### PR DESCRIPTION
grabbou: "This has been recently added to Node 8.x. Since it makes our tests to fail, I decided to
do a workaround that works for all the versions."

Originally patched in `0.52-stable` by grabbou

Fixes Node 6 JavaScript tests.