### PR TITLE
Add react-native-qwidgets to haste/cli whitelists

### DIFF
--- a/jest/hasteImpl.js
+++ b/jest/hasteImpl.js
@@ -16,6 +16,7 @@ const ROOTS = [
   path.resolve(__dirname, '..') + path.sep,
   path.resolve(__dirname, '../../react-native-windows') + path.sep,
   path.resolve(__dirname, '../../react-native-dom') + path.sep,
+  path.resolve(__dirname, '../../react-native-qwidgets') + path.sep,
 ];
 
 const BLACKLISTED_PATTERNS /*: Array<RegExp> */ = [
@@ -37,7 +38,7 @@ const NAME_REDUCERS /*: Array<[RegExp, string]> */ = [
   // strip .js/.js.flow suffix
   [/^(.*)\.js(\.flow)?$/, '$1'],
   // strip .android/.ios/.native/.web suffix
-  [/^(.*)\.(android|ios|native|web|windows|dom)$/, '$1'],
+  [/^(.*)\.(android|ios|native|web|windows|dom|qwidgets)$/, '$1'],
 ];
 
 const haste = {

--- a/local-cli/core/index.js
+++ b/local-cli/core/index.js
@@ -70,11 +70,11 @@ const defaultConfig = {
   hasteImplModulePath: require.resolve('../../jest/hasteImpl'),
 
   getPlatforms(): Array<string> {
-    return ['ios', 'android', 'windows', 'web', 'dom'];
+    return ['ios', 'android', 'windows', 'web', 'dom', 'qwidgets'];
   },
 
   getProvidesModuleNodeModules(): Array<string> {
-    return ['react-native', 'react-native-windows', 'react-native-dom'];
+    return ['react-native', 'react-native-windows', 'react-native-dom', 'react-native-qwidgets'];
   },
 };
 


### PR DESCRIPTION
This pull request adds support for my (currently unreleased) React Native renderer for [QWidgets](https://doc.qt.io/qt-5/qtwidgets-index.html). I am not yet ready for a public release but would like to see if I could get this in to 0.57 so it works with the bundler out-of-the-box when I do release it. 

Context: this is how platforms `windows` (https://github.com/facebook/react-native/commit/54942746d4037e1153e14fcfc95e4edc772d296a) and `dom` (#20393) were added. Echoing the sentiments in both links ideally there should be some kind of API for adding these platforms, but I'm not sure what it could look like.

Test Plan:
----------
I have tested and successfully bundled using this command:

```sh
react-native bundle --entry-file index.js --bundle-output test.bundle --platform qwidgets
```

Release Notes:
--------------
[CLI] [ENHANCEMENT] [jest/hasteImpl.js] - Add `react-native-qwidgets` and `qwidgets` to haste whitelist
[CLI] [ENHANCEMENT] [local-cli/core/index.js] - Add `react-native-qwidgets` and `qwidgets` to metro config
