### PR TITLE
Fix modal and alert dismissal bugs

### DIFF
--- a/React/Views/RCTModalHostView.h
+++ b/React/Views/RCTModalHostView.h
@@ -43,7 +43,12 @@
 
 @protocol RCTModalHostViewInteractor <NSObject>
 
-- (void)presentModalHostView:(RCTModalHostView *)modalHostView withViewController:(RCTModalHostViewController *)viewController animated:(BOOL)animated;
-- (void)dismissModalHostView:(RCTModalHostView *)modalHostView withViewController:(RCTModalHostViewController *)viewController animated:(BOOL)animated;
+- (void)presentModalHostView:(RCTModalHostView *)modalHostView
+          withViewController:(RCTModalHostViewController *)viewController
+                    animated:(BOOL)animated;
+- (void)dismissModalHostView:(RCTModalHostView *)modalHostView
+          withViewController:(RCTModalHostViewController *)viewController
+                    animated:(BOOL)animated
+                  completion:(void (^)(void))completionHandler;
 
 @end

--- a/React/Views/RCTModalHostView.m
+++ b/React/Views/RCTModalHostView.m
@@ -161,8 +161,12 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:coder)
 - (void)dismissModalViewController
 {
   if (_isPresented) {
-    [_delegate dismissModalHostView:self withViewController:_modalViewController animated:[self hasAnimationType]];
-    _isPresented = NO;
+    [_delegate dismissModalHostView:self
+                 withViewController:_modalViewController
+                           animated:[self hasAnimationType]
+                         completion:^{
+                           self->_isPresented = NO;
+                         }];
   }
 }
 

--- a/React/Views/RCTModalHostViewController.m
+++ b/React/Views/RCTModalHostViewController.m
@@ -72,5 +72,4 @@
 #endif // RCT_DEV
 #endif // !TARGET_OS_TV
 
-
 @end


### PR DESCRIPTION
Fixes #22237

Summary:

1. Fixed a bug with dismissing modals that caused the modal to stay on screen after being dismissed if some other view controller is presented on top of it.

2. Fixed an issue where dismissing a modal (by changing its `visible` property) would also hide alerts presented on top of it (i.e. shown after the modal became visible). This is achieved by presenting each alert in a separate `UIWindow` instance.

3. Fixed a bug where showing two modals rapidly and hiding them would leave an empty (invisible) `RCTModalHostViewController` hanging on screen, which made it impossible to interact with the app as the view controller is display on top of everything.

These changes affect iOS only (no JS/Android changes).

Test Plan:
----------

Need some help with filling this section...

Changelog:
----------

  [iOS] [Fixed] - Fixed various issues with dismissing alerts and modals