### PR TITLE
Add Touchable E2E tests

### DIFF
--- a/RNTester/e2e/__tests__/Touchable-test.js
+++ b/RNTester/e2e/__tests__/Touchable-test.js
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails oncall+react_native
+ * @format
+ */
+
+/* global element, by, expect */
+
+describe('Touchable', () => {
+  beforeAll(async () => {
+    await element(by.id('explorer_search')).replaceText('<Touchable*');
+    await element(
+      by.label('<Touchable*> and onPress Touchable and onPress examples.'),
+    ).tap();
+  });
+
+  afterAll(async () => {
+    //TODO - remove app state persistency, till then, we must go back to main screen,
+    await element(by.label('Back')).tap();
+  });
+
+  it('Touchable Without Feedback should be tappable', async () => {
+    await element(by.label('Tap Here For No Feedback!')).tap();
+    await expect(
+      element(by.text('TouchableWithoutFeedback onPress')),
+    ).toBeVisible();
+  });
+});

--- a/RNTester/e2e/__tests__/Touchable-test.js
+++ b/RNTester/e2e/__tests__/Touchable-test.js
@@ -23,6 +23,13 @@ describe('Touchable', () => {
     await element(by.label('Back')).tap();
   });
 
+  it('Touchable Highlight should be tappable', async () => {
+    await element(by.id('touchable_highlight_image_button')).tap();
+    await expect(element(by.id('touchable_highlight_console'))).toHaveText(
+      'TouchableHighlight onPress',
+    );
+  });
+
   it('Touchable Without Feedback should be tappable', async () => {
     await element(by.label('Tap Here For No Feedback!')).tap();
     await expect(

--- a/RNTester/e2e/__tests__/Touchable-test.js
+++ b/RNTester/e2e/__tests__/Touchable-test.js
@@ -29,4 +29,9 @@ describe('Touchable', () => {
       element(by.text('TouchableWithoutFeedback onPress')),
     ).toBeVisible();
   });
+
+  it('Text should be tappable', async () => {
+    await element(by.text('Text has built-in onPress handling')).tap();
+    await expect(element(by.text('text onPress'))).toBeVisible();
+  });
 });

--- a/RNTester/js/TouchableExample.js
+++ b/RNTester/js/TouchableExample.js
@@ -148,9 +148,9 @@ class TouchableHighlightBox extends React.Component<{}, $FlowFixMeState> {
   render() {
     let textLog = '';
     if (this.state.timesPressed > 1) {
-      textLog = this.state.timesPressed + 'x TouchableHighlightBox onPress';
+      textLog = this.state.timesPressed + 'x TouchableHighlight onPress';
     } else if (this.state.timesPressed > 0) {
-      textLog = 'TouchableHighlightBox onPress';
+      textLog = 'TouchableHighlight onPress';
     }
 
     return (
@@ -158,11 +158,13 @@ class TouchableHighlightBox extends React.Component<{}, $FlowFixMeState> {
         <View style={styles.row}>
           <TouchableHighlight
             style={styles.wrapper}
+            testID="touchable_highlight_image_button"
             onPress={this.touchableOnPress}>
             <Image source={heartImage} style={styles.image} />
           </TouchableHighlight>
           <TouchableHighlight
             style={styles.wrapper}
+            testID="touchable_highlight_text_button"
             activeOpacity={1}
             tvParallaxProperties={{
               pressMagnification: 1.3,
@@ -176,7 +178,9 @@ class TouchableHighlightBox extends React.Component<{}, $FlowFixMeState> {
           </TouchableHighlight>
         </View>
         <View style={styles.logBox}>
-          <Text>{textLog}</Text>
+          <Text testID="touchable_highlight_console">
+            {textLog}
+          </Text>
         </View>
       </View>
     );

--- a/RNTester/js/TouchableExample.js
+++ b/RNTester/js/TouchableExample.js
@@ -45,30 +45,7 @@ exports.examples = [
       'background color change as well with the activeOpacity and ' +
       'underlayColor props.',
     render: function() {
-      return (
-        <View>
-          <View style={styles.row}>
-            <TouchableHighlight
-              style={styles.wrapper}
-              onPress={() => console.log('stock THW image - highlight')}>
-              <Image source={heartImage} style={styles.image} />
-            </TouchableHighlight>
-            <TouchableHighlight
-              style={styles.wrapper}
-              activeOpacity={1}
-              tvParallaxProperties={{
-                pressMagnification: 1.3,
-                pressDuration: 0.6,
-              }}
-              underlayColor="rgb(210, 230, 255)"
-              onPress={() => console.log('custom THW text - highlight')}>
-              <View style={styles.wrapperCustom}>
-                <Text style={styles.text}>Tap Here For Custom Highlight!</Text>
-              </View>
-            </TouchableHighlight>
-          </View>
-        </View>
-      );
+      return <TouchableHighlightBox />;
     },
   },
   {
@@ -156,6 +133,35 @@ exports.examples = [
     },
   },
 ];
+
+class TouchableHighlightBox extends React.Component<{}, $FlowFixMeState> {
+  render() {
+    return (
+      <View>
+        <View style={styles.row}>
+          <TouchableHighlight
+            style={styles.wrapper}
+            onPress={() => console.log('stock THW image - highlight')}>
+            <Image source={heartImage} style={styles.image} />
+          </TouchableHighlight>
+          <TouchableHighlight
+            style={styles.wrapper}
+            activeOpacity={1}
+            tvParallaxProperties={{
+              pressMagnification: 1.3,
+              pressDuration: 0.6,
+            }}
+            underlayColor="rgb(210, 230, 255)"
+            onPress={() => console.log('custom THW text - highlight')}>
+            <View style={styles.wrapperCustom}>
+              <Text style={styles.text}>Tap Here For Custom Highlight!</Text>
+            </View>
+          </TouchableHighlight>
+        </View>
+      </View>
+    );
+  }
+}
 
 class TouchableWithoutFeedbackBox extends React.Component<{}, $FlowFixMeState> {
   state = {

--- a/RNTester/js/TouchableExample.js
+++ b/RNTester/js/TouchableExample.js
@@ -135,13 +135,30 @@ exports.examples = [
 ];
 
 class TouchableHighlightBox extends React.Component<{}, $FlowFixMeState> {
+  state = {
+    timesPressed: 0,
+  };
+
+  touchableOnPress = () => {
+    this.setState({
+      timesPressed: this.state.timesPressed + 1,
+    });
+  };
+
   render() {
+    let textLog = '';
+    if (this.state.timesPressed > 1) {
+      textLog = this.state.timesPressed + 'x TouchableHighlightBox onPress';
+    } else if (this.state.timesPressed > 0) {
+      textLog = 'TouchableHighlightBox onPress';
+    }
+
     return (
       <View>
         <View style={styles.row}>
           <TouchableHighlight
             style={styles.wrapper}
-            onPress={() => console.log('stock THW image - highlight')}>
+            onPress={this.touchableOnPress}>
             <Image source={heartImage} style={styles.image} />
           </TouchableHighlight>
           <TouchableHighlight
@@ -152,11 +169,14 @@ class TouchableHighlightBox extends React.Component<{}, $FlowFixMeState> {
               pressDuration: 0.6,
             }}
             underlayColor="rgb(210, 230, 255)"
-            onPress={() => console.log('custom THW text - highlight')}>
+            onPress={this.touchableOnPress}>
             <View style={styles.wrapperCustom}>
               <Text style={styles.text}>Tap Here For Custom Highlight!</Text>
             </View>
           </TouchableHighlight>
+        </View>
+        <View style={styles.logBox}>
+          <Text>{textLog}</Text>
         </View>
       </View>
     );


### PR DESCRIPTION
Adds some initial tests for Touchable*. It only tests the first screen worth of examples; in a separate PR I'll work on an alternate way to "scroll" to individual examples in tests, before I add tests for the rest of the Touchable examples.

On the live stream where I began writing these tests, I reorganized the "Touchable feedback examples" to the top of the list so it would be on-screen for testing. I didn't include this reorganization or test in this PR; that can be added in once the "alternative to scrolling" is added in, to avoid having to reorganize.

Changelog:
----------
[General] [Added] - Add E2E tests for Touchable