### PR TITLE
Fix skipped test on local-cli

### DIFF
--- a/local-cli/link/__tests__/ios/addFileToProject.spec.js
+++ b/local-cli/link/__tests__/ios/addFileToProject.spec.js
@@ -24,13 +24,13 @@ describe('ios::addFileToProject', () => {
     project.parseSync();
   });
 
-  xit('should add file to a project', () => {
+  it('should add file to a project', () => {
+    const fileRef = addFileToProject(
+      project,
+      '../../__fixtures__/linearGradient.pbxproj',
+    ).fileRef;
     expect(
-      _.includes(
-        Object.keys(project.pbxFileReferenceSection()),
-        addFileToProject(project, '../../__fixtures__/linearGradient.pbxproj')
-          .fileRef,
-      ),
+      _.includes(Object.keys(project.pbxFileReferenceSection()), fileRef),
     ).toBeTruthy();
   });
 });


### PR DESCRIPTION
Fix skipped test for ios pbxproject helper`addFileToProject`.

Test Plan:
----------
Run:
```
yarn test local-cli/link/__tests__/ios/addFileToProject.spec.js
```

Changelog:
----------
[General] [Fixed] - Fix skipped test for ios pbxproject helper addFileToProject in local-cli
