### PR TITLE
[HMR] Fix HMR syntax error messages (`message` instead of `description`)

### DIFF
--- a/Libraries/Utilities/HMRClient.js
+++ b/Libraries/Utilities/HMRClient.js
@@ -121,7 +121,7 @@ Error: ${e.message}`
         }
         case 'error': {
           HMRLoadingView.hide();
-          throw new Error(data.body.type + ' ' + data.body.description);
+          throw new Error(`${data.body.type}: ${data.body.message}`);
         }
         default: {
           throw new Error(`Unexpected message: ${data}`);


### PR DESCRIPTION
## Motivation
The code to display HMR errors on the client was reading the `description` field from Metro payloads. Metro does not include `description` in the body of its error payloads -- only in its `body.errors[]` items. This commit changes RN's HMR code to show `body.message` (set consistently with https://github.com/facebook/metro/pull/124) instead of the non-existent `body.description`.

## Test Plan
Open a test RN app, enable HMR, and then introduce a syntax error in an app source file. See that the redbox provides information about the syntax error instead of just saying "TransformError undefined".

## Related PRs
- https://github.com/facebook/metro/pull/124

## Release Notes

[GENERAL][ENHANCEMENT][HMR] - Fix display of syntax error messages when HMR is enabled