### PR TITLE
[TimerMixin] Removing TimerMixin on ProgressViewIOSExample

### DIFF
--- a/RNTester/js/ProgressViewIOSExample.js
+++ b/RNTester/js/ProgressViewIOSExample.js
@@ -17,11 +17,10 @@ var {ProgressViewIOS, StyleSheet, View} = ReactNative;
 /* $FlowFixMe(>=0.54.0 site=react_native_oss) This comment suppresses an error
  * found when Flow v0.54 was deployed. To see the error delete this comment and
  * run Flow. */
-var TimerMixin = require('react-timer-mixin');
 
 var ProgressViewExample = createReactClass({
   displayName: 'ProgressViewExample',
-  mixins: [TimerMixin],
+  _rafId: (null: ?AnimationFrameID),
 
   getInitialState() {
     return {
@@ -33,10 +32,16 @@ var ProgressViewExample = createReactClass({
     this.updateProgress();
   },
 
+  componentWillUnmount() {
+    if (this._rafId != null) {
+      cancelAnimationFrame(this._rafId);
+    }
+  },
+
   updateProgress() {
     var progress = this.state.progress + 0.01;
     this.setState({progress});
-    this.requestAnimationFrame(() => this.updateProgress());
+    this._rafId = requestAnimationFrame(() => this.updateProgress());
   },
 
   getProgress(offset) {


### PR DESCRIPTION
Related to #21485.
Removed TimerMixin from the `RNTester/js/ProgressViewIOSExample.js` screen since it is currently not used.

# Test Plan
- [x] `npm run prettier`
- [x] `npm run flow-check-ios`
- [x] `npm run flow-check-android`
- [x] runtime tests using `ProgressViewIOSExample` on Android and iOS

**RNTester steps**

- [x] Run RNTester.
- [x] Navigate to `ProgressViewIOSExample` and check if the animations are executed correctly and without lag.

# Release Notes
[GENERAL] [ENHANCEMENT] [RNTester/js/ProgressViewIOSExample.js] - remove TimerMixin dependency