### PR TITLE
Fixed issue #20112

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/modules/camera/CameraRollManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/camera/CameraRollManager.java
@@ -443,7 +443,7 @@ public class CameraRollManager extends ReactContextBaseJavaModule {
           retriever.release();
           photoDescriptor.close();
         }
-      } catch (IOException e) {
+      } catch (Exception e) {
         FLog.e(ReactConstants.TAG, "Could not get video metadata for " + photoUri.toString(), e);
         return false;
       }


### PR DESCRIPTION
Changed catching IOException to Exception
Fixed issue #20112

### Test Plan:
This change will fix issue #20112. 
Try download broken video (attached to issue #20112) and open on your Android device. In production build it will crash the app, on dev - you'll see the red screen with error "setDataSource failed: status - 0x80000000".
Expected behavior: broken video just will be ignored.

### Release Notes:
[ANDROID] [BUGFIX][ReactAndroid/src/main/java/com/facebook/react/modules/camera/CameraRollManager.java] - Changed catching IOException to Exception. Fixed error "setDataSource failed: status - 0x80000000"