### PR TITLE
Apply #18278 to fix TextInput.clear() bug

### DIFF
--- a/Libraries/Text/TextInput/RCTBaseTextInputView.m
+++ b/Libraries/Text/TextInput/RCTBaseTextInputView.m
@@ -93,6 +93,28 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithFrame:(CGRect)frame)
   [self setNeedsLayout];
 }
 
+- (NSString *)text
+{
+  return [self attributedText].string;
+}
+
+- (void)setText:(NSString *)text
+{
+  if (self.attributedText.length > 0) {
+    //copy the attributes
+    NSRange range = NSMakeRange(self.attributedText.length-1, self.attributedText.length);
+    NSDictionary *attributes = [self.attributedText attributesAtIndex:0 effectiveRange:&range];
+    NSMutableAttributedString *newString = [[NSMutableAttributedString alloc] initWithString:text attributes:attributes];
+    NSMutableAttributedString *primaryStringMutable = [[NSMutableAttributedString alloc] initWithAttributedString:self.attributedText];
+    
+    //change the string
+    [primaryStringMutable setAttributedString:newString];
+    [self setAttributedText:[[NSAttributedString alloc] initWithAttributedString:primaryStringMutable]];
+  } else {
+    [self setAttributedText:[[NSAttributedString alloc] initWithString: text]];
+  }
+}
+
 - (NSAttributedString *)attributedText
 {
   return self.backedTextInputView.attributedText;

--- a/Libraries/Text/TextInput/RCTBaseTextInputViewManager.m
+++ b/Libraries/Text/TextInput/RCTBaseTextInputViewManager.m
@@ -60,6 +60,7 @@ RCT_EXPORT_VIEW_PROPERTY(onChange, RCTBubblingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onSelectionChange, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onTextInput, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onScroll, RCTDirectEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(text, NSString)
 
 RCT_EXPORT_VIEW_PROPERTY(mostRecentEventCount, NSInteger)
 


### PR DESCRIPTION
Apply [#18278](https://github.com/facebook/react-native/pull/18278) to fix TextInput.clear() bug ([#18272](https://github.com/facebook/react-native/issues/18272))