### PR TITLE
[iOS] Fix cookies not being sent after a redirected response

### DIFF
--- a/Libraries/Network/RCTHTTPRequestHandler.mm
+++ b/Libraries/Network/RCTHTTPRequestHandler.mm
@@ -109,6 +109,21 @@ totalBytesExpectedToSend:(int64_t)totalBytesExpectedToSend
 }
 
 - (void)URLSession:(NSURLSession *)session
+              task:(NSURLSessionTask *)task
+willPerformHTTPRedirection:(NSHTTPURLResponse *)response
+        newRequest:(NSURLRequest *)request
+ completionHandler:(void (^)(NSURLRequest *))completionHandler
+{
+  // Reset the cookies on redirect.
+  // This is necessary because we're not letting iOS handle cookies by itself
+  NSMutableURLRequest *nextRequest = [request mutableCopy];
+
+  NSArray<NSHTTPCookie *> *cookies = [[NSHTTPCookieStorage sharedHTTPCookieStorage] cookiesForURL:request.URL];
+  nextRequest.allHTTPHeaderFields = [NSHTTPCookie requestHeaderFieldsWithCookies:cookies];
+  completionHandler(nextRequest);
+}
+
+- (void)URLSession:(NSURLSession *)session
           dataTask:(NSURLSessionDataTask *)task
 didReceiveResponse:(NSURLResponse *)response
  completionHandler:(void (^)(NSURLSessionResponseDisposition))completionHandler


### PR DESCRIPTION
Fixes https://github.com/facebook/react-native/issues/19376

On iOS, the `HTTPShouldHandleCookies` boolean has no effect when custom cookies are set (see https://developer.apple.com/documentation/foundation/nsmutableurlrequest/1415485-httpshouldhandlecookies?preferredLanguage=occ). Setting custom cookies prevents the cookies of a redirect response from being re-used in the subsequent request.
This is why issue https://github.com/facebook/react-native/issues/19376 is opened.
The fix is to intercept the redirect request, and to manually set the cookies. This effectively makes the Android and iOS behaviours converge.

Changelog:
----------
  [iOS] [Fixed] - Fix cookies not being sent on iOS after redirect