### PR TITLE
Text support boxNone mode: only \u2610 and \u2611 are clickable

### DIFF
--- a/Libraries/Text/Text/RCTTextView.h
+++ b/Libraries/Text/Text/RCTTextView.h
@@ -8,12 +8,14 @@
  */
 
 #import <UIKit/UIKit.h>
+#import <React/RCTPointerEvents.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface RCTTextView : UIView
 
 @property (nonatomic, assign) BOOL selectable;
+@property (nonatomic, assign) RCTPointerEvents pointerEvents;
 
 - (void)setTextStorage:(NSTextStorage *)textStorage
           contentFrame:(CGRect)contentFrame

--- a/Libraries/Text/Text/RCTTextViewManager.m
+++ b/Libraries/Text/Text/RCTTextViewManager.m
@@ -91,4 +91,32 @@ RCT_EXPORT_VIEW_PROPERTY(selectable, BOOL)
   [self.bridge.uiManager setNeedsLayout];
 }
 
+#pragma mark - Custom Box none
+
+RCT_CUSTOM_VIEW_PROPERTY(pointerEvents, RCTPointerEvents, RCTTextView)
+{
+  if ([view respondsToSelector:@selector(setPointerEvents:)]) {
+    view.pointerEvents = json ? [RCTConvert RCTPointerEvents:json] : defaultView.pointerEvents;
+    return;
+  }
+
+  if (!json) {
+    view.userInteractionEnabled = defaultView.userInteractionEnabled;
+    return;
+  }
+  RCTPointerEvents pointerEvents = [RCTConvert RCTPointerEvents:json];
+  view.userInteractionEnabled = (pointerEvents != RCTPointerEventsNone);
+  if (pointerEvents == RCTPointerEventsBoxNone) {
+    view.accessibilityViewIsModal = NO;
+  }
+  switch (pointerEvents) {
+    case RCTPointerEventsUnspecified:
+    case RCTPointerEventsBoxNone:
+    case RCTPointerEventsNone:
+      break;
+    default:
+      RCTLogError(@"UIView base class does not support pointerEvent value: %@", json);
+  }
+}
+
 @end

--- a/RNTester/js/TextExample.ios.js
+++ b/RNTester/js/TextExample.ios.js
@@ -288,6 +288,60 @@ class TextBaseLineLayoutExample extends React.Component<*, *> {
   }
 }
 
+class TextBoxNoneExample extends React.Component<*, *> {
+  render() {
+    const styles = {
+      container: {
+        height: 500,
+        backgroundColor: '#F5FCFF',
+      },
+      underView: {
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        width: 200,
+        height: 200,
+        padding: 40,
+        backgroundColor:'rgba(255, 200, 200, 0.5)',
+        zIndex: -1,
+      },
+      topTextOverlay: {
+        position: 'absolute',
+        top: 50,
+        left: 100,
+        width: 200,
+        height: 100,
+        backgroundColor:'rgba(200, 255, 200, 0.5)',
+        zIndex: 1,
+      },
+    };
+
+    return (
+      <View style={styles.container}>
+        <View style={styles.underView}>
+            <Text
+              style={{backgroundColor:'rgba(0,0,0,0.1)'}}
+              onPress={()=>{alert('underView clicked')}}
+            >
+              Clickable text in under view
+            </Text>
+        </View>
+        <Text
+          style={styles.topTextOverlay}
+          pointerEvents="box-none"
+        >
+            <Text
+              style={{backgroundColor:'rgba(0,0,0,0.1)'}}
+              onPress={()=>{alert('topView clicked')}}
+            >
+              only clicking {"\u2610"} or {"\u2611"} will trigger event, other event will pass to underView
+            </Text>
+        </Text>
+      </View>
+    );
+  }
+}
+
 exports.title = '<Text>';
 exports.description = 'Base component for rendering styled text.';
 exports.displayName = 'TextExample';
@@ -850,4 +904,10 @@ exports.examples = [
       return <TextBaseLineLayoutExample />;
     },
   },
+  {
+    title: 'Text Custom BoxNone support',
+    render: function() {
+      return <TextBoxNoneExample />;
+    },
+  }
 ];


### PR DESCRIPTION
see RNTester example. This is for OnigiriNote app

![0030-02-16 11 55 48](https://user-images.githubusercontent.com/32716/36292968-9cfe83b0-1310-11e8-8be0-682eb97adf72.jpg)
