### PR TITLE
Android ndk-build fix for ndk-r14+

### DIFF
--- a/ReactAndroid/src/main/jni/react/jni/Android.mk
+++ b/ReactAndroid/src/main/jni/react/jni/Android.mk
@@ -37,7 +37,7 @@ LOCAL_CFLAGS += $(CXX11_FLAGS)
 LOCAL_EXPORT_CPPFLAGS := $(CXX11_FLAGS)
 
 LOCAL_LDLIBS += -landroid
-LOCAL_SHARED_LIBRARIES := libfolly_json libfbjni libjsc libglog_init libyoga libprivatedata
+LOCAL_SHARED_LIBRARIES := libfolly_json libfb libjsc libglog_init libyoga libprivatedata
 LOCAL_STATIC_LIBRARIES := libreactnative
 
 include $(BUILD_SHARED_LIBRARY)


### PR DESCRIPTION
According to [ndk release notes](https://github.com/android-ndk/ndk/wiki/Changelog-r14-beta1#ndk-build) flag APP_ALLOW_MISSING_DEPS should be set to true in order to fix ndk-build tool.

## Test Plan
If it builds it will work. On older ndk flag is ignored.

## Release Notes
[ANDROID] [MINOR] [Application.mk]  - build with android-ndk-14+ supported

