### PR TITLE
fix: change template to work with jest

### DIFF
--- a/template/_babelrc
+++ b/template/_babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["module:metro-react-native-babel-preset"]
-}

--- a/template/babel.config.js
+++ b/template/babel.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  presets: ['module:metro-react-native-babel-preset'],
+};


### PR DESCRIPTION
This change is required to make `yarn test` work in newly initialized project.
## Why?
`Jest@23` doesn't play well with new babel, so we need to install `babel-core@^7.0.0-bridge.0` and change `.babelrc` to `babel.config.js` to make it work. This is a temporary change till `jest` releases stable `24` version.

Test Plan:
----------
Already tested it locally using `verdaccio` to publish `react-native` and `@react-native-community@cli` locally.

cc. @grabbou @thymikee 
