### PR TITLE
 [createReactClass] remove createReactClass from the IntegrationTests/ReactContentSizeUpdateTest.js

### DIFF
--- a/IntegrationTests/ReactContentSizeUpdateTest.js
+++ b/IntegrationTests/ReactContentSizeUpdateTest.js
@@ -11,7 +11,6 @@
 'use strict';
 
 const React = require('react');
-const createReactClass = require('create-react-class');
 const ReactNative = require('react-native');
 const RCTNativeAppEventEmitter = require('RCTNativeAppEventEmitter');
 
@@ -25,39 +24,34 @@ const reactViewHeight = 102;
 const newReactViewWidth = 201;
 const newReactViewHeight = 202;
 
-const ReactContentSizeUpdateTest = createReactClass({
-  displayName: 'ReactContentSizeUpdateTest',
-  _timeoutID: (null: ?TimeoutID),
-  _subscription: (null: ?EmitterSubscription),
+type State = {|
+  height: number,
+  width: number,
+|};
 
-  UNSAFE_componentWillMount: function() {
+class ReactContentSizeUpdateTest extends React.Component<{}, State>{
+  _timeoutID: ?TimeoutID = null;
+  _subscription: ?EmitterSubscription = null;
+
+  state = {
+    height: reactViewHeight,
+    width: reactViewWidth,
+  };
+
+  UNSAFE_componentWillMount() {
     this._subscription = RCTNativeAppEventEmitter.addListener(
       'rootViewDidChangeIntrinsicSize',
       this.rootViewDidChangeIntrinsicSize,
     );
-  },
+  }
 
-  getInitialState: function() {
-    return {
-      height: reactViewHeight,
-      width: reactViewWidth,
-    };
-  },
-
-  updateViewSize: function() {
-    this.setState({
-      height: newReactViewHeight,
-      width: newReactViewWidth,
-    });
-  },
-
-  componentDidMount: function() {
+  componentDidMount() {
     this._timeoutID = setTimeout(() => {
       this.updateViewSize();
     }, 1000);
-  },
+  }
 
-  componentWillUnmount: function() {
+  componentWillUnmount() {
     if (this._timeoutID != null) {
       clearTimeout(this._timeoutID);
     }
@@ -65,24 +59,32 @@ const ReactContentSizeUpdateTest = createReactClass({
     if (this._subscription != null) {
       this._subscription.remove();
     }
-  },
+  }
 
-  rootViewDidChangeIntrinsicSize: function(intrinsicSize) {
+  updateViewSize = () => {
+    this.setState({
+      height: newReactViewHeight,
+      width: newReactViewWidth,
+    });
+  };
+
+  rootViewDidChangeIntrinsicSize = (intrinsicSize: {
+    height: number,
+    width: number,
+  }) => {
     if (
       intrinsicSize.height === newReactViewHeight &&
       intrinsicSize.width === newReactViewWidth
     ) {
       TestModule.markTestPassed(true);
     }
-  },
+  };
 
   render() {
     return (
       <View style={{height: this.state.height, width: this.state.width}} />
     );
-  },
-});
-
-ReactContentSizeUpdateTest.displayName = 'ReactContentSizeUpdateTest';
+  }
+}
 
 module.exports = ReactContentSizeUpdateTest;

--- a/IntegrationTests/ReactContentSizeUpdateTest.js
+++ b/IntegrationTests/ReactContentSizeUpdateTest.js
@@ -29,7 +29,7 @@ type State = {|
   width: number,
 |};
 
-class ReactContentSizeUpdateTest extends React.Component<{}, State>{
+class ReactContentSizeUpdateTest extends React.Component<{}, State> {
   _timeoutID: ?TimeoutID = null;
   _subscription: ?EmitterSubscription = null;
 


### PR DESCRIPTION
Related to #21581 .
Removed createReactClass from the IntegrationTests/ReactContentSizeUpdateTest.js

## Test Plan
 - [x] npm run prettier
 - [x] npm run flow-check-ios
 - [x] npm run flow-check-android

## Release Notes
[GENERAL] [ENHANCEMENT] [IntegrationTests/ReactContentSizeUpdateTest.js] - remove createReactClass dependency