### PR TITLE
Fix Attempt to invoke virtual method 'void com.facebook.react.uimanager.ReactShadowNode.addChildAt(com.facebook.react.uimanager.ReactShadowNode, int)' on a null object reference

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIImplementation.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIImplementation.java
@@ -478,12 +478,23 @@ public class UIImplementation {
     ReadableArray childrenTags) {
 
     ReactShadowNode cssNodeToManage = mShadowNodeRegistry.getNode(viewTag);
+    if (cssNodeToManage == null) {
+      FLog.w(
+        ReactConstants.TAG,
+        "Tried to add children to non-existent parent with tag " + viewTag
+      );
+      return;
+    }
 
     for (int i = 0; i < childrenTags.size(); i++) {
-      ReactShadowNode cssNodeToAdd = mShadowNodeRegistry.getNode(childrenTags.getInt(i));
+      int childTag = childrenTags.getInt(i);
+      ReactShadowNode cssNodeToAdd = mShadowNodeRegistry.getNode(childTag);
       if (cssNodeToAdd == null) {
-        throw new IllegalViewOperationException("Trying to add unknown view tag: "
-          + childrenTags.getInt(i));
+        FLog.w(
+          ReactConstants.TAG,
+          "Tried to add a non-existent child with tag " + childTag + " to parent with tag " + viewTag
+        );
+        return;
       }
       cssNodeToManage.addChildAt(cssNodeToAdd, i);
     }


### PR DESCRIPTION
Fixes #20078 
I based my fix on a similar issue resolved with [this](https://github.com/facebook/react-native/commit/5873a228f41bca763c35c470375a9f3cb36f80ab) commit.

Test Plan:
----------
As I mentioned in opened issue, it's very hard to create a consistent reproduction, same goes to testing the issue.

Release Notes:
--------------
Help reviewers and the release process by writing your own release notes. See below for an example.
[ANDROID] [BUGFIX] [UIImplementation] - Handle passing incorrect view tag to setChildren()

