### PR TITLE
Expose scrollEnabled as iOS prop for TextInput

### DIFF
--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -156,6 +156,7 @@ type IOSProps = $ReadOnly<{|
     | 'username'
     | 'password'
   ),
+  scrollEnabled?: ?boolean,
 |}>;
 
 type AndroidProps = $ReadOnly<{|


### PR DESCRIPTION
Summary: Expose scrollEnabled as iOS prop for TextInput

Differential Revision: D9383477
