### PR TITLE
[FIX] ListView requestAnimationFrame leak

### DIFF
--- a/Libraries/Lists/ListView/ListView.js
+++ b/Libraries/Lists/ListView/ListView.js
@@ -544,10 +544,7 @@ const ListView = createReactClass({
 
   _requestAnimationFrame: function(fn: () => void): void {
     const rafId = requestAnimationFrame(() => {
-      const index = this._rafIds.indexOf(rafId);
-      if (index !== -1) {
-        this._rafIds.splice(index, 1);
-      }
+      this._rafIds = this._rafIds.filter(id => id !== rafId);
       fn();
     });
     this._rafIds.push(rafId);

--- a/Libraries/Lists/ListView/ListView.js
+++ b/Libraries/Lists/ListView/ListView.js
@@ -544,7 +544,10 @@ const ListView = createReactClass({
 
   _requestAnimationFrame: function(fn: () => void): void {
     const rafId = requestAnimationFrame(() => {
-      this._rafIds.splice(this._rafIds.indexOf(rafId));
+      const index = this._rafIds.indexOf(rafId);
+      if (index !== -1) {
+        this._rafIds.splice(index, 1);
+      }
       fn();
     });
     this._rafIds.push(rafId);


### PR DESCRIPTION
Related to https://github.com/facebook/react-native/pull/21488
Disclaimer: I made this PR.

I think there's some requestAnimationFrame events that are not cleared on unmount because of bad use of `splice` method.

## Test Plan:

- All flow tests succeed.
- RNTester: iOS (this change should only affect iOS because calculateChildFrames is iOS only)
Show perf monitor, show ListView* screen, start scrolling. UI frame Rate is used at the beginning. When scrolling there is no drop in FPS rate.
- TODO: I'll write a load test for ListView

## Release Notes:
[GENERAL] [ENHANCEMENT] [ListView.js] - rm TimerMixin