### PR TITLE
Prepare Groovy scripts for Kotlin DSL migration

### DIFF
--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -40,67 +40,67 @@ task createNativeDepsDirectories {
 
 task downloadBoost(dependsOn: createNativeDepsDirectories, type: Download) {
     src "https://github.com/react-native-community/boost-for-react-native/releases/download/v${BOOST_VERSION.replace("_", ".")}-0/boost_${BOOST_VERSION}.tar.gz"
-    onlyIfNewer true
-    overwrite false
-    dest new File(downloadsDir, "boost_${BOOST_VERSION}.tar.gz")
+    onlyIfNewer(true)
+    overwrite(false)
+    dest(new File(downloadsDir, "boost_${BOOST_VERSION}.tar.gz"))
 }
 
 task prepareBoost(dependsOn: boostPath ? [] : [downloadBoost], type: Copy) {
-    from boostPath ?: tarTree(resources.gzip(downloadBoost.dest))
-    from 'src/main/jni/third-party/boost/Android.mk'
-    include 'Android.mk', "boost_${BOOST_VERSION}/boost/**/*.hpp", 'boost/boost/**/*.hpp'
+    from(boostPath ?: tarTree(resources.gzip(downloadBoost.dest)))
+    from("src/main/jni/third-party/boost/Android.mk")
+    include("Android.mk", "boost_${BOOST_VERSION}/boost/**/*.hpp", "boost/boost/**/*.hpp")
     includeEmptyDirs = false
-    into "$thirdPartyNdkDir/boost"
+    into("$thirdPartyNdkDir/boost")
     doLast {
         file("$thirdPartyNdkDir/boost/boost").renameTo("$thirdPartyNdkDir/boost/boost_${BOOST_VERSION}")
     }
 }
 
 task downloadDoubleConversion(dependsOn: createNativeDepsDirectories, type: Download) {
-    src "https://github.com/google/double-conversion/archive/v${DOUBLE_CONVERSION_VERSION}.tar.gz"
-    onlyIfNewer true
-    overwrite false
-    dest new File(downloadsDir, "double-conversion-${DOUBLE_CONVERSION_VERSION}.tar.gz")
+    src("https://github.com/google/double-conversion/archive/v${DOUBLE_CONVERSION_VERSION}.tar.gz")
+    onlyIfNewer(true)
+    overwrite(false)
+    dest(new File(downloadsDir, "double-conversion-${DOUBLE_CONVERSION_VERSION}.tar.gz"))
 }
 
 task prepareDoubleConversion(dependsOn: dependenciesPath ? [] : [downloadDoubleConversion], type: Copy) {
-    from dependenciesPath ?: tarTree(downloadDoubleConversion.dest)
-    from 'src/main/jni/third-party/double-conversion/Android.mk'
-    include "double-conversion-${DOUBLE_CONVERSION_VERSION}/src/**/*", 'Android.mk'
+    from(dependenciesPath ?: tarTree(downloadDoubleConversion.dest))
+    from("src/main/jni/third-party/double-conversion/Android.mk")
+    include("double-conversion-${DOUBLE_CONVERSION_VERSION}/src/**/*", "Android.mk")
     filesMatching('*/src/**/*', { fname -> fname.path = "double-conversion/${fname.name}" })
     includeEmptyDirs = false
-    into "$thirdPartyNdkDir/double-conversion"
+    into("$thirdPartyNdkDir/double-conversion")
 }
 
 task downloadFolly(dependsOn: createNativeDepsDirectories, type: Download) {
-    src "https://github.com/facebook/folly/archive/v${FOLLY_VERSION}.tar.gz"
-    onlyIfNewer true
-    overwrite false
-    dest new File(downloadsDir, "folly-${FOLLY_VERSION}.tar.gz");
+    src("https://github.com/facebook/folly/archive/v${FOLLY_VERSION}.tar.gz")
+    onlyIfNewer(true)
+    overwrite(false)
+    dest(new File(downloadsDir, "folly-${FOLLY_VERSION}.tar.gz"))
 }
 
 task prepareFolly(dependsOn: dependenciesPath ? [] : [downloadFolly], type: Copy) {
-    from dependenciesPath ?: tarTree(downloadFolly.dest)
-    from 'src/main/jni/third-party/folly/Android.mk'
-    include "folly-${FOLLY_VERSION}/folly/**/*", 'Android.mk'
+    from(dependenciesPath ?: tarTree(downloadFolly.dest))
+    from("src/main/jni/third-party/folly/Android.mk")
+    include("folly-${FOLLY_VERSION}/folly/**/*", "Android.mk")
     eachFile { fname -> fname.path = (fname.path - "folly-${FOLLY_VERSION}/") }
     includeEmptyDirs = false
-    into "$thirdPartyNdkDir/folly"
+    into("$thirdPartyNdkDir/folly")
 }
 
 task downloadGlog(dependsOn: createNativeDepsDirectories, type: Download) {
-    src "https://github.com/google/glog/archive/v${GLOG_VERSION}.tar.gz"
-    onlyIfNewer true
-    overwrite false
-    dest new File(downloadsDir, "glog-${GLOG_VERSION}.tar.gz")
+    src("https://github.com/google/glog/archive/v${GLOG_VERSION}.tar.gz")
+    onlyIfNewer(true)
+    overwrite(false)
+    dest(new File(downloadsDir, "glog-${GLOG_VERSION}.tar.gz"))
 }
 
 // Prepare glog sources to be compiled, this task will perform steps that normally should've been
 // executed by automake. This way we can avoid dependencies on make/automake
 task prepareGlog(dependsOn: dependenciesPath ? [] : [downloadGlog], type: Copy) {
-    from dependenciesPath ?: tarTree(downloadGlog.dest)
-    from 'src/main/jni/third-party/glog/'
-    include "glog-${GLOG_VERSION}/src/**/*", 'Android.mk', 'config.h'
+    from(dependenciesPath ?: tarTree(downloadGlog.dest))
+    from("src/main/jni/third-party/glog/")
+    include("glog-${GLOG_VERSION}/src/**/*", "Android.mk", "config.h")
     includeEmptyDirs = false
     filesMatching('**/*.h.in') {
         filter(ReplaceTokens, tokens: [
@@ -122,22 +122,22 @@ task prepareGlog(dependsOn: dependenciesPath ? [] : [downloadGlog], type: Copy) 
         ])
         it.path = (it.name - '.in')
     }
-    into "$thirdPartyNdkDir/glog"
+    into("$thirdPartyNdkDir/glog")
 
     doLast {
         copy {
-            from fileTree(dir: "$thirdPartyNdkDir/glog", includes: ["stl_logging.h", "logging.h", "raw_logging.h", "vlog_is_on.h", "**/glog/log_severity.h"]).files
+            from(fileTree(dir: "$thirdPartyNdkDir/glog", includes: ["stl_logging.h", "logging.h", "raw_logging.h", "vlog_is_on.h", "**/glog/log_severity.h"]).files)
             includeEmptyDirs = false
-            into "$thirdPartyNdkDir/glog/exported/glog"
+            into("$thirdPartyNdkDir/glog/exported/glog")
         }
     }
 }
 
 task downloadJSC(dependsOn: createNativeDepsDirectories, type: Download) {
-    src "https://registry.npmjs.org/jsc-android/-/jsc-android-${JSC_VERSION}.tgz"
-    onlyIfNewer true
-    overwrite false
-    dest new File(downloadsDir, "jsc-${JSC_VERSION}.tar.gz")
+    src("https://registry.npmjs.org/jsc-android/-/jsc-android-${JSC_VERSION}.tgz")
+    onlyIfNewer(true)
+    overwrite(false)
+    dest(new File(downloadsDir, "jsc-${JSC_VERSION}.tar.gz"))
 }
 
 // Create Android.mk library module based on jsc from npm
@@ -150,25 +150,25 @@ task prepareJSC(dependsOn: downloadJSC) {
         def headerFiles = jscTar.matching({ it.include "**/include/*.h" })
 
         copy {
-            from soFiles
-            from headerFiles
-            from "src/main/jni/third-party/jsc/Android.mk"
+            from(soFiles)
+            from(headerFiles)
+            from("src/main/jni/third-party/jsc/Android.mk")
 
             filesMatching("**/*.h", { it.path = "JavaScriptCore/${it.name}" })
 
-            includeEmptyDirs false
-            into "$thirdPartyNdkDir/jsc"
+            includeEmptyDirs(false)
+            into("$thirdPartyNdkDir/jsc")
         }
     }
 }
 task downloadNdkBuildDependencies {
     if (!boostPath) {
-        dependsOn downloadBoost
+        dependsOn(downloadBoost)
     }
-    dependsOn downloadDoubleConversion
-    dependsOn downloadFolly
-    dependsOn downloadGlog
-    dependsOn downloadJSC
+    dependsOn(downloadDoubleConversion)
+    dependsOn(downloadFolly)
+    dependsOn(downloadGlog)
+    dependsOn(downloadJSC)
 }
 
 def getNdkBuildName() {
@@ -225,7 +225,7 @@ def getNdkBuildFullPath() {
 task buildReactNdkLib(dependsOn: [prepareJSC, prepareBoost, prepareDoubleConversion, prepareFolly, prepareGlog], type: Exec) {
     inputs.dir('src/main/jni/react')
     outputs.dir("$buildDir/react-ndk/all")
-    commandLine getNdkBuildFullPath(),
+    commandLine(getNdkBuildFullPath(),
             'NDK_PROJECT_PATH=null',
             "NDK_APPLICATION_MK=$projectDir/src/main/jni/Application.mk",
             'NDK_OUT=' + temporaryDir,
@@ -235,110 +235,111 @@ task buildReactNdkLib(dependsOn: [prepareJSC, prepareBoost, prepareDoubleConvers
             "REACT_SRC_DIR=$projectDir/src/main/java/com/facebook/react",
             '-C', file('src/main/jni/react/jni').absolutePath,
             '--jobs', project.findProperty("jobs") ?: Runtime.runtime.availableProcessors()
+    )
 }
 
 task cleanReactNdkLib(type: Exec) {
-    ignoreExitValue true
-    errorOutput new ByteArrayOutputStream()
-    commandLine getNdkBuildFullPath(),
+    ignoreExitValue(true)
+    errorOutput(new ByteArrayOutputStream())
+    commandLine(getNdkBuildFullPath(),
             "NDK_APPLICATION_MK=$projectDir/src/main/jni/Application.mk",
             "THIRD_PARTY_NDK_DIR=$buildDir/third-party-ndk",
             "REACT_COMMON_DIR=$projectDir/../ReactCommon",
             '-C', file('src/main/jni/react/jni').absolutePath,
-            'clean'
+            'clean')
     doLast {
         file(AAR_OUTPUT_URL).delete()
-        println "Deleted aar output dir at ${file(AAR_OUTPUT_URL)}"
+        println("Deleted aar output dir at ${file(AAR_OUTPUT_URL)}")
     }
 }
 
 task packageReactNdkLibs(dependsOn: buildReactNdkLib, type: Copy) {
-    from "$buildDir/react-ndk/all"
-    from "$thirdPartyNdkDir/jsc/jni"
-    into "$buildDir/react-ndk/exported"
+    from("$buildDir/react-ndk/all")
+    from("$thirdPartyNdkDir/jsc/jni")
+    into("$buildDir/react-ndk/exported")
 }
 
 task packageReactNdkLibsForBuck(dependsOn: packageReactNdkLibs, type: Copy) {
-    from "$buildDir/react-ndk/exported"
-    into "src/main/jni/prebuilt/lib"
+    from("$buildDir/react-ndk/exported")
+    into("src/main/jni/prebuilt/lib")
 }
 
 android {
     compileSdkVersion 28
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility(JavaVersion.VERSION_1_8)
+        targetCompatibility(JavaVersion.VERSION_1_8)
     }
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 27
-        versionCode 1
-        versionName "1.0"
+        minSdkVersion(16)
+        targetSdkVersion(27)
+        versionCode(1)
+        versionName("1.0")
 
-        consumerProguardFiles 'proguard-rules.pro'
+        consumerProguardFiles("proguard-rules.pro")
 
         ndk {
-            moduleName "reactnativejni"
+            moduleName("reactnativejni")
         }
 
-        buildConfigField 'boolean', 'IS_INTERNAL_BUILD', 'false'
-        buildConfigField 'int', 'EXOPACKAGE_FLAGS', '0'
-        testApplicationId "com.facebook.react.tests.gradle"
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        buildConfigField("boolean", "IS_INTERNAL_BUILD", "false")
+        buildConfigField("int", "EXOPACKAGE_FLAGS", "0")
+        testApplicationId("com.facebook.react.tests.gradle")
+        testInstrumentationRunner("android.support.test.runner.AndroidJUnitRunner")
     }
 
     sourceSets.main {
         jni.srcDirs = []
-        jniLibs.srcDir "$buildDir/react-ndk/exported"
+        jniLibs.srcDir("$buildDir/react-ndk/exported")
         res.srcDirs = ['src/main/res/devsupport', 'src/main/res/shell', 'src/main/res/views/modal', 'src/main/res/views/uimanager']
         java {
             srcDirs = ['src/main/java', 'src/main/libraries/soloader/java', 'src/main/jni/first-party/fb/jni/java']
-            exclude 'com/facebook/react/processing'
-            exclude 'com/facebook/react/module/processing'
+            exclude("com/facebook/react/processing")
+            exclude("com/facebook/react/module/processing")
         }
     }
 
     tasks.withType(JavaCompile) {
-        compileTask -> compileTask.dependsOn packageReactNdkLibs
+        compileTask -> compileTask.dependsOn(packageReactNdkLibs)
     }
 
-    clean.dependsOn cleanReactNdkLib
+    clean.dependsOn(cleanReactNdkLib)
 
     lintOptions {
-        abortOnError false
+        abortOnError(false)
     }
     packagingOptions {
-        exclude 'META-INF/NOTICE'
-        exclude 'META-INF/LICENSE'
+        exclude("META-INF/NOTICE")
+        exclude("META-INF/LICENSE")
     }
 }
 
 dependencies {
-    api 'com.facebook.infer.annotation:infer-annotation:0.11.2'
-    api 'javax.inject:javax.inject:1'
-    api 'com.android.support:appcompat-v7:28.0.0'
-    api "com.facebook.fresco:fresco:${FRESCO_VERSION}"
-    api "com.facebook.fresco:imagepipeline-okhttp3:${FRESCO_VERSION}"
-    api "com.facebook.soloader:soloader:${SO_LOADER_VERSION}"
-    api 'com.google.code.findbugs:jsr305:3.0.2'
-    api "com.squareup.okhttp3:okhttp:${OKHTTP_VERSION}"
-    api "com.squareup.okhttp3:okhttp-urlconnection:${OKHTTP_VERSION}"
-    api 'com.squareup.okio:okio:1.15.0'
+    api("com.facebook.infer.annotation:infer-annotation:0.11.2")
+    api("javax.inject:javax.inject:1")
+    api("com.android.support:appcompat-v7:28.0.0")
+    api("com.facebook.fresco:fresco:${FRESCO_VERSION}")
+    api("com.facebook.fresco:imagepipeline-okhttp3:${FRESCO_VERSION}")
+    api("com.facebook.soloader:soloader:${SO_LOADER_VERSION}")
+    api("com.google.code.findbugs:jsr305:3.0.2")
+    api("com.squareup.okhttp3:okhttp:${OKHTTP_VERSION}")
+    api("com.squareup.okhttp3:okhttp-urlconnection:${OKHTTP_VERSION}")
+    api("com.squareup.okio:okio:1.15.0")
 
-    testImplementation "junit:junit:${JUNIT_VERSION}"
-    testImplementation "org.powermock:powermock-api-mockito:${POWERMOCK_VERSION}"
-    testImplementation "org.powermock:powermock-module-junit4-rule:${POWERMOCK_VERSION}"
-    testImplementation "org.powermock:powermock-classloading-xstream:${POWERMOCK_VERSION}"
-    testImplementation "org.mockito:mockito-core:${MOCKITO_CORE_VERSION}"
-    testImplementation "org.easytesting:fest-assert-core:${FEST_ASSERT_CORE_VERSION}"
-    testImplementation "org.robolectric:robolectric:${ROBOLECTRIC_VERSION}"
+    testImplementation("junit:junit:${JUNIT_VERSION}")
+    testImplementation("org.powermock:powermock-api-mockito:${POWERMOCK_VERSION}")
+    testImplementation("org.powermock:powermock-module-junit4-rule:${POWERMOCK_VERSION}")
+    testImplementation("org.powermock:powermock-classloading-xstream:${POWERMOCK_VERSION}")
+    testImplementation("org.mockito:mockito-core:${MOCKITO_CORE_VERSION}")
+    testImplementation("org.easytesting:fest-assert-core:${FEST_ASSERT_CORE_VERSION}")
+    testImplementation("org.robolectric:robolectric:${ROBOLECTRIC_VERSION}")
 
-    androidTestImplementation fileTree(dir: 'src/main/third-party/java/buck-android-support/', include: ['*.jar'])
-    androidTestImplementation "com.android.support.test:runner:${ANDROID_SUPPORT_TEST_VERSION}"
-    androidTestImplementation "com.android.support.test:rules:${ANDROID_SUPPORT_TEST_VERSION}"
-    androidTestImplementation "org.mockito:mockito-core:${MOCKITO_CORE_VERSION}"
+    androidTestImplementation(fileTree(dir: 'src/main/third-party/java/buck-android-support/', include: ['*.jar']))
+    androidTestImplementation("com.android.support.test:runner:${ANDROID_SUPPORT_TEST_VERSION}")
+    androidTestImplementation("com.android.support.test:rules:${ANDROID_SUPPORT_TEST_VERSION}")
+    androidTestImplementation("org.mockito:mockito-core:${MOCKITO_CORE_VERSION}")
 }
 
-apply from: 'release.gradle'
+apply(from: "release.gradle")

--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -39,7 +39,7 @@ task createNativeDepsDirectories {
 }
 
 task downloadBoost(dependsOn: createNativeDepsDirectories, type: Download) {
-    src "https://github.com/react-native-community/boost-for-react-native/releases/download/v${BOOST_VERSION.replace("_", ".")}-0/boost_${BOOST_VERSION}.tar.gz"
+    src("https://github.com/react-native-community/boost-for-react-native/releases/download/v${BOOST_VERSION.replace("_", ".")}-0/boost_${BOOST_VERSION}.tar.gz")
     onlyIfNewer(true)
     overwrite(false)
     dest(new File(downloadsDir, "boost_${BOOST_VERSION}.tar.gz"))
@@ -67,7 +67,7 @@ task prepareDoubleConversion(dependsOn: dependenciesPath ? [] : [downloadDoubleC
     from(dependenciesPath ?: tarTree(downloadDoubleConversion.dest))
     from("src/main/jni/third-party/double-conversion/Android.mk")
     include("double-conversion-${DOUBLE_CONVERSION_VERSION}/src/**/*", "Android.mk")
-    filesMatching('*/src/**/*', { fname -> fname.path = "double-conversion/${fname.name}" })
+    filesMatching("*/src/**/*", { fname -> fname.path = "double-conversion/${fname.name}" })
     includeEmptyDirs = false
     into("$thirdPartyNdkDir/double-conversion")
 }
@@ -102,25 +102,25 @@ task prepareGlog(dependsOn: dependenciesPath ? [] : [downloadGlog], type: Copy) 
     from("src/main/jni/third-party/glog/")
     include("glog-${GLOG_VERSION}/src/**/*", "Android.mk", "config.h")
     includeEmptyDirs = false
-    filesMatching('**/*.h.in') {
+    filesMatching("**/*.h.in") {
         filter(ReplaceTokens, tokens: [
-                ac_cv_have_unistd_h           : '1',
-                ac_cv_have_stdint_h           : '1',
-                ac_cv_have_systypes_h         : '1',
-                ac_cv_have_inttypes_h         : '1',
-                ac_cv_have_libgflags          : '0',
-                ac_google_start_namespace     : 'namespace google {',
-                ac_cv_have_uint16_t           : '1',
-                ac_cv_have_u_int16_t          : '1',
-                ac_cv_have___uint16           : '0',
-                ac_google_end_namespace       : '}',
-                ac_cv_have___builtin_expect   : '1',
-                ac_google_namespace           : 'google',
-                ac_cv___attribute___noinline  : '__attribute__ ((noinline))',
-                ac_cv___attribute___noreturn  : '__attribute__ ((noreturn))',
-                ac_cv___attribute___printf_4_5: '__attribute__((__format__ (__printf__, 4, 5)))'
+                ac_cv_have_unistd_h           : "1",
+                ac_cv_have_stdint_h           : "1",
+                ac_cv_have_systypes_h         : "1",
+                ac_cv_have_inttypes_h         : "1",
+                ac_cv_have_libgflags          : "0",
+                ac_google_start_namespace     : "namespace google {",
+                ac_cv_have_uint16_t           : "1",
+                ac_cv_have_u_int16_t          : "1",
+                ac_cv_have___uint16           : "0",
+                ac_google_end_namespace       : "}",
+                ac_cv_have___builtin_expect   : "1",
+                ac_google_namespace           : "google",
+                ac_cv___attribute___noinline  : "__attribute__ ((noinline))",
+                ac_cv___attribute___noreturn  : "__attribute__ ((noreturn))",
+                ac_cv___attribute___printf_4_5: "__attribute__((__format__ (__printf__, 4, 5)))"
         ])
-        it.path = (it.name - '.in')
+        it.path = (it.name - ".in")
     }
     into("$thirdPartyNdkDir/glog")
 
@@ -181,21 +181,21 @@ def getNdkBuildName() {
 
 def findNdkBuildFullPath() {
     // we allow to provide full path to ndk-build tool
-    if (hasProperty('ndk.command')) {
-        return property('ndk.command')
+    if (hasProperty("ndk.command")) {
+        return property("ndk.command")
     }
     // or just a path to the containing directory
-    if (hasProperty('ndk.path')) {
-        def ndkDir = property('ndk.path')
+    if (hasProperty("ndk.path")) {
+        def ndkDir = property("ndk.path")
         return new File(ndkDir, getNdkBuildName()).getAbsolutePath()
     }
-    if (System.getenv('ANDROID_NDK') != null) {
-        def ndkDir = System.getenv('ANDROID_NDK')
+    if (System.getenv("ANDROID_NDK") != null) {
+        def ndkDir = System.getenv("ANDROID_NDK")
         return new File(ndkDir, getNdkBuildName()).getAbsolutePath()
     }
-    def ndkDir = android.hasProperty('plugin') ? android.plugin.ndkFolder :
-            plugins.getPlugin('com.android.library').hasProperty('sdkHandler') ?
-                    plugins.getPlugin('com.android.library').sdkHandler.getNdkFolder() :
+    def ndkDir = android.hasProperty("plugin") ? android.plugin.ndkFolder :
+            plugins.getPlugin("com.android.library").hasProperty("sdkHandler") ?
+                    plugins.getPlugin("com.android.library").sdkHandler.getNdkFolder() :
                     android.ndkDirectory.absolutePath
     if (ndkDir) {
         return new File(ndkDir, getNdkBuildName()).getAbsolutePath()
@@ -223,18 +223,18 @@ def getNdkBuildFullPath() {
 }
 
 task buildReactNdkLib(dependsOn: [prepareJSC, prepareBoost, prepareDoubleConversion, prepareFolly, prepareGlog], type: Exec) {
-    inputs.dir('src/main/jni/react')
+    inputs.dir("src/main/jni/react")
     outputs.dir("$buildDir/react-ndk/all")
     commandLine(getNdkBuildFullPath(),
-            'NDK_PROJECT_PATH=null',
+            "NDK_PROJECT_PATH=null",
             "NDK_APPLICATION_MK=$projectDir/src/main/jni/Application.mk",
-            'NDK_OUT=' + temporaryDir,
+            "NDK_OUT=" + temporaryDir,
             "NDK_LIBS_OUT=$buildDir/react-ndk/all",
             "THIRD_PARTY_NDK_DIR=$buildDir/third-party-ndk",
             "REACT_COMMON_DIR=$projectDir/../ReactCommon",
             "REACT_SRC_DIR=$projectDir/src/main/java/com/facebook/react",
-            '-C', file('src/main/jni/react/jni').absolutePath,
-            '--jobs', project.findProperty("jobs") ?: Runtime.runtime.availableProcessors()
+            "-C", file("src/main/jni/react/jni").absolutePath,
+            "--jobs", project.findProperty("jobs") ?: Runtime.runtime.availableProcessors()
     )
 }
 
@@ -245,8 +245,8 @@ task cleanReactNdkLib(type: Exec) {
             "NDK_APPLICATION_MK=$projectDir/src/main/jni/Application.mk",
             "THIRD_PARTY_NDK_DIR=$buildDir/third-party-ndk",
             "REACT_COMMON_DIR=$projectDir/../ReactCommon",
-            '-C', file('src/main/jni/react/jni').absolutePath,
-            'clean')
+            "-C", file("src/main/jni/react/jni").absolutePath,
+            "clean")
     doLast {
         file(AAR_OUTPUT_URL).delete()
         println("Deleted aar output dir at ${file(AAR_OUTPUT_URL)}")
@@ -293,9 +293,9 @@ android {
     sourceSets.main {
         jni.srcDirs = []
         jniLibs.srcDir("$buildDir/react-ndk/exported")
-        res.srcDirs = ['src/main/res/devsupport', 'src/main/res/shell', 'src/main/res/views/modal', 'src/main/res/views/uimanager']
+        res.srcDirs = ["src/main/res/devsupport", "src/main/res/shell", "src/main/res/views/modal", "src/main/res/views/uimanager"]
         java {
-            srcDirs = ['src/main/java', 'src/main/libraries/soloader/java', 'src/main/jni/first-party/fb/jni/java']
+            srcDirs = ["src/main/java", "src/main/libraries/soloader/java", "src/main/jni/first-party/fb/jni/java"]
             exclude("com/facebook/react/processing")
             exclude("com/facebook/react/module/processing")
         }
@@ -336,7 +336,7 @@ dependencies {
     testImplementation("org.easytesting:fest-assert-core:${FEST_ASSERT_CORE_VERSION}")
     testImplementation("org.robolectric:robolectric:${ROBOLECTRIC_VERSION}")
 
-    androidTestImplementation(fileTree(dir: 'src/main/third-party/java/buck-android-support/', include: ['*.jar']))
+    androidTestImplementation(fileTree(dir: "src/main/third-party/java/buck-android-support/", include: ["*.jar"]))
     androidTestImplementation("com.android.support.test:runner:${ANDROID_SUPPORT_TEST_VERSION}")
     androidTestImplementation("com.android.support.test:rules:${ANDROID_SUPPORT_TEST_VERSION}")
     androidTestImplementation("org.mockito:mockito-core:${MOCKITO_CORE_VERSION}")

--- a/ReactAndroid/release.gradle
+++ b/ReactAndroid/release.gradle
@@ -15,7 +15,7 @@ ext {
 // 2) To upload artifact to maven central use: :uploadArchives (you'd need to have the permission to do that)
 
 def isReleaseBuild() {
-    return VERSION_NAME.contains('SNAPSHOT') == false
+    return VERSION_NAME.contains("SNAPSHOT") == false
 }
 
 def getRepositoryUrl() {
@@ -23,11 +23,11 @@ def getRepositoryUrl() {
 }
 
 def getRepositoryUsername() {
-    return project.findProperty('repositoryUsername') ?: ''
+    return project.findProperty("repositoryUsername") ?: ""
 }
 
 def getRepositoryPassword() {
-    return project.findProperty('repositoryPassword') ?: ''
+    return project.findProperty("repositoryPassword") ?: ""
 }
 
 def configureReactNativePom(def pom) {
@@ -74,18 +74,18 @@ afterEvaluate { project ->
     task androidJavadoc(type: Javadoc) {
         source = android.sourceSets.main.java.srcDirs
         classpath += files(android.bootClasspath)
-        classpath += files(project.getConfigurations().getByName('compile').asList())
+        classpath += files(project.getConfigurations().getByName("compile").asList())
         include("**/*.java")
         exclude("**/ReactBuildConfig.java")
     }
 
     task androidJavadocJar(type: Jar, dependsOn: androidJavadoc) {
-        classifier = 'javadoc'
+        classifier = "javadoc"
         from(androidJavadoc.destinationDir)
     }
 
     task androidSourcesJar(type: Jar) {
-        classifier = 'sources'
+        classifier = "sources"
         from(android.sourceSets.main.java.srcDirs)
         include("**/*.java")
     }
@@ -106,7 +106,7 @@ afterEvaluate { project ->
     group = GROUP
 
     signing {
-        required { isReleaseBuild() && gradle.taskGraph.hasTask('uploadArchives') }
+        required { isReleaseBuild() && gradle.taskGraph.hasTask("uploadArchives") }
         sign(configurations.archives)
     }
 

--- a/ReactAndroid/release.gradle
+++ b/ReactAndroid/release.gradle
@@ -3,8 +3,8 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-apply plugin: 'maven'
-apply plugin: 'signing'
+apply(plugin: "maven")
+apply(plugin: "signing")
 
 ext {
     AAR_OUTPUT_URL = "file://${projectDir}/../android"
@@ -19,7 +19,7 @@ def isReleaseBuild() {
 }
 
 def getRepositoryUrl() {
-    return project.findProperty('repositoryUrl') ?: 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'
+    return project.findProperty("repositoryUrl") ?: "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
 }
 
 def getRepositoryUsername() {
@@ -32,30 +32,30 @@ def getRepositoryPassword() {
 
 def configureReactNativePom(def pom) {
     pom.project {
-        name POM_NAME
-        artifactId POM_ARTIFACT_ID
-        packaging POM_PACKAGING
-        description 'A framework for building native apps with React'
-        url 'https://github.com/facebook/react-native'
+        name(POM_NAME)
+        artifactId(POM_ARTIFACT_ID)
+        packaging(POM_PACKAGING)
+        description("A framework for building native apps with React")
+        url("https://github.com/facebook/react-native")
 
         scm {
-            url 'https://github.com/facebook/react-native.git'
-            connection 'scm:git:https://github.com/facebook/react-native.git'
-            developerConnection 'scm:git:git@github.com:facebook/react-native.git'
+            url("https://github.com/facebook/react-native.git")
+            connection("scm:git:https://github.com/facebook/react-native.git")
+            developerConnection("scm:git:git@github.com:facebook/react-native.git")
         }
 
         licenses {
             license {
-                name 'MIT License'
-                url 'https://github.com/facebook/react-native/blob/master/LICENSE'
-                distribution 'repo'
+                name("MIT License")
+                url("https://github.com/facebook/react-native/blob/master/LICENSE")
+                distribution("repo")
             }
         }
 
         developers {
             developer {
-                id 'facebook'
-                name 'Facebook'
+                id("facebook")
+                name("Facebook")
             }
         }
     }
@@ -64,7 +64,7 @@ def configureReactNativePom(def pom) {
 if (JavaVersion.current().isJava8Compatible()) {
   allprojects {
     tasks.withType(Javadoc) {
-      options.addStringOption('Xdoclint:none', '-quiet')
+      options.addStringOption("Xdoclint:none", "-quiet")
     }
   }
 }
@@ -75,31 +75,31 @@ afterEvaluate { project ->
         source = android.sourceSets.main.java.srcDirs
         classpath += files(android.bootClasspath)
         classpath += files(project.getConfigurations().getByName('compile').asList())
-        include '**/*.java'
-        exclude '**/ReactBuildConfig.java'
+        include("**/*.java")
+        exclude("**/ReactBuildConfig.java")
     }
 
     task androidJavadocJar(type: Jar, dependsOn: androidJavadoc) {
         classifier = 'javadoc'
-        from androidJavadoc.destinationDir
+        from(androidJavadoc.destinationDir)
     }
 
     task androidSourcesJar(type: Jar) {
         classifier = 'sources'
-        from android.sourceSets.main.java.srcDirs
-        include '**/*.java'
+        from(android.sourceSets.main.java.srcDirs)
+        include("**/*.java")
     }
 
     android.libraryVariants.all { variant ->
         def name = variant.name.capitalize()
         task "jar${name}"(type: Jar, dependsOn: variant.javaCompileProvider.get()) {
-            from variant.javaCompileProvider.get().destinationDir
+            from(variant.javaCompileProvider.get().destinationDir)
         }
     }
 
     artifacts {
-        archives androidSourcesJar
-        archives androidJavadocJar
+        archives(androidSourcesJar)
+        archives(androidJavadocJar)
     }
 
     version = VERSION_NAME
@@ -107,7 +107,7 @@ afterEvaluate { project ->
 
     signing {
         required { isReleaseBuild() && gradle.taskGraph.hasTask('uploadArchives') }
-        sign configurations.archives
+        sign(configurations.archives)
     }
 
     uploadArchives {
@@ -124,7 +124,7 @@ afterEvaluate { project ->
 
             }
 
-            configureReactNativePom pom
+            configureReactNativePom(pom)
         }
     }
 
@@ -132,9 +132,9 @@ afterEvaluate { project ->
         configuration = configurations.archives
         repositories.mavenDeployer {
             // Deploy to react-native/android, ready to publish to npm
-            repository url: AAR_OUTPUT_URL
+            repository(url: AAR_OUTPUT_URL)
 
-            configureReactNativePom pom
+            configureReactNativePom(pom)
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -10,8 +10,8 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.0'
-        classpath 'de.undercouch:gradle-download-task:3.4.3'
+        classpath("com.android.tools.build:gradle:3.3.0")
+        classpath("de.undercouch:gradle-download-task:3.4.3")
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -26,7 +26,7 @@ allprojects {
 
         def androidSdk = System.getenv("ANDROID_SDK")
         maven {
-            url "$androidSdk/extras/m2repository/"
+            url("$androidSdk/extras/m2repository/")
         }
     }
 }

--- a/react.gradle
+++ b/react.gradle
@@ -50,11 +50,11 @@ afterEvaluate {
 
             // Set up inputs and outputs so gradle can cache the result
             inputs.files fileTree(dir: reactRoot, excludes: inputExcludes)
-            outputs.dir jsBundleDir
-            outputs.dir resourcesDir
+            outputs.dir(jsBundleDir)
+            outputs.dir(resourcesDir)
 
             // Set up the call to the react-native cli
-            workingDir reactRoot
+            workingDir(reactRoot)
 
             // Set up dev mode
             def devEnabled = !(config."devDisabledIn${targetName}"
@@ -113,12 +113,12 @@ afterEvaluate {
                 group = "react"
                 description = "copy bundled resources into custom location for ${targetName}."
 
-                from resourcesDir
-                into file(resourcesDirConfigValue)
+                from(resourcesDir)
+                into(file(resourcesDirConfigValue))
 
                 dependsOn(currentBundleTask)
 
-                enabled currentBundleTask.enabled
+                enabled(currentBundleTask.enabled)
             }
 
             packageTask.dependsOn(currentCopyResTask)
@@ -134,24 +134,24 @@ afterEvaluate {
             description = "copy bundled JS into ${targetName}."
 
             if (config."jsBundleDir${targetName}") {
-                from jsBundleDir
-                into file(config."jsBundleDir${targetName}")
+                from(jsBundleDir)
+                into(file(config."jsBundleDir${targetName}"))
             } else {
                 into ("$buildDir/intermediates")
                 into ("assets/${targetPath}") {
-                    from jsBundleDir
+                    from(jsBundleDir)
                 }
 
                 // Workaround for Android Gradle Plugin 3.2+ new asset directory
                 into ("merged_assets/${variant.name}/merge${targetName}Assets/out") {
-                    from jsBundleDir
+                    from(jsBundleDir)
                 }
             }
 
             // mergeAssets must run first, as it clears the intermediates directory
             dependsOn(variant.mergeAssetsProvider.get())
 
-            enabled currentBundleTask.enabled
+            enabled(currentBundleTask.enabled)
         }
 
         packageTask.dependsOn(currentAssetsCopyTask)

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,5 +3,5 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-include ':ReactAndroid'
-include ':RNTester:android:app'
+include(":ReactAndroid")
+include(":RNTester:android:app")


### PR DESCRIPTION
## Summary

Using Kotlin DSL in Gradle instead of Groovy will help detect problems early on using static typing, and it has advanced IDE support. This PR prepares Groovy script for Kotlin DSL migration per **Migrating build logic from Groovy to Kotlin** guide. Here is the excerpt: 

>As a first migration step, it is recommended to prepare your Groovy build scripts by
> - unifying quotes using double quotes,
> - disambiguating function invocations and property assignments (using respectively parentheses and assignment operator).

See: https://guides.gradle.org/migrating-build-logic-from-groovy-to-kotlin/

## Changelog

[Android] [Changed] - Prepare Gradle scripts for Kotlin DSL migration

## Test Plan

CI is green