### PR TITLE
Catch exception and report it when making a network request with invalid URL on Android

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/modules/network/NetworkingModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/network/NetworkingModule.java
@@ -266,7 +266,13 @@ public final class NetworkingModule extends ReactContextBaseJavaModule {
       return;
     }
 
-    Request.Builder requestBuilder = new Request.Builder().url(url);
+    Request.Builder requestBuilder;
+    try {
+      requestBuilder = new Request.Builder().url(url);
+    } catch (Exception e) {
+      ResponseUtil.onRequestError(eventEmitter, requestId, e.getMessage(), null);
+      return;
+    }
 
     if (requestId != 0) {
       requestBuilder.tag(requestId);

--- a/ReactAndroid/src/test/java/com/facebook/react/modules/network/NetworkingModuleTest.java
+++ b/ReactAndroid/src/test/java/com/facebook/react/modules/network/NetworkingModuleTest.java
@@ -170,6 +170,34 @@ public class NetworkingModuleTest {
     verifyErrorEmit(emitter, 0);
   }
 
+  @Test
+  public void testFailInvalidUrl() throws Exception {
+    RCTDeviceEventEmitter emitter = mock(RCTDeviceEventEmitter.class);
+    ReactApplicationContext context = mock(ReactApplicationContext.class);
+    when(context.getJSModule(any(Class.class))).thenReturn(emitter);
+
+    OkHttpClient httpClient = mock(OkHttpClient.class);
+    OkHttpClient.Builder clientBuilder = mock(OkHttpClient.Builder.class);
+    when(clientBuilder.build()).thenReturn(httpClient);
+    when(httpClient.newBuilder()).thenReturn(clientBuilder);
+    NetworkingModule networkingModule = new NetworkingModule(context, "", httpClient);
+
+    mockEvents();
+
+    networkingModule.sendRequest(
+      "GET",
+      "aaa",
+      /* requestId */ 0,
+      /* headers */ JavaOnlyArray.of(),
+      /* body */ null,
+      /* responseType */ "text",
+      /* useIncrementalUpdates*/ true,
+      /* timeout */ 0,
+      /* withCredentials */ false);
+
+    verifyErrorEmit(emitter, 0);
+  }
+
   private static void verifyErrorEmit(RCTDeviceEventEmitter emitter, int requestId) {
     ArgumentCaptor<WritableArray> captor = ArgumentCaptor.forClass(WritableArray.class);
     verify(emitter).emit(eq("didCompleteNetworkResponse"), captor.capture());


### PR DESCRIPTION
Currently if you invoke `fetch()` with an invalid URL ("aaa" for
example) you cannot catch the error in javascript since it's not
reported. Instead the entire app crashes.

Fixes #7436 and #18087

Hopefully.

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes. 

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to React Native here: http://facebook.github.io/react-native/docs/contributing.html

Happy contributing!

-->

## Motivation

Fix using fetch on Android with user generated input. 

## Test Plan

Added relevant unit test

`./scripts/run-android-local-unit-tests.sh` all pass

## Release Notes

[ANDROID] [BUGFIX] [fetch] - Allow "unexpected url" exception to be caught on Android when using fetch
<!--
Help reviewers and the release process by writing your own release notes

**INTERNAL and MINOR tagged notes will not be included in the next version's final release notes.**

  CATEGORY
[----------]        TYPE
[ CLI      ]   [-------------]      LOCATION
[ DOCS     ]   [ BREAKING    ]   [-------------]
[ GENERAL  ]   [ BUGFIX      ]   [-{Component}-]
[ INTERNAL ]   [ ENHANCEMENT ]   [ {File}      ]
[ IOS      ]   [ FEATURE     ]   [ {Directory} ]   |-----------|
[ ANDROID  ]   [ MINOR       ]   [ {Framework} ] - | {Message} |
[----------]   [-------------]   [-------------]   |-----------|

[CATEGORY] [TYPE] [LOCATION] - MESSAGE

 EXAMPLES:

 [IOS] [BREAKING] [FlatList] - Change a thing that breaks other things
 [ANDROID] [BUGFIX] [TextInput] - Did a thing to TextInput
 [CLI] [FEATURE] [local-cli/info/info.js] - CLI easier to do things with
 [DOCS] [BUGFIX] [GettingStarted.md] - Accidentally a thing/word
 [GENERAL] [ENHANCEMENT] [Yoga] - Added new yoga thing/position
 [INTERNAL] [FEATURE] [./scripts] - Added thing to script that nobody will see
-->
