### PR TITLE
[iOS] Fix triangle views on iOS

### DIFF
--- a/React/Views/RCTBorderDrawing.m
+++ b/React/Views/RCTBorderDrawing.m
@@ -224,13 +224,15 @@ static UIImage *RCTGetSolidBorderImage(RCTCornerRadii cornerRadii,
     borderInsets.right + MAX(cornerInsets.bottomRight.width, cornerInsets.topRight.width)
   };
 
-  // Asymmetrical edgeInsets cause strange artifacting on iOS 10 and earlier.
-  edgeInsets = (UIEdgeInsets){
-    MAX(edgeInsets.top, edgeInsets.bottom),
-    MAX(edgeInsets.left, edgeInsets.right),
-    MAX(edgeInsets.top, edgeInsets.bottom),
-    MAX(edgeInsets.left, edgeInsets.right),
-  };
+  if (hasCornerRadii) {
+    // Asymmetrical edgeInsets cause strange artifacting on iOS 10 and earlier.
+    edgeInsets = (UIEdgeInsets){
+      MAX(edgeInsets.top, edgeInsets.bottom),
+      MAX(edgeInsets.left, edgeInsets.right),
+      MAX(edgeInsets.top, edgeInsets.bottom),
+      MAX(edgeInsets.left, edgeInsets.right),
+    };
+  }
 
   const CGSize size = makeStretchable ? (CGSize){
     // 1pt for the middle stretchable area along each axis


### PR DESCRIPTION
## Summary

Fixes #22824 #21945 , the bug comes from #21208 , it was to fix #11897. Now Let's constrain edge adjust only when view has corners.

## Changelog

[iOS] [Fixed] - Fix triangle views on iOS

## Test Plan

Fixes issues like #11897 and #22824 #21945 , but attention, I'm not have device like comment in #11897, so I didn't test issue in #11897, but maybe I didn't break it, because only view which has corner may have issue like #11897.