### PR TITLE
Fix RNTester build failure in CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -203,6 +203,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",
+    "@babel/runtime": "^7.0.0",
     "async": "^2.4.0",
     "babel-eslint": "9.0.0",
     "babel-generator": "^6.26.0",


### PR DESCRIPTION
Summary:
If you cd into `~/fbsource/xplat/js/react-native-github` and run:

```
xcodebuild -project RNTester/RNTester.xcodeproj -scheme RNTester -configuration Release -sdk iphonesimulator -derivedDataPath RNTester/build -quiet
```

The command fails with the following error:
```
?  react-native-github xcodebuild -project RNTester/RNTester.xcodeproj -scheme RNTester -configuration Release -sdk iphonesimulator -derivedDataPath RNTester/build -quiet
=== BUILD TARGET RNTester OF PROJECT RNTester WITH CONFIGURATION Release ===
+ DEST=/Users/ramanpreet/fbsource/xplat/js/react-native-github/RNTester/build/Build/Products/Release-iphonesimulator/RNTester.app
+ [[ Release = *Debug* ]]
+ [[ -n '' ]]
+ case "$CONFIGURATION" in
+ DEV=false
+++ dirname /Users/ramanpreet/fbsource/xplat/js/react-native-github/RNTester/../scripts/react-native-xcode.sh
++ cd /Users/ramanpreet/fbsource/xplat/js/react-native-github/RNTester/../scripts/..
++ pwd
+ REACT_NATIVE_DIR=/Users/ramanpreet/fbsource/xplat/js/react-native-github
+ cd /Users/ramanpreet/fbsource/xplat/js/react-native-github/../..
+ '[' -z '' ']'
+ export NVM_DIR=/Users/ramanpreet/.nvm
+ NVM_DIR=/Users/ramanpreet/.nvm
+ [[ -s index.ios.js ]]
+ ENTRY_FILE=RNTester/js/RNTesterApp.ios.js
+ [[ -s /Users/ramanpreet/.nvm/nvm.sh ]]
++ command -v brew
+ [[ -x /usr/local/bin/brew ]]
++ brew --prefix nvm
+ [[ -s /usr/local/Cellar/nvm/0.33.11/nvm.sh ]]
+ [[ -x /Users/ramanpreet/.nodenv/bin/nodenv ]]
++ command -v brew
+ [[ -x /usr/local/bin/brew ]]
++ brew --prefix nodenv
+ [[ -x /usr/local/Cellar/nodenv/1.1.2/bin/nodenv ]]
+ '[' -z node ']'
+ '[' -z '' ']'
+ export CLI_PATH=/Users/ramanpreet/fbsource/xplat/js/react-native-github/local-cli/cli.js
+ CLI_PATH=/Users/ramanpreet/fbsource/xplat/js/react-native-github/local-cli/cli.js
+ '[' -z '' ']'
+ BUNDLE_COMMAND=bundle
+ [[ -z '' ]]
+ CONFIG_ARG=
+ type node
+ BUNDLE_FILE=/Users/ramanpreet/fbsource/xplat/js/react-native-github/RNTester/build/Build/Products/Release-iphonesimulator/RNTester.app/main.jsbundle
+ node /Users/ramanpreet/fbsource/xplat/js/react-native-github/local-cli/cli.js bundle --entry-file RNTester/js/RNTesterApp.ios.js --platform ios --dev false --reset-cache --bundle-output /Users/ramanpreet/fbsource/xplat/js/react-native-github/RNTester/build/Build/Products/Release-iphonesimulator/RNTester.app/main.jsbundle --assets-dest /Users/ramanpreet/fbsource/xplat/js/react-native-github/RNTester/build/Build/Products/Release-iphonesimulator/RNTester.app
warning: the transform cache was reset.
Loading dependency graph, done.

Unable to resolve module `babel/runtime/helpers/classCallCheck` from `/Users/ramanpreet/fbsource/xplat/js/react-native-github/RNTester/js/RNTesterApp.ios.js`: Module `babel/runtime/helpers/classCallCheck` does not exist in the Haste module map

This might be related to https://github.com/facebook/react-native/issues/4968
To resolve try the following:
  1. Clear watchman watches: `watchman watch-del-all`.
  2. Delete the `node_modules` folder: `rm -rf node_modules && npm install`.
  3. Reset Metro Bundler cache: `rm -rf /tmp/metro-bundler-cache-*` or `npm start -- --reset-cache`.
  4. Remove haste cache: `rm -rf /tmp/haste-map-react-native-packager-*`.

Error: Unable to resolve module `babel/runtime/helpers/classCallCheck` from `/Users/ramanpreet/fbsource/xplat/js/react-native-github/RNTester/js/RNTesterApp.ios.js`: Module `babel/runtime/helpers/classCallCheck` does not exist in the Haste module map

This might be related to https://github.com/facebook/react-native/issues/4968
To resolve try the following:
  1. Clear watchman watches: `watchman watch-del-all`.
  2. Delete the `node_modules` folder: `rm -rf node_modules && npm install`.
  3. Reset Metro Bundler cache: `rm -rf /tmp/metro-bundler-cache-*` or `npm start -- --reset-cache`.
  4. Remove haste cache: `rm -rf /tmp/haste-map-react-native-packager-*`.
    at ModuleResolver.resolveDependency (/Users/ramanpreet/fbsource/xplat/js/react-native-github/node_modules/metro/src/node-haste/DependencyGraph/ModuleResolution.js:209:1301)
    at ResolutionRequest.resolveDependency (/Users/ramanpreet/fbsource/xplat/js/react-native-github/node_modules/metro/src/node-haste/DependencyGraph/ResolutionRequest.js:83:16)
    at DependencyGraph.resolveDependency (/Users/ramanpreet/fbsource/xplat/js/react-native-github/node_modules/metro/src/node-haste/DependencyGraph.js:238:485)
    at Object.resolve (/Users/ramanpreet/fbsource/xplat/js/react-native-github/node_modules/metro/src/lib/transformHelpers.js:180:25)
    at dependencies.map.result (/Users/ramanpreet/fbsource/xplat/js/react-native-github/node_modules/metro/src/DeltaBundler/traverseDependencies.js:311:29)
    at Array.map (<anonymous>)
    at resolveDependencies (/Users/ramanpreet/fbsource/xplat/js/react-native-github/node_modules/metro/src/DeltaBundler/traverseDependencies.js:307:16)
    at /Users/ramanpreet/fbsource/xplat/js/react-native-github/node_modules/metro/src/DeltaBundler/traverseDependencies.js:164:33
    at Generator.next (<anonymous>)
    at step (/Users/ramanpreet/fbsource/xplat/js/react-native-github/node_modules/metro/src/DeltaBundler/traverseDependencies.js:266:307)

+ [[ false != true ]]
+ [[ ! -f /Users/ramanpreet/fbsource/xplat/js/react-native-github/RNTester/build/Build/Products/Release-iphonesimulator/RNTester.app/main.jsbundle ]]
+ echo 'error: File /Users/ramanpreet/fbsource/xplat/js/react-native-github/RNTester/build/Build/Products/Release-iphonesimulator/RNTester.app/main.jsbundle does not exist. This must be a bug with'
error: File /Users/ramanpreet/fbsource/xplat/js/react-native-github/RNTester/build/Build/Products/Release-iphonesimulator/RNTester.app/main.jsbundle does not exist. This must be a bug with
+ echo 'React Native, please report it here: https://github.com/facebook/react-native/issues'
React Native, please report it here: https://github.com/facebook/react-native/issues
+ exit 2
** BUILD FAILED **
```

Basically, we're missing the `babel/runtime/helpers/classCallCheck` function. Installing `babel/runtime` fixed the issue.

Differential Revision: D10021475
