### PR TITLE
Added WebView deprecation warning

### DIFF
--- a/Libraries/react-native/react-native-implementation.js
+++ b/Libraries/react-native/react-native-implementation.js
@@ -14,6 +14,7 @@ const invariant = require('invariant');
 
 let showedListViewDeprecation = false;
 let showedSwipeableListViewDeprecation = false;
+let showedWebWiewDeprecation = false;
 
 // Export React, plus some native additions.
 module.exports = {
@@ -167,6 +168,14 @@ module.exports = {
     return require('VirtualizedList');
   },
   get WebView() {
+    if (!showedWebWiewDeprecation) {
+      console.warn(
+        'WebView has been extracted from react-native core and will be removed in a future release. ' +
+          'See https://github.com/react-native-community/react-native-webview for more information',
+      );
+
+      showedWebWiewDeprecation = true;
+    }
     return require('WebView');
   },
 

--- a/Libraries/react-native/react-native-implementation.js
+++ b/Libraries/react-native/react-native-implementation.js
@@ -171,7 +171,8 @@ module.exports = {
     if (!showedWebWiewDeprecation) {
       console.warn(
         'WebView has been extracted from react-native core and will be removed in a future release. ' +
-          'See https://github.com/react-native-community/react-native-webview for more information',
+          "It can now be installed and imported from 'react-native-webview' instead of 'react-native'. " +
+          'See https://github.com/react-native-community/react-native-webview for more informations.',
       );
 
       showedWebWiewDeprecation = true;


### PR DESCRIPTION
Changelog:
----------

Help reviewers and the release process by writing your own changelog entry. See http://facebook.github.io/react-native/docs/contributing#changelog for an example.

[General] [Deprecated] - Deprecation warning for WebView as it has been extracted from core. 


Test Plan:
----------

importing WebView from react-native will now trigger a warning.