### PR TITLE
switch node 8 image to official one

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -276,9 +276,7 @@ defaults: &defaults
 js_defaults: &js_defaults
   <<: *defaults
   docker:
-    - image: circleci/node:8
-  environment:
-    - PATH: "/opt/yarn/yarn-v1.5.1/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+    - image: node:8
 
 android_defaults: &android_defaults
   <<: *defaults


### PR DESCRIPTION
## Summary

node 8 image has yarn too. Also the official one has the latest yarn.

## Test Plan

pass current ci.
