### PR TITLE
[iOS] Fix build error warning of Text module

### DIFF
--- a/Libraries/Text/TextInput/RCTBaseTextInputView.m
+++ b/Libraries/Text/TextInput/RCTBaseTextInputView.m
@@ -235,7 +235,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithFrame:(CGRect)frame)
                              };
 
           #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 110000 /* __IPHONE_11_0 */
-            if (@available(iOS 11.0, *)) {
+            if (@available(iOS 11.0, tvOS 11.0, *)) {
               NSDictionary<NSString *, NSString *> * iOS11extras = @{@"username": UITextContentTypeUsername,
                                                                      @"password": UITextContentTypePassword};
 
@@ -247,7 +247,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithFrame:(CGRect)frame)
           #endif
 
           #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 120000 /* __IPHONE_12_0 */
-            if (@available(iOS 12.0, *)) {
+            if (@available(iOS 12.0, tvOS 12.0, *)) {
               NSDictionary<NSString *, NSString *> * iOS12extras = @{@"newPassword": UITextContentTypeNewPassword,
                                                                      @"oneTimeCode": UITextContentTypeOneTimeCode};
 


### PR DESCRIPTION

## Summary

Throw error warning when build Text module, we can add tvOS available check to remove error.

## Changelog

[iOS] [Fixed] - Fix build error warning of Text module

## Test Plan

Build successful, not have error warning like below:
<img width="1041" alt="194d2d4d-7d9d-4e20-8f2d-c3e0ba3c80f2" src="https://user-images.githubusercontent.com/5061845/53221749-bf63c000-36a5-11e9-9a6a-2b0a3ff0621b.png">