### PR TITLE
[analysis-bot] Suggest running yarn lint --fix

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -8,3 +8,5 @@ pr-inactivity-bookmarklet.js
 question-bookmarklet.js
 flow/
 danger/
+bots/
+scripts/

--- a/.eslintignore
+++ b/.eslintignore
@@ -7,6 +7,4 @@ Libraries/Renderer/*
 pr-inactivity-bookmarklet.js
 question-bookmarklet.js
 flow/
-danger/
-bots/
-scripts/
+bots/node_modules

--- a/scripts/circleci/code-analysis-bot.js
+++ b/scripts/circleci/code-analysis-bot.js
@@ -30,6 +30,12 @@ function push(arr, key, value) {
   arr[key].push(value);
 }
 
+const converterSummary = {
+  eslint: '`eslint` found some issues. Run `yarn lint --fix` to automatically fix problems.',
+  flow: '`flow` found some issues.',
+  shellcheck: '`shellcheck` found some issues.',
+};
+
 /**
  * There is unfortunately no standard format to report an error, so we have
  * to write a specific converter for each tool we want to support.
@@ -250,7 +256,7 @@ function main(messages, owner, repo, number) {
       let body = '**Code analysis results:**\n\n';
       const uniqueconvertersUsed = [...new Set(convertersUsed)];
       uniqueconvertersUsed.forEach(converter => {
-        body += '* `' + converter + '` found some issues.\n';
+        body += '* ' + converterSummary[converter] + '\n';
       });
 
       sendReview(owner, repo, number, sha, body, comments);

--- a/scripts/circleci/code-analysis-bot.js
+++ b/scripts/circleci/code-analysis-bot.js
@@ -31,7 +31,8 @@ function push(arr, key, value) {
 }
 
 const converterSummary = {
-  eslint: '`eslint` found some issues. Run `yarn lint --fix` to automatically fix problems.',
+  eslint:
+    '`eslint` found some issues. Run `yarn lint --fix` to automatically fix problems.',
   flow: '`flow` found some issues.',
   shellcheck: '`shellcheck` found some issues.',
 };


### PR DESCRIPTION
## Summary

This PR expands the code analysis script to allow for customizing the GitHub Review left by @analysis-bot whenever it finds code-level issues.

Some, but not all, `eslint` errors are fixable by running `yarn lint --fix`. When the `eslint` converter finds warnings or errors, the bot will suggest running the command as part of the review.

The script could be adjusted to only suggest this when `eslint` returns a non-zero `fixableErrorCount` or `fixableWarningCount`, but I think this is a good first step to get people to unblock themselves when they see this type of review from the bot.

I've also excluded `bots/` and `scripts/` from eslint as these have several `eslint` errors that need to be addressed. These directories do not contain core RN code, so they can be excluded for now.

## Changelog

[GENERAL] [Changed] - @analysis-bot will suggest fixing eslint warnings on code reviews

## Test Plan

Intentionally added a prettier issue in `RNTester/js/ScrollViewExample.js` in 7617afa, and confirmed bot left a review in https://github.com/facebook/react-native/pull/23413#pullrequestreview-202961036:
![screen shot 2019-02-12 at 3 24 52 pm](https://user-images.githubusercontent.com/165856/52675061-655f3f80-2eda-11e9-9947-e810dfd74cb5.png)

