### PR TITLE
[Docs] Remove references to Travis

### DIFF
--- a/RNTester/RNTesterIntegrationTests/RNTesterSnapshotTests.m
+++ b/RNTester/RNTesterIntegrationTests/RNTesterSnapshotTests.m
@@ -48,7 +48,6 @@ RCT_TEST(TextExample)
 // No switch or slider available on tvOS
 RCT_TEST(SwitchExample)
 RCT_TEST(SliderExample)
-// TabBarExample on tvOS passes locally but not on Travis
 RCT_TEST(TabBarExample)
 #endif
 

--- a/Releases.md
+++ b/Releases.md
@@ -36,7 +36,8 @@ The following are required for the local test suite to run:
 
 ### Step 1: Check everything works
 
-Before cutting a release branch, make sure CI systems [Travis](https://travis-ci.org/facebook/react-native) and [Circle](https://circleci.com/gh/facebook/react-native) are green.
+Before cutting a release branch, make sure [Circle](https://circleci.com/gh/facebook/react-native) CI system is green.
+
 
 Before executing the following script, make sure you have:
 - An Android emulator / Genymotion device running

--- a/scripts/android-e2e-test.js
+++ b/scripts/android-e2e-test.js
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  *
- * Used in run-ci-e2e-test.js and executed in Travis and Circle CI.
+ * Used in run-ci-e2e-test.js and executed in Circle CI.
  * E2e test that verifies that init app can be installed, compiled, started and Hot Module reloading and Chrome debugging work.
  * For other examples of appium refer to: https://github.com/appium/sample-code/tree/master/sample-code/examples/node and
  * https://www.npmjs.com/package/wd-android


### PR DESCRIPTION
## Motivation
react-native project is migrated travis to circleCI.
but the document has some leavings.

## Test Plan
Only Docs Edited

## Related PRs
https://github.com/facebook/react-native/pull/16354
https://github.com/facebook/react-native/pull/16364

## Release Notes
[ DOCS] Remove references to Travis
changed Releases.md
changed RNTester/RNTesterIntegrationTests/RNTesterSnapshotTests.m
changed scripts/android-e2e-test.js