### PR TITLE
[iOS] Add `folly_compiler_flags` to Core subspec

### DIFF
--- a/React.podspec
+++ b/React.podspec
@@ -66,6 +66,7 @@ Pod::Spec.new do |s|
                               "React/Views/RCTSlider*",
                               "React/Views/RCTSwitch*",
                               "React/Views/RCTWebView*"
+    ss.compiler_flags       = folly_compiler_flags
     ss.header_dir           = "React"
     ss.framework            = "JavaScriptCore"
     ss.libraries            = "stdc++"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

This fixes the following iOS build error when using React via pods (using the new Xcode build system);

> project/Pods/Folly/folly/portability/Config.h:20:10: 'folly/folly-config.h' file not found

https://github.com/react-native-community/react-native-releases/issues/79#issuecomment-463628317
https://github.com/react-native-community/react-native-releases/issues/79#issuecomment-463675118
https://github.com/react-native-community/react-native-releases/issues/79#issuecomment-464117823

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See http://facebook.github.io/react-native/docs/contributing#changelog for an example. -->

[iOS] [Fixed] - Fixed a "'folly/folly-config.h' file not found" build error when using React via CocoaPods

## Test Plan

**Before:**
![image](https://user-images.githubusercontent.com/5347038/52899349-1b7b9f80-31e1-11e9-892d-7b57ad4a508a.png)


**After:**
![image](https://user-images.githubusercontent.com/5347038/52899359-27fff800-31e1-11e9-8c05-d59fff4a1bdf.png)

