### PR TITLE
iOS: Fix Crash when CameraRoll is getting assets from iCloud and no filename is provided. #13671

### DIFF
--- a/Libraries/CameraRoll/RCTCameraRollManager.m
+++ b/Libraries/CameraRoll/RCTCameraRollManager.m
@@ -199,7 +199,7 @@ RCT_EXPORT_METHOD(getPhotos:(NSDictionary *)params
               @"group_name": [group valueForProperty:ALAssetsGroupPropertyName],
               @"image": @{
                 @"uri": uri,
-                @"filename" : filename,
+                @"filename" : filename ? filename : @"",
                 @"height": @(dimensions.height),
                 @"width": @(dimensions.width),
                 @"isStored": @YES,

--- a/Libraries/CameraRoll/RCTCameraRollManager.m
+++ b/Libraries/CameraRoll/RCTCameraRollManager.m
@@ -199,7 +199,7 @@ RCT_EXPORT_METHOD(getPhotos:(NSDictionary *)params
               @"group_name": [group valueForProperty:ALAssetsGroupPropertyName],
               @"image": @{
                 @"uri": uri,
-                @"filename" : filename ? filename : @"",
+                @"filename" : filename ?: [NSNull null],
                 @"height": @(dimensions.height),
                 @"width": @(dimensions.width),
                 @"isStored": @YES,


### PR DESCRIPTION
## Motivation

RCTCameraRollManager.m crashes when there is no filename provided for the asset (usually from iCloud). #13671

## Test Plan

Tested on real device with iCloud library using the library without and after my fix. It worked after my changes.

## Release Notes
[IOS] [BUGFIX] [CameraRoll] - Changed the filename if nil to be empty when the asset is coming from iCloud.