### PR TITLE
Enable metro hmr server in local-cli

### DIFF
--- a/local-cli/server/runServer.js
+++ b/local-cli/server/runServer.js
@@ -65,6 +65,7 @@ async function runServer(args: Args, config: ConfigT) {
     secure: args.https,
     secureCert: args.cert,
     secureKey: args.key,
+    hmrEnabled: true,
   });
 
   const wsProxy = webSocketProxy.attachToServer(


### PR DESCRIPTION
The `hmrEnabled` flag was not passed to the metro runServer config which caused HMR to be broken.

Test Plan:
----------
Test that hmr works by applying the fix locally

Release Notes:
--------------
[CLI] [MINOR] [runServer.js] - Enable metro hmr server in local-cli
