### PR TITLE
Generate ip.txt before SKIP_BUNDLING check

### DIFF
--- a/scripts/react-native-xcode.sh
+++ b/scripts/react-native-xcode.sh
@@ -8,6 +8,20 @@
 # This script is supposed to be invoked as part of Xcode build process
 # and relies on environment variables (including PWD) set by Xcode
 
+# Print commands before executing them (useful for troubleshooting)
+set -x
+DEST=$CONFIGURATION_BUILD_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH
+
+# Enables iOS devices to get the IP address of the machine running Metro Bundler
+if [[ "$CONFIGURATION" = *Debug* && ! "$PLATFORM_NAME" == *simulator ]]; then
+  IP=$(ipconfig getifaddr en0)
+  if [ -z "$IP" ]; then
+    IP=$(ifconfig | grep 'inet ' | grep -v ' 127.' | cut -d\   -f2  | awk 'NR==1{print $1}')
+  fi
+
+  echo "$IP" > "$DEST/ip.txt"
+fi
+
 if [[ "$SKIP_BUNDLING" ]]; then
   echo "SKIP_BUNDLING enabled; skipping."
   exit 0;
@@ -89,19 +103,6 @@ nodejs_not_found()
 }
 
 type $NODE_BINARY >/dev/null 2>&1 || nodejs_not_found
-
-# Print commands before executing them (useful for troubleshooting)
-set -x
-DEST=$CONFIGURATION_BUILD_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH
-
-if [[ "$CONFIGURATION" = *Debug* && ! "$PLATFORM_NAME" == *simulator ]]; then
-  IP=$(ipconfig getifaddr en0)
-  if [ -z "$IP" ]; then
-    IP=$(ifconfig | grep 'inet ' | grep -v ' 127.' | cut -d\   -f2  | awk 'NR==1{print $1}')
-  fi
-
-  echo "$IP" > "$DEST/ip.txt"
-fi
 
 BUNDLE_FILE="$DEST/main.jsbundle"
 


### PR DESCRIPTION
Fixes #20553. 

Re-applies the change as described in https://github.com/facebook/react-native/pull/16533, which was closed for being stale. Thanks to @emusgrave for the original PR/change.

Test Plan:
----------
1. Ensure build directory clean
2. Run a debug build targeting a physical iOS device
3. Verify application loads JS bundle via a packager URL, and does not attempt to load a local pre-packaged JS bundle

Release Notes:
--------------
Help reviewers and the release process by writing your own release notes. See below for an example.

[INTERNAL] [BUGFIX] [./scripts] - Enable physical devices to still load from packager when SKIP_BUNDLING is set for clean Debug builds

<!--
  **INTERNAL and MINOR tagged notes will not be included in the next version's final release notes.**

    CATEGORY
  [----------]      TYPE
  [ CLI      ] [-------------]    LOCATION
  [ DOCS     ] [ BREAKING    ] [-------------]
  [ GENERAL  ] [ BUGFIX      ] [ {Component} ]
  [ INTERNAL ] [ ENHANCEMENT ] [ {Filename}  ]
  [ IOS      ] [ FEATURE     ] [ {Directory} ]   |-----------|
  [ ANDROID  ] [ MINOR       ] [ {Framework} ] - | {Message} |
  [----------] [-------------] [-------------]   |-----------|

 EXAMPLES:

 [IOS] [BREAKING] [FlatList] - Change a thing that breaks other things
 [ANDROID] [BUGFIX] [TextInput] - Did a thing to TextInput
 [CLI] [FEATURE] [local-cli/info/info.js] - CLI easier to do things with
 [DOCS] [BUGFIX] [GettingStarted.md] - Accidentally a thing/word
 [GENERAL] [ENHANCEMENT] [Yoga] - Added new yoga thing/position
 [INTERNAL] [FEATURE] [./scripts] - Added thing to script that nobody will see
-->
