### PR TITLE
remove `useNativeDriver` for backgroundColor animation

### DIFF
--- a/RNTester/js/AnimatedGratuitousApp/AnExSet.js
+++ b/RNTester/js/AnimatedGratuitousApp/AnExSet.js
@@ -77,12 +77,10 @@ class AnExSet extends React.Component<Object, any> {
             inputRange: [0, 300], // and interpolate pixel distance
             outputRange: [1, 0], // to a fraction.
           }),
-          useNativeDriver: true,
         }).start();
       },
       onPanResponderMove: Animated.event(
         [null, {dy: this.state.dismissY}], // track pan gesture
-        {useNativeDriver: true},
       ),
       onPanResponderRelease: (e, gestureState) => {
         if (gestureState.dy > 100) {
@@ -90,7 +88,6 @@ class AnExSet extends React.Component<Object, any> {
         } else {
           Animated.spring(this.props.openVal, {
             toValue: 1, // animate back open if released early
-            useNativeDriver: true,
           }).start();
         }
       },


### PR DESCRIPTION
this PR try to resolve the Redbox: Style property 'backgroundColor' is not supported by native animated module when running rntester app.


Test Plan:
----------
- [x] All flow tests
- [x] RNTester app on iOS

Release Notes:
--------------

[RNTester] [BUGFIX] [RNTester/js/AnimatedGratuitousApp/AnExSet] - rm `useNativeDriver` in backgroundColor animation