### PR TITLE
Disallow requiring from invariant/warning

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -25,6 +25,11 @@
 ; Ignore metro
 .*/node_modules/metro/.*
 
+; These should not be required directly
+; require from fbjs/lib instead: require('fbjs/lib/invariant')
+.*/node_modules/invariant/.*
+.*/node_modules/warning/.*
+
 [include]
 
 [libs]


### PR DESCRIPTION
In this repo we have to require from fbjs/lib/invariant and issues occur when we require directly from invariant/warning. Flow doesn't complain about those requires right now because we have a transitive dependency on invariant and warning causing them to happen to be at the root of node_modules. 

This change blacklists requiring directly from invariant and warning using Flow. @janicduplessis opened a pull request to do this with ESLint back in 2017: https://github.com/facebook/react-native/pull/13014

Test Plan:
I changed a require to point to invariant instead of fbjs/lib/invariant, got the warning:
<img width="968" alt="screen shot 2018-06-08 at 9 39 19 pm" src="https://user-images.githubusercontent.com/249164/41187735-78494d22-6b65-11e8-9ae3-e3c339185fbc.png">
