### PR TITLE
[iOS] [Added] - Allow overriding ENTRY_FILE on react-native-xcode.sh script

### DIFF
--- a/scripts/react-native-xcode.sh
+++ b/scripts/react-native-xcode.sh
@@ -63,10 +63,13 @@ cd $PROJECT_ROOT
 [ -z "$NVM_DIR" ] && export NVM_DIR="$HOME/.nvm"
 
 # Define entry file
-if [[ -s "index.ios.js" ]]; then
-  ENTRY_FILE=${1:-index.ios.js}
-else
-  ENTRY_FILE=${1:-index.js}
+if [[ "$ENTRY_FILE" ]]; then
+  # Use ENTRY_FILE defined by user
+  :
+elif [[ -s "index.ios.js" ]]; then
+   ENTRY_FILE=${1:-index.ios.js}
+ else
+   ENTRY_FILE=${1:-index.js}
 fi
 
 if [[ -s "$HOME/.nvm/nvm.sh" ]]; then


### PR DESCRIPTION
## Summary

1. Feature parity with Android, that already have this extensibility point on `build.gradle`:
https://github.com/facebook/react-native/blob/7c9805ce163c5a027da2b8458e87d9b582ba9ba6/react.gradle#L12

2. Helps with using react-native on a monorepo project (yarn workspaces) without having to use the no-hoist feature (e.g. in my case the `ENTRY_FILE` is on `root/packages/mobile/index.js` instead of `root/index.ios.js`)

## Changelog

[iOS] [Added] - Allow overriding ENTRY_FILE on react-native-xcode.sh script

## Test Plan

I've been using this patch on [DevHub](https://github.com/devhubapp/devhub) for a few months now (https://github.com/devhubapp/devhub/search?q=ENTRY_FILE&unscoped_q=ENTRY_FILE).
