### PR TITLE
[iOS] Fixed placeholder font not consistent with text's font when in multiline mode

### DIFF
--- a/Libraries/Text/TextInput/Multiline/RCTUITextView.m
+++ b/Libraries/Text/TextInput/Multiline/RCTUITextView.m
@@ -98,6 +98,7 @@ static UIColor *defaultPlaceholderColor()
   }
   self.typingAttributes = reactTextAttributes.effectiveTextAttributes;
   _reactTextAttributes = reactTextAttributes;
+  _placeholderView.font = self.font ?: defaultPlaceholderFont();
 }
 
 - (RCTTextAttributes *)reactTextAttributes


### PR DESCRIPTION
## Summary

Placeholder's font not consistent with text's font, it leads to cursor dislocation. We need to keep consistent between placeholder and text.

## Changelog

[iOS] [Fixed] - Fixed placeholder font not consistent with text's font when in multiline mode

## Test Plan

Reproduce code:
```
        <TextInput 
  placeholder="Lorem ipsum dolor sit amet, risus nunc, mauris congue mus facilisis. Sit quis euismod. Nisl ad conubia vivamus hymenaeos massa, aliquam qui a sagittis et, eget etiam a ut sollicitudin suscipit, ut nisl cras tincidunt vestibulum sodales. Maecenas vivamus necessitatibus non, in sapien. Mauris ante"
  multiline={true}
/>
```

Before:
<img width="375" alt="image" src="https://user-images.githubusercontent.com/5061845/53402494-d16a9900-39ec-11e9-9e1f-bf60ca530661.png">

After:
<img width="375" alt="image" src="https://user-images.githubusercontent.com/5061845/53402279-67ea8a80-39ec-11e9-8e3a-37a7a1f39ed3.png">
