### PR TITLE
Make google repo priority higher than jcenter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,9 +20,9 @@ buildscript {
 
 allprojects {
     repositories {
+        google()
         jcenter()
         mavenLocal()
-        google()
 
         def androidSdk = System.getenv("ANDROID_SDK")
         maven {

--- a/local-cli/templates/HelloWorld/android/build.gradle
+++ b/local-cli/templates/HelloWorld/android/build.gradle
@@ -22,13 +22,13 @@ buildscript {
 
 allprojects {
     repositories {
+        google()
         mavenLocal()
         jcenter()
         maven {
             // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
             url "$rootDir/../node_modules/react-native/android"
         }
-        google()
     }
 }
 


### PR DESCRIPTION
Fixes https://github.com/facebook/react-native/issues/21907#issuecomment-432319128 and prevent similar issues happening again
