### PR TITLE
android tests.env set buildtools version 26.0.3, build sdk 26, target 22

### DIFF
--- a/scripts/.tests.env
+++ b/scripts/.tests.env
@@ -4,11 +4,11 @@
 
 ## ANDROID ##
 # Android SDK Build Tools revision
-export ANDROID_SDK_BUILD_TOOLS_REVISION=23.0.1
+export ANDROID_SDK_BUILD_TOOLS_REVISION=26.0.3
 # Android API Level we build with
-export ANDROID_SDK_BUILD_API_LEVEL="23"
+export ANDROID_SDK_BUILD_API_LEVEL="26"
 # Minimum Android API Level we target
-export ANDROID_SDK_TARGET_API_LEVEL="19"
+export ANDROID_SDK_TARGET_API_LEVEL="22"
 # Android Virtual Device name
 export AVD_NAME="testAVD"
 # ABI to use in Android Virtual Device


### PR DESCRIPTION
Circle CI tests fail because build tools 26.0.3 is not available. This PR updates tests.env to have build tools 26.0.3, build sdk 26 and target sdk 22.

## Test Plan

Circle CI test won't fail due to lack of build tools 26.0.3