### PR TITLE
Removed unnecessary code in Libraries/Text/Text.js

### DIFF
--- a/Libraries/Text/Text.js
+++ b/Libraries/Text/Text.js
@@ -108,10 +108,9 @@ class TouchableText extends React.Component<Props, State> {
     responseHandlers: null,
   };
 
-  static getDerivedStateFromProps(nextProps: Props, prevState: State): ?State {
+  static getDerivedStateFromProps(nextProps: Props, prevState: State): $Shape<State> | null {
     return prevState.responseHandlers == null && isTouchable(nextProps)
       ? {
-          ...prevState,
           responseHandlers: prevState.createResponderHandlers(),
         }
       : null;


### PR DESCRIPTION
I don't think it's necessary to use spread properties (prevState) in `getDerivedStateFromProps` 

Test Plan:
----------
- [x] Check npm run flow
- [x] Check npm run flow-check-ios
- [x] Check npm run flow-check-android

Changelog:
----------
[GENERAL] [ENHANCEMENT] [Libraries/Text] - remove unnecessary code
