### PR TITLE
Button: Remove PropTypes

### DIFF
--- a/Libraries/Components/Button.js
+++ b/Libraries/Components/Button.js
@@ -13,7 +13,6 @@
 const ColorPropType = require('ColorPropType');
 const Platform = require('Platform');
 const React = require('React');
-const PropTypes = require('prop-types');
 const StyleSheet = require('StyleSheet');
 const Text = require('Text');
 const TouchableNativeFeedback = require('TouchableNativeFeedback');
@@ -21,6 +20,45 @@ const TouchableOpacity = require('TouchableOpacity');
 const View = require('View');
 
 const invariant = require('fbjs/lib/invariant');
+
+import type {PressEvent} from 'CoreEventTypes';
+
+type ButtonProps = $ReadOnly<{|
+  /**
+   * Text to display inside the button
+   */
+  title: string,
+
+  /**
+   * Handler to be called when the user taps the button
+   */
+  onPress: (event?: PressEvent) => mixed,
+
+  /**
+   * Color of the text (iOS), or background color of the button (Android)
+   */
+  color?: ?string,
+
+  /**
+   * TV preferred focus (see documentation for the View component).
+   */
+  hasTVPreferredFocus?: ?boolean,
+
+  /**
+   * Text to display for blindness accessibility features
+   */
+  accessibilityLabel?: ?string,
+
+  /**
+   * If true, disable all interactions for this component.
+   */
+  disabled?: ?boolean,
+
+  /**
+   * Used to locate this view in end-to-end tests.
+   */
+  testID?: ?string,
+|}>;
 
 /**
  * A basic button component that should render nicely on any platform. Supports
@@ -50,46 +88,7 @@ const invariant = require('fbjs/lib/invariant');
  *
  */
 
-class Button extends React.Component<{
-  title: string,
-  onPress: () => any,
-  color?: ?string,
-  hasTVPreferredFocus?: ?boolean,
-  accessibilityLabel?: ?string,
-  disabled?: ?boolean,
-  testID?: ?string,
-}> {
-  static propTypes = {
-    /**
-     * Text to display inside the button
-     */
-    title: PropTypes.string.isRequired,
-    /**
-     * Text to display for blindness accessibility features
-     */
-    accessibilityLabel: PropTypes.string,
-    /**
-     * Color of the text (iOS), or background color of the button (Android)
-     */
-    color: ColorPropType,
-    /**
-     * If true, disable all interactions for this component.
-     */
-    disabled: PropTypes.bool,
-    /**
-     * TV preferred focus (see documentation for the View component).
-     */
-    hasTVPreferredFocus: PropTypes.bool,
-    /**
-     * Handler to be called when the user taps the button
-     */
-    onPress: PropTypes.func.isRequired,
-    /**
-     * Used to locate this view in end-to-end tests.
-     */
-    testID: PropTypes.string,
-  };
-
+class Button extends React.Component<ButtonProps> {
   render() {
     const {
       accessibilityLabel,


### PR DESCRIPTION
Part of: https://github.com/react-native-community/discussions-and-proposals/issues/29

This PR removes the `prop-types` from the `Button` component, and cleans up its flow type definitions.

Test Plan:
----------
`flow check` passes 100%!

Release Notes:
--------------
Help reviewers and the release process by writing your own release notes. See below for an example.

[GENERAL] [ENHANCEMENT] [Libraries/Components/Button.js] - Removed the PropTypes from the Button component, and re-organized the flow types. Also improved the definition for `onPress`.

