### PR TITLE
Make SafeAreaView to work on iOS < 11

### DIFF
--- a/React/Views/SafeAreaView/RCTSafeAreaView.m
+++ b/React/Views/SafeAreaView/RCTSafeAreaView.m
@@ -14,7 +14,6 @@
 
 @implementation RCTSafeAreaView {
   __weak RCTBridge *_bridge;
-  BOOL _safeAreaAvailable;
   UIEdgeInsets _currentSafeAreaInsets;
 }
 
@@ -22,7 +21,6 @@
 {
   if (self = [super initWithFrame:CGRectZero]) {
     _bridge = bridge;
-    _safeAreaAvailable = [self respondsToSelector:@selector(safeAreaInsets)];
   }
 
   return self;
@@ -43,7 +41,7 @@ static BOOL UIEdgeInsetsEqualToEdgeInsetsWithThreshold(UIEdgeInsets insets1, UIE
 
 - (void)safeAreaInsetsDidChange
 {
-  if (!_safeAreaAvailable) {
+  if (![self respondsToSelector:@selector(safeAreaInsets)]) {
     return;
   }
 
@@ -56,7 +54,7 @@ static BOOL UIEdgeInsetsEqualToEdgeInsetsWithThreshold(UIEdgeInsets insets1, UIE
 - (void)layoutSubviews
 {
   [super layoutSubviews];
-  if (_safeAreaAvailable) {
+  if ([self respondsToSelector:@selector(safeAreaInsets)]) {
     return;
   }
   UIViewController* vc = self.reactViewController;

--- a/React/Views/SafeAreaView/RCTSafeAreaView.m
+++ b/React/Views/SafeAreaView/RCTSafeAreaView.m
@@ -14,6 +14,7 @@
 
 @implementation RCTSafeAreaView {
   __weak RCTBridge *_bridge;
+  BOOL _safeAreaAvailable;
   UIEdgeInsets _currentSafeAreaInsets;
 }
 
@@ -21,6 +22,7 @@
 {
   if (self = [super initWithFrame:CGRectZero]) {
     _bridge = bridge;
+    _safeAreaAvailable = [self respondsToSelector:@selector(safeAreaInsets)];
   }
 
   return self;
@@ -28,8 +30,6 @@
 
 RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)decoder)
 RCT_NOT_IMPLEMENTED(- (instancetype)initWithFrame:(CGRect)frame)
-
-#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 110000 /* __IPHONE_11_0 */
 
 static BOOL UIEdgeInsetsEqualToEdgeInsetsWithThreshold(UIEdgeInsets insets1, UIEdgeInsets insets2, CGFloat threshold) {
   return
@@ -39,9 +39,11 @@ static BOOL UIEdgeInsetsEqualToEdgeInsetsWithThreshold(UIEdgeInsets insets1, UIE
     ABS(insets1.bottom - insets2.bottom) <= threshold;
 }
 
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 110000 /* __IPHONE_11_0 */
+
 - (void)safeAreaInsetsDidChange
 {
-  if (![self respondsToSelector:@selector(safeAreaInsets)]) {
+  if (!_safeAreaAvailable) {
     return;
   }
 
@@ -59,5 +61,41 @@ static BOOL UIEdgeInsetsEqualToEdgeInsetsWithThreshold(UIEdgeInsets insets1, UIE
 }
 
 #endif
+
+// Emulate safe area for iOS < 11
+- (void)layoutSubviews
+{
+  [super layoutSubviews];
+  if (_safeAreaAvailable) {
+    return;
+  }
+  UIViewController* vc = self.reactViewController;
+  if (!vc) {
+    return;
+  }
+  CGFloat topLayoutOffset = vc.topLayoutGuide.length;
+  CGFloat bottomLayoutOffset = vc.bottomLayoutGuide.length;
+  CGRect safeArea = vc.view.bounds;
+  safeArea.origin.y += topLayoutOffset;
+  safeArea.size.height -= topLayoutOffset + bottomLayoutOffset;
+  CGRect localSafeArea = [vc.view convertRect:safeArea toView:self];
+  UIEdgeInsets safeAreaInsets = UIEdgeInsetsMake(0, 0, 0, 0);
+  if (CGRectGetMinY(localSafeArea) > CGRectGetMinY(self.bounds)) {
+    safeAreaInsets.top = CGRectGetMinY(localSafeArea) - CGRectGetMinY(self.bounds);
+  }
+  if (CGRectGetMaxY(localSafeArea) < CGRectGetMaxY(self.bounds)) {
+    safeAreaInsets.bottom = CGRectGetMaxY(self.bounds) - CGRectGetMaxY(localSafeArea);
+  }
+
+  if (UIEdgeInsetsEqualToEdgeInsetsWithThreshold(safeAreaInsets, _currentSafeAreaInsets, 1.0 / RCTScreenScale())) {
+    return;
+  }
+
+  _currentSafeAreaInsets = safeAreaInsets;
+
+  RCTSafeAreaViewLocalData *localData =
+  [[RCTSafeAreaViewLocalData alloc] initWithInsets:safeAreaInsets];
+  [_bridge.uiManager setLocalData:localData forView:self];
+}
 
 @end

--- a/React/Views/SafeAreaView/RCTSafeAreaView.m
+++ b/React/Views/SafeAreaView/RCTSafeAreaView.m
@@ -47,17 +47,7 @@ static BOOL UIEdgeInsetsEqualToEdgeInsetsWithThreshold(UIEdgeInsets insets1, UIE
     return;
   }
 
-  UIEdgeInsets safeAreaInsets = self.safeAreaInsets;
-
-  if (UIEdgeInsetsEqualToEdgeInsetsWithThreshold(safeAreaInsets, _currentSafeAreaInsets, 1.0 / RCTScreenScale())) {
-    return;
-  }
-
-  _currentSafeAreaInsets = safeAreaInsets;
-
-  RCTSafeAreaViewLocalData *localData =
-    [[RCTSafeAreaViewLocalData alloc] initWithInsets:safeAreaInsets];
-  [_bridge.uiManager setLocalData:localData forView:self];
+  [self setSafeAreaInsets:self.safeAreaInsets];
 }
 
 #endif
@@ -87,14 +77,18 @@ static BOOL UIEdgeInsetsEqualToEdgeInsetsWithThreshold(UIEdgeInsets insets1, UIE
     safeAreaInsets.bottom = CGRectGetMaxY(self.bounds) - CGRectGetMaxY(localSafeArea);
   }
 
+  [self setSafeAreaInsets:safeAreaInsets];
+}
+
+- (void)setSafeAreaInsets:(UIEdgeInsets)safeAreaInsets
+{
   if (UIEdgeInsetsEqualToEdgeInsetsWithThreshold(safeAreaInsets, _currentSafeAreaInsets, 1.0 / RCTScreenScale())) {
     return;
   }
 
   _currentSafeAreaInsets = safeAreaInsets;
 
-  RCTSafeAreaViewLocalData *localData =
-  [[RCTSafeAreaViewLocalData alloc] initWithInsets:safeAreaInsets];
+  RCTSafeAreaViewLocalData *localData = [[RCTSafeAreaViewLocalData alloc] initWithInsets:safeAreaInsets];
   [_bridge.uiManager setLocalData:localData forView:self];
 }
 


### PR DESCRIPTION
Currently `SafeAreaView` works only on iOS 11, because implemented in terms of native safeArea API, that not exists in older iOS versions. But this make it hard to use the component in real applications, because content will be under top bars on older versions of iOS and no reliable way to workaround this in js. More motivation in #17638 

This changeset emulate safe area in terms of `UIViewController` layout guides API if safeArea not available.

Fixes #17638, #18255

## Test Plan

I run RNTester with these simulators: iPhone6 (9.3), iPhone6 (10.0), iPhone6 (11.2), iPhoneX (11.2)
- Start RNTester application
- Look on top header, it should not overlap status bar
- Go to the `<SafeAreaView>` example, open modal
- Modal area should not overlap status bar

### RNTester before change

<img src="http://vovkasm.skitch.vovkasm.org/iPhone6_10_20662C5B.png" width="40%"> <img src="http://vovkasm.skitch.vovkasm.org/iPhone6_11_20662CC8.png" width="40%">

### RNTester after change

<img src="http://vovkasm.skitch.vovkasm.org/iPhone6_10_pr_20662DE6.png" width="40%"> <img src="http://vovkasm.skitch.vovkasm.org/iPhone6_11_pr_20662DA8.png" width="40%">

## Release Notes

[IOS] [BUGFIX] [SafeAreaView] - Make SafeAreaView to work on iOS < 11

