### PR TITLE
Android WebView: opt-in for handling of iframe urls 

### DIFF
--- a/Libraries/Components/WebView/WebView.android.js
+++ b/Libraries/Components/WebView/WebView.android.js
@@ -65,6 +65,7 @@ class WebView extends React.Component {
     onMessage: PropTypes.func,
     onContentSizeChange: PropTypes.func,
     startInLoadingState: PropTypes.bool, // force WebView to show loadingView on first load
+    handleIFrameLoadingEvent: PropTypes.bool, // allow handling of iframe loading events
     style: ViewPropTypes.style,
 
     html: deprecatedPropType(
@@ -236,7 +237,8 @@ class WebView extends React.Component {
     javaScriptEnabled : true,
     thirdPartyCookiesEnabled: true,
     scalesPageToFit: true,
-    saveFormDataDisabled: false
+    saveFormDataDisabled: false,
+    handleIFrameLoadingEvent: false
   };
 
   state = {
@@ -300,6 +302,7 @@ class WebView extends React.Component {
         injectedJavaScript={this.props.injectedJavaScript}
         userAgent={this.props.userAgent}
         javaScriptEnabled={this.props.javaScriptEnabled}
+        handleIFrameLoadingEvent={this.props.handleIFrameLoadingEvent}
         thirdPartyCookiesEnabled={this.props.thirdPartyCookiesEnabled}
         domStorageEnabled={this.props.domStorageEnabled}
         messagingEnabled={typeof this.props.onMessage === 'function'}

--- a/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebViewManager.java
@@ -110,6 +110,7 @@ public class ReactWebViewManager extends SimpleViewManager<WebView> {
 
     protected boolean mLastLoadFailed = false;
     protected @Nullable ReadableArray mUrlPrefixesForDefaultIntent;
+    protected boolean handleIFrameLoadingEvent = false;
 
     @Override
     public void onPageFinished(WebView webView, String url) {
@@ -186,6 +187,18 @@ public class ReactWebViewManager extends SimpleViewManager<WebView> {
           webView,
           new TopLoadingErrorEvent(webView.getId(), eventData));
     }
+    
+    @Override
+    public void doUpdateVisitedHistory(WebView webView, String url, boolean isReload) {
+        super.doUpdateVisitedHistory(webView, url, isReload);
+
+        if (handleIFrameLoadingEvent)
+          dispatchEvent(
+              webView,
+              new TopLoadingStartEvent(
+                  webView.getId(),
+                  createWebViewEvent(webView, url)));
+      }
 
     protected void emitFinishEvent(WebView webView, String url) {
       dispatchEvent(
@@ -210,6 +223,10 @@ public class ReactWebViewManager extends SimpleViewManager<WebView> {
 
     public void setUrlPrefixesForDefaultIntent(ReadableArray specialUrls) {
       mUrlPrefixesForDefaultIntent = specialUrls;
+    }
+    
+    public void setHandleIFrameLoadingEvent(boolean enabled) {
+      handleIFrameLoadingEvent = enabled;
     }
   }
 
@@ -395,7 +412,7 @@ public class ReactWebViewManager extends SimpleViewManager<WebView> {
   public void setJavaScriptEnabled(WebView view, boolean enabled) {
     view.getSettings().setJavaScriptEnabled(enabled);
   }
-
+  
   @ReactProp(name = "thirdPartyCookiesEnabled")
   public void setThirdPartyCookiesEnabled(WebView view, boolean enabled) {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
@@ -444,6 +461,14 @@ public class ReactWebViewManager extends SimpleViewManager<WebView> {
   @ReactProp(name = "messagingEnabled")
   public void setMessagingEnabled(WebView view, boolean enabled) {
     ((ReactWebView) view).setMessagingEnabled(enabled);
+  }
+  
+  @ReactProp(name = "handleIFrameLoadingEvent")
+  public void setHandleIFrameLoadingEvent(WebView view, boolean enabled) {
+    ReactWebViewClient client = ((ReactWebView) view).getReactWebViewClient();
+    if (client != null) {
+      client.setHandleIFrameLoadingEvent(enabled);
+    }
   }
 
   @ReactProp(name = "source")


### PR DESCRIPTION
<!-- 
  Required: Write your motivation here.
  If this PR fixes an issue, type "Fixes #issueNumber" to automatically close the issue when the PR is merged.
-->
Fixes #18442 
This is a PR to allow developers to revert back to WebView behavior in 0.48.4 regarding the loading of iframes. Currently Webview no longer detects the loading of iframe urls. And this is needed to detect and bookmark Google AMPs.

With the prop handleIFrameLoadingEvent, we can opt in for the firing of these events.

## Test Plan
I tested the changes on WebView 
- without the parameter, 
- with the parameter at False, 
- and with the parameter at True.

It worked as intended. I can now retrieve AMP urls when the parameter is at True.

<!-- 
  Required: Write your test plan here. If you changed any code, please provide us with 
  clear instructions on how you verified your changes work. Bonus points for screenshots and videos! 
-->

## Related PRs

Related to [ffbd3db](https://github.com/facebook/react-native/commit/ffbd3db61bce21b9332f7783086fce703706031f) which removed  the firing of the loading events. for iframes. 

<!-- 
  Does this PR require a documentation change? 
  Create a PR at https://github.com/facebook/react-native-website and add a link to it here.
-->
Yes. Below the PR for documentation change
[PR269](https://github.com/facebook/react-native-website/pull/269)

## Release Notes

<!-- 
  Required. 
  Help reviewers and the release process by writing your own release notes. See below for an example.
-->

[ANDROID] [BUGFIX] [WEBVIEW] - Added a prop handleIFrameLoadingEvent to Webview to allow opt-in for the firing of loading events for iframes (not only top level pages).

<!--
  **INTERNAL and MINOR tagged notes will not be included in the next version's final release notes.**

    CATEGORY
  [----------]      TYPE
  [ CLI      ] [-------------]    LOCATION
  [ DOCS     ] [ BREAKING    ] [-------------]
  [ GENERAL  ] [ BUGFIX      ] [ {Component} ]
  [ INTERNAL ] [ ENHANCEMENT ] [ {Filename}  ]
  [ IOS      ] [ FEATURE     ] [ {Directory} ]   |-----------|
  [ ANDROID  ] [ MINOR       ] [ {Framework} ] - | {Message} |
  [----------] [-------------] [-------------]   |-----------|

 EXAMPLES:

 [IOS] [BREAKING] [FlatList] - Change a thing that breaks other things
 [ANDROID] [BUGFIX] [TextInput] - Did a thing to TextInput
 [CLI] [FEATURE] [local-cli/info/info.js] - CLI easier to do things with
 [DOCS] [BUGFIX] [GettingStarted.md] - Accidentally a thing/word
 [GENERAL] [ENHANCEMENT] [Yoga] - Added new yoga thing/position
 [INTERNAL] [FEATURE] [./scripts] - Added thing to script that nobody will see
-->
