### PR TITLE
Bump jest version to 23.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -213,7 +213,7 @@
     "eslint-plugin-react": "7.8.2",
     "eslint-plugin-react-native": "^3.2.1",
     "flow-bin": "^0.75.0",
-    "jest": "23.1.0",
+    "jest": "23.2.0",
     "jest-junit": "4.0.0",
     "prettier": "1.13.4",
     "react": "16.4.1",


### PR DESCRIPTION
[Jest 23.2.0](https://github.com/facebook/jest/blob/master/CHANGELOG.md#2320) landed fix for `MockNativeMethods` access in react-native jest preset.

Test Plan:
----------
Pass CI

Release Notes:
--------------

[INTERNAL] [BUGFIX] [package.json] - Bump jest version to 23.2.0

<!--
  **INTERNAL and MINOR tagged notes will not be included in the next version's final release notes.**

    CATEGORY
  [----------]      TYPE
  [ CLI      ] [-------------]    LOCATION
  [ DOCS     ] [ BREAKING    ] [-------------]
  [ GENERAL  ] [ BUGFIX      ] [ {Component} ]
  [ INTERNAL ] [ ENHANCEMENT ] [ {Filename}  ]
  [ IOS      ] [ FEATURE     ] [ {Directory} ]   |-----------|
  [ ANDROID  ] [ MINOR       ] [ {Framework} ] - | {Message} |
  [----------] [-------------] [-------------]   |-----------|

 EXAMPLES:

 [IOS] [BREAKING] [FlatList] - Change a thing that breaks other things
 [ANDROID] [BUGFIX] [TextInput] - Did a thing to TextInput
 [CLI] [FEATURE] [local-cli/info/info.js] - CLI easier to do things with
 [DOCS] [BUGFIX] [GettingStarted.md] - Accidentally a thing/word
 [GENERAL] [ENHANCEMENT] [Yoga] - Added new yoga thing/position
 [INTERNAL] [FEATURE] [./scripts] - Added thing to script that nobody will see
-->
