### PR TITLE
[tvOS][TVEventHandler] Differentiate swipe and tap events

### DIFF
--- a/React/Base/RCTTVRemoteHandler.m
+++ b/React/Base/RCTTVRemoteHandler.m
@@ -69,22 +69,22 @@ NSString *const RCTTVRemoteEventSwipeDown = @"swipeDown";
                                          name:RCTTVRemoteEventSelect];
 
     // Up
-    [self addTapGestureRecognizerWithSelector:@selector(swipedUp:)
+    [self addTapGestureRecognizerWithSelector:@selector(tappedUp:)
                                     pressType:UIPressTypeUpArrow
                                          name:RCTTVRemoteEventUp];
 
     // Down
-    [self addTapGestureRecognizerWithSelector:@selector(swipedDown:)
+    [self addTapGestureRecognizerWithSelector:@selector(tappedDown:)
                                     pressType:UIPressTypeDownArrow
                                          name:RCTTVRemoteEventDown];
 
     // Left
-    [self addTapGestureRecognizerWithSelector:@selector(swipedLeft:)
+    [self addTapGestureRecognizerWithSelector:@selector(tappedLeft:)
                                     pressType:UIPressTypeLeftArrow
                                          name:RCTTVRemoteEventLeft];
 
     // Right
-    [self addTapGestureRecognizerWithSelector:@selector(swipedRight:)
+    [self addTapGestureRecognizerWithSelector:@selector(tappedRight:)
                                     pressType:UIPressTypeRightArrow
                                          name:RCTTVRemoteEventRight];
 
@@ -158,20 +158,40 @@ NSString *const RCTTVRemoteEventSwipeDown = @"swipeDown";
 
 - (void)swipedUp:(UIGestureRecognizer *)r
 {
-  [self sendAppleTVEvent:RCTTVRemoteEventUp toView:r.view];
+  [self sendAppleTVEvent:RCTTVRemoteEventSwipeUp toView:r.view];
 }
 
 - (void)swipedDown:(UIGestureRecognizer *)r
 {
-  [self sendAppleTVEvent:RCTTVRemoteEventDown toView:r.view];
+  [self sendAppleTVEvent:RCTTVRemoteEventSwipeDown toView:r.view];
 }
 
 - (void)swipedLeft:(UIGestureRecognizer *)r
 {
-  [self sendAppleTVEvent:RCTTVRemoteEventLeft toView:r.view];
+  [self sendAppleTVEvent:RCTTVRemoteEventSwipeLeft toView:r.view];
 }
 
 - (void)swipedRight:(UIGestureRecognizer *)r
+{
+  [self sendAppleTVEvent:RCTTVRemoteEventSwipeRight toView:r.view];
+}
+
+- (void)tappedUp:(UIGestureRecognizer *)r
+{
+  [self sendAppleTVEvent:RCTTVRemoteEventUp toView:r.view];
+}
+
+- (void)tappedDown:(UIGestureRecognizer *)r
+{
+  [self sendAppleTVEvent:RCTTVRemoteEventDown toView:r.view];
+}
+
+- (void)tappedLeft:(UIGestureRecognizer *)r
+{
+  [self sendAppleTVEvent:RCTTVRemoteEventLeft toView:r.view];
+}
+
+- (void)tappedRight:(UIGestureRecognizer *)r
 {
   [self sendAppleTVEvent:RCTTVRemoteEventRight toView:r.view];
 }


### PR DESCRIPTION
Motivation:
----------

As developers want to handle multiple actions on Siri Remote input when using TVEventHandler, it is crucial to differentiate 'swap' and 'tap' events.

Changelog:
----------

[tvOS] [Changed] - 'up', 'down', 'left' and 'right' events are now connected with tapping on edges of remote. New events 'swipeUp', 'swipeDown', 'swipeLeft' and 'swipeRight' added to detect swipes.

Test Plan:
----------

Create simple component which should react to user input:

```javascript
var TVEventHandler = require('TVEventHandler');

class Example extends React.Component {
  _tvEventHandler: any;

  _enableTVEventHandler() {
    this._tvEventHandler = new TVEventHandler();
    this._tvEventHandler.enable(this, function(cmp, evt) {
      if (evt && evt.eventType === 'right') {
        // tap right
      } else if(evt && evt.eventType === 'up') {
        // tap up
      } else if(evt && evt.eventType === 'left') {
        // tap left
      } else if(evt && evt.eventType === 'down') {
        // tap down
      } else if(evt && evt.eventType === 'swipeRight') {
        // swipe right
      } else if(evt && evt.eventType === 'swipeUp') {
        // swipe up
      } else if(evt && evt.eventType === 'swipeLeft') {
        // swipe left
      } else if(evt && evt.eventType === 'swipeDown') {
        // swipe down
      }
    });
  }

  _disableTVEventHandler() {
    if (this._tvEventHandler) {
      this._tvEventHandler.disable();
      delete this._tvEventHandler;
    }
  }

  componentDidMount() {
    this._enableTVEventHandler();
  }

  componentWillUnmount() {
    this._disableTVEventHandler();
  }
}
```
