### PR TITLE
SYSTEM_ALERT_WINDOW only in debug builds

### DIFF
--- a/ReactAndroid/src/main/AndroidManifest.xml
+++ b/ReactAndroid/src/main/AndroidManifest.xml
@@ -1,7 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.facebook.react">
 
-    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
-
     <application />
 
 </manifest>

--- a/template/android/app/src/debug/AndroidManifest.xml
+++ b/template/android/app/src/debug/AndroidManifest.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
+
+    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
+
     <application tools:targetApi="28" tools:ignore="GoogleAppIndexingWarning" android:networkSecurityConfig="@xml/react_native_config" />
 </manifest>

--- a/template/android/app/src/main/AndroidManifest.xml
+++ b/template/android/app/src/main/AndroidManifest.xml
@@ -2,7 +2,6 @@
   package="com.helloworld">
 
     <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
 
     <application
       android:name=".MainApplication"


### PR DESCRIPTION
## Summary

SYSTEM_ALERT_WINDOW permission is used only for debug builds to show draw overlay views or show warnings/errors. This permissions is unused in release builds, and there is an issue regarding removing unused permissions on Android build https://github.com/facebook/react-native/issues/5886#issuecomment-464495388. This PR removes SYSTEM_ALERT_WINDOW from all builds bug debug.

## Changelog

[Android] [Changed] - SYSTEM_ALERT_WINDOW permissions available only in debug builds

## Test Plan

CI is green, and I tested it in my apps.