### PR TITLE
Fabric: Remove designated initializer in LayoutMetrics.h

### DIFF
--- a/ReactCommon/fabric/core/layout/LayoutMetrics.h
+++ b/ReactCommon/fabric/core/layout/LayoutMetrics.h
@@ -57,7 +57,10 @@ struct LayoutMetrics {
  * Represents some undefined, not-yet-computed or meaningless value of
  * `LayoutMetrics` type.
  */
-static const LayoutMetrics EmptyLayoutMetrics = {.frame = {.size = {-1, -1}}};
+static const LayoutMetrics EmptyLayoutMetrics = {/* .frame = */ {
+    /* .origin = */ {0, 0},
+    /* .size = */ {-1, -1},
+}};
 
 } // namespace react
 } // namespace facebook


### PR DESCRIPTION
## Summary

This pull request removes the designated initializer in `LayoutMetrics.h`. This will help improve the portability of this file.

## Changelog

[General] [Changed] - Fabric: Remove designated initializer in LayoutMetrics.h

## Test Plan

Fabric has been built on MSVC 2017 and Ubuntu 18.04 + Clang 6, and the tests run without issue