### PR TITLE
[createReactClass] remove createReactClass from the RNTester/js/TextExample.ios.js

### DIFF
--- a/RNTester/js/TextExample.ios.js
+++ b/RNTester/js/TextExample.ios.js
@@ -11,10 +11,9 @@
 'use strict';
 
 const Platform = require('Platform');
-var React = require('react');
-var createReactClass = require('create-react-class');
-var ReactNative = require('react-native');
-var {Text, TextInput, View, LayoutAnimation, Button} = ReactNative;
+const React = require('react');
+const ReactNative = require('react-native');
+const {Text, TextInput, View, LayoutAnimation, Button} = ReactNative;
 const TextLegend = require('./Shared/TextLegend');
 
 type TextAlignExampleRTLState = {|
@@ -122,12 +121,20 @@ class AttributeToggler extends React.Component<{}, $FlowFixMeState> {
   }
 }
 
-var AdjustingFontSize = createReactClass({
-  displayName: 'AdjustingFontSize',
-  getInitialState: function() {
-    return {dynamicText: '', shouldRender: true};
-  },
-  reset: function() {
+type AdjustingFontSizeState = {|
+  dynamicText: string,
+  shouldRender: boolean,
+|};
+
+class AdjustingFontSize extends React.Component<{}, AdjustingFontSizeState> {
+  static displayName: ?string = 'AdjustingFontSize';
+
+  state = {
+    dynamicText: '',
+    shouldRender: true,
+  };
+
+  reset = () => {
     LayoutAnimation.easeInEaseOut();
     this.setState({
       shouldRender: false,
@@ -139,23 +146,26 @@ var AdjustingFontSize = createReactClass({
         shouldRender: true,
       });
     }, 300);
-  },
-  addText: function() {
+  };
+
+  addText = () => {
     this.setState({
       dynamicText:
         this.state.dynamicText +
         (Math.floor((Math.random() * 10) % 2) ? ' foo' : ' bar'),
     });
-  },
-  removeText: function() {
+  };
+
+  removeText = () => {
     this.setState({
       dynamicText: this.state.dynamicText.slice(
         0,
         this.state.dynamicText.length - 4,
       ),
     });
-  },
-  render: function() {
+  };
+
+  render() {
     if (!this.state.shouldRender) {
       return <View />;
     }
@@ -221,8 +231,8 @@ var AdjustingFontSize = createReactClass({
         </View>
       </View>
     );
-  },
-});
+  }
+}
 
 class TextBaseLineLayoutExample extends React.Component<*, *> {
   render() {


### PR DESCRIPTION
Related to #21581 .
Removed createReactClass from the RNTester/js/TextExample.ios.js

## Test Plan
- [x] npm run prettier
- [x]  npm run flow-check-ios
- [x] npm run flow-check-android

## Release Notes
[GENERAL] [ENHANCEMENT] [RNTester/js/TextExample.ios.js] - remove createReactClass dependency