### PR TITLE
[Android] [TextInput]: Add prop to configure `importantForAutofill`.

### DIFF
--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -230,6 +230,13 @@ type AndroidProps = $ReadOnly<{|
   underlineColorAndroid?: ?ColorValue,
   inlineImageLeft?: ?string,
   inlineImagePadding?: ?number,
+  importantForAutofill?: ?(
+    | 'auto'
+    | 'no'
+    | 'noExcludeDescendants'
+    | 'yes'
+    | 'yesExcludeDescendants'
+  ),
 |}>;
 
 type Props = $ReadOnly<{|

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
@@ -10,6 +10,7 @@ package com.facebook.react.views.textinput;
 import android.graphics.PorterDuff;
 import android.graphics.Typeface;
 import android.graphics.drawable.Drawable;
+import android.os.Build;
 import android.support.v4.content.ContextCompat;
 import android.text.Editable;
 import android.text.InputFilter;
@@ -277,6 +278,24 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
     if (selection.hasKey("start") && selection.hasKey("end")) {
       view.setSelection(selection.getInt("start"), selection.getInt("end"));
     }
+  }
+
+  @ReactProp(name = "importantForAutofill")
+  public void setImportantForAutofill(ReactEditText view, @Nullable String value) {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+      return;
+    }
+    int mode = View.IMPORTANT_FOR_AUTOFILL_AUTO;
+    if ("no".equals(value)) {
+      mode = View.IMPORTANT_FOR_AUTOFILL_NO;
+    } else if ("noExcludeDescendants".equals(value)) {
+      mode = View.IMPORTANT_FOR_AUTOFILL_NO_EXCLUDE_DESCENDANTS;
+    } else if ("yes".equals(value)) {
+      mode = View.IMPORTANT_FOR_AUTOFILL_YES;
+    } else if ("yesExcludeDescendants".equals(value)) {
+      mode = View.IMPORTANT_FOR_AUTOFILL_YES_EXCLUDE_DESCENDANTS;
+    }
+    view.setImportantForAutofill(mode);
   }
 
   @ReactProp(name = "onSelectionChange", defaultBoolean = false)


### PR DESCRIPTION
In API 26, autofill framework was introduced in Android.
Read more about Autofill at https://developer.android.com/guide/topics/text/autofill.

Now, if in case for some text input if developer wants to disable
autofill then he can take help from this `importantForAutoFill` prop
and pass `no` to it.

Also important of auto fill can be configured with this prop, like:
* `auto`: Let the Android System use its heuristics to determine if the view is important for autofill.
* `no`: This view isn't important for autofill.
* `noExcludeDescendants`: This view and its children aren't important for autofill.
* `yes`: This view is important for autofill.
* `yesExcludeDescendants`: This view is important for autofill, but its children aren't important for autofill.

Default value if `auto`.

Read more at: https://developer.android.com/guide/topics/text/autofill-optimize


Changelog:
----------
[Android] [Added] - Add prop to configure `importantForAutofill` in `TextInput`.

Test Plan:
----------
Just add ` importantForAutofill="yesExcludeDescendants"` to `TextInput`.

like this:
```
 <TextInput
          style={{ height: 40, borderColor: 'gray', borderWidth: 1 }}
          onChangeText={text => this.setState({ text })}
          value={this.state.text}
          importantForAutofill="yesExcludeDescendants"
        />
```

Motivation:
----------
Android Oreo introduced the AutoFill Framework, for secure communication between an app and autofill services (e.g. Password managers). When using `<TextInput>` on Android Oreo+, the system already tries to autofill (based on heuristics), but there is no way to set configuring options or **disable**.

So I thought to add ability to **disable**/**configure** this auto fill importance.
