### PR TITLE
Remove extra space in source_files

### DIFF
--- a/React.podspec
+++ b/React.podspec
@@ -84,7 +84,7 @@ Pod::Spec.new do |s|
 
   s.subspec "tvOS" do |ss|
     ss.dependency             "React/Core"
-    ss.source_files         = "React/**/RCTTV*.{h, m}"
+    ss.source_files         = "React/**/RCTTV*.{h,m}"
   end
 
   s.subspec "jschelpers" do |ss|


### PR DESCRIPTION
This was causing tvOS builds to fail because .m files weren’t being included.

## Test Plan

 - Add `tvOS` subspec to your project with a tvOS target.
 - Build
 - Profit.

## Release Notes

[TVOS] [BREAKING] [React.podspec] - Fix building for tvOS with CocoaPods