### PR TITLE
update gradle-plugin@2.3.3, gradle@3.5, gradle-download-task@3.4.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,8 +10,8 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.2'
-        classpath 'de.undercouch:gradle-download-task:3.1.2'
+        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'de.undercouch:gradle-download-task:3.4.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.5-all.zip

--- a/local-cli/templates/HelloWorld/android/build.gradle
+++ b/local-cli/templates/HelloWorld/android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:2.3.3'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/local-cli/templates/HelloWorld/android/gradle/wrapper/gradle-wrapper.properties
+++ b/local-cli/templates/HelloWorld/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.5-all.zip


### PR DESCRIPTION
Now we use build tools version 26, and makes it possible to use android gradle plugin 2.3.3 (requires build tools 25), gradle 3.x for improved build performance and developer experience. Also it will help targeting SDK 26 easier.

Android gradle plugin to 2.3.3 requires gradle version 3.3 or above, and gradle download task version 3.2.0 and above supports gradle version 3.3. Therefore, it's better to use latest gradle 3.x or 3.5, and gradle download task 3.4.0.

## Test Plan

React Native and apps will build much faster and run as before.