### PR TITLE
Fix for #22891: change type for iOS accessiblityActions from NSString to NSArray<NSString*>

### DIFF
--- a/React/Views/RCTViewManager.m
+++ b/React/Views/RCTViewManager.m
@@ -109,7 +109,7 @@ RCT_EXPORT_VIEW_PROPERTY(nativeID, NSString)
 
 // Acessibility related properties
 RCT_REMAP_VIEW_PROPERTY(accessible, reactAccessibilityElement.isAccessibilityElement, BOOL)
-RCT_REMAP_VIEW_PROPERTY(accessibilityActions, reactAccessibilityElement.accessibilityActions, NSString)
+RCT_REMAP_VIEW_PROPERTY(accessibilityActions, reactAccessibilityElement.accessibilityActions, NSArray<NSString *>)
 RCT_REMAP_VIEW_PROPERTY(accessibilityLabel, reactAccessibilityElement.accessibilityLabel, NSString)
 RCT_REMAP_VIEW_PROPERTY(accessibilityHint, reactAccessibilityElement.accessibilityHint, NSString)
 RCT_REMAP_VIEW_PROPERTY(accessibilityTraits, reactAccessibilityElement.accessibilityTraits, UIAccessibilityTraits)


### PR DESCRIPTION
The bug is described in #22891.

It's possible this might not be the right fix, since the original type comes from the commit introducing the feature (36ad8138997c195b8728906ceb51bd31338b6a24). But after making this change custom VoiceOver actions work in my real project and my reduced test project.

Changelog:
----------

[iOS] [Fixed] - Fix supplying an array of custom VoiceOver actions via accessibilityActions prop


Test Plan:
----------

I'm honestly not familiar enough with testing iOS to add useful tests for this. I ran the tests before and after, and the same tests (mostly snapshot tests) were failing in both cases.