### PR TITLE
Fix Android, DevServerHelper from calling okhttp3 response.body.string() twice

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevServerHelper.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevServerHelper.java
@@ -479,10 +479,11 @@ public class DevServerHelper {
               callback.onPackagerStatusFetched(false);
               return;
             }
-            if (!PACKAGER_OK_STATUS.equals(body.string())) {
+            String bodyString = body.string(); // cannot call body.string() twice, stored it into variable. https://github.com/square/okhttp/issues/1240#issuecomment-68142603
+            if (!PACKAGER_OK_STATUS.equals(bodyString)) {
               FLog.e(
                   ReactConstants.TAG,
-                  "Got unexpected response from packager when requesting status: " + body.string());
+                  "Got unexpected response from packager when requesting status: " + bodyString);
               callback.onPackagerStatusFetched(false);
               return;
             }


### PR DESCRIPTION
Fixing from call response.body.string() twice in DevServerHelper.java.
https://github.com/square/okhttp/issues/1240#issuecomment-68142603

I'm getting error like this
```
05-01 21:16:47.080 22836-23064/com.my.company.bundle E/AndroidRuntime: FATAL EXCEPTION: OkHttp Dispatcher
                                                                               Process: com.my.company.bundle, PID: 22836
                                                                               java.lang.IllegalStateException: closed
                                                                                   at okio.RealBufferedSource.rangeEquals(RealBufferedSource.java:398)
                                                                                   at okio.RealBufferedSource.rangeEquals(RealBufferedSource.java:392)
                                                                                   at okhttp3.internal.c.a(Util.java:449)
                                                                                   at okhttp3.v.string(ResponseBody.java:174)
                                                                                   at com.facebook.react.devsupport.f$8.onResponse(DevServerHelper.java:487)
                                                                                   at com.newrelic.agent.android.instrumentation.okhttp3.CallbackExtension.onResponse(CallbackExtension.java:41)
                                                                                   at okhttp3.s$a.c(RealCall.java:153)
                                                                                   at okhttp3.internal.b.run(NamedRunnable.java:32)
                                                                                   at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1162)
                                                                                   at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:636)
                                                                                   at java.lang.Thread.run(Thread.java:764)
```


<!-- 
  Required: Write your motivation here.
  If this PR fixes an issue, type "Fixes #issueNumber" to automatically close the issue when the PR is merged.
-->

## Test Plan
- In my case, My device is using a Proxy, and tried to connect the packager. When it failed from connecting packager through websocket, It crash by this line of code.
<!-- 
  Required: Write your test plan here. If you changed any code, please provide us with 
  clear instructions on how you verified your changes work. Bonus points for screenshots and videos! 
-->

## Related PRs

<!-- 
  Does this PR require a documentation change? 
  Create a PR at https://github.com/facebook/react-native-website and add a link to it here.
-->

## Release Notes

<!-- 
  Required. 
  Help reviewers and the release process by writing your own release notes. See below for an example.
-->

[ANDROID] [BUGFIX] [DevServerHelper] - fixing from calling body.string() twice.

<!--
  **INTERNAL and MINOR tagged notes will not be included in the next version's final release notes.**

    CATEGORY
  [----------]      TYPE
  [ CLI      ] [-------------]    LOCATION
  [ DOCS     ] [ BREAKING    ] [-------------]
  [ GENERAL  ] [ BUGFIX      ] [ {Component} ]
  [ INTERNAL ] [ ENHANCEMENT ] [ {Filename}  ]
  [ IOS      ] [ FEATURE     ] [ {Directory} ]   |-----------|
  [ ANDROID  ] [ MINOR       ] [ {Framework} ] - | {Message} |
  [----------] [-------------] [-------------]   |-----------|

 EXAMPLES:

 [IOS] [BREAKING] [FlatList] - Change a thing that breaks other things
 [ANDROID] [BUGFIX] [TextInput] - Did a thing to TextInput
 [CLI] [FEATURE] [local-cli/info/info.js] - CLI easier to do things with
 [DOCS] [BUGFIX] [GettingStarted.md] - Accidentally a thing/word
 [GENERAL] [ENHANCEMENT] [Yoga] - Added new yoga thing/position
 [INTERNAL] [FEATURE] [./scripts] - Added thing to script that nobody will see
-->
