### PR TITLE
[Android][Fixed] - Fix the IndexOutOfBoundsException when wrong tag is used in manageChildren because of animation.

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeViewHierarchyManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeViewHierarchyManager.java
@@ -410,10 +410,11 @@ public class NativeViewHierarchyManager {
         if (mLayoutAnimationEnabled &&
             mLayoutAnimator.shouldAnimateLayout(viewToRemove) &&
             arrayContains(tagsToDelete, viewToRemove.getId())) {
-          // The view will be removed and dropped by the 'delete' layout animation
-          // instead, so do nothing
+          // Mark the View so that it will be removed and dropped by the 'delete'
+          // layout animation and ensure the index won't be miscalculated.
+          viewManager.addDeleteMark(viewToManage, indexToRemove);
         } else {
-          viewManager.removeViewAt(viewToManage, indexToRemove);
+          viewManager.removeView(viewToManage, viewToRemove);
         }
 
         lastIndexToRemove = indexToRemove;

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewGroupManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewGroupManager.java
@@ -68,6 +68,16 @@ public abstract class ViewGroupManager <T extends ViewGroup>
     return parent.getChildAt(index);
   }
 
+  /**
+   * Use the method when a view should be removed by layout animation
+   * Note that this is only used in ReactViewGroup at the moment
+   *
+   * @param parent the parent ViewGroup
+   * @param index the index that should attatch a delete mark
+   */
+  public void addDeleteMark(T parent, int index) {
+  }
+
   public void removeViewAt(T parent, int index) {
     parent.removeViewAt(index);
   }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
@@ -44,6 +44,7 @@ import com.facebook.react.uimanager.RootViewUtil;
 import com.facebook.react.uimanager.ViewGroupDrawingOrderHelper;
 import com.facebook.react.uimanager.ViewProps;
 import com.facebook.yoga.YogaConstants;
+import java.util.ArrayList;
 import javax.annotation.Nullable;
 
 import static com.facebook.react.common.ReactConstants.TAG;
@@ -61,6 +62,11 @@ public class ReactViewGroup extends ViewGroup implements
   private static final LayoutParams sDefaultLayoutParam = new ViewGroup.LayoutParams(0, 0);
   /* should only be used in {@link #updateClippingToRect} */
   private static final Rect sHelperRect = new Rect();
+  /* should only be used when using layout animation. */
+  public @Nullable ArrayList<Integer> mDeleteMark = null;
+  /* -1 represents the delete mark is not enabled. */
+  public int mMarkedChildCount = -1;
+
 
   /**
    * This listener will be set for child views when removeClippedSubview property is enabled. When


### PR DESCRIPTION
Fix the IndexOutOfBoundsException when wrong tag is used in manageChildren because of animation.

## Summary

When using animation, some views may not be removed immediately. Instead, they will be removed when the animation is finished. This can cause incorrect index or even crashes. 

- Bad Case:
``` 
import React, { Component } from 'react';
import { Text, View, UIManager, LayoutAnimation } from 'react-native';

class Screen extends Component {
  showB = true;
  toggle = () => {
    this.showB = !this.showB;
    this.forceUpdate();
  };

  componentWillUpdate(/* A garder : nextProps , nextState */) {
    LayoutAnimation.easeInEaseOut();
  }

  render() {
    return (
    <View style={{flex: 1, backgroundColor: '#F5FCFF'}}>
      <View style={{ margin: 40 }}>
        <Text onPress={this.toggle}>Click 2 times here to make app crash</Text>
        {
          [
            <View key={0}>
              <Text>A</Text>
              {
                this.showB ?
                  <Text>B</Text>
                  :
                  null
              }
            </View>,
            <View key={1}>
              <Text>A</Text>
              {
                this.showB ?
                  <Text>B</Text>
                  :
                  null
              }
            </View>,
          ]
        }
      </View>
    </View>
    );
  }
}

export default Screen;
```

- Root Cause:
<img width="394" alt="image" src="https://user-images.githubusercontent.com/47712583/53007441-39abfe80-3472-11e9-8b62-5cacdf0a610c.png">

1. Index 2(the first B) is supposed to be removed, but it is not removed immediately because of animation. 
2. Index 3(the second B) is supposed to be removed then, but the first B has  not be removed yet. Therefore the second A is removed by mistake.

- Solution:
A mark is used to adjust the index. Using an delete-mark to represent the view going to be deleted can help find out the correct index when the animation finish and therefore fix the problem. In mDeleteMark, Integer(0) represents a normal view while Integer(1) represents the view that should be removed but because of animation it should be removed later. The true index can be gotten by calculating the number of Integer(1).

- Issue:#17118

## Changelog

[Android][Fixed] - Fix the IndexOutOfBoundsException when wrong tag is used in manageChildren because of animation.

## Test Plan

- Open the Android emulator or an Android device.
- Create a react-native-app with the bad case code above.
- Tap the button and see if it will crash.