### PR TITLE
add google maven repo in android project template

### DIFF
--- a/local-cli/templates/HelloWorld/android/build.gradle
+++ b/local-cli/templates/HelloWorld/android/build.gradle
@@ -3,6 +3,10 @@
 buildscript {
     repositories {
         jcenter()
+        maven {
+            url 'https://maven.google.com/'
+            name 'Google'
+        }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
@@ -19,6 +23,10 @@ allprojects {
         maven {
             // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
             url "$rootDir/../node_modules/react-native/android"
+        }
+        maven {
+            url 'https://maven.google.com/'
+            name 'Google'
         }
     }
 }


### PR DESCRIPTION
This PR will add Google maven repo to RN project template that contains com.android.support:appcompat-v7:26.1.0, thus fixes `react-native run-android` using version 0.56.0-rc.1

CI is Green - https://circleci.com/gh/dulmandakh/react-native/235

## Test Plan

new Android projects will build and run just fine.