### PR TITLE
Add top offset for react loading view on Kitkat

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevLoadingViewController.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevLoadingViewController.java
@@ -12,9 +12,12 @@ package com.facebook.react.devsupport;
 import android.app.Activity;
 import android.content.Context;
 import android.graphics.Color;
+import android.graphics.Rect;
+import android.os.Build;
 import android.view.Gravity;
 import android.view.LayoutInflater;
 import android.view.ViewGroup;
+import android.view.Window;
 import android.widget.PopupWindow;
 import android.widget.TextView;
 
@@ -53,7 +56,7 @@ public class DevLoadingViewController {
   }
 
   public void showMessage(final String message, final int color, final int backgroundColor) {
-    if (!sEnabled ) {
+    if (!sEnabled) {
       return;
     }
 
@@ -147,6 +150,16 @@ public class DevLoadingViewController {
       return;
     }
 
+    int topOffset = 0;
+    if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.KITKAT) {
+      // On Android SDK <= 19 PopupWindow#showAtLocation uses absolute screen position. In order for
+      // loading view to be placed below status bar (if the status bar is present) we need to pass
+      // an appropriate Y offset.
+      Rect rectangle = new Rect();
+      currentActivity.getWindow().getDecorView().getWindowVisibleDisplayFrame(rectangle);
+      topOffset = rectangle.top;
+    }
+
     mDevLoadingPopup = new PopupWindow(
             mDevLoadingView,
             ViewGroup.LayoutParams.MATCH_PARENT,
@@ -156,8 +169,9 @@ public class DevLoadingViewController {
     mDevLoadingPopup.showAtLocation(
             currentActivity.getWindow().getDecorView(),
             Gravity.NO_GRAVITY,
+
             0,
-            0);
+            topOffset);
   }
 
   private void hideInternal() {


### PR DESCRIPTION
## Motivation

This PR fixes the problem with dev loading view on KitKat and older Android devices after #16596

## Test Plan

Install RNTester app on Android API 19 or lower device. See green loading view show up under status bar. Do the same with full screen theme set and see it show up correctly at the top of the screen.
Verify the green loading bar displays correctly on devices with API > 19 too.

## Related PRs

This fixes an issue introduced in #16596

## Release Notes

[ANDROID][MINOR][DevSupport] - Fix green dev loading bar on Android Kitkat and below
