### PR TITLE
Map textContentType strings to Objective-C constants

### DIFF
--- a/Libraries/Text/TextInput/RCTBaseTextInputView.m
+++ b/Libraries/Text/TextInput/RCTBaseTextInputView.m
@@ -131,9 +131,9 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithFrame:(CGRect)frame)
 
   [attributedTextCopy removeAttribute:RCTTextAttributesTagAttributeName
                                 range:NSMakeRange(0, attributedTextCopy.length)];
-  
+
   textNeedsUpdate = ([self textOf:attributedTextCopy equals:backedTextInputViewTextCopy] == NO);
-  
+
   if (eventLag == 0 && textNeedsUpdate) {
     UITextRange *selection = self.backedTextInputView.selectedTextRange;
     NSInteger oldTextLength = self.backedTextInputView.attributedText.string.length;
@@ -193,9 +193,61 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithFrame:(CGRect)frame)
 {
   #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_10_0
     if (@available(iOS 10.0, *)) {
+
+        static dispatch_once_t onceToken;
+        static NSDictionary<NSString *, NSString *> *contentTypeMap;
+
+        dispatch_once(&onceToken, ^{
+            contentTypeMap = @{@"none": @"",
+                               @"URL": UITextContentTypeURL,
+                               @"addressCity": UITextContentTypeAddressCity,
+                               @"addressCityAndState":UITextContentTypeAddressCityAndState,
+                               @"addressState": UITextContentTypeAddressState,
+                               @"countryName": UITextContentTypeCountryName,
+                               @"creditCardNumber": UITextContentTypeCreditCardNumber,
+                               @"emailAddress": UITextContentTypeEmailAddress,
+                               @"familyName": UITextContentTypeFamilyName,
+                               @"fullStreetAddress": UITextContentTypeFullStreetAddress,
+                               @"givenName": UITextContentTypeGivenName,
+                               @"jobTitle": UITextContentTypeJobTitle,
+                               @"location": UITextContentTypeLocation,
+                               @"middleName": UITextContentTypeMiddleName,
+                               @"name": UITextContentTypeName,
+                               @"namePrefix": UITextContentTypeNamePrefix,
+                               @"nameSuffix": UITextContentTypeNameSuffix,
+                               @"nickname": UITextContentTypeNickname,
+                               @"organizationName": UITextContentTypeOrganizationName,
+                               @"postalCode": UITextContentTypePostalCode,
+                               @"streetAddressLine1": UITextContentTypeStreetAddressLine1,
+                               @"streetAddressLine2": UITextContentTypeStreetAddressLine2,
+                               @"sublocality": UITextContentTypeSublocality,
+                               @"telephoneNumber": UITextContentTypeTelephoneNumber,
+                               };
+
+            if (@available(iOS 11.0, *)) {
+                NSDictionary<NSString *, NSString *> * extras = @{@"username": UITextContentTypeUsername,
+                                                                  @"password": UITextContentTypePassword};
+
+                NSMutableDictionary<NSString *, NSString *> * baseMap = [contentTypeMap mutableCopy];
+                [baseMap addEntriesFromDictionary:extras];
+
+                contentTypeMap = [baseMap copy];
+            }
+
+            if (@available(iOS 12.0, *)) {
+                NSDictionary<NSString *, NSString *> * extras = @{@"newPassword": UITextContentTypeNewPassword,
+                                                                  @"oneTimeCode": UITextContentTypeOneTimeCode};
+
+                NSMutableDictionary<NSString *, NSString *> * baseMap = [contentTypeMap mutableCopy];
+                [baseMap addEntriesFromDictionary:extras];
+
+                contentTypeMap = [baseMap copy];
+            }
+        });
+
         // Setting textContentType to an empty string will disable any
         // default behaviour, like the autofill bar for password inputs
-        self.backedTextInputView.textContentType = [type isEqualToString:@"none"] ? @"" : type;
+        self.backedTextInputView.textContentType = type ? contentTypeMap[type] : type;
     }
   #endif
 }

--- a/RNTester/js/TextInputExample.ios.js
+++ b/RNTester/js/TextInputExample.ios.js
@@ -1085,4 +1085,19 @@ exports.examples = [
       );
     },
   },
+  {
+    title: 'Text Content Type',
+    render: function() {
+      return (
+        <View>
+          <WithLabel label="emailAddress">
+            <TextInput textContentType="emailAddress" style={styles.default} />
+          </WithLabel>
+          <WithLabel label="name">
+            <TextInput textContentType="name" style={styles.default} />
+          </WithLabel>
+        </View>
+      );
+    },
+  },
 ];


### PR DESCRIPTION
Fixes #22578

Currently the only `textContentType` values that work are: `username`, `password`, `location`, `name` and `nickname`. This is due to the strings provided by React Native not matching up with the underlying string constants used in iOS (with the exception of the aforementioned types). Issue #22578 has more detail examples/explanation.

Test Plan:
----------
Added a **Text Content Type** example to the RNTester app which shows two examples which weren't previously working.

> **Note:** In my testing, most (if not all) `textContentType` values don't work on the simulator, instead they need to be tested on a real device.

Before | After
---|---
![img_1584](https://user-images.githubusercontent.com/721323/49712029-a0ed4b80-fc96-11e8-8ba6-3df81845ab09.PNG) | ![img_1583](https://user-images.githubusercontent.com/721323/49712035-a3e83c00-fc96-11e8-9da3-aa27c2a85e85.PNG)


Changelog:
----------

[iOS] [Fixed] - Fixes textContentTypes not working by mapping textContentType strings to Objective-C constants - Fixes #22578 