### PR TITLE
replace `propTypes` with `type Props` from Libraries/Components/WebView/WebView.ios.js.

### DIFF
--- a/Libraries/Components/WebView/WebView.ios.js
+++ b/Libraries/Components/WebView/WebView.ios.js
@@ -723,16 +723,8 @@ class WebView extends React.Component<Props, State> {
   }
 }
 
-const RCTWebView = requireNativeComponent(
-  'RCTWebView',
-  WebView,
-  WebView.extraNativeComponentConfig,
-);
-const RCTWKWebView = requireNativeComponent(
-  'RCTWKWebView',
-  WebView,
-  WebView.extraNativeComponentConfig,
-);
+const RCTWebView = requireNativeComponent('RCTWebView');
+const RCTWKWebView = requireNativeComponent('RCTWKWebView');
 
 const styles = StyleSheet.create({
   container: {

--- a/Libraries/Components/WebView/WebViewShared.js
+++ b/Libraries/Components/WebView/WebViewShared.js
@@ -14,6 +14,7 @@ const escapeStringRegexp = require('escape-string-regexp');
 
 const WebViewShared = {
   defaultOriginWhitelist: ['http://*', 'https://*'],
+  decelerationRate: 'fast',
   extractOrigin: (url: string): ?string => {
     const result = /^[A-Za-z0-9]+:(\/\/)?[^/]*/.exec(url);
     return result === null ? null : result[0];


### PR DESCRIPTION
Fixes #22205.

I tried "Strengthening Flow Types for Core Components #22100".
But there is `propTypes` on Libraries/Components/WebView/WebView.ios.js.
I think, `propTypes` should be removed before trying to strengthening Flow Types.
So this PR replace `propTypes` with `type Props`.

Test Plan:
- [x] npm run test
- [x] npm run prettier
- [x] npm run flow-check-ios
- [x] npm run flow-check-android
- [x] npm run flow

Changelog:
- replace PropTypes with type Props
- avoid to pass unused args to `requireNativeComponent`