### PR TITLE
Change error message on interpolation

### DIFF
--- a/Libraries/Animated/src/nodes/AnimatedInterpolation.js
+++ b/Libraries/Animated/src/nodes/AnimatedInterpolation.js
@@ -285,7 +285,7 @@ function checkValidInputRange(arr: Array<number>) {
        * mean this implicit string conversion, you can do something like
        * String(myThing)
        */
-      'inputRange must be monotonically increasing ' + arr,
+      'inputRange must be monotonically non-decreasing ' + arr,
     );
   }
 }


### PR DESCRIPTION
Change message in Animated.Interpolation to "inputRange must be monotonically non-decreasing" as it's allowed to give the same x's like in the test [example](https://github.com/facebook/react-native/blob/4435f087713e1d0ac3639e3b3196d71c6402898e/Libraries/Animated/src/__tests__/Interpolation-test.js#L71)


## Test Plan

Simply giving improper value of interpolation input

[GENERAL] [MINOR] [AnimatedInterpolation.js] - Change error message on interpolation improper range error