### PR TITLE
[NativeMethodsMixin] ProgressViewIOS: Remove PropTypes and NativeMethodsMixin, convert to functional component

### DIFF
--- a/Libraries/Components/ProgressViewIOS/ProgressViewIOS.ios.js
+++ b/Libraries/Components/ProgressViewIOS/ProgressViewIOS.ios.js
@@ -21,8 +21,6 @@ import type {ImageSource} from 'ImageSource';
 import type {ColorValue} from 'StyleSheetTypes';
 import type {ViewProps} from 'ViewPropTypes';
 
-const RCTProgressView = requireNativeComponent('RCTProgressView');
-
 type Props = $ReadOnly<{|
   ...ViewProps,
 
@@ -57,12 +55,18 @@ type Props = $ReadOnly<{|
   trackImage?: ?ImageSource,
 |}>;
 
+type NativeProgressViewIOS = Class<NativeComponent<Props>>;
+
+const RCTProgressView = ((requireNativeComponent(
+  'RCTProgressView',
+): any): NativeProgressViewIOS);
+
 /**
  * Use `ProgressViewIOS` to render a UIProgressView on iOS.
  */
 const ProgressViewIOS = (
   props: Props,
-  forwardedRef?: ?React.Ref<'RCTProgressView'>,
+  forwardedRef?: ?React.Ref<typeof RCTProgressView>,
 ) => (
   <RCTProgressView
     {...props}
@@ -80,4 +84,4 @@ const styles = StyleSheet.create({
 // $FlowFixMe - TODO T29156721 `React.forwardRef` is not defined in Flow, yet.
 const ProgressViewIOSWithRef = React.forwardRef(ProgressViewIOS);
 
-module.exports = (ProgressViewIOSWithRef: Class<NativeComponent<Props>>);
+module.exports = (ProgressViewIOSWithRef: NativeProgressViewIOS);

--- a/Libraries/Components/ProgressViewIOS/ProgressViewIOS.ios.js
+++ b/Libraries/Components/ProgressViewIOS/ProgressViewIOS.ios.js
@@ -10,17 +10,13 @@
 
 'use strict';
 
-const DeprecatedViewPropTypes = require('DeprecatedViewPropTypes');
-const Image = require('Image');
-const NativeMethodsMixin = require('NativeMethodsMixin');
-const PropTypes = require('prop-types');
 const React = require('React');
-const ReactNative = require('ReactNative');
 const StyleSheet = require('StyleSheet');
 
 const createReactClass = require('create-react-class');
 const requireNativeComponent = require('requireNativeComponent');
 
+import type {NativeComponent} from 'ReactNative';
 import type {ImageSource} from 'ImageSource';
 import type {ColorValue} from 'StyleSheetTypes';
 import type {ViewProps} from 'ViewPropTypes';
@@ -29,63 +25,51 @@ const RCTProgressView = requireNativeComponent('RCTProgressView');
 
 type Props = $ReadOnly<{|
   ...ViewProps,
+
+  /**
+   * The progress bar style.
+   */
   progressViewStyle?: ?('default' | 'bar'),
+
+  /**
+   * The progress value (between 0 and 1).
+   */
   progress?: ?number,
+
+  /**
+   * The tint color of the progress bar itself.
+   */
   progressTintColor?: ?ColorValue,
-  trackTintColor?: ?string,
+
+  /**
+   * The tint color of the progress bar track.
+   */
+  trackTintColor?: ?ColorValue,
+
+  /**
+   * A stretchable image to display as the progress bar.
+   */
   progressImage?: ?ImageSource,
+
+  /**
+   * A stretchable image to display behind the progress bar.
+   */
   trackImage?: ?ImageSource,
 |}>;
 
 /**
  * Use `ProgressViewIOS` to render a UIProgressView on iOS.
  */
-const ProgressViewIOS = createReactClass({
-  displayName: 'ProgressViewIOS',
-  mixins: [NativeMethodsMixin],
-
-  propTypes: {
-    ...DeprecatedViewPropTypes,
-    /**
-     * The progress bar style.
-     */
-    progressViewStyle: PropTypes.oneOf(['default', 'bar']),
-
-    /**
-     * The progress value (between 0 and 1).
-     */
-    progress: PropTypes.number,
-
-    /**
-     * The tint color of the progress bar itself.
-     */
-    progressTintColor: PropTypes.string,
-
-    /**
-     * The tint color of the progress bar track.
-     */
-    trackTintColor: PropTypes.string,
-
-    /**
-     * A stretchable image to display as the progress bar.
-     */
-    progressImage: Image.propTypes.source,
-
-    /**
-     * A stretchable image to display behind the progress bar.
-     */
-    trackImage: Image.propTypes.source,
-  },
-
-  render: function() {
-    return (
-      <RCTProgressView
-        {...this.props}
-        style={[styles.progressView, this.props.style]}
-      />
-    );
-  },
-});
+const ProgressViewIOS = (
+  props: Props,
+  forwardedRef?: ?React.Ref<'RCTProgressView'>,
+) => (
+  <RCTProgressView
+    {...props}
+    style={[styles.progressView, props.style]}
+    ref={forwardedRef}
+  />
+);
 
 const styles = StyleSheet.create({
   progressView: {
@@ -93,6 +77,7 @@ const styles = StyleSheet.create({
   },
 });
 
-module.exports = ((ProgressViewIOS: any): Class<
-  ReactNative.NativeComponent<Props>,
->);
+// $FlowFixMe - TODO T29156721 `React.forwardRef` is not defined in Flow, yet.
+const ProgressViewIOSWithRef = React.forwardRef(ProgressViewIOS);
+
+module.exports = (ProgressViewIOSWithRef: Class<NativeComponent<Props>>);


### PR DESCRIPTION
This PR converts `ProgressViewIOS` from a `createReactClass` component to a functional component, and removes the remaining proptypes. Its use of `NativeMethodsMixin` has been ported to a `forwardRef` to the native component.

Test Plan:
----------
I have used it in RNTester, and the example progress bars work fine.

Release Notes:
--------------
[GENERAL] [ENHANCEMENT] [Libraries/Components/ProgressViewIOS/ProgressViewIOS.ios.js] - Remove PropTypes and NativeEventsMixin, convert to functional component
