### PR TITLE
Fix Metro preset version

### DIFF
--- a/local-cli/init/init.js
+++ b/local-cli/init/init.js
@@ -99,7 +99,7 @@ function generateProject(destinationRoot, newProjectName, options) {
     });
   }
   if (!options['skip-jest']) {
-    const jestDeps = `jest babel-jest metro-react-native-babel-preset@^0.43.5 react-test-renderer@${reactVersion}`;
+    const jestDeps = `jest babel-jest metro-react-native-babel-preset react-test-renderer@${reactVersion}`;
     if (yarnVersion) {
       console.log('Adding Jest...');
       execSync(`yarn add ${jestDeps} --dev --exact`, {stdio: 'inherit'});


### PR DESCRIPTION
This pull request removes the hard-coded version of the `metro-react-native-babel-preset` as defined in the `init` command. That way, the version always matches React Native version specified in its `package.json`, making it match Metro version.

CC: @kelset 