### PR TITLE
[iOS] Remove compatible system code for iOS8 and before

### DIFF
--- a/Libraries/Text/TextInput/Multiline/RCTUITextView.m
+++ b/Libraries/Text/TextInput/Multiline/RCTUITextView.m
@@ -222,35 +222,10 @@ static UIColor *defaultPlaceholderColor()
 - (CGSize)sizeThatFits:(CGSize)size
 {
   // Returned fitting size depends on text size and placeholder size.
-  CGSize textSize = [self fixedSizeThatFits:size];
+  CGSize textSize = [super sizeThatFits:size];
   CGSize placeholderSize = self.placeholderSize;
   // Returning size DOES contain `textContainerInset` (aka `padding`).
   return CGSizeMake(MAX(textSize.width, placeholderSize.width), MAX(textSize.height, placeholderSize.height));
-}
-
-- (CGSize)fixedSizeThatFits:(CGSize)size
-{
-  // UITextView on iOS 8 has a bug that automatically scrolls to the top
-  // when calling `sizeThatFits:`. Use a copy so that self is not screwed up.
-  static BOOL useCustomImplementation = NO;
-  static dispatch_once_t onceToken;
-  dispatch_once(&onceToken, ^{
-    useCustomImplementation = ![[NSProcessInfo processInfo] isOperatingSystemAtLeastVersion:(NSOperatingSystemVersion){9,0,0}];
-  });
-
-  if (!useCustomImplementation) {
-    return [super sizeThatFits:size];
-  }
-
-  if (!_detachedTextView) {
-    _detachedTextView = [UITextView new];
-  }
-
-  _detachedTextView.attributedText = self.attributedText;
-  _detachedTextView.font = self.font;
-  _detachedTextView.textContainerInset = self.textContainerInset;
-
-  return [_detachedTextView sizeThatFits:size];
 }
 
 #pragma mark - Context Menu

--- a/React/Base/RCTMultipartDataTask.m
+++ b/React/Base/RCTMultipartDataTask.m
@@ -11,20 +11,6 @@
 
 @end
 
-// We need this ugly runtime check because [streamTask captureStreams] below fails on iOS version
-// earlier than 9.0. Unfortunately none of the proper ways of checking worked:
-//
-// - NSURLSessionStreamTask class is available and is not Null on iOS 8
-// - [[NSURLSessionStreamTask new] respondsToSelector:@selector(captureStreams)] is always NO
-// - The instance we get in URLSession:dataTask:didBecomeStreamTask: is of __NSCFURLLocalStreamTaskFromDataTask
-//   and it responds to captureStreams on iOS 9+ but doesn't on iOS 8. Which means we can't get direct access
-//   to the streams on iOS 8 and at that point it's too late to change the behavior back to dataTask
-// - The compile-time #ifdef's can't be used because an app compiled for iOS8 can still run on iOS9
-
-static BOOL isStreamTaskSupported() {
-  return [[NSProcessInfo processInfo] isOperatingSystemAtLeastVersion:(NSOperatingSystemVersion){9,0,0}];
-}
-
 @implementation RCTMultipartDataTask {
   NSURL *_url;
   RCTMultipartDataTaskCallback _partHandler;
@@ -52,9 +38,7 @@ static BOOL isStreamTaskSupported() {
   NSURLSession *session = [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration defaultSessionConfiguration]
                                                         delegate:self delegateQueue:nil];
   NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:_url];
-  if (isStreamTaskSupported()) {
-    [request addValue:@"multipart/mixed" forHTTPHeaderField:@"Accept"];
-  }
+  [request addValue:@"multipart/mixed" forHTTPHeaderField:@"Accept"];
   NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request];
   [dataTask resume];
   [session finishTasksAndInvalidate];

--- a/React/Views/RCTFont.mm
+++ b/React/Views/RCTFont.mm
@@ -142,19 +142,8 @@ static UIFont *cachedSystemFont(CGFloat size, RCTFontWeight weight)
     if (defaultFontHandler) {
       NSString *fontWeightDescription = FontWeightDescriptionFromUIFontWeight(weight);
       font = defaultFontHandler(size, fontWeightDescription);
-    } else if ([UIFont respondsToSelector:@selector(systemFontOfSize:weight:)]) {
-      // Only supported on iOS8.2 and above
-      font = [UIFont systemFontOfSize:size weight:weight];
     } else {
-      if (weight >= UIFontWeightBold) {
-        font = [UIFont boldSystemFontOfSize:size];
-      } else if (weight >= UIFontWeightMedium) {
-        font = [UIFont fontWithName:@"HelveticaNeue-Medium" size:size];
-      } else if (weight <= UIFontWeightLight) {
-        font = [UIFont fontWithName:@"HelveticaNeue-Light" size:size];
-      } else {
-        font = [UIFont systemFontOfSize:size];
-      }
+      font = [UIFont systemFontOfSize:size weight:weight];
     }
 
     {


### PR DESCRIPTION
## Summary

We already only support `iOS9+`, so we can remove all compatible codes now.

## Changelog

[iOS] [Fixed] - Remove compatible system code for iOS8 and before

## Test Plan

CicleCI passes.