### PR TITLE
Feature/fix method call test types

### DIFF
--- a/Libraries/ReactNative/requireFabricComponent.js
+++ b/Libraries/ReactNative/requireFabricComponent.js
@@ -55,7 +55,7 @@ function requireNativeComponent(
   function attachDefaultEventTypes(viewConfig: any) {
     // This is supported on UIManager platforms (ex: Android),
     // as lazy view managers are not implemented for all platforms.
-    // See [UIManager] for details on constants and implementation.
+    // See [UIManager] for details on constants and implementations.
     if (UIManager.ViewManagerNames) {
       // Lazy view managers enabled.
       viewConfig = merge(viewConfig, UIManager.getDefaultEventTypes());

--- a/Libraries/ReactNative/requireFabricComponent.js
+++ b/Libraries/ReactNative/requireFabricComponent.js
@@ -53,22 +53,21 @@ function requireNativeComponent(
   extraConfig?: ?{nativeOnly?: Object},
 ): React$ComponentType<any> | string {
   function attachDefaultEventTypes(viewConfig: any) {
-    if (Platform.OS === 'android') {
-      // This is supported on Android platform only,
-      // as lazy view managers discovery is Android-specific.
-      if (UIManager.ViewManagerNames) {
-        // Lazy view managers enabled.
-        viewConfig = merge(viewConfig, UIManager.getDefaultEventTypes());
-      } else {
-        viewConfig.bubblingEventTypes = merge(
-          viewConfig.bubblingEventTypes,
-          UIManager.genericBubblingEventTypes,
-        );
-        viewConfig.directEventTypes = merge(
-          viewConfig.directEventTypes,
-          UIManager.genericDirectEventTypes,
-        );
-      }
+    // This is supported on UIManager platforms (ex: Android),
+    // as lazy view managers are not implemented for all platforms.
+    // See [UIManager] for details on constants and implementation.
+    if (UIManager.ViewManagerNames) {
+      // Lazy view managers enabled.
+      viewConfig = merge(viewConfig, UIManager.getDefaultEventTypes());
+    } else {
+      viewConfig.bubblingEventTypes = merge(
+        viewConfig.bubblingEventTypes,
+        UIManager.genericBubblingEventTypes,
+      );
+      viewConfig.directEventTypes = merge(
+        viewConfig.directEventTypes,
+        UIManager.genericDirectEventTypes,
+      );
     }
   }
 

--- a/Libraries/ReactNative/requireNativeComponent.js
+++ b/Libraries/ReactNative/requireNativeComponent.js
@@ -53,7 +53,7 @@ function requireNativeComponent(
   function attachDefaultEventTypes(viewConfig: any) {
     // This is supported on UIManager platforms (ex: Android),
     // as lazy view managers are not implemented for all platforms.
-    // See [UIManager] for details on constants and implementation.
+    // See [UIManager] for details on constants and implementations.
     if (UIManager.ViewManagerNames) {
       // Lazy view managers enabled.
       viewConfig = merge(viewConfig, UIManager.getDefaultEventTypes());

--- a/Libraries/ReactNative/requireNativeComponent.js
+++ b/Libraries/ReactNative/requireNativeComponent.js
@@ -51,22 +51,21 @@ function requireNativeComponent(
   extraConfig?: ?{nativeOnly?: Object},
 ): React$ComponentType<any> | string {
   function attachDefaultEventTypes(viewConfig: any) {
-    if (Platform.OS === 'android') {
-      // This is supported on Android platform only,
-      // as lazy view managers discovery is Android-specific.
-      if (UIManager.ViewManagerNames) {
-        // Lazy view managers enabled.
-        viewConfig = merge(viewConfig, UIManager.getDefaultEventTypes());
-      } else {
-        viewConfig.bubblingEventTypes = merge(
-          viewConfig.bubblingEventTypes,
-          UIManager.genericBubblingEventTypes,
-        );
-        viewConfig.directEventTypes = merge(
-          viewConfig.directEventTypes,
-          UIManager.genericDirectEventTypes,
-        );
-      }
+    // This is supported on UIManager platforms (ex: Android),
+    // as lazy view managers are not implemented for all platforms.
+    // See [UIManager] for details on constants and implementation.
+    if (UIManager.ViewManagerNames) {
+      // Lazy view managers enabled.
+      viewConfig = merge(viewConfig, UIManager.getDefaultEventTypes());
+    } else {
+      viewConfig.bubblingEventTypes = merge(
+        viewConfig.bubblingEventTypes,
+        UIManager.genericBubblingEventTypes,
+      );
+      viewConfig.directEventTypes = merge(
+        viewConfig.directEventTypes,
+        UIManager.genericDirectEventTypes,
+      );
     }
   }
 

--- a/ReactCommon/cxxreact/tests/methodcall.cpp
+++ b/ReactCommon/cxxreact/tests/methodcall.cpp
@@ -64,7 +64,7 @@ TEST(parseMethodCalls, InvalidReturnFormat) {
   }
 }
 
-TEST(parseMethodCalls, NumberReturn) {
+TEST(parseMethodCalls, StringReturn) {
   auto jsText = "[[0],[0],[[\"foobar\"]]]";
   auto returnedCalls = parseMethodCalls(folly::parseJson(jsText));
   ASSERT_EQ(1, returnedCalls.size());
@@ -74,7 +74,7 @@ TEST(parseMethodCalls, NumberReturn) {
   ASSERT_EQ("foobar", returnedCall.arguments[0].asString());
 }
 
-TEST(parseMethodCalls, StringReturn) {
+TEST(parseMethodCalls, NumberReturn) {
   auto jsText = "[[0],[0],[[42.16]]]";
   auto returnedCalls = parseMethodCalls(folly::parseJson(jsText));
   ASSERT_EQ(1, returnedCalls.size());


### PR DESCRIPTION
While reviewing some of the C++ tests, we noticed a little naming problem.  This PR aligns the testing name with the actual type being tested. :)

## Test Plan

* Run existing test suites

## Related PRs

n/a

## Release Notes

[ GENERAL  ] [ BUGFIX      ] [ ReactCommon ] Align test names with types being tested.
