### PR TITLE
Removing broken check for height auto-sizing

### DIFF
--- a/Libraries/Text/Text/RCTTextShadowView.m
+++ b/Libraries/Text/Text/RCTTextShadowView.m
@@ -28,7 +28,6 @@ NSString *const RCTReactTagAttributeName = @"ReactTagAttributeName";
 static NSString *const kShadowViewAttributeName = @"RCTShadowViewAttributeName";
 
 static CGFloat const kAutoSizeWidthErrorMargin  = 0.05f;
-static CGFloat const kAutoSizeHeightErrorMargin = 0.025f;
 static CGFloat const kAutoSizeGranularity       = 0.001f;
 
 @implementation RCTTextShadowView
@@ -45,7 +44,6 @@ static YGSize RCTMeasure(YGNodeRef node, float width, YGMeasureMode widthMode, f
 {
   RCTTextShadowView *shadowText = (__bridge RCTTextShadowView *)YGNodeGetContext(node);
   NSTextStorage *textStorage = [shadowText buildTextStorageForWidth:width widthMode:widthMode];
-  [shadowText calculateTextFrame:textStorage];
   NSLayoutManager *layoutManager = textStorage.layoutManagers.firstObject;
   NSTextContainer *textContainer = layoutManager.textContainers.firstObject;
   CGSize computedSize = [layoutManager usedRectForTextContainer:textContainer].size;
@@ -576,8 +574,7 @@ static YGSize RCTMeasure(YGNodeRef node, float width, YGMeasureMode widthMode, f
   textContainer.maximumNumberOfLines == 0;
 
   if (fitLines && fitSize) {
-    if ((requiredSize.width + (CGRectGetWidth(frame) * kAutoSizeWidthErrorMargin)) > CGRectGetWidth(frame) &&
-        (requiredSize.height + (CGRectGetHeight(frame) * kAutoSizeHeightErrorMargin)) > CGRectGetHeight(frame))
+    if ((requiredSize.width + (CGRectGetWidth(frame) * kAutoSizeWidthErrorMargin)) > CGRectGetWidth(frame))
     {
       return RCTSizeWithinRange;
     } else {


### PR DESCRIPTION
I implemented this feature originally. 

Not sure exactly what happened, probably some squashing issue, or something changing over the years, but without removing these elements, the font always scales down as low as possible, rather than just low enough to fit the text into the frame in the view. 

Once they're removed, it works properly, and functions just like the native iOS adjustsFontSizeToFit.

With these changes, this is what we ship to Production. @shergin would you mind chiming in here?

## Motivation

This has a bug where the text shrinks forever without these changes.

## Test Plan

We ship this to production.