### PR TITLE
default hitSlop values to 0

### DIFF
--- a/Libraries/Components/Touchable/Touchable.js
+++ b/Libraries/Components/Touchable/Touchable.js
@@ -481,10 +481,10 @@ const TouchableMixin = {
       : null;
 
     if (hitSlop) {
-      pressExpandLeft += hitSlop.left;
-      pressExpandTop += hitSlop.top;
-      pressExpandRight += hitSlop.right;
-      pressExpandBottom += hitSlop.bottom;
+      pressExpandLeft += hitSlop.left || 0;
+      pressExpandTop += hitSlop.top || 0;
+      pressExpandRight += hitSlop.right || 0;
+      pressExpandBottom += hitSlop.bottom || 0;
     }
 
     const touch = TouchEventUtils.extractSingleTouch(e.nativeEvent);


### PR DESCRIPTION
## Motiviation

Experienced a `TouchableOpacity` releasing the `PanResponder` without invoking `onPress` due to a missing a direction key in the `hitSlop` prop; The missing key caused the corresponding pressExpand to become NaN which causes `isTouchWithinActive` to become falsey, when it should be truthy.

If defaulting to 0 is undesired behavior, I'm happy to take a different approach.

Test Plan:
----------
Used local version of react-native within the application as well as running existing test suite.

New tests don't seem necessary based on the added code.

Changelog:
----------
[General] [Fixed] - Fix unexpected responder release by defaulting hitSlop object values to 0 within touchableHandleResponderMove