### PR TITLE
add option to init current directory

### DIFF
--- a/react-native-cli/index.js
+++ b/react-native-cli/index.js
@@ -1,12 +1,12 @@
 #!/usr/bin/env node
 
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- *
- * @format
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
  */
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -25,9 +25,6 @@
 //
 // The only reason to modify this file is to add more warnings and
 // troubleshooting information for the `react-native init` command.
-//
-// To allow for graceful failure on older node versions, this file should
-// retain ES5 compatibility.
 //
 // Do not make breaking changes! We absolutely don't want to have to
 // tell people to update their global version of react-native-cli.
@@ -51,7 +48,6 @@ var semver = require('semver');
  *   if you are in a RN app folder
  * init - to create a new project and npm install it
  *   --verbose - to print logs while init
- *   --template - name of the template to use, e.g. --template navigation
  *   --version <alternative react-native package> - override default (https://registry.npmjs.org/react-native@latest),
  *      package to install, examples:
  *     - "0.22.0-rc1" - A new app will be created using a specific version of React Native from npm repo
@@ -62,7 +58,12 @@ var semver = require('semver');
 var options = require('minimist')(process.argv.slice(2));
 
 var CLI_MODULE_PATH = function() {
-  return path.resolve(process.cwd(), 'node_modules', 'react-native', 'cli.js');
+  return path.resolve(
+    process.cwd(),
+    'node_modules',
+    'react-native',
+    'cli.js'
+  );
 };
 
 var REACT_NATIVE_PACKAGE_JSON_PATH = function() {
@@ -70,7 +71,7 @@ var REACT_NATIVE_PACKAGE_JSON_PATH = function() {
     process.cwd(),
     'node_modules',
     'react-native',
-    'package.json',
+    'package.json'
   );
 };
 
@@ -85,11 +86,9 @@ function getYarnVersionIfAvailable() {
   try {
     // execSync returns a Buffer -> convert to string
     if (process.platform.startsWith('win')) {
-      yarnVersion = (execSync('yarn --version 2> NUL').toString() || '').trim();
+      yarnVersion = (execSync('yarn --version').toString() || '').trim();
     } else {
-      yarnVersion = (
-        execSync('yarn --version 2>/dev/null').toString() || ''
-      ).trim();
+      yarnVersion = (execSync('yarn --version 2>/dev/null').toString() || '').trim();
     }
   } catch (error) {
     return null;
@@ -118,72 +117,93 @@ if (cli) {
   cli.run();
 } else {
   if (options._.length === 0 && (options.h || options.help)) {
-    console.log(
-      [
-        '',
-        '  Usage: react-native [command] [options]',
-        '',
-        '',
-        '  Commands:',
-        '',
-        '    init <ProjectName> [options]  generates a new project and installs its dependencies',
-        '',
-        '  Options:',
-        '',
-        '    -h, --help    output usage information',
-        '    -v, --version use a specific version of React Native',
-        '    --template use an app template. Use --template to see available templates.',
-        '',
-      ].join('\n'),
-    );
+    console.log([
+      '',
+      '  Usage: react-native [command] [options]',
+      '',
+      '',
+      '  Commands:',
+      '',
+      '    init <ProjectName> [options]  generates a new project and installs its dependencies',
+      '',
+      '  Options:',
+      '',
+      '    -h, --help    output usage information',
+      '    -v, --version output the version number',
+      '',
+    ].join('\n'));
     process.exit(0);
   }
 
   if (commands.length === 0) {
     console.error(
-      'You did not pass any commands, run `react-native --help` to see a list of all available commands.',
+      'You did not pass any commands, run `react-native --help` to see a list of all available commands.'
     );
     process.exit(1);
   }
 
   switch (commands[0]) {
-    case 'init':
-      if (!commands[1]) {
-        console.error('Usage: react-native init <ProjectName> [--verbose]');
-        process.exit(1);
-      } else {
-        init(commands[1], options);
-      }
-      break;
-    default:
-      console.error(
-        'Command `%s` unrecognized. ' +
-          'Make sure that you have run `npm install` and that you are inside a react-native project.',
-        commands[0],
-      );
-      process.exit(1);
-      break;
+  case 'init':
+          if (!commands[1]) {
+              initParentFolder(options)
+    } else {
+      init(commands[1], options);
+    }
+    break;
+  default:
+    console.error(
+      'Command `%s` unrecognized. ' +
+      'Make sure that you have run `npm install` and that you are inside a react-native project.',
+      commands[0]
+    );
+    process.exit(1);
+    break;
   }
 }
 
+function initParentFolder(options) {
+    var property = {
+        name: 'yesno',
+        message: `Do you want to init react-native in the current folder?`,
+        validator: /y[es]*|n[o]?/,
+        warning: 'Must respond yes or no',
+        default: 'no'
+    };
+
+    prompt.get(property, function (err, result) {
+        if (result.yesno[0] === 'y') {
+            createProjectWithinFolder(options);
+        } else {
+            console.error(
+                chalk.yellow('\nUsage:') + chalk.white('\ninit new project in subfolder: ') + chalk.white('react-native init <ProjectName> [--verbose]') +
+                chalk.white('\ninit current folder: ') + chalk.white('react-native init')
+            );
+            process.exit(1);
+        }
+    });
+
+}
+
 function validateProjectName(name) {
-  if (!String(name).match(/^[$A-Z_][0-9A-Z_$]*$/i)) {
+  if (!name.match(/^[$A-Z_][0-9A-Z_$]*$/i)) {
     console.error(
       '"%s" is not a valid name for a project. Please use a valid identifier ' +
         'name (alphanumeric).',
-      name,
+      name
     );
-    process.exit(1);
+      return false;
   }
 
   if (name === 'React') {
     console.error(
       '"%s" is not a valid name for a project. Please do not use the ' +
         'reserved word "React".',
-      name,
+      name
     );
-    process.exit(1);
+      return false;
   }
+
+    return true;
 }
 
 /**
@@ -194,7 +214,7 @@ function validateProjectName(name) {
  *                       don't use yarn even if available.
  */
 function init(name, options) {
-  validateProjectName(name);
+    if (!validateProjectName(name)) process.exit(1);
 
   if (fs.existsSync(name)) {
     createAfterConfirmation(name, options);
@@ -211,10 +231,10 @@ function createAfterConfirmation(name, options) {
     message: 'Directory ' + name + ' already exists. Continue?',
     validator: /y[es]*|n[o]?/,
     warning: 'Must respond yes or no',
-    default: 'no',
+    default: 'no'
   };
 
-  prompt.get(property, function(err, result) {
+  prompt.get(property, function (err, result) {
     if (result.yesno[0] === 'y') {
       createProject(name, options);
     } else {
@@ -230,7 +250,7 @@ function createProject(name, options) {
 
   console.log(
     'This will walk you through creating a new React Native project in',
-    root,
+    root
   );
 
   if (!fs.existsSync(root)) {
@@ -242,18 +262,50 @@ function createProject(name, options) {
     version: '0.0.1',
     private: true,
     scripts: {
-      start: 'node node_modules/react-native/local-cli/cli.js start',
-      ios: 'react-native run-ios',
-      android: 'react-native run-android',
-    },
+      start: 'node node_modules/react-native/local-cli/cli.js start'
+    }
   };
-  fs.writeFileSync(
-    path.join(root, 'package.json'),
-    JSON.stringify(packageJson),
-  );
+  fs.writeFileSync(path.join(root, 'package.json'), JSON.stringify(packageJson));
   process.chdir(root);
 
   run(root, projectName, options);
+}
+
+function createProjectWithinFolder(options) {
+    var root = path.resolve();
+    var packageJson = require(path.join(root, 'package.json'));
+
+    if (!packageJson) {
+        console.log('package.json not found, cannot proceed');
+        process.exit(1);
+    }
+
+    var projectName = packageJson.name;
+
+    if (!validateProjectName(projectName)) {
+        var property = {
+            name: 'name',
+            message: `new project name`,
+            pattern: /^[$A-Z_][0-9A-Z_$]*$/i,
+            warning: 'Must supply a valid name',
+            required: true,
+        };
+
+
+        prompt.get(property, function (err, result) {
+            if (result.name) {
+                console.log(result.name);
+                packageJson.name = result.name;
+                fs.writeFileSync(path.join(root, 'package.json'), JSON.stringify(packageJson));
+                run(root, result.name, options);
+            } else {
+                console.error(
+                    'Unable to rename project'
+                );
+                process.exit(1);
+            }
+        });
+    }
 }
 
 function getInstallPackage(rnPackage) {
@@ -269,9 +321,10 @@ function getInstallPackage(rnPackage) {
 }
 
 function run(root, projectName, options) {
-  var rnPackage = options.version; // e.g. '0.38' or '/path/to/archive.tgz'
-  var forceNpmClient = options.npm;
-  var yarnVersion = !forceNpmClient && getYarnVersionIfAvailable();
+  // E.g. '0.38' or '/path/to/archive.tgz'
+  const rnPackage = options.version;
+  const forceNpmClient = options.npm;
+  const yarnVersion = (!forceNpmClient) && getYarnVersionIfAvailable();
   var installCommand;
   if (options.installCommand) {
     // In CI environments it can be useful to provide a custom command,
@@ -288,12 +341,9 @@ function run(root, projectName, options) {
     } else {
       console.log('Installing ' + getInstallPackage(rnPackage) + '...');
       if (!forceNpmClient) {
-        console.log(
-          'Consider installing yarn to make this faster: https://yarnpkg.com',
-        );
+        console.log('Consider installing yarn to make this faster: https://yarnpkg.com');
       }
-      installCommand =
-        'npm install --save --save-exact ' + getInstallPackage(rnPackage);
+      installCommand = 'npm install --save --save-exact ' + getInstallPackage(rnPackage);
       if (options.verbose) {
         installCommand += ' --verbose';
       }
@@ -317,15 +367,13 @@ function checkNodeVersion() {
     return;
   }
   if (!semver.satisfies(process.version, packageJson.engines.node)) {
-    console.error(
-      chalk.red(
+    console.error(chalk.red(
         'You are currently running Node %s but React Native requires %s. ' +
-          'Please use a supported version of Node.\n' +
-          'See https://facebook.github.io/react-native/docs/getting-started.html',
+        'Please use a supported version of Node.\n' +
+        'See https://facebook.github.io/react-native/docs/getting-started.html'
       ),
       process.version,
-      packageJson.engines.node,
-    );
+      packageJson.engines.node);
   }
 }
 
@@ -334,9 +382,8 @@ function printVersionsAndExit(reactNativePackageJsonPath) {
   try {
     console.log('react-native: ' + require(reactNativePackageJsonPath).version);
   } catch (e) {
-    console.log(
-      'react-native: n/a - not inside a React Native project directory',
-    );
+    console.log('react-native: n/a - not inside a React Native project directory');
   }
   process.exit();
 }
+


### PR DESCRIPTION
### I came across a need to run `react-native init` on an existing folder.

Use case:
----------
Pulling a repo from git results in a new directory.
Running `react-native init myApp` result in a new directory.
**If I pull the repo from git I can't init it and vise-versa**.
Things get messy. Git freaks out or react-native doesn't work.

This makes it hard to work on react-native projects from different machines and/or collaborate with others.
I didn't find a proper workaround, AFAIK there isn't a simple one.

Test Plan:
----------
I ran the command with the new option several times:

```
react-native init
react-native run-android

```

It worked!

Release Notes:
--------------

[CLI] [FEATURE] [react-native-cli/index.js] - CLI add option to init react-native in the current directory by simply running `react-native init`
<!--
  **INTERNAL and MINOR tagged notes will not be included in the next version's final release notes.**

    CATEGORY
  [----------]      TYPE
  [ CLI      ] [-------------]    LOCATION
  [ DOCS     ] [ BREAKING    ] [-------------]
  [ GENERAL  ] [ BUGFIX      ] [ {Component} ]
  [ INTERNAL ] [ ENHANCEMENT ] [ {Filename}  ]
  [ IOS      ] [ FEATURE     ] [ {Directory} ]   |-----------|
  [ ANDROID  ] [ MINOR       ] [ {Framework} ] - | {Message} |
  [----------] [-------------] [-------------]   |-----------|

 EXAMPLES:

 [IOS] [BREAKING] [FlatList] - Change a thing that breaks other things
 [ANDROID] [BUGFIX] [TextInput] - Did a thing to TextInput
 [CLI] [FEATURE] [local-cli/info/info.js] - CLI easier to do things with
 [DOCS] [BUGFIX] [GettingStarted.md] - Accidentally a thing/word
 [GENERAL] [ENHANCEMENT] [Yoga] - Added new yoga thing/position
 [INTERNAL] [FEATURE] [./scripts] - Added thing to script that nobody will see
-->
