### PR TITLE
Currently Focused field was returning undefined

### DIFF
--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -325,7 +325,7 @@ const TextInput = createReactClass({
   displayName: 'TextInput',
   statics: {
     State: {
-      currentlyFocusedField: TextInputState.currentlyFocusedField,
+      currentlyFocusedField: TextInputState.currentlyFocusedField.bind(TextInputState),
       focusTextInput: (textFieldID: ?number) => {
         console.warn(
           '`focusTextInput` is deprecated, use the `focus` method of the `TextInput` ref instead.',


### PR DESCRIPTION
Hello,

After upgrading my project to rn-0.56 from rn-0.52., I had issues with getting the node of the TextInput that is focused on my screens, so I could do proper scrolling below the TextInput. 

Issue is very simple, TextInput.State.currentlyFocusedField() is losing reference and that's why it didn't work. My change is just one line of code and it's pretty much self explained.