### PR TITLE
Remove injectJavascript from WebView propTypes definition

### DIFF
--- a/Libraries/Components/WebView/WebView.android.js
+++ b/Libraries/Components/WebView/WebView.android.js
@@ -191,12 +191,6 @@ class WebView extends React.Component {
     originWhitelist: PropTypes.arrayOf(PropTypes.string),
 
     /**
-     * Function that accepts a string that will be passed to the WebView and
-     * executed immediately as JavaScript.
-     */
-    injectJavaScript: PropTypes.func,
-
-    /**
      * Specifies the mixed content mode. i.e WebView will allow a secure origin to load content from any other origin.
      *
      * Possible values for `mixedContentMode` are:

--- a/Libraries/Components/WebView/WebView.ios.js
+++ b/Libraries/Components/WebView/WebView.ios.js
@@ -363,12 +363,6 @@ class WebView extends React.Component {
     originWhitelist: PropTypes.arrayOf(PropTypes.string),
 
     /**
-     * Function that accepts a string that will be passed to the WebView and
-     * executed immediately as JavaScript.
-     */
-    injectJavaScript: PropTypes.func,
-
-    /**
      * Specifies the mixed content mode. i.e WebView will allow a secure origin to load content from any other origin.
      *
      * Possible values for `mixedContentMode` are:


### PR DESCRIPTION
Related to https://github.com/facebook/react-native-website/pull/646

`injectJavascript` isn't a consumed prop of `WebView` -- it's a class method. This PR removes the prop type for it to prevent confusion in the future.

Test Plan:
----------
No test required, only removes an unused PropType.

Changelog:
----------
[General][Fixed] - Removed unused `injectJavascript` from `WebView` prop types