### PR TITLE
Remove remaining PropTypes from and modernize Swipable* Classes

### DIFF
--- a/Libraries/Components/Timer/Timer.js
+++ b/Libraries/Components/Timer/Timer.js
@@ -1,0 +1,118 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow
+ */
+
+'use strict';
+
+const React = require('React');
+
+const setter = function(_setter: Function, key: string, _clearer?: ?Function) {
+  return function(callback: Function, delta: number, ...args: Array<any>) {
+    const id = _setter(() => {
+      _clearer && _clearer.call(this, id);
+      callback.apply(this, args);
+    }, delta);
+
+    if (!this[key]) {
+      this[key] = [id];
+    } else {
+      this[key].push(id);
+    }
+
+    return id;
+  };
+};
+
+const clearer = function(_clearer: Function, key: string) {
+  return function(id: any): void {
+    if (this[key]) {
+      const index = this[key].indexOf(id);
+      if (index !== -1) {
+        this[key].splice(index, 1);
+      }
+    }
+    _clearer(id);
+  };
+};
+
+const _clearTimeout = clearer(clearTimeout, '_timeouts');
+const _setTimeout = setter(setTimeout, '_timeouts', _clearTimeout);
+
+const _clearInterval = clearer(clearInterval, '_intervals');
+const _setInterval = setter(setInterval, '_intervals');
+
+const _clearImmediate = clearer(clearImmediate, '_immediates');
+const _setImmediate = setter(setImmediate, '_immediates', _clearImmediate);
+
+const _cancelAnimationFrame = clearer(cancelAnimationFrame, '_rafs');
+const _requestAnimationFrame = setter(
+  requestAnimationFrame,
+  '_rafs',
+  _cancelAnimationFrame,
+);
+
+/**
+ * A simple Timer component that provides timers that will be automatically
+ * cleared when it is unmounted.
+ *
+ * Use it by getting a handle to it via the ref api:
+ *   <Timer ref={timer => { this._timer = timer; }} />
+ *
+ * And in one of your class' methods after the component was mounted:
+ *   this._timer.setTimeout(() => {}, 1000);
+ *
+ * This component accepts no child components.
+ */
+class Timer extends React.Component<{}> {
+  _timeouts: ?Array<TimeoutID>;
+  _intervals: ?Array<IntervalID>;
+  _immediates: ?Array<number>;
+  _rafs: ?Array<AnimationFrameID>;
+
+  componentWillUnmount() {
+    this._timeouts &&
+      this._timeouts.forEach(id => {
+        clearTimeout(id);
+      });
+    this._timeouts = null;
+    this._intervals &&
+      this._intervals.forEach(id => {
+        clearInterval(id);
+      });
+    this._intervals = null;
+    this._immediates &&
+      this._immediates.forEach(id => {
+        clearImmediate(id);
+      });
+    this._immediates = null;
+    this._rafs &&
+      this._rafs.forEach(id => {
+        cancelAnimationFrame(id);
+      });
+    this._rafs = null;
+  }
+
+  setTimeout = _setTimeout;
+  clearTimeout = _clearTimeout;
+
+  setInterval = _setInterval;
+  clearInterval = _clearInterval;
+
+  setImmediate = _setImmediate;
+  clearImmediate = _clearImmediate;
+
+  requestAnimationFrame = _requestAnimationFrame;
+  cancelAnimationFrame = _cancelAnimationFrame;
+
+  render() {
+    return null;
+  }
+}
+
+module.exports = Timer;

--- a/Libraries/Components/Timer/__tests__/Timer-test.js
+++ b/Libraries/Components/Timer/__tests__/Timer-test.js
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+'use strict';
+
+global.setImmediate = jest.fn();
+global.clearImmediate = jest.fn();
+global.requestAnimationFrame = jest.fn();
+global.cancelAnimationFrame = jest.fn();
+
+jest.useFakeTimers();
+
+const Timer = require('../Timer');
+
+const React = require('React');
+const ReactTestRenderer = require('react-test-renderer');
+
+describe('Timer', () => {
+  [
+    {setter: 'setTimeout', clearer: 'clearTimeout', key: '_timeouts'},
+    {setter: 'setInterval', clearer: 'clearInterval', key: '_intervals'},
+    {setter: 'setImmediate', clearer: 'clearImmediate', key: '_immediates'},
+    {
+      setter: 'requestAnimationFrame',
+      clearer: 'cancelAnimationFrame',
+      key: '_rafs',
+    },
+  ].forEach(type => {
+    it(`should apply basic ${type.setter} correctly`, () => {
+      const root = ReactTestRenderer.create(<Timer />);
+      const ref = root.getInstance();
+
+      expect(ref[type.key]).toEqual(undefined);
+
+      global[type.setter].mockClear();
+      global[type.setter].mockReturnValueOnce(1);
+      global[type.clearer].mockClear();
+      const cb = jest.fn();
+      const id = ref[type.setter](cb, 10);
+
+      expect(global[type.setter]).toHaveBeenCalled();
+      expect(global[type.clearer]).not.toBeCalled();
+      expect(ref[type.key]).toEqual([id]);
+
+      root.unmount();
+
+      expect(global[type.clearer]).toBeCalledWith(id);
+      expect(ref[type.key]).toEqual(null);
+    });
+
+    it(`should apply ${type.clearer} correctly`, () => {
+      const root = ReactTestRenderer.create(<Timer />);
+      const ref = root.getInstance();
+
+      let id = 1;
+      global[type.setter].mockClear();
+      global[type.setter].mockImplementationOnce(() => {
+        return id++;
+      });
+      global[type.clearer].mockClear();
+      const cb = jest.fn();
+
+      const id1 = ref[type.setter](cb, 10);
+      const id2 = ref[type.setter](cb, 10);
+      const id3 = ref[type.setter](cb, 10);
+      ref[type.clearer](id2);
+      expect(global[type.clearer]).toBeCalledWith(id2);
+      const id4 = ref[type.setter](cb, 10);
+      ref[type.clearer](id1);
+      expect(global[type.clearer]).toBeCalledWith(id1);
+      const id5 = ref[type.setter](cb, 10);
+      ref[type.clearer](id5);
+      expect(global[type.clearer]).toBeCalledWith(id5);
+      ref[type.clearer](id3);
+      expect(global[type.clearer]).toBeCalledWith(id3);
+
+      expect(ref[type.key]).toEqual([id4]);
+
+      root.unmount();
+
+      expect(global[type.clearer]).toBeCalledWith(id4);
+      expect(ref[type.key]).toEqual(null);
+    });
+
+    it(`should remove bookeeping when callback is called for ${
+      type.setter
+    }`, () => {
+      const root = ReactTestRenderer.create(<Timer />);
+      const ref = root.getInstance();
+
+      global[type.setter].mockClear();
+      global[type.setter].mockReturnValueOnce(1);
+      global[type.clearer].mockClear();
+      const cb = jest.fn();
+      const id = ref[type.setter](cb, 10);
+      expect(cb).not.toBeCalled();
+      global[type.setter].mock.calls[0][0]();
+      expect(cb).toBeCalled();
+
+      if (type.setter !== 'setInterval') {
+        expect(global[type.clearer]).toBeCalledWith(id);
+        expect(ref[type.key]).toEqual([]);
+      } else {
+        expect(global[type.clearer]).not.toBeCalled();
+        expect(ref[type.key]).toEqual([id]);
+      }
+    });
+  });
+});

--- a/Libraries/Experimental/SwipeableRow/SwipeableFlatList.js
+++ b/Libraries/Experimental/SwipeableRow/SwipeableFlatList.js
@@ -12,28 +12,31 @@
 import type {Props as FlatListProps} from 'FlatList';
 import type {renderItemType} from 'VirtualizedList';
 
-const PropTypes = require('prop-types');
 const React = require('React');
 const SwipeableRow = require('SwipeableRow');
 const FlatList = require('FlatList');
 
-type SwipableListProps = {
+type Props = {
   /**
    * To alert the user that swiping is possible, the first row can bounce
    * on component mount.
    */
   bounceFirstRowOnMount: boolean,
-  // Maximum distance to open to after a swipe
+  /**
+   * Maximum distance to open to after a swipe
+   */
   maxSwipeDistance: number | (Object => number),
-  // Callback method to render the view that will be unveiled on swipe
+  /**
+   * Callback method to render the view that will be unveiled on swipe
+   */
   renderQuickActions: renderItemType,
 };
 
-type Props<ItemT> = SwipableListProps & FlatListProps<ItemT>;
+export type SwipableListProps<ItemT> = Props & FlatListProps<ItemT>;
 
-type State = {
+type State = {|
   openRowKey: ?string,
-};
+|};
 
 /**
  * A container component that renders multiple SwipeableRow's in a FlatList
@@ -52,29 +55,12 @@ type State = {
  * - More to come
  */
 
-class SwipeableFlatList<ItemT> extends React.Component<Props<ItemT>, State> {
-  props: Props<ItemT>;
-  state: State;
-
+class SwipeableFlatList<ItemT> extends React.Component<
+  SwipableListProps<ItemT>,
+  State,
+> {
   _flatListRef: ?FlatList<ItemT> = null;
   _shouldBounceFirstRowOnMount: boolean = false;
-
-  static propTypes = {
-    ...FlatList.propTypes,
-
-    /**
-     * To alert the user that swiping is possible, the first row can bounce
-     * on component mount.
-     */
-    bounceFirstRowOnMount: PropTypes.bool.isRequired,
-
-    // Maximum distance to open to after a swipe
-    maxSwipeDistance: PropTypes.oneOfType([PropTypes.number, PropTypes.func])
-      .isRequired,
-
-    // Callback method to render the view that will be unveiled on swipe
-    renderQuickActions: PropTypes.func.isRequired,
-  };
 
   static defaultProps = {
     ...FlatList.defaultProps,
@@ -82,7 +68,7 @@ class SwipeableFlatList<ItemT> extends React.Component<Props<ItemT>, State> {
     renderQuickActions: () => null,
   };
 
-  constructor(props: Props<ItemT>, context: any): void {
+  constructor(props: SwipableListProps<ItemT>, context: any): void {
     super(props, context);
     this.state = {
       openRowKey: null,

--- a/Libraries/Experimental/SwipeableRow/SwipeableListView.js
+++ b/Libraries/Experimental/SwipeableRow/SwipeableListView.js
@@ -11,26 +11,49 @@
 'use strict';
 
 const ListView = require('ListView');
-const PropTypes = require('prop-types');
 const React = require('React');
 const SwipeableListViewDataSource = require('SwipeableListViewDataSource');
 const SwipeableRow = require('SwipeableRow');
 
-type DefaultProps = {
-  bounceFirstRowOnMount: boolean,
-  renderQuickActions: Function,
-};
+import type {Props as ListViewProps} from 'ListView';
 
-type Props = {
+export type SwipeableListViewProps = $ReadOnly<{|
+  ...ListViewProps,
+
+  /**
+   * To alert the user that swiping is possible, the first row can bounce
+   * on component mount.
+   */
   bounceFirstRowOnMount: boolean,
+  /**
+   * Use `SwipeableListView.getNewDataSource()` to get a data source to use,
+   * then use it just like you would a normal ListView data source
+   */
   dataSource: SwipeableListViewDataSource,
+  /**
+   * Maximum distance to open to after a swipe
+   */
   maxSwipeDistance:
     | number
     | ((rowData: any, sectionID: string, rowID: string) => number),
   onScroll?: ?Function,
-  renderRow: Function,
-  renderQuickActions: Function,
-};
+  /**
+   * Callback method to render the swipeable view
+   */
+  renderRow: (
+    rowData: any,
+    sectionID: string,
+    rowID: string,
+  ) => React.Element<any>,
+  /**
+   * Callback method to render the view that will be unveiled on swipe
+   */
+  renderQuickActions: (
+    rowData: any,
+    sectionID: string,
+    rowID: string,
+  ) => React.Element<any>,
+|}>;
 
 type State = {
   dataSource: Object,
@@ -54,10 +77,7 @@ type State = {
  * - It can bounce the 1st row of the list so users know it's swipeable
  * - More to come
  */
-class SwipeableListView extends React.Component<Props, State> {
-  props: Props;
-  state: State;
-
+class SwipeableListView extends React.Component<SwipeableListViewProps, State> {
   _listViewRef: ?React.Element<any> = null;
   _shouldBounceFirstRowOnMount: boolean = false;
 
@@ -70,32 +90,12 @@ class SwipeableListView extends React.Component<Props, State> {
     });
   }
 
-  static propTypes = {
-    /**
-     * To alert the user that swiping is possible, the first row can bounce
-     * on component mount.
-     */
-    bounceFirstRowOnMount: PropTypes.bool.isRequired,
-    /**
-     * Use `SwipeableListView.getNewDataSource()` to get a data source to use,
-     * then use it just like you would a normal ListView data source
-     */
-    dataSource: PropTypes.instanceOf(SwipeableListViewDataSource).isRequired,
-    // Maximum distance to open to after a swipe
-    maxSwipeDistance: PropTypes.oneOfType([PropTypes.number, PropTypes.func])
-      .isRequired,
-    // Callback method to render the swipeable view
-    renderRow: PropTypes.func.isRequired,
-    // Callback method to render the view that will be unveiled on swipe
-    renderQuickActions: PropTypes.func.isRequired,
-  };
-
   static defaultProps = {
     bounceFirstRowOnMount: false,
     renderQuickActions: () => null,
   };
 
-  constructor(props: Props, context: any): void {
+  constructor(props: SwipeableListViewProps, context: any): void {
     super(props, context);
 
     this._shouldBounceFirstRowOnMount = this.props.bounceFirstRowOnMount;
@@ -104,7 +104,7 @@ class SwipeableListView extends React.Component<Props, State> {
     };
   }
 
-  UNSAFE_componentWillReceiveProps(nextProps: Props): void {
+  UNSAFE_componentWillReceiveProps(nextProps: SwipeableListViewProps): void {
     if (
       this.state.dataSource.getDataSource() !==
       nextProps.dataSource.getDataSource()
@@ -175,11 +175,7 @@ class SwipeableListView extends React.Component<Props, State> {
   }
 
   // This enables rows having variable width slideoutView.
-  _getMaxSwipeDistance(
-    rowData: Object,
-    sectionID: string,
-    rowID: string,
-  ): number {
+  _getMaxSwipeDistance(rowData: any, sectionID: string, rowID: string): number {
     if (typeof this.props.maxSwipeDistance === 'function') {
       return this.props.maxSwipeDistance(rowData, sectionID, rowID);
     }
@@ -188,7 +184,7 @@ class SwipeableListView extends React.Component<Props, State> {
   }
 
   _renderRow = (
-    rowData: Object,
+    rowData: any,
     sectionID: string,
     rowID: string,
   ): React.Element<any> => {

--- a/Libraries/Experimental/SwipeableRow/SwipeableQuickActionButton.js
+++ b/Libraries/Experimental/SwipeableRow/SwipeableQuickActionButton.js
@@ -19,12 +19,7 @@ const View = require('View');
 
 import type {ImageSource} from 'ImageSource';
 
-/**
- * Standard set of quick action buttons that can, if the user chooses, be used
- * with SwipeableListView. Each button takes an image and text with optional
- * formatting.
- */
-class SwipeableQuickActionButton extends React.Component<{
+export type SwipeableQuickActionButtonProps = $ReadOnly<{|
   accessibilityLabel?: string,
   imageSource?: ?(ImageSource | number),
   imageStyle?: ?DeprecatedViewPropTypes.style,
@@ -34,7 +29,16 @@ class SwipeableQuickActionButton extends React.Component<{
   testID?: string,
   text?: ?(string | Object | Array<string | Object>),
   textStyle?: ?DeprecatedViewPropTypes.style,
-}> {
+|}>;
+
+/**
+ * Standard set of quick action buttons that can, if the user chooses, be used
+ * with SwipeableListView. Each button takes an image and text with optional
+ * formatting.
+ */
+class SwipeableQuickActionButton extends React.Component<
+  SwipeableQuickActionButtonProps,
+> {
   render(): React.Node {
     if (!this.props.imageSource && !this.props.text && !this.props.mainView) {
       return null;

--- a/Libraries/Experimental/SwipeableRow/SwipeableQuickActions.js
+++ b/Libraries/Experimental/SwipeableRow/SwipeableQuickActions.js
@@ -10,10 +10,15 @@
 
 'use strict';
 
-const DeprecatedViewPropTypes = require('DeprecatedViewPropTypes');
 const React = require('React');
 const StyleSheet = require('StyleSheet');
 const View = require('View');
+
+import type {ViewStyleProp} from 'StyleSheet';
+
+export type SwipeableQuickActionsProps = $ReadOnly<{|
+  style?: ViewStyleProp,
+|}>;
 
 /**
  * A thin wrapper around standard quick action buttons that can, if the user
@@ -25,11 +30,9 @@ const View = require('View');
  *   <SwipeableQuickActionButton {..props} />
  * </SwipeableQuickActions>
  */
-class SwipeableQuickActions extends React.Component<{style?: $FlowFixMe}> {
-  static propTypes = {
-    style: DeprecatedViewPropTypes.style,
-  };
-
+class SwipeableQuickActions extends React.Component<
+  SwipeableQuickActionsProps,
+> {
   render(): React.Node {
     // $FlowFixMe found when converting React.createClass to ES6
     const children = this.props.children;

--- a/Libraries/Experimental/SwipeableRow/SwipeableRow.js
+++ b/Libraries/Experimental/SwipeableRow/SwipeableRow.js
@@ -16,13 +16,9 @@ const PanResponder = require('PanResponder');
 const React = require('React');
 const PropTypes = require('prop-types');
 const StyleSheet = require('StyleSheet');
-/* $FlowFixMe(>=0.54.0 site=react_native_oss) This comment suppresses an error
- * found when Flow v0.54 was deployed. To see the error delete this comment and
- * run Flow. */
-const TimerMixin = require('react-timer-mixin');
+const Timer = require('Timer');
 const View = require('View');
 
-const createReactClass = require('create-react-class');
 const emptyFunction = require('fbjs/lib/emptyFunction');
 
 const IS_RTL = I18nManager.isRTL;
@@ -57,19 +53,36 @@ const RIGHT_SWIPE_BOUNCE_BACK_DURATION = 300;
  */
 const RIGHT_SWIPE_THRESHOLD = 30 * SLOW_SPEED_SWIPE_FACTOR;
 
-type Props = $ReadOnly<{|
+export type SwipableRowProps = $ReadOnly<{|
   children?: ?React.Node,
   isOpen?: ?boolean,
-  maxSwipeDistance?: ?number,
+  maxSwipeDistance: number,
   onClose?: ?Function,
   onOpen?: ?Function,
   onSwipeEnd?: ?Function,
   onSwipeStart?: ?Function,
   preventSwipeRight?: ?boolean,
+  /**
+   * Should bounce the row on mount
+   */
   shouldBounceOnMount?: ?boolean,
+  /**
+   * A ReactElement that is unveiled when the user swipes
+   */
   slideoutView?: ?React.Node,
-  swipeThreshold?: ?number,
+  /**
+   * The minimum swipe distance required before fully animating the swipe. If
+   * the user swipes less than this distance, the item will return to its
+   * previous (open/close) position.
+   */
+  swipeThreshold: number,
 |}>;
+
+type State = {|
+  currentLeft: any,
+  isSwipeableViewRendered: boolean,
+  rowHeight: ?number,
+|};
 
 /**
  * Creates a swipable row that allows taps on the main item and a custom View
@@ -78,62 +91,34 @@ type Props = $ReadOnly<{|
  * used in a normal ListView. See the renderRow for SwipeableListView to see how
  * to use this component separately.
  */
-const SwipeableRow = createReactClass({
-  displayName: 'SwipeableRow',
-  _panResponder: {},
-  _previousLeft: CLOSED_LEFT_POSITION,
+class SwipeableRow extends React.Component<SwipableRowProps, State> {
+  _timer: ?Timer = null;
 
-  mixins: [TimerMixin],
+  static defaultProps = {
+    isOpen: false,
+    preventSwipeRight: false,
+    maxSwipeDistance: 0,
+    onOpen: emptyFunction,
+    onClose: emptyFunction,
+    onSwipeEnd: emptyFunction,
+    onSwipeStart: emptyFunction,
+    swipeThreshold: 30,
+  };
 
-  propTypes: {
-    children: PropTypes.any,
-    isOpen: PropTypes.bool,
-    preventSwipeRight: PropTypes.bool,
-    maxSwipeDistance: PropTypes.number.isRequired,
-    onOpen: PropTypes.func.isRequired,
-    onClose: PropTypes.func.isRequired,
-    onSwipeEnd: PropTypes.func.isRequired,
-    onSwipeStart: PropTypes.func.isRequired,
-    // Should bounce the row on mount
-    shouldBounceOnMount: PropTypes.bool,
+  state = {
+    currentLeft: new Animated.Value(this._previousLeft),
     /**
-     * A ReactElement that is unveiled when the user swipes
+     * In order to render component A beneath component B, A must be rendered
+     * before B. However, this will cause "flickering", aka we see A briefly
+     * then B. To counter this, _isSwipeableViewRendered flag is used to set
+     * component A to be transparent until component B is loaded.
      */
-    slideoutView: PropTypes.node.isRequired,
-    /**
-     * The minimum swipe distance required before fully animating the swipe. If
-     * the user swipes less than this distance, the item will return to its
-     * previous (open/close) position.
-     */
-    swipeThreshold: PropTypes.number.isRequired,
-  },
+    isSwipeableViewRendered: false,
+    rowHeight: null,
+  };
 
-  getInitialState(): Object {
-    return {
-      currentLeft: new Animated.Value(this._previousLeft),
-      /**
-       * In order to render component A beneath component B, A must be rendered
-       * before B. However, this will cause "flickering", aka we see A briefly
-       * then B. To counter this, _isSwipeableViewRendered flag is used to set
-       * component A to be transparent until component B is loaded.
-       */
-      isSwipeableViewRendered: false,
-      rowHeight: (null: ?number),
-    };
-  },
-
-  getDefaultProps(): Object {
-    return {
-      isOpen: false,
-      preventSwipeRight: false,
-      maxSwipeDistance: 0,
-      onOpen: emptyFunction,
-      onClose: emptyFunction,
-      onSwipeEnd: emptyFunction,
-      onSwipeStart: emptyFunction,
-      swipeThreshold: 30,
-    };
-  },
+  _panResponder = {};
+  _previousLeft = CLOSED_LEFT_POSITION;
 
   UNSAFE_componentWillMount(): void {
     this._panResponder = PanResponder.create({
@@ -146,7 +131,7 @@ const SwipeableRow = createReactClass({
       onPanResponderTerminate: this._handlePanResponderEnd,
       onShouldBlockNativeResponder: (event, gestureState) => false,
     });
-  },
+  }
 
   componentDidMount(): void {
     if (this.props.shouldBounceOnMount) {
@@ -154,11 +139,12 @@ const SwipeableRow = createReactClass({
        * Do the on mount bounce after a delay because if we animate when other
        * components are loading, the animation will be laggy
        */
-      this.setTimeout(() => {
-        this._animateBounceBack(ON_MOUNT_BOUNCE_DURATION);
-      }, ON_MOUNT_BOUNCE_DELAY);
+      this._timer &&
+        this._timer.setTimeout(() => {
+          this._animateBounceBack(ON_MOUNT_BOUNCE_DURATION);
+        }, ON_MOUNT_BOUNCE_DELAY);
     }
-  },
+  }
 
   UNSAFE_componentWillReceiveProps(nextProps: Object): void {
     /**
@@ -168,9 +154,9 @@ const SwipeableRow = createReactClass({
     if (this.props.isOpen && !nextProps.isOpen) {
       this._animateToClosedPosition();
     }
-  },
+  }
 
-  render(): React.Element<any> {
+  render(): React.Node {
     // The view hidden behind the main view
     let slideOutView;
     if (this.state.isSwipeableViewRendered && this.state.rowHeight) {
@@ -191,25 +177,34 @@ const SwipeableRow = createReactClass({
       </Animated.View>
     );
 
+    const timer = (
+      <Timer
+        ref={timer => {
+          this._timer = timer;
+        }}
+      />
+    );
+
     return (
       <View {...this._panResponder.panHandlers}>
         {slideOutView}
         {swipeableView}
+        {timer}
       </View>
     );
-  },
+  }
 
   close(): void {
-    this.props.onClose();
+    this.props.onClose && this.props.onClose();
     this._animateToClosedPosition();
-  },
+  }
 
   _onSwipeableViewLayout(event: Object): void {
     this.setState({
       isSwipeableViewRendered: true,
       rowHeight: event.nativeEvent.layout.height,
     });
-  },
+  }
 
   _handleMoveShouldSetPanResponderCapture(
     event: Object,
@@ -217,38 +212,38 @@ const SwipeableRow = createReactClass({
   ): boolean {
     // Decides whether a swipe is responded to by this component or its child
     return gestureState.dy < 10 && this._isValidSwipe(gestureState);
-  },
+  }
 
-  _handlePanResponderGrant(event: Object, gestureState: Object): void {},
+  _handlePanResponderGrant(event: Object, gestureState: Object): void {}
 
   _handlePanResponderMove(event: Object, gestureState: Object): void {
     if (this._isSwipingExcessivelyRightFromClosedPosition(gestureState)) {
       return;
     }
 
-    this.props.onSwipeStart();
+    this.props.onSwipeStart && this.props.onSwipeStart();
 
     if (this._isSwipingRightFromClosed(gestureState)) {
       this._swipeSlowSpeed(gestureState);
     } else {
       this._swipeFullSpeed(gestureState);
     }
-  },
+  }
 
   _isSwipingRightFromClosed(gestureState: Object): boolean {
     const gestureStateDx = IS_RTL ? -gestureState.dx : gestureState.dx;
     return this._previousLeft === CLOSED_LEFT_POSITION && gestureStateDx > 0;
-  },
+  }
 
   _swipeFullSpeed(gestureState: Object): void {
     this.state.currentLeft.setValue(this._previousLeft + gestureState.dx);
-  },
+  }
 
   _swipeSlowSpeed(gestureState: Object): void {
     this.state.currentLeft.setValue(
       this._previousLeft + gestureState.dx / SLOW_SPEED_SWIPE_FACTOR,
     );
-  },
+  }
 
   _isSwipingExcessivelyRightFromClosedPosition(gestureState: Object): boolean {
     /**
@@ -261,14 +256,14 @@ const SwipeableRow = createReactClass({
       this._isSwipingRightFromClosed(gestureState) &&
       gestureStateDx > RIGHT_SWIPE_THRESHOLD
     );
-  },
+  }
 
   _onPanResponderTerminationRequest(
     event: Object,
     gestureState: Object,
   ): boolean {
     return false;
-  },
+  }
 
   _animateTo(
     toValue: number,
@@ -283,14 +278,14 @@ const SwipeableRow = createReactClass({
       this._previousLeft = toValue;
       callback();
     });
-  },
+  }
 
   _animateToOpenPosition(): void {
     const maxSwipeDistance = IS_RTL
       ? -this.props.maxSwipeDistance
       : this.props.maxSwipeDistance;
     this._animateTo(-maxSwipeDistance);
-  },
+  }
 
   _animateToOpenPositionWith(speed: number, distMoved: number): void {
     /**
@@ -312,15 +307,15 @@ const SwipeableRow = createReactClass({
       ? -this.props.maxSwipeDistance
       : this.props.maxSwipeDistance;
     this._animateTo(-maxSwipeDistance, duration);
-  },
+  }
 
   _animateToClosedPosition(duration: number = SWIPE_DURATION): void {
     this._animateTo(CLOSED_LEFT_POSITION, duration);
-  },
+  }
 
   _animateToClosedPositionDuringBounce(): void {
     this._animateToClosedPosition(RIGHT_SWIPE_BOUNCE_BACK_DURATION);
-  },
+  }
 
   _animateBounceBack(duration: number): void {
     /**
@@ -335,7 +330,7 @@ const SwipeableRow = createReactClass({
       duration,
       this._animateToClosedPositionDuringBounce,
     );
-  },
+  }
 
   // Ignore swipes due to user's finger moving slightly when tapping
   _isValidSwipe(gestureState: Object): boolean {
@@ -348,7 +343,7 @@ const SwipeableRow = createReactClass({
     }
 
     return Math.abs(gestureState.dx) > HORIZONTAL_SWIPE_DISTANCE_THRESHOLD;
-  },
+  }
 
   _shouldAnimateRemainder(gestureState: Object): boolean {
     /**
@@ -359,21 +354,21 @@ const SwipeableRow = createReactClass({
       Math.abs(gestureState.dx) > this.props.swipeThreshold ||
       gestureState.vx > HORIZONTAL_FULL_SWIPE_SPEED_THRESHOLD
     );
-  },
+  }
 
   _handlePanResponderEnd(event: Object, gestureState: Object): void {
     const horizontalDistance = IS_RTL ? -gestureState.dx : gestureState.dx;
     if (this._isSwipingRightFromClosed(gestureState)) {
-      this.props.onOpen();
+      this.props.onOpen && this.props.onOpen();
       this._animateBounceBack(RIGHT_SWIPE_BOUNCE_BACK_DURATION);
     } else if (this._shouldAnimateRemainder(gestureState)) {
       if (horizontalDistance < 0) {
         // Swiped left
-        this.props.onOpen();
+        this.props.onOpen && this.props.onOpen();
         this._animateToOpenPositionWith(gestureState.vx, horizontalDistance);
       } else {
         // Swiped right
-        this.props.onClose();
+        this.props.onClose && this.props.onClose();
         this._animateToClosedPosition();
       }
     } else {
@@ -384,13 +379,8 @@ const SwipeableRow = createReactClass({
       }
     }
 
-    this.props.onSwipeEnd();
-  },
-});
-
-// TODO: Delete this when `SwipeableRow` uses class syntax.
-class TypedSwipeableRow extends React.Component<Props> {
-  close() {}
+    this.props.onSwipeEnd && this.props.onSwipeEnd();
+  }
 }
 
 const styles = StyleSheet.create({
@@ -403,4 +393,4 @@ const styles = StyleSheet.create({
   },
 });
 
-module.exports = ((SwipeableRow: any): Class<TypedSwipeableRow>);
+module.exports = SwipeableRow;

--- a/Libraries/Lists/ListView/ListView.js
+++ b/Libraries/Lists/ListView/ListView.js
@@ -33,7 +33,7 @@ const DEFAULT_SCROLL_RENDER_AHEAD = 1000;
 const DEFAULT_END_REACHED_THRESHOLD = 1000;
 const DEFAULT_SCROLL_CALLBACK_THROTTLE = 50;
 
-type Props = $ReadOnly<{|
+export type Props = $ReadOnly<{|
   ...ScrollViewProps,
 
   /**

--- a/RNTester/js/SwipeableListViewExample.js
+++ b/RNTester/js/SwipeableListViewExample.js
@@ -10,10 +10,8 @@
 
 'use strict';
 
-var React = require('react');
-var createReactClass = require('create-react-class');
-var ReactNative = require('react-native');
-var {
+const React = require('react');
+const {
   Image,
   SwipeableListView,
   TouchableHighlight,
@@ -21,31 +19,26 @@ var {
   Text,
   View,
   Alert,
-} = ReactNative;
+} = require('react-native');
 
-var RNTesterPage = require('./RNTesterPage');
+const RNTesterPage = require('./RNTesterPage');
 
-var SwipeableListViewSimpleExample = createReactClass({
-  displayName: 'SwipeableListViewSimpleExample',
-  statics: {
-    title: '<SwipeableListView>',
-    description: 'Performant, scrollable, swipeable list of data.',
-  },
+class SwipeableListViewSimpleExample extends React.Component<
+  $FlowFixMeProps,
+  $FlowFixMeState,
+> {
+  static title = '<SwipeableListView>';
+  static description = 'Performant, scrollable, swipeable list of data.';
 
-  getInitialState: function() {
-    var ds = SwipeableListView.getNewDataSource();
-    return {
-      dataSource: ds.cloneWithRowsAndSections(...this._genDataSource({})),
-    };
-  },
+  state = {
+    dataSource: SwipeableListView.getNewDataSource().cloneWithRowsAndSections(
+      ...this._genDataSource({}),
+    ),
+  };
 
-  _pressData: ({}: {[key: number]: boolean}),
+  _pressData: {[key: number]: boolean} = {};
 
-  UNSAFE_componentWillMount: function() {
-    this._pressData = {};
-  },
-
-  render: function() {
+  render(): React.Node {
     return (
       <RNTesterPage
         title={this.props.navigator ? null : '<SwipeableListView>'}
@@ -78,16 +71,11 @@ var SwipeableListViewSimpleExample = createReactClass({
         />
       </RNTesterPage>
     );
-  },
+  }
 
-  _renderRow: function(
-    rowData: Object,
-    sectionID: number,
-    rowID: number,
-    highlightRow: (sectionID: number, rowID: number) => void,
-  ) {
-    var rowHash = Math.abs(hashCode(rowData.id));
-    var imgSource = THUMB_URLS[rowHash % THUMB_URLS.length];
+  _renderRow = (rowData: Object, sectionID: string, rowID: string) => {
+    const rowHash = Math.abs(hashCode(rowData.id));
+    const imgSource = THUMB_URLS[rowHash % THUMB_URLS.length];
     return (
       <TouchableHighlight onPress={() => {}}>
         <View>
@@ -100,31 +88,31 @@ var SwipeableListViewSimpleExample = createReactClass({
         </View>
       </TouchableHighlight>
     );
-  },
+  };
 
-  _genDataSource: function(pressData: {[key: number]: boolean}): Array<any> {
-    var dataBlob = {};
-    var sectionIDs = ['Section 0'];
-    var rowIDs = [[]];
+  _genDataSource(pressData: {[key: number]: boolean}): Array<any> {
+    const dataBlob = {};
+    const sectionIDs = ['Section 0'];
+    const rowIDs = [[]];
     /**
      * dataBlob example below:
-      {
-        'Section 0': {
-          'Row 0': {
-            id: '0',
-            text: 'row 0 text'
-          },
-          'Row 1': {
-            id: '1',
-            text: 'row 1 text'
-          }
-        }
-      }
-    */
+     *   {
+     *     'Section 0': {
+     *       'Row 0': {
+     *         id: '0',
+     *         text: 'row 0 text'
+     *       },
+     *       'Row 1': {
+     *         id: '1',
+     *         text: 'row 1 text'
+     *       }
+     *     }
+     *   }
+     */
     // only one section in this example
     dataBlob['Section 0'] = {};
-    for (var ii = 0; ii < 100; ii++) {
-      var pressedText = pressData[ii] ? ' (pressed)' : '';
+    for (let ii = 0; ii < 100; ii++) {
+      const pressedText = pressData[ii] ? ' (pressed)' : '';
       dataBlob[sectionIDs[0]]['Row ' + ii] = {
         id: 'Row ' + ii,
         text: 'Row ' + ii + pressedText,
@@ -132,13 +120,13 @@ var SwipeableListViewSimpleExample = createReactClass({
       rowIDs[0].push('Row ' + ii);
     }
     return [dataBlob, sectionIDs, rowIDs];
-  },
+  }
 
-  _renderSeperator: function(
-    sectionID: number,
-    rowID: number,
+  _renderSeperator = (
+    sectionID: string,
+    rowID: string,
     adjacentRowHighlighted: boolean,
-  ) {
+  ) => {
     return (
       <View
         key={`${sectionID}-${rowID}`}
@@ -148,10 +136,10 @@ var SwipeableListViewSimpleExample = createReactClass({
         }}
       />
     );
-  },
-});
+  };
+}
 
-var THUMB_URLS = [
+const THUMB_URLS = [
   require('./Thumbnails/like.png'),
   require('./Thumbnails/dislike.png'),
   require('./Thumbnails/call.png'),
@@ -165,19 +153,26 @@ var THUMB_URLS = [
   require('./Thumbnails/superlike.png'),
   require('./Thumbnails/victory.png'),
 ];
-var LOREM_IPSUM =
-  'Lorem ipsum dolor sit amet, ius ad pertinax oportere accommodare, an vix civibus corrumpit referrentur. Te nam case ludus inciderint, te mea facilisi adipiscing. Sea id integre luptatum. In tota sale consequuntur nec. Erat ocurreret mei ei. Eu paulo sapientem vulputate est, vel an accusam intellegam interesset. Nam eu stet pericula reprimique, ea vim illud modus, putant invidunt reprehendunt ne qui.';
+
+const LOREM_IPSUM = [
+  'Lorem ipsum dolor sit amet, ius ad pertinax oportere accommodare, an vix ',
+  'civibus corrumpit referrentur. Te nam case ludus inciderint, te mea facilisi ',
+  'adipiscing. Sea id integre luptatum. In tota sale consequuntur nec. Erat ',
+  'ocurreret mei ei. Eu paulo sapientem vulputate est, vel an accusam ',
+  'intellegam interesset. Nam eu stet pericula reprimique, ea vim illud modus, ',
+  'putant invidunt reprehendunt ne qui.',
+].join('');
 
 /* eslint no-bitwise: 0 */
-var hashCode = function(str) {
-  var hash = 15;
-  for (var ii = str.length - 1; ii >= 0; ii--) {
+const hashCode = function(str) {
+  let hash = 15;
+  for (let ii = str.length - 1; ii >= 0; ii--) {
     hash = (hash << 5) - hash + str.charCodeAt(ii);
   }
   return hash;
 };
 
-var styles = StyleSheet.create({
+const styles = StyleSheet.create({
   row: {
     flexDirection: 'row',
     justifyContent: 'center',


### PR DESCRIPTION
Part of: https://github.com/react-native-community/discussions-and-proposals/issues/29

This PR removes all remaining PropTypes from the classes in `Libraries/Experimental/SwipeableRow`, and converts `SwipeableRow` from an old-style `createReactClass` to a proper subclass of `React.Component`.

This needed an alternative to `TimerMixin`, so I created a special `<Timer />` component based off of it that can be used through a ref. So it can still use timers that will be automatically terminated when the component is unmounted.

Test Plan:
----------
`flow check` passes.

A new test for the `Timer` component based off of the `TimerMixin` test has been added to `Libraries/Components/Timer/__tests__/Timer-test.js`

Release Notes:
--------------

[GENERAL] [FEATURE] [Libraries/Components/Timer/Timer.js] - Added a new `Timer` component based off of `react-timer-mixin`
[GENERAL] [FEATURE] [Libraries/Components/Timer/__tests__/Timer-test.js] - Added a test for the `Timer` component
[GENERAL] [ENHANCEMENT] [Libraries/Experimental/SwipeableRow/SwipeableFlatList.js] - Cleaned up and exported props
[GENERAL] [ENHANCEMENT] [Libraries/Experimental/SwipeableRow/SwipeableListView.js] - Removed proptypes and moved prop documentation to the flow types
[GENERAL] [ENHANCEMENT] [Libraries/Experimental/SwipeableRow/SwipeableQuickActionButton.js] - Moved props to a separate declaration and exported them
[GENERAL] [ENHANCEMENT] [Libraries/Experimental/SwipeableRow/SwipeableQuickActions.js] - Converted proptypes to flow types
[GENERAL] [ENHANCEMENT] [Libraries/Experimental/SwipeableRow/SwipeableRow.js] - Converted from `createReactClass` to a class component, and removed all proptypes
[GENERAL] [MINOR] [Libraries/Lists/ListView/ListView.js] - Exported props type so `SwipeableFlatList` can use them.
[GENERAL] [ENHANCEMENT] [RNTester/js/SwipeableListViewExample.js] - Finished ES6 modernization
