### PR TITLE
Fix regression in StyleSheet.setStyleAttributePreprocessor

### DIFF
--- a/Libraries/StyleSheet/StyleSheet.js
+++ b/Libraries/StyleSheet/StyleSheet.js
@@ -339,7 +339,7 @@ module.exports = {
   ) {
     let value;
 
-    if (typeof ReactNativeStyleAttributes[property] === 'string') {
+    if (typeof ReactNativeStyleAttributes[property] === true) {
       value = {};
     } else if (typeof ReactNativeStyleAttributes[property] === 'object') {
       value = ReactNativeStyleAttributes[property];

--- a/Libraries/StyleSheet/StyleSheet.js
+++ b/Libraries/StyleSheet/StyleSheet.js
@@ -339,7 +339,7 @@ module.exports = {
   ) {
     let value;
 
-    if (typeof ReactNativeStyleAttributes[property] === true) {
+    if (ReactNativeStyleAttributes[property] === true) {
       value = {};
     } else if (typeof ReactNativeStyleAttributes[property] === 'object') {
       value = ReactNativeStyleAttributes[property];


### PR DESCRIPTION
This regression was caused by 199c918 - property values are initialized to true rather than a string that matches the property name now.

Test Plan:
----------
- Expo depends on `StyleSheet.setStyleAttributePreprocessor` in order to map fontFamily names to internal unique ids that represent the font families in our asset system: https://github.com/expo/expo/blob/0c238c1b66e649ed8c90993164e850459f310b95/packages/expo/src/launch/registerRootComponent.tsx#L24
- It's easy to test this with an identity function: `StyleSheet.setStyleAttributePreprocessor('fontFamily', name => name);` - this will result in the following error:

```
fontFamily is not a valid style attribute
- node_modules/react-native/Libraries/StyleSheet/StyleSheet.js:347:23 in setStyleAttributePreprocessor
```

With this patch, this error is resolved.

Changelog:
----------
- [General] [Fixed] - Update StyleSheet.setStyleAttributePreprocessor for new format of ReactNativeStyleAttributes.