### PR TITLE
Fix implicit conversion warning in RCTInspector.mm

### DIFF
--- a/React/Inspector/RCTInspector.mm
+++ b/React/Inspector/RCTInspector.mm
@@ -80,7 +80,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
 + (RCTInspectorLocalConnection *)connectPage:(NSInteger)pageId
                          forRemoteConnection:(RCTInspectorRemoteConnection *)remote
 {
-  auto localConnection = getInstance()->connect(pageId, std::make_unique<RemoteConnection>(remote));
+  auto localConnection = getInstance()->connect((int)pageId, std::make_unique<RemoteConnection>(remote));
   return [[RCTInspectorLocalConnection alloc] initWithConnection:std::move(localConnection)];
 }
 


### PR DESCRIPTION
## Summary

Fixes Xcode warning: `Implicit conversion loses integer precision: 'NSInteger' (aka 'long') to 'int'`.

## Changelog

[iOS] [Fixed] - Fix implicit conversion warning in RCTInspector.mm

## Test Plan

Checked that RNTester was built without this warning in Xcode.