### PR TITLE
Allow specifying iOS version for run-ios with simulator option

### DIFF
--- a/local-cli/runIOS/__tests__/findMatchingSimulator-test.js
+++ b/local-cli/runIOS/__tests__/findMatchingSimulator-test.js
@@ -459,6 +459,139 @@ describe('findMatchingSimulator', () => {
     });
   });
 
+  it('should return the simulator with the specified version (multi ios versions)', () => {
+    expect(findMatchingSimulator({
+        'devices': {
+          'iOS 9.2': [
+            {
+              'state': 'Shutdown',
+              'availability': '(unavailable, runtime profile not found)',
+              'name': 'iPhone 4s',
+              'udid': 'B9B5E161-416B-43C4-A78F-729CB96CC8C6'
+            },
+            {
+              'state': 'Shutdown',
+              'availability': '(available)',
+              'name': 'iPhone 5',
+              'udid': '1CCBBF8B-5773-4EA6-BD6F-C308C87A1ADB'
+            },
+            {
+              'state': 'Shutdown',
+              'availability': '(available)',
+              'name': 'iPhone 6',
+              'udid': 'BA0D93BD-07E6-4182-9B0A-F60A2474139C'
+            },
+            {
+              'state': 'Shutdown',
+              'availability': '(available)',
+              'name': 'iPhone 6 (Plus)',
+              'udid': '9564ABEE-9EC2-4B4A-B443-D3710929A45A'
+            },
+            {
+              'state': 'Shutdown',
+              'availability': '(available)',
+              'name': 'iPhone 6s',
+              'udid': 'D0F29BE7-CC3C-4976-888D-C739B4F50508'
+            }
+          ],
+          'iOS 10.0': [
+            {
+              'state': 'Shutdown',
+              'availability': '(available)',
+              'name': 'iPhone 6',
+              'udid': '2FF48AE5-CC3B-4C80-8D25-48966A6BE2C0'
+            },
+            {
+              'state': 'Shutdown',
+              'availability': '(available)',
+              'name': 'iPhone 6 (Plus)',
+              'udid': '841E33FE-E8A1-4B65-9FF8-6EAA6442A3FC'
+            },
+            {
+              'state': 'Shutdown',
+              'availability': '(available)',
+              'name': 'iPhone 6s',
+              'udid': 'CBBB8FB8-77AB-49A9-8297-4CCFE3189C22'
+            },
+            {
+              'state': 'Booted',
+              'availability': '(available)',
+              'name': 'iPhone 7',
+              'udid': '3A409DC5-5188-42A6-8598-3AA6F34607A5'
+            }
+          ]
+        }
+      },
+      'iPhone 6s (10.0)'
+    )).toEqual({
+      udid: 'CBBB8FB8-77AB-49A9-8297-4CCFE3189C22',
+      name: 'iPhone 6s',
+      booted: false,
+      version: 'iOS 10.0'
+    });
+  });
+
+  it('should return null if the version is specified and no device with the exact version exists (multi ios versions)', () => {
+    expect(findMatchingSimulator({
+        'devices': {
+          'iOS 9.2': [
+            {
+              'state': 'Shutdown',
+              'availability': '(unavailable, runtime profile not found)',
+              'name': 'iPhone 4s',
+              'udid': 'B9B5E161-416B-43C4-A78F-729CB96CC8C6'
+            },
+            {
+              'state': 'Shutdown',
+              'availability': '(available)',
+              'name': 'iPhone 5',
+              'udid': '1CCBBF8B-5773-4EA6-BD6F-C308C87A1ADB'
+            },
+            {
+              'state': 'Shutdown',
+              'availability': '(available)',
+              'name': 'iPhone 6',
+              'udid': 'BA0D93BD-07E6-4182-9B0A-F60A2474139C'
+            },
+            {
+              'state': 'Shutdown',
+              'availability': '(available)',
+              'name': 'iPhone 6 (Plus)',
+              'udid': '9564ABEE-9EC2-4B4A-B443-D3710929A45A'
+            },
+            {
+              'state': 'Shutdown',
+              'availability': '(available)',
+              'name': 'iPhone 6s',
+              'udid': 'D0F29BE7-CC3C-4976-888D-C739B4F50508'
+            }
+          ],
+          'iOS 10.0': [
+            {
+              'state': 'Shutdown',
+              'availability': '(available)',
+              'name': 'iPhone 6',
+              'udid': '2FF48AE5-CC3B-4C80-8D25-48966A6BE2C0'
+            },
+            {
+              'state': 'Shutdown',
+              'availability': '(available)',
+              'name': 'iPhone 6 (Plus)',
+              'udid': '841E33FE-E8A1-4B65-9FF8-6EAA6442A3FC'
+            },
+            {
+              'state': 'Booted',
+              'availability': '(available)',
+              'name': 'iPhone 7',
+              'udid': '3A409DC5-5188-42A6-8598-3AA6F34607A5'
+            }
+          ]
+        }
+      },
+      'iPhone 6s (10.0)'
+    )).toEqual(null);
+  });
+
   it('should return AppleTV devices if in the list', () => {
     expect(findMatchingSimulator({
       'devices': {

--- a/local-cli/runIOS/findMatchingSimulator.js
+++ b/local-cli/runIOS/findMatchingSimulator.js
@@ -7,25 +7,39 @@
 'use strict';
 
 /**
- * Takes in a parsed simulator list and a desired name, and returns an object with the matching simulator.
+ * Takes in a parsed simulator list and a desired name, and returns an object with the matching simulator. The desired
+ * name can optionally include the iOS version in between parenthesis after the device name. Ex: "iPhone 6 (9.2)" in
+ * which case it'll attempt to find a simulator with the exact version specified.
  *
- * If the simulatorName argument is null, we'll go into default mode and return the currently booted simulator, or if
+ * If the simulatorString argument is null, we'll go into default mode and return the currently booted simulator, or if
  * none is booted, it will be the first in the list.
  *
  * @param Object simulators a parsed list from `xcrun simctl list --json devices` command
- * @param String|null simulatorName the string with the name of desired simulator. If null, it will use the currently
+ * @param String|null simulatorString the string with the name of desired simulator. If null, it will use the currently
  *        booted simulator, or if none are booted, the first in the list.
  * @returns {Object} {udid, name, version}
  */
-function findMatchingSimulator(simulators, simulatorName) {
+function findMatchingSimulator(simulators, simulatorString) {
   if (!simulators.devices) {
     return null;
   }
   const devices = simulators.devices;
+
+  const parsedSimulatorName = simulatorString ? simulatorString.match(/(.*)? (?:\((.*)?\))?/) : [];
+  if (parsedSimulatorName[2] !== undefined) {
+    var simulatorVersion = parsedSimulatorName[2];
+    var simulatorName = parsedSimulatorName[1];
+  } else {
+    simulatorName = simulatorString;
+  }
+
   var match;
   for (let version in devices) {
     // Making sure the version of the simulator is an iOS or tvOS (Removes Apple Watch, etc)
     if (!version.startsWith('iOS') && !version.startsWith('tvOS')) {
+      continue;
+    }
+    if (simulatorVersion && !version.endsWith(simulatorVersion)) {
       continue;
     }
     for (let i in devices[version]) {

--- a/local-cli/runIOS/runIOS.js
+++ b/local-cli/runIOS/runIOS.js
@@ -297,7 +297,7 @@ module.exports = {
   ],
   options: [{
     command: '--simulator [string]',
-    description: 'Explicitly set simulator to use',
+    description: 'Explicitly set simulator to use. Optionally include iOS version between parenthesis at the end to match an exact version.',
     default: 'iPhone 6',
   } , {
     command: '--configuration [string]',


### PR DESCRIPTION
Fixes #19069 

The --simulator option for the run-ios command now can take an optional
iOS version between parenthesis to further match the desired simulator.
This is useful if you have installed simulators for different iOS
versions and you want to run the app in an especific one. Example:

react-native run-ios --simulator "iPhone 6s (9.3)"

Thank you for sending the PR! We appreciate you spending the time to work on these changes. 
Help us understand your motivation by explaining why you decided to make this change.

## Test Plan

Updated tests for the findMatchingSimulator function to include test cases specifying iOS version, and tested on the command line in my app to make sure it has the expected behavior.

## Release Notes

[CLI] [ENHANCEMENT] [{/runIOS/findMatchingSimulator.js}] - run-ios command with the --simulator option now allows specifying the iOS version to run an specific simulator if you have multiple versions of the simulator installed. Example: `react-native run-ios --simulator "iPhone 6s (9.3)"`.