### PR TITLE
Fix flow type for maxFontSizeMultiplier on TextInput

### DIFF
--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -179,7 +179,7 @@ type Props = $ReadOnly<{|
   autoCorrect?: ?boolean,
   autoFocus?: ?boolean,
   allowFontScaling?: ?boolean,
-  maxFontSizeMultiplier?: ?boolean,
+  maxFontSizeMultiplier?: ?number,
   editable?: ?boolean,
   keyboardType?: ?KeyboardType,
   returnKeyType?: ?ReturnKeyType,


### PR DESCRIPTION
This flow type is wrong, probably just a copy paste mistake.

Test Plan:
----------
Run flow

Release Notes:
--------------
[GENERAL] [BUGFIX] [TextInput] - Fix flow type for maxFontSizeMultiplier on TextInput
