### PR TITLE
fix(image): compare incoming image size

### DIFF
--- a/Libraries/Image/RCTImageView.m
+++ b/Libraries/Image/RCTImageView.m
@@ -413,7 +413,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
     }
 
     // Don't reload if the current image size is the maximum size of the image source
-    CGSize imageSourceSize = _imageSource.size;
+    CGSize imageSourceSize = (_imageSource ? _imageSource : _pendingImageSource).size;
     if (imageSize.width * imageScale == imageSourceSize.width * _imageSource.scale &&
         imageSize.height * imageScale == imageSourceSize.height * _imageSource.scale) {
       return;


### PR DESCRIPTION
If a frame calculation occurs when a image is pending then it can fail to reload the image when the image size and pending size are out of whack. This results in a situation where the image is scaled for no reason and ends up all blurry.

