### PR TITLE
Fix artifacting on RN-drawn borders with asymmetric radii

### DIFF
--- a/React/Views/RCTBorderDrawing.m
+++ b/React/Views/RCTBorderDrawing.m
@@ -217,11 +217,19 @@ static UIImage *RCTGetSolidBorderImage(RCTCornerRadii cornerRadii,
   (borderInsets.top + cornerInsets.topRight.height +
    borderInsets.bottom + cornerInsets.bottomLeft.height <= viewSize.height);
 
-  const UIEdgeInsets edgeInsets = (UIEdgeInsets){
+  UIEdgeInsets edgeInsets = (UIEdgeInsets){
     borderInsets.top + MAX(cornerInsets.topLeft.height, cornerInsets.topRight.height),
     borderInsets.left + MAX(cornerInsets.topLeft.width, cornerInsets.bottomLeft.width),
     borderInsets.bottom + MAX(cornerInsets.bottomLeft.height, cornerInsets.bottomRight.height),
     borderInsets.right + MAX(cornerInsets.bottomRight.width, cornerInsets.topRight.width)
+  };
+
+  // Asymmetrical edgeInsets cause strange artifacting on iOS 10 and earlier.
+  edgeInsets = (UIEdgeInsets){
+    MAX(edgeInsets.top, edgeInsets.bottom),
+    MAX(edgeInsets.left, edgeInsets.right),
+    MAX(edgeInsets.top, edgeInsets.bottom),
+    MAX(edgeInsets.left, edgeInsets.right),
   };
 
   const CGSize size = makeStretchable ? (CGSize){


### PR DESCRIPTION
This PR fixes an obscure rendering bug on iOS for borders with asymmetric radii. It appears to be a problem with the custom drawing that React Native performs when it cannot use native UIKit/CoreAnimation border drawing.

Test Plan:
----------

We've been using this patch in our production app without issue since July 2018. I've seen this issue on the latest version of iOS 10, as well as iOS 11.2 (though it seems to not be an issue on iOS 11.4 any longer).

I've included before/after screenshots below, which also show the CSS needed to cause the artifacting.

![react-native-border-before](https://user-images.githubusercontent.com/822205/45776475-fcbcb100-bc20-11e8-859f-c355b964d145.PNG)

![react-native-border-after](https://user-images.githubusercontent.com/822205/45776477-ffb7a180-bc20-11e8-87d3-c058481a7f29.PNG)


Release Notes:
--------------

[IOS] [BUGFIX] [BorderDrawing] - Fixed visual artifacts on borders with asymmetric radii