### PR TITLE
[Android] Fix Image.getSize throws exception. issue #23816

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/modules/image/ImageLoaderModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/image/ImageLoaderModule.java
@@ -32,6 +32,7 @@ import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.module.annotations.ReactModule;
+import com.facebook.react.views.imagehelper.ImageSource;
 
 @ReactModule(name = ImageLoaderModule.NAME)
 public class ImageLoaderModule extends ReactContextBaseJavaModule implements
@@ -77,8 +78,8 @@ public class ImageLoaderModule extends ReactContextBaseJavaModule implements
       return;
     }
 
-    Uri uri = Uri.parse(uriString);
-    ImageRequest request = ImageRequestBuilder.newBuilderWithSource(uri).build();
+    ImageSource imageSource = new ImageSource(getReactApplicationContext(), uriString);
+    ImageRequest request = ImageRequestBuilder.newBuilderWithSource(imageSource.getUri()).build();
 
     DataSource<CloseableReference<CloseableImage>> dataSource =
       Fresco.getImagePipeline().fetchDecodedImage(request, mCallerContext);
@@ -138,8 +139,8 @@ public class ImageLoaderModule extends ReactContextBaseJavaModule implements
       return;
     }
 
-    Uri uri = Uri.parse(uriString);
-    ImageRequest request = ImageRequestBuilder.newBuilderWithSource(uri).build();
+    ImageSource imageSource = new ImageSource(getReactApplicationContext(), uriString);
+    ImageRequest request = ImageRequestBuilder.newBuilderWithSource(imageSource.getUri()).build();
 
     DataSource<Void> prefetchSource =
       Fresco.getImagePipeline().prefetchToDiskCache(request, mCallerContext);


### PR DESCRIPTION
## Summary

In the issue https://github.com/facebook/react-native/issues/23816, reporting Image.getSize doesn't work on the Android. I was able to reproduce this issue, too.

By having a deep look at the source, I finally figured it out.The bug is in the `com.facebook.react.modules.image.ImageLoaderModule#getSize` function.

As in the  issue https://github.com/facebook/react-native/issues/23816, I use this code to reproduce the bug:

```jsx
import React, {Component} from 'react';
import { View, Image } from 'react-native';

export default () => {
    console.log("maxieeee :" + JSON.stringify(Image.getSize('react_native')))

    return <View></View>
}
```

In the code abrove, `'react_native'` is a image file in the  Android drawable folder (Hybrid App's Resource).

In the function `com.facebook.react.modules.image.ImageLoaderModule#getSize`:

```java
public void getSize(
    final String uriString,
    final Promise promise) {
```

The value of `uriString` is `'react_native'`. This value will pass into:

```
Uri uri = Uri.parse(uriString);
```

But Uri class can't handle `'react_native'`. It expects uri like `"android.resource://org.xyz.abc/drawable/react_native"`.

So in my fix commit, I use ImageSource class to parse uriString. It will handle the uri properly, both remote and local.

But one thing worries me: 

- The ImageSource class is in the package of `com.facebook.react.views.imagehelper`. 
- The ImageLoaderModule class is in the package of `com.facebook.react.modules.image`
- Can I import ImageSource from ImageLoaderModule?

## Changelog

[Android] [Fixed] - Fix Image.getSize throws exception. issue #23816

## Test Plan

Test code:

```jsx
import React, {Component} from 'react';
import { View, Image } from 'react-native';

export default () => {
    console.log("maxieeee :" + JSON.stringify(Image.getSize('react_native')))

    return <View></View>
}
```

In the code abrove, `'react_native'` is a image file in the  Android drawable folder (Hybrid App's Resource).

If the bug has been fixed:

- The console will log the correct image size
- The "Failed to get size for image: " warning on the screen won't appear. (There's a screenshot of the warning  https://user-images.githubusercontent.com/3392007/54027135-574fc680-41db-11e9-8099-4a2f8e677898.png)
