### PR TITLE
Add `onScroll` prop to Android WebView

### DIFF
--- a/Libraries/Components/WebView/WebView.android.js
+++ b/Libraries/Components/WebView/WebView.android.js
@@ -56,6 +56,7 @@ class WebView extends React.Component {
     onNavigationStateChange: PropTypes.func,
     onMessage: PropTypes.func,
     onContentSizeChange: PropTypes.func,
+    onScroll: PropTypes.func,
     startInLoadingState: PropTypes.bool, // force WebView to show loadingView on first load
     style: ViewPropTypes.style,
 
@@ -326,6 +327,7 @@ class WebView extends React.Component {
         onLoadingStart={this.onLoadingStart}
         onLoadingFinish={this.onLoadingFinish}
         onLoadingError={this.onLoadingError}
+        onScroll={this.onScroll}
         testID={this.props.testID}
         geolocationEnabled={this.props.geolocationEnabled}
         mediaPlaybackRequiresUserAction={
@@ -454,6 +456,11 @@ class WebView extends React.Component {
     const {onMessage} = this.props;
     onMessage && onMessage(event);
   };
+
+  onScroll = (event: Event) => {
+    const {onScroll} = this.props;
+    onScroll && onScroll(event);
+  }
 }
 
 const RCTWebView = requireNativeComponent('RCTWebView');


### PR DESCRIPTION
This PR adds `onScroll` prop to `WebView` component on Android.

This prop would be useful for scenarios that requires to listen to `WebView` scroll events, such as hiding a bottom toolbar when scrolling down and showing it again when scrolling up.

## Test Plan

![android-webview-scroll](https://user-images.githubusercontent.com/1135129/40481644-9d1b8062-5f84-11e8-950e-b513f17d08e0.gif)

## Release Notes

[ANDROID] [FEATURE] [WebView] - Add `onScroll` prop

## Related Issues/PRs

#1961
#18048
