### PR TITLE
Switch babel preset to metro-react-native-babel-preset

### DIFF
--- a/local-cli/init/init.js
+++ b/local-cli/init/init.js
@@ -99,7 +99,7 @@ function generateProject(destinationRoot, newProjectName, options) {
     });
   }
   if (!options['skip-jest']) {
-    const jestDeps = `jest babel-jest babel-preset-react-native@^5 react-test-renderer@${reactVersion}`;
+    const jestDeps = `jest babel-jest metro-react-native-babel-preset@^0.43.5 react-test-renderer@${reactVersion}`;
     if (yarnVersion) {
       console.log('Adding Jest...');
       execSync(`yarn add ${jestDeps} --dev --exact`, {stdio: 'inherit'});

--- a/local-cli/templates/HelloWorld/_babelrc
+++ b/local-cli/templates/HelloWorld/_babelrc
@@ -1,3 +1,3 @@
 {
-  "presets": ["react-native"]
+  "presets": ["module:metro-react-native-babel-preset"]
 }


### PR DESCRIPTION
Fixes #20567, #20327

Test Plan:
----------
Test to create a bare-bones project and run it on a device.

Release Notes:
--------------
Help reviewers and the release process by writing your own release notes. See below for an example.

[GENERAL] [BUGFIX] [Babel] - Switch templated babel preset from `babel-preset-react-native` to `metro-react-native-babel-preset`
