### PR TITLE
SysTraceSection.h: Improve 'unused' macro portability

### DIFF
--- a/ReactCommon/cxxreact/SystraceSection.h
+++ b/ReactCommon/cxxreact/SystraceSection.h
@@ -9,8 +9,12 @@
 #include <fbsystrace.h>
 #endif
 
-#ifdef __OBJC__
-#define RCT_UNUSED ___unused
+#ifdef __unused
+#define RCT_UNUSED __unused
+#elif __cplusplus >= 201703L
+#define RCT_UNUSED [[maybe_unused]]
+#elif defined(__GNUC__)
+#define RCT_UNUSED __attribute__((unused))
 #else
 #define RCT_UNUSED
 #endif

--- a/ReactCommon/cxxreact/SystraceSection.h
+++ b/ReactCommon/cxxreact/SystraceSection.h
@@ -9,6 +9,12 @@
 #include <fbsystrace.h>
 #endif
 
+#ifdef __OBJC__
+#define RCT_UNUSED ___unused
+#else
+#define RCT_UNUSED
+#endif
+
 namespace facebook {
 namespace react {
 
@@ -26,7 +32,7 @@ struct ConcreteSystraceSection {
 public:
   template<typename... ConvertsToStringPiece>
   explicit
-  ConcreteSystraceSection(__unused const char* name, __unused ConvertsToStringPiece&&... args)
+  ConcreteSystraceSection(RCT_UNUSED const char* name, RCT_UNUSED ConvertsToStringPiece&&... args)
     : m_section(TRACE_TAG_REACT_CXX_BRIDGE, name, args...)
   {}
 
@@ -39,7 +45,7 @@ struct DummySystraceSection {
 public:
   template<typename... ConvertsToStringPiece>
   explicit
-  DummySystraceSection(__unused const char* name, __unused ConvertsToStringPiece&&... args)
+  DummySystraceSection(RCT_UNUSED const char* name, RCT_UNUSED ConvertsToStringPiece&&... args)
     {}
 };
 using SystraceSection = DummySystraceSection;


### PR DESCRIPTION
## Summary

#23588 made use of the macro `__unused` to help suppress noisy compiler warnings. However, this is a GCC-only macro, so this causes compile errors in some environments.

This pull request introduces an `RCT_UNUSED` macro in `SysTraceSection.h` that will use `__unused` in GCC environments, and be a no-op in other environments. 

## Changelog

[General] [Fixed] - `SysTraceSection.h`: Improved portability

## Test Plan

No regressions have been noticed.