### PR TITLE
[GENERAL] [BUGFIX] [Image] Fix props width, height and tintColor

### DIFF
--- a/Libraries/Image/Image.android.js
+++ b/Libraries/Image/Image.android.js
@@ -239,7 +239,7 @@ const Image = createReactClass({
     let sources;
     if (source.uri) {
       const {width, height} = source;
-      style = flattenStyle([{width, height}, styles.base, this.props.style]);
+      style = flattenStyle(['width' in source && { width }, 'height' in source && { height }, styles.base, this.props.style].filter(Boolean)) || {};
       sources = [{uri: source.uri}];
     } else {
       style = flattenStyle([styles.base, this.props.style]);

--- a/Libraries/Image/Image.ios.js
+++ b/Libraries/Image/Image.ios.js
@@ -106,8 +106,8 @@ const Image = createReactClass({
     }
 
     const resizeMode =
-      this.props.resizeMode || (style || {}).resizeMode || 'cover'; // Workaround for flow bug t7737108
-    const tintColor = this.props.tintColor || (style || {}).tintColor; // Workaround for flow bug t7737108
+      (style || {}).resizeMode || this.props.resizeMode || 'cover'; // Workaround for flow bug t7737108
+    const tintColor = (style || {}).tintColor || this.props.tintColor; // Workaround for flow bug t7737108
 
     if (this.props.src) {
       console.warn(

--- a/Libraries/Image/Image.ios.js
+++ b/Libraries/Image/Image.ios.js
@@ -97,7 +97,7 @@ const Image = createReactClass({
     } else {
       const {width, height, uri} = source;
       style =
-        flattenStyle([{width, height}, styles.base, this.props.style]) || {};
+        flattenStyle(['width' in source && { width }, 'height' in source && { height }, styles.base, this.props.style].filter(Boolean)) || {};
       sources = [source];
 
       if (uri === '') {
@@ -107,7 +107,7 @@ const Image = createReactClass({
 
     const resizeMode =
       this.props.resizeMode || (style || {}).resizeMode || 'cover'; // Workaround for flow bug t7737108
-    const tintColor = (style || {}).tintColor; // Workaround for flow bug t7737108
+    const tintColor = this.props.tintColor || (style || {}).tintColor; // Workaround for flow bug t7737108
 
     if (this.props.src) {
       console.warn(


### PR DESCRIPTION
<!-- All ImageStylePropTypes works when passed as normal props, except these three.-->

## Test Plan

Currently this already works with the live version:
- `<View width={100} height={100} margin={100} />`
- `<Image width={100} height={100} source={[{ uri: '' }]} />` `// width and height when source is an array`
- `<Image margin={100} />` `// any style as prop, except tintColor`

This only works after this pr:
- `<Image width={100} height={100} source={{ uri: '' } />` `// width and height when source is not an array`
- `<Image tintColor="#0000FF" />` `// tintColor as prop`

```jsx
<Image
  width={200}
  height={200}
  borderRadius={100}
  margin={20}
  source={{ uri: 'https://arcweb.co/wp-content/uploads/2016/10/react-logo-1000-transparent.png' }}
  // style={{ width: 300, height: 300, tintColor: 'purple' }}
  tintColor="green"
/>
```

## Release Notes

[GENERAL] [BUGFIX] [Image] Fix props width, height and tintColor

<!--
  **INTERNAL and MINOR tagged notes will not be included in the next version's final release notes.**

    CATEGORY
  [----------]      TYPE
  [ CLI      ] [-------------]    LOCATION
  [ DOCS     ] [ BREAKING    ] [-------------]
  [ GENERAL  ] [ BUGFIX      ] [ {Component} ]
  [ INTERNAL ] [ ENHANCEMENT ] [ {Filename}  ]
  [ IOS      ] [ FEATURE     ] [ {Directory} ]   |-----------|
  [ ANDROID  ] [ MINOR       ] [ {Framework} ] - | {Message} |
  [----------] [-------------] [-------------]   |-----------|

 EXAMPLES:

 [IOS] [BREAKING] [FlatList] - Change a thing that breaks other things
 [ANDROID] [BUGFIX] [TextInput] - Did a thing to TextInput
 [CLI] [FEATURE] [local-cli/info/info.js] - CLI easier to do things with
 [DOCS] [BUGFIX] [GettingStarted.md] - Accidentally a thing/word
 [GENERAL] [ENHANCEMENT] [Yoga] - Added new yoga thing/position
 [INTERNAL] [FEATURE] [./scripts] - Added thing to script that nobody will see
-->
