### PR TITLE
Use existing character set in POST body when possible

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/modules/network/NetworkingModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/network/NetworkingModule.java
@@ -375,7 +375,9 @@ public final class NetworkingModule extends ReactContextBaseJavaModule {
         // Use getBytes() to convert the body into a byte[], preventing okhttp from
         // appending the character set to the Content-Type header when otherwise unspecified
         // https://github.com/facebook/react-native/issues/8237
-        Charset charset = contentMediaType.charset(StandardCharsets.UTF_8);
+        Charset charset = contentMediaType == null
+          ? StandardCharsets.UTF_8
+          : contentMediaType.charset(StandardCharsets.UTF_8);
         requestBody = RequestBody.create(contentMediaType, body.getBytes(charset));
       }
     } else if (data.hasKey(REQUEST_BODY_KEY_BASE64)) {

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/network/NetworkingModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/network/NetworkingModule.java
@@ -372,7 +372,11 @@ public final class NetworkingModule extends ReactContextBaseJavaModule {
           return;
         }
       } else {
-        requestBody = RequestBody.create(contentMediaType, body.getBytes(StandardCharsets.UTF_8));
+        // Use getBytes() to convert the body into a byte[], preventing okhttp from
+        // appending the character set to the Content-Type header when otherwise unspecified
+        // https://github.com/facebook/react-native/issues/8237
+        Charset charset = contentMediaType.charset(StandardCharsets.UTF_8);
+        requestBody = RequestBody.create(contentMediaType, body.getBytes(charset));
       }
     } else if (data.hasKey(REQUEST_BODY_KEY_BASE64)) {
       if (contentType == null) {


### PR DESCRIPTION
## Summary

This commit fixes a bug introduced in a previous attempt (https://github.com/facebook/react-native/pull/23580) to address an issue where okhttp appended `charset=utf-8` to the Content-Type header when otherwise not specified.

In that commit, I converted all characters to UTF-8, however it should instead use an existing encoding when possible.

Related issues:
https://github.com/facebook/react-native/issues/8237#issuecomment-466304854

## Changelog

[Android][fixed] - Respect existing character set when specified in fetch() POST request

## Test Plan

Updated my test case to include a button that posts UTF-16 JSON:
https://github.com/nhunzaker/rn-charset-issue

Without this change, sending UTF-16 JSON fails to decode on the node server.