### PR TITLE
editorconfig: Set indent_size for BUCK files to 4

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,3 +12,6 @@ indent_size = 2
 
 [*.gradle]
 indent_size = 4
+
+[BUCK]
+indent_size = 4


### PR DESCRIPTION
The `BUCK` build files' indentation are 4 spaces large. This PR adds a small modification to `.editorconfig` to reflect that. Especially important for them, because an improperly indented line would be a syntax error.

Test Plan:
----------
When using an editor with an EditorConfig plugin, it now properly recognizes the tab width as being 4 on `BUCK` files.

Release Notes:
--------------
[GENERAL] [MINOR] [.editorconfig] - Set `indent_size` to 4 for BUCK files.
