### PR TITLE
Add specific exception for rendering raw text outside of <Text>

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactShadowNodeImpl.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactShadowNodeImpl.java
@@ -13,6 +13,7 @@ import com.facebook.debug.tags.ReactDebugOverlayTags;
 import com.facebook.infer.annotation.Assertions;
 import com.facebook.react.common.build.ReactBuildConfig;
 import com.facebook.react.uimanager.annotations.ReactPropertyHolder;
+import com.facebook.react.views.text.ReactRawTextShadowNode;
 import com.facebook.yoga.YogaAlign;
 import com.facebook.yoga.YogaBaselineFunction;
 import com.facebook.yoga.YogaConfig;
@@ -226,13 +227,21 @@ public class ReactShadowNodeImpl implements ReactShadowNode<ReactShadowNodeImpl>
     if (mYogaNode != null && !isYogaLeafNode()) {
       YogaNode childYogaNode = child.mYogaNode;
       if (childYogaNode == null) {
-        throw new RuntimeException(
-            "Cannot add a child that doesn't have a YogaNode to a parent without a measure "
-                + "function! (Trying to add a '"
-                + child.toString()
-                + "' to a '"
-                + toString()
-                + "')");
+
+        if (child instanceof ReactRawTextShadowNode) {
+          throw new RuntimeException(
+              "Raw text cannot be used outside of a <Text> tag. Not rendering string: '"
+                  + ((ReactRawTextShadowNode) child).getText()
+                  + "'");
+        } else {
+          throw new RuntimeException(
+              "Cannot add a child that doesn't have a YogaNode to a parent without a measure "
+                  + "function! (Trying to add a '"
+                  + child.toString()
+                  + "' to a '"
+                  + toString()
+                  + "')");
+        }
       }
       mYogaNode.addChildAt(childYogaNode, i);
     }


### PR DESCRIPTION
This matched the iOS implementation and is a more explicit exception for the most common case.


Release Notes:
--------------

[ANDROID] [ENHANCEMENT] [ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactShadowNodeImpl.java] - Add specific exception for rendering raw text outside of `<Text>`

Currently when trying to render raw text outside of a <Text> tag, the iOS message is explicit about what the error is whilst the Android error is too abstract to be useful. This PR makes the Android error message identical to the iOS one.

Image of current exceptions side by side:
![screen shot 2018-10-29 at 12 54 42](https://user-images.githubusercontent.com/8819594/47645911-f94f0a80-db7a-11e8-88f5-2351487987c2.png)
