### PR TITLE
Remove some methods that have `NS_UNAVAILABLE` set

### DIFF
--- a/Libraries/Text/TextInput/Multiline/RCTMultilineTextInputView.m
+++ b/Libraries/Text/TextInput/Multiline/RCTMultilineTextInputView.m
@@ -40,9 +40,6 @@
   return self;
 }
 
-RCT_NOT_IMPLEMENTED(- (instancetype)initWithFrame:(CGRect)frame)
-RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)coder)
-
 - (id<RCTBackedTextInputViewProtocol>)backedTextInputView
 {
   return _backedTextInputView;

--- a/Libraries/Text/TextInput/Multiline/RCTUITextView.m
+++ b/Libraries/Text/TextInput/Multiline/RCTUITextView.m
@@ -108,12 +108,6 @@ static UIColor *defaultPlaceholderColor()
   _placeholderView.textAlignment = textAlignment;
 }
 
-- (void)setText:(NSString *)text
-{
-  [super setText:text];
-  [self textDidChange];
-}
-
 - (void)setAttributedText:(NSAttributedString *)attributedText
 {
   [super setAttributedText:attributedText];

--- a/Libraries/Text/TextInput/Singleline/RCTSinglelineTextInputView.m
+++ b/Libraries/Text/TextInput/Singleline/RCTSinglelineTextInputView.m
@@ -32,9 +32,6 @@
   return self;
 }
 
-RCT_NOT_IMPLEMENTED(- (instancetype)initWithFrame:(CGRect)frame)
-RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)coder)
-
 - (id<RCTBackedTextInputViewProtocol>)backedTextInputView
 {
   return _backedTextInputView;

--- a/Libraries/Text/TextInput/Singleline/RCTUITextField.m
+++ b/Libraries/Text/TextInput/Singleline/RCTUITextField.m
@@ -121,12 +121,6 @@
 
 #pragma mark - Overrides
 
-- (void)setSelectedTextRange:(UITextRange *)selectedTextRange
-{
-  [super setSelectedTextRange:selectedTextRange];
-  [_textInputDelegateAdapter selectedTextRangeWasSet];
-}
-
 - (void)setSelectedTextRange:(UITextRange *)selectedTextRange notifyDelegate:(BOOL)notifyDelegate
 {
   if (!notifyDelegate) {


### PR DESCRIPTION
These lines were causing erros with the e2e tests on ios.
There are some methods that are not going to be called, and some definitions that are not correct.

needed for #19574.

## Test Plan

we will run the e2e tests.

## Related PRs
#19574 

## Release Notes
[INTERNAL] [MINOR] [Tests] - Fix some definitions.
