### PR TITLE
Fix expose originalConsole issue

### DIFF
--- a/Libraries/polyfills/console.js
+++ b/Libraries/polyfills/console.js
@@ -516,6 +516,14 @@ function consoleGroupEndPolyfill() {
 
 if (global.nativeLoggingHook) {
   const originalConsole = global.console;
+  // Preserve the original `console` as `originalConsole`
+  if (__DEV__ && originalConsole) {
+    const descriptor = Object.getOwnPropertyDescriptor(global, 'console');
+    if (descriptor) {
+      Object.defineProperty(global, 'originalConsole', descriptor);
+    }
+  }
+
   global.console = {
     error: getNativeLogFunction(LOG_LEVELS.error),
     info: getNativeLogFunction(LOG_LEVELS.info),
@@ -532,12 +540,6 @@ if (global.nativeLoggingHook) {
   // sometimes useful. Ex: on OS X, this will let you see rich output in
   // the Safari Web Inspector console.
   if (__DEV__ && originalConsole) {
-    // Preserve the original `console` as `originalConsole`
-    const descriptor = Object.getOwnPropertyDescriptor(global, 'console');
-    if (descriptor) {
-      Object.defineProperty(global, 'originalConsole', descriptor);
-    }
-
     Object.keys(console).forEach(methodName => {
       const reactNativeMethod = console[methodName];
       if (originalConsole[methodName]) {


### PR DESCRIPTION
The "originalConsole" expose is incorrect in the "polyfills/console.js"

Changelog:
----------

[GENERAL] [Fixed] - Fixed originalConsole expose issue

Test Plan:
----------

Visit "originalConsole" should get original console object.
Ex: Debug iOS in the Safari Debugger
