### PR TITLE
SwipeableListView: Remove PropTypes

### DIFF
--- a/Libraries/Experimental/SwipeableRow/SwipeableListView.js
+++ b/Libraries/Experimental/SwipeableRow/SwipeableListView.js
@@ -11,30 +11,53 @@
 'use strict';
 
 const ListView = require('ListView');
-const PropTypes = require('prop-types');
 const React = require('React');
 const SwipeableListViewDataSource = require('SwipeableListViewDataSource');
 const SwipeableRow = require('SwipeableRow');
 
-type DefaultProps = {
-  bounceFirstRowOnMount: boolean,
-  renderQuickActions: Function,
-};
+import type {Props as ListViewProps} from 'ListView';
 
-type Props = {
+type Props = $ReadOnly<{|
+  ...ListViewProps,
+
+  /**
+   * To alert the user that swiping is possible, the first row can bounce
+   * on component mount.
+   */
   bounceFirstRowOnMount: boolean,
+  /**
+   * Use `SwipeableListView.getNewDataSource()` to get a data source to use,
+   * then use it just like you would a normal ListView data source
+   */
   dataSource: SwipeableListViewDataSource,
+  /**
+   * Maximum distance to open to after a swipe
+   */
   maxSwipeDistance:
     | number
-    | ((rowData: any, sectionID: string, rowID: string) => number),
+    | ((rowData: Object, sectionID: string, rowID: string) => number),
   onScroll?: ?Function,
-  renderRow: Function,
-  renderQuickActions: Function,
-};
+  /**
+   * Callback method to render the swipeable view
+   */
+  renderRow: (
+    rowData: Object,
+    sectionID: string,
+    rowID: string,
+  ) => React.Element<any>,
+  /**
+   * Callback method to render the view that will be unveiled on swipe
+   */
+  renderQuickActions: (
+    rowData: Object,
+    sectionID: string,
+    rowID: string,
+  ) => React.Element<any>,
+|}>;
 
-type State = {
+type State = {|
   dataSource: Object,
-};
+|};
 
 /**
  * A container component that renders multiple SwipeableRow's in a ListView
@@ -69,26 +92,6 @@ class SwipeableListView extends React.Component<Props, State> {
       sectionHeaderHasChanged: (s1, s2) => s1 !== s2,
     });
   }
-
-  static propTypes = {
-    /**
-     * To alert the user that swiping is possible, the first row can bounce
-     * on component mount.
-     */
-    bounceFirstRowOnMount: PropTypes.bool.isRequired,
-    /**
-     * Use `SwipeableListView.getNewDataSource()` to get a data source to use,
-     * then use it just like you would a normal ListView data source
-     */
-    dataSource: PropTypes.instanceOf(SwipeableListViewDataSource).isRequired,
-    // Maximum distance to open to after a swipe
-    maxSwipeDistance: PropTypes.oneOfType([PropTypes.number, PropTypes.func])
-      .isRequired,
-    // Callback method to render the swipeable view
-    renderRow: PropTypes.func.isRequired,
-    // Callback method to render the view that will be unveiled on swipe
-    renderQuickActions: PropTypes.func.isRequired,
-  };
 
   static defaultProps = {
     bounceFirstRowOnMount: false,

--- a/Libraries/Experimental/SwipeableRow/SwipeableListView.js
+++ b/Libraries/Experimental/SwipeableRow/SwipeableListView.js
@@ -15,7 +15,7 @@ const React = require('React');
 const SwipeableListViewDataSource = require('SwipeableListViewDataSource');
 const SwipeableRow = require('SwipeableRow');
 
-import type {Props as ListViewProps} from 'ListView';
+type ListViewProps = React.ElementConfig<typeof ListView>;
 
 type Props = $ReadOnly<{|
   ...ListViewProps,

--- a/Libraries/Lists/ListView/ListView.js
+++ b/Libraries/Lists/ListView/ListView.js
@@ -33,7 +33,7 @@ const DEFAULT_SCROLL_RENDER_AHEAD = 1000;
 const DEFAULT_END_REACHED_THRESHOLD = 1000;
 const DEFAULT_SCROLL_CALLBACK_THROTTLE = 50;
 
-export type Props = $ReadOnly<{|
+type Props = $ReadOnly<{|
   ...ScrollViewProps,
 
   /**

--- a/Libraries/Lists/ListView/ListView.js
+++ b/Libraries/Lists/ListView/ListView.js
@@ -33,7 +33,7 @@ const DEFAULT_SCROLL_RENDER_AHEAD = 1000;
 const DEFAULT_END_REACHED_THRESHOLD = 1000;
 const DEFAULT_SCROLL_CALLBACK_THROTTLE = 50;
 
-type Props = $ReadOnly<{|
+export type Props = $ReadOnly<{|
   ...ScrollViewProps,
 
   /**

--- a/RNTester/js/Shared/RNTesterTypes.js
+++ b/RNTester/js/Shared/RNTesterTypes.js
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow
+ */
+
+'use strict';
+
+import type {ComponentType} from 'React';
+
+export type RNTesterProps = $ReadOnly<{|
+  navigator?: ?$ReadOnlyArray<
+    $ReadOnly<{|
+      title: string,
+      component: ComponentType<any>,
+      backButtonTitle: string,
+      passProps: any,
+    |}>,
+  >,
+|}>;

--- a/RNTester/js/SwipeableListViewExample.js
+++ b/RNTester/js/SwipeableListViewExample.js
@@ -24,9 +24,10 @@ const {
 const RNTesterPage = require('./RNTesterPage');
 
 import type {RNTesterProps} from 'RNTesterTypes';
+import type {SwipeableListViewDataSource} from 'SwipeableListViewDataSource';
 
 type State = {|
-  dataSource: Object,
+  dataSource: SwipeableListViewDataSource,
 |};
 
 class SwipeableListViewSimpleExample extends React.Component<
@@ -79,7 +80,7 @@ class SwipeableListViewSimpleExample extends React.Component<
     );
   }
 
-  _renderRow = (rowData: Object, sectionID: string, rowID: string) => {
+  _renderRow(rowData: Object, sectionID: string, rowID: string) {
     const rowHash = Math.abs(hashCode(rowData.id));
     const imgSource = THUMB_URLS[rowHash % THUMB_URLS.length];
     return (
@@ -96,7 +97,7 @@ class SwipeableListViewSimpleExample extends React.Component<
     );
   };
 
-  _genDataSource(pressData: {[key: number]: boolean}): Array<any> {
+  _genDataSource(pressData: {[key: number]: boolean}) {
     const dataBlob = {};
     const sectionIDs = ['Section 0'];
     const rowIDs = [[]];
@@ -115,7 +116,8 @@ class SwipeableListViewSimpleExample extends React.Component<
      *     }
      *   }
      */
-    // only one section in this example
+
+    // Only one section in this example
     dataBlob['Section 0'] = {};
     for (let ii = 0; ii < 100; ii++) {
       const pressedText = pressData[ii] ? ' (pressed)' : '';
@@ -128,11 +130,11 @@ class SwipeableListViewSimpleExample extends React.Component<
     return [dataBlob, sectionIDs, rowIDs];
   }
 
-  _renderSeperator = (
+  _renderSeperator(
     sectionID: string,
     rowID: string,
     adjacentRowHighlighted: boolean,
-  ) => {
+  ) {
     return (
       <View
         key={`${sectionID}-${rowID}`}
@@ -169,14 +171,15 @@ const LOREM_IPSUM = [
   'putant invidunt reprehendunt ne qui.',
 ].join('');
 
-/* eslint no-bitwise: 0 */
-const hashCode = function(str) {
+/* eslint-disable no-bitwise */
+const hashCode = str => {
   let hash = 15;
   for (let ii = str.length - 1; ii >= 0; ii--) {
     hash = (hash << 5) - hash + str.charCodeAt(ii);
   }
   return hash;
 };
+/* eslint-enable no-bitwise */
 
 const styles = StyleSheet.create({
   row: {

--- a/RNTester/js/SwipeableListViewExample.js
+++ b/RNTester/js/SwipeableListViewExample.js
@@ -10,10 +10,8 @@
 
 'use strict';
 
-var React = require('react');
-var createReactClass = require('create-react-class');
-var ReactNative = require('react-native');
-var {
+const React = require('react');
+const {
   Image,
   SwipeableListView,
   TouchableHighlight,
@@ -21,31 +19,32 @@ var {
   Text,
   View,
   Alert,
-} = ReactNative;
+} = require('react-native');
 
-var RNTesterPage = require('./RNTesterPage');
+const RNTesterPage = require('./RNTesterPage');
 
-var SwipeableListViewSimpleExample = createReactClass({
-  displayName: 'SwipeableListViewSimpleExample',
-  statics: {
-    title: '<SwipeableListView>',
-    description: 'Performant, scrollable, swipeable list of data.',
-  },
+import type {RNTesterProps} from 'RNTesterTypes';
 
-  getInitialState: function() {
-    var ds = SwipeableListView.getNewDataSource();
-    return {
-      dataSource: ds.cloneWithRowsAndSections(...this._genDataSource({})),
-    };
-  },
+type State = {|
+  dataSource: Object,
+|};
 
-  _pressData: ({}: {[key: number]: boolean}),
+class SwipeableListViewSimpleExample extends React.Component<
+  RNTesterProps,
+  State,
+> {
+  static title = '<SwipeableListView>';
+  static description = 'Performant, scrollable, swipeable list of data.';
 
-  UNSAFE_componentWillMount: function() {
-    this._pressData = {};
-  },
+  state = {
+    dataSource: SwipeableListView.getNewDataSource().cloneWithRowsAndSections(
+      ...this._genDataSource({}),
+    ),
+  };
 
-  render: function() {
+  _pressData: {[key: number]: boolean} = {};
+
+  render(): React.Node {
     return (
       <RNTesterPage
         title={this.props.navigator ? null : '<SwipeableListView>'}
@@ -78,16 +77,11 @@ var SwipeableListViewSimpleExample = createReactClass({
         />
       </RNTesterPage>
     );
-  },
+  }
 
-  _renderRow: function(
-    rowData: Object,
-    sectionID: number,
-    rowID: number,
-    highlightRow: (sectionID: number, rowID: number) => void,
-  ) {
-    var rowHash = Math.abs(hashCode(rowData.id));
-    var imgSource = THUMB_URLS[rowHash % THUMB_URLS.length];
+  _renderRow = (rowData: Object, sectionID: string, rowID: string) => {
+    const rowHash = Math.abs(hashCode(rowData.id));
+    const imgSource = THUMB_URLS[rowHash % THUMB_URLS.length];
     return (
       <TouchableHighlight onPress={() => {}}>
         <View>
@@ -100,31 +94,31 @@ var SwipeableListViewSimpleExample = createReactClass({
         </View>
       </TouchableHighlight>
     );
-  },
+  };
 
-  _genDataSource: function(pressData: {[key: number]: boolean}): Array<any> {
-    var dataBlob = {};
-    var sectionIDs = ['Section 0'];
-    var rowIDs = [[]];
+  _genDataSource(pressData: {[key: number]: boolean}): Array<any> {
+    const dataBlob = {};
+    const sectionIDs = ['Section 0'];
+    const rowIDs = [[]];
     /**
      * dataBlob example below:
-      {
-        'Section 0': {
-          'Row 0': {
-            id: '0',
-            text: 'row 0 text'
-          },
-          'Row 1': {
-            id: '1',
-            text: 'row 1 text'
-          }
-        }
-      }
-    */
+     *   {
+     *     'Section 0': {
+     *       'Row 0': {
+     *         id: '0',
+     *         text: 'row 0 text'
+     *       },
+     *       'Row 1': {
+     *         id: '1',
+     *         text: 'row 1 text'
+     *       }
+     *     }
+     *   }
+     */
     // only one section in this example
     dataBlob['Section 0'] = {};
-    for (var ii = 0; ii < 100; ii++) {
-      var pressedText = pressData[ii] ? ' (pressed)' : '';
+    for (let ii = 0; ii < 100; ii++) {
+      const pressedText = pressData[ii] ? ' (pressed)' : '';
       dataBlob[sectionIDs[0]]['Row ' + ii] = {
         id: 'Row ' + ii,
         text: 'Row ' + ii + pressedText,
@@ -132,13 +126,13 @@ var SwipeableListViewSimpleExample = createReactClass({
       rowIDs[0].push('Row ' + ii);
     }
     return [dataBlob, sectionIDs, rowIDs];
-  },
+  }
 
-  _renderSeperator: function(
-    sectionID: number,
-    rowID: number,
+  _renderSeperator = (
+    sectionID: string,
+    rowID: string,
     adjacentRowHighlighted: boolean,
-  ) {
+  ) => {
     return (
       <View
         key={`${sectionID}-${rowID}`}
@@ -148,10 +142,10 @@ var SwipeableListViewSimpleExample = createReactClass({
         }}
       />
     );
-  },
-});
+  };
+}
 
-var THUMB_URLS = [
+const THUMB_URLS = [
   require('./Thumbnails/like.png'),
   require('./Thumbnails/dislike.png'),
   require('./Thumbnails/call.png'),
@@ -165,19 +159,26 @@ var THUMB_URLS = [
   require('./Thumbnails/superlike.png'),
   require('./Thumbnails/victory.png'),
 ];
-var LOREM_IPSUM =
-  'Lorem ipsum dolor sit amet, ius ad pertinax oportere accommodare, an vix civibus corrumpit referrentur. Te nam case ludus inciderint, te mea facilisi adipiscing. Sea id integre luptatum. In tota sale consequuntur nec. Erat ocurreret mei ei. Eu paulo sapientem vulputate est, vel an accusam intellegam interesset. Nam eu stet pericula reprimique, ea vim illud modus, putant invidunt reprehendunt ne qui.';
+
+const LOREM_IPSUM = [
+  'Lorem ipsum dolor sit amet, ius ad pertinax oportere accommodare, an vix ',
+  'civibus corrumpit referrentur. Te nam case ludus inciderint, te mea facilisi ',
+  'adipiscing. Sea id integre luptatum. In tota sale consequuntur nec. Erat ',
+  'ocurreret mei ei. Eu paulo sapientem vulputate est, vel an accusam ',
+  'intellegam interesset. Nam eu stet pericula reprimique, ea vim illud modus, ',
+  'putant invidunt reprehendunt ne qui.',
+].join('');
 
 /* eslint no-bitwise: 0 */
-var hashCode = function(str) {
-  var hash = 15;
-  for (var ii = str.length - 1; ii >= 0; ii--) {
+const hashCode = function(str) {
+  let hash = 15;
+  for (let ii = str.length - 1; ii >= 0; ii--) {
     hash = (hash << 5) - hash + str.charCodeAt(ii);
   }
   return hash;
 };
 
-var styles = StyleSheet.create({
+const styles = StyleSheet.create({
   row: {
     flexDirection: 'row',
     justifyContent: 'center',


### PR DESCRIPTION
This PR removes the remaining proptypes from `SwipeableListView`, and cleans up its flow types a bit. Its RNTester example has also been cleaned up, and turned into an ES6 class.

`ListView`'s props have been exported so this can use it.

Test Plan:
----------
`flow check` passes.

Release Notes:
--------------
Help reviewers and the release process by writing your own release notes. See below for an example.

[GENERAL] [ENHANCEMENT] [Libraries/Experimental/SwipeableRow/SwipeableListView.js] - PropTypes have been removed
[GENERAL] [MINOR] [Libraries/Lists/ListView/ListView.js] - Flow proptypes have been exported
[GENERAL] [ENHANCEMENT] [RNTester/js/Shared/RNTesterTypes.js] - Created basic flow types for RNTester components 
[GENERAL] [ENHANCEMENT] [RNTester/js/SwipeableListViewExample.js] - Converted from `createReactClass` to ES6 class, and other general cleanup.
