### PR TITLE
Fix tests in template project (0.58-stable)

### DIFF
--- a/local-cli/.npmignore
+++ b/local-cli/.npmignore
@@ -1,2 +1,3 @@
 __fixtures__
 __tests__
+!/templates/HelloWorld/__tests__

--- a/local-cli/generator/copyProjectTemplateAndReplace.js
+++ b/local-cli/generator/copyProjectTemplateAndReplace.js
@@ -127,6 +127,7 @@ function translateFilePath(path) {
     .replace('_BUCK', 'BUCK')
     .replace('_gitignore', '.gitignore')
     .replace('_gitattributes', '.gitattributes')
+    .replace('_babel.config.js', 'babel.config.js')
     .replace('_babelrc', '.babelrc')
     .replace('_flowconfig', '.flowconfig')
     .replace('_buckconfig', '.buckconfig')

--- a/local-cli/init/init.js
+++ b/local-cli/init/init.js
@@ -90,7 +90,7 @@ function generateProject(destinationRoot, newProjectName, options) {
     });
   }
   if (!options['skip-jest']) {
-    const jestDeps = `jest babel-jest metro-react-native-babel-preset react-test-renderer@${reactVersion}`;
+    const jestDeps = `jest babel-core@^7.0.0-bridge.0 babel-jest metro-react-native-babel-preset react-test-renderer@${reactVersion}`;
     if (yarnVersion) {
       console.log('Adding Jest...');
       execSync(`yarn add ${jestDeps} --dev --exact`, {stdio: 'inherit'});

--- a/local-cli/templates/HelloWorld/_babel.config.js
+++ b/local-cli/templates/HelloWorld/_babel.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  presets: ["module:metro-react-native-babel-preset"]
+}

--- a/local-cli/templates/HelloWorld/_babelrc
+++ b/local-cli/templates/HelloWorld/_babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["module:metro-react-native-babel-preset"]
-}


### PR DESCRIPTION
This fixes template application sample tests.
1. Fix adding __tests__ folder to npm package
2. Fix tests itself (add babel-core to deps and rename .babelrc to babel.config.js)

Unfortunately some changes can't be applied to master branch because of cli extraction. Moreover some changes (probably addition of babel-core to deps) will not be needed when jest 24 will be released. So this is path specially for 0.58-stable branch.

I think after apply this, we also should do some things:
1. Recheck npmignore patterns in master branch, remove unused and ensure that templates packed correctly.
2. Recheck our deps and config in HelloWorld template after jest 24 will be released.

Changelog:
----------

[General] [Fixed] - Fix tests in template HelloWorld application

Test Plan:
----------

```sh
# Prepare RN tarball for testing
cd /Volumes/work/react-native
npm pack
# clear yarn cache
yarn cache clean

# Test with yarn
cd /Volumes/work/tmp
react-native init --version /Volumes/work/react-native/react-native-0.58.0-rc.3.tgz Sample1
cd Sample1
yarn test
# Tests passed

# Test without yarn (yarn not available on system)
cd /Volumes/work/tmp
react-native init --version /Volumes/work/react-native/react-native-0.58.0-rc.3.tgz Sample1
cd Sample1
npm test
# Tests passed

# Recheck dependencies with fresh reinstall
cd /Volumes/work/tmp/Sample1
rm -rf node_modules yarn.lock package-lock.json
npm install
npm test
# Tests passed
```