### PR TITLE
add flow typing for transform prop

### DIFF
--- a/Libraries/Components/View/ViewPropTypes.js
+++ b/Libraries/Components/View/ViewPropTypes.js
@@ -30,6 +30,7 @@ import type {
 } from 'ViewAccessibility';
 import type {EdgeInsetsProp} from 'EdgeInsetsPropType';
 import type {TVViewProps} from 'TVViewPropTypes';
+import type {TransformProps} from 'TransformPropTypes';
 import type {Layout, LayoutEvent} from 'CoreEventTypes';
 
 const stylePropType = StyleSheetPropType(ViewStylePropTypes);
@@ -77,6 +78,8 @@ export type ViewProps = $ReadOnly<{|
   // There's no easy way to create a different type if (Platform.isTV):
   // so we must include TVViewProps
   ...TVViewProps,
+
+  ...TransformProps,
 
   accessible?: boolean,
   accessibilityLabel?:

--- a/Libraries/StyleSheet/TransformPropTypes.js
+++ b/Libraries/StyleSheet/TransformPropTypes.js
@@ -106,4 +106,21 @@ const TransformPropTypes = {
   ),
 };
 
+export type TransformProps = $ReadOnly<{|
+  transform?: Array<
+    $Shape<{perspective: number}> |
+    $Shape<{rotate: string}> |
+    $Shape<{rotateX: string}> |
+    $Shape<{rotateY: string}> |
+    $Shape<{rotateZ: string}> |
+    $Shape<{scale: number}> |
+    $Shape<{scaleX: number}> |
+    $Shape<{scaleY: number}> |
+    $Shape<{translateX: number}> |
+    $Shape<{translateY: number}> |
+    $Shape<{skewX: string}> |
+    $Shape<{skewY: string}>
+  >,
+|}>;
+
 module.exports = TransformPropTypes;


### PR DESCRIPTION
Fixes:
----------
Fixes a flow error that occurs when using the transform prop on the View component.

`[flow] Cannot create `View` element because property `transform` is missing in object type [1] but exists in props [2]. (References: [1] [2])`

Test Plan:
----------
Flow no longer yield any errors when using transform on the View component.

Release Notes:
--------------
[ GENERAL ] [ BUGFIX ] [ {./Libraries} ] - Fixed flow error


