### PR TITLE
bump android gradle plugin to 3.3.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.1'
+        classpath 'com.android.tools.build:gradle:3.3.0'
         classpath 'de.undercouch:gradle-download-task:3.4.3'
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/template/android/build.gradle
+++ b/template/android/build.gradle
@@ -12,7 +12,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.1'
+        classpath 'com.android.tools.build:gradle:3.3.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
Android Gradle Plugin 3.3.0 add many improvements in compile time speed, but also enable R8 shrinker.

Changelog:
----------

[Android] [Changed] - Bump Android Gradle Plugin to 3.3.0


Test Plan:
----------
Everything should work as before