### PR TITLE
Update docs on splitting APKs

### DIFF
--- a/docs/signed-apk-android.md
+++ b/docs/signed-apk-android.md
@@ -103,6 +103,9 @@ By default, the generated APK has the native code for both x86 and ARMv7a CPU ar
 
 You can create an APK for each CPU by changing the following line in android/app/build.gradle:
 ``` diff
+- ndk {
+-   abiFilters "armeabi-v7a", "x86"
+- }
 - def enableSeparateBuildPerCPUArchitecture = false
 + def enableSeparateBuildPerCPUArchitecture = true
 ```


### PR DESCRIPTION
Gradle v3.1 complains about conflicting configuration as below

<pre>
Conflicting configuration : 'armeabi-v7a,x86' in ndk abiFilters cannot be present when splits abi filters are set : x86,armeabi-v7a
</pre>

Release Notes:
--------------
[ DOCS][MINOR][signed-apk-android.md] - Improve docs on splitting APKs for newer version of gradle
<!--
  **INTERNAL and MINOR tagged notes will not be included in the next version's final release notes.**

    CATEGORY
  [----------]      TYPE
  [ CLI      ] [-------------]    LOCATION
  [ DOCS     ] [ BREAKING    ] [-------------]
  [ GENERAL  ] [ BUGFIX      ] [ {Component} ]
  [ INTERNAL ] [ ENHANCEMENT ] [ {Filename}  ]
  [ IOS      ] [ FEATURE     ] [ {Directory} ]   |-----------|
  [ ANDROID  ] [ MINOR       ] [ {Framework} ] - | {Message} |
  [----------] [-------------] [-------------]   |-----------|

 EXAMPLES:

 [IOS] [BREAKING] [FlatList] - Change a thing that breaks other things
 [ANDROID] [BUGFIX] [TextInput] - Did a thing to TextInput
 [CLI] [FEATURE] [local-cli/info/info.js] - CLI easier to do things with
 [DOCS] [BUGFIX] [GettingStarted.md] - Accidentally a thing/word
 [GENERAL] [ENHANCEMENT] [Yoga] - Added new yoga thing/position
 [INTERNAL] [FEATURE] [./scripts] - Added thing to script that nobody will see
-->
