### PR TITLE
Give RNPM the ability to look for plugins in `@scoped` modules

### DIFF
--- a/local-cli/core/__tests__/findPlugins.spec.js
+++ b/local-cli/core/__tests__/findPlugins.spec.js
@@ -66,4 +66,19 @@ describe('findPlugins', () => {
     }));
     expect(findPlugins([ROOT]).commands).toHaveLength(1);
   });
+
+  it('returns plugins in scoped modules', () => {
+    jest.mock(pjsonPath, () => ({
+      dependencies: {
+        '@org/rnpm-plugin-test': '*',
+        '@org/react-native-test': '*',
+        '@react-native/test': '*',
+        '@react-native-org/test': '*',
+      },
+    }));
+
+    expect(findPlugins([ROOT])).toHaveProperty('commands');
+    expect(findPlugins([ROOT])).toHaveProperty('platforms');
+    expect(findPlugins([ROOT]).commands[0]).toBe('@org/rnpm-plugin-test');
+  });
 });

--- a/local-cli/core/findPlugins.js
+++ b/local-cli/core/findPlugins.js
@@ -14,14 +14,23 @@ const union = require('lodash').union;
 const uniq = require('lodash').uniq;
 const flatten = require('lodash').flatten;
 
+const RNPM_PLUGIN_PATTERNS = [/^rnpm-plugin-/, /^@(.*)\/rnpm-plugin-/];
+
+const REACT_NATIVE_PLUGIN_PATTERNS = [
+  /^react-native-/,
+  /^@(.*)\/react-native-/,
+  /^@react-native(.*)\/(?!rnpm-plugin-)/,
+];
+
 /**
  * Filter dependencies by name pattern
  * @param  {String} dependency Name of the dependency
  * @return {Boolean}           If dependency is a rnpm plugin
  */
-const isRNPMPlugin = dependency => dependency.indexOf('rnpm-plugin-') === 0;
+const isRNPMPlugin = dependency =>
+  RNPM_PLUGIN_PATTERNS.some(pattern => pattern.test(dependency));
 const isReactNativePlugin = dependency =>
-  dependency.indexOf('react-native-') === 0;
+  REACT_NATIVE_PLUGIN_PATTERNS.some(pattern => pattern.test(dependency));
 
 const readPackage = folder => {
   try {

--- a/local-cli/core/index.js
+++ b/local-cli/core/index.js
@@ -152,7 +152,13 @@ async function getCliConfig(): Promise<RNConfig> {
  */
 function getProjectCommands(): Array<CommandT> {
   const commands = plugins.commands.map(pathToCommands => {
-    const name = pathToCommands.split(path.sep)[0];
+    const name =
+      pathToCommands[0] === '@'
+        ? pathToCommands
+            .split(path.sep)
+            .slice(0, 2)
+            .join(path.sep)
+        : pathToCommands.split(path.sep)[0];
 
     return attachPackage(
       require(path.join(appRoot, 'node_modules', pathToCommands)),


### PR DESCRIPTION
This PR gives RNPM the ability to look for plugins in `@scoped` modules.

The regexes for finding RNPM plugins will match these hypothetical examples:

 * `rnpm-plugin-foo`
 * `@org/rnpm-plugin-foo`

The regexes for finding React Native plugins will match these hypothetical examples:

 * `react-native-foo`
 * `@org/react-native-foo`
 * `@react-native/module` (will be useful in the slimmening)
 * `@react-native-foo/module`

RNPM plugins will be able to benefit from this immediately, but React Native plugins will run into this Metro issue currently:

https://github.com/facebook/metro/issues/241

Test Plan:
----------
Test cases have been added to `findPlugins.spec.js`.

Release Notes:
--------------
Help reviewers and the release process by writing your own release notes. See below for an example.

[CLI] [ENHANCEMENT] [local-cli/core/__tests__/findPlugins.spec.js] - Tests for scoped modules have been added
[CLI] [ENHANCEMENT] [local-cli/core/findPlugins.js] - `isRNPMPlugin()` and `isReactNativePlugin()` have been updated to check a package name against an array of regexes, rather than simply checking for a prefix
[CLI] [ENHANCEMENT] [local-cli/core/index.js] - Fixed `getProjectCommands()` to be able to handle scoped modules