### PR TITLE
[Android][DevSupport] Add Network Security Config file (fixes #22375)

### DIFF
--- a/ReactAndroid/src/main/res/devsupport/xml/network_security_config.xml
+++ b/ReactAndroid/src/main/res/devsupport/xml/network_security_config.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+  <domain-config cleartextTrafficPermitted="true">
+    <domain includeSubdomains="false">localhost</domain>
+    <domain includeSubdomains="false">10.0.2.2</domain>
+    <domain includeSubdomains="false">10.0.3.2</domain>
+  </domain-config>
+</network-security-config>


### PR DESCRIPTION
This fixes #22375. Android API level 28 and above now blocks all [clear text requests](https://developer.android.com/training/articles/security-config#CleartextTrafficPermitted) unless a network configuration rule is added to exclude it specifically.

The packager falls into this category and therefore gets blocked; resulting in the app being unable to connect to it.

Domains/IPs for the config have been taken from [here](https://github.com/facebook/react-native/blob/master/ReactAndroid/src/main/java/com/facebook/react/modules/systeminfo/AndroidInfoHelpers.java#L20-L22).

This change only adds to DevSupport android resources - so won't affect builds without DevSupport, e.g. release builds.

Changelog:
----------

[ANDROID] [DevSupport] add Network Security Config file to allow access to packager via cleartext requests in Android API 28 and above. (fixes #22375)

Test Plan:
----------

Built an app API 28 Android App with RN Android building from source, prior to this change the packager would not connect and show the following Error in Android logs;

![image](https://user-images.githubusercontent.com/5347038/51563641-f0718a80-1e84-11e9-88e0-c0cd38155a8f.png)

After applying this change the connection is now successful.

