### PR TITLE
refine android config

### DIFF
--- a/local-cli/templates/HelloWorld/android/build.gradle
+++ b/local-cli/templates/HelloWorld/android/build.gradle
@@ -1,6 +1,13 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
+    ext {
+        buildToolsVersion = "27.0.3"
+        minSdkVersion = 16
+        compileSdkVersion = 27
+        targetSdkVersion = 26
+        supportLibVersion = "27.1.1"
+    }
     repositories {
         jcenter()
         google()
@@ -25,13 +32,6 @@ allprojects {
     }
 }
 
-ext {
-    buildToolsVersion = "27.0.3"
-    minSdkVersion = 16
-    compileSdkVersion = 27
-    targetSdkVersion = 26
-    supportLibVersion = "27.1.1"
-}
 
 task wrapper(type: Wrapper) {
     gradleVersion = '4.4'


### PR DESCRIPTION
## Motivation
By this change we can unify version early, like we can make kotlin version share in buildscript and app dependency the same time ([butterknife](https://github.com/JakeWharton/butterknife/blob/master/build.gradle) use the same).
## Test Plan
pass all current ci and one of my project https://github.com/gengjiawen/ReactNative64bitDemo.
## Related PRs
none
## Release Notes
 [GENERAL] [ANDROID] [TEMPLATE] - refine android config