### PR TITLE
Normalize scheme for URL on Android

### DIFF
--- a/Libraries/Linking/Linking.js
+++ b/Libraries/Linking/Linking.js
@@ -57,13 +57,6 @@ class Linking extends NativeEventEmitter {
    * See https://facebook.github.io/react-native/docs/linking.html#openurl
    */
   openURL(url: string): Promise<any> {
-    // Android Intent requires protocols http and https to be in lowercase.
-    // https:// and http:// works, but Https:// and Http:// doesn't.
-    if (url.toLowerCase().startsWith('https://')) {
-      url = url.replace(url.substr(0, 8), 'https://');
-    } else if (url.toLowerCase().startsWith('http://')) {
-      url = url.replace(url.substr(0, 7), 'http://');
-    }
     this._validateURL(url);
     return LinkingManager.openURL(url);
   }

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/intent/IntentModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/intent/IntentModule.java
@@ -79,7 +79,7 @@ public class IntentModule extends ReactContextBaseJavaModule {
 
     try {
       Activity currentActivity = getCurrentActivity();
-      Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
+      Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url).normalizeScheme());
 
       String selfPackageName = getReactApplicationContext().getPackageName();
       ComponentName componentName = intent.resolveActivity(


### PR DESCRIPTION
Android requires lowercase for URL scheme. This commit https://github.com/facebook/react-native/commit/d00bdb9bb8b9b11bce900689c7e28cebd2eb0807 fixed it but on React Native side.
Because it is Android specific, it should be fixed on Android side.

Android has method to normalize url scheme: https://developer.android.com/reference/android/net/Uri.html#normalizeScheme() 

Test Plan:
---------
```java
> import android.net.Uri;
> 
> Uri.parse("Http://google.com").normalizeScheme();

Result: http://google.com
> import android.net.Uri;
> 
> Uri.parse("HtTps://google.com").normalizeScheme();

Result: https://google.com
```

Release Notes:
--------------
[ANDROID] [BUGFIX] [Component] - Normalize Android URI scheme