### PR TITLE
fix for haste module lookup

### DIFF
--- a/jest/hasteImpl.js
+++ b/jest/hasteImpl.js
@@ -12,12 +12,12 @@
 
 const path = require('path');
 
-const ROOT = path.join(__dirname, '..');
+const ROOT = path.join(__dirname, '..').replace(/\\/g, '/');
 
 const BLACKLISTED_PATTERNS /*: Array<RegExp> */ = [
   /.*\/__(mocks|tests)__\/.*/,
-  /^Libraries\/Animated\/src\/polyfills\/.*/,
-  /^Libraries\/Renderer\/fb\/.*/,
+  /^Libraries\/Animated\/src\/polyfills\/.*/i,
+  /^Libraries\/Renderer\/fb\/.*/i,
 ];
 
 const WHITELISTED_PREFIXES /*: Array<string> */ = [
@@ -45,6 +45,10 @@ const haste = {
     filePath /*: string */,
     sourceCode /*: ?string */,
   ) /*: string | void */ {
+    if (filePath[1] === ':') {
+      filePath = filePath[0].toLowerCase() + filePath.substr(1);
+    }
+    filePath = filePath.replace(/\\/g, '/');
     if (!isHastePath(filePath)) {
       return undefined;
     }
@@ -54,6 +58,7 @@ const haste = {
       filePath,
     );
 
+    console.log('hasteid', hasteName);
     return hasteName;
   },
 };

--- a/local-cli/cliEntry.js
+++ b/local-cli/cliEntry.js
@@ -35,9 +35,9 @@ commander.version(pkg.version);
 const defaultOptParser = val => val;
 
 const handleError = err => {
-  console.error();
+  console.error('********************');
   console.error(err.message || err);
-  console.error();
+  console.error(err.stack);
   process.exit(1);
 };
 

--- a/setupBabel.js
+++ b/setupBabel.js
@@ -20,7 +20,8 @@ const BABEL_ENABLED_PATHS = ['local-cli'];
  */
 function setupBabel() {
   babelRegisterOnly(
-    babelRegisterOnly.buildRegExps(__dirname, BABEL_ENABLED_PATHS),
+    // babelRegisterOnly.buildRegExps(__dirname, BABEL_ENABLED_PATHS),
+    [/local-cli/],
   );
 }
 


### PR DESCRIPTION
the new haste module lookup method instead of  `providesModule` has some path-related problems in windows, such as 
1. the type of slash
2. the insensitive case of path, especially the drive letter

the best solution is converting all the slash to `/` and the drive letter to lowercase before all follow-up checks.