### PR TITLE
Add support for out-of-tree platform plugins

### DIFF
--- a/jest/__tests__/hasteImpl-test.js
+++ b/jest/__tests__/hasteImpl-test.js
@@ -32,7 +32,7 @@ it('returns the correct haste name for a RN library file', () => {
 });
 
 it('returns the correct haste name for a file with a platform suffix', () => {
-  for (const platform of ['android', 'ios', 'native', 'web', 'windows']) {
+  for (const platform of ['android', 'ios', 'native']) {
     expect(
       getHasteName(
         getPath(

--- a/jest/hasteImpl.js
+++ b/jest/hasteImpl.js
@@ -24,7 +24,7 @@ const pluginNameReducers /*: Array<[RegExp, string]> */ = plugins.haste.platform
 
 const ROOTS = [
   path.resolve(__dirname, '..') + path.sep,
-  ...pluginRoots
+  ...pluginRoots,
 ];
 
 const BLACKLISTED_PATTERNS /*: Array<RegExp> */ = [
@@ -48,7 +48,7 @@ const NAME_REDUCERS /*: Array<[RegExp, string]> */ = [
   // strip platform suffix
   [/^(.*)\.(android|ios|native)$/, '$1'],
   // strip plugin platform suffixes
-  ...pluginNameReducers
+  ...pluginNameReducers,
 ];
 
 const haste = {

--- a/jest/hasteImpl.js
+++ b/jest/hasteImpl.js
@@ -16,16 +16,20 @@ const findPlugins = require('../local-cli/core/findPlugins');
 const plugins = findPlugins([path.resolve(__dirname, '../../../')]);
 
 // Detect out-of-tree platforms and add them to the whitelists
-const pluginRoots /*: Array<string> */ = plugins.haste.providesModuleNodeModules.map(
-  name => path.resolve(__dirname, '../../', name) + path.sep);
+const pluginRoots /*: Array<
+  string,
+> */ = plugins.haste.providesModuleNodeModules.map(
+  name => path.resolve(__dirname, '../../', name) + path.sep,
+);
 
-const pluginNameReducers /*: Array<[RegExp, string]> */ = plugins.haste.platforms.map(
-  name => [new RegExp(`^(.*)\.(${name})$`), '$1']);
+const pluginNameReducers /*: Array<
+  [RegExp, string],
+> */ = plugins.haste.platforms.map(name => [
+  new RegExp(`^(.*)\.(${name})$`),
+  '$1',
+]);
 
-const ROOTS = [
-  path.resolve(__dirname, '..') + path.sep,
-  ...pluginRoots,
-];
+const ROOTS = [path.resolve(__dirname, '..') + path.sep, ...pluginRoots];
 
 const BLACKLISTED_PATTERNS /*: Array<RegExp> */ = [
   /.*[\\\/]__(mocks|tests)__[\\\/].*/,

--- a/jest/hasteImpl.js
+++ b/jest/hasteImpl.js
@@ -11,11 +11,20 @@
 'use strict';
 
 const path = require('path');
+const findPlugins = require('../local-cli/core/findPlugins');
+
+const plugins = findPlugins([path.resolve(__dirname, '../../../')]);
+
+// Detect out-of-tree platforms and add them to the whitelists
+const pluginRoots /*: Array<string> */ = plugins.haste.providesModuleNodeModules.map(
+  name => path.resolve(__dirname, '../../', name) + path.sep);
+
+const pluginNameReducers /*: Array<[RegExp, string]> */ = plugins.haste.platforms.map(
+  name => [new RegExp(`^(.*)\.(${name})$`), '$1']);
 
 const ROOTS = [
   path.resolve(__dirname, '..') + path.sep,
-  path.resolve(__dirname, '../../react-native-windows') + path.sep,
-  path.resolve(__dirname, '../../react-native-dom') + path.sep,
+  ...pluginRoots
 ];
 
 const BLACKLISTED_PATTERNS /*: Array<RegExp> */ = [
@@ -36,8 +45,10 @@ const NAME_REDUCERS /*: Array<[RegExp, string]> */ = [
   [/^(?:.*[\\\/])?([a-zA-Z0-9$_.-]+)$/, '$1'],
   // strip .js/.js.flow suffix
   [/^(.*)\.js(\.flow)?$/, '$1'],
-  // strip .android/.ios/.native/.web suffix
-  [/^(.*)\.(android|ios|native|web|windows|dom)$/, '$1'],
+  // strip platform suffix
+  [/^(.*)\.(android|ios|native)$/, '$1'],
+  // strip plugin platform suffixes
+  ...pluginNameReducers
 ];
 
 const haste = {

--- a/local-cli/core/findPlugins.js
+++ b/local-cli/core/findPlugins.js
@@ -52,8 +52,8 @@ const getEmptyPluginConfig = () => ({
   platforms: [],
   haste: {
     platforms: [],
-    providesModuleNodeModules: []
-  }
+    providesModuleNodeModules: [],
+  },
 });
 
 const findHasteConfigInPackageAndConcat = (pjson, haste) => {
@@ -67,11 +67,10 @@ const findHasteConfigInPackageAndConcat = (pjson, haste) => {
   }
 
   if (pkgHaste.providesModuleNodeModules) {
-    haste.providesModuleNodeModules = 
+    haste.providesModuleNodeModules =
       haste.providesModuleNodeModules.concat(pkgHaste.providesModuleNodeModules);
   }
 };
-
 
 const findPluginInFolder = folder => {
   const pjson = readPackage(folder);
@@ -119,7 +118,7 @@ module.exports = function findPlugins(folders) {
     platforms: uniq(flatten(plugins.map(p => p.platforms))),
     haste: {
       platforms: uniq(flatten(plugins.map(p => p.haste.platforms))),
-      providesModuleNodeModules: uniq(flatten(plugins.map(p => p.haste.providesModuleNodeModules)))
-    }
+      providesModuleNodeModules: uniq(flatten(plugins.map(p => p.haste.providesModuleNodeModules))),
+    },
   };
 };

--- a/local-cli/core/index.js
+++ b/local-cli/core/index.js
@@ -70,11 +70,11 @@ const defaultConfig = {
   hasteImplModulePath: require.resolve('../../jest/hasteImpl'),
 
   getPlatforms(): Array<string> {
-    return ['ios', 'android', 'windows', 'web', 'dom'];
+    return ['ios', 'android', 'native', ...plugins.haste.platforms];
   },
 
   getProvidesModuleNodeModules(): Array<string> {
-    return ['react-native', 'react-native-windows', 'react-native-dom'];
+    return ['react-native', ...plugins.haste.providesModuleNodeModules];
   },
 };
 
@@ -133,8 +133,10 @@ async function getCliConfig(): Promise<RNConfig> {
 
   config.transformer.assetRegistryPath = ASSET_REGISTRY_PATH;
   config.resolver.hasteImplModulePath = config.resolver.hasteImplModulePath || defaultConfig.hasteImplModulePath;
-  config.resolver.platforms = config.resolver.platforms || defaultConfig.getPlatforms();
-  config.resolver.providesModuleNodeModules = config.resolver.providesModuleNodeModules || defaultConfig.getProvidesModuleNodeModules();
+  config.resolver.platforms = config.resolver.platforms ?
+    config.resolver.platforms.concat(defaultConfig.getPlatforms()) : defaultConfig.getPlatforms();
+  config.resolver.providesModuleNodeModules = config.resolver.providesModuleNodeModules ?
+    config.resolver.providesModuleNodeModules.concat(defaultConfig.getProvidesModuleNodeModules()) : defaultConfig.getProvidesModuleNodeModules();
 
   return {...defaultRNConfig, ...config};
 }

--- a/local-cli/core/index.js
+++ b/local-cli/core/index.js
@@ -132,11 +132,17 @@ async function getCliConfig(): Promise<RNConfig> {
   );
 
   config.transformer.assetRegistryPath = ASSET_REGISTRY_PATH;
-  config.resolver.hasteImplModulePath = config.resolver.hasteImplModulePath || defaultConfig.hasteImplModulePath;
-  config.resolver.platforms = config.resolver.platforms ?
-    config.resolver.platforms.concat(defaultConfig.getPlatforms()) : defaultConfig.getPlatforms();
-  config.resolver.providesModuleNodeModules = config.resolver.providesModuleNodeModules ?
-    config.resolver.providesModuleNodeModules.concat(defaultConfig.getProvidesModuleNodeModules()) : defaultConfig.getProvidesModuleNodeModules();
+  config.resolver.hasteImplModulePath =
+    config.resolver.hasteImplModulePath || defaultConfig.hasteImplModulePath;
+  config.resolver.platforms = config.resolver.platforms
+    ? config.resolver.platforms.concat(defaultConfig.getPlatforms())
+    : defaultConfig.getPlatforms();
+  config.resolver.providesModuleNodeModules = config.resolver
+    .providesModuleNodeModules
+    ? config.resolver.providesModuleNodeModules.concat(
+        defaultConfig.getProvidesModuleNodeModules(),
+      )
+    : defaultConfig.getProvidesModuleNodeModules();
 
   return {...defaultRNConfig, ...config};
 }


### PR DESCRIPTION
This pull request adds the ability for a platform developer to provide a `"haste"` key under the `"rnpm"` key in their `package.json` which allows the packager to pick up that platform's javascript files. The intent is to remove the need to have custom platforms hardcoded in. This is inspired by the `"jest": { "haste": {} }` key used by jest.

For example, React Native Dom would have an entry like:

```json
{
  "rnpm": {
    "haste": {
      "providesModuleNodeModules": [
        "react-native-dom"
      ],
      "platforms": [
        "dom"
      ]
    }
  }
}
```

Support for more keys (path blacklists perhaps?) could be added in the future.

This succeeds #20662, as per a discussion I had with @matthargett.

I've got an open discussion over here as well: https://github.com/react-native-community/discussions-and-proposals/issues/21

Test Plan:
----------
I've modified a local copy of RNDom to have the above example in its `package.json` in an unmodified default React Native app project, and a JS bundle was build successfully.

Release Notes:
--------------

[CLI] [ENHANCEMENT] [local-cli/core/findPlugins.js] - Modified the `findPlugins` function to handle this new `haste` field
[CLI] [ENHANCEMENT] [local-cli/core/index.js] - Removed the hardcoded platforms and switched to use output from `findPlugins`
