### PR TITLE
Allow for undefined userConfig

### DIFF
--- a/local-cli/core/__tests__/android/getProjectConfig.spec.js
+++ b/local-cli/core/__tests__/android/getProjectConfig.spec.js
@@ -37,6 +37,13 @@ describe('android::getProjectConfig', () => {
     });
   });
 
+  it("returns `null` if manifest file hasn't been found and userConfig is not defined", () => {
+    const userConfig = undefined;
+    const folder = '/noManifest';
+
+    expect(getProjectConfig(folder, userConfig)).toBeNull();
+  });
+
   it("returns `null` if manifest file hasn't been found", () => {
     const userConfig = {};
     const folder = '/noManifest';

--- a/local-cli/core/android/index.js
+++ b/local-cli/core/android/index.js
@@ -18,7 +18,7 @@ const getPackageName = (manifest) => manifest.attr.package;
  * Gets android project config by analyzing given folder and taking some
  * defaults specified by user into consideration
  */
-exports.projectConfig = function projectConfigAndroid(folder, userConfig) {
+exports.projectConfig = function projectConfigAndroid(folder, userConfig = {}) {
   const src = userConfig.sourceDir || findAndroidAppFolder(folder);
 
   if (!src) {
@@ -89,7 +89,7 @@ exports.projectConfig = function projectConfigAndroid(folder, userConfig) {
  * Same as projectConfigAndroid except it returns
  * different config that applies to packages only
  */
-exports.dependencyConfig = function dependencyConfigAndroid(folder, userConfig) {
+exports.dependencyConfig = function dependencyConfigAndroid(folder, userConfig = {}) {
   const src = userConfig.sourceDir || findAndroidAppFolder(folder);
 
   if (!src) {


### PR DESCRIPTION
Fixes #18249 

This PR fixes an error that occurs when running `react-native link` in projects laid out as described on the React Native website section on integrating with existing apps (https://facebook.github.io/react-native/docs/integration-with-existing-apps.html) where an `ios/` subdirectory exists but an `android/` subdirectory does not exist

## Test Plan

<img width="1050" alt="screenshot 2018-04-02 14 57 27" src="https://user-images.githubusercontent.com/2475286/38210733-3f4bd9ea-3686-11e8-9bd3-d299812a015c.png">

## Related PRs

None

## Release Notes

[CLI] [BUGFIX] [local-cli/core/android/index.js] - Allow for undefined userConfig