### PR TITLE
return process.cwd() from `getProjectRoot` for symlink installs

### DIFF
--- a/local-cli/util/Config.js
+++ b/local-cli/util/Config.js
@@ -32,7 +32,7 @@ function getProjectRoot() {
     // React Native was installed using CocoaPods.
     return path.resolve(__dirname, '../../../..');
   }
-  return path.resolve(__dirname, '../..');
+  return process.cwd();
 }
 
 const resolveSymlinksForRoots = roots =>


### PR DESCRIPTION
When the `react-native` package is a symlink in the `node_modules` of your project, [the `cwd` option passed to `loadConfig`](https://github.com/facebook/react-native/blob/e82a2178afa1bf8b08056c6ff18184dddcf1c9c8/local-cli/util/Config.js#L86) is incorrectly inferred to be the `react-native` package. This results in the CLI failing to find the `metro.config.js` module of your project.

When `process.cwd() + "/node_modules/react-native"` does *not* exist, the `react-native bundle` command will fail before `getProjectRoot` is ever called.

Thus, when the `react-native` package is a symlink, you're required to run `react-native bundle` in the project root and nowhere else.

Test Plan:
----------
[This repro](https://github.com/aleclarson/repro/tree/rn-symlink#readme) guides you through the current `react-native` throwing an error, and then the `react-native` patched by this commit *not* throwing an error.

Release Notes:
--------------
```
[CLI] [BUGFIX] [local-cli/util/Config.js] - Fix react-native as a symlink
```

<!--
  **INTERNAL and MINOR tagged notes will not be included in the next version's final release notes.**

    CATEGORY
  [----------]      TYPE
  [ CLI      ] [-------------]    LOCATION
  [ DOCS     ] [ BREAKING    ] [-------------]
  [ GENERAL  ] [ BUGFIX      ] [ {Component} ]
  [ INTERNAL ] [ ENHANCEMENT ] [ {Filename}  ]
  [ IOS      ] [ FEATURE     ] [ {Directory} ]   |-----------|
  [ ANDROID  ] [ MINOR       ] [ {Framework} ] - | {Message} |
  [----------] [-------------] [-------------]   |-----------|

 EXAMPLES:

 [IOS] [BREAKING] [FlatList] - Change a thing that breaks other things
 [ANDROID] [BUGFIX] [TextInput] - Did a thing to TextInput
 [CLI] [FEATURE] [local-cli/info/info.js] - CLI easier to do things with
 [DOCS] [BUGFIX] [GettingStarted.md] - Accidentally a thing/word
 [GENERAL] [ENHANCEMENT] [Yoga] - Added new yoga thing/position
 [INTERNAL] [FEATURE] [./scripts] - Added thing to script that nobody will see
-->
