### PR TITLE
add back buildToolsVersion to build.gradle

### DIFF
--- a/template/android/build.gradle
+++ b/template/android/build.gradle
@@ -2,6 +2,7 @@
 
 buildscript {
     ext {
+        buildToolsVersion = "28.0.3"
         minSdkVersion = 16
         compileSdkVersion = 28
         targetSdkVersion = 27


### PR DESCRIPTION
## Summary

add back buildToolsVersion to build.gradle, because many third-party modules depend on it. The lack of this info causing issues in 0.58.

## Changelog

[Android] [Changed] - add back buildToolsVersion to template

## Test Plan

CI is green, and everything should work as normal.