### PR TITLE
Removed method call to RCTRootView::setReactPreferredFocusedView as ...

### DIFF
--- a/React/Views/RCTTVView.m
+++ b/React/Views/RCTTVView.m
@@ -180,7 +180,6 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:unused)
 
       rootview = [rootview superview];
 
-      [(RCTRootView *)rootview setReactPreferredFocusedView:self];
       [rootview setNeedsFocusUpdate];
       [rootview updateFocusIfNeeded];
     });


### PR DESCRIPTION
…it doesn't exist (#21593)

Fixes #21593

RCTTVView.m contains a method called `setHasTVPreferredFocus`, where the following function call breaks the build:

      [(RCTRootView *)rootview setReactPreferredFocusedView:self];

`setReactPreferredFocusedView` was formerly part of **RCTRootViewInternal.h** but was removed sometime.

Test Plan:
----------

In terminal:

> cd /tmp
> git clone git@github.com:facebook/react-native.git
> cd react-native 
> grep -HRi "setReactPreferredFocusedView" *

will (without this PR) result in:

```
$ grep -HRi "setReactPreferredFocusedView" *
React/Views/RCTTVView.m:      [(RCTRootView *)rootview setReactPreferredFocusedView:self];
```

No file declares a method called "setReactPreferredFocusedView".

When it comes to build RN with iosTV-Support including `RCTTVView.m`, the build process will fail on this.
After applying this PR the build will go through successfully.

Release Notes:
--------------
Help reviewers and the release process by writing your own release notes. See below for an example.

[GENERAL] [BUGFIX] [React/Views/RCTTVView.m] - called selector does not exist.

