### PR TITLE
Fix `run-ios` not turning on Simulator app

### DIFF
--- a/local-cli/runIOS/runIOS.js
+++ b/local-cli/runIOS/runIOS.js
@@ -112,6 +112,24 @@ function runOnSimulator(xcodeProject, args, scheme) {
     if (!selectedSimulator) {
       throw new Error(`Could not find ${args.simulator} simulator`);
     }
+    
+    /**
+		 * Booting simulator through `xcrun simctl boot` will boot it in the `headless` mode
+		 * (running in the background).
+		 *
+		 * In order for user to see the app and the simulator itself, we have to make sure
+		 * that the Simulator.app is running.
+		 *
+		 * We also pass it `-CurrentDeviceUDID` so that when we launch it for the first time,
+		 * it will not boot the "default" device, but the one we set. If the app is already running,
+		 * this flag has no effect.
+		 */
+		child_process.execFileSync('open', [
+			'/Applications/Xcode.app/Contents/Developer/Applications/Simulator.app',
+			'--args',
+			'-CurrentDeviceUDID',
+			selectedSimulator.udid
+		]);
 
     if (!selectedSimulator.booted) {
       const simulatorFullName = formattedDeviceName(selectedSimulator);


### PR DESCRIPTION
Right now, `run-ios` will "boot" Simulator in the headless mode in the background, as long as the Simulator.app is not running. It is exactly what "detox" does - it executes your test suite in the background.

It seems to me that the author of this change was testing it with `Simulator.app` open.

In order to fix this behavior, we have to make sure it runs before we attempt booting.

This passed through the release process since we don't use `run-ios` there (it recommends turning on XCode and testing manually which is what I have done recently too).

CC: @kelset @koenpunt @hramos 

Related: #18681