### PR TITLE
[flow-strict] Flow strict-local in TimePickerAndroid.ios.js

### DIFF
--- a/Libraries/Components/TimePickerAndroid/TimePickerAndroid.ios.js
+++ b/Libraries/Components/TimePickerAndroid/TimePickerAndroid.ios.js
@@ -5,13 +5,29 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @flow
+ * @flow strict-local
  */
 
 'use strict';
 
+import type {SyntheticEvent} from 'CoreEventTypes';
+
+type Options = {
+  hour: number,
+  minute: number,
+  is24Hour: boolean,
+  mode: 'clock' | 'spinner' | 'default',
+};
+type TimePickerAndroidEvent = SyntheticEvent<
+  $ReadOnly<{|
+    action: string,
+    hour: number,
+    minute: number,
+  |}>,
+>;
+
 const TimePickerAndroid = {
-  async open(options: Object): Promise<Object> {
+  async open(options: Options): Promise<TimePickerAndroidEvent> {
     return Promise.reject({
       message: 'TimePickerAndroid is not supported on this platform.',
     });


### PR DESCRIPTION
Related to #22100

Turn Flow strict mode on for Libraries/Components/TimePickerAndroid/TimePickerAndroid.android.ios.js.

## Test Plan:
- [x] npm run prettier
- [x] npm run flow
- [x] npm run flow-check-ios
- [x] npm run flow-check-android
- [x] npm run lint
- [x] npm run test

## Changelog:
[GENERAL][ENHANCEMENT][TimePickerAndroid.android.ios.js] - apply flow strict-local