### PR TITLE
WebView:IOS Fix scalesPagesToFit while using loader

### DIFF
--- a/Libraries/Components/WebView/WebView.ios.js
+++ b/Libraries/Components/WebView/WebView.ios.js
@@ -404,6 +404,7 @@ class WebView extends React.Component {
 
   static defaultProps = {
     originWhitelist: WebViewShared.defaultOriginWhitelist,
+    scalesPageToFit: true,
   };
 
   state = {


### PR DESCRIPTION
Summary:
This fixes #2087

scalesPageToFit is enabled by default for Android
which is somehow not the same for IOS. So while using
webView with Loader and startInLoadingState, it renders
the page un-scaled, which is inconsistent.

It renders scaled pages if we pass scalesPageToFit explicitly
to the webView, but we should have same defaults across Android
and IOS unless there's a very strong reason not to be consistent