### PR TITLE
[CI] Remove checksum fallbacks to ensure clean installs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,13 +1,20 @@
 aliases:
   # Cache Management
-  - &restore-cache-yarn
+  - &restore-yarn-cache
     keys:
-      - v2-yarn-{{ arch }}-{{ checksum "package.json" }}
-  - &save-cache-yarn
+      - v1-yarn-cache-{{ arch }}
+  - &save-yarn-cache
+    paths:
+      - ~/.cache/yarn
+    key: v1-yarn-cache-{{ arch }}
+
+  - &restore-node-modules
+    keys:
+      - v2-node-modules-{{ arch }}-{{ checksum "package.json" }}
+  - &save-node-modules
     paths:
       - node_modules
-      - ~/.cache/yarn
-    key: v2-yarn-{{ arch }}-{{ checksum "package.json" }}
+    key: v2-node-modules-{{ arch }}-{{ checksum "package.json" }}
 
   - &restore-cache-analysis
     keys:
@@ -320,9 +327,11 @@ jobs:
       - checkout
       - run: *setup-artifacts
 
-      - restore-cache: *restore-cache-yarn
+      - restore-cache: *restore-yarn-cache
+      - restore-cache: *restore-node-modules
       - run: *yarn
-      - save-cache: *save-cache-yarn
+      - save-cache: *save-yarn-cache
+      - save-cache: *save-node-modules
 
       # Basic checks against the checkout, cache...
       - run: *run-sanity-checks
@@ -449,9 +458,11 @@ jobs:
       - run: *gradle-download-deps
       - save-cache: *save-cache-gradle-downloads
 
-      - restore-cache: *restore-cache-yarn
+      - restore-cache: *restore-yarn-cache
+      - restore-cache: *restore-node-modules
       - run: *yarn
-      - save-cache: *save-cache-yarn
+      - save-cache: *save-yarn-cache
+      - save-cache: *save-node-modules
 
       - run:
           name: Publish React Native Package

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,6 @@ aliases:
   - &restore-cache-yarn
     keys:
       - v1-yarn-{{ arch }}-{{ checksum "package.json" }}
-      - v1-yarn-{{ arch }}-
   - &save-cache-yarn
     paths:
       - node_modules

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,17 +2,16 @@ aliases:
   # Cache Management
   - &restore-cache-yarn
     keys:
-      - v1-yarn-{{ arch }}-{{ checksum "package.json" }}
+      - v2-yarn-{{ arch }}-{{ checksum "package.json" }}
   - &save-cache-yarn
     paths:
       - node_modules
       - ~/.cache/yarn
-    key: v1-yarn-{{ arch }}-{{ checksum "package.json" }}
+    key: v2-yarn-{{ arch }}-{{ checksum "package.json" }}
 
   - &restore-cache-analysis
     keys:
       - v1-analysis-dependencies-{{ arch }}-{{ checksum "package.json" }}{{ checksum "bots/package.json" }}
-      - v1-analysis-dependencies-{{ arch }}-
   - &save-cache-analysis
     paths:
       - bots/node_modules
@@ -44,8 +43,6 @@ aliases:
     keys:
       - v1-apt-{{ .Branch }}-{{ checksum "scripts/circleci/apt-get-android-deps.sh" }}
       # Fallback in case this is a first-time run on a fork
-      # You always want to match checksum, if it fails,
-      # proceed with a fresh install.
       - v1-apt-master-{{ checksum "scripts/circleci/apt-get-android-deps.sh" }}
   - &save-cache-apt
     paths:
@@ -55,7 +52,6 @@ aliases:
   - &restore-cache-ndk
     keys:
       - v3-android-ndk-{{ arch }}-r10e-{{ checksum "scripts/android-setup.sh" }}
-      - v3-android-ndk-{{ arch }}-r10e-
   - &save-cache-ndk
     paths:
       - /opt/ndk


### PR DESCRIPTION
If `package.json` has changed, let's throw away the cache and let yarn install do its thing.

# Test Plan

Circle CI.

# Release Notes

[INTERNAL][MINOR][CircleCI] - Remove checksum fallbacks