### PR TITLE
iOS: WebView stays in loading state

### DIFF
--- a/Libraries/Components/WebView/WebView.ios.js
+++ b/Libraries/Components/WebView/WebView.ios.js
@@ -678,7 +678,7 @@ const styles = StyleSheet.create({
     marginBottom: 10,
   },
   hidden: {
-    height: 0,
+    height: 1, // UIWebView does not finish loading when 100% hidden; see https://github.com/facebook/react-native/issues/5974
     flex: 0, // disable 'flex:1' when hiding a View
   },
   loadingView: {


### PR DESCRIPTION
## MOTIVATION

Fixes #5974

`WebView` does not load when `startInLoadingState` is `true` on iOS; Android works perfectly fine. The issue is a hidden `UIWebView` never exits the loading state.

## Test Plan

React Native: 0.52.2
iOS: 11.3

I added a simple logging statement and it logs:
```
2018-06-07 22:32:34.481172-0500 HarvestPoint[52403:2799087] LOADING:: TRUE, TRUE
```

That's the only log it gets when `startInLoadingState={true}` on JS. If I turn that off, you'll see a list of `TRUE, TRUE` then a `FALSE, FALSE` which then renders the UI.

The fix sets the default height to `1` which actually loads the UI. Once there is a height, the iOS code properly triggers the `onLoadingFinish` callback.

## Related PRs

#16792: Migrate RCTWebView to WKWebView

## Release Notes

[IOS] [BUGFIX] [WebView] - Set a default height on a hidden `WebView` to avoid `UIWebView` problem