### PR TITLE
Fabric: Remove designated initializers in '/uimanager/'

### DIFF
--- a/ReactCommon/fabric/uimanager/ComponentDescriptorRegistry.cpp
+++ b/ReactCommon/fabric/uimanager/ComponentDescriptorRegistry.cpp
@@ -113,12 +113,13 @@ SharedShadowNode ComponentDescriptorRegistry::createNode(
   ComponentName componentName = componentNameByReactViewName(viewName);
   const SharedComponentDescriptor &componentDescriptor = (*this)[componentName];
 
-  SharedShadowNode shadowNode = componentDescriptor->createShadowNode(
-      {.tag = tag,
-       .rootTag = rootTag,
-       .eventEmitter =
-           componentDescriptor->createEventEmitter(std::move(eventTarget), tag),
-       .props = componentDescriptor->cloneProps(nullptr, RawProps(props))});
+  SharedShadowNode shadowNode = componentDescriptor->createShadowNode({
+      /* .tag = */ tag,
+      /* .rootTag = */ rootTag,
+      /* .props = */ componentDescriptor->cloneProps(nullptr, RawProps(props)),
+      /* .eventEmitter = */
+      componentDescriptor->createEventEmitter(std::move(eventTarget), tag),
+  });
   return shadowNode;
 }
 

--- a/ReactCommon/fabric/uimanager/Scheduler.cpp
+++ b/ReactCommon/fabric/uimanager/Scheduler.cpp
@@ -124,9 +124,16 @@ void Scheduler::renderTemplateToSurface(
           [&](const SharedRootShadowNode &oldRootShadowNode) {
             return std::make_shared<RootShadowNode>(
                 *oldRootShadowNode,
-                ShadowNodeFragment{.children =
-                                       std::make_shared<SharedShadowNodeList>(
-                                           SharedShadowNodeList{tree})});
+                ShadowNodeFragment{
+                    /* .tag = */ ShadowNodeFragment::tagPlaceholder(),
+                    /* .rootTag = */ ShadowNodeFragment::surfaceIdPlaceholder(),
+                    /* .props = */ ShadowNodeFragment::propsPlaceholder(),
+                    /* .eventEmitter = */
+                    ShadowNodeFragment::eventEmitterPlaceholder(),
+                    /* .children = */
+                    std::make_shared<SharedShadowNodeList>(
+                        SharedShadowNodeList{tree}),
+                });
           },
           commitStartTime);
     });
@@ -148,8 +155,15 @@ void Scheduler::stopSurface(SurfaceId surfaceId) const {
               return std::make_shared<RootShadowNode>(
                   *oldRootShadowNode,
                   ShadowNodeFragment{
-                      .children =
-                          ShadowNode::emptySharedShadowNodeSharedList()});
+                      /* .tag = */ ShadowNodeFragment::tagPlaceholder(),
+                      /* .rootTag = */
+                      ShadowNodeFragment::surfaceIdPlaceholder(),
+                      /* .props = */ ShadowNodeFragment::propsPlaceholder(),
+                      /* .eventEmitter = */
+                      ShadowNodeFragment::eventEmitterPlaceholder(),
+                      /* .children = */
+                      ShadowNode::emptySharedShadowNodeSharedList(),
+                  });
             },
             commitStartTime);
       });
@@ -247,7 +261,14 @@ void Scheduler::uiManagerDidFinishTransaction(
         [&](const SharedRootShadowNode &oldRootShadowNode) {
           return std::make_shared<RootShadowNode>(
               *oldRootShadowNode,
-              ShadowNodeFragment{.children = rootChildNodes});
+              ShadowNodeFragment{
+                  /* .tag = */ ShadowNodeFragment::tagPlaceholder(),
+                  /* .rootTag = */ ShadowNodeFragment::surfaceIdPlaceholder(),
+                  /* .props = */ ShadowNodeFragment::propsPlaceholder(),
+                  /* .eventEmitter = */
+                  ShadowNodeFragment::eventEmitterPlaceholder(),
+                  /* .children = */ rootChildNodes,
+              });
         },
         startCommitTime);
   });

--- a/ReactCommon/fabric/uimanager/ShadowTree.cpp
+++ b/ReactCommon/fabric/uimanager/ShadowTree.cpp
@@ -91,10 +91,10 @@ ShadowTree::ShadowTree(
 
   rootShadowNode_ = std::static_pointer_cast<const RootShadowNode>(
       rootComponentDescriptor.createShadowNode(ShadowNodeFragment{
-          .tag = surfaceId,
-          .rootTag = surfaceId,
-          .props = props,
-          .eventEmitter = noopEventEmitter,
+          /* .tag = */ surfaceId,
+          /* .rootTag = */ surfaceId,
+          /* .props = */ props,
+          /* .eventEmitter = */ noopEventEmitter,
       }));
 }
 
@@ -104,7 +104,13 @@ ShadowTree::~ShadowTree() {
         return std::make_shared<RootShadowNode>(
             *oldRootShadowNode,
             ShadowNodeFragment{
-                .children = ShadowNode::emptySharedShadowNodeSharedList()});
+                /* .tag = */ ShadowNodeFragment::tagPlaceholder(),
+                /* .rootTag = */ ShadowNodeFragment::surfaceIdPlaceholder(),
+                /* .props = */ ShadowNodeFragment::propsPlaceholder(),
+                /* .eventEmitter = */
+                ShadowNodeFragment::eventEmitterPlaceholder(),
+                /* .children = */ ShadowNode::emptySharedShadowNodeSharedList(),
+            });
       },
       getTime());
 }

--- a/ReactCommon/fabric/uimanager/UIManager.cpp
+++ b/ReactCommon/fabric/uimanager/UIManager.cpp
@@ -21,13 +21,16 @@ SharedShadowNode UIManager::createNode(
   const auto &props = componentDescriptor.cloneProps(nullptr, rawProps);
   const auto &state = componentDescriptor.createInitialState(props);
 
-  auto shadowNode = componentDescriptor.createShadowNode(
-      {.tag = tag,
-       .rootTag = surfaceId,
-       .eventEmitter =
-           componentDescriptor.createEventEmitter(std::move(eventTarget), tag),
-       .props = props,
-       .state = state});
+  auto shadowNode = componentDescriptor.createShadowNode({
+      /* .tag = */ tag,
+      /* .rootTag = */ surfaceId,
+      /* .props = */ props,
+      /* .eventEmitter = */
+      componentDescriptor.createEventEmitter(std::move(eventTarget), tag),
+      /* .children = */ ShadowNodeFragment::childrenPlaceholder(),
+      /* .localData = */ ShadowNodeFragment::localDataPlaceholder(),
+      /* .state = */ state,
+  });
 
   if (delegate_) {
     delegate_->uiManagerDidCreateShadowNode(shadowNode);
@@ -48,10 +51,14 @@ SharedShadowNode UIManager::cloneNode(
   auto clonedShadowNode = componentDescriptor.cloneShadowNode(
       *shadowNode,
       {
-          .props = rawProps ? componentDescriptor.cloneProps(
-                                  shadowNode->getProps(), *rawProps)
-                            : ShadowNodeFragment::propsPlaceholder(),
-          .children = children,
+          /* .tag = */ ShadowNodeFragment::tagPlaceholder(),
+          /* .rootTag = */ ShadowNodeFragment::surfaceIdPlaceholder(),
+          /* .props = */
+          rawProps ? componentDescriptor.cloneProps(
+                         shadowNode->getProps(), *rawProps)
+                   : ShadowNodeFragment::propsPlaceholder(),
+          /* .eventEmitter = */ ShadowNodeFragment::eventEmitterPlaceholder(),
+          /* .children = */ children,
       });
 
   return clonedShadowNode;
@@ -88,7 +95,11 @@ void UIManager::setNativeProps(
   auto &componentDescriptor =
       componentDescriptorRegistry_->at(shadowNode->getComponentHandle());
   auto props = componentDescriptor.cloneProps(shadowNode->getProps(), rawProps);
-  auto newShadowNode = shadowNode->clone(ShadowNodeFragment{.props = props});
+  auto newShadowNode = shadowNode->clone({
+      /* .tag = */ ShadowNodeFragment::tagPlaceholder(),
+      /* .rootTag = */ ShadowNodeFragment::surfaceIdPlaceholder(),
+      /* .props = */ props,
+  });
 
   shadowTreeRegistry_->visit(
       shadowNode->getRootTag(), [&](const ShadowTree &shadowTree) {
@@ -141,7 +152,15 @@ void UIManager::updateState(
       componentDescriptorRegistry_->at(shadowNode->getComponentHandle());
   auto state =
       componentDescriptor.createState(shadowNode->getState(), rawStateData);
-  auto newShadowNode = shadowNode->clone(ShadowNodeFragment{.state = state});
+  auto newShadowNode = shadowNode->clone({
+      /* .tag = */ ShadowNodeFragment::tagPlaceholder(),
+      /* .rootTag = */ ShadowNodeFragment::surfaceIdPlaceholder(),
+      /* .props = */ ShadowNodeFragment::propsPlaceholder(),
+      /* .eventEmitter = */ ShadowNodeFragment::eventEmitterPlaceholder(),
+      /* .children = */ ShadowNodeFragment::childrenPlaceholder(),
+      /* .localData = */ ShadowNodeFragment::localDataPlaceholder(),
+      /* .state = */ state,
+  });
 
   shadowTreeRegistry_->visit(
       shadowNode->getRootTag(), [&](const ShadowTree &shadowTree) {


### PR DESCRIPTION
## Summary

This pull request removes the designated initializers under the `fabric/uimanager/` folder. This will help improve the portability of these files.

## Changelog

[General] [Fixed] - Removed designated initializers under the `fabric/uimanager/` folder

## Test Plan

The Fabric test suite runs successfully without regressions.