### PR TITLE
Fix: Add displayName to ActivityIndicator

### DIFF
--- a/Libraries/Components/ActivityIndicator/ActivityIndicator.js
+++ b/Libraries/Components/ActivityIndicator/ActivityIndicator.js
@@ -112,6 +112,7 @@ const ActivityIndicator = (
 
 // $FlowFixMe - TODO T29156721 `React.forwardRef` is not defined in Flow, yet.
 const ActivityIndicatorWithRef = React.forwardRef(ActivityIndicator);
+ActivityIndicatorWithRef.displayName = 'ActivityIndicator';
 
 ActivityIndicatorWithRef.defaultProps = {
   animating: true,

--- a/Libraries/Components/ActivityIndicator/__tests__/ActivityIndicator-test.js
+++ b/Libraries/Components/ActivityIndicator/__tests__/ActivityIndicator-test.js
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @emails oncall+react_native
+ */
+
+'use strict';
+
+const React = require('React');
+const ReactTestRenderer = require('react-test-renderer');
+const ActivityIndicator = require('ActivityIndicator');
+
+describe('ActivityIndicator', () => {
+  it('renders correctly', () => {
+    const instance = ReactTestRenderer.create(
+      <ActivityIndicator size="large" color="#0000ff" />,
+    );
+
+    expect(instance.toJSON()).toMatchSnapshot();
+  });
+});

--- a/Libraries/Components/ActivityIndicator/__tests__/__snapshots__/ActivityIndicator-test.js.snap
+++ b/Libraries/Components/ActivityIndicator/__tests__/__snapshots__/ActivityIndicator-test.js.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ActivityIndicator renders correctly 1`] = `
+<ActivityIndicator
+  animating={true}
+  color="#0000ff"
+  hidesWhenStopped={true}
+  size="large"
+/>
+`;


### PR DESCRIPTION
Summary:
Similar to #21950, this adds displayName to `ActivityIndicator`, so it displays the correct component name in snapshots instead of `Component`.

Fixes #21937 (a little bit more than it was already fixed).

Test Plan:
----------
yarn test - ActivityIndicator's - ActivityIndicator-test.js.snap should Show <ActivityIndicator>

Changelog/Release Notes:
----------
[General] [Fixed] - Add displayName to ActivityIndicator for snapshots
