### PR TITLE
Fix build error for Android projects that use `apply plugin: "com.android.library"`

### DIFF
--- a/react.gradle
+++ b/react.gradle
@@ -17,7 +17,9 @@ def bundleConfig = config.bundleConfig ? "${reactRoot}/${config.bundleConfig}" :
 
 
 afterEvaluate {
-    android.applicationVariants.all { def variant ->
+    def isAndroidLibrary = plugins.hasPlugin("com.android.library")
+    def variants = isAndroidLibrary ? android.libraryVariants : android.applicationVariants
+    variants.all { def variant ->
         // Create variant and target names
         def targetName = variant.name.capitalize()
         def targetPath = variant.dirName
@@ -96,6 +98,9 @@ afterEvaluate {
         def packageTask = variant.hasProperty("packageApplication")
             ? variant.packageApplication
             : tasks.findByName("package${targetName}")
+        if (variant.hasProperty("packageLibrary")) {
+            packageTask = variant.packageLibrary
+        }
 
         def resourcesDirConfigValue = config."resourcesDir${targetName}"
         if (resourcesDirConfigValue) {


### PR DESCRIPTION
This PR allows Android projects that use `apply plugin: "com.android.library"` to build successfully. A recent regression caused by https://github.com/facebook/react-native/pull/20526 means that building one of these projects always fails with this error:

```
FAILURE: Build failed with an exception.

* Where:
Script '/Users/james/src/SampleLibrary/node_modules/react-native/react.gradle' line: 15

* What went wrong:
A problem occurred configuring project ':app'.
> Could not get unknown property 'applicationVariants' for object of type com.android.build.gradle.LibraryExtension.

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 0s
```

This change updates `react.gradle` to cater to both application and library projects by selectively using `android.applicationVariants` or `android.libraryVariants`.

Fixes https://github.com/facebook/react-native/issues/22310.

Test Plan:
----------

Build any Android project with `apply plugin: "com.android.library"` using `./gradlew build` (I have a sample project here: https://github.com/jtreanor/sample-library-react-native). It will now succeed with these changes.

Changelog:
----------

[Android] [Fixed] - Fixed build error with Android library projects