### PR TITLE
[iOS] [Animated] Fix Animated-driven transform state when deleting views from view hierarchy 

### DIFF
--- a/Libraries/Animated/src/nodes/AnimatedProps.js
+++ b/Libraries/Animated/src/nodes/AnimatedProps.js
@@ -75,9 +75,6 @@ class AnimatedProps extends AnimatedNode {
   }
 
   __detach(): void {
-    if (this.__isNative && this._animatedView) {
-      this.__disconnectAnimatedView();
-    }
     for (const key in this._props) {
       const value = this._props[key];
       if (value instanceof AnimatedNode) {

--- a/Libraries/NativeAnimation/RCTNativeAnimatedNodesManager.h
+++ b/Libraries/NativeAnimation/RCTNativeAnimatedNodesManager.h
@@ -11,7 +11,7 @@
 
 @protocol RCTValueAnimatedNodeObserver;
 
-@interface RCTNativeAnimatedNodesManager : NSObject
+@interface RCTNativeAnimatedNodesManager : NSObject<RCTUIManagerDelegate>
 
 - (nonnull instancetype)initWithUIManager:(nonnull RCTUIManager *)uiManager;
 

--- a/Libraries/NativeAnimation/RCTNativeAnimatedNodesManager.m
+++ b/Libraries/NativeAnimation/RCTNativeAnimatedNodesManager.m
@@ -27,6 +27,7 @@
 #import "RCTTransformAnimatedNode.h"
 #import "RCTValueAnimatedNode.h"
 #import "RCTTrackingAnimatedNode.h"
+#import <React/RCTUIManager.h>
 
 @implementation RCTNativeAnimatedNodesManager
 {
@@ -46,8 +47,16 @@
     _animationNodes = [NSMutableDictionary new];
     _eventDrivers = [NSMutableDictionary new];
     _activeAnimations = [NSMutableSet new];
+    _uiManager.delegate = self;
   }
   return self;
+}
+
+- (void)didDeregisteredView: (NSNumber *)viewTag {
+  RCTAnimatedNode *node = _animationNodes[viewTag];
+  if (node && [node isKindOfClass:RCTPropsAnimatedNode.class]) {
+    [(RCTPropsAnimatedNode *)node disconnectFromView:viewTag];
+  }
 }
 
 #pragma mark -- Graph

--- a/React/Modules/RCTUIManager.h
+++ b/React/Modules/RCTUIManager.h
@@ -13,6 +13,11 @@
 #import <React/RCTRootView.h>
 #import <React/RCTViewManager.h>
 
+@protocol RCTUIManagerDelegate
+- (void)didDeregisteredView: (NSNumber *)viewTag;
+@end
+
+
 /**
  * Posted right before re-render happens. This is a chance for views to invalidate their state so
  * next render cycle will pick up updated views and layout appropriately.
@@ -26,6 +31,8 @@ RCT_EXTERN NSString *const RCTUIManagerWillUpdateViewsDueToContentSizeMultiplier
  * The RCTUIManager is the module responsible for updating the view hierarchy.
  */
 @interface RCTUIManager : NSObject <RCTBridgeModule, RCTInvalidating>
+
+@property (weak) id<RCTUIManagerDelegate> delegate;
 
 /**
  * Register a root view tag and creates corresponding `rootView` and

--- a/React/Modules/RCTUIManager.m
+++ b/React/Modules/RCTUIManager.m
@@ -432,6 +432,7 @@ static NSDictionary *deviceOrientationEventBody(UIDeviceOrientation orientation)
         [(id<RCTInvalidating>)subview invalidate];
       }
       [registry removeObjectForKey:subview.reactTag];
+      [self.delegate didDeregisteredView:subview.reactTag];
     });
   }
 }


### PR DESCRIPTION
This is an implementation of proposal https://github.com/facebook/react-native/issues/17475.
I haven't been using ReactNative since original evaluation about a year ago, upon revisiting I see this issue is still around.


Issue:
------

When deleting a view which UI state (like transform) has been connected to AnimatedProps, said state is reset to defaults before running deleting animation (fade to transparent using opacity, by default). This makes it impossible to implement nice swipe-to-delete experience (when swipe is driven by native driver)

Proposal
---------

To iterate what I described in https://github.com/facebook/react-native/issues/17475: instead of disconnected animated component from native view when component is unmounted, keep that connection at native side around until native view is fully purged from the hierarchy.

Concerns:
----------

I'm not 100% sure this is a correct approach. May there be legitimate use cases when AnimatedProps has to be disconnected from native view while latter has to remain in the hierarchy? If anyone has broader context around this mechanism I'd like to discuss.


Changelog:
----------

[iOS] [Changed] - AnimatedProps isn't disconnected from native view (by calling `__disconnectAnimatedView`) when component is unmounted on js side. Instead, runtime on native side is keeping track of such connections and disconnects when native view is fully removed from hierarchy.



Test Plan:
----------

As a proof-of-concept please see gif provided in https://github.com/facebook/react-native/issues/17475.
I wanted to provide a proper integration test but couldn't wrap my head around how to best do it. Any help or hint on direction would much appreciated. 