### PR TITLE
export Props types for end users

### DIFF
--- a/Libraries/Components/Touchable/TouchableBounce.js
+++ b/Libraries/Components/Touchable/TouchableBounce.js
@@ -33,7 +33,7 @@ type State = {
 
 const PRESS_RETENTION_OFFSET = {top: 20, left: 20, right: 20, bottom: 30};
 
-type Props = $ReadOnly<{|
+export type Props = $ReadOnly<{|
   ...TouchableWithoutFeedbackProps,
 
   onPressWithCompletion?: ?Function,

--- a/Libraries/Components/Touchable/TouchableHighlight.js
+++ b/Libraries/Components/Touchable/TouchableHighlight.js
@@ -42,7 +42,7 @@ type IOSProps = $ReadOnly<{|
   tvParallaxProperties?: ?Object,
 |}>;
 
-type Props = $ReadOnly<{|
+export type Props = $ReadOnly<{|
   ...TouchableWithoutFeedbackProps,
   ...IOSProps,
 

--- a/Libraries/Components/Touchable/TouchableOpacity.js
+++ b/Libraries/Components/Touchable/TouchableOpacity.js
@@ -34,7 +34,7 @@ type TVProps = $ReadOnly<{|
   tvParallaxProperties?: ?TVParallaxPropertiesType,
 |}>;
 
-type Props = $ReadOnly<{|
+export type Props = $ReadOnly<{|
   ...TouchableWithoutFeedbackProps,
   ...TVProps,
   activeOpacity?: ?number,


### PR DESCRIPTION
Related to #22100 

When using Flow, it is handy to be able to inherit from `Props` type for components in user code because the typing can be stricter.

For example:

```
type SubmitButtonProps = $ReadOnly<{|
  ...TouchableHighlightProps,

  onPress: ?() => void,
  style?: ?ViewStyleProp,
  title: string,
|}>;
```

## Test Plan:
* [x]  npm run prettier
* [ ]  npm run flow-check-ios
* [ ]  npm run flow-check-android
 
## Release Notes:
[GENERAL] [ENHANCEMENT] [Components/Touchable/TouchableBounce.js] - export Props Flow types
[GENERAL] [ENHANCEMENT] [Components/Touchable/TouchableHighlight.js] - export Props Flow types
[GENERAL] [ENHANCEMENT] [Components/Touchable/TouchableOpacity.js] - export Props Flow types