### PR TITLE
Add deprecation warning for ViewPagerAndroid

### DIFF
--- a/Libraries/react-native/react-native-implementation.js
+++ b/Libraries/react-native/react-native-implementation.js
@@ -163,6 +163,12 @@ module.exports = {
     return require('View');
   },
   get ViewPagerAndroid() {
+    warnOnce(
+      'viewpager-moved',
+      'ViewPagerAndroid has been extracted from react-native core and will be removed in a future release. ' +
+        "It can now be installed and imported from '@react-native-community/viewpager' instead of 'react-native'. " +
+        'See https://github.com/react-native-community/react-native-viewpager',
+    );
     return require('ViewPagerAndroid');
   },
   get VirtualizedList() {


### PR DESCRIPTION
## Summary

Add a deprecation warning for the [ViewPagerAndroid](https://facebook.github.io/react-native/docs/viewpagerandroid) module as part of #23313.

## Changelog

[General] [Deprecated] - Deprecated [ViewPagerAndroid](https://facebook.github.io/react-native/docs/viewpagerandroid) as it has now been moved to [@react-native-community/viewpager](https://github.com/react-native-community/react-native-viewpager)

## Test Plan

Open the RNTester app to the ViewPagerAndroid example and see the warning yellow box appear.