### PR TITLE
bump android plugin to 3.3.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:3.3.0")
+        classpath("com.android.tools.build:gradle:3.3.1")
         classpath("de.undercouch:gradle-download-task:3.4.3")
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/template/android/build.gradle
+++ b/template/android/build.gradle
@@ -13,7 +13,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.0'
+        classpath 'com.android.tools.build:gradle:3.3.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
## Summary

Bump Android Plugin to 3.3.1, with many bug fixes and performance improvements. Split the change from https://github.com/facebook/react-native/pull/23324 to make cherry-pick easy to 0.59 branch. 

## Changelog

[Android] [Changed] - bump Android Plugin to 3.3.1

## Test Plan

CI is green