### PR TITLE
Replace magic numbers with `safeAreaInsets` in `RCTDevLoadingView`

### DIFF
--- a/React/DevSupport/RCTDevLoadingView.m
+++ b/React/DevSupport/RCTDevLoadingView.m
@@ -72,9 +72,11 @@ RCT_EXPORT_METHOD(showMessage:(NSString *)message color:(UIColor *)color backgro
     self->_showDate = [NSDate date];
     if (!self->_window && !RCTRunningInTestEnvironment()) {
       CGSize screenSize = [UIScreen mainScreen].bounds.size;
-      if (screenSize.height == 812 /* iPhone X */) {
-        self->_window = [[UIWindow alloc] initWithFrame:CGRectMake(0, 0, screenSize.width, 60)];
-        self->_label = [[UILabel alloc] initWithFrame:CGRectMake(0, 30, self->_window.bounds.size.width, 30)];
+      
+      if (@available(iOS 11.0, *)) {
+        UIWindow *window = UIApplication.sharedApplication.keyWindow;
+        self->_window = [[UIWindow alloc] initWithFrame:CGRectMake(0, 0, screenSize.width, window.safeAreaInsets.top + 30)];
+        self->_label = [[UILabel alloc] initWithFrame:CGRectMake(0, window.safeAreaInsets.top, screenSize.width, 30)];
       } else {
         self->_window = [[UIWindow alloc] initWithFrame:CGRectMake(0, 0, screenSize.width, 22)];
         self->_label = [[UILabel alloc] initWithFrame:self->_window.bounds];


### PR DESCRIPTION
This PR replaces magic numbers used for offsetting `RCTDevLoadingView` when running on iPhone X, in favour of `safeAreaInsets`.

## Test Plan
Tested on iPhone X and iPhone 8. Here is a screenshot showing how it looks on iPhone X.
![nansi](https://user-images.githubusercontent.com/3900360/39599961-b4239d90-4ef3-11e8-97f4-269d571a6c8d.png)

## Release Notes
[INTERNAL] [ENHANCEMENT] [RCTDevLoadingView] - Replace magic numbers with `safeAreaInsets` in `RCTDevLoadingView`