### PR TITLE
[iOS] Fixed wrong placeholder size calculation in multiline text input mode

### DIFF
--- a/Libraries/Text/TextInput/Multiline/RCTUITextView.m
+++ b/Libraries/Text/TextInput/Multiline/RCTUITextView.m
@@ -184,7 +184,8 @@ static UIColor *defaultPlaceholderColor()
 {
   UIEdgeInsets textContainerInset = self.textContainerInset;
   NSString *placeholder = self.placeholder ?: @"";
-  CGSize placeholderSize = [placeholder sizeWithAttributes:@{NSFontAttributeName: self.font ?: defaultPlaceholderFont()}];
+  CGSize maxPlaceholderSize = CGSizeMake(UIEdgeInsetsInsetRect(self.bounds, textContainerInset).size.width, CGFLOAT_MAX);
+  CGSize placeholderSize = [placeholder boundingRectWithSize:maxPlaceholderSize options:NSStringDrawingUsesLineFragmentOrigin attributes:@{NSFontAttributeName: self.font ?: defaultPlaceholderFont()} context:nil].size;
   placeholderSize = CGSizeMake(RCTCeilPixelValue(placeholderSize.width), RCTCeilPixelValue(placeholderSize.height));
   placeholderSize.width += textContainerInset.left + textContainerInset.right;
   placeholderSize.height += textContainerInset.top + textContainerInset.bottom;


### PR DESCRIPTION
## Summary

We have the wrong calculation of placeholder size currently, leads `contentSize` or some things inaccuracy.

## Changelog

[iOS] [Fixed] - Fixed wrong placeholder size calculation in multiline text input mode

## Test Plan

`placeholderSize` calculate correct.