### PR TITLE
Fix textTransform inheritance on Android

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactBaseTextShadowNode.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactBaseTextShadowNode.java
@@ -555,7 +555,7 @@ public abstract class ReactBaseTextShadowNode extends LayoutShadowNode {
   public void setTextTransform(@Nullable String textTransform) {
     if (textTransform == null) {
       mTextTransform = TextTransform.UNSET;
-    } else if("none".equals(textTransform)) {
+    } else if ("none".equals(textTransform)) {
       mTextTransform = TextTransform.NONE;
     } else if ("uppercase".equals(textTransform)) {
       mTextTransform = TextTransform.UPPERCASE;

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactBaseTextShadowNode.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactBaseTextShadowNode.java
@@ -553,7 +553,9 @@ public abstract class ReactBaseTextShadowNode extends LayoutShadowNode {
 
   @ReactProp(name = PROP_TEXT_TRANSFORM)
   public void setTextTransform(@Nullable String textTransform) {
-    if (textTransform == null || "none".equals(textTransform)) {
+    if (textTransform == null) {
+      mTextTransform = TextTransform.UNSET;
+    } else if("none".equals(textTransform)) {
       mTextTransform = TextTransform.NONE;
     } else if ("uppercase".equals(textTransform)) {
       mTextTransform = TextTransform.UPPERCASE;


### PR DESCRIPTION
The `textTransform` inheritance is currently broken on Android because we don't map constants properly in `setTextTransform`. `null` should map to `TextTransform.UNSET`.

```
<Text style={{textTransform: 'uppercase'}}>
  <Text style={{textTransform: 'none'}}>a</Text>
  <Text style={{textTransform: null}}>b</Text>
</Text>
```

This should render `aB` but renders `ab` on android before this fix.

Thanks @rigdern for pointing this out!

Changelog:
----------

[Android] [Fixed] - Fix textTransform inheritance on Android

Test Plan:
----------

Using the example above I reproduced the bug and made sure it renders the proper value after the fix.
