### PR TITLE
Backwards compatibility in findMatchingSimulator version input

### DIFF
--- a/local-cli/runIOS/findMatchingSimulator.js
+++ b/local-cli/runIOS/findMatchingSimulator.js
@@ -44,7 +44,7 @@ function findMatchingSimulator(simulators, simulatorString) {
     if (!version.includes('iOS') && !version.includes('tvOS')) {
       continue;
     }
-    let versionWithDashReplacedByDot = version.replace(/-/g,'\.')
+    let versionWithDashReplacedByDot = version.replace(/-/g,'\.');
     if (simulatorVersion && !versionWithDashReplacedByDot.endsWith(simulatorVersion)) {
       continue;
     }

--- a/local-cli/runIOS/findMatchingSimulator.js
+++ b/local-cli/runIOS/findMatchingSimulator.js
@@ -44,7 +44,8 @@ function findMatchingSimulator(simulators, simulatorString) {
     if (!version.includes('iOS') && !version.includes('tvOS')) {
       continue;
     }
-    if (simulatorVersion && !version.endsWith(simulatorVersion)) {
+    let versionWithDashReplacedByDot = version.replace(/-/g,'\.')
+    if (simulatorVersion && !versionWithDashReplacedByDot.endsWith(simulatorVersion)) {
       continue;
     }
     for (let i in devices[version]) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
handling dot-version input in findMatchingSimulator also when using newest xcrun to list devices. Format of xcrun output has changed

When parsing simulator names in order to run on iOS simulator, the version provided by xcrun now is separated by a dash instead of a dot. Therefore when input to run-ios --simulator is specified with an iOS version (in dot-format), the simulator will not be found. 

This started happening for me after I installed the latest XCode (beta). I am currently using XCode "Version 10.2 beta (10P82s)", but I have tried using xcode-select to point towards the latest stable XCode version as well, but the problem still occurs. My version of xcrun is "xcrun version 43.1."

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See http://facebook.github.io/react-native/docs/contributing#changelog for an example. -->

[iOS] [Changed] - Backwards compatibility in input format for run-ios --simulator "<device-type (device-version)>"

## Test Plan

<!-- Write your test plan here (**REQUIRED**). Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Run the command "react-native run-ios --simulator "iPhone X (12.2)". Without the fix I get the error
Could not find iPhone X simulator
With the fix, it starts fine (Assuming you have an iPhone X 12.2 simulator installed on your machine.)

