### PR TITLE
[iOS][VirtualizedList] Fix scroll over bottom with scrollToIndex

### DIFF
--- a/Libraries/Lists/VirtualizedList.js
+++ b/Libraries/Lists/VirtualizedList.js
@@ -321,12 +321,17 @@ class VirtualizedList extends React.PureComponent<Props, State> {
       return;
     }
     const frame = this._getFrameMetricsApprox(index);
+
+    const maxOffset = Math.max(0, this._scrollMetrics.contentLength - this._scrollMetrics.visibleLength);
     const offset =
       Math.max(
         0,
-        frame.offset -
-          (viewPosition || 0) *
-            (this._scrollMetrics.visibleLength - frame.length),
+        Math.min(
+          maxOffset,
+          frame.offset -
+            (viewPosition || 0) *
+              (this._scrollMetrics.visibleLength - frame.length),
+        )
       ) - (viewOffset || 0);
     /* $FlowFixMe(>=0.53.0 site=react_native_fb,react_native_oss) This comment
      * suppresses an error when upgrading Flow's support for React. To see the


### PR DESCRIPTION
Fixes #13594

Test Plan:
----------
This example shows that the behavior `scrollToIndex` of `VirtualizedList` (`FlatList`) differs between Android and iOS.
The behavior of Android is accurate, while on iOS it scrolls over bottom.
Over scrolled VirtualizedList jumps to a different location with a little scroll.

Verify the problem and issue #13594, tested this fix worked.

### Problem
<img src="https://user-images.githubusercontent.com/443965/42087101-254d6b96-7bd0-11e8-8978-3b5393feb982.gif" width="360">

### Expected Behavior (this PR)
<img src="https://user-images.githubusercontent.com/443965/42087125-3411bd76-7bd0-11e8-8713-d97beab8bc87.gif" width="360">

### Android
There is no problem on Android. It is probably corrected by the OS.
<img src="https://user-images.githubusercontent.com/443965/42087112-2b821ac0-7bd0-11e8-91cf-2d2573d125ab.gif" width="360">


Release Notes:
--------------
[IOS][BUGFIX][VirtualizedList] - Scroll over bottom with scrollToIndex in iOS

<!--
  **INTERNAL and MINOR tagged notes will not be included in the next version's final release notes.**

    CATEGORY
  [----------]      TYPE
  [ CLI      ] [-------------]    LOCATION
  [ DOCS     ] [ BREAKING    ] [-------------]
  [ GENERAL  ] [ BUGFIX      ] [ {Component} ]
  [ INTERNAL ] [ ENHANCEMENT ] [ {Filename}  ]
  [ IOS      ] [ FEATURE     ] [ {Directory} ]   |-----------|
  [ ANDROID  ] [ MINOR       ] [ {Framework} ] - | {Message} |
  [----------] [-------------] [-------------]   |-----------|

 EXAMPLES:

 [IOS] [BREAKING] [FlatList] - Change a thing that breaks other things
 [ANDROID] [BUGFIX] [TextInput] - Did a thing to TextInput
 [CLI] [FEATURE] [local-cli/info/info.js] - CLI easier to do things with
 [DOCS] [BUGFIX] [GettingStarted.md] - Accidentally a thing/word
 [GENERAL] [ENHANCEMENT] [Yoga] - Added new yoga thing/position
 [INTERNAL] [FEATURE] [./scripts] - Added thing to script that nobody will see
-->
