### PR TITLE
Change the number of days to kill stales from 3 to 7

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -2,7 +2,7 @@
 # Number of days of inactivity before an issue becomes stale
 daysUntilStale: 90
 # Number of days of inactivity before a stale issue is closed
-daysUntilClose: 3
+daysUntilClose: 7
 # Issues with these labels will never be considered stale
 exemptLabels:
   - Good first issue


### PR DESCRIPTION
Basically, saw this commit this morning and had a chance to discuss it with @matthargett and @AndrewJack and overall I agree with their criticism about 3 days being too little time for people to react to it.