### PR TITLE
Update getBuildPath to grab from xcodebuild -showBuildSettings comman…

### DIFF
--- a/local-cli/runIOS/runIOS.js
+++ b/local-cli/runIOS/runIOS.js
@@ -34,7 +34,6 @@ const getBuildPath = function(projectName, isWorkspace, scheme, configuration = 
 
   let path = /target React:(.|\n)*?target (.*?):(.|\n)*? BUILT_PRODUCTS_DIR = (.*?)\n/m.exec(output);
   let match = path[4];
-  console.log(match);
 
   return `${match}/${appName}.app`;
 };


### PR DESCRIPTION
…d so that custom per-configuration build paths are respected. Uses BUILT_PRODUCTS_DIR for the target immediately after React target in the output- it would be nicer if we could use the target name to ensure we're pulling the exact directory, but I can't get the target name without a ton of work reading other xcode project files and plists. However, every correctly configured scheme /should/ have the main target directly after React (if this is not always the case, I'll update where it will pull the correct target for the scheme). 

Thank you for sending the PR! We appreciate you spending the time to work on these changes. 
Help us understand your motivation by explaining why you decided to make this change.

<!-- 
  Required: Write your motivation here.
  If this PR fixes an issue, type "Fixes #issueNumber" to automatically close the issue when the PR is merged.
-->

Fixes #19300 

## Test Plan

<!-- 
  Required: Write your test plan here. If you changed any code, please provide us with 
  clear instructions on how you verified your changes work. Bonus points for screenshots and videos! 
-->

Tested run-ios with multiple schemes/configurations (Debug, DebugProd, DebugQa in my case).

## Related PRs

<!-- 
  Does this PR require a documentation change? 
  Create a PR at https://github.com/facebook/react-native-website and add a link to it here.
-->

## Release Notes

<!-- 
  Required. 
  Help reviewers and the release process by writing your own release notes. See below for an example.
-->

[CLI] [BUGFIX] [runIOS] - Updates run-ios to use xcodebuild's BUILT_PRODUCTS_DIR when installing applications.

<!--
  **INTERNAL and MINOR tagged notes will not be included in the next version's final release notes.**

    CATEGORY
  [----------]      TYPE
  [ CLI      ] [-------------]    LOCATION
  [ DOCS     ] [ BREAKING    ] [-------------]
  [ GENERAL  ] [ BUGFIX      ] [ {Component} ]
  [ INTERNAL ] [ ENHANCEMENT ] [ {Filename}  ]
  [ IOS      ] [ FEATURE     ] [ {Directory} ]   |-----------|
  [ ANDROID  ] [ MINOR       ] [ {Framework} ] - | {Message} |
  [----------] [-------------] [-------------]   |-----------|

 EXAMPLES:

 [IOS] [BREAKING] [FlatList] - Change a thing that breaks other things
 [ANDROID] [BUGFIX] [TextInput] - Did a thing to TextInput
 [CLI] [FEATURE] [local-cli/info/info.js] - CLI easier to do things with
 [DOCS] [BUGFIX] [GettingStarted.md] - Accidentally a thing/word
 [GENERAL] [ENHANCEMENT] [Yoga] - Added new yoga thing/position
 [INTERNAL] [FEATURE] [./scripts] - Added thing to script that nobody will see
-->
