### PR TITLE
remove unnecessary Android version checks

### DIFF
--- a/ReactAndroid/src/androidTest/java/com/facebook/react/testing/rule/ReactNativeTestRule.java
+++ b/ReactAndroid/src/androidTest/java/com/facebook/react/testing/rule/ReactNativeTestRule.java
@@ -114,11 +114,7 @@ public class ReactNativeTestRule implements TestRule {
                       @Override
                       public void onGlobalLayout() {
                         if (isLayoutUpdated.get()) {
-                          if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
-                            mView.getViewTreeObserver().removeOnGlobalLayoutListener(this);
-                          } else {
-                            mView.getViewTreeObserver().removeGlobalOnLayoutListener(this);
-                          }
+                          mView.getViewTreeObserver().removeOnGlobalLayoutListener(this);
                           mLatch.countDown();
                         }
                       }

--- a/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
@@ -322,11 +322,7 @@ public class ReactRootView extends SizeMonitoringFrameLayout
   }
 
   private void removeOnGlobalLayoutListener() {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
-      getViewTreeObserver().removeOnGlobalLayoutListener(getCustomGlobalLayoutListener());
-    } else {
-      getViewTreeObserver().removeGlobalOnLayoutListener(getCustomGlobalLayoutListener());
-    }
+    getViewTreeObserver().removeOnGlobalLayoutListener(getCustomGlobalLayoutListener());
   }
 
   @Override
@@ -669,7 +665,7 @@ public class ReactRootView extends SizeMonitoringFrameLayout
     }
 
     private boolean areMetricsEqual(DisplayMetrics displayMetrics, DisplayMetrics otherMetrics) {
-      if (Build.VERSION.SDK_INT >= 17) {
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
         return displayMetrics.equals(otherMetrics);
       } else {
         // DisplayMetrics didn't have an equals method before API 17.

--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevLoadingViewController.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevLoadingViewController.java
@@ -10,11 +10,9 @@ package com.facebook.react.devsupport;
 import static android.view.ViewGroup.LayoutParams.MATCH_PARENT;
 import static android.view.ViewGroup.LayoutParams.WRAP_CONTENT;
 
-import android.annotation.TargetApi;
 import android.app.Activity;
 import android.content.Context;
 import android.graphics.Rect;
-import android.os.Build;
 import android.view.Gravity;
 import android.view.LayoutInflater;
 import android.widget.PopupWindow;
@@ -31,7 +29,6 @@ import javax.annotation.Nullable;
 /**
  * Controller to display loading messages on top of the screen. All methods are thread safe.
  */
-@TargetApi(Build.VERSION_CODES.CUPCAKE)
 public class DevLoadingViewController {
   private static boolean sEnabled = true;
   private final ReactInstanceManagerDevHelper mReactInstanceManagerHelper;

--- a/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricEventEmitter.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricEventEmitter.java
@@ -12,8 +12,6 @@ import static com.facebook.react.uimanager.events.TouchesHelper.TOP_TOUCH_CANCEL
 import static com.facebook.react.uimanager.events.TouchesHelper.TOP_TOUCH_END_KEY;
 import static com.facebook.react.uimanager.events.TouchesHelper.TOUCHES_KEY;
 
-import android.annotation.TargetApi;
-import android.os.Build;
 import android.util.Pair;
 import com.facebook.common.logging.FLog;
 import com.facebook.react.bridge.ReadableMap;
@@ -27,7 +25,6 @@ import java.util.HashSet;
 import java.util.Set;
 import javax.annotation.Nullable;
 
-@TargetApi(Build.VERSION_CODES.ECLAIR)
 public class FabricEventEmitter implements RCTEventEmitter {
 
   private static final String TAG = FabricEventEmitter.class.getSimpleName();

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/accessibilityinfo/AccessibilityInfoModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/accessibilityinfo/AccessibilityInfoModule.java
@@ -30,7 +30,7 @@ public class AccessibilityInfoModule extends ReactContextBaseJavaModule
 
     public static final String NAME = "AccessibilityInfo";
 
-    @TargetApi(19)
+    @TargetApi(Build.VERSION_CODES.KITKAT)
     private class ReactTouchExplorationStateChangeListener
             implements AccessibilityManager.TouchExplorationStateChangeListener {
 
@@ -51,7 +51,7 @@ public class AccessibilityInfoModule extends ReactContextBaseJavaModule
         Context appContext = context.getApplicationContext();
         mAccessibilityManager = (AccessibilityManager) appContext.getSystemService(Context.ACCESSIBILITY_SERVICE);
         mEnabled = mAccessibilityManager.isTouchExplorationEnabled();
-        if (Build.VERSION.SDK_INT >= 19) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
             mTouchExplorationStateChangeListener = new ReactTouchExplorationStateChangeListener();
         }
     }
@@ -76,7 +76,7 @@ public class AccessibilityInfoModule extends ReactContextBaseJavaModule
 
     @Override
     public void onHostResume() {
-        if (Build.VERSION.SDK_INT >= 19) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
             mAccessibilityManager.addTouchExplorationStateChangeListener(
                     mTouchExplorationStateChangeListener);
         }
@@ -85,7 +85,7 @@ public class AccessibilityInfoModule extends ReactContextBaseJavaModule
 
     @Override
     public void onHostPause() {
-        if (Build.VERSION.SDK_INT >= 19) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
             mAccessibilityManager.removeTouchExplorationStateChangeListener(
                     mTouchExplorationStateChangeListener);
         }

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/camera/CameraRollManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/camera/CameraRollManager.java
@@ -68,36 +68,17 @@ public class CameraRollManager extends ReactContextBaseJavaModule {
   private static final String ASSET_TYPE_VIDEOS = "Videos";
   private static final String ASSET_TYPE_ALL = "All";
 
-
-  public static final boolean IS_JELLY_BEAN_OR_LATER =
-      Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN;
-
-  private static final String[] PROJECTION;
-  static {
-    if (IS_JELLY_BEAN_OR_LATER) {
-      PROJECTION = new String[] {
-          Images.Media._ID,
-          Images.Media.MIME_TYPE,
-          Images.Media.BUCKET_DISPLAY_NAME,
-          Images.Media.DATE_TAKEN,
-          MediaStore.MediaColumns.WIDTH,
-          MediaStore.MediaColumns.HEIGHT,
-          Images.Media.LONGITUDE,
-          Images.Media.LATITUDE,
-          MediaStore.MediaColumns.DATA
-      };
-    } else {
-      PROJECTION = new String[] {
-          Images.Media._ID,
-          Images.Media.MIME_TYPE,
-          Images.Media.BUCKET_DISPLAY_NAME,
-          Images.Media.DATE_TAKEN,
-          Images.Media.LONGITUDE,
-          Images.Media.LATITUDE,
-          MediaStore.MediaColumns.DATA
-      };
-    }
-  }
+  private static final String[] PROJECTION = {
+    Images.Media._ID,
+    Images.Media.MIME_TYPE,
+    Images.Media.BUCKET_DISPLAY_NAME,
+    Images.Media.DATE_TAKEN,
+    MediaStore.MediaColumns.WIDTH,
+    MediaStore.MediaColumns.HEIGHT,
+    Images.Media.LONGITUDE,
+    Images.Media.LATITUDE,
+    MediaStore.MediaColumns.DATA
+  };
 
   private static final String SELECTION_BUCKET = Images.Media.BUCKET_DISPLAY_NAME + " = ?";
   private static final String SELECTION_DATE_TAKEN = Images.Media.DATE_TAKEN + " < ?";
@@ -375,8 +356,8 @@ public class CameraRollManager extends ReactContextBaseJavaModule {
     int mimeTypeIndex = media.getColumnIndex(Images.Media.MIME_TYPE);
     int groupNameIndex = media.getColumnIndex(Images.Media.BUCKET_DISPLAY_NAME);
     int dateTakenIndex = media.getColumnIndex(Images.Media.DATE_TAKEN);
-    int widthIndex = IS_JELLY_BEAN_OR_LATER ? media.getColumnIndex(MediaStore.MediaColumns.WIDTH) : -1;
-    int heightIndex = IS_JELLY_BEAN_OR_LATER ? media.getColumnIndex(MediaStore.MediaColumns.HEIGHT) : -1;
+    int widthIndex = media.getColumnIndex(MediaStore.MediaColumns.WIDTH);
+    int heightIndex = media.getColumnIndex(MediaStore.MediaColumns.HEIGHT);
     int longitudeIndex = media.getColumnIndex(Images.Media.LONGITUDE);
     int latitudeIndex = media.getColumnIndex(Images.Media.LATITUDE);
     int dataIndex = media.getColumnIndex(MediaStore.MediaColumns.DATA);
@@ -424,18 +405,13 @@ public class CameraRollManager extends ReactContextBaseJavaModule {
     WritableMap image = new WritableNativeMap();
     Uri photoUri = Uri.parse("file://" + media.getString(dataIndex));
     image.putString("uri", photoUri.toString());
-    float width = -1;
-    float height = -1;
-    if (IS_JELLY_BEAN_OR_LATER) {
-      width = media.getInt(widthIndex);
-      height = media.getInt(heightIndex);
-    }
+    float width = media.getInt(widthIndex);
+    float height = media.getInt(heightIndex);
 
     String mimeType = URLConnection.guessContentTypeFromName(photoUri.toString());
 
     if (mimeType != null
-        && mimeType.startsWith("video")
-        && android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.GINGERBREAD_MR1) {
+        && mimeType.startsWith("video")) {
       try {
         AssetFileDescriptor photoDescriptor = resolver.openAssetFileDescriptor(photoUri, "r");
         MediaMetadataRetriever retriever = new MediaMetadataRetriever();

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/clipboard/ClipboardModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/clipboard/ClipboardModule.java
@@ -7,11 +7,9 @@
 
 package com.facebook.react.modules.clipboard;
 
-import android.annotation.SuppressLint;
 import android.content.ClipboardManager;
 import android.content.ClipData;
 import android.content.Context;
-import android.os.Build;
 
 import com.facebook.react.bridge.ContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
@@ -57,16 +55,10 @@ public class ClipboardModule extends ContextBaseJavaModule {
     }
   }
 
-  @SuppressLint("DeprecatedMethod")
   @ReactMethod
   public void setString(String text) {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
-      ClipData clipdata = ClipData.newPlainText(null, text);
-      ClipboardManager clipboard = getClipboardService();
-      clipboard.setPrimaryClip(clipdata);
-    } else {
-      ClipboardManager clipboard = getClipboardService();
-      clipboard.setText(text);
-    }
+    ClipData clipdata = ClipData.newPlainText(null, text);
+    ClipboardManager clipboard = getClipboardService();
+    clipboard.setPrimaryClip(clipdata);
   }
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/location/LocationModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/location/LocationModule.java
@@ -12,6 +12,7 @@ import android.location.Location;
 import android.location.LocationListener;
 import android.location.LocationManager;
 import android.location.LocationProvider;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import com.facebook.common.logging.FLog;
@@ -216,7 +217,7 @@ public class LocationModule extends ReactContextBaseJavaModule {
     map.putMap("coords", coords);
     map.putDouble("timestamp", location.getTime());
 
-    if (android.os.Build.VERSION.SDK_INT >= 18) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
       map.putBoolean("mocked", location.isFromMockProvider());
     }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/network/OkHttpClientProvider.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/network/OkHttpClientProvider.java
@@ -96,7 +96,7 @@ public class OkHttpClientProvider {
     enables it.
    */
   public static OkHttpClient.Builder enableTls12OnPreLollipop(OkHttpClient.Builder client) {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN && Build.VERSION.SDK_INT <= Build.VERSION_CODES.KITKAT) {
+    if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.KITKAT) {
       try {
         client.sslSocketFactory(new TLSSocketFactory());
 

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
@@ -198,7 +198,7 @@ public abstract class BaseViewManager<T extends View, C extends LayoutShadowNode
 
   @ReactProp(name = PROP_ACCESSIBILITY_LIVE_REGION)
   public void setAccessibilityLiveRegion(T view, String liveRegion) {
-    if (Build.VERSION.SDK_INT >= 19) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
       if (liveRegion == null || liveRegion.equals("none")) {
         view.setAccessibilityLiveRegion(View.ACCESSIBILITY_LIVE_REGION_NONE);
       } else if (liveRegion.equals("polite")) {

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/DisplayMetricsHolder.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/DisplayMetricsHolder.java
@@ -68,7 +68,7 @@ public class DisplayMetricsHolder {
     // The real metrics include system decor elements (e.g. soft menu bar).
     //
     // See: http://developer.android.com/reference/android/view/Display.html#getRealMetrics(android.util.DisplayMetrics)
-    if (Build.VERSION.SDK_INT >= 17) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
       display.getRealMetrics(screenDisplayMetrics);
     } else {
       // For 14 <= API level <= 16, we need to invoke getRawHeight and getRawWidth to get the real dimensions.

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeViewHierarchyManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeViewHierarchyManager.java
@@ -7,9 +7,7 @@
 
 package com.facebook.react.uimanager;
 
-import android.annotation.TargetApi;
 import android.content.res.Resources;
-import android.os.Build;
 import com.facebook.common.logging.FLog;
 import android.util.SparseArray;
 import android.util.SparseBooleanArray;
@@ -213,14 +211,12 @@ public class NativeViewHierarchyManager {
     }
   }
 
-  @TargetApi(Build.VERSION_CODES.DONUT)
   private void updateInstanceHandle(View viewToUpdate, long instanceHandle) {
     UiThreadUtil.assertOnUiThread();
     viewToUpdate.setTag(R.id.view_tag_instance_handle, instanceHandle);
   }
 
   @Nullable
-  @TargetApi(Build.VERSION_CODES.DONUT)
   public long getInstanceHandle(int reactTag) {
     View view = mTagsToViews.get(reactTag);
     if (view == null) {

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputLocalData.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputLocalData.java
@@ -28,14 +28,8 @@ public final class ReactTextInputLocalData {
     mTextSize = editText.getTextSize();
     mInputType = editText.getInputType();
     mPlaceholder = editText.getHint();
-
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
-      mMinLines = editText.getMinLines();
-      mMaxLines = editText.getMaxLines();
-    } else {
-      mMinLines = 1;
-      mMaxLines = 1;
-    }
+    mMinLines = editText.getMinLines();
+    mMaxLines = editText.getMaxLines();
 
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
       mBreakStrategy = editText.getBreakStrategy();

--- a/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactDrawableHelper.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactDrawableHelper.java
@@ -42,8 +42,7 @@ public class ReactDrawableHelper {
             " couldn't be found in the resource list");
       }
       if (context.getTheme().resolveAttribute(attrID, sResolveOutValue, true)) {
-        final int version = Build.VERSION.SDK_INT;
-        if (version >= 21) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
           return context.getResources()
               .getDrawable(sResolveOutValue.resourceId, context.getTheme());
         } else {
@@ -54,7 +53,7 @@ public class ReactDrawableHelper {
             " couldn't be resolved into a drawable");
       }
     } else if ("RippleAndroid".equals(type)) {
-      if (Build.VERSION.SDK_INT < 21) {
+      if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
         throw new JSApplicationIllegalArgumentException("Ripple drawable is not available on " +
             "android API <21");
       }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
@@ -254,8 +254,7 @@ public class ReactViewGroup extends ViewGroup implements
     ReactViewBackgroundDrawable backgroundDrawable = getOrCreateReactViewBackground();
     backgroundDrawable.setRadius(borderRadius);
 
-    if (Build.VERSION_CODES.HONEYCOMB < Build.VERSION.SDK_INT
-      && Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN_MR2) {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN_MR2) {
       final int UPDATED_LAYER_TYPE =
         backgroundDrawable.hasRoundedBorders()
           ? View.LAYER_TYPE_SOFTWARE
@@ -271,8 +270,7 @@ public class ReactViewGroup extends ViewGroup implements
     ReactViewBackgroundDrawable backgroundDrawable = getOrCreateReactViewBackground();
     backgroundDrawable.setRadius(borderRadius, position);
 
-    if (Build.VERSION_CODES.HONEYCOMB < Build.VERSION.SDK_INT
-        && Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN_MR2) {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN_MR2) {
       final int UPDATED_LAYER_TYPE =
           backgroundDrawable.hasRoundedBorders()
               ? View.LAYER_TYPE_SOFTWARE

--- a/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.java
@@ -242,7 +242,7 @@ public class ReactViewManager extends ViewGroupManager<ReactViewGroup> {
           throw new JSApplicationIllegalArgumentException(
               "Illegal number of arguments for 'updateHotspot' command");
         }
-        if (Build.VERSION.SDK_INT >= 21) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
           float x = PixelUtil.toPixelFromDIP(args.getDouble(0));
           float y = PixelUtil.toPixelFromDIP(args.getDouble(1));
           root.drawableHotspotChanged(x, y);

--- a/ReactAndroid/src/main/java/com/facebook/systrace/Systrace.java
+++ b/ReactAndroid/src/main/java/com/facebook/systrace/Systrace.java
@@ -55,13 +55,13 @@ public class Systrace {
   }
 
   public static void beginSection(long tag, final String sectionName) {
-    if (Build.VERSION.SDK_INT >= 18) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
       Trace.beginSection(sectionName);
     }
   }
 
   public static void endSection(long tag) {
-    if (Build.VERSION.SDK_INT >= 18) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
       Trace.endSection();
     }
   }

--- a/ReactAndroid/src/test/java/com/facebook/react/views/text/ReactTextTest.java
+++ b/ReactAndroid/src/test/java/com/facebook/react/views/text/ReactTextTest.java
@@ -12,11 +12,9 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 
-import android.annotation.TargetApi;
 import android.graphics.Color;
 import android.graphics.Typeface;
 import android.graphics.drawable.Drawable;
-import android.os.Build;
 import android.text.Spanned;
 import android.text.TextUtils;
 import android.text.style.AbsoluteSizeSpan;
@@ -406,9 +404,6 @@ public class ReactTextTest {
     assertThat(textView.getText().toString()).isEqualTo(testTextTransformed);
   }
 
-  // JELLY_BEAN is needed for TextView#getMaxLines(), which is OK, because in the actual code we
-  // only use TextView#setMaxLines() which exists since API Level 1.
-  @TargetApi(Build.VERSION_CODES.JELLY_BEAN)
   @Test
   public void testMaxLinesApplied() {
     UIManagerModule uiManager = getUIManagerModule();


### PR DESCRIPTION
## Summary

React Native's minSdkVersion is 16, or we support Android versions 16 (Jelly Bean) and above. But in the code we have many checks if Android is Jelly Bean or newer, which are unnecessary. This PR removes unnecessary Android version checks, also uses Android version names instead of numbers.

## Changelog

[Android] [Changes] - remove unnecessary Android version checks

## Test Plan

CI is green and works as usual.