### PR TITLE
Fix blob response parsing for empty body on iOS

### DIFF
--- a/Libraries/Blob/RCTBlobManager.mm
+++ b/Libraries/Blob/RCTBlobManager.mm
@@ -258,6 +258,9 @@ RCT_EXPORT_METHOD(release:(NSString *)blobId)
 
 - (id)handleNetworkingResponse:(NSURLResponse *)response data:(NSData *)data
 {
+  // An empty body will have nil for data, in this case we need to return
+  // an empty blob as per the XMLHttpRequest spec.
+  data = data ?: [NSData new];
   return @{
     @"blobId": [self store:data],
     @"offset": @0,

--- a/Libraries/Network/RCTNetworking.mm
+++ b/Libraries/Network/RCTNetworking.mm
@@ -439,10 +439,6 @@ RCT_EXPORT_MODULE()
 {
   RCTAssertThread(_methodQueue, @"sendData: must be called on method queue");
 
-  if (data.length == 0) {
-    return;
-  }
-
   id responseData = nil;
   for (id<RCTNetworkingResponseHandler> handler in _responseHandlers) {
     if ([handler canHandleNetworkingResponse:responseType]) {
@@ -452,6 +448,10 @@ RCT_EXPORT_MODULE()
   }
 
   if (!responseData) {
+    if (data.length == 0) {
+      return;
+    }
+
     if ([responseType isEqualToString:@"text"]) {
       // No carry storage is required here because the entire data has been loaded.
       responseData = [RCTNetworking decodeTextData:data fromResponse:task.response withCarryData:nil];


### PR DESCRIPTION
We currently handle empty body poorly in the iOS blob implementation, this happens because of an early return that cause the blob response to not be processed by the blob module, resulting in an empty string as the body instead of a blob object. We also need to make sure to create an empty blob object when data is nil (empty body) as per the XMLHttpRequest spec. The Android implementation was already handling this properly.

Fixes #18223

## Test Plan

Send a HEAD request

```js
fetch('https://apipre.monkimun.com/whoami', {
  body: null,
  method: 'HEAD',
  headers: {
    Accept: 'application/json',
    'Content-Type': 'application/json',
  },
})
```

## Release Notes

[IOS][BUGFIX][Blob] - Fix blob response parsing for empty body