### PR TITLE
[CI] Update Android packages cache key

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,12 +22,11 @@ aliases:
 
   - &restore-cache-android-packages
     keys:
-      - v1-android-sdkmanager-packages-{{ arch }}-api-26-alpha-{{ checksum "scripts/android-setup.sh" }}
-      - v1-android-sdkmanager-packages-{{ arch }}-api-26-alpha-
+      - v1-android-sdkmanager-packages-api-26-alpha-{{ checksum "scripts/.tests.env" }}
   - &save-cache-android-packages
     paths:
       - /opt/android/sdk
-    key: v1-android-sdkmanager-packages-{{ arch }}-api-26-alpha-{{ checksum "scripts/android-setup.sh" }}
+    key: v1-android-sdkmanager-packages-api-26-alpha-{{ checksum "scripts/.tests.env" }}
 
   - &restore-cache-gradle
     keys:

--- a/scripts/.tests.env
+++ b/scripts/.tests.env
@@ -7,6 +7,8 @@
 export ANDROID_SDK_BUILD_TOOLS_REVISION=26.0.3
 # Android API Level we build with
 export ANDROID_SDK_BUILD_API_LEVEL="26"
+# Google APIs for Android level
+export ANDROID_GOOGLE_API_LEVEL="23"
 # Minimum Android API Level we target
 export ANDROID_SDK_TARGET_API_LEVEL="19"
 # Android Virtual Device name

--- a/scripts/android-setup.sh
+++ b/scripts/android-setup.sh
@@ -17,8 +17,10 @@ function getAndroidPackages {
     sdkmanager "platforms;android-$ANDROID_SDK_TARGET_API_LEVEL"
     echo "Installing SDK build tools, revision $ANDROID_SDK_BUILD_TOOLS_REVISION..."
     sdkmanager "build-tools;$ANDROID_SDK_BUILD_TOOLS_REVISION"
-    echo "Installing Google APIs for Android API level $ANDROID_SDK_BUILD_API_LEVEL..."
-    sdkmanager "add-ons;addon-google_apis-google-$ANDROID_SDK_BUILD_API_LEVEL"
+    # These moved to "system-images;android-$ANDROID_SDK_BUILD_API_LEVEL;google_apis;x86" starting with API level 25, but there is no ARM version.
+    # If our tests do not use Google APIs, we can ommit these.
+    # echo "Installing Google APIs ANDROID_SDK_BUILD_API_LEVEL..."
+    # sdkmanager "add-ons;addon-google_apis-google-$ANDROID_SDK_BUILD_API_LEVEL"
     echo "Installing Android Support Repository"
     sdkmanager "extras;android;m2repository"
     $CI && touch $DEPS

--- a/scripts/android-setup.sh
+++ b/scripts/android-setup.sh
@@ -18,9 +18,8 @@ function getAndroidPackages {
     echo "Installing SDK build tools, revision $ANDROID_SDK_BUILD_TOOLS_REVISION..."
     sdkmanager "build-tools;$ANDROID_SDK_BUILD_TOOLS_REVISION"
     # These moved to "system-images;android-$ANDROID_SDK_BUILD_API_LEVEL;google_apis;x86" starting with API level 25, but there is no ARM version.
-    # If our tests do not use Google APIs, we can ommit these.
-    # echo "Installing Google APIs ANDROID_SDK_BUILD_API_LEVEL..."
-    # sdkmanager "add-ons;addon-google_apis-google-$ANDROID_SDK_BUILD_API_LEVEL"
+    echo "Installing Google APIs $ANDROID_GOOGLE_API_LEVEL..."
+    sdkmanager "add-ons;addon-google_apis-google-$ANDROID_GOOGLE_API_LEVEL"
     echo "Installing Android Support Repository"
     sdkmanager "extras;android;m2repository"
     $CI && touch $DEPS

--- a/scripts/android-setup.sh
+++ b/scripts/android-setup.sh
@@ -16,7 +16,7 @@ function getAndroidPackages {
     echo "Installing target SDK for Android API level $ANDROID_SDK_TARGET_API_LEVEL..."
     sdkmanager "platforms;android-$ANDROID_SDK_TARGET_API_LEVEL"
     echo "Installing SDK build tools, revision $ANDROID_SDK_BUILD_TOOLS_REVISION..."
-    sdkmanager "build-tools;android-$ANDROID_SDK_BUILD_TOOLS_REVISION"
+    sdkmanager "build-tools;$ANDROID_SDK_BUILD_TOOLS_REVISION"
     echo "Installing Google APIs for Android API level $ANDROID_SDK_BUILD_API_LEVEL..."
     sdkmanager "add-ons;addon-google_apis-google-$ANDROID_SDK_BUILD_API_LEVEL"
     echo "Installing Android Support Repository"


### PR DESCRIPTION
Packages are now defined in `scripts/.tests.env`, so the checksum is updated accordingly.

We also throw away the cache if the checksum fails as not doing so may prevent us from picking up new packages due to the filesystem check in `scripts/android-setup.sh`#getAndroidPackages(), as the presence of the `installed-dependencies` file restored from cache will incorrectly flag all deps as being installed.