### PR TITLE
Expose AsyncLocalStorage get/set methods

### DIFF
--- a/React/Modules/RCTAsyncLocalStorage.h
+++ b/React/Modules/RCTAsyncLocalStorage.h
@@ -31,4 +31,11 @@
 // For clearing data when the bridge may not exist, e.g. when logging out.
 + (void)clearAllData;
 
+// Grab data from the cache. ResponseBlock result array will have an error at position 0, and an array of arrays at position 1.
+- (void)multiGet:(NSArray<NSString *> *)keys callback:(RCTResponseSenderBlock)callback;
+
+// Add multiple key value pairs to the cache.
+- (void)multiSet:(NSArray<NSArray<NSString *> *> *)kvPairs callback:(RCTResponseSenderBlock)callback;
+
+
 @end


### PR DESCRIPTION
## This PR exposes AsyncLocalStorage get/set methods to native code.

Currently, if an app uses AsyncStorage on the JS side, there is no public interface to access stored data from the native side. 

In our app, written in Swift, I have written a [helper](https://gist.github.com/ejmartin504/d501abe55c28450a0e52ac39aee7b0e6) that pulls out the data. I accomplished this by reverse-engineering the code in RCTAsyncLocalStorage.m. It would have been far easier had this code been exposed to native.


## Test Plan

I made this change locally and tested out getting the data from Swift code. This worked like a charm:

```swift
let storage = RCTAsyncLocalStorage()
let cacheKey = "test"
storage.methodQueue?.async {
    self.storage.multiGet([cacheKey]) { values in
        print(values)
    }
} 
```

## Release Notes

[IOS ][ENHANCEMENT ][RCTAsyncLocalStorage.h] - Expose AsyncLocalStorage get/set methods to native code.

<!--
  **INTERNAL and MINOR tagged notes will not be included in the next version's final release notes.**

    CATEGORY
  [----------]      TYPE
  [ CLI      ] [-------------]    LOCATION
  [ DOCS     ] [ BREAKING    ] [-------------]
  [ GENERAL  ] [ BUGFIX      ] [ {Component} ]
  [ INTERNAL ] [ ENHANCEMENT ] [ {Filename}  ]
  [ IOS      ] [ FEATURE     ] [ {Directory} ]   |-----------|
  [ ANDROID  ] [ MINOR       ] [ {Framework} ] - | {Message} |
  [----------] [-------------] [-------------]   |-----------|

 EXAMPLES:

 [IOS] [BREAKING] [FlatList] - Change a thing that breaks other things
 [ANDROID] [BUGFIX] [TextInput] - Did a thing to TextInput
 [CLI] [FEATURE] [local-cli/info/info.js] - CLI easier to do things with
 [DOCS] [BUGFIX] [GettingStarted.md] - Accidentally a thing/word
 [GENERAL] [ENHANCEMENT] [Yoga] - Added new yoga thing/position
 [INTERNAL] [FEATURE] [./scripts] - Added thing to script that nobody will see
-->