### PR TITLE
[iOS] Add CF_RETURNS_NOT_RETAINED annotate for Objective-C method which returns Core Foundation object

### DIFF
--- a/Libraries/ART/RCTConvert+ART.h
+++ b/Libraries/ART/RCTConvert+ART.h
@@ -15,7 +15,7 @@
 
 @interface RCTConvert (ART)
 
-+ (CGPathRef)CGPath:(id)json;
++ (CGPathRef)CGPath:(id)json CF_RETURNS_NOT_RETAINED;
 + (CTTextAlignment)CTTextAlignment:(id)json;
 + (ARTTextFrame)ARTTextFrame:(id)json;
 + (ARTCGFloatArray)ARTCGFloatArray:(id)json;
@@ -23,7 +23,7 @@
 
 + (CGPoint)CGPoint:(id)json offset:(NSUInteger)offset;
 + (CGRect)CGRect:(id)json offset:(NSUInteger)offset;
-+ (CGColorRef)CGColor:(id)json offset:(NSUInteger)offset;
-+ (CGGradientRef)CGGradient:(id)json offset:(NSUInteger)offset;
++ (CGColorRef)CGColor:(id)json offset:(NSUInteger)offset CF_RETURNS_NOT_RETAINED;
++ (CGGradientRef)CGGradient:(id)json offset:(NSUInteger)offset CF_RETURNS_NOT_RETAINED;
 
 @end


### PR DESCRIPTION
Changelog:
----------

[iOS][Fixed] - Add CF_RETURNS_NOT_RETAINED annotate for Objective-C method which returns Core Foundation object

Test Plan:
----------

Annotate the Objective-C returned objects memory management.
