### PR TITLE
Update RCTLinkingManager.h to explicitly state the 'nullability' of parameters

### DIFF
--- a/Libraries/LinkingIOS/RCTLinkingManager.h
+++ b/Libraries/LinkingIOS/RCTLinkingManager.h
@@ -11,17 +11,17 @@
 
 @interface RCTLinkingManager : RCTEventEmitter
 
-+ (BOOL)application:(UIApplication *)app
-            openURL:(NSURL *)URL
-            options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options;
++ (BOOL)application:(nonnull UIApplication *)app
+            openURL:(nonnull NSURL *)URL
+            options:(nonnull NSDictionary<UIApplicationOpenURLOptionsKey, id> *)options;
 
-+ (BOOL)application:(UIApplication *)application
-            openURL:(NSURL *)URL
-  sourceApplication:(NSString *)sourceApplication
-         annotation:(id)annotation;
++ (BOOL)application:(nonnull UIApplication *)application
+              openURL:(nonnull NSURL *)URL
+    sourceApplication:(nullable NSString *)sourceApplication
+           annotation:(nonnull id)annotation;
 
-+ (BOOL)application:(UIApplication *)application
-continueUserActivity:(NSUserActivity *)userActivity
-  restorationHandler:(void (^)(NSArray * __nullable))restorationHandler;
++ (BOOL)application:(nonnull UIApplication *)application
+    continueUserActivity:(nonnull NSUserActivity *)userActivity
+      restorationHandler:(nonnull void (^)(NSArray *__nullable))restorationHandler;
 
 @end


### PR DESCRIPTION
Fixes #20797

As mentioned in #20797 when running `react-native run-ios Xcode 9.2 will complain about the nullability of pointers in `RCTLinkingManager.h`.

Test Plan:
----------
My testing method probably isn't the best as I'm not sure what the best way to go about testing native code in isolation but I verified these changer worked by doing the following:
1. Run and see build fail
```
react-native init TestProject --version="0.57.0-rc.0"
cd TestProject
react-native run-ios
```
2. Update `node_modules/react-native/Libraries/LinkingIOS/RCTLinkingManager.h` with the changes in this pull request.
3. Re-run `react-native run-ios` and verify build succeeds.

Release Notes:
--------------
[IOS] [BUGFIX] [RCTLinkingManager] - Update method signatures in RCTLinkingManager.h to prevent build errors with Xcode 9.2.

