### PR TITLE
Allow changing the project path in react-native-xcode.sh

### DIFF
--- a/scripts/react-native-xcode.sh
+++ b/scripts/react-native-xcode.sh
@@ -53,9 +53,11 @@ esac
 
 # Path to react-native folder inside node_modules
 REACT_NATIVE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# The project should be located next to where react-native is installed
+# in node_modules.
+PROJECT_ROOT=${PROJECT_ROOT:-"$REACT_NATIVE_DIR/../.."}
 
-# Xcode project file for React Native apps is located in ios/ subfolder
-cd "${REACT_NATIVE_DIR}"/../..
+cd $PROJECT_ROOT
 
 # Define NVM_DIR and source the nvm.sh setup script
 [ -z "$NVM_DIR" ] && export NVM_DIR="$HOME/.nvm"


### PR DESCRIPTION
## Summary

When using react-native inside a monorepo with yarn workspaces the react-native installation can get hoisted and the assumption that the project is located in the folder where node_modules is is no longer true.

### Solution

To handle this case I added an option to pass the path of the project root.

For example when using yarn workspace we can use something like this in the xcode scripts:

Assumes the following folder structure
/packages/myapp
/node_modules/react-native

```sh
export NODE_BINARY=node
export PROJECT_ROOT=$PWD/..
../../../node_modules/react-native/scripts/react-native-xcode.sh
```

### Alternatives

It could be possible to change the default to `$PWD/..` since pwd is where the xcode project is located but then it would break if the native project structure is not the one we assume. To avoid the breaking change I decided to just keep the existing behaviour and allow changing the path with `PROJECT_ROOT`.

## Changelog

[ios] [added] - Allow changing the project path in react-native-xcode.sh

## Test Plan

Tested in a project that setting PROJECT_ROOT env overrides the default project root config and that not setting the variable keeps the same behaviour as before.
