### PR TITLE
Update Pull Request and Issue templates.

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,3 +1,4 @@
-Please use one of the provided templates:
+👉 Please follow one of these issue templates:
 - https://github.com/facebook/react-native/issues/new/choose
 
+Note: to keep the backlog clean and actionable, issues may be immediately closed if they do not follow one of the above issue templates.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,16 +1,15 @@
-Thank you for sending the PR! We appreciate you spending the time to work on these changes.
-Help us understand your motivation by explaining why you decided to make this change:
+<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->
 
+## Summary
 
-Changelog:
-----------
+<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
 
-Help reviewers and the release process by writing your own changelog entry. See http://facebook.github.io/react-native/docs/contributing#changelog for an example.
+## Changelog
+
+<!-- Help reviewers and the release process by writing your own changelog entry. See http://facebook.github.io/react-native/docs/contributing#changelog for an example. -->
 
 [CATEGORY] [TYPE] - Message
 
+## Test Plan
 
-Test Plan:
-----------
-
-Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible.
+<!-- Write your test plan here (**REQUIRED**). Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->


### PR DESCRIPTION
As a maintainer, I noticed that the description for a PR is often missing, which makes it hard to understand why a change is made. Because some of the text isn't using HTML comments, the same text explaining how to fill out the changelog and test plan pops up and isn't removed by people. This PR fixes both of these issues.

I also made another small update to the main issue template to urge people to use one of the other templates, with an explanation that we will close poorly formatted issues.

Changelog:
----------

[General] [Changed] - Updated GitHub templates


Test Plan:
----------
yolo