### PR TITLE
Make generic event types less platform-specific

### DIFF
--- a/Libraries/ReactNative/requireFabricComponent.js
+++ b/Libraries/ReactNative/requireFabricComponent.js
@@ -53,22 +53,21 @@ function requireNativeComponent(
   extraConfig?: ?{nativeOnly?: Object},
 ): React$ComponentType<any> | string {
   function attachDefaultEventTypes(viewConfig: any) {
-    if (Platform.OS === 'android') {
-      // This is supported on Android platform only,
-      // as lazy view managers discovery is Android-specific.
-      if (UIManager.ViewManagerNames) {
-        // Lazy view managers enabled.
-        viewConfig = merge(viewConfig, UIManager.getDefaultEventTypes());
-      } else {
-        viewConfig.bubblingEventTypes = merge(
-          viewConfig.bubblingEventTypes,
-          UIManager.genericBubblingEventTypes,
-        );
-        viewConfig.directEventTypes = merge(
-          viewConfig.directEventTypes,
-          UIManager.genericDirectEventTypes,
-        );
-      }
+    // This is used for lazy view managers discovery.
+    if (UIManager.ViewManagerNames) {
+      // Lazy view managers enabled.
+      viewConfig = merge(viewConfig, UIManager.getDefaultEventTypes());
+    } else if (UIManager.genericBubblingEventTypes || UIManager.genericDirectEventTypes) {
+      // This is used when a generic set of events
+      // is configured for all view managers.
+      viewConfig.bubblingEventTypes = merge(
+        viewConfig.bubblingEventTypes,
+        UIManager.genericBubblingEventTypes,
+      );
+      viewConfig.directEventTypes = merge(
+        viewConfig.directEventTypes,
+        UIManager.genericDirectEventTypes,
+      );
     }
   }
 

--- a/Libraries/ReactNative/requireNativeComponent.js
+++ b/Libraries/ReactNative/requireNativeComponent.js
@@ -51,22 +51,21 @@ function requireNativeComponent(
   extraConfig?: ?{nativeOnly?: Object},
 ): React$ComponentType<any> | string {
   function attachDefaultEventTypes(viewConfig: any) {
-    if (Platform.OS === 'android') {
-      // This is supported on Android platform only,
-      // as lazy view managers discovery is Android-specific.
-      if (UIManager.ViewManagerNames) {
-        // Lazy view managers enabled.
-        viewConfig = merge(viewConfig, UIManager.getDefaultEventTypes());
-      } else {
-        viewConfig.bubblingEventTypes = merge(
-          viewConfig.bubblingEventTypes,
-          UIManager.genericBubblingEventTypes,
-        );
-        viewConfig.directEventTypes = merge(
-          viewConfig.directEventTypes,
-          UIManager.genericDirectEventTypes,
-        );
-      }
+    // This is used for lazy view managers discovery.
+    if (UIManager.ViewManagerNames) {
+      // Lazy view managers enabled.
+      viewConfig = merge(viewConfig, UIManager.getDefaultEventTypes());
+    } else if (UIManager.genericBubblingEventTypes || UIManager.genericDirectEventTypes) {
+      // This is used when a generic set of events
+      // is configured for all view managers.
+      viewConfig.bubblingEventTypes = merge(
+        viewConfig.bubblingEventTypes,
+        UIManager.genericBubblingEventTypes,
+      );
+      viewConfig.directEventTypes = merge(
+        viewConfig.directEventTypes,
+        UIManager.genericDirectEventTypes,
+      );
     }
   }
 


### PR DESCRIPTION
A previous PR (#18308) enabled lazy loading of view manager constants.

This PR enables any platform to use of generic bubbling and direct event types by exposing the constants `genericBubblingEventTypes` or `genericDirectEventTypes` on the UIManagerModule.

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes. 

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to React Native here: http://facebook.github.io/react-native/docs/contributing.html

Happy contributing!

-->

## Motivation

I am adding lazy view managers to react-native-windows, and would like to use the same approach of loading "generic" event types that apply to all view managers only once.

## Test Plan

Run jest tests. Run sample app on iOS and Android.

## Related PRs

#18308

## Release Notes
<!--
Help reviewers and the release process by writing your own release notes

**INTERNAL and MINOR tagged notes will not be included in the next version's final release notes.**

  CATEGORY
[----------]        TYPE
[ CLI      ]   [-------------]      LOCATION
[ DOCS     ]   [ BREAKING    ]   [-------------]
[ GENERAL  ]   [ BUGFIX      ]   [-{Component}-]
[ INTERNAL ]   [ ENHANCEMENT ]   [ {File}      ]
[ IOS      ]   [ FEATURE     ]   [ {Directory} ]   |-----------|
[ ANDROID  ]   [ MINOR       ]   [ {Framework} ] - | {Message} |
[----------]   [-------------]   [-------------]   |-----------|

[CATEGORY] [TYPE] [LOCATION] - MESSAGE

 EXAMPLES:

 [IOS] [BREAKING] [FlatList] - Change a thing that breaks other things
 [ANDROID] [BUGFIX] [TextInput] - Did a thing to TextInput
 [CLI] [FEATURE] [local-cli/info/info.js] - CLI easier to do things with
 [DOCS] [BUGFIX] [GettingStarted.md] - Accidentally a thing/word
 [GENERAL] [ENHANCEMENT] [Yoga] - Added new yoga thing/position
 [INTERNAL] [FEATURE] [./scripts] - Added thing to script that nobody will see
-->

[GENERAL][ENHANCEMENT][MINOR][Libraries/ReactNative/requireNativeComponent.js] - Enable any platform to use generic event types.
