### PR TITLE
Remove persistence from RNTester app

### DIFF
--- a/RNTester/e2e/__tests__/Button-test.js
+++ b/RNTester/e2e/__tests__/Button-test.js
@@ -8,10 +8,11 @@
  * @format
  */
 
-/* global element, by, expect */
+/* global device, element, by, expect */
 
 describe('Button', () => {
   beforeAll(async () => {
+    await device.reloadReactNative();
     await element(by.id('explorer_search')).replaceText('<Button>');
     await element(
       by.label('<Button> Simple React Native button component.'),

--- a/RNTester/e2e/__tests__/Switch-test.js
+++ b/RNTester/e2e/__tests__/Switch-test.js
@@ -8,12 +8,13 @@
  * @format
  */
 
-/* global element, by, expect */
+/* global device, element, by, expect */
 
 const jestExpect = require('expect');
 
 describe('Switch', () => {
   beforeAll(async () => {
+    await device.reloadReactNative();
     await element(by.id('explorer_search')).replaceText('<Switch>');
     await element(by.label('<Switch> Native boolean input')).tap();
   });

--- a/RNTester/js/RNTesterApp.ios.js
+++ b/RNTester/js/RNTesterApp.ios.js
@@ -70,17 +70,8 @@ class RNTesterApp extends React.Component<Props, RNTesterNavigationState> {
         );
         const urlAction = URIActionMap(url);
         const launchAction = exampleAction || urlAction;
-        if (err || !storedString) {
-          const initialAction = launchAction || {type: 'InitialAction'};
-          this.setState(RNTesterNavigationReducer(undefined, initialAction));
-          return;
-        }
-        const storedState = JSON.parse(storedString);
-        if (launchAction) {
-          this.setState(RNTesterNavigationReducer(storedState, launchAction));
-          return;
-        }
-        this.setState(storedState);
+        const initialAction = launchAction || {type: 'InitialAction'};
+        this.setState(RNTesterNavigationReducer(undefined, initialAction));
       });
     });
 

--- a/RNTester/js/RNTesterExampleList.js
+++ b/RNTester/js/RNTesterExampleList.js
@@ -18,13 +18,11 @@ const Text = require('Text');
 const TextInput = require('TextInput');
 const TouchableHighlight = require('TouchableHighlight');
 const RNTesterActions = require('./RNTesterActions');
-const RNTesterStatePersister = require('./RNTesterStatePersister');
 const View = require('View');
 
 /* $FlowFixMe(>=0.78.0 site=react_native_android_fb) This issue was found when
  * making Flow check .android.js files. */
 import type {RNTesterExample} from './RNTesterList.ios';
-import type {PassProps} from './RNTesterStatePersister';
 import type {TextStyleProp, ViewStyleProp} from 'StyleSheet';
 
 type Props = {
@@ -33,7 +31,6 @@ type Props = {
     ComponentExamples: Array<RNTesterExample>,
     APIExamples: Array<RNTesterExample>,
   },
-  persister: PassProps<*>,
   searchTextInputStyle: TextStyleProp,
   style?: ?ViewStyleProp,
 };
@@ -73,8 +70,10 @@ const renderSectionHeader = ({section}) => (
 );
 
 class RNTesterExampleList extends React.Component<Props, $FlowFixMeState> {
+  state = {filter: ''};
+
   render() {
-    const filterText = this.props.persister.state.filter;
+    const filterText = this.state.filter;
     let filterRegex = /.*/;
 
     try {
@@ -178,13 +177,13 @@ class RNTesterExampleList extends React.Component<Props, $FlowFixMeState> {
           autoCorrect={false}
           clearButtonMode="always"
           onChangeText={text => {
-            this.props.persister.setState(() => ({filter: text}));
+            this.setState(() => ({filter: text}));
           }}
           placeholder="Search..."
           underlineColorAndroid="transparent"
           style={[styles.searchTextInput, this.props.searchTextInputStyle]}
           testID="explorer_search"
-          value={this.props.persister.state.filter}
+          value={this.state.filter}
         />
       </View>
     );
@@ -197,17 +196,6 @@ class RNTesterExampleList extends React.Component<Props, $FlowFixMeState> {
 
 const ItemSeparator = ({highlighted}) => (
   <View style={highlighted ? styles.separatorHighlighted : styles.separator} />
-);
-
-/* $FlowFixMe(>=0.85.0 site=react_native_fb) This comment suppresses an error
- * found when Flow v0.85 was deployed. To see the error, delete this comment
- * and run Flow. */
-RNTesterExampleList = RNTesterStatePersister.createContainer(
-  RNTesterExampleList,
-  {
-    cacheKeySuffix: () => 'mainList',
-    getInitialState: () => ({filter: ''}),
-  },
 );
 
 const styles = StyleSheet.create({

--- a/RNTester/js/RNTesterExampleList.js
+++ b/RNTester/js/RNTesterExampleList.js
@@ -31,7 +31,6 @@ type Props = {
     ComponentExamples: Array<RNTesterExample>,
     APIExamples: Array<RNTesterExample>,
   },
-  searchTextInputStyle: TextStyleProp,
   style?: ?ViewStyleProp,
 };
 
@@ -181,7 +180,7 @@ class RNTesterExampleList extends React.Component<Props, $FlowFixMeState> {
           }}
           placeholder="Search..."
           underlineColorAndroid="transparent"
-          style={[styles.searchTextInput, this.props.searchTextInputStyle]}
+          style={styles.searchTextInput}
           testID="explorer_search"
           value={this.state.filter}
         />


### PR DESCRIPTION
Previously the RNTester app saved what screen you were on and what filter text was entered into the initial screen. This made e2e testing complex, as each test needed to manually restore the state to the home screen. If the state ever got out of sync with the test's expectations, it could lead to multiple failed tests.

There is still one specific component that uses persistence: `RNTesterSettingSwitchRow`. Persistence can be removed from this component next time tests for it are updated. As a result, `RNTesterStatePersister` is not yet entirely removed from the app.

Test Plan:
----------
CI running yarn test-ios-e2e will confirm the tests still pass.

You can also run RNTester manually to confirm that after quitting and restarting the app, you're returned to the home screen of the app, and the filter state is not saved.

Changelog:
----------
[General] [Removed] - Remove persistence from RNTester app
