### PR TITLE
Fix RCTImageLoader multi thread crash

### DIFF
--- a/Libraries/Network/RCTHTTPRequestHandler.mm
+++ b/Libraries/Network/RCTHTTPRequestHandler.mm
@@ -77,7 +77,7 @@ RCT_EXPORT_MODULE()
                                                capacity:0];
   }
   __block NSURLSessionDataTask *task = nil;
-  dispatch_async(self->_methodQueue, ^{
+  dispatch_sync(self->_methodQueue, ^{
     task = [self->_session dataTaskWithRequest:request];
   });
   {


### PR DESCRIPTION
Fix crash similar to #22410 
react-native: 0.51.0
react: 16.0.0


Changelog:
----------

[iOS] [Changed] - Use onw serial queue to execute invalidate and send request action in RCTHTTPRequestHandler.mm.

Message:
--------

```
- (void)invalidate
{
  [_session invalidateAndCancel];
  _session = nil;
}

- (NSURLSessionDataTask *)sendRequest:(NSURLRequest *)request
                         withDelegate:(id<RCTURLRequestDelegate>)delegate
{
  // Lazy setup
  if (!_session && [self isValid]) {
    NSOperationQueue *callbackQueue = [NSOperationQueue new];
    callbackQueue.maxConcurrentOperationCount = 1;
    callbackQueue.underlyingQueue = [[_bridge networking] methodQueue];
    NSURLSessionConfiguration *configuration = [NSURLSessionConfiguration defaultSessionConfiguration];
    [configuration setHTTPShouldSetCookies:YES];
    [configuration setHTTPCookieAcceptPolicy:NSHTTPCookieAcceptPolicyAlways];
    [configuration setHTTPCookieStorage:[NSHTTPCookieStorage sharedHTTPCookieStorage]];
    _session = [NSURLSession sessionWithConfiguration:configuration
                                             delegate:self
                                        delegateQueue:callbackQueue];

    std::lock_guard<std::mutex> lock(_mutex);
    _delegates = [[NSMapTable alloc] initWithKeyOptions:NSPointerFunctionsStrongMemory
                                           valueOptions:NSPointerFunctionsStrongMemory
                                               capacity:0];
  }

  NSURLSessionDataTask *task = [_session dataTaskWithRequest:request];
  {
    std::lock_guard<std::mutex> lock(_mutex);
    [_delegates setObject:delegate forKey:task];
  }
  [task resume];
  return task;
}

```

now the invalidate function is called by the RCTBridge.invalidate->RCTCxxBridge.invalidate->[moduleData.instance invalidate] , this is on the "com.facebook.react.HTTPRequestHandlerQueue".
the sendRequest:withDelegate function is called by RCTImageLoader and is on the  "com.facebook.react.imageLoaderURLRequestQueue".

when one thread step in invalidate and execute [_session invalidateAndCancel] and the another thread step in sendRequest:withDelegate and execute [_session dataTaskWithRequest:request], the _session is invalidate, so there will be a crash "Task created in a session that has been invalidated"


Test Plan:
----------

The crash can be hard to reproduce. so we can do something to increase the probability.
1. Create a RN page with a list of <Image>
2. I use sleep(3) between [_session invalidateAndCancel]  and _session = nil, and then use sleep(2) before [_session dataTaskWithRequest:request]
3. I force to call [bridge invalidate] when RN controller released to invoke the function of RCTHTTPRequestHandler
4. Go to the RN page, the image invoke sendRequest. Then pop the page, it will invoke invalidate. Multi image loading will frequently cause the crash.

