### PR TITLE
[CI] Test Xcode 10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -434,6 +434,31 @@ jobs:
       - store_test_results:
           path: ~/react-native/reports/junit
 
+  # Xcode 10: Runs unit tests on iOS and Apple TV devices
+  test_objc_xcode10:
+    macos:
+      xcode: "10.0.0"
+    steps:
+      - checkout
+      - run: *setup-artifacts
+      - run: *yarn
+
+      - run: *boot-simulator-iphone
+      - run: *boot-simulator-appletv
+      - run: *brew-install-watchman
+
+      - run: *run-objc-ios-tests
+      - run: *run-objc-tvos-tests
+
+      # TODO: Fix these failing tests.
+      - run: *display-broken-tests-warning
+      - run: *run-podspec-tests
+      - run: *run-objc-ios-e2e-tests
+      - run: *run-objc-tvos-e2e-tests
+
+      - store_test_results:
+          path: ~/react-native/reports/junit
+
   # Runs end to end tests (Detox)
   test_detox_end_to_end:
     <<: *macos_defaults
@@ -653,10 +678,6 @@ workflows:
           requires:
             - checkout_code
 
-      # Test JavaScript and Node 10 compatibility
-      - test_node10:
-          filters: *filter-ignore-gh-pages
-
       # Test Android
       - test_android:
           filters: *filter-ignore-gh-pages
@@ -674,8 +695,21 @@ workflows:
           requires:
             - checkout_code
 
+      # Tooling Compatibility Checks
+      # Checks that newer tooling is well supported.
+      # Test Xcode 10 compatibility
+      - test_objc_xcode10:
+          filters: *filter-ignore-gh-pages
+      # Test Node 10 compatibility
+      - test_node10:
+          filters: *filter-ignore-gh-pages
+
       # Only runs on vX.X.X tags if all tests are green
       - publish_npm_package:
+          # ignore any commit on any branch by default
+          branches:
+            ignore: /.*/
+          # only act on version tags
           filters:
             tags:
               only: /v[0-9]+(\.[0-9]+)*(\-rc(\.[0-9]+)?)?/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -436,6 +436,7 @@ jobs:
 
   # Xcode 10: Runs unit tests on iOS and Apple TV devices
   test_objc_xcode10:
+    <<: *defaults
     macos:
       xcode: "10.0.0"
     steps:
@@ -696,21 +697,18 @@ workflows:
             - checkout_code
 
       # Tooling Compatibility Checks
-      # Checks that newer tooling is well supported.
-      # Test Xcode 10 compatibility
       - test_objc_xcode10:
           filters: *filter-ignore-gh-pages
-      # Test Node 10 compatibility
       - test_node10:
           filters: *filter-ignore-gh-pages
 
       # Only runs on vX.X.X tags if all tests are green
       - publish_npm_package:
-          # ignore any commit on any branch by default
-          branches:
-            ignore: /.*/
-          # only act on version tags
           filters:
+            # ignore any commit on any branch by default
+            branches:
+              ignore: /.*/
+            # only act on version tags
             tags:
               only: /v[0-9]+(\.[0-9]+)*(\-rc(\.[0-9]+)?)?/
           requires:


### PR DESCRIPTION
This also fixes an issue with tagged commit Circle CI jobs, and avoids running the `publish_npm_package` on every commit. The new config ignores commits on *all branches*, but should still catch git tags.