### PR TITLE
Making JSI_EXPORT macro definition conditional

### DIFF
--- a/ReactCommon/jsi/jsi.h
+++ b/ReactCommon/jsi/jsi.h
@@ -13,7 +13,9 @@
 #include <string>
 #include <vector>
 
+#ifndef JSI_EXPORT
 #define JSI_EXPORT __attribute__((visibility("default")))
+#endif
 
 class FBJSRuntime;
 namespace facebook {


### PR DESCRIPTION
This change enables defining the macro at a more global and central location. And thereby allowing us to building this file using MSVC.