### PR TITLE
Fabric: fix border memory leaks

### DIFF
--- a/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -326,10 +326,24 @@ static RCTCornerRadii RCTCornerRadiiFromBorderRadii(BorderRadii borderRadii)
 
 static RCTBorderColors RCTBorderColorsFromBorderColors(BorderColors borderColors)
 {
-  return RCTBorderColors{.left = RCTCGColorRefFromSharedColor(borderColors.left),
-                         .top = RCTCGColorRefFromSharedColor(borderColors.top),
-                         .bottom = RCTCGColorRefFromSharedColor(borderColors.bottom),
-                         .right = RCTCGColorRefFromSharedColor(borderColors.right)};
+  CGColorRef leftColor = RCTCGColorRefFromSharedColor(borderColors.left);
+  CGColorRef topColor = RCTCGColorRefFromSharedColor(borderColors.top);
+  CGColorRef bottomColor = RCTCGColorRefFromSharedColor(borderColors.bottom);
+  CGColorRef rightColor = RCTCGColorRefFromSharedColor(borderColors.right);
+  
+  RCTBorderColors colors = RCTBorderColors{
+    .left = leftColor,
+    .top = topColor,
+    .bottom = bottomColor,
+    .right = rightColor
+  }
+
+  CGColorRelease(leftColor);
+  CGColorRelease(topColor);
+  CGColorRelease(bottomColor);
+  CGColorRelease(rightColor);
+
+  return colors;
 }
 
 static UIEdgeInsets UIEdgeInsetsFromBorderInsets(EdgeInsets edgeInsets)
@@ -396,7 +410,9 @@ static RCTBorderStyle RCTBorderStyleFromBorderStyle(BorderStyle borderStyle)
     }
 
     layer.borderWidth = (CGFloat)borderMetrics.borderWidths.left;
-    layer.borderColor = RCTCGColorRefFromSharedColor(borderMetrics.borderColors.left);
+    CGColorRef borderColor = RCTCGColorRefFromSharedColor(borderMetrics.borderColors.left)
+    layer.borderColor = borderColor;
+    CGColorRelease(borderColor);
     layer.cornerRadius = (CGFloat)borderMetrics.borderRadii.topLeft;
     layer.backgroundColor = _backgroundColor.CGColor;
     _contentView.layer.cornerRadius = (CGFloat)borderMetrics.borderRadii.topLeft;

--- a/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -326,24 +326,12 @@ static RCTCornerRadii RCTCornerRadiiFromBorderRadii(BorderRadii borderRadii)
 
 static RCTBorderColors RCTBorderColorsFromBorderColors(BorderColors borderColors)
 {
-  CGColorRef leftColor = RCTCGColorRefFromSharedColor(borderColors.left);
-  CGColorRef topColor = RCTCGColorRefFromSharedColor(borderColors.top);
-  CGColorRef bottomColor = RCTCGColorRefFromSharedColor(borderColors.bottom);
-  CGColorRef rightColor = RCTCGColorRefFromSharedColor(borderColors.right);
-  
-  RCTBorderColors colors = RCTBorderColors{
-    .left = leftColor,
-    .top = topColor,
-    .bottom = bottomColor,
-    .right = rightColor
-  }
-
-  CGColorRelease(leftColor);
-  CGColorRelease(topColor);
-  CGColorRelease(bottomColor);
-  CGColorRelease(rightColor);
-
-  return colors;
+  return RCTBorderColors{
+    .left = RCTCGColorRefUnretainedFromSharedColor(borderColors.left),
+    .top =  RCTCGColorRefUnretainedFromSharedColor(borderColors.top),
+    .bottom =  RCTCGColorRefUnretainedFromSharedColor(borderColors.bottom),
+    .right = RCTCGColorRefUnretainedFromSharedColor(borderColors.right)
+  };
 }
 
 static UIEdgeInsets UIEdgeInsetsFromBorderInsets(EdgeInsets edgeInsets)

--- a/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -398,7 +398,7 @@ static RCTBorderStyle RCTBorderStyleFromBorderStyle(BorderStyle borderStyle)
     }
 
     layer.borderWidth = (CGFloat)borderMetrics.borderWidths.left;
-    CGColorRef borderColor = RCTCGColorRefFromSharedColor(borderMetrics.borderColors.left)
+    CGColorRef borderColor = RCTCGColorRefFromSharedColor(borderMetrics.borderColors.left);
     layer.borderColor = borderColor;
     CGColorRelease(borderColor);
     layer.cornerRadius = (CGFloat)borderMetrics.borderRadii.topLeft;

--- a/React/Fabric/RCTConversions.h
+++ b/React/Fabric/RCTConversions.h
@@ -30,6 +30,12 @@ inline UIColor *_Nullable RCTUIColorFromSharedColor(const facebook::react::Share
   return sharedColor ? [UIColor colorWithCGColor:sharedColor.get()] : nil;
 }
 
+CF_RETURNS_NOT_RETAINED
+inline CGColorRef RCTCGColorRefUnretainedFromSharedColor(const facebook::react::SharedColor &sharedColor) {
+  return sharedColor ? sharedColor.get() : nil;
+}
+
+CF_RETURNS_RETAINED
 inline CGColorRef RCTCGColorRefFromSharedColor(const facebook::react::SharedColor &sharedColor) {
   return sharedColor ? CGColorCreateCopy(sharedColor.get()) : nil;
 }

--- a/React/Fabric/RCTConversions.h
+++ b/React/Fabric/RCTConversions.h
@@ -30,13 +30,13 @@ inline UIColor *_Nullable RCTUIColorFromSharedColor(const facebook::react::Share
   return sharedColor ? [UIColor colorWithCGColor:sharedColor.get()] : nil;
 }
 
-CF_RETURNS_NOT_RETAINED
-inline CGColorRef RCTCGColorRefUnretainedFromSharedColor(const facebook::react::SharedColor &sharedColor) {
+
+inline CF_RETURNS_NOT_RETAINED CGColorRef RCTCGColorRefUnretainedFromSharedColor(const facebook::react::SharedColor &sharedColor) {
   return sharedColor ? sharedColor.get() : nil;
 }
 
-CF_RETURNS_RETAINED
-inline CGColorRef RCTCGColorRefFromSharedColor(const facebook::react::SharedColor &sharedColor) {
+
+inline CF_RETURNS_RETAINED CGColorRef RCTCGColorRefFromSharedColor(const facebook::react::SharedColor &sharedColor) {
   return sharedColor ? CGColorCreateCopy(sharedColor.get()) : nil;
 }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
This fixes a few memory leaks in fabrics handling of colors for borders, when using CGColorRef's we must be diligent about releasing the memory back.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See http://facebook.github.io/react-native/docs/contributing#changelog for an example. -->

[iOS] [Fixed] - Border style memory leaks

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
Run RNTester, and ensure it is working, notice no memory leaks from CoreGraphics.