### PR TITLE
Fix relayout of inline views

### DIFF
--- a/Libraries/Text/VirtualText/RCTVirtualTextShadowView.m
+++ b/Libraries/Text/VirtualText/RCTVirtualTextShadowView.m
@@ -16,31 +16,6 @@
   BOOL _isLayoutDirty;
 }
 
-#pragma mark - Life Cycle
-
-- (void)insertReactSubview:(RCTShadowView *)subview atIndex:(NSInteger)index
-{
-  [super insertReactSubview:subview atIndex:index];
-
-  [self dirtyLayout];
-
-  if (![subview isKindOfClass:[RCTVirtualTextShadowView class]]) {
-    YGNodeSetDirtiedFunc(subview.yogaNode, RCTVirtualTextShadowViewYogaNodeDirtied);
-  }
-
-}
-
-- (void)removeReactSubview:(RCTShadowView *)subview
-{
-  if (![subview isKindOfClass:[RCTVirtualTextShadowView class]]) {
-    YGNodeSetDirtiedFunc(subview.yogaNode, NULL);
-  }
-
-  [self dirtyLayout];
-
-  [super removeReactSubview:subview];
-}
-
 #pragma mark - Layout
 
 - (void)dirtyLayout
@@ -58,16 +33,6 @@
 - (void)clearLayout
 {
   _isLayoutDirty = NO;
-}
-
-static void RCTVirtualTextShadowViewYogaNodeDirtied(YGNodeRef node)
-{
-  RCTShadowView *shadowView = (__bridge RCTShadowView *)YGNodeGetContext(node);
-
-  RCTVirtualTextShadowView *virtualTextShadowView =
-    (RCTVirtualTextShadowView *)shadowView.reactSuperview;
-
-  [virtualTextShadowView dirtyLayout];
 }
 
 @end


### PR DESCRIPTION
If a view inside of an inline view became dirty (e.g. its top/left prop changed), its position would not update on screen. This is because Yoga didn't know the view needed to be relaid out because Yoga's dirty signal didn't propagate all the way up to the root.

The problem is that inline views don't have a parent in the Yoga tree causing Yoga's dirtiness signal propagation to get cut off early. The fix is, when an inline views gets dirty, mark the parent Text's Yoga node as dirty. This will cause Yoga's dirtiness signal to propagate all the way up to the root node.

Yoga has a hook to inform you when your node is marked as dirty: `YGNodeSetDirtiedFunc`. We leverage this to find out when an inline view's Yoga node gets dirtied.

React Native almost handled this case. Everything worked fine as long as the inline view was nested inside of a virtual text node like this:

```
<Text>
  <Text>
    <InlineView />
  </Text>
</Text>
```

However, the bug repros when the inline view is nested in a non-virtual text node:

```
<Text>
  <InlineView />
</Text>
```

The fix is to move the special dirtiness propagation logic from `RCTVirtualTextShadowView` to `RCTBaseTextShadowView`.

**Test Plan**

Created an inline view. Tested the following kinds of updates on the inline view's content:
  - Moved the content
  - Removed the content
  - Added the content

Tested this for an inline view that is directly inside of a text node as well as one that is nested under a virtual text node.

Here's the code I used for the inline view that moved its content after 2 seconds:

```
const RN = require('react-native');
const React = require('react');

export default class InlineView extends React.Component {
  constructor(props, context) {
    super(props, context);
    this.state = { posBottom: false };
  }

  componentDidMount() {
    super.componentDidMount && super.componentDidMount();
    setTimeout(() => { this.setState({ posBottom: true }); }, 2000);
  }

  render() {
    const pos = this.state.posBottom ? 25 : 0;
    const color = this.state.posBottom ? 'pink' : 'green';
    return (
      <RN.View style={{ width: 50, height: 50, backgroundColor: 'steelblue'}}>
        <RN.View style={{ width: 25, height: 25, top: pos, left: pos, backgroundColor: color }} />
      </RN.View>
    );
  }
}
```

Adam Comella
Microsoft Corp.