### PR TITLE
added utfsequence to react-native exports

### DIFF
--- a/Libraries/react-native/react-native-implementation.js
+++ b/Libraries/react-native/react-native-implementation.js
@@ -269,6 +269,9 @@ const ReactNative = {
   get unstable_batchedUpdates() {
     return require('ReactNative').unstable_batchedUpdates;
   },
+  get UTFSequence() {
+    return require('UTFSequence');
+  },
   get Vibration() {
     return require('Vibration');
   },


### PR DESCRIPTION
Fixes #20935 

Added UTFSequence module to React-Native exports. Put it under // APIs but I'm not certain if it belongs there.