### PR TITLE
Update React.podspec for RCTText

### DIFF
--- a/React.podspec
+++ b/React.podspec
@@ -204,7 +204,7 @@ Pod::Spec.new do |s|
 
   s.subspec "RCTText" do |ss|
     ss.dependency             "React/Core"
-    ss.source_files         = "Libraries/Text/*.{h,m}"
+    ss.source_files         = "Libraries/Text/**/*.{h,m}"
   end
 
   s.subspec "RCTVibration" do |ss|


### PR DESCRIPTION
Some of the classes of RCTText are now in the subfolders, this will fix pod integration for texts

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes. 

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to React Native here: http://facebook.github.io/react-native/docs/contributing.html

Happy contributing!

-->

## Motivation

I have integrated React Native into my project with [this guide](https://facebook.github.io/react-native/docs/integration-with-existing-apps.html) and got the error `No component found for view with name RCTText`. Searching in the web did not give any useful information so I started to dig into the code and found out that there is now subfolders and pod taking only root classes. After making this change project started to compile again.

## Test Plan

Create empty project with pods integrated add `RCTText` subspec and in `.js` file add  some `<Text>` element


## Release Notes
Fixed `RCTText` subspec integration.