### PR TITLE
Resolve protocol http, https when not in lowercase

### DIFF
--- a/Libraries/Linking/Linking.js
+++ b/Libraries/Linking/Linking.js
@@ -57,6 +57,11 @@ class Linking extends NativeEventEmitter {
    * See https://facebook.github.io/react-native/docs/linking.html#openurl
    */
   openURL(url: string): Promise<any> {
+    if (url.toLowerCase().indexOf('https://') == 0) {
+      url = url.replace(url.substr(0, 8), 'https://');
+    } else if (url.toLowerCase().indexOf('http://') == 0) {
+      url = url.replace(url.substr(0, 7), 'https://');
+    }
     this._validateURL(url);
     return LinkingManager.openURL(url);
   }

--- a/Libraries/Linking/Linking.js
+++ b/Libraries/Linking/Linking.js
@@ -57,9 +57,9 @@ class Linking extends NativeEventEmitter {
    * See https://facebook.github.io/react-native/docs/linking.html#openurl
    */
   openURL(url: string): Promise<any> {
-    if (url.toLowerCase().indexOf('https://') == 0) {
+    if (url.toLowerCase().indexOf('https://') === 0) {
       url = url.replace(url.substr(0, 8), 'https://');
-    } else if (url.toLowerCase().indexOf('http://') == 0) {
+    } else if (url.toLowerCase().indexOf('http://') === 0) {
       url = url.replace(url.substr(0, 7), 'https://');
     }
     this._validateURL(url);

--- a/Libraries/Linking/Linking.js
+++ b/Libraries/Linking/Linking.js
@@ -58,6 +58,7 @@ class Linking extends NativeEventEmitter {
    */
   openURL(url: string): Promise<any> {
     // Android Intent requires protocols http and https to be in lowercase.
+    // https:// and http:// works, but Https:// and Http:// doesn't.
     if (url.toLowerCase().startsWith('https://')) {
       url = url.replace(url.substr(0, 8), 'https://');
     } else if (url.toLowerCase().startsWith('http://')) {

--- a/Libraries/Linking/Linking.js
+++ b/Libraries/Linking/Linking.js
@@ -57,10 +57,11 @@ class Linking extends NativeEventEmitter {
    * See https://facebook.github.io/react-native/docs/linking.html#openurl
    */
   openURL(url: string): Promise<any> {
-    if (url.toLowerCase().indexOf('https://') === 0) {
+    // Android Intent requires protocols http and https to be in lowercase.
+    if (url.toLowerCase().startsWith('https://')) {
       url = url.replace(url.substr(0, 8), 'https://');
-    } else if (url.toLowerCase().indexOf('http://') === 0) {
-      url = url.replace(url.substr(0, 7), 'https://');
+    } else if (url.toLowerCase().startsWith('http://')) {
+      url = url.replace(url.substr(0, 7), 'http://');
     }
     this._validateURL(url);
     return LinkingManager.openURL(url);


### PR DESCRIPTION
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
Help us understand your motivation by explaining why you decided to make this change.

If this PR fixes an issue, type "Fixes #issueNumber" to automatically close the issue when the PR is merged.

_Pull requests that expand test coverage are more likely to get reviewed. Add a test case whenever possible!_

Test Plan:
----------
Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!  

I have added to my react native app that has to open URLs with protocols(Https) that have uppercases. Added console log of the url back and forth to test if the url has changed.
You can easily build an react-native app like https://snack.expo.io/@hyunjongl/android-linking-protocol-problem and see if this resolves it.
![image](https://user-images.githubusercontent.com/18255953/46191516-d1c61180-c332-11e8-845e-d1791ee88fd7.png)
This is the screenshot of the console log where I try to open a URL with Https, and the code will automatically change it into https.

Release Notes:
--------------
Fixes #21395
[ANDROID][ENHANCEMENT][Libraries/Linking/Linking.js]
https://snack.expo.io/@hyunjongl/android-linking-protocol-problem   
  
There issue is that when you have a URL with protocol that has an uppercase, it works in iOS, but won't work in Android. (check the Expo above).  
There are a lot of user generated URLs in social platforms, and I bet it is not a good Idea to change what the user have wrote. Also currently I feel like iOS and Android behave differently in this issue which makes me feel bad.  
So, I am suggesting a way to change the protocol['http://', 'https://'] into lowercase just before opening the browser. However, as I am very new to this community, it might not be the best place to add the lines, so comments are very welcome.   

TL;DR Added few lines to change the protocol string to lowercase when some are in uppercase.


<!--
  **INTERNAL and MINOR tagged notes will not be included in the next version's final release notes.**

    CATEGORY
  [----------]      TYPE
  [ CLI      ] [-------------]    LOCATION
  [ DOCS     ] [ BREAKING    ] [-------------]
  [ GENERAL  ] [ BUGFIX      ] [ {Component} ]
  [ INTERNAL ] [ ENHANCEMENT ] [ {Filename}  ]
  [ IOS      ] [ FEATURE     ] [ {Directory} ]   |-----------|
  [ ANDROID  ] [ MINOR       ] [ {Framework} ] - | {Message} |
  [----------] [-------------] [-------------]   |-----------|

 EXAMPLES:

 [IOS] [BREAKING] [FlatList] - Change a thing that breaks other things
 [ANDROID] [BUGFIX] [TextInput] - Did a thing to TextInput
 [CLI] [FEATURE] [local-cli/info/info.js] - CLI easier to do things with
 [DOCS] [BUGFIX] [GettingStarted.md] - Accidentally a thing/word
 [GENERAL] [ENHANCEMENT] [Yoga] - Added new yoga thing/position
 [INTERNAL] [FEATURE] [./scripts] - Added thing to script that nobody will see
-->
