### PR TITLE
Fix ignored --projectRoot/watchFolders arguments

### DIFF
--- a/local-cli/server/runServer.js
+++ b/local-cli/server/runServer.js
@@ -58,6 +58,8 @@ async function runServer(args: Args, config: ConfigT) {
   config.server.port = args.port;
   config.reporter = reporter;
   config.resetCache = args.resetCache;
+  config.projectRoot = args.projectRoot;
+  config.watchFolders = args.watchFolders.slice(0);
   config.server.enhanceMiddleware = middleware =>
     middlewareManager.getConnectInstance().use(middleware);
 


### PR DESCRIPTION
Due to @Kureev's cleanup in https://github.com/facebook/react-native/commit/c4a66a89a28152cd4b81e2b0f80ab3aac34d6872 some arguments are no longer properly passed to metro, but just the default values. This broke the `--projectRoot` and `--watchFolders` arguments used by storybook to change the bundle entrypoint. 

This PR simply fixes the regression by assigning these values from argv instead of reading config defaults. 

Related: the undocumented `REACT_NATIVE_APP_ROOT` env var is broken, not sure for how long, but I can fix it as a part of this PR or make a new one. 

Test Plan:
----------
I created a new folder called `newroot` with a different `index.js`, started metro with `react-native start --projectRoot newroot` and got new content. 

Release Notes:
--------------
 [CLI] [BUGFIX] [local-cli/server/runServer.js] - Fix --projectRoot/watchFolders arguments ignored