### PR TITLE
Add workaround for Android Gradle Plugin 3.2 change to asset dir

### DIFF
--- a/react.gradle
+++ b/react.gradle
@@ -125,6 +125,11 @@ afterEvaluate {
             from jsBundleDir
             into file(config."jsBundleDir${targetName}" ?:
                 "$buildDir/intermediates/assets/${targetPath}")
+                
+            // Workaround for Android Gradle Plugin 3.2+ new asset directory
+            from jsBundleDir
+            into file(config."jsBundleDir${targetName}" ?:
+                "$buildDir/intermediates/merged_assets/${targetPath}/merge${targetName}Assets/out")
 
             // mergeAssets must run first, as it clears the intermediates directory
             dependsOn(variant.mergeAssets)


### PR DESCRIPTION
Android Gradle Plugin 3.2 uses a new intermediates/merged_assets directory instead of intermediates/assets. This workaround copies the javascript bundle to both directories for compatibility purposes.

Fixes #21132
Fixes #18357 

Test Plan:
----------
Build and run release variant of react-native hello world with Android Studio 3.2, observe that javascript bundle exists in built apk.

Release Notes:
--------------
[ANDROID] [BUGFIX] [react.gradle] - Make asset generation compatible with Android Gradle plugin 3.2 and later.
