### PR TITLE
[iOS] Add Image query cache result type

### DIFF
--- a/Libraries/Image/Image.ios.js
+++ b/Libraries/Image/Image.ios.js
@@ -48,7 +48,7 @@ function prefetch(url: string) {
 
 async function queryCache(
   urls: Array<string>,
-): Promise<Map<string, 'memory' | 'disk'>> {
+): Promise<Map<string, 'memory' | 'disk' | 'disk/memory'>> {
   return await ImageViewManager.queryCache(urls);
 }
 

--- a/Libraries/Image/RCTImageLoader.m
+++ b/Libraries/Image/RCTImageLoader.m
@@ -808,9 +808,12 @@ static UIImage *RCTResizeImageIfNeeded(UIImage *image,
       NSCachedURLResponse *cachedResponse = [NSURLCache.sharedURLCache cachedResponseForRequest:urlRequest];
       if (cachedResponse) {
         if (cachedResponse.storagePolicy == NSURLCacheStorageAllowedInMemoryOnly) {
-          [results setObject:@"memory" forKey:urlRequest.URL.absoluteString];
+          results[urlRequest.URL.absoluteString] = @"memory";
+        } else if (NSURLCache.sharedURLCache.currentMemoryUsage == 0) {
+          // We have no means to check wether cache from disk or memory, but if currentMemoryUsage is disabled, it must be on disk
+          results[urlRequest.URL.absoluteString] = @"disk";
         } else {
-          [results setObject:@"disk" forKey:urlRequest.URL.absoluteString];
+          results[urlRequest.URL.absoluteString] = @"disk/memory";
         }
       }
     }

--- a/Libraries/Image/RCTImageLoader.m
+++ b/Libraries/Image/RCTImageLoader.m
@@ -810,7 +810,8 @@ static UIImage *RCTResizeImageIfNeeded(UIImage *image,
         if (cachedResponse.storagePolicy == NSURLCacheStorageAllowedInMemoryOnly) {
           results[urlRequest.URL.absoluteString] = @"memory";
         } else if (NSURLCache.sharedURLCache.currentMemoryUsage == 0) {
-          // We have no means to check wether cache from disk or memory, but if currentMemoryUsage is disabled, it must be on disk
+          // We can't check whether the file is cached on disk or memory.
+          // However, if currentMemoryUsage is disabled, it must be read from disk.
           results[urlRequest.URL.absoluteString] = @"disk";
         } else {
           results[urlRequest.URL.absoluteString] = @"disk/memory";


### PR DESCRIPTION
## Summary

In iOS, seems we have no ways to check wether the cached item is from disk or memory, only `storagePolicy == NSURLCacheStorageAllowedInMemoryOnly ` we can think it's from memory. So we need to add a new result like `disk/memory`?

## Changelog

[iOS] [Added] - Add Image query cache result type

## Test Plan

If we can't check cached item from disk or memory, return "disk/memory".
