### PR TITLE
Disable no-inline-styles lint rule for RNTester

### DIFF
--- a/RNTester/.eslintrc
+++ b/RNTester/.eslintrc
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "react-native/no-inline-styles": 0
+  }
+}


### PR DESCRIPTION
We have a million of inline styles in RNTester which causes a lot of noise with the lint bot in PRs. The rule makes sense for the main libraries but for RNTester it usually makes examples easier to read to just use inline styles.  Also reduces lint warnings from 357 to 77.

Changelog:
----------

[General] [Changed] - Disable no-inline-styles lint rule for RNTester

Test Plan:
----------

run `yarn lint`
