### PR TITLE
Don't reset desiredAccuracy on every update/error

### DIFF
--- a/Libraries/Geolocation/RCTLocationObserver.m
+++ b/Libraries/Geolocation/RCTLocationObserver.m
@@ -353,11 +353,6 @@ RCT_EXPORT_METHOD(getCurrentPosition:(RCTLocationOptions)options
       [_locationManager stopUpdatingLocation];
   }
 
-  // Reset location accuracy if desiredAccuracy is changed.
-  // Otherwise update accuracy will force triggering didUpdateLocations, watchPosition would keeping receiving location updates, even there's no location changes.
-  if (ABS(_locationManager.desiredAccuracy - RCT_DEFAULT_LOCATION_ACCURACY) > 0.000001) {
-    _locationManager.desiredAccuracy = RCT_DEFAULT_LOCATION_ACCURACY;
-  }
 }
 
 - (void)locationManager:(CLLocationManager *)manager didFailWithError:(NSError *)error
@@ -389,11 +384,6 @@ RCT_EXPORT_METHOD(getCurrentPosition:(RCTLocationOptions)options
   }
   [_pendingRequests removeAllObjects];
 
-  // Reset location accuracy if desiredAccuracy is changed.
-  // Otherwise update accuracy will force triggering didUpdateLocations, watchPosition would keeping receiving location updates, even there's no location changes.
-  if (ABS(_locationManager.desiredAccuracy - RCT_DEFAULT_LOCATION_ACCURACY) > 0.000001) {
-    _locationManager.desiredAccuracy = RCT_DEFAULT_LOCATION_ACCURACY;
-  }
 }
 
 static void checkLocationConfig()


### PR DESCRIPTION
See https://github.com/facebook/react-native/issues/7680.

On iOS the RCTLocationObserver delegate is overriding `desiredAccuracy` every time CLLocationManager calls `didUpdateLocations` or `didFailWitError`.  `desiredAccuracy` is reset to
`RCT_DEFAULT_LOCATION_ACCURACY` (100 meters) This effectively makes it impossible for a react-native app to use any location accuracy other than the default.

This commit simply removes the code which resets the desired accuracy, as there seems to be no rationale for doing so. The reset code was added as part of [a large general
change](https://github.com/facebook/react-native/commit/705a8e0144775ff695f26a1f6b41d0baa6bed683) so the original intention is unclear from the history. If somebody can explain it to me, I'm happy to rework this PR accordingly.

Changelog:
----------
[iOS] [Fixed] - Location Services accuracy constantly reset to default of 100 meters.


Test Plan:
----------

We've been using this in production at FATMAP for nearly a year. It works. I'm unclear on how to actually test this in code, so would appreciate any tips.
