### PR TITLE
VirtualizedList: Fix spacer size calculation

### DIFF
--- a/Libraries/Lists/VirtualizedList.js
+++ b/Libraries/Lists/VirtualizedList.js
@@ -785,8 +785,7 @@ class VirtualizedList extends React.PureComponent<Props, State> {
             if (stickyIndicesFromProps.has(ii + stickyOffset)) {
               const initBlock = this._getFrameMetricsApprox(lastInitialIndex);
               const stickyBlock = this._getFrameMetricsApprox(ii);
-              const leadSpace =
-                stickyBlock.offset - (initBlock.offset + initBlock.length);
+              const leadSpace = stickyBlock.offset - initBlock.offset;
               cells.push(
                 <View key="$sticky_lead" style={{[spacerKey]: leadSpace}} />,
               );


### PR DESCRIPTION
## Motivation

See https://github.com/facebook/react-native/issues/18104

## Test Plan

Tested the above snack with:
- stickyHeadersEnabled true/false
- initialScrollIndex set and not

Visibly verified consistent rendering.

## Release Notes

[GENERAL] [BUGFIX] [VirtualizedList] - Fix for jumpy content when initialScrollIndex specified
