### PR TITLE
Respect GIF metadata for loop counts

### DIFF
--- a/Libraries/Image/RCTGIFImageDecoder.m
+++ b/Libraries/Image/RCTGIFImageDecoder.m
@@ -84,7 +84,7 @@ RCT_EXPORT_MODULE()
     // Create animation
     CAKeyframeAnimation *animation = [CAKeyframeAnimation animationWithKeyPath:@"contents"];
     animation.calculationMode = kCAAnimationDiscrete;
-    animation.repeatCount = loopCount == 0 ? HUGE_VALF : loopCount;
+    animation.repeatCount = loopCount;
     animation.keyTimes = keyTimes;
     animation.values = images;
     animation.duration = duration;


### PR DESCRIPTION
Right now RCTGIFImageDecoder is hard coded to loop "forever" when it encounters a gif with a loop count set to be zero.  Android already works correctly... or iOS works correctly and Android is broken.

