### PR TITLE
fix RCTNetInfo first time connection status

### DIFF
--- a/Libraries/Network/RCTNetInfo.m
+++ b/Libraries/Network/RCTNetInfo.m
@@ -36,12 +36,14 @@ static NSString *const RCTReachabilityStateCell = @"cell";
 
 @implementation RCTNetInfo
 {
+  SCNetworkReachabilityRef _firstTimeReachability;
   SCNetworkReachabilityRef _reachability;
   NSString *_connectionType;
   NSString *_effectiveConnectionType;
   NSString *_statusDeprecated;
   NSString *_host;
   BOOL _isObserving;
+  RCTPromiseResolveBlock _resolve;
 }
 
 RCT_EXPORT_MODULE()
@@ -49,7 +51,18 @@ RCT_EXPORT_MODULE()
 static void RCTReachabilityCallback(__unused SCNetworkReachabilityRef target, SCNetworkReachabilityFlags flags, void *info)
 {
   RCTNetInfo *self = (__bridge id)info;
-  if ([self setReachabilityStatus:flags] && self->_isObserving) {
+  BOOL didSetReachabilityFlags = [self setReachabilityStatus:flags];
+  if (self->_firstTimeReachability && self->_resolve) {
+    SCNetworkReachabilityUnscheduleFromRunLoop(self->_firstTimeReachability, CFRunLoopGetMain(), kCFRunLoopCommonModes);
+    CFRelease(self->_firstTimeReachability);
+    self->_resolve(@{@"connectionType": self->_connectionType ?: RCTConnectionTypeUnknown,
+                     @"effectiveConnectionType": self->_effectiveConnectionType ?: RCTEffectiveConnectionTypeUnknown,
+                     @"network_info": self->_statusDeprecated ?: RCTReachabilityStateUnknown});
+    self->_firstTimeReachability = nil;
+    self->_resolve = nil;
+  }
+
+  if (didSetReachabilityFlags && self->_isObserving) {
     [self sendEventWithName:@"networkStatusDidChange" body:@{@"connectionType": self->_connectionType,
                                                              @"effectiveConnectionType": self->_effectiveConnectionType,
                                                              @"network_info": self->_statusDeprecated}];
@@ -163,12 +176,8 @@ static void RCTReachabilityCallback(__unused SCNetworkReachabilityRef target, SC
 RCT_EXPORT_METHOD(getCurrentConnectivity:(RCTPromiseResolveBlock)resolve
                   reject:(__unused RCTPromiseRejectBlock)reject)
 {
-  SCNetworkReachabilityRef reachability = [self getReachabilityRef];
-  SCNetworkReachabilityUnscheduleFromRunLoop(reachability, CFRunLoopGetMain(), kCFRunLoopCommonModes);
-  CFRelease(reachability);
-  resolve(@{@"connectionType": _connectionType ?: RCTConnectionTypeUnknown,
-            @"effectiveConnectionType": _effectiveConnectionType ?: RCTEffectiveConnectionTypeUnknown,
-            @"network_info": _statusDeprecated ?: RCTReachabilityStateUnknown});
+  _firstTimeReachability = [self getReachabilityRef];
+  _resolve = resolve;
 }
 
 @end


### PR DESCRIPTION
Fixes #20804, #8615, https://github.com/facebook/react-native/issues/18368#issuecomment-400610022

Test Plan:
----------

1. Works without `connectionChange` event listener

Test Code:
```
import React, {Component} from 'react';
import {Platform, StyleSheet, Text, View, NetInfo} from 'react-native';

export default class App extends Component {
  state = {
    isConnected: false
  };

  componentWillMount() {
    NetInfo.isConnected.fetch().then(isConnected => {
      this.setState({
        isConnected
      });
    });
  }

  render() {
    return (
      <View style={styles.container}>
        <Text>{`isConnected: ${this.state.isConnected}`}</Text>
      </View>
    );
  }
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    justifyContent: 'center',
    alignItems: 'center',
  },
});
```


The code shown above will now return the right connection status. If you're connected to Wifi or cellular, it will return `true`, else `false`. Previously, it always returned false for the first time.

![img_1594](https://user-images.githubusercontent.com/1824298/44554794-3eddfa00-a72a-11e8-8c99-1eef5dc43508.JPG)


2. Works with `connectionChange` event listener

Test Code:
```
import React, {Component} from 'react';
import {Platform, StyleSheet, Text, View, NetInfo} from 'react-native';

export default class App extends Component {
  state = {
    isConnected: false
  };

  componentWillMount() {
    NetInfo.isConnected.fetch().then(isConnected => {
      this.setState({
        isConnected
      });
    });
    const handleFirstConnectivityChange = (isConnected) => {
      this.setState({
        isConnected
      });
    }
    NetInfo.isConnected.addEventListener(
      'connectionChange',
      handleFirstConnectivityChange
    );
  }

  render() {
    return (
      <View style={styles.container}>
        <Text>{`isConnected: ${this.state.isConnected}`}</Text>
      </View>
    );
  }
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    justifyContent: 'center',
    alignItems: 'center',
    backgroundColor: '#F5FCFF',
  },
});
```

The change done in this PR does not create any regression in the event listener flow. This still works perfectly fine.

Release Notes:
--------------

[IOS] [BUGFIX] [NETINFO] - fixes RCTNetInfo incorrect first time connection status

<!--
  **INTERNAL and MINOR tagged notes will not be included in the next version's final release notes.**

    CATEGORY
  [----------]      TYPE
  [ CLI      ] [-------------]    LOCATION
  [ DOCS     ] [ BREAKING    ] [-------------]
  [ GENERAL  ] [ BUGFIX      ] [ {Component} ]
  [ INTERNAL ] [ ENHANCEMENT ] [ {Filename}  ]
  [ IOS      ] [ FEATURE     ] [ {Directory} ]   |-----------|
  [ ANDROID  ] [ MINOR       ] [ {Framework} ] - | {Message} |
  [----------] [-------------] [-------------]   |-----------|

 EXAMPLES:

 [IOS] [BREAKING] [FlatList] - Change a thing that breaks other things
 [ANDROID] [BUGFIX] [TextInput] - Did a thing to TextInput
 [CLI] [FEATURE] [local-cli/info/info.js] - CLI easier to do things with
 [DOCS] [BUGFIX] [GettingStarted.md] - Accidentally a thing/word
 [GENERAL] [ENHANCEMENT] [Yoga] - Added new yoga thing/position
 [INTERNAL] [FEATURE] [./scripts] - Added thing to script that nobody will see
-->
