### PR TITLE
Enable background updates when NSLocationWhenInUseUsageDescription is set

### DIFF
--- a/Libraries/Geolocation/RCTLocationObserver.m
+++ b/Libraries/Geolocation/RCTLocationObserver.m
@@ -202,19 +202,17 @@ RCT_EXPORT_METHOD(requestAuthorization)
     _locationManager = [CLLocationManager new];
     _locationManager.delegate = self;
   }
-
+  // On iOS 9+ we also need to enable background updates
+  NSArray *backgroundModes  = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"UIBackgroundModes"];
+  if (backgroundModes && [backgroundModes containsObject:@"location"]) {
+    if ([_locationManager respondsToSelector:@selector(setAllowsBackgroundLocationUpdates:)]) {
+      [_locationManager setAllowsBackgroundLocationUpdates:YES];
+    }
+  }
   // Request location access permission
   if ([[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSLocationAlwaysUsageDescription"] &&
     [_locationManager respondsToSelector:@selector(requestAlwaysAuthorization)]) {
     [_locationManager requestAlwaysAuthorization];
-
-    // On iOS 9+ we also need to enable background updates
-    NSArray *backgroundModes  = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"UIBackgroundModes"];
-    if (backgroundModes && [backgroundModes containsObject:@"location"]) {
-      if ([_locationManager respondsToSelector:@selector(setAllowsBackgroundLocationUpdates:)]) {
-        [_locationManager setAllowsBackgroundLocationUpdates:YES];
-      }
-    }
   } else if ([[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSLocationWhenInUseUsageDescription"] &&
     [_locationManager respondsToSelector:@selector(requestWhenInUseAuthorization)]) {
     [_locationManager requestWhenInUseAuthorization];


### PR DESCRIPTION
# Description

Location updates are not working in background when user allows **When in use authorization**, but works when user allows **Always allow**.

In Geolocation/RCTLocationObserver.m, setAllowsBackgroundLocationUpdates are set only for **Always allow** case, but native iOS allows us to setAllowsBackgroundLocationUpdates even for **When in use authorization**.

Solution:
setAllowsBackgroundLocationUpdates is now set for both cases.

# Changelog

[iOS] [Fixed] RCTLocationObserver - Enable background location updates when NSLocationWhenInUseUsageDescription is set

# Test Plan

Target: iOS 11+ 
Permissions: 
-> Permissions.request('location', { type: 'always' })
-> set location in the UIBackgroundModes.
-> geolocation.watchPosition();
-> Background the application and you would see location updates works even when app is in background. On iOS 11+ a blue banner on top is displayed showing "Your application is Actively Using Your Location". 
