### PR TITLE
Update link command for Android project

### DIFF
--- a/local-cli/link/__fixtures__/android/build.gradle
+++ b/local-cli/link/__fixtures__/android/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-    compile fileTree(dir: "libs", include: ["*.jar"])
-    compile "com.android.support:appcompat-v7:27.1.1"
-    compile "com.facebook.react:react-native:+"
+    implementation fileTree(dir: "libs", include: ["*.jar"])
+    implementation "com.android.support:appcompat-v7:27.1.1"
+    implementation "com.facebook.react:react-native:+"
 }

--- a/local-cli/link/__fixtures__/android/patchedBuild.gradle
+++ b/local-cli/link/__fixtures__/android/patchedBuild.gradle
@@ -1,9 +1,9 @@
 dependencies {
-    compile project(':test')
-    compile(project(':test2')) {
+    implementation project(':test')
+    implementation(project(':test2')) {
       exclude(group: 'org.unwanted', module: 'test10')
     }
-    compile fileTree(dir: "libs", include: ["*.jar"])
-    compile "com.android.support:appcompat-v7:27.1.1"
-    compile "com.facebook.react:react-native:+"
+    implementation fileTree(dir: "libs", include: ["*.jar"])
+    implementation "com.android.support:appcompat-v7:27.1.1"
+    implementation "com.facebook.react:react-native:+"
 }

--- a/local-cli/link/__tests__/android/makeBuildPatch.spec.js
+++ b/local-cli/link/__tests__/android/makeBuildPatch.spec.js
@@ -26,12 +26,12 @@ describe('makeBuildPatch', () => {
 
   it('should make a correct patch', () => {
     const {patch} = makeBuildPatch(name);
-    expect(patch).toBe(`    compile project(':${name}')\n`);
+    expect(patch).toBe(`    implementation project(':${name}')\n`);
   });
 
   it('should make a correct install check pattern', () => {
     const {installPattern} = makeBuildPatch(name);
-    const match = `/\\s{4}(compile)(\\(|\\s)(project)\\(\\':${name}\\'\\)(\\)|\\s)/`;
+    const match = `/\\s{4}(implementation)(\\(|\\s)(project)\\(\\':${name}\\'\\)(\\)|\\s)/`;
     expect(installPattern.toString()).toBe(match);
   });
 });
@@ -39,12 +39,14 @@ describe('makeBuildPatch', () => {
 describe('makeBuildPatchWithScopedPackage', () => {
   it('should make a correct patch', () => {
     const {patch} = makeBuildPatch(scopedName);
-    expect(patch).toBe(`    compile project(':${normalizedScopedName}')\n`);
+    expect(patch).toBe(
+      `    implementation project(':${normalizedScopedName}')\n`,
+    );
   });
 
   it('should make a correct install check pattern', () => {
     const {installPattern} = makeBuildPatch(scopedName);
-    const match = `/\\s{4}(compile)(\\(|\\s)(project)\\(\\':${normalizedScopedName}\\'\\)(\\)|\\s)/`;
+    const match = `/\\s{4}(implementation)(\\(|\\s)(project)\\(\\':${normalizedScopedName}\\'\\)(\\)|\\s)/`;
     expect(installPattern.toString()).toBe(match);
   });
 });

--- a/local-cli/link/android/patches/makeBuildPatch.js
+++ b/local-cli/link/android/patches/makeBuildPatch.js
@@ -12,12 +12,12 @@ const normalizeProjectName = require('./normalizeProjectName');
 module.exports = function makeBuildPatch(name) {
   const normalizedProjectName = normalizeProjectName(name);
   const installPattern = new RegExp(
-    `\\s{4}(compile)(\\(|\\s)(project)\\(\\\':${normalizedProjectName}\\\'\\)(\\)|\\s)`,
+    `\\s{4}(implementation)(\\(|\\s)(project)\\(\\\':${normalizedProjectName}\\\'\\)(\\)|\\s)`,
   );
 
   return {
     installPattern,
     pattern: /[^ \t]dependencies {(\r\n|\n)/,
-    patch: `    compile project(':${normalizedProjectName}')\n`,
+    patch: `    implementation project(':${normalizedProjectName}')\n`,
   };
 };


### PR DESCRIPTION
Motivation:
--------------
PR #20767 bumped the version of the Android Gradle Plugin to v3 which uses the newer Gradle dependency configurations `implementation` and `api` which make `compile` obsolete.

While the PR updated the template Gradle configuration, it did not cover the `link` command which will still link native modules using `compile` resulting in a warning message beeing displayed during an app build.

Since `compile` will be eventually removed by Gradle, this commit updates the `link` command to attach native modules using `implementation`.

Test Plan:
----------
Ran the tests on my branch:

![screenshot from 2018-08-26 12-37-28](https://user-images.githubusercontent.com/1713151/44627388-7b2d7800-a92d-11e8-8b74-f0231abd22d3.png)

**Note:** *test_android*, *test_detox_end_to_end* and *test_objc* seem to fail for other reasons discussed in https://github.com/facebook/react-native/pull/20854.

then,

1. Initialized a new RN project using the most recent candidate which is necessary for the project to understand the new `implementation` dependency configuration keyword
```
react-native init demoProject --version="0.57.0-rc.3"
```
2. Added a RN native module that targets Android as a dependency
```
yarn add react-native-custom-tabs
```
3. Copied the `local-cli/link` folder from my branch into `demoProject/node_modules/react-native/local-cli`
4. Followed the [additional step](https://github.com/droibit/react-native-custom-tabs#installation) in the module guide (added a repository).
5. Linked the added module using the local modified react-native
```
yarn run react-native link react-native-custom-tabs
```
![screenshot from 2018-08-26 12-47-58](https://user-images.githubusercontent.com/1713151/44627532-bdf04f80-a92f-11e8-9163-1c0e882e52ba.png)

6. Checked that `android/app/build.gradle` has been patched correctly with `implementation`.

![screenshot from 2018-08-26 12-53-41](https://user-images.githubusercontent.com/1713151/44627538-dbbdb480-a92f-11e8-82cd-156d9d202b0d.png)

7. Checked that `android/settings.gradle` and `MainApplication.java` have been patched as usual.
8. Built and installed successfully on a physical device without the deprecation warning (ignore the ones in the screenshot as they are related to the custom-tabs module as itself is not using the new configurations).
```
yarn run react-native run-android
```
![screenshot from 2018-08-26 13-13-18](https://user-images.githubusercontent.com/1713151/44627670-d6616980-a931-11e8-8687-835644628a78.png)

9. Unlinked and checked that is was successful.

Related PRs:
--------------
- https://github.com/facebook/react-native/pull/20767.

Release Notes:
--------------
[CLI] [ENHANCEMENT] [local-cli/link] - Updated `link` to link Android modules as `implementation` dependencies.

<!--
  **INTERNAL and MINOR tagged notes will not be included in the next version's final release notes.**

    CATEGORY
  [----------]      TYPE
  [ CLI      ] [-------------]    LOCATION
  [ DOCS     ] [ BREAKING    ] [-------------]
  [ GENERAL  ] [ BUGFIX      ] [ {Component} ]
  [ INTERNAL ] [ ENHANCEMENT ] [ {Filename}  ]
  [ IOS      ] [ FEATURE     ] [ {Directory} ]   |-----------|
  [ ANDROID  ] [ MINOR       ] [ {Framework} ] - | {Message} |
  [----------] [-------------] [-------------]   |-----------|

 EXAMPLES:

 [IOS] [BREAKING] [FlatList] - Change a thing that breaks other things
 [ANDROID] [BUGFIX] [TextInput] - Did a thing to TextInput
 [CLI] [FEATURE] [local-cli/info/info.js] - CLI easier to do things with
 [DOCS] [BUGFIX] [GettingStarted.md] - Accidentally a thing/word
 [GENERAL] [ENHANCEMENT] [Yoga] - Added new yoga thing/position
 [INTERNAL] [FEATURE] [./scripts] - Added thing to script that nobody will see
-->
