### PR TITLE
Remove android initialAppState fallback check

### DIFF
--- a/Libraries/AppState/AppState.js
+++ b/Libraries/AppState/AppState.js
@@ -38,9 +38,7 @@ class AppState extends NativeEventEmitter {
       memoryWarning: new Map(),
     };
 
-    // TODO: Remove the 'active' fallback after `initialAppState` is exported by
-    // the Android implementation.
-    this.currentState = RCTAppState.initialAppState || 'active';
+    this.currentState = RCTAppState.initialAppState;
 
     let eventUpdated = false;
 

--- a/React/Modules/RCTAppState.m
+++ b/React/Modules/RCTAppState.m
@@ -12,7 +12,7 @@
 #import "RCTEventDispatcher.h"
 #import "RCTUtils.h"
 
-static NSString *RCTCurrentAppBackgroundState()
+static NSString *RCTCurrentAppState()
 {
   static NSDictionary *states;
   static dispatch_once_t onceToken;
@@ -54,7 +54,7 @@ RCT_EXPORT_MODULE()
 
 - (NSDictionary *)getConstants
 {
-  return @{@"initialAppState": RCTCurrentAppBackgroundState()};
+  return @{@"initialAppState": RCTCurrentAppState()};
 }
 
 #pragma mark - Lifecycle
@@ -105,7 +105,7 @@ RCT_EXPORT_MODULE()
   } else if ([notification.name isEqualToString:UIApplicationWillEnterForegroundNotification]) {
     newState = @"background";
   } else {
-    newState = RCTCurrentAppBackgroundState();
+    newState = RCTCurrentAppState();
   }
 
   if (![newState isEqualToString:_lastKnownState]) {
@@ -123,7 +123,7 @@ RCT_EXPORT_MODULE()
 RCT_EXPORT_METHOD(getCurrentAppState:(RCTResponseSenderBlock)callback
                   error:(__unused RCTResponseSenderBlock)error)
 {
-  callback(@[@{@"app_state": RCTCurrentAppBackgroundState()}]);
+  callback(@[@{@"app_state": RCTCurrentAppState()}]);
 }
 
 @end


### PR DESCRIPTION
## Summary

1. We expose the `initialAppState` for Android in #19935, so we can remove the fallback check for Android.
2. Rename `RCTCurrentAppBackgroundState` to `RCTCurrentAppState`, it's a private file function, so it's safe to rename, `RCTCurrentAppState` is more suitable because we actually get app state, not app background state. 

## Changelog

[Android] [Enhancement] - Remove android `initialAppState` fallback check.

## Test Plan

Android support `initialAppState`.
