### PR TITLE
Suppress spurious warning about RCTCxxModule

### DIFF
--- a/React/Base/RCTBridge.m
+++ b/React/Base/RCTBridge.m
@@ -106,6 +106,9 @@ void RCTVerifyAllModulesExported(NSArray *extraModules)
 
   for (unsigned int i = 0; i < classCount; i++) {
     Class cls = classes[i];
+    if (strncmp(class_getName(cls), "RCTCxxModule", strlen("RCTCxxModule")) == 0) {
+      continue;
+    }
     Class superclass = cls;
     while (superclass) {
       if (class_conformsToProtocol(superclass, @protocol(RCTBridgeModule))) {


### PR DESCRIPTION
<!-- 
  Required: Write your motivation here.
  If this PR fixes an issue, type "Fixes #issueNumber" to automatically close the issue when the PR is merged.
-->

On a relatively stock / default setup of RN on iOS you'll see the warning "Class RCTCxxModule was not exported. Did you forget to use RCT_EXPORT_MODULE()?" pop up on every launch. This change resolves that issue. 

Fixes #14806 .

This supersedes PR #19794 .

## Test Plan

Try a fresh project by following the RN iOS tutorial, and observe that there are no more warnings after making this change.

## Release Notes

[IOS] [MINOR] [CxxBridge] - Fix "Class RCTCxxModule was not exported"
