### PR TITLE
Fix warning in InputAccessoryView

### DIFF
--- a/Libraries/Components/TextInput/InputAccessoryView.js
+++ b/Libraries/Components/TextInput/InputAccessoryView.js
@@ -11,6 +11,7 @@
 
 const ColorPropType = require('ColorPropType');
 const DeprecatedViewPropTypes = require('DeprecatedViewPropTypes');
+const Platform = require('Platform');
 const React = require('React');
 const StyleSheet = require('StyleSheet');
 
@@ -89,7 +90,9 @@ type Props = {
 
 class InputAccessoryView extends React.Component<Props> {
   render(): React.Node {
-    console.warn('<InputAccessoryView> is not supported on Android yet.');
+    if (Platform.OS !== 'ios') {
+      console.warn('<InputAccessoryView> is only supported on iOS.');
+    }
 
     if (React.Children.count(this.props.children) === 0) {
       return null;


### PR DESCRIPTION
Currently the warning is always triggered, even on iOS. This simply adds a platform check and tweak the message.

Test Plan:
----------
Check that the warning is no longer triggered in RNTester.

Release Notes:
--------------
Help reviewers and the release process by writing your own release notes. See below for an example.

[GENERAL] [BUGFIX] [InputAccessoryView] - Fix warning in InputAccessoryView
