### PR TITLE
Fixed for supporting flow of AsyncStorage.

### DIFF
--- a/IntegrationTests/AsyncStorageTest.js
+++ b/IntegrationTests/AsyncStorageTest.js
@@ -71,7 +71,6 @@ function testSetAndGet() {
     AsyncStorage.getItem(KEY_1, (err2, result) => {
       expectAsyncNoError('testSetAndGet/getItem', err2);
       expectEqual(result, VAL_1, 'testSetAndGet setItem');
-      expectTrue(result !== null, 'should not be null');
       updateMessage('get(key_1) correctly returned ' + String(result));
       runTestCase('should get null for missing key', testMissingGet);
     });
@@ -106,7 +105,6 @@ function testRemoveItem() {
     AsyncStorage.setItem(KEY_2, VAL_2, () => {
       AsyncStorage.getAllKeys((err, result) => {
         expectAsyncNoError('testRemoveItem/getAllKeys', err);
-        expectTrue(result !== null, 'should not be null');
         expectTrue(
           Array.isArray(result) &&
             result.indexOf(KEY_1) >= 0 &&

--- a/IntegrationTests/AsyncStorageTest.js
+++ b/IntegrationTests/AsyncStorageTest.js
@@ -71,7 +71,8 @@ function testSetAndGet() {
     AsyncStorage.getItem(KEY_1, (err2, result) => {
       expectAsyncNoError('testSetAndGet/getItem', err2);
       expectEqual(result, VAL_1, 'testSetAndGet setItem');
-      updateMessage('get(key_1) correctly returned ' + result);
+      expectTrue(result !== null, 'should not be null');
+      updateMessage('get(key_1) correctly returned ' + String(result));
       runTestCase('should get null for missing key', testMissingGet);
     });
   });
@@ -81,7 +82,8 @@ function testMissingGet() {
   AsyncStorage.getItem(KEY_2, (err, result) => {
     expectAsyncNoError('testMissingGet/setItem', err);
     expectEqual(result, null, 'testMissingGet');
-    updateMessage('missing get(key_2) correctly returned ' + result);
+    expectTrue(result === null, 'should be null');
+    updateMessage('missing get(key_2) correctly returned ' + String(result));
     runTestCase('check set twice results in a single key', testSetTwice);
   });
 }
@@ -104,9 +106,10 @@ function testRemoveItem() {
     AsyncStorage.setItem(KEY_2, VAL_2, () => {
       AsyncStorage.getAllKeys((err, result) => {
         expectAsyncNoError('testRemoveItem/getAllKeys', err);
+        expectTrue(result !== null, 'should not be null');
         expectTrue(
-          result.indexOf(KEY_1) >= 0 && result.indexOf(KEY_2) >= 0,
-          'Missing KEY_1 or KEY_2 in ' + '(' + result + ')',
+          Array.isArray(result) && result.indexOf(KEY_1) >= 0 && result.indexOf(KEY_2) >= 0,
+          'Missing KEY_1 or KEY_2 in ' + '(' + String(result) + ')',
         );
         updateMessage('testRemoveItem - add two items');
         AsyncStorage.removeItem(KEY_1, err2 => {
@@ -122,9 +125,10 @@ function testRemoveItem() {
             updateMessage('key properly removed ');
             AsyncStorage.getAllKeys((err4, result3) => {
               expectAsyncNoError('testRemoveItem/getAllKeys', err4);
+              expectTrue(result3 !== null, 'should not be null');
               expectTrue(
-                result3.indexOf(KEY_1) === -1,
-                'Unexpected: KEY_1 present in ' + result3,
+                Array.isArray(result3) && result3.indexOf(KEY_1) === -1,
+                'Unexpected: KEY_1 present in ' + String(result3),
               );
               updateMessage('proper length returned.');
               runTestCase('should merge values', testMerge);
@@ -143,7 +147,8 @@ function testMerge() {
       expectAsyncNoError('testMerge/mergeItem', err2);
       AsyncStorage.getItem(KEY_MERGE, (err3, result) => {
         expectAsyncNoError('testMerge/setItem', err3);
-        expectEqual(JSON.parse(result), VAL_MERGE_EXPECT, 'testMerge');
+        expectTrue(result !== null, 'should not be null');
+        expectEqual(result && JSON.parse(result), VAL_MERGE_EXPECT, 'testMerge');
         updateMessage('objects deeply merged\nDone!');
         runTestCase('multi set and get', testOptimizedMultiGet);
       });

--- a/IntegrationTests/AsyncStorageTest.js
+++ b/IntegrationTests/AsyncStorageTest.js
@@ -108,7 +108,9 @@ function testRemoveItem() {
         expectAsyncNoError('testRemoveItem/getAllKeys', err);
         expectTrue(result !== null, 'should not be null');
         expectTrue(
-          Array.isArray(result) && result.indexOf(KEY_1) >= 0 && result.indexOf(KEY_2) >= 0,
+          Array.isArray(result) &&
+            result.indexOf(KEY_1) >= 0 &&
+            result.indexOf(KEY_2) >= 0,
           'Missing KEY_1 or KEY_2 in ' + '(' + String(result) + ')',
         );
         updateMessage('testRemoveItem - add two items');
@@ -148,7 +150,11 @@ function testMerge() {
       AsyncStorage.getItem(KEY_MERGE, (err3, result) => {
         expectAsyncNoError('testMerge/setItem', err3);
         expectTrue(result !== null, 'should not be null');
-        expectEqual(result && JSON.parse(result), VAL_MERGE_EXPECT, 'testMerge');
+        expectEqual(
+          result && JSON.parse(result),
+          VAL_MERGE_EXPECT,
+          'testMerge',
+        );
         updateMessage('objects deeply merged\nDone!');
         runTestCase('multi set and get', testOptimizedMultiGet);
       });

--- a/Libraries/Storage/AsyncStorage.js
+++ b/Libraries/Storage/AsyncStorage.js
@@ -53,8 +53,8 @@ const AsyncStorage = {
    */
   getItem: function(
     key: string,
-    callback?: ?(error: ?Error, result: ?string) => void,
-  ): Promise<?string> {
+    callback?: ?(error: ?Error, result: string | null) => void,
+  ): Promise<string | null> {
     return new Promise((resolve, reject) => {
       RCTAsyncStorage.multiGet([key], function(errors, result) {
         // Unpack result to get value from [[key,value]]

--- a/Libraries/Storage/AsyncStorage.js
+++ b/Libraries/Storage/AsyncStorage.js
@@ -5,8 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @noflow
- * @flow-weak
+ * @flow
  * @jsdoc
  */
 
@@ -40,7 +39,7 @@ const AsyncStorage = {
   getItem: function(
     key: string,
     callback?: ?(error: ?Error, result: ?string) => void,
-  ): Promise {
+  ): Promise<any> {
     return new Promise((resolve, reject) => {
       RCTAsyncStorage.multiGet([key], function(errors, result) {
         // Unpack result to get value from [[key,value]]
@@ -65,7 +64,7 @@ const AsyncStorage = {
     key: string,
     value: string,
     callback?: ?(error: ?Error) => void,
-  ): Promise {
+  ): Promise<any> {
     return new Promise((resolve, reject) => {
       RCTAsyncStorage.multiSet([[key, value]], function(errors) {
         const errs = convertErrors(errors);
@@ -87,7 +86,7 @@ const AsyncStorage = {
   removeItem: function(
     key: string,
     callback?: ?(error: ?Error) => void,
-  ): Promise {
+  ): Promise<any> {
     return new Promise((resolve, reject) => {
       RCTAsyncStorage.multiRemove([key], function(errors) {
         const errs = convertErrors(errors);
@@ -113,7 +112,7 @@ const AsyncStorage = {
     key: string,
     value: string,
     callback?: ?(error: ?Error) => void,
-  ): Promise {
+  ): Promise<any> {
     return new Promise((resolve, reject) => {
       RCTAsyncStorage.multiMerge([[key, value]], function(errors) {
         const errs = convertErrors(errors);
@@ -134,7 +133,7 @@ const AsyncStorage = {
    *
    * See http://facebook.github.io/react-native/docs/asyncstorage.html#clear
    */
-  clear: function(callback?: ?(error: ?Error) => void): Promise {
+  clear: function(callback?: ?(error: ?Error) => void): Promise<any> {
     return new Promise((resolve, reject) => {
       RCTAsyncStorage.clear(function(error) {
         callback && callback(convertError(error));
@@ -154,7 +153,7 @@ const AsyncStorage = {
    */
   getAllKeys: function(
     callback?: ?(error: ?Error, keys: ?Array<string>) => void,
-  ): Promise {
+  ): Promise<any> {
     return new Promise((resolve, reject) => {
       RCTAsyncStorage.getAllKeys(function(error, keys) {
         callback && callback(convertError(error), keys);
@@ -223,7 +222,7 @@ const AsyncStorage = {
   multiGet: function(
     keys: Array<string>,
     callback?: ?(errors: ?Array<Error>, result: ?Array<Array<string>>) => void,
-  ): Promise {
+  ): Promise<any> {
     if (!this._immediate) {
       this._immediate = setImmediate(() => {
         this._immediate = null;
@@ -231,7 +230,7 @@ const AsyncStorage = {
       });
     }
 
-    const getRequest = {
+    const getRequest:Object = {
       keys: keys,
       callback: callback,
       // do we need this?
@@ -264,8 +263,8 @@ const AsyncStorage = {
    */
   multiSet: function(
     keyValuePairs: Array<Array<string>>,
-    callback?: ?(errors: ?Array<Error>) => void,
-  ): Promise {
+    callback?: ?(errors: ?Array<?Error>) => void,
+  ): Promise<any> {
     return new Promise((resolve, reject) => {
       RCTAsyncStorage.multiSet(keyValuePairs, function(errors) {
         const error = convertErrors(errors);
@@ -286,8 +285,8 @@ const AsyncStorage = {
    */
   multiRemove: function(
     keys: Array<string>,
-    callback?: ?(errors: ?Array<Error>) => void,
-  ): Promise {
+    callback?: ?(errors: ?Array<?Error>) => void,
+  ): Promise<any> {
     return new Promise((resolve, reject) => {
       RCTAsyncStorage.multiRemove(keys, function(errors) {
         const error = convertErrors(errors);
@@ -311,8 +310,8 @@ const AsyncStorage = {
    */
   multiMerge: function(
     keyValuePairs: Array<Array<string>>,
-    callback?: ?(errors: ?Array<Error>) => void,
-  ): Promise {
+    callback?: ?(errors: ?Array<?Error>) => void,
+  ): Promise<any> {
     return new Promise((resolve, reject) => {
       RCTAsyncStorage.multiMerge(keyValuePairs, function(errors) {
         const error = convertErrors(errors);
@@ -333,19 +332,19 @@ if (!RCTAsyncStorage.multiMerge) {
   delete AsyncStorage.multiMerge;
 }
 
-function convertErrors(errs) {
+function convertErrors(errs):?Array<?Error> {
   if (!errs) {
     return null;
   }
   return (Array.isArray(errs) ? errs : [errs]).map(e => convertError(e));
 }
 
-function convertError(error) {
+function convertError(error):?Error {
   if (!error) {
     return null;
   }
-  const out = new Error(error.message);
-  out.key = error.key; // flow doesn't like this :(
+  const out:Object = new Error(error.message);
+  out.key = error.key;
   return out;
 }
 

--- a/Libraries/Storage/AsyncStorage.js
+++ b/Libraries/Storage/AsyncStorage.js
@@ -19,6 +19,14 @@ const RCTAsyncStorage =
   NativeModules.AsyncSQLiteDBStorage ||
   NativeModules.AsyncLocalStorage;
 
+type MultiRequestType = {|
+  keys: Array<string>,
+  callback: ?(errors: ?Array<Error>, result: ?Array<Array<string>>) => void,
+  keyIndex: number,
+  resolve: ?(result?: Promise<any>) => void,
+  reject: ?(error?: any) => void,
+|};
+
 /**
  * `AsyncStorage` is a simple, unencrypted, asynchronous, persistent, key-value
  * storage system that is global to the app.  It should be used instead of
@@ -27,7 +35,7 @@ const RCTAsyncStorage =
  * See http://facebook.github.io/react-native/docs/asyncstorage.html
  */
 const AsyncStorage = {
-  _getRequests: ([]: Array<any>),
+  _getRequests: ([]: Array<MultiRequestType>),
   _getKeys: ([]: Array<string>),
   _immediate: (null: ?number),
 
@@ -38,8 +46,8 @@ const AsyncStorage = {
    */
   getItem: function(
     key: string,
-    callback?: ?(error: ?Error, result: string|null) => void,
-  ): Promise<string|null> {
+    callback?: ?(error: ?Error, result: ?string) => void,
+  ): Promise<?string> {
     return new Promise((resolve, reject) => {
       RCTAsyncStorage.multiGet([key], function(errors, result) {
         // Unpack result to get value from [[key,value]]
@@ -154,7 +162,7 @@ const AsyncStorage = {
    */
   getAllKeys: function(
     callback?: ?(error: ?Error, keys: ?Array<string>) => void,
-  ): Promise<?Array<string>> {
+  ): Promise<$ReadOnlyArray<string>> {
     return new Promise((resolve, reject) => {
       RCTAsyncStorage.getAllKeys(function(error, keys) {
         const err = convertError(error);
@@ -232,7 +240,7 @@ const AsyncStorage = {
       });
     }
 
-    const getRequest: Object = {
+    const getRequest: MultiRequestType = {
       keys: keys,
       callback: callback,
       // do we need this?
@@ -265,7 +273,7 @@ const AsyncStorage = {
    */
   multiSet: function(
     keyValuePairs: Array<Array<string>>,
-    callback?: ?(errors: ?Array<?Error>) => void,
+    callback?: ?(errors: ?$ReadOnlyArray<?Error>) => void,
   ): Promise<null> {
     return new Promise((resolve, reject) => {
       RCTAsyncStorage.multiSet(keyValuePairs, function(errors) {
@@ -287,7 +295,7 @@ const AsyncStorage = {
    */
   multiRemove: function(
     keys: Array<string>,
-    callback?: ?(errors: ?Array<?Error>) => void,
+    callback?: ?(errors: ?$ReadOnlyArray<?Error>) => void,
   ): Promise<null> {
     return new Promise((resolve, reject) => {
       RCTAsyncStorage.multiRemove(keys, function(errors) {
@@ -312,7 +320,7 @@ const AsyncStorage = {
    */
   multiMerge: function(
     keyValuePairs: Array<Array<string>>,
-    callback?: ?(errors: ?Array<?Error>) => void,
+    callback?: ?(errors: ?$ReadOnlyArray<?Error>) => void,
   ): Promise<null> {
     return new Promise((resolve, reject) => {
       RCTAsyncStorage.multiMerge(keyValuePairs, function(errors) {
@@ -334,7 +342,7 @@ if (!RCTAsyncStorage.multiMerge) {
   delete AsyncStorage.multiMerge;
 }
 
-function convertErrors(errs): ?Array<?Error> {
+function convertErrors(errs): ?$ReadOnlyArray<?Error> {
   if (!errs) {
     return null;
   }

--- a/Libraries/Storage/AsyncStorage.js
+++ b/Libraries/Storage/AsyncStorage.js
@@ -38,8 +38,8 @@ const AsyncStorage = {
    */
   getItem: function(
     key: string,
-    callback?: ?(error: ?Error, result: ?string) => void,
-  ): Promise<any> {
+    callback?: ?(error: ?Error, result: string|null) => void,
+  ): Promise<string|null> {
     return new Promise((resolve, reject) => {
       RCTAsyncStorage.multiGet([key], function(errors, result) {
         // Unpack result to get value from [[key,value]]
@@ -64,7 +64,7 @@ const AsyncStorage = {
     key: string,
     value: string,
     callback?: ?(error: ?Error) => void,
-  ): Promise<any> {
+  ): Promise<null> {
     return new Promise((resolve, reject) => {
       RCTAsyncStorage.multiSet([[key, value]], function(errors) {
         const errs = convertErrors(errors);
@@ -86,7 +86,7 @@ const AsyncStorage = {
   removeItem: function(
     key: string,
     callback?: ?(error: ?Error) => void,
-  ): Promise<any> {
+  ): Promise<null> {
     return new Promise((resolve, reject) => {
       RCTAsyncStorage.multiRemove([key], function(errors) {
         const errs = convertErrors(errors);
@@ -112,7 +112,7 @@ const AsyncStorage = {
     key: string,
     value: string,
     callback?: ?(error: ?Error) => void,
-  ): Promise<any> {
+  ): Promise<null> {
     return new Promise((resolve, reject) => {
       RCTAsyncStorage.multiMerge([[key, value]], function(errors) {
         const errs = convertErrors(errors);
@@ -133,12 +133,13 @@ const AsyncStorage = {
    *
    * See http://facebook.github.io/react-native/docs/asyncstorage.html#clear
    */
-  clear: function(callback?: ?(error: ?Error) => void): Promise<any> {
+  clear: function(callback?: ?(error: ?Error) => void): Promise<null> {
     return new Promise((resolve, reject) => {
       RCTAsyncStorage.clear(function(error) {
-        callback && callback(convertError(error));
-        if (error && convertError(error)) {
-          reject(convertError(error));
+        const err = convertError(error);
+        callback && callback(err);
+        if (err) {
+          reject(err);
         } else {
           resolve(null);
         }
@@ -153,12 +154,13 @@ const AsyncStorage = {
    */
   getAllKeys: function(
     callback?: ?(error: ?Error, keys: ?Array<string>) => void,
-  ): Promise<any> {
+  ): Promise<?Array<string>> {
     return new Promise((resolve, reject) => {
       RCTAsyncStorage.getAllKeys(function(error, keys) {
-        callback && callback(convertError(error), keys);
-        if (error) {
-          reject(convertError(error));
+        const err = convertError(error);
+        callback && callback(err, keys);
+        if (err) {
+          reject(err);
         } else {
           resolve(keys);
         }
@@ -222,7 +224,7 @@ const AsyncStorage = {
   multiGet: function(
     keys: Array<string>,
     callback?: ?(errors: ?Array<Error>, result: ?Array<Array<string>>) => void,
-  ): Promise<any> {
+  ): Promise<?Array<Array<string>>> {
     if (!this._immediate) {
       this._immediate = setImmediate(() => {
         this._immediate = null;
@@ -264,7 +266,7 @@ const AsyncStorage = {
   multiSet: function(
     keyValuePairs: Array<Array<string>>,
     callback?: ?(errors: ?Array<?Error>) => void,
-  ): Promise<any> {
+  ): Promise<null> {
     return new Promise((resolve, reject) => {
       RCTAsyncStorage.multiSet(keyValuePairs, function(errors) {
         const error = convertErrors(errors);
@@ -286,7 +288,7 @@ const AsyncStorage = {
   multiRemove: function(
     keys: Array<string>,
     callback?: ?(errors: ?Array<?Error>) => void,
-  ): Promise<any> {
+  ): Promise<null> {
     return new Promise((resolve, reject) => {
       RCTAsyncStorage.multiRemove(keys, function(errors) {
         const error = convertErrors(errors);
@@ -311,7 +313,7 @@ const AsyncStorage = {
   multiMerge: function(
     keyValuePairs: Array<Array<string>>,
     callback?: ?(errors: ?Array<?Error>) => void,
-  ): Promise<any> {
+  ): Promise<null> {
     return new Promise((resolve, reject) => {
       RCTAsyncStorage.multiMerge(keyValuePairs, function(errors) {
         const error = convertErrors(errors);
@@ -343,7 +345,8 @@ function convertError(error): ?Error {
   if (!error) {
     return null;
   }
-  const out: Object = new Error(error.message);
+  const out = new Error(error.message);
+  // $FlowFixMe: adding custom properties to error.
   out.key = error.key;
   return out;
 }

--- a/Libraries/Storage/AsyncStorage.js
+++ b/Libraries/Storage/AsyncStorage.js
@@ -230,7 +230,7 @@ const AsyncStorage = {
       });
     }
 
-    const getRequest:Object = {
+    const getRequest: Object = {
       keys: keys,
       callback: callback,
       // do we need this?
@@ -332,18 +332,18 @@ if (!RCTAsyncStorage.multiMerge) {
   delete AsyncStorage.multiMerge;
 }
 
-function convertErrors(errs):?Array<?Error> {
+function convertErrors(errs): ?Array<?Error> {
   if (!errs) {
     return null;
   }
   return (Array.isArray(errs) ? errs : [errs]).map(e => convertError(e));
 }
 
-function convertError(error):?Error {
+function convertError(error): ?Error {
   if (!error) {
     return null;
   }
-  const out:Object = new Error(error.message);
+  const out: Object = new Error(error.message);
   out.key = error.key;
   return out;
 }

--- a/RNTester/js/AsyncStorageExample.js
+++ b/RNTester/js/AsyncStorageExample.js
@@ -31,7 +31,7 @@ class BasicStorageExample extends React.Component<{}, $FlowFixMeState> {
   _loadInitialState = async () => {
     try {
       const value = await AsyncStorage.getItem(STORAGE_KEY);
-      if (value !== null) {
+      if (value) {
         this.setState({selectedValue: value});
         this._appendMessage('Recovered selection from disk: ' + value);
       } else {

--- a/RNTester/js/AsyncStorageExample.js
+++ b/RNTester/js/AsyncStorageExample.js
@@ -31,7 +31,7 @@ class BasicStorageExample extends React.Component<{}, $FlowFixMeState> {
   _loadInitialState = async () => {
     try {
       const value = await AsyncStorage.getItem(STORAGE_KEY);
-      if (value) {
+      if (value !== null) {
         this.setState({selectedValue: value});
         this._appendMessage('Recovered selection from disk: ' + value);
       } else {


### PR DESCRIPTION
As you know, `AsyncStorage` does not support flow. This is a little inconvenient when developing.

I hope this helps.

Test Plan:
----------
- [x] Check npm run flow
- [x] Check npm run flow-check-ios
- [x] Check npm run flow-check-android

Release Notes:
----------
[GENERAL] [ENHANCEMENT] [Libraries/Storage/AsyncStorage.js] - support flow
