### PR TITLE
RCTRootView: add needsReRender flag - fixes 20115

### DIFF
--- a/React/Base/RCTRootView.m
+++ b/React/Base/RCTRootView.m
@@ -46,6 +46,7 @@ NSString *const RCTContentDidAppearNotification = @"RCTContentDidAppearNotificat
   NSString *_moduleName;
   RCTRootContentView *_contentView;
   BOOL _passThroughTouches;
+  BOOL _needsReRenderBecauseAppPropertiesChanged;
   CGSize _intrinsicContentSize;
 }
 
@@ -68,6 +69,7 @@ NSString *const RCTContentDidAppearNotification = @"RCTContentDidAppearNotificat
     _bridge = bridge;
     _moduleName = moduleName;
     _appProperties = [initialProperties copy];
+    _needsReRenderBecauseAppPropertiesChanged = NO;
     _loadingViewFadeDelay = 0.25;
     _loadingViewFadeDuration = 0.25;
     _sizeFlexibility = RCTRootViewSizeFlexibilityNone;
@@ -257,6 +259,8 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
   RCTBridge *bridge = notification.userInfo[@"bridge"];
   if (bridge != _contentView.bridge) {
     [self bundleFinishedLoading:bridge];
+  } else if(_needsReRenderBecauseAppPropertiesChanged) {
+    [self runApplication:bridge];
   }
 }
 
@@ -330,6 +334,8 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
 
   if (_contentView && _bridge.valid && !_bridge.loading) {
     [self runApplication:_bridge];
+  } else {
+    _needsReRenderBecauseAppPropertiesChanged = YES;
   }
 }
 


### PR DESCRIPTION
See https://github.com/facebook/react-native/issues/20115

I know there is probably a lot wrong with this implementation: 

- Not sure if this bug should be fixed in this file
- Not sure if you want a flag like this just for this reason?
- Even if you want the flag, the name should probably be something else.. 

Please view it as a first take on fixing 20115 (this is my first ReactNative PR \0/). 

Test Plan:
----------
See https://github.com/facebook/react-native/issues/20115

Release Notes:
--------------
[IOS] [BREAKING] [RCTRootView] - Fix bug where view is not re-rendered if AppProperties change while bridge is loading
