### PR TITLE
[fix] Fixing overscrolling issue on Virtualized List

### DIFF
--- a/Libraries/Lists/VirtualizedList.js
+++ b/Libraries/Lists/VirtualizedList.js
@@ -330,13 +330,20 @@ class VirtualizedList extends React.PureComponent<Props, State> {
       return;
     }
     const frame = this._getFrameMetricsApprox(index);
-    const offset =
+    const maxScroll =
+      this._scrollMetrics.contentLength - this._scrollMetrics.visibleLength;
+    let offset =
       Math.max(
         0,
         frame.offset -
           (viewPosition || 0) *
             (this._scrollMetrics.visibleLength - frame.length),
       ) - (viewOffset || 0);
+
+    /* Fix for overscrolling */
+    if (offset > maxScroll) {
+      offset = maxScroll;
+    }
     /* $FlowFixMe(>=0.53.0 site=react_native_fb,react_native_oss) This comment
      * suppresses an error when upgrading Flow's support for React. To see the
      * error delete this comment and run Flow. */


### PR DESCRIPTION
Changelog:
----------
- [iOS][fixed] Fixed overscroll behavior on iOS virtualized lists

Test Plan:
----------
- Create a section list (for iOS)
- Attempt to scroll to an item towards the bottom

**Expected:** List scrolls to the item to the correct position without overscrolling the list
**Actual:** List is over scrolling to put the item in the proper position. This causes future scrolling to jump.

**Before:**
![before](https://user-images.githubusercontent.com/2447456/51815230-b89b8600-227c-11e9-98e4-3abe735046b4.gif)

**After:**
![after](https://user-images.githubusercontent.com/2447456/51815232-bd603a00-227c-11e9-8805-a6a744023e22.gif)



