### PR TITLE
react-native-xcode.sh: Support Homebrew-installed nodenv

### DIFF
--- a/scripts/react-native-xcode.sh
+++ b/scripts/react-native-xcode.sh
@@ -62,6 +62,8 @@ fi
 # Set up the nodenv node version manager if present
 if [[ -x "$HOME/.nodenv/bin/nodenv" ]]; then
   eval "$("$HOME/.nodenv/bin/nodenv" init -)"
+elif [[ -x "$(command -v brew)" && -x "$(brew --prefix nodenv)/bin/nodenv" ]]; then
+  eval "$("$(brew --prefix nodenv)/bin/nodenv" init -)"
 fi
 
 [ -z "$NODE_BINARY" ] && export NODE_BINARY="node"


### PR DESCRIPTION
As well as nvm.

https://github.com/facebook/react-native/blob/9d315f4a1e7b0c9cd80a51903db0b1b561b19e33/scripts/react-native-xcode.sh#L56-L60

## Test Plan

Build React Native iOS app with Release configuration and run the script using `node` command which is installed through Homebrew-installed `nodenv` and `node-build`.

## Related PRs

None.

## Release Notes

[IOS] [ENHANCEMENT] [scripts/react-native-xcode.sh] - Support Homebrew-installed nodenv