### PR TITLE
[TimerMixin] Remove TimerMixin on ReactContentSizeUpdateTest

### DIFF
--- a/IntegrationTests/ReactContentSizeUpdateTest.js
+++ b/IntegrationTests/ReactContentSizeUpdateTest.js
@@ -14,7 +14,6 @@ const createReactClass = require('create-react-class');
 const ReactNative = require('react-native');
 const RCTNativeAppEventEmitter = require('RCTNativeAppEventEmitter');
 const Subscribable = require('Subscribable');
-const TimerMixin = require('react-timer-mixin');
 
 const {View} = ReactNative;
 
@@ -27,7 +26,8 @@ const newReactViewHeight = 202;
 
 const ReactContentSizeUpdateTest = createReactClass({
   displayName: 'ReactContentSizeUpdateTest',
-  mixins: [Subscribable.Mixin, TimerMixin],
+  mixins: [Subscribable.Mixin],
+  _timeoutID: (null: ?TimeoutID),
 
   UNSAFE_componentWillMount: function() {
     this.addListenerOn(
@@ -52,9 +52,15 @@ const ReactContentSizeUpdateTest = createReactClass({
   },
 
   componentDidMount: function() {
-    this.setTimeout(() => {
+    this._timeoutID = setTimeout(() => {
       this.updateViewSize();
     }, 1000);
+  },
+
+  componentWillUnmount: function() {
+    if (this._timeoutID != null) {
+      clearTimeout(this._timeoutID);
+    }
   },
 
   rootViewDidChangeIntrinsicSize: function(intrinsicSize) {


### PR DESCRIPTION
Related to #21485.
Removed `TimerMixin` from `ReactContentSizeUpdateTest`.

Test Plan:
----------
I am still not sure on how test this change since the change was made on `ReactContentSizeUpdateTest` which is a `IntegrationTest`.
The file is referenced at `IntegrationTests/RCTRootViewIntegrationTestApp.js` and `RNTester/RNTesterIntegrationTests/RCTRootViewIntegrationTests.m` which seems to be some kind of suit of tests, but I have not found any run instructions for that. I am thinking about on how to guarantee that the test is correct since it might pass now, but not really testing what it was supposed to test, etc.

Who do we test the 'tester' ? haha.
It would be nice to have some guidance here. 

On the other hand, I've made sure to run: 
- [x]  yarn run prettier
- [x]  yarn run flow-check-ios
- [x]  yarn run flow-check-android

All done with no errors =]

Release Notes:
--------------
[GENERAL] [ENHANCEMENT] [IntegrationTests/ReactContentSizeUpdateTest.js] - Remove TimerMixin in favor of TimeoutID and controlled timeout