### PR TITLE
Detox debug build

### DIFF
--- a/RNTester/README.md
+++ b/RNTester/README.md
@@ -58,6 +58,29 @@ Run the following commands from the react-native folder:
 
 _Note: The native libs are still built using gradle. Full build with buck is coming soon(tm)._
 
+## Running Detox Tests on iOS
+
+Install Detox from [here](https://github.com/wix/Detox/blob/master/docs/Introduction.GettingStarted.md).
+
+To run the tests locally or on CI, run the following commands from the react-native folder:
+
+    yarn build-ios-e2e
+    yarn test-ios-e2e
+
+These are the equivalent of running:
+
+    detox build -c ios.sim.release
+    detox test -c ios.sim.release --cleanup
+
+These build the app in Release mode, so the production code is bundled and included in the built app.
+
+When developing E2E tests, you may want to run in development mode, so that changes to the production code show up immediately. To do this, run:
+
+    detox build -c ios.sim.debug
+    detox test -c ios.sim.debug
+
+You will also need to have Metro Bundler running in another terminal. Note that if you've previously run the E2E tests in release mode, you may need to delete the `RNTester/build` folder before rerunning `detox build`.
+
 ## Built from source
 
 Building the app on both iOS and Android means building the React Native framework from source. This way you're running the latest native and JS code the way you see it in your clone of the github repo.

--- a/RNTester/README.md
+++ b/RNTester/README.md
@@ -62,7 +62,7 @@ _Note: The native libs are still built using gradle. Full build with buck is com
 
 Install Detox from [here](https://github.com/wix/Detox/blob/master/docs/Introduction.GettingStarted.md).
 
-To run the tests locally or on CI, run the following commands from the react-native folder:
+To run the e2e tests locally, run the following commands from the react-native folder:
 
     yarn build-ios-e2e
     yarn test-ios-e2e

--- a/package.json
+++ b/package.json
@@ -250,6 +250,12 @@
         "build": "xcodebuild -project RNTester/RNTester.xcodeproj -scheme RNTester -configuration Release -sdk iphonesimulator -derivedDataPath RNTester/build -UseModernBuildSystem=NO -quiet",
         "type": "ios.simulator",
         "name": "iPhone 8"
+      },
+      "ios.sim.debug": {
+        "binaryPath": "RNTester/build/Build/Products/Debug-iphonesimulator/RNTester.app/",
+        "build": "xcodebuild -project RNTester/RNTester.xcodeproj -scheme RNTester -configuration Debug -sdk iphonesimulator -derivedDataPath RNTester/build -UseModernBuildSystem=NO -quiet",
+        "type": "ios.simulator",
+        "name": "iPhone 8"
       }
     }
   }


### PR DESCRIPTION
Adds a Detox configuration and instructions for running the app in development mode in Detox. This speeds up developing tests, because changes to production code don't require a full rebuild.

Test Plan:
----------
As described in `RNTester/Readme.md`:

When developing E2E tests, you may want to run in development mode, so that changes to the production code show up immediately. To do this, run:

    detox build -c ios.sim.debug
    detox test -c ios.sim.debug

The previous release mode can still be done by running:

    yarn build-ios-e2e
    yarn test-ios-e2e

Or:

    detox build -c ios.sim.release
    detox test -c ios.sim.release --cleanup

Changelog:
----------
[General] [Added] - Add debug configuration for Detox tests
