### PR TITLE
Fix crash in nativeInjectHMRUpdate

### DIFF
--- a/ReactCommon/cxxreact/JSCExecutor.cpp
+++ b/ReactCommon/cxxreact/JSCExecutor.cpp
@@ -113,7 +113,7 @@ static JSValueRef nativeInjectHMRUpdate(
     const JSValueRef arguments[],
     JSValueRef* exception) {
   String execJSString = Value(ctx, arguments[0]).toString();
-  String jsURL = Value(ctx, arguments[1]).toString();
+  String jsURL = argumentCount > 1 ? Value(ctx, arguments[1]).toString() : String();
   evaluateScript(ctx, execJSString, jsURL);
   return Value::makeUndefined(ctx);
 }


### PR DESCRIPTION
Fix crash in nativeInjectHMRUpdate if it is called with only one argument from JS

Fixes #22116

For more deep explanation, see comments thread from here: https://github.com/facebook/react-native/issues/22116#issuecomment-440420713

Environment:
-------------

This fix dedicated for `0.57-stable` branch, because crashed code was part of old JSC executor, that was replaced in master with new JSI code.

Test Plan:
----------
Ensure that application no more crash when enable HMR from dev menu.

Changelog:
----------
Help reviewers and the release process by writing your own changelog entry. When the change doesn't impact React Native developers, it may be ommitted from the changelog for brevity. See below for an example.

[iOS] [Fixed] - Fix application crash when HMR enabled