### PR TITLE
Remove Array.from in BackHandler.android.js to fix bug on back press

### DIFF
--- a/Libraries/Utilities/BackHandler.android.js
+++ b/Libraries/Utilities/BackHandler.android.js
@@ -22,9 +22,7 @@ var _backPressSubscriptions = new Set();
 
 RCTDeviceEventEmitter.addListener(DEVICE_BACK_EVENT, function() {
   var invokeDefault = true;
-  let subscriptions = [];
-  _backPressSubscriptions.forEach(subscription => subscriptions.push(subscription));
-  subscriptions = subscriptions.reverse();
+  var subscriptions = Array.from(_backPressSubscriptions.values()).reverse();
 
   for (var i = 0; i < subscriptions.length; ++i) {
     if (subscriptions[i]()) {

--- a/Libraries/Utilities/BackHandler.android.js
+++ b/Libraries/Utilities/BackHandler.android.js
@@ -22,7 +22,9 @@ var _backPressSubscriptions = new Set();
 
 RCTDeviceEventEmitter.addListener(DEVICE_BACK_EVENT, function() {
   var invokeDefault = true;
-  var subscriptions = Array.from(_backPressSubscriptions.values()).reverse();
+  let subscriptions = [];
+  _backPressSubscriptions.forEach(subscription => subscriptions.push(subscription));
+  subscriptions = subscriptions.reverse();
 
   for (var i = 0; i < subscriptions.length; ++i) {
     if (subscriptions[i]()) {

--- a/Libraries/polyfills/Array.es6.js
+++ b/Libraries/polyfills/Array.es6.js
@@ -28,9 +28,7 @@ if (!Array.from) {
 
     var C = this;
     var items = Object(arrayLike);
-    var symbolIterator = typeof Symbol === 'function'
-      ? Symbol.iterator
-      : '@@iterator';
+    var symbolIterator = '@@iterator';
     var mapping = typeof mapFn === 'function';
     var usingIterator = typeof items[symbolIterator] === 'function';
     var key = 0;

--- a/Libraries/vendor/core/toIterator.js
+++ b/Libraries/vendor/core/toIterator.js
@@ -22,9 +22,7 @@ var KIND_KEY = 'key';
 var KIND_VALUE = 'value';
 var KIND_KEY_VAL = 'key+value';
 /*global Symbol: true*/
-var ITERATOR_SYMBOL = (typeof Symbol === 'function')
-    ? Symbol.iterator
-    : '@@iterator';
+var ITERATOR_SYMBOL = '@@iterator';
 
 var toIterator = (function() {
   if (!(Array.prototype[ITERATOR_SYMBOL] &&

--- a/babel-preset/transforms/transform-symbol-member.js
+++ b/babel-preset/transforms/transform-symbol-member.js
@@ -32,6 +32,10 @@ module.exports = function symbolMember(babel) {
         }
 
         let node = path.node;
+        if (!isIteratorProperty(node)) {
+          path.replaceWith('@@iterator');
+          return;
+        }
 
         path.replaceWith(
           t.conditionalExpression(
@@ -64,4 +68,8 @@ function isAppropriateMember(path) {
     node.object.type === 'Identifier' &&
     node.object.name === 'Symbol' &&
     node.property.type === 'Identifier';
+}
+
+function isIteratorProperty(node) {
+  return node.property.name === 'iterator';
 }


### PR DESCRIPTION
## Motivation

An issue on the BackHandler of Android has been introduced by [this commit](https://github.com/facebook/react-native/commit/165b38ab7abdf9d769efddde39da35a03564284b#diff-9c3e02e844d6379291698a3c1210055a). When we want to customise the back press behaviour, no matter if the `hardwareBackPress`listener returns true or false, the app is exited. It must due to a conflict between the `Set` polyfill and an other one as it does not happen on every app.

See [the issue](https://github.com/facebook/react-native/issues/15497) here.

## Test Plan

Use a custom listener like this one for `hardwareBackPress`:
```javascript
  backAction = () => {
    return true
  };
```

Here are 2 videos.
The first one is made with the fix (RN 0.52.2) : 
![ezgif-1-744ca685e9](https://user-images.githubusercontent.com/15011364/35682893-892d6482-0762-11e8-92a1-d5e1d36e250b.gif)

The second one is without the fix (RN 0.52.2 as well) :
![ezgif-1-9f7a6d3dcc](https://user-images.githubusercontent.com/15011364/35682689-d917a1b6-0761-11e8-980b-925b34f0f9af.gif)

## Release Notes
[ANDROID] [BUGFIX] [BackHandler] - Fix the backPress: if the listener returns true, the app does not exit