### PR TITLE
Fix bugs in makePackagePatch and unlink

### DIFF
--- a/local-cli/link/android/registerNativeModule.js
+++ b/local-cli/link/android/registerNativeModule.js
@@ -10,7 +10,7 @@ const makeStringsPatch = require('./patches/makeStringsPatch');
 const makeSettingsPatch = require('./patches/makeSettingsPatch');
 const makeBuildPatch = require('./patches/makeBuildPatch');
 const makeImportPatch = require('./patches/makeImportPatch');
-const makePackagePatch = require('./patches/makePackagePatch');
+const { applyPackagePatch } = require('./patches/makePackagePatch');
 
 module.exports = function registerNativeAndroidModule(
   name,
@@ -30,7 +30,7 @@ module.exports = function registerNativeAndroidModule(
 
   applyPatch(
     projectConfig.mainFilePath,
-    makePackagePatch(androidConfig.packageInstance, params, name)
+    applyPackagePatch(androidConfig.packageInstance, params, name)
   );
 
   applyPatch(

--- a/local-cli/link/android/unregisterNativeModule.js
+++ b/local-cli/link/android/unregisterNativeModule.js
@@ -13,7 +13,7 @@ const makeSettingsPatch = require('./patches/makeSettingsPatch');
 const makeBuildPatch = require('./patches/makeBuildPatch');
 const makeStringsPatch = require('./patches/makeStringsPatch');
 const makeImportPatch = require('./patches/makeImportPatch');
-const makePackagePatch = require('./patches/makePackagePatch');
+const { revokePackagePatch } = require('./patches/makePackagePatch');
 
 module.exports = function unregisterNativeAndroidModule(
   name,
@@ -41,7 +41,7 @@ module.exports = function unregisterNativeAndroidModule(
 
   revokePatch(
     projectConfig.mainFilePath,
-    makePackagePatch(androidConfig.packageInstance, params, name)
+    revokePackagePatch(projectConfig.mainFilePath, androidConfig.packageInstance, params, name)
   );
 
   revokePatch(

--- a/local-cli/link/unlink.js
+++ b/local-cli/link/unlink.js
@@ -1,3 +1,4 @@
+
 /**
  * Copyright (c) 2015-present, Facebook, Inc.
  *
@@ -48,7 +49,7 @@ const unlinkDependency = (platforms, project, dependency, packageName, otherDepe
         otherDependencies
       );
 
-      log.info(`Platform '${platform}' module ${dependency.name} has been successfully unlinked`);
+      log.info(`Platform '${platform}' module ${packageName} has been successfully unlinked`);
     });
 };
 


### PR DESCRIPTION

## Motivation
I was not able to successfully unlink react-native-sound. I found out that its because of [this]
(https://github.com/facebook/react-native/compare/master...ranjithnori:master#diff-db954092efbf6e08bd25168c258a510dL15)

This PR is aimed at improvising react-native unlink by comparing with a regex instead of a string in makePackagePatch.js. 

It also contains a minor bug fix in unlink.js
-->

## Test Plan
Have been successfully able to link and unlink react-native-sound, react-native-image-crop-picker on a sample app created with react-native init.

`react-native link react-native-sound`

![screen shot 2018-03-27 at 9 36 15 am](https://user-images.githubusercontent.com/4106656/37946300-54c0ed12-31a2-11e8-880e-fe6f2ca957b8.png)

![screen shot 2018-03-27 at 9 32 07 am](https://user-images.githubusercontent.com/4106656/37946203-cfd6a0ba-31a1-11e8-87c0-5604e6d9c720.png)

`react-native unlink react-native-sound `

![screen shot 2018-03-27 at 9 35 34 am](https://user-images.githubusercontent.com/4106656/37946283-3ddf11be-31a2-11e8-8ab8-d6536a7267fa.png)

![screen shot 2018-03-27 at 9 34 25 am](https://user-images.githubusercontent.com/4106656/37946250-18aca9f6-31a2-11e8-9028-0e84510b78a9.png)


## Related PRs

Closely related to [#18207](https://github.com/facebook/react-native/pull/18207)

## Release Notes

[CLI] [BUGFIX] [local-cli/link/android/patches/makePackagePatch.js] - Bug fix related to react-native-unlink (Android)
