### PR TITLE
Properly validate JS->native method calls

### DIFF
--- a/React/Base/RCTModuleData.mm
+++ b/React/Base/RCTModuleData.mm
@@ -330,9 +330,11 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init);
 
 - (dispatch_queue_t)methodQueue
 {
-  (void)[self instance];
-  RCTAssert(_methodQueue != nullptr, @"Module %@ has no methodQueue (instance: %@, bridge.valid: %d)",
-            self, _instance, _bridge.valid);
+  if (_bridge.valid) {
+    id instance = self.instance;
+    RCTAssert(_methodQueue != nullptr, @"Module %@ has no methodQueue (instance: %@)",
+              self, instance);
+  }
   return _methodQueue;
 }
 

--- a/React/CxxModule/RCTNativeModule.mm
+++ b/React/CxxModule/RCTNativeModule.mm
@@ -71,17 +71,19 @@ void RCTNativeModule::invoke(unsigned int methodId, folly::dynamic &&params, int
     invokeInner(weakBridge, weakModuleData, methodId, std::move(params));
   };
 
-  if (m_bridge.valid) {
-    dispatch_queue_t queue = m_moduleData.methodQueue;
-    if (queue == RCTJSThread) {
-      block();
-    } else if (queue) {
-      dispatch_async(queue, block);
-    }
-  } else {
-    RCTLog(@"Attempted to invoke `%u` (method ID) on `%@` (NativeModule name) with an invalid bridge.",
-               methodId, m_moduleData.name);
+  dispatch_queue_t queue = m_moduleData.methodQueue;
+  if (queue == RCTJSThread) {
+    block();
+  } else if (queue) {
+    dispatch_async(queue, block);
   }
+
+  #ifdef RCT_DEV
+  if (!queue) {
+    RCTLog(@"Attempted to invoke `%u` (method ID) on `%@` (NativeModule name) without a method queue.",
+           methodId, m_moduleData.name);
+  }
+  #endif
 }
 
 MethodCallResult RCTNativeModule::callSerializableNativeHook(unsigned int reactMethodId, folly::dynamic &&params) {


### PR DESCRIPTION
## Summary

Between invalidating a bridge and suspending its JS thread, native modules may have their methods called.

Only warn when a native module has been invalidated, which happens right before its JS thread is suspended.

Avoid initializing a native module's instance if its bridge is invalidated.

/cc @fkgozali https://github.com/facebook/react-native/commit/f94521244798f859648d1769f397102c06d763f0#commitcomment-32467567

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See http://facebook.github.io/react-native/docs/contributing#changelog for an example. -->

[iOS] [Fixed] - Properly validate JS->native method calls

## Test Plan

N/A