### PR TITLE
Increase Tls1.2.0 support on Android (5.0.1 and below) 

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/modules/network/OkHttpClientProvider.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/network/OkHttpClientProvider.java
@@ -23,7 +23,6 @@ import java.util.concurrent.TimeUnit;
 
 import okhttp3.ConnectionSpec;
 import okhttp3.OkHttpClient;
-import okhttp3.TlsVersion;
 
 /**
  * Helper class that provides the same OkHttpClient instance that will be used for all networking
@@ -47,7 +46,7 @@ public class OkHttpClientProvider {
     }
     return sClient;
   }
-  
+
   // okhttp3 OkHttpClient is immutable
   // This allows app to init an OkHttpClient with custom settings.
   public static void replaceOkHttpClient(OkHttpClient client) {
@@ -91,12 +90,8 @@ public class OkHttpClientProvider {
 
         client.sslSocketFactory(new TLSSocketFactory(trustManager), trustManager);
 
-        ConnectionSpec cs = new ConnectionSpec.Builder(ConnectionSpec.MODERN_TLS)
-                .tlsVersions(TlsVersion.TLS_1_0, TlsVersion.TLS_1_1, TlsVersion.TLS_1_2)
-                .build();
-
         List<ConnectionSpec> specs = new ArrayList<>();
-        specs.add(cs);
+        specs.add(ConnectionSpec.MODERN_TLS);
         specs.add(ConnectionSpec.COMPATIBLE_TLS);
         specs.add(ConnectionSpec.CLEARTEXT);
 

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/network/OkHttpClientProvider.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/network/OkHttpClientProvider.java
@@ -65,16 +65,16 @@ public class OkHttpClientProvider {
       .writeTimeout(0, TimeUnit.MILLISECONDS)
       .cookieJar(new ReactCookieJarContainer());
 
-    return enableTls12OnPreLollipop(client);
+    return enableTls12OnLollipopAndBelow(client).build();
   }
 
   /*
-    On Android 4.1-4.4 (API level 16 to 19) TLS 1.1 and 1.2 are
+    On Android 4.1-5.0 (API level 16 to 21) TLS 1.1 and 1.2 are
     available but not enabled by default. The following method
     enables it.
    */
-  public static OkHttpClient.Builder enableTls12OnPreLollipop(OkHttpClient.Builder client) {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN && Build.VERSION.SDK_INT <= Build.VERSION_CODES.KITKAT) {
+  public static OkHttpClient.Builder enableTls12OnLollipopAndBelow(OkHttpClient.Builder client) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN && Build.VERSION.SDK_INT <= Build.VERSION_CODES.LOLLIPOP) {
       try {
         client.sslSocketFactory(new TLSSocketFactory());
 

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/network/OkHttpClientProvider.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/network/OkHttpClientProvider.java
@@ -16,12 +16,9 @@ import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
 import javax.net.ssl.X509TrustManager;
 import java.security.KeyStore;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import okhttp3.ConnectionSpec;
 import okhttp3.OkHttpClient;
 
 /**
@@ -31,10 +28,12 @@ import okhttp3.OkHttpClient;
 public class OkHttpClientProvider {
 
   // Centralized OkHttpClient for all networking requests.
-  private static @Nullable OkHttpClient sClient;
+  private static @Nullable
+  OkHttpClient sClient;
 
   // User-provided OkHttpClient factory
-  private static @Nullable OkHttpClientFactory sFactory;
+  private static @Nullable
+  OkHttpClientFactory sFactory;
 
   public static void setOkHttpClientFactory(OkHttpClientFactory factory) {
     sFactory = factory;
@@ -89,13 +88,6 @@ public class OkHttpClientProvider {
         X509TrustManager trustManager = (X509TrustManager) trustManagers[0];
 
         client.sslSocketFactory(new TLSSocketFactory(trustManager), trustManager);
-
-        List<ConnectionSpec> specs = new ArrayList<>();
-        specs.add(ConnectionSpec.MODERN_TLS);
-        specs.add(ConnectionSpec.COMPATIBLE_TLS);
-        specs.add(ConnectionSpec.CLEARTEXT);
-
-        client.connectionSpecs(specs);
       } catch (Exception exc) {
         FLog.e("OkHttpClientProvider", "Error while enabling TLS 1.2", exc);
       }

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/network/OkHttpClientProvider.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/network/OkHttpClientProvider.java
@@ -79,7 +79,7 @@ public class OkHttpClientProvider {
         client.sslSocketFactory(new TLSSocketFactory());
 
         ConnectionSpec cs = new ConnectionSpec.Builder(ConnectionSpec.MODERN_TLS)
-                .tlsVersions(TlsVersion.TLS_1_2)
+                .tlsVersions(TlsVersion.TLS_1_0, TlsVersion.TLS_1_1, TlsVersion.TLS_1_2)
                 .build();
 
         List<ConnectionSpec> specs = new ArrayList<>();

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/network/TLSSocketFactory.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/network/TLSSocketFactory.java
@@ -6,16 +6,17 @@
  */
 package com.facebook.react.modules.network;
 
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.Socket;
 import java.net.UnknownHostException;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
-
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLSocket;
-import javax.net.ssl.SSLSocketFactory;
 
 /**
  *
@@ -26,9 +27,9 @@ import javax.net.ssl.SSLSocketFactory;
 public class TLSSocketFactory extends SSLSocketFactory {
     private SSLSocketFactory delegate;
 
-    public TLSSocketFactory() throws KeyManagementException, NoSuchAlgorithmException {
+    public TLSSocketFactory(X509TrustManager trustManager) throws KeyManagementException, NoSuchAlgorithmException {
         SSLContext context = SSLContext.getInstance("TLS");
-        context.init(null, null, null);
+        context.init(null, new TrustManager[]{trustManager}, null);
         delegate = context.getSocketFactory();
     }
 


### PR DESCRIPTION
## Motivation

On older Android devices (5.0.1 and below), TLS1.2 is not supported by default. There is already a fix in place for this on React Native, but it requires some improvements. Added a few extra details to cover wider range of devices:

- Current fix covers SDK 19 and below, but same issue is reported up to api 21 for some Samsung devices. Increased version check for the fix
- Current fix only forces Tlsv1.2 but we should keep the support for 1.1 and 1.0, so switched to default connection specs from OkHttpClient
- `sslSocketFactory` method in OkHttpClient is deprecated. Applied the recommended fix from OkHttpClient documentations. Deprecated method uses reflection to access TrustManager, which requires an extra proguard rule on projects. 

## Test Plan

- This PR is an improvement on an existing fix. All tests are running as expected.

## Related PRs

Previous commit on the issue: https://github.com/facebook/react-native/commit/55ebb89916bd084c3c352d0f9948ae0583e583ac

## Release Notes

[ANDROID] [BUGFIX][OkHttpClientProvider.java] Fixed issues with TLSv1.2 on older devices