### PR TITLE
Fix of the memory leaks in catalyst. 

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/NativeModuleRegistry.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/NativeModuleRegistry.java
@@ -83,6 +83,7 @@ public class NativeModuleRegistry {
       for (ModuleHolder module : mModules.values()) {
         module.destroy();
       }
+      mModules.clear();
     } finally {
       Systrace.endSection(Systrace.TRACE_TAG_REACT_JAVA_BRIDGE);
     }


### PR DESCRIPTION
ReactApplicationContext holds a reference to the CatalystInstanceImpl which holds references to the NativeModules. Many native modules store the references to objects holding the references to the Activity holders. The examples of such modules are UIManagerModule, NativeAnimatedModule and many others.

As result without this change caching the ReactApplicationContext causes Activity leaks. It is counter-intuitive.

Test Plan:
----------
Test with LeakCannery for memory leaks on JSEngine re-creation

Changelog:
----------
[Android] [Fixed] - ReactAppliclationContext leaks activity.
