### PR TITLE
use TraceCompat

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/systrace/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/systrace/BUCK
@@ -1,4 +1,4 @@
-load("//tools/build_defs/oss:rn_defs.bzl", "rn_android_library")
+load("//tools/build_defs/oss:rn_defs.bzl", "react_native_dep", "rn_android_library")
 
 rn_android_library(
     name = "systrace",
@@ -6,4 +6,7 @@ rn_android_library(
     visibility = [
         "PUBLIC",
     ],
+    provided_deps = [
+        react_native_dep("third-party/android/support/v4:lib-support-v4"),
+    ]
 )

--- a/ReactAndroid/src/main/java/com/facebook/systrace/Systrace.java
+++ b/ReactAndroid/src/main/java/com/facebook/systrace/Systrace.java
@@ -7,8 +7,7 @@
 
 package com.facebook.systrace;
 
-import android.os.Build;
-import android.os.Trace;
+import android.support.v4.os.TraceCompat;
 
 /**
  * Systrace stub that mostly does nothing but delegates to Trace for beginning/ending sections.
@@ -55,15 +54,11 @@ public class Systrace {
   }
 
   public static void beginSection(long tag, final String sectionName) {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
-      Trace.beginSection(sectionName);
-    }
+    TraceCompat.beginSection(sectionName);
   }
 
   public static void endSection(long tag) {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
-      Trace.endSection();
-    }
+    TraceCompat.endSection();
   }
 
   public static void beginAsyncSection(

--- a/ReactAndroid/src/test/java/com/facebook/react/bridge/BUCK
+++ b/ReactAndroid/src/test/java/com/facebook/react/bridge/BUCK
@@ -34,6 +34,7 @@ rn_robolectric_test(
         ":testhelpers",
         react_native_dep("libraries/fbcore/src/test/java/com/facebook/powermock:powermock"),
         react_native_dep("libraries/soloader/java/com/facebook/soloader:soloader"),
+        react_native_dep("third-party/android/support/v4:lib-support-v4"),
         react_native_dep("third-party/java/fest:fest"),
         react_native_dep("third-party/java/jsr-305:jsr-305"),
         react_native_dep("third-party/java/junit:junit"),


### PR DESCRIPTION
## Summary

I was working to use more Android Support Library in RN core, but wasn't able to finish it. So this PR is for only Systrace and TraceCompat only.

## Changelog

[Android] [Changed] - Use TraceCompat in Systrace

## Test Plan

CI is green, and everything works as expected.
