### PR TITLE
Update Readable/WritableNativeArray

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/ReadableNativeArray.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/ReadableNativeArray.java
@@ -32,6 +32,7 @@ public class ReadableNativeArray extends NativeArray implements ReadableArray {
   //WriteOnce but not in the constructor fields
   private @Nullable Object[] mLocalArray;
   private @Nullable ReadableType[] mLocalTypeArray;
+  protected boolean iUseNativeAccessor = false;
 
   private static int jniPassCounter = 0;
   private static boolean mUseNativeAccessor = false;
@@ -77,7 +78,7 @@ public class ReadableNativeArray extends NativeArray implements ReadableArray {
 
   @Override
   public int size() {
-    if (mUseNativeAccessor) {
+    if (mUseNativeAccessor || iUseNativeAccessor) {
       jniPassCounter++;
       return sizeNative();
     }
@@ -87,7 +88,7 @@ public class ReadableNativeArray extends NativeArray implements ReadableArray {
 
   @Override
   public boolean isNull(int index) {
-    if (mUseNativeAccessor) {
+    if (mUseNativeAccessor || iUseNativeAccessor) {
       jniPassCounter++;
       return isNullNative(index);
     }
@@ -97,7 +98,7 @@ public class ReadableNativeArray extends NativeArray implements ReadableArray {
 
   @Override
   public boolean getBoolean(int index) {
-    if (mUseNativeAccessor) {
+    if (mUseNativeAccessor || iUseNativeAccessor) {
       jniPassCounter++;
       return getBooleanNative(index);
     }
@@ -107,7 +108,7 @@ public class ReadableNativeArray extends NativeArray implements ReadableArray {
 
   @Override
   public double getDouble(int index) {
-    if (mUseNativeAccessor) {
+    if (mUseNativeAccessor || iUseNativeAccessor) {
       jniPassCounter++;
       return getDoubleNative(index);
     }
@@ -117,7 +118,7 @@ public class ReadableNativeArray extends NativeArray implements ReadableArray {
 
   @Override
   public int getInt(int index) {
-    if (mUseNativeAccessor) {
+    if (mUseNativeAccessor || iUseNativeAccessor) {
       jniPassCounter++;
       return getIntNative(index);
     }
@@ -127,7 +128,7 @@ public class ReadableNativeArray extends NativeArray implements ReadableArray {
 
   @Override
   public String getString(int index) {
-    if (mUseNativeAccessor) {
+    if (mUseNativeAccessor || iUseNativeAccessor) {
       jniPassCounter++;
       return getStringNative(index);
     }
@@ -137,7 +138,7 @@ public class ReadableNativeArray extends NativeArray implements ReadableArray {
 
   @Override
   public ReadableNativeArray getArray(int index) {
-    if (mUseNativeAccessor) {
+    if (mUseNativeAccessor || iUseNativeAccessor) {
       jniPassCounter++;
       return getArrayNative(index);
     }
@@ -147,7 +148,7 @@ public class ReadableNativeArray extends NativeArray implements ReadableArray {
 
   @Override
   public ReadableNativeMap getMap(int index) {
-    if (mUseNativeAccessor) {
+    if (mUseNativeAccessor || iUseNativeAccessor) {
       jniPassCounter++;
       return getMapNative(index);
     }
@@ -157,7 +158,7 @@ public class ReadableNativeArray extends NativeArray implements ReadableArray {
 
   @Override
   public ReadableType getType(int index) {
-    if (mUseNativeAccessor) {
+    if (mUseNativeAccessor || iUseNativeAccessor) {
       jniPassCounter++;
       return getTypeNative(index);
     }

--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/WritableNativeArray.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/WritableNativeArray.java
@@ -24,6 +24,8 @@ public class WritableNativeArray extends ReadableNativeArray implements Writable
 
   public WritableNativeArray() {
     super(initHybrid());
+
+    iUseNativeAccessor = true;
   }
 
   @Override


### PR DESCRIPTION
Fixes #20256 

`mUseNativeAccessor` is a static property of the ReadableNativeArray class. This fix works by introducing an instance variable `iUseNativeAccessor` which determines whether the instance should always make native accesses. The array will make native accesses if either  `mUseNativeAccessor` or `iUseNativeAccessor` is true. WriteableNativeArray then sets `iUseNativeAccessor` true in the constructor. 

The main problem I faced here is how to make the read methods read natively in the WriteableNativeArray subclass. You can't override variables/static variables. One option I explored was to create a method shouldUseNative which is overridable. However, I thought the performance hit would be too large from requiring a method invocation on every read.

Happy to put more work into fixing this. Let me know what the best way to do things is.

Test Plan:
----------
Re-ran https://github.com/skaplan/thirddebug/ which was used to reproduce the issue. Output is correct.

Release Notes:
--------------
Help reviewers and the release process by writing your own release notes. See below for an example.

[ANDROID] [BUGFIX] [WriteableNativeArray] - Fixed bug that cached reads don't respect new writes.