### PR TITLE
Fix for scrollview android

### DIFF
--- a/Libraries/Components/ScrollView/ScrollView.js
+++ b/Libraries/Components/ScrollView/ScrollView.js
@@ -681,7 +681,7 @@ const ScrollView = createReactClass({
       }
     }
     if (Platform.OS === 'android') {
-      if (this.props.keyboardDismissMode === 'on-drag') {
+      if (this.props.keyboardDismissMode === 'on-drag' && this.state.isTouching) {
         dismissKeyboard();
       }
     }


### PR DESCRIPTION
# Motivation

Trying this again with a fresh pullrequest as the old one kept having issued due to rebasing.

Fixes #16635
the issue is a little serious if you use a scrollview which contains textinput, you will never get a chance to input something since keyboard will always be dismissed because of on-drag event if your scroll-view use the property: keyboardDismissMode ='on-drag'

# Test Plan
verify the issue #16635 and tested this fix worked

# Release Notes
[ANDROID] [BUGFIX] [ScrollView] - Check that isTouching is also set when dismissing keyboard with on-drag android.