### PR TITLE
[iOS] Add headers and custom album to CameraRoll

### DIFF
--- a/Libraries/CameraRoll/CameraRoll.js
+++ b/Libraries/CameraRoll/CameraRoll.js
@@ -10,7 +10,7 @@
 'use strict';
 
 const PropTypes = require('prop-types');
-const {checkPropTypes} = PropTypes;
+const { checkPropTypes } = PropTypes;
 const RCTCameraRollManager = require('NativeModules').CameraRollManager;
 
 const deprecatedCreateStrictShapeTypeChecker = require('deprecatedCreateStrictShapeTypeChecker');
@@ -179,19 +179,32 @@ class CameraRoll {
    * See https://facebook.github.io/react-native/docs/cameraroll.html#savetocameraroll
    */
   static saveToCameraRoll(
-    tag: string,
+    tag: (string | object),
     type?: 'photo' | 'video',
+    album?: string,
   ): Promise<string> {
     invariant(
-      typeof tag === 'string',
-      'CameraRoll.saveToCameraRoll must be a valid string.',
+      typeof tag === 'string' || typeof tag === 'object',
+      'CameraRoll.saveToCameraRoll must be a valid string or object.',
     );
 
     invariant(
       type === 'photo' || type === 'video' || type === undefined,
       `The second argument to saveToCameraRoll must be 'photo' or 'video'. You passed ${type ||
-        'unknown'}`,
+      'unknown'}`,
     );
+
+    invariant(
+      typeof album === 'string' || album === undefined,
+      `The thirth argument to saveToCameraRoll must be valid string. You passed ${album ||
+      'unknown'}`,
+    );
+
+    if (typeof tag === 'string') {
+      tag = {
+        'uri': tag
+      }
+    }
 
     let mediaType = 'photo';
     if (type) {
@@ -200,7 +213,11 @@ class CameraRoll {
       mediaType = 'video';
     }
 
-    return RCTCameraRollManager.saveToCameraRoll(tag, mediaType);
+    if (!album) {
+      album = '';
+    }
+
+    return RCTCameraRollManager.saveToCameraRoll(tag, mediaType, album);
   }
 
   /**
@@ -212,8 +229,8 @@ class CameraRoll {
   static getPhotos(params: GetPhotosParams): Promise<PhotoIdentifiersPage> {
     if (__DEV__) {
       checkPropTypes(
-        {params: getPhotosParamChecker},
-        {params},
+        { params: getPhotosParamChecker },
+        { params },
         'params',
         'CameraRoll.getPhotos',
       );
@@ -227,15 +244,15 @@ class CameraRoll {
         const callback = arguments[1];
         successCallback = response => {
           checkPropTypes(
-            {response: getPhotosReturnChecker},
-            {response},
+            { response: getPhotosReturnChecker },
+            { response },
             'response',
             'CameraRoll.getPhotos callback',
           );
           callback(response);
         };
       }
-      const errorCallback = arguments[2] || (() => {});
+      const errorCallback = arguments[2] || (() => { });
       RCTCameraRollManager.getPhotos(params).then(
         successCallback,
         errorCallback,

--- a/Libraries/CameraRoll/CameraRoll.js
+++ b/Libraries/CameraRoll/CameraRoll.js
@@ -213,10 +213,6 @@ class CameraRoll {
       mediaType = 'video';
     }
 
-    if (!album) {
-      album = '';
-    }
-
     return RCTCameraRollManager.saveToCameraRoll(tag, mediaType, album);
   }
 

--- a/Libraries/CameraRoll/CameraRoll.js
+++ b/Libraries/CameraRoll/CameraRoll.js
@@ -10,7 +10,7 @@
 'use strict';
 
 const PropTypes = require('prop-types');
-const { checkPropTypes } = PropTypes;
+const {checkPropTypes} = PropTypes;
 const RCTCameraRollManager = require('NativeModules').CameraRollManager;
 
 const deprecatedCreateStrictShapeTypeChecker = require('deprecatedCreateStrictShapeTypeChecker');
@@ -179,7 +179,7 @@ class CameraRoll {
    * See https://facebook.github.io/react-native/docs/cameraroll.html#savetocameraroll
    */
   static saveToCameraRoll(
-    tag: (string | object),
+    tag: string | object,
     type?: 'photo' | 'video',
     album?: string,
   ): Promise<string> {
@@ -190,21 +190,19 @@ class CameraRoll {
 
     invariant(
       type === 'photo' || type === 'video' || type === undefined,
-      `The second argument to saveToCameraRoll must be 'photo' or 'video'. You passed ${type ||
-      'unknown'}`,
+      `The second argument to saveToCameraRoll must be 'photo' or 'video'. You passed ${type || 'unknown'}`,
     );
 
     invariant(
       typeof album === 'string' || album === undefined,
-      `The thirth argument to saveToCameraRoll must be valid string. You passed ${album ||
-      'unknown'}`,
+      `The thirth argument to saveToCameraRoll must be valid string. You passed ${album || 'unknown'}`,
     );
 
     if (typeof tag === 'string') {
       tag = {
-        'uri': tag
+        uri: tag
       }
-    }
+    };
 
     let mediaType = 'photo';
     if (type) {
@@ -225,8 +223,8 @@ class CameraRoll {
   static getPhotos(params: GetPhotosParams): Promise<PhotoIdentifiersPage> {
     if (__DEV__) {
       checkPropTypes(
-        { params: getPhotosParamChecker },
-        { params },
+        {params: getPhotosParamChecker},
+        {params},
         'params',
         'CameraRoll.getPhotos',
       );
@@ -240,8 +238,8 @@ class CameraRoll {
         const callback = arguments[1];
         successCallback = response => {
           checkPropTypes(
-            { response: getPhotosReturnChecker },
-            { response },
+            {response: getPhotosReturnChecker},
+            {response},
             'response',
             'CameraRoll.getPhotos callback',
           );


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

The CameraRoll has no options to download with header if needed. By using the object we can use this. 

We can search by an album but we can not save to a custom album. The photo/video will be saved to the CameraRoll but 

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See http://facebook.github.io/react-native/docs/contributing#changelog for an example. -->

[iOS] [Added] - Object option to use custom headers for saving to cameraRoll
[iOS] [Added] - New album parameter to save to custom album and if it not exists created album

## Test Plan

No tests changed

## Usage example

```
CameraRoll.saveToCameraRoll({'uri': 'https://facebook.github.io/react-native/img/header_logo.png'});
CameraRoll.saveToCameraRoll({'uri': 'https://facebook.github.io/react-native/img/header_logo.png'}, 'photo', 'album_name');
```