### PR TITLE
Rename RCTImageCacheDelegate -> RCTImageCache in code comment

### DIFF
--- a/Libraries/Image/RCTImageLoader.h
+++ b/Libraries/Image/RCTImageLoader.h
@@ -140,7 +140,7 @@ typedef dispatch_block_t RCTImageLoaderCancellationBlock;
 
 /**
  * Allows developers to set their own caching implementation for
- * decoded images as long as it conforms to the RCTImageCacheDelegate
+ * decoded images as long as it conforms to the RCTImageCache
  * protocol. This method should be called in bridgeDidInitializeModule.
  */
 - (void)setImageCache:(id<RCTImageCache>)cache;


### PR DESCRIPTION
Update reference to property in code comment in `RCTImageLoader`. There is no protocol named `RCTImageCacheDelegate` in the codebase. Its just `RCTImageCache` and it exists [here](https://github.com/facebook/react-native/blob/f2894e58cf6d1c30975b670f5abf3aaa8d345ed1/Libraries/Image/RCTImageLoader.h#L22).

Test Plan:
----------
N/A

Changelog:
----------

[iOS] [Fixed] - Rename RCTImageCacheDelegate -> RCTImageCache in code comment