### PR TITLE
Use relative path for SCRIPTDIR

### DIFF
--- a/scripts/ios-install-third-party.sh
+++ b/scripts/ios-install-third-party.sh
@@ -63,7 +63,7 @@ function fetch_and_unpack () {
 
 mkdir -p third-party
 
-SCRIPTDIR=$(cd $(dirname "$0") && pwd)
+SCRIPTDIR=$(dirname "$0")
 
 fetch_and_unpack glog-0.3.5.tar.gz https://github.com/google/glog/archive/v0.3.5.tar.gz 61067502c5f9769d111ea1ee3f74e6ddf0a5f9cc "\"$SCRIPTDIR/ios-configure-glog.sh\""
 fetch_and_unpack double-conversion-1.1.6.tar.gz https://github.com/google/double-conversion/archive/v1.1.6.tar.gz 1c7d88afde3aaeb97bb652776c627b49e132e8e0


### PR DESCRIPTION
Fixes https://github.com/facebook/react-native/issues/22521

The current approach has an issue with white spaces when compiling in Xcode 10.1

![space](https://user-images.githubusercontent.com/615282/49782648-07836f80-fd52-11e8-952f-b93f8c593c60.png)

Change back to relative path fixes this issue


Test Plan:
----------
Init a new project with white space in the name and compile it in Xcode. It should pass with this pr.

Changelog:
----------
None