### PR TITLE
Fix wrong root path in RNTester gradle config

### DIFF
--- a/RNTester/android/app/build.gradle
+++ b/RNTester/android/app/build.gradle
@@ -60,7 +60,7 @@ import com.android.build.OutputFile
 project.ext.react = [
     bundleAssetName: "RNTesterApp.android.bundle",
     entryFile: file("../../js/RNTesterApp.android.js"),
-    root: "../../../../",
+    root: "../../../",
     inputExcludes: ["android/**", "./**"]
 ]
 


### PR DESCRIPTION
Currrent(0.54-stable) root path in RNTester gradle config would cause a failure when trying to compile a release version for RNTester:
```
module.js:545
    throw err;
    ^

Error: Cannot find module ’TheParentDirectoryOfCurrentRepo/local-cli/cli.js'
    at Function.Module._resolveFilename (module.js:543:15)
    at Function.Module._load (module.js:470:25)
    at Function.Module.runMain (module.js:690:10)
    at startup (bootstrap_node.js:194:16)
    at bootstrap_node.js:666:3
:RNTester:android:app:bundleReleaseJsAndAssets FAILED
```

## Release Notes

[ANDROID] [INTERNAL] [RNTester] - Fix wrong root path in RNTester gradle config