### PR TITLE
fix(image): return dest target rect if source zero

### DIFF
--- a/Libraries/Image/RCTImageUtils.m
+++ b/Libraries/Image/RCTImageUtils.m
@@ -55,6 +55,9 @@ CGRect RCTTargetRect(CGSize sourceSize, CGSize destSize,
   if (CGSizeEqualToSize(destSize, CGSizeZero)) {
     // Assume we require the largest size available
     return (CGRect){CGPointZero, sourceSize};
+  } else if (CGSizeEqualToSize(sourceSize, CGSizeZero)) {
+    // Assume we require the destination size
+    return (CGRect){CGPointZero, destSize};
   }
 
   CGFloat aspect = sourceSize.width / sourceSize.height;


### PR DESCRIPTION
If the provided source size if `{0. 0}` we cannot calculate the aspect ratio due to a divide by zero error. If the provided source size is zeroed, and the destination size is non-zero we can assume we want the destination size.
