### PR TITLE
[Internal] [Fix] Broken publish step on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -383,6 +383,9 @@ jobs:
   publish_npm_package:
     <<: *android_defaults
     steps:
+      # Checkout code so that we can work with `git` in publish.js
+      - checkout
+      
       - attach_workspace:
           at: ~/react-native
 
@@ -606,6 +609,7 @@ workflows:
       - approve_publish_npm_package:
           filters: *filter-only-stable
           type: approval
+
       - publish_npm_package:
           requires:
             - checkout_code

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -386,9 +386,6 @@ jobs:
       # Checkout code so that we can work with `git` in publish.js
       - checkout
       
-      - attach_workspace:
-          at: ~/react-native
-
       # Configure Android SDK and related dependencies
       - run: *configure-android-path
       - run: *install-android-build-dependencies
@@ -600,11 +597,7 @@ workflows:
 
   # Only runs on NN-stable branches
   deploy:
-    jobs:
-      # Checkout repo and run Yarn
-      - checkout_code:
-          filters: *filter-only-stable
-          
+    jobs:          
       # If we are on a stable branch, wait for approval to deploy to npm
       - approve_publish_npm_package:
           filters: *filter-only-stable
@@ -612,5 +605,4 @@ workflows:
 
       - publish_npm_package:
           requires:
-            - checkout_code
             - approve_publish_npm_package


### PR DESCRIPTION
Every `job` is run in a separate container and so, `checkout` step is required for the Git host to be added to `~/.ssh/known_hosts`. Without this step, it will timeout after 10 minutes waiting for you to add (yes) or reject (no) from known hosts (we get this prompt when we checkout from a host for the very first time).
