### PR TITLE
Support additional UIBarStyle's in RCTConvert

### DIFF
--- a/React/Base/RCTConvert.m
+++ b/React/Base/RCTConvert.m
@@ -407,6 +407,8 @@ RCT_ENUM_CONVERTER(UIViewContentMode, (@{
 RCT_ENUM_CONVERTER(UIBarStyle, (@{
   @"default": @(UIBarStyleDefault),
   @"black": @(UIBarStyleBlack),
+  @"blackOpaque": @(UIBarStyleBlackOpaque),
+  @"blackTranslucent": @(UIBarStyleBlackTranslucent),  
 }), UIBarStyleDefault, integerValue)
 #endif
 


### PR DESCRIPTION
Adds two additional UIBarStyles to RCTConvert

- [x] UIBarStyleBlackOpaque
- [x] UIBarStyleBlackTranslucent

Does not affect any tests or current usage of this conversion.