### PR TITLE
Added groupCollapsed polyfill

### DIFF
--- a/Libraries/polyfills/console.js
+++ b/Libraries/polyfills/console.js
@@ -520,7 +520,6 @@ function consoleGroupPolyfill(label) {
   groupStack.push(GROUP_PAD);
 }
 
-
 function consoleGroupCollapsedPolyfill(label) {
   global.nativeLoggingHook(groupFormat(GROUP_CLOSE, label), LOG_LEVELS.info);
   groupStack.push(GROUP_PAD);

--- a/Libraries/polyfills/console.js
+++ b/Libraries/polyfills/console.js
@@ -520,6 +520,12 @@ function consoleGroupPolyfill(label) {
   groupStack.push(GROUP_PAD);
 }
 
+
+function consoleGroupCollapsedPolyfill(label) {
+  global.nativeLoggingHook(groupFormat(GROUP_CLOSE, label), LOG_LEVELS.info);
+  groupStack.push(GROUP_PAD);
+}
+
 function consoleGroupEndPolyfill() {
   groupStack.pop();
   global.nativeLoggingHook(groupFormat(GROUP_CLOSE), LOG_LEVELS.info);
@@ -537,6 +543,7 @@ if (global.nativeLoggingHook) {
     table: consoleTablePolyfill,
     group: consoleGroupPolyfill,
     groupEnd: consoleGroupEndPolyfill,
+    groupCollapsed: consoleGroupCollapsedPolyfill,
   };
 
   // If available, also call the original `console` method since that is


### PR DESCRIPTION
`groupCollapsed` is used to group logs but collapsed which is very useful when the console has many logs (e.g. when using `redux-logger`).

For developers who prefer to debug iOS apps using Safari JSC, the `groupCollapsed` was not polyfilled.

Fixes #21446 

Test Plan:
----------
I tested it in the Safari Developer console.

**Input**:

```
console.groupCollapsed('Hello RN')
console.log('some data', {hello: "world"})
console.log('another line')
console.log('and another one')
console.groupEnd()
```

**Output**:
A single collapsed log containing the other logs as expected. See demo below.

**Demo**:

![groupcollapsed_demo](https://user-images.githubusercontent.com/767013/46386035-a6209e00-c71b-11e8-812a-ec7f96950057.gif)


Release Notes:
--------------

[GENERAL] [ENHANCEMENT] [JSC] - Added `groupCollapsed` to the console polyfill to enable log collapsing in consoles such as Safari  
