### PR TITLE
Fix TouchHistoryMath import

### DIFF
--- a/Libraries/Interaction/PanResponder.js
+++ b/Libraries/Interaction/PanResponder.js
@@ -10,7 +10,7 @@
 'use strict';
 
 const InteractionManager = require('./InteractionManager');
-const TouchHistoryMath = require('TouchHistoryMath');
+const TouchHistoryMath = require('./TouchHistoryMath');
 
 const currentCentroidXOfTouchesChangedAfter = TouchHistoryMath.currentCentroidXOfTouchesChangedAfter;
 const currentCentroidYOfTouchesChangedAfter = TouchHistoryMath.currentCentroidYOfTouchesChangedAfter;


### PR DESCRIPTION
The reference needed to be updated after the file was moved in this commit:
https://github.com/facebook/react-native/commit/06085d38366373f3135074dc14e2c9871ca4fe29

Otherwise, results in the packager failing with the following error:
> Unable to resolve module TouchHistoryMath from /node_modules/react-native/Libraries/Interaction/PanResponder.js: Module TouchHistoryMath does not exist in the Haste module map