### PR TITLE
[CI] Reënable iOS and tvOS tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -211,27 +211,27 @@ aliases:
       mkdir -p ~/react-native/reports/junit/
 
   - &build-objc-ios-test-app
-    name: Build Objective-C iOS Test App
+    name: Build iOS Test App
     command: ./scripts/objc-test-ios.sh
   
   - &run-objc-ios-tests
-    name: Objective-C iOS Test Suite
+    name: iOS Test Suite
     command: ./scripts/objc-test-ios.sh test
 
   - &build-objc-tvos-test-app
-    name: Build Objective-C tvOS Test App
+    name: Build tvOS Test App
     command: ./scripts/objc-test-tvos.sh
 
   - &run-objc-tvos-tests
-    name: Objective-C tvOS Test Suite
+    name: tvOS Test Suite
     command: ./scripts/objc-test-tvos.sh test
 
   - &run-objc-ios-e2e-tests
-    name: Objective-C iOS End-to-End Test Suite
+    name: iOS End-to-End Test Suite
     command: node ./scripts/run-ci-e2e-tests.js --ios --js --retries 3;
 
   - &run-objc-tvos-e2e-tests
-    name: Objective-C tvOS End-to-End Test Suite
+    name: tvOS End-to-End Test Suite
     command: node ./scripts/run-ci-e2e-tests.js --tvos --js --retries 3;
 
 defaults: &defaults
@@ -263,7 +263,6 @@ macos_defaults: &macos_defaults
 version: 2
 jobs:
 
-  # Set up a Node environment for downstream jobs
   checkout_code:
     <<: *js_defaults
     steps:
@@ -332,7 +331,7 @@ jobs:
           path: ~/react-native/reports/junit
 
   # Builds iOS test app
-  build_objc_ios_test_app:
+  build_ios_test_app:
     <<: *macos_defaults
     dependencies:
       pre:
@@ -344,14 +343,13 @@ jobs:
       - run: *build-objc-ios-test-app
 
   # Runs unit tests on iOS devices
-  test_objc_ios:
+  test_ios:
     <<: *macos_defaults
-    dependencies:
-      pre:
-        - xcrun instruments -w "iPhone 5s (11.1)" || true
     steps:
       - attach_workspace:
           at: ~/react-native
+
+      - run: xcrun instruments -w "iPhone 5s (11.1)" || true
 
       - run: *run-objc-ios-tests
 
@@ -361,11 +359,8 @@ jobs:
           path: ~/react-native/reports/junit
 
   # Builds tvOS test app
-  build_objc_tvos_test_app:
+  build_tvos_test_app:
     <<: *macos_defaults
-    dependencies:
-      pre:
-        - xcrun instruments -w "Apple TV 1080p (11.1)" || true
     steps:
       - attach_workspace:
           at: ~/react-native
@@ -373,14 +368,13 @@ jobs:
       - run: *build-objc-tvos-test-app
 
   # Runs unit tests on tvOS devices
-  test_objc_tvos:
+  test_tvos:
     <<: *macos_defaults
-    dependencies:
-      pre:
-        - xcrun instruments -w "Apple TV 1080p (11.1)" || true
     steps:
       - attach_workspace:
           at: ~/react-native
+
+      - run: xcrun instruments -w "Apple TV 1080p (11.1)" || true
 
       - run: brew install watchman
       - run: *run-objc-tvos-tests
@@ -391,7 +385,7 @@ jobs:
           path: ~/react-native/reports/junit
 
   # Runs end to end tests
-  test_objc_ios_e2e:
+  test_ios_e2e:
     <<: *macos_defaults
     dependencies:
       pre:
@@ -578,8 +572,7 @@ workflows:
 
   tests:
     jobs:
-
-      # Checkout repo and run Yarn
+      # Checkout repo
       - checkout_code:
           filters: *filter-ignore-gh-pages
 
@@ -606,23 +599,23 @@ workflows:
             - checkout_code
 
       # Build iOS & tvOS test apps
-      - build_objc_ios_test_app:
+      - build_ios_test_app:
           filters: *filter-ignore-gh-pages
           requires:
             - checkout_code
-      - build_objc_tvos_test_app:
+      - build_tvos_test_app:
           filters: *filter-ignore-gh-pages
           requires:
             - checkout_code
 
       # Test tvOS
-      - test_objc_tvos:
+      - test_tvos:
           filters: *filter-ignore-gh-pages
           requires:
             - checkout_code
 
       # End-to-end tests
-      - test_objc_ios_e2e:
+      - test_ios_e2e:
           filters: *filter-ignore-gh-pages
           requires:
             - checkout_code
@@ -633,10 +626,9 @@ workflows:
       # Checkout repo and run Yarn
       - checkout_code:
           filters: *filter-ignore-master-stable
-          
+         
       # Run code checks
       - analyze_pr:            
-          filters: *filter-ignore-master-stable
           requires:            
             - checkout_code
 
@@ -665,7 +657,7 @@ workflows:
   #     # The following were DISABLED because they have not run since 
   #     # the migration from Travis, and they have broken since then,
   #     # Test iOS & tvOS
-  #     - test_objc_ios:
+  #     - test_ios:
   #         filters: *filter-ignore-gh-pages
   #         requires:
   #           - checkout_code

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -325,15 +325,6 @@ jobs:
       - store_test_results:
           path: ~/react-native/reports/junit
 
-  # Builds iOS test app
-  build_ios_test_app:
-    <<: *macos_defaults
-    steps:
-      - attach_workspace:
-          at: ~/react-native
-
-      - run: *build-objc-ios-test-app
-
   # Runs unit tests on iOS devices
   test_ios:
     <<: *macos_defaults
@@ -347,15 +338,6 @@ jobs:
 
       - store_test_results:
           path: ~/react-native/reports/junit
-
-  # Builds tvOS test app
-  build_tvos_test_app:
-    <<: *macos_defaults
-    steps:
-      - attach_workspace:
-          at: ~/react-native
-
-      - run: *build-objc-tvos-test-app
 
   # Runs unit tests on tvOS devices
   test_tvos:
@@ -580,17 +562,7 @@ workflows:
           requires:
             - checkout_code
 
-      # Build iOS & tvOS test apps
-      - build_ios_test_app:
-          filters: *filter-ignore-gh-pages
-          requires:
-            - checkout_code
-      - build_tvos_test_app:
-          filters: *filter-ignore-gh-pages
-          requires:
-            - checkout_code
-
-  #     # Test iOS & tvOS
+      # Test iOS & tvOS
       - test_ios:
           filters: *filter-ignore-gh-pages
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -614,6 +614,12 @@ workflows:
           requires:
             - checkout_code
 
+      # Test tvOS
+      - test_objc_tvos:
+          filters: *filter-ignore-gh-pages
+          requires:
+            - checkout_code
+
       # End-to-end tests
       - test_objc_ios_e2e:
           filters: *filter-ignore-gh-pages
@@ -649,25 +655,21 @@ workflows:
   # workflow to avoid marking benign PRs as broken.
   # To run them, uncomment the entire block and open a PR (do not merge). 
   # Once a test is fixed, move the test definition to the 'tests' workflow.
-  disabled_tests:
-    jobs:
-      # Checkout repo and run Yarn (pre-req, should succeed)
-      - checkout_code:
-          filters: *filter-ignore-gh-pages
+  # disabled_tests:
+  #   jobs:
+  #     # Checkout repo and run Yarn (pre-req, should succeed)
+  #     - checkout_code:
+  #         filters: *filter-ignore-gh-pages
 
-      # The following were DISABLED because they have not run since 
-      # the migration from Travis, and they have broken since then,
-      # Test iOS & tvOS
-      - test_objc_ios:
-          filters: *filter-ignore-gh-pages
-          requires:
-            - checkout_code
-      - test_objc_tvos:
-          filters: *filter-ignore-gh-pages
-          requires:
-            - checkout_code
-      # CocoaPods
-      - test_podspec:
-          filters: *filter-ignore-gh-pages
-          requires:
-            - checkout_code
+  #     # The following were DISABLED because they have not run since 
+  #     # the migration from Travis, and they have broken since then,
+  #     # Test iOS & tvOS
+  #     - test_objc_ios:
+  #         filters: *filter-ignore-gh-pages
+  #         requires:
+  #           - checkout_code
+  #     # CocoaPods
+  #     - test_podspec:
+  #         filters: *filter-ignore-gh-pages
+  #         requires:
+  #           - checkout_code

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -334,9 +334,6 @@ jobs:
   # Builds iOS test app
   build_ios_test_app:
     <<: *macos_defaults
-    dependencies:
-      pre:
-        - xcrun instruments -w "iPhone 5s (11.1)" || true
     steps:
       - attach_workspace:
           at: ~/react-native
@@ -351,7 +348,7 @@ jobs:
           at: ~/react-native
 
       - run: xcrun instruments -w "iPhone 5s (11.1)" || true
-
+      - run: brew install watchman
       - run: *run-objc-ios-tests
 
       - store_test_results:
@@ -376,7 +373,6 @@ jobs:
           at: ~/react-native
 
       - run: xcrun instruments -w "Apple TV 1080p (11.1)" || true
-
       - run: brew install watchman
       - run: *run-objc-tvos-tests
 
@@ -610,7 +606,11 @@ workflows:
           requires:
             - checkout_code
 
-      # Test tvOS
+  #     # Test iOS & tvOS
+      - test_ios:
+          filters: *filter-ignore-gh-pages
+          requires:
+            - checkout_code
       - test_tvos:
           filters: *filter-ignore-gh-pages
           requires:
@@ -663,11 +663,6 @@ workflows:
 
   #     # The following were DISABLED because they have not run since 
   #     # the migration from Travis, and they have broken since then,
-  #     # Test iOS & tvOS
-  #     - test_ios:
-  #         filters: *filter-ignore-gh-pages
-  #         requires:
-  #           - checkout_code
   #     # CocoaPods
   #     - test_podspec:
   #         filters: *filter-ignore-gh-pages

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -382,6 +382,7 @@ jobs:
       - attach_workspace:
           at: ~/react-native
 
+      - run: brew install watchman
       - run: *run-objc-tvos-tests
 
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -293,8 +293,6 @@ jobs:
       - store_test_results:
           path: ~/react-native/reports/junit
       - store_artifacts:
-          path: ~/react-native/reports/junit
-      - store_artifacts:
           path: ~/react-native/yarn.lock
 
   # Runs JavaScript tests on Node 8
@@ -307,8 +305,6 @@ jobs:
       - run: *run-js-tests
 
       - store_test_results:
-          path: ~/react-native/reports/junit
-      - store_artifacts:
           path: ~/react-native/reports/junit
 
   # Runs JavaScript tests on Node 6
@@ -327,8 +323,6 @@ jobs:
       - run: *run-js-tests
 
       - store_test_results:
-          path: ~/react-native/reports/junit
-      - store_artifacts:
           path: ~/react-native/reports/junit
 
   # Builds iOS test app
@@ -353,8 +347,6 @@ jobs:
 
       - store_test_results:
           path: ~/react-native/reports/junit
-      - store_artifacts:
-          path: ~/react-native/reports/junit
 
   # Builds tvOS test app
   build_tvos_test_app:
@@ -378,24 +370,18 @@ jobs:
 
       - store_test_results:
           path: ~/react-native/reports/junit
-      - store_artifacts:
-          path: ~/react-native/reports/junit
 
   # Runs end to end tests
   test_ios_e2e:
     <<: *macos_defaults
-    dependencies:
-      pre:
-        - xcrun instruments -w "iPhone 5s (11.1)" || true
     steps:
       - attach_workspace:
           at: ~/react-native
 
+      - run: xcrun instruments -w "iPhone 5s (11.1)" || true
       - run: *run-objc-ios-e2e-tests
 
       - store_test_results:
-          path: ~/react-native/reports/junit
-      - store_artifacts:
           path: ~/react-native/reports/junit
 
   # Checks podspec
@@ -514,8 +500,6 @@ jobs:
       # post (always runs)
       - run: *collect-android-test-results
       - store_test_results:
-          path: ~/react-native/reports/junit
-      - store_artifacts:
           path: ~/react-native/reports/junit
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -649,25 +649,25 @@ workflows:
   # workflow to avoid marking benign PRs as broken.
   # To run them, uncomment the entire block and open a PR (do not merge). 
   # Once a test is fixed, move the test definition to the 'tests' workflow.
-  # disabled_tests:
-  #   jobs:
-  #     # Checkout repo and run Yarn (pre-req, should succeed)
-  #     - checkout_code:
-  #         filters: *filter-ignore-gh-pages
+  disabled_tests:
+    jobs:
+      # Checkout repo and run Yarn (pre-req, should succeed)
+      - checkout_code:
+          filters: *filter-ignore-gh-pages
 
-  #     # The following were DISABLED because they have not run since 
-  #     # the migration from Travis, and they have broken since then,
-  #     # Test iOS & tvOS
-  #     - test_objc_ios:
-  #         filters: *filter-ignore-gh-pages
-  #         requires:
-  #           - checkout_code
-  #     - test_objc_tvos:
-  #         filters: *filter-ignore-gh-pages
-  #         requires:
-  #           - checkout_code
-  #     # CocoaPods
-  #     - test_podspec:
-  #         filters: *filter-ignore-gh-pages
-  #         requires:
-  #           - checkout_code
+      # The following were DISABLED because they have not run since 
+      # the migration from Travis, and they have broken since then,
+      # Test iOS & tvOS
+      - test_objc_ios:
+          filters: *filter-ignore-gh-pages
+          requires:
+            - checkout_code
+      - test_objc_tvos:
+          filters: *filter-ignore-gh-pages
+          requires:
+            - checkout_code
+      # CocoaPods
+      - test_podspec:
+          filters: *filter-ignore-gh-pages
+          requires:
+            - checkout_code

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -612,11 +612,7 @@ workflows:
       # Checkout repo and run Yarn
       - checkout_code:
           filters: *filter-ignore-master-stable
-<<<<<<< HEAD
-         
-=======
           
->>>>>>> merge checkout/yarn
       # Run code checks
       - analyze_pr:            
           filters: *filter-ignore-master-stable

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -263,6 +263,7 @@ macos_defaults: &macos_defaults
 version: 2
 jobs:
 
+  # Set up a Node environment for downstream jobs
   checkout_code:
     <<: *js_defaults
     steps:
@@ -572,7 +573,8 @@ workflows:
 
   tests:
     jobs:
-      # Checkout repo
+
+      # Checkout repo and run Yarn
       - checkout_code:
           filters: *filter-ignore-gh-pages
 
@@ -626,9 +628,14 @@ workflows:
       # Checkout repo and run Yarn
       - checkout_code:
           filters: *filter-ignore-master-stable
+<<<<<<< HEAD
          
+=======
+          
+>>>>>>> merge checkout/yarn
       # Run code checks
       - analyze_pr:            
+          filters: *filter-ignore-master-stable
           requires:            
             - checkout_code
 

--- a/scripts/objc-test.sh
+++ b/scripts/objc-test.sh
@@ -73,9 +73,6 @@ curl 'http://localhost:8081/IntegrationTests/RCTRootViewIntegrationTestApp.bundl
 rm temp.bundle
 
 # Run tests
-# TODO: We use xcodebuild because xctool would stall when collecting info about
-# the tests before running them. Switch back when this issue with xctool has
-# been resolved.
 xcodebuild \
   -project "RNTester/RNTester.xcodeproj" \
   -scheme $SCHEME \
@@ -87,9 +84,6 @@ xcodebuild \
 else
 
 # Don't run tests. No need to pass -destination to xcodebuild.
-# TODO: We use xcodebuild because xctool would stall when collecting info about
-# the tests before running them. Switch back when this issue with xctool has
-# been resolved.
 xcodebuild \
   -project "RNTester/RNTester.xcodeproj" \
   -scheme $SCHEME \


### PR DESCRIPTION
Although the test suites have a handful of failing tests, the jobs themselves do not fail.

Let's get these tests back into the fold so that we may track our progress getting these back to a good state.

cc @dlowder-salesforce

# Test Plan

Run tests on Circle, and confirm everything is green: https://circleci.com/workflow-run/4dd1a84b-502d-4ad6-aa41-64c768392a6b

If you go into the test iOS and test tvOS jobs, you will see that we are collecting test results at the top. These results show the failing individual tests.