### PR TITLE
"Fix" `Print: Entry, ":CFBundleIdentifier", Does Not Exist` error

### DIFF
--- a/local-cli/runIOS/runIOS.js
+++ b/local-cli/runIOS/runIOS.js
@@ -227,10 +227,8 @@ function buildProject(xcodeProject, udid, scheme, configuration = 'Debug', launc
       }
       //FULL_PRODUCT_NAME is the actual file name of the app, which actually comes from the Product Name in the build config, which does not necessary match a scheme name,  example output line: export FULL_PRODUCT_NAME="Super App Dev.app"
       let productNameMatch = /export FULL_PRODUCT_NAME="?(.+).app"?$/m.exec(buildOutput);
-      if (productNameMatch && productNameMatch.length && productNameMatch.length > 1) {
-        return resolve(productNameMatch[1]);//0 is the full match, 1 is the app name
-      }
-      return buildProcess.error ? reject(buildProcess.error) : resolve();
+      //[0] of productNameMatch is the full match, [1] is the app name
+      return resolve(productNameMatch && productNameMatch.length && productNameMatch.length > 1 ? productNameMatch[1] : undefined);
     });
   });
 }


### PR DESCRIPTION
Hi. If a build triggered by `run-ios` command fails, the execution continues and `Print: Entry, ":CFBundleIdentifier", Does Not Exist` error is shown. Often that's the last thing people see in console output and they decide that's an issue they're having, when in reality they have build errors.

Take a look at this sample output (don't mind failed build command, that's just me messing with some random files to make builds to fail):

```
** BUILD FAILED **


The following build commands failed:
	CompileC /Users/angly/Work/test/ios/build/Build/Intermediates.noindex/React.build/Debug-iphonesimulator/yoga.build/Objects-normal/x86_64/YGNodePrint.o /Users/angly/Work/test/node_modules/react-native/ReactCommon/yoga/yoga/YGNodePrint.cpp normal x86_64 c++ com.apple.compilers.llvm.clang.1_0.compiler
(1 failure)

Installing build/Build/Products/Debug-iphonesimulator/test.app
An error was encountered processing the command (domain=NSPOSIXErrorDomain, code=2):
Failed to install the requested application
An application bundle was not found at the provided path.
Provide a valid path to the desired application bundle.
Print: Entry, ":CFBundleIdentifier", Does Not Exist

Command failed: /usr/libexec/PlistBuddy -c Print:CFBundleIdentifier build/Build/Products/Debug-iphonesimulator/test.app/Info.plist
Print: Entry, ":CFBundleIdentifier", Does Not Exist
```

The part of script that produces output that starts with `Installing` shouldn't be executed if a build is failed.

I've checked `local-cli/runIOS/runIOS.js` file and discovered that `buildProcess.error` is never truthy and there isn't really any checks if a build is failed. This PR changes that. And make process to exit with non-zero exit code on build fails.

## Test Plan

Create a blank project. Run `react-native run-ios` in it's folder. See that all is ok (that this PR doesn't break successful builds). Mess with some random files to get a build to fail, run `react-native run-ios` again. See that on build fails the script doesn't try to install non-existent app and therefore doesn't produce `Print: Entry, ":CFBundleIdentifier", Does Not Exist` error.

## Release Notes

[CLI][BUGFIX][local-cli/runIOS/runIOS.js] - Stop script execution on build fails