### PR TITLE
cause error "No component found for view with name "RCTText"" in ios

### DIFF
--- a/React.podspec
+++ b/React.podspec
@@ -204,7 +204,7 @@ Pod::Spec.new do |s|
 
   s.subspec "RCTText" do |ss|
     ss.dependency             "React/Core"
-    ss.source_files         = "Libraries/Text/*.{h,m}"
+    ss.source_files         = "Libraries/Text/**/*.{h,m}"
   end
 
   s.subspec "RCTVibration" do |ss|


### PR DESCRIPTION
## Motivation

The project refactor /Library/Text include the directory ,but React.podspec isn't update the config of RCTText subspec ,cause error "No component found for view with name "RCTText""

## Test Plan

fix the bug.

## Related PRs

none

## Release Notes

 [IOS] [BUGFIX] [RCTText] - No component found for view with name "RCTText"
