### PR TITLE
[TimerMixin] Removing TimerMixin on TextInput

### DIFF
--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -22,7 +22,6 @@ const StyleSheet = require('StyleSheet');
 const Text = require('Text');
 const TextAncestor = require('TextAncestor');
 const TextInputState = require('TextInputState');
-const TimerMixin = require('react-timer-mixin');
 const TouchableWithoutFeedback = require('TouchableWithoutFeedback');
 const UIManager = require('UIManager');
 
@@ -803,7 +802,7 @@ const TextInput = createReactClass({
    * `NativeMethodsMixin` will look for this when invoking `setNativeProps`. We
    * make `this` look like an actual native component class.
    */
-  mixins: [NativeMethodsMixin, TimerMixin],
+  mixins: [NativeMethodsMixin],
 
   /**
    * Returns `true` if the input is currently focused; `false` otherwise.
@@ -819,6 +818,7 @@ const TextInput = createReactClass({
   _focusSubscription: (undefined: ?Function),
   _lastNativeText: (undefined: ?string),
   _lastNativeSelection: (undefined: ?Selection),
+  _rafId: (null: ?AnimationFrameID),
 
   componentDidMount: function() {
     this._lastNativeText = this.props.value;
@@ -833,7 +833,7 @@ const TextInput = createReactClass({
         'focus',
         el => {
           if (this === el) {
-            this.requestAnimationFrame(this.focus);
+            this._rafId = requestAnimationFrame(this.focus);
           } else if (this.isFocused()) {
             this.blur();
           }
@@ -844,7 +844,7 @@ const TextInput = createReactClass({
       }
     } else {
       if (this.props.autoFocus) {
-        this.requestAnimationFrame(this.focus);
+        this._rafId = requestAnimationFrame(this.focus);
       }
     }
   },
@@ -857,6 +857,9 @@ const TextInput = createReactClass({
     const tag = ReactNative.findNodeHandle(this._inputRef);
     if (tag != null) {
       TextInputState.unregisterInput(tag);
+    }
+    if (this._rafId !== null) {
+      cancelAnimationFrame(this._rafId);
     }
   },
 

--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -858,7 +858,7 @@ const TextInput = createReactClass({
     if (tag != null) {
       TextInputState.unregisterInput(tag);
     }
-    if (this._rafId !== null) {
+    if (this._rafId != null) {
       cancelAnimationFrame(this._rafId);
     }
   },


### PR DESCRIPTION
Related to #21485.
Removed TimerMixin from Libraries/Components/TextInput/TextInput.js

Test Plan:
----------

- [x] run prettier
- [x] npm run flow-check-ios 
- [x] npm run flow-check-android

RNTester:

- [x] run tester for Android
- [x] checked that the TextInput component has same animation when focus

Release Notes:
--------------
[GENERAL] [ENHANCEMENT] [Libraries/Components/TextInput/TextInput.js] - remove TimerMixin
