### PR TITLE
New LayoutContext API to access the frame and safe area of the root view

### DIFF
--- a/Libraries/ReactNative/AppRegistry.js
+++ b/Libraries/ReactNative/AppRegistry.js
@@ -112,6 +112,7 @@ const AppRegistry = {
           ),
           appParameters.initialProps,
           appParameters.rootTag,
+          appParameters.initialLayoutContext,
           wrapperComponentProvider && wrapperComponentProvider(appParameters),
           appParameters.fabric,
           false,

--- a/Libraries/ReactNative/RootViewLayout.js
+++ b/Libraries/ReactNative/RootViewLayout.js
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow local-strict
+ * @format
+ */
+
+const React = require('React');
+const EmitterSubscription = require('EmitterSubscription');
+const RCTDeviceEventEmitter = require('RCTDeviceEventEmitter');
+
+import type {Layout} from 'CoreEventTypes';
+
+export type LayoutContext = $ReadOnly<{|
+  layout: Layout,
+  safeAreaInsets: $ReadOnly<{|
+    top: number,
+    right: number,
+    bottom: number,
+    left: number,
+  |}>,
+|}>;
+
+/**
+ * Context used to provide layout metrics from the root view the component
+ * tree is being rendered in. This is useful when sync measurements are
+ * required.
+ */
+const Context: React.Context<LayoutContext> = React.createContext({
+  layout: {x: 0, y: 0, width: 0, height: 0},
+  safeAreaInsets: {top: 0, right: 0, bottom: 0, left: 0},
+});
+
+type Props = {|
+  children: React.Node,
+  initialLayoutContext: LayoutContext,
+  rootTag: number,
+|};
+
+type State = {
+  layoutContext: LayoutContext,
+};
+
+class RootViewLayoutManager extends React.Component<Props, State> {
+  state = {
+    layoutContext: this.props.initialLayoutContext,
+  };
+  _subscription: EmitterSubscription | null = null;
+
+  componentDidMount() {
+    this._subscription = RCTDeviceEventEmitter.addListener(
+      'didUpdateLayoutContext',
+      ({rootTag, layoutContext}) => {
+        if (rootTag === this.props.rootTag) {
+          this.setState({layoutContext});
+        }
+      },
+    );
+  }
+
+  componentWillUnmount() {
+    if (this._subscription !== null) {
+      this._subscription.remove();
+    }
+  }
+
+  render() {
+    return (
+      <Context.Provider value={this.state.layoutContext}>
+        {this.props.children}
+      </Context.Provider>
+    );
+  }
+}
+
+module.exports = {
+  Context,
+  Manager: RootViewLayoutManager,
+};

--- a/Libraries/ReactNative/RootViewLayout.js
+++ b/Libraries/ReactNative/RootViewLayout.js
@@ -47,7 +47,7 @@ function RootViewLayoutManager({
   const [layoutContext, setLayoutContext] = React.useState<LayoutContext>(
     initialLayoutContext,
   );
-  React.useEffect(() => {
+  React.useLayoutEffect(() => {
     const subscription = RCTDeviceEventEmitter.addListener(
       'didUpdateLayoutContext',
       event => {

--- a/Libraries/ReactNative/renderApplication.js
+++ b/Libraries/ReactNative/renderApplication.js
@@ -16,8 +16,11 @@ import type {IPerformanceLogger} from 'createPerformanceLogger';
 import PerformanceLoggerContext from 'PerformanceLoggerContext';
 const React = require('React');
 const ReactFabricIndicator = require('ReactFabricIndicator');
+const RootViewLayout = require('RootViewLayout');
 
 const invariant = require('invariant');
+
+import type {LayoutContext} from 'RootViewLayout';
 
 // require BackHandler so it sets the default handler that exits the app if no listeners respond
 require('BackHandler');
@@ -26,6 +29,7 @@ function renderApplication<Props: Object>(
   RootComponent: React.ComponentType<Props>,
   initialProps: Props,
   rootTag: any,
+  initialLayoutContext: LayoutContext,
   WrapperComponent?: ?React.ComponentType<*>,
   fabric?: boolean,
   showFabricIndicator?: boolean,
@@ -36,12 +40,16 @@ function renderApplication<Props: Object>(
   let renderable = (
     <PerformanceLoggerContext.Provider
       value={scopedPerformanceLogger ?? GlobalPerformanceLogger}>
-      <AppContainer rootTag={rootTag} WrapperComponent={WrapperComponent}>
-        <RootComponent {...initialProps} rootTag={rootTag} />
-        {fabric === true && showFabricIndicator === true ? (
-          <ReactFabricIndicator />
-        ) : null}
-      </AppContainer>
+      <RootViewLayout.Manager
+        initialLayoutContext={initialLayoutContext}
+        rootTag={rootTag}>
+        <AppContainer rootTag={rootTag} WrapperComponent={WrapperComponent}>
+          <RootComponent {...initialProps} rootTag={rootTag} />
+          {fabric === true && showFabricIndicator === true ? (
+            <ReactFabricIndicator />
+          ) : null}
+        </AppContainer>
+      </RootViewLayout.Manager>
     </PerformanceLoggerContext.Provider>
   );
 

--- a/Libraries/react-native/react-native-implementation.js
+++ b/Libraries/react-native/react-native-implementation.js
@@ -71,6 +71,9 @@ module.exports = {
   get KeyboardAvoidingView() {
     return require('KeyboardAvoidingView');
   },
+  get LayoutContext() {
+    return require('RootViewLayout').Context.Consumer;
+  },
   get MaskedViewIOS() {
     warnOnce(
       'maskedviewios-moved',

--- a/RNTester/js/LayoutContextExample.js
+++ b/RNTester/js/LayoutContextExample.js
@@ -1,0 +1,112 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow
+ */
+
+'use strict';
+
+const React = require('react');
+const {
+  LayoutContext,
+  StyleSheet,
+  View,
+  StatusBar,
+  Button,
+  Platform,
+} = require('react-native');
+
+const BORDER_WIDTH = 2;
+
+type Props = {
+  onExampleExit: () => void,
+};
+
+type State = {
+  hidden: boolean,
+  translucent: boolean,
+};
+
+class LayoutContextExample extends React.Component<Props, State> {
+  static title = '<LayoutContext>';
+  static description =
+    'LayoutContext allows getting layout metrics for the current root view.';
+  static external = true;
+
+  state = {
+    hidden: false,
+    translucent: false,
+  };
+
+  render() {
+    return (
+      <LayoutContext>
+        {({layout, safeAreaInsets}) => {
+          return (
+            <>
+              <StatusBar
+                hidden={this.state.hidden}
+                translucent={this.state.translucent}
+                backgroundColor="rgba(0, 0, 0, 0.3)"
+              />
+              <View
+                style={[
+                  styles.container,
+                  {
+                    width: layout.width,
+                    height: layout.height,
+                    paddingTop: safeAreaInsets.top - BORDER_WIDTH,
+                    paddingRight: safeAreaInsets.right - BORDER_WIDTH,
+                    paddingBottom: safeAreaInsets.bottom - BORDER_WIDTH,
+                    paddingLeft: safeAreaInsets.left - BORDER_WIDTH,
+                  },
+                ]}>
+                <View style={styles.content}>
+                  <Button
+                    title="Toggle status bar hidden"
+                    onPress={() =>
+                      this.setState(state => ({hidden: !state.hidden}))
+                    }
+                  />
+                  {Platform.OS === 'android' && (
+                    <Button
+                      title="Toggle status bar translucent"
+                      onPress={() =>
+                        this.setState(state => ({
+                          translucent: !state.translucent,
+                        }))
+                      }
+                    />
+                  )}
+                  <Button title="Close" onPress={this.props.onExampleExit} />
+                </View>
+              </View>
+            </>
+          );
+        }}
+      </LayoutContext>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  container: {
+    borderWidth: BORDER_WIDTH,
+    borderColor: 'red',
+    backgroundColor: '#589c90',
+  },
+  content: {
+    flex: 1,
+    backgroundColor: 'white',
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderWidth: BORDER_WIDTH,
+    borderColor: 'blue',
+  },
+});
+
+module.exports = LayoutContextExample;

--- a/RNTester/js/LayoutContextExample.js
+++ b/RNTester/js/LayoutContextExample.js
@@ -15,6 +15,7 @@ const {
   LayoutContext,
   StyleSheet,
   View,
+  Text,
   StatusBar,
   Button,
   Platform,
@@ -45,7 +46,7 @@ class LayoutContextExample extends React.Component<Props, State> {
   render() {
     return (
       <LayoutContext>
-        {({layout, safeAreaInsets}) => {
+        {ctx => {
           return (
             <>
               <StatusBar
@@ -57,15 +58,23 @@ class LayoutContextExample extends React.Component<Props, State> {
                 style={[
                   styles.container,
                   {
-                    width: layout.width,
-                    height: layout.height,
-                    paddingTop: safeAreaInsets.top - BORDER_WIDTH,
-                    paddingRight: safeAreaInsets.right - BORDER_WIDTH,
-                    paddingBottom: safeAreaInsets.bottom - BORDER_WIDTH,
-                    paddingLeft: safeAreaInsets.left - BORDER_WIDTH,
+                    width: ctx.layout.width,
+                    height: ctx.layout.height,
+                    paddingTop: ctx.safeAreaInsets.top - BORDER_WIDTH,
+                    paddingRight: ctx.safeAreaInsets.right - BORDER_WIDTH,
+                    paddingBottom: ctx.safeAreaInsets.bottom - BORDER_WIDTH,
+                    paddingLeft: ctx.safeAreaInsets.left - BORDER_WIDTH,
                   },
                 ]}>
                 <View style={styles.content}>
+                  <Text
+                    style={{
+                      marginBottom: 32,
+                      backgroundColor: '#eee',
+                      padding: 16,
+                    }}>
+                    {JSON.stringify(ctx, null, 2)}
+                  </Text>
                   <Button
                     title="Toggle status bar hidden"
                     onPress={() =>
@@ -102,10 +111,9 @@ const styles = StyleSheet.create({
   content: {
     flex: 1,
     backgroundColor: 'white',
-    alignItems: 'center',
-    justifyContent: 'center',
     borderWidth: BORDER_WIDTH,
     borderColor: 'blue',
+    padding: 32,
   },
 });
 

--- a/RNTester/js/RNTesterApp.android.js
+++ b/RNTester/js/RNTesterApp.android.js
@@ -112,8 +112,8 @@ class RNTesterApp extends React.Component<Props, RNTesterNavigationState> {
            * found when making Flow check .android.js files. */
           this.drawer = drawer;
         }}
-        renderNavigationView={this._renderDrawerContent}
-        statusBarBackgroundColor="#589c90">
+        renderNavigationView={this._renderDrawerContent}>
+        <StatusBar backgroundColor="#589c90" />
         {this._renderApp()}
       </DrawerLayoutAndroid>
     );
@@ -245,7 +245,6 @@ const styles = StyleSheet.create({
   },
   drawerContentWrapper: {
     flex: 1,
-    paddingTop: StatusBar.currentHeight,
     backgroundColor: 'white',
   },
 });

--- a/RNTester/js/RNTesterList.android.js
+++ b/RNTester/js/RNTesterList.android.js
@@ -34,6 +34,10 @@ const ComponentExamples: Array<RNTesterExample> = [
     module: require('./ImageExample'),
   },
   {
+    key: 'LayoutContextExample',
+    module: require('./LayoutContextExample'),
+  },
+  {
     key: 'ModalExample',
     module: require('./ModalExample'),
   },

--- a/RNTester/js/RNTesterList.ios.js
+++ b/RNTester/js/RNTesterList.ios.js
@@ -54,6 +54,11 @@ const ComponentExamples: Array<RNTesterExample> = [
     supportsTVOS: false,
   },
   {
+    key: 'LayoutContextExample',
+    module: require('./LayoutContextExample'),
+    supportsTVOS: true,
+  },
+  {
     key: 'LayoutEventsExample',
     module: require('./LayoutEventsExample'),
     supportsTVOS: true,

--- a/RNTester/js/Shared/RNTesterTypes.js
+++ b/RNTester/js/Shared/RNTesterTypes.js
@@ -31,13 +31,15 @@ export type RNTesterExampleModuleItem = $ReadOnly<{|
   render: () => React.Node,
 |}>;
 
-export type RNTesterExampleModule = $ReadOnly<{|
-  title: string,
-  description: string,
-  displayName?: ?string,
-  framework?: string,
-  examples: Array<RNTesterExampleModuleItem>,
-|}>;
+export type RNTesterExampleModule =
+  | $ReadOnly<{|
+      title: string,
+      description: string,
+      displayName?: ?string,
+      framework?: string,
+      examples: Array<RNTesterExampleModuleItem>,
+    |}>
+  | ComponentType<any>;
 
 export type RNTesterExample = $ReadOnly<{|
   key: string,

--- a/React/Base/RCTRootView.m
+++ b/React/Base/RCTRootView.m
@@ -402,10 +402,13 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
     return;
   }
   NSDictionary *layoutContext = RCTCreateLayoutContext(frame, safeAreaInsets);
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
   [_bridge.eventDispatcher sendDeviceEventWithName:@"didUpdateLayoutContext" body:@{
     @"rootTag": _contentView.reactTag,
     @"layoutContext": layoutContext,
   }];
+#pragma clang diagnostic pop
 
   _lastFrame = frame;
   _lastSafeAreaInsets = safeAreaInsets;

--- a/React/React.xcodeproj/project.pbxproj
+++ b/React/React.xcodeproj/project.pbxproj
@@ -151,6 +151,8 @@
 		14F484561AABFCE100FDF6B9 /* RCTSliderManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 14F484551AABFCE100FDF6B9 /* RCTSliderManager.m */; };
 		14F7A0EC1BDA3B3C003C6C10 /* RCTPerfMonitor.m in Sources */ = {isa = PBXBuildFile; fileRef = 14F7A0EB1BDA3B3C003C6C10 /* RCTPerfMonitor.m */; };
 		14F7A0F01BDA714B003C6C10 /* RCTFPSGraph.m in Sources */ = {isa = PBXBuildFile; fileRef = 14F7A0EF1BDA714B003C6C10 /* RCTFPSGraph.m */; };
+		1904A8A021D823680024F51F /* RCTSafeAreaUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 1904A89E21D823680024F51F /* RCTSafeAreaUtils.h */; };
+		1904A8A121D823680024F51F /* RCTSafeAreaUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 1904A89F21D823680024F51F /* RCTSafeAreaUtils.m */; };
 		191E3EBE1C29D9AF00C180A6 /* RCTRefreshControlManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 191E3EBD1C29D9AF00C180A6 /* RCTRefreshControlManager.m */; };
 		191E3EC11C29DC3800C180A6 /* RCTRefreshControl.m in Sources */ = {isa = PBXBuildFile; fileRef = 191E3EC01C29DC3800C180A6 /* RCTRefreshControl.m */; };
 		199B8A6F1F44DB16005DEF67 /* RCTVersion.h in Headers */ = {isa = PBXBuildFile; fileRef = 199B8A6E1F44DB16005DEF67 /* RCTVersion.h */; };
@@ -1987,6 +1989,8 @@
 		14F7A0EB1BDA3B3C003C6C10 /* RCTPerfMonitor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTPerfMonitor.m; sourceTree = "<group>"; };
 		14F7A0EE1BDA714B003C6C10 /* RCTFPSGraph.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = RCTFPSGraph.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
 		14F7A0EF1BDA714B003C6C10 /* RCTFPSGraph.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTFPSGraph.m; sourceTree = "<group>"; };
+		1904A89E21D823680024F51F /* RCTSafeAreaUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTSafeAreaUtils.h; sourceTree = "<group>"; };
+		1904A89F21D823680024F51F /* RCTSafeAreaUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTSafeAreaUtils.m; sourceTree = "<group>"; };
 		191E3EBC1C29D9AF00C180A6 /* RCTRefreshControlManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTRefreshControlManager.h; sourceTree = "<group>"; };
 		191E3EBD1C29D9AF00C180A6 /* RCTRefreshControlManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTRefreshControlManager.m; sourceTree = "<group>"; };
 		191E3EBF1C29DC3800C180A6 /* RCTRefreshControl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTRefreshControl.h; sourceTree = "<group>"; };
@@ -2798,6 +2802,8 @@
 		59D031E41F8353D3008361F0 /* SafeAreaView */ = {
 			isa = PBXGroup;
 			children = (
+				1904A89E21D823680024F51F /* RCTSafeAreaUtils.h */,
+				1904A89F21D823680024F51F /* RCTSafeAreaUtils.m */,
 				59D031E51F8353D3008361F0 /* RCTSafeAreaShadowView.h */,
 				59D031E61F8353D3008361F0 /* RCTSafeAreaShadowView.m */,
 				59D031E71F8353D3008361F0 /* RCTSafeAreaView.h */,
@@ -3457,6 +3463,7 @@
 				3D80DA4C1DF820620028D040 /* RCTAppState.h in Headers */,
 				3D80DA4D1DF820620028D040 /* RCTAsyncLocalStorage.h in Headers */,
 				3D80DA4E1DF820620028D040 /* RCTClipboard.h in Headers */,
+				1904A8A021D823680024F51F /* RCTSafeAreaUtils.h in Headers */,
 				3D80DA4F1DF820620028D040 /* RCTDevLoadingView.h in Headers */,
 				3D80DA501DF820620028D040 /* RCTDevMenu.h in Headers */,
 				3D80DA511DF820620028D040 /* RCTEventEmitter.h in Headers */,
@@ -4484,6 +4491,7 @@
 				1450FF8A1BCFF28A00208362 /* RCTProfileTrampoline-x86_64.S in Sources */,
 				13D9FEEB1CDCCECF00158BD7 /* RCTEventEmitter.m in Sources */,
 				599FAA3E1FB274980058CCF6 /* RCTSurfaceRootShadowView.m in Sources */,
+				1904A8A121D823680024F51F /* RCTSafeAreaUtils.m in Sources */,
 				AC70D2E91DE489E4002E6351 /* RCTJavaScriptLoader.mm in Sources */,
 				39C50FFB2046EE3500CEE534 /* RCTVersion.m in Sources */,
 				14F7A0EC1BDA3B3C003C6C10 /* RCTPerfMonitor.m in Sources */,

--- a/React/Views/SafeAreaView/RCTSafeAreaUtils.h
+++ b/React/Views/SafeAreaView/RCTSafeAreaUtils.h
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <UIKit/UIKit.h>
+#import <React/RCTDefines.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * Returns if two edge insets are equal with `threshold` for epsilon.
+ */
+RCT_EXTERN BOOL RCTUIEdgeInsetsEqualToEdgeInsetsWithThreshold(UIEdgeInsets insets1, UIEdgeInsets insets2, CGFloat threshold);
+
+/**
+ * Returns the safe area insets for a view with a polyfill for ios < 11.
+ */
+RCT_EXTERN UIEdgeInsets RCTSafeAreaInsetsForView(UIView *view, BOOL emulateUnlessSupported);
+
+NS_ASSUME_NONNULL_END

--- a/React/Views/SafeAreaView/RCTSafeAreaUtils.m
+++ b/React/Views/SafeAreaView/RCTSafeAreaUtils.m
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import "RCTSafeAreaUtils.h"
+
+#import <React/UIView+React.h>
+
+BOOL RCTUIEdgeInsetsEqualToEdgeInsetsWithThreshold(UIEdgeInsets insets1, UIEdgeInsets insets2, CGFloat threshold)
+{
+  return
+    ABS(insets1.left - insets2.left) <= threshold &&
+    ABS(insets1.right - insets2.right) <= threshold &&
+    ABS(insets1.top - insets2.top) <= threshold &&
+    ABS(insets1.bottom - insets2.bottom) <= threshold;
+}
+
+UIEdgeInsets RCTSafeAreaInsetsForView(UIView *view, BOOL emulateUnlessSupported)
+{
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 110000 /* __IPHONE_11_0 */
+  if (@available(iOS 11, *)) {
+    return view.safeAreaInsets;
+  }
+#endif
+
+  if (!emulateUnlessSupported) {
+    return UIEdgeInsetsZero;
+  }
+
+  UIViewController* vc = view.reactViewController;
+  if (!vc) {
+    return UIEdgeInsetsZero;
+  }
+
+  CGFloat topLayoutOffset = vc.topLayoutGuide.length;
+  CGFloat bottomLayoutOffset = vc.bottomLayoutGuide.length;
+  CGRect safeArea = vc.view.bounds;
+  safeArea.origin.y += topLayoutOffset;
+  safeArea.size.height -= topLayoutOffset + bottomLayoutOffset;
+  CGRect localSafeArea = [vc.view convertRect:safeArea toView:view];
+  UIEdgeInsets safeAreaInsets = UIEdgeInsetsMake(0, 0, 0, 0);
+  if (CGRectGetMinY(localSafeArea) > CGRectGetMinY(view.bounds)) {
+    safeAreaInsets.top = CGRectGetMinY(localSafeArea) - CGRectGetMinY(view.bounds);
+  }
+  if (CGRectGetMaxY(localSafeArea) < CGRectGetMaxY(view.bounds)) {
+    safeAreaInsets.bottom = CGRectGetMaxY(view.bounds) - CGRectGetMaxY(localSafeArea);
+  }
+
+  return safeAreaInsets;
+}

--- a/ReactAndroid/src/androidTest/js/UIManagerTestModule.js
+++ b/ReactAndroid/src/androidTest/js/UIManagerTestModule.js
@@ -234,28 +234,54 @@ const UpdatePositionInListTestAppStyles = StyleSheet.create({
  */
 const emptyExactProps = Object.freeze({});
 
+const mockLayoutContext = {
+  layout: {x: 0, y: 0, width: 540, height: 720},
+  safeAreaInsets: {top: 20, right: 0, bottom: 0, left: 0},
+};
+
 const UIManagerTestModule = {
   renderFlexTestApplication(rootTag: number) {
-    renderApplication(FlexTestApp, emptyExactProps, rootTag);
+    renderApplication(FlexTestApp, emptyExactProps, rootTag, mockLayoutContext);
   },
   renderFlexWithTextApplication(rootTag: number) {
-    renderApplication(FlexWithText, emptyExactProps, rootTag);
+    renderApplication(
+      FlexWithText,
+      emptyExactProps,
+      rootTag,
+      mockLayoutContext,
+    );
   },
   renderAbsolutePositionBottomRightTestApplication(rootTag: number) {
     renderApplication(
       AbsolutePositionBottomRightTestApp,
       emptyExactProps,
       rootTag,
+      mockLayoutContext,
     );
   },
   renderAbsolutePositionTestApplication(rootTag: number) {
-    renderApplication(AbsolutePositionTestApp, emptyExactProps, rootTag);
+    renderApplication(
+      AbsolutePositionTestApp,
+      emptyExactProps,
+      rootTag,
+      mockLayoutContext,
+    );
   },
   renderCenteredTextViewTestApplication(rootTag: number, text: string) {
-    renderApplication(CenteredTextView, {text: text}, rootTag);
+    renderApplication(
+      CenteredTextView,
+      {text: text},
+      rootTag,
+      mockLayoutContext,
+    );
   },
   renderUpdatePositionInListTestApplication(rootTag: number) {
-    renderApplication(UpdatePositionInListTestApp, emptyExactProps, rootTag);
+    renderApplication(
+      UpdatePositionInListTestApp,
+      emptyExactProps,
+      rootTag,
+      mockLayoutContext,
+    );
   },
   flushUpdatePositionInList,
 };

--- a/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
@@ -527,7 +527,6 @@ public class ReactRootView extends FrameLayout implements RootView {
     windowInsets.bottom = Math.max(windowLocation[1] + getHeight() + windowInsets.bottom - screenMetrics.heightPixels, 0);
     windowInsets.right = Math.max(windowLocation[0] + getWidth() + windowInsets.right - screenMetrics.widthPixels, 0);
     return windowInsets;
-
   }
 
   private WritableMap getLayoutContext() {
@@ -689,11 +688,11 @@ public class ReactRootView extends FrameLayout implements RootView {
     private int mDeviceRotation = 0;
     private DisplayMetrics mWindowMetrics = new DisplayMetrics();
     private DisplayMetrics mScreenMetrics = new DisplayMetrics();
-    private int mWidth = 0;
-    private int mHeight = 0;
-    private float mX = 0;
-    private float mY = 0;
-    private @Nullable RootViewInsets mSafeAreaInsets;
+    private int mWidth = getWidth();
+    private int mHeight = getHeight();
+    private float mX = getX();
+    private float mY = getY();
+    private RootViewInsets mSafeAreaInsets = getSafeAreaInsets();
 
     /* package */ CustomGlobalLayoutListener() {
       DisplayMetricsHolder.initDisplayMetricsIfNotInitialized(getContext().getApplicationContext());

--- a/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
@@ -795,7 +795,7 @@ public class ReactRootView extends FrameLayout implements RootView {
       }
     }
 
-    private boolean areInsetsEqual(RootViewInsets insets, RootViewInsets otherInsets) {
+    private boolean areInsetsEqual(@Nullable RootViewInsets insets, @Nullable RootViewInsets otherInsets) {
       return insets != null &&
         otherInsets != null &&
         insets.top == otherInsets.top &&


### PR DESCRIPTION
Motivation:
----------
There is currently no way to access layout metrics from the root view that contains the component tree. This can be useful when you need to access these values from JS synchronously without having to rely on the `onLayout` event of a top level view which is async and can cause flickers.

It is roughly the equivalent of the `Dimensions` module for screen / window size but instead based on the `RootView` that the component is rendered in with a more modern `Context` based api. This also be useful for hybrid apps where the root view might not cover the entire screen.

Another goal of this is to be able to expose `safeAreaInset` values which cannot be accessed currently from JS. `SafeAreaView` is sometimes not flexible enough if we want to apply the insets manually in JS (for example use margins instead of padding).

Test Plan:
----------
### iOS RNTester

The red square is a view that has width and height set to the LayoutContext frame with padding equal to the LayoutContext safeAreaInsets. The blue square is a view that fills the content of its parent to show the safe areas.

Sample code from the RNTester example to illustrate this

```js
return (
  <LayoutContext>
    {({layout, safeAreaInsets}) => (
      <View
        style={{
          width: layout.width,
          height: layout.height,
          paddingTop: safeAreaInsets.top,
          paddingRight: safeAreaInsets.right,
          paddingBottom: safeAreaInsets.bottom,
          paddingLeft: safeAreaInsets.left,
          backgroundColor: 'red',
        }}>
          <View style={{flex: 1, backgroundColor: 'blue'}} />
        </View>
    )}
  </LayoutContext>
);
```

### iOS

- Test that safe area insets and frame match the actual app frame for iOS 11 and iOS < 11 (polyfilled version)

- Test insets on iPhone X with screen rotation

<img src="https://user-images.githubusercontent.com/2677334/45182441-34723480-b1ef-11e8-8f5e-e3ba7ee4e9a7.png" height="250" />

<img src="https://user-images.githubusercontent.com/2677334/45182450-3c31d900-b1ef-11e8-9574-643bde00f1ab.png" height="250" />

- Test insets on iPhone X with root view that doesn't cover the screen

<img src="https://user-images.githubusercontent.com/2677334/45182433-2cb29000-b1ef-11e8-9b20-ca78a048ff10.png" height="250" />

- Test that showing and hiding the status bar updates the safe area. This doesn't work on iOS < 11 but also doesn't work for the SafeAreaView component. I couldn't find a way to make it work since the status bar frame changed event is not triggered when hiding / showing. Also kvo for the statusBarHidden prop did not work either for some reason... This isn't a big deal anyway.

- Test toggling the on-call status bar

### Android

- Test changing the status bar hidden prop
- Test changing the status bar translucent prop
- Test screen rotation
- Test making the navigation bar transparent (https://stackoverflow.com/a/31596735)

<img src="https://user-images.githubusercontent.com/2677334/50552337-f1851280-0c5e-11e9-9761-e033f24d5a20.png" height="250" />

<img src="https://user-images.githubusercontent.com/2677334/50552353-2ee9a000-0c5f-11e9-8d08-246528b190d2.png" height="250" />

Release Notes:
--------------
[General] [Added] - New LayoutContext API to access the frame and safe area of the root view