### PR TITLE
Add flow types to PanResponder

### DIFF
--- a/Libraries/Experimental/SwipeableRow/SwipeableRow.js
+++ b/Libraries/Experimental/SwipeableRow/SwipeableRow.js
@@ -25,6 +25,9 @@ const View = require('View');
 const createReactClass = require('create-react-class');
 const emptyFunction = require('fbjs/lib/emptyFunction');
 
+import type {LayoutEvent, PressEvent} from 'CoreEventTypes';
+import type {GestureState} from 'PanResponder';
+
 const IS_RTL = I18nManager.isRTL;
 
 // NOTE: Eventually convert these consts to an input object of configurations
@@ -204,7 +207,7 @@ const SwipeableRow = createReactClass({
     this._animateToClosedPosition();
   },
 
-  _onSwipeableViewLayout(event: Object): void {
+  _onSwipeableViewLayout(event: LayoutEvent): void {
     this.setState({
       isSwipeableViewRendered: true,
       rowHeight: event.nativeEvent.layout.height,
@@ -212,16 +215,19 @@ const SwipeableRow = createReactClass({
   },
 
   _handleMoveShouldSetPanResponderCapture(
-    event: Object,
-    gestureState: Object,
+    event: PressEvent,
+    gestureState: GestureState,
   ): boolean {
     // Decides whether a swipe is responded to by this component or its child
     return gestureState.dy < 10 && this._isValidSwipe(gestureState);
   },
 
-  _handlePanResponderGrant(event: Object, gestureState: Object): void {},
+  _handlePanResponderGrant(
+    event: PressEvent,
+    gestureState: GestureState,
+  ): void {},
 
-  _handlePanResponderMove(event: Object, gestureState: Object): void {
+  _handlePanResponderMove(event: PressEvent, gestureState: GestureState): void {
     if (this._isSwipingExcessivelyRightFromClosedPosition(gestureState)) {
       return;
     }
@@ -235,22 +241,24 @@ const SwipeableRow = createReactClass({
     }
   },
 
-  _isSwipingRightFromClosed(gestureState: Object): boolean {
+  _isSwipingRightFromClosed(gestureState: GestureState): boolean {
     const gestureStateDx = IS_RTL ? -gestureState.dx : gestureState.dx;
     return this._previousLeft === CLOSED_LEFT_POSITION && gestureStateDx > 0;
   },
 
-  _swipeFullSpeed(gestureState: Object): void {
+  _swipeFullSpeed(gestureState: GestureState): void {
     this.state.currentLeft.setValue(this._previousLeft + gestureState.dx);
   },
 
-  _swipeSlowSpeed(gestureState: Object): void {
+  _swipeSlowSpeed(gestureState: GestureState): void {
     this.state.currentLeft.setValue(
       this._previousLeft + gestureState.dx / SLOW_SPEED_SWIPE_FACTOR,
     );
   },
 
-  _isSwipingExcessivelyRightFromClosedPosition(gestureState: Object): boolean {
+  _isSwipingExcessivelyRightFromClosedPosition(
+    gestureState: GestureState,
+  ): boolean {
     /**
      * We want to allow a BIT of right swipe, to allow users to know that
      * swiping is available, but swiping right does not do anything
@@ -264,8 +272,8 @@ const SwipeableRow = createReactClass({
   },
 
   _onPanResponderTerminationRequest(
-    event: Object,
-    gestureState: Object,
+    event: PressEvent,
+    gestureState: GestureState,
   ): boolean {
     return false;
   },
@@ -338,7 +346,7 @@ const SwipeableRow = createReactClass({
   },
 
   // Ignore swipes due to user's finger moving slightly when tapping
-  _isValidSwipe(gestureState: Object): boolean {
+  _isValidSwipe(gestureState: GestureState): boolean {
     if (
       this.props.preventSwipeRight &&
       this._previousLeft === CLOSED_LEFT_POSITION &&
@@ -350,7 +358,7 @@ const SwipeableRow = createReactClass({
     return Math.abs(gestureState.dx) > HORIZONTAL_SWIPE_DISTANCE_THRESHOLD;
   },
 
-  _shouldAnimateRemainder(gestureState: Object): boolean {
+  _shouldAnimateRemainder(gestureState: GestureState): boolean {
     /**
      * If user has swiped past a certain distance, animate the rest of the way
      * if they let go
@@ -361,7 +369,7 @@ const SwipeableRow = createReactClass({
     );
   },
 
-  _handlePanResponderEnd(event: Object, gestureState: Object): void {
+  _handlePanResponderEnd(event: PressEvent, gestureState: GestureState): void {
     const horizontalDistance = IS_RTL ? -gestureState.dx : gestureState.dx;
     if (this._isSwipingRightFromClosed(gestureState)) {
       this.props.onOpen();

--- a/Libraries/Interaction/PanResponder.js
+++ b/Libraries/Interaction/PanResponder.js
@@ -129,43 +129,55 @@ export type GestureState = {|
    * ID of the gestureState - persisted as long as there at least one touch on screen
    */
   stateID: number,
+
   /**
    * The latest screen coordinates of the recently-moved touch
    */
   moveX: number,
+
   /**
    * The latest screen coordinates of the recently-moved touch
    */
   moveY: number,
+
   /**
    * The screen coordinates of the responder grant
    */
   x0: number,
+
   /**
    * The screen coordinates of the responder grant
    */
   y0: number,
+
   /**
    * Accumulated distance of the gesture since the touch started
    */
   dx: number,
+
   /**
    * Accumulated distance of the gesture since the touch started
    */
   dy: number,
+
   /**
    * Current velocity of the gesture
    */
   vx: number,
+
   /**
    * Current velocity of the gesture
    */
   vy: number,
+
   /**
    * Number of touches currently on screen
    */
   numberActiveTouches: number,
+
   /**
+   * All `gestureState` accounts for timeStamps up until this value
+   *
    * @private
    */
   _accountsForMovesUpTo: number,

--- a/Libraries/Types/CoreEventTypes.js
+++ b/Libraries/Types/CoreEventTypes.js
@@ -26,6 +26,12 @@ export type SyntheticEvent<T> = $ReadOnly<{|
   persist: () => void,
   target: ?number,
   timeStamp: number,
+  touchHistory: $ReadOnly<{|
+    indexOfSingleActiveTouch: number,
+    mostRecentTimeStamp: number,
+    numberActiveTouches: number,
+    touchBank: $ReadOnlyArray<number>,
+  |}>,
   type: ?string,
 |}>;
 

--- a/Libraries/Types/CoreEventTypes.js
+++ b/Libraries/Types/CoreEventTypes.js
@@ -26,13 +26,17 @@ export type SyntheticEvent<T> = $ReadOnly<{|
   persist: () => void,
   target: ?number,
   timeStamp: number,
+  type: ?string,
+|}>;
+
+export type ResponderSyntheticEvent<T> = $ReadOnly<{|
+  ...SyntheticEvent<T>,
   touchHistory: $ReadOnly<{|
     indexOfSingleActiveTouch: number,
     mostRecentTimeStamp: number,
     numberActiveTouches: number,
     touchBank: $ReadOnlyArray<number>,
   |}>,
-  type: ?string,
 |}>;
 
 export type Layout = $ReadOnly<{|
@@ -63,7 +67,7 @@ export type TextLayoutEvent = SyntheticEvent<
   |}>,
 >;
 
-export type PressEvent = SyntheticEvent<
+export type PressEvent = ResponderSyntheticEvent<
   $ReadOnly<{|
     changedTouches: $ReadOnlyArray<$PropertyType<PressEvent, 'nativeEvent'>>,
     force: number,

--- a/Libraries/Types/CoreEventTypes.js
+++ b/Libraries/Types/CoreEventTypes.js
@@ -35,7 +35,20 @@ export type ResponderSyntheticEvent<T> = $ReadOnly<{|
     indexOfSingleActiveTouch: number,
     mostRecentTimeStamp: number,
     numberActiveTouches: number,
-    touchBank: $ReadOnlyArray<number>,
+    touchBank: $ReadOnlyArray<
+      $ReadOnly<{|
+        touchActive: boolean,
+        startPageX: number,
+        startPageY: number,
+        startTimeStamp: number,
+        currentPageX: number,
+        currentPageY: number,
+        currentTimeStamp: number,
+        previousPageX: number,
+        previousPageY: number,
+        previousTimeStamp: number,
+      |}>,
+    >,
   |}>,
 |}>;
 


### PR DESCRIPTION
This PR adds flow types to the `PanResponder` module. It is part of my effort to flowtype the `Swipable*` classes.

A new `touchHistory` field had to be added to `SyntheticEvent` as well.

Test Plan:
----------
Flow check and running the whole jest test suite showed no signs of regressions.

Release Notes:
--------------

[GENERAL] [ENHANCEMENT] [Libraries/Interaction/PanResponder.js] - Added flow type annotations, and exported the `GestureState` type which is used by callbacks.
[GENERAL] [ENHANCEMENT] [Libraries/Experimental/SwipeableRow/SwipeableRow.js] - Flow typed `SwipableRow`'s use of PanResponder
[GENERAL] [ENHANCEMENT] [Libraries/Types/CoreEventTypes.js] - Added a new `touchHistory` field to `SyntheticEvent`

<!--
  **INTERNAL and MINOR tagged notes will not be included in the next version's final release notes.**

    CATEGORY
  [----------]      TYPE
  [ CLI      ] [-------------]    LOCATION
  [ DOCS     ] [ BREAKING    ] [-------------]
  [ GENERAL  ] [ BUGFIX      ] [ {Component} ]
  [ INTERNAL ] [ ENHANCEMENT ] [ {Filename}  ]
  [ IOS      ] [ FEATURE     ] [ {Directory} ]   |-----------|
  [ ANDROID  ] [ MINOR       ] [ {Framework} ] - | {Message} |
  [----------] [-------------] [-------------]   |-----------|

 EXAMPLES:

 [IOS] [BREAKING] [FlatList] - Change a thing that breaks other things
 [ANDROID] [BUGFIX] [TextInput] - Did a thing to TextInput
 [CLI] [FEATURE] [local-cli/info/info.js] - CLI easier to do things with
 [DOCS] [BUGFIX] [GettingStarted.md] - Accidentally a thing/word
 [GENERAL] [ENHANCEMENT] [Yoga] - Added new yoga thing/position
 [INTERNAL] [FEATURE] [./scripts] - Added thing to script that nobody will see
-->
