### PR TITLE
[ANDROID][MINOR]: ReactAndroid - "compile" to "implementation"

### DIFF
--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -304,7 +304,7 @@ dependencies {
     api "com.squareup.okhttp3:okhttp:${OKHTTP_VERSION}"
     api "com.squareup.okhttp3:okhttp-urlconnection:${OKHTTP_VERSION}"
     api 'com.squareup.okio:okio:1.14.0'
-    compile project(':android-jsc')
+    implementation project(':android-jsc')
 
     testImplementation "junit:junit:${JUNIT_VERSION}"
     testImplementation "org.powermock:powermock-api-mockito:${POWERMOCK_VERSION}"

--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -304,7 +304,7 @@ dependencies {
     api "com.squareup.okhttp3:okhttp:${OKHTTP_VERSION}"
     api "com.squareup.okhttp3:okhttp-urlconnection:${OKHTTP_VERSION}"
     api 'com.squareup.okio:okio:1.14.0'
-    implementation project(':android-jsc')
+    api project(':android-jsc')
 
     testImplementation "junit:junit:${JUNIT_VERSION}"
     testImplementation "org.powermock:powermock-api-mockito:${POWERMOCK_VERSION}"


### PR DESCRIPTION
With this syncing with gradle gives 0 beautiful warnings.

# Test Plan:
- RNTester to sync without warnings.

# Release Notes
[ANDROID] [MINOR] - ReactAndroid - "compile" to "implementation" for `android-jsc`