### PR TITLE
iOS: Support inline view truncation

### DIFF
--- a/Libraries/Text/Text/RCTTextShadowView.m
+++ b/Libraries/Text/Text/RCTTextShadowView.m
@@ -290,6 +290,9 @@
         RCTRoundPixelValue(attachmentSize.width),
         RCTRoundPixelValue(attachmentSize.height)
       }};
+      
+      NSRange truncatedGlyphRange = [layoutManager truncatedGlyphRangeInLineFragmentForGlyphAtIndex:range.location];
+      BOOL viewIsTruncated = NSIntersectionRange(range, truncatedGlyphRange).length != 0;
 
       RCTLayoutContext localLayoutContext = layoutContext;
       localLayoutContext.absolutePosition.x += frame.origin.x;
@@ -300,9 +303,9 @@
                         layoutDirection:self.layoutMetrics.layoutDirection
                           layoutContext:localLayoutContext];
 
-      // Reinforcing a proper frame origin for the Shadow View.
       RCTLayoutMetrics localLayoutMetrics = shadowView.layoutMetrics;
-      localLayoutMetrics.frame.origin = frame.origin;
+      localLayoutMetrics.frame.origin = frame.origin; // Reinforcing a proper frame origin for the Shadow View.
+      localLayoutMetrics.isHiddenDueToClipping = viewIsTruncated;
       [shadowView layoutWithMetrics:localLayoutMetrics layoutContext:localLayoutContext];
     }
   ];

--- a/Libraries/Text/Text/RCTTextShadowView.m
+++ b/Libraries/Text/Text/RCTTextShadowView.m
@@ -305,7 +305,9 @@
 
       RCTLayoutMetrics localLayoutMetrics = shadowView.layoutMetrics;
       localLayoutMetrics.frame.origin = frame.origin; // Reinforcing a proper frame origin for the Shadow View.
-      localLayoutMetrics.isHiddenDueToClipping = viewIsTruncated;
+      if (viewIsTruncated) {
+        localLayoutMetrics.displayType = RCTDisplayTypeNone;
+      }
       [shadowView layoutWithMetrics:localLayoutMetrics layoutContext:localLayoutContext];
     }
   ];

--- a/React/Modules/RCTUIManager.m
+++ b/React/Modules/RCTUIManager.m
@@ -488,6 +488,7 @@ static NSDictionary *deviceOrientationEventBody(UIDeviceOrientation orientation)
     UIUserInterfaceLayoutDirection layoutDirection;
     BOOL isNew;
     BOOL parentIsNew;
+    BOOL isHiddenDueToClipping;
   } RCTFrameData;
 
   // Construct arrays then hand off to main thread
@@ -505,6 +506,7 @@ static NSDictionary *deviceOrientationEventBody(UIDeviceOrientation orientation)
         layoutMetrics.layoutDirection,
         shadowView.isNewView,
         shadowView.superview.isNewView,
+        layoutMetrics.isHiddenDueToClipping
       };
     }
   }
@@ -566,6 +568,7 @@ static NSDictionary *deviceOrientationEventBody(UIDeviceOrientation orientation)
       RCTLayoutAnimation *updatingLayoutAnimation = isNew ? nil : layoutAnimationGroup.updatingLayoutAnimation;
       BOOL shouldAnimateCreation = isNew && !frameData.parentIsNew;
       RCTLayoutAnimation *creatingLayoutAnimation = shouldAnimateCreation ? layoutAnimationGroup.creatingLayoutAnimation : nil;
+      BOOL isHiddenDueToClipping = frameData.isHiddenDueToClipping;
 
       void (^completion)(BOOL) = ^(BOOL finished) {
         completionsCalled++;
@@ -580,6 +583,10 @@ static NSDictionary *deviceOrientationEventBody(UIDeviceOrientation orientation)
 
       if (view.reactLayoutDirection != layoutDirection) {
         view.reactLayoutDirection = layoutDirection;
+      }
+      
+      if (view.isHidden != isHiddenDueToClipping) {
+        view.hidden = isHiddenDueToClipping;
       }
 
       if (creatingLayoutAnimation) {

--- a/React/Modules/RCTUIManager.m
+++ b/React/Modules/RCTUIManager.m
@@ -488,7 +488,7 @@ static NSDictionary *deviceOrientationEventBody(UIDeviceOrientation orientation)
     UIUserInterfaceLayoutDirection layoutDirection;
     BOOL isNew;
     BOOL parentIsNew;
-    BOOL isHiddenDueToClipping;
+    RCTDisplayType displayType;
   } RCTFrameData;
 
   // Construct arrays then hand off to main thread
@@ -506,7 +506,7 @@ static NSDictionary *deviceOrientationEventBody(UIDeviceOrientation orientation)
         layoutMetrics.layoutDirection,
         shadowView.isNewView,
         shadowView.superview.isNewView,
-        layoutMetrics.isHiddenDueToClipping
+        layoutMetrics.displayType
       };
     }
   }
@@ -568,7 +568,7 @@ static NSDictionary *deviceOrientationEventBody(UIDeviceOrientation orientation)
       RCTLayoutAnimation *updatingLayoutAnimation = isNew ? nil : layoutAnimationGroup.updatingLayoutAnimation;
       BOOL shouldAnimateCreation = isNew && !frameData.parentIsNew;
       RCTLayoutAnimation *creatingLayoutAnimation = shouldAnimateCreation ? layoutAnimationGroup.creatingLayoutAnimation : nil;
-      BOOL isHiddenDueToClipping = frameData.isHiddenDueToClipping;
+      BOOL isHidden = frameData.displayType == RCTDisplayTypeNone;
 
       void (^completion)(BOOL) = ^(BOOL finished) {
         completionsCalled++;
@@ -585,8 +585,8 @@ static NSDictionary *deviceOrientationEventBody(UIDeviceOrientation orientation)
         view.reactLayoutDirection = layoutDirection;
       }
       
-      if (view.isHidden != isHiddenDueToClipping) {
-        view.hidden = isHiddenDueToClipping;
+      if (view.isHidden != isHidden) {
+        view.hidden = isHidden;
       }
 
       if (creatingLayoutAnimation) {

--- a/React/Views/RCTLayout.h
+++ b/React/Views/RCTLayout.h
@@ -26,7 +26,6 @@ struct RCTLayoutMetrics {
   UIEdgeInsets borderWidth;
   RCTDisplayType displayType;
   UIUserInterfaceLayoutDirection layoutDirection;
-  BOOL isHiddenDueToClipping;
 };
 typedef struct CG_BOXABLE RCTLayoutMetrics RCTLayoutMetrics;
 
@@ -44,8 +43,7 @@ static inline BOOL RCTLayoutMetricsEqualToLayoutMetrics(RCTLayoutMetrics a, RCTL
     CGRectEqualToRect(a.contentFrame, b.contentFrame) &&
     UIEdgeInsetsEqualToEdgeInsets(a.borderWidth, b.borderWidth) &&
     a.displayType == b.displayType &&
-    a.layoutDirection == b.layoutDirection &&
-    a.isHiddenDueToClipping == b.isHiddenDueToClipping;
+    a.layoutDirection == b.layoutDirection;
 }
 
 RCT_EXTERN RCTLayoutMetrics RCTLayoutMetricsFromYogaNode(YGNodeRef yogaNode);

--- a/React/Views/RCTLayout.h
+++ b/React/Views/RCTLayout.h
@@ -26,6 +26,7 @@ struct RCTLayoutMetrics {
   UIEdgeInsets borderWidth;
   RCTDisplayType displayType;
   UIUserInterfaceLayoutDirection layoutDirection;
+  BOOL isHiddenDueToClipping;
 };
 typedef struct CG_BOXABLE RCTLayoutMetrics RCTLayoutMetrics;
 
@@ -43,7 +44,8 @@ static inline BOOL RCTLayoutMetricsEqualToLayoutMetrics(RCTLayoutMetrics a, RCTL
     CGRectEqualToRect(a.contentFrame, b.contentFrame) &&
     UIEdgeInsetsEqualToEdgeInsets(a.borderWidth, b.borderWidth) &&
     a.displayType == b.displayType &&
-    a.layoutDirection == b.layoutDirection;
+    a.layoutDirection == b.layoutDirection &&
+    a.isHiddenDueToClipping == b.isHiddenDueToClipping;
 }
 
 RCT_EXTERN RCTLayoutMetrics RCTLayoutMetricsFromYogaNode(YGNodeRef yogaNode);


### PR DESCRIPTION
If text is truncated and an inline view appears after the truncation point, the user should not see the inline view. Instead, we have a bug such that the inline view is always visible at the end of the visible text.

This commit fixes this by marking the inline view as hidden if it appears after the truncation point.

This appears to be a regression. React Native used to have logic similar to what this commit is adding: https://github.com/facebook/react-native/blob/1e2a924ba60001c6f0587c7561536f00b2922cbf/Libraries/Text/RCTShadowText.m#L186-L192

**Before fix**

Inline view (blue square) is visible even though it appears after the truncation point:

![image](https://user-images.githubusercontent.com/199935/46382038-d3a71200-c65d-11e8-8179-2ce4aad8d010.png)

The full text being rendered was:

```
<Text numberOfLines={1}>
  Lorem ipsum dolor sit amet, consectetur adipiscing elit,
  sed do eiusmod tempor incididunt ut labore et dolore magna
  <View style={{width: 50, height: 50, backgroundColor: 'steelblue'}} />
</Text>
```

**After fix**

Inline view is properly truncated:

![image](https://user-images.githubusercontent.com/199935/46382067-fdf8cf80-c65d-11e8-84ea-e2b71c229dae.png)

**Test Plan**

Tested that the inline view is hidden if it appears after the truncation point when `numberOfLines` is 1 and 2. Similarly, verified that the inline view is visible if it appears before the truncation point.

**Release Notes**

[IOS] [BUGFIX] [Text] - Fix case where inline view is visible even though it should have been truncated

Adam Comella
Microsoft Corp.