### PR TITLE
limit ndk jobs for RNTester on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -569,7 +569,7 @@ jobs:
       - run:
           name: Build Android RNTester
           command: |
-            ./gradlew RNTester:android:app:assembleRelease
+            ./gradlew RNTester:android:app:assembleRelease -Pjobs=$BUILD_THREADS
 
       # Collect Results
       - run: *collect-android-test-results


### PR DESCRIPTION
Limit number of NDK jobs of ReactAndroid on CI using $BUILD_THREADS environment variable. Otherwise, it was spawning 32 jobs while building RNTester, which caused in OOM or unexpected failure.

CI: https://circleci.com/gh/dulmandakh/react-native/387
## Test Plan

Android CI is green again 😍