### PR TITLE
Fixed for supporting mediaPlaybackRequiresUserAction under iOS 10.

### DIFF
--- a/React/Views/RCTWKWebView.m
+++ b/React/Views/RCTWKWebView.m
@@ -76,7 +76,9 @@ static NSString *const MessageHanderName = @"ReactNative";
     wkWebViewConfig.mediaTypesRequiringUserActionForPlayback = _mediaPlaybackRequiresUserAction
       ? WKAudiovisualMediaTypeAll
       : WKAudiovisualMediaTypeNone;
-   wkWebViewConfig.dataDetectorTypes = _dataDetectorTypes;
+    wkWebViewConfig.dataDetectorTypes = _dataDetectorTypes;
+#else
+    wkWebViewConfig.mediaPlaybackRequiresUserAction = _mediaPlaybackRequiresUserAction;
 #endif
 
     _webView = [[WKWebView alloc] initWithFrame:self.bounds configuration: wkWebViewConfig];


### PR DESCRIPTION
There is a problem that the `mediaPlaybackRequiresUserAction` property does not work in WKWebView(`useWebKit`) under iOS 10.

I fully know you are currently working to migrate the core's WebView to the standalone `react-native-webview` project. This has already been submitted to PR in `react-native-webview` and will be merged soon. I hope this fix applies to `react-native` before your migration is done.

Test Plan:
----------
I checked that `mediaPlaybackRequiresUserAction` property works in my service as intended. I think this is a small change that is less likely to cause problems.

Release Notes:
--------------
[IOS] [BUGFIX] [React/Views/RCTWKWebView.m] - Fixed for `mediaPlaybackRequiresUserAction` in WKWebView under iOS 10.
