### PR TITLE
Migrate to new GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,3 +1,9 @@
+---
+name: 🐛 Bug Report
+about: Something is not working as expected.
+
+---
+
 <!--
   We use GitHub Issues exclusively for tracking bugs in React Native.
   Questions? Visit http://facebook.github.io/react-native/help.html
@@ -15,8 +21,8 @@
 <!-- Required. Run `react-native info` in your terminal and paste its contents here. -->
 
 ## Steps to Reproduce
-<!-- 
-  Required. Let us know how to reproduce the issue. Include a code sample, share a project, 
+<!--
+  Required. Let us know how to reproduce the issue. Include a code sample, share a project,
   or share an app that reproduces the issue using [Snack](https://snack.expo.io/).
 -->
 

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,6 +1,6 @@
 ---
 name: 💬 Question
-about: Questions about using React Native
+about: For questions about using React Native in your app.
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,21 @@
+---
+name: 💬 Question
+about: Questions about using React Native
+
+---
+
+--------------^ Click "Preview" for a nicer view!
+
+We use GitHub Issues exclusively for tracking bugs in React Native. If you need help with your React Native app, the right place to go depends on the type of help that you need.
+
+### Stack Overflow
+
+Many members of the community use Stack Overflow to ask questions. Read through the [existing questions](http://stackoverflow.com/questions/tagged/react-native?sort=frequent) tagged with **react-native** or [ask your own](http://stackoverflow.com/questions/ask?tags=react-native)!
+
+### Discussion Forum
+
+For longer-form conversations about React Native, we’ve set up a [discussion forum at **discuss.reactjs.org**](https://discuss.reactjs.org/t/welcome-react-native-community-group/10239). This forum is a great place for discussion about best practices and application architecture as well as the future of React Native. If you have an answerable code-level question, please post it to [Stack Overflow](http://stackoverflow.com/questions/ask?tags=react-native) instead.
+
+### Reactiflux Chat
+
+If you need an answer right away, check out the [Reactiflux Discord](https://discord.gg/0ZcbPKXt5bZjGY5n) community. There are usually a number of React Native experts there who can help out or point you to somewhere you might want to look.


### PR DESCRIPTION
This will allow us to present a user with a different template depending on the type of help they need.

To do:

1. Update the bot so that it auto-closes any issue that contains text from `question.md` (i.e. tried to ask a question through GitHub).
2. In a separate PR: new template to handle feature requests (update the bot to allow these to remain open)
3. Allow multiple other types of issues, such as requesting a cherry pick, or reporting a regression vs. something that does not work as expected.
4. Link to Stack Overflow / Discuss directly if and when GitHub allows the 'Get Started' button to point to a URL.