### PR TITLE
[CI] Use one time password when publishing to npm

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -605,8 +605,10 @@ jobs:
   publish_npm_package:
     <<: *android_defaults
     steps:
-      - attach_workspace:
-          at: ~/react-native
+      - checkout
+
+      - restore-cache: *restore-yarn-cache
+      - run: *yarn
 
       # Configure Android SDK and related dependencies
       - run: *configure-android-path
@@ -633,13 +635,19 @@ jobs:
       - run: *yarn
 
       - run:
-          name: Publish React Native Package
+          name: Authenticate with npm
+          command: echo "//registry.npmjs.org/:_authToken=${CIRCLE_NPM_TOKEN}" > ~/.npmrc
+
+      - run:
+          name: Authenticate git user
           command: |
-            echo "//registry.npmjs.org/:_authToken=${CIRCLE_NPM_TOKEN}" > ~/.npmrc
-            git config --global user.email "reactjs-bot@users.noreply.github.com"
+            git config --global user.email "react-native-bot@users.noreply.github.com"
             git config --global user.name "npm Deployment Script"
-            echo "machine github.com login reactjs-bot password $GITHUB_TOKEN" > ~/.netrc
-            node ./scripts/publish-npm.js
+            echo "machine github.com login react-native-bot password $GITHUB_TOKEN" > ~/.netrc
+
+      - run:
+          name: Publish React Native Package
+          command: node ./scripts/publish-npm.js
 
 # Workflows enables us to run multiple jobs in parallel
 workflows:


### PR DESCRIPTION
This pull request addresses the failing publish-npm.js script from earlier this week. For background, last month we reset all npm access tokens for any package related to Facebook, and we now require all accounts with publish permissions to have two factor enabled.

The publish-npm.js script relied on one such token that is configured in Circle CI as a envvar. The token has been updated in Circle CI, but we now need a way of passing the one time password to npm.

With this PR, we can now grab the otp from Circle CI's envvars. Considering otps are ephemeral, this requires the NPM_CONFIG_OTP envvar to be set by someone with publishing permissions anytime a new release will be pushed to npm. The token is short lived, but it would still be good to clear the envvar after the package is published. Circle CI envvars are not passed on to PR/forked builds.

This PR is effectively a breaking change for the release process, as the publish step will not succeed if the OTP is not valid.

OTPs are short-lived, and the publish_npm_package job will definitely outlive the token. Unfortunately this will require some timing to get right, but the alternative is to ssh into the Circle CI machine and re-run the `npm publish --otp` command, which again would still require someone with publish access to provide the otp.