### PR TITLE
Use afterEvaluate to make gradle bundle task work with configureondemand

### DIFF
--- a/RNTester/android/app/gradle.properties
+++ b/RNTester/android/app/gradle.properties
@@ -1,4 +1,6 @@
 android.useDeprecatedNdk=true
+org.gradle.parallel=true
+org.gradle.configureondemand=true
 MYAPP_RELEASE_STORE_FILE=my-release-key.keystore
 MYAPP_RELEASE_KEY_ALIAS=my-key-alias
 MYAPP_RELEASE_STORE_PASSWORD=*****

--- a/react.gradle
+++ b/react.gradle
@@ -23,7 +23,7 @@ void runBefore(String dependentTaskName, Task task) {
     }
 }
 
-gradle.projectsEvaluated {
+afterEvaluate {
     // Grab all build types and product flavors
     def buildTypes = android.buildTypes.collect { type -> type.name }
     def productFlavors = android.productFlavors.collect { flavor -> flavor.name }


### PR DESCRIPTION
The js bundle task does not run when `org.gradle.configureondemand` is set to true. This uses `afterEvaluate` instead of `gradle.projectsEvaluated` which is executed properly.

## Test Plan

Add `org.gradle.configureondemand=true`, run RNTester in release mode and make sure the bundle task is run.

## Release Notes

[ANDROID] [BUGFIX] [LOCATION] - Fix release bundle task when org.gradle.configureondemand=true