### PR TITLE
[CI] Run publish_npm_package job on tagged commits without any pre-reqs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -729,12 +729,6 @@ workflows:
             # only act on version tags
             tags:
               only: /v[0-9]+(\.[0-9]+)*(\-rc(\.[0-9]+)?)?/
-          requires:
-            - analyze
-            - test_detox_end_to_end
-            - test_javascript
-            - test_objc
-            - test_android
 
       # Run code checks
       - analyze_pr:


### PR DESCRIPTION
This PR gets master back on sync with fixes made to 0.57-stable.

Test Plan: This was just tested as part of the 0.57.2 release process.