### PR TITLE
TextInput component fix maxLength property when entering characters at the beginning.

### DIFF
--- a/IntegrationTests/IntegrationTestsApp.js
+++ b/IntegrationTests/IntegrationTestsApp.js
@@ -36,6 +36,7 @@ const TESTS = [
   require('./SyncMethodTest'),
   require('./WebSocketTest'),
   require('./AccessibilityManagerTest'),
+  require('./TextInputTest'),
 ];
 
 TESTS.forEach(

--- a/IntegrationTests/TextInputTest.js
+++ b/IntegrationTests/TextInputTest.js
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow
+ */
+
+'use strict';
+
+const React = require('react');
+const ReactNative = require('react-native');
+const {View, TextInput} = ReactNative;
+const {TestModule} = ReactNative.NativeModules;
+
+function expectTrue(condition: boolean, message: string): boolean {
+  if (!condition) {
+    throw new Error(message);
+  }
+
+  return condition;
+}
+
+class TextInputTest extends React.Component<{}, $FlowFixMeState> {
+  textInputRef: any;
+  state = {
+    text: '123',
+  };
+
+  componentDidMount() {
+    if (!TestModule.verifySnapshot) {
+      throw new Error('TestModule.verifySnapshot not defined.');
+    }
+
+    this.updateText();
+  }
+
+  updateText() {
+    // set native cursor to 0
+    this.textInputRef.setNativeProps({selection: {start: 0, end: 0}});
+
+    this.setState({text: '0'.concat(this.state.text)}, () => {
+      const componentState = this.state.text;
+
+      this.done(
+        expectTrue(
+          componentState === '0123',
+          'Component updates the state text property correctly.',
+        ),
+      );
+    });
+  }
+
+  done = (success: boolean) => {
+    TestModule.markTestPassed(success);
+  };
+
+  render() {
+    return (
+      <View>
+        <TextInput
+          ref={ref => (this.textInputRef = ref)}
+          maxLength={5}
+          value={this.state.text}
+        />
+      </View>
+    );
+  }
+}
+
+TextInputTest.displayName = 'TextInputTest';
+
+module.exports = TextInputTest;

--- a/Libraries/Text/TextInput/RCTBaseTextInputView.m
+++ b/Libraries/Text/TextInput/RCTBaseTextInputView.m
@@ -336,7 +336,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithFrame:(CGRect)frame)
   if (!NSEqualRanges(range, NSMakeRange(0, 0)) && _predictedText) {
     _predictedText = [_predictedText stringByReplacingCharactersInRange:range withString:text];
   } else {
-    _predictedText = text;
+    _predictedText = [backedTextInputView.attributedText.string stringByReplacingCharactersInRange:range withString:text];
   }
 
   if (_onTextInput) {

--- a/RNTester/RNTesterIntegrationTests/RNTesterIntegrationTests.m
+++ b/RNTester/RNTesterIntegrationTests/RNTesterIntegrationTests.m
@@ -73,6 +73,7 @@ RCT_TEST(SyncMethodTest)
 RCT_TEST(PromiseTest)
 RCT_TEST_ONLY_WITH_PACKAGER(WebSocketTest)
 RCT_TEST(AccessibilityManagerTest)
+RCT_TEST(TextInputTest)
 
 #if !TARGET_OS_TV // tvOS does not fully support WebView
 RCT_TEST(WebViewTest)


### PR DESCRIPTION
Fix TextInput component and the maxLength property when entering characters at the beginning. (#21639).

Improvements: In `TextInputTest.js` We could place the native cursor at the beginning of the input in the function `componentDidMount`. Not sure how to do that from the JavaScript.

Summary:
----------
- In RCTBaseTextInputView.m the ivar _predictedText is not updated correctly when inserting at the beginning.
- The actual fix is to update the value before the checking the text mismatch from `backedTextInputView`.

Test Plan:
----------
- When entering 1 character at the beginning of the TextInput, we expect to have only 1 character inserted. However we experience that the character is inserted and the current value is duplicated.
- Insert `0` character before the value `123` with: `<TextInput maxLength={5} />`.
![broken-input](https://user-images.githubusercontent.com/1864359/47005734-a44fd500-d134-11e8-9ebe-269074bb03a2.gif)


Release Notes:
--------------
[IOS] [BUGFIX] [TextInput] - Fix maxLength property when entering characters at the beginning.

Result:
--------------

![ios-input-fixed](https://user-images.githubusercontent.com/1864359/46958057-3bffe580-d099-11e8-9087-025c2b7bdb9d.gif)
