### PR TITLE
Fix Android overflow for horizontal scroll container

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollContainerView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollContainerView.java
@@ -25,6 +25,9 @@ public class ReactHorizontalScrollContainerView extends ViewGroup {
 
   @Override
   protected void onLayout(boolean changed, int left, int top, int right, int bottom) {
+    // Allow overflow for current class instance
+    setClipChildren(false);
+
     if (mLayoutDirection == LAYOUT_DIRECTION_RTL) {
       // When the layout direction is RTL, we expect Yoga to give us a layout
       // that extends off the screen to the left so we re-center it with left=0

--- a/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.java
@@ -214,6 +214,7 @@ public class ReactHorizontalScrollView extends HorizontalScrollView implements
 
   @Override
   protected void onLayout(boolean changed, int l, int t, int r, int b) {
+    setClipChildren(false);
     // Call with the present values in order to re-layout if necessary
     scrollTo(getScrollX(), getScrollY());
   }


### PR DESCRIPTION
This change fixes an overflow issue related to horizontal scroll views. Currently, any child `<View/>` within a horizontal `<FlatList/>` will be clipped by default and this change aims to fix this issue.

Changelog:
----------

[Android] [Fixed] - Fixed an Android overflow issue with horizontal scroll views

Test Plan:
----------

* Create a horizontal `<FlatList/>` with styled items having `scale: 2` and a border around each item
* Item border **should not** be cut-off once app is launched