### PR TITLE
Added new command for different directory

### DIFF
--- a/local-cli/runAndroid/runAndroid.js
+++ b/local-cli/runAndroid/runAndroid.js
@@ -172,9 +172,12 @@ function tryInstallAppOnDevice(args, device) {
   }
 }
 
-function tryLaunchAppOnDevice(device, packageNameWithSuffix, packageName, adbPath, mainActivity) {
+function tryLaunchAppOnDevice(device, packageNameWithSuffix, packageName, adbPath, launcherDir, mainActivity) {
   try {
-    const adbArgs = ['-s', device, 'shell', 'am', 'start', '-n', packageNameWithSuffix + '/' + packageName + '.' + mainActivity];
+    var adbArgs = ['-s', device, 'shell', 'am', 'start', '-n', packageNameWithSuffix + '/' + packageName + '.' + mainActivity];
+    if(launcherDir !== undefined) {
+        adbArgs = ['-s', device, 'shell', 'am', 'start', '-n', packageNameWithSuffix + '/' + packageName + '.' + launcherDir + '.' + mainActivity];
+    }
     console.log(chalk.bold(
       `Starting the app on ${device} (${adbPath} ${adbArgs.join(' ')})...`
     ));
@@ -189,7 +192,7 @@ function tryLaunchAppOnDevice(device, packageNameWithSuffix, packageName, adbPat
 function installAndLaunchOnDevice(args, selectedDevice, packageNameWithSuffix, packageName, adbPath) {
   tryRunAdbReverse(args.port, selectedDevice);
   tryInstallAppOnDevice(args, selectedDevice);
-  tryLaunchAppOnDevice(selectedDevice, packageNameWithSuffix, packageName, adbPath, args.mainActivity);
+  tryLaunchAppOnDevice(selectedDevice, packageNameWithSuffix, packageName, adbPath, args.activityLauncherDir, args.mainActivity);
 }
 
 function runOnAllDevices(args, cmd, packageNameWithSuffix, packageName, adbPath){
@@ -237,15 +240,21 @@ function runOnAllDevices(args, cmd, packageNameWithSuffix, packageName, adbPath)
     if (devices && devices.length > 0) {
       devices.forEach((device) => {
         tryRunAdbReverse(args.port, device);
-        tryLaunchAppOnDevice(device, packageNameWithSuffix, packageName, adbPath, args.mainActivity);
+        tryLaunchAppOnDevice(device, packageNameWithSuffix, packageName, adbPath, args.activityLauncherDir,args.mainActivity);
       });
     } else {
       try {
         // If we cannot execute based on adb devices output, fall back to
         // shell am start
-        const fallbackAdbArgs = [
+        var fallbackAdbArgs = [
           'shell', 'am', 'start', '-n', packageNameWithSuffix + '/' + packageName + '.MainActivity'
         ];
+
+        if(args.activityLauncherDir !== undefined) {
+            const fallbackAdbArgs = [
+                'shell', 'am', 'start', '-n', packageNameWithSuffix + '/' + packageName + '.' + args.activityLauncherDir + '.MainActivity'
+            ];
+        }
         console.log(chalk.bold(
           `Starting the app (${adbPath} ${fallbackAdbArgs.join(' ')}...`
         ));
@@ -341,5 +350,9 @@ module.exports = {
     command: '--port [number]',
     default: process.env.RCT_METRO_PORT || 8081,
     parse: (val: string) => Number(val),
+  }, {
+    command: '--activityLauncherDir [string]',
+    description: 'Specify an folder for launcher activity.',
+    default: undefined,
   }],
 };


### PR DESCRIPTION
initially, our runAndroid.js pick a default path (i.e package + '.' + .MainActivity), which has a problem because existing android app have different project structure and most of the developer, maintain clean architecture in the different directory
Example If suppose if '.MainActivity' is placed in 'activity' directory then react-native still don't have an option where explicitly provide activity launcher directory, So that I have to add another command where we can provide activity launcher directory by using the following command (i.e = react-native run-android --activityLauncherDir=.activity.xxx.yyy, it indicates your launcher activity present in - package.activity.xxx.yyy.MainActvity)

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes. 

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to React Native here: http://facebook.github.io/react-native/docs/contributing.html

Happy contributing!

-->

## Motivation

When it merge it motivate me. 

## Test Plan

`command: '--activityLauncherDir [string]',
  description: 'Specify an folder for launcher activity.',
  default: undefined,`

**Run command when your launcher activity in different directory**

<img width="1406" alt="screen shot 2018-02-02 at 12 54 12 am" src="https://user-images.githubusercontent.com/3988942/35698739-f8a4649a-07b3-11e8-8a50-ee7e884b14c3.png">

**Execute successfully**

<img width="1409" alt="screen shot 2018-02-02 at 12 15 52 am" src="https://user-images.githubusercontent.com/3988942/35698780-1deb3648-07b4-11e8-87f7-1f3c4ea717e4.png">



## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/react-native-website, and link to your PR here.)

## Release Notes

[CLI] [ENHANCEMENT] [local-cli/runAndroid/runAndroid.js] - RN command line enhancement
[ANDROID] [ENHANCEMENT] [runAndroid.js] - Open launcher from anywhere via specify directory


 EXAMPLES:
#14952 
Example - `react-native run-android --activityLauncherDir=[Dir1].[Dir2]` ...so on and enter
[[CLI] [ENHANCEMENT] [local-cli/runAndroid/runAndroid.js]
[ANDROID] [ENHANCEMENT] [runAndroid.js]
@hramos 
