### PR TITLE
fix babel 7 polyfills

### DIFF
--- a/RNTester/android/app/build.gradle
+++ b/RNTester/android/app/build.gradle
@@ -120,6 +120,11 @@ android {
             signingConfig signingConfigs.release
         }
     }
+
+    lintOptions {
+        abortOnError false
+    }
+
     // applicationVariants are e.g. debug, release
     applicationVariants.all { variant ->
         variant.outputs.each { output ->

--- a/ReactAndroid/proguard-rules.pro
+++ b/ReactAndroid/proguard-rules.pro
@@ -55,6 +55,10 @@
 # See libs/proxy/src/main/java/com/facebook/fbui/textlayoutbuilder/proxy for details.
 -dontwarn android.text.StaticLayout
 
+# So loader
+-keep class com.facebook.soloader.SoLoader {*;}
+-dontwarn com.facebook.soloader.SoLoader
+
 # okhttp
 
 -keepattributes Signature


### PR DESCRIPTION
## Motivation
fix current ci.

## Test Plan

`npm run test-ci` won't report `TypeError: babelHelpers.objectSpread is not a function`. But first, you need fix some issue in metro, see https://github.com/facebook/react-native/commit/f8d6b97140cffe8d18b2558f94570c8d1b410d5c#r28646980.

## Related PRs



## Release Notes

<!-- 
  Required. 
  Help reviewers and the release process by writing your own release notes. See below for an example.
-->

 [GENERAL] [BUGFIX] [Babel] add missing polyfill.

<!--
  **INTERNAL and MINOR tagged notes will not be included in the next version's final release notes.**

    CATEGORY
  [----------]      TYPE
  [ CLI      ] [-------------]    LOCATION
  [ DOCS     ] [ BREAKING    ] [-------------]
  [ GENERAL  ] [ BUGFIX      ] [ {Component} ]
  [ INTERNAL ] [ ENHANCEMENT ] [ {Filename}  ]
  [ IOS      ] [ FEATURE     ] [ {Directory} ]   |-----------|
  [ ANDROID  ] [ MINOR       ] [ {Framework} ] - | {Message} |
  [----------] [-------------] [-------------]   |-----------|

 EXAMPLES:

 [IOS] [BREAKING] [FlatList] - Change a thing that breaks other things
 [ANDROID] [BUGFIX] [TextInput] - Did a thing to TextInput
 [CLI] [FEATURE] [local-cli/info/info.js] - CLI easier to do things with
 [DOCS] [BUGFIX] [GettingStarted.md] - Accidentally a thing/word
 [GENERAL] [ENHANCEMENT] [Yoga] - Added new yoga thing/position
 [INTERNAL] [FEATURE] [./scripts] - Added thing to script that nobody will see
-->
