### PR TITLE
Make upgrade cli compatible to babel7.

### DIFF
--- a/react-native-git-upgrade/package.json
+++ b/react-native-git-upgrade/package.json
@@ -15,7 +15,8 @@
     "url": "https://github.com/facebook/react-native.git"
   },
   "dependencies": {
-    "babel-core": "^6.18.0",
+    "@babel/core": "^7.2.2",
+    "babel-core": "^7.0.0-bridge.0",
     "babel-preset-es2015-node": "^6.1.1",
     "babel-preset-stage-3": "^6.17.0",
     "babel-register": "^6.18.0",


### PR DESCRIPTION
Old babel package makes recent `react-native` project with babel7 fails running `react-native-git-upgrade`. Refer to #18886.


Changelog:
----------

[GENERAL] [FIXED] - Fix `react-native-git-upgrade` to be compatible with `babel7` project.


Test Plan:
----------

1. Create a new `react-native` project above `0.56` which uses `babel7`.
2. Run `react-native-git-upgrade` will result failed saying `babel6` version is incompatible.