### PR TITLE
[CI] Skip metro bump commits

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,7 +126,7 @@ aliases:
     command: |
       # Skip yarn install on metro bump commits as the package is not yet
       # available on npm
-      if [[ `echo $GIT_COMMIT_DESC | grep -c "Bump metro@"` -eq 0]]; then
+      if [[ $(echo "$GIT_COMMIT_DESC" | grep -c "Bump metro@") -eq 0]]; then
         yarn install --non-interactive --cache-folder ~/.cache/yarn
       fi
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,7 +126,7 @@ aliases:
     command: |
       # Skip yarn install on metro bump commits as the package is not yet
       # available on npm
-      if [[ $(echo "$GIT_COMMIT_DESC" | grep -c "Bump metro@") -eq 0]]; then
+      if [[ $(echo "$GIT_COMMIT_DESC" | grep -c "Bump metro@") -eq 0 ]]; then
         yarn install --non-interactive --cache-folder ~/.cache/yarn
       fi
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -344,7 +344,6 @@ jobs:
   checkout_code:
     <<: *js_defaults
     steps:
-      -
       - checkout
       - run: *setup-artifacts
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,8 +122,13 @@ aliases:
     command: source scripts/android-setup.sh && getAndroidNDK
 
   - &yarn
-    |
-      yarn install --non-interactive --cache-folder ~/.cache/yarn
+    name: Run Yarn
+    command: |
+      # Skip yarn install on metro bump commits as the package is not yet
+      # available on npm
+      if [[ `echo $GIT_COMMIT_DESC | grep -c "Bump metro@"` -eq 0]]; then
+        yarn install --non-interactive --cache-folder ~/.cache/yarn
+      fi
 
   - &install-yarn
     name: Install Yarn
@@ -304,6 +309,8 @@ aliases:
 
 defaults: &defaults
   working_directory: ~/react-native
+  environment:
+    - GIT_COMMIT_DESC: git log --format=oneline -n 1 $CIRCLE_SHA1
 
 js_defaults: &js_defaults
   <<: *defaults
@@ -337,6 +344,7 @@ jobs:
   checkout_code:
     <<: *js_defaults
     steps:
+      -
       - checkout
       - run: *setup-artifacts
 


### PR DESCRIPTION
New metro releases are published to npm when a "Bump metro" commit is synced to GitHub and picked up by facebook/metro's Circle CI.
The same commit is picked up by facebook/react-native's Circle CI, but it will fail the checkout job because yarn will not find the new package on npm.
This is expected because the package will only be published to npm after Circle CI is done running on facebook/metro.

We can safely skip `yarn install` on these commits, and rely on the restored yarn cache instead.