### PR TITLE
[Standalone for NativeComponents] ProgressBarAndroid

### DIFF
--- a/Libraries/Components/ProgressBarAndroid/ProgressBarAndroid.android.js
+++ b/Libraries/Components/ProgressBarAndroid/ProgressBarAndroid.android.js
@@ -12,12 +12,10 @@
 
 const React = require('React');
 
-const requireNativeComponent = require('requireNativeComponent');
+const ProgressBarAndroidNativeComponent = require('ProgressBarAndroidNativeComponent');
 
-import type {NativeComponent} from 'ReactNative';
 import type {ViewProps} from 'ViewPropTypes';
-
-const AndroidProgressBar = requireNativeComponent('AndroidProgressBar');
+import type {ProgressBarAndroidType} from 'ProgressBarAndroidNativeComponent';
 
 export type ProgressBarAndroidProps = $ReadOnly<{|
   ...ViewProps,
@@ -84,9 +82,9 @@ export type ProgressBarAndroidProps = $ReadOnly<{|
  */
 const ProgressBarAndroid = (
   props: ProgressBarAndroidProps,
-  forwardedRef: ?React.Ref<'AndroidProgressBar'>,
+  forwardedRef: ?React.Ref<ProgressBarAndroidType>,
 ) => {
-  return <AndroidProgressBar {...props} ref={forwardedRef} />;
+  return <ProgressBarAndroidNativeComponent {...props} ref={forwardedRef} />;
 };
 
 const ProgressBarAndroidToExport = React.forwardRef(ProgressBarAndroid);
@@ -103,6 +101,4 @@ ProgressBarAndroidToExport.defaultProps = {
 /* $FlowFixMe(>=0.89.0 site=react_native_android_fb) This comment suppresses an
  * error found when Flow v0.89 was deployed. To see the error, delete this
  * comment and run Flow. */
-module.exports = (ProgressBarAndroidToExport: Class<
-  NativeComponent<ProgressBarAndroidProps>,
->);
+module.exports = (ProgressBarAndroidToExport: ProgressBarAndroidType);

--- a/Libraries/Components/ProgressBarAndroid/ProgressBarAndroid.android.js
+++ b/Libraries/Components/ProgressBarAndroid/ProgressBarAndroid.android.js
@@ -15,7 +15,6 @@ const React = require('React');
 const ProgressBarAndroidNativeComponent = require('ProgressBarAndroidNativeComponent');
 
 import type {ViewProps} from 'ViewPropTypes';
-import type {ProgressBarAndroidType} from 'ProgressBarAndroidNativeComponent';
 
 export type ProgressBarAndroidProps = $ReadOnly<{|
   ...ViewProps,
@@ -82,7 +81,7 @@ export type ProgressBarAndroidProps = $ReadOnly<{|
  */
 const ProgressBarAndroid = (
   props: ProgressBarAndroidProps,
-  forwardedRef: ?React.Ref<ProgressBarAndroidType>,
+  forwardedRef: ?React.Ref<typeof ProgressBarAndroidNativeComponent>,
 ) => {
   return <ProgressBarAndroidNativeComponent {...props} ref={forwardedRef} />;
 };
@@ -101,4 +100,4 @@ ProgressBarAndroidToExport.defaultProps = {
 /* $FlowFixMe(>=0.89.0 site=react_native_android_fb) This comment suppresses an
  * error found when Flow v0.89 was deployed. To see the error, delete this
  * comment and run Flow. */
-module.exports = (ProgressBarAndroidToExport: ProgressBarAndroidType);
+module.exports = (ProgressBarAndroidToExport: ProgressBarAndroidNativeComponent);

--- a/Libraries/Components/ProgressBarAndroid/ProgressBarAndroidNativeComponent.js
+++ b/Libraries/Components/ProgressBarAndroid/ProgressBarAndroidNativeComponent.js
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ */
+
+'use strict';
+
+const requireNativeComponent = require('requireNativeComponent');
+
+import type {ViewProps} from 'ViewPropTypes';
+import type {NativeComponent} from 'ReactNative';
+
+type NativeProps = $ReadOnly<{|
+  ...ViewProps,
+  styleAttr?: string,
+  typeAttr?: string,
+  indeterminate: boolean,
+  progress?: number,
+  animating?: ?boolean,
+  color?: ?string,
+  testID?: ?string,
+|}>;
+
+export type ProgressBarAndroidType = Class<NativeComponent<NativeProps>>;
+
+module.exports = ((requireNativeComponent(
+  'AndroidProgressBar',
+): any): ProgressBarAndroidType);

--- a/Libraries/Components/ProgressBarAndroid/ProgressBarAndroidNativeComponent.js
+++ b/Libraries/Components/ProgressBarAndroid/ProgressBarAndroidNativeComponent.js
@@ -26,7 +26,7 @@ type NativeProps = $ReadOnly<{|
   testID?: ?string,
 |}>;
 
-export type ProgressBarAndroidType = Class<NativeComponent<NativeProps>>;
+type ProgressBarAndroidType = Class<NativeComponent<NativeProps>>;
 
 module.exports = ((requireNativeComponent(
   'AndroidProgressBar',


### PR DESCRIPTION
his PR is related to #22990

Changelog:
----------

[Android][Changed] - move the call to requireNativeComponent from ProgressBarAndroid.android.js to ProgressBarAndroidNativeComponent.js

Test Plan:
----------

- [x] npm run lint
- [x] npm run flow-check-android
- [x] npm run flow
- [x] npm run test