### PR TITLE
Support background timers on iOS via NSTimer

### DIFF
--- a/React/Modules/RCTTiming.m
+++ b/React/Modules/RCTTiming.m
@@ -96,6 +96,7 @@ static const NSTimeInterval kIdleCallbackFrameDeadline = 0.001;
   NSMutableDictionary<NSNumber *, _RCTTimer *> *_timers;
   NSTimer *_sleepTimer;
   BOOL _sendIdleEvents;
+  BOOL _inBackground;
 }
 
 @synthesize bridge = _bridge;
@@ -110,12 +111,13 @@ RCT_EXPORT_MODULE()
 
   _paused = YES;
   _timers = [NSMutableDictionary new];
+  _inBackground = NO;
 
   for (NSString *name in @[UIApplicationWillResignActiveNotification,
                            UIApplicationDidEnterBackgroundNotification,
                            UIApplicationWillTerminateNotification]) {
     [[NSNotificationCenter defaultCenter] addObserver:self
-                                             selector:@selector(stopTimers)
+                                             selector:@selector(appDidMoveToBackground)
                                                  name:name
                                                object:nil];
   }
@@ -123,7 +125,7 @@ RCT_EXPORT_MODULE()
   for (NSString *name in @[UIApplicationDidBecomeActiveNotification,
                            UIApplicationWillEnterForegroundNotification]) {
     [[NSNotificationCenter defaultCenter] addObserver:self
-                                             selector:@selector(startTimers)
+                                             selector:@selector(appDidMoveToForeground)
                                                  name:name
                                                object:nil];
   }
@@ -148,8 +150,29 @@ RCT_EXPORT_MODULE()
   _bridge = nil;
 }
 
+- (void)appDidMoveToBackground
+{
+  // Deactivate the CADisplayLink while in the background.
+  [self stopTimers];
+  _inBackground = YES;
+
+  // Issue one final timer callback, which will schedule a
+  // background NSTimer, if needed.
+  [self didUpdateFrame:nil];
+}
+
+- (void)appDidMoveToForeground
+{
+  _inBackground = NO;
+  [self startTimers];
+}
+
 - (void)stopTimers
 {
+  if (_inBackground) {
+    return;
+  }
+
   if (!_paused) {
     _paused = YES;
     if (_pauseCallback) {
@@ -160,7 +183,7 @@ RCT_EXPORT_MODULE()
 
 - (void)startTimers
 {
-  if (!_bridge || ![self hasPendingTimers]) {
+  if (!_bridge || _inBackground || ![self hasPendingTimers]) {
     return;
   }
 
@@ -225,7 +248,11 @@ RCT_EXPORT_MODULE()
   // Switch to a paused state only if we didn't call any timer this frame, so if
   // in response to this timer another timer is scheduled, we don't pause and unpause
   // the displaylink frivolously.
-  if (!_sendIdleEvents && timersToCall.count == 0) {
+  if (_inBackground) {
+    if (_timers.count) {
+      [self scheduleSleepTimer:nextScheduledTarget];
+    }
+  } else if (!_sendIdleEvents && timersToCall.count == 0) {
     // No need to call the pauseCallback as RCTDisplayLink will ask us about our paused
     // status immediately after completing this call
     if (_timers.count == 0) {
@@ -295,7 +322,10 @@ RCT_EXPORT_METHOD(createTimer:(nonnull NSNumber *)callbackID
                                                 targetTime:targetTime
                                                    repeats:repeats];
   _timers[callbackID] = timer;
-  if (_paused) {
+
+  if (_inBackground) {
+    [self scheduleSleepTimer:timer.target];
+  } else if (_paused) {
     if ([timer.target timeIntervalSinceNow] > kMinimumSleepInterval) {
       [self scheduleSleepTimer:timer.target];
     } else {


### PR DESCRIPTION
This PR is a minimalistic change to RCTTiming that causes it to switch exclusively to NSTimer (i.e., the 'sleep timer') in order to continue triggering timers when the app has moved to the background.

Motivation:
----------

Many people have expressed a desire for background timer support on iOS. (See #1282, #167, and #16493). In our app — a podcast/audio player — we use background timers to ensure that we never lose track of the user's playback position, should the app crash or be terminated by the OS.

The RCTTimer module uses a RN-managed CADisplayLink if the next requested timer is less than a second away; otherwise, it switches to an NSTimer (which is refers to as a 'sleep timer' in source). The RN-managed CADisplayLink is always disabled when the app goes to the background (and thus cannot be used); however, the NSTimer will still issue its callbacks in the background.

This PR adds a flag to track whether the app is in the background, and if so, all timers are routed through NSTimer until the app returns to the foreground. @vishnevskiy at Discord opened a similar PR (#16493) that implements a drop-in for CADisplayLink which falls back to NSTimer, but I decided to incorporate the background-NSTimer logic directly into RCTTimer, since NSTimer is already in use.

~It's worth noting that the background NSTimer may not fire as often as requested — it may give the appearance of lagging depending upon your app's priority in the background. For our audio app, NSTimer fires exactly on schedule if there's an open AVAudioSession and audio is playing; if audio is not playing, it fires about half as often as requested, which is still adequate for networking polling and other tasks.~

It's worth noting that background timers only function as long as an app is actually running in the background. Apple offers a variety of Background Modes (which can be toggled in the Capabilities section of the target inspector in Xcode), and the app will need to be legitimately using one of these modes in order for this change to provide any value — otherwise it will be terminated within a couple of seconds of moving to the background.

The good thing about this change is that for apps that do perform essential computation in support of their Background Mode, they can now use `setTimeout` and `setInterval` without problem — whereas in the past, neither would ever trigger their callback until the app returns to the foreground.

Open Question:
---------

~Despite the demand for this timer behavior, it's not clear whether this should be specifically opt-in. There's nothing specifically breaking about this change, but an app that abuses timers may lead to increased battery consumption if they now fire in the background.~

~On the other hand, if we were to make this an opt-in feature, it's not clear how to do it other than to expose a top-level function to toggle it (and that feels hacky and undiscoverable). RN's timers are based upon standard JS functions which cannot have their parameters modified to take additional flags.~

This is no longer a concern due to the fact that the app must have a valid Background Mode, which is already a multi-step opt-in process.

Test Plan:
----------

We've been using this patch in our production app without issue since January 2018.

I've tested on a real iPhone 6 running iOS 10 and a real iPhone 8 running iOS 11. It also functions as expected on various simulators.

To demonstrate the difference, here is a before and after video.

Before | After
:-------------------------:|:-------------------------:
![2018-09-19-react-native-background-timers-before](https://user-images.githubusercontent.com/822205/45781410-e10bd780-bc2d-11e8-85ee-f3f226d0d6f9.gif)  |  ![2018-09-19-react-native-background-timers-after](https://user-images.githubusercontent.com/822205/45781415-e406c800-bc2d-11e8-8e31-8f25368d9a30.gif)

Release Notes:
--------------

[IOS] [ENHANCEMENT] [Timers] - Support background timers on iOS