### PR TITLE
Fix installing step of `run-ios` command

### DIFF
--- a/local-cli/runIOS/runIOS.js
+++ b/local-cli/runIOS/runIOS.js
@@ -24,7 +24,7 @@ const getBuildPath = function (configuration = 'Debug', appName, isDevice) {
     device = 'iphonesimulator';
   }
 
-  return `Build/Products/${configuration}-${device}/${appName}.app`;
+  return `build/Build/Products/${configuration}-${device}/${appName}.app`;
 };
 const xcprettyAvailable = function() {
   try {


### PR DESCRIPTION
To date if you create a new `react-native@0.55.0` project and try to build/run it for iOS via CLI, e.g. by running:

```
$ react-native init test
$ cd test
$ react-native run-ios --no-packager
```

the build would succeed, but installing will fail afterwards:

```
** BUILD SUCCEEDED **


Installing Build/Products/Debug-iphonesimulator/test.app
An error was encountered processing the command (domain=NSPOSIXErrorDomain, code=2):
Failed to install the requested application
An application bundle was not found at the provided path.
Provide a valid path to the desired application bundle.
Print: Entry, ":CFBundleIdentifier", Does Not Exist

Command failed: /usr/libexec/PlistBuddy -c Print:CFBundleIdentifier Build/Products/Debug-iphonesimulator/test.app/Info.plist
Print: Entry, ":CFBundleIdentifier", Does Not Exist
```

This fail happens because `/usr/libexec/PlistBuddy` can't find `Info.plist` file at the provided path.

This is a regression introduced by changes from PR #17963 (accepted in https://github.com/facebook/react-native/commit/5447ca67076a110e2b0df03b014f53d1df4646ab). If you execute test plan from that PR, it would fail.

As per why:

By default, `run-ios` process's working directory is `$PROJECT_DIR/ios`.

According to [this line in `runIOS.js`](https://github.com/facebook/react-native/blob/3cd2b4342653d0cc6edfc9e7d436d73bfb4f139f/local-cli/runIOS/runIOS.js#L184), `xcodebuild` places all artifacts in `build` directory.

And the default Xcode paths for products is `Build/Products` (at least of Xcode 9.2 which I use, and Xcode 9.3 which I tested this with also).

So, the required `Info.plist` file is actually being created at `$PROJECT_DIR/ios/build/Build/Products/Debug-iphonesimulator/test.app/Info.plist` (with double `build`, the first from `derivedDataPath` key, the second from default products path). Relatively to `run-ios` process's working directory, the path of the file is `build/Build/Products/Debug-iphonesimulator/test.app/Info.plist`.

PR #17963 changed correct path to incorrect, thus introducing this regression.

If changes from that PR are reverted, CLI doesn't fail on install step.

I catch this error on both existing project and a freshly created test project. I can build/run an app from Xcode just fine, but running from CLI still would fail. The other workaround is to change path of products artifacts in Xcode, which is user settings and therefore can't be commited to a project's repo with VCS.

## Test Plan

Run:

```
$ react-native init test
$ cd test
$ react-native run-ios --no-packager
```

Ensure that it doesn't fail on install step and produce output similar to this:

```
Installing build/Build/Products/Debug-iphonesimulator/test.app
Launching org.reactjs.native.example.test
```

## Related PRs

#17963

## Release Notes

[CLI][BUGFIX][local-cli/runIOS/runIOS.js] - Fix failing of `run-ios` command on install step