### PR TITLE
Allow CxxModules to implement methods with two callbacks

### DIFF
--- a/ReactCommon/cxxreact/CxxModule.h
+++ b/ReactCommon/cxxreact/CxxModule.h
@@ -67,11 +67,10 @@ public:
     std::string name;
 
     size_t callbacks;
+    bool isPromise;
     std::function<void(folly::dynamic, Callback, Callback)> func;
 
     std::function<folly::dynamic(folly::dynamic)> syncFunc;
-
-    bool isPromise;
 
     const char *getType() {
       assert(func || syncFunc);

--- a/ReactCommon/cxxreact/CxxModule.h
+++ b/ReactCommon/cxxreact/CxxModule.h
@@ -71,9 +71,11 @@ public:
 
     std::function<folly::dynamic(folly::dynamic)> syncFunc;
 
+    bool isPromise;
+
     const char *getType() {
       assert(func || syncFunc);
-      return func ? (callbacks == 2 ? "promise" : "async") : "sync";
+      return func ? (isPromise ? "promise" : "async") : "sync";
     }
 
     // std::function/lambda ctors
@@ -82,24 +84,36 @@ public:
            std::function<void()>&& afunc)
       : name(std::move(aname))
       , callbacks(0)
+      , isPromise(false)
       , func(std::bind(std::move(afunc))) {}
 
     Method(std::string aname,
            std::function<void(folly::dynamic)>&& afunc)
       : name(std::move(aname))
       , callbacks(0)
-      , func(std::bind(std::move(afunc), _1)) {}
+      , isPromise(false)
+      , func(std::bind(std::move(afunc), std::placeholders::_1)) {}
 
     Method(std::string aname,
            std::function<void(folly::dynamic, Callback)>&& afunc)
       : name(std::move(aname))
       , callbacks(1)
-      , func(std::bind(std::move(afunc), _1, _2)) {}
+      , isPromise(false)
+      , func(std::bind(std::move(afunc), std::placeholders::_1, std::placeholders::_2)) {}
 
     Method(std::string aname,
            std::function<void(folly::dynamic, Callback, Callback)>&& afunc)
       : name(std::move(aname))
       , callbacks(2)
+      , isPromise(true)
+      , func(std::move(afunc)) {}
+
+    Method(std::string aname,
+           std::function<void(folly::dynamic, Callback, Callback)>&& afunc,
+           AsyncTagType)
+      : name(std::move(aname))
+      , callbacks(2)
+      , isPromise(false)
       , func(std::move(afunc)) {}
 
     // method pointer ctors
@@ -108,25 +122,39 @@ public:
     Method(std::string aname, T* t, void (T::*method)())
       : name(std::move(aname))
       , callbacks(0)
+      , isPromise(false)
       , func(std::bind(method, t)) {}
 
     template <typename T>
     Method(std::string aname, T* t, void (T::*method)(folly::dynamic))
       : name(std::move(aname))
       , callbacks(0)
-      , func(std::bind(method, t, _1)) {}
+      , isPromise(false)
+      , func(std::bind(method, t, std::placeholders::_1)) {}
 
     template <typename T>
     Method(std::string aname, T* t, void (T::*method)(folly::dynamic, Callback))
       : name(std::move(aname))
       , callbacks(1)
-      , func(std::bind(method, t, _1, _2)) {}
+      , isPromise(false)
+      , func(std::bind(method, t, std::placeholders::_1, std::placeholders::_2)) {}
 
     template <typename T>
     Method(std::string aname, T* t, void (T::*method)(folly::dynamic, Callback, Callback))
       : name(std::move(aname))
       , callbacks(2)
-      , func(std::bind(method, t, _1, _2, _3)) {}
+      , isPromise(true)
+      , func(std::bind(method, t, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3)) {}
+
+    template <typename T>
+    Method(std::string aname,
+          T* t,
+          void (T::*method)(folly::dynamic, Callback, Callback),
+          AsyncTagType)
+      : name(std::move(aname))
+      , callbacks(2)
+      , isPromise(false)
+      , func(std::bind(method, t, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3)) {}
 
     // sync std::function/lambda ctors
 
@@ -139,6 +167,7 @@ public:
            SyncTagType)
       : name(std::move(aname))
       , callbacks(0)
+      , isPromise(false)
       , syncFunc([afunc=std::move(afunc)] (const folly::dynamic&)
                  { return afunc(); })
     {}
@@ -148,6 +177,7 @@ public:
            SyncTagType)
       : name(std::move(aname))
       , callbacks(0)
+      , isPromise(false)
       , syncFunc(std::move(afunc))
       {}
   };

--- a/ReactCommon/cxxreact/SampleCxxModule.cpp
+++ b/ReactCommon/cxxreact/SampleCxxModule.cpp
@@ -114,7 +114,7 @@ auto SampleCxxModule::getMethods() -> std::vector<Method> {
         sample_->hello();
         return nullptr;
       }, SyncTag),
-    Method("addIfPositiveAsPromise", [this](dynamic args, Callback cb, Callback cbError) {
+    Method("addIfPositiveAsPromise", [](dynamic args, Callback cb, Callback cbError) {
         auto a = jsArgAsDouble(args, 0);
         auto b = jsArgAsDouble(args, 1);
         if (a < 0 || b < 0) {
@@ -123,7 +123,7 @@ auto SampleCxxModule::getMethods() -> std::vector<Method> {
           cb({a + b});
         }
       }),
-    Method("addIfPositiveAsAsync", [this](dynamic args, Callback cb, Callback cbError) {
+    Method("addIfPositiveAsAsync", [](dynamic args, Callback cb, Callback cbError) {
         auto a = jsArgAsDouble(args, 0);
         auto b = jsArgAsDouble(args, 1);
         if (a < 0 || b < 0) {

--- a/ReactCommon/cxxreact/SampleCxxModule.cpp
+++ b/ReactCommon/cxxreact/SampleCxxModule.cpp
@@ -114,6 +114,25 @@ auto SampleCxxModule::getMethods() -> std::vector<Method> {
         sample_->hello();
         return nullptr;
       }, SyncTag),
+    Method("addIfPositiveAsPromise", [this](dynamic args, Callback cb, Callback cbError) {
+        auto a = jsArgAsDouble(args, 0);
+        auto b = jsArgAsDouble(args, 1);
+        if (a < 0 || b < 0) {
+          cbError("Negative number!");
+        } else {
+          cb(a + b);
+        }
+      }),
+    Method("addIfPositiveAsAsync", [this](dynamic args, Callback cb, Callback cbError) {
+        auto a = jsArgAsDouble(args, 0);
+        auto b = jsArgAsDouble(args, 1);
+        if (a < 0 || b < 0) {
+          cbError("Negative number!");
+        } else {
+          cb(a + b);
+        }
+      }, AsyncTag),
+
   };
 }
 

--- a/ReactCommon/cxxreact/SampleCxxModule.cpp
+++ b/ReactCommon/cxxreact/SampleCxxModule.cpp
@@ -118,18 +118,18 @@ auto SampleCxxModule::getMethods() -> std::vector<Method> {
         auto a = jsArgAsDouble(args, 0);
         auto b = jsArgAsDouble(args, 1);
         if (a < 0 || b < 0) {
-          cbError("Negative number!");
+          cbError({"Negative number!"});
         } else {
-          cb(a + b);
+          cb({a + b});
         }
       }),
     Method("addIfPositiveAsAsync", [this](dynamic args, Callback cb, Callback cbError) {
         auto a = jsArgAsDouble(args, 0);
         auto b = jsArgAsDouble(args, 1);
         if (a < 0 || b < 0) {
-          cbError("Negative number!");
+          cbError({"Negative number!"});
         } else {
-          cb(a + b);
+          cb({a + b});
         }
       }, AsyncTag),
 


### PR DESCRIPTION
When writing a native module in C++ using CxxModule, its not currently possible to write async methods which take two callbacks, that shouldn't be projected to JS as a promise.  I hit this when trying to implement the AppState module in c++.  AppState has a single method on it, getCurrentAppState, which takes two callbacks (a success and a failure callback).

This change adds a couple of new CxxModule::Method ctors, which allow devs to specify that they want two callbacks, but not a promise.  This is done using an extra tag in the ctor, similar to how you specify that you want to make a synchronous method.  I used the existing AsyncTag to indicate that the 2 callback version should be async, and not a promise.


Test Plan:
----------
Implemented the AppState module using a CxxModule for an out of tree platform.  Added sample usage to the Sample CxxModule.




Release Notes:
--------------
Help reviewers and the release process by writing your own release notes. See below for an example.

[MINOR] [ENHANCEMENT] [CxxModule.h] - Allow CxxModules to implement functions which take two callbacks

<!--
  **INTERNAL and MINOR tagged notes will not be included in the next version's final release notes.**

    CATEGORY
  [----------]      TYPE
  [ CLI      ] [-------------]    LOCATION
  [ DOCS     ] [ BREAKING    ] [-------------]
  [ GENERAL  ] [ BUGFIX      ] [ {Component} ]
  [ INTERNAL ] [ ENHANCEMENT ] [ {Filename}  ]
  [ IOS      ] [ FEATURE     ] [ {Directory} ]   |-----------|
  [ ANDROID  ] [ MINOR       ] [ {Framework} ] - | {Message} |
  [----------] [-------------] [-------------]   |-----------|

 EXAMPLES:

 [IOS] [BREAKING] [FlatList] - Change a thing that breaks other things
 [ANDROID] [BUGFIX] [TextInput] - Did a thing to TextInput
 [CLI] [FEATURE] [local-cli/info/info.js] - CLI easier to do things with
 [DOCS] [BUGFIX] [GettingStarted.md] - Accidentally a thing/word
 [GENERAL] [ENHANCEMENT] [Yoga] - Added new yoga thing/position
 [INTERNAL] [FEATURE] [./scripts] - Added thing to script that nobody will see
-->
