### PR TITLE
Re-add displayName to View

### DIFF
--- a/Libraries/Components/View/View.js
+++ b/Libraries/Components/View/View.js
@@ -33,6 +33,7 @@ export type Props = ViewProps;
  * @see http://facebook.github.io/react-native/docs/view.html
  */
 class View extends ReactNative.NativeComponent<Props> {
+  static displayName = 'View';
   static propTypes = ViewPropTypes;
   static childContextTypes = ViewContextTypes;
 


### PR DESCRIPTION
This was removed in https://github.com/facebook/react-native/commit/26734a8473ac2f5715f2b7a016f0cc8a15c6f073, which breaks my snapshot tests (jest + enzyme). I discovered it when updating react native from 0.52 to 0.55. It's a pretty minor thing, but the component is now showing up as `Component` instead of `View`.

Interestingly, the react dev tools still show `View`, so this might not be the correct way to fix this.

## Test Plan

Applied the change to my local project and re-ran tests. Things work!

Before:
```
 FAIL  src/components/container/__tests__/container.native.js (7.703s)
  <Container />
    ✕ renders natively (4782ms)

  ● <Container /> › renders natively

    expect(value).toMatchSnapshot()
    
    Received value does not match stored snapshot 1.
    
    - Snapshot
    + Received
    
    @@ -1,6 +1,6 @@
    - <View
    + <Component
        style={
          Array [
            Object {
              "borderColor": "#425263",
            },

      10 | describe("<Container />", () => {
      11 |     it("renders natively", () => {
    > 12 |         expect(shallow(<Container />).dive()).toMatchSnapshot();
      13 |     });
      14 | 
      15 |     it("doesn't pass classes through to native components", () => {
      
      at Object.<anonymous> (src/components/container/__tests__/container.native.js:12:47)
```

After:
```
 PASS  src/components/container/__tests__/container.native.js
  <Container />
    ✓ renders natively (414ms)
```

## Release Notes

[GENERAL] [BUGFIX] [View] - Fix `displayName` regression