### PR TITLE
[Android] [Deprecated] - update to gradle 4.10.1 or high

### DIFF
--- a/react.gradle
+++ b/react.gradle
@@ -92,11 +92,11 @@ afterEvaluate {
         } else {
             variant.registerResGeneratingTask(currentBundleTask)
         }
-        variant.mergeResources.dependsOn(currentBundleTask)
+        variant.mergeResourcesProvider.get().dependsOn(currentBundleTask)
 
         // packageApplication for Android plugin 3.x
         def packageTask = variant.hasProperty("packageApplication")
-            ? variant.packageApplication
+            ? variant.packageApplicationProvider.get()
             : tasks.findByName("package${targetName}")
         if (variant.hasProperty("packageLibrary")) {
             packageTask = variant.packageLibrary
@@ -149,7 +149,7 @@ afterEvaluate {
             }
 
             // mergeAssets must run first, as it clears the intermediates directory
-            dependsOn(variant.mergeAssets)
+            dependsOn(variant.mergeAssetsProvider.get())
 
             enabled currentBundleTask.enabled
         }


### PR DESCRIPTION
Add suport to gradle 4.10.1 or high!
The new version of android studio 3.3 recommendete to update gradle project to 4.10.1 

> To take advantage of the latest features, improvements, and security fixes, we strongly recommend that you update the Android Gradle plugin to version 3.3.0 and Gradle to version 4.10.1. [Release notes ](https://developer.android.com/studio/releases/gradle-plugin) 

>Android plugin 3.2.0 and higher now support building the Android App Bundle—a new upload format that defers APK generation and signing to compatible app stores, such as Google Play. With app bundles, you no longer have to build, sign, and manage multiple APKs, and users get smaller, more optimized downloads. [Learn more](https://developer.android.com/guide/app-bundle/?utm_source=android-studio)

but if the upgrade to the new Android gradle many warnings come up, becouse meny things was obsoleted 

> WARNING: API 'variant.getMergeResources()' is obsolete and has been replaced with 'variant.getMergeResourcesProvider()'. 

> WARNING: API 'variant.getPackageApplication()' is obsolete and has been replaced with 'variant.getPackageApplicationProvider()'.

> WARNING: API 'variant.getMergeAssets()' is obsolete and has been replaced with 'variant.getMergeAssetsProvider()'. 

> It will be removed at the end of 2019.
> For more information, [see ](https://d.android.com/r/tools/task-configuration-avoidance.)
> To determine what is calling variant.getMergeAssets(), use -Pandroid.debug.obsoleteApi=true on the command line to display a stack trace.


Changelog:
----------
[Android] [Deprecated] - fix warinings obsolete to update to gradle 4.10.1 or high

Test Plan:
----------
change gradle-wrapper.proprerties:
`- distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip`
`+ distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip`

and in build.gradle

` - classpath 'com.android.tools.build:gradle:3.2.0'`
`+ classpath 'com.android.tools.build:gradle:3.3.0'`

for warnnings starts, use this change and fix the problem! =)
