### PR TITLE
Fix deepFreezeAndThrowOnMutationInDev error caused by objects without a prototype

### DIFF
--- a/Libraries/Utilities/__tests__/deepFreezeAndThrowOnMutationInDev-test.js
+++ b/Libraries/Utilities/__tests__/deepFreezeAndThrowOnMutationInDev-test.js
@@ -26,6 +26,13 @@ describe('deepFreezeAndThrowOnMutationInDev', function() {
     expect(() => deepFreezeAndThrowOnMutationInDev()).not.toThrow();
   });
 
+  it('should not throw on object without prototype', () => {
+    __DEV__ = true;
+    var o = Object.create(null);
+    o.key = 'Value';
+    expect(() => deepFreezeAndThrowOnMutationInDev(o)).not.toThrow();
+  });
+
   it('should throw on mutation in dev with strict', () => {
     'use strict';
     __DEV__ = true;

--- a/Libraries/Utilities/deepFreezeAndThrowOnMutationInDev.js
+++ b/Libraries/Utilities/deepFreezeAndThrowOnMutationInDev.js
@@ -39,10 +39,11 @@ function deepFreezeAndThrowOnMutationInDev(object: Object) {
     }
 
     var keys = Object.keys(object);
+    const hasOwnProperty = Object.prototype.hasOwnProperty;
 
     for (var i = 0; i < keys.length; i++) {
       var key = keys[i];
-      if (Object.hasOwnProperty.call(object, key)) {
+      if (hasOwnProperty.call(object, key)) {
         Object.defineProperty(object, key, {
           get: identity.bind(null, object[key])
         });
@@ -57,7 +58,7 @@ function deepFreezeAndThrowOnMutationInDev(object: Object) {
 
     for (var i = 0; i < keys.length; i++) {
       var key = keys[i];
-      if (Object.hasOwnProperty.call(object, key)) {
+      if (hasOwnProperty.call(object, key)) {
         deepFreezeAndThrowOnMutationInDev(object[key]);
       }
     }

--- a/Libraries/Utilities/deepFreezeAndThrowOnMutationInDev.js
+++ b/Libraries/Utilities/deepFreezeAndThrowOnMutationInDev.js
@@ -43,8 +43,12 @@ function deepFreezeAndThrowOnMutationInDev(object: Object) {
     for (var i = 0; i < keys.length; i++) {
       var key = keys[i];
       if (Object.hasOwnProperty.call(object, key)) {
-        object.__defineGetter__(key, identity.bind(null, object[key]));
-        object.__defineSetter__(key, throwOnImmutableMutation.bind(null, key));
+        Object.defineProperty(object, key, {
+          get: identity.bind(null, object[key])
+        });
+        Object.defineProperty(object, key, {
+          set: throwOnImmutableMutation.bind(null, key)
+        });
       }
     }
 

--- a/Libraries/Utilities/deepFreezeAndThrowOnMutationInDev.js
+++ b/Libraries/Utilities/deepFreezeAndThrowOnMutationInDev.js
@@ -42,7 +42,7 @@ function deepFreezeAndThrowOnMutationInDev(object: Object) {
 
     for (var i = 0; i < keys.length; i++) {
       var key = keys[i];
-      if (object.hasOwnProperty(key)) {
+      if (Object.hasOwnProperty.call(object, key)) {
         object.__defineGetter__(key, identity.bind(null, object[key]));
         object.__defineSetter__(key, throwOnImmutableMutation.bind(null, key));
       }
@@ -53,7 +53,7 @@ function deepFreezeAndThrowOnMutationInDev(object: Object) {
 
     for (var i = 0; i < keys.length; i++) {
       var key = keys[i];
-      if (object.hasOwnProperty(key)) {
+      if (Object.hasOwnProperty.call(object, key)) {
         deepFreezeAndThrowOnMutationInDev(object[key]);
       }
     }


### PR DESCRIPTION
This PR fixes a bug in `deepFreezeAndThrowOnMutationInDev` which did not take into account that objects passed to it may have been created with `Object.create(null)` and thus may not have a prototype. Such objects don't have the methods `hasOwnProperty`, `__defineGetter__`, or `__defineSetter__` on the instance. 

I ran into an unrecoverable error in React Native when passing this type of object across the bridge because `deepFreezeAndThrowOnMutationInDev` attempts to call `object.hasOwnProperty(key)`, `object.__defineGetter__` and `object__defineSetter__` on objects passed to it. But my object instance does not have these prototype methods.

Changes:
* Modified calls to `object.hasOwnProperty(key)` to use `Object.prototype.hasOwnProperty.call(object, key)` (Per ESLint rule [here](https://eslint.org/docs/rules/no-prototype-builtins))
* Modified calls to deprecated methods `object.__defineGetter__` and `object.__defineSetter__` to instead use `Object.defineProperty` to define get and set methods on the object. (Per guidance on [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/__defineGetter__))
* Added a new test to `deepFreezeAndThrowOnMutationInDev-test` to verify the fix.

## Test Plan

I tried to create a reproducible example to post to Snack by passing prototype-less objects to a `Text` component, in various ways, but they appear to be converted to plain objects before crossing the bridge and therefore they do not throw an error.

However, I was able to create a new test to reproduce the issue. I added the following test to `deepFreezeAndThrowOnMutationInDev-test`:

```JavaScript
it('should not throw on object without prototype', () => {
    __DEV__ = true;
    var o = Object.create(null);
    o.key = 'Value';
    expect(() => deepFreezeAndThrowOnMutationInDev(o)).not.toThrow();
  });
```

The changes in this PR include this new test.

ESLint test produced 0 Errors and no change in Warning count (1014)

## Related PRs
N/A
Other areas with _possibly_ the same issue:
https://github.com/facebook/react-native/blob/c6b96c0df789717d53ec520ad28ba0ae00db6ec2/Libraries/vendor/core/mergeInto.js#L50
https://github.com/facebook/react-native/blob/8dc3ba0444c94d9bbb66295b5af885bff9b9cd34/Libraries/ReactNative/requireNativeComponent.js#L134

## Release Notes
 [GENERAL] [BUGFIX] [Libraries/Utilities/deepFreezeAndThrowOnMutationInDev] -Fix for compatibility with objects without a prototype.
