### PR TITLE
Bootstrap new project with template of package.json

### DIFF
--- a/local-cli/util/PackageManager.js
+++ b/local-cli/util/PackageManager.js
@@ -71,4 +71,5 @@ function remove(packageName) {
 module.exports = {
   add: add,
   remove: remove,
+  callYarnOrNpm: callYarnOrNpm,
 };


### PR DESCRIPTION
There was conversation in comments to PR https://github.com/facebook/react-native/pull/18164 , where introduced devDependencies.json file, but also in templates we have many other settings, for i.e. settings for jest, prettier, detox and so on. So it would be great if instead of different files for each case (like `dependencies.json` and devDependencies.json`) we could change whole `package.json` that represented in template.

In this PR I introduce new file called `package.template.json`, this is file that replace initially generated `package.json`. Actually this file not replace all content, instead content will merge. This is doing because user can set project name through `cli` (that represented as `name` field) and choose RN version (or even default will be fresh one) that we anyway need in our `package.json`, so IMO best strategy is merge initially generated file with template, not replacing fields that already exist.

Another point, that I want to mention, it's custom scripts after project bootstrap. At first I thought about some custom realisation, but then I realise that `postinstall` npm hook is better place for this. You can see example [there](https://github.com/Sprit3Dan/react-native-supercharged/blob/master/package.template.json#L8).

## Test Plan

I don't know about test plan, but I test it on our [template](https://github.com/Sprit3Dan/react-native-supercharged).

## Related PRs

As I mentioned above, PR https://github.com/facebook/react-native/pull/18164 conversation is recommended to read.

## Release Notes

[CLI] [FEATURE] [local-cli/generator/templates.js] - Better way to make custom templates with their own settings
