### PR TITLE
[iOS] Added support of __nullable and __nonnull for module exported method signature

### DIFF
--- a/React/Base/RCTModuleMethod.mm
+++ b/React/Base/RCTModuleMethod.mm
@@ -106,9 +106,11 @@ static RCTNullability RCTParseNullability(const char **input)
 
 static RCTNullability RCTParseNullabilityPostfix(const char **input)
 {
-  if (RCTReadString(input, "_Nullable")) {
+  if (RCTReadString(input, "_Nullable") ||
+      RCTReadString(input, "__nullable")) {
     return RCTNullable;
-  } else if (RCTReadString(input, "_Nonnull")) {
+  } else if (RCTReadString(input, "_Nonnull") ||
+             RCTReadString(input, "__nonnull")) {
     return RCTNonnullable;
   }
   return RCTNullabilityUnspecified;


### PR DESCRIPTION
## Summary

For the `NullabilityPostfix`, we can use `_Nullable` or `__nullable`. Please see https://developer.apple.com/swift/blog/?id=25 , and we also use it in our code.

## Changelog

[iOS] [Added] - Added support of __nullable and __nonnull for module exported method signature

## Test Plan

Support `__nullable` annotate like :
`RCT_EXPORT_METHOD(addEvent:(NSString * __nullable)name`