### PR TITLE
Fix broken jsiexecutor search path.

### DIFF
--- a/React.podspec
+++ b/React.podspec
@@ -120,7 +120,7 @@ Pod::Spec.new do |s|
     ss.source_files         = "ReactCommon/jsiexecutor/jsireact/*.{cpp,h}"
     ss.private_header_files = "ReactCommon/jsiexecutor/jsireact/*.h"
     ss.header_dir           = "jsireact"
-    ss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\"" }
+    ss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\", \"$(PODS_TARGET_SRCROOT)/ReactCommon/jsiexecutor\"" }
   end
 
   s.subspec "jsi" do |ss|


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
This resolves issue #23217.

## Change-log
iOS apps no longer run into missing header files for JSIExecutor.

## Test Plan

1. Create native iOS app.
1. Add react native using master branch as documented in the guides.
1. Run pod install on iOS portion of project.
1. Compile the native app in Xcode.