### PR TITLE
Fix #20991 - use name from app.json if available

### DIFF
--- a/react-native-git-upgrade/cliEntry.js
+++ b/react-native-git-upgrade/cliEntry.js
@@ -114,10 +114,18 @@ function readPackageFiles(useYarn) {
     'package.json',
   );
   const pakPath = path.resolve(process.cwd(), 'package.json');
+  const appPath = path.resolve(process.cwd(), 'app.json');
+  let app = null;
+  try {
+    app = parseJsonFile(appPath);
+  } catch (err) {
+    log.warn('Unable to parse app.json', err.message);
+  }
   return {
     reactNativeNodeModulesPak: parseJsonFile(reactNativeNodeModulesPakPath),
     reactNodeModulesPak: parseJsonFile(reactNodeModulesPakPath),
     pak: parseJsonFile(pakPath),
+    app: app,
   };
 }
 
@@ -306,8 +314,9 @@ async function run(requestedVersion, cliArgs) {
       reactNativeNodeModulesPak,
       reactNodeModulesPak,
       pak,
+      app,
     } = readPackageFiles(useYarn);
-    const appName = pak.name;
+    const appName = (app && app.name) || pak.name;
     const currentVersion = reactNativeNodeModulesPak.version;
     const currentReactVersion = reactNodeModulesPak.version;
     const declaredVersion = pak.dependencies['react-native'];


### PR DESCRIPTION
Fix #20991 - use name from `app.json` if available, instead of using `package.json`.

Test Plan:
----------
I haven't tested my plan 😬but didn't want to file a trivial, low-priority issue here without a PR, since those just take up space!

Release Notes:
--------------
Help reviewers and the release process by writing your own release notes. See below for an example.
[CLI] [ENHANCEMENT] [react-native-git-upgrade] - Use name from app.json if available