### PR TITLE
Fix deprecation warning message in Switch

### DIFF
--- a/Libraries/Components/Switch/Switch.js
+++ b/Libraries/Components/Switch/Switch.js
@@ -109,7 +109,7 @@ class Switch extends React.Component<Props> {
       _thumbColor = thumbTintColor;
       if (__DEV__) {
         console.warn(
-          'Switch: `thumbTintColor` is deprecated, use `_thumbColor` instead.',
+          'Switch: `thumbTintColor` is deprecated, use `thumbColor` instead.',
         );
       }
     }


### PR DESCRIPTION
Test Plan:
----------
No test plan required here, just a very simple fix for typo depreciation warning message for `Switch`.

Release Notes:
--------------
[GENERAL] [MINOR] [Switch] - Fix deprecation warning message in Switch
