### PR TITLE
Implement Image.defaultSource property on Android

### DIFF
--- a/Libraries/Image/Image.android.js
+++ b/Libraries/Image/Image.android.js
@@ -75,6 +75,10 @@ var Image = createReactClass({
      */
     blurRadius: PropTypes.number,
     /**
+    * See https://facebook.github.io/react-native/docs/image.html#defaultsource
+    */
+    defaultSource: PropTypes.number,
+    /**
      * See https://facebook.github.io/react-native/docs/image.html#loadingindicatorsource
      */
     loadingIndicatorSource: PropTypes.oneOfType([
@@ -197,6 +201,7 @@ var Image = createReactClass({
 
   render: function() {
     const source = resolveAssetSource(this.props.source);
+    const defaultSource = resolveAssetSource(this.props.defaultSource);
     const loadingIndicatorSource = resolveAssetSource(
       this.props.loadingIndicatorSource,
     );
@@ -217,6 +222,12 @@ var Image = createReactClass({
     if (this.props.children) {
       throw new Error(
         'The <Image> component cannot contain children. If you want to render content on top of the image, consider using the <ImageBackground> component or absolute positioning.',
+      );
+    }
+
+    if (this.props.defaultSource && this.props.loadingIndicatorSource) {
+      throw new Error(
+        'The <Image> component cannot have defaultSource and loadingIndicatorSource at the same time. Please use either defaultSource or loadingIndicatorSource.',
       );
     }
 
@@ -243,6 +254,9 @@ var Image = createReactClass({
         ),
         src: sources,
         headers: source.headers,
+        defaultSrc: defaultSource
+          ? defaultSource.uri
+          : null,
         loadingIndicatorSrc: loadingIndicatorSource
           ? loadingIndicatorSource.uri
           : null,
@@ -268,6 +282,7 @@ var cfg = {
   nativeOnly: {
     src: true,
     headers: true,
+    defaultSrc: true,
     loadingIndicatorSrc: true,
     shouldNotifyLoadEvents: true,
   },

--- a/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageManager.java
@@ -88,6 +88,12 @@ public class ReactImageManager extends SimpleViewManager<ReactImageView> {
     view.setBlurRadius(blurRadius);
   }
 
+  // In JS this is Image.props.defaultSource
+  @ReactProp(name = "defaultSrc")
+  public void setDefaultSource(ReactImageView view, @Nullable String source) {
+    view.setDefaultSource(source);
+  }
+
   // In JS this is Image.props.loadingIndicatorSource.uri
   @ReactProp(name = "loadingIndicatorSrc")
   public void setLoadingIndicatorSource(ReactImageView view, @Nullable String source) {

--- a/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageView.java
@@ -182,6 +182,7 @@ public class ReactImageView extends GenericDraweeView {
 
   private @Nullable ImageSource mImageSource;
   private @Nullable ImageSource mCachedImageSource;
+  private @Nullable Drawable mDefaultImageDrawable;
   private @Nullable Drawable mLoadingImageDrawable;
   private int mBorderColor;
   private int mOverlayColor;
@@ -356,6 +357,11 @@ public class ReactImageView extends GenericDraweeView {
     mIsDirty = true;
   }
 
+  public void setDefaultSource(@Nullable String name) {
+    mDefaultImageDrawable = ResourceDrawableIdHelper.getInstance().getResourceDrawable(getContext(), name);
+    mIsDirty = true;
+  }
+
   public void setLoadingIndicatorSource(@Nullable String name) {
     Drawable drawable = ResourceDrawableIdHelper.getInstance().getResourceDrawable(getContext(), name);
     mLoadingImageDrawable =
@@ -414,6 +420,10 @@ public class ReactImageView extends GenericDraweeView {
 
     GenericDraweeHierarchy hierarchy = getHierarchy();
     hierarchy.setActualImageScaleType(mScaleType);
+
+    if (mDefaultImageDrawable != null) {
+      hierarchy.setPlaceholderImage(mDefaultImageDrawable, ScalingUtils.ScaleType.CENTER);
+    }
 
     if (mLoadingImageDrawable != null) {
       hierarchy.setPlaceholderImage(mLoadingImageDrawable, ScalingUtils.ScaleType.CENTER);


### PR DESCRIPTION
This pull request implements Image.defaultSource property on Android, using Fresco (http://frescolib.org/docs/placeholder-failure-retry.html), which will show placeholder image (local asset) while loading remote image. Implementation code is almost same with loadingIndicatorSource, but without rotation.

This requires release or production to bundle local images in an APK file.

This provides feature parity with iOS.

## Test Plan

Set Image.defaultSource on Android, and will show it while loading Image.source.

```JSX
<Image
  defaultSource={require('<path to image>')}
  source={{uri: '<url to remote image>'}}
  style={{ height: 300, width: 300 }}
/>
```

## Release Notes

[ANDROID] [FEATURE] [IMAGE] - Image.defaultSource will show local image as placeholder while loading remote Image.source.
