### PR TITLE
[iOS] Add additionalSafeAreaInsets prop for SafeAreaView

### DIFF
--- a/Libraries/Components/SafeAreaView/RCTSafeAreaViewNativeComponent.js
+++ b/Libraries/Components/SafeAreaView/RCTSafeAreaViewNativeComponent.js
@@ -12,10 +12,12 @@ const requireNativeComponent = require('requireNativeComponent');
 
 import type {ViewProps} from 'ViewPropTypes';
 import type {NativeComponent} from 'ReactNative';
+import type {EdgeInsetsProp} from 'EdgeInsetsPropType';
 
 type NativeProps = $ReadOnly<{|
   ...ViewProps,
   emulateUnlessSupported?: boolean,
+  additionalSafeAreaInsets?: ?EdgeInsetsProp,
 |}>;
 
 type RCTSafeAreaViewNativeType = Class<NativeComponent<NativeProps>>;

--- a/Libraries/Components/SafeAreaView/SafeAreaView.js
+++ b/Libraries/Components/SafeAreaView/SafeAreaView.js
@@ -13,10 +13,21 @@ const React = require('React');
 const View = require('View');
 
 import type {ViewProps} from 'ViewPropTypes';
+import type {EdgeInsetsProp} from 'EdgeInsetsPropType';
 
 type Props = $ReadOnly<{|
   ...ViewProps,
   emulateUnlessSupported?: boolean,
+|}>;
+
+type IOSProps = $ReadOnly<{|
+  ...Props,
+  /**
+   * Custom insets that you specify to modify safe area.
+   *
+   * @platform ios
+   */
+  additionalSafeAreaInsets?: ?EdgeInsetsProp,
 |}>;
 
 let exported;
@@ -39,7 +50,7 @@ if (Platform.OS === 'android') {
   };
 } else {
   const RCTSafeAreaViewNativeComponent = require('RCTSafeAreaViewNativeComponent');
-  exported = class SafeAreaView extends React.Component<Props> {
+  exported = class SafeAreaView extends React.Component<IOSProps> {
     render(): React.Node {
       return (
         <RCTSafeAreaViewNativeComponent

--- a/React/Views/SafeAreaView/RCTSafeAreaView.h
+++ b/React/Views/SafeAreaView/RCTSafeAreaView.h
@@ -18,6 +18,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithBridge:(RCTBridge *)bridge;
 
 @property (nonatomic, assign) BOOL emulateUnlessSupported;
+@property (nonatomic, assign) UIEdgeInsets reactAdditionalSafeAreaInsets;
 
 @end
 

--- a/React/Views/SafeAreaView/RCTSafeAreaViewManager.m
+++ b/React/Views/SafeAreaView/RCTSafeAreaViewManager.m
@@ -16,6 +16,7 @@
 RCT_EXPORT_MODULE()
 
 RCT_EXPORT_VIEW_PROPERTY(emulateUnlessSupported, BOOL)
+RCT_REMAP_VIEW_PROPERTY(additionalSafeAreaInsets, reactAdditionalSafeAreaInsets, UIEdgeInsets)
 
 - (UIView *)view
 {


### PR DESCRIPTION
## Summary

Currently, if we use `SafeAreaView`, we lose the `padding` prop, https://github.com/facebook/react-native/blob/master/React/Views/SafeAreaView/RCTSafeAreaShadowView.m#L36, so the insets can only determined by system, but, actually, user may wants some additional insets based on system safe area, like #22211, and we can also see Apple document, https://developer.apple.com/documentation/uikit/uiviewcontroller/2902284-additionalsafeareainsets?language=objc#, it also has `additionalSafeAreaInsets` for `ViewController`, so I think we can add `additionalSafeAreaInsets` prop for user to do custom insets.

## Changelog

[iOS] [Added] - Add additionalSafeAreaInsets prop for SafeAreaView

## Test Plan

After we added `additionalSafeAreaInsets` prop, the final safe area equals to system safe area plus user custom safe area:

```
      <SafeAreaView style={styles.container} additionalSafeAreaInsets={{top: 50, left: 0, bottom: 0, right: 0}}>
        <View style={styles.content} />
      </SafeAreaView>

  container: {
    flex: 1,
    backgroundColor: 'red',
    padding: 50, // This padding is not respected
  },
  content: {
    flex: 1,
    backgroundColor: 'yellow',
  },
```

<img width="375" alt="image" src="https://user-images.githubusercontent.com/5061845/53871191-b6c0a180-4036-11e9-9fd7-aa62b5c19fae.png">

