### PR TITLE
Allow ReactActivityDelegate subclass to overrride mainComponentName

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/ReactActivityDelegate.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactActivityDelegate.java
@@ -75,9 +75,14 @@ public class ReactActivityDelegate {
     return getReactNativeHost().getReactInstanceManager();
   }
 
+  public String getMainComponentName() {
+    return mMainComponentName;
+  }
+
   protected void onCreate(Bundle savedInstanceState) {
-    if (mMainComponentName != null) {
-      loadApp(mMainComponentName);
+    String mainComponentName = getMainComponentName();
+    if (mainComponentName != null) {
+      loadApp(mainComponentName);
     }
     mDoubleTapReloadRecognizer = new DoubleTapReloadRecognizer();
   }


### PR DESCRIPTION
Currently, the final field mMainComponentName is used. This field is
initialized in the constructor of ReactActivityDelegate, and the
ReactActivityDelegate itself is initialized in the constructor of
ReactActivity. This means that the only way you can pass a main
component name to ReactActivityDelegate, is when your ReactActivity
subclass is constructed. At this point in the lifecycle of an
activity, the getIntent() value that the activity was initialized by
returns null, making it impossible to set the mainComponentName
dynamically based on data passed to the activity via an intent.

The mMainComponentName final field is also only used in onCreate of
the delegate, so it's not actually needed by the ReactActivityDelegate
at construction time. So the above limitation is not fundamental, it's
just a side effect of the API design.

By allowing subclasses of ReactActivityDelegate to implement a
getMainComponentName method, the subclass then has full control of how
to initialize the value. So an implementation of getMainComponentName
could be:

    public String getMainComponentName() {
        return getIntent().getStringExtra("reactMainComponentName");
    }

This commit doesn't remove anything and only adds a new method, so it
should be fully backwards compatible.

Thank you for sending the PR! We appreciate you spending the time to work on these changes. 
Help us understand your motivation by explaining why you decided to make this change.

<!-- 
  Required: Write your motivation here.
  If this PR fixes an issue, type "Fixes #issueNumber" to automatically close the issue when the PR is merged.
-->

## Test Plan

<!-- 
  Required: Write your test plan here. If you changed any code, please provide us with 
  clear instructions on how you verified your changes work. Bonus points for screenshots and videos! 
-->

## Related PRs

<!-- 
  Does this PR require a documentation change? 
  Create a PR at https://github.com/facebook/react-native-website and add a link to it here.
-->

## Release Notes

<!-- 
  Required. 
  Help reviewers and the release process by writing your own release notes. See below for an example.
-->

[ANDROID] [ENHANCEMENT] [ReactActivityDelegate] - Added ability for subclasses to override component name

<!--
  **INTERNAL and MINOR tagged notes will not be included in the next version's final release notes.**

    CATEGORY
  [----------]      TYPE
  [ CLI      ] [-------------]    LOCATION
  [ DOCS     ] [ BREAKING    ] [-------------]
  [ GENERAL  ] [ BUGFIX      ] [ {Component} ]
  [ INTERNAL ] [ ENHANCEMENT ] [ {Filename}  ]
  [ IOS      ] [ FEATURE     ] [ {Directory} ]   |-----------|
  [ ANDROID  ] [ MINOR       ] [ {Framework} ] - | {Message} |
  [----------] [-------------] [-------------]   |-----------|

 EXAMPLES:

 [IOS] [BREAKING] [FlatList] - Change a thing that breaks other things
 [ANDROID] [BUGFIX] [TextInput] - Did a thing to TextInput
 [CLI] [FEATURE] [local-cli/info/info.js] - CLI easier to do things with
 [DOCS] [BUGFIX] [GettingStarted.md] - Accidentally a thing/word
 [GENERAL] [ENHANCEMENT] [Yoga] - Added new yoga thing/position
 [INTERNAL] [FEATURE] [./scripts] - Added thing to script that nobody will see
-->

## Changelog:

[Android] [Enhancement] - Added ability for subclasses of ReactActivityDelegate to override component name