### PR TITLE
If source.method is "post", use HTTP POST method

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebViewManager.java
@@ -525,7 +525,7 @@ public class ReactWebViewManager extends SimpleViewManager<WebView> {
         }
         if (source.hasKey("method")) {
           String method = source.getString("method");
-          if (method.equals(HTTP_METHOD_POST)) {
+          if (method.equalsIgnoreCase(HTTP_METHOD_POST)) {
             byte[] postData = null;
             if (source.hasKey("body")) {
               String body = source.getString("body");


### PR DESCRIPTION
The React Native Web View takes a method option to determine if HTTP GET or HTTP POST should be used.
For iPhone this is not case sensitive, meaning that `method: "post"` is allowed.
For Android "post" is not understood and therefore the request will be using HTTP GET.

I suggest we ignore case for the method, or throw an Exception.

Test Plan:
----------
Given that I add a `<WebView />` with `source.method` as lowercase `"post"` and source.uri as `http://httpbin.org/post`
When I view the WebView
Then the web view should show post data
It should not say "Method not allowed"

Release Notes:
--------------
 [ANDROID] [BUGFIX] [WebView] - Use postUrl if method is "post"
