### PR TITLE
package.json: Add flow check commands for iOS and Android

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -185,9 +185,12 @@ aliases:
     name: Lint code
     command: scripts/circleci/exec_swallow_error.sh yarn lint --format junit -o ~/react-native/reports/junit/eslint/results.xml
 
-  - &run-flow-checks
-    name: Check for errors in code using Flow
+  - &run-flow-checks-ios
+    name: Check for errors in code using Flow (iOS)
     command: yarn flow-check-ios
+
+  - &run-flow-checks-android
+    name: Check for errors in code using Flow (Android)
     command: yarn flow-check-android
 
   - &run-sanity-checks
@@ -378,7 +381,8 @@ jobs:
           at: ~/react-native
 
       - run: *run-lint-checks
-      - run: *run-flow-checks
+      - run: *run-flow-checks-ios
+      - run: *run-flow-checks-android
 
       - store_test_results:
           path: ~/react-native/reports/junit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -187,7 +187,8 @@ aliases:
 
   - &run-flow-checks
     name: Check for errors in code using Flow
-    command: yarn flow check
+    command: yarn flow-check-ios
+    command: yarn flow-check-android
 
   - &run-sanity-checks
     name: Sanity checks

--- a/package.json
+++ b/package.json
@@ -126,6 +126,8 @@
     "test": "jest",
     "test-ci": "JEST_JUNIT_OUTPUT=\"reports/junit/js-test-results.xml\" jest --maxWorkers=2 --ci --testResultsProcessor=\"jest-junit\"",
     "flow": "flow",
+    "flow-check-ios": "flow check",
+    "flow-check-android": "flow check --flowconfig-name .flowconfig.android",
     "lint": "eslint .",
     "prettier": "prettier \"./**/*.js\" --write",
     "docker-setup-android": "docker pull reactnativeci/android-base:latest",


### PR DESCRIPTION
This PR adds these two scripts to `package.json`:

 * `flow-check-ios` - for running `flow check` on `.ios.js` files
 * `flow-check-android` - for running `flow check` on `.android.js` files

The Android command makes use of the new `--flowconfig-name` option added to Flow in `0.80.0`

Test Plan:
----------
Both commands have been ran and work as expected.

Release Notes:
--------------
[GENERAL] [ENHANCEMENT] [package.json] - Added flow check commands for iOS and Android
