### PR TITLE
Added filtering to RNTester example screens

### DIFF
--- a/RNTester/js/RNTesterExampleContainer.js
+++ b/RNTester/js/RNTesterExampleContainer.js
@@ -42,7 +42,7 @@ class RNTesterExampleContainer extends React.Component {
       const Example = this.props.module.examples[0].render;
       return <Example />;
     }
-    
+
     const filter = ({example, filterRegex}) => filterRegex.test(example.title);
 
     const sections = [

--- a/RNTester/js/RNTesterExampleContainer.js
+++ b/RNTester/js/RNTesterExampleContainer.js
@@ -12,6 +12,7 @@
 const React = require('react');
 const {Platform} = require('react-native');
 const RNTesterBlock = require('./RNTesterBlock');
+const RNTesterExampleFilter = require('./RNTesterExampleFilter');
 const RNTesterPage = require('./RNTesterPage');
 
 class RNTesterExampleContainer extends React.Component {
@@ -37,9 +38,25 @@ class RNTesterExampleContainer extends React.Component {
       return <this.props.module />;
     }
 
+    const filter = ({example, filterRegex}) => filterRegex.test(example.title);
+
+    const sections = [
+      {
+        data: this.props.module.examples,
+        title: 'EXAMPLES',
+        key: 'e',
+      },
+    ];
+
     return (
       <RNTesterPage title={this.props.title}>
-        {this.props.module.examples.map(this.renderExample)}
+        <RNTesterExampleFilter
+          sections={sections}
+          filter={filter}
+          render={({filteredSections}) =>
+            filteredSections[0].data.map(this.renderExample)
+          }
+        />
       </RNTesterPage>
     );
   }

--- a/RNTester/js/RNTesterExampleContainer.js
+++ b/RNTester/js/RNTesterExampleContainer.js
@@ -38,6 +38,11 @@ class RNTesterExampleContainer extends React.Component {
       return <this.props.module />;
     }
 
+    if (this.props.module.examples.length === 1) {
+      const Example = this.props.module.examples[0].render;
+      return <Example />;
+    }
+    
     const filter = ({example, filterRegex}) => filterRegex.test(example.title);
 
     const sections = [

--- a/RNTester/js/RNTesterExampleFilter.js
+++ b/RNTester/js/RNTesterExampleFilter.js
@@ -1,0 +1,115 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow
+ */
+
+const Platform = require('Platform');
+const React = require('react');
+const StyleSheet = require('StyleSheet');
+const TextInput = require('TextInput');
+const View = require('View');
+
+import type {RNTesterExample} from './RNTesterList.ios';
+
+type Props = {
+  render: Function,
+  list: {
+    ComponentExamples: Array<RNTesterExample>,
+    APIExamples: Array<RNTesterExample>,
+  },
+};
+
+class RNTesterExampleFilter extends React.Component<Props, $FlowFixMeState> {
+  state = {filter: ''};
+
+  render() {
+    const filterText = this.state.filter;
+    let filterRegex = /.*/;
+
+    try {
+      filterRegex = new RegExp(String(filterText), 'i');
+    } catch (error) {
+      console.warn(
+        'Failed to create RegExp: %s\n%s',
+        filterText,
+        error.message,
+      );
+    }
+
+    const filter = example =>
+      /* $FlowFixMe(>=0.68.0 site=react_native_fb) This comment suppresses an
+       * error found when Flow v0.68 was deployed. To see the error delete this
+       * comment and run Flow. */
+      this.props.disableSearch ||
+      (filterRegex.test(example.module.title) &&
+        (!Platform.isTV || example.supportsTVOS));
+
+    const sections = [
+      {
+        data: this.props.list.ComponentExamples.filter(filter),
+        title: 'COMPONENTS',
+        key: 'c',
+      },
+      {
+        data: this.props.list.APIExamples.filter(filter),
+        title: 'APIS',
+        key: 'a',
+      },
+    ];
+    return (
+      <View>
+        {this._renderTextInput()}
+        {this.props.render({sections})}
+      </View>
+    );
+  }
+
+  _renderTextInput(): ?React.Element<any> {
+    /* $FlowFixMe(>=0.68.0 site=react_native_fb) This comment suppresses an
+     * error found when Flow v0.68 was deployed. To see the error delete this
+     * comment and run Flow. */
+    if (this.props.disableSearch) {
+      return null;
+    }
+    return (
+      <View style={styles.searchRow}>
+        <TextInput
+          autoCapitalize="none"
+          autoCorrect={false}
+          clearButtonMode="always"
+          onChangeText={text => {
+            this.setState(() => ({filter: text}));
+          }}
+          placeholder="Search..."
+          underlineColorAndroid="transparent"
+          style={styles.searchTextInput}
+          testID="explorer_search"
+          value={this.state.filter}
+        />
+      </View>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  searchRow: {
+    backgroundColor: '#eeeeee',
+    padding: 10,
+  },
+  searchTextInput: {
+    backgroundColor: 'white',
+    borderColor: '#cccccc',
+    borderRadius: 3,
+    borderWidth: 1,
+    paddingLeft: 8,
+    paddingVertical: 0,
+    height: 35,
+  },
+});
+
+module.exports = RNTesterExampleFilter;

--- a/RNTester/js/RNTesterExampleFilter.js
+++ b/RNTester/js/RNTesterExampleFilter.js
@@ -49,22 +49,15 @@ class RNTesterExampleFilter extends React.Component<Props, $FlowFixMeState> {
       (filterRegex.test(example.module.title) &&
         (!Platform.isTV || example.supportsTVOS));
 
-    const sections = [
-      {
-        data: this.props.list.ComponentExamples.filter(filter),
-        title: 'COMPONENTS',
-        key: 'c',
-      },
-      {
-        data: this.props.list.APIExamples.filter(filter),
-        title: 'APIS',
-        key: 'a',
-      },
-    ];
+    const filteredSections = this.props.sections.map(section => ({
+      ...section,
+      data: section.data.filter(filter),
+    }));
+
     return (
       <View>
         {this._renderTextInput()}
-        {this.props.render({sections})}
+        {this.props.render({filteredSections})}
       </View>
     );
   }

--- a/RNTester/js/RNTesterExampleFilter.js
+++ b/RNTester/js/RNTesterExampleFilter.js
@@ -8,6 +8,8 @@
  * @flow
  */
 
+'use strict';
+
 const React = require('react');
 const StyleSheet = require('StyleSheet');
 const TextInput = require('TextInput');

--- a/RNTester/js/RNTesterExampleFilter.js
+++ b/RNTester/js/RNTesterExampleFilter.js
@@ -8,20 +8,15 @@
  * @flow
  */
 
-const Platform = require('Platform');
 const React = require('react');
 const StyleSheet = require('StyleSheet');
 const TextInput = require('TextInput');
 const View = require('View');
 
-import type {RNTesterExample} from './RNTesterList.ios';
-
 type Props = {
+  filter: Function,
   render: Function,
-  list: {
-    ComponentExamples: Array<RNTesterExample>,
-    APIExamples: Array<RNTesterExample>,
-  },
+  sections: Object,
 };
 
 class RNTesterExampleFilter extends React.Component<Props, $FlowFixMeState> {
@@ -45,9 +40,7 @@ class RNTesterExampleFilter extends React.Component<Props, $FlowFixMeState> {
       /* $FlowFixMe(>=0.68.0 site=react_native_fb) This comment suppresses an
        * error found when Flow v0.68 was deployed. To see the error delete this
        * comment and run Flow. */
-      this.props.disableSearch ||
-      (filterRegex.test(example.module.title) &&
-        (!Platform.isTV || example.supportsTVOS));
+      this.props.disableSearch || this.props.filter({example, filterRegex});
 
     const filteredSections = this.props.sections.map(section => ({
       ...section,

--- a/RNTester/js/RNTesterExampleList.js
+++ b/RNTester/js/RNTesterExampleList.js
@@ -10,14 +10,13 @@
 
 'use strict';
 
-const Platform = require('Platform');
 const React = require('react');
 const SectionList = require('SectionList');
 const StyleSheet = require('StyleSheet');
 const Text = require('Text');
-const TextInput = require('TextInput');
 const TouchableHighlight = require('TouchableHighlight');
 const RNTesterActions = require('./RNTesterActions');
+const RNTesterExampleFilter = require('./RNTesterExampleFilter');
 const View = require('View');
 
 /* $FlowFixMe(>=0.78.0 site=react_native_android_fb) This issue was found when
@@ -67,89 +66,6 @@ class RowComponent extends React.PureComponent<{
 const renderSectionHeader = ({section}) => (
   <Text style={styles.sectionHeader}>{section.title}</Text>
 );
-
-type FilterProps = {
-  render: Function,
-  list: {
-    ComponentExamples: Array<RNTesterExample>,
-    APIExamples: Array<RNTesterExample>,
-  },
-};
-
-class RNTesterExampleFilter extends React.Component<
-  FilterProps,
-  $FlowFixMeState,
-> {
-  state = {filter: ''};
-
-  render() {
-    const filterText = this.state.filter;
-    let filterRegex = /.*/;
-
-    try {
-      filterRegex = new RegExp(String(filterText), 'i');
-    } catch (error) {
-      console.warn(
-        'Failed to create RegExp: %s\n%s',
-        filterText,
-        error.message,
-      );
-    }
-
-    const filter = example =>
-      /* $FlowFixMe(>=0.68.0 site=react_native_fb) This comment suppresses an
-       * error found when Flow v0.68 was deployed. To see the error delete this
-       * comment and run Flow. */
-      this.props.disableSearch ||
-      (filterRegex.test(example.module.title) &&
-        (!Platform.isTV || example.supportsTVOS));
-
-    const sections = [
-      {
-        data: this.props.list.ComponentExamples.filter(filter),
-        title: 'COMPONENTS',
-        key: 'c',
-      },
-      {
-        data: this.props.list.APIExamples.filter(filter),
-        title: 'APIS',
-        key: 'a',
-      },
-    ];
-    return (
-      <View>
-        {this._renderTextInput()}
-        {this.props.render({sections})}
-      </View>
-    );
-  }
-
-  _renderTextInput(): ?React.Element<any> {
-    /* $FlowFixMe(>=0.68.0 site=react_native_fb) This comment suppresses an
-     * error found when Flow v0.68 was deployed. To see the error delete this
-     * comment and run Flow. */
-    if (this.props.disableSearch) {
-      return null;
-    }
-    return (
-      <View style={styles.searchRow}>
-        <TextInput
-          autoCapitalize="none"
-          autoCorrect={false}
-          clearButtonMode="always"
-          onChangeText={text => {
-            this.setState(() => ({filter: text}));
-          }}
-          placeholder="Search..."
-          underlineColorAndroid="transparent"
-          style={styles.searchTextInput}
-          testID="explorer_search"
-          value={this.state.filter}
-        />
-      </View>
-    );
-  }
-}
 
 class RNTesterExampleList extends React.Component<Props, $FlowFixMeState> {
   render() {
@@ -259,19 +175,6 @@ const styles = StyleSheet.create({
     fontSize: 15,
     color: '#888888',
     lineHeight: 20,
-  },
-  searchRow: {
-    backgroundColor: '#eeeeee',
-    padding: 10,
-  },
-  searchTextInput: {
-    backgroundColor: 'white',
-    borderColor: '#cccccc',
-    borderRadius: 3,
-    borderWidth: 1,
-    paddingLeft: 8,
-    paddingVertical: 0,
-    height: 35,
   },
 });
 

--- a/RNTester/js/RNTesterExampleList.js
+++ b/RNTester/js/RNTesterExampleList.js
@@ -69,17 +69,30 @@ const renderSectionHeader = ({section}) => (
 
 class RNTesterExampleList extends React.Component<Props, $FlowFixMeState> {
   render() {
+    const sections = [
+      {
+        data: this.props.list.ComponentExamples,
+        title: 'COMPONENTS',
+        key: 'c',
+      },
+      {
+        data: this.props.list.APIExamples,
+        title: 'APIS',
+        key: 'a',
+      },
+    ];
+
     return (
       <View style={[styles.listContainer, this.props.style]}>
         {this._renderTitleRow()}
         <RNTesterExampleFilter
-          list={this.props.list}
-          render={({sections}) => (
+          sections={sections}
+          render={({filteredSections}) => (
             <SectionList
               ItemSeparatorComponent={ItemSeparator}
               contentContainerStyle={{backgroundColor: 'white'}}
               style={styles.list}
-              sections={sections}
+              sections={filteredSections}
               renderItem={this._renderItem}
               enableEmptySections={true}
               itemShouldUpdate={this._itemShouldUpdate}

--- a/RNTester/js/RNTesterExampleList.js
+++ b/RNTester/js/RNTesterExampleList.js
@@ -10,6 +10,7 @@
 
 'use strict';
 
+const Platform = require('Platform');
 const React = require('react');
 const SectionList = require('SectionList');
 const StyleSheet = require('StyleSheet');
@@ -69,6 +70,13 @@ const renderSectionHeader = ({section}) => (
 
 class RNTesterExampleList extends React.Component<Props, $FlowFixMeState> {
   render() {
+    const filter = ({example, filterRegex}) =>
+      /* $FlowFixMe(>=0.68.0 site=react_native_fb) This comment suppresses an
+      * error found when Flow v0.68 was deployed. To see the error delete this
+      * comment and run Flow. */
+      filterRegex.test(example.module.title) &&
+      (!Platform.isTV || example.supportsTVOS);
+
     const sections = [
       {
         data: this.props.list.ComponentExamples,
@@ -87,6 +95,7 @@ class RNTesterExampleList extends React.Component<Props, $FlowFixMeState> {
         {this._renderTitleRow()}
         <RNTesterExampleFilter
           sections={sections}
+          filter={filter}
           render={({filteredSections}) => (
             <SectionList
               ItemSeparatorComponent={ItemSeparator}

--- a/RNTester/js/RNTesterExampleList.js
+++ b/RNTester/js/RNTesterExampleList.js
@@ -99,7 +99,7 @@ class RNTesterExampleList extends React.Component<Props, $FlowFixMeState> {
           render={({filteredSections}) => (
             <SectionList
               ItemSeparatorComponent={ItemSeparator}
-              contentContainerStyle={{backgroundColor: 'white'}}
+              contentContainerStyle={styles.sectionListContentContainer}
               style={styles.list}
               sections={filteredSections}
               renderItem={this._renderItem}
@@ -188,6 +188,9 @@ const styles = StyleSheet.create({
   separatorHighlighted: {
     height: StyleSheet.hairlineWidth,
     backgroundColor: 'rgb(217, 217, 217)',
+  },
+  sectionListContentContainer: {
+    backgroundColor: 'white',
   },
   rowTitleText: {
     fontSize: 17,

--- a/RNTester/js/RNTesterExampleList.js
+++ b/RNTester/js/RNTesterExampleList.js
@@ -68,7 +68,18 @@ const renderSectionHeader = ({section}) => (
   <Text style={styles.sectionHeader}>{section.title}</Text>
 );
 
-class RNTesterExampleList extends React.Component<Props, $FlowFixMeState> {
+type FilterProps = {
+  render: Function,
+  list: {
+    ComponentExamples: Array<RNTesterExample>,
+    APIExamples: Array<RNTesterExample>,
+  },
+};
+
+class RNTesterExampleFilter extends React.Component<
+  FilterProps,
+  $FlowFixMeState,
+> {
   state = {filter: ''};
 
   render() {
@@ -106,21 +117,62 @@ class RNTesterExampleList extends React.Component<Props, $FlowFixMeState> {
       },
     ];
     return (
+      <View>
+        {this._renderTextInput()}
+        {this.props.render({sections})}
+      </View>
+    );
+  }
+
+  _renderTextInput(): ?React.Element<any> {
+    /* $FlowFixMe(>=0.68.0 site=react_native_fb) This comment suppresses an
+     * error found when Flow v0.68 was deployed. To see the error delete this
+     * comment and run Flow. */
+    if (this.props.disableSearch) {
+      return null;
+    }
+    return (
+      <View style={styles.searchRow}>
+        <TextInput
+          autoCapitalize="none"
+          autoCorrect={false}
+          clearButtonMode="always"
+          onChangeText={text => {
+            this.setState(() => ({filter: text}));
+          }}
+          placeholder="Search..."
+          underlineColorAndroid="transparent"
+          style={styles.searchTextInput}
+          testID="explorer_search"
+          value={this.state.filter}
+        />
+      </View>
+    );
+  }
+}
+
+class RNTesterExampleList extends React.Component<Props, $FlowFixMeState> {
+  render() {
+    return (
       <View style={[styles.listContainer, this.props.style]}>
         {this._renderTitleRow()}
-        {this._renderTextInput()}
-        <SectionList
-          ItemSeparatorComponent={ItemSeparator}
-          contentContainerStyle={{backgroundColor: 'white'}}
-          style={styles.list}
-          sections={sections}
-          renderItem={this._renderItem}
-          enableEmptySections={true}
-          itemShouldUpdate={this._itemShouldUpdate}
-          keyboardShouldPersistTaps="handled"
-          automaticallyAdjustContentInsets={false}
-          keyboardDismissMode="on-drag"
-          renderSectionHeader={renderSectionHeader}
+        <RNTesterExampleFilter
+          list={this.props.list}
+          render={({sections}) => (
+            <SectionList
+              ItemSeparatorComponent={ItemSeparator}
+              contentContainerStyle={{backgroundColor: 'white'}}
+              style={styles.list}
+              sections={sections}
+              renderItem={this._renderItem}
+              enableEmptySections={true}
+              itemShouldUpdate={this._itemShouldUpdate}
+              keyboardShouldPersistTaps="handled"
+              automaticallyAdjustContentInsets={false}
+              keyboardDismissMode="on-drag"
+              renderSectionHeader={renderSectionHeader}
+            />
+          )}
         />
       </View>
     );
@@ -159,32 +211,6 @@ class RNTesterExampleList extends React.Component<Props, $FlowFixMeState> {
           this.props.onNavigate(RNTesterActions.ExampleList());
         }}
       />
-    );
-  }
-
-  _renderTextInput(): ?React.Element<any> {
-    /* $FlowFixMe(>=0.68.0 site=react_native_fb) This comment suppresses an
-     * error found when Flow v0.68 was deployed. To see the error delete this
-     * comment and run Flow. */
-    if (this.props.disableSearch) {
-      return null;
-    }
-    return (
-      <View style={styles.searchRow}>
-        <TextInput
-          autoCapitalize="none"
-          autoCorrect={false}
-          clearButtonMode="always"
-          onChangeText={text => {
-            this.setState(() => ({filter: text}));
-          }}
-          placeholder="Search..."
-          underlineColorAndroid="transparent"
-          style={styles.searchTextInput}
-          testID="explorer_search"
-          value={this.state.filter}
-        />
-      </View>
     );
   }
 

--- a/RNTester/js/RNTesterExampleList.js
+++ b/RNTester/js/RNTesterExampleList.js
@@ -23,7 +23,7 @@ const View = require('View');
 /* $FlowFixMe(>=0.78.0 site=react_native_android_fb) This issue was found when
  * making Flow check .android.js files. */
 import type {RNTesterExample} from './RNTesterList.ios';
-import type {TextStyleProp, ViewStyleProp} from 'StyleSheet';
+import type {ViewStyleProp} from 'StyleSheet';
 
 type Props = {
   onNavigate: Function,


### PR DESCRIPTION
This PR adds filtering functionality to individual example screens of RNTester. This is useful for Detox testing of RNTester, since Detox requires elements to be visible on the screen before they can be interacted with. Instead of needing to scroll an arbitrary amount, the test can enter the name of the example to be tested, just as is done on the main screen. This will lead to simpler and more reliable E2E tests for long example screens. This PR doesn't add any automated tests using the filter; those will be added in a separate PR.

This is implemented by extracting the existing filtering functionality out of `RNTesterExampleList` into a shared `RNTesterExampleFilter` component that can be used both within `RNTesterExampleList` (the main screen) and `RNTesterExampleContainer` (the example screen).

![simulator screen shot - iphone 8 - 2018-12-24 at 08 22 46](https://user-images.githubusercontent.com/15832198/50401564-4273a300-0755-11e9-9120-9bf8fbb70261.png)

![simulator screen shot - iphone 8 - 2018-12-24 at 08 22 51](https://user-images.githubusercontent.com/15832198/50401566-44d5fd00-0755-11e9-9637-6e5ddce1c476.png)


Changelog:
----------

[General] [Added] - Added filtering to RNTester example screens


Test Plan:
----------

Run RNTester and tap into example screens. Confirm examples still display, and that typing into the filter field filters the list of examples.
