### PR TITLE
Update maven_repositories url

### DIFF
--- a/.buckconfig
+++ b/.buckconfig
@@ -7,7 +7,7 @@
 
 [maven_repositories]
   central = https://repo1.maven.org/maven2
-  google = https://maven.google.com
+  google = https://dl.google.com/dl/android/maven2/
 
 [alias]
   rntester = //RNTester/android/app:app


### PR DESCRIPTION
Update maven_repositories url to `https://dl.google.com/dl/android/maven2/` while the previous url `https://maven.google.com` has always been redirect to `https://dl.google.com/dl/android/maven2/`.

Test plan:
When run `react-native run-andriod` in command line, It always has been timeout error when using `https://maven.google.com`, while using `https://dl.google.com/dl/android/maven2/` instead works well.

[ANDROID] [ENHANCEMENT] [url] - Use the original url.
<!--
  **INTERNAL and MINOR tagged notes will not be included in the next version's final release notes.**

    CATEGORY
  [----------]      TYPE
  [ CLI      ] [-------------]    LOCATION
  [ DOCS     ] [ BREAKING    ] [-------------]
  [ GENERAL  ] [ BUGFIX      ] [ {Component} ]
  [ INTERNAL ] [ ENHANCEMENT ] [ {Filename}  ]
  [ IOS      ] [ FEATURE     ] [ {Directory} ]   |-----------|
  [ ANDROID  ] [ MINOR       ] [ {Framework} ] - | {Message} |
  [----------] [-------------] [-------------]   |-----------|

 EXAMPLES:

 [IOS] [BREAKING] [FlatList] - Change a thing that breaks other things
 [ANDROID] [BUGFIX] [TextInput] - Did a thing to TextInput
 [CLI] [FEATURE] [local-cli/info/info.js] - CLI easier to do things with
 [DOCS] [BUGFIX] [GettingStarted.md] - Accidentally a thing/word
 [GENERAL] [ENHANCEMENT] [Yoga] - Added new yoga thing/position
 [INTERNAL] [FEATURE] [./scripts] - Added thing to script that nobody will see
-->