### PR TITLE
Fix issue with composing text not being cleared on some Android devices

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
@@ -385,7 +385,13 @@ public class ReactEditText extends EditText {
     mContainsImages = reactTextUpdate.containsImages();
     mIsSettingTextFromJS = true;
 
-    getText().replace(0, length(), spannableStringBuilder);
+    // On some devices, when the text is cleared, buggy keyboards will not clear the composing
+    // text so, we have to set text to null, which will clear the currently composing text.
+    if (reactTextUpdate.getText().length() == 0) {
+      setText(null);
+    } else {
+      getText().replace(0, length(), spannableStringBuilder);
+    }
 
     mIsSettingTextFromJS = false;
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {


### PR DESCRIPTION
## Summary
Clearing the android TextInput text programmatically (i.e. calling: this.textInputRef.clear()) does not clear the previously composing text, if enabled, causing inconveniences when such behaviour is desired (i.e. chat input box, where you constantly have to clear the input after sending a message). Instead, the currently observed behaviour is that, after a new text is entered (usually as soon as the first letter), the previously composing text reappears making the input unusable.

The effect is only observable on some devices, for example, we observed it on Samsung S6 devices using both Android 6 and 7, and several LG devices running Android 6.

This issue is only present when clearing the text; setting text to some other value does not produce the same effect.

<!-- 
  Required: Write your motivation here.
  If this PR fixes an issue, type "Fixes #issueNumber" to automatically close the issue when the PR is merged.
-->

## Test Plan

```JS
// minimum code example
state = { v: "" };
_changeText = v => this.setState({ v });
clear = () => this.textInputRef.clear();

render() {
  return (
    <View style={styles.container}>
      <TouchableOpacity onPress={this.clear}>
        <Text> Clear </Text>
      </TouchableOpacity>
      <TextInput
        ref={ref => this.textInputRef = ref}
        value={this.state.v}
        onChangeText={this._changeText}
      />
    </View>
  );
}
```

Steps to reproduce(test):
  - Have a previously named device with default keyboard.
  - Have autocorrect enabled in the phone settings.
  - Type something in the input (preferably incomplete word so the autocomplete is not triggered).
  - Press clear.
  - Type a letter.
  - You will then see the previously composing text appear again.

## Release Notes

 [ANDROID] [Fixed] - Fix issue with composing text not being cleared 