### PR TITLE
Add SUPPORT document, update other GitHub templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,27 +1,29 @@
 ---
-name: 🐛 Bug Report
+name: "🐛 Bug Report"
 about: You want to report a reproducible bug or regression in React Native.
-labels: "Type: Bug Report"
+title: ''
+labels: 'Type: Bug Report'
+
 ---
 
 ## 🐛 Bug Report
-<!-- 
+<!--
   A clear and concise description of what the bug is.
   Include screenshots if needed.
 -->
 
 ## To Reproduce
-<!-- 
+<!--
   Steps to reproduce the behavior.
 -->
 
 ## Expected Behavior
-<!-- 
+<!--
   A clear and concise description of what you expected to happen.
 -->
 
 ## Code Example
-<!-- 
+<!--
   Please provide a Snack (https://snack.expo.io/), a link to a repository on GitHub, or
   provide a minimal code example that reproduces the problem.
   Here are some tips for providing a minimal example: https://stackoverflow.com/help/mcve.
@@ -30,6 +32,6 @@ labels: "Type: Bug Report"
 -->
 
 ## Environment
-<!-- 
+<!--
   Run `react-native info` in your terminal and copy the results here.
 -->

--- a/.github/ISSUE_TEMPLATE/discussion.md
+++ b/.github/ISSUE_TEMPLATE/discussion.md
@@ -1,7 +1,9 @@
 ---
-name: 🚀 Discussion
+name: "🚀 Discussion"
 about: You have an idea that could make React Native better, or you want to discuss some aspect of the framework.
-labels: "Type: Discussion"
+title: 'Discussion: '
+labels: 'Type: Discussion'
+
 ---
 
 If you want to participate in casual discussions about the use of React Native, consider participating in one of the following forums:

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,7 +1,9 @@
 ---
-name: 📃 Documentation Bug
+name: "📃 Documentation Bug"
 about: You want to report something that is wrong or missing from the documentation.
-labels: "Type: Docs"
+title: 'Docs:'
+labels: 'Type: Docs'
+
 ---
 
 The React Native website is hosted on a separate repository. You may let the

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,15 +1,26 @@
 ---
-name: 💬 Questions and Help
+name: "🤔 Questions and Help"
 about: You need help writing your React Native app.
-labels: "Type: Question"
+title: 'Question: '
+labels: 'Type: Question'
+
 ---
 
-GitHub Issues in the `facebook/react-native` repository are used exclusively for tracking bugs in the React Native framework. Please do not submit support requests through GitHub.
-
-For questions or help, please see:
-- The React Native help page: http://facebook.github.io/react-native/help
-- The React Native channel in Reactiflux: https://discord.gg/0ZcbPKXt5bZjGY5n
-- The react-native tag on Stack Overflow: http://stackoverflow.com/questions/tagged/react-native
+We use GitHub Issues exclusively to track bugs in React Native. As it happens, support requests that are created as issues are likely to be closed. We want to make sure you are able to find the help you seek. Please take a look at the following resources.
 
 
-### Please note that this issue tracker is not a help forum and requests for help will be closed.
+## Coding Questions
+
+### https://stackoverflow.com/questions/tagged/react-native
+
+If you have a coding question related to React Native, it might be better suited for Stack Overflow. It's a great place to browse through frequent questions about using React Native, as well as ask for help with specific questions.
+
+
+## Talk to other React Native developers
+
+### https://www.reactiflux.com/
+
+Reactiflux is an active community of React and React Native developers. If you are looking for immediate assistance or have a general question about React Native, the #react-native channel is a good place to start.
+
+
+> For a full list of community resources, check out React Native's Community page at https://facebook.github.io/react-native/help.

--- a/.github/ISSUE_TEMPLATE/regression.md
+++ b/.github/ISSUE_TEMPLATE/regression.md
@@ -1,12 +1,15 @@
 ---
-name: 💥 Regression Report
+name: "💥 Regression Report"
 about: You want to report unexpected behavior that worked in previous releases.
-labels: "Type: Bug Report", "Impact: Regression"
+title: 'Regression: '
+labels: 'Type: Bug Report, Impact: Regression'
+
 ---
 
 ## 💥 Regression Report
-<!-- 
+<!--
   A clear and concise description of what the regression is.
+  Include screenshots if needed.
 -->
 
 ## Last working version
@@ -23,12 +26,12 @@ Stopped working in version:
 
 ## Expected Behavior
 
-<!-- 
+<!--
   A clear and concise description of what you expected to happen.
 -->
 
 ## Code Example
-<!-- 
+<!--
   Please provide a Snack (https://snack.expo.io/), a link to a repository on GitHub, or
   provide a minimal code example that reproduces the problem.
   Here are some tips for providing a minimal example: https://stackoverflow.com/help/mcve.
@@ -37,6 +40,6 @@ Stopped working in version:
 -->
 
 ## Environment
-<!-- 
+<!--
   Run `react-native info` in your terminal and copy the results here.
 -->

--- a/.github/SUPPORT
+++ b/.github/SUPPORT
@@ -1,0 +1,35 @@
+Thanks for using React Native! If you need help with your React Native app, the right place to go depends on the type of help that you need.
+
+
+## 🤔 I have a question or need help with my React Native app.
+
+If you have a coding question related to React Native, it might be better suited for Stack Overflow. It's a great place to browse through [frequent questions about using React Native](https://stackoverflow.com/questions/tagged/react-native?sort=frequent&pageSize=15), as well as [ask for help with specific questions](https://stackoverflow.com/questions/tagged/react-native).
+
+[Reactiflux](https://www.reactiflux.com/) is an active community of React and React Native developers. If you are looking for immediate assistance or have a general question about React Native, the #react-native channel is a good place to start.
+
+
+## 📃 I found something that seems wrong in the documentation.
+
+The React Native website is hosted on a [separate repository](https://github.com/facebook/react-native-website). If you want to report something that is wrong or missing from the documentation, [please open a new issue there](https://github.com/facebook/react-native-website/issues).
+
+
+## 🐛 I found a bug in React Native.
+
+If you want to report a reproducible bug or regression in the React Native library, you can [create a new issue](https://github.com/facebook/react-native/issues/new?labels=Type%3A+Bug+Report&template=bug_report.md). It's a good idea to look through [open issues](https://github.com/facebook/react-native/issues) before doing so, as someone else may have reported a similar issue.
+
+
+## 🚀 I want to discuss the future of React Native.
+
+If you'd like to discuss topics related to the future of React Native, please check out the [React Native Community Discussions and Proposals](https://github.com/react-native-community/discussions-and-proposals) repository.
+
+
+## 💬 I want to talk to other React Native developers.
+
+If you want to participate in casual discussions about the use of React Native, consider participating in one of the following forums:
+
+- [Reactiflux Discord Server](https://www.reactiflux)
+- [Spectrum Chat](https://spectrum.chat/react-native)
+- [React Native Community Facebook Group](https://www.facebook.com/groups/react.native.community)
+
+
+> For a full list of community resources, check out [React Native's Community page](https://facebook.github.io/react-native/help).

--- a/RNTester/README.md
+++ b/RNTester/README.md
@@ -12,7 +12,7 @@ Before running the app, make sure you ran:
 
 ### Running on iOS
 
-Mac OS and Xcode are required.
+Both macOS and Xcode are required.
 
 - Open `RNTester/RNTester.xcodeproj` in Xcode
 - Hit the Run button

--- a/bots/dangerfile.js
+++ b/bots/dangerfile.js
@@ -64,7 +64,7 @@ const correctlyFormattedChangelog = changelogRegex.test(danger.github.pr.body);
 
 // Provides advice if a changelog is missing
 const changelogInstructions =
-  'A changelog entry has the following format: [`[CATEGORY] [TYPE] - Message`](http://facebook.github.io/react-native/docs/contributing#changelog).';
+  'A changelog entry has the following format: `[CATEGORY] [TYPE] - Message`.\n\n<details>CATEGORY may be:\n\n- General\n- iOS\n- Android\n\nTYPE may be:\n\n- Added, for new features.\n- Changed, for changes in existing functionality.\n- Deprecated, for soon-to-be removed features.\n- Removed, for now removed features.\n- Fixed, for any bug fixes.\n- Security, in case of vulnerabilities.\n\nMESSAGE may answer "what and why" on a feature level.   Use this to briefly tell React Native users about notable changes.</details>';
 if (!includesChangelog) {
   const title = ':clipboard: Missing Changelog';
   const idea =


### PR DESCRIPTION
## Summary  

See https://help.github.com/en/articles/adding-support-resources-to-your-project. The SUPPORT file is surfaced by GitHub in several useful places. The goal is to increase discoverability of all support resources, giving the reader an opportunity to find the help they need before they open an issue in the              repository. A secondary goal is to use a friendlier tone when communicating our processes.

The issue templates have been standardized to follow the format used by GitHub's template tool. A bug in the "Regressions" template, due to its use of multiple labels, is fixed as well.
The bot will explain how a changelog can be fixed when it nags a PR.

## Changelog

[General][Added] - Added SUPPORT resources, friendlier messaging.

## Test Plan

N/A