### PR TITLE
[Linux/OSX] Add missing "--terminal" argument to run-android

### DIFF
--- a/local-cli/runAndroid/runAndroid.js
+++ b/local-cli/runAndroid/runAndroid.js
@@ -348,7 +348,7 @@ function runOnAllDevices(
   }
 }
 
-function startServerInNewWindow(port, terminalArg) {
+function startServerInNewWindow(port, terminal = process.env.REACT_TERMINAL) {
   // set up OS-specific filenames and commands
   const isWindows = /^win/.test(process.platform);
   const scriptFile = isWindows
@@ -363,7 +363,6 @@ function startServerInNewWindow(port, terminalArg) {
   const scriptsDir = path.resolve(__dirname, '..', '..', 'scripts');
   const launchPackagerScript = path.resolve(scriptsDir, scriptFile);
   const procConfig = {cwd: scriptsDir};
-  const terminal = terminalArg || process.env.REACT_TERMINAL;
 
   // set up the .packager.(env|bat) file to ensure the packager starts on the right port
   const packagerEnvFile = path.join(

--- a/local-cli/runAndroid/runAndroid.js
+++ b/local-cli/runAndroid/runAndroid.js
@@ -60,7 +60,7 @@ function runAndroid(argv, config, args) {
     } else {
       // result == 'not_running'
       console.log(chalk.bold('Starting JS server...'));
-      startServerInNewWindow(args.port);
+      startServerInNewWindow(args.port, args.terminal);
     }
     return buildAndRun(args);
   });
@@ -348,7 +348,7 @@ function runOnAllDevices(
   }
 }
 
-function startServerInNewWindow(port) {
+function startServerInNewWindow(port, terminalArg) {
   // set up OS-specific filenames and commands
   const isWindows = /^win/.test(process.platform);
   const scriptFile = isWindows
@@ -363,7 +363,7 @@ function startServerInNewWindow(port) {
   const scriptsDir = path.resolve(__dirname, '..', '..', 'scripts');
   const launchPackagerScript = path.resolve(scriptsDir, scriptFile);
   const procConfig = {cwd: scriptsDir};
-  const terminal = process.env.REACT_TERMINAL;
+  const terminal = terminalArg || process.env.REACT_TERMINAL;
 
   // set up the .packager.(env|bat) file to ensure the packager starts on the right port
   const packagerEnvFile = path.join(
@@ -390,14 +390,16 @@ function startServerInNewWindow(port) {
     }
     return child_process.spawnSync('open', [launchPackagerScript], procConfig);
   } else if (process.platform === 'linux') {
-    procConfig.detached = true;
     if (terminal) {
+      procConfig.detached = true;
       return child_process.spawn(
         terminal,
         ['-e', 'sh ' + launchPackagerScript],
         procConfig,
       );
     }
+    // By default, the child shell process will be attached to the parent
+    procConfig.detached = false;
     return child_process.spawn('sh', [launchPackagerScript], procConfig);
   } else if (/^win/.test(process.platform)) {
     procConfig.detached = true;
@@ -473,6 +475,12 @@ module.exports = {
       command: '--port [number]',
       default: process.env.RCT_METRO_PORT || 8081,
       parse: (val: string) => Number(val),
+    },
+    {
+      command: '--terminal [string]',
+      description:
+        'Launches the Metro Bundler in a new window using the specified terminal path.',
+      default: '',
     },
   ],
 };


### PR DESCRIPTION
Commit 79e498b7fbf19ab50bb73697602910fb827ff928 claims that "--terminal" has been added as an argument to the "run-android" script which it hasn't. Instead it adds a new environment variable "process.env.REACT_TERMINAL" which seems to be undocumented and nowhere else in the repository. 

This commit now allows Linux and OSX users to specify their custom terminal :

    react-native run-android --terminal=x-terminal-emulator

Additionally the metro bundler child process "detached" option has been set to false if no terminal has been specified on Linux which fixes an issue where the packager would be running in the background and would have to manually be closed by finding the process. 

Fixes #18122

Test Plan:
----------
None

Release Notes:
--------------
[CLI] [BUGFIX] [local-cli/runAndroid/runAndroid.js] - Add missing "--terminal" argument