### PR TITLE
Android: include error types in getCurrentPosition error

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/modules/location/PositionError.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/location/PositionError.java
@@ -35,9 +35,17 @@ public class PositionError {
   public static WritableMap buildError(int code, String message) {
     WritableMap error = Arguments.createMap();
     error.putInt("code", code);
+
     if (message != null) {
       error.putString("message", message);
     }
+    
+    /**
+    * Provide error types in error message. Feature parity with iOS
+    */
+    error.putInt("PERMISSION_DENIED", PERMISSION_DENIED);
+    error.putInt("POSITION_UNAVAILABLE", POSITION_UNAVAILABLE);
+    error.putInt("TIMEOUT", TIMEOUT);
     return error;
   }
 }


### PR DESCRIPTION
Thank you for sending the PR! We appreciate you spending the time to work on these changes. 
Help us understand your motivation by explaining why you decided to make this change.

Include geolocation error types in error, and provide feature parity with iOS.

## Test Plan

If error occurs when you call getCurrentPosition, then error object includes PERMISSION_DENIED, POSITION_UNAVAILABLE, TIMEOUT keys with error codes. It should be used to compare with error.code value.

## Release Notes

This is minor fix that provides feature parity with iOS.