### PR TITLE
Fix issue #21065 getInspectorDataForViewTag is not a function

### DIFF
--- a/Libraries/Inspector/Inspector.js
+++ b/Libraries/Inspector/Inspector.js
@@ -51,9 +51,11 @@ function findRenderers(): $ReadOnlyArray<ReactRenderer> {
 function getInspectorDataForViewTag(touchedViewTag: number) {
   for (let i = 0; i < renderers.length; i++) {
     const renderer = renderers[i];
-    const inspectorData = renderer.getInspectorDataForViewTag(touchedViewTag);
-    if (inspectorData.hierarchy.length > 0) {
-      return inspectorData;
+    if (Object.prototype.hasOwnProperty.call(renderer, 'getInspectorDataForViewTag')) {
+      const inspectorData = renderer.getInspectorDataForViewTag(touchedViewTag);
+      if (inspectorData.hierarchy.length > 0) {
+        return inspectorData;
+      }
     }
   }
   throw new Error('Expected to find at least one React renderer.');


### PR DESCRIPTION
Fix renderer.getInspectorDataForViewTag is not a function when try Toggle Inspector

Fixes #21065

Release Notes:
--------------
[BUGFIX] [MINOR] [/react-native/Libraries/Inspector/Inspector.js] 