### PR TITLE
Fix failing Switch E2E tests

### DIFF
--- a/RNTester/e2e/__tests__/Switch-test.js
+++ b/RNTester/e2e/__tests__/Switch-test.js
@@ -13,14 +13,10 @@
 const jestExpect = require('expect');
 
 describe('Switch', () => {
-  beforeAll(async () => {
+  beforeEach(async () => {
     await device.reloadReactNative();
     await element(by.id('explorer_search')).replaceText('<Switch>');
     await element(by.label('<Switch> Native boolean input')).tap();
-  });
-
-  afterAll(async () => {
-    await element(by.label('Back')).tap();
   });
 
   it('Switch that starts off should switch', async () => {

--- a/RNTester/e2e/__tests__/Switch-test.js
+++ b/RNTester/e2e/__tests__/Switch-test.js
@@ -23,7 +23,7 @@ describe('Switch', () => {
     await element(by.label('Back')).tap();
   });
 
-  it('Switch that starts on should switch', async () => {
+  it('Switch that starts off should switch', async () => {
     const testID = 'on-off-initial-off';
     const indicatorID = 'on-off-initial-off-indicator';
 
@@ -34,7 +34,7 @@ describe('Switch', () => {
     await expect(element(by.id(indicatorID))).toHaveText('On');
   });
 
-  it('Switch that starts off should switch', async () => {
+  it('Switch that starts on should switch', async () => {
     const testID = 'on-off-initial-on';
     const indicatorID = 'on-off-initial-on-indicator';
 


### PR DESCRIPTION
Switch E2E tests have been failing on master, although they pass locally.

Changelog:
----------

Help reviewers and the release process by writing your own changelog entry. See http://facebook.github.io/react-native/docs/contributing#changelog for an example.

[General] [Fixed] - Fix failing Switch E2E tests


Test Plan:
----------

Switch E2E tests should pass on CI
