### PR TITLE
TextInput: Remove use of legacy context API

### DIFF
--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -12,7 +12,6 @@
 const DeprecatedColorPropType = require('DeprecatedColorPropType');
 const DeprecatedViewPropTypes = require('DeprecatedViewPropTypes');
 const DocumentSelectionState = require('DocumentSelectionState');
-const EventEmitter = require('EventEmitter');
 const NativeMethodsMixin = require('NativeMethodsMixin');
 const Platform = require('Platform');
 const PropTypes = require('prop-types');
@@ -827,26 +826,6 @@ const TextInput = createReactClass({
       // tag is null only in unit tests
       TextInputState.registerInput(tag);
     }
-
-    if (this.context.focusEmitter) {
-      this._focusSubscription = this.context.focusEmitter.addListener(
-        'focus',
-        el => {
-          if (this === el) {
-            this._rafId = requestAnimationFrame(this.focus);
-          } else if (this.isFocused()) {
-            this.blur();
-          }
-        },
-      );
-      if (this.props.autoFocus) {
-        this.context.onFocusRequested(this);
-      }
-    } else {
-      if (this.props.autoFocus) {
-        this._rafId = requestAnimationFrame(this.focus);
-      }
-    }
   },
 
   componentWillUnmount: function() {
@@ -861,11 +840,6 @@ const TextInput = createReactClass({
     if (this._rafId != null) {
       cancelAnimationFrame(this._rafId);
     }
-  },
-
-  contextTypes: {
-    onFocusRequested: PropTypes.func,
-    focusEmitter: PropTypes.instanceOf(EventEmitter),
   },
 
   /**


### PR DESCRIPTION
This removes the use of the legacy context API in `TextInput`.

Nothing in OSS appears to make use of the `focusEmitter`.

Test Plan:
----------
Flow and ESLint has been ran. No regressions have been noticed in RNTester

Changelog:
----------

[General] [Removed] - TextInput: Removed use of legacy context API
