### PR TITLE
Add allowScrollOutOfBounds to ScrollView

### DIFF
--- a/Libraries/Components/ScrollView/ScrollView.js
+++ b/Libraries/Components/ScrollView/ScrollView.js
@@ -76,6 +76,12 @@ type IOSProps = $ReadOnly<{|
    */
   automaticallyAdjustContentInsets?: ?boolean,
   /**
+   * Set to false if the scroll should be clamped to the bounds of the
+   * ScrollView children when using the scrollTo() function. The default value is true.
+   * @platform ios
+   */
+  allowScrollOutOfBounds?: ?boolean,
+  /**
    * The amount by which the scroll view content is inset from the edges
    * of the scroll view. Defaults to `{top: 0, left: 0, bottom: 0, right: 0}`.
    * @platform ios
@@ -976,6 +982,10 @@ class ScrollView extends React.Component<Props, State> {
       : styles.baseVertical;
     const props = {
       ...this.props,
+      allowScrollOutOfBounds:
+        this.props.allowScrollOutOfBounds !== undefined
+          ? this.props.allowScrollOutOfBounds
+          : true,
       alwaysBounceHorizontal,
       alwaysBounceVertical,
       style: ([baseStyle, this.props.style]: ?Array<any>),

--- a/React/Views/ScrollView/RCTScrollView.h
+++ b/React/Views/ScrollView/RCTScrollView.h
@@ -38,6 +38,7 @@
  */
 @property (nonatomic, readonly) UIScrollView *scrollView;
 
+@property (nonatomic, assign) BOOL allowScrollOutOfBounds;
 @property (nonatomic, assign) UIEdgeInsets contentInset;
 @property (nonatomic, assign) BOOL automaticallyAdjustContentInsets;
 @property (nonatomic, assign) BOOL DEPRECATED_sendUpdatedChildFrames;

--- a/React/Views/ScrollView/RCTScrollViewManager.m
+++ b/React/Views/ScrollView/RCTScrollViewManager.m
@@ -54,6 +54,7 @@ RCT_EXPORT_MODULE()
   return [[RCTScrollView alloc] initWithEventDispatcher:self.bridge.eventDispatcher];
 }
 
+RCT_EXPORT_VIEW_PROPERTY(allowScrollOutOfBounds, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(alwaysBounceHorizontal, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(alwaysBounceVertical, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(bounces, BOOL)


### PR DESCRIPTION
When using the scrollTo() function the user can specify a x/y position
that tells the ScrollView to scroll to. Prior to this patch the x/y were
not validated which could cause the SrollView to scroll to a position
outside the content view bounds, leaving the screen empty (the content
disapears, since it goes outside the screen). In order to fix this problem,
this commit imposes that the x/y must be inside the view bounds if allowScrollOutOfBounds
is set to false. This new prop is also set to true automatically to not break
existing apps which may depends on this feature.

Note that this behavior does not occur on Android, because the
Android's framework itself implements this features via [1] and [2], which are used
by React Native.

[1]: https://developer.android.com/reference/android/widget/ScrollView#smoothScrollTo(int,%20int)
[2]: https://developer.android.com/reference/android/widget/ScrollView.html#scrollTo(int,%20int)


Changelog:
----------

[iOS] [Added] - Add allowScrollOutOfBounds to ScrollView


Test Plan:
----------
Run the following code on a iOS simulator/device and play around with the new `allowScrollOutOfBounds` property.

* When set to `false` the `scrollToOffset` will stop at the last item (the item 12)
* When set to `true` the `scrollToOffset` will scroll outside the content bounds and leave the screen completely white.

```javascript
import React, {Component} from 'react';
import { StyleSheet, Text, View, FlatList, SafeAreaView } from 'react-native';

const data = [
  { key: "1" },
  { key: "2" },
  { key: "3" },
  { key: "4" },
  { key: "5" },
  { key: "6" },
  { key: "7" },
  { key: "8" },
  { key: "9" },
  { key: "10" },
  { key: "11" },
  { key: "12" }
];

export default class App extends Component {
  componentDidMount() {
    this.timeoutID = setTimeout(() => {
      if (this.flatList) {
        console.log('sdsadsadasdads');
        this.flatList.scrollToOffset({
          offset: 10000,
          animated: true
        });
      }
      this.timeoutID = null;
    }, 2000);
  }

  componentWillUnmount() {
    clearTimeout(this.timeoutID);
  }

  renderItem({ item: { key }}) {
    return (
      <View style={styles.view}>
        <Text style={styles.text}>{key}</Text>
      </View>
    )
  }

  onRef = (flatList) => {
    this.flatList = flatList;
  };

  timeoutID = null;
  flatList = null;

  render() {
    return (
      <SafeAreaView>
        <FlatList
          allowScrollOutOfBounds={false} // NOTE THIS NEW FLAG
          ref={this.onRef}
          style={styles.container}
          data={data}
          renderItem={this.renderItem}
        />
      </SafeAreaView>
    );
  }
}

const styles = StyleSheet.create({
  container: {
    paddingTop: 20,
    backgroundColor: '#F5FCFF',
  },
  view: {
    marginBottom: 10,
    justifyContent: 'center',
    alignItems: 'center',
    width: '100%',
    backgroundColor: 'green',
    height: 100,
  },
  text: {
    color: 'red',
    fontSize: 20,
  },
});

```

# GIF demo

## Without the patch
![iOS scroll problem](https://i.imgur.com/rZxVChQ.gif)

## With the patch
![iOS scroll problem](https://i.imgur.com/tpAL8pN.gif)

fixes #22768 