### PR TITLE
Fix failing Android CI

### DIFF
--- a/ReactAndroid/src/androidTest/java/com/facebook/react/testing/rule/BUCK
+++ b/ReactAndroid/src/androidTest/java/com/facebook/react/testing/rule/BUCK
@@ -1,6 +1,7 @@
 # BUILD FILE SYNTAX: SKYLARK
 load(
     "//tools/build_defs/oss:rn_defs.bzl",
+    "IS_OSS_BUILD",
     "react_native_dep",
     "react_native_integration_tests_target",
     "react_native_target",
@@ -13,9 +14,7 @@ rn_android_library(
     visibility = [
         "PUBLIC",
     ],
-    deps = [
-        react_native_dep("java/com/facebook/testing/instrumentation:instrumentation"),
-        react_native_dep("java/com/facebook/testing/instrumentation/base:base"),
+    deps = ([
         react_native_dep("third-party/java/espresso:espresso"),
         react_native_dep("third-party/java/jsr-305:jsr-305"),
         react_native_dep("third-party/java/junit:junit"),
@@ -31,5 +30,8 @@ rn_android_library(
         react_native_target("java/com/facebook/react/modules/core:core"),
         react_native_target("java/com/facebook/react/shell:shell"),
         react_native_target("java/com/facebook/react/uimanager:uimanager"),
-    ],
+    ]) + ([
+        react_native_dep("java/com/facebook/testing/instrumentation:instrumentation"),
+        react_native_dep("java/com/facebook/testing/instrumentation/base:base"),
+    ]) if not IS_OSS_BUILD else [],
 )

--- a/ReactAndroid/src/androidTest/java/com/facebook/react/tests/core/BUCK
+++ b/ReactAndroid/src/androidTest/java/com/facebook/react/tests/core/BUCK
@@ -1,6 +1,7 @@
 # BUILD FILE SYNTAX: SKYLARK
 load(
     "//tools/build_defs/oss:rn_defs.bzl",
+    "IS_OSS_BUILD",
     "react_native_dep",
     "react_native_integration_tests_target",
     "react_native_target",
@@ -10,8 +11,7 @@ load(
 rn_android_library(
     name = "core",
     srcs = glob(["*.java"]),
-    deps = [
-        react_native_dep("java/com/facebook/fbreact/testing:testing"),
+    deps = ([
         react_native_dep("third-party/java/espresso:espresso"),
         react_native_dep("third-party/java/fest:fest"),
         react_native_dep("third-party/java/junit:junit"),
@@ -22,5 +22,7 @@ rn_android_library(
         react_native_target("java/com/facebook/react/bridge:bridge"),
         react_native_target("java/com/facebook/react/shell:shell"),
         react_native_target("java/com/facebook/react/uimanager:uimanager"),
-    ],
+    ]) + ([
+        react_native_dep("java/com/facebook/fbreact/testing:testing"),
+    ]) if not IS_OSS_BUILD else [],
 )

--- a/ReactAndroid/src/main/java/com/facebook/react/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/BUCK
@@ -5,6 +5,7 @@ rn_android_library(
     srcs = glob(["*.java"]),
     provided_deps = [
         react_native_dep("third-party/android/support/v4:lib-support-v4"),
+        react_native_dep("third-party/android/support-annotations:android-support-annotations"),
     ],
     visibility = [
         "PUBLIC",


### PR DESCRIPTION
This PR does 2 things:

 * Have Facebook internal dependencies only be added if `IS_OSS_BUILD` is `True`. This syntax is used in other BUCK files in the codebase.
    * `ReactAndroid/src/androidTest/java/com/facebook/react/tests/core/BUCK`
    * `ReactAndroid/src/androidTest/java/com/facebook/react/testing/rule/BUCK`
* Add a missing Android dependency to this BUCK file:
    * `ReactAndroid/src/main/java/com/facebook/react/BUCK`

As a result, `test_android` is passing again.

Test Plan:
----------
CircleCi `test_android` passes

Release Notes:
--------------
Help reviewers and the release process by writing your own release notes. See below for an example.

[ANDROID] [BUGFIX] [ReactAndroid/src/androidTest/java/com/facebook/react/testing/rule/BUCK] - Set internal dependencies to only be included in non-OSS builds
[ANDROID] [BUGFIX] [ReactAndroid/src/androidTest/java/com/facebook/react/tests/core/BUCK] - Set internal dependencies to only be included in non-OSS builds
[ANDROID] [BUGFIX] [ReactAndroid/src/main/java/com/facebook/react/BUCK] - Add missing dependency