### PR TITLE
Remove useless additionnal blur call

### DIFF
--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -1198,7 +1198,6 @@ const TextInput = createReactClass({
   },
 
   _onBlur: function(event: Event) {
-    this.blur();
     if (this.props.onBlur) {
       this.props.onBlur(event);
     }


### PR DESCRIPTION
I noticed that the _onBlur method was not exactly similar to the _onFocus one in the TextInput component. 

After digging, I found that the blurTextInput method in the TextInputState.js file was call twice in a raw instead of once when the textinput component should blur.

By removing this line, I fix this unecessary multiple call.