### PR TITLE
add new config resetBeforeIteration for Animated.loop

### DIFF
--- a/Libraries/Animated/src/AnimatedImplementation.js
+++ b/Libraries/Animated/src/AnimatedImplementation.js
@@ -419,7 +419,7 @@ const stagger = function(
 
 type LoopAnimationConfig = {
   iterations: number,
-  resetBeforeIteratios: boolean,
+  resetBeforeIteration: boolean,
 };
 
 const loop = function(

--- a/Libraries/Animated/src/AnimatedImplementation.js
+++ b/Libraries/Animated/src/AnimatedImplementation.js
@@ -417,11 +417,14 @@ const stagger = function(
   );
 };
 
-type LoopAnimationConfig = {iterations: number};
+type LoopAnimationConfig = {
+  iterations: number,
+  resetBeforeIteratios: boolean,
+};
 
 const loop = function(
   animation: CompositeAnimation,
-  {iterations = -1}: LoopAnimationConfig = {},
+  {iterations = -1, resetBeforeIteration = true}: LoopAnimationConfig = {},
 ): CompositeAnimation {
   let isFinished = false;
   let iterationsSoFar = 0;
@@ -436,7 +439,7 @@ const loop = function(
           callback && callback(result);
         } else {
           iterationsSoFar++;
-          animation.reset();
+          resetBeforeIteration && animation.reset();
           animation.start(restart);
         }
       };

--- a/Libraries/Animated/src/__tests__/Animated-test.js
+++ b/Libraries/Animated/src/__tests__/Animated-test.js
@@ -443,6 +443,37 @@ describe('Animated tests', () => {
     });
   });
 
+  it('does not reset animation in a loop if resetBeforeIteration is false', () => {
+    const animation = {
+      start: jest.fn(),
+      reset: jest.fn(),
+      _isUsingNativeDriver: () => false,
+    };
+    const cb = jest.fn();
+
+    const loop = Animated.loop(animation, {resetBeforeIteration: false});
+
+    expect(animation.start).not.toBeCalled();
+
+    loop.start(cb);
+
+    expect(animation.start).toBeCalled();
+    expect(animation.reset).not.toBeCalled();
+    expect(cb).not.toBeCalled();
+
+    animation.start.mock.calls[0][0]({finished: true}); // End of loop 1
+    expect(animation.reset).not.toBeCalled();
+    expect(cb).not.toBeCalled();
+
+    animation.start.mock.calls[0][0]({finished: true}); // End of loop 2
+    expect(animation.reset).not.toBeCalled();
+    expect(cb).not.toBeCalled();
+
+    animation.start.mock.calls[0][0]({finished: true}); // End of loop 3
+    expect(animation.reset).not.toBeCalled();
+    expect(cb).not.toBeCalled();
+  });
+
   describe('Animated Parallel', () => {
     it('works with an empty parallel', () => {
       const cb = jest.fn();


### PR DESCRIPTION
Fixes #20560

Test Plan:
----------
* Test, that `animation.reset()` does not get called, when `resetBeforeIteration` is set to `false`.
* Make sure to default the new configuration to match the previous behaviour so that no existing test fails.

Release Notes:
--------------
[GENERAL] [ENHANCEMENT] [Animated] - Added resetBeforeIteration configuration for Animated.loop
