### PR TITLE
[iOS] Revert RCTRootView's backgroundColor to white

### DIFF
--- a/template/ios/HelloWorld/AppDelegate.m
+++ b/template/ios/HelloWorld/AppDelegate.m
@@ -20,7 +20,7 @@
                                                    moduleName:@"HelloWorld"
                                             initialProperties:nil];
 
-  rootView.backgroundColor = [UIColor blackColor];
+  rootView.backgroundColor = [[UIColor alloc] initWithRed:1.0f green:1.0f blue:1.0f alpha:1];
 
   self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
   UIViewController *rootViewController = [UIViewController new];


### PR DESCRIPTION
## Summary

Fixes #23314 , the change came from #20945 , its purpose is to fix orientation change issue in HelloWord template, but I think it's just a trick, to make rootView's backgroundColor the same as window backgroundColor, the orientation issue seems related to [UIManager setAvailableSize:forRootView:](https://github.com/facebook/react-native/blob/d2fc19f4aa94888b7c3d3f4a5fb621bf96a1aff9/React/Modules/RCTUIManager.m#L343) async layout things.

## Changelog

[iOS] [Fixed] - Revert RCTRootView's backgroundColor to white.

## Test Plan

N/A.

CC @kelset .