### PR TITLE
Fix jest snapshot testing on windows

### DIFF
--- a/jest-preset.json
+++ b/jest-preset.json
@@ -15,7 +15,7 @@
   ],
   "transform": {
     "^.+\\.js$": "babel-jest",
-    "^[./a-zA-Z0-9$_-]+\\.(bmp|gif|jpg|jpeg|mp4|png|psd|svg|webp)$": "<rootDir>/node_modules/react-native/jest/assetFileTransformer.js"
+    "^.+\\.(bmp|gif|jpg|jpeg|mp4|png|psd|svg|webp)$": "<rootDir>/node_modules/react-native/jest/assetFileTransformer.js"
   },
   "transformIgnorePatterns": [
     "node_modules/(?!(jest-)?react-native|react-clone-referenced-element)"

--- a/jest/assetFileTransformer.js
+++ b/jest/assetFileTransformer.js
@@ -21,7 +21,7 @@ module.exports = {
   // the Jest snapshot.
   process: (_, filename) =>
     `module.exports = {
-      testUri: ${JSON.stringify(path.relative(__dirname, filename))}
+      testUri: ${JSON.stringify(path.relative(__dirname, filename).replace(/\\/g, '/'))}
     };`,
   getCacheKey: createCacheKeyFunction([__filename]),
 };

--- a/jest/assetFileTransformer.js
+++ b/jest/assetFileTransformer.js
@@ -21,7 +21,10 @@ module.exports = {
   // the Jest snapshot.
   process: (_, filename) =>
     `module.exports = {
-      testUri: ${JSON.stringify(path.relative(__dirname, filename).replace(/\\/g, '/'))}
+      testUri: 
+        ${JSON.stringify(
+          path.relative(__dirname, filename).replace(/\\/g, '/'),
+        )}
     };`,
   getCacheKey: createCacheKeyFunction([__filename]),
 };

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "jest": {
     "transform": {
-      "^[./a-zA-Z0-9$_-]+\\.(bmp|gif|jpg|jpeg|mp4|png|psd|svg|webp)$": "<rootDir>/jest/assetFileTransformer.js",
+      "^.+\\.(bmp|gif|jpg|jpeg|mp4|png|psd|svg|webp)$": "<rootDir>/jest/assetFileTransformer.js",
       ".*": "./jest/preprocessor.js"
     },
     "setupFiles": [


### PR DESCRIPTION
Fixes #19370

## Test Plan

Applied changes to existing project that uses jest snapshot testing. Testing was broken before and now works.

To verify: Run any snapshot test containing an image reference on Windows before and after this PR.

## Related PRs
#13319 introduced the issue fixed in this PR

## Release Notes

[WINDOWS][BUGFIX][jest] - Fixed jest snapshot testing on windows