### PR TITLE
[ScrollView] Remove mixins from ScrollView

### DIFF
--- a/Libraries/Components/ScrollView/ScrollView.js
+++ b/Libraries/Components/ScrollView/ScrollView.js
@@ -608,6 +608,16 @@ const ScrollView = createReactClass({
     this._scrollViewRef && this._scrollViewRef.setNativeProps(props);
   },
 
+  /**
+   * Returns a reference to the underlying scroll responder, which supports
+   * operations like `scrollTo`. All ScrollView-like components should
+   * implement this method so that they can be composed while providing access
+   * to the underlying scroll responder's methods.
+   */
+  getScrollResponder: function(): ScrollView {
+    return this;
+  },
+
   getScrollableNode: function(): any {
     return ReactNative.findNodeHandle(this._scrollViewRef);
   },

--- a/Libraries/Components/ScrollView/ScrollView.js
+++ b/Libraries/Components/ScrollView/ScrollView.js
@@ -598,7 +598,6 @@ const ScrollView = createReactClass({
 
   componentWillUnmount: function() {
     this._scrollResponder.componentWillUnmount();
-
     if (this._scrollAnimatedValueAttachment) {
       this._scrollAnimatedValueAttachment.detach();
     }


### PR DESCRIPTION
As a part of https://github.com/facebook/react-native/pull/22301 it turned out that we need to first convert `ScrollView` to class component. As a first step to do so, here's removal of using `mixins` API, in favor of populating `_scrollResponder` field with `ScrollResponder.Mixin` (still used) methods.

Test Plan:
----------
Played around with RNTester app and looks ok, but I'd like more eyes on it.

Changelog:
----------

[ScrollView][Removed] – Remove mixins from ScrollView

cc @TheSavior 