### PR TITLE
Prevent okhttp from adding ;charset=utf8 to ContentType Header

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/modules/network/NetworkingModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/network/NetworkingModule.java
@@ -372,7 +372,7 @@ public final class NetworkingModule extends ReactContextBaseJavaModule {
           return;
         }
       } else {
-        requestBody = RequestBody.create(contentMediaType, body.getBytes());
+        requestBody = RequestBody.create(contentMediaType, body.getBytes(StandardCharsets.UTF_8));
       }
     } else if (data.hasKey(REQUEST_BODY_KEY_BASE64)) {
       if (contentType == null) {

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/network/NetworkingModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/network/NetworkingModule.java
@@ -372,7 +372,7 @@ public final class NetworkingModule extends ReactContextBaseJavaModule {
           return;
         }
       } else {
-        requestBody = RequestBody.create(contentMediaType, body);
+        requestBody = RequestBody.create(contentMediaType, body.getBytes());
       }
     } else if (data.hasKey(REQUEST_BODY_KEY_BASE64)) {
       if (contentType == null) {

--- a/ReactAndroid/src/test/java/com/facebook/react/modules/network/NetworkingModuleTest.java
+++ b/ReactAndroid/src/test/java/com/facebook/react/modules/network/NetworkingModuleTest.java
@@ -342,7 +342,7 @@ public class NetworkingModuleTest {
     ArgumentCaptor<Request> argumentCaptor = ArgumentCaptor.forClass(Request.class);
     verify(httpClient).newCall(argumentCaptor.capture());
 
-    // Verify okhttp does not append "charset=utf8
+    // Verify okhttp does not append "charset=utf-8"
     assertThat(argumentCaptor.getValue().body().contentType().toString()).isEqualTo("application/json");
   }
 


### PR DESCRIPTION
## Summary

Before this commit, `fetch()` calls append `"charset=utf8"` to the `Content-Type` header on Android (and not on iOS). This is because of an implementation detail in the okhttp library. This means that you can make a call on the JavaScript side like:

```javascript
let body = JSON.stringify({ key: "value" });

let headers = {
  "Content-Type": "application/json"
};

fetch("http://10.0.2.2:3000", { method: "POST", body, headers });
```

However the resulting request appends the utf8 character:

```
POST - 13:34:32:
  content-type: application/json; charset=utf-8
  content-length: 15
  host: 10.0.2.2:3000
  connection: Keep-Alive
  accept-encoding: gzip
  user-agent: okhttp/3.12.1
```

Passing byte array into the RequestBody avoids this, as recommended by a maintainer of okhttp:

https://github.com/square/okhttp/issues/2099#issuecomment-366757161

Related issues: 
https://github.com/facebook/react-native/issues/8237

## Changelog

[Android][fixed] - Prevent fetch() POST requests on Android from appending `charset=utf-8` to `Content-Type` header.

## Test Plan

I setup a test project here: https://github.com/nhunzaker/rn-charset-issue. It includes a simple node server that logs header output from requests. With this change, the server no longer reports the addition of `charset=utf-8` in the `Content-Type` header.