### PR TITLE
set blob as default XMLHttpRequest header response type if supported

### DIFF
--- a/Libraries/vendor/core/whatwg-fetch.js
+++ b/Libraries/vendor/core/whatwg-fetch.js
@@ -516,6 +516,10 @@
         xhr.withCredentials = false;
       }
 
+      if ('responseType' in xhr && support.blob) {
+        xhr.responseType = 'blob'
+      }
+
       request.headers.forEach(function(value, name) {
         xhr.setRequestHeader(name, value);
       });


### PR DESCRIPTION
This is a problem that is discussed in issue #21092 

Related issues: #21851 #19717

Found the code to eventually fix this issue [here](https://github.com/github/fetch/blob/899b155746630c32d83ee29a38642da16b314ecb/fetch.js#L486)

### Test Plan

- [x] Fetching an image locally and check if the blob is there, as well as its size > 0.

### Release Notes:
___
Help reviewers and the release process by writing your own release notes. See below for an example.

[GENERAL] [ENHANCEMENT] [whatwg-fetch] - set blob as default XMLHttpRequest header response type if supported