### PR TITLE
feat(permissions-android): export Rationale type and add missing properties according to docs

### DIFF
--- a/Libraries/PermissionsAndroid/PermissionsAndroid.js
+++ b/Libraries/PermissionsAndroid/PermissionsAndroid.js
@@ -12,9 +12,12 @@
 
 const NativeModules = require('NativeModules');
 
-type Rationale = {
+export type Rationale = {
   title: string,
   message: string,
+  buttonPositive: string,
+  buttonNegative?: string,
+  buttonNeutral?: string,
 };
 
 type PermissionStatus = 'granted' | 'denied' | 'never_ask_again';

--- a/Libraries/PermissionsAndroid/PermissionsAndroid.js
+++ b/Libraries/PermissionsAndroid/PermissionsAndroid.js
@@ -15,7 +15,7 @@ const NativeModules = require('NativeModules');
 export type Rationale = {
   title: string,
   message: string,
-  buttonPositive: string,
+  buttonPositive?: string,
   buttonNegative?: string,
   buttonNeutral?: string,
 };


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

I checked the documentation over at https://facebook.github.io/react-native/docs/permissionsandroid and the documented properties `buttonPositive`, `buttonNegative` and `buttonNeutral` are not available in the flow-type definitions. 

___

Also the Rationale type is not exported which makes it hard to reuse it in a library or in your own application code.

However I do not know if it is actually intended to import "internal" flow-types from `react-native` since I could not find any other type or interface being exported. So I am not 100% sure if I should have done this.

## Changelog

[General] [Added] - Export Rationale flow-type and add missing properties `buttonPositive`, `buttonNegative` and `buttonNeutral` to the documentation.


## Test Plan

run flow
