### PR TITLE
[flow-strict] Flow strict in DatePickerAndroid.android.js, DatePickerAndroid.ios.js

### DIFF
--- a/Libraries/Components/DatePickerAndroid/DatePickerAndroid.android.js
+++ b/Libraries/Components/DatePickerAndroid/DatePickerAndroid.android.js
@@ -5,17 +5,38 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @flow
+ * @flow strict-local
  */
 
 'use strict';
 
 const DatePickerModule = require('NativeModules').DatePickerAndroid;
 
+type Options = $ReadOnly<{|
+  date?: ?(Date | number),
+  minDate?: ?(Date | number),
+  maxDate?: ?(Date | number),
+  mode?: ?('calender' | 'spinner' | 'default'),
+|}>;
+
+type DatePickerModuleOpen =
+  | {|
+      action: 'dateSetAction',
+      year: number,
+      month: number,
+      day: number,
+    |}
+  | {|
+      action: 'dismissedAction',
+      year: typeof undefined,
+      month: typeof undefined,
+      day: typeof undefined,
+    |};
+
 /**
  * Convert a Date to a timestamp.
  */
-function _toMillis(options: Object, key: string) {
+function _toMillis(options: Options, key: string) {
   const dateVal = options[key];
   // Is it a Date object?
   if (typeof dateVal === 'object' && typeof dateVal.getMonth === 'function') {
@@ -65,7 +86,7 @@ class DatePickerAndroid {
    * Note the native date picker dialog has some UI glitches on Android 4 and lower
    * when using the `minDate` and `maxDate` options.
    */
-  static async open(options: Object): Promise<Object> {
+  static async open(options: Options): Promise<DatePickerModuleOpen> {
     const optionsMs = options;
     if (optionsMs) {
       _toMillis(options, 'date');

--- a/Libraries/Components/DatePickerAndroid/DatePickerAndroid.android.js
+++ b/Libraries/Components/DatePickerAndroid/DatePickerAndroid.android.js
@@ -99,15 +99,11 @@ class DatePickerAndroid {
   /**
    * A date has been selected.
    */
-  static get dateSetAction() {
-    return 'dateSetAction';
-  }
+  static dateSetAction = 'dateSetAction';
   /**
    * The dialog has been dismissed.
    */
-  static get dismissedAction() {
-    return 'dismissedAction';
-  }
+  static dismissedAction = 'dismissedAction';
 }
 
 module.exports = DatePickerAndroid;

--- a/Libraries/Components/DatePickerAndroid/DatePickerAndroid.android.js
+++ b/Libraries/Components/DatePickerAndroid/DatePickerAndroid.android.js
@@ -19,7 +19,7 @@ type Options = $ReadOnly<{|
   mode?: ?('calender' | 'spinner' | 'default'),
 |}>;
 
-type DatePickerModuleOpen =
+type DatePickerOpenAction =
   | {|
       action: 'dateSetAction',
       year: number,
@@ -86,7 +86,7 @@ class DatePickerAndroid {
    * Note the native date picker dialog has some UI glitches on Android 4 and lower
    * when using the `minDate` and `maxDate` options.
    */
-  static async open(options: Options): Promise<DatePickerModuleOpen> {
+  static async open(options: Options): Promise<DatePickerOpenAction> {
     const optionsMs = options;
     if (optionsMs) {
       _toMillis(options, 'date');

--- a/Libraries/Components/DatePickerAndroid/DatePickerAndroid.ios.js
+++ b/Libraries/Components/DatePickerAndroid/DatePickerAndroid.ios.js
@@ -17,22 +17,8 @@ type Options = $ReadOnly<{|
   mode?: ?('calender' | 'spinner' | 'default'),
 |}>;
 
-type DatePickerModuleOpen =
-  | {|
-      action: 'dateSetAction',
-      year: number,
-      month: number,
-      day: number,
-    |}
-  | {|
-      action: 'dismissedAction',
-      year: typeof undefined,
-      month: typeof undefined,
-      day: typeof undefined,
-    |};
-
 const DatePickerAndroid = {
-  async open(options: Options): Promise<DatePickerModuleOpen> {
+  async open(options: Options): Promise<void> {
     return Promise.reject({
       message: 'DatePickerAndroid is not supported on this platform.',
     });

--- a/Libraries/Components/DatePickerAndroid/DatePickerAndroid.ios.js
+++ b/Libraries/Components/DatePickerAndroid/DatePickerAndroid.ios.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @flow
+ * @flow strict-local
  */
 
 'use strict';
@@ -17,8 +17,22 @@ type Options = $ReadOnly<{|
   mode?: ?('calender' | 'spinner' | 'default'),
 |}>;
 
+type DatePickerModuleOpen =
+  | {|
+      action: 'dateSetAction',
+      year: number,
+      month: number,
+      day: number,
+    |}
+  | {|
+      action: 'dismissedAction',
+      year: typeof undefined,
+      month: typeof undefined,
+      day: typeof undefined,
+    |};
+
 const DatePickerAndroid = {
-  async open(options: Options): Promise<Object> {
+  async open(options: Options): Promise<DatePickerModuleOpen> {
     return Promise.reject({
       message: 'DatePickerAndroid is not supported on this platform.',
     });

--- a/Libraries/Components/DatePickerAndroid/DatePickerAndroid.ios.js
+++ b/Libraries/Components/DatePickerAndroid/DatePickerAndroid.ios.js
@@ -10,8 +10,15 @@
 
 'use strict';
 
+type Options = $ReadOnly<{|
+  date?: ?(Date | number),
+  minDate?: ?(Date | number),
+  maxDate?: ?(Date | number),
+  mode?: ?('calender' | 'spinner' | 'default'),
+|}>;
+
 const DatePickerAndroid = {
-  async open(options: Object): Promise<Object> {
+  async open(options: Options): Promise<Object> {
     return Promise.reject({
       message: 'DatePickerAndroid is not supported on this platform.',
     });


### PR DESCRIPTION
Related to #22100

Turn Flow strict mode on for DatePickerAndroid

## Test Plan:
- [x] npm run prettier
- [ ] npm run flow-check-ios
- [ ] npm run flow-check-android
 
This error was happend #22101 #22048 

## Release Notes:
[GENERAL] [ENHANCEMENT] [Components/DatePickerAndroid/DatePickerAndroid.android.js] - Flow strict mode
[GENERAL] [ENHANCEMENT] [Components/DatePickerAndroid/DatePickerAndroid.ios.js] - Flow strict mode