### PR TITLE
Fix crash during Archiving project in IOS

### DIFF
--- a/Libraries/Image/RCTImageCache.m
+++ b/Libraries/Image/RCTImageCache.m
@@ -14,6 +14,7 @@
 #import <React/RCTConvert.h>
 #import <React/RCTNetworking.h>
 #import <React/RCTUtils.h>
+#import <React/RCTResizeMode.h>
 
 #import "RCTImageUtils.h"
 
@@ -22,8 +23,8 @@ static const NSUInteger RCTMaxCachableDecodedImageSizeInBytes = 1048576; // 1MB
 static NSString *RCTCacheKeyForImage(NSString *imageTag, CGSize size, CGFloat scale,
                                      RCTResizeMode resizeMode, NSString *responseDate)
 {
-    return [NSString stringWithFormat:@"%@|%g|%g|%g|%lld|%@",
-            imageTag, size.width, size.height, scale, (long long)resizeMode, responseDate];
+  return [NSString stringWithFormat:@"%@|%g|%g|%g|%lld|%@",
+          imageTag, size.width, size.height, scale, (long long)resizeMode, responseDate];
 }
 
 @implementation RCTImageCache
@@ -36,7 +37,7 @@ static NSString *RCTCacheKeyForImage(NSString *imageTag, CGSize size, CGFloat sc
 {
   _decodedImageCache = [NSCache new];
   _decodedImageCache.totalCostLimit = 5 * 1024 * 1024; // 5MB
-
+  
   [[NSNotificationCenter defaultCenter] addObserver:self
                                            selector:@selector(clearCache)
                                                name:UIApplicationDidReceiveMemoryWarningNotification
@@ -45,7 +46,7 @@ static NSString *RCTCacheKeyForImage(NSString *imageTag, CGSize size, CGFloat sc
                                            selector:@selector(clearCache)
                                                name:UIApplicationWillResignActiveNotification
                                              object:nil];
-
+  
   return self;
 }
 

--- a/Releases.md
+++ b/Releases.md
@@ -74,7 +74,6 @@ Go to [Circle CI](https://circleci.com/gh/facebook/react-native) and look for th
 
 Write the release notes, or post in [React Native Core Contributors](https://www.facebook.com/groups/reactnativeoss/) that the RC is ready to find a voluteer. You can also use [react-native-release-notes](https://github.com/knowbody/react-native-release-notes) to generate a draft of release notes.
 
-
 To go through all the commits that went into a release, one way is to use the GitHub compare view:
 
 ```

--- a/Releases.md
+++ b/Releases.md
@@ -74,6 +74,8 @@ Go to [Circle CI](https://circleci.com/gh/facebook/react-native) and look for th
 
 Write the release notes, or post in [React Native Core Contributors](https://www.facebook.com/groups/reactnativeoss/) that the RC is ready to find a voluteer. You can also use [react-native-release-notes](https://github.com/knowbody/react-native-release-notes) to generate a draft of release notes.
 
+Fix crash on latest iOS
+
 To go through all the commits that went into a release, one way is to use the GitHub compare view:
 
 ```

--- a/Releases.md
+++ b/Releases.md
@@ -74,7 +74,6 @@ Go to [Circle CI](https://circleci.com/gh/facebook/react-native) and look for th
 
 Write the release notes, or post in [React Native Core Contributors](https://www.facebook.com/groups/reactnativeoss/) that the RC is ready to find a voluteer. You can also use [react-native-release-notes](https://github.com/knowbody/react-native-release-notes) to generate a draft of release notes.
 
-Fix crash on latest iOS
 
 To go through all the commits that went into a release, one way is to use the GitHub compare view:
 


### PR DESCRIPTION
Thank you for sending the PR! We appreciate you spending the time to work on these changes. 
Help us understand your motivation by explaining why you decided to make this change.


  To fix issue that crash on XCode 9.3

## Test Plan

Archive the project in XCode 9.3

## Related PRs

This does not change any documentation
## Release Notes

 To fix issue that crash on XCode 9.3


 [IOS] [BREAKING] [RCTImageCache.m] - Crash during archiving in XCode 9.3

