### PR TITLE
Fix - Unable to build React target after a 'pod install'

### DIFF
--- a/ReactCommon/yoga/yoga.podspec
+++ b/ReactCommon/yoga/yoga.podspec
@@ -41,4 +41,8 @@ Pod::Spec.new do |spec|
   source_files = 'yoga/**/*.{cpp,h}'
   source_files = File.join('ReactCommon/yoga', source_files) if ENV['INSTALL_YOGA_WITHOUT_PATH_OPTION']
   spec.source_files = source_files
+
+  # Only expose the needed headers
+  spec.public_header_files = 'yoga/Yoga.h', 'yoga/YGEnums.h', 'yoga/YGMacros.h'
+
 end


### PR DESCRIPTION
The following error was thrown:
'string' file not found

To fix the issue, the Yoga's headers importing classes from the STL
have been excluded from the generated umbrella file via the podspec.

## Motivation

Integrate React Native into an existing native app.

## Test Plan

This has been tested by building a native app using the React pod.
