### PR TITLE
Fix for Windows - Backslashes is the escape

### DIFF
--- a/local-cli/link/android/patches/makeSettingsPatch.js
+++ b/local-cli/link/android/patches/makeSettingsPatch.js
@@ -10,6 +10,8 @@
 const path = require('path');
 const normalizeProjectName = require('./normalizeProjectName');
 
+const isWin = process.platform === 'win32';
+
 module.exports = function makeSettingsPatch(
   name,
   androidConfig,
@@ -21,6 +23,16 @@ module.exports = function makeSettingsPatch(
   );
   const normalizedProjectName = normalizeProjectName(name);
 
+  /*
+   * Fix for Windows
+   * Backslashes is the escape character and will result in
+   * an invalid path in settings.gradle
+   * https://github.com/facebook/react-native/issues/23176
+   */
+  if (isWin) {
+    projectDir = projectDir.replace(/\\/g, '/');
+  }
+  
   return {
     pattern: '\n',
     patch:


### PR DESCRIPTION
   Fix for Windows Backslashes is the escape character and will result in an invalid path in settings.gradle
  [issue:23176]( https://github.com/facebook/react-native/issues/23176)
  i found this fix in past commit (0.57) and i submit again.

Changelog:
----------

[Android] [Fixed] - Fix for Windows Backslashes is the escape character and will result in an invalid path in settings.gradle

Test Plan:
----------

in windows run react-native link and start error,  Backslashes is the escape character and will result in an invalid path in settings.gradle