### PR TITLE
Un-deprecate TextInput.State.focusTextInput and TextInput.State.blurTextInput

### DIFF
--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -326,18 +326,8 @@ const TextInput = createReactClass({
   statics: {
     State: {
       currentlyFocusedField: TextInputState.currentlyFocusedField,
-      focusTextInput: (textFieldID: ?number) => {
-        console.warn(
-          '`focusTextInput` is deprecated, use the `focus` method of the `TextInput` ref instead.',
-        );
-        TextInputState.focusTextInput(textFieldID);
-      },
-      blurTextInput: (textFieldID: ?number) => {
-        console.warn(
-          '`blurTextInput` is deprecated, use `Keyboard.dismiss` or the `blur` method of the `TextInput` ref.',
-        );
-        TextInputState.blurTextInput(textFieldID);
-      },
+      focusTextInput: TextInputState.focusTextInput,
+      blurTextInput: TextInputState.blurTextInput,
     },
   },
   propTypes: {


### PR DESCRIPTION
In https://github.com/facebook/react-native/pull/18936 we decided to deprecate `focusTextInput` and `blurTextInput` but since then I found a valid use case for it that is pretty much impossible to implement otherwise.

React Navigation uses it to blur / re-focus the input during the swipe back gesture. Blur can be done with Keyboard.dismiss but without this api we cannot re-focus the text field that was focused if the swipe back gesture is cancelled. See https://github.com/react-navigation/react-navigation/blob/master/src/navigators/createKeyboardAwareNavigator.js#L21-L34

I think it is best to just bring back this api.

Test Plan:
----------
Tested that the warning is now gone and that keyboard dismissal / re-open works properly in an app that uses react-navigation.

Release Notes:
--------------
[GENERAL] [ENHANCEMENT] [TextInput] - Un-deprecate TextInput.State.focusTextInput and TextInput.State.blurTextInput