### PR TITLE
[Standalone for NativeComponents] RCTSafeAreaView

### DIFF
--- a/Libraries/Components/SafeAreaView/RCTSafeAreaViewNativeComponent.js
+++ b/Libraries/Components/SafeAreaView/RCTSafeAreaViewNativeComponent.js
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow
+ */
+
+const requireNativeComponent = require('requireNativeComponent');
+
+import type {ViewProps} from 'ViewPropTypes';
+import type {NativeComponent} from 'ReactNative';
+
+type NativeProps = $ReadOnly<{|
+  ...ViewProps,
+  emulateUnlessSupported?: boolean,
+|}>;
+
+type RCTSafeAreaViewNativeType = Class<NativeComponent<NativeProps>>;
+
+module.exports = ((requireNativeComponent(
+  'RCTSafeAreaView',
+): any): RCTSafeAreaViewNativeType);

--- a/Libraries/Components/SafeAreaView/SafeAreaView.js
+++ b/Libraries/Components/SafeAreaView/SafeAreaView.js
@@ -11,7 +11,6 @@
 const Platform = require('Platform');
 const React = require('React');
 const View = require('View');
-const requireNativeComponent = require('requireNativeComponent');
 
 import type {ViewProps} from 'ViewPropTypes';
 
@@ -39,10 +38,15 @@ if (Platform.OS === 'android') {
     }
   };
 } else {
-  const RCTSafeAreaView = requireNativeComponent('RCTSafeAreaView');
+  const RCTSafeAreaViewNativeComponent = require('RCTSafeAreaViewNativeComponent');
   exported = class SafeAreaView extends React.Component<Props> {
     render(): React.Node {
-      return <RCTSafeAreaView emulateUnlessSupported={true} {...this.props} />;
+      return (
+        <RCTSafeAreaViewNativeComponent
+          emulateUnlessSupported={true}
+          {...this.props}
+        />
+      );
     }
   };
 }


### PR DESCRIPTION
Part of #22990 

Changelog:
----------

[iOS] [Changed] - Create individual `RCTSafeAreaViewNativeComponent` JS file from `SafeAreaView` with flow typing.

Test Plan:
----------

- [x] npm run lint
- [x] npm run flow-check-ios
- [x] npm run flow
- [x] npm run test
