### PR TITLE
Added nestedScrollEnabled prop to scroll view for android

### DIFF
--- a/Libraries/Components/ScrollView/ScrollView.js
+++ b/Libraries/Components/ScrollView/ScrollView.js
@@ -277,7 +277,7 @@ const ScrollView = createReactClass({
     minimumZoomScale: PropTypes.number,
      /**
      * Enables nested scrolling for Android API level 21+.
-     * Nested scrolling is supported by default in iOS platforms
+     * Nested scrolling is supported by default on iOS
      * @platform android
      */
     nestedScrollEnabled: PropTypes.bool,

--- a/Libraries/Components/ScrollView/ScrollView.js
+++ b/Libraries/Components/ScrollView/ScrollView.js
@@ -275,6 +275,12 @@ const ScrollView = createReactClass({
      * @platform ios
      */
     minimumZoomScale: PropTypes.number,
+     /**
+     * Enables nested scrolling for Android API level 21+.
+     * Nested scrolling is supported by default in iOS platforms
+     * @platform android
+     */
+    nestedScrollEnabled: PropTypes.bool,
     /**
      * Called when the momentum scroll starts (scroll which occurs as the ScrollView glides to a stop).
      */

--- a/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollViewManager.java
@@ -124,7 +124,7 @@ public class ReactHorizontalScrollViewManager
   }
 
   @ReactProp(name = "nestedScrollEnabled")
-  public void setNestedScrollEnabled(ReactScrollView view, boolean value) {
+  public void setNestedScrollEnabled(ReactHorizontalScrollView view, boolean value) {
     ViewCompat.setNestedScrollingEnabled(view, value);
   }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollViewManager.java
@@ -123,9 +123,6 @@ public class ReactHorizontalScrollViewManager
     view.setOverScrollMode(ReactScrollViewHelper.parseOverScrollMode(value));
   }
 
-  /**
-   * Enables/Disables nested scrolling
-   */
   @ReactProp(name = "nestedScrollEnabled")
   public void setNestedScrollEnabled(ReactScrollView view, boolean value) {
     ViewCompat.setNestedScrollingEnabled(view, value);

--- a/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollViewManager.java
@@ -8,7 +8,9 @@
 package com.facebook.react.views.scroll;
 
 import android.graphics.Color;
+import android.support.v4.view.ViewCompat;
 import android.util.DisplayMetrics;
+
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.module.annotations.ReactModule;
 import com.facebook.react.uimanager.DisplayMetricsHolder;
@@ -21,6 +23,7 @@ import com.facebook.react.uimanager.ViewProps;
 import com.facebook.react.uimanager.annotations.ReactProp;
 import com.facebook.react.uimanager.annotations.ReactPropGroup;
 import com.facebook.yoga.YogaConstants;
+
 import javax.annotation.Nullable;
 
 /**
@@ -118,6 +121,14 @@ public class ReactHorizontalScrollViewManager
   @ReactProp(name = "overScrollMode")
   public void setOverScrollMode(ReactHorizontalScrollView view, String value) {
     view.setOverScrollMode(ReactScrollViewHelper.parseOverScrollMode(value));
+  }
+
+  /**
+   * Enables/Disables nested scrolling
+   */
+  @ReactProp(name = "nestedScrollEnabled")
+  public void setNestedScrollEnabled(ReactScrollView view, boolean value) {
+    ViewCompat.setNestedScrollingEnabled(view, value);
   }
 
   @Override

--- a/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewManager.java
@@ -124,9 +124,6 @@ public class ReactScrollViewManager
     view.setOverScrollMode(ReactScrollViewHelper.parseOverScrollMode(value));
   }
 
-  /**
-   * Enables/Disables nested scrolling
-   */
   @ReactProp(name = "nestedScrollEnabled")
   public void setNestedScrollEnabled(ReactScrollView view, boolean value) {
     ViewCompat.setNestedScrollingEnabled(view, value);

--- a/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewManager.java
@@ -9,6 +9,8 @@ package com.facebook.react.views.scroll;
 
 import android.annotation.TargetApi;
 import android.graphics.Color;
+import android.support.v4.view.ViewCompat;
+
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.common.MapBuilder;
 import com.facebook.react.module.annotations.ReactModule;
@@ -21,8 +23,9 @@ import com.facebook.react.uimanager.ViewProps;
 import com.facebook.react.uimanager.annotations.ReactProp;
 import com.facebook.react.uimanager.annotations.ReactPropGroup;
 import com.facebook.yoga.YogaConstants;
-import java.util.Map;
+
 import javax.annotation.Nullable;
+import java.util.Map;
 
 /**
  * View manager for {@link ReactScrollView} components.
@@ -119,6 +122,14 @@ public class ReactScrollViewManager
   @ReactProp(name = "overScrollMode")
   public void setOverScrollMode(ReactScrollView view, String value) {
     view.setOverScrollMode(ReactScrollViewHelper.parseOverScrollMode(value));
+  }
+
+  /**
+   * Enables/Disables nested scrolling
+   */
+  @ReactProp(name = "nestedScrollEnabled")
+  public void setNestedScrollEnabled(ReactScrollView view, boolean value) {
+    ViewCompat.setNestedScrollingEnabled(view, value);
   }
 
   @Override


### PR DESCRIPTION
## Motivation

Nested scrolling in scrollViews, listViews and flatLists are enabled on iOS by default, but needs to be enabled manually on Android. This PR introduces a `nestedScrollEnabled` property to ScrollViews to support nested scrolling on Android 21 and above.

Enabling nested scroll will resolve issues with coordinator layout in android and required to support a collapsing toolbar. 

## Test Plan

Tested on the test app. We are also using this property in our app currently to support scrolling behaviour required by coordinator layouts.

## Release Notes

[ANDROID] [ENHANCEMENT] [ScrollView] - Added a prop to enable nested scrolling