### PR TITLE
create api to allow clients to present a client credential for authentication

### DIFF
--- a/React/Views/RCTWKWebView.h
+++ b/React/Views/RCTWKWebView.h
@@ -36,6 +36,7 @@ shouldStartLoadForRequest:(NSMutableDictionary<NSString *, id> *)request
 @property (nonatomic, assign) UIEdgeInsets contentInset;
 @property (nonatomic, assign) BOOL automaticallyAdjustContentInsets;
 
++ (void)setClientAuthenticationCredential:(nullable NSURLCredential*)credential;
 - (void)postMessage:(NSString *)message;
 - (void)injectJavaScript:(NSString *)script;
 - (void)goForward;

--- a/React/Views/RCTWKWebView.m
+++ b/React/Views/RCTWKWebView.m
@@ -10,6 +10,8 @@
 #import "RCTAutoInsetsProtocol.h"
 
 static NSString *const MessageHanderName = @"ReactNative";
+static NSURLCredential* clientAuthenticationCredential;
+
 
 @interface RCTWKWebView () <WKUIDelegate, WKNavigationDelegate, WKScriptMessageHandler, UIScrollViewDelegate, RCTAutoInsetsProtocol>
 @property (nonatomic, copy) RCTDirectEventBlock onLoadingStart;
@@ -308,6 +310,25 @@ static NSString *const MessageHanderName = @"ReactNative";
   }
 
   [self setBackgroundColor: _savedBackgroundColor];
+}
+
++ (void)setClientAuthenticationCredential:(nullable NSURLCredential*)credential {
+  clientAuthenticationCredential = credential;
+}
+
+- (void)                    webView:(WKWebView *)webView
+  didReceiveAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge
+                  completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition disposition, NSURLCredential * _Nullable))completionHandler
+{
+  if (!clientAuthenticationCredential) {
+    completionHandler(NSURLSessionAuthChallengePerformDefaultHandling, nil);
+    return;
+  }
+  if ([[challenge protectionSpace] authenticationMethod] == NSURLAuthenticationMethodClientCertificate) {
+    completionHandler(NSURLSessionAuthChallengeUseCredential, clientAuthenticationCredential);
+  } else {
+    completionHandler(NSURLSessionAuthChallengePerformDefaultHandling, nil);
+}
 }
 
 - (void)evaluateJS:(NSString *)js


### PR DESCRIPTION
Summary: In order for TLS Mutual Auth to work for webviews, the caller must present a credential. Expose a setter that can be called to set a credential.

Differential Revision: D13095969
