### PR TITLE
[Android] Checkbox to inherit from AppCompatCheckBox

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/checkbox/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/checkbox/BUCK
@@ -5,6 +5,7 @@ rn_android_library(
     srcs = glob(["*.java"]),
     provided_deps = [
         react_native_dep("third-party/android/support/v4:lib-support-v4"),
+        react_native_dep("third-party/android/support/v7/appcompat-orig:appcompat"),
     ],
     visibility = [
         "PUBLIC",

--- a/ReactAndroid/src/main/java/com/facebook/react/views/checkbox/ReactCheckBox.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/checkbox/ReactCheckBox.java
@@ -7,10 +7,10 @@
 package com.facebook.react.views.checkbox;
 
 import android.content.Context;
-import android.widget.CheckBox;
+import android.support.v7.widget.AppCompatCheckBox;
 
 /** CheckBox that has its value controlled by JS. */
-/*package*/ class ReactCheckBox extends CheckBox {
+/*package*/ class ReactCheckBox extends AppCompatCheckBox {
 
   private boolean mAllowChange;
 


### PR DESCRIPTION
## Motivation

The checkbox components inherits from `android.widget.CheckBox`. `AppCompatCheckBox` offers better appearance and support for advanced features (eg. tinting) on older APIs. 

~~However, the build fails for some reason; If somebody could shed some light on this, I'd appreciate it.~~ Thanks for the comment, I was being blind and somehow ignored the BUCK file.

## Test Plan

I have created a simple app with a checkbox.

Screenshot from android 4.1 (current master):

<img src="https://user-images.githubusercontent.com/1566403/37357997-2d34bdb8-26ea-11e8-8c77-709a4f96c6bf.png" width="300" />


Screenshot after applying the change, also android 4.1:

<img src="https://user-images.githubusercontent.com/1566403/37358016-3c28fb86-26ea-11e8-8dca-3a92e41450c9.png" width="300" />

## Related PRs

https://github.com/facebook/react-native/pull/18300 (this PR is needed to support tinting on older android api levels)

## Release Notes

[ANDROID]  [ENHANCEMENT]  [Checkbox] - Checkbox inherits from AppCompatCheckBox

