### PR TITLE
[WIP] Add `disableYellowBox` to `YellowBox` API

### DIFF
--- a/Libraries/ReactNative/YellowBox.js
+++ b/Libraries/ReactNative/YellowBox.js
@@ -358,6 +358,10 @@ class YellowBox extends React.Component<
     });
   }
 
+  static disableYellowBox(val: boolean): void {
+    disableYellowBox = val;
+  }
+
   componentDidMount() {
     let scheduled = null;
     this._listener = _warningEmitter.addListener('warning', warningMap => {

--- a/Libraries/ReactNative/YellowBox.js
+++ b/Libraries/ReactNative/YellowBox.js
@@ -38,7 +38,7 @@ type WarningInfo = {
 const _warningEmitter = new EventEmitter();
 const _warningMap: Map<string, WarningInfo> = new Map();
 const IGNORED_WARNINGS: Array<string> = [];
-const DISABLE_YELLOW_BOX: boolean = false;
+let DISABLE_YELLOW_BOX: boolean = false;
 
 /**
  * YellowBox renders warnings at the bottom of the app being developed.

--- a/Libraries/ReactNative/YellowBox.js
+++ b/Libraries/ReactNative/YellowBox.js
@@ -38,6 +38,7 @@ type WarningInfo = {
 const _warningEmitter = new EventEmitter();
 const _warningMap: Map<string, WarningInfo> = new Map();
 const IGNORED_WARNINGS: Array<string> = [];
+const DISABLE_YELLOW_BOX: boolean = false;
 
 /**
  * YellowBox renders warnings at the bottom of the app being developed.
@@ -84,6 +85,8 @@ if (__DEV__) {
   };
 
   if (Platform.isTesting) {
+    DISABLE_YELLOW_BOX = true;
+    // DEPRECATED
     (console: any).disableYellowBox = true;
   }
 
@@ -107,6 +110,10 @@ function sprintf(format, ...args) {
 }
 
 function updateWarningMap(...args): void {
+  if (DISABLE_YELLOW_BOX) {
+    return;
+  }
+  // DEPRECATED
   if (console.disableYellowBox) {
     return;
   }
@@ -381,6 +388,10 @@ class YellowBox extends React.Component<
   }
 
   render() {
+    if (DISABLE_YELLOW_BOX || this.state.warningMap.size === 0) {
+      return null;
+    }
+    // DEPRECATED
     if (console.disableYellowBox || this.state.warningMap.size === 0) {
       return null;
     }

--- a/Libraries/ReactNative/YellowBox.js
+++ b/Libraries/ReactNative/YellowBox.js
@@ -358,8 +358,8 @@ class YellowBox extends React.Component<
     });
   }
 
-  static disableYellowBox(val: boolean): void {
-    disableYellowBox = val;
+  static disableYellowBox(disableYellowBox: boolean): void {
+    DISABLE_YELLOW_BOX = disableYellowBox;
   }
 
   componentDidMount() {


### PR DESCRIPTION
## Motivation

0.52.0 deprecated `console.ignoredYellowBox`; while investigating that, I found the related feature of disabling the component entirely using `console.disableYellowBox`. It seems like both should be present in the **YellowBox** api together, not just one.

## Test Plan

Check with local build. More details coming soon.

## Related PRs

facebook/react-native@a974c14

## Release Notes
