### PR TITLE
Ignore DevDependencies when generating template.

### DIFF
--- a/local-cli/generator/templates.js
+++ b/local-cli/generator/templates.js
@@ -171,7 +171,7 @@ function createFromRemoteTemplate(
       // only for publishing the template to npm.
       // We want to ignore this dummy file, otherwise it would overwrite
       // our project's package.json file.
-      ignorePaths: ['package.json', 'dependencies.json'],
+      ignorePaths: ['package.json', 'dependencies.json','devDependencies.json'],
     });
     installTemplateDependencies(templatePath, yarnVersion);
     installTemplateDevDependencies(templatePath, yarnVersion);


### PR DESCRIPTION
Regarding [Add devDependenices support for templates](https://github.com/facebook/react-native/commit/c4ab03a18e75e6ed55444b5d86f3ceee435b9a78).

Once a project is created using the custom template command with devDependencies inside, the devDependenices.json file is also copied to the new projects directory. 

By adding this to the ignore paths we stop the devDependenices being copied into the new projects directory.

Test Plan:
----------
In [react-native-cli/index.js] i updated the CLI_MODULE_PATH to direct to: "../local-cli/cli.js" Then ran `node react-native/react-native-cli init <ProjectName> --template https://github.com/mediamonks/react-native-template-mediamonks `

Release Notes:
--------------
Help reviewers and the release process by writing your own release notes. See below for an example.

 [CLI] [MINOR] [local-cli/generator/templates.js] - Add devDependencies.json to ignorePaths

<!--
  **INTERNAL and MINOR tagged notes will not be included in the next version's final release notes.**

    CATEGORY
  [----------]      TYPE
  [ CLI      ] [-------------]    LOCATION
  [ DOCS     ] [ BREAKING    ] [-------------]
  [ GENERAL  ] [ BUGFIX      ] [ {Component} ]
  [ INTERNAL ] [ ENHANCEMENT ] [ {Filename}  ]
  [ IOS      ] [ FEATURE     ] [ {Directory} ]   |-----------|
  [ ANDROID  ] [ MINOR       ] [ {Framework} ] - | {Message} |
  [----------] [-------------] [-------------]   |-----------|

 EXAMPLES:

 [IOS] [BREAKING] [FlatList] - Change a thing that breaks other things
 [ANDROID] [BUGFIX] [TextInput] - Did a thing to TextInput
 [DOCS] [BUGFIX] [GettingStarted.md] - Accidentally a thing/word
 [GENERAL] [ENHANCEMENT] [Yoga] - Added new yoga thing/position
 [INTERNAL] [FEATURE] [./scripts] - Added thing to script that nobody will see
-->