### PR TITLE
[CI] Update path to code analysis script

### DIFF
--- a/scripts/circleci/analyze_scripts.sh
+++ b/scripts/circleci/analyze_scripts.sh
@@ -8,7 +8,7 @@ IFS=$'\n'
 
 results=( "$(find . -type f -not -path "*node_modules*" -not -path "*third-party*" -name '*.sh' -exec sh -c  'shellcheck "$1" -f json' -- {} \;)" )
 
-cat <(echo shellcheck; printf '%s\n' "${results[@]}" | jq .,[] | jq -s . | jq --compact-output --raw-output '[ (.[] | .[] | . ) ]') | node bots/code-analysis-bot.js
+cat <(echo shellcheck; printf '%s\n' "${results[@]}" | jq .,[] | jq -s . | jq --compact-output --raw-output '[ (.[] | .[] | . ) ]') | node scripts/circleci/code-analysis-bot.js
 
 # check status
 STATUS=$?


### PR DESCRIPTION
The script was moved after the original ShellCheck PR was opened, and this was lost during the rebase.