### PR TITLE
Disable onKeyPress logic when handler not defined

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
@@ -81,6 +81,7 @@ public class ReactEditText extends EditText {
   private @Nullable ScrollWatcher mScrollWatcher;
   private final InternalKeyListener mKeyListener;
   private boolean mDetectScrollMovement = false;
+  private boolean mOnKeyPress = false;
   private float mLetterSpacingPt = 0;
 
   private ReactViewBackgroundManager mReactBackgroundManager;
@@ -175,7 +176,7 @@ public class ReactEditText extends EditText {
   public InputConnection onCreateInputConnection(EditorInfo outAttrs) {
     ReactContext reactContext = (ReactContext) getContext();
     InputConnection inputConnection = super.onCreateInputConnection(outAttrs);
-    if (inputConnection != null) {
+    if (inputConnection != null && mOnKeyPress) {
       inputConnection = new ReactEditTextInputConnectionWrapper(inputConnection, reactContext, this);
     }
 
@@ -272,6 +273,10 @@ public class ReactEditText extends EditText {
 
   public void setBlurOnSubmit(@Nullable Boolean blurOnSubmit) {
     mBlurOnSubmit = blurOnSubmit;
+  }
+
+  public void setOnKeyPress(boolean onKeyPress) {
+    mOnKeyPress = onKeyPress;
   }
 
   public boolean getBlurOnSubmit() {

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
@@ -308,6 +308,11 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
     }
   }
 
+  @ReactProp(name = "onKeyPress", defaultBoolean = false)
+  public void setOnKeyPress(final ReactEditText view, boolean onKeyPress) {
+    view.setOnKeyPress(onKeyPress);
+  }
+
   // Sets the letter spacing as an absolute point size.
   // This extra handling, on top of what ReactBaseTextShadowNode already does, is required for the
   // correct display of spacing in placeholder (hint) text.


### PR DESCRIPTION
<!-- 
  Required: Write your motivation here.
  If this PR fixes an issue, type "Fixes #issueNumber" to automatically close the issue when the PR is merged.
-->

## Motivation
There are some bugs surrounding the use of unicode characters that are causing issues with `onKeyPress` on Android: see https://github.com/facebook/react-native/issues/18405#issuecomment-373624413.
We disable the creation and use of `ReactEditTextInputConnectionWrapper` unless the onKeyPress prop is specified, so that this code is 'opt-in' & not a general regression for every use of the TextInput.
N.B. it seems to introduce a lot of unnecessary code complexity to allow for enabling/disabling the onKeyPress events after a InputConnection has been created in `onCreateInputConnection` when the keyboard focusses (a new input connection is created whenever a TextInput gains focus) so I opted not to for simplicity's sake.

## Test Plan
Build & debug RNTest app, verify ReactEditTextInputConnectionWrapper code not executed if onKeyPress function not specified.

<!-- 
  Required: Write your test plan here. If you changed any code, please provide us with 
  clear instructions on how you verified your changes work. Bonus points for screenshots and videos! 
-->

## Release Notes
[ANDROID] [BUGFIX] [TextInput] - Disable TextInput onKeyPress event from being fired unless callback specified.
