### PR TITLE
[CI] Fix JUnit report location when running Jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
   ],
   "scripts": {
     "test": "jest",
-    "test-ci": "JEST_JUNIT_OUTPUT=\"~/reports/junit/js-test-results.xml\" jest --maxWorkers=2 --ci --testResultsProcessor=\"jest-junit\"",
+    "test-ci": "JEST_JUNIT_OUTPUT=\"reports/junit/js-test-results.xml\" jest --maxWorkers=2 --ci --testResultsProcessor=\"jest-junit\"",
     "flow": "flow",
     "lint": "eslint .",
     "prettier": "find . -name node_modules -prune -or -name '*.js' -print | xargs prettier --write",


### PR DESCRIPTION
We were incorrectly writing jest's junit output to ~/reports/ instead of ~/react-native/reports.

## Test Plan

Run on Circle and confirm JUnit test results are rendered: https://circleci.com/gh/hramos/react-native/2208

## Release Notes

[INTERNAL][MINOR][CI] - JUnit test collection

[skip ci]