### PR TITLE
Fix bug in comparison logic of object property

### DIFF
--- a/Libraries/vendor/core/mergeInto.js
+++ b/Libraries/vendor/core/mergeInto.js
@@ -23,7 +23,7 @@ function mergeInto(one, two) {
   if (two != null) {
     checkMergeObjectArg(two);
     for (var key in two) {
-      if (!two.hasOwnProperty(key)) {
+      if (!Object.prototype.hasOwnProperty.call(two, key)) {
         continue;
       }
       one[key] = two[key];


### PR DESCRIPTION
`instance.hasOwnProperty` has potential danger because of some object could be eliminate own prototype chain. Update code be more reliable.

This PR is solution of #22308 issue. (Fixes #22308)


Test Plan:
----------
It was tested on latest local version of react native project with `test`, `test-ci` scripts. In addition to, `Object.create(null)` was tested and works well. Another test doesn't seems to be necessary.

Changelog:
----------
[General] [Fixed] - Fix object comparison be more reliable

<!--

  CATEGORY may be:

  - [General]
  - [iOS]
  - [Android]

  TYPE may be:

  - [Added] for new features.
  - [Changed] for changes in existing functionality.
  - [Deprecated] for soon-to-be removed features.
  - [Removed] for now removed features.
  - [Fixed] for any bug fixes.
  - [Security] in case of vulnerabilities.

  For more detail, see https://keepachangelog.com/en/1.0.0/#how

  MESSAGE may answer "what and why" on a feature level. Use this to briefly tell React Native users about notable changes.

  EXAMPLES:

  [General] [Added] - Add snapToOffsets prop to ScrollView component
  [General] [Fixed] - Fix various issues in snapToInterval on ScrollView component
  [iOS] [Fixed] - Fix crash in RCTImagePicker

-->