### PR TITLE
Fix root view cleanup

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
@@ -90,6 +90,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -1057,9 +1058,11 @@ public class ReactInstanceManager {
     }
 
     synchronized (mAttachedRootViews) {
-      for (ReactRootView rootView : mAttachedRootViews) {
+      for (Iterator iterator = mAttachedRootViews.iterator(); iterator.hasNext();) {
+        ReactRootView rootView = (ReactRootView) iterator.next();
         rootView.removeAllViews();
         rootView.setId(View.NO_ID);
+        iterator.remove();
       }
     }
 


### PR DESCRIPTION
The tearDownReactContext method of ReactInstanceManager was not removing
root views from its private mAttachedRootViews member.

The perceived problem was that when an Android application with multiple
root views was reloaded, root JS components that existed prior to that
reload were being remounted. They did not appear on screen, but React
life cycle methods such as componentWillMount were being called.

## Test Plan

I've created a MCVE project to illustrate the problem.

https://github.com/viotti/react-native-arvc-mcve

## Related PRs

None.

## Release Notes

[ANDROID] [BUGFIX] [ReactInstanceManager.java] - Fix root view cleanup
