### PR TITLE
Throw an error if an invalid platform is passed to the bundler

### DIFF
--- a/local-cli/bundle/buildBundle.js
+++ b/local-cli/bundle/buildBundle.js
@@ -17,6 +17,7 @@ const Server = require('metro/src/Server');
 /* $FlowFixMe(site=react_native_oss) */
 const outputBundle = require('metro/src/shared/output/bundle');
 const path = require('path');
+const chalk = require('chalk');
 const saveAssets = require('./saveAssets');
 
 import type {RequestOptions, OutputOptions} from './types.flow';
@@ -38,6 +39,22 @@ async function buildBundle(
   // have other choice than defining it as an env variable here.
   process.env.NODE_ENV = args.dev ? 'development' : 'production';
   const config = await configPromise;
+
+  if (config.resolver.platforms.indexOf(args.platform) === -1) {
+    console.log(
+      chalk.red(
+        'Invalid platform (' +
+          args.platform +
+          ') selected. \n' +
+          'Available platforms are: \n' +
+          '  ' +
+          config.resolver.platforms.join(', ') +
+          '\n' +
+          'If you are trying to bundle for an out-of-tree platform, it may not be installed.',
+      ),
+    );
+    throw new Error('Invalid platform selected.');
+  }
 
   let sourceMapUrl = args.sourcemapOutput;
   if (sourceMapUrl && !args.sourcemapUseAbsolutePath) {

--- a/local-cli/bundle/buildBundle.js
+++ b/local-cli/bundle/buildBundle.js
@@ -42,16 +42,12 @@ async function buildBundle(
 
   if (config.resolver.platforms.indexOf(args.platform) === -1) {
     console.log(
-      chalk.red(
-        'Invalid platform (' +
-          args.platform +
-          ') selected. \n' +
-          'Available platforms are: \n' +
-          '  ' +
-          config.resolver.platforms.join(', ') +
-          '\n' +
-          'If you are trying to bundle for an out-of-tree platform, it may not be installed.',
-      ),
+      chalk.red(`Invalid platform (${args.platform}) selected.
+
+Available platforms are:
+  ${config.resolver.platforms.join(', ')}
+
+If you are trying to bundle for an out-of-tree platform, it may not be installed.`),
     );
     throw new Error('Invalid platform selected.');
   }

--- a/local-cli/core/index.js
+++ b/local-cli/core/index.js
@@ -22,6 +22,7 @@ const {ASSET_REGISTRY_PATH} = require('./Constants');
  * found when Flow v0.54 was deployed. To see the error delete this comment and
  * run Flow. */
 const flatten = require('lodash').flatten;
+const uniq = require('lodash').uniq;
 /* $FlowFixMe(>=0.54.0 site=react_native_oss) This comment suppresses an error
  * found when Flow v0.54 was deployed. To see the error delete this comment and
  * run Flow. */
@@ -131,18 +132,20 @@ async function getCliConfig(): Promise<RNConfig> {
     cliArgs.config != null ? path.resolve(__dirname, cliArgs.config) : null,
   );
 
-  config.transformer.assetRegistryPath = ASSET_REGISTRY_PATH;
-  config.resolver.hasteImplModulePath =
-    config.resolver.hasteImplModulePath || defaultConfig.hasteImplModulePath;
-  config.resolver.platforms = config.resolver.platforms
+  const platforms = config.resolver.platforms
     ? config.resolver.platforms.concat(defaultConfig.getPlatforms())
     : defaultConfig.getPlatforms();
-  config.resolver.providesModuleNodeModules = config.resolver
-    .providesModuleNodeModules
+  let providesModuleNodeModules = config.resolver.providesModuleNodeModules
     ? config.resolver.providesModuleNodeModules.concat(
         defaultConfig.getProvidesModuleNodeModules(),
       )
     : defaultConfig.getProvidesModuleNodeModules();
+
+  config.transformer.assetRegistryPath = ASSET_REGISTRY_PATH;
+  config.resolver.hasteImplModulePath =
+    config.resolver.hasteImplModulePath || defaultConfig.hasteImplModulePath;
+  config.resolver.platforms = uniq(platforms);
+  config.resolver.providesModuleNodeModules = uniq(providesModuleNodeModules);
 
   return {...defaultRNConfig, ...config};
 }


### PR DESCRIPTION
This pull request will have the React Native CLI throw an error if an invalid platform is passed to it, rather than the previous behavior where it would fail silently and give errors about missing files (like `AccessibilityInfo`)

```bash
> react-native bundle --entry-file index.js --bundle-output test.bundle --platform test
Invalid platform (test) selected.
Available platforms are:
  ios, android, windows, web, native
If you are trying to bundle for an out-of-tree platform, it may not be installed.
```

Test Plan:
----------
I've tested passing a registered `--platform` to `react-native bundle`, and it builds without issue. I've also passed an invalid string and this error is thrown as expected.

Release Notes:
--------------
[CLI] [ENHANCEMENT] [local-cli/bundle/buildBundle.js] - Added a check to verify that the `--platform` passed to the bundler is valid
[CLI] [ENHANCEMENT] [local-cli/core/index.js] - Using lodash's `uniq` to get rid of duplicate entries in `platforms` and `providesModuleNodeModules`. Before, "ios" and "android" were in the list twice.