### PR TITLE
Publish releases automatically, update docs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -665,17 +665,16 @@ workflows:
           requires:
             - checkout_code
 
-  # Only runs on NN-stable branches
+  # Only runs on vX.X.X tags
   deploy:
     jobs:
-      # If we are on a stable branch, wait for approval to deploy to npm
-      - approve_publish_npm_package:
-          filters: *filter-only-stable
-          type: approval
-
       - publish_npm_package:
-          requires:
-            - approve_publish_npm_package
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*(\-rc(\.[0-9]+)?)?/
+
 
   # These tests are flaky or are yet to be fixed. They are placed on their own
   # workflow to avoid marking benign PRs as broken.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -652,6 +652,20 @@ workflows:
           requires:
             - checkout_code
 
+      # Only runs on vX.X.X tags if all tests are green
+      - publish_npm_package:
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*(\-rc(\.[0-9]+)?)?/
+          requires:
+            - test_javascript
+            - test_ios
+            - test_tvos
+            - test_end_to_end
+            - analyze
+
   # Only runs on PRs
   analyze:
     jobs:
@@ -664,16 +678,6 @@ workflows:
           filters: *filter-ignore-master-stable
           requires:
             - checkout_code
-
-  # Only runs on vX.X.X tags
-  deploy:
-    jobs:
-      - publish_npm_package:
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*(\-rc(\.[0-9]+)?)?/
 
 
   # These tests are flaky or are yet to be fixed. They are placed on their own

--- a/Releases.md
+++ b/Releases.md
@@ -14,14 +14,10 @@ React Native follows a monthly release train. Every month, a new branch created 
 | 0.40.0  | 1st of December     | 1st of January   |
 | 0.41.0  | 1st of January      | 1st of February  |
 | 0.42.0  | 1st of February     | 1st of March     |
-| 0.43.0  | 1st of March        | 1st of April     |
-| 0.44.0  | 1st of April        | 1st of May       |
-| 0.45.0  | 1st of May          | 1st of June      |
-| 0.46.0  | 1st of June         | 1st of July      |
-| 0.47.0  | 1st of July         | 1st of August    |
-| 0.48.0  | 1st of August       | 1st of September |
-| 0.49.0  | 1st of September    | 1st of October   |
-| 0.50.0  | 1st of October      | 1st of November  |
+|  ...    |       ...           |      ...         |
+| 0.56.0  | 1st of June         | 1st of July      |
+| 0.57.0  | 1st of July         | 1st of August    |
+| 0.58.0  | 1st of August       | 1st of October   |
 | ...     | ...                 | ...              |
 
 -------------------
@@ -31,6 +27,7 @@ React Native follows a monthly release train. Every month, a new branch created 
 ### Prerequisites
 
 The following are required for the local test suite to run:
+
 - macOS with [Android dev environment set up](https://github.com/facebook/react-native/blob/master/ReactAndroid/README.md)
 - At least 0.2.0 [react-native-cli](https://www.npmjs.com/package/react-native-cli) installed globally
 
@@ -38,8 +35,8 @@ The following are required for the local test suite to run:
 
 Before cutting a release branch, make sure [Circle](https://circleci.com/gh/facebook/react-native) CI system is green.
 
-
 Before executing the following script, make sure you have:
+
 - An Android emulator / Genymotion device running
 - No packager running in any of the projects
 
@@ -57,18 +54,15 @@ Run:
 
 ```bash
 git checkout -b <version_you_are_releasing>-stable
-# e.g. git checkout -b 0.50-stable
+# e.g. git checkout -b 0.57-stable
 
 ./scripts/bump-oss-version.js <exact-version_you_are_releasing>
-# e.g. ./scripts/bump-oss-version.js 0.50.0-rc
-# You can use the --remote option to specify a Git remote other than the default "origin"
-git push --tags
-git push
+# e.g. ./scripts/bump-oss-version.js 0.57.0-rc.0
 ```
 
-Circle CI will automatically run the tests and publish to npm with the version you have specified (e.g `0.50.0-rc`) and tag `next` meaning that this version will not be installed for users by default.
+Circle CI will automatically run the tests and publish to npm with the version you have specified (e.g `0.57.0-rc.0`) and tag `next` meaning that this version will not be installed for users by default.
 
-Go to [Circle CI](https://circleci.com/gh/facebook/react-native) and look for the build triggered by your push (e.g. _0.50-stable, [0.50.0] Bump version numbers_), then scroll down to the npm publish step to verify the package was published successfully (the build will be red if not).
+Go to [Circle CI](https://circleci.com/gh/facebook/workflows/react-native) and look for the `tests` workflow triggered by your push (e.g. _0.57-stable, [0.57.0] Bump version numbers_). Once the workflow passes all tests, you can "accept" the `deploy` workflow to publish the release to npm.
 
 ### Step 3: Write the release notes
 
@@ -89,7 +83,9 @@ Sometimes commit messages might be really short / confusing - try rewording them
 - `Fix logging reported by RUN_JS_BUNDLE` -> `Fix systrace logging of RUN_JS_BUNDLE event`
 - `Fixes hot code reloading issue` -> `Fix an edge case in hot module reloading`
 
-Before posting the list of changes, consider asking one of contributors for their opinion. Once everything is ready, post the release notes: https://github.com/facebook/react-native/releases
+Open a pull request against CHANGELOG.md at https://github.com/react-native-community/react-native-releases and ask for feedback.
+
+Once everything is ready, create a new release at https://github.com/facebook/react-native/releases and link to the release notes.
 
 **Important**: For release candidate releases, make sure to check "This is a pre-release".
 
@@ -177,7 +173,7 @@ Go to https://github.com/facebook/react-native/releases and find the release not
 
 A stable release is promoted roughly a month after the release branch is cut (refer to the schedule above). The release may be delayed for several reasons, including major issues in the release candidate. Make sure that all bug fixes that have been nominated in your tracking issue have been addressed as needed. Avoid cherry-picking commits that have not been vetted in the release candidate phase at this point.
 
-Once you are sure that the release is solid, perform the following steps. Note that they're similar to the steps you may have followed earlier when patching the release candidate, but we're not cherry-picking any additional commits at this point. 
+Once you are sure that the release is solid, perform the following steps. Note that they're similar to the steps you may have followed earlier when patching the release candidate, but we're not cherry-picking any additional commits at this point.
 
 ### Step 1: Check out the release branch
 

--- a/Releases.md
+++ b/Releases.md
@@ -29,7 +29,7 @@ React Native follows a monthly release train. Every month, a new branch created 
 The following are required for the local test suite to run:
 
 - macOS with [Android dev environment set up](https://github.com/facebook/react-native/blob/master/ReactAndroid/README.md)
-- At least 0.2.0 [react-native-cli](https://www.npmjs.com/package/react-native-cli) installed globally
+- [react-native-cli](https://www.npmjs.com/package/react-native-cli) installed globally (v0.2.0 or newer)
 
 ### Step 1: Check everything works
 
@@ -56,13 +56,12 @@ Run:
 git checkout -b <version_you_are_releasing>-stable
 # e.g. git checkout -b 0.57-stable
 
-./scripts/bump-oss-version.js <exact-version_you_are_releasing>
+./scripts/bump-oss-version.js <exact_version_you_are_releasing>
 # e.g. ./scripts/bump-oss-version.js 0.57.0-rc.0
+#  or  ./scripts/bump-oss-version.js 0.58.0
 ```
 
 Circle CI will automatically run the tests and publish to npm with the version you have specified (e.g `0.57.0-rc.0`) and tag `next` meaning that this version will not be installed for users by default.
-
-Go to [Circle CI](https://circleci.com/gh/facebook/workflows/react-native) and look for the `tests` workflow triggered by your push (e.g. _0.57-stable, [0.57.0] Bump version numbers_). Once the workflow passes all tests, you can "accept" the `deploy` workflow to publish the release to npm.
 
 ### Step 3: Write the release notes
 

--- a/Releases.md
+++ b/Releases.md
@@ -104,7 +104,7 @@ Now that the release is out in the open, go ahead and create a GitHub issue titl
 
 -------------------
 
-## How to release an RC update (e.g. 0.50.0-rc.1, 0.50.0-rc.2)
+## How to release an RC update (e.g. 0.57.0-rc.1, 0.57.0-rc.2)
 
 The release is now in the open, people are finding bugs, and fixes have landed in master. People have been nominating fixes in the issue you created above. Use your best judgment to decide which commits merit an RC update. It's a good idea to do a new RC release when several small and non-risky bugs have been fixed. Having a few RC releases can also help people bisect in case we cherry-pick a bad commit by mistake.
 
@@ -117,10 +117,10 @@ Follow these steps to check out the release branch:
 
 ```bash
 git checkout <version_you_are_patching>-stable
-# e.g. git checkout 0.50-stable
+# e.g. git checkout 0.57-stable
 
 git pull origin <version_you_are_patching>-stable
-# e.g. git pull origin 0.50-stable
+# e.g. git pull origin 0.57-stable
 ```
 
 > If you don't have a local checkout of the release branch, you can run the following instead:
@@ -148,27 +148,18 @@ If everything worked, run the following to bump the version number:
 
 ```bash
 ./scripts/bump-oss-version.js <exact_version_you_are_releasing>
-# e.g. ./scripts/bump-oss-version.js 0.50.0-rc.1
+# e.g. ./scripts/bump-oss-version.js 0.57.0-rc.1
 ```
 
-### Step 5: Push to GitHub
+Again, Circle CI will automatically run the tests and publish to npm with the version you have specified (e.g `0.57.0-rc.1`).
 
-Finally, push the new tags and commits to GitHub:
+### Step 5: Update the release notes
 
-```
-git push --tags
-git push
-````
-
-Again, Circle CI will automatically run the tests and publish to npm with the version you have specified (e.g `0.50.0-rc.1`).
-
-### Step 6: Update the release notes
-
-Go to https://github.com/facebook/react-native/releases and find the release notes for this release candidate. Edit them so that they now point to the tag that you've just created. We want single release notes per version. For example, if there is v0.50.0-rc and you just released v0.50.0-rc.1, the release notes should live on the v0.50.0-rc.1 tag at https://github.com/facebook/react-native/tags
+Go to https://github.com/facebook/react-native/releases and find the release notes for this release candidate. Edit them so that they now point to the tag that you've just created. We want single release notes per version. For example, if there is v0.57.0-rc and you just released v0.57.0-rc.1, the release notes should live on the v0.57.0-rc.1 tag at https://github.com/facebook/react-native/tags
 
 -------------------
 
-## How to do the final stable release (e.g. 0.50.0, 0.50.1)
+## How to do the final stable release (e.g. 0.57.0, 0.57.1)
 
 A stable release is promoted roughly a month after the release branch is cut (refer to the schedule above). The release may be delayed for several reasons, including major issues in the release candidate. Make sure that all bug fixes that have been nominated in your tracking issue have been addressed as needed. Avoid cherry-picking commits that have not been vetted in the release candidate phase at this point.
 
@@ -178,10 +169,10 @@ Once you are sure that the release is solid, perform the following steps. Note t
 
 ```bash
 git checkout <version_you_are_patching>-stable
-# e.g. git checkout 0.50-stable
+# e.g. git checkout 0.57-stable
 
 git pull origin <version_you_are_patching>-stable
-# e.g. git pull origin 0.50-stable
+# e.g. git pull origin 0.57-stable
 ```
 
 > If you don't have a local checkout of the release branch, you can run the following instead:
@@ -201,28 +192,18 @@ If everything worked:
 
 ```bash
 ./scripts/bump-oss-version.js <exact_version_you_are_releasing>
-# e.g. ./scripts/bump-oss-version.js 0.50.0
+# e.g. ./scripts/bump-oss-version.js 0.57.0
 ```
 
-### Step 4: Push to GitHub
+As with the release candidate, Circle CI will automatically run the tests and publish to npm with the version you have specified (e.g `0.57.0`).
 
-Finally, push the new tags and commits to GitHub:
-
-```
-git push --tags
-git push
-```
-
-As with the release candidate, Circle CI will automatically run the tests and publish to npm with the version you have specified (e.g `0.50.0`).
-
-Go to [Circle CI](https://circleci.com/gh/facebook/react-native) and look for the build triggered by your push (e.g. _0.50-stable, [0.50.0] Bump version numbers_), then scroll down to the npm publish step to verify the package was published successfully (the build will be red if not).
+Go to [Circle CI](https://circleci.com/gh/facebook/react-native) and look for the build triggered by your push (e.g. _0.57-stable, [0.57.0] Bump version numbers_), then scroll down to the npm publish step to verify the package was published successfully (the build will be red if not).
 
 This will now become the latest release, and will be installed by users by default. At this point, the website will be updated and the docs for this release will be displayed by default.
 
-### Step 5: Update the release notes
+### Step 4: Update the release notes
 
-Once you see that the website is displaying the version that you have just created, you will need to update the release notes. Move the release notes from the release candidate, to the tag that you've just created. We want single release notes per version. For example, if there is v0.50.0-rc and later we release v0.50.0, the release notes should live on v0.50.0:
-https://github.com/facebook/react-native/tags
+Go to https://github.com/facebook/react-native/releases and find the release notes for this release candidate. Edit them so that they now point to the tag that you've just created. We want single release notes per version. For example, if there is v0.57.0 and you just released v0.57.1, the release notes should live on the v0.57.1 tag at https://github.com/facebook/react-native/tags
 
 For non-RC releases: Uncheck the box "This is a pre-release" and publish the notes.
 


### PR DESCRIPTION
Now that tests are green, we can return to automatic publishing to npm based on git tags. As long as all tests are passing, deploying a new release of React Native is as easy as tagging a commit. I've updated `Releases.md` to reflect today's release process.

Future Work: Include information about updating the website, as this is no longer done automatically.