### PR TITLE
DX: log full js errors instead of just error messages (ExceptionsManager)

### DIFF
--- a/Libraries/Core/ExceptionsManager.js
+++ b/Libraries/Core/ExceptionsManager.js
@@ -62,9 +62,9 @@ function handleException(e: Error, isFatal: boolean) {
     e = new Error(e);
   }
   if (console._errorOriginal) {
-    console._errorOriginal(e.message);
+    console._errorOriginal(e);
   } else {
-    console.error(e.message);
+    console.error(e);
   }
   reportException(e, isFatal);
 }


### PR DESCRIPTION
## Motivation

This is really annoying DX to not have full stacktrace of errors in Chrome developer tools.

This kind of error is totally unactionnable without deeper debugging, as we don't have a single stacktrace, while it could be made actionnable easily

![image](https://user-images.githubusercontent.com/749374/35510653-479a9406-04f9-11e8-8790-2512e4033105.png)

Some issues already have been opened regarding this problem, yet they did not get much attention and got closed by stale bot.

https://github.com/facebook/react-native/issues/16661
https://github.com/facebook/react-native/issues/16205

## Test Plan

Errors are logged appropriately in Chrome developer tools with full stacktrace

## Release Notes

[ENHANCEMENT][MINOR][ExceptionsManager.js] Log full errors instead of just error messages

## Other


I must admin I may not see all the implications of why the message did got logged instead of the full exception in the first place. 

If you know why and there's a good reason, please tell me and we can probably do something better than current state to help people debug RN apps.

