### PR TITLE
Added nullability specifier to factory typedef

### DIFF
--- a/React/Base/Surface/SurfaceHostingView/RCTSurfaceHostingView.h
+++ b/React/Base/Surface/SurfaceHostingView/RCTSurfaceHostingView.h
@@ -13,7 +13,7 @@
 @class RCTBridge;
 @class RCTSurface;
 
-typedef UIView *(^RCTSurfaceHostingViewActivityIndicatorViewFactory)();
+typedef UIView *_Nullable(^RCTSurfaceHostingViewActivityIndicatorViewFactory)();
 
 NS_ASSUME_NONNULL_BEGIN
 


### PR DESCRIPTION
## Motivation

Build breaks if nullability is specified for only a subset of declarations inside a header file.

## Test Plan

This change does not change any behaviour. Nevertheless, maybe I chose the wrong nullability specifier. Since it was not provided before I decided to choose the safe `_Nullable` one.

## Release Notes

[IOS] [BUGFIX] [RCTSurfaceHostingView] - added nullability flag