### PR TITLE
Flow strict in Picker.js, PickerIOS.ios.js, PickerAndroid.android.js

### DIFF
--- a/Libraries/Components/Picker/Picker.js
+++ b/Libraries/Components/Picker/Picker.js
@@ -32,7 +32,7 @@ type PickerItemProps = $ReadOnly<{|
    * The value to be passed to picker's `onValueChange` callback when
    * this item is selected. Can be a string or an integer.
    */
-  value?: any,
+  value?: ?(number | string),
 
   /**
    * Color of this item's text.
@@ -63,14 +63,14 @@ type PickerProps = $ReadOnly<{|
   /**
    * Value matching value of one of the items. Can be a string or an integer.
    */
-  selectedValue?: any,
+  selectedValue?: ?(number | string),
 
   /**
    * Callback for when an item is selected. This is called with the following parameters:
    *   - `itemValue`: the `value` prop of the item that was selected
-   *   - `itemPosition`: the index of the selected item in this picker
+   *   - `itemIndex`: the index of the selected item in this picker
    */
-  onValueChange?: ?(newValue: any, newIndex: number) => mixed,
+  onValueChange?: ?(itemValue: number | string, itemIndex: number) => mixed,
 
   /**
    * If set to false, the picker will be disabled, i.e. the user will not be able to make a

--- a/Libraries/Components/Picker/PickerAndroid.android.js
+++ b/Libraries/Components/Picker/PickerAndroid.android.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @flow
+ * @flow strict-local
  */
 
 'use strict';
@@ -37,7 +37,7 @@ type PickerAndroidProps = $ReadOnly<{|
   selectedValue?: any,
   enabled?: ?boolean,
   mode?: ?('dialog' | 'dropdown'),
-  onValueChange?: ?(newValue: any, newIndex: number) => mixed,
+  onValueChange?: ?(itemValue: number | string, itemIndex: number) => mixed,
   prompt?: ?string,
   testID?: string,
 |}>;

--- a/Libraries/Components/Picker/PickerIOS.ios.js
+++ b/Libraries/Components/Picker/PickerIOS.ios.js
@@ -27,14 +27,14 @@ import type {TextStyleProp} from 'StyleSheet';
 
 type PickerIOSChangeEvent = SyntheticEvent<
   $ReadOnly<{|
-    newValue: any,
+    newValue: number | string,
     newIndex: number,
   |}>,
 >;
 
 type RCTPickerIOSItemType = $ReadOnly<{|
   label: ?Label,
-  value: ?any,
+  value: ?(number | string),
   textColor: ?number,
 |}>;
 
@@ -62,8 +62,8 @@ type Props = $ReadOnly<{|
   children: React.ChildrenArray<React.Element<typeof PickerIOSItem>>,
   itemStyle?: ?TextStyleProp,
   onChange?: ?(event: PickerIOSChangeEvent) => mixed,
-  onValueChange?: ?(newValue: any, newIndex: number) => mixed,
-  selectedValue: any,
+  onValueChange?: ?(itemValue: number | string, itemIndex: number) => mixed,
+  selectedValue: ?(number | string),
 |}>;
 
 type State = {|
@@ -73,7 +73,7 @@ type State = {|
 
 type ItemProps = $ReadOnly<{|
   label: ?Label,
-  value?: ?any,
+  value?: ?(number | string),
   color?: ?ColorValue,
 |}>;
 

--- a/RNTester/js/PickerExample.js
+++ b/RNTester/js/PickerExample.js
@@ -116,7 +116,7 @@ class PickerExample extends React.Component<{}, $FlowFixMeState> {
     this.setState({mode: newMode});
   };
 
-  onValueChange = (key: string, value: string) => {
+  onValueChange = (key: string, value: string | number) => {
     const newState = {};
     newState[key] = value;
     this.setState(newState);


### PR DESCRIPTION
Related to #22100

Turn Flow strict mode on for Picker

## Test Plan:
- [x] npm run prettier
- [ ] npm run flow-check-ios
- [ ] npm run flow-check-android
 

## Release Notes:
[GENERAL] [ENHANCEMENT] [Libraries/Components/Picker/Picker.js] - Flow strict mode
[GENERAL] [ENHANCEMENT] [Libraries/Components/Picker/PickerIOS.ios.js] - Flow strict mode
[GENERAL] [ENHANCEMENT] [Libraries/Components/Picker/PickerAndroid.android.js] - Flow strict mode
