### PR TITLE
Fix incorrect merged asset path with flavor for Android Gradle Plugin 3.2.

### DIFF
--- a/react.gradle
+++ b/react.gradle
@@ -132,7 +132,7 @@ afterEvaluate {
                 }
 
                 // Workaround for Android Gradle Plugin 3.2+ new asset directory
-                into ("merged_assets/${targetPath}/merge${targetName}Assets/out") {
+                into ("merged_assets/${variant.name}/merge${targetName}Assets/out") {
                     from jsBundleDir
                 }
             }


### PR DESCRIPTION
When we use product flavor (e.g. develop/production) with Android Gradle Plugin 3.2,
javascript bundle is not copied due to that merged asset path point to incorrect location.

related #21408

<!-- 
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
Help us understand your motivation by explaining why you decided to make this change.

If this PR fixes an issue, type "Fixes #issueNumber" to automatically close the issue when the PR is merged.

_Pull requests that expand test coverage are more likely to get reviewed. Add a test case whenever possible!_
-->

Test Plan:
----------
1. Create new plain react native project.
2. Edit `android/app/build.gradle`, add simple product flavor `one`, `two`.
3. Assemble release apk, and we can find `index.android.bundle` in apk.

Release Notes:
--------------
[ANDROID][BUGFIX][react.gradle] - Fix incorrect merged asset path for Android Gralde Plugin 3.2.

<!--
Help reviewers and the release process by writing your own release notes. See below for an example.

[CATEGORY] [TYPE] [LOCATION] - Message
-->

<!--
  **INTERNAL and MINOR tagged notes will not be included in the next version's final release notes.**

    CATEGORY
  [----------]      TYPE
  [ CLI      ] [-------------]    LOCATION
  [ DOCS     ] [ BREAKING    ] [-------------]
  [ GENERAL  ] [ BUGFIX      ] [ {Component} ]
  [ INTERNAL ] [ ENHANCEMENT ] [ {Filename}  ]
  [ IOS      ] [ FEATURE     ] [ {Directory} ]   |-----------|
  [ ANDROID  ] [ MINOR       ] [ {Framework} ] - | {Message} |
  [----------] [-------------] [-------------]   |-----------|

 EXAMPLES:

 [IOS] [BREAKING] [FlatList] - Change a thing that breaks other things
 [ANDROID] [BUGFIX] [TextInput] - Did a thing to TextInput
 [CLI] [FEATURE] [local-cli/info/info.js] - CLI easier to do things with
 [DOCS] [BUGFIX] [GettingStarted.md] - Accidentally a thing/word
 [GENERAL] [ENHANCEMENT] [Yoga] - Added new yoga thing/position
 [INTERNAL] [FEATURE] [./scripts] - Added thing to script that nobody will see
-->
