### PR TITLE
[createReactClass] remove createReactClass from RNTester/js/SwipeableFlatListExample.js

### DIFF
--- a/RNTester/js/SwipeableFlatListExample.js
+++ b/RNTester/js/SwipeableFlatListExample.js
@@ -10,7 +10,6 @@
 'use strict';
 
 const React = require('react');
-const createReactClass = require('create-react-class');
 const ReactNative = require('react-native');
 const {
   Image,
@@ -23,6 +22,8 @@ const {
 } = ReactNative;
 
 const RNTesterPage = require('./RNTesterPage');
+
+import type {RNTesterProps} from 'RNTesterTypes';
 
 const data = [
   {
@@ -42,14 +43,11 @@ const data = [
   },
 ];
 
-const SwipeableFlatListExample = createReactClass({
-  displayName: 'SwipeableFlatListExample',
-  statics: {
-    title: '<SwipeableFlatList>',
-    description: 'Performant, scrollable, swipeable list of data.',
-  },
+class SwipeableFlatListExample extends React.Component<RNTesterProps> {
+  static title = '<SwipeableFlatList>';
+  static description = 'Performant, scrollable, swipeable list of data.';
 
-  render: function() {
+  render() {
     return (
       <RNTesterPage
         title={this.props.navigator ? null : '<SwipeableListView>'}
@@ -64,9 +62,9 @@ const SwipeableFlatListExample = createReactClass({
         />
       </RNTesterPage>
     );
-  },
+  }
 
-  _renderItem: function({item}): ?React.Element<any> {
+  _renderItem({item}): ?React.Element<any> {
     return (
       <View style={styles.row}>
         <Image style={styles.rowIcon} source={item.icon} />
@@ -75,9 +73,9 @@ const SwipeableFlatListExample = createReactClass({
         </View>
       </View>
     );
-  },
+  }
 
-  _renderQuickActions: function({item}: Object): ?React.Element<any> {
+  _renderQuickActions({item}: Object): ?React.Element<any> {
     return (
       <View style={styles.actionsContainer}>
         <TouchableHighlight
@@ -102,8 +100,8 @@ const SwipeableFlatListExample = createReactClass({
         </TouchableHighlight>
       </View>
     );
-  },
-});
+  }
+}
 
 var styles = StyleSheet.create({
   row: {


### PR DESCRIPTION
Related to #21581 .
Removed createReactClass from the RNTester/js/SwipeableFlatListExample.js

Test Plan
-----

 - [x]  npm run prettier
- [x]  npm run flow-check-ios
- [x]  npm run flow-check-android
- [x]  Run RNTester app, go to SwipeableFlatList component, everything works.

Release Notes
--------

[GENERAL] [ENHANCEMENT] [RNTester/js/SwipeableFlatListExample.js] - remove createReactClass dependency