### PR TITLE
add google maven repo required by appcompat-v7 26

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,10 @@ buildscript {
     repositories {
         jcenter()
         mavenLocal()
+        maven {
+            url 'https://maven.google.com/'
+            name 'Google'
+        }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.2'
@@ -18,6 +22,10 @@ allprojects {
     repositories {
         jcenter()
         mavenLocal()
+        maven {
+            url 'https://maven.google.com/'
+            name 'Google'
+        }
 
         def androidSdk = System.getenv("ANDROID_SDK")
         maven {


### PR DESCRIPTION
add google maven repo required by appcompat-v7 26

## Test Plan

CI will download appcompat-v7 version 26.0.2

## Release Notes

[GENERAL][MINOR][Android] - add google maven repo required by appcompat-v7 26