### PR TITLE
Fix PickerAndroid breaking when child is null. 

### DIFF
--- a/Libraries/Components/Picker/Picker.js
+++ b/Libraries/Components/Picker/Picker.js
@@ -143,7 +143,7 @@ class Picker extends React.Component<PickerProps> {
       return (
         /* $FlowFixMe(>=0.81.0 site=react_native_android_fb) This suppression
          * was added when renaming suppression sites. */
-        <PickerAndroid {...this.props}>{this.props.children.filter(item => item !== 0)}</PickerAndroid>
+        <PickerAndroid {...this.props}>{this.props.children}</PickerAndroid>
       );
     } else {
       return <UnimplementedView />;

--- a/Libraries/Components/Picker/Picker.js
+++ b/Libraries/Components/Picker/Picker.js
@@ -143,7 +143,7 @@ class Picker extends React.Component<PickerProps> {
       return (
         /* $FlowFixMe(>=0.81.0 site=react_native_android_fb) This suppression
          * was added when renaming suppression sites. */
-        <PickerAndroid {...this.props}>{this.props.children}</PickerAndroid>
+        <PickerAndroid {...this.props}>{this.props.children.filter(item => item !== 0)}</PickerAndroid>
       );
     } else {
       return <UnimplementedView />;

--- a/Libraries/Components/Picker/PickerAndroid.android.js
+++ b/Libraries/Components/Picker/PickerAndroid.android.js
@@ -64,7 +64,7 @@ class PickerAndroid extends React.Component<
   ): PickerAndroidState {
     let selectedIndex = 0;
     const items = React.Children.map(props.children, (child, index) => {
-      if (child === 0){
+      if (child === 0) {
         return;
       }
       if (child.props.value === props.selectedValue) {

--- a/Libraries/Components/Picker/PickerAndroid.android.js
+++ b/Libraries/Components/Picker/PickerAndroid.android.js
@@ -65,7 +65,7 @@ class PickerAndroid extends React.Component<
     let selectedIndex = 0;
     const items = React.Children.map(props.children, (child, index) => {
       if (child === 0){
-        return 0;
+        return;
       }
       if (child.props.value === props.selectedValue) {
         selectedIndex = index;

--- a/Libraries/Components/Picker/PickerAndroid.android.js
+++ b/Libraries/Components/Picker/PickerAndroid.android.js
@@ -113,7 +113,9 @@ class PickerAndroid extends React.Component<
     if (this.props.onValueChange) {
       const position = event.nativeEvent.position;
       if (position >= 0) {
-        const children = React.Children.toArray(this.props.children).filter(item => item !== 0);
+        const children = React.Children.toArray(this.props.children).filter(
+          item => item !== 0
+        );
         const value = children[position].props.value;
         /* $FlowFixMe(>=0.78.0 site=react_native_android_fb) This issue was
          * found when making Flow check .android.js files. */

--- a/Libraries/Components/Picker/PickerAndroid.android.js
+++ b/Libraries/Components/Picker/PickerAndroid.android.js
@@ -64,9 +64,6 @@ class PickerAndroid extends React.Component<
   ): PickerAndroidState {
     let selectedIndex = 0;
     const items = React.Children.map(props.children, (child, index) => {
-      if (child === null) {
-        return;
-      }
       if (child.props.value === props.selectedValue) {
         selectedIndex = index;
       }

--- a/Libraries/Components/Picker/PickerAndroid.android.js
+++ b/Libraries/Components/Picker/PickerAndroid.android.js
@@ -64,6 +64,9 @@ class PickerAndroid extends React.Component<
   ): PickerAndroidState {
     let selectedIndex = 0;
     const items = React.Children.map(props.children, (child, index) => {
+      if (child === 0){
+        return 0;
+      }
       if (child.props.value === props.selectedValue) {
         selectedIndex = index;
       }
@@ -110,7 +113,7 @@ class PickerAndroid extends React.Component<
     if (this.props.onValueChange) {
       const position = event.nativeEvent.position;
       if (position >= 0) {
-        const children = React.Children.toArray(this.props.children);
+        const children = React.Children.toArray(this.props.children).filter(item => item !== 0);
         const value = children[position].props.value;
         /* $FlowFixMe(>=0.78.0 site=react_native_android_fb) This issue was
          * found when making Flow check .android.js files. */


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
On conditional rendering if child is null then the PickerAndroid breaks.
## Changelog
when conditional rendering is used then picker breaks when the child is null.

This conditional rendering inside Picker fails when a is 1, because child will be null in PickerAndroid.android.js.
```
{
   this.state.a === 2 && <Picker.Item label="value" value="value" />
}
```
<!-- Help reviewers and the release process by writing your own changelog entry. See http://facebook.github.io/react-native/docs/contributing#changelog for an example. -->

[ANDROID] [FIXED] - Filter props.children.
