### PR TITLE
Add support for resource-id

### DIFF
--- a/ReactAndroid/src/androidTest/java/com/facebook/react/testing/BUCK
+++ b/ReactAndroid/src/androidTest/java/com/facebook/react/testing/BUCK
@@ -35,6 +35,7 @@ rn_android_library(
         react_native_target("java/com/facebook/react/modules/debug:interfaces"),
         react_native_target("java/com/facebook/react/shell:shell"),
         react_native_target("java/com/facebook/react/uimanager:uimanager"),
+        react_native_target("java/com/facebook/react/uimanager/util:util"),
         react_native_target("res:uimanager"),
     ],
 )

--- a/ReactAndroid/src/androidTest/java/com/facebook/react/testing/ReactAppTestActivity.java
+++ b/ReactAndroid/src/androidTest/java/com/facebook/react/testing/ReactAppTestActivity.java
@@ -41,7 +41,9 @@ import com.facebook.react.uimanager.UIManagerModule;
 import com.facebook.react.uimanager.ViewManager;
 import com.facebook.react.uimanager.ViewManagerRegistry;
 import com.facebook.react.uimanager.events.EventDispatcher;
+import com.facebook.react.uimanager.util.ReactFindViewUtil;
 import java.util.Arrays;
+import com.facebook.react.uimanager.util.ReactFindViewUtil;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -77,7 +79,7 @@ public class ReactAppTestActivity extends FragmentActivity
     setContentView(rootView);
 
     mScreenshotingFrameLayout = new ScreenshotingFrameLayout(this);
-    mScreenshotingFrameLayout.setId(ROOT_VIEW_ID);
+    ReactFindViewUtil.setReactTag(mScreenshotingFrameLayout, ROOT_VIEW_ID);
     rootView.addView(mScreenshotingFrameLayout);
 
     mReactRootView = new ReactRootView(this);

--- a/ReactAndroid/src/androidTest/java/com/facebook/react/tests/CatalystUIManagerTestCase.java
+++ b/ReactAndroid/src/androidTest/java/com/facebook/react/tests/CatalystUIManagerTestCase.java
@@ -24,6 +24,7 @@ import com.facebook.react.testing.ReactTestHelper;
 import com.facebook.react.uimanager.PixelUtil;
 import com.facebook.react.uimanager.UIManagerModule;
 import com.facebook.react.uimanager.ViewManager;
+import com.facebook.react.uimanager.util.ReactFindViewUtil;
 import com.facebook.react.views.text.ReactRawTextManager;
 import com.facebook.react.views.text.ReactTextViewManager;
 import com.facebook.react.views.view.ReactViewManager;
@@ -97,7 +98,7 @@ public class CatalystUIManagerTestCase extends ReactIntegrationTestCase {
 
   public void testFlexUIRendered() {
     FrameLayout rootView = createRootView();
-    jsModule.renderFlexTestApplication(rootView.getId());
+    jsModule.renderFlexTestApplication(ReactFindViewUtil.getReactTag(rootView));
     waitForBridgeAndUIIdle();
 
     assertEquals(1, rootView.getChildCount());
@@ -121,7 +122,7 @@ public class CatalystUIManagerTestCase extends ReactIntegrationTestCase {
   // Find what could be different and make the test independent of env
   // public void testFlexWithTextViews() {
   //   FrameLayout rootView = createRootView();
-  //   jsModule.renderFlexWithTextApplication(rootView.getId());
+  //   jsModule.renderFlexWithTextApplication(ReactFindViewUtil.getReactTag(rootView));
   //   waitForBridgeAndUIIdle();
   //
   //   assertEquals(1, rootView.getChildCount());
@@ -159,7 +160,7 @@ public class CatalystUIManagerTestCase extends ReactIntegrationTestCase {
 
   public void testAbsolutePositionUIRendered() {
     FrameLayout rootView = createRootView();
-    jsModule.renderAbsolutePositionTestApplication(rootView.getId());
+    jsModule.renderAbsolutePositionTestApplication(ReactFindViewUtil.getReactTag(rootView));
     waitForBridgeAndUIIdle();
 
     assertEquals(1, rootView.getChildCount());
@@ -173,7 +174,7 @@ public class CatalystUIManagerTestCase extends ReactIntegrationTestCase {
 
   public void testUpdatePositionInList() {
     FrameLayout rootView = createRootView();
-    jsModule.renderUpdatePositionInListTestApplication(rootView.getId());
+    jsModule.renderUpdatePositionInListTestApplication(ReactFindViewUtil.getReactTag(rootView));
     waitForBridgeAndUIIdle();
 
     ViewGroup containerView = getViewByTestId(rootView, "container");
@@ -202,7 +203,7 @@ public class CatalystUIManagerTestCase extends ReactIntegrationTestCase {
 
   public void testAbsolutePositionBottomRightUIRendered() {
     FrameLayout rootView = createRootView();
-    jsModule.renderAbsolutePositionBottomRightTestApplication(rootView.getId());
+    jsModule.renderAbsolutePositionBottomRightTestApplication(ReactFindViewUtil.getReactTag(rootView));
     waitForBridgeAndUIIdle();
 
     assertEquals(1, rootView.getChildCount());

--- a/ReactAndroid/src/androidTest/java/com/facebook/react/tests/TextInputTestCase.java
+++ b/ReactAndroid/src/androidTest/java/com/facebook/react/tests/TextInputTestCase.java
@@ -154,7 +154,7 @@ public class TextInputTestCase extends ReactAppInstrumentationTestCase {
 
     eventDispatcher.dispatchEvent(
         new ReactTextChangedEvent(
-            reactEditText.getId(),
+            ReactFindViewUtil.getReactTag(reactEditText),
             newText.toString(),
             (int) PixelUtil.toDIPFromPixel(contentWidth),
             (int) PixelUtil.toDIPFromPixel(contentHeight),
@@ -162,7 +162,7 @@ public class TextInputTestCase extends ReactAppInstrumentationTestCase {
 
     eventDispatcher.dispatchEvent(
         new ReactTextInputEvent(
-            reactEditText.getId(),
+            ReactFindViewUtil.getReactTag(reactEditText),
             newText.toString(),
             "",
             start,
@@ -186,7 +186,7 @@ public class TextInputTestCase extends ReactAppInstrumentationTestCase {
 
     eventDispatcher.dispatchEvent(
         new ReactTextChangedEvent(
-            reactEditText.getId(),
+            ReactFindViewUtil.getReactTag(reactEditText),
             newText.toString(),
             (int) PixelUtil.toDIPFromPixel(contentWidth),
             (int) PixelUtil.toDIPFromPixel(contentHeight),
@@ -194,7 +194,7 @@ public class TextInputTestCase extends ReactAppInstrumentationTestCase {
 
     eventDispatcher.dispatchEvent(
         new ReactTextInputEvent(
-            reactEditText.getId(),
+            ReactFindViewUtil.getReactTag(reactEditText),
             moreText,
             "",
             start,
@@ -218,7 +218,7 @@ public class TextInputTestCase extends ReactAppInstrumentationTestCase {
 
     eventDispatcher.dispatchEvent(
         new ReactTextChangedEvent(
-            reactEditText.getId(),
+            ReactFindViewUtil.getReactTag(reactEditText),
             newText.toString(),
             (int) PixelUtil.toDIPFromPixel(contentWidth),
             (int) PixelUtil.toDIPFromPixel(contentHeight),
@@ -226,7 +226,7 @@ public class TextInputTestCase extends ReactAppInstrumentationTestCase {
 
     eventDispatcher.dispatchEvent(
         new ReactTextInputEvent(
-            reactEditText.getId(),
+            ReactFindViewUtil.getReactTag(reactEditText),
             moreText,
             "",
             start,

--- a/ReactAndroid/src/main/java/com/facebook/react/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/BUCK
@@ -34,6 +34,7 @@ rn_android_library(
         react_native_target("java/com/facebook/react/modules/systeminfo:systeminfo"),
         react_native_target("java/com/facebook/react/modules/toast:toast"),
         react_native_target("java/com/facebook/react/uimanager:uimanager"),
+        react_native_target("java/com/facebook/react/uimanager/util:util"),
         react_native_target("java/com/facebook/react/module/annotations:annotations"),
         react_native_target("java/com/facebook/react/views/imagehelper:imagehelper"),
     ],

--- a/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
@@ -84,6 +84,7 @@ import com.facebook.react.packagerconnection.RequestHandler;
 import com.facebook.react.uimanager.DisplayMetricsHolder;
 import com.facebook.react.uimanager.UIManagerHelper;
 import com.facebook.react.uimanager.ViewManager;
+import com.facebook.react.uimanager.util.ReactFindViewUtil;
 import com.facebook.react.views.imagehelper.ResourceDrawableIdHelper;
 import com.facebook.soloader.SoLoader;
 import com.facebook.systrace.Systrace;
@@ -719,7 +720,7 @@ public class ReactInstanceManager {
 
     // Reset view content as it's going to be populated by the application content from JS.
     rootView.removeAllViews();
-    rootView.setId(View.NO_ID);
+    ReactFindViewUtil.setReactTag(rootView, View.NO_ID);
 
     // If react context is being created in the background, JS application will be started
     // automatically when creation completes, as root view is part of the attached root view list.
@@ -1077,7 +1078,7 @@ public class ReactInstanceManager {
     synchronized (mAttachedRootViews) {
       for (ReactRootView rootView : mAttachedRootViews) {
         rootView.removeAllViews();
-        rootView.setId(View.NO_ID);
+        ReactFindViewUtil.setReactTag(rootView, View.NO_ID);
       }
     }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/BUCK
@@ -15,6 +15,7 @@ rn_android_library(
         react_native_dep("third-party/java/okio:okio"),
         react_native_target("java/com/facebook/debug/holder:holder"),
         react_native_target("java/com/facebook/react/uimanager:uimanager"),
+        react_native_target("java/com/facebook/react/uimanager/util:util"),
         react_native_target("java/com/facebook/debug/tags:tags"),
         react_native_target("java/com/facebook/react/bridge:bridge"),
         react_native_target("java/com/facebook/react/common:common"),

--- a/ReactAndroid/src/main/java/com/facebook/react/touch/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/touch/BUCK
@@ -1,4 +1,4 @@
-load("//tools/build_defs/oss:rn_defs.bzl", "react_native_dep", "rn_android_library")
+load("//tools/build_defs/oss:rn_defs.bzl", "react_native_dep", "react_native_target", "rn_android_library")
 
 rn_android_library(
     name = "touch",
@@ -9,5 +9,6 @@ rn_android_library(
     deps = [
         react_native_dep("third-party/java/infer-annotations:infer-annotations"),
         react_native_dep("third-party/java/jsr-305:jsr-305"),
+        react_native_target("java/com/facebook/react/uimanager/util:util"),
     ],
 )

--- a/ReactAndroid/src/main/java/com/facebook/react/touch/JSResponderHandler.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/touch/JSResponderHandler.java
@@ -13,6 +13,8 @@ import android.view.MotionEvent;
 import android.view.ViewGroup;
 import android.view.ViewParent;
 
+import com.facebook.react.uimanager.util.ReactFindViewUtil;
+
 /**
  * This class coordinates JSResponder commands for {@link UIManagerModule}. It should be set as
  * OnInterceptTouchEventListener for all newly created native views that implements
@@ -68,7 +70,7 @@ public class JSResponderHandler implements OnInterceptTouchEventListener {
       // Therefore since "UP" event is the last event in a gesture, we should just let it reach the
       // original target that is a child view of {@param v}.
       // http://developer.android.com/reference/android/view/ViewGroup.html#onInterceptTouchEvent(android.view.MotionEvent)
-      return v.getId() == currentJSResponder;
+      return ReactFindViewUtil.getReactTag(v) == currentJSResponder;
     }
     return false;
   }

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
@@ -5,8 +5,10 @@
 
 package com.facebook.react.uimanager;
 
+import android.content.res.Resources;
 import android.graphics.Color;
 import android.os.Build;
+import android.support.annotation.IdRes;
 import android.view.View;
 import android.view.ViewParent;
 import com.facebook.react.R;
@@ -51,6 +53,7 @@ public abstract class BaseViewManager<T extends View, C extends LayoutShadowNode
    */
   public static final String PROP_TEST_ID = "testID";
   public static final String PROP_NATIVE_ID = "nativeID";
+  public static final String RESOURCE_ID = "id";
 
   private static MatrixMathHelper.MatrixDecompositionContext sMatrixDecompositionContext =
       new MatrixMathHelper.MatrixDecompositionContext();
@@ -100,6 +103,9 @@ public abstract class BaseViewManager<T extends View, C extends LayoutShadowNode
 
   @ReactProp(name = PROP_TEST_ID)
   public void setTestId(T view, String testId) {
+    String packageName = view.getContext().getPackageName();
+    @IdRes int viewId = view.getResources().getIdentifier(testId, RESOURCE_ID, packageName);
+    view.setId(viewId);
     view.setTag(R.id.react_test_id, testId);
 
     // temporarily set the tag and keyed tags to avoid end to end test regressions

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeViewHierarchyManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeViewHierarchyManager.java
@@ -35,6 +35,7 @@ import com.facebook.react.touch.JSResponderHandler;
 import com.facebook.react.uimanager.common.SizeMonitoringFrameLayout;
 import com.facebook.react.uimanager.layoutanimation.LayoutAnimationController;
 import com.facebook.react.uimanager.layoutanimation.LayoutAnimationListener;
+import com.facebook.react.uimanager.util.ReactFindViewUtil;
 import com.facebook.systrace.Systrace;
 import com.facebook.systrace.SystraceMessage;
 import javax.annotation.Nullable;
@@ -264,7 +265,7 @@ public class NativeViewHierarchyManager {
       // Use android View id field to store React tag. This is possible since we don't inflate
       // React views from layout xmls. Thus it is easier to just reuse that field instead of
       // creating another (potentially much more expensive) mapping from view to React tag
-      view.setId(tag);
+      ReactFindViewUtil.setReactTag(view, tag);
       if (initialProps != null) {
         viewManager.updateProperties(view, initialProps);
       }
@@ -282,13 +283,15 @@ public class NativeViewHierarchyManager {
     StringBuilder stringBuilder = new StringBuilder();
 
     if (null != viewToManage) {
-      stringBuilder.append("View tag:" + viewToManage.getId() + "\n");
+      stringBuilder.append("View tag:" + ReactFindViewUtil.getReactTag(viewToManage) + "\n");
       stringBuilder.append("  children(" + viewManager.getChildCount(viewToManage) + "): [\n");
       for (int index=0; index<viewManager.getChildCount(viewToManage); index+=16) {
         for (int innerOffset=0;
              ((index+innerOffset) < viewManager.getChildCount(viewToManage)) && innerOffset < 16;
              innerOffset++) {
-          stringBuilder.append(viewManager.getChildAt(viewToManage, index+innerOffset).getId() + ",");
+          View child = viewManager.getChildAt(viewToManage, index+innerOffset);
+          int reactTag = ReactFindViewUtil.getReactTag(child);
+          stringBuilder.append(reactTag + ",");
         }
         stringBuilder.append("\n");
       }
@@ -408,7 +411,7 @@ public class NativeViewHierarchyManager {
 
         if (mLayoutAnimationEnabled &&
             mLayoutAnimator.shouldAnimateLayout(viewToRemove) &&
-            arrayContains(tagsToDelete, viewToRemove.getId())) {
+            arrayContains(tagsToDelete, ReactFindViewUtil.getReactTag(viewToRemove))) {
           // The view will be removed and dropped by the 'delete' layout animation
           // instead, so do nothing
         } else {
@@ -542,7 +545,7 @@ public class NativeViewHierarchyManager {
       int tag,
       ViewGroup view,
       ThemedReactContext themedContext) {
-    if (view.getId() != View.NO_ID) {
+    if (ReactFindViewUtil.getReactTag(view) != View.NO_ID) {
       throw new IllegalViewOperationException(
           "Trying to add a root view with an explicit id already set. React Native uses " +
           "the id field to track react tags and will overwrite this field. If that is fine, " +
@@ -552,7 +555,7 @@ public class NativeViewHierarchyManager {
     mTagsToViews.put(tag, view);
     mTagsToViewManagers.put(tag, mRootViewManager);
     mRootTags.put(tag, true);
-    view.setId(tag);
+    ReactFindViewUtil.setReactTag(view, tag);
   }
 
   /**
@@ -560,24 +563,25 @@ public class NativeViewHierarchyManager {
    */
   protected synchronized void dropView(View view) {
     UiThreadUtil.assertOnUiThread();
-    if (!mRootTags.get(view.getId())) {
+    int reactTag = ReactFindViewUtil.getReactTag(view);
+    if (!mRootTags.get(reactTag)) {
       // For non-root views we notify viewmanager with {@link ViewManager#onDropInstance}
-      resolveViewManager(view.getId()).onDropViewInstance(view);
+      resolveViewManager(reactTag).onDropViewInstance(view);
     }
-    ViewManager viewManager = mTagsToViewManagers.get(view.getId());
+    ViewManager viewManager = mTagsToViewManagers.get(reactTag);
     if (view instanceof ViewGroup && viewManager instanceof ViewGroupManager) {
       ViewGroup viewGroup = (ViewGroup) view;
       ViewGroupManager viewGroupManager = (ViewGroupManager) viewManager;
       for (int i = viewGroupManager.getChildCount(viewGroup) - 1; i >= 0; i--) {
         View child = viewGroupManager.getChildAt(viewGroup, i);
-        if (mTagsToViews.get(child.getId()) != null) {
+        if (mTagsToViews.get(ReactFindViewUtil.getReactTag(child)) != null) {
           dropView(child);
         }
       }
       viewGroupManager.removeAllViews(viewGroup);
     }
-    mTagsToViews.remove(view.getId());
-    mTagsToViewManagers.remove(view.getId());
+    mTagsToViews.remove(reactTag);
+    mTagsToViewManagers.remove(reactTag);
   }
 
   public synchronized void removeRootView(int rootViewTag) {

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/TouchTargetHelper.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/TouchTargetHelper.java
@@ -19,6 +19,7 @@ import android.view.ViewGroup;
 import com.facebook.react.bridge.JSApplicationIllegalArgumentException;
 import com.facebook.react.bridge.UiThreadUtil;
 import com.facebook.react.touch.ReactHitSlopView;
+import com.facebook.react.uimanager.util.ReactFindViewUtil;
 
 /**
  * Class responsible for identifying which react view should handle a given {@link MotionEvent}.
@@ -85,7 +86,7 @@ public class TouchTargetHelper {
       float[] viewCoords,
       @Nullable int[] nativeViewTag) {
     UiThreadUtil.assertOnUiThread();
-    int targetTag = viewGroup.getId();
+    int targetTag = ReactFindViewUtil.getReactTag(viewGroup);
     // Store eventCoords in array so that they are modified to be relative to the targetView found.
     viewCoords[0] = eventX;
     viewCoords[1] = eventY;
@@ -94,7 +95,7 @@ public class TouchTargetHelper {
       View reactTargetView = findClosestReactAncestor(nativeTargetView);
       if (reactTargetView != null) {
         if (nativeViewTag != null) {
-          nativeViewTag[0] = reactTargetView.getId();
+          nativeViewTag[0] = ReactFindViewUtil.getReactTag(reactTargetView);
         }
         targetTag = getTouchTargetForView(reactTargetView, viewCoords[0], viewCoords[1]);
       }
@@ -103,7 +104,7 @@ public class TouchTargetHelper {
   }
 
   private static View findClosestReactAncestor(View view) {
-    while (view != null && view.getId() <= 0) {
+    while (view != null && ReactFindViewUtil.getReactTag(view) <= 0) {
       view = (View) view.getParent();
     }
     return view;
@@ -239,7 +240,7 @@ public class TouchTargetHelper {
         // ViewGroup).
         if (view instanceof ReactCompoundView) {
           int reactTag = ((ReactCompoundView)view).reactTagForTouch(eventCoords[0], eventCoords[1]);
-          if (reactTag != view.getId()) {
+          if (reactTag != ReactFindViewUtil.getReactTag(view)) {
             // make sure we exclude the View itself because of the PointerEvents.BOX_NONE
             return view;
           }
@@ -271,7 +272,7 @@ public class TouchTargetHelper {
       // {@link #findTouchTargetView()}.
       return ((ReactCompoundView) targetView).reactTagForTouch(eventX, eventY);
     }
-    return targetView.getId();
+    return ReactFindViewUtil.getReactTag(targetView);
   }
 
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/util/ReactFindViewUtil.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/util/ReactFindViewUtil.java
@@ -144,4 +144,13 @@ public class ReactFindViewUtil {
     Object tag = view.getTag(R.id.view_tag_native_id);
     return tag instanceof String ? (String) tag : null;
   }
+
+  public static Integer getReactTag(View view) {
+    Object tag = view.getTag(R.id.react_tag_id);
+    return tag instanceof Integer ? (Integer) tag : View.NO_ID;
+  }
+
+  public static void setReactTag(View view, int reactTag) {
+    view.setTag(R.id.react_tag_id, reactTag);
+  }
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/checkbox/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/checkbox/BUCK
@@ -16,5 +16,6 @@ rn_android_library(
         react_native_target("java/com/facebook/react/common:common"),
         react_native_target("java/com/facebook/react/uimanager:uimanager"),
         react_native_target("java/com/facebook/react/uimanager/annotations:annotations"),
+        react_native_target("java/com/facebook/react/uimanager/util:util"),
     ],
 )

--- a/ReactAndroid/src/main/java/com/facebook/react/views/checkbox/ReactCheckBoxManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/checkbox/ReactCheckBoxManager.java
@@ -14,6 +14,7 @@ import com.facebook.react.uimanager.UIManagerModule;
 import com.facebook.react.uimanager.ViewProps;
 import com.facebook.react.uimanager.annotations.ReactProp;
 import com.facebook.react.uimanager.events.EventDispatcher;
+import com.facebook.react.uimanager.util.ReactFindViewUtil;
 
 /** View manager for {@link ReactCheckBox} components. */
 public class ReactCheckBoxManager extends SimpleViewManager<ReactCheckBox> {
@@ -24,10 +25,11 @@ public class ReactCheckBoxManager extends SimpleViewManager<ReactCheckBox> {
       new CompoundButton.OnCheckedChangeListener() {
         @Override
         public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
+          int viewId = ReactFindViewUtil.getReactTag(buttonView);
           ReactContext reactContext = (ReactContext) buttonView.getContext();
           reactContext
               .getNativeModule(UIManagerModule.class).getEventDispatcher()
-              .dispatchEvent(new ReactCheckBoxEvent(buttonView.getId(), isChecked));
+              .dispatchEvent(new ReactCheckBoxEvent(viewId, isChecked));
         }
       };
 

--- a/ReactAndroid/src/main/java/com/facebook/react/views/drawer/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/drawer/BUCK
@@ -18,6 +18,7 @@ rn_android_library(
         react_native_target("java/com/facebook/react/module/annotations:annotations"),
         react_native_target("java/com/facebook/react/uimanager:uimanager"),
         react_native_target("java/com/facebook/react/uimanager/annotations:annotations"),
+        react_native_target("java/com/facebook/react/uimanager/util:util"),
         react_native_target("java/com/facebook/react/views/scroll:scroll"),
     ],
 )

--- a/ReactAndroid/src/main/java/com/facebook/react/views/drawer/ReactDrawerLayoutManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/drawer/ReactDrawerLayoutManager.java
@@ -23,6 +23,7 @@ import com.facebook.react.uimanager.UIManagerModule;
 import com.facebook.react.uimanager.ViewGroupManager;
 import com.facebook.react.uimanager.annotations.ReactProp;
 import com.facebook.react.uimanager.events.EventDispatcher;
+import com.facebook.react.uimanager.util.ReactFindViewUtil;
 import com.facebook.react.views.drawer.events.DrawerClosedEvent;
 import com.facebook.react.views.drawer.events.DrawerOpenedEvent;
 import com.facebook.react.views.drawer.events.DrawerSlideEvent;
@@ -182,25 +183,25 @@ public class ReactDrawerLayoutManager extends ViewGroupManager<ReactDrawerLayout
     @Override
     public void onDrawerSlide(View view, float v) {
       mEventDispatcher.dispatchEvent(
-          new DrawerSlideEvent(mDrawerLayout.getId(), v));
+          new DrawerSlideEvent(ReactFindViewUtil.getReactTag(mDrawerLayout), v));
     }
 
     @Override
     public void onDrawerOpened(View view) {
       mEventDispatcher.dispatchEvent(
-        new DrawerOpenedEvent(mDrawerLayout.getId()));
+        new DrawerOpenedEvent(ReactFindViewUtil.getReactTag(mDrawerLayout)));
     }
 
     @Override
     public void onDrawerClosed(View view) {
       mEventDispatcher.dispatchEvent(
-          new DrawerClosedEvent(mDrawerLayout.getId()));
+          new DrawerClosedEvent(ReactFindViewUtil.getReactTag(mDrawerLayout)));
     }
 
     @Override
     public void onDrawerStateChanged(int i) {
       mEventDispatcher.dispatchEvent(
-          new DrawerStateChangedEvent(mDrawerLayout.getId(), i));
+          new DrawerStateChangedEvent(ReactFindViewUtil.getReactTag(mDrawerLayout), i));
     }
   }
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/image/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/image/BUCK
@@ -45,6 +45,7 @@ rn_android_library(
         react_native_target("java/com/facebook/react/common:common"),
         react_native_target("java/com/facebook/react/module/annotations:annotations"),
         react_native_target("java/com/facebook/react/uimanager:uimanager"),
+        react_native_target("java/com/facebook/react/uimanager/util:util"),
         react_native_target("java/com/facebook/react/modules/fresco:fresco"),
         react_native_target("java/com/facebook/react/uimanager/annotations:annotations"),
         react_native_target("java/com/facebook/react/views/imagehelper:withmultisource"),

--- a/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageView.java
@@ -53,6 +53,7 @@ import com.facebook.react.uimanager.FloatUtil;
 import com.facebook.react.uimanager.PixelUtil;
 import com.facebook.react.uimanager.UIManagerModule;
 import com.facebook.react.uimanager.events.EventDispatcher;
+import com.facebook.react.uimanager.util.ReactFindViewUtil;
 import com.facebook.react.views.imagehelper.ImageSource;
 import com.facebook.react.views.imagehelper.MultiSourceHelper;
 import com.facebook.react.views.imagehelper.MultiSourceHelper.MultiSourceResult;
@@ -241,8 +242,9 @@ public class ReactImageView extends GenericDraweeView {
       mControllerListener = new BaseControllerListener<ImageInfo>() {
         @Override
         public void onSubmit(String id, Object callerContext) {
+          Integer reactTag = ReactFindViewUtil.getReactTag(ReactImageView.this);
           mEventDispatcher.dispatchEvent(
-            new ImageLoadEvent(getId(), ImageLoadEvent.ON_LOAD_START));
+            new ImageLoadEvent(reactTag, ImageLoadEvent.ON_LOAD_START));
         }
 
         @Override
@@ -251,20 +253,22 @@ public class ReactImageView extends GenericDraweeView {
           @Nullable final ImageInfo imageInfo,
           @Nullable Animatable animatable) {
           if (imageInfo != null) {
+            Integer reactTag = ReactFindViewUtil.getReactTag(ReactImageView.this);
             mEventDispatcher.dispatchEvent(
-              new ImageLoadEvent(getId(), ImageLoadEvent.ON_LOAD,
+              new ImageLoadEvent(reactTag, ImageLoadEvent.ON_LOAD,
                 mImageSource.getSource(), imageInfo.getWidth(), imageInfo.getHeight()));
             mEventDispatcher.dispatchEvent(
-              new ImageLoadEvent(getId(), ImageLoadEvent.ON_LOAD_END));
+              new ImageLoadEvent(reactTag, ImageLoadEvent.ON_LOAD_END));
           }
         }
 
         @Override
         public void onFailure(String id, Throwable throwable) {
+          Integer reactTag = ReactFindViewUtil.getReactTag(ReactImageView.this);
           mEventDispatcher.dispatchEvent(
-            new ImageLoadEvent(getId(), ImageLoadEvent.ON_ERROR));
+            new ImageLoadEvent(reactTag, ImageLoadEvent.ON_ERROR));
           mEventDispatcher.dispatchEvent(
-            new ImageLoadEvent(getId(), ImageLoadEvent.ON_LOAD_END));
+            new ImageLoadEvent(reactTag, ImageLoadEvent.ON_LOAD_END));
         }
       };
     }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/modal/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/modal/BUCK
@@ -17,6 +17,7 @@ rn_android_library(
         react_native_target("java/com/facebook/react/touch:touch"),
         react_native_target("java/com/facebook/react/uimanager:uimanager"),
         react_native_target("java/com/facebook/react/uimanager/annotations:annotations"),
+        react_native_target("java/com/facebook/react/uimanager/util:util"),
         react_native_target("java/com/facebook/react/views/view:view"),
         react_native_target("res:modal"),
     ],

--- a/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostManager.java
@@ -16,6 +16,7 @@ import com.facebook.react.uimanager.UIManagerModule;
 import com.facebook.react.uimanager.ViewGroupManager;
 import com.facebook.react.uimanager.annotations.ReactProp;
 import com.facebook.react.uimanager.events.EventDispatcher;
+import com.facebook.react.uimanager.util.ReactFindViewUtil;
 import java.util.Map;
 
 /**
@@ -77,14 +78,14 @@ public class ReactModalHostManager extends ViewGroupManager<ReactModalHostView> 
       new ReactModalHostView.OnRequestCloseListener() {
         @Override
         public void onRequestClose(DialogInterface dialog) {
-          dispatcher.dispatchEvent(new RequestCloseEvent(view.getId()));
+          dispatcher.dispatchEvent(new RequestCloseEvent(ReactFindViewUtil.getReactTag(view)));
         }
       });
     view.setOnShowListener(
       new DialogInterface.OnShowListener() {
         @Override
         public void onShow(DialogInterface dialog) {
-          dispatcher.dispatchEvent(new ShowEvent(view.getId()));
+          dispatcher.dispatchEvent(new ShowEvent(ReactFindViewUtil.getReactTag(view)));
         }
       });
   }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.java
@@ -28,6 +28,7 @@ import com.facebook.react.uimanager.JSTouchDispatcher;
 import com.facebook.react.uimanager.RootView;
 import com.facebook.react.uimanager.UIManagerModule;
 import com.facebook.react.uimanager.events.EventDispatcher;
+import com.facebook.react.uimanager.util.ReactFindViewUtil;
 import com.facebook.react.views.view.ReactViewGroup;
 import java.util.ArrayList;
 import javax.annotation.Nullable;
@@ -320,7 +321,7 @@ public class ReactModalHostView extends ViewGroup implements LifecycleEventListe
     protected void onSizeChanged(final int w, final int h, int oldw, int oldh) {
       super.onSizeChanged(w, h, oldw, oldh);
       if (getChildCount() > 0) {
-        final int viewTag = getChildAt(0).getId();
+        final int viewTag = ReactFindViewUtil.getReactTag(getChildAt(0));
         ReactContext reactContext = getReactContext();
         reactContext.runOnNativeModulesQueueThread(
           new GuardedRunnable(reactContext) {

--- a/ReactAndroid/src/main/java/com/facebook/react/views/picker/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/picker/BUCK
@@ -14,5 +14,6 @@ rn_android_library(
         react_native_target("java/com/facebook/react/module/annotations:annotations"),
         react_native_target("java/com/facebook/react/uimanager:uimanager"),
         react_native_target("java/com/facebook/react/uimanager/annotations:annotations"),
+        react_native_target("java/com/facebook/react/uimanager/util:util"),
     ],
 )

--- a/ReactAndroid/src/main/java/com/facebook/react/views/picker/ReactPickerManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/picker/ReactPickerManager.java
@@ -23,6 +23,7 @@ import com.facebook.react.uimanager.UIManagerModule;
 import com.facebook.react.uimanager.ViewProps;
 import com.facebook.react.uimanager.annotations.ReactProp;
 import com.facebook.react.uimanager.events.EventDispatcher;
+import com.facebook.react.uimanager.util.ReactFindViewUtil;
 import com.facebook.react.views.picker.events.PickerItemSelectEvent;
 import javax.annotation.Nullable;
 
@@ -152,7 +153,7 @@ public abstract class ReactPickerManager extends SimpleViewManager<ReactPicker> 
     @Override
     public void onItemSelected(int position) {
       mEventDispatcher.dispatchEvent( new PickerItemSelectEvent(
-              mReactPicker.getId(), position));
+              ReactFindViewUtil.getReactTag(mReactPicker), position));
     }
   }
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/scroll/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/scroll/BUCK
@@ -20,6 +20,7 @@ rn_android_library(
         react_native_target("java/com/facebook/react/touch:touch"),
         react_native_target("java/com/facebook/react/uimanager:uimanager"),
         react_native_target("java/com/facebook/react/uimanager/annotations:annotations"),
+        react_native_target("java/com/facebook/react/uimanager/util:util"),
         react_native_target("java/com/facebook/react/views/view:view"),
     ],
 )

--- a/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewHelper.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewHelper.java
@@ -12,7 +12,9 @@ import android.view.ViewGroup;
 import com.facebook.react.bridge.JSApplicationIllegalArgumentException;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.uimanager.UIManagerModule;
+import com.facebook.react.uimanager.util.ReactFindViewUtil;
 import com.facebook.react.uimanager.events.EventDispatcher;
+import com.facebook.react.uimanager.util.ReactFindViewUtil;
 
 /**
  * Helper class that deals with emitting Scroll Events.
@@ -71,7 +73,7 @@ public class ReactScrollViewHelper {
     ReactContext reactContext = (ReactContext) scrollView.getContext();
     reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher().dispatchEvent(
         ScrollEvent.obtain(
-            scrollView.getId(),
+            ReactFindViewUtil.getReactTag(scrollView),
             scrollEventType,
             scrollView.getScrollX(),
             scrollView.getScrollY(),

--- a/ReactAndroid/src/main/java/com/facebook/react/views/slider/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/slider/BUCK
@@ -16,5 +16,6 @@ rn_android_library(
         react_native_target("java/com/facebook/react/common:common"),
         react_native_target("java/com/facebook/react/uimanager:uimanager"),
         react_native_target("java/com/facebook/react/uimanager/annotations:annotations"),
+        react_native_target("java/com/facebook/react/uimanager/util:util"),
     ],
 )

--- a/ReactAndroid/src/main/java/com/facebook/react/views/slider/ReactSliderManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/slider/ReactSliderManager.java
@@ -22,7 +22,9 @@ import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.UIManagerModule;
 import com.facebook.react.uimanager.ViewProps;
 import com.facebook.react.uimanager.annotations.ReactProp;
+import com.facebook.react.uimanager.util.ReactFindViewUtil;
 import com.facebook.react.uimanager.events.EventDispatcher;
+import com.facebook.react.uimanager.util.ReactFindViewUtil;
 import com.facebook.yoga.YogaMeasureFunction;
 import com.facebook.yoga.YogaMeasureMode;
 import com.facebook.yoga.YogaMeasureOutput;
@@ -110,7 +112,7 @@ public class ReactSliderManager extends SimpleViewManager<ReactSlider> {
           ReactContext reactContext = (ReactContext) seekbar.getContext();
           reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher().dispatchEvent(
               new ReactSliderEvent(
-                  seekbar.getId(),
+                  ReactFindViewUtil.getReactTag(seekbar),
                   ((ReactSlider) seekbar).toRealProgress(progress),
                   fromUser));
         }
@@ -124,7 +126,7 @@ public class ReactSliderManager extends SimpleViewManager<ReactSlider> {
           ReactContext reactContext = (ReactContext) seekbar.getContext();
           reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher().dispatchEvent(
               new ReactSlidingCompleteEvent(
-                  seekbar.getId(),
+                  ReactFindViewUtil.getReactTag(seekbar),
                   ((ReactSlider) seekbar).toRealProgress(seekbar.getProgress())));
         }
       };

--- a/ReactAndroid/src/main/java/com/facebook/react/views/swiperefresh/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/swiperefresh/BUCK
@@ -16,6 +16,7 @@ rn_android_library(
         react_native_target("java/com/facebook/react/module/annotations:annotations"),
         react_native_target("java/com/facebook/react/uimanager:uimanager"),
         react_native_target("java/com/facebook/react/uimanager/annotations:annotations"),
+        react_native_target("java/com/facebook/react/uimanager/util:util"),
         react_native_target("java/com/facebook/react/views/scroll:scroll"),
     ],
 )

--- a/ReactAndroid/src/main/java/com/facebook/react/views/swiperefresh/SwipeRefreshLayoutManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/swiperefresh/SwipeRefreshLayoutManager.java
@@ -21,6 +21,7 @@ import com.facebook.react.uimanager.ViewGroupManager;
 import com.facebook.react.uimanager.ViewProps;
 import com.facebook.react.uimanager.annotations.ReactProp;
 import com.facebook.react.uimanager.events.EventDispatcher;
+import com.facebook.react.uimanager.util.ReactFindViewUtil;
 import java.util.Map;
 import javax.annotation.Nullable;
 
@@ -90,7 +91,7 @@ public class SwipeRefreshLayoutManager extends ViewGroupManager<ReactSwipeRefres
           @Override
           public void onRefresh() {
             reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher()
-                .dispatchEvent(new RefreshEvent(view.getId()));
+                .dispatchEvent(new RefreshEvent(ReactFindViewUtil.getReactTag(view)));
           }
         });
   }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/switchview/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/switchview/BUCK
@@ -16,5 +16,6 @@ rn_android_library(
         react_native_target("java/com/facebook/react/common:common"),
         react_native_target("java/com/facebook/react/uimanager:uimanager"),
         react_native_target("java/com/facebook/react/uimanager/annotations:annotations"),
+        react_native_target("java/com/facebook/react/uimanager/util:util"),
     ],
 )

--- a/ReactAndroid/src/main/java/com/facebook/react/views/switchview/ReactSwitchManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/switchview/ReactSwitchManager.java
@@ -20,7 +20,9 @@ import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.UIManagerModule;
 import com.facebook.react.uimanager.ViewProps;
 import com.facebook.react.uimanager.annotations.ReactProp;
+import com.facebook.react.uimanager.util.ReactFindViewUtil;
 import com.facebook.react.uimanager.events.EventDispatcher;
+import com.facebook.react.uimanager.util.ReactFindViewUtil;
 import com.facebook.yoga.YogaMeasureFunction;
 import com.facebook.yoga.YogaMeasureMode;
 import com.facebook.yoga.YogaMeasureOutput;
@@ -107,7 +109,7 @@ public class ReactSwitchManager extends SimpleViewManager<ReactSwitch> {
           ReactContext reactContext = (ReactContext) buttonView.getContext();
           reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher().dispatchEvent(
               new ReactSwitchEvent(
-                  buttonView.getId(),
+                  ReactFindViewUtil.getReactTag(buttonView),
                   isChecked));
         }
       };

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/BUCK
@@ -16,6 +16,7 @@ rn_android_library(
         react_native_target("java/com/facebook/react/module/annotations:annotations"),
         react_native_target("java/com/facebook/react/uimanager:uimanager"),
         react_native_target("java/com/facebook/react/uimanager/annotations:annotations"),
+        react_native_target("java/com/facebook/react/uimanager/util:util"),
         react_native_target("java/com/facebook/react/views/view:view"),
     ],
 )

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
@@ -18,6 +18,7 @@ import android.view.ViewGroup;
 import android.widget.TextView;
 import com.facebook.react.uimanager.ReactCompoundView;
 import com.facebook.react.uimanager.ViewDefaults;
+import com.facebook.react.uimanager.util.ReactFindViewUtil;
 import com.facebook.react.views.view.ReactViewBackgroundManager;
 import javax.annotation.Nullable;
 
@@ -75,7 +76,7 @@ public class ReactTextView extends TextView implements ReactCompoundView {
   @Override
   public int reactTagForTouch(float touchX, float touchY) {
     CharSequence text = getText();
-    int target = getId();
+    int target = ReactFindViewUtil.getReactTag(this);
 
     int x = (int) touchX;
     int y = (int) touchY;

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/BUCK
@@ -20,6 +20,7 @@ rn_android_library(
         react_native_target("java/com/facebook/react/modules/core:core"),
         react_native_target("java/com/facebook/react/uimanager:uimanager"),
         react_native_target("java/com/facebook/react/uimanager/annotations:annotations"),
+        react_native_target("java/com/facebook/react/uimanager/util:util"),
         react_native_target("java/com/facebook/react/views/imagehelper:imagehelper"),
         react_native_target("java/com/facebook/react/views/scroll:scroll"),
         react_native_target("java/com/facebook/react/views/text:text"),

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
@@ -35,6 +35,7 @@ import com.facebook.infer.annotation.Assertions;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.uimanager.PixelUtil;
 import com.facebook.react.uimanager.UIManagerModule;
+import com.facebook.react.uimanager.util.ReactFindViewUtil;
 import com.facebook.react.views.text.CustomStyleSpan;
 import com.facebook.react.views.text.ReactTagSpan;
 import com.facebook.react.views.text.ReactTextUpdate;
@@ -478,7 +479,8 @@ public class ReactEditText extends EditText {
     ReactContext reactContext = (ReactContext) getContext();
     UIManagerModule uiManager = reactContext.getNativeModule(UIManagerModule.class);
     final ReactTextInputLocalData localData = new ReactTextInputLocalData(this);
-    uiManager.setViewLocalData(getId(), localData);
+    int reactTag = ReactFindViewUtil.getReactTag(this);
+    uiManager.setViewLocalData(reactTag, localData);
   }
 
   /* package */ void setGravityHorizontal(int gravityHorizontal) {

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditTextInputConnectionWrapper.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditTextInputConnectionWrapper.java
@@ -14,6 +14,7 @@ import android.view.inputmethod.InputConnectionWrapper;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.uimanager.UIManagerModule;
 import com.facebook.react.uimanager.events.EventDispatcher;
+import com.facebook.react.uimanager.util.ReactFindViewUtil;
 import javax.annotation.Nullable;
 
 /**
@@ -155,7 +156,7 @@ class ReactEditTextInputConnectionWrapper extends InputConnectionWrapper {
     }
     mEventDispatcher.dispatchEvent(
         new ReactTextInputKeyPressEvent(
-            mEditText.getId(),
+            ReactFindViewUtil.getReactTag(mEditText),
             key));
   }
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
@@ -41,6 +41,7 @@ import com.facebook.react.uimanager.ViewProps;
 import com.facebook.react.uimanager.annotations.ReactProp;
 import com.facebook.react.uimanager.annotations.ReactPropGroup;
 import com.facebook.react.uimanager.events.EventDispatcher;
+import com.facebook.react.uimanager.util.ReactFindViewUtil;
 import com.facebook.react.views.imagehelper.ResourceDrawableIdHelper;
 import com.facebook.react.views.scroll.ScrollEvent;
 import com.facebook.react.views.scroll.ScrollEventType;
@@ -730,13 +731,13 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
       // TODO: t7936714 merge these events
       mEventDispatcher.dispatchEvent(
           new ReactTextChangedEvent(
-              mEditText.getId(),
+              ReactFindViewUtil.getReactTag(mEditText),
               s.toString(),
               mEditText.incrementAndGetEventCounter()));
 
       mEventDispatcher.dispatchEvent(
           new ReactTextInputEvent(
-              mEditText.getId(),
+              ReactFindViewUtil.getReactTag(mEditText),
               newText,
               oldText,
               start,
@@ -761,15 +762,15 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
             if (hasFocus) {
               eventDispatcher.dispatchEvent(
                   new ReactTextInputFocusEvent(
-                      editText.getId()));
+                      ReactFindViewUtil.getReactTag(editText)));
             } else {
               eventDispatcher.dispatchEvent(
                   new ReactTextInputBlurEvent(
-                      editText.getId()));
+                      ReactFindViewUtil.getReactTag(editText)));
 
               eventDispatcher.dispatchEvent(
                   new ReactTextInputEndEditingEvent(
-                      editText.getId(),
+                      ReactFindViewUtil.getReactTag(editText),
                       editText.getText().toString()));
             }
           }
@@ -798,7 +799,7 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
 
               eventDispatcher.dispatchEvent(
                   new ReactTextInputSubmitEditingEvent(
-                      editText.getId(),
+                      ReactFindViewUtil.getReactTag(editText),
                       editText.getText().toString()));
 
               if (blurOnSubmit) {
@@ -845,7 +846,7 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
 
         mEventDispatcher.dispatchEvent(
           new ReactContentSizeChangedEvent(
-            mEditText.getId(),
+            ReactFindViewUtil.getReactTag(mEditText),
             PixelUtil.toDIPFromPixel(contentWidth),
             PixelUtil.toDIPFromPixel(contentHeight)));
       }
@@ -873,7 +874,7 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
       if (mPreviousSelectionStart != start || mPreviousSelectionEnd != end) {
         mEventDispatcher.dispatchEvent(
             new ReactTextInputSelectionEvent(
-                mReactEditText.getId(),
+                ReactFindViewUtil.getReactTag(mReactEditText),
                 start,
                 end
             ));
@@ -901,7 +902,7 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
     public void onScrollChanged(int horiz, int vert, int oldHoriz, int oldVert) {
       if (mPreviousHoriz != horiz || mPreviousVert != vert) {
         ScrollEvent event = ScrollEvent.obtain(
-          mReactEditText.getId(),
+          ReactFindViewUtil.getReactTag(mReactEditText),
           ScrollEventType.SCROLL,
           horiz,
           vert,

--- a/ReactAndroid/src/main/java/com/facebook/react/views/toolbar/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/toolbar/BUCK
@@ -21,5 +21,6 @@ rn_android_library(
         react_native_target("java/com/facebook/react/common:common"),
         react_native_target("java/com/facebook/react/uimanager:uimanager"),
         react_native_target("java/com/facebook/react/uimanager/annotations:annotations"),
+        react_native_target("java/com/facebook/react/uimanager/util:util"),
     ],
 )

--- a/ReactAndroid/src/main/java/com/facebook/react/views/toolbar/ReactToolbarManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/toolbar/ReactToolbarManager.java
@@ -23,6 +23,7 @@ import com.facebook.react.uimanager.UIManagerModule;
 import com.facebook.react.uimanager.ViewGroupManager;
 import com.facebook.react.uimanager.annotations.ReactProp;
 import com.facebook.react.uimanager.events.EventDispatcher;
+import com.facebook.react.uimanager.util.ReactFindViewUtil;
 import com.facebook.react.views.toolbar.events.ToolbarClickEvent;
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -124,7 +125,7 @@ public class ReactToolbarManager extends ViewGroupManager<ReactToolbar> {
           @Override
           public void onClick(View v) {
             mEventDispatcher.dispatchEvent(
-                new ToolbarClickEvent(view.getId(), -1));
+                new ToolbarClickEvent(ReactFindViewUtil.getReactTag(view), -1));
           }
         });
 
@@ -134,7 +135,7 @@ public class ReactToolbarManager extends ViewGroupManager<ReactToolbar> {
           public boolean onMenuItemClick(MenuItem menuItem) {
             mEventDispatcher.dispatchEvent(
                 new ToolbarClickEvent(
-                    view.getId(),
+                    ReactFindViewUtil.getReactTag(view),
                     menuItem.getOrder()));
             return true;
           }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/viewpager/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/viewpager/BUCK
@@ -18,6 +18,7 @@ rn_android_library(
         react_native_target("java/com/facebook/react/module/annotations:annotations"),
         react_native_target("java/com/facebook/react/uimanager:uimanager"),
         react_native_target("java/com/facebook/react/uimanager/annotations:annotations"),
+        react_native_target("java/com/facebook/react/uimanager/util:util"),
         react_native_target("java/com/facebook/react/views/scroll:scroll"),
     ],
 )

--- a/ReactAndroid/src/main/java/com/facebook/react/views/viewpager/ReactViewPager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/viewpager/ReactViewPager.java
@@ -18,6 +18,7 @@ import com.facebook.react.common.ReactConstants;
 import com.facebook.react.uimanager.UIManagerModule;
 import com.facebook.react.uimanager.events.EventDispatcher;
 import com.facebook.react.uimanager.events.NativeGestureUtil;
+import com.facebook.react.uimanager.util.ReactFindViewUtil;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -120,15 +121,17 @@ public class ReactViewPager extends ViewPager {
 
     @Override
     public void onPageScrolled(int position, float positionOffset, int positionOffsetPixels) {
+      Integer reactTag = ReactFindViewUtil.getReactTag(ReactViewPager.this);
       mEventDispatcher.dispatchEvent(
-          new PageScrollEvent(getId(), position, positionOffset));
+          new PageScrollEvent(reactTag, position, positionOffset));
     }
 
     @Override
     public void onPageSelected(int position) {
       if (!mIsCurrentItemFromJs) {
+        Integer reactTag = ReactFindViewUtil.getReactTag(ReactViewPager.this);
         mEventDispatcher.dispatchEvent(
-            new PageSelectedEvent(getId(), position));
+            new PageSelectedEvent(reactTag, position));
       }
     }
 
@@ -148,8 +151,9 @@ public class ReactViewPager extends ViewPager {
         default:
           throw new IllegalStateException("Unsupported pageScrollState");
       }
+      Integer reactTag = ReactFindViewUtil.getReactTag(ReactViewPager.this);
       mEventDispatcher.dispatchEvent(
-        new PageScrollStateChangedEvent(getId(), pageScrollState));
+        new PageScrollStateChangedEvent(reactTag, pageScrollState));
     }
   }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/views/webview/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/webview/BUCK
@@ -14,5 +14,6 @@ rn_android_library(
         react_native_target("java/com/facebook/react/module/annotations:annotations"),
         react_native_target("java/com/facebook/react/uimanager:uimanager"),
         react_native_target("java/com/facebook/react/uimanager/annotations:annotations"),
+        react_native_target("java/com/facebook/react/uimanager/util:util"),
     ],
 )

--- a/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebViewManager.java
@@ -45,6 +45,7 @@ import com.facebook.react.uimanager.annotations.ReactProp;
 import com.facebook.react.uimanager.events.ContentSizeChangeEvent;
 import com.facebook.react.uimanager.events.Event;
 import com.facebook.react.uimanager.events.EventDispatcher;
+import com.facebook.react.uimanager.util.ReactFindViewUtil;
 import com.facebook.react.views.webview.events.TopLoadingErrorEvent;
 import com.facebook.react.views.webview.events.TopLoadingFinishEvent;
 import com.facebook.react.views.webview.events.TopLoadingStartEvent;
@@ -134,7 +135,7 @@ public class ReactWebViewManager extends SimpleViewManager<WebView> {
       dispatchEvent(
         webView,
         new TopLoadingStartEvent(
-          webView.getId(),
+          ReactFindViewUtil.getReactTag(webView),
           createWebViewEvent(webView, url)));
     }
 
@@ -205,20 +206,20 @@ public class ReactWebViewManager extends SimpleViewManager<WebView> {
 
       dispatchEvent(
         webView,
-        new TopLoadingErrorEvent(webView.getId(), eventData));
+        new TopLoadingErrorEvent(ReactFindViewUtil.getReactTag(webView), eventData));
     }
 
     protected void emitFinishEvent(WebView webView, String url) {
       dispatchEvent(
         webView,
         new TopLoadingFinishEvent(
-          webView.getId(),
+          ReactFindViewUtil.getReactTag(webView),
           createWebViewEvent(webView, url)));
     }
 
     protected WritableMap createWebViewEvent(WebView webView, String url) {
       WritableMap event = Arguments.createMap();
-      event.putDouble("target", webView.getId());
+      event.putDouble("target", ReactFindViewUtil.getReactTag(webView));
       // Don't use webView.getUrl() here, the URL isn't updated to the new value yet in callbacks
       // like onPageFinished
       event.putString("url", url);
@@ -365,7 +366,7 @@ public class ReactWebViewManager extends SimpleViewManager<WebView> {
     }
 
     public void onMessage(String message) {
-      dispatchEvent(this, new TopMessageEvent(this.getId(), message));
+      dispatchEvent(this, new TopMessageEvent(ReactFindViewUtil.getReactTag(this), message));
     }
 
     protected void cleanupCallbacksAndDestroy() {
@@ -691,7 +692,7 @@ public class ReactWebViewManager extends SimpleViewManager<WebView> {
           dispatchEvent(
             webView,
             new ContentSizeChangeEvent(
-              webView.getId(),
+              ReactFindViewUtil.getReactTag(webView),
               webView.getWidth(),
               webView.getContentHeight()));
         }

--- a/ReactAndroid/src/main/res/views/uimanager/values/ids.xml
+++ b/ReactAndroid/src/main/res/views/uimanager/values/ids.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+  <!-- tag is used to store the react tag -->
+  <item type="id" name="react_tag_id"/>
+
   <!-- tag is used to store the testID tag -->
   <item type="id" name="react_test_id"/>
 

--- a/ReactAndroid/src/test/java/com/facebook/react/BUCK
+++ b/ReactAndroid/src/test/java/com/facebook/react/BUCK
@@ -22,6 +22,7 @@ rn_robolectric_test(
         react_native_target("java/com/facebook/react/common:common"),
         react_native_target("java/com/facebook/react/touch:touch"),
         react_native_target("java/com/facebook/react/uimanager:uimanager"),
+        react_native_target("java/com/facebook/react/uimanager/util:util"),
         react_native_target("java/com/facebook/react/views/text:text"),
         react_native_target("java/com/facebook/react/views/view:view"),
         react_native_tests_target("java/com/facebook/react/bridge:testhelpers"),

--- a/ReactAndroid/src/test/java/com/facebook/react/RootViewTest.java
+++ b/ReactAndroid/src/test/java/com/facebook/react/RootViewTest.java
@@ -26,6 +26,7 @@ import com.facebook.react.uimanager.DisplayMetricsHolder;
 import com.facebook.react.uimanager.events.Event;
 import com.facebook.react.uimanager.events.EventDispatcher;
 import com.facebook.react.uimanager.events.RCTEventEmitter;
+import com.facebook.react.uimanager.util.ReactFindViewUtil;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -110,7 +111,7 @@ public class RootViewTest {
     int rootViewId = 7;
 
     ReactRootView rootView = new ReactRootView(mReactContext);
-    rootView.setId(rootViewId);
+    ReactFindViewUtil.setReactTag(rootView, rootViewId);
     rootView.startReactApplication(instanceManager, "");
     rootView.simulateAttachForTesting();
 

--- a/ReactAndroid/src/test/java/com/facebook/react/uimanager/BUCK
+++ b/ReactAndroid/src/test/java/com/facebook/react/uimanager/BUCK
@@ -32,6 +32,7 @@ rn_robolectric_test(
         react_native_target("java/com/facebook/react/touch:touch"),
         react_native_target("java/com/facebook/react/uimanager:uimanager"),
         react_native_target("java/com/facebook/react/uimanager/annotations:annotations"),
+        react_native_target("java/com/facebook/react/uimanager/util:util"),
         react_native_target("java/com/facebook/react/views/text:text"),
         react_native_target("java/com/facebook/react/views/view:view"),
         react_native_target("res:uimanager"),

--- a/ReactAndroid/src/test/java/com/facebook/react/uimanager/UIManagerModuleTest.java
+++ b/ReactAndroid/src/test/java/com/facebook/react/uimanager/UIManagerModuleTest.java
@@ -32,6 +32,7 @@ import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactTestHelper;
 import com.facebook.react.modules.core.ChoreographerCompat;
 import com.facebook.react.modules.core.ReactChoreographer;
+import com.facebook.react.uimanager.util.ReactFindViewUtil;
 import com.facebook.react.views.text.ReactRawTextManager;
 import com.facebook.react.views.text.ReactRawTextShadowNode;
 import com.facebook.react.views.text.ReactTextViewManager;
@@ -479,22 +480,22 @@ public class UIManagerModuleTest {
     TestMoveDeleteHierarchy hierarchy = createMoveDeleteHierarchy(uiManager);
 
     View view0 = hierarchy.nativeRootView.getChildAt(0);
-    assertThat(view0.getId()).isEqualTo(hierarchy.view0);
+    assertThat(ReactFindViewUtil.getReactTag(view0)).isEqualTo(hierarchy.view0);
 
     View viewWithChildren1 = hierarchy.nativeRootView.getChildAt(1);
-    assertThat(viewWithChildren1.getId()).isEqualTo(hierarchy.viewWithChildren1);
+    assertThat(ReactFindViewUtil.getReactTag(viewWithChildren1)).isEqualTo(hierarchy.viewWithChildren1);
 
     View childView0 = ((ViewGroup) viewWithChildren1).getChildAt(0);
-    assertThat(childView0.getId()).isEqualTo(hierarchy.childView0);
+    assertThat(ReactFindViewUtil.getReactTag(childView0)).isEqualTo(hierarchy.childView0);
 
     View childView1 = ((ViewGroup) viewWithChildren1).getChildAt(1);
-    assertThat(childView1.getId()).isEqualTo(hierarchy.childView1);
+    assertThat(ReactFindViewUtil.getReactTag(childView1)).isEqualTo(hierarchy.childView1);
 
     View view2 = hierarchy.nativeRootView.getChildAt(2);
-    assertThat(view2.getId()).isEqualTo(hierarchy.view2);
+    assertThat(ReactFindViewUtil.getReactTag(view2)).isEqualTo(hierarchy.view2);
 
     View view3 = hierarchy.nativeRootView.getChildAt(3);
-    assertThat(view3.getId()).isEqualTo(hierarchy.view3);
+    assertThat(ReactFindViewUtil.getReactTag(view3)).isEqualTo(hierarchy.view3);
   }
 
   @Test


### PR DESCRIPTION
Track react tag using android.view.View.tag. Allow developers to set resource id by setting component.testID

Fixes #9777

## Test Plan

First, you need to declare the resource id by creating /_your_android_studio_folder_/res/values/ids.xml

```
<?xml version="1.0" encoding="utf-8"?>
<resources>
<item type="id" name="my_test_id"/>
</resources>
```

Second, set the testID of your component to a resource name.

```
<Button
onPress={onButtonPress}
title="Press Me"
testID='test_id'
/>
```

Third, run the app and observe the resource id using UIAutomator viewer (/Android/sdk/tools/bin/uiautomatorviewer)

## Changelog

[ANDROID] [Fixes] - BaseViewManager: Allow developers to set resource id by setting component.testID
