### PR TITLE
textInput: Fix placeholder is not completely visible on Android.

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputLocalData.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputLocalData.java
@@ -21,11 +21,13 @@ public final class ReactTextInputLocalData {
   private final int mMaxLines;
   private final int mInputType;
   private final int mBreakStrategy;
+  private final  CharSequence mPlaceholder;
 
   public ReactTextInputLocalData(EditText editText) {
     mText = new SpannableStringBuilder(editText.getText());
     mTextSize = editText.getTextSize();
     mInputType = editText.getInputType();
+    mPlaceholder = editText.getHint();
 
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
       mMinLines = editText.getMinLines();
@@ -48,6 +50,7 @@ public final class ReactTextInputLocalData {
     editText.setMinLines(mMinLines);
     editText.setMaxLines(mMaxLines);
     editText.setInputType(mInputType);
+    editText.setHint(mPlaceholder);
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
       editText.setBreakStrategy(mBreakStrategy);
     }


### PR DESCRIPTION
## Motivation
On Android, placeholder of TextInput is not completely visible.
TextInput had some default fixed width. On iOS it is perfectly
visible.

This commit makes it consistent on both the platforms.

Before:
https://user-images.githubusercontent.com/39303760/43045649-54cb45e8-8dda-11e8-9935-059ad8ee9def.png

After:
https://user-images.githubusercontent.com/39303760/43045650-54fb9428-8dda-11e8-88b8-176839d6c0a7.png

Testing code:
https://github.com/jainkuniya/TestTextInput/blob/a0a6fbb491e979fe7cc9d0a580d67790b3481eb8/App.js


## Test Plan
Clone code from https://github.com/jainkuniya/TestTextInput/blob/a0a6fbb491e979fe7cc9d0a580d67790b3481eb8/App.js and test on Android with and without this commit.

Before:
https://user-images.githubusercontent.com/39303760/43045649-54cb45e8-8dda-11e8-9935-059ad8ee9def.png

After:
https://user-images.githubusercontent.com/39303760/43045650-54fb9428-8dda-11e8-88b8-176839d6c0a7.png


## Release Notes
 [ANDROID] [BUGFIX] [TextInput] - Fix placeholder is not completely visible on Android.
