### PR TITLE
Fix system font scaling issues on nested <Text /> component on Android

### DIFF
--- a/Libraries/Text/Text.js
+++ b/Libraries/Text/Text.js
@@ -267,6 +267,7 @@ const RCTVirtualText =
           ...ReactNativeViewAttributes.UIView,
           isHighlighted: true,
           maxFontSizeMultiplier: true,
+          allowFontScaling: true,
         },
         uiViewClassName: 'RCTVirtualText',
       }));


### PR DESCRIPTION
### Motivation

`allowFontScaling` prop doesn't works as expected on nested `<Text />` component especially when specify `fontSize`. So I added allowFontScaling in validAttributes when creating `RCTVirtualText` component.

### Test Plan

I created a test app with codes below:

```javascript
type Props = {};
export default class App extends Component<Props> {
  render() {
    return (
      <View style={styles.container}>
        <Text
          style={styles.welcome}
          allowFontScaling={false}
        >
          Welcome to React Native!
        </Text>
        <Text
          style={styles.instructions}
          allowFontScaling={false}
        >
          To get started, edit{' '}
          <Text
            style={styles.instructions}
            allowFontScaling={false}
          >
            App.js
          </Text>
        </Text>
        <Text
          style={styles.instructions}
          allowFontScaling={false}
        >
          {instructions}
        </Text>
      </View>
    );
  }
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    justifyContent: 'center',
    alignItems: 'center',
    backgroundColor: '#F5FCFF',
  },
  welcome: {
    fontSize: 20,
    textAlign: 'center',
    margin: 10,
  },
  instructions: {
    fontSize: 14,
    textAlign: 'center',
    color: '#333333',
    marginBottom: 5,
  },
});
```

After setting system font size as big as possible in Android settings menu, run above code.
The result was looks like this:

![screenshot_20190107-122542_rnandroidfontscalingissue](https://user-images.githubusercontent.com/8934513/50747533-b050bc00-1277-11e9-9008-fcd2e7883482.jpg)

And if you apply my commit, the result will looks like this:

![screenshot_20190107-122534_rnandroidfontscalingissue](https://user-images.githubusercontent.com/8934513/50747560-cfe7e480-1277-11e9-822c-a2c90eede4f8.jpg)

### Changelog

[Android] [Fixed] - Fix allowFontScaling prop to work as expected on nested <Text /> component