### PR TITLE
Fixing link to Android build guide.

### DIFF
--- a/ReactAndroid/README.md
+++ b/ReactAndroid/README.md
@@ -1,6 +1,6 @@
 # Building React Native for Android
 
-See the [docs on the website](https://facebook.github.io/react-native/docs/android-building-from-source.html).
+See the [docs on the website](https://facebook.github.io/react-native/docs/building-from-source.html#android).
 
 # Running tests
 


### PR DESCRIPTION
While browsing the repository, I noticed that the link to how to build for Android has changed. It's a very simple fix.

## Test Plan

Verifying that the URL is correct.

## Related PRs

None.

## Release Notes

<!-- 
  Required. 
  Help reviewers and the release process by writing your own release notes. See below for an example.
-->

[DOCS] [BUGFIX] [ReactAndroid/README.md] - Incorrect URL
