### PR TITLE
bump NDK APP_PLATFORM to android-16

### DIFF
--- a/ReactAndroid/src/main/jni/Application.mk
+++ b/ReactAndroid/src/main/jni/Application.mk
@@ -1,7 +1,7 @@
 APP_BUILD_SCRIPT := Android.mk
 
 APP_ABI := armeabi-v7a x86
-APP_PLATFORM := android-9
+APP_PLATFORM := android-16
 
 APP_MK_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 


### PR DESCRIPTION
This PR will bump NDK APP_PLATFORM to android-16. Below is the excerpt from NDK documentation

> This variable contains the minimum Android platform version you want to support. For example, a value of android-15 specifies that your library uses APIs that are not available below Android 4.0.3 (API level 15) and can't be used on devices running a lower platform version. For a complete list of platform names and corresponding Android system images, see Android NDK Native APIs.

Test Plan:
----------

Will build and run as usual on Android API 16 and above versions.

Release Notes:
--------------
Help reviewers and the release process by writing your own release notes. See below for an example.

[ANDROID] [ENHANCEMENT] [NDK] - bump APP_PLATFORM to android-16