### PR TITLE
Android Text: Fix `letterSpacing` rendering when `fontSize` changes

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/CustomLetterSpacingSpan.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/CustomLetterSpacingSpan.java
@@ -42,10 +42,8 @@ public class CustomLetterSpacingSpan extends MetricAffectingSpan {
   }
 
   private void apply(TextPaint paint) {
-    // mLetterSpacing and paint.getTextSize() are both in pixels,
-    // yielding an accurate em value.
     if (!Float.isNaN(mLetterSpacing)) {
-      paint.setLetterSpacing(mLetterSpacing / paint.getTextSize());
+      paint.setLetterSpacing(mLetterSpacing);
     }
   }
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/TextAttributes.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/TextAttributes.java
@@ -121,9 +121,13 @@ public class TextAttributes {
       return Float.NaN;
     }
 
-    return mAllowFontScaling
+    float letterSpacingPixels = mAllowFontScaling
       ? PixelUtil.toPixelFromSP(mLetterSpacing)
       : PixelUtil.toPixelFromDIP(mLetterSpacing);
+
+    // `letterSpacingPixels` and `getEffectiveFontSize` are both in pixels,
+    // yielding an accurate em value.
+    return letterSpacingPixels / getEffectiveFontSize();
   }
 
   public String toString() {

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
@@ -660,7 +660,7 @@ public class ReactEditText extends EditText {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
       float effectiveLetterSpacing = mTextAttributes.getEffectiveLetterSpacing();
       if (!Float.isNaN(effectiveLetterSpacing)) {
-        setLetterSpacing(effectiveLetterSpacing / getTextSize());
+        setLetterSpacing(effectiveLetterSpacing);
       }
     }
   }


### PR DESCRIPTION
If you set `letterSpacing` on an outer text and then set `fontSize` on an inner text, the wrong `letterSpacing` will be rendered.

Here's an example:

```
<Text style={{ fontSize: 10, letterSpacing: 10 }}>
  <Text style={{ fontSize: 20 }}>Some text</Text>
</Text>
```

`fontSize` affects letter spacing. In this case, the bug is that setting `fontSize` to `20` doesn't cause the letter spacing to be recalculated.

Notice that the logic for applying letter spacing only applies it if the node has a different value for `getEffectiveLetterSpacing()` than its parent. The problem is that `getEffectiveLetterSpacing()` doesn't represent the final letter spacing value -- it doesn't take `fontSize` into account. Consequently, it sometimes incorrectly skips applying letter spacing as illustrated above.

The fix is to ensure `getEffectiveLetterSpacing()` represents the final rendered letter spacing value. To do this, some of the letter spacing calculation code was moved from `CustomLetterSpacingSpan` to `getEffectiveLetterSpacing()`.

Test Plan:
----------

Created a test app where I set `fontSize` and `letterSpacing` in different nested combinations and verified that letter spacing is rendered correctly. Did this with `Text` and `TextInput`. Also verified that the `TextInput's` `placeholder` works properly with `letterSpacing`.

Changelog:
----------

[Android] [Fixed] - Text: Fix `letterSpacing` rendering when `fontSize` changes

Adam Comella
Microsoft Corp.