### PR TITLE
Fix CocoaPods integration without DevSupport subspec

### DIFF
--- a/React/Modules/RCTDevSettings.mm
+++ b/React/Modules/RCTDevSettings.mm
@@ -18,7 +18,6 @@
 #import "RCTEventDispatcher.h"
 #import "RCTJSCSamplingProfiler.h"
 #import "RCTLog.h"
-#import "RCTPackagerClient.h"
 #import "RCTProfile.h"
 #import "RCTUtils.h"
 
@@ -35,6 +34,7 @@ static NSString *const kRCTDevSettingStartSamplingProfilerOnLaunch = @"startSamp
 static NSString *const kRCTDevSettingsUserDefaultsKey = @"RCTDevMenu";
 
 #if ENABLE_PACKAGER_CONNECTION
+#import "RCTPackagerClient.h"
 #import "RCTPackagerConnection.h"
 #endif
 
@@ -201,6 +201,7 @@ RCT_EXPORT_MODULE()
 #endif
 }
 
+#if ENABLE_PACKAGER_CONNECTION
 static void pokeSamplingProfiler(RCTBridge *const bridge, RCTPackagerClientResponder *const responder)
 {
   if (!bridge) {
@@ -224,6 +225,7 @@ static void pokeSamplingProfiler(RCTBridge *const bridge, RCTPackagerClientRespo
     [responder respondWithResult:results];
   }
 }
+#endif
 
 - (dispatch_queue_t)methodQueue
 {


### PR DESCRIPTION
This is the thing which is handled in https://github.com/orta/cocoapods-fix-react-native today.

https://github.com/orta/cocoapods-fix-react-native/blob/89a78ad34950b5d6b3de657914c8ced8bf37ee8e/lib/cocoapods-fix-react-native/versions/0_55_3-post.rb#L140-L164

This should be the correct fix for #17799.

## Test Plan

<!-- 
  Required: Write your test plan here. If you changed any code, please provide us with 
  clear instructions on how you verified your changes work. Bonus points for screenshots and videos! 
-->

Integrating React Native into an existing iOS project using CocoaPods without `DevSupport` subspec and seeing if the project successfully compiles.

## Release Notes

<!-- 
  Required. 
  Help reviewers and the release process by writing your own release notes. See below for an example.
-->

[IOS] [BUGFIX] [DevSupport] - Fix CocoaPods integration without DevSupport subspec