### PR TITLE
Change location of iOS build cache directory to ~/Library/Caches/

### DIFF
--- a/scripts/ios-install-third-party.sh
+++ b/scripts/ios-install-third-party.sh
@@ -4,14 +4,14 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-cachedir="$HOME/.rncache"
+cachedir="$HOME/Library/Caches/com.facebook.ReactNativeBuild"
 mkdir -p "$cachedir"
 
 function file_fail () {
     cachefile=$1
     msg=$2
 
-    echo "$msg.  Debug info:" 2>&1
+    echo "$msg. Debug info:" 2>&1
     ls -l "$cachefile" 2>&1
     shasum "$cachefile" 2>&1
     exit 1
@@ -29,7 +29,7 @@ function fetch_and_unpack () {
     while true; do
         if [ -f "$cachedir/$file" ]; then
            if shasum -p "$cachedir/$file" |
-              awk -v hash="$hash" '{exit $1 != hash}'; then
+               awk -v hash="$hash" '{exit $1 != hash}'; then
                break
            else
                echo "Incorrect hash:" 2>&1


### PR DESCRIPTION
Instead of using ~/.rncache use the special Caches directory designed for caching files. This fixes #21780.

Changelog:
----------

[iOS] [Changed] - Moved iOS build cache directory to ~/Library/Caches/


Test Plan:
----------

1. Execute ./scripts/ios-install-third-party.sh
2. Check that the directory ~/Library/Caches/com.facebook.ReactNativeBuild is created and that the .tar.gz files of dependencies are present

or better:

1. Create a new project: `react-native init ReactNativeCacheTest`
2. 
   ```
   cd ReactNativeCacheTest
   cp /path/to/react-native-code/scripts/ios-install-third-party.sh node_modules/react-native/scripts/
   ```
3. `react-native run-ios`
4. Check that the directory ~/Library/Caches/com.facebook.ReactNativeBuild is created and that the .tar.gz files of dependencies are present
