### PR TITLE
StaticRenderer: Removed prop types

### DIFF
--- a/Libraries/Components/StaticRenderer.js
+++ b/Libraries/Components/StaticRenderer.js
@@ -12,20 +12,20 @@
 
 const React = require('React');
 
-type StaticRendererProps = $ReadOnly<{|
+type Props = $ReadOnly<{|
   /**
    * Indicates whether the render function needs to be called again
    */
   shouldUpdate: boolean,
   /**
-   * (props) => renderable
-   * A function that takes in certain props that are used to render a component
+   * () => renderable
+   * A function that returns a renderable component
    */
-  render: Function,
+  render: () => React.Node,
 |}>;
 
-class StaticRenderer extends React.Component<StaticRendererProps> {
-  shouldComponentUpdate(nextProps: StaticRendererProps): boolean {
+class StaticRenderer extends React.Component<Props> {
+  shouldComponentUpdate(nextProps: Props): boolean {
     return nextProps.shouldUpdate;
   }
 

--- a/Libraries/Components/StaticRenderer.js
+++ b/Libraries/Components/StaticRenderer.js
@@ -12,18 +12,20 @@
 
 const React = require('React');
 
-const PropTypes = require('prop-types');
-
-class StaticRenderer extends React.Component<{
+type StaticRendererProps = $ReadOnly<{|
+  /**
+   * Indicates whether the render function needs to be called again
+   */
   shouldUpdate: boolean,
+  /**
+   * (props) => renderable
+   * A function that takes in certain props that are used to render a component
+   */
   render: Function,
-}> {
-  static propTypes = {
-    shouldUpdate: PropTypes.bool.isRequired,
-    render: PropTypes.func.isRequired,
-  };
+|}>;
 
-  shouldComponentUpdate(nextProps: {shouldUpdate: boolean}): boolean {
+class StaticRenderer extends React.Component<StaticRendererProps> {
+  shouldComponentUpdate(nextProps: StaticRendererProps): boolean {
     return nextProps.shouldUpdate;
   }
 


### PR DESCRIPTION
related #21342 

 The `render` function, I was not able to specifically type since the props passed to it may vary. At the moment only `renderRow` function from ListView component is using StaticRenderer, and the type of the renderRow function is `Function`.
Let me know what your thoughts are on this. Thank you

Test Plan:
Ran against flow check for android and ios

Release Notes:
 [GENERAL] [ENHANCEMENT] [StaticRenderer.js] - Converted PropTypes to Flow
