### PR TITLE
Fix DynamicFromMap object pool synchronization

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/DynamicFromMap.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/DynamicFromMap.java
@@ -9,13 +9,18 @@ package com.facebook.react.bridge;
 
 import javax.annotation.Nullable;
 
-import android.support.v4.util.Pools;
+import android.support.v4.util.Pools.SimplePool;
 
 /**
  * Implementation of Dynamic wrapping a ReadableMap.
  */
 public class DynamicFromMap implements Dynamic {
-  private static final Pools.SimplePool<DynamicFromMap> sPool = new Pools.SimplePool<>(10);
+  private static final ThreadLocal<SimplePool<DynamicFromMap>> sPool = new ThreadLocal<SimplePool<DynamicFromMap>>() {
+    @Override
+    protected SimplePool<DynamicFromMap> initialValue() {
+      return new SimplePool<>(10);
+    }
+  };
 
   private @Nullable ReadableMap mMap;
   private @Nullable String mName;
@@ -24,7 +29,7 @@ public class DynamicFromMap implements Dynamic {
   private DynamicFromMap() {}
 
   public static DynamicFromMap create(ReadableMap map, String name) {
-    DynamicFromMap dynamic = sPool.acquire();
+    DynamicFromMap dynamic = sPool.get().acquire();
     if (dynamic == null) {
       dynamic = new DynamicFromMap();
     }
@@ -37,7 +42,7 @@ public class DynamicFromMap implements Dynamic {
   public void recycle() {
     mMap = null;
     mName = null;
-    sPool.release(this);
+    sPool.get().release(this);
   }
 
   @Override


### PR DESCRIPTION
## Motivation
DynamicFromMap internally uses SimplePool object to recycle dynamic prop objects. But the pool is not multi-thread safe. Currently the most used dynamic props are size props such as left, paddingVertical, marginTop and so on. These props are only accessed from the layout thread so the pool works fine. If a dynamic prop is needed in UI thread, then the two threads can access the same pool object and cause random errors. This PR make the pool object thread local to avoid synchronization. After this change there are two pool objects created in the process.

## Test Plan
Tested in official Airbnb app after updating accessibilityComponentType to be dynamic.

## Related PRs
Once this is merged, I'll send another PR to support "disabled" state in `accessibilityComponentType`.

## Release Notes
[ANDROID] [BUGFIX] [DynamicFromMap] - Fix a crash caused by dynamic props.
