### PR TITLE
[ANDROID] [ENHANCEMENT] [build] - Use clang to build Android libraries 

### DIFF
--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -86,17 +86,6 @@ task prepareFolly(dependsOn: dependenciesPath ? [] : [downloadFolly], type: Copy
     include "folly-${FOLLY_VERSION}/folly/**/*", 'Android.mk'
     eachFile {fname -> fname.path = (fname.path - "folly-${FOLLY_VERSION}/")}
     includeEmptyDirs = false
-
-    // Patch for folly build break on gcc 4.9 and could be removed after build by clang
-    filesMatching('**/container/detail/F14Policy.h') {
-        filter(ReplaceTokens, tokens: [
-            'ObjectHolder(Args&&... args) : value_{std::forward<Args>(args)...} {}': 'ObjectHolder(Args&&... args) : value_({std::forward<Args>(args)...}) {}',
-            'ObjectHolder(Args&&... args) : T{std::forward<Args>(args)...} {}': 'ObjectHolder(Args&&... args) : T({std::forward<Args>(args)...}) {}',
-        ],
-        beginToken: '',
-        endToken: '')
-    }
-
     into "$thirdPartyNdkDir/folly"
 }
 

--- a/ReactAndroid/src/main/jni/Application.mk
+++ b/ReactAndroid/src/main/jni/Application.mk
@@ -24,11 +24,9 @@ APP_MK_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 #   etc.) are defined inside build.gradle.
 NDK_MODULE_PATH := $(APP_MK_DIR)$(HOST_DIRSEP)$(THIRD_PARTY_NDK_DIR)$(HOST_DIRSEP)$(REACT_COMMON_DIR)$(HOST_DIRSEP)$(APP_MK_DIR)first-party$(HOST_DIRSEP)$(REACT_SRC_DIR)
 
-APP_STL := gnustl_shared
+APP_STL := c++_shared
 
 # Make sure every shared lib includes a .note.gnu.build-id header
-APP_CFLAGS := -Wall -Werror
+APP_CFLAGS := -Wall -Werror -Wno-unused-lambda-capture
 APP_CPPFLAGS := -std=c++1y
 APP_LDFLAGS := -Wl,--build-id
-
-NDK_TOOLCHAIN_VERSION := 4.9

--- a/ReactAndroid/src/main/jni/third-party/folly/Android.mk
+++ b/ReactAndroid/src/main/jni/third-party/folly/Android.mk
@@ -26,6 +26,7 @@ FOLLY_FLAGS := \
   -DFOLLY_NO_CONFIG=1 \
   -DFOLLY_HAVE_CLOCK_GETTIME=1 \
   -DFOLLY_HAVE_MEMRCHR=1 \
+  -DFOLLY_USE_LIBCPP=1 \
 
 # If APP_PLATFORM in Application.mk targets android-23 above, please comment this line.
 # NDK uses GNU style stderror_r() after API 23.


### PR DESCRIPTION
Fixes #20342 and support for future NDK r18

TODO:
-------

~~- [x] Wait folly merged with this [fix](https://github.com/facebook/folly/pull/953)~~

- [ ] ~~Wait android-jsc with clang built. See https://github.com/facebook/react-native/issues/20302#issuecomment-431383278 for details.
      Workaround to test without clang android-jsc: put libgnustl_shared.so directly into apk, i.e. will have both libstd++ (for JSC) and libc++ (for libreactnativejni.so) runtime.
       Or maybe try to use [community maintained android-jsc](https://github.com/react-community/jsc-android-buildscripts#how-to-use-it-with-my-react-native-app) which is built by clang.~~
JSC should also built by clang. Wait for https://github.com/Kudo/android-jsc/commit/0437216a29dbd8c7c492c317f3447dd8089d70fd landed.

~~- [x] Upgrade iOS folly version as well~~

Test Plan:
----------
Test by RNTester

Release Notes:
--------------
[ANDROID] [ENHANCEMENT] [build] - Use clang to build Android libraries