### PR TITLE
Add proptypes for scrollview drag start & end handlers

### DIFF
--- a/Libraries/Components/ScrollView/ScrollView.js
+++ b/Libraries/Components/ScrollView/ScrollView.js
@@ -257,6 +257,15 @@ const ScrollView = createReactClass({
      */
     onScroll: PropTypes.func,
     /**
+     * Called when the user begins to drag the scroll view.
+     */
+    onScrollBeginDrag: PropTypes.func,
+    /**
+     * Called when the user stops dragging the scroll view and it either stops
+     * or begins to glide.
+     */
+    onScrollEndDrag: PropTypes.func,
+    /**
      * Called when scrollable content view of the ScrollView changes.
      *
      * Handler function is passed the content width and content height as parameters:


### PR DESCRIPTION
## Motivation

`ScrollView` has a bunch of `onFoo` handlers for scrolling-related events, most of which have a proptype defined and are documented. However, `onScrollBeginDrag` and `onScrollEndDrag` do not currently have a proptype and are not currently documented (as noted at https://stackoverflow.com/a/41793747/1709587). It seems reasonable to bring consistency and to provide documentation of these otherwise hard-to-discover props.

## Test Plan

I haven't added or run any tests, and don't plan to do so (beyond waiting and seeing that no existing checks fail in CircleCI).

## Related PRs

I have also created a PR to update the documentation at https://github.com/facebook/react-native-website/pull/99

## <s>Release Notes</s>

*(None needed; this isn't a functionality change.)*