### PR TITLE
Fixed string ref which was causing alert on react <Strictmode>

### DIFF
--- a/Libraries/Components/Keyboard/KeyboardAvoidingView.js
+++ b/Libraries/Components/Keyboard/KeyboardAvoidingView.js
@@ -64,8 +64,9 @@ class KeyboardAvoidingView extends React.Component<Props, State> {
 
   _frame: ?ViewLayout = null;
   _subscriptions: Array<EmitterSubscription> = [];
+  viewRef: {current: React.ElementRef<any> | null};
 
-  constructor(props) {
+  constructor(props: Props) {
     super(props);
     this.state = {bottom: 0};
     this.viewRef = React.createRef();

--- a/Libraries/Components/Keyboard/KeyboardAvoidingView.js
+++ b/Libraries/Components/Keyboard/KeyboardAvoidingView.js
@@ -52,8 +52,6 @@ type State = {|
   bottom: number,
 |};
 
-const viewRef = 'VIEW';
-
 /**
  * View that moves out of the way when the keyboard appears by automatically
  * adjusting its height, position, or bottom padding.
@@ -67,9 +65,11 @@ class KeyboardAvoidingView extends React.Component<Props, State> {
   _frame: ?ViewLayout = null;
   _subscriptions: Array<EmitterSubscription> = [];
 
-  state = {
-    bottom: 0,
-  };
+  constructor(props) {
+    super(props);
+    this.state = {bottom: 0};
+    this.viewRef = React.createRef();
+  }
 
   _relativeKeyboardHeight(keyboardFrame): number {
     const frame = this._frame;
@@ -171,7 +171,7 @@ class KeyboardAvoidingView extends React.Component<Props, State> {
         }
         return (
           <View
-            ref={viewRef}
+            ref={this.viewRef}
             style={StyleSheet.compose(
               style,
               heightStyle,
@@ -185,7 +185,7 @@ class KeyboardAvoidingView extends React.Component<Props, State> {
       case 'position':
         return (
           <View
-            ref={viewRef}
+            ref={this.viewRef}
             style={style}
             onLayout={this._onLayout}
             {...props}>
@@ -204,7 +204,7 @@ class KeyboardAvoidingView extends React.Component<Props, State> {
       case 'padding':
         return (
           <View
-            ref={viewRef}
+            ref={this.viewRef}
             style={StyleSheet.compose(
               style,
               {paddingBottom: bottomHeight},
@@ -218,7 +218,7 @@ class KeyboardAvoidingView extends React.Component<Props, State> {
       default:
         return (
           <View
-            ref={viewRef}
+            ref={this.viewRef}
             onLayout={this._onLayout}
             style={style}
             {...props}>


### PR DESCRIPTION
Changelog:
----------
[General] [Fixed] - After using React's `<StricMode>` it was discovered that a string ref was set, which is bad practice. 


Test Plan:
----------
Simple PR, just changed how ref is declared
closes #23132 