### PR TITLE
Adding pod target config to `yoga` to solve warning.

### DIFF
--- a/ReactCommon/yoga/yoga.podspec
+++ b/ReactCommon/yoga/yoga.podspec
@@ -33,6 +33,8 @@ Pod::Spec.new do |spec|
       '-fPIC'
   ]
 
+  spec.pod_target_xcconfig = { 'WARNING_CFLAGS' => "-Wno-shorten-64-to-32" }
+
   # Pinning to the same version as React.podspec.
   spec.platforms = { :ios => "8.0", :tvos => "9.2" }
 


### PR DESCRIPTION
Adding pod target config to `yoga` to solve warning when integrate `react-native` of `0.52.1` with `cocoapods` .

Warning:
```
/Users/OceanHorn/ReactNative/demo0124/Demo/node_modules/react-native/ReactCommon/Yoga/yoga/YGNodePrint.cpp:208:46: error: implicit conversion loses integer precision: 'size_type' (aka 'unsigned long') to 'const uint32_t' (aka 'const unsigned int') [-Werror,-Wshorten-64-to-32]
  const uint32_t childCount = node->children.size();
                 ~~~~~~~~~~   ~~~~~~~~~~~~~~~^~~~~~
1 error generated.
```

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes. 

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to React Native here: http://facebook.github.io/react-native/docs/contributing.html

Happy contributing!

-->

## Motivation

Solve warning when integrate `react-native` `0.52.1` with `cocoapods`.

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/react-native-website, and link to your PR here.)

## Release Notes
 [IOS] [BUGFIX] [Yoga] - Added a target config.

