### PR TITLE
Suppress lint errors in Dialog module. remove abortOnError=false

### DIFF
--- a/RNTester/android/app/build.gradle
+++ b/RNTester/android/app/build.gradle
@@ -121,10 +121,6 @@ android {
         }
     }
 
-    lintOptions {
-        abortOnError false
-    }
-
     // applicationVariants are e.g. debug, release
     applicationVariants.all { variant ->
         variant.outputs.each { output ->

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/dialog/AlertFragment.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/dialog/AlertFragment.java
@@ -9,6 +9,7 @@ package com.facebook.react.modules.dialog;
 
 import javax.annotation.Nullable;
 
+import android.annotation.SuppressLint;
 import android.app.AlertDialog;
 import android.app.Dialog;
 import android.app.DialogFragment;
@@ -34,6 +35,7 @@ public class AlertFragment extends DialogFragment implements DialogInterface.OnC
       mListener = null;
   }
 
+  @SuppressLint("ValidFragment")
   public AlertFragment(@Nullable DialogModule.AlertFragmentListener listener, Bundle arguments) {
     mListener = listener;
     setArguments(arguments);

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/dialog/SupportAlertFragment.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/dialog/SupportAlertFragment.java
@@ -9,6 +9,7 @@ package com.facebook.react.modules.dialog;
 
 import javax.annotation.Nullable;
 
+import android.annotation.SuppressLint;
 import android.app.Dialog;
 import android.content.DialogInterface;
 import android.os.Bundle;
@@ -27,6 +28,7 @@ public class SupportAlertFragment extends DialogFragment implements DialogInterf
       mListener = null;
   }
 
+  @SuppressLint("ValidFragment")
   public SupportAlertFragment(@Nullable DialogModule.AlertFragmentListener listener, Bundle arguments) {
     mListener = listener;
     setArguments(arguments);

--- a/build.gradle
+++ b/build.gradle
@@ -35,12 +35,4 @@ allprojects {
             url "$androidSdk/extras/m2repository/"
         }
     }
-
-    project.configurations.all {
-        resolutionStrategy.eachDependency { details ->
-            if (details.requested.group == 'com.facebook.soloader') {
-                details.useVersion "0.3.0"
-            }
-        }
-    }
 }


### PR DESCRIPTION
Suppress lint errors in Dialog module. remove abortOnError=false.

This might hide future problems, so removing it
``` gradle
lintOptions {	
  abortOnError false
}	
```

Builds locally just fine. But CI is failing for unknown reasons. https://circleci.com/gh/dulmandakh/react-native/265

## Test Plan

RNTester will built without errors