### PR TITLE
Fix: Avoid contentInsets overwrites scrollIndicatorInsets on iOS #13025

### DIFF
--- a/React/Views/ScrollView/RCTScrollView.m
+++ b/React/Views/ScrollView/RCTScrollView.m
@@ -394,6 +394,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
     _automaticallyAdjustContentInsets = YES;
     _DEPRECATED_sendUpdatedChildFrames = NO;
     _contentInset = UIEdgeInsetsZero;
+    _scrollIndicatorInsets = UIEdgeInsetsZero;
     _contentSize = CGSizeZero;
     _lastClippedToRect = CGRectNull;
 
@@ -552,6 +553,10 @@ static inline void RCTApplyTranformationAccordingLayoutDirection(UIView *view, U
                     withScrollView:_scrollView
                       updateOffset:NO];
 
+  if (!UIEdgeInsetsEqualToEdgeInsets(scrollIndicatorInsets, _scrollIndicatorInsets)) {
+     _scrollView.scrollIndicatorInsets = scrollIndicatorInsets;
+  }
+  
   _scrollView.contentOffset = contentOffset;
 }
 


### PR DESCRIPTION
Fix to avoid contentInsets always overwrites scrollIndicatorInsets of ScrollView/ListView.
According to issue #13025 https://github.com/facebook/react-native/blob/a8391bde7d757d01521a6d12170fb9090c17a6a0/React/Views/RCTView.m#L299
always overide `scrollIndicatorInsets` when called and only works when `contentInsets` is not set.
We only need to worry about when `contentInsets` is set, We only have to check and reset it after `autoAdjustInsetsForView` is called.

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes. 

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to React Native here: http://facebook.github.io/react-native/docs/contributing.html

Happy contributing!

-->

## Motivation

Fix: https://github.com/facebook/react-native/issues/13025

## Test Plan
![](http://i.giphy.com/26DMZ1UCP7zKw2E3S.gif) ![](http://i.giphy.com/xUOwGjmAJ68E5Cqcso.gif)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/react-native-website, and link to your PR here.)

## Release Notes
<!--
Help reviewers and the release process by writing your own release notes

**INTERNAL and MINOR tagged notes will not be included in the next version's final release notes.**

  CATEGORY
[----------]        TYPE
[ CLI      ]   [-------------]      LOCATION
[ DOCS     ]   [ BREAKING    ]   [-------------]
[ GENERAL  ]   [ BUGFIX      ]   [-{Component}-]
[ INTERNAL ]   [ ENHANCEMENT ]   [ {File}      ]
[ IOS      ]   [ FEATURE     ]   [ {Directory} ]   |-----------|
[ ANDROID  ]   [ MINOR       ]   [ {Framework} ] - | {Message} |
[----------]   [-------------]   [-------------]   |-----------|

[CATEGORY] [TYPE] [LOCATION] - MESSAGE

 EXAMPLES:

 [IOS] [BREAKING] [FlatList] - Change a thing that breaks other things
 [ANDROID] [BUGFIX] [TextInput] - Did a thing to TextInput
 [CLI] [FEATURE] [local-cli/info/info.js] - CLI easier to do things with
 [DOCS] [BUGFIX] [GettingStarted.md] - Accidentally a thing/word
 [GENERAL] [ENHANCEMENT] [Yoga] - Added new yoga thing/position
 [INTERNAL] [FEATURE] [./scripts] - Added thing to script that nobody will see
-->
