### PR TITLE
[CI] Propagate exit code in test_objc

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -284,7 +284,7 @@ aliases:
 
   - &boot-simulator-iphone
     name: Boot iPhone Simulator
-    command: xcrun simctl boot "iPhone 5s" || true
+    command: xcrun simctl boot "iPhone XS" || true
 
   - &boot-simulator-appletv
     name: Boot Apple TV Simulator
@@ -436,12 +436,6 @@ jobs:
 
       - run: *run-objc-ios-tests
       - run: *run-objc-tvos-tests
-
-      # TODO: Fix these failing tests.
-      - run: *display-broken-tests-warning
-      - run: *run-podspec-tests
-      - run: *run-objc-ios-e2e-tests
-      - run: *run-objc-tvos-e2e-tests
 
       - store_test_results:
           path: ~/react-native/reports/junit

--- a/scripts/.tests.env
+++ b/scripts/.tests.env
@@ -17,12 +17,9 @@ export AVD_NAME="testAVD"
 export AVD_ABI=x86
 
 ## IOS ##
-export IOS_TARGET_OS="11.4"
-export IOS_DEVICE="iPhone 5s"
-
-export SCHEME="RNTester"
-export SDK="iphonesimulator${IOS_TARGET_OS}"
-export DESTINATION="platform=iOS Simulator,OS=${IOS_TARGET_OS},name=${IOS_DEVICE}"
+export IOS_TARGET_OS="12.1"
+export IOS_DEVICE="iPhone XS"
+export TVOS_DEVICE="Apple TV"
 
 ## CI OVERRIDES ##
 # Values to override when running in CI

--- a/scripts/objc-test-ios.sh
+++ b/scripts/objc-test-ios.sh
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 #
 # Script used to run iOS tests.
-# If not arguments are passed to the script, it will only compile
+# If no arguments are passed to the script, it will only compile
 # the RNTester.
 # If the script is called with a single argument "test", we'll
 # also run the RNTester integration test (needs JS and packager):
@@ -18,10 +18,13 @@ ROOT=$(dirname "$SCRIPTS")
 
 cd "$ROOT"
 
+# shellcheck disable=SC1091
+source "scripts/.tests.env"
+
 export TEST_NAME="iOS"
 export SCHEME="RNTester"
 export SDK="iphonesimulator"
-export DESTINATION="platform=iOS Simulator,name=iPhone XS,OS=12.1"
+export DESTINATION="platform=iOS Simulator,name=${IOS_DEVICE},OS=${IOS_TARGET_OS}"
 
 # If there's a "test" argument, pass it to the test script.
-. ./scripts/objc-test.sh $1
+./scripts/objc-test.sh $1

--- a/scripts/objc-test-tvos.sh
+++ b/scripts/objc-test-tvos.sh
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 #
 # Script used to run tvOS tests.
-# If not arguments are passed to the script, it will only compile
+# If no arguments are passed to the script, it will only compile
 # the RNTester.
 # If the script is called with a single argument "test", we'll
 # also run the RNTester integration test (needs JS and packager):
@@ -18,10 +18,13 @@ ROOT=$(dirname "$SCRIPTS")
 
 cd "$ROOT"
 
+# shellcheck disable=SC1091
+source "scripts/.tests.env"
+
 export TEST_NAME="tvOS"
 export SCHEME="RNTester-tvOS"
 export SDK="appletvsimulator"
-export DESTINATION="platform=tvOS Simulator,name=Apple TV,OS=12.1"
+export DESTINATION="platform=tvOS Simulator,name=${TVOS_DEVICE},OS=${IOS_TARGET_OS}"
 
 # If there's a "test" argument, pass it to the test script.
-. ./scripts/objc-test.sh $1
+./scripts/objc-test.sh $1

--- a/scripts/objc-test.sh
+++ b/scripts/objc-test.sh
@@ -17,17 +17,17 @@ set -ex
 SCRIPTS=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 ROOT=$(dirname $SCRIPTS)
 
-cd $ROOT
+cd "$ROOT"
 
 # Create cleanup handler
 function cleanup {
-  EXIT_CODE=$?
+  EXIT=$?
   set +e
 
-  if [ $EXIT_CODE -ne 0 ];
+  if [ $EXIT -ne 0 ];
   then
     WATCHMAN_LOGS=/usr/local/Cellar/watchman/3.1/var/run/watchman/$USER.log
-    [ -f $WATCHMAN_LOGS ] && cat $WATCHMAN_LOGS
+    [ -f "$WATCHMAN_LOGS" ] && cat "$WATCHMAN_LOGS"
   fi
   # kill whatever is occupying port 8081 (packager)
   lsof -i tcp:8081 | awk 'NR!=1 {print $2}' | xargs kill
@@ -61,7 +61,7 @@ function waitForPackager {
 if [ "$1" = "test" ]; then
 
 # Start the packager
-npm run start --max-workers=1 || echo "Can't start packager automatically" &
+yarn start --max-workers=1 || echo "Can't start packager automatically" &
 # Start the WebSocket test server
 open "./IntegrationTests/launchWebSocketServer.command" || echo "Can't start web socket server automatically"
 
@@ -80,20 +80,21 @@ rm temp.bundle
 # Run tests
 xcodebuild \
   -project "RNTester/RNTester.xcodeproj" \
-  -scheme $SCHEME \
-  -sdk $SDK \
+  -scheme "$SCHEME" \
+  -sdk "$SDK" \
   -destination "$DESTINATION" \
   -UseModernBuildSystem=NO \
   build test \
-  | xcpretty --report junit --output "$HOME/react-native/reports/junit/$TEST_NAME/results.xml"
+  | xcpretty --report junit --output "$HOME/react-native/reports/junit/$TEST_NAME/results.xml" \
+  && exit "${PIPESTATUS[0]}"
 
 else
 
 # Don't run tests. No need to pass -destination to xcodebuild.
 xcodebuild \
   -project "RNTester/RNTester.xcodeproj" \
-  -scheme $SCHEME \
-  -sdk $SDK \
+  -scheme "$SCHEME" \
+  -sdk "$SDK" \
   -UseModernBuildSystem=NO \
   build
 


### PR DESCRIPTION
Any failures in `test_objc` within the objc-test.sh script have been kept hidden as `xcpretty` was swallowing the exit code from xcodebuild.

Fixes the issue @TheSavior brought up in #22470 where failing snapshot tests were not reflected on Circle. 

## Test Plan:

Run on Circle CI and confirm `test_objc` fails (iOS tests *are* broken on master).