### PR TITLE
[WIP] Fabric podspecs

### DIFF
--- a/React.podspec
+++ b/React.podspec
@@ -66,7 +66,6 @@ Pod::Spec.new do |s|
                               "React/Views/RCTSlider*",
                               "React/Views/RCTSwitch*",
                               "React/Views/RCTWebView*"
-    ss.compiler_flags       = folly_compiler_flags
     ss.header_dir           = "React"
     ss.framework            = "JavaScriptCore"
     ss.libraries            = "stdc++"
@@ -95,8 +94,10 @@ Pod::Spec.new do |s|
     ss.dependency             "React/Core"
     ss.dependency             "React/fabric"
     ss.compiler_flags       = folly_compiler_flags
-    ss.source_files         = "React/Fabric/**/*.{c,h,m,mm,S,cpp}"
-    ss.exclude_files        = "**/tests/*"
+    ss.source_files         = "React/Fabric/**/*.{c,h,m,mm,S,cpp}",
+                              "ReactCommon/fabric/**/*.{c,h,m,mm,S,cpp}"
+    ss.exclude_files        = "**/tests/*",
+                              "**/android/*"
     ss.header_dir           = "React"
     ss.framework            = "JavaScriptCore"
     ss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\"" }
@@ -117,19 +118,15 @@ Pod::Spec.new do |s|
     ss.dependency             "React/cxxreact"
     ss.dependency             "React/jsi"
     ss.dependency             "Folly", folly_version
-    ss.dependency             "DoubleConversion"
-    ss.dependency             "glog"
     ss.compiler_flags       = folly_compiler_flags
     ss.source_files         = "ReactCommon/jsiexecutor/jsireact/*.{cpp,h}"
     ss.private_header_files = "ReactCommon/jsiexecutor/jsireact/*.h"
     ss.header_dir           = "jsireact"
-    ss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\", \"$(PODS_TARGET_SRCROOT)/ReactCommon/jsiexecutor\"" }
+    ss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\"" }
   end
 
   s.subspec "jsi" do |ss|
     ss.dependency             "Folly", folly_version
-    ss.dependency             "DoubleConversion"
-    ss.dependency             "glog"
     ss.compiler_flags       = folly_compiler_flags
     ss.source_files         = "ReactCommon/jsi/*.{cpp,h}"
     ss.private_header_files = "ReactCommon/jsi/*.h"
@@ -147,8 +144,6 @@ Pod::Spec.new do |s|
     ss.dependency             "React/jsinspector"
     ss.dependency             "boost-for-react-native", "1.63.0"
     ss.dependency             "Folly", folly_version
-    ss.dependency             "DoubleConversion"
-    ss.dependency             "glog"
     ss.compiler_flags       = folly_compiler_flags
     ss.source_files         = "ReactCommon/cxxreact/*.{cpp,h}"
     ss.exclude_files        = "ReactCommon/cxxreact/SampleCxxModule.*"
@@ -160,9 +155,9 @@ Pod::Spec.new do |s|
     ss.subspec "activityindicator" do |sss|
       sss.dependency             "Folly", folly_version
       sss.compiler_flags       = folly_compiler_flags
-      sss.source_files         = "ReactCommon/fabric/activityindicator/**/*.{cpp,h}"
+      sss.source_files         = "ReactCommon/fabric/components/activityindicator/*.{cpp,h}"
       sss.exclude_files        = "**/tests/*"
-      sss.header_dir           = "fabric/activityindicator"
+      sss.header_dir           = "react/components/activityindicator"
       sss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/Folly\"" }
     end
 
@@ -171,7 +166,16 @@ Pod::Spec.new do |s|
       sss.compiler_flags       = folly_compiler_flags
       sss.source_files         = "ReactCommon/fabric/attributedstring/**/*.{cpp,h}"
       sss.exclude_files        = "**/tests/*"
-      sss.header_dir           = "fabric/attributedstring"
+      sss.header_dir           = "react/attributedstring"
+      sss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/Folly\"" }
+    end
+
+    ss.subspec "config" do |sss|
+      sss.dependency             "Folly", folly_version
+      sss.compiler_flags       = folly_compiler_flags
+      sss.source_files         = "ReactCommon/config/**/*.{cpp,h}"
+      sss.exclude_files        = "**/tests/*"
+      sss.header_dir           = "react/config"
       sss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/Folly\"" }
     end
 
@@ -180,7 +184,7 @@ Pod::Spec.new do |s|
       sss.compiler_flags       = folly_compiler_flags
       sss.source_files         = "ReactCommon/fabric/core/**/*.{cpp,h}"
       sss.exclude_files        = "**/tests/*"
-      sss.header_dir           = "fabric/core"
+      sss.header_dir           = "react/core"
       sss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/Folly\"" }
     end
 
@@ -189,43 +193,105 @@ Pod::Spec.new do |s|
       sss.compiler_flags       = folly_compiler_flags
       sss.source_files         = "ReactCommon/fabric/debug/**/*.{cpp,h}"
       sss.exclude_files        = "**/tests/*"
-      sss.header_dir           = "fabric/debug"
+      sss.header_dir           = "react/debug"
+      sss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/Folly\"" }
+    end
+
+    ss.subspec "events" do |sss|
+      sss.dependency             "Folly", folly_version
+      sss.compiler_flags       = folly_compiler_flags
+      sss.source_files         = "ReactCommon/fabric/events/*.{cpp,h}"
+      sss.exclude_files        = "**/tests/*"
+      sss.header_dir           = "react/events"
       sss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/Folly\"" }
     end
 
     ss.subspec "graphics" do |sss|
       sss.dependency             "Folly", folly_version
       sss.compiler_flags       = folly_compiler_flags
-      sss.source_files         = "ReactCommon/fabric/graphics/**/*.{cpp,h}"
+      sss.source_files         = "ReactCommon/fabric/graphics/*.{cpp,h}", 
+                                 "ReactCommon/fabric/graphics/platform/ios/*.{cpp,h}"
       sss.exclude_files        = "**/tests/*"
-      sss.header_dir           = "fabric/graphics"
+      sss.header_dir           = "react/graphics"
+      sss.frameworks           = "CoreGraphics", 
+                                 "UIKit", 
+                                 "Foundation"
+      sss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/Folly\"" }
+    end
+
+    ss.subspec "image" do |sss|
+      sss.dependency             "Folly", folly_version
+      sss.compiler_flags       = folly_compiler_flags
+      sss.source_files         = "ReactCommon/fabric/components/image/*.{cpp,h}" 
+      sss.exclude_files        = "**/tests/*"
+      sss.header_dir           = "react/components/image"
+      sss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/Folly\"" }
+    end
+
+    ss.subspec "imagemanager" do |sss|
+      sss.dependency             "Folly", folly_version
+      sss.compiler_flags       = folly_compiler_flags
+      sss.source_files         = "ReactCommon/fabric/imagemanager/*.{cpp,h}", 
+                                 "ReactCommon/fabric/imagemanager/platform/ios/*.{cpp,h,mm}"
+      sss.exclude_files        = "**/tests/*"
+      sss.header_dir           = "react/imagemanager"
+      sss.frameworks           = "CoreGraphics", 
+                                 "UIKit", 
+                                 "Foundation"
+      sss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/Folly\"" }
+    end
+
+    ss.subspec "mounting" do |sss|
+      sss.dependency             "Folly", folly_version
+      sss.compiler_flags       = folly_compiler_flags
+      sss.source_files         = "ReactCommon/fabric/mounting/*.{cpp,h}"
+      sss.exclude_files        = "**/tests/*"
+      sss.header_dir           = "react/mounting"
+      sss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/Folly\"" }
+    end
+
+    ss.subspec "root" do |sss|
+      sss.dependency             "Folly", folly_version
+      sss.compiler_flags       = folly_compiler_flags
+      sss.source_files         = "ReactCommon/fabric/components/root/**/*.{cpp,h}"
+      sss.exclude_files        = "**/tests/*"
+      sss.header_dir           = "react/components/root"
       sss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/Folly\"" }
     end
 
     ss.subspec "scrollview" do |sss|
       sss.dependency             "Folly", folly_version
       sss.compiler_flags       = folly_compiler_flags
-      sss.source_files         = "ReactCommon/fabric/scrollview/**/*.{cpp,h}"
+      sss.source_files         = "ReactCommon/fabric/components/scrollview/*.{cpp,h}"
       sss.exclude_files        = "**/tests/*"
-      sss.header_dir           = "fabric/scrollview"
+      sss.header_dir           = "react/components/scrollview"
+      sss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/Folly\"" }
+    end
+
+    ss.subspec "slider" do |sss|
+      sss.dependency             "Folly", folly_version
+      sss.compiler_flags       = folly_compiler_flags
+      sss.source_files         = "ReactCommon/fabric/components/slider/*.{cpp,h}"
+      sss.exclude_files        = "**/tests/*"
+      sss.header_dir           = "react/components/slider"
       sss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/Folly\"" }
     end
 
     ss.subspec "text" do |sss|
       sss.dependency             "Folly", folly_version
       sss.compiler_flags       = folly_compiler_flags
-      sss.source_files         = "ReactCommon/fabric/text/**/*.{cpp,h}"
+      sss.source_files         = "ReactCommon/fabric/components/text/**/*.{cpp,h}"
       sss.exclude_files        = "**/tests/*"
-      sss.header_dir           = "fabric/text"
+      sss.header_dir           = "react/components/text"
       sss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/Folly\"" }
     end
 
     ss.subspec "textlayoutmanager" do |sss|
       sss.dependency             "Folly", folly_version
       sss.compiler_flags       = folly_compiler_flags
-      sss.source_files         = "ReactCommon/fabric/textlayoutmanager/**/*.{cpp,h,mm}"
+      sss.source_files         = "ReactCommon/fabric/textlayoutmanager/platform/ios/**/*.{cpp,h,mm}"
       sss.exclude_files        = "**/tests/*"
-      sss.header_dir           = "fabric/textlayoutmanager"
+      sss.header_dir           = "react/textlayoutmanager"
       sss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/Folly\"" }
     end
 
@@ -234,7 +300,16 @@ Pod::Spec.new do |s|
       sss.compiler_flags       = folly_compiler_flags
       sss.source_files         = "ReactCommon/fabric/uimanager/**/*.{cpp,h}"
       sss.exclude_files        = "**/tests/*"
-      sss.header_dir           = "fabric/uimanager"
+      sss.header_dir           = "react/uimanager"
+      sss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/Folly\"" }
+    end
+
+    ss.subspec "utils" do |sss|
+      sss.dependency             "Folly", folly_version
+      sss.compiler_flags       = folly_compiler_flags
+      sss.source_files         = "ReactCommon/utils/*.{cpp,h}"
+      sss.exclude_files        = "**/tests/*"
+      sss.header_dir           = "react/utils"
       sss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/Folly\"" }
     end
 
@@ -242,9 +317,9 @@ Pod::Spec.new do |s|
       sss.dependency             "Folly", folly_version
       sss.dependency             "yoga"
       sss.compiler_flags       = folly_compiler_flags
-      sss.source_files         = "ReactCommon/fabric/view/**/*.{cpp,h}"
+      sss.source_files         = "ReactCommon/fabric/components/view/**/*.{cpp,h}"
       sss.exclude_files        = "**/tests/*"
-      sss.header_dir           = "fabric/view"
+      sss.header_dir           = "react/components/view"
       sss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/Folly\"" }
     end
   end

--- a/ReactCommon/fabric/sample/SampleComponentDescriptorFactor.cpp
+++ b/ReactCommon/fabric/sample/SampleComponentDescriptorFactor.cpp
@@ -20,7 +20,7 @@ ComponentRegistryFactory getDefaultComponentRegistryFactory() {
             const SharedContextContainer &contextContainer) {
     auto registry = std::make_shared<ComponentDescriptorRegistry>();
     return registry;
-  }
+  };
 }
 
 } // namespace react

--- a/third-party-podspecs/Folly.podspec
+++ b/third-party-podspecs/Folly.podspec
@@ -16,22 +16,55 @@ Pod::Spec.new do |spec|
   spec.dependency 'boost-for-react-native'
   spec.dependency 'DoubleConversion'
   spec.dependency 'glog'
-  spec.compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1'
+  spec.dependency 'libevent'
+  spec.compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -DFOLLY_HAVE_PTHREAD=1'
   spec.source_files = 'folly/String.cpp',
                       'folly/Conv.cpp',
                       'folly/Demangle.cpp',
                       'folly/Format.cpp',
+                      'folly/FileUtil.cpp',
                       'folly/ScopeGuard.cpp',
+                      'folly/StringBase.cpp',
                       'folly/Unicode.cpp',
                       'folly/dynamic.cpp',
                       'folly/json.cpp',
                       'folly/json_pointer.cpp',
                       'folly/container/detail/F14Table.cpp',
                       'folly/detail/Demangle.cpp',
+                      'folly/detail/AtFork.cpp',
+                      'folly/detail/MemoryIdler.cpp',
+                      'folly/detail/StaticSingletonManager.cpp',
                       'folly/hash/SpookyHashV2.cpp',
+                      'folly/futures/Future.cpp',
                       'folly/lang/Assume.cpp',
                       'folly/lang/ColdClass.cpp',
-                      'folly/memory/detail/MallocImpl.cpp'
+                      'folly/portability/BitsFunctexcept.cpp',
+                      'folly/memory/detail/MallocImpl.cpp',
+                      'folly/memory/MallctlHelper.cpp',
+                      'folly/futures/ThreadWheelTimekeeper.cpp',
+                      'folly/Executor.cpp',
+                      'folly/executors/InlineExecutor.cpp',
+                      'folly/executors/TimedDrivableExecutor.cpp',
+                      'folly/ExceptionWrapper.cpp',
+                      'folly/io/async/Request.cpp',
+                      'folly/detail/ThreadLocalDetail.cpp',
+                      'folly/SharedMutex.cpp',
+                      'folly/concurrency/CacheLocality.cpp',
+                      'folly/detail/Futex.cpp',
+                      'folly/portability/SysUio.cpp',
+                      'folly/synchronization/ParkingLot.cpp',
+                      'folly/synchronization/Hazptr.cpp',
+                      'folly/io/async/HHWheelTimer.cpp',
+                      'folly/synchronization/WaitOptions.cpp',
+                      'folly/synchronization/AsymmetricMemoryBarrier.cpp',
+                      'folly/io/async/AsyncTimeout.cpp',
+                      'folly/io/async/EventBase.cpp',
+                      'folly/io/async/EventHandler.cpp',
+                      'folly/system/ThreadName.cpp',
+                      'folly/Singleton.cpp',
+                      'folly/io/async/VirtualEventBase.cpp',
+                      'folly/io/async/TimeoutManager.cpp',
+                      'folly/lang/SafeAssert.cpp'
   # workaround for https://github.com/facebook/react-native/issues/14326
   spec.preserve_paths = 'folly/*.h',
                         'folly/container/*.h',
@@ -40,10 +73,24 @@ Pod::Spec.new do |spec|
                         'folly/functional/*.h',
                         'folly/hash/*.h',
                         'folly/lang/*.h',
+                        'folly/futures/*.h',
+                        'folly/futures/detail/*.h',
+                        'folly/executors/*.h',
+                        'folly/concurrency/*.h',
+                        'folly/system/*.h',
+                        'folly/synchronization/*.h',
+                        'folly/synchronization/detail/*.h',
+                        'folly/io/async/*.h',
+                        'folly/tracing/*.h',
+                        'folly/experimental/*.h',
                         'folly/memory/*.h',
                         'folly/memory/detail/*.h',
                         'folly/portability/*.h'
-  spec.libraries           = "stdc++"
+  spec.libraries           = "c++"
+  spec.xcconfig = {
+    'USE_HEADERMAP' => 'NO',
+  }
+  spec.header_mappings_dir = '.'
   spec.pod_target_xcconfig = { "USE_HEADERMAP" => "NO",
                                "CLANG_CXX_LANGUAGE_STANDARD" => "c++14",
                                "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)\" \"$(PODS_ROOT)/boost-for-react-native\" \"$(PODS_ROOT)/DoubleConversion\"" }

--- a/third-party-podspecs/libevent.podspec
+++ b/third-party-podspecs/libevent.podspec
@@ -1,0 +1,260 @@
+
+Pod::Spec.new do |s|
+
+    s.name         = "libevent"
+    s.version      = "2.1.5-beta"
+    s.summary      = "An event notification library."
+  
+    s.description  = <<-DESC
+  The libevent API provides a mechanism to execute a callback function when a
+  specific event occurs on a file descriptor or after a timeout has been reached.
+  Furthermore, libevent also supports callbacks due to signals or regular
+  timeouts.
+                     DESC
+  
+    s.homepage     = "http://libevent.org"
+    s.documentation_url = "http://www.wangafu.net/~nickm/libevent-2.1/doxygen/html/"
+  
+    s.license      = "BSD"
+  
+    s.authors             = { "Nick Mathewson" => "nickm@alum.mit.edu",
+                              "Niels Provos" => "provos@umich.edu" }
+  
+    s.platform     = :ios, "8.0"
+  
+    #  When using multiple platforms
+    # s.ios.deployment_target = "5.0"
+    # s.osx.deployment_target = "10.7"
+    # s.watchos.deployment_target = "2.0"
+    s.compiler_flags = '-Wno-shorten-64-to-32', '-Wno-unused-function', '-Wno-unreachable-code',
+                       '-Wno-tautological-constant-out-of-range-compare',
+                       '-Wno-constant-conversion',
+                       '-Wno-ambiguous-macro'
+  
+    s.source = { :git => "https://github.com/libevent/libevent.git",
+                 :tag => "release-2.1.5-beta" }
+  
+    s.source_files  = [ "*.h",
+                        "buffer.c",
+                        "bufferevent.c",
+                        "bufferevent_filter.c",
+                        "bufferevent_pair.c",
+                        "bufferevent_ratelim.c",
+                        "bufferevent_sock.c",
+                        "evdns.c",
+                        "event.c",
+                        "event_tagging.c",
+                        "evmap.c",
+                        "evthread.c",
+                        "evthread_pthread.c",
+                        "evrpc.c",
+                        "evutil.c",
+                        "evutil_rand.c",
+                        "evutil_time.c",
+                        "http.c",
+                        "kqueue.c",
+                        "listener.c",
+                        "log.c",
+                        "poll.c",
+                        "select.c",
+                        "signal.c",
+                        "include/event.h",
+                        "include/evutil.h",
+                        "include/event2/buffer.h",
+                        "include/event2/buffer_compat.h",
+                        "include/event2/bufferevent.h",
+                        "include/event2/bufferevent_compat.h",
+                        "include/event2/bufferevent_struct.h",
+                        "include/event2/dns.h",
+                        "include/event2/dns_compat.h",
+                        "include/event2/tag_compat.h",
+                        "include/event2/dns_struct.h",
+                        "include/event2/event.h",
+                        "include/event2/event_compat.h",
+                        "include/event2/event_struct.h",
+                        "include/event2/event-config.h",
+                        "include/event2/http.h",
+                        "include/event2/http_compat.h",
+                        "include/event2/http_struct.h",
+                        "include/event2/keyvalq_struct.h",
+                        "include/event2/listener.h",
+                        "include/event2/tag.h",
+                        "include/event2/thread.h",
+                        "include/event2/rpc.h",
+                        "include/event2/rpc_struct.h",
+                        "include/event2/util.h",
+                        "include/event2/visibility.h",
+                        "include/sys/queue.h" ]
+    s.header_mappings_dir = "include"
+    s.xcconfig = {
+      'USE_HEADERMAP' => 'NO',
+    }
+  
+    s.public_header_files = "include/event2/*.h",
+                            "include/*.h"
+  
+    s.prepare_command = <<-CMD
+  mkdir -p include/sys
+  cp compat/sys/queue.h include/sys
+  cat > include/event2/event-config.h <<EVENT_CONFIG_H
+  #ifndef EVENT2_EVENT_CONFIG_H_INCLUDED_
+  #define EVENT2_EVENT_CONFIG_H_INCLUDED_
+  #define EVENT__HAVE_ARC4RANDOM 1
+  #define EVENT__HAVE_ARC4RANDOM_BUF 1
+  #define EVENT__HAVE_ARPA_INET_H 1
+  #define EVENT__HAVE_DECL_CTL_KERN 1
+  #define EVENT__HAVE_DECL_KERN_ARND 0
+  #define EVENT__HAVE_DECL_KERN_RANDOM 0
+  #define EVENT__HAVE_DECL_RANDOM_UUID 0
+  #define EVENT__HAVE_DLFCN_H 1
+  #define EVENT__HAVE_FCNTL 1
+  #define EVENT__HAVE_FCNTL_H 1
+  #define EVENT__HAVE_FD_MASK 1
+  #define EVENT__HAVE_GETADDRINFO 1
+  #define EVENT__HAVE_GETEGID 1
+  #define EVENT__HAVE_GETEUID 1
+  #define EVENT__HAVE_GETIFADDRS 1
+  #define EVENT__HAVE_GETNAMEINFO 1
+  #define EVENT__HAVE_GETPROTOBYNUMBER 1
+  #define EVENT__HAVE_GETTIMEOFDAY 1
+  #define EVENT__HAVE_IFADDRS_H 1
+  #define EVENT__HAVE_INET_NTOP 1
+  #define EVENT__HAVE_INET_PTON 1
+  #define EVENT__HAVE_INTTYPES_H 1
+  #define EVENT__HAVE_ISSETUGID 1
+  #define EVENT__HAVE_KQUEUE 1
+  #define EVENT__HAVE_LIBZ 1
+  #define EVENT__HAVE_MACH_ABSOLUTE_TIME 1
+  #define EVENT__HAVE_MACH_MACH_TIME_H 1
+  #define EVENT__HAVE_MEMORY_H 1
+  #define EVENT__HAVE_MMAP 1
+  #define EVENT__HAVE_NANOSLEEP 1
+  #define EVENT__HAVE_NETDB_H 1
+  #define EVENT__HAVE_NETINET_IN_H 1
+  #define EVENT__HAVE_NETINET_TCP_H 1
+  #define EVENT__HAVE_PIPE 1
+  #define EVENT__HAVE_POLL 1
+  #define EVENT__HAVE_POLL_H 1
+  #define EVENT__HAVE_PTHREADS 1
+  #define EVENT__HAVE_PUTENV 1
+  #define EVENT__HAVE_SA_FAMILY_T 1
+  #define EVENT__HAVE_SELECT 1
+  #define EVENT__HAVE_SENDFILE 1
+  #define EVENT__HAVE_SETENV 1
+  #define EVENT__HAVE_SETFD 1
+  #define EVENT__HAVE_SETRLIMIT 1
+  #define EVENT__HAVE_SIGACTION 1
+  #define EVENT__HAVE_SIGNAL 1
+  #define EVENT__HAVE_STDARG_H 1
+  #define EVENT__HAVE_STDDEF_H 1
+  #define EVENT__HAVE_STDINT_H 1
+  #define EVENT__HAVE_STDLIB_H 1
+  #define EVENT__HAVE_STRINGS_H 1
+  #define EVENT__HAVE_STRING_H 1
+  #define EVENT__HAVE_STRLCPY 1
+  #define EVENT__HAVE_STRSEP 1
+  #define EVENT__HAVE_STRTOK_R 1
+  #define EVENT__HAVE_STRTOLL 1
+  #define EVENT__HAVE_STRUCT_ADDRINFO 1
+  #define EVENT__HAVE_STRUCT_IN6_ADDR 1
+  #define EVENT__HAVE_STRUCT_SOCKADDR_IN6 1
+  #define EVENT__HAVE_STRUCT_SOCKADDR_IN6_SIN6_LEN 1
+  #define EVENT__HAVE_STRUCT_SOCKADDR_IN_SIN_LEN 1
+  #define EVENT__HAVE_STRUCT_SOCKADDR_STORAGE 1
+  #define EVENT__HAVE_STRUCT_SOCKADDR_STORAGE_SS_FAMILY 1
+  #define EVENT__HAVE_SYSCTL 1
+  #define EVENT__HAVE_SYS_EVENT_H 1
+  #define EVENT__HAVE_SYS_IOCTL_H 1
+  #define EVENT__HAVE_SYS_MMAN_H 1
+  #define EVENT__HAVE_SYS_PARAM_H 1
+  #define EVENT__HAVE_SYS_QUEUE_H 1
+  #define EVENT__HAVE_SYS_RESOURCE_H 1
+  #define EVENT__HAVE_SYS_SELECT_H 1
+  #define EVENT__HAVE_SYS_SOCKET_H 1
+  #define EVENT__HAVE_SYS_STAT_H 1
+  #define EVENT__HAVE_SYS_SYSCTL_H 1
+  #define EVENT__HAVE_SYS_TIME_H 1
+  #define EVENT__HAVE_SYS_TYPES_H 1
+  #define EVENT__HAVE_SYS_UIO_H 1
+  #define EVENT__HAVE_SYS_WAIT_H 1
+  #define EVENT__HAVE_TAILQFOREACH 1
+  #define EVENT__HAVE_TIMERADD 1
+  #define EVENT__HAVE_TIMERCLEAR 1
+  #define EVENT__HAVE_TIMERCMP 1
+  #define EVENT__HAVE_TIMERISSET 1
+  #define EVENT__HAVE_UINT16_T 1
+  #define EVENT__HAVE_UINT32_T 1
+  #define EVENT__HAVE_UINT64_T 1
+  #define EVENT__HAVE_UINT8_T 1
+  #define EVENT__HAVE_UINTPTR_T 1
+  #define EVENT__HAVE_UMASK 1
+  #define EVENT__HAVE_UNISTD_H 1
+  #define EVENT__HAVE_UNSETENV 1
+  #define EVENT__HAVE_USLEEP 1
+  #define EVENT__HAVE_VASPRINTF 1
+  #define EVENT__HAVE_ZLIB_H 1
+  #define EVENT__LT_OBJDIR ".libs/"
+  #define EVENT__NUMERIC_VERSION 0x02010500
+  #define EVENT__PACKAGE "libevent"
+  #define EVENT__PACKAGE_BUGREPORT ""
+  #define EVENT__PACKAGE_NAME "libevent"
+  #define EVENT__PACKAGE_STRING "libevent 2.1.5-beta"
+  #define EVENT__PACKAGE_TARNAME "libevent"
+  #define EVENT__PACKAGE_URL ""
+  #define EVENT__PACKAGE_VERSION "2.1.5-beta"
+  #define EVENT__SIZEOF_INT 4
+  #define EVENT__SIZEOF_LONG 8
+  #define EVENT__SIZEOF_LONG_LONG 8
+  #define EVENT__SIZEOF_OFF_T 8
+  #define EVENT__SIZEOF_PTHREAD_T 8
+  #define EVENT__SIZEOF_SHORT 2
+  #define EVENT__SIZEOF_SIZE_T 8
+  #define EVENT__SIZEOF_VOID_P 8
+  #define EVENT__STDC_HEADERS 1
+  #define EVENT__TIME_WITH_SYS_TIME 1
+  #ifndef EVENT___ALL_SOURCE
+  # define EVENT___ALL_SOURCE 1
+  #endif
+  #ifndef EVENT___GNU_SOURCE
+  # define EVENT___GNU_SOURCE 1
+  #endif
+  #ifndef EVENT___POSIX_PTHREAD_SEMANTICS
+  # define EVENT___POSIX_PTHREAD_SEMANTICS 1
+  #endif
+  #ifndef EVENT___TANDEM_SOURCE
+  # define EVENT___TANDEM_SOURCE 1
+  #endif
+  #ifndef EVENT____EXTENSIONS__
+  # define EVENT____EXTENSIONS__ 1
+  #endif
+  #define EVENT__VERSION "2.1.5-beta"
+  #ifndef EVENT___DARWIN_USE_64_BIT_INODE
+  # define EVENT___DARWIN_USE_64_BIT_INODE 1
+  #endif
+  #endif /* event2/event-config.h */
+  EVENT_CONFIG_H
+  
+  cat > evconfig-private.h << EVCONFIG_PRIVATE_H
+  #ifndef EVCONFIG_PRIVATE_H_INCLUDED_
+  #define EVCONFIG_PRIVATE_H_INCLUDED_
+  #ifndef _ALL_SOURCE
+  # define _ALL_SOURCE 1
+  #endif
+  #ifndef _GNU_SOURCE
+  # define _GNU_SOURCE 1
+  #endif
+  #ifndef _POSIX_PTHREAD_SEMANTICS
+  # define _POSIX_PTHREAD_SEMANTICS 1
+  #endif
+  #ifndef _TANDEM_SOURCE
+  # define _TANDEM_SOURCE 1
+  #endif
+  #ifndef __EXTENSIONS__
+  # define __EXTENSIONS__ 1
+  #endif
+  #endif
+  EVCONFIG_PRIVATE_H
+  CMD
+  
+    s.requires_arc = false
+  end


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
In service of #22989. This PR adds a podspec capable of building / linking fabric with RNTester. A lot of the folly work is based on @kmagiera commits a few months ago, found [here](https://github.com/kmagiera/react-native/commits/fabric3).

## Todo
- [ ] Proper fix for Float.h conflicting with system headers. (Is a rename okay?)
- [ ] SliderEventEmitter uses floats, which causes Xcode to complain
- [ ] RCTSwitchComponentView references rncore, which appears to be missing 
- [ ] Importing RCTSurfacePresenter.h to AppDelegate causes header errors (due to not being objc++)
- [ ] Check if all folly imports are required
- [ ] Check if libevent is required.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See http://facebook.github.io/react-native/docs/contributing#changelog for an example. -->

[iOS] [Added] - Fabric podspec

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
Pod install RCTFabric & RCTFabricSample & libevent to RNTester, run.