### PR TITLE
[TimerMixin] Removing TimerMixin on SwipeableRow

### DIFF
--- a/Libraries/Experimental/SwipeableRow/SwipeableRow.js
+++ b/Libraries/Experimental/SwipeableRow/SwipeableRow.js
@@ -155,7 +155,7 @@ const SwipeableRow = createReactClass({
        * Do the on mount bounce after a delay because if we animate when other
        * components are loading, the animation will be laggy
        */
-      this._timeoutID = this.setTimeout(() => {
+      this._timeoutID = setTimeout(() => {
         this._animateBounceBack(ON_MOUNT_BOUNCE_DURATION);
       }, ON_MOUNT_BOUNCE_DELAY);
     }

--- a/Libraries/Experimental/SwipeableRow/SwipeableRow.js
+++ b/Libraries/Experimental/SwipeableRow/SwipeableRow.js
@@ -19,7 +19,6 @@ const StyleSheet = require('StyleSheet');
 /* $FlowFixMe(>=0.54.0 site=react_native_oss) This comment suppresses an error
  * found when Flow v0.54 was deployed. To see the error delete this comment and
  * run Flow. */
-const TimerMixin = require('react-timer-mixin');
 const View = require('View');
 
 const createReactClass = require('create-react-class');

--- a/Libraries/Experimental/SwipeableRow/SwipeableRow.js
+++ b/Libraries/Experimental/SwipeableRow/SwipeableRow.js
@@ -85,8 +85,7 @@ const SwipeableRow = createReactClass({
   displayName: 'SwipeableRow',
   _panResponder: {},
   _previousLeft: CLOSED_LEFT_POSITION,
-
-  mixins: [TimerMixin],
+  _timeoutID: (null: ?TimeoutID),
 
   propTypes: {
     children: PropTypes.any,
@@ -157,7 +156,7 @@ const SwipeableRow = createReactClass({
        * Do the on mount bounce after a delay because if we animate when other
        * components are loading, the animation will be laggy
        */
-      this.setTimeout(() => {
+      this._timeoutID = this.setTimeout(() => {
         this._animateBounceBack(ON_MOUNT_BOUNCE_DURATION);
       }, ON_MOUNT_BOUNCE_DELAY);
     }
@@ -170,6 +169,12 @@ const SwipeableRow = createReactClass({
      */
     if (this.props.isOpen && !nextProps.isOpen) {
       this._animateToClosedPosition();
+    }
+  },
+
+  componentWillUnmount() {
+    if (this._timeoutID != null) {
+      clearTimeout(this._timeoutID);
     }
   },
 

--- a/RNTester/js/SwipeableListViewExample.js
+++ b/RNTester/js/SwipeableListViewExample.js
@@ -52,6 +52,7 @@ class SwipeableListViewSimpleExample extends React.Component<
         noSpacer={true}
         noScroll={true}>
         <SwipeableListView
+          bounceFirstRowOnMount={true}
           dataSource={this.state.dataSource}
           maxSwipeDistance={100}
           renderQuickActions={(


### PR DESCRIPTION
Related to #21485.
Removed TimerMixin from the SwipeableRow component since it is currently not used.
Added a test case for `SwipeableRow` animation in the `SwipeableListViewSimpleExample`, by adding the `bounceFirstRowOnMount` prop, to check for any runtime issues with the setTimeout method.

# Test Plan
- [x] `npm run prettier`
- [x] `npm run flow-check-ios`
- [x] `npm run flow-check-android`
- [x] runtime tests using `SwipeableFlatListExample` on Android and iOS
- [x] runtime tests using `SwipeableListViewSimpleExample` on Android and iOS

**RNTester steps**

- [x] Run RNTester.
- [x] Navigate to `SwipeableFlatListExample` and check if the `_animateBounceBack` animation executes when the `shouldBounceOnMount` props is passed.
- [x] Swipe the row and check if the events ran correctly
- [x] Navigate to `SwipeableListViewSimpleExample` and check if the `_animateBounceBack` animation executes when the `shouldBounceOnMount` props is passed.
- [x] Swipe the row and check if the events ran correctly

# Release Notes
[GENERAL] [ENHANCEMENT] [Libraries/Experimental/SwipeableRow/SwipeableRow.js] - remove TimerMixin dependency
[GENERAL] [ENHANCEMENT] [RNTester/js/SwipeableListViewSimpleExample.js] - Add bounceFirstRowOnMount to guarantee the SwipeableRow correct behavior.