### PR TITLE
Handle update of `secureTextEntry` of `TextInput` in iOS

### DIFF
--- a/Libraries/Text/TextInput/RCTBaseTextInputView.m
+++ b/Libraries/Text/TextInput/RCTBaseTextInputView.m
@@ -412,10 +412,23 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithFrame:(CGRect)frame)
 
 - (void)didSetProps:(NSArray<NSString *> *)changedProps
 {
+  [self shouldHandleSecureTextEntryChange:changedProps];
+
   if ([changedProps containsObject:@"inputAccessoryViewID"] && self.inputAccessoryViewID) {
     [self setCustomInputAccessoryViewWithNativeID:self.inputAccessoryViewID];
   } else if (!self.inputAccessoryViewID) {
     [self setDefaultInputAccessoryView];
+  }
+}
+
+- (void)shouldHandleSecureTextEntryChange:(NSArray<NSString *> *)changedProps
+{
+  BOOL didSecureTextEntryUpdate = [changedProps containsObject: @"secureTextEntry"];
+  if (didSecureTextEntryUpdate) {
+    NSAttributedString *originalText = self.backedTextInputView.attributedText;
+    
+    self.backedTextInputView.attributedText = nil;
+    self.backedTextInputView.attributedText = originalText;
   }
 }
 


### PR DESCRIPTION
This PR fixes #5859, which causes the `TextInput` to have a space appended to the end when you change the value of `secureTextEntry` prop in iOS:

Before | After
:--- | :---
![before](https://user-images.githubusercontent.com/6207220/37958125-ec47badc-31af-11e8-9a18-b7e58c3c5317.gif)|![after](https://user-images.githubusercontent.com/6207220/37958126-ec6b69be-31af-11e8-827f-f0b1c31c38fb.gif)

I found a few workarounds online and the simplest one in my opinion is [this SO answer](https://stackoverflow.com/a/22537788/4252781).

I'm definitely open to hear more opinions on the implementation.

## Test Plan

My test plan is very basic, having a `<TextInput />` and dynamically switching `secureTextEntry` prop between `true`/`false` will show the bug. 

## Release Notes

[IOS] [BUGFIX] [Libraries/Text/TextInput/RCTBaseTextInputView.m] - Fix bug with space being appended to the end of input value when changing `secureTextEntry`.
