### PR TITLE
All android logs are dispatched through FLog java class

### DIFF
--- a/ReactAndroid/src/main/jni/first-party/fb/log.cpp
+++ b/ReactAndroid/src/main/jni/first-party/fb/log.cpp
@@ -26,8 +26,9 @@ int fb_printLog(int prio, const char *tag,  const char *fmt, ...) {
   va_end(va_args);
   if (gLogHandler != NULL) {
       gLogHandler(prio, tag, logBuffer);
+  } else {
+    __android_log_write(prio, tag, logBuffer);
   }
-  __android_log_write(prio, tag, logBuffer);
   return result;
 }
 

--- a/ReactAndroid/src/main/jni/react/jni/JSLogging.cpp
+++ b/ReactAndroid/src/main/jni/react/jni/JSLogging.cpp
@@ -5,10 +5,49 @@
 
 #include "JSLogging.h"
 
+#include <fb/Environment.h>
 #include <fb/log.h>
+
+#include <jni/LocalReference.h>
+#include <jni/LocalString.h>
+
+using namespace facebook::jni;
 
 namespace facebook {
 namespace react {
+namespace JSLogging {
+
+static jclass gLoggerClass;
+static jmethodID gVerboseLogMethod;
+static jmethodID gDebugLogMethod;
+static jmethodID gInfoLogMethod;
+static jmethodID gWarnLogMethod;
+static jmethodID gErrorLogMethod;
+
+jmethodID priorityToMethodId(int logLevel) {
+  jmethodID methodId;
+  switch (logLevel) {
+    case ANDROID_LOG_VERBOSE:
+      methodId = gVerboseLogMethod;
+      break;
+    case ANDROID_LOG_DEBUG:
+      methodId = gDebugLogMethod;
+      break;
+    case ANDROID_LOG_INFO:
+      methodId = gInfoLogMethod;
+      break;
+    case ANDROID_LOG_WARN:
+      methodId = gWarnLogMethod;
+      break;
+    case ANDROID_LOG_ERROR:
+    case ANDROID_LOG_FATAL:
+      methodId = gErrorLogMethod;
+      break;
+    default:
+      methodId = gVerboseLogMethod;
+  }
+  return methodId;
+}
 
 void reactAndroidLoggingHook(
     const std::string& message,
@@ -23,5 +62,26 @@ void reactAndroidLoggingHook(
       message, static_cast<android_LogPriority>(logLevel + ANDROID_LOG_DEBUG));
 }
 
+void androidLogHandler(int prio, const char* tag, const char* message) {
+  ThreadScope threadScope;
+  JNIEnv *env = Environment::current();
+  LocalString tagString(tag);
+  LocalString messageString(message);
+  env->CallStaticVoidMethod(gLoggerClass, priorityToMethodId(prio), tagString.string(), messageString.string());
+}
+
+void registerNatives() {
+  JNIEnv* env = Environment::current();
+  jclass loggerClass = env->FindClass("com/facebook/common/logging/FLog");
+  gLoggerClass = (jclass)env->NewGlobalRef(loggerClass);
+  gVerboseLogMethod = env->GetStaticMethodID(loggerClass, "v", "(Ljava/lang/String;Ljava/lang/String;)V");
+  gDebugLogMethod = env->GetStaticMethodID(loggerClass, "d", "(Ljava/lang/String;Ljava/lang/String;)V");
+  gInfoLogMethod = env->GetStaticMethodID(loggerClass, "i", "(Ljava/lang/String;Ljava/lang/String;)V");
+  gWarnLogMethod = env->GetStaticMethodID(loggerClass, "w", "(Ljava/lang/String;Ljava/lang/String;)V");
+  gErrorLogMethod = env->GetStaticMethodID(loggerClass, "e", "(Ljava/lang/String;Ljava/lang/String;)V");
+  setLogHandler(androidLogHandler);
+}
+
+} // namespace JSLogging
 } // namespace react
 } // namespace facebook

--- a/ReactAndroid/src/main/jni/react/jni/JSLogging.h
+++ b/ReactAndroid/src/main/jni/react/jni/JSLogging.h
@@ -10,6 +10,7 @@
 
 namespace facebook {
 namespace react {
+namespace JSLogging {
 
 void reactAndroidLoggingHook(
     const std::string& message,
@@ -18,5 +19,8 @@ void reactAndroidLoggingHook(
     const std::string& message,
     unsigned int logLevel);
 
+void registerNatives();
+
+} // namespace JSLogging
 } // namespace react
 } // namespace facebook

--- a/ReactAndroid/src/main/jni/react/jni/OnLoad.cpp
+++ b/ReactAndroid/src/main/jni/react/jni/OnLoad.cpp
@@ -66,7 +66,6 @@ extern "C" JNIEXPORT jint JNI_OnLoad(JavaVM* vm, void* reserved) {
     gloginit::initialize();
     FLAGS_minloglevel = 0;
     JSLogging::registerNatives();
-    JSCJavaScriptExecutorHolder::registerNatives();
     ProxyJavaScriptExecutorHolder::registerNatives();
     CatalystInstanceImpl::registerNatives();
     CxxModuleWrapperBase::registerNatives();

--- a/ReactAndroid/src/main/jni/react/jni/OnLoad.cpp
+++ b/ReactAndroid/src/main/jni/react/jni/OnLoad.cpp
@@ -15,6 +15,7 @@
 #include "CxxModuleWrapper.h"
 #include "JavaScriptExecutorHolder.h"
 #include "JCallback.h"
+#include "JSLogging.h"
 #include "NativeDeltaClient.h"
 #include "ProxyExecutor.h"
 #include "WritableNativeArray.h"
@@ -64,6 +65,8 @@ extern "C" JNIEXPORT jint JNI_OnLoad(JavaVM* vm, void* reserved) {
   return initialize(vm, [] {
     gloginit::initialize();
     FLAGS_minloglevel = 0;
+    JSLogging::registerNatives();
+    JSCJavaScriptExecutorHolder::registerNatives();
     ProxyJavaScriptExecutorHolder::registerNatives();
     CatalystInstanceImpl::registerNatives();
     CxxModuleWrapperBase::registerNatives();


### PR DESCRIPTION
## Motivation
Currently, c++ & javascript logs on Android are written directly to logcat instead of using the FLog java class.
As a result, it is impossible to customize C++ and javascript logging by providing a different LoggerDelegate implementation.

With this change, it is possible to enable saving logs to file by providing a custom implementation of LoggingDelegate.

Without this change, the logs written by JS and C++ code will never land to the file.

## Test Plan
Make sure that logging still works.
Make custom LoggingDelegate which logs to the file.
Make sure that all logs are saved.

## Release Notes
[ANDROID] [ENHANCEMENT] [Logging] - All logs are written using the FLog class. It is possible to customize logging behavior across the board.