### PR TITLE
Fix Android WebView not displaying bundled assets

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebViewManager.java
@@ -18,6 +18,7 @@ import java.util.Locale;
 import java.util.Map;
 
 import android.content.ActivityNotFoundException;
+import android.content.Context;
 import android.content.Intent;
 import android.graphics.Bitmap;
 import android.graphics.Picture;
@@ -462,7 +463,7 @@ public class ReactWebViewManager extends SimpleViewManager<WebView> {
         return;
       }
       if (source.hasKey("uri")) {
-        String url = source.getString("uri");
+        String url = resolveSourceUri(view.getContext(), source.getString("uri"));
         String previousUrl = view.getUrl();
         if (previousUrl != null && previousUrl.equals(url)) {
           return;
@@ -620,6 +621,23 @@ public class ReactWebViewManager extends SimpleViewManager<WebView> {
       };
     }
     return mPictureListener;
+  }
+
+  protected String resolveSourceUri(Context context, String sourceUri) {
+    if (sourceUri != null && !sourceUri.contains(":/")) {
+      // The source is just a string, so it's probably a bundled resource
+      // which was copied into the app resource folder by the react native packager
+      // so try to find it
+      String[] resTypes = {"raw", "drawable"};
+      for (String resType : resTypes) {
+        int id = context.getResources().getIdentifier(sourceUri, resType, context.getPackageName());
+        if (id != 0) {
+          return "file:///android_res/" + resType + "/" + sourceUri;
+        }
+      }
+    }
+
+    return sourceUri;
   }
 
   protected static void dispatchEvent(WebView webView, Event event) {


### PR DESCRIPTION
## Motivation

On Android, when using `WebView` with `source={require('./page.html')}` it displays a blank page on release builds (or when `bundleInDebug: true` is set under `project.ext.react` in `android/app/build.gradle`).

The bug is not present on iOS (debug and release) or on Android in debug mode.

The bug was reported several times:
- facebook/react-native#7924
- facebook/react-native#16133

The reason it happens is because on release builds, the native ReactWebView loads the `uri` of the bundled asset, which in this case is just the resource name:

```javascript
{ 
  __packager_asset: true,
  width: undefined,
  height: undefined,
  uri: 'page',
  scale: 1
}
```

The fix I'm proposing resolves the resource name to get a valid url which can be loaded successfully by the `ReactWebView`.

I've also investigated a fix for this on the JS side but it would require augmenting the `resolveAssetSource` method so it works for any type of asset for the `WebView` (html, svg, png, etc) and still remains compatible when `resolveAssetSource` is used within the `Image` component.

Let me know what you think.

## Test Plan

- Setup new React Native project: `react-native init WebViewTest`
- Create `page.html`
```html
<html>
    <head>
        <title>Title</title>
    </head>
    <body>
        <h1>Hello World</h1>
    </body>
</html>
```
- Modify `App.js`
```jsx
import React, { Component } from 'react';
import {
  AppRegistry,
  StyleSheet,
  WebView,
  View
} from 'react-native';

export default class WebViewTest extends Component {
  render() {
    return (
      <View style={styles.container}>
        <WebView
          scalesPageToFit={true}
          source={require('./page.html')}
        />
      </View>
    );
  }
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
  },
});
```
- Build Release APK
- Run On Android
- `Hello World` should be displayed

## Related PRs

N/A

## Release Notes

[ANDROID] [BUGFIX] [WebView] - Make source={require('./page.html')} work in release mode