### PR TITLE
Update schedule/tracing to scheduler/tracing in comments and logging

### DIFF
--- a/Libraries/Renderer/oss/ReactFabric-dev.js
+++ b/Libraries/Renderer/oss/ReactFabric-dev.js
@@ -13198,12 +13198,12 @@ var warnAboutInvalidUpdates = void 0;
 
 if (enableSchedulerTracing) {
   // Provide explicit error message when production+profiling bundle of e.g. react-dom
-  // is used with production (non-profiling) bundle of schedule/tracing
+  // is used with production (non-profiling) bundle of scheduler/tracing
   invariant(
     tracing.__interactionsRef != null &&
       tracing.__interactionsRef.current != null,
     "It is not supported to run the profiling version of a renderer (for example, `react-dom/profiling`) " +
-      "without also replacing the `schedule/tracing` module with `schedule/tracing-profiling`. " +
+      "without also replacing the `scheduler/tracing` module with `scheduler/tracing-profiling`. " +
       "Your bundler might have a setting for aliasing both modules. " +
       "Learn more at http://fb.me/react-profiling"
   );

--- a/Libraries/Renderer/oss/ReactFabric-profiling.js
+++ b/Libraries/Renderer/oss/ReactFabric-profiling.js
@@ -4755,7 +4755,7 @@ var Dispatcher = { readContext: readContext },
 invariant(
   null != tracing.__interactionsRef &&
     null != tracing.__interactionsRef.current,
-  "It is not supported to run the profiling version of a renderer (for example, `react-dom/profiling`) without also replacing the `schedule/tracing` module with `schedule/tracing-profiling`. Your bundler might have a setting for aliasing both modules. Learn more at http://fb.me/react-profiling"
+  "It is not supported to run the profiling version of a renderer (for example, `react-dom/profiling`) without also replacing the `scheduler/tracing` module with `scheduler/tracing-profiling`. Your bundler might have a setting for aliasing both modules. Learn more at http://fb.me/react-profiling"
 );
 var isWorking = !1,
   nextUnitOfWork = null,

--- a/Libraries/Renderer/oss/ReactNativeRenderer-dev.js
+++ b/Libraries/Renderer/oss/ReactNativeRenderer-dev.js
@@ -13495,12 +13495,12 @@ var warnAboutInvalidUpdates = void 0;
 
 if (enableSchedulerTracing) {
   // Provide explicit error message when production+profiling bundle of e.g. react-dom
-  // is used with production (non-profiling) bundle of schedule/tracing
+  // is used with production (non-profiling) bundle of scheduler/tracing
   invariant(
     tracing.__interactionsRef != null &&
       tracing.__interactionsRef.current != null,
     "It is not supported to run the profiling version of a renderer (for example, `react-dom/profiling`) " +
-      "without also replacing the `schedule/tracing` module with `schedule/tracing-profiling`. " +
+      "without also replacing the `scheduler/tracing` module with `scheduler/tracing-profiling`. " +
       "Your bundler might have a setting for aliasing both modules. " +
       "Learn more at http://fb.me/react-profiling"
   );

--- a/Libraries/Renderer/oss/ReactNativeRenderer-profiling.js
+++ b/Libraries/Renderer/oss/ReactNativeRenderer-profiling.js
@@ -5003,7 +5003,7 @@ var Dispatcher = { readContext: readContext },
 invariant(
   null != tracing.__interactionsRef &&
     null != tracing.__interactionsRef.current,
-  "It is not supported to run the profiling version of a renderer (for example, `react-dom/profiling`) without also replacing the `schedule/tracing` module with `schedule/tracing-profiling`. Your bundler might have a setting for aliasing both modules. Learn more at http://fb.me/react-profiling"
+  "It is not supported to run the profiling version of a renderer (for example, `react-dom/profiling`) without also replacing the `scheduler/tracing` module with `scheduler/tracing-profiling`. Your bundler might have a setting for aliasing both modules. Learn more at http://fb.me/react-profiling"
 );
 var isWorking = !1,
   nextUnitOfWork = null,


### PR DESCRIPTION
The comments and logging about scheduler/tracing were still referencing schedule/tracing. 
This adds the `r`

Test Plan:
----------
ran `yarn lint` and `yarn test`

Changelog:
----------
[General] [Changed] - Updated reference to schedule/tracing to scheduler/tracing in error messages