### PR TITLE
Parse simulator list

### DIFF
--- a/local-cli/runIOS/findMatchingSimulator.js
+++ b/local-cli/runIOS/findMatchingSimulator.js
@@ -41,7 +41,7 @@ function findMatchingSimulator(simulators, simulatorString) {
   var match;
   for (let version in devices) {
     // Making sure the version of the simulator is an iOS or tvOS (Removes Apple Watch, etc)
-    if (!version.startsWith('iOS') && !version.startsWith('tvOS')) {
+    if (!version.includes('iOS') && !version.includes('tvOS')) {
       continue;
     }
     if (simulatorVersion && !version.endsWith(simulatorVersion)) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
When parsing simulator names in order to run on iOS simulator, the name now contains the prefix "com.apple.CoreSimulator.SimRuntime." Therefore the check to filter out simulators that are not iOS or tvOS needs not to check for startsWith, but rather to check for includes.
Without the fix, I am not able to start and run the iOS simulator through the react-native cli

This started happening for me after I installed the latest XCode (beta). I am currently using XCode "Version 10.2 beta (10P82s)", but I have tried using xcode-select to point towards the latest stable XCode version as well, but the problem still occurs. My version of xcrun is "xcrun version 43.1."

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See http://facebook.github.io/react-native/docs/contributing#changelog for an example. -->

[iOS] [Changed]- Enabling start of iOS/tvOS simulators when simulator versions are reported with apple-prefixes.

## Test Plan

<!-- Write your test plan here (**REQUIRED**). Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Run the command react-native run-ios. Without the fix I get the error
Could not find iPhone X simulator
With the fix, it starts fine.
