### PR TITLE
[flow-strict] - create missing AndroidDrawable flow types in ViewPropTypes.js.

### DIFF
--- a/Libraries/Components/View/ViewPropTypes.js
+++ b/Libraries/Components/View/ViewPropTypes.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @flow
+ * @flow strict-local
  */
 
 'use strict';
@@ -205,9 +205,22 @@ type GestureResponderEventProps = $ReadOnly<{|
   onStartShouldSetResponderCapture?: ?(e: PressEvent) => boolean,
 |}>;
 
+type AndroidDrawableThemeAttr = $ReadOnly<{|
+  type: 'ThemeAttrAndroid',
+  attribute: string,
+|}>;
+
+type AndroidDrawableRipple = $ReadOnly<{|
+  type: 'RippleAndroid',
+  color?: ?number,
+  borderless?: ?boolean,
+|}>;
+
+type AndroidDrawable = AndroidDrawableThemeAttr | AndroidDrawableRipple;
+
 type AndroidViewProps = $ReadOnly<{|
-  nativeBackgroundAndroid?: ?Object,
-  nativeForegroundAndroid?: ?Object,
+  nativeBackgroundAndroid?: ?AndroidDrawable,
+  nativeForegroundAndroid?: ?AndroidDrawable,
 
   /**
    * Whether this `View` should render itself (and all of its children) into a


### PR DESCRIPTION
Related to #22100 

Enhance last ViewPropTypes flow types.

## Test Plan:
- [x] yarn run prettier
- [x] yarn run flow-check-ios
- [x] yarn run flow-check-android


## Changelog:
[GENERAL] [ENHANCEMENT] [ViewPropTypes.js] - Enhance Flow types definitions