### PR TITLE
[iOS] Remove application:openURL:sourceApplication:annotation: of LinkingManager

### DIFF
--- a/Libraries/LinkingIOS/RCTLinkingManager.h
+++ b/Libraries/LinkingIOS/RCTLinkingManager.h
@@ -16,11 +16,6 @@
             options:(nonnull NSDictionary<UIApplicationOpenURLOptionsKey, id> *)options;
 
 + (BOOL)application:(nonnull UIApplication *)application
-              openURL:(nonnull NSURL *)URL
-    sourceApplication:(nullable NSString *)sourceApplication
-           annotation:(nonnull id)annotation;
-
-+ (BOOL)application:(nonnull UIApplication *)application
     continueUserActivity:(nonnull NSUserActivity *)userActivity
       restorationHandler:(nonnull void (^)(NSArray *__nullable))restorationHandler;
 

--- a/Libraries/LinkingIOS/RCTLinkingManager.m
+++ b/Libraries/LinkingIOS/RCTLinkingManager.m
@@ -57,15 +57,6 @@ RCT_EXPORT_MODULE()
 }
 
 + (BOOL)application:(UIApplication *)application
-            openURL:(NSURL *)URL
-  sourceApplication:(NSString *)sourceApplication
-         annotation:(id)annotation
-{
-  postNotificationWithURL(URL, self);
-  return YES;
-}
-
-+ (BOOL)application:(UIApplication *)application
 continueUserActivity:(NSUserActivity *)userActivity
   restorationHandler:(void (^)(NSArray * __nullable))restorationHandler
 {

--- a/RNTester/RNTester/AppDelegate.m
+++ b/RNTester/RNTester/AppDelegate.m
@@ -61,13 +61,6 @@
   return [RCTLinkingManager application:app openURL:url options:options];
 }
 
-- (BOOL)application:(UIApplication *)application openURL:(NSURL *)url
-  sourceApplication:(NSString *)sourceApplication annotation:(id)annotation
-{
-  return [RCTLinkingManager application:application openURL:url
-                      sourceApplication:sourceApplication annotation:annotation];
-}
-
 - (void)loadSourceForBridge:(RCTBridge *)bridge
                  onProgress:(RCTSourceLoadProgressBlock)onProgress
                  onComplete:(RCTSourceLoadBlock)loadCallback


### PR DESCRIPTION
## Summary

Related to #22609 . `application:openURL:sourceApplication:annotation: ` already deprecated in `iOS9`, `react-native` only supports iOS which target greater or equal to `iOS9`, so we can just remove it totally.

## Changelog

[iOS] [Removed] - Remove application:openURL:sourceApplication:annotation: of LinkingManager

## Test Plan

On iOS system which greater or equal to `iOS9`, `application:openURL:sourceApplication:annotation: ` should not be called by system or user, use `application:openURL:options:` instead.