### PR TITLE
Initial Detox E2E iOS configuration to be run on RNTester

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -497,6 +497,8 @@ jobs:
             brew tap wix/brew
             brew install applesimutils
 
+      - run: *yarn
+      
       - run:
           name: Run Detox Tests
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -474,33 +474,33 @@ jobs:
 
   test_end_to_end_detox:
     <<: *macos_defaults
-     steps:
-        - attach_workspace:
-            at: ~/react-native
+    steps:
+      - attach_workspace:
+          at: ~/react-native
 
-        - run:
-            name: Configure Environment Variables
-            command: |
-              echo 'export PATH=/usr/local/opt/node@8/bin:$PATH' >> $BASH_ENV
-              source $BASH_ENV
+      - run:
+          name: Configure Environment Variables
+          command: |
+            echo 'export PATH=/usr/local/opt/node@8/bin:$PATH' >> $BASH_ENV
+            source $BASH_ENV
 
-        - run:
-            name: Install Node 8
-            command: |
-              brew install node@8
-              brew link node@8
-              node -v
+      - run:
+          name: Install Node 8
+          command: |
+            brew install node@8
+            brew link node@8
+            node -v
 
-        - run:
-            name: Install Apple Simulator Utilities
-            command: |
-              brew tap wix/brew
-              brew install applesimutils
+      - run:
+          name: Install Apple Simulator Utilities
+          command: |
+            brew tap wix/brew
+            brew install applesimutils
 
-        - run:
-            name: Run Detox Tests
-            command: |
-              yarn run test-ios-e2e
+      - run:
+          name: Run Detox Tests
+          command: |
+            yarn run test-ios-e2e
 
   # Publishes new version onto npm
   publish_npm_package:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -463,6 +463,8 @@ jobs:
           command: |
             brew install node@8
             brew link node@8
+            brew tap wix/brew
+            brew install applesimutils
             node -v
 
       - run: *run-objc-ios-e2e-tests
@@ -471,6 +473,31 @@ jobs:
 
       - store_test_results:
           path: ~/react-native/reports/junit
+
+  test_end_to_end_detox:
+    <<: *macos_defaults
+     steps:
+        - attach_workspace:
+            at: ~/react-native
+
+        - run:
+          name: Configure Environment Variables
+          command: |
+            echo 'export PATH=/usr/local/opt/node@8/bin:$PATH' >> $BASH_ENV
+            source $BASH_ENV
+
+        - run:
+          name: Install Node 8
+          command: |
+            brew install node@8
+            brew link node@8
+            brew tap wix/brew
+            brew install applesimutils
+            node -v
+        -run:
+          name: Run Detox Tests
+          command: |
+          yarn run test-ios-e2e
 
   # Publishes new version onto npm
   publish_npm_package:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -479,17 +479,17 @@ jobs:
             at: ~/react-native
 
         - run:
-          name: Configure Environment Variables
-          command: |
-            echo 'export PATH=/usr/local/opt/node@8/bin:$PATH' >> $BASH_ENV
-            source $BASH_ENV
+            name: Configure Environment Variables
+            command: |
+              echo 'export PATH=/usr/local/opt/node@8/bin:$PATH' >> $BASH_ENV
+              source $BASH_ENV
 
         - run:
-          name: Install Node 8
-          command: |
-            brew install node@8
-            brew link node@8
-            node -v
+            name: Install Node 8
+            command: |
+              brew install node@8
+              brew link node@8
+              node -v
 
         - run:
             name: Install Apple Simulator Utilities

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -463,8 +463,6 @@ jobs:
           command: |
             brew install node@8
             brew link node@8
-            brew tap wix/brew
-            brew install applesimutils
             node -v
 
       - run: *run-objc-ios-e2e-tests
@@ -491,13 +489,18 @@ jobs:
           command: |
             brew install node@8
             brew link node@8
-            brew tap wix/brew
-            brew install applesimutils
             node -v
-        -run:
-          name: Run Detox Tests
-          command: |
-          yarn run test-ios-e2e
+
+        - run:
+            name: Install Apple Simulator Utilities
+            command: |
+              brew tap wix/brew
+              brew install applesimutils
+
+        - run:
+            name: Run Detox Tests
+            command: |
+              yarn run test-ios-e2e
 
   # Publishes new version onto npm
   publish_npm_package:
@@ -709,6 +712,12 @@ workflows:
 
       # End-to-end tests
       - test_end_to_end:
+          filters: *filter-ignore-gh-pages
+          requires:
+            - checkout_code
+
+      # End-to-end tests (Detox)
+      - test_end_to_end_detox:
           filters: *filter-ignore-gh-pages
           requires:
             - checkout_code

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -325,16 +325,12 @@ aliases:
   - &run-objc-ios-e2e-tests
     name: iOS End-to-End Test Suite
     command: |
-      if [ $((0 % CIRCLE_NODE_TOTAL)) -eq "$CIRCLE_NODE_INDEX" ]; then
-        node ./scripts/run-ci-e2e-tests.js --ios --retries 3;
-      fi
+      node ./scripts/run-ci-e2e-tests.js --ios --retries 3;
 
   - &run-objc-tvos-e2e-tests
     name: tvOS End-to-End Test Suite
     command: |
-      if [ $((1 % CIRCLE_NODE_TOTAL)) -eq "$CIRCLE_NODE_INDEX" ]; then
-        node ./scripts/run-ci-e2e-tests.js --tvos --js --retries 3;
-      fi
+      node ./scripts/run-ci-e2e-tests.js --tvos --js --retries 3;
 
   - &run-android-e2e-tests
     name: Android End-to-End Test Suite
@@ -444,13 +440,13 @@ jobs:
   # Runs end to end tests
   test_end_to_end:
     <<: *macos_defaults
-    parallelism: 2
     steps:
       - attach_workspace:
           at: ~/react-native
 
-      - run: *boot-simulator-iphone
-      - run: *boot-simulator-appletv
+      - run:
+          name: Boot iOS Simulator
+          command: xcrun simctl boot "iPhone 5s" || true
 
       - run:
           name: Configure Environment Variables
@@ -466,30 +462,6 @@ jobs:
             node -v
 
       - run: *run-objc-ios-e2e-tests
-      # Disabled for now
-      # - run: *run-objc-tvos-e2e-tests
-
-      - store_test_results:
-          path: ~/react-native/reports/junit
-
-  test_end_to_end_detox:
-    <<: *macos_defaults
-    steps:
-      - attach_workspace:
-          at: ~/react-native
-
-      - run:
-          name: Configure Environment Variables
-          command: |
-            echo 'export PATH=/usr/local/opt/node@8/bin:$PATH' >> $BASH_ENV
-            source $BASH_ENV
-
-      - run:
-          name: Install Node 8
-          command: |
-            brew install node@8
-            brew link node@8
-            node -v
 
       - run:
           name: Install Apple Simulator Utilities
@@ -497,17 +469,16 @@ jobs:
             brew tap wix/brew
             brew install applesimutils
 
-      - run: *yarn
-
       - run:
-          name: Build iOS app for simulator
-          command: |
-            yarn run build-ios-e2e
+          name: Build iOS App for Simulator
+          command: yarn run build-ios-e2e
 
       - run:
           name: Run Detox Tests
-          command: |
-            yarn run test-ios-e2e
+          command: yarn run test-ios-e2e
+
+      - store_test_results:
+          path: ~/react-native/reports/junit
 
   # Publishes new version onto npm
   publish_npm_package:
@@ -719,12 +690,6 @@ workflows:
 
       # End-to-end tests
       - test_end_to_end:
-          filters: *filter-ignore-gh-pages
-          requires:
-            - checkout_code
-
-      # End-to-end tests (Detox)
-      - test_end_to_end_detox:
           filters: *filter-ignore-gh-pages
           requires:
             - checkout_code

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -498,7 +498,12 @@ jobs:
             brew install applesimutils
 
       - run: *yarn
-      
+
+      - run:
+          name: Build iOS app for simulator
+          command: |
+            yarn run build-ios-e2e
+
       - run:
           name: Run Detox Tests
           command: |

--- a/.eslintrc
+++ b/.eslintrc
@@ -52,7 +52,8 @@
     "setTimeout": false,
     "window": false,
     "XMLHttpRequest": false,
-    "pit": false
+    "pit": false,
+    "jasmine": true
   },
 
   "rules": {

--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,4 @@ package-lock.json
 
 # ReactCommon subdir shouldn't have Xcode project
 /ReactCommon/**/*.xcodeproj
+RNTester/build

--- a/RNTester/e2e/config.json
+++ b/RNTester/e2e/config.json
@@ -1,0 +1,6 @@
+{
+  "setupTestFrameworkScriptFile" : "./init.js",
+  "testEnvironment": "node",
+  "bail": true,
+  "verbose": true
+}

--- a/RNTester/e2e/init.js
+++ b/RNTester/e2e/init.js
@@ -1,0 +1,23 @@
+const detox = require('detox');
+const config = require('../../package.json').detox;
+const adapter = require('detox/runners/jest/adapter');
+
+jest.setTimeout(480000);
+jasmine.getEnv().addReporter(adapter);
+
+beforeAll(async () => {
+  await detox.init(config);
+});
+
+beforeEach(async function() {
+  await adapter.beforeEach();
+});
+
+afterAll(async () => {
+  await adapter.afterAll();
+  await detox.cleanup();
+});
+
+process.on('unhandledRejection', (reason, p) => {
+  console.log('Unhandled Rejection at: Promise', p, 'reason:', reason);
+});

--- a/RNTester/e2e/sanity.test.js
+++ b/RNTester/e2e/sanity.test.js
@@ -1,3 +1,5 @@
+/* global device, element, by, expect */
+
 describe('Sanity', () => {
   beforeEach(async () => {
     await device.reloadReactNative();

--- a/RNTester/e2e/sanity.test.js
+++ b/RNTester/e2e/sanity.test.js
@@ -1,0 +1,38 @@
+describe('Sanity', () => {
+  beforeEach(async () => {
+    await device.reloadReactNative();
+    await element(by.label(`<Button> Simple React Native button component.`)).tap();
+  });
+
+  afterEach(async () => {
+    //TODO - remove app state persistency, till then, we must go back to main screen,
+    await element(by.label('Back')).tap();
+  });
+
+  it('Simple button should be tappable', async () => {
+    await element(by.label('Press Me')).tap();
+    await expect(element(by.text('Simple has been pressed!'))).toBeVisible();
+    await element(by.text('OK')).tap();
+  });
+
+  it('Adjusted color button should be tappable', async () => {
+    await element(by.label('Press Purple')).tap();
+    await expect(element(by.text('Purple has been pressed!'))).toBeVisible();
+    await element(by.text('OK')).tap();
+  });
+
+  it(`Two buttons with JustifyContent:'space-between' should be tappable`, async () => {
+    await element(by.label('This looks great!')).tap();
+    await expect(element(by.text('Left has been pressed!'))).toBeVisible();
+    await element(by.text('OK')).tap();
+
+    await element(by.label('Ok!')).tap();
+    await expect(element(by.text('Right has been pressed!'))).toBeVisible();
+    await element(by.text('OK')).tap();
+  });
+
+  it('Disabled button should not interact', async () => {
+    await element(by.label('I Am Disabled')).tap();
+    await expect(element(by.text('Disabled has been pressed!'))).toBeNotVisible();
+  });
+});

--- a/RNTester/js/ButtonExample.js
+++ b/RNTester/js/ButtonExample.js
@@ -14,9 +14,9 @@ const React = require('react');
 const ReactNative = require('react-native');
 const {Alert, Button, View} = ReactNative;
 
-const onButtonPress = () => {
-  Alert.alert('Button has been pressed!');
-};
+function onButtonPress(buttonName) {
+  Alert.alert(`${buttonName} has been pressed!`);
+}
 
 exports.displayName = 'ButtonExample';
 exports.framework = 'React';
@@ -33,7 +33,7 @@ exports.examples = [
     render: function() {
       return (
         <Button
-          onPress={onButtonPress}
+          onPress={() => onButtonPress('Simple')}
           title="Press Me"
           accessibilityLabel="See an informative alert"
         />
@@ -49,7 +49,7 @@ exports.examples = [
     render: function() {
       return (
         <Button
-          onPress={onButtonPress}
+          onPress={() => onButtonPress('Purple')}
           title="Press Purple"
           color="#841584"
           accessibilityLabel="Learn more about purple"
@@ -65,12 +65,12 @@ exports.examples = [
       return (
         <View style={{flexDirection: 'row', justifyContent: 'space-between'}}>
           <Button
-            onPress={onButtonPress}
+            onPress={() => onButtonPress('Left')}
             title="This looks great!"
             accessibilityLabel="This sounds great!"
           />
           <Button
-            onPress={onButtonPress}
+            onPress={() => onButtonPress('Right')}
             title="Ok!"
             color="#841584"
             accessibilityLabel="Ok, Great!"
@@ -86,7 +86,7 @@ exports.examples = [
       return (
         <Button
           disabled
-          onPress={onButtonPress}
+          onPress={() => onButtonPress('Disabled')}
           title="I Am Disabled"
           accessibilityLabel="See an informative alert"
         />

--- a/package.json
+++ b/package.json
@@ -137,7 +137,8 @@
     "test-android-all": "yarn run docker-build-android && yarn run test-android-run-unit && yarn run test-android-run-instrumentation && yarn run test-android-run-e2e",
     "test-android-instrumentation": "yarn run docker-build-android && yarn run test-android-run-instrumentation",
     "test-android-unit": "yarn run docker-build-android && yarn run test-android-run-unit",
-    "test-android-e2e": "yarn run docker-build-android && yarn run test-android-run-e2e"
+    "test-android-e2e": "yarn run docker-build-android && yarn run test-android-run-e2e",
+    "test-ios-e2e": "detox build -c ios.sim.release && detox test -c ios.sim.release --cleanup"
   },
   "bin": {
     "react-native": "local-cli/wrong-react-native.js"
@@ -203,6 +204,7 @@
     "async": "^2.4.0",
     "babel-eslint": "9.0.0-beta.2",
     "babel-generator": "^6.26.0",
+    "detox": "^8.0.0",
     "eslint": "5.1.0",
     "eslint-config-fb-strict": "22.1.0",
     "eslint-config-fbjs": "2.0.1",
@@ -220,5 +222,18 @@
     "react-test-renderer": "16.4.1",
     "shelljs": "^0.7.8",
     "sinon": "^2.2.0"
+  },
+  "detox": {
+    "test-runner": "jest",
+    "runner-config": "RNTester/e2e/config.json",
+    "specs": "RNTester/e2e",
+    "configurations": {
+      "ios.sim.release": {
+        "binaryPath": "RNTester/build/Build/Products/Release-iphonesimulator/RNTester.app/",
+        "build": "xcodebuild -project RNTester/RNTester.xcodeproj -scheme RNTester -configuration Release -sdk iphonesimulator -derivedDataPath RNTester/build",
+        "type": "ios.simulator",
+        "name": "iPhone 8"
+      }
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -138,7 +138,8 @@
     "test-android-instrumentation": "yarn run docker-build-android && yarn run test-android-run-instrumentation",
     "test-android-unit": "yarn run docker-build-android && yarn run test-android-run-unit",
     "test-android-e2e": "yarn run docker-build-android && yarn run test-android-run-e2e",
-    "test-ios-e2e": "detox build -c ios.sim.release && detox test -c ios.sim.release --cleanup"
+    "build-ios-e2e": "detox build -c ios.sim.release",
+    "test-ios-e2e": "detox test -c ios.sim.release --cleanup"
   },
   "bin": {
     "react-native": "local-cli/wrong-react-native.js"
@@ -230,7 +231,7 @@
     "configurations": {
       "ios.sim.release": {
         "binaryPath": "RNTester/build/Build/Products/Release-iphonesimulator/RNTester.app/",
-        "build": "xcodebuild -project RNTester/RNTester.xcodeproj -scheme RNTester -configuration Release -sdk iphonesimulator -derivedDataPath RNTester/build",
+        "build": "xcodebuild -project RNTester/RNTester.xcodeproj -scheme RNTester -configuration Release -sdk iphonesimulator -derivedDataPath RNTester/build -quiet",
         "type": "ios.simulator",
         "name": "iPhone 8"
       }


### PR DESCRIPTION
This PR adds initial setup for Detox E2E iOS and some tests for ButtonExample.

Test Plan:
----------
Circle CI should run this as a separate job, boot a Simulator, build RNTester iOS and run e2e.

Release Notes:
--------------
TBA

 [INTERNAL] [ENHANCEMENT] [CI] - MOAR TESTS!!!

