### PR TITLE
Fix a race condition in AppState that prevents listeners from being notified

### DIFF
--- a/Libraries/AppState/AppState.js
+++ b/Libraries/AppState/AppState.js
@@ -64,14 +64,7 @@ class AppState extends NativeEventEmitter {
         // It's possible that the state will have changed here & listeners need to be notified
         if (!eventUpdated && this.currentState !== appStateData.app_state) {
           this.currentState = appStateData.app_state;
-          if (this._eventHandlers['change']) {
-            this._eventHandlers['change'].forEach((subscription, key, map) => {
-              subscription.listener.apply(
-                subscription.context,
-                [appStateData]
-              );
-            });
-          }
+          this.emit('appStateDidChange', appStateData);
         }
       },
       logError

--- a/Libraries/AppState/AppState.js
+++ b/Libraries/AppState/AppState.js
@@ -61,8 +61,17 @@ class AppState extends NativeEventEmitter {
     // prop and expose `getCurrentAppState` method directly.
     RCTAppState.getCurrentAppState(
       (appStateData) => {
-        if (!eventUpdated) {
+        // It's possible that the state will have changed here & listeners need to be notified
+        if (!eventUpdated && this.currentState !== appStateData.app_state) {
           this.currentState = appStateData.app_state;
+          if (this._eventHandlers['change']) {
+            this._eventHandlers['change'].forEach((subscription, key, map) => {
+              subscription.listener.apply(
+                subscription.context,
+                [appStateData]
+              );
+            });
+          }
         }
       },
       logError


### PR DESCRIPTION
If someone has setup a subscription on AppState and we correct AppState via getCurrentAppState call, we need to notify all the subscribers of AppState.
1 ) Initial AppState.currentState = 'active'
2-start) Subscribe to AppState Changes
3-start) Fetch Current AppState
4 ) App Code subscribes to AppState module
5 ) App becomes backgrounded
2-finish) AppState listeners are setup (missing background event)
3-finish) AppState.currentState updated to background

At this point the subscription setup in 4) will never be called with the change.

## Motivation

AppState should always call subscribers on change

## Test Plan

This is very difficult to formally test since it's due to a race condition. We've seen this condition via bug reports but have had no local repro.

## Release Notes

[GENERAL][BUGFIX][AppState] - Fix a race condition that could prevent AppState subscription change listener from firing on initial launch