### PR TITLE
Check if child view != null before dropping. Fixes #20288

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeViewHierarchyManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeViewHierarchyManager.java
@@ -570,7 +570,7 @@ public class NativeViewHierarchyManager {
       ViewGroupManager viewGroupManager = (ViewGroupManager) viewManager;
       for (int i = viewGroupManager.getChildCount(viewGroup) - 1; i >= 0; i--) {
         View child = viewGroupManager.getChildAt(viewGroup, i);
-        if (mTagsToViews.get(child.getId()) != null) {
+        if (child != null && mTagsToViews.get(child.getId()) != null) {
           dropView(child);
         }
       }


### PR DESCRIPTION
Fixes our top crash when framework try drop a view from parent, but it's a null (already removed etc.).

Fixes #20288 

Test Plan:
----------
No test plan, crashes happen rarely and very hard to reproduce.

Release Notes:
--------------
[ANDROID] [BUGFIX] [NativeViewHierarchyManager.java] - Fixes crash when trying to drop null child view

