### PR TITLE
[iOS] Fix image wrong scale factor when load image from file system

### DIFF
--- a/React/Base/RCTUtils.m
+++ b/React/Base/RCTUtils.m
@@ -706,9 +706,9 @@ UIImage *__nullable RCTImageFromLocalAssetURL(NSURL *imageURL)
     image = [UIImage imageNamed:imageName];
   }
 
-  if (!image && imageURL.isFileURL) {
+  if (!image) {
     // Attempt to load from the file system
-    NSString *filePath = imageURL.path;
+    NSString *filePath = [NSString stringWithUTF8String:[imageURL fileSystemRepresentation]];
     if (filePath.pathExtension.length == 0) {
       filePath = [filePath stringByAppendingPathExtension:@"png"];
     }

--- a/React/Base/RCTUtils.m
+++ b/React/Base/RCTUtils.m
@@ -708,13 +708,11 @@ UIImage *__nullable RCTImageFromLocalAssetURL(NSURL *imageURL)
 
   if (!image) {
     // Attempt to load from the file system
-    NSData *fileData;
-    if (imageURL.pathExtension.length == 0) {
-      fileData = [NSData dataWithContentsOfURL:[imageURL URLByAppendingPathExtension:@"png"]];
-    } else {
-      fileData = [NSData dataWithContentsOfURL:imageURL];
+    NSString *filePath = imageURL.path;
+    if (filePath.pathExtension.length == 0) {
+      filePath = [filePath stringByAppendingPathExtension:@"png"];
     }
-    image = [UIImage imageWithData:fileData];
+    image = [UIImage imageWithContentsOfFile:filePath];
   }
 
   if (!image && !bundle) {

--- a/React/Base/RCTUtils.m
+++ b/React/Base/RCTUtils.m
@@ -706,7 +706,7 @@ UIImage *__nullable RCTImageFromLocalAssetURL(NSURL *imageURL)
     image = [UIImage imageNamed:imageName];
   }
 
-  if (!image) {
+  if (!image && imageURL.isFileURL) {
     // Attempt to load from the file system
     NSString *filePath = imageURL.path;
     if (filePath.pathExtension.length == 0) {


### PR DESCRIPTION
## Summary

Regression, fix image load from `~/Library` not respect scale factor. 
Fixes #22383 , the bug comes from [Clean up some URL path handling](https://github.com/facebook/react-native/commit/998197f444aca06cde0d5258469b3d314f8ea8b9).

## Changelog

[iOS] [Fixed] - Fix image wrong scale factor when load image from file system

## Test Plan

If we have picture `panda`, and has `@1x/@2x/@3x` photo, we can load the correct image based on screen scale factor.
`<Image source={{uri: '~/Library/panda.jpg', width: 300, height: 300}} />`