### PR TITLE
Update window size when the in-call status bar is toggled

### DIFF
--- a/React/UIUtils/RCTUIUtils.m
+++ b/React/UIUtils/RCTUIUtils.m
@@ -7,19 +7,31 @@
 
 #import "RCTUIUtils.h"
 
+#import "RCTUtils.h"
+
 RCTDimensions RCTGetDimensions(CGFloat fontScale)
 {
   UIScreen *mainScreen = UIScreen.mainScreen;
   CGSize screenSize = mainScreen.bounds.size;
   RCTDimensions result;
-  typeof (result.window) dims = {
+  typeof (result.screen) screen = {
     .width = screenSize.width,
     .height = screenSize.height,
     .scale = mainScreen.scale,
     .fontScale = fontScale
   };
-  result.window = dims;
-  result.screen = dims;
+  result.screen = screen;
+
+  // Use bounds of the root view to take into consideration the size change
+  // when the in-call status bar is opened.
+  CGSize windowSize = RCTKeyWindow().rootViewController.view.bounds.size;
+  typeof (result.window) window = {
+    .width = windowSize.width,
+    .height = windowSize.height,
+    .scale = mainScreen.scale,
+    .fontScale = fontScale
+  };
+  result.window = window;
 
   return result;
 }


### PR DESCRIPTION
When the in-call status bar is toggled, the Dimensions module window doesn't resize properly. The current code assumes that window and screen is always the same on iOS but it is not the case for when the in-call status bar is on. The viewport size is reduced by 20px in that case.

This results in the following behaviour changes:
- The `Dimensions` module `change` event is now triggered when the in-call status bar is toggled
- The `window` and `screen` values of the `Dimensions` module are not always the same on iOS, currently only different when the in-call status bar is opened.
- The `Dimensions` module `change` event is now triggered when the status bar is shown / hidden. Right now this is not ideal but I'm planning to add `safeAreaInsets` to the `Dimensions` module and in that case the change event will be meaningful. 

`RCTKeyWindow().rootViewController.view.bounds` seemed the best way I found to get the proper value for when the in-call status bar is on. Might want to verify this also work properly in non-pure RN apps.

Test Plan:
----------
- Tested that a view that has exactly the size of the window (using `Dimensions.get('window')` still fits properly when the in-call status bar is on.
- Tested that the `Dimensions` module values are still updated properly on screen rotation (and only once). Also works if the status bar is hidden.

Release Notes:
--------------
[IOS] [BREAKING] [Dimensions] - Update window size when the in-call status bar is toggled