### PR TITLE
Export ImageURISource type

### DIFF
--- a/Libraries/Image/ImageSource.js
+++ b/Libraries/Image/ImageSource.js
@@ -14,7 +14,7 @@
 // that might have more keys. This also has to be inexact to support taking
 // instances of classes like FBIcon.
 // https://fburl.com/8lynhvtw
-type ImageURISource = $ReadOnly<{
+export type ImageURISource = $ReadOnly<{
   uri?: ?string,
   bundle?: ?string,
   method?: ?string,


### PR DESCRIPTION
Exporting ImageURISource because we needed to use it in a custom Image component. This should be a case for other people too since handling of `number` ImageSources and `ImageURISource` ImageSources are way different.

Release Notes:
--------------

[GENERAL] [ENHANCEMENT] [Image] - Export "ImageURISource" Flow type