### PR TITLE
Prevent console logging on iOS 11.3+ within WebSocket

### DIFF
--- a/Libraries/WebSocket/RCTReconnectingWebSocket.m
+++ b/Libraries/WebSocket/RCTReconnectingWebSocket.m
@@ -19,6 +19,27 @@
 
 #if RCT_DEV // Only supported in dev mode
 
+// From https://github.com/apple/swift/blob/ad40c770bfe372f879b530443a3d94761fe258a6/stdlib/public/SDK/os/os_log.m
+typedef struct os_log_pack_s {
+  uint64_t olp_continuous_time;
+  struct timespec olp_wall_time;
+  const void *olp_mh;
+  const void *olp_pc;
+  const char *olp_format;
+  uint8_t olp_data[0];
+} os_log_pack_s, *os_log_pack_t;
+
+static void (*orig__nwlog_pack)(os_log_pack_t pack, os_log_type_t logType);
+
+static void my__nwlog_pack(os_log_pack_t pack, os_log_type_t logType)
+{
+  if (logType == OS_LOG_TYPE_ERROR) {
+    if (strstr(pack->olp_format, "%{public}s %s Connection has no connected handler") == NULL) {
+      orig__nwlog_pack(pack, logType);
+    }
+  }
+}
+
 static void (*orig_nwlog_legacy_v)(int, char*, va_list);
 
 static void my_nwlog_legacy_v(int level, char *format, va_list args) {
@@ -46,7 +67,7 @@ static void my_os_log_error_impl(void *dso, os_log_t log, os_log_type_t type, co
   }
 }
 
-#endif /* __IPHONE_11_0 */
+#endif /* RCT_DEV */
 
 @interface RCTReconnectingWebSocket () <RCTSRWebSocketDelegate>
 @end
@@ -63,6 +84,9 @@ static void my_os_log_error_impl(void *dso, os_log_t log, os_log_type_t type, co
     rebind_symbols((struct rebinding[1]){
       {"nwlog_legacy_v", my_nwlog_legacy_v, (void *)&orig_nwlog_legacy_v}
     }, 1);
+    rebind_symbols((struct rebinding[1]){
+      {"__nwlog_pack", my__nwlog_pack, (void *)&orig__nwlog_pack}},
+                   1);
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 110000 /* __IPHONE_11_0 */
     rebind_symbols((struct rebinding[1]){
       {"_os_log_error_impl", my_os_log_error_impl, (void *)&orig_os_log_error_impl}


### PR DESCRIPTION
Thank you for sending the PR! We appreciate you spending the time to work on these changes. 
Help us understand your motivation by explaining why you decided to make this change.

Fixes Xcode console output for web socket connections. Apple uses OSLog for logging within libnetworking starting 11.3+. The old way we hook into logging to prevent it will not work anymore.  

Let's hook into `__nwlog_pack` that is exclusively used by libnetworking and prevent the logging in there.
