### PR TITLE
Fix documentation links

### DIFF
--- a/react-native-git-upgrade/README.md
+++ b/react-native-git-upgrade/README.md
@@ -6,7 +6,7 @@ It uses Git under the hood to automatically resolve merge conflicts in project t
 
 ## Usage
 
-See the [Upgrading docs](https://facebook.github.io/react-native/releases/next/docs/upgrading.html) on the React Native website.
+See the [Upgrading docs](https://facebook.github.io/react-native/docs/upgrading.html) on the React Native website.
 
 Basic usage:
 


### PR DESCRIPTION
Old link gives `404 File not found`.

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes. 

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to React Native here: http://facebook.github.io/react-native/docs/contributing.html

Happy contributing!

-->
