### PR TITLE
[Android] Add support for full-screen WebView

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebChromeClient.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebChromeClient.java
@@ -15,7 +15,7 @@ import com.facebook.react.common.build.ReactBuildConfig;
 import static android.view.ViewGroup.LayoutParams;
 
 /**
- * Wrapper Client for {@link WebViewConfig}. It overrides methods for geolocation permissions,
+ * Wrapper Client for {@link WebChromeClient}. It overrides methods for geolocation permissions,
  * console messages (which were previously overwritten ad hoc in {@link ReactWebViewManager}) and
  * onShowCustomView and onHideCustomView for handling fullscreen move
  */

--- a/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebChromeClient.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebChromeClient.java
@@ -17,7 +17,7 @@ import static android.view.ViewGroup.LayoutParams;
 /**
  * Wrapper Client for {@link WebChromeClient}. It overrides methods for geolocation permissions,
  * console messages (which were previously overwritten ad hoc in {@link ReactWebViewManager}) and
- * onShowCustomView and onHideCustomView for handling fullscreen move
+ * onShowCustomView and onHideCustomView for handling fullscreen view
  */
 public class ReactWebChromeClient extends WebChromeClient {
 

--- a/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebChromeClient.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebChromeClient.java
@@ -1,0 +1,76 @@
+package com.facebook.react.views.webview;
+
+import android.graphics.Color;
+import android.view.Gravity;
+import android.view.View;
+import android.view.ViewGroup;
+import android.webkit.ConsoleMessage;
+import android.webkit.GeolocationPermissions;
+import android.webkit.WebChromeClient;
+import android.widget.FrameLayout;
+
+import com.facebook.react.bridge.ReactContext;
+import com.facebook.react.common.build.ReactBuildConfig;
+
+import static android.view.ViewGroup.LayoutParams;
+
+/**
+ * Wrapper Client for {@link WebViewConfig}. It overrides methods for geolocation permissions,
+ * console messages (which were previously overwritten ad hoc in {@link ReactWebViewManager}) and
+ * onShowCustomView and onHideCustomView for handling fullscreen move
+ */
+public class ReactWebChromeClient extends WebChromeClient {
+
+  private final FrameLayout.LayoutParams FULLSCREEN_LAYOUT_PARAMS = new FrameLayout.LayoutParams(
+          LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT, Gravity.CENTER);
+
+  private WebChromeClient.CustomViewCallback mCustomViewCallback;
+  private View mFullScreenView;
+  private ReactContext mReactContext;
+
+  public ReactWebChromeClient(ReactContext reactContext) {
+    mReactContext = reactContext;
+  }
+
+  @Override
+  public boolean onConsoleMessage(ConsoleMessage message) {
+    if (ReactBuildConfig.DEBUG) {
+      return super.onConsoleMessage(message);
+    }
+    // Ignore console logs in non debug builds.
+    return true;
+  }
+
+  @Override
+  public void onGeolocationPermissionsShowPrompt(String origin, GeolocationPermissions.Callback callback) {
+    callback.invoke(origin, true, false);
+  }
+
+  @Override
+  public void onShowCustomView(View view, CustomViewCallback callback) {
+    if (mFullScreenView != null) {
+      callback.onCustomViewHidden();
+      return;
+    }
+    // Store the view for hiding handling
+    mFullScreenView = view;
+    mCustomViewCallback = callback;
+    view.setBackgroundColor(Color.BLACK);
+    getRootView().addView(view, FULLSCREEN_LAYOUT_PARAMS);
+  }
+
+  @Override
+  public void onHideCustomView() {
+    if (mFullScreenView == null) {
+      return;
+    }
+    mFullScreenView.setVisibility(View.GONE);
+    getRootView().removeView(mFullScreenView);
+    mFullScreenView = null;
+    mCustomViewCallback.onCustomViewHidden();
+  }
+
+  private ViewGroup getRootView() {
+    return ((ViewGroup) mReactContext.getCurrentActivity().findViewById(android.R.id.content));
+  }
+}

--- a/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebViewManager.java
@@ -391,21 +391,7 @@ public class ReactWebViewManager extends SimpleViewManager<WebView> {
   @TargetApi(Build.VERSION_CODES.LOLLIPOP)
   protected WebView createViewInstance(ThemedReactContext reactContext) {
     ReactWebView webView = createReactWebViewInstance(reactContext);
-    webView.setWebChromeClient(new WebChromeClient() {
-      @Override
-      public boolean onConsoleMessage(ConsoleMessage message) {
-        if (ReactBuildConfig.DEBUG) {
-          return super.onConsoleMessage(message);
-        }
-        // Ignore console logs in non debug builds.
-        return true;
-      }
-
-      @Override
-      public void onGeolocationPermissionsShowPrompt(String origin, GeolocationPermissions.Callback callback) {
-        callback.invoke(origin, true, false);
-      }
-    });
+    webView.setWebChromeClient(new ReactWebChromeClient(reactContext));
     reactContext.addLifecycleEventListener(webView);
     mWebViewConfig.configWebView(webView);
     WebSettings settings = webView.getSettings();

--- a/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebViewManager.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import android.content.ActivityNotFoundException;
 import android.content.Intent;
 import android.graphics.Bitmap;
+import android.graphics.Color;
 import android.graphics.Picture;
 import android.net.Uri;
 import android.os.Build;


### PR DESCRIPTION
Motivation: Handle issue https://github.com/facebook/react-native/issues/16444
It was impossible to show full screen in Android's WebView 

## Test Plan

Simply go to page like youtube.com and try to enter full-screen. Before this changes it wasn't possible to do it

## Related PRs
Inspired by: https://github.com/facebook/react-native/pull/10327

## Release Notes

 [ANDROID] [Feature] [WebView] - Add full-screen view

