### PR TITLE
[createReactClass] Remove createReactClass from SwipeableRow

### DIFF
--- a/Libraries/Experimental/SwipeableRow/SwipeableRow.js
+++ b/Libraries/Experimental/SwipeableRow/SwipeableRow.js
@@ -57,15 +57,15 @@ const RIGHT_SWIPE_THRESHOLD = 30 * SLOW_SPEED_SWIPE_FACTOR;
 type Props = $ReadOnly<{|
   children?: ?React.Node,
   isOpen?: ?boolean,
-  maxSwipeDistance: number,
-  onClose?: ?Function,
-  onOpen?: ?Function,
-  onSwipeEnd?: ?Function,
-  onSwipeStart?: ?Function,
+  maxSwipeDistance?: ?number,
+  onClose?: ?() => void,
+  onOpen?: ?() => void,
+  onSwipeEnd?: ?() => void,
+  onSwipeStart?: ?() => void,
   preventSwipeRight?: ?boolean,
   shouldBounceOnMount?: ?boolean,
   slideoutView?: ?React.Node,
-  swipeThreshold: number,
+  swipeThreshold?: ?number,
 |}>;
 
 type State = {
@@ -82,7 +82,81 @@ type State = {
  * to use this component separately.
  */
 class SwipeableRow extends React.Component<Props, State> {
-  _panResponder = {};
+  _handleMoveShouldSetPanResponderCapture = (
+    event: PressEvent,
+    gestureState: GestureState,
+  ): boolean => {
+    // Decides whether a swipe is responded to by this component or its child
+    return gestureState.dy < 10 && this._isValidSwipe(gestureState);
+  };
+
+  _handlePanResponderGrant = (
+    event: PressEvent,
+    gestureState: GestureState,
+  ): void => {};
+
+  _handlePanResponderMove = (
+    event: PressEvent,
+    gestureState: GestureState,
+  ): void => {
+    if (this._isSwipingExcessivelyRightFromClosedPosition(gestureState)) {
+      return;
+    }
+
+    this.props.onSwipeStart && this.props.onSwipeStart();
+
+    if (this._isSwipingRightFromClosed(gestureState)) {
+      this._swipeSlowSpeed(gestureState);
+    } else {
+      this._swipeFullSpeed(gestureState);
+    }
+  };
+
+  _onPanResponderTerminationRequest = (
+    event: PressEvent,
+    gestureState: GestureState,
+  ): boolean => {
+    return false;
+  };
+
+  _handlePanResponderEnd = (
+    event: PressEvent,
+    gestureState: GestureState,
+  ): void => {
+    const horizontalDistance = IS_RTL ? -gestureState.dx : gestureState.dx;
+    if (this._isSwipingRightFromClosed(gestureState)) {
+      this.props.onOpen && this.props.onOpen();
+      this._animateBounceBack(RIGHT_SWIPE_BOUNCE_BACK_DURATION);
+    } else if (this._shouldAnimateRemainder(gestureState)) {
+      if (horizontalDistance < 0) {
+        // Swiped left
+        this.props.onOpen && this.props.onOpen();
+        this._animateToOpenPositionWith(gestureState.vx, horizontalDistance);
+      } else {
+        // Swiped right
+        this.props.onClose && this.props.onClose();
+        this._animateToClosedPosition();
+      }
+    } else {
+      if (this._previousLeft === CLOSED_LEFT_POSITION) {
+        this._animateToClosedPosition();
+      } else {
+        this._animateToOpenPosition();
+      }
+    }
+
+    this.props.onSwipeEnd && this.props.onSwipeEnd();
+  };
+  _panResponder = PanResponder.create({
+    onMoveShouldSetPanResponderCapture: this
+      ._handleMoveShouldSetPanResponderCapture,
+    onPanResponderGrant: this._handlePanResponderGrant,
+    onPanResponderMove: this._handlePanResponderMove,
+    onPanResponderRelease: this._handlePanResponderEnd,
+    onPanResponderTerminationRequest: this._onPanResponderTerminationRequest,
+    onPanResponderTerminate: this._handlePanResponderEnd,
+    onShouldBlockNativeResponder: (event, gestureState) => false,
+  });
   _previousLeft = CLOSED_LEFT_POSITION;
   _timeoutID: ?TimeoutID = null;
 
@@ -108,19 +182,6 @@ class SwipeableRow extends React.Component<Props, State> {
     isSwipeableViewRendered: false,
     rowHeight: null,
   };
-
-  UNSAFE_componentWillMount(): void {
-    this._panResponder = PanResponder.create({
-      onMoveShouldSetPanResponderCapture: this
-        ._handleMoveShouldSetPanResponderCapture,
-      onPanResponderGrant: this._handlePanResponderGrant,
-      onPanResponderMove: this._handlePanResponderMove,
-      onPanResponderRelease: this._handlePanResponderEnd,
-      onPanResponderTerminationRequest: this._onPanResponderTerminationRequest,
-      onPanResponderTerminate: this._handlePanResponderEnd,
-      onShouldBlockNativeResponder: (event, gestureState) => false,
-    });
-  }
 
   componentDidMount(): void {
     if (this.props.shouldBounceOnMount) {
@@ -184,39 +245,12 @@ class SwipeableRow extends React.Component<Props, State> {
     this._animateToClosedPosition();
   }
 
-  _onSwipeableViewLayout(event: LayoutEvent): void {
+  _onSwipeableViewLayout = (event: LayoutEvent): void => {
     this.setState({
       isSwipeableViewRendered: true,
       rowHeight: event.nativeEvent.layout.height,
     });
-  }
-
-  _handleMoveShouldSetPanResponderCapture(
-    event: PressEvent,
-    gestureState: GestureState,
-  ): boolean {
-    // Decides whether a swipe is responded to by this component or its child
-    return gestureState.dy < 10 && this._isValidSwipe(gestureState);
-  }
-
-  _handlePanResponderGrant(
-    event: PressEvent,
-    gestureState: GestureState,
-  ): void {}
-
-  _handlePanResponderMove(event: PressEvent, gestureState: GestureState): void {
-    if (this._isSwipingExcessivelyRightFromClosedPosition(gestureState)) {
-      return;
-    }
-
-    this.props.onSwipeStart && this.props.onSwipeStart();
-
-    if (this._isSwipingRightFromClosed(gestureState)) {
-      this._swipeSlowSpeed(gestureState);
-    } else {
-      this._swipeFullSpeed(gestureState);
-    }
-  }
+  };
 
   _isSwipingRightFromClosed(gestureState: GestureState): boolean {
     const gestureStateDx = IS_RTL ? -gestureState.dx : gestureState.dx;
@@ -248,13 +282,6 @@ class SwipeableRow extends React.Component<Props, State> {
     );
   }
 
-  _onPanResponderTerminationRequest(
-    event: PressEvent,
-    gestureState: GestureState,
-  ): boolean {
-    return false;
-  }
-
   _animateTo(
     toValue: number,
     duration: number = SWIPE_DURATION,
@@ -271,11 +298,11 @@ class SwipeableRow extends React.Component<Props, State> {
   }
 
   _animateToOpenPosition(): void {
-    const maxSwipeDistance = IS_RTL
-      ? -this.props.maxSwipeDistance
-      : this.props.maxSwipeDistance;
-
-    this._animateTo(-maxSwipeDistance);
+    const maxSwipeDistance = this.props.maxSwipeDistance ?? 0;
+    const directionAwareMaxSwipeDistance = IS_RTL
+      ? -maxSwipeDistance
+      : maxSwipeDistance;
+    this._animateTo(-directionAwareMaxSwipeDistance);
   }
 
   _animateToOpenPositionWith(speed: number, distMoved: number): void {
@@ -287,26 +314,25 @@ class SwipeableRow extends React.Component<Props, State> {
       speed > HORIZONTAL_FULL_SWIPE_SPEED_THRESHOLD
         ? speed
         : HORIZONTAL_FULL_SWIPE_SPEED_THRESHOLD;
+    const maxSwipeDistance = this.props.maxSwipeDistance ?? 0;
     /**
      * Calculate the duration the row should take to swipe the remaining distance
      * at the same speed the user swiped (or the speed threshold)
      */
-    const duration = Math.abs(
-      (this.props.maxSwipeDistance - Math.abs(distMoved)) / speed,
-    );
-    const maxSwipeDistance = IS_RTL
-      ? -this.props.maxSwipeDistance
-      : this.props.maxSwipeDistance;
-    this._animateTo(-maxSwipeDistance, duration);
+    const duration = Math.abs((maxSwipeDistance - Math.abs(distMoved)) / speed);
+    const directionAwareMaxSwipeDistance = IS_RTL
+      ? -maxSwipeDistance
+      : maxSwipeDistance;
+    this._animateTo(-directionAwareMaxSwipeDistance, duration);
   }
 
   _animateToClosedPosition(duration: number = SWIPE_DURATION): void {
     this._animateTo(CLOSED_LEFT_POSITION, duration);
   }
 
-  _animateToClosedPositionDuringBounce(): void {
+  _animateToClosedPositionDuringBounce = (): void => {
     this._animateToClosedPosition(RIGHT_SWIPE_BOUNCE_BACK_DURATION);
-  }
+  };
 
   _animateBounceBack(duration: number): void {
     /**
@@ -341,36 +367,11 @@ class SwipeableRow extends React.Component<Props, State> {
      * If user has swiped past a certain distance, animate the rest of the way
      * if they let go
      */
+    const swipeThreshold = this.props.swipeThreshold ?? 0;
     return (
-      Math.abs(gestureState.dx) > this.props.swipeThreshold ||
+      Math.abs(gestureState.dx) > swipeThreshold ||
       gestureState.vx > HORIZONTAL_FULL_SWIPE_SPEED_THRESHOLD
     );
-  }
-
-  _handlePanResponderEnd(event: PressEvent, gestureState: GestureState): void {
-    const horizontalDistance = IS_RTL ? -gestureState.dx : gestureState.dx;
-    if (this._isSwipingRightFromClosed(gestureState)) {
-      this.props.onOpen && this.props.onOpen();
-      this._animateBounceBack(RIGHT_SWIPE_BOUNCE_BACK_DURATION);
-    } else if (this._shouldAnimateRemainder(gestureState)) {
-      if (horizontalDistance < 0) {
-        // Swiped left
-        this.props.onOpen && this.props.onOpen();
-        this._animateToOpenPositionWith(gestureState.vx, horizontalDistance);
-      } else {
-        // Swiped right
-        this.props.onClose && this.props.onClose();
-        this._animateToClosedPosition();
-      }
-    } else {
-      if (this._previousLeft === CLOSED_LEFT_POSITION) {
-        this._animateToClosedPosition();
-      } else {
-        this._animateToOpenPosition();
-      }
-    }
-
-    this.props.onSwipeEnd && this.props.onSwipeEnd();
   }
 }
 


### PR DESCRIPTION
Related to #21581

Remove createReactClass from SwipeableRow.

## Test Plan:
- All flow tests succeed.
-RNTester > SwipeableFlatList, scroll, swipe left, swipe right
-RNTester > SwipeableListView, scroll, swipe left, swipe right

## Release Notes:

[GENERAL] [ENHANCEMENT] [SwipeableRow.js] - rm createReactClass