### PR TITLE
Make run-ios command play nicely with multiple Xcode versions

### DIFF
--- a/local-cli/runIOS/runIOS.js
+++ b/local-cli/runIOS/runIOS.js
@@ -160,8 +160,11 @@ function runOnSimulator(xcodeProject, args, scheme) {
      * it will not boot the "default" device, but the one we set. If the app is already running,
      * this flag has no effect.
      */
+    const activeDeveloperDir = child_process
+      .execFileSync('xcode-select', ['-p'], {encoding: 'utf8'})
+      .trim();
     child_process.execFileSync('open', [
-      '/Applications/Xcode.app/Contents/Developer/Applications/Simulator.app',
+      `${activeDeveloperDir}/Applications/Simulator.app`,
       '--args',
       '-CurrentDeviceUDID',
       selectedSimulator.udid,


### PR DESCRIPTION
I started using Xcode 10 beta and spotted that even though react-native cli is using cli tools from Xcode 10 for building it tries to open simulator from Xcode 9.4. Turned out that path to simulator app is hardcoded and doesn’t care about active developer directory.

## Test Plan
1. You have to have more than one Xcode version (ie. 9.4 and 10 beta).
2. Change active developer directory to Xcode beta (`xcode-select -s /Applications/Xcode-beta.app/Contents/Developer`).
3. Without fix `react-native run-ios` will open simulator from Xcode 9.4, with fix it'll open simulator from active developer directory.

## Release Notes
[CLI][IOS] [BUGFIX] [./local-cli] - use simulator from active developer directory 