### PR TITLE
Enable obfuscation in ProGuard rules by default

### DIFF
--- a/local-cli/templates/HelloWorld/android/app/proguard-rules.pro
+++ b/local-cli/templates/HelloWorld/android/app/proguard-rules.pro
@@ -18,7 +18,7 @@
 
 # Disabling obfuscation is useful if you collect stack traces from production crashes
 # (unless you are using a system that supports de-obfuscate the stack traces).
--dontobfuscate
+# -dontobfuscate
 
 # React Native
 


### PR DESCRIPTION
This PR enables obfuscation in ProGuard by default when creating a new project, and documents how developers can turn obfuscation off if they desire.

## Motivation

The ProGuard phase is currently disabled by default. If a developer wanted to enable ProGuard, the first thing they would see is the following line in their build.gradle file: `def enableProguardInReleaseBuilds = false`

It's really easy to assume that enabling this flag will setup code shrinking and obfuscation, as this is the default behaviour for a completely native Android Studio project, or when running ProGuard from the command line directly.

However, the generated ProGuard rules override the default behaviour. Without visually inspecting the rules file, searching for a mapping file, or analyzing the Dex file classes, this isn't immediately obvious, as the APK will be smaller, and gradle will show the Proguard task as completing.

Personally I find this confusing and really wasn't expecting for obfuscation to be disabled - most Android Error Reporting services allow deobfuscation of stacktraces via mapping files.

## Test Plan

1. Create a new project using `react-native init MyProject`
2. Observe that `-dontobfuscate` is commented out

## Release Notes

[ANDROID] [MINOR] [ProGuard] - Enables obfuscation by default in newly created projects
