### PR TITLE
Remove trailing slash from origin header if no port is specified

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/modules/websocket/WebSocketModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/websocket/WebSocketModule.java
@@ -357,7 +357,7 @@ public final class WebSocketModule extends ReactContextBaseJavaModule {
           requestURI.getHost(),
           requestURI.getPort());
       } else {
-        defaultOrigin = String.format("%s://%s/", scheme, requestURI.getHost());
+        defaultOrigin = String.format("%s://%s", scheme, requestURI.getHost());
       }
 
       return defaultOrigin;


### PR DESCRIPTION
Fixes #16304

The standard format for origin HTTP headers does not allow a trailing slash. In order to not get warnings when connecting a websocket, I removed the trailing slash when generating the default origin HTTP header for the websocket connect request.

Release Notes:
----------
[Android] [Fixed] - Fixed default origin header for websocket connections to match the standard format (https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Origin) in WebSocketModule