### PR TITLE
keep desiredAccuracy if observer is active

### DIFF
--- a/Libraries/Geolocation/RCTLocationObserver.m
+++ b/Libraries/Geolocation/RCTLocationObserver.m
@@ -355,7 +355,10 @@ RCT_EXPORT_METHOD(getCurrentPosition:(RCTLocationOptions)options
 
   // Reset location accuracy if desiredAccuracy is changed.
   // Otherwise update accuracy will force triggering didUpdateLocations, watchPosition would keeping receiving location updates, even there's no location changes.
-  if (ABS(_locationManager.desiredAccuracy - RCT_DEFAULT_LOCATION_ACCURACY) > 0.000001) {
+  if (_observingLocation && ABS(_locationManager.desiredAccuracy - _observerOptions.accuracy) > 0.000001) {
+    _locationManager.desiredAccuracy = _observerOptions.accuracy;
+  }
+  if (!_observingLocation && ABS(_locationManager.desiredAccuracy - RCT_DEFAULT_LOCATION_ACCURACY) > 0.000001) {
     _locationManager.desiredAccuracy = RCT_DEFAULT_LOCATION_ACCURACY;
   }
 }


### PR DESCRIPTION
If watchPosition was called with high accuracy and getCurrentPosition is called the CLLocationManager desiredAccuracy is reset to default low value.

This patch resets the accuracy to the accuracy of the active observer if no getCurrentPosition task is queued, and to default only if there is also no observer active.

Changelog:
----------

[iOS] [Fixed] - Geolocation: Keep the desired location accuracy when an observer is active



Test Plan:
----------

Verify that geolocation getCurrentPosition and watchPosition is still working, and that the returned accuracy of the GPS signal matches the highAccuracy setting.
