### PR TITLE
chore: update comment in DrawerLayoutAndroid

### DIFF
--- a/Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.android.js
+++ b/Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.android.js
@@ -288,7 +288,10 @@ class DrawerLayoutAndroid extends React.Component<Props, State> {
 
   /**
    * Closing and opening example
-   * Note: To access the drawer you have to give it a ref. Refs do not work on stateless components
+   * Note: To access the drawer you have to give it a ref
+   *
+   * Class component:
+   *
    * render () {
    *   this.openDrawer = () => {
    *     this.refs.DRAWER.openDrawer()
@@ -298,9 +301,25 @@ class DrawerLayoutAndroid extends React.Component<Props, State> {
    *   }
    *   return (
    *     <DrawerLayoutAndroid ref={'DRAWER'}>
+   *      {children}
    *     </DrawerLayoutAndroid>
    *   )
    * }
+   *
+   * Function component:
+   *
+   * const drawerRef = useRef()
+   * const openDrawer = () => {
+   *   drawerRef.current.openDrawer()
+   * }
+   * const closeDrawer = () => {
+   *   drawerRef.current.closeDrawer()
+   * }
+   * return (
+   *   <DrawerLayoutAndroid ref={drawerRef}>
+   *     {children}
+   *   </DrawerLayoutAndroid>
+   * )
    */
   _getDrawerLayoutHandle() {
     return ReactNative.findNodeHandle(this._nativeRef.current);


### PR DESCRIPTION
...referencing stale function component limitations

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

While preparing a short tutorial on the DrawerLayoutAndroid using the v59 RC, I came across a comment that we can update that states refs as being available only in Class components. This updates that with both class and function components.

If we'd rather delete the comment entirely and move both examples to the website, I'm fine with that too. The current docs page doesn't address the imperative API. https://facebook.github.io/react-native/docs/drawerlayoutandroid

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See http://facebook.github.io/react-native/docs/contributing#changelog for an example. -->

[General] [fixed] - Update stale comment to provide both class and functional component ref example for DrawerLayoutAndroid

## Test Plan

This code only affects source code comments in one file. I wouldn't expect any testing to be necessary.