### PR TITLE
Don't reconnect inspector if connection refused

### DIFF
--- a/React/Inspector/RCTInspectorPackagerConnection.m
+++ b/React/Inspector/RCTInspectorPackagerConnection.m
@@ -201,7 +201,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
     [self abort:@"Websocket exception"
       withCause:error];
   }
-  if (!_closed) {
+  if (!_closed && [error code] != ECONNREFUSED) {
     [self reconnect];
   }
 }


### PR DESCRIPTION
(Together with a pr to react-devtools) Fixes https://github.com/facebook/react-native/issues/21030

## Changelog

[iOS] [Fixed] - Fix infinite retry loop of inspector