### PR TITLE
Fix `currentlyFocusedField` by Removing `this` usage in TextInputState

### DIFF
--- a/Libraries/Components/TextInput/TextInputState.js
+++ b/Libraries/Components/TextInput/TextInputState.js
@@ -18,73 +18,74 @@
 const Platform = require('Platform');
 const UIManager = require('UIManager');
 
+let currentlyFocusedID: ?number = null;
 const inputs = new Set();
 
-const TextInputState = {
-  /**
-   * Internal state
-   */
-  _currentlyFocusedID: (null: ?number),
+/**
+ * Returns the ID of the currently focused text field, if one exists
+ * If no text field is focused it returns null
+ */
+function currentlyFocusedField(): ?number {
+  return currentlyFocusedID;
+}
 
-  /**
-   * Returns the ID of the currently focused text field, if one exists
-   * If no text field is focused it returns null
-   */
-  currentlyFocusedField: function(): ?number {
-    return this._currentlyFocusedID;
-  },
-
-  /**
-   * @param {number} TextInputID id of the text field to focus
-   * Focuses the specified text field
-   * noop if the text field was already focused
-   */
-  focusTextInput: function(textFieldID: ?number) {
-    if (this._currentlyFocusedID !== textFieldID && textFieldID !== null) {
-      this._currentlyFocusedID = textFieldID;
-      if (Platform.OS === 'ios') {
-        UIManager.focus(textFieldID);
-      } else if (Platform.OS === 'android') {
-        UIManager.dispatchViewManagerCommand(
-          textFieldID,
-          UIManager.AndroidTextInput.Commands.focusTextInput,
-          null,
-        );
-      }
+/**
+ * @param {number} TextInputID id of the text field to focus
+ * Focuses the specified text field
+ * noop if the text field was already focused
+ */
+function focusTextInput(textFieldID: ?number) {
+  if (currentlyFocusedID !== textFieldID && textFieldID !== null) {
+    currentlyFocusedID = textFieldID;
+    if (Platform.OS === 'ios') {
+      UIManager.focus(textFieldID);
+    } else if (Platform.OS === 'android') {
+      UIManager.dispatchViewManagerCommand(
+        textFieldID,
+        UIManager.AndroidTextInput.Commands.focusTextInput,
+        null,
+      );
     }
-  },
+  }
+}
 
-  /**
-   * @param {number} textFieldID id of the text field to unfocus
-   * Unfocuses the specified text field
-   * noop if it wasn't focused
-   */
-  blurTextInput: function(textFieldID: ?number) {
-    if (this._currentlyFocusedID === textFieldID && textFieldID !== null) {
-      this._currentlyFocusedID = null;
-      if (Platform.OS === 'ios') {
-        UIManager.blur(textFieldID);
-      } else if (Platform.OS === 'android') {
-        UIManager.dispatchViewManagerCommand(
-          textFieldID,
-          UIManager.AndroidTextInput.Commands.blurTextInput,
-          null,
-        );
-      }
+/**
+ * @param {number} textFieldID id of the text field to unfocus
+ * Unfocuses the specified text field
+ * noop if it wasn't focused
+ */
+function blurTextInput(textFieldID: ?number) {
+  if (currentlyFocusedID === textFieldID && textFieldID !== null) {
+    currentlyFocusedID = null;
+    if (Platform.OS === 'ios') {
+      UIManager.blur(textFieldID);
+    } else if (Platform.OS === 'android') {
+      UIManager.dispatchViewManagerCommand(
+        textFieldID,
+        UIManager.AndroidTextInput.Commands.blurTextInput,
+        null,
+      );
     }
-  },
+  }
+}
 
-  registerInput: function(textFieldID: number) {
-    inputs.add(textFieldID);
-  },
+function registerInput(textFieldID: number) {
+  inputs.add(textFieldID);
+}
 
-  unregisterInput: function(textFieldID: number) {
-    inputs.delete(textFieldID);
-  },
+function unregisterInput(textFieldID: number) {
+  inputs.delete(textFieldID);
+}
 
-  isTextInput: function(textFieldID: number) {
-    return inputs.has(textFieldID);
-  },
+function isTextInput(textFieldID: number) {
+  return inputs.has(textFieldID);
+}
+
+module.exports = {
+  currentlyFocusedField,
+  focusTextInput,
+  blurTextInput,
+  registerInput,
+  unregisterInput,
+  isTextInput,
 };
-
-module.exports = TextInputState;


### PR DESCRIPTION
I broke `currentlyFocusedField` when adding it back in ce3b7b8204dad0fd62a76a0ce66472eca4b25bc8 because `this` no longer refers to the proper object because it is assigned here https://github.com/facebook/react-native/commit/ce3b7b8204dad0fd62a76a0ce66472eca4b25bc8#diff-b48972356bc8dca4a00747d002fc3dd5R330. This code was pretty prone to breaking so I simply removed the `this` usage and rely on a top level variable instead. Also moved everything to named functions.

Test Plan:
----------
Tested that calling currentlyFocusedField actually returns a value if a text input is focused.

Release Notes:
--------------

[GENERAL] [BUGFIX] [TextInputState] - Fix `currentlyFocusedField` by Removing `this` usage in TextInputState
