### PR TITLE
Added Dimensions jest mock

### DIFF
--- a/Libraries/Utilities/__tests__/Dimensions-test.js
+++ b/Libraries/Utilities/__tests__/Dimensions-test.js
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+'use strict';
+
+var Dimensions = require('../Dimensions');
+
+describe('Dimensions', () => {
+
+  describe('should have the correct methods', () => {
+
+    describe('get', () => {
+      it('should return an object with shape `width` and `height`', () => {
+        expect(Dimensions.get).toBeTruthy();
+        expect(typeof Dimensions.get).toEqual('function');
+
+        const dim = Dimensions.get('');
+        expect(dim).toHaveProperty('width');
+        expect(dim).toHaveProperty('height');
+        expect(typeof dim.width).toEqual('number');
+        expect(typeof dim.height).toEqual('number');
+      });
+    });
+
+  });
+
+});

--- a/jest/setup.js
+++ b/jest/setup.js
@@ -122,6 +122,12 @@ const mockNativeModules = {
       },
     },
   },
+  Dimensions: {
+    get: jest.fn(() => ({
+      width: 750,
+      height: 1334,
+    })),
+  },
   FacebookSDK: {
     login: jest.fn(),
     logout: jest.fn(),


### PR DESCRIPTION
Clone of https://github.com/facebook/react-native/pull/16104

This was necessary because Dimensions.get broke my personal test suite. Example:

```
 FAIL  __tests__/index.spec.js
  ● Test suite failed to run

    Invariant Violation: No dimension set for key screen

      at invariant (node_modules/fbjs/lib/invariant.js:44:15)
      at Function.get (node_modules/react-native/Libraries/Utilities/Dimensions.js:93:1)
      at Object.<anonymous> (my/own/components/Failure.js:16:25)
```
## Changelog:

[General][Added] - Add Dimensions jest test

## Test Plan

I took the liberty to add a jest test [here](https://github.com/jkomyno/react-native/blob/master/Libraries/Utilities/__tests__/Dimensions-test.js), and it works according to `yarn test`.
Since I've added a new file, I also copy-pasted the copyright at the top that file.

Please note that when I cloned the repo, Libraries/Image/__tests__/resolveAssetSource-test.js didn't pass, so I got the following result:

```
Test Suites: 1 failed, 2 skipped, 87 passed, 88 of 90 total
Tests:       1 failed, 4 skipped, 477 passed, 482 total
Snapshots:   36 passed, 36 total
Time:        5.81s
```