### PR TITLE
deprecate ReactFragmentActivity

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/ReactFragmentActivity.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactFragmentActivity.java
@@ -19,9 +19,11 @@ import com.facebook.react.modules.core.PermissionAwareActivity;
 import com.facebook.react.modules.core.PermissionListener;
 
 /**
- * Base Activity for React Native applications. Like {@link ReactActivity} but extends
- * {@link FragmentActivity} instead of {@link android.app.Activity}.
+ * @deprecated
+ * ReactFragmentActivity will be removed in 0.57 release.
+ * Use {@link ReactActivity} instead.
  */
+@Deprecated
 public abstract class ReactFragmentActivity extends FragmentActivity implements
   DefaultHardwareBackBtnHandler, PermissionAwareActivity {
 


### PR DESCRIPTION
Android Support Library page says https://developer.android.com/topic/libraries/support-library/
> Caution: Starting with Support Library release 26.0.0 (July 2017), the minimum supported API level across most support libraries has increased to Android 4.0 (API level 14) for most library packages. For more information, see Version Support and Package Names in this document.

_android.support.v4.app.FragmentActivity_ is used to support **Fragment**s on Android API versions below 11. Now, we support only API version 14 and above, it's ok to remove _ReactFragmentActivity_ that extends _FragmentActivity_.

Once ReactFragmentActivity removed, we can remove some codes that use _android.support.v4_ to work support _ReactFragmentActivity_ on **unsupported** Android versions. 

CI is failing for unknown reasons: https://circleci.com/gh/dulmandakh/react-native/278
> Received 'killed' signal
## Test Plan

Everything will build and work just fine, except showing _ ReactFragmentActivity_ as deprecated