### PR TITLE
use same signing config for debug build

### DIFF
--- a/RNTester/android/app/build.gradle
+++ b/RNTester/android/app/build.gradle
@@ -114,6 +114,9 @@ android {
         }
     }
     buildTypes {
+        debug {
+            signingConfig signingConfigs.release
+        }
         release {
             minifyEnabled enableProguardInReleaseBuilds
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'


### PR DESCRIPTION
## Motivation
use same signing config for debug build 
## Test Plan
pass all current ci.
## Related PRs
none
## Release Notes
 [GENERAL] [INTERNAL] [RNTester] - use same signing config for debug build .