### PR TITLE
Fixes animated gifs incorrectly looping/not stopping on last frame

### DIFF
--- a/Libraries/Image/RCTGIFImageDecoder.m
+++ b/Libraries/Image/RCTGIFImageDecoder.m
@@ -32,8 +32,18 @@ RCT_EXPORT_MODULE()
 {
   CGImageSourceRef imageSource = CGImageSourceCreateWithData((CFDataRef)imageData, NULL);
   NSDictionary<NSString *, id> *properties = (__bridge_transfer NSDictionary *)CGImageSourceCopyProperties(imageSource, NULL);
-  NSUInteger loopCount = [properties[(id)kCGImagePropertyGIFDictionary][(id)kCGImagePropertyGIFLoopCount] unsignedIntegerValue];
-
+  NSUInteger loopCount = 0;
+  if ([[properties[(id)kCGImagePropertyGIFDictionary] allKeys] containsObject:(id)kCGImagePropertyGIFLoopCount]) {
+    loopCount = [properties[(id)kCGImagePropertyGIFDictionary][(id)kCGImagePropertyGIFLoopCount] unsignedIntegerValue];
+    if (loopCount == 0) {
+      // A loop count of 0 means infinite
+      loopCount = HUGE_VALF;
+    } else {
+      // A loop count of 1 means it should repeat twice, 2 means, thrice, etc.
+      loopCount += 1;
+    }
+  }
+  
   UIImage *image = nil;
   size_t imageCount = CGImageSourceGetCount(imageSource);
   if (imageCount > 1) {
@@ -84,11 +94,12 @@ RCT_EXPORT_MODULE()
     // Create animation
     CAKeyframeAnimation *animation = [CAKeyframeAnimation animationWithKeyPath:@"contents"];
     animation.calculationMode = kCAAnimationDiscrete;
-    animation.repeatCount = loopCount == 0 ? HUGE_VALF : loopCount;
+    animation.repeatCount = loopCount;
     animation.keyTimes = keyTimes;
     animation.values = images;
     animation.duration = duration;
     animation.removedOnCompletion = NO;
+    animation.fillMode = kCAFillModeForwards;
     image.reactKeyframeAnimation = animation;
 
   } else {


### PR DESCRIPTION
Currently, if you load an animated gif using the standard `Image` component, it will not correctly respect the loop count property found in the Netscape App Extension block of the file. The issues are as follows:

1) If the App Extension isn't present, the animated gif loops indefinitely when it should not loop at all.
2) If the App Extension is present, the animated gif loops one less time than it should.

The other issue is that once the looping completes, the image doesn't pause at the last frame but instead, loops back to the beginning of the animation e.g. frame 1.

The fix does a few things:

1) If there is _no_ App Extension present, the image doesn't loop at all
2) If there _is_ an App Extension present, it loops the correct amount of times. For instance, if the loop count is 1, it means the gif should loop _once_ after it finishes playing, for a total of _two_ total loops.
3) Once the number of loops completes (assuming loop count isn't set to 0 which means infinite), the animation pauses on the last frame.

Test Plan:
----------

The easiest way to verify this works is to take the attached images which are labeled with how many times an image should loop. The number of times the lips in the image come to the foreground of the animation should match how many loops the animation is set to play.

You can verify the behavior for animated gifs now matches most other animated gif implementations like the one found in Chrome.

![giphy-no-loop-no-app-extension](https://user-images.githubusercontent.com/475235/47662060-76688880-db57-11e8-9851-182b75ff23c0.gif)
No loop

![giphy-loop-once](https://user-images.githubusercontent.com/475235/47662063-7799b580-db57-11e8-989b-41ff2040d8bf.gif)
Loop once

![giphy-loop-twice](https://user-images.githubusercontent.com/475235/47662061-77011f00-db57-11e8-904f-a1824912ace9.gif)
Loop twice

![giphy-loop-thrice](https://user-images.githubusercontent.com/475235/47662062-77011f00-db57-11e8-89a7-5176a03fa736.gif)
Loop thrice

![giphy-forever](https://user-images.githubusercontent.com/475235/47662064-7799b580-db57-11e8-934a-3cc2f2043c7b.gif)
Loop forever

Release Notes:
--------------

 [IOS] [BUGFIX] [Image] - Fixes an issue where animated gifs weren't looping correctly
 [IOS] [BUGFIX] [Image] - Fixes an issue where animated gifs weren't stopping at the last frame
