### PR TITLE
Use app name from app.json for registering application

### DIFF
--- a/local-cli/templates/HelloWorld/index.js
+++ b/local-cli/templates/HelloWorld/index.js
@@ -1,5 +1,5 @@
 import { AppRegistry } from 'react-native';
 import App from './App';
-import { name as appName} from './app.json';
+import { name as appName } from './app.json';
 
 AppRegistry.registerComponent(appName, () => App);

--- a/local-cli/templates/HelloWorld/index.js
+++ b/local-cli/templates/HelloWorld/index.js
@@ -1,4 +1,5 @@
 import { AppRegistry } from 'react-native';
 import App from './App';
+import { name as appName} from './app.json'
 
-AppRegistry.registerComponent('HelloWorld', () => App);
+AppRegistry.registerComponent(appName, () => App);

--- a/local-cli/templates/HelloWorld/index.js
+++ b/local-cli/templates/HelloWorld/index.js
@@ -1,5 +1,5 @@
 import { AppRegistry } from 'react-native';
 import App from './App';
-import { name as appName} from './app.json'
+import { name as appName} from './app.json';
 
 AppRegistry.registerComponent(appName, () => App);


### PR DESCRIPTION
## Motivation

Currently when we change the app name in `app.json`, run `react-native eject` and then run the application, we get the following error `Application HelloWorld2 has not been registered`

<img src="https://user-images.githubusercontent.com/6805530/34646396-9a68ccd0-f38c-11e7-9a49-9f985dc20f14.png" width="33%" />

This PR picks up the app name from app.json while registering the application, which prevents the additional step for the user to change the app name while registering in the `index.js`

## Test Plan

Tested using sinopia. The new app generated with the `react-native init HelloWorld` contains the changes made.

## Release Notes

[CLI] [ENHANCEMENT] [index.js] - App name picked from from app.json for registering application.