### PR TITLE
Remove var in Libraries/Component

### DIFF
--- a/Libraries/Components/RefreshControl/RefreshControl.js
+++ b/Libraries/Components/RefreshControl/RefreshControl.js
@@ -20,15 +20,16 @@ const nullthrows = require('nullthrows');
 import type {ColorValue} from 'StyleSheetTypes';
 import type {ViewProps} from 'ViewPropTypes';
 
+let RefreshLayoutConsts;
 if (Platform.OS === 'android') {
   const AndroidSwipeRefreshLayout = require('UIManager').getViewManagerConfig(
     'AndroidSwipeRefreshLayout',
   );
-  var RefreshLayoutConsts = AndroidSwipeRefreshLayout
+  RefreshLayoutConsts = AndroidSwipeRefreshLayout
     ? AndroidSwipeRefreshLayout.Constants
     : {SIZE: {}};
 } else {
-  var RefreshLayoutConsts = {SIZE: {}};
+  RefreshLayoutConsts = {SIZE: {}};
 }
 type NativeRefreshControlType = Class<NativeComponent<RefreshControlProps>>;
 

--- a/Libraries/Components/TabBarIOS/TabBarItemIOS.ios.js
+++ b/Libraries/Components/TabBarIOS/TabBarItemIOS.ios.js
@@ -132,20 +132,21 @@ class TabBarItemIOS extends React.Component<Props, State> {
       showedDeprecationWarning = true;
     }
   }
-  
+
   render() {
     const {style, children, ...props} = this.props;
 
     // if the tab has already been shown once, always continue to show it so we
     // preserve state between tab transitions
+    let tabContents;
     if (this.state.hasBeenSelected) {
-      var tabContents = (
+      tabContents = (
         <StaticContainer shouldUpdate={this.props.selected}>
           {children}
         </StaticContainer>
       );
     } else {
-      var tabContents = <View />;
+      tabContents = <View />;
     }
 
     return (


### PR DESCRIPTION
I removed `var` in Libraries/Component.

# Test Plan
- [x] npm run prettier
- [x] npm run flow-check-ios
- [x] npm run flow-check-android

# Release Notes
[GENERAL] [ENHANCEMENT] [Libraries/Component] - remove `var`