### PR TITLE
Show packager error stack

### DIFF
--- a/local-cli/cliEntry.js
+++ b/local-cli/cliEntry.js
@@ -34,10 +34,14 @@ commander.version(pkg.version);
 
 const defaultOptParser = val => val;
 
-const handleError = err => {
+const handleError = (err) => {
   console.error();
   console.error(err.message || err);
   console.error();
+  if (err.stack) {
+    console.error(err.stack);
+    console.error();
+  }
   process.exit(1);
 };
 

--- a/local-cli/cliEntry.js
+++ b/local-cli/cliEntry.js
@@ -34,7 +34,7 @@ commander.version(pkg.version);
 
 const defaultOptParser = val => val;
 
-const handleError = (err) => {
+const handleError = err => {
   console.error();
   console.error(err.message || err);
   console.error();


### PR DESCRIPTION
Motivation: get more info from packager errors to easier debug them

## Test Plan
add `throw new Error('error')` here https://github.com/iyegoroff/react-native/blob/635f2740c28da594f236d4227b6450fddef4b599/local-cli/cliEntry.js#L116 and run
`react-native start` to see error stack
<!-- 
  Required: Write your test plan here. If you changed any code, please provide us with 
  clear instructions on how you verified your changes work. Bonus points for screenshots and videos! 
-->
[CLI] [ENHANCEMENT] [local-cli/cliEntry.js] - Show packager error stack

<!--
  **INTERNAL and MINOR tagged notes will not be included in the next version's final release notes.**

    CATEGORY
  [----------]      TYPE
  [ CLI      ] [-------------]    LOCATION
  [ DOCS     ] [ BREAKING    ] [-------------]
  [ GENERAL  ] [ BUGFIX      ] [ {Component} ]
  [ INTERNAL ] [ ENHANCEMENT ] [ {Filename}  ]
  [ IOS      ] [ FEATURE     ] [ {Directory} ]   |-----------|
  [ ANDROID  ] [ MINOR       ] [ {Framework} ] - | {Message} |
  [----------] [-------------] [-------------]   |-----------|

 EXAMPLES:

 [IOS] [BREAKING] [FlatList] - Change a thing that breaks other things
 [ANDROID] [BUGFIX] [TextInput] - Did a thing to TextInput
 [CLI] [FEATURE] [local-cli/info/info.js] - CLI easier to do things with
 [DOCS] [BUGFIX] [GettingStarted.md] - Accidentally a thing/word
 [GENERAL] [ENHANCEMENT] [Yoga] - Added new yoga thing/position
 [INTERNAL] [FEATURE] [./scripts] - Added thing to script that nobody will see
-->
