### PR TITLE
Fixed status code when run-android fails

### DIFF
--- a/local-cli/runAndroid/runAndroid.js
+++ b/local-cli/runAndroid/runAndroid.js
@@ -132,7 +132,13 @@ function buildAndRun(args) {
       console.log(chalk.red('Argument missing for parameter --deviceId'));
     }
   } else {
-    return runOnAllDevices(args, cmd, packageNameWithSuffix, packageName, adbPath);
+    return runOnAllDevices(
+      args,
+      cmd,
+      packageNameWithSuffix,
+      packageName,
+      adbPath,
+    );
   }
 }
 

--- a/local-cli/runAndroid/runAndroid.js
+++ b/local-cli/runAndroid/runAndroid.js
@@ -121,7 +121,7 @@ function buildAndRun(args) {
   const adbPath = getAdbPath();
   if (args.deviceId) {
     if (isString(args.deviceId)) {
-      runOnSpecificDevice(
+      return runOnSpecificDevice(
         args,
         cmd,
         packageNameWithSuffix,
@@ -132,7 +132,7 @@ function buildAndRun(args) {
       console.log(chalk.red('Argument missing for parameter --deviceId'));
     }
   } else {
-    runOnAllDevices(args, cmd, packageNameWithSuffix, packageName, adbPath);
+    return runOnAllDevices(args, cmd, packageNameWithSuffix, packageName, adbPath);
   }
 }
 
@@ -305,7 +305,7 @@ function runOnAllDevices(
     // stderr is automatically piped from the gradle process, so the user
     // should see the error already, there is no need to do
     // `console.log(e.stderr)`
-    return Promise.reject();
+    return Promise.reject(e);
   }
   const devices = adb.getDevices();
   if (devices && devices.length > 0) {
@@ -343,7 +343,7 @@ function runOnAllDevices(
       // stderr is automatically piped from the gradle process, so the user
       // should see the error already, there is no need to do
       // `console.log(e.stderr)`
-      return Promise.reject();
+      return Promise.reject(e);
     }
   }
 }


### PR DESCRIPTION
Fixes #21011 

Test Plan:
----------

See the steps on how to reproduce on the original issue, after this PR the process no longer exits with 0, but exit code 1.

Release Notes:
--------------
Help reviewers and the release process by writing your own release notes. See below for an example.

[CLI] [BUGFIX] [local-cli/runAndroid/runAndroid.js] - Fixed status code when `run-android` fails.
