### PR TITLE
[Bugfix] Fixing Unhandled promise rejection on iOS WebView

### DIFF
--- a/Libraries/Components/WebView/WebView.ios.js
+++ b/Libraries/Components/WebView/WebView.ios.js
@@ -487,7 +487,7 @@ class WebView extends React.Component {
       );
       shouldStart = shouldStart && passesWhitelist;
       if (!passesWhitelist) {
-        Linking.openURL(url);
+        Linking.openURL(url).then(() => (/*ignored*/)).catch(() => (/*ignored*/));
       }
       if (this.props.onShouldStartLoadWithRequest) {
         shouldStart =

--- a/Libraries/Components/WebView/WebView.ios.js
+++ b/Libraries/Components/WebView/WebView.ios.js
@@ -487,7 +487,13 @@ class WebView extends React.Component {
       );
       shouldStart = shouldStart && passesWhitelist;
       if (!passesWhitelist) {
-        Linking.openURL(url).then(() => (/*ignored*/)).catch(() => (/*ignored*/));
+        Linking.openURL(url)
+          .then(() => {
+            //ignored
+          })
+          .catch(() => {
+            //ignored
+          });
       }
       if (this.props.onShouldStartLoadWithRequest) {
         shouldStart =


### PR DESCRIPTION
Fixes #20917

Test Plan:
----------
Unhandled promise, just finished off the .then and the .catch promise blocks

Release Notes:
--------------
Not needed for this.

[ IOS  ] [ BUGFIX      ] [ WebView ] - Fixing Unhandled promise rejection on iOS WebView

<!--
  **INTERNAL and MINOR tagged notes will not be included in the next version's final release notes.**

    CATEGORY
  [----------]      TYPE
  [ CLI      ] [-------------]    LOCATION
  [ DOCS     ] [ BREAKING    ] [-------------]
  [ GENERAL  ] [ BUGFIX      ] [ {Component} ]
  [ INTERNAL ] [ ENHANCEMENT ] [ {Filename}  ]
  [ IOS      ] [ FEATURE     ] [ {Directory} ]   |-----------|
  [ ANDROID  ] [ MINOR       ] [ {Framework} ] - | {Message} |
  [----------] [-------------] [-------------]   |-----------|

 EXAMPLES:

 [IOS] [BREAKING] [FlatList] - Change a thing that breaks other things
 [ANDROID] [BUGFIX] [TextInput] - Did a thing to TextInput
 [CLI] [FEATURE] [local-cli/info/info.js] - CLI easier to do things with
 [DOCS] [BUGFIX] [GettingStarted.md] - Accidentally a thing/word
 [GENERAL] [ENHANCEMENT] [Yoga] - Added new yoga thing/position
 [INTERNAL] [FEATURE] [./scripts] - Added thing to script that nobody will see
-->
