### PR TITLE
Fabric: Fix building on MSVC

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -5,7 +5,7 @@ AlignConsecutiveAssignments: false
 AlignConsecutiveDeclarations: false
 AlignEscapedNewlinesLeft: true
 AlignOperands:   false
-AlignTrailingComments: false
+AlignTrailingComments: true
 AllowAllParametersOfDeclarationOnNextLine: false
 AllowShortBlocksOnASingleLine: false
 AllowShortCaseLabelsOnASingleLine: false

--- a/ReactCommon/fabric/components/image/ImageShadowNode.cpp
+++ b/ReactCommon/fabric/components/image/ImageShadowNode.cpp
@@ -48,7 +48,9 @@ ImageSource ImageShadowNode::getImageSource() const {
   auto sources = getProps()->sources;
 
   if (sources.size() == 0) {
-    return {.type = ImageSource::Type::Invalid};
+    return {
+        ImageSource::Type::Invalid // type
+    };
   }
 
   if (sources.size() == 1) {

--- a/ReactCommon/fabric/components/image/conversions.h
+++ b/ReactCommon/fabric/components/image/conversions.h
@@ -16,7 +16,10 @@ namespace react {
 
 inline void fromRawValue(const RawValue &value, ImageSource &result) {
   if (value.hasType<std::string>()) {
-    result = {.type = ImageSource::Type::Remote, .uri = (std::string)value};
+    result = {
+        ImageSource::Type::Remote, // type
+        (std::string)value         // uri
+    };
     return;
   }
 

--- a/ReactCommon/fabric/components/root/RootShadowNode.cpp
+++ b/ReactCommon/fabric/components/root/RootShadowNode.cpp
@@ -29,7 +29,12 @@ UnsharedRootShadowNode RootShadowNode::clone(
   auto props = std::make_shared<const RootProps>(
       *getProps(), layoutConstraints, layoutContext);
   auto newRootShadowNode = std::make_shared<RootShadowNode>(
-      *this, ShadowNodeFragment{.props = props});
+      *this,
+      ShadowNodeFragment{
+          0,     // tag,
+          0,     // rootTag,
+          props, // props
+      });
   return newRootShadowNode;
 }
 
@@ -55,11 +60,24 @@ UnsharedRootShadowNode RootShadowNode::clone(
     sharedChildren = std::make_shared<SharedShadowNodeList>(children);
 
     oldChild = ancestor.get().shared_from_this();
-    newChild = oldChild->clone(ShadowNodeFragment{.children = sharedChildren});
+    newChild = oldChild->clone({
+        0,                                            // tag,
+        0,                                            // rootTag,
+        ShadowNodeFragment::nullSharedProps(),        // props
+        ShadowNodeFragment::nullSharedEventEmitter(), // eventEmitter
+        sharedChildren,                               // children
+    });
   }
 
   return std::make_shared<RootShadowNode>(
-      *this, ShadowNodeFragment{.children = sharedChildren});
+      *this,
+      ShadowNodeFragment{
+          0,                                            // tag,
+          0,                                            // rootTag,
+          ShadowNodeFragment::nullSharedProps(),        // props
+          ShadowNodeFragment::nullSharedEventEmitter(), // eventEmitter
+          sharedChildren,                               // children
+      });
 }
 
 } // namespace react

--- a/ReactCommon/fabric/components/root/RootShadowNode.cpp
+++ b/ReactCommon/fabric/components/root/RootShadowNode.cpp
@@ -31,8 +31,8 @@ UnsharedRootShadowNode RootShadowNode::clone(
   auto newRootShadowNode = std::make_shared<RootShadowNode>(
       *this,
       ShadowNodeFragment{
-          0,     // tag,
-          0,     // rootTag,
+          0,     // tag
+          0,     // rootTag
           props, // props
       });
   return newRootShadowNode;
@@ -61,8 +61,8 @@ UnsharedRootShadowNode RootShadowNode::clone(
 
     oldChild = ancestor.get().shared_from_this();
     newChild = oldChild->clone({
-        0,                                            // tag,
-        0,                                            // rootTag,
+        0,                                            // tag
+        0,                                            // rootTag
         ShadowNodeFragment::nullSharedProps(),        // props
         ShadowNodeFragment::nullSharedEventEmitter(), // eventEmitter
         sharedChildren,                               // children
@@ -72,8 +72,8 @@ UnsharedRootShadowNode RootShadowNode::clone(
   return std::make_shared<RootShadowNode>(
       *this,
       ShadowNodeFragment{
-          0,                                            // tag,
-          0,                                            // rootTag,
+          0,                                            // tag
+          0,                                            // rootTag
           ShadowNodeFragment::nullSharedProps(),        // props
           ShadowNodeFragment::nullSharedEventEmitter(), // eventEmitter
           sharedChildren,                               // children

--- a/ReactCommon/fabric/components/view/ViewProps.cpp
+++ b/ReactCommon/fabric/components/view/ViewProps.cpp
@@ -79,21 +79,24 @@ ViewProps::ViewProps(const ViewProps &sourceProps, const RawProps &rawProps)
 
 BorderMetrics ViewProps::resolveBorderMetrics(bool isRTL) const {
   auto borderWidths = CascadedBorderWidths{
-      .left = optionalFloatFromYogaValue(yogaStyle.border[YGEdgeLeft]),
-      .top = optionalFloatFromYogaValue(yogaStyle.border[YGEdgeTop]),
-      .right = optionalFloatFromYogaValue(yogaStyle.border[YGEdgeRight]),
-      .bottom = optionalFloatFromYogaValue(yogaStyle.border[YGEdgeBottom]),
-      .start = optionalFloatFromYogaValue(yogaStyle.border[YGEdgeStart]),
-      .end = optionalFloatFromYogaValue(yogaStyle.border[YGEdgeEnd]),
-      .horizontal =
-          optionalFloatFromYogaValue(yogaStyle.border[YGEdgeHorizontal]),
-      .vertical = optionalFloatFromYogaValue(yogaStyle.border[YGEdgeVertical]),
-      .all = optionalFloatFromYogaValue(yogaStyle.border[YGEdgeAll])};
+      optionalFloatFromYogaValue(yogaStyle.border[YGEdgeLeft]),   // left
+      optionalFloatFromYogaValue(yogaStyle.border[YGEdgeTop]),    // top
+      optionalFloatFromYogaValue(yogaStyle.border[YGEdgeRight]),  // right
+      optionalFloatFromYogaValue(yogaStyle.border[YGEdgeBottom]), // bottom
+      optionalFloatFromYogaValue(yogaStyle.border[YGEdgeStart]),  // start
+      optionalFloatFromYogaValue(yogaStyle.border[YGEdgeEnd]),    // end
+      optionalFloatFromYogaValue(
+          yogaStyle.border[YGEdgeHorizontal]), // horizontal
+      optionalFloatFromYogaValue(yogaStyle.border[YGEdgeVertical]), // vertical
+      optionalFloatFromYogaValue(yogaStyle.border[YGEdgeAll]),      // all
+  };
 
-  return {.borderColors = borderColors.resolve(isRTL, {}),
-          .borderWidths = borderWidths.resolve(isRTL, 0),
-          .borderRadii = borderRadii.resolve(isRTL, 0),
-          .borderStyles = borderStyles.resolve(isRTL, BorderStyle::Solid)};
+  return {
+      borderColors.resolve(isRTL, {}),                 // borderColors
+      borderWidths.resolve(isRTL, 0),                  // borderWidths
+      borderRadii.resolve(isRTL, 0),                   // borderRadii
+      borderStyles.resolve(isRTL, BorderStyle::Solid), // borderStyles
+  };
 }
 
 #pragma mark - DebugStringConvertible

--- a/ReactCommon/fabric/components/view/primitives.h
+++ b/ReactCommon/fabric/components/view/primitives.h
@@ -204,11 +204,12 @@ struct CascadedRectangleEdges {
     const auto verticalOrAllOrDefault =
         vertical.value_or(all.value_or(defaults));
 
-    return Counterpart{
-        .left = left.value_or(leading.value_or(horizontalOrAllOrDefault)),
-        .right = right.value_or(trailing.value_or(horizontalOrAllOrDefault)),
-        .top = top.value_or(verticalOrAllOrDefault),
-        .bottom = bottom.value_or(verticalOrAllOrDefault)};
+    return {
+        left.value_or(leading.value_or(horizontalOrAllOrDefault)),   // left
+        right.value_or(trailing.value_or(horizontalOrAllOrDefault)), // right
+        top.value_or(verticalOrAllOrDefault),                        // top
+        bottom.value_or(verticalOrAllOrDefault),                     // bottom
+    };
   }
 
   bool operator==(const CascadedRectangleEdges<T> &rhs) const {
@@ -261,14 +262,15 @@ struct CascadedRectangleCorners {
     const auto bottomTrailing = isRTL ? bottomStart : bottomEnd;
 
     return Counterpart{
-        .topLeft =
-            topLeft.value_or(topLeading.value_or(all.value_or(defaults))),
-        .topRight =
-            topRight.value_or(topTrailing.value_or(all.value_or(defaults))),
-        .bottomLeft =
-            bottomLeft.value_or(topLeading.value_or(all.value_or(defaults))),
-        .bottomRight =
-            bottomRight.value_or(topTrailing.value_or(all.value_or(defaults)))};
+        topLeft.value_or(
+            topLeading.value_or(all.value_or(defaults))), // topLeft
+        topRight.value_or(
+            topTrailing.value_or(all.value_or(defaults))), // topRight
+        bottomLeft.value_or(
+            topLeading.value_or(all.value_or(defaults))), // bottomLeft
+        bottomRight.value_or(
+            topTrailing.value_or(all.value_or(defaults))), // bottomRight
+    };
   }
 
   bool operator==(const CascadedRectangleCorners<T> &rhs) const {

--- a/ReactCommon/fabric/core/layout/LayoutMetrics.h
+++ b/ReactCommon/fabric/core/layout/LayoutMetrics.h
@@ -57,7 +57,10 @@ struct LayoutMetrics {
  * Represents some undefined, not-yet-computed or meaningless value of
  * `LayoutMetrics` type.
  */
-static const LayoutMetrics EmptyLayoutMetrics = {.frame = {.size = {-1, -1}}};
+static const LayoutMetrics EmptyLayoutMetrics = {{
+    {0, 0},  // origin
+    {-1, -1} // size
+}};
 
 } // namespace react
 } // namespace facebook

--- a/ReactCommon/fabric/core/shadownode/ShadowNode.cpp
+++ b/ReactCommon/fabric/core/shadownode/ShadowNode.cpp
@@ -31,7 +31,9 @@ ShadowNode::ShadowNode(
       rootTag_(fragment.rootTag),
       props_(fragment.props),
       eventEmitter_(fragment.eventEmitter),
-      children_(fragment.children ?: emptySharedShadowNodeSharedList()),
+      children_(
+          fragment.children ? fragment.children
+                            : emptySharedShadowNodeSharedList()),
       cloneFunction_(cloneFunction),
       childrenAreShared_(true),
       revision_(1) {
@@ -42,12 +44,17 @@ ShadowNode::ShadowNode(
 ShadowNode::ShadowNode(
     const ShadowNode &sourceShadowNode,
     const ShadowNodeFragment &fragment)
-    : tag_(fragment.tag ?: sourceShadowNode.tag_),
-      rootTag_(fragment.rootTag ?: sourceShadowNode.rootTag_),
-      props_(fragment.props ?: sourceShadowNode.props_),
-      eventEmitter_(fragment.eventEmitter ?: sourceShadowNode.eventEmitter_),
-      children_(fragment.children ?: sourceShadowNode.children_),
-      localData_(fragment.localData ?: sourceShadowNode.localData_),
+    : tag_(fragment.tag ? fragment.tag : sourceShadowNode.tag_),
+      rootTag_(fragment.rootTag ? fragment.rootTag : sourceShadowNode.rootTag_),
+      props_(fragment.props ? fragment.props : sourceShadowNode.props_),
+      eventEmitter_(
+          fragment.eventEmitter ? fragment.eventEmitter
+                                : sourceShadowNode.eventEmitter_),
+      children_(
+          fragment.children ? fragment.children : sourceShadowNode.children_),
+      localData_(
+          fragment.localData ? fragment.localData
+                             : sourceShadowNode.localData_),
       cloneFunction_(sourceShadowNode.cloneFunction_),
       childrenAreShared_(true),
       revision_(sourceShadowNode.revision_ + 1) {

--- a/ReactCommon/fabric/core/tests/ComponentDescriptorTest.cpp
+++ b/ReactCommon/fabric/core/tests/ComponentDescriptorTest.cpp
@@ -22,11 +22,12 @@ TEST(ComponentDescriptorTest, createShadowNode) {
 
   const auto &raw = RawProps(folly::dynamic::object("nativeID", "abc"));
   SharedProps props = descriptor->cloneProps(nullptr, raw);
-  SharedShadowNode node = descriptor->createShadowNode(
-      ShadowNodeFragment{.tag = 9,
-                         .rootTag = 1,
-                         .props = props,
-                         .eventEmitter = descriptor->createEventEmitter(0, 9)});
+  SharedShadowNode node = descriptor->createShadowNode(ShadowNodeFragment{
+      9,                                    // tag
+      1,                                    // rootTag
+      props,                                // props
+      descriptor->createEventEmitter(0, 9), // eventEmitter
+  });
 
   ASSERT_EQ(node->getComponentHandle(), TestShadowNode::Handle());
   ASSERT_STREQ(
@@ -43,11 +44,12 @@ TEST(ComponentDescriptorTest, cloneShadowNode) {
 
   const auto &raw = RawProps(folly::dynamic::object("nativeID", "abc"));
   SharedProps props = descriptor->cloneProps(nullptr, raw);
-  SharedShadowNode node = descriptor->createShadowNode(
-      ShadowNodeFragment{.tag = 9,
-                         .rootTag = 1,
-                         .props = props,
-                         .eventEmitter = descriptor->createEventEmitter(0, 9)});
+  SharedShadowNode node = descriptor->createShadowNode(ShadowNodeFragment{
+      9,                                    // tag
+      1,                                    // rootTag
+      props,                                // props
+      descriptor->createEventEmitter(0, 9), // eventEmitter
+  });
   SharedShadowNode cloned = descriptor->cloneShadowNode(*node, {});
 
   ASSERT_STREQ(cloned->getComponentName().c_str(), "Test");
@@ -62,21 +64,24 @@ TEST(ComponentDescriptorTest, appendChild) {
 
   const auto &raw = RawProps(folly::dynamic::object("nativeID", "abc"));
   SharedProps props = descriptor->cloneProps(nullptr, raw);
-  SharedShadowNode node1 = descriptor->createShadowNode(
-      ShadowNodeFragment{.tag = 1,
-                         .rootTag = 1,
-                         .props = props,
-                         .eventEmitter = descriptor->createEventEmitter(0, 1)});
-  SharedShadowNode node2 = descriptor->createShadowNode(
-      ShadowNodeFragment{.tag = 2,
-                         .rootTag = 1,
-                         .props = props,
-                         .eventEmitter = descriptor->createEventEmitter(0, 2)});
-  SharedShadowNode node3 = descriptor->createShadowNode(
-      ShadowNodeFragment{.tag = 3,
-                         .rootTag = 1,
-                         .props = props,
-                         .eventEmitter = descriptor->createEventEmitter(0, 3)});
+  SharedShadowNode node1 = descriptor->createShadowNode(ShadowNodeFragment{
+      1,                                    // tag
+      1,                                    // rootTag
+      props,                                // props
+      descriptor->createEventEmitter(0, 1), // eventEmitter
+  });
+  SharedShadowNode node2 = descriptor->createShadowNode(ShadowNodeFragment{
+      2,                                    // tag
+      1,                                    // rootTag
+      props,                                // props
+      descriptor->createEventEmitter(0, 2), // eventEmitter
+  });
+  SharedShadowNode node3 = descriptor->createShadowNode(ShadowNodeFragment{
+      3,                                    // tag
+      1,                                    // rootTag
+      props,                                // props
+      descriptor->createEventEmitter(0, 3), // eventEmitter
+  });
 
   descriptor->appendChild(node1, node2);
   descriptor->appendChild(node1, node3);

--- a/ReactCommon/fabric/core/tests/ShadowNodeTest.cpp
+++ b/ReactCommon/fabric/core/tests/ShadowNodeTest.cpp
@@ -29,10 +29,12 @@ TEST(ShadowNodeTest, handleProps) {
 TEST(ShadowNodeTest, handleShadowNodeCreation) {
   auto node = std::make_shared<TestShadowNode>(
       ShadowNodeFragment{
-          .tag = 9,
-          .rootTag = 1,
-          .props = std::make_shared<const TestProps>(),
-          .children = ShadowNode::emptySharedShadowNodeSharedList()},
+          9,                                             // tag
+          1,                                             // rootTag
+          std::make_shared<const TestProps>(),           // props
+          ShadowNodeFragment::nullSharedEventEmitter(),  // eventEmitter
+          ShadowNode::emptySharedShadowNodeSharedList(), // children
+      },
       nullptr);
 
   ASSERT_FALSE(node->getSealed());
@@ -52,10 +54,12 @@ TEST(ShadowNodeTest, handleShadowNodeCreation) {
 TEST(ShadowNodeTest, handleShadowNodeSimpleCloning) {
   auto node = std::make_shared<TestShadowNode>(
       ShadowNodeFragment{
-          .tag = 9,
-          .rootTag = 1,
-          .props = std::make_shared<const TestProps>(),
-          .children = ShadowNode::emptySharedShadowNodeSharedList()},
+          9,                                             // tag
+          1,                                             // rootTag
+          std::make_shared<const TestProps>(),           // props
+          ShadowNodeFragment::nullSharedEventEmitter(),  // eventEmitter
+          ShadowNode::emptySharedShadowNodeSharedList(), // children
+      },
       nullptr);
   auto node2 = std::make_shared<TestShadowNode>(*node, ShadowNodeFragment{});
 
@@ -69,24 +73,30 @@ TEST(ShadowNodeTest, handleShadowNodeMutation) {
   auto props = std::make_shared<const TestProps>();
   auto node1 = std::make_shared<TestShadowNode>(
       ShadowNodeFragment{
-          .tag = 1,
-          .rootTag = 1,
-          .props = std::make_shared<const TestProps>(),
-          .children = ShadowNode::emptySharedShadowNodeSharedList()},
+          1,                                             // tag
+          1,                                             // rootTag
+          std::make_shared<const TestProps>(),           // props
+          ShadowNodeFragment::nullSharedEventEmitter(),  // eventEmitter
+          ShadowNode::emptySharedShadowNodeSharedList(), // children
+      },
       nullptr);
   auto node2 = std::make_shared<TestShadowNode>(
       ShadowNodeFragment{
-          .tag = 2,
-          .rootTag = 1,
-          .props = std::make_shared<const TestProps>(),
-          .children = ShadowNode::emptySharedShadowNodeSharedList()},
+          2,                                             // tag
+          1,                                             // rootTag
+          std::make_shared<const TestProps>(),           // props
+          ShadowNodeFragment::nullSharedEventEmitter(),  // eventEmitter
+          ShadowNode::emptySharedShadowNodeSharedList(), // children
+      },
       nullptr);
   auto node3 = std::make_shared<TestShadowNode>(
       ShadowNodeFragment{
-          .tag = 3,
-          .rootTag = 1,
-          .props = std::make_shared<const TestProps>(),
-          .children = ShadowNode::emptySharedShadowNodeSharedList()},
+          3,                                             // tag
+          1,                                             // rootTag
+          std::make_shared<const TestProps>(),           // props
+          ShadowNodeFragment::nullSharedEventEmitter(),  // eventEmitter
+          ShadowNode::emptySharedShadowNodeSharedList(), // children
+      },
       nullptr);
 
   node1->appendChild(node2);
@@ -120,10 +130,12 @@ TEST(ShadowNodeTest, handleShadowNodeMutation) {
 TEST(ShadowNodeTest, handleCloneFunction) {
   auto firstNode = std::make_shared<TestShadowNode>(
       ShadowNodeFragment{
-          .tag = 9,
-          .rootTag = 1,
-          .props = std::make_shared<const TestProps>(),
-          .children = ShadowNode::emptySharedShadowNodeSharedList()},
+          9,                                             // tag
+          1,                                             // rootTag
+          std::make_shared<const TestProps>(),           // props
+          ShadowNodeFragment::nullSharedEventEmitter(),  // eventEmitter
+          ShadowNode::emptySharedShadowNodeSharedList(), // children
+      },
       nullptr);
 
   // The shadow node is not clonable if `cloneFunction` is not provided,
@@ -131,10 +143,12 @@ TEST(ShadowNodeTest, handleCloneFunction) {
 
   auto secondNode = std::make_shared<TestShadowNode>(
       ShadowNodeFragment{
-          .tag = 9,
-          .rootTag = 1,
-          .props = std::make_shared<const TestProps>(),
-          .children = ShadowNode::emptySharedShadowNodeSharedList()},
+          9,                                             // tag
+          1,                                             // rootTag
+          std::make_shared<const TestProps>(),           // props
+          ShadowNodeFragment::nullSharedEventEmitter(),  // eventEmitter
+          ShadowNode::emptySharedShadowNodeSharedList(), // children
+      },
       [](const ShadowNode &shadowNode, const ShadowNodeFragment &fragment) {
         return std::make_shared<TestShadowNode>(shadowNode, fragment);
       });
@@ -167,24 +181,30 @@ TEST(ShadowNodeTest, handleLocalData) {
   auto props = std::make_shared<const TestProps>();
   auto firstNode = std::make_shared<TestShadowNode>(
       ShadowNodeFragment{
-          .tag = 9,
-          .rootTag = 1,
-          .props = props,
-          .children = ShadowNode::emptySharedShadowNodeSharedList()},
+          9,                                             // tag
+          1,                                             // rootTag
+          props,                                         // props
+          ShadowNodeFragment::nullSharedEventEmitter(),  // eventEmitter
+          ShadowNode::emptySharedShadowNodeSharedList(), // children
+      },
       nullptr);
   auto secondNode = std::make_shared<TestShadowNode>(
       ShadowNodeFragment{
-          .tag = 9,
-          .rootTag = 1,
-          .props = props,
-          .children = ShadowNode::emptySharedShadowNodeSharedList()},
+          9,                                             // tag
+          1,                                             // rootTag
+          props,                                         // props
+          ShadowNodeFragment::nullSharedEventEmitter(),  // eventEmitter
+          ShadowNode::emptySharedShadowNodeSharedList(), // children
+      },
       nullptr);
   auto thirdNode = std::make_shared<TestShadowNode>(
       ShadowNodeFragment{
-          .tag = 9,
-          .rootTag = 1,
-          .props = props,
-          .children = ShadowNode::emptySharedShadowNodeSharedList()},
+          9,                                             // tag
+          1,                                             // rootTag
+          props,                                         // props
+          ShadowNodeFragment::nullSharedEventEmitter(),  // eventEmitter
+          ShadowNode::emptySharedShadowNodeSharedList(), // children
+      },
       nullptr);
 
   firstNode->setLocalData(localData42);
@@ -220,46 +240,84 @@ TEST(ShadowNodeTest, handleBacktracking) {
 
   auto nodeAA = std::make_shared<TestShadowNode>(
       ShadowNodeFragment{
-          .props = props,
-          .children = ShadowNode::emptySharedShadowNodeSharedList()},
+          0,                                             // tag
+          0,                                             // rootTag
+          props,                                         // props
+          ShadowNodeFragment::nullSharedEventEmitter(),  // eventEmitter
+          ShadowNode::emptySharedShadowNodeSharedList(), // children
+      },
       nullptr);
 
   auto nodeABA = std::make_shared<TestShadowNode>(
       ShadowNodeFragment{
-          .props = props,
-          .children = ShadowNode::emptySharedShadowNodeSharedList()},
+          0,                                             // tag
+          0,                                             // rootTag
+          props,                                         // props
+          ShadowNodeFragment::nullSharedEventEmitter(),  // eventEmitter
+          ShadowNode::emptySharedShadowNodeSharedList(), // children
+      },
       nullptr);
   auto nodeABB = std::make_shared<TestShadowNode>(
       ShadowNodeFragment{
-          .props = props,
-          .children = ShadowNode::emptySharedShadowNodeSharedList()},
+          0,                                             // tag
+          0,                                             // rootTag
+          props,                                         // props
+          ShadowNodeFragment::nullSharedEventEmitter(),  // eventEmitter
+          ShadowNode::emptySharedShadowNodeSharedList(), // children
+      },
       nullptr);
   auto nodeABC = std::make_shared<TestShadowNode>(
       ShadowNodeFragment{
-          .props = props,
-          .children = ShadowNode::emptySharedShadowNodeSharedList()},
+          0,                                             // tag
+          0,                                             // rootTag
+          props,                                         // props
+          ShadowNodeFragment::nullSharedEventEmitter(),  // eventEmitter
+          ShadowNode::emptySharedShadowNodeSharedList(), // children
+      },
       nullptr);
 
   auto nodeABChildren = std::make_shared<std::vector<SharedShadowNode>>(
       std::vector<SharedShadowNode>{nodeABA, nodeABB, nodeABC});
   auto nodeAB = std::make_shared<TestShadowNode>(
-      ShadowNodeFragment{.props = props, .children = nodeABChildren}, nullptr);
+      ShadowNodeFragment{
+          0,                                            // tag
+          0,                                            // rootTag
+          props,                                        // props
+          ShadowNodeFragment::nullSharedEventEmitter(), // eventEmitter
+          nodeABChildren,                               // children
+      },
+      nullptr);
 
   auto nodeAC = std::make_shared<TestShadowNode>(
       ShadowNodeFragment{
-          .props = props,
-          .children = ShadowNode::emptySharedShadowNodeSharedList()},
+          0,                                             // tag
+          0,                                             // rootTag
+          props,                                         // props
+          ShadowNodeFragment::nullSharedEventEmitter(),  // eventEmitter
+          ShadowNode::emptySharedShadowNodeSharedList(), // children
+      },
       nullptr);
 
   auto nodeAChildren = std::make_shared<std::vector<SharedShadowNode>>(
       std::vector<SharedShadowNode>{nodeAA, nodeAB, nodeAC});
   auto nodeA = std::make_shared<TestShadowNode>(
-      ShadowNodeFragment{.props = props, .children = nodeAChildren}, nullptr);
+      ShadowNodeFragment{
+          0,                                            // tag
+          0,                                            // rootTag
+          props,                                        // props
+          ShadowNodeFragment::nullSharedEventEmitter(), // eventEmitter
+          nodeAChildren,                                // children
+      },
+      nullptr);
 
   auto nodeZ = std::make_shared<TestShadowNode>(
       ShadowNodeFragment{
-          .props = props,
-          .children = ShadowNode::emptySharedShadowNodeSharedList()},
+          0,                                             // tag
+          0,                                             // rootTag
+          props,                                         // props
+          ShadowNodeFragment::nullSharedEventEmitter(),  // eventEmitter
+          ShadowNode::emptySharedShadowNodeSharedList(), // children
+      },
       nullptr);
 
   std::vector<std::reference_wrapper<const ShadowNode>> ancestors = {};

--- a/ReactCommon/fabric/debug/DebugStringConvertibleItem.h
+++ b/ReactCommon/fabric/debug/DebugStringConvertibleItem.h
@@ -21,7 +21,6 @@ namespace react {
 // in custom implementations of `getDebugChildren` and `getDebugProps`.
 class DebugStringConvertibleItem : public DebugStringConvertible {
  public:
-  DebugStringConvertibleItem() = default;
   DebugStringConvertibleItem(const DebugStringConvertibleItem &item) = default;
 
   DebugStringConvertibleItem(

--- a/ReactCommon/fabric/events/EventBeatBasedExecutor.cpp
+++ b/ReactCommon/fabric/events/EventBeatBasedExecutor.cpp
@@ -27,15 +27,19 @@ EventBeatBasedExecutor::EventBeatBasedExecutor(
 
 void EventBeatBasedExecutor::operator()(Routine routine, Mode mode) const {
   if (mode == Mode::Asynchronous) {
-    execute({.routine = std::move(routine)});
+    execute({
+        std::move(routine), // routine
+    });
     return;
   }
 
   std::mutex mutex;
   mutex.lock();
 
-  execute({.routine = std::move(routine),
-           .callback = [&mutex]() { mutex.unlock(); }});
+  execute({
+      std::move(routine),             // routine
+      [&mutex]() { mutex.unlock(); }, // callback
+  });
 
   mutex.lock();
 }

--- a/ReactCommon/fabric/mounting/ShadowViewMutation.cpp
+++ b/ReactCommon/fabric/mounting/ShadowViewMutation.cpp
@@ -11,32 +11,49 @@ namespace facebook {
 namespace react {
 
 ShadowViewMutation ShadowViewMutation::CreateMutation(ShadowView shadowView) {
-  return ShadowViewMutation{
-      .type = Create, .newChildShadowView = shadowView, .index = -1};
+  return {
+      Create,     // type
+      {},         // parentShadowView
+      shadowView, // newChildShadowView
+      {},         // oldChildShadowView
+      -1,         // index
+  };
 }
 
 ShadowViewMutation ShadowViewMutation::DeleteMutation(ShadowView shadowView) {
-  return {.type = Delete, .oldChildShadowView = shadowView, .index = -1};
+  return {
+      Delete,     // type
+      {},         // parentShadowView
+      shadowView, // oldChildShadowView
+      {},         // newChildShadowView
+      -1,         // index
+  };
 }
 
 ShadowViewMutation ShadowViewMutation::InsertMutation(
     ShadowView parentShadowView,
     ShadowView childShadowView,
     int index) {
-  return {.type = Insert,
-          .parentShadowView = parentShadowView,
-          .newChildShadowView = childShadowView,
-          .index = index};
+  return {
+      Insert,           // type
+      parentShadowView, // parentShadowView
+      {},               // oldChildShadowView
+      childShadowView,  // newChildShadowView
+      index,            // index
+  };
 }
 
 ShadowViewMutation ShadowViewMutation::RemoveMutation(
     ShadowView parentShadowView,
     ShadowView childShadowView,
     int index) {
-  return {.type = Remove,
-          .parentShadowView = parentShadowView,
-          .oldChildShadowView = childShadowView,
-          .index = index};
+  return {
+      Remove,           // type
+      parentShadowView, // parentShadowView
+      childShadowView,  // oldChildShadowView
+      {},               // newChildShadowView
+      index,            // index
+  };
 }
 
 ShadowViewMutation ShadowViewMutation::UpdateMutation(
@@ -44,11 +61,13 @@ ShadowViewMutation ShadowViewMutation::UpdateMutation(
     ShadowView oldChildShadowView,
     ShadowView newChildShadowView,
     int index) {
-  return {.type = Update,
-          .parentShadowView = parentShadowView,
-          .oldChildShadowView = oldChildShadowView,
-          .newChildShadowView = newChildShadowView,
-          .index = index};
+  return {
+      Update,             // type
+      parentShadowView,   // parentShadowView
+      oldChildShadowView, // oldChildShadowView
+      newChildShadowView, // newChildShadowView
+      index,              // index
+  };
 }
 
 } // namespace react

--- a/ReactCommon/fabric/uimanager/ComponentDescriptorRegistry.cpp
+++ b/ReactCommon/fabric/uimanager/ComponentDescriptorRegistry.cpp
@@ -113,12 +113,13 @@ SharedShadowNode ComponentDescriptorRegistry::createNode(
   ComponentName componentName = componentNameByReactViewName(viewName);
   const SharedComponentDescriptor &componentDescriptor = (*this)[componentName];
 
-  SharedShadowNode shadowNode = componentDescriptor->createShadowNode(
-      {.tag = tag,
-       .rootTag = rootTag,
-       .eventEmitter =
-           componentDescriptor->createEventEmitter(std::move(eventTarget), tag),
-       .props = componentDescriptor->cloneProps(nullptr, RawProps(props))});
+  SharedShadowNode shadowNode = componentDescriptor->createShadowNode({
+      tag,                                                       // tag
+      rootTag,                                                   // rootTag
+      componentDescriptor->cloneProps(nullptr, RawProps(props)), // props
+      componentDescriptor->createEventEmitter(
+          std::move(eventTarget), tag), // eventEmitter
+  });
   return shadowNode;
 }
 

--- a/ReactCommon/fabric/uimanager/Scheduler.cpp
+++ b/ReactCommon/fabric/uimanager/Scheduler.cpp
@@ -105,9 +105,15 @@ void Scheduler::renderTemplateToSurface(
           [&](const SharedRootShadowNode &oldRootShadowNode) {
             return std::make_shared<RootShadowNode>(
                 *oldRootShadowNode,
-                ShadowNodeFragment{.children =
-                                       std::make_shared<SharedShadowNodeList>(
-                                           SharedShadowNodeList{tree})});
+                ShadowNodeFragment{
+                    0,                                     // tag
+                    0,                                     // rootTag
+                    ShadowNodeFragment::nullSharedProps(), // sharedProps
+                    ShadowNodeFragment::
+                        nullSharedEventEmitter(), // eventEmitter
+                    std::make_shared<SharedShadowNodeList>(
+                        SharedShadowNodeList{tree}), // children
+                });
           },
           commitStartTime);
     });
@@ -127,8 +133,13 @@ void Scheduler::stopSurface(SurfaceId surfaceId) const {
               return std::make_shared<RootShadowNode>(
                   *oldRootShadowNode,
                   ShadowNodeFragment{
-                      .children =
-                          ShadowNode::emptySharedShadowNodeSharedList()});
+                      0,                                     // tag
+                      0,                                     // rootTag
+                      ShadowNodeFragment::nullSharedProps(), // sharedProps
+                      ShadowNodeFragment::
+                          nullSharedEventEmitter(), // eventEmitter
+                      ShadowNode::emptySharedShadowNodeSharedList(), // children
+                  });
             },
             commitStartTime);
       });
@@ -213,7 +224,13 @@ void Scheduler::uiManagerDidFinishTransaction(
         [&](const SharedRootShadowNode &oldRootShadowNode) {
           return std::make_shared<RootShadowNode>(
               *oldRootShadowNode,
-              ShadowNodeFragment{.children = rootChildNodes});
+              ShadowNodeFragment{
+                  0,                                            // tag
+                  0,                                            // rootTag
+                  ShadowNodeFragment::nullSharedProps(),        // sharedProps
+                  ShadowNodeFragment::nullSharedEventEmitter(), // eventEmitter
+                  rootChildNodes,                               // children
+              });
         },
         startCommitTime);
   });

--- a/ReactCommon/fabric/uimanager/ShadowTree.cpp
+++ b/ReactCommon/fabric/uimanager/ShadowTree.cpp
@@ -88,10 +88,10 @@ ShadowTree::ShadowTree(
 
   rootShadowNode_ = std::make_shared<RootShadowNode>(
       ShadowNodeFragment{
-          .tag = surfaceId,
-          .rootTag = surfaceId,
-          .props = props,
-          .eventEmitter = noopEventEmitter,
+          surfaceId,        // tag
+          surfaceId,        // rootTag
+          props,            // props
+          noopEventEmitter, // eventEmitter
       },
       nullptr);
 }
@@ -102,7 +102,12 @@ ShadowTree::~ShadowTree() {
         return std::make_shared<RootShadowNode>(
             *oldRootShadowNode,
             ShadowNodeFragment{
-                .children = ShadowNode::emptySharedShadowNodeSharedList()});
+                0,                                             // tag
+                0,                                             // rootTag
+                ShadowNodeFragment::nullSharedProps(),         // props
+                ShadowNodeFragment::nullSharedEventEmitter(),  // eventEmitter
+                ShadowNode::emptySharedShadowNodeSharedList(), // children
+            });
       },
       getTime());
 }


### PR DESCRIPTION
## Summary

This pull request modifies the source code in the `ReactCommon/fabric` directory so it will build on MSVC 2017

The following changes have been done:

 * Removed the usages of designated initializers and replaced them with list initializers. This is the vast majority of the changes done to Fabric
 * Changed the rule `AlignTrailingComments` in the `.clang-format` file to `true` so the comments on the initializers are nicely organized like this:
```cpp
    newChild = oldChild->clone({
        0,                                            // tag
        0,                                            // rootTag
        ShadowNodeFragment::nullSharedProps(),        // props
        ShadowNodeFragment::nullSharedEventEmitter(), // eventEmitter
        sharedChildren,                               // children
    });
```
* Changed the null coalescing operator usage (`?:`) to a ternary in `ReactCommon/fabric/core/shadownode/ShadowNode.cpp`
* Removed default constructor in `ReactCommon/fabric/debug/DebugStringConvertibleItem.h` that was conflicting with the constructor that has all default values - MSVC had issues with this

## Changelog

[General] [Fixed] - Fixed Fabric compilation on MSVC

## Test Plan

The Fabric test suite has been ran on builds made with Windows + MSVC 2017 and Ubuntu 18.10 + Clang 7.0.0, and all tests pass on both platforms

```
[----------] Global test environment tear-down
[==========] 31 tests from 17 test suites ran. (573 ms total)
[  PASSED  ] 31 tests.
```