### PR TITLE
added extra sinopia config to support packages

### DIFF
--- a/react-native-cli/README.md
+++ b/react-native-cli/README.md
@@ -35,6 +35,10 @@ Running it for the first time creates a default config file. Open `~/.config/sin
         allow_access: $all
         allow_publish: $all
 
+      '**':
+        allow_access: $all
+        proxy: npmjs
+
       '*':
         allow_access: $all
         proxy: npmjs


### PR DESCRIPTION
 [DOCS] [BUGFIX] [react-native-cli/README.md] - fixed sinopia configuration docs

now that babel uses scoped packages the extra sinpoia config also
requires the rule to cover ** which will satisfy such repositories like
@babel/core

The only other issue I had with getting started using this doc was node-gyp being an absolute horror to get running (a dependancy of sinpoia) I don't really know if writing debugging tips/links for macos in these docs is relevant. 

