### PR TITLE
Android: Adding sendIntent on Linking module

### DIFF
--- a/Libraries/Linking/Linking.js
+++ b/Libraries/Linking/Linking.js
@@ -81,6 +81,20 @@ class Linking extends NativeEventEmitter {
     return LinkingManager.getInitialURL();
   }
 
+  /*
+  * Launch an Android intent with extras (optional)
+  *
+  * @platform android
+  *
+  * See https://facebook.github.io/react-native/docs/linking.html#sendintent
+  */
+  sendIntent(
+    action: String,
+    extras?: [{key: string, value: string | number | boolean}],
+  ) {
+    return LinkingManager.sendIntent(action, extras);
+  }
+
   _validateURL(url: string) {
     invariant(
       typeof url === 'string',

--- a/RNTester/js/LinkingExample.js
+++ b/RNTester/js/LinkingExample.js
@@ -12,9 +12,11 @@
 const React = require('react');
 const {
   Linking,
+  Platform,
   StyleSheet,
   Text,
   TouchableOpacity,
+  ToastAndroid,
   View,
 } = require('react-native');
 
@@ -46,20 +48,56 @@ class OpenURLButton extends React.Component<Props> {
   }
 }
 
+class SendIntentButton extends React.Component<Props> {
+  handleIntent = async () => {
+    try {
+      await Linking.sendIntent(this.props.action, this.props.extras);
+    } catch (e) {
+      ToastAndroid.show(e.message, ToastAndroid.LONG);
+    }
+  };
+
+  render() {
+    return (
+      <TouchableOpacity onPress={this.handleIntent}>
+        <View style={[styles.button, styles.buttonIntent]}>
+          <Text style={styles.text}>{this.props.action}</Text>
+        </View>
+      </TouchableOpacity>
+    );
+  }
+}
+
 class IntentAndroidExample extends React.Component {
   static title = 'Linking';
   static description = 'Shows how to use Linking to open URLs.';
 
   render() {
     return (
-      <RNTesterBlock title="Open external URLs">
-        <OpenURLButton url={'https://www.facebook.com'} />
-        <OpenURLButton url={'http://www.facebook.com'} />
-        <OpenURLButton url={'http://facebook.com'} />
-        <OpenURLButton url={'fb://notifications'} />
-        <OpenURLButton url={'geo:37.484847,-122.148386'} />
-        <OpenURLButton url={'tel:9876543210'} />
-      </RNTesterBlock>
+      <View>
+        <RNTesterBlock title="Open external URLs">
+          <OpenURLButton url={'https://www.facebook.com'} />
+          <OpenURLButton url={'http://www.facebook.com'} />
+          <OpenURLButton url={'http://facebook.com'} />
+          <OpenURLButton url={'fb://notifications'} />
+          <OpenURLButton url={'geo:37.484847,-122.148386'} />
+          <OpenURLButton url={'tel:9876543210'} />
+        </RNTesterBlock>
+        {Platform.OS === 'android' && (
+          <RNTesterBlock title="Send intents">
+            <SendIntentButton action="android.intent.action.POWER_USAGE_SUMMARY" />
+            <Text style={styles.textSeparator}>
+              Next one will crash if Facebook app is not installed.
+            </Text>
+            <SendIntentButton
+              action="android.settings.APP_NOTIFICATION_SETTINGS"
+              extras={[
+                {'android.provider.extra.APP_PACKAGE': 'com.facebook.katana'},
+              ]}
+            />
+          </RNTesterBlock>
+        )}
+      </View>
     );
   }
 }
@@ -70,8 +108,14 @@ const styles = StyleSheet.create({
     backgroundColor: '#3B5998',
     marginBottom: 10,
   },
+  buttonIntent: {
+    backgroundColor: '#009688',
+  },
   text: {
     color: 'white',
+  },
+  textSeparator: {
+    paddingBottom: 8,
   },
 });
 

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/intent/IntentModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/intent/IntentModule.java
@@ -10,6 +10,7 @@ package com.facebook.react.modules.intent;
 import android.app.Activity;
 import android.content.ComponentName;
 import android.content.Intent;
+import android.content.pm.PackageManager;
 import android.net.Uri;
 
 import com.facebook.react.bridge.JSApplicationIllegalArgumentException;
@@ -17,7 +18,12 @@ import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
+import com.facebook.react.bridge.ReadableArray;
+import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.bridge.ReadableType;
 import com.facebook.react.module.annotations.ReactModule;
+
+import javax.annotation.Nullable;
 
 /**
  * Intent module. Launch other activities or open URLs.
@@ -132,5 +138,68 @@ public class IntentModule extends ReactContextBaseJavaModule {
       promise.reject(new JSApplicationIllegalArgumentException(
           "Could not check if URL '" + url + "' can be opened: " + e.getMessage()));
     }
+  }
+
+  /**
+   * Allows to send intents on Android
+   * 
+   * For example, you can open the Notification Category screen for a specific application
+   * passing action = 'android.settings.CHANNEL_NOTIFICATION_SETTINGS'
+   * and extras = [
+   * { 'android.provider.extra.APP_PACKAGE': 'your.package.name.here' },
+   * { 'android.provider.extra.CHANNEL_ID': 'your.channel.id.here }
+   * ]
+   *
+   * @param action The general action to be performed
+   * @param extras An array of extras [{ String, String | Number | Boolean }]
+   */
+  @ReactMethod
+  public void sendIntent(String action, @Nullable ReadableArray extras, Promise promise) {
+    if (action == null || action.isEmpty()) {
+      promise.reject(new JSApplicationIllegalArgumentException("Invalid Action: " + action + "."));
+      return;
+    }
+
+    Intent intent = new Intent(action);
+
+    PackageManager packageManager = getReactApplicationContext().getPackageManager();
+    if (intent.resolveActivity(packageManager) == null) {
+      promise.reject(new JSApplicationIllegalArgumentException("Could not launch Intent with action " + action + "."));
+      return;
+    }
+
+    if (extras != null) {
+      for (int i = 0; i < extras.size(); i++) {
+        ReadableMap map = extras.getMap(i);
+        String name = map.keySetIterator().nextKey();
+        ReadableType type = map.getType(name);
+
+        switch (type) {
+          case String: {
+            intent.putExtra(name, map.getString(name));
+            break;
+          }
+          case Number: {
+            // We cannot know from JS if is an Integer or Double
+            // See: https://github.com/facebook/react-native/issues/4141
+            // We might need to find a workaround if this is really an issue
+            Double number = map.getDouble(name);
+            intent.putExtra(name, number);
+            break;
+          }
+          case Boolean: {
+            intent.putExtra(name, map.getBoolean(name));
+            break;
+          }
+          default: {
+            promise.reject(new JSApplicationIllegalArgumentException(
+                "Extra type for " + name + " not supported."));
+            return;
+          }
+        }
+      }
+    }
+
+    getReactApplicationContext().startActivity(intent);
   }
 }

--- a/jest/setup.js
+++ b/jest/setup.js
@@ -171,6 +171,7 @@ const mockNativeModules = {
     addEventListener: jest.fn(),
     getInitialURL: jest.fn(() => Promise.resolve()),
     removeEventListener: jest.fn(),
+    sendIntent: jest.fn(),
   },
   LocationObserver: {
     getCurrentPosition: jest.fn(),


### PR DESCRIPTION
This PR implements "Add a standardized way to send intents on Android" discussed in https://github.com/react-native-community/discussions-and-proposals/issues/34.

Test Plan:
----------
Linking section of RNTester on Android (on iOS that part should not be there). See:

| Battery        | Facebook notifications           | 
| ------------- |:-------------:| 
| ![battery](https://user-images.githubusercontent.com/774577/48572338-7dd6b280-e909-11e8-94f9-99971a8a0233.gif) | ![facebook](https://user-images.githubusercontent.com/774577/48572348-85965700-e909-11e8-960d-f2aedffc59a5.gif)

Changelog:
----------
[Android] [Added] - Add `sendIntent` to Linking module