### PR TITLE
Added new command for different directory

### DIFF
--- a/local-cli/runAndroid/runAndroid.js
+++ b/local-cli/runAndroid/runAndroid.js
@@ -172,9 +172,9 @@ function tryInstallAppOnDevice(args, device) {
   }
 }
 
-function tryLaunchAppOnDevice(device, packageNameWithSuffix, packageName, adbPath, mainActivity) {
+function tryLaunchAppOnDevice(device, packageNameWithSuffix, packageName, adbPath, launcherDir, mainActivity) {
   try {
-    const adbArgs = ['-s', device, 'shell', 'am', 'start', '-n', packageNameWithSuffix + '/' + packageName + '.' + mainActivity];
+    const adbArgs = ['-s', device, 'shell', 'am', 'start', '-n', packageNameWithSuffix + '/' + packageName + launcherDir + '.' + mainActivity];
     console.log(chalk.bold(
       `Starting the app on ${device} (${adbPath} ${adbArgs.join(' ')})...`
     ));
@@ -189,7 +189,7 @@ function tryLaunchAppOnDevice(device, packageNameWithSuffix, packageName, adbPat
 function installAndLaunchOnDevice(args, selectedDevice, packageNameWithSuffix, packageName, adbPath) {
   tryRunAdbReverse(args.port, selectedDevice);
   tryInstallAppOnDevice(args, selectedDevice);
-  tryLaunchAppOnDevice(selectedDevice, packageNameWithSuffix, packageName, adbPath, args.mainActivity);
+  tryLaunchAppOnDevice(selectedDevice, packageNameWithSuffix, packageName, adbPath, args.activityLauncherDir, args.mainActivity);
 }
 
 function runOnAllDevices(args, cmd, packageNameWithSuffix, packageName, adbPath){
@@ -237,14 +237,14 @@ function runOnAllDevices(args, cmd, packageNameWithSuffix, packageName, adbPath)
     if (devices && devices.length > 0) {
       devices.forEach((device) => {
         tryRunAdbReverse(args.port, device);
-        tryLaunchAppOnDevice(device, packageNameWithSuffix, packageName, adbPath, args.mainActivity);
+        tryLaunchAppOnDevice(device, packageNameWithSuffix, packageName, adbPath, args.activityLauncherDir,args.mainActivity);
       });
     } else {
       try {
         // If we cannot execute based on adb devices output, fall back to
         // shell am start
         const fallbackAdbArgs = [
-          'shell', 'am', 'start', '-n', packageNameWithSuffix + '/' + packageName + '.MainActivity'
+          'shell', 'am', 'start', '-n', packageNameWithSuffix + '/' + packageName + args.activityLauncherDir + '.MainActivity'
         ];
         console.log(chalk.bold(
           `Starting the app (${adbPath} ${fallbackAdbArgs.join(' ')}...`
@@ -341,5 +341,9 @@ module.exports = {
     command: '--port [number]',
     default: process.env.RCT_METRO_PORT || 8081,
     parse: (val: string) => Number(val),
+  }, {
+    command: '--activityLauncherDir [string]',
+    description: 'Specify an folder for launcher activity.',
+    default: '',
   }],
 };


### PR DESCRIPTION
Initially, our runAndroid.js pick a default path (i.e package + '.' + .MainActivity), which has a problem because existing android app have different project structure and most of the developer, maintain clean architecture in different directory
Example If suppose if '.MainActivity' is placed in 'activity' directory then react-native still don't have an option where explicitly provide activity launcher directory, So that I have to add another command where we can provide activity launcher directory by using the following command (i.e = react-native run-android --activityLauncherDir=.activity.xxx.yyy, it indicates your launcher activity present in - package.activity.xxx.yyy.MainActvity)

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes. 

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to React Native here: http://facebook.github.io/react-native/docs/contributing.html

Happy contributing!

-->

## Motivation

Code merge is my motivation

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/react-native-website, and link to your PR here.)

## Release Notes
<!--
Help reviewers and the release process by writing your own release notes

**INTERNAL and MINOR tagged notes will not be included in the next version's final release notes.**

  CATEGORY
[----------]        TYPE
[ CLI      ]   [-------------]      LOCATION
[ DOCS     ]   [ BREAKING    ]   [-------------]
[ GENERAL  ]   [ BUGFIX      ]   [-{Component}-]
[ INTERNAL ]   [ ENHANCEMENT ]   [ {File}      ]
[ IOS      ]   [ FEATURE     ]   [ {Directory} ]   |-----------|
[ ANDROID  ]   [ MINOR       ]   [ {Framework} ] - | {Message} |
[----------]   [-------------]   [-------------]   |-----------|

[CATEGORY] [TYPE] [LOCATION] - MESSAGE

 EXAMPLES:

Running /Users/atulsakhala/Library/Android/sdk/platform-tools/adb -s ZY223M69JK reverse tcp:8081 tcp:8081
Starting the app on ZY223M69JK (/Users/atulsakhala/Library/Android/sdk/platform-tools/adb -s ZY223M69JK shell am start -n com.rivigo.pilot.app/com.rivigo.pilot.app.MainActivity)...
Starting: Intent { cmp=com.rivigo.pilot.app/.MainActivity }
Error type 3
Error: Activity class {com.rivigo.pilot.app/com.rivigo.pilot.app.MainActivity} does not exist.

Resolution
react-native run-android --activityLauncherDir=[.][ParentFolder.childFolder] 


-->
