### PR TITLE
android compileSdk 26, build-tools 26.0.2

### DIFF
--- a/.buckconfig
+++ b/.buckconfig
@@ -7,6 +7,7 @@
 
 [maven_repositories]
   central = https://repo1.maven.org/maven2
+  google = https://maven.google.com
 
 [alias]
   rntester = //RNTester/android/app:app

--- a/.buckconfig
+++ b/.buckconfig
@@ -1,6 +1,6 @@
 
 [android]
-  target = android-26
+  target = Google Inc.:Google APIs:23
 
 [download]
   max_number_of_retries = 3

--- a/.buckconfig
+++ b/.buckconfig
@@ -1,6 +1,6 @@
 
 [android]
-  target = Google Inc.:Google APIs:23
+  target = android-26
 
 [download]
   max_number_of_retries = 3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,12 +67,12 @@ aliases:
 
   - &restore-cache-buck
     keys:
-      - v3-buck-{{ arch }}-v2018.02.16.01
+      - v3-buck-{{ arch }}-v2018.03.26.01
   - &save-cache-buck
     paths:
       - ~/buck
       - ~/okbuck
-    key: v3-buck-{{ arch }}-v2018.02.16.01
+    key: v3-buck-{{ arch }}-v2018.03.26.01
 
   - &restore-cache-watchman
     keys:
@@ -140,7 +140,7 @@ aliases:
     name: Install BUCK
     command: |
       if [[ ! -e ~/buck ]]; then
-        git clone https://github.com/facebook/buck.git ~/buck --branch v2018.02.16.01 --depth=1
+        git clone https://github.com/facebook/buck.git ~/buck --branch v2018.03.26.01 --depth=1
       fi
       cd ~/buck && ant
       buck --version

--- a/RNTester/android/app/build.gradle
+++ b/RNTester/android/app/build.gradle
@@ -84,8 +84,8 @@ def enableSeparateBuildPerCPUArchitecture = false
 def enableProguardInReleaseBuilds = false
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion 26
+    buildToolsVersion "26.0.2"
 
     defaultConfig {
         applicationId "com.facebook.react.uiapp"
@@ -137,7 +137,7 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:23.0.1'
+    compile 'com.android.support:appcompat-v7:26.1.0'
 
     // Build React Native from source
     compile project(':ReactAndroid')

--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -242,8 +242,8 @@ task packageReactNdkLibsForBuck(dependsOn: packageReactNdkLibs, type: Copy) {
 }
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion 26
+    buildToolsVersion "26.0.2"
 
     defaultConfig {
         minSdkVersion 16
@@ -292,7 +292,7 @@ android {
 dependencies {
     compile fileTree(dir: 'src/main/third-party/java/infer-annotations/', include: ['*.jar'])
     compile 'javax.inject:javax.inject:1'
-    compile 'com.android.support:appcompat-v7:23.0.1'
+    compile 'com.android.support:appcompat-v7:26.1.0'
     compile 'com.facebook.fbui.textlayoutbuilder:textlayoutbuilder:1.0.0'
     compile 'com.facebook.fresco:fresco:1.9.0'
     compile 'com.facebook.fresco:imagepipeline-okhttp3:1.9.0'

--- a/ReactAndroid/libs/BUCK
+++ b/ReactAndroid/libs/BUCK
@@ -6,8 +6,8 @@ android_prebuilt_aar(
 
 remote_file(
     name = "appcompat-binary-aar",
-    sha1 = "7d659f671541394a8bc2b9f909950aa2a5ec87ff",
-    url = "mvn:com.android.support:appcompat-v7:aar:23.0.1",
+    sha1 = "da5771a9ac6e8f3a461360eed3c6f921dc7580fd",
+    url = "mvn:com.android.support:appcompat-v7:aar:26.1.0",
 )
 
 android_prebuilt_aar(

--- a/ReactAndroid/src/main/java/com/facebook/react/common/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/common/BUCK
@@ -10,6 +10,9 @@ rn_android_library(
         ["**/*.java"],
         excludes = SUB_PROJECTS,
     ),
+    provided_deps = [
+        react_native_dep("third-party/android/support/v4:lib-support-v4"),
+    ],
     required_for_source_only_abi = True,
     visibility = [
         "PUBLIC",
@@ -19,7 +22,6 @@ rn_android_library(
         react_native_dep("libraries/fbcore/src/main/java/com/facebook/common/logging:logging"),
         react_native_dep("third-party/java/infer-annotations:infer-annotations"),
         react_native_dep("third-party/java/jsr-305:jsr-305"),
-        react_native_dep("third-party/android/support/v4:lib-support-v4"),
     ],
     exported_deps = [
         react_native_dep("java/com/facebook/proguard/annotations:annotations"),

--- a/ReactAndroid/src/main/java/com/facebook/react/common/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/common/BUCK
@@ -10,9 +10,6 @@ rn_android_library(
         ["**/*.java"],
         excludes = SUB_PROJECTS,
     ),
-    provided_deps = [
-        react_native_dep("third-party/android/support/v4:lib-support-v4"),
-    ],
     required_for_source_only_abi = True,
     visibility = [
         "PUBLIC",
@@ -22,6 +19,7 @@ rn_android_library(
         react_native_dep("libraries/fbcore/src/main/java/com/facebook/common/logging:logging"),
         react_native_dep("third-party/java/infer-annotations:infer-annotations"),
         react_native_dep("third-party/java/jsr-305:jsr-305"),
+        react_native_dep("third-party/android/support/v4:lib-support-v4"),
     ],
     exported_deps = [
         react_native_dep("java/com/facebook/proguard/annotations:annotations"),

--- a/ReactAndroid/src/main/third-party/android/support-annotations/BUCK
+++ b/ReactAndroid/src/main/third-party/android/support-annotations/BUCK
@@ -6,6 +6,6 @@ prebuilt_jar(
 
 remote_file(
     name = "support-annotations-binary-aar",
-    sha1 = "1fce89a6428c51467090d7f424e4c9c3dbd55f7e",
-    url = "mvn:com.android.support:support-annotations:jar:23.0.1",
+    sha1 = "0814258103cf26a15fcc26ecce35f5b7d24b73f8",
+    url = "mvn:com.android.support:support-annotations:jar:26.1.0",
 )

--- a/ReactAndroid/src/main/third-party/android/support/v4/BUCK
+++ b/ReactAndroid/src/main/third-party/android/support/v4/BUCK
@@ -5,9 +5,27 @@ android_library(
       ":lib-support-v4-support-core-utils",
       ":lib-support-v4-support-core-ui",
       ":lib-support-v4-support-media-compat",
-      ":lib-support-v4-support-fragment"
+      ":lib-support-v4-support-fragment",
+      ":android-lifecycle-runtime",
+      ":android-lifecycle-common.jar",
+      ":android-lifecycle-core.jar"
     ],
     visibility = ["PUBLIC"],
+)
+
+prebuilt_jar(
+    name = "android-lifecycle-common.jar",
+    binary_jar = ":android-lifecycle-common-jar"
+)
+
+prebuilt_jar(
+    name = "android-lifecycle-core.jar",
+    binary_jar = ":android-lifecycle-core-jar"
+)
+
+android_prebuilt_aar(
+    name = "android-lifecycle-runtime",
+    aar = ":android-lifecycle-runtime-aar",
 )
 
 android_prebuilt_aar(
@@ -33,6 +51,24 @@ android_prebuilt_aar(
 android_prebuilt_aar(
     name = "lib-support-v4-support-fragment",
     aar = ":lib-support-v4-support-fragment-aar",
+)
+
+remote_file(
+  name = "android-lifecycle-runtime-aar",
+  sha1 = "30c60a8a357ee1321ffd0c9f08ef54b24045cd10",
+  url = "mvn:android.arch.lifecycle:runtime:aar:1.0.0"
+)
+
+remote_file(
+  name = "android-lifecycle-common-jar",
+  sha1 = "e414a4cb28434e25c4f6aa71426eb20cf4874ae9",
+  url = "mvn:android.arch.lifecycle:common:jar:1.0.0"
+)
+
+remote_file(
+  name = "android-lifecycle-core-jar",
+  sha1 = "a2d487452376193fc8c103dd2b9bd5f2b1b44563",
+  url = "mvn:android.arch.core:common:jar:1.0.0"
 )
 
 remote_file(

--- a/ReactAndroid/src/main/third-party/android/support/v4/BUCK
+++ b/ReactAndroid/src/main/third-party/android/support/v4/BUCK
@@ -1,11 +1,70 @@
-android_prebuilt_aar(
+android_library(
     name = "lib-support-v4",
-    aar = ":lib-support-v4-binary-aar",
+    deps = [
+      ":lib-support-v4-support-compat",
+      ":lib-support-v4-support-core-utils",
+      ":lib-support-v4-support-core-ui",
+      ":lib-support-v4-support-media-compat",
+      ":lib-support-v4-support-fragment"
+    ]
+)
+
+android_prebuilt_aar(
+    name = "lib-support-v4-support-compat",
+    aar = ":lib-support-v4-support-compat-aar",
     visibility = ["PUBLIC"],
 )
 
+android_prebuilt_aar(
+  name = "lib-support-v4-support-core-utils",
+  aar = ":lib-support-v4-support-core-utils-aar",
+  visibility = ["PUBLIC"],
+)
+
+android_prebuilt_aar(
+  name = "lib-support-v4-support-core-ui",
+  aar = ":lib-support-v4-support-core-ui-aar",
+  visibility = ["PUBLIC"],
+)
+
+android_prebuilt_aar(
+  name = "lib-support-v4-support-media-compat",
+  aar = ":lib-support-v4-support-media-compat-aar",
+  visibility = ["PUBLIC"],
+)
+
+android_prebuilt_aar(
+  name = "lib-support-v4-support-fragment",
+  aar = ":lib-support-v4-support-fragment-aar",
+  visibility = ["PUBLIC"],
+)
+
 remote_file(
-    name = "lib-support-v4-binary-aar",
-    sha1 = "444114b772e5eee3e66f9236ace4acc1964a33b8",
-    url = "mvn:com.android.support:support-v4:aar:26.1.0",
+    name = "lib-support-v4-support-compat-aar",
+    sha1 = "1e1c8ffc01d277d8f01dfd11d5d2ce3a2af4b98c",
+    url = "mvn:com.android.support:support-compat:aar:26.1.0",
+)
+
+remote_file(
+    name = "lib-support-v4-support-core-utils-aar",
+    sha1 = "1bfaae21c4d5c5532c5e732071e9ce234cd58cff",
+    url = "mvn:com.android.support:support-core-utils:aar:26.1.0",
+)
+
+remote_file(
+  name = "lib-support-v4-support-core-ui-aar",
+  sha1 = "e306308d54052a1ded7bf9c2f5c2fdf5152a1f22",
+  url = "mvn:com.android.support:support-core-ui:aar:26.1.0",
+)
+
+remote_file(
+  name = "lib-support-v4-support-media-compat-aar",
+  sha1 = "09fb587f27cde19aa8f2e50c5c9ee645d9aec44d",
+  url = "mvn:com.android.support:support-media-compat:aar:26.1.0",
+)
+
+remote_file(
+  name = "lib-support-v4-support-fragment-aar",
+  sha1 = "ddacf369bb98dd6558606558de8ddcd53895cf91",
+  url = "mvn:com.android.support:support-fragment:aar:26.1.0",
 )

--- a/ReactAndroid/src/main/third-party/android/support/v4/BUCK
+++ b/ReactAndroid/src/main/third-party/android/support/v4/BUCK
@@ -6,6 +6,6 @@ android_prebuilt_aar(
 
 remote_file(
     name = "lib-support-v4-binary-aar",
-    sha1 = "9e8da0e4ecf9f63258c7fbd273889252cba2d0c3",
-    url = "mvn:com.android.support:support-v4:aar:23.0.1",
+    sha1 = "444114b772e5eee3e66f9236ace4acc1964a33b8",
+    url = "mvn:com.android.support:support-v4:aar:26.1.0",
 )

--- a/ReactAndroid/src/main/third-party/android/support/v4/BUCK
+++ b/ReactAndroid/src/main/third-party/android/support/v4/BUCK
@@ -1,42 +1,38 @@
 android_library(
     name = "lib-support-v4",
-    deps = [
+    exported_deps = [
       ":lib-support-v4-support-compat",
       ":lib-support-v4-support-core-utils",
       ":lib-support-v4-support-core-ui",
       ":lib-support-v4-support-media-compat",
       ":lib-support-v4-support-fragment"
-    ]
+    ],
+    visibility = ["PUBLIC"],
 )
 
 android_prebuilt_aar(
     name = "lib-support-v4-support-compat",
     aar = ":lib-support-v4-support-compat-aar",
-    visibility = ["PUBLIC"],
 )
 
 android_prebuilt_aar(
-  name = "lib-support-v4-support-core-utils",
-  aar = ":lib-support-v4-support-core-utils-aar",
-  visibility = ["PUBLIC"],
+    name = "lib-support-v4-support-core-utils",
+    aar = ":lib-support-v4-support-core-utils-aar",
 )
 
 android_prebuilt_aar(
-  name = "lib-support-v4-support-core-ui",
-  aar = ":lib-support-v4-support-core-ui-aar",
-  visibility = ["PUBLIC"],
+    name = "lib-support-v4-support-core-ui",
+    aar = ":lib-support-v4-support-core-ui-aar",
 )
 
 android_prebuilt_aar(
-  name = "lib-support-v4-support-media-compat",
-  aar = ":lib-support-v4-support-media-compat-aar",
-  visibility = ["PUBLIC"],
+    name = "lib-support-v4-support-media-compat",
+    aar = ":lib-support-v4-support-media-compat-aar",
 )
 
 android_prebuilt_aar(
-  name = "lib-support-v4-support-fragment",
-  aar = ":lib-support-v4-support-fragment-aar",
-  visibility = ["PUBLIC"],
+    name = "lib-support-v4-support-fragment",
+    aar = ":lib-support-v4-support-fragment-aar",
 )
 
 remote_file(

--- a/ReactAndroid/src/main/third-party/android/support/v7/appcompat-orig/BUCK
+++ b/ReactAndroid/src/main/third-party/android/support/v7/appcompat-orig/BUCK
@@ -56,6 +56,6 @@ python_binary(
 
 remote_file(
     name = "appcompat-binary-aar",
-    sha1 = "7d659f671541394a8bc2b9f909950aa2a5ec87ff",
-    url = "mvn:com.android.support:appcompat-v7:aar:23.0.1",
+    sha1 = "da5771a9ac6e8f3a461360eed3c6f921dc7580fd",
+    url = "mvn:com.android.support:appcompat-v7:aar:26.1.0",
 )

--- a/local-cli/link/__fixtures__/android/build.gradle
+++ b/local-cli/link/__fixtures__/android/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
     compile fileTree(dir: "libs", include: ["*.jar"])
-    compile "com.android.support:appcompat-v7:23.0.1"
+    compile "com.android.support:appcompat-v7:26.1.0"
     compile "com.facebook.react:react-native:0.18.+"
 }

--- a/local-cli/link/__fixtures__/android/patchedBuild.gradle
+++ b/local-cli/link/__fixtures__/android/patchedBuild.gradle
@@ -4,6 +4,6 @@ dependencies {
       exclude(group: 'org.unwanted', module: 'test10')
     }
     compile fileTree(dir: "libs", include: ["*.jar"])
-    compile "com.android.support:appcompat-v7:23.0.1"
+    compile "com.android.support:appcompat-v7:26.1.0"
     compile "com.facebook.react:react-native:0.18.+"
 }

--- a/local-cli/templates/HelloWorld/android/app/build.gradle
+++ b/local-cli/templates/HelloWorld/android/app/build.gradle
@@ -94,8 +94,8 @@ def enableSeparateBuildPerCPUArchitecture = false
 def enableProguardInReleaseBuilds = false
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion 26
+    buildToolsVersion "26.0.2"
 
     defaultConfig {
         applicationId "com.helloworld"
@@ -138,7 +138,7 @@ android {
 
 dependencies {
     compile fileTree(dir: "libs", include: ["*.jar"])
-    compile "com.android.support:appcompat-v7:23.0.1"
+    compile "com.android.support:appcompat-v7:26.1.0"
     compile "com.facebook.react:react-native:+"  // From node_modules
 }
 

--- a/scripts/.tests.env
+++ b/scripts/.tests.env
@@ -4,9 +4,9 @@
 
 ## ANDROID ##
 # Android SDK Build Tools revision
-export ANDROID_SDK_BUILD_TOOLS_REVISION=23.0.1
+export ANDROID_SDK_BUILD_TOOLS_REVISION=26.0.2
 # Android API Level we build with
-export ANDROID_SDK_BUILD_API_LEVEL="23"
+export ANDROID_SDK_BUILD_API_LEVEL="26"
 # Google APIs for Android level
 export ANDROID_GOOGLE_API_LEVEL="23"
 # Minimum Android API Level we target


### PR DESCRIPTION
This PR uses android build tools 26.0.2, support library 26.1.0 (with android lifecycle) and setting compileSdkVersion to 26, but leaving minSdkVersion and targetSdkVersion intact.

CI builds just fine, but having error with bundling JS or same error as master.

Sorry, that I messed up with PR git history 😄

@hramos 