### PR TITLE
Disable animation native driver in AnimatedGratuisousApp of RNTester

### DIFF
--- a/RNTester/js/AnimatedGratuitousApp/AnExSet.js
+++ b/RNTester/js/AnimatedGratuitousApp/AnExSet.js
@@ -77,12 +77,10 @@ class AnExSet extends React.Component<Object, any> {
             inputRange: [0, 300], // and interpolate pixel distance
             outputRange: [1, 0], // to a fraction.
           }),
-          useNativeDriver: true,
         }).start();
       },
       onPanResponderMove: Animated.event(
         [null, {dy: this.state.dismissY}], // track pan gesture
-        {useNativeDriver: true},
       ),
       onPanResponderRelease: (e, gestureState) => {
         if (gestureState.dy > 100) {
@@ -90,7 +88,6 @@ class AnExSet extends React.Component<Object, any> {
         } else {
           Animated.spring(this.props.openVal, {
             toValue: 1, // animate back open if released early
-            useNativeDriver: true,
           }).start();
         }
       },


### PR DESCRIPTION
`Animated.event` not work with direct events and not bubbling events, which means it does not work with `PanResponder`, please see [Animation Caveats](https://facebook.github.io/react-native/docs/animations#caveats)

Changelog:
----------

[General] [Fixed] - Disable animation native driver in AnimatedGratuisousApp of RNTester.


Test Plan:
----------

As before, if click or pan the header view, the unexpected error appear, after `PR` fixed, things work fine.
<img width="375" alt="image" src="https://user-images.githubusercontent.com/5061845/51798834-d9031a80-2253-11e9-862a-1bd83eb093c4.png">

<img width="375" alt="image" src="https://user-images.githubusercontent.com/5061845/51798821-9d685080-2253-11e9-99bb-122857c9d43f.png">