### PR TITLE
Bump iOS min in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The focus of React Native is on developer efficiency across all the platforms yo
 
 See the official [React Native website](https://facebook.github.io/react-native/) for an introduction to React Native.
 
-Supported operating systems are >= Android 4.1 (API 16) and >= iOS 8.0.
+Supported operating systems are >= Android 4.1 (API 16) and >= iOS 9.0.
 
 - [Getting Started](#getting-started)
 - [Documentation](#documentation)


### PR DESCRIPTION
iOS 8 was dropped as of 0.56.