### PR TITLE
Add prop "disableSwipe" to SwipeableFlatList and SwipeableRow

### DIFF
--- a/Libraries/Experimental/SwipeableRow/SwipeableFlatList.js
+++ b/Libraries/Experimental/SwipeableRow/SwipeableFlatList.js
@@ -34,6 +34,11 @@ type SwipableListProps = {
    * Callback method to render the view that will be unveiled on swipe
    */
   renderQuickActions: renderItemType,
+
+  /**
+   * Disable swipping on rows
+   */
+  disableSwipe: boolean,
 };
 
 type Props<ItemT> = SwipableListProps & FlatListProps<ItemT>;
@@ -67,6 +72,7 @@ class SwipeableFlatList<ItemT> extends React.Component<Props<ItemT>, State> {
     ...FlatList.defaultProps,
     bounceFirstRowOnMount: true,
     renderQuickActions: () => null,
+    disableSwipe: false,
   };
 
   constructor(props: Props<ItemT>, context: any): void {
@@ -113,7 +119,7 @@ class SwipeableFlatList<ItemT> extends React.Component<Props<ItemT>, State> {
     }
 
     let shouldBounceOnMount = false;
-    if (this._shouldBounceFirstRowOnMount) {
+    if (this._shouldBounceFirstRowOnMount && !this.props.disableSwipe) {
       this._shouldBounceFirstRowOnMount = false;
       shouldBounceOnMount = true;
     }
@@ -127,7 +133,8 @@ class SwipeableFlatList<ItemT> extends React.Component<Props<ItemT>, State> {
         onClose={() => this._onClose(key)}
         shouldBounceOnMount={shouldBounceOnMount}
         onSwipeEnd={this._setListViewScrollable}
-        onSwipeStart={this._setListViewNotScrollable}>
+        onSwipeStart={this._setListViewNotScrollable}
+        disableSwipe={this.props.disableSwipe}>
         {this.props.renderItem(info)}
       </SwipeableRow>
     );

--- a/Libraries/Experimental/SwipeableRow/SwipeableRow.js
+++ b/Libraries/Experimental/SwipeableRow/SwipeableRow.js
@@ -67,6 +67,7 @@ type Props = $ReadOnly<{|
   shouldBounceOnMount?: ?boolean,
   slideoutView?: ?React.Node,
   swipeThreshold?: ?number,
+  disableSwipe?: ?boolean,
 |}>;
 
 type State = {
@@ -100,7 +101,11 @@ class SwipeableRow extends React.Component<Props, State> {
     event: PressEvent,
     gestureState: GestureState,
   ): void => {
-    if (this._isSwipingExcessivelyRightFromClosedPosition(gestureState)) {
+    const disableSwipe = this.props.disableSwipe ?? false;
+    if (
+      disableSwipe ||
+      this._isSwipingExcessivelyRightFromClosedPosition(gestureState)
+    ) {
       return;
     }
 
@@ -124,6 +129,10 @@ class SwipeableRow extends React.Component<Props, State> {
     event: PressEvent,
     gestureState: GestureState,
   ): void => {
+    const disableSwipe = this.props.disableSwipe ?? false;
+    if (disableSwipe) {
+      return;
+    }
     const horizontalDistance = IS_RTL ? -gestureState.dx : gestureState.dx;
     if (this._isSwipingRightFromClosed(gestureState)) {
       this.props.onOpen && this.props.onOpen();


### PR DESCRIPTION
Motivation:
----------
Sometimes you are rendering multiple SwipeableFlatList at the same time (Ex: one per tab) and some of them wont require swiping because there are not associated quickActions for any (there could be more use cases).
So instead of programatically need to render either FlatList or SwipeableFlatList, using this prop saves you from overcomplicating your render with a simple boolean prop.

Test Plan:
----------
  npm run prettier
  npm run flow-check-ios
  npm run flow-check-android
  Run RNTester app, go to SwipeableFlatList, added prop disableSwipe={true} to component, everything works as expected.

Easy to reproduce PR, just add the prop to `react-native/RNTester/js/SwipeableFlatListExample.js` and run it. Rows wont swipe anymore :)
```
<SwipeableFlatList
  data={data}
  disableSwipe={true}
  bounceFirstRowOnMount={true}
  maxSwipeDistance={160}
  renderItem={this._renderItem.bind(this)}
  renderQuickActions={this._renderQuickActions.bind(this)}
 />
```

Changelog:
----------
[General][Added] - Add prop *disableSwipe* to `SwipeableFlatList.js` and `SwipeableRow.js`