### PR TITLE
Update EventEmitter.js

### DIFF
--- a/Libraries/vendor/emitter/EventEmitter.js
+++ b/Libraries/vendor/emitter/EventEmitter.js
@@ -176,7 +176,7 @@ class EventEmitter {
         const subscription = subscriptions[i];
 
         // The subscription may have been removed during this event loop.
-        if (subscription) {
+        if (subscription && subscription.listener) {
           this._currentSubscription = subscription;
           subscription.listener.apply(
             subscription.context,


### PR DESCRIPTION
added protection for emit() because subscription.listener may have been removed during event loop

Changelog:
----------

[GENERAL][FIX] Avoid crash when subscription listener may have been removed during event loop