### PR TITLE
[VirtualizedList] Fix viewability calculation to include viewport offset

### DIFF
--- a/Libraries/Lists/ViewabilityHelper.js
+++ b/Libraries/Lists/ViewabilityHelper.js
@@ -97,6 +97,7 @@ class ViewabilityHelper {
   computeViewableItems(
     itemCount: number,
     scrollOffset: number,
+    viewportOffset: number,
     viewportHeight: number,
     getFrameMetrics: (index: number) => ?{length: number, offset: number},
     renderRange?: {first: number, last: number}, // Optional optimization to reduce the scan size
@@ -130,7 +131,7 @@ class ViewabilityHelper {
       if (!metrics) {
         continue;
       }
-      const top = metrics.offset - scrollOffset;
+      const top = metrics.offset - scrollOffset - viewportOffset;
       const bottom = top + metrics.length;
       if (top < viewportHeight && bottom > 0) {
         firstVisible = idx;
@@ -160,6 +161,7 @@ class ViewabilityHelper {
   onUpdate(
     itemCount: number,
     scrollOffset: number,
+    viewportOffset: number,
     viewportHeight: number,
     getFrameMetrics: (index: number) => ?{length: number, offset: number},
     createViewToken: (index: number, isViewable: boolean) => ViewToken,
@@ -181,6 +183,7 @@ class ViewabilityHelper {
       viewableIndices = this.computeViewableItems(
         itemCount,
         scrollOffset,
+        viewportOffset,
         viewportHeight,
         getFrameMetrics,
         renderRange,

--- a/Libraries/Lists/VirtualizedList.js
+++ b/Libraries/Lists/VirtualizedList.js
@@ -1014,6 +1014,7 @@ class VirtualizedList extends React.PureComponent<Props, State> {
   _totalCellsMeasured = 0;
   _updateCellsToRenderBatcher: Batchinator;
   _viewabilityTuples: Array<ViewabilityHelperCallbackTuple> = [];
+  _viewportOffset: number = 0;
 
   _captureScrollRef = ref => {
     this._scrollRef = ref;
@@ -1064,6 +1065,9 @@ class VirtualizedList extends React.PureComponent<Props, State> {
 
   _onCellLayout(e, cellKey, index) {
     const layout = e.nativeEvent.layout;
+    if (index === 0) {
+      this._viewportOffset = this._selectOffset(layout);
+    }
     const next = {
       offset: this._selectOffset(layout),
       length: this._selectLength(layout),
@@ -1606,6 +1610,7 @@ class VirtualizedList extends React.PureComponent<Props, State> {
       tuple.viewabilityHelper.onUpdate(
         getItemCount(data),
         this._scrollMetrics.offset,
+        this._viewportOffset,
         this._scrollMetrics.visibleLength,
         this._getFrameMetrics,
         this._createViewToken,


### PR DESCRIPTION
Test Plan:
----------
Tested on the home vrshell panel of ovrsource, which renders the scroll view at ~(172, 800) instead of (0,0), and saw that the viewable items passed to onViewableItemsChanged was the correct items, as opposed to a small subset of those items, given that previously the ViewabilityHelper was not factoring in the scrollview position into the viewability calculation.

Changelog:
----------

[General] [Fixed] - Add viewportOffset class property and use it to fix viewability calculation

-->