### PR TITLE
Fix SectionList layout of RNTester on iOS

### DIFF
--- a/Libraries/ART/ARTCGFloatArray.h
+++ b/Libraries/ART/ARTCGFloatArray.h
@@ -7,7 +7,7 @@
 
 // A little helper to make sure we have the right memory allocation ready for use.
 // We assume that we will only this in one place so no reference counting is necessary.
-// Needs to be freed when dealloced.
+// Needs to be freed when deallocated.
 
 // This is fragile since this relies on these values not getting reused. Consider
 // wrapping these in an Obj-C class or some ARC hackery to get refcounting.

--- a/Libraries/ART/ARTTextFrame.h
+++ b/Libraries/ART/ARTTextFrame.h
@@ -9,7 +9,7 @@
 
 // A little helper to make sure we have a set of lines including width ready for use.
 // We assume that we will only this in one place so no reference counting is necessary.
-// Needs to be freed when dealloced.
+// Needs to be freed when deallocated.
 
 // This is fragile since this relies on these values not getting reused. Consider
 // wrapping these in an Obj-C class or some ARC hackery to get refcounting.

--- a/RNTester/js/RNTesterExampleFilter.js
+++ b/RNTester/js/RNTesterExampleFilter.js
@@ -53,7 +53,7 @@ class RNTesterExampleFilter extends React.Component<Props, State> {
     }));
 
     return (
-      <View>
+      <View style={styles.container}>
         {this._renderTextInput()}
         {this.props.render({filteredSections})}
       </View>
@@ -97,6 +97,9 @@ const styles = StyleSheet.create({
     paddingLeft: 8,
     paddingVertical: 0,
     height: 35,
+  },
+  container: {
+    flex: 1,
   },
 });
 


### PR DESCRIPTION
Changelog:
----------

[iOS] [Fixed] - Fix SectionList layout of RNTester on iOS


Test Plan:
----------

Before, the last row of sectionList can not show on screen, like below:
<img width="339" alt="image" src="https://user-images.githubusercontent.com/5061845/51591638-7e528180-1f28-11e9-9c21-97c382426aa0.png">

After fix, layout of section list do correct like below:
<img width="339" alt="image" src="https://user-images.githubusercontent.com/5061845/51591726-c1acf000-1f28-11e9-8f9a-337b982a9c3c.png">
