### PR TITLE
Copy bundled resources and js in Android App Bundle builds

### DIFF
--- a/react.gradle
+++ b/react.gradle
@@ -97,6 +97,9 @@ afterEvaluate {
             ? variant.packageApplication
             : tasks.findByName("package${targetName}")
 
+        // pre bundle build task for Android plugin 3.2+
+        def buildPreBundleTask = tasks.findByName("build${targetName}PreBundle")
+
         def resourcesDirConfigValue = config."resourcesDir${targetName}"
         if (resourcesDirConfigValue) {
             def currentCopyResTask = tasks.create(
@@ -114,6 +117,9 @@ afterEvaluate {
             }
 
             packageTask.dependsOn(currentCopyResTask)
+            if (buildPreBundleTask != null) {
+                buildPreBundleTask.dependsOn(currentCopyResTask)
+            }
         }
 
         def currentAssetsCopyTask = tasks.create(
@@ -144,5 +150,8 @@ afterEvaluate {
         }
 
         packageTask.dependsOn(currentAssetsCopyTask)
+        if (buildPreBundleTask != null) {
+            buildPreBundleTask.dependsOn(currentAssetsCopyTask)
+        }
     }
 }


### PR DESCRIPTION
Android App Bundle builds use the packageBundle and bundle tasks instead
of the package and assemble tasks the APK builds use. Because of this,
the resources and js bundles weren't getting copied into the final
artifact. In an App Bundle build, the merged assets must be present
during the buildPreBundle step in order to arrive in the App Bundle.

Test Plan:
----------

- Verify APK build in Android Studio 3.1.4, 3.2, and 3.3 still build successfully
- Verify bundle build in Android Studio 3.2 and 3.3 build successfully
(Clean project between each build, as leftovers from past builds would previously cause the bundle build to incidentally work.)

Release Notes:
--------------

[ANDROID] [BUGFIX] [react.gradle] - Fix packaging resources and js in Android App Bundle builds
