### PR TITLE
remove envinfo from dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -167,7 +167,6 @@
     "create-react-class": "^15.6.3",
     "debug": "^2.2.0",
     "denodeify": "^1.2.1",
-    "envinfo": "^5.7.0",
     "errorhandler": "^1.5.0",
     "escape-string-regexp": "^1.0.5",
     "event-target-shim": "^1.0.5",


### PR DESCRIPTION
remove it since `react-native-cli` already moved out.

## Test Plan
pass current ci.