### PR TITLE
[Standalone for NativeComponents] AndroidSwipeRefreshLayout

### DIFF
--- a/Libraries/Components/RefreshControl/AndroidSwipeRefreshLayoutNativeComponent.js
+++ b/Libraries/Components/RefreshControl/AndroidSwipeRefreshLayoutNativeComponent.js
@@ -1,0 +1,93 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow
+ */
+
+'use strict';
+
+const Platform = require('Platform');
+const requireNativeComponent = require('requireNativeComponent');
+
+import type {ColorValue} from 'StyleSheetTypes';
+import type {ViewProps} from 'ViewPropTypes';
+import type {NativeComponent} from 'ReactNative';
+
+let RefreshLayoutConsts;
+if (Platform.OS === 'android') {
+  const AndroidSwipeRefreshLayout = require('UIManager').getViewManagerConfig(
+    'AndroidSwipeRefreshLayout',
+  );
+  RefreshLayoutConsts = AndroidSwipeRefreshLayout
+    ? AndroidSwipeRefreshLayout.Constants
+    : {SIZE: {}};
+} else {
+  RefreshLayoutConsts = {SIZE: {}};
+}
+
+type IOSProps = $ReadOnly<{|
+  /**
+   * The color of the refresh indicator.
+   */
+  tintColor?: ?ColorValue,
+  /**
+   * Title color.
+   */
+  titleColor?: ?ColorValue,
+  /**
+   * The title displayed under the refresh indicator.
+   */
+  title?: ?string,
+|}>;
+
+type AndroidProps = $ReadOnly<{|
+  /**
+   * Whether the pull to refresh functionality is enabled.
+   */
+  enabled?: ?boolean,
+  /**
+   * The colors (at least one) that will be used to draw the refresh indicator.
+   */
+  colors?: ?$ReadOnlyArray<ColorValue>,
+  /**
+   * The background color of the refresh indicator.
+   */
+  progressBackgroundColor?: ?ColorValue,
+  /**
+   * Size of the refresh indicator, see RefreshControl.SIZE.
+   */
+  size?: ?(
+    | typeof RefreshLayoutConsts.SIZE.DEFAULT
+    | typeof RefreshLayoutConsts.SIZE.LARGE
+  ),
+  /**
+   * Progress view top offset
+   */
+  progressViewOffset?: ?number,
+|}>;
+
+export type NativeProps = $ReadOnly<{|
+  ...ViewProps,
+  ...IOSProps,
+  ...AndroidProps,
+
+  /**
+   * Called when the view starts refreshing.
+   */
+  onRefresh?: ?() => mixed,
+
+  /**
+   * Whether the view should be indicating an active refresh.
+   */
+  refreshing: boolean,
+|}>;
+
+type AndroidSwipeRefreshLayoutNativeType = Class<NativeComponent<NativeProps>>;
+
+module.exports = ((requireNativeComponent(
+  'AndroidSwipeRefreshLayout',
+): any): AndroidSwipeRefreshLayoutNativeType);

--- a/Libraries/Components/RefreshControl/RCTRefreshControlNativeComponent.js
+++ b/Libraries/Components/RefreshControl/RCTRefreshControlNativeComponent.js
@@ -1,0 +1,93 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow
+ */
+
+'use strict';
+
+const Platform = require('Platform');
+const requireNativeComponent = require('requireNativeComponent');
+
+import type {ColorValue} from 'StyleSheetTypes';
+import type {ViewProps} from 'ViewPropTypes';
+import type {NativeComponent} from 'ReactNative';
+
+let RefreshLayoutConsts;
+if (Platform.OS === 'android') {
+  const AndroidSwipeRefreshLayout = require('UIManager').getViewManagerConfig(
+    'AndroidSwipeRefreshLayout',
+  );
+  RefreshLayoutConsts = AndroidSwipeRefreshLayout
+    ? AndroidSwipeRefreshLayout.Constants
+    : {SIZE: {}};
+} else {
+  RefreshLayoutConsts = {SIZE: {}};
+}
+
+type IOSProps = $ReadOnly<{|
+  /**
+   * The color of the refresh indicator.
+   */
+  tintColor?: ?ColorValue,
+  /**
+   * Title color.
+   */
+  titleColor?: ?ColorValue,
+  /**
+   * The title displayed under the refresh indicator.
+   */
+  title?: ?string,
+|}>;
+
+type AndroidProps = $ReadOnly<{|
+  /**
+   * Whether the pull to refresh functionality is enabled.
+   */
+  enabled?: ?boolean,
+  /**
+   * The colors (at least one) that will be used to draw the refresh indicator.
+   */
+  colors?: ?$ReadOnlyArray<ColorValue>,
+  /**
+   * The background color of the refresh indicator.
+   */
+  progressBackgroundColor?: ?ColorValue,
+  /**
+   * Size of the refresh indicator, see RefreshControl.SIZE.
+   */
+  size?: ?(
+    | typeof RefreshLayoutConsts.SIZE.DEFAULT
+    | typeof RefreshLayoutConsts.SIZE.LARGE
+  ),
+  /**
+   * Progress view top offset
+   */
+  progressViewOffset?: ?number,
+|}>;
+
+export type NativeProps = $ReadOnly<{|
+  ...ViewProps,
+  ...IOSProps,
+  ...AndroidProps,
+
+  /**
+   * Called when the view starts refreshing.
+   */
+  onRefresh?: ?() => mixed,
+
+  /**
+   * Whether the view should be indicating an active refresh.
+   */
+  refreshing: boolean,
+|}>;
+
+type RCTRefreshControlNativeType = Class<NativeComponent<NativeProps>>;
+
+module.exports = ((requireNativeComponent(
+  'RCTRefreshControl',
+): any): RCTRefreshControlNativeType);

--- a/Libraries/Components/RefreshControl/RefreshControl.js
+++ b/Libraries/Components/RefreshControl/RefreshControl.js
@@ -14,7 +14,8 @@ const Platform = require('Platform');
 const React = require('React');
 const {NativeComponent} = require('ReactNative');
 
-const requireNativeComponent = require('requireNativeComponent');
+const AndroidSwipeRefreshLayoutNativeComponent = require('AndroidSwipeRefreshLayoutNativeComponent');
+const RCTRefreshControlNativeComponent = require('RCTRefreshControlNativeComponent');
 const nullthrows = require('nullthrows');
 
 import type {ColorValue} from 'StyleSheetTypes';
@@ -35,8 +36,8 @@ type NativeRefreshControlType = Class<NativeComponent<RefreshControlProps>>;
 
 const NativeRefreshControl: NativeRefreshControlType =
   Platform.OS === 'ios'
-    ? (requireNativeComponent('RCTRefreshControl'): any)
-    : (requireNativeComponent('AndroidSwipeRefreshLayout'): any);
+    ? RCTRefreshControlNativeComponent
+    : AndroidSwipeRefreshLayoutNativeComponent;
 
 type IOSProps = $ReadOnly<{|
   /**


### PR DESCRIPTION
Changelog:
----------

[iOS] [Changed] - moved RCTRefreshControl from RefreshControl as a separate component, as mentioned in #22990 
[Android] [Changed] - moved AndroidSwipeRefreshLayout from RefreshControl as a separate component, as mentioned in #22990 

Test Plan:
----------

- [x] npm test
- [x] npm run flow
- [x] npm run flow-check-ios
- [x] npm run flow-check-android
- [x] npm run lint
