### PR TITLE
[TimerMixin] Remove TimerMixin from TouchableOpacity

### DIFF
--- a/Libraries/Components/Touchable/TouchableOpacity.js
+++ b/Libraries/Components/Touchable/TouchableOpacity.js
@@ -15,7 +15,6 @@ const Easing = require('Easing');
 const NativeMethodsMixin = require('NativeMethodsMixin');
 const React = require('React');
 const PropTypes = require('prop-types');
-const TimerMixin = require('react-timer-mixin');
 const Touchable = require('Touchable');
 const TouchableWithoutFeedback = require('TouchableWithoutFeedback');
 
@@ -132,7 +131,7 @@ type Props = $ReadOnly<{|
  */
 const TouchableOpacity = ((createReactClass({
   displayName: 'TouchableOpacity',
-  mixins: [TimerMixin, Touchable.Mixin, NativeMethodsMixin],
+  mixins: [Touchable.Mixin, NativeMethodsMixin],
 
   propTypes: {
     ...TouchableWithoutFeedback.propTypes,


### PR DESCRIPTION
Related to #21485 
This PR removes TimerMixin from TouchableOpacity

Test Plan:
----------
All flow types passes
Ran RNTester

![out](https://user-images.githubusercontent.com/20520102/46552777-2416ad80-c8b2-11e8-9b5b-f2b68015808c.gif)

Release Notes:
--------------
[GENERAL] [ENHANCEMENT] [TouchableOpacity.js] - Removed TimerMixin.
