### PR TITLE
Add requiresImmediateCxxNativeModuleSetup property to RCTCxxModule and immediately initialize CxxNativeModule if true.

### DIFF
--- a/React/Base/RCTModuleData.h
+++ b/React/Base/RCTModuleData.h
@@ -60,6 +60,11 @@ typedef id<RCTBridgeModule>(^RCTBridgeModuleProvider)(void);
 @property (nonatomic, assign) BOOL requiresMainQueueSetup;
 
 /**
+ * Returns YES if Cxx native module instance must be created at startup.
+ */
+@property (nonatomic, assign) BOOL requiresImmediateCxxNativeModuleSetup;
+
+/**
  * Returns YES if module has constants to export.
  */
 @property (nonatomic, assign, readonly) BOOL hasConstantsToExport;

--- a/React/Base/RCTModuleData.mm
+++ b/React/Base/RCTModuleData.mm
@@ -67,6 +67,13 @@
         "on a background thread unless explicitly opted-out of.", _moduleClass, methodName);
     }
   }
+    
+  const BOOL implementsRequiresImmediateCxxNativeModuleSetup = [_moduleClass respondsToSelector:@selector(requiresImmediateCxxNativeModuleSetup)];
+  if (implementsRequiresImmediateCxxNativeModuleSetup) {
+    _requiresImmediateCxxNativeModuleSetup = [_moduleClass requiresImmediateCxxNativeModuleSetup];
+  } else {
+    _requiresImmediateCxxNativeModuleSetup = NO;
+  }
 }
 
 - (instancetype)initWithModuleClass:(Class)moduleClass

--- a/React/CxxModule/RCTCxxModule.mm
+++ b/React/CxxModule/RCTCxxModule.mm
@@ -31,6 +31,11 @@ using namespace facebook::react;
   return NO;
 }
 
++ (BOOL)requiresImmediateCxxNativeModuleSetup
+{
+  return NO;
+}
+
 - (void)lazyInit
 {
   if (!_module) {

--- a/React/CxxModule/RCTCxxUtils.mm
+++ b/React/CxxModule/RCTCxxUtils.mm
@@ -28,6 +28,7 @@ std::vector<std::unique_ptr<NativeModule>> createNativeModules(NSArray<RCTModule
       nativeModules.emplace_back(std::make_unique<CxxNativeModule>(
         instance,
         [moduleData.name UTF8String],
+        [moduleData requiresImmediateCxxNativeModuleSetup],
         [moduleData] { return [(RCTCxxModule *)(moduleData.instance) createModule]; },
         std::make_shared<DispatchMessageQueueThread>(moduleData)));
     } else {

--- a/ReactAndroid/src/main/jni/react/jni/ModuleRegistryBuilder.cpp
+++ b/ReactAndroid/src/main/jni/react/jni/ModuleRegistryBuilder.cpp
@@ -44,7 +44,7 @@ std::vector<std::unique_ptr<NativeModule>> buildNativeModuleList(
   if (cxxModules) {
     for (const auto& cm : *cxxModules) {
       modules.emplace_back(folly::make_unique<CxxNativeModule>(
-                             winstance, cm->getName(), cm->getProvider(), moduleMessageQueue));
+                             winstance, cm->getName(), false, cm->getProvider(), moduleMessageQueue));
     }
   }
   return modules;

--- a/ReactCommon/cxxreact/CxxNativeModule.h
+++ b/ReactCommon/cxxreact/CxxNativeModule.h
@@ -22,12 +22,17 @@ class RN_EXPORT CxxNativeModule : public NativeModule {
 public:
   CxxNativeModule(std::weak_ptr<Instance> instance,
                   std::string name,
+                  bool requiresImmediateInit,
                   xplat::module::CxxModule::Provider provider,
                   std::shared_ptr<MessageQueueThread> messageQueueThread)
   : instance_(instance)
   , name_(std::move(name))
   , provider_(provider)
-  , messageQueueThread_(messageQueueThread) {}
+  , messageQueueThread_(messageQueueThread) {
+      if (requiresImmediateInit) {
+          lazyInit();
+      }
+  }
 
   std::string getName() override;
   std::vector<MethodDescriptor> getMethods() override;


### PR DESCRIPTION
This allows for CxxModules with methods which require a bridge instance (for example, emitting an event) to be called from native code, without requiring them to be initialised by some other means (e.g. being called from Javascript, or calling `getMethods`) first.

## Rationale

I have been experimenting with using pure C++ modules with React Native, as our application is made up of a C++ core with a React Native UI, and makes use of a lot of communication both ways across the bridge. Creating Objective C wrappers for every call has proven to be quite verbose, so native C++ modules would be quite a productivity and code complexity win.

Unfortunately there isn't a great deal of documentation around this topic, so I've been figuring it out as I go along.

I was able to create a CxxModule accessible from Javascript, but as described in https://github.com/facebook/react-native/issues/18509, I've been having issues getting a reference to the CxxModule from native code in order to emit events from C++ to Javascript.

The crux of the issue seems to be that the module instance returned from e.g. `moduleForName` is the `CxxModule` rather than `CxxNativeModule` instance, and so has no `_instance` set, and therefore cannot communicate back to React Native. In addition to this, the module is not initialised until you either call into it from Javascript or call e.g. `getMethods`, and accessing modules this way requires Objective C code to access the bridge and get the module instance so is not pure C++.

I've spent quite a lot of time looking at the React Native source code, attempting to determine why things work the way they do, and have considered several approaches to solving this problem (e.g. providing a way to get the `CxxNativeModule` from the module registry via the bridge), but after a lot of experimentation, I decided upon the approach in this PR. It is the smallest change I could think of to achieve the goals, and is low risk in the sense that it opt-in and does not modify the default behaviour of React Native.

## Example code

I've created a simple example of how this can be used at https://github.com/tomduncalf/react-native-cxx-module/tree/working - the relevant part is in https://github.com/tomduncalf/react-native-cxx-module/tree/working/ios/rnfresh/ReactNative, and the changes from the "not working" version can be seen at https://github.com/tomduncalf/react-native-cxx-module/commit/40235ce2e541508a09a3463133c5b7a9bae60f06

By specifying that a module requires immediate CxxNativeModule setup, we know that the constructor of the CxxModule will be called at app startup time, then we can store a reference to it somewhere shared (in this case, the `ModuleRegistry`, which could equally be a singleton), and we can then access a fully working instance of our module anywhere from our native codebase.

Note that this code is currently iOS only - any advice on the right approach for Android would be welcome, but I am currently not targetting Android so have no device to test on.

If this is not the right approach I'd be very happy to discuss further - I thought this was a good way to get the ball rolling, as there are no docs about this and it would be a massive help for our project!

## Test Plan

Tested in existing project and in the simple example above. There appear to be no automated tests around this area, but the change is low risk in that it does not change defaults.

## Related PRs

There is no related documentation, but I'd be happy to create some if we are happy with this approach!

## Release Notes

<!--
  Required.
  Help reviewers and the release process by writing your own release notes. See below for an example.
-->

[INTERNAL] [ENHANCEMENT] [CxxModule] - Allow a RCTCxxModule to specify that it `requiresImmediateCxxNativeModuleSetup`, which will cause the module to be immediately initialised rather than lazily.

<!--
  **INTERNAL and MINOR tagged notes will not be included in the next version's final release notes.**

    CATEGORY
  [----------]      TYPE
  [ CLI      ] [-------------]    LOCATION
  [ DOCS     ] [ BREAKING    ] [-------------]
  [ GENERAL  ] [ BUGFIX      ] [ {Component} ]
  [ INTERNAL ] [ ENHANCEMENT ] [ {Filename}  ]
  [ IOS      ] [ FEATURE     ] [ {Directory} ]   |-----------|
  [ ANDROID  ] [ MINOR       ] [ {Framework} ] - | {Message} |
  [----------] [-------------] [-------------]   |-----------|

 EXAMPLES:

 [IOS] [BREAKING] [FlatList] - Change a thing that breaks other things
 [ANDROID] [BUGFIX] [TextInput] - Did a thing to TextInput
 [CLI] [FEATURE] [local-cli/info/info.js] - CLI easier to do things with
 [DOCS] [BUGFIX] [GettingStarted.md] - Accidentally a thing/word
 [GENERAL] [ENHANCEMENT] [Yoga] - Added new yoga thing/position
 [INTERNAL] [FEATURE] [./scripts] - Added thing to script that nobody will see
-->
