### PR TITLE
fix: prevent exception when imageName is null

### DIFF
--- a/React/Base/RCTUtils.m
+++ b/React/Base/RCTUtils.m
@@ -698,10 +698,12 @@ UIImage *__nullable RCTImageFromLocalAssetURL(NSURL *imageURL)
   }
 
   UIImage *image = nil;
-  if (bundle) {
-    image = [UIImage imageNamed:imageName inBundle:bundle compatibleWithTraitCollection:nil];
-  } else {
-    image = [UIImage imageNamed:imageName];
+  if (imageName) {
+    if (bundle) {
+      image = [UIImage imageNamed:imageName inBundle:bundle compatibleWithTraitCollection:nil];
+    } else {
+      image = [UIImage imageNamed:imageName];
+    }
   }
 
   if (!image) {


### PR DESCRIPTION
When an image source is parsed via `RCTImageFromLocalAssetURL` there seem to be certain situations in which `imageName` is empty from `RCTBundlePathForURL`. Any call to `UIImage imageNamed` with a an empty parameter will throw an exception:

```
CUICatalog: Invalid asset name supplied: '(null)'
```

In my case, the asset URL was pointing to an image in the application sandbox rather than the `NSBundle`. In this case `UIImage imageNamed` was throwing before the call to `NSData dataWithContentsOfURL` below could correctly resolve the image.

This change simply skips the call to `UIImage imageNamed` if no `imageName` value is set.

Test Plan:
----------
This is not a breaking change. Test by loading various images both inside and outside of the app NSBundle. The resolution order is unchanged, the only exception being that images outside of the app bundle will not attempt to resolve using the `imageNamed` method.

Release Notes:
--------------
[IOS] [BUGFIX] [RCTUtils] - Prevent exceptions when asset URL is outside of the NSBundle.
