### PR TITLE
Remove PropTypes and DeprecatedViewPropTypes from ViewerPagerAndroid.android.js

### DIFF
--- a/Libraries/Components/ViewPager/ViewPagerAndroid.android.js
+++ b/Libraries/Components/ViewPager/ViewPagerAndroid.android.js
@@ -153,7 +153,7 @@ class ViewPagerAndroid extends React.Component<Props> {
   };
 
   /* $FlowFixMe(>=0.78.0 site=react_native_android_fb) This issue was found
-             * when making Flow check .android.js files. */
+    * when making Flow check .android.js files. */
   _childrenWithOverridenStyle = (): Array => {
     // Override styles so that each page will fill the parent. Native component
     // will handle positioning of elements, so it's not important to offset

--- a/Libraries/Components/ViewPager/ViewPagerAndroid.android.js
+++ b/Libraries/Components/ViewPager/ViewPagerAndroid.android.js
@@ -10,8 +10,6 @@
 
 'use strict';
 
-const DeprecatedViewPropTypes = require('DeprecatedViewPropTypes');
-const PropTypes = require('prop-types');
 const React = require('React');
 const ReactNative = require('ReactNative');
 const UIManager = require('UIManager');
@@ -72,84 +70,73 @@ export type ViewPagerScrollState = $Enum<{
  * }
  * ```
  */
-class ViewPagerAndroid extends React.Component<{
-  initialPage?: number,
-  onPageScroll?: Function,
-  onPageScrollStateChanged?: Function,
-  onPageSelected?: Function,
-  pageMargin?: number,
-  peekEnabled?: boolean,
-  keyboardDismissMode?: 'none' | 'on-drag',
-  scrollEnabled?: boolean,
-}> {
-  /* $FlowFixMe(>=0.78.0 site=react_native_android_fb) This issue was found
-   * when making Flow check .android.js files. */
-  static propTypes = {
-    ...DeprecatedViewPropTypes,
-    /**
-     * Index of initial page that should be selected. Use `setPage` method to
-     * update the page, and `onPageSelected` to monitor page changes
-     */
-    initialPage: PropTypes.number,
 
-    /**
-     * Executed when transitioning between pages (ether because of animation for
-     * the requested page change or when user is swiping/dragging between pages)
-     * The `event.nativeEvent` object for this callback will carry following data:
-     *  - position - index of first page from the left that is currently visible
-     *  - offset - value from range [0,1) describing stage between page transitions.
-     *    Value x means that (1 - x) fraction of the page at "position" index is
-     *    visible, and x fraction of the next page is visible.
-     */
-    onPageScroll: PropTypes.func,
+type Props = $ReadOnly<{|
+  /**
+   * Index of initial page that should be selected. Use `setPage` method to
+   * update the page, and `onPageSelected` to monitor page changes
+   */
+  initialPage?: ?number,
 
-    /**
-     * Function called when the page scrolling state has changed.
-     * The page scrolling state can be in 3 states:
-     * - idle, meaning there is no interaction with the page scroller happening at the time
-     * - dragging, meaning there is currently an interaction with the page scroller
-     * - settling, meaning that there was an interaction with the page scroller, and the
-     *   page scroller is now finishing it's closing or opening animation
-     */
-    onPageScrollStateChanged: PropTypes.func,
+  /**
+   * Executed when transitioning between pages (ether because of animation for
+   * the requested page change or when user is swiping/dragging between pages)
+   * The `event.nativeEvent` object for this callback will carry following data:
+   *  - position - index of first page from the left that is currently visible
+   *  - offset - value from range [0,1) describing stage between page transitions.
+   *    Value x means that (1 - x) fraction of the page at "position" index is
+   *    visible, and x fraction of the next page is visible.
+   */
+  onPageScroll?: ?Function,
 
-    /**
-     * This callback will be called once ViewPager finish navigating to selected page
-     * (when user swipes between pages). The `event.nativeEvent` object passed to this
-     * callback will have following fields:
-     *  - position - index of page that has been selected
-     */
-    onPageSelected: PropTypes.func,
+  /**
+   * Function called when the page scrolling state has changed.
+   * The page scrolling state can be in 3 states:
+   * - idle, meaning there is no interaction with the page scroller happening at the time
+   * - dragging, meaning there is currently an interaction with the page scroller
+   * - settling, meaning that there was an interaction with the page scroller, and the
+   *   page scroller is now finishing it's closing or opening animation
+   */
+  onPageScrollStateChanged?: ?Function,
 
-    /**
-     * Blank space to show between pages. This is only visible while scrolling, pages are still
-     * edge-to-edge.
-     */
-    pageMargin: PropTypes.number,
+  /**
+   * This callback will be called once ViewPager finish navigating to selected page
+   * (when user swipes between pages). The `event.nativeEvent` object passed to this
+   * callback will have following fields:
+   *  - position - index of page that has been selected
+   */
+  onPageSelected?: ?Function,
 
-    /**
-     * Determines whether the keyboard gets dismissed in response to a drag.
-     *   - 'none' (the default), drags do not dismiss the keyboard.
-     *   - 'on-drag', the keyboard is dismissed when a drag begins.
-     */
-    keyboardDismissMode: PropTypes.oneOf([
-      'none', // default
-      'on-drag',
-    ]),
+  /**
+   * Blank space to show between pages. This is only visible while scrolling, pages are still
+   * edge-to-edge.
+   */
+  pageMargin?: ?number,
 
-    /**
-     * When false, the content does not scroll.
-     * The default value is true.
-     */
-    scrollEnabled: PropTypes.bool,
+  /**
+   * Determines whether the keyboard gets dismissed in response to a drag.
+   *   - 'none' (the default), drags do not dismiss the keyboard.
+   *   - 'on-drag', the keyboard is dismissed when a drag begins.
+   */
+  keyboardDismissMode?: ?$ReadOnlyArray<
+    | 'none' // default
+    | 'on-drag',
+  >,
 
-    /**
-     * Whether enable showing peekFraction or not. If this is true, the preview of
-     * last and next page will show in current screen. Defaults to false.
-     */
-    peekEnabled: PropTypes.bool,
-  };
+  /**
+   * When false, the content does not scroll.
+   * The default value is true.
+   */
+  scrollEnabled?: ?boolean,
 
+  /**
+   * Whether enable showing peekFraction or not. If this is true, the preview of
+   * last and next page will show in current screen. Defaults to false.
+   */
+  peekEnabled?: ?boolean,
+|}>;
+
+class ViewPagerAndroid extends React.Component<Props> {
   componentDidMount() {
     if (this.props.initialPage != null) {
       this.setPageWithoutAnimation(this.props.initialPage);
@@ -157,19 +144,19 @@ class ViewPagerAndroid extends React.Component<{
   }
 
   /* $FlowFixMe(>=0.78.0 site=react_native_android_fb) This issue was found
-   * when making Flow check .android.js files. */
+             * when making Flow check .android.js files. */
   getInnerViewNode = (): ReactComponent => {
     return this.refs[VIEWPAGER_REF].getInnerViewNode();
   };
 
   /* $FlowFixMe(>=0.78.0 site=react_native_android_fb) This issue was found
-   * when making Flow check .android.js files. */
+             * when making Flow check .android.js files. */
   _childrenWithOverridenStyle = (): Array => {
     // Override styles so that each page will fill the parent. Native component
     // will handle positioning of elements, so it's not important to offset
     // them correctly.
     /* $FlowFixMe(>=0.78.0 site=react_native_android_fb) This issue was found
-     * when making Flow check .android.js files. */
+                         * when making Flow check .android.js files. */
     return React.Children.map(this.props.children, function(child) {
       if (!child) {
         return null;
@@ -256,7 +243,7 @@ class ViewPagerAndroid extends React.Component<{
         {...this.props}
         ref={VIEWPAGER_REF}
         /* $FlowFixMe(>=0.78.0 site=react_native_android_fb) This issue was
-         * found when making Flow check .android.js files. */
+                * found when making Flow check .android.js files. */
         style={this.props.style}
         onPageScroll={this._onPageScroll}
         onPageScrollStateChanged={this._onPageScrollStateChanged}

--- a/Libraries/Components/ViewPager/ViewPagerAndroid.android.js
+++ b/Libraries/Components/ViewPager/ViewPagerAndroid.android.js
@@ -23,6 +23,8 @@ const VIEWPAGER_REF = 'viewPager';
 
 type Event = Object;
 
+import type {ViewProps} from 'ViewPropTypes';
+
 export type ViewPagerScrollState = $Enum<{
   idle: string,
   dragging: string,
@@ -72,6 +74,7 @@ export type ViewPagerScrollState = $Enum<{
  */
 
 type Props = $ReadOnly<{|
+  ...ViewProps,
   /**
    * Index of initial page that should be selected. Use `setPage` method to
    * update the page, and `onPageSelected` to monitor page changes
@@ -144,7 +147,7 @@ class ViewPagerAndroid extends React.Component<Props> {
   }
 
   /* $FlowFixMe(>=0.78.0 site=react_native_android_fb) This issue was found
-             * when making Flow check .android.js files. */
+  * when making Flow check .android.js files. */
   getInnerViewNode = (): ReactComponent => {
     return this.refs[VIEWPAGER_REF].getInnerViewNode();
   };
@@ -156,7 +159,7 @@ class ViewPagerAndroid extends React.Component<Props> {
     // will handle positioning of elements, so it's not important to offset
     // them correctly.
     /* $FlowFixMe(>=0.78.0 site=react_native_android_fb) This issue was found
-                         * when making Flow check .android.js files. */
+    * when making Flow check .android.js files. */
     return React.Children.map(this.props.children, function(child) {
       if (!child) {
         return null;
@@ -243,7 +246,7 @@ class ViewPagerAndroid extends React.Component<Props> {
         {...this.props}
         ref={VIEWPAGER_REF}
         /* $FlowFixMe(>=0.78.0 site=react_native_android_fb) This issue was
-                * found when making Flow check .android.js files. */
+        * found when making Flow check .android.js files. */
         style={this.props.style}
         onPageScroll={this._onPageScroll}
         onPageScrollStateChanged={this._onPageScrollStateChanged}


### PR DESCRIPTION
Related to #21342
Remove PropTypes and DeprecatedViewPropTypes from ViewerPagerAndroid.android.js

Test Plan:
----------
Flow tests succeed

- [x] yarn prettier
- [x] yarn flow-check-android
- [x] yarn flow-check-ios

Release Notes:
--------------
[GENERAL] [ENHANCEMENT] [ViewPagerAndroid.android.js] replace prop-types by Flow
<!--
  **INTERNAL and MINOR tagged notes will not be included in the next version's final release notes.**

    CATEGORY
  [----------]      TYPE
  [ CLI      ] [-------------]    LOCATION
  [ DOCS     ] [ BREAKING    ] [-------------]
  [ GENERAL  ] [ BUGFIX      ] [ {Component} ]
  [ INTERNAL ] [ ENHANCEMENT ] [ {Filename}  ]
  [ IOS      ] [ FEATURE     ] [ {Directory} ]   |-----------|
  [ ANDROID  ] [ MINOR       ] [ {Framework} ] - | {Message} |
  [----------] [-------------] [-------------]   |-----------|

 EXAMPLES:

 [IOS] [BREAKING] [FlatList] - Change a thing that breaks other things
 [ANDROID] [BUGFIX] [TextInput] - Did a thing to TextInput
 [CLI] [FEATURE] [local-cli/info/info.js] - CLI easier to do things with
 [DOCS] [BUGFIX] [GettingStarted.md] - Accidentally a thing/word
 [GENERAL] [ENHANCEMENT] [Yoga] - Added new yoga thing/position
 [INTERNAL] [FEATURE] [./scripts] - Added thing to script that nobody will see
-->
