### PR TITLE
TextInput - Add hideKeyboardOnSubmit prop

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
@@ -82,6 +82,7 @@ public class ReactEditText extends EditText {
   private final InternalKeyListener mKeyListener;
   private boolean mDetectScrollMovement = false;
   private float mLetterSpacingPt = 0;
+  private boolean mHideKeyboardOnSubmit = true;
 
   private ReactViewBackgroundManager mReactBackgroundManager;
 
@@ -155,7 +156,7 @@ public class ReactEditText extends EditText {
   // since we only allow JS to change focus, which in turn causes TextView to crash.
   @Override
   public boolean onKeyUp(int keyCode, KeyEvent event) {
-    if (keyCode == KeyEvent.KEYCODE_ENTER && !isMultiline()) {
+    if (keyCode == KeyEvent.KEYCODE_ENTER && !isMultiline() && getHideKeyboardOnSubmit()) {
       hideSoftKeyboard();
       return true;
     }
@@ -650,6 +651,14 @@ public class ReactEditText extends EditText {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
       setLetterSpacing(PixelUtil.toPixelFromSP(mLetterSpacingPt) / getTextSize());
     }
+  }
+
+  public void setHideKeyboardOnSubmit(Boolean hideKeyboardOnSubmit) {
+    mHideKeyboardOnSubmit = hideKeyboardOnSubmit;
+  }
+
+  public boolean getHideKeyboardOnSubmit() {
+    return mHideKeyboardOnSubmit;
   }
 
   /**

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
@@ -659,6 +659,11 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
     }
   }
 
+  @ReactProp(name = "hideKeyboardOnSubmit", defaultBoolean = true)
+  public void setHideKeyboardOnSubmit(ReactEditText view, Boolean hideKeyboardOnSubmit) {
+    view.setHideKeyboardOnSubmit(hideKeyboardOnSubmit);
+  }
+
   /**
    * This code was taken from the method parseNumericFontWeight of the class ReactTextShadowNode
    * TODO: Factor into a common place they can both use

--- a/ReactAndroid/src/test/java/com/facebook/react/views/textinput/TextInputTest.java
+++ b/ReactAndroid/src/test/java/com/facebook/react/views/textinput/TextInputTest.java
@@ -12,7 +12,6 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 
-import android.widget.EditText;
 import com.facebook.react.ReactRootView;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.JavaOnlyArray;
@@ -95,7 +94,7 @@ public class TextInputTest {
         ReactTextInputManager.REACT_CLASS,
         rootTag,
         JavaOnlyMap.of(
-            ViewProps.FONT_SIZE, 13.37, ViewProps.HEIGHT, 20.0, "placeholder", hintStr));
+            ViewProps.FONT_SIZE, 13.37, ViewProps.HEIGHT, 20.0, "placeholder", hintStr, "hideKeyboardOnSubmit", false));
 
     uiManager.manageChildren(
         rootTag,
@@ -108,10 +107,11 @@ public class TextInputTest {
     uiManager.onBatchComplete();
     executePendingChoreographerCallbacks();
 
-    EditText editText = (EditText) rootView.getChildAt(0);
+    ReactEditText editText = (ReactEditText) rootView.getChildAt(0);
     assertThat(editText.getHint()).isEqualTo(hintStr);
     assertThat(editText.getTextSize()).isEqualTo((float) Math.ceil(13.37));
     assertThat(editText.getHeight()).isEqualTo(20);
+    assertThat(editText.getHideKeyboardOnSubmit()).isEqualTo(false);
   }
 
   @Test
@@ -129,7 +129,7 @@ public class TextInputTest {
         ReactTextInputManager.REACT_CLASS,
         rootTag,
         JavaOnlyMap.of(
-            ViewProps.FONT_SIZE, 13.37, ViewProps.HEIGHT, 20.0, "placeholder", hintStr));
+            ViewProps.FONT_SIZE, 13.37, ViewProps.HEIGHT, 20.0, "placeholder", hintStr, "hideKeyboardOnSubmit", true));
 
     uiManager.manageChildren(
         rootTag,
@@ -141,25 +141,27 @@ public class TextInputTest {
     uiManager.onBatchComplete();
     executePendingChoreographerCallbacks();
 
-    EditText editText = (EditText) rootView.getChildAt(0);
+    ReactEditText editText = (ReactEditText) rootView.getChildAt(0);
     assertThat(editText.getHint()).isEqualTo(hintStr);
     assertThat(editText.getTextSize()).isEqualTo((float) Math.ceil(13.37));
     assertThat(editText.getHeight()).isEqualTo(20);
+    assertThat(editText.getHideKeyboardOnSubmit()).isEqualTo(true);
 
     final String hintStr2 = "such hint";
     uiManager.updateView(
         textInputTag,
         ReactTextInputManager.REACT_CLASS,
         JavaOnlyMap.of(
-            ViewProps.FONT_SIZE, 26.74, ViewProps.HEIGHT, 40.0, "placeholder", hintStr2));
+            ViewProps.FONT_SIZE, 26.74, ViewProps.HEIGHT, 40.0, "placeholder", hintStr2, "hideKeyboardOnSubmit", false));
 
     uiManager.onBatchComplete();
     executePendingChoreographerCallbacks();
 
-    EditText updatedEditText = (EditText) rootView.getChildAt(0);
+    ReactEditText updatedEditText = (ReactEditText) rootView.getChildAt(0);
     assertThat(updatedEditText.getHint()).isEqualTo(hintStr2);
     assertThat(updatedEditText.getTextSize()).isEqualTo((float) Math.ceil(26.74f));
     assertThat(updatedEditText.getHeight()).isEqualTo(40);
+    assertThat(updatedEditText.getHideKeyboardOnSubmit()).isEqualTo(false);
   }
 
   private void executePendingChoreographerCallbacks() {


### PR DESCRIPTION
Today, when we press `Enter` after write in a input, the keyboard is being hide by default, this is a normal approach, but here at @loggi we come into a case that we want to keep the keyboard open when the user press enter in a input.

## Test Plan
To test it, you pass the prop as `false` for `TextInput`, type something and press `enter`, the keyboard should stay open.
* I added a unit test to check if prop is being propagate for the component, but looks like unit tests are disable for **textinput**.

## Release Notes

[GENERAL] [ENHANCEMENT] [TextInput] - Adding a prop called `hideKeyboardOnSubmit`, it controls if the keyboard will be hidden or not when press `enter/return`.
