### PR TITLE
Quote "$NODE_BINARY" in react-native-xcode.sh

### DIFF
--- a/scripts/react-native-xcode.sh
+++ b/scripts/react-native-xcode.sh
@@ -102,11 +102,11 @@ nodejs_not_found()
   exit 2
 }
 
-type $NODE_BINARY >/dev/null 2>&1 || nodejs_not_found
+type "$NODE_BINARY" >/dev/null 2>&1 || nodejs_not_found
 
 BUNDLE_FILE="$DEST/main.jsbundle"
 
-$NODE_BINARY "$CLI_PATH" $BUNDLE_COMMAND \
+"$NODE_BINARY" "$CLI_PATH" $BUNDLE_COMMAND \
   $CONFIG_ARG \
   --entry-file "$ENTRY_FILE" \
   --platform ios \


### PR DESCRIPTION
Fix build errors when path to $NODE_BINARY contains spaces:

error: Can't find '/Path/With Spaces/To/node' binary to build React Native bundle

Why would $NODE_BINARY contain spaces? In my case, I am using sentry-cli which wraps the NODE_BINARY in it's own executable. The local path to the project, and thus the $NODE_BINARY, contains a space on my GoCD build agent.

'/Users/go/Library/Application Support/Go Agent/pipelines/my-ios-app/node_modules/@sentry/cli/sentry-cli

See https://github.com/getsentry/react-native-sentry/issues/484 https://github.com/getsentry/react-native-sentry/issues/389 

Test Plan:
----------
Rebuild with xcode

Release Notes:
--------------

 [IOS] [BUGFIX] [scripts/react-native-xcode.sh] - Fix build errors when path to $NODE_BINARY contains spaces
