### PR TITLE
Remove jest and jest-junit from runtime dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -178,8 +178,6 @@
     "graceful-fs": "^4.1.3",
     "inquirer": "^3.0.6",
     "invariant": "^2.2.4",
-    "jest": "24.0.0-alpha.6",
-    "jest-junit": "5.2.0",
     "lodash": "^4.17.5",
     "metro-babel-register": "0.51.0",
     "metro-react-native-babel-transformer": "0.51.0",


### PR DESCRIPTION
## Summary

Commit 06c13b3e066636b414f5dc19c919dcb138763c71 pretend to update jest
to new version, but also adds jest and jest-junit to runtime dependencies
list (in addition to dev dependencies).

This commit fixes this, by removing jest and jest-junit from runtime
dependeincies.

As for motivation... story is short:
1. Updating RN 0.58.1 -> 0.58.3 I found that whole babel@6 infrastructure was returned to my `node_modules` (it is dangerous, because many tools like metro can found it and use it instead of babel@7).
2. It was because of this commit: 9d19ab0c0ca3cb50b4edddde52ae25dc6e80e055 that have 130 random files changed (and provides no meaning description).
But it points to: b864e7e63ef496facd12d65919b624e446203922 (which also provides no meaning description, why it was reverted?)
And finally points to: 696bd89013aa08ebffcbd2c4595ac393b6c26531, which was a "sync with master" commit. Ok. So it was from master.
3. Then I checked that jest still in runtime dependencies on master and fixed that. Also I hope this will be cherry picked into 0.58-stable.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See http://facebook.github.io/react-native/docs/contributing#changelog for an example. -->

[General] [Fixed] - Fix jest and jest-junit to be only development dependencies

## Test Plan

I'm already have this change in my fork of 0.58-stable branch, all worked as expected.
