### PR TITLE
make sure to check array bounds in VirtualizedSectionList

### DIFF
--- a/Libraries/Lists/VirtualizedSectionList.js
+++ b/Libraries/Lists/VirtualizedSectionList.js
@@ -221,9 +221,9 @@ class VirtualizedSectionList<SectionT: SectionBase> extends React.PureComponent<
     trailingSection?: ?SectionT,
   } {
     let itemIndex = index;
-    const defaultKeyExtractor = this.props.keyExtractor;
-    for (let ii = 0; ii < this.props.sections.length; ii++) {
-      const section = this.props.sections[ii];
+    const {sections} = this.props
+    for (let ii = 0; ii < sections.length; ii++) {
+      const section = sections[ii];
       const key = section.key || String(ii);
       itemIndex -= 1; // The section adds an item for the header
       if (itemIndex >= section.data.length + 1) {
@@ -234,7 +234,7 @@ class VirtualizedSectionList<SectionT: SectionBase> extends React.PureComponent<
           key: key + ':header',
           index: null,
           header: true,
-          trailingSection: this.props.sections[ii + 1],
+          trailingSection: sections[ii + 1],
         };
       } else if (itemIndex === section.data.length) {
         return {
@@ -242,18 +242,18 @@ class VirtualizedSectionList<SectionT: SectionBase> extends React.PureComponent<
           key: key + ':footer',
           index: null,
           header: false,
-          trailingSection: this.props.sections[ii + 1],
+          trailingSection: sections[ii + 1],
         };
       } else {
-        const keyExtractor = section.keyExtractor || defaultKeyExtractor;
+        const keyExtractor = section.keyExtractor || this.props.keyExtractor;
         return {
           section,
           key: key + ':' + keyExtractor(section.data[itemIndex], itemIndex),
           index: itemIndex,
           leadingItem: section.data[itemIndex - 1],
-          leadingSection: this.props.sections[ii - 1],
-          trailingItem: section.data[itemIndex + 1],
-          trailingSection: this.props.sections[ii + 1],
+          leadingSection: sections[ii - 1],
+          trailingItem: section.data.length > itemIndex + 1 ? section.data[itemIndex + 1] : undefined,
+          trailingSection: sections[ii + 1],
         };
       }
     }

--- a/Libraries/Lists/VirtualizedSectionList.js
+++ b/Libraries/Lists/VirtualizedSectionList.js
@@ -221,7 +221,7 @@ class VirtualizedSectionList<SectionT: SectionBase> extends React.PureComponent<
     trailingSection?: ?SectionT,
   } {
     let itemIndex = index;
-    const {sections} = this.props
+    const {sections} = this.props;
     for (let ii = 0; ii < sections.length; ii++) {
       const section = sections[ii];
       const key = section.key || String(ii);
@@ -252,7 +252,10 @@ class VirtualizedSectionList<SectionT: SectionBase> extends React.PureComponent<
           index: itemIndex,
           leadingItem: section.data[itemIndex - 1],
           leadingSection: sections[ii - 1],
-          trailingItem: section.data.length > itemIndex + 1 ? section.data[itemIndex + 1] : undefined,
+          trailingItem:
+            section.data.length > itemIndex + 1
+              ? section.data[itemIndex + 1]
+              : undefined,
           trailingSection: sections[ii + 1],
         };
       }


### PR DESCRIPTION
SectionList accesses items outside of the array bounds.

This was discovered when using mobx, which warns you: `[mobx.array] Attempt to read an array index (${index}) that is out of bounds`. This is because `section.data[itemIndex + 1]` goes beyond array length.

This PR adds an array length check and simplifies the code a bit to avoid repetitive `this.props.`