### PR TITLE
Adding JSON support to FormData polyfill

### DIFF
--- a/Libraries/Network/__tests__/FormData-test.js
+++ b/Libraries/Network/__tests__/FormData-test.js
@@ -55,4 +55,30 @@ describe('FormData', function() {
     };
     expect(formData.getParts()[0]).toMatchObject(expectedPart);
   });
+
+  it('should return json object', function() {
+
+    let payoad = {
+      key: 1,
+      title : 'wine bottle'
+    };
+    let strPayloard = JSON.stringify(payload);
+
+    formData.append('json', {
+      value: payoad,
+      type: 'application/json',
+      name :'wine'
+    });
+
+    const expectedPart = {
+      string: strPayloard,
+      type: 'application/json',
+      headers: {
+        'content-disposition': 'form-data; name="wine"',
+        'content-type': 'application/json',
+      },
+      fieldName: 'json',
+    };
+    expect(formData.getParts()[0]).toMatchObject(expectedPart);
+  });
 });


### PR DESCRIPTION
Hi team !


In some circumstances, we need to send a **JSON** payload as a **part** of the `FormData`.
For instance, here is what we need to send, as a final payload:

```
--boundary_1234-abcd 
Content-Type: application/json 
Content-Disposition: form-data; name="mywine" 
{
    'key' : 1,
    'title' : 'red wine'
} 
--boundary_1234-abcd-- 
```

Today, the `FormData` class does not allow us to specify `Content-Type` if the payload *is not* a blob uri.

This PR fixes this issue, allowing the user to pass a JSON payload with a type property `Content-Type: application/json`.   
To do it, the `FormData` value provided by the user, must have a `value` property, containing the JSON object:
``` javascript

{
 value: {}, // JSON Payload
 type : 'application/json',
 name: 'arbitrary_name'
}

``` 
Basically, here is a straightforward sample:

``` JavaScript

    let payload = {
      key: 1,
      title : 'red wine'
    };
   
   formData.append('json', {
      value: payload,
      type: 'application/json',
      name :'mywine'
   });
``` 

Changelog:
----------
[General][added] - Add JSON support to FormData polyfill

Test Plan:
----------
The FormData is updated.    
See `Librairies/Network/__tests__/FormData-test.js`


