### PR TITLE
Fix TextInput shadow props not update when setText on iOS

### DIFF
--- a/Libraries/Text/TextInput/RCTBaseTextInputShadowView.m
+++ b/Libraries/Text/TextInput/RCTBaseTextInputShadowView.m
@@ -60,6 +60,7 @@
   }
 
   _localAttributedText = attributedText;
+  _text = attributedText.string;
   [self dirtyLayout];
 }
 


### PR DESCRIPTION
Fixes #20224

Test Plan:
----------
The code as below, click `TouchableOpacity`, click textInput , edit text, then click `TouchableOpacity` again.

```
import React from "react";
import { View, Text, TextInput, TouchableOpacity } from "react-native";

export default class App extends React.Component {
  state = {
    isReactNative: true
  };

  insertText = () => {
    this.textInput.setNativeProps({ text: "ReactNative" });
  };

  render() {
    return (
      <View style={{ paddingTop: 128, alignItems: "center" }}>
        <TextInput
          style={{
            width: "100%",
            backgroundColor: "#ccc",
            fontSize: 48,
            textAlign: "center"
          }}
          ref={ref => {
            this.textInput = ref;
          }}
        />

        <TouchableOpacity style={{ padding: 16 }} onPress={this.insertText}>
          <Text style={{ fontSize: 24 }}>Insert ReactNative</Text>
        </TouchableOpacity>
      </View>
    );
  }
}
```

Release Notes:
----------
 [IOS] [BUGFIX] [TextInput] - Fix TextInput shadow props not update when update local data.