### PR TITLE
bump glog to 0.3.5

### DIFF
--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -24,7 +24,7 @@ def thirdPartyNdkDir = new File("$buildDir/third-party-ndk")
 //   - boost_1_63_0
 //   - double-conversion-1.1.1
 //   - folly-deprecate-dynamic-initializer
-//   - glog-0.3.3
+//   - glog-0.3.5
 //   - jsc-headers
 def dependenciesPath = System.getenv("REACT_NATIVE_DEPENDENCIES")
 
@@ -89,10 +89,10 @@ task prepareFolly(dependsOn: dependenciesPath ? [] : [downloadFolly], type: Copy
 }
 
 task downloadGlog(dependsOn: createNativeDepsDirectories, type: Download) {
-    src 'https://github.com/google/glog/archive/v0.3.3.tar.gz'
+    src 'https://github.com/google/glog/archive/v0.3.5.tar.gz'
     onlyIfNewer true
     overwrite false
-    dest new File(downloadsDir, 'glog-0.3.3.tar.gz')
+    dest new File(downloadsDir, 'glog-0.3.5.tar.gz')
 }
 
 // Prepare glog sources to be compiled, this task will perform steps that normally should've been
@@ -100,7 +100,7 @@ task downloadGlog(dependsOn: createNativeDepsDirectories, type: Download) {
 task prepareGlog(dependsOn: dependenciesPath ? [] : [downloadGlog], type: Copy) {
     from dependenciesPath ?: tarTree(downloadGlog.dest)
     from 'src/main/jni/third-party/glog/'
-    include 'glog-0.3.3/src/**/*', 'Android.mk', 'config.h'
+    include 'glog-0.3.5/src/**/*', 'Android.mk', 'config.h'
     includeEmptyDirs = false
     filesMatching('**/*.h.in') {
         filter(ReplaceTokens, tokens: [

--- a/ReactAndroid/src/main/jni/third-party/glog/Android.mk
+++ b/ReactAndroid/src/main/jni/third-party/glog/Android.mk
@@ -3,17 +3,17 @@ LOCAL_PATH:= $(call my-dir)
 include $(CLEAR_VARS)
 
 LOCAL_SRC_FILES := \
-  glog-0.3.3/src/demangle.cc \
-  glog-0.3.3/src/logging.cc \
-  glog-0.3.3/src/raw_logging.cc \
-  glog-0.3.3/src/signalhandler.cc \
-  glog-0.3.3/src/symbolize.cc \
-  glog-0.3.3/src/utilities.cc \
-  glog-0.3.3/src/vlog_is_on.cc
+  glog-0.3.5/src/demangle.cc \
+  glog-0.3.5/src/logging.cc \
+  glog-0.3.5/src/raw_logging.cc \
+  glog-0.3.5/src/signalhandler.cc \
+  glog-0.3.5/src/symbolize.cc \
+  glog-0.3.5/src/utilities.cc \
+  glog-0.3.5/src/vlog_is_on.cc
 
-LOCAL_C_INCLUDES += $(LOCAL_PATH) $(LOCAL_PATH)/.. $(LOCAL_PATH)/glog-0.3.3/src/
+LOCAL_C_INCLUDES += $(LOCAL_PATH) $(LOCAL_PATH)/.. $(LOCAL_PATH)/glog-0.3.5/src/
 
-LOCAL_EXPORT_C_INCLUDES := $(LOCAL_PATH)/.. $(LOCAL_PATH)/glog-0.3.3/src/
+LOCAL_EXPORT_C_INCLUDES := $(LOCAL_PATH)/.. $(LOCAL_PATH)/glog-0.3.5/src/
 
 LOCAL_CFLAGS += \
   -Wall \

--- a/ReactAndroid/src/main/jni/third-party/glog/config.h
+++ b/ReactAndroid/src/main/jni/third-party/glog/config.h
@@ -49,6 +49,9 @@
 /* define if the compiler implements namespaces */
 #define HAVE_NAMESPACES 1
 
+/* NDK android-16 provides ssize_t pread(int, void*, size_t, off_t) */
+#define HAVE_PREAD 1
+
 /* Define if you have POSIX threads libraries and header files. */
 #define HAVE_PTHREAD 1
 
@@ -132,7 +135,7 @@
 #define PACKAGE_NAME "glog"
 
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "glog 0.3.3"
+#define PACKAGE_STRING "glog 0.3.5"
 
 /* Define to the one symbol short name of this package. */
 #define PACKAGE_TARNAME "glog"
@@ -141,7 +144,7 @@
 #define PACKAGE_URL ""
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "0.3.3"
+#define PACKAGE_VERSION "0.3.5"
 
 /* How to access the PC from a struct ucontext */
 /* #undef PC_FROM_UCONTEXT */
@@ -163,7 +166,7 @@
 #define TEST_SRC_DIR "."
 
 /* Version number of package */
-#define VERSION "0.3.3"
+#define VERSION "0.3.5"
 
 /* Stops putting the code inside the Google namespace */
 #define _END_GOOGLE_NAMESPACE_ }


### PR DESCRIPTION
bump glog to 0.3.5.

Version 0.3.4 added support for libc++ or clang. Starting with revision 11, Android NDK recommends and defaults to clang, so it'll add support for it.

notable changes in 0.3.4 and 0.3.5:
* add libc++ support
* reduce dynamic allocation from 3 to 1 per log message
* style fix for C++11
* Add CMake support

Test Plan:
----------
Builds and runs as usual