### PR TITLE
Add inverted prop in SectionListExample

### DIFF
--- a/RNTester/js/SectionListExample.js
+++ b/RNTester/js/SectionListExample.js
@@ -139,7 +139,6 @@ class SectionListExample extends React.PureComponent<{}, $FlowFixMeState> {
         <SeparatorComponent />
         <AnimatedSectionList
           ref={this._captureRef}
-          contentContainerStyle={{ borderWidth:1, borderColor: 'red' }}
           ListHeaderComponent={HeaderComponent}
           ListFooterComponent={FooterComponent}
           SectionSeparatorComponent={(info) =>

--- a/RNTester/js/SectionListExample.js
+++ b/RNTester/js/SectionListExample.js
@@ -76,6 +76,7 @@ class SectionListExample extends React.PureComponent<{}, $FlowFixMeState> {
     filterText: '',
     logViewable: false,
     virtualized: true,
+    inverted: false,
   };
 
   _scrollPos = new Animated.Value(0);
@@ -125,6 +126,7 @@ class SectionListExample extends React.PureComponent<{}, $FlowFixMeState> {
             {renderSmallSwitchOption(this, 'virtualized')}
             {renderSmallSwitchOption(this, 'logViewable')}
             {renderSmallSwitchOption(this, 'debug')}
+            {renderSmallSwitchOption(this, 'inverted')}
             <Spindicator value={this._scrollPos} />
           </View>
           <View style={styles.scrollToRow}>
@@ -137,6 +139,7 @@ class SectionListExample extends React.PureComponent<{}, $FlowFixMeState> {
         <SeparatorComponent />
         <AnimatedSectionList
           ref={this._captureRef}
+          contentContainerStyle={{ borderWidth:1, borderColor: 'red' }}
           ListHeaderComponent={HeaderComponent}
           ListFooterComponent={FooterComponent}
           SectionSeparatorComponent={(info) =>
@@ -146,6 +149,7 @@ class SectionListExample extends React.PureComponent<{}, $FlowFixMeState> {
             <CustomSeparatorComponent {...info} text="ITEM SEPARATOR" />
           }
           debug={this.state.debug}
+          inverted={this.state.inverted}
           enableVirtualization={this.state.virtualized}
           onRefresh={() => Alert.alert('onRefresh: nothing to refresh :P')}
           onScroll={this._scrollSinkY}
@@ -232,6 +236,8 @@ const styles = StyleSheet.create({
   },
   optionSection: {
     flexDirection: 'row',
+    flexWrap: 'wrap',
+    alignItems: 'center',
   },
   searchRow: {
     paddingHorizontal: 10,


### PR DESCRIPTION
## Motivation
This PR adds an option to pass`inverted` prop to SectionListExample in RNTester. FlatListExample already has this option but it's not available in SectionListExample.

## Test Plan
Run RNTester app on device or simulator and select SectionListExample. Depending on switching `inverted` option, you can see either inverted list or not.

## Release Notes
[GENERAL][ENHANCEMENT][RNTeater] - Add inverted prop to SectionListExample
