### PR TITLE
[iOS] [BUGFIX] [Cocoapods integration ]Fixing error when using RCTAnimation in Swift project using cocoapods

### DIFF
--- a/Libraries/NativeAnimation/RCTNativeAnimatedNodesManager.h
+++ b/Libraries/NativeAnimation/RCTNativeAnimatedNodesManager.h
@@ -6,8 +6,11 @@
  */
 
 #import <Foundation/Foundation.h>
-
+#if __has_include(<RCTAnimation/RCTValueAnimatedNode.h>)
 #import <RCTAnimation/RCTValueAnimatedNode.h>
+#else
+#import "RCTValueAnimatedNode.h"
+#endif
 #import <React/RCTBridgeModule.h>
 #import <React/RCTUIManager.h>
 


### PR DESCRIPTION
Hello,

When you try to install React Native with RCTAnimation dependency using Cocoapods on an existing swift project, it does not compile.

This PR fixed the problem explained in this issue :#13198.

The solution was already presented here: #13198  but never implemented.

Test Plan:
----------
Clone this project that demonstrate the bug : https://github.com/barrault01/swift-reactnative.git
```
git clone https://github.com/barrault01/swift-reactnative.git
yarn install
cd ios
pod install
open ReatNativeSwift.xcworkspace 
```
To fix the bug update the version of react-native on the package.json
```
{
  "name": "MyReactNativeApp",
  "version": "0.0.1",
  "private": true,
  "scripts": {
    "start": "node node_modules/react-native/local-cli/cli.js start"
  },
  "dependencies": {
    "react": "16.4.1",
    "react-native": "git://github.com/barrault01/react-native.git#70f7e5ea9ed226604d795b6646f14a8192b860fb"
  }
}
```
Then run do this again on the root folder of the project:
```
yarn install
cd ios
pod install
open ReatNativeSwift.xcworkspace 
```
And now the build will sucessed. 

Release Notes:
--------------
[iOS] [BUGFIX] [Cocoapods integration] - now using RCTAnimation subspecs does not make the build failed on iOS when integrated React Native using Cocoapods.
