### PR TITLE
bump glog to 0.3.5

### DIFF
--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -24,7 +24,7 @@ def thirdPartyNdkDir = new File("$buildDir/third-party-ndk")
 //   - boost_1_63_0
 //   - double-conversion-1.1.1
 //   - folly-deprecate-dynamic-initializer
-//   - glog-0.3.3
+//   - glog-0.3.5
 //   - jsc-headers
 def dependenciesPath = System.getenv("REACT_NATIVE_DEPENDENCIES")
 


### PR DESCRIPTION
bump glog to 0.3.5.

Version 0.3.4 added support for libc++ or clang. Newer versions of Android NDK, recommends and defaults to clang, so it'll add support for it.

Test Plan:
----------
Builds and runs as usual.