### PR TITLE
Keep placeholder paragraph style same with single line text input

### DIFF
--- a/Libraries/Text/TextInput/Singleline/RCTUITextField.m
+++ b/Libraries/Text/TextInput/Singleline/RCTUITextField.m
@@ -122,6 +122,11 @@
     effectiveTextAttributes[NSKernAttributeName] = @(_reactTextAttributes.letterSpacing);
   }
   
+  NSParagraphStyle *paragraphStyle = [_reactTextAttributes effectiveParagraphStyle];
+  if (paragraphStyle) {
+    effectiveTextAttributes[NSParagraphStyleAttributeName] = paragraphStyle;
+  }
+  
   return [effectiveTextAttributes copy];
 }
 


### PR DESCRIPTION
## Summary

Keep placeholder paragraph style same with text input.

## Changelog

[iOS] [Fixed] - Keep placeholder paragraph style same with single line text input

## Test Plan

```
        <TextInput multiline={false} style={{fontSize: 18,
        textAlign: "center",
        }}
        placeholder="At every tiled on ye defer do.  "
        />
```
