### PR TITLE
Make sure refreshControl shows up on initial render if specified

### DIFF
--- a/React/Views/RCTRefreshControl.m
+++ b/React/Views/RCTRefreshControl.m
@@ -44,7 +44,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
   // If the control is refreshing when mounted we need to call
   // beginRefreshing in layoutSubview or it doesn't work.
   if (_currentRefreshingState && _isInitialRender) {
-    [self beginRefreshing];
+    [self beginRefreshingProgrammatically];
   }
   _isInitialRender = false;
 }


### PR DESCRIPTION


## Motivation

[this commit](https://github.com/facebook/react-native/commit/2e1707d0e600a30057511390dd87c18c00f19a59) which was just a small refactor broke refreshControl behavior - if we render FlatList with refreshing=true, the refreshControl won't be visible on initial render.

The problem is, the [previous beginRefreshing method](https://github.com/facebook/react-native/commit/2e1707d0e600a30057511390dd87c18c00f19a59#diff-cfafa8d7e42ab87ab863f917e187a4aeL51) was renamed to `beginRefreshingProgramatically` and the old call was left in one place [here](https://github.com/facebook/react-native/commit/2e1707d0e600a30057511390dd87c18c00f19a59#diff-cfafa8d7e42ab87ab863f917e187a4aeR47).

Now, I am not sure what kind of jumping the mentioned commit was fixing, but since this fix only concerns the initial render, I believe it will not influence the jumping fix.

## Test Plan

I have tested this locally in my app, can provide a video if needed.

## Related PRs

none

## Release Notes

 [IOS] [BUGFIX] [RefreshControl] - Make sure refreshControl shows up on initial render if specified

