### PR TITLE
Fix for crash when height or width is nil

### DIFF
--- a/Libraries/CameraRoll/RCTImagePickerManager.m
+++ b/Libraries/CameraRoll/RCTImagePickerManager.m
@@ -123,7 +123,7 @@ didFinishPickingMediaWithInfo:(NSDictionary<NSString *, id> *)info
   // WARNING: Using ImageStoreManager may cause a memory leak because the
   // image isn't automatically removed from store once we're done using it.
   [_bridge.imageStoreManager storeImage:originalImage withBlock:^(NSString *tempImageTag) {
-    [self _dismissPicker:picker args:tempImageTag ? @[tempImageTag, height, width] : nil];
+    [self _dismissPicker:picker args:tempImageTag ? @[tempImageTag, RCTNullIfNil(height), RCTNullIfNil(width)] : nil];
   }];
 }
 


### PR DESCRIPTION
This PR fixes the issue of height/width being nil in line no 128 of RCTImagePickerManager.m . 
`    [self _dismissPicker:picker args:tempImageTag ? @[tempImageTag, height, width] : nil];
`
Fixes#20411

Test Plan 
----------
To verify the fix , please make the changes to make either height, width or both `nil `
 in `- (void)imagePickerController:(UIImagePickerController *)picker
didFinishPickingMediaWithInfo:(NSDictionary<NSString *, id> *)info` function of RCTImagePickerManager.m , run the code , you will see the error saying , one of the argument is nil from the array .

![crashscenario](https://user-images.githubusercontent.com/763696/43397014-133ae8fc-9421-11e8-9730-c5906cb8dbea.png)

![crashhandledscenario](https://user-images.githubusercontent.com/763696/43397012-130e42f2-9421-11e8-80fc-cb1abaf8197c.png)

Now run the code with the fix , it will not crash .  

Release Notes:
--------------
[IOS][BUGFIX][RCTImagePickerManager] - Change in RCTImagePickerManager to handle crashes if height/width is nil .


