### PR TITLE
[iOS] helpful error on canOpenURL for missing scheme

### DIFF
--- a/Libraries/LinkingIOS/RCTLinkingManager.m
+++ b/Libraries/LinkingIOS/RCTLinkingManager.m
@@ -106,13 +106,23 @@ RCT_EXPORT_METHOD(canOpenURL:(NSURL *)URL
     return;
   }
 
-  // TODO: on iOS9 this will fail if URL isn't included in the plist
-  // we should probably check for that and reject in that case instead of
-  // simply resolving with NO
-
   // This can be expensive, so we deliberately don't call on main thread
   BOOL canOpen = [RCTSharedApplication() canOpenURL:URL];
-  resolve(@(canOpen));
+
+  NSString *scheme = [URL scheme];
+    
+  // in iOS 9 and above canOpenURL returns NO without a helpful error
+  // check if a custom scheme is being used, and if it exists in LSApplicationQueriesSchemes
+  if (![[scheme lowercaseString] hasPrefix:@"http"] && ![[scheme lowercaseString] hasPrefix:@"https"]) {
+    NSArray *querySchemes = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"LSApplicationQueriesSchemes"];
+    if (querySchemes != nil && ([querySchemes containsObject:scheme] || [querySchemes containsObject:[scheme lowercaseString]])) {
+      resolve(@(canOpen));
+    } else {
+      reject(RCTErrorUnspecified, [NSString stringWithFormat:@"Unable to open URL: %@, add %@ to LSApplicationQueriesSchemes in Info.plist.", URL, scheme], nil);
+    }
+  } else {
+    resolve(@(canOpen));
+  }
 }
 
 RCT_EXPORT_METHOD(getInitialURL:(RCTPromiseResolveBlock)resolve

--- a/Libraries/LinkingIOS/RCTLinkingManager.m
+++ b/Libraries/LinkingIOS/RCTLinkingManager.m
@@ -111,14 +111,14 @@ RCT_EXPORT_METHOD(canOpenURL:(NSURL *)URL
 
   NSString *scheme = [URL scheme];
     
-  // in iOS 9 and above canOpenURL returns NO without a helpful error
-  // check if a custom scheme is being used, and if it exists in LSApplicationQueriesSchemes
+  // On iOS 9 and above canOpenURL returns NO without a helpful error.
+  // Check if a custom scheme is being used, and if it exists in LSApplicationQueriesSchemes
   if (![[scheme lowercaseString] hasPrefix:@"http"] && ![[scheme lowercaseString] hasPrefix:@"https"]) {
     NSArray *querySchemes = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"LSApplicationQueriesSchemes"];
     if (querySchemes != nil && ([querySchemes containsObject:scheme] || [querySchemes containsObject:[scheme lowercaseString]])) {
       resolve(@(canOpen));
     } else {
-      reject(RCTErrorUnspecified, [NSString stringWithFormat:@"Unable to open URL: %@, add %@ to LSApplicationQueriesSchemes in Info.plist.", URL, scheme], nil);
+      reject(RCTErrorUnspecified, [NSString stringWithFormat:@"Unable to open URL: %@. Add %@ to LSApplicationQueriesSchemes in your Info.plist.", URL, scheme], nil);
     }
   } else {
     resolve(@(canOpen));


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
iOS 9 introduced a whitelist for schemes that apps are allowed to open / check against, the current behavior of React Native is to simple return `NO` when a scheme is missing from that whitelist. It would be more helpful to throw an error with a suggested fix for the problem:
```
Unable to open URL: asos://checkout, add asos to LSApplicationQueriesSchemes in Info.plist.
```

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See http://facebook.github.io/react-native/docs/contributing#changelog for an example. -->

[iOS] [Changed] - canOpenURL throws when custom scheme isn't in LSApplicationQueriesSchemes.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
Tested on RNTester.