### PR TITLE
Add DeltaBundler's Flow types to flow config

### DIFF
--- a/flow-github/metro.js
+++ b/flow-github/metro.js
@@ -36,6 +36,10 @@ declare module 'metro/src/DeltaBundler' {
   declare module.exports: any;
 }
 
+declare module 'metro/src/DeltaBundler/types.flow.js' {
+  declare module.exports: any;
+}
+
 declare module 'metro/src/ModuleGraph/types.flow.js' {
   declare module.exports: any;
 }


### PR DESCRIPTION
This PR adds a declaration to `flow-github/metro.js` that fixes this error in `ci/circleci: analyze`:

```
Error ----------------------------------------------------- node_modules/metro-config/src/configTypes.flow.js.flow:18:27

Cannot resolve module `metro/src/DeltaBundler/types.flow.js`.

   18| import type {Module} from 'metro/src/DeltaBundler/types.flow.js';
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

Test Plan:
----------
This fixes an error that happens during `yarn flow check` - it now passes.

Release Notes:
--------------

[CLI] [BUGFIX] [flow-github/metro.js] - Added a flow type declaration for `metro/src/DeltaBundler/types.flow.js`
