### PR TITLE
[Standalone for NativeComponents] AndroidCheckBox

### DIFF
--- a/Libraries/Components/CheckBox/AndroidCheckBoxNativeComponent.js
+++ b/Libraries/Components/CheckBox/AndroidCheckBoxNativeComponent.js
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ */
+'use strict';
+
+const requireNativeComponent = require('requireNativeComponent');
+
+import type {ViewProps} from 'ViewPropTypes';
+import type {SyntheticEvent} from 'CoreEventTypes';
+import type {NativeComponent} from 'ReactNative';
+
+type CheckBoxEvent = SyntheticEvent<
+  $ReadOnly<{|
+    target: number,
+    value: boolean,
+  |}>,
+>;
+
+type NativeProps = $ReadOnly<{|
+  ...ViewProps,
+
+  /**
+   * Used in case the props change removes the component.
+   */
+  onChange?: ?(event: CheckBoxEvent) => mixed,
+
+  /**
+   * Invoked with the new value when the value changes.
+   */
+  onValueChange?: ?(value: boolean) => mixed,
+
+  /**
+   * Used to locate this view in end-to-end tests.
+   */
+  testID?: ?string,
+
+  on?: ?boolean,
+  enabled?: boolean,
+|}>;
+
+export type CheckBoxNativeType = Class<NativeComponent<NativeProps>>;
+
+module.exports = ((requireNativeComponent(
+  'AndroidCheckBox',
+): any): CheckBoxNativeType);

--- a/Libraries/Components/CheckBox/AndroidCheckBoxNativeComponent.js
+++ b/Libraries/Components/CheckBox/AndroidCheckBoxNativeComponent.js
@@ -44,7 +44,7 @@ type NativeProps = $ReadOnly<{|
   enabled?: boolean,
 |}>;
 
-export type CheckBoxNativeType = Class<NativeComponent<NativeProps>>;
+type CheckBoxNativeType = Class<NativeComponent<NativeProps>>;
 
 module.exports = ((requireNativeComponent(
   'AndroidCheckBox',

--- a/Libraries/Components/CheckBox/CheckBox.android.js
+++ b/Libraries/Components/CheckBox/CheckBox.android.js
@@ -12,13 +12,14 @@
 const React = require('React');
 const StyleSheet = require('StyleSheet');
 
-const requireNativeComponent = require('requireNativeComponent');
+const AndroidCheckBoxNativeComponent = require('AndroidCheckBoxNativeComponent');
 const nullthrows = require('nullthrows');
 const setAndForwardRef = require('setAndForwardRef');
 
 import type {ViewProps} from 'ViewPropTypes';
 import type {SyntheticEvent} from 'CoreEventTypes';
 import type {NativeComponent} from 'ReactNative';
+import type {CheckBoxNativeType} from 'AndroidCheckBoxNativeComponent';
 
 type CheckBoxEvent = SyntheticEvent<
   $ReadOnly<{|
@@ -46,15 +47,6 @@ type CommonProps = $ReadOnly<{|
   testID?: ?string,
 |}>;
 
-type NativeProps = $ReadOnly<{|
-  ...CommonProps,
-
-  on?: ?boolean,
-  enabled?: boolean,
-|}>;
-
-type CheckBoxNativeType = Class<NativeComponent<NativeProps>>;
-
 type Props = $ReadOnly<{|
   ...CommonProps,
 
@@ -75,10 +67,6 @@ type Props = $ReadOnly<{|
    */
   forwardedRef?: ?React.Ref<CheckBoxNativeType>,
 |}>;
-
-const RCTCheckBox = ((requireNativeComponent(
-  'AndroidCheckBox',
-): any): CheckBoxNativeType);
 
 /**
  * Renders a boolean input (Android only).
@@ -169,7 +157,7 @@ class CheckBox extends React.Component<Props> {
     };
 
     return (
-      <RCTCheckBox
+      <AndroidCheckBoxNativeComponent
         {...nativeProps}
         ref={this._setNativeRef}
         onChange={this._onChange}

--- a/Libraries/Components/CheckBox/CheckBox.android.js
+++ b/Libraries/Components/CheckBox/CheckBox.android.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @flow
+ * @flow strict-local
  * @format
  */
 'use strict';
@@ -19,7 +19,6 @@ const setAndForwardRef = require('setAndForwardRef');
 import type {ViewProps} from 'ViewPropTypes';
 import type {SyntheticEvent} from 'CoreEventTypes';
 import type {NativeComponent} from 'ReactNative';
-import type {CheckBoxNativeType} from 'AndroidCheckBoxNativeComponent';
 
 type CheckBoxEvent = SyntheticEvent<
   $ReadOnly<{|
@@ -46,6 +45,15 @@ type CommonProps = $ReadOnly<{|
    */
   testID?: ?string,
 |}>;
+
+type NativeProps = $ReadOnly<{|
+  ...CommonProps,
+
+  on?: ?boolean,
+  enabled?: boolean,
+|}>;
+
+type CheckBoxNativeType = Class<NativeComponent<NativeProps>>;
 
 type Props = $ReadOnly<{|
   ...CommonProps,


### PR DESCRIPTION
This PR is related to #22990

Changelog:
----------
[Android][Changed]  - move the call to requireNativeComponent from `Checkbox.android.js` to `AndroidCheckBoxNativeComponent.js`


Test Plan:
----------
 - [x] npm run lint
 - [x]  npm run flow-check-android
 - [x]  npm run flow-check-ios
 - [x] npm run flow
 - [x] npm run test