### PR TITLE
fix windows gradle bug

### DIFF
--- a/RNTester/android/app/build.gradle
+++ b/RNTester/android/app/build.gradle
@@ -62,7 +62,7 @@ project.ext.react = [
     bundleAssetName: "RNTesterApp.android.bundle",
     entryFile: file("../../js/RNTesterApp.android.js"),
     root: "$rootDir",
-    inputExcludes: ["android/**", "./**"]
+    inputExcludes: ["android/**", "./**", ".gradle/**"]
 ]
 
 apply from: "../../../react.gradle"


### PR DESCRIPTION
## Motivation
fix windows gradle bug, you can also see full log in https://ci.appveyor.com/project/gengjiawen/react-native/build/1.0.11/job/ic0nml8s4qbmni4e.
```
FAILURE: Build failed with an exception.

* What went wrong:
Failed to capture snapshot of input files for task ':RNTester:android:app:bundleReleaseJsAndAssets' property '$1' during up-to-date check.
> Failed to create MD5 hash for file content.

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org
```
Build success log: https://ci.appveyor.com/project/gengjiawen/react-native/build/1.0.12/job/xuaj8tm3p1piovbt.

## Test Plan
pass all current ci.
## Related PRs
https://github.com/facebook/react-native/pull/20281
## Release Notes
 [GENERAL] [INTERNAL] [RNTester] - fix windows gradle bug