### PR TITLE
bump metro to 0.40.1 in babel-preset

### DIFF
--- a/babel-preset/package.json
+++ b/babel-preset/package.json
@@ -41,6 +41,6 @@
     "@babel/plugin-transform-template-literals": "7.0.0-beta.47",
     "@babel/plugin-transform-unicode-regex": "7.0.0-beta.47",
     "@babel/template": "7.0.0-beta.47",
-    "metro-babel7-plugin-react-transform": "^0.40.0"
+    "metro-babel7-plugin-react-transform": "^0.40.1"
   }
 }


### PR DESCRIPTION
Bump metro to 0.40.1 in babel-preset, that is left out from https://github.com/facebook/react-native/commit/770dd38bbbec20e40e4895d512da19af20e0d0d0.

Test Plan:
----------
Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!