### PR TITLE
Incorrect ref API usage fixed.

### DIFF
--- a/ReactAndroid/src/main/jni/react/jni/ReadableNativeArray.cpp
+++ b/ReactAndroid/src/main/jni/react/jni/ReadableNativeArray.cpp
@@ -113,7 +113,7 @@ local_ref<JArrayClass<jobject>> ReadableNativeArray::importTypeArray() {
   jint size = array_.size();
   auto jarray = JArrayClass<jobject>::newArray(size);
   for (jint i = 0; i < size; i++) {
-    jarray->setElement(i, ReadableNativeArray::getType(i).release());
+    jarray->setElement(i, ReadableNativeArray::getType(i).get());
   }
   return jarray;
 }


### PR DESCRIPTION
release method of local_ref and global_ref doesn't call deallocator, in fact, it leaves the caller responsible for deletion of the reference, while otherwise the reference is released on scope left.

Fixes #18292.

Test Plan:
----------
If there is a mistake in the change it won't even run.
Pass the big array (bigger than 512 elements) and call importTypes method on it. If it doesn't crash the problem is fixed.

Release Notes:
--------------
[ANDROID] [BUGFIX] [JNI] - Fixes spontaneous local_ref table overflow.