### PR TITLE
Silence warning "Class RCTCxxModule was not exported"

### DIFF
--- a/React/CxxModule/RCTCxxModule.mm
+++ b/React/CxxModule/RCTCxxModule.mm
@@ -21,10 +21,7 @@ using namespace facebook::react;
   std::unique_ptr<facebook::xplat::module::CxxModule> _module;
 }
 
-+ (NSString *)moduleName
-{
-  return @"";
-}
+RCT_EXPORT_MODULE()
 
 + (BOOL)requiresMainQueueSetup
 {


### PR DESCRIPTION
<!-- 
  Required: Write your motivation here.
  If this PR fixes an issue, type "Fixes #issueNumber" to automatically close the issue when the PR is merged.
-->

On a relatively stock / default setup of RN on iOS you'll see the warning "Class RCTCxxModule was not exported. Did you forget to use RCT_EXPORT_MODULE()?" pop up on every launch. This change resolves that issue. 

Fixes #14806

## Test Plan

Try a fresh project by following the RN iOS tutorial, and observe that there are no more warnings after making this change.

## Release Notes

[IOS] [MINOR] [CxxBridge] - Fix "Class RCTCxxModule was not exported"
