### PR TITLE
Use Backlog label to keep issues open

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -12,12 +12,13 @@ exemptLabels:
   - "Help Wanted :octocat:"
   - "Impact: Regression"
   - "Resolution: PR Submitted"
+  - "Resolution: Backlog"
 # Label to use when marking an issue as stale
-staleLabel: Stale 
+staleLabel: Stale
 # Comment to post when marking an issue as stale. Set to `false` to disable
 markComment: >
   Hey there, it looks like there has been no activity on this issue recently. Has the issue been fixed, or does it still require the community's attention? This issue may be closed if no further activity occurs.
-  You may also label this issue as "For Discussion" or "Good first issue" and I will leave it open.
+  You may also label this issue as a "Discussion" or add it to the "Backlog" and I will leave it open.
   Thank you for your contributions.
 # Comment to post when closing a stale issue. Set to `false` to disable
 closeComment: >


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

The Stale bot closes issues that have been inactive for 97 days (90 days until marked as stale, then 7 days of no activity before it is closed). This helps us focus on issues that affect new releases, and gets rid of drive-by issues where there has been no follow up. This process, however, does not acknowledge there's a type of issue that trascends releases and which the team might want to keep track of in order to fix in a future release.

The "Resolution: Backlog" label can be used to mark these types of issues, and keep the bot from closing them.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See http://facebook.github.io/react-native/docs/contributing#changelog for an example. -->

[General] [Added] - GitHub: Add Backlog label

## Test Plan

N/A
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->