### PR TITLE
Added: informational error message on getting Android drawable folder…

### DIFF
--- a/Libraries/Image/assetPathUtils.js
+++ b/Libraries/Image/assetPathUtils.js
@@ -51,12 +51,11 @@ function getAndroidResourceFolderName(asset: PackagerAsset, scale: number) {
   var suffix = getAndroidAssetSuffix(scale);
   if (!suffix) {
     throw new Error(
-      
-       "Don't know which android drawable suffix to use for scale: " + scale +
-        '\nAsset: ' +
-        JSON.stringify(asset, null, '\t') +
-        '\nPossible scales are:' +
-        JSON.stringify(androidScaleSuffix, null, '\t'),
+      "Don't know which android drawable suffix to use for scale: " + scale +
+      '\nAsset: ' +
+      JSON.stringify(asset, null, '\t') +
+      '\nPossible scales are:' +
+      JSON.stringify(androidScaleSuffix, null, '\t'),
     );
   }
   const androidFolder = 'drawable-' + suffix;

--- a/Libraries/Image/assetPathUtils.js
+++ b/Libraries/Image/assetPathUtils.js
@@ -51,12 +51,12 @@ function getAndroidResourceFolderName(asset: PackagerAsset, scale: number) {
   var suffix = getAndroidAssetSuffix(scale);
   if (!suffix) {
     throw new Error(
-        "Don't know which android drawable suffix to use for scale: " +
-        scale +
-        '\nAsset: ' +
-        JSON.stringify(asset, null, '\t') +
-        '\nPossible scales are:' +
-        JSON.stringify(androidScaleSuffix, null, '\t'),
+      "Don't know which android drawable suffix to use for scale: " +
+      scale +
+      '\nAsset: ' +
+      JSON.stringify(asset, null, '\t') +
+      '\nPossible scales are:' +
+      JSON.stringify(androidScaleSuffix, null, '\t'),
     );
   }
   const androidFolder = 'drawable-' + suffix;

--- a/Libraries/Image/assetPathUtils.js
+++ b/Libraries/Image/assetPathUtils.js
@@ -13,12 +13,12 @@
 import type {PackagerAsset} from './AssetRegistry';
 
 const androidScaleSuffix = {
-  "0.75": 'ldpi',
-  "1": 'mdpi',
-  "1.5": 'hdpi',
-  "2": 'xhdpi',
-  "3": 'xxhdpi',
-  "4": 'xxxhdpi'
+  '0.75': 'ldpi',
+  '1': 'mdpi',
+  '1.5': 'hdpi',
+  '2': 'xhdpi',
+  '3': 'xxhdpi',
+  '4': 'xxxhdpi'
 };
 
 /**
@@ -52,8 +52,8 @@ function getAndroidResourceFolderName(asset: PackagerAsset, scale: number) {
   if (!suffix) {
     throw new Error(
       'Don\'t know which android drawable suffix to use for scale: ' + scale +
-      '\nAsset: ' + JSON.stringify(asset, null, '\t') +
-      '\nPossible scales are:' +
+        '\nAsset: ' + JSON.stringify(asset, null, '\t') +
+        '\nPossible scales are:' +
         JSON.stringify(androidScaleSuffix, null, '\t')
     );
   }

--- a/Libraries/Image/assetPathUtils.js
+++ b/Libraries/Image/assetPathUtils.js
@@ -51,7 +51,7 @@ function getAndroidResourceFolderName(asset: PackagerAsset, scale: number) {
   var suffix = getAndroidAssetSuffix(scale);
   if (!suffix) {
     throw new Error(
-        "Don't know which android drawable suffix to use for scale: " +
+      "Don't know which android drawable suffix to use for scale: " +
         scale +
         '\nAsset: ' +
         JSON.stringify(asset, null, '\t') +

--- a/Libraries/Image/assetPathUtils.js
+++ b/Libraries/Image/assetPathUtils.js
@@ -13,12 +13,12 @@
 import type {PackagerAsset} from './AssetRegistry';
 
 const androidScaleSuffix = {
-  "0.75": "ldpi",
-  "1": "mdpi",
-  "1.5": "hdpi",
-  "2": "xhdpi",
-  "3": "xxhdpi",
-  "4": "xxxhdpi"
+  "0.75": 'ldpi',
+  "1": 'mdpi',
+  "1.5": 'hdpi',
+  "2": 'xhdpi',
+  "3": 'xxhdpi',
+  "4": 'xxxhdpi'
 };
 
 /**
@@ -51,10 +51,10 @@ function getAndroidResourceFolderName(asset: PackagerAsset, scale: number) {
   var suffix = getAndroidAssetSuffix(scale);
   if (!suffix) {
     throw new Error(
-      "Don\'t know which android drawable suffix to use for scale: " + scale +
-      "\nAsset: " + JSON.stringify(asset, null, '\t') +
-      "\nPossible scales are:" +
-      JSON.stringify(androidScaleSuffix, null, '\t')
+      'Don\'t know which android drawable suffix to use for scale: ' + scale +
+      '\nAsset: ' + JSON.stringify(asset, null, '\t') +
+      '\nPossible scales are:' +
+        JSON.stringify(androidScaleSuffix, null, '\t')
     );
   }
   const androidFolder = 'drawable-' + suffix;

--- a/Libraries/Image/assetPathUtils.js
+++ b/Libraries/Image/assetPathUtils.js
@@ -51,13 +51,11 @@ function getAndroidResourceFolderName(asset: PackagerAsset, scale: number) {
   var suffix = getAndroidAssetSuffix(scale);
   if (!suffix) {
     throw new Error(
-      
       "Don't know which android drawable suffix to use for scale: " + scale +
         '\nAsset: ' +
         JSON.stringify(asset, null, '\t') +
         '\nPossible scales are:' +
         JSON.stringify(androidScaleSuffix, null, '\t'),
-      
     );
   }
   const androidFolder = 'drawable-' + suffix;

--- a/Libraries/Image/assetPathUtils.js
+++ b/Libraries/Image/assetPathUtils.js
@@ -52,9 +52,9 @@ function getAndroidResourceFolderName(asset: PackagerAsset, scale: number) {
   if (!suffix) {
     throw new Error(
       "Don't know which android drawable suffix to use for scale: " + scale +
-       '\nAsset: ' + 
+       '\nAsset: ' +
        JSON.stringify(asset, null, '\t') +
-       '\nPossible scales are:' + 
+       '\nPossible scales are:' +
        JSON.stringify(androidScaleSuffix, null, '\t'),
     );
   }

--- a/Libraries/Image/assetPathUtils.js
+++ b/Libraries/Image/assetPathUtils.js
@@ -54,7 +54,7 @@ function getAndroidResourceFolderName(asset: PackagerAsset, scale: number) {
       'Don\'t know which android drawable suffix to use for scale: ' + scale +
         '\nAsset: ' + JSON.stringify(asset, null, '\t') +
         '\nPossible scales are:' +
-        JSON.stringify(androidScaleSuffix, null, '\t')
+        JSON.stringify(androidScaleSuffix, null, '\t'),
     );
   }
   const androidFolder = 'drawable-' + suffix;

--- a/Libraries/Image/assetPathUtils.js
+++ b/Libraries/Image/assetPathUtils.js
@@ -18,7 +18,7 @@ const androidScaleSuffix = {
   '1.5': 'hdpi',
   '2': 'xhdpi',
   '3': 'xxhdpi',
-  '4': 'xxxhdpi'
+  '4': 'xxxhdpi',
 };
 
 /**

--- a/Libraries/Image/assetPathUtils.js
+++ b/Libraries/Image/assetPathUtils.js
@@ -13,12 +13,12 @@
 import type {PackagerAsset} from './AssetRegistry';
 
 const androidScaleSuffix = {
-  '0.75': 'ldpi',
-  '1': 'mdpi',
-  '1.5': 'hdpi',
-  '2': 'xhdpi',
-  '3': 'xxhdpi',
-  '4': 'xxxhdpi'
+  "0.75": "ldpi",
+  "1": "mdpi",
+  "1.5": "hdpi",
+  "2": "xhdpi",
+  "3": "xxhdpi",
+  "4": "xxxhdpi"
 };
 
 /**
@@ -51,9 +51,10 @@ function getAndroidResourceFolderName(asset: PackagerAsset, scale: number) {
   var suffix = getAndroidAssetSuffix(scale);
   if (!suffix) {
     throw new Error(
-      'Don\'t know which android drawable suffix to use for scale: ' + scale +
-      '\nAsset: ' + JSON.stringify(asset, null, '\t') +
-      '\nPossible scales are:' + JSON.stringify(androidScaleSuffix, null, '\t')
+      "Don\'t know which android drawable suffix to use for scale: " + scale +
+      "\nAsset: " + JSON.stringify(asset, null, '\t') +
+      "\nPossible scales are:" +
+      JSON.stringify(androidScaleSuffix, null, '\t')
     );
   }
   const androidFolder = 'drawable-' + suffix;

--- a/Libraries/Image/assetPathUtils.js
+++ b/Libraries/Image/assetPathUtils.js
@@ -51,9 +51,10 @@ function getAndroidResourceFolderName(asset: PackagerAsset, scale: number) {
   var suffix = getAndroidAssetSuffix(scale);
   if (!suffix) {
     throw new Error(
-      'Don\'t know which android drawable suffix to use for scale: ' + scale +
-       '\nAsset: ' + JSON.stringify(asset, null, '\t') +
-       '\nPossible scales are:' +
+      "Don\'t know which android drawable suffix to use for scale: " + scale +
+       '\nAsset: ' + 
+       JSON.stringify(asset, null, '\t') + 
+       '\nPossible scales are:' + 
        JSON.stringify(androidScaleSuffix, null, '\t'),
     );
   }

--- a/Libraries/Image/assetPathUtils.js
+++ b/Libraries/Image/assetPathUtils.js
@@ -53,9 +53,9 @@ function getAndroidResourceFolderName(asset: PackagerAsset, scale: number) {
     throw new Error(
       "Don't know which android drawable suffix to use for scale: " + scale +
       '\nAsset: ' +
-      JSON.stringify(asset, null, '\t') +
+        JSON.stringify(asset, null, '\t') +
       '\nPossible scales are:' +
-      JSON.stringify(androidScaleSuffix, null, '\t'),
+        JSON.stringify(androidScaleSuffix, null, '\t'),
     );
   }
   const androidFolder = 'drawable-' + suffix;

--- a/Libraries/Image/assetPathUtils.js
+++ b/Libraries/Image/assetPathUtils.js
@@ -51,7 +51,7 @@ function getAndroidResourceFolderName(asset: PackagerAsset, scale: number) {
   var suffix = getAndroidAssetSuffix(scale);
   if (!suffix) {
     throw new Error(
-      "Don't know which android drawable suffix to use for scale: " + scale +
+        "Don't know which android drawable suffix to use for scale: " + scale +
         '\nAsset: ' +
         JSON.stringify(asset, null, '\t') +
         '\nPossible scales are:' +

--- a/Libraries/Image/assetPathUtils.js
+++ b/Libraries/Image/assetPathUtils.js
@@ -51,12 +51,12 @@ function getAndroidResourceFolderName(asset: PackagerAsset, scale: number) {
   var suffix = getAndroidAssetSuffix(scale);
   if (!suffix) {
     throw new Error(
-      "Don't know which android drawable suffix to use for scale: " +
-      scale +
-      '\nAsset: ' +
-      JSON.stringify(asset, null, '\t') +
-      '\nPossible scales are:' +
-      JSON.stringify(androidScaleSuffix, null, '\t'),
+        "Don't know which android drawable suffix to use for scale: " +
+        scale +
+        '\nAsset: ' +
+        JSON.stringify(asset, null, '\t') +
+        '\nPossible scales are:' +
+        JSON.stringify(androidScaleSuffix, null, '\t'),
     );
   }
   const androidFolder = 'drawable-' + suffix;

--- a/Libraries/Image/assetPathUtils.js
+++ b/Libraries/Image/assetPathUtils.js
@@ -52,9 +52,9 @@ function getAndroidResourceFolderName(asset: PackagerAsset, scale: number) {
   if (!suffix) {
     throw new Error(
       'Don\'t know which android drawable suffix to use for scale: ' + scale +
-        '\nAsset: ' + JSON.stringify(asset, null, '\t') +
-        '\nPossible scales are:' +
-        JSON.stringify(androidScaleSuffix, null, '\t'),
+       '\nAsset: ' + JSON.stringify(asset, null, '\t') +
+       '\nPossible scales are:' +
+       JSON.stringify(androidScaleSuffix, null, '\t'),
     );
   }
   const androidFolder = 'drawable-' + suffix;

--- a/Libraries/Image/assetPathUtils.js
+++ b/Libraries/Image/assetPathUtils.js
@@ -51,7 +51,8 @@ function getAndroidResourceFolderName(asset: PackagerAsset, scale: number) {
   var suffix = getAndroidAssetSuffix(scale);
   if (!suffix) {
     throw new Error(
-        "Don't know which android drawable suffix to use for scale: " + scale +
+        "Don't know which android drawable suffix to use for scale: " +
+        scale +
         '\nAsset: ' +
         JSON.stringify(asset, null, '\t') +
         '\nPossible scales are:' +

--- a/Libraries/Image/assetPathUtils.js
+++ b/Libraries/Image/assetPathUtils.js
@@ -12,26 +12,25 @@
 
 import type {PackagerAsset} from './AssetRegistry';
 
+const androidScaleSuffix = {
+  '0.75': 'ldpi',
+  '1': 'mdpi',
+  '1.5': 'hdpi',
+  '2': 'xhdpi',
+  '3': 'xxhdpi',
+  '4': 'xxxhdpi'
+};
+
 /**
  * FIXME: using number to represent discrete scale numbers is fragile in essence because of
  * floating point numbers imprecision.
  */
 function getAndroidAssetSuffix(scale: number): string {
-  switch (scale) {
-    case 0.75:
-      return 'ldpi';
-    case 1:
-      return 'mdpi';
-    case 1.5:
-      return 'hdpi';
-    case 2:
-      return 'xhdpi';
-    case 3:
-      return 'xxhdpi';
-    case 4:
-      return 'xxxhdpi';
+  if (scale.toString() in androidScaleSuffix) {
+    return androidScaleSuffix[scale.toString()];
   }
-  throw new Error('no such scale');
+
+  throw new Error('no such scale ' + scale.toString());
 }
 
 // See https://developer.android.com/guide/topics/resources/drawable-resource.html
@@ -52,8 +51,9 @@ function getAndroidResourceFolderName(asset: PackagerAsset, scale: number) {
   var suffix = getAndroidAssetSuffix(scale);
   if (!suffix) {
     throw new Error(
-      "Don't know which android drawable suffix to use for asset: " +
-        JSON.stringify(asset),
+      'Don\'t know which android drawable suffix to use for scale: ' + scale +
+      '\nAsset: ' + JSON.stringify(asset, null, '\t') +
+      '\nPossible scales are:' + JSON.stringify(androidScaleSuffix, null, '\t')
     );
   }
   const androidFolder = 'drawable-' + suffix;

--- a/Libraries/Image/assetPathUtils.js
+++ b/Libraries/Image/assetPathUtils.js
@@ -51,7 +51,7 @@ function getAndroidResourceFolderName(asset: PackagerAsset, scale: number) {
   var suffix = getAndroidAssetSuffix(scale);
   if (!suffix) {
     throw new Error(
-      "Don\'t know which android drawable suffix to use for scale: " + scale +
+      "Don't know which android drawable suffix to use for scale: " + scale +
        '\nAsset: ' + 
        JSON.stringify(asset, null, '\t') + 
        '\nPossible scales are:' + 

--- a/Libraries/Image/assetPathUtils.js
+++ b/Libraries/Image/assetPathUtils.js
@@ -51,11 +51,13 @@ function getAndroidResourceFolderName(asset: PackagerAsset, scale: number) {
   var suffix = getAndroidAssetSuffix(scale);
   if (!suffix) {
     throw new Error(
+      
       "Don't know which android drawable suffix to use for scale: " + scale +
-      '\nAsset: ' +
+        '\nAsset: ' +
         JSON.stringify(asset, null, '\t') +
-      '\nPossible scales are:' +
+        '\nPossible scales are:' +
         JSON.stringify(androidScaleSuffix, null, '\t'),
+      
     );
   }
   const androidFolder = 'drawable-' + suffix;

--- a/Libraries/Image/assetPathUtils.js
+++ b/Libraries/Image/assetPathUtils.js
@@ -51,7 +51,7 @@ function getAndroidResourceFolderName(asset: PackagerAsset, scale: number) {
   var suffix = getAndroidAssetSuffix(scale);
   if (!suffix) {
     throw new Error(
-        "Don't know which android drawable suffix to use for scale: " + scale +
+      "Don't know which android drawable suffix to use for scale: " + scale +
         '\nAsset: ' +
         JSON.stringify(asset, null, '\t') +
         '\nPossible scales are:' +

--- a/Libraries/Image/assetPathUtils.js
+++ b/Libraries/Image/assetPathUtils.js
@@ -53,7 +53,7 @@ function getAndroidResourceFolderName(asset: PackagerAsset, scale: number) {
     throw new Error(
       "Don't know which android drawable suffix to use for scale: " + scale +
        '\nAsset: ' + 
-       JSON.stringify(asset, null, '\t') + 
+       JSON.stringify(asset, null, '\t') +
        '\nPossible scales are:' + 
        JSON.stringify(androidScaleSuffix, null, '\t'),
     );

--- a/Libraries/Image/assetPathUtils.js
+++ b/Libraries/Image/assetPathUtils.js
@@ -51,11 +51,12 @@ function getAndroidResourceFolderName(asset: PackagerAsset, scale: number) {
   var suffix = getAndroidAssetSuffix(scale);
   if (!suffix) {
     throw new Error(
-      "Don't know which android drawable suffix to use for scale: " + scale +
-       '\nAsset: ' +
-       JSON.stringify(asset, null, '\t') +
-       '\nPossible scales are:' +
-       JSON.stringify(androidScaleSuffix, null, '\t'),
+      
+       "Don't know which android drawable suffix to use for scale: " + scale +
+        '\nAsset: ' +
+        JSON.stringify(asset, null, '\t') +
+        '\nPossible scales are:' +
+        JSON.stringify(androidScaleSuffix, null, '\t'),
     );
   }
   const androidFolder = 'drawable-' + suffix;


### PR DESCRIPTION
… suffix for asset

Better informational error message on getting Android drawable folder suffix error using the asset name scale.

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes. 

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to React Native here: http://facebook.github.io/react-native/docs/contributing.html

Happy contributing!

-->

## Motivation

I've got an not well described error when trying to bundle my React Native project package.

## Test Plan

You can test the React Native bundle command like this:

node node_modules/react-native/local-cli/cli.js bundle --platform android --dev false --reset-cache --entry-file index.android.js --bundle-output /project/android/app/build/intermediates/assets/release/index.android.bundle --assets-dest /project/android/app/build

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/react-native-website, and link to your PR here.)

## Release Notes
<!--
Help reviewers and the release process by writing your own release notes

**INTERNAL and MINOR tagged notes will not be included in the next version's final release notes.**

  CATEGORY
[----------]        TYPE
[ CLI      ]   [-------------]      LOCATION
[ DOCS     ]   [ BREAKING    ]   [-------------]
[ GENERAL  ]   [ BUGFIX      ]   [-{Component}-]
[ INTERNAL ]   [ ENHANCEMENT ]   [ {File}      ]
[ IOS      ]   [ FEATURE     ]   [ {Directory} ]   |-----------|
[ ANDROID  ]   [ MINOR       ]   [ {Framework} ] - | {Message} |
[----------]   [-------------]   [-------------]   |-----------|

[CATEGORY] [TYPE] [LOCATION] - MESSAGE

 EXAMPLES:

 [IOS] [BREAKING] [FlatList] - Change a thing that breaks other things
 [ANDROID] [BUGFIX] [TextInput] - Did a thing to TextInput
 [CLI] [FEATURE] [local-cli/info/info.js] - CLI easier to do things with
 [DOCS] [BUGFIX] [GettingStarted.md] - Accidentally a thing/word
 [GENERAL] [ENHANCEMENT] [Yoga] - Added new yoga thing/position
 [INTERNAL] [FEATURE] [./scripts] - Added thing to script that nobody will see
-->
