### PR TITLE
Fix autocorrect onChangeText firing (#22691)

### DIFF
--- a/Libraries/Text/TextInput/RCTBackedTextInputDelegateAdapter.m
+++ b/Libraries/Text/TextInput/RCTBackedTextInputDelegateAdapter.m
@@ -16,7 +16,6 @@ static void *TextFieldSelectionObservingContext = &TextFieldSelectionObservingCo
 
 @implementation RCTBackedTextFieldDelegateAdapter {
   __weak UITextField<RCTBackedTextInputViewProtocol> *_backedTextInputView;
-  BOOL _textDidChangeIsComing;
   UITextRange *_previousSelectedTextRange;
 }
 
@@ -58,22 +57,12 @@ static void *TextFieldSelectionObservingContext = &TextFieldSelectionObservingCo
 
 - (void)textFieldDidEndEditing:(__unused UITextField *)textField
 {
-  if (_textDidChangeIsComing) {
-    // iOS does't call `textViewDidChange:` delegate method if the change was happened because of autocorrection
-    // which was triggered by losing focus. So, we call it manually.
-    _textDidChangeIsComing = NO;
-    [_backedTextInputView.textInputDelegate textInputDidChange];
-  }
-
   [_backedTextInputView.textInputDelegate textInputDidEndEditing];
 }
 
 - (BOOL)textField:(__unused UITextField *)textField shouldChangeCharactersInRange:(NSRange)range replacementString:(NSString *)string
 {
   BOOL result = [_backedTextInputView.textInputDelegate textInputShouldChangeTextInRange:range replacementText:string];
-  if (result) {
-    _textDidChangeIsComing = YES;
-  }
   return result;
 }
 
@@ -86,9 +75,7 @@ static void *TextFieldSelectionObservingContext = &TextFieldSelectionObservingCo
 
 - (void)textFieldDidChange
 {
-  _textDidChangeIsComing = NO;
   [_backedTextInputView.textInputDelegate textInputDidChange];
-
   // `selectedTextRangeWasSet` isn't triggered during typing.
   [self textFieldProbablyDidChangeSelection];
 }
@@ -136,12 +123,11 @@ static void *TextFieldSelectionObservingContext = &TextFieldSelectionObservingCo
 
 #pragma mark - RCTBackedTextViewDelegateAdapter (for UITextView)
 
-@interface RCTBackedTextViewDelegateAdapter () <UITextViewDelegate>
+@interface RCTBackedTextViewDelegateAdapter () <UITextViewDelegate, NSTextStorageDelegate>
 @end
 
 @implementation RCTBackedTextViewDelegateAdapter {
   __weak UITextView<RCTBackedTextInputViewProtocol> *_backedTextInputView;
-  BOOL _textDidChangeIsComing;
   UITextRange *_previousSelectedTextRange;
 }
 
@@ -150,10 +136,20 @@ static void *TextFieldSelectionObservingContext = &TextFieldSelectionObservingCo
   if (self = [super init]) {
     _backedTextInputView = backedTextInputView;
     backedTextInputView.delegate = self;
+    backedTextInputView.textStorage.delegate = self;
   }
 
   return self;
 }
+
+#pragma mark -
+- (void)textStorage:(NSTextStorage *)textStorage
+  didProcessEditing:(__unused NSTextStorageEditActions)editedMask
+              range:(__unused NSRange)editedRange
+     changeInLength:(__unused NSInteger)delta {
+  [_backedTextInputView.textInputDelegate textInputDidChange];
+}
+
 
 #pragma mark - UITextViewDelegate
 
@@ -174,13 +170,6 @@ static void *TextFieldSelectionObservingContext = &TextFieldSelectionObservingCo
 
 - (void)textViewDidEndEditing:(__unused UITextView *)textView
 {
-  if (_textDidChangeIsComing) {
-    // iOS does't call `textViewDidChange:` delegate method if the change was happened because of autocorrection
-    // which was triggered by losing focus. So, we call it manually.
-    _textDidChangeIsComing = NO;
-    [_backedTextInputView.textInputDelegate textInputDidChange];
-  }
-
   [_backedTextInputView.textInputDelegate textInputDidEndEditing];
 }
 
@@ -196,16 +185,7 @@ static void *TextFieldSelectionObservingContext = &TextFieldSelectionObservingCo
   }
 
   BOOL result = [_backedTextInputView.textInputDelegate textInputShouldChangeTextInRange:range replacementText:text];
-  if (result) {
-    _textDidChangeIsComing = YES;
-  }
   return result;
-}
-
-- (void)textViewDidChange:(__unused UITextView *)textView
-{
-  _textDidChangeIsComing = NO;
-  [_backedTextInputView.textInputDelegate textInputDidChange];
 }
 
 - (void)textViewDidChangeSelection:(__unused UITextView *)textView

--- a/Libraries/Text/TextInput/RCTBackedTextInputDelegateAdapter.m
+++ b/Libraries/Text/TextInput/RCTBackedTextInputDelegateAdapter.m
@@ -16,6 +16,7 @@ static void *TextFieldSelectionObservingContext = &TextFieldSelectionObservingCo
 
 @implementation RCTBackedTextFieldDelegateAdapter {
   __weak UITextField<RCTBackedTextInputViewProtocol> *_backedTextInputView;
+  BOOL _textDidChangeIsComing;
   UITextRange *_previousSelectedTextRange;
 }
 
@@ -57,12 +58,22 @@ static void *TextFieldSelectionObservingContext = &TextFieldSelectionObservingCo
 
 - (void)textFieldDidEndEditing:(__unused UITextField *)textField
 {
+  if (_textDidChangeIsComing) {
+    // iOS does't call `textViewDidChange:` delegate method if the change was happened because of autocorrection
+    // which was triggered by losing focus. So, we call it manually.
+    _textDidChangeIsComing = NO;
+    [_backedTextInputView.textInputDelegate textInputDidChange];
+  }
+
   [_backedTextInputView.textInputDelegate textInputDidEndEditing];
 }
 
 - (BOOL)textField:(__unused UITextField *)textField shouldChangeCharactersInRange:(NSRange)range replacementString:(NSString *)string
 {
   BOOL result = [_backedTextInputView.textInputDelegate textInputShouldChangeTextInRange:range replacementText:string];
+  if (result) {
+    _textDidChangeIsComing = YES;
+  }
   return result;
 }
 
@@ -75,7 +86,9 @@ static void *TextFieldSelectionObservingContext = &TextFieldSelectionObservingCo
 
 - (void)textFieldDidChange
 {
+  _textDidChangeIsComing = NO;
   [_backedTextInputView.textInputDelegate textInputDidChange];
+
   // `selectedTextRangeWasSet` isn't triggered during typing.
   [self textFieldProbablyDidChangeSelection];
 }
@@ -123,11 +136,12 @@ static void *TextFieldSelectionObservingContext = &TextFieldSelectionObservingCo
 
 #pragma mark - RCTBackedTextViewDelegateAdapter (for UITextView)
 
-@interface RCTBackedTextViewDelegateAdapter () <UITextViewDelegate, NSTextStorageDelegate>
+@interface RCTBackedTextViewDelegateAdapter () <UITextViewDelegate>
 @end
 
 @implementation RCTBackedTextViewDelegateAdapter {
   __weak UITextView<RCTBackedTextInputViewProtocol> *_backedTextInputView;
+  BOOL _textDidChangeIsComing;
   UITextRange *_previousSelectedTextRange;
 }
 
@@ -136,20 +150,10 @@ static void *TextFieldSelectionObservingContext = &TextFieldSelectionObservingCo
   if (self = [super init]) {
     _backedTextInputView = backedTextInputView;
     backedTextInputView.delegate = self;
-    backedTextInputView.textStorage.delegate = self;
   }
 
   return self;
 }
-
-#pragma mark -
-- (void)textStorage:(NSTextStorage *)textStorage
-  didProcessEditing:(__unused NSTextStorageEditActions)editedMask
-              range:(__unused NSRange)editedRange
-     changeInLength:(__unused NSInteger)delta {
-  [_backedTextInputView.textInputDelegate textInputDidChange];
-}
-
 
 #pragma mark - UITextViewDelegate
 
@@ -170,6 +174,13 @@ static void *TextFieldSelectionObservingContext = &TextFieldSelectionObservingCo
 
 - (void)textViewDidEndEditing:(__unused UITextView *)textView
 {
+  if (_textDidChangeIsComing) {
+    // iOS does't call `textViewDidChange:` delegate method if the change was happened because of autocorrection
+    // which was triggered by losing focus. So, we call it manually.
+    _textDidChangeIsComing = NO;
+    [_backedTextInputView.textInputDelegate textInputDidChange];
+  }
+
   [_backedTextInputView.textInputDelegate textInputDidEndEditing];
 }
 
@@ -185,7 +196,16 @@ static void *TextFieldSelectionObservingContext = &TextFieldSelectionObservingCo
   }
 
   BOOL result = [_backedTextInputView.textInputDelegate textInputShouldChangeTextInRange:range replacementText:text];
+  if (result) {
+    _textDidChangeIsComing = YES;
+  }
   return result;
+}
+
+- (void)textViewDidChange:(__unused UITextView *)textView
+{
+  _textDidChangeIsComing = NO;
+  [_backedTextInputView.textInputDelegate textInputDidChange];
 }
 
 - (void)textViewDidChangeSelection:(__unused UITextView *)textView


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
This fixes an issue where autocorrect changes may cause `onChangeText` to not fire. It subscribes to the underlying `textStorage` of the UITextView. It is possible this fixes a few other issues, due to the nature of listening to the underlying textStorage changes. 

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See http://facebook.github.io/react-native/docs/contributing#changelog for an example. -->

[iOS] [Fixed] - iOS firing onChangeText when choosing autocorrect options

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
Open RNTester, and interact with textfields. 