### PR TITLE
Fix regression in Android unlink command

### DIFF
--- a/local-cli/link/__fixtures__/android/patchedBuild.gradle
+++ b/local-cli/link/__fixtures__/android/patchedBuild.gradle
@@ -3,6 +3,7 @@ dependencies {
     implementation(project(':test2')) {
       exclude(group: 'org.unwanted', module: 'test10')
     }
+    compile project(':testDeprecated')
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation "com.android.support:appcompat-v7:27.1.1"
     implementation "com.facebook.react:react-native:+"

--- a/local-cli/link/__tests__/android/isInstalled.spec.js
+++ b/local-cli/link/__tests__/android/isInstalled.spec.js
@@ -26,6 +26,10 @@ describe('android::isInstalled', () => {
     expect(isInstalled(projectConfig, 'test2')).toBeTruthy();
   });
 
+  it('should return true when project is already in build.gradle using compile', () => {
+    expect(isInstalled(projectConfig, 'testDeprecated')).toBeTruthy();
+  });
+
   it('should return false when project is not in build.gradle', () =>
     expect(isInstalled(projectConfig, 'test3')).toBeFalsy());
 });

--- a/local-cli/link/android/isInstalled.js
+++ b/local-cli/link/android/isInstalled.js
@@ -9,8 +9,12 @@
 
 const fs = require('fs');
 const makeBuildPatch = require('./patches/makeBuildPatch');
+const makeDeprecatedBuildPatch = require('./patches/makeDeprecatedBuildPatch');
 
 module.exports = function isInstalled(config, name) {
   const buildGradle = fs.readFileSync(config.buildGradlePath);
-  return makeBuildPatch(name).installPattern.test(buildGradle);
+  return (
+    makeBuildPatch(name).installPattern.test(buildGradle) ||
+    makeDeprecatedBuildPatch(name).installPattern.test(buildGradle)
+  );
 };

--- a/local-cli/link/android/patches/makeDeprecatedBuildPatch.js
+++ b/local-cli/link/android/patches/makeDeprecatedBuildPatch.js
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+const normalizeProjectName = require('./normalizeProjectName');
+
+module.exports = function makeDeprecatedBuildPatch(name) {
+  const normalizedProjectName = normalizeProjectName(name);
+  const installPattern = new RegExp(
+    `\\s{4}(compile)(\\(|\\s)(project)\\(\\\':${normalizedProjectName}\\\'\\)(\\)|\\s)`,
+  );
+
+  return {
+    installPattern,
+    pattern: /[^ \t]dependencies {(\r\n|\n)/,
+    patch: `    compile project(':${normalizedProjectName}')\n`,
+  };
+};

--- a/local-cli/link/android/unregisterNativeModule.js
+++ b/local-cli/link/android/unregisterNativeModule.js
@@ -13,6 +13,7 @@ const toCamelCase = require('lodash').camelCase;
 const revokePatch = require('./patches/revokePatch');
 const makeSettingsPatch = require('./patches/makeSettingsPatch');
 const makeBuildPatch = require('./patches/makeBuildPatch');
+const makeDeprecatedBuildPatch = require('./patches/makeDeprecatedBuildPatch');
 const makeStringsPatch = require('./patches/makeStringsPatch');
 const makeImportPatch = require('./patches/makeImportPatch');
 const makePackagePatch = require('./patches/makePackagePatch');
@@ -23,6 +24,7 @@ module.exports = function unregisterNativeAndroidModule(
   projectConfig,
 ) {
   const buildPatch = makeBuildPatch(name);
+  const deprecatedBuildPatch = makeDeprecatedBuildPatch(name);
   const strings = fs.readFileSync(projectConfig.stringsPath, 'utf8');
   var params = {};
 
@@ -39,6 +41,7 @@ module.exports = function unregisterNativeAndroidModule(
   );
 
   revokePatch(projectConfig.buildGradlePath, buildPatch);
+  revokePatch(projectConfig.buildGradlePath, deprecatedBuildPatch);
   revokePatch(projectConfig.stringsPath, makeStringsPatch(params, name));
 
   revokePatch(


### PR DESCRIPTION
Motivation:
--------------
Commit 4dfdec9b28074b311ffd75084d9d2a3cbd41a800 introduced a regression in the `unlink` command for Android projects: native modules previously linked with the now-deprecated `compile` configuration will not be detected anymore and by extension will not be unlinked.

`unlink` should be aware of both new and deprecated options to ensure functionality also in existing projects that previously linked modules with the old convention.

This PR fixes the regression by:
1. `makeDeprecatedNativeModule` is added so to have the deprecated patch line that could be present in the Gradle build file.
2. updating the Android `isInstalled` to check, for a given package name, for both `compile` (using the function introduced in step 1) and `implementation` dependency records in `build.gradle`.
3. Android `unregisterNativeModule` will proceed to revoke both possible patch lines from `build.gradle`.

This PR together with commit 4dfdec9b28074b311ffd75084d9d2a3cbd41a800 provide the following behaviour:

- `link` will continue to work as intended using `implementation`. This works without issues even with older packages that still use `compile` internally for their own dependencies.
- `link` will detect previously linked packages with `compile` and will not proceed with a new linkage. Instead, it will log that `Platform 'android' module X is already linked`.
- `unlink` will detect dependencies with both `compile` and `implementation` and proceed to unlink as expected.

Test Plan:
----------
- Ran tests locally on my branch, all related tests passed.
- Manually tried the changes on my existing projects that still use `compile` and the described behaviour listed above was matched.

Related PRs:
--------------
- #20853

Release Notes:
--------------
[CLI] [BUGFIX] [local-cli/link] - Fixed regression in Android `unlink`.

<!--
  **INTERNAL and MINOR tagged notes will not be included in the next version's final release notes.**

    CATEGORY
  [----------]      TYPE
  [ CLI      ] [-------------]    LOCATION
  [ DOCS     ] [ BREAKING    ] [-------------]
  [ GENERAL  ] [ BUGFIX      ] [ {Component} ]
  [ INTERNAL ] [ ENHANCEMENT ] [ {Filename}  ]
  [ IOS      ] [ FEATURE     ] [ {Directory} ]   |-----------|
  [ ANDROID  ] [ MINOR       ] [ {Framework} ] - | {Message} |
  [----------] [-------------] [-------------]   |-----------|

 EXAMPLES:

 [IOS] [BREAKING] [FlatList] - Change a thing that breaks other things
 [ANDROID] [BUGFIX] [TextInput] - Did a thing to TextInput
 [CLI] [FEATURE] [local-cli/info/info.js] - CLI easier to do things with
 [DOCS] [BUGFIX] [GettingStarted.md] - Accidentally a thing/word
 [GENERAL] [ENHANCEMENT] [Yoga] - Added new yoga thing/position
 [INTERNAL] [FEATURE] [./scripts] - Added thing to script that nobody will see
-->
