### PR TITLE
TouchEventEmitter: Fix assignment of Y coordinates

### DIFF
--- a/ReactCommon/fabric/components/view/TouchEventEmitter.cpp
+++ b/ReactCommon/fabric/components/view/TouchEventEmitter.cpp
@@ -15,11 +15,11 @@ namespace react {
 static folly::dynamic touchPayload(const Touch &touch) {
   folly::dynamic object = folly::dynamic::object();
   object["locationX"] = touch.offsetPoint.x;
-  object["locationY"] = touch.offsetPoint.x;
+  object["locationY"] = touch.offsetPoint.y;
   object["pageX"] = touch.pagePoint.x;
-  object["pageY"] = touch.pagePoint.x;
+  object["pageY"] = touch.pagePoint.y;
   object["screenX"] = touch.screenPoint.x;
-  object["screenY"] = touch.screenPoint.x;
+  object["screenY"] = touch.screenPoint.y;
   object["identifier"] = touch.identifier;
   object["target"] = touch.target;
   object["timestamp"] = touch.timestamp * 1000;


### PR DESCRIPTION
This patch fixes the the assignment of Y coordinate information in the event payloads in `TouchEventEmitter`, which were inadvertently being assigned X coordinate data.

Test Plan:
----------
No way to test locally yet.

Changelog:
----------

[General] [Fixed] - Fabric: Fixed Y coordinate data in Touch events
