### PR TITLE
Fix dependency configuration warnings

### DIFF
--- a/local-cli/templates/HelloWorld/android/app/build.gradle
+++ b/local-cli/templates/HelloWorld/android/app/build.gradle
@@ -137,9 +137,9 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: "libs", include: ["*.jar"])
-    compile "com.android.support:appcompat-v7:${rootProject.ext.supportLibVersion}"
-    compile "com.facebook.react:react-native:+"  // From node_modules
+    implementation fileTree(dir: "libs", include: ["*.jar"])
+    implementation "com.android.support:appcompat-v7:${rootProject.ext.supportLibVersion}"
+    implementation "com.facebook.react:react-native:+"  // From node_modules
 }
 
 // Run this once to be able to run the application with BUCK


### PR DESCRIPTION
Configuration 'compile' is obsolete and has been replaced with 'implementation' and 'api'.
It will be removed at the end of 2018. For more information see: http://d.android.com/r/tools/update-dependency-configurations.html

Release Notes:
--------------
[ANDROID] [ENHANCEMENT] [build.gradle] - Fix dependency configuration warning
