### PR TITLE
BREAKING - default underlineColorAndroid to transparent

### DIFF
--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -638,6 +638,7 @@ const TextInput = createReactClass({
   getDefaultProps(): Object {
     return {
       allowFontScaling: true,
+      underlineColorAndroid: 'transparent',
     };
   },
   /**


### PR DESCRIPTION
Set default `underlineColorAndroid` to `transparent`.
<!-- 
  Required: Write your motivation here.
  If this PR fixes an issue, type "Fixes #issueNumber" to automatically close the issue when the PR is merged.
-->

Fixes #18938

## Test Plan

<!-- 
  Required: Write your test plan here. If you changed any code, please provide us with 
  clear instructions on how you verified your changes work. Bonus points for screenshots and videos! 
-->

Use a TextInput in a component without defining `underlineColorAndroid`, the underline color should be transparent. 

## Related PRs

<!-- 
  Does this PR require a documentation change? 
  Create a PR at https://github.com/facebook/react-native-website and add a link to it here.
-->

## Release Notes

<!-- 
  Required. 
  Help reviewers and the release process by writing your own release notes. See below for an example.
-->

[ANDROID] [BREAKING] [TextInput] - set default underlineColorAndroid to transparent

<!--
  **INTERNAL and MINOR tagged notes will not be included in the next version's final release notes.**

    CATEGORY
  [----------]      TYPE
  [ CLI      ] [-------------]    LOCATION
  [ DOCS     ] [ BREAKING    ] [-------------]
  [ GENERAL  ] [ BUGFIX      ] [ {Component} ]
  [ INTERNAL ] [ ENHANCEMENT ] [ {Filename}  ]
  [ IOS      ] [ FEATURE     ] [ {Directory} ]   |-----------|
  [ ANDROID  ] [ MINOR       ] [ {Framework} ] - | {Message} |
  [----------] [-------------] [-------------]   |-----------|

 EXAMPLES:

 [IOS] [BREAKING] [FlatList] - Change a thing that breaks other things
 [ANDROID] [BUGFIX] [TextInput] - Did a thing to TextInput
 [CLI] [FEATURE] [local-cli/info/info.js] - CLI easier to do things with
 [DOCS] [BUGFIX] [GettingStarted.md] - Accidentally a thing/word
 [GENERAL] [ENHANCEMENT] [Yoga] - Added new yoga thing/position
 [INTERNAL] [FEATURE] [./scripts] - Added thing to script that nobody will see
-->
