### PR TITLE
[createReactClass] remove createReactClass from the RNTester/js/PanResponderExample.js

### DIFF
--- a/RNTester/js/PanResponderExample.js
+++ b/RNTester/js/PanResponderExample.js
@@ -14,20 +14,25 @@ const React = require('react');
 const ReactNative = require('react-native');
 const {PanResponder, StyleSheet, View} = ReactNative;
 
+import type {PanResponderInstance} from 'PanResponder';
+
+type CircleStylesType = {|
+  backgroundColor: string,
+  left: number,
+  top: number,
+|};
+
 const CIRCLE_SIZE = 80;
 
 class PanResponderExample extends React.Component<{}> {
-  static displayName: ?string = 'PanResponderExample';
+  static title = 'PanResponder Sample';
+  static description =
+    'Shows the Use of PanResponder to provide basic gesture handling';
 
-  statics: {
-    title: 'PanResponder Sample',
-    description: 'Shows the use of PanResponder to provide basic gesture handling.',
-  };
-
-  _panResponder: Object = {};
+  _panResponder: PanResponderInstance | Object = {};
   _previousLeft: number = 0;
   _previousTop: number = 0;
-  _circleStyles: Object = {};
+  _circleStyles: {|style: CircleStylesType | Object|} = {style: {}};
   circle: ?{setNativeProps(props: Object): void} = null;
 
   UNSAFE_componentWillMount() {

--- a/RNTester/js/PanResponderExample.js
+++ b/RNTester/js/PanResponderExample.js
@@ -10,29 +10,27 @@
 
 'use strict';
 
-var React = require('react');
-var createReactClass = require('create-react-class');
-var ReactNative = require('react-native');
-var {PanResponder, StyleSheet, View} = ReactNative;
+const React = require('react');
+const ReactNative = require('react-native');
+const {PanResponder, StyleSheet, View} = ReactNative;
 
-var CIRCLE_SIZE = 80;
+const CIRCLE_SIZE = 80;
 
-var PanResponderExample = createReactClass({
-  displayName: 'PanResponderExample',
+class PanResponderExample extends React.Component<{}> {
+  static displayName: ?string = 'PanResponderExample';
 
   statics: {
     title: 'PanResponder Sample',
-    description:
-      'Shows the use of PanResponder to provide basic gesture handling.',
-  },
+    description: 'Shows the use of PanResponder to provide basic gesture handling.',
+  };
 
-  _panResponder: {},
-  _previousLeft: 0,
-  _previousTop: 0,
-  _circleStyles: {},
-  circle: (null: ?{setNativeProps(props: Object): void}),
+  _panResponder: Object = {};
+  _previousLeft: number = 0;
+  _previousTop: number = 0;
+  _circleStyles: Object = {};
+  circle: ?{setNativeProps(props: Object): void} = null;
 
-  UNSAFE_componentWillMount: function() {
+  UNSAFE_componentWillMount() {
     this._panResponder = PanResponder.create({
       onStartShouldSetPanResponder: this._handleStartShouldSetPanResponder,
       onMoveShouldSetPanResponder: this._handleMoveShouldSetPanResponder,
@@ -50,13 +48,59 @@ var PanResponderExample = createReactClass({
         backgroundColor: 'green',
       },
     };
-  },
+  }
 
-  componentDidMount: function() {
+  componentDidMount() {
     this._updateNativeStyles();
-  },
+  }
 
-  render: function() {
+  _highlight = () => {
+    this._circleStyles.style.backgroundColor = 'blue';
+    this._updateNativeStyles();
+  };
+
+  _unHighlight = () => {
+    this._circleStyles.style.backgroundColor = 'green';
+    this._updateNativeStyles();
+  };
+
+  _updateNativeStyles = () => {
+    this.circle && this.circle.setNativeProps(this._circleStyles);
+  };
+
+  _handleStartShouldSetPanResponder = (
+    e: Object,
+    gestureState: Object,
+  ): boolean => {
+    // Should we become active when the user presses down on the circle?
+    return true;
+  };
+
+  _handleMoveShouldSetPanResponder = (
+    e: Object,
+    gestureState: Object,
+  ): boolean => {
+    // Should we become active when the user moves a touch over the circle?
+    return true;
+  };
+
+  _handlePanResponderGrant = (e: Object, gestureState: Object) => {
+    this._highlight();
+  };
+
+  _handlePanResponderMove = (e: Object, gestureState: Object) => {
+    this._circleStyles.style.left = this._previousLeft + gestureState.dx;
+    this._circleStyles.style.top = this._previousTop + gestureState.dy;
+    this._updateNativeStyles();
+  };
+
+  _handlePanResponderEnd = (e: Object, gestureState: Object) => {
+    this._unHighlight();
+    this._previousLeft += gestureState.dx;
+    this._previousTop += gestureState.dy;
+  };
+
+  render() {
     return (
       <View style={styles.container}>
         <View
@@ -68,52 +112,8 @@ var PanResponderExample = createReactClass({
         />
       </View>
     );
-  },
-
-  _highlight: function() {
-    this._circleStyles.style.backgroundColor = 'blue';
-    this._updateNativeStyles();
-  },
-
-  _unHighlight: function() {
-    this._circleStyles.style.backgroundColor = 'green';
-    this._updateNativeStyles();
-  },
-
-  _updateNativeStyles: function() {
-    this.circle && this.circle.setNativeProps(this._circleStyles);
-  },
-
-  _handleStartShouldSetPanResponder: function(
-    e: Object,
-    gestureState: Object,
-  ): boolean {
-    // Should we become active when the user presses down on the circle?
-    return true;
-  },
-
-  _handleMoveShouldSetPanResponder: function(
-    e: Object,
-    gestureState: Object,
-  ): boolean {
-    // Should we become active when the user moves a touch over the circle?
-    return true;
-  },
-
-  _handlePanResponderGrant: function(e: Object, gestureState: Object) {
-    this._highlight();
-  },
-  _handlePanResponderMove: function(e: Object, gestureState: Object) {
-    this._circleStyles.style.left = this._previousLeft + gestureState.dx;
-    this._circleStyles.style.top = this._previousTop + gestureState.dy;
-    this._updateNativeStyles();
-  },
-  _handlePanResponderEnd: function(e: Object, gestureState: Object) {
-    this._unHighlight();
-    this._previousLeft += gestureState.dx;
-    this._previousTop += gestureState.dy;
-  },
-});
+  }
+}
 
 var styles = StyleSheet.create({
   circle: {

--- a/RNTester/js/PanResponderExample.js
+++ b/RNTester/js/PanResponderExample.js
@@ -16,11 +16,11 @@ const {PanResponder, StyleSheet, View} = ReactNative;
 
 import type {PanResponderInstance} from 'PanResponder';
 
-type CircleStylesType = {|
-  backgroundColor: string,
-  left: number,
-  top: number,
-|};
+type CircleStylesType = {
+  backgroundColor?: string,
+  left?: number,
+  top?: number,
+};
 
 const CIRCLE_SIZE = 80;
 
@@ -29,10 +29,10 @@ class PanResponderExample extends React.Component<{}> {
   static description =
     'Shows the Use of PanResponder to provide basic gesture handling';
 
-  _panResponder: PanResponderInstance | Object = {};
+  _panResponder: ?PanResponderInstance = null;
   _previousLeft: number = 0;
   _previousTop: number = 0;
-  _circleStyles: {|style: CircleStylesType | Object|} = {style: {}};
+  _circleStyles: {|style: CircleStylesType|} = {style: {}};
   circle: ?{setNativeProps(props: Object): void} = null;
 
   UNSAFE_componentWillMount() {
@@ -113,7 +113,7 @@ class PanResponderExample extends React.Component<{}> {
             this.circle = circle;
           }}
           style={styles.circle}
-          {...this._panResponder.panHandlers}
+          {...this._panResponder?.panHandlers}
         />
       </View>
     );


### PR DESCRIPTION
Related to #21581 .
Removed createReactClass from the RNTester/js/PanResponderExample.js

## Test Plan
 - [x] npm run prettier
 - [x] npm run flow-check-ios
 - [x] npm run flow-check-android

## Release Notes
[GENERAL] [ENHANCEMENT] [RNTester/js/PanResponderExample.js] - remove createReactClass dependency