### PR TITLE
improve contrast ratio in debugger-ui dark mode

### DIFF
--- a/local-cli/server/util/debugger-ui/index.html
+++ b/local-cli/server/util/debugger-ui/index.html
@@ -247,10 +247,10 @@
   }
   body.dark {
     background-color: #242424;
-    color: #666;
+    color: #afafaf;
   }
   .dark .shortcut {
-    color: #777;
+    color: #c1c1c1;
   }
   .dark a {
     color: #3b99fc;


### PR DESCRIPTION
The font colors in the debugger-ui dark mode are not accessible. This PR ensures [Level AAA Conformance to Web Content Accessibility Guidelines 2.0](https://www.w3.org/WAI/WCAG2AAA-Conformance) which makes it better to read for everyone.

Test Plan:
----------
No tests needed, CSS changes only.

Release Notes:
--------------

[GENERAL][ENHANCEMENT][./local-cli/server/util/debugger-ui/index.html] improve contrast ratio in debugger-ui dark mode