### PR TITLE
Support non-integer modulus in ModulusAnimatedNode on Android

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/animated/ModulusAnimatedNode.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/animated/ModulusAnimatedNode.java
@@ -17,14 +17,14 @@ import com.facebook.react.bridge.ReadableMap;
 
   private final NativeAnimatedNodesManager mNativeAnimatedNodesManager;
   private final int mInputNode;
-  private final int mModulus;
+  private final double mModulus;
 
   public ModulusAnimatedNode(
       ReadableMap config,
       NativeAnimatedNodesManager nativeAnimatedNodesManager) {
     mNativeAnimatedNodesManager = nativeAnimatedNodesManager;
     mInputNode = config.getInt("input");
-    mModulus = config.getInt("modulus");
+    mModulus = config.getDouble("modulus");
   }
 
   @Override


### PR DESCRIPTION
## Motivation

`Animated.modulo(value, modulus)` supports a non-integer modulus in the iOS and JS implementations but crashes on Android when `useNativeDriver` is set to `true`.

## Test Plan

Unfortunately, I'm not fluent enough with this codebase to add a Java test for this fix - especially as I couldn't find any analogous tests to extrapolate from. However, the fix itself seems straightforward enough.

## Related PRs

None needed

## Release Notes
[ANDROID] [BUGFIX] [Animated] - Support non-integer modulus in .modulo()