### PR TITLE
Fixing bugs in link and unlink

### DIFF
--- a/local-cli/link/ios/common/isInstalled.js
+++ b/local-cli/link/ios/common/isInstalled.js
@@ -1,6 +1,6 @@
 const isInstalledIOS = require('../isInstalled');
 const isInstalledPods = require('../../pods/isInstalled');
 
-module.exports = function isInstalled(config, name) {
-  return isInstalledIOS(config, name) || isInstalledPods(config, name);
+module.exports = function isInstalled(projectConfig, name, dependencyConfig) {
+  return isInstalledIOS(projectConfig, dependencyConfig) || isInstalledPods(projectConfig, dependencyConfig);
 };

--- a/local-cli/link/ios/common/unregisterNativeModule.js
+++ b/local-cli/link/ios/common/unregisterNativeModule.js
@@ -1,8 +1,8 @@
 const compact = require('lodash').compact;
 const isInstalledIOS = require('../isInstalled');
 const isInstalledPods = require('../../pods/isInstalled');
-const unregisterDependencyIOS = require('../registerNativeModule');
-const unregisterDependencyPods = require('../../pods/registerNativeModule');
+const unregisterDependencyIOS = require('../unregisterNativeModule');
+const unregisterDependencyPods = require('../../pods/unregisterNativeModule');
 
 module.exports = function unregisterNativeModule(
   name,

--- a/local-cli/link/link.js
+++ b/local-cli/link/link.js
@@ -49,7 +49,7 @@ const linkDependency = (platforms, project, dependency) => {
         return null;
       }
 
-      const isInstalled = linkConfig.isInstalled(project[platform], dependency.config[platform]);
+      const isInstalled = linkConfig.isInstalled(project[platform], dependency.name, dependency.config[platform]);
 
       if (isInstalled) {
         log.info(chalk.grey(`Platform '${platform}' module ${dependency.name} is already linked`));

--- a/local-cli/link/unlink.js
+++ b/local-cli/link/unlink.js
@@ -32,7 +32,7 @@ const unlinkDependency = (platforms, project, dependency, packageName, otherDepe
         return;
       }
 
-      const isInstalled = linkConfig.isInstalled(project[platform], dependency[platform]);
+      const isInstalled = linkConfig.isInstalled(project[platform], packageName, dependency[platform]);
 
       if (!isInstalled) {
         log.info(`Platform '${platform}' module ${packageName} is not installed`);


### PR DESCRIPTION
Android uses the name of the package, not the config, for the `isInstalled` check. Sending both parameters to `isInstalled` so we have a consistent API.

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes. 

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to React Native here: http://facebook.github.io/react-native/docs/contributing.html

Happy contributing!

-->

## Motivation

A bug was uncovered in the react-native link command where Android would not unlink because the wrong parameters were being sent to `isInstalled`.

## Test Plan

Successfully linked and unlinked `react-native-fs` on Windows and Mac. Jest tests pass.

## Related PRs

#17000 
#18131 

## Release Notes
<!--
Help reviewers and the release process by writing your own release notes

**INTERNAL and MINOR tagged notes will not be included in the next version's final release notes.**

  CATEGORY
[----------]        TYPE
[ CLI      ]   [-------------]      LOCATION
[ DOCS     ]   [ BREAKING    ]   [-------------]
[ GENERAL  ]   [ BUGFIX      ]   [-{Component}-]
[ INTERNAL ]   [ ENHANCEMENT ]   [ {File}      ]
[ IOS      ]   [ FEATURE     ]   [ {Directory} ]   |-----------|
[ ANDROID  ]   [ MINOR       ]   [ {Framework} ] - | {Message} |
[----------]   [-------------]   [-------------]   |-----------|

[CATEGORY] [TYPE] [LOCATION] - MESSAGE

 EXAMPLES:

 [IOS] [BREAKING] [FlatList] - Change a thing that breaks other things
 [ANDROID] [BUGFIX] [TextInput] - Did a thing to TextInput
 [CLI] [FEATURE] [local-cli/info/info.js] - CLI easier to do things with
 [DOCS] [BUGFIX] [GettingStarted.md] - Accidentally a thing/word
 [GENERAL] [ENHANCEMENT] [Yoga] - Added new yoga thing/position
 [INTERNAL] [FEATURE] [./scripts] - Added thing to script that nobody will see
-->

[CLI][BUGFIX][local-cli/link/link.js] - Fix issue with `isInstalled` check for Android
[CLI][BUGFIX][local-cli/link/unlink.js] - Fix issue with `isInstalled` check for Android 
[CLI][BUGFIX][local-cli/link/ios/common/unregisterNativeModule.js] - Fix references to unregister implementations.