### PR TITLE
[CI] Clear cache to resolve iOS, tvOS workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,8 @@ aliases:
       - v1-yarn-{{ arch }}-{{ .Branch }}-{{ checksum "package.json" }}
       # Fallback in case checksum fails
       - v1-yarn-{{ arch }}-{{ .Branch }}-
+      # Fallback in case this is a first-time run on a fork
+      - v1-yarn-{{ arch }}-master-
   - &save-yarn-cache
     paths:
       - node_modules
@@ -16,6 +18,8 @@ aliases:
       - v1-analysis-dependencies-{{ arch }}-{{ .Branch }}-{{ checksum "package.json" }}{{ checksum "bots/package.json" }}
       # Fallback in case checksum fails
       - v1-analysis-dependencies-{{ arch }}-{{ .Branch }}-
+      # Fallback in case this is a first-time run on a fork
+      - v1-analysis-dependencies-{{ arch }}-master-
   - &save-cache-analysis
     paths:
       - bots/node_modules
@@ -27,6 +31,8 @@ aliases:
       - v1-android-sdkmanager-packages-{{ arch }}-{{ .Branch }}-api-26-alpha-{{ checksum "scripts/circle-ci-android-setup.sh" }}
       # Fallback in case checksum fails
       - v1-android-sdkmanager-packages-{{ arch }}-{{ .Branch }}-api-26-alpha-
+      # Fallback in case this is a first-time run on a fork
+      - v1-android-sdkmanager-packages-{{ arch }}-master-api-26-alpha-
   - &save-cache-android-packages
     paths:
       - /opt/android/sdk

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,43 +2,45 @@ aliases:
   # Cache Management
   - &restore-yarn-cache
     keys:
-      - v1-yarn-{{ arch }}-{{ checksum "package.json" }}
+      - v1-yarn-{{ arch }}-{{ .Branch }}-{{ checksum "package.json" }}
       # Fallback in case checksum fails
-      - v1-yarn-{{ arch }}-
+      - v1-yarn-{{ arch }}-{{ .Branch }}-
   - &save-yarn-cache
     paths:
       - node_modules
       - ~/.cache/yarn
-    key: v1-yarn-{{ arch }}-{{ checksum "package.json" }}
+    key: v1-yarn-{{ arch }}-{{ .Branch }}-{{ checksum "package.json" }}
 
   - &restore-cache-analysis
     keys:
-      - v1-analysis-dependencies-{{ arch }}-{{ checksum "package.json" }}{{ checksum "bots/package.json" }}
+      - v1-analysis-dependencies-{{ arch }}-{{ .Branch }}-{{ checksum "package.json" }}{{ checksum "bots/package.json" }}
       # Fallback in case checksum fails
-      - v1-analysis-dependencies-{{ arch }}-
+      - v1-analysis-dependencies-{{ arch }}-{{ .Branch }}-
   - &save-cache-analysis
     paths:
       - bots/node_modules
       - node_modules
-    key: v1-analysis-dependencies-{{ arch }}-{{ checksum "package.json" }}{{ checksum "bots/package.json" }}
+    key: v1-analysis-dependencies-{{ arch }}-{{ .Branch }}-{{ checksum "package.json" }}{{ checksum "bots/package.json" }}
 
   - &restore-cache-android-packages
     keys:
-      - v1-android-sdkmanager-packages-{{ arch }}-api-26-alpha-{{ checksum "scripts/circle-ci-android-setup.sh" }}
+      - v1-android-sdkmanager-packages-{{ arch }}-{{ .Branch }}-api-26-alpha-{{ checksum "scripts/circle-ci-android-setup.sh" }}
       # Fallback in case checksum fails
-      - v1-android-sdkmanager-packages-{{ arch }}-api-26-alpha-
+      - v1-android-sdkmanager-packages-{{ arch }}-{{ .Branch }}-api-26-alpha-
   - &save-cache-android-packages
     paths:
       - /opt/android/sdk
-    key: v1-android-sdkmanager-packages-{{ arch }}-api-26-alpha-{{ checksum "scripts/circle-ci-android-setup.sh" }}
+    key: v1-android-sdkmanager-packages-{{ arch }}-{{ .Branch }}-api-26-alpha-{{ checksum "scripts/circle-ci-android-setup.sh" }}
 
   - &restore-cache-ndk
     keys:
-      - v2-android-ndk-{{ arch }}-r10e-32-64
+      - v2-android-ndk-{{ arch }}-r10e-32-64-{{ checksum "scripts/circle-ci-android-setup.sh" }}
+      # Fallback in case checksum fails
+      - v2-android-ndk-{{ arch }}-r10e-32-64-
   - &save-cache-ndk
     paths:
       - /opt/ndk
-    key: v2-android-ndk-{{ arch }}-r10e-32-64
+    key: v2-android-ndk-{{ arch }}-r10e-32-64-{{ checksum "scripts/circle-ci-android-setup.sh" }}
 
   - &restore-cache-buck
     keys:
@@ -152,9 +154,11 @@ aliases:
     command: yarn flow check
     when: always
 
-  - &run-license-checks
-    name: Check license
-    command: ./scripts/circleci/check_license.sh
+  - &run-sanity-checks
+    name: Sanity checks
+    command: |
+      ./scripts/circleci/check_license.sh
+      ./scripts/circleci/check_cache.sh
     when: always
     
   - &build-android-app
@@ -209,18 +213,10 @@ aliases:
     name: Initial Setup
     command: | 
       mkdir -p ~/react-native/reports/junit/
-
-  - &build-objc-ios-test-app
-    name: Build iOS Test App
-    command: ./scripts/objc-test-ios.sh
   
   - &run-objc-ios-tests
     name: iOS Test Suite
     command: ./scripts/objc-test-ios.sh test
-
-  - &build-objc-tvos-test-app
-    name: Build tvOS Test App
-    command: ./scripts/objc-test-tvos.sh
 
   - &run-objc-tvos-tests
     name: tvOS Test Suite
@@ -274,6 +270,9 @@ jobs:
       - run: *yarn
       - save-cache: *save-yarn-cache
 
+      # Basic checks against the checkout, cache...
+      - run: *run-sanity-checks
+
       - persist_to_workspace:
           root: .
           paths: .
@@ -288,7 +287,6 @@ jobs:
 
       - run: *run-lint-checks
       - run: *run-flow-checks
-      - run: *run-license-checks
 
       - store_test_results:
           path: ~/react-native/reports/junit

--- a/scripts/circleci/check_cache.sh
+++ b/scripts/circleci/check_cache.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -e
+
+# Make sure we don't accidentally restore a cache that contains the Metro
+# filename issue that was fixed in Metro 0.25, originally introduced in
+# D6752278. Once fixed, this was causing sporadic failures in the iOS
+# and tvOS workflows as the issue persisted in the cached node_modules
+#
+# The filename issue can be summarized as follows:
+# A version of Metro was published to npm with HmrClient.js and
+# HmrClient.js.flow files, while the repo contains HMRClient.js and
+# HMRClient.js.flow. This was due to a case issue in the publisher's
+# host machine.
+# The issue this is checking for is manifested by the presence of all
+# of the following files: HmrClient.js, HMRClient.js, HmrClient.js.flow,
+# HMRClient.js.flow.
+
+EXPECTED='1'
+ACTUAL=$(ls node_modules/metro/src/lib/bundle-modules/*.js | xargs | awk '{print tolower($0)}' | tr ' ' '\n' | grep hmrclient.js | wc -l | tr -d '[:space:]')
+
+if [ "$EXPECTED" != "$ACTUAL" ]; then
+  echo "HmrClient.js crept into the cache?"
+  echo $(ls node_modules/metro/src/lib/bundle-modules/H*lient.js)
+  exit 1
+fi


### PR DESCRIPTION
tvOS and iOS workflows were flaky, apparently due to a stale cache that contained a problematic version of the Metro dependency. Thanks to @motiz88 for identifying the potential cause of flakiness in https://github.com/react-native-community/react-native-releases/issues/2#issuecomment-371905315.

# Test Plan

https://circleci.com/workflow-run/440180a2-e888-4f27-bec9-b8e5d9be6708

# Release Notes

[GENERAL] [MINOR] [CI] - Resolve iOS, tvOS failures in Circle