### PR TITLE
Prevent forcing lower-casing in HTTP request headers

### DIFF
--- a/Libraries/Network/XMLHttpRequest.js
+++ b/Libraries/Network/XMLHttpRequest.js
@@ -435,7 +435,7 @@ class XMLHttpRequest extends EventTarget(...XHR_EVENTS) {
     if (this.readyState !== this.OPENED) {
       throw new Error('Request has not been opened');
     }
-    this._headers[header.toLowerCase()] = String(value);
+    this._headers[header] = String(value);
   }
 
   /**


### PR DESCRIPTION
The purpose of the change is to comply with the servers that accept only network requests with a specific case headers, e.g `Content-Type`, `Authorization`, etc.

Currently all the headers get lower-cased which is often not the desirable action. The normalization happens currently in `Libraries/Network/XMLHttpRequest.js` as well as in the third-party `fetch` implementation library that React uses (https://github.com/github/fetch/blob/master/fetch.js#L50). The change gives flexibility to specify the desirable casing (if using different third-party networking library or a custom implementation of `xmlHttpRequest`), leaving all the other users unaffected, because the `fetch` will keep on lowercasing the headers. 

## Test Plan

The code can be tested by inspecting the network requests.

## Release Notes

 [GENERAL] [MINOR] [XMLHttpRequest.js] - Allow specific header casing in HTTP requests


