### PR TITLE
RCTAsyncLocalStorage: don't reset the data when have no access to the manifest

### DIFF
--- a/React/Modules/RCTAsyncLocalStorage.m
+++ b/React/Modules/RCTAsyncLocalStorage.m
@@ -237,16 +237,33 @@ RCT_EXPORT_MODULE()
     }
     RCTHasCreatedStorageDirectory = YES;
   }
+
   if (!_haveSetup) {
-    NSDictionary *errorOut;
+    NSDictionary *errorOut = nil;
     NSString *serialized = RCTReadFile(RCTGetManifestFilePath(), RCTManifestFileName, &errorOut);
-    _manifest = serialized ? RCTJSONParseMutable(serialized, &error) : [NSMutableDictionary new];
-    if (error) {
-      RCTLogWarn(@"Failed to parse manifest - creating new one.\n\n%@", error);
-      _manifest = [NSMutableDictionary new];
+    if (!serialized) {
+    	if (errorOut) {
+     		// We cannot simply create a new manifest in case the file does exist but we have no access to it.
+				// This can happen when data protection is enabled for the app and we are trying to read the manifect
+				// while the device is locked. (The app can be started by the system even if the device is locked due to
+				// e.g. a geofence event.)
+      	RCTLogError(@"Could not open the existing manifest, perhaps data protection is enabled?\n\n%@", errorOut);
+      	return errorOut;
+      } else {
+      	// We can get nil without errors only when the file does not exist.
+        RCTLogTrace(@"Manifest does not exist - creating a new one.\n\n%@", errorOut);
+        _manifest = [NSMutableDictionary new];
+      }
+    } else {
+    	_manifest = RCTJSONParseMutable(serialized, &error);
+      if (!_manifest) {
+        RCTLogError(@"Failed to parse manifest - creating a new one.\n\n%@", error);
+        _manifest = [NSMutableDictionary new];
+      }
     }
     _haveSetup = YES;
   }
+
   return nil;
 }
 

--- a/React/Modules/RCTAsyncLocalStorage.m
+++ b/React/Modules/RCTAsyncLocalStorage.m
@@ -244,9 +244,9 @@ RCT_EXPORT_MODULE()
     if (!serialized) {
       if (errorOut) {
         // We cannot simply create a new manifest in case the file does exist but we have no access to it.
-			  // This can happen when data protection is enabled for the app and we are trying to read the manifect
-			  // while the device is locked. (The app can be started by the system even if the device is locked due to
-			  // e.g. a geofence event.)
+        // This can happen when data protection is enabled for the app and we are trying to read the manifect
+        // while the device is locked. (The app can be started by the system even if the device is locked due to
+        // e.g. a geofence event.)
         RCTLogError(@"Could not open the existing manifest, perhaps data protection is enabled?\n\n%@", errorOut);
         return errorOut;
       } else {

--- a/React/Modules/RCTAsyncLocalStorage.m
+++ b/React/Modules/RCTAsyncLocalStorage.m
@@ -243,10 +243,10 @@ RCT_EXPORT_MODULE()
     NSString *serialized = RCTReadFile(RCTGetManifestFilePath(), RCTManifestFileName, &errorOut);
     if (!serialized) {
       if (errorOut) {
-        // We cannot simply create a new manifest in case the file does exist but we have no access to it.
-        // This can happen when data protection is enabled for the app and we are trying to read the manifect
-        // while the device is locked. (The app can be started by the system even if the device is locked due to
-        // e.g. a geofence event.)
+        // We cannot simply create a new manifest in case the file does exist but we have no access 
+        // to it. This can happen when data protection is enabled for the app and we are trying to 
+        // read the manifest while the device is locked (the app can be started by the system, even
+        // if the device is locked, due to, e.g., a geofence event).
         RCTLogError(@"Could not open the existing manifest, perhaps data protection is enabled?\n\n%@", errorOut);
         return errorOut;
       } else {

--- a/React/Modules/RCTAsyncLocalStorage.m
+++ b/React/Modules/RCTAsyncLocalStorage.m
@@ -243,7 +243,7 @@ RCT_EXPORT_MODULE()
     NSString *serialized = RCTReadFile(RCTGetManifestFilePath(), RCTManifestFileName, &errorOut);
     if (!serialized) {
       if (errorOut) {
-     	  // We cannot simply create a new manifest in case the file does exist but we have no access to it.
+        // We cannot simply create a new manifest in case the file does exist but we have no access to it.
 			  // This can happen when data protection is enabled for the app and we are trying to read the manifect
 			  // while the device is locked. (The app can be started by the system even if the device is locked due to
 			  // e.g. a geofence event.)

--- a/React/Modules/RCTAsyncLocalStorage.m
+++ b/React/Modules/RCTAsyncLocalStorage.m
@@ -242,20 +242,20 @@ RCT_EXPORT_MODULE()
     NSDictionary *errorOut = nil;
     NSString *serialized = RCTReadFile(RCTGetManifestFilePath(), RCTManifestFileName, &errorOut);
     if (!serialized) {
-    	if (errorOut) {
-     		// We cannot simply create a new manifest in case the file does exist but we have no access to it.
-				// This can happen when data protection is enabled for the app and we are trying to read the manifect
-				// while the device is locked. (The app can be started by the system even if the device is locked due to
-				// e.g. a geofence event.)
-      	RCTLogError(@"Could not open the existing manifest, perhaps data protection is enabled?\n\n%@", errorOut);
-      	return errorOut;
+      if (errorOut) {
+     	  // We cannot simply create a new manifest in case the file does exist but we have no access to it.
+			  // This can happen when data protection is enabled for the app and we are trying to read the manifect
+			  // while the device is locked. (The app can be started by the system even if the device is locked due to
+			  // e.g. a geofence event.)
+        RCTLogError(@"Could not open the existing manifest, perhaps data protection is enabled?\n\n%@", errorOut);
+        return errorOut;
       } else {
-      	// We can get nil without errors only when the file does not exist.
+        // We can get nil without errors only when the file does not exist.
         RCTLogTrace(@"Manifest does not exist - creating a new one.\n\n%@", errorOut);
         _manifest = [NSMutableDictionary new];
       }
     } else {
-    	_manifest = RCTJSONParseMutable(serialized, &error);
+      _manifest = RCTJSONParseMutable(serialized, &error);
       if (!_manifest) {
         RCTLogError(@"Failed to parse manifest - creating a new one.\n\n%@", error);
         _manifest = [NSMutableDictionary new];


### PR DESCRIPTION
Starting with an empty dictionary is a reasonable fallback in case the manifest cannot be parsed, however it would lead to data loss when the app temporarily has no access to its documents due to data protection being enabled and the device being locked. 

Changelog:
----------

[iOS] [Fixed] - Fix a data loss problem in RCTAsyncLocalStorage happening when data protection is enabled for the app which starts when the device is locked due to background push notification, geofence event, etc.

Test Plan:
----------

Only checked with an app we are making. Before the fix, when data protection was turned on and the app would start due to a geofence event while the phone was locked, then it would begin with an empty state, which would be later successfully saved when the user would unlock the phone and start the app manually. After the fix, the app would silently crash in this case, which is far from ideal behavior, but at least no data loss would occur. 
