### PR TITLE
Set encoding to UTF-8 in Android. Fixes #4873

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebViewManager.java
@@ -89,7 +89,7 @@ public class ReactWebViewManager extends SimpleViewManager<WebView> {
   protected static final String REACT_CLASS = "RCTWebView";
 
   protected static final String HTML_ENCODING = "UTF-8";
-  protected static final String HTML_MIME_TYPE = "text/html";
+  protected static final String HTML_MIME_TYPE = "text/html; charset=utf-8";
   protected static final String BRIDGE_NAME = "__REACT_WEB_VIEW_BRIDGE";
 
   protected static final String HTTP_METHOD_POST = "POST";


### PR DESCRIPTION
Test Plan:
----------
1. Load the HTML below into a webview on Android:
```
let html = `<html lang="fr">
<head>
</head>
<body>
commandité
</body>`;

<WebView
        originWhitelist={['*']}
        source={{ html: html }}
      />```

2. The French "e" should have the proper accent.

Release Notes:
--------------
[Android][BUGFIX][WebView] - Set encoding to UTF-8 in Android. Fixes #4873