### PR TITLE
fix: add local-cli to react-native package

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,7 +129,8 @@
     "ReactCommon",
     "README.md",
     "third-party-podspecs",
-    "template"
+    "template",
+    "local-cli"
   ],
   "scripts": {
     "start": "node cli.js start",


### PR DESCRIPTION
Make `local-cli` part of `react-native` package to prevent breaking changes.