### PR TITLE
[Android/EditText]: Fix case where TextInput loses text selection ability

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
@@ -588,6 +588,15 @@ public class ReactEditText extends EditText {
   @Override
   public void onAttachedToWindow() {
     super.onAttachedToWindow();
+    
+    // Bug workaround for losing text selection ability, see:
+    // https://code.google.com/p/android/issues/detail?id=208169
+    // This should allow users to copy and paste text from TextInput elements inside ViewPagerAndroid
+    if (isEnabled()) {
+      setEnabled(false);
+      setEnabled(true);
+    }
+
     if (mContainsImages) {
       Spanned text = getText();
       TextInlineImageSpan[] spans = text.getSpans(0, text.length(), TextInlineImageSpan.class);


### PR DESCRIPTION
In some instances setting style properties such as height to a TextInput that's inside a ViewPager will not allow the user to select and edit text. 

Android logcat will instead display: "TextView does not support text selection. Selection cancelled."

This seems to be an Android bug -  https://code.google.com/p/android/issues/detail?id=208169

This workaround manually toggles the "enabled" state from false to true when the EditText is attached to the window to circumvent this bug.

Fixes #20887 

Test Plan:
----------
No test plan.

Release Notes:
--------------

[ANDROID] [BUGFIX] [TextInput] - Fix case where TextInput loses text selection ability