### PR TITLE
[CI] Gate failing steps behind a username check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -287,33 +287,32 @@ aliases:
     name: tvOS Test Suite
     command: ./scripts/objc-test-tvos.sh test
 
-  - &run-podspec-tests
-    name: Test CocoaPods (Ignoring failures)
+  - &display-broken-tests-warning
+    name: Running broken tests (Ignore any failures past this point)
     command: |
-      echo 'The following step is known to be failing in master, and any failures will be ignored.'
-      scripts/circleci/exec_swallow_error.sh ./scripts/process-podspecs.sh
+      echo 'The following steps are known to be failing on master.'
+      echo 'They will no-op for most users.'
+      echo 'PRs that bring these back to green are appreciated.'
+
+  - &run-podspec-tests
+    name: Test CocoaPods (Disabled)
+    command: ./scripts/circleci/exec_author_check.sh ./scripts/process-podspecs.sh
 
   - &run-e2e-tests
-    name: End-to-End Test Suite
-    command: node ./scripts/run-ci-e2e-tests.js --android --ios --tvos --js --retries 3;
+    name: End-to-End Test Suite (Disabled)
+    command: ./scripts/circleci/exec_author_check.sh node ./scripts/run-ci-e2e-tests.js --android --ios --tvos --js --retries 3;
 
   - &run-objc-ios-e2e-tests
-    name: iOS End-to-End Test Suite (Ignoring failures)
-    command: |
-      echo 'The following step is known to be failing in master, and any failures will be ignored.'
-      scripts/circleci/exec_swallow_error.sh node ./scripts/run-ci-e2e-tests.js --ios --retries 3;
+    name: iOS End-to-End Test Suite (Disabled)
+    command: ./scripts/circleci/exec_author_check.sh node ./scripts/run-ci-e2e-tests.js --ios --retries 3;
 
   - &run-objc-tvos-e2e-tests
-    name: tvOS End-to-End Test Suite (Ignoring failures)
-    command: |
-      echo 'The following step is known to be failing in master, and any failures will be ignored.'
-      scripts/circleci/exec_swallow_error.sh node ./scripts/run-ci-e2e-tests.js --tvos --js --retries 3;
+    name: tvOS End-to-End Test Suite (Disabled)
+    command: ./scripts/circleci/exec_author_check.sh node ./scripts/run-ci-e2e-tests.js --tvos --js --retries 3;
 
   - &run-android-e2e-tests
-    name: Android End-to-End Test Suite (Ignoring failures)
-    command:  |
-      echo 'The following step is known to be failing in master, and any failures will be ignored.'
-      scripts/circleci/exec_swallow_error.sh node ./scripts/run-ci-e2e-tests.js --android --retries 3;
+    name: Android End-to-End Test Suite (Disabled)
+    command: ./scripts/circleci/exec_author_check.sh node ./scripts/run-ci-e2e-tests.js --android --retries 3;
 
   - &run-js-e2e-tests
     name: JavaScript End-to-End Test Suite
@@ -426,10 +425,8 @@ jobs:
       - run: *run-objc-ios-tests
       - run: *run-objc-tvos-tests
 
-      # The following are "disabled" - the steps will
-      # still run, but failures will be ignored.
-      # This is good for debugging flaky CI steps.
-      # TODO: Reenable as soon as they are in working order.
+      # TODO: Fix these failing tests.
+      - run: *display-broken-tests-warning
       - run: *run-podspec-tests
       - run: *run-objc-ios-e2e-tests
       - run: *run-objc-tvos-e2e-tests
@@ -458,20 +455,15 @@ jobs:
             brew install applesimutils
             node -v
       - run: *yarn
-      # The following are "disabled" - the steps will
-      # still run, but failures will be ignored.
-      # This is good for debugging flaky CI steps.
-      # TODO: Reenable as soon as they are in working order.
+
+      # TODO: Fix these failing tests.
+      - run: *display-broken-tests-warning
       - run:
-          name: Build iOS app for simulator (Ignoring failures)
-          command: |
-            echo 'The following step is known to be failing in master, and any failures will be ignored.'
-            scripts/circleci/exec_swallow_error.sh yarn run build-ios-e2e
+          name: Build iOS app for simulator (Disabled)
+          command: ./scripts/circleci/exec_author_check.sh yarn run build-ios-e2e
       - run:
-          name: Run Detox Tests (Ignoring failures)
-          command: |
-            echo 'The following step is known to be failing in master, and any failures will be ignored.'
-            scripts/circleci/exec_swallow_error.sh yarn run test-ios-e2e
+          name: Run Detox Tests (Disabled)
+          command: ./scripts/circleci/exec_author_check.sh yarn run test-ios-e2e
 
   # Set up an Android environment for downstream jobs
   test_android:
@@ -536,10 +528,8 @@ jobs:
       - run: *build-android-rntester-app
 
       # Run Android end-to-end tests
-      # The following are "disabled" - the steps will
-      # still run, but failures will be ignored.
-      # This is good for debugging flaky CI steps.
-      # TODO: Reenable as soon as they are in working order.
+      # TODO: Fix these failing tests.
+      - run: *display-broken-tests-warning
       - run: *run-android-e2e-tests
 
       # Collect Results

--- a/scripts/circleci/exec_author_check.sh
+++ b/scripts/circleci/exec_author_check.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# This is meant to be used to keep failing tests from
+# running for regular contributors, while still letting
+# them run on PRs submitted by core contributors.
+# Useful when working to bring a failing step back to green.
+
+# Add yourself here if you'd like to pass the whitelist.
+# Once N > 1 we should change this into an array check.
+if [ "$CIRCLE_PR_USERNAME" == "hramos" ]; then
+  # execute command
+  "$@"
+else
+  echo "Skipping " "$@" " as user is not whitelisted"
+fi

--- a/scripts/circleci/exec_author_check.sh
+++ b/scripts/circleci/exec_author_check.sh
@@ -7,9 +7,9 @@
 
 # Add yourself here if you'd like to pass the whitelist.
 # Once N > 1 we should change this into an array check.
-if [ "$CIRCLE_PR_USERNAME" == "hramos" ]; then
+if [ "$CIRCLE_USERNAME" == "hramos" ]; then
   # execute command
   "$@"
 else
-  echo "Skipping " "$@" " as user is not whitelisted"
+  echo "Skipping" "$@" ", user is not whitelisted"
 fi

--- a/scripts/circleci/exec_swallow_error.sh
+++ b/scripts/circleci/exec_swallow_error.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# execute command
-"$@"
+# Execute command, and catch timeouts (CI has a 10 minute default timeout)
+timeout 570 "$@"
 
 # check status
 STATUS=$?

--- a/scripts/circleci/exec_swallow_error.sh
+++ b/scripts/circleci/exec_swallow_error.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# Execute command, and catch timeouts (CI has a 10 minute default timeout)
-timeout 570 "$@"
+# execute command
+"$@"
 
 # check status
 STATUS=$?


### PR DESCRIPTION
There are some steps known to be failing on master. This pollutes checks for unrelated PRs.

This PR will make it so that PRs submitted by anyone other than myself will no-op on these steps.

Future work: Have an array of whitelisted contributors, and make it much easier to turn individual tests on and off.

Test Plan:
Detox no-opped on https://circleci.com/gh/hramos/react-native/3744 (as I was using $CIRCLE_PR_USERNAME but the build was triggered by a fork)

Detox failed on https://circleci.com/gh/hramos/react-native/3754 (as I am now checking for $CIRCLE_USERNAME which matches whoever triggered the build, and in this case it matched hramos)