### PR TITLE
use requireActual and requireMock from jest instead of require

### DIFF
--- a/jest/mockComponent.js
+++ b/jest/mockComponent.js
@@ -10,7 +10,7 @@
 'use strict';
 
 module.exports = (moduleName, instanceMethods) => {
-  const RealComponent = require.requireActual(moduleName);
+  const RealComponent = jest.requireActual(moduleName);
   const React = require('react');
 
   const SuperClass =

--- a/jest/setup.js
+++ b/jest/setup.js
@@ -9,19 +9,17 @@
 
 'use strict';
 
-const MockNativeMethods = require.requireActual('./MockNativeMethods');
-const mockComponent = require.requireActual('./mockComponent');
+const MockNativeMethods = jest.requireActual('./MockNativeMethods');
+const mockComponent = jest.requireActual('./mockComponent');
 
-require.requireActual('../Libraries/polyfills/babelHelpers.js');
-require.requireActual('../Libraries/polyfills/Object.es7.js');
-require.requireActual('../Libraries/polyfills/error-guard');
+jest.requireActual('../Libraries/polyfills/babelHelpers.js');
+jest.requireActual('../Libraries/polyfills/Object.es7.js');
+jest.requireActual('../Libraries/polyfills/error-guard');
 
 global.__DEV__ = true;
 
-global.Promise = require.requireActual('promise');
-global.regeneratorRuntime = require.requireActual(
-  'regenerator-runtime/runtime',
-);
+global.Promise = jest.requireActual('promise');
+global.regeneratorRuntime = jest.requireActual('regenerator-runtime/runtime');
 
 global.requestAnimationFrame = function(callback) {
   return setTimeout(callback, 0);
@@ -42,12 +40,12 @@ jest
   .mock('TextInput', () => mockComponent('TextInput'))
   .mock('Modal', () => mockComponent('Modal'))
   .mock('View', () => mockComponent('View', MockNativeMethods))
-  .mock('RefreshControl', () => require.requireMock('RefreshControlMock'))
-  .mock('ScrollView', () => require.requireMock('ScrollViewMock'))
+  .mock('RefreshControl', () => jest.requireMock('RefreshControlMock'))
+  .mock('ScrollView', () => jest.requireMock('ScrollViewMock'))
   .mock('ActivityIndicator', () => mockComponent('ActivityIndicator'))
-  .mock('ListView', () => require.requireMock('ListViewMock'))
+  .mock('ListView', () => jest.requireMock('ListViewMock'))
   .mock('ListViewDataSource', () => {
-    const DataSource = require.requireActual('ListViewDataSource');
+    const DataSource = jest.requireActual('ListViewDataSource');
     DataSource.prototype.toJSON = function() {
       function ListViewDataSource(dataBlob) {
         this.items = 0;
@@ -68,9 +66,7 @@ jest
     return DataSource;
   })
   .mock('AnimatedImplementation', () => {
-    const AnimatedImplementation = require.requireActual(
-      'AnimatedImplementation',
-    );
+    const AnimatedImplementation = jest.requireActual('AnimatedImplementation');
     const oldCreate = AnimatedImplementation.createAnimatedComponent;
     AnimatedImplementation.createAnimatedComponent = function(Component) {
       const Wrapped = oldCreate(Component);
@@ -80,7 +76,7 @@ jest
     return AnimatedImplementation;
   })
   .mock('ReactNative', () => {
-    const ReactNative = require.requireActual('ReactNative');
+    const ReactNative = jest.requireActual('ReactNative');
     const NativeMethodsMixin =
       ReactNative.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED
         .NativeMethodsMixin;

--- a/local-cli/core/__fixtures__/android.js
+++ b/local-cli/core/__fixtures__/android.js
@@ -7,8 +7,8 @@
  * @format
  */
 
-const fs = require.requireActual('fs');
-const path = require.requireActual('path');
+const fs = jest.requireActual('fs');
+const path = jest.requireActual('path');
 
 const manifest = fs.readFileSync(
   path.join(__dirname, './files/AndroidManifest.xml'),

--- a/local-cli/core/__fixtures__/dependencies.js
+++ b/local-cli/core/__fixtures__/dependencies.js
@@ -1,6 +1,6 @@
 /** @format */
 
-const fs = require.requireActual('fs');
+const fs = jest.requireActual('fs');
 const path = require('path');
 const android = require('./android');
 

--- a/local-cli/core/__fixtures__/ios.js
+++ b/local-cli/core/__fixtures__/ios.js
@@ -1,6 +1,6 @@
 /** @format */
 
-const fs = require.requireActual('fs');
+const fs = jest.requireActual('fs');
 const path = require('path');
 
 exports.valid = {

--- a/local-cli/link/__tests__/ios/writePlist.spec.js
+++ b/local-cli/link/__tests__/ios/writePlist.spec.js
@@ -16,13 +16,13 @@ jest.mock('fs');
 let plistPath = null;
 jest.mock('../../ios/getPlistPath', () => () => plistPath);
 
-const {readFileSync} = require.requireActual('fs');
+const {readFileSync} = jest.requireActual('fs');
 const fs = require('fs');
 
 const xcode = require('xcode');
 const writePlist = require('../../ios/writePlist');
 
-const realPath = require.requireActual('path');
+const realPath = jest.requireActual('path');
 const projectPath = realPath.join(
   __dirname,
   '../../__fixtures__/project.pbxproj',


### PR DESCRIPTION
A while back Jest introduced `jest.requireActual` and `jest.requireMock` which are aliases to `require.requireActual` and `require.requireMock`. We believe that users should use official Jest API and are planning to deprecate the latter.

Test Plan:
--------------

Only Jest-related changes, CI should be green.

Release Notes:
--------------

[GENERAL] [ENHANCEMENT] [tests] - Use requireActual and requireMock from jest object instead of require.