### PR TITLE
SwipeableFlatList, SwipeableQuickActions: Remove PropTypes

### DIFF
--- a/Libraries/Experimental/SwipeableRow/SwipeableFlatList.js
+++ b/Libraries/Experimental/SwipeableRow/SwipeableFlatList.js
@@ -17,23 +17,31 @@ const React = require('React');
 const SwipeableRow = require('SwipeableRow');
 const FlatList = require('FlatList');
 
+// TODO: Make this $ReadOnly and Exact. Will require doing the same to the props in
+//       Libraries/Lists/*
 type SwipableListProps = {
   /**
    * To alert the user that swiping is possible, the first row can bounce
    * on component mount.
    */
   bounceFirstRowOnMount: boolean,
-  // Maximum distance to open to after a swipe
+
+  /**
+   * Maximum distance to open to after a swipe
+   */
   maxSwipeDistance: number | (Object => number),
-  // Callback method to render the view that will be unveiled on swipe
+
+  /**
+   * Callback method to render the view that will be unveiled on swipe
+   */
   renderQuickActions: renderItemType,
 };
 
 type Props<ItemT> = SwipableListProps & FlatListProps<ItemT>;
 
-type State = {
+type State = {|
   openRowKey: ?string,
-};
+|};
 
 /**
  * A container component that renders multiple SwipeableRow's in a FlatList
@@ -53,28 +61,8 @@ type State = {
  */
 
 class SwipeableFlatList<ItemT> extends React.Component<Props<ItemT>, State> {
-  props: Props<ItemT>;
-  state: State;
-
   _flatListRef: ?FlatList<ItemT> = null;
   _shouldBounceFirstRowOnMount: boolean = false;
-
-  static propTypes = {
-    ...FlatList.propTypes,
-
-    /**
-     * To alert the user that swiping is possible, the first row can bounce
-     * on component mount.
-     */
-    bounceFirstRowOnMount: PropTypes.bool.isRequired,
-
-    // Maximum distance to open to after a swipe
-    maxSwipeDistance: PropTypes.oneOfType([PropTypes.number, PropTypes.func])
-      .isRequired,
-
-    // Callback method to render the view that will be unveiled on swipe
-    renderQuickActions: PropTypes.func.isRequired,
-  };
 
   static defaultProps = {
     ...FlatList.defaultProps,

--- a/Libraries/Experimental/SwipeableRow/SwipeableQuickActions.js
+++ b/Libraries/Experimental/SwipeableRow/SwipeableQuickActions.js
@@ -10,10 +10,15 @@
 
 'use strict';
 
-const DeprecatedViewPropTypes = require('DeprecatedViewPropTypes');
 const React = require('React');
 const StyleSheet = require('StyleSheet');
 const View = require('View');
+
+import type {ViewStyleProp} from 'StyleSheet';
+
+type Props = $ReadOnly<{|
+  style?: ?ViewStyleProp,
+|}>;
 
 /**
  * A thin wrapper around standard quick action buttons that can, if the user
@@ -25,11 +30,7 @@ const View = require('View');
  *   <SwipeableQuickActionButton {..props} />
  * </SwipeableQuickActions>
  */
-class SwipeableQuickActions extends React.Component<{style?: $FlowFixMe}> {
-  static propTypes = {
-    style: DeprecatedViewPropTypes.style,
-  };
-
+class SwipeableQuickActions extends React.Component<Props> {
   render(): React.Node {
     // $FlowFixMe found when converting React.createClass to ES6
     const children = this.props.children;


### PR DESCRIPTION
Part of: https://github.com/facebook/react-native/issues/21342

This PR removes the prop types for the components `SwipeableFlatList` and `SwipeableQuickActions`.

The props for `SwipeableFlatList` have been left as not $ReadOnly, because it needs the types in `Libraries/Lists/*` to also be cleaned up. A todo notice has been added.

Test Plan:
----------
Flow checks pass.

Release Notes:
--------------

[GENERAL] [ENHANCEMENT] [Libraries/Experimental/SwipeableRow/SwipeableFlatList.js] - Removed proptypes
[GENERAL] [ENHANCEMENT] [Libraries/Experimental/SwipeableRow/SwipeableQuickActions.js] - Removed proptypes

