### PR TITLE
RCTSafeAreaShadowView does not correctly adjust for RTL when setting padding

### DIFF
--- a/React/Views/SafeAreaView/RCTSafeAreaShadowView.m
+++ b/React/Views/SafeAreaView/RCTSafeAreaShadowView.m
@@ -11,6 +11,7 @@
 #import <yoga/Yoga.h>
 
 #import "RCTSafeAreaViewLocalData.h"
+#import "RCTI18nUtil.h"
 
 @implementation RCTSafeAreaShadowView
 
@@ -21,12 +22,23 @@
 
   UIEdgeInsets insets = localData.insets;
 
-  super.paddingLeft = (YGValue){insets.left, YGUnitPoint};
-  super.paddingRight = (YGValue){insets.right, YGUnitPoint};
   super.paddingTop = (YGValue){insets.top, YGUnitPoint};
   super.paddingBottom = (YGValue){insets.bottom, YGUnitPoint};
 
-  [self didSetProps:@[@"paddingLeft", @"paddingRight", @"paddingTop", @"paddingBottom"]];
+  if ([[RCTI18nUtil sharedInstance] doLeftAndRightSwapInRTL]) {
+    if ([[RCTI18nUtil sharedInstance] isRTL]) {
+      super.paddingStart = (YGValue){insets.right, YGUnitPoint};
+      super.paddingEnd = (YGValue){insets.left, YGUnitPoint};
+    } else {
+      super.paddingStart = (YGValue){insets.left, YGUnitPoint};
+      super.paddingEnd = (YGValue){insets.right, YGUnitPoint};
+    }
+    [self didSetProps:@[@"paddingStart", @"paddingEnd", @"paddingTop", @"paddingBottom"]];
+  } else {
+    super.paddingLeft = (YGValue){insets.left, YGUnitPoint};
+    super.paddingRight = (YGValue){insets.right, YGUnitPoint};
+    [self didSetProps:@[@"paddingLeft", @"paddingRight", @"paddingTop", @"paddingBottom"]];
+  }
 }
 
 /**


### PR DESCRIPTION
Issue
----
`RCTSafeAreaShadowView` currently sets `paddingLeft` and `paddingRight`:

```
UIEdgeInsets insets = localData.insets;

  super.paddingLeft = (YGValue){insets.left, YGUnitPoint};
  super.paddingRight = (YGValue){insets.right, YGUnitPoint};
  super.paddingTop = (YGValue){insets.top, YGUnitPoint};
super.paddingBottom = (YGValue){insets.bottom, YGUnitPoint};
```

But, when `RCTShadowView` propagates the padding settings to Yoga, it adjusts for RTL when `doLeftAndRightSwapInRTL` is set to true:

```
static void RCTProcessMetaPropsPadding(const YGValue metaProps[META_PROP_COUNT], YGNodeRef node) {
  if (![[RCTI18nUtil sharedInstance] doLeftAndRightSwapInRTL]) {
    RCT_SET_YGVALUE(metaProps[META_PROP_START], YGNodeStyleSetPadding, node, YGEdgeStart);
    RCT_SET_YGVALUE(metaProps[META_PROP_END], YGNodeStyleSetPadding, node, YGEdgeEnd);
    RCT_SET_YGVALUE(metaProps[META_PROP_LEFT], YGNodeStyleSetPadding, node, YGEdgeLeft);
    RCT_SET_YGVALUE(metaProps[META_PROP_RIGHT], YGNodeStyleSetPadding, node, YGEdgeRight);
  } else {
    YGValue start = metaProps[META_PROP_START].unit == YGUnitUndefined ? metaProps[META_PROP_LEFT] : metaProps[META_PROP_START];
    YGValue end = metaProps[META_PROP_END].unit == YGUnitUndefined ? metaProps[META_PROP_RIGHT] : metaProps[META_PROP_END];
    RCT_SET_YGVALUE(start, YGNodeStyleSetPadding, node, YGEdgeStart);
    RCT_SET_YGVALUE(end, YGNodeStyleSetPadding, node, YGEdgeEnd);
}
...

```

Because `RCTSafeAreaShadowView` only sets `paddingLeft` and `paddingRight`, and not `paddingStart` and `paddingEnd`, `paddingLeft` is always treated as `YGEdgeStart` and `paddingRight` is always treated as `YGEdgeEnd`. This is incorrect in RTL scenarios, where left == end and right == start.

Fix
----
When `doLeftAndRightSwapInRTL` is set to true, we set `paddingStart` and `paddingEnd`, rather than `paddingLeft/Right`, in `RCTSafeAreaShadowView`. When `doLeftAndRightSwapInRTL` is set to false, we maintain the previous behavior.

Test Plan
----
Validated SafeAreaView works as it did before when in LTR and when `doLeftAndRightSwapInRTL` == false.

Validated that SafeAreaView now works correctly in RTL, with padding no longer being swapped.

Changelog
----
[iOS][Fixed] - SafeAreaView padding is incorrect in RTL