### PR TITLE
Enable edge antialiasing only for transforms with perspective

### DIFF
--- a/React/Base/RCTModuleMethod.mm
+++ b/React/Base/RCTModuleMethod.mm
@@ -544,7 +544,6 @@ RCT_EXTERN_C_END
   [_invocation invokeWithTarget:module];
 #endif
 
-  index = 2;
   [_retainedObjects removeAllObjects];
 
   if (_methodInfo->isSync) {

--- a/React/Modules/RCTUIManager.m
+++ b/React/Modules/RCTUIManager.m
@@ -133,7 +133,7 @@ RCT_EXPORT_MODULE()
 
 - (void)setBridge:(RCTBridge *)bridge
 {
-  RCTAssert(_bridge == nil, @"Should not re-use same UIIManager instance");
+  RCTAssert(_bridge == nil, @"Should not re-use same UIManager instance");
   _bridge = bridge;
 
   _shadowViewRegistry = [NSMutableDictionary new];

--- a/React/Views/RCTViewManager.m
+++ b/React/Views/RCTViewManager.m
@@ -141,8 +141,8 @@ RCT_CUSTOM_VIEW_PROPERTY(shouldRasterizeIOS, BOOL, RCTView)
 RCT_CUSTOM_VIEW_PROPERTY(transform, CATransform3D, RCTView)
 {
   view.layer.transform = json ? [RCTConvert CATransform3D:json] : defaultView.layer.transform;
-  // TODO: Improve this by enabling edge antialiasing only for transforms with rotation or skewing
-  view.layer.allowsEdgeAntialiasing = !CATransform3DIsIdentity(view.layer.transform);
+  // Enable edge antialiasing in perspective transforms
+  view.layer.allowsEdgeAntialiasing = !(view.layer.transform.m34 == 0.0f);
 }
 
 RCT_CUSTOM_VIEW_PROPERTY(pointerEvents, RCTPointerEvents, RCTView)


### PR DESCRIPTION
## Test Plan
Tested under `iPhone6+` and simulator, test `perspective` and `skew*` props of `View`.
 The `jag` only happed when `m34` of `transform` is not equal to `0.0f`.

## Related PRs

No related PRs.

## Changelog

[iOS] [Added] - RCTViewManager: Enable edge antialiasing only for transforms with perspective.
