### PR TITLE
Fix #17610, Add fixtures to metro blacklist

### DIFF
--- a/local-cli/util/Config.js
+++ b/local-cli/util/Config.js
@@ -17,7 +17,7 @@ const getPolyfills = require('../../rn-get-polyfills');
 const invariant = require('fbjs/lib/invariant');
 const path = require('path');
 
-const {Config: MetroConfig} = require('metro');
+const {Config: MetroConfig, createBlacklist} = require('metro');
 
 const RN_CLI_CONFIG = 'rn-cli.config.js';
 
@@ -56,6 +56,10 @@ const getProjectRoots = () => {
   return resolveSymlinksForRoots([getProjectPath()]);
 };
 
+const getBlacklistRE = () => {
+  return createBlacklist([/.*\/__fixtures__\/.*/]);
+};
+
 /**
  * Module capable of getting the configuration out of a given file.
  *
@@ -67,6 +71,7 @@ const getProjectRoots = () => {
 const Config = {
   DEFAULT: ({
     ...MetroConfig.DEFAULT,
+    getBlacklistRE,
     getProjectRoots,
     getPolyfills,
     getModulesRunBeforeMainModule: () => [


### PR DESCRIPTION
Include a default blacklist into the build settings to prevent
processing of incorrect fixture files by Metro.

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes. 

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to React Native here: http://facebook.github.io/react-native/docs/contributing.html

Happy contributing!

-->

## Motivation

Fix #17610 issue, preventing metro from processing fixture files

## Test Plan
1. Have a working demo
2. Install https://github.com/oblador/react-native-vector-icons
3. Use in a component
4. Start the app
5. The app starts successfully and display the icons

## Related PRs

## Release Notes
[ GENERAL  ]  [ BUGFIX ]  [local-cli/util/Config.js] - Add default file blacklist