### PR TITLE
Fix running gradle clean

### DIFF
--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -224,7 +224,7 @@ task buildReactNdkLib(dependsOn: [prepareJSC, prepareBoost, prepareDoubleConvers
             '--jobs', project.hasProperty("jobs") ? project.property("jobs") : Runtime.runtime.availableProcessors()
 }
 
-task cleanReactNdkLib(type: Exec) {
+task cleanReactNdkLib(dependsOn: [prepareJSC, prepareBoost, prepareDoubleConversion, prepareFolly, prepareGlog], type: Exec) {
     commandLine getNdkBuildFullPath(),
             "NDK_APPLICATION_MK=$projectDir/src/main/jni/Application.mk",
             "THIRD_PARTY_NDK_DIR=$buildDir/third-party-ndk",


### PR DESCRIPTION
Cleaning out caches and rebuilding is a common task when working on a RN project to fix projects when they get into a weird state that can be difficult to track down.  Fixing the ability to clean a gradle project is vital part of being to reset things to a clean state and is currently broken unless you run a different grade task beforehand 

Test Plan:
----------
Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!

Validate that the following commands completes successfully:
```
$ cd react/native/project/path
$ cd android
$ ./gradlew clean
```

Release Notes:
--------------
Help reviewers and the release process by writing your own release notes. See below for an example.

[ANDROID] [BUGFIX] [ReactAndroid/build.gradle] - Fixes being able to run gradle clean

