### PR TITLE
Add asyncToGenerator to the babelHelper

### DIFF
--- a/Libraries/polyfills/babelHelpers.js
+++ b/Libraries/polyfills/babelHelpers.js
@@ -604,3 +604,36 @@ function _iterableToArray(iter) {
 }
 
 babelHelpers.iterableToArray = _iterableToArray;
+
+// ### asyncToGenerator ###
+
+function _asyncToGenerator(fn) {
+  return function () {
+    var gen = fn.apply(this, arguments);
+    return new Promise(function (resolve, reject) {
+      function step(key, arg) {
+        try {
+          var info = gen[key](arg);
+          var value = info.value;
+        } catch (error) {
+          reject(error);
+          return;
+        }
+
+        if (info.done) {
+          resolve(value);
+        } else {
+          return Promise.resolve(value).then(function (value) {
+            step('next', value);
+          }, function (err) {
+            step('throw', err);
+          });
+        }
+      }
+
+      return step('next');
+    });
+  };
+};
+
+babelHelpers.asyncToGenerator = _asyncToGenerator;

--- a/Libraries/polyfills/babelHelpers.js
+++ b/Libraries/polyfills/babelHelpers.js
@@ -608,9 +608,9 @@ babelHelpers.iterableToArray = _iterableToArray;
 // ### asyncToGenerator ###
 
 function _asyncToGenerator(fn) {
-  return function () {
+  return function() {
     var gen = fn.apply(this, arguments);
-    return new Promise(function (resolve, reject) {
+    return new Promise(function(resolve, reject) {
       function step(key, arg) {
         try {
           var info = gen[key](arg);
@@ -623,17 +623,20 @@ function _asyncToGenerator(fn) {
         if (info.done) {
           resolve(value);
         } else {
-          return Promise.resolve(value).then(function (value) {
-            step('next', value);
-          }, function (err) {
-            step('throw', err);
-          });
+          return Promise.resolve(value).then(
+            function(value) {
+              step('next', value);
+            },
+            function(err) {
+              step('throw', err);
+            },
+          );
         }
       }
 
       return step('next');
     });
   };
-};
+}
 
 babelHelpers.asyncToGenerator = _asyncToGenerator;

--- a/Libraries/polyfills/babelHelpers.js
+++ b/Libraries/polyfills/babelHelpers.js
@@ -624,8 +624,8 @@ function _asyncToGenerator(fn) {
           resolve(value);
         } else {
           return Promise.resolve(value).then(
-            function(value) {
-              step('next', value);
+            function(val) {
+              step('next', val);
             },
             function(err) {
               step('throw', err);


### PR DESCRIPTION
This is an existing problem which is discussed in this [issue](https://github.com/facebook/react-native/issues/16333#issuecomment-350425444)

Release Notes:
--------------
Help reviewers and the release process by writing your own release notes. See below for an example.

[GENERAL] [ENHANCEMENT] [Polyfills] - Add asyncToGenerator to the babelHelper

<!--
  **INTERNAL and MINOR tagged notes will not be included in the next version's final release notes.**

    CATEGORY
  [----------]      TYPE
  [ CLI      ] [-------------]    LOCATION
  [ DOCS     ] [ BREAKING    ] [-------------]
  [ GENERAL  ] [ BUGFIX      ] [ {Component} ]
  [ INTERNAL ] [ ENHANCEMENT ] [ {Filename}  ]
  [ IOS      ] [ FEATURE     ] [ {Directory} ]   |-----------|
  [ ANDROID  ] [ MINOR       ] [ {Framework} ] - | {Message} |
  [----------] [-------------] [-------------]   |-----------|

 EXAMPLES:

 [IOS] [BREAKING] [FlatList] - Change a thing that breaks other things
 [ANDROID] [BUGFIX] [TextInput] - Did a thing to TextInput
 [CLI] [FEATURE] [local-cli/info/info.js] - CLI easier to do things with
 [DOCS] [BUGFIX] [GettingStarted.md] - Accidentally a thing/word
 [GENERAL] [ENHANCEMENT] [Yoga] - Added new yoga thing/position
 [INTERNAL] [FEATURE] [./scripts] - Added thing to script that nobody will see
-->
