### PR TITLE
Android: Fix crash when perf monitor does not run within UI thread.

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/DebugOverlayController.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/DebugOverlayController.java
@@ -99,12 +99,12 @@ import javax.annotation.Nullable;
     UiThreadUtil.runOnUiThread(new Runnable() {
       @Override
       public void run() {
-        if (!permissionCheck(mReactContext)) {
-          FLog.d(ReactConstants.TAG, "Wait for overlay permission to be set");
+        if (mFPSDebugViewContainer != null) {
           return;
         }
 
-        if (mFPSDebugViewContainer != null) {
+        if (!permissionCheck(mReactContext)) {
+          FLog.d(ReactConstants.TAG, "Wait for overlay permission to be set");
           return;
         }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/DebugOverlayController.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/DebugOverlayController.java
@@ -21,7 +21,6 @@ import android.widget.FrameLayout;
 
 import com.facebook.common.logging.FLog;
 import com.facebook.react.bridge.ReactContext;
-import com.facebook.react.bridge.UiThreadUtil;
 import com.facebook.react.common.ReactConstants;
 
 import javax.annotation.Nullable;
@@ -96,43 +95,33 @@ import javax.annotation.Nullable;
   }
 
   private void showFpsDebugView() {
-    UiThreadUtil.runOnUiThread(new Runnable() {
-      @Override
-      public void run() {
-        if (mFPSDebugViewContainer != null) {
-          return;
-        }
+    if (mFPSDebugViewContainer != null) {
+      return;
+    }
 
-        if (!permissionCheck(mReactContext)) {
-          FLog.d(ReactConstants.TAG, "Wait for overlay permission to be set");
-          return;
-        }
+    if (!permissionCheck(mReactContext)) {
+      FLog.d(ReactConstants.TAG, "Wait for overlay permission to be set");
+      return;
+    }
 
-        mFPSDebugViewContainer = new FpsView(mReactContext);
-        WindowManager.LayoutParams params = new WindowManager.LayoutParams(
-          WindowManager.LayoutParams.MATCH_PARENT,
-          WindowManager.LayoutParams.MATCH_PARENT,
-          WindowOverlayCompat.TYPE_SYSTEM_OVERLAY,
-          WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE
-              | WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE,
-          PixelFormat.TRANSLUCENT);
-        mWindowManager.addView(mFPSDebugViewContainer, params);
-      }
-    });
+    mFPSDebugViewContainer = new FpsView(mReactContext);
+    WindowManager.LayoutParams params = new WindowManager.LayoutParams(
+      WindowManager.LayoutParams.MATCH_PARENT,
+      WindowManager.LayoutParams.MATCH_PARENT,
+      WindowOverlayCompat.TYPE_SYSTEM_OVERLAY,
+      WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE
+        | WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE,
+      PixelFormat.TRANSLUCENT);
+    mWindowManager.addView(mFPSDebugViewContainer, params);
   }
 
   private void hideFpsDebugView() {
-    UiThreadUtil.runOnUiThread(new Runnable() {
-      @Override
-      public void run() {
-        if (mFPSDebugViewContainer == null) {
-          return;
-        }
-        mFPSDebugViewContainer.removeAllViews();
-        mWindowManager.removeView(mFPSDebugViewContainer);
-        mFPSDebugViewContainer = null;
-      }
-    });
+    if (mFPSDebugViewContainer == null) {
+      return;
+    }
+    mFPSDebugViewContainer.removeAllViews();
+    mWindowManager.removeView(mFPSDebugViewContainer);
+    mFPSDebugViewContainer = null;
   }
 
   public void setFpsDebugViewVisible(boolean fpsDebugViewVisible) {

--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/DebugOverlayController.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/DebugOverlayController.java
@@ -95,30 +95,51 @@ import javax.annotation.Nullable;
     mWindowManager = (WindowManager) reactContext.getSystemService(Context.WINDOW_SERVICE);
   }
 
-  public void setFpsDebugViewVisible(final boolean fpsDebugViewVisible) {
+  private void showFpsDebugView() {
     UiThreadUtil.runOnUiThread(new Runnable() {
       @Override
       public void run() {
-        if (fpsDebugViewVisible && mFPSDebugViewContainer == null) {
-          if (!permissionCheck(mReactContext)) {
-            FLog.d(ReactConstants.TAG, "Wait for overlay permission to be set");
-            return;
-          }
-          mFPSDebugViewContainer = new FpsView(mReactContext);
-          WindowManager.LayoutParams params = new WindowManager.LayoutParams(
-            WindowManager.LayoutParams.MATCH_PARENT,
-            WindowManager.LayoutParams.MATCH_PARENT,
-            WindowOverlayCompat.TYPE_SYSTEM_OVERLAY,
-            WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE
-              | WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE,
-            PixelFormat.TRANSLUCENT);
-          mWindowManager.addView(mFPSDebugViewContainer, params);
-        } else if (!fpsDebugViewVisible && mFPSDebugViewContainer != null) {
-          mFPSDebugViewContainer.removeAllViews();
-          mWindowManager.removeView(mFPSDebugViewContainer);
-          mFPSDebugViewContainer = null;
+        if (!permissionCheck(mReactContext)) {
+          FLog.d(ReactConstants.TAG, "Wait for overlay permission to be set");
+          return;
         }
+
+        if (mFPSDebugViewContainer != null) {
+          return;
+        }
+
+        mFPSDebugViewContainer = new FpsView(mReactContext);
+        WindowManager.LayoutParams params = new WindowManager.LayoutParams(
+          WindowManager.LayoutParams.MATCH_PARENT,
+          WindowManager.LayoutParams.MATCH_PARENT,
+          WindowOverlayCompat.TYPE_SYSTEM_OVERLAY,
+          WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE
+              | WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE,
+          PixelFormat.TRANSLUCENT);
+        mWindowManager.addView(mFPSDebugViewContainer, params);
       }
     });
+  }
+
+  private void hideFpsDebugView() {
+    UiThreadUtil.runOnUiThread(new Runnable() {
+      @Override
+      public void run() {
+        if (mFPSDebugViewContainer == null) {
+          return;
+        }
+        mFPSDebugViewContainer.removeAllViews();
+        mWindowManager.removeView(mFPSDebugViewContainer);
+        mFPSDebugViewContainer = null;
+      }
+    });
+  }
+
+  public void setFpsDebugViewVisible(boolean fpsDebugViewVisible) {
+    if (fpsDebugViewVisible) {
+      showFpsDebugView();
+    } else {
+      hideFpsDebugView();
+    }
   }
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerImpl.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerImpl.java
@@ -710,13 +710,13 @@ public class DevSupportManagerImpl implements
 
     mCurrentContext = reactContext;
 
-    // Recreate debug overlay controller with new CatalystInstance object
-    if (mDebugOverlayController != null) {
-      mDebugOverlayController.setFpsDebugViewVisible(false);
-    }
-    if (reactContext != null) {
-      mDebugOverlayController = new DebugOverlayController(reactContext);
-    }
+    // Recreate debug overlay controller with new CatalystInstance object onto Ui thread
+    UiThreadUtil.runOnUiThread(new Runnable() {
+        @Override
+        public void run() {
+          recreateDebugOverlayController();
+        }
+      });
 
     if (mDevSettings.isHotModuleReplacementEnabled() && mCurrentContext != null) {
       try {
@@ -731,6 +731,17 @@ public class DevSupportManagerImpl implements
     }
 
     reloadSettings();
+  }
+
+  private void recreateDebugOverlayController() {
+    UiThreadUtil.assertOnUiThread();
+
+    if (mDebugOverlayController != null) {
+      mDebugOverlayController.setFpsDebugViewVisible(false);
+    }
+    if (mCurrentContext != null) {
+      mDebugOverlayController = new DebugOverlayController(mCurrentContext);
+    }
   }
 
   @Override


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes. 

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to React Native here: http://facebook.github.io/react-native/docs/contributing.html

Happy contributing!

-->

## Motivation

Application crash when FpsDebugView(Perf monitor) does not run within UI Thread.
#16042, and [this comment](https://github.com/facebook/react-native/issues/16546#issuecomment-355214148) are relative issue.
```
E/AndroidRuntime(17714): android.view.ViewRootImpl$CalledFromWrongThreadException: Only the original thread that created a view hierarchy can touch its views.
...
E/AndroidRuntime(17714): at com.facebook.react.devsupport.DebugOverlayController.setFpsDebugViewVisible(DebugOverlayController.java:49
```
I think that it will be possible to reproduce when move the task that updates the UI onto the another thread. (Android Main Thread <> JS Thread?).
So I have changed the code that create FpsDebugView to work only within the UI Thread. 

## Test Plan

1. Turn on Perf monitor.
2. Open dev menu, and click "reload"
3. Move the task that updates the UI onto the another thread.

## Release Notes

[ANDROID] [BUGFIX] [Devtools] - Fix crash when perf monitor does not run within UI thread.

<!--
Help reviewers and the release process by writing your own release notes

**INTERNAL and MINOR tagged notes will not be included in the next version's final release notes.**

  CATEGORY
[----------]        TYPE
[ CLI      ]   [-------------]      LOCATION
[ DOCS     ]   [ BREAKING    ]   [-------------]
[ GENERAL  ]   [ BUGFIX      ]   [-{Component}-]
[ INTERNAL ]   [ ENHANCEMENT ]   [ {File}      ]
[ IOS      ]   [ FEATURE     ]   [ {Directory} ]   |-----------|
[ ANDROID  ]   [ MINOR       ]   [ {Framework} ] - | {Message} |
[----------]   [-------------]   [-------------]   |-----------|

[CATEGORY] [TYPE] [LOCATION] - MESSAGE

 EXAMPLES:

 [IOS] [BREAKING] [FlatList] - Change a thing that breaks other things
 [ANDROID] [BUGFIX] [TextInput] - Did a thing to TextInput
 [CLI] [FEATURE] [local-cli/info/info.js] - CLI easier to do things with
 [DOCS] [BUGFIX] [GettingStarted.md] - Accidentally a thing/word
 [GENERAL] [ENHANCEMENT] [Yoga] - Added new yoga thing/position
 [INTERNAL] [FEATURE] [./scripts] - Added thing to script that nobody will see
-->