### PR TITLE
don't crash app from _handleLongDelay

### DIFF
--- a/Libraries/Components/Touchable/Touchable.js
+++ b/Libraries/Components/Touchable/Touchable.js
@@ -623,7 +623,7 @@ const TouchableMixin = {
     const curState = this.state.touchable.touchState;
     if (curState !== States.RESPONDER_ACTIVE_PRESS_IN &&
         curState !== States.RESPONDER_ACTIVE_LONG_PRESS_IN) {
-      console.error('Attempted to transition from state `' + curState + '` to `' +
+      console.warn('Attempted to transition from state `' + curState + '` to `' +
         States.RESPONDER_ACTIVE_LONG_PRESS_IN + '`, which is not supported. This is ' +
         'most likely due to `Touchable.longPressDelayTimeout` not being cancelled.');
     } else {


### PR DESCRIPTION
The console.error message from _handleLongDelay seems to get called when remote debugging for Android, even though the handler for the touchable seems to work.

The red screen is unnecessary and it should just be a warning, if that.

Thank you for sending the PR! We appreciate you spending the time to work on these changes. 
Help us understand your motivation by explaining why you decided to make this change.

Fixes #11989

## Test Plan

This is difficult to reproduce but can happen if you are remote debugging on an Android device and using many Touchables in rapid succession. 

## Related PRs

None.

## Release Notes

[ANDROID][BUGFIX][Touchable] - Warn instead of throwing an error from _handleLongDelay