### PR TITLE
[iOS] Keep placeholder paragraph style same with text input

### DIFF
--- a/Libraries/Text/RCTTextAttributes.h
+++ b/Libraries/Text/RCTTextAttributes.h
@@ -67,6 +67,11 @@ extern NSString *const RCTTextAttributesTagAttributeName;
 - (NSDictionary<NSAttributedStringKey, id> *)effectiveTextAttributes;
 
 /**
+ * Constructed paragraph style.
+ */
+- (NSParagraphStyle *_Nullable)effectiveParagraphStyle;
+
+/**
  * Constructed font.
  */
 - (UIFont *)effectiveFont;

--- a/Libraries/Text/RCTTextAttributes.m
+++ b/Libraries/Text/RCTTextAttributes.m
@@ -79,6 +79,44 @@ NSString *const RCTTextAttributesTagAttributeName = @"RCTTextAttributesTagAttrib
   _textTransform = textAttributes->_textTransform != RCTTextTransformUndefined ? textAttributes->_textTransform : _textTransform;
 }
 
+- (NSParagraphStyle *)effectiveParagraphStyle
+{
+  // Paragraph Style
+  NSMutableParagraphStyle *paragraphStyle = [NSMutableParagraphStyle new];
+  BOOL isParagraphStyleUsed = NO;
+  if (_alignment != NSTextAlignmentNatural) {
+    NSTextAlignment alignment = _alignment;
+    if (_layoutDirection == UIUserInterfaceLayoutDirectionRightToLeft) {
+      if (alignment == NSTextAlignmentRight) {
+        alignment = NSTextAlignmentLeft;
+      } else if (alignment == NSTextAlignmentLeft) {
+        alignment = NSTextAlignmentRight;
+      }
+    }
+    
+    paragraphStyle.alignment = alignment;
+    isParagraphStyleUsed = YES;
+  }
+  
+  if (_baseWritingDirection != NSWritingDirectionNatural) {
+    paragraphStyle.baseWritingDirection = _baseWritingDirection;
+    isParagraphStyleUsed = YES;
+  }
+  
+  if (!isnan(_lineHeight)) {
+    CGFloat lineHeight = _lineHeight * self.effectiveFontSizeMultiplier;
+    paragraphStyle.minimumLineHeight = lineHeight;
+    paragraphStyle.maximumLineHeight = lineHeight;
+    isParagraphStyleUsed = YES;
+  }
+  
+  if (isParagraphStyleUsed) {
+    return [paragraphStyle copy];
+  }
+  
+  return nil;
+}
+
 - (NSDictionary<NSAttributedStringKey, id> *)effectiveTextAttributes
 {
   NSMutableDictionary<NSAttributedStringKey, id> *attributes =
@@ -107,35 +145,8 @@ NSString *const RCTTextAttributesTagAttributeName = @"RCTTextAttributesTagAttrib
   }
 
   // Paragraph Style
-  NSMutableParagraphStyle *paragraphStyle = [NSMutableParagraphStyle new];
-  BOOL isParagraphStyleUsed = NO;
-  if (_alignment != NSTextAlignmentNatural) {
-    NSTextAlignment alignment = _alignment;
-    if (_layoutDirection == UIUserInterfaceLayoutDirectionRightToLeft) {
-      if (alignment == NSTextAlignmentRight) {
-        alignment = NSTextAlignmentLeft;
-      } else if (alignment == NSTextAlignmentLeft) {
-        alignment = NSTextAlignmentRight;
-      }
-    }
-
-    paragraphStyle.alignment = alignment;
-    isParagraphStyleUsed = YES;
-  }
-
-  if (_baseWritingDirection != NSWritingDirectionNatural) {
-    paragraphStyle.baseWritingDirection = _baseWritingDirection;
-    isParagraphStyleUsed = YES;
-  }
-
-  if (!isnan(_lineHeight)) {
-    CGFloat lineHeight = _lineHeight * self.effectiveFontSizeMultiplier;
-    paragraphStyle.minimumLineHeight = lineHeight;
-    paragraphStyle.maximumLineHeight = lineHeight;
-    isParagraphStyleUsed = YES;
-  }
-
-  if (isParagraphStyleUsed) {
+  NSParagraphStyle *paragraphStyle = [self effectiveParagraphStyle];
+  if (paragraphStyle) {
     attributes[NSParagraphStyleAttributeName] = paragraphStyle;
   }
 

--- a/Libraries/Text/TextInput/Multiline/RCTUITextView.m
+++ b/Libraries/Text/TextInput/Multiline/RCTUITextView.m
@@ -257,11 +257,8 @@ static UIColor *defaultPlaceholderColor()
                                                                                                                             NSForegroundColorAttributeName: self.placeholderColor ?: defaultPlaceholderColor(),
                                                                                                                             NSKernAttributeName:isnan(_reactTextAttributes.letterSpacing) ? @0 : @(_reactTextAttributes.letterSpacing)
                                                                                                                             }];
-  if (!isnan(_reactTextAttributes.lineHeight)) {
-    NSMutableParagraphStyle *paragraphStyle = [NSMutableParagraphStyle new];
-    CGFloat lineHeight = _reactTextAttributes.lineHeight * _reactTextAttributes.effectiveFontSizeMultiplier;
-    paragraphStyle.minimumLineHeight = lineHeight;
-    paragraphStyle.maximumLineHeight = lineHeight;
+  NSParagraphStyle *paragraphStyle = [_reactTextAttributes effectiveParagraphStyle];
+  if (paragraphStyle) {
     effectiveTextAttributes[NSParagraphStyleAttributeName] = paragraphStyle;
   }
   


### PR DESCRIPTION
## Summary

Keep placeholder paragraph style same with text input.

## Changelog

[iOS] [Fixed] - Keep placeholder paragraph style same with text input

## Test Plan

```
        <TextInput multiline={true} style={{fontSize: 18,
        textAlign: "center",
        }}
        placeholder="At every tiled on ye defer do. No attention suspected oh difficult. Fond his say old meet cold find come whom. The sir park sake bred. Wonder matter now can estate esteem assure fat roused. Am performed on existence as discourse is. Pleasure friendly at marriage blessing or. "
        />
```

@cpojer Is this what we want? 🤔 

<img width="375" alt="image" src="https://user-images.githubusercontent.com/5061845/53785401-50168780-3f53-11e9-90ed-776aa6e9c9e9.png">
