### PR TITLE
Make RNTester build and pass again

### DIFF
--- a/RNTester/e2e/config.json
+++ b/RNTester/e2e/config.json
@@ -1,5 +1,5 @@
 {
-  "setupTestFrameworkScriptFile" : "./__tests__/init.js",
+  "setupTestFrameworkScriptFile" : "./test-init.js",
   "testEnvironment": "node",
   "bail": true,
   "verbose": true

--- a/RNTester/e2e/test-init.js
+++ b/RNTester/e2e/test-init.js
@@ -8,7 +8,7 @@
 /* eslint-env jasmine */
 
 const detox = require('detox');
-const config = require('../../../package.json').detox;
+const config = require('../../package.json').detox;
 const adapter = require('detox/runners/jest/adapter');
 
 jest.setTimeout(480000);

--- a/package.json
+++ b/package.json
@@ -237,7 +237,7 @@
     "configurations": {
       "ios.sim.release": {
         "binaryPath": "RNTester/build/Build/Products/Release-iphonesimulator/RNTester.app/",
-        "build": "xcodebuild -project RNTester/RNTester.xcodeproj -scheme RNTester -configuration Release -sdk iphonesimulator -derivedDataPath RNTester/build -quiet",
+        "build": "xcodebuild -project RNTester/RNTester.xcodeproj -scheme RNTester -configuration Release -sdk iphonesimulator -derivedDataPath RNTester/build -UseModernBuildSystem=NO -quiet",
         "type": "ios.simulator",
         "name": "iPhone 8"
       }


### PR DESCRIPTION
Detox was failing because of build errors due to the new xcode10 build system. These errors were fixed by @RSNara in https://github.com/facebook/react-native/commit/b7349f9857df331e4c618256158662ea1f819ed5 but this callsite was missed.

Test Plan:
----------
I ran `yarn build-ios-e2e && yarn test-ios-e2e`. 

Before this change I got build errors like:

```
1) Target 'React-tvOS' (project 'React') has copy command from 'react-native/React/Views/RCTRefreshControlManager.h' to 'react-native/RNTester/build/Build/Products/Release-iphonesimulator/include/React/RCTRefreshControlManager.h'
2) Target 'React' (project 'React') has copy command from 'react-native/React/Views/RCTRefreshControlManager.h' to 'react-native/RNTester/build/Build/Products/Release-iphonesimulator/include/React/RCTRefreshControlManager.h'
```

![screen shot 2018-11-30 at 4 50 13 pm](https://user-images.githubusercontent.com/249164/49321967-0afc3880-f4c0-11e8-86f8-7f2857462857.png)

Changelog:
----------

[General] [Fixed] - RNTester runs and passes again in CI