### PR TITLE
Fix snapshot tests on iOS

### DIFF
--- a/RNTester/js/RNTesterApp.ios.js
+++ b/RNTester/js/RNTesterApp.ios.js
@@ -177,7 +177,10 @@ RNTesterList.ComponentExamples.concat(RNTesterList.APIExamples).forEach(
         render() {
           return (
             <SnapshotViewIOS>
-              <RNTesterExampleContainer module={ExampleModule} />
+              <RNTesterExampleContainer
+                module={ExampleModule}
+                displayFilter={false}
+              />
             </SnapshotViewIOS>
           );
         }

--- a/RNTester/js/RNTesterExampleContainer.js
+++ b/RNTester/js/RNTesterExampleContainer.js
@@ -34,12 +34,14 @@ class RNTesterExampleContainer extends React.Component {
   }
 
   render(): React.Element<any> {
-    if (this.props.module.examples.length === 1) {
-      const Example = this.props.module.examples[0].render;
-      return <Example />;
+    if (!this.props.module.examples) {
+      return <this.props.module />;
     }
 
-    if (this.props.displayFilter === false) {
+    if (
+      this.props.displayFilter === false ||
+      this.props.module.examples.length === 1
+    ) {
       return (
         <RNTesterPage title={this.props.title}>
           {this.props.module.examples.map(this.renderExample)}

--- a/RNTester/js/RNTesterExampleContainer.js
+++ b/RNTester/js/RNTesterExampleContainer.js
@@ -34,10 +34,6 @@ class RNTesterExampleContainer extends React.Component {
   }
 
   render(): React.Element<any> {
-    if (!this.props.module.examples) {
-      return <this.props.module />;
-    }
-
     if (
       this.props.displayFilter === false ||
       this.props.module.examples.length === 1

--- a/RNTester/js/RNTesterExampleContainer.js
+++ b/RNTester/js/RNTesterExampleContainer.js
@@ -39,6 +39,14 @@ class RNTesterExampleContainer extends React.Component {
       return <Example />;
     }
 
+    if (this.props.displayFilter === false) {
+      return (
+        <RNTesterPage title={this.props.title}>
+          {this.props.module.examples.map(this.renderExample)}
+        </RNTesterPage>
+      );
+    }
+
     const filter = ({example, filterRegex}) => filterRegex.test(example.title);
 
     const sections = [


### PR DESCRIPTION
This PR fixes failing snapshot tests on iOS that were caused by https://github.com/facebook/react-native/commit/bd79303d5bd043431d249f58caf86e6ec42b9a47

What it does is it hides newly introduced "filter" input when running snapshot tests. 

It also fixes a glitch that happened when there was only one example to show (e.g. ART Example - missing RNTesterPage wrapper).

CC: @rickhanlonii @CodingItWrong 