### PR TITLE
Fix Promise polyfill flow type

### DIFF
--- a/Libraries/Components/AccessibilityInfo/AccessibilityInfo.ios.js
+++ b/Libraries/Components/AccessibilityInfo/AccessibilityInfo.ios.js
@@ -44,7 +44,7 @@ const AccessibilityInfo = {
    *
    * See http://facebook.github.io/react-native/docs/accessibilityinfo.html#fetch
    */
-  fetch: function(): Promise {
+  fetch: function(): Promise<boolean> {
     return new Promise((resolve, reject) => {
       AccessibilityManager.getCurrentVoiceOverState(resolve, reject);
     });

--- a/flow/Promise.js
+++ b/flow/Promise.js
@@ -45,3 +45,7 @@ declare class Promise<+R> {
 
   static cast<T>(object?: T): Promise<T>;
 }
+
+declare module 'Promise' {
+  declare module.exports: typeof Promise;
+}


### PR DESCRIPTION
This pull request adds a `declare module 'Promise'` entry to `flow/Promise.js`. Previously, it seemed that the type of the `Promise` module was `any`.

This fixes a flow error that shows up for me and some other people:

```
Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ Libraries/Core/polyfillPromise.js:21:33

Importing from an untyped module makes it any and is not safe! Did you mean to add // @flow to the top of Promise?
(untyped-import)

     18│  * If you don't need these polyfills, don't use InitializeCore; just directly
     19│  * require the modules you need from InitializeCore for setup.
     20│  */
     21│ polyfillGlobal('Promise', () => require('Promise'));
     22│

```

An improper use of `Promise<T>` in `AccessibilityInfo.ios.js` that was revealed after I did this is now also fixed.

Test Plan:
----------
`yarn flow-check-ios` and `yarn flow-check-android` have been ran and both pass.

Release Notes:
--------------

[GENERAL] [MINOR] [Libraries/Components/AccessibilityInfo/AccessibilityInfo.ios.js] - Fixed a type annotation
[GENERAL] [MINOR] [flow/Promise.js] - Added a `declare module` entry
