### PR TITLE
bump RNTester targetSdkVersion to 26

### DIFF
--- a/RNTester/android/app/build.gradle
+++ b/RNTester/android/app/build.gradle
@@ -90,7 +90,7 @@ android {
     defaultConfig {
         applicationId "com.facebook.react.uiapp"
         minSdkVersion 16
-        targetSdkVersion 23
+        targetSdkVersion 26
         versionCode 1
         versionName "1.0"
         ndk {


### PR DESCRIPTION
Motivation
bump RNTester targetSdkVersion to 26

Test Plan
pass all current ci.

Related PRs
none

Release Notes
[GENERAL] [INTERNAL] [RNTester] - bump RNTester targetSdkVersion to 26