### PR TITLE
Flow strict ScrollViewMock

### DIFF
--- a/Libraries/Components/ScrollView/__mocks__/ScrollViewMock.js
+++ b/Libraries/Components/ScrollView/__mocks__/ScrollViewMock.js
@@ -5,14 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @flow
+ * @flow strict-local
  */
 
 /* eslint-env jest */
 
 'use strict';
-
-declare var jest: any;
 
 const React = require('React');
 const View = require('View');


### PR DESCRIPTION
Related to #22100 

Turn Flow strict mode on for ScrollViewMock. 
This file used to declare jest var as `any` but jest module is already typed in root flow folder.

Note: I had to use a quick fix for polyfillPromise. See here #22101 

### Test Plan:
- All flow tests succeed.

### Release Notes:

[GENERAL] [ENHANCEMENT] [ScrollViewMock.js] - Flow strict mode