### PR TITLE
Make JS loading progress use tabular numbers

### DIFF
--- a/React/DevSupport/RCTDevLoadingView.m
+++ b/React/DevSupport/RCTDevLoadingView.m
@@ -90,7 +90,8 @@ RCT_EXPORT_METHOD(showMessage:(NSString *)message color:(UIColor *)color backgro
       // set a root VC so rotation is supported
       self->_window.rootViewController = [UIViewController new];
 
-      self->_label.font = [UIFont systemFontOfSize:12.0];
+      self->_label.font = [UIFont monospacedDigitSystemFontOfSize:12.0
+                                                           weight:UIFontWeightRegular];
       self->_label.textAlignment = NSTextAlignmentCenter;
     }
 


### PR DESCRIPTION
Test Plan:
----------

It'll look like the gif below:

![untitled](https://user-images.githubusercontent.com/7275322/42378516-71d8df96-811f-11e8-9144-895b135d7560.gif)

Release Notes:
--------------

[IOS] [ENHANCEMENT] [DevLoadingView] - Make JS loading progress use tabular numbers to make reading easier