### PR TITLE
[Lean Core] Add warning that CameraRoll has been moved to RNC

### DIFF
--- a/Libraries/react-native/react-native-implementation.js
+++ b/Libraries/react-native/react-native-implementation.js
@@ -213,6 +213,12 @@ module.exports = {
     return require('BackHandler');
   },
   get CameraRoll() {
+    warnOnce(
+      'cameraroll-moved',
+      'CameraRoll has been extracted from react-native core and will be removed in a future release. ' +
+        "It can now be installed and imported from '@react-native-community/cameraroll' instead of 'react-native'. " +
+        'See https://github.com/react-native-community/react-native-cameraroll',
+    );
     return require('CameraRoll');
   },
   get Clipboard() {


### PR DESCRIPTION
## Summary
Adds a moved warning to the CameraRoll import directing people to the @react-native-community/cameraroll package.

## Changelog

[Lean Core] [Warning] add warning that CameraRoll has been moved to RNC

## Test Plan
<img width="377" alt="screenshot 2019-03-03 at 21 11 11" src="https://user-images.githubusercontent.com/1605731/53695634-fe59ea00-3df8-11e9-9060-283575b3d0a4.png">
