### PR TITLE
Prepend passed sourceExts to default ones and pass them to metro

### DIFF
--- a/local-cli/server/runServer.js
+++ b/local-cli/server/runServer.js
@@ -70,6 +70,13 @@ async function runServer(args: Args, config: ConfigT) {
   config.server.enhanceMiddleware = middleware =>
     middlewareManager.getConnectInstance().use(middleware);
 
+  if (args.sourceExts !== config.resolver.sourceExts) {
+    // $FlowFixMe Metro configuration is immutable.
+    config.resolver.sourceExts = args.sourceExts.concat(
+      config.resolver.sourceExts,
+    );
+  }
+
   const serverInstance = await Metro.runServer(config, {
     host: args.host,
     secure: args.https,


### PR DESCRIPTION
Fixes react-native start not using passed --sourceExts #21854

Test Plan:
----------
```
react-native init TestProject
cd TestProject
cp App.js App.e2e.js
# Make a visible change in App.e2e.js
react-native start --sourceExts e2e.js
react-native run-ios
# Check to see that the packager is taking the App.e2e.js file instead of the App.js one
```

Release Notes:
--------------
[CLI] [BUGFIX] [ local-cli/server/runServer.js] - Pass down --sourceExts to metro packager (fixes regression)