### PR TITLE
Remove flaky Switch e2e test

### DIFF
--- a/RNTester/e2e/__tests__/Switch-test.js
+++ b/RNTester/e2e/__tests__/Switch-test.js
@@ -37,17 +37,6 @@ describe('Switch', () => {
       await expect(element(by.id(testID))).toHaveValue('1');
       await expect(element(by.id(indicatorID))).toHaveText('On');
     });
-
-    it('Switch that starts on should switch', async () => {
-      const testID = 'on-off-initial-on';
-      const indicatorID = 'on-off-initial-on-indicator';
-
-      await expect(element(by.id(testID))).toHaveValue('1');
-      await expect(element(by.id(indicatorID))).toHaveText('On');
-      await element(by.id(testID)).tap();
-      await expect(element(by.id(testID))).toHaveValue('0');
-      await expect(element(by.id(indicatorID))).toHaveText('Off');
-    });
   });
 
   describe('Switches can be disabled', () => {


### PR DESCRIPTION
## Summary

'Switch that starts on should switch' appears to be flaky, as it has failed on seemingly unrelated commits, only to succeed on the next CI run. `Switch` is scheduled to be removed from the core repository anyway, so I'm removing this test to ensure we get a clear signal for the rest of the repository.

## Changelog

[GENERAL] [Changed] - Tests: Removed flaky Switch e2e test.

## Test Plan

Can't fail a test that is not there!