### PR TITLE
JSI: Minor tweaks for building on MSVC

### DIFF
--- a/ReactCommon/jsi/jsi.h
+++ b/ReactCommon/jsi/jsi.h
@@ -1,7 +1,7 @@
 //  Copyright (c) Facebook, Inc. and its affiliates.
 //
 // This source code is licensed under the MIT license found in the
- // LICENSE file in the root directory of this source tree.
+// LICENSE file in the root directory of this source tree.
 
 #pragma once
 
@@ -14,7 +14,11 @@
 #include <vector>
 
 #ifndef JSI_EXPORT
+#ifdef _MSC_VER
+#define JSI_EXPORT
+#else
 #define JSI_EXPORT __attribute__((visibility("default")))
+#endif
 #endif
 
 class FBJSRuntime;
@@ -300,8 +304,8 @@ class PropNameID : public Pointer {
  public:
   using Pointer::Pointer;
 
-  PropNameID(Runtime& runtime, const PropNameID& other)
-      : PropNameID(runtime.clonePropNameID(other.ptr_)) {}
+  PropNameID(Runtime &runtime, const PropNameID &other)
+      : Pointer(runtime.clonePropNameID(other.ptr_)) {}
 
   PropNameID(PropNameID&& other) = default;
   PropNameID& operator=(PropNameID&& other) = default;


### PR DESCRIPTION
## Summary

This pull request makes two minor changes to `jsi.h`:

 * Tweak the `JSI_EXPORT` macro to automatically set itself to an empty value if `_MSC_VER` is defined - like how was done by @acoates-ms [here](https://github.com/facebook/react-native/blob/8beb4bb58ab93af8c95af6844230d62c85ccab78/ReactCommon/cxxreact/JSBigString.h#L15-L21).
 * Tweak the call to constructor `Pointer(Runtime::PointerValue* ptr)` in the constructor for `PropNameID`. I am not sure why MSVC wasn't working with the original version, but it compiles after I tweak that.

## Changelog

[General] [Fixed] - Tweaked `jsi.h` to build on MSVC

## Test Plan

JSI successfully compiled under Visual Studio 2017