### PR TITLE
Exclude jsbundle files from VCS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,6 @@ node_modules
 
 /coverage
 /third-party
+
+# Bundle artifact
+*.jsbundle


### PR DESCRIPTION
## Motivation

jsbundle files can be generated, and are quite large and therefore, I think should be excluded from being committed to the repo.

[ GENERAL ][ MINOR ][.gitignore] - Included a new entry to exclude jsbundle files