### PR TITLE
Use RCTBridgeDelegate in the new project template

### DIFF
--- a/template/ios/HelloWorld/AppDelegate.h
+++ b/template/ios/HelloWorld/AppDelegate.h
@@ -5,9 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#import <React/RCTBridgeDelegate.h>
 #import <UIKit/UIKit.h>
 
-@interface AppDelegate : UIResponder <UIApplicationDelegate>
+@interface AppDelegate : UIResponder <UIApplicationDelegate, RCTBridgeDelegate>
 
 @property (nonatomic, strong) UIWindow *window;
 

--- a/template/ios/HelloWorld/AppDelegate.m
+++ b/template/ios/HelloWorld/AppDelegate.m
@@ -7,6 +7,7 @@
 
 #import "AppDelegate.h"
 
+#import <React/RCTBridge.h>
 #import <React/RCTBundleURLProvider.h>
 #import <React/RCTRootView.h>
 
@@ -14,18 +15,11 @@
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
-  NSURL *jsCodeLocation;
+  RCTBridge *bridge = [[RCTBridge alloc] initWithDelegate:self launchOptions:launchOptions];
+  RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:bridge
+                                                   moduleName:@"HelloWorld"
+                                            initialProperties:nil];
 
-  #ifdef DEBUG
-    jsCodeLocation = [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index" fallbackResource:nil];
-  #else
-    jsCodeLocation = [[NSBundle mainBundle] URLForResource:@"main" withExtension:@"jsbundle"];
-  #endif
-
-  RCTRootView *rootView = [[RCTRootView alloc] initWithBundleURL:jsCodeLocation
-                                                      moduleName:@"HelloWorld"
-                                               initialProperties:nil
-                                                   launchOptions:launchOptions];
   rootView.backgroundColor = [UIColor blackColor];
 
   self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
@@ -34,6 +28,15 @@
   self.window.rootViewController = rootViewController;
   [self.window makeKeyAndVisible];
   return YES;
+}
+
+- (NSURL *)sourceURLForBridge:(RCTBridge *)bridge
+{
+#if DEBUG
+  return [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index" fallbackResource:nil];
+#else
+  return [[NSBundle mainBundle] URLForResource:@"main" withExtension:@"jsbundle"];
+#endif
 }
 
 @end


### PR DESCRIPTION
The main goal of this change is to fix an issue that happens on iOS when the native app starts before the packager server is available which causes app reloads to fail continually until the app is restarted.

What happens is that with the current setup we call `RCTBundleURLProvider#jsBundleURLForBundleRoot` once in `AppDelegate#didFinishLaunchingWithOptions`. If at that point the packager server is not running yet it will return nil (expected behaviour) and that will be passed to the bridge constructor. Subsequent reloads will keep trying to load this nil bundle url since it has no way to ask `RCTBundleURLProvider` for a new url now that the packager is actually running.

We can fix this by using `RCTBridgeDelegate` instead which is a lot more flexible. Instead of passing the bundle url at construction time it will call the `sourceURLForBridge` method each time the bridge is reloaded. This means that even if the packager is not running yet and that `RCTBundleURLProvider` returns nil for the first invocation, subsequent reloads will call `RCTBundleURLProvider` again for a new value.

Changelog:
----------

[iOS] [Added] - Use RCTBridgeDelegate in the new project template


Test Plan:
----------

Tested that using `RCTBridgeDelegate` fixed the issue by building an app first without starting the packager and waiting for the no bundle preset redscreen. Then I started the packager and hit reload and made sure the app was able to load properly. Before this fix the app would keep failing to load the bundle even if the packager was started.

I wasn't able to test the template directly (no sure how to do this now that local-cli is in another repo) but I applied the same changes that I did to my app to the template file carefully.
