### PR TITLE
Whitelist react-native-dom in haste/cli config defaults

### DIFF
--- a/jest/hasteImpl.js
+++ b/jest/hasteImpl.js
@@ -15,6 +15,7 @@ const path = require('path');
 const ROOTS = [
   path.resolve(__dirname, '..') + path.sep,
   path.resolve(__dirname, '../../react-native-windows') + path.sep,
+  path.resolve(__dirname, '../../react-native-dom') + path.sep,
 ];
 
 const BLACKLISTED_PATTERNS /*: Array<RegExp> */ = [
@@ -36,7 +37,7 @@ const NAME_REDUCERS /*: Array<[RegExp, string]> */ = [
   // strip .js/.js.flow suffix
   [/^(.*)\.js(\.flow)?$/, '$1'],
   // strip .android/.ios/.native/.web suffix
-  [/^(.*)\.(android|ios|native|web|windows)$/, '$1'],
+  [/^(.*)\.(android|ios|native|web|windows|dom)$/, '$1'],
 ];
 
 const haste = {

--- a/local-cli/core/index.js
+++ b/local-cli/core/index.js
@@ -70,11 +70,11 @@ const defaultConfig = {
   hasteImplModulePath: require.resolve('../../jest/hasteImpl'),
 
   getPlatforms(): Array<string> {
-    return ['ios', 'android', 'windows', 'web'];
+    return ['ios', 'android', 'windows', 'web', 'dom'];
   },
 
   getProvidesModuleNodeModules(): Array<string> {
-    return ['react-native', 'react-native-windows'];
+    return ['react-native', 'react-native-windows', 'react-native-dom'];
   },
 };
 


### PR DESCRIPTION
This adds `react-native-dom` to `hasteImpl.js` because it's not currently possible to configure it from an out of tree platform. Also adds the relevant `providesModuleNodeModules` and `platforms` values to the default RN CLI config. This should hopefully be able to be removed once better support for out of tree platforms is implemented.

Test Plan:
----------

Confirmed that the updated config correctly builds an RNDom project by pulling my fork as a dependency (though it required some other changes for some unrelated `local-cli` issues).

Release Notes:
--------------
Help reviewers and the release process by writing your own release notes. See below for an example.

[CLI] [ENHANCEMENT] [jest/hasteImpl.js] - Whitelist react-native-dom in haste/cli config defaults