### PR TITLE
Add missing TV keys found on TV remote controllers

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/ReactAndroidHWInputDeviceHelper.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactAndroidHWInputDeviceHelper.java
@@ -30,12 +30,18 @@ public class ReactAndroidHWInputDeviceHelper {
     .put(KeyEvent.KEYCODE_ENTER, "select")
     .put(KeyEvent.KEYCODE_SPACE, "select")
     .put(KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE, "playPause")
+    .put(KeyEvent.KEYCODE_MEDIA_PLAY, "play")
+    .put(KeyEvent.KEYCODE_MEDIA_PAUSE, "pause")
+    .put(KeyEvent.KEYCODE_MEDIA_STOP, "stop")
     .put(KeyEvent.KEYCODE_MEDIA_REWIND, "rewind")
     .put(KeyEvent.KEYCODE_MEDIA_FAST_FORWARD, "fastForward")
+    .put(KeyEvent.KEYCODE_MEDIA_PREVIOUS, "previous")
+    .put(KeyEvent.KEYCODE_MEDIA_NEXT, "next")
     .put(KeyEvent.KEYCODE_DPAD_UP, "up")
     .put(KeyEvent.KEYCODE_DPAD_RIGHT, "right")
     .put(KeyEvent.KEYCODE_DPAD_DOWN, "down")
     .put(KeyEvent.KEYCODE_DPAD_LEFT, "left")
+    .put(KeyEvent.KEYCODE_MEDIA_AUDIO_TRACK, "audioTrack")
     .build();
 
   /**


### PR DESCRIPTION
There were some Keys that were not being handled by TVEventHandler but found on almost all traditional Android TV controllers and widely used by Android TV app e.g. next key which on pressing skips to next playback.

This PR simply adds those missing keys.

Currently missing keys:
![Missing keyst](https://i.imgur.com/lNd3bE2.jpg)


Test Plan:
----------
It simply adds some map key values. Doesn't change any mechanism.
Also tested on android TV emulator and SONY Android TV on both debug and release mode.

Release Notes:
--------------


[ANDROID] [ENHANCEMENT ] [TVEventHandler] - Adds the missing Keys for handling

