### PR TITLE
UITemplateProcessor: Fix case of include path

### DIFF
--- a/ReactCommon/fabric/uimanager/UITemplateProcessor.cpp
+++ b/ReactCommon/fabric/uimanager/UITemplateProcessor.cpp
@@ -14,7 +14,7 @@
 #include <react/components/view/ViewShadowNode.h>
 #include <react/core/LayoutContext.h>
 #include <react/core/ShadowNodeFragment.h>
-#include <react/core/componentDescriptor.h>
+#include <react/core/ComponentDescriptor.h>
 #include <react/debug/DebugStringConvertible.h>
 #include <react/debug/DebugStringConvertibleItem.h>
 


### PR DESCRIPTION
This pull request fixes a path name to be a proper case in `UITemplateProcessor`, which fixes this build warning:

```
{snip}/react/uimanager/UITemplateProcessor.cpp:17:10: warning: non-portable path to file '<react/core/ComponentDescriptor.h>';
      specified path differs in case from file name on disk [-Wnonportable-include-path]
#include <react/core/componentDescriptor.h>
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         <react/core/ComponentDescriptor.h>
1 warning generated.
```

Test Plan:
----------
This warning is no longer produced when building this file

Changelog:
----------

[GENERAL] [Fixed] - Fabric: Fixed case of include path in `UITemplateProcessor`
