### PR TITLE
Update node-notifier (has mem leak fix)

### DIFF
--- a/package.json
+++ b/package.json
@@ -181,7 +181,7 @@
     "mkdirp": "^0.5.1",
     "morgan": "^1.9.0",
     "node-fetch": "^1.3.3",
-    "node-notifier": "^5.1.2",
+    "node-notifier": "^5.2.1",
     "npmlog": "^2.0.4",
     "opn": "^3.0.2",
     "optimist": "^0.6.1",


### PR DESCRIPTION
## Motivation

Noticed that we're on a version of node-notifier that has a leak mentioned [here](https://github.com/mikaelbr/node-notifier/issues/183) and fixed in the newest version. 

## Test plan

Automated tests

## Release Notes
 [INTERNAL] [BUGFIX] [package.json] - Update node-notifier dependency