### PR TITLE
Handling the presence of multiple devices for android logging

### DIFF
--- a/local-cli/logAndroid/logAndroid.js
+++ b/local-cli/logAndroid/logAndroid.js
@@ -4,21 +4,49 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @format
  */
 
 'use strict';
 
 const chalk = require('chalk');
 const child_process = require('child_process');
+const adb = require('../runAndroid/adb');
+const prompt = require('../generator/promptSync')();
 
 /**
  * Starts adb logcat
  */
-function logAndroid(_device_name) {
-  return new Promise((resolve, reject) => {
-    _logAndroid(resolve, reject, _device_name);
-  });
+function logAndroid() 
+{
+	let deviceList = [];
+	let _device_name = "";
+
+	try { deviceList = adb.getDevices(); }
+	catch (e) { console.log(chalk.red('Coud not get devices list. Do you have adb in your PATH?')); }
+
+	if (deviceList.length > 1)
+	{
+		console.log(chalk.bold("\r\nMultiple connected devices found, please choose one among them from the list below :\r\n"));
+		let counter = 1;
+		deviceList.forEach( dev => {
+			console.log( "   "+dev+ "\t : " + counter);
+			counter++;
+		});
+		console.log("\r\nEnter the number against the device of your choice :");
+		const choice = prompt();
+		
+		if (!isNaN(choice) && !!deviceList[choice-1])
+			_device_name = deviceList[choice-1];
+		else
+			console.log(chalk.red("Invalid entry. Going ahead without specifying the device."));
+
+		console.log("\r\n");
+	}
+
+	return new Promise((resolve, reject) => {
+		_logAndroid(resolve, reject, _device_name);
+	});
+
 }
 
 function _logAndroid(resolve, reject, _device_name) {

--- a/local-cli/logAndroid/logAndroid.js
+++ b/local-cli/logAndroid/logAndroid.js
@@ -16,36 +16,36 @@ const prompt = require('../generator/promptSync')();
 /**
  * Starts adb logcat
  */
-function logAndroid() 
-{
-	let deviceList = [];
-	let _device_name = "";
+function logAndroid() {
+  let deviceList = [];
+  let _device_name = "";
 
-	try { deviceList = adb.getDevices(); }
-	catch (e) { console.log(chalk.red('Coud not get devices list. Do you have adb in your PATH?')); }
+  try{
+    deviceList = adb.getDevices();
+  }catch(e){
+    console.log(chalk.red('Coud not get devices list. Do you have adb in your PATH?'));
+  }
 
-	if (deviceList.length > 1)
-	{
-		console.log(chalk.bold("\r\nMultiple connected devices found, please choose one among them from the list below :\r\n"));
-		let counter = 1;
-		deviceList.forEach( dev => {
-			console.log( "   "+dev+ "\t : " + counter);
-			counter++;
-		});
-		console.log("\r\nEnter the number against the device of your choice :");
-		const choice = prompt();
-		
-		if (!isNaN(choice) && !!deviceList[choice-1])
-			_device_name = deviceList[choice-1];
-		else
-			console.log(chalk.red("Invalid entry. Going ahead without specifying the device."));
+  if (deviceList.length > 1) {
+    console.log(chalk.bold("\r\nMultiple connected devices found, please choose one among them from the list below :\r\n"));
+    let counter = 1;
+    deviceList.forEach( (dev) => {
+      console.log( "   "+dev+ "\t : " + counter);
+      counter++;
+    });
+    console.log("\r\nEnter the number against the device of your choice :");
+    const choice = prompt();
+    if (!isNaN(choice) && !!deviceList[choice-1]){
+      _device_name = deviceList[choice-1];
+    }else{
+      console.log(chalk.red("Invalid entry. Going ahead without specifying the device."));
+  }
+    console.log("\r\n");
+  }
 
-		console.log("\r\n");
-	}
-
-	return new Promise((resolve, reject) => {
-		_logAndroid(resolve, reject, _device_name);
-	});
+  return new Promise((resolve, reject) => {
+    _logAndroid(resolve, reject, _device_name);
+  });
 
 }
 
@@ -57,12 +57,10 @@ function _logAndroid(resolve, reject, _device_name) {
 
     let adbArgs = ['logcat', '*:S', 'ReactNative:V', 'ReactNativeJS:V'];
 
-    if (_device_name.length > 0)
+    if (_device_name.length > 0){
       adbArgs.unshift("-s", _device_name);
-    
-    console.log(
-      chalk.bold(`Starting the logger (${adbPath} ${adbArgs.join(' ')})...`),
-    );
+    }
+    console.log(chalk.bold(`Starting the logger (${adbPath} ${adbArgs.join(' ')})...`));
 
     const log = child_process.spawnSync(adbPath, adbArgs, {stdio: 'inherit'});
 

--- a/local-cli/logAndroid/logAndroid.js
+++ b/local-cli/logAndroid/logAndroid.js
@@ -15,20 +15,23 @@ const child_process = require('child_process');
 /**
  * Starts adb logcat
  */
-function logAndroid() {
+function logAndroid(_device_name) {
   return new Promise((resolve, reject) => {
-    _logAndroid(resolve, reject);
+    _logAndroid(resolve, reject, _device_name);
   });
 }
 
-function _logAndroid() {
+function _logAndroid(resolve, reject, _device_name) {
   try {
     const adbPath = process.env.ANDROID_HOME
       ? process.env.ANDROID_HOME + '/platform-tools/adb'
       : 'adb';
 
-    const adbArgs = ['logcat', '*:S', 'ReactNative:V', 'ReactNativeJS:V'];
+    let adbArgs = ['logcat', '*:S', 'ReactNative:V', 'ReactNativeJS:V'];
 
+    if (_device_name.length > 0)
+      adbArgs.unshift("-s", _device_name);
+    
     console.log(
       chalk.bold(`Starting the logger (${adbPath} ${adbArgs.join(' ')})...`),
     );


### PR DESCRIPTION
When testing on multiple android devices, its very common for the user to want to see the device logs from a specific device. I had a hard time with this, eventually deciding to run the adb command directly. Wanted to provide some solution to the problem, so I haveupdated  logAndroid.js to present an option to the user to specify/select the device when multiple devices are available. A device name will be picked up from the list of connected devices, and this device name will be passed on to the adb argument array with a "-s" flag preceding it, and logcat will be run against that device.

Test Plan:
-----------
1. Run "react-native log-android" without any device/emulators connected. 
Expected Result: The logger should wait till a device is connected

2. Run "react-native log-android" with only one device/emulators connected. 
Expected Result: The logger should output logs from the connected device/emulator

3. Run "react-native log-android" with more than one device/emulators connected. 
Expected Result : The logger should present the user with a list of connected devices, and an option to select the device from which logs has to be fetched.

4. Run "react-native log-android" with more than one device/emulators connected and provide a wrong input.
Expected Result : The logger should inform the user about the invalid entry, and exit the program.

Release Notes:
--------------
[CLI] [FEATURE] [local-cli/logAndroid/logAndroid.js] - Added option to run the logger for a specific android device.