### PR TITLE
[GENERAL][BUGFIX] Add asyncToGenerator to babel polyfills

### DIFF
--- a/Libraries/polyfills/babelHelpers.js
+++ b/Libraries/polyfills/babelHelpers.js
@@ -604,3 +604,35 @@ function _iterableToArray(iter) {
 }
 
 babelHelpers.iterableToArray = _iterableToArray;
+
+function _asyncToGenerator(fn) {
+  return function () {
+    var gen = fn.apply(this, arguments);
+    return new Promise(function (resolve, reject) {
+      function step(key, arg) {
+        try {
+          var info = gen[key](arg);
+          var value = info.value;
+        } catch (error) {
+          reject(error);
+          return;
+        }
+
+        if (info.done) {
+          resolve(value);
+        } else {
+          return Promise.resolve(value).then(function (value) {
+            step("next", value);
+          }, function (err) {
+            step("throw", err);
+          });
+        }
+      }
+
+      return step("next");
+    });
+  };
+};
+
+
+babelHelpers.asyncToGenerator = _asyncToGenerator;


### PR DESCRIPTION
Fixes #4844
Fixes #12589
Among others

This adds the `asyncToGenerator` function to React Native's included Babel polyfills, in order to correct an error that causes some published apps to crash if it's not present.

As [previously noted](https://github.com/facebook/react-native/issues/4844#issuecomment-204035720), this is redundant with the use of `regenerator-transform`, and may be less performant. **Unfortunately, `asyncToGenerator` is required by a lot of third-party packages in the NPM ecosystem**, and a React Native consumer can't always just remove an offending plugin from their `.babelrc` to get their app working again.

This is an especially problematic issue because it can often crop up if some random sub-dependency unexpectedly changes the way it's transpiled. Apps in production can lose countless hours of debugging time trying to sort this out.

Until there's a better workaround for third-party packages that don't play nice with React Native's babel configuration, I feel that adding this polyfill is a necessary stopgap. Other solutions, such as adding it to `global.babelHelpers` in your app's entry point, don't seem to work.

Release Notes:
--------------
[GENERAL] [BUGFIX] [Libraries/polyfills/babelHelpers.js] - Adds asyncToGenerator polyfill for better third-party library compatibility 
