### PR TITLE
[GitHub] Update issue templates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,5 +7,5 @@ React/Views/* @shergin
 React/Modules/* @shergin
 React/CxxBridge/* @mhorowitz
 ReactAndroid/src/main/java/com/facebook/react/animated/* @janicduplessis
-**/*.md @hramos
-package.json @hramos
+**/*.md @hramos @cpojer
+package.json @hramos @cpojer

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -5,27 +5,31 @@ labels: "Type: Bug Report"
 ---
 
 ## 🐛 Bug Report
-
-A clear and concise description of what the bug is.
-Include screenshots if needed.
+<!-- 
+    A clear and concise description of what the bug is.
+    Include screenshots if needed.
+-->
 
 ## To Reproduce
-
-Steps to reproduce the behavior.
+<!-- 
+    Steps to reproduce the behavior.
+-->
 
 ## Expected Behavior
+<!-- 
+    A clear and concise description of what you expected to happen.
+-->
 
-A clear and concise description of what you expected to happen.
+## Code Example
+<!-- 
+    Please provide a Snack (https://snack.expo.io/), a link to a repository on GitHub, or
+    provide a minimal code example that reproduces the problem.
+    Here are some tips for providing a minimal example: https://stackoverflow.com/help/mcve.
 
-## Link to Snack or repo (highly encouraged)
-
-Please provide either a Snack (https://snack.expo.io/) or a minimal repository on GitHub.
-Here are some tips for providing a minimal example: https://stackoverflow.com/help/mcve.
-
-Issues without a reproduction link are likely to stall.
+    Issues without a reproduction link are likely to stall.
+-->
 
 ## Environment
-
-```bash
-Run `react-native info` in your terminal and copy the results here.
-```
+<!-- 
+    Run `react-native info` in your terminal and copy the results here.
+-->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,30 +6,30 @@ labels: "Type: Bug Report"
 
 ## 🐛 Bug Report
 <!-- 
-    A clear and concise description of what the bug is.
-    Include screenshots if needed.
+  A clear and concise description of what the bug is.
+  Include screenshots if needed.
 -->
 
 ## To Reproduce
 <!-- 
-    Steps to reproduce the behavior.
+  Steps to reproduce the behavior.
 -->
 
 ## Expected Behavior
 <!-- 
-    A clear and concise description of what you expected to happen.
+  A clear and concise description of what you expected to happen.
 -->
 
 ## Code Example
 <!-- 
-    Please provide a Snack (https://snack.expo.io/), a link to a repository on GitHub, or
-    provide a minimal code example that reproduces the problem.
-    Here are some tips for providing a minimal example: https://stackoverflow.com/help/mcve.
+  Please provide a Snack (https://snack.expo.io/), a link to a repository on GitHub, or
+  provide a minimal code example that reproduces the problem.
+  Here are some tips for providing a minimal example: https://stackoverflow.com/help/mcve.
 
-    Issues without a reproduction link are likely to stall.
+  Issues without a reproduction link are likely to stall.
 -->
 
 ## Environment
 <!-- 
-    Run `react-native info` in your terminal and copy the results here.
+  Run `react-native info` in your terminal and copy the results here.
 -->

--- a/.github/ISSUE_TEMPLATE/discussion.md
+++ b/.github/ISSUE_TEMPLATE/discussion.md
@@ -1,7 +1,18 @@
 ---
-name: I want to discuss or propose a change to React Native.
+name: 🚀 Discussion or Proposal
 about: You have an idea that could make React Native better, or you want to discuss some aspect of the framework.
+labels: "Type: Discussion"
 ---
 
 The React Native community has set up a separate repository to track discussions and proposals:
 - https://github.com/react-native-community/discussions-and-proposals
+
+If you want to participate in casual discussions about the use of React Native, consider participating in one of the following forums:
+- Discord Community: https://discord.gg/0ZcbPKXt5bZjGY5n
+- Spectrum Chat: https://spectrum.chat/react-native
+- Facebook Group: https://www.facebook.com/groups/react.native.community
+
+For a full list of community resources:
+- http://facebook.github.io/react-native/help
+
+### Please note that discussions and proposals opened as issues in the core React Native repository will be closed.

--- a/.github/ISSUE_TEMPLATE/discussion.md
+++ b/.github/ISSUE_TEMPLATE/discussion.md
@@ -1,11 +1,8 @@
 ---
-name: 🚀 Discussion or Proposal
+name: 🚀 Discussion
 about: You have an idea that could make React Native better, or you want to discuss some aspect of the framework.
 labels: "Type: Discussion"
 ---
-
-The React Native community has set up a separate repository to track discussions and proposals:
-- https://github.com/react-native-community/discussions-and-proposals
 
 If you want to participate in casual discussions about the use of React Native, consider participating in one of the following forums:
 - Discord Community: https://discord.gg/0ZcbPKXt5bZjGY5n
@@ -15,4 +12,7 @@ If you want to participate in casual discussions about the use of React Native, 
 For a full list of community resources:
 - http://facebook.github.io/react-native/help
 
-### Please note that discussions and proposals opened as issues in the core React Native repository will be closed.
+If you'd like to discuss topics related to the future of React Native, please check out the discussions and proposals repo:
+- https://github.com/react-native-community/discussions-and-proposals
+
+### Please note that discussions opened as issues in the core React Native repository will be closed.

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,10 +1,12 @@
 ---
-name: I found a problem with the documentation.
+name: 📃 Documentation Bug
 about: You want to report something that is wrong or missing from the documentation.
-labels: "🚫Docs"
+labels: "Type: Docs"
 ---
 
 The React Native website is hosted on a separate repository. You may let the
 team know about any issues with the documentation by opening an issue there:
 - https://github.com/facebook/react-native-website
 - https://github.com/facebook/react-native-website/issues
+
+### Please do not open a documentation issue in the core React Native repository.

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,17 +1,15 @@
 ---
-name: I need help using React Native.
+name: 💬 Questions and Help
 about: You need help writing your React Native app.
-labels: "Question"
+labels: "Type: Question"
 ---
 
-GitHub Issues in the `facebook/react-native` repository are used exclusively for tracking bugs
-in the React Native framework. Please do not submit support requests through GitHub.
+GitHub Issues in the `facebook/react-native` repository are used exclusively for tracking bugs in the React Native framework. Please do not submit support requests through GitHub.
 
-Many members of the community use Stack Overflow to ask questions:
-* Read through the existing questions tagged with **react-native**:
-  http://stackoverflow.com/questions/tagged/react-native
+For questions or help, please see:
+- The React Native help page: http://facebook.github.io/react-native/help
+- The React Native channel in Reactiflux: https://discord.gg/0ZcbPKXt5bZjGY5n
+- The react-native tag on Stack Overflow: http://stackoverflow.com/questions/tagged/react-native
 
-* Ask your own:
-  http://stackoverflow.com/questions/ask?tags=react-native
 
-If you need an answer right away, check out the Reactiflux Discord community at https://discord.gg/0ZcbPKXt5bZjGY5n. There are usually a number of React Native experts there who can help out or point you to somewhere you might want to look.
+### Please note that this issue tracker is not a help forum and requests for help will be closed.

--- a/.github/ISSUE_TEMPLATE/regression.md
+++ b/.github/ISSUE_TEMPLATE/regression.md
@@ -5,8 +5,9 @@ labels: "Type: Bug Report", "Impact: Regression"
 ---
 
 ## 💥 Regression Report
-
-A clear and concise description of what the regression is.
+<!-- 
+  A clear and concise description of what the regression is.
+-->
 
 ## Last working version
 
@@ -16,21 +17,26 @@ Stopped working in version:
 
 ## To Reproduce
 
-Steps to reproduce the behavior.
+<!--
+  Steps to reproduce the behavior.
+-->
 
 ## Expected Behavior
 
-A clear and concise description of what you expected to happen.
+<!-- 
+  A clear and concise description of what you expected to happen.
+-->
 
-## Link to Snack or repo (highly encouraged)
+## Code Example
+<!-- 
+  Please provide a Snack (https://snack.expo.io/), a link to a repository on GitHub, or
+  provide a minimal code example that reproduces the problem.
+  Here are some tips for providing a minimal example: https://stackoverflow.com/help/mcve.
 
-Please provide either a Snack (https://snack.expo.io/) or a minimal repository on GitHub.
-Here are some tips for providing a minimal example: https://stackoverflow.com/help/mcve.
-
-Issues without a reproduction link are likely to stall.
+  Issues without a reproduction link are likely to stall.
+-->
 
 ## Environment
-
-```bash
-Run `react-native info` in your terminal and copy the results here.
-```
+<!-- 
+  Run `react-native info` in your terminal and copy the results here.
+-->

--- a/.github/ISSUE_TEMPLATE/regression.md
+++ b/.github/ISSUE_TEMPLATE/regression.md
@@ -1,13 +1,18 @@
 ---
-name: 🐛 Bug Report
-about: You want to report a reproducible bug or regression in React Native.
-labels: "Type: Bug Report"
+name: 💥 Regression Report
+about: You want to report unexpected behavior that worked in previous releases.
+labels: "Type: Bug Report", "Impact: Regression"
 ---
 
-## 🐛 Bug Report
+## 💥 Regression Report
 
-A clear and concise description of what the bug is.
-Include screenshots if needed.
+A clear and concise description of what the regression is.
+
+## Last working version
+
+Worked up to version:
+
+Stopped working in version:
 
 ## To Reproduce
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,4 +12,4 @@
 
 ## Test Plan
 
-<!-- Write your test plan here (**REQUIRED**). Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
+<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->


### PR DESCRIPTION
## Summary

Go back to simpler issue template titles, with emoji. The goal is to make it easier, at a glance, to pick the right template.

We also add a new "regression" template that will automatically label the issue as a regression.

Other changes:
- Added Christoph as a CODEOWNER for package.json and markdown file changes. Usually, any PR that touches package.json has to be imported manually by a Facebook employee.

## Changelog

[General] [Changed] - Updated GitHub issue templates.

## Test Plan

Did not test.