### PR TITLE
Fabric: Remove designated initializers in View

### DIFF
--- a/ReactCommon/fabric/components/view/ViewProps.cpp
+++ b/ReactCommon/fabric/components/view/ViewProps.cpp
@@ -79,23 +79,25 @@ ViewProps::ViewProps(const ViewProps &sourceProps, const RawProps &rawProps)
 
 BorderMetrics ViewProps::resolveBorderMetrics(bool isRTL) const {
   auto borderWidths = CascadedBorderWidths{
-      optionalFloatFromYogaValue(yogaStyle.border[YGEdgeLeft]), // left
-      optionalFloatFromYogaValue(yogaStyle.border[YGEdgeTop]), // top
-      optionalFloatFromYogaValue(yogaStyle.border[YGEdgeRight]), // right
-      optionalFloatFromYogaValue(yogaStyle.border[YGEdgeBottom]), // bottom
-      optionalFloatFromYogaValue(yogaStyle.border[YGEdgeStart]), // start
-      optionalFloatFromYogaValue(yogaStyle.border[YGEdgeEnd]), // end
-      optionalFloatFromYogaValue(
-          yogaStyle.border[YGEdgeHorizontal]), // horizontal
-      optionalFloatFromYogaValue(yogaStyle.border[YGEdgeVertical]), // vertical
-      optionalFloatFromYogaValue(yogaStyle.border[YGEdgeAll]), // all
+      /* .left = */ optionalFloatFromYogaValue(yogaStyle.border[YGEdgeLeft]),
+      /* .top = */ optionalFloatFromYogaValue(yogaStyle.border[YGEdgeTop]),
+      /* .right = */ optionalFloatFromYogaValue(yogaStyle.border[YGEdgeRight]),
+      /* .bottom = */
+      optionalFloatFromYogaValue(yogaStyle.border[YGEdgeBottom]),
+      /* .start = */ optionalFloatFromYogaValue(yogaStyle.border[YGEdgeStart]),
+      /* .end = */ optionalFloatFromYogaValue(yogaStyle.border[YGEdgeEnd]),
+      /* .horizontal = */
+      optionalFloatFromYogaValue(yogaStyle.border[YGEdgeHorizontal]),
+      /* .vertical = */
+      optionalFloatFromYogaValue(yogaStyle.border[YGEdgeVertical]),
+      /* .all = */ optionalFloatFromYogaValue(yogaStyle.border[YGEdgeAll]),
   };
 
   return {
-      borderColors.resolve(isRTL, {}), // borderColors
-      borderWidths.resolve(isRTL, 0), // borderWidths
-      borderRadii.resolve(isRTL, 0), // borderRadii
-      borderStyles.resolve(isRTL, BorderStyle::Solid), // borderStyles
+      /* .borderColors = */ borderColors.resolve(isRTL, {}),
+      /* .borderWidths = */ borderWidths.resolve(isRTL, 0),
+      /* .borderRadii = */ borderRadii.resolve(isRTL, 0),
+      /* .borderStyles = */ borderStyles.resolve(isRTL, BorderStyle::Solid),
   };
 }
 

--- a/ReactCommon/fabric/components/view/ViewProps.cpp
+++ b/ReactCommon/fabric/components/view/ViewProps.cpp
@@ -79,21 +79,24 @@ ViewProps::ViewProps(const ViewProps &sourceProps, const RawProps &rawProps)
 
 BorderMetrics ViewProps::resolveBorderMetrics(bool isRTL) const {
   auto borderWidths = CascadedBorderWidths{
-      .left = optionalFloatFromYogaValue(yogaStyle.border[YGEdgeLeft]),
-      .top = optionalFloatFromYogaValue(yogaStyle.border[YGEdgeTop]),
-      .right = optionalFloatFromYogaValue(yogaStyle.border[YGEdgeRight]),
-      .bottom = optionalFloatFromYogaValue(yogaStyle.border[YGEdgeBottom]),
-      .start = optionalFloatFromYogaValue(yogaStyle.border[YGEdgeStart]),
-      .end = optionalFloatFromYogaValue(yogaStyle.border[YGEdgeEnd]),
-      .horizontal =
-          optionalFloatFromYogaValue(yogaStyle.border[YGEdgeHorizontal]),
-      .vertical = optionalFloatFromYogaValue(yogaStyle.border[YGEdgeVertical]),
-      .all = optionalFloatFromYogaValue(yogaStyle.border[YGEdgeAll])};
+      optionalFloatFromYogaValue(yogaStyle.border[YGEdgeLeft]), // left
+      optionalFloatFromYogaValue(yogaStyle.border[YGEdgeTop]), // top
+      optionalFloatFromYogaValue(yogaStyle.border[YGEdgeRight]), // right
+      optionalFloatFromYogaValue(yogaStyle.border[YGEdgeBottom]), // bottom
+      optionalFloatFromYogaValue(yogaStyle.border[YGEdgeStart]), // start
+      optionalFloatFromYogaValue(yogaStyle.border[YGEdgeEnd]), // end
+      optionalFloatFromYogaValue(
+          yogaStyle.border[YGEdgeHorizontal]), // horizontal
+      optionalFloatFromYogaValue(yogaStyle.border[YGEdgeVertical]), // vertical
+      optionalFloatFromYogaValue(yogaStyle.border[YGEdgeAll]), // all
+  };
 
-  return {.borderColors = borderColors.resolve(isRTL, {}),
-          .borderWidths = borderWidths.resolve(isRTL, 0),
-          .borderRadii = borderRadii.resolve(isRTL, 0),
-          .borderStyles = borderStyles.resolve(isRTL, BorderStyle::Solid)};
+  return {
+      borderColors.resolve(isRTL, {}), // borderColors
+      borderWidths.resolve(isRTL, 0), // borderWidths
+      borderRadii.resolve(isRTL, 0), // borderRadii
+      borderStyles.resolve(isRTL, BorderStyle::Solid), // borderStyles
+  };
 }
 
 #pragma mark - DebugStringConvertible

--- a/ReactCommon/fabric/components/view/primitives.h
+++ b/ReactCommon/fabric/components/view/primitives.h
@@ -205,10 +205,11 @@ struct CascadedRectangleEdges {
         vertical.value_or(all.value_or(defaults));
 
     return {
-        left.value_or(leading.value_or(horizontalOrAllOrDefault)), // left
-        right.value_or(trailing.value_or(horizontalOrAllOrDefault)), // right
-        top.value_or(verticalOrAllOrDefault), // top
-        bottom.value_or(verticalOrAllOrDefault), // bottom
+        /* .left = */ left.value_or(leading.value_or(horizontalOrAllOrDefault)),
+        /* .right = */
+        right.value_or(trailing.value_or(horizontalOrAllOrDefault)),
+        /* .top = */ top.value_or(verticalOrAllOrDefault),
+        /* .bottom = */ bottom.value_or(verticalOrAllOrDefault),
     };
   }
 
@@ -262,14 +263,14 @@ struct CascadedRectangleCorners {
     const auto bottomTrailing = isRTL ? bottomStart : bottomEnd;
 
     return {
-        topLeft.value_or(
-            topLeading.value_or(all.value_or(defaults))), // topLeft
-        topRight.value_or(
-            topTrailing.value_or(all.value_or(defaults))), // topRight
-        bottomLeft.value_or(
-            topLeading.value_or(all.value_or(defaults))), // bottomLeft
-        bottomRight.value_or(
-            topTrailing.value_or(all.value_or(defaults))), // bottomRight
+        /* .topLeft = */ topLeft.value_or(
+            topLeading.value_or(all.value_or(defaults))),
+        /* .topRight = */
+        topRight.value_or(topTrailing.value_or(all.value_or(defaults))),
+        /* .bottomLeft = */
+        bottomLeft.value_or(topLeading.value_or(all.value_or(defaults))),
+        /* .bottomRight = */
+        bottomRight.value_or(topTrailing.value_or(all.value_or(defaults))),
     };
   }
 

--- a/ReactCommon/fabric/components/view/primitives.h
+++ b/ReactCommon/fabric/components/view/primitives.h
@@ -204,11 +204,12 @@ struct CascadedRectangleEdges {
     const auto verticalOrAllOrDefault =
         vertical.value_or(all.value_or(defaults));
 
-    return Counterpart{
-        .left = left.value_or(leading.value_or(horizontalOrAllOrDefault)),
-        .right = right.value_or(trailing.value_or(horizontalOrAllOrDefault)),
-        .top = top.value_or(verticalOrAllOrDefault),
-        .bottom = bottom.value_or(verticalOrAllOrDefault)};
+    return {
+        left.value_or(leading.value_or(horizontalOrAllOrDefault)), // left
+        right.value_or(trailing.value_or(horizontalOrAllOrDefault)), // right
+        top.value_or(verticalOrAllOrDefault), // top
+        bottom.value_or(verticalOrAllOrDefault), // bottom
+    };
   }
 
   bool operator==(const CascadedRectangleEdges<T> &rhs) const {
@@ -260,15 +261,16 @@ struct CascadedRectangleCorners {
     const auto bottomLeading = isRTL ? bottomEnd : bottomStart;
     const auto bottomTrailing = isRTL ? bottomStart : bottomEnd;
 
-    return Counterpart{
-        .topLeft =
-            topLeft.value_or(topLeading.value_or(all.value_or(defaults))),
-        .topRight =
-            topRight.value_or(topTrailing.value_or(all.value_or(defaults))),
-        .bottomLeft =
-            bottomLeft.value_or(topLeading.value_or(all.value_or(defaults))),
-        .bottomRight =
-            bottomRight.value_or(topTrailing.value_or(all.value_or(defaults)))};
+    return {
+        topLeft.value_or(
+            topLeading.value_or(all.value_or(defaults))), // topLeft
+        topRight.value_or(
+            topTrailing.value_or(all.value_or(defaults))), // topRight
+        bottomLeft.value_or(
+            topLeading.value_or(all.value_or(defaults))), // bottomLeft
+        bottomRight.value_or(
+            topTrailing.value_or(all.value_or(defaults))), // bottomRight
+    };
   }
 
   bool operator==(const CascadedRectangleCorners<T> &rhs) const {


### PR DESCRIPTION
## Summary

This pull request removes the designated initializers in `react/components/view/**` to improve portability.

## Changelog

[General] [Changed] - Fabric: Remove designated initializers in View

## Test Plan

Tests build and pass in Ubuntu 18.10 + Clang 7