### PR TITLE
Check PATENTS does not creep into files

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,6 +152,11 @@ aliases:
     command: yarn flow check
     when: always
 
+  - &run-license-checks
+    name: Check license
+    command: ./scripts/circleci/check_license.sh
+    when: always
+    
   - &build-android-app
     name: Build Android App
     command: |
@@ -275,7 +280,7 @@ jobs:
 
   # Runs JavaScript lint and flow checks.
   # Currently will fail a PR if lint/flow raises issues.
-  js_checks:
+  analyze:
     <<: *js_defaults
     steps:
       - attach_workspace:
@@ -283,6 +288,7 @@ jobs:
 
       - run: *run-lint-checks
       - run: *run-flow-checks
+      - run: *run-license-checks
 
       - store_test_results:
           path: ~/react-native/reports/junit
@@ -576,8 +582,8 @@ workflows:
       - checkout_code:
           filters: *filter-ignore-gh-pages
 
-      # Run lint and flow checks
-      - js_checks:
+      # Run lint, flow, and other checks
+      - analyze:
           filters: *filter-ignore-gh-pages
           requires:
             - checkout_code

--- a/Libraries/NativeAnimation/Nodes/RCTTrackingAnimatedNode.h
+++ b/Libraries/NativeAnimation/Nodes/RCTTrackingAnimatedNode.h
@@ -1,10 +1,8 @@
 /**
  * Copyright (c) 2015-present, Facebook, Inc.
- * All rights reserved.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 #import "RCTAnimatedNode.h"

--- a/Libraries/NativeAnimation/Nodes/RCTTrackingAnimatedNode.m
+++ b/Libraries/NativeAnimation/Nodes/RCTTrackingAnimatedNode.m
@@ -1,10 +1,8 @@
 /**
  * Copyright (c) 2015-present, Facebook, Inc.
- * All rights reserved.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 #import "RCTTrackingAnimatedNode.h"

--- a/ReactAndroid/src/main/java/com/facebook/react/animated/TrackingAnimatedNode.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/animated/TrackingAnimatedNode.java
@@ -1,10 +1,8 @@
 /**
  * Copyright (c) 2015-present, Facebook, Inc.
- * All rights reserved.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.react.animated;

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/CustomLetterSpacingSpan.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/CustomLetterSpacingSpan.java
@@ -1,10 +1,8 @@
 /**
  * Copyright (c) 2015-present, Facebook, Inc.
- * All rights reserved.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.react.views.text;

--- a/ReactCommon/yoga/yoga/YGLayout.cpp
+++ b/ReactCommon/yoga/yoga/YGLayout.cpp
@@ -1,11 +1,10 @@
 /**
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) 2015-present, Facebook, Inc.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
+
 #include "YGLayout.h"
 
 const std::array<float, 2> kYGDefaultDimensionValues = {

--- a/ReactCommon/yoga/yoga/YGLayout.h
+++ b/ReactCommon/yoga/yoga/YGLayout.h
@@ -1,11 +1,10 @@
 /**
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) 2015-present, Facebook, Inc.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
+
 #pragma once
 #include "Yoga-internal.h"
 

--- a/ReactCommon/yoga/yoga/YGStyle.cpp
+++ b/ReactCommon/yoga/yoga/YGStyle.cpp
@@ -1,11 +1,10 @@
 /**
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) 2015-present, Facebook, Inc.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
+
 #include "YGStyle.h"
 
 const YGValue kYGValueUndefined = {YGUndefined, YGUnitUndefined};

--- a/ReactCommon/yoga/yoga/YGStyle.h
+++ b/ReactCommon/yoga/yoga/YGStyle.h
@@ -1,11 +1,10 @@
 /**
- * Copyright (c) 2014-present, Facebook, Inc.
- * All rights reserved.
+ * Copyright (c) 2015-present, Facebook, Inc.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
+ 
 #pragma once
 #include "Yoga-internal.h"
 #include "Yoga.h"

--- a/scripts/circleci/check_license.sh
+++ b/scripts/circleci/check_license.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+
+# Make sure we don't introduce accidental references to PATENTS.
+EXPECTED='scripts/circleci/check_license.sh'
+ACTUAL=$(git grep -l PATENTS)
+
+if [ "$EXPECTED" != "$ACTUAL" ]; then
+  echo "PATENTS crept into some new files?"
+  diff -u <(echo "$EXPECTED") <(echo "$ACTUAL") || true
+  exit 1
+fi


### PR DESCRIPTION
Some files have crept into the repo with the old license header. These are usually from PRs that were opened prior to the re-licensing of the project.

## Test Plan

Let the script run, prior to fixing the errant files. The script outputs the following:

```
PATENTS crept into some new files?
--- /dev/fd/63	2018-03-01 01:42:48.250153746 +0000
+++ /dev/fd/62	2018-03-01 01:42:48.250153746 +0000
@@ -1 +1,9 @@
+Libraries/NativeAnimation/Nodes/RCTTrackingAnimatedNode.h
+Libraries/NativeAnimation/Nodes/RCTTrackingAnimatedNode.m
+ReactAndroid/src/main/java/com/facebook/react/animated/TrackingAnimatedNode.java
+ReactAndroid/src/main/java/com/facebook/react/views/text/CustomLetterSpacingSpan.java
+ReactCommon/yoga/yoga/YGLayout.cpp
+ReactCommon/yoga/yoga/YGLayout.h
+ReactCommon/yoga/yoga/YGStyle.cpp
+ReactCommon/yoga/yoga/YGStyle.h
 scripts/circleci/check_license.sh
Exited with code 1
```

Fix the headers in these files and run the script again. No output, exit code 0.