### PR TITLE
add talkback navigation support for links and header

### DIFF
--- a/RNTester/js/AccessibilityAndroidExample.android.js
+++ b/RNTester/js/AccessibilityAndroidExample.android.js
@@ -111,6 +111,31 @@ class AccessibilityAndroidExample extends React.Component {
           </View>
         </RNTesterBlock>
 
+        <RNTesterBlock title="Touchable with accessibilityRole = header">
+          <View
+            accessible={true}
+            accessibilityLabel="I'm a header, so I read it instead of embedded text."
+            accessibilityRole="header">
+            <Text style={{color: 'green'}}>This is</Text>
+            <Text style={{color: 'blue'}}>
+              nontouchable accessible view with label.
+            </Text>
+          </View>
+        </RNTesterBlock>
+
+        <RNTesterBlock title="Touchable with accessibilityRole = link">
+          <TouchableWithoutFeedback
+            onPress={() =>
+              ToastAndroid.show('Toasts work by default', ToastAndroid.SHORT)
+            }
+            accessibilityRole="link">
+            <View style={styles.embedded}>
+              <Text>Click me</Text>
+              <Text>Or not</Text>
+            </View>
+          </TouchableWithoutFeedback>
+        </RNTesterBlock>
+
         <RNTesterBlock title="Touchable with accessibilityRole = button">
           <TouchableWithoutFeedback
             onPress={() =>

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/AccessibilityDelegateUtil.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/AccessibilityDelegateUtil.java
@@ -9,6 +9,9 @@ import android.content.Context;
 import android.support.v4.view.AccessibilityDelegateCompat;
 import android.support.v4.view.ViewCompat;
 import android.support.v4.view.accessibility.AccessibilityNodeInfoCompat;
+import android.support.v4.view.accessibility.AccessibilityNodeInfoCompat.CollectionItemInfoCompat;
+import android.text.SpannableString;
+import android.text.style.URLSpan;
 import android.view.View;
 import com.facebook.react.R;
 import java.util.Locale;
@@ -98,7 +101,6 @@ public class AccessibilityDelegateUtil {
           public void onInitializeAccessibilityNodeInfo(
             View host, AccessibilityNodeInfoCompat info) {
             super.onInitializeAccessibilityNodeInfo(host, info);
-            setRole(info, accessibilityRole, view.getContext());
             if (!(accessibilityHint == null)) {
               String contentDescription=(String)info.getContentDescription();
               if (contentDescription != null) {
@@ -108,6 +110,8 @@ public class AccessibilityDelegateUtil {
                 info.setContentDescription(accessibilityHint);
               }
             }
+
+            setRole(info, accessibilityRole, view.getContext());
           }
         });
     }
@@ -127,6 +131,18 @@ public class AccessibilityDelegateUtil {
     if (Locale.getDefault().getLanguage().equals(new Locale("en").getLanguage())) {
       if (role.equals(AccessibilityRole.LINK)) {
         nodeInfo.setRoleDescription(context.getString(R.string.link_description));
+
+        if (nodeInfo.getContentDescription() != null) {
+          SpannableString spannable = new SpannableString(nodeInfo.getContentDescription());
+          spannable.setSpan(new URLSpan(""), 0, spannable.length(), 0);
+          nodeInfo.setContentDescription(spannable);
+        }
+
+        if (nodeInfo.getText() != null) {
+          SpannableString spannable = new SpannableString(nodeInfo.getText());
+          spannable.setSpan(new URLSpan(""), 0, spannable.length(), 0);
+          nodeInfo.setText(spannable);
+        }
       }
       if (role.equals(AccessibilityRole.SEARCH)) {
         nodeInfo.setRoleDescription(context.getString(R.string.search_description));
@@ -139,6 +155,15 @@ public class AccessibilityDelegateUtil {
       }
       if (role.equals(AccessibilityRole.ADJUSTABLE)) {
         nodeInfo.setRoleDescription(context.getString(R.string.adjustable_description));
+      }
+      if (role.equals(AccessibilityRole.HEADER)) {
+        nodeInfo.setRoleDescription(context.getString(R.string.header_description));
+
+        final AccessibilityNodeInfoCompat.CollectionItemInfoCompat itemInfo =
+        AccessibilityNodeInfoCompat.CollectionItemInfoCompat.obtain(
+                0, 1, 0, 1,
+                true);
+        nodeInfo.setCollectionItemInfo(itemInfo);
       }
     }
     if (role.equals(AccessibilityRole.IMAGEBUTTON)) {

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/AccessibilityDelegateUtil.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/AccessibilityDelegateUtil.java
@@ -158,11 +158,8 @@ public class AccessibilityDelegateUtil {
       }
       if (role.equals(AccessibilityRole.HEADER)) {
         nodeInfo.setRoleDescription(context.getString(R.string.header_description));
-
         final AccessibilityNodeInfoCompat.CollectionItemInfoCompat itemInfo =
-        AccessibilityNodeInfoCompat.CollectionItemInfoCompat.obtain(
-                0, 1, 0, 1,
-                true);
+          AccessibilityNodeInfoCompat.CollectionItemInfoCompat.obtain(0, 1, 0, 1, true);
         nodeInfo.setCollectionItemInfo(itemInfo);
       }
     }

--- a/ReactAndroid/src/main/res/views/uimanager/values/strings.xml
+++ b/ReactAndroid/src/main/res/views/uimanager/values/strings.xml
@@ -20,4 +20,8 @@
     name="adjustable_description"
     translatable="false"
     >Adjustable</string>
+  <string
+    name="header_description"
+    translatable="false"
+    >Heading</string>
 </resources>


### PR DESCRIPTION
## Summary
1. add role description for heading
2. add talkback navigation support for link and header

Fixes #22440 

## Test Plan:

1. talkback link navigation for accessibilityRole="link"
2. talkback heading navigation for accessibilityRole="header"
3. talkback reading heading suffix for accessibilityRole="header"
4. talkback link for view component with and without accessibilityHint

## Changelog:

[Android] [Changed] - Add talkback navigation support for links and header
