### PR TITLE
Bugfix: Check NodeJS version successfully even for old runtimes (Fixes #20769)

### DIFF
--- a/local-cli/server/checkNodeVersion.js
+++ b/local-cli/server/checkNodeVersion.js
@@ -4,7 +4,10 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @format
+ * Be mindful that this script may be run by legacy NodeJS runtimes. Keep this
+ * script ES5 compatible (e.g. do not insert the `@format` pragma here which
+ * may introduce non-ES5 compatible syntax.)
+ *
  */
 
 'use strict';
@@ -36,7 +39,7 @@ module.exports = function() {
         marginLeft: 1,
         marginRight: 1,
         paddingBottom: 1,
-      }),
+      })
     );
     process.exit(1);
   }


### PR DESCRIPTION
Fixes #20769

Release notes
--------------
[CLI] [BUGFIX] [local-cli/server/checkNodeVersion.js] - Disable auto-formatting in `local-cli/server/checkNodeVersion.js` since it introduces ES6 and ES7 syntax (trailing comma in argument list) which in turn makes ES5 engines crash with a `SyntaxError`.