### PR TITLE
Fix local-cli assetRegistryPath and middlewares

### DIFF
--- a/local-cli/server/middleware/MiddlewareManager.js
+++ b/local-cli/server/middleware/MiddlewareManager.js
@@ -19,8 +19,8 @@ const indexPageMiddleware = require('./indexPage');
 const copyToClipBoardMiddleware = require('./copyToClipBoardMiddleware');
 const loadRawBodyMiddleware = require('./loadRawBodyMiddleware');
 const openStackFrameInEditorMiddleware = require('./openStackFrameInEditorMiddleware');
-const statusPageMiddleware = require('./statusPageMiddleware.js');
-const systraceProfileMiddleware = require('./systraceProfileMiddleware.js');
+const statusPageMiddleware = require('./statusPageMiddleware');
+const systraceProfileMiddleware = require('./systraceProfileMiddleware');
 const getDevToolsMiddleware = require('./getDevToolsMiddleware');
 
 type Options = {

--- a/local-cli/server/runServer.js
+++ b/local-cli/server/runServer.js
@@ -16,9 +16,13 @@ const Metro = require('metro');
 
 const {Terminal} = require('metro-core');
 
+const messageSocket = require('./util/messageSocket');
 const morgan = require('morgan');
 const path = require('path');
+const webSocketProxy = require('./util/webSocketProxy');
 const MiddlewareManager = require('./middleware/MiddlewareManager');
+
+const {ASSET_REGISTRY_PATH} = require('../core/Constants');
 
 import type {ConfigT} from 'metro';
 
@@ -55,6 +59,9 @@ async function runServer(args: Args, config: ConfigT) {
   const serverInstance = await Metro.runServer({
     config: {
       ...config,
+      assetRegistryPath: ASSET_REGISTRY_PATH,
+      enhanceMiddleware: middleware =>
+        middlewareManager.getConnectInstance().use(middleware),
       hmrEnabled: true,
       maxWorkers: args.maxWorkers,
       reporter,
@@ -69,6 +76,14 @@ async function runServer(args: Args, config: ConfigT) {
     host: args.host,
     port: args.port,
   });
+
+  const wsProxy = webSocketProxy.attachToServer(
+    serverInstance,
+    '/debugger-proxy',
+  );
+  const ms = messageSocket.attachToServer(serverInstance, '/message');
+  middlewareManager.attachDevToolsSocket(wsProxy);
+  middlewareManager.attachDevToolsSocket(ms);
 
   // In Node 8, the default keep-alive for an HTTP connection is 5 seconds. In
   // early versions of Node 8, this was implemented in a buggy way which caused

--- a/local-cli/server/runServer.js
+++ b/local-cli/server/runServer.js
@@ -62,19 +62,19 @@ async function runServer(args: Args, config: ConfigT) {
       assetRegistryPath: ASSET_REGISTRY_PATH,
       enhanceMiddleware: middleware =>
         middlewareManager.getConnectInstance().use(middleware),
-      hmrEnabled: true,
-      maxWorkers: args.maxWorkers,
-      reporter,
-      secure: args.https,
-      secureKey: args.key,
-      secureCert: args.cert,
       transformModulePath: args.transformer
         ? path.resolve(args.transformer)
         : config.getTransformModulePath(),
-      watch: !args.nonPersistent,
     },
+    hmrEnabled: true,
     host: args.host,
+    maxWorkers: args.maxWorkers,
     port: args.port,
+    reporter,
+    secure: args.https,
+    secureCert: args.cert,
+    secureKey: args.key,
+    watch: !args.nonPersistent,
   });
 
   const wsProxy = webSocketProxy.attachToServer(

--- a/local-cli/server/runServer.js
+++ b/local-cli/server/runServer.js
@@ -74,7 +74,6 @@ async function runServer(args: Args, config: ConfigT) {
     secure: args.https,
     secureCert: args.cert,
     secureKey: args.key,
-    watch: !args.nonPersistent,
   });
 
   const wsProxy = webSocketProxy.attachToServer(


### PR DESCRIPTION
This fixes some regressions with local-cli introduced in c4a66a89a28152cd4b81e2b0f80ab3aac34d6872. Fixes #20008.

- We didn't pass `assetRegistryPath` which caused the following error when loading the bundle:
```
error: bundling failed: Error: Unable to resolve module `missing-asset-registry-path` from `/Users/janic/Developer/react-native/RNTester/js/uie_thumb_normal@2x.png`: Module `missing-asset-registry-path` does not exist in the Haste module map
```
- The middlewares were not added to the metro server. This causes some packager server features to fail. The one I noticed is that the /status endpoint didn't exist anymore which causes CI to fail and also Android to not load the bundle from the packager initially. The remote debugging feature was also broken.

Test Plan:
----------
- Run RNTester and make sure the app loads properly.
- Test the /status endpoint to make sure middlewares are added.
- Test remote debugging and make sure it works as expected.

Release Notes:
--------------
Marking this as internal since the regression hasn't made it to a release.

[INTERNAL] [BUGFIX] [runServer.js] - Fix local-cli assetRegistryPath and middlewares

