### PR TITLE
Fix ListEmptyComponent is rendered upside down when using inverted flag.

### DIFF
--- a/Libraries/Lists/VirtualizedList.js
+++ b/Libraries/Lists/VirtualizedList.js
@@ -934,7 +934,7 @@ class VirtualizedList extends React.PureComponent<Props, State> {
           : this.props.inverted,
       stickyHeaderIndices,
     };
-    if (inversionStyle && itemCount != 0) {
+    if (inversionStyle && itemCount !== 0) {
       /* $FlowFixMe(>=0.70.0 site=react_native_fb) This comment suppresses an
        * error found when Flow v0.70 was deployed. To see the error delete
        * this comment and run Flow. */

--- a/Libraries/Lists/VirtualizedList.js
+++ b/Libraries/Lists/VirtualizedList.js
@@ -934,7 +934,7 @@ class VirtualizedList extends React.PureComponent<Props, State> {
           : this.props.inverted,
       stickyHeaderIndices,
     };
-    if (inversionStyle) {
+    if (inversionStyle && itemCount != 0) {
       /* $FlowFixMe(>=0.70.0 site=react_native_fb) This comment suppresses an
        * error found when Flow v0.70 was deployed. To see the error delete
        * this comment and run Flow. */


### PR DESCRIPTION
Fix ListEmptyComponent is rendered upside down when using inverted flag.

Fixes #21196 

Test Plan:
Try `FlatList` with `inverted` flag like below.
```
          <FlatList
            style={{
              alignSelf: 'stretch',
              paddingHorizontal: 16 * ratio,
            }}
            ListEmptyComponent={this.renderEmptyView}
            keyExtractor={(item, index) => index.toString()}
            data={ this.state.data }
            renderItem={this.renderUsers}
            inverted={true}
          />
```
Previous result:
![image](https://user-images.githubusercontent.com/27461460/46510743-c2d8e500-c885-11e8-93c5-c01b80dad97b.png)

Fixed result:
![image](https://user-images.githubusercontent.com/27461460/46510745-c66c6c00-c885-11e8-9b67-24106cd88bb1.png)

Release Notes:
[General] [Fixed] - Fix ListEmptyComponent is rendered upside down when using inverted flag.