### PR TITLE
enable proguard in release mode

### DIFF
--- a/template/android/app/build.gradle
+++ b/template/android/app/build.gradle
@@ -91,7 +91,7 @@ def enableSeparateBuildPerCPUArchitecture = false
 /**
  * Run Proguard to shrink the Java bytecode in release builds.
  */
-def enableProguardInReleaseBuilds = false
+def enableProguardInReleaseBuilds = true
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion


### PR DESCRIPTION
## Motivation
This is default behavior  in android project. With progurad the code runs fast, the apk is smaller.
## Test Plan
pass all current ci.
## Release Notes
[Android] [Feature] - enable proguard in release mode
