### PR TITLE
Make type of RefreshControl.onRefresh less strict

### DIFF
--- a/Libraries/Components/RefreshControl/RefreshControl.js
+++ b/Libraries/Components/RefreshControl/RefreshControl.js
@@ -87,7 +87,7 @@ export type RefreshControlProps = $ReadOnly<{|
   /**
    * Called when the view starts refreshing.
    */
-  onRefresh?: ?() => void,
+  onRefresh?: ?() => mixed,
 
   /**
    * Whether the view should be indicating an active refresh.


### PR DESCRIPTION
I think a common pattern is to use async functions with the onRefresh prop to reload data. I made the type `mixed` since we don't care about what the function returns. Could also be `void | Promise<void>` I haven't really seen a pattern for those in the codebase.

Test Plan:
----------
Run flow

Changelog:
----------
[General] [Fixed] - Make type of RefreshControl.onRefresh less strict