### PR TITLE
Update DevLoadingView to Support iPhone X

### DIFF
--- a/React/DevSupport/RCTDevLoadingView.m
+++ b/React/DevSupport/RCTDevLoadingView.m
@@ -73,8 +73,14 @@ RCT_EXPORT_METHOD(showMessage:(NSString *)message color:(UIColor *)color backgro
   dispatch_async(dispatch_get_main_queue(), ^{
     self->_showDate = [NSDate date];
     if (!self->_window && !RCTRunningInTestEnvironment()) {
-      CGFloat screenWidth = [UIScreen mainScreen].bounds.size.width;
-      self->_window = [[UIWindow alloc] initWithFrame:CGRectMake(0, 0, screenWidth, 22)];
+      CGSize screenSize = [UIScreen mainScreen].bounds.size;
+      if (screenSize.height == 812) {
+        self->_window = [[UIWindow alloc] initWithFrame:CGRectMake(0, 0, screenSize.width, 60)];
+        self->_label = [[UILabel alloc] initWithFrame:CGRectMake(0, 30, self->_window.bounds.size.width, 30)];
+      } else {
+        self->_window = [[UIWindow alloc] initWithFrame:CGRectMake(0, 0, screenSize.width, 22)];
+        self->_label = [[UILabel alloc] initWithFrame:self->_window.bounds];
+      }
 #if TARGET_OS_TV
       self->_window.windowLevel = UIWindowLevelNormal + 1;
 #else
@@ -83,7 +89,6 @@ RCT_EXPORT_METHOD(showMessage:(NSString *)message color:(UIColor *)color backgro
       // set a root VC so rotation is supported
       self->_window.rootViewController = [UIViewController new];
 
-      self->_label = [[UILabel alloc] initWithFrame:self->_window.bounds];
       self->_label.font = [UIFont systemFontOfSize:12.0];
       self->_label.textAlignment = NSTextAlignmentCenter;
 

--- a/React/DevSupport/RCTDevLoadingView.m
+++ b/React/DevSupport/RCTDevLoadingView.m
@@ -74,13 +74,14 @@ RCT_EXPORT_METHOD(showMessage:(NSString *)message color:(UIColor *)color backgro
     self->_showDate = [NSDate date];
     if (!self->_window && !RCTRunningInTestEnvironment()) {
       CGSize screenSize = [UIScreen mainScreen].bounds.size;
-      if (screenSize.height == 812) {
+      if (screenSize.height == 812 /* iPhone X */) {
         self->_window = [[UIWindow alloc] initWithFrame:CGRectMake(0, 0, screenSize.width, 60)];
         self->_label = [[UILabel alloc] initWithFrame:CGRectMake(0, 30, self->_window.bounds.size.width, 30)];
       } else {
         self->_window = [[UIWindow alloc] initWithFrame:CGRectMake(0, 0, screenSize.width, 22)];
         self->_label = [[UILabel alloc] initWithFrame:self->_window.bounds];
       }
+      [self->_window addSubview:self->_label];
 #if TARGET_OS_TV
       self->_window.windowLevel = UIWindowLevelNormal + 1;
 #else
@@ -91,8 +92,6 @@ RCT_EXPORT_METHOD(showMessage:(NSString *)message color:(UIColor *)color backgro
 
       self->_label.font = [UIFont systemFontOfSize:12.0];
       self->_label.textAlignment = NSTextAlignmentCenter;
-
-      [self->_window addSubview:self->_label];
     }
 
     self->_label.text = message;


### PR DESCRIPTION
## Motivation

The current implementation of DevLoadingView for iPhone currently gives a static height of `22` and does not take into account iPhoneX screen dimensions. 

## Test Plan
Devices: All iPhone devices currently available with Xcode v9.2
SDK: 8.1, 9, 10, 11

Validate resize only occurs on iPhone X devices and others remain consistent. 

### Screenshots / GIFs
Before: 
![feb-10-2018 12-30-20](https://user-images.githubusercontent.com/1743953/36065313-7b41f2ea-0e5e-11e8-87f2-928e26536077.gif)

After:
![feb-10-2018 12-28-15](https://user-images.githubusercontent.com/1743953/36065317-848e4f7e-0e5e-11e8-8aab-70cb5db32f31.gif)

## Release Notes
[GENERAL][ENHANCEMENT][{React}] - Improvements to DevLoadingView for iPhone X 
