### PR TITLE
ReactPicker extends AppCompatSpinner

### DIFF
--- a/ReactAndroid/src/androidTest/java/com/facebook/react/tests/BUCK
+++ b/ReactAndroid/src/androidTest/java/com/facebook/react/tests/BUCK
@@ -7,6 +7,7 @@ rn_android_library(
         "PUBLIC",
     ],
     deps = [
+        react_native_dep("third-party/android/support/v7/appcompat-orig:appcompat"),
         react_native_dep("third-party/android/support/v4:lib-support-v4"),
         react_native_dep("third-party/java/jsr-305:jsr-305"),
         react_native_dep("third-party/java/junit:junit"),

--- a/ReactAndroid/src/androidTest/java/com/facebook/react/tests/BUCK
+++ b/ReactAndroid/src/androidTest/java/com/facebook/react/tests/BUCK
@@ -7,7 +7,6 @@ rn_android_library(
         "PUBLIC",
     ],
     deps = [
-        react_native_dep("third-party/android/support/v7/appcompat-orig:appcompat"),
         react_native_dep("third-party/android/support/v4:lib-support-v4"),
         react_native_dep("third-party/java/jsr-305:jsr-305"),
         react_native_dep("third-party/java/junit:junit"),

--- a/ReactAndroid/src/main/java/com/facebook/react/views/picker/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/picker/BUCK
@@ -6,9 +6,10 @@ rn_android_library(
     visibility = [
         "PUBLIC",
     ],
-    deps = [
-        react_native_dep("third-party/android/support/v4:lib-support-v4"),
+    provided_deps = [
         react_native_dep("third-party/android/support/v7/appcompat-orig:appcompat"),
+    ],
+    deps = [
         react_native_dep("third-party/java/infer-annotations:infer-annotations"),
         react_native_dep("third-party/java/jsr-305:jsr-305"),
         react_native_target("java/com/facebook/react/bridge:bridge"),

--- a/ReactAndroid/src/main/java/com/facebook/react/views/picker/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/picker/BUCK
@@ -7,6 +7,8 @@ rn_android_library(
         "PUBLIC",
     ],
     deps = [
+        react_native_dep("third-party/android/support/v4:lib-support-v4"),
+        react_native_dep("third-party/android/support/v7/appcompat-orig:appcompat"),
         react_native_dep("third-party/java/infer-annotations:infer-annotations"),
         react_native_dep("third-party/java/jsr-305:jsr-305"),
         react_native_target("java/com/facebook/react/bridge:bridge"),

--- a/ReactAndroid/src/main/java/com/facebook/react/views/picker/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/picker/BUCK
@@ -7,6 +7,7 @@ rn_android_library(
         "PUBLIC",
     ],
     provided_deps = [
+        react_native_dep("third-party/android/support/v4:lib-support-v4"),
         react_native_dep("third-party/android/support/v7/appcompat-orig:appcompat"),
     ],
     deps = [

--- a/ReactAndroid/src/main/java/com/facebook/react/views/picker/ReactPicker.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/picker/ReactPicker.java
@@ -8,6 +8,7 @@
 package com.facebook.react.views.picker;
 
 import android.content.Context;
+import android.support.v7.widget.AppCompatSpinner;
 import android.util.AttributeSet;
 import android.view.View;
 import android.widget.AdapterView;
@@ -17,9 +18,9 @@ import com.facebook.react.common.annotations.VisibleForTesting;
 
 import javax.annotation.Nullable;
 
-public class ReactPicker extends Spinner {
+public class ReactPicker extends AppCompatSpinner {
 
-  private int mMode = MODE_DIALOG;
+  private int mMode = Spinner.MODE_DIALOG;
   private @Nullable Integer mPrimaryColor;
   private @Nullable OnSelectListener mOnSelectListener;
   private @Nullable Integer mStagedSelection;

--- a/ReactAndroid/src/main/java/com/facebook/react/views/slider/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/slider/BUCK
@@ -8,7 +8,6 @@ rn_android_library(
     ],
     deps = [
         YOGA_TARGET,
-        react_native_dep("third-party/android/support/v7/appcompat-orig:appcompat"),
         react_native_dep("third-party/java/jsr-305:jsr-305"),
         react_native_target("java/com/facebook/react/bridge:bridge"),
         react_native_target("java/com/facebook/react/common:common"),

--- a/ReactAndroid/src/main/java/com/facebook/react/views/slider/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/slider/BUCK
@@ -3,14 +3,12 @@ load("//tools/build_defs/oss:rn_defs.bzl", "YOGA_TARGET", "react_native_dep", "r
 rn_android_library(
     name = "slider",
     srcs = glob(["*.java"]),
-    provided_deps = [
-        react_native_dep("third-party/android/support/v7/appcompat-orig:appcompat"),
-    ],
     visibility = [
         "PUBLIC",
     ],
     deps = [
         YOGA_TARGET,
+        react_native_dep("third-party/android/support/v7/appcompat-orig:appcompat"),
         react_native_dep("third-party/java/jsr-305:jsr-305"),
         react_native_target("java/com/facebook/react/bridge:bridge"),
         react_native_target("java/com/facebook/react/common:common"),

--- a/ReactAndroid/src/main/third-party/android/support/v7/appcompat-orig/BUCK
+++ b/ReactAndroid/src/main/third-party/android/support/v7/appcompat-orig/BUCK
@@ -19,8 +19,7 @@ rn_android_library(
         ":res-for-appcompat",
     ],
     exported_deps = [
-        ":classes-for-react-native",
-        react_native_dep("third-party/android/support-annotations:android-support-annotations"),
+        ":classes-for-react-native"
     ],
 )
 

--- a/ReactAndroid/src/main/third-party/android/support/v7/appcompat-orig/BUCK
+++ b/ReactAndroid/src/main/third-party/android/support/v7/appcompat-orig/BUCK
@@ -19,11 +19,7 @@ rn_android_library(
         ":res-for-appcompat",
     ],
     exported_deps = [
-<<<<<<< HEAD
         ":classes-for-react-native"
-=======
-        ":classes-for-react-native",
->>>>>>> master
     ],
 )
 


### PR DESCRIPTION
## Summary

Google recommends to extend AppCompat widget, and this PR changes ReactPicker to extend AppCompatSpinner.

## Changelog

[Android] [Changed] - ReactPicker extends AppCompatSpinner

## Test Plan

CI is green, and everything works as before.