### PR TITLE
Critical improvements for Map and Set polyfills.

### DIFF
--- a/Libraries/Core/__tests__/MapAndSetPolyfills-test.js
+++ b/Libraries/Core/__tests__/MapAndSetPolyfills-test.js
@@ -1,0 +1,104 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @emails oncall+react_native
+ */
+'use strict';
+
+// Save these methods so that we can restore them afterward.
+const {freeze, seal, preventExtensions} = Object;
+
+function setup() {
+  jest.setMock('../../vendor/core/_shouldPolyfillES6Collection', () => true);
+  jest.unmock('_wrapObjectFreezeAndFriends');
+  require('_wrapObjectFreezeAndFriends');
+}
+
+function cleanup() {
+  Object.assign(Object, {freeze, seal, preventExtensions});
+}
+
+describe('Map polyfill', () => {
+  setup();
+
+  const Map = require('Map');
+
+  it('is not native', () => {
+    const getCode = Function.prototype.toString.call(Map.prototype.get);
+    expect(getCode).not.toContain('[native code]');
+    expect(getCode).toContain('getIndex');
+  });
+
+  it('should tolerate non-extensible object keys', () => {
+    const map = new Map();
+    const key = Object.create(null);
+    Object.freeze(key);
+    map.set(key, key);
+    expect(map.size).toBe(1);
+    expect(map.has(key)).toBe(true);
+    map.delete(key);
+    expect(map.size).toBe(0);
+    expect(map.has(key)).toBe(false);
+  });
+
+  it('should not get confused by prototypal inheritance', () => {
+    const map = new Map();
+    const proto = Object.create(null);
+    const base = Object.create(proto);
+    map.set(proto, proto);
+    expect(map.size).toBe(1);
+    expect(map.has(proto)).toBe(true);
+    expect(map.has(base)).toBe(false);
+    map.set(base, base);
+    expect(map.size).toBe(2);
+    expect(map.get(proto)).toBe(proto);
+    expect(map.get(base)).toBe(base);
+  });
+
+  afterAll(cleanup);
+});
+
+describe('Set polyfill', () => {
+  setup();
+
+  const Set = require('Set');
+
+  it('is not native', () => {
+    const addCode = Function.prototype.toString.call(Set.prototype.add);
+    expect(addCode).not.toContain('[native code]');
+  });
+
+  it('should tolerate non-extensible object elements', () => {
+    const set = new Set();
+    const elem = Object.create(null);
+    Object.freeze(elem);
+    set.add(elem);
+    expect(set.size).toBe(1);
+    expect(set.has(elem)).toBe(true);
+    set.add(elem);
+    expect(set.size).toBe(1);
+    set.delete(elem);
+    expect(set.size).toBe(0);
+    expect(set.has(elem)).toBe(false);
+  });
+
+  it('should not get confused by prototypal inheritance', () => {
+    const set = new Set();
+    const proto = Object.create(null);
+    const base = Object.create(proto);
+    set.add(proto);
+    expect(set.size).toBe(1);
+    expect(set.has(proto)).toBe(true);
+    expect(set.has(base)).toBe(false);
+    set.add(base);
+    expect(set.size).toBe(2);
+    expect(set.has(proto)).toBe(true);
+    expect(set.has(base)).toBe(true);
+  });
+
+  afterAll(cleanup);
+});

--- a/Libraries/Core/polyfillES6Collections.js
+++ b/Libraries/Core/polyfillES6Collections.js
@@ -18,8 +18,10 @@ const {polyfillGlobal} = require('PolyfillFunctions');
  */
 const _shouldPolyfillCollection = require('_shouldPolyfillES6Collection');
 if (_shouldPolyfillCollection('Map')) {
+  require('_wrapObjectFreezeAndFriends');
   polyfillGlobal('Map', () => require('Map'));
 }
 if (_shouldPolyfillCollection('Set')) {
+  require('_wrapObjectFreezeAndFriends');
   polyfillGlobal('Set', () => require('Set'));
 }

--- a/Libraries/vendor/core/Map.js
+++ b/Libraries/vendor/core/Map.js
@@ -26,6 +26,9 @@ module.exports = (function(global, undefined) {
     return global.Map;
   }
 
+  // In case this module has not already been evaluated, import it now.
+  require('./_wrapObjectFreezeAndFriends');
+
   /**
    * == ES6 Map Collection ==
    *
@@ -38,15 +41,17 @@ module.exports = (function(global, undefined) {
    *
    * https://people.mozilla.org/~jorendorff/es6-draft.html#sec-map-objects
    *
-   * There only two -- rather small -- diviations from the spec:
+   * There only two -- rather small -- deviations from the spec:
    *
-   * 1. The use of frozen objects as keys.
-   *    We decided not to allow and simply throw an error. The reason being is
-   *    we store a "hash" on the object for fast access to it's place in the
-   *    internal map entries.
-   *    If this turns out to be a popular use case it's possible to implement by
-   *    overiding `Object.freeze` to store a "hash" property on the object
-   *    for later use with the map.
+   * 1. The use of untagged frozen objects as keys.
+   *    We decided not to allow and simply throw an error, because this
+   *    implementation of Map works by tagging objects used as Map keys
+   *    with a secret hash property for fast access to the object's place
+   *    in the internal _mapData array. However, to limit the impact of
+   *    this spec deviation, Libraries/Core/InitializeCore.js also wraps
+   *    Object.freeze, Object.seal, and Object.preventExtensions so that
+   *    they tag objects before making them non-extensible, by inserting
+   *    each object into a Map and then immediately removing it.
    *
    * 2. The `size` property on a map object is a regular property and not a
    *    computed property on the prototype as described by the spec.

--- a/Libraries/vendor/core/Map.js
+++ b/Libraries/vendor/core/Map.js
@@ -553,15 +553,17 @@ module.exports = (function(global, undefined) {
       }
 
       if (isExtensible(o)) {
-        hashCounter += 1;
         if (isES5) {
           Object.defineProperty(o, hashProperty, {
             enumerable: false,
             writable: false,
             configurable: false,
-            value: hashCounter,
+            value: ++hashCounter,
           });
-        } else if (o.propertyIsEnumerable) {
+          return hashCounter;
+        }
+
+        if (o.propertyIsEnumerable) {
           // Since we can't define a non-enumerable property on the object
           // we'll hijack one of the less-used non-enumerable properties to
           // save our hash on it. Additionally, since this is a function it
@@ -569,22 +571,19 @@ module.exports = (function(global, undefined) {
           o.propertyIsEnumerable = function() {
             return propIsEnumerable.apply(this, arguments);
           };
-          o.propertyIsEnumerable[hashProperty] = hashCounter;
-        } else {
-          throw new Error('Unable to set a non-enumerable property on object.');
+          return o.propertyIsEnumerable[hashProperty] = ++hashCounter;
         }
-        return hashCounter;
-      } else {
-        // If the object is not extensible, fall back to storing it in an
-        // array and using Array.prototype.indexOf to find it.
-        let index = nonExtensibleObjects.indexOf(o);
-        if (index < 0) {
-          index = nonExtensibleObjects.length;
-          nonExtensibleObjects[index] = o;
-          nonExtensibleHashes[index] = ++hashCounter;
-        }
-        return nonExtensibleHashes[index];
       }
+
+      // If the object is not extensible, fall back to storing it in an
+      // array and using Array.prototype.indexOf to find it.
+      let index = nonExtensibleObjects.indexOf(o);
+      if (index < 0) {
+        index = nonExtensibleObjects.length;
+        nonExtensibleObjects[index] = o;
+        nonExtensibleHashes[index] = ++hashCounter;
+      }
+      return nonExtensibleHashes[index];
     };
   })();
 

--- a/Libraries/vendor/core/Map.js
+++ b/Libraries/vendor/core/Map.js
@@ -29,6 +29,8 @@ module.exports = (function(global, undefined) {
   // In case this module has not already been evaluated, import it now.
   require('./_wrapObjectFreezeAndFriends');
 
+  const hasOwn = Object.prototype.hasOwnProperty;
+
   /**
    * == ES6 Map Collection ==
    *
@@ -450,7 +452,7 @@ module.exports = (function(global, undefined) {
         // If the `SECRET_SIZE_PROP` property is already defined then we're not
         // in the first call to `initMap` (e.g. coming from `map.clear()`) so
         // all we need to do is reset the size without defining the properties.
-        if (map.hasOwnProperty(SECRET_SIZE_PROP)) {
+        if (hasOwn.call(map, SECRET_SIZE_PROP)) {
           map[SECRET_SIZE_PROP] = 0;
         } else {
           Object.defineProperty(map, SECRET_SIZE_PROP, {
@@ -536,17 +538,15 @@ module.exports = (function(global, undefined) {
      * @return {number}
      */
     return function getHash(o) {
-      // eslint-disable-line no-shadow
-      if (o[hashProperty]) {
+      if (hasOwn.call(o, hashProperty)) {
         return o[hashProperty];
-      } else if (
-        !isES5 &&
-        o.propertyIsEnumerable &&
-        o.propertyIsEnumerable[hashProperty]
-      ) {
-        return o.propertyIsEnumerable[hashProperty];
-      } else if (!isES5 && o[hashProperty]) {
-        return o[hashProperty];
+      }
+
+      if (!isES5) {
+        if (hasOwn.call(o, "propertyIsEnumerable") &&
+            hasOwn.call(o.propertyIsEnumerable, hashProperty)) {
+          return o.propertyIsEnumerable[hashProperty];
+        }
       }
 
       if (isExtensible(o)) {

--- a/Libraries/vendor/core/Map.js
+++ b/Libraries/vendor/core/Map.js
@@ -531,6 +531,9 @@ module.exports = (function(global, undefined) {
     const hashProperty = '__MAP_POLYFILL_INTERNAL_HASH__';
     let hashCounter = 0;
 
+    const nonExtensibleObjects = [];
+    const nonExtensibleHashes = [];
+
     /**
      * Get the "hash" associated with an object.
      *
@@ -572,7 +575,15 @@ module.exports = (function(global, undefined) {
         }
         return hashCounter;
       } else {
-        throw new Error('Non-extensible objects are not allowed as keys.');
+        // If the object is not extensible, fall back to storing it in an
+        // array and using Array.prototype.indexOf to find it.
+        let index = nonExtensibleObjects.indexOf(o);
+        if (index < 0) {
+          index = nonExtensibleObjects.length;
+          nonExtensibleObjects[index] = o;
+          nonExtensibleHashes[index] = ++hashCounter;
+        }
+        return nonExtensibleHashes[index];
       }
     };
   })();

--- a/Libraries/vendor/core/_wrapObjectFreezeAndFriends.js
+++ b/Libraries/vendor/core/_wrapObjectFreezeAndFriends.js
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @author Ben Newman (@benjamn) <ben@benjamn.com>
+ * @flow
+ * @format
  */
 
 'use strict';
@@ -20,7 +22,7 @@ function getTestMap() {
 ["freeze", "seal", "preventExtensions"].forEach(name => {
   const method = Object[name];
   if (typeof method === "function") {
-    Object[name] = function (obj) {
+    (Object: any)[name] = function (obj) {
       try {
         // If .set succeeds, also call .delete to avoid leaking memory.
         getTestMap().set(obj, obj).delete(obj);

--- a/Libraries/vendor/core/_wrapObjectFreezeAndFriends.js
+++ b/Libraries/vendor/core/_wrapObjectFreezeAndFriends.js
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @author Ben Newman (@benjamn) <ben@benjamn.com>
+ */
+
+'use strict';
+
+let testMap; // Initialized lazily.
+function getTestMap() {
+  return testMap || (testMap = new (require('./Map'))());
+}
+
+// Wrap Object.{freeze,seal,preventExtensions} so each function adds its
+// argument to a Map first, which gives our ./Map.js polyfill a chance to
+// tag the object before it becomes non-extensible.
+["freeze", "seal", "preventExtensions"].forEach(name => {
+  const method = Object[name];
+  if (typeof method === "function") {
+    Object[name] = function (obj) {
+      try {
+        // If .set succeeds, also call .delete to avoid leaking memory.
+        getTestMap().set(obj, obj).delete(obj);
+      } finally {
+        // If .set fails, the exception will be silently swallowed
+        // by this return-from-finally statement, and the method will
+        // behave exactly as it did before it was wrapped.
+        return method.call(Object, obj);
+      }
+    };
+  }
+});


### PR DESCRIPTION
Test Plan:
---
See included tests.

Release Notes:
---
* [POLYFILL] [SPEC] The `Map` and `Set` polyfills no longer reject non-extensible object keys, through a combination of tagging objects _before_ they become non-extensible, and falling back to a linear `Array#indexOf` lookup when there is no other option.
* [POLYFILL] [BUGFIX] Fixed a critical bug that caused `Map` and `Set` object hashes to collide with the hashes of other objects in their prototype chains.

Details
---
When I first discovered these bugs in the course of investigating https://github.com/apollographql/react-apollo/issues/2442, I was disappointed and disheartened, and I was tempted to recommend that Apollo developers find a replacement for the React Native `Map` and `Set` polyfills.

However, as I dug into the code and investigated alternative polyfills, I realized that this `Map` polyfill has the potential to be one of the fastest and best polyfills available, since almost every other polyfill avoids tagging object keys, and instead resorts to linear lookup. I hope this PR demonstrates that we can provide constant-time lookup in (almost) all cases, even for frozen object keys.

While I can certainly provide more creative solutions to developers who use my libraries, from monkey-patching `Map.prototype` to using the `react-native` override field in `package.json`, I think the best solution is simply to improve the official polyfills, which is what I've tried to do in this PR.

Please read the commit messages and the comments that I've added to the code for more explanation, and thanks for your consideration!