### PR TITLE
[ GENERAL ][ BUGFIX ][ jest/preprocessor.js ] - Invalid use of destructuring

### DIFF
--- a/jest/preprocessor.js
+++ b/jest/preprocessor.js
@@ -43,7 +43,9 @@ module.exports = {
         src,
         Object.assign(
           {filename: file},
-          {sourceType: 'script', ...nodeOptions, ast: false},
+          {sourceType: 'script'},
+          nodeOptions,
+          {ast: false}
         ),
       ).code;
     }

--- a/jest/preprocessor.js
+++ b/jest/preprocessor.js
@@ -41,12 +41,12 @@ module.exports = {
       // node specific transforms only
       return babelTransformSync(
         src,
-        Object.assign(
-          {filename: file},
-          {sourceType: 'script'},
-          nodeOptions,
-          {ast: false}
-        ),
+        {
+          filename: file,
+          sourceType: 'script',
+          ...nodeOptions,
+          ast: false
+        },
       ).code;
     }
 


### PR DESCRIPTION
Test Plan:
----------
I had the same issues running tests as mentioned in: https://github.com/facebook/react-native/issues/19859

I followed the suggestions but ran into another error:
```
  ● Test suite failed to run

    /Users/umair/projects/my-project/node_modules/react-native/jest/preprocessor.js:49
              {sourceType: 'script', ...nodeOptions, ast: false},
                                     ^^^

    SyntaxError: Unexpected token ...
```

The `preprocessor.js` code in question is:
```
      // node specific transforms only
      return babelTransformSync(
        src,
        Object.assign(
          {filename: file},
          {sourceType: 'script', ...nodeOptions, ast: false},
        ),
      ).code;
```

Specifically line 46: `{sourceType: 'script', ...nodeOptions, ast: false},` is an invalid use of object destructuring and since this object is part of an `Object.assign` statement I simply broke the constituents up into arguments as follows:
```
        Object.assign(
          {filename: file},
          {sourceType: 'script'},
          nodeOptions, 
          {ast: false}
        ),
```

Release Notes:
--------------
[GENERAL][BUGFIX][jest/preprocessor.js] - fixes invalid use of object destructuring in preprocessor.js

