### PR TITLE
Enable optional chaining and nullish coalescing in flowconfig template

### DIFF
--- a/local-cli/templates/HelloWorld/_flowconfig
+++ b/local-cli/templates/HelloWorld/_flowconfig
@@ -29,6 +29,9 @@ node_modules/react-native/flow-github/
 [options]
 emoji=true
 
+esproposal.optional_chaining=enable
+esproposal.nullish_coalescing=enable
+
 module.system=haste
 module.system.haste.use_name_reducers=true
 # get basename


### PR DESCRIPTION
Follow up to a9792ac4c8ee04f9832a99e95e1afebbb568d230 and #20516

This makes sure new projects typecheck properly since RN can use this syntax.

Test Plan:
----------
N/A trivial

Release Notes:
--------------
[CLI] [ENHANCEMENT] [flowconfig] - Enable optional chaining and nullish coalescing in flowconfig template