### PR TITLE
Add minify flag to react-native bundle command

### DIFF
--- a/local-cli/bundle/buildBundle.js
+++ b/local-cli/bundle/buildBundle.js
@@ -54,6 +54,7 @@ async function buildBundle(
     maxWorkers: number,
     resetCache: boolean,
     transformer: string,
+    minify: boolean,
   },
   config: ConfigT,
   output = outputBundle,

--- a/local-cli/bundle/buildBundle.js
+++ b/local-cli/bundle/buildBundle.js
@@ -71,7 +71,7 @@ async function buildBundle(
     entryFile: args.entryFile,
     sourceMapUrl,
     dev: args.dev,
-    minify: !args.dev,
+    minify: args.minify !== undefined ? args.minify : !args.dev,
     platform: args.platform,
   };
 

--- a/local-cli/bundle/bundleCommandLineArgs.js
+++ b/local-cli/bundle/bundleCommandLineArgs.js
@@ -25,6 +25,12 @@ module.exports = [
     parse: (val) => val === 'false' ? false : true,
     default: true,
   }, {
+    command: '--minify [boolean]',
+    description: 'Allows overriding whether bundle is minified. This defaults to ' +
+      'false if dev is true, and true if dev is false. Disabling minification ' +
+      'can be useful for speeding up production builds for testing purposes.',
+    parse: (val) => val === 'false' ? false : true,
+  }, {
     command: '--bundle-output <string>',
     description: 'File name where to store the resulting bundle, ex. /tmp/groups.bundle',
   }, {


### PR DESCRIPTION
## Motivation

We have found that it is useful to work with production rather than dev bundles when working on e.g. performance and animation tuning.

For a larger app, `react-native bundle` with `--dev false` can get very slow due to minification - in our case, this was especially true of library code (e.g. the AWS SDK taking nearly 15 secs to minify on a top-spec MBP 15"). This is fine when just building every now and then, but when making frequent changes and rebuilding, it becomes quite painful.

Currently there is no way to perform a release (non-dev) build, with minification disabled. This PR adds an optional `--minify` flag to enable developers to disable minification, reducing build times significantly for our use case.

## Test Plan

Checked output bundle size, to ensure behaviour stays the same as the existing default when `--minify` is not specified, and that the `minify` flag gets passed through to Metro bundler correctly if specified.

## Related PRs

N/A

## Release Notes

[GENERAL] [ENHANCEMENT] [Bundler] - Added optional --minify flag to bundler