### PR TITLE
[flow-strict] Flow strict-local in InternalScrollViewTypes

### DIFF
--- a/Libraries/Components/ScrollView/InternalScrollViewType.js
+++ b/Libraries/Components/ScrollView/InternalScrollViewType.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @flow strict-local
+ * @flow
  */
 
 const ReactNative = require('ReactNative');
@@ -26,7 +26,7 @@ class InternalScrollViewType<Props> extends ReactNative.NativeComponent<Props> {
   scrollToEnd(options?: ?{animated?: boolean}) {}
   scrollWithoutAnimationTo(y: number = 0, x: number = 0) {}
 
-  getScrollResponder() {}
+  getScrollResponder(): any {}
   getScrollableNode(): ?number {}
   getInnerViewNode(): ?number {}
 

--- a/Libraries/Components/ScrollView/InternalScrollViewType.js
+++ b/Libraries/Components/ScrollView/InternalScrollViewType.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @flow
+ * @flow strict-local
  */
 
 const ReactNative = require('ReactNative');
@@ -26,12 +26,12 @@ class InternalScrollViewType<Props> extends ReactNative.NativeComponent<Props> {
   scrollToEnd(options?: ?{animated?: boolean}) {}
   scrollWithoutAnimationTo(y: number = 0, x: number = 0) {}
 
-  getScrollResponder(): any {}
-  getScrollableNode(): any {}
-  getInnerViewNode(): any {}
+  getScrollResponder() {}
+  getScrollableNode(): ?number {}
+  getInnerViewNode(): ?number {}
 
   scrollResponderScrollNativeHandleToKeyboard(
-    nodeHandle: any,
+    nodeHandle: number,
     additionalOffset?: number,
     preventNegativeScrollOffset?: boolean,
   ) {}

--- a/Libraries/Utilities/__tests__/deepFreezeAndThrowOnMutationInDev-test.js
+++ b/Libraries/Utilities/__tests__/deepFreezeAndThrowOnMutationInDev-test.js
@@ -134,7 +134,7 @@ describe('deepFreezeAndThrowOnMutationInDev', function() {
     expect(o.key1.key2).toBe('newValue');
   });
 
-  it('shouldn\'t recurse infinitely', () => {
+  it("shouldn't recurse infinitely", () => {
     __DEV__ = true;
     const o = {};
     o.circular = o;


### PR DESCRIPTION
Issue in focus: #22100 

All instances of `any` were replaced with their respective Flow types.
`getScrollResponder()` returned `this` and after going through the official flow documentation for [functions](https://flow.org/en/docs/types/functions/) , I removed the return type altogether. If this was a wrong approach, please correct me.
Any changes needed will be implemented at the earliest of my convenience (^_^)

Test Plan:
----------
* [x]  yarn prettier
* [x]  npm run lint
* [x]  npm run flow
* [x]  npm run flow-check-android

Release Notes:
----------
[GENERAL][ENHANCEMENT][InternalScrollViewType.js] - Flow Type
[GENERAL][FIXED][deepFreezeAndThrowOnMutationInDev-test.js] - Lint Error

<!--

  CATEGORY may be:

  - [General]
  - [iOS]
  - [Android]

  TYPE may be:

  - [Added] for new features.
  - [Changed] for changes in existing functionality.
  - [Deprecated] for soon-to-be removed features.
  - [Removed] for now removed features.
  - [Fixed] for any bug fixes.
  - [Security] in case of vulnerabilities.

  For more detail, see https://keepachangelog.com/en/1.0.0/#how

  MESSAGE may answer "what and why" on a feature level. Use this to briefly tell React Native users about notable changes.

  EXAMPLES:

  [General] [Added] - Add snapToOffsets prop to ScrollView component
  [General] [Fixed] - Fix various issues in snapToInterval on ScrollView component
  [iOS] [Fixed] - Fix crash in RCTImagePicker

-->