### PR TITLE
Enable nullish coalescing in flow config

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -41,6 +41,7 @@ flow-github/
 emoji=true
 
 esproposal.optional_chaining=enable
+esproposal.nullish_coalescing=enable
 
 module.system=haste
 module.system.haste.use_name_reducers=true


### PR DESCRIPTION
Follow up to a9792ac4c8ee04f9832a99e95e1afebbb568d230. I assume it's enabled for fb flow config so we can avoid future breakages if someone decide to use this syntax.

Test Plan:
----------
Flow passed on CI

Release Notes:
--------------
[INTERNAL] [ENHANCEMENT] [flowconfig] - Enable nullish coalescing in flow config