### PR TITLE
Fix View/Text displayName

### DIFF
--- a/Libraries/Components/View/View.js
+++ b/Libraries/Components/View/View.js
@@ -49,6 +49,7 @@ if (__DEV__) {
     };
     // $FlowFixMe - TODO T29156721 `React.forwardRef` is not defined in Flow, yet.
     ViewToExport = React.forwardRef(View);
+    ViewToExport.displayName = 'View';
   }
 }
 

--- a/Libraries/Text/Text.js
+++ b/Libraries/Text/Text.js
@@ -277,6 +277,7 @@ const Text = (
 };
 // $FlowFixMe - TODO T29156721 `React.forwardRef` is not defined in Flow, yet.
 const TextToExport = React.forwardRef(Text);
+TextToExport.displayName = 'Text';
 
 // TODO: Deprecate this.
 TextToExport.propTypes = DeprecatedTextPropTypes;

--- a/Libraries/YellowBox/Data/__tests__/__snapshots__/YellowBoxCategory-test.js.snap
+++ b/Libraries/YellowBox/Data/__tests__/__snapshots__/YellowBoxCategory-test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`YellowBoxCategory renders a single substitution 1`] = `
 Array [
-  <Component
+  <Text
     style={
       Object {
         "fontWeight": "bold",
@@ -10,21 +10,21 @@ Array [
     }
   >
     "A"
-  </Component>,
+  </Text>,
 ]
 `;
 
 exports[`YellowBoxCategory renders content with no substitutions 1`] = `
 Array [
-  <Component>
+  <Text>
     A
-  </Component>,
+  </Text>,
 ]
 `;
 
 exports[`YellowBoxCategory renders multiple substitutions 1`] = `
 Array [
-  <Component
+  <Text
     style={
       Object {
         "fontWeight": "bold",
@@ -32,11 +32,11 @@ Array [
     }
   >
     "A"
-  </Component>,
-  <Component>
+  </Text>,
+  <Text>
      
-  </Component>,
-  <Component
+  </Text>,
+  <Text
     style={
       Object {
         "fontWeight": "bold",
@@ -44,11 +44,11 @@ Array [
     }
   >
     "B"
-  </Component>,
-  <Component>
+  </Text>,
+  <Text>
      
-  </Component>,
-  <Component
+  </Text>,
+  <Text
     style={
       Object {
         "fontWeight": "bold",
@@ -56,16 +56,16 @@ Array [
     }
   >
     "C"
-  </Component>,
+  </Text>,
 ]
 `;
 
 exports[`YellowBoxCategory renders substitutions with leading content 1`] = `
 Array [
-  <Component>
+  <Text>
     !
-  </Component>,
-  <Component
+  </Text>,
+  <Text
     style={
       Object {
         "fontWeight": "bold",
@@ -73,13 +73,13 @@ Array [
     }
   >
     "A"
-  </Component>,
+  </Text>,
 ]
 `;
 
 exports[`YellowBoxCategory renders substitutions with trailing content 1`] = `
 Array [
-  <Component
+  <Text
     style={
       Object {
         "fontWeight": "bold",
@@ -87,9 +87,9 @@ Array [
     }
   >
     "A"
-  </Component>,
-  <Component>
+  </Text>,
+  <Text>
     !
-  </Component>,
+  </Text>,
 ]
 `;


### PR DESCRIPTION
Adds the displayName prop to `View` and `Text` components. Because these now use `React.forwardRef`, they were showing as `Component` instead of their actual names.

Thanks to @ljharb for helping to pinpoint the source of the issue!

Fixes #21937 

Test Plan:
----------
Snapshot test for `YellowBoxCategory` should pass

Release Notes:
--------------
[GENERAL] [BUGFIX] [View] - Add displayName prop to `View` components
[GENERAL] [BUGFIX] [Text] - Add displayName prop to `Text` components

<!--
  **INTERNAL and MINOR tagged notes will not be included in the next version's final release notes.**

    CATEGORY
  [----------]      TYPE
  [ CLI      ] [-------------]    LOCATION
  [ DOCS     ] [ BREAKING    ] [-------------]
  [ GENERAL  ] [ BUGFIX      ] [ {Component} ]
  [ INTERNAL ] [ ENHANCEMENT ] [ {Filename}  ]
  [ IOS      ] [ FEATURE     ] [ {Directory} ]   |-----------|
  [ ANDROID  ] [ MINOR       ] [ {Framework} ] - | {Message} |
  [----------] [-------------] [-------------]   |-----------|

 EXAMPLES:

 [IOS] [BREAKING] [FlatList] - Change a thing that breaks other things
 [ANDROID] [BUGFIX] [TextInput] - Did a thing to TextInput
 [CLI] [FEATURE] [local-cli/info/info.js] - CLI easier to do things with
 [DOCS] [BUGFIX] [GettingStarted.md] - Accidentally a thing/word
 [GENERAL] [ENHANCEMENT] [Yoga] - Added new yoga thing/position
 [INTERNAL] [FEATURE] [./scripts] - Added thing to script that nobody will see
-->
