### PR TITLE
WIP Fix Jest deprecation warning

### DIFF
--- a/RNTester/e2e/config.json
+++ b/RNTester/e2e/config.json
@@ -1,5 +1,5 @@
 {
-  "setupTestFrameworkScriptFile" : "./test-init.js",
+  "setupFilesAfterEnv" : ["./test-init.js"],
   "testEnvironment": "node",
   "bail": true,
   "verbose": true

--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
     "test-android-unit": "yarn run docker-build-android && yarn run test-android-run-unit",
     "test-android-e2e": "yarn run docker-build-android && yarn run test-android-run-e2e",
     "build-ios-e2e": "detox build -c ios.sim.release",
-    "test-ios-e2e": "detox test -c ios.sim.release --cleanup"
+    "test-ios-e2e": "detox test -c ios.sim.release"
   },
   "peerDependencies": {
     "react": "16.6.3"


### PR DESCRIPTION
**Please do not merge:** troubleshooting the Detox E2E tests from #22621 in progress

Fixes a deprecation warning from Jest: 'Option "setupTestFrameworkScriptFile" was replaced by configuration "setupFilesAfterEnv", which supports multiple paths.'

By fixing this warnings, we increase contributors' confidence that things are working correctly, and draw attention to any warnings that they _should_ pay attention to, if and when they arise.

Test Plan:
----------

Run:

```
detox build -c ios.sim.debug
detox test -c ios.sim.debug
```

You should not see any warnings in the console.

Changelog:
----------
[General] [Fixed] - Fix Jest deprecation warning
