### PR TITLE
fix checkbox casting crash in old android versions

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/checkbox/ReactCheckBoxManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/checkbox/ReactCheckBoxManager.java
@@ -6,6 +6,8 @@
  */
 package com.facebook.react.views.checkbox;
 
+import android.content.Context;
+import android.support.v7.widget.TintContextWrapper;
 import android.widget.CompoundButton;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.uimanager.SimpleViewManager;
@@ -13,7 +15,6 @@ import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.UIManagerModule;
 import com.facebook.react.uimanager.ViewProps;
 import com.facebook.react.uimanager.annotations.ReactProp;
-import com.facebook.react.uimanager.events.EventDispatcher;
 
 /** View manager for {@link ReactCheckBox} components. */
 public class ReactCheckBoxManager extends SimpleViewManager<ReactCheckBox> {
@@ -24,10 +25,21 @@ public class ReactCheckBoxManager extends SimpleViewManager<ReactCheckBox> {
       new CompoundButton.OnCheckedChangeListener() {
         @Override
         public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
-          ReactContext reactContext = (ReactContext) buttonView.getContext();
+          ReactContext reactContext = getReactContext(buttonView);
           reactContext
               .getNativeModule(UIManagerModule.class).getEventDispatcher()
               .dispatchEvent(new ReactCheckBoxEvent(buttonView.getId(), isChecked));
+        }
+
+        private ReactContext getReactContext(CompoundButton buttonView) {
+          ReactContext reactContext;
+          Context ctx = buttonView.getContext();
+          if (ctx instanceof TintContextWrapper) {
+            reactContext = (ReactContext) ((TintContextWrapper) ctx).getBaseContext();
+          } else {
+            reactContext = (ReactContext) buttonView.getContext();
+          }
+          return reactContext;
         }
       };
 


### PR DESCRIPTION
## Summary

fixes casting on older android versions reported in #22885
## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See http://facebook.github.io/react-native/docs/contributing#changelog for an example. -->

[Android] [Fixed] - fix casting crash in android checkbox


## Test Plan

run the RNTester app on android 4.4 and tick a checkbox
