### PR TITLE
Rename and move ViewStylePropTypes

### DIFF
--- a/Libraries/Animated/src/createAnimatedComponent.js
+++ b/Libraries/Animated/src/createAnimatedComponent.js
@@ -12,7 +12,7 @@
 const {AnimatedEvent} = require('./AnimatedEvent');
 const AnimatedProps = require('./nodes/AnimatedProps');
 const React = require('React');
-const ViewStylePropTypes = require('ViewStylePropTypes');
+const DeprecatedViewStylePropTypes = require('DeprecatedViewStylePropTypes');
 
 const invariant = require('fbjs/lib/invariant');
 
@@ -184,7 +184,7 @@ function createAnimatedComponent(Component: any): any {
         return;
       }
 
-      for (const key in ViewStylePropTypes) {
+      for (const key in DeprecatedViewStylePropTypes) {
         if (!propTypes[key] && props[key] !== undefined) {
           console.warn(
             'You are setting the style `{ ' +

--- a/Libraries/Components/Slider/Slider.js
+++ b/Libraries/Components/Slider/Slider.js
@@ -66,7 +66,7 @@ type Props = $ReadOnly<{|
 
   /**
    * Used to style and layout the `Slider`.  See `StyleSheet.js` and
-   * `ViewStylePropTypes.js` for more info.
+   * `DeprecatedViewStylePropTypes.js` for more info.
    */
   style?: ?ViewStyleProp,
 

--- a/Libraries/Components/View/ReactNativeStyleAttributes.js
+++ b/Libraries/Components/View/ReactNativeStyleAttributes.js
@@ -12,7 +12,7 @@
 
 const DeprecatedImageStylePropTypes = require('DeprecatedImageStylePropTypes');
 const TextStylePropTypes = require('TextStylePropTypes');
-const ViewStylePropTypes = require('ViewStylePropTypes');
+const DeprecatedViewStylePropTypes = require('DeprecatedViewStylePropTypes');
 
 const processColor = require('processColor');
 const processTransform = require('processTransform');
@@ -21,7 +21,7 @@ const sizesDiffer = require('sizesDiffer');
 const ReactNativeStyleAttributes = {};
 
 for (const attributeName of Object.keys({
-  ...ViewStylePropTypes,
+  ...DeprecatedViewStylePropTypes,
   ...TextStylePropTypes,
   ...DeprecatedImageStylePropTypes,
 })) {

--- a/Libraries/DeprecatedPropTypes/DeprecatedViewPropTypes.js
+++ b/Libraries/DeprecatedPropTypes/DeprecatedViewPropTypes.js
@@ -14,7 +14,7 @@ const DeprecatedEdgeInsetsPropType = require('DeprecatedEdgeInsetsPropType');
 const PlatformViewPropTypes = require('PlatformViewPropTypes');
 const PropTypes = require('prop-types');
 const DeprecatedStyleSheetPropType = require('DeprecatedStyleSheetPropType');
-const ViewStylePropTypes = require('ViewStylePropTypes');
+const DeprecatedViewStylePropTypes = require('DeprecatedViewStylePropTypes');
 
 const {
   AccessibilityComponentTypes,
@@ -23,7 +23,9 @@ const {
   AccessibilityStates,
 } = require('ViewAccessibility');
 
-const stylePropType = DeprecatedStyleSheetPropType(ViewStylePropTypes);
+const stylePropType = DeprecatedStyleSheetPropType(
+  DeprecatedViewStylePropTypes,
+);
 
 module.exports = {
   /**

--- a/Libraries/DeprecatedPropTypes/DeprecatedViewStylePropTypes.js
+++ b/Libraries/DeprecatedPropTypes/DeprecatedViewStylePropTypes.js
@@ -19,7 +19,7 @@ const DeprecatedTransformPropTypes = require('DeprecatedTransformPropTypes');
 /**
  * Warning: Some of these properties may not be supported in all releases.
  */
-const ViewStylePropTypes = {
+const DeprecatedViewStylePropTypes = {
   ...LayoutPropTypes,
   ...DeprecatedShadowPropTypesIOS,
   ...DeprecatedTransformPropTypes,
@@ -58,4 +58,4 @@ const ViewStylePropTypes = {
   elevation: ReactPropTypes.number,
 };
 
-module.exports = ViewStylePropTypes;
+module.exports = DeprecatedViewStylePropTypes;

--- a/Libraries/StyleSheet/StyleSheetValidation.js
+++ b/Libraries/StyleSheet/StyleSheetValidation.js
@@ -12,7 +12,7 @@
 
 const DeprecatedImageStylePropTypes = require('DeprecatedImageStylePropTypes');
 const TextStylePropTypes = require('TextStylePropTypes');
-const ViewStylePropTypes = require('ViewStylePropTypes');
+const DeprecatedViewStylePropTypes = require('DeprecatedViewStylePropTypes');
 
 const invariant = require('fbjs/lib/invariant');
 
@@ -87,7 +87,7 @@ const allStylePropTypes = {};
 if (__DEV__ && !global.__RCTProfileIsProfiling) {
   StyleSheetValidation.addValidStylePropTypes(DeprecatedImageStylePropTypes);
   StyleSheetValidation.addValidStylePropTypes(TextStylePropTypes);
-  StyleSheetValidation.addValidStylePropTypes(ViewStylePropTypes);
+  StyleSheetValidation.addValidStylePropTypes(DeprecatedViewStylePropTypes);
 }
 
 module.exports = StyleSheetValidation;

--- a/Libraries/Text/TextStylePropTypes.js
+++ b/Libraries/Text/TextStylePropTypes.js
@@ -12,10 +12,10 @@
 
 const DeprecatedColorPropType = require('DeprecatedColorPropType');
 const ReactPropTypes = require('prop-types');
-const ViewStylePropTypes = require('ViewStylePropTypes');
+const DeprecatedViewStylePropTypes = require('DeprecatedViewStylePropTypes');
 
 const TextStylePropTypes = {
-  ...ViewStylePropTypes,
+  ...DeprecatedViewStylePropTypes,
 
   color: DeprecatedColorPropType,
   fontFamily: ReactPropTypes.string,


### PR DESCRIPTION
Related to #21342
* Renamed ViewStyleProps to DeprecatedViewStyleProps.
* Moved propType declaration to `react-native/Libraries/DeprecatedPropTypes`
*  ImageProps.js: moved propType declarations to DeprecatedImageProps.js.

Test Plan:
--------------
Ran the following scripts with no errors:

* `npm run prettier`
* `npm run flow-check-ios`
* `npm run flow-check-android`

Release Notes:
--------------
[GENERAL] [ENHANCEMENT] [Libraries/Components/View/ViewStyleProps.js] - remove
[GENERAL] [ENHANCEMENT] [Libraries/DeprecatedPropTypes/DeprecatedViewStylePropTypes.js] - created
[GENERAL] [ENHANCEMENT] [Libraries/Animated/src/createAnimatedComponent.js] - renamed ViewStyleProps to DeprecatedViewStyleProps
[GENERAL] [ENHANCEMENT] [Libraries/Components/Slider/Slider.js] - renamed ViewStyleProps to DeprecatedViewStyleProps
[GENERAL] [ENHANCEMENT] [Libraries/Components/View/ReactNativeStyleAttributes.js] - renamed ViewStyleProps to DeprecatedViewStyleProps
[GENERAL] [ENHANCEMENT] [Libraries/DeprecatedPropTypes/DeprecatedViewPropTypes.js] - renamed ViewStyleProps to DeprecatedViewStyleProps
[GENERAL] [ENHANCEMENT] [Libraries/StyleSheet/StyleSheetValidation.js] - renamed ViewStyleProps to DeprecatedViewStyleProps
[GENERAL] [ENHANCEMENT] [Libraries/Text/TextStylePropTypes.js] - renamed ViewStyleProps to DeprecatedViewStyleProps