### PR TITLE
[WIP] Make PR template consistent with Changelog

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,7 +13,7 @@ Changelog:
 ----------
 Help reviewers and the release process by writing your own changelog entry. When the change doesn't impact React Native developers, it may be ommitted from the changelog for brevity. See below for an example.
 
-[TYPE] [CATEGORY] - Message
+[CATEGORY] [TYPE] - Message
 
 <!--
 
@@ -38,8 +38,8 @@ Help reviewers and the release process by writing your own changelog entry. When
 
   EXAMPLES:
 
-  [Added] [General] - Add snapToOffsets prop to ScrollView component
-  [Fixed] [General] - Fix various issues in snapToInterval on ScrollView component
-  [Fixed] [iOS] - Fix crash in RCTImagePicker
+  [General] [Added] - Add snapToOffsets prop to ScrollView component
+  [General] [Fixed] - Fix various issues in snapToInterval on ScrollView component
+  [iOS] [Fixed] - Fix crash in RCTImagePicker
 
 -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,31 +9,37 @@ Test Plan:
 ----------
 Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!
 
-Release Notes:
---------------
-Help reviewers and the release process by writing your own release notes. See below for an example.
+Changelog:
+----------
+Help reviewers and the release process by writing your own changelog entry. When the change doesn't impact React Native developers, it may be ommitted from the changelog for brevity. See below for an example.
 
-[CATEGORY] [TYPE] [LOCATION] - Message
+[TYPE] [CATEGORY] - Message
 
 <!--
-  **INTERNAL and MINOR tagged notes will not be included in the next version's final release notes.**
 
-    CATEGORY
-  [----------]      TYPE
-  [ CLI      ] [-------------]    LOCATION
-  [ DOCS     ] [ BREAKING    ] [-------------]
-  [ GENERAL  ] [ BUGFIX      ] [ {Component} ]
-  [ INTERNAL ] [ ENHANCEMENT ] [ {Filename}  ]
-  [ IOS      ] [ FEATURE     ] [ {Directory} ]   |-----------|
-  [ ANDROID  ] [ MINOR       ] [ {Framework} ] - | {Message} |
-  [----------] [-------------] [-------------]   |-----------|
+  CATEGORY may be:
 
- EXAMPLES:
+  - [General]
+  - [iOS]
+  - [Android]
 
- [IOS] [BREAKING] [FlatList] - Change a thing that breaks other things
- [ANDROID] [BUGFIX] [TextInput] - Did a thing to TextInput
- [CLI] [FEATURE] [local-cli/info/info.js] - CLI easier to do things with
- [DOCS] [BUGFIX] [GettingStarted.md] - Accidentally a thing/word
- [GENERAL] [ENHANCEMENT] [Yoga] - Added new yoga thing/position
- [INTERNAL] [FEATURE] [./scripts] - Added thing to script that nobody will see
+  TYPE may be:
+
+  - [Added] for new features.
+  - [Changed] for changes in existing functionality.
+  - [Deprecated] for soon-to-be removed features.
+  - [Removed] for now removed features.
+  - [Fixed] for any bug fixes.
+  - [Security] in case of vulnerabilities.
+
+  For more detail, see https://keepachangelog.com/en/1.0.0/#how
+
+  MESSAGE may answer "what and why" on a feature level. Use this to briefly tell React Native users about notable changes.
+
+  EXAMPLES:
+
+  [Added] [General] - Add snapToOffsets prop to ScrollView component
+  [Fixed] [General] - Fix various issues in snapToInterval on ScrollView component
+  [Fixed] [iOS] - Fix crash in RCTImagePicker
+
 -->

--- a/bots/dangerfile.js
+++ b/bots/dangerfile.js
@@ -39,7 +39,7 @@ if (!includesTestPlan) {
 }
 
 // Regex looks for given categories, types, a file/framework/component, and a message - broken into 4 capture groups
-const releaseNotesRegex = /\[\s?(ANDROID|CLI|DOCS|GENERAL|INTERNAL|IOS|TVOS|WINDOWS)\s?\]\s*?\[\s?(BREAKING|BUGFIX|ENHANCEMENT|FEATURE|MINOR)\s?\]\s*?\[(.*)\]\s*?\-\s*?(.*)/gi;
+const releaseNotesRegex = /\[\s?(ANDROID|GENERAL|IOS)\s?\]\s*?\[\s?(ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY)\s?\]\s*?\-\s*?(.*)/gi;
 const includesReleaseNotes =
   danger.github.pr.body &&
   danger.github.pr.body.toLowerCase().includes('release notes');


### PR DESCRIPTION
In the new changelog format, we're following [Keep a Changelog](https://keepachangelog.com/en/1.0.0). This change updates the PR template to follow their change types, plus it simplifies the *CATEGORY* field to follow the changelog's groupings. Some simplified examples have been provided, though I plan to revisit this after 0.58 to add real-world examples. This change is motivated by react-native-community/react-native-releases#47.

Test Plan:
----------
Not applicable. This is a change only to the contributing process's documentation and the dangerfile.

Release Notes:
--------------
Not applicable. This is an internal change to the development platform, not a user-facing change.
