### PR TITLE
[createReactClass] Remove createReactClass from ProgressBarAndroidExample

### DIFF
--- a/Libraries/Components/ProgressBarAndroid/ProgressBarAndroid.android.js
+++ b/Libraries/Components/ProgressBarAndroid/ProgressBarAndroid.android.js
@@ -19,7 +19,7 @@ import type {ViewProps} from 'ViewPropTypes';
 
 const AndroidProgressBar = requireNativeComponent('AndroidProgressBar');
 
-type Props = $ReadOnly<{|
+export type ProgressBarAndroidProps = $ReadOnly<{|
   ...ViewProps,
 
   /**
@@ -83,7 +83,7 @@ type Props = $ReadOnly<{|
  * ```
  */
 const ProgressBarAndroid = (
-  props: Props,
+  props: ProgressBarAndroidProps,
   forwardedRef: ?React.Ref<'AndroidProgressBar'>,
 ) => {
   return <AndroidProgressBar {...props} ref={forwardedRef} />;
@@ -98,4 +98,6 @@ ProgressBarAndroidToExport.defaultProps = {
   animating: true,
 };
 
-module.exports = (ProgressBarAndroidToExport: Class<NativeComponent<Props>>);
+module.exports = (ProgressBarAndroidToExport: Class<
+  NativeComponent<ProgressBarAndroidProps>,
+>);

--- a/RNTester/js/ProgressBarAndroidExample.android.js
+++ b/RNTester/js/ProgressBarAndroidExample.android.js
@@ -26,7 +26,7 @@ type MovingBarState = {
 };
 
 class MovingBar extends React.Component<MovingBarProps, MovingBarState> {
-  _intervalID: (null: ?IntervalID);
+  _intervalID: ?IntervalID = null;
 
   state = {
     progress: 0,

--- a/RNTester/js/ProgressBarAndroidExample.android.js
+++ b/RNTester/js/ProgressBarAndroidExample.android.js
@@ -17,12 +17,17 @@ const RNTesterPage = require('RNTesterPage');
 
 type ProgressBarProps = React.ElementConfig<typeof ProgressBar>;
 
-type MovingBarProps = $ReadOnly<$Diff<ProgressBarProps, {
-  progress: $ElementType<ProgressBarProps, 'progress'>
-}>>;
+type MovingBarProps = $ReadOnly<
+  $Diff<
+    ProgressBarProps,
+    {
+      progress: $ElementType<ProgressBarProps, 'progress'>,
+    },
+  >,
+>;
 
 type MovingBarState = {
-  progress: number
+  progress: number,
 };
 
 class MovingBar extends React.Component<MovingBarProps, MovingBarState> {
@@ -35,7 +40,7 @@ class MovingBar extends React.Component<MovingBarProps, MovingBarState> {
   componentDidMount() {
     this._intervalID = setInterval(() => {
       const progress = (this.state.progress + 0.02) % 1;
-      this.setState({ progress });
+      this.setState({progress});
     }, 50);
   }
 
@@ -48,7 +53,7 @@ class MovingBar extends React.Component<MovingBarProps, MovingBarState> {
   render() {
     return <ProgressBar progress={this.state.progress} {...this.props} />;
   }
-};
+}
 
 class ProgressBarAndroidExample extends React.Component<{}> {
   static title = '<ProgressBarAndroid>';

--- a/RNTester/js/ProgressBarAndroidExample.android.js
+++ b/RNTester/js/ProgressBarAndroidExample.android.js
@@ -15,16 +15,17 @@ const React = require('React');
 const RNTesterBlock = require('RNTesterBlock');
 const RNTesterPage = require('RNTesterPage');
 
-type ProgressBarProps = React.ElementConfig<typeof ProgressBar>;
+import type {ProgressBarAndroidProps} from 'ProgressBarAndroid';
 
-type MovingBarProps = $ReadOnly<
-  $Diff<
-    ProgressBarProps,
+type MovingBarProps = $ReadOnly<{|
+  ...$Diff<
+    ProgressBarAndroidProps,
     {
-      progress: $ElementType<ProgressBarProps, 'progress'>,
+      progress: ?number,
     },
   >,
->;
+  indeterminate: false,
+|}>;
 
 type MovingBarState = {
   progress: number,

--- a/RNTester/js/ProgressBarAndroidExample.android.js
+++ b/RNTester/js/ProgressBarAndroidExample.android.js
@@ -10,39 +10,45 @@
 
 'use strict';
 
-var ProgressBar = require('ProgressBarAndroid');
-var React = require('React');
-var createReactClass = require('create-react-class');
-var RNTesterBlock = require('RNTesterBlock');
-var RNTesterPage = require('RNTesterPage');
+const ProgressBar = require('ProgressBarAndroid');
+const React = require('React');
+const RNTesterBlock = require('RNTesterBlock');
+const RNTesterPage = require('RNTesterPage');
 
-var MovingBar = createReactClass({
-  displayName: 'MovingBar',
-  _intervalID: (null: ?IntervalID),
+type ProgressBarProps = React.ElementConfig<typeof ProgressBar>;
 
-  getInitialState: function() {
-    return {
-      progress: 0,
-    };
-  },
+type MovingBarProps = $ReadOnly<$Diff<ProgressBarProps, {
+  progress: $ElementType<ProgressBarProps, 'progress'>
+}>>;
 
-  componentDidMount: function() {
+type MovingBarState = {
+  progress: number
+};
+
+class MovingBar extends React.Component<MovingBarProps, MovingBarState> {
+  _intervalID: (null: ?IntervalID);
+
+  state = {
+    progress: 0,
+  };
+
+  componentDidMount() {
     this._intervalID = setInterval(() => {
-      var progress = (this.state.progress + 0.02) % 1;
-      this.setState({progress: progress});
+      const progress = (this.state.progress + 0.02) % 1;
+      this.setState({ progress });
     }, 50);
-  },
+  }
 
-  componentWillUnmount: function() {
+  componentWillUnmount() {
     if (this._intervalID != null) {
       clearInterval(this._intervalID);
     }
-  },
+  }
 
-  render: function() {
+  render() {
     return <ProgressBar progress={this.state.progress} {...this.props} />;
-  },
-});
+  }
+};
 
 class ProgressBarAndroidExample extends React.Component<{}> {
   static title = '<ProgressBarAndroid>';


### PR DESCRIPTION
Related to #21581

This PR was already opened here https://github.com/facebook/react-native/pull/21600 but seems to be inactive.

Remove createReactClass from ProgressBarAndroidExample.

## Test Plan:
- `yarn run flow` && `yarn run flow-check-android` succeed.
- RNTester app ProgressBarAndroidExample on Android.

## Release Notes:
[GENERAL] [ENHANCEMENT] [ProgressBarAndroidExample.android.js] - rm createReactClass