### PR TITLE
Fix jest-preset to use internal preprocessor (fix testing with 0.56)

### DIFF
--- a/jest-preset.json
+++ b/jest-preset.json
@@ -14,7 +14,7 @@
     "<rootDir>/node_modules/react-native/Libraries/react-native/"
   ],
   "transform": {
-    "^.+\\.js$": "babel-jest",
+    "^.+\\.js$": "<rootDir>/node_modules/react-native/jest/preprocessor.js",
     "^.+\\.(bmp|gif|jpg|jpeg|mp4|png|psd|svg|webp)$": "<rootDir>/node_modules/react-native/jest/assetFileTransformer.js"
   },
   "transformIgnorePatterns": [

--- a/jest/preprocessor.js
+++ b/jest/preprocessor.js
@@ -98,6 +98,8 @@ module.exports = {
         [require('@babel/plugin-transform-for-of'), {loose: true}],
         [require('@babel/plugin-transform-react-display-name')],
         [require('@babel/plugin-transform-react-jsx-source')],
+        // used to hoist jest mocks
+        [require('babel-plugin-jest-hoist')],
       ],
     });
 


### PR DESCRIPTION
Fixes #19859 at least until problem will be fixed properly.

By unknown reason babel-jest can't transform tests and react-native's files, see #19859 for details. But internal preprocessor.js can, so use it for now in published jest-preset.json.

Test Plan:
----------
From original issue:
- Create app `react-native init Test56 --version=0.56.0`
- `cd Test56`
- `mkdir __tests__`
- create file `__tests__/AppTest.js` that has following lines:
```
import React from 'react';
import renderer from 'react-test-renderer';
import App from '../App';

test('App matches Snapshot', () => {
  const component = renderer.create(<App />);
  let tree = component.toJSON();
  expect(tree).toMatchSnapshot();
});
```
- `npm test`

Slighly modified repo for reproduction: https://github.com/dlowder-salesforce/rn-56-test/tree/eb0611b1870c410cd4a7458a740a3ac52bad2827
Fixed repo: https://github.com/vovkasm/rn-56-test/tree/a00fc639bd6a681591131c24e3ee976ae374438e

@kelset You want to be mentioned ;-)
 
Release Notes:
--------------

[GENERAL] [BUGFIX] [jest-preset.json] - Fix js transformation in jest

