### PR TITLE
Fabric: Change naming scheme of `ShadowNodeFragment` placeholders

### DIFF
--- a/ReactCommon/fabric/core/shadownode/ShadowNodeFragment.cpp
+++ b/ReactCommon/fabric/core/shadownode/ShadowNodeFragment.cpp
@@ -10,22 +10,30 @@
 namespace facebook {
 namespace react {
 
-SharedProps &ShadowNodeFragment::nullSharedProps() {
+Tag ShadowNodeFragment::tagPlaceholder() {
+  return 0;
+}
+
+Tag ShadowNodeFragment::surfaceIdPlaceholder() {
+  return 0;
+}
+
+SharedProps &ShadowNodeFragment::propsPlaceholder() {
   static auto &instance = *new SharedProps();
   return instance;
 }
 
-SharedEventEmitter &ShadowNodeFragment::nullSharedEventEmitter() {
+SharedEventEmitter &ShadowNodeFragment::eventEmitterPlaceholder() {
   static auto &instance = *new SharedEventEmitter();
   return instance;
 }
 
-SharedShadowNodeSharedList &ShadowNodeFragment::nullSharedChildren() {
+SharedShadowNodeSharedList &ShadowNodeFragment::childrenPlaceholder() {
   static auto &instance = *new SharedShadowNodeSharedList();
   return instance;
 }
 
-SharedLocalData &ShadowNodeFragment::nullLocalData() {
+SharedLocalData &ShadowNodeFragment::localDataPlaceholder() {
   static auto &instance = *new SharedLocalData();
   return instance;
 }

--- a/ReactCommon/fabric/core/shadownode/ShadowNodeFragment.h
+++ b/ReactCommon/fabric/core/shadownode/ShadowNodeFragment.h
@@ -26,15 +26,17 @@ namespace react {
 struct ShadowNodeFragment {
   Tag tag = 0;
   Tag rootTag = 0;
-  const SharedProps &props = nullSharedProps();
-  const SharedEventEmitter &eventEmitter = nullSharedEventEmitter();
-  const SharedShadowNodeSharedList &children = nullSharedChildren();
-  const SharedLocalData &localData = nullLocalData();
+  const SharedProps &props = propsPlaceholder();
+  const SharedEventEmitter &eventEmitter = eventEmitterPlaceholder();
+  const SharedShadowNodeSharedList &children = childrenPlaceholder();
+  const SharedLocalData &localData = localDataPlaceholder();
 
-  static SharedProps &nullSharedProps();
-  static SharedEventEmitter &nullSharedEventEmitter();
-  static SharedShadowNodeSharedList &nullSharedChildren();
-  static SharedLocalData &nullLocalData();
+  static Tag tagPlaceholder();
+  static Tag surfaceIdPlaceholder();
+  static SharedProps &propsPlaceholder();
+  static SharedEventEmitter &eventEmitterPlaceholder();
+  static SharedShadowNodeSharedList &childrenPlaceholder();
+  static SharedLocalData &localDataPlaceholder();
 };
 
 } // namespace react

--- a/ReactCommon/fabric/uimanager/UIManager.cpp
+++ b/ReactCommon/fabric/uimanager/UIManager.cpp
@@ -47,7 +47,7 @@ SharedShadowNode UIManager::cloneNode(
       {
           .props = rawProps ? componentDescriptor.cloneProps(
                                   shadowNode->getProps(), *rawProps)
-                            : ShadowNodeFragment::nullSharedProps(),
+                            : ShadowNodeFragment::propsPlaceholder(),
           .children = children,
       });
 


### PR DESCRIPTION
## Summary

This pull request implements some suggestions made in #23414, namely:

* Rename `ShadowNodeFragment::nullSharedProps()` (and family) to `ShadowNodeFragment::propsPlaceholder()`;
* Introduce similar functions for the rest of members (tag and rootTag);

Later pull requests to remove designated initializers from Fabric (for MSVC support) will use these

I'd like to do the rename of `rootTag` to `surfaceId` as well, but would make sense to do in a separate diff as that would result in a great deal of changes.

## Changelog

[General] [Changed] - Changed naming scheme of `ShadowNodeFragment` placeholders, and added placeholders for remaining members

## Test Plan

Fabric test suite runs and passes on Ubuntu 18.10 + Clang 7