### PR TITLE
Flow type RefreshControl

### DIFF
--- a/Libraries/Components/RefreshControl/RefreshControl.js
+++ b/Libraries/Components/RefreshControl/RefreshControl.js
@@ -87,7 +87,7 @@ export type RefreshControlProps = $ReadOnly<{|
   /**
    * Called when the view starts refreshing.
    */
-  onRefresh?: ?Function,
+  onRefresh?: ?() => void,
 
   /**
    * Whether the view should be indicating an active refresh.


### PR DESCRIPTION
Related to #22100

Enhance Flow types for RefreshControl specifying `onRefresh` props type.
There are still 2 `any` left using `requireNativeComponent` that need to be addressed to turn Flow to strict mode.

I went through `RCTRefreshControl` and `AndroidSwipeRefreshLayout` classes to understand where this method came from.

### Test Plan:
- All flow tests succeed.

### Release Notes:

[GENERAL] [ENHANCEMENT] [RefreshControl.js] - Flow onRefresh type