### PR TITLE
enhance RNTester android config

### DIFF
--- a/RNTester/android/app/build.gradle
+++ b/RNTester/android/app/build.gradle
@@ -58,9 +58,10 @@ import com.android.build.OutputFile
  */
 
 project.ext.react = [
+    cliPath: "$rootDir/local-cli/cli.js",
     bundleAssetName: "RNTesterApp.android.bundle",
     entryFile: file("../../js/RNTesterApp.android.js"),
-    root: "../../../",
+    root: "$rootDir",
     inputExcludes: ["android/**", "./**"]
 ]
 

--- a/RNTester/android/app/src/main/java/com/facebook/react/uiapp/RNTesterApplication.java
+++ b/RNTester/android/app/src/main/java/com/facebook/react/uiapp/RNTesterApplication.java
@@ -34,7 +34,7 @@ public class RNTesterApplication extends Application implements ReactApplication
 
     @Override
     public boolean getUseDeveloperSupport() {
-      return true;
+      return BuildConfig.DEBUG;
     }
 
     @Override


### PR DESCRIPTION
## Motivation

* cliPath is not config right
* root config can be better config instead of a relative path which can easily go wrong if location changed
* DeveloperSupport should only be in debug mode.

## Test Plan

* make https://github.com/facebook/react-native/pull/18732 change on local. 
* config signingConfig 
* execute `./gradlew :RNTester:android:app:assembleRelease`, and run app on device to check everything is fine.

## Related PRs

none

## Release Notes

[GENERAL][ENHANCEMENT][RNTester]