### PR TITLE
Move fabric dependecies out of OSS instrumentation tests

### DIFF
--- a/ReactAndroid/src/androidTest/java/com/facebook/react/testing/BUCK
+++ b/ReactAndroid/src/androidTest/java/com/facebook/react/testing/BUCK
@@ -13,8 +13,6 @@ rn_android_library(
         "PUBLIC",
     ],
     deps = [
-        react_native_dep("java/com/facebook/fbreact/fabricxx:fabricxx"),
-        react_native_dep("java/com/facebook/fbreact/fabricxx/jsi:jsi"),
         react_native_dep("libraries/soloader/java/com/facebook/soloader:soloader"),
         react_native_dep("third-party/android/support/v4:lib-support-v4"),
         react_native_dep("third-party/java/buck-android-support:buck-android-support"),
@@ -39,5 +37,3 @@ rn_android_library(
         react_native_target("res:uimanager"),
     ],
 )
-
-# /Users/dvacca/fbsource/fbandroid/xplat_cell/ReactAndroid/src/androidTest/java/com/facebook/react/testing/BUCK

--- a/ReactAndroid/src/androidTest/java/com/facebook/react/testing/FabricUIManagerFactory.java
+++ b/ReactAndroid/src/androidTest/java/com/facebook/react/testing/FabricUIManagerFactory.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc.
+ *
+ * <p>This source code is licensed under the MIT license found in the LICENSE file in the root
+ * directory of this source tree.
+ */
+package com.facebook.react.testing;
+
+import com.facebook.react.bridge.JavaScriptContextHolder;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.UIManager;
+import com.facebook.react.uimanager.ViewManagerRegistry;
+
+/** Factory used to create FabricUIManager in Testing infrastructure. */
+public interface FabricUIManagerFactory {
+
+  UIManager getFabricUIManager(
+      ReactApplicationContext reactApplicationContext,
+      ViewManagerRegistry viewManagerRegistry,
+      JavaScriptContextHolder jsContext);
+}

--- a/ReactAndroid/src/androidTest/java/com/facebook/react/testing/ReactAppTestActivity.java
+++ b/ReactAndroid/src/androidTest/java/com/facebook/react/testing/ReactAppTestActivity.java
@@ -15,7 +15,6 @@ import android.support.v4.app.FragmentActivity;
 import android.view.View;
 import android.view.ViewTreeObserver;
 import android.widget.FrameLayout;
-import com.facebook.fbreact.fabricxx.jsi.Binding;
 import com.facebook.infer.annotation.Assertions;
 import com.facebook.react.ReactInstanceManager;
 import com.facebook.react.ReactInstanceManagerBuilder;
@@ -29,8 +28,6 @@ import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.UIManager;
 import com.facebook.react.common.LifecycleState;
-import com.facebook.react.fabric.FabricBinder;
-import com.facebook.react.fabric.FabricBinding;
 import com.facebook.react.modules.core.DefaultHardwareBackBtnHandler;
 import com.facebook.react.modules.core.PermissionAwareActivity;
 import com.facebook.react.modules.core.PermissionListener;
@@ -199,7 +196,7 @@ public class ReactAppTestActivity extends FragmentActivity
           throw new RuntimeException("Layout never occurred for component " + appKey, e);}
   }
 
-  public void loadBundle(ReactInstanceSpecForTest spec, String bundleName, boolean useDevSupport) {
+  public void loadBundle(final ReactInstanceSpecForTest spec, String bundleName, boolean useDevSupport) {
 
     mBridgeIdleSignaler = new ReactBridgeIdleSignaler();
 
@@ -243,25 +240,12 @@ public class ReactAppTestActivity extends FragmentActivity
                         return new JSIModuleProvider() {
                           @Override
                           public UIManager get() {
-                            List<ViewManager> viewManagers =
-                                mReactInstanceManager.getOrCreateViewManagers(
-                                    reactApplicationContext);
-                            EventDispatcher eventDispatcher =
-                                reactApplicationContext
-                                    .getNativeModule(UIManagerModule.class)
-                                    .getEventDispatcher();
-
                             ViewManagerRegistry viewManagerRegistry =
                               new ViewManagerRegistry(
                                 mReactInstanceManager.getOrCreateViewManagers(reactApplicationContext));
 
-                            UIManager uiManager =
-                              new com.facebook.fbreact.fabricxx.UIManager(
-                                reactApplicationContext, viewManagerRegistry, jsContext);
-
-                            FabricBinding binding = new Binding();
-                            binding.installFabric(jsContext, (FabricBinder) uiManager);
-                            return uiManager;
+                            FabricUIManagerFactory factory = spec.getFabricUIManagerFactory();
+                            return factory != null ? factory.getFabricUIManager(reactApplicationContext, viewManagerRegistry, jsContext) : null;
                           }
                         };
                       }

--- a/ReactAndroid/src/androidTest/java/com/facebook/react/testing/ReactInstanceSpecForTest.java
+++ b/ReactAndroid/src/androidTest/java/com/facebook/react/testing/ReactInstanceSpecForTest.java
@@ -1,10 +1,9 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * <p>This source code is licensed under the MIT license found in the LICENSE file in the root
+ * directory of this source tree.
  */
-
 package com.facebook.react.testing;
 
 import android.annotation.SuppressLint;
@@ -27,10 +26,11 @@ import javax.annotation.Nullable;
 public class ReactInstanceSpecForTest {
 
   private final List<NativeModule> mNativeModules =
-    new ArrayList<NativeModule>(Arrays.asList(new FakeWebSocketModule()));
+      new ArrayList<NativeModule>(Arrays.asList(new FakeWebSocketModule()));
   private final List<Class<? extends JavaScriptModule>> mJSModuleSpecs = new ArrayList<>();
   private final List<ViewManager> mViewManagers = new ArrayList<>();
   private final ArrayList<ReactPackage> mReactPackages = new ArrayList<>();
+  @Nullable private FabricUIManagerFactory mFabricUIManagerFactory = null;
   @Nullable private JavaScriptExecutorFactory mJavaScriptExecutorFactory = null;
 
   public ReactInstanceSpecForTest addNativeModule(NativeModule module) {
@@ -38,7 +38,8 @@ public class ReactInstanceSpecForTest {
     return this;
   }
 
-  public ReactInstanceSpecForTest setJavaScriptExecutorFactory(JavaScriptExecutorFactory javaScriptExecutorFactory) {
+  public ReactInstanceSpecForTest setJavaScriptExecutorFactory(
+      JavaScriptExecutorFactory javaScriptExecutorFactory) {
     mJavaScriptExecutorFactory = javaScriptExecutorFactory;
     return this;
   }
@@ -50,6 +51,16 @@ public class ReactInstanceSpecForTest {
     }
     mReactPackages.add(reactPackage);
     return this;
+  }
+
+  public ReactInstanceSpecForTest setFabricUIManagerFactory(@Nullable FabricUIManagerFactory fabricUIManagerFactory) {
+    mFabricUIManagerFactory = fabricUIManagerFactory;
+    return this;
+  }
+
+  @Nullable
+  public FabricUIManagerFactory getFabricUIManagerFactory() {
+    return mFabricUIManagerFactory;
   }
 
   public ReactInstanceSpecForTest addPackages(List<ReactPackage> reactPackages) {

--- a/ReactAndroid/src/androidTest/java/com/facebook/react/testing/ReactInstrumentationTest.java
+++ b/ReactAndroid/src/androidTest/java/com/facebook/react/testing/ReactInstrumentationTest.java
@@ -1,10 +1,9 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * <p>This source code is licensed under the MIT license found in the LICENSE file in the root
+ * directory of this source tree.
  */
-
 package com.facebook.react.testing;
 
 import android.content.Intent;
@@ -20,17 +19,18 @@ import javax.annotation.Nullable;
 /**
  * Base class for instrumentation tests that runs React based application.
  *
- * This is similar to ReactAppInstrumentationTestCase except ReactInstrumentationTest allows
+ * <p>This is similar to ReactAppInstrumentationTestCase except ReactInstrumentationTest allows
  * optional rendering of components. A test case can render no components or render multiple
  * components.
  */
-public abstract class ReactInstrumentationTest extends
-    ActivityInstrumentationTestCase2<ReactAppTestActivity> implements IdleWaiter {
+public abstract class ReactInstrumentationTest
+    extends ActivityInstrumentationTestCase2<ReactAppTestActivity> implements IdleWaiter {
 
   protected StringRecordingModule mRecordingModule;
 
-  @Nullable
-  protected JavaScriptExecutorFactory mJavaScriptExecutorFactory = null;
+  @Nullable protected FabricUIManagerFactory mFabricUIManagerFactory = null;
+
+  @Nullable protected JavaScriptExecutorFactory mJavaScriptExecutorFactory = null;
 
   public ReactInstrumentationTest() {
     super(ReactAppTestActivity.class);
@@ -45,15 +45,10 @@ public abstract class ReactInstrumentationTest extends
     setActivityIntent(intent);
     mRecordingModule = new StringRecordingModule();
     final ReactAppTestActivity activity = getActivity();
-    activity.loadBundle(
-        createReactInstanceSpecForTest(),
-        getBundleName(),
-        getEnableDevSupport());
+    activity.loadBundle(createReactInstanceSpecForTest(), getBundleName(), getEnableDevSupport());
   }
 
-  /**
-   * Renders this component within this test's activity
-   */
+  /** Renders this component within this test's activity */
   public void renderComponent(final String componentName) {
     getActivity().renderComponent(componentName, null);
     waitForBridgeAndUIIdle();
@@ -71,8 +66,8 @@ public abstract class ReactInstrumentationTest extends
   }
 
   public <T extends View> T getViewByTestId(String testID) {
-    return (T) ReactTestHelper
-        .getViewWithReactTestId((ViewGroup) getRootView().getParent(), testID);
+    return (T)
+        ReactTestHelper.getViewWithReactTestId((ViewGroup) getRootView().getParent(), testID);
   }
 
   public SingleTouchGestureGenerator createGestureGenerator() {
@@ -99,21 +94,20 @@ public abstract class ReactInstrumentationTest extends
     return getReactContext().getJSModule(jsInterface);
   }
 
-  /**
-   * Override this method to provide extra native modules to be loaded before the app starts
-   */
+  /** Override this method to provide extra native modules to be loaded before the app starts */
   protected ReactInstanceSpecForTest createReactInstanceSpecForTest() {
     ReactInstanceSpecForTest reactInstanceSpecForTest =
-      new ReactInstanceSpecForTest().addNativeModule(mRecordingModule);
+        new ReactInstanceSpecForTest().addNativeModule(mRecordingModule);
     if (mJavaScriptExecutorFactory != null) {
       reactInstanceSpecForTest.setJavaScriptExecutorFactory(mJavaScriptExecutorFactory);
+    }
+    if (mFabricUIManagerFactory != null) {
+      reactInstanceSpecForTest.setFabricUIManagerFactory(mFabricUIManagerFactory);
     }
     return reactInstanceSpecForTest;
   }
 
-  /**
-   * Implement this method to provide the bundle for this test
-   */
+  /** Implement this method to provide the bundle for this test */
   protected abstract String getBundleName();
 
   protected ReactContext getReactContext() {


### PR DESCRIPTION
Summary: This diff moves fabric dependencies out of OSS instrumentation tests (js/react-native-github/ReactAndroid/src/androidTest/java/com/facebook/react/testing/BUCK), this will un-break build of OSS project in CI.

Differential Revision: D10020517
