### PR TITLE
Add Object.is polyfill

### DIFF
--- a/Libraries/polyfills/Object.es6.js
+++ b/Libraries/polyfills/Object.es6.js
@@ -63,3 +63,8 @@ Object.assign = function(target, sources) {
 
   return target;
 };
+
+Object.is = function(x, y) {
+  /* eslint no-self-compare: "off" */
+  return x === y ? x !== 0 || 1 / x === 1 / y : x !== x && y !== y;
+};

--- a/Libraries/polyfills/__tests__/Object.es6-test.js
+++ b/Libraries/polyfills/__tests__/Object.es6-test.js
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+describe('Object (ES6)', () => {
+  beforeEach(() => {
+    delete Object.entries;
+    delete Object.values;
+    jest.resetModules();
+    require('../Object.es6');
+  });
+
+  describe('Object.is', () => {
+    it('should pass', () => {
+      expect(Object.is('foo', 'foo')).toEqual(true);
+      const test = {a: 1};
+      expect(Object.is(test, test)).toEqual(true);
+      expect(Object.is(null, null)).toEqual(true);
+      expect(Object.is(0, -0)).toEqual(false);
+      expect(Object.is(-0, -0)).toEqual(true);
+      expect(Object.is(NaN, 0 / 0)).toEqual(true);
+    });
+  });
+});


### PR DESCRIPTION
JS run on Android is missing `Object.is`. I add `Object.is` polyfill for it work as well.

<!-- 
  Required: Write your motivation here.
  If this PR fixes an issue, type "Fixes #issueNumber" to automatically close the issue when the PR is merged.
-->

Fixes #19139

## Related PRs

None

## Test Plan

<!-- 
  Required: Write your test plan here. If you changed any code, please provide us with 
  clear instructions on how you verified your changes work. Bonus points for screenshots and videos! 
-->

`npm run test` with no failing test.

## Release Notes

<!-- 
  Required. 
  Help reviewers and the release process by writing your own release notes. See below for an example.
-->

[GENERAL][BUGFIX][Babel] - add missing polyfill: Object.is

<!--
  **INTERNAL and MINOR tagged notes will not be included in the next version's final release notes.**

    CATEGORY
  [----------]      TYPE
  [ CLI      ] [-------------]    LOCATION
  [ DOCS     ] [ BREAKING    ] [-------------]
  [ GENERAL  ] [ BUGFIX      ] [ {Component} ]
  [ INTERNAL ] [ ENHANCEMENT ] [ {Filename}  ]
  [ IOS      ] [ FEATURE     ] [ {Directory} ]   |-----------|
  [ ANDROID  ] [ MINOR       ] [ {Framework} ] - | {Message} |
  [----------] [-------------] [-------------]   |-----------|

 EXAMPLES:

 [IOS] [BREAKING] [FlatList] - Change a thing that breaks other things
 [ANDROID] [BUGFIX] [TextInput] - Did a thing to TextInput
 [CLI] [FEATURE] [local-cli/info/info.js] - CLI easier to do things with
 [DOCS] [BUGFIX] [GettingStarted.md] - Accidentally a thing/word
 [GENERAL] [ENHANCEMENT] [Yoga] - Added new yoga thing/position
 [INTERNAL] [FEATURE] [./scripts] - Added thing to script that nobody will see
-->
