### PR TITLE
Add platform hook for View style props

### DIFF
--- a/Libraries/Components/View/PlatformViewStylePropTypes.android.js
+++ b/Libraries/Components/View/PlatformViewStylePropTypes.android.js
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @providesModule PlatformViewStylePropTypes
+ * @flow
+ */
+
+module.export = {
+  /**
+   * (Android-only) Sets the elevation of a view, using Android's underlying
+   * [elevation API](https://developer.android.com/training/material/shadows-clipping.html#Elevation).
+   * This adds a drop shadow to the item and affects z-order for overlapping views.
+   * Only supported on Android 5.0+, has no effect on earlier versions.
+   * @platform android
+   */
+  elevation: ReactPropTypes.number,
+};

--- a/Libraries/Components/View/PlatformViewStylePropTypes.ios.js
+++ b/Libraries/Components/View/PlatformViewStylePropTypes.ios.js
@@ -1,0 +1,11 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @providesModule PlatformViewStylePropTypes
+ * @flow
+ */
+
+module.export = {};

--- a/Libraries/Components/View/ViewStylePropTypes.js
+++ b/Libraries/Components/View/ViewStylePropTypes.js
@@ -12,6 +12,7 @@
 var ColorPropType = require('ColorPropType');
 var LayoutPropTypes = require('LayoutPropTypes');
 var ReactPropTypes = require('prop-types');
+var PlatformViewStylePropTypes = require('PlatformViewStylePropTypes');
 var ShadowPropTypesIOS = require('ShadowPropTypesIOS');
 var TransformPropTypes = require('TransformPropTypes');
 
@@ -20,6 +21,7 @@ var TransformPropTypes = require('TransformPropTypes');
  */
 var ViewStylePropTypes = {
   ...LayoutPropTypes,
+  ...PlatformViewStylePropTypes,
   ...ShadowPropTypesIOS,
   ...TransformPropTypes,
   backfaceVisibility: ReactPropTypes.oneOf(['visible', 'hidden']),
@@ -47,14 +49,6 @@ var ViewStylePropTypes = {
   borderBottomWidth: ReactPropTypes.number,
   borderLeftWidth: ReactPropTypes.number,
   opacity: ReactPropTypes.number,
-  /**
-   * (Android-only) Sets the elevation of a view, using Android's underlying
-   * [elevation API](https://developer.android.com/training/material/shadows-clipping.html#Elevation).
-   * This adds a drop shadow to the item and affects z-order for overlapping views.
-   * Only supported on Android 5.0+, has no effect on earlier versions.
-   * @platform android
-   */
-  elevation: ReactPropTypes.number,
 };
 
 module.exports = ViewStylePropTypes;


### PR DESCRIPTION
Similar to the `ViewPropTypes` hook to allow customization of prop types for iOS and Android, it's also useful to allow platforms to override style prop types.

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes. 

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to React Native here: http://facebook.github.io/react-native/docs/contributing.html

Happy contributing!

-->

## Motivation

(Write your motivation here.)

## Test Plan

Run jest tests.

## Related PRs

https://github.com/facebook/react-native/pull/15175

## Release Notes
<!--
Help reviewers and the release process by writing your own release notes

**INTERNAL and MINOR tagged notes will not be included in the next version's final release notes.**

  CATEGORY
[----------]        TYPE
[ CLI      ]   [-------------]      LOCATION
[ DOCS     ]   [ BREAKING    ]   [-------------]
[ GENERAL  ]   [ BUGFIX      ]   [-{Component}-]
[ INTERNAL ]   [ ENHANCEMENT ]   [ {File}      ]
[ IOS      ]   [ FEATURE     ]   [ {Directory} ]   |-----------|
[ ANDROID  ]   [ MINOR       ]   [ {Framework} ] - | {Message} |
[----------]   [-------------]   [-------------]   |-----------|

[CATEGORY] [TYPE] [LOCATION] - MESSAGE

 EXAMPLES:

 [IOS] [BREAKING] [FlatList] - Change a thing that breaks other things
 [ANDROID] [BUGFIX] [TextInput] - Did a thing to TextInput
 [CLI] [FEATURE] [local-cli/info/info.js] - CLI easier to do things with
 [DOCS] [BUGFIX] [GettingStarted.md] - Accidentally a thing/word
 [GENERAL] [ENHANCEMENT] [Yoga] - Added new yoga thing/position
 [INTERNAL] [FEATURE] [./scripts] - Added thing to script that nobody will see
-->
[GENERAL][ENHANCEMENT][MINOR][View] - Add platform hook for adding View style props
