### PR TITLE
decouple compileSdk version from build tools version

### DIFF
--- a/scripts/validate-android-test-env.sh
+++ b/scripts/validate-android-test-env.sh
@@ -56,7 +56,7 @@ fi
 BUILD_TOOLS_VERSION=`grep buildToolsVersion $(dirname $0)/../ReactAndroid/build.gradle | sed 's/^[^"]*\"//' | sed 's/"//'`
 
 # MAJOR is something like "23"
-MAJOR=`grep targetSdkVersion $(dirname $0)/../ReactAndroid/build.gradle | sed 's/[^[:digit:]]//g'`
+MAJOR=`grep compileSdkVersion $(dirname $0)/../ReactAndroid/build.gradle | sed 's/[^[:digit:]]//g'`
 
 # Check that we have the right major version of the Android SDK.
 PLATFORM_DIR="$ANDROID_HOME/platforms/android-$MAJOR"

--- a/scripts/validate-android-test-env.sh
+++ b/scripts/validate-android-test-env.sh
@@ -56,7 +56,7 @@ fi
 BUILD_TOOLS_VERSION=`grep buildToolsVersion $(dirname $0)/../ReactAndroid/build.gradle | sed 's/^[^"]*\"//' | sed 's/"//'`
 
 # MAJOR is something like "23"
-MAJOR=`echo $BUILD_TOOLS_VERSION | sed 's/\..*//'`
+MAJOR=`grep targetSdkVersion $(dirname $0)/../ReactAndroid/build.gradle | sed 's/[^[:digit:]]//g'`
 
 # Check that we have the right major version of the Android SDK.
 PLATFORM_DIR="$ANDROID_HOME/platforms/android-$MAJOR"


### PR DESCRIPTION
Android CI was failing due to that it was trying to extract major version from build tools and use it to compile ReactAndroid. Now, it'll extract compileSdkVersion from ReactAndroid/build.gradle and use it.

Issue was that https://github.com/facebook/react-native/commit/68c7999c25efbc6fabf67e4130ac086c401b88e0 dowgraded compileSdk version to 26 while retaining build tools version as 27.0.3, so CI was trying to use SDK 27.

Test Plan:
----------
Fixed causes of https://circleci.com/gh/facebook/react-native/52560, https://circleci.com/gh/facebook/react-native/52645. But still failing due to unexported buck dependencies from FB