### PR TITLE
Modified declarations from vars to const

### DIFF
--- a/Libraries/Lists/ListView/ListViewDataSource.js
+++ b/Libraries/Lists/ListView/ListViewDataSource.js
@@ -62,7 +62,7 @@ type ParamType = {
  *
  * ```
  * getInitialState: function() {
- *   var ds = new ListView.DataSource({rowHasChanged: this._rowHasChanged});
+ *   const ds = new ListView.DataSource({rowHasChanged: this._rowHasChanged});
  *   return {ds};
  * },
  * _onDataArrived(newData) {
@@ -356,7 +356,7 @@ class ListViewDataSource {
     const prevSectionsHash = keyedDictionaryFromArray(prevSectionIDs);
     const prevRowsHash = {};
     for (let ii = 0; ii < prevRowIDs.length; ii++) {
-      var sectionID = prevSectionIDs[ii];
+      const sectionID = prevSectionIDs[ii];
       warning(
         !prevRowsHash[sectionID],
         'SectionID appears more than once: ' + sectionID,
@@ -370,7 +370,7 @@ class ListViewDataSource {
 
     let dirty;
     for (let sIndex = 0; sIndex < this.sectionIdentities.length; sIndex++) {
-      var sectionID = this.sectionIdentities[sIndex];
+      const sectionID = this.sectionIdentities[sIndex];
       // dirty if the sectionHeader is new or _sectionHasChanged is true
       dirty = !prevSectionsHash[sectionID];
       const sectionHeaderHasChanged = this._sectionHeaderHasChanged;


### PR DESCRIPTION
Replaces the keywords `var` with `const` in `Libraries/Lists/ListView/ListViewDataSource.js`

Test Plan:
----------
- [x] Check `npm run flow`
- [x] Check `npm run flow-check-ios`
- [x] Check `npm run flow-check-android`

Release Notes:
--------------
Help reviewers and the release process by writing your own release notes. See below for an example.

[GENERAL] [INTERNAL] [Libraries/Lists/ListView/ListViewDataSource.js] - Changed declarations from var to const in ListViewDataSource.js 