### PR TITLE
[CI] Re-enable Detox e2e [DO NOT LAND]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -314,29 +314,6 @@ aliases:
     name: End-to-End Test Suite
     command: node ./scripts/run-ci-e2e-tests.js --android --ios --tvos --js --retries 3;
 
-  - &install-node-8
-    name: Install Node 8
-    command: |
-      echo 'export PATH=/usr/local/opt/node@8/bin:$PATH' >> $BASH_ENV
-      source $BASH_ENV
-      brew install node@8
-      brew link node@8
-      node -v
-
-  - &install-apple-simulator-utils
-    name: Install Apple Simulator Utilities
-    command: |
-      brew tap wix/brew
-      brew install applesimutils
-
-  - &build-ios-app-e2e
-    name: Build iOS App for Simulator
-    command: yarn run build-ios-e2e
-
-  - &run-ios-detox-tests
-    name: Run Detox Tests
-    command: yarn run test-ios-e2e
-
   - &run-objc-ios-e2e-tests
     name: iOS End-to-End Test Suite
     command: |
@@ -469,23 +446,23 @@ jobs:
           path: ~/react-native/reports/junit
 
   # Runs end to end tests (Detox)
-  # Disabled.
   test_detox_end_to_end:
     <<: *macos_defaults
     steps:
-      - attach_workspace:
-          at: ~/react-native
+      - checkout
 
-      - run: *boot-simulator-iphone
+      - run: echo 'export PATH=/usr/local/opt/node@8/bin:$PATH' >> $BASH_ENV
+      - run: source $BASH_ENV
+      - run: brew install node@8
+      - run: brew link node@8
+      - run: node -v
 
-      - run: *install-node-8
-      - run: *install-apple-simulator-utils
-      - run: *build-ios-app-e2e
-
-      - run: *run-ios-detox-tests
-
-      - store_test_results:
-          path: ~/react-native/reports/junit
+      - run: brew tap wix/brew
+      - run: brew install applesimutils
+      - run: yarn cache clean
+      - run: yarn
+      - run: yarn run build-ios-e2e
+      - run: yarn run test-ios-e2e
 
   # Set up an Android environment for downstream jobs
   test_android:
@@ -685,10 +662,8 @@ workflows:
       #     requires:
       #       - checkout_code
 
-      # - test_detox_end_to_end:
-      #     filters: *filter-ignore-gh-pages
-      #     requires:
-      #       - checkout_code
+      - test_detox_end_to_end:
+          filters: *filter-ignore-gh-pages
 
 
       # Only runs on vX.X.X tags if all tests are green

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -449,20 +449,31 @@ jobs:
   test_detox_end_to_end:
     <<: *macos_defaults
     steps:
-      - checkout
-
-      - run: echo 'export PATH=/usr/local/opt/node@8/bin:$PATH' >> $BASH_ENV
-      - run: source $BASH_ENV
-      - run: brew install node@8
-      - run: brew link node@8
-      - run: node -v
-
-      - run: brew tap wix/brew
-      - run: brew install applesimutils
-      - run: yarn cache clean
-      - run: yarn
-      - run: yarn run build-ios-e2e
-      - run: yarn run test-ios-e2e
+      - attach_workspace:
+          at: ~/react-native
+      - run: xcrun simctl boot "iPhone 5s" || true
+      - run:
+          name: Configure Environment Variables
+          command: |
+            echo 'export PATH=/usr/local/opt/node@8/bin:$PATH' >> $BASH_ENV
+            source $BASH_ENV
+      - run:
+          name: Install Node 8
+          command: |
+            brew install node@8
+            brew link node@8
+            brew tap wix/brew
+            brew install applesimutils
+            node -v
+      - run: *yarn
+      - run:
+          name: Build iOS app for simulator
+          command: |
+            yarn run build-ios-e2e
+      - run:
+          name: Run Detox Tests
+          command: |
+            yarn run test-ios-e2e
 
   # Set up an Android environment for downstream jobs
   test_android:
@@ -664,6 +675,8 @@ workflows:
 
       - test_detox_end_to_end:
           filters: *filter-ignore-gh-pages
+          requires:
+            - checkout_code
 
 
       # Only runs on vX.X.X tags if all tests are green


### PR DESCRIPTION
This workflow was added recently, but was disabled as it was not green on master.

This PR re-enables the step in order to surface any failures. Do not land, unless `test_detox_end_to_end` is actually green.