### PR TITLE
have circle ci use xcode 9.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -374,9 +374,8 @@ jobs:
       - attach_workspace:
           at: ~/react-native
 
-      - run: xcrun instruments -w "iPhone 5s (11.2)" || true
+      - run: xcrun instruments -w "iPhone 5s (11.3)" || true
       # See https://github.com/Homebrew/homebrew-core/issues/26358.
-      - run: brew upgrade --cleanup python > /dev/null
       - run: brew install watchman
       - run: *run-objc-ios-tests
 
@@ -390,9 +389,8 @@ jobs:
       - attach_workspace:
           at: ~/react-native
 
-      - run: xcrun instruments -w "Apple TV 1080p (11.2)" || true
+      - run: xcrun instruments -w "Apple TV (11.3)" || true
       # See https://github.com/Homebrew/homebrew-core/issues/26358.
-      - run: brew upgrade --cleanup python > /dev/null
       - run: brew install watchman
       - run: *run-objc-tvos-tests
 
@@ -406,7 +404,7 @@ jobs:
       - attach_workspace:
           at: ~/react-native
 
-      - run: xcrun instruments -w "iPhone 5s (11.2)" || true
+      - run: xcrun instruments -w "iPhone 5s (11.3)" || true
       - run: *run-objc-ios-e2e-tests
 
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -374,7 +374,7 @@ jobs:
       - attach_workspace:
           at: ~/react-native
 
-      - run: xcrun instruments -w "iPhone 5s (11.3)" || true
+      - run: xcrun instruments -w "iPhone 5s (11.4)" || true
       # See https://github.com/Homebrew/homebrew-core/issues/26358.
       - run: brew install watchman
       - run: *run-objc-ios-tests
@@ -389,7 +389,7 @@ jobs:
       - attach_workspace:
           at: ~/react-native
 
-      - run: xcrun instruments -w "Apple TV (11.3)" || true
+      - run: xcrun instruments -w "Apple TV (11.4)" || true
       # See https://github.com/Homebrew/homebrew-core/issues/26358.
       - run: brew install watchman
       - run: *run-objc-tvos-tests
@@ -404,7 +404,7 @@ jobs:
       - attach_workspace:
           at: ~/react-native
 
-      - run: xcrun instruments -w "iPhone 5s (11.3)" || true
+      - run: xcrun instruments -w "iPhone 5s (11.4)" || true
       - run: *run-objc-ios-e2e-tests
 
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -376,7 +376,7 @@ jobs:
 
       - run: xcrun instruments -w "iPhone 5s (11.2)" || true
       # See https://github.com/Homebrew/homebrew-core/issues/26358.
-      - run: brew upgrade python > /dev/null
+      - run: brew upgrade --cleanup python > /dev/null
       - run: brew install watchman
       - run: *run-objc-ios-tests
 
@@ -392,7 +392,7 @@ jobs:
 
       - run: xcrun instruments -w "Apple TV 1080p (11.2)" || true
       # See https://github.com/Homebrew/homebrew-core/issues/26358.
-      - run: brew upgrade python > /dev/null
+      - run: brew upgrade --cleanup python > /dev/null
       - run: brew install watchman
       - run: *run-objc-tvos-tests
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -316,7 +316,7 @@ android_defaults: &android_defaults
 macos_defaults: &macos_defaults
   <<: *defaults
   macos:
-    xcode: "9.2.0"
+    xcode: "9.4.0"
 
 version: 2
 jobs:


### PR DESCRIPTION
Circle CI just released Xcode 9.4 https://discuss.circleci.com/t/xcode-9-4-availability-on-circleci/22648/5

## Test Plan

Make sure react native still works with Xcode 9.4.

## Related PRs 

None

## Release Notes
[IOS][MINOR] Upgrade CI