### PR TITLE
Add jsx extension to transform and testMatch in jest-preset

### DIFF
--- a/jest-preset.js
+++ b/jest-preset.js
@@ -24,7 +24,7 @@ module.exports = {
   },
   modulePathIgnorePatterns: [`${dir}/Libraries/react-native/`],
   transform: {
-    '^.+\\.(js|ts|tsx)$': 'babel-jest',
+    '^.+\\.(js|ts|tsx|jsx)$': 'babel-jest',
     '^.+\\.(bmp|gif|jpg|jpeg|mp4|png|psd|svg|webp)$': require.resolve(
       './jest/assetFileTransformer.js',
     ),
@@ -33,8 +33,8 @@ module.exports = {
     'node_modules/(?!(jest-)?react-native|react-clone-referenced-element)',
   ],
   testMatch: [
-    '**/__tests__/**/*.(js|ts|tsx)',
-    '**/?(*.)+(spec|test).(js|ts|tsx)',
+    '**/__tests__/**/*.(js|ts|tsx|jsx)',
+    '**/?(*.)+(spec|test).(js|ts|tsx|jsx)',
   ],
   setupFiles: [require.resolve('./jest/setup.js')],
   testEnvironment: 'node',


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

A lot of time people will write react components and tests in files with extension **.jsx**. So, tests ending with this extension don't run and the component files written with this extension don't get transpiled.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See http://facebook.github.io/react-native/docs/contributing#changelog for an example. -->

[General] [Fixed] - Add jsx extension to transform and testMatch in jest-preset

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
