### PR TITLE
[FlowCleanup] Replace DeprecatedViewPropTypes.style for ViewStyleProp on IntegrationTestHarnessTest and InputAccessoryView

### DIFF
--- a/IntegrationTests/IntegrationTestHarnessTest.js
+++ b/IntegrationTests/IntegrationTestHarnessTest.js
@@ -10,28 +10,22 @@
 
 'use strict';
 
-/* $FlowFixMe(>=0.54.0 site=react_native_oss) This comment suppresses an error
- * found when Flow v0.54 was deployed. To see the error delete this comment and
- * run Flow. */
 const requestAnimationFrame = require('fbjs/lib/requestAnimationFrame');
 const React = require('react');
-const PropTypes = require('prop-types');
 const ReactNative = require('react-native');
 const {Text, View} = ReactNative;
 const {TestModule} = ReactNative.NativeModules;
 
-class IntegrationTestHarnessTest extends React.Component<
-  {
-    shouldThrow?: boolean,
-    waitOneFrame?: boolean,
-  },
-  $FlowFixMeState,
-> {
-  static propTypes = {
-    shouldThrow: PropTypes.bool,
-    waitOneFrame: PropTypes.bool,
-  };
+type Props = $ReadOnly<{|
+  shouldThrow?: boolean,
+  waitOneFrame?: boolean,
+|}>;
 
+type State = {|
+  done: boolean,
+|};
+
+class IntegrationTestHarnessTest extends React.Component<Props, State> {
   state = {
     done: false,
   };

--- a/IntegrationTests/IntegrationTestHarnessTest.js
+++ b/IntegrationTests/IntegrationTestHarnessTest.js
@@ -17,8 +17,8 @@ const {Text, View} = ReactNative;
 const {TestModule} = ReactNative.NativeModules;
 
 type Props = $ReadOnly<{|
-  shouldThrow?: boolean,
-  waitOneFrame?: boolean,
+  shouldThrow?: ?boolean,
+  waitOneFrame?: ?boolean,
 |}>;
 
 type State = {|

--- a/Libraries/Components/TextInput/InputAccessoryView.js
+++ b/Libraries/Components/TextInput/InputAccessoryView.js
@@ -84,9 +84,9 @@ type Props = $ReadOnly<{|
    * An ID which is used to associate this `InputAccessoryView` to
    * specified TextInput(s).
    */
-  nativeID?: string,
-  style?: ViewStyleProp,
-  backgroundColor?: DeprecatedColorPropType,
+  nativeID?: ?string,
+  style?: ?ViewStyleProp,
+  backgroundColor?: ?DeprecatedColorPropType,
 |}>;
 
 class InputAccessoryView extends React.Component<Props> {

--- a/Libraries/Components/TextInput/InputAccessoryView.js
+++ b/Libraries/Components/TextInput/InputAccessoryView.js
@@ -10,7 +10,6 @@
 'use strict';
 
 const DeprecatedColorPropType = require('DeprecatedColorPropType');
-const DeprecatedViewPropTypes = require('DeprecatedViewPropTypes');
 const Platform = require('Platform');
 const React = require('React');
 const StyleSheet = require('StyleSheet');
@@ -18,6 +17,8 @@ const StyleSheet = require('StyleSheet');
 const requireNativeComponent = require('requireNativeComponent');
 
 const RCTInputAccessoryView = requireNativeComponent('RCTInputAccessoryView');
+
+import type {ViewStyleProp} from 'StyleSheet';
 
 /**
  * Note: iOS only
@@ -77,16 +78,16 @@ const RCTInputAccessoryView = requireNativeComponent('RCTInputAccessoryView');
  * For an example, look at InputAccessoryViewExample.js in RNTester.
  */
 
-type Props = {
+type Props = $ReadOnly<{|
   +children: React.Node,
   /**
    * An ID which is used to associate this `InputAccessoryView` to
    * specified TextInput(s).
    */
   nativeID?: string,
-  style?: DeprecatedViewPropTypes.style,
+  style?: ViewStyleProp,
   backgroundColor?: DeprecatedColorPropType,
-};
+|}>;
 
 class InputAccessoryView extends React.Component<Props> {
   render(): React.Node {


### PR DESCRIPTION
related #21342

Test Plan:
----------

- [x] yarn prettier
- [x] yarn flow-check-android
- [x] yarn flow-check-ios

Release Notes:
--------------
[GENERAL] [ENHANCEMENT] [InputAccessoryView.js] Replace DeprecatedViewPropTypes.style for ViewStyleProp
[GENERAL] [ENHANCEMENT] [IntegrationTestHarnessTest.js] Replace PropTypes
<!--
  **INTERNAL and MINOR tagged notes will not be included in the next version's final release notes.**

    CATEGORY
  [----------]      TYPE
  [ CLI      ] [-------------]    LOCATION
  [ DOCS     ] [ BREAKING    ] [-------------]
  [ GENERAL  ] [ BUGFIX      ] [ {Component} ]
  [ INTERNAL ] [ ENHANCEMENT ] [ {Filename}  ]
  [ IOS      ] [ FEATURE     ] [ {Directory} ]   |-----------|
  [ ANDROID  ] [ MINOR       ] [ {Framework} ] - | {Message} |
  [----------] [-------------] [-------------]   |-----------|

 EXAMPLES:

 [IOS] [BREAKING] [FlatList] - Change a thing that breaks other things
 [ANDROID] [BUGFIX] [TextInput] - Did a thing to TextInput
 [CLI] [FEATURE] [local-cli/info/info.js] - CLI easier to do things with
 [DOCS] [BUGFIX] [GettingStarted.md] - Accidentally a thing/word
 [GENERAL] [ENHANCEMENT] [Yoga] - Added new yoga thing/position
 [INTERNAL] [FEATURE] [./scripts] - Added thing to script that nobody will see
-->
