### PR TITLE
Add extra flowtype stubs for metro

### DIFF
--- a/flow-github/metro.js
+++ b/flow-github/metro.js
@@ -27,3 +27,39 @@ declare module 'metro/src/lib/bundle-modules/HMRClient' {
 declare module 'metro/src/lib/TerminalReporter' {
   declare module.exports: any;
 }
+
+declare module 'metro/src/Bundler' {
+  declare module.exports: any;
+}
+
+declare module 'metro/src/DeltaBundler' {
+  declare module.exports: any;
+}
+
+declare module 'metro/src/ModuleGraph/types.flow.js' {
+  declare module.exports: any;
+}
+
+declare module 'metro/src/lib/getMaxWorkers' {
+  declare module.exports: any;
+}
+
+declare module 'metro/src/lib/createModuleIdFactory' {
+  declare module.exports: any;
+}
+
+declare module 'metro/src/shared/types.flow' {
+  declare module.exports: any;
+}
+
+declare module 'metro/src/lib/reporting' {
+  declare module.exports: any;
+}
+
+declare module 'metro/src/Server' {
+  declare module.exports: any;
+}
+
+declare module 'metro/src/ModuleGraph/worker/collectDependencies' {
+  declare module.exports: any;
+}

--- a/local-cli/core/index.js
+++ b/local-cli/core/index.js
@@ -129,7 +129,9 @@ const defaultRNConfig = {
  */
 async function getCliConfig(): Promise<RNConfig> {
   const cliArgs = minimist(process.argv.slice(2));
-  const config = await Config.load(path.resolve(__dirname, cliArgs.config));
+  const config = await Config.load(
+    cliArgs.config != null ? path.resolve(__dirname, cliArgs.config) : null,
+  );
 
   config.transformer.assetRegistryPath = ASSET_REGISTRY_PATH;
   config.resolver.hasteImplModulePath = defaultConfig.hasteImplModulePath;

--- a/local-cli/util/Config.js
+++ b/local-cli/util/Config.js
@@ -84,8 +84,10 @@ const Config = {
   getProjectPath,
   getProjectRoots,
 
-  async load(configFile: string): Promise<ConfigT> {
-    const config: ConfigT = await loadConfig({config: configFile});
+  async load(configFile: ?string): Promise<ConfigT> {
+    const config: ConfigT = await loadConfig(
+      configFile ? {config: configFile} : {},
+    );
 
     return mergeConfig(config, this.DEFAULT);
   },


### PR DESCRIPTION
We ignore some `metro` flowtypes, which made `flow check` fail on `metro-config`. I now also added the `metro` stubs needed by `metro-config` to make `flow check` pass.

Test Plan:
----------
`flow check`

