### PR TITLE
[General] Remove __fbRequireBatchedBridge call when not get batchedBridge

### DIFF
--- a/ReactCommon/jsiexecutor/jsireact/JSIExecutor.cpp
+++ b/ReactCommon/jsiexecutor/jsireact/JSIExecutor.cpp
@@ -285,13 +285,8 @@ void JSIExecutor::bindBridge() {
     Value batchedBridgeValue =
         runtime_->global().getProperty(*runtime_, "__fbBatchedBridge");
     if (batchedBridgeValue.isUndefined()) {
-      Function requireBatchedBridge = runtime_->global().getPropertyAsFunction(
-          *runtime_, "__fbRequireBatchedBridge");
-      batchedBridgeValue = requireBatchedBridge.call(*runtime_);
-      if (batchedBridgeValue.isUndefined()) {
-        throw JSINativeException(
-            "Could not get BatchedBridge, make sure your bundle is packaged correctly");
-      }
+      throw JSINativeException(
+                               "Could not get BatchedBridge, make sure your bundle is packaged correctly");
     }
 
     Object batchedBridge = batchedBridgeValue.asObject(*runtime_);


### PR DESCRIPTION
## Summary

From the git log, we added `__fbRequireBatchedBridge` in this commit  https://github.com/facebook/react-native/commit/6dc3a83e88ed120decbeaed8e4e62dc2bb7107a3, I don't ensure wether I missed something, we actually don't define `__fbRequireBatchedBridge` on `JS` or `Native` side, so `__fbRequireBatchedBridge` getter operation itself would throw exception.

## Changelog

[General] [Fixed] - Remove __fbRequireBatchedBridge call when not get batchedBridge

## Test Plan

When we didn't get BatchedBridge, throw exception immediately.
