### PR TITLE
Add workaround for Android Gradle Plugin 3.2 change to asset dir

### DIFF
--- a/react.gradle
+++ b/react.gradle
@@ -122,9 +122,20 @@ afterEvaluate {
             group = "react"
             description = "copy bundled JS into ${targetName}."
 
-            from jsBundleDir
-            into file(config."jsBundleDir${targetName}" ?:
-                "$buildDir/intermediates/assets/${targetPath}")
+            if (config."jsBundleDir${targetName}") {
+                from jsBundleDir
+                into file(config."jsBundleDir${targetName}")
+            } else {
+                into ("$buildDir/intermediates")
+                into ("assets/${targetPath}") {
+                    from jsBundleDir
+                }
+
+                // Workaround for Android Gradle Plugin 3.2+ new asset directory
+                into ("merged_assets/${targetPath}/merge${targetName}Assets/out") {
+                    from jsBundleDir
+                }
+            }
 
             // mergeAssets must run first, as it clears the intermediates directory
             dependsOn(variant.mergeAssets)


### PR DESCRIPTION
Android Gradle Plugin 3.2 uses a new intermediates/merged_assets directory instead of intermediates/assets. This workaround copies the javascript bundle to both directories for compatibility purposes.

Fixes #21132 
Fixes #18357 

Test Plan:
----------
Build and run release variant of react-native hello world with Android Studio 3.1.4 and 3.2 with and without jsBundleDirDebug set, observe that javascript bundle exists in built apk.

Release Notes:
--------------
Help reviewers and the release process by writing your own release notes. See below for an example.

[ANDROID] [BUGFIX] [react.gradle] - Make asset generation compatible with Android Gradle plugin 3.2 and later.