### PR TITLE
Loosen Platform check to allow better code sharing for out-of-tree platforms

### DIFF
--- a/Libraries/ReactNative/UIManager.js
+++ b/Libraries/ReactNative/UIManager.js
@@ -77,7 +77,7 @@ if (Platform.OS === 'ios') {
       });
     }
   });
-} else if (Platform.OS === 'android' && UIManager.ViewManagerNames) {
+} else if (UIManager.ViewManagerNames) {
   UIManager.ViewManagerNames.forEach(viewManagerName => {
     defineLazyObjectProperty(UIManager, viewManagerName, {
       get: () => UIManager.getConstantsForViewManager(viewManagerName),


### PR DESCRIPTION
## Motivation

Don't lock out other non-iOS platforms (e.g. Windows) with an overly
specific check. This change allows this JS file to be re-used instead of copied and modified. There was one other instance of this pattern, but I'll submit it separate for easier cherry-picking.

## Test Plan

Tested Android and iOS playground on simulators.

## Release Notes
 [GENERAL] [ENHANCEMENT] - some core ReactNative JS library files will be easier to re-use across RN platforms.
