### PR TITLE
Use evaluateJavascript for WebView postMessage, if available

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebViewManager.java
@@ -639,7 +639,7 @@ public class ReactWebViewManager extends SimpleViewManager<WebView> {
         try {
           JSONObject eventInitDict = new JSONObject();
           eventInitDict.put("data", args.getString(0));
-          root.loadUrl("javascript:(function () {" +
+          String code = "(function () {" +
             "var event;" +
             "var data = " + eventInitDict.toString() + ";" +
             "try {" +
@@ -649,7 +649,12 @@ public class ReactWebViewManager extends SimpleViewManager<WebView> {
               "event.initMessageEvent('message', true, true, data.data, data.origin, data.lastEventId, data.source);" +
             "}" +
             "document.dispatchEvent(event);" +
-          "})();");
+          "})();";
+          if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+            root.evaluateJavascript(code, null);
+          } else {
+            root.loadUrl("javascript:" + code);
+          }
         } catch (JSONException e) {
           throw new RuntimeException(e);
         }


### PR DESCRIPTION
loadUrl's behavior on Android 4.4+ is to URL decode the input prior to evaluating it, so a `%22` in the input will be decoded to `"`. Since it is not escaped, this quote introduces a syntax error into the javascript, preventing execution.

This changes `postMessage` to use `evaluateJavascript` on Android 4.4+ to fix #19611

## Test Plan

Manual:

1. `react-native init Test`, `cd Test`, replace `App.js` with example from #19611
2. `yarn add github:jordoh/react-native#android-postMessage-evaluateJavascript` and set up to build react-native from source
3. `react-native run-android` and verify that pressing the `postMessage with %22` button changes the text in the WebView to "success".

![image](https://user-images.githubusercontent.com/450345/41242700-14291a42-6d55-11e8-9eea-83b530069233.png)

## Related PRs

There have been PRs to implement a similar change in `injectedJavaScript`, which appear to stall on the discussion of whether the inconsistency in behavior is acceptable: 

- https://github.com/facebook/react-native/pull/9945 (closed)
- https://github.com/facebook/react-native/pull/12321 (open)

However, [per this issue](https://issuetracker.google.com/issues/36995865), my understanding is that Android before 4.4 did not URL decode the string passed to `loadUrl`, so calling `loadURL` would not suffer from #19611 - though there may be other differences in the behavior of `evaluateJavascript` and the pre-4.4 `loadUrl` that I am unaware of.

## Release Notes

[ANDROID] [ BUGFIX] [WebView] - Fix `"%22"` in `postMessage` failing on Android 4.4+
