### PR TITLE
Remove var in Libraries/Utilities/buildStyleInterpolator.js

### DIFF
--- a/Libraries/Utilities/buildStyleInterpolator.js
+++ b/Libraries/Utilities/buildStyleInterpolator.js
@@ -189,17 +189,17 @@ const buildStyleInterpolator = function(anims) {
           );
           didMatrix = true;
         } else {
-          var next = computeNextValLinearScalar(anim, value);
+          const next = computeNextValLinearScalar(anim, value);
           didChange = setNextValAndDetectChange(result, name, next, didChange);
         }
       } else if (anim.type === 'constant') {
-        var next = anim.value;
+        const next = anim.value;
         didChange = setNextValAndDetectChange(result, name, next, didChange);
       } else if (anim.type === 'step') {
-        var next = value >= anim.threshold ? anim.to : anim.from;
+        const next = value >= anim.threshold ? anim.to : anim.from;
         didChange = setNextValAndDetectChange(result, name, next, didChange);
       } else if (anim.type === 'identity') {
-        var next = value;
+        const next = value;
         didChange = setNextValAndDetectChange(result, name, next, didChange);
       }
     }


### PR DESCRIPTION
Replaces the keywords var with const in Libraries/Utilities/buildStyleInterpolator.js

Test Plan:
----------
- [x] Check npm run flow
- [x] Check npm run flow-check-ios
- [x] Check npm run flow-check-android

Release Notes:
--------------
[GENERAL] [ENHANCEMENT] [Libraries/Utilities/buildStyleInterpolator.js] - remove var