### PR TITLE
[iOS] Fix TextInput maxLength when insert characters at begin

### DIFF
--- a/Libraries/Text/TextInput/RCTBaseTextInputView.m
+++ b/Libraries/Text/TextInput/RCTBaseTextInputView.m
@@ -338,11 +338,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithFrame:(CGRect)frame)
 
   NSString *previousText = [_predictedText substringWithRange:range] ?: @"";
 
-  if (!_predictedText || backedTextInputView.attributedText.string.length == 0) {
-    _predictedText = text;
-  } else {
-    _predictedText = [_predictedText stringByReplacingCharactersInRange:range withString:text];
-  }
+  _predictedText = [backedTextInputView.attributedText.string stringByReplacingCharactersInRange:range withString:text];
 
   if (_onTextInput) {
     _onTextInput(@{

--- a/Libraries/Text/TextInput/RCTBaseTextInputView.m
+++ b/Libraries/Text/TextInput/RCTBaseTextInputView.m
@@ -330,13 +330,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithFrame:(CGRect)frame)
     }
   }
 
-  if (range.location + range.length > _predictedText.length) {
-    // _predictedText got out of sync in a bad way, so let's just force sync it.  Haven't been able to repro this, but
-    // it's causing a real crash here: #6523822
-    _predictedText = backedTextInputView.attributedText.string;
-  }
-
-  NSString *previousText = [_predictedText substringWithRange:range] ?: @"";
+  NSString *previousText = backedTextInputView.attributedText.string ?: @"";
 
   _predictedText = [backedTextInputView.attributedText.string stringByReplacingCharactersInRange:range withString:text];
 
@@ -372,7 +366,6 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithFrame:(CGRect)frame)
     [self textInputShouldChangeTextInRange:predictionRange replacementText:replacement];
     // JS will assume the selection changed based on the location of our shouldChangeTextInRange, so reset it.
     [self textInputDidChangeSelection];
-    _predictedText = backedTextInputView.attributedText.string;
   }
 
   _nativeEventCount++;

--- a/Libraries/Text/TextInput/RCTBaseTextInputView.m
+++ b/Libraries/Text/TextInput/RCTBaseTextInputView.m
@@ -331,8 +331,12 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithFrame:(CGRect)frame)
   }
 
   NSString *previousText = backedTextInputView.attributedText.string ?: @"";
-
-  _predictedText = [backedTextInputView.attributedText.string stringByReplacingCharactersInRange:range withString:text];
+  
+  if (range.location + range.length > backedTextInputView.attributedText.string.length) {
+    _predictedText = backedTextInputView.attributedText.string;
+  } else {
+    _predictedText = [backedTextInputView.attributedText.string stringByReplacingCharactersInRange:range withString:text];
+  }
 
   if (_onTextInput) {
     _onTextInput(@{


### PR DESCRIPTION
## Summary

Fixes #21639 , seems we tried to fix this before, please see related `PR` like [D10392176](https://github.com/facebook/react-native/commit/36507e4a3c2fa58dcfdc9bd389b37536c66006d0), #18627, but they don't solve it totally. 

## Changelog

[iOS] [Fixed] - Fix TextInput maxLength when insert characters at begin

## Test Plan

From the git log, we faced some issues, like [Backspace event](https://github.com/facebook/react-native/pull/18627), we need to ensure no regression happened, issues like #21639 #18627 should be fixed.
