### PR TITLE
fixed naming conflict in createAnimatedComponent setComponentRef

### DIFF
--- a/Libraries/Animated/src/__tests__/createdAnimatedComponent-test.js
+++ b/Libraries/Animated/src/__tests__/createdAnimatedComponent-test.js
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @emails oncall+react_native
+ */
+
+'use strict';
+
+const View = require('View');
+const Image = require('Image');
+const createAnimatedComponent = require('createAnimatedComponent');
+describe('createAnimatedComponent tests', () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+  describe('Animated.View', function() {
+    it('should create component without error', function() {
+      const AnimatedViewComponent = createAnimatedComponent(View);
+
+      const instance = new AnimatedViewComponent();
+
+      expect(instance).toBeTruthy();
+    });
+  });
+  describe('Animated.Image', function() {
+    it('should create component without error', function() {
+      const AnimatedImageComponent = createAnimatedComponent(Image);
+
+      const instance = new AnimatedImageComponent();
+
+      expect(instance).toBeTruthy();
+    });
+  });
+});

--- a/Libraries/Animated/src/createAnimatedComponent.js
+++ b/Libraries/Animated/src/createAnimatedComponent.js
@@ -163,7 +163,7 @@ function createAnimatedComponent(Component: any): any {
         />
       );
     }
-  
+
     _internalSetComponentRef(c) {
       this._prevComponent = this._component;
       this._component = c;

--- a/Libraries/Animated/src/createAnimatedComponent.js
+++ b/Libraries/Animated/src/createAnimatedComponent.js
@@ -36,7 +36,7 @@ function createAnimatedComponent(Component: any): any {
 
     constructor(props: Object) {
       super(props);
-      this._setComponentRef = this._setComponentRef.bind(this);
+      this._setComponentRef = this._internalSetComponentRef.bind(this);
     }
 
     componentWillUnmount() {
@@ -163,8 +163,8 @@ function createAnimatedComponent(Component: any): any {
         />
       );
     }
-
-    _setComponentRef(c) {
+  
+    _internalSetComponentRef(c) {
       this._prevComponent = this._component;
       this._component = c;
     }


### PR DESCRIPTION
Fixes #20588

Test Plan:
----------
* Added unit tests around createAnimatedComponent to verify no breaking changes

Release Notes:
--------------
[INTERNAL] [BUGFIX] [Libraries/Animated/createAnimatedComponent.js] - Change the name of an internal function to not conflict class bound version