### PR TITLE
[iOS] Fix pod install error in configure: C compiler cannot create executables

### DIFF
--- a/scripts/ios-configure-glog.sh
+++ b/scripts/ios-configure-glog.sh
@@ -20,8 +20,6 @@ if [ -z "$CURRENT_ARCH" ] || [ "$CURRENT_ARCH" == "undefined_arch" ]; then
     fi
 fi
 
-export CXX="$(xcrun -find -sdk $PLATFORM_NAME cc) -arch $CURRENT_ARCH -isysroot $(xcrun -sdk $PLATFORM_NAME --show-sdk-path)"
-
 # Remove automake symlink if it exists
 if [ -h "test-driver" ]; then
     rm test-driver

--- a/scripts/ios-configure-glog.sh
+++ b/scripts/ios-configure-glog.sh
@@ -20,8 +20,7 @@ if [ -z "$CURRENT_ARCH" ] || [ "$CURRENT_ARCH" == "undefined_arch" ]; then
     fi
 fi
 
-export CC="$(xcrun -find -sdk $PLATFORM_NAME cc) -arch $CURRENT_ARCH -isysroot $(xcrun -sdk $PLATFORM_NAME --show-sdk-path)"
-export CXX="$CC"
+export CXX="$(xcrun -find -sdk $PLATFORM_NAME cc) -arch $CURRENT_ARCH -isysroot $(xcrun -sdk $PLATFORM_NAME --show-sdk-path)"
 
 # Remove automake symlink if it exists
 if [ -h "test-driver" ]; then


### PR DESCRIPTION
## Summary

Running `pod install` in a react-native project configured via CocoaPods (https://facebook.github.io/react-native/docs/integration-with-existing-apps#configuring-cocoapods-dependencies) results in the error already described in: 
 - https://stackoverflow.com/questions/48928498/configure-error-c-compiler-cannot-create-executables-react-native

The workaround specified in the answer works:
```
cd node_modules/react-native/third-party/glog-0.3.4/
./configure --host arm-apple-darwin
```

This issue https://github.com/facebook/react-native/issues/14174 documents the fix which I believe introduces the problem on my environment. OSX `10.13.6` Xcode `9.4.1`

This seems to be related to the setting of the `CC` environment variable. When not setting this variable but only `CXX` the problem disappears. 

Note that I'm not sure why setting neither `CC` nor `CXX` works (as per the SO post) and this therefore should be tested on other environments. See below for detailed logs which might help identify further what the issue is. Maybe there was an upstream 

## Changelog

[iOS] [Fixed] - Fix compilation error on pod install for glog

## Test Plan

In `node_modules/react-native/third-party/glog-0.3.5/`

On a fresh bash session (without setting `CXX` and `CC`, i.e. the Stack Overflow fix):
```
$ ./configure --host arm-apple-darwin
[...]
checking for arm-apple-darwin-gcc... no
checking for gcc... gcc
checking whether the C compiler works... yes
checking for C compiler default output file name... a.out
checking for suffix of executables...
checking whether we are cross compiling... no
checking for suffix of object files... o
checking whether we are using the GNU C compiler... yes
checking whether gcc accepts -g... yes
checking for gcc option to accept ISO C89... none needed
checking whether gcc understands -c and -o together... yes
checking for style of include used by make... GNU
checking dependency style of gcc... gcc3
checking how to run the C preprocessor... gcc -E
checking for arm-apple-darwin-g++... no
checking for arm-apple-darwin-c++... no
checking for arm-apple-darwin-gpp... no
checking for arm-apple-darwin-aCC... no
checking for arm-apple-darwin-CC... no
checking for arm-apple-darwin-cxx... no
checking for arm-apple-darwin-cc++... no
checking for arm-apple-darwin-cl.exe... no
checking for arm-apple-darwin-FCC... no
checking for arm-apple-darwin-KCC... no
checking for arm-apple-darwin-RCC... no
checking for arm-apple-darwin-xlC_r... no
checking for arm-apple-darwin-xlC... no
checking for g++... g++
checking whether we are using the GNU C++ compiler... yes
checking whether g++ accepts -g... yes
checking dependency style of g++... gcc3
checking build system type... i386-apple-darwin17.7.0
checking host system type... arm-apple-darwin
```

Setting `CXX` and `CC` manually (as done in the `./scripts/ios-configure-glog.sh` script) raises the error: 
```
$ export CC="$(xcrun -find -sdk iphoneos cc) -arch armv7 -isysroot $(xcrun -sdk iphoneos --show-sdk-path)"
$ export CXX=$CC
$ ./configure --host arm-apple-darwin
[...]
checking for arm-apple-darwin-gcc... /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc -arch armv7 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk
checking whether the C compiler works... no
configure: error: in `/Users/.../Library/Caches/CocoaPods/Pods/External/glog/2263bd123499e5b93b5efe24871be317-91426':
configure: error: C compiler cannot create executables
See `config.log' for more details
```

In the same session, unsetting CC (i.e. with only `export CXX="$(xcrun -find -sdk $PLATFORM_NAME cc) -arch $CURRENT_ARCH -isysroot $(xcrun -sdk $PLATFORM_NAME --show-sdk-path)"`)
:
```
$ unset CC
$ ./configure --host arm-apple-darwin
[...]
checking for arm-apple-darwin-gcc... no
checking for gcc... gcc
checking whether the C compiler works... yes
checking for C compiler default output file name... a.out
checking for suffix of executables...
checking whether we are cross compiling... no
checking for suffix of object files... o
checking whether we are using the GNU C compiler... yes
checking whether gcc accepts -g... yes
checking for gcc option to accept ISO C89... none needed
checking whether gcc understands -c and -o together... yes
checking for style of include used by make... GNU
checking dependency style of gcc... gcc3
checking how to run the C preprocessor... gcc -E
checking whether we are using the GNU C++ compiler... yes
checking whether /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc -arch armv7 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk accepts -g... yes
checking dependency style of /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc -arch armv7 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk... gcc3
checking build system type... i386-apple-darwin17.7.0
checking host system type... arm-apple-darwin
```

cc @javache 