### PR TITLE
[WIP] [NativeAnimated] Allow using layout props

### DIFF
--- a/Libraries/Animated/src/NativeAnimatedHelper.js
+++ b/Libraries/Animated/src/NativeAnimatedHelper.js
@@ -153,6 +153,8 @@ const STYLES_WHITELIST = {
   borderTopLeftRadius: true,
   borderTopRightRadius: true,
   borderTopStartRadius: true,
+  width: true,
+  height: true,
   elevation: true,
   /* ios styles */
   shadowOpacity: true,

--- a/Libraries/NativeAnimation/Nodes/RCTPropsAnimatedNode.m
+++ b/Libraries/NativeAnimation/Nodes/RCTPropsAnimatedNode.m
@@ -9,6 +9,7 @@
 
 #import <React/RCTLog.h>
 #import <React/RCTUIManager.h>
+#import <React/RCTUIManagerUtils.h>
 
 #import "RCTAnimationUtils.h"
 #import "RCTStyleAnimatedNode.h"
@@ -55,9 +56,11 @@
   }
 
   if (_propsDictionary.count) {
-    [_uiManager synchronouslyUpdateViewOnUIThread:_connectedViewTag
-                                         viewName:_connectedViewName
-                                            props:_propsDictionary];
+    RCTUnsafeExecuteOnUIManagerQueueSync(^{
+      [self->_uiManager synchronouslyUpdateViewOnPseudoUIManagerThread:self->_connectedViewTag
+                                                              viewName:self->_connectedViewName
+                                                                 props:self->_propsDictionary];
+    });
   }
 }
 
@@ -83,12 +86,12 @@
   if (!_connectedViewTag) {
     return;
   }
-  
+
   for (NSNumber *parentTag in self.parentNodes.keyEnumerator) {
     RCTAnimatedNode *parentNode = [self.parentNodes objectForKey:parentTag];
     if ([parentNode isKindOfClass:[RCTStyleAnimatedNode class]]) {
       [self->_propsDictionary addEntriesFromDictionary:[(RCTStyleAnimatedNode *)parentNode propsDictionary]];
-      
+
     } else if ([parentNode isKindOfClass:[RCTValueAnimatedNode class]]) {
       NSString *property = [self propertyNameForParentTag:parentTag];
       CGFloat value = [(RCTValueAnimatedNode *)parentNode value];
@@ -97,9 +100,9 @@
   }
 
   if (_propsDictionary.count) {
-    [_uiManager synchronouslyUpdateViewOnUIThread:_connectedViewTag
-                                         viewName:_connectedViewName
-                                            props:_propsDictionary];
+    [_uiManager synchronouslyUpdateViewOnPseudoUIManagerThread:_connectedViewTag
+                                                      viewName:_connectedViewName
+                                                         props:_propsDictionary];
   }
 }
 

--- a/Libraries/NativeAnimation/RCTNativeAnimatedNodesManager.m
+++ b/Libraries/NativeAnimation/RCTNativeAnimatedNodesManager.m
@@ -8,6 +8,7 @@
 #import "RCTNativeAnimatedNodesManager.h"
 
 #import <React/RCTConvert.h>
+#import <React/RCTUIManagerUtils.h>
 
 #import "RCTAdditionAnimatedNode.h"
 #import "RCTAnimatedNode.h"
@@ -432,11 +433,15 @@
 
 - (void)updateAnimations
 {
-  [_animationNodes enumerateKeysAndObjectsUsingBlock:^(NSNumber *key, RCTAnimatedNode *node, BOOL *stop) {
-    if (node.needsUpdate) {
-      [node updateNodeIfNecessary];
-    }
-  }];
+  RCTUnsafeExecuteOnUIManagerQueueSync(^{
+    [self->_animationNodes enumerateKeysAndObjectsUsingBlock:^(NSNumber *key, RCTAnimatedNode *node, BOOL *stop) {
+      if (node.needsUpdate) {
+        [node updateNodeIfNecessary];
+      }
+    }];
+
+    [self->_uiManager synchronouslyLayoutOnPseudoUIManagerThread];
+  });
 }
 
 @end

--- a/RNTester/js/NativeAnimationsExample.js
+++ b/RNTester/js/NativeAnimationsExample.js
@@ -174,7 +174,7 @@ class InternalSettings extends React.Component<
             this._stallInterval = setInterval(() => {
               const start = Date.now();
               console.warn('burn CPU');
-              while (Date.now() - start < 100) {}
+              while (Date.now() - start < 200) {}
             }, 300);
           }}
           onDisable={() => {
@@ -220,23 +220,11 @@ class EventExample extends React.Component<{}, $FlowFixMeState> {
   };
 
   render() {
-    const opacity = this.state.scrollX.interpolate({
-      inputRange: [0, 200],
-      outputRange: [1, 0],
-    });
     return (
-      <View>
-        <Animated.View
-          style={[
-            styles.block,
-            {
-              opacity,
-            },
-          ]}
-        />
+      <View style={{height: 100, marginTop: 16}}>
         <Animated.ScrollView
           horizontal
-          style={{height: 100, marginTop: 16}}
+          style={{flex: 1}}
           scrollEventThrottle={16}
           onScroll={Animated.event(
             [{nativeEvent: {contentOffset: {x: this.state.scrollX}}}],
@@ -248,9 +236,24 @@ class EventExample extends React.Component<{}, $FlowFixMeState> {
               backgroundColor: '#eee',
               justifyContent: 'center',
             }}>
-            <Text>Scroll me!</Text>
+            <Text style={{marginLeft: 100}}>Scroll me!</Text>
           </View>
         </Animated.ScrollView>
+        <Animated.View
+          style={[
+            {
+              position: 'absolute',
+              left: 0,
+              top: 0,
+              bottom: 0,
+              width: 100,
+              transform: [
+                {translateX: Animated.multiply(this.state.scrollX, -1)},
+              ],
+              backgroundColor: 'blue',
+            },
+          ]}
+        />
       </View>
     );
   }
@@ -625,6 +628,32 @@ exports.examples = [
                       translateX: anim,
                     },
                   ],
+                },
+              ]}
+            />
+          )}
+        </Tester>
+      );
+    },
+  },
+  {
+    title: 'Layout props',
+    render: function() {
+      return (
+        <Tester type="spring" config={{bounciness: 0}}>
+          {anim => (
+            <Animated.View
+              style={[
+                styles.block,
+                {
+                  height: anim.interpolate({
+                    inputRange: [0, 1],
+                    outputRange: [20, 100],
+                  }),
+                  width: anim.interpolate({
+                    inputRange: [0, 1],
+                    outputRange: [20, 50],
+                  }),
                 },
               ]}
             />

--- a/React/Base/RCTEventDispatcher.m
+++ b/React/Base/RCTEventDispatcher.m
@@ -45,7 +45,6 @@ static NSNumber *RCTGetEventID(id<RCTEvent> event)
   NSMutableArray<NSNumber *> *_eventQueue;
   BOOL _eventsDispatchScheduled;
   NSHashTable<id<RCTEventDispatcherObserver>> *_observers;
-  NSLock *_observersLock;
 }
 
 @synthesize bridge = _bridge;
@@ -60,7 +59,6 @@ RCT_EXPORT_MODULE()
   _eventQueueLock = [NSLock new];
   _eventsDispatchScheduled = NO;
   _observers = [NSHashTable weakObjectsHashTable];
-  _observersLock = [NSLock new];
 }
 
 - (void)sendAppEventWithName:(NSString *)name body:(id)body
@@ -142,13 +140,9 @@ RCT_EXPORT_MODULE()
 
 - (void)sendEvent:(id<RCTEvent>)event
 {
-  [_observersLock lock];
-
   for (id<RCTEventDispatcherObserver> observer in _observers) {
     [observer eventDispatcherWillDispatchEvent:event];
   }
-
-  [_observersLock unlock];
 
   [_eventQueueLock lock];
 
@@ -183,16 +177,12 @@ RCT_EXPORT_MODULE()
 
 - (void)addDispatchObserver:(id<RCTEventDispatcherObserver>)observer
 {
-  [_observersLock lock];
   [_observers addObject:observer];
-  [_observersLock unlock];
 }
 
 - (void)removeDispatchObserver:(id<RCTEventDispatcherObserver>)observer
 {
-  [_observersLock lock];
   [_observers removeObject:observer];
-  [_observersLock unlock];
 }
 
 - (void)dispatchEvent:(id<RCTEvent>)event

--- a/React/Modules/RCTUIManager.h
+++ b/React/Modules/RCTUIManager.h
@@ -106,14 +106,19 @@ RCT_EXTERN NSString *const RCTUIManagerWillUpdateViewsDueToContentSizeMultiplier
 - (void)prependUIBlock:(RCTViewManagerUIBlock)block;
 
 /**
- * Used by native animated module to bypass the process of updating the values through the shadow
- * view hierarchy. This method will directly update native views, which means that updates for
- * layout-related propertied won't be handled properly.
- * Make sure you know what you're doing before calling this method :)
+ * Update a view and its shadow view synchronously from the pseudo ui manager thread.
+ * Only use if you know what you are doing :)
  */
-- (void)synchronouslyUpdateViewOnUIThread:(NSNumber *)reactTag
-                                 viewName:(NSString *)viewName
-                                    props:(NSDictionary *)props;
+- (void)synchronouslyUpdateViewOnPseudoUIManagerThread:(NSNumber *)reactTag
+                                              viewName:(NSString *)viewName
+                                                 props:(NSDictionary *)props;
+
+/**
+ * Perform layout synchronously from the pseudo ui manager thread.
+ * Bypasses batching to avoid interferring with any pending batches.
+ * Only use if you know what you are doing :)
+ */
+- (void)synchronouslyLayoutOnPseudoUIManagerThread;
 
 /**
  * Given a reactTag from a component, find its root view, if possible.

--- a/React/Modules/RCTUIManager.m
+++ b/React/Modules/RCTUIManager.m
@@ -986,14 +986,33 @@ RCT_EXPORT_METHOD(updateView:(nonnull NSNumber *)reactTag
   [self _shadowView:shadowView didReceiveUpdatedProps:[props allKeys]];
 }
 
-- (void)synchronouslyUpdateViewOnUIThread:(NSNumber *)reactTag
-                                 viewName:(NSString *)viewName
-                                    props:(NSDictionary *)props
+- (void)synchronouslyUpdateViewOnPseudoUIManagerThread:(NSNumber *)reactTag
+                                              viewName:(NSString *)viewName
+                                                 props:(NSDictionary *)props
 {
-  RCTAssertMainQueue();
-  RCTComponentData *componentData = _componentDataByName[viewName];
-  UIView *view = _viewRegistry[reactTag];
+  RCTAssertPseudoUIManagerQueue();
+
+  RCTShadowView *shadowView = self->_shadowViewRegistry[reactTag];
+  RCTComponentData *componentData = self->_componentDataByName[shadowView.viewName ?: viewName];
+  [componentData setProps:props forShadowView:shadowView];
+  [shadowView didSetProps:[props allKeys]];
+
+  UIView *view = self->_viewRegistry[reactTag];
   [componentData setProps:props forView:view];
+  [view didSetProps:[props allKeys]];
+}
+
+- (void)synchronouslyLayoutOnPseudoUIManagerThread
+{
+  RCTAssertPseudoUIManagerQueue();
+
+  for (NSNumber *reactTag in self->_rootViewTags) {
+    RCTRootShadowView *rootView = (RCTRootShadowView *)self->_shadowViewRegistry[reactTag];
+    RCTViewManagerUIBlock block = [self uiBlockWithLayoutUpdateForRootView:rootView];
+    if (block != nil) {
+      block(self, self->_viewRegistry);
+    }
+  }
 }
 
 RCT_EXPORT_METHOD(focus:(nonnull NSNumber *)reactTag)
@@ -1174,7 +1193,7 @@ RCT_EXPORT_METHOD(dispatchViewManagerCommand:(nonnull NSNumber *)reactTag
     [tags addObject:shadowView.reactTag];
   }
 
-  [self addUIBlock:^(RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry) {
+  [self addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry) {
     for (NSNumber *tag in tags) {
       UIView<RCTComponent> *view = viewRegistry[tag];
       [view didUpdateReactSubviews];
@@ -1199,7 +1218,7 @@ RCT_EXPORT_METHOD(dispatchViewManagerCommand:(nonnull NSNumber *)reactTag
     [tags setObject:props forKey:shadowView.reactTag];
   }
 
-  [self addUIBlock:^(RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry) {
+  [self addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry) {
     for (NSNumber *tag in tags) {
       UIView<RCTComponent> *view = viewRegistry[tag];
       [view didSetProps:[tags objectForKey:tag]];

--- a/React/Modules/RCTUIManagerUtils.h
+++ b/React/Modules/RCTUIManagerUtils.h
@@ -78,6 +78,13 @@ RCT_EXTERN BOOL RCTIsUIManagerQueue(void);
 RCT_EXTERN BOOL RCTIsPseudoUIManagerQueue(void);
 
 /**
+ * Assert that we are currently on Pseudo UIManager queue.
+ * Please do not use this unless you really know what you're doing.
+ */
+#define RCTAssertPseudoUIManagerQueue() RCTAssert(RCTIsPseudoUIManagerQueue(), \
+@"This function must be called on the pseudo ui manager queue (using RCTUnsafeExecuteOnUIManagerQueueSync)")
+
+/**
  * *Asynchronously* executes the specified block on the UIManager queue.
  * Unlike `dispatch_async()` this will execute the block immediately
  * if we're already on the UIManager queue.

--- a/ReactAndroid/src/main/java/com/facebook/react/animated/NativeAnimatedNodesManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/animated/NativeAnimatedNodesManager.java
@@ -570,6 +570,12 @@ import javax.annotation.Nullable;
       }
     }
 
+    // Once all shadow nodes are updated we can do layout synchonously
+    // from the UI thread.
+    if (updatedNodesCount > 0) {
+      mUIImplementation.synchronouslyDispatchViewUpdatesOnUIThread();
+    }
+
     // Verify that we've visited *all* active nodes. Throw otherwise as this would mean there is a
     // cycle in animated node graph. We also take advantage of the fact that all active nodes are
     // visited in the step above so that all the nodes properties `mActiveIncomingNodes` are set to

--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactContext.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactContext.java
@@ -285,6 +285,10 @@ public class ReactContext extends ContextWrapper {
     Assertions.assertNotNull(mNativeModulesMessageQueueThread).runOnQueue(runnable);
   }
 
+  public void runOnNativeModulesQueueThreadSync(Runnable runnable) {
+    Assertions.assertNotNull(mNativeModulesMessageQueueThread).runOnQueueSync(runnable);
+  }
+
   public void assertOnJSQueueThread() {
     Assertions.assertNotNull(mJSMessageQueueThread).assertIsOnThread();
   }

--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/queue/MessageQueueThread.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/queue/MessageQueueThread.java
@@ -25,6 +25,13 @@ public interface MessageQueueThread {
   void runOnQueue(Runnable runnable);
 
   /**
+   * Runs the given Runnable on this Thread synchronously. The calling thread will be blocked
+   * until the Runnable is finished executing.
+   */
+  @DoNotStrip
+  void runOnQueueSync(Runnable runnable);
+
+  /**
    * Runs the given Callable on this Thread. It will be submitted to the end of the event queue even
    * if it is being submitted from the same queue Thread.
    */


### PR DESCRIPTION
This updates the way native animated update props and uses the same code path as regular updates, this allows using all layout props. To make this work we need to do layout synchronously on the main thread to make sure views are updated synchronously in response to gesture events.

To be able to do this I added `runOnQueueSync` which blocks the calling thread while running some code on the desired thread. Since the shadow tree is mutable we need to do this to avoid race conditions.

The update is done in two passes. First the native animated driver updates shadow nodes props that are connected to animated props, then it actually does layout and updates native views by calling `dispatchViewUpdates`.

Test Plan:
----------
Added an example animation with layout props to RNTester
Made sure all current RNTester native animation examples behave properly with JS stalls enabled.

Release Notes:
--------------
Help reviewers and the release process by writing your own release notes. See below for an example.

[GENERAL] [ENHANCEMENT] [NativeAnimated] - Allow using layout props
