### PR TITLE
Set default value for back overshoot

### DIFF
--- a/Libraries/Animated/src/Easing.js
+++ b/Libraries/Animated/src/Easing.js
@@ -175,10 +175,7 @@ class Easing {
    *
    * - http://tiny.cc/back_default (s = 1.70158, default)
    */
-  static back(s: number): (t: number) => number {
-    if (s === undefined) {
-      s = 1.70158;
-    }
+  static back(s: number = 1.70158): (t: number) => number {
     return t => t * t * ((s + 1) * t - s);
   }
 


### PR DESCRIPTION
## Motivation

When using `Easing.back()` the overshoot value falls back to `1.70158` (10%) if left undefined. However, this is not clear from the function signature so with flow type checking we still need to pass in a value. This PR updates the default to be set in the signature already, allowing us to call `Easing.back()` with flow knowing the value is set.

This was already set like this for `elastic`:

https://github.com/facebook/react-native/blob/8a7f68e21147e7372e79b19b9701d4fccd852174/Libraries/Animated/src/Easing.js#L164

Another alternative would be to change the type to `number | void` but i think this is clearer.

## Test Plan

Not applicable since this doesn't change any behavior

## Related PRs

n/a

## Release Notes

[GENERAL] [MINOR] [Animated] - Flow: set overshoot to optional in back easing
