### PR TITLE
[iOS] Fixed crash if event doesn't have body parameter

### DIFF
--- a/React/Base/RCTEventDispatcher.m
+++ b/React/Base/RCTEventDispatcher.m
@@ -85,11 +85,15 @@ RCT_EXPORT_MODULE()
     RCTAssert([body[@"target"] isKindOfClass:[NSNumber class]],
       @"Event body dictionary must include a 'target' property containing a React tag");
   }
+  
+  if (!body[@"target"]) {
+    return;
+  }
 
   name = RCTNormalizeInputEventName(name);
   [_bridge enqueueJSCall:@"RCTEventEmitter"
                   method:@"receiveEvent"
-                    args:body ? @[body[@"target"], name, body] : @[body[@"target"], name]
+                    args:@[body[@"target"], name, body]
               completion:NULL];
 }
 


### PR DESCRIPTION
## Summary

We need to check `body[@"target"]` wether equal to `nil`, if it is, return to prevent crash.

## Changelog

[iOS] [Fixed] - Fixed crash if event doesn't have body parameter

## Test Plan

If `body[@"target"]` is `nil`, not crash.