### PR TITLE
[WIP] Convert switchview target to Android X

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/switchview/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/switchview/BUCK
@@ -3,6 +3,7 @@ load("//tools/build_defs/oss:rn_defs.bzl", "YOGA_TARGET", "react_native_dep", "r
 rn_android_library(
     name = "switchview",
     srcs = glob(["*.java"]),
+    is_androidx = True,
     provided_deps = [
         react_native_dep("third-party/android/support/v7/appcompat-orig:appcompat"),
     ],

--- a/ReactAndroid/src/main/java/com/facebook/react/views/switchview/ReactSwitch.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/switchview/ReactSwitch.java
@@ -10,7 +10,7 @@ package com.facebook.react.views.switchview;
 import android.content.Context;
 import android.graphics.PorterDuff;
 import android.graphics.drawable.Drawable;
-import android.support.v7.widget.SwitchCompat;
+import androidx.appcompat.widget.SwitchCompat;
 import javax.annotation.Nullable;
 
 /**

--- a/ReactAndroid/src/main/third-party/android/androidx/BUCK
+++ b/ReactAndroid/src/main/third-party/android/androidx/BUCK
@@ -1,0 +1,653 @@
+load("//tools/build_defs:fb_native_wrapper.bzl", "fb_native")
+
+fb_native.prebuilt_jar(
+    name = "annotation",
+    binary_jar = ":annotation.jar",
+    visibility = ["PUBLIC"],
+)
+
+fb_native.android_library(
+    name = "appcompat",
+    visibility = ["PUBLIC"],
+    exported_deps = [
+        ":appcompat-binary",
+        ":annotation",
+        ":collection",
+        ":core",
+        ":cursoradapter",
+        ":fragment",
+        ":legacy-support-core-utils",
+        ":vectordrawable",
+        ":vectordrawable-animated",
+    ]
+)
+
+fb_native.android_library(
+    name = "asynclayoutinflater",
+    visibility = ["PUBLIC"],
+    exported_deps = [
+        ":asynclayoutinflater-binary",
+        ":annotation",
+        ":core",
+    ]
+)
+
+fb_native.android_library(
+    name = "collection",
+    visibility = ["PUBLIC"],
+    exported_deps = [
+        ":collection-binary",
+        ":annotation",
+    ]
+)
+
+fb_native.android_library(
+    name = "coordinatorlayout",
+    visibility = ["PUBLIC"],
+    exported_deps = [
+        ":coordinatorlayout-binary",
+        ":annotation",
+        ":core",
+        ":customview",
+    ]
+)
+
+fb_native.android_library(
+    name = "core",
+    visibility = ["PUBLIC"],
+    exported_deps = [
+        ":core-binary",
+        ":annotation",
+        ":collection",
+        ":lifecycle-runtime",
+        ":versionedparcelable",
+    ]
+)
+
+fb_native.android_library(
+    name = "core-common",
+    visibility = ["PUBLIC"],
+    exported_deps = [
+        ":core-common-binary",
+        ":annotation",
+    ]
+)
+
+fb_native.android_library(
+    name = "core-runtime",
+    visibility = ["PUBLIC"],
+    exported_deps = [
+        ":core-runtime-binary",
+        ":core-common",
+    ]
+)
+
+fb_native.android_library(
+    name = "cursoradapter",
+    visibility = ["PUBLIC"],
+    exported_deps = [
+        ":cursoradapter-binary",
+        ":annotation",
+    ]
+)
+
+fb_native.android_library(
+    name = "customview",
+    visibility = ["PUBLIC"],
+    exported_deps = [
+        ":customview-binary",
+        ":annotation",
+        ":core",
+    ]
+)
+
+fb_native.android_library(
+    name = "documentfile",
+    visibility = ["PUBLIC"],
+    exported_deps = [
+        ":documentfile-binary",
+        ":annotation",
+    ]
+)
+
+fb_native.android_library(
+    name = "drawerlayout",
+    visibility = ["PUBLIC"],
+    exported_deps = [
+        ":drawerlayout-binary",
+        ":annotation",
+        ":core",
+        ":customview",
+    ]
+)
+
+fb_native.android_library(
+    name = "fragment",
+    visibility = ["PUBLIC"],
+    exported_deps = [
+        ":fragment-binary",
+        ":annotation",
+        ":core",
+        ":legacy-support-core-ui",
+        ":legacy-support-core-utils",
+        ":lifecycle-viewmodel",
+        ":loader",
+    ]
+)
+
+fb_native.android_library(
+    name = "interpolator",
+    visibility = ["PUBLIC"],
+    exported_deps = [
+        ":interpolator-binary",
+        ":annotation",
+    ]
+)
+
+fb_native.android_library(
+    name = "legacy-support-core-ui",
+    visibility = ["PUBLIC"],
+    exported_deps = [
+        ":legacy-support-core-ui-binary",
+        ":annotation",
+        ":asynclayoutinflater",
+        ":coordinatorlayout",
+        ":core",
+        ":cursoradapter",
+        ":customview",
+        ":drawerlayout",
+        ":interpolator",
+        ":legacy-support-core-utils",
+        ":slidingpanelayout",
+        ":swiperefreshlayout",
+        ":viewpager",
+    ]
+)
+
+
+fb_native.android_library(
+    name = "legacy-support-core-utils",
+    visibility = ["PUBLIC"],
+    exported_deps = [
+        ":legacy-support-core-utils-binary",
+        ":annotation",
+        ":core",
+        ":documentfile",
+        ":loader",
+        ":localbroadcastmanager",
+        ":print",
+    ]
+)
+
+fb_native.android_library(
+    name = "lifecycle-common",
+    visibility = ["PUBLIC"],
+    exported_deps = [
+        ":lifecycle-common-binary",
+        ":annotation",
+    ]
+)
+
+fb_native.android_library(
+    name = "lifecycle-livedata",
+    visibility = ["PUBLIC"],
+    exported_deps = [
+        ":lifecycle-livedata-binary",
+        ":core-common",
+        ":core-runtime",
+        ":lifecycle-livedata-core",
+    ]
+)
+
+fb_native.android_library(
+    name = "lifecycle-livedata-core",
+    visibility = ["PUBLIC"],
+    exported_deps = [
+        ":lifecycle-livedata-core-binary",
+        ":core-common",
+        ":core-runtime",
+        ":lifecycle-common",
+    ]
+)
+
+fb_native.android_library(
+    name = "lifecycle-runtime",
+    visibility = ["PUBLIC"],
+    exported_deps = [
+        ":lifecycle-runtime-binary",
+        ":annotation",
+        ":core-common",
+        ":lifecycle-common",
+    ]
+)
+
+fb_native.android_library(
+    name = "lifecycle-viewmodel",
+    visibility = ["PUBLIC"],
+    exported_deps = [
+        ":lifecycle-viewmodel-binary",
+        ":annotation",
+    ]
+)
+
+fb_native.android_library(
+    name = "localbroadcastmanager",
+    visibility = ["PUBLIC"],
+    exported_deps = [
+        ":localbroadcastmanager-binary",
+        ":annotation",
+    ]
+)
+
+fb_native.android_library(
+    name = "loader",
+    visibility = ["PUBLIC"],
+    exported_deps = [
+        ":loader-binary",
+        ":annotation",
+        ":core",
+        ":lifecycle-livedata",
+        ":lifecycle-viewmodel",
+    ]
+)
+
+fb_native.android_library(
+    name = "print",
+    visibility = ["PUBLIC"],
+    exported_deps = [
+        ":print-binary",
+        ":annotation",
+    ]
+)
+
+fb_native.android_library(
+    name = "slidingpanelayout",
+    visibility = ["PUBLIC"],
+    exported_deps = [
+        ":slidingpanelayout-binary",
+        ":annotation",
+        ":core",
+        ":customview",
+    ]
+)
+
+fb_native.android_library(
+    name = "swiperefreshlayout",
+    visibility = ["PUBLIC"],
+    exported_deps = [
+        ":swiperefreshlayout-binary",
+        ":annotation",
+        ":core",
+        ":interpolator",
+    ]
+)
+
+fb_native.android_library(
+    name = "vectordrawable",
+    visibility = ["PUBLIC"],
+    exported_deps = [
+        ":vectordrawable-binary",
+        ":annotation",
+        ":core",
+    ]
+)
+
+fb_native.android_library(
+    name = "vectordrawable-animated",
+    visibility = ["PUBLIC"],
+    exported_deps = [
+        ":vectordrawable-animated-binary",
+        ":legacy-support-core-ui",
+        ":vectordrawable",
+    ]
+)
+
+fb_native.android_library(
+    name = "versionedparcelable",
+    visibility = ["PUBLIC"],
+    exported_deps = [
+        ":versionedparcelable-binary",
+        ":annotation",
+        ":collection",
+    ]
+)
+
+fb_native.android_library(
+    name = "viewpager",
+    visibility = ["PUBLIC"],
+    exported_deps = [
+        ":viewpager-binary",
+        ":annotation",
+        ":core",
+        ":customview",
+    ]
+)
+
+# Internal targets
+fb_native.android_prebuilt_aar(
+    name = "appcompat-binary",
+    aar = ":appcompat-binary-aar",
+)
+
+fb_native.android_prebuilt_aar(
+    name = "asynclayoutinflater-binary",
+    aar = ":asynclayoutinflater-binary-aar",
+)
+
+fb_native.prebuilt_jar(
+    name = "collection-binary",
+    binary_jar = ":collection-binary.jar",
+)
+
+fb_native.android_prebuilt_aar(
+    name = "coordinatorlayout-binary",
+    aar = ":coordinatorlayout-binary-aar",
+)
+
+fb_native.android_prebuilt_aar(
+    name = "core-binary",
+    aar = ":core-binary-aar",
+)
+
+fb_native.prebuilt_jar(
+    name = "core-common-binary",
+    binary_jar = ":core-common-binary.jar",
+)
+
+fb_native.android_prebuilt_aar(
+    name = "core-runtime-binary",
+    aar = ":core-runtime-binary-aar",
+)
+
+fb_native.android_prebuilt_aar(
+    name = "cursoradapter-binary",
+    aar = ":cursoradapter-binary-aar",
+)
+
+fb_native.android_prebuilt_aar(
+    name = "customview-binary",
+    aar = ":customview-binary-aar",
+)
+
+fb_native.android_prebuilt_aar(
+    name = "documentfile-binary",
+    aar = ":documentfile-binary-aar",
+)
+
+fb_native.android_prebuilt_aar(
+    name = "drawerlayout-binary",
+    aar = ":drawerlayout-binary-aar",
+)
+
+fb_native.android_prebuilt_aar(
+    name = "fragment-binary",
+    aar = ":fragment-binary-aar",
+)
+
+fb_native.android_prebuilt_aar(
+    name = "interpolator-binary",
+    aar = ":interpolator-binary-aar",
+)
+
+fb_native.android_prebuilt_aar(
+    name = "legacy-support-core-ui-binary",
+    aar = ":legacy-support-core-ui-binary-aar",
+)
+
+fb_native.android_prebuilt_aar(
+    name = "legacy-support-core-utils-binary",
+    aar = ":legacy-support-core-utils-binary-aar",
+)
+
+fb_native.prebuilt_jar(
+    name = "lifecycle-common-binary",
+    binary_jar = ":lifecycle-common-binary.jar",
+)
+
+fb_native.android_prebuilt_aar(
+    name = "lifecycle-livedata-binary",
+    aar = ":lifecycle-livedata-binary-aar",
+)
+
+fb_native.android_prebuilt_aar(
+    name = "lifecycle-livedata-core-binary",
+    aar = ":lifecycle-livedata-core-binary-aar",
+)
+
+fb_native.android_prebuilt_aar(
+    name = "lifecycle-runtime-binary",
+    aar = ":lifecycle-runtime-binary-aar",
+)
+
+fb_native.android_prebuilt_aar(
+    name = "lifecycle-viewmodel-binary",
+    aar = ":lifecycle-viewmodel-binary-aar",
+)
+
+fb_native.android_prebuilt_aar(
+    name = "loader-binary",
+    aar = ":loader-binary-aar",
+)
+
+fb_native.android_prebuilt_aar(
+    name = "localbroadcastmanager-binary",
+    aar = ":localbroadcastmanager-binary-aar",
+)
+
+fb_native.android_prebuilt_aar(
+    name = "print-binary",
+    aar = ":print-binary-aar",
+)
+
+fb_native.android_prebuilt_aar(
+    name = "slidingpanelayout-binary",
+    aar = ":slidingpanelayout-binary-aar",
+)
+
+fb_native.android_prebuilt_aar(
+    name = "swiperefreshlayout-binary",
+    aar = ":swiperefreshlayout-binary-aar",
+)
+
+fb_native.android_prebuilt_aar(
+    name = "vectordrawable-binary",
+    aar = ":vectordrawable-binary-aar",
+)
+
+fb_native.android_prebuilt_aar(
+    name = "vectordrawable-animated-binary",
+    aar = ":vectordrawable-animated-binary-aar",
+)
+
+fb_native.android_prebuilt_aar(
+    name = "versionedparcelable-binary",
+    aar = ":versionedparcelable-binary-aar",
+)
+
+
+fb_native.android_prebuilt_aar(
+    name = "viewpager-binary",
+    aar = ":viewpager-binary-aar",
+)
+
+# Remote files
+fb_native.remote_file(
+    name = "annotation.jar",
+    sha1 = "2dfd8f6b2a8fc466a1ae4e329fb79cd580f6393f",
+    url = "mvn:androidx.annotation:annotation:jar:1.0.1",
+)
+
+fb_native.remote_file(
+    name = "appcompat-binary-aar",
+    sha1 = "002533a36c928bb27a3cc6843a25f83754b3c3ae",
+    url = "mvn:androidx.appcompat:appcompat:aar:1.0.2",
+)
+
+fb_native.remote_file(
+    name = "asynclayoutinflater-binary-aar",
+    sha1 = "5ffa788d19a6863799f25cb50d4fdfb0ec649037",
+    url = "mvn:androidx.asynclayoutinflater:asynclayoutinflater:aar:1.0.0",
+)
+
+
+fb_native.remote_file(
+    name = "collection-binary.jar",
+    sha1 = "42858b26cafdaa69b6149f45dfc2894007bc2c7a",
+    url = "mvn:androidx.collection:collection:jar:1.0.0",
+)
+
+fb_native.remote_file(
+    name = "core-binary-aar",
+    sha1 = "263deba7f9c24bd0cefb93c0aaaf402cc50828ee",
+    url = "mvn:androidx.core:core:aar:1.0.1",
+)
+
+fb_native.remote_file(
+    name = "core-common-binary.jar",
+    sha1 = "bb21b9a11761451b51624ac428d1f1bb5deeac38",
+    url = "mvn:androidx.arch.core:core-common:jar:2.0.0",
+)
+
+fb_native.remote_file(
+    name = "core-runtime-binary-aar",
+    sha1 = "c5be9edf9ca9135a465d23939f6e7d0e1cf90b41",
+    url = "mvn:androidx.arch.core:core-runtime:aar:2.0.0",
+)
+
+fb_native.remote_file(
+    name = "coordinatorlayout-binary-aar",
+    sha1 = "7664385a7e39112b780baf8819ee880dcd3c4094",
+    url = "mvn:androidx.coordinatorlayout:coordinatorlayout:aar:1.0.0",
+)
+
+fb_native.remote_file(
+    name = "cursoradapter-binary-aar",
+    sha1 = "74014983a86b83cbce534dec4e7aa9312f5f5d82",
+    url = "mvn:androidx.cursoradapter:cursoradapter:aar:1.0.0",
+)
+
+fb_native.remote_file(
+    name = "customview-binary-aar",
+    sha1 = "30f5ff6075d112f8076e733b24410e68159735b6",
+    url = "mvn:androidx.customview:customview:aar:1.0.0",
+)
+
+fb_native.remote_file(
+    name = "documentfile-binary-aar",
+    sha1 = "66104345c90cd8c2fd5ad2d3aad692b280e10c32",
+    url = "mvn:androidx.documentfile:documentfile:aar:1.0.0",
+)
+
+fb_native.remote_file(
+    name = "drawerlayout-binary-aar",
+    sha1 = "dd02c7e207136e1272b33815cc61e57676ed13a2",
+    url = "mvn:androidx.drawerlayout:drawerlayout:aar:1.0.0",
+)
+
+fb_native.remote_file(
+    name = "fragment-binary-aar",
+    sha1 = "0b40f6a2ae814f72d1e71a5df6dc1283c00cd52f",
+    url = "mvn:androidx.fragment:fragment:aar:1.0.0",
+)
+
+fb_native.remote_file(
+    name = "interpolator-binary-aar",
+    sha1 = "8a01fa254a23b9388571eb6334b03707c7d122d7",
+    url = "mvn:androidx.interpolator:interpolator:aar:1.0.0",
+)
+
+fb_native.remote_file(
+    name = "legacy-support-core-ui-binary-aar",
+    sha1 = "61a264f996046e059f889914050fae1e75d3b702",
+    url = "mvn:androidx.legacy:legacy-support-core-ui:aar:1.0.0",
+)
+
+fb_native.remote_file(
+    name = "legacy-support-core-utils-binary-aar",
+    sha1 = "9b9570042115da8629519090dfeb71df75da59fc",
+    url = "mvn:androidx.legacy:legacy-support-core-utils:aar:1.0.0",
+)
+
+fb_native.remote_file(
+    name = "lifecycle-common-binary.jar",
+    sha1 = "e070ffae07452331bc5684734fce6831d531785c",
+    url = "mvn:androidx.lifecycle:lifecycle-common:jar:2.0.0",
+)
+
+fb_native.remote_file(
+    name = "lifecycle-livedata-binary-aar",
+    sha1 = "c17007cd0b21d6401910b0becdd16c438c68a9af",
+    url = "mvn:androidx.lifecycle:lifecycle-livedata:aar:2.0.0",
+)
+
+fb_native.remote_file(
+    name = "lifecycle-livedata-core-binary-aar",
+    sha1 = "1a7cee84b43fa935231b016f0665cd56a72fa9db",
+    url = "mvn:androidx.lifecycle:lifecycle-livedata-core:aar:2.0.0",
+)
+
+fb_native.remote_file(
+    name = "lifecycle-runtime-binary-aar",
+    sha1 = "ea27e9e79e9a0fbedfa4dbbef5ddccf0e1d9d73f",
+    url = "mvn:androidx.lifecycle:lifecycle-runtime:aar:2.0.0",
+)
+
+fb_native.remote_file(
+    name = "lifecycle-viewmodel-binary-aar",
+    sha1 = "6417c576c458137456d996914c50591e7f4acc24",
+    url = "mvn:androidx.lifecycle:lifecycle-viewmodel:aar:2.0.0",
+)
+
+fb_native.remote_file(
+    name = "loader-binary-aar",
+    sha1 = "8af8b6cec0da85c207d03e15840e0722cbc71e70",
+    url = "mvn:androidx.loader:loader:aar:1.0.0",
+)
+
+fb_native.remote_file(
+    name = "localbroadcastmanager-binary-aar",
+    sha1 = "2734f31c8321e83ce6b60570d14777fc33cc2ece",
+    url = "mvn:androidx.localbroadcastmanager:localbroadcastmanager:aar:1.0.0",
+)
+
+fb_native.remote_file(
+    name = "print-binary-aar",
+    sha1 = "7722094652c48ebe27acc94d74a55e759e4635ff",
+    url = "mvn:androidx.print:print:aar:1.0.0",
+)
+
+fb_native.remote_file(
+    name = "slidingpanelayout-binary-aar",
+    sha1 = "37eba9ccbf09b75cc4aa78a5e182d5b8ba79ad6a",
+    url = "mvn:androidx.slidingpanelayout:slidingpanelayout:aar:1.0.0",
+)
+
+fb_native.remote_file(
+    name = "swiperefreshlayout-binary-aar",
+    sha1 = "4fd265b80a2b0fbeb062ab2bc4b1487521507762",
+    url = "mvn:androidx.swiperefreshlayout:swiperefreshlayout:aar:1.0.0",
+)
+
+fb_native.remote_file(
+    name = "vectordrawable-binary-aar",
+    sha1 = "33d1eb71849dffbad12add134a25eb63cad4a1eb",
+    url = "mvn:androidx.vectordrawable:vectordrawable:aar:1.0.1",
+)
+
+fb_native.remote_file(
+    name = "vectordrawable-animated-binary-aar",
+    sha1 = "0a41681ac4e1747f87237e489699089ad46b7a5e",
+    url = "mvn:androidx.vectordrawable:vectordrawable-animated:aar:1.0.0",
+)
+
+fb_native.remote_file(
+    name = "versionedparcelable-binary-aar",
+    sha1 = "52718baf7e51ccba173b468a1034caba8140752e",
+    url = "mvn:androidx.versionedparcelable:versionedparcelable:aar:1.0.0",
+)
+
+fb_native.remote_file(
+    name = "viewpager-binary-aar",
+    sha1 = "1f90e13820f96c2fb868f9674079a551678d68b2",
+    url = "mvn:androidx.viewpager:viewpager:aar:1.0.0",
+)

--- a/tools/build_defs/oss/rn_defs.bzl
+++ b/tools/build_defs/oss/rn_defs.bzl
@@ -119,7 +119,30 @@ def rn_android_library(name, deps = [], plugins = [], *args, **kwargs):
 
         plugins = list(set(plugins + react_module_plugins))
 
-    native.android_library(name = name, deps = deps, plugins = plugins, *args, **kwargs)
+    is_androidx = kwargs.pop('is_androidx', False)
+    provided_deps = kwargs.pop('provided_deps', [])
+    appcompat = react_native_dep("third-party/android/support/v7/appcompat-orig:appcompat")
+    support_v4 = react_native_dep("third-party/android/support/v4:lib-support-v4")
+
+    if is_androidx and (appcompat in deps or appcompat in provided_deps):
+        # add androidx target to provided_deps
+        pass
+        # provided_deps.append(
+        #     react_native_dep(
+        #         ""
+        #     )
+        # )
+
+    if is_androidx and (support_v4 in deps or support_v4 in provided_deps):
+        # add androidx target to provided_deps
+        pass
+        # provided_deps.append(
+        #     react_native_dep(
+        #         ""
+        #     )
+        # )
+
+    native.android_library(name = name, deps = deps, plugins = plugins, provided_deps = provided_deps, *args, **kwargs)
 
 def rn_android_binary(*args, **kwargs):
     native.android_binary(*args, **kwargs)


### PR DESCRIPTION
Summary:
Codemod by `intellij_convert_to_ax.py` affecting 1 targets:
    fbsource//xplat/js/react-native-github/ReactAndroid/src/main/java/com/facebook/react/views/switchview:switchviewAndroid

Differential Revision: D14151899
