### PR TITLE
switch to yarn in appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,8 +32,8 @@ install:
 
     - ps: Install-Product node $env:nodejs_version
     - node --version
-    - npm --version
-    - appveyor-retry npm install
+    - yarn --version
+    - appveyor-retry yarn install
 
 build_script:
   - gradlew.bat RNTester:android:app:assembleRelease


### PR DESCRIPTION
## Motivation
switch to yarn to keep consistent. Windows android  build pass: https://ci.appveyor.com/project/gengjiawen/react-native/build/job/xyof6052yg2uhnmw.
## Test Plan
pass all current ci.
## Related PRs
none
## Release Notes
 [GENERAL] [INTERNAL] [CI] - switch to yarn.