### PR TITLE
Check return value from malloc

### DIFF
--- a/Libraries/Image/RCTImageBlurUtils.m
+++ b/Libraries/Image/RCTImageBlurUtils.m
@@ -35,6 +35,12 @@ UIImage *RCTBlurredImageWithRadius(UIImage *inputImage, CGFloat radius)
   size_t bytes = buffer1.rowBytes * buffer1.height;
   buffer1.data = malloc(bytes);
   buffer2.data = malloc(bytes);
+  if (!buffer1.data || !buffer2.data) {
+    // CWE - 391 : Unchecked error condition
+    // https://www.cvedetails.com/cwe-details/391/Unchecked-Error-Condition.html
+    // https://eli.thegreenplace.net/2009/10/30/handling-out-of-memory-conditions-in-c
+    abort();
+  }
 
   // A description of how to compute the box kernel width from the Gaussian
   // radius (aka standard deviation) appears in the SVG spec:
@@ -45,6 +51,12 @@ UIImage *RCTBlurredImageWithRadius(UIImage *inputImage, CGFloat radius)
   //create temp buffer
   void *tempBuffer = malloc((size_t)vImageBoxConvolve_ARGB8888(&buffer1, &buffer2, NULL, 0, 0, boxSize, boxSize,
                                                                NULL, kvImageEdgeExtend + kvImageGetTempBufferSize));
+  if (!tempBuffer) {
+    // CWE - 391 : Unchecked error condition
+    // https://www.cvedetails.com/cwe-details/391/Unchecked-Error-Condition.html
+    // https://eli.thegreenplace.net/2009/10/30/handling-out-of-memory-conditions-in-c
+    abort();
+  }
 
   //copy image data
   CFDataRef dataSource = CGDataProviderCopyData(CGImageGetDataProvider(imageRef));

--- a/Libraries/Network/RCTNetworking.mm
+++ b/Libraries/Network/RCTNetworking.mm
@@ -50,6 +50,12 @@ static NSString *RCTGenerateFormBoundary()
   const char *boundaryChars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_.";
 
   char *bytes = (char*)malloc(boundaryLength);
+  if (!bytes) {
+    // CWE - 391 : Unchecked error condition
+    // https://www.cvedetails.com/cwe-details/391/Unchecked-Error-Condition.html
+    // https://eli.thegreenplace.net/2009/10/30/handling-out-of-memory-conditions-in-c
+    abort();
+  }
   size_t charCount = strlen(boundaryChars);
   for (int i = 0; i < boundaryLength; i++) {
     bytes[i] = boundaryChars[arc4random_uniform((u_int32_t)charCount)];

--- a/React/Base/RCTModuleMethod.mm
+++ b/React/Base/RCTModuleMethod.mm
@@ -302,6 +302,12 @@ RCT_EXTERN_C_END
 
           [argumentBlocks addObject:^(__unused RCTBridge *bridge, NSUInteger index, id json) {
             void *returnValue = malloc(typeSignature.methodReturnLength);
+            if (!returnValue) {
+              // CWE - 391 : Unchecked error condition
+              // https://www.cvedetails.com/cwe-details/391/Unchecked-Error-Condition.html
+              // https://eli.thegreenplace.net/2009/10/30/handling-out-of-memory-conditions-in-c
+              abort();
+            }
             [typeInvocation setArgument:&json atIndex:2];
             [typeInvocation invoke];
             [typeInvocation getReturnValue:returnValue];

--- a/React/Profiler/RCTProfile.m
+++ b/React/Profiler/RCTProfile.m
@@ -76,14 +76,16 @@ static systrace_arg_t *newSystraceArgsFromDictionary(NSDictionary<NSString *, NS
   }
 
   systrace_arg_t *systrace_args = malloc(sizeof(systrace_arg_t) * args.count);
-  __block size_t i = 0;
-  [args enumerateKeysAndObjectsUsingBlock:^(NSString *key, NSString *value, __unused BOOL *stop) {
-    systrace_args[i].key = [key UTF8String];
-    systrace_args[i].key_len = [key length];
-    systrace_args[i].value = [value UTF8String];
-    systrace_args[i].value_len = [value length];
-    i++;
-  }];
+  if (systrace_args) {
+    __block size_t i = 0;
+    [args enumerateKeysAndObjectsUsingBlock:^(NSString *key, NSString *value, __unused BOOL *stop) {
+      systrace_args[i].key = [key UTF8String];
+      systrace_args[i].key_len = [key length];
+      systrace_args[i].value = [value UTF8String];
+      systrace_args[i].value_len = [value length];
+      i++;
+    }];
+  }
   return systrace_args;
 }
 

--- a/React/Views/RCTComponentData.m
+++ b/React/Views/RCTComponentData.m
@@ -167,6 +167,12 @@ static RCTPropBlock createNSInvocationSetter(NSMethodSignature *typeSignature, S
     if (json) {
       freeValueOnCompletion = YES;
       value = malloc(typeSignature.methodReturnLength);
+      if (!value) {
+        // CWE - 391 : Unchecked error condition
+        // https://www.cvedetails.com/cwe-details/391/Unchecked-Error-Condition.html
+        // https://eli.thegreenplace.net/2009/10/30/handling-out-of-memory-conditions-in-c
+        abort();
+      }
       [typeInvocation setArgument:&json atIndex:2];
       [typeInvocation invoke];
       [typeInvocation getReturnValue:value];


### PR DESCRIPTION
Calls abort() in cases where malloc returns NULL.

Checking the return value from malloc is good practice and is required to pass a [Veracode security scan](https://www.veracode.com/). This will let developers who are required to submit their software to Veracode use React Native.

Test Plan:
----------
* Using the Xcode debugger, I put breakpoints on the conditionals added after calls to malloc
* Ran the RNTesterUnitTests
* The breakpoints for the code added to `RCTModuleMethod` and `RCTComponentData` were hit and behavior was unchanged

I didn't see unit tests for the other changed modules.

Release Notes:
--------------
Help reviewers and the release process by writing your own release notes. See below for an example.

[IOS] [MINOR] [React] - Check return value from malloc

<!--
  **INTERNAL and MINOR tagged notes will not be included in the next version's final release notes.**

    CATEGORY
  [----------]      TYPE
  [ CLI      ] [-------------]    LOCATION
  [ DOCS     ] [ BREAKING    ] [-------------]
  [ GENERAL  ] [ BUGFIX      ] [ {Component} ]
  [ INTERNAL ] [ ENHANCEMENT ] [ {Filename}  ]
  [ IOS      ] [ FEATURE     ] [ {Directory} ]   |-----------|
  [ ANDROID  ] [ MINOR       ] [ {Framework} ] - | {Message} |
  [----------] [-------------] [-------------]   |-----------|

 EXAMPLES:

 [IOS] [BREAKING] [FlatList] - Change a thing that breaks other things
 [ANDROID] [BUGFIX] [TextInput] - Did a thing to TextInput
 [CLI] [FEATURE] [local-cli/info/info.js] - CLI easier to do things with
 [DOCS] [BUGFIX] [GettingStarted.md] - Accidentally a thing/word
 [GENERAL] [ENHANCEMENT] [Yoga] - Added new yoga thing/position
 [INTERNAL] [FEATURE] [./scripts] - Added thing to script that nobody will see
-->
