### PR TITLE
PickerAndroid send children only if item is not equal to zero

### DIFF
--- a/Libraries/Components/Picker/Picker.js
+++ b/Libraries/Components/Picker/Picker.js
@@ -143,7 +143,7 @@ class Picker extends React.Component<PickerProps> {
       return (
         /* $FlowFixMe(>=0.81.0 site=react_native_android_fb) This suppression
          * was added when renaming suppression sites. */
-        <PickerAndroid {...this.props}>{this.props.children}</PickerAndroid>
+        <PickerAndroid {...this.props}>{this.props.children.filter(item => item !== 0)}</PickerAndroid>
       );
     } else {
       return <UnimplementedView />;

--- a/Libraries/Components/Picker/PickerAndroid.android.js
+++ b/Libraries/Components/Picker/PickerAndroid.android.js
@@ -64,9 +64,6 @@ class PickerAndroid extends React.Component<
   ): PickerAndroidState {
     let selectedIndex = 0;
     const items = React.Children.map(props.children, (child, index) => {
-      if (child === null) {
-        return;
-      }
       if (child.props.value === props.selectedValue) {
         selectedIndex = index;
       }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
when conditional rendering is used then picker breaks when the child is null.
This conditional rendering inside Picker fails when a is 1, because child will be null in PickerAndroid.android.js.
```
{
   this.state.a === 2 && <Picker.Item label="value" value="value" />
}
```


<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See http://facebook.github.io/react-native/docs/contributing#changelog for an example. -->

[ANDROID] [FIXED] - Filter children and remove null values.

