### PR TITLE
Fix  rename legacy component lifecycles

### DIFF
--- a/RNTester/js/ImageEditingExample.js
+++ b/RNTester/js/ImageEditingExample.js
@@ -184,7 +184,7 @@ class ImageCropper extends React.Component<$FlowFixMeProps, $FlowFixMeState> {
   _scaledImageSize: ImageSize;
   _horizontal: boolean;
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     // Scale an image to the minimum size that is large enough to completely
     // fill the crop box.
     const widthRatio = this.props.image.width / this.props.size.width;


### PR DESCRIPTION
Adding an “UNSAFE_” prefix to `componentWillMount`.

If this PR fixes an issue, type "Fixes #issueNumber" to automatically close the issue when the PR is merged.

### Test Plan: 
- [x] yarn test
- [x] yarn flow
- [x] yarn flow-check-ios
- [x] yarn flow-check-android

### Release Notes:
[General] [Fixed] - adding an UNSAFE_ prefix