### PR TITLE
Update GitHub Issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,22 +6,13 @@ about: Report a reproducible bug or regression in the core React Native library.
 <!-- Requirements: please go through this checklist before opening a new issue -->
   - [ ] Review the documentation: https://facebook.github.io/react-native
   - [ ] Search for existing issues: https://github.com/facebook/react-native/issues
-  - [ ] Use the latest React Native version: https://github.com/facebook/react-native/releases
-  - [ ] Run `react-native info` in your terminal and paste its contents under "Environment"
-  - [ ] Let us know how to reproduce the issue. Include a code sample, share a project, or
-    share an app that reproduces the issue using https://snack.expo.io/
+  - [ ] Use the latest React Native release: https://github.com/facebook/react-native/releases
 
 ## Environment
-<!-- Required. -->
+Run `react-native info` in your terminal and paste its contents here.
 
 ## Description
-<!-- Describe your issue in detail. -->
+Describe your issue in detail. Include screenshots if needed. If this is a regression, let us know.
 
-## Steps to Reproduce
-<!-- Required. -->
-
-## Expected Behavior
-<!-- Write what you thought would happen. -->
-
-## Actual Behavior
-<!-- Write what happened. Include screenshots if needed. If this is a regression, let us know. -->
+## Reproducible Demo
+Let us know how to reproduce the issue. Include a code sample, share a project, or     share an app that reproduces the issue using https://snack.expo.io/. Please follow the guidelines for providing a MCVE: https://stackoverflow.com/help/mcve

--- a/.github/ISSUE_TEMPLATE/discussion.md
+++ b/.github/ISSUE_TEMPLATE/discussion.md
@@ -1,15 +1,19 @@
 ---
 name: 🗣 Start a Discussion
 about: Use https://discuss.reactjs.org/ to propose changes or discuss feature requests.
+---
 
-guidelines: |
-  If you feel strongly about starting a discussion as a GitHub Issue instead of using the discussion forum, please follow this template.
-  We kindly ask that issues of this type are kept to a minimum to ensure bug reports and regressions are given the priority they require.
-  Maintainers may flag an issue for Stack Overflow or kindly ask you to move the discussion to https://discuss.reactjs.org at their own discretion.
+Please use https://discuss.reactjs.org/ to propose changes or discuss feature requests.
+
+If you feel strongly about starting a discussion as a GitHub Issue instead of using the discussion forum, you may follow this template.
+
+We kindly ask that issues of this type are kept to a minimum to ensure bug reports and regressions are given the priority they require.
+
+Maintainers may flag an issue for Stack Overflow or kindly ask you to move the discussion to https://discuss.reactjs.org at their own discretion.
 
 ---
 
-## For Discussion
+# For Discussion
 
 <!-- Describe your issue in detail. -->
 


### PR DESCRIPTION
Now that we have templates for everything we want to handle in the repo, the bot will go back to automatically closing issues that do not use one of the provided templates.

We have an escape valve for generic issues ("For Discussion"), so anyone who gets their issue closed automatically by the bot is unlikely to have read our instructions.