### PR TITLE
Support for scoped templates

### DIFF
--- a/local-cli/generator/templates.js
+++ b/local-cli/generator/templates.js
@@ -75,7 +75,13 @@ function createFromRemoteTemplate(
     templateName = template.substr(template.lastIndexOf('/') + 1);
   } else {
     // e.g 'demo'
-    installPackage = 'react-native-template-' + template;
+    let scope = ''
+    if(template[0] === '@' && template.length > 3 && template.includes('/', 2)) {
+      [scope, ...template] = template.split('/')
+      scope += '/'
+      template = template.join('/')
+    }
+    installPackage = `${scope}react-native-template-${template}`;
     templateName = installPackage;
   }
 

--- a/local-cli/generator/templates.js
+++ b/local-cli/generator/templates.js
@@ -75,11 +75,15 @@ function createFromRemoteTemplate(
     templateName = template.substr(template.lastIndexOf('/') + 1);
   } else {
     // e.g 'demo'
-    let scope = ''
-    if(template[0] === '@' && template.length > 3 && template.includes('/', 2)) {
-      [scope, ...template] = template.split('/')
-      scope += '/'
-      template = template.join('/')
+    let scope = '';
+    if (
+      template[0] === '@' &&
+      template.length > 3 &&
+      template.includes('/', 2)
+    ) {
+      [scope, ...template] = template.split('/');
+      scope += '/';
+      template = template.join('/');
     }
     installPackage = `${scope}react-native-template-${template}`;
     templateName = installPackage;


### PR DESCRIPTION
This is a rebase of #18974 in the hopes that it would get merged.

Add support for templates published as scoped packages. Partially fixes #18973.

Test Plan

Published a template as a scoped package and installed it.

Related PRs

Documentation says nothing regarding lack of support for scoped packages, so intuitively they should work. This pull-request just makes that intuitive assumption true, so I think no changes on documentation are needed.

Release Notes

[CLI] [BUGFIX] [local-cli/generator/templates.js] - Support for scoped npm packages as templates
