### PR TITLE
cast to long to allow building with xcode 9.3, iOS 11.3

### DIFF
--- a/Libraries/Image/RCTImageCache.m
+++ b/Libraries/Image/RCTImageCache.m
@@ -24,8 +24,8 @@ static const NSUInteger RCTMaxCachableDecodedImageSizeInBytes = 1048576; // 1MB
 static NSString *RCTCacheKeyForImage(NSString *imageTag, CGSize size, CGFloat scale,
                                      RCTResizeMode resizeMode, NSString *responseDate)
 {
-    return [NSString stringWithFormat:@"%@|%g|%g|%g|%zd|%@",
-            imageTag, size.width, size.height, scale, resizeMode, responseDate];
+    return [NSString stringWithFormat:@"%@|%g|%g|%g|%lld|%@",
+            imageTag, size.width, size.height, scale, (long long)resizeMode, responseDate];
 }
 
 @implementation RCTImageCache

--- a/Libraries/Text/RCTTextField.m
+++ b/Libraries/Text/RCTTextField.m
@@ -90,7 +90,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
                               notifyDelegate:YES];
     }
   } else if (eventLag > RCTTextUpdateLagWarningThreshold) {
-    RCTLogWarn(@"Native TextInput(%@) is %zd events ahead of JS - try to make your JS faster.", _backedTextInput.text, eventLag);
+    RCTLogWarn(@"Native TextInput(%@) is %lld events ahead of JS - try to make your JS faster.", _backedTextInput.text, (long long)eventLag);
   }
 }
 

--- a/Libraries/Text/RCTTextInput.m
+++ b/Libraries/Text/RCTTextInput.m
@@ -87,7 +87,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithFrame:(CGRect)frame)
   if (eventLag == 0 && ![previousSelectedTextRange isEqual:selectedTextRange]) {
     [backedTextInput setSelectedTextRange:selectedTextRange notifyDelegate:NO];
   } else if (eventLag > RCTTextUpdateLagWarningThreshold) {
-    RCTLogWarn(@"Native TextInput(%@) is %zd events ahead of JS - try to make your JS faster.", backedTextInput.text, eventLag);
+    RCTLogWarn(@"Native TextInput(%@) is %lld events ahead of JS - try to make your JS faster.", backedTextInput.text, (long long)eventLag);
   }
 }
 

--- a/Libraries/Text/RCTTextView.m
+++ b/Libraries/Text/RCTTextView.m
@@ -235,7 +235,7 @@ static NSAttributedString *removeReactTagFromString(NSAttributedString *string)
 
     [self invalidateContentSize];
   } else if (eventLag > RCTTextUpdateLagWarningThreshold) {
-    RCTLogWarn(@"Native TextInput(%@) is %zd events ahead of JS - try to make your JS faster.", self.text, eventLag);
+    RCTLogWarn(@"Native TextInput(%@) is %lld events ahead of JS - try to make your JS faster.", self.text, (long long)eventLag);
   }
 }
 


### PR DESCRIPTION
Thank you for sending the PR! We appreciate you spending the time to work on these changes. 
Help us understand your motivation by explaining why you decided to make this change.

This PR patches RN 0.49.5.  It follows directly from the compiler error messages to cast to long long for arguments to NSString in four locations.  One for RCTImageCache and the others for RCTLogWarn about events ahead of JS.

this fixes issue #18638

Fixes #18638

## Test Plan

Able to build in simulator, on device, archived, testflight, and app store with react-native 0.49.5 on xcode 9.3 running on iOS 11.3

## Release Notes

Patches 0.49.5 to be able to compile on xcode 9.3 and iOS 11.3.

