### PR TITLE
fix use of C++ syntax in an header file

### DIFF
--- a/React/Base/Surface/SurfaceHostingView/RCTSurfaceHostingView.mm
+++ b/React/Base/Surface/SurfaceHostingView/RCTSurfaceHostingView.mm
@@ -70,8 +70,8 @@ RCT_NOT_IMPLEMENTED(- (nullable instancetype)initWithCoder:(NSCoder *)coder)
   RCTSurfaceMinimumSizeAndMaximumSizeFromSizeAndSizeMeasureMode(
     self.bounds.size,
     _sizeMeasureMode,
-    minimumSize,
-    maximumSize
+    &minimumSize,
+    &maximumSize
   );
 
   [_surface setMinimumSize:minimumSize
@@ -107,8 +107,8 @@ RCT_NOT_IMPLEMENTED(- (nullable instancetype)initWithCoder:(NSCoder *)coder)
   RCTSurfaceMinimumSizeAndMaximumSizeFromSizeAndSizeMeasureMode(
     size,
     _sizeMeasureMode,
-    minimumSize,
-    maximumSize
+    &minimumSize,
+    &maximumSize
   );
 
   return [_surface sizeThatFitsMinimumSize:minimumSize

--- a/React/Base/Surface/SurfaceHostingView/RCTSurfaceSizeMeasureMode.h
+++ b/React/Base/Surface/SurfaceHostingView/RCTSurfaceSizeMeasureMode.h
@@ -28,6 +28,6 @@ typedef NS_OPTIONS(NSInteger, RCTSurfaceSizeMeasureMode) {
 RCT_EXTERN void RCTSurfaceMinimumSizeAndMaximumSizeFromSizeAndSizeMeasureMode(
   CGSize size,
   RCTSurfaceSizeMeasureMode sizeMeasureMode,
-  CGSize &minimumSize,
-  CGSize &maximumSize
+  CGSize *minimumSize,
+  CGSize *maximumSize
 );

--- a/React/Base/Surface/SurfaceHostingView/RCTSurfaceSizeMeasureMode.mm
+++ b/React/Base/Surface/SurfaceHostingView/RCTSurfaceSizeMeasureMode.mm
@@ -12,25 +12,25 @@
 void RCTSurfaceMinimumSizeAndMaximumSizeFromSizeAndSizeMeasureMode(
   CGSize size,
   RCTSurfaceSizeMeasureMode sizeMeasureMode,
-  CGSize &minimumSize,
-  CGSize &maximumSize
+  CGSize *minimumSize,
+  CGSize *maximumSize
 ) {
-  minimumSize = CGSizeZero;
-  maximumSize = CGSizeMake(CGFLOAT_MAX, CGFLOAT_MAX);
+  *minimumSize = CGSizeZero;
+  *maximumSize = CGSizeMake(CGFLOAT_MAX, CGFLOAT_MAX);
 
   if (sizeMeasureMode & RCTSurfaceSizeMeasureModeWidthExact) {
-    minimumSize.width = size.width;
-    maximumSize.width = size.width;
+    minimumSize->width = size.width;
+    maximumSize->width = size.width;
   }
   else if (sizeMeasureMode & RCTSurfaceSizeMeasureModeWidthAtMost) {
-    maximumSize.width = size.width;
+    maximumSize->width = size.width;
   }
 
   if (sizeMeasureMode & RCTSurfaceSizeMeasureModeHeightExact) {
-    minimumSize.height = size.height;
-    maximumSize.height = size.height;
+    minimumSize->height = size.height;
+    maximumSize->height = size.height;
   }
   else if (sizeMeasureMode & RCTSurfaceSizeMeasureModeHeightAtMost) {
-    maximumSize.height = size.height;
+    maximumSize->height = size.height;
   }
 }


### PR DESCRIPTION
All public header files can be included from Obj-C and Swift, except RCTSurfaceSizeMeasureMode.h which contains C++ code.
 
## Test Plan

Change is trivial and can be validated by review.

## Related PRs

None.

## Release Notes

[IOS][BUGFIX][{RCTSurfaceSizeMeasureMode.h}] - fix use of C++ syntax in an header file that could be included from Obj-C and Swift
