### PR TITLE
Fix RNTesterUnitTests failure

### DIFF
--- a/RNTester/RNTester.xcodeproj/project.pbxproj
+++ b/RNTester/RNTester.xcodeproj/project.pbxproj
@@ -131,6 +131,7 @@
 		C654F0B31EB34A73000B7A9A /* RNTesterTestModule.m in Sources */ = {isa = PBXBuildFile; fileRef = C654F0B21EB34A73000B7A9A /* RNTesterTestModule.m */; };
 		C654F17E1EB34D24000B7A9A /* RNTesterTestModule.m in Sources */ = {isa = PBXBuildFile; fileRef = C654F0B21EB34A73000B7A9A /* RNTesterTestModule.m */; };
 		D85B829E1AB6D5D7003F4FE2 /* libRCTVibration.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D85B829C1AB6D5CE003F4FE2 /* libRCTVibration.a */; };
+		E77B20F321C481F8007FDF6D /* JavaScriptCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EDEBC7DA214C681C00DD5AC8 /* JavaScriptCore.framework */; };
 		ED2970992150247000B7C4FE /* JavaScriptCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ED2970982150247000B7C4FE /* JavaScriptCore.framework */; };
 		EDEBC856214C774100DD5AC8 /* JavaScriptCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EDEBC7DA214C681C00DD5AC8 /* JavaScriptCore.framework */; };
 /* End PBXBuildFile section */
@@ -573,6 +574,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E77B20F321C481F8007FDF6D /* JavaScriptCore.framework in Frameworks */,
 				19BA89031F8439A700741C5A /* libRCTBlob.a in Frameworks */,
 				192F69DA1E8240E2008692C7 /* libRCTAnimation.a in Frameworks */,
 				14D6D71E1B2222EF001FB087 /* libRCTActionSheet.a in Frameworks */,


### PR DESCRIPTION
Summary:
Add JavaScriptCore.framework to RNTester's RNTesterUnitTests target. This resolves the failure seen when running `scripts/objc-test-ios.sh test` seen in Circle CI.

 See D9875409 for a related diff (https://github.com/facebook/react-native/commit/78fcf7c5598ce7f5d0d62110eb34fe5a4b962e71 in open source).

Without this diff, `scripts/objc-test-ios.sh test` would fail with the following error (see Circle https://circleci.com/gh/facebook/react-native/63704):

```
�  ld: symbol(s) not found for architecture x86_64

�  clang: error: linker command failed with exit code 1 (use -v to see invocation)

Testing failed:
	"_JSObjectGetPrototype", referenced from:
	"_JSObjectSetPrototype", referenced from:
	"_JSPropertyNameAccumulatorAddName", referenced from:
	"_JSObjectCopyPropertyNames", referenced from:
	"_JSContextGetGlobalObject", referenced from:
	"_JSValueMakeString", referenced from:
	"_JSValueIsNumber", referenced from:
	"_JSClassCreate", referenced from:
	"_JSObjectGetPropertyAtIndex", referenced from:
	"_JSObjectMakeArray", referenced from:
	"_JSEvaluateScript", referenced from:
	"_JSValueIsUndefined", referenced from:
	"_JSPropertyNameArrayGetCount", referenced from:
	"_JSPropertyNameArrayGetNameAtIndex", referenced from:
	"_JSPropertyNameArrayRelease", referenced from:
	"_JSValueMakeUndefined", referenced from:
	"_JSValueMakeNull", referenced from:
	"_JSStringCreateWithUTF8CString", referenced from:
	"_JSObjectSetProperty", referenced from:
	"_JSObjectHasProperty", referenced from:
	"_kJSClassDefinitionEmpty", referenced from:
	"_JSObjectIsFunction", referenced from:
	"_JSValueIsBoolean", referenced from:
	"_JSValueIsInstanceOfConstructor", referenced from:
	"_JSValueIsObjectOfClass", referenced from:
	"_JSValueToNumber", referenced from:
	"_JSGlobalContextRelease", referenced from:
	"_JSValueToBoolean", referenced from:
	"_JSValueIsArray", referenced from:
	"_JSValueMakeNumber", referenced from:
	"_JSObjectSetPrivate", referenced from:
	"_JSValueIsNull", referenced from:
	"_JSObjectSetPropertyAtIndex", referenced from:
	"_JSValueIsObject", referenced from:
	"_JSValueMakeBoolean", referenced from:
	"_JSValueUnprotect", referenced from:
	"_JSValueToStringCopy", referenced from:
	"_JSObjectGetProperty", referenced from:
	"_JSValueToObject", referenced from:
	"_JSObjectGetPrivate", referenced from:
	"_JSStringRelease", referenced from:
	"_JSGlobalContextRetain", referenced from:
	"_JSStringIsEqual", referenced from:
	"_JSStringGetMaximumUTF8CStringSize", referenced from:
	"_JSObjectCallAsFunction", referenced from:
	"_JSStringGetUTF8CString", referenced from:
	"_JSValueProtect", referenced from:
	"_JSValueIsString", referenced from:
	"_JSStringRetain", referenced from:
	"_JSObjectMake", referenced from:
	"_JSGlobalContextCreateInGroup", referenced from:
	"_JSObjectCallAsConstructor", referenced from:
	Linker command failed with exit code 1 (use -v to see invocation)
	Testing cancelled because the build failed.
** TEST FAILED **
```

Differential Revision: D13474936
