### PR TITLE
Separate MaskedViewExample into individual examples

### DIFF
--- a/RNTester/js/MaskedViewExample.js
+++ b/RNTester/js/MaskedViewExample.js
@@ -11,8 +11,6 @@
 'use strict';
 
 const React = require('react');
-const RNTesterBlock = require('RNTesterBlock');
-const RNTesterPage = require('RNTesterPage');
 const {
   Animated,
   Image,
@@ -23,25 +21,15 @@ const {
 } = require('react-native');
 
 type Props = $ReadOnly<{||}>;
-type State = {|
+type ChangingChildrenState = {|
   alternateChildren: boolean,
 |};
 
-class MaskedViewExample extends React.Component<Props, State> {
-  state = {
-    alternateChildren: true,
-  };
-
+class AnimatedMaskExample extends React.Component<Props> {
   _maskRotateAnimatedValue = new Animated.Value(0);
   _maskScaleAnimatedValue = new Animated.Value(1);
 
   componentDidMount() {
-    setInterval(() => {
-      this.setState(state => ({
-        alternateChildren: !state.alternateChildren,
-      }));
-    }, 1000);
-
     Animated.loop(
       Animated.sequence([
         Animated.timing(this._maskScaleAnimatedValue, {
@@ -68,102 +56,73 @@ class MaskedViewExample extends React.Component<Props, State> {
 
   render() {
     return (
-      <RNTesterPage title="<MaskedViewIOS>">
-        <RNTesterBlock title="Basic Mask">
-          <View style={{width: 300, height: 300, alignSelf: 'center'}}>
-            <MaskedViewIOS
-              style={{flex: 1}}
-              maskElement={
-                <View style={styles.maskContainerStyle}>
-                  <Text style={styles.maskTextStyle}>Basic Mask</Text>
-                </View>
-              }>
-              <View style={{flex: 1, backgroundColor: 'blue'}} />
-              <View style={{flex: 1, backgroundColor: 'red'}} />
-            </MaskedViewIOS>
-          </View>
-        </RNTesterBlock>
-        <RNTesterBlock title="Image Mask">
-          <View
+      <View style={{width: 300, height: 300, alignSelf: 'center'}}>
+        <MaskedViewIOS
+          style={{flex: 1}}
+          maskElement={
+            <Animated.View
+              style={[
+                styles.maskContainerStyle,
+                {transform: [{scale: this._maskScaleAnimatedValue}]},
+              ]}>
+              <Text style={styles.maskTextStyle}>Basic Mask</Text>
+            </Animated.View>
+          }>
+          <Animated.View
             style={{
-              width: 300,
-              height: 300,
-              alignSelf: 'center',
-              backgroundColor: '#eeeeee',
+              flex: 1,
+              transform: [
+                {
+                  rotate: this._maskRotateAnimatedValue.interpolate({
+                    inputRange: [0, 360],
+                    outputRange: ['0deg', '360deg'],
+                  }),
+                },
+              ],
             }}>
-            <MaskedViewIOS
-              style={{flex: 1}}
-              maskElement={
-                <View style={styles.maskContainerStyle}>
-                  <Image
-                    style={{height: 200, width: 200}}
-                    source={require('./imageMask.png')}
-                  />
-                </View>
-              }>
-              <View style={styles.maskContainerStyle}>
-                <Image
-                  resizeMode="cover"
-                  style={{width: 200, height: 200}}
-                  source={{
-                    uri:
-                      'https://38.media.tumblr.com/9e9bd08c6e2d10561dd1fb4197df4c4e/tumblr_mfqekpMktw1rn90umo1_500.gif',
-                  }}
-                />
-              </View>
-            </MaskedViewIOS>
-          </View>
-        </RNTesterBlock>
-        <RNTesterBlock title="Animated Mask">
-          <View style={{width: 300, height: 300, alignSelf: 'center'}}>
-            <MaskedViewIOS
-              style={{flex: 1}}
-              maskElement={
-                <Animated.View
-                  style={[
-                    styles.maskContainerStyle,
-                    {transform: [{scale: this._maskScaleAnimatedValue}]},
-                  ]}>
-                  <Text style={styles.maskTextStyle}>Basic Mask</Text>
-                </Animated.View>
-              }>
-              <Animated.View
-                style={{
-                  flex: 1,
-                  transform: [
-                    {
-                      rotate: this._maskRotateAnimatedValue.interpolate({
-                        inputRange: [0, 360],
-                        outputRange: ['0deg', '360deg'],
-                      }),
-                    },
-                  ],
-                }}>
-                <View style={{flex: 1, backgroundColor: 'blue'}} />
-                <View style={{flex: 1, backgroundColor: 'red'}} />
-              </Animated.View>
-            </MaskedViewIOS>
-          </View>
-        </RNTesterBlock>
-        <RNTesterBlock title="Mask w/ Changing Children">
-          <View style={{width: 300, height: 300, alignSelf: 'center'}}>
-            <MaskedViewIOS
-              style={{flex: 1}}
-              maskElement={
-                <View style={styles.maskContainerStyle}>
-                  <Text style={styles.maskTextStyle}>Basic Mask</Text>
-                </View>
-              }>
-              {this.state.alternateChildren
-                ? [
-                    <View key={1} style={{flex: 1, backgroundColor: 'blue'}} />,
-                    <View key={2} style={{flex: 1, backgroundColor: 'red'}} />,
-                  ]
-                : null}
-            </MaskedViewIOS>
-          </View>
-        </RNTesterBlock>
-      </RNTesterPage>
+            <View style={{flex: 1, backgroundColor: 'blue'}} />
+            <View style={{flex: 1, backgroundColor: 'red'}} />
+          </Animated.View>
+        </MaskedViewIOS>
+      </View>
+    );
+  }
+}
+
+class ChangingChildrenMaskExample extends React.Component<
+  Props,
+  ChangingChildrenState,
+> {
+  state = {
+    alternateChildren: true,
+  };
+
+  componentDidMount() {
+    setInterval(() => {
+      this.setState(state => ({
+        alternateChildren: !state.alternateChildren,
+      }));
+    }, 1000);
+  }
+
+  render() {
+    return (
+      <View style={{width: 300, height: 300, alignSelf: 'center'}}>
+        <MaskedViewIOS
+          style={{flex: 1}}
+          maskElement={
+            <View style={styles.maskContainerStyle}>
+              <Text style={styles.maskTextStyle}>Basic Mask</Text>
+            </View>
+          }>
+          {this.state.alternateChildren
+            ? [
+                <View key={1} style={{flex: 1, backgroundColor: 'blue'}} />,
+                <View key={2} style={{flex: 1, backgroundColor: 'red'}} />,
+              ]
+            : null}
+        </MaskedViewIOS>
+      </View>
     );
   }
 }
@@ -187,9 +146,70 @@ exports.description =
   'Renders the child view with a mask specified in the `renderMask` prop.';
 exports.examples = [
   {
-    title: 'Simple masked view',
-    render: function(): React.Element<typeof MaskedViewExample> {
-      return <MaskedViewExample />;
+    title: 'Basic Mask',
+    render: function(): React.Element<typeof View> {
+      return (
+        <View style={{width: 300, height: 300, alignSelf: 'center'}}>
+          <MaskedViewIOS
+            style={{flex: 1}}
+            maskElement={
+              <View style={styles.maskContainerStyle}>
+                <Text style={styles.maskTextStyle}>Basic Mask</Text>
+              </View>
+            }>
+            <View style={{flex: 1, backgroundColor: 'blue'}} />
+            <View style={{flex: 1, backgroundColor: 'red'}} />
+          </MaskedViewIOS>
+        </View>
+      );
+    },
+  },
+  {
+    title: 'Image Mask',
+    render: function(): React.Element<typeof View> {
+      return (
+        <View
+          style={{
+            width: 300,
+            height: 300,
+            alignSelf: 'center',
+            backgroundColor: '#eeeeee',
+          }}>
+          <MaskedViewIOS
+            style={{flex: 1}}
+            maskElement={
+              <View style={styles.maskContainerStyle}>
+                <Image
+                  style={{height: 200, width: 200}}
+                  source={require('./imageMask.png')}
+                />
+              </View>
+            }>
+            <View style={styles.maskContainerStyle}>
+              <Image
+                resizeMode="cover"
+                style={{width: 200, height: 200}}
+                source={{
+                  uri:
+                    'https://38.media.tumblr.com/9e9bd08c6e2d10561dd1fb4197df4c4e/tumblr_mfqekpMktw1rn90umo1_500.gif',
+                }}
+              />
+            </View>
+          </MaskedViewIOS>
+        </View>
+      );
+    },
+  },
+  {
+    title: 'Animated Mask',
+    render: function(): React.Element<typeof AnimatedMaskExample> {
+      return <AnimatedMaskExample />;
+    },
+  },
+  {
+    title: 'Mask w/ Changing Children',
+    render: function(): React.Element<typeof ChangingChildrenMaskExample> {
+      return <ChangingChildrenMaskExample />;
     },
   },
 ];

--- a/RNTester/js/MaskedViewExample.js
+++ b/RNTester/js/MaskedViewExample.js
@@ -56,7 +56,7 @@ class AnimatedMaskExample extends React.Component<Props> {
 
   render() {
     return (
-      <View style={{width: 300, height: 300, alignSelf: 'center'}}>
+      <View style={{width: 340, height: 300, alignSelf: 'center'}}>
         <MaskedViewIOS
           style={{flex: 1}}
           maskElement={
@@ -107,7 +107,7 @@ class ChangingChildrenMaskExample extends React.Component<
 
   render() {
     return (
-      <View style={{width: 300, height: 300, alignSelf: 'center'}}>
+      <View style={{width: 340, height: 300, alignSelf: 'center'}}>
         <MaskedViewIOS
           style={{flex: 1}}
           maskElement={
@@ -149,7 +149,7 @@ exports.examples = [
     title: 'Basic Mask',
     render: function(): React.Element<typeof View> {
       return (
-        <View style={{width: 300, height: 300, alignSelf: 'center'}}>
+        <View style={{width: 340, height: 300, alignSelf: 'center'}}>
           <MaskedViewIOS
             style={{flex: 1}}
             maskElement={
@@ -170,7 +170,7 @@ exports.examples = [
       return (
         <View
           style={{
-            width: 300,
+            width: 340,
             height: 300,
             alignSelf: 'center',
             backgroundColor: '#eeeeee',

--- a/RNTester/js/MaskedViewExample.js
+++ b/RNTester/js/MaskedViewExample.js
@@ -56,9 +56,9 @@ class AnimatedMaskExample extends React.Component<Props> {
 
   render() {
     return (
-      <View style={{width: 340, height: 300, alignSelf: 'center'}}>
+      <View style={styles.exampleWrapperStyle}>
         <MaskedViewIOS
-          style={{flex: 1}}
+          style={styles.flexStyle}
           maskElement={
             <Animated.View
               style={[
@@ -80,8 +80,8 @@ class AnimatedMaskExample extends React.Component<Props> {
                 },
               ],
             }}>
-            <View style={{flex: 1, backgroundColor: 'blue'}} />
-            <View style={{flex: 1, backgroundColor: 'red'}} />
+            <View style={styles.blueStyle} />
+            <View style={styles.redStyle} />
           </Animated.View>
         </MaskedViewIOS>
       </View>
@@ -107,9 +107,9 @@ class ChangingChildrenMaskExample extends React.Component<
 
   render() {
     return (
-      <View style={{width: 340, height: 300, alignSelf: 'center'}}>
+      <View style={styles.exampleWrapperStyle}>
         <MaskedViewIOS
-          style={{flex: 1}}
+          style={styles.flexStyle}
           maskElement={
             <View style={styles.maskContainerStyle}>
               <Text style={styles.maskTextStyle}>Basic Mask</Text>
@@ -117,8 +117,8 @@ class ChangingChildrenMaskExample extends React.Component<
           }>
           {this.state.alternateChildren
             ? [
-                <View key={1} style={{flex: 1, backgroundColor: 'blue'}} />,
-                <View key={2} style={{flex: 1, backgroundColor: 'red'}} />,
+                <View key={1} style={styles.blueStyle} />,
+                <View key={2} style={styles.redStyle} />,
               ]
             : null}
         </MaskedViewIOS>
@@ -128,6 +128,15 @@ class ChangingChildrenMaskExample extends React.Component<
 }
 
 const styles = StyleSheet.create({
+  exampleWrapperStyle: {
+    width: 340,
+    height: 300,
+    alignSelf: 'center',
+  },
+  imageStyle: {
+    height: 200,
+    width: 200,
+  },
   maskContainerStyle: {
     flex: 1,
     backgroundColor: 'transparent',
@@ -139,6 +148,20 @@ const styles = StyleSheet.create({
     fontSize: 40,
     fontWeight: 'bold',
   },
+  blueStyle: {
+    flex: 1,
+    backgroundColor: 'blue',
+  },
+  redStyle: {
+    flex: 1,
+    backgroundColor: 'red',
+  },
+  grayStyle: {
+    backgroundColor: '#eeeeee',
+  },
+  flexStyle: {
+    flex: 1,
+  },
 });
 
 exports.title = '<MaskedViewIOS>';
@@ -149,16 +172,16 @@ exports.examples = [
     title: 'Basic Mask',
     render: function(): React.Element<typeof View> {
       return (
-        <View style={{width: 340, height: 300, alignSelf: 'center'}}>
+        <View style={styles.exampleWrapperStyle}>
           <MaskedViewIOS
-            style={{flex: 1}}
+            style={styles.flexStyle}
             maskElement={
               <View style={styles.maskContainerStyle}>
                 <Text style={styles.maskTextStyle}>Basic Mask</Text>
               </View>
             }>
-            <View style={{flex: 1, backgroundColor: 'blue'}} />
-            <View style={{flex: 1, backgroundColor: 'red'}} />
+            <View style={styles.blueStyle} />
+            <View style={styles.redStyle} />
           </MaskedViewIOS>
         </View>
       );
@@ -168,19 +191,13 @@ exports.examples = [
     title: 'Image Mask',
     render: function(): React.Element<typeof View> {
       return (
-        <View
-          style={{
-            width: 340,
-            height: 300,
-            alignSelf: 'center',
-            backgroundColor: '#eeeeee',
-          }}>
+        <View style={[styles.exampleWrapperStyle, styles.grayStyle]}>
           <MaskedViewIOS
-            style={{flex: 1}}
+            style={styles.flexStyle}
             maskElement={
               <View style={styles.maskContainerStyle}>
                 <Image
-                  style={{height: 200, width: 200}}
+                  style={styles.imageStyle}
                   source={require('./imageMask.png')}
                 />
               </View>
@@ -188,7 +205,7 @@ exports.examples = [
             <View style={styles.maskContainerStyle}>
               <Image
                 resizeMode="cover"
-                style={{width: 200, height: 200}}
+                style={styles.imageStyle}
                 source={{
                   uri:
                     'https://38.media.tumblr.com/9e9bd08c6e2d10561dd1fb4197df4c4e/tumblr_mfqekpMktw1rn90umo1_500.gif',


### PR DESCRIPTION
In RNTester, previously the MaskedViewExample was returned as a single example record. However, within that one example there were several sub-examples. Now that we've implemented example filtering, filtering didn't really work for MaskedViewExample because it only operates on top-level examples.

There was no benefit to grouping MaskedViewExample into a single example, so this PR splits it into separate examples.


Changelog:
----------

Help reviewers and the release process by writing your own changelog entry. See http://facebook.github.io/react-native/docs/contributing#changelog for an example.

[General] [Fixed] - Fix filtering of MaskedViewExample by splitting into separate example records.


Test Plan:
----------

Run RNTester, select MaskedViewIOS, and confirm all of the following appear:

- Basic Mask
- Image Mask
- Animated Mask
- Mask w/ Changing Children

Confirm they all look/behave the same as they do on master.

Confirm typing into the "Search…" field filters MaskedViewIOS examples.


