### PR TITLE
Resolves #23390: cxxreact, jsi and jsiexecutor depends on DoubleConversion and glog.

### DIFF
--- a/React.podspec
+++ b/React.podspec
@@ -116,6 +116,8 @@ Pod::Spec.new do |s|
     ss.dependency             "React/cxxreact"
     ss.dependency             "React/jsi"
     ss.dependency             "Folly", folly_version
+    ss.dependency             "DoubleConversion"
+    ss.dependency             "glog"
     ss.compiler_flags       = folly_compiler_flags
     ss.source_files         = "ReactCommon/jsiexecutor/jsireact/*.{cpp,h}"
     ss.private_header_files = "ReactCommon/jsiexecutor/jsireact/*.h"
@@ -125,6 +127,8 @@ Pod::Spec.new do |s|
 
   s.subspec "jsi" do |ss|
     ss.dependency             "Folly", folly_version
+    ss.dependency             "DoubleConversion"
+    ss.dependency             "glog"
     ss.compiler_flags       = folly_compiler_flags
     ss.source_files         = "ReactCommon/jsi/*.{cpp,h}"
     ss.private_header_files = "ReactCommon/jsi/*.h"
@@ -142,6 +146,8 @@ Pod::Spec.new do |s|
     ss.dependency             "React/jsinspector"
     ss.dependency             "boost-for-react-native", "1.63.0"
     ss.dependency             "Folly", folly_version
+    ss.dependency             "DoubleConversion"
+    ss.dependency             "glog"
     ss.compiler_flags       = folly_compiler_flags
     ss.source_files         = "ReactCommon/cxxreact/*.{cpp,h}"
     ss.exclude_files        = "ReactCommon/cxxreact/SampleCxxModule.*"


### PR DESCRIPTION

## Summary

Resolves #23390: **cxxreact**, **jsi** and **jsiexecutor** depends on **DoubleConversion** and **glog**.

This cause:
```
Undefined symbols for architecture x86_64:
  "google::LogMessage::LogMessage(char const*, int, int)", referenced from:
      std::__1::__function::__func<facebook::react::CxxNativeModule::invoke(unsigned int, folly::dynamic&&, int)::$_1, std::__1::allocator<facebook::react::CxxNativeModule::invoke(unsigned int, folly::dynamic&&, int)::$_1>, void ()>::operator()() in CxxNativeModule.o
      std::__1::__function::__func<facebook::react::NativeToJsBridge::callFunction(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&&, folly::dynamic&&)::$_1, std::__1::allocator<facebook::react::NativeToJsBridge::callFunction(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&&, folly::dynamic&&)::$_1>, void (facebook::react::JSExecutor*)>::operator()(facebook::react::JSExecutor*&&) in NativeToJsBridge.o
      std::__1::__function::__func<facebook::react::NativeToJsBridge::invokeCallback(double, folly::dynamic&&)::$_2, std::__1::allocator<facebook::react::NativeToJsBridge::invokeCallback(double, folly::dynamic&&)::$_2>, void (facebook::react::JSExecutor*)>::operator()(facebook::react::JSExecutor*&&) in NativeToJsBridge.o
  "double_conversion::DoubleToStringConverter::ToShortestIeeeNumber(double, double_conversion::StringBuilder*, double_conversion::DoubleToStringConverter::DtoaMode) const", referenced from:
      std::__1::enable_if<(std::is_floating_point<double>::value) && (IsSomeString<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >::value), void>::type folly::toAppend<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, double>(double, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >*, double_conversion::DoubleToStringConverter::DtoaMode, unsigned int) in CxxNativeModule.o
      std::__1::enable_if<(std::is_floating_point<double>::value) && (IsSomeString<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >::value), void>::type folly::toAppend<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, double>(double, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >*, double_conversion::DoubleToStringConverter::DtoaMode, unsigned int) in JSIDynamic.o
      double_conversion::DoubleToStringConverter::ToShortest(double, double_conversion::StringBuilder*) const in JSIDynamic.o
      double_conversion::DoubleToStringConverter::ToShortestSingle(float, double_conversion::StringBuilder*) const in JSIDynamic.o
      std::__1::enable_if<(std::is_floating_point<double>::value) && (IsSomeString<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >::value), void>::type folly::toAppend<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, double>(double, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >*, double_conversion::DoubleToStringConverter::DtoaMode, unsigned int) in JSIExecutor.o
      std::__1::enable_if<(std::is_floating_point<double>::value) && (IsSomeString<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >::value), void>::type folly::toAppend<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, double>(double, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >*, double_conversion::DoubleToStringConverter::DtoaMode, unsigned int) in MethodCall.o
  "double_conversion::DoubleToStringConverter::ToFixed(double, int, double_conversion::StringBuilder*) const", referenced from:
      std::__1::enable_if<(std::is_floating_point<double>::value) && (IsSomeString<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >::value), void>::type folly::toAppend<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, double>(double, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >*, double_conversion::DoubleToStringConverter::DtoaMode, unsigned int) in CxxNativeModule.o
      std::__1::enable_if<(std::is_floating_point<double>::value) && (IsSomeString<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >::value), void>::type folly::toAppend<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, double>(double, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >*, double_conversion::DoubleToStringConverter::DtoaMode, unsigned int) in JSIDynamic.o
      std::__1::enable_if<(std::is_floating_point<double>::value) && (IsSomeString<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >::value), void>::type folly::toAppend<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, double>(double, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >*, double_conversion::DoubleToStringConverter::DtoaMode, unsigned int) in JSIExecutor.o
      std::__1::enable_if<(std::is_floating_point<double>::value) && (IsSomeString<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >::value), void>::type folly::toAppend<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, double>(double, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >*, double_conversion::DoubleToStringConverter::DtoaMode, unsigned int) in MethodCall.o
  "google::LogMessageFatal::LogMessageFatal(char const*, int)", referenced from:
      std::__1::enable_if<(std::is_floating_point<double>::value) && (IsSomeString<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >::value), void>::type folly::toAppend<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, double>(double, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >*, double_conversion::DoubleToStringConverter::DtoaMode, unsigned int) in CxxNativeModule.o
      facebook::react::Instance::initializeBridge(std::__1::unique_ptr<facebook::react::InstanceCallback, std::__1::default_delete<facebook::react::InstanceCallback> >, std::__1::shared_ptr<facebook::react::JSExecutorFactory>, std::__1::shared_ptr<facebook::react::MessageQueueThread>, std::__1::shared_ptr<facebook::react::ModuleRegistry>) in Instance.o
      folly::detail::ScopeGuardImpl<facebook::react::JSBigFileString::fromPath(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&)::$_0, true>::~ScopeGuardImpl() in JSBigString.o
      facebook::react::JSBigFileString::c_str() const in JSBigString.o
      facebook::jsi::valueFromDynamic(facebook::jsi::Runtime&, folly::dynamic const&) in JSIDynamic.o
      std::__1::enable_if<(std::is_floating_point<double>::value) && (IsSomeString<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >::value), void>::type folly::toAppend<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, double>(double, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >*, double_conversion::DoubleToStringConverter::DtoaMode, unsigned int) in JSIDynamic.o
      facebook::react::JSIExecutor::callNativeModules(facebook::jsi::Value const&, bool) in JSIExecutor.o
      ...
  "double_conversion::DoubleToStringConverter::ToPrecision(double, int, double_conversion::StringBuilder*) const", referenced from:
      std::__1::enable_if<(std::is_floating_point<double>::value) && (IsSomeString<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >::value), void>::type folly::toAppend<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, double>(double, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >*, double_conversion::DoubleToStringConverter::DtoaMode, unsigned int) in CxxNativeModule.o
      std::__1::enable_if<(std::is_floating_point<double>::value) && (IsSomeString<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >::value), void>::type folly::toAppend<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, double>(double, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >*, double_conversion::DoubleToStringConverter::DtoaMode, unsigned int) in JSIDynamic.o
      std::__1::enable_if<(std::is_floating_point<double>::value) && (IsSomeString<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >::value), void>::type folly::toAppend<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, double>(double, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >*, double_conversion::DoubleToStringConverter::DtoaMode, unsigned int) in JSIExecutor.o
      std::__1::enable_if<(std::is_floating_point<double>::value) && (IsSomeString<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >::value), void>::type folly::toAppend<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, double>(double, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >*, double_conversion::DoubleToStringConverter::DtoaMode, unsigned int) in MethodCall.o
  "google::LogMessage::stream()", referenced from:
      std::__1::enable_if<(std::is_floating_point<double>::value) && (IsSomeString<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >::value), void>::type folly::toAppend<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, double>(double, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >*, double_conversion::DoubleToStringConverter::DtoaMode, unsigned int) in CxxNativeModule.o
      std::__1::__function::__func<facebook::react::CxxNativeModule::invoke(unsigned int, folly::dynamic&&, int)::$_1, std::__1::allocator<facebook::react::CxxNativeModule::invoke(unsigned int, folly::dynamic&&, int)::$_1>, void ()>::operator()() in CxxNativeModule.o
      facebook::react::Instance::initializeBridge(std::__1::unique_ptr<facebook::react::InstanceCallback, std::__1::default_delete<facebook::react::InstanceCallback> >, std::__1::shared_ptr<facebook::react::JSExecutorFactory>, std::__1::shared_ptr<facebook::react::MessageQueueThread>, std::__1::shared_ptr<facebook::react::ModuleRegistry>) in Instance.o
      folly::detail::ScopeGuardImpl<facebook::react::JSBigFileString::fromPath(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&)::$_0, true>::~ScopeGuardImpl() in JSBigString.o
      facebook::react::JSBigFileString::c_str() const in JSBigString.o
      facebook::jsi::valueFromDynamic(facebook::jsi::Runtime&, folly::dynamic const&) in JSIDynamic.o
      std::__1::enable_if<(std::is_floating_point<double>::value) && (IsSomeString<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >::value), void>::type folly::toAppend<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, double>(double, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >*, double_conversion::DoubleToStringConverter::DtoaMode, unsigned int) in JSIDynamic.o
      ...
  "google::LogMessage::~LogMessage()", referenced from:
      std::__1::__function::__func<facebook::react::CxxNativeModule::invoke(unsigned int, folly::dynamic&&, int)::$_1, std::__1::allocator<facebook::react::CxxNativeModule::invoke(unsigned int, folly::dynamic&&, int)::$_1>, void ()>::operator()() in CxxNativeModule.o
      std::__1::__function::__func<facebook::react::NativeToJsBridge::callFunction(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&&, folly::dynamic&&)::$_1, std::__1::allocator<facebook::react::NativeToJsBridge::callFunction(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&&, folly::dynamic&&)::$_1>, void (facebook::react::JSExecutor*)>::operator()(facebook::react::JSExecutor*&&) in NativeToJsBridge.o
      std::__1::__function::__func<facebook::react::NativeToJsBridge::invokeCallback(double, folly::dynamic&&)::$_2, std::__1::allocator<facebook::react::NativeToJsBridge::invokeCallback(double, folly::dynamic&&)::$_2>, void (facebook::react::JSExecutor*)>::operator()(facebook::react::JSExecutor*&&) in NativeToJsBridge.o
  "google::LogMessageFatal::~LogMessageFatal()", referenced from:
      std::__1::enable_if<(std::is_floating_point<double>::value) && (IsSomeString<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >::value), void>::type folly::toAppend<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, double>(double, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >*, double_conversion::DoubleToStringConverter::DtoaMode, unsigned int) in CxxNativeModule.o
      facebook::react::Instance::initializeBridge(std::__1::unique_ptr<facebook::react::InstanceCallback, std::__1::default_delete<facebook::react::InstanceCallback> >, std::__1::shared_ptr<facebook::react::JSExecutorFactory>, std::__1::shared_ptr<facebook::react::MessageQueueThread>, std::__1::shared_ptr<facebook::react::ModuleRegistry>) in Instance.o
      folly::detail::ScopeGuardImpl<facebook::react::JSBigFileString::fromPath(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&)::$_0, true>::~ScopeGuardImpl() in JSBigString.o
      facebook::react::JSBigFileString::c_str() const in JSBigString.o
      facebook::jsi::valueFromDynamic(facebook::jsi::Runtime&, folly::dynamic const&) in JSIDynamic.o
      std::__1::enable_if<(std::is_floating_point<double>::value) && (IsSomeString<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >::value), void>::type folly::toAppend<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, double>(double, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >*, double_conversion::DoubleToStringConverter::DtoaMode, unsigned int) in JSIDynamic.o
      facebook::react::JSIExecutor::callNativeModules(facebook::jsi::Value const&, bool) in JSIExecutor.o
      ...
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

## Changelog

[iOS] [Fixed] - Added `DoubleConversion` and `glog` to `cxxreact`, `jsi` and `jsiexecutor` subspecs in `React.podspec` file.

The goal of this PR is to have no need to fix #23390 by manually adding **DoubleConversion** and **glog** to _Link Binary With Libraries_ of **React** framework target in @cocoapods project.

![captura de pantalla 2019-02-12 a las 17 12 05](https://user-images.githubusercontent.com/297950/52650102-deb25e80-2ee9-11e9-9595-f7fbd4730671.png)

## Test Plan

[Here's](https://github.com/alexruperez/ReactNative23390) a sample project that reproduces the compilation error.
