### PR TITLE
FIX: Ensure permission denied in geolocation.getCurrentPosition rejects the Promise

### DIFF
--- a/Libraries/Geolocation/Geolocation.js
+++ b/Libraries/Geolocation/Geolocation.js
@@ -82,27 +82,12 @@ const Geolocation = {
       typeof geo_success === 'function',
       'Must provide a valid geo_success callback.',
     );
-    let hasPermission = true;
-    // Supports Android's new permission model. For Android older devices,
-    // it's always on.
-    if (Platform.OS === 'android' && Platform.Version >= 23) {
-      hasPermission = await PermissionsAndroid.check(
-        PermissionsAndroid.PERMISSIONS.ACCESS_FINE_LOCATION,
-      );
-      if (!hasPermission) {
-        const status = await PermissionsAndroid.request(
-          PermissionsAndroid.PERMISSIONS.ACCESS_FINE_LOCATION,
-        );
-        hasPermission = status === PermissionsAndroid.RESULTS.GRANTED;
-      }
-    }
-    if (hasPermission) {
-      RCTLocationObserver.getCurrentPosition(
-        geo_options || {},
-        geo_success,
-        geo_error || logError,
-      );
-    }
+    // Permission checks/requests are done on the native side
+    RCTLocationObserver.getCurrentPosition(
+      geo_options || {},
+      geo_success,
+      geo_error || logError,
+    );
   },
 
   /*

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/location/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/location/BUCK
@@ -14,5 +14,6 @@ rn_android_library(
         react_native_target("java/com/facebook/react/common:common"),
         react_native_target("java/com/facebook/react/module/annotations:annotations"),
         react_native_target("java/com/facebook/react/modules/core:core"),
+        react_native_target("java/com/facebook/react/modules/permissions:permissions"),
     ],
 )


### PR DESCRIPTION
fixes #22535

Moves the permission request logic on Android M and above to Native side to mimic IOS behavior.

Changelog:
----------

[Android] [Fixed] - Ensure permission denied in geolocation.getCurrentPosition rejects the promise

Test Plan:
----------

Verified manually with a test project which requests location via Geolocation service. If the permission request is denied by the user the promise is rejected as well.

https://github.com/Jyrno42/rn-geoloctest