### PR TITLE
Use main.jsbundle in iOS template for production build

### DIFF
--- a/local-cli/templates/HelloWorld/ios/HelloWorld/AppDelegate.m
+++ b/local-cli/templates/HelloWorld/ios/HelloWorld/AppDelegate.m
@@ -16,7 +16,11 @@
 {
   NSURL *jsCodeLocation;
 
-  jsCodeLocation = [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index" fallbackResource:nil];
+  #ifdef DEBUG
+    jsCodeLocation = [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index" fallbackResource:nil];
+  #else
+    jsCodeLocation = [[NSBundle mainBundle] URLForResource:@"main" withExtension:@"jsbundle"];
+  #endif
 
   RCTRootView *rootView = [[RCTRootView alloc] initWithBundleURL:jsCodeLocation
                                                       moduleName:@"HelloWorld"


### PR DESCRIPTION
Default HelloWorld template for iOS doesn't make production main.jsbundle. This is little bit confusing in compare with Android building app when everything works one first run.

Make it seamless, reduce confuse.
Based on docs https://facebook.github.io/react-native/docs/running-on-device#3-configure-app-to-use-static-bundle

Fixes #22335 
Fixes #18562

Test Plan:
----------
CI green

Changelog:
----------

[iOS] [Changed] - Use main.jsbundle in template for production build

<!--

  CATEGORY may be:

  - [General]
  - [iOS]
  - [Android]

  TYPE may be:

  - [Added] for new features.
  - [Changed] for changes in existing functionality.
  - [Deprecated] for soon-to-be removed features.
  - [Removed] for now removed features.
  - [Fixed] for any bug fixes.
  - [Security] in case of vulnerabilities.

  For more detail, see https://keepachangelog.com/en/1.0.0/#how

  MESSAGE may answer "what and why" on a feature level. Use this to briefly tell React Native users about notable changes.

  EXAMPLES:

  [General] [Added] - Add snapToOffsets prop to ScrollView component
  [General] [Fixed] - Fix various issues in snapToInterval on ScrollView component
  [iOS] [Fixed] - Fix crash in RCTImagePicker

-->