### PR TITLE
JSI: Minor tweaks for building on MSVC

### DIFF
--- a/ReactCommon/jsi/jsi.h
+++ b/ReactCommon/jsi/jsi.h
@@ -336,7 +336,7 @@ class PropNameID : public Pointer {
   using Pointer::Pointer;
 
   PropNameID(Runtime& runtime, const PropNameID& other)
-      : PropNameID(runtime.clonePropNameID(other.ptr_)) {}
+      : Pointer(runtime.clonePropNameID(other.ptr_)) {}
 
   PropNameID(PropNameID&& other) = default;
   PropNameID& operator=(PropNameID&& other) = default;


### PR DESCRIPTION
## Summary

This is a re-submit of #23367, which was accidentally over-written in this commit:

https://github.com/facebook/react-native/commit/0d7faf6f73b942126e1f45016cde8fd480fd0164

This pull request makes this change to `jsi.h`:

 * Tweak the call to constructor `Pointer(Runtime::PointerValue* ptr)` in the constructor for `PropNameID`. I am not sure why MSVC wasn't working with the original version, but it compiles after I tweak that.

## Changelog

[General] [Fixed] - Tweaked `jsi.h` to build on MSVC

## Test Plan

JSI successfully compiled under Visual Studio 2017