### PR TITLE
Always write the manifest in multiRemove

### DIFF
--- a/React/Modules/RCTAsyncLocalStorage.m
+++ b/React/Modules/RCTAsyncLocalStorage.m
@@ -423,10 +423,8 @@ RCT_EXPORT_METHOD(multiRemove:(NSArray<NSString *> *)keys
         NSString *filePath = [self _filePathForKey:key];
         [[NSFileManager defaultManager] removeItemAtPath:filePath error:nil];
         [RCTGetCache() removeObjectForKey:key];
-        // remove the key from manifest, but no need to mark as changed just for
-        // this, as the cost of checking again next time is negligible.
-        [_manifest removeObjectForKey:key];
-      } else if (_manifest[key]) {
+      }
+      if (_manifest[key]) {
         changedManifest = YES;
         [_manifest removeObjectForKey:key];
       }


### PR DESCRIPTION
RCTAsyncLocalStorage did not write the manifest after removing a value that was larger than RCTInlineValueThreshold. This meant that the values would still be on disk as null in the manifest.json, and if the app didn't do anything to make the manifest get written out again the null values would persist in the AsyncStorage and be returned by getAllKeys. We need to always write out the manifest.json even if the value is in the overflow storage files.

Thank you for sending the PR! We appreciate you spending the time to work on these changes. 
Help us understand your motivation by explaining why you decided to make this change.

Fixes #9196.

## Test Plan

Not sure where the tests are for this?

## Related PRs

none.

## Release Notes

[IOS] [BUGFIX] [AsyncStorage] - Correctly remove keys of large values from AsyncStorage.

@tadeuzagallo @nicklockwood @dannycochran 