### PR TITLE
[CI] [npm] Deploy to npm on tagged commits only

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -677,12 +677,11 @@ workflows:
       # Only runs on vX.X.X tags if all tests are green
       - publish_npm_package:
           filters:
-            branches:
-              only:
-                - /.*-stable/
             tags:
               only: /v[0-9]+(\.[0-9]+)*(\-rc(\.[0-9]+)?)?/
           requires:
+            - analyze
+            - test_detox_end_to_end
             - test_javascript
             - test_objc
             - test_android

--- a/scripts/publish-npm.js
+++ b/scripts/publish-npm.js
@@ -13,26 +13,28 @@
  * This script publishes a new version of react-native to NPM.
  * It is supposed to run in CI environment, not on a developer's machine.
  *
- * To make it easier for developers it uses some logic to identify with which version to publish the package.
+ * To make it easier for developers it uses some logic to identify with which
+ * version to publish the package.
  *
  * To cut a branch (and release RC):
  * - Developer: `git checkout -b 0.XY-stable`
- * - Developer: `git tag v0.XY.0-rc` and `git push --tags` to git@github.com:facebook/react-native.git
- * - CI: test and deploy to npm (run this script) with version 0.XY.0-rc with tag "next"
+ * - Developer: `./scripts/bump-oss-version.js v0.XY.0-rc.0`
+ * - CI: test and deploy to npm (run this script) with version `0.XY.0-rc.0`
+ *   with tag "next"
  *
  * To update RC release:
  * - Developer: `git checkout 0.XY-stable`
  * - Developer: cherry-pick whatever changes needed
- * - Developer: `git tag v0.XY.0-rc1` and `git push --tags` to git@github.com:facebook/react-native.git
- * - CI: test and deploy to npm (run this script) with version 0.XY.0-rc1 with tag "next"
+ * - Developer: `./scripts/bump-oss-version.js v0.XY.0-rc.1`
+ * - CI: test and deploy to npm (run this script) with version `0.XY.0-rc.1`
+ *   with tag "next"
  *
  * To publish a release:
  * - Developer: `git checkout 0.XY-stable`
  * - Developer: cherry-pick whatever changes needed
- * - Developer: `git tag latest`
- * - Developer: `git tag v0.XY.0`
- * - Developer: `git push --tags` to git@github.com:facebook/react-native.git
- * - CI: test and deploy to npm (run this script) with version 0.XY.0 with and not tag (latest is implied by npm)
+ * - Developer: `./scripts/bump-oss-version.js v0.XY.0`
+ * - CI: test and deploy to npm (run this script) with version `0.XY.0`
+ *   and no tag ("latest" is implied by npm)
  *
  * To patch old release:
  * - Developer: `git checkout 0.XY-stable`
@@ -43,23 +45,28 @@
  * there is a version higher than XY
  *
  * Important tags:
- * If tag v0.XY.0-rcZ is present on the commit then publish to npm with version 0.XY.0-rcZ and tag next
+ * If tag v0.XY.0-rc.Z is present on the commit then publish to npm with version 0.XY.0-rc.Z and tag next
  * If tag v0.XY.Z is present on the commit then publish to npm with version 0.XY.Z and no tag (npm will consider it latest)
  */
 
 /*eslint-disable no-undef */
 require('shelljs/global');
 
-const buildBranch = process.env.CIRCLE_BRANCH;
+const buildTag = process.env.CIRCLE_TAG;
 const otp = process.env.NPM_CONFIG_OTP;
 
-let branchVersion;
-if (buildBranch.indexOf('-stable') !== -1) {
-  branchVersion = buildBranch.slice(0, buildBranch.indexOf('-stable'));
-} else {
-  echo('Error: We publish only from stable branches');
-  exit(0);
+if (!buildTag) {
+  echo('Error: We publish only from git tags');
+  exit(1);
 }
+
+let match = buildTag.match(/^v(\d+\.\d+)\.\d+(?:-.+)?$/);
+if (!match) {
+  echo('Error: We publish only from release version git tags');
+  exit(1);
+}
+// 0.33
+let [, branchVersion] = match;
 
 // 34c034298dc9cad5a4553964a5a324450fda0385
 const currentCommit = exec('git rev-parse HEAD', {silent: true}).stdout.trim();


### PR DESCRIPTION
This PR applies some fixes I made to the 0.57-stable branch to ensure we only run on commits tagged as "v0.57.1", as an example. This also ensures we only deploy after all tests pass.

Test Plan:
----------
Tested on Circle CI

Release Notes:
--------------

[INTERNAL] [BUGFIX] [CircleCI] - Ensure releases are attempted only on tagged commits
