### PR TITLE
fix undefined_arch error in Xcode 10 beta

### DIFF
--- a/scripts/ios-configure-glog.sh
+++ b/scripts/ios-configure-glog.sh
@@ -2,7 +2,19 @@
 set -e
 
 PLATFORM_NAME="${PLATFORM_NAME:-iphoneos}"
-CURRENT_ARCH="${CURRENT_ARCH:-armv7}"
+CURRENT_ARCH="${CURRENT_ARCH}"
+
+if [ -z "$CURRENT_ARCH" ] || [ "$CURRENT_ARCH" == "undefined_arch" ]; then
+    # Xcode 10 beta sets CURRENT_ARCH to "undefined_arch", this leads to incorrect linker arg.
+    # it's better to rely on platform name as fallback because architecture differs between simulator and device
+
+    if [[ "$PLATFORM_NAME" == *"simulator"* ]]; then
+        CURRENT_ARCH="x86_64"
+    else 
+        # arm64 is the current CPU architecture (since the iPhone 5S)
+        CURRENT_ARCH="arm64"
+    fi
+fi
 
 export CC="$(xcrun -find -sdk $PLATFORM_NAME cc) -arch $CURRENT_ARCH -isysroot $(xcrun -sdk $PLATFORM_NAME --show-sdk-path)"
 export CXX="$CC"

--- a/scripts/ios-configure-glog.sh
+++ b/scripts/ios-configure-glog.sh
@@ -11,8 +11,7 @@ if [ -z "$CURRENT_ARCH" ] || [ "$CURRENT_ARCH" == "undefined_arch" ]; then
     if [[ "$PLATFORM_NAME" == *"simulator"* ]]; then
         CURRENT_ARCH="x86_64"
     else 
-        # arm64 is the current CPU architecture (since the iPhone 5S)
-        CURRENT_ARCH="arm64"
+        CURRENT_ARCH="armv7"
     fi
 fi
 


### PR DESCRIPTION
Fixes #19774

I spotted that in  Xcode 10 beta `CURRENT_ARCH` is set to string `undefined_arch`.  This PR will add fallback based on platform name (simulators are `x86_64` and everything since iPhone 5s is `arm64`).

Test Plan:
----------
Try to build on Xcode 10 beta - build will pass without issues.
Check if it works on Xcode 9 - build will pass as well.

Release Notes:
--------------
[IOS][INTERNAL] [ENHANCEMENT] [./scripts/ios-configure-glog.sh] - fix undefined_arch error in Xcode 10 beta