### PR TITLE
Introduce 'setAndForwardRef' helper function

### DIFF
--- a/Libraries/Utilities/__tests__/setAndForwardRef-test.js
+++ b/Libraries/Utilities/__tests__/setAndForwardRef-test.js
@@ -4,6 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
+ * @flow
  * @format
  * @emails oncall+react_native
  */
@@ -15,56 +16,58 @@ const ReactTestRenderer = require('react-test-renderer');
 
 const setAndForwardRef = require('setAndForwardRef');
 
-let innerFuncCalled = false;
-let outerFuncCalled = false;
+describe('setAndForwardRef', () => {
+  let innerFuncCalled = false;
+  let outerFuncCalled = false;
 
-class ForwardedComponent extends React.Component {
-  testFunc() {
-    innerFuncCalled = true;
-    return true;
-  }
+  class ForwardedComponent extends React.Component<{||}> {
+    testFunc() {
+      innerFuncCalled = true;
+      return true;
+    }
 
-  render() {
-    return null;
-  }
-}
-
-class TestComponent extends React.Component {
-  _nativeRef = null;
-  _setNativeRef = setAndForwardRef({
-    getForwardedRef: () => this.props.forwardedRef,
-    setLocalRef: ref => {
-      this._nativeRef = ref;
-    },
-  });
-
-  componentDidMount() {
-    if (this.props.callFunc) {
-      this._nativeRef.testFunc();
-      outerFuncCalled = true;
+    render() {
+      return null;
     }
   }
 
-  render() {
-    return <ForwardedComponent ref={this._setNativeRef} />;
+  type Props = $ReadOnly<{|
+    callFunc?: ?boolean,
+    forwardedRef: React.Ref<typeof ForwardedComponent>,
+  |}>;
+
+  class TestComponent extends React.Component<Props> {
+    _nativeRef: ?React.ElementRef<typeof ForwardedComponent> = null;
+    _setNativeRef = setAndForwardRef({
+      getForwardedRef: () => this.props.forwardedRef,
+      setLocalRef: ref => {
+        this._nativeRef = ref;
+      },
+    });
+
+    componentDidMount() {
+      if (this.props.callFunc) {
+        outerFuncCalled = this._nativeRef && this._nativeRef.testFunc();
+      }
+    }
+
+    render() {
+      return <ForwardedComponent ref={this._setNativeRef} />;
+    }
   }
-}
 
-const TestComponentWithRef = React.forwardRef((props, ref) => (
-  <TestComponent {...props} forwardedRef={ref} />
-));
-
-describe('setAndForwardRef', () => {
-  let createdRef = null;
+  // $FlowFixMe - TODO T29156721 `React.forwardRef` is not defined in Flow, yet.
+  const TestComponentWithRef = React.forwardRef((props, ref) => (
+    <TestComponent {...props} forwardedRef={ref} />
+  ));
 
   beforeEach(() => {
-    createdRef = React.createRef();
     innerFuncCalled = false;
     outerFuncCalled = false;
   });
 
   it('should forward refs (function-based)', () => {
-    let testRef = null;
+    let testRef: ?React.ElementRef<typeof ForwardedComponent> = null;
 
     ReactTestRenderer.create(
       <TestComponentWithRef
@@ -73,18 +76,49 @@ describe('setAndForwardRef', () => {
         }}
       />,
     );
-    const val = testRef.testFunc();
+
+    const val = testRef && testRef.testFunc();
 
     expect(innerFuncCalled).toBe(true);
     expect(val).toBe(true);
   });
 
   it('should forward refs (createRef-based)', () => {
+    const createdRef = React.createRef<typeof ForwardedComponent>();
+
     ReactTestRenderer.create(<TestComponentWithRef ref={createdRef} />);
-    const val = createdRef.current.testFunc();
+
+    const val = createdRef.current && createdRef.current.testFunc();
 
     expect(innerFuncCalled).toBe(true);
     expect(val).toBe(true);
+  });
+
+  it('should forward refs (string-based)', () => {
+    class Test extends React.Component<{||}> {
+      refs: $ReadOnly<{|
+        stringRef?: ?React.ElementRef<typeof ForwardedComponent>,
+      |}>;
+
+      componentDidMount() {
+        this.refs.stringRef && this.refs.stringRef.testFunc();
+      }
+
+      render() {
+        /**
+         * Can't directly pass the test component to `ReactTestRenderer.create`,
+         * otherwise it will throw. See:
+         * https://reactjs.org/warnings/refs-must-have-owner.html#strings-refs-outside-the-render-method
+         */
+        /* eslint-disable react/no-string-refs */
+        return <TestComponentWithRef ref="stringRef" />;
+        /* eslint-enable react/no-string-refs */
+      }
+    }
+
+    ReactTestRenderer.create(<Test />);
+
+    expect(innerFuncCalled).toBe(true);
   });
 
   it('should be able to use the ref from inside of the forwarding class', () => {
@@ -94,13 +128,5 @@ describe('setAndForwardRef', () => {
 
     expect(innerFuncCalled).toBe(true);
     expect(outerFuncCalled).toBe(true);
-  });
-
-  it('should throw on string-based refs', () => {
-    /* eslint-disable react/no-string-refs */
-    expect(() =>
-      ReactTestRenderer.create(<TestComponentWithRef ref="stringRef" />),
-    ).toThrow();
-    /* eslint-enable react/no-string-refs */
   });
 });

--- a/Libraries/Utilities/__tests__/setAndForwardRef-test.js
+++ b/Libraries/Utilities/__tests__/setAndForwardRef-test.js
@@ -1,0 +1,106 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @emails oncall+react_native
+ */
+
+'use strict';
+
+const React = require('React');
+const ReactTestRenderer = require('react-test-renderer');
+
+const setAndForwardRef = require('setAndForwardRef');
+
+let innerFuncCalled = false;
+let outerFuncCalled = false;
+
+class ForwardedComponent extends React.Component {
+  testFunc() {
+    innerFuncCalled = true;
+    return true;
+  }
+
+  render() {
+    return null;
+  }
+}
+
+class TestComponent extends React.Component {
+  _nativeRef = null;
+  _setNativeRef = setAndForwardRef({
+    getForwardedRef: () => this.props.forwardedRef,
+    setLocalRef: ref => {
+      this._nativeRef = ref;
+    },
+  });
+
+  componentDidMount() {
+    if (this.props.callFunc) {
+      this._nativeRef.testFunc();
+      outerFuncCalled = true;
+    }
+  }
+
+  render() {
+    return <ForwardedComponent ref={this._setNativeRef} />;
+  }
+}
+
+const TestComponentWithRef = React.forwardRef((props, ref) => (
+  <TestComponent {...props} forwardedRef={ref} />
+));
+
+describe('setAndForwardRef', () => {
+  let createdRef = null;
+
+  beforeEach(() => {
+    createdRef = React.createRef();
+    innerFuncCalled = false;
+    outerFuncCalled = false;
+  });
+
+  it('should forward refs (function-based)', () => {
+    let testRef = null;
+
+    ReactTestRenderer.create(
+      <TestComponentWithRef
+        ref={ref => {
+          testRef = ref;
+        }}
+      />,
+    );
+    const val = testRef.testFunc();
+
+    expect(innerFuncCalled).toBe(true);
+    expect(val).toBe(true);
+  });
+
+  it('should forward refs (createRef-based)', () => {
+    ReactTestRenderer.create(<TestComponentWithRef ref={createdRef} />);
+    const val = createdRef.current.testFunc();
+
+    expect(innerFuncCalled).toBe(true);
+    expect(val).toBe(true);
+  });
+
+  it('should be able to use the ref from inside of the forwarding class', () => {
+    expect(() =>
+      ReactTestRenderer.create(<TestComponentWithRef callFunc={true} />),
+    ).not.toThrow();
+
+    expect(innerFuncCalled).toBe(true);
+    expect(outerFuncCalled).toBe(true);
+  });
+
+  it('should throw on string-based refs', () => {
+    /* eslint-disable react/no-string-refs */
+    expect(() =>
+      ReactTestRenderer.create(<TestComponentWithRef ref="stringRef" />),
+    ).toThrow();
+    /* eslint-enable react/no-string-refs */
+  });
+});

--- a/Libraries/Utilities/__tests__/setAndForwardRef-test.js
+++ b/Libraries/Utilities/__tests__/setAndForwardRef-test.js
@@ -101,7 +101,9 @@ describe('setAndForwardRef', () => {
       |}>;
 
       componentDidMount() {
+        /* eslint-disable react/no-string-refs */
         this.refs.stringRef && this.refs.stringRef.testFunc();
+        /* eslint-enable react/no-string-refs */
       }
 
       render() {

--- a/Libraries/Utilities/setAndForwardRef.js
+++ b/Libraries/Utilities/setAndForwardRef.js
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow
+ */
+
+'use strict';
+
+const invariant = require('fbjs/lib/invariant');
+
+import type React from 'React';
+
+type Args = $ReadOnly<{|
+  getForwardedRef: () => ?React.Ref<any>,
+  setLocalRef: (ref: React.ElementRef<any>) => mixed,
+|}>;
+
+/**
+ * This is a helper function for when a component needs to be able to forward a ref
+ * to a child component, but still needs to have access to that component as part of
+ * its implementation.
+ *
+ * Its main use case is in wrappers for native components.
+ *
+ * Usage:
+ *
+ *   class MyView extends React.Component {
+ *     _nativeRef = null;
+ *
+ *     _setNativeRef = setAndForwardRef({
+ *       getForwardedRef: () => this.props.forwardedRef,
+ *       setLocalRef: ref => {
+ *         this._nativeRef = ref;
+ *       },
+ *     });
+ *
+ *     render() {
+ *       return <View ref={this._setNativeRef} />;
+ *     }
+ *   }
+ *
+ *   const MyViewWithRef = React.forwardRef((props, ref) => (
+ *     <MyView {...props} forwardedRef={ref} />
+ *   ));
+ *
+ *   module.exports = MyViewWithRef;
+ */
+
+function setAndForwardRef({getForwardedRef, setLocalRef}: Args) {
+  return function forwardRef(ref: React.ElementRef<any>) {
+    const forwardedRef = getForwardedRef();
+
+    setLocalRef(ref);
+
+    // Forward to user ref prop (if one has been specified)
+    // String-based refs cannot be shared.
+    if (typeof forwardedRef === 'string') {
+      invariant(
+        false,
+        `String-based refs are not supported on this component. Got ref: '${forwardedRef}'`,
+      );
+    } else if (typeof forwardedRef === 'function') {
+      forwardedRef(ref);
+    } else if (typeof forwardedRef === 'object' && forwardedRef != null) {
+      forwardedRef.current = ref;
+    }
+  };
+}
+
+module.exports = setAndForwardRef;

--- a/Libraries/Utilities/setAndForwardRef.js
+++ b/Libraries/Utilities/setAndForwardRef.js
@@ -57,15 +57,11 @@ function setAndForwardRef({getForwardedRef, setLocalRef}: Args) {
     setLocalRef(ref);
 
     // Forward to user ref prop (if one has been specified)
-    // String-based refs cannot be shared.
-    if (typeof forwardedRef === 'string') {
-      invariant(
-        false,
-        `String-based refs are not supported on this component. Got ref: '${forwardedRef}'`,
-      );
-    } else if (typeof forwardedRef === 'function') {
+    if (typeof forwardedRef === 'function') {
+      // Handle function-based refs. String-based refs are handled as functions.
       forwardedRef(ref);
     } else if (typeof forwardedRef === 'object' && forwardedRef != null) {
+      // Handle createRef-based refs
       forwardedRef.current = ref;
     }
   };


### PR DESCRIPTION
This PR introduces a new helper function called `setAndForwardRef`. It is intended to help with moving components that depend on `NativeMethodsMixin` off of `createReactClass`.

It allows for classes that depend on having a ref to a native component to be able to also forward the native component ref to user code.

Usage is like this:

```js
class MyView extends React.Component {
  _nativeRef = null;
  _setNativeRef = setAndForwardRef({
    getForwardedRef: () => this.props.forwardedRef,
    setLocalRef: ref => {
      this._nativeRef = ref;
    },
  });
  render() {
    return <View ref={this._setNativeRef} />;
  }
}
const MyViewWithRef = React.forwardRef((props, ref) => (
  <MyView {...props} forwardedRef={ref} />
));
module.exports = MyViewWithRef;
```

Test Plan:
----------
A new Jest test has been added to `Libraries/Utilities/__tests__/setAndForwardRef-test.js` to put this helper function through its paces.

Release Notes:
--------------
Help reviewers and the release process by writing your own release notes. See below for an example.

[GENERAL] [ENHANCEMENT] [Libraries/Utilities/__tests__/setAndForwardRef-test.js] - Added tests for the `setAndForwardRef` helper function
[GENERAL] [ENHANCEMENT] [Libraries/Utilities/setAndForwardRef.js] - Added new helper function for forwarding refs inside of class components

