### PR TITLE
Move and rename  StyleSheetPropType to DeprecatedStyleSheetPropType

### DIFF
--- a/Libraries/DeprecatedPropTypes/DeprecatedStyleSheetPropType.js
+++ b/Libraries/DeprecatedPropTypes/DeprecatedStyleSheetPropType.js
@@ -13,7 +13,7 @@
 const createStrictShapeTypeChecker = require('createStrictShapeTypeChecker');
 const flattenStyle = require('flattenStyle');
 
-function StyleSheetPropType(shape: {
+function DeprecatedStyleSheetPropType(shape: {
   [key: string]: ReactPropsCheckType,
 }): ReactPropsCheckType {
   const shapePropType = createStrictShapeTypeChecker(shape);
@@ -28,4 +28,4 @@ function StyleSheetPropType(shape: {
   };
 }
 
-module.exports = StyleSheetPropType;
+module.exports = DeprecatedStyleSheetPropType;

--- a/Libraries/DeprecatedPropTypes/DeprecatedViewPropTypes.js
+++ b/Libraries/DeprecatedPropTypes/DeprecatedViewPropTypes.js
@@ -13,7 +13,7 @@
 const DeprecatedEdgeInsetsPropType = require('DeprecatedEdgeInsetsPropType');
 const PlatformViewPropTypes = require('PlatformViewPropTypes');
 const PropTypes = require('prop-types');
-const StyleSheetPropType = require('StyleSheetPropType');
+const DeprecatedStyleSheetPropType = require('DeprecatedStyleSheetPropType');
 const ViewStylePropTypes = require('ViewStylePropTypes');
 
 const {
@@ -23,7 +23,7 @@ const {
   AccessibilityStates,
 } = require('ViewAccessibility');
 
-const stylePropType = StyleSheetPropType(ViewStylePropTypes);
+const stylePropType = DeprecatedStyleSheetPropType(ViewStylePropTypes);
 
 module.exports = {
   /**

--- a/Libraries/Image/Image.android.js
+++ b/Libraries/Image/Image.android.js
@@ -17,7 +17,7 @@ const PropTypes = require('prop-types');
 const React = require('React');
 const ReactNative = require('ReactNative');
 const StyleSheet = require('StyleSheet');
-const StyleSheetPropType = require('StyleSheetPropType');
+const DeprecatedStyleSheetPropType = require('DeprecatedStyleSheetPropType');
 const ImageViewNativeComponent = require('ImageViewNativeComponent');
 const TextAncestor = require('TextAncestor');
 
@@ -38,7 +38,7 @@ function generateRequestId() {
 
 const ImageProps = {
   ...DeprecatedViewPropTypes,
-  style: StyleSheetPropType(ImageStylePropTypes),
+  style: DeprecatedStyleSheetPropType(ImageStylePropTypes),
   /**
    * See https://facebook.github.io/react-native/docs/image.html#source
    */

--- a/Libraries/Image/ImageProps.js
+++ b/Libraries/Image/ImageProps.js
@@ -14,7 +14,7 @@ const DeprecatedEdgeInsetsPropType = require('DeprecatedEdgeInsetsPropType');
 const ImageSourcePropType = require('ImageSourcePropType');
 const ImageStylePropTypes = require('ImageStylePropTypes');
 const PropTypes = require('prop-types');
-const StyleSheetPropType = require('StyleSheetPropType');
+const DeprecatedStyleSheetPropType = require('DeprecatedStyleSheetPropType');
 
 import type {DimensionValue} from 'StyleSheetTypes';
 import type {ViewProps} from 'ViewPropTypes';
@@ -78,7 +78,7 @@ module.exports = {
   /**
    * See https://facebook.github.io/react-native/docs/image.html#style
    */
-  style: StyleSheetPropType(ImageStylePropTypes),
+  style: DeprecatedStyleSheetPropType(ImageStylePropTypes),
   /**
    * The image source (either a remote URL or a local file resource).
    *

--- a/Libraries/Text/TextPropTypes.js
+++ b/Libraries/Text/TextPropTypes.js
@@ -13,10 +13,10 @@
 const DeprecatedColorPropType = require('DeprecatedColorPropType');
 const DeprecatedEdgeInsetsPropType = require('DeprecatedEdgeInsetsPropType');
 const PropTypes = require('prop-types');
-const StyleSheetPropType = require('StyleSheetPropType');
+const DeprecatedStyleSheetPropType = require('DeprecatedStyleSheetPropType');
 const TextStylePropTypes = require('TextStylePropTypes');
 
-const stylePropType = StyleSheetPropType(TextStylePropTypes);
+const stylePropType = DeprecatedStyleSheetPropType(TextStylePropTypes);
 
 module.exports = {
   /**


### PR DESCRIPTION
This PR moves and renames all references of StyleSheetPropType  to DeprecatedStyleSheetPropType
Related to #21342 

Test Plan:
----------
```
yarn flow-check-ios
yarn flow-check-android
yarn prettier
```
- [x] All flow checks pass.

Release Notes:
--------------
[GENERAL] [ENHANCEMENT] [Libraries/DeprecatedPropTypes/DeprecatedStyleSheetPropType.js] - Created.
