### PR TITLE
[iOS] Prevent crash when scrollEnabled used in singleline textinput

### DIFF
--- a/Libraries/Text/TextInput/Singleline/RCTUITextField.m
+++ b/Libraries/Text/TextInput/Singleline/RCTUITextField.m
@@ -87,6 +87,16 @@
   self.enabled = editable;
 }
 
+- (void)setScrollEnabled:(BOOL)enabled
+{
+  // Do noting, compatible with multiline textinput
+}
+
+- (BOOL)scrollEnabled
+{
+  return NO;
+}
+
 #pragma mark - Context Menu
 
 - (BOOL)canPerformAction:(SEL)action withSender:(id)sender


### PR DESCRIPTION
## Summary

Fixes #22949 , #21339. Currently, multiline textInput uses `UITextView` but singleline textInput uses `UITextField`, so singleline textinput may crash when use `scrollEnabled` property.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See http://facebook.github.io/react-native/docs/contributing#changelog for an example. -->

[iOS] [Fixed] - Prevent crash when scrollEnabled used in singleline textinput

## Test Plan

Not crash when uses the code like below:
```
<TextInput multiline={false} scrollEnabled={true}/>
```