### PR TITLE
[NativeAnimated] Reuse props and event nodes

### DIFF
--- a/Libraries/Animated/src/AnimatedEvent.js
+++ b/Libraries/Animated/src/AnimatedEvent.js
@@ -17,10 +17,10 @@ const invariant = require('fbjs/lib/invariant');
 const {shouldUseNativeDriver} = require('./NativeAnimatedHelper');
 
 export type Mapping = {[key: string]: Mapping} | AnimatedValue;
-export type EventConfig = {
+export type EventConfig = $ReadOnly<{|
   listener?: ?Function,
   useNativeDriver?: boolean,
-};
+|}>;
 
 function attachNativeEvent(
   viewRef: any,
@@ -86,7 +86,10 @@ class AnimatedEvent {
   };
   __isNative: boolean;
 
-  constructor(argMapping: Array<?Mapping>, config?: EventConfig = {}) {
+  constructor(
+    argMapping: Array<?Mapping>,
+    config?: EventConfig = ({}: Object),
+  ) {
     this._argMapping = argMapping;
     if (config.listener) {
       this.__addListener(config.listener);

--- a/Libraries/Animated/src/NativeAnimatedHelper.js
+++ b/Libraries/Animated/src/NativeAnimatedHelper.js
@@ -196,7 +196,7 @@ function addWhitelistedInterpolationParam(param: string): void {
   SUPPORTED_INTERPOLATION_PARAMS[param] = true;
 }
 
-function validateTransform(configs: Array<Object>): void {
+function validateTransform(configs: $ReadOnlyArray<Object>): void {
   configs.forEach(config => {
     if (!TRANSFORM_WHITELIST.hasOwnProperty(config.property)) {
       throw new Error(


### PR DESCRIPTION
Integrate some improvements that were made in reanimated to avoid recreating events, props, style and transform nodes on every re-render. Note that this optimisation only works when reusing Animated node instances between renders (this means not creating new nodes in render).

Test Plan:
----------
Added some code to trigger re-renders periodically in RNTester native animated example and made sure nodes were being reused (had to remove intermediary nodes created in render).

Release Notes:
--------------
[GENERAL] [ENHANCEMENT] [NativeAnimated] - Reuse props and event nodes