### PR TITLE
Re-sourcing profile Xcode to update node version

### DIFF
--- a/scripts/react-native-xcode.sh
+++ b/scripts/react-native-xcode.sh
@@ -8,6 +8,9 @@
 # This script is supposed to be invoked as part of Xcode build process
 # and relies on environment variables (including PWD) set by Xcode
 
+#Re-sourcing profile to update Xcode node version since Xcode use old node version
+source /.bash_profile
+
 # Print commands before executing them (useful for troubleshooting)
 set -x
 DEST=$CONFIGURATION_BUILD_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH


### PR DESCRIPTION
Re-sourcing profile to update Xcode node version since Xcode use old node version and for some people (our team). This can cause the bundle to fail building main.jsbundle

Thank you for sending the PR! We appreciate you spending the time to work on these changes.
Help us understand your motivation by explaining why you decided to make this change.

If this PR fixes an issue, type "Fixes #issueNumber" to automatically close the issue when the PR is merged.

_Pull requests that expand test coverage are more likely to get reviewed. Add a test case whenever possible!_

Test Plan:
----------

**Problem**
XCode 10 using wrong node version (older) so it cannot build the main.jsbundle when release the app on IOS

**Test failed case before editing the code:**

Run command react native for release:
```
react-native run-ios --configuration Release
```
-> The bundle will not be generated, XCode throw in error

**Test success case after editing the code:**

Run command react native for release:
```
react-native run-ios --configuration Release
```
-> IOS app is upload to test flight or ipa file is generated


Release Notes:
--------------
[IOS][BUGFIX] [./scripts]  - Sourcing XCode node version again when release to help re-bundling mainjs file when X code generate react native app version `^0.57.x`
