### PR TITLE
Fix launching iOS simulator regression

### DIFF
--- a/local-cli/runIOS/runIOS.js
+++ b/local-cli/runIOS/runIOS.js
@@ -115,15 +115,12 @@ function runOnSimulator(xcodeProject, args, scheme) {
 
     if (!selectedSimulator.booted) {
       const simulatorFullName = formattedDeviceName(selectedSimulator);
-      console.log(`Booting ${simulatorFullName}...`);
+      console.log(`Launching ${simulatorFullName}...`);
       try {
-        child_process.execFileSync('xcrun', ['simctl', 'boot', selectedSimulator.udid]);
+        child_process.spawnSync('xcrun', ['instruments', '-w', selectedSimulator.udid]);
       } catch (e) {
-        throw new Error(
-`Could not boot ${args.simulator} simulator. Is there already a simulator running?
-Running multiple simulators is only supported from Xcode 9 and up.
-Try closing the simulator or run the command again without specifying a simulator.`
-        );
+        // instruments always fail with 255 because it expects more arguments,
+        // but we want it to only launch the simulator
       }
     }
 


### PR DESCRIPTION
PR #17284 (accepted in 2ad34075f1d048bebb08ef30799ac0d081073150) introduced a couple of regressions.

~1. There's the code:~
```
.then((appName) => resolve(selectedSimulator.udid, appName));
/* ... */
.then((udid, appName) => {
```

~~This makes `appName` to be always `undefined` as per `resolve` accepts only 1 argument. This regression causes issues if an app name differs from a scheme name.~

~This PR fixes this by wrapping both values in an array.~

This was fixed in 589eae1432cc4bbc16221f841e27b038099fd128.

2. The code
```
child_process.execFileSync('xcrun', ['simctl', 'boot', selectedSimulator.udid]);
```
makes a simulator *boot*, but the simulator *doesn't launch*. That's a regression, which forces developers to launch simulators by other means (by running a number of elaborate console commands, by running Xcode, or by running a simulator manually).

This PR reverts that part of changes.

## Test Plan

Create a blank project with a name that differs from scheme name. Try to `react-native run-ios` in it. See that a simulator is launched and installing succeeds. Without this changes simulator wouldn't launch, and installing step would fail because of app name mismatch.

## Related PRs

#17284

## Release Notes

[CLI][BUGFIX][local-cli/runIOS/runIOS.js] - Fix running on multiple simulators feature regressions