### PR TITLE
While linking plugin ask for params only once

### DIFF
--- a/local-cli/link/link.js
+++ b/local-cli/link/link.js
@@ -37,7 +37,9 @@ log.heading = 'rnpm-link';
 
 const dedupeAssets = (assets) => uniqBy(assets, asset => path.basename(asset));
 
-const linkDependency = (platforms, project, dependency) => {
+const linkDependency = async (platforms, project, dependency) => {
+  const params = await pollParams(dependency.config.params);
+
   Object.keys(platforms || {})
     .forEach(platform => {
       if (!project[platform] || !dependency.config[platform]) {
@@ -56,18 +58,16 @@ const linkDependency = (platforms, project, dependency) => {
         return null;
       }
 
-      return pollParams(dependency.config.params).then(params => {
-        log.info(`Linking ${dependency.name} ${platform} dependency`);
+      log.info(`Linking ${dependency.name} ${platform} dependency`);
 
-        linkConfig.register(
-          dependency.name,
-          dependency.config[platform],
-          params,
-          project[platform]
-        );
+      linkConfig.register(
+        dependency.name,
+        dependency.config[platform],
+        params,
+        project[platform]
+      );
 
-        log.info(`Platform '${platform}' module ${dependency.name} has been successfully linked`);
-      });
+      log.info(`Platform '${platform}' module ${dependency.name} has been successfully linked`);
     });
 };
 


### PR DESCRIPTION
Resolve #18333

## Motivation

CLI should ask users for params only once and waiting for response while linking plugin

## Test Plan

Ran the `link` commands for iOS and Android and confirmed that params requested only once.

## Related PRs

#17961

## Release Notes
[CLI][FEATURE][local-cli/link/link.js] - Requesting link params only once for all platforms
