### PR TITLE
Restore catch-all issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,3 @@
+GitHub Issues in the `facebook/react-native` repository are used exclusively for tracking bugs in React Native.
+
+Please take a look at the issue templates at https://github.com/facebook/react-native/issues/new/choose before submitting a new issue. Following one of the issue templates will ensure maintainers can route your request efficiently. Thanks!

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,12 +4,7 @@ about: Something is not working as expected.
 
 ---
 
-<!--
-  We use GitHub Issues exclusively for tracking bugs in React Native.
-  Questions? Visit http://facebook.github.io/react-native/help.html
-  If this issue is about documentation or the website, please file it at:
-  https://github.com/facebook/react-native-website/issues/new
--->
+<!-- GitHub Issues in the `facebook/react-native` repository are used exclusively for tracking bugs in React Native. -->
 
 - [ ] I have reviewed the [documentation](https://facebook.github.io/react-native)
 - [ ] I have searched [existing issues](https://github.com/facebook/react-native/issues)

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,0 +1,9 @@
+---
+name: 📖 Documentation Issue
+about: Report issues with the docs at https://github.com/facebook/react-native-website/issues
+
+---
+
+GitHub Issues in the `facebook/react-native` repository are used exclusively for tracking bugs in React Native.
+
+If you would like to report an issue in the React Native documentation, or anything related to the [React Native website](http://facebook.github.io/react-native), please visit https://github.com/facebook/react-native-website/issues.

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -6,7 +6,7 @@ about: For questions about using React Native in your app.
 
 --------------^ Click "Preview" for a nicer view!
 
-We use GitHub Issues exclusively for tracking bugs in React Native. If you need help with your React Native app, the right place to go depends on the type of help that you need.
+GitHub Issues in the `facebook/react-native` repository are used exclusively for tracking bugs in React Native. If you need help with your React Native app, the right place to go depends on the type of help that you need.
 
 ### Stack Overflow
 


### PR DESCRIPTION
Without this, people may still submit non-templated issues.