### PR TITLE
Android: Adjust border radius to maximum of half the smallest side

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewBackgroundDrawable.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewBackgroundDrawable.java
@@ -277,7 +277,10 @@ public class ReactViewBackgroundDrawable extends Drawable {
   }
 
   public float getFullBorderRadius() {
-    return YogaConstants.isUndefined(mBorderRadius) ? 0 : mBorderRadius;
+    float desiredRadius = YogaConstants.isUndefined(mBorderRadius) ? 0 : mBorderRadius;
+    float minSide = Math.min(getBounds().height(), getBounds().width());
+    float radius = Math.min(minSide / 2, desiredRadius);
+    return radius;
   }
 
   public float getBorderRadius(final BorderRadiusLocation location) {


### PR DESCRIPTION
## Motivation
Currently, if a View has a border radius set to larger than the size of the View, and there s a borderWidth set, there is a very serious performance problem on Android.

## Test Plan

This can be verified easily by making any view with a thin border, and watching the Android GPU performance or memory as it is rendered. Native memory allocation will immediately max out, and the GPU render profiler will look like this:

![screenshot_1515418843](https://user-images.githubusercontent.com/8819594/34768660-2f92cca6-f604-11e7-953b-773503e279e3.png)

Memory:
![screen shot 2018-01-08 at 16 44 25](https://user-images.githubusercontent.com/8819594/34768668-34b5f00a-f604-11e7-9661-cc386f10f10d.png)

With the fix, these problems disappear.

## Release Notes
 [ANDROID] [BUGFIX][View] - Treat larger than possible border radius as meaning 50% of the smallest side
