### PR TITLE
bump targetSdkVersion to 28

### DIFF
--- a/RNTester/android/app/build.gradle
+++ b/RNTester/android/app/build.gradle
@@ -101,7 +101,7 @@ android {
     defaultConfig {
         applicationId "com.facebook.react.uiapp"
         minSdkVersion 16
-        targetSdkVersion 27
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
     }

--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -274,7 +274,7 @@ android {
 
     defaultConfig {
         minSdkVersion(16)
-        targetSdkVersion(27)
+        targetSdkVersion(28)
         versionCode(1)
         versionName("1.0")
 

--- a/template/android/build.gradle
+++ b/template/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         buildToolsVersion = "28.0.3"
         minSdkVersion = 16
         compileSdkVersion = 28
-        targetSdkVersion = 27
+        targetSdkVersion = 28
         supportLibVersion = "28.0.0"
     }
     repositories {


### PR DESCRIPTION
## Summary

Bump targetSdkVersion to 28

## Changelog

[Android] [Changed] - Bump targetSdkVersion to 28

## Test Plan

CI is green, and apps will work as usual.