### PR TITLE
[iOS] Fix small typo in comments of reactDecodedImageBytes

### DIFF
--- a/Libraries/Image/RCTImageLoader.h
+++ b/Libraries/Image/RCTImageLoader.h
@@ -53,7 +53,7 @@ typedef dispatch_block_t RCTImageLoaderCancellationBlock;
 @property (nonatomic, copy) CAKeyframeAnimation *reactKeyframeAnimation;
 
 /**
- * Image's memory bytes. It has the dafault calculation of single image of GIF, if you have custom calculation of image decoded bytes, you can assign it using your value.
+ * Image's memory bytes. It has the dafault calculation of static image or GIF, if you have custom calculation of image decoded bytes, you can assign it using your value.
  */
 @property (nonatomic, assign) NSInteger reactDecodedImageBytes;
 

--- a/Libraries/Image/RCTImageLoader.h
+++ b/Libraries/Image/RCTImageLoader.h
@@ -53,7 +53,7 @@ typedef dispatch_block_t RCTImageLoaderCancellationBlock;
 @property (nonatomic, copy) CAKeyframeAnimation *reactKeyframeAnimation;
 
 /**
- * Image's memory bytes. It has the dafault calculation of static image or GIF, if you have custom calculation of image decoded bytes, you can assign it using your value.
+ * Memory bytes of the image with the default calculation of static image or GIF. Custom calculations of decoded bytes can be assigned manually.
  */
 @property (nonatomic, assign) NSInteger reactDecodedImageBytes;
 


### PR DESCRIPTION
Changelog:
----------

[iOS] [Fixed] - Fix small typo in comments of reactDecodedImageBytes


Test Plan:
----------

N/A.

@cpojer Hi, in #22731 , sorry I make a typo in the comments, let's fix them now. 😂 