### PR TITLE
Fix duplicate function declaration in WebSockets

### DIFF
--- a/Libraries/WebSocket/WebSocket.js
+++ b/Libraries/WebSocket/WebSocket.js
@@ -175,10 +175,6 @@ class WebSocket extends EventTarget(...WEBSOCKET_EVENTS) {
     this._binaryType = binaryType;
   }
 
-  get binaryType(): ?BinaryType {
-    return this._binaryType;
-  }
-
   close(code?: number, reason?: string): void {
     if (this.readyState === this.CLOSING || this.readyState === this.CLOSED) {
       return;


### PR DESCRIPTION
Fixes the only ESLint error pending to resolve. It was a duplicate `get` declaration.

Test Plan:
----------
Run:
```
yarn lint
```
Check there are no more ESLint errors.

Release Notes:
--------------
[INTERNAL] [ENHANCEMENT] [eslint] - Fix eslint error