### PR TITLE
[Node 8] Bump to Node 8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -365,24 +365,6 @@ jobs:
       - store_test_results:
           path: ~/react-native/reports/junit
 
-  # Runs JavaScript tests on Node 6
-  test_javascript_node6_compatibility:
-    <<: *defaults
-    docker:
-      - image: circleci/node:6
-    steps:
-      - checkout
-      - run: *setup-artifacts
-
-      - restore-cache: *restore-cache-yarn
-      - run: *yarn
-      - save-cache: *save-cache-yarn
-
-      - run: *run-js-tests
-
-      - store_test_results:
-          path: ~/react-native/reports/junit
-
   # Runs unit tests on iOS devices
   test_ios:
     <<: *macos_defaults
@@ -623,10 +605,6 @@ workflows:
           filters: *filter-ignore-gh-pages
           requires:
             - checkout_code
-
-      # Test JavaScript using Node 6, the minimum supported version
-      - test_javascript_node6_compatibility:
-          filters: *filter-ignore-gh-pages
 
       # Test Android
       - test_android:

--- a/local-cli/server/checkNodeVersion.js
+++ b/local-cli/server/checkNodeVersion.js
@@ -14,7 +14,7 @@ var formatBanner = require('metro-core/src/formatBanner');
 var semver = require('semver');
 
 module.exports = function() {
-  if (!semver.satisfies(process.version, '>=4')) {
+  if (!semver.satisfies(process.version, '>=8')) {
     var engine = semver.satisfies(process.version, '<1') ? 'Node' : 'io.js';
 
     var message =
@@ -24,7 +24,7 @@ module.exports = function() {
       process.version +
       '.\n' +
       '\n' +
-      'React Native runs on Node 4.0 or newer. There are several ways to ' +
+      'React Native runs on Node 8.0 or newer. There are several ways to ' +
       'upgrade Node.js depending on your preference.\n' +
       '\n' +
       'nvm:       nvm install node && nvm alias default node\n' +
@@ -32,7 +32,7 @@ module.exports = function() {
       'Installer: download the Mac .pkg from https://nodejs.org/\n' +
       '\n' +
       'About Node.js:   https://nodejs.org\n' +
-      'Follow along at: https://github.com/facebook/react-native/issues/2545';
+      'Follow along at: https://github.com/facebook/react-native/issues/19226';
     console.log(
       formatBanner(message, {
         chalkFunction: chalk.green,

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "git@github.com:facebook/react-native.git"
   },
   "engines": {
-    "node": ">=4"
+    "node": ">=8"
   },
   "prettier": {
     "requirePragma": true,


### PR DESCRIPTION
Moving to Node 8 in React Native will allow us to be consistent with Facebook, e.g. trailing commas.

As of April 30, Node 4.x is end of life, and Node 6.x entered maintenance mode (see https://medium.com/the-node-js-collection/april-2018-release-updates-from-the-node-js-project-71687e1f7742).

This will require our docs to be updated to require Node 8 as a minimum. This should be done as part of the following PR: https://github.com/facebook/react-native-website/pull/355

Circle CI already runs all JS tests using Node 8, and it has an extra compatibility check that uses Node 6. This workflow is dropped as we no longer need to check for failures when Node 6 is used.

See https://github.com/facebook/react-native/issues/19226

Test Plan
=========

flow
CircleCI

Release Notes
=============

[GENERAL] [BREAKING] [Node] - Bump minimum req. Node version to 8