### PR TITLE
Added placeholder attributes example to RNTester

### DIFF
--- a/RNTester/js/TextInputExample.ios.js
+++ b/RNTester/js/TextInputExample.ios.js
@@ -530,6 +530,11 @@ const styles = StyleSheet.create({
     padding: 4,
     marginBottom: 4,
   },
+  multilinePlaceholderStyles: {
+    letterSpacing: 10,
+    lineHeight: 20,
+    textAlign: 'center',
+  },
   multilineExpandable: {
     height: 'auto',
     maxHeight: 100,
@@ -540,6 +545,10 @@ const styles = StyleSheet.create({
     fontSize: 18,
     fontFamily: 'Cochin',
     height: 60,
+  },
+  singlelinePlaceholderStyles: {
+    letterSpacing: 10,
+    textAlign: 'center',
   },
   eventLabel: {
     margin: 3,
@@ -1119,6 +1128,28 @@ exports.examples = [
           </WithLabel>
           <WithLabel label="name">
             <TextInput textContentType="name" style={styles.default} />
+          </WithLabel>
+        </View>
+      );
+    },
+  },
+  {
+    title: 'TextInput Placeholder Styles',
+    render: function() {
+      return (
+        <View>
+          <WithLabel label="letterSpacing: 10 lineHeight: 20 textAlign: 'center'">
+            <TextInput
+              placeholder="multiline text input"
+              multiline={true}
+              style={[styles.multiline, styles.multilinePlaceholderStyles]}
+            />
+          </WithLabel>
+          <WithLabel label="letterSpacing: 10 textAlign: 'center'">
+            <TextInput
+              placeholder="singleline"
+              style={[styles.default, styles.singlelinePlaceholderStyles]}
+            />
           </WithLabel>
         </View>
       );


### PR DESCRIPTION
## Summary

After some works, we already support some attributes to text input's placeholder, so we can add example to show it in RNTester.

## Changelog

[iOS] [Added] - Added placeholder attributes example to RNTester

## Test Plan

We added `TextInput Placeholder Styles` example:

<img width="375" alt="image" src="https://user-images.githubusercontent.com/5061845/53812513-9f31dc00-3f96-11e9-880e-5781582ff3fc.png">


