### PR TITLE
Added support for using animated values as the target of an interpolation.

### DIFF
--- a/Libraries/Animated/src/AnimatedImplementation.js
+++ b/Libraries/Animated/src/AnimatedImplementation.js
@@ -39,6 +39,34 @@ import type {TimingAnimationConfig} from './animations/TimingAnimation';
 import type {DecayAnimationConfig} from './animations/DecayAnimation';
 import type {SpringAnimationConfig} from './animations/SpringAnimation';
 import type {Mapping, EventConfig} from './AnimatedEvent';
+import type {InterpolationConfigType} from './nodes/AnimatedInterpolation';
+
+const interpolateMethod = function(
+  config: InterpolationConfigType,
+): AnimatedInterpolation {
+  console.warn(
+    'The animation.interpolate(config) method will be removed from animated nodes in favour of Animated.interpolate(animation, config).',
+  );
+  return new AnimatedInterpolation(this, config);
+};
+
+// To avoid some code duplication and a circular dependency we
+// are adding the interpolate method directly onto these prototypes.
+// This should eventually be removed.
+//$FlowFixMe
+AnimatedAddition.prototype.interpolate = interpolateMethod;
+//$FlowFixMe
+AnimatedDiffClamp.prototype.interpolate = interpolateMethod;
+//$FlowFixMe
+AnimatedDivision.prototype.interpolate = interpolateMethod;
+//$FlowFixMe
+AnimatedInterpolation.prototype.interpolate = interpolateMethod;
+//$FlowFixMe
+AnimatedModulo.prototype.interpolate = interpolateMethod;
+//$FlowFixMe
+AnimatedMultiplication.prototype.interpolate = interpolateMethod;
+//$FlowFixMe
+AnimatedValue.prototype.interpolate = interpolateMethod;
 
 export type CompositeAnimation = {
   start: (callback?: ?EndCallback) => void,
@@ -231,6 +259,13 @@ const timing = function(
       },
     }
   );
+};
+
+const interpolate = function(
+  value: AnimatedValue,
+  config: InterpolationConfigType,
+): AnimatedInterpolation {
+  return new AnimatedInterpolation(value, config);
 };
 
 const decay = function(
@@ -545,6 +580,12 @@ module.exports = {
    * See http://facebook.github.io/react-native/docs/animated.html#node
    */
   Node: AnimatedNode,
+
+  /**
+   * Interpolates the value before updating the property, e.g. mapping 0-1 to
+   * 0-10.
+   */
+  interpolate,
 
   /**
    * Animates a value from an initial velocity to zero based on a decay

--- a/Libraries/Animated/src/__tests__/AnimatedNative-test.js
+++ b/Libraries/Animated/src/__tests__/AnimatedNative-test.js
@@ -475,8 +475,9 @@ describe('Native Animated', () => {
       expect(nativeAnimatedModule.createAnimatedNode)
         .toBeCalledWith(expect.any(Number), {
           type: 'interpolation',
+          parent: expect.any(Number),
           inputRange: [10, 20],
-          outputRange: [0, 1],
+          outputRange: [expect.any(Number), expect.any(Number)],
           extrapolateLeft: 'extend',
           extrapolateRight: 'extend',
         });

--- a/Libraries/Animated/src/nodes/AnimatedAddition.js
+++ b/Libraries/Animated/src/nodes/AnimatedAddition.js
@@ -10,12 +10,9 @@
  */
 'use strict';
 
-const AnimatedInterpolation = require('./AnimatedInterpolation');
 const AnimatedNode = require('./AnimatedNode');
 const AnimatedValue = require('./AnimatedValue');
 const AnimatedWithChildren = require('./AnimatedWithChildren');
-
-import type {InterpolationConfigType} from './AnimatedInterpolation';
 
 class AnimatedAddition extends AnimatedWithChildren {
   _a: AnimatedNode;
@@ -35,10 +32,6 @@ class AnimatedAddition extends AnimatedWithChildren {
 
   __getValue(): number {
     return this._a.__getValue() + this._b.__getValue();
-  }
-
-  interpolate(config: InterpolationConfigType): AnimatedInterpolation {
-    return new AnimatedInterpolation(this, config);
   }
 
   __attach(): void {

--- a/Libraries/Animated/src/nodes/AnimatedDiffClamp.js
+++ b/Libraries/Animated/src/nodes/AnimatedDiffClamp.js
@@ -10,11 +10,8 @@
  */
 'use strict';
 
-const AnimatedInterpolation = require('./AnimatedInterpolation');
 const AnimatedNode = require('./AnimatedNode');
 const AnimatedWithChildren = require('./AnimatedWithChildren');
-
-import type {InterpolationConfigType} from './AnimatedInterpolation';
 
 class AnimatedDiffClamp extends AnimatedWithChildren {
   _a: AnimatedNode;
@@ -35,10 +32,6 @@ class AnimatedDiffClamp extends AnimatedWithChildren {
   __makeNative() {
     this._a.__makeNative();
     super.__makeNative();
-  }
-
-  interpolate(config: InterpolationConfigType): AnimatedInterpolation {
-    return new AnimatedInterpolation(this, config);
   }
 
   __getValue(): number {

--- a/Libraries/Animated/src/nodes/AnimatedDivision.js
+++ b/Libraries/Animated/src/nodes/AnimatedDivision.js
@@ -10,12 +10,9 @@
  */
 'use strict';
 
-const AnimatedInterpolation = require('./AnimatedInterpolation');
 const AnimatedNode = require('./AnimatedNode');
 const AnimatedValue = require('./AnimatedValue');
 const AnimatedWithChildren = require('./AnimatedWithChildren');
-
-import type {InterpolationConfigType} from './AnimatedInterpolation';
 
 class AnimatedDivision extends AnimatedWithChildren {
   _a: AnimatedNode;
@@ -40,10 +37,6 @@ class AnimatedDivision extends AnimatedWithChildren {
       console.error('Detected division by zero in AnimatedDivision');
     }
     return a / b;
-  }
-
-  interpolate(config: InterpolationConfigType): AnimatedInterpolation {
-    return new AnimatedInterpolation(this, config);
   }
 
   __attach(): void {

--- a/Libraries/Animated/src/nodes/AnimatedModulo.js
+++ b/Libraries/Animated/src/nodes/AnimatedModulo.js
@@ -10,11 +10,8 @@
  */
 'use strict';
 
-const AnimatedInterpolation = require('./AnimatedInterpolation');
 const AnimatedNode = require('./AnimatedNode');
 const AnimatedWithChildren = require('./AnimatedWithChildren');
-
-import type {InterpolationConfigType} from './AnimatedInterpolation';
 
 class AnimatedModulo extends AnimatedWithChildren {
   _a: AnimatedNode;
@@ -35,10 +32,6 @@ class AnimatedModulo extends AnimatedWithChildren {
     return (
       (this._a.__getValue() % this._modulus + this._modulus) % this._modulus
     );
-  }
-
-  interpolate(config: InterpolationConfigType): AnimatedInterpolation {
-    return new AnimatedInterpolation(this, config);
   }
 
   __attach(): void {

--- a/Libraries/Animated/src/nodes/AnimatedMultiplication.js
+++ b/Libraries/Animated/src/nodes/AnimatedMultiplication.js
@@ -10,12 +10,9 @@
  */
 'use strict';
 
-const AnimatedInterpolation = require('./AnimatedInterpolation');
 const AnimatedNode = require('./AnimatedNode');
 const AnimatedValue = require('./AnimatedValue');
 const AnimatedWithChildren = require('./AnimatedWithChildren');
-
-import type {InterpolationConfigType} from './AnimatedInterpolation';
 
 class AnimatedMultiplication extends AnimatedWithChildren {
   _a: AnimatedNode;
@@ -35,10 +32,6 @@ class AnimatedMultiplication extends AnimatedWithChildren {
 
   __getValue(): number {
     return this._a.__getValue() * this._b.__getValue();
-  }
-
-  interpolate(config: InterpolationConfigType): AnimatedInterpolation {
-    return new AnimatedInterpolation(this, config);
   }
 
   __attach(): void {

--- a/Libraries/Animated/src/nodes/AnimatedNode.js
+++ b/Libraries/Animated/src/nodes/AnimatedNode.js
@@ -34,6 +34,22 @@ class AnimatedNode {
     return [];
   }
 
+  /**
+   * Deprecated - Use `Animated.interpolate(animation, config)` instead.
+   *
+   * Interpolates the value before updating the property, e.g. mapping 0-1 to
+   * 0-10. Not available on all node types.
+   *
+   * @deprecated
+   */
+  interpolate(config: any): AnimatedNode {
+    throw new Error(
+      'This node type does not implement an interpolate method,' +
+        ' the interpolate method will be removed from all nodes' +
+        ' in favour of Animated.interpolate(animation, config).',
+    );
+  }
+
   /* Methods and props used by native Animated impl */
   __isNative: boolean;
   __nativeTag: ?number;

--- a/Libraries/Animated/src/nodes/AnimatedValue.js
+++ b/Libraries/Animated/src/nodes/AnimatedValue.js
@@ -10,14 +10,11 @@
  */
 'use strict';
 
-const AnimatedInterpolation = require('./AnimatedInterpolation');
-const AnimatedNode = require('./AnimatedNode');
 const AnimatedWithChildren = require('./AnimatedWithChildren');
 const InteractionManager = require('InteractionManager');
 const NativeAnimatedHelper = require('../NativeAnimatedHelper');
 
 import type Animation, {EndCallback} from '../animations/Animation';
-import type {InterpolationConfigType} from './AnimatedInterpolation';
 import type AnimatedTracking from './AnimatedTracking';
 
 const NativeAnimatedAPI = NativeAnimatedHelper.API;
@@ -31,11 +28,11 @@ let _uniqueId = 1;
  * transparently when you render your Animated components.
  *
  *               new Animated.Value(0)
- *     .interpolate()        .interpolate()    new Animated.Value(1)
- *         opacity               translateY      scale
- *          style                         transform
- *         View#234                         style
- *                                         View#123
+ *     Animated.interpolate()     Animated.interpolate()    new Animated.Value(1)
+ *         opacity                       translateY              scale
+ *          style                                    transform
+ *         View#234                                    style
+ *                                                    View#123
  *
  * A) Top Down phase
  * When an Animated.Value is updated, we recursively go down through this
@@ -259,14 +256,6 @@ class AnimatedValue extends AnimatedWithChildren {
   resetAnimation(callback?: ?(value: number) => void): void {
     this.stopAnimation(callback);
     this._value = this._startingValue;
-  }
-
-  /**
-   * Interpolates the value before updating the property, e.g. mapping 0-1 to
-   * 0-10.
-   */
-  interpolate(config: InterpolationConfigType): AnimatedInterpolation {
-    return new AnimatedInterpolation(this, config);
   }
 
   /**

--- a/Libraries/NativeAnimation/Nodes/RCTInterpolationAnimatedNode.m
+++ b/Libraries/NativeAnimation/Nodes/RCTInterpolationAnimatedNode.m
@@ -36,36 +36,36 @@
   return self;
 }
 
-- (void)onAttachedToNode:(RCTAnimatedNode *)parent
-{
-  [super onAttachedToNode:parent];
-  if ([parent isKindOfClass:[RCTValueAnimatedNode class]]) {
-    _parentNode = (RCTValueAnimatedNode *)parent;
-  }
-}
-
-- (void)onDetachedFromNode:(RCTAnimatedNode *)parent
-{
-  [super onDetachedFromNode:parent];
-  if (_parentNode == parent) {
-    _parentNode = nil;
-  }
-}
-
 - (void)performUpdate
 {
   [super performUpdate];
+  _parentNode = (RCTValueAnimatedNode *)[self.parentNodes objectForKey:self.config[@"parent"]];
   if (!_parentNode) {
     return;
   }
-
+  
   CGFloat inputValue = _parentNode.value;
-
-  self.value = RCTInterpolateValueInRange(inputValue,
-                                          _inputRange,
-                                          _outputRange,
-                                          _extrapolateLeft,
-                                          _extrapolateRight);
+  
+  NSUInteger rangeIndex = RCTFindIndexOfNearestValue(inputValue, _inputRange);
+  CGFloat inputMin = _inputRange[rangeIndex].doubleValue;
+  CGFloat inputMax = _inputRange[rangeIndex + 1].doubleValue;
+  
+  NSNumber *minTag = _outputRange[rangeIndex];
+  RCTValueAnimatedNode *outputMin = (RCTValueAnimatedNode *)[self.parentNodes objectForKey:minTag];
+  
+  NSNumber *maxTag = _outputRange[rangeIndex + 1];
+  RCTValueAnimatedNode *outputMax = (RCTValueAnimatedNode *)[self.parentNodes objectForKey:maxTag];
+  
+  CGFloat outputMinValue = outputMin.value;
+  CGFloat outputMaxValue = outputMax.value;
+  
+  self.value = RCTInterpolateValue(inputValue,
+                                   inputMin,
+                                   inputMax,
+                                   outputMinValue,
+                                   outputMaxValue,
+                                   _extrapolateLeft,
+                                   _extrapolateRight);
 }
 
 @end

--- a/Libraries/NativeAnimation/RCTAnimationUtils.h
+++ b/Libraries/NativeAnimation/RCTAnimationUtils.h
@@ -14,6 +14,8 @@ static NSString *const EXTRAPOLATE_TYPE_IDENTITY = @"identity";
 static NSString *const EXTRAPOLATE_TYPE_CLAMP = @"clamp";
 static NSString *const EXTRAPOLATE_TYPE_EXTEND = @"extend";
 
+RCT_EXTERN NSUInteger RCTFindIndexOfNearestValue(CGFloat value, NSArray<NSNumber *> *range);
+
 RCT_EXTERN CGFloat RCTInterpolateValueInRange(CGFloat value,
                                               NSArray<NSNumber *> *inputRange,
                                               NSArray<NSNumber *> *outputRange,

--- a/Libraries/NativeAnimation/RCTAnimationUtils.m
+++ b/Libraries/NativeAnimation/RCTAnimationUtils.m
@@ -9,7 +9,7 @@
 
 #import <React/RCTLog.h>
 
-static NSUInteger _RCTFindIndexOfNearestValue(CGFloat value, NSArray<NSNumber *> *range)
+NSUInteger RCTFindIndexOfNearestValue(CGFloat value, NSArray<NSNumber *> *range)
 {
   NSUInteger index;
   NSUInteger rangeCount = range.count;
@@ -69,7 +69,7 @@ CGFloat RCTInterpolateValueInRange(CGFloat value,
                                    NSString *extrapolateLeft,
                                    NSString *extrapolateRight)
 {
-  NSUInteger rangeIndex = _RCTFindIndexOfNearestValue(value, inputRange);
+  NSUInteger rangeIndex = RCTFindIndexOfNearestValue(value, inputRange);
   CGFloat inputMin = inputRange[rangeIndex].doubleValue;
   CGFloat inputMax = inputRange[rangeIndex + 1].doubleValue;
   CGFloat outputMin = outputRange[rangeIndex].doubleValue;

--- a/ReactAndroid/src/main/java/com/facebook/react/animated/InterpolationAnimatedNode.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/animated/InterpolationAnimatedNode.java
@@ -6,6 +6,7 @@
  */
 package com.facebook.react.animated;
 
+import com.facebook.react.bridge.JSApplicationCausedNativeException;
 import com.facebook.react.bridge.JSApplicationIllegalArgumentException;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
@@ -21,6 +22,14 @@ import javax.annotation.Nullable;
   public static final String EXTRAPOLATE_TYPE_IDENTITY = "identity";
   public static final String EXTRAPOLATE_TYPE_CLAMP = "clamp";
   public static final String EXTRAPOLATE_TYPE_EXTEND = "extend";
+
+  private static int[] fromIntArray(ReadableArray ary) {
+    int[] res = new int[ary.size()];
+    for (int i = 0; i < res.length; i++) {
+      res[i] = ary.getInt(i);
+    }
+    return res;
+  }
 
   private static double[] fromDoubleArray(ReadableArray ary) {
     double[] res = new double[ary.size()];
@@ -75,22 +84,43 @@ import javax.annotation.Nullable;
       (result - inputMin) / (inputMax - inputMin);
   }
 
+  private static ValueAnimatedNode getValueAnimatedNode(
+          NativeAnimatedNodesManager nativeAnimatedNodesManager,
+          int tag) {
+    AnimatedNode node = nativeAnimatedNodesManager.getNodeById(tag);
+    Boolean invalid = node == null || !(node instanceof ValueAnimatedNode);
+    if (invalid) {
+      String error = "Illegal node ID set in outputRange of Animated.interpolate node";
+      throw new JSApplicationCausedNativeException(error);
+    }
+    return (ValueAnimatedNode) node;
+  }
+
   /*package*/ static double interpolate(
-      double value,
-      double[] inputRange,
-      double[] outputRange,
-      String extrapolateLeft,
-      String extrapolateRight
-  ) {
+          NativeAnimatedNodesManager nativeAnimatedNodesManager,
+          double value,
+          double[] inputRange,
+          int[] outputRangeNodeTags,
+          String extrapolateLeft,
+          String extrapolateRight) {
     int rangeIndex = findRangeIndex(value, inputRange);
-    return interpolate(
-      value,
-      inputRange[rangeIndex],
-      inputRange[rangeIndex + 1],
-      outputRange[rangeIndex],
-      outputRange[rangeIndex + 1],
-      extrapolateLeft,
-      extrapolateRight);
+    double inputStart = inputRange[rangeIndex];
+    double inputEnd = inputRange[rangeIndex + 1];
+    double outputStart = InterpolationAnimatedNode.getValueAnimatedNode(
+            nativeAnimatedNodesManager,
+            outputRangeNodeTags[rangeIndex]).getValue();
+    double outputEnd = InterpolationAnimatedNode.getValueAnimatedNode(
+            nativeAnimatedNodesManager,
+            outputRangeNodeTags[rangeIndex + 1]).getValue();
+    return InterpolationAnimatedNode.interpolate(
+            value,
+            inputStart,
+            inputEnd,
+            outputStart,
+            outputEnd,
+            extrapolateLeft,
+            extrapolateRight
+    );
   }
 
   private static int findRangeIndex(double value, double[] ranges) {
@@ -103,36 +133,22 @@ import javax.annotation.Nullable;
     return index - 1;
   }
 
+  private final NativeAnimatedNodesManager mNativeAnimatedNodesManager;
+  private @Nullable ValueAnimatedNode mParent;
   private final double mInputRange[];
-  private final double mOutputRange[];
+  private final int mOutputRangeNodeTags[];
   private final String mExtrapolateLeft;
   private final String mExtrapolateRight;
-  private @Nullable ValueAnimatedNode mParent;
 
-  public InterpolationAnimatedNode(ReadableMap config) {
+  public InterpolationAnimatedNode(
+          ReadableMap config,
+          NativeAnimatedNodesManager nativeAnimatedNodesManager) {
+    mNativeAnimatedNodesManager = nativeAnimatedNodesManager;
+    mParent = (ValueAnimatedNode) nativeAnimatedNodesManager.getNodeById(config.getInt("parent"));
     mInputRange = fromDoubleArray(config.getArray("inputRange"));
-    mOutputRange = fromDoubleArray(config.getArray("outputRange"));
+    mOutputRangeNodeTags = fromIntArray(config.getArray("outputRange"));
     mExtrapolateLeft = config.getString("extrapolateLeft");
     mExtrapolateRight = config.getString("extrapolateRight");
-  }
-
-  @Override
-  public void onAttachedToNode(AnimatedNode parent) {
-    if (mParent != null) {
-      throw new IllegalStateException("Parent already attached");
-    }
-    if (!(parent instanceof ValueAnimatedNode)) {
-      throw new IllegalArgumentException("Parent is of an invalid type");
-    }
-    mParent = (ValueAnimatedNode) parent;
-  }
-
-  @Override
-  public void onDetachedFromNode(AnimatedNode parent) {
-    if (parent != mParent) {
-      throw new IllegalArgumentException("Invalid parent node provided");
-    }
-    mParent = null;
   }
 
   @Override
@@ -142,6 +158,13 @@ import javax.annotation.Nullable;
       // unattached node.
       return;
     }
-    mValue = interpolate(mParent.getValue(), mInputRange, mOutputRange, mExtrapolateLeft, mExtrapolateRight);
+    mValue = interpolate(
+            mNativeAnimatedNodesManager,
+            mParent.getValue(),
+            mInputRange,
+            mOutputRangeNodeTags,
+            mExtrapolateLeft,
+            mExtrapolateRight
+    );
   }
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/animated/NativeAnimatedNodesManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/animated/NativeAnimatedNodesManager.java
@@ -90,7 +90,7 @@ import javax.annotation.Nullable;
     } else if ("props".equals(type)) {
       node = new PropsAnimatedNode(config, this, mUIImplementation);
     } else if ("interpolation".equals(type)) {
-      node = new InterpolationAnimatedNode(config);
+      node = new InterpolationAnimatedNode(config, this);
     } else if ("addition".equals(type)) {
       node = new AdditionAnimatedNode(config, this);
     } else if ("subtraction".equals(type)) {

--- a/ReactAndroid/src/test/java/com/facebook/react/animated/NativeAnimatedInterpolationTest.java
+++ b/ReactAndroid/src/test/java/com/facebook/react/animated/NativeAnimatedInterpolationTest.java
@@ -1,19 +1,119 @@
 package com.facebook.react.animated;
 
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.JavaOnlyArray;
+import com.facebook.react.bridge.JavaOnlyMap;
+import com.facebook.react.common.MapBuilder;
+import com.facebook.react.uimanager.UIImplementation;
+import com.facebook.react.uimanager.UIManagerModule;
+import com.facebook.react.uimanager.events.EventDispatcher;
+
+import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.rule.PowerMockRule;
 import org.robolectric.RobolectricTestRunner;
 
+import java.util.Map;
+
 import static org.fest.assertions.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 /**
  * Tests method used by {@link InterpolationAnimatedNode} to interpolate value of the input nodes.
  */
+@PrepareForTest({Arguments.class})
 @RunWith(RobolectricTestRunner.class)
+@PowerMockIgnore({"org.mockito.*", "org.robolectric.*", "android.*"})
 public class NativeAnimatedInterpolationTest {
+  @Rule
+  public PowerMockRule rule = new PowerMockRule();
 
-  private double simpleInterpolation(double value, double[] input, double[] output) {
+  private UIManagerModule mUIManagerMock;
+  private UIImplementation mUIImplementationMock;
+  private EventDispatcher mEventDispatcherMock;
+  private NativeAnimatedNodesManager mNativeAnimatedNodesManager;
+
+  @Before
+  public void setUp() {
+    PowerMockito.mockStatic(Arguments.class);
+    PowerMockito.when(Arguments.createArray()).thenAnswer(new Answer<Object>() {
+      @Override
+      public Object answer(InvocationOnMock invocation) throws Throwable {
+        return new JavaOnlyArray();
+      }
+    });
+    PowerMockito.when(Arguments.createMap()).thenAnswer(new Answer<Object>() {
+      @Override
+      public Object answer(InvocationOnMock invocation) throws Throwable {
+        return new JavaOnlyMap();
+      }
+    });
+
+    mUIManagerMock = mock(UIManagerModule.class);
+    mUIImplementationMock = mock(UIImplementation.class);
+    mEventDispatcherMock = mock(EventDispatcher.class);
+    PowerMockito.when(mUIManagerMock.getUIImplementation()).thenAnswer(new Answer<UIImplementation>() {
+      @Override
+      public UIImplementation answer(InvocationOnMock invocation) throws Throwable {
+        return mUIImplementationMock;
+      }
+    });
+    PowerMockito.when(mUIManagerMock.getEventDispatcher()).thenAnswer(new Answer<EventDispatcher>() {
+      @Override
+      public EventDispatcher answer(InvocationOnMock invocation) throws Throwable {
+        return mEventDispatcherMock;
+      }
+    });
+    PowerMockito.when(mUIManagerMock.getConstants()).thenAnswer(new Answer<Object>() {
+      @Override
+      public Object answer(InvocationOnMock invocation) throws Throwable {
+        return MapBuilder.of("customDirectEventTypes", MapBuilder.newHashMap());
+      }
+    });
+    PowerMockito
+            .when(mUIManagerMock.getDirectEventNamesResolver())
+            .thenAnswer(new Answer<UIManagerModule.CustomEventNamesResolver>() {
+              @Override
+              public UIManagerModule.CustomEventNamesResolver answer(InvocationOnMock invocation) throws Throwable {
+                return new UIManagerModule.CustomEventNamesResolver() {
+                  @Override
+                  public String resolveCustomEventName(String eventName) {
+                    Map<String, Map> directEventTypes =
+                            (Map<String, Map>) mUIManagerMock.getConstants().get("customDirectEventTypes");
+                    if (directEventTypes != null) {
+                      Map<String, String> customEventType = (Map<String, String>) directEventTypes.get(eventName);
+                      if (customEventType != null) {
+                        return customEventType.get("registrationName");
+                      }
+                    }
+                    return eventName;
+                  }
+                };
+              }
+            });
+    mNativeAnimatedNodesManager = new NativeAnimatedNodesManager(mUIManagerMock);
+  }
+
+  private int tag = 0;
+
+  private int createNode(double value) {
+    tag = tag + 1;
+    mNativeAnimatedNodesManager.createAnimatedNode(
+            tag,
+            JavaOnlyMap.of("type", "value", "value", value, "offset", 0d));
+    return tag;
+  }
+
+  private double simpleInterpolation(double value, double[] input, int[] output) {
     return InterpolationAnimatedNode.interpolate(
+      mNativeAnimatedNodesManager,
       value,
       input,
       output,
@@ -25,7 +125,7 @@ public class NativeAnimatedInterpolationTest {
   @Test
   public void testSimpleOneToOneMapping() {
     double[] input = new double[] {0d, 1d};
-    double[] output = new double[] {0d, 1d};
+    int[] output = new int[] {this.createNode(0d), this.createNode(1d)};
     assertThat(simpleInterpolation(0, input, output)).isEqualTo(0);
     assertThat(simpleInterpolation(0.5, input, output)).isEqualTo(0.5);
     assertThat(simpleInterpolation(0.8, input, output)).isEqualTo(0.8);
@@ -35,7 +135,7 @@ public class NativeAnimatedInterpolationTest {
   @Test
   public void testWiderOutputRange() {
     double[] input = new double[] {0d, 1d};
-    double[] output = new double[] {100d, 200d};
+    int[] output = new int[] {this.createNode(100d), this.createNode(200d)};
     assertThat(simpleInterpolation(0, input, output)).isEqualTo(100);
     assertThat(simpleInterpolation(0.5, input, output)).isEqualTo(150);
     assertThat(simpleInterpolation(0.8, input, output)).isEqualTo(180);
@@ -45,7 +145,7 @@ public class NativeAnimatedInterpolationTest {
   @Test
   public void testWiderInputRange() {
     double[] input = new double[] {2000d, 3000d};
-    double[] output = new double[] {1d, 2d};
+    int[] output = new int[] {this.createNode(1d), this.createNode(2d)};
     assertThat(simpleInterpolation(2000, input, output)).isEqualTo(1);
     assertThat(simpleInterpolation(2250, input, output)).isEqualTo(1.25);
     assertThat(simpleInterpolation(2800, input, output)).isEqualTo(1.8);
@@ -55,7 +155,10 @@ public class NativeAnimatedInterpolationTest {
   @Test
   public void testManySegments() {
     double[] input = new double[] {-1d, 1d, 5d};
-    double[] output = new double[] {0, 10d, 20d};
+    int[] output = new int[] {
+            this.createNode(0d),
+            this.createNode(10d),
+            this.createNode(20d)};
     assertThat(simpleInterpolation(-1, input, output)).isEqualTo(0);
     assertThat(simpleInterpolation(0, input, output)).isEqualTo(5);
     assertThat(simpleInterpolation(1, input, output)).isEqualTo(10);
@@ -66,7 +169,7 @@ public class NativeAnimatedInterpolationTest {
   @Test
   public void testExtendExtrapolate() {
     double[] input = new double[] {10d, 20d};
-    double[] output = new double[] {0d, 1d};
+    int[] output = new int[] {this.createNode(0d), this.createNode(1d)};
     assertThat(simpleInterpolation(30d, input, output)).isEqualTo(2);
     assertThat(simpleInterpolation(5d, input, output)).isEqualTo(-0.5);
   }
@@ -74,8 +177,9 @@ public class NativeAnimatedInterpolationTest {
   @Test
   public void testClampExtrapolate() {
     double[] input = new double[] {10d, 20d};
-    double[] output = new double[] {0d, 1d};
+    int[] output = new int[] {this.createNode(0d), this.createNode(1d)};
     assertThat(InterpolationAnimatedNode.interpolate(
+      mNativeAnimatedNodesManager,
       30d,
       input,
       output,
@@ -83,6 +187,7 @@ public class NativeAnimatedInterpolationTest {
       InterpolationAnimatedNode.EXTRAPOLATE_TYPE_CLAMP
     )).isEqualTo(1);
     assertThat(InterpolationAnimatedNode.interpolate(
+      mNativeAnimatedNodesManager,
       5d,
       input,
       output,
@@ -94,8 +199,9 @@ public class NativeAnimatedInterpolationTest {
   @Test
   public void testIdentityExtrapolate() {
     double[] input = new double[] {10d, 20d};
-    double[] output = new double[] {0d, 1d};
+    int[] output = new int[] {this.createNode(0d), this.createNode(1d)};
     assertThat(InterpolationAnimatedNode.interpolate(
+      mNativeAnimatedNodesManager,
       30d,
       input,
       output,
@@ -103,6 +209,7 @@ public class NativeAnimatedInterpolationTest {
       InterpolationAnimatedNode.EXTRAPOLATE_TYPE_IDENTITY
     )).isEqualTo(30);
     assertThat(InterpolationAnimatedNode.interpolate(
+      mNativeAnimatedNodesManager,
       5d,
       input,
       output,

--- a/ReactAndroid/src/test/java/com/facebook/react/animated/NativeAnimatedNodeTraversalTest.java
+++ b/ReactAndroid/src/test/java/com/facebook/react/animated/NativeAnimatedNodeTraversalTest.java
@@ -871,19 +871,32 @@ public class NativeAnimatedNodeTraversalTest {
 
   @Test
   public void testInterpolationNode() {
+    int parentNodeTag = 1;
     mNativeAnimatedNodesManager.createAnimatedNode(
-      1,
+      parentNodeTag,
       JavaOnlyMap.of("type", "value", "value", 10d, "offset", 0d));
+
+    int outputStartTag = 11;
+    mNativeAnimatedNodesManager.createAnimatedNode(
+            outputStartTag,
+            JavaOnlyMap.of("type", "value", "value", 0d, "offset", 0d));
+
+    int outputEndTag = 12;
+    mNativeAnimatedNodesManager.createAnimatedNode(
+            outputEndTag,
+            JavaOnlyMap.of("type", "value", "value", 1d, "offset", 0d));
 
     mNativeAnimatedNodesManager.createAnimatedNode(
       2,
       JavaOnlyMap.of(
+        "parent",
+        parentNodeTag,
         "type",
         "interpolation",
         "inputRange",
         JavaOnlyArray.of(10d, 20d),
         "outputRange",
-        JavaOnlyArray.of(0d, 1d),
+        JavaOnlyArray.of(outputStartTag, outputEndTag),
         "extrapolateLeft",
         "extend",
         "extrapolateRight",


### PR DESCRIPTION
![animated](https://user-images.githubusercontent.com/1537615/36432480-477f1560-1628-11e8-8146-bab62d0b170a.gif)

## Motivation

More complex animations can be created by combining an interpolation with an animated `outputRange`.

An example of basic usage is shown here: https://twitter.com/atomarranger/status/965802252597387264

## Test Plan

An example is added to RNTester to demonstrate the usage of this feature with and without `useNativeDriver`.

## Release Notes

[GENERAL] [FEATURE] [Native Animated] - Added support for using animated values as the target of an interpolation.