### PR TITLE
Use javax.annotation.version of Nullable in views/common to fix Android build

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/common/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/common/BUCK
@@ -10,5 +10,6 @@ android_library(
         "PUBLIC",
     ],
     deps = [
+        react_native_dep("third-party/java/jsr-305:jsr-305"),
     ],
 )

--- a/ReactAndroid/src/main/java/com/facebook/react/views/common/ViewHelper.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/common/ViewHelper.java
@@ -4,8 +4,8 @@ package com.facebook.react.views.common;
 
 import android.graphics.drawable.Drawable;
 import android.os.Build;
-import android.support.annotation.Nullable;
 import android.view.View;
+import javax.annotation.Nullable;
 
 /** Helper class for Views */
 public class ViewHelper {


### PR DESCRIPTION
## Motivation

Getting the Android tests to pass on CI. Currently [`master` is failing during the APK build step](https://circleci.com/gh/facebook/react-native/30696) due to e8aa60430ce73df04e553a1d5c5b017a0a2845d8.

## Test Plan

The `test-android` job on Travis should now not fail during the APK build step.

## Release Notes

[INTERNAL] [BUGFIX] [react/views/common] - Use javax.annotation version of Nullable to fix build
