### PR TITLE
Feature/add decimal pad to android

### DIFF
--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -86,12 +86,12 @@ export type KeyboardType =
   | 'numeric'
   | 'phone-pad'
   | 'number-pad'
+  | 'decimal-pad'
   // iOS-only
   | 'ascii-capable'
   | 'numbers-and-punctuation'
   | 'url'
   | 'name-phone-pad'
-  | 'decimal-pad'
   | 'twitter'
   | 'web-search'
   // Android-only
@@ -388,6 +388,7 @@ const TextInput = createReactClass({
      * - `default`
      * - `numeric`
      * - `number-pad`
+     * - `decimal-pad`
      * - `email-address`
      * - `phone-pad`
      *
@@ -399,7 +400,6 @@ const TextInput = createReactClass({
      * - `numbers-and-punctuation`
      * - `url`
      * - `name-phone-pad`
-     * - `decimal-pad`
      * - `twitter`
      * - `web-search`
      *

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
@@ -70,8 +70,9 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
   private static final int BLUR_TEXT_INPUT = 2;
 
   private static final int INPUT_TYPE_KEYBOARD_NUMBER_PAD = InputType.TYPE_CLASS_NUMBER; 
-  private static final int INPUT_TYPE_KEYBOARD_NUMBERED = INPUT_TYPE_KEYBOARD_NUMBER_PAD |
-          InputType.TYPE_NUMBER_FLAG_DECIMAL |
+  private static final int INPUT_TYPE_KEYBOARD_DECIMAL_PAD = INPUT_TYPE_KEYBOARD_NUMBER_PAD |
+          InputType.TYPE_NUMBER_FLAG_DECIMAL;
+  private static final int INPUT_TYPE_KEYBOARD_NUMBERED = INPUT_TYPE_KEYBOARD_DECIMAL_PAD |
           InputType.TYPE_NUMBER_FLAG_SIGNED;
   private static final int PASSWORD_VISIBILITY_FLAG = InputType.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD &
         ~InputType.TYPE_TEXT_VARIATION_PASSWORD;
@@ -82,6 +83,7 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
 
   private static final String KEYBOARD_TYPE_EMAIL_ADDRESS = "email-address";
   private static final String KEYBOARD_TYPE_NUMERIC = "numeric";
+  private static final String KEYBOARD_TYPE_DECIMAL_PAD = "decimal-pad";
   private static final String KEYBOARD_TYPE_NUMBER_PAD = "number-pad";
   private static final String KEYBOARD_TYPE_PHONE_PAD = "phone-pad";
   private static final String KEYBOARD_TYPE_VISIBLE_PASSWORD = "visible-password";
@@ -567,6 +569,8 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
       flagsToSet = INPUT_TYPE_KEYBOARD_NUMBERED;
     } else if (KEYBOARD_TYPE_NUMBER_PAD.equalsIgnoreCase(keyboardType)) {
       flagsToSet = INPUT_TYPE_KEYBOARD_NUMBER_PAD;
+    } else if (KEYBOARD_TYPE_DECIMAL_PAD.equalsIgnoreCase(keyboardType)) {
+      flagsToSet = INPUT_TYPE_KEYBOARD_DECIMAL_PAD;
     } else if (KEYBOARD_TYPE_EMAIL_ADDRESS.equalsIgnoreCase(keyboardType)) {
       flagsToSet = InputType.TYPE_TEXT_VARIATION_EMAIL_ADDRESS | InputType.TYPE_CLASS_TEXT;
     } else if (KEYBOARD_TYPE_PHONE_PAD.equalsIgnoreCase(keyboardType)) {

--- a/ReactAndroid/src/test/java/com/facebook/react/views/textinput/ReactTextInputPropertyTest.java
+++ b/ReactAndroid/src/test/java/com/facebook/react/views/textinput/ReactTextInputPropertyTest.java
@@ -231,6 +231,7 @@ public class ReactTextInputPropertyTest {
   @Test
   public void testKeyboardType() {
     ReactEditText view = mManager.createViewInstance(mThemedContext);
+    int numberPadTypeFlags = InputType.TYPE_CLASS_NUMBER;
     int decimalPadTypeFlags = InputType.TYPE_CLASS_NUMBER | InputType.TYPE_NUMBER_FLAG_DECIMAL;
     int numericTypeFlags =
         InputType.TYPE_CLASS_NUMBER | InputType.TYPE_NUMBER_FLAG_DECIMAL |
@@ -249,6 +250,9 @@ public class ReactTextInputPropertyTest {
 
     mManager.updateProperties(view, buildStyles("keyboardType", "text"));
     assertThat(view.getInputType() & generalKeyboardTypeFlags).isEqualTo(InputType.TYPE_CLASS_TEXT);
+
+    mManager.updateProperties(view, buildStyles("keyboardType", "number-pad"));
+    assertThat(view.getInputType() & generalKeyboardTypeFlags).isEqualTo(numberPadTypeFlags);
 
     mManager.updateProperties(view, buildStyles("keyboardType", "decimal-pad"));
     assertThat(view.getInputType() & generalKeyboardTypeFlags).isEqualTo(decimalPadTypeFlags);

--- a/ReactAndroid/src/test/java/com/facebook/react/views/textinput/ReactTextInputPropertyTest.java
+++ b/ReactAndroid/src/test/java/com/facebook/react/views/textinput/ReactTextInputPropertyTest.java
@@ -231,6 +231,7 @@ public class ReactTextInputPropertyTest {
   @Test
   public void testKeyboardType() {
     ReactEditText view = mManager.createViewInstance(mThemedContext);
+    int decimalPadTypeFlags = InputType.TYPE_CLASS_NUMBER | InputType.TYPE_NUMBER_FLAG_DECIMAL;
     int numericTypeFlags =
         InputType.TYPE_CLASS_NUMBER | InputType.TYPE_NUMBER_FLAG_DECIMAL |
         InputType.TYPE_NUMBER_FLAG_SIGNED;
@@ -248,6 +249,9 @@ public class ReactTextInputPropertyTest {
 
     mManager.updateProperties(view, buildStyles("keyboardType", "text"));
     assertThat(view.getInputType() & generalKeyboardTypeFlags).isEqualTo(InputType.TYPE_CLASS_TEXT);
+
+    mManager.updateProperties(view, buildStyles("keyboardType", "decimal-pad"));
+    assertThat(view.getInputType() & generalKeyboardTypeFlags).isEqualTo(decimalPadTypeFlags);
 
     mManager.updateProperties(view, buildStyles("keyboardType", "numeric"));
     assertThat(view.getInputType() & generalKeyboardTypeFlags).isEqualTo(numericTypeFlags);


### PR DESCRIPTION
For a current use-case we need the a keyboard with characters 0-9 and a decimal point (or comma depending on language settings)

This exists on iOS as UIKeyboardType "decimalPad" and this is what react-native maps to for both "numeric" and "decimal-pad". This also exists on Android as inputType "numberDecimal", but is currently not accessible through react-native.

This PR maps the value "decimal-pad" of the keyboardType property of TextInput to the Android inputType "numberDecimal", effectively making "decimal-pad" cross platform without breaking anything.

## Relevant links to documentation
* https://facebook.github.io/react-native/docs/textinput.html#keyboardtype
* https://developer.apple.com/documentation/uikit/uikeyboardtype
* https://developer.android.com/reference/android/widget/TextView#attr_android:inputType


## Additional benefit 
There is this bug in some Samsung keyboards where both the - sign and decimal sign disappear when the keyboardType is set to "number" and both the "signed" and "decimal" flags are set. (Like is the case when using the react-native keyboardType prop "numeric".) https://androidforums.com/threads/numeric-soft-keyboard-missing-minus-sign-in-android-8-0-samsung-a5.1272628/ 

For developers that need decimal numbers but not negative ones, using "decimal-pad" will provide a workaround. I reproduced this on a Samsung A5 only, but maybe other phones have this exact issue. https://github.com/facebook/react-native/issues/12988 https://github.com/facebook/react-native/issues/12977 https://github.com/facebook/react-native/issues/17473 https://github.com/facebook/react-native/issues/17474

## Test Plan

* Added testcase consistent with existing keyboardType tests
* Also added testcase for the related, but missing number-pad

## Related PRs

This PR follows the same approach as the recently merged PR introducing "number-pad" https://github.com/facebook/react-native/pull/18350/commits/b638847a46491bd75e7ce7928c73f7cb78399195

Documentation PR: https://github.com/facebook/react-native-website/pull/405

## Release Notes

 [ANDROID] [ENHANCEMENT] [TextInput] - Added "decimal-pad" keyboard type