### PR TITLE
Replace global.alert use to fix eslint warnings

### DIFF
--- a/RNTester/js/AccessibilityIOSExample.js
+++ b/RNTester/js/AccessibilityIOSExample.js
@@ -12,18 +12,22 @@
 
 const React = require('react');
 const ReactNative = require('react-native');
-const {AccessibilityInfo, Text, View, TouchableOpacity} = ReactNative;
+const {AccessibilityInfo, Text, View, TouchableOpacity, Alert} = ReactNative;
 
 class AccessibilityIOSExample extends React.Component<{}> {
   render() {
     return (
       <View>
         <View
-          onAccessibilityTap={() => alert('onAccessibilityTap success')}
+          onAccessibilityTap={() =>
+            Alert.alert('Alert', 'onAccessibilityTap success')
+          }
           accessible={true}>
           <Text>Accessibility normal tap example</Text>
         </View>
-        <View onMagicTap={() => alert('onMagicTap success')} accessible={true}>
+        <View
+          onMagicTap={() => Alert.alert('Alert', 'onMagicTap success')}
+          accessible={true}>
           <Text>Accessibility magic tap example</Text>
         </View>
         <View accessibilityLabel="Some announcement" accessible={true}>

--- a/RNTester/js/ActionSheetIOSExample.js
+++ b/RNTester/js/ActionSheetIOSExample.js
@@ -12,7 +12,14 @@
 
 const React = require('react');
 const ReactNative = require('react-native');
-const {ActionSheetIOS, StyleSheet, takeSnapshot, Text, View} = ReactNative;
+const {
+  ActionSheetIOS,
+  StyleSheet,
+  takeSnapshot,
+  Text,
+  View,
+  Alert,
+} = ReactNative;
 
 const BUTTONS = ['Option 0', 'Option 1', 'Option 2', 'Delete', 'Cancel'];
 const DESTRUCTIVE_INDEX = 3;
@@ -106,7 +113,7 @@ class ShareActionSheetExample extends React.Component<
         subject: 'a subject to go in the email heading',
         excludedActivityTypes: ['com.apple.UIKit.activity.PostToTwitter'],
       },
-      error => alert(error),
+      error => Alert.alert('Error', error),
       (completed, method) => {
         let text;
         if (completed) {
@@ -146,7 +153,7 @@ class ShareScreenshotExample extends React.Component<{}, $FlowFixMeState> {
             url: uri,
             excludedActivityTypes: ['com.apple.UIKit.activity.PostToTwitter'],
           },
-          error => alert(error),
+          error => Alert.alert('Error', error),
           (completed, method) => {
             let text;
             if (completed) {
@@ -158,7 +165,7 @@ class ShareScreenshotExample extends React.Component<{}, $FlowFixMeState> {
           },
         );
       })
-      .catch(error => alert(error));
+      .catch(error => Alert.alert('Error', error));
   };
 }
 

--- a/RNTester/js/GeolocationExample.js
+++ b/RNTester/js/GeolocationExample.js
@@ -12,7 +12,7 @@
 
 const React = require('react');
 const ReactNative = require('react-native');
-const {StyleSheet, Text, View} = ReactNative;
+const {StyleSheet, Text, View, Alert} = ReactNative;
 
 exports.framework = 'React';
 exports.title = 'Geolocation';
@@ -41,7 +41,7 @@ class GeolocationExample extends React.Component<{}, $FlowFixMeState> {
         const initialPosition = JSON.stringify(position);
         this.setState({initialPosition});
       },
-      error => alert(JSON.stringify(error)),
+      error => Alert.alert('Error', JSON.stringify(error)),
       {enableHighAccuracy: true, timeout: 20000, maximumAge: 1000},
     );
     this.watchID = navigator.geolocation.watchPosition(position => {

--- a/RNTester/js/MultiColumnExample.js
+++ b/RNTester/js/MultiColumnExample.js
@@ -12,7 +12,7 @@
 
 const React = require('react');
 const ReactNative = require('react-native');
-const {FlatList, StyleSheet, Text, View} = ReactNative;
+const {FlatList, StyleSheet, Text, View, Alert} = ReactNative;
 
 const RNTesterPage = require('./RNTesterPage');
 
@@ -91,7 +91,9 @@ class MultiColumnExample extends React.PureComponent<
           data={filteredData}
           key={this.state.numColumns + (this.state.fixedHeight ? 'f' : 'v')}
           numColumns={this.state.numColumns || 1}
-          onRefresh={() => alert('onRefresh: nothing to refresh :P')}
+          onRefresh={() =>
+            Alert.alert('Alert', 'onRefresh: nothing to refresh :P')
+          }
           refreshing={false}
           renderItem={this._renderItemComponent}
           disableVirtualization={!this.state.virtualized}

--- a/RNTester/js/TextInputExample.ios.js
+++ b/RNTester/js/TextInputExample.ios.js
@@ -14,7 +14,7 @@ const Button = require('Button');
 const InputAccessoryView = require('InputAccessoryView');
 const React = require('react');
 const ReactNative = require('react-native');
-const {Text, TextInput, View, StyleSheet, Slider, Switch} = ReactNative;
+const {Text, TextInput, View, StyleSheet, Slider, Switch, Alert} = ReactNative;
 
 class WithLabel extends React.Component<$FlowFixMeProps> {
   render() {
@@ -862,7 +862,9 @@ exports.examples = [
             returnKeyType="next"
             blurOnSubmit={true}
             multiline={true}
-            onSubmitEditing={event => alert(event.nativeEvent.text)}
+            onSubmitEditing={event =>
+              Alert.alert('Alert', event.nativeEvent.text)
+            }
           />
         </View>
       );

--- a/RNTester/js/TransparentHitTestExample.js
+++ b/RNTester/js/TransparentHitTestExample.js
@@ -12,13 +12,13 @@
 
 const React = require('react');
 const ReactNative = require('react-native');
-const {Text, View, TouchableOpacity} = ReactNative;
+const {Text, View, TouchableOpacity, Alert} = ReactNative;
 
 class TransparentHitTestExample extends React.Component<{}> {
   render() {
     return (
       <View style={{flex: 1}}>
-        <TouchableOpacity onPress={() => alert('Hi!')}>
+        <TouchableOpacity onPress={() => Alert.alert('Alert', 'Hi!')}>
           <Text>HELLO!</Text>
         </TouchableOpacity>
 


### PR DESCRIPTION
Replaces `alert` with `Alert.alert` to fix eslint warnings.

Test Plan:
----------
```
yarn lint
```
Check `no-alert` lint warning displayed.

Changelog:
----------
[INTERNAL] [ENHANCEMENT] - Replace `alert` with `Alert.alert` to fix eslint warning.