### PR TITLE
Fixed 0.54 - iOS] fetch HEAD requests fail with `Invalid response for blob`

### DIFF
--- a/Libraries/Network/XMLHttpRequest.js
+++ b/Libraries/Network/XMLHttpRequest.js
@@ -254,7 +254,11 @@ class XMLHttpRequest extends EventTarget(...XHR_EVENTS) {
         if (typeof this._response === 'object' && this._response) {
           this._cachedResponse = BlobManager.createFromOptions(this._response);
         } else {
-          throw new Error(`Invalid response for blob: ${this._response}`);
+          if (this._response === '')  {
+            this._cachedResponse = null;
+          } else {
+            throw new Error(`Invalid response for blob: ${this._response}`);
+          }
         }
         break;
 


### PR DESCRIPTION
Fixes #18223

## Test Plan
 
```
fetch('https://apipre.monkimun.com/whoami', {
  body: null,
  method: 'HEAD',
  headers: {
    Accept: 'application/json',
    'Content-Type': 'application/json',
  },
})
  .then(response => response.json())
  .then(json => console.log(json));
```

Additional information can be found in the issue #18223

## Related PRs

## Release Notes
CATEGORY

[ANDROID] [BUGFIX] [XMLHttpRequest] - Fixed an issue where fetch HEAD requests would fail with `Invalid response for blob`
[IOS] [BUGFIX] [XMLHttpRequest] - Fixed an issue where fetch HEAD requests would fail with `Invalid response for blob`