### PR TITLE
Fix keyboard handling with keyboardShouldPersistTaps: never

### DIFF
--- a/Libraries/Components/ScrollResponder.js
+++ b/Libraries/Components/ScrollResponder.js
@@ -207,8 +207,8 @@ const ScrollResponderMixin = {
       !keyboardShouldPersistTaps || keyboardShouldPersistTaps === 'never';
     if (
       keyboardNeverPersistTaps &&
-      currentlyFocusedTextInput != null
-      /* && !TextInputState.isTextInput(e.target) */
+      currentlyFocusedTextInput != null &&
+      !TextInputState.isTextInput(e.target)
     ) {
       return true;
     }


### PR DESCRIPTION
When `keyboardShouldPersistTaps` is `"never"` it would break when doing the following steps:

- Tap input 1, keyboard goes up
- Tap input 2, keyboard stays down (The bug I expected without the isTextInput check was that it would dismiss instead :o )
- Tap outside, keyboard stays down. It should dismiss here since it should never persist taps (unless tapping another input)

What seems to happen is that RN `currentlyFocusedTextInput` goes out of sync with the focused text input and is null even if there is still a text input focused. I haven't had time to investigate the cause of that (probably some race condition because of trying to focus and blur at the same time) but we should not try to dismiss the keyboard when tapping another TextInput in the first place.

## Test Plan

I reproduced the bug mentioned by setting `keyboardShouldPersistTaps` to `"never"` in RNTesterPage.js and then using the steps described above. I made sure that the bug did not happen after this change.

## Release Notes

[GENERAL][BUGFIX][ScrollResponder] - Fix keyboard handling with keyboardShouldPersistTaps: never