### PR TITLE
Expose a getter for overflow setting in ReactViewGroup

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
@@ -644,7 +644,7 @@ public class ReactViewGroup extends ViewGroup implements
     invalidate();
   }
 
-  public String getOverflow() {
+  public @Nullable String getOverflow() {
     return mOverflow;
   }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
@@ -644,6 +644,10 @@ public class ReactViewGroup extends ViewGroup implements
     invalidate();
   }
 
+  public String getOverflow() {
+    return mOverflow;
+  }
+
   /**
    * Set the background for the view or remove the background. It calls {@link
    * #setBackground(Drawable)} or {@link #setBackgroundDrawable(Drawable)} based on the sdk version.


### PR DESCRIPTION
This change adds getter for overflow attribute in ReactViewGroup class. Overflow setting can affect how view children are drawn but also how hit testing behaves when receiving touch. Exposing this setting makes it possible for gesture-handler library to implement proper hit testing that takes into account overflow property of a view.

Test Plan:
----------
This change only adds a getter function that will be used by external libraries. 

Release Notes:
--------------
[ANDROID] [MINOR] [ReactViewGroup] - Expose a getter for overflow setting in ReactViewGroup