### PR TITLE
Fix rerender count on RNTester blue tab

### DIFF
--- a/RNTester/js/TabBarIOSExample.js
+++ b/RNTester/js/TabBarIOSExample.js
@@ -56,9 +56,10 @@ class TabBarExample extends React.Component<Props, State> {
           onPress={() => {
             this.setState({
               selectedTab: 'blueTab',
+              notifCount: this.state.notifCount + 1,
             });
           }}>
-          {this._renderContent('#414A8C', 'Blue Tab')}
+          {this._renderContent('#414A8C', 'Blue Tab', this.state.notifCount)}
         </TabBarIOS.Item>
         <TabBarIOS.Item
           systemIcon="history"


### PR DESCRIPTION
In the RNTester TabBarIOS screen, the content of the blue tab suggested it should be displaying a count for the number of rerenders, but it was not:

![before](https://user-images.githubusercontent.com/15832198/50725270-d122e100-10c0-11e9-88a2-1030f6dc3b9a.jpg)

This PR adds the count onto the blue tab:

![after](https://user-images.githubusercontent.com/15832198/50725275-dbdd7600-10c0-11e9-9f8f-0835fe1ea054.jpg)

The other two tabs already had the counter working correctly.

Changelog:
----------

[General] [Fixed] - Fix rerender count on RNTester blue tab


Test Plan:
----------

Open the TabBarIOS screen in RNTester. Confirm a number appears next to "re-renders of the Blue Tab" that increases as you tap the blue tab.