### PR TITLE
[iOS] Fixed onScroll prop in mulitline TextInput

### DIFF
--- a/Libraries/Text/TextInput/RCTBackedTextInputDelegate.h
+++ b/Libraries/Text/TextInput/RCTBackedTextInputDelegate.h
@@ -27,6 +27,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)textInputDidChangeSelection;
 
+@optional
+
+- (void)scrollViewDidScroll:(UIScrollView *)scrollView;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Libraries/Text/TextInput/RCTBackedTextInputDelegateAdapter.m
+++ b/Libraries/Text/TextInput/RCTBackedTextInputDelegateAdapter.m
@@ -213,6 +213,15 @@ static void *TextFieldSelectionObservingContext = &TextFieldSelectionObservingCo
   [self textViewProbablyDidChangeSelection];
 }
 
+#pragma mark - UIScrollViewDelegate
+
+- (void)scrollViewDidScroll:(UIScrollView *)scrollView
+{
+  if ([_backedTextInputView.textInputDelegate respondsToSelector:@selector(scrollViewDidScroll:)]) {
+    [_backedTextInputView.textInputDelegate scrollViewDidScroll:scrollView];
+  }
+}
+
 #pragma mark - Public Interface
 
 - (void)skipNextTextInputDidChangeSelectionEventWithTextRange:(UITextRange *)textRange


### PR DESCRIPTION
## Summary

We lose the support of `onScroll` prop for multiline TextInput, let's add it again.

## Changelog

[iOS] [Fixed] - Fixed onScroll prop in mulitline TextInput

## Test Plan

Code like below can trigger `onScroll` event:
```
        <TextInput style={{height:50}} onScroll={() => {
              console.log('onScroll!');
            }}
  multiline={true}
/>
```
