### PR TITLE
Force version of build tools and compile SDK from root project on all android modules

### DIFF
--- a/local-cli/templates/HelloWorld/android/build.gradle
+++ b/local-cli/templates/HelloWorld/android/build.gradle
@@ -38,3 +38,14 @@ ext {
     targetSdkVersion = 26
     supportLibVersion = "26.1.0"
 }
+
+subprojects { subproject ->
+    afterEvaluate {
+        if ((subproject.plugins.hasPlugin('android') || subproject.plugins.hasPlugin('android-library'))) {
+            android {
+                compileSdkVersion rootProject.ext.compileSdkVersion
+                buildToolsVersion rootProject.ext.buildToolsVersion
+            }
+        }
+    }
+}


### PR DESCRIPTION
It resolves all those:
```
Error:The SDK Build Tools revision (??.?.?) is too low for project ‘:(…) Minimum required is 25.0.0
```
by forcing the same version of build tools and compile SDK on all android modules.

Almost all native android modules will not compile on rn 0.56 because buildToolsVersion and
compileSdkVersion were updated and what most packages have is too low.

Test Plan:
----------
You can add any native module that haven't been updated after rn 0.56 ie. `react-native-config@0.11.5` and try to run on android. It'll error with `The SDK Build Tools revision (...)` message. Adding changes proposed in this PR to your `build.gradle` will fix that.

Release Notes:
--------------
[ANDROID] [ENHANCEMENT] [build.gradle] - force version of build tools and compile SDK from root project on android modules