### PR TITLE
ios-simulator: change default iphone version

### DIFF
--- a/local-cli/runIOS/runIOS.js
+++ b/local-cli/runIOS/runIOS.js
@@ -410,7 +410,7 @@ module.exports = {
     {
       command: '--simulator [string]',
       description: 'Explicitly set simulator to use',
-      default: 'iPhone 6',
+      default: 'iPhone X',
     },
     {
       command: '--configuration [string]',


### PR DESCRIPTION
this is just a suggestion, but as the iPhone 6 is discontinued by Apple
and the new iPhone line will match the X version, it could be good to update the default simulator.

it could also be the iPhone 8, feel free to suggest other changes!

Thank you for sending the PR! We appreciate you spending the time to work on these changes. 
Help us understand your motivation by explaining why you decided to make this change.

If this PR fixes an issue, type "Fixes #issueNumber" to automatically close the issue when the PR is merged.

Test Plan:
----------
Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!

Release Notes:
--------------
Help reviewers and the release process by writing your own release notes. See below for an example.

[CATEGORY] [TYPE] [LOCATION] - Message

<!--
  **INTERNAL and MINOR tagged notes will not be included in the next version's final release notes.**

    CATEGORY
  [----------]      TYPE
  [ CLI      ] [-------------]    LOCATION
  [ DOCS     ] [ BREAKING    ] [-------------]
  [ GENERAL  ] [ BUGFIX      ] [ {Component} ]
  [ INTERNAL ] [ ENHANCEMENT ] [ {Filename}  ]
  [ IOS      ] [ FEATURE     ] [ {Directory} ]   |-----------|
  [ ANDROID  ] [ MINOR       ] [ {Framework} ] - | {Message} |
  [----------] [-------------] [-------------]   |-----------|

 EXAMPLES:

 [IOS] [BREAKING] [FlatList] - Change a thing that breaks other things
 [ANDROID] [BUGFIX] [TextInput] - Did a thing to TextInput
 [CLI] [FEATURE] [local-cli/info/info.js] - CLI easier to do things with
 [DOCS] [BUGFIX] [GettingStarted.md] - Accidentally a thing/word
 [GENERAL] [ENHANCEMENT] [Yoga] - Added new yoga thing/position
 [INTERNAL] [FEATURE] [./scripts] - Added thing to script that nobody will see
-->
