### PR TITLE
feat: expose AnimatedEvent

### DIFF
--- a/Libraries/Animated/src/AnimatedImplementation.js
+++ b/Libraries/Animated/src/AnimatedImplementation.js
@@ -684,6 +684,11 @@ module.exports = {
    */
   forkEvent,
   unforkEvent,
+  
+  /**
+   * Expose Event class, so it can be used as a type for type checkers.
+   */
+  Event: AnimatedEvent,
 
   __PropsOnlyForTests: AnimatedProps,
 };

--- a/Libraries/Animated/src/AnimatedImplementation.js
+++ b/Libraries/Animated/src/AnimatedImplementation.js
@@ -684,7 +684,7 @@ module.exports = {
    */
   forkEvent,
   unforkEvent,
-  
+
   /**
    * Expose Event class, so it can be used as a type for type checkers.
    */


### PR DESCRIPTION
Some third party components rely on the `AnimatedEvent` as a type (see https://github.com/kmagiera/react-native-gesture-handler/blob/master/Swipeable.js#L9). In order to not rely on a path which could change at any time it would be great to expose it.

Changelog:
----------

[General][added] - Expose AnimatedEvent

Test Plan:
----------

n/a
