### PR TITLE
Hotfix to include react-native-windows in hasteImpl accepted paths

### DIFF
--- a/jest/hasteImpl.js
+++ b/jest/hasteImpl.js
@@ -12,7 +12,10 @@
 
 const path = require('path');
 
-const ROOT = path.join(__dirname, '..');
+const ROOTS = [
+  path.resolve(__dirname, '..') + path.sep,
+  path.resolve(__dirname, '../../react-native-windows') + path.sep,
+];
 
 const BLACKLISTED_PATTERNS /*: Array<RegExp> */ = [
   /.*\/__(mocks|tests)__\/.*/,
@@ -33,7 +36,7 @@ const NAME_REDUCERS /*: Array<[RegExp, string]> */ = [
   // strip .js/.js.flow suffix
   [/^(.*)\.js(\.flow)?$/, '$1'],
   // strip .android/.ios/.native/.web suffix
-  [/^(.*)\.(android|ios|native|web)$/, '$1'],
+  [/^(.*)\.(android|ios|native|web|windows)$/, '$1'],
 ];
 
 const haste = {
@@ -63,11 +66,12 @@ function isHastePath(filePath /*: string */) /*: boolean */ {
     return false;
   }
 
-  if (!filePath.startsWith(ROOT)) {
+  const root = ROOTS.find(r => filePath.startsWith(r));
+  if (!root) {
     return false;
   }
 
-  filePath = filePath.substr(ROOT.length + 1);
+  filePath = filePath.substr(root.length);
   if (BLACKLISTED_PATTERNS.some(pattern => pattern.test(filePath))) {
     return false;
   }

--- a/local-cli/core/index.js
+++ b/local-cli/core/index.js
@@ -72,6 +72,14 @@ const pluginPlatforms = plugins.platforms.reduce((acc, pathToPlatforms) => {
 const defaultRNConfig = {
   hasteImplModulePath: require.resolve('../../jest/hasteImpl'),
 
+  getPlatforms(): Array<string> {
+    return ['ios', 'android', 'windows', 'web'];
+  },
+
+  getProvidesModuleNodeModules(): Array<string> {
+    return ['react-native', 'react-native-windows'];
+  },
+
   getProjectCommands(): Array<CommandT> {
     const commands = plugins.commands.map(pathToCommands => {
       const name = pathToCommands.split(path.sep)[0];


### PR DESCRIPTION
Summary:
We removed support for providesModule annotations and maintained support for Haste names in installed modules via `providesModuleNodeModules`, but our default `hasteImpl` doesn't take them into account. We need to find a better way to override core components from plugins but meanwhile this adds an exception for react-native-windows in the default `hasteImpl` to unblock their upgrade to the latest RC.

Fixes https://github.com/facebook/metro/issues/188

Reviewed By: mjesun

Differential Revision: D8695207
