### PR TITLE
Fabric: Remove designated initializers in Image

### DIFF
--- a/ReactCommon/fabric/components/image/ImageShadowNode.cpp
+++ b/ReactCommon/fabric/components/image/ImageShadowNode.cpp
@@ -49,7 +49,7 @@ ImageSource ImageShadowNode::getImageSource() const {
 
   if (sources.size() == 0) {
     return {
-        ImageSource::Type::Invalid // type
+        /* .type = */ ImageSource::Type::Invalid,
     };
   }
 

--- a/ReactCommon/fabric/components/image/ImageShadowNode.cpp
+++ b/ReactCommon/fabric/components/image/ImageShadowNode.cpp
@@ -48,7 +48,9 @@ ImageSource ImageShadowNode::getImageSource() const {
   auto sources = getProps()->sources;
 
   if (sources.size() == 0) {
-    return {.type = ImageSource::Type::Invalid};
+    return {
+        ImageSource::Type::Invalid // type
+    };
   }
 
   if (sources.size() == 1) {

--- a/ReactCommon/fabric/components/image/conversions.h
+++ b/ReactCommon/fabric/components/image/conversions.h
@@ -16,7 +16,10 @@ namespace react {
 
 inline void fromRawValue(const RawValue &value, ImageSource &result) {
   if (value.hasType<std::string>()) {
-    result = {.type = ImageSource::Type::Remote, .uri = (std::string)value};
+    result = {
+        ImageSource::Type::Remote, // type
+        (std::string)value // uri
+    };
     return;
   }
 

--- a/ReactCommon/fabric/components/image/conversions.h
+++ b/ReactCommon/fabric/components/image/conversions.h
@@ -17,8 +17,8 @@ namespace react {
 inline void fromRawValue(const RawValue &value, ImageSource &result) {
   if (value.hasType<std::string>()) {
     result = {
-        ImageSource::Type::Remote, // type
-        (std::string)value // uri
+        /* .type = */ ImageSource::Type::Remote,
+        /* .uri = */ (std::string)value,
     };
     return;
   }


### PR DESCRIPTION
## Summary

This pull request removes the designated initializers in `react/components/image/**` to improve portability.

## Changelog

[General] [Changed] - Fabric: Remove designated initializers in Image

## Test Plan

Tests build and pass in Ubuntu 18.10 + Clang 7