### PR TITLE
fix No bundle url present in iOS

### DIFF
--- a/local-cli/templates/HelloWorld/ios/HelloWorld/Info.plist
+++ b/local-cli/templates/HelloWorld/ios/HelloWorld/Info.plist
@@ -43,6 +43,8 @@
 	<key>NSAppTransportSecurity</key>
 	<!--See http://ste.vn/2015/06/10/configuring-app-transport-security-ios-9-osx-10-11/ -->
 	<dict>
+    <key>NSAllowsArbitraryLoads</key>
+    <true/>
 		<key>NSExceptionDomains</key>
 		<dict>
 			<key>localhost</key>


### PR DESCRIPTION
## Motivation
fix No bundle url present in iOS.
Related issue: https://github.com/facebook/react-native/issues/14118, https://github.com/facebook/react-native/issues/12754.
## Test Plan
Pass all current ci
## Related PRs
none
## Release Notes
 [GENERAL] [BUGFIX] [iOS] - fix No bundle url present in iOS