### PR TITLE
Make perspective transformation look exactly same on iOS and Android

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
@@ -234,11 +234,11 @@ public abstract class BaseViewManager<T extends View, C extends LayoutShadowNode
       float scale = DisplayMetricsHolder.getScreenDisplayMetrics().density;
 
       // The following converts the matrix's perspective to a camera distance
-      // such that the camera perspective looks the same on Android and iOS
-      // While comparing the output between android and ios, it seemed like
-      // the native android implementation removed the screen density from the
-      // calculation, so taking square and also the normalization value at
-      // sqrt(5) produced an exact replica with ios
+      // such that the camera perspective looks the same on Android and iOS.
+      // The native Android implementation removed the screen density from the
+      // calculation, so squaring and a normalization value of
+      // sqrt(5) produced an exact replica with ios.
+      // For more information, see https://github.com/facebook/react-native/pull/18302
       float normalizedCameraDistance = scale * scale * cameraDistance * CAMERA_DISTANCE_NORMALIZATION_MULTIPLIER;
       view.setCameraDistance(normalizedCameraDistance);
 

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
@@ -237,7 +237,7 @@ public abstract class BaseViewManager<T extends View, C extends LayoutShadowNode
       // such that the camera perspective looks the same on Android and iOS.
       // The native Android implementation removed the screen density from the
       // calculation, so squaring and a normalization value of
-      // sqrt(5) produced an exact replica with ios.
+      // sqrt(5) produces an exact replica with iOS.
       // For more information, see https://github.com/facebook/react-native/pull/18302
       float normalizedCameraDistance = scale * scale * cameraDistance * CAMERA_DISTANCE_NORMALIZATION_MULTIPLIER;
       view.setCameraDistance(normalizedCameraDistance);

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
@@ -44,7 +44,7 @@ public abstract class BaseViewManager<T extends View, C extends LayoutShadowNode
   private static final String PROP_TRANSLATE_Y = "translateY";
 
   private static final int PERSPECTIVE_ARRAY_INVERTED_CAMERA_DISTANCE_INDEX = 2;
-  private static final float CAMERA_DISTANCE_NORMALIZATION_MULTIPLIER = 5;
+  private static final float CAMERA_DISTANCE_NORMALIZATION_MULTIPLIER = (float)Math.sqrt(5);
 
   /**
    * Used to locate views in end-to-end (UI) tests.
@@ -235,7 +235,11 @@ public abstract class BaseViewManager<T extends View, C extends LayoutShadowNode
 
       // The following converts the matrix's perspective to a camera distance
       // such that the camera perspective looks the same on Android and iOS
-      float normalizedCameraDistance = scale * cameraDistance * CAMERA_DISTANCE_NORMALIZATION_MULTIPLIER;
+      // While comparing the output between android and ios, it seemed like
+      // the native android implementation removed the screen density from the
+      // calculation, so taking square and also the normalization value at
+      // sqrt(5) produced an exact replica with ios
+      float normalizedCameraDistance = scale * scale * cameraDistance * CAMERA_DISTANCE_NORMALIZATION_MULTIPLIER;
       view.setCameraDistance(normalizedCameraDistance);
 
     }


### PR DESCRIPTION
Summary:
There is a variation in iOS and Android output while performing perspective transformation. The variation exists even when used in Android devices with different screen density. 

Test Plan:
I carried out tests on multiple devices with different perspective value and varying rotation X angle, and back calculated the Camera Distance value from the screen shots. On iOS the values were almost equal to the `Pixel Density * Perspective` value wheres on Android devices the Distance would always come out to be approximately `2.24 * Perspective` value irrespective of the device screen density. I used the following code to use perspective transformation and verified that output matched exactly on all platforms.
```javascript
const PERSPECTIVE = Platform.OS === 'ios' ? P : (P * PixelRatio.get()) / Math.sqrt(5);
```
The code was then translated to the `BaseViewManager.java` and verified that the output matched on all platforms.

Changelog:
[ANDROID] [BUGFIX] [Perspective Transformation] - Corrected perspective transformation to look exactly same on iOS and Android devices.
