### PR TITLE
Suggest git apply --reject for failed upgrades

### DIFF
--- a/react-native-git-upgrade/cliEntry.js
+++ b/react-native-git-upgrade/cliEntry.js
@@ -376,7 +376,9 @@ async function run(requestedVersion, cliArgs) {
     } catch (err) {
       log.warn(
         'The upgrade process succeeded but there might be conflicts to be resolved. ' +
-        'See above for the list of files that have merge conflicts.');
+        'See above for the list of files that have merge conflicts. ' +
+        'If you don’t see the expected changes, try running:\n' +
+        `git apply --reject ${patchPath}`);
     } finally {
       log.info('Upgrade done');
       if (cliArgs.verbose) {


### PR DESCRIPTION
The upgrade script uses `git apply --3way`:

https://github.com/facebook/react-native/blob/4906f8d28cdbaf1b432494b473a4c61c1e193881/react-native-git-upgrade/cliEntry.js#L368-L369

If you've already upgraded something that React Native upgraded, this will silently fail. For example if you have already upgraded Gradle to the version available in the new version of React Native, the 3-way patch will fail. In this case, the upgraded version is installed into `node_modules` but `package.json` is not updated. More context, discussion, and information is in https://github.com/facebook/react-native/issues/12112#issuecomment-292619346.

Until a more robust solution is implemented, this PR proposes to mitigate the effects of the problem by informing the user of the possible issue and instructing them of a workaround.

## Test Plan

In an affected project, I ran `react-native-git-upgrade` after applying my patch.

As expected, I now receive the following output:

![image](https://user-images.githubusercontent.com/789577/38165770-6209ac68-34de-11e8-9d96-7c782e9ef7ce.png)

After running the suggested command, `git status` now shows me the two rejections:

![image](https://user-images.githubusercontent.com/789577/38165796-d10ca7c8-34de-11e8-9037-8427513e3a84.png)

And I can now [manually apply](https://stackoverflow.com/a/28569128/1445366) these changes.

## Related PRs

#17266 proposed to solve the problem by switching from `--3way` to `--reject` entirely, which I think was a subpar solution since `--3way` is the happy path. This PR was closed due to the author not signing the CLA.

## Release Notes

[CLI] [ENHANCEMENT] [react-native-git-upgrade/cliEntry.js] - Provide instructions for upgrading React Native when 3-way merges don't apply
