### PR TITLE
[PropTypes -> Flow] Split PointPropType

### DIFF
--- a/Libraries/DeprecatedPropTypes/DeprecatedPointPropType.js
+++ b/Libraries/DeprecatedPropTypes/DeprecatedPointPropType.js
@@ -10,9 +10,11 @@
 
 'use strict';
 
-export type PointProp = $ReadOnly<{
-  x: number,
-  y: number,
-}>;
+const PropTypes = require('prop-types');
 
-module.exports = PointProp;
+const PointPropType = PropTypes.shape({
+  x: PropTypes.number,
+  y: PropTypes.number,
+});
+
+module.exports = PointPropType;

--- a/Libraries/StyleSheet/PointPropType.js
+++ b/Libraries/StyleSheet/PointPropType.js
@@ -14,5 +14,3 @@ export type PointProp = $ReadOnly<{
   x: number,
   y: number,
 }>;
-
-module.exports = PointProp;


### PR DESCRIPTION
This PR split PointPropType.js into PointPropType.js with Flow definition and  Libraries/DeprecatedPointPropType.js remaining with PropTypes definition.

Related to #21342  

Test Plan:
----------
All flow tests succeed.

Release Notes:
--------------
[GENERAL] [ENHANCEMENT] [PointPropType.js] - Flow types only.
[GENERAL] [ENHANCEMENT] [Libraries/DeprecatedPropTypes/DeprecatedPointPropType.js] - Created deprecated PropType reference.