### PR TITLE
Fix android duplicate linking

### DIFF
--- a/local-cli/link/link.js
+++ b/local-cli/link/link.js
@@ -49,7 +49,8 @@ const linkDependency = (platforms, project, dependency) => {
         return null;
       }
 
-      const isInstalled = linkConfig.isInstalled(project[platform], dependency.config[platform]);
+      const isInstalledParameter = platform == "android" ? dependency.name : dependency.config[platform];
+      const isInstalled = linkConfig.isInstalled(project[platform], isInstalledParameter);
 
       if (isInstalled) {
         log.info(chalk.grey(`Platform '${platform}' module ${dependency.name} is already linked`));


### PR DESCRIPTION
android isInstalled has a different signature than ios counterpart

## Motivation

Run `react-native link` on a project with an android library that is already linked: the check will fail and will link again.

This should fix #18053

## Test Plan

AppCenter SDK for React-Native uses linking. Running react-native link on appcenter package would constantly add the imports, the moduleConfig strings and add duplicated code to MainApplication.java without this patch.

I also tested it didn't break ios linking.

## Release Notes
<!--
Help reviewers and the release process by writing your own release notes

**INTERNAL and MINOR tagged notes will not be included in the next version's final release notes.**

  CATEGORY
[----------]        TYPE
[ CLI      ]   [-------------]      LOCATION
[ DOCS     ]   [ BREAKING    ]   [-------------]
[ GENERAL  ]   [ BUGFIX      ]   [-{Component}-]
[ INTERNAL ]   [ ENHANCEMENT ]   [ {File}      ]
[ IOS      ]   [ FEATURE     ]   [ {Directory} ]   |-----------|
[ ANDROID  ]   [ MINOR       ]   [ {Framework} ] - | {Message} |
[----------]   [-------------]   [-------------]   |-----------|

[CATEGORY] [TYPE] [LOCATION] - MESSAGE

 EXAMPLES:

 [IOS] [BREAKING] [FlatList] - Change a thing that breaks other things
 [ANDROID] [BUGFIX] [TextInput] - Did a thing to TextInput
 [CLI] [FEATURE] [local-cli/info/info.js] - CLI easier to do things with
 [DOCS] [BUGFIX] [GettingStarted.md] - Accidentally a thing/word
 [GENERAL] [ENHANCEMENT] [Yoga] - Added new yoga thing/position
 [INTERNAL] [FEATURE] [./scripts] - Added thing to script that nobody will see
-->
[ANDROID] [BUGFIX] Fix `react-native link` adding duplicate code and configuration when running a second time.