### PR TITLE
Support for scoped templates

### DIFF
--- a/local-cli/generator/templates.js
+++ b/local-cli/generator/templates.js
@@ -116,7 +116,13 @@ function createFromRemoteTemplate(template, destPath, newProjectName, yarnVersio
      templateName = template.substr(template.lastIndexOf('/') + 1);
   } else {
     // e.g 'demo'
-    installPackage = 'react-native-template-' + template;
+    let scope = ''
+    if(template[0] === '@' && template.length > 3 && template.includes('/', 2)) {
+      [scope, ...template] = template.split('/')
+      scope += '/'
+      template = template.join('/')
+    }
+    installPackage = `${scope}react-native-template-${template}`;
     templateName = installPackage;
   }
 


### PR DESCRIPTION
Add support for templates published as scoped packages. Partially fixes #18973.

## Test Plan

Published a template as a scoped package and installed it.

## Related PRs

Documentation doesn't says nothing regarding lack of support for scoped packages, so intuitively they should work. This pull-request just makes that intuitive assumption true, so I think no changes on documentation are needed.

## Release Notes

<!-- 
  Required. 
  Help reviewers and the release process by writing your own release notes. See below for an example.
-->

[CLI] [BUGFIX] [local-cli/generator/templates.js] - Support for scoped `npm` packages as templates