### PR TITLE
[iOS] Keep placeholder attributes sync with text input text's attributes

### DIFF
--- a/Libraries/Text/TextInput/Multiline/RCTUITextView.m
+++ b/Libraries/Text/TextInput/Multiline/RCTUITextView.m
@@ -82,7 +82,7 @@ static UIColor *defaultPlaceholderColor()
 - (void)setPlaceholder:(NSString *)placeholder
 {
   _placeholder = placeholder;
-  _placeholderView.text = _placeholder;
+  _placeholderView.attributedText = [[NSAttributedString alloc] initWithString:_placeholder ?: @"" attributes:[self placeholderEffectiveTextAttributes]];
 }
 
 - (void)setPlaceholderColor:(UIColor *)placeholderColor
@@ -98,7 +98,8 @@ static UIColor *defaultPlaceholderColor()
   }
   self.typingAttributes = reactTextAttributes.effectiveTextAttributes;
   _reactTextAttributes = reactTextAttributes;
-  _placeholderView.font = self.font ?: defaultPlaceholderFont();
+  // Update placeholder text attributes
+  [self setPlaceholder:_placeholder];
 }
 
 - (RCTTextAttributes *)reactTextAttributes
@@ -247,6 +248,17 @@ static UIColor *defaultPlaceholderColor()
 {
   BOOL isVisible = _placeholder.length != 0 && self.attributedText.length == 0;
   _placeholderView.hidden = !isVisible;
+}
+
+- (NSDictionary<NSAttributedStringKey, id> *)placeholderEffectiveTextAttributes
+{
+  NSDictionary<NSAttributedStringKey, id> *effectiveTextAttributes = @{
+                                                                       NSFontAttributeName: _reactTextAttributes.effectiveFont ?: defaultPlaceholderFont(),
+                                                                       NSForegroundColorAttributeName: self.placeholderColor ?: defaultPlaceholderColor(),
+                                                                       NSKernAttributeName:isnan(_reactTextAttributes.letterSpacing) ? @0 : @(_reactTextAttributes.letterSpacing)
+                                                                       };
+  
+  return effectiveTextAttributes;
 }
 
 #pragma mark - Utility Methods

--- a/Libraries/Text/TextInput/Singleline/RCTUITextField.m
+++ b/Libraries/Text/TextInput/Singleline/RCTUITextField.m
@@ -70,6 +70,7 @@
   }
   self.defaultTextAttributes = reactTextAttributes.effectiveTextAttributes;
   _reactTextAttributes = reactTextAttributes;
+  [self _updatePlaceholder];
 }
 
 - (RCTTextAttributes *)reactTextAttributes
@@ -86,6 +87,10 @@
   NSMutableDictionary *attributes = [NSMutableDictionary new];
   if (_placeholderColor) {
     [attributes setObject:_placeholderColor forKey:NSForegroundColorAttributeName];
+  }
+  // Kerning
+  if (!isnan(_reactTextAttributes.letterSpacing)) {
+    attributes[NSKernAttributeName] = @(_reactTextAttributes.letterSpacing);
   }
 
   self.attributedPlaceholder = [[NSAttributedString alloc] initWithString:self.placeholder


### PR DESCRIPTION
## Summary

We need to keep placeholder attributes sync with text input's text attributes, like `font`,`kern` ....., to keep style the same.

Also fixes #19002 .

## Changelog

[iOS] [Fixed] - Keep placeholder attributes sync with text input text's attributes

## Test Plan

When text input has style attributes like `letterSpacing`,`font`, they also applied to placeholder text attributes.

```
        <TextInput
  style={{ letterSpacing: 10 }}
  placeholder="I will not respect letterSpacing value on iOS, I will not respect letterSpacing value on iOS"
  multiline={true}
```

<img width="375" alt="image" src="https://user-images.githubusercontent.com/5061845/53705985-fdf63900-3e62-11e9-9bb3-3827363f9e68.png">
