### PR TITLE
[iOS] Remove dispatch_queue nil operation when invalidate module data

### DIFF
--- a/React/Base/RCTModuleData.mm
+++ b/React/Base/RCTModuleData.mm
@@ -338,7 +338,6 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init);
 
 - (void)invalidate
 {
-  _methodQueue = nil;
 }
 
 - (NSString *)description


### PR DESCRIPTION
## Summary

Try to fix #23564 , previously, we would nil the dispatch_queue when invalidate `Bridge`, seems it has race condition when get and set concurrency, leads `queue` becomes dangling pointer and throw `EXC_BAD_ACCESS` exception. Now, we let `RCTModuleData` nil it in dealloc.

## Changelog

[iOS] [Fixed] - Remove dispatch_queue nil operation when invalidate module data

## Test Plan

Race condition seems hard to reproduce, we just need to ensure this would not break currently behavior.