### PR TITLE
[flow-strict] Flow strict TouchableOpacity

### DIFF
--- a/Libraries/Components/AppleTV/TVViewPropTypes.js
+++ b/Libraries/Components/AppleTV/TVViewPropTypes.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-type TVParallaxPropertiesType = $ReadOnly<{|
+export type TVParallaxPropertiesType = $ReadOnly<{|
   /**
    * If true, parallax effects are enabled.  Defaults to true.
    */

--- a/Libraries/Components/Touchable/TouchableOpacity.js
+++ b/Libraries/Components/Touchable/TouchableOpacity.js
@@ -24,14 +24,14 @@ const flattenStyle = require('flattenStyle');
 
 import type {Props as TouchableWithoutFeedbackProps} from 'TouchableWithoutFeedback';
 import type {ViewStyleProp} from 'StyleSheet';
-
-type Event = Object;
+import type {TVParallaxPropertiesType} from 'TVViewPropTypes';
+import type {PressEvent} from 'CoreEventTypes';
 
 const PRESS_RETENTION_OFFSET = {top: 20, left: 20, right: 20, bottom: 30};
 
 type TVProps = $ReadOnly<{|
   hasTVPreferredFocus?: ?boolean,
-  tvParallaxProperties?: ?Object,
+  tvParallaxProperties?: ?TVParallaxPropertiesType,
 |}>;
 
 type Props = $ReadOnly<{|
@@ -193,7 +193,7 @@ const TouchableOpacity = ((createReactClass({
    * `Touchable.Mixin` self callbacks. The mixin will invoke these if they are
    * defined on your component.
    */
-  touchableHandleActivePressIn: function(e: Event) {
+  touchableHandleActivePressIn: function(e: PressEvent) {
     if (e.dispatchConfig.registrationName === 'onResponderGrant') {
       this._opacityActive(0);
     } else {
@@ -202,16 +202,16 @@ const TouchableOpacity = ((createReactClass({
     this.props.onPressIn && this.props.onPressIn(e);
   },
 
-  touchableHandleActivePressOut: function(e: Event) {
+  touchableHandleActivePressOut: function(e: PressEvent) {
     this._opacityInactive(250);
     this.props.onPressOut && this.props.onPressOut(e);
   },
 
-  touchableHandlePress: function(e: Event) {
+  touchableHandlePress: function(e: PressEvent) {
     this.props.onPress && this.props.onPress(e);
   },
 
-  touchableHandleLongPress: function(e: Event) {
+  touchableHandleLongPress: function(e: PressEvent) {
     this.props.onLongPress && this.props.onLongPress(e);
   },
 


### PR DESCRIPTION
Related to #22100

Enhance Flow types for TouchableOpacity specifying Touchable event types and TvParallaxPropertiesType.
I had to export TvParallaxPropertiesType from TVViewPropTypes file.
There are still 1 any left using requireNativeComponent and a dependency to `Touchable` that need to be addressed to turn Flow to strict mode.

I guess `Touchable` is a lot more work since there's no flow annotation and it's still good old Mixin.

### Test Plan:
- All flow tests succeed.

### Release Notes:

[GENERAL] [ENHANCEMENT] [TouchableOpacity.js] - Flow types
[GENERAL] [ENHANCEMENT] [TVViewPropTypes.js] - Export type