### PR TITLE
Fix/rm timermixin touchable without feedback

### DIFF
--- a/Libraries/Components/Touchable/TouchableWithoutFeedback.js
+++ b/Libraries/Components/Touchable/TouchableWithoutFeedback.js
@@ -13,7 +13,6 @@
 const DeprecatedEdgeInsetsPropType = require('DeprecatedEdgeInsetsPropType');
 const React = require('React');
 const PropTypes = require('prop-types');
-const TimerMixin = require('react-timer-mixin');
 const Touchable = require('Touchable');
 const View = require('View');
 
@@ -80,7 +79,7 @@ export type Props = $ReadOnly<{|
  */
 const TouchableWithoutFeedback = ((createReactClass({
   displayName: 'TouchableWithoutFeedback',
-  mixins: [TimerMixin, Touchable.Mixin],
+  mixins: [Touchable.Mixin],
 
   propTypes: {
     accessible: PropTypes.bool,

--- a/RNTester/js/TouchableExample.js
+++ b/RNTester/js/TouchableExample.js
@@ -21,6 +21,7 @@ var {
   TouchableOpacity,
   Platform,
   TouchableNativeFeedback,
+  TouchableWithoutFeedback,
   View,
 } = ReactNative;
 
@@ -68,6 +69,12 @@ exports.examples = [
           </View>
         </View>
       );
+    },
+  },
+  {
+    title: '<TouchableWithoutFeedback>',
+    render: function() {
+      return <TouchableWithoutFeedbackBox />;
     },
   },
   {
@@ -149,6 +156,40 @@ exports.examples = [
     },
   },
 ];
+
+class TouchableWithoutFeedbackBox extends React.Component<{}, $FlowFixMeState> {
+  state = {
+    timesPressed: 0,
+  };
+
+  textOnPress = () => {
+    this.setState({
+      timesPressed: this.state.timesPressed + 1,
+    });
+  };
+
+  render() {
+    var textLog = '';
+    if (this.state.timesPressed > 1) {
+      textLog = this.state.timesPressed + 'x TouchableWithoutFeedback onPress';
+    } else if (this.state.timesPressed > 0) {
+      textLog = 'TouchableWithoutFeedback onPress';
+    }
+
+    return (
+      <View>
+        <TouchableWithoutFeedback onPress={this.textOnPress}>
+          <View style={styles.wrapperCustom}>
+            <Text style={styles.text}>Tap Here For No Feedback!</Text>
+          </View>
+        </TouchableWithoutFeedback>
+        <View style={styles.logBox}>
+          <Text>{textLog}</Text>
+        </View>
+      </View>
+    );
+  }
+}
 
 class TextOnPressBox extends React.Component<{}, $FlowFixMeState> {
   state = {
@@ -359,6 +400,31 @@ class TouchableDisabled extends React.Component<{}> {
           onPress={() => console.log('custom THW text - highlight')}>
           <Text style={styles.button}>Enabled TouchableHighlight</Text>
         </TouchableHighlight>
+
+        <TouchableWithoutFeedback
+          onPress={() => console.log('TWOF has been clicked')}
+          disabled={true}>
+          <View style={styles.wrapperCustom}>
+            <Text
+              style={[
+                styles.button,
+                styles.nativeFeedbackButton,
+                styles.disabledButton,
+              ]}>
+              Disabled TouchableWithoutFeedback
+            </Text>
+          </View>
+        </TouchableWithoutFeedback>
+
+        <TouchableWithoutFeedback
+          onPress={() => console.log('TWOF has been clicked')}
+          disabled={false}>
+          <View style={styles.wrapperCustom}>
+            <Text style={[styles.button, styles.nativeFeedbackButton]}>
+              Enabled TouchableWithoutFeedback
+            </Text>
+          </View>
+        </TouchableWithoutFeedback>
 
         {Platform.OS === 'android' && (
           <TouchableNativeFeedback


### PR DESCRIPTION
Related to #21485.
Removed `TimerMixin` from the `TouchableWithoutFeedback` component since it is currently not used.
Added tests cases for `TouchableWithoutFeedback` to check for any runtime issues.

Test Plan:
____

Ran:
* npm run prettier

Additionally ran the following scripts with no errors:
* npm run flow-check-ios
* npm run flow-check-android

Following the removal of `TimerMixin`, the `TouchableWithoutFeedback` component has been tested during runtime using `RNTester` to surface any runtime issues. The change was tested on both iOS and Android with no obvious errors.

*RNTester steps:*
* Run `RNTester`. 
* Navigate to  `“<Touchable*> and onPress”`
* Second box provides  a simple test to verify that `<TouchableWithoutFeedback />` works as expected:

*General behavior for `TouchableWithoutFeedback`:*
<img width="393" alt="screenshot 2018-10-04 at 23 17 43" src="https://user-images.githubusercontent.com/8699937/46507355-63a0b380-c838-11e8-88d3-05451116a637.png">

Added tests for `disabled` state for `TouchableWithoutFeedback` to mirror tests for other `Touchable*` types:
<img width="393" alt="screenshot 2018-10-04 at 23 17 50" src="https://user-images.githubusercontent.com/8699937/46507384-8206af00-c838-11e8-8150-1d492a6ff0a2.png">

Release Notes:
_____
[GENERAL] [ENHANCEMENT] [Libraries/Components/Touchable/TouchableWithoutFeedback.js] - remove TimerMixin dependency
[GENERAL] [ENHANCEMENT] [RNTester/js/TouchableExample.js] - Add TouchableWithoutFeedback test cases.