### PR TITLE
Fixes facebook/react-native#9777 Add support for resource-id

### DIFF
--- a/ReactAndroid/src/androidTest/java/com/facebook/react/testing/ReactAppTestActivity.java
+++ b/ReactAndroid/src/androidTest/java/com/facebook/react/testing/ReactAppTestActivity.java
@@ -37,6 +37,7 @@ import com.facebook.react.testing.idledetection.ReactIdleDetectionUtil;
 import com.facebook.react.uimanager.UIImplementationProvider;
 import com.facebook.react.uimanager.ViewManager;
 import com.facebook.react.uimanager.ViewManagerRegistry;
+import com.facebook.react.uimanager.util.ReactFindViewUtil;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -73,7 +74,7 @@ public class ReactAppTestActivity extends FragmentActivity
     setContentView(rootView);
 
     mScreenshotingFrameLayout = new ScreenshotingFrameLayout(this);
-    mScreenshotingFrameLayout.setId(ROOT_VIEW_ID);
+    ReactFindViewUtil.setReactTag(mScreenshotingFrameLayout, ROOT_VIEW_ID);
     rootView.addView(mScreenshotingFrameLayout);
 
     mReactRootView = new ReactRootView(this);

--- a/ReactAndroid/src/androidTest/java/com/facebook/react/tests/CatalystUIManagerTestCase.java
+++ b/ReactAndroid/src/androidTest/java/com/facebook/react/tests/CatalystUIManagerTestCase.java
@@ -98,7 +98,7 @@ public class CatalystUIManagerTestCase extends ReactIntegrationTestCase {
 
   public void testFlexUIRendered() {
     FrameLayout rootView = createRootView();
-    jsModule.renderFlexTestApplication(rootView.getId());
+    jsModule.renderFlexTestApplication(rootReactFindViewUtil.getReactTag(view));
     waitForBridgeAndUIIdle();
 
     assertEquals(1, rootView.getChildCount());
@@ -122,7 +122,7 @@ public class CatalystUIManagerTestCase extends ReactIntegrationTestCase {
   // Find what could be different and make the test independent of env
   // public void testFlexWithTextViews() {
   //   FrameLayout rootView = createRootView();
-  //   jsModule.renderFlexWithTextApplication(rootView.getId());
+  //   jsModule.renderFlexWithTextApplication(rootReactFindViewUtil.getReactTag(view));
   //   waitForBridgeAndUIIdle();
   //
   //   assertEquals(1, rootView.getChildCount());
@@ -160,7 +160,7 @@ public class CatalystUIManagerTestCase extends ReactIntegrationTestCase {
 
   public void testAbsolutePositionUIRendered() {
     FrameLayout rootView = createRootView();
-    jsModule.renderAbsolutePositionTestApplication(rootView.getId());
+    jsModule.renderAbsolutePositionTestApplication(rootReactFindViewUtil.getReactTag(view));
     waitForBridgeAndUIIdle();
 
     assertEquals(1, rootView.getChildCount());
@@ -174,7 +174,7 @@ public class CatalystUIManagerTestCase extends ReactIntegrationTestCase {
 
   public void testUpdatePositionInList() {
     FrameLayout rootView = createRootView();
-    jsModule.renderUpdatePositionInListTestApplication(rootView.getId());
+    jsModule.renderUpdatePositionInListTestApplication(rootReactFindViewUtil.getReactTag(view));
     waitForBridgeAndUIIdle();
 
     ViewGroup containerView = getViewByTestId(rootView, "container");
@@ -203,7 +203,7 @@ public class CatalystUIManagerTestCase extends ReactIntegrationTestCase {
 
   public void testAbsolutePositionBottomRightUIRendered() {
     FrameLayout rootView = createRootView();
-    jsModule.renderAbsolutePositionBottomRightTestApplication(rootView.getId());
+    jsModule.renderAbsolutePositionBottomRightTestApplication(rootReactFindViewUtil.getReactTag(view));
     waitForBridgeAndUIIdle();
 
     assertEquals(1, rootView.getChildCount());

--- a/ReactAndroid/src/androidTest/java/com/facebook/react/tests/TextInputTestCase.java
+++ b/ReactAndroid/src/androidTest/java/com/facebook/react/tests/TextInputTestCase.java
@@ -154,7 +154,7 @@ public class TextInputTestCase extends ReactAppInstrumentationTestCase {
 
     eventDispatcher.dispatchEvent(
         new ReactTextChangedEvent(
-            reactEditText.getId(),
+            ReactFindViewUtil.getReactTag(reactEditText),
             newText.toString(),
             (int) PixelUtil.toDIPFromPixel(contentWidth),
             (int) PixelUtil.toDIPFromPixel(contentHeight),
@@ -162,7 +162,7 @@ public class TextInputTestCase extends ReactAppInstrumentationTestCase {
 
     eventDispatcher.dispatchEvent(
         new ReactTextInputEvent(
-            reactEditText.getId(),
+            ReactFindViewUtil.getReactTag(reactEditText),
             newText.toString(),
             "",
             start,
@@ -186,7 +186,7 @@ public class TextInputTestCase extends ReactAppInstrumentationTestCase {
 
     eventDispatcher.dispatchEvent(
         new ReactTextChangedEvent(
-            reactEditText.getId(),
+            ReactFindViewUtil.getReactTag(reactEditText),
             newText.toString(),
             (int) PixelUtil.toDIPFromPixel(contentWidth),
             (int) PixelUtil.toDIPFromPixel(contentHeight),
@@ -194,7 +194,7 @@ public class TextInputTestCase extends ReactAppInstrumentationTestCase {
 
     eventDispatcher.dispatchEvent(
         new ReactTextInputEvent(
-            reactEditText.getId(),
+            ReactFindViewUtil.getReactTag(reactEditText),
             moreText,
             "",
             start,
@@ -218,7 +218,7 @@ public class TextInputTestCase extends ReactAppInstrumentationTestCase {
 
     eventDispatcher.dispatchEvent(
         new ReactTextChangedEvent(
-            reactEditText.getId(),
+            ReactFindViewUtil.getReactTag(reactEditText),
             newText.toString(),
             (int) PixelUtil.toDIPFromPixel(contentWidth),
             (int) PixelUtil.toDIPFromPixel(contentHeight),
@@ -226,7 +226,7 @@ public class TextInputTestCase extends ReactAppInstrumentationTestCase {
 
     eventDispatcher.dispatchEvent(
         new ReactTextInputEvent(
-            reactEditText.getId(),
+            ReactFindViewUtil.getReactTag(reactEditText),
             moreText,
             "",
             start,

--- a/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
@@ -80,6 +80,7 @@ import com.facebook.react.uimanager.DisplayMetricsHolder;
 import com.facebook.react.uimanager.UIImplementationProvider;
 import com.facebook.react.uimanager.UIManagerModule;
 import com.facebook.react.uimanager.ViewManager;
+import com.facebook.react.uimanager.util.ReactFindViewUtil;
 import com.facebook.react.views.imagehelper.ResourceDrawableIdHelper;
 import com.facebook.soloader.SoLoader;
 import com.facebook.systrace.Systrace;
@@ -714,7 +715,7 @@ public class ReactInstanceManager {
 
     // Reset view content as it's going to be populated by the application content from JS.
     rootView.removeAllViews();
-    rootView.setId(View.NO_ID);
+    ReactFindViewUtil.setReactTag(rootView, View.NO_ID);
 
     // If react context is being created in the background, JS application will be started
     // automatically when creation completes, as root view is part of the attached root view list.
@@ -1054,7 +1055,7 @@ public class ReactInstanceManager {
     synchronized (mAttachedRootViews) {
       for (ReactRootView rootView : mAttachedRootViews) {
         rootView.removeAllViews();
-        rootView.setId(View.NO_ID);
+        ReactFindViewUtil.setReactTag(rootView, View.NO_ID);
       }
     }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerImpl.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerImpl.java
@@ -57,6 +57,7 @@ import com.facebook.react.packagerconnection.RequestHandler;
 import com.facebook.react.packagerconnection.Responder;
 
 import com.facebook.react.uimanager.IllegalViewOperationException;
+import com.facebook.react.uimanager.util.ReactFindViewUtil;
 import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
@@ -341,7 +342,7 @@ public class DevSupportManagerImpl implements
       final Pair<View, Integer> deepestPairView = getDeepestNativeView(view);
 
       View deepestView = deepestPairView.first;
-      Integer tagId = deepestView.getId();
+      Integer tagId = ReactFindViewUtil.getReactTag(deepestView);
       final int depth = deepestPairView.second;
       JSDevSupport JSDevSupport = mCurrentContext.getNativeModule(JSDevSupport.class);
       JSDevSupport.getJSHierarchy(tagId.toString(), new JSDevSupport.DevSupportCallback() {

--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/InspectorPackagerConnection.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/InspectorPackagerConnection.java
@@ -16,6 +16,7 @@ import android.os.Looper;
 
 import com.facebook.common.logging.FLog;
 import com.facebook.react.bridge.Inspector;
+import com.facebook.react.uimanager.util.ReactFindViewUtil;
 
 import okhttp3.OkHttpClient;
 import okhttp3.Request;

--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/InspectorPackagerConnection.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/InspectorPackagerConnection.java
@@ -16,7 +16,6 @@ import android.os.Looper;
 
 import com.facebook.common.logging.FLog;
 import com.facebook.react.bridge.Inspector;
-import com.facebook.react.uimanager.util.ReactFindViewUtil;
 
 import okhttp3.OkHttpClient;
 import okhttp3.Request;

--- a/ReactAndroid/src/main/java/com/facebook/react/flat/ClippingDrawCommandManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/flat/ClippingDrawCommandManager.java
@@ -23,6 +23,7 @@ import com.facebook.common.logging.FLog;
 import com.facebook.infer.annotation.Assertions;
 import com.facebook.react.uimanager.ReactClippingViewGroup;
 import com.facebook.react.uimanager.ReactClippingViewGroupHelper;
+import com.facebook.react.uimanager.util.ReactFindViewUtil;
 
 /**
  * Abstract class for a {@link DrawCommandManager} with directional clipping.  Allows support for
@@ -310,7 +311,7 @@ import com.facebook.react.uimanager.ReactClippingViewGroupHelper;
 
   @Override
   void onClippedViewDropped(View view) {
-    unclip(view.getId());
+    unclip(ReactFindViewUtil.getReactTag(view));
     mFlatViewGroup.removeDetachedView(view);
   }
 
@@ -440,7 +441,7 @@ import com.facebook.react.uimanager.ReactClippingViewGroupHelper;
   private void updateClippingRecursively() {
     for (int i = 0, children = mClippingViewGroups.size(); i < children; i++) {
       ReactClippingViewGroup view = mClippingViewGroups.get(i);
-      if (isNotClipped(((View) view).getId())) {
+      if (isNotClipped(ReactFindViewUtil.getReactTag((View) view))) {
         view.updateClippingRect();
       }
     }
@@ -465,12 +466,12 @@ import com.facebook.react.uimanager.ReactClippingViewGroupHelper;
   private void updateClippingToCurrentRect() {
     for (int i = 0, size = mFlatViewGroup.getChildCount(); i < size; i++) {
       View view = mFlatViewGroup.getChildAt(i);
-      int index = mDrawViewIndexMap.get(view.getId());
+      int index = mDrawViewIndexMap.get(ReactFindViewUtil.getReactTag(view));
       if (withinBounds(index) || animating(view)) {
         mViewsToKeep.add(view);
       } else {
         mViewsToRemove.append(i, view);
-        clip(view.getId(), view);
+        clip(ReactFindViewUtil.getReactTag(view), view);
       }
     }
 
@@ -497,7 +498,7 @@ import com.facebook.react.uimanager.ReactClippingViewGroupHelper;
 
     for (int i = 0, size = mViewsToKeep.size(); i < size; i++) {
       View view = mViewsToKeep.get(i);
-      int commandIndex = mDrawViewIndexMap.get(view.getId());
+      int commandIndex = mDrawViewIndexMap.get(ReactFindViewUtil.getReactTag(view));
       if (current <= commandIndex) {
         while (current != commandIndex) {
           if (mDrawCommands[current] instanceof DrawView) {
@@ -595,7 +596,8 @@ import com.facebook.react.uimanager.ReactClippingViewGroupHelper;
       // This is the command index of the next view that we need to draw.  Since a view might be
       // animating, this view is either before all the commands onscreen, onscreen, or after the
       // onscreen commands.
-      int viewIndex = mDrawViewIndexMap.get(mFlatViewGroup.getChildAt(i).getId());
+      int reactTag = ReactFindViewUtil.getReactTag(mFlatViewGroup.getChildAt(i));
+      int viewIndex = mDrawViewIndexMap.get(reactTag);
       if (mStop < viewIndex) {
         // The current view is outside of the viewport bounds.  We want to draw all the commands
         // up to the stop, then draw all the views outside the viewport bounds.

--- a/ReactAndroid/src/main/java/com/facebook/react/flat/FlatNativeViewHierarchyManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/flat/FlatNativeViewHierarchyManager.java
@@ -23,6 +23,7 @@ import com.facebook.react.uimanager.common.SizeMonitoringFrameLayout;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.ViewGroupManager;
 import com.facebook.react.uimanager.ViewManagerRegistry;
+import com.facebook.react.uimanager.util.ReactFindViewUtil;
 
 /**
  * FlatNativeViewHierarchyManager is the only class that performs View manipulations. All of this
@@ -51,7 +52,7 @@ import com.facebook.react.uimanager.ViewManagerRegistry;
     // When unmounting, ReactInstanceManager.detachViewFromInstance() will check id of the
     // top-level View (SizeMonitoringFrameLayout) and pass it back to JS. We want that View's id to
     // be set, otherwise NativeViewHierarchyManager will not be able to cleanup properly.
-    view.setId(tag);
+    ReactFindViewUtil.setReactTag(view, tag);
 
     addRootViewGroup(tag, root, themedContext);
   }

--- a/ReactAndroid/src/main/java/com/facebook/react/flat/FlatViewGroup.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/flat/FlatViewGroup.java
@@ -37,6 +37,7 @@ import com.facebook.react.uimanager.PointerEvents;
 import com.facebook.react.uimanager.ReactCompoundViewGroup;
 import com.facebook.react.uimanager.ReactPointerEventsView;
 import com.facebook.react.uimanager.UIManagerModule;
+import com.facebook.react.uimanager.util.ReactFindViewUtil;
 import com.facebook.react.views.image.ImageLoadEvent;
 import com.facebook.react.uimanager.ReactClippingViewGroup;
 
@@ -205,7 +206,7 @@ import com.facebook.react.uimanager.ReactClippingViewGroup;
      * b) PointerEvents.NONE - this method will NOT be executed, because the View will be filtered
      *    out by TouchTargetHelper.
      * c) PointerEvents.BOX_NONE - TouchTargetHelper will make sure that {@link #reactTagForTouch()}
-     *     doesn't return getId().
+     *     doesn't return ReactFindViewUtil.getReactTag(this).
      */
     SoftAssertions.assertCondition(
         mPointerEvents != PointerEvents.NONE,
@@ -219,7 +220,7 @@ import com.facebook.react.uimanager.ReactClippingViewGroup;
     }
 
     // no children found
-    return getId();
+    return ReactFindViewUtil.getReactTag(this);
   }
 
   @Override

--- a/ReactAndroid/src/main/java/com/facebook/react/touch/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/touch/BUCK
@@ -9,5 +9,6 @@ rn_android_library(
     deps = [
         react_native_dep("third-party/java/infer-annotations:infer-annotations"),
         react_native_dep("third-party/java/jsr-305:jsr-305"),
+        react_native_target("java/com/facebook/react/uimanager/util:util"),
     ],
 )

--- a/ReactAndroid/src/main/java/com/facebook/react/touch/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/touch/BUCK
@@ -1,4 +1,4 @@
-load("//ReactNative:DEFS.bzl", "rn_android_library", "react_native_dep")
+load("//ReactNative:DEFS.bzl", "rn_android_library", "react_native_dep", "react_native_target")
 
 rn_android_library(
     name = "touch",

--- a/ReactAndroid/src/main/java/com/facebook/react/touch/JSResponderHandler.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/touch/JSResponderHandler.java
@@ -13,6 +13,8 @@ import android.view.MotionEvent;
 import android.view.ViewGroup;
 import android.view.ViewParent;
 
+import com.facebook.react.uimanager.util.ReactFindViewUtil;
+
 /**
  * This class coordinates JSResponder commands for {@link UIManagerModule}. It should be set as
  * OnInterceptTouchEventListener for all newly created native views that implements
@@ -68,7 +70,7 @@ public class JSResponderHandler implements OnInterceptTouchEventListener {
       // Therefore since "UP" event is the last event in a gesture, we should just let it reach the
       // original target that is a child view of {@param v}.
       // http://developer.android.com/reference/android/view/ViewGroup.html#onInterceptTouchEvent(android.view.MotionEvent)
-      return v.getId() == currentJSResponder;
+      return ReactFindViewUtil.getReactTag(v) == currentJSResponder;
     }
     return false;
   }

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
@@ -2,8 +2,10 @@
 
 package com.facebook.react.uimanager;
 
+import android.content.res.Resources;
 import android.graphics.Color;
 import android.os.Build;
+import android.support.annotation.IdRes;
 import android.view.View;
 import android.view.ViewParent;
 import com.facebook.react.R;
@@ -43,6 +45,7 @@ public abstract class BaseViewManager<T extends View, C extends LayoutShadowNode
    */
   public static final String PROP_TEST_ID = "testID";
   public static final String PROP_NATIVE_ID = "nativeID";
+  public static final String RESOURCE_ID = "id";
 
   private static MatrixMathHelper.MatrixDecompositionContext sMatrixDecompositionContext =
       new MatrixMathHelper.MatrixDecompositionContext();
@@ -92,6 +95,9 @@ public abstract class BaseViewManager<T extends View, C extends LayoutShadowNode
 
   @ReactProp(name = PROP_TEST_ID)
   public void setTestId(T view, String testId) {
+    String packageName = view.getContext().getPackageName();
+    @IdRes int viewId = view.getResources().getIdentifier(testId, RESOURCE_ID, packageName);
+    view.setId(viewId);
     view.setTag(R.id.react_test_id, testId);
 
     // temporarily set the tag and keyed tags to avoid end to end test regressions

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeViewHierarchyManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeViewHierarchyManager.java
@@ -32,6 +32,7 @@ import com.facebook.react.touch.JSResponderHandler;
 import com.facebook.react.uimanager.common.SizeMonitoringFrameLayout;
 import com.facebook.react.uimanager.layoutanimation.LayoutAnimationController;
 import com.facebook.react.uimanager.layoutanimation.LayoutAnimationListener;
+import com.facebook.react.uimanager.util.ReactFindViewUtil;
 import com.facebook.systrace.Systrace;
 import com.facebook.systrace.SystraceMessage;
 import javax.annotation.Nullable;
@@ -228,7 +229,7 @@ public class NativeViewHierarchyManager {
       // Use android View id field to store React tag. This is possible since we don't inflate
       // React views from layout xmls. Thus it is easier to just reuse that field instead of
       // creating another (potentially much more expensive) mapping from view to React tag
-      view.setId(tag);
+      ReactFindViewUtil.setReactTag(view, tag);
       if (initialProps != null) {
         viewManager.updateProperties(view, initialProps);
       }
@@ -246,13 +247,15 @@ public class NativeViewHierarchyManager {
     StringBuilder stringBuilder = new StringBuilder();
 
     if (null != viewToManage) {
-      stringBuilder.append("View tag:" + viewToManage.getId() + "\n");
+      stringBuilder.append("View tag:" + ReactFindViewUtil.getReactTag(viewToManage) + "\n");
       stringBuilder.append("  children(" + viewManager.getChildCount(viewToManage) + "): [\n");
       for (int index=0; index<viewManager.getChildCount(viewToManage); index+=16) {
         for (int innerOffset=0;
              ((index+innerOffset) < viewManager.getChildCount(viewToManage)) && innerOffset < 16;
              innerOffset++) {
-          stringBuilder.append(viewManager.getChildAt(viewToManage, index+innerOffset).getId() + ",");
+          View child = viewManager.getChildAt(viewToManage, index+innerOffset);
+          int reactTag = ReactFindViewUtil.getReactTag(child);
+          stringBuilder.append(reactTag + ",");
         }
         stringBuilder.append("\n");
       }
@@ -372,7 +375,7 @@ public class NativeViewHierarchyManager {
 
         if (mLayoutAnimationEnabled &&
             mLayoutAnimator.shouldAnimateLayout(viewToRemove) &&
-            arrayContains(tagsToDelete, viewToRemove.getId())) {
+            arrayContains(tagsToDelete, ReactFindViewUtil.getReactTag(viewToRemove))) {
           // The view will be removed and dropped by the 'delete' layout animation
           // instead, so do nothing
         } else {
@@ -506,7 +509,7 @@ public class NativeViewHierarchyManager {
       int tag,
       ViewGroup view,
       ThemedReactContext themedContext) {
-    if (view.getId() != View.NO_ID) {
+    if (ReactFindViewUtil.getReactTag(view) != View.NO_ID) {
       throw new IllegalViewOperationException(
           "Trying to add a root view with an explicit id already set. React Native uses " +
           "the id field to track react tags and will overwrite this field. If that is fine, " +
@@ -516,7 +519,7 @@ public class NativeViewHierarchyManager {
     mTagsToViews.put(tag, view);
     mTagsToViewManagers.put(tag, mRootViewManager);
     mRootTags.put(tag, true);
-    view.setId(tag);
+    ReactFindViewUtil.setReactTag(view, tag);
   }
 
   /**
@@ -524,24 +527,24 @@ public class NativeViewHierarchyManager {
    */
   protected synchronized void dropView(View view) {
     UiThreadUtil.assertOnUiThread();
-    if (!mRootTags.get(view.getId())) {
+    if (!mRootTags.get(ReactFindViewUtil.getReactTag(view))) {
       // For non-root views we notify viewmanager with {@link ViewManager#onDropInstance}
-      resolveViewManager(view.getId()).onDropViewInstance(view);
+      resolveViewManager(ReactFindViewUtil.getReactTag(view)).onDropViewInstance(view);
     }
-    ViewManager viewManager = mTagsToViewManagers.get(view.getId());
+    ViewManager viewManager = mTagsToViewManagers.get(ReactFindViewUtil.getReactTag(view));
     if (view instanceof ViewGroup && viewManager instanceof ViewGroupManager) {
       ViewGroup viewGroup = (ViewGroup) view;
       ViewGroupManager viewGroupManager = (ViewGroupManager) viewManager;
       for (int i = viewGroupManager.getChildCount(viewGroup) - 1; i >= 0; i--) {
         View child = viewGroupManager.getChildAt(viewGroup, i);
-        if (mTagsToViews.get(child.getId()) != null) {
+        if (mTagsToViews.get(ReactFindViewUtil.getReactTag(child)) != null) {
           dropView(child);
         }
       }
       viewGroupManager.removeAllViews(viewGroup);
     }
-    mTagsToViews.remove(view.getId());
-    mTagsToViewManagers.remove(view.getId());
+    mTagsToViews.remove(ReactFindViewUtil.getReactTag(view));
+    mTagsToViewManagers.remove(ReactFindViewUtil.getReactTag(view));
   }
 
   public synchronized void removeRootView(int rootViewTag) {

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/TouchTargetHelper.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/TouchTargetHelper.java
@@ -19,6 +19,7 @@ import android.view.ViewGroup;
 import com.facebook.react.bridge.JSApplicationIllegalArgumentException;
 import com.facebook.react.bridge.UiThreadUtil;
 import com.facebook.react.touch.ReactHitSlopView;
+import com.facebook.react.uimanager.util.ReactFindViewUtil;
 
 /**
  * Class responsible for identifying which react view should handle a given {@link MotionEvent}.
@@ -85,7 +86,7 @@ public class TouchTargetHelper {
       float[] viewCoords,
       @Nullable int[] nativeViewTag) {
     UiThreadUtil.assertOnUiThread();
-    int targetTag = viewGroup.getId();
+    int targetTag = ReactFindViewUtil.getReactTag(viewGroup);
     // Store eventCoords in array so that they are modified to be relative to the targetView found.
     viewCoords[0] = eventX;
     viewCoords[1] = eventY;
@@ -94,7 +95,7 @@ public class TouchTargetHelper {
       View reactTargetView = findClosestReactAncestor(nativeTargetView);
       if (reactTargetView != null) {
         if (nativeViewTag != null) {
-          nativeViewTag[0] = reactTargetView.getId();
+          nativeViewTag[0] = ReactFindViewUtil.getReactTag(reactTargetView);
         }
         targetTag = getTouchTargetForView(reactTargetView, viewCoords[0], viewCoords[1]);
       }
@@ -103,7 +104,7 @@ public class TouchTargetHelper {
   }
 
   private static View findClosestReactAncestor(View view) {
-    while (view != null && view.getId() <= 0) {
+    while (view != null && ReactFindViewUtil.getReactTag(view) <= 0) {
       view = (View) view.getParent();
     }
     return view;
@@ -239,7 +240,7 @@ public class TouchTargetHelper {
         // ViewGroup).
         if (view instanceof ReactCompoundView) {
           int reactTag = ((ReactCompoundView)view).reactTagForTouch(eventCoords[0], eventCoords[1]);
-          if (reactTag != view.getId()) {
+          if (reactTag != ReactFindViewUtil.getReactTag(view)) {
             // make sure we exclude the View itself because of the PointerEvents.BOX_NONE
             return view;
           }
@@ -271,7 +272,7 @@ public class TouchTargetHelper {
       // {@link #findTouchTargetView()}.
       return ((ReactCompoundView) targetView).reactTagForTouch(eventX, eventY);
     }
-    return targetView.getId();
+    return ReactFindViewUtil.getReactTag(targetView);
   }
 
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/util/ReactFindViewUtil.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/util/ReactFindViewUtil.java
@@ -149,4 +149,13 @@ public class ReactFindViewUtil {
     Object tag = view.getTag(R.id.view_tag_native_id);
     return tag instanceof String ? (String) tag : null;
   }
+
+  public static Integer getReactTag(View view) {
+    Object tag = view.getTag(R.id.react_tag_id);
+    return tag instanceof Integer ? (Integer) tag : View.NO_ID;
+  }
+
+  public static void setReactTag(View view, int reactTag) {
+    view.setTag(R.id.react_tag_id, reactTag);
+  }
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/checkbox/ReactCheckBoxManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/checkbox/ReactCheckBoxManager.java
@@ -13,6 +13,7 @@ import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.UIManagerModule;
 import com.facebook.react.uimanager.ViewProps;
 import com.facebook.react.uimanager.annotations.ReactProp;
+import com.facebook.react.uimanager.util.ReactFindViewUtil;
 
 /** View manager for {@link ReactCheckBox} components. */
 public class ReactCheckBoxManager extends SimpleViewManager<ReactCheckBox> {
@@ -27,7 +28,7 @@ public class ReactCheckBoxManager extends SimpleViewManager<ReactCheckBox> {
           reactContext
               .getNativeModule(UIManagerModule.class)
               .getEventDispatcher()
-              .dispatchEvent(new ReactCheckBoxEvent(buttonView.getId(), isChecked));
+              .dispatchEvent(new ReactCheckBoxEvent(ReactFindViewUtil.getReactTag(buttonView), isChecked));
         }
       };
 

--- a/ReactAndroid/src/main/java/com/facebook/react/views/drawer/ReactDrawerLayoutManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/drawer/ReactDrawerLayoutManager.java
@@ -29,6 +29,7 @@ import com.facebook.react.uimanager.UIManagerModule;
 import com.facebook.react.uimanager.ViewGroupManager;
 import com.facebook.react.uimanager.annotations.ReactProp;
 import com.facebook.react.uimanager.events.EventDispatcher;
+import com.facebook.react.uimanager.util.ReactFindViewUtil;
 import com.facebook.react.views.drawer.events.DrawerClosedEvent;
 import com.facebook.react.views.drawer.events.DrawerOpenedEvent;
 import com.facebook.react.views.drawer.events.DrawerSlideEvent;
@@ -185,25 +186,25 @@ public class ReactDrawerLayoutManager extends ViewGroupManager<ReactDrawerLayout
     @Override
     public void onDrawerSlide(View view, float v) {
       mEventDispatcher.dispatchEvent(
-          new DrawerSlideEvent(mDrawerLayout.getId(), v));
+          new DrawerSlideEvent(ReactFindViewUtil.getReactTag(mDrawerLayout), v));
     }
 
     @Override
     public void onDrawerOpened(View view) {
       mEventDispatcher.dispatchEvent(
-        new DrawerOpenedEvent(mDrawerLayout.getId()));
+        new DrawerOpenedEvent(ReactFindViewUtil.getReactTag(mDrawerLayout)));
     }
 
     @Override
     public void onDrawerClosed(View view) {
       mEventDispatcher.dispatchEvent(
-          new DrawerClosedEvent(mDrawerLayout.getId()));
+          new DrawerClosedEvent(ReactFindViewUtil.getReactTag(mDrawerLayout)));
     }
 
     @Override
     public void onDrawerStateChanged(int i) {
       mEventDispatcher.dispatchEvent(
-          new DrawerStateChangedEvent(mDrawerLayout.getId(), i));
+          new DrawerStateChangedEvent(ReactFindViewUtil.getReactTag(mDrawerLayout), i));
     }
   }
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageView.java
@@ -51,7 +51,7 @@ import com.facebook.react.uimanager.FloatUtil;
 import com.facebook.react.uimanager.PixelUtil;
 import com.facebook.react.uimanager.UIManagerModule;
 import com.facebook.react.uimanager.events.EventDispatcher;
-import com.facebook.react.views.image.ImageResizeMode;
+import com.facebook.react.uimanager.util.ReactFindViewUtil;
 import com.facebook.react.views.imagehelper.ImageSource;
 import com.facebook.react.views.imagehelper.MultiSourceHelper;
 import com.facebook.react.views.imagehelper.MultiSourceHelper.MultiSourceResult;
@@ -235,8 +235,9 @@ public class ReactImageView extends GenericDraweeView {
       mControllerListener = new BaseControllerListener<ImageInfo>() {
         @Override
         public void onSubmit(String id, Object callerContext) {
+          Integer reactTag = ReactFindViewUtil.getReactTag(ReactImageView.this);
           mEventDispatcher.dispatchEvent(
-              new ImageLoadEvent(getId(), ImageLoadEvent.ON_LOAD_START));
+              new ImageLoadEvent(reactTag, ImageLoadEvent.ON_LOAD_START));
         }
 
         @Override
@@ -245,20 +246,22 @@ public class ReactImageView extends GenericDraweeView {
             @Nullable final ImageInfo imageInfo,
             @Nullable Animatable animatable) {
           if (imageInfo != null) {
+            Integer reactTag = ReactFindViewUtil.getReactTag(ReactImageView.this);
             mEventDispatcher.dispatchEvent(
-              new ImageLoadEvent(getId(), ImageLoadEvent.ON_LOAD,
+              new ImageLoadEvent(reactTag, ImageLoadEvent.ON_LOAD,
                 mImageSource.getSource(), imageInfo.getWidth(), imageInfo.getHeight()));
             mEventDispatcher.dispatchEvent(
-              new ImageLoadEvent(getId(), ImageLoadEvent.ON_LOAD_END));
+              new ImageLoadEvent(reactTag, ImageLoadEvent.ON_LOAD_END));
           }
         }
 
         @Override
         public void onFailure(String id, Throwable throwable) {
+          Integer reactTag = ReactFindViewUtil.getReactTag(ReactImageView.this);
           mEventDispatcher.dispatchEvent(
-            new ImageLoadEvent(getId(), ImageLoadEvent.ON_ERROR));
+            new ImageLoadEvent(reactTag, ImageLoadEvent.ON_ERROR));
           mEventDispatcher.dispatchEvent(
-            new ImageLoadEvent(getId(), ImageLoadEvent.ON_LOAD_END));
+            new ImageLoadEvent(reactTag, ImageLoadEvent.ON_LOAD_END));
         }
       };
     }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageView.java
@@ -52,6 +52,7 @@ import com.facebook.react.uimanager.PixelUtil;
 import com.facebook.react.uimanager.UIManagerModule;
 import com.facebook.react.uimanager.events.EventDispatcher;
 import com.facebook.react.uimanager.util.ReactFindViewUtil;
+import com.facebook.react.views.image.ImageResizeMode;
 import com.facebook.react.views.imagehelper.ImageSource;
 import com.facebook.react.views.imagehelper.MultiSourceHelper;
 import com.facebook.react.views.imagehelper.MultiSourceHelper.MultiSourceResult;

--- a/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostManager.java
@@ -19,6 +19,7 @@ import com.facebook.react.uimanager.UIManagerModule;
 import com.facebook.react.uimanager.ViewGroupManager;
 import com.facebook.react.uimanager.annotations.ReactProp;
 import com.facebook.react.uimanager.events.EventDispatcher;
+import com.facebook.react.uimanager.util.ReactFindViewUtil;
 
 /**
  * View manager for {@link ReactModalHostView} components.
@@ -79,14 +80,14 @@ public class ReactModalHostManager extends ViewGroupManager<ReactModalHostView> 
       new ReactModalHostView.OnRequestCloseListener() {
         @Override
         public void onRequestClose(DialogInterface dialog) {
-          dispatcher.dispatchEvent(new RequestCloseEvent(view.getId()));
+          dispatcher.dispatchEvent(new RequestCloseEvent(ReactFindViewUtil.getReactTag(view)));
         }
       });
     view.setOnShowListener(
       new DialogInterface.OnShowListener() {
         @Override
         public void onShow(DialogInterface dialog) {
-          dispatcher.dispatchEvent(new ShowEvent(view.getId()));
+          dispatcher.dispatchEvent(new ShowEvent(ReactFindViewUtil.getReactTag(view)));
         }
       });
   }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.java
@@ -28,6 +28,7 @@ import com.facebook.react.uimanager.JSTouchDispatcher;
 import com.facebook.react.uimanager.RootView;
 import com.facebook.react.uimanager.UIManagerModule;
 import com.facebook.react.uimanager.events.EventDispatcher;
+import com.facebook.react.uimanager.util.ReactFindViewUtil;
 import com.facebook.react.views.view.ReactViewGroup;
 import java.util.ArrayList;
 import javax.annotation.Nullable;
@@ -320,7 +321,7 @@ public class ReactModalHostView extends ViewGroup implements LifecycleEventListe
     protected void onSizeChanged(final int w, final int h, int oldw, int oldh) {
       super.onSizeChanged(w, h, oldw, oldh);
       if (getChildCount() > 0) {
-        final int viewTag = getChildAt(0).getId();
+        final int viewTag = ReactFindViewUtil.getReactTag(getChildAt(0));
         ReactContext reactContext = getReactContext();
         reactContext.runOnNativeModulesQueueThread(
           new GuardedRunnable(reactContext) {

--- a/ReactAndroid/src/main/java/com/facebook/react/views/picker/ReactPickerManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/picker/ReactPickerManager.java
@@ -26,6 +26,7 @@ import com.facebook.react.uimanager.UIManagerModule;
 import com.facebook.react.uimanager.ViewProps;
 import com.facebook.react.uimanager.annotations.ReactProp;
 import com.facebook.react.uimanager.events.EventDispatcher;
+import com.facebook.react.uimanager.util.ReactFindViewUtil;
 import com.facebook.react.views.picker.events.PickerItemSelectEvent;
 
 /**
@@ -154,7 +155,7 @@ public abstract class ReactPickerManager extends SimpleViewManager<ReactPicker> 
     @Override
     public void onItemSelected(int position) {
       mEventDispatcher.dispatchEvent( new PickerItemSelectEvent(
-              mReactPicker.getId(), position));
+              ReactFindViewUtil.getReactTag(mReactPicker), position));
     }
   }
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewHelper.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewHelper.java
@@ -13,6 +13,7 @@ import android.view.ViewGroup;
 import com.facebook.react.bridge.JSApplicationIllegalArgumentException;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.uimanager.UIManagerModule;
+import com.facebook.react.uimanager.util.ReactFindViewUtil;
 
 /**
  * Helper class that deals with emitting Scroll Events.
@@ -71,7 +72,7 @@ public class ReactScrollViewHelper {
     ReactContext reactContext = (ReactContext) scrollView.getContext();
     reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher().dispatchEvent(
         ScrollEvent.obtain(
-            scrollView.getId(),
+            ReactFindViewUtil.getReactTag(scrollView),
             scrollEventType,
             scrollView.getScrollX(),
             scrollView.getScrollY(),

--- a/ReactAndroid/src/main/java/com/facebook/react/views/slider/ReactSliderManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/slider/ReactSliderManager.java
@@ -22,6 +22,7 @@ import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.UIManagerModule;
 import com.facebook.react.uimanager.ViewProps;
 import com.facebook.react.uimanager.annotations.ReactProp;
+import com.facebook.react.uimanager.util.ReactFindViewUtil;
 import com.facebook.yoga.YogaMeasureFunction;
 import com.facebook.yoga.YogaMeasureMode;
 import com.facebook.yoga.YogaMeasureOutput;
@@ -97,7 +98,7 @@ public class ReactSliderManager extends SimpleViewManager<ReactSlider> {
           ReactContext reactContext = (ReactContext) seekbar.getContext();
           reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher().dispatchEvent(
               new ReactSliderEvent(
-                  seekbar.getId(),
+                  ReactFindViewUtil.getReactTag(seekbar),
                   ((ReactSlider) seekbar).toRealProgress(progress),
                   fromUser));
         }
@@ -111,7 +112,7 @@ public class ReactSliderManager extends SimpleViewManager<ReactSlider> {
           ReactContext reactContext = (ReactContext) seekbar.getContext();
           reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher().dispatchEvent(
               new ReactSlidingCompleteEvent(
-                  seekbar.getId(),
+                  ReactFindViewUtil.getReactTag(seekbar),
                   ((ReactSlider) seekbar).toRealProgress(seekbar.getProgress())));
         }
       };

--- a/ReactAndroid/src/main/java/com/facebook/react/views/swiperefresh/SwipeRefreshLayoutManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/swiperefresh/SwipeRefreshLayoutManager.java
@@ -23,6 +23,7 @@ import com.facebook.react.uimanager.UIManagerModule;
 import com.facebook.react.uimanager.ViewGroupManager;
 import com.facebook.react.uimanager.ViewProps;
 import com.facebook.react.uimanager.annotations.ReactProp;
+import com.facebook.react.uimanager.util.ReactFindViewUtil;
 
 import static com.facebook.react.views.swiperefresh.SwipeRefreshLayoutManager.REACT_CLASS;
 
@@ -92,7 +93,7 @@ public class SwipeRefreshLayoutManager extends ViewGroupManager<ReactSwipeRefres
           @Override
           public void onRefresh() {
             reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher()
-                .dispatchEvent(new RefreshEvent(view.getId()));
+                .dispatchEvent(new RefreshEvent(ReactFindViewUtil.getReactTag(view)));
           }
         });
   }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/switchview/ReactSwitchManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/switchview/ReactSwitchManager.java
@@ -13,7 +13,6 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.CompoundButton;
 
-import com.facebook.react.uimanager.util.ReactFindViewUtil;
 import com.facebook.yoga.YogaMeasureMode;
 import com.facebook.yoga.YogaMeasureFunction;
 import com.facebook.yoga.YogaNode;
@@ -25,6 +24,7 @@ import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.UIManagerModule;
 import com.facebook.react.uimanager.ViewProps;
 import com.facebook.react.uimanager.annotations.ReactProp;
+import com.facebook.react.uimanager.util.ReactFindViewUtil;
 
 /**
  * View manager for {@link ReactSwitch} components.

--- a/ReactAndroid/src/main/java/com/facebook/react/views/switchview/ReactSwitchManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/switchview/ReactSwitchManager.java
@@ -13,6 +13,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.CompoundButton;
 
+import com.facebook.react.uimanager.util.ReactFindViewUtil;
 import com.facebook.yoga.YogaMeasureMode;
 import com.facebook.yoga.YogaMeasureFunction;
 import com.facebook.yoga.YogaNode;
@@ -93,7 +94,7 @@ public class ReactSwitchManager extends SimpleViewManager<ReactSwitch> {
           ReactContext reactContext = (ReactContext) buttonView.getContext();
           reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher().dispatchEvent(
               new ReactSwitchEvent(
-                  buttonView.getId(),
+                  ReactFindViewUtil.getReactTag(buttonView),
                   isChecked));
         }
       };

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
@@ -18,6 +18,7 @@ import android.view.ViewGroup;
 import android.widget.TextView;
 import com.facebook.react.uimanager.ReactCompoundView;
 import com.facebook.react.uimanager.ViewDefaults;
+import com.facebook.react.uimanager.util.ReactFindViewUtil;
 import com.facebook.react.views.view.ReactViewBackgroundManager;
 import javax.annotation.Nullable;
 
@@ -75,7 +76,7 @@ public class ReactTextView extends TextView implements ReactCompoundView {
   @Override
   public int reactTagForTouch(float touchX, float touchY) {
     CharSequence text = getText();
-    int target = getId();
+    int target = ReactFindViewUtil.getReactTag(this);
 
     int x = (int) touchX;
     int y = (int) touchY;

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
@@ -35,6 +35,7 @@ import com.facebook.infer.annotation.Assertions;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.uimanager.PixelUtil;
 import com.facebook.react.uimanager.UIManagerModule;
+import com.facebook.react.uimanager.util.ReactFindViewUtil;
 import com.facebook.react.views.text.CustomStyleSpan;
 import com.facebook.react.views.text.ReactTagSpan;
 import com.facebook.react.views.text.ReactTextUpdate;
@@ -473,7 +474,8 @@ public class ReactEditText extends EditText {
     ReactContext reactContext = (ReactContext) getContext();
     UIManagerModule uiManager = reactContext.getNativeModule(UIManagerModule.class);
     final ReactTextInputLocalData localData = new ReactTextInputLocalData(this);
-    uiManager.setViewLocalData(getId(), localData);
+    Integer reactTag = ReactFindViewUtil.getReactTag(this);
+    uiManager.setViewLocalData(reactTag, localData);
   }
 
   /* package */ void setGravityHorizontal(int gravityHorizontal) {

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditTextInputConnectionWrapper.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditTextInputConnectionWrapper.java
@@ -16,6 +16,7 @@ import android.view.inputmethod.InputConnectionWrapper;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.uimanager.UIManagerModule;
 import com.facebook.react.uimanager.events.EventDispatcher;
+import com.facebook.react.uimanager.util.ReactFindViewUtil;
 
 /**
  * A class to implement the TextInput 'onKeyPress' API on android for soft keyboards.
@@ -156,7 +157,7 @@ class ReactEditTextInputConnectionWrapper extends InputConnectionWrapper {
     }
     mEventDispatcher.dispatchEvent(
         new ReactTextInputKeyPressEvent(
-            mEditText.getId(),
+            ReactFindViewUtil.getReactTag(mEditText),
             key));
   }
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
@@ -40,6 +40,7 @@ import com.facebook.react.uimanager.ViewProps;
 import com.facebook.react.uimanager.annotations.ReactProp;
 import com.facebook.react.uimanager.annotations.ReactPropGroup;
 import com.facebook.react.uimanager.events.EventDispatcher;
+import com.facebook.react.uimanager.util.ReactFindViewUtil;
 import com.facebook.react.views.imagehelper.ResourceDrawableIdHelper;
 import com.facebook.react.views.scroll.ScrollEvent;
 import com.facebook.react.views.scroll.ScrollEventType;
@@ -720,13 +721,13 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
       // TODO: t7936714 merge these events
       mEventDispatcher.dispatchEvent(
           new ReactTextChangedEvent(
-              mEditText.getId(),
+              ReactFindViewUtil.getReactTag(mEditText),
               s.toString(),
               mEditText.incrementAndGetEventCounter()));
 
       mEventDispatcher.dispatchEvent(
           new ReactTextInputEvent(
-              mEditText.getId(),
+              ReactFindViewUtil.getReactTag(mEditText),
               newText,
               oldText,
               start,
@@ -751,15 +752,15 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
             if (hasFocus) {
               eventDispatcher.dispatchEvent(
                   new ReactTextInputFocusEvent(
-                      editText.getId()));
+                      ReactFindViewUtil.getReactTag(editText)));
             } else {
               eventDispatcher.dispatchEvent(
                   new ReactTextInputBlurEvent(
-                      editText.getId()));
+                      ReactFindViewUtil.getReactTag(editText)));
 
               eventDispatcher.dispatchEvent(
                   new ReactTextInputEndEditingEvent(
-                      editText.getId(),
+                      ReactFindViewUtil.getReactTag(editText),
                       editText.getText().toString()));
             }
           }
@@ -788,7 +789,7 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
 
               eventDispatcher.dispatchEvent(
                   new ReactTextInputSubmitEditingEvent(
-                      editText.getId(),
+                      ReactFindViewUtil.getReactTag(editText),
                       editText.getText().toString()));
 
               if (blurOnSubmit) {
@@ -835,7 +836,7 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
 
         mEventDispatcher.dispatchEvent(
           new ReactContentSizeChangedEvent(
-            mEditText.getId(),
+            ReactFindViewUtil.getReactTag(mEditText),
             PixelUtil.toDIPFromPixel(contentWidth),
             PixelUtil.toDIPFromPixel(contentHeight)));
       }
@@ -863,7 +864,7 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
       if (mPreviousSelectionStart != start || mPreviousSelectionEnd != end) {
         mEventDispatcher.dispatchEvent(
             new ReactTextInputSelectionEvent(
-                mReactEditText.getId(),
+                ReactFindViewUtil.getReactTag(mReactEditText),
                 start,
                 end
             ));
@@ -891,7 +892,7 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
     public void onScrollChanged(int horiz, int vert, int oldHoriz, int oldVert) {
       if (mPreviousHoriz != horiz || mPreviousVert != vert) {
         ScrollEvent event = ScrollEvent.obtain(
-          mReactEditText.getId(),
+          ReactFindViewUtil.getReactTag(mReactEditText),
           ScrollEventType.SCROLL,
           horiz,
           vert,

--- a/ReactAndroid/src/main/java/com/facebook/react/views/toolbar/ReactToolbarManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/toolbar/ReactToolbarManager.java
@@ -23,6 +23,7 @@ import com.facebook.react.uimanager.UIManagerModule;
 import com.facebook.react.uimanager.ViewGroupManager;
 import com.facebook.react.uimanager.annotations.ReactProp;
 import com.facebook.react.uimanager.events.EventDispatcher;
+import com.facebook.react.uimanager.util.ReactFindViewUtil;
 import com.facebook.react.views.toolbar.events.ToolbarClickEvent;
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -125,7 +126,7 @@ public class ReactToolbarManager extends ViewGroupManager<ReactToolbar> {
           @Override
           public void onClick(View v) {
             mEventDispatcher.dispatchEvent(
-                new ToolbarClickEvent(view.getId(), -1));
+                new ToolbarClickEvent(ReactFindViewUtil.getReactTag(view), -1));
           }
         });
 
@@ -135,7 +136,7 @@ public class ReactToolbarManager extends ViewGroupManager<ReactToolbar> {
           public boolean onMenuItemClick(MenuItem menuItem) {
             mEventDispatcher.dispatchEvent(
                 new ToolbarClickEvent(
-                    view.getId(),
+                    ReactFindViewUtil.getReactTag(view),
                     menuItem.getOrder()));
             return true;
           }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/viewpager/ReactViewPager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/viewpager/ReactViewPager.java
@@ -18,6 +18,7 @@ import com.facebook.react.common.ReactConstants;
 import com.facebook.react.uimanager.UIManagerModule;
 import com.facebook.react.uimanager.events.EventDispatcher;
 import com.facebook.react.uimanager.events.NativeGestureUtil;
+import com.facebook.react.uimanager.util.ReactFindViewUtil;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -120,15 +121,17 @@ public class ReactViewPager extends ViewPager {
 
     @Override
     public void onPageScrolled(int position, float positionOffset, int positionOffsetPixels) {
+      Integer reactTag = ReactFindViewUtil.getReactTag(ReactViewPager.this);
       mEventDispatcher.dispatchEvent(
-          new PageScrollEvent(getId(), position, positionOffset));
+          new PageScrollEvent(reactTag, position, positionOffset));
     }
 
     @Override
     public void onPageSelected(int position) {
       if (!mIsCurrentItemFromJs) {
+        Integer reactTag = ReactFindViewUtil.getReactTag(ReactViewPager.this);
         mEventDispatcher.dispatchEvent(
-            new PageSelectedEvent(getId(), position));
+            new PageSelectedEvent(reactTag, position));
       }
     }
 
@@ -148,8 +151,9 @@ public class ReactViewPager extends ViewPager {
         default:
           throw new IllegalStateException("Unsupported pageScrollState");
       }
+      Integer reactTag = ReactFindViewUtil.getReactTag(ReactViewPager.this);
       mEventDispatcher.dispatchEvent(
-        new PageScrollStateChangedEvent(getId(), pageScrollState));
+        new PageScrollStateChangedEvent(reactTag, pageScrollState));
     }
   }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebViewManager.java
@@ -52,6 +52,7 @@ import com.facebook.react.uimanager.annotations.ReactProp;
 import com.facebook.react.uimanager.events.ContentSizeChangeEvent;
 import com.facebook.react.uimanager.events.Event;
 import com.facebook.react.uimanager.events.EventDispatcher;
+import com.facebook.react.uimanager.util.ReactFindViewUtil;
 import com.facebook.react.views.webview.events.TopLoadingErrorEvent;
 import com.facebook.react.views.webview.events.TopLoadingFinishEvent;
 import com.facebook.react.views.webview.events.TopLoadingStartEvent;
@@ -131,7 +132,7 @@ public class ReactWebViewManager extends SimpleViewManager<WebView> {
       dispatchEvent(
           webView,
           new TopLoadingStartEvent(
-              webView.getId(),
+              ReactFindViewUtil.getReactTag(webView),
               createWebViewEvent(webView, url)));
     }
 
@@ -184,20 +185,20 @@ public class ReactWebViewManager extends SimpleViewManager<WebView> {
 
       dispatchEvent(
           webView,
-          new TopLoadingErrorEvent(webView.getId(), eventData));
+          new TopLoadingErrorEvent(ReactFindViewUtil.getReactTag(webView), eventData));
     }
 
     protected void emitFinishEvent(WebView webView, String url) {
       dispatchEvent(
           webView,
           new TopLoadingFinishEvent(
-              webView.getId(),
+              ReactFindViewUtil.getReactTag(webView),
               createWebViewEvent(webView, url)));
     }
 
     protected WritableMap createWebViewEvent(WebView webView, String url) {
       WritableMap event = Arguments.createMap();
-      event.putDouble("target", webView.getId());
+      event.putDouble("target", ReactFindViewUtil.getReactTag(webView));
       // Don't use webView.getUrl() here, the URL isn't updated to the new value yet in callbacks
       // like onPageFinished
       event.putString("url", url);
@@ -326,7 +327,7 @@ public class ReactWebViewManager extends SimpleViewManager<WebView> {
     }
 
     public void onMessage(String message) {
-      dispatchEvent(this, new TopMessageEvent(this.getId(), message));
+      dispatchEvent(this, new TopMessageEvent(ReactFindViewUtil.getReactTag(this), message));
     }
 
     protected void cleanupCallbacksAndDestroy() {
@@ -611,7 +612,7 @@ public class ReactWebViewManager extends SimpleViewManager<WebView> {
           dispatchEvent(
             webView,
             new ContentSizeChangeEvent(
-              webView.getId(),
+              ReactFindViewUtil.getReactTag(webView),
               webView.getWidth(),
               webView.getContentHeight()));
         }

--- a/ReactAndroid/src/main/res/views/uimanager/values/ids.xml
+++ b/ReactAndroid/src/main/res/views/uimanager/values/ids.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+  <!-- tag is used to store the react tag -->
+  <item type="id" name="react_tag_id"/>
+
   <!-- tag is used to store the testID tag -->
   <item type="id" name="react_test_id"/>
 

--- a/ReactAndroid/src/test/java/com/facebook/react/RootViewTest.java
+++ b/ReactAndroid/src/test/java/com/facebook/react/RootViewTest.java
@@ -26,6 +26,7 @@ import com.facebook.react.uimanager.DisplayMetricsHolder;
 import com.facebook.react.uimanager.events.Event;
 import com.facebook.react.uimanager.events.EventDispatcher;
 import com.facebook.react.uimanager.events.RCTEventEmitter;
+import com.facebook.react.uimanager.util.ReactFindViewUtil;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -110,7 +111,7 @@ public class RootViewTest {
     int rootViewId = 7;
 
     ReactRootView rootView = new ReactRootView(mReactContext);
-    rootView.setId(rootViewId);
+    ReactFindViewUtil.setReactTag(rootView, rootViewId);
     rootView.startReactApplication(instanceManager, "");
     rootView.simulateAttachForTesting();
 

--- a/ReactAndroid/src/test/java/com/facebook/react/uimanager/BUCK
+++ b/ReactAndroid/src/test/java/com/facebook/react/uimanager/BUCK
@@ -30,6 +30,7 @@ rn_robolectric_test(
         react_native_target("java/com/facebook/react/touch:touch"),
         react_native_target("java/com/facebook/react/uimanager:uimanager"),
         react_native_target("java/com/facebook/react/uimanager/annotations:annotations"),
+        react_native_target("java/com/facebook/react/uimanager/util:util"),
         react_native_target("java/com/facebook/react/views/text:text"),
         react_native_target("java/com/facebook/react/views/view:view"),
         react_native_tests_target("java/com/facebook/react/bridge:testhelpers"),

--- a/ReactAndroid/src/test/java/com/facebook/react/uimanager/UIManagerModuleTest.java
+++ b/ReactAndroid/src/test/java/com/facebook/react/uimanager/UIManagerModuleTest.java
@@ -32,6 +32,7 @@ import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactTestHelper;
 import com.facebook.react.modules.core.ChoreographerCompat;
 import com.facebook.react.modules.core.ReactChoreographer;
+import com.facebook.react.uimanager.util.ReactFindViewUtil;
 import com.facebook.react.views.text.ReactRawTextManager;
 import com.facebook.react.views.text.ReactRawTextShadowNode;
 import com.facebook.react.views.text.ReactTextViewManager;
@@ -479,22 +480,22 @@ public class UIManagerModuleTest {
     TestMoveDeleteHierarchy hierarchy = createMoveDeleteHierarchy(uiManager);
 
     View view0 = hierarchy.nativeRootView.getChildAt(0);
-    assertThat(view0.getId()).isEqualTo(hierarchy.view0);
+    assertThat(ReactFindViewUtil.getReactTag(view0)).isEqualTo(hierarchy.view0);
 
     View viewWithChildren1 = hierarchy.nativeRootView.getChildAt(1);
-    assertThat(viewWithChildren1.getId()).isEqualTo(hierarchy.viewWithChildren1);
+    assertThat(ReactFindViewUtil.getReactTag(viewWithChildren1)).isEqualTo(hierarchy.viewWithChildren1);
 
     View childView0 = ((ViewGroup) viewWithChildren1).getChildAt(0);
-    assertThat(childView0.getId()).isEqualTo(hierarchy.childView0);
+    assertThat(ReactFindViewUtil.getReactTag(childView0)).isEqualTo(hierarchy.childView0);
 
     View childView1 = ((ViewGroup) viewWithChildren1).getChildAt(1);
-    assertThat(childView1.getId()).isEqualTo(hierarchy.childView1);
+    assertThat(ReactFindViewUtil.getReactTag(childView1)).isEqualTo(hierarchy.childView1);
 
     View view2 = hierarchy.nativeRootView.getChildAt(2);
-    assertThat(view2.getId()).isEqualTo(hierarchy.view2);
+    assertThat(ReactFindViewUtil.getReactTag(view2)).isEqualTo(hierarchy.view2);
 
     View view3 = hierarchy.nativeRootView.getChildAt(3);
-    assertThat(view3.getId()).isEqualTo(hierarchy.view3);
+    assertThat(ReactFindViewUtil.getReactTag(view3)).isEqualTo(hierarchy.view3);
   }
 
   @Test


### PR DESCRIPTION
Track react tag using android.view.View.tag.  Allow developers to set resource id by setting component.testID

Thank you for sending the PR! We appreciate you spending the time to work on these changes. 
Help us understand your motivation by explaining why you decided to make this change.

This pull request fixes the following issue.
https://github.com/facebook/react-native/issues/9777

## Test Plan

First, you need to declare the resource id by creating /_your_android_studio_folder_/res/values/ids.xml

```
<?xml version="1.0" encoding="utf-8"?>
<resources>
    <item type="id" name="my_test_id"/>
</resources>
```

Second, set the testID of your component to a resource name.

```
<Button
    onPress={onButtonPress}
    title="Press Me"
    testID='test_id'
    />
```

Third, run the app and observe the resource id using UIAutomator viewer (/Android/sdk/tools/bin/uiautomatorviewer)

## Related PRs

This PR doesn't require a documentation change.

## Release Notes

[ANDROID] [BUGFIX] [com/facebook/react/uimanager/BaseViewManager] - Allow developers to set resource id by setting component.testID