### PR TITLE
[iOS][WebSocket] use correct delegate queue in RCTRSWebSocket

### DIFF
--- a/Libraries/WebSocket/RCTWebSocketModule.m
+++ b/Libraries/WebSocket/RCTWebSocketModule.m
@@ -82,6 +82,7 @@ RCT_EXPORT_METHOD(connect:(NSURL *)URL protocols:(NSArray *)protocols options:(N
   }];
 
   RCTSRWebSocket *webSocket = [[RCTSRWebSocket alloc] initWithURLRequest:request protocols:protocols];
+  [webSocket setDelegateDispatchQueue: _methodQueue];
   webSocket.delegate = self;
   webSocket.reactTag = socketID;
   if (!_sockets) {

--- a/Libraries/WebSocket/RCTWebSocketModule.m
+++ b/Libraries/WebSocket/RCTWebSocketModule.m
@@ -82,7 +82,7 @@ RCT_EXPORT_METHOD(connect:(NSURL *)URL protocols:(NSArray *)protocols options:(N
   }];
 
   RCTSRWebSocket *webSocket = [[RCTSRWebSocket alloc] initWithURLRequest:request protocols:protocols];
-  [webSocket setDelegateDispatchQueue: _methodQueue];
+  [webSocket setDelegateDispatchQueue:_methodQueue];
   webSocket.delegate = self;
   webSocket.reactTag = socketID;
   if (!_sockets) {


### PR DESCRIPTION
## Motivation

This commit makes the websocket's delegate dispatch queue use `RCTWebSocketModule`'s method queue. 

This fixes a bug where didReceiveMessage was called on the wrong queue, which is especially harmful if the websocket has a contentHandler expects to be running on the RCTWebSocketModule's method queue.

This also fixes the race condition where `_contentHandlers` and `_sockets` can be mutated from the main dispatch queue (the default in `RCTRSWebSocket`) and `RCTWebSocketModule`'s method queue. 

## Test Plan
Websockets still work, and hopefully crash less now.

## Release Notes

- [iOS][BUGFIX][WebSocket] fix crashes caused by a race condition in websocket delegates.