### PR TITLE
gradle repo priority

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,9 +5,9 @@
 
 buildscript {
     repositories {
-        jcenter()
         mavenLocal()
         google()
+        jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.1.4'
@@ -20,9 +20,9 @@ buildscript {
 
 allprojects {
     repositories {
+        mavenLocal()
         google()
         jcenter()
-        mavenLocal()
 
         def androidSdk = System.getenv("ANDROID_SDK")
         maven {

--- a/local-cli/templates/HelloWorld/android/build.gradle
+++ b/local-cli/templates/HelloWorld/android/build.gradle
@@ -9,8 +9,8 @@ buildscript {
         supportLibVersion = "27.1.1"
     }
     repositories {
-        jcenter()
         google()
+        jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.1.4'
@@ -22,8 +22,8 @@ buildscript {
 
 allprojects {
     repositories {
-        google()
         mavenLocal()
+        google()
         jcenter()
         maven {
             // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm


### PR DESCRIPTION
Changed gradle repo list to have consistent priority. mavenLocal is top priority because it requires manual setup, also won't conflict with other repos.

Test Plan:
----------
CI is green