### PR TITLE
Deprecate interpolate method from animated nodes and add to AnimatedImplementation.

### DIFF
--- a/Libraries/Animated/src/AnimatedImplementation.js
+++ b/Libraries/Animated/src/AnimatedImplementation.js
@@ -38,6 +38,34 @@ import type {TimingAnimationConfig} from './animations/TimingAnimation';
 import type {DecayAnimationConfig} from './animations/DecayAnimation';
 import type {SpringAnimationConfig} from './animations/SpringAnimation';
 import type {Mapping, EventConfig} from './AnimatedEvent';
+import type {InterpolationConfigType} from './nodes/AnimatedInterpolation';
+
+const interpolateMethod = function(
+  config: InterpolationConfigType,
+): AnimatedInterpolation {
+  console.warn(
+    'The animation.interpolate(config) method will be removed from animated nodes in favour of Animated.interpolate(animation, config).',
+  );
+  return new AnimatedInterpolation(this, config);
+};
+
+// To avoid some code duplication and a circular dependency we
+// are adding the interpolate method directly onto these prototypes.
+// This should eventually be removed.
+//$FlowFixMe
+AnimatedAddition.prototype.interpolate = interpolateMethod;
+//$FlowFixMe
+AnimatedDiffClamp.prototype.interpolate = interpolateMethod;
+//$FlowFixMe
+AnimatedDivision.prototype.interpolate = interpolateMethod;
+//$FlowFixMe
+AnimatedInterpolation.prototype.interpolate = interpolateMethod;
+//$FlowFixMe
+AnimatedModulo.prototype.interpolate = interpolateMethod;
+//$FlowFixMe
+AnimatedMultiplication.prototype.interpolate = interpolateMethod;
+//$FlowFixMe
+AnimatedValue.prototype.interpolate = interpolateMethod;
 
 export type CompositeAnimation = {
   start: (callback?: ?EndCallback) => void,
@@ -230,6 +258,13 @@ const timing = function(
       },
     }
   );
+};
+
+const interpolate = function(
+  value: AnimatedValue,
+  config: InterpolationConfigType,
+): AnimatedInterpolation {
+  return new AnimatedInterpolation(value, config);
 };
 
 const decay = function(
@@ -544,6 +579,12 @@ module.exports = {
    * See http://facebook.github.io/react-native/docs/animated.html#node
    */
   Node: AnimatedNode,
+
+  /**
+   * Interpolates the value before updating the property, e.g. mapping 0-1 to
+   * 0-10.
+   */
+  interpolate,
 
   /**
    * Animates a value from an initial velocity to zero based on a decay

--- a/Libraries/Animated/src/nodes/AnimatedAddition.js
+++ b/Libraries/Animated/src/nodes/AnimatedAddition.js
@@ -9,12 +9,9 @@
  */
 'use strict';
 
-const AnimatedInterpolation = require('./AnimatedInterpolation');
 const AnimatedNode = require('./AnimatedNode');
 const AnimatedValue = require('./AnimatedValue');
 const AnimatedWithChildren = require('./AnimatedWithChildren');
-
-import type {InterpolationConfigType} from './AnimatedInterpolation';
 
 class AnimatedAddition extends AnimatedWithChildren {
   _a: AnimatedNode;
@@ -34,10 +31,6 @@ class AnimatedAddition extends AnimatedWithChildren {
 
   __getValue(): number {
     return this._a.__getValue() + this._b.__getValue();
-  }
-
-  interpolate(config: InterpolationConfigType): AnimatedInterpolation {
-    return new AnimatedInterpolation(this, config);
   }
 
   __attach(): void {

--- a/Libraries/Animated/src/nodes/AnimatedDiffClamp.js
+++ b/Libraries/Animated/src/nodes/AnimatedDiffClamp.js
@@ -9,11 +9,8 @@
  */
 'use strict';
 
-const AnimatedInterpolation = require('./AnimatedInterpolation');
 const AnimatedNode = require('./AnimatedNode');
 const AnimatedWithChildren = require('./AnimatedWithChildren');
-
-import type {InterpolationConfigType} from './AnimatedInterpolation';
 
 class AnimatedDiffClamp extends AnimatedWithChildren {
   _a: AnimatedNode;
@@ -34,10 +31,6 @@ class AnimatedDiffClamp extends AnimatedWithChildren {
   __makeNative() {
     this._a.__makeNative();
     super.__makeNative();
-  }
-
-  interpolate(config: InterpolationConfigType): AnimatedInterpolation {
-    return new AnimatedInterpolation(this, config);
   }
 
   __getValue(): number {

--- a/Libraries/Animated/src/nodes/AnimatedDivision.js
+++ b/Libraries/Animated/src/nodes/AnimatedDivision.js
@@ -9,12 +9,9 @@
  */
 'use strict';
 
-const AnimatedInterpolation = require('./AnimatedInterpolation');
 const AnimatedNode = require('./AnimatedNode');
 const AnimatedValue = require('./AnimatedValue');
 const AnimatedWithChildren = require('./AnimatedWithChildren');
-
-import type {InterpolationConfigType} from './AnimatedInterpolation';
 
 class AnimatedDivision extends AnimatedWithChildren {
   _a: AnimatedNode;
@@ -39,10 +36,6 @@ class AnimatedDivision extends AnimatedWithChildren {
       console.error('Detected division by zero in AnimatedDivision');
     }
     return a / b;
-  }
-
-  interpolate(config: InterpolationConfigType): AnimatedInterpolation {
-    return new AnimatedInterpolation(this, config);
   }
 
   __attach(): void {

--- a/Libraries/Animated/src/nodes/AnimatedInterpolation.js
+++ b/Libraries/Animated/src/nodes/AnimatedInterpolation.js
@@ -333,10 +333,6 @@ class AnimatedInterpolation extends AnimatedWithChildren {
     return this._interpolation(parentValue);
   }
 
-  interpolate(config: InterpolationConfigType): AnimatedInterpolation {
-    return new AnimatedInterpolation(this, config);
-  }
-
   __attach(): void {
     this._parent.__addChild(this);
   }

--- a/Libraries/Animated/src/nodes/AnimatedModulo.js
+++ b/Libraries/Animated/src/nodes/AnimatedModulo.js
@@ -9,11 +9,8 @@
  */
 'use strict';
 
-const AnimatedInterpolation = require('./AnimatedInterpolation');
 const AnimatedNode = require('./AnimatedNode');
 const AnimatedWithChildren = require('./AnimatedWithChildren');
-
-import type {InterpolationConfigType} from './AnimatedInterpolation';
 
 class AnimatedModulo extends AnimatedWithChildren {
   _a: AnimatedNode;
@@ -34,10 +31,6 @@ class AnimatedModulo extends AnimatedWithChildren {
     return (
       (this._a.__getValue() % this._modulus + this._modulus) % this._modulus
     );
-  }
-
-  interpolate(config: InterpolationConfigType): AnimatedInterpolation {
-    return new AnimatedInterpolation(this, config);
   }
 
   __attach(): void {

--- a/Libraries/Animated/src/nodes/AnimatedMultiplication.js
+++ b/Libraries/Animated/src/nodes/AnimatedMultiplication.js
@@ -9,12 +9,9 @@
  */
 'use strict';
 
-const AnimatedInterpolation = require('./AnimatedInterpolation');
 const AnimatedNode = require('./AnimatedNode');
 const AnimatedValue = require('./AnimatedValue');
 const AnimatedWithChildren = require('./AnimatedWithChildren');
-
-import type {InterpolationConfigType} from './AnimatedInterpolation';
 
 class AnimatedMultiplication extends AnimatedWithChildren {
   _a: AnimatedNode;
@@ -34,10 +31,6 @@ class AnimatedMultiplication extends AnimatedWithChildren {
 
   __getValue(): number {
     return this._a.__getValue() * this._b.__getValue();
-  }
-
-  interpolate(config: InterpolationConfigType): AnimatedInterpolation {
-    return new AnimatedInterpolation(this, config);
   }
 
   __attach(): void {

--- a/Libraries/Animated/src/nodes/AnimatedNode.js
+++ b/Libraries/Animated/src/nodes/AnimatedNode.js
@@ -33,6 +33,22 @@ class AnimatedNode {
     return [];
   }
 
+  /**
+   * Deprecated - Use `Animated.interpolate(animation, config)` instead.
+   *
+   * Interpolates the value before updating the property, e.g. mapping 0-1 to
+   * 0-10. Not available on all node types.
+   *
+   * @deprecated
+   */
+  interpolate(config: any): AnimatedNode {
+    throw new Error(
+      'This node type does not implement an interpolate method,' +
+        ' the interpolate method will be removed from all nodes' +
+        ' in favour of Animated.interpolate(animation, config).',
+    );
+  }
+
   /* Methods and props used by native Animated impl */
   __isNative: boolean;
   __nativeTag: ?number;

--- a/Libraries/Animated/src/nodes/AnimatedValue.js
+++ b/Libraries/Animated/src/nodes/AnimatedValue.js
@@ -9,14 +9,11 @@
  */
 'use strict';
 
-const AnimatedInterpolation = require('./AnimatedInterpolation');
-const AnimatedNode = require('./AnimatedNode');
 const AnimatedWithChildren = require('./AnimatedWithChildren');
 const InteractionManager = require('InteractionManager');
 const NativeAnimatedHelper = require('../NativeAnimatedHelper');
 
 import type Animation, {EndCallback} from '../animations/Animation';
-import type {InterpolationConfigType} from './AnimatedInterpolation';
 import type AnimatedTracking from './AnimatedTracking';
 
 const NativeAnimatedAPI = NativeAnimatedHelper.API;
@@ -30,11 +27,11 @@ let _uniqueId = 1;
  * transparently when you render your Animated components.
  *
  *               new Animated.Value(0)
- *     .interpolate()        .interpolate()    new Animated.Value(1)
- *         opacity               translateY      scale
- *          style                         transform
- *         View#234                         style
- *                                         View#123
+ *     Animated.interpolate()     Animated.interpolate()    new Animated.Value(1)
+ *         opacity                       translateY              scale
+ *          style                                    transform
+ *         View#234                                    style
+ *                                                    View#123
  *
  * A) Top Down phase
  * When an Animated.Value is updated, we recursively go down through this
@@ -258,14 +255,6 @@ class AnimatedValue extends AnimatedWithChildren {
   resetAnimation(callback?: ?(value: number) => void): void {
     this.stopAnimation(callback);
     this._value = this._startingValue;
-  }
-
-  /**
-   * Interpolates the value before updating the property, e.g. mapping 0-1 to
-   * 0-10.
-   */
-  interpolate(config: InterpolationConfigType): AnimatedInterpolation {
-    return new AnimatedInterpolation(this, config);
   }
 
   /**


### PR DESCRIPTION
## Motivation

```js
// Current form.
myAnimation.interpolate(config)
```

```js
// Consistent with other types of animated nodes and animations.
Animated.interpolate(myAnimation, config)
Animated.diffClamp(myAnimation, min, max)
Animated.add(myAnimation, myOtherAnimation)
Animated.sping(myAnimation, config)
Animated.timing(myAnimation, config)
```

- Less code duplication.
- More consistent.
- Will allow for using `AnimatedValue` within `AnimatedInterpolation`.

## Test Plan

Have existing tests pass.

## Could eventually be a breaking change:

* **Who does this affect**: Anyone using `animation.interpolate(config)`.
* **How to migrate**: Switch to using `Animated.interpolate(animation, config)`.
* **Why make this breaking change**: It is more consistent, reduces code duplication, and reduces the risk of creating a circular dependency.
* **Severity (number of people affected x effort)**: This could affect a lot of people. It is relatively easy to fix though. It could probably be fixed using a codemod or even just some regex.

## Release Notes

[GENERAL] [MINOR] [Native Animated] - Deprecate interpolate method from animated nodes and add to AnimatedImplementation.