### PR TITLE
remove redundant targetApi and version checks

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/Arguments.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/Arguments.java
@@ -25,7 +25,7 @@ public class Arguments {
       object instanceof Long ||
       object instanceof Byte ||
       object instanceof Short) {
-      return new Double(((Number) object).doubleValue());
+      return ((Number) object).doubleValue();
     } else if (object.getClass().isArray()) {
       return makeNativeArray(object);
     } else if (object instanceof List) {

--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerImpl.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerImpl.java
@@ -7,7 +7,6 @@
 
 package com.facebook.react.devsupport;
 
-import android.annotation.TargetApi;
 import android.app.Activity;
 import android.app.ActivityManager;
 import android.app.AlertDialog;
@@ -95,7 +94,6 @@ import okhttp3.RequestBody;
  * {@code <activity android:name="com.facebook.react.devsupport.DevSettingsActivity"/>}
  * {@code <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>}
  */
-@TargetApi(11)
 public class DevSupportManagerImpl implements
     DevSupportManager,
     PackagerCommandListener,

--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/FpsView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/FpsView.java
@@ -9,7 +9,6 @@ package com.facebook.react.devsupport;
 
 import java.util.Locale;
 
-import android.annotation.TargetApi;
 import android.widget.FrameLayout;
 import android.widget.TextView;
 
@@ -26,7 +25,6 @@ import com.facebook.react.modules.debug.FpsDebugFrameCallback;
  *
  * NB: Requires API 16 for use of FpsDebugFrameCallback.
  */
-@TargetApi(16)
 public class FpsView extends FrameLayout {
 
   private static final int UPDATE_INTERVAL_MS = 500;

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/core/ChoreographerCompat.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/core/ChoreographerCompat.java
@@ -8,10 +8,7 @@
  */
 package com.facebook.react.modules.core;
 
-import android.annotation.TargetApi;
-import android.os.Build;
 import android.os.Handler;
-import android.os.Looper;
 import android.view.Choreographer;
 import com.facebook.react.bridge.UiThreadUtil;
 
@@ -22,8 +19,6 @@ import com.facebook.react.bridge.UiThreadUtil;
 public class ChoreographerCompat {
 
   private static final long ONE_FRAME_MILLIS = 17;
-  private static final boolean IS_JELLYBEAN_OR_HIGHER =
-    Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN;
   private static ChoreographerCompat sInstance;
 
   private Handler mHandler;
@@ -38,55 +33,36 @@ public class ChoreographerCompat {
   }
 
   private ChoreographerCompat() {
-    if (IS_JELLYBEAN_OR_HIGHER) {
-      mChoreographer = getChoreographer();
-    } else {
-      mHandler = new Handler(Looper.getMainLooper());
-    }
+    mChoreographer = getChoreographer();
   }
 
   public void postFrameCallback(FrameCallback callbackWrapper) {
-    if (IS_JELLYBEAN_OR_HIGHER) {
-      choreographerPostFrameCallback(callbackWrapper.getFrameCallback());
-    } else {
-      mHandler.postDelayed(callbackWrapper.getRunnable(), 0);
-    }
+    choreographerPostFrameCallback(callbackWrapper.getFrameCallback());
   }
 
   public void postFrameCallbackDelayed(FrameCallback callbackWrapper, long delayMillis) {
-    if (IS_JELLYBEAN_OR_HIGHER) {
-      choreographerPostFrameCallbackDelayed(callbackWrapper.getFrameCallback(), delayMillis);
-    } else {
-      mHandler.postDelayed(callbackWrapper.getRunnable(), delayMillis + ONE_FRAME_MILLIS);
-    }
+    choreographerPostFrameCallbackDelayed(callbackWrapper.getFrameCallback(), delayMillis);
   }
 
   public void removeFrameCallback(FrameCallback callbackWrapper) {
-    if (IS_JELLYBEAN_OR_HIGHER) {
-      choreographerRemoveFrameCallback(callbackWrapper.getFrameCallback());
-    } else {
-      mHandler.removeCallbacks(callbackWrapper.getRunnable());
-    }
+    choreographerRemoveFrameCallback(callbackWrapper.getFrameCallback());
   }
 
-  @TargetApi(Build.VERSION_CODES.JELLY_BEAN)
   private Choreographer getChoreographer() {
     return Choreographer.getInstance();
   }
 
-  @TargetApi(Build.VERSION_CODES.JELLY_BEAN)
+
   private void choreographerPostFrameCallback(Choreographer.FrameCallback frameCallback) {
     mChoreographer.postFrameCallback(frameCallback);
   }
 
-  @TargetApi(Build.VERSION_CODES.JELLY_BEAN)
   private void choreographerPostFrameCallbackDelayed(
     Choreographer.FrameCallback frameCallback,
     long delayMillis) {
     mChoreographer.postFrameCallbackDelayed(frameCallback, delayMillis);
   }
 
-  @TargetApi(Build.VERSION_CODES.JELLY_BEAN)
   private void choreographerRemoveFrameCallback(Choreographer.FrameCallback frameCallback) {
     mChoreographer.removeFrameCallback(frameCallback);
   }
@@ -101,7 +77,6 @@ public class ChoreographerCompat {
     private Runnable mRunnable;
     private Choreographer.FrameCallback mFrameCallback;
 
-    @TargetApi(Build.VERSION_CODES.JELLY_BEAN)
     Choreographer.FrameCallback getFrameCallback() {
       if (mFrameCallback == null) {
         mFrameCallback = new Choreographer.FrameCallback() {

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/core/ChoreographerCompat.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/core/ChoreographerCompat.java
@@ -52,7 +52,6 @@ public class ChoreographerCompat {
     return Choreographer.getInstance();
   }
 
-
   private void choreographerPostFrameCallback(Choreographer.FrameCallback frameCallback) {
     mChoreographer.postFrameCallback(frameCallback);
   }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/modal/ModalHostHelper.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/modal/ModalHostHelper.java
@@ -5,7 +5,6 @@
 
 package com.facebook.react.views.modal;
 
-import android.annotation.TargetApi;
 import android.content.Context;
 import android.content.res.Resources;
 import android.content.res.TypedArray;
@@ -34,7 +33,6 @@ import com.facebook.infer.annotation.Assertions;
    * and landscape on tablets.
    * This should only be called on the native modules/shadow nodes thread.
    */
-  @TargetApi(16)
   public static Point getModalHostSize(Context context) {
     WindowManager wm = (WindowManager) context.getSystemService(Context.WINDOW_SERVICE);
     Display display = Assertions.assertNotNull(wm).getDefaultDisplay();

--- a/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.java
@@ -7,7 +7,6 @@
 
 package com.facebook.react.views.scroll;
 
-import android.annotation.TargetApi;
 import android.content.Context;
 import android.graphics.Canvas;
 import android.graphics.Color;
@@ -42,7 +41,6 @@ import javax.annotation.Nullable;
 /**
  * Similar to {@link ReactScrollView} but only supports horizontal scrolling.
  */
-@TargetApi(16)
 public class ReactHorizontalScrollView extends HorizontalScrollView implements
     ReactClippingViewGroup {
 

--- a/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
@@ -7,7 +7,6 @@
 
 package com.facebook.react.views.scroll;
 
-import android.annotation.TargetApi;
 import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.Rect;
@@ -42,7 +41,6 @@ import javax.annotation.Nullable;
  * <p>ReactScrollView only supports vertical scrolling. For horizontal scrolling,
  * use {@link ReactHorizontalScrollView}.
  */
-@TargetApi(11)
 public class ReactScrollView extends ScrollView implements ReactClippingViewGroup, ViewGroup.OnHierarchyChangeListener, View.OnLayoutChangeListener {
 
   private static @Nullable Field sScrollerField;

--- a/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewManager.java
@@ -7,7 +7,6 @@
 
 package com.facebook.react.views.scroll;
 
-import android.annotation.TargetApi;
 import android.graphics.Color;
 import android.support.v4.view.ViewCompat;
 import android.util.DisplayMetrics;
@@ -37,7 +36,6 @@ import javax.annotation.Nullable;
  * <p>Note that {@link ReactScrollView} and {@link ReactScrollView} are exposed to JS
  * as a single ScrollView component, configured via the {@code horizontal} boolean property.
  */
-@TargetApi(11)
 @ReactModule(name = ReactScrollViewManager.REACT_CLASS)
 public class ReactScrollViewManager
     extends ViewGroupManager<ReactScrollView>

--- a/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
@@ -7,6 +7,7 @@
 
 package com.facebook.react.views.view;
 
+import android.annotation.SuppressLint;
 import android.annotation.TargetApi;
 import android.content.Context;
 import android.graphics.Canvas;
@@ -149,6 +150,7 @@ public class ReactViewGroup extends ViewGroup implements
   }
 
   @Override
+  @SuppressLint("MissingSuperCall")
   public void requestLayout() {
     // No-op, terminate `requestLayout` here, UIManagerModule handles laying out children and
     // `layout` is called on all RN-managed views by `NativeViewHierarchyManager`

--- a/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
@@ -672,11 +672,7 @@ public class ReactViewGroup extends ViewGroup implements
    *     background
    */
   private void updateBackgroundDrawable(Drawable drawable) {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
-      super.setBackground(drawable);
-    } else {
-      super.setBackgroundDrawable(drawable);
-    }
+    super.setBackground(drawable);
   }
 
   @Override

--- a/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/webview/ReactWebViewManager.java
@@ -78,7 +78,6 @@ import org.json.JSONObject;
  * page - canGoBack - boolean, whether there is anything on a history stack to go back -
  * canGoForward - boolean, whether it is possible to request GO_FORWARD command
  */
-@TargetApi(Build.VERSION_CODES.HONEYCOMB)
 @ReactModule(name = ReactWebViewManager.REACT_CLASS)
 public class ReactWebViewManager extends SimpleViewManager<WebView> {
 
@@ -447,10 +446,8 @@ public class ReactWebViewManager extends SimpleViewManager<WebView> {
 
     settings.setAllowFileAccess(false);
     settings.setAllowContentAccess(false);
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
-      settings.setAllowFileAccessFromFileURLs(false);
-      setAllowUniversalAccessFromFileURLs(webView, false);
-    }
+    settings.setAllowFileAccessFromFileURLs(false);
+    setAllowUniversalAccessFromFileURLs(webView, false);
     setMixedContentMode(webView, "never");
 
     // Fixes broken full-screen modals/galleries due to body height being 0.


### PR DESCRIPTION
## Summary

RN supports API 16 and above, but we have redundant historical artifacts where we check and target APIs 16 and below. This PR removes redundant artifacts.

## Changelog

[Android] [Changed] - remove redundant targetApi and version checks

## Test Plan

CI is green, and RN works as before. But fewer lint warnings.