### PR TITLE
[Danger] Do not mention people, suggest labels

### DIFF
--- a/bots/dangerfile.js
+++ b/bots/dangerfile.js
@@ -61,22 +61,18 @@ if (!includesReleaseNotes) {
   const category = releaseNotesCaptureGroups[1].toLowerCase();
 
   // Use Release Notes to Tag PRs appropriately
-  // if (category === 'ios' ){
-  //   markdown('@facebook-github-bot label iOS');
-  // }
+  if (category === 'ios' || category === 'tvos') {
+    message('Suggested label: iOS');
+  }
 
-  // if (category === 'android' ){
-  //   markdown('@facebook-github-bot label Android');
-  // }
+  if (category === 'android') {
+    message('Suggested label: Android');
+  }
+
+  if (category === 'cli') {
+    message('Suggested label: Tooling');
+  }
 }
-
-// Tags PRs that have been submitted by a core contributor.
-// TODO: Switch to using an actual MAINTAINERS file.
-const taskforce = fs.readFileSync('./IssueCommands.txt', 'utf8').split('\n')[0].split(':')[1];
-const isSubmittedByTaskforce = includes(taskforce, danger.github.pr.user.login);
-// if (isSubmittedByTaskforce) {
-//   markdown('@facebook-github-bot label Core Team');
-// }
 
 // Tags big PRs
 var bigPRThreshold = 600;
@@ -84,14 +80,10 @@ if (danger.github.pr.additions + danger.github.pr.deletions > bigPRThreshold) {
   const title = ':exclamation: Big PR';
   const idea = `This PR is extremely unlikely to get reviewed because it touches ${danger.github.pr.additions + danger.github.pr.deletions} lines.`;
   warn(`${title} - <i>${idea}</i>`);
-
-  // markdown('@facebook-github-bot large-pr');
 } else if (danger.git.modified_files + danger.git.added_files + danger.git.deleted_files > bigPRThreshold) {
   const title = ':exclamation: Big PR';
   const idea = `This PR is extremely unlikely to get reviewed because it touches ${danger.git.modified_files + danger.git.added_files + danger.git.deleted_files} files.`;
   warn(`${title} - <i>${idea}</i>`);
-
-  // markdown('@facebook-github-bot large-pr');
 }
 
 // Warns if the PR is opened against stable, as commits need to be cherry picked and tagged by a release maintainer.
@@ -106,24 +98,4 @@ if (!isMergeRefMaster && isMergeRefStable) {
   const title = ':exclamation: Base Branch';
   const idea = 'The base branch for this PR is something other than `master`. [Are you sure you want to target something other than the `master` branch?](http://facebook.github.io/react-native/docs/contributing.html#pull-requests)';
   fail(`${title} - <i>${idea}</i>`);
-}
-
-// People can add themselves to CODEOWNERS in order to be automatically added as reviewers when a file matching a glob pattern is modified. The following will have the bot add a mention in that case.
-const codeowners = fs.readFileSync('../.github/CODEOWNERS', 'utf8').split('\n');
-let mentions = [];
-codeowners.forEach((codeowner) => {
-  const pattern = codeowner.split(' ')[0];
-  const owners = codeowner.substring(pattern.length).trim().split(' ');
-
-  const modifiedFileHasOwner = path => minimatch(path, pattern);
-  const modifiesOwnedCode = danger.git.modified_files.filter(modifiedFileHasOwner).length > 0;
-
-  if (modifiesOwnedCode) {
-    mentions = mentions.concat(owners);
-  }
-});
-const isOwnedCodeModified = mentions.length > 0;
-if (isOwnedCodeModified) {
-  const uniqueMentions = new Set(mentions);
-  markdown('Attention: ' + [...uniqueMentions].join(', '));
 }


### PR DESCRIPTION
GitHub notifications have been made noisier with these automatic mentions. We can rely on the automatic reviewer tags instead.

Also: suggest labels that may be used, based on release notes (the danger bot cannot add labels itself).