### PR TITLE
allow run script in node_modules/react-native/scripts

### DIFF
--- a/scripts/ios-install-third-party.sh
+++ b/scripts/ios-install-third-party.sh
@@ -64,6 +64,9 @@ function fetch_and_unpack () {
 mkdir -p third-party
 
 SCRIPTDIR=$(dirname "$0")
+if [ "$SCRIPTDIR" = "." ]; then
+	SCRIPTDIR=$(pwd)
+fi
 
 fetch_and_unpack glog-0.3.5.tar.gz https://github.com/google/glog/archive/v0.3.5.tar.gz 61067502c5f9769d111ea1ee3f74e6ddf0a5f9cc "\"$SCRIPTDIR/ios-configure-glog.sh\""
 fetch_and_unpack double-conversion-1.1.6.tar.gz https://github.com/google/double-conversion/archive/v1.1.6.tar.gz 1c7d88afde3aaeb97bb652776c627b49e132e8e0


### PR DESCRIPTION
SCRIPTDIR is "." if run node_modules/react/scripts.
So, I got the following message.


```
$ cd node_modules/react-native/scripts
$ sh ios-install-third-party.sh
Unpacking /Users/takkanm/.rncache/glog-0.3.5.tar.gz...
ios-install-third-party.sh: line 56: ./ios-configure-glog.sh: No such file or directory
Unpacking /Users/takkanm/.rncache/double-conversion-1.1.6.tar.gz...
Unpacking /Users/takkanm/.rncache/boost_1_63_0.tar.gz...
Unpacking /Users/takkanm/.rncache/folly-2016.10.31.00.tar.gz...
```

Test Plan:
----------
No

Release Notes:
--------------

[INTERNAL ][ENHANCEMENT][scripts/ios-install-third-party.sh] - Allow run script in script dir
