### PR TITLE
Revert "Better Android Gradle Plugin 3.x integration"

### DIFF
--- a/react.gradle
+++ b/react.gradle
@@ -6,117 +6,112 @@ def cliPath = config.cliPath ?: "node_modules/react-native/local-cli/cli.js"
 def bundleAssetName = config.bundleAssetName ?: "index.android.bundle"
 def entryFile = config.entryFile ?: "index.android.js"
 def bundleCommand = config.bundleCommand ?: "bundle"
-def reactRoot = file(config.root ?: "../../")
+
+// because elvis operator
+def elvisFile(thing) {
+    return thing ? file(thing) : null;
+}
+
+def reactRoot = elvisFile(config.root) ?: file("../../")
 def inputExcludes = config.inputExcludes ?: ["android/**", "ios/**"]
 def bundleConfig = config.bundleConfig ? "${reactRoot}/${config.bundleConfig}" : null ;
 
+void runBefore(String dependentTaskName, Task task) {
+    Task dependentTask = tasks.findByPath(dependentTaskName);
+    if (dependentTask != null) {
+        dependentTask.dependsOn task
+    }
+}
 
 gradle.projectsEvaluated {
-    android.applicationVariants.all { def variant ->
-        // Create variant and target names
-        def targetName = variant.name.capitalize()
-        def targetPath = variant.dirName
+    // Grab all build types and product flavors
+    def buildTypes = android.buildTypes.collect { type -> type.name }
+    def productFlavors = android.productFlavors.collect { flavor -> flavor.name }
 
-        // React js bundle directories
-        def jsBundleDir = file("$buildDir/generated/assets/react/${targetPath}")
-        def resourcesDir = file("$buildDir/generated/res/react/${targetPath}")
+    // When no product flavors defined, use empty
+    if (!productFlavors) productFlavors.add('')
 
-        def jsBundleFile = file("$jsBundleDir/$bundleAssetName")
+    productFlavors.each { productFlavorName ->
+        buildTypes.each { buildTypeName ->
+            // Create variant and target names
+            def flavorNameCapitalized = "${productFlavorName.capitalize()}"
+            def buildNameCapitalized = "${buildTypeName.capitalize()}"
+            def targetName = "${flavorNameCapitalized}${buildNameCapitalized}"
+            def targetPath = productFlavorName ?
+                    "${productFlavorName}/${buildTypeName}" :
+                    "${buildTypeName}"
 
-        // Additional node and packager commandline arguments
-        def nodeExecutableAndArgs = config.nodeExecutableAndArgs ?: ["node"]
-        def extraPackagerArgs = config.extraPackagerArgs ?: []
+            // React js bundle directories
+            def jsBundleDirConfigName = "jsBundleDir${targetName}"
+            def jsBundleDir = elvisFile(config."$jsBundleDirConfigName") ?:
+                    file("$buildDir/intermediates/assets/${targetPath}")
 
-        def currentBundleTask = tasks.create(
-            name: "bundle${targetName}JsAndAssets",
-            type: Exec) {
-            group = "react"
-            description = "bundle JS and assets for ${targetName}."
+            def resourcesDirConfigName = "resourcesDir${targetName}"
+            def resourcesDir = elvisFile(config."${resourcesDirConfigName}") ?:
+                    file("$buildDir/intermediates/res/merged/${targetPath}")
+            def jsBundleFile = file("$jsBundleDir/$bundleAssetName")
 
-            // Create dirs if they are not there (e.g. the "clean" task just ran)
-            doFirst {
-                jsBundleDir.deleteDir()
-                jsBundleDir.mkdirs()
-                resourcesDir.deleteDir()
-                resourcesDir.mkdirs()
-            }
+            // Bundle task name for variant
+            def bundleJsAndAssetsTaskName = "bundle${targetName}JsAndAssets"
 
-            // Set up inputs and outputs so gradle can cache the result
-            inputs.files fileTree(dir: reactRoot, excludes: inputExcludes)
-            outputs.dir jsBundleDir
-            outputs.dir resourcesDir
+            // Additional node and packager commandline arguments
+            def nodeExecutableAndArgs = config.nodeExecutableAndArgs ?: ["node"]
+            def extraPackagerArgs = config.extraPackagerArgs ?: []
 
-            // Set up the call to the react-native cli
-            workingDir reactRoot
-
-            // Set up dev mode
-            def devEnabled = !(config."devDisabledIn${targetName}"
-                || targetName.toLowerCase().contains("release"))
-
-            def extraArgs = extraPackagerArgs;
-
-            if (bundleConfig) {
-                extraArgs = extraArgs.clone()
-                extraArgs.add("--config");
-                extraArgs.add(bundleConfig);
-            }
-
-            if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-                commandLine("cmd", "/c", *nodeExecutableAndArgs, cliPath, bundleCommand, "--platform", "android", "--dev", "${devEnabled}",
-                    "--reset-cache", "--entry-file", entryFile, "--bundle-output", jsBundleFile, "--assets-dest", resourcesDir, *extraArgs)
-            } else {
-                commandLine(*nodeExecutableAndArgs, cliPath, bundleCommand, "--platform", "android", "--dev", "${devEnabled}",
-                    "--reset-cache", "--entry-file", entryFile, "--bundle-output", jsBundleFile, "--assets-dest", resourcesDir, *extraArgs)
-            }
-
-            enabled config."bundleIn${targetName}" ||
-                config."bundleIn${variant.buildType.name.capitalize()}" ?:
-                targetName.toLowerCase().contains("release")
-        }
-
-        // Expose a minimal interface on the application variant and the task itself:
-        variant.ext.bundleJsAndAssets = currentBundleTask
-        currentBundleTask.ext.generatedResFolders = files(resourcesDir).builtBy(currentBundleTask)
-        currentBundleTask.ext.generatedAssetsFolders = files(jsBundleDir).builtBy(currentBundleTask)
-
-        variant.registerGeneratedResFolders(currentBundleTask.generatedResFolders)
-        variant.mergeResources.dependsOn(currentBundleTask)
-
-        def resourcesDirConfigValue = config."resourcesDir${targetName}"
-        if (resourcesDirConfigValue) {
-            def currentCopyResTask = tasks.create(
-                name: "copy${targetName}BundledResources",
-                type: Copy) {
+            def currentBundleTask = tasks.create(
+                    name: bundleJsAndAssetsTaskName,
+                    type: Exec) {
                 group = "react"
-                description = "copy bundled resources into custom location for ${targetName}."
+                description = "bundle JS and assets for ${targetName}."
 
-                from resourcesDir
-                into file(resourcesDirConfigValue)
+                // Create dirs if they are not there (e.g. the "clean" task just ran)
+                doFirst {
+                    jsBundleDir.mkdirs()
+                    resourcesDir.mkdirs()
+                }
 
-                dependsOn(currentBundleTask)
+                // Set up inputs and outputs so gradle can cache the result
+                inputs.files fileTree(dir: reactRoot, excludes: inputExcludes)
+                outputs.dir jsBundleDir
+                outputs.dir resourcesDir
 
-                enabled currentBundleTask.enabled
+                // Set up the call to the react-native cli
+                workingDir reactRoot
+
+                // Set up dev mode
+                def devEnabled = !(config."devDisabledIn${targetName}"
+                    || targetName.toLowerCase().contains("release"))
+
+                def extraArgs = extraPackagerArgs;
+
+                if (bundleConfig) {
+                  extraArgs = extraArgs.clone()
+                  extraArgs.add("--config");
+                  extraArgs.add(bundleConfig);
+                }
+
+                if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+                    commandLine("cmd", "/c", *nodeExecutableAndArgs, cliPath, bundleCommand, "--platform", "android", "--dev", "${devEnabled}",
+                            "--reset-cache", "--entry-file", entryFile, "--bundle-output", jsBundleFile, "--assets-dest", resourcesDir, *extraArgs)
+                } else {
+                    commandLine(*nodeExecutableAndArgs, cliPath, bundleCommand, "--platform", "android", "--dev", "${devEnabled}",
+                            "--reset-cache", "--entry-file", entryFile, "--bundle-output", jsBundleFile, "--assets-dest", resourcesDir, *extraArgs)
+                }
+
+                enabled config."bundleIn${targetName}" ||
+                    config."bundleIn${buildTypeName.capitalize()}" ?:
+                            targetName.toLowerCase().contains("release")
             }
 
-            variant.packageApplication.dependsOn(currentCopyResTask)
+            // Hook bundle${productFlavor}${buildType}JsAndAssets into the android build process
+            currentBundleTask.dependsOn("merge${targetName}Resources")
+            currentBundleTask.dependsOn("merge${targetName}Assets")
+
+            runBefore("process${flavorNameCapitalized}Armeabi-v7a${buildNameCapitalized}Resources", currentBundleTask)
+            runBefore("process${flavorNameCapitalized}X86${buildNameCapitalized}Resources", currentBundleTask)
+            runBefore("processUniversal${targetName}Resources", currentBundleTask)
+            runBefore("process${targetName}Resources", currentBundleTask)
+            runBefore("dataBindingProcessLayouts${targetName}", currentBundleTask)
         }
-
-        def currentAssetsCopyTask = tasks.create(
-            name: "copy${targetName}BundledJs",
-            type: Copy) {
-            group = "react"
-            description = "copy bundled JS into ${targetName}."
-
-            from jsBundleDir
-            into file(config."jsBundleDir${targetName}" ?:
-                "$buildDir/intermediates/assets/${targetPath}")
-
-            // mergeAssets must run first, as it clears the intermediates directory
-            dependsOn(variant.mergeAssets)
-
-            enabled currentBundleTask.enabled
-        }
-
-        variant.packageApplication.dependsOn(currentAssetsCopyTask)
     }
 }


### PR DESCRIPTION
This reverts commit d16ff3bd8b92fa84a9007bf5ebedd8153e4c089d.

## Motivation

Currently breaks with the gradle version used by RN, I think there has been some work to update that to a more recent one but for now I think we should just revert it.

It errors with: 

```
Could not find method registerGeneratedResFolders() for arguments [file collection] on object of type com.android.build.gradle.internal.api.ApplicationVariantImpl.
```

## Test Plan

Tested that RN tester now builds when using the right react.gradle (#18188)

## Release Notes

[ ANDROID ] [ BUGFIX ] [ react.gradle ] - REVERT "Support Android Gradle Plugin 3.x and AAPT2"
[ ANDROID ] [ FEATURE ] [ react.gradle ] - REVERT "Expose the bundling task and its outputs via ext properties"