### PR TITLE
Fix Picker.onValueChange on Android sometimes not fired due to race condition

### DIFF
--- a/Libraries/Components/Picker/PickerAndroid.android.js
+++ b/Libraries/Components/Picker/PickerAndroid.android.js
@@ -49,7 +49,6 @@ type Item = $ReadOnly<{|
 |}>;
 
 type PickerAndroidState = {|
-  initialSelectedIndex: number,
   selectedIndex: number,
   items: $ReadOnlyArray<Item>,
 |};
@@ -62,26 +61,9 @@ class PickerAndroid extends React.Component<
   PickerAndroidProps,
   PickerAndroidState,
 > {
-  /* $FlowFixMe(>=0.78.0 site=react_native_android_fb) This issue was found
-   * when making Flow check .android.js files. */
-  constructor(props, context) {
-    super(props, context);
-    const state = this._stateFromProps(props);
-
-    this.state = {
-      ...state,
-      initialSelectedIndex: state.selectedIndex,
-    };
-  }
-
-  /* $FlowFixMe(>=0.78.0 site=react_native_android_fb) This issue was found
-   * when making Flow check .android.js files. */
-  UNSAFE_componentWillReceiveProps(nextProps) {
-    this.setState(this._stateFromProps(nextProps));
-  }
-
-  // Translate prop and children into stuff that the native picker understands.
-  _stateFromProps = props => {
+  static getDerivedStateFromProps(
+    props: PickerAndroidProps,
+  ): PickerAndroidState {
     let selectedIndex = 0;
     const items = React.Children.map(props.children, (child, index) => {
       if (child.props.value === props.selectedValue) {
@@ -99,7 +81,9 @@ class PickerAndroid extends React.Component<
       return childProps;
     });
     return {selectedIndex, items};
-  };
+  }
+
+  state = PickerAndroid.getDerivedStateFromProps(this.props);
 
   render() {
     const Picker =
@@ -111,7 +95,7 @@ class PickerAndroid extends React.Component<
       mode: this.props.mode,
       onSelect: this._onChange,
       prompt: this.props.prompt,
-      selected: this.state.initialSelectedIndex,
+      selected: this.state.selectedIndex,
       testID: this.props.testID,
       style: [styles.pickerAndroid, this.props.style],
       /* $FlowFixMe(>=0.78.0 site=react_native_android_fb) This issue was found
@@ -135,19 +119,7 @@ class PickerAndroid extends React.Component<
         this.props.onValueChange(null, position);
       }
     }
-    /* $FlowFixMe(>=0.78.0 site=react_native_android_fb) This issue was found
-     * when making Flow check .android.js files. */
-    this._lastNativePosition = event.nativeEvent.position;
-    this.forceUpdate();
-  };
 
-  componentDidMount() {
-    /* $FlowFixMe(>=0.78.0 site=react_native_android_fb) This issue was found
-     * when making Flow check .android.js files. */
-    this._lastNativePosition = this.state.initialSelectedIndex;
-  }
-
-  componentDidUpdate() {
     // The picker is a controlled component. This means we expect the
     // on*Change handlers to be in charge of updating our
     // `selectedValue` prop. That way they can also
@@ -156,18 +128,13 @@ class PickerAndroid extends React.Component<
     // truth, not the native component.
     if (
       this.refs[REF_PICKER] &&
-      /* $FlowFixMe(>=0.78.0 site=react_native_android_fb) This issue was found
-       * when making Flow check .android.js files. */
-      this.state.selectedIndex !== this._lastNativePosition
+      this.state.selectedIndex !== event.nativeEvent.position
     ) {
       this.refs[REF_PICKER].setNativeProps({
         selected: this.state.selectedIndex,
       });
-      /* $FlowFixMe(>=0.78.0 site=react_native_android_fb) This issue was found
-       * when making Flow check .android.js files. */
-      this._lastNativePosition = this.state.selectedIndex;
     }
-  }
+  };
 }
 
 const styles = StyleSheet.create({


### PR DESCRIPTION
Changelog:
----------

[Android] [Fixed] - Fix Picker.onValueChange sometimes not fired due to race condition. Fixes #15556

Root Cause:
------------

Please check my code snippet at https://snack.expo.io/@kudochien/android-picker-issue
and try to select different items on Picker to see if console.log() hit.
If calling setState() with some latency, e.g. setTimeout() or changes from redux,
the second time changing picker item on UI, the onValueChange() will be not fired. 

The root cause comes from the `forceUpdate` in PickerAndroid.android.js.
If user's setState() update comes after forceUpdate(), the flow will be:
1. First time select picker item
2. onValueChange + forceUpdate
3. user's setState() + componentDidUpdate + setNativeProps({ selected: ... })
4. mSuppressNextEvent = true
5. Second time select picker item
6. Since mSuppressNextEvent is true, the onValueChange will not be fired.

Solution:
---------

Like other controlled components, disable change listener during setup values from JS.
Android Spinner `setSelection(int position)` is asynchronous call, i.e. will fire onItemSelected in next run loop and is not suitable for us.
`setSelection(int position, boolean animate)`, however, is synchronous call which I used.

Some more references about setSelection:
https://stackoverflow.com/a/43512925/2590265
http://androidxref.com/8.1.0_r33/xref/frameworks/base/core/java/android/widget/AbsSpinner.java#276
The two arguments version will use `setSelectionInt()` which set mBlockLayoutRequests as true to prevent onItemSelected call from next layout().

I also moved the setOnItemSelectedListener() call after onLayout to prevent onValueChange() during intialization.

Test Plan:
----------

1. Test PickerExample in RNTester
2. Test my test cases at https://snack.expo.io/@kudochien/android-picker-issue with and without setTimeout()
3. I also removed some FlowFixMe, tested with this command to ensure no flow errors:
```
yarn flow start --flowconfig-name .flowconfig.android
yarn flow status --flowconfig-name .flowconfig.android
```
