### PR TITLE
Fix memory usage display in Perf Monitor

### DIFF
--- a/React/Profiler/RCTPerfMonitor.m
+++ b/React/Profiler/RCTPerfMonitor.m
@@ -68,8 +68,7 @@ static vm_size_t RCTGetResidentMemorySize(void)
     kern_return_t kernelReturn = task_info(mach_task_self(), TASK_VM_INFO, (task_info_t) &vmInfo, &count);
     if(kernelReturn == KERN_SUCCESS) {
         memoryUsageInByte = (vm_size_t) vmInfo.phys_footprint;
-    } else {
-    }
+    } 
     return memoryUsageInByte;
 }
 


### PR DESCRIPTION
According to: https://github.com/apple/darwin-xnu/blob/master/osfmk/kern/bsd_kern.c#L420
The result is the same as Xcode app memory uesd.

## Test Plan

Before Fix:

<img width="250" alt="before" src="https://user-images.githubusercontent.com/22233256/41394508-ce810362-6fdc-11e8-8d40-73703ec93bc3.png">
<img width="266" alt="before1" src="https://user-images.githubusercontent.com/22233256/41394511-d00a9a0e-6fdc-11e8-9f18-2198e8de2410.png">

After Fix:
<img width="270" alt="after" src="https://user-images.githubusercontent.com/22233256/41394517-d5a56ff2-6fdc-11e8-8d19-41e046c4b511.png">
<img width="267" alt="after1" src="https://user-images.githubusercontent.com/22233256/41394520-d7a3c600-6fdc-11e8-98c4-e3024a4532ec.png">

## Related PRs

<!-- 
  Does this PR require a documentation change? 
  Create a PR at https://github.com/facebook/react-native-website and add a link to it here.
-->

## Release Notes

[IOS] [BUGFIX] [Monitor] - fix memory perf monitor. Make sure the memory footprint is the same as Jetsam.


<!--
  **INTERNAL and MINOR tagged notes will not be included in the next version's final release notes.**

    CATEGORY
  [----------]      TYPE
  [ CLI      ] [-------------]    LOCATION
  [ DOCS     ] [ BREAKING    ] [-------------]
  [ GENERAL  ] [ BUGFIX      ] [ {Component} ]
  [ INTERNAL ] [ ENHANCEMENT ] [ {Filename}  ]
  [ IOS      ] [ FEATURE     ] [ {Directory} ]   |-----------|
  [ ANDROID  ] [ MINOR       ] [ {Framework} ] - | {Message} |
  [----------] [-------------] [-------------]   |-----------|

 EXAMPLES:

 [IOS] [BREAKING] [FlatList] - Change a thing that breaks other things
 [ANDROID] [BUGFIX] [TextInput] - Did a thing to TextInput
 [CLI] [FEATURE] [local-cli/info/info.js] - CLI easier to do things with
 [DOCS] [BUGFIX] [GettingStarted.md] - Accidentally a thing/word
 [GENERAL] [ENHANCEMENT] [Yoga] - Added new yoga thing/position
 [INTERNAL] [FEATURE] [./scripts] - Added thing to script that nobody will see
-->
