### PR TITLE
Allow Application to Customize NetworkingModule's OkHttpClient on Android

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/modules/network/OkHttpClientProvider.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/network/OkHttpClientProvider.java
@@ -29,6 +29,9 @@ import okhttp3.TlsVersion;
  */
 public class OkHttpClientProvider {
 
+  // customize the builder used in the createClient() call
+  private static @Nullable OkHttpClient.Builder sClientBuilder;
+
   // Centralized OkHttpClient for all networking requests.
   private static @Nullable OkHttpClient sClient;
 
@@ -38,20 +41,32 @@ public class OkHttpClientProvider {
     }
     return sClient;
   }
-  
+
   // okhttp3 OkHttpClient is immutable
   // This allows app to init an OkHttpClient with custom settings.
   public static void replaceOkHttpClient(OkHttpClient client) {
     sClient = client;
   }
 
-  public static OkHttpClient createClient() {
+  public static OkHttpClient.Builder getOkHttpClientBuilder() {
+    if (sClientBuilder != null) {
+      return sClientBuilder;
+    }
     // No timeouts by default
-    OkHttpClient.Builder client = new OkHttpClient.Builder()
+    return new OkHttpClient.Builder()
       .connectTimeout(0, TimeUnit.MILLISECONDS)
       .readTimeout(0, TimeUnit.MILLISECONDS)
       .writeTimeout(0, TimeUnit.MILLISECONDS)
       .cookieJar(new ReactCookieJarContainer());
+  }
+
+  // this allows the app to customize the client returned by createClient()
+  public static void replaceOkHttpClientBuilder(OkHttpClient.Builder clientBuilder) {
+    sClientBuilder = clientBuilder;
+  }
+
+  public static OkHttpClient createClient() {
+    OkHttpClient.Builder client = getOkHttpClientBuilder();
 
     return enableTls12OnPreLollipop(client).build();
   }


### PR DESCRIPTION
## Motivation

Currently there is no way for the application to customize NetworkingModule's internal OkHttpClient., say, for example, to add certificate pinning, specialized cookie storage or any other of a host of customizations that an application might require.

Recently, React Native added an `OkHttpClientProvider` class to facilitate this sort of customization. Unfortunately, even with this addition, there still remains no way for an application to customize the client returned by `createClient()`. This change corrects this oversight.

The change here is simply to provide an optional `createClient()` customization point by setting a custom okhttpclient builder (by calling `replaceOkHttpClientBuilder()`.  _The behavior of all existing applications is unaffected by this added capability_.

Issue #13487
## Test Plan

By inspection. 

Behavior of existing apps is unaffected by this change.

## Release Notes

[MINOR]  [ANDROID]  [ENHANCEMENT] [NetworkingModule]
