### PR TITLE
Halve the period of time until an issue is considered stale

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -6,7 +6,9 @@ daysUntilClose: 30
 exemptLabels:
   - Good first issue
   - For Discussion
-  - Core Team 
+  - Core Team
+  - "Help Wanted :octocat:"
+  - ":warning:Regression"
 # Label to use when marking an issue as stale
 staleLabel: Stale 
 # Comment to post when marking an issue as stale. Set to `false` to disable

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,7 +1,7 @@
 # Number of days of inactivity before an issue becomes stale
-daysUntilStale: 180
+daysUntilStale: 90
 # Number of days of inactivity before a stale issue is closed
-daysUntilClose: 60
+daysUntilClose: 30
 # Issues with these labels will never be considered stale
 exemptLabels:
   - Good first issue

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,3 +1,4 @@
+# Configuration for probot-stale - https://github.com/probot/stale
 # Number of days of inactivity before an issue becomes stale
 daysUntilStale: 90
 # Number of days of inactivity before a stale issue is closed


### PR DESCRIPTION
## Description

I propose halving the time required to flag and close an issue due to inactivity. The new time period would be 90 days (~3 months), at which point the bot will flag an issue as stale. This starts the second timer, where if the issue sees no further activity within 30 days, it will be closed by the bot.

_Extra: Do not automatically mark as stale issues labeled as regressions or "Help Wanted"_

### Why?

Currently, an issue must see no activity for 180 days (~six months), at which point it is labeled stale. It will then take a further 60 days of inactivity before the issue is closed.

Take for example issue 9773. It was opened in September 2016, and closed for inactivity in November 2016. It was then resurrected February 2018. Three months later, no activity has occurred. This is, in my opinion, too lenient and the issue should be closed.

### History

Last year, we reached a point where the repo has over 1,500 open issues. After finding some of these issues had no activity for over a year, I enabled a Stale bot on the repository which took care of closing any issue that saw no activity over a two week period. This helped us get to 200 open issues after some time. 

After hearing feedback from the community that the bot was too aggressive on new issues, and considering that 200 open issues on such a broad project as React Native is not too high of a number, I dialed down the Stale bot so that it would take up to ~8 months to close a stale issue. In hindsight, I believe this was too big of an over-correction on my part. With open issues now topping 600, I think it's about time the Stale bot starts closing inactive issues again.

### Closing inactive issues help us focus on what matters

My view is that closing an issue does not indicate the issue is invalid. Closing an issue for inactivity is a sign that the issue is not problematic enough to inspire a member of the community to followup and/or propose a fix through a PR. Closing stale issues as soon as possible should help maintainers surface active issues with the greatest impact on users of the library.

## Test Plan

None, configuration change.

## Release Notes

[INTERNAL] [MINOR] [stale.yml] - Update Stale bot to halve stale closing times.

