### PR TITLE
limit Android NDK jobs on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -569,7 +569,7 @@ jobs:
       - run:
           name: Build Android RNTester
           command: |
-            ./gradlew RNTester:android:app:assembleRelease
+            ./gradlew RNTester:android:app:assembleRelease -Pjobs=$BUILD_THREADS
 
       # Collect Results
       - run: *collect-android-test-results

--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -18,6 +18,7 @@ import org.apache.tools.ant.filters.ReplaceTokens
 
 def customDownloadsDir = System.getenv("REACT_NATIVE_DOWNLOADS_DIR")
 def downloadsDir = customDownloadsDir ? new File(customDownloadsDir) : new File("$buildDir/downloads")
+def ndkJobs = System.getenv("BUILD_THREADS")
 def thirdPartyNdkDir = new File("$buildDir/third-party-ndk")
 
 // You need to have following folders in this directory:
@@ -221,7 +222,7 @@ task buildReactNdkLib(dependsOn: [prepareJSC, prepareBoost, prepareDoubleConvers
             "THIRD_PARTY_NDK_DIR=$buildDir/third-party-ndk",
             "REACT_COMMON_DIR=$projectDir/../ReactCommon",
             '-C', file('src/main/jni/react/jni').absolutePath,
-            '--jobs', project.hasProperty("jobs") ? project.property("jobs") : Runtime.runtime.availableProcessors()
+            '--jobs', ndkJobs ?: project.hasProperty("jobs") ? project.property("jobs") : Runtime.runtime.availableProcessors()
 }
 
 task cleanReactNdkLib(type: Exec) {

--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -18,7 +18,6 @@ import org.apache.tools.ant.filters.ReplaceTokens
 
 def customDownloadsDir = System.getenv("REACT_NATIVE_DOWNLOADS_DIR")
 def downloadsDir = customDownloadsDir ? new File(customDownloadsDir) : new File("$buildDir/downloads")
-def ndkJobs = System.getenv("BUILD_THREADS")
 def thirdPartyNdkDir = new File("$buildDir/third-party-ndk")
 
 // You need to have following folders in this directory:
@@ -222,7 +221,7 @@ task buildReactNdkLib(dependsOn: [prepareJSC, prepareBoost, prepareDoubleConvers
             "THIRD_PARTY_NDK_DIR=$buildDir/third-party-ndk",
             "REACT_COMMON_DIR=$projectDir/../ReactCommon",
             '-C', file('src/main/jni/react/jni').absolutePath,
-            '--jobs', ndkJobs ?: project.hasProperty("jobs") ? project.property("jobs") : Runtime.runtime.availableProcessors()
+            '--jobs', project.hasProperty("jobs") ? project.property("jobs") : Runtime.runtime.availableProcessors()
 }
 
 task cleanReactNdkLib(type: Exec) {


### PR DESCRIPTION
Limit number of NDK jobs of ReactAndroid on CI using $BUILD_THREADS environment variable. Otherwise, it was spawning 32 jobs while building RNTester, which caused in OOM or unexpected failure.

CI: https://circleci.com/gh/dulmandakh/react-native/322

## Test Plan

Android CI is green again 😍 