### PR TITLE
Fix indentation in react-native link for Android

### DIFF
--- a/local-cli/link/__tests__/android/makePackagePatch.spec.js
+++ b/local-cli/link/__tests__/android/makePackagePatch.spec.js
@@ -30,6 +30,6 @@ describe('makePackagePatch@0.20', () => {
     const {patch} = makePackagePatch(packageInstance, params, name);
     const processedInstance = applyParams(packageInstance, params, name);
 
-    expect(patch).toBe(',\n            ' + processedInstance);
+    expect(patch).toBe(',\n          ' + processedInstance);
   });
 });

--- a/local-cli/link/android/patches/makePackagePatch.js
+++ b/local-cli/link/android/patches/makePackagePatch.js
@@ -12,8 +12,13 @@ const applyParams = require('./applyParams');
 module.exports = function makePackagePatch(packageInstance, params, prefix) {
   const processedInstance = applyParams(packageInstance, params, prefix);
 
+  const regexp = new RegExp(
+    `,\\n\\s+${processedInstance.replace('(', '\\(').replace(')', '\\)')}`,
+  );
+
   return {
     pattern: 'new MainReactPackage()',
-    patch: ',\n            ' + processedInstance,
+    patch: ',\n          ' + processedInstance,
+    regexp,
   };
 };

--- a/local-cli/link/android/patches/revokePatch.js
+++ b/local-cli/link/android/patches/revokePatch.js
@@ -12,6 +12,6 @@ const fs = require('fs');
 module.exports = function revokePatch(file, patch) {
   fs.writeFileSync(
     file,
-    fs.readFileSync(file, 'utf8').replace(patch.patch, ''),
+    fs.readFileSync(file, 'utf8').replace(patch.regexp || patch.patch, ''),
   );
 };


### PR DESCRIPTION
If I am not mistaken, `react-native link` introduces wrong indentation in `MainApplication.java`.

Proposed changes accounts for both backwards compatibility (`react-native unlink` will be able to handle libs added either before or after the change) and any future change in whitespace.

The `revokePatch.js` file was a bit problematic since it expects to remove exactly what was added, therefore I've introduced `regexp` field to the `patch` object which is used in the `revokePatch.js` if present. This way it is compatible with all other patches and allows for handling regexp changes easily. 

**BUT** in order to not introduce any mess to the codebase, this way of using `regexp` field should be accepted and expected for future changes like this one regarding `react-native link` for Android.

Test Plan:
----------

1. Create empty `react-native-init $PROJECT_NAME`.
2. Install any lib requiring linking, link it on current build via `react-native link $LIBRARY_NAME`.
3. Switch to RN version with proposed changes (quickest way is to manually modify your local `/node_modules/react-native` with those two patches).
4. Link another library.
> **NOTE:** _There should be now two linked libraries in `android/app/src/main/java/com/$PROJECT_NAME/MainApplication.java`: one with correct and one with incorrect indentation.
5. Run `react-native unlink $LIBRARY_NAME; react-native unlink $ANOTHER_LIBRARY_NAME`.

Now **both** libraries should be gone (i.e. the one added before and the one added after proposed change).

Release Notes:
--------------

[INTERNAL] [ENHANCEMENT] [/local-cli/link/android/patches] - Fix indentation in react-native link for Android
