### PR TITLE
Make facebook::react::Instance methods overridable.

### DIFF
--- a/RNTester/RNTester.xcodeproj/project.pbxproj
+++ b/RNTester/RNTester.xcodeproj/project.pbxproj
@@ -135,6 +135,8 @@
 		E77B20F321C481F8007FDF6D /* JavaScriptCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EDEBC7DA214C681C00DD5AC8 /* JavaScriptCore.framework */; };
 		ED2970992150247000B7C4FE /* JavaScriptCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ED2970982150247000B7C4FE /* JavaScriptCore.framework */; };
 		EDEBC856214C774100DD5AC8 /* JavaScriptCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EDEBC7DA214C681C00DD5AC8 /* JavaScriptCore.framework */; };
+		E657CBCC217EA7BA004BA961 /* MockInstance.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E657CBCA217EA7BA004BA961 /* MockInstance.cpp */; };
+		E657CBCE217EAEA0004BA961 /* MockInstanceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E657CBCD217EAEA0004BA961 /* MockInstanceTests.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -569,6 +571,9 @@
 		D85B82911AB6D5CE003F4FE2 /* RCTVibration.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTVibration.xcodeproj; path = ../Libraries/Vibration/RCTVibration.xcodeproj; sourceTree = "<group>"; };
 		ED2970982150247000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS12.0.sdk/System/Library/Frameworks/JavaScriptCore.framework; sourceTree = DEVELOPER_DIR; };
 		EDEBC7DA214C681C00DD5AC8 /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
+		E657CBCA217EA7BA004BA961 /* MockInstance.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = MockInstance.cpp; sourceTree = "<group>"; };
+		E657CBCB217EA7BA004BA961 /* MockInstance.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = MockInstance.hpp; sourceTree = "<group>"; };
+		E657CBCD217EAEA0004BA961 /* MockInstanceTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MockInstanceTests.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -824,6 +829,9 @@
 				3DD981D51D33C6FB007DC7BE /* RNTesterUnitTestsBundle.js */,
 				14D6D7101B220EB3001FB087 /* libOCMock.a */,
 				14D6D7011B220AE3001FB087 /* OCMock */,
+				E657CBCA217EA7BA004BA961 /* MockInstance.cpp */,
+				E657CBCB217EA7BA004BA961 /* MockInstance.hpp */,
+				E657CBCD217EAEA0004BA961 /* MockInstanceTests.m */,
 			);
 			path = RNTesterUnitTests;
 			sourceTree = "<group>";
@@ -1687,8 +1695,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E657CBCE217EAEA0004BA961 /* MockInstanceTests.m in Sources */,
 				1497CFB01B21F5E400C1F8F2 /* RCTFontTests.m in Sources */,
 				13BCE84F1C9C209600DD7AAD /* RCTComponentPropsTests.m in Sources */,
+				E657CBCC217EA7BA004BA961 /* MockInstance.cpp in Sources */,
 				144D21241B2204C5006DB32B /* RCTImageUtilTests.m in Sources */,
 				C60A228221C9726800B820FE /* RCTFormatErrorTests.m in Sources */,
 				1393D0381B68CD1300E1B601 /* RCTModuleMethodTests.mm in Sources */,
@@ -1830,10 +1840,17 @@
 		004D28A61AAF61C70097A701 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					FOLLY_NO_CONFIG,
+					"FOLLY_USE_LIBCPP=1",
+				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)/RNTesterUnitTests",
+					"$(SRCROOT)/../third-party/boost_1_63_0",
+					"$(SRCROOT)/../third-party/folly-2016.10.31.00",
+					"$(SRCROOT)/../third-party/glog-0.3.5/src",
 				);
 				INFOPLIST_FILE = RNTesterUnitTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
@@ -1853,6 +1870,9 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)/RNTesterUnitTests",
+					"$(SRCROOT)/../third-party/boost_1_63_0",
+					"$(SRCROOT)/../third-party/folly-2016.10.31.00",
+					"$(SRCROOT)/../third-party/glog-0.3.5/src",
 				);
 				INFOPLIST_FILE = RNTesterUnitTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;

--- a/RNTester/RNTester.xcodeproj/project.pbxproj
+++ b/RNTester/RNTester.xcodeproj/project.pbxproj
@@ -1879,6 +1879,11 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_CXX_LANGUAGE_STANDARD = "c++14";
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					FOLLY_NO_CONFIG,
+					"FOLLY_USE_LIBCPP=1",
+				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)/RNTesterUnitTests",

--- a/RNTester/RNTester.xcodeproj/project.pbxproj
+++ b/RNTester/RNTester.xcodeproj/project.pbxproj
@@ -1854,6 +1854,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"$(inherited)",
 					FOLLY_NO_CONFIG,
+					"FOLLY_MOBILE=1",
 					"FOLLY_USE_LIBCPP=1",
 				);
 				HEADER_SEARCH_PATHS = (
@@ -1882,6 +1883,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"$(inherited)",
 					FOLLY_NO_CONFIG,
+					"FOLLY_MOBILE=1",
 					"FOLLY_USE_LIBCPP=1",
 				);
 				HEADER_SEARCH_PATHS = (

--- a/RNTester/RNTester.xcodeproj/project.pbxproj
+++ b/RNTester/RNTester.xcodeproj/project.pbxproj
@@ -1849,7 +1849,7 @@
 					"$(inherited)",
 					"$(SRCROOT)/RNTesterUnitTests",
 					"$(SRCROOT)/../third-party/boost_1_63_0",
-					"$(SRCROOT)/../third-party/folly-2016.10.31.00",
+					"$(SRCROOT)/../third-party/folly-2018.10.22.00",
 					"$(SRCROOT)/../third-party/glog-0.3.5/src",
 				);
 				INFOPLIST_FILE = RNTesterUnitTests/Info.plist;
@@ -1871,7 +1871,7 @@
 					"$(inherited)",
 					"$(SRCROOT)/RNTesterUnitTests",
 					"$(SRCROOT)/../third-party/boost_1_63_0",
-					"$(SRCROOT)/../third-party/folly-2016.10.31.00",
+					"$(SRCROOT)/../third-party/folly-2018.10.22.00",
 					"$(SRCROOT)/../third-party/glog-0.3.5/src",
 				);
 				INFOPLIST_FILE = RNTesterUnitTests/Info.plist;

--- a/RNTester/RNTester.xcodeproj/project.pbxproj
+++ b/RNTester/RNTester.xcodeproj/project.pbxproj
@@ -132,6 +132,8 @@
 		C654F0B31EB34A73000B7A9A /* RNTesterTestModule.m in Sources */ = {isa = PBXBuildFile; fileRef = C654F0B21EB34A73000B7A9A /* RNTesterTestModule.m */; };
 		C654F17E1EB34D24000B7A9A /* RNTesterTestModule.m in Sources */ = {isa = PBXBuildFile; fileRef = C654F0B21EB34A73000B7A9A /* RNTesterTestModule.m */; };
 		D85B829E1AB6D5D7003F4FE2 /* libRCTVibration.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D85B829C1AB6D5CE003F4FE2 /* libRCTVibration.a */; };
+		E657CBCC217EA7BA004BA961 /* MockInstance.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E657CBCA217EA7BA004BA961 /* MockInstance.cpp */; };
+		E657CBCE217EAEA0004BA961 /* MockInstanceTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = E657CBCD217EAEA0004BA961 /* MockInstanceTests.mm */; };
 		E77B20F321C481F8007FDF6D /* JavaScriptCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EDEBC7DA214C681C00DD5AC8 /* JavaScriptCore.framework */; };
 		ED2970992150247000B7C4FE /* JavaScriptCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ED2970982150247000B7C4FE /* JavaScriptCore.framework */; };
 		EDEBC856214C774100DD5AC8 /* JavaScriptCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EDEBC7DA214C681C00DD5AC8 /* JavaScriptCore.framework */; };
@@ -1840,6 +1842,7 @@
 		004D28A61AAF61C70097A701 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "c++14";
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"$(inherited)",
 					FOLLY_NO_CONFIG,
@@ -1867,6 +1870,7 @@
 		004D28A71AAF61C70097A701 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "c++14";
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)/RNTesterUnitTests",

--- a/RNTester/RNTester.xcodeproj/project.pbxproj
+++ b/RNTester/RNTester.xcodeproj/project.pbxproj
@@ -136,7 +136,7 @@
 		ED2970992150247000B7C4FE /* JavaScriptCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ED2970982150247000B7C4FE /* JavaScriptCore.framework */; };
 		EDEBC856214C774100DD5AC8 /* JavaScriptCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EDEBC7DA214C681C00DD5AC8 /* JavaScriptCore.framework */; };
 		E657CBCC217EA7BA004BA961 /* MockInstance.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E657CBCA217EA7BA004BA961 /* MockInstance.cpp */; };
-		E657CBCE217EAEA0004BA961 /* MockInstanceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E657CBCD217EAEA0004BA961 /* MockInstanceTests.m */; };
+		E657CBCE217EAEA0004BA961 /* MockInstanceTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = E657CBCD217EAEA0004BA961 /* MockInstanceTests.mm */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -573,7 +573,7 @@
 		EDEBC7DA214C681C00DD5AC8 /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
 		E657CBCA217EA7BA004BA961 /* MockInstance.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = MockInstance.cpp; sourceTree = "<group>"; };
 		E657CBCB217EA7BA004BA961 /* MockInstance.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = MockInstance.hpp; sourceTree = "<group>"; };
-		E657CBCD217EAEA0004BA961 /* MockInstanceTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MockInstanceTests.m; sourceTree = "<group>"; };
+		E657CBCD217EAEA0004BA961 /* MockInstanceTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = MockInstanceTests.mm; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -831,7 +831,7 @@
 				14D6D7011B220AE3001FB087 /* OCMock */,
 				E657CBCA217EA7BA004BA961 /* MockInstance.cpp */,
 				E657CBCB217EA7BA004BA961 /* MockInstance.hpp */,
-				E657CBCD217EAEA0004BA961 /* MockInstanceTests.m */,
+				E657CBCD217EAEA0004BA961 /* MockInstanceTests.mm */,
 			);
 			path = RNTesterUnitTests;
 			sourceTree = "<group>";
@@ -1695,7 +1695,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E657CBCE217EAEA0004BA961 /* MockInstanceTests.m in Sources */,
+				E657CBCE217EAEA0004BA961 /* MockInstanceTests.mm in Sources */,
 				1497CFB01B21F5E400C1F8F2 /* RCTFontTests.m in Sources */,
 				13BCE84F1C9C209600DD7AAD /* RCTComponentPropsTests.m in Sources */,
 				E657CBCC217EA7BA004BA961 /* MockInstance.cpp in Sources */,

--- a/RNTester/RNTester.xcodeproj/project.pbxproj
+++ b/RNTester/RNTester.xcodeproj/project.pbxproj
@@ -134,6 +134,7 @@
 		D85B829E1AB6D5D7003F4FE2 /* libRCTVibration.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D85B829C1AB6D5CE003F4FE2 /* libRCTVibration.a */; };
 		E657CBCC217EA7BA004BA961 /* MockInstance.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E657CBCA217EA7BA004BA961 /* MockInstance.cpp */; };
 		E657CBCE217EAEA0004BA961 /* MockInstanceTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = E657CBCD217EAEA0004BA961 /* MockInstanceTests.mm */; };
+		E6CBDB2A218BCB06002A9E15 /* SampleCxxModule.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E6CBDB28218BCB06002A9E15 /* SampleCxxModule.cpp */; };
 		E77B20F321C481F8007FDF6D /* JavaScriptCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EDEBC7DA214C681C00DD5AC8 /* JavaScriptCore.framework */; };
 		ED2970992150247000B7C4FE /* JavaScriptCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ED2970982150247000B7C4FE /* JavaScriptCore.framework */; };
 		EDEBC856214C774100DD5AC8 /* JavaScriptCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EDEBC7DA214C681C00DD5AC8 /* JavaScriptCore.framework */; };
@@ -576,6 +577,10 @@
 		E657CBCA217EA7BA004BA961 /* MockInstance.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = MockInstance.cpp; sourceTree = "<group>"; };
 		E657CBCB217EA7BA004BA961 /* MockInstance.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = MockInstance.hpp; sourceTree = "<group>"; };
 		E657CBCD217EAEA0004BA961 /* MockInstanceTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = MockInstanceTests.mm; sourceTree = "<group>"; };
+		E6CBDB28218BCB06002A9E15 /* SampleCxxModule.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = SampleCxxModule.cpp; sourceTree = "<group>"; };
+		E6CBDB29218BCB06002A9E15 /* SampleCxxModule.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = SampleCxxModule.hpp; sourceTree = "<group>"; };
+		ED2970982150247000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS12.0.sdk/System/Library/Frameworks/JavaScriptCore.framework; sourceTree = DEVELOPER_DIR; };
+		EDEBC7DA214C681C00DD5AC8 /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -834,6 +839,8 @@
 				E657CBCA217EA7BA004BA961 /* MockInstance.cpp */,
 				E657CBCB217EA7BA004BA961 /* MockInstance.hpp */,
 				E657CBCD217EAEA0004BA961 /* MockInstanceTests.mm */,
+				E6CBDB28218BCB06002A9E15 /* SampleCxxModule.cpp */,
+				E6CBDB29218BCB06002A9E15 /* SampleCxxModule.hpp */,
 			);
 			path = RNTesterUnitTests;
 			sourceTree = "<group>";
@@ -1705,6 +1712,7 @@
 				C60A228221C9726800B820FE /* RCTFormatErrorTests.m in Sources */,
 				1393D0381B68CD1300E1B601 /* RCTModuleMethodTests.mm in Sources */,
 				1300627F1B59179B0043FE5A /* RCTGzipTests.m in Sources */,
+				E6CBDB2A218BCB06002A9E15 /* SampleCxxModule.cpp in Sources */,
 				1497CFAF1B21F5E400C1F8F2 /* RCTConvert_NSURLTests.m in Sources */,
 				13129DD41C85F87C007D611C /* RCTModuleInitNotificationRaceTests.m in Sources */,
 				192F69B81E82409A008692C7 /* RCTAnimationUtilsTests.m in Sources */,

--- a/RNTester/RNTesterUnitTests/MockInstance.cpp
+++ b/RNTester/RNTesterUnitTests/MockInstance.cpp
@@ -1,10 +1,7 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
 //
-//  MockInstance.cpp
-//  RNTesterUnitTests
-//
-//  Created by Julio Cesar Rocha on 10/22/18.
-//  Copyright © 2018 Facebook. All rights reserved.
-//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 #include "MockInstance.hpp"
 

--- a/RNTester/RNTesterUnitTests/MockInstance.cpp
+++ b/RNTester/RNTesterUnitTests/MockInstance.cpp
@@ -13,9 +13,9 @@
 using namespace facebook::react;
 
 using facebook::xplat::jsArgAsInt;
-using std::map;
+using std::vector;
 
-MockInstance::MockInstance(std::shared_ptr<map<int64_t, int64_t>> sumCache)
+MockInstance::MockInstance(std::shared_ptr<vector<int64_t>> sumCache)
 : sumCache_{sumCache}
 {
 }
@@ -77,7 +77,7 @@ bool MockInstance::isInspectable()
 void MockInstance::callJSFunction(std::string &&module, std::string &&method,
                     folly::dynamic &&params)
 {
-  sumCache_->insert({jsArgAsInt(params, 0), jsArgAsInt(params, 1)});
+  sumCache_->emplace_back(jsArgAsInt(params, 0));
 }
 
 void MockInstance::callJSCallback(uint64_t callbackId, folly::dynamic &&params)

--- a/RNTester/RNTesterUnitTests/MockInstance.cpp
+++ b/RNTester/RNTesterUnitTests/MockInstance.cpp
@@ -8,7 +8,17 @@
 
 #include "MockInstance.hpp"
 
+#include <cxxreact/JsArgumentHelpers.h>
+
 using namespace facebook::react;
+
+using facebook::xplat::jsArgAsInt;
+using std::map;
+
+MockInstance::MockInstance(std::shared_ptr<map<int64_t, int64_t>> sumCache)
+: sumCache_{sumCache}
+{
+}
 
 void MockInstance::loadApplication(std::unique_ptr<RAMBundleRegistry> bundleRegistry,
                      std::unique_ptr<const JSBigString> startupScript,
@@ -67,6 +77,7 @@ bool MockInstance::isInspectable()
 void MockInstance::callJSFunction(std::string &&module, std::string &&method,
                     folly::dynamic &&params)
 {
+  sumCache_->insert({jsArgAsInt(params, 0), jsArgAsInt(params, 1)});
 }
 
 void MockInstance::callJSCallback(uint64_t callbackId, folly::dynamic &&params)

--- a/RNTester/RNTesterUnitTests/MockInstance.cpp
+++ b/RNTester/RNTesterUnitTests/MockInstance.cpp
@@ -1,0 +1,93 @@
+//
+//  MockInstance.cpp
+//  RNTesterUnitTests
+//
+//  Created by Julio Cesar Rocha on 10/22/18.
+//  Copyright © 2018 Facebook. All rights reserved.
+//
+
+#include "MockInstance.hpp"
+
+using namespace facebook::react;
+
+void MockInstance::loadApplication(std::unique_ptr<RAMBundleRegistry> bundleRegistry,
+                     std::unique_ptr<const JSBigString> startupScript,
+                     std::string startupScriptSourceURL)
+{
+}
+void MockInstance::loadApplicationSync(std::unique_ptr<RAMBundleRegistry> bundleRegistry,
+                         std::unique_ptr<const JSBigString> startupScript,
+                         std::string startupScriptSourceURL)
+{
+}
+
+void MockInstance::initializeBridge(std::unique_ptr<InstanceCallback> callback,
+                      std::shared_ptr<JSExecutorFactory> jsef,
+                      std::shared_ptr<MessageQueueThread> jsQueue,
+                      std::shared_ptr<ModuleRegistry> moduleRegistry)
+{
+}
+
+void MockInstance::setSourceURL(std::string /*sourceURL*/)
+{
+}
+
+void MockInstance::loadScriptFromString(std::unique_ptr<const JSBigString> string,
+                          std::string sourceURL, bool loadSynchronously)
+{
+}
+
+void MockInstance::loadRAMBundleFromFile(const std::string& sourcePath,
+                           const std::string& sourceURL,
+                           bool loadSynchronously)
+{
+}
+
+void MockInstance::loadRAMBundle(std::unique_ptr<RAMBundleRegistry> bundleRegistry,
+                   std::unique_ptr<const JSBigString> startupScript,
+                   std::string startupScriptSourceURL, bool loadSynchronously)
+{
+}
+
+void MockInstance::setGlobalVariable(std::string propName,
+                       std::unique_ptr<const JSBigString> jsonValue)
+{
+}
+
+void *MockInstance::getJavaScriptContext()
+{
+  return nullptr;
+}
+
+bool MockInstance::isInspectable()
+{
+  return false;
+}
+
+void MockInstance::callJSFunction(std::string &&module, std::string &&method,
+                    folly::dynamic &&params)
+{
+}
+
+void MockInstance::callJSCallback(uint64_t callbackId, folly::dynamic &&params)
+{
+}
+
+// This method is experimental, and may be modified or removed.
+void MockInstance::registerBundle(uint32_t bundleId, const std::string& bundlePath)
+{
+}
+
+const ModuleRegistry &MockInstance::getModuleRegistry() const
+{
+  return *moduleRegistry_;
+}
+
+ModuleRegistry &MockInstance::getModuleRegistry()
+{
+  return *moduleRegistry_;
+}
+
+void MockInstance::handleMemoryPressure(int pressureLevel)
+{
+}

--- a/RNTester/RNTesterUnitTests/MockInstance.cpp
+++ b/RNTester/RNTesterUnitTests/MockInstance.cpp
@@ -71,6 +71,11 @@ bool MockInstance::isInspectable()
   return false;
 }
 
+bool MockInstance::isBatchActive()
+{
+  return false;
+}
+
 void MockInstance::callJSFunction(std::string &&module, std::string &&method,
                     folly::dynamic &&params)
 {

--- a/RNTester/RNTesterUnitTests/MockInstance.hpp
+++ b/RNTester/RNTesterUnitTests/MockInstance.hpp
@@ -19,6 +19,8 @@
 
 class MockInstance : public facebook::react::Instance {
 private:
+  std::shared_ptr<std::map<std::int64_t, std::int64_t>> sumCache_;
+  
   void loadApplication(std::unique_ptr<facebook::react::RAMBundleRegistry> bundleRegistry,
                                std::unique_ptr<const facebook::react::JSBigString> startupScript,
                                std::string startupScriptSourceURL) override;
@@ -27,6 +29,8 @@ private:
                                    std::string startupScriptSourceURL) override;
 
 public:
+  MockInstance(std::shared_ptr<std::map<std::int64_t, std::int64_t>> sumCache);
+  
    void initializeBridge(std::unique_ptr<facebook::react::InstanceCallback> callback,
                                 std::shared_ptr<facebook::react::JSExecutorFactory> jsef,
                                 std::shared_ptr<facebook::react::MessageQueueThread> jsQueue,

--- a/RNTester/RNTesterUnitTests/MockInstance.hpp
+++ b/RNTester/RNTesterUnitTests/MockInstance.hpp
@@ -42,6 +42,7 @@ public:
                                  std::unique_ptr<const facebook::react::JSBigString> jsonValue) override;
    void *getJavaScriptContext() override;
    bool isInspectable() override;
+   bool isBatchActive() override;
    void callJSFunction(std::string &&module, std::string &&method,
                               folly::dynamic &&params) override;
    void callJSCallback(uint64_t callbackId, folly::dynamic &&params) override;

--- a/RNTester/RNTesterUnitTests/MockInstance.hpp
+++ b/RNTester/RNTesterUnitTests/MockInstance.hpp
@@ -19,7 +19,7 @@
 
 class MockInstance : public facebook::react::Instance {
 private:
-  std::shared_ptr<std::map<std::int64_t, std::int64_t>> sumCache_;
+  std::shared_ptr<std::vector<std::int64_t>> sumCache_;
   
   void loadApplication(std::unique_ptr<facebook::react::RAMBundleRegistry> bundleRegistry,
                                std::unique_ptr<const facebook::react::JSBigString> startupScript,
@@ -29,7 +29,7 @@ private:
                                    std::string startupScriptSourceURL) override;
 
 public:
-  MockInstance(std::shared_ptr<std::map<std::int64_t, std::int64_t>> sumCache);
+  MockInstance(std::shared_ptr<std::vector<std::int64_t>> sumCache);
   
    void initializeBridge(std::unique_ptr<facebook::react::InstanceCallback> callback,
                                 std::shared_ptr<facebook::react::JSExecutorFactory> jsef,

--- a/RNTester/RNTesterUnitTests/MockInstance.hpp
+++ b/RNTester/RNTesterUnitTests/MockInstance.hpp
@@ -1,17 +1,7 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
 //
-//  MockInstance.hpp
-//  RNTesterUnitTests
-//
-//  Created by Julio Cesar Rocha on 10/22/18.
-//  Copyright © 2018 Facebook. All rights reserved.
-//
-
-//#ifndef MockInstance_hpp
-//#define MockInstance_hpp
-//
-//#include <stdio.h>
-//
-//#endif /* MockInstance_hpp */
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 #pragma once
 

--- a/RNTester/RNTesterUnitTests/MockInstance.hpp
+++ b/RNTester/RNTesterUnitTests/MockInstance.hpp
@@ -1,0 +1,62 @@
+//
+//  MockInstance.hpp
+//  RNTesterUnitTests
+//
+//  Created by Julio Cesar Rocha on 10/22/18.
+//  Copyright © 2018 Facebook. All rights reserved.
+//
+
+//#ifndef MockInstance_hpp
+//#define MockInstance_hpp
+//
+//#include <stdio.h>
+//
+//#endif /* MockInstance_hpp */
+
+#pragma once
+
+#include <cxxreact/Instance.h>
+
+class MockInstance : public facebook::react::Instance {
+private:
+  void loadApplication(std::unique_ptr<facebook::react::RAMBundleRegistry> bundleRegistry,
+                               std::unique_ptr<const facebook::react::JSBigString> startupScript,
+                               std::string startupScriptSourceURL) override;
+  void loadApplicationSync(std::unique_ptr<facebook::react::RAMBundleRegistry> bundleRegistry,
+                                   std::unique_ptr<const facebook::react::JSBigString> startupScript,
+                                   std::string startupScriptSourceURL) override;
+
+public:
+   void initializeBridge(std::unique_ptr<facebook::react::InstanceCallback> callback,
+                                std::shared_ptr<facebook::react::JSExecutorFactory> jsef,
+                                std::shared_ptr<facebook::react::MessageQueueThread> jsQueue,
+                                std::shared_ptr<facebook::react::ModuleRegistry> moduleRegistry) override;
+  
+   void setSourceURL(std::string sourceURL) override;
+  
+   void loadScriptFromString(std::unique_ptr<const facebook::react::JSBigString> string,
+                                    std::string sourceURL, bool loadSynchronously) override;
+//  static bool isIndexedRAMBundle(const char *sourcePath);
+   void loadRAMBundleFromFile(const std::string& sourcePath,
+                                     const std::string& sourceURL,
+                                     bool loadSynchronously) override;
+   void loadRAMBundle(std::unique_ptr<facebook::react::RAMBundleRegistry> bundleRegistry,
+                             std::unique_ptr<const facebook::react::JSBigString> startupScript,
+                             std::string startupScriptSourceURL, bool loadSynchronously) override;
+//  bool supportsProfiling();
+   void setGlobalVariable(std::string propName,
+                                 std::unique_ptr<const facebook::react::JSBigString> jsonValue) override;
+   void *getJavaScriptContext() override;
+   bool isInspectable() override;
+   void callJSFunction(std::string &&module, std::string &&method,
+                              folly::dynamic &&params) override;
+   void callJSCallback(uint64_t callbackId, folly::dynamic &&params) override;
+  
+  // This method is experimental, and may be modified or removed.
+   void registerBundle(uint32_t bundleId, const std::string& bundlePath) override;
+  
+   const facebook::react::ModuleRegistry &getModuleRegistry() const override;
+   facebook::react::ModuleRegistry &getModuleRegistry() override;
+  
+   void handleMemoryPressure(int pressureLevel) override;
+};

--- a/RNTester/RNTesterUnitTests/MockInstanceTests.m
+++ b/RNTester/RNTesterUnitTests/MockInstanceTests.m
@@ -1,0 +1,40 @@
+//
+//  MockInstanceTests.m
+//  RNTesterUnitTests
+//
+//  Created by Julio Cesar Rocha on 10/22/18.
+//  Copyright © 2018 Facebook. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+//#import "MockInstance.hpp" //TODO: Fix "'conditional_variable' file not found @ Instance.h"
+
+@interface MockInstanceTests : XCTestCase
+
+@end
+
+@implementation MockInstanceTests
+
+- (void)setUp {
+    [super setUp];
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+}
+
+- (void)tearDown {
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+    [super tearDown];
+}
+
+- (void)testExample {
+    // This is an example of a functional test case.
+    // Use XCTAssert and related functions to verify your tests produce the correct results.
+}
+
+- (void)testPerformanceExample {
+    // This is an example of a performance test case.
+    [self measureBlock:^{
+        // Put the code you want to measure the time of here.
+    }];
+}
+
+@end

--- a/RNTester/RNTesterUnitTests/MockInstanceTests.mm
+++ b/RNTester/RNTesterUnitTests/MockInstanceTests.mm
@@ -5,11 +5,44 @@
 
 #import <XCTest/XCTest.h>
 
+#import <React/RCTBridgeModule.h>
+
 #import "MockInstance.hpp"
 #import "SampleCxxModule.hpp"
 
 using folly::dynamic;
 using std::vector;
+
+@interface MyModule : NSObject <RCTBridgeModule>
+
+@property facebook::react::Instance* instance;
+
+- (instancetype) initWithInstance:(facebook::react::Instance*) instance;
+
+@end
+
+@implementation MyModule
+
+// To export a module named CalendarManager
+RCT_EXPORT_MODULE();
+
+- (instancetype) initWithInstance:(facebook::react::Instance *)instance
+{
+  self = [super init];
+  if (self)
+  {
+    _instance = instance;
+  }
+  
+  return self;
+}
+
+RCT_EXPORT_METHOD(sum:(NSInteger)a b:(NSInteger)b)
+{
+  //_instance->callJSFunction("Calculator", "sum", dynamic::array(a, b));
+}
+
+@end
 
 @interface MockInstanceTests : XCTestCase
 
@@ -40,8 +73,14 @@ using std::vector;
 //  int64_t result = cache->front();
 //  XCTAssert(result == 5); // 2 + 3
   
-  auto module = std::make_unique<SampleNativeModule>(instance);
-  module->invoke(0, dynamic::array(2, 3), 0);
+//  auto module = std::make_unique<SampleNativeModule>(instance);
+//  module->invoke(0, dynamic::array(2, 3), 0);
+  
+  //auto module = [[MyModule alloc] initWithInstance:instance.get()];
+  
+  //instance->callJSFunction("mod", "meth", dynamic::array(2,3));
+
+  auto x = folly::dynamic::array(2, 3);
 
   XCTAssert(true);
 }

--- a/RNTester/RNTesterUnitTests/MockInstanceTests.mm
+++ b/RNTester/RNTesterUnitTests/MockInstanceTests.mm
@@ -7,7 +7,7 @@
 //
 
 #import <XCTest/XCTest.h>
-//#import "MockInstance.hpp" //TODO: Fix "'conditional_variable' file not found @ Instance.h"
+#import "MockInstance.hpp"
 
 @interface MockInstanceTests : XCTestCase
 

--- a/RNTester/RNTesterUnitTests/MockInstanceTests.mm
+++ b/RNTester/RNTesterUnitTests/MockInstanceTests.mm
@@ -11,6 +11,10 @@
 #import "MockInstance.hpp"
 #import "SampleCxxModule.hpp"
 
+using folly::dynamic;
+using std::map;
+using std::vector;
+
 @interface MockInstanceTests : XCTestCase
 
 @end
@@ -27,21 +31,21 @@
     [super tearDown];
 }
 
-- (void)testExample {
+- (void)testMockCallJSFunction {
     // This is an example of a functional test case.
     // Use XCTAssert and related functions to verify your tests produce the correct results.
 
-  std::shared_ptr<MockInstance> instance = std::make_shared<MockInstance>();
-  std::unique_ptr<SampleCxxModule> module = std::make_unique<SampleCxxModule>();
-  
-  module->setInstance(instance);
-}
+  auto cache = std::make_shared<map<int64_t, int64_t>>();
+  auto instance = std::make_shared<MockInstance>(cache);
+  auto module = std::make_unique<SampleCxxModule>();
 
-- (void)testPerformanceExample {
-    // This is an example of a performance test case.
-    [self measureBlock:^{
-        // Put the code you want to measure the time of here.
-    }];
+  module->setInstance(instance);
+  
+  auto sumMethod = module->getMethods()[0]; // First method: 'sum'.
+  sumMethod.func(dynamic::array(2, 3), [](vector<dynamic>){}, [](vector<dynamic>){});
+  
+  auto result = cache->at(2);
+  XCTAssert(result == 2 + 3);
 }
 
 @end

--- a/RNTester/RNTesterUnitTests/MockInstanceTests.mm
+++ b/RNTester/RNTesterUnitTests/MockInstanceTests.mm
@@ -1,10 +1,7 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
 //
-//  MockInstanceTests.m
-//  RNTesterUnitTests
-//
-//  Created by Julio Cesar Rocha on 10/22/18.
-//  Copyright © 2018 Facebook. All rights reserved.
-//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 #import <XCTest/XCTest.h>
 

--- a/RNTester/RNTesterUnitTests/MockInstanceTests.mm
+++ b/RNTester/RNTesterUnitTests/MockInstanceTests.mm
@@ -7,7 +7,9 @@
 //
 
 #import <XCTest/XCTest.h>
+
 #import "MockInstance.hpp"
+#import "SampleCxxModule.hpp"
 
 @interface MockInstanceTests : XCTestCase
 
@@ -28,6 +30,11 @@
 - (void)testExample {
     // This is an example of a functional test case.
     // Use XCTAssert and related functions to verify your tests produce the correct results.
+
+  std::shared_ptr<MockInstance> instance = std::make_shared<MockInstance>();
+  std::unique_ptr<SampleCxxModule> module = std::make_unique<SampleCxxModule>();
+  
+  module->setInstance(instance);
 }
 
 - (void)testPerformanceExample {

--- a/RNTester/RNTesterUnitTests/MockInstanceTests.mm
+++ b/RNTester/RNTesterUnitTests/MockInstanceTests.mm
@@ -30,15 +30,20 @@ using std::vector;
 - (void)testMockCallJSFunction {
   auto cache = std::make_shared<vector<int64_t>>();
   auto instance = std::make_shared<MockInstance>(cache);
-  auto module = std::make_unique<SampleCxxModule>();
+//  auto module = std::make_unique<SampleCxxModule>();
+//
+//  module->setInstance(instance);
+//
+//  auto sumMethod = module->getMethods()[0]; // First method: 'sum'.
+//  sumMethod.func(dynamic::array(2, 3), [](vector<dynamic>){}, [](vector<dynamic>){}); // 5
+//
+//  int64_t result = cache->front();
+//  XCTAssert(result == 5); // 2 + 3
+  
+  auto module = std::make_unique<SampleNativeModule>(instance);
+  module->invoke(0, dynamic::array(2, 3), 0);
 
-  module->setInstance(instance);
-  
-  auto sumMethod = module->getMethods()[0]; // First method: 'sum'.
-  sumMethod.func(dynamic::array(2, 3), [](vector<dynamic>){}, [](vector<dynamic>){}); // 5
-  
-  int64_t result = cache->front();
-  XCTAssert(result == 5); // 2 + 3
+  XCTAssert(true);
 }
 
 @end

--- a/RNTester/RNTesterUnitTests/MockInstanceTests.mm
+++ b/RNTester/RNTesterUnitTests/MockInstanceTests.mm
@@ -12,7 +12,6 @@
 #import "SampleCxxModule.hpp"
 
 using folly::dynamic;
-using std::map;
 using std::vector;
 
 @interface MockInstanceTests : XCTestCase
@@ -32,20 +31,17 @@ using std::vector;
 }
 
 - (void)testMockCallJSFunction {
-    // This is an example of a functional test case.
-    // Use XCTAssert and related functions to verify your tests produce the correct results.
-
-  auto cache = std::make_shared<map<int64_t, int64_t>>();
+  auto cache = std::make_shared<vector<int64_t>>();
   auto instance = std::make_shared<MockInstance>(cache);
   auto module = std::make_unique<SampleCxxModule>();
 
   module->setInstance(instance);
   
   auto sumMethod = module->getMethods()[0]; // First method: 'sum'.
-  sumMethod.func(dynamic::array(2, 3), [](vector<dynamic>){}, [](vector<dynamic>){});
+  sumMethod.func(dynamic::array(2, 3), [](vector<dynamic>){}, [](vector<dynamic>){}); // 5
   
-  auto result = cache->at(2);
-  XCTAssert(result == 2 + 3);
+  int64_t result = cache->front();
+  XCTAssert(result == 5); // 2 + 3
 }
 
 @end

--- a/RNTester/RNTesterUnitTests/MockInstanceTests.mm
+++ b/RNTester/RNTesterUnitTests/MockInstanceTests.mm
@@ -13,37 +13,6 @@
 using folly::dynamic;
 using std::vector;
 
-@interface MyModule : NSObject <RCTBridgeModule>
-
-@property facebook::react::Instance* instance;
-
-- (instancetype) initWithInstance:(facebook::react::Instance*) instance;
-
-@end
-
-@implementation MyModule
-
-// To export a module named CalendarManager
-RCT_EXPORT_MODULE();
-
-- (instancetype) initWithInstance:(facebook::react::Instance *)instance
-{
-  self = [super init];
-  if (self)
-  {
-    _instance = instance;
-  }
-  
-  return self;
-}
-
-RCT_EXPORT_METHOD(sum:(NSInteger)a b:(NSInteger)b)
-{
-  //_instance->callJSFunction("Calculator", "sum", dynamic::array(a, b));
-}
-
-@end
-
 @interface MockInstanceTests : XCTestCase
 
 @end
@@ -63,26 +32,15 @@ RCT_EXPORT_METHOD(sum:(NSInteger)a b:(NSInteger)b)
 - (void)testMockCallJSFunction {
   auto cache = std::make_shared<vector<int64_t>>();
   auto instance = std::make_shared<MockInstance>(cache);
-//  auto module = std::make_unique<SampleCxxModule>();
-//
-//  module->setInstance(instance);
-//
-//  auto sumMethod = module->getMethods()[0]; // First method: 'sum'.
-//  sumMethod.func(dynamic::array(2, 3), [](vector<dynamic>){}, [](vector<dynamic>){}); // 5
-//
-//  int64_t result = cache->front();
-//  XCTAssert(result == 5); // 2 + 3
-  
-//  auto module = std::make_unique<SampleNativeModule>(instance);
-//  module->invoke(0, dynamic::array(2, 3), 0);
-  
-  //auto module = [[MyModule alloc] initWithInstance:instance.get()];
-  
-  //instance->callJSFunction("mod", "meth", dynamic::array(2,3));
+  auto module = std::make_unique<SampleCxxModule>();
 
-  auto x = folly::dynamic::array(2, 3);
+  module->setInstance(instance);
 
-  XCTAssert(true);
+  auto sumMethod = module->getMethods()[0]; // First method: 'sum'.
+  sumMethod.func(dynamic::array(2, 3), [](vector<dynamic>){}, [](vector<dynamic>){}); // 5
+
+  int64_t result = cache->front();
+  XCTAssert(result == 5); // 2 + 3
 }
 
 @end

--- a/RNTester/RNTesterUnitTests/SampleCxxModule.cpp
+++ b/RNTester/RNTesterUnitTests/SampleCxxModule.cpp
@@ -38,10 +38,13 @@ vector<SampleCxxModule::Method> SampleCxxModule::getMethods()
   return
   {
     Method("sum", [instance = this->getInstance().lock()](dynamic args)
-     {
-       auto sum = jsArgAsInt(args, 0) + jsArgAsInt(args, 1);
-       if (instance)
-         instance->callJSFunction("MockedModule", "mockedMethod", dynamic::array(jsArgAsInt(args, 0), sum));
-     })
+    {
+      int64_t sum = 0;
+      for(auto& val : args)
+        sum += val.getInt();
+
+      if (instance)
+        instance->callJSFunction("MockedModule", "mockedMethod", dynamic::array(sum));
+    })
   };
 }

--- a/RNTester/RNTesterUnitTests/SampleCxxModule.cpp
+++ b/RNTester/RNTesterUnitTests/SampleCxxModule.cpp
@@ -16,35 +16,35 @@ using std::map;
 using std::string;
 using std::vector;
 
-SampleCxxModule::SampleCxxModule()
-{
-}
-
-string SampleCxxModule::getName()
-{
-  return "SampleCxxModule";
-}
-
-map<string, dynamic> SampleCxxModule::getConstants()
-{
-  return {};
-}
-
-vector<SampleCxxModule::Method> SampleCxxModule::getMethods()
-{
-  return
-  {
-    Method("sum", [instance = this->getInstance().lock()](dynamic args)
-    {
-      int64_t sum = 0;
-      for(auto& val : args)
-        sum += val.getInt();
-
-      if (instance)
-        instance->callJSFunction("MockedModule", "mockedMethod", dynamic::array(sum));
-    })
-  };
-}
+//SampleCxxModule::SampleCxxModule()
+//{
+//}
+//
+//string SampleCxxModule::getName()
+//{
+//  return "SampleCxxModule";
+//}
+//
+//map<string, dynamic> SampleCxxModule::getConstants()
+//{
+//  return {};
+//}
+//
+//vector<SampleCxxModule::Method> SampleCxxModule::getMethods()
+//{
+//  return
+//  {
+//    Method("sum", [instance = this->getInstance().lock()](dynamic args)
+//    {
+//      int64_t sum = 0;
+//      for(auto& val : args)
+//        sum += val.getInt();
+//
+//      if (instance)
+//        instance->callJSFunction("MockedModule", "mockedMethod", dynamic::array(sum));
+//    })
+//  };
+//}
 
 SampleNativeModule::SampleNativeModule(std::shared_ptr<facebook::react::Instance> instance)
   : m_wkInstance { instance }
@@ -58,7 +58,10 @@ string SampleNativeModule::getName()
 
 vector<MethodDescriptor> SampleNativeModule::getMethods()
 {
-  return {};
+  return
+  {
+    { "sum", "sync" }
+  };
 }
 
 dynamic SampleNativeModule::getConstants()
@@ -68,6 +71,8 @@ dynamic SampleNativeModule::getConstants()
 
 void SampleNativeModule::invoke(unsigned int reactMethodId, dynamic&& params, int callId)
 {
+//  if (auto instance = m_wkInstance.lock())
+//    instance->callJSFunction(getName(), "sum", std::move(params));
 }
 
 MethodCallResult SampleNativeModule::callSerializableNativeHook(unsigned int reactMethodId, dynamic&& args)

--- a/RNTester/RNTesterUnitTests/SampleCxxModule.cpp
+++ b/RNTester/RNTesterUnitTests/SampleCxxModule.cpp
@@ -1,10 +1,7 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
 //
-//  SampleCxxModule.cpp
-//  RNTesterUnitTests
-//
-//  Created by Julio Cesar Rocha on 11/1/18.
-//  Copyright © 2018 Facebook. All rights reserved.
-//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 #include "SampleCxxModule.hpp"
 

--- a/RNTester/RNTesterUnitTests/SampleCxxModule.cpp
+++ b/RNTester/RNTesterUnitTests/SampleCxxModule.cpp
@@ -1,0 +1,48 @@
+//
+//  SampleCxxModule.cpp
+//  RNTesterUnitTests
+//
+//  Created by Julio Cesar Rocha on 11/1/18.
+//  Copyright © 2018 Facebook. All rights reserved.
+//
+
+#include "SampleCxxModule.hpp"
+
+#include <cxxreact/Instance.h>
+#include <cxxreact/JsArgumentHelpers.h>
+
+using namespace facebook::react;
+
+using facebook::xplat::jsArgAsInt;
+using folly::dynamic;
+using std::map;
+using std::string;
+using std::vector;
+
+SampleCxxModule::SampleCxxModule()
+{
+}
+
+string SampleCxxModule::getName()
+{
+  return "SampleCxxModule";
+}
+
+map<string, dynamic> SampleCxxModule::getConstants()
+{
+  return {};
+}
+
+vector<SampleCxxModule::Method> SampleCxxModule::getMethods()
+{
+  std::weak_ptr<facebook::react::Instance> instance = this->getInstance();
+  
+  return
+  {
+    Method("foo", [instance = this->getInstance().lock()](dynamic args)
+     {
+       if (instance)
+         instance->callJSFunction("RCTDeviceEventEmitter", "emit", dynamic::array(jsArgAsInt(args, 0)));
+     })
+  };
+}

--- a/RNTester/RNTesterUnitTests/SampleCxxModule.cpp
+++ b/RNTester/RNTesterUnitTests/SampleCxxModule.cpp
@@ -16,66 +16,32 @@ using std::map;
 using std::string;
 using std::vector;
 
-//SampleCxxModule::SampleCxxModule()
-//{
-//}
-//
-//string SampleCxxModule::getName()
-//{
-//  return "SampleCxxModule";
-//}
-//
-//map<string, dynamic> SampleCxxModule::getConstants()
-//{
-//  return {};
-//}
-//
-//vector<SampleCxxModule::Method> SampleCxxModule::getMethods()
-//{
-//  return
-//  {
-//    Method("sum", [instance = this->getInstance().lock()](dynamic args)
-//    {
-//      int64_t sum = 0;
-//      for(auto& val : args)
-//        sum += val.getInt();
-//
-//      if (instance)
-//        instance->callJSFunction("MockedModule", "mockedMethod", dynamic::array(sum));
-//    })
-//  };
-//}
-
-SampleNativeModule::SampleNativeModule(std::shared_ptr<facebook::react::Instance> instance)
-  : m_wkInstance { instance }
+SampleCxxModule::SampleCxxModule()
 {
 }
 
-string SampleNativeModule::getName()
+string SampleCxxModule::getName()
 {
-  return "SampleNativeModule";
+  return "SampleCxxModule";
 }
 
-vector<MethodDescriptor> SampleNativeModule::getMethods()
+map<string, dynamic> SampleCxxModule::getConstants()
+{
+  return {};
+}
+
+vector<SampleCxxModule::Method> SampleCxxModule::getMethods()
 {
   return
   {
-    { "sum", "sync" }
+    Method("sum", [instance = this->getInstance().lock()](dynamic args)
+    {
+      int64_t sum = 0;
+      for(auto& val : args)
+        sum += val.getInt();
+
+      if (instance)
+        instance->callJSFunction("MockedModule", "mockedMethod", dynamic::array(sum));
+    })
   };
-}
-
-dynamic SampleNativeModule::getConstants()
-{
-  return {};
-}
-
-void SampleNativeModule::invoke(unsigned int reactMethodId, dynamic&& params, int callId)
-{
-//  if (auto instance = m_wkInstance.lock())
-//    instance->callJSFunction(getName(), "sum", std::move(params));
-}
-
-MethodCallResult SampleNativeModule::callSerializableNativeHook(unsigned int reactMethodId, dynamic&& args)
-{
-  return {};
 }

--- a/RNTester/RNTesterUnitTests/SampleCxxModule.cpp
+++ b/RNTester/RNTesterUnitTests/SampleCxxModule.cpp
@@ -45,3 +45,32 @@ vector<SampleCxxModule::Method> SampleCxxModule::getMethods()
     })
   };
 }
+
+SampleNativeModule::SampleNativeModule(std::shared_ptr<facebook::react::Instance> instance)
+  : m_wkInstance { instance }
+{
+}
+
+string SampleNativeModule::getName()
+{
+  return "SampleNativeModule";
+}
+
+vector<MethodDescriptor> SampleNativeModule::getMethods()
+{
+  return {};
+}
+
+dynamic SampleNativeModule::getConstants()
+{
+  return {};
+}
+
+void SampleNativeModule::invoke(unsigned int reactMethodId, dynamic&& params, int callId)
+{
+}
+
+MethodCallResult SampleNativeModule::callSerializableNativeHook(unsigned int reactMethodId, dynamic&& args)
+{
+  return {};
+}

--- a/RNTester/RNTesterUnitTests/SampleCxxModule.cpp
+++ b/RNTester/RNTesterUnitTests/SampleCxxModule.cpp
@@ -35,14 +35,13 @@ map<string, dynamic> SampleCxxModule::getConstants()
 
 vector<SampleCxxModule::Method> SampleCxxModule::getMethods()
 {
-  std::weak_ptr<facebook::react::Instance> instance = this->getInstance();
-  
   return
   {
-    Method("foo", [instance = this->getInstance().lock()](dynamic args)
+    Method("sum", [instance = this->getInstance().lock()](dynamic args)
      {
+       auto sum = jsArgAsInt(args, 0) + jsArgAsInt(args, 1);
        if (instance)
-         instance->callJSFunction("RCTDeviceEventEmitter", "emit", dynamic::array(jsArgAsInt(args, 0)));
+         instance->callJSFunction("MockedModule", "mockedMethod", dynamic::array(jsArgAsInt(args, 0), sum));
      })
   };
 }

--- a/RNTester/RNTesterUnitTests/SampleCxxModule.hpp
+++ b/RNTester/RNTesterUnitTests/SampleCxxModule.hpp
@@ -13,10 +13,11 @@ class SampleCxxModule : public facebook::xplat::module::CxxModule
 public:
   SampleCxxModule();
   
-  std::string getName();
+  std::string getName() override;
+
+  std::map<std::string, folly::dynamic> getConstants() override;
   
-  std::map<std::string, folly::dynamic> getConstants();
-  std::vector<Method> getMethods();
+  std::vector<Method> getMethods() override;
 };
 
 #endif /* SampleCxxModule_hpp */

--- a/RNTester/RNTesterUnitTests/SampleCxxModule.hpp
+++ b/RNTester/RNTesterUnitTests/SampleCxxModule.hpp
@@ -9,17 +9,17 @@
 #include <cxxreact/CxxModule.h>
 #include <cxxreact/NativeModule.h>
 
-class SampleCxxModule : public facebook::xplat::module::CxxModule
-{
-public:
-  SampleCxxModule();
-  
-  std::string getName() override;
-
-  std::map<std::string, folly::dynamic> getConstants() override;
-  
-  std::vector<Method> getMethods() override;
-};
+//class SampleCxxModule : public facebook::xplat::module::CxxModule
+//{
+//public:
+//  SampleCxxModule();
+//
+//  std::string getName() override;
+//
+//  std::map<std::string, folly::dynamic> getConstants() override;
+//
+//  std::vector<Method> getMethods() override;
+//};
 
 class SampleNativeModule : public facebook::react::NativeModule
 {

--- a/RNTester/RNTesterUnitTests/SampleCxxModule.hpp
+++ b/RNTester/RNTesterUnitTests/SampleCxxModule.hpp
@@ -7,6 +7,7 @@
 #define SampleCxxModule_hpp
 
 #include <cxxreact/CxxModule.h>
+#include <cxxreact/NativeModule.h>
 
 class SampleCxxModule : public facebook::xplat::module::CxxModule
 {
@@ -18,6 +19,20 @@ public:
   std::map<std::string, folly::dynamic> getConstants() override;
   
   std::vector<Method> getMethods() override;
+};
+
+class SampleNativeModule : public facebook::react::NativeModule
+{
+  std::weak_ptr<facebook::react::Instance> m_wkInstance;
+  
+public:
+  SampleNativeModule(std::shared_ptr<facebook::react::Instance> instance);
+
+  std::string getName() override;
+  std::vector<facebook::react::MethodDescriptor> getMethods() override;
+  folly::dynamic getConstants() override;
+  void invoke(unsigned int reactMethodId, folly::dynamic&& params, int callId) override;
+  facebook::react::MethodCallResult callSerializableNativeHook(unsigned int reactMethodId, folly::dynamic&& args) override;
 };
 
 #endif /* SampleCxxModule_hpp */

--- a/RNTester/RNTesterUnitTests/SampleCxxModule.hpp
+++ b/RNTester/RNTesterUnitTests/SampleCxxModule.hpp
@@ -9,30 +9,16 @@
 #include <cxxreact/CxxModule.h>
 #include <cxxreact/NativeModule.h>
 
-//class SampleCxxModule : public facebook::xplat::module::CxxModule
-//{
-//public:
-//  SampleCxxModule();
-//
-//  std::string getName() override;
-//
-//  std::map<std::string, folly::dynamic> getConstants() override;
-//
-//  std::vector<Method> getMethods() override;
-//};
-
-class SampleNativeModule : public facebook::react::NativeModule
+class SampleCxxModule : public facebook::xplat::module::CxxModule
 {
-  std::weak_ptr<facebook::react::Instance> m_wkInstance;
-  
 public:
-  SampleNativeModule(std::shared_ptr<facebook::react::Instance> instance);
+  SampleCxxModule();
 
   std::string getName() override;
-  std::vector<facebook::react::MethodDescriptor> getMethods() override;
-  folly::dynamic getConstants() override;
-  void invoke(unsigned int reactMethodId, folly::dynamic&& params, int callId) override;
-  facebook::react::MethodCallResult callSerializableNativeHook(unsigned int reactMethodId, folly::dynamic&& args) override;
+
+  std::map<std::string, folly::dynamic> getConstants() override;
+
+  std::vector<Method> getMethods() override;
 };
 
 #endif /* SampleCxxModule_hpp */

--- a/RNTester/RNTesterUnitTests/SampleCxxModule.hpp
+++ b/RNTester/RNTesterUnitTests/SampleCxxModule.hpp
@@ -1,10 +1,7 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
 //
-//  SampleCxxModule.hpp
-//  RNTesterUnitTests
-//
-//  Created by Julio Cesar Rocha on 11/1/18.
-//  Copyright © 2018 Facebook. All rights reserved.
-//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
 
 #ifndef SampleCxxModule_hpp
 #define SampleCxxModule_hpp

--- a/RNTester/RNTesterUnitTests/SampleCxxModule.hpp
+++ b/RNTester/RNTesterUnitTests/SampleCxxModule.hpp
@@ -1,0 +1,25 @@
+//
+//  SampleCxxModule.hpp
+//  RNTesterUnitTests
+//
+//  Created by Julio Cesar Rocha on 11/1/18.
+//  Copyright © 2018 Facebook. All rights reserved.
+//
+
+#ifndef SampleCxxModule_hpp
+#define SampleCxxModule_hpp
+
+#include <cxxreact/CxxModule.h>
+
+class SampleCxxModule : public facebook::xplat::module::CxxModule
+{
+public:
+  SampleCxxModule();
+  
+  std::string getName();
+  
+  std::map<std::string, folly::dynamic> getConstants();
+  std::vector<Method> getMethods();
+};
+
+#endif /* SampleCxxModule_hpp */

--- a/ReactCommon/cxxreact/Instance.h
+++ b/ReactCommon/cxxreact/Instance.h
@@ -53,7 +53,7 @@ public:
   virtual void loadRAMBundle(std::unique_ptr<RAMBundleRegistry> bundleRegistry,
                      std::unique_ptr<const JSBigString> startupScript,
                      std::string startupScriptSourceURL, bool loadSynchronously);
-  virtual bool supportsProfiling();
+  bool supportsProfiling();
   virtual void setGlobalVariable(std::string propName,
                          std::unique_ptr<const JSBigString> jsonValue);
   virtual void *getJavaScriptContext();
@@ -72,7 +72,7 @@ public:
   virtual void handleMemoryPressure(int pressureLevel);
 
 protected:
-  virtual void callNativeModules(folly::dynamic &&calls, bool isEndOfBatch);
+  void callNativeModules(folly::dynamic &&calls, bool isEndOfBatch);
   virtual void loadApplication(std::unique_ptr<RAMBundleRegistry> bundleRegistry,
                        std::unique_ptr<const JSBigString> startupScript,
                        std::string startupScriptSourceURL);

--- a/ReactCommon/cxxreact/Instance.h
+++ b/ReactCommon/cxxreact/Instance.h
@@ -37,46 +37,46 @@ struct InstanceCallback {
 class RN_EXPORT Instance {
 public:
   ~Instance();
-  void initializeBridge(std::unique_ptr<InstanceCallback> callback,
+  virtual void initializeBridge(std::unique_ptr<InstanceCallback> callback,
                         std::shared_ptr<JSExecutorFactory> jsef,
                         std::shared_ptr<MessageQueueThread> jsQueue,
                         std::shared_ptr<ModuleRegistry> moduleRegistry);
 
-  void setSourceURL(std::string sourceURL);
+  virtual void setSourceURL(std::string sourceURL);
 
-  void loadScriptFromString(std::unique_ptr<const JSBigString> string,
+  virtual void loadScriptFromString(std::unique_ptr<const JSBigString> string,
                             std::string sourceURL, bool loadSynchronously);
   static bool isIndexedRAMBundle(const char *sourcePath);
-  void loadRAMBundleFromFile(const std::string& sourcePath,
+  virtual void loadRAMBundleFromFile(const std::string& sourcePath,
                              const std::string& sourceURL,
                              bool loadSynchronously);
-  void loadRAMBundle(std::unique_ptr<RAMBundleRegistry> bundleRegistry,
+  virtual void loadRAMBundle(std::unique_ptr<RAMBundleRegistry> bundleRegistry,
                      std::unique_ptr<const JSBigString> startupScript,
                      std::string startupScriptSourceURL, bool loadSynchronously);
-  bool supportsProfiling();
-  void setGlobalVariable(std::string propName,
+  virtual bool supportsProfiling();
+  virtual void setGlobalVariable(std::string propName,
                          std::unique_ptr<const JSBigString> jsonValue);
-  void *getJavaScriptContext();
-  bool isInspectable();
-  bool isBatchActive();
-  void callJSFunction(std::string &&module, std::string &&method,
+  virtual void *getJavaScriptContext();
+  virtual bool isInspectable();
+  virtual bool isBatchActive();
+  virtual void callJSFunction(std::string &&module, std::string &&method,
                       folly::dynamic &&params);
-  void callJSCallback(uint64_t callbackId, folly::dynamic &&params);
+  virtual void callJSCallback(uint64_t callbackId, folly::dynamic &&params);
 
   // This method is experimental, and may be modified or removed.
-  void registerBundle(uint32_t bundleId, const std::string& bundlePath);
+  virtual void registerBundle(uint32_t bundleId, const std::string& bundlePath);
 
-  const ModuleRegistry &getModuleRegistry() const;
-  ModuleRegistry &getModuleRegistry();
+  virtual const ModuleRegistry &getModuleRegistry() const;
+  virtual ModuleRegistry &getModuleRegistry();
 
-  void handleMemoryPressure(int pressureLevel);
+  virtual void handleMemoryPressure(int pressureLevel);
 
-private:
-  void callNativeModules(folly::dynamic &&calls, bool isEndOfBatch);
-  void loadApplication(std::unique_ptr<RAMBundleRegistry> bundleRegistry,
+protected:
+  virtual void callNativeModules(folly::dynamic &&calls, bool isEndOfBatch);
+  virtual void loadApplication(std::unique_ptr<RAMBundleRegistry> bundleRegistry,
                        std::unique_ptr<const JSBigString> startupScript,
                        std::string startupScriptSourceURL);
-  void loadApplicationSync(std::unique_ptr<RAMBundleRegistry> bundleRegistry,
+  virtual void loadApplicationSync(std::unique_ptr<RAMBundleRegistry> bundleRegistry,
                            std::unique_ptr<const JSBigString> startupScript,
                            std::string startupScriptSourceURL);
 

--- a/ReactCommon/cxxreact/Instance.h
+++ b/ReactCommon/cxxreact/Instance.h
@@ -36,7 +36,7 @@ struct InstanceCallback {
 
 class RN_EXPORT Instance {
 public:
-  ~Instance();
+  virtual ~Instance();
   virtual void initializeBridge(std::unique_ptr<InstanceCallback> callback,
                         std::shared_ptr<JSExecutorFactory> jsef,
                         std::shared_ptr<MessageQueueThread> jsQueue,


### PR DESCRIPTION
## Summary:

### Public methods for class `facebook::react::Instance` become virtual, making them fully mockable.

Currently, custom types (i.e. deriving `facebook::xplat::module::CxxModule` or `facebook::react::JSExcecutor`) that need to interact with the `facebook::react::Instance` can't be fully unit tested without bootstrapping a full ReactNative app.

This change aims to make all public methods virtual so mock implementations of `facebook::react::Instance` can be written and any interaction with this class can be simulated in isolation, which will allow for complete and lightweight unit tests.

## Changelog: 

[GENERAL] [ENHANCEMENT] [ReactCommon] - Allow facebook::react::Instance to be extended for unit testing / mocking purposes.

## Test Plan:

- Build
- Run unit and integration tests for both iOS and Android
