### PR TITLE
[Circle] Add disabled tests to CircleCI config, bump Xcode/iOS/tvOS versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -205,9 +205,17 @@ aliases:
     command: | 
       mkdir -p ~/react-native/reports/junit/
 
-  - &run-objc_ios-tests
+  - &build-objc-ios-test-app
+    name: Build Objective-C iOS Test App
+    command: ./scripts/objc-test-ios.sh
+  
+  - &run-objc-ios-tests
     name: Objective-C iOS Test Suite
     command: ./scripts/objc-test-ios.sh test
+
+  - &build-objc-tvos-test-app
+    name: Build Objective-C tvOS Test App
+    command: ./scripts/objc-test-tvos.sh
 
   - &run-objc-tvos-tests
     name: Objective-C tvOS Test Suite
@@ -317,6 +325,18 @@ jobs:
       - store_artifacts:
           path: ~/react-native/reports/junit
 
+  # Builds iOS test app
+  build_objc_ios_test_app:
+    <<: *macos_defaults
+    dependencies:
+      pre:
+        - xcrun instruments -w "iPhone 5s (11.1)" || true
+    steps:
+      - attach_workspace:
+          at: ~/react-native
+
+      - run: *build-objc-ios-test-app
+
   # Runs unit tests on iOS devices
   test_objc_ios:
     <<: *macos_defaults
@@ -327,12 +347,24 @@ jobs:
       - attach_workspace:
           at: ~/react-native
 
-      - run: *run-objc_ios-tests
+      - run: *run-objc-ios-tests
 
       - store_test_results:
           path: ~/react-native/reports/junit
       - store_artifacts:
           path: ~/react-native/reports/junit
+
+  # Builds tvOS test app
+  build_objc_tvos_test_app:
+    <<: *macos_defaults
+    dependencies:
+      pre:
+        - xcrun instruments -w "Apple TV 1080p (11.1)" || true
+    steps:
+      - attach_workspace:
+          at: ~/react-native
+
+      - run: *build-objc-tvos-test-app
 
   # Runs unit tests on tvOS devices
   test_objc_tvos:
@@ -564,12 +596,12 @@ workflows:
           requires:
             - checkout_code
 
-      # Test iOS & tvOS
-      - test_objc_ios:
+      # Build iOS & tvOS test apps
+      - build_objc_ios_test_app:
           filters: *filter-ignore-gh-pages
           requires:
             - checkout_code
-      - test_objc_tvos:
+      - build_objc_tvos_test_app:
           filters: *filter-ignore-gh-pages
           requires:
             - checkout_code
@@ -580,11 +612,31 @@ workflows:
           requires:
             - checkout_code
 
+  # These tests are flaky or are yet to be fixed. They are placed on their own 
+  # workflow to avoid marking benign PRs as broken.
+  disabled_tests:
+    jobs:
+      # Checkout repo and run Yarn
+      - checkout_code:
+        filters: *filter-ignore-gh-pages
+
+      # Test iOS & tvOS
+      - test_objc_ios:
+        filters: *filter-ignore-gh-pages
+        requires:
+          - checkout_code
+    
+      - test_objc_tvos:
+        filters: *filter-ignore-gh-pages
+        requires:
+          - checkout_code
+      
       # CocoaPods
       - test_podspec:
-          filters: *filter-ignore-gh-pages
-          requires:
-            - checkout_code
+        filters: *filter-ignore-gh-pages
+        requires:
+          - checkout_code
+
 
   # Only runs on PRs
   analyze:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -207,11 +207,11 @@ aliases:
 
   - &run-objc_ios-tests
     name: Objective-C iOS Test Suite
-    command: ./scripts/objc-test-ios.sh
+    command: ./scripts/objc-test-ios.sh test
 
   - &run-objc-tvos-tests
     name: Objective-C tvOS Test Suite
-    command: ./scripts/objc-test-tvos.sh
+    command: ./scripts/objc-test-tvos.sh test
 
   - &run-objc-ios-e2e-tests
     name: Objective-C iOS End-to-End Test Suite

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -245,7 +245,7 @@ android_defaults: &android_defaults
 macos_defaults: &macos_defaults
   <<: *defaults
   macos:
-    xcode: "9.0"
+    xcode: "9.2"
 
 version: 2
 jobs:
@@ -322,7 +322,7 @@ jobs:
     <<: *macos_defaults
     dependencies:
       pre:
-        - xcrun instruments -w "iPhone 5s (10.3.1)" || true
+        - xcrun instruments -w "iPhone 5s (11.1)" || true
     steps:
       - attach_workspace:
           at: ~/react-native
@@ -339,7 +339,7 @@ jobs:
     <<: *macos_defaults
     dependencies:
       pre:
-        - xcrun instruments -w "Apple TV 1080p (10.0)" || true
+        - xcrun instruments -w "Apple TV 1080p (11.1)" || true
     steps:
       - attach_workspace:
           at: ~/react-native
@@ -356,7 +356,7 @@ jobs:
     <<: *macos_defaults
     dependencies:
       pre:
-        - xcrun instruments -w "iPhone 5s (10.3.1)" || true
+        - xcrun instruments -w "iPhone 5s (11.1)" || true
     steps:
       - attach_workspace:
           at: ~/react-native
@@ -370,9 +370,7 @@ jobs:
 
   # Checks podspec
   test_podspec:
-    <<: *defaults
-    macos:
-      xcode: "9.0"
+    <<: *macos_defaults
     steps:
       - attach_workspace:
           at: ~/react-native
@@ -578,6 +576,12 @@ workflows:
 
       # End-to-end tests
       - test_objc_ios_e2e:
+          filters: *filter-ignore-gh-pages
+          requires:
+            - checkout_code
+
+      # CocoaPods
+      - test_podspec:
           filters: *filter-ignore-gh-pages
           requires:
             - checkout_code

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -245,7 +245,7 @@ android_defaults: &android_defaults
 macos_defaults: &macos_defaults
   <<: *defaults
   macos:
-    xcode: "9.2"
+    xcode: "9.2.0"
 
 version: 2
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -567,7 +567,7 @@ jobs:
 workflows:
   version: 2
 
-  test:
+  tests:
     jobs:
 
       # Checkout repo and run Yarn
@@ -612,33 +612,6 @@ workflows:
           requires:
             - checkout_code
 
-  # These tests are flaky or are yet to be fixed. They are placed on their own 
-  # workflow to avoid marking benign PRs as broken.
-  # TODO: Only run on branches? Master? Avoid PRs?
-  disabled_tests:
-    jobs:
-      # Checkout repo and run Yarn
-      - checkout_code:
-          filters: *filter-ignore-gh-pages
-
-      # Test iOS & tvOS
-      - test_objc_ios:
-          filters: *filter-ignore-gh-pages
-          requires:
-            - checkout_code
-    
-      - test_objc_tvos:
-          filters: *filter-ignore-gh-pages
-          requires:
-            - checkout_code
-      
-      # CocoaPods
-      - test_podspec:
-          filters: *filter-ignore-gh-pages
-          requires:
-            - checkout_code
-
-
   # Only runs on PRs
   analyze:
     jobs:
@@ -667,3 +640,30 @@ workflows:
           requires:
             - checkout_code
             - approve_publish_npm_package
+
+  # These tests are flaky or are yet to be fixed. They are placed on their own 
+  # workflow to avoid marking benign PRs as broken.
+  # To run them, uncomment the entire block and open a PR (do not merge). 
+  # Once a test is fixed, move the test definition to the 'tests' workflow.
+  # disabled_tests:
+  #   jobs:
+  #     # Checkout repo and run Yarn (pre-req, should succeed)
+  #     - checkout_code:
+  #         filters: *filter-ignore-gh-pages
+
+  #     # The following were DISABLED because they have not run since 
+  #     # the migration from Travis, and they have broken since then,
+  #     # Test iOS & tvOS
+  #     - test_objc_ios:
+  #         filters: *filter-ignore-gh-pages
+  #         requires:
+  #           - checkout_code
+  #     - test_objc_tvos:
+  #         filters: *filter-ignore-gh-pages
+  #         requires:
+  #           - checkout_code
+  #     # CocoaPods
+  #     - test_podspec:
+  #         filters: *filter-ignore-gh-pages
+  #         requires:
+  #           - checkout_code

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -614,28 +614,29 @@ workflows:
 
   # These tests are flaky or are yet to be fixed. They are placed on their own 
   # workflow to avoid marking benign PRs as broken.
+  # TODO: Only run on branches? Master? Avoid PRs?
   disabled_tests:
     jobs:
       # Checkout repo and run Yarn
       - checkout_code:
-        filters: *filter-ignore-gh-pages
+          filters: *filter-ignore-gh-pages
 
       # Test iOS & tvOS
       - test_objc_ios:
-        filters: *filter-ignore-gh-pages
-        requires:
-          - checkout_code
+          filters: *filter-ignore-gh-pages
+          requires:
+            - checkout_code
     
       - test_objc_tvos:
-        filters: *filter-ignore-gh-pages
-        requires:
-          - checkout_code
+          filters: *filter-ignore-gh-pages
+          requires:
+            - checkout_code
       
       # CocoaPods
       - test_podspec:
-        filters: *filter-ignore-gh-pages
-        requires:
-          - checkout_code
+          filters: *filter-ignore-gh-pages
+          requires:
+            - checkout_code
 
 
   # Only runs on PRs


### PR DESCRIPTION
These tests have not run for one reason or another since the migration from Travis. They are not passing, and are commented out to avoid flagging new PRs as breaking. These tests need to be fixed and re-enabled ASAP.