### PR TITLE
Rearrange PR Template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,45 +1,16 @@
 Thank you for sending the PR! We appreciate you spending the time to work on these changes.
-Help us understand your motivation by explaining why you decided to make this change.
+Help us understand your motivation by explaining why you decided to make this change:
 
-If this PR fixes an issue, type "Fixes #issueNumber" to automatically close the issue when the PR is merged.
-
-_Pull requests that expand test coverage are more likely to get reviewed. Add a test case whenever possible!_
-
-Test Plan:
-----------
-Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!
 
 Changelog:
 ----------
-Help reviewers and the release process by writing your own changelog entry. When the change doesn't impact React Native developers, it may be ommitted from the changelog for brevity. See below for an example.
+
+Help reviewers and the release process by writing your own changelog entry. See http://facebook.github.io/react-native/docs/contributing#changelog for an example.
 
 [CATEGORY] [TYPE] - Message
 
-<!--
 
-  CATEGORY may be:
+Test Plan:
+----------
 
-  - [General]
-  - [iOS]
-  - [Android]
-
-  TYPE may be:
-
-  - [Added] for new features.
-  - [Changed] for changes in existing functionality.
-  - [Deprecated] for soon-to-be removed features.
-  - [Removed] for now removed features.
-  - [Fixed] for any bug fixes.
-  - [Security] in case of vulnerabilities.
-
-  For more detail, see https://keepachangelog.com/en/1.0.0/#how
-
-  MESSAGE may answer "what and why" on a feature level. Use this to briefly tell React Native users about notable changes.
-
-  EXAMPLES:
-
-  [General] [Added] - Add snapToOffsets prop to ScrollView component
-  [General] [Fixed] - Fix various issues in snapToInterval on ScrollView component
-  [iOS] [Fixed] - Fix crash in RCTImagePicker
-
--->
+Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible.


### PR DESCRIPTION
This ensures the changelog is captured as part of the commit description, and not the test plan, when the PR is imported into Phabricator