### PR TITLE
[Android] fix cleanReactNdkLib task failure

### DIFF
--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -210,7 +210,7 @@ task buildReactNdkLib(dependsOn: [prepareJSC, prepareBoost, prepareDoubleConvers
             '--jobs', project.hasProperty("jobs") ? project.property("jobs") : Runtime.runtime.availableProcessors()
 }
 
-task cleanReactNdkLib(type: Exec) {
+task cleanReactNdkLib(dependsOn: [prepareJSC, prepareBoost, prepareDoubleConversion, prepareFolly, prepareGlog], type: Exec) {
     commandLine getNdkBuildFullPath(),
             "NDK_APPLICATION_MK=$projectDir/src/main/jni/Application.mk",
             "THIRD_PARTY_NDK_DIR=$buildDir/third-party-ndk",


### PR DESCRIPTION
**Question:**
cleanReactNdkLib task failure caused by module not found , first-party/fb/Android.mk: Cannot find module with tag 'folly' in import path

**Link:**
[https://github.com/facebook/react-native/pull/7935](#7935)
[https://github.com/facebook/react-native/pull/9096](#9096)

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes. 

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to React Native here: http://facebook.github.io/react-native/docs/contributing.html

Happy contributing!

-->

## Motivation

I'm still facing this issue,  just can't stand it any more.


