### PR TITLE
Remove "unique key" warning when interacting

### DIFF
--- a/Libraries/Inspector/ElementProperties.js
+++ b/Libraries/Inspector/ElementProperties.js
@@ -75,11 +75,10 @@ class ElementProperties extends React.Component<{
               this.props.hierarchy,
               (hierarchyItem, i) => (
                 <TouchableHighlight
-                  key={'item-' + i}
                   style={[styles.breadItem, i === selection && styles.selected]}
                   // $FlowFixMe found when converting React.createClass to ES6
                   onPress={() => this.props.setSelection(i)}>
-                  <Text style={styles.breadItemText}>
+                  <Text key={'item-' + i} style={styles.breadItemText}>
                     {hierarchyItem.name}
                   </Text>
                 </TouchableHighlight>


### PR DESCRIPTION
Adding a unique key to the touchable did not remove the warning for `Each child in an array or iterator should have a unique "key" prop`. Instead it needed to be added to the Element inside.

## Test Plan

Open inspector on emulator, inspect various elements in any app, and verify the warnings (yellow boxes) are not being thrown anymore.

## Release Notes

[ GENERAL ][ BUGFIX ][ INSPECTOR ] - resolved "unique key" warnings when interacting with inspector.
