### PR TITLE
switch to official node image in ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -346,13 +346,11 @@ jobs:
       - store_test_results:
           path: ~/react-native/reports/junit
 
-  # Run JavaScript tests on Node 10
+  # Run JavaScript tests on Node lts
   test_node10:
     <<: *defaults
     docker:
-      - image: circleci/node:10
-    environment:
-      - PATH: "/opt/yarn/yarn-v1.5.1/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+      - image: node:lts
     steps:
       - checkout
       - run: *setup-artifacts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -346,7 +346,7 @@ jobs:
       - store_test_results:
           path: ~/react-native/reports/junit
 
-  # Run JavaScript tests on Node lts
+  # Run JavaScript tests on Node LTS
   test_node_lts:
     <<: *defaults
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -347,7 +347,7 @@ jobs:
           path: ~/react-native/reports/junit
 
   # Run JavaScript tests on Node lts
-  test_node10:
+  test_node_lts:
     <<: *defaults
     docker:
       - image: node:lts
@@ -615,7 +615,7 @@ workflows:
             - checkout_code
 
       # Tooling Compatibility Checks
-      - test_node10:
+      - test_node_lts:
           filters: *filter-ignore-gh-pages
 
   releases:


### PR DESCRIPTION
## Summary
The official node image bundled with yarn by default, and it has maintained by the official group so we can always get the latest version.

## Test Plan

pass current ci.
