### PR TITLE
React native gradle support for flavor dimensions

### DIFF
--- a/react.gradle
+++ b/react.gradle
@@ -27,110 +27,111 @@ afterEvaluate {
     def isAndroidLibrary = plugins.hasPlugin("com.android.library")
     // Grab all build types and product flavors
     def buildTypes = android.buildTypes.collect { type -> type.name }
-    def productFlavors = android.productFlavors.collect { flavor -> flavor.name }
+    def productFlavors = android.applicationVariants.collect { flavor -> flavor }
 
     // When no product flavors defined, use empty
     if (!productFlavors) productFlavors.add('')
 
-    productFlavors.each { productFlavorName ->
-        buildTypes.each { buildTypeName ->
-            // Create variant and target names
-            def flavorNameCapitalized = "${productFlavorName.capitalize()}"
-            def buildNameCapitalized = "${buildTypeName.capitalize()}"
-            def targetName = "${flavorNameCapitalized}${buildNameCapitalized}"
-            def targetPath = productFlavorName ?
-                    "${productFlavorName}/${buildTypeName}" :
-                    "${buildTypeName}"
+    productFlavors.each { productFlavor ->
+        def productFlavorName = productFlavor.flavorName
+        def buildTypeName = productFlavor.buildType.name
 
-            // React js bundle directories
-            def jsBundleDirConfigName = "jsBundleDir${targetName}"
-            def jsBundleDir = elvisFile(config."$jsBundleDirConfigName") ?:
-                    file("$buildDir/intermediates/assets/${targetPath}")
+        // Create variant and target names
+        def flavorNameCapitalized = "${productFlavorName.capitalize()}"
+        def buildNameCapitalized = "${buildTypeName.capitalize()}"
+        def targetName = "${flavorNameCapitalized}${buildNameCapitalized}"
+        def targetPath = productFlavorName ?
+                "${productFlavorName}/${buildTypeName}" :
+                "${buildTypeName}"
 
-            def resourcesDirConfigName = "resourcesDir${targetName}"
-            def resourcesDir = elvisFile(config."${resourcesDirConfigName}") ?:
-                    file("$buildDir/intermediates/res/merged/${targetPath}")
-            def jsBundleFile = file("$jsBundleDir/$bundleAssetName")
+        // React js bundle directories
+        def jsBundleDirConfigName = "jsBundleDir${targetName}"
+        def jsBundleDir = elvisFile(config."$jsBundleDirConfigName") ?:
+                file("$buildDir/intermediates/assets/${targetPath}")
 
-            // Bundle task name for variant
-            def bundleJsAndAssetsTaskName = "bundle${targetName}JsAndAssets"
+        def resourcesDirConfigName = "resourcesDir${targetName}"
+        def resourcesDir = elvisFile(config."${resourcesDirConfigName}") ?:
+                file("$buildDir/intermediates/res/merged/${targetPath}")
+        def jsBundleFile = file("$jsBundleDir/$bundleAssetName")
 
-            // Additional node and packager commandline arguments
-            def nodeExecutableAndArgs = config.nodeExecutableAndArgs ?: ["node"]
-            def extraPackagerArgs = config.extraPackagerArgs ?: []
+        // Bundle task name for variant
+        def bundleJsAndAssetsTaskName = "bundle${targetName}JsAndAssets"
 
-            def currentBundleTask = tasks.create(
-                    name: bundleJsAndAssetsTaskName,
-                    type: Exec) {
-                group = "react"
-                description = "bundle JS and assets for ${targetName}."
+        // Additional node and packager commandline arguments
+        def nodeExecutableAndArgs = config.nodeExecutableAndArgs ?: ["node"]
+        def extraPackagerArgs = config.extraPackagerArgs ?: []
 
-                // Create dirs if they are not there (e.g. the "clean" task just ran)
-                doFirst {
-                    jsBundleDir.mkdirs()
-                    resourcesDir.mkdirs()
-                }
+        def currentBundleTask = tasks.create(
+                name: bundleJsAndAssetsTaskName,
+                type: Exec) {
+            group = "react"
+            description = "bundle JS and assets for ${targetName}."
 
-                // Set up inputs and outputs so gradle can cache the result
-                inputs.files fileTree(dir: reactRoot, excludes: inputExcludes)
-                outputs.dir jsBundleDir
-                outputs.dir resourcesDir
-
-                // Set up the call to the react-native cli
-                workingDir reactRoot
-
-                // Set up dev mode
-                def devEnabled = !(config."devDisabledIn${targetName}"
-                    || targetName.toLowerCase().contains("release"))
-
-                def extraArgs = extraPackagerArgs;
-
-                if (bundleConfig) {
-                  extraArgs = extraArgs.clone()
-                  extraArgs.add("--config");
-                  extraArgs.add(bundleConfig);
-                }
-
-                if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-                    commandLine("cmd", "/c", *nodeExecutableAndArgs, cliPath, bundleCommand, "--platform", "android", "--dev", "${devEnabled}",
-                            "--reset-cache", "--entry-file", entryFile, "--bundle-output", jsBundleFile, "--assets-dest", resourcesDir, *extraArgs)
-                } else {
-                    commandLine(*nodeExecutableAndArgs, cliPath, bundleCommand, "--platform", "android", "--dev", "${devEnabled}",
-                            "--reset-cache", "--entry-file", entryFile, "--bundle-output", jsBundleFile, "--assets-dest", resourcesDir, *extraArgs)
-                }
-
-                enabled config."bundleIn${targetName}" ||
-                    config."bundleIn${buildTypeName.capitalize()}" ?:
-                            targetName.toLowerCase().contains("release")
-
-                if (isAndroidLibrary) {
-                    doLast {
-                        def moveFunc = { resSuffix ->
-                            File originalDir = file("${resourcesDir}/drawable-${resSuffix}")
-                            if (originalDir.exists()) {
-                                File destDir = file("${resourcesDir}/drawable-${resSuffix}-v4")
-                                ant.move(file: originalDir, tofile: destDir)
-                            }
-                        }
-                        moveFunc.curry("ldpi").call()
-                        moveFunc.curry("mdpi").call()
-                        moveFunc.curry("hdpi").call()
-                        moveFunc.curry("xhdpi").call()
-                        moveFunc.curry("xxhdpi").call()
-                        moveFunc.curry("xxxhdpi").call()
-                    }
-                }
+            // Create dirs if they are not there (e.g. the "clean" task just ran)
+            doFirst {
+                jsBundleDir.mkdirs()
+                resourcesDir.mkdirs()
             }
 
-            // Hook bundle${productFlavor}${buildType}JsAndAssets into the android build process
-            currentBundleTask.dependsOn("merge${targetName}Resources")
-            currentBundleTask.dependsOn("merge${targetName}Assets")
+            // Set up inputs and outputs so gradle can cache the result
+            inputs.files fileTree(dir: reactRoot, excludes: inputExcludes)
+            outputs.dir jsBundleDir
+            outputs.dir resourcesDir
 
-            runBefore("process${flavorNameCapitalized}Armeabi-v7a${buildNameCapitalized}Resources", currentBundleTask)
-            runBefore("process${flavorNameCapitalized}X86${buildNameCapitalized}Resources", currentBundleTask)
-            runBefore("processUniversal${targetName}Resources", currentBundleTask)
-            runBefore("process${targetName}Resources", currentBundleTask)
-            runBefore("dataBindingProcessLayouts${targetName}", currentBundleTask)
+            // Set up the call to the react-native cli
+            workingDir reactRoot
+
+            // Set up dev mode
+            def devEnabled = !(config."devDisabledIn${targetName}"
+                || targetName.toLowerCase().contains("release"))
+
+            def extraArgs = extraPackagerArgs;
+
+            if (bundleConfig) {
+                extraArgs = extraArgs.clone()
+                extraArgs.add("--config");
+                extraArgs.add(bundleConfig);
+            }
+
+            if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+                commandLine("cmd", "/c", *nodeExecutableAndArgs, cliPath, bundleCommand, "--platform", "android", "--dev", "${devEnabled}",
+                        "--reset-cache", "--entry-file", entryFile, "--bundle-output", jsBundleFile, "--assets-dest", resourcesDir, *extraArgs)
+            } else {
+                commandLine(*nodeExecutableAndArgs, cliPath, bundleCommand, "--platform", "android", "--dev", "${devEnabled}",
+                        "--reset-cache", "--entry-file", entryFile, "--bundle-output", jsBundleFile, "--assets-dest", resourcesDir, *extraArgs)
+            }
+
+            enabled config."bundleIn${targetName}" ||
+                config."bundleIn${buildTypeName.capitalize()}" ?:
+                        targetName.toLowerCase().contains("release")
+
+            if (isAndroidLibrary) {
+                doLast {
+                    def moveFunc = { resSuffix ->
+                        File originalDir = file("${resourcesDir}/drawable-${resSuffix}")
+                        if (originalDir.exists()) {
+                            File destDir = file("${resourcesDir}/drawable-${resSuffix}-v4")
+                            ant.move(file: originalDir, tofile: destDir)
+                        }
+                    }
+                    moveFunc.curry("ldpi").call()
+                    moveFunc.curry("mdpi").call()
+                    moveFunc.curry("hdpi").call()
+                    moveFunc.curry("xhdpi").call()
+                    moveFunc.curry("xxhdpi").call()
+                    moveFunc.curry("xxxhdpi").call()
+                }
+            }
         }
+
+        // Hook bundle${productFlavor}${buildType}JsAndAssets into the android build process
+        currentBundleTask.dependsOn("merge${targetName}Resources")
+        currentBundleTask.dependsOn("merge${targetName}Assets")
+
+        runBefore("process${flavorNameCapitalized}Armeabi-v7a${buildNameCapitalized}Resources", currentBundleTask)
+        runBefore("process${flavorNameCapitalized}X86${buildNameCapitalized}Resources", currentBundleTask)
+        runBefore("processUniversal${targetName}Resources", currentBundleTask)
+        runBefore("process${targetName}Resources", currentBundleTask)
+        runBefore("dataBindingProcessLayouts${targetName}", currentBundleTask)
     }
 }


### PR DESCRIPTION
Related info -> https://developer.android.com/studio/build/build-variants

Currently react native gradle only supports `{flavor}{BuildType}` for example, `devDebug`, `qaDebug`, `qaRelease` but android now also supports `flavorDimensions` which can be utilised by people to have different environments like prod, staging etc and make builds according to those, `{flavor}{flavorDimension}{buildType}` is the final name for it, example could be qaStagingDebug, qaProdDebug, devProdRelease, etc.

To support these one can simply collect `applicationVariants` instead of `productFlavors` and `buildTypes`. Application variants give full flavorName with dimension and buildType is also available to it.

Similar PR opened a while ago https://github.com/facebook/react-native/pull/14792 for the same feature.

Integrating react-native into an existing app which uses flavors is a challenge and we had to take a fork of it in my organisation. Please inform of any other testing steps needed to be done.

The changes may seem quite a lot, but actually only 3 line have been modified, 2 added and one changed, the change is large due to the reduced indent caused by the removal of a loop on `buildTypes` 

Test Plan:
----------
- Tested this on `create-react-native-app` project after eject from expo (don’t know how to build with expo tbh)
<img width="820" alt="screen shot 2018-07-03 at 2 10 49 pm" src="https://user-images.githubusercontent.com/2863124/42210171-1f7d2368-7ece-11e8-8924-f004af9310ab.png">

- Tested in a project with product flavors like `qaDevStagingDebug`, `qaDevProdDebug` etc, where `prod` and `staging` are flavor dimensions.

> Testing done on MacOS only.

Release Notes:
--------------
Help reviewers and the release process by writing your own release notes. See below for an example.

[ANDROID] [ENHANCEMENT] [Gradle] - Added flavor dimension support using application variants

<!--
  **INTERNAL and MINOR tagged notes will not be included in the next version's final release notes.**

    CATEGORY
  [----------]      TYPE
  [ CLI      ] [-------------]    LOCATION
  [ DOCS     ] [ BREAKING    ] [-------------]
  [ GENERAL  ] [ BUGFIX      ] [ {Component} ]
  [ INTERNAL ] [ ENHANCEMENT ] [ {Filename}  ]
  [ IOS      ] [ FEATURE     ] [ {Directory} ]   |-----------|
  [ ANDROID  ] [ MINOR       ] [ {Framework} ] - | {Message} |
  [----------] [-------------] [-------------]   |-----------|

 EXAMPLES:

 [IOS] [BREAKING] [FlatList] - Change a thing that breaks other things
 [ANDROID] [BUGFIX] [TextInput] - Did a thing to TextInput
 [CLI] [FEATURE] [local-cli/info/info.js] - CLI easier to do things with
 [DOCS] [BUGFIX] [GettingStarted.md] - Accidentally a thing/word
 [GENERAL] [ENHANCEMENT] [Yoga] - Added new yoga thing/position
 [INTERNAL] [FEATURE] [./scripts] - Added thing to script that nobody will see
-->
