### PR TITLE
Test and document Image resizeMode=center on iOS

### DIFF
--- a/Libraries/Image/Image.ios.js
+++ b/Libraries/Image/Image.ios.js
@@ -241,6 +241,10 @@ const Image = createReactClass({
      *
      * - `repeat`: Repeat the image to cover the frame of the view. The
      * image will keep it's size and aspect ratio. (iOS only)
+     *
+     * - 'center': Scale the image down so that it is completely visible,
+     * if bigger than the area of the view.
+     * The image will not be scaled up.
      */
     resizeMode: PropTypes.oneOf([
       'cover',

--- a/RNTester/js/ImageExample.js
+++ b/RNTester/js/ImageExample.js
@@ -572,18 +572,16 @@ exports.examples = [
                     />
                   </View>
                 : null }
-                { Platform.OS === 'android' ?
-                  <View style={styles.leftMargin}>
-                    <Text style={[styles.resizeModeText]}>
-                      Center
-                    </Text>
-                    <Image
-                      style={styles.resizeMode}
-                      resizeMode={Image.resizeMode.center}
-                      source={image}
-                    />
-                  </View>
-                : null }
+                <View style={styles.leftMargin}>
+                  <Text style={[styles.resizeModeText]}>
+                    Center
+                  </Text>
+                  <Image
+                    style={styles.resizeMode}
+                    resizeMode={Image.resizeMode.center}
+                    source={image}
+                  />
+                </View>
               </View>
             </View>
           );


### PR DESCRIPTION
## Motivation

`<Image resizeMode="center">` already works on iOS (implemented in #8792), but is neither tested nor documented the way the other `resizeMode` values are.

This PR primarily enables the relevant RNTester case on iOS, and secondarily copies over the doc comment from `Image.android.js` to `Image.ios.js`. A PR to `react-native-website` will follow shortly and it is there I will try and revise the wording a bit.

## Test Plan

Updated RNTester screenshot (iOS):

<img src=https://user-images.githubusercontent.com/2246565/35470720-44b38282-0357-11e8-941c-1b3c5a1b2f3b.png width=300>


## Related PRs

react-native-website PR coming soon.

## Release Notes
[IOS] [MINOR] [Image] - Include resizeMode=center in RNTester
