### PR TITLE
StatusBar: Remove PropTypes

### DIFF
--- a/Libraries/Components/StatusBar/StatusBar.js
+++ b/Libraries/Components/StatusBar/StatusBar.js
@@ -11,8 +11,6 @@
 'use strict';
 
 const React = require('React');
-const PropTypes = require('prop-types');
-const ColorPropType = require('ColorPropType');
 const Platform = require('Platform');
 
 const processColor = require('processColor');
@@ -55,9 +53,47 @@ export type StatusBarAnimation = $Enum<{
   slide: string,
 }>;
 
-type DefaultProps = {
-  animated: boolean,
-};
+type StatusBarProps = $ReadOnly<{|
+  /**
+   * If the status bar is hidden.
+   */
+  hidden?: ?boolean,
+  /**
+   * If the transition between status bar property changes should be animated.
+   * Supported for backgroundColor, barStyle and hidden.
+   */
+  animated?: ?boolean,
+  /**
+   * The background color of the status bar.
+   * @platform android
+   */
+  backgroundColor?: ?string,
+  /**
+   * If the status bar is translucent.
+   * When translucent is set to true, the app will draw under the status bar.
+   * This is useful when using a semi transparent status bar color.
+   *
+   * @platform android
+   */
+  translucent?: ?boolean,
+  /**
+   * Sets the color of the status bar text.
+   */
+  barStyle?: ?('default' | 'light-content' | 'dark-content'),
+  /**
+   * If the network activity indicator should be visible.
+   *
+   * @platform ios
+   */
+  networkActivityIndicatorVisible?: ?boolean,
+  /**
+   * The transition effect when showing and hiding the status bar using the `hidden`
+   * prop. Defaults to 'fade'.
+   *
+   * @platform ios
+   */
+  showHideTransition?: ?('fade' | 'slide'),
+|}>;
 
 /**
  * Merges the prop stack with the default values.
@@ -148,15 +184,7 @@ function createStackEntry(props: any): any {
  *
  * `currentHeight` (Android only) The height of the status bar.
  */
-class StatusBar extends React.Component<{
-  hidden?: boolean,
-  animated?: boolean,
-  backgroundColor?: string,
-  translucent?: boolean,
-  barStyle?: 'default' | 'light-content' | 'dark-content',
-  networkActivityIndicatorVisible?: boolean,
-  showHideTransition?: 'fade' | 'slide',
-}> {
+class StatusBar extends React.Component<StatusBarProps> {
   static _propsStack = [];
 
   static _defaultProps = createStackEntry({
@@ -260,48 +288,6 @@ class StatusBar extends React.Component<{
     StatusBar._defaultProps.translucent = translucent;
     StatusBarManager.setTranslucent(translucent);
   }
-
-  static propTypes = {
-    /**
-     * If the status bar is hidden.
-     */
-    hidden: PropTypes.bool,
-    /**
-     * If the transition between status bar property changes should be animated.
-     * Supported for backgroundColor, barStyle and hidden.
-     */
-    animated: PropTypes.bool,
-    /**
-     * The background color of the status bar.
-     * @platform android
-     */
-    backgroundColor: ColorPropType,
-    /**
-     * If the status bar is translucent.
-     * When translucent is set to true, the app will draw under the status bar.
-     * This is useful when using a semi transparent status bar color.
-     *
-     * @platform android
-     */
-    translucent: PropTypes.bool,
-    /**
-     * Sets the color of the status bar text.
-     */
-    barStyle: PropTypes.oneOf(['default', 'light-content', 'dark-content']),
-    /**
-     * If the network activity indicator should be visible.
-     *
-     * @platform ios
-     */
-    networkActivityIndicatorVisible: PropTypes.bool,
-    /**
-     * The transition effect when showing and hiding the status bar using the `hidden`
-     * prop. Defaults to 'fade'.
-     *
-     * @platform ios
-     */
-    showHideTransition: PropTypes.oneOf(['fade', 'slide']),
-  };
 
   static defaultProps = {
     animated: false,


### PR DESCRIPTION
Part of: https://github.com/react-native-community/discussions-and-proposals/issues/29

This PR removes the remaining PropTypes from `StatusBar` and moves its flowtypes to its own definition.

Test Plan:
----------
`flow check` passes for android and ios.

Release Notes:
--------------

[GENERAL] [ENHANCEMENT] [Libraries/Components/StatusBar/StatusBar.js] - Removed PropTypes
