### PR TITLE
Fix: D8450498 breaks test_end_to_end job

### DIFF
--- a/local-cli/util/Config.js
+++ b/local-cli/util/Config.js
@@ -78,6 +78,7 @@ const Config = {
     ],
     getProjectRoots,
     getPolyfills,
+    getWatchFolders: () => [getProjectPath()],
     getResolverMainFields: () => ['react-native', 'browser', 'main'],
     getTransformModulePath: () =>
       require.resolve('metro/src/reactNativeTransformer'),


### PR DESCRIPTION
Summary: Because of the way react-native local-cli communicates with metro, getWatchFolders function was always returning an empty array that triggered an error.

Differential Revision: D8650733
