### PR TITLE
Add ability to customise WebSocket OkHttp client on Android

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/modules/websocket/WebSocketModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/websocket/WebSocketModule.java
@@ -22,6 +22,8 @@ import com.facebook.react.common.ReactConstants;
 import com.facebook.react.module.annotations.ReactModule;
 import com.facebook.react.modules.core.DeviceEventManagerModule;
 import com.facebook.react.modules.network.ForwardingCookieHandler;
+import com.facebook.react.modules.network.OkHttpClientProvider;
+
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -84,7 +86,7 @@ public final class WebSocketModule extends ReactContextBaseJavaModule {
     @Nullable final ReadableArray protocols,
     @Nullable final ReadableMap options,
     final int id) {
-    OkHttpClient client = new OkHttpClient.Builder()
+    OkHttpClient client = OkHttpClientProvider.getOkHttpClient().newBuilder()
       .connectTimeout(10, TimeUnit.SECONDS)
       .writeTimeout(10, TimeUnit.SECONDS)
       .readTimeout(0, TimeUnit.MINUTES) // Disable timeouts for read


### PR DESCRIPTION
## Motivation

Summary:
Prior to 22efd95, users could customise the OkHttp client used by React Native on Android by calling setOkHttpClientFactory in OkHttpClientProvider.

This functionality has a variety of legitimate applications from changing connection timeouts or pool size to Stetho integration. In this commit also provide the ability for WebSocket.

Closes #18920

## Test Plan

Create React Native application and set a custom factory in the constructor, e.g. OkHttpClientProvider.setOkHttpClientFactory(new CustomNetworkModule());

Where a custom factory would look like:

```
class CustomNetworkModule implements OkHttpClientFactory {
    public OkHttpClient createNewNetworkModuleClient() {
        return new OkHttpClient.Builder().build();
    }
}
```

## Related PRs

None

## Release Notes

[ANDROID] [MINOR] [WebSocket] - Also use the custom factory set in OkHttpClientProvider for customising the WebSocket OkHttp client used by React Native