### PR TITLE
Fix breaking of PickerAndroid when child is null.

### DIFF
--- a/Libraries/Components/Picker/PickerAndroid.android.js
+++ b/Libraries/Components/Picker/PickerAndroid.android.js
@@ -64,7 +64,7 @@ class PickerAndroid extends React.Component<
   ): PickerAndroidState {
     let selectedIndex = 0;
     const items = React.Children.map(props.children, (child, index) => {
-      if (child === null){
+      if (child === null) {
         return;
       }
       if (child.props.value === props.selectedValue) {

--- a/Libraries/Components/Picker/PickerAndroid.android.js
+++ b/Libraries/Components/Picker/PickerAndroid.android.js
@@ -64,6 +64,9 @@ class PickerAndroid extends React.Component<
   ): PickerAndroidState {
     let selectedIndex = 0;
     const items = React.Children.map(props.children, (child, index) => {
+      if (child === null){
+        return;
+      }
       if (child.props.value === props.selectedValue) {
         selectedIndex = index;
       }


### PR DESCRIPTION
when conditional rendering is used then picker breaks when the child is null.

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
This conditional rendering inside Picker fails when a is 1, because child will be null in PickerAndroid.android.js.
```
{
   this.state.a === 2 && <Picker.Item label="value" value="value" />
}
```
## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See http://facebook.github.io/react-native/docs/contributing#changelog for an example. -->

[ANDROID] [FIXED] - When child is null it returns.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
After changes this code works
```
{
   this.state.a === 2 && <Picker.Item label="value" value="value" />
}
```
