### PR TITLE
Removing warning for Pointer is missing a nullability type specifier …

### DIFF
--- a/React/Base/Surface/SurfaceHostingView/RCTSurfaceHostingView.h
+++ b/React/Base/Surface/SurfaceHostingView/RCTSurfaceHostingView.h
@@ -15,7 +15,7 @@
 @class RCTBridge;
 @class RCTSurface;
 
-typedef UIView *(^RCTSurfaceHostingViewActivityIndicatorViewFactory)();
+typedef UIView *_Nullable(^RCTSurfaceHostingViewActivityIndicatorViewFactory)(void);
 
 NS_ASSUME_NONNULL_BEGIN
 


### PR DESCRIPTION
Xcode 9 has compiler settings that are more strict. This can occur if someone updates there project to use the default settings.

This patch declares the default type instead of allowing the compiler to determine it. Instead of () we now say (void) in a block call.

Motivation
It was just trying to get my project totally empty of warnings, and it has no side effects. If there are side effects, then we should fix the type and not go with empty to represent void.

Test Plan
Update project settings in Xcode. This code doesn't have any known side effects since the compiler assumes the type is void when not declared.

Release Notes
[DOCS] - Fixed potential compiler build issue on Xcode 9 after updating settings in project.