### PR TITLE
WIP: [TESTS] [IOS] [CI] RNTesterSnapshotTests add support iOS 12 device

### DIFF
--- a/RNTester/RNTesterIntegrationTests/RNTesterSnapshotTests.m
+++ b/RNTester/RNTesterIntegrationTests/RNTesterSnapshotTests.m
@@ -23,10 +23,8 @@
 - (void)setUp
 {
   _runner = RCTInitRunnerForApp(@"RNTester/js/RNTesterApp.ios", nil, nil);
-  if ([[[UIDevice currentDevice] systemVersion] floatValue] >= 11) {
-    _runner.testSuffix = @"-iOS11";
-  } else if ([[[UIDevice currentDevice] systemVersion] floatValue] >= 10) {
-    _runner.testSuffix = @"-iOS10";
+  if ([[[UIDevice currentDevice] systemVersion] floatValue] >= 10) {
+    _runner.testSuffix = [NSString stringWithFormat:@"-iOS%d", UIDevice.currentDevice.systemVersion.intValue];
   }
   _runner.recordMode = NO;
 }


### PR DESCRIPTION
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
Help us understand your motivation by explaining why you decided to make this change:


Changelog:
----------
Currently ci in master fail for `test_ios`. Due to test in `RNTesterSnapshotTests`

Reference: https://circleci.com/gh/facebook/react-native/68285?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link

[iOS] [Fixed] - Fix test ios in ci


Test Plan:
----------
test_ios in CI should pass
