### PR TITLE
Apply little strength flow type for Libraries/Components/WebView/WebView.ios.js.

### DIFF
--- a/Libraries/Components/WebView/WebView.ios.js
+++ b/Libraries/Components/WebView/WebView.ios.js
@@ -11,10 +11,7 @@
 'use strict';
 
 const ActivityIndicator = require('ActivityIndicator');
-const DeprecatedViewPropTypes = require('DeprecatedViewPropTypes');
-const DeprecatedEdgeInsetsPropType = require('DeprecatedEdgeInsetsPropType');
 const Linking = require('Linking');
-const PropTypes = require('prop-types');
 const React = require('React');
 const ReactNative = require('ReactNative');
 const StyleSheet = require('StyleSheet');
@@ -23,7 +20,6 @@ const UIManager = require('UIManager');
 const View = require('View');
 const WebViewShared = require('WebViewShared');
 
-const deprecatedPropType = require('deprecatedPropType');
 const invariant = require('fbjs/lib/invariant');
 const keyMirror = require('fbjs/lib/keyMirror');
 const processDecelerationRate = require('processDecelerationRate');

--- a/Libraries/Components/WebView/WebView.ios.js
+++ b/Libraries/Components/WebView/WebView.ios.js
@@ -723,16 +723,8 @@ class WebView extends React.Component<Props, State> {
   }
 }
 
-const RCTWebView = requireNativeComponent(
-  'RCTWebView',
-  WebView,
-  WebView.extraNativeComponentConfig,
-);
-const RCTWKWebView = requireNativeComponent(
-  'RCTWKWebView',
-  WebView,
-  WebView.extraNativeComponentConfig,
-);
+const RCTWebView = requireNativeComponent('RCTWebView');
+const RCTWKWebView = requireNativeComponent('RCTWKWebView');
 
 const styles = StyleSheet.create({
   container: {

--- a/Libraries/Components/WebView/WebView.ios.js
+++ b/Libraries/Components/WebView/WebView.ios.js
@@ -460,7 +460,16 @@ type Props = $ReadOnly<{|
 |}>;
 
 /* TODO: Make State type strict */
-type State = Object;
+type State = {
+  viewState: string,
+  lastErrorEvent: ?{
+    domain: string,
+    code: number,
+    description: string,
+  },
+  startInLoadingState: boolean,
+  loading?: string,
+};
 
 class WebView extends React.Component<Props, State> {
   static JSNavigationScheme = JSNavigationScheme;
@@ -473,7 +482,7 @@ class WebView extends React.Component<Props, State> {
 
   state = {
     viewState: WebViewState.IDLE,
-    lastErrorEvent: (null: ?ErrorEvent),
+    lastErrorEvent: null,
     startInLoadingState: true,
   };
 
@@ -514,9 +523,8 @@ class WebView extends React.Component<Props, State> {
         errorEvent.description,
       );
     } else if (this.state.viewState !== WebViewState.IDLE) {
-      console.error(
-        'RCTWebView invalid state encountered: ' + this.state.loading,
-      );
+      const loading = this.state.loading || 'undefined';
+      console.error('RCTWebView invalid state encountered: ' + loading);
     }
 
     const webViewStyles = [styles.container, styles.webView, this.props.style];

--- a/Libraries/Components/WebView/WebViewShared.js
+++ b/Libraries/Components/WebView/WebViewShared.js
@@ -14,6 +14,7 @@ const escapeStringRegexp = require('escape-string-regexp');
 
 const WebViewShared = {
   defaultOriginWhitelist: ['http://*', 'https://*'],
+  decelerationRate: 'fast',
   extractOrigin: (url: string): ?string => {
     const result = /^[A-Za-z0-9]+:(\/\/)?[^/]*/.exec(url);
     return result === null ? null : result[0];


### PR DESCRIPTION
This is new version of PR #22284  
Fixes #22205.

I tried "Strengthening Flow Types for Core Components #22100".
But there is `propTypes` on Libraries/Components/WebView/WebView.ios.js.
I think, `propTypes` should be removed before trying to strengthening Flow Types.
So this PR replace `propTypes` with `type Props` and little strengthen Flow Types.

Test Plan:
- [x] npm run test
- [x] npm run prettier
- [x] npm run flow-check-ios
- [x] npm run flow-check-android
- [x] npm run flow

Changelog:
- replace PropTypes with type Props
- avoid to pass unused args to `requireNativeComponent`
- little strengthen flow types