### PR TITLE
[iOS] Fixes alert view block first responder

### DIFF
--- a/React/Modules/RCTAlertManager.m
+++ b/React/Modules/RCTAlertManager.m
@@ -177,7 +177,9 @@ RCT_EXPORT_METHOD(alertWithArgs:(NSDictionary *)args
   }
   [_alertControllers addObject:alertController];
 
-  [presentingController presentViewController:alertController animated:YES completion:nil];
+  dispatch_async(dispatch_get_main_queue(), ^{
+    [presentingController presentViewController:alertController animated:YES completion:nil];
+  });
 }
 
 @end


### PR DESCRIPTION
## Summary

Fixes #23076 , the reason is `blur()` is managed by `UIManager`, `UIManager` maintains all operations and execute them each `batchDidComplete`, which means every time `JS` finish callback native , but `Alert` module would call directly, this mess up the order of method call, for example like below, even `this.$input.blur()` is called before `Alert.alert()`, but in native side, `Alert.alert()` is called before `this.$input.blur()`.

```
        <TextInput style={{ borderWidth: 1 }} ref={$input => this.$input = $input} />
        <Button title="Show Alert" onPress={() => {
          // // `blur` works if using without `Alert`
          this.$input && this.$input.blur()
          // // `blur` is not working
          Alert.alert('show alert', 'desc', [
            { text: 'cancel', style: 'cancel' },
            { text: 'show', onPress: () => {
            }},
          ])
        }} />
```

## Changelog

[iOS] [Fixed] - Fixes alert view block first responder

## Test Plan

After fix, example like below, `blur` can works.
```
import * as React from 'react';
import { TextInput, View, Alert, Button } from 'react-native';

export default class App extends React.Component {
  render() {
    return (
      <View style={{ flex: 1, justifyContent: 'center' }}>
        <TextInput style={{ borderWidth: 1 }} ref={$input => this.$input = $input} />
        <Button title="Show Alert" onPress={() => {
          this.$input && this.$input.blur()
          Alert.alert('show alert', 'desc', [
            { text: 'cancel', style: 'cancel' },
            { text: 'show', onPress: () => { 
            }},
          ])
        }} />
      </View>
    );
  }
}
```