### PR TITLE
[createReactClass] remove createReactClass from RNTester/js/ProgressViewIOSExample.js

### DIFF
--- a/RNTester/js/ProgressViewIOSExample.js
+++ b/RNTester/js/ProgressViewIOSExample.js
@@ -10,41 +10,41 @@
 
 'use strict';
 
-var React = require('react');
-var createReactClass = require('create-react-class');
-var ReactNative = require('react-native');
-var {ProgressViewIOS, StyleSheet, View} = ReactNative;
+const React = require('react');
+const ReactNative = require('react-native');
+const {ProgressViewIOS, StyleSheet, View} = ReactNative;
 
-var ProgressViewExample = createReactClass({
-  displayName: 'ProgressViewExample',
-  _rafId: (null: ?AnimationFrameID),
+type State = {|
+  progress: number,
+|};
 
-  getInitialState() {
-    return {
-      progress: 0,
-    };
-  },
+class ProgressViewExample extends React.Component<{}, State> {
+  _rafId: ?AnimationFrameID = null;
+
+  state = {
+    progress: 0,
+  };
 
   componentDidMount() {
     this.updateProgress();
-  },
+  }
 
   componentWillUnmount() {
     if (this._rafId != null) {
       cancelAnimationFrame(this._rafId);
     }
-  },
+  }
 
-  updateProgress() {
+  updateProgress = () => {
     var progress = this.state.progress + 0.01;
     this.setState({progress});
     this._rafId = requestAnimationFrame(() => this.updateProgress());
-  },
+  };
 
-  getProgress(offset) {
+  getProgress = offset => {
     var progress = this.state.progress + offset;
     return Math.sin(progress % Math.PI) % 1;
-  },
+  };
 
   render() {
     return (
@@ -75,8 +75,8 @@ var ProgressViewExample = createReactClass({
         />
       </View>
     );
-  },
-});
+  }
+}
 
 exports.displayName = (undefined: ?string);
 exports.framework = 'React';

--- a/RNTester/js/ProgressViewIOSExample.js
+++ b/RNTester/js/ProgressViewIOSExample.js
@@ -14,11 +14,12 @@ const React = require('react');
 const ReactNative = require('react-native');
 const {ProgressViewIOS, StyleSheet, View} = ReactNative;
 
+type Props = {||};
 type State = {|
   progress: number,
 |};
 
-class ProgressViewExample extends React.Component<{}, State> {
+class ProgressViewExample extends React.Component<Props, State> {
   _rafId: ?AnimationFrameID = null;
 
   state = {


### PR DESCRIPTION
Related to #21581 .
Removed createReactClass from the RNTester/js/ProgressViewIOSExample.js

Test Plan
----------

  - [x] npm run prettier
  - [x] npm run flow-check-ios
  - [x] npm run flow-check-android
- [x] Run RNTester app, go to ProgressViewIOS component, everything works.

Release Notes
--------------

[GENERAL] [ENHANCEMENT] [RNTester/js/ProgressViewIOSExample.js] - remove createReactClass dependency