### PR TITLE
[Animated] check for undefined values in the config object for vector animations

### DIFF
--- a/Libraries/Animated/src/AnimatedImplementation.js
+++ b/Libraries/Animated/src/AnimatedImplementation.js
@@ -110,6 +110,7 @@ const maybeVectorAnim = function(
     const configX = {...config};
     const configY = {...config};
     for (const key in config) {
+      if (config[key] === undefined || config[key] === null) continue;
       const {x, y} = config[key];
       if (x !== undefined && y !== undefined) {
         configX[key] = x;

--- a/Libraries/Animated/src/AnimatedImplementation.js
+++ b/Libraries/Animated/src/AnimatedImplementation.js
@@ -110,7 +110,9 @@ const maybeVectorAnim = function(
     const configX = {...config};
     const configY = {...config};
     for (const key in config) {
-      if (config[key] === undefined || config[key] === null) continue;
+      if (config[key] === undefined || config[key] === null) {
+        continue;
+      }
       const {x, y} = config[key];
       if (x !== undefined && y !== undefined) {
         configX[key] = x;

--- a/Libraries/Animated/src/__tests__/Animated-test.js
+++ b/Libraries/Animated/src/__tests__/Animated-test.js
@@ -782,6 +782,25 @@ describe('Animated tests', () => {
       expect(Math.round(value2.__getValue().x)).toEqual(2);
       expect(Math.round(value2.__getValue().y)).toEqual(2);
     });
+
+    it('should accept undefined values in the config object', () => {
+      const value1 = new Animated.ValueXY();
+      const value2 = new Animated.ValueXY();
+      Animated.spring(value2, {
+        toValue: value1,
+        tension: 3000, // faster spring for faster test
+        friction: 60,
+        stiffness: undefined,
+      }).start();
+      value1.setValue({x: 1, y: 1});
+      jest.runAllTimers();
+      expect(Math.round(value2.__getValue().x)).toEqual(1);
+      expect(Math.round(value2.__getValue().y)).toEqual(1);
+      value1.setValue({x: 2, y: 2});
+      jest.runAllTimers();
+      expect(Math.round(value2.__getValue().x)).toEqual(2);
+      expect(Math.round(value2.__getValue().y)).toEqual(2);
+    });
   });
 
   describe('Animated Listeners', () => {


### PR DESCRIPTION
If you passed in a config object with an `undefined` value for XY animation, the destructuring of the config keys result in an exception since you can't destrcuture a null or undefined value.

Test Plan:
----------

- Test case added

Release Notes
--------------

[ GENERAL ] [ BUGFIX ] [ {Animated.spring} ] - Fix bug with config object for vector animations when a key has an undefined value