### PR TITLE
Moved requireNativeComponent to a new file

### DIFF
--- a/Libraries/Components/ProgressBarAndroid/AndroidProgressBarNativeComponent.js
+++ b/Libraries/Components/ProgressBarAndroid/AndroidProgressBarNativeComponent.js
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ */
+'use strict';
+
+const requireNativeComponent = require('requireNativeComponent');
+
+import type {ViewProps} from 'ViewPropTypes';
+import type {SyntheticEvent} from 'CoreEventTypes';
+import type {NativeComponent} from 'ReactNative';
+
+module.exports = requireNativeComponent('AndroidProgressBar');

--- a/Libraries/Components/ProgressBarAndroid/ProgressBarAndroid.android.js
+++ b/Libraries/Components/ProgressBarAndroid/ProgressBarAndroid.android.js
@@ -12,12 +12,10 @@
 
 const React = require('React');
 
-const requireNativeComponent = require('requireNativeComponent');
-
 import type {NativeComponent} from 'ReactNative';
 import type {ViewProps} from 'ViewPropTypes';
 
-const AndroidProgressBar = requireNativeComponent('AndroidProgressBar');
+const AndroidProgressBar = require('AndroidProgressBarNativeComponent');
 
 export type ProgressBarAndroidProps = $ReadOnly<{|
   ...ViewProps,


### PR DESCRIPTION
Changelog:
----------

[Android] [Changed] - I did some work for issue #22990. All the imports connected to requireNativeComponent in ProgressBarAndroid were moved to a separate file.

Test Plan:
----------

- [X] yarn test

- [X] yarn flow

- [X] yarn lint

Question: 
---------

Would the types seen here in `ProgressBarAndroid.android.js` need to be duplicated or moved into my new file? I wasn't sure if they are meant to be, considering they are being exported. 

``` javascript
export type ProgressBarAndroidProps = $ReadOnly<{|
  ...ViewProps,

  /**
   * Style of the ProgressBar and whether it shows indeterminate progress (e.g. spinner).
   *
   * `indeterminate` can only be false if `styleAttr` is Horizontal, and requires a
   * `progress` value.
   */
  ...
    | {|
        styleAttr: 'Horizontal',
        indeterminate: false,
        progress: number,
      |}
    | {|
        typeAttr:
          | 'Horizontal'
          | 'Normal'
          | 'Small'
          | 'Large'
          | 'Inverse'
          | 'SmallInverse'
          | 'LargeInverse',
        indeterminate: true,
      |},
  /**
   * Whether to show the ProgressBar (true, the default) or hide it (false).
   */
  animating?: ?boolean,
  /**
   * Color of the progress bar.
   */
  color?: ?string,
  /**
   * Used to locate this view in end-to-end tests.
   */
  testID?: ?string,
|}>;
```
