### PR TITLE
[CI] Enforce lockfile is kept up to date

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -198,6 +198,7 @@ aliases:
     command: |
       ./scripts/circleci/check_license.sh
       ./scripts/circleci/check_cache.sh
+      ./scripts/circleci/validate_yarn_lockfile.sh
     when: always
 
   - &download-dependencies-gradle

--- a/scripts/circleci/validate_yarn_lockfile.sh
+++ b/scripts/circleci/validate_yarn_lockfile.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# Abort the mission if any command fails
+set -e
+
+# Allow the script to be invoked from various environments
+if [[ -z "${OVERRIDE_YARN_BINARY}" ]]; then
+  YARN_BINARY=$(command -v yarn)
+else
+  YARN_BINARY="${OVERRIDE_YARN_BINARY}"
+fi
+
+REACT_NATIVE_TEMP_DIR=$(mktemp -d /tmp/react-native-XXXXXXXX)
+
+function cleanup {
+  set +e
+  rm -rf "$REACT_NATIVE_TEMP_DIR"
+  set -e
+}
+
+function msg {
+  echo -e " "
+  echo -e "\\x1B[36m${1}\\x1B[0m";
+  echo -e "\\x1B[36m${1//?/=}\\x1B[0m"
+}
+
+trap cleanup EXIT
+
+cp -R ./package.json "$REACT_NATIVE_TEMP_DIR"
+cp -R ./yarn.lock "$REACT_NATIVE_TEMP_DIR"
+pushd "$REACT_NATIVE_TEMP_DIR" >/dev/null
+
+if ! $YARN_BINARY --ignore-scripts --silent --non-interactive --mutex network --frozen-lockfile; then
+  msg "Yarn validation failed."
+  echo "This means the package.json and yarn.lock disagree in some way."
+  echo "Try fixing it by running \`yarn\` and comitting the changes."
+fi
+
+popd >/dev/null

--- a/scripts/circleci/validate_yarn_lockfile.sh
+++ b/scripts/circleci/validate_yarn_lockfile.sh
@@ -33,7 +33,7 @@ pushd "$REACT_NATIVE_TEMP_DIR" >/dev/null
 if ! $YARN_BINARY --ignore-scripts --silent --non-interactive --mutex network --frozen-lockfile; then
   msg "Yarn validation failed."
   echo "This means the package.json and yarn.lock disagree in some way."
-  echo "Try fixing it by running \`yarn\` and comitting the changes."
+  echo "Try fixing it by running \`yarn\` and committing the changes."
 fi
 
 popd >/dev/null


### PR DESCRIPTION
Adds a new script that runs Yarn with --frozen-lockfile, and fails if Yarn finds the lockfile is out of sync.

Keeping the lockfile in sync with package.json will ensure our internal open source tests can run offline, as our offline mirror is updated whenever the lockfile changes.

# Test Plan:

Reverted yarn.lock to https://raw.githubusercontent.com/facebook/react-native/6eeff75849c9b8bf91592c1b7906b4dab8fba518/yarn.lock, then ran `scripts/circleci/validate_yarn_lockfile.sh`, and verified the script failed as expected.

I then ran Yarn without the --frozen-lockfile flag, and reran the validation script. This time, the script finished successfully.