### PR TITLE
Leak mutex to avoid a crashing issue

### DIFF
--- a/React/Views/RCTFont.mm
+++ b/React/Views/RCTFont.mm
@@ -126,12 +126,12 @@ static NSString *FontWeightDescriptionFromUIFontWeight(UIFontWeight fontWeight)
 static UIFont *cachedSystemFont(CGFloat size, RCTFontWeight weight)
 {
   static NSCache *fontCache;
-  static std::mutex fontCacheMutex;
+  static std::mutex *fontCacheMutex = new std::mutex;
 
   NSString *cacheKey = [NSString stringWithFormat:@"%.1f/%.2f", size, weight];
   UIFont *font;
   {
-    std::lock_guard<std::mutex> lock(fontCacheMutex);
+    std::lock_guard<std::mutex> lock(*fontCacheMutex);
     if (!fontCache) {
       fontCache = [NSCache new];
     }
@@ -158,7 +158,7 @@ static UIFont *cachedSystemFont(CGFloat size, RCTFontWeight weight)
     }
 
     {
-      std::lock_guard<std::mutex> lock(fontCacheMutex);
+      std::lock_guard<std::mutex> lock(*fontCacheMutex);
       [fontCache setObject:font forKey:cacheKey];
     }
   }


### PR DESCRIPTION
Try to solve https://github.com/facebook/react-native/issues/13588
ref: https://github.com/facebook/componentkit/pull/906


Test Plan:
----------
Regression / smoke tests should be enough.

Changelog:
----------
[iOS] [Fixed] - Fix a crashing issue on RCTFont / mutex