### PR TITLE
Fix condition in Interpolation

### DIFF
--- a/Libraries/Animated/src/nodes/AnimatedInterpolation.js
+++ b/Libraries/Animated/src/nodes/AnimatedInterpolation.js
@@ -278,7 +278,7 @@ function checkValidInputRange(arr: Array<number>) {
   invariant(arr.length >= 2, 'inputRange must have at least 2 elements');
   for (let i = 1; i < arr.length; ++i) {
     invariant(
-      arr[i] >= arr[i - 1],
+      arr[i] > arr[i - 1],
       /* $FlowFixMe(>=0.13.0) - In the addition expression below this comment,
        * one or both of the operands may be something that doesn't cleanly
        * convert to a string, like undefined, null, and object, etc. If you really


### PR DESCRIPTION
Fix condition of checking monotonicity in Animated.Interpolation

In order to handle proper interpolation condition we need to check if there's no two y value for the same x as linear interpolation is not possible then (from mathematical point of view).

## Test Plan
As it make condition harder to handle it's quite easy to test.

```
<Animated.View
        style={{
          opacity: fadeAnim.interpolate({
            inputRange: [0, 0, 1],
            outputRange: [0, 1,  1]
          }),         // Bind opacity to animated value
        }}
      >
        {this.props.children}
      </Animated.View>
    );
``` 
Code above should imply an error (which is correct behaviour)



[GENERAL] [BUGFIX] [AnimtedInterpolation] -Fix condition of checking monotonicity in Animated.Interpolation
