### PR TITLE
WIP add type for functions

### DIFF
--- a/Libraries/Components/Touchable/TouchableWithoutFeedback.js
+++ b/Libraries/Components/Touchable/TouchableWithoutFeedback.js
@@ -26,7 +26,7 @@ const {
   DeprecatedAccessibilityTraits,
 } = require('DeprecatedViewAccessibility');
 
-import type {PressEvent} from 'CoreEventTypes';
+import type {PressEvent, LayoutEvent} from 'CoreEventTypes';
 import type {EdgeInsetsProp} from 'EdgeInsetsPropType';
 import type {
   AccessibilityComponentType,
@@ -58,13 +58,13 @@ export type Props = $ReadOnly<{|
   disabled?: ?boolean,
   hitSlop?: ?EdgeInsetsProp,
   nativeID?: ?string,
-  onBlur?: ?Function,
-  onFocus?: ?Function,
-  onLayout?: ?Function,
-  onLongPress?: ?Function,
-  onPress?: ?Function,
-  onPressIn?: ?Function,
-  onPressOut?: ?Function,
+  onBlur?: ?() => mixed,
+  onFocus?: ?() => mixed,
+  onLayout?: ?(event: LayoutEvent) => mixed,
+  onLongPress?: ?(event: PressEvent) => mixed,
+  onPress?: ?(event: PressEvent) => mixed,
+  onPressIn?: ?(event: PressEvent) => mixed,
+  onPressOut?: ?(event: PressEvent) => mixed,
   pressRetentionOffset?: ?EdgeInsetsProp,
   rejectResponderTermination?: ?boolean,
   testID?: ?string,


### PR DESCRIPTION
Related to #22100
This PR is work in progress.

@MengjueW 
Hello! I'm trying to enhance flowtypes for TouchableWithoutFeedback.
And I think `_linearTap` has problem now... onPress would pass only 1 argument but this function requires `refName` as the first argument and `e` as the second. I tried to fix this but I don't know the purpose of this file and don't know the specification... Could you please advice for me??

https://github.com/facebook/react-native/blob/06c13b3e066636b414f5dc19c919dcb138763c71/RNTester/js/RTLExample.js#L529-L544