### PR TITLE
Fix warning message for UIManager.getViewManagerConfig

### DIFF
--- a/Libraries/ReactNative/UIManager.js
+++ b/Libraries/ReactNative/UIManager.js
@@ -133,7 +133,7 @@ if (__DEV__) {
         get: () => {
           console.warn(
             `Accessing view manager configs directly off UIManager via UIManager['${viewManagerName}'] ` +
-              `is no longer supported. Use UIManager.getViewManager('${viewManagerName}') instead.`,
+              `is no longer supported. Use UIManager.getViewManagerConfig('${viewManagerName}') instead.`,
           );
           return UIManager.getViewManagerConfig(viewManagerName);
         },


### PR DESCRIPTION
Fix the warning message, the method is actually called `getViewManagerConfig`

Test Plan:
----------
N/A

Release Notes:
--------------
[GENERAL] [MINOR] [UIManager] - Fix warning message for UIManager.getViewManagerConfig