### PR TITLE
Duration cannot be less then 10ms

### DIFF
--- a/Libraries/Components/Keyboard/KeyboardAvoidingView.js
+++ b/Libraries/Components/Keyboard/KeyboardAvoidingView.js
@@ -99,9 +99,10 @@ class KeyboardAvoidingView extends React.Component<Props, State> {
 
     if (duration && easing) {
       LayoutAnimation.configureNext({
-        duration: duration,
+        // We have to pass the duration equal to minimal accepted duration defined here: RCTLayoutAnimation.m
+        duration: duration > 10 ? duration : 10,
         update: {
-          duration: duration,
+          duration: duration > 10 ? duration : 10,
           type: LayoutAnimation.Types[easing] || 'keyboard',
         },
       });


### PR DESCRIPTION
Related to: #21853

Fixes #21853

Test Plan:
----------
This is an intermittent timing issue. It happens when you scroll quickly from the top to the bottom to dismiss the keyboard, right after a bounce happens in a ScrollView, the duration of the event has to be less than 10ms for the error to occur (see the attached gifs).

![fixed](https://user-images.githubusercontent.com/7595998/47207235-06a21300-d38b-11e8-9e12-2a3bc7da43a9.gif)
![crash](https://user-images.githubusercontent.com/7595998/47207236-06a21300-d38b-11e8-9dd9-96b457824bc8.gif)

Release Notes:
--------------

[IOS] [BUGFIX] [KeyboardAvoidingView] - Fix the crash when transition duration < 10ms
