### PR TITLE
Remove newLayout check when begin layout calculation && fix comment of RCTShadowView

### DIFF
--- a/React/Views/RCTShadowView.h
+++ b/React/Views/RCTShadowView.h
@@ -22,7 +22,7 @@ typedef void (^RCTApplierBlock)(NSDictionary<NSNumber *, UIView *> *viewRegistry
  * 1. A node is in one of three lifecycles: uninitialized, computed, dirtied.
  * 1. RCTBridge may call any of the padding/margin/width/height/top/left setters. A setter would dirty
  *    the node and all of its ancestors.
- * 2. At the end of each Bridge transaction, we call collectUpdatedFrames:widthConstraint:heightConstraint
+ * 2. At the end of each Bridge transaction, we call layoutWithMinimumSize:maximumSize:layoutDirection:layoutContext
  *    at the root node to recursively lay out the entire hierarchy.
  * 3. If a node is "computed" and the constraint passed from above is identical to the constraint used to
  *    perform the last computation, we skip laying out the subtree entirely.

--- a/React/Views/RCTShadowView.m
+++ b/React/Views/RCTShadowView.m
@@ -281,10 +281,6 @@ static void RCTProcessMetaPropsBorder(const YGValue metaProps[META_PROP_COUNT], 
 
   RCTAssert(!YGNodeIsDirty(yogaNode), @"Attempt to get layout metrics from dirtied Yoga node.");
 
-  if (!YGNodeGetHasNewLayout(yogaNode)) {
-    return;
-  }
-
   YGNodeSetHasNewLayout(yogaNode, false);
 
   RCTLayoutMetrics layoutMetrics = RCTLayoutMetricsFromYogaNode(yogaNode);


### PR DESCRIPTION
1.  Please see [layout calculate](https://github.com/facebook/react-native/blob/73d57461229ebb398af769883bf994801943ceca/React/Views/RCTShadowView.m#L275), it would forcedly set `hasNewLayout` of `yogaNode` to `true`. So we only need to reset it, don't need to check again.
2. We have removed `collectUpdatedProperties:parentProperties:` from this [commit](https://github.com/facebook/react-native/commit/0f9fc4b2953d52fa1754e786dc5c74bfecbeaaca) and give these states all to `Yoga`.

Test Plan:
----------
Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!
Please see [layout calculate](https://github.com/facebook/react-native/blob/73d57461229ebb398af769883bf994801943ceca/React/Views/RCTShadowView.m#L275), it would forcedly set `hasNewLayout` of `yogaNode` to `true`. So we only need to reset it, don't need to check again.

Release Notes:
--------------

[IOS][ENHANCEMENT][RCTShadowView] - Remove unnecessary newLayout check