### PR TITLE
fix: disable `inlineRequires` to fix jest tests

### DIFF
--- a/jest/preprocessor.js
+++ b/jest/preprocessor.js
@@ -53,7 +53,7 @@ module.exports = {
         enableBabelRuntime: false,
         experimentalImportSupport: false,
         hot: false,
-        inlineRequires: true,
+        inlineRequires: false,
         minify: false,
         platform: '',
         projectRoot: '',


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Fixes #22175. 

Currently, all new projects created with the cli are broken without this change. You get `TypeError: Cannot read property 'default' of undefined` for every file that uses class properties.

Steps to reproduce:

1. init a new project
2. add a class property to `App.js`
3. add a `transform` in the `jest` config in `package.json` which uses `jest/preprocessor.js`.
4. Run `npm test`

Other related issues: #22437 https://github.com/expo/expo/issues/2595

Folks having been using the fix in this PR as a workaround for quite some time now. (https://github.com/expo/expo/issues/2595#issuecomment-443193112, https://github.com/facebook/react-native/issues/22175#issuecomment-436959462) It would make sense to support this out of the box. 

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See http://facebook.github.io/react-native/docs/contributing#changelog for an example. -->

[General] [Fixed] - disable `inlineRequires` to fix jest tests

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
Run the above mentioned reproduction steps and see if the error occurs anymore.