### PR TITLE
Use Changelog instead of Release Notes for danger bot

### DIFF
--- a/bots/dangerfile.js
+++ b/bots/dangerfile.js
@@ -39,11 +39,11 @@ if (!includesTestPlan) {
 }
 
 // Regex looks for given categories, types, a file/framework/component, and a message - broken into 4 capture groups
-const changelogNotesRegex = /\[\s?(ANDROID|GENERAL|IOS)\s?\]\s*?\[\s?(ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY)\s?\]\s*?\-\s*?(.*)/gi;
+const changelogRegex = /\[\s?(ANDROID|GENERAL|IOS)\s?\]\s*?\[\s?(ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY)\s?\]\s*?\-\s*?(.*)/gi;
 const includesChangelog =
   danger.github.pr.body &&
   danger.github.pr.body.toLowerCase().includes('changelog');
-const correctlyFormattedChangelog = changelogNotesRegex.test(
+const correctlyFormattedChangelog = changelogRegex.test(
   danger.github.pr.body,
 );
 

--- a/bots/dangerfile.js
+++ b/bots/dangerfile.js
@@ -43,9 +43,7 @@ const changelogRegex = /\[\s?(ANDROID|GENERAL|IOS)\s?\]\s*?\[\s?(ADDED|CHANGED|D
 const includesChangelog =
   danger.github.pr.body &&
   danger.github.pr.body.toLowerCase().includes('changelog');
-const correctlyFormattedChangelog = changelogRegex.test(
-  danger.github.pr.body,
-);
+const correctlyFormattedChangelog = changelogRegex.test(danger.github.pr.body);
 
 if (!includesChangelog) {
   const title = ':clipboard: Changelog';

--- a/bots/dangerfile.js
+++ b/bots/dangerfile.js
@@ -39,21 +39,21 @@ if (!includesTestPlan) {
 }
 
 // Regex looks for given categories, types, a file/framework/component, and a message - broken into 4 capture groups
-const releaseNotesRegex = /\[\s?(ANDROID|GENERAL|IOS)\s?\]\s*?\[\s?(ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY)\s?\]\s*?\-\s*?(.*)/gi;
-const includesReleaseNotes =
+const changelogNotesRegex = /\[\s?(ANDROID|GENERAL|IOS)\s?\]\s*?\[\s?(ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY)\s?\]\s*?\-\s*?(.*)/gi;
+const includesChangelog =
   danger.github.pr.body &&
-  danger.github.pr.body.toLowerCase().includes('release notes');
-const correctlyFormattedReleaseNotes = releaseNotesRegex.test(
+  danger.github.pr.body.toLowerCase().includes('changelog');
+const correctlyFormattedChangelog = changelogNotesRegex.test(
   danger.github.pr.body,
 );
 
-if (!includesReleaseNotes) {
-  const title = ':clipboard: Release Notes';
-  const idea = 'This PR appears to be missing Release Notes.';
+if (!includesChangelog) {
+  const title = ':clipboard: Changelog';
+  const idea = 'This PR appears to be missing Changelog.';
   warn(`${title} - <i>${idea}</i>`);
-} else if (!correctlyFormattedReleaseNotes) {
-  const title = ':clipboard: Release Notes';
-  const idea = 'This PR may have incorrectly formatted Release Notes.';
+} else if (!correctlyFormattedChangelog) {
+  const title = ':clipboard: Changelog';
+  const idea = 'This PR may have incorrectly formatted Changelog.';
   warn(`${title} - <i>${idea}</i>`);
 }
 


### PR DESCRIPTION
In #22117 we changed the PR template to use `Changelog` instead of `Release notes` and now danger bot is complaining as it wasn't updated there. 

cc @turnrye 

Test Plan:
----------
No test plan needed.
(It actually complained about wrong changelog so it's working 👍 )

Changelog:
----------
Not a user-facing changes.