### PR TITLE
ViewPagerAndroid: measure and layout after adding a view to the container

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/viewpager/ReactViewPager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/viewpager/ReactViewPager.java
@@ -36,24 +36,11 @@ public class ReactViewPager extends ViewPager {
     void addView(View child, int index) {
       mViews.add(index, child);
       notifyDataSetChanged();
-      // This will prevent view pager from detaching views for pages that are not currently selected
-      // We need to do that since {@link ViewPager} relies on layout passes to position those views
-      // in a right way (also thanks to {@link ReactViewPagerManager#needsCustomLayoutForChildren}
-      // returning {@code true}). Currently we only call {@link View#measure} and
-      // {@link View#layout} after yoga step.
-
-      // TODO(7323049): Remove this workaround once we figure out a way to re-layout some views on
-      // request
-      setOffscreenPageLimit(mViews.size());
     }
 
     void removeViewAt(int index) {
       mViews.remove(index);
       notifyDataSetChanged();
-
-      // TODO(7323049): Remove this workaround once we figure out a way to re-layout some views on
-      // request
-      setOffscreenPageLimit(mViews.size());
     }
 
     /**
@@ -102,6 +89,7 @@ public class ReactViewPager extends ViewPager {
     public Object instantiateItem(ViewGroup container, int position) {
       View view = mViews.get(position);
       container.addView(view, 0, generateDefaultLayoutParams());
+      post(measureAndLayout);
       return view;
     }
 


### PR DESCRIPTION
Currently, when adding views to ViewPagerAndroid after it was attached, those views would not show up as they had a size of 0. This fixes that by measuring and layouting after adding a view to the container.

Fixes #14296

## Test Plan

See https://github.com/danilobuerger/react-native-viewpagerandroid-dynamic

1. yarn install
2. yarn run android
3. You will see two pages
4. Press "ADDPAGE"
5. Scroll to the third page, it will be empty
6. Use react-native master with this patch
7. yarn run android
8. You will see two pages
9. Press "ADDPAGE"
10. Scroll to the third page, it will show "3 page (Scroll Me)"

## Related PRs

Relates to #14867 (ping @satya164 / @hramos)

## Release Notes

[ANDROID] [BUGFIX] [ViewPagerAndroid] - Fixed rendering of dynamically added views
