### PR TITLE
imp: Add templates to rn package

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,7 +128,8 @@
     "ReactAndroid",
     "ReactCommon",
     "README.md",
-    "third-party-podspecs"
+    "third-party-podspecs",
+    "template"
   ],
   "scripts": {
     "start": "node cli.js start",


### PR DESCRIPTION
Changelog:
----------

[General] [added] - Add `templates` to `react-native` package.

### Why?

We need a `template` to initialize new RN project from `react-native-cli`. We are planning to remove `templates` from `cli` to be always synced with chosen rn version. Issue for that in `react-native-cli` is here: https://github.com/react-native-community/react-native-cli/issues/39 .
cc @grabbou @cpojer 

