### PR TITLE
[WebView] [BUGFIX] onMessage should not break postMessage

### DIFF
--- a/React/Views/RCTWebView.m
+++ b/React/Views/RCTWebView.m
@@ -322,6 +322,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
         "}"
 
         "window.postMessage = function(data) {"
+          "window.originalPostMessage.apply(window, arguments);"
           "messageQueue.push(String(data));"
           "processQueue();"
         "};"

--- a/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebViewManager.java
@@ -319,6 +319,7 @@ public class ReactWebViewManager extends SimpleViewManager<WebView> {
         loadUrl("javascript:(" +
           "window.originalPostMessage = window.postMessage," +
           "window.postMessage = function(data) {" +
+            "window.originalPostMessage.apply(window, arguments);" +
             BRIDGE_NAME + ".postMessage(String(data));" +
           "}" +
         ")");


### PR DESCRIPTION
`onMessage` handler, replaces original `window.postMessage` function, so messages being sent by the applications never arrive to their target destinations. Some application like `twitter.com` are simply broken in such environments.

This PR, changes the implementation of replaced `window.postMessage` to call the original function in order to prevent website breakage. 

Those issues are probably caused by described problem:
* https://github.com/facebook/react-native/issues/14586
* https://github.com/facebook/react-native/issues/10865
There are probably more reports like that.

I've tested changes on Android and I'm assuming the iOS version should work as well.

## Test Plan

Create a WebView component with `onMessage` handler and `url` set to `https://twitter.com/`. Log in to twitter.

With changes of this PR, twitter feed will load correctly. Without changes, no tweets will be loaded.

## Release Notes

[WebView] [BUGFIX] - onMessage should not break postMessage
