### PR TITLE
Remove undefined value on init cli command

### DIFF
--- a/local-cli/cliEntry.js
+++ b/local-cli/cliEntry.js
@@ -60,7 +60,7 @@ function printHelpInformation() {
   let output = [
     '',
     chalk.bold(chalk.cyan(`  react-native ${cmdName} ${this.usage()}`)),
-    `  ${this._description}`,
+    this._description ? `  ${this._description}` : '',
     '',
     ...sourceInformation,
     `  ${chalk.bold('Options:')}`,


### PR DESCRIPTION
Fixes `undefined` description message when running `react-native init --help` on an existing React Native project.

Test Plan:
----------
Run the cli from `react-native` repo:
```
> cd react-native
> yarn
> node local-cli/cli.js init --help
```
And see that the description no longer says `undefined`

Release Notes:
--------------
[CLI][BUGFIX][local-cli/cliEntry.js] - Fix undefined description message when running `init` cli command help.
