### PR TITLE
Fix event handlers for DPad arrows on Android TV

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/ReactAndroidHWInputDeviceHelper.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactAndroidHWInputDeviceHelper.java
@@ -12,8 +12,8 @@ import android.view.View;
 
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.bridge.WritableNativeMap;
-import com.facebook.react.common.MapBuilder;
 
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -25,20 +25,19 @@ public class ReactAndroidHWInputDeviceHelper {
    * Contains a mapping between handled KeyEvents and the corresponding navigation event
    * that should be fired when the KeyEvent is received.
    */
-  private static final Map<Integer, String> KEY_EVENTS_ACTIONS = MapBuilder.of(
-    KeyEvent.KEYCODE_DPAD_CENTER,
-    "select",
-    KeyEvent.KEYCODE_ENTER,
-    "select",
-    KeyEvent.KEYCODE_SPACE,
-    "select",
-    KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE,
-    "playPause",
-    KeyEvent.KEYCODE_MEDIA_REWIND,
-    "rewind",
-    KeyEvent.KEYCODE_MEDIA_FAST_FORWARD,
-    "fastForward"
-  );
+  private static final Map<Integer, String> KEY_EVENTS_ACTIONS = new HashMap<>();
+  static {
+    KEY_EVENTS_ACTIONS.put(KeyEvent.KEYCODE_DPAD_CENTER, "select");
+    KEY_EVENTS_ACTIONS.put(KeyEvent.KEYCODE_ENTER, "select");
+    KEY_EVENTS_ACTIONS.put(KeyEvent.KEYCODE_SPACE, "select");
+    KEY_EVENTS_ACTIONS.put(KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE, "playPause");
+    KEY_EVENTS_ACTIONS.put(KeyEvent.KEYCODE_MEDIA_REWIND, "rewind");
+    KEY_EVENTS_ACTIONS.put(KeyEvent.KEYCODE_MEDIA_FAST_FORWARD, "fastForward");
+    KEY_EVENTS_ACTIONS.put(KeyEvent.KEYCODE_DPAD_UP, "up");
+    KEY_EVENTS_ACTIONS.put(KeyEvent.KEYCODE_DPAD_RIGHT, "right");
+    KEY_EVENTS_ACTIONS.put(KeyEvent.KEYCODE_DPAD_DOWN, "down");
+    KEY_EVENTS_ACTIONS.put(KeyEvent.KEYCODE_DPAD_LEFT, "left");
+  }
 
   /**
    * We keep a reference to the last focused view id

--- a/ReactAndroid/src/main/java/com/facebook/react/ReactAndroidHWInputDeviceHelper.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactAndroidHWInputDeviceHelper.java
@@ -12,8 +12,8 @@ import android.view.View;
 
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.bridge.WritableNativeMap;
+import com.facebook.react.common.MapBuilder;
 
-import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -25,19 +25,18 @@ public class ReactAndroidHWInputDeviceHelper {
    * Contains a mapping between handled KeyEvents and the corresponding navigation event
    * that should be fired when the KeyEvent is received.
    */
-  private static final Map<Integer, String> KEY_EVENTS_ACTIONS = new HashMap<>();
-  static {
-    KEY_EVENTS_ACTIONS.put(KeyEvent.KEYCODE_DPAD_CENTER, "select");
-    KEY_EVENTS_ACTIONS.put(KeyEvent.KEYCODE_ENTER, "select");
-    KEY_EVENTS_ACTIONS.put(KeyEvent.KEYCODE_SPACE, "select");
-    KEY_EVENTS_ACTIONS.put(KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE, "playPause");
-    KEY_EVENTS_ACTIONS.put(KeyEvent.KEYCODE_MEDIA_REWIND, "rewind");
-    KEY_EVENTS_ACTIONS.put(KeyEvent.KEYCODE_MEDIA_FAST_FORWARD, "fastForward");
-    KEY_EVENTS_ACTIONS.put(KeyEvent.KEYCODE_DPAD_UP, "up");
-    KEY_EVENTS_ACTIONS.put(KeyEvent.KEYCODE_DPAD_RIGHT, "right");
-    KEY_EVENTS_ACTIONS.put(KeyEvent.KEYCODE_DPAD_DOWN, "down");
-    KEY_EVENTS_ACTIONS.put(KeyEvent.KEYCODE_DPAD_LEFT, "left");
-  }
+  private static final Map<Integer, String> KEY_EVENTS_ACTIONS = MapBuilder.<Integer, String>builder()
+    .put(KeyEvent.KEYCODE_DPAD_CENTER, "select")
+    .put(KeyEvent.KEYCODE_ENTER, "select")
+    .put(KeyEvent.KEYCODE_SPACE, "select")
+    .put(KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE, "playPause")
+    .put(KeyEvent.KEYCODE_MEDIA_REWIND, "rewind")
+    .put(KeyEvent.KEYCODE_MEDIA_FAST_FORWARD, "fastForward")
+    .put(KeyEvent.KEYCODE_DPAD_UP, "up")
+    .put(KeyEvent.KEYCODE_DPAD_RIGHT, "right")
+    .put(KeyEvent.KEYCODE_DPAD_DOWN, "down")
+    .put(KeyEvent.KEYCODE_DPAD_LEFT, "left")
+    .build();
 
   /**
    * We keep a reference to the last focused view id


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes. 
Help us understand your motivation by explaining why you decided to make this change.

If this PR fixes an issue, type "Fixes #issueNumber" to automatically close the issue when the PR is merged.
-->

Fixes #20924 
DPad arrow events were missing from `KEY_EVENTS_ACTIONS` which meant that they were not broadcasted by `TVEventHandler`.


Test Plan:
----------
<!--
Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!
-->

1. DPad arrow events are correctly send to JS and are received by `TVEventHandler`
    ```js
    this.tvEventHandler.enable(this, function(cmp, evt) {
      console.log('TVEvent', evt);
    });
    ```
    ![zrzut ekranu 2018-09-17 o 10 08 37](https://user-images.githubusercontent.com/15357032/45612016-da306980-ba61-11e8-803c-250cfa697809.png)

1. All other events ("select", "playPause", etc.) are still sent correctly
    ![zrzut ekranu 2018-09-17 o 10 11 10](https://user-images.githubusercontent.com/15357032/45612079-0f3cbc00-ba62-11e8-87e8-7122f50baa76.png)

1. Navigating between selectable components still works correctly

Release Notes:
--------------
<!--
Help reviewers and the release process by writing your own release notes. See below for an example.
-->

[ANDROID] [BUGFIX] [AndroidTV] - Fixed missing DPad arrow event handlers

<!--
  **INTERNAL and MINOR tagged notes will not be included in the next version's final release notes.**

    CATEGORY
  [----------]      TYPE
  [ CLI      ] [-------------]    LOCATION
  [ DOCS     ] [ BREAKING    ] [-------------]
  [ GENERAL  ] [ BUGFIX      ] [ {Component} ]
  [ INTERNAL ] [ ENHANCEMENT ] [ {Filename}  ]
  [ IOS      ] [ FEATURE     ] [ {Directory} ]   |-----------|
  [ ANDROID  ] [ MINOR       ] [ {Framework} ] - | {Message} |
  [----------] [-------------] [-------------]   |-----------|

 EXAMPLES:

 [IOS] [BREAKING] [FlatList] - Change a thing that breaks other things
 [ANDROID] [BUGFIX] [TextInput] - Did a thing to TextInput
 [CLI] [FEATURE] [local-cli/info/info.js] - CLI easier to do things with
 [DOCS] [BUGFIX] [GettingStarted.md] - Accidentally a thing/word
 [GENERAL] [ENHANCEMENT] [Yoga] - Added new yoga thing/position
 [INTERNAL] [FEATURE] [./scripts] - Added thing to script that nobody will see
-->
