### PR TITLE
fix packager start in 0.58

### DIFF
--- a/scripts/packager.sh
+++ b/scripts/packager.sh
@@ -9,4 +9,4 @@ THIS_DIR=$(cd -P "$(dirname "$(readlink "${BASH_SOURCE[0]}" || echo "${BASH_SOUR
 # shellcheck source=/dev/null
 source "${THIS_DIR}/.packager.env"
 cd "$THIS_DIR/.." || exit
-node "./cli.js" start "$@"
+node "./local-cli/cli.js" start "$@"


### PR DESCRIPTION
This PR fixes packager during **react-native run-ios** and **react-native run-android**.

On reddit and discord many developers say that **react-native run-ios** failing on 0.58. But I found that **react-native start** works just fine. So did some investigation and found that if check is false when **react-native run-ios** but true when **react-native start**.
https://github.com/facebook/react-native/blob/57ad19758db60992a4d8ab55219d86eb892ac2b0/local-cli/cli.js#L23

It checks if script is run from shell, then starts the packager. Also found that **react-native start** calls this **react-natvie/local-cli/cli.js** directly and check is true. And dug little further to find that **packager.sh** is calling **react-native/cli.js** which imports **react-native/local-cli/cli.js**, therefore check is false.
