### PR TITLE
circle ci: yarn cache uses package.json checksum as a key

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,11 +2,12 @@ aliases:
   # Cache Management
   - &restore-yarn-cache
     keys:
+      - v1-yarn-cache-{{ arch }}-{{ checksum "package.json" }}
       - v1-yarn-cache-{{ arch }}
   - &save-yarn-cache
     paths:
       - ~/.cache/yarn
-    key: v1-yarn-cache-{{ arch }}
+    key: v1-yarn-cache-{{ arch }}-{{ checksum "package.json" }}
 
   - &restore-node-modules
     keys:


### PR DESCRIPTION
To better utilize Circle CI caching, yarn cache will use package.json file checksum as key in addition to arch, because in most cases yarn cache will be updated if package.json updates.

Circle CI sample apps use yarn.lock checksum as yarn cache key, but react-native don't have yarn.lock in the repo, so it's best to use package.json instead.