### PR TITLE
Assign RCTContentDidAppearNotification in RootContentView

### DIFF
--- a/React/Base/RCTRootContentView.m
+++ b/React/Base/RCTRootContentView.m
@@ -15,6 +15,8 @@
 #import "RCTUIManager.h"
 #import "UIView+React.h"
 
+NSString *const RCTContentDidAppearNotification = @"RCTContentDidAppearNotification";
+
 @implementation RCTRootContentView
 
 - (instancetype)initWithFrame:(CGRect)frame


### PR DESCRIPTION
TL;DR: Fix downstream apps that rely on RCTRootContentView posting the `RCTContentDidAppearNotification` notification, such as Detox.

Before RCTRootContentView was split out from RCTRootView (https://github.com/facebook/react-native/commit/c02c78a6816c111123990d99c964b31abc4319fc#diff-41282a9c005f910019d4f0fe557dbfb0), both relied on the following line to assign the value of `RCTContentDidAppearNotification`, found in `RCTRootView.m`:

`NSString *const RCTContentDidAppearNotification = @"RCTContentDidAppearNotification";`

After RCTRootContentView was split out, `RCTContentDidAppearNotification` was defined in `RCTRootContentView.h` but it was never assigned a value. Thus when `insertReactSubview` in RCTRootContentView posts the `RCTContentDidAppearNotification` notification, it doesn't actually have a value. This behavior causes downstream apps that wait for the root view content to appear by attaching listeners by name (e.g., `[[NSNotificationCenter defaultCenter] addObserverForName:@"RCTContentDidAppearNotification" ...]`, https://github.com/wix/detox/blob/master/detox/ios/Detox/ReactNativeSupport.m#L207) to fail.

My PR simply assigns the correct value to `RCTContentDidAppearNotification`, just like in https://github.com/facebook/react-native/blob/master/React/Base/RCTRootView.m#L35. I suspect that was @shergin's original intention when he split out the files, so this is basically fixing a typo.

## Test Plan

None.

## Related PRs

None.

## Release Notes

[IOS] [BUGFIX] [React/Base/RCTRootContentView.m] - Fix downstream apps depending on RCTContentDidAppearNotification