### PR TITLE
Fix E2E warnings

### DIFF
--- a/RNTester/e2e/config.json
+++ b/RNTester/e2e/config.json
@@ -1,5 +1,5 @@
 {
-  "setupTestFrameworkScriptFile" : "./test-init.js",
+  "setupFilesAfterEnv" : ["./test-init.js"],
   "testEnvironment": "node",
   "bail": true,
   "verbose": true

--- a/RNTester/js/RNTesterApp.ios.js
+++ b/RNTester/js/RNTesterApp.ios.js
@@ -30,6 +30,7 @@ const {
   Text,
   View,
   SafeAreaView,
+  YellowBox,
 } = ReactNative;
 
 import type {RNTesterExample} from './RNTesterList.ios';
@@ -39,6 +40,12 @@ import type {RNTesterNavigationState} from './RNTesterNavigationReducer';
 type Props = {
   exampleFromAppetizeParams: string,
 };
+
+YellowBox.ignoreWarnings([
+  'ListView and SwipeableListView are deprecated',
+  'ListView is deprecated',
+  'Module RCTImagePickerManager requires main queue setup',
+]);
 
 const APP_STATE_KEY = 'RNTesterAppState.v2';
 

--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
     "test-android-unit": "yarn run docker-build-android && yarn run test-android-run-unit",
     "test-android-e2e": "yarn run docker-build-android && yarn run test-android-run-e2e",
     "build-ios-e2e": "detox build -c ios.sim.release",
-    "test-ios-e2e": "detox test -c ios.sim.release --cleanup"
+    "test-ios-e2e": "detox test -c ios.sim.release"
   },
   "peerDependencies": {
     "react": "16.6.3"


### PR DESCRIPTION
Fixes two types of warnings that occur when running E2E tests:

1. A deprecation warning from Jest: 'Option "setupTestFrameworkScriptFile" was replaced by configuration "setupFilesAfterEnv", which supports multiple paths.'
2. YellowBox warnings when running the app in debug mode, about components that are deprecated and that require main queue setup.

By fixing these warnings, we increase contributors' confidence that things are working correctly, and draw attention to any warnings that they _should_ pay attention to, if and when they arise.

I feel confident that we should hide the deprecated-component warnings; we _want_ to use these components because we want them to be tested, until they're removed entirely.

For the warning "Module RCTImagePickerManager requires main queue setup", if that's something that can be fixed with reasonable effort in the RNTester code then I think it would be better to do so. Otherwise, I think it is good to hide the warning, because this is a condition we expect: it's not something a contributor should pay attention to.

Test Plan:
----------

Run:

```
detox build -c ios.sim.debug
detox test -c ios.sim.debug
```

You should not see any warnings in the console, or any YellowBox warnings in the simulator.

Changelog:
----------
[General] [Fixed] - Fix E2E warnings
