### PR TITLE
Fix SwipeableActionButton styling.

### DIFF
--- a/Libraries/Experimental/SwipeableRow/SwipeableQuickActionButton.js
+++ b/Libraries/Experimental/SwipeableRow/SwipeableQuickActionButton.js
@@ -37,6 +37,9 @@ class SwipeableQuickActionButton extends React.Component<{
    * found when Flow v0.82 was deployed. To see the error delete this comment
    * and run Flow. */
   style?: ?DeprecatedViewPropTypes.style,
+  /* $FlowFixMe(>=0.82.0 site=react_native_fb) This comment suppresses an error
+   * found when Flow v0.82 was deployed. To see the error delete this comment
+   * and run Flow. */
   containerStyle?: ?DeprecatedViewPropTypes.style,
   testID?: string,
   text?: ?(string | Object | Array<string | Object>),

--- a/Libraries/Experimental/SwipeableRow/SwipeableQuickActionButton.js
+++ b/Libraries/Experimental/SwipeableRow/SwipeableQuickActionButton.js
@@ -37,6 +37,7 @@ class SwipeableQuickActionButton extends React.Component<{
    * found when Flow v0.82 was deployed. To see the error delete this comment
    * and run Flow. */
   style?: ?DeprecatedViewPropTypes.style,
+  containerStyle?: ?DeprecatedViewPropTypes.style,
   testID?: string,
   text?: ?(string | Object | Array<string | Object>),
   /* $FlowFixMe(>=0.82.0 site=react_native_fb) This comment suppresses an error
@@ -64,8 +65,9 @@ class SwipeableQuickActionButton extends React.Component<{
       <TouchableHighlight
         onPress={this.props.onPress}
         testID={this.props.testID}
-        underlayColor="transparent">
-        <View style={this.props.style}>{mainView}</View>
+        underlayColor="transparent"
+        style={this.props.containerStyle}>
+        {mainView}
       </TouchableHighlight>
     );
   }


### PR DESCRIPTION
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
Help us understand your motivation by explaining why you decided to make this change:


Changelog:
----------

Help reviewers and the release process by writing your own changelog entry. See http://facebook.github.io/react-native/docs/contributing#changelog for an example.

[General] [Fixed] - Same style was applied twice to SwipeableQuickActionButton in a recent commit causing problems with the buttons layout.

Test Plan:
----------
I have tested the changes locally in my app. The swipeable action buttons got messed up after I upgraded to latest react native. I found that a recent commit https://github.com/facebook/react-native/commit/886d70516eb2daaa5554599811918f16e78140cd#diff-46bd7d6f94be9729ed39ea900705327e has added support for a custom view but in the process, we are applying the passed in style twice to the buttons. Also, I don't see the point of applying passed in style to a custom view when a user can just apply it themselves while passing it.

Below is how the quick action buttons appeared after the upgrade. They are supposed to take up equal space.
![screenshot 2019-01-23 at 10 55 08 am](https://user-images.githubusercontent.com/7475133/51584931-73362c00-1efd-11e9-9fb5-d62545510a50.png)

This is how they appeared after the fix. This is exactly how they appeared before I upgraded react-native also.

![screenshot 2019-01-23 at 10 54 29 am](https://user-images.githubusercontent.com/7475133/51584939-79c4a380-1efd-11e9-8240-a9f553a681c0.png)

To test it, I am using a swipeable flat list where each item is a swipeable row. The swipeable actions are given equal space among each by using a `flex: 1`.
