### PR TITLE
[Standalone for NativeComponents] RCTTabBar

### DIFF
--- a/Libraries/Components/TabBarIOS/RCTTabBarNativeComponent.js
+++ b/Libraries/Components/TabBarIOS/RCTTabBarNativeComponent.js
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow
+ */
+
+'use strict';
+
+const requireNativeComponent = require('requireNativeComponent');
+
+import type {ViewProps} from 'ViewPropTypes';
+import type {ColorValue} from 'StyleSheetTypes';
+
+import type {NativeComponent} from 'ReactNative';
+
+type NativeProps = $ReadOnly<{|
+  ...ViewProps,
+  unselectedTintColor?: ColorValue,
+  tintColor?: ColorValue,
+  unselectedItemTintColor?: ColorValue,
+  barTintColor?: ColorValue,
+  barStyle?: ?('default' | 'black'),
+  translucent?: ?boolean,
+  itemPositioning?: ?('fill' | 'center' | 'auto'),
+|}>;
+
+type RCTTabBarNativeType = Class<NativeComponent<NativeProps>>;
+
+module.exports = ((requireNativeComponent(
+  'RCTTabBar',
+): any): RCTTabBarNativeType);

--- a/Libraries/Components/TabBarIOS/TabBarIOS.ios.js
+++ b/Libraries/Components/TabBarIOS/TabBarIOS.ios.js
@@ -14,12 +14,10 @@ const React = require('React');
 const StyleSheet = require('StyleSheet');
 const TabBarItemIOS = require('TabBarItemIOS');
 
-const requireNativeComponent = require('requireNativeComponent');
+const RCTTabBar = require('RCTTabBarNativeComponent');
 
 import type {ViewProps} from 'ViewPropTypes';
 import type {ColorValue} from 'StyleSheetTypes';
-
-const RCTTabBar = requireNativeComponent('RCTTabBar');
 
 type Props = $ReadOnly<{|
   ...ViewProps,


### PR DESCRIPTION
His PR is related to #22990

Changelog:
----------

[IOS][Changed] - move the call to requireNativeComponent from TabBarIOS.ios.js to RCTTabBarNativeComponent.js

Test Plan:
----------

- [x] npm run lint
- [x] npm run flow-check-android
- [x] npm run flow
- [x] npm run test