### PR TITLE
Fix #18279: Add 'addNetworkingHandler' to jest mock setup

### DIFF
--- a/jest/setup.js
+++ b/jest/setup.js
@@ -297,6 +297,7 @@ const mockNativeModules = {
   BlobModule: {
     BLOB_URI_SCHEME: 'content',
     BLOB_URI_HOST: null,
+    addNetworkingHandler: jest.fn(),
     enableBlobSupport: jest.fn(),
     disableBlobSupport: jest.fn(),
     createFromParts: jest.fn(),


### PR DESCRIPTION
Fixes #18279 by adding the correct methods to the jest mocks setup file.

## Test Plan

Test by no longer including the workarounds in [issue comments](https://github.com/facebook/react-native/issues/18279#issuecomment-374177940). A [comment from @hramos](https://github.com/facebook/react-native/issues/18279#issuecomment-371914037) mentioned improving the test coverage as well, but I wasn't certain how to achieve that.

## Release Notes

[GENERAL] [BUGFIX] [BlobManager] - Fixed the jest mocks to avoid breaking tests
