### PR TITLE
[FlowCleanup] Split ViewAccessibility into DeprecatedViewAccessibility and rename r…

### DIFF
--- a/Libraries/Components/Touchable/TouchableWithoutFeedback.js
+++ b/Libraries/Components/Touchable/TouchableWithoutFeedback.js
@@ -21,19 +21,19 @@ const createReactClass = require('create-react-class');
 const ensurePositiveDelayProps = require('ensurePositiveDelayProps');
 
 const {
-  AccessibilityComponentTypes,
-  AccessibilityRoles,
-  AccessibilityStates,
-  AccessibilityTraits,
-} = require('ViewAccessibility');
+  DeprecatedAccessibilityComponentTypes,
+  DeprecatedAccessibilityRoles,
+  DeprecatedAccessibilityStates,
+  DeprecatedAccessibilityTraits,
+} = require('DeprecatedViewAccessibility');
 
 import type {PressEvent} from 'CoreEventTypes';
 import type {EdgeInsetsProp} from 'EdgeInsetsPropType';
 import type {
   AccessibilityComponentType,
   AccessibilityRole,
-  AccessibilityStates as AccessibilityStatesFlow,
-  AccessibilityTraits as AccessibilityTraitsFlow,
+  AccessibilityStates,
+  AccessibilityTraits,
 } from 'ViewAccessibility';
 
 const PRESS_RETENTION_OFFSET = {top: 20, left: 20, right: 20, bottom: 30};
@@ -50,8 +50,8 @@ export type Props = $ReadOnly<{|
   accessibilityHint?: ?Stringish,
   accessibilityIgnoresInvertColors?: ?boolean,
   accessibilityRole?: ?AccessibilityRole,
-  accessibilityStates?: ?AccessibilityStatesFlow,
-  accessibilityTraits?: ?AccessibilityTraitsFlow,
+  accessibilityStates?: ?AccessibilityStates,
+  accessibilityTraits?: ?AccessibilityTraits,
   children?: ?React.Node,
   delayLongPress?: ?number,
   delayPressIn?: ?number,
@@ -84,14 +84,16 @@ const TouchableWithoutFeedback = ((createReactClass({
     accessible: PropTypes.bool,
     accessibilityLabel: PropTypes.node,
     accessibilityHint: PropTypes.string,
-    accessibilityComponentType: PropTypes.oneOf(AccessibilityComponentTypes),
-    accessibilityRole: PropTypes.oneOf(AccessibilityRoles),
+    accessibilityComponentType: PropTypes.oneOf(
+      DeprecatedAccessibilityComponentTypes,
+    ),
+    accessibilityRole: PropTypes.oneOf(DeprecatedAccessibilityRoles),
     accessibilityStates: PropTypes.arrayOf(
-      PropTypes.oneOf(AccessibilityStates),
+      PropTypes.oneOf(DeprecatedAccessibilityStates),
     ),
     accessibilityTraits: PropTypes.oneOfType([
-      PropTypes.oneOf(AccessibilityTraits),
-      PropTypes.arrayOf(PropTypes.oneOf(AccessibilityTraits)),
+      PropTypes.oneOf(DeprecatedAccessibilityTraits),
+      PropTypes.arrayOf(PropTypes.oneOf(DeprecatedAccessibilityTraits)),
     ]),
     /**
      * When `accessible` is true (which is the default) this may be called when

--- a/Libraries/Components/View/ViewAccessibility.js
+++ b/Libraries/Components/View/ViewAccessibility.js
@@ -39,6 +39,7 @@ export type AccessibilityComponentType =
   | 'radiobutton_checked'
   | 'radiobutton_unchecked';
 
+// This must be kept in sync with the AccessibilityRolesMask in RCTViewManager.m
 export type AccessibilityRole =
   | 'none'
   | 'button'
@@ -52,48 +53,5 @@ export type AccessibilityRole =
   | 'header'
   | 'summary';
 
+// This must be kept in sync with the AccessibilityStatesMask in RCTViewManager.m
 export type AccessibilityStates = $ReadOnlyArray<'disabled' | 'selected'>;
-
-module.exports = {
-  AccessibilityTraits: [
-    'none',
-    'button',
-    'link',
-    'header',
-    'search',
-    'image',
-    'selected',
-    'plays',
-    'key',
-    'text',
-    'summary',
-    'disabled',
-    'frequentUpdates',
-    'startsMedia',
-    'adjustable',
-    'allowsDirectInteraction',
-    'pageTurn',
-  ],
-  AccessibilityComponentTypes: [
-    'none',
-    'button',
-    'radiobutton_checked',
-    'radiobutton_unchecked',
-  ],
-  // This must be kept in sync with the AccessibilityRolesMask in RCTViewManager.m
-  AccessibilityRoles: [
-    'none',
-    'button',
-    'link',
-    'search',
-    'image',
-    'keyboardkey',
-    'text',
-    'adjustable',
-    'imagebutton',
-    'header',
-    'summary',
-  ],
-  // This must be kept in sync with the AccessibilityStatesMask in RCTViewManager.m
-  AccessibilityStates: ['selected', 'disabled'],
-};

--- a/Libraries/DeprecatedPropTypes/DeprecatedViewAccessibility.js
+++ b/Libraries/DeprecatedPropTypes/DeprecatedViewAccessibility.js
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow strict
+ */
+
+'use strict';
+
+module.exports = {
+  DeprecatedAccessibilityTraits: [
+    'none',
+    'button',
+    'link',
+    'header',
+    'search',
+    'image',
+    'selected',
+    'plays',
+    'key',
+    'text',
+    'summary',
+    'disabled',
+    'frequentUpdates',
+    'startsMedia',
+    'adjustable',
+    'allowsDirectInteraction',
+    'pageTurn',
+  ],
+  DeprecatedAccessibilityComponentTypes: [
+    'none',
+    'button',
+    'radiobutton_checked',
+    'radiobutton_unchecked',
+  ],
+  // This must be kept in sync with the AccessibilityRolesMask in RCTViewManager.m
+  DeprecatedAccessibilityRoles: [
+    'none',
+    'button',
+    'link',
+    'search',
+    'image',
+    'keyboardkey',
+    'text',
+    'adjustable',
+    'imagebutton',
+    'header',
+    'summary',
+  ],
+  // This must be kept in sync with the AccessibilityStatesMask in RCTViewManager.m
+  DeprecatedAccessibilityStates: ['selected', 'disabled'],
+};

--- a/Libraries/DeprecatedPropTypes/DeprecatedViewPropTypes.js
+++ b/Libraries/DeprecatedPropTypes/DeprecatedViewPropTypes.js
@@ -17,11 +17,11 @@ const DeprecatedStyleSheetPropType = require('DeprecatedStyleSheetPropType');
 const ViewStylePropTypes = require('ViewStylePropTypes');
 
 const {
-  AccessibilityComponentTypes,
-  AccessibilityTraits,
-  AccessibilityRoles,
-  AccessibilityStates,
-} = require('ViewAccessibility');
+  DeprecatedAccessibilityComponentTypes,
+  DeprecatedAccessibilityTraits,
+  DeprecatedAccessibilityRoles,
+  DeprecatedAccessibilityStates,
+} = require('DeprecatedViewAccessibility');
 
 const stylePropType = DeprecatedStyleSheetPropType(ViewStylePropTypes);
 
@@ -75,17 +75,21 @@ module.exports = {
    *
    * See http://facebook.github.io/react-native/docs/view.html#accessibilitycomponenttype
    */
-  accessibilityComponentType: PropTypes.oneOf(AccessibilityComponentTypes),
+  accessibilityComponentType: PropTypes.oneOf(
+    DeprecatedAccessibilityComponentTypes,
+  ),
 
   /**
    * Indicates to accessibility services to treat UI component like a specific role.
    */
-  accessibilityRole: PropTypes.oneOf(AccessibilityRoles),
+  accessibilityRole: PropTypes.oneOf(DeprecatedAccessibilityRoles),
 
   /**
    * Indicates to accessibility services that UI Component is in a specific State.
    */
-  accessibilityStates: PropTypes.arrayOf(PropTypes.oneOf(AccessibilityStates)),
+  accessibilityStates: PropTypes.arrayOf(
+    PropTypes.oneOf(DeprecatedAccessibilityStates),
+  ),
   /**
    * Indicates to accessibility services whether the user should be notified
    * when this view changes. Works for Android API >= 19 only.
@@ -123,8 +127,8 @@ module.exports = {
    * See http://facebook.github.io/react-native/docs/view.html#accessibilitytraits
    */
   accessibilityTraits: PropTypes.oneOfType([
-    PropTypes.oneOf(AccessibilityTraits),
-    PropTypes.arrayOf(PropTypes.oneOf(AccessibilityTraits)),
+    PropTypes.oneOf(DeprecatedAccessibilityTraits),
+    PropTypes.arrayOf(PropTypes.oneOf(DeprecatedAccessibilityTraits)),
   ]),
 
   /**

--- a/React/Views/RCTViewManager.m
+++ b/React/Views/RCTViewManager.m
@@ -151,7 +151,7 @@ RCT_CUSTOM_VIEW_PROPERTY(transform, CATransform3D, RCTView)
 
 RCT_CUSTOM_VIEW_PROPERTY(accessibilityRole, UIAccessibilityTraits, RCTView)
 {
-  // This mask must be kept in sync with the AccessibilityRoles enum defined in ViewAccessibility.js
+  // This mask must be kept in sync with the AccessibilityRoles enum defined in ViewAccessibility.js and DeprecatedViewAccessibility.js
   const UIAccessibilityTraits AccessibilityRolesMask = UIAccessibilityTraitNone | UIAccessibilityTraitButton | UIAccessibilityTraitLink | UIAccessibilityTraitSearchField | UIAccessibilityTraitImage | UIAccessibilityTraitKeyboardKey | UIAccessibilityTraitStaticText | UIAccessibilityTraitAdjustable | UIAccessibilityTraitHeader | UIAccessibilityTraitSummaryElement;
 
   UIAccessibilityTraits newTraits = json ? [RCTConvert UIAccessibilityTraits:json] : defaultView.accessibilityTraits;
@@ -161,7 +161,7 @@ RCT_CUSTOM_VIEW_PROPERTY(accessibilityRole, UIAccessibilityTraits, RCTView)
 
 RCT_CUSTOM_VIEW_PROPERTY(accessibilityStates, UIAccessibilityTraits, RCTView)
 {
-  // This mask must be kept in sync with the AccessibilityStates enum defined in ViewAccessibility.js
+  // This mask must be kept in sync with the AccessibilityStates enum defined in ViewAccessibility.js and DeprecatedViewAccessibility.js
   const UIAccessibilityTraits AccessibilityStatesMask = UIAccessibilityTraitNotEnabled | UIAccessibilityTraitSelected;
 
   UIAccessibilityTraits newTraits = json ? [RCTConvert UIAccessibilityTraits:json] : defaultView.accessibilityTraits;


### PR DESCRIPTION
This PR splits and renames all references of ViewAccessibility to DeprecatedViewAccessibility 
Related to #21342

Test Plan:
---------------------------------------------------
```
yarn flow-check-ios
yarn flow-check-android
yarn prettier
```
- [X] All flow checks pass.


Release Notes:
--------------------------------------------
[GENERAL] [ENHANCEMENT] [Libraries/DeprecatedPropTypes/DeprecatedViewAccessibility.js] - Created
[GENERAL] [ENHANCEMENT] [ViewAccessibility.js] - Only flow types.