### PR TITLE
resizeMode applies to Image.defaultSource

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageView.java
@@ -439,7 +439,7 @@ public class ReactImageView extends GenericDraweeView {
     hierarchy.setActualImageScaleType(mScaleType);
 
     if (mDefaultImageDrawable != null) {
-      hierarchy.setPlaceholderImage(mDefaultImageDrawable, ScalingUtils.ScaleType.CENTER);
+      hierarchy.setPlaceholderImage(mDefaultImageDrawable, ScalingUtils.ScaleType.FIT_CENTER);
     }
 
     if (mLoadingImageDrawable != null) {

--- a/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageView.java
@@ -439,7 +439,7 @@ public class ReactImageView extends GenericDraweeView {
     hierarchy.setActualImageScaleType(mScaleType);
 
     if (mDefaultImageDrawable != null) {
-      hierarchy.setPlaceholderImage(mDefaultImageDrawable, ScalingUtils.ScaleType.FIT_CENTER);
+      hierarchy.setPlaceholderImage(mDefaultImageDrawable, mScaleType);
     }
 
     if (mLoadingImageDrawable != null) {


### PR DESCRIPTION
resizeMode applies to Image.defaultSource, because depending on screen resolution sometimes we see padding around defaultSource image while source loading. Now we can control scale of both source and defaultSource.

Changelog:
----------
[Android] [Fixed] - Image.resizeMode will apply to defaultSource, enhanced user experience. Previously, resizeMode didn't applied to defaultSource, therefore depending on screen resolution sometimes we see padding around defaultSource image while source loading.