### PR TITLE
[GH] Increase n days before issue considered stale

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -11,10 +11,10 @@ exemptLabels:
 staleLabel: Stale 
 # Comment to post when marking an issue as stale. Set to `false` to disable
 markComment: >
-  This issue has been automatically marked as stale because it has not had
-  recent activity. It will be closed if no further activity occurs.
-  Maybe the issue has been fixed in a recent release, or perhaps it is not affecting a lot of people.
-  If you think this issue should definitely remain open, please let us know why.
+  Hey there, it looks like there has been no activity on this issue recently. Has the issue been fixed, or does it still require the community's attention? This issue may be closed if no further activity occurs.
+  You may also label this issue as "For Discussion" or "Good first issue" and I will leave it open.
   Thank you for your contributions.
 # Comment to post when closing a stale issue. Set to `false` to disable
-closeComment: false
+closeComment: >
+  Closing this issue after a prolonged period of inactivity. If this issue is still present in the latest release, please feel free to create a new issue with up-to-date information.
+only: issues

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,7 +1,7 @@
 # Number of days of inactivity before an issue becomes stale
-daysUntilStale: 60
+daysUntilStale: 180
 # Number of days of inactivity before a stale issue is closed
-daysUntilClose: 7
+daysUntilClose: 60
 # Issues with these labels will never be considered stale
 exemptLabels:
   - Good first issue


### PR DESCRIPTION
This repository has Probot's [Stale workflow](https://github.com/probot/stale) enabled. It is configured via the `.github/stale.yml` file.

In this PR, we increase number of days before an issue becomes stale to ~six months, and increase days until the same issue is closed after inactivity to ~2 months.

It also limits the stale bot to issues only.