### PR TITLE
Remove AlertExample from RNTester in iOS

### DIFF
--- a/RNTester/js/RNTesterList.ios.js
+++ b/RNTester/js/RNTesterList.ios.js
@@ -212,11 +212,6 @@ const APIExamples: Array<RNTesterExample> = [
     supportsTVOS: true,
   },
   {
-    key: 'AlertExample',
-    module: require('./AlertExample').AlertExample,
-    supportsTVOS: true,
-  },
-  {
     key: 'AlertIOSExample',
     module: require('./AlertIOSExample'),
     supportsTVOS: true,


### PR DESCRIPTION
Changelog:
----------

[iOS] [Removed] - Removed AlertExample from RNTester in iOS.


Test Plan:
----------

Before, when we click `Alert` row from `APIS` section, RNTester came to error, after it, `Alert` row be removed, and actually `AlertIOS` row already contains `Alert` row does.

<img width="341" alt="0d321aca-49dc-4742-9c57-1c16f8ffa546" src="https://user-images.githubusercontent.com/5061845/51541697-6c270380-1e94-11e9-96eb-b6a3dd72c610.png">

The error like below, the reason is AlertExample not exports examples array.

<img width="339" alt="e5907e50-67be-4636-a2c6-d3353f86868e" src="https://user-images.githubusercontent.com/5061845/51541799-b314f900-1e94-11e9-8fc0-e938871136ac.png">



