### PR TITLE
Bump Detox to 9.x

### DIFF
--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -315,7 +315,7 @@ dependencies {
     testImplementation "org.robolectric:robolectric:${ROBOLECTRIC_VERSION}"
 
     androidTestImplementation fileTree(dir: 'src/main/third-party/java/buck-android-support/', include: ['*.jar'])
-    androidTestImplementation 'com.android.support.test:runner:0.3'
+    androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation "org.mockito:mockito-core:${MOCKITO_CORE_VERSION}"
 }
 

--- a/local-cli/templates/HelloWorld/android/gradle/wrapper/gradle-wrapper.properties
+++ b/local-cli/templates/HelloWorld/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10-all.zip

--- a/package.json
+++ b/package.json
@@ -209,7 +209,7 @@
     "async": "^2.4.0",
     "babel-eslint": "9.0.0",
     "babel-generator": "^6.26.0",
-    "detox": "^8.2.3",
+    "detox": "^9.0.4",
     "eslint": "5.1.0",
     "eslint-config-fb-strict": "22.1.0",
     "eslint-config-fbjs": "2.0.1",


### PR DESCRIPTION
Fixes #21539 

Ran `npm test-ios-e2e` and all tests are passing after upgrade. 