### PR TITLE
Exclude jsbundle files from VCS

### DIFF
--- a/local-cli/templates/HelloWorld/_gitignore
+++ b/local-cli/templates/HelloWorld/_gitignore
@@ -51,3 +51,6 @@ buck-out/
 */fastlane/report.xml
 */fastlane/Preview.html
 */fastlane/screenshots
+
+# Bundle artifact
+*.jsbundle


### PR DESCRIPTION
## Motivation

jsbundle files can be generated, and are quite large and therefore, I think should be excluded from being committed to the repo.

[ GENERAL ][ MINOR ][local-cli/templates/_gitignore] - Included a new entry to ignore jsbundle files