### PR TITLE
Move and Rename propType definitions in TransformPropTypes

### DIFF
--- a/Libraries/Components/View/ViewStylePropTypes.js
+++ b/Libraries/Components/View/ViewStylePropTypes.js
@@ -14,7 +14,7 @@ const ColorPropType = require('ColorPropType');
 const LayoutPropTypes = require('LayoutPropTypes');
 const ReactPropTypes = require('prop-types');
 const ShadowPropTypesIOS = require('ShadowPropTypesIOS');
-const TransformPropTypes = require('TransformPropTypes');
+const DeprecatedTransformPropTypes = require('DeprecatedTransformPropTypes');
 
 /**
  * Warning: Some of these properties may not be supported in all releases.
@@ -22,7 +22,7 @@ const TransformPropTypes = require('TransformPropTypes');
 const ViewStylePropTypes = {
   ...LayoutPropTypes,
   ...ShadowPropTypesIOS,
-  ...TransformPropTypes,
+  ...DeprecatedTransformPropTypes,
   backfaceVisibility: ReactPropTypes.oneOf(['visible', 'hidden']),
   backgroundColor: ColorPropType,
   borderColor: ColorPropType,

--- a/Libraries/DeprecatedPropTypes/DeprecatedTransformPropTypes.js
+++ b/Libraries/DeprecatedPropTypes/DeprecatedTransformPropTypes.js
@@ -40,23 +40,7 @@ const DecomposedMatrixPropType = function(
   }
 };
 
-const TransformPropTypes = {
-  /**
-   * `transform` accepts an array of transformation objects. Each object specifies
-   * the property that will be transformed as the key, and the value to use in the
-   * transformation. Objects should not be combined. Use a single key/value pair
-   * per object.
-   *
-   * The rotate transformations require a string so that the transform may be
-   * expressed in degrees (deg) or radians (rad). For example:
-   *
-   * `transform([{ rotateX: '45deg' }, { rotateZ: '0.785398rad' }])`
-   *
-   * The skew transformations require a string so that the transform may be
-   * expressed in degrees (deg). For example:
-   *
-   * `transform([{ skewX: '45deg' }])`
-   */
+const DeprecatedTransformPropTypes = {
   transform: ReactPropTypes.arrayOf(
     ReactPropTypes.oneOfType([
       ReactPropTypes.shape({perspective: ReactPropTypes.number}),
@@ -73,17 +57,8 @@ const TransformPropTypes = {
       ReactPropTypes.shape({skewY: ReactPropTypes.string}),
     ]),
   ),
-
-  /**
-   * Deprecated. Use the transform prop instead.
-   */
   transformMatrix: TransformMatrixPropType,
-  /**
-   * Deprecated. Use the transform prop instead.
-   */
   decomposedMatrix: DecomposedMatrixPropType,
-
-  /* Deprecated transform props used on Android only */
   scaleX: deprecatedPropType(
     ReactPropTypes.number,
     'Use the transform prop instead.',
@@ -106,4 +81,4 @@ const TransformPropTypes = {
   ),
 };
 
-module.exports = TransformPropTypes;
+module.exports = DeprecatedTransformPropTypes;

--- a/Libraries/Image/ImageStylePropTypes.js
+++ b/Libraries/Image/ImageStylePropTypes.js
@@ -14,12 +14,12 @@ const ImageResizeMode = require('ImageResizeMode');
 const LayoutPropTypes = require('LayoutPropTypes');
 const ReactPropTypes = require('prop-types');
 const ShadowPropTypesIOS = require('ShadowPropTypesIOS');
-const TransformPropTypes = require('TransformPropTypes');
+const DeprecatedTransformPropTypes = require('DeprecatedTransformPropTypes');
 
 const ImageStylePropTypes = {
   ...LayoutPropTypes,
   ...ShadowPropTypesIOS,
-  ...TransformPropTypes,
+  ...DeprecatedTransformPropTypes,
   resizeMode: ReactPropTypes.oneOf(Object.keys(ImageResizeMode)),
   backfaceVisibility: ReactPropTypes.oneOf(['visible', 'hidden']),
   backgroundColor: ColorPropType,

--- a/Libraries/StyleSheet/StyleSheetTypes.js
+++ b/Libraries/StyleSheet/StyleSheetTypes.js
@@ -90,6 +90,22 @@ export type ____LayoutStyle_Internal = $ReadOnly<{|
 |}>;
 
 export type ____TransformStyle_Internal = $ReadOnly<{|
+  /**
+   * `transform` accepts an array of transformation objects. Each object specifies
+   * the property that will be transformed as the key, and the value to use in the
+   * transformation. Objects should not be combined. Use a single key/value pair
+   * per object.
+   *
+   * The rotate transformations require a string so that the transform may be
+   * expressed in degrees (deg) or radians (rad). For example:
+   *
+   * `transform([{ rotateX: '45deg' }, { rotateZ: '0.785398rad' }])`
+   *
+   * The skew transformations require a string so that the transform may be
+   * expressed in degrees (deg). For example:
+   *
+   * `transform([{ skewX: '45deg' }])`
+   */
   transform?: $ReadOnlyArray<
     | {|+perspective: number | AnimatedNode|}
     | {|+rotate: string | AnimatedNode|}


### PR DESCRIPTION
related #21342

## TODO

move TransformPropTypes.js
fix flow error

## CheckList

- [x] yarn prettier
- [x] yarn flow-check-android
- [x] yarn flow-check-ios

## Test Plan
All flow checks pass.

## Release Notes
[GENERAL] [ENHANCEMENT] [DeprecatedTransformPropTypes.js] - Created.
