### PR TITLE
Android TextInput: Support `allowFontScaling` on placeholder

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
@@ -644,6 +644,13 @@ public class ReactEditText extends EditText {
     applyTextAttributes();
   }
 
+  public void setAllowFontScaling(boolean allowFontScaling) {
+    if (mTextAttributes.getAllowFontScaling() != allowFontScaling) {
+      mTextAttributes.setAllowFontScaling(allowFontScaling);
+      applyTextAttributes();
+    }
+  }
+
   public void setFontSize(float fontSize) {
     mTextAttributes.setFontSize(fontSize);
     applyTextAttributes();

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
@@ -319,6 +319,11 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
     view.setLetterSpacingPt(letterSpacing);
   }
 
+  @ReactProp(name = ViewProps.ALLOW_FONT_SCALING, defaultBoolean = true)
+  public void setAllowFontScaling(ReactEditText view, boolean allowFontScaling) {
+    view.setAllowFontScaling(allowFontScaling);
+  }
+
   @ReactProp(name = "placeholder")
   public void setPlaceholder(ReactEditText view, @Nullable String placeholder) {
     view.setHint(placeholder);


### PR DESCRIPTION
Currently, the `TextInput's` placeholder is always sized as though `allowFontScaling` is `true`.

Note that `allowFontScaling` works fine for the content of the `TextInput`. The reason is that we set the font size in two places: in the shadow node and in the Android view. The shadow node logic determines the size of the content and the Android view logic determines the size of the placeholder. The handler for the `allowFontScaling` prop is only present in the shadow node logic. Consequently, the Android view logic always uses the default value of `true` for the `allowFontScaling` prop.

The fix is to add logic for handling the `allowFontScaling` prop to the Android view.

It would be great if we could handle all text props in one spot instead of duplicating code between the shadow node and the Android view. That would eliminate this whole class of bugs. However, I don't have enough familiarity with the history of this code to know how hard that would be or if it's even possible.

Fixes #18827.

Test Plan:
----------

Verified that `Text`, the content of a `TextInput`, and the placeholder of a `TextInput` are all rendered the same way for all values of `allowFontScaling` (`undefined`, `true`, `false`).

Changelog:
----------

[Android] [Fixed] - TextInput: Support `allowFontScaling` on placeholder

Adam Comella
Microsoft Corp.
