### PR TITLE
RNTester: Add `allowFontScaling` example to Android

### DIFF
--- a/RNTester/js/TextExample.android.js
+++ b/RNTester/js/TextExample.android.js
@@ -461,6 +461,25 @@ class TextExample extends React.Component<{}> {
             keep writing it{"'"}ll just keep going and going
           </Text>
         </RNTesterBlock>
+        <RNTesterBlock title="allowFontScaling attribute">
+          <Text>
+            By default, text will respect Text Size accessibility setting on
+            Android. It means that all font sizes will be increased or decreased
+            depending on the value of the Text Size setting in the OS's Settings app.
+          </Text>
+          <Text style={{ marginTop: 10 }}>
+            You can disable scaling for your Text component by passing {'"'}allowFontScaling={
+              '{'
+            }false{'}"'} prop.
+          </Text>
+          <Text allowFontScaling={false} style={{marginTop: 20, fontSize: 15}}>
+            This text will not scale.{' '}
+            <Text style={{fontSize: 15}}>
+              This text also won't scale because it inherits "allowFontScaling"
+              from its parent.
+            </Text>
+          </Text>
+        </RNTesterBlock>
         <RNTesterBlock title="selectable attribute">
           <Text selectable>
             This text is selectable if you click-and-hold, and will offer the

--- a/RNTester/js/TextExample.android.js
+++ b/RNTester/js/TextExample.android.js
@@ -465,9 +465,10 @@ class TextExample extends React.Component<{}> {
           <Text>
             By default, text will respect Text Size accessibility setting on
             Android. It means that all font sizes will be increased or decreased
-            depending on the value of the Text Size setting in the OS's Settings app.
+            depending on the value of the Text Size setting in the OS's Settings
+            app.
           </Text>
-          <Text style={{ marginTop: 10 }}>
+          <Text style={{marginTop: 10}}>
             You can disable scaling for your Text component by passing {'"'}allowFontScaling={
               '{'
             }false{'}"'} prop.

--- a/RNTester/js/TextExample.ios.js
+++ b/RNTester/js/TextExample.ios.js
@@ -869,7 +869,7 @@ exports.examples = [
         <View>
           <Text>
             By default, text will respect Text Size accessibility setting on
-            iOS. It means that all font sizes will be increased or descreased
+            iOS. It means that all font sizes will be increased or decreased
             depending on the value of Text Size setting in{' '}
             <Text style={{fontWeight: 'bold'}}>
               Settings.app - Display & Brightness - Text Size
@@ -880,8 +880,12 @@ exports.examples = [
               '{'
             }false{'}"'} prop.
           </Text>
-          <Text allowFontScaling={false} style={{marginTop: 20}}>
-            This text will not scale.
+          <Text allowFontScaling={false} style={{marginTop: 20, fontSize: 15}}>
+            This text will not scale.{' '}
+            <Text style={{fontSize: 15}}>
+              This text also won't scale because it inherits "allowFontScaling"
+              from its parent.
+            </Text>
           </Text>
         </View>
       );

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/TextAttributes.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/TextAttributes.java
@@ -5,6 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+package com.facebook.react.views.text;
+
+import com.facebook.react.uimanager.PixelUtil;
+import com.facebook.react.uimanager.ViewDefaults;
+
 /*
  * Currently, TextAttributes consists of a subset of text props that need to be passed from parent
  * to child so inheritance can be implemented correctly. An example complexity that causes a prop
@@ -12,12 +17,6 @@
  * the rendered aka effective value. For example, to figure out the rendered/effective font size,
  * you need to take into account the fontSize and allowFontScaling props.
  */
-
-package com.facebook.react.views.text;
-
-import com.facebook.react.uimanager.PixelUtil;
-import com.facebook.react.uimanager.ViewDefaults;
-
 public class TextAttributes {
   private boolean mAllowFontScaling = true;
   private float mFontSize = Float.NaN;


### PR DESCRIPTION
iOS's `allowFontScaling` example was copied to Android. Also, I added a case illustrating that `allowFontScaling` gets inherited in nested `<Text>` scenarios. This tests the bug fix from #22917. This nested case was added to both iOS and Android.

Also, moved the comment in `TextAttributes.java` from the top of the file to the top of the class definition as requested in #22917.

Test Plan:
----------

Used the OS settings to increase the font scale to the maximum. Opened RNTester on iOS and Android and verified that the text in the `allowFontScaling` example that has `allowFontScaling` set to `false` does not get scaled.

Changelog:
----------

[Android] [Added] - RNTester: Added demo of `Text's` `allowFontScaling` prop

Adam Comella
Microsoft Corp.