### PR TITLE
Don't crash on second resolve or reject in PromiseImpl.

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/PromiseImpl.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/PromiseImpl.java
@@ -28,6 +28,8 @@ public class PromiseImpl implements Promise {
   public void resolve(Object value) {
     if (mResolve != null) {
       mResolve.invoke(value);
+      mResolve = null;
+      mReject = null;
     }
   }
 
@@ -67,5 +69,7 @@ public class PromiseImpl implements Promise {
       // TODO(8850038): add the stack trace info in, need to figure out way to serialize that
       mReject.invoke(errorInfo);
     }
+    mResolve = null;
+    mReject = null;
   }
 }


### PR DESCRIPTION
Promise semantics per JS should allow calling resolve or reject repeatedly without crashing. Only the first one should do anything, but others should be allowed. This change fixes the Java bridge for Android. A separate change is needed for iOS.

Issue #20262 

Test Plan:
----------
Where are the bridge tests?

Make a @ReactMethod that takes a Promise. Call promise.resolve() twice.

Release Notes:

--------------
[ANDROID] [BUGFIX] [Bridge] - Ignore resolve or reject calls on bridge Promises in Java.

<!--
  **INTERNAL and MINOR tagged notes will not be included in the next version's final release notes.**

    CATEGORY
  [----------]      TYPE
  [ CLI      ] [-------------]    LOCATION
  [ DOCS     ] [ BREAKING    ] [-------------]
  [ GENERAL  ] [ BUGFIX      ] [ {Component} ]
  [ INTERNAL ] [ ENHANCEMENT ] [ {Filename}  ]
  [ IOS      ] [ FEATURE     ] [ {Directory} ]   |-----------|
  [ ANDROID  ] [ MINOR       ] [ {Framework} ] - | {Message} |
  [----------] [-------------] [-------------]   |-----------|

 EXAMPLES:

 [IOS] [BREAKING] [FlatList] - Change a thing that breaks other things
 [ANDROID] [BUGFIX] [TextInput] - Did a thing to TextInput
 [CLI] [FEATURE] [local-cli/info/info.js] - CLI easier to do things with
 [DOCS] [BUGFIX] [GettingStarted.md] - Accidentally a thing/word
 [GENERAL] [ENHANCEMENT] [Yoga] - Added new yoga thing/position
 [INTERNAL] [FEATURE] [./scripts] - Added thing to script that nobody will see
-->
