### PR TITLE
[NativeMethodsMixin] CheckBox: Convert NativeMethodsMixin to forwardedRef, convert to class

### DIFF
--- a/Libraries/Components/CheckBox/CheckBox.android.js
+++ b/Libraries/Components/CheckBox/CheckBox.android.js
@@ -10,7 +10,6 @@
 'use strict';
 
 const React = require('React');
-const ReactNative = require('ReactNative');
 const StyleSheet = require('StyleSheet');
 
 const requireNativeComponent = require('requireNativeComponent');

--- a/Libraries/Components/CheckBox/CheckBox.android.js
+++ b/Libraries/Components/CheckBox/CheckBox.android.js
@@ -192,8 +192,8 @@ const styles = StyleSheet.create({
 type CheckBoxType = Class<NativeComponent<Props>>;
 
 // $FlowFixMe - TODO T29156721 `React.forwardRef` is not defined in Flow, yet.
-const CheckBoxWithRef = React.forwardRef((props, ref) => (
-  <CheckBox {...props} forwardedRef={ref} />
-));
+const CheckBoxWithRef = React.forwardRef(function CheckBoxWithRef(props, ref) {
+  return <CheckBox {...props} forwardedRef={ref} />;
+});
 
 module.exports = (CheckBoxWithRef: CheckBoxType);

--- a/Libraries/Components/CheckBox/CheckBox.android.js
+++ b/Libraries/Components/CheckBox/CheckBox.android.js
@@ -15,10 +15,9 @@ const StyleSheet = require('StyleSheet');
 const requireNativeComponent = require('requireNativeComponent');
 const nullthrows = require('nullthrows');
 
-const RCTCheckBox = requireNativeComponent('AndroidCheckBox');
-
 import type {ViewProps} from 'ViewPropTypes';
 import type {SyntheticEvent} from 'CoreEventTypes';
+import type {NativeComponent} from 'ReactNative';
 
 type CheckBoxEvent = SyntheticEvent<
   $ReadOnly<{|
@@ -62,6 +61,18 @@ type Props = $ReadOnly<{|
    */
   ref?: ?Object,
 |}>;
+
+type NativeProps = $ReadOnly<{|
+  ...Props,
+  on?: ?boolean,
+  enabled?: boolean,
+|}>;
+
+type CheckBoxNativeType = Class<NativeComponent<NativeProps>>;
+
+const RCTCheckBox = ((requireNativeComponent(
+  'AndroidCheckBox',
+): any): CheckBoxNativeType);
 
 /**
  * Renders a boolean input (Android only).
@@ -119,8 +130,7 @@ type Props = $ReadOnly<{|
  * @keyword toggle
  */
 class CheckBox extends React.Component<Props> {
-  // $FlowFixMe How to type a native component to be able to call setNativeProps
-  _nativeRef: ?React.ElementRef<typeof RCTCheckBox> = null;
+  _nativeRef: ?React.ElementRef<CheckBoxNativeType> = null;
 
   static defaultProps = {
     value: false,

--- a/Libraries/Components/CheckBox/CheckBox.android.js
+++ b/Libraries/Components/CheckBox/CheckBox.android.js
@@ -26,21 +26,7 @@ type CheckBoxEvent = SyntheticEvent<
   |}>,
 >;
 
-type Props = $ReadOnly<{|
-  ...ViewProps,
-
-  /**
-   * The value of the checkbox.  If true the checkbox will be turned on.
-   * Default value is false.
-   */
-  value?: ?boolean,
-
-  /**
-   * If true the user won't be able to toggle the checkbox.
-   * Default value is false.
-   */
-  disabled?: ?boolean,
-
+type CommonProps = $ReadOnly<{|
   /**
    * Used in case the props change removes the component.
    */
@@ -59,11 +45,31 @@ type Props = $ReadOnly<{|
   /**
    * Used to get the ref for the native checkbox
    */
-  ref?: ?Object,
+  // $FlowFixMe: Properly type the ref prop type
+  ref?: $FlowIssue,
+|}>;
+
+type Props = $ReadOnly<{|
+  ...ViewProps,
+  ...CommonProps,
+
+  /**
+   * The value of the checkbox.  If true the checkbox will be turned on.
+   * Default value is false.
+   */
+  value?: ?boolean,
+
+  /**
+   * If true the user won't be able to toggle the checkbox.
+   * Default value is false.
+   */
+  disabled?: ?boolean,
 |}>;
 
 type NativeProps = $ReadOnly<{|
-  ...Props,
+  ...ViewProps,
+  ...CommonProps,
+
   on?: ?boolean,
   enabled?: boolean,
 |}>;
@@ -161,18 +167,19 @@ class CheckBox extends React.Component<Props> {
   };
 
   render() {
-    const props = {
-      ...this.props,
+    const {disabled, value, ...props} = this.props;
+    const nativeProps = {
+      ...props,
       onStartShouldSetResponder: () => true,
       onResponderTerminationRequest: () => false,
-      enabled: !this.props.disabled,
-      on: this.props.value,
-      style: [styles.rctCheckBox, this.props.style],
+      enabled: !disabled,
+      on: value,
+      style: [styles.rctCheckBox, props.style],
     };
 
     return (
       <RCTCheckBox
-        {...props}
+        {...nativeProps}
         ref={this._setAndForwardRef}
         onChange={this._onChange}
       />

--- a/Libraries/Components/CheckBox/CheckBox.android.js
+++ b/Libraries/Components/CheckBox/CheckBox.android.js
@@ -159,14 +159,14 @@ class CheckBox extends React.Component<Props> {
   };
 
   render() {
-    const {disabled, value, forwardedRef, ...props} = this.props;
+    const {disabled, value, style, forwardedRef, ...props} = this.props;
     const nativeProps = {
       ...props,
       onStartShouldSetResponder: () => true,
       onResponderTerminationRequest: () => false,
       enabled: !disabled,
       on: value,
-      style: [styles.rctCheckBox, props.style],
+      style: [styles.rctCheckBox, style],
     };
 
     return (


### PR DESCRIPTION
This PR converts the use of `NativeMethodsMixin` in `CheckBox.android.js`, and converts it to an ES6-style class.

Test Plan:
----------
I have tested it in RNTester, and I ran in to no issues.

Release Notes:
--------------

[GENERAL] [ENHANCEMENT] [Libraries/Components/CheckBox/CheckBox.android.js] - Convert NativeMethodsMixin to forwardedRef, converted to ES6 class

<!--
  **INTERNAL and MINOR tagged notes will not be included in the next version's final release notes.**

    CATEGORY
  [----------]      TYPE
  [ CLI      ] [-------------]    LOCATION
  [ DOCS     ] [ BREAKING    ] [-------------]
  [ GENERAL  ] [ BUGFIX      ] [ {Component} ]
  [ INTERNAL ] [ ENHANCEMENT ] [ {Filename}  ]
  [ IOS      ] [ FEATURE     ] [ {Directory} ]   |-----------|
  [ ANDROID  ] [ MINOR       ] [ {Framework} ] - | {Message} |
  [----------] [-------------] [-------------]   |-----------|

 EXAMPLES:

 [IOS] [BREAKING] [FlatList] - Change a thing that breaks other things
 [ANDROID] [BUGFIX] [TextInput] - Did a thing to TextInput
 [CLI] [FEATURE] [local-cli/info/info.js] - CLI easier to do things with
 [DOCS] [BUGFIX] [GettingStarted.md] - Accidentally a thing/word
 [GENERAL] [ENHANCEMENT] [Yoga] - Added new yoga thing/position
 [INTERNAL] [FEATURE] [./scripts] - Added thing to script that nobody will see
-->
