### PR TITLE
local-cli: restore symlink scanning in default case

### DIFF
--- a/local-cli/util/Config.js
+++ b/local-cli/util/Config.js
@@ -41,15 +41,16 @@ const resolveSymlinksForRoots = roots =>
      * error found when Flow v0.70 was deployed. To see the error delete this
      * comment and run Flow. */
     (arr, rootPath) => arr.concat(findSymlinkedModules(rootPath, roots)),
-    [...roots],
+    [],
   );
 
 const getWatchFolders = () => {
   const root = process.env.REACT_NATIVE_APP_ROOT;
   if (root) {
-    return resolveSymlinksForRoots([path.resolve(root)]);
+    const rootFullPath = path.resolve(root);
+    return [rootFullPath, ...resolveSymlinksForRoots([rootFullPath])];
   }
-  return [];
+  return resolveSymlinksForRoots([getProjectRoot()]);
 };
 
 const getBlacklistRE = () => {


### PR DESCRIPTION
Commit 9a77ff5 seems to disable symlink scanning for apps that don't
have a config file. This commit should restore that, without breaking
those with a config file.

Fixes #21735

--------

Thank you for sending the PR! We appreciate you spending the time to work on these changes.
Help us understand your motivation by explaining why you decided to make this change.

If this PR fixes an issue, type "Fixes #issueNumber" to automatically close the issue when the PR is merged.

_Pull requests that expand test coverage are more likely to get reviewed. Add a test case whenever possible!_

Test Plan:
----------
Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!

- Make sure it bundles peat-psuwit/react-native-symlink-scan-demo@4298dcc.
  - Checkout that commit, then points react-native to this PR (don't forget to also update react).
  - Run `react-native start`, then go to http://localhost:8081/index.bundle?platform=android to see that it bundles correctly.
- Make sure it bundles newly-created React Native project.
- Make sure it doesn't re-introduce #20712
  - As peat-psuwit/react-native-symlink-scan-demo@4298dcc doesn't have any config file, if it bundles on Windows, then #20712 shouldn't be back.

Release Notes:
--------------
Help reviewers and the release process by writing your own release notes. See below for an example.

[CLI] [BUGFIX] [local-cli/util/Config.js] - Restore symlink scanning in default case

<!--
  **INTERNAL and MINOR tagged notes will not be included in the next version's final release notes.**

    CATEGORY
  [----------]      TYPE
  [ CLI      ] [-------------]    LOCATION
  [ DOCS     ] [ BREAKING    ] [-------------]
  [ GENERAL  ] [ BUGFIX      ] [ {Component} ]
  [ INTERNAL ] [ ENHANCEMENT ] [ {Filename}  ]
  [ IOS      ] [ FEATURE     ] [ {Directory} ]   |-----------|
  [ ANDROID  ] [ MINOR       ] [ {Framework} ] - | {Message} |
  [----------] [-------------] [-------------]   |-----------|

 EXAMPLES:

 [IOS] [BREAKING] [FlatList] - Change a thing that breaks other things
 [ANDROID] [BUGFIX] [TextInput] - Did a thing to TextInput
 [CLI] [FEATURE] [local-cli/info/info.js] - CLI easier to do things with
 [DOCS] [BUGFIX] [GettingStarted.md] - Accidentally a thing/word
 [GENERAL] [ENHANCEMENT] [Yoga] - Added new yoga thing/position
 [INTERNAL] [FEATURE] [./scripts] - Added thing to script that nobody will see
-->
