### PR TITLE
Fabric/DebugStringConvertibleItem.h: Fix for MSVC

### DIFF
--- a/ReactCommon/fabric/debug/DebugStringConvertibleItem.h
+++ b/ReactCommon/fabric/debug/DebugStringConvertibleItem.h
@@ -21,7 +21,6 @@ namespace react {
 // in custom implementations of `getDebugChildren` and `getDebugProps`.
 class DebugStringConvertibleItem : public DebugStringConvertible {
  public:
-  DebugStringConvertibleItem() = default;
   DebugStringConvertibleItem(const DebugStringConvertibleItem &item) = default;
 
   DebugStringConvertibleItem(


### PR DESCRIPTION
## Summary

This pull request removes a constructor in `DebugStringConvertibleItem.h` that was causing this issue in MSVC:

```
DebugStringConvertibleItem.cpp(20): error C2600: 'facebook::react::DebugStringConvertibleItem::DebugStringConvertibleItem': cannot define a compiler-generated special member function (must be declared in the class first)
```

It was likely conflicting with the constructor that has default values for all of its arguments.

## Changelog

[General] [Fixed] - Fixed `DebugStringConvertibleItem` compilation on MSVC

## Test Plan

`DebugStringConvertibleXXXXX` now builds on MSVC, and also the build has been verified on Ubuntu 18.10 + Clang