### PR TITLE
android: Make minWidth of TextInput 0 like iOS.

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputLocalData.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputLocalData.java
@@ -7,6 +7,7 @@
 
 package com.facebook.react.views.textinput;
 
+import android.graphics.Color;
 import android.os.Build;
 import android.text.SpannableStringBuilder;
 import android.util.TypedValue;
@@ -48,6 +49,7 @@ public final class ReactTextInputLocalData {
     editText.setMinLines(mMinLines);
     editText.setMaxLines(mMaxLines);
     editText.setInputType(mInputType);
+    editText.setBackgroundColor(Color.TRANSPARENT);
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
       editText.setBreakStrategy(mBreakStrategy);
     }


### PR DESCRIPTION
## Motivation

Currenlty TextInput on Android has some default minWidth, but on iOS
it is 0. So this commit makes TextInput width consistent on both the
platform.

On Android, if no text is present and no placeholder is provided, it's
width is 0 (assuming padding: 0 style is applied). But as soon as a
single char is entered in the input, it width becomes more than that
of char. It is no more WRAP_CONTENT. This commit fixes it.

Note: Setting backgroundColor has no affect on TextInput background
color, as background color is handled by backgroundManger.

Before:
https://user-images.githubusercontent.com/39303760/43045548-252fae7a-8dd8-11e8-8948-bb37c2b0689e.png

After:
https://user-images.githubusercontent.com/39303760/43045549-255c3bac-8dd8-11e8-8b12-30f413777544.png

Testing code:
https://github.com/jainkuniya/TestTextInput/blob/3bd6d6621d20bb6f13ede84e63e6948963febc9b/App.js

## Test Plan
Clone code from https://github.com/jainkuniya/TestTextInput/blob/3bd6d6621d20bb6f13ede84e63e6948963febc9b/App.js and test on Android with and without this commit.

Before:
https://user-images.githubusercontent.com/39303760/43045548-252fae7a-8dd8-11e8-8948-bb37c2b0689e.png

After:
https://user-images.githubusercontent.com/39303760/43045549-255c3bac-8dd8-11e8-8b12-30f413777544.png



## Release Notes
 [ANDROID] [BUGFIX] [TextInput] - Make minWidth of TextInput 0 like iOS.
