### PR TITLE
ReactSlider extends AppCompatSeekBar

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/slider/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/slider/BUCK
@@ -3,14 +3,13 @@ load("//tools/build_defs/oss:rn_defs.bzl", "YOGA_TARGET", "react_native_dep", "r
 rn_android_library(
     name = "slider",
     srcs = glob(["*.java"]),
-    provided_deps = [
-        react_native_dep("third-party/android/support/v7/appcompat-orig:appcompat"),
-    ],
     visibility = [
         "PUBLIC",
     ],
     deps = [
         YOGA_TARGET,
+        react_native_dep("third-party/android/support/v7/appcompat-orig:appcompat"),
+        react_native_dep("third-party/android/support/v4:lib-support-v4"),
         react_native_dep("third-party/java/jsr-305:jsr-305"),
         react_native_target("java/com/facebook/react/bridge:bridge"),
         react_native_target("java/com/facebook/react/common:common"),

--- a/ReactAndroid/src/main/java/com/facebook/react/views/slider/ReactSlider.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/slider/ReactSlider.java
@@ -8,8 +8,8 @@ package com.facebook.react.views.slider;
 
 import android.content.Context;
 import android.os.Build;
+import android.support.v7.widget.AppCompatSeekBar;
 import android.util.AttributeSet;
-import android.widget.SeekBar;
 import javax.annotation.Nullable;
 
 /**
@@ -20,7 +20,7 @@ import javax.annotation.Nullable;
  *
  * <p>Note that the slider is _not_ a controlled component (setValue isn't called during dragging).
  */
-public class ReactSlider extends SeekBar {
+public class ReactSlider extends AppCompatSeekBar {
 
   /**
    * If step is 0 (unset) we default to this total number of steps. Don't use 100 which leads to

--- a/ReactAndroid/src/main/third-party/android/support/v7/appcompat-orig/BUCK
+++ b/ReactAndroid/src/main/third-party/android/support/v7/appcompat-orig/BUCK
@@ -20,7 +20,6 @@ rn_android_library(
     ],
     exported_deps = [
         ":classes-for-react-native",
-        react_native_dep("third-party/android/support-annotations:android-support-annotations"),
     ],
 )
 

--- a/ReactAndroid/src/test/java/com/facebook/react/views/BUCK
+++ b/ReactAndroid/src/test/java/com/facebook/react/views/BUCK
@@ -15,6 +15,7 @@ rn_robolectric_test(
         react_native_dep("libraries/fresco/fresco-react-native:imagepipeline"),
         react_native_dep("libraries/soloader/java/com/facebook/soloader:soloader"),
         react_native_dep("third-party/android/support/v4:lib-support-v4"),
+        react_native_dep("third-party/android/support/v7/appcompat-orig:appcompat"),
         react_native_dep("third-party/java/fest:fest"),
         react_native_dep("third-party/java/jsr-305:jsr-305"),
         react_native_dep("third-party/java/junit:junit"),

--- a/ReactAndroid/src/test/java/com/facebook/react/views/BUCK
+++ b/ReactAndroid/src/test/java/com/facebook/react/views/BUCK
@@ -15,7 +15,6 @@ rn_robolectric_test(
         react_native_dep("libraries/fresco/fresco-react-native:imagepipeline"),
         react_native_dep("libraries/soloader/java/com/facebook/soloader:soloader"),
         react_native_dep("third-party/android/support/v4:lib-support-v4"),
-        react_native_dep("third-party/android/support/v7/appcompat-orig:appcompat"),
         react_native_dep("third-party/java/fest:fest"),
         react_native_dep("third-party/java/jsr-305:jsr-305"),
         react_native_dep("third-party/java/junit:junit"),


### PR DESCRIPTION
## Summary

Google recommends to use AppCompat widgets, and this PR changes ReactSlider to extend AppCompatSeekBar.

## Changelog

[Android] [Changed] - ReactSlider extends AppCompatSeekBar

## Test Plan

CI is green and everything works as normal.