### PR TITLE
Add fix for refresh control state's race condition.

### DIFF
--- a/React/Views/RCTRefreshControl.m
+++ b/React/Views/RCTRefreshControl.m
@@ -23,7 +23,7 @@
 {
   if ((self = [super init])) {
     [self addTarget:self action:@selector(refreshControlValueChanged) forControlEvents:UIControlEventValueChanged];
-    _currentRefreshingStateClock=1;
+    _currentRefreshingStateClock = 1;
     _currentRefreshingStateTimestamp = 0;
     _isInitialRender = true;
     _currentRefreshingState = false;

--- a/React/Views/RCTRefreshControl.m
+++ b/React/Views/RCTRefreshControl.m
@@ -12,6 +12,7 @@
 @implementation RCTRefreshControl {
   BOOL _isInitialRender;
   BOOL _currentRefreshingState;
+  UInt64 _currentRefreshingStateClock;
   UInt64 _currentRefreshingStateTimestamp;
   BOOL _refreshingProgrammatically;
   NSString *_title;
@@ -22,6 +23,7 @@
 {
   if ((self = [super init])) {
     [self addTarget:self action:@selector(refreshControlValueChanged) forControlEvents:UIControlEventValueChanged];
+    _currentRefreshingStateClock=1;
     _currentRefreshingStateTimestamp = 0;
     _isInitialRender = true;
     _currentRefreshingState = false;
@@ -65,7 +67,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
                      animations:^(void) {
                        [scrollView setContentOffset:offset];
                      } completion:^(__unused BOOL finished) {
-                       if(beginRefreshingTimestamp == _currentRefreshingStateTimestamp) {
+                       if(beginRefreshingTimestamp == self->_currentRefreshingStateTimestamp) {
                          [super beginRefreshing];
                          [self setCurrentRefreshingState:super.refreshing];
                        }
@@ -86,7 +88,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
                      animations:^(void) {
                        [scrollView setContentOffset:offset];
                      } completion:^(__unused BOOL finished) {
-                       if(endRefreshingTimestamp == _currentRefreshingStateTimestamp) {
+                       if(endRefreshingTimestamp == self->_currentRefreshingStateTimestamp) {
                          [super endRefreshing];
                          [self setCurrentRefreshingState:super.refreshing];
                        }
@@ -145,7 +147,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
 - (void)setCurrentRefreshingState:(BOOL)refreshing
 {
   _currentRefreshingState = refreshing;
-  _currentRefreshingStateTimestamp = [[NSDate date] timeIntervalSince1970]*1000;
+  _currentRefreshingStateTimestamp = _currentRefreshingStateClock++;
 }
 
 - (void)refreshControlValueChanged


### PR DESCRIPTION
Fixes #21762 

Test Plan:
----------
1. assign refreshing to true, which initiates beginRefreshingProgrammatically
2. before beginRefreshingProgrammatically animation ends, change refreshing state by assigning refreshing to false.
3. animation ends and overrides real state (refreshing: false) into previous state (refreshing: true)

Release Notes:
----------
[BUGFIX][iOS][RefreshControl] Fix race condition that would overwrite state changes
