### PR TITLE
remove deprecated setBackgroundDrawable use

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/common/ViewHelper.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/common/ViewHelper.java
@@ -6,7 +6,6 @@
 package com.facebook.react.views.common;
 
 import android.graphics.drawable.Drawable;
-import android.os.Build;
 import android.view.View;
 
 /** Helper class for Views */
@@ -14,18 +13,13 @@ public class ViewHelper {
 
   /**
    * Set the background to a given Drawable, or remove the background. It calls {@link
-   * View#setBackground(Drawable)} or {@link View#setBackgroundDrawable(Drawable)} based on the sdk
-   * version.
+   * View#setBackground(Drawable)}.
    *
    * @param view {@link View} to apply the background.
    * @param drawable {@link Drawable} The Drawable to use as the background, or null to remove the
    *     background
    */
   public static void setBackground(View view, Drawable drawable) {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
-      view.setBackground(drawable);
-    } else {
-      view.setBackgroundDrawable(drawable);
-    }
+    view.setBackground(drawable);
   }
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
@@ -668,7 +668,7 @@ public class ReactViewGroup extends ViewGroup implements
 
   /**
    * Set the background for the view or remove the background. It calls {@link
-   * #setBackground(Drawable)} or {@link #setBackgroundDrawable(Drawable)} based on the sdk version.
+   * #setBackground(Drawable)}.
    *
    * @param drawable {@link Drawable} The Drawable to use as the background, or null to remove the
    *     background

--- a/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
@@ -674,11 +674,7 @@ public class ReactViewGroup extends ViewGroup implements
    *     background
    */
   private void updateBackgroundDrawable(Drawable drawable) {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
-      super.setBackground(drawable);
-    } else {
-      super.setBackgroundDrawable(drawable);
-    }
+    super.setBackground(drawable);
   }
 
   @Override


### PR DESCRIPTION
## Summary

View.setBackgroundDrawable is deprecated in API 16, which is RN's minSdkVersion, so it's safe to remove its usage.

## Changelog

Nothing special, just very small cleanup.

[Android][Changed] - remove use of deprecated View.setBackgroundDrawable

## Test Plan

CI is green and everything will work as usual.