### PR TITLE
adds type checking to Animated toValue and iterations key values to m…

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/animated/FrameBasedAnimationDriver.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/animated/FrameBasedAnimationDriver.java
@@ -41,8 +41,17 @@ class FrameBasedAnimationDriver extends AnimationDriver {
     for (int i = 0; i < numberOfFrames; i++) {
       mFrames[i] = frames.getDouble(i);
     }
-    mToValue = config.hasKey("toValue") ? config.getDouble("toValue") : 0;
-    mIterations = config.hasKey("iterations") ? config.getInt("iterations") : 1;
+    if(config.hasKey("toValue")) {
+      mToValue = config.getType("toValue") == ReadableType.Number ? config.getDouble("toValue") : 0;
+    } else {
+      mToValue = 0;
+    }
+    if(config.hasKey("iterations")) {
+      mIterations = config.getType("iterations") == ReadableType.Number ?
+                                                    config.getInt("iterations") : 1;
+    } else {
+      mIterations = 1;
+    }
     mCurrentLoop = 1;
     mHasFinished = mIterations == 0;
     mStartFrameTimeNanos = -1;

--- a/ReactAndroid/src/main/java/com/facebook/react/animated/FrameBasedAnimationDriver.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/animated/FrameBasedAnimationDriver.java
@@ -50,7 +50,7 @@ class FrameBasedAnimationDriver extends AnimationDriver {
       mIterations = config.getType("iterations") == ReadableType.Number ?
                                                     config.getInt("iterations") : 1;
     } else {
-      mIterations = 1;
+      mIterations = 1; 
     }
     mCurrentLoop = 1;
     mHasFinished = mIterations == 0;

--- a/ReactAndroid/src/main/java/com/facebook/react/animated/FrameBasedAnimationDriver.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/animated/FrameBasedAnimationDriver.java
@@ -9,6 +9,7 @@ package com.facebook.react.animated;
 
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.bridge.ReadableType;
 
 /**
  * Implementation of {@link AnimationDriver} which provides a support for simple time-based
@@ -50,7 +51,7 @@ class FrameBasedAnimationDriver extends AnimationDriver {
       mIterations = config.getType("iterations") == ReadableType.Number ?
                                                     config.getInt("iterations") : 1;
     } else {
-      mIterations = 1; 
+      mIterations = 1;
     }
     mCurrentLoop = 1;
     mHasFinished = mIterations == 0;


### PR DESCRIPTION
…ake sure Android does not crash from bad params when using useNativeDriver

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Android apps crash when using Animated useNativeDriver: true and the toValue is not a number.  See issue here with test case.  [Issue](https://github.com/facebook/react-native/issues/23810)

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See http://facebook.github.io/react-native/docs/contributing#changelog for an example. -->

[Android] [fixed] - Fix crash when using Animated with useNativeDriver and a non Number toValue

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
Run [Snack](https://snack.expo.io/ry8tHCRLN)  code with patched React Native core.  Malformed parameters will no longer crash Android app.  