### PR TITLE
Expose initialAppState constant from Android native AppState module

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/modules/appstate/AppStateModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/appstate/AppStateModule.java
@@ -1,10 +1,8 @@
 /**
  * Copyright (c) 2015-present, Facebook, Inc.
- * All rights reserved.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 package com.facebook.react.modules.appstate;

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/appstate/AppStateModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/appstate/AppStateModule.java
@@ -1,8 +1,10 @@
 /**
  * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
  */
 
 package com.facebook.react.modules.appstate;
@@ -14,8 +16,12 @@ import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.common.LifecycleState;
 import com.facebook.react.module.annotations.ReactModule;
 import com.facebook.react.modules.core.DeviceEventManagerModule.RCTDeviceEventEmitter;
+
+import java.util.HashMap;
+import java.util.Map;
 
 @ReactModule(name = AppStateModule.NAME)
 public class AppStateModule extends ReactContextBaseJavaModule
@@ -26,10 +32,15 @@ public class AppStateModule extends ReactContextBaseJavaModule
   public static final String APP_STATE_ACTIVE = "active";
   public static final String APP_STATE_BACKGROUND = "background";
 
-  private String mAppState = "uninitialized";
+  private static final String INITIAL_STATE = "initialAppState";
+
+  private String mAppState;
 
   public AppStateModule(ReactApplicationContext reactContext) {
     super(reactContext);
+    reactContext.addLifecycleEventListener(this);
+    mAppState = (reactContext.getLifecycleState() == LifecycleState.RESUMED ?
+            APP_STATE_ACTIVE : APP_STATE_BACKGROUND);
   }
 
   @Override
@@ -38,8 +49,10 @@ public class AppStateModule extends ReactContextBaseJavaModule
   }
 
   @Override
-  public void initialize() {
-    getReactApplicationContext().addLifecycleEventListener(this);
+  public Map<String, Object> getConstants() {
+    HashMap<String, Object> constants = new HashMap<>();
+    constants.put(INITIAL_STATE, mAppState);
+    return constants;
   }
 
   @ReactMethod


### PR DESCRIPTION
This PR addresses TODO left in _AppState.js_

The goal is to align AppState module implementation between iOS and Android. iOS native module exposes _initialAppState_ constant that AppState.js relies on, while Android doesn't expose that constant and js implementation uses a fallback. This PR aims to remove a need for a fallback

Test Plan:
----------
Changes were tested with the help of debugger and a test Android application:
 - when app was launched by user via UI AppState was 'active'
 - when app was woken up/launched by incoming push AppState was 'background'

Release Notes:
--------------
Help reviewers and the release process by writing your own release notes. See below for an example.

[ANDROID] [TODO] [AppState] - Exposed initialAppState constant from Android native AppState module

<!--
  **INTERNAL and MINOR tagged notes will not be included in the next version's final release notes.**

    CATEGORY
  [----------]      TYPE
  [ CLI      ] [-------------]    LOCATION
  [ DOCS     ] [ BREAKING    ] [-------------]
  [ GENERAL  ] [ BUGFIX      ] [ {Component} ]
  [ INTERNAL ] [ ENHANCEMENT ] [ {Filename}  ]
  [ IOS      ] [ FEATURE     ] [ {Directory} ]   |-----------|
  [ ANDROID  ] [ MINOR       ] [ {Framework} ] - | {Message} |
  [----------] [-------------] [-------------]   |-----------|

 EXAMPLES:

 [IOS] [BREAKING] [FlatList] - Change a thing that breaks other things
 [ANDROID] [BUGFIX] [TextInput] - Did a thing to TextInput
 [CLI] [FEATURE] [local-cli/info/info.js] - CLI easier to do things with
 [DOCS] [BUGFIX] [GettingStarted.md] - Accidentally a thing/word
 [GENERAL] [ENHANCEMENT] [Yoga] - Added new yoga thing/position
 [INTERNAL] [FEATURE] [./scripts] - Added thing to script that nobody will see
-->
