### PR TITLE
check isAvailable key on simulator object

### DIFF
--- a/local-cli/runIOS/__tests__/findMatchingSimulator-test.js
+++ b/local-cli/runIOS/__tests__/findMatchingSimulator-test.js
@@ -65,6 +65,58 @@ describe('findMatchingSimulator', () => {
     });
   });
 
+  it('should find simulator with new xcrun format', () => {
+    expect(
+      findMatchingSimulator(
+        {
+          devices: {
+            'iOS 12.1': [
+              {
+                state: 'Shutdown',
+                isAvailable: 'YES',
+                name: 'iPhone 6s',
+                udid: 'D0F29BE7-CC3C-4976-888D-C739B4F50508',
+              },
+              {
+                state: 'Shutdown',
+                isAvailable: 'YES',
+                name: 'iPhone 6',
+                udid: 'BA0D93BD-07E6-4182-9B0A-F60A2474139C',
+              },
+              {
+                state: 'Shutdown',
+                isAvailable: 'YES',
+                name: 'iPhone XS Max',
+                udid: 'B9B5E161-416B-43C4-A78F-729CB96CC8C6',
+                availabilityError: '',
+              },
+              {
+                state: 'Shutdown',
+                isAvailable: 'YES',
+                name: 'iPad Air',
+                udid: '1CCBBF8B-5773-4EA6-BD6F-C308C87A1ADB',
+                availabilityError: '',
+              },
+              {
+                state: 'Shutdown',
+                isAvailable: 'YES',
+                name: 'iPad (5th generation)',
+                udid: '9564ABEE-9EC2-4B4A-B443-D3710929A45A',
+                availabilityError: '',
+              },
+            ],
+          },
+        },
+        'iPhone 6',
+      ),
+    ).toEqual({
+      udid: 'BA0D93BD-07E6-4182-9B0A-F60A2474139C',
+      name: 'iPhone 6',
+      booted: false,
+      version: 'iOS 12.1',
+    });
+  });
+
   it('should return null if no simulators available', () => {
     expect(
       findMatchingSimulator(

--- a/local-cli/runIOS/findMatchingSimulator.js
+++ b/local-cli/runIOS/findMatchingSimulator.js
@@ -34,7 +34,10 @@ function findMatchingSimulator(simulators, simulatorName) {
     for (let i in devices[version]) {
       let simulator = devices[version][i];
       // Skipping non-available simulator
-      if (simulator.availability !== '(available)') {
+      if (
+        simulator.availability !== '(available)' &&
+        simulator.isAvailable !== 'YES'
+      ) {
         continue;
       }
       let booted = simulator.state === 'Booted';


### PR DESCRIPTION


With the new xcode command line tools (10.1 beta2), running `xcrun simctl list --json devices` seems to gives us a slightly different format than what we were expecting. More specifically, the `availability` key is changed to `isAvailable` and returns `'YES'` if the simulator is available:

Before:
```js
devices: {
  'iOS 9.2': [
    {
      state: 'Shutdown',
      availability: '(unavailable, runtime profile not found)',
      name: 'iPhone 4s',
      udid: 'B9B5E161-416B-43C4-A78F-729CB96CC8C6',
    },
    {
      state: 'Shutdown',
      availability: '(unavailable, runtime profile not found)',
      name: 'iPhone 5',
      udid: '1CCBBF8B-5773-4EA6-BD6F-C308C87A1ADB',
    },
    ...
   ]
}
```
After:
```js
devices: {
  'iOS 12.1': [
    {
      state: 'Shutdown',
      isAvailable: 'YES',
      name: 'iPhone 6s',
      udid: 'D0F29BE7-CC3C-4976-888D-C739B4F50508',
    },
    {
      state: 'Shutdown',
      isAvailable: 'YES',
      name: 'iPhone 6',
      udid: 'BA0D93BD-07E6-4182-9B0A-F60A2474139C',
    },
    ...
   ]
}
```

Without this fix, `npm run ios` is not able to launch the simulator correctly and returns the following error:

```
Could not find iPhone 6 simulator

Error: Could not find iPhone 6 simulator
    at resolve (/Users/antonyc/Projects/AwesomeProject/node_modules/react-native/local-cli/runIOS/runIOS.js:148:13)
    at new Promise (<anonymous>)
    at runOnSimulator (/Users/antonyc/Projects/AwesomeProject/node_modules/react-native/local-cli/runIOS/runIOS.js:134:10)
    at Object.runIOS [as func] (/Users/antonyc/Projects/AwesomeProject/node_modules/react-native/local-cli/runIOS/runIOS.js:106:12)
    at Promise.resolve.then (/Users/antonyc/Projects/AwesomeProject/node_modules/react-native/local-cli/cliEntry.js:117:22)
```

Test Plan:
----------
Updated findMatchingSimulator-test.js with a test case that uses the new format.

Release Notes:
--------------
[CLI] [BUGFIX] [runIOS] - Accomodate xcrun changes to look for `isAvailable` key so that it is able to match the correct simulator

<!--
  **INTERNAL and MINOR tagged notes will not be included in the next version's final release notes.**

    CATEGORY
  [----------]      TYPE
  [ CLI      ] [-------------]    LOCATION
  [ DOCS     ] [ BREAKING    ] [-------------]
  [ GENERAL  ] [ BUGFIX      ] [ {Component} ]
  [ INTERNAL ] [ ENHANCEMENT ] [ {Filename}  ]
  [ IOS      ] [ FEATURE     ] [ {Directory} ]   |-----------|
  [ ANDROID  ] [ MINOR       ] [ {Framework} ] - | {Message} |
  [----------] [-------------] [-------------]   |-----------|

 EXAMPLES:

 [IOS] [BREAKING] [FlatList] - Change a thing that breaks other things
 [ANDROID] [BUGFIX] [TextInput] - Did a thing to TextInput
 [CLI] [FEATURE] [local-cli/info/info.js] - CLI easier to do things with
 [DOCS] [BUGFIX] [GettingStarted.md] - Accidentally a thing/word
 [GENERAL] [ENHANCEMENT] [Yoga] - Added new yoga thing/position
 [INTERNAL] [FEATURE] [./scripts] - Added thing to script that nobody will see
-->
