### PR TITLE
Add DerivedData to BLACKLISTED_PATTERNS for haste paths

### DIFF
--- a/jest/hasteImpl.js
+++ b/jest/hasteImpl.js
@@ -60,6 +60,7 @@ const BLACKLISTED_PATTERNS /*: Array<RegExp> */ = [
   /.*[\\\/]__(mocks|tests)__[\\\/].*/,
   /^Libraries[\\\/]Animated[\\\/]src[\\\/]polyfills[\\\/].*/,
   /^Libraries[\\\/]Renderer[\\\/]fb[\\\/].*/,
+  /DerivedData[\\\/].*/,
 ];
 
 const WHITELISTED_PREFIXES /*: Array<string> */ = [


### PR DESCRIPTION
## Summary

Each time, when I run `iOS` tests like `RNTesterIntegrationTests`, Xcode will copy the bundle in `DerivedData` directory, and we added `RNTesterUnitTestsBundle.js` to bundle, so it leads `Haste module naming collision`, I think we can add `DerivedData` directory to blacklist.

<img width="752" alt="c7d7dcbd-6507-481a-a8ef-64f16fec3a6f" src="https://user-images.githubusercontent.com/5061845/53960917-6888cc80-4122-11e9-9d1d-faac97f73a26.png">


## Changelog

[iOS] [Fixed] - Add DerivedData to BLACKLISTED_PATTERNS for haste paths

## Test Plan

No `Error: jest-haste-map: Haste module naming collision` can throw, even though we run the tests.