### PR TITLE
Allow third party components to render strings

### DIFF
--- a/Libraries/Renderer/oss/ReactFabric-dev.js
+++ b/Libraries/Renderer/oss/ReactFabric-dev.js
@@ -3733,14 +3733,15 @@ function getRootHostContext(rootContainerInstance) {
   return { isInAParentText: false };
 }
 
-function getChildHostContext(parentHostContext, type, rootContainerInstance) {
+function getChildHostContext(parentHostContext, fiber, rootContainerInstance) {
   var prevIsInAParentText = parentHostContext.isInAParentText;
   var isInAParentText =
-    type === "AndroidTextInput" || // Android
-    type === "RCTMultilineTextInputView" || // iOS
-    type === "RCTSinglelineTextInputView" || // iOS
-    type === "RCTText" ||
-    type === "RCTVirtualText";
+    fiber.type === "AndroidTextInput" || // Android
+    fiber.type === "RCTMultilineTextInputView" || // iOS
+    fiber.type === "RCTSinglelineTextInputView" || // iOS
+    fiber.type === "RCTText" ||
+    fiber.type === "RCTVirtualText" ||
+    (fiber.return && fiber.return.type && fiber.return.type.canRenderString);
 
   if (prevIsInAParentText !== isInAParentText) {
     return { isInAParentText: isInAParentText };
@@ -6606,7 +6607,7 @@ function getHostContext() {
 function pushHostContext(fiber) {
   var rootInstance = requiredContext(rootInstanceStackCursor.current);
   var context = requiredContext(contextStackCursor$1.current);
-  var nextContext = getChildHostContext(context, fiber.type, rootInstance);
+  var nextContext = getChildHostContext(context, fiber, rootInstance);
 
   // Don't push this Fiber's context unless it's unique.
   if (context === nextContext) {

--- a/Libraries/Renderer/oss/ReactFabric-prod.js
+++ b/Libraries/Renderer/oss/ReactFabric-prod.js
@@ -3728,13 +3728,14 @@ function beginWork(current, workInProgress, renderExpirationTime) {
       return (
         requiredContext(rootInstanceStackCursor.current),
         (renderExpirationTime = requiredContext(contextStackCursor$1.current)),
-        (props = workInProgress.type),
+        (props = workInProgress),
         (props =
-          "AndroidTextInput" === props ||
-          "RCTMultilineTextInputView" === props ||
-          "RCTSinglelineTextInputView" === props ||
-          "RCTText" === props ||
-          "RCTVirtualText" === props),
+          "AndroidTextInput" === props.type ||
+          "RCTMultilineTextInputView" === props.type ||
+          "RCTSinglelineTextInputView" === props.type ||
+          "RCTText" === props.type ||
+          "RCTVirtualText" === props.type ||
+          (props.return && props.return.type && props.return.type.canRenderString)),
         (props =
           renderExpirationTime.isInAParentText !== props
             ? { isInAParentText: props }

--- a/Libraries/Renderer/oss/ReactFabric-profiling.js
+++ b/Libraries/Renderer/oss/ReactFabric-profiling.js
@@ -3752,13 +3752,14 @@ function beginWork(current, workInProgress, renderExpirationTime) {
       return (
         requiredContext(rootInstanceStackCursor.current),
         (renderExpirationTime = requiredContext(contextStackCursor$1.current)),
-        (props = workInProgress.type),
+        (props = workInProgress),
         (props =
-          "AndroidTextInput" === props ||
-          "RCTMultilineTextInputView" === props ||
-          "RCTSinglelineTextInputView" === props ||
-          "RCTText" === props ||
-          "RCTVirtualText" === props),
+          "AndroidTextInput" === props.type ||
+          "RCTMultilineTextInputView" === props.type ||
+          "RCTSinglelineTextInputView" === props.type ||
+          "RCTText" === props.type ||
+          "RCTVirtualText" === props.type ||
+          (props.return && props.return.type && props.return.type.canRenderString)),
         (props =
           renderExpirationTime.isInAParentText !== props
             ? { isInAParentText: props }

--- a/Libraries/Renderer/oss/ReactNativeRenderer-dev.js
+++ b/Libraries/Renderer/oss/ReactNativeRenderer-dev.js
@@ -3930,14 +3930,15 @@ function getRootHostContext(rootContainerInstance) {
   return { isInAParentText: false };
 }
 
-function getChildHostContext(parentHostContext, type, rootContainerInstance) {
+function getChildHostContext(parentHostContext, fiber, rootContainerInstance) {
   var prevIsInAParentText = parentHostContext.isInAParentText;
   var isInAParentText =
-    type === "AndroidTextInput" || // Android
-    type === "RCTMultilineTextInputView" || // iOS
-    type === "RCTSinglelineTextInputView" || // iOS
-    type === "RCTText" ||
-    type === "RCTVirtualText";
+    fiber.type === "AndroidTextInput" || // Android
+    fiber.type === "RCTMultilineTextInputView" || // iOS
+    fiber.type === "RCTSinglelineTextInputView" || // iOS
+    fiber.type === "RCTText" ||
+    fiber.type === "RCTVirtualText" ||
+    (fiber.return && fiber.return.type && fiber.return.type.canRenderString);
 
   if (prevIsInAParentText !== isInAParentText) {
     return { isInAParentText: isInAParentText };
@@ -6894,7 +6895,7 @@ function getHostContext() {
 function pushHostContext(fiber) {
   var rootInstance = requiredContext(rootInstanceStackCursor.current);
   var context = requiredContext(contextStackCursor$1.current);
-  var nextContext = getChildHostContext(context, fiber.type, rootInstance);
+  var nextContext = getChildHostContext(context, fiber, rootInstance);
 
   // Don't push this Fiber's context unless it's unique.
   if (context === nextContext) {

--- a/Libraries/Renderer/oss/ReactNativeRenderer-prod.js
+++ b/Libraries/Renderer/oss/ReactNativeRenderer-prod.js
@@ -3782,13 +3782,14 @@ function beginWork(current, workInProgress, renderExpirationTime) {
       return (
         requiredContext(rootInstanceStackCursor.current),
         (renderExpirationTime = requiredContext(contextStackCursor$1.current)),
-        (props = workInProgress.type),
+        (props = workInProgress),
         (props =
-          "AndroidTextInput" === props ||
-          "RCTMultilineTextInputView" === props ||
-          "RCTSinglelineTextInputView" === props ||
-          "RCTText" === props ||
-          "RCTVirtualText" === props),
+          "AndroidTextInput" === props.type ||
+          "RCTMultilineTextInputView" === props.type ||
+          "RCTSinglelineTextInputView" === props.type ||
+          "RCTText" === props.type ||
+          "RCTVirtualText" === props.type ||
+          (props.return && props.return.type && props.return.type.canRenderString)),
         (props =
           renderExpirationTime.isInAParentText !== props
             ? { isInAParentText: props }

--- a/Libraries/Renderer/oss/ReactNativeRenderer-profiling.js
+++ b/Libraries/Renderer/oss/ReactNativeRenderer-profiling.js
@@ -3807,13 +3807,14 @@ function beginWork(current, workInProgress, renderExpirationTime) {
       return (
         requiredContext(rootInstanceStackCursor.current),
         (renderExpirationTime = requiredContext(contextStackCursor$1.current)),
-        (props = workInProgress.type),
+        (props = workInProgress),
         (props =
-          "AndroidTextInput" === props ||
-          "RCTMultilineTextInputView" === props ||
-          "RCTSinglelineTextInputView" === props ||
-          "RCTText" === props ||
-          "RCTVirtualText" === props),
+          "AndroidTextInput" === props.type ||
+          "RCTMultilineTextInputView" === props.type ||
+          "RCTSinglelineTextInputView" === props.type ||
+          "RCTText" === props.type ||
+          "RCTVirtualText" === props.type ||
+          (props.return && props.return.type && props.return.type.canRenderString)),
         (props =
           renderExpirationTime.isInAParentText !== props
             ? { isInAParentText: props }


### PR DESCRIPTION
After introducing new invariant checks in 0.56.0 release, third party native components that can render strings became broken - e.g. https://github.com/iyegoroff/react-native-text-gradient/issues/11

This PR allows third party components to render strings if they have static property `canRenderString` set to `true`.

Usage:

```js
const ICanRenderString = createReactClass({
  statics: {
    canRenderString: true
  },
  ...
};

class ICanRenderStringToo extends React.Component {
  static canRenderString = true;
}
```

Test Plan:
----------
This can be tested on react-native-text-gradient example:
1) ```bash
     $ git clone git@github.com:iyegoroff/react-native-text-gradient.git
     $ cd react-native-text-gradient
     $ git checkout fb-test
     $ cd TextGradientExample
     $ npm i
     $ react-native run-ios
     ```
2) example app should compile and run without errors, on the screen you should see text "Welcome to React Native!"
3) optionally, you can check that react-native core components behavior is not changed:
  ```js
  <Text>text</Text> // OK
  <TextInput>text-input</TextInput> // OK
  <View>view</View> // Invariant Violation: Text strings must be rendered within a <Text> component
  ```
4) Open "Dev Settings", uncheck "JS Dev Mode", reload the bundle and repeat items 2 and 3

Release Notes:
--------------
[GENERAL] [ENHANCEMENT] [Renderer] - Allow third party components to render strings

<!--
  **INTERNAL and MINOR tagged notes will not be included in the next version's final release notes.**

    CATEGORY
  [----------]      TYPE
  [ CLI      ] [-------------]    LOCATION
  [ DOCS     ] [ BREAKING    ] [-------------]
  [ GENERAL  ] [ BUGFIX      ] [ {Component} ]
  [ INTERNAL ] [ ENHANCEMENT ] [ {Filename}  ]
  [ IOS      ] [ FEATURE     ] [ {Directory} ]   |-----------|
  [ ANDROID  ] [ MINOR       ] [ {Framework} ] - | {Message} |
  [----------] [-------------] [-------------]   |-----------|

 EXAMPLES:

 [IOS] [BREAKING] [FlatList] - Change a thing that breaks other things
 [ANDROID] [BUGFIX] [TextInput] - Did a thing to TextInput
 [CLI] [FEATURE] [local-cli/info/info.js] - CLI easier to do things with
 [DOCS] [BUGFIX] [GettingStarted.md] - Accidentally a thing/word
 [GENERAL] [ENHANCEMENT] [Yoga] - Added new yoga thing/position
 [INTERNAL] [FEATURE] [./scripts] - Added thing to script that nobody will see
-->
