### PR TITLE
[FIX][Android]: The ART '<Surface>' becomes invisible in Android

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/art/ARTSurfaceViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/art/ARTSurfaceViewManager.java
@@ -60,7 +60,8 @@ public class ARTSurfaceViewManager extends
 
   @Override
   public void updateExtraData(ARTSurfaceView root, Object extraData) {
-    root.setSurfaceTextureListener((ARTSurfaceViewShadowNode) extraData);
+    ARTSurfaceViewShadowNode shadowNode = (ARTSurfaceViewShadowNode) extraData;
+    shadowNode.setupSurfaceTextureListener(root);
   }
 
   @Override

--- a/ReactAndroid/src/main/java/com/facebook/react/views/art/ARTSurfaceViewShadowNode.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/art/ARTSurfaceViewShadowNode.java
@@ -16,6 +16,7 @@ import android.view.Surface;
 import android.graphics.PorterDuff;
 import android.graphics.SurfaceTexture;
 import android.view.TextureView;
+import android.os.Build;
 
 import com.facebook.common.logging.FLog;
 import com.facebook.react.common.ReactConstants;
@@ -23,13 +24,15 @@ import com.facebook.react.uimanager.LayoutShadowNode;
 import com.facebook.react.uimanager.UIViewOperationQueue;
 import com.facebook.react.uimanager.ReactShadowNode;
 import com.facebook.react.uimanager.ViewProps;
+import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.annotations.ReactProp;
+import com.facebook.react.bridge.LifecycleEventListener;
 
 /**
  * Shadow node for ART virtual tree root - ARTSurfaceView
  */
 public class ARTSurfaceViewShadowNode extends LayoutShadowNode
-  implements TextureView.SurfaceTextureListener {
+  implements TextureView.SurfaceTextureListener, LifecycleEventListener {
 
   private @Nullable Surface mSurface;
 
@@ -95,6 +98,33 @@ public class ARTSurfaceViewShadowNode extends LayoutShadowNode
       markChildrenUpdatesSeen(child);
     }
   }
+
+  @Override
+  public void setThemedContext(ThemedReactContext themedContext) {
+    super.setThemedContext(themedContext);
+    if (Build.VERSION.SDK_INT > Build.VERSION_CODES.N) {
+      themedContext.addLifecycleEventListener(this);
+    }
+  }
+
+  @Override
+  public void dispose() {
+    super.dispose();
+    if (Build.VERSION.SDK_INT > Build.VERSION_CODES.N) {
+      getThemedContext().removeLifecycleEventListener(this);
+    }
+  }
+
+  @Override
+  public void onHostResume() {
+    drawOutput();
+  }
+
+  @Override
+  public void onHostPause() {}
+
+  @Override
+  public void onHostDestroy() {}
 
   @Override
   public void onSurfaceTextureAvailable(SurfaceTexture surface, int width, int height) {

--- a/ReactAndroid/src/main/java/com/facebook/react/views/art/ARTSurfaceViewShadowNode.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/art/ARTSurfaceViewShadowNode.java
@@ -104,7 +104,7 @@ public class ARTSurfaceViewShadowNode extends LayoutShadowNode
 
   @Override
   public boolean onSurfaceTextureDestroyed(SurfaceTexture surface) {
-    surface.release();
+    mSurface.release();
     mSurface = null;
     return true;
   }


### PR DESCRIPTION
Hello Everyone, this series of commits helps to fix problems related to ART on Android. The main problem in here is that the ART components would disappear if the user turns off the screen and then turn it on again.  It's important to note that this behaviour only occurs after Android N (7.1 or higher).

Test Plan:
----------
 * Open the Android emulator using API level 25 or higher (Android 7.1 or higher)
 * Create an react-native-app with the following code:
```javascript
import React, { Component } from 'react';
import { Platform, StyleSheet, Text, View, ART } from "react-native";


const path = ART.Path();

path.moveTo(0, 0);
path.lineTo(10, 10);

type Props = {};
export default class App extends Component<Props> {
  render() {
    return (
      <View style={styles.container}>
        <ART.Surface width={300} height={300}>
          <ART.Shape d="M150 0 L75 200 L225 200 Z" fill="#ff0000"/>
        </ART.Surface>
      </View>
    );
  }
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    justifyContent: 'center',
    alignItems: 'center',
    backgroundColor: '#F5FCFF',
  },
});
```
* After the App is running, turn off the screen
* Wait some seconds and turn it on again
* **Expected result**: The triangle should be visible
* **Unexpected result ( without this patch series)**: The triangle will not be visible

Changelog:
----------

[Android] [BUGFIX] [ARTSurfaceViewShadowNode] - Properly release mSurface
[Android] [BUGFIX] [ARTSurfaceViewShadowNode] - Fix Surface becoming invisible in Android
[Android] [BUGFIX] [ARTSurfaceViewShadowNode] - Fix surface not being drawed on app startup

Fixes #17565