### PR TITLE
Fixes 'Invalid render range' crash

### DIFF
--- a/Libraries/Lists/ViewabilityHelper.js
+++ b/Libraries/Lists/ViewabilityHelper.js
@@ -121,10 +121,13 @@ class ViewabilityHelper {
     }
     let firstVisible = -1;
     const {first, last} = renderRange || {first: 0, last: itemCount - 1};
-    invariant(
-      last < itemCount,
-      'Invalid render range ' + JSON.stringify({renderRange, itemCount}),
-    );
+    if (last >= itemCount) {
+      console.warn(
+        'Invalid render range computing viewability ' +
+        JSON.stringify({renderRange, itemCount}),
+      );
+      return [];
+    }
     for (let idx = first; idx <= last; idx++) {
       const metrics = getFrameMetrics(idx);
       if (!metrics) {


### PR DESCRIPTION
When a list is updated to have fewer items and the user immediately
scrolls, the `ViewabilityHelper` `computeViewableItems` can be invoked
from the scroll and cause a crash.

This side effect *should* be relatively minor; the ViewabilityHelper shouldn't
cause a crash, as it generally would be used for analytics to see what users are viewing. I suggest changing this to a warning instead of a crash.  Other react-native developers seem to [also be getting this occasionally](https://github.com/facebook/react-native/issues/20289).

Changelog:
----------

[General] [Fixed] - `Invalid render range` crash changed to warning when viewability helper detects an anomaly in list data.

Test Plan:
----------

Reproducing this issue doesn't happen 100% of the time.  We thought we had fixed it, but it still occurs on our production app in crash logs.

The best way to repro is to 
1. Render a `FlatlList` with an `onViewableItemsChanged` callback defined
2. Render a long list with 1000+ items so it can be scrollable
3. When an item in the list is clicked, remove some items from the flat list and re-render. Using `this.forceUpdate` on the owner component seems to help introduce the invariant violation, but it's not required. We are also seeing this happen occasionally with `this.setState({...})` triggering the re-render of the list.

After setting up the list, click an item in the list and and immediately scroll. It also seems a little easier to reproduce on Android, but I have seen it happen on both platforms.
