### PR TITLE
[createReactClass] remove createReactClass from  ProgressViewIOS.ios.js

### DIFF
--- a/Libraries/Components/ProgressViewIOS/ProgressViewIOS.ios.js
+++ b/Libraries/Components/ProgressViewIOS/ProgressViewIOS.ios.js
@@ -13,7 +13,6 @@
 const React = require('React');
 const StyleSheet = require('StyleSheet');
 
-const createReactClass = require('create-react-class');
 const requireNativeComponent = require('requireNativeComponent');
 
 import type {NativeComponent} from 'ReactNative';


### PR DESCRIPTION
Related to #21581 .
Removed createReactClass from the Libraries/Components/ProgressViewIOS/ProgressViewIOS.ios.js

## Test Plan
- [x] npm run prettier
- [x] npm run flow-check-ios
- [x] npm run flow-check-android
## Release Notes
[GENERAL] [ENHANCEMENT] [Libraries/Components/ProgressViewIOS/ProgressViewIOS.ios.js] - remove createReactClass dependency