### PR TITLE
[fix][android] allow bundling to be disabled for release

### DIFF
--- a/react.gradle
+++ b/react.gradle
@@ -69,9 +69,11 @@ afterEvaluate {
                     "--reset-cache", "--entry-file", entryFile, "--bundle-output", jsBundleFile, "--assets-dest", resourcesDir, *extraArgs)
             }
 
-            enabled config."bundleIn${targetName}" ||
-                config."bundleIn${variant.buildType.name.capitalize()}" ?:
-                targetName.toLowerCase().contains("release")
+            enabled config."bundleIn${targetName}" != null
+                  ? config."bundleIn${targetName}"
+                  : config."bundleIn${variant.buildType.name.capitalize()}" != null
+                    ? config."bundleIn${variant.buildType.name.capitalize()}"
+                    : targetName.toLowerCase().contains("release")
         }
 
         // Expose a minimal interface on the application variant and the task itself:


### PR DESCRIPTION
It was not previously possible to disable the bundling of assets for android when bundling in release mode. That meant that it would *always* fall back to `true`, because setting `bundleInRelease` to `false` will fall through to `targetName.toLowerCase().contains("release")` (which would be true).

Closes #18892 where I tried this earlier but had problems with the builds that I couldn't understand and seemed unrelated.

Test Plan:
----------
I've been running this patch using `patch-package` for a while, without any dramas. 

It can be tested pretty easily. On current `master`, set `bundleIn<variant>Release` to be false. The bundle will still happen. Switch to this branch and make the same change and the bundle will be disabled.

Release Notes:
--------------

[ANDROID] [BUGFIX] [react.gradle] - Allow disabling of bundling for release builds