### PR TITLE
Fixes #20712 on unix-like OS

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "scripts/ios-install-third-party.sh",
     "scripts/launchPackager.bat",
     "scripts/launchPackager.command",
+    "scripts/packager.sh",
     "scripts/react-native-xcode.sh",
     "jest-preset.json",
     "jest",


### PR DESCRIPTION
## Motivation
add `packager.sh` for run-android task for unix like system. This only fix on linux and macOS.
## Test Plan
pass all current ci.
## Related PRs
none
## Release Notes
 [GENERAL] [BUGFIX] [CLI] - add `packager.sh` back for run-android task