### PR TITLE
Enable Java8

### DIFF
--- a/.buckconfig
+++ b/.buckconfig
@@ -11,3 +11,7 @@
 
 [alias]
   rntester = //RNTester/android/app:app
+
+[java]
+source_level = 8
+target_level = 8

--- a/.buckconfig
+++ b/.buckconfig
@@ -11,7 +11,3 @@
 
 [alias]
   rntester = //RNTester/android/app:app
-
-[java]
-source_level = 8
-target_level = 8

--- a/RNTester/android/app/build.gradle
+++ b/RNTester/android/app/build.gradle
@@ -93,6 +93,11 @@ def enableProguardInReleaseBuilds = true
 android {
     compileSdkVersion 28
 
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
     defaultConfig {
         applicationId "com.facebook.react.uiapp"
         minSdkVersion 16

--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -266,6 +266,11 @@ task packageReactNdkLibsForBuck(dependsOn: packageReactNdkLibs, type: Copy) {
 android {
     compileSdkVersion 28
 
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 27

--- a/template/android/app/build.gradle
+++ b/template/android/app/build.gradle
@@ -96,6 +96,11 @@ def enableProguardInReleaseBuilds = false
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
 
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
     defaultConfig {
         applicationId "com.helloworld"
         minSdkVersion rootProject.ext.minSdkVersion


### PR DESCRIPTION
## Summary

Running *lint* on RN found that there are some Java 8 features used without specifying Java 8 compatibility in projects. This PR adds Java 8 compatibility and fixes errors caused by Java 8 feature use. I suspend that it may be cause of many failures on older Androids, but also found that many modules/packages switched to and require Java 8.

```java
../../src/main/java/com/facebook/react/devsupport/BundleDownloader.java:167: Try-with-resources requires API level 19 (current min is 16)
../../src/main/java/com/facebook/react/devsupport/DevServerHelper.java:658: Try-with-resources requires API level 19 (current min is 16)
```

For more information https://developer.android.com/studio/write/java8-support

## Changelog

[Android] [Changed] - Enable Java 8

## Test Plan
CI is green, and everything should work just fine. And 2 errors in summary are gone.