### PR TITLE
Remove obsolete comment

### DIFF
--- a/Libraries/Components/Picker/PickerAndroid.android.js
+++ b/Libraries/Components/Picker/PickerAndroid.android.js
@@ -70,7 +70,6 @@ class PickerAndroid extends React.Component<{
     this.setState(this._stateFromProps(nextProps));
   }
 
-  // Translate prop and children into stuff that the native picker understands.
   _stateFromProps = (props) => {
     var selectedIndex = 0;
     const items = React.Children.map(props.children, (child, index) => {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes. 

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to React Native here: http://facebook.github.io/react-native/docs/contributing.html

Happy contributing!

-->

## Motivation

Obsolete code, removed because it speaks for it self

## Test Plan (not required)

Not Required, just removed a comment line. 
Still I've runned the following tests
- ./scripts/objc-test-ios.sh 
- npm run lint, 
- npm test

with the result of,

Test Suites: 2 skipped, 98 passed, 98 of 100 total
Tests:       4 skipped, 534 passed, 538 total
Snapshots:   37 passed, 37 total
Time:        27.211s
Ran all test suites.

## Release Notes
[DOCS] [MINOR] [PickerAndroid] - obsolete comment, code speaks for it self