### PR TITLE
Fix multiple calls to onMomentumScrollEnd when interrupted by dragging on Android

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
@@ -194,6 +194,8 @@ public class ReactScrollView extends ScrollView implements ReactClippingViewGrou
         NativeGestureUtil.notifyNativeGestureStarted(this, ev);
         ReactScrollViewHelper.emitScrollBeginDragEvent(this);
         mDragging = true;
+        mFlinging = false;
+        mDoneFlinging = false;
         enableFpsListener();
         return true;
       }
@@ -300,6 +302,11 @@ public class ReactScrollView extends ScrollView implements ReactClippingViewGrou
       Runnable r = new Runnable() {
         @Override
         public void run() {
+          // It's possible the fling was interrupted by the user.
+          if (!mFlinging) {
+            return;
+          }
+
           if (mDoneFlinging) {
             mFlinging = false;
             disableFpsListener();


### PR DESCRIPTION
Fixes #18568.

Interrupting a momentum scroll by dragging will incorrectly fire two `onMomentumScrollEnd` events, both of which happen too early. This can be fixed by stopping the fling when the user starts dragging again and checking whether the fling is still going on in the runnable that eventually detects when a fling has ended.

Test Plan:
----------

The original issue #18568 has a test case and very helpful instructions on how to replicate the issue. Thanks @AbdallaMohamed!

Release Notes:
--------------

[ANDROID] [BUGFIX] [ScrollView] - ScrollView no longer calls onMomentumScrollEnd twice and too early when a momentum scroll is interrupted by dragging on Android.

<!--
  **INTERNAL and MINOR tagged notes will not be included in the next version's final release notes.**

    CATEGORY
  [----------]      TYPE
  [ CLI      ] [-------------]    LOCATION
  [ DOCS     ] [ BREAKING    ] [-------------]
  [ GENERAL  ] [ BUGFIX      ] [ {Component} ]
  [ INTERNAL ] [ ENHANCEMENT ] [ {Filename}  ]
  [ IOS      ] [ FEATURE     ] [ {Directory} ]   |-----------|
  [ ANDROID  ] [ MINOR       ] [ {Framework} ] - | {Message} |
  [----------] [-------------] [-------------]   |-----------|

 EXAMPLES:

 [IOS] [BREAKING] [FlatList] - Change a thing that breaks other things
 [ANDROID] [BUGFIX] [TextInput] - Did a thing to TextInput
 [CLI] [FEATURE] [local-cli/info/info.js] - CLI easier to do things with
 [DOCS] [BUGFIX] [GettingStarted.md] - Accidentally a thing/word
 [GENERAL] [ENHANCEMENT] [Yoga] - Added new yoga thing/position
 [INTERNAL] [FEATURE] [./scripts] - Added thing to script that nobody will see
-->
