### PR TITLE
Remove PropTypes from Modal.js

### DIFF
--- a/Libraries/Modal/Modal.js
+++ b/Libraries/Modal/Modal.js
@@ -31,6 +31,8 @@ const ModalEventEmitter =
     : null;
 
 import type EmitterSubscription from 'EmitterSubscription';
+import type {ViewProps} from 'ViewPropTypes';
+import type {SyntheticEvent} from 'CoreEventTypes';
 
 /**
  * The Modal component is a simple way to present content above an enclosing view.
@@ -44,95 +46,110 @@ import type EmitterSubscription from 'EmitterSubscription';
 // destroyed before the callback is fired.
 let uniqueModalIdentifier = 0;
 
-class Modal extends React.Component<Object> {
-  static propTypes = {
-    /**
-     * The `animationType` prop controls how the modal animates.
-     *
-     * See https://facebook.github.io/react-native/docs/modal.html#animationtype
-     */
-    animationType: PropTypes.oneOf(['none', 'slide', 'fade']),
-    /**
-     * The `presentationStyle` prop controls how the modal appears.
-     *
-     * See https://facebook.github.io/react-native/docs/modal.html#presentationstyle
-     */
-    presentationStyle: PropTypes.oneOf([
-      'fullScreen',
-      'pageSheet',
-      'formSheet',
-      'overFullScreen',
-    ]),
-    /**
-     * The `transparent` prop determines whether your modal will fill the
-     * entire view.
-     *
-     * See https://facebook.github.io/react-native/docs/modal.html#transparent
-     */
-    transparent: PropTypes.bool,
-    /**
-     * The `hardwareAccelerated` prop controls whether to force hardware
-     * acceleration for the underlying window.
-     *
-     * See https://facebook.github.io/react-native/docs/modal.html#hardwareaccelerated
-     */
-    hardwareAccelerated: PropTypes.bool,
-    /**
-     * The `visible` prop determines whether your modal is visible.
-     *
-     * See https://facebook.github.io/react-native/docs/modal.html#visible
-     */
-    visible: PropTypes.bool,
-    /**
-     * The `onRequestClose` callback is called when the user taps the hardware
-     * back button on Android or the menu button on Apple TV.
-     *
-     * See https://facebook.github.io/react-native/docs/modal.html#onrequestclose
-     */
-    onRequestClose:
-      Platform.isTV || Platform.OS === 'android'
-        ? PropTypes.func.isRequired
-        : PropTypes.func,
-    /**
-     * The `onShow` prop allows passing a function that will be called once the
-     * modal has been shown.
-     *
-     * See https://facebook.github.io/react-native/docs/modal.html#onshow
-     */
-    onShow: PropTypes.func,
-    /**
-     * The `onDismiss` prop allows passing a function that will be called once
-     * the modal has been dismissed.
-     *
-     * See https://facebook.github.io/react-native/docs/modal.html#ondismiss
-     */
-    onDismiss: PropTypes.func,
-    animated: deprecatedPropType(
-      PropTypes.bool,
-      'Use the `animationType` prop instead.',
-    ),
-    /**
-     * The `supportedOrientations` prop allows the modal to be rotated to any of the specified orientations.
-     *
-     * See https://facebook.github.io/react-native/docs/modal.html#supportedorientations
-     */
-    supportedOrientations: PropTypes.arrayOf(
-      PropTypes.oneOf([
-        'portrait',
-        'portrait-upside-down',
-        'landscape',
-        'landscape-left',
-        'landscape-right',
-      ]),
-    ),
-    /**
-     * The `onOrientationChange` callback is called when the orientation changes while the modal is being displayed.
-     *
-     * See https://facebook.github.io/react-native/docs/modal.html#onorientationchange
-     */
-    onOrientationChange: PropTypes.func,
-  };
+export type OrientationChangeEvent = SyntheticEvent<
+  $ReadOnly<{|
+    orientation: 'portrait' | 'landscape',
+  |}>,
+>;
 
+export type ModalProps = $ReadOnly<{|
+  ...ViewProps,
+
+  /**
+   * The `animationType` prop controls how the modal animates.
+   *
+   * See https://facebook.github.io/react-native/docs/modal.html#animationtype
+   */
+  animationType?: ?('none' | 'slide' | 'fade'),
+
+  /**
+   * The `presentationStyle` prop controls how the modal appears.
+   *
+   * See https://facebook.github.io/react-native/docs/modal.html#presentationstyle
+   */
+  presentationStyle?: ?(
+    | 'fullScreen'
+    | 'pageSheet'
+    | 'formSheet'
+    | 'overFullScreen'
+  ),
+
+  /**
+   * The `transparent` prop determines whether your modal will fill the
+   * entire view.
+   *
+   * See https://facebook.github.io/react-native/docs/modal.html#transparent
+   */
+  transparent?: ?boolean,
+
+  /**
+   * The `hardwareAccelerated` prop controls whether to force hardware
+   * acceleration for the underlying window.
+   *
+   * See https://facebook.github.io/react-native/docs/modal.html#hardwareaccelerated
+   */
+  hardwareAccelerated?: ?boolean,
+
+  /**
+   * The `visible` prop determines whether your modal is visible.
+   *
+   * See https://facebook.github.io/react-native/docs/modal.html#visible
+   */
+  visible?: boolean,
+
+  /**
+   * The `onRequestClose` callback is called when the user taps the hardware
+   * back button on Android or the menu button on Apple TV.
+   *
+   * This is required on Apple TV and Android.
+   *
+   * See https://facebook.github.io/react-native/docs/modal.html#onrequestclose
+   */
+  onRequestClose?: (event?: SyntheticEvent<null>) => mixed,
+
+  /**
+   * The `onShow` prop allows passing a function that will be called once the
+   * modal has been shown.
+   *
+   * See https://facebook.github.io/react-native/docs/modal.html#onshow
+   */
+  onShow?: (event?: SyntheticEvent<null>) => mixed,
+
+  /**
+   * The `onDismiss` prop allows passing a function that will be called once
+   * the modal has been dismissed.
+   *
+   * See https://facebook.github.io/react-native/docs/modal.html#ondismiss
+   */
+  onDismiss?: () => mixed,
+
+  /**
+   * Deprecated. Use the `animationType` prop instead.
+   */
+  animated?: ?boolean,
+
+  /**
+   * The `supportedOrientations` prop allows the modal to be rotated to any of the specified orientations.
+   *
+   * See https://facebook.github.io/react-native/docs/modal.html#supportedorientations
+   */
+  supportedOrientations?: ?Array<
+    | 'portrait'
+    | 'portrait-upside-down'
+    | 'landscape'
+    | 'landscape-left'
+    | 'landscape-right',
+  >,
+
+  /**
+   * The `onOrientationChange` callback is called when the orientation changes while the modal is being displayed.
+   *
+   * See https://facebook.github.io/react-native/docs/modal.html#onorientationchange
+   */
+  onOrientationChange?: (event: OrientationChangeEvent) => mixed,
+|}>;
+
+class Modal extends React.Component<ModalProps> {
   static defaultProps = {
     visible: true,
     hardwareAccelerated: false,
@@ -145,7 +162,7 @@ class Modal extends React.Component<Object> {
   _identifier: number;
   _eventSubscription: ?EmitterSubscription;
 
-  constructor(props: Object) {
+  constructor(props: ModalProps) {
     super(props);
     Modal._confirmProps(props);
     this._identifier = uniqueModalIdentifier++;
@@ -182,11 +199,11 @@ class Modal extends React.Component<Object> {
     }
   }
 
-  UNSAFE_componentWillReceiveProps(nextProps: Object) {
+  UNSAFE_componentWillReceiveProps(nextProps: ModalProps) {
     Modal._confirmProps(nextProps);
   }
 
-  static _confirmProps(props: Object) {
+  static _confirmProps(props: ModalProps) {
     if (
       props.presentationStyle &&
       props.presentationStyle !== 'overFullScreen' &&


### PR DESCRIPTION
This PR converts the Prop Types in `Modal` to Flow Types, and fills out the callback types a bit more.

Context Types are left in for now.

Test Plan:
----------
`flow check` passes.

Release Notes:
--------------

[GENERAL] [ENHANCEMENT] [Libraries/Modal/Modal.js] - Converted Prop Types to Flow Types
