### PR TITLE
Fix permissions android request below m

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/modules/permissions/PermissionsModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/permissions/PermissionsModule.java
@@ -95,8 +95,8 @@ public class PermissionsModule extends ReactContextBaseJavaModule implements Per
   public void requestPermission(final String permission, final Promise promise) {
     Context context = getReactApplicationContext().getBaseContext();
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
-      promise.resolve(context.checkPermission(permission, Process.myPid(), Process.myUid()) ==
-              PackageManager.PERMISSION_GRANTED);
+      context.checkPermission(permission, Process.myPid(), Process.myUid()) ==
+              PackageManager.PERMISSION_GRANTED ? promise.resolve(GRANTED) : promise.reject(DENIED)
       return;
     }
     if (context.checkSelfPermission(permission) == PackageManager.PERMISSION_GRANTED) {

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/permissions/PermissionsModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/permissions/PermissionsModule.java
@@ -96,7 +96,7 @@ public class PermissionsModule extends ReactContextBaseJavaModule implements Per
     Context context = getReactApplicationContext().getBaseContext();
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
       context.checkPermission(permission, Process.myPid(), Process.myUid()) ==
-              PackageManager.PERMISSION_GRANTED ? promise.resolve(GRANTED) : promise.reject(DENIED)
+              PackageManager.PERMISSION_GRANTED ? promise.resolve(GRANTED) : promise.reject(DENIED);
       return;
     }
     if (context.checkSelfPermission(permission) == PackageManager.PERMISSION_GRANTED) {


### PR DESCRIPTION
Running PermissionsAndroid.request() on Android versions below M returns boolean value rather than string value as documented, thus causing inconsistency. This PR returns string value for all Android versions.

## Test Plan

```jsx
async function requestCameraPermission() {
  try {
    const granted = await PermissionsAndroid.request(
      PermissionsAndroid.PERMISSIONS.CAMERA,
      {
        'title': 'Cool Photo App Camera Permission',
        'message': 'Cool Photo App needs access to your camera ' +
                   'so you can take awesome pictures.'
      }
    )
    console.log(typeof granted);
  } catch (err) {
    console.warn(err)
  }
}
```

This will print string on Android version below M, than boolean before.

## Release Notes

<!-- 
  Required. 
  Help reviewers and the release process by writing your own release notes. See below for an example.
-->

[CATEGORY] [TYPE] [LOCATION] - Message

<!--
  **INTERNAL and MINOR tagged notes will not be included in the next version's final release notes.**

    CATEGORY
  [----------]      TYPE
  [ CLI      ] [-------------]    LOCATION
  [ DOCS     ] [ BREAKING    ] [-------------]
  [ GENERAL  ] [ BUGFIX      ] [ {Component} ]
  [ INTERNAL ] [ ENHANCEMENT ] [ {Filename}  ]
  [ IOS      ] [ FEATURE     ] [ {Directory} ]   |-----------|
  [ ANDROID  ] [ MINOR       ] [ {Framework} ] - | {Message} |
  [----------] [-------------] [-------------]   |-----------|

 EXAMPLES:

 [IOS] [BREAKING] [FlatList] - Change a thing that breaks other things
 [ANDROID] [BUGFIX] [TextInput] - Did a thing to TextInput
 [CLI] [FEATURE] [local-cli/info/info.js] - CLI easier to do things with
 [DOCS] [BUGFIX] [GettingStarted.md] - Accidentally a thing/word
 [GENERAL] [ENHANCEMENT] [Yoga] - Added new yoga thing/position
 [INTERNAL] [FEATURE] [./scripts] - Added thing to script that nobody will see
-->
