### PR TITLE
Fix eslint errors and warnings in preprocessor.js

### DIFF
--- a/jest/preprocessor.js
+++ b/jest/preprocessor.js
@@ -23,7 +23,7 @@ const babelRegisterOnly = require('metro-babel-register');
 const createCacheKeyFunction = require('fbjs-scripts/jest/createCacheKeyFunction');
 const generate = require('@babel/generator').default;
 
-const nodeFiles = RegExp(
+const nodeFiles = new RegExp(
   [
     '/local-cli/',
     '/metro(?:-[^/]*)?/', // metro, metro-core, metro-source-map, metro-etc
@@ -39,15 +39,12 @@ module.exports = {
   process(src /*: string */, file /*: string */) {
     if (nodeFiles.test(file)) {
       // node specific transforms only
-      return babelTransformSync(
-        src,
-        {
-          filename: file,
-          sourceType: 'script',
-          ...nodeOptions,
-          ast: false
-        },
-      ).code;
+      return babelTransformSync(src, {
+        filename: file,
+        sourceType: 'script',
+        ...nodeOptions,
+        ast: false,
+      }).code;
     }
 
     const {ast} = transformer.transform({


### PR DESCRIPTION
Test Plan:
----------
Fixing eslint errors and warnings below.

```
react-native/jest/preprocessor.js
  42:33  error    Replace `⏎········src,⏎·······` with `src,`         prettier/prettier
  45:1   error    Replace `··········` with `········`                prettier/prettier
  46:1   error    Delete `··`                                         prettier/prettier
  47:1   error    Delete `··`                                         prettier/prettier
  48:9   error    Replace `··ast:·false⏎········}` with `ast:·false`  prettier/prettier
  48:21  warning  Missing trailing comma                              comma-dangle
  50:7   error    Insert `}`                                          prettier/prettier
```

Release Notes:
--------------
[INTERNAL][MINOR] - Fix eslint errors and warnings in preprocessor.js

<!--
  **INTERNAL and MINOR tagged notes will not be included in the next version's final release notes.**

    CATEGORY
  [----------]      TYPE
  [ CLI      ] [-------------]    LOCATION
  [ DOCS     ] [ BREAKING    ] [-------------]
  [ GENERAL  ] [ BUGFIX      ] [ {Component} ]
  [ INTERNAL ] [ ENHANCEMENT ] [ {Filename}  ]
  [ IOS      ] [ FEATURE     ] [ {Directory} ]   |-----------|
  [ ANDROID  ] [ MINOR       ] [ {Framework} ] - | {Message} |
  [----------] [-------------] [-------------]   |-----------|

 EXAMPLES:

 [IOS] [BREAKING] [FlatList] - Change a thing that breaks other things
 [ANDROID] [BUGFIX] [TextInput] - Did a thing to TextInput
 [CLI] [FEATURE] [local-cli/info/info.js] - CLI easier to do things with
 [DOCS] [BUGFIX] [GettingStarted.md] - Accidentally a thing/word
 [GENERAL] [ENHANCEMENT] [Yoga] - Added new yoga thing/position
 [INTERNAL] [FEATURE] [./scripts] - Added thing to script that nobody will see
-->
