### PR TITLE
Keep the ignored files during the upgrade process

### DIFF
--- a/react-native-git-upgrade/cliEntry.js
+++ b/react-native-git-upgrade/cliEntry.js
@@ -303,7 +303,7 @@ async function run(requestedVersion, cliArgs) {
     await exec('git init', verbose);
 
     log.info('Save current .gitignore file');
-    await copyCurrentGitIgnoreFile(tmpDir);
+    copyCurrentGitIgnoreFile(tmpDir);
 
     log.info('Add all files to commit');
     await exec('git add .', verbose);

--- a/react-native-git-upgrade/cliEntry.js
+++ b/react-native-git-upgrade/cliEntry.js
@@ -147,6 +147,28 @@ function configureGitEnv(tmpDir) {
   process.env.GIT_WORK_TREE = '.';
 }
 
+function copyCurrentGitIgnoreFile(tmpDir) {
+  /*
+   * The user may have added new files or directories in the .gitignore file.
+   * We need to keep those files ignored during the process, otherwise they
+   * will be deleted.
+   * See https://github.com/facebook/react-native/issues/12237
+   */
+  try {
+    const gitignorePath = path.resolve(process.cwd(), '.gitignore');
+    const repoExcludePath = path.resolve(tmpDir, process.env.GIT_DIR, 'info/exclude');
+    const content = fs.readFileSync(gitignorePath, 'utf8');
+    fs.appendFileSync(repoExcludePath, content);
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      log.info('No .gitignore file found, this step is a no-op');
+      return;
+    }
+
+    throw err;
+  }
+}
+
 function generateTemplates(generatorDir, appName, verbose) {
   try {
     const yeomanGeneratorEntryPoint = path.resolve(generatorDir, 'index.js');
@@ -277,8 +299,11 @@ async function run(requestedVersion, cliArgs) {
     log.info('Configure Git environment');
     configureGitEnv(tmpDir);
 
-    log.info('Init Git repository');
+    log.info('Init temporary Git repository');
     await exec('git init', verbose);
+
+    log.info('Save current .gitignore file');
+    await copyCurrentGitIgnoreFile(tmpDir);
 
     log.info('Add all files to commit');
     await exec('git add .', verbose);


### PR DESCRIPTION
## Motivation

This PR fixes the issue #12237 relative to react-native-git-upgrade.

When the user adds new files to the .gitignore file, those files are deleted during the upgrade process because it starts by creating a fresh .gitignore file without user's modification, so the user's ignored files are no longer ignored and they are deleted during the upgrading process.

The best solution I've found to keep the user's ignored files... ignored, consists in appending the content of the .gitignore file in the `<TEMP DIR>/.git-rn/info/exclude` file.
The user's ignored files are now ignored at the repository level, they no longer interfere with the upgrade process.

Reminder: The tool uses a temporary local Git repository generated on the fly, so we can do whatever we want in it.

## Test Plan

- Publish react-native-git-upgrade to sinopia
- `npm install -g react-native-git-upgrade`
- Init a new project with an old version: `react-native init MyApp --version=0.50.0`
- Create a new file named `dummy-ignored-file.json` in the project's root
- Append `dummy-ignored-file.json` to the `.gitignore` file
- Run `react-native-git-upgrade`

👉 The `dummy-ignored-file.json` is not deleted.

## Release Notes

[CLI][BUGFIX][react-native-git-upgrade] - Keep the user's ignored files while upgrading
<!--
Help reviewers and the release process by writing your own release notes

**INTERNAL and MINOR tagged notes will not be included in the next version's final release notes.**

  CATEGORY
[----------]        TYPE
[ CLI      ]   [-------------]      LOCATION
[ DOCS     ]   [ BREAKING    ]   [-------------]
[ GENERAL  ]   [ BUGFIX      ]   [-{Component}-]
[ INTERNAL ]   [ ENHANCEMENT ]   [ {File}      ]
[ IOS      ]   [ FEATURE     ]   [ {Directory} ]   |-----------|
[ ANDROID  ]   [ MINOR       ]   [ {Framework} ] - | {Message} |
[----------]   [-------------]   [-------------]   |-----------|

[CATEGORY] [TYPE] [LOCATION] - MESSAGE

 EXAMPLES:

 [IOS] [BREAKING] [FlatList] - Change a thing that breaks other things
 [ANDROID] [BUGFIX] [TextInput] - Did a thing to TextInput
 [CLI] [FEATURE] [local-cli/info/info.js] - CLI easier to do things with
 [DOCS] [BUGFIX] [GettingStarted.md] - Accidentally a thing/word
 [GENERAL] [ENHANCEMENT] [Yoga] - Added new yoga thing/position
 [INTERNAL] [FEATURE] [./scripts] - Added thing to script that nobody will see
-->

