### PR TITLE
Do not bring app out of immersive mode when a modal is presented

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.java
@@ -213,6 +213,7 @@ public class ReactModalHostView extends ViewGroup implements LifecycleEventListe
     Activity currentActivity = getCurrentActivity();
     Context context = currentActivity == null ? getContext() : currentActivity;
     mDialog = new Dialog(context, theme);
+    mDialog.getWindow().setFlags(WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE, WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE);
 
     mDialog.setContentView(getContentView());
     updateProperties();
@@ -252,6 +253,12 @@ public class ReactModalHostView extends ViewGroup implements LifecycleEventListe
     }
     if (currentActivity != null && !currentActivity.isFinishing()) {
       mDialog.show();
+      if(context instanceof Activity){
+        mDialog.getWindow().getDecorView().setSystemUiVisibility(
+          ((Activity)context).getWindow().getDecorView().getSystemUiVisibility()
+        );
+      }
+      mDialog.getWindow().clearFlags(WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE);
     }
   }
 


### PR DESCRIPTION
This does fix the issue, however, another, perhaps related issue persists, the dialog/modal occasionally uses what would be the height of the app in non-immersive mode, in immersive mode. Meaning that the background, what ever it is set as, does not use the full available height.

See https://stackoverflow.com/a/23207365 for more info.

Known Problems:
---------
* [Date/time picker](https://facebook.github.io/react-native/docs/datepickerandroid) still brings app out of immersive mode - The date/time picker dialog needs the same treatment (this MR) as `RN Modal` using a wrapper.
* Focusing on text input, which brings up keyboard, also brings app out of immersive mode. Sometimes temporarily, sometimes permanently - Needs investigating. I have tried [this](https://stackoverflow.com/a/25129542), unfortunately it doesn't work. **Workaround I'm using for this, is to call a native module method to re-apply immersive mode flags after `keyboardDidHide` on JS side.**


Changelog:
----------

[Android] [Fixed] - Dialog (RN Modal) brings app permanently out of immersive mode

Test Plan:
----------

- RN Modal no longer brings app out of immersive mode

