### PR TITLE
Rename requiresMainThreadSetup -> requiresMainQueueSetup in code comment

### DIFF
--- a/React/Base/RCTBridgeModule.h
+++ b/React/Base/RCTBridgeModule.h
@@ -301,7 +301,7 @@ RCT_EXTERN void RCTRegisterModule(Class); \
  * for the lifetime of the bridge, so it is not suitable for returning dynamic values, but may be used for long-lived
  * values such as session keys, that are regenerated only as part of a reload of the entire React application.
  *
- * If you implement this method and do not implement `requiresMainThreadSetup`, you will trigger deprecated logic
+ * If you implement this method and do not implement `requiresMainQueueSetup`, you will trigger deprecated logic
  * that eagerly initializes your module on bridge startup. In the future, this behaviour will be changed to default
  * to initializing lazily, and even modules with constants will be initialized lazily.
  */


### PR DESCRIPTION
Update reference to property in code comment in `RCTBridgeModule`. There is no such thing as `requiresMainThreadSetup` in the codebase. Its called `requiresMainQueueSetup` now.

Test Plan:
----------
N/A

Changelog:
----------

[iOS] [Fixed] - Rename requiresMainThreadSetup -> requiresMainQueueSetup in code comment

<!--

  CATEGORY may be:

  - [General]
  - [iOS]
  - [Android]

  TYPE may be:

  - [Added] for new features.
  - [Changed] for changes in existing functionality.
  - [Deprecated] for soon-to-be removed features.
  - [Removed] for now removed features.
  - [Fixed] for any bug fixes.
  - [Security] in case of vulnerabilities.

  For more detail, see https://keepachangelog.com/en/1.0.0/#how

  MESSAGE may answer "what and why" on a feature level. Use this to briefly tell React Native users about notable changes.

  EXAMPLES:

  [General] [Added] - Add snapToOffsets prop to ScrollView component
  [General] [Fixed] - Fix various issues in snapToInterval on ScrollView component
  [iOS] [Fixed] - Fix crash in RCTImagePicker

-->