### PR TITLE
Expose InputAccessoryView Module

### DIFF
--- a/Libraries/react-native/react-native-implementation.js
+++ b/Libraries/react-native/react-native-implementation.js
@@ -26,6 +26,7 @@ const ReactNative = {
   get ImageBackground() { return require('ImageBackground'); },
   get ImageEditor() { return require('ImageEditor'); },
   get ImageStore() { return require('ImageStore'); },
+  get InputAccessoryView() { return require('InputAccessoryView') },
   get KeyboardAvoidingView() { return require('KeyboardAvoidingView'); },
   get ListView() { return require('ListView'); },
   get MaskedViewIOS() { return require('MaskedViewIOS'); },

--- a/RNTester/js/InputAccessoryViewExample.js
+++ b/RNTester/js/InputAccessoryViewExample.js
@@ -11,15 +11,18 @@
 
 'use strict';
 
-const Alert = require('Alert');
-const Button = require('Button');
-const InputAccessoryView = require('InputAccessoryView');
 const React = require('React');
-const ScrollView = require('ScrollView');
-const StyleSheet = require('StyleSheet');
-const Text = require('Text');
-const TextInput = require('TextInput');
-const View = require('View');
+const ReactNative = require('react-native');
+const {
+  Alert,
+  Button,
+  InputAccessoryView,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} = ReactNative;
 
 class Message extends React.PureComponent<*> {
   render() {


### PR DESCRIPTION
The latest release of react-native (0.55.2) does not expose the new `InputAccessoryView` component; It can't be accessed at all. This change fixes this problem.

## Test Plan

* Problem: Snack showing the problem: https://snack.expo.io/B1fDQRYif
* Proof: `RNTester` still works with adapted imports

## Related PRs

No related PRs.

## Release Notes

[IOS] [BUGFIX] [InputAccessoryView] - Expose `InputAccessoryView` so it can be imported
