### PR TITLE
iOS: fix the baseline issue when displaying a mixture of different-language characters

### DIFF
--- a/Libraries/Text/Text/RCTTextShadowView.m
+++ b/Libraries/Text/Text/RCTTextShadowView.m
@@ -133,30 +133,37 @@
     return;
   }
 
-  [attributedText beginEditing];
-
+  __block CGFloat maximumFontLineHeight = 0;
+  
   [attributedText enumerateAttribute:NSFontAttributeName
                              inRange:NSMakeRange(0, attributedText.length)
                              options:NSAttributedStringEnumerationLongestEffectiveRangeNotRequired
                           usingBlock:
-    ^(UIFont *font, NSRange range, __unused BOOL *stop) {
-      if (!font) {
-        return;
-      }
-
-      if (maximumLineHeight <= font.lineHeight) {
-        return;
-      }
-
-      CGFloat baseLineOffset = maximumLineHeight / 2.0 - font.lineHeight / 2.0;
-
-      [attributedText addAttribute:NSBaselineOffsetAttributeName
-                             value:@(baseLineOffset)
-                             range:range];
+   ^(UIFont *font, NSRange range, __unused BOOL *stop) {
+     if (!font) {
+       return;
      }
-   ];
-
-   [attributedText endEditing];
+     
+     if (maximumFontLineHeight <= font.lineHeight) {
+       maximumFontLineHeight = font.lineHeight;
+     }
+     
+   }
+  ];
+  
+  if (maximumLineHeight < maximumFontLineHeight) {
+    return;
+  }
+  
+  [attributedText beginEditing];
+  
+  CGFloat baseLineOffset = maximumLineHeight / 2.0 - maximumFontLineHeight / 2.0;
+  
+  [attributedText addAttribute:NSBaselineOffsetAttributeName
+                         value:@(baseLineOffset)
+                         range:NSMakeRange(0, attributedText.length)];
+  
+  [attributedText endEditing];
 }
 
 - (NSAttributedString *)attributedTextWithMeasuredAttachmentsThatFitSize:(CGSize)size


### PR DESCRIPTION
This fixes #19193 

Characters of different languages may have different height and different baseline, even with a same font and same font-size. When they mixed together, iOS will adjust their baselines automatically, to display a suitable view of text. 

The problem is the behavior of dealing with the text-style property 'lineHeight'.

It once to be a right way at version 0.52.3, to setting a base-line-offset attribute for the whole range of the string. However, in current version, it enumerated the string, and set a different  base-line-offset for different font-height characters. 

And this behavior broke the baseline adjustment made by the iOS. It just make every character's baseline aligned to a same line. But it is not supposed to displaying characters of different languages like that. Chinese characters' baseline is the bottom of each, however, it is not for English characters.

So maybe it is the better way to give a same value of base-line-offset attribute for the whole string. And this PR just did that: found the biggest value of font-height in the text, and calculate the offset with that biggest value, then set to the whole string. This will keep the origin baseline adjustment for different languages' chars made by iOS.

## Test Plan

Since I always got an error when running the snapshot test locally, I can't even pass the them with the unmodified code in master branch.

The error is "Nesting of <View> within <Text> is not currently supported."

After I comment all of the check of that error from the source code, I got a different snapshot from the reference ones. It seems that all components which will cause that error are not rendered in the reference images. 

Since this PR changed the behavior of 'lineHeight' property, it's better to add a new snapshot case for the situation of different-language-characters' mixture. So maybe somebody could help me with that or maybe it should be a issue?

## Release Notes

[IOS] [BUGFIX] [Text] - fix the baseline issue when displaying a mixture of different-language characters