### PR TITLE
Add desktop platform-related stylesheet props

### DIFF
--- a/Libraries/Components/View/ViewStylePropTypes.js
+++ b/Libraries/Components/View/ViewStylePropTypes.js
@@ -15,6 +15,7 @@ const LayoutPropTypes = require('LayoutPropTypes');
 const ReactPropTypes = require('prop-types');
 const ShadowPropTypesIOS = require('ShadowPropTypesIOS');
 const TransformPropTypes = require('TransformPropTypes');
+const DesktopPropTypes = require('DesktopPropTypes');
 
 /**
  * Warning: Some of these properties may not be supported in all releases.
@@ -23,6 +24,7 @@ const ViewStylePropTypes = {
   ...LayoutPropTypes,
   ...ShadowPropTypesIOS,
   ...TransformPropTypes,
+  ...DesktopPropTypes,
   backfaceVisibility: ReactPropTypes.oneOf(['visible', 'hidden']),
   backgroundColor: ColorPropType,
   borderColor: ColorPropType,

--- a/Libraries/StyleSheet/DesktopPropTypes.js
+++ b/Libraries/StyleSheet/DesktopPropTypes.js
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow
+ */
+
+'use strict';
+
+const ReactPropTypes = require('prop-types');
+
+const DesktopPropTypes = {
+  /**
+   * (Desktop platforms only) Allows a `View` to be used to create a draggable area for a window.
+   * This is useful for frameless windows.
+   *
+   * This may conflict with clickable child components such as buttons - use `no-drag` on them to
+   * disable this behavior.
+   */
+  appRegion: ReactPropTypes.oneOf(['drag', 'no-drag']),
+
+  /**
+   * (Desktop platforms only) Specifies what style of cursor is displayed when the mouse pointer is
+   * over a `View`.
+   */
+  cursor: ReactPropTypes.oneOf([
+    'auto',
+    'default',
+    'none',
+    'context-menu',
+    'help',
+    'pointer',
+    'progress',
+    'wait',
+    'cell',
+    'crosshair',
+    'text',
+    'vertical-text',
+    'alias',
+    'copy',
+    'move',
+    'no-drop',
+    'not-allowed',
+    'e-resize',
+    'n-resize',
+    'ne-resize',
+    'nw-resize',
+    's-resize',
+    'se-resize',
+    'sw-resize',
+    'w-resize',
+    'ew-resize',
+    'ns-resize',
+    'nesw-resize',
+    'nwse-resize',
+    'col-resize',
+    'row-resize',
+    'all-scroll',
+    'zoom-in',
+    'zoom-out',
+    'grab',
+    'grabbing',
+  ]),
+};
+
+module.exports = DesktopPropTypes;

--- a/Libraries/StyleSheet/StyleSheet.js
+++ b/Libraries/StyleSheet/StyleSheet.js
@@ -28,6 +28,7 @@ import type {
   ____LayoutStyle_Internal,
   ____ShadowStyle_Internal,
   ____TransformStyle_Internal,
+  ____DesktopStyle_Internal,
 } from 'StyleSheetTypes';
 
 /**
@@ -162,6 +163,7 @@ export type DangerouslyImpreciseStyle = ____DangerouslyImpreciseStyle_Internal;
 export type LayoutStyle = ____LayoutStyle_Internal;
 export type ShadowStyle = ____ShadowStyle_Internal;
 export type TransformStyle = ____TransformStyle_Internal;
+export type DesktopStyle = ____DesktopStyle_Internal;
 
 let hairlineWidth = PixelRatio.roundToNearestPixel(0.4);
 if (hairlineWidth === 0) {

--- a/Libraries/StyleSheet/StyleSheetTypes.js
+++ b/Libraries/StyleSheet/StyleSheetTypes.js
@@ -125,10 +125,52 @@ export type ____ShadowStyle_Internal = $ReadOnly<{|
   shadowRadius?: number,
 |}>;
 
+export type ____DesktopStyle_Internal = $ReadOnly<{|
+  appRegion?: 'drag' | 'no-drag',
+  cursor?:
+    | 'auto'
+    | 'default'
+    | 'none'
+    | 'context-menu'
+    | 'help'
+    | 'pointer'
+    | 'progress'
+    | 'wait'
+    | 'cell'
+    | 'crosshair'
+    | 'text'
+    | 'vertical-text'
+    | 'alias'
+    | 'copy'
+    | 'move'
+    | 'no-drop'
+    | 'not-allowed'
+    | 'e-resize'
+    | 'n-resize'
+    | 'ne-resize'
+    | 'nw-resize'
+    | 's-resize'
+    | 'se-resize'
+    | 'sw-resize'
+    | 'w-resize'
+    | 'ew-resize'
+    | 'ns-resize'
+    | 'nesw-resize'
+    | 'nwse-resize'
+    | 'col-resize'
+    | 'row-resize'
+    | 'all-scroll'
+    | 'zoom-in'
+    | 'zoom-out'
+    | 'grab'
+    | 'grabbing',
+|}>;
+
 export type ____ViewStyle_Internal = $ReadOnly<{|
   ...$Exact<____LayoutStyle_Internal>,
   ...$Exact<____ShadowStyle_Internal>,
   ...$Exact<____TransformStyle_Internal>,
+  ...$Exact<____DesktopStyle_Internal>,
   backfaceVisibility?: 'visible' | 'hidden',
   backgroundColor?: ColorValue,
   borderColor?: ColorValue,


### PR DESCRIPTION
This PR adds the ReactPropTypes and Flow definitions for two style properties that are not useful for mobile platforms, but will be useful for desktop implementations:

 * `cursor` - for setting what the cursor's style will be when hovering over a `<View />`
 * `appRegion` - to make `View`s into draggable areas of a window, and also for marking children of said views non-draggable (like buttons). This is named after the `--webkit-app-region` property seen in [Chrome apps](https://developer.chrome.com/apps/app_window) and [Electron apps](https://github.com/electron/electron/blob/master/docs/api/frameless-window.md#draggable-region)

These could also be utilized by React Native Dom and React Native Web. (mapping `appRegion` back to `--webkit-app-region`)

Test Plan:
----------
In a test project I was able to use `appRegion` and `cursor` in a `StyleSheet` and have `flow check` pass.

Release Notes:
--------------

[GENERAL] [ENHANCEMENT] [Libraries/StyleSheet/DesktopPropTypes.js] - Added Desktop Prop Types
[GENERAL] [ENHANCEMENT] [Libraries/Components/View/ViewStylePropTypes.js] - Added Desktop Prop Types
[GENERAL] [ENHANCEMENT] [Libraries/StyleSheet/StyleSheetTypes.js] - Added Desktop style flow types
[GENERAL] [ENHANCEMENT] [Libraries/StyleSheet/StyleSheet.js] - Added Desktop style flow types
