### PR TITLE
[iOS] Add lineHeight support of placeholder for multiline text input

### DIFF
--- a/Libraries/Text/TextInput/Multiline/RCTUITextView.m
+++ b/Libraries/Text/TextInput/Multiline/RCTUITextView.m
@@ -252,13 +252,20 @@ static UIColor *defaultPlaceholderColor()
 
 - (NSDictionary<NSAttributedStringKey, id> *)placeholderEffectiveTextAttributes
 {
-  NSDictionary<NSAttributedStringKey, id> *effectiveTextAttributes = @{
-                                                                       NSFontAttributeName: _reactTextAttributes.effectiveFont ?: defaultPlaceholderFont(),
-                                                                       NSForegroundColorAttributeName: self.placeholderColor ?: defaultPlaceholderColor(),
-                                                                       NSKernAttributeName:isnan(_reactTextAttributes.letterSpacing) ? @0 : @(_reactTextAttributes.letterSpacing)
-                                                                       };
+  NSMutableDictionary<NSAttributedStringKey, id> *effectiveTextAttributes = [NSMutableDictionary dictionaryWithDictionary:@{
+                                                                                                                            NSFontAttributeName: _reactTextAttributes.effectiveFont ?: defaultPlaceholderFont(),
+                                                                                                                            NSForegroundColorAttributeName: self.placeholderColor ?: defaultPlaceholderColor(),
+                                                                                                                            NSKernAttributeName:isnan(_reactTextAttributes.letterSpacing) ? @0 : @(_reactTextAttributes.letterSpacing)
+                                                                                                                            }];
+  if (!isnan(_reactTextAttributes.lineHeight)) {
+    NSMutableParagraphStyle *paragraphStyle = [NSMutableParagraphStyle new];
+    CGFloat lineHeight = _reactTextAttributes.lineHeight * _reactTextAttributes.effectiveFontSizeMultiplier;
+    paragraphStyle.minimumLineHeight = lineHeight;
+    paragraphStyle.maximumLineHeight = lineHeight;
+    effectiveTextAttributes[NSParagraphStyleAttributeName] = paragraphStyle;
+  }
   
-  return effectiveTextAttributes;
+  return [effectiveTextAttributes copy];
 }
 
 #pragma mark - Utility Methods


### PR DESCRIPTION
## Summary

After some refactor of text input attributes, we can now add style attributes  the same as text input's attributes, from https://github.com/facebook/react-native/issues/19002#issuecomment-467171589, user wants placeholder to support line-height , I think we can add it now for multiline text input.

## Changelog

[iOS] [Added] - Added lineHeight support of placeholder for multiline text input

## Test Plan

Now, if text input has `lineHeight` attribute, we also apply it to placeholder.

```
        <TextInput multiline={true} style={{fontSize: 18,
        letterSpacing: 10,
        lineHeight: 60,
        }}
        placeholder="At every tiled on ye defer do. No attention suspected oh difficult. Fond his say old meet cold find come whom. The sir park sake bred. Wonder matter now can estate esteem assure fat roused. Am performed on existence as discourse is. Pleasure friendly at marriage blessing or. "
        />
```

<img width="377" alt="image" src="https://user-images.githubusercontent.com/5061845/53776644-9a870c80-3f31-11e9-94ef-1116532a79ed.png">


