### PR TITLE
fix the TextInput can't control input length when value's length > maxLength

### DIFF
--- a/Libraries/Text/TextInput/RCTBaseTextInputView.m
+++ b/Libraries/Text/TextInput/RCTBaseTextInputView.m
@@ -305,9 +305,9 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithFrame:(CGRect)frame)
   }
 
   if (_maxLength) {
-    NSUInteger allowedLength = _maxLength.integerValue - backedTextInputView.attributedText.string.length + range.length;
+    NSInteger allowedLength = _maxLength.integerValue - backedTextInputView.attributedText.string.length + range.length;
 
-    if (text.length > allowedLength) {
+    if (allowedLength < 0 || text.length > allowedLength) {
       // If we typed/pasted more than one character, limit the text inputted.
       if (text.length > 1) {
         // Truncate the input string so the result is exactly maxLength


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
I found the TextInput can't control input length when default value's length > maxLength.
for example：
1.Set the value in special cases
```
<TextInput value={'12345678'} maxLength={6}/>
```
2.Quickly press the keyboard with multiple fingers

```
// RCTBaseTextInputView.m
……
if (_maxLength) {
    NSUInteger allowedLength = _maxLength.integerValue - backedTextInputView.attributedText.string.length + range.length;
    if (text.length > allowedLength) {
……
```
when value's length > maxLength,the allowedLength not a negative number.it was transformed into a big number,because it is type NSUInteger.so the `text.length > allowedLength` always false.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See http://facebook.github.io/react-native/docs/contributing#changelog for an example. -->

[iOS][Fixed] - fix the TextInput can't control input length when value's length > maxLength


## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
```
<TextInput value={'12345678'} maxLength={6}/>
```
