### PR TITLE
Bump RN Preset to @next, fix Objective-C e2e tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,6 +148,7 @@
   "dependencies": {
     "absolute-path": "^0.0.0",
     "art": "^0.10.0",
+    "babel-preset-react-native": "^5.0.0",
     "base64-js": "^1.1.2",
     "chalk": "^1.1.1",
     "commander": "^2.9.0",

--- a/scripts/run-ci-e2e-tests.js
+++ b/scripts/run-ci-e2e-tests.js
@@ -199,11 +199,15 @@ try {
         exec('sleep 10s');
         if (argv.tvos) {
           return exec(
-            'xcodebuild -destination "platform=tvOS Simulator,name=Apple TV 1080p,OS=10.0" -scheme EndToEndTest-tvOS -sdk appletvsimulator test | xcpretty && exit ${PIPESTATUS[0]}',
+            'xcodebuild -destination "platform=tvOS Simulator,name=Apple TV 1080p,OS=10.0" -scheme EndToEndTest-tvOS -sdk appletvsimulator test | xcpretty --report junit --output ~/react-native/reports/junit/' +
+              iosTestType +
+              '-e2e-xcodebuild-results.xml && exit ${PIPESTATUS[0]}',
           ).code;
         } else {
           return exec(
-            'xcodebuild -destination "platform=iOS Simulator,name=iPhone 5s,OS=10.3.1" -scheme EndToEndTest -sdk iphonesimulator test | xcpretty && exit ${PIPESTATUS[0]}',
+            'xcodebuild -destination "platform=iOS Simulator,name=iPhone 5s,OS=10.0" -scheme EndToEndTest -sdk iphonesimulator test | xcpretty --report junit --output ~/react-native/reports/junit/' +
+              iosTestType +
+              '-e2e-xcodebuild-results.xml && exit ${PIPESTATUS[0]}',
           ).code;
         }
       }, numberOfRetries)


### PR DESCRIPTION
We opt in to the @next version of the React Native Babel Preset, as required after the bump to Babel 7. This fixes the Objective-C end-to-end test failure in master.

See https://github.com/facebook/react-native/commit/                            34bd776af2f2529009188fced91083203a48fd40#commitcomment-29024085 for prior       discussion. 

There have already been several changes made to the repo during the transition to Babel 7. This PR should bring all tests back to green and allow us to move forward with the 0.56 branch cut.

cc @grabbou, @qfox, @chirag04

Test Plan:
Ran on Circle CI, observed test succeeded: https://circleci.com/workflow-run/cf67b0c9-d053-441c-859e-90c63ea17a94

Release Notes:

[GENERAL] [BREAKING] [Babel] - Bump React Native Babel Preset version to Babel v7 compliant release