### PR TITLE
Added WebView InitialScale Property for Android

### DIFF
--- a/Libraries/Components/WebView/WebView.android.js
+++ b/Libraries/Components/WebView/WebView.android.js
@@ -232,6 +232,12 @@ class WebView extends React.Component {
      * @platform android
      */
     urlPrefixesForDefaultIntent: PropTypes.arrayOf(PropTypes.string),
+
+    /*
+     * Sets the initial percentage scale for this WebView. 0 means default.
+     * @platform android
+     */
+    initialScale: PropTypes.number,
   };
 
   static defaultProps = {
@@ -318,6 +324,7 @@ class WebView extends React.Component {
         mixedContentMode={this.props.mixedContentMode}
         saveFormDataDisabled={this.props.saveFormDataDisabled}
         urlPrefixesForDefaultIntent={this.props.urlPrefixesForDefaultIntent}
+        initialScale={this.props.initialScale}
         {...nativeConfig.props}
       />;
 

--- a/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebViewManager.java
@@ -540,6 +540,11 @@ public class ReactWebViewManager extends SimpleViewManager<WebView> {
     }
   }
 
+  @ReactProp(name = "initialScale")
+  public void setInitialScale(WebView view, int scaleInPercent) {
+    view.setInitialScale(scaleInPercent);
+  }
+
   @Override
   protected void addEventEmitters(ThemedReactContext reactContext, WebView view) {
     // Do not register default touch emitter and let WebView implementation handle touches


### PR DESCRIPTION
## Motivation

Helping a website look it's best on Android.

## Test Plan

Try different `<WebView initialScale={??} />` values to test.

## Related PRs

facebook/react-native-website#64
facebook/react-native#17190

## Release Notes

[ANDROID][FEATURE][ReactWebViewManager.java] Added WebView InitialScale option