### PR TITLE
bump gradle to 4.4

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.5.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip

--- a/local-cli/templates/HelloWorld/android/gradle/wrapper/gradle-wrapper.properties
+++ b/local-cli/templates/HelloWorld/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.5.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip


### PR DESCRIPTION
Bump gradle to 4.4, version used by android studio 3.x and gradle plugin 3.x. This will help make migration easier and smoother.

CI: https://circleci.com/gh/dulmandakh/react-native/591

FYI: I found that gradle 4.8 works fine with gradle plugin 2.3, but gradle plugin 3.x displays warnings and asks to disable on demand configuration.

Test Plan:
----------
Builds and runs as usual

Release Notes:
--------------

[ANDROID] [ENHANCEMENT] [GRADLE] - bump to 4.4
