### PR TITLE
[iOS] Fixed wrong contentSize calculation when placeholder is hidden in multiline text input

### DIFF
--- a/Libraries/Text/TextInput/Multiline/RCTUITextView.m
+++ b/Libraries/Text/TextInput/Multiline/RCTUITextView.m
@@ -195,7 +195,7 @@ static UIColor *defaultPlaceholderColor()
 - (CGSize)contentSize
 {
   CGSize contentSize = super.contentSize;
-  CGSize placeholderSize = self.placeholderSize;
+  CGSize placeholderSize = _placeholderView.isHidden ? CGSizeZero : self.placeholderSize;
   // When a text input is empty, it actually displays a placehoder.
   // So, we have to consider `placeholderSize` as a minimum `contentSize`.
   // Returning size DOES contain `textContainerInset` (aka `padding`).


### PR DESCRIPTION
## Summary

Currently, we pick the max size of text view's contentSize and placeholder's size, actually, if placeholder is be hidden, we should only return text view's contentSize.

## Changelog

[iOS] [Fixed] - Fixed wrong contentSize calculation when placeholder is hidden in multiline text input

## Test Plan

Get the correct `contentSize` of multiline text input.
