### PR TITLE
Remove TimerMixin on ProgressBarAndroidExample.android.js

### DIFF
--- a/RNTester/js/ProgressBarAndroidExample.android.js
+++ b/RNTester/js/ProgressBarAndroidExample.android.js
@@ -16,11 +16,9 @@ var createReactClass = require('create-react-class');
 var RNTesterBlock = require('RNTesterBlock');
 var RNTesterPage = require('RNTesterPage');
 
-var TimerMixin = require('react-timer-mixin');
-
 var MovingBar = createReactClass({
   displayName: 'MovingBar',
-  mixins: [TimerMixin],
+  _timeoutID: (null: ?TimeoutID),
 
   getInitialState: function() {
     return {
@@ -29,10 +27,16 @@ var MovingBar = createReactClass({
   },
 
   componentDidMount: function() {
-    this.setInterval(() => {
+    this._timeoutID = setInterval(() => {
       var progress = (this.state.progress + 0.02) % 1;
       this.setState({progress: progress});
     }, 50);
+  },
+
+  componentWillUnmount: function() {
+    if (this._timeoutID != null) {
+      clearTimeout(this._timeoutID);
+    }
   },
 
   render: function() {

--- a/RNTester/js/ProgressBarAndroidExample.android.js
+++ b/RNTester/js/ProgressBarAndroidExample.android.js
@@ -18,7 +18,7 @@ var RNTesterPage = require('RNTesterPage');
 
 var MovingBar = createReactClass({
   displayName: 'MovingBar',
-  _timeoutID: (null: ?TimeoutID),
+  _intervalID: (null: ?IntervalID),
 
   getInitialState: function() {
     return {
@@ -27,15 +27,15 @@ var MovingBar = createReactClass({
   },
 
   componentDidMount: function() {
-    this._timeoutID = setInterval(() => {
+    this._intervalID = setInterval(() => {
       var progress = (this.state.progress + 0.02) % 1;
       this.setState({progress: progress});
     }, 50);
   },
 
   componentWillUnmount: function() {
-    if (this._timeoutID != null) {
-      clearTimeout(this._timeoutID);
+    if (this._intervalID != null) {
+      clearInterval(this._intervalID);
     }
   },
 


### PR DESCRIPTION
Related to #21485.
Removed TimerMixin from the `RNTester/js/ProgressBarAndroidExample.android.js` since it is currently not used.

## Test Plan
- [x] npm run prettier
- [x] npm run flow-check-ios
- [x] npm run flow-check-android


### Run RNTester.
In progress 🙇 

## Release Notes
[GENERAL] [ENHANCEMENT] [RNTester/js/ProgressBarAndroidExample.android.js] - remove TimerMixin dependency