### PR TITLE
#22990 add RCTDatePickerNativeComponent types

### DIFF
--- a/Libraries/Components/DatePicker/DatePickerIOS.ios.js
+++ b/Libraries/Components/DatePicker/DatePickerIOS.ios.js
@@ -18,12 +18,11 @@ const StyleSheet = require('StyleSheet');
 const View = require('View');
 
 const invariant = require('invariant');
-const requireNativeComponent = require('requireNativeComponent');
 
 import type {ViewProps} from 'ViewPropTypes';
 import type {SyntheticEvent} from 'CoreEventTypes';
 
-const RCTDatePickerIOS = requireNativeComponent('RCTDatePicker');
+const RCTDatePickerNativeComponent = require('RCTDatePickerNativeComponent');
 
 type Event = SyntheticEvent<
   $ReadOnly<{|
@@ -119,7 +118,7 @@ class DatePickerIOS extends React.Component<Props> {
   };
 
   // $FlowFixMe How to type a native component to be able to call setNativeProps
-  _picker: ?React.ElementRef<typeof RCTDatePickerIOS> = null;
+  _picker: ?React.ElementRef<typeof RCTDatePickerNativeComponent> = null;
 
   componentDidUpdate() {
     if (this.props.date) {
@@ -147,7 +146,7 @@ class DatePickerIOS extends React.Component<Props> {
     );
     return (
       <View style={props.style}>
-        <RCTDatePickerIOS
+        <RCTDatePickerNativeComponent
           testID={props.testID}
           ref={picker => {
             this._picker = picker;

--- a/Libraries/Components/DatePicker/RCTDatePickerNativeComponent.js
+++ b/Libraries/Components/DatePicker/RCTDatePickerNativeComponent.js
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow
+ */
+
+'use strict';
+
+const requireNativeComponent = require('requireNativeComponent');
+
+import type {SyntheticEvent} from 'CoreEventTypes';
+import type {ViewProps} from 'ViewPropTypes';
+import type {NativeComponent} from 'ReactNative';
+
+type Event = SyntheticEvent<
+  $ReadOnly<{|
+    timestamp: number,
+  |}>,
+>;
+
+type NativeProps = $ReadOnly<{|
+  ...ViewProps,
+  date?: ?number,
+  initialDate?: ?Date,
+  locale?: ?string,
+  maximumDate?: ?number,
+  minimumDate?: ?number,
+  minuteInterval?: ?(1 | 2 | 3 | 4 | 5 | 6 | 10 | 12 | 15 | 20 | 30),
+  mode?: ?('date' | 'time' | 'datetime'),
+  onChange?: ?(event: Event) => void,
+  timeZoneOffsetInMinutes?: ?number,
+|}>;
+type RCTDatePickerNativeType = Class<NativeComponent<NativeProps>>;
+
+module.exports = ((requireNativeComponent(
+  'RCTDatePicker',
+): any): RCTDatePickerNativeType);


### PR DESCRIPTION
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
Help us understand your motivation by explaining why you decided to make this change:


Changelog:
----------

[iOS] [Changed] - As mentioned in #22990, I have moved native components required by DatePickerIOS.ios.js into separate files and added Flow Typing.


Test Plan:
----------

* yarn test
* yarn lint Libraries/Components/DatePicker/*
* yarn flow
