### PR TITLE
Bridge Android's WebView `onScrollChanged`.

### DIFF
--- a/Libraries/Components/WebView/WebView.android.js
+++ b/Libraries/Components/WebView/WebView.android.js
@@ -230,6 +230,12 @@ class WebView extends React.Component {
      * @platform android
      */
     urlPrefixesForDefaultIntent: PropTypes.arrayOf(PropTypes.string),
+    /**
+     * Used on Android only, a function that is called whenever the WebView's
+     * scroll position changes.
+     * @platform android
+     */
+    onScrollChanged: PropTypes.func,
   };
 
   static defaultProps = {
@@ -316,6 +322,7 @@ class WebView extends React.Component {
         mixedContentMode={this.props.mixedContentMode}
         saveFormDataDisabled={this.props.saveFormDataDisabled}
         urlPrefixesForDefaultIntent={this.props.urlPrefixesForDefaultIntent}
+        onScrollChanged={this.props.onScrollChanged}
         {...nativeConfig.props}
       />;
 

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModuleConstants.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModuleConstants.java
@@ -90,6 +90,8 @@ import java.util.Map;
         .put("topScroll", MapBuilder.of(rn, "onScroll"))
         .put("topMomentumScrollBegin", MapBuilder.of(rn, "onMomentumScrollBegin"))
         .put("topMomentumScrollEnd", MapBuilder.of(rn, "onMomentumScrollEnd"))
+        // Scroll event for WebViews.
+        .put("onScrollChanged", MapBuilder.of(rn, "onScrollChanged"))
         .build();
   }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/views/webview/events/OnScrollChangedEvent.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/webview/events/OnScrollChangedEvent.java
@@ -1,10 +1,8 @@
 /**
  * Copyright (c) 2015-present, Facebook, Inc.
- * All rights reserved.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.react.views.webview.events;

--- a/ReactAndroid/src/main/java/com/facebook/react/views/webview/events/OnScrollChangedEvent.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/webview/events/OnScrollChangedEvent.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+package com.facebook.react.views.webview.events;
+
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.uimanager.events.Event;
+import com.facebook.react.uimanager.events.RCTEventEmitter;
+
+/**
+ * Event emitted when a WebView has been scrolled.
+ */
+public class OnScrollChangedEvent extends Event<OnScrollChangedEvent> {
+
+  public static final String EVENT_NAME = "onScrollChanged";
+
+  private final int mX;
+  private final int mY;
+  private final int mPrevX;
+  private final int mPrevY;
+
+  /**
+    * @param viewId the ID of the view
+    * @param x the current horizontal scroll origin
+    * @param y the current vertical scroll origin
+    * @param prevX the previous horizontal scroll origin
+    * @param prevY the previous vertical scroll origin
+    */
+  public OnScrollChangedEvent(int viewId, int x, int y, int prevX, int prevY) {
+    super(viewId);
+    mX = x;
+    mY = y;
+    mPrevX = prevX;
+    mPrevY = prevY;
+  }
+
+  @Override
+  public String getEventName() {
+    return EVENT_NAME;
+  }
+
+  @Override
+  public void dispatch(RCTEventEmitter rctEventEmitter) {
+    WritableMap data = Arguments.createMap();
+    data.putInt("x", mX);
+    data.putInt("y", mY);
+    data.putInt("prevX", mPrevX);
+    data.putInt("prevY", mPrevY);
+    rctEventEmitter.receiveEvent(getViewTag(), EVENT_NAME, data);
+  }
+}


### PR DESCRIPTION
## Motivation

This change introduces `onScrollChanged`: https://developer.android.com/reference/android/webkit/WebView.html#onScrollChanged(int, int, int, int). This function will allow RN users to detect internal scroll events. The particular use case that motivated this change is positioning a view based on the scroll position of a webview.

## Test Plan

- Create an Android React Native app (with these changes). Add a `WebView` without the `onScrollChanged` prop and ensure there are no errors. Add a `onScrollChanged` prop and ensure horizontal and vertical scrolls are reported. Test app: https://github.com/hblumberg/RNWebViewTest
- Run `npm run lint` and JavaScript / Android tests (https://facebook.github.io/react-native/docs/testing.html) and ensure no new errors are reported.

## Related PRs

https://github.com/facebook/react-native-website/pull/211

## Release Notes
[ANDROID] [FEATURE] [WebView] - `onScrollChanged` added