### PR TITLE
android targetSdkVersion is 26

### DIFF
--- a/RNTester/android/app/build.gradle
+++ b/RNTester/android/app/build.gradle
@@ -90,7 +90,7 @@ android {
     defaultConfig {
         applicationId "com.facebook.react.uiapp"
         minSdkVersion 16
-        targetSdkVersion 23
+        targetSdkVersion 26
         versionCode 1
         versionName "1.0"
         ndk {

--- a/RNTester/android/app/src/main/AndroidManifest.xml
+++ b/RNTester/android/app/src/main/AndroidManifest.xml
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest
   xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.facebook.react.uiapp"
-  android:versionCode="1"
-  android:versionName="1.0">
+  package="com.facebook.react.uiapp">
 
   <uses-permission android:name="android.permission.INTERNET" />
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
@@ -15,10 +13,6 @@
   <!--Just to show permissions example-->
   <uses-permission android:name="android.permission.CAMERA"/>
   <uses-permission android:name="android.permission.READ_CALENDAR"/>
-
-  <uses-sdk
-    android:minSdkVersion="16"
-    android:targetSdkVersion="23" />
 
   <!--
   android:icon is used to display launcher icon on mobile devices.

--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -250,7 +250,7 @@ android {
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 22
+        targetSdkVersion 26
         versionCode 1
         versionName "1.0"
 

--- a/ReactAndroid/src/androidTest/AndroidManifest.xml
+++ b/ReactAndroid/src/androidTest/AndroidManifest.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.facebook.react.tests.gradle"
-          android:versionCode="1"
-          android:versionName="1.0" >
-  <uses-sdk android:targetSdkVersion="7" />
+          package="com.facebook.react.tests.gradle">
   <supports-screens android:anyDensity="true" />
   <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />


### PR DESCRIPTION
This PR sets gradle targetSdkVersion to 26, which will satisfy new requirements from Play Store. Also removed redundant config from manifest files.

Test Plan:
----------
Everything build and run as usual.

Release Notes:
--------------

[ANDROID] [ENHANCEMENT] [SDK] - targetSdkVersion is 26