### PR TITLE
Fix for 17348

### DIFF
--- a/Libraries/Components/Subscribable.js
+++ b/Libraries/Components/Subscribable.js
@@ -30,7 +30,7 @@ Subscribable.Mixin = {
   },
 
   componentWillUnmount: function() {
-    this._subscribableSubscriptions.forEach(
+    this._subscribableSubscriptions && this._subscribableSubscriptions.forEach(
       (subscription) => subscription.remove()
     );
     this._subscribableSubscriptions = null;


### PR DESCRIPTION
Fixes https://github.com/facebook/react-native/issues/17348 - Unhandled JS Exception: TypeError: undefined is not an object (evaluating 'this._subscribableSubscriptions.forEach')

## Test Plan

Same existing tests applies, just added extra checks.

## Release Notes

This patch fixes the issue https://github.com/facebook/react-native/issues/17348

 [ANDROID] [BUGFIX] [Subscribable] - Fix for https://github.com/facebook/react-native/issues/17348
 [IOS] [BUGFIX] [Subscribable] - Fix for https://github.com/facebook/react-native/issues/17348
