### PR TITLE
Separate RTL examples in RNTester

### DIFF
--- a/RNTester/js/RTLExample.js
+++ b/RNTester/js/RTLExample.js
@@ -491,40 +491,13 @@ class RTLExample extends React.Component<any, State> {
 
     this.state = {
       pan,
-      isRTL: IS_RTL,
     };
   }
 
   render() {
     return (
-      <ScrollView
-        style={[
-          styles.container,
-          // `direction` property is supported only on iOS now.
-          Platform.OS === 'ios'
-            ? {direction: this.state.isRTL ? 'rtl' : 'ltr'}
-            : null,
-        ]}>
+      <ScrollView style={styles.container}>
         <RNTesterPage title={'Right-to-Left (RTL) UI Layout'}>
-          <RNTesterBlock title={'Current Layout Direction'}>
-            <View style={styles.directionBox}>
-              <Text style={styles.directionText}>
-                {this.state.isRTL ? 'Right-to-Left' : 'Left-to-Right'}
-              </Text>
-            </View>
-          </RNTesterBlock>
-          <RNTesterBlock title={'Quickly Test RTL Layout'}>
-            <View style={styles.flexDirectionRow}>
-              <Text style={styles.switchRowTextView}>forceRTL</Text>
-              <View style={styles.switchRowSwitchView}>
-                <Switch
-                  onValueChange={this._onDirectionChange}
-                  style={styles.rightAlignStyle}
-                  value={this.state.isRTL}
-                />
-              </View>
-            </View>
-          </RNTesterBlock>
           <SimpleListItemExample />
           <TextAlignmentExample
             title={'Default Text Alignment'}
@@ -563,17 +536,6 @@ class RTLExample extends React.Component<any, State> {
       </ScrollView>
     );
   }
-
-  _onDirectionChange = () => {
-    I18nManager.forceRTL(!this.state.isRTL);
-    this.setState({isRTL: !this.state.isRTL});
-    Alert.alert(
-      'Reload this page',
-      'Please reload this page to change the UI direction! ' +
-        'All examples in this app will be affected. ' +
-        'Check them out to see what they look like in RTL layout.',
-    );
-  };
 
   _onPanResponderGrant = (e: Object, gestureState: Object) => {
     this.state.pan.stopAnimation(value => {

--- a/RNTester/js/RTLExample.js
+++ b/RNTester/js/RTLExample.js
@@ -197,7 +197,7 @@ class AnimationExample extends React.Component<any, State> {
       <RNTesterBlock
         title={'Controlling Animation'}
         description={'Animation direction according to layout'}>
-        <View style={styles.view}>
+        <View style={styles.view} onLayout={this._onLayout}>
           <AnimationBlock
             onPress={this._linearTap}
             imgStyle={{
@@ -211,6 +211,12 @@ class AnimationExample extends React.Component<any, State> {
       </RNTesterBlock>
     );
   }
+
+  _onLayout = (e: Object) => {
+    this.setState({
+      windowWidth: e.nativeEvent.layout.width,
+    });
+  };
 
   _linearTap = (e: Object) => {
     this.setState({

--- a/RNTester/js/RTLExample.js
+++ b/RNTester/js/RTLExample.js
@@ -181,7 +181,7 @@ const SimpleListItemExample = withRTLState(({isRTL, setRTL}) => {
 });
 
 const AnimationContainer = withRTLState(({isRTL, setRTL}) => {
-  return <AnimationExample />;
+  return <AnimationExample isRTL={isRTL} setRTL={setRTL} />;
 });
 
 class AnimationExample extends React.Component<any, State> {
@@ -200,13 +200,14 @@ class AnimationExample extends React.Component<any, State> {
       <RNTesterBlock
         title={'Controlling Animation'}
         description={'Animation direction according to layout'}>
+        <RTLToggler setRTL={this.props.setRTL} isRTL={this.props.isRTL} />
         <View style={styles.view} onLayout={this._onLayout}>
           <AnimationBlock
             onPress={this._linearTap}
             imgStyle={{
               transform: [
                 {translateX: this.state.linear},
-                {scaleX: IS_RTL ? -1 : 1},
+                {scaleX: this.props.isRTL ? -1 : 1},
               ],
             }}
           />
@@ -230,7 +231,7 @@ class AnimationExample extends React.Component<any, State> {
     });
     const offset = IMAGE_SIZE[0] / SCALE / 2 + 10;
     const toMaxDistance =
-      (IS_RTL ? -1 : 1) * (this.state.windowWidth / 2 - offset);
+      (this.props.isRTL ? -1 : 1) * (this.state.windowWidth / 2 - offset);
     Animated.timing(this.state.linear, {
       toValue: this.state.toggleStatus[e] ? toMaxDistance : 0,
       duration: 2000,

--- a/RNTester/js/RTLExample.js
+++ b/RNTester/js/RTLExample.js
@@ -89,6 +89,35 @@ const TextAlignmentExample = withRTLState(({isRTL, setRTL, ...props}) => {
   );
 });
 
+const IconsExample = withRTLState(({isRTL, setRTL}) => {
+  return (
+    <RNTesterBlock title={'Working With Icons'}>
+      <RTLToggler setRTL={setRTL} isRTL={isRTL} />
+      <View
+        style={[styles.flexDirectionRow, {direction: isRTL ? 'rtl' : 'ltr'}]}>
+        <View>
+          <Image
+            source={require('./Thumbnails/like.png')}
+            style={styles.image}
+          />
+          <Text style={styles.fontSizeExtraSmall}>
+            Without directional meaning
+          </Text>
+        </View>
+        <View style={styles.rightAlignStyle}>
+          <Image
+            source={require('./Thumbnails/poke.png')}
+            style={[styles.image, styles.withRTLStyle]}
+          />
+          <Text style={styles.fontSizeExtraSmall}>
+            With directional meaning
+          </Text>
+        </View>
+      </View>
+    </RNTesterBlock>
+  );
+});
+
 function AnimationBlock(props) {
   return (
     <View style={styles.block}>
@@ -466,28 +495,7 @@ class RTLExample extends React.Component<any, State> {
             }
             style={[styles.fontSizeSmall, styles.textAlignRight]}
           />
-          <RNTesterBlock title={'Working With Icons'}>
-            <View style={styles.flexDirectionRow}>
-              <View>
-                <Image
-                  source={require('./Thumbnails/like.png')}
-                  style={styles.image}
-                />
-                <Text style={styles.fontSizeExtraSmall}>
-                  Without directional meaning
-                </Text>
-              </View>
-              <View style={styles.rightAlignStyle}>
-                <Image
-                  source={require('./Thumbnails/poke.png')}
-                  style={[styles.image, styles.withRTLStyle]}
-                />
-                <Text style={styles.fontSizeExtraSmall}>
-                  With directional meaning
-                </Text>
-              </View>
-            </View>
-          </RNTesterBlock>
+          <IconsExample />
           <RNTesterBlock
             title={'Controlling Animation'}
             description={'Animation direction according to layout'}>

--- a/RNTester/js/RTLExample.js
+++ b/RNTester/js/RTLExample.js
@@ -65,10 +65,11 @@ function ListItem(props) {
   );
 }
 
-function TextAlignmentExample(props) {
+const TextAlignmentExample = withRTLState(({isRTL, setRTL, ...props}) => {
   return (
     <RNTesterBlock title={props.title} description={props.description}>
-      <View>
+      <RTLToggler setRTL={setRTL} isRTL={isRTL} />
+      <View style={{direction: isRTL ? 'rtl' : 'ltr'}}>
         <Text style={props.style}>
           Left-to-Right language without text alignment.
         </Text>
@@ -86,7 +87,7 @@ function TextAlignmentExample(props) {
       </View>
     </RNTesterBlock>
   );
-}
+});
 
 function AnimationBlock(props) {
   return (
@@ -116,7 +117,9 @@ function withRTLState(Component) {
 
     render() {
       const setRTL = isRTL => this.setState({isRTL: isRTL});
-      return <Component isRTL={this.state.isRTL} setRTL={setRTL} />;
+      return (
+        <Component isRTL={this.state.isRTL} setRTL={setRTL} {...this.props} />
+      );
     }
   };
 }

--- a/RNTester/js/RTLExample.js
+++ b/RNTester/js/RTLExample.js
@@ -73,7 +73,7 @@ const TextAlignmentExample = withRTLState(({isRTL, setRTL, ...props}) => {
   return (
     <View>
       <RTLToggler setRTL={setRTL} isRTL={isRTL} />
-      <View style={{direction: isRTL ? 'rtl' : 'ltr'}}>
+      <View style={directionStyle(isRTL)}>
         <Text style={props.style}>
           Left-to-Right language without text alignment.
         </Text>
@@ -97,8 +97,7 @@ const IconsExample = withRTLState(({isRTL, setRTL}) => {
   return (
     <View>
       <RTLToggler setRTL={setRTL} isRTL={isRTL} />
-      <View
-        style={[styles.flexDirectionRow, {direction: isRTL ? 'rtl' : 'ltr'}]}>
+      <View style={[styles.flexDirectionRow, directionStyle(isRTL)]}>
         <View>
           <Image
             source={require('./Thumbnails/like.png')}
@@ -220,7 +219,7 @@ const SimpleListItemExample = withRTLState(({isRTL, setRTL}) => {
   return (
     <View>
       <RTLToggler setRTL={setRTL} isRTL={isRTL} />
-      <View style={[styles.list, {direction: isRTL ? 'rtl' : 'ltr'}]}>
+      <View style={[styles.list, directionStyle(isRTL)]}>
         <ListItem imageSource={require('./Thumbnails/like.png')} />
         <ListItem imageSource={require('./Thumbnails/poke.png')} />
       </View>
@@ -414,7 +413,7 @@ const BorderWidthExample = withRTLState(({isRTL, setRTL}) => {
       <Text>borderEndWidth: 50</Text>
       <Text />
       <Text style={styles.bold}>Demo: </Text>
-      <View style={{direction: isRTL ? 'rtl' : 'ltr'}}>
+      <View style={directionStyle(isRTL)}>
         <View
           style={{
             borderStartWidth: 10,
@@ -437,7 +436,7 @@ const BorderColorExample = withRTLState(({isRTL, setRTL}) => {
       <Text>borderEndColor: 'green',</Text>
       <Text />
       <Text style={styles.bold}>Demo: </Text>
-      <View style={{direction: isRTL ? 'rtl' : 'ltr'}}>
+      <View style={directionStyle(isRTL)}>
         <View
           style={{
             borderStartColor: 'red',
@@ -465,7 +464,7 @@ const BorderRadiiExample = withRTLState(({isRTL, setRTL}) => {
       <Text>borderBottomEndRadius: 40</Text>
       <Text />
       <Text style={styles.bold}>Demo: </Text>
-      <View style={{direction: isRTL ? 'rtl' : 'ltr'}}>
+      <View style={directionStyle(isRTL)}>
         <View
           style={{
             borderWidth: 10,
@@ -498,7 +497,7 @@ const BorderExample = withRTLState(({isRTL, setRTL}) => {
       <Text>borderBottomEndRadius: 40</Text>
       <Text />
       <Text style={styles.bold}>Demo: </Text>
-      <View style={{direction: isRTL ? 'rtl' : 'ltr'}}>
+      <View style={directionStyle(isRTL)}>
         <View
           style={{
             borderStartColor: 'red',
@@ -519,6 +518,9 @@ const BorderExample = withRTLState(({isRTL, setRTL}) => {
     </View>
   );
 });
+
+const directionStyle = isRTL =>
+  Platform.OS === 'ios' ? {direction: isRTL ? 'rtl' : 'ltr'} : null;
 
 const styles = StyleSheet.create({
   container: {

--- a/RNTester/js/RTLExample.js
+++ b/RNTester/js/RTLExample.js
@@ -66,7 +66,7 @@ function ListItem(props) {
 
 const TextAlignmentExample = withRTLState(({isRTL, setRTL, ...props}) => {
   return (
-    <RNTesterBlock title={props.title} description={props.description}>
+    <View>
       <RTLToggler setRTL={setRTL} isRTL={isRTL} />
       <View style={{direction: isRTL ? 'rtl' : 'ltr'}}>
         <Text style={props.style}>
@@ -84,13 +84,13 @@ const TextAlignmentExample = withRTLState(({isRTL, setRTL, ...props}) => {
             '\u05D9\u05D9\u05E9\u05D5\u05E8 \u05D8\u05E7\u05E1\u05D8'}
         </Text>
       </View>
-    </RNTesterBlock>
+    </View>
   );
 });
 
 const IconsExample = withRTLState(({isRTL, setRTL}) => {
   return (
-    <RNTesterBlock title={'Working With Icons'}>
+    <View>
       <RTLToggler setRTL={setRTL} isRTL={isRTL} />
       <View
         style={[styles.flexDirectionRow, {direction: isRTL ? 'rtl' : 'ltr'}]}>
@@ -113,7 +113,7 @@ const IconsExample = withRTLState(({isRTL, setRTL}) => {
           </Text>
         </View>
       </View>
-    </RNTesterBlock>
+    </View>
   );
 });
 
@@ -170,13 +170,13 @@ const RTLToggler = ({isRTL, setRTL}) => {
 
 const SimpleListItemExample = withRTLState(({isRTL, setRTL}) => {
   return (
-    <RNTesterBlock title={'A Simple List Item Layout'}>
+    <View>
       <RTLToggler setRTL={setRTL} isRTL={isRTL} />
       <View style={[styles.list, {direction: isRTL ? 'rtl' : 'ltr'}]}>
         <ListItem imageSource={require('./Thumbnails/like.png')} />
         <ListItem imageSource={require('./Thumbnails/poke.png')} />
       </View>
-    </RNTesterBlock>
+    </View>
   );
 });
 
@@ -197,9 +197,7 @@ class AnimationExample extends React.Component<any, State> {
 
   render() {
     return (
-      <RNTesterBlock
-        title={'Controlling Animation'}
-        description={'Animation direction according to layout'}>
+      <View>
         <RTLToggler setRTL={this.props.setRTL} isRTL={this.props.isRTL} />
         <View style={styles.view} onLayout={this._onLayout}>
           <AnimationBlock
@@ -212,7 +210,7 @@ class AnimationExample extends React.Component<any, State> {
             }}
           />
         </View>
-      </RNTesterBlock>
+      </View>
     );
   }
 
@@ -244,7 +242,7 @@ const PaddingExample = withRTLState(({isRTL, setRTL}) => {
   const color = 'teal';
 
   return (
-    <RNTesterBlock title={'Padding Start/End'}>
+    <View>
       <Text style={styles.bold}>Styles</Text>
       <Text>paddingStart: 50,</Text>
       <Text>paddingEnd: 10</Text>
@@ -272,13 +270,13 @@ const PaddingExample = withRTLState(({isRTL, setRTL}) => {
           <RTLToggler setRTL={setRTL} isRTL={isRTL} />
         </View>
       </View>
-    </RNTesterBlock>
+    </View>
   );
 });
 
 const MarginExample = withRTLState(({isRTL, setRTL}) => {
   return (
-    <RNTesterBlock title={'Margin Start/End'}>
+    <View>
       <Text style={styles.bold}>Styles</Text>
       <Text>marginStart: 50,</Text>
       <Text>marginEnd: 10</Text>
@@ -306,13 +304,13 @@ const MarginExample = withRTLState(({isRTL, setRTL}) => {
           <RTLToggler setRTL={setRTL} isRTL={isRTL} />
         </View>
       </View>
-    </RNTesterBlock>
+    </View>
   );
 });
 
 const PositionExample = withRTLState(({isRTL, setRTL}) => {
   return (
-    <RNTesterBlock title={'Position Start/End'}>
+    <View>
       <Text style={styles.bold}>Styles</Text>
       <Text>start: 50</Text>
       <Text />
@@ -356,13 +354,13 @@ const PositionExample = withRTLState(({isRTL, setRTL}) => {
           <RTLToggler setRTL={setRTL} isRTL={isRTL} />
         </View>
       </View>
-    </RNTesterBlock>
+    </View>
   );
 });
 
 const BorderWidthExample = withRTLState(({isRTL, setRTL}) => {
   return (
-    <RNTesterBlock title={'Border Width Start/End'}>
+    <View>
       <Text style={styles.bold}>Styles</Text>
       <Text>borderStartWidth: 10,</Text>
       <Text>borderEndWidth: 50</Text>
@@ -379,13 +377,13 @@ const BorderWidthExample = withRTLState(({isRTL, setRTL}) => {
           </View>
         </View>
       </View>
-    </RNTesterBlock>
+    </View>
   );
 });
 
 const BorderColorExample = withRTLState(({isRTL, setRTL}) => {
   return (
-    <RNTesterBlock title={'Border Color Start/End'}>
+    <View>
       <Text style={styles.bold}>Styles</Text>
       <Text>borderStartColor: 'red',</Text>
       <Text>borderEndColor: 'green',</Text>
@@ -405,13 +403,13 @@ const BorderColorExample = withRTLState(({isRTL, setRTL}) => {
           </View>
         </View>
       </View>
-    </RNTesterBlock>
+    </View>
   );
 });
 
 const BorderRadiiExample = withRTLState(({isRTL, setRTL}) => {
   return (
-    <RNTesterBlock title={'Border Radii Start/End'}>
+    <View>
       <Text style={styles.bold}>Styles</Text>
       <Text>borderTopStartRadius: 10,</Text>
       <Text>borderTopEndRadius: 20,</Text>
@@ -434,13 +432,13 @@ const BorderRadiiExample = withRTLState(({isRTL, setRTL}) => {
           </View>
         </View>
       </View>
-    </RNTesterBlock>
+    </View>
   );
 });
 
 const BorderExample = withRTLState(({isRTL, setRTL}) => {
   return (
-    <RNTesterBlock title={'Border '}>
+    <View>
       <Text style={styles.bold}>Styles</Text>
       <Text>borderStartColor: 'red',</Text>
       <Text>borderEndColor: 'green',</Text>
@@ -470,54 +468,9 @@ const BorderExample = withRTLState(({isRTL, setRTL}) => {
           </View>
         </View>
       </View>
-    </RNTesterBlock>
+    </View>
   );
 });
-
-class RTLExample extends React.Component<any, State> {
-  render() {
-    return (
-      <ScrollView style={styles.container}>
-        <RNTesterPage title={'Right-to-Left (RTL) UI Layout'}>
-          <SimpleListItemExample />
-          <TextAlignmentExample
-            title={'Default Text Alignment'}
-            description={
-              'In iOS, it depends on active language. ' +
-              'In Android, it depends on the text content.'
-            }
-            style={styles.fontSizeSmall}
-          />
-          <TextAlignmentExample
-            title={"Using textAlign: 'left'"}
-            description={
-              'In iOS/Android, text alignment flips regardless of ' +
-              'languages or text content.'
-            }
-            style={[styles.fontSizeSmall, styles.textAlignLeft]}
-          />
-          <TextAlignmentExample
-            title={"Using textAlign: 'right'"}
-            description={
-              'In iOS/Android, text alignment flips regardless of ' +
-              'languages or text content.'
-            }
-            style={[styles.fontSizeSmall, styles.textAlignRight]}
-          />
-          <IconsExample />
-          <AnimationContainer />
-          <PaddingExample />
-          <MarginExample />
-          <PositionExample />
-          <BorderWidthExample />
-          <BorderColorExample />
-          <BorderRadiiExample />
-          <BorderExample />
-        </RNTesterPage>
-      </ScrollView>
-    );
-  }
-}
 
 const styles = StyleSheet.create({
   container: {
@@ -641,9 +594,99 @@ exports.title = 'RTLExample';
 exports.description = 'Examples to show how to apply components to RTL layout.';
 exports.examples = [
   {
-    title: 'Simple RTL',
+    title: 'A Simple List Item Layout',
     render: function(): React.Element<typeof RTLExample> {
-      return <RTLExample />;
+      return <SimpleListItemExample />;
+    },
+  },
+  {
+    title: 'Default Text Alignment',
+    description:
+      'In iOS, it depends on active language. ' +
+      'In Android, it depends on the text content.',
+    render: function(): React.Element<typeof RTLExample> {
+      return <TextAlignmentExample style={styles.fontSizeSmall} />;
+    },
+  },
+  {
+    title: "Using textAlign: 'left'",
+    description:
+      'In iOS/Android, text alignment flips regardless of ' +
+      'languages or text content.',
+    render: function(): React.Element<typeof RTLExample> {
+      return (
+        <TextAlignmentExample
+          style={[styles.fontSizeSmall, styles.textAlignLeft]}
+        />
+      );
+    },
+  },
+  {
+    title: "Using textAlign: 'right'",
+    description:
+      'In iOS/Android, text alignment flips regardless of ' +
+      'languages or text content.',
+    render: function(): React.Element<typeof RTLExample> {
+      return (
+        <TextAlignmentExample
+          style={[styles.fontSizeSmall, styles.textAlignRight]}
+        />
+      );
+    },
+  },
+  {
+    title: 'Working With Icons',
+    render: function(): React.Element<typeof RTLExample> {
+      return <IconsExample />;
+    },
+  },
+  {
+    title: 'Controlling Animation',
+    description: 'Animation direction according to layout',
+    render: function(): React.Element<typeof RTLExample> {
+      return <AnimationContainer />;
+    },
+  },
+  {
+    title: 'Padding Start/End',
+    render: function(): React.Element<typeof RTLExample> {
+      return <PaddingExample />;
+    },
+  },
+  {
+    title: 'Margin Start/End',
+    render: function(): React.Element<typeof RTLExample> {
+      return <MarginExample />;
+    },
+  },
+  {
+    title: 'Position Start/End',
+    render: function(): React.Element<typeof RTLExample> {
+      return <PositionExample />;
+    },
+  },
+  {
+    title: 'Border Width Start/End',
+    render: function(): React.Element<typeof RTLExample> {
+      return <BorderWidthExample />;
+    },
+  },
+  {
+    title: 'Border Color Start/End',
+    render: function(): React.Element<typeof RTLExample> {
+      return <BorderColorExample />;
+    },
+  },
+  {
+    title: 'Border Radii Start/End',
+    render: function(): React.Element<typeof RTLExample> {
+      return <BorderRadiiExample />;
+    },
+  },
+  {
+    title: 'Border',
+    render: function(): React.Element<typeof RTLExample> {
+      return <BorderExample />;
     },
   },
 ];

--- a/RNTester/js/RTLExample.js
+++ b/RNTester/js/RTLExample.js
@@ -184,14 +184,21 @@ class RTLToggleExample extends React.Component<any, RTLToggleState> {
 
   render() {
     return (
-      <View style={styles.flexDirectionRow}>
-        <Text style={styles.switchRowTextView}>forceRTL</Text>
-        <View style={styles.switchRowSwitchView}>
-          <Switch
-            onValueChange={this._onDirectionChange}
-            style={styles.rightAlignStyle}
-            value={this.state.isRTL}
-          />
+      <View>
+        <View style={styles.directionBox}>
+          <Text style={styles.directionText}>
+            {this.state.isRTL ? 'Right-to-Left' : 'Left-to-Right'}
+          </Text>
+        </View>
+        <View style={styles.flexDirectionRow}>
+          <Text style={styles.switchRowTextView}>forceRTL</Text>
+          <View style={styles.switchRowSwitchView}>
+            <Switch
+              onValueChange={this._onDirectionChange}
+              style={styles.rightAlignStyle}
+              value={this.state.isRTL}
+            />
+          </View>
         </View>
       </View>
     );
@@ -523,6 +530,7 @@ const styles = StyleSheet.create({
     backgroundColor: '#f8f8f8',
     borderWidth: 0.5,
     borderColor: 'black',
+    marginBottom: 15,
   },
   directionText: {
     padding: 10,
@@ -635,7 +643,7 @@ exports.title = 'RTLExample';
 exports.description = 'Examples to show how to apply components to RTL layout.';
 exports.examples = [
   {
-    title: 'Quickly Test RTL Layout',
+    title: 'Current Layout Direction',
     render: function(): React.Element<any> {
       return <RTLToggleExample />;
     },

--- a/RNTester/js/RTLExample.js
+++ b/RNTester/js/RTLExample.js
@@ -36,7 +36,6 @@ type State = {
   pan: Object,
   linear: Object,
   isRTL: boolean,
-  windowWidth: number,
 };
 
 const SCALE = PixelRatio.get();
@@ -486,11 +485,8 @@ class RTLExample extends React.Component<any, State> {
     });
 
     this.state = {
-      toggleStatus: {},
       pan,
-      linear: new Animated.Value(0),
       isRTL: IS_RTL,
-      windowWidth: 0,
     };
   }
 
@@ -503,8 +499,7 @@ class RTLExample extends React.Component<any, State> {
           Platform.OS === 'ios'
             ? {direction: this.state.isRTL ? 'rtl' : 'ltr'}
             : null,
-        ]}
-        onLayout={this._onLayout}>
+        ]}>
         <RNTesterPage title={'Right-to-Left (RTL) UI Layout'}>
           <RNTesterBlock title={'Current Layout Direction'}>
             <View style={styles.directionBox}>
@@ -564,12 +559,6 @@ class RTLExample extends React.Component<any, State> {
     );
   }
 
-  _onLayout = (e: Object) => {
-    this.setState({
-      windowWidth: e.nativeEvent.layout.width,
-    });
-  };
-
   _onDirectionChange = () => {
     I18nManager.forceRTL(!this.state.isRTL);
     this.setState({isRTL: !this.state.isRTL});
@@ -579,23 +568,6 @@ class RTLExample extends React.Component<any, State> {
         'All examples in this app will be affected. ' +
         'Check them out to see what they look like in RTL layout.',
     );
-  };
-
-  _linearTap = (e: Object) => {
-    this.setState({
-      toggleStatus: {
-        ...this.state.toggleStatus,
-        [e]: !this.state.toggleStatus[e],
-      },
-    });
-    const offset = IMAGE_SIZE[0] / SCALE / 2 + 10;
-    const toMaxDistance =
-      (IS_RTL ? -1 : 1) * (this.state.windowWidth / 2 - offset);
-    Animated.timing(this.state.linear, {
-      toValue: this.state.toggleStatus[e] ? toMaxDistance : 0,
-      duration: 2000,
-      useNativeDriver: true,
-    }).start();
   };
 
   _onPanResponderGrant = (e: Object, gestureState: Object) => {

--- a/RNTester/js/RTLExample.js
+++ b/RNTester/js/RTLExample.js
@@ -180,6 +180,10 @@ const SimpleListItemExample = withRTLState(({isRTL, setRTL}) => {
   );
 });
 
+const AnimationContainer = withRTLState(({isRTL, setRTL}) => {
+  return <AnimationExample />;
+});
+
 class AnimationExample extends React.Component<any, State> {
   constructor(props: Object) {
     super(props);
@@ -546,7 +550,7 @@ class RTLExample extends React.Component<any, State> {
             style={[styles.fontSizeSmall, styles.textAlignRight]}
           />
           <IconsExample />
-          <AnimationExample />
+          <AnimationContainer />
           <PaddingExample />
           <MarginExample />
           <PositionExample />

--- a/RNTester/js/RTLExample.js
+++ b/RNTester/js/RTLExample.js
@@ -137,6 +137,18 @@ const RTLToggler = ({isRTL, setRTL}) => {
   );
 };
 
+const SimpleListItemExample = withRTLState(({isRTL, setRTL}) => {
+  return (
+    <RNTesterBlock title={'A Simple List Item Layout'}>
+      <RTLToggler setRTL={setRTL} isRTL={isRTL} />
+      <View style={[styles.list, {direction: isRTL ? 'rtl' : 'ltr'}]}>
+        <ListItem imageSource={require('./Thumbnails/like.png')} />
+        <ListItem imageSource={require('./Thumbnails/poke.png')} />
+      </View>
+    </RNTesterBlock>
+  );
+});
+
 const PaddingExample = withRTLState(({isRTL, setRTL}) => {
   const color = 'teal';
 
@@ -426,12 +438,7 @@ class RTLExample extends React.Component<any, State> {
               </View>
             </View>
           </RNTesterBlock>
-          <RNTesterBlock title={'A Simple List Item Layout'}>
-            <View style={styles.list}>
-              <ListItem imageSource={require('./Thumbnails/like.png')} />
-              <ListItem imageSource={require('./Thumbnails/poke.png')} />
-            </View>
-          </RNTesterBlock>
+          <SimpleListItemExample />
           <TextAlignmentExample
             title={'Default Text Alignment'}
             description={

--- a/RNTester/js/RTLExample.js
+++ b/RNTester/js/RTLExample.js
@@ -181,6 +181,32 @@ const SimpleListItemExample = withRTLState(({isRTL, setRTL}) => {
   );
 });
 
+class AnimationExample extends React.Component<any, State> {
+  constructor(props: Object) {
+    super(props);
+  }
+
+  render() {
+    return (
+      <RNTesterBlock
+        title={'Controlling Animation'}
+        description={'Animation direction according to layout'}>
+        <View style={styles.view}>
+          <AnimationBlock
+            onPress={this.props.linearTap}
+            imgStyle={{
+              transform: [
+                {translateX: this.props.linear},
+                {scaleX: IS_RTL ? -1 : 1},
+              ],
+            }}
+          />
+        </View>
+      </RNTesterBlock>
+    );
+  }
+}
+
 const PaddingExample = withRTLState(({isRTL, setRTL}) => {
   const color = 'teal';
 
@@ -496,21 +522,10 @@ class RTLExample extends React.Component<any, State> {
             style={[styles.fontSizeSmall, styles.textAlignRight]}
           />
           <IconsExample />
-          <RNTesterBlock
-            title={'Controlling Animation'}
-            description={'Animation direction according to layout'}>
-            <View style={styles.view}>
-              <AnimationBlock
-                onPress={this._linearTap}
-                imgStyle={{
-                  transform: [
-                    {translateX: this.state.linear},
-                    {scaleX: IS_RTL ? -1 : 1},
-                  ],
-                }}
-              />
-            </View>
-          </RNTesterBlock>
+          <AnimationExample
+            linearTap={this._linearTap}
+            linear={this.state.linear}
+          />
           <PaddingExample />
           <MarginExample />
           <PositionExample />

--- a/RNTester/js/RTLExample.js
+++ b/RNTester/js/RTLExample.js
@@ -475,25 +475,6 @@ const BorderExample = withRTLState(({isRTL, setRTL}) => {
 });
 
 class RTLExample extends React.Component<any, State> {
-  _panResponder: Object;
-
-  constructor(props: Object) {
-    super(props);
-    const pan = new Animated.ValueXY();
-
-    this._panResponder = PanResponder.create({
-      onStartShouldSetPanResponder: () => true,
-      onPanResponderGrant: this._onPanResponderGrant,
-      onPanResponderMove: Animated.event([null, {dx: pan.x, dy: pan.y}]),
-      onPanResponderRelease: this._onPanResponderEnd,
-      onPanResponderTerminate: this._onPanResponderEnd,
-    });
-
-    this.state = {
-      pan,
-    };
-  }
-
   render() {
     return (
       <ScrollView style={styles.container}>
@@ -536,23 +517,6 @@ class RTLExample extends React.Component<any, State> {
       </ScrollView>
     );
   }
-
-  _onPanResponderGrant = (e: Object, gestureState: Object) => {
-    this.state.pan.stopAnimation(value => {
-      this.state.pan.setOffset(value);
-    });
-  };
-
-  _onPanResponderEnd = (e: Object, gestureState: Object) => {
-    this.state.pan.flattenOffset();
-    Animated.sequence([
-      Animated.decay(this.state.pan, {
-        velocity: {x: gestureState.vx, y: gestureState.vy},
-        deceleration: 0.995,
-      }),
-      Animated.spring(this.state.pan, {toValue: {x: 0, y: 0}}),
-    ]).start();
-  };
 }
 
 const styles = StyleSheet.create({

--- a/RNTester/js/RTLExample.js
+++ b/RNTester/js/RTLExample.js
@@ -33,6 +33,16 @@ type State = {
   isRTL: boolean,
 };
 
+type RTLToggleState = {
+  isRTL: boolean,
+};
+
+type AnimationState = {
+  toggleStatus: any,
+  linear: Object,
+  windowWidth: number,
+};
+
 const SCALE = PixelRatio.get();
 const IMAGE_DIMENSION = 100 * SCALE;
 const IMAGE_SIZE = [IMAGE_DIMENSION, IMAGE_DIMENSION];
@@ -163,7 +173,7 @@ const RTLToggler = ({isRTL, setRTL}) => {
   );
 };
 
-class ForceRTLExample extends React.Component {
+class RTLToggleExample extends React.Component<any, RTLToggleState> {
   constructor(props: Object) {
     super(props);
 
@@ -215,7 +225,7 @@ const AnimationContainer = withRTLState(({isRTL, setRTL}) => {
   return <AnimationExample isRTL={isRTL} setRTL={setRTL} />;
 });
 
-class AnimationExample extends React.Component<any, State> {
+class AnimationExample extends React.Component<any, AnimationState> {
   constructor(props: Object) {
     super(props);
 
@@ -626,13 +636,13 @@ exports.description = 'Examples to show how to apply components to RTL layout.';
 exports.examples = [
   {
     title: 'Quickly Test RTL Layout',
-    render: function(): React.Element<typeof RTLExample> {
-      return <ForceRTLExample />;
+    render: function(): React.Element<any> {
+      return <RTLToggleExample />;
     },
   },
   {
     title: 'A Simple List Item Layout',
-    render: function(): React.Element<typeof RTLExample> {
+    render: function(): React.Element<any> {
       return <SimpleListItemExample />;
     },
   },
@@ -641,7 +651,7 @@ exports.examples = [
     description:
       'In iOS, it depends on active language. ' +
       'In Android, it depends on the text content.',
-    render: function(): React.Element<typeof RTLExample> {
+    render: function(): React.Element<any> {
       return <TextAlignmentExample style={styles.fontSizeSmall} />;
     },
   },
@@ -650,7 +660,7 @@ exports.examples = [
     description:
       'In iOS/Android, text alignment flips regardless of ' +
       'languages or text content.',
-    render: function(): React.Element<typeof RTLExample> {
+    render: function(): React.Element<any> {
       return (
         <TextAlignmentExample
           style={[styles.fontSizeSmall, styles.textAlignLeft]}
@@ -663,7 +673,7 @@ exports.examples = [
     description:
       'In iOS/Android, text alignment flips regardless of ' +
       'languages or text content.',
-    render: function(): React.Element<typeof RTLExample> {
+    render: function(): React.Element<any> {
       return (
         <TextAlignmentExample
           style={[styles.fontSizeSmall, styles.textAlignRight]}
@@ -673,56 +683,56 @@ exports.examples = [
   },
   {
     title: 'Working With Icons',
-    render: function(): React.Element<typeof RTLExample> {
+    render: function(): React.Element<any> {
       return <IconsExample />;
     },
   },
   {
     title: 'Controlling Animation',
     description: 'Animation direction according to layout',
-    render: function(): React.Element<typeof RTLExample> {
+    render: function(): React.Element<any> {
       return <AnimationContainer />;
     },
   },
   {
     title: 'Padding Start/End',
-    render: function(): React.Element<typeof RTLExample> {
+    render: function(): React.Element<any> {
       return <PaddingExample />;
     },
   },
   {
     title: 'Margin Start/End',
-    render: function(): React.Element<typeof RTLExample> {
+    render: function(): React.Element<any> {
       return <MarginExample />;
     },
   },
   {
     title: 'Position Start/End',
-    render: function(): React.Element<typeof RTLExample> {
+    render: function(): React.Element<any> {
       return <PositionExample />;
     },
   },
   {
     title: 'Border Width Start/End',
-    render: function(): React.Element<typeof RTLExample> {
+    render: function(): React.Element<any> {
       return <BorderWidthExample />;
     },
   },
   {
     title: 'Border Color Start/End',
-    render: function(): React.Element<typeof RTLExample> {
+    render: function(): React.Element<any> {
       return <BorderColorExample />;
     },
   },
   {
     title: 'Border Radii Start/End',
-    render: function(): React.Element<typeof RTLExample> {
+    render: function(): React.Element<any> {
       return <BorderRadiiExample />;
     },
   },
   {
     title: 'Border',
-    render: function(): React.Element<typeof RTLExample> {
+    render: function(): React.Element<any> {
       return <BorderExample />;
     },
   },

--- a/RNTester/js/RTLExample.js
+++ b/RNTester/js/RTLExample.js
@@ -184,6 +184,12 @@ const SimpleListItemExample = withRTLState(({isRTL, setRTL}) => {
 class AnimationExample extends React.Component<any, State> {
   constructor(props: Object) {
     super(props);
+
+    this.state = {
+      toggleStatus: {},
+      linear: new Animated.Value(0),
+      windowWidth: 0,
+    };
   }
 
   render() {
@@ -193,10 +199,10 @@ class AnimationExample extends React.Component<any, State> {
         description={'Animation direction according to layout'}>
         <View style={styles.view}>
           <AnimationBlock
-            onPress={this.props.linearTap}
+            onPress={this._linearTap}
             imgStyle={{
               transform: [
-                {translateX: this.props.linear},
+                {translateX: this.state.linear},
                 {scaleX: IS_RTL ? -1 : 1},
               ],
             }}
@@ -205,6 +211,23 @@ class AnimationExample extends React.Component<any, State> {
       </RNTesterBlock>
     );
   }
+
+  _linearTap = (e: Object) => {
+    this.setState({
+      toggleStatus: {
+        ...this.state.toggleStatus,
+        [e]: !this.state.toggleStatus[e],
+      },
+    });
+    const offset = IMAGE_SIZE[0] / SCALE / 2 + 10;
+    const toMaxDistance =
+      (IS_RTL ? -1 : 1) * (this.state.windowWidth / 2 - offset);
+    Animated.timing(this.state.linear, {
+      toValue: this.state.toggleStatus[e] ? toMaxDistance : 0,
+      duration: 2000,
+      useNativeDriver: true,
+    }).start();
+  };
 }
 
 const PaddingExample = withRTLState(({isRTL, setRTL}) => {
@@ -522,10 +545,7 @@ class RTLExample extends React.Component<any, State> {
             style={[styles.fontSizeSmall, styles.textAlignRight]}
           />
           <IconsExample />
-          <AnimationExample
-            linearTap={this._linearTap}
-            linear={this.state.linear}
-          />
+          <AnimationExample />
           <PaddingExample />
           <MarginExample />
           <PositionExample />

--- a/RNTester/js/RTLExample.js
+++ b/RNTester/js/RTLExample.js
@@ -168,6 +168,42 @@ const RTLToggler = ({isRTL, setRTL}) => {
   );
 };
 
+class ForceRTLExample extends React.Component {
+  constructor(props: Object) {
+    super(props);
+
+    this.state = {
+      isRTL: IS_RTL,
+    };
+  }
+
+  render() {
+    return (
+      <View style={styles.flexDirectionRow}>
+        <Text style={styles.switchRowTextView}>forceRTL</Text>
+        <View style={styles.switchRowSwitchView}>
+          <Switch
+            onValueChange={this._onDirectionChange}
+            style={styles.rightAlignStyle}
+            value={this.state.isRTL}
+          />
+        </View>
+      </View>
+    );
+  }
+
+  _onDirectionChange = () => {
+    I18nManager.forceRTL(!this.state.isRTL);
+    this.setState({isRTL: !this.state.isRTL});
+    Alert.alert(
+      'Reload this page',
+      'Please reload this page to change the UI direction! ' +
+        'All examples in this app will be affected. ' +
+        'Check them out to see what they look like in RTL layout.',
+    );
+  };
+}
+
 const SimpleListItemExample = withRTLState(({isRTL, setRTL}) => {
   return (
     <View>
@@ -593,6 +629,12 @@ const styles = StyleSheet.create({
 exports.title = 'RTLExample';
 exports.description = 'Examples to show how to apply components to RTL layout.';
 exports.examples = [
+  {
+    title: 'Quickly Test RTL Layout',
+    render: function(): React.Element<typeof RTLExample> {
+      return <ForceRTLExample />;
+    },
+  },
   {
     title: 'A Simple List Item Layout',
     render: function(): React.Element<typeof RTLExample> {

--- a/RNTester/js/RTLExample.js
+++ b/RNTester/js/RTLExample.js
@@ -16,9 +16,7 @@ const {
   Animated,
   I18nManager,
   Image,
-  PanResponder,
   PixelRatio,
-  ScrollView,
   StyleSheet,
   Text,
   TouchableWithoutFeedback,
@@ -27,9 +25,6 @@ const {
   Button,
 } = ReactNative;
 const Platform = require('Platform');
-
-const RNTesterPage = require('./RNTesterPage');
-const RNTesterBlock = require('./RNTesterBlock');
 
 type State = {
   toggleStatus: any,


### PR DESCRIPTION
## Summary

Splits RTLExample into separate exported examples, so they can be filtered. This will help with Detox tests.

Previously the single forceRTL toggle affected multiple examples because they all share state—although the box model examples at the end had their own toggles. Now each example has its own RTL toggle so it is always available even when examples are filtered, and so the examples don't have to share state. There is still the separate forceRTL toggle that changes the setting in `I18nManager`, which affects the default setting when the page appears, as well as the direction of the "with directional meaning" pointer icon.

## Changelog

[General] [Changed] - Split RTLExample into separate exported examples

## Test Plan

Run RTLExample on master and observe the behavior of each example. Run RTLExample again on this branch and confirm each example behaves the same way. Confirm filtering works within RTLExample.
