### PR TITLE
Add oneTimeCode to textContentType typings

### DIFF
--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -155,6 +155,7 @@ type IOSProps = $ReadOnly<{|
     | 'telephoneNumber'
     | 'username'
     | 'password'
+    | 'oneTimeCode'
   ),
   scrollEnabled?: ?boolean,
 |}>;
@@ -787,6 +788,7 @@ const TextInput = createReactClass({
       'telephoneNumber',
       'username',
       'password',
+      'oneTimeCode',
     ]),
   },
   getDefaultProps(): Object {


### PR DESCRIPTION
iOS 12 supports a new `textContentType` attribute with the value `oneTimeCode` for extracting security codes from single-factor SMS login flows.

https://developer.apple.com/documentation/security/password_autofill/enabling_password_autofill_on_a_text_input_view

This commit adds the Flow typings and Prop Types.

As far as I can see no changes need to be made to the iOS code for this change. 

If this change is accepted I would also make a follow-up PR for the documentation.

Release Notes:
--------------

 [IOS] [ENHANCEMENT] [TextInput] - Added `oneTimeCode` typings and prop types to the `textContentType` prop of `TextInput`.
