### PR TITLE
[iOS] Fix RCTJavaScriptLoader loadBundleAtURL error case

### DIFF
--- a/React/CxxBridge/RCTCxxBridge.mm
+++ b/React/CxxBridge/RCTCxxBridge.mm
@@ -409,9 +409,10 @@ struct RCTInstanceCallback : public InstanceCallback {
                                          "server or have included a .jsbundle file in your application bundle.");
     onSourceLoad(error, nil);
   } else {
+    __weak RCTCxxBridge *weakSelf = self;
     [RCTJavaScriptLoader loadBundleAtURL:self.bundleURL onProgress:onProgress onComplete:^(NSError *error, RCTSource *source) {
       if (error) {
-        RCTLogError(@"Failed to load bundle(%@) with error:(%@ %@)", self.bundleURL, error.localizedDescription, error.localizedFailureReason);
+        [weakSelf handleError:error];
         return;
       }
       onSourceLoad(error, source);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Change the function called when an error is returned from the completionHandler of the `RCTJavaScriptLoader(loadBundleAtURL:onProgress:onComplete:)`.

* AS-IS
    - `RCTLogError()`
    - This error method does not post any notification for users. So users cannot receive notification when `RCTJavaScriptLoader(loadBundleAtURL:onProgress:onComplete:)` complete with error.(i.e. bundleURL is is invalid but not nil, `http://1`, `http://localho:8081/index.bundle`)

* TO-BE
    - `handleError(error:)`
    -  Call this method will post notification for users when `completionHandler` fails with error.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See http://facebook.github.io/react-native/docs/contributing#changelog for an example. -->

[iOS] [Fixed] - Change the function called when an error is returned from the completionHandler of the `RCTJavaScriptLoader(loadBundleAtURL:onProgress:onComplete:)`.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->


* Test Code - Set `sourceURL` of `RCTBridge` is invalid, but not nil.

```swift
import UIKit
import React

class ViewController: UIViewController {

    var bridge: RCTBridge?

    override func viewDidLoad() {
        super.viewDidLoad()
        NotificationCenter.default.addObserver(self, selector: #selector(bridgeDidFailToLoad),
                                               name: Notification.Name.RCTJavaScriptDidFailToLoad, object: nil)
        self.bridge = RCTBridge(delegate: self, launchOptions: nil)
    }

    @objc func bridgeDidFailToLoad(_ notification: Notification) {
        print("[RCT] RCTJavaScriptDidFailToLoad", notification)
    }
}

extension ViewController: RCTBridgeDelegate {
    func sourceURL(for bridge: RCTBridge!) -> URL! {
        // will not become nil, but invalid
        let url = URL(string: "http://localho:8081/index.bundle") 
        return url
    }
}
```

* `bridgeDidFailToLoad(_:)`will be called with notification like this.

```
[RCT] RCTJavaScriptDidFailToLoad name = RCTJavaScriptDidFailToLoadNotification, 
object = Optional(<RCTBridge: 0x600001370a10>), 
userInfo = Optional([AnyHashable("error"): Error Domain=RCTJavaScriptLoaderErrorDomain Code=3 "Could not connect to development server.
```

Previous(`RCTLogError()`) | Updated(`handleError(error:)`)
:---: | :---: | 
<img src="https://user-images.githubusercontent.com/13018877/53817067-12901980-3fa8-11e9-84fc-7d32a22fffdc.png" width="300px"> |<img src="https://user-images.githubusercontent.com/13018877/53817066-11f78300-3fa8-11e9-92bb-46ff3d172462.png" width="300px">