### PR TITLE
Upgrade ws package

### DIFF
--- a/package.json
+++ b/package.json
@@ -193,7 +193,7 @@
     "serve-static": "^1.13.1",
     "shell-quote": "1.6.1",
     "stacktrace-parser": "^0.1.3",
-    "ws": "^1.1.0",
+    "ws": "^5.2.2",
     "xcode": "^0.9.1",
     "xmldoc": "^0.4.0",
     "yargs": "^9.0.0"


### PR DESCRIPTION
Security fix for https://nodesecurity.io/advisories/550 (rating: HIGH)

The `ws` project uses [GitHub releases for a ChangeLog](https://github.com/websockets/ws/releases).

Test Plan:
----------
I haven't tested this change yet -- I'm not familiar with how the `ws` package works, and I expect there are some backwards-incompatible changes between version 1 and version 5. I wanted to make this pull request anyway, in the hopes that someone more familiar with this package would be able to review it and suggest changes for the codebase.

Release Notes:
--------------
[INTERNAL] [BUGFIX] [package.json] - Upgrade the `ws` package, to close a [security vulnerability](https://nodesecurity.io/advisories/550)
