### PR TITLE
Improve inverted VirtualizedList implementation

### DIFF
--- a/Libraries/Lists/VirtualizedList.js
+++ b/Libraries/Lists/VirtualizedList.js
@@ -661,6 +661,7 @@ class VirtualizedList extends React.PureComponent<Props, State> {
       getItem,
       getItemCount,
       horizontal,
+      inverted,
       keyExtractor,
     } = this.props;
     const stickyOffset = this.props.ListHeaderComponent ? 1 : 0;
@@ -681,6 +682,7 @@ class VirtualizedList extends React.PureComponent<Props, State> {
           cellKey={key}
           fillRateHelper={this._fillRateHelper}
           horizontal={horizontal}
+          inverted={inverted}
           index={ii}
           item={item}
           key={key}
@@ -1611,6 +1613,7 @@ class CellRenderer extends React.Component<
     cellKey: string,
     fillRateHelper: FillRateHelper,
     horizontal: ?boolean,
+    inverted: ?boolean,
     index: number,
     item: Item,
     onLayout: (event: Object) => void, // This is extracted by ScrollViewStickyHeader
@@ -1685,6 +1688,7 @@ class CellRenderer extends React.Component<
       ItemSeparatorComponent,
       fillRateHelper,
       horizontal,
+      inverted,
       item,
       index,
       parentProps,
@@ -1709,8 +1713,8 @@ class CellRenderer extends React.Component<
       <ItemSeparatorComponent {...this.state.separatorProps} />
     );
     const cellStyle = horizontal
-      ? {flexDirection: 'row'}
-      : {flexDirection: 'column'};
+      ? {flexDirection: inverted ? 'row-reverse' : 'row'}
+      : {flexDirection: inverted ? 'column-reverse' : 'column'};
     if (!CellRendererComponent) {
       return (
         /* $FlowFixMe(>=0.89.0 site=react_native_fb) This comment suppresses an

--- a/Libraries/Lists/VirtualizedList.js
+++ b/Libraries/Lists/VirtualizedList.js
@@ -1759,10 +1759,10 @@ class VirtualizedCellWrapper extends React.Component<{
 
 const styles = StyleSheet.create({
   verticallyInverted: {
-    flexDirection: 'row-reverse',
+    flexDirection: 'column-reverse',
   },
   horizontallyInverted: {
-    flexDirection: 'column-reverse',
+    flexDirection: 'row-reverse',
   },
   debug: {
     flex: 1,

--- a/Libraries/Lists/VirtualizedList.js
+++ b/Libraries/Lists/VirtualizedList.js
@@ -653,7 +653,6 @@ class VirtualizedList extends React.PureComponent<Props, State> {
     stickyIndicesFromProps: Set<number>,
     first: number,
     last: number,
-    inversionStyle: ViewStyleProp,
   ) {
     const {
       CellRendererComponent,
@@ -683,7 +682,6 @@ class VirtualizedList extends React.PureComponent<Props, State> {
           fillRateHelper={this._fillRateHelper}
           horizontal={horizontal}
           index={ii}
-          inversionStyle={inversionStyle}
           item={item}
           key={key}
           prevCellKey={prevCellKey}
@@ -758,10 +756,7 @@ class VirtualizedList extends React.PureComponent<Props, State> {
           key="$header">
           <View
             onLayout={this._onLayoutHeader}
-            style={StyleSheet.compose(
-              inversionStyle,
-              this.props.ListHeaderComponentStyle,
-            )}>
+            style={this.props.ListHeaderComponentStyle}>
             {
               // $FlowFixMe - Typing ReactNativeComponent revealed errors
               element
@@ -785,7 +780,6 @@ class VirtualizedList extends React.PureComponent<Props, State> {
         stickyIndicesFromProps,
         0,
         lastInitialIndex,
-        inversionStyle,
       );
       const firstAfterInitial = Math.max(lastInitialIndex + 1, first);
       if (!isVirtualizationDisabled && first > lastInitialIndex + 1) {
@@ -810,7 +804,6 @@ class VirtualizedList extends React.PureComponent<Props, State> {
                 stickyIndicesFromProps,
                 ii,
                 ii,
-                inversionStyle,
               );
               const trailSpace =
                 this._getFrameMetricsApprox(first).offset -
@@ -839,7 +832,6 @@ class VirtualizedList extends React.PureComponent<Props, State> {
         stickyIndicesFromProps,
         firstAfterInitial,
         last,
-        inversionStyle,
       );
       if (!this._hasWarned.keys && _usedIndexForKey) {
         console.warn(
@@ -884,7 +876,7 @@ class VirtualizedList extends React.PureComponent<Props, State> {
               element.props.onLayout(event);
             }
           },
-          style: [element.props.style, inversionStyle],
+          style: element.props.style,
         }),
       );
     }
@@ -901,10 +893,7 @@ class VirtualizedList extends React.PureComponent<Props, State> {
           key="$footer">
           <View
             onLayout={this._onLayoutFooter}
-            style={StyleSheet.compose(
-              inversionStyle,
-              this.props.ListFooterComponentStyle,
-            )}>
+            style={this.props.ListFooterComponentStyle}>
             {
               // $FlowFixMe - Typing ReactNativeComponent revealed errors
               element
@@ -921,6 +910,7 @@ class VirtualizedList extends React.PureComponent<Props, State> {
       onScrollBeginDrag: this._onScrollBeginDrag,
       onScrollEndDrag: this._onScrollEndDrag,
       onMomentumScrollEnd: this._onMomentumScrollEnd,
+      contentContainerStyle: inversionStyle,
       scrollEventThrottle: this.props.scrollEventThrottle, // TODO: Android support
       invertStickyHeaders:
         this.props.invertStickyHeaders !== undefined
@@ -928,12 +918,6 @@ class VirtualizedList extends React.PureComponent<Props, State> {
           : this.props.inverted,
       stickyHeaderIndices,
     };
-    if (inversionStyle && itemCount !== 0) {
-      /* $FlowFixMe(>=0.70.0 site=react_native_fb) This comment suppresses an
-       * error found when Flow v0.70 was deployed. To see the error delete
-       * this comment and run Flow. */
-      scrollProps.style = [inversionStyle, this.props.style];
-    }
 
     this._hasMore =
       this.state.last < this.props.getItemCount(this.props.data) - 1;
@@ -980,6 +964,7 @@ class VirtualizedList extends React.PureComponent<Props, State> {
   _fillRateHelper: FillRateHelper;
   _frames = {};
   _footerLength = 0;
+  _distanceFromEnd = 0;
   _hasDataChangedSinceEndReached = true;
   _hasInteracted = false;
   _hasMore = false;
@@ -1243,9 +1228,12 @@ class VirtualizedList extends React.PureComponent<Props, State> {
       getItemCount,
       onEndReached,
       onEndReachedThreshold,
+      inverted,
     } = this.props;
     const {contentLength, visibleLength, offset} = this._scrollMetrics;
-    const distanceFromEnd = contentLength - visibleLength - offset;
+    const distanceFromEnd = inverted
+      ? offset
+      : contentLength - visibleLength - offset;
     if (
       onEndReached &&
       this.state.last === getItemCount(data) - 1 &&
@@ -1253,12 +1241,15 @@ class VirtualizedList extends React.PureComponent<Props, State> {
        * error found when Flow v0.63 was deployed. To see the error delete this
        * comment and run Flow. */
       distanceFromEnd < onEndReachedThreshold * visibleLength &&
+      distanceFromEnd !== this._distanceFromEnd &&
       (this._hasDataChangedSinceEndReached ||
         this._scrollMetrics.contentLength !== this._sentEndForContentLength)
     ) {
       // Only call onEndReached once for a given dataset + content length.
       this._hasDataChangedSinceEndReached = false;
       this._sentEndForContentLength = this._scrollMetrics.contentLength;
+      //We record the value to prevent from calling twice, especially when distanceFromEnd===0 as the scroll will stick to the top
+      this._distanceFromEnd = distanceFromEnd;
       onEndReached({distanceFromEnd});
     }
   }
@@ -1447,7 +1438,7 @@ class VirtualizedList extends React.PureComponent<Props, State> {
   };
 
   _updateCellsToRender = () => {
-    const {data, getItemCount, onEndReachedThreshold} = this.props;
+    const {data, getItemCount, onEndReachedThreshold, inverted} = this.props;
     const isVirtualizationDisabled = this._isVirtualizationDisabled();
     this._updateViewableItems(data);
     if (!data) {
@@ -1476,7 +1467,9 @@ class VirtualizedList extends React.PureComponent<Props, State> {
         }
       } else {
         const {contentLength, offset, visibleLength} = this._scrollMetrics;
-        const distanceFromEnd = contentLength - visibleLength - offset;
+        const distanceFromEnd = inverted
+          ? offset
+          : contentLength - visibleLength - offset;
         const renderAhead =
           /* $FlowFixMe(>=0.63.0 site=react_native_fb) This comment suppresses
            * an error found when Flow v0.63 was deployed. To see the error
@@ -1619,7 +1612,6 @@ class CellRenderer extends React.Component<
     fillRateHelper: FillRateHelper,
     horizontal: ?boolean,
     index: number,
-    inversionStyle: ViewStyleProp,
     item: Item,
     onLayout: (event: Object) => void, // This is extracted by ScrollViewStickyHeader
     onUnmount: (cellKey: string) => void,
@@ -1695,7 +1687,6 @@ class CellRenderer extends React.Component<
       horizontal,
       item,
       index,
-      inversionStyle,
       parentProps,
     } = this.props;
     const {renderItem, getItemLayout} = parentProps;
@@ -1717,13 +1708,9 @@ class CellRenderer extends React.Component<
     const itemSeparator = ItemSeparatorComponent && (
       <ItemSeparatorComponent {...this.state.separatorProps} />
     );
-    const cellStyle = inversionStyle
-      ? horizontal
-        ? [{flexDirection: 'row-reverse'}, inversionStyle]
-        : [{flexDirection: 'column-reverse'}, inversionStyle]
-      : horizontal
-        ? [{flexDirection: 'row'}, inversionStyle]
-        : inversionStyle;
+    const cellStyle = horizontal
+      ? {flexDirection: 'row'}
+      : {flexDirection: 'column'};
     if (!CellRendererComponent) {
       return (
         /* $FlowFixMe(>=0.89.0 site=react_native_fb) This comment suppresses an
@@ -1772,10 +1759,10 @@ class VirtualizedCellWrapper extends React.Component<{
 
 const styles = StyleSheet.create({
   verticallyInverted: {
-    transform: [{scaleY: -1}],
+    flexDirection: 'row-reverse',
   },
   horizontallyInverted: {
-    transform: [{scaleX: -1}],
+    flexDirection: 'column-reverse',
   },
   debug: {
     flex: 1,

--- a/Libraries/Lists/__tests__/__snapshots__/FlatList-test.js.snap
+++ b/Libraries/Lists/__tests__/__snapshots__/FlatList-test.js.snap
@@ -6,6 +6,7 @@ exports[`FlatList renders all the bells and whistles 1`] = `
   ListEmptyComponent={[Function]}
   ListFooterComponent={[Function]}
   ListHeaderComponent={[Function]}
+  contentContainerStyle={null}
   data={
     Array [
       Object {
@@ -65,7 +66,11 @@ exports[`FlatList renders all the bells and whistles 1`] = `
       <header />
     </View>
     <View
-      style={null}
+      style={
+        Object {
+          "flexDirection": "column",
+        }
+      }
     >
       <View
         style={
@@ -84,7 +89,11 @@ exports[`FlatList renders all the bells and whistles 1`] = `
       <separator />
     </View>
     <View
-      style={null}
+      style={
+        Object {
+          "flexDirection": "column",
+        }
+      }
     >
       <View
         style={
@@ -103,7 +112,11 @@ exports[`FlatList renders all the bells and whistles 1`] = `
       <separator />
     </View>
     <View
-      style={null}
+      style={
+        Object {
+          "flexDirection": "column",
+        }
+      }
     >
       <View
         style={
@@ -128,6 +141,7 @@ exports[`FlatList renders all the bells and whistles 1`] = `
 
 exports[`FlatList renders empty list 1`] = `
 <RCTScrollView
+  contentContainerStyle={null}
   data={Array []}
   disableVirtualization={false}
   getItem={[Function]}
@@ -158,6 +172,7 @@ exports[`FlatList renders empty list 1`] = `
 
 exports[`FlatList renders null list 1`] = `
 <RCTScrollView
+  contentContainerStyle={null}
   disableVirtualization={false}
   getItem={[Function]}
   getItemCount={[Function]}
@@ -187,6 +202,7 @@ exports[`FlatList renders null list 1`] = `
 
 exports[`FlatList renders simple list 1`] = `
 <RCTScrollView
+  contentContainerStyle={null}
   data={
     Array [
       Object {
@@ -226,7 +242,11 @@ exports[`FlatList renders simple list 1`] = `
   <View>
     <View
       onLayout={[Function]}
-      style={null}
+      style={
+        Object {
+          "flexDirection": "column",
+        }
+      }
     >
       <item
         value="i1"
@@ -234,7 +254,11 @@ exports[`FlatList renders simple list 1`] = `
     </View>
     <View
       onLayout={[Function]}
-      style={null}
+      style={
+        Object {
+          "flexDirection": "column",
+        }
+      }
     >
       <item
         value="i2"
@@ -242,7 +266,11 @@ exports[`FlatList renders simple list 1`] = `
     </View>
     <View
       onLayout={[Function]}
-      style={null}
+      style={
+        Object {
+          "flexDirection": "column",
+        }
+      }
     >
       <item
         value="i3"

--- a/Libraries/Lists/__tests__/__snapshots__/SectionList-test.js.snap
+++ b/Libraries/Lists/__tests__/__snapshots__/SectionList-test.js.snap
@@ -2,6 +2,7 @@
 
 exports[`SectionList rendering empty section headers is fine 1`] = `
 <RCTScrollView
+  contentContainerStyle={null}
   data={
     Array [
       Object {
@@ -61,11 +62,19 @@ exports[`SectionList rendering empty section headers is fine 1`] = `
   <View>
     <View
       onLayout={[Function]}
-      style={null}
+      style={
+        Object {
+          "flexDirection": "column",
+        }
+      }
     />
     <View
       onLayout={[Function]}
-      style={null}
+      style={
+        Object {
+          "flexDirection": "column",
+        }
+      }
     >
       <item
         v="i1"
@@ -73,7 +82,11 @@ exports[`SectionList rendering empty section headers is fine 1`] = `
     </View>
     <View
       onLayout={[Function]}
-      style={null}
+      style={
+        Object {
+          "flexDirection": "column",
+        }
+      }
     >
       <item
         v="i2"
@@ -81,7 +94,11 @@ exports[`SectionList rendering empty section headers is fine 1`] = `
     </View>
     <View
       onLayout={[Function]}
-      style={null}
+      style={
+        Object {
+          "flexDirection": "column",
+        }
+      }
     />
   </View>
 </RCTScrollView>
@@ -89,6 +106,7 @@ exports[`SectionList rendering empty section headers is fine 1`] = `
 
 exports[`SectionList renders a footer when there is no data 1`] = `
 <RCTScrollView
+  contentContainerStyle={null}
   data={
     Array [
       Object {
@@ -135,7 +153,11 @@ exports[`SectionList renders a footer when there is no data 1`] = `
   <View>
     <View
       onLayout={[Function]}
-      style={null}
+      style={
+        Object {
+          "flexDirection": "column",
+        }
+      }
     >
       <sectionHeader
         v="section:s1"
@@ -143,7 +165,11 @@ exports[`SectionList renders a footer when there is no data 1`] = `
     </View>
     <View
       onLayout={[Function]}
-      style={null}
+      style={
+        Object {
+          "flexDirection": "column",
+        }
+      }
     >
       <sectionFooter
         v="section:s1"
@@ -155,6 +181,7 @@ exports[`SectionList renders a footer when there is no data 1`] = `
 
 exports[`SectionList renders a footer when there is no data and no header 1`] = `
 <RCTScrollView
+  contentContainerStyle={null}
   data={
     Array [
       Object {
@@ -200,11 +227,19 @@ exports[`SectionList renders a footer when there is no data and no header 1`] = 
   <View>
     <View
       onLayout={[Function]}
-      style={null}
+      style={
+        Object {
+          "flexDirection": "column",
+        }
+      }
     />
     <View
       onLayout={[Function]}
-      style={null}
+      style={
+        Object {
+          "flexDirection": "column",
+        }
+      }
     >
       <sectionFooter
         v="section:s1"
@@ -220,6 +255,7 @@ exports[`SectionList renders all the bells and whistles 1`] = `
   ListFooterComponent={[Function]}
   ListHeaderComponent={[Function]}
   SectionSeparatorComponent={[Function]}
+  contentContainerStyle={null}
   data={
     Array [
       Object {
@@ -348,7 +384,11 @@ exports[`SectionList renders all the bells and whistles 1`] = `
     </View>
     <View
       onLayout={[Function]}
-      style={null}
+      style={
+        Object {
+          "flexDirection": "column",
+        }
+      }
     >
       <sectionHeader
         v="section:s1"
@@ -356,7 +396,11 @@ exports[`SectionList renders all the bells and whistles 1`] = `
     </View>
     <View
       onLayout={[Function]}
-      style={null}
+      style={
+        Object {
+          "flexDirection": "column",
+        }
+      }
     >
       <View>
         <sectionSeparator
@@ -372,7 +416,11 @@ exports[`SectionList renders all the bells and whistles 1`] = `
     </View>
     <View
       onLayout={[Function]}
-      style={null}
+      style={
+        Object {
+          "flexDirection": "column",
+        }
+      }
     >
       <View>
         <itemForSection1
@@ -385,7 +433,11 @@ exports[`SectionList renders all the bells and whistles 1`] = `
     </View>
     <View
       onLayout={[Function]}
-      style={null}
+      style={
+        Object {
+          "flexDirection": "column",
+        }
+      }
     >
       <sectionFooter
         v="section:s1"
@@ -393,7 +445,11 @@ exports[`SectionList renders all the bells and whistles 1`] = `
     </View>
     <View
       onLayout={[Function]}
-      style={null}
+      style={
+        Object {
+          "flexDirection": "column",
+        }
+      }
     >
       <sectionHeader
         v="section:s2"
@@ -401,7 +457,11 @@ exports[`SectionList renders all the bells and whistles 1`] = `
     </View>
     <View
       onLayout={[Function]}
-      style={null}
+      style={
+        Object {
+          "flexDirection": "column",
+        }
+      }
     >
       <View>
         <sectionSeparator
@@ -417,7 +477,11 @@ exports[`SectionList renders all the bells and whistles 1`] = `
     </View>
     <View
       onLayout={[Function]}
-      style={null}
+      style={
+        Object {
+          "flexDirection": "column",
+        }
+      }
     >
       <View>
         <defaultItem
@@ -430,7 +494,11 @@ exports[`SectionList renders all the bells and whistles 1`] = `
     </View>
     <View
       onLayout={[Function]}
-      style={null}
+      style={
+        Object {
+          "flexDirection": "column",
+        }
+      }
     >
       <sectionFooter
         v="section:s2"
@@ -438,7 +506,11 @@ exports[`SectionList renders all the bells and whistles 1`] = `
     </View>
     <View
       onLayout={[Function]}
-      style={null}
+      style={
+        Object {
+          "flexDirection": "column",
+        }
+      }
     >
       <sectionHeader
         v="section:s3"
@@ -446,7 +518,11 @@ exports[`SectionList renders all the bells and whistles 1`] = `
     </View>
     <View
       onLayout={[Function]}
-      style={null}
+      style={
+        Object {
+          "flexDirection": "column",
+        }
+      }
     >
       <View>
         <sectionSeparator
@@ -462,7 +538,11 @@ exports[`SectionList renders all the bells and whistles 1`] = `
     </View>
     <View
       onLayout={[Function]}
-      style={null}
+      style={
+        Object {
+          "flexDirection": "column",
+        }
+      }
     >
       <View>
         <defaultItem
@@ -475,7 +555,11 @@ exports[`SectionList renders all the bells and whistles 1`] = `
     </View>
     <View
       onLayout={[Function]}
-      style={null}
+      style={
+        Object {
+          "flexDirection": "column",
+        }
+      }
     >
       <sectionFooter
         v="section:s3"
@@ -494,6 +578,7 @@ exports[`SectionList renders all the bells and whistles 1`] = `
 
 exports[`SectionList renders empty list 1`] = `
 <RCTScrollView
+  contentContainerStyle={null}
   data={Array []}
   disableVirtualization={false}
   getItem={[Function]}

--- a/Libraries/Lists/__tests__/__snapshots__/VirtualizedList-test.js.snap
+++ b/Libraries/Lists/__tests__/__snapshots__/VirtualizedList-test.js.snap
@@ -526,7 +526,7 @@ exports[`VirtualizedList renders all the bells and whistles 1`] = `
     <View
       style={
         Object {
-          "flexDirection": "column",
+          "flexDirection": "column-reverse",
         }
       }
     >
@@ -538,7 +538,7 @@ exports[`VirtualizedList renders all the bells and whistles 1`] = `
     <View
       style={
         Object {
-          "flexDirection": "column",
+          "flexDirection": "column-reverse",
         }
       }
     >
@@ -550,7 +550,7 @@ exports[`VirtualizedList renders all the bells and whistles 1`] = `
     <View
       style={
         Object {
-          "flexDirection": "column",
+          "flexDirection": "column-reverse",
         }
       }
     >
@@ -562,7 +562,7 @@ exports[`VirtualizedList renders all the bells and whistles 1`] = `
     <View
       style={
         Object {
-          "flexDirection": "column",
+          "flexDirection": "column-reverse",
         }
       }
     >
@@ -574,7 +574,7 @@ exports[`VirtualizedList renders all the bells and whistles 1`] = `
     <View
       style={
         Object {
-          "flexDirection": "column",
+          "flexDirection": "column-reverse",
         }
       }
     >

--- a/Libraries/Lists/__tests__/__snapshots__/VirtualizedList-test.js.snap
+++ b/Libraries/Lists/__tests__/__snapshots__/VirtualizedList-test.js.snap
@@ -463,7 +463,7 @@ exports[`VirtualizedList renders all the bells and whistles 1`] = `
   ListHeaderComponent={[Function]}
   contentContainerStyle={
     Object {
-      "flexDirection": "row-reverse",
+      "flexDirection": "column-reverse",
     }
   }
   data={

--- a/Libraries/Lists/__tests__/__snapshots__/VirtualizedList-test.js.snap
+++ b/Libraries/Lists/__tests__/__snapshots__/VirtualizedList-test.js.snap
@@ -2,6 +2,7 @@
 
 exports[`VirtualizedList handles nested lists 1`] = `
 <RCTScrollView
+  contentContainerStyle={null}
   data={
     Array [
       Object {
@@ -35,9 +36,14 @@ exports[`VirtualizedList handles nested lists 1`] = `
   <View>
     <View
       onLayout={[Function]}
-      style={null}
+      style={
+        Object {
+          "flexDirection": "column",
+        }
+      }
     >
       <View
+        contentContainerStyle={null}
         data={
           Array [
             Object {
@@ -70,7 +76,11 @@ exports[`VirtualizedList handles nested lists 1`] = `
       >
         <View
           onLayout={[Function]}
-          style={null}
+          style={
+            Object {
+              "flexDirection": "column",
+            }
+          }
         >
           <item
             title="outer0:inner0"
@@ -78,7 +88,11 @@ exports[`VirtualizedList handles nested lists 1`] = `
         </View>
         <View
           onLayout={[Function]}
-          style={null}
+          style={
+            Object {
+              "flexDirection": "column",
+            }
+          }
         >
           <item
             title="outer0:inner1"
@@ -88,9 +102,14 @@ exports[`VirtualizedList handles nested lists 1`] = `
     </View>
     <View
       onLayout={[Function]}
-      style={null}
+      style={
+        Object {
+          "flexDirection": "column",
+        }
+      }
     >
       <RCTScrollView
+        contentContainerStyle={null}
         data={
           Array [
             Object {
@@ -125,12 +144,9 @@ exports[`VirtualizedList handles nested lists 1`] = `
           <View
             onLayout={[Function]}
             style={
-              Array [
-                Object {
-                  "flexDirection": "row",
-                },
-                null,
-              ]
+              Object {
+                "flexDirection": "row",
+              }
             }
           >
             <item
@@ -140,12 +156,9 @@ exports[`VirtualizedList handles nested lists 1`] = `
           <View
             onLayout={[Function]}
             style={
-              Array [
-                Object {
-                  "flexDirection": "row",
-                },
-                null,
-              ]
+              Object {
+                "flexDirection": "row",
+              }
             }
           >
             <item
@@ -162,6 +175,7 @@ exports[`VirtualizedList handles nested lists 1`] = `
 exports[`VirtualizedList handles separators correctly 1`] = `
 <RCTScrollView
   ItemSeparatorComponent={[Function]}
+  contentContainerStyle={null}
   data={
     Array [
       Object {
@@ -198,7 +212,11 @@ exports[`VirtualizedList handles separators correctly 1`] = `
   <View>
     <View
       onLayout={[Function]}
-      style={null}
+      style={
+        Object {
+          "flexDirection": "column",
+        }
+      }
     >
       <item
         title="i0"
@@ -214,7 +232,11 @@ exports[`VirtualizedList handles separators correctly 1`] = `
     </View>
     <View
       onLayout={[Function]}
-      style={null}
+      style={
+        Object {
+          "flexDirection": "column",
+        }
+      }
     >
       <item
         title="i1"
@@ -230,7 +252,11 @@ exports[`VirtualizedList handles separators correctly 1`] = `
     </View>
     <View
       onLayout={[Function]}
-      style={null}
+      style={
+        Object {
+          "flexDirection": "column",
+        }
+      }
     >
       <item
         title="i2"
@@ -243,6 +269,7 @@ exports[`VirtualizedList handles separators correctly 1`] = `
 exports[`VirtualizedList handles separators correctly 2`] = `
 <RCTScrollView
   ItemSeparatorComponent={[Function]}
+  contentContainerStyle={null}
   data={
     Array [
       Object {
@@ -279,7 +306,11 @@ exports[`VirtualizedList handles separators correctly 2`] = `
   <View>
     <View
       onLayout={[Function]}
-      style={null}
+      style={
+        Object {
+          "flexDirection": "column",
+        }
+      }
     >
       <item
         title="i0"
@@ -295,7 +326,11 @@ exports[`VirtualizedList handles separators correctly 2`] = `
     </View>
     <View
       onLayout={[Function]}
-      style={null}
+      style={
+        Object {
+          "flexDirection": "column",
+        }
+      }
     >
       <item
         title="i1"
@@ -311,7 +346,11 @@ exports[`VirtualizedList handles separators correctly 2`] = `
     </View>
     <View
       onLayout={[Function]}
-      style={null}
+      style={
+        Object {
+          "flexDirection": "column",
+        }
+      }
     >
       <item
         title="i2"
@@ -324,6 +363,7 @@ exports[`VirtualizedList handles separators correctly 2`] = `
 exports[`VirtualizedList handles separators correctly 3`] = `
 <RCTScrollView
   ItemSeparatorComponent={[Function]}
+  contentContainerStyle={null}
   data={
     Array [
       Object {
@@ -360,7 +400,11 @@ exports[`VirtualizedList handles separators correctly 3`] = `
   <View>
     <View
       onLayout={[Function]}
-      style={null}
+      style={
+        Object {
+          "flexDirection": "column",
+        }
+      }
     >
       <item
         title="i0"
@@ -376,7 +420,11 @@ exports[`VirtualizedList handles separators correctly 3`] = `
     </View>
     <View
       onLayout={[Function]}
-      style={null}
+      style={
+        Object {
+          "flexDirection": "column",
+        }
+      }
     >
       <item
         title="i1"
@@ -393,7 +441,11 @@ exports[`VirtualizedList handles separators correctly 3`] = `
     </View>
     <View
       onLayout={[Function]}
-      style={null}
+      style={
+        Object {
+          "flexDirection": "column",
+        }
+      }
     >
       <item
         title="i2"
@@ -409,6 +461,11 @@ exports[`VirtualizedList renders all the bells and whistles 1`] = `
   ListEmptyComponent={[Function]}
   ListFooterComponent={[Function]}
   ListHeaderComponent={[Function]}
+  contentContainerStyle={
+    Object {
+      "flexDirection": "row-reverse",
+    }
+  }
   data={
     Array [
       Object {
@@ -456,18 +513,6 @@ exports[`VirtualizedList renders all the bells and whistles 1`] = `
   renderItem={[Function]}
   scrollEventThrottle={50}
   stickyHeaderIndices={Array []}
-  style={
-    Array [
-      Object {
-        "transform": Array [
-          Object {
-            "scaleY": -1,
-          },
-        ],
-      },
-      undefined,
-    ]
-  }
   updateCellsBatchingPeriod={50}
   windowSize={21}
 >
@@ -475,32 +520,14 @@ exports[`VirtualizedList renders all the bells and whistles 1`] = `
   <View>
     <View
       onLayout={[Function]}
-      style={
-        Object {
-          "transform": Array [
-            Object {
-              "scaleY": -1,
-            },
-          ],
-        }
-      }
     >
       <header />
     </View>
     <View
       style={
-        Array [
-          Object {
-            "flexDirection": "column-reverse",
-          },
-          Object {
-            "transform": Array [
-              Object {
-                "scaleY": -1,
-              },
-            ],
-          },
-        ]
+        Object {
+          "flexDirection": "column",
+        }
       }
     >
       <item
@@ -510,18 +537,9 @@ exports[`VirtualizedList renders all the bells and whistles 1`] = `
     </View>
     <View
       style={
-        Array [
-          Object {
-            "flexDirection": "column-reverse",
-          },
-          Object {
-            "transform": Array [
-              Object {
-                "scaleY": -1,
-              },
-            ],
-          },
-        ]
+        Object {
+          "flexDirection": "column",
+        }
       }
     >
       <item
@@ -531,18 +549,9 @@ exports[`VirtualizedList renders all the bells and whistles 1`] = `
     </View>
     <View
       style={
-        Array [
-          Object {
-            "flexDirection": "column-reverse",
-          },
-          Object {
-            "transform": Array [
-              Object {
-                "scaleY": -1,
-              },
-            ],
-          },
-        ]
+        Object {
+          "flexDirection": "column",
+        }
       }
     >
       <item
@@ -552,18 +561,9 @@ exports[`VirtualizedList renders all the bells and whistles 1`] = `
     </View>
     <View
       style={
-        Array [
-          Object {
-            "flexDirection": "column-reverse",
-          },
-          Object {
-            "transform": Array [
-              Object {
-                "scaleY": -1,
-              },
-            ],
-          },
-        ]
+        Object {
+          "flexDirection": "column",
+        }
       }
     >
       <item
@@ -573,18 +573,9 @@ exports[`VirtualizedList renders all the bells and whistles 1`] = `
     </View>
     <View
       style={
-        Array [
-          Object {
-            "flexDirection": "column-reverse",
-          },
-          Object {
-            "transform": Array [
-              Object {
-                "scaleY": -1,
-              },
-            ],
-          },
-        ]
+        Object {
+          "flexDirection": "column",
+        }
       }
     >
       <item
@@ -593,15 +584,6 @@ exports[`VirtualizedList renders all the bells and whistles 1`] = `
     </View>
     <View
       onLayout={[Function]}
-      style={
-        Object {
-          "transform": Array [
-            Object {
-              "scaleY": -1,
-            },
-          ],
-        }
-      }
     >
       <footer />
     </View>
@@ -611,6 +593,7 @@ exports[`VirtualizedList renders all the bells and whistles 1`] = `
 
 exports[`VirtualizedList renders empty list 1`] = `
 <RCTScrollView
+  contentContainerStyle={null}
   data={Array []}
   disableVirtualization={false}
   getItem={[Function]}
@@ -641,6 +624,7 @@ exports[`VirtualizedList renders empty list with empty component 1`] = `
   ListEmptyComponent={[Function]}
   ListFooterComponent={[Function]}
   ListHeaderComponent={[Function]}
+  contentContainerStyle={null}
   data={Array []}
   disableVirtualization={false}
   getItem={[Function]}
@@ -681,6 +665,7 @@ exports[`VirtualizedList renders empty list with empty component 1`] = `
 exports[`VirtualizedList renders list with empty component 1`] = `
 <RCTScrollView
   ListEmptyComponent={[Function]}
+  contentContainerStyle={null}
   data={
     Array [
       Object {
@@ -711,7 +696,11 @@ exports[`VirtualizedList renders list with empty component 1`] = `
   <View>
     <View
       onLayout={[Function]}
-      style={null}
+      style={
+        Object {
+          "flexDirection": "column",
+        }
+      }
     >
       <item
         value="hello"
@@ -723,6 +712,7 @@ exports[`VirtualizedList renders list with empty component 1`] = `
 
 exports[`VirtualizedList renders null list 1`] = `
 <RCTScrollView
+  contentContainerStyle={null}
   disableVirtualization={false}
   getItem={[Function]}
   getItemCount={[Function]}
@@ -749,6 +739,7 @@ exports[`VirtualizedList renders null list 1`] = `
 
 exports[`VirtualizedList renders simple list 1`] = `
 <RCTScrollView
+  contentContainerStyle={null}
   data={
     Array [
       Object {
@@ -785,7 +776,11 @@ exports[`VirtualizedList renders simple list 1`] = `
   <View>
     <View
       onLayout={[Function]}
-      style={null}
+      style={
+        Object {
+          "flexDirection": "column",
+        }
+      }
     >
       <item
         value="i1"
@@ -793,7 +788,11 @@ exports[`VirtualizedList renders simple list 1`] = `
     </View>
     <View
       onLayout={[Function]}
-      style={null}
+      style={
+        Object {
+          "flexDirection": "column",
+        }
+      }
     >
       <item
         value="i2"
@@ -801,7 +800,11 @@ exports[`VirtualizedList renders simple list 1`] = `
     </View>
     <View
       onLayout={[Function]}
-      style={null}
+      style={
+        Object {
+          "flexDirection": "column",
+        }
+      }
     >
       <item
         value="i3"
@@ -813,6 +816,7 @@ exports[`VirtualizedList renders simple list 1`] = `
 
 exports[`VirtualizedList test getItem functionality where data is not an Array 1`] = `
 <RCTScrollView
+  contentContainerStyle={null}
   data={
     Map {
       "id_0" => Object {
@@ -843,7 +847,11 @@ exports[`VirtualizedList test getItem functionality where data is not an Array 1
   <View>
     <View
       onLayout={[Function]}
-      style={null}
+      style={
+        Object {
+          "flexDirection": "column",
+        }
+      }
     >
       <item
         value="item_0"


### PR DESCRIPTION
Use flex instead of complex transform inversion. Better for performance, readability and provides natural behaviour for onEndReached.

## Summary

The current implementation of `inverted` in `VirtualizedList` introduces a lot of problems, especially combined with the `onEndReached` events. You can see it [here](https://codesandbox.io/s/p5373vlm).

The scroll is reverted in an unnatural way, the onEndReached is not emitted at the right moment, and the scroll bar seems to be teleported randomly.

## Changelog

[General] [Fixed] - Better implementation for `inverted` and `onEndReached` on `VirtualizedList`

## Test Plan

Would you mind helping me on this part? What should I do exactly?
