### PR TITLE
Remove the deprecated `isIPhoneX_deprecated` constant

### DIFF
--- a/RNTester/js/SafeAreaViewExample.js
+++ b/RNTester/js/SafeAreaViewExample.js
@@ -64,36 +64,12 @@ class SafeAreaViewExample extends React.Component<
   }
 }
 
-class IsIPhoneXExample extends React.Component<{}> {
-  render() {
-    return (
-      <View>
-        <Text>
-          Is this an iPhone X:{' '}
-          {DeviceInfo.isIPhoneX_deprecated
-            ? 'Yeah!'
-            : 'Nope. (Or `isIPhoneX_deprecated` was already removed.)'}
-        </Text>
-      </View>
-    );
-  }
-}
-
 exports.examples = [
   {
     title: '<SafeAreaView> Example',
     description:
       'SafeAreaView automatically applies paddings reflect the portion of the view that is not covered by other (special) ancestor views.',
     render: () => <SafeAreaViewExample />,
-  },
-  {
-    title: 'isIPhoneX_deprecated Example',
-    description:
-      '`DeviceInfo.isIPhoneX_deprecated` returns true only on iPhone X. ' +
-      'Note: This prop is deprecated and will be removed right after June 01, 2018. ' +
-      'Please use this only for a quick and temporary solution. ' +
-      'Use <SafeAreaView> instead.',
-    render: () => <IsIPhoneXExample />,
   },
 ];
 

--- a/React/Modules/RCTDeviceInfo.m
+++ b/React/Modules/RCTDeviceInfo.m
@@ -51,22 +51,6 @@ RCT_EXPORT_MODULE()
 #endif
 }
 
-static BOOL RCTIsIPhoneX() {
-  static BOOL isIPhoneX = NO;
-  static dispatch_once_t onceToken;
-
-  dispatch_once(&onceToken, ^{
-    RCTAssertMainQueue();
-
-    isIPhoneX = CGSizeEqualToSize(
-      [UIScreen mainScreen].nativeBounds.size,
-      CGSizeMake(1125, 2436)
-    );
-  });
-
-  return isIPhoneX;
-}
-
 static NSDictionary *RCTExportedDimensions(RCTBridge *bridge)
 {
   RCTAssertMainQueue();
@@ -102,11 +86,6 @@ static NSDictionary *RCTExportedDimensions(RCTBridge *bridge)
 {
   return @{
     @"Dimensions": RCTExportedDimensions(_bridge),
-    // Note:
-    // This prop is deprecated and will be removed right after June 01, 2018.
-    // Please use this only for a quick and temporary solution.
-    // Use <SafeAreaView> instead.
-    @"isIPhoneX_deprecated": @(RCTIsIPhoneX()),
   };
 }
 


### PR DESCRIPTION
Cleanup the `isIPhoneX_deprecated` constant which was said to be removed by June 1st 2018.

Test Plan:
----------
Make sure there are not more occurrences of `isIPhoneX_deprecated` and that RNTester builds.

Release Notes:
--------------
[IOS] [BREAKING] [DeviceInfo] - Remove the deprecated `isIPhoneX_deprecated` constant