### PR TITLE
[ANDROID][BUGFIX][BlobModule] Switch equality check in BlobModule.java

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/modules/blob/BlobModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/blob/BlobModule.java
@@ -79,7 +79,7 @@ public class BlobModule extends ReactContextBaseJavaModule {
       @Override
       public boolean supports(Uri uri, String responseType) {
         String scheme = uri.getScheme();
-        boolean isRemote = scheme.equals("http") || scheme.equals("https");
+        boolean isRemote = "http".equals(scheme) || "https".equals(scheme);
 
         return (!isRemote && responseType.equals("blob"));
       }


### PR DESCRIPTION
Switch the equality check to avoid crash on the first item. The check can be on a null object and return the correct result.

Fixes #18709 

## Test Plan

Just a simple switch on equals, to make sure we're not bombing out by having a null scheme. 

## Related PRs

No related PRs and does not require a document change.

## Release Notes

[ANDROID][BUGFIX][BlobModule] Switch equality check in BlobModule.java

