### PR TITLE
Native Animated - Support border radius

### DIFF
--- a/Libraries/Animated/src/NativeAnimatedHelper.js
+++ b/Libraries/Animated/src/NativeAnimatedHelper.js
@@ -150,7 +150,6 @@ const STYLES_WHITELIST = {
   borderBottomLeftRadius: true,
   borderBottomRightRadius: true,
   borderBottomStartRadius: true,
-  borderBottomWidth: true,
   borderTopEndRadius: true,
   borderTopLeftRadius: true,
   borderTopRightRadius: true,

--- a/Libraries/Animated/src/NativeAnimatedHelper.js
+++ b/Libraries/Animated/src/NativeAnimatedHelper.js
@@ -145,6 +145,16 @@ const API = {
 const STYLES_WHITELIST = {
   opacity: true,
   transform: true,
+  borderRadius: true,
+  borderBottomEndRadius: true,
+  borderBottomLeftRadius: true,
+  borderBottomRightRadius: true,
+  borderBottomStartRadius: true,
+  borderBottomWidth: true,
+  borderTopEndRadius: true,
+  borderTopLeftRadius: true,
+  borderTopRightRadius: true,
+  borderTopStartRadius: true,
   /* ios styles */
   shadowOpacity: true,
   shadowRadius: true,


### PR DESCRIPTION
Border radius already works properly with native animated but was not in the whitelisted props.

## Test Plan

Tested in an app that animating border radius with native animated actually works.


## Release Notes

[GENERAL] [ENHANCEMENT] [NativeAnimated] - Support border radius