### PR TITLE
Fix broken links in table of contents Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,13 +56,13 @@ React Native brings [**React**'s][r] declarative UI framework to iOS and Android
 
 ## Contents
 
-- [Requirements](#requirements)
-- [Building your first React Native app](#building-your-first-react-native-app)
-- [Documentation](#documentation)
-- [Upgrading](#upgrading)
-- [How to Contribute](#how-to-contribute)
-- [Code of Conduct](#code-of-conduct)
-- [License](#license)
+- [Requirements](#-requirements)
+- [Building your first React Native app](#-building-your-first-react-native-app)
+- [Documentation](#-documentation)
+- [Upgrading](#-upgrading)
+- [How to Contribute](#-how-to-contribute)
+- [Code of Conduct](#-code-of-conduct)
+- [License](#-license)
 
 
 ## 📋 Requirements


### PR DESCRIPTION
## Summary
I noticed the links under `## Contents` weren't clickable in the README.md file. This PR makes the links in table of contents clickable again.

## Changelog
[General] [Fixed] - Fix broken links for the table of contents in `README.md`

## Test Plan
- Preview the rendered readme inside this PR and click the table of contents links.
- Expect the page to instantly scroll to the selected section of the page.
