### PR TITLE
fix incorrect type which makes animated gifs not loop forever on device

### DIFF
--- a/Libraries/Image/RCTGIFImageDecoder.m
+++ b/Libraries/Image/RCTGIFImageDecoder.m
@@ -32,7 +32,7 @@ RCT_EXPORT_MODULE()
 {
   CGImageSourceRef imageSource = CGImageSourceCreateWithData((CFDataRef)imageData, NULL);
   NSDictionary<NSString *, id> *properties = (__bridge_transfer NSDictionary *)CGImageSourceCopyProperties(imageSource, NULL);
-  NSUInteger loopCount = 0;
+  CGFloat loopCount = 0;
   if ([[properties[(id)kCGImagePropertyGIFDictionary] allKeys] containsObject:(id)kCGImagePropertyGIFLoopCount]) {
     loopCount = [properties[(id)kCGImagePropertyGIFDictionary][(id)kCGImagePropertyGIFLoopCount] unsignedIntegerValue];
     if (loopCount == 0) {
@@ -43,7 +43,7 @@ RCT_EXPORT_MODULE()
       loopCount += 1;
     }
   }
-  
+
   UIImage *image = nil;
   size_t imageCount = CGImageSourceGetCount(imageSource);
   if (imageCount > 1) {


### PR DESCRIPTION
https://github.com/facebook/react-native/issues/22985

This 1 liner fixes the animation looping being broken on ios devices. The original source of the bug is here: https://github.com/facebook/react-native/commit/95ef882#diff-e57b12f931820d7e0949e5cbb2701dcfR35

We set the value to a special large float, and assign it to repeatCount which is also a float, so this should be a float.

Changelog:

[iOS] [Fixed] - Fix animated GIFs not looping forever