### PR TITLE
Correct RCTAnimation import

### DIFF
--- a/Libraries/NativeAnimation/RCTNativeAnimatedNodesManager.h
+++ b/Libraries/NativeAnimation/RCTNativeAnimatedNodesManager.h
@@ -6,10 +6,10 @@
  */
 
 #import <Foundation/Foundation.h>
-
-#import <RCTAnimation/RCTValueAnimatedNode.h>
 #import <React/RCTBridgeModule.h>
 #import <React/RCTUIManager.h>
+
+@protocol RCTValueAnimatedNodeObserver;
 
 @interface RCTNativeAnimatedNodesManager : NSObject
 


### PR DESCRIPTION
## Motivation
Fixing error
node_modules/react-native/Libraries/NativeAnimation/RCTNativeAnimatedNodesManager.h:12:9: 'RCTAnimation/RCTValueAnimatedNode.h' file not found

I'm integrating react native into an existing app through cocoa pods and similar to other PRs
PR https://github.com/facebook/react-native/pull/16192
PR https://github.com/facebook/react-native/pull/16271
PR https://github.com/facebook/react-native/pull/17764
When integrating with cocoa pods
```
pod 'React', :path => './node_modules/react-native', :subspecs => [
    'Core',
    'DevSupport', # Include this to enable In-App Devmenu if RN >= 0.43
    'RCTText',
    'RCTNetwork',
    'RCTWebSocket', # needed for debugging
    'RCTImage',
    'RCTWebSocket',
    'BatchedBridge',
    'RCTLinkingIOS',
    'RCTActionSheet',
    'RCTAnimation'
    ]
```
With `RCTAnimation` being the important part for this PR.

Also note without this PR and the other PR's above if anyone is trying to integrate react native into an existing app i.e. through cocoa pods they won't be able too. I think the latest working version is 

## Test Plan

My app wouldn't build without changing this line

## Related PRs

PR https://github.com/facebook/react-native/pull/16192
PR https://github.com/facebook/react-native/pull/16271
PR https://github.com/facebook/react-native/pull/17764


## Release Notes

 [IOS] [BREAKING] [PODS] - Fixed RCTAnimation import for integrating with cocoapods