### PR TITLE
Fix CircleCI build error

### DIFF
--- a/ContainerShip/Dockerfile.android
+++ b/ContainerShip/Dockerfile.android
@@ -47,7 +47,7 @@ ADD build.gradle /app/build.gradle
 ADD react.gradle /app/react.gradle
 
 # run gradle downloads
-RUN ./gradlew :ReactAndroid:downloadBoost :ReactAndroid:downloadDoubleConversion :ReactAndroid:downloadFolly :ReactAndroid:downloadGlog :ReactAndroid:downloadJSCHeaders
+RUN ./gradlew :ReactAndroid:downloadBoost :ReactAndroid:downloadDoubleConversion :ReactAndroid:downloadFolly :ReactAndroid:downloadGlog :ReactAndroid:downloadJSC
 
 # compile native libs with Gradle script, we need bridge for unit and integration tests
 RUN ./gradlew :ReactAndroid:packageReactNdkLibsForBuck -Pjobs=1 -Pcom.android.build.threadPoolSize=1

--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -85,6 +85,17 @@ task prepareFolly(dependsOn: dependenciesPath ? [] : [downloadFolly], type: Copy
     include "folly-${FOLLY_VERSION}/folly/**/*", 'Android.mk'
     eachFile { fname -> fname.path = (fname.path - "folly-${FOLLY_VERSION}/") }
     includeEmptyDirs = false
+
+    // Patch for folly build break on gcc 4.9 and could be removed after build by clang
+    filesMatching('**/container/detail/F14Policy.h') {
+        filter(ReplaceTokens, tokens: [
+                'ObjectHolder(Args&&... args) : value_{std::forward<Args>(args)...} {}': 'ObjectHolder(Args&&... args) : value_({std::forward<Args>(args)...}) {}',
+                'ObjectHolder(Args&&... args) : T{std::forward<Args>(args)...} {}'     : 'ObjectHolder(Args&&... args) : T({std::forward<Args>(args)...}) {}',
+        ],
+                beginToken: '',
+                endToken: '')
+    }
+
     into "$thirdPartyNdkDir/folly"
 }
 

--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -85,17 +85,6 @@ task prepareFolly(dependsOn: dependenciesPath ? [] : [downloadFolly], type: Copy
     include "folly-${FOLLY_VERSION}/folly/**/*", 'Android.mk'
     eachFile { fname -> fname.path = (fname.path - "folly-${FOLLY_VERSION}/") }
     includeEmptyDirs = false
-
-    // Patch for folly build break on gcc 4.9 and could be removed after build by clang
-    filesMatching('**/container/detail/F14Policy.h') {
-        filter(ReplaceTokens, tokens: [
-                'ObjectHolder(Args&&... args) : value_{std::forward<Args>(args)...} {}': 'ObjectHolder(Args&&... args) : value_({std::forward<Args>(args)...}) {}',
-                'ObjectHolder(Args&&... args) : T{std::forward<Args>(args)...} {}'     : 'ObjectHolder(Args&&... args) : T({std::forward<Args>(args)...}) {}',
-        ],
-                beginToken: '',
-                endToken: '')
-    }
-
     into "$thirdPartyNdkDir/folly"
 }
 

--- a/scripts/circleci/gradle_download_deps.sh
+++ b/scripts/circleci/gradle_download_deps.sh
@@ -6,4 +6,4 @@
 
 set -e
 
-./gradlew :ReactAndroid:downloadBoost :ReactAndroid:downloadDoubleConversion :ReactAndroid:downloadFolly :ReactAndroid:downloadGlog :ReactAndroid:downloadJSCHeaders
+./gradlew :ReactAndroid:downloadBoost :ReactAndroid:downloadDoubleConversion :ReactAndroid:downloadFolly :ReactAndroid:downloadGlog :ReactAndroid:downloadJSC


### PR DESCRIPTION

Summary:
----------

side effect of gradle task name changed from https://github.com/facebook/react-native/commit/f3e5cce4745c0ad9a5c697be772757a03e15edc5

Changelog:
----------

[Android] [Fixed] - Fix CircleCI build error


Test Plan:
----------

Makes CI green
