### PR TITLE
Android WebView Bugfix: loadUrl() ignores default encoding

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebViewManager.java
@@ -453,12 +453,11 @@ public class ReactWebViewManager extends SimpleViewManager<WebView> {
     if (source != null) {
       if (source.hasKey("html")) {
         String html = source.getString("html");
+        String baseUrl = null;
         if (source.hasKey("baseUrl")) {
-          view.loadDataWithBaseURL(
-              source.getString("baseUrl"), html, HTML_MIME_TYPE, HTML_ENCODING, null);
-        } else {
-          view.loadData(html, HTML_MIME_TYPE, HTML_ENCODING);
+          baseUrl = source.getString("baseUrl");
         }
+        view.loadDataWithBaseURL(baseUrl, html, HTML_MIME_TYPE, HTML_ENCODING, null);
         return;
       }
       if (source.hasKey("uri")) {


### PR DESCRIPTION
Closes #17385 

The loadUrl() method ignores the default encoding on Android KitKat.

## Motivation
I manage to reproduce the issue described by #17385 using Android KitKat (emulator).

## Test Plan
I tested by modifying the RNTester project with the changes below. I have tested on Android KitKat (emulator) and Android Oreo 8.1 (device - Nexus 6p).

```diff
 <html>
   <head>
     <title>Hello Static World</title>
-    <meta http-equiv="content-type" content="text/html; charset=utf-8">
     <meta name="viewport" content="width=320, user-scalable=no">
     <style type="text/css">
       body {
@@ -391,7 +390,7 @@ const HTML = `
     </style>
   </head>
   <body>
-    <h1>Hello Static World</h1>
+    <h1>Hello Static World olá</h1>
   </body>
 </html>
```

## Release Notes
[ANDROID] [BUGFIX] [WebView] - Default encoding for html content on older Android versions
