### PR TITLE
Turn off JS deltas by default

### DIFF
--- a/ReactAndroid/src/main/res/devsupport/xml/preferences.xml
+++ b/ReactAndroid/src/main/res/devsupport/xml/preferences.xml
@@ -23,7 +23,7 @@
       android:key="js_bundle_deltas"
       android:title="Use JS Deltas"
       android:summary="Request delta bundles from metro to get faster reloads (Experimental)"
-      android:defaultValue="true"
+      android:defaultValue="false"
       />
     <CheckBoxPreference
         android:key="animations_debug"


### PR DESCRIPTION
Use JS deltas prevents resolving source maps when using remote debugging:

https://github.com/facebook/react-native/issues/18416

This doesn't fix the underlying issue but I don't think a feature that describes itself as experimental should be enabled by default.

## Test Plan

Attempt to do remote debugging on an Android device in 0.54.2

## Related PRs

None.

## Release Notes

[ANDROID] [BUGFIX] [Preferences] - Disable using JS deltas by default.
