### PR TITLE
Make AccessibilityInfo.setAccessibilityFocus cross platform

### DIFF
--- a/Libraries/Components/AccessibilityInfo/AccessibilityInfo.android.js
+++ b/Libraries/Components/AccessibilityInfo/AccessibilityInfo.android.js
@@ -12,6 +12,7 @@
 
 const NativeModules = require('NativeModules');
 const RCTDeviceEventEmitter = require('RCTDeviceEventEmitter');
+const UIManager = require('UIManager');
 
 const RCTAccessibilityInfo = NativeModules.AccessibilityInfo;
 
@@ -65,6 +66,15 @@ const AccessibilityInfo = {
     }
     listener.remove();
     _subscriptions.delete(handler);
+  },
+
+  /**
+   * Set accessibility focus to a react component.
+   *
+   * See http://facebook.github.io/react-native/docs/accessibilityinfo.html#setaccessibilityfocus
+   */
+  setAccessibilityFocus: function(reactTag: number): void {
+    UIManager.sendAccessibilityEvent(reactTag, 8);
   },
 };
 

--- a/Libraries/Components/AccessibilityInfo/AccessibilityInfo.ios.js
+++ b/Libraries/Components/AccessibilityInfo/AccessibilityInfo.ios.js
@@ -93,8 +93,6 @@ const AccessibilityInfo = {
   /**
    * Set accessibility focus to a react component.
    *
-   * @platform ios
-   *
    * See http://facebook.github.io/react-native/docs/accessibilityinfo.html#setaccessibilityfocus
    */
   setAccessibilityFocus: function(reactTag: number): void {


### PR DESCRIPTION
Currently, `AccessibilityInfo.setAccessibilityFocus` is only available on iOS. The same behaviour can be achieved on Android by dispatching the proper accessibility event. I implemented the same function for Android, to make life slightly more convenient for the developer.

Today, developers must write something like this:
```
if (Platform.OS === 'ios') {
     AccessibilityInfo.setAccessibilityFocus(reactTag)
} else {
     UIManager.sendAccessibilityEvent(reactTag, 8)
}
```

With this change, the following is enough for both Android and iOS:
```
AccessibilityInfo.setAccessibilityFocus(reactTag)
```

Test Plan:
----------
I made the same change in the `react-native` package in my project's node_modules, and checked that it worked on an Android device with TalkBack activated. 

Release Notes:
--------------
[ANDROID] [ENHANCEMENT] [AccessibilityInfo] - Implement AccessibilityInfo.setAccessibilityFocus for Android

