### PR TITLE
Improving Modal `visible` prop check to handle undefined and null

### DIFF
--- a/Libraries/Modal/Modal.js
+++ b/Libraries/Modal/Modal.js
@@ -217,7 +217,7 @@ class Modal extends React.Component<Props> {
   }
 
   render(): React.Node {
-    if (!!this.props.visible === false) {
+    if (this.props.visible !== true) {
       return null;
     }
 

--- a/Libraries/Modal/Modal.js
+++ b/Libraries/Modal/Modal.js
@@ -217,7 +217,7 @@ class Modal extends React.Component<Props> {
   }
 
   render(): React.Node {
-    if (this.props.visible === false) {
+    if (!!this.props.visible === false) {
       return null;
     }
 


### PR DESCRIPTION
Changing the the this.props.visible if to be ` if (!!this.props.visible === false)` . So passing undefined, or other values wont set the modal to be visible. Granting that anything that is not true, will set the modal to null on the render.

I make this this PR, because on the company that im working, we used a lot of RN. At the moment, we arent using anything like flow or TS. But to grant that the modals will only show if they are set visible to true i have changed the if made.

_Pull requests that expand test coverage are more likely to get reviewed. Add a test case whenever possible!_

Test Plan:
----------
Just initiate any project, and import the Modal from RN. The try pass undefined, or any value different from a boolean. The expected behaviour was to only show the modal if you pass true.

Before
` if (this.props.visible === false)`

After
` if (this.props.visible !== true)`

Release Notes:
--------------

[GENERAL] [MINOR] [Libraries/Modal/Modal.js] - Adjusting the verification to set the modal to visible on the render. Ensuring that the modal will only show if true is passed to it.

<!--
  **INTERNAL and MINOR tagged notes will not be included in the next version's final release notes.**

    CATEGORY
  [ BUGFIX ] [ Modal ]

 EXAMPLES:

 [IOS][ANDROID] [BUGFIX] [Modal] - Change the verification to show the modal.
-->


