### PR TITLE
Fix error `Property with 'retain' (or strong) attribute must be of ob…

### DIFF
--- a/React/Base/RCTBridgeModule.h
+++ b/React/Base/RCTBridgeModule.h
@@ -108,7 +108,11 @@ RCT_EXTERN void RCTRegisterModule(Class); \
  * and the bridge will populate the methodQueue property for you automatically
  * when it initializes the module.
  */
+#if OS_OBJECT_HAVE_OBJC_SUPPORT == 1
 @property (nonatomic, strong, readonly) dispatch_queue_t methodQueue;
+#else
+@property (nonatomic, assign, readonly) dispatch_queue_t methodQueue;
+#endif
 
 /**
  * Wrap the parameter line of your method implementation with this macro to


### PR DESCRIPTION
Fix error `Property with 'retain' (or strong) attribute must be of object type`.

 Fixes #18853 


## Test Plan
  It puzzled me, but everything runs right to me after modifying the code.

## Release Notes
A `dispatch_queue_t` `object` in common is not an object in lower versions of iOS(<6.0) or OSX(<10.8). 
Macro `OS_OBJECT_HAVE_OBJC_SUPPORT ` defines that OS objects like GCD have objective C support. So ARC, memory management, reference counting etc. applies to GCD objects.


[IOS] [BUGFIX] [RCTBridgeModule.h] - add macro to avoid `Property with 'retain' (or strong) attribute must be of object type` error.

