### PR TITLE
Turn Flow strict mode on for DatePickerIOS

### DIFF
--- a/Libraries/Components/DatePicker/DatePickerIOS.ios.js
+++ b/Libraries/Components/DatePicker/DatePickerIOS.ios.js
@@ -159,7 +159,11 @@ class DatePickerIOS extends React.Component<Props> {
                 ? props.initialDate.getTime()
                 : undefined
           }
-          locale={props.locale}
+          locale={
+            props.locale != null && props.locale !== ''
+              ? props.locale
+              : undefined
+          }
           maximumDate={
             props.maximumDate ? props.maximumDate.getTime() : undefined
           }

--- a/Libraries/Components/DatePicker/DatePickerIOS.ios.js
+++ b/Libraries/Components/DatePicker/DatePickerIOS.ios.js
@@ -27,7 +27,7 @@ const RCTDatePickerIOS = requireNativeComponent('RCTDatePicker');
 
 type Event = SyntheticEvent<
   $ReadOnly<{|
-    timestamp: string | number,
+    timestamp: number,
   |}>,
 >;
 

--- a/Libraries/Components/DatePicker/DatePickerIOS.ios.js
+++ b/Libraries/Components/DatePicker/DatePickerIOS.ios.js
@@ -8,7 +8,7 @@
  * This is a controlled component version of RCTDatePickerIOS
  *
  * @format
- * @flow
+ * @flow strict-local
  */
 
 'use strict';
@@ -21,10 +21,15 @@ const View = require('View');
 const requireNativeComponent = require('requireNativeComponent');
 
 import type {ViewProps} from 'ViewPropTypes';
+import type {SyntheticEvent} from 'CoreEventTypes';
 
 const RCTDatePickerIOS = requireNativeComponent('RCTDatePicker');
 
-type Event = Object;
+type Event = SyntheticEvent<
+  $ReadOnly<{|
+    timestamp: string | number,
+  |}>,
+>;
 
 type Props = $ReadOnly<{|
   ...ViewProps,
@@ -154,7 +159,7 @@ class DatePickerIOS extends React.Component<Props> {
                 ? props.initialDate.getTime()
                 : undefined
           }
-          locale={props.locale ? props.locale : undefined}
+          locale={props.locale}
           maximumDate={
             props.maximumDate ? props.maximumDate.getTime() : undefined
           }


### PR DESCRIPTION
Related to #22100

Turn Flow strict mode on for DatePickerIOS.

## Test Plan:
- [x] npm run prettier
- [x] npm run flow-check-ios
- [x] npm run flow-check-android
 
This error was happend #22101 #22048 

## Release Notes:
[GENERAL] [ENHANCEMENT] [Components/DatePicker/DatePickerIOS.ios.js] - Flow strict mode