### PR TITLE
Calculate Correct Window Dimensions for iOS

### DIFF
--- a/React/Modules/RCTDeviceInfo.m
+++ b/React/Modules/RCTDeviceInfo.m
@@ -77,16 +77,23 @@ static NSDictionary *RCTExportedDimensions(RCTBridge *bridge)
   RCTAssertMainQueue();
 
   RCTDimensions dimensions = RCTGetDimensions(bridge.accessibilityManager.multiplier);
-  typeof (dimensions.window) window = dimensions.window; // Window and Screen are considered equal for iOS.
-  NSDictionary<NSString *, NSNumber *> *dims = @{
+  typeof (dimensions.window) window = dimensions.window;
+  NSDictionary<NSString *, NSNumber *> *dimsWindow = @{
       @"width": @(window.width),
       @"height": @(window.height),
       @"scale": @(window.scale),
       @"fontScale": @(window.fontScale)
   };
+  typeof (dimensions.screen) screen = dimensions.screen;
+  NSDictionary<NSString *, NSNumber *> *dimsScreen = @{
+      @"width": @(screen.width),
+      @"height": @(screen.height),
+      @"scale": @(screen.scale),
+      @"fontScale": @(screen.fontScale)
+  };
   return @{
-      @"window": dims,
-      @"screen": dims
+      @"window": dimsWindow,
+      @"screen": dimsScreen
   };
 }
 

--- a/React/Modules/RCTDeviceInfo.m
+++ b/React/Modules/RCTDeviceInfo.m
@@ -191,7 +191,7 @@ static NSDictionary *RCTExportedDimensions(RCTBridge *bridge)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
       [_bridge.eventDispatcher sendDeviceEventWithName:@"didUpdateDimensions"
-                                                  body:RCTExportedDimensions(_bridge)];
+                                                  body:nextInterfaceDimensions];
 #pragma clang diagnostic pop
   }
 

--- a/React/UIUtils/RCTUIUtils.m
+++ b/React/UIUtils/RCTUIUtils.m
@@ -7,19 +7,32 @@
 
 #import "RCTUIUtils.h"
 
+#import "RCTUtils.h"
+
 RCTDimensions RCTGetDimensions(CGFloat fontScale)
 {
   UIScreen *mainScreen = UIScreen.mainScreen;
   CGSize screenSize = mainScreen.bounds.size;
+
+  UIView *mainWindow;
+  mainWindow = RCTKeyWindow();
+  CGSize windowSize = mainWindow.bounds.size;
+
   RCTDimensions result;
-  typeof (result.window) dims = {
+  typeof (result.screen) dimsScreen = {
     .width = screenSize.width,
     .height = screenSize.height,
     .scale = mainScreen.scale,
     .fontScale = fontScale
   };
-  result.window = dims;
-  result.screen = dims;
+  typeof (result.window) dimsWindow = {
+    .width = windowSize.width,
+    .height = windowSize.height,
+    .scale = mainScreen.scale,
+    .fontScale = fontScale
+  };
+  result.screen = dimsScreen;
+  result.window = dimsWindow;
 
   return result;
 }


### PR DESCRIPTION
Fixes: #16152

## Changelog:

[iOS] [Fixed] - Pass back correct dimensions for application window in Dimensions module


Test Plan:
----------
Before:
On iOS, when using `Dimensions.get()` for either screen or window, the same value for width and height would be passed back for both screen and window. These values both represent the width and height of the whole screen regardless of the size of the window.

This behavior was similar for listening to the Dimension change event. The even would fire for orientation changes, but would not fire for changes to the window size (e.g. split view app resizing).

After:
On iOS, when the Dimensions module passes back dimensions for the screen, it uses the full screen dimensions. For window, it now uses just the dimensions of the window. This goes back to Objective C and uses `RCTKeyWindow`.

For event handling, the code watches for the application to become active (`UIApplicationDidBecomeActiveNotification`) and then recalculates the window dimensions, compares it to the previous dimensions, and sends a change event if there was a change.

For testing, I threw together a project. I pointed it to a branch on my forked version of react-native.
https://github.com/rdonnelly/WindowVsScreenRN

Please feel free to let me know if anything needs re-working.
