### PR TITLE
AnimatedImplementation: Make sure we don't attempt to start an animation with index above array-length.

### DIFF
--- a/Libraries/Animated/src/AnimatedImplementation.js
+++ b/Libraries/Animated/src/AnimatedImplementation.js
@@ -293,7 +293,7 @@ const sequence = function(
 
       if (animations.length === 0) {
         callback && callback({finished: true});
-      } else {
+      } else if (animations[current]){
         animations[current].start(onComplete);
       }
     },


### PR DESCRIPTION
Sometimes, the index for the animations-array will be outside the range of the array, so we need a nullcheck before attempting to do `animations[current].start(onComplete);`

fixes #17699

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes. 

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to React Native here: http://facebook.github.io/react-native/docs/contributing.html

Happy contributing!

-->

## Motivation

Fix the bug.

## Test Plan

Tested it in application, simple fix so should not have any side-effects.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/react-native-website, and link to your PR here.)

## Release Notes

[Android] [Fixes] - AnimatedImplementation : Make sure we don't attempt to start an animation with index above array-length. 