### PR TITLE
[TEST] Add missing tests for Animated.forkEvent

### DIFF
--- a/Libraries/Animated/src/__tests__/Animated-test.js
+++ b/Libraries/Animated/src/__tests__/Animated-test.js
@@ -572,7 +572,7 @@ describe('Animated tests', () => {
       expect(listener.mock.calls.length).toBe(1);
       expect(listener).toBeCalledWith({foo: 42});
     });
-    it('should call forked event listeners', () => {
+    it('should call forked event listeners, with Animated.event() listener', () => {
       const value = new Animated.Value(0);
       const listener = jest.fn();
       const handler = Animated.event([{foo: value}], {listener});
@@ -582,6 +582,24 @@ describe('Animated tests', () => {
       expect(value.__getValue()).toBe(42);
       expect(listener.mock.calls.length).toBe(1);
       expect(listener).toBeCalledWith({foo: 42});
+      expect(listener2.mock.calls.length).toBe(1);
+      expect(listener2).toBeCalledWith({foo: 42});
+    });
+    it('should call forked event listeners, with js listener', () => {
+      const listener = jest.fn();
+      const listener2 = jest.fn();
+      const forkedHandler = Animated.forkEvent(listener, listener2);
+      forkedHandler({foo: 42});
+      expect(listener.mock.calls.length).toBe(1);
+      expect(listener).toBeCalledWith({foo: 42});
+      expect(listener2.mock.calls.length).toBe(1);
+      expect(listener2).toBeCalledWith({foo: 42});
+    });
+    it('should call forked event listeners, with undefined listener', () => {
+      const listener = undefined;
+      const listener2 = jest.fn();
+      const forkedHandler = Animated.forkEvent(listener, listener2);
+      forkedHandler({foo: 42});
       expect(listener2.mock.calls.length).toBe(1);
       expect(listener2).toBeCalledWith({foo: 42});
     });


### PR DESCRIPTION
`forkEvent` is generally used to intercept an existing listener and add a new js listener to it, considering the original listener can be null/js/Animated.event(). I added tests to ensure the 3 cases of the implementation are all covered.

Test Plan:
----------
Tests are passing

Release Notes:
--------------

[INTERNAL] [ENHANCEMENT] [Animated] Add Animated.forkEvent tests for better coverage

