### PR TITLE
Refine Keyboard API Event typings

### DIFF
--- a/Libraries/Components/Keyboard/Keyboard.js
+++ b/Libraries/Components/Keyboard/Keyboard.js
@@ -17,13 +17,20 @@ const KeyboardObserver = require('NativeModules').KeyboardObserver;
 const dismissKeyboard = require('dismissKeyboard');
 const KeyboardEventEmitter = new NativeEventEmitter(KeyboardObserver);
 
-type KeyboardEventName =
+export type KeyboardEventName =
   | 'keyboardWillShow'
   | 'keyboardDidShow'
   | 'keyboardWillHide'
   | 'keyboardDidHide'
   | 'keyboardWillChangeFrame'
   | 'keyboardDidChangeFrame';
+
+export type KeyboardEventEasing =
+  | 'easeIn'
+  | 'easeInEaseOut'
+  | 'easeOut'
+  | 'linear'
+  | 'keyboard';
 
 type ScreenRect = $ReadOnly<{|
   screenX: number,
@@ -33,11 +40,11 @@ type ScreenRect = $ReadOnly<{|
 |}>;
 
 export type KeyboardEvent = $ReadOnly<{|
-  duration?: number,
-  easing?: string,
+  duration: number,
+  easing: KeyboardEventEasing,
   endCoordinates: ScreenRect,
-  startCoordinates?: ScreenRect,
-  isEventFromThisApp?: boolean,
+  startCoordinates: ScreenRect,
+  isEventFromThisApp: boolean,
 |}>;
 
 type KeyboardEventListener = (e: KeyboardEvent) => void;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

- Improve type inference of the `event.easing` keyboard event property with the `KeyboardEventEasing` type.
- Exporting `KeyboardEventName` and `KeyboardEventEasing` for others to use.
- Removing unnecessary optional property flag (ie.`?`) for all properties in `KeyboardEvent`. (I personally haven't seen any of the properties not being returned for all keyboard events).

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See http://facebook.github.io/react-native/docs/contributing#changelog for an example. -->

[iOS] [Changed] - Refine Keyboard API Event typings 

## Test Plan

<!-- Write your test plan here (**REQUIRED**). Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

1. Load a dummy app, subscribe to all keyboard events, and console.log the event properties.
2. Perform some keyboard actions (bringing up, splitting, dismissing)
3. All events should contain the properties described in the `KeyboardEvent` type.
