### PR TITLE
Remove var in Libraries/Utilities/deepFreezeAndThrowOnMutationInDev.js

### DIFF
--- a/Libraries/Utilities/deepFreezeAndThrowOnMutationInDev.js
+++ b/Libraries/Utilities/deepFreezeAndThrowOnMutationInDev.js
@@ -41,8 +41,8 @@ function deepFreezeAndThrowOnMutationInDev<T: Object>(object: T): T {
     const keys = Object.keys(object);
     const hasOwnProperty = Object.prototype.hasOwnProperty;
 
-    for (var i = 0; i < keys.length; i++) {
-      var key = keys[i];
+    for (let i = 0; i < keys.length; i++) {
+      const key = keys[i];
       if (hasOwnProperty.call(object, key)) {
         Object.defineProperty(object, key, {
           get: identity.bind(null, object[key]),
@@ -56,8 +56,8 @@ function deepFreezeAndThrowOnMutationInDev<T: Object>(object: T): T {
     Object.freeze(object);
     Object.seal(object);
 
-    for (var i = 0; i < keys.length; i++) {
-      var key = keys[i];
+    for (let i = 0; i < keys.length; i++) {
+      const key = keys[i];
       if (hasOwnProperty.call(object, key)) {
         deepFreezeAndThrowOnMutationInDev(object[key]);
       }


### PR DESCRIPTION
Replaces the keywords var with let or const in Libraries/Utilities/deepFreezeAndThrowOnMutationInDev.js

## Test Plan:

- [x] Check npm run flow
- [x] Check npm run flow-check-ios
- [x] Check npm run flow-check-android

## Release Notes:
[GENERAL] [ENHANCEMENT] [Libraries/Utilities/deepFreezeAndThrowOnMutationInDev.js] - remove var