### PR TITLE
Debug only code were leaking into release builds on iOS.

### DIFF
--- a/React/Base/RCTUtils.m
+++ b/React/Base/RCTUtils.m
@@ -810,7 +810,7 @@ static void RCTGetRGBAColorComponents(CGColorRef color, CGFloat rgba[4])
     default:
     {
 
-#ifdef RCT_DEBUG
+#if RCT_DEBUG
       //unsupported format
       RCTLogError(@"Unsupported color model: %i", model);
 #endif

--- a/React/CxxBridge/RCTCxxBridge.mm
+++ b/React/CxxBridge/RCTCxxBridge.mm
@@ -654,7 +654,7 @@ struct RCTInstanceCallback : public InstanceCallback {
   NSArray<RCTModuleData *> *moduleDataById = [self registerModulesForClasses:modules];
 
   if (lazilyDiscovered) {
-#ifdef RCT_DEBUG
+#if RCT_DEBUG
     // Lazily discovered modules do not require instantiation here,
     // as they are not allowed to have pre-instantiated instance
     // and must not require the main queue.


### PR DESCRIPTION
RCT_DEBUG is always defined - it is just rather 0 or 1 so
```#ifndef RCT_DEBUG is always true```

Test Plan:
----------
No testing is needed it is minor typo fix.

Release Notes:
--------------
[MINOR] [IOS] [DEBUG] - Message


