### PR TITLE
No force layout of superview and contentSize recalculation if intrinsicContentSize not changed

### DIFF
--- a/React/Base/RCTRootView.m
+++ b/React/Base/RCTRootView.m
@@ -343,13 +343,13 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
 
   _intrinsicContentSize = intrinsicContentSize;
 
-  [self invalidateIntrinsicContentSize];
-  [self.superview setNeedsLayout];
-
   // Don't notify the delegate if the content remains invisible or its size has not changed
   if (bothSizesHaveAZeroDimension || sizesAreEqual) {
     return;
   }
+  
+  [self invalidateIntrinsicContentSize];
+  [self.superview setNeedsLayout];
 
   [_delegate rootViewDidChangeIntrinsicSize:self];
 }


### PR DESCRIPTION
Test Plan:
----------
No need test.

Release Notes:
--------------
[IOS][ENHANCEMENT][RCTRootView] - No force layout of superview and contentSize recalculation if intrinsicContentSize not changed