### PR TITLE
[iOS] Add image bytes property of UIImage

### DIFF
--- a/Libraries/Image/RCTImageCache.m
+++ b/Libraries/Image/RCTImageCache.m
@@ -71,7 +71,7 @@ static NSString *RCTCacheKeyForImage(NSString *imageTag, CGSize size, CGFloat sc
   if (!image) {
     return;
   }
-  CGFloat bytes = image.size.width * image.size.height * image.scale * image.scale * 4;
+  NSInteger bytes = image.reactDecodedImageBytes;
   if (bytes <= RCTMaxCachableDecodedImageSizeInBytes) {
     [self->_decodedImageCache setObject:image
                                  forKey:cacheKey

--- a/Libraries/Image/RCTImageLoader.h
+++ b/Libraries/Image/RCTImageLoader.h
@@ -52,6 +52,11 @@ typedef dispatch_block_t RCTImageLoaderCancellationBlock;
 
 @property (nonatomic, copy) CAKeyframeAnimation *reactKeyframeAnimation;
 
+/**
+ * Image's memory bytes. It has the dafault calculation of single image of GIF, if you have custom calculation of image decoded bytes, you can assign it using your value.
+ */
+@property (nonatomic, assign) NSInteger reactDecodedImageBytes;
+
 @end
 
 @interface RCTImageLoader : NSObject <RCTBridgeModule, RCTURLRequestHandler>

--- a/Libraries/Image/RCTImageLoader.m
+++ b/Libraries/Image/RCTImageLoader.m
@@ -20,6 +20,17 @@
 #import "RCTImageCache.h"
 #import "RCTImageUtils.h"
 
+static NSInteger RCTImageBytesForImage(UIImage *image)
+{
+  CAKeyframeAnimation *keyFrameAnimation = [image reactKeyframeAnimation];
+  NSInteger singleImageBytes = image.size.width * image.size.height * image.scale * image.scale * 4;
+  if (keyFrameAnimation) {
+    return keyFrameAnimation.values.count * singleImageBytes;
+  } else {
+    return image.images ? image.images.count * singleImageBytes : singleImageBytes;
+  }
+}
+
 @implementation UIImage (React)
 
 - (CAKeyframeAnimation *)reactKeyframeAnimation
@@ -30,6 +41,20 @@
 - (void)setReactKeyframeAnimation:(CAKeyframeAnimation *)reactKeyframeAnimation
 {
     objc_setAssociatedObject(self, @selector(reactKeyframeAnimation), reactKeyframeAnimation, OBJC_ASSOCIATION_COPY_NONATOMIC);
+}
+
+- (NSInteger)reactDecodedImageBytes
+{
+  NSNumber *imageBytes = objc_getAssociatedObject(self, _cmd);
+  if (!imageBytes) {
+    imageBytes = @(RCTImageBytesForImage(self));
+  }
+  return [imageBytes integerValue];
+}
+
+- (void)setReactDecodedImageBytes:(NSInteger)bytes
+{
+  objc_setAssociatedObject(self, @selector(reactDecodedImageBytes), @(bytes), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }
 
 @end


### PR DESCRIPTION
* Added a `reactDecodedImageBytes` property of `UIImage`, to give the chances if user wants to do custom memory calculation.
* Fixes wrong calculation of GIF decoded image bytes.

Changelog:
----------

[iOS] [Fixed] - Fixes image decoded bytes calculation


Test Plan:
----------

For single image, works the same as before. For GIFs, we get the decoded bytes using `total frames * single image bytes`.
