### PR TITLE
Check if config contains a key before fetching. Default to 0

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/animated/FrameBasedAnimationDriver.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/animated/FrameBasedAnimationDriver.java
@@ -41,7 +41,7 @@ class FrameBasedAnimationDriver extends AnimationDriver {
     for (int i = 0; i < numberOfFrames; i++) {
       mFrames[i] = frames.getDouble(i);
     }
-    mToValue = config.getDouble("toValue");
+    mToValue = config.hasKey("toValue") ? config.getDouble("toValue") : 0;
     mIterations = config.hasKey("iterations") ? config.getInt("iterations") : 1;
     mCurrentLoop = 1;
     mHasFinished = mIterations == 0;


### PR DESCRIPTION
Potential Fix to #19793 

## Test Plan

modified the code and tried to recreate the bug and was unable to. The red screen never popped up and nothing else seemed to be affected in a negative way.

## Release Notes

[ANDROID] [BUGFIX] [FrameBasedAnimationDriver.java] - Safely unwrapping ReadableMap by defaulting to 0 if key not present.
