### PR TITLE
Get random values

### DIFF
--- a/IntegrationTests/CryptoTest.js
+++ b/IntegrationTests/CryptoTest.js
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2018-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow
+ */
+
+'use strict';
+
+declare var crypto: {getRandomValues: (data: Uint8Array) => Uint8Array};
+
+const React = require('react');
+const ReactNative = require('react-native');
+const {View} = ReactNative;
+const {TestModule} = ReactNative.NativeModules;
+
+class CryptoTest extends React.Component<{}> {
+  componentDidMount() {
+    const data = new Uint8Array(8);
+    const returnValue = crypto.getRandomValues(data);
+
+    const returnsArray = data === returnValue;
+    const populatesData = data.find(value => value !== 0) !== undefined;
+
+    TestModule.markTestPassed(returnsArray && populatesData);
+  }
+
+  render(): React.Node {
+    return <View />;
+  }
+}
+
+CryptoTest.displayName = 'CryptoTest';
+
+module.exports = CryptoTest;

--- a/IntegrationTests/IntegrationTestsApp.js
+++ b/IntegrationTests/IntegrationTestsApp.js
@@ -31,6 +31,7 @@ const TESTS = [
   require('./SimpleSnapshotTest'),
   require('./ImageCachePolicyTest'),
   require('./ImageSnapshotTest'),
+  require('./CryptoTest'),
   require('./PromiseTest'),
   require('./WebViewTest'),
   require('./SyncMethodTest'),

--- a/RNTester/RNTesterIntegrationTests/RNTesterIntegrationTests.m
+++ b/RNTester/RNTesterIntegrationTests/RNTesterIntegrationTests.m
@@ -70,6 +70,7 @@ RCT_TEST(ImageSnapshotTest)
 //RCT_TEST(LayoutEventsTest) // Disabled due to flakiness: #8686784
 RCT_TEST(SimpleSnapshotTest)
 RCT_TEST(SyncMethodTest)
+RCT_TEST(CryptoTest)
 RCT_TEST(PromiseTest)
 RCT_TEST_ONLY_WITH_PACKAGER(WebSocketTest)
 RCT_TEST(AccessibilityManagerTest)

--- a/React/React.xcodeproj/project.pbxproj
+++ b/React/React.xcodeproj/project.pbxproj
@@ -199,6 +199,10 @@
 		14F484561AABFCE100FDF6B9 /* RCTSliderManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 14F484551AABFCE100FDF6B9 /* RCTSliderManager.m */; };
 		14F7A0EC1BDA3B3C003C6C10 /* RCTPerfMonitor.m in Sources */ = {isa = PBXBuildFile; fileRef = 14F7A0EB1BDA3B3C003C6C10 /* RCTPerfMonitor.m */; };
 		14F7A0F01BDA714B003C6C10 /* RCTFPSGraph.m in Sources */ = {isa = PBXBuildFile; fileRef = 14F7A0EF1BDA714B003C6C10 /* RCTFPSGraph.m */; };
+		15698CC82125A6B300EE2C0D /* Crypto.h in Headers */ = {isa = PBXBuildFile; fileRef = 15698CC62125A6B200EE2C0D /* Crypto.h */; };
+		15698CC92125A6B300EE2C0D /* Crypto.h in Headers */ = {isa = PBXBuildFile; fileRef = 15698CC62125A6B200EE2C0D /* Crypto.h */; };
+		15698CCA2125A6B300EE2C0D /* Crypto.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 15698CC72125A6B300EE2C0D /* Crypto.cpp */; };
+		15698CCB2125A6B300EE2C0D /* Crypto.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 15698CC72125A6B300EE2C0D /* Crypto.cpp */; };
 		191E3EBE1C29D9AF00C180A6 /* RCTRefreshControlManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 191E3EBD1C29D9AF00C180A6 /* RCTRefreshControlManager.m */; };
 		191E3EC11C29DC3800C180A6 /* RCTRefreshControl.m in Sources */ = {isa = PBXBuildFile; fileRef = 191E3EC01C29DC3800C180A6 /* RCTRefreshControl.m */; };
 		199B8A6F1F44DB16005DEF67 /* RCTVersion.h in Headers */ = {isa = PBXBuildFile; fileRef = 199B8A6E1F44DB16005DEF67 /* RCTVersion.h */; };
@@ -2068,6 +2072,8 @@
 		14F7A0EB1BDA3B3C003C6C10 /* RCTPerfMonitor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTPerfMonitor.m; sourceTree = "<group>"; };
 		14F7A0EE1BDA714B003C6C10 /* RCTFPSGraph.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = RCTFPSGraph.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
 		14F7A0EF1BDA714B003C6C10 /* RCTFPSGraph.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTFPSGraph.m; sourceTree = "<group>"; };
+		15698CC62125A6B200EE2C0D /* Crypto.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Crypto.h; sourceTree = "<group>"; };
+		15698CC72125A6B300EE2C0D /* Crypto.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Crypto.cpp; sourceTree = "<group>"; };
 		191E3EBC1C29D9AF00C180A6 /* RCTRefreshControlManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTRefreshControlManager.h; sourceTree = "<group>"; };
 		191E3EBD1C29D9AF00C180A6 /* RCTRefreshControlManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTRefreshControlManager.m; sourceTree = "<group>"; };
 		191E3EBF1C29DC3800C180A6 /* RCTRefreshControl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTRefreshControl.h; sourceTree = "<group>"; };
@@ -2759,6 +2765,8 @@
 		3D4A621D1DDD3985001F41B4 /* jschelpers */ = {
 			isa = PBXGroup;
 			children = (
+				15698CC72125A6B300EE2C0D /* Crypto.cpp */,
+				15698CC62125A6B200EE2C0D /* Crypto.h */,
 				19DED2281E77E29200F089BB /* systemJSCWrapper.cpp */,
 				3D7A27DC1DE32541002E3F95 /* JavaScriptCore.h */,
 				3D92B1071E0369AD0018521A /* JSCHelpers.cpp */,
@@ -3376,6 +3384,7 @@
 				19F61C041E8495FF00571D81 /* JSCHelpers.h in Headers */,
 				19F61C051E8495FF00571D81 /* noncopyable.h in Headers */,
 				19F61C061E8495FF00571D81 /* Unicode.h in Headers */,
+				15698CC92125A6B300EE2C0D /* Crypto.h in Headers */,
 				19F61C071E8495FF00571D81 /* Value.h in Headers */,
 				3D3030251DF8295E00D6DDAE /* JavaScriptCore.h in Headers */,
 				3D3030261DF8295E00D6DDAE /* JSCWrapper.h in Headers */,
@@ -3423,6 +3432,7 @@
 				13EBC6821E28733C00880AC5 /* Value.h in Headers */,
 				13EBC6811E28733C00880AC5 /* Unicode.h in Headers */,
 				13EBC6801E28733C00880AC5 /* noncopyable.h in Headers */,
+				15698CC82125A6B300EE2C0D /* Crypto.h in Headers */,
 				13EBC67E1E28726000880AC5 /* JSCHelpers.h in Headers */,
 				3D3CD93D1DE5FC1400167DC4 /* JavaScriptCore.h in Headers */,
 				3D3CD93E1DE5FC1400167DC4 /* JSCWrapper.h in Headers */,
@@ -4387,6 +4397,7 @@
 				13EBC6731E2870DE00880AC5 /* Value.cpp in Sources */,
 				13EBC67D1E28725900880AC5 /* JSCHelpers.cpp in Sources */,
 				135A9C021E7B0F4800587AEB /* systemJSCWrapper.cpp in Sources */,
+				15698CCA2125A6B300EE2C0D /* Crypto.cpp in Sources */,
 				13EBC67B1E28723000880AC5 /* Unicode.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -4399,6 +4410,7 @@
 				13EBC6781E2870E400880AC5 /* JSCWrapper.cpp in Sources */,
 				13EBC6771E2870E400880AC5 /* JSCHelpers.cpp in Sources */,
 				135A9C011E7B0F4700587AEB /* systemJSCWrapper.cpp in Sources */,
+				15698CCB2125A6B300EE2C0D /* Crypto.cpp in Sources */,
 				13EBC67A1E2870E400880AC5 /* Value.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ReactAndroid/src/androidTest/java/com/facebook/react/tests/JSCryptoTest.java
+++ b/ReactAndroid/src/androidTest/java/com/facebook/react/tests/JSCryptoTest.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) 2018-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.tests;
+
+import com.facebook.react.bridge.CatalystInstance;
+import com.facebook.react.bridge.JavaScriptModule;
+import com.facebook.react.bridge.UiThreadUtil;
+import com.facebook.react.modules.appstate.AppStateModule;
+import com.facebook.react.modules.core.ReactChoreographer;
+import com.facebook.react.modules.deviceinfo.DeviceInfoModule;
+import com.facebook.react.testing.FakeWebSocketModule;
+import com.facebook.react.testing.ReactIntegrationTestCase;
+import com.facebook.react.testing.ReactTestHelper;
+import com.facebook.react.testing.StringRecordingModule;
+import com.facebook.react.uimanager.UIManagerModule;
+import com.facebook.react.uimanager.ViewManager;
+import com.facebook.react.views.view.ReactViewManager;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Test crypto-based functionality of JS VM
+ */
+public class JSCryptoTest extends ReactIntegrationTestCase {
+
+  private interface TestJSCryptoModule extends JavaScriptModule {
+    void getRandomValues();
+  }
+
+  StringRecordingModule mStringRecordingModule;
+
+  private CatalystInstance mInstance;
+
+  @Override
+  protected void setUp() throws Exception {
+    super.setUp();
+
+    List<ViewManager> viewManagers = Arrays.<ViewManager>asList(
+        new ReactViewManager());
+    final UIManagerModule mUIManager = new UIManagerModule(
+        getContext(),
+        viewManagers,
+        0);
+    UiThreadUtil.runOnUiThread(
+        new Runnable() {
+          @Override
+          public void run() {
+            ReactChoreographer.initialize();
+            mUIManager.onHostResume();
+          }
+        });
+    waitForIdleSync();
+
+    mStringRecordingModule = new StringRecordingModule();
+    mInstance = ReactTestHelper.catalystInstanceBuilder(this)
+        .addNativeModule(mStringRecordingModule)
+        .addNativeModule(mUIManager)
+        .addNativeModule(new DeviceInfoModule(getContext()))
+        .addNativeModule(new AppStateModule(getContext()))
+        .addNativeModule(new FakeWebSocketModule())
+        .build();
+  }
+
+  public void testGetRandomValues() {
+    TestJSCryptoModule testModule = mInstance.getJSModule(TestJSCryptoModule.class);
+    waitForBridgeAndUIIdle();
+
+    testModule.getRandomValues();
+    waitForBridgeAndUIIdle();
+
+    String[] answers = mStringRecordingModule.getCalls().toArray(new String[0]);
+    assertEquals("true", answers[0]);
+  }
+}

--- a/ReactAndroid/src/androidTest/js/TestBundle.js
+++ b/ReactAndroid/src/androidTest/js/TestBundle.js
@@ -16,6 +16,7 @@ console.disableYellowBox = true;
 require('ProgressBarTestModule');
 require('ViewRenderingTestModule');
 require('TestJavaToJSArgumentsModule');
+require('TestJSCryptoModule');
 require('TestJSLocaleModule');
 require('TestJSToJavaParametersModule');
 require('TestJavaToJSReturnValuesModule');

--- a/ReactAndroid/src/androidTest/js/TestJSCryptoModule.js
+++ b/ReactAndroid/src/androidTest/js/TestJSCryptoModule.js
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2018-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+'use strict';
+
+/* global crypto */
+
+var BatchedBridge = require('BatchedBridge');
+var Recording = require('NativeModules').Recording;
+
+var TestJSCryptoModule = {
+  getRandomValues: function() {
+    const data = new Uint8Array(8);
+    const returnValue = crypto.getRandomValues(data);
+
+    const returnsArray = data === returnValue;
+    const populatesData = data.find(value => value !== 0) !== undefined;
+
+    Recording.record(returnsArray && populatesData ? 'true' : 'false');
+  },
+};
+
+BatchedBridge.registerCallableModule('TestJSCryptoModule', TestJSCryptoModule);
+
+module.exports = TestJSCryptoModule;

--- a/ReactCommon/cxxreact/JSCExecutor.cpp
+++ b/ReactCommon/cxxreact/JSCExecutor.cpp
@@ -143,6 +143,11 @@ JSCExecutor::JSCExecutor(
         "nativeModuleProxy",
         exceptionWrapMethod<&JSCExecutor::getNativeModule>());
   }
+
+  {
+    SystraceSection s("nativeModuleCrypto object");
+    installGlobalCrypto(m_context);
+  }
 }
 
 JSCExecutor::~JSCExecutor() {

--- a/ReactCommon/jschelpers/Android.mk
+++ b/ReactCommon/jschelpers/Android.mk
@@ -5,6 +5,7 @@ include $(CLEAR_VARS)
 LOCAL_MODULE := jschelpers
 
 LOCAL_SRC_FILES := \
+  Crypto.cpp \
   JSCHelpers.cpp \
   Unicode.cpp \
   Value.cpp \

--- a/ReactCommon/jschelpers/BUCK
+++ b/ReactCommon/jschelpers/BUCK
@@ -1,6 +1,7 @@
 load("//ReactNative:DEFS.bzl", "ANDROID", "ANDROID_JSC_INTERNAL_DEPS", "APPLE", "APPLE_JSC_INTERNAL_DEPS", "react_native_xplat_target", "rn_xplat_cxx_library")
 
 EXPORTED_HEADERS = [
+    "Crypto.h",
     "JavaScriptCore.h",
     "JSCHelpers.h",
     "JSCWrapper.h",

--- a/ReactCommon/jschelpers/Crypto.cpp
+++ b/ReactCommon/jschelpers/Crypto.cpp
@@ -1,0 +1,122 @@
+// Copyright (c) 2018-present, Facebook, Inc.
+
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "Crypto.h"
+
+#include "JSCHelpers.h"
+
+#ifdef __APPLE__
+#import <Security/SecRandom.h>
+#else
+#include <cstdio>
+#endif
+
+namespace facebook {
+namespace react {
+
+JSValueRef getRandomValues(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef *exception) {
+  auto type = JSC_JSValueGetTypedArrayType(ctx, arguments[0], exception);
+  if (*exception != nullptr) return JSC_JSValueMakeUndefined(ctx);
+
+  auto typedArray = JSC_JSValueToObject(ctx, arguments[0], exception);
+  if (*exception != nullptr) return JSC_JSValueMakeUndefined(ctx);
+
+  /* 1. If array is not of an integer type (i.e., Int8Array, Uint8Array, Int16Array, Uint16Array, Int32Array, Uint32Array or UInt8ClampedArray), throw a TypeMismatchError and terminate the algorithm. */
+  if (type == kJSTypedArrayTypeNone) {
+    JSValueRef errorMsgValue = JSC_JSValueMakeString(ctx, JSC_JSStringCreateWithUTF8CString(ctx, "TypeMismatchError"));
+    JSValueRef args[] = {errorMsgValue};
+
+    JSObjectRef errorObj = JSC_JSObjectMakeError(ctx, 1, args, exception);
+    if (*exception != nullptr) return JSC_JSValueMakeUndefined(ctx);
+
+    JSValueRef errorRef = JSC_JSValueToObject(ctx, errorObj, exception);
+    if (*exception != nullptr) return JSC_JSValueMakeUndefined(ctx);
+
+    *exception = errorRef;
+    return JSC_JSValueMakeUndefined(ctx);
+  }
+
+  auto length = JSC_JSObjectGetTypedArrayLength(ctx, typedArray, exception);
+  if (*exception != nullptr) return JSC_JSValueMakeUndefined(ctx);
+
+  /* 2. If the byteLength of array is greater than 65536, throw a QuotaExceededError and terminate the algorithm. */
+  if (length > 65536) {
+    JSValueRef errorMsgValue = JSC_JSValueMakeString(ctx, JSC_JSStringCreateWithUTF8CString(ctx, "QuotaExceededError"));
+    JSValueRef args[] = {errorMsgValue};
+
+    JSObjectRef errorObj = JSC_JSObjectMakeError(ctx, 1, args, exception);
+    if (*exception != nullptr) return JSC_JSValueMakeUndefined(ctx);
+
+    JSValueRef errorRef = JSC_JSValueToObject(ctx, errorObj, exception);
+    if (*exception != nullptr) return JSC_JSValueMakeUndefined(ctx);
+
+    *exception = errorRef;
+    return JSC_JSValueMakeUndefined(ctx);
+  }
+
+  uint8_t *ptr = static_cast<uint8_t*>(JSC_JSObjectGetTypedArrayBytesPtr(ctx, typedArray, exception));
+  if (*exception != nullptr) return JSC_JSValueMakeUndefined(ctx);
+
+  auto offset = JSC_JSObjectGetTypedArrayByteOffset(ctx, typedArray, exception);
+  if (*exception != nullptr) return JSC_JSValueMakeUndefined(ctx);
+
+#ifdef __APPLE__
+  auto result = SecRandomCopyBytes(kSecRandomDefault, length, ptr + offset);
+
+  if (result != errSecSuccess) {
+    JSValueRef errorMsgValue = JSC_JSValueMakeString(ctx, JSC_JSStringCreateWithUTF8CString(ctx, "Failed to retreive random values"));
+    JSValueRef args[] = {errorMsgValue};
+
+    JSObjectRef errorObj = JSC_JSObjectMakeError(ctx, 1, args, exception);
+    if (*exception != nullptr) return JSC_JSValueMakeUndefined(ctx);
+
+    JSValueRef errorRef = JSC_JSValueToObject(ctx, errorObj, exception);
+    if (*exception != nullptr) return JSC_JSValueMakeUndefined(ctx);
+
+    *exception = errorRef;
+    return JSC_JSValueMakeUndefined(ctx);
+  }
+#else
+  auto fd = fopen("/dev/urandom", "r");
+
+  if (fd == nullptr) {
+    JSValueRef errorMsgValue = JSC_JSValueMakeString(ctx, JSC_JSStringCreateWithUTF8CString(ctx, "Failed to open /dev/urandom"));
+    JSValueRef args[] = {errorMsgValue};
+
+    JSObjectRef errorObj = JSC_JSObjectMakeError(ctx, 1, args, exception);
+    if (*exception != nullptr) return JSC_JSValueMakeUndefined(ctx);
+
+    JSValueRef errorRef = JSC_JSValueToObject(ctx, errorObj, exception);
+    if (*exception != nullptr) return JSC_JSValueMakeUndefined(ctx);
+
+    *exception = errorRef;
+    return JSC_JSValueMakeUndefined(ctx);
+  }
+
+  /* 3. Overwrite all elements of array with cryptographically random values of the appropriate type. */
+  auto result = fread(ptr + offset, 1, length, fd);
+
+  fclose(fd);
+
+  if (result != length) {
+    JSValueRef errorMsgValue = JSC_JSValueMakeString(ctx, JSC_JSStringCreateWithUTF8CString(ctx, "Failed to retreive enough random values"));
+    JSValueRef args[] = {errorMsgValue};
+
+    JSObjectRef errorObj = JSC_JSObjectMakeError(ctx, 1, args, exception);
+    if (*exception != nullptr) return JSC_JSValueMakeUndefined(ctx);
+
+    JSValueRef errorRef = JSC_JSValueToObject(ctx, errorObj, exception);
+    if (*exception != nullptr) return JSC_JSValueMakeUndefined(ctx);
+
+    *exception = errorRef;
+    return JSC_JSValueMakeUndefined(ctx);
+  }
+#endif
+
+  /* 4. Return array. */
+  return arguments[0];
+}
+
+} }

--- a/ReactCommon/jschelpers/Crypto.h
+++ b/ReactCommon/jschelpers/Crypto.h
@@ -1,0 +1,14 @@
+// Copyright (c) 2018-present, Facebook, Inc.
+
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include "JSCHelpers.h"
+
+namespace facebook {
+namespace react {
+__attribute__((visibility("default"))) JSValueRef getRandomValues(JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef *exception);
+}
+}

--- a/ReactCommon/jschelpers/JSCHelpers.cpp
+++ b/ReactCommon/jschelpers/JSCHelpers.cpp
@@ -15,6 +15,7 @@
 #include <pthread.h>
 #endif
 
+#include "Crypto.h"
 #include "JavaScriptCore.h"
 #include "Value.h"
 #include <privatedata/PrivateDataBase.h>
@@ -202,6 +203,17 @@ void installGlobalProxy(
   JSC_JSClassRelease(isCustomJSC, proxyClass);
 
   Object::getGlobalObject(ctx).setProperty(name, Value(ctx, proxyObj));
+}
+
+void installGlobalCrypto(JSGlobalContextRef ctx) {
+  JSObjectRef cryptoObject = JSC_JSObjectMake(ctx, NULL, NULL);
+
+  JSStringRef getRandomValuesName = JSC_JSStringCreateWithUTF8CString(ctx, "getRandomValues");
+  JSObjectRef getRandomValuesFunction = JSC_JSObjectMakeFunctionWithCallback(ctx, getRandomValuesName, getRandomValues);
+  JSC_JSObjectSetProperty(ctx, cryptoObject, getRandomValuesName, getRandomValuesFunction, kJSPropertyAttributeReadOnly & kJSPropertyAttributeDontDelete, NULL);
+  JSC_JSStringRelease(ctx, getRandomValuesName);
+
+  Object::getGlobalObject(ctx).setProperty("crypto", Value(ctx, cryptoObject));
 }
 
 void removeGlobal(JSGlobalContextRef ctx, const char* name) {

--- a/ReactCommon/jschelpers/JSCHelpers.h
+++ b/ReactCommon/jschelpers/JSCHelpers.h
@@ -85,6 +85,8 @@ void installGlobalProxy(
     const char* name,
     JSObjectGetPropertyCallback callback);
 
+void installGlobalCrypto(JSGlobalContextRef ctx);
+
 void removeGlobal(JSGlobalContextRef ctx, const char* name);
 
 JSValueRef evaluateScript(

--- a/ReactCommon/jschelpers/JSCWrapper.h
+++ b/ReactCommon/jschelpers/JSCWrapper.h
@@ -128,6 +128,7 @@ struct JSCWrapper {
   // JSValue
   JSC_WRAPPER_METHOD(JSValueCreateJSONString);
   JSC_WRAPPER_METHOD(JSValueGetType);
+  JSC_WRAPPER_METHOD(JSValueGetTypedArrayType);
   JSC_WRAPPER_METHOD(JSValueMakeFromJSONString);
   JSC_WRAPPER_METHOD(JSValueMakeBoolean);
   JSC_WRAPPER_METHOD(JSValueMakeNull);
@@ -141,6 +142,11 @@ struct JSCWrapper {
   JSC_WRAPPER_METHOD(JSValueToStringCopy);
   JSC_WRAPPER_METHOD(JSValueUnprotect);
   JSC_WRAPPER_METHOD(JSValueIsNull);
+
+  // JSTypedArray
+  JSC_WRAPPER_METHOD(JSObjectGetTypedArrayLength);
+  JSC_WRAPPER_METHOD(JSObjectGetTypedArrayBytesPtr);
+  JSC_WRAPPER_METHOD(JSObjectGetTypedArrayByteOffset);
 
   // Sampling profiler
   JSC_WRAPPER_METHOD(JSSamplingProfilerEnabled);

--- a/ReactCommon/jschelpers/JavaScriptCore.h
+++ b/ReactCommon/jschelpers/JavaScriptCore.h
@@ -110,6 +110,7 @@ jsc_poison(JSStringCopyCFString JSStringCreateWithCharacters JSStringCreateWithC
 // JSValueRef
 #define JSC_JSValueCreateJSONString(...) __jsc_wrapper(JSValueCreateJSONString, __VA_ARGS__)
 #define JSC_JSValueGetType(...) __jsc_wrapper(JSValueGetType, __VA_ARGS__)
+#define JSC_JSValueGetTypedArrayType(...) __jsc_wrapper(JSValueGetTypedArrayType, __VA_ARGS__)
 #define JSC_JSValueMakeFromJSONString(...) __jsc_wrapper(JSValueMakeFromJSONString, __VA_ARGS__)
 #define JSC_JSValueMakeBoolean(...) __jsc_wrapper(JSValueMakeBoolean, __VA_ARGS__)
 #define JSC_JSValueMakeNull(...) __jsc_wrapper(JSValueMakeNull, __VA_ARGS__)
@@ -175,6 +176,10 @@ jsc_poison(JSObjectCopyPropertyNames JSPropertyNameAccumulatorAddName
            JSPropertyNameArrayRelease JSPropertyNameArrayRetain)
 
 // JSTypedArray
+#define JSC_JSObjectGetTypedArrayLength(...) __jsc_wrapper(JSObjectGetTypedArrayLength, __VA_ARGS__)
+#define JSC_JSObjectGetTypedArrayBytesPtr(...) __jsc_wrapper(JSObjectGetTypedArrayBytesPtr, __VA_ARGS__)
+#define JSC_JSObjectGetTypedArrayByteOffset(...) __jsc_wrapper(JSObjectGetTypedArrayByteOffset, __VA_ARGS__)
+
 jsc_poison(JSObjectMakeArrayBufferWithBytesNoCopy JSObjectMakeTypedArray
            JSObjectMakeTypedArrayWithArrayBuffer
            JSObjectMakeTypedArrayWithArrayBufferAndOffset

--- a/ReactCommon/jschelpers/systemJSCWrapper.cpp
+++ b/ReactCommon/jschelpers/systemJSCWrapper.cpp
@@ -108,6 +108,7 @@ const JSCWrapper* systemJSCWrapper() {
 
       .JSValueCreateJSONString = JSValueCreateJSONString,
       .JSValueGetType = JSValueGetType,
+      .JSValueGetTypedArrayType = JSValueGetTypedArrayType,
       .JSValueMakeFromJSONString = JSValueMakeFromJSONString,
       .JSValueMakeBoolean = JSValueMakeBoolean,
       .JSValueMakeNull = JSValueMakeNull,
@@ -121,6 +122,10 @@ const JSCWrapper* systemJSCWrapper() {
       .JSValueToStringCopy = JSValueToStringCopy,
       .JSValueUnprotect = JSValueUnprotect,
       .JSValueIsNull = JSValueIsNull,
+
+      .JSObjectGetTypedArrayLength = JSObjectGetTypedArrayLength,
+      .JSObjectGetTypedArrayBytesPtr = JSObjectGetTypedArrayBytesPtr,
+      .JSObjectGetTypedArrayByteOffset = JSObjectGetTypedArrayByteOffset,
 
       .JSSamplingProfilerEnabled = JSSamplingProfilerEnabled,
       .JSPokeSamplingProfiler =


### PR DESCRIPTION
Test Plan:
----------
Apart from the added integration tests, an easy way to test this out is to generate a new empty project with `react-native --init` and add this single line to the `render` function:

```js
  <Text>{crypto.getRandomValues(new Uint8Array(1))[0]}</Text>
```

When running the app you should see a number between `0` and `255` (inclusively).

Release Notes:
--------------
Help reviewers and the release process by writing your own release notes. See below for an example.

[GENERAL] [FEATURE] [JSC] - Add `crypto.getRandomValues` to the global JavaScript Context

Motivation:
-----------

The motivation for getting this into core, instead of in a module, is that it's very hard to build this as a module. Since there is no way to expose synchronous functions from a module, the only way to do this that I can think of would be to expose an initial secure seed from the module, and the implement a secure RNG in JavaScript.

Including it here makes it use the built-in secure RNG which I think is a huge plus, since it moves the job of devising a secure RNG to the platform.

As for including this at all, there are two strong arguments:

1) Having access to good random numbers is useful for a number of functions, and `getRandomValues` provides much stronger guarantees, and a more robust API, over `Math.random()`. If you want to generate a random password, generate the answer to a guessing game, or let the "AI" of your game do things at random, you want good random numbers.

2) There are a lot of libraries on npm which uses `getRandomValues` in the background, by adding this in a standards-compliant way, they will just work out of the box on React Native. There are also many libraries who are falling back on `Math.random` and in many cases breaks expectation by not using a secure RNG.

    A good example is the `uuid` package, a very popular package for generating UUIDs. UUID v4 is supposed to be 122 bits of randomness, but `Math.random` doesn't make guarantees that the result will contain that many bits of entropy. `getRandomValues` is also a much nicer API then repeatedly calling `Math.random()`.