### PR TITLE
flow-github/metro.js: Add missing module declaration

### DIFF
--- a/flow-github/metro.js
+++ b/flow-github/metro.js
@@ -67,3 +67,7 @@ declare module 'metro/src/Server' {
 declare module 'metro/src/ModuleGraph/worker/collectDependencies' {
   declare module.exports: any;
 }
+
+declare module 'metro/src/JSTransformer/worker' {
+  declare module.exports: any;
+}


### PR DESCRIPTION
This pull request adds a missing module stub for `metro/src/JSTransformer/worker` to `flow-github/metro.js` that allows Flow checking to pass again.

Test Plan:
----------
`yarn flow-check-ios` and `yarn flow-check-android` both pass.

Release Notes:
--------------

[GENERAL] [BUGFIX] [flow-github/metro.js] - Add module declaration stub for `metro/src/JSTransformer/worker`

<!--
  **INTERNAL and MINOR tagged notes will not be included in the next version's final release notes.**

    CATEGORY
  [----------]      TYPE
  [ CLI      ] [-------------]    LOCATION
  [ DOCS     ] [ BREAKING    ] [-------------]
  [ GENERAL  ] [ BUGFIX      ] [ {Component} ]
  [ INTERNAL ] [ ENHANCEMENT ] [ {Filename}  ]
  [ IOS      ] [ FEATURE     ] [ {Directory} ]   |-----------|
  [ ANDROID  ] [ MINOR       ] [ {Framework} ] - | {Message} |
  [----------] [-------------] [-------------]   |-----------|

 EXAMPLES:

 [IOS] [BREAKING] [FlatList] - Change a thing that breaks other things
 [ANDROID] [BUGFIX] [TextInput] - Did a thing to TextInput
 [CLI] [FEATURE] [local-cli/info/info.js] - CLI easier to do things with
 [DOCS] [BUGFIX] [GettingStarted.md] - Accidentally a thing/word
 [GENERAL] [ENHANCEMENT] [Yoga] - Added new yoga thing/position
 [INTERNAL] [FEATURE] [./scripts] - Added thing to script that nobody will see
-->
