### PR TITLE
Fix issue #18439: Alert.alert without message kills apps even after refreshing

### DIFF
--- a/Libraries/Alert/AlertIOS.js
+++ b/Libraries/Alert/AlertIOS.js
@@ -96,10 +96,10 @@ class AlertIOS {
       console.warn(
         'AlertIOS.alert() with a 4th "type" parameter is deprecated and will be removed. Use AlertIOS.prompt() instead.',
       );
-      this.prompt(title, message, callbackOrButtons, type);
+      this.prompt(title, message = '', callbackOrButtons, type);
       return;
     }
-    this.prompt(title, message, callbackOrButtons, 'default');
+    this.prompt(title, message = '', callbackOrButtons, 'default');
   }
 
   /**

--- a/Libraries/Alert/AlertIOS.js
+++ b/Libraries/Alert/AlertIOS.js
@@ -96,10 +96,8 @@ class AlertIOS {
       console.warn(
         'AlertIOS.alert() with a 4th "type" parameter is deprecated and will be removed. Use AlertIOS.prompt() instead.',
       );
-      this.prompt(title, message = '', callbackOrButtons, type);
-      return;
     }
-    this.prompt(title, message = '', callbackOrButtons, 'default');
+    this.prompt(title, message = '', callbackOrButtons, type = 'default');
   }
 
   /**

--- a/React/Base/RCTConvert.m
+++ b/React/Base/RCTConvert.m
@@ -36,18 +36,20 @@ RCT_NUMBER_CONVERTER(NSUInteger, unsignedIntegerValue)
  * representable json values that require no conversion.
  */
 #if RCT_DEBUG
-#define RCT_JSON_CONVERTER(type)           \
-+ (type *)type:(id)json                    \
-{                                          \
-  if ([json isKindOfClass:[type class]]) { \
-    return json;                           \
-  } else if (json) {                       \
-    RCTLogConvertError(json, @#type);      \
-  }                                        \
-  return nil;                              \
+#define RCT_JSON_CONVERTER(type)                    \
++ (type *)type:(id)json                             \
+{                                                   \
+  if ([json isKindOfClass:[type class]]) {          \
+    return json;                                    \
+  } else if ([json isKindOfClass:[NSNull class]]) { \
+    return nil;                                     \
+  } else if (json) {                                \
+    RCTLogConvertError(json, @#type);               \
+  }                                                 \
+  return nil;                                       \
 }
 #else
-#define RCT_JSON_CONVERTER(type)           \
+#define RCT_JSON_CONVERTER(type)                    \
 + (type *)type:(id)json { return json; }
 #endif
 

--- a/React/Modules/RCTAlertManager.m
+++ b/React/Modules/RCTAlertManager.m
@@ -64,7 +64,10 @@ RCT_EXPORT_METHOD(alertWithArgs:(NSDictionary *)args
                   callback:(RCTResponseSenderBlock)callback)
 {
   NSString *title = [RCTConvert NSString:args[@"title"]];
-  NSString *message = [RCTConvert NSString:args[@"message"]];
+  NSString *message = nil;
+  if (![args[@"message"] isKindOfClass:[NSNull class]]) {
+    message = [RCTConvert NSString:args[@"message"]];
+  }
   RCTAlertViewStyle type = [RCTConvert RCTAlertViewStyle:args[@"type"]];
   NSArray<NSDictionary *> *buttons = [RCTConvert NSDictionaryArray:args[@"buttons"]];
   NSString *defaultValue = [RCTConvert NSString:args[@"defaultValue"]];

--- a/React/Modules/RCTAlertManager.m
+++ b/React/Modules/RCTAlertManager.m
@@ -64,10 +64,7 @@ RCT_EXPORT_METHOD(alertWithArgs:(NSDictionary *)args
                   callback:(RCTResponseSenderBlock)callback)
 {
   NSString *title = [RCTConvert NSString:args[@"title"]];
-  NSString *message = nil;
-  if (![args[@"message"] isKindOfClass:[NSNull class]]) {
-    message = [RCTConvert NSString:args[@"message"]];
-  }
+  NSString *message = [RCTConvert NSString:args[@"message"]];
   RCTAlertViewStyle type = [RCTConvert RCTAlertViewStyle:args[@"type"]];
   NSArray<NSDictionary *> *buttons = [RCTConvert NSDictionaryArray:args[@"buttons"]];
   NSString *defaultValue = [RCTConvert NSString:args[@"defaultValue"]];


### PR DESCRIPTION
Fixes issue #18439 

Test Plan:
----------
1. Create a simple component:
```
import React from 'react';
import { Text, View, TouchableOpacity, Alert } from 'react-native';

export default class App extends React.Component {
  showAlert = () => {
     Alert.alert('Title', [
      {
        text: 'Cancel',
        style: 'cancel'
      },
      {
        text: 'Ok',
        onPress: () => console.log('Pressed Ok.')
      }
    ], { cancelable: false })
  }
  
  render() {
    return (
      <View>
        <TouchableOpacity onPress={() => this.showAlert()}>
          <Text>Show alert</Text>
        </TouchableOpacity>
      </View>
    );
  }
}
```
2. Run the app and observe an issue described in #18439.
3. Apply the fix.
4. Verify the issue is gone.

Release Notes:
--------------
[ IOS ] [ BUGFIX ] [ AlertIOS ] - Fix AlertIOS so that it doesn't crash when no message is provided.
