### PR TITLE
[WIP] Add safeAreaInsets to the Dimensions module

### DIFF
--- a/Libraries/Utilities/Dimensions.js
+++ b/Libraries/Utilities/Dimensions.js
@@ -66,6 +66,7 @@ class Dimensions {
       eventEmitter.emit('change', {
         window: dimensions.window,
         screen: dimensions.screen,
+        safeAreaInsets: dimensions.safeAreaInsets,
       });
     } else {
       dimensionsInitialized = true;

--- a/React/Modules/RCTDeviceInfo.m
+++ b/React/Modules/RCTDeviceInfo.m
@@ -79,9 +79,16 @@ static NSDictionary *RCTExportedDimensions(RCTBridge *bridge)
       @"scale": @(window.scale),
       @"fontScale": @(window.fontScale)
   };
+  NSDictionary<NSString *, NSNumber *> *safeAreaInsets = @{
+    @"left": @(dimensions.safeAreaInsets.left),
+    @"top": @(dimensions.safeAreaInsets.top),
+    @"right": @(dimensions.safeAreaInsets.right),
+    @"bottom": @(dimensions.safeAreaInsets.bottom),
+  };
   return @{
       @"window": dims,
-      @"screen": dims
+      @"screen": dims,
+      @"safeAreaInsets": safeAreaInsets,
   };
 }
 

--- a/React/UIUtils/RCTUIUtils.h
+++ b/React/UIUtils/RCTUIUtils.h
@@ -20,6 +20,9 @@ typedef struct {
   struct {
     CGFloat width, height, scale, fontScale;
   } window, screen;
+  struct {
+    CGFloat left, top, right, bottom;
+  } safeAreaInsets;
 } RCTDimensions;
 extern __attribute__((visibility("default")))
 RCTDimensions RCTGetDimensions(CGFloat fontScale);

--- a/React/UIUtils/RCTUIUtils.m
+++ b/React/UIUtils/RCTUIUtils.m
@@ -21,6 +21,24 @@ RCTDimensions RCTGetDimensions(CGFloat fontScale)
   result.window = dims;
   result.screen = dims;
 
+  if (@available(iOS 11.0, *)) {
+    UIEdgeInsets windowInsets = RCTKeyWindow().rootViewController.view.safeAreaInsets;
+    typeof (result.safeAreaInsets) safeAreaInsets = {
+      .left = windowInsets.left,
+      .top = windowInsets.top,
+      .right = windowInsets.right,
+      .bottom = windowInsets.bottom
+    };
+    result.safeAreaInsets = safeAreaInsets;
+  } else {
+    // Polyfill `safeAreaInsets` for iOS < 11. We only care about the status bar.
+    typeof (result.safeAreaInsets) safeAreaInsets = {
+      // TODO: Test this with in-call status bar.
+      .top = RCTSharedApplication().statusBarFrame.size.height
+    };
+    result.safeAreaInsets = safeAreaInsets;
+  }
+
   return result;
 }
 


### PR DESCRIPTION
There are some use cases where `SafeAreaView` doesn't work because we need to do some computations or apply the values manually in JS (ex.: margin instead of padding). This exposes the safe area insets of the screen as a new value on the `Dimensions` module.

Kind of depends on #19919

TODO:
- RNTester example
- Docs
- Test iOS < 11 polyfill
- Android

Test Plan:
----------
TODO

Release Notes:
--------------
[GENERAL] [FEATURE] [Dimensions] - Add safeAreaInsets to the Dimensions module