### PR TITLE
Add back TextInput.State

### DIFF
--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -168,6 +168,12 @@ class TextInput extends React.Component<Props> {
     underlineColorAndroid: 'transparent',
   };
 
+  static State = {
+    currentlyFocusedField: TextInputState.currentlyFocusedField,
+    focusTextInput: TextInputState.focusTextInput,
+    blurTextInput: TextInputState.blurTextInput,
+  };
+
   _inputRef: ?React.ElementRef<Class<TextInputType>> = null;
   _lastNativeText: ?Stringish = null;
   _lastNativeSelection: ?Selection = null;


### PR DESCRIPTION
9ea129517922d8a23a5c81128e4dcf97f04a5129 forgot to add back the static `TextInput.State`.

Test Plan:
----------
Tested in an app that crashed because of this

Changelog:
----------
[General] [Fixed] - Add back TextInput.State