### PR TITLE
iOS Remove invalid bridge warning

### DIFF
--- a/React/CxxModule/RCTNativeModule.mm
+++ b/React/CxxModule/RCTNativeModule.mm
@@ -78,9 +78,6 @@ void RCTNativeModule::invoke(unsigned int methodId, folly::dynamic &&params, int
     } else if (queue) {
       dispatch_async(queue, block);
     }
-  } else {
-    RCTLogWarn(@"Attempted to invoke `%u` (method ID) on `%@` (NativeModule name) with an invalid bridge.",
-               methodId, m_moduleData.name);
   }
 }
 


### PR DESCRIPTION
## Summary

I remove the invalid bridge warning because I believe that it is a pain that every time that the JS gets refreshed this warnings are being thrown. If the project increase size and more and more NativeModules are added this warnings just spam the emulator or the device.

I understand the reason of validating if the bridge is valid. However in case of invalidness nothing is done, just the warning is thrown. Hence, the reason of removing it to improve the development process.

## Changelog

[iOS] [Removed] - Invalid bridge warning message

## Test Plan

* Live Reloads
* Pressing Cmd+D and hit **Reload** or any other action that triggers reload.

Does not show this warning anymore
