### PR TITLE
Fabric: Remove designated initializers in Events and Mounting

### DIFF
--- a/ReactCommon/fabric/core/events/EventBeatBasedExecutor.cpp
+++ b/ReactCommon/fabric/core/events/EventBeatBasedExecutor.cpp
@@ -26,7 +26,7 @@ EventBeatBasedExecutor::EventBeatBasedExecutor(
 void EventBeatBasedExecutor::operator()(Routine routine, Mode mode) const {
   if (mode == Mode::Asynchronous) {
     execute({
-        std::move(routine), // routine
+        /* .routine = */ std::move(routine),
     });
     return;
   }
@@ -35,8 +35,8 @@ void EventBeatBasedExecutor::operator()(Routine routine, Mode mode) const {
   mutex.lock();
 
   execute({
-      std::move(routine), // routine
-      [&mutex]() { mutex.unlock(); }, // callback
+      /* .routine = */ std::move(routine),
+      /* .callback = */ [&mutex]() { mutex.unlock(); },
   });
 
   mutex.lock();

--- a/ReactCommon/fabric/core/events/EventBeatBasedExecutor.cpp
+++ b/ReactCommon/fabric/core/events/EventBeatBasedExecutor.cpp
@@ -25,15 +25,19 @@ EventBeatBasedExecutor::EventBeatBasedExecutor(
 
 void EventBeatBasedExecutor::operator()(Routine routine, Mode mode) const {
   if (mode == Mode::Asynchronous) {
-    execute({.routine = std::move(routine)});
+    execute({
+        std::move(routine), // routine
+    });
     return;
   }
 
   std::mutex mutex;
   mutex.lock();
 
-  execute({.routine = std::move(routine),
-           .callback = [&mutex]() { mutex.unlock(); }});
+  execute({
+      std::move(routine), // routine
+      [&mutex]() { mutex.unlock(); }, // callback
+  });
 
   mutex.lock();
 }

--- a/ReactCommon/fabric/mounting/ShadowView.h
+++ b/ReactCommon/fabric/mounting/ShadowView.h
@@ -23,6 +23,8 @@ struct ShadowView final {
   ShadowView() = default;
   ShadowView(const ShadowView &shadowView) = default;
 
+  ~ShadowView(){};
+
   /*
    * Constructs a `ShadowView` from given `ShadowNode`.
    */

--- a/ReactCommon/fabric/mounting/ShadowViewMutation.cpp
+++ b/ReactCommon/fabric/mounting/ShadowViewMutation.cpp
@@ -11,32 +11,49 @@ namespace facebook {
 namespace react {
 
 ShadowViewMutation ShadowViewMutation::CreateMutation(ShadowView shadowView) {
-  return ShadowViewMutation{
-      .type = Create, .newChildShadowView = shadowView, .index = -1};
+  return {
+      Create, // type
+      {}, // parentShadowView
+      shadowView, // newChildShadowView
+      {}, // oldChildShadowView
+      -1, // index
+  };
 }
 
 ShadowViewMutation ShadowViewMutation::DeleteMutation(ShadowView shadowView) {
-  return {.type = Delete, .oldChildShadowView = shadowView, .index = -1};
+  return {
+      Delete, // type
+      {}, // parentShadowView
+      shadowView, // oldChildShadowView
+      {}, // newChildShadowView
+      -1, // index
+  };
 }
 
 ShadowViewMutation ShadowViewMutation::InsertMutation(
     ShadowView parentShadowView,
     ShadowView childShadowView,
     int index) {
-  return {.type = Insert,
-          .parentShadowView = parentShadowView,
-          .newChildShadowView = childShadowView,
-          .index = index};
+  return {
+      Insert, // type
+      parentShadowView, // parentShadowView
+      {}, // oldChildShadowView
+      childShadowView, // newChildShadowView
+      index, // index
+  };
 }
 
 ShadowViewMutation ShadowViewMutation::RemoveMutation(
     ShadowView parentShadowView,
     ShadowView childShadowView,
     int index) {
-  return {.type = Remove,
-          .parentShadowView = parentShadowView,
-          .oldChildShadowView = childShadowView,
-          .index = index};
+  return {
+      Remove, // type
+      parentShadowView, // parentShadowView
+      childShadowView, // oldChildShadowView
+      {}, // newChildShadowView
+      index, // index
+  };
 }
 
 ShadowViewMutation ShadowViewMutation::UpdateMutation(
@@ -44,11 +61,13 @@ ShadowViewMutation ShadowViewMutation::UpdateMutation(
     ShadowView oldChildShadowView,
     ShadowView newChildShadowView,
     int index) {
-  return {.type = Update,
-          .parentShadowView = parentShadowView,
-          .oldChildShadowView = oldChildShadowView,
-          .newChildShadowView = newChildShadowView,
-          .index = index};
+  return {
+      Update, // type
+      parentShadowView, // parentShadowView
+      oldChildShadowView, // oldChildShadowView
+      newChildShadowView, // newChildShadowView
+      index, // index
+  };
 }
 
 } // namespace react

--- a/ReactCommon/fabric/mounting/ShadowViewMutation.cpp
+++ b/ReactCommon/fabric/mounting/ShadowViewMutation.cpp
@@ -12,21 +12,21 @@ namespace react {
 
 ShadowViewMutation ShadowViewMutation::CreateMutation(ShadowView shadowView) {
   return {
-      Create, // type
-      {}, // parentShadowView
-      shadowView, // newChildShadowView
-      {}, // oldChildShadowView
-      -1, // index
+      /* .type = */ Create,
+      /* .parentShadowView = */ {},
+      /* .newChildShadowView = */ shadowView,
+      /* .oldChildShadowView = */ {},
+      /* .index = */ -1,
   };
 }
 
 ShadowViewMutation ShadowViewMutation::DeleteMutation(ShadowView shadowView) {
   return {
-      Delete, // type
-      {}, // parentShadowView
-      shadowView, // oldChildShadowView
-      {}, // newChildShadowView
-      -1, // index
+      /* .type = */ Delete,
+      /* .parentShadowView = */ {},
+      /* .oldChildShadowView = */ shadowView,
+      /* .newChildShadowView = */ {},
+      /* .index = */ -1,
   };
 }
 
@@ -35,11 +35,11 @@ ShadowViewMutation ShadowViewMutation::InsertMutation(
     ShadowView childShadowView,
     int index) {
   return {
-      Insert, // type
-      parentShadowView, // parentShadowView
-      {}, // oldChildShadowView
-      childShadowView, // newChildShadowView
-      index, // index
+      /* .type = */ Insert,
+      /* .parentShadowView = */ parentShadowView,
+      /* .oldChildShadowView = */ {},
+      /* .newChildShadowView = */ childShadowView,
+      /* .index = */ index,
   };
 }
 
@@ -48,11 +48,11 @@ ShadowViewMutation ShadowViewMutation::RemoveMutation(
     ShadowView childShadowView,
     int index) {
   return {
-      Remove, // type
-      parentShadowView, // parentShadowView
-      childShadowView, // oldChildShadowView
-      {}, // newChildShadowView
-      index, // index
+      /* .type = */ Remove,
+      /* .parentShadowView = */ parentShadowView,
+      /* .oldChildShadowView = */ childShadowView,
+      /* .newChildShadowView = */ {},
+      /* .index = */ index,
   };
 }
 
@@ -62,11 +62,11 @@ ShadowViewMutation ShadowViewMutation::UpdateMutation(
     ShadowView newChildShadowView,
     int index) {
   return {
-      Update, // type
-      parentShadowView, // parentShadowView
-      oldChildShadowView, // oldChildShadowView
-      newChildShadowView, // newChildShadowView
-      index, // index
+      /* .type = */ Update,
+      /* .parentShadowView = */ parentShadowView,
+      /* .oldChildShadowView = */ oldChildShadowView,
+      /* .newChildShadowView = */ newChildShadowView,
+      /* .index = */ index,
   };
 }
 


### PR DESCRIPTION
## Summary

This pull request removes the designated initializers in `react/mounting/**` and `react/events/**` to improve portability.

A destructor was also defined for `ShadowView` to fix this error:

```
ShadowViewMutation.cpp:14: error: undefined reference to 'facebook::react::ShadowView::~ShadowView()'
ShadowViewMutation.cpp:24: error: undefined reference to 'facebook::react::ShadowView::~ShadowView()'
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
```

## Changelog

[General] [Changed] - Fabric: Remove designated initializers in Events and Mounting

## Test Plan

Tests build and pass in Ubuntu 18.10 + Clang 7