### PR TITLE
[PickerIOS] fix missing selection indicator lines

### DIFF
--- a/React/Views/RCTPicker.m
+++ b/React/Views/RCTPicker.m
@@ -23,6 +23,7 @@
     _selectedIndex = NSNotFound;
     _textAlign = NSTextAlignmentCenter;
     self.delegate = self;
+    [self selectRow:0 inComponent:0 animated:YES]; // Workaround for missing selection indicator lines (see https://stackoverflow.com/questions/39564660/uipickerview-selection-indicator-not-visible-in-ios10)
   }
   return self;
 }


### PR DESCRIPTION
## Motivation

This PR is based on https://github.com/facebook/react-native/pull/13342 by @pvinis and fixes https://github.com/facebook/react-native/issues/14442.

As suggested in the discussion on the PR mentioned above, I moved the code from `React/Views/RCTPickerManager.m` to the `initWithFrame` function in `React/Views/RCTPicker.m` and verified that it still fixes the problem.

## Test Plan

Before the change in this PR the selection indicator lines are missing when the Picker is initially added to the View and only appear after changing to a different Tab and back. This happens both in the Simulator and my real device (iPhone 6S on iOS 11.3).

![beforechange](https://user-images.githubusercontent.com/7568362/38824104-7b294cae-41a8-11e8-8609-7a647ab3adb8.png)

After the change, the indicator lines always appear. I did not notice any side effects of this change when playing around with the Picker in different configurations.

![afterchange](https://user-images.githubusercontent.com/7568362/38824109-82a5b382-41a8-11e8-8af3-ca07c8b2c30e.png)

## Related PRs

https://github.com/facebook/react-native/pull/13342 also fixes this issue but appears to be inactive.

## Release Notes

[IOS] [BUGFIX] [PickerIOS] - Fixed missing selection indicator lines