### PR TITLE
[flow-strict] Flow strict TouchableHighlight

### DIFF
--- a/Libraries/Components/AppleTV/TVViewPropTypes.js
+++ b/Libraries/Components/AppleTV/TVViewPropTypes.js
@@ -10,31 +10,46 @@
 
 'use strict';
 
-type TVParallaxPropertiesType = $ReadOnly<{|
+export type TVParallaxPropertiesType = $ReadOnly<{|
   /**
    * If true, parallax effects are enabled.  Defaults to true.
    */
-  enabled: boolean,
+  enabled?: boolean,
 
   /**
    * Defaults to 2.0.
    */
-  shiftDistanceX: number,
+  shiftDistanceX?: number,
 
   /**
    * Defaults to 2.0.
    */
-  shiftDistanceY: number,
+  shiftDistanceY?: number,
 
   /**
    * Defaults to 0.05.
    */
-  tiltAngle: number,
+  tiltAngle?: number,
 
   /**
    * Defaults to 1.0
    */
-  magnification: number,
+  magnification?: number,
+
+  /**
+   * Defaults to 1.0
+   */
+  pressMagnification?: number,
+
+  /**
+   * Defaults to 0.3
+   */
+  pressDuration?: number,
+
+  /**
+   * Defaults to 0.3
+   */
+  pressDelay?: number,
 |}>;
 
 /**

--- a/Libraries/Components/Touchable/TouchableHighlight.js
+++ b/Libraries/Components/Touchable/TouchableHighlight.js
@@ -28,6 +28,7 @@ import type {PressEvent} from 'CoreEventTypes';
 import type {ViewStyleProp} from 'StyleSheet';
 import type {ColorValue} from 'StyleSheetTypes';
 import type {Props as TouchableWithoutFeedbackProps} from 'TouchableWithoutFeedback';
+import type {TVParallaxPropertiesType} from 'TVViewPropTypes';
 
 const DEFAULT_PROPS = {
   activeOpacity: 0.85,
@@ -39,7 +40,7 @@ const PRESS_RETENTION_OFFSET = {top: 20, left: 20, right: 20, bottom: 30};
 
 type IOSProps = $ReadOnly<{|
   hasTVPreferredFocus?: ?boolean,
-  tvParallaxProperties?: ?Object,
+  tvParallaxProperties?: ?TVParallaxPropertiesType,
 |}>;
 
 type Props = $ReadOnly<{|
@@ -49,8 +50,8 @@ type Props = $ReadOnly<{|
   activeOpacity?: ?number,
   underlayColor?: ?ColorValue,
   style?: ?ViewStyleProp,
-  onShowUnderlay?: ?Function,
-  onHideUnderlay?: ?Function,
+  onShowUnderlay?: ?() => void,
+  onHideUnderlay?: ?() => void,
   testOnly_pressed?: ?boolean,
 |}>;
 
@@ -185,18 +186,7 @@ const TouchableHighlight = ((createReactClass({
      */
     hasTVPreferredFocus: PropTypes.bool,
     /**
-     * *(Apple TV only)* Object with properties to control Apple TV parallax effects.
-     *
-     * enabled: If true, parallax effects are enabled.  Defaults to true.
-     * shiftDistanceX: Defaults to 2.0.
-     * shiftDistanceY: Defaults to 2.0.
-     * tiltAngle: Defaults to 0.05.
-     * magnification: Defaults to 1.0.
-     * pressMagnification: Defaults to 1.0.
-     * pressDuration: Defaults to 0.3.
-     * pressDelay: Defaults to 0.0.
-     *
-     * @platform ios
+     * Apple TV parallax effects
      */
     tvParallaxProperties: PropTypes.object,
     /**


### PR DESCRIPTION
Related to #22100

Enhance Flow types for TouchableOpacity specifying underlay functions and TvParallaxPropertiesType.
I had to export and enhance TvParallaxPropertiesType from TVViewPropTypes file. This does not break this other PR also using this exported type. #22146 

There is still some work to do in order to turn flow to strict mode.

## Test Plan:
- All flow tests succeed.

## Release Notes:
[GENERAL] [ENHANCEMENT] [TouchableHighlight.js] - Flow types
[GENERAL] [ENHANCEMENT] [TVViewPropTypes.js] - Export and enhance type