### PR TITLE
Merged PR 76925: garbage collection is called in case of memory warning

### DIFF
--- a/ReactAndroid/src/main/jni/react/jni/CatalystInstanceImpl.cpp
+++ b/ReactAndroid/src/main/jni/react/jni/CatalystInstanceImpl.cpp
@@ -261,7 +261,7 @@ jlong CatalystInstanceImpl::getJavaScriptContext() {
 }
 
 void CatalystInstanceImpl::handleMemoryPressure(int pressureLevel) {
-  instance_->handleMemoryPressure(pressureLevel);
+  instance_->handleMemoryPressure(static_cast<JSMemoryPressure>(pressureLevel));
 }
 
 }}

--- a/ReactCommon/cxxreact/Android.mk
+++ b/ReactCommon/cxxreact/Android.mk
@@ -18,7 +18,7 @@ LOCAL_SRC_FILES := \
   JSCTracing.cpp \
   JSCUtils.cpp \
   JSDeltaBundleClient.cpp \
-	JSExecutor.cpp \
+  JSExecutor.cpp \
   JSIndexedRAMBundle.cpp \
   MethodCall.cpp \
   ModuleRegistry.cpp \

--- a/ReactCommon/cxxreact/Instance.cpp
+++ b/ReactCommon/cxxreact/Instance.cpp
@@ -15,6 +15,7 @@
 #include "RecoverableError.h"
 #include "SystraceSection.h"
 
+#include <cxxreact/Platform.h>
 #include <cxxreact/JSIndexedRAMBundle.h>
 #include <folly/Memory.h>
 #include <folly/MoveWrapper.h>
@@ -173,7 +174,7 @@ const ModuleRegistry &Instance::getModuleRegistry() const {
 
 ModuleRegistry &Instance::getModuleRegistry() { return *moduleRegistry_; }
 
-void Instance::handleMemoryPressure(int pressureLevel) {
+void Instance::handleMemoryPressure(JSMemoryPressure pressureLevel) {
   nativeToJsBridge_->handleMemoryPressure(pressureLevel);
 }
 

--- a/ReactCommon/cxxreact/Instance.h
+++ b/ReactCommon/cxxreact/Instance.h
@@ -68,7 +68,7 @@ public:
   const ModuleRegistry &getModuleRegistry() const;
   ModuleRegistry &getModuleRegistry();
 
-  void handleMemoryPressure(int pressureLevel);
+  void handleMemoryPressure(JSMemoryPressure pressureLevel);
 
 private:
   void callNativeModules(folly::dynamic &&calls, bool isEndOfBatch);

--- a/ReactCommon/cxxreact/JSCExecutor.cpp
+++ b/ReactCommon/cxxreact/JSCExecutor.cpp
@@ -691,10 +691,11 @@ bool JSCExecutor::isInspectable() {
   return canUseInspector(m_context);
 }
 
-void JSCExecutor::handleMemoryPressure(int pressureLevel) {
-#ifdef WITH_JSC_MEMORY_PRESSURE
-  JSHandleMemoryPressure(
-      this, m_context, static_cast<JSMemoryPressure>(pressureLevel));
+void JSCExecutor::handleMemoryPressure(JSMemoryPressure pressureLevel) {
+#if defined WITH_JSC_MEMORY_PRESSURE
+  JSHandleMemoryPressure(this, m_context, pressureLevel);
+#else
+  JSC_JSGarbageCollect(m_context);
 #endif
 }
 

--- a/ReactCommon/cxxreact/JSCExecutor.h
+++ b/ReactCommon/cxxreact/JSCExecutor.h
@@ -90,7 +90,7 @@ public:
 
   virtual bool isInspectable() override;
 
-  virtual void handleMemoryPressure(int pressureLevel) override;
+  virtual void handleMemoryPressure(JSMemoryPressure pressureLevel) override;
 
   virtual void destroy() override;
 

--- a/ReactCommon/cxxreact/JSExecutor.h
+++ b/ReactCommon/cxxreact/JSExecutor.h
@@ -9,6 +9,7 @@
 #include <string>
 
 #include <cxxreact/NativeModule.h>
+#include <cxxreact/Platform.h>
 #include <folly/dynamic.h>
 
 #ifndef RN_EXPORT
@@ -104,7 +105,7 @@ public:
    */
   virtual std::string getDescription() = 0;
 
-  virtual void handleMemoryPressure(int pressureLevel) {}
+  virtual void handleMemoryPressure(JSMemoryPressure pressureLevel) {}
 
   virtual void destroy() {}
   virtual ~JSExecutor() {}

--- a/ReactCommon/cxxreact/NativeToJsBridge.cpp
+++ b/ReactCommon/cxxreact/NativeToJsBridge.cpp
@@ -219,7 +219,7 @@ bool NativeToJsBridge::isInspectable() {
   return m_executor->isInspectable();
 }
 
-void NativeToJsBridge::handleMemoryPressure(int pressureLevel) {
+void NativeToJsBridge::handleMemoryPressure(JSMemoryPressure pressureLevel) {
   runOnExecutorQueue([=] (JSExecutor* executor) {
     executor->handleMemoryPressure(pressureLevel);
   });

--- a/ReactCommon/cxxreact/NativeToJsBridge.h
+++ b/ReactCommon/cxxreact/NativeToJsBridge.h
@@ -76,7 +76,7 @@ public:
   void* getJavaScriptContext();
   bool isInspectable();
 
-  void handleMemoryPressure(int pressureLevel);
+  void handleMemoryPressure(JSMemoryPressure pressureLevel);
 
   /**
    * Synchronously tears down the bridge and the main executor.

--- a/ReactCommon/cxxreact/Platform.h
+++ b/ReactCommon/cxxreact/Platform.h
@@ -19,6 +19,12 @@
 namespace facebook {
 namespace react {
 
+enum JSMemoryPressure {
+  UI_HIDDEN,
+  MODERATE,
+  CRITICAL,
+};
+
 namespace JSCNativeHooks {
 
 using Hook = JSValueRef(*)(

--- a/ReactCommon/jschelpers/JavaScriptCore.h
+++ b/ReactCommon/jschelpers/JavaScriptCore.h
@@ -86,6 +86,7 @@ jsc_poison(JSContextGetGlobalContext JSContextGetGlobalObject JSContextGetGroup 
 // JSEvaluate
 #define JSC_JSEvaluateScript(...) __jsc_wrapper(JSEvaluateScript, __VA_ARGS__)
 #define JSC_JSEvaluateBytecodeBundle(...) __jsc_wrapper(JSEvaluateBytecodeBundle, __VA_ARGS__)
+#define JSC_JSGarbageCollect(...) __jsc_wrapper(JSGarbageCollect, __VA_ARGS__)
 
 jsc_poison(JSCheckScriptSyntax JSEvaluateScript JSEvaluateBytecodeBundle JSGarbageCollect)
 


### PR DESCRIPTION
JS garbage collection is called in case of memory warning for both iOS and Android.

Test Plan:
----------
Make sure that app calls garbage collector in case memory needs to be reclaimed.

[GENERAL] [ENHANCEMENT] [JSEngine] - OSS version calls the garbage collector in case memory warning occurs.

