### PR TITLE
Make 'button' default accessibility trait / comp. type for Touchables

### DIFF
--- a/Libraries/Components/Touchable/TouchableBounce.js
+++ b/Libraries/Components/Touchable/TouchableBounce.js
@@ -76,7 +76,12 @@ const TouchableBounce = createReactClass({
   },
 
   getDefaultProps: function() {
-    return {releaseBounciness: 10, releaseVelocity: 10};
+    return {
+      accessibilityComponentType: 'button',
+      accessibilityTraits: 'button',
+      releaseBounciness: 10,
+      releaseVelocity: 10,
+    };
   },
 
   getInitialState: function(): State {

--- a/Libraries/Components/Touchable/TouchableHighlight.js
+++ b/Libraries/Components/Touchable/TouchableHighlight.js
@@ -28,6 +28,8 @@ const ensurePositiveDelayProps = require('ensurePositiveDelayProps');
 import type {PressEvent} from 'CoreEventTypes';
 
 const DEFAULT_PROPS = {
+  accessibilityComponentType: 'button',
+  accessibilityTraits: 'button',
   activeOpacity: 0.85,
   delayPressOut: 100,
   underlayColor: 'black',

--- a/Libraries/Components/Touchable/TouchableNativeFeedback.android.js
+++ b/Libraries/Components/Touchable/TouchableNativeFeedback.android.js
@@ -138,6 +138,7 @@ const TouchableNativeFeedback = createReactClass({
 
   getDefaultProps: function() {
     return {
+      accessibilityComponentType: 'button',
       background: this.SelectableBackground(),
     };
   },

--- a/Libraries/Components/Touchable/TouchableOpacity.js
+++ b/Libraries/Components/Touchable/TouchableOpacity.js
@@ -139,6 +139,8 @@ const TouchableOpacity = createReactClass({
 
   getDefaultProps: function() {
     return {
+      accessibilityComponentType: 'button',
+      accessibilityTraits: 'button',
       activeOpacity: 0.2,
     };
   },

--- a/Libraries/Components/Touchable/TouchableWithoutFeedback.js
+++ b/Libraries/Components/Touchable/TouchableWithoutFeedback.js
@@ -112,6 +112,13 @@ const TouchableWithoutFeedback = createReactClass({
     hitSlop: EdgeInsetsPropType,
   },
 
+  getDefaultProps: function() {
+    return {
+      accessibilityComponentType: 'button',
+      accessibilityTraits: 'button'
+    };
+  },
+
   getInitialState: function() {
     return this.touchableGetInitialState();
   },

--- a/Libraries/Components/Touchable/__tests__/__snapshots__/TouchableHighlight-test.js.snap
+++ b/Libraries/Components/Touchable/__tests__/__snapshots__/TouchableHighlight-test.js.snap
@@ -2,9 +2,9 @@
 
 exports[`TouchableHighlight renders correctly 1`] = `
 <View
-  accessibilityComponentType={undefined}
+  accessibilityComponentType="button"
   accessibilityLabel={undefined}
-  accessibilityTraits={undefined}
+  accessibilityTraits="button"
   accessible={true}
   hasTVPreferredFocus={undefined}
   hitSlop={undefined}


### PR DESCRIPTION
Hi! I first wrote a FR here https://react-native.canny.io/feature-requests/p/default-accessibility-traitaccessibilitycomponenttype-on-touchables, but I thought I might as well make the PR.

I find myself writing

```
accessibilityTraits="button"
accessibilityComponentType="button"
```

on all Touchable* components in my app. Why do not the Touchable* components have this set by default? I'm sure you have good reasons for having it as it is today, but I can't find them, and I'd like to argue for having these props set to "button" as default:

* All react-native apps are more accessible "out-of-the-box"

* I struggle to think of cases where you would want to have an accessible Touchable that should NOT have a trait/componentType specified

* Native Android/iOS buttons are all announcing themselves as buttons without the developer having to explicitly set trait/type.

* Less boilerplate code!

More on the first bullet point: Think about all the developers that do not care about accessibility. Their apps would become a lot more user friendly for people dependent on screen readers, without the developer having to do anything.
## Test Plan

* Ran `yarn test`.
* Used the Accessibility Inspector to inspect the RNTester app in simulator to see that buttons got the Button trait.

<img width="813" alt="screen shot 2018-03-19 at 13 07 38" src="https://user-images.githubusercontent.com/4339443/37594993-5edc5ca4-2b77-11e8-88a6-fa066059247f.png">

## Related PRs

https://github.com/facebook/react-native-website/pull/263

## Release Notes

<!-- 
  Required. 
  Help reviewers and the release process by writing your own release notes. See below for an example.
-->

Am I doing this correctly? :)

[IOS] [ENHANCEMENT] [Libraries/Components/Touchable] - Make "button" default accessibility trait / component type for Touchable components
[ANDROID] [ENHANCEMENT] [Libraries/Components/Touchable] - Make "button" default accessibility trait / component type for Touchable components
<!--
  **INTERNAL and MINOR tagged notes will not be included in the next version's final release notes.**

    CATEGORY
  [----------]      TYPE
  [ CLI      ] [-------------]    LOCATION
  [ DOCS     ] [ BREAKING    ] [-------------]
  [ GENERAL  ] [ BUGFIX      ] [ {Component} ]
  [ INTERNAL ] [ ENHANCEMENT ] [ {Filename}  ]
  [ IOS      ] [ FEATURE     ] [ {Directory} ]   |-----------|
  [ ANDROID  ] [ MINOR       ] [ {Framework} ] - | {Message} |
  [----------] [-------------] [-------------]   |-----------|

 EXAMPLES:

 [IOS] [BREAKING] [FlatList] - Change a thing that breaks other things
 [ANDROID] [BUGFIX] [TextInput] - Did a thing to TextInput
 [CLI] [FEATURE] [local-cli/info/info.js] - CLI easier to do things with
 [DOCS] [BUGFIX] [GettingStarted.md] - Accidentally a thing/word
 [GENERAL] [ENHANCEMENT] [Yoga] - Added new yoga thing/position
 [INTERNAL] [FEATURE] [./scripts] - Added thing to script that nobody will see
-->
