### PR TITLE
Fixing easing support on React Native Animated

### DIFF
--- a/Libraries/Animated/src/NativeAnimatedHelper.js
+++ b/Libraries/Animated/src/NativeAnimatedHelper.js
@@ -179,6 +179,7 @@ const TRANSFORM_WHITELIST = {
 const SUPPORTED_INTERPOLATION_PARAMS = {
   inputRange: true,
   outputRange: true,
+  easing: true,
   extrapolate: true,
   extrapolateRight: true,
   extrapolateLeft: true,


### PR DESCRIPTION
Fixing easing support on React Native Animated

Test Plan:
----------
By interpolating an AnimatedValue, documentation says easing could be configured, but instead I'm getting "Error: Interpolation property 'easing' is not supported by native animated module".

Changelog:
----------
[General][Fixed] - Support 'easing' as configuration option for Animated.Value
