### PR TITLE
Fix for Image displayName, currently displaying as <Component> in tests

### DIFF
--- a/Libraries/Image/Image.android.js
+++ b/Libraries/Image/Image.android.js
@@ -259,6 +259,7 @@ let Image = (
 };
 
 Image = React.forwardRef(Image);
+Image.displayName = 'Image';
 
 /**
  * Retrieve the width and height (in pixels) of an image prior to displaying it

--- a/Libraries/Image/Image.ios.js
+++ b/Libraries/Image/Image.ios.js
@@ -124,6 +124,7 @@ let Image = (
 };
 
 Image = React.forwardRef(Image);
+Image.displayName = 'Image';
 
 /**
  * Retrieve the width and height (in pixels) of an image prior to displaying it.


### PR DESCRIPTION
## Summary
As per https://github.com/facebook/react-native/issues/21937, Image `displayName` is not set. This means it comes through as `<Component>` in tests.

## Changelog

[General][fixed] - fix `displayName` for `Image`

## Test Plan

As there were only a couple of files changed, I amended the files directly in the `node_modules` to test and it worked as expected.
`component.debug()` in Jest now shows `<Image...` rather than `<Component...`