### PR TITLE
Add deprecation warning while importing Slider component

### DIFF
--- a/Libraries/react-native/react-native-implementation.js
+++ b/Libraries/react-native/react-native-implementation.js
@@ -104,6 +104,12 @@ module.exports = {
     return require('SegmentedControlIOS');
   },
   get Slider() {
+    warnOnce(
+      'slider-moved',
+      'Slider has been extracted from react-native core and will be removed in a future release. ' +
+        "It can now be installed and imported from '@react-native-community/slider' instead of 'react-native'. " +
+        'See https://github.com/react-native-community/react-native-slider for more informations.',
+    );
     return require('Slider');
   },
   get SnapshotViewIOS() {

--- a/Libraries/react-native/react-native-implementation.js
+++ b/Libraries/react-native/react-native-implementation.js
@@ -108,7 +108,7 @@ module.exports = {
       'slider-moved',
       'Slider has been extracted from react-native core and will be removed in a future release. ' +
         "It can now be installed and imported from '@react-native-community/slider' instead of 'react-native'. " +
-        'See https://github.com/react-native-community/react-native-slider for more informations.',
+        'See https://github.com/react-native-community/react-native-slider',
     );
     return require('Slider');
   },


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Introducing the deprecation warning for those who are importing `Slider` component (https://github.com/facebook/react-native/issues/23313)

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See http://facebook.github.io/react-native/docs/contributing#changelog for an example. -->

[General] [Deprecated] - Deprecated Slider as it has now been moved to `@react-native-community/slider`

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Open the RNTester app to the Slider examples and see the warning yellow box appear.