### PR TITLE
Update terminal title to 'Metro Bundler'

### DIFF
--- a/scripts/launchPackager.bat
+++ b/scripts/launchPackager.bat
@@ -6,7 +6,7 @@
 :: of patent rights can be found in the PATENTS file in the same directory.
 
 @echo off
-title React Packager
+title Metro Bundler
 node "%~dp0..\local-cli\cli.js" start
 pause
 exit

--- a/scripts/launchPackager.command
+++ b/scripts/launchPackager.command
@@ -8,7 +8,7 @@
 # of patent rights can be found in the PATENTS file in the same directory.
 
 # Set terminal title
-echo -en "\033]0;React Packager\a"
+echo -en "\033]0;Metro Bundler\a"
 clear
 
 THIS_DIR=$(dirname "$0")


### PR DESCRIPTION
## Motivation

I noticed in v0.50.0 all mentions of 'packager' were updated to 'Metro Bundler':

https://github.com/facebook/react-native/commit/12eb04b2364102a6679e3dc6fb0fd4d62be0ae00

It seems like command which launches the bundler still sets the terminal title to 'React Packager'. This PR simply updates the title from 'React Packager' to 'Metro Bundler'.
 
## Test Plan

Run `scripts/launchPackager.command`/`scripts/launchPackager.bat` and check title:

<img width="907" alt="screen shot 2018-01-05 at 14 02 53" src="https://user-images.githubusercontent.com/754498/34612337-3e93e8ca-f221-11e7-98f9-c5190674868e.png">

## Release Notes

[GENERAL] [ENHANCEMENT] [./scripts]