### PR TITLE
Do not override `metro.config.js` settings

### DIFF
--- a/local-cli/core/index.js
+++ b/local-cli/core/index.js
@@ -132,9 +132,9 @@ async function getCliConfig(): Promise<RNConfig> {
   );
 
   config.transformer.assetRegistryPath = ASSET_REGISTRY_PATH;
-  config.resolver.hasteImplModulePath = defaultConfig.hasteImplModulePath;
-  config.resolver.platforms = defaultConfig.getPlatforms();
-  config.resolver.providesModuleNodeModules = defaultConfig.getProvidesModuleNodeModules();
+  config.resolver.hasteImplModulePath = config.resolver.hasteImplModulePath || defaultConfig.hasteImplModulePath;
+  config.resolver.platforms = config.resolver.platforms || defaultConfig.getPlatforms();
+  config.resolver.providesModuleNodeModules = config.resolver.providesModuleNodeModules || defaultConfig.getProvidesModuleNodeModules();
 
   return {...defaultRNConfig, ...config};
 }


### PR DESCRIPTION
React Native overrides the `metro.config.js` settings for, e.g., `hasteImplModulePath`, which prevents us from adding a `metro.config.js` file to the repo for `react-native-windows` to allow us to resolve Haste modules at the top-level of the repo. This change ensures that if a user has a `metro.config.js` file, those settings are not overwritten by React Native.

Test Plan:
----------

Run `npm test`, also confirmed that this change allows me to set a different `hasteImplModulePath` for `react-native-windows`.

Release Notes:
--------------
Help reviewers and the release process by writing your own release notes. See below for an example.

[CATEGORY] [TYPE] [LOCATION] - Message

<!--
  **INTERNAL and MINOR tagged notes will not be included in the next version's final release notes.**

    CATEGORY
  [----------]      TYPE
  [ CLI      ] [-------------]    LOCATION
  [ DOCS     ] [ BREAKING    ] [-------------]
  [ GENERAL  ] [ BUGFIX      ] [ {Component} ]
  [ INTERNAL ] [ ENHANCEMENT ] [ {Filename}  ]
  [ IOS      ] [ FEATURE     ] [ {Directory} ]   |-----------|
  [ ANDROID  ] [ MINOR       ] [ {Framework} ] - | {Message} |
  [----------] [-------------] [-------------]   |-----------|

 EXAMPLES:

 [IOS] [BREAKING] [FlatList] - Change a thing that breaks other things
 [ANDROID] [BUGFIX] [TextInput] - Did a thing to TextInput
 [CLI] [FEATURE] [local-cli/info/info.js] - CLI easier to do things with
 [DOCS] [BUGFIX] [GettingStarted.md] - Accidentally a thing/word
 [GENERAL] [ENHANCEMENT] [Yoga] - Added new yoga thing/position
 [INTERNAL] [FEATURE] [./scripts] - Added thing to script that nobody will see
-->

[GENERAL][CLI][local-cli/core/index.js] - Do not override `metro.config.js` settings