### PR TITLE
[Circle] Cache apt dependencies in test_android

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,6 +51,18 @@ aliases:
       - ~/.gradle
     key: v1-gradle-{{ arch }}-{{ .Branch }}-{{ checksum "build.gradle" }}-{{ checksum "ReactAndroid/build.gradle" }}
 
+  - &restore-cache-apt
+    keys:
+      - v1-apt-{{ arch }}-{{ .Branch }}-{{ checksum ".circleci/config.yml" }}
+      # Fallback in case checksum fails
+      - v1-apt-{{ arch }}-{{ .Branch }}-
+      # Fallback in case this is a first-time run on a fork
+      - v1-apt-{{ arch }}-master-
+  - &save-cache-apt
+    paths:
+      - ~/vendor/apt
+    key: v1-apt-{{ arch }}-{{ .Branch }}-{{ checksum ".circleci/config.yml" }}
+
   - &restore-cache-ndk
     keys:
       - v2-android-ndk-{{ arch }}-r10e-32-64-{{ checksum "scripts/circle-ci-android-setup.sh" }}
@@ -156,7 +168,20 @@ aliases:
     name: Install Android Build Dependencies
     command: |
       sudo apt-get update -y
-      sudo apt-get install ant autoconf automake g++ gcc libqt5widgets5 lib32z1 lib32stdc++6  make maven python-dev python3-dev qml-module-qtquick-controls qtdeclarative5-dev file -y
+      if ! [[ -d ~/vendor/apt ]]; then
+        mkdir -p ~/vendor/apt
+      fi
+      # First check for archives cache
+      if ! [[ -d ~/vendor/apt/archives ]]; then
+        # It doesn't so download the packages
+        sudo apt-get install --download-only ant autoconf automake g++ gcc libqt5widgets5 lib32z1 lib32stdc++6  make maven python-dev python3-dev qml-module-qtquick-controls qtdeclarative5-dev file -y
+        # Then move them to our cache directory
+        sudo cp -R /var/cache/apt ~/vendor/
+        # Making sure our user has ownership, in order to cache
+        sudo chown -R ${USER:=$(/usr/bin/id -run)}:$USER ~/vendor/apt
+      fi
+      # Install all packages in the cache
+      sudo dpkg -i ~/vendor/apt/archives/*.deb
 
   - &validate-android-sdk
     name: Validate Android SDK Install
@@ -412,7 +437,11 @@ jobs:
       
       # Configure Android SDK and related dependencies
       - run: *configure-android-path
+
+      - run: *restore-cache-apt
       - run: *install-android-build-dependencies
+      - run: *save-cache-apt
+
       - restore-cache: *restore-cache-android-packages
       - run: *install-android-packages
       - save-cache: *save-cache-android-packages

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,7 +122,8 @@ aliases:
       yarn install --non-interactive --cache-folder ~/.cache/yarn
 
   - &install-yarn
-    |
+    name: Install Yarn
+    command: |
       curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
       echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
       sudo apt-get update && sudo apt-get install yarn
@@ -132,7 +133,8 @@ aliases:
       npm install --no-package-lock --no-spin --no-progress
 
   - &install-buck
-    |
+    name: Install BUCK
+    command: |
       if [[ ! -e ~/buck ]]; then
         git clone https://github.com/facebook/buck.git ~/buck --branch v2018.02.16.01 --depth=1
       fi
@@ -140,7 +142,8 @@ aliases:
       buck --version
 
   - &install-node
-    |
+    name: Install Node
+    command: |
       curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
       sudo apt-get install -y nodejs
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ aliases:
       # Fallback in case checksum fails
       - v1-apt-{{ arch }}-{{ .Branch }}-
       # Fallback in case this is a first-time run on a fork
-      - v1-apt-{{ arch }}-master
+      - v1-apt-{{ arch }}-master-
   - &save-cache-apt
     paths:
       - ~/vendor/apt
@@ -474,9 +474,9 @@ jobs:
 
       # Configure Android SDK and related dependencies
       - run: *configure-android-path
-      - run: *restore-cache-apt
+      - restore-cache: *restore-cache-apt
       - run: *install-android-build-dependencies
-      - run: *save-cache-apt
+      - save-cache: *save-cache-apt
 
       - restore-cache: *restore-cache-android-packages
       - run: *install-android-packages

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -174,13 +174,16 @@ aliases:
       # First check for archives cache
       if ! [[ -d ~/vendor/apt/archives ]]; then
         # It doesn't so download the packages
-        sudo apt-get install --download-only ant autoconf automake g++ gcc libqt5widgets5 lib32z1 lib32stdc++6  make maven python-dev python3-dev qml-module-qtquick-controls qtdeclarative5-dev file -y
+        echo "Downloading build dependencies..."
+        # If you add a package to the next line, you might need to update the apt cache key
+        sudo apt-get install --download-only ant autoconf automake g++ gcc libqt5widgets5 lib32z1 lib32stdc++6 make maven python-dev python3-dev qml-module-qtquick-controls qtdeclarative5-dev file -y
         # Then move them to our cache directory
         sudo cp -R /var/cache/apt ~/vendor/
         # Making sure our user has ownership, in order to cache
         sudo chown -R ${USER:=$(/usr/bin/id -run)}:$USER ~/vendor/apt
       fi
       # Install all packages in the cache
+      echo "Installing build dependencies..."
       sudo dpkg -i ~/vendor/apt/archives/*.deb
 
   - &validate-android-sdk

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,16 @@ aliases:
       - /opt/android/sdk
     key: v1-android-sdkmanager-packages-{{ arch }}-{{ .Branch }}-api-26-alpha-{{ checksum "scripts/circle-ci-android-setup.sh" }}
 
+  - &restore-cache-gradle
+    keys:
+      - v1-gradle-{{ arch }}-{{ .Branch }}
+      # Fallback in case this is a first-time run on a fork
+      - v1-gradle-{{ arch }}-master
+  - &save-cache-gradle
+    paths:
+      - ~/.gradle
+    key: v1-gradle-{{ arch }}-{{ .Branch }}
+
   - &restore-cache-ndk
     keys:
       - v2-android-ndk-{{ arch }}-r10e-32-64-{{ checksum "scripts/circle-ci-android-setup.sh" }}
@@ -481,7 +491,11 @@ jobs:
       - run: buck fetch ReactAndroid/src/main/java/com/facebook/react/shell
       - run: buck fetch ReactAndroid/src/test/...
       - run: buck fetch ReactAndroid/src/androidTest/...
+
+      # Gradle
+      - restore-cache: *restore-cache-gradle
       - run: ./gradlew :ReactAndroid:downloadBoost :ReactAndroid:downloadDoubleConversion :ReactAndroid:downloadFolly :ReactAndroid:downloadGlog :ReactAndroid:downloadJSCHeaders
+      - save-cache: *save-cache-gradle
 
       # Build and compile
       - run: *build-android-app

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,13 +40,16 @@ aliases:
 
   - &restore-cache-gradle
     keys:
-      - v1-gradle-{{ arch }}-{{ .Branch }}
+      - v1-gradle-{{ arch }}-{{ .Branch }}-{{ checksum "build.gradle" }}-{{ checksum "ReactAndroid/build.gradle" }}
+      # Fallback in case checksum fails
+      - v1-gradle-{{ arch }}-{{ .Branch }}-{{ checksum "build.gradle" }}-
+      - v1-gradle-{{ arch }}-{{ .Branch }}-
       # Fallback in case this is a first-time run on a fork
-      - v1-gradle-{{ arch }}-master
+      - v1-gradle-{{ arch }}-master-
   - &save-cache-gradle
     paths:
       - ~/.gradle
-    key: v1-gradle-{{ arch }}-{{ .Branch }}
+    key: v1-gradle-{{ arch }}-{{ .Branch }}-{{ checksum "build.gradle" }}-{{ checksum "ReactAndroid/build.gradle" }}
 
   - &restore-cache-ndk
     keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,15 +53,15 @@ aliases:
 
   - &restore-cache-apt
     keys:
-      - v1-apt-{{ arch }}-{{ .Branch }}-{{ checksum ".circleci/config.yml" }}
+      - v1-apt-{{ arch }}-{{ .Branch }}-{{ checksum "scripts/circleci/apt-get-android-deps.sh" }}
       # Fallback in case checksum fails
       - v1-apt-{{ arch }}-{{ .Branch }}-
       # Fallback in case this is a first-time run on a fork
-      - v1-apt-{{ arch }}-master-
+      - v1-apt-{{ arch }}-master
   - &save-cache-apt
     paths:
       - ~/vendor/apt
-    key: v1-apt-{{ arch }}-{{ .Branch }}-{{ checksum ".circleci/config.yml" }}
+    key: v1-apt-{{ arch }}-{{ .Branch }}-{{ checksum "scripts/circleci/apt-get-android-deps.sh" }}
 
   - &restore-cache-ndk
     keys:
@@ -166,25 +166,7 @@ aliases:
 
   - &install-android-build-dependencies
     name: Install Android Build Dependencies
-    command: |
-      sudo apt-get update -y
-      if ! [[ -d ~/vendor/apt ]]; then
-        mkdir -p ~/vendor/apt
-      fi
-      # First check for archives cache
-      if ! [[ -d ~/vendor/apt/archives ]]; then
-        # It doesn't so download the packages
-        echo "Downloading build dependencies..."
-        # If you add a package to the next line, you might need to update the apt cache key
-        sudo apt-get install --download-only ant autoconf automake g++ gcc libqt5widgets5 lib32z1 lib32stdc++6 make maven python-dev python3-dev qml-module-qtquick-controls qtdeclarative5-dev file -y
-        # Then move them to our cache directory
-        sudo cp -R /var/cache/apt ~/vendor/
-        # Making sure our user has ownership, in order to cache
-        sudo chown -R ${USER:=$(/usr/bin/id -run)}:$USER ~/vendor/apt
-      fi
-      # Install all packages in the cache
-      echo "Installing build dependencies..."
-      sudo dpkg -i ~/vendor/apt/archives/*.deb
+    command: ./scripts/circleci/apt-get-android-deps.sh
 
   - &validate-android-sdk
     name: Validate Android SDK Install
@@ -440,10 +422,7 @@ jobs:
       
       # Configure Android SDK and related dependencies
       - run: *configure-android-path
-
-      - run: *restore-cache-apt
       - run: *install-android-build-dependencies
-      - run: *save-cache-apt
 
       - restore-cache: *restore-cache-android-packages
       - run: *install-android-packages
@@ -495,7 +474,10 @@ jobs:
 
       # Configure Android SDK and related dependencies
       - run: *configure-android-path
+      - run: *restore-cache-apt
       - run: *install-android-build-dependencies
+      - run: *save-cache-apt
+
       - restore-cache: *restore-cache-android-packages
       - run: *install-android-packages
       - save-cache: *save-cache-android-packages

--- a/scripts/circleci/apt-get-android-deps.sh
+++ b/scripts/circleci/apt-get-android-deps.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -e
+
+echo "Downloading package lists..."
+sudo apt-get update -y
+
+if ! [[ -d ~/vendor/apt ]]; then
+  mkdir -p ~/vendor/apt
+fi
+
+# First check for archives cache
+if ! [[ -d ~/vendor/apt/archives ]]; then
+  # It doesn't so download the packages
+  echo "Downloading build dependencies..."
+  sudo apt-get install --download-only ant autoconf automake g++ gcc libqt5widgets5 lib32z1 lib32stdc++6 make maven python-dev python3-dev qml-module-qtquick-controls qtdeclarative5-dev file -y
+  # Then move them to our cache directory
+  sudo cp -R /var/cache/apt ~/vendor/
+  # Making sure our user has ownership, in order to cache
+  sudo chown -R ${USER:=$(/usr/bin/id -run)}:$USER ~/vendor/apt
+fi
+
+# Install all packages in the cache
+echo "Installing build dependencies..."
+sudo dpkg -i ~/vendor/apt/archives/*.deb


### PR DESCRIPTION
Test Plan: 

https://circleci.com/gh/hramos/react-native/1658

The failure is unrelated. You can see the restore-cache-apt, save-cache-apt, and apt-get-android-deps.sh steps all working as expected in that run.