### PR TITLE
Android - decouple TextInput cursorColor from selectionColor

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
@@ -349,7 +349,8 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
     setCursorColor(view, color);
   }
 
-  private void setCursorColor(ReactEditText view, @Nullable Integer color) {
+  @ReactProp(name = "cursorColor", customType = "Color")
+  public void setCursorColor(ReactEditText view, @Nullable Integer color) {
     // Evil method that uses reflection because there is no public API to changes
     // the cursor color programmatically.
     // Based on http://stackoverflow.com/questions/25996032/how-to-change-programatically-edittext-cursor-color-in-android.


### PR DESCRIPTION

Basically I want my cursor to be the same color of the text. Which means obviously that selecting the text will make it invisibible (ie, red text on red selection rectangle)

Today, setting a selection color does set a cursor color, which may be a good default in some cases, but we don't always couple these 2 colors together.

See original commit of @janicduplessis https://github.com/facebook/react-native/commit/ae57b25134c4db8be8539a0f0e6e52d46c850339

I'd like to be able to set different colors for selection and cursor.


Test Plan:
----------

Not sure exactly this can be tested except manually. The initial commit did not introduce test for this method:
https://github.com/facebook/react-native/commit/ae57b25134c4db8be8539a0f0e6e52d46c850339

Release Notes:
--------------

[ANDROID] [ENHANCEMENT] [TextInput] - Allow to set cursor color independently from highlight color

