### PR TITLE
iOS: Add a maxFontSizeMultiplier prop to <Text> and <TextInput>

### DIFF
--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -177,7 +177,7 @@ type Props = $ReadOnly<{|
   autoCorrect?: ?boolean,
   autoFocus?: ?boolean,
   allowFontScaling?: ?boolean,
-  maxContentSizeMultiplier?: ?boolean,
+  maxFontSizeMultiplier?: ?boolean,
   editable?: ?boolean,
   keyboardType?: ?KeyboardType,
   returnKeyType?: ?ReturnKeyType,
@@ -373,9 +373,9 @@ const TextInput = createReactClass({
      * Possible values:
      * `null/undefined` (default): inherit from the parent node or the global default (0)
      * `0`: no max, ignore parent/global default
-     * `>= 1`: sets the maxContentSizeMultiplier of this node to this value
+     * `>= 1`: sets the maxFontSizeMultiplier of this node to this value
      */
-    maxContentSizeMultiplier: PropTypes.number,
+    maxFontSizeMultiplier: PropTypes.number,
     /**
      * If `false`, text is not editable. The default value is `true`.
      */
@@ -945,7 +945,7 @@ const TextInput = createReactClass({
           <Text
             style={props.style}
             allowFontScaling={props.allowFontScaling}
-            maxContentSizeMultiplier={props.maxContentSizeMultiplier}
+            maxFontSizeMultiplier={props.maxFontSizeMultiplier}
           >
             {children}
           </Text>

--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -177,6 +177,7 @@ type Props = $ReadOnly<{|
   autoCorrect?: ?boolean,
   autoFocus?: ?boolean,
   allowFontScaling?: ?boolean,
+  maxContentSizeMultiplier?: ?boolean,
   editable?: ?boolean,
   keyboardType?: ?KeyboardType,
   returnKeyType?: ?ReturnKeyType,
@@ -367,6 +368,14 @@ const TextInput = createReactClass({
      * default is `true`.
      */
     allowFontScaling: PropTypes.bool,
+    /**
+     * Specifies largest possible scale a font can reach when `allowFontScaling` is enabled.
+     * Possible values:
+     * `null/undefined` (default): inherit from the parent node or the global default (0)
+     * `0`: no max, ignore parent/global default
+     * `>= 1`: sets the maxContentSizeMultiplier of this node to this value
+     */
+    maxContentSizeMultiplier: PropTypes.number,
     /**
      * If `false`, text is not editable. The default value is `true`.
      */
@@ -933,7 +942,11 @@ const TextInput = createReactClass({
       );
       if (childCount >= 1) {
         children = (
-          <Text style={props.style} allowFontScaling={props.allowFontScaling}>
+          <Text
+            style={props.style}
+            allowFontScaling={props.allowFontScaling}
+            maxContentSizeMultiplier={props.maxContentSizeMultiplier}
+          >
             {children}
           </Text>
         );

--- a/Libraries/Text/BaseText/RCTBaseTextViewManager.m
+++ b/Libraries/Text/BaseText/RCTBaseTextViewManager.m
@@ -36,6 +36,7 @@ RCT_REMAP_SHADOW_PROPERTY(fontWeight, textAttributes.fontWeight, NSString)
 RCT_REMAP_SHADOW_PROPERTY(fontStyle, textAttributes.fontStyle, NSString)
 RCT_REMAP_SHADOW_PROPERTY(fontVariant, textAttributes.fontVariant, NSArray)
 RCT_REMAP_SHADOW_PROPERTY(allowFontScaling, textAttributes.allowFontScaling, BOOL)
+RCT_REMAP_SHADOW_PROPERTY(maxContentSizeMultiplier, textAttributes.maxContentSizeMultiplier, CGFloat)
 RCT_REMAP_SHADOW_PROPERTY(letterSpacing, textAttributes.letterSpacing, CGFloat)
 // Paragraph Styles
 RCT_REMAP_SHADOW_PROPERTY(lineHeight, textAttributes.lineHeight, CGFloat)

--- a/Libraries/Text/BaseText/RCTBaseTextViewManager.m
+++ b/Libraries/Text/BaseText/RCTBaseTextViewManager.m
@@ -36,7 +36,7 @@ RCT_REMAP_SHADOW_PROPERTY(fontWeight, textAttributes.fontWeight, NSString)
 RCT_REMAP_SHADOW_PROPERTY(fontStyle, textAttributes.fontStyle, NSString)
 RCT_REMAP_SHADOW_PROPERTY(fontVariant, textAttributes.fontVariant, NSArray)
 RCT_REMAP_SHADOW_PROPERTY(allowFontScaling, textAttributes.allowFontScaling, BOOL)
-RCT_REMAP_SHADOW_PROPERTY(maxContentSizeMultiplier, textAttributes.maxContentSizeMultiplier, CGFloat)
+RCT_REMAP_SHADOW_PROPERTY(maxFontSizeMultiplier, textAttributes.maxFontSizeMultiplier, CGFloat)
 RCT_REMAP_SHADOW_PROPERTY(letterSpacing, textAttributes.letterSpacing, CGFloat)
 // Paragraph Styles
 RCT_REMAP_SHADOW_PROPERTY(lineHeight, textAttributes.lineHeight, CGFloat)

--- a/Libraries/Text/RCTTextAttributes.h
+++ b/Libraries/Text/RCTTextAttributes.h
@@ -31,7 +31,7 @@ extern NSString *const RCTTextAttributesTagAttributeName;
 @property (nonatomic, copy, nullable) NSString *fontFamily;
 @property (nonatomic, assign) CGFloat fontSize;
 @property (nonatomic, assign) CGFloat fontSizeMultiplier;
-@property (nonatomic, assign) CGFloat maxContentSizeMultiplier;
+@property (nonatomic, assign) CGFloat maxFontSizeMultiplier;
 @property (nonatomic, copy, nullable) NSString *fontWeight;
 @property (nonatomic, copy, nullable) NSString *fontStyle;
 @property (nonatomic, copy, nullable) NSArray<NSString *> *fontVariant;
@@ -72,7 +72,7 @@ extern NSString *const RCTTextAttributesTagAttributeName;
 - (UIFont *)effectiveFont;
 
 /**
- * Font size multiplier reflects `allowFontScaling`, `fontSizeMultiplier`, and `maxContentSizeMultiplier`.
+ * Font size multiplier reflects `allowFontScaling`, `fontSizeMultiplier`, and `maxFontSizeMultiplier`.
  */
 - (CGFloat)effectiveFontSizeMultiplier;
 

--- a/Libraries/Text/RCTTextAttributes.h
+++ b/Libraries/Text/RCTTextAttributes.h
@@ -31,6 +31,7 @@ extern NSString *const RCTTextAttributesTagAttributeName;
 @property (nonatomic, copy, nullable) NSString *fontFamily;
 @property (nonatomic, assign) CGFloat fontSize;
 @property (nonatomic, assign) CGFloat fontSizeMultiplier;
+@property (nonatomic, assign) CGFloat maxContentSizeMultiplier;
 @property (nonatomic, copy, nullable) NSString *fontWeight;
 @property (nonatomic, copy, nullable) NSString *fontStyle;
 @property (nonatomic, copy, nullable) NSArray<NSString *> *fontVariant;
@@ -71,7 +72,7 @@ extern NSString *const RCTTextAttributesTagAttributeName;
 - (UIFont *)effectiveFont;
 
 /**
- * Font size multiplier reflects `allowFontScaling` and `fontSizeMultiplier`.
+ * Font size multiplier reflects `allowFontScaling`, `fontSizeMultiplier`, and `maxContentSizeMultiplier`.
  */
 - (CGFloat)effectiveFontSizeMultiplier;
 

--- a/Libraries/Text/RCTTextAttributes.m
+++ b/Libraries/Text/RCTTextAttributes.m
@@ -24,7 +24,7 @@ NSString *const RCTTextAttributesTagAttributeName = @"RCTTextAttributesTagAttrib
     _lineHeight = NAN;
     _textDecorationStyle = NSUnderlineStyleSingle;
     _fontSizeMultiplier = NAN;
-    _maxContentSizeMultiplier = NAN;
+    _maxFontSizeMultiplier = NAN;
     _alignment = NSTextAlignmentNatural;
     _baseWritingDirection = NSWritingDirectionNatural;
     _textShadowRadius = NAN;
@@ -50,7 +50,7 @@ NSString *const RCTTextAttributesTagAttributeName = @"RCTTextAttributesTagAttrib
   _fontFamily = textAttributes->_fontFamily ?: _fontFamily;
   _fontSize = !isnan(textAttributes->_fontSize) ? textAttributes->_fontSize : _fontSize;
   _fontSizeMultiplier = !isnan(textAttributes->_fontSizeMultiplier) ? textAttributes->_fontSizeMultiplier : _fontSizeMultiplier;
-  _maxContentSizeMultiplier = !isnan(textAttributes->_maxContentSizeMultiplier) ? textAttributes->_maxContentSizeMultiplier : _maxContentSizeMultiplier;
+  _maxFontSizeMultiplier = !isnan(textAttributes->_maxFontSizeMultiplier) ? textAttributes->_maxFontSizeMultiplier : _maxFontSizeMultiplier;
   _fontWeight = textAttributes->_fontWeight ?: _fontWeight;
   _fontStyle = textAttributes->_fontStyle ?: _fontStyle;
   _fontVariant = textAttributes->_fontVariant ?: _fontVariant;
@@ -197,8 +197,8 @@ NSString *const RCTTextAttributesTagAttributeName = @"RCTTextAttributesTagAttrib
 
   if (fontScalingEnabled) {
     CGFloat fontSizeMultiplier = !isnan(_fontSizeMultiplier) ? _fontSizeMultiplier : 1.0;
-    CGFloat maxContentSizeMultiplier = !isnan(_maxContentSizeMultiplier) ? _maxContentSizeMultiplier : 0.0;
-    return maxContentSizeMultiplier >= 1.0 ? fminf(maxContentSizeMultiplier, fontSizeMultiplier) : fontSizeMultiplier;
+    CGFloat maxFontSizeMultiplier = !isnan(_maxFontSizeMultiplier) ? _maxFontSizeMultiplier : 0.0;
+    return maxFontSizeMultiplier >= 1.0 ? fminf(maxFontSizeMultiplier, fontSizeMultiplier) : fontSizeMultiplier;
   } else {
     return 1.0;
   }
@@ -270,7 +270,7 @@ NSString *const RCTTextAttributesTagAttributeName = @"RCTTextAttributesTagAttrib
     RCTTextAttributesCompareObjects(_fontFamily) &&
     RCTTextAttributesCompareFloats(_fontSize) &&
     RCTTextAttributesCompareFloats(_fontSizeMultiplier) &&
-    RCTTextAttributesCompareFloats(_maxContentSizeMultiplier) &&
+    RCTTextAttributesCompareFloats(_maxFontSizeMultiplier) &&
     RCTTextAttributesCompareStrings(_fontWeight) &&
     RCTTextAttributesCompareObjects(_fontStyle) &&
     RCTTextAttributesCompareObjects(_fontVariant) &&

--- a/Libraries/Text/RCTTextAttributes.m
+++ b/Libraries/Text/RCTTextAttributes.m
@@ -14,9 +14,6 @@
 NSString *const RCTTextAttributesIsHighlightedAttributeName = @"RCTTextAttributesIsHighlightedAttributeName";
 NSString *const RCTTextAttributesTagAttributeName = @"RCTTextAttributesTagAttributeName";
 
-// Setting the default to 0 indicates that there is no max.
-static CGFloat defaultMaxContentSizeMultiplier = 0.0;
-
 @implementation RCTTextAttributes
 
 - (instancetype)init
@@ -200,7 +197,7 @@ static CGFloat defaultMaxContentSizeMultiplier = 0.0;
 
   if (fontScalingEnabled) {
     CGFloat fontSizeMultiplier = !isnan(_fontSizeMultiplier) ? _fontSizeMultiplier : 1.0;
-    CGFloat maxContentSizeMultiplier = !isnan(_maxContentSizeMultiplier) ? _maxContentSizeMultiplier : defaultMaxContentSizeMultiplier;
+    CGFloat maxContentSizeMultiplier = !isnan(_maxContentSizeMultiplier) ? _maxContentSizeMultiplier : 0.0;
     return maxContentSizeMultiplier >= 1.0 ? fminf(maxContentSizeMultiplier, fontSizeMultiplier) : fontSizeMultiplier;
   } else {
     return 1.0;

--- a/Libraries/Text/Text.js
+++ b/Libraries/Text/Text.js
@@ -58,6 +58,7 @@ const viewConfig = {
     numberOfLines: true,
     ellipsizeMode: true,
     allowFontScaling: true,
+    maxContentSizeMultiplier: true,
     disabled: true,
     selectable: true,
     selectionColor: true,
@@ -257,6 +258,7 @@ const RCTVirtualText =
         validAttributes: {
           ...ReactNativeViewAttributes.UIView,
           isHighlighted: true,
+          maxContentSizeMultiplier: true,
         },
         uiViewClassName: 'RCTVirtualText',
       }));

--- a/Libraries/Text/Text.js
+++ b/Libraries/Text/Text.js
@@ -58,7 +58,7 @@ const viewConfig = {
     numberOfLines: true,
     ellipsizeMode: true,
     allowFontScaling: true,
-    maxContentSizeMultiplier: true,
+    maxFontSizeMultiplier: true,
     disabled: true,
     selectable: true,
     selectionColor: true,
@@ -258,7 +258,7 @@ const RCTVirtualText =
         validAttributes: {
           ...ReactNativeViewAttributes.UIView,
           isHighlighted: true,
-          maxContentSizeMultiplier: true,
+          maxFontSizeMultiplier: true,
         },
         uiViewClassName: 'RCTVirtualText',
       }));

--- a/Libraries/Text/Text/RCTTextViewManager.m
+++ b/Libraries/Text/Text/RCTTextViewManager.m
@@ -24,7 +24,6 @@
 @implementation RCTTextViewManager
 {
   NSHashTable<RCTTextShadowView *> *_shadowViews;
-  CGFloat _fontSizeMultiplier;
 }
 
 RCT_EXPORT_MODULE(RCTText)

--- a/Libraries/Text/TextPropTypes.js
+++ b/Libraries/Text/TextPropTypes.js
@@ -105,9 +105,9 @@ module.exports = {
    * Possible values:
    * `null/undefined` (default): inherit from the parent node or the global default (0)
    * `0`: no max, ignore parent/global default
-   * `>= 1`: sets the maxContentSizeMultiplier of this node to this value
+   * `>= 1`: sets the maxFontSizeMultiplier of this node to this value
    */
-  maxContentSizeMultiplier: PropTypes.number,
+  maxFontSizeMultiplier: PropTypes.number,
   /**
    * Indicates whether the view is an accessibility element.
    *

--- a/Libraries/Text/TextPropTypes.js
+++ b/Libraries/Text/TextPropTypes.js
@@ -101,6 +101,14 @@ module.exports = {
    */
   allowFontScaling: PropTypes.bool,
   /**
+   * Specifies largest possible scale a font can reach when `allowFontScaling` is enabled.
+   * Possible values:
+   * `null/undefined` (default): inherit from the parent node or the global default (0)
+   * `0`: no max, ignore parent/global default
+   * `>= 1`: sets the maxContentSizeMultiplier of this node to this value
+   */
+  maxContentSizeMultiplier: PropTypes.number,
+  /**
    * Indicates whether the view is an accessibility element.
    *
    * See https://facebook.github.io/react-native/docs/text.html#accessible


### PR DESCRIPTION
**Motivation**

Whenever a user changes the system font size to its maximum allowable setting, React Native apps that allow font scaling can become unusable because the text gets too big. Experimenting with a native app like iMessage on iOS, the font size used for non-body text (e.g. header, navigational elements) is capped while the body text (e.g. text in the message bubbles) is allowed to grow.

This PR introduces a new prop on `<Text>` and `<TextInput>` called `maxFontSizeMultiplier`. This enables devs to set the maximum allowed text scale factor on a Text/TextInput. The default is 0 which means no limit.

Another PR will add this feature to Android.

**Test Plan**

I created a test app which utilizes all categories of values of `maxFontSizeMultiplier`:
  - `undefined`: inherit from parent
  - `0`: no limit
  - `1`, `1.2`: fixed limits

I tried this with `Text`, `TextInput` with `value`, and `TextInput` with children. For `Text`, I also verified that nesting works properly (if a child `Text` doesn't specify `maxFontSizeMultiplier`, it inherits it from its parent).

Lastly, we've been using a version of this in Skype for several months.

**Release Notes**

[GENERAL] [ENHANCEMENT] [Text/TextInput] - Added maxFontSizeMultiplier prop to prevent some text from getting unusably large as user increases OS's font scale setting (iOS)

Adam Comella
Microsoft Corp.