### PR TITLE
Flesh out the URL polyfill a bit more

### DIFF
--- a/Libraries/Blob/URL.js
+++ b/Libraries/Blob/URL.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @flow strict-local
  */
 
 'use strict';
@@ -51,15 +50,15 @@ if (BlobModule && typeof BlobModule.BLOB_URI_SCHEME === 'string') {
 // Small subset from whatwg-url: https://github.com/jsdom/whatwg-url/tree/master/lib
 // The reference code bloat comes from Unicode issues with URLs, so those won't work here.
 export class URLSearchParams {
-  constructor(params) {
-    this.searchParams = [];
+  searchParams = [];
 
+  constructor(params: any) {
     if (typeof params === 'object') {
       Object.keys(params).forEach(key => this.append(key, params[key]));
     }
   }
 
-  append(key, value) {
+  append(key: string, value: string) {
     this.searchParams.push([key, value]);
   }
 
@@ -82,7 +81,7 @@ export class URLSearchParams {
   }
 }
 
-class URL {
+export class URL {
   _searchParamsInstance = null;
   static urlRegexp = /^((http[s]?|ftp):\/)?\/?([^:\/\s]+)((\/\w+)*\/)([\w\-\.]+[^#?\s]+)(.*)?(#[\w\-]+)?$/;
 
@@ -93,7 +92,7 @@ class URL {
     );
   }
 
-  constructor(url, base) {
+  constructor(url: string, base: string) {
     let baseUrl = null;
     if (base) {
       if (typeof base === 'string') {
@@ -119,11 +118,11 @@ class URL {
     }
   }
 
-  get href() {
+  get href(): string {
     return this.toString();
   }
 
-  toJSON() {
+  toJSON(): string {
     return this.toString();
   }
 
@@ -167,7 +166,7 @@ class URL {
     throw new Error('not implemented');
   }
 
-  toString() {
+  toString(): string {
     if (this._searchParamsInstance === null) {
       return this._url;
     }
@@ -175,12 +174,13 @@ class URL {
     return this._url + separator + this._searchParamsInstance.paramString;
   }
 
-  get searchParams() {
+  get searchParams(): URLSearchParams {
     if (this._searchParamsInstance == null) {
       this._searchParamsInstance = new URLSearchParams();
     }
     return this._searchParamsInstance;
   }
+
   static createObjectURL(blob: Blob) {
     if (BLOB_URL_PREFIX === null) {
       throw new Error('Cannot create URL for blob!');
@@ -194,5 +194,3 @@ class URL {
     // Do nothing.
   }
 }
-
-module.exports = URL;

--- a/Libraries/Blob/URL.js
+++ b/Libraries/Blob/URL.js
@@ -30,9 +30,9 @@ if (BlobModule && typeof BlobModule.BLOB_URI_SCHEME === 'string') {
  * <manifest>
  *   <application>
  *     <provider
- *       android:name='com.facebook.react.modules.blob.BlobProvider'
- *       android:authorities='@string/blob_provider_authority'
- *       android:exported='false'
+ *       android:name="com.facebook.react.modules.blob.BlobProvider"
+ *       android:authorities="@string/blob_provider_authority"
+ *       android:exported="false"
  *     />
  *   </application>
  * </manifest>
@@ -42,7 +42,7 @@ if (BlobModule && typeof BlobModule.BLOB_URI_SCHEME === 'string') {
  *
  * ```xml
  * <resources>
- *   <string name='blob_provider_authority'>your.app.package.blobs</string>
+ *   <string name="blob_provider_authority">your.app.package.blobs</string>
  * </resources>
  * ```
  */
@@ -50,7 +50,7 @@ if (BlobModule && typeof BlobModule.BLOB_URI_SCHEME === 'string') {
 // Small subset from whatwg-url: https://github.com/jsdom/whatwg-url/tree/master/lib
 // The reference code bloat comes from Unicode issues with URLs, so those won't work here.
 export class URLSearchParams {
-  searchParams = [];
+  _searchParams = [];
 
   constructor(params: any) {
     if (typeof params === 'object') {
@@ -59,37 +59,69 @@ export class URLSearchParams {
   }
 
   append(key: string, value: string) {
-    this.searchParams.push([key, value]);
+    this._searchParams.push([key, value]);
   }
 
-  get paramString() {
-    if (this.searchParams.length === 0) {
-      return '';
-    }
-    const last = this.searchParams.length - 1;
-    return this.searchParams.reduce((acc, curr, index) => {
-      return acc + curr.join('=') + (index === last ? '' : '&');
-    }, '');
+  delete(name) {
+    throw new Error('not implemented');
+  }
+
+  get(name) {
+    throw new Error('not implemented');
+  }
+
+  getAll(name) {
+    throw new Error('not implemented');
+  }
+
+  has(name) {
+    throw new Error('not implemented');
+  }
+
+  set(name, value) {
+    throw new Error('not implemented');
+  }
+
+  sort() {
+    throw new Error('not implemented');
   }
 
   [Symbol.iterator]() {
-    return this.searchParams[Symbol.iterator]();
+    return this._searchParams[Symbol.iterator]();
   }
 
   toString() {
-    return this.paramString;
+    if (this._searchParams.length === 0) {
+      return '';
+    }
+    const last = this._searchParams.length - 1;
+    return this._searchParams.reduce((acc, curr, index) => {
+      return acc + curr.join('=') + (index === last ? '' : '&');
+    }, '');
   }
+}
+
+function validateBaseUrl(url: string) {
+  // from this MIT-licensed gist: https://gist.github.com/dperini/729294
+  return /^(?:(?:(?:https?|ftp):)?\/\/)(?:(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)(?:\.(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)*(?:\.(?:[a-z\u00a1-\uffff]{2,})))(?::\d{2,5})?(?:[/?#]\S*)?$/i.test(
+    url,
+  );
 }
 
 export class URL {
   _searchParamsInstance = null;
-  static urlRegexp = /^((http[s]?|ftp):\/)?\/?([^:\/\s]+)((\/\w+)*\/)([\w\-\.]+[^#?\s]+)(.*)?(#[\w\-]+)?$/;
 
-  static validateBaseUrl(url: string) {
-    // from this MIT-licensed gist: https://gist.github.com/dperini/729294
-    return /^(?:(?:(?:https?|ftp):)?\/\/)(?:(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)(?:\.(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)*(?:\.(?:[a-z\u00a1-\uffff]{2,})))(?::\d{2,5})?(?:[/?#]\S*)?$/i.test(
-      url,
-    );
+  static createObjectURL(blob: Blob) {
+    if (BLOB_URL_PREFIX === null) {
+      throw new Error('Cannot create URL for blob!');
+    }
+    return `${BLOB_URL_PREFIX}${blob.data.blobId}?offset=${
+      blob.data.offset
+    }&size=${blob.size}`;
+  }
+
+  static revokeObjectURL(url: string) {
+    // Do nothing.
   }
 
   constructor(url: string, base: string) {
@@ -97,7 +129,7 @@ export class URL {
     if (base) {
       if (typeof base === 'string') {
         baseUrl = base;
-        if (!URL.validateBaseUrl(baseUrl)) {
+        if (!validateBaseUrl(baseUrl)) {
           throw new TypeError(`Invalid base URL: ${baseUrl}`);
         }
       } else if (typeof base === 'object') {
@@ -118,11 +150,19 @@ export class URL {
     }
   }
 
-  get href(): string {
-    return this.toString();
+  get hash() {
+    throw new Error('not implemented');
   }
 
-  toJSON(): string {
+  get host() {
+    throw new Error('not implemented');
+  }
+
+  get hostname() {
+    throw new Error('not implemented');
+  }
+
+  get href(): string {
     return this.toString();
   }
 
@@ -130,15 +170,11 @@ export class URL {
     throw new Error('not implemented');
   }
 
-  get username() {
-    throw new Error('not implemented');
-  }
-
   get password() {
     throw new Error('not implemented');
   }
 
-  get hostname() {
+  get pathname() {
     throw new Error('not implemented');
   }
 
@@ -150,28 +186,8 @@ export class URL {
     throw new Error('not implemented');
   }
 
-  get host() {
-    throw new Error('not implemented');
-  }
-
-  get pathname() {
-    throw new Error('not implemented');
-  }
-
   get search() {
     throw new Error('not implemented');
-  }
-
-  get hash() {
-    throw new Error('not implemented');
-  }
-
-  toString(): string {
-    if (this._searchParamsInstance === null) {
-      return this._url;
-    }
-    const separator = this._url.indexOf('?') > -1 ? '&' : '?';
-    return this._url + separator + this._searchParamsInstance.paramString;
   }
 
   get searchParams(): URLSearchParams {
@@ -181,16 +197,19 @@ export class URL {
     return this._searchParamsInstance;
   }
 
-  static createObjectURL(blob: Blob) {
-    if (BLOB_URL_PREFIX === null) {
-      throw new Error('Cannot create URL for blob!');
-    }
-    return `${BLOB_URL_PREFIX}${blob.data.blobId}?offset=${
-      blob.data.offset
-    }&size=${blob.size}`;
+  toJSON(): string {
+    return this.toString();
   }
 
-  static revokeObjectURL(url: string) {
-    // Do nothing.
+  toString(): string {
+    if (this._searchParamsInstance === null) {
+      return this._url;
+    }
+    const separator = this._url.indexOf('?') > -1 ? '&' : '?';
+    return this._url + separator + this._searchParamsInstance.toString();
+  }
+
+  get username() {
+    throw new Error('not implemented');
   }
 }

--- a/Libraries/Blob/__tests__/URL-test.js
+++ b/Libraries/Blob/__tests__/URL-test.js
@@ -9,7 +9,7 @@
  */
 'use strict';
 
-const URL = require('URL');
+const URL = require('URL').URL;
 
 describe('URL', function() {
   it('should pass Mozilla Dev Network examples', () => {

--- a/Libraries/Blob/__tests__/URL-test.js
+++ b/Libraries/Blob/__tests__/URL-test.js
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @emails oncall+react_native
+ */
+'use strict';
+
+const URL = require('URL');
+
+describe('URL', function() {
+  it('should pass Mozilla Dev Network examples', () => {
+    const a = new URL('/', 'https://developer.mozilla.org');
+    expect(a.href).toBe('https://developer.mozilla.org/');
+    const b = new URL('https://developer.mozilla.org');
+    expect(b.href).toBe('https://developer.mozilla.org/');
+    const c = new URL('en-US/docs', b);
+    expect(c.href).toBe('https://developer.mozilla.org/en-US/docs');
+    const d = new URL('/en-US/docs', b);
+    expect(d.href).toBe('https://developer.mozilla.org/en-US/docs');
+    const f = new URL('/en-US/docs', d);
+    expect(f.href).toBe('https://developer.mozilla.org/en-US/docs');
+    // from original test suite, but requires complex implementation
+    // const g = new URL(
+    //   '/en-US/docs',
+    //   'https://developer.mozilla.org/fr-FR/toto',
+    // );
+    // expect(g.href).toBe('https://developer.mozilla.org/en-US/docs');
+    const h = new URL('/en-US/docs', a);
+    expect(h.href).toBe('https://developer.mozilla.org/en-US/docs');
+  });
+});

--- a/Libraries/Core/setUpXHR.js
+++ b/Libraries/Core/setUpXHR.js
@@ -28,4 +28,5 @@ polyfillGlobal('WebSocket', () => require('WebSocket'));
 polyfillGlobal('Blob', () => require('Blob'));
 polyfillGlobal('File', () => require('File'));
 polyfillGlobal('FileReader', () => require('FileReader'));
-polyfillGlobal('URL', () => require('URL'));
+polyfillGlobal('URL', () => require('URL').URL); // flowlint-line untyped-import:off
+polyfillGlobal('URLSearchParams', () => require('URL').URLSearchParams); // flowlint-line untyped-import:off


### PR DESCRIPTION
This expands functionality of URL minimally so Apollo Server can run in React Native contexts. Add explicit-fail getters so undefined values won't get generated from the otherwise missing implemenation.

Use of URL in apollo-server here: https://github.com/apollographql/apollo-server/blob/458bc71eadde52483ccaef209df3eb1f1bcb4424/packages/apollo-datasource-rest/src/RESTDataSource.ts#L79

Credit to my colleague @dysonpro for debugging the issue and providing the initial working stub implementation.

Changelog:
----------

Help reviewers and the release process by writing your own changelog entry. See http://facebook.github.io/react-native/docs/contributing#changelog for an example.

[INTERNAL] [ENHANCEMENT] - Support construction, toString(), and href() of URL objects.


Test Plan:
----------

I added new unit tests for URL to cover the implementation added, based on the whatwg tests. To prevent silent or weird failures, I added explicit getters from URL public interface that throw exceptions when called. After this change, our app bundle that uses apollo-server was able to load and run.