### PR TITLE
Fix linting for examples

### DIFF
--- a/IntegrationTests/AsyncStorageTest.js
+++ b/IntegrationTests/AsyncStorageTest.js
@@ -10,6 +10,8 @@
 
 'use strict';
 
+/* eslint-disable react-native/no-inline-styles */
+
 const React = require('react');
 const ReactNative = require('react-native');
 const {AsyncStorage, Text, View} = ReactNative;

--- a/IntegrationTests/ImageCachePolicyTest.js
+++ b/IntegrationTests/ImageCachePolicyTest.js
@@ -10,6 +10,8 @@
 
 'use strict';
 
+/* eslint-disable react-native/no-inline-styles */
+
 const React = require('react');
 const ReactNative = require('react-native');
 const {Image, View, Text, StyleSheet} = ReactNative;

--- a/IntegrationTests/IntegrationTestHarnessTest.js
+++ b/IntegrationTests/IntegrationTestHarnessTest.js
@@ -10,6 +10,8 @@
 
 'use strict';
 
+/* eslint-disable react-native/no-inline-styles */
+
 const requestAnimationFrame = require('fbjs/lib/requestAnimationFrame');
 const React = require('react');
 const ReactNative = require('react-native');

--- a/IntegrationTests/SimpleSnapshotTest.js
+++ b/IntegrationTests/SimpleSnapshotTest.js
@@ -10,6 +10,8 @@
 
 'use strict';
 
+/* eslint-disable react-native/no-inline-styles */
+
 const React = require('react');
 const ReactNative = require('react-native');
 /* $FlowFixMe(>=0.54.0 site=react_native_oss) This comment suppresses an error

--- a/Libraries/Components/Touchable/Touchable.js
+++ b/Libraries/Components/Touchable/Touchable.js
@@ -9,6 +9,8 @@
 
 'use strict';
 
+/* eslint-disable react-native/no-inline-styles */
+
 const BoundingDimensions = require('BoundingDimensions');
 const Platform = require('Platform');
 const Position = require('Position');

--- a/Libraries/Experimental/WindowedListView.js
+++ b/Libraries/Experimental/WindowedListView.js
@@ -10,6 +10,8 @@
 
 'use strict';
 
+/* eslint-disable react-native/no-inline-styles */
+
 const Batchinator = require('Batchinator');
 const IncrementalGroup = require('IncrementalGroup');
 const React = require('React');

--- a/Libraries/Lists/VirtualizedList.js
+++ b/Libraries/Lists/VirtualizedList.js
@@ -7,7 +7,10 @@
  * @flow
  * @format
  */
+
 'use strict';
+
+/* eslint-disable react-native/no-inline-styles */
 
 const Batchinator = require('Batchinator');
 const FillRateHelper = require('FillRateHelper');

--- a/RNTester/js/AccessibilityAndroidExample.android.js
+++ b/RNTester/js/AccessibilityAndroidExample.android.js
@@ -9,6 +9,8 @@
 
 'use strict';
 
+/* eslint-disable react-native/no-inline-styles */
+
 const React = require('react');
 const ReactNative = require('react-native');
 const {

--- a/RNTester/js/ActivityIndicatorExample.js
+++ b/RNTester/js/ActivityIndicatorExample.js
@@ -10,6 +10,8 @@
 
 'use strict';
 
+/* eslint-disable react-native/no-inline-styles */
+
 import React, {Component} from 'react';
 import {ActivityIndicator, StyleSheet, View} from 'react-native';
 

--- a/RNTester/js/AlertIOSExample.js
+++ b/RNTester/js/AlertIOSExample.js
@@ -10,6 +10,8 @@
 
 'use strict';
 
+/* eslint-disable react-native/no-inline-styles */
+
 const React = require('react');
 const ReactNative = require('react-native');
 const {StyleSheet, View, Text, TouchableHighlight, AlertIOS} = ReactNative;

--- a/RNTester/js/AnimatedExample.js
+++ b/RNTester/js/AnimatedExample.js
@@ -10,6 +10,8 @@
 
 'use strict';
 
+/* eslint-disable react-native/no-inline-styles */
+
 const React = require('react');
 const ReactNative = require('react-native');
 const {Animated, Easing, StyleSheet, Text, View} = ReactNative;

--- a/RNTester/js/AnimatedGratuitousApp/AnExScroll.js
+++ b/RNTester/js/AnimatedGratuitousApp/AnExScroll.js
@@ -10,6 +10,8 @@
 
 'use strict';
 
+/* eslint-disable react-native/no-inline-styles */
+
 const React = require('react');
 const ReactNative = require('react-native');
 const {Animated, Image, ScrollView, StyleSheet, Text, View} = ReactNative;

--- a/RNTester/js/AnimatedGratuitousApp/AnExTilt.js
+++ b/RNTester/js/AnimatedGratuitousApp/AnExTilt.js
@@ -10,6 +10,8 @@
 
 'use strict';
 
+/* eslint-disable react-native/no-inline-styles */
+
 const React = require('react');
 const ReactNative = require('react-native');
 const {Animated, PanResponder, StyleSheet} = ReactNative;

--- a/RNTester/js/BorderExample.js
+++ b/RNTester/js/BorderExample.js
@@ -9,6 +9,8 @@
 
 'use strict';
 
+/* eslint-disable react-native/no-inline-styles */
+
 const React = require('react');
 const ReactNative = require('react-native');
 const {StyleSheet, View} = ReactNative;

--- a/RNTester/js/BoxShadowExample.js
+++ b/RNTester/js/BoxShadowExample.js
@@ -9,6 +9,8 @@
 
 'use strict';
 
+/* eslint-disable react-native/no-inline-styles */
+
 const React = require('react');
 const ReactNative = require('react-native');
 const {Image, StyleSheet, View} = ReactNative;

--- a/RNTester/js/ButtonExample.js
+++ b/RNTester/js/ButtonExample.js
@@ -10,6 +10,8 @@
 
 'use strict';
 
+/* eslint-disable react-native/no-inline-styles */
+
 const React = require('react');
 const ReactNative = require('react-native');
 const {Alert, Button, View} = ReactNative;

--- a/RNTester/js/CheckBoxExample.js
+++ b/RNTester/js/CheckBoxExample.js
@@ -7,7 +7,10 @@
  * @flow
  * @format
  */
+
 'use strict';
+
+/* eslint-disable react-native/no-inline-styles */
 
 const React = require('react');
 const ReactNative = require('react-native');

--- a/RNTester/js/ClipboardExample.js
+++ b/RNTester/js/ClipboardExample.js
@@ -10,6 +10,8 @@
 
 'use strict';
 
+/* eslint-disable react-native/no-inline-styles */
+
 const React = require('react');
 const ReactNative = require('react-native');
 const {Clipboard, View, Text} = ReactNative;

--- a/RNTester/js/ImageCapInsetsExample.js
+++ b/RNTester/js/ImageCapInsetsExample.js
@@ -10,6 +10,8 @@
 
 'use strict';
 
+/* eslint-disable react-native/no-inline-styles */
+
 const React = require('react');
 const ReactNative = require('react-native');
 

--- a/RNTester/js/ImageExample.js
+++ b/RNTester/js/ImageExample.js
@@ -10,6 +10,8 @@
 
 'use strict';
 
+/* eslint-disable react-native/no-inline-styles */
+
 const React = require('react');
 const ReactNative = require('react-native');
 const {

--- a/RNTester/js/LayoutExample.js
+++ b/RNTester/js/LayoutExample.js
@@ -10,6 +10,8 @@
 
 'use strict';
 
+/* eslint-disable react-native/no-inline-styles */
+
 const React = require('react');
 const ReactNative = require('react-native');
 const {StyleSheet, Text, View} = ReactNative;

--- a/RNTester/js/ListViewExample.js
+++ b/RNTester/js/ListViewExample.js
@@ -10,6 +10,8 @@
 
 'use strict';
 
+/* eslint-disable react-native/no-inline-styles */
+
 const React = require('react');
 const ReactNative = require('react-native');
 const {

--- a/RNTester/js/MaskedViewExample.js
+++ b/RNTester/js/MaskedViewExample.js
@@ -10,6 +10,8 @@
 
 'use strict';
 
+/* eslint-disable react-native/no-inline-styles */
+
 const React = require('react');
 const RNTesterBlock = require('RNTesterBlock');
 const RNTesterPage = require('RNTesterPage');

--- a/RNTester/js/NativeAnimationsExample.js
+++ b/RNTester/js/NativeAnimationsExample.js
@@ -10,6 +10,8 @@
 
 'use strict';
 
+/* eslint-disable react-native/no-inline-styles */
+
 const React = require('react');
 const ReactNative = require('react-native');
 const {

--- a/RNTester/js/PickerExample.js
+++ b/RNTester/js/PickerExample.js
@@ -10,6 +10,8 @@
 
 'use strict';
 
+/* eslint-disable react-native/no-inline-styles */
+
 const React = require('react');
 const ReactNative = require('react-native');
 const StyleSheet = require('StyleSheet');

--- a/RNTester/js/PickerIOSExample.js
+++ b/RNTester/js/PickerIOSExample.js
@@ -10,6 +10,8 @@
 
 'use strict';
 
+/* eslint-disable react-native/no-inline-styles */
+
 const React = require('react');
 const ReactNative = require('react-native');
 const {PickerIOS, Text, View} = ReactNative;

--- a/RNTester/js/RNTesterExampleList.js
+++ b/RNTester/js/RNTesterExampleList.js
@@ -10,6 +10,8 @@
 
 'use strict';
 
+/* eslint-disable react-native/no-inline-styles */
+
 const Platform = require('Platform');
 const React = require('react');
 const SectionList = require('SectionList');

--- a/RNTester/js/RTLExample.js
+++ b/RNTester/js/RTLExample.js
@@ -7,7 +7,10 @@
  * @flow
  * @format
  */
+
 'use strict';
+
+/* eslint-disable react-native/no-inline-styles */
 
 const React = require('react');
 const ReactNative = require('react-native');

--- a/RNTester/js/ScrollViewExample.js
+++ b/RNTester/js/ScrollViewExample.js
@@ -7,7 +7,10 @@
  * @flow
  * @format
  */
+
 'use strict';
+
+/* eslint-disable react-native/no-inline-styles */
 
 const ActivityIndicator = require('ActivityIndicator');
 const Platform = require('Platform');

--- a/RNTester/js/SectionListExample.js
+++ b/RNTester/js/SectionListExample.js
@@ -10,6 +10,8 @@
 
 'use strict';
 
+/* eslint-disable react-native/no-inline-styles */
+
 const React = require('react');
 const ReactNative = require('react-native');
 const {Alert, Animated, Button, StyleSheet, Text, View} = ReactNative;

--- a/RNTester/js/SegmentedControlIOSExample.js
+++ b/RNTester/js/SegmentedControlIOSExample.js
@@ -10,6 +10,8 @@
 
 'use strict';
 
+/* eslint-disable react-native/no-inline-styles */
+
 const React = require('react');
 const ReactNative = require('react-native');
 const {SegmentedControlIOS, Text, View, StyleSheet} = ReactNative;

--- a/RNTester/js/Shared/TextLegend.js
+++ b/RNTester/js/Shared/TextLegend.js
@@ -10,6 +10,8 @@
 
 'use strict';
 
+/* eslint-disable react-native/no-inline-styles */
+
 const React = require('React');
 const {Picker, Text, View} = require('react-native');
 

--- a/RNTester/js/SwipeableListViewExample.js
+++ b/RNTester/js/SwipeableListViewExample.js
@@ -10,6 +10,8 @@
 
 'use strict';
 
+/* eslint-disable react-native/no-inline-styles */
+
 const React = require('react');
 const {
   Image,

--- a/RNTester/js/SwitchExample.js
+++ b/RNTester/js/SwitchExample.js
@@ -10,6 +10,8 @@
 
 'use strict';
 
+/* eslint-disable react-native/no-inline-styles */
+
 const React = require('react');
 const ReactNative = require('react-native');
 const {Switch, Text, View} = ReactNative;

--- a/RNTester/js/TVEventHandlerExample.js
+++ b/RNTester/js/TVEventHandlerExample.js
@@ -10,6 +10,8 @@
 
 'use strict';
 
+/* eslint-disable react-native/no-inline-styles */
+
 const React = require('react');
 const ReactNative = require('react-native');
 

--- a/RNTester/js/TextExample.android.js
+++ b/RNTester/js/TextExample.android.js
@@ -10,6 +10,8 @@
 
 'use strict';
 
+/* eslint-disable react-native/no-inline-styles */
+
 const React = require('react');
 const ReactNative = require('react-native');
 const {Image, StyleSheet, Text, View} = ReactNative;

--- a/RNTester/js/TextExample.ios.js
+++ b/RNTester/js/TextExample.ios.js
@@ -10,6 +10,8 @@
 
 'use strict';
 
+/* eslint-disable react-native/no-inline-styles */
+
 const Platform = require('Platform');
 const React = require('react');
 const ReactNative = require('react-native');

--- a/RNTester/js/TextInputExample.android.js
+++ b/RNTester/js/TextInputExample.android.js
@@ -10,6 +10,8 @@
 
 'use strict';
 
+/* eslint-disable react-native/no-inline-styles */
+
 const React = require('react');
 const ReactNative = require('react-native');
 const {Text, TextInput, View, StyleSheet, Slider, Switch} = ReactNative;

--- a/RNTester/js/TextInputExample.ios.js
+++ b/RNTester/js/TextInputExample.ios.js
@@ -10,6 +10,8 @@
 
 'use strict';
 
+/* eslint-disable react-native/no-inline-styles */
+
 const Button = require('Button');
 const InputAccessoryView = require('InputAccessoryView');
 const React = require('react');

--- a/RNTester/js/ToolbarAndroidExample.android.js
+++ b/RNTester/js/ToolbarAndroidExample.android.js
@@ -10,6 +10,8 @@
 
 'use strict';
 
+/* eslint-disable react-native/no-inline-styles */
+
 const React = require('react');
 const ReactNative = require('react-native');
 

--- a/RNTester/js/TouchableExample.js
+++ b/RNTester/js/TouchableExample.js
@@ -10,6 +10,8 @@
 
 'use strict';
 
+/* eslint-disable react-native/no-inline-styles */
+
 const React = require('react');
 const ReactNative = require('react-native');
 const {

--- a/RNTester/js/TransformExample.js
+++ b/RNTester/js/TransformExample.js
@@ -10,6 +10,8 @@
 
 'use strict';
 
+/* eslint-disable react-native/no-inline-styles */
+
 const React = require('react');
 const ReactNative = require('react-native');
 const {Animated, StyleSheet, Text, View} = ReactNative;

--- a/RNTester/js/TransparentHitTestExample.js
+++ b/RNTester/js/TransparentHitTestExample.js
@@ -10,6 +10,8 @@
 
 'use strict';
 
+/* eslint-disable react-native/no-inline-styles */
+
 const React = require('react');
 const ReactNative = require('react-native');
 const {Text, View, TouchableOpacity} = ReactNative;

--- a/RNTester/js/WebSocketExample.js
+++ b/RNTester/js/WebSocketExample.js
@@ -8,6 +8,7 @@
  */
 'use strict';
 
+/* eslint-disable react-native/no-inline-styles */
 /* eslint-env browser */
 
 const React = require('react');

--- a/RNTester/js/WebViewExample.js
+++ b/RNTester/js/WebViewExample.js
@@ -10,6 +10,8 @@
 
 'use strict';
 
+/* eslint-disable react-native/no-inline-styles */
+
 const React = require('react');
 const ReactNative = require('react-native');
 const {

--- a/RNTester/js/XHRExampleCookies.js
+++ b/RNTester/js/XHRExampleCookies.js
@@ -10,6 +10,8 @@
 
 'use strict';
 
+/* eslint-disable react-native/no-inline-styles */
+
 const React = require('react');
 const ReactNative = require('react-native');
 const {StyleSheet, Text, TouchableHighlight, View, WebView} = ReactNative;

--- a/RNTester/js/XHRExampleFetch.js
+++ b/RNTester/js/XHRExampleFetch.js
@@ -10,6 +10,8 @@
 
 'use strict';
 
+/* eslint-disable react-native/no-inline-styles */
+
 const React = require('react');
 const ReactNative = require('react-native');
 const {StyleSheet, Text, TextInput, View, Platform} = ReactNative;

--- a/ReactAndroid/src/androidTest/js/CatalystRootViewTestModule.js
+++ b/ReactAndroid/src/androidTest/js/CatalystRootViewTestModule.js
@@ -9,6 +9,8 @@
 
 'use strict';
 
+/* eslint-disable react-native/no-inline-styles */
+
 var React = require('React');
 var Recording = require('NativeModules').Recording;
 var View = require('View');

--- a/ReactAndroid/src/androidTest/js/LayoutEventsTestApp.js
+++ b/ReactAndroid/src/androidTest/js/LayoutEventsTestApp.js
@@ -9,6 +9,8 @@
 
 'use strict';
 
+/* eslint-disable react-native/no-inline-styles */
+
 var React = require('React');
 var View = require('View');
 

--- a/ReactAndroid/src/androidTest/js/ProgressBarTestModule.js
+++ b/ReactAndroid/src/androidTest/js/ProgressBarTestModule.js
@@ -9,6 +9,8 @@
 
 'use strict';
 
+/* eslint-disable react-native/no-inline-styles */
+
 var BatchedBridge = require('BatchedBridge');
 var React = require('React');
 var ProgressBar = require('ProgressBarAndroid');

--- a/ReactAndroid/src/androidTest/js/SwipeRefreshLayoutTestModule.js
+++ b/ReactAndroid/src/androidTest/js/SwipeRefreshLayoutTestModule.js
@@ -9,6 +9,8 @@
 
 'use strict';
 
+/* eslint-disable react-native/no-inline-styles */
+
 var BatchedBridge = require('BatchedBridge');
 var React = require('React');
 var RecordingModule = require('NativeModules')

--- a/ReactAndroid/src/androidTest/js/TextInputTestModule.js
+++ b/ReactAndroid/src/androidTest/js/TextInputTestModule.js
@@ -9,6 +9,8 @@
 
 'use strict';
 
+/* eslint-disable react-native/no-inline-styles */
+
 var BatchedBridge = require('BatchedBridge');
 var React = require('React');
 var StyleSheet = require('StyleSheet');

--- a/ReactAndroid/src/androidTest/js/ViewRenderingTestModule.js
+++ b/ReactAndroid/src/androidTest/js/ViewRenderingTestModule.js
@@ -9,6 +9,8 @@
 
 'use strict';
 
+/* eslint-disable react-native/no-inline-styles */
+
 var BatchedBridge = require('BatchedBridge');
 var React = require('React');
 var View = require('View');


### PR DESCRIPTION
Fixes linting for all examples and tests with React components by disabling the ESLint rule `react-native/no-inline-styles`.

Test Plan:
----------
Run linting from the React Native project:
```
> cd react-native
> yarn
> yarn lint
```
And see less linting issues than before.

Release Notes:
--------------
[INTERNAL] [ENHANCEMENT] [eslint] - Fix eslint issues for examples