### PR TITLE
Fix crash in RNTester when removing/developing tests

### DIFF
--- a/RNTester/js/RNTesterApp.ios.js
+++ b/RNTester/js/RNTesterApp.ios.js
@@ -110,7 +110,7 @@ class RNTesterApp extends React.Component<Props, RNTesterNavigationState> {
     }
     if (this.state.openExample) {
       const Component = RNTesterList.Modules[this.state.openExample];
-      if (Component.external) {
+      if (Component && Component.external) {
         return <Component onExampleExit={this._handleBack} />;
       } else {
         return (


### PR DESCRIPTION
Ensure that the current openExample (stored in AsyncStorage) exists in the module list.


<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

It's possible for the example to be missing if a test was removed & previously open in RNTester OR when actively developing RNTester tests & switching between branches

## Changelog

[General] [Fixed] - Potential crash in RNTester when removing/developing test cases

## Test Plan

1) Create a new RNTester test file
2) Open it in the app
3) Remove the previously added RNTester test
4) Re-open RNTester app (expect no crash/exception)
