### PR TITLE
Add missing mock for AppState (removeEventListener)

### DIFF
--- a/jest/setup.js
+++ b/jest/setup.js
@@ -115,6 +115,7 @@ const mockNativeModules = {
   },
   AppState: {
     addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
   },
   AsyncLocalStorage: {
     multiGet: jest.fn((keys, callback) => process.nextTick(() => callback(null, []))),


### PR DESCRIPTION
## Motivation

I am testing with Jest a component that use [AppState.removeEventListener](https://facebook.github.io/react-native/docs/appstate.html#removeeventlistener) and I am currently facing a fatal error saying that `AppState.removeEventListener` is `undefined`. 

## Test Plan

Create a component that uses `AppState`, e.g.

```jsx
import React, { Component } from 'react';
import { AppState } from 'react-native';

class TestComponent extends Component {
  componentDidMount() {
    AppState.addEventListener('change', this.stateChangeListener);
  }
  componentWillUnmount() {
    AppState.removeEventListener('change', this.stateChangeListener);
  }
}
```

It should pass test using Jest (snapshots)

## Related PRs

It's the continuation of #11199. This PR finish the mock for the native module `AppState`.

## Release Notes

[ GENERAL  ]   [ BUGFIX      ]   [AppState] Add missing mock for Jest for `removeEventListener` method.