### PR TITLE
Fix the comment for getSize in Image.android.js

### DIFF
--- a/Libraries/Image/Image.android.js
+++ b/Libraries/Image/Image.android.js
@@ -262,9 +262,9 @@ let Image = (
 Image = React.forwardRef(Image);
 
 /**
- * Retrieve the width and height (in pixels) of an image prior to displaying it. 
+ * Retrieve the width and height (in pixels) of an image prior to displaying it
  *
- * See https://facebook.github.io/react-native/docs/image#getsize
+ * See https://facebook.github.io/react-native/docs/image.html#getsize
  */
 Image.getSize = getSize;
 

--- a/Libraries/Image/Image.android.js
+++ b/Libraries/Image/Image.android.js
@@ -262,10 +262,9 @@ let Image = (
 Image = React.forwardRef(Image);
 
 /**
- * Prefetches a remote image for later use by downloading it to the disk
- * cache
+ * Retrieve the width and height (in pixels) of an image prior to displaying it. 
  *
- * See https://facebook.github.io/react-native/docs/image.html#prefetch
+ * See https://facebook.github.io/react-native/docs/image#getsize
  */
 Image.getSize = getSize;
 


### PR DESCRIPTION
A minor change to the comment in the Image.android.js file. 

Test Plan:
----------
No runnable code changed 

Release Notes:
--------------
[DOCS] [BUGFIX] [Image.android.js] - Fix the copy-paste comment
