### PR TITLE
Fixed: [Android] Error: Duplicate resources #22234

### DIFF
--- a/react.gradle
+++ b/react.gradle
@@ -47,7 +47,22 @@ afterEvaluate {
                 resourcesDir.deleteDir()
                 resourcesDir.mkdirs()
             }
-
+            doLast {
+                def moveFunc = { resSuffix ->
+                    File originalDir = file("$buildDir/generated/res/react/release/drawable-${resSuffix}");
+                    if (originalDir.exists()) {
+                        File destDir = file("$buildDir/../src/main/res/drawable-${resSuffix}");
+                        ant.move(file: originalDir, tofile: destDir);
+                    }
+                }
+                moveFunc.curry("ldpi").call()
+                moveFunc.curry("mdpi").call()
+                moveFunc.curry("hdpi").call()
+                moveFunc.curry("xhdpi").call()
+                moveFunc.curry("xxhdpi").call()
+                moveFunc.curry("xxxhdpi").call()
+            }
+            
             // Set up inputs and outputs so gradle can cache the result
             inputs.files fileTree(dir: reactRoot, excludes: inputExcludes)
             outputs.dir(jsBundleDir)


### PR DESCRIPTION
Fixed error "Duplicate resources" while building APK file in Android

"[drawable-.../...]/.../android/app/src/main/res/drawable-mdpi/FILE [drawable-.../...] /.../android/app/build/generated/res/react/release/drawable-mdpi-v4/FILE: Error: Duplicate resources"

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See http://facebook.github.io/react-native/docs/contributing#changelog for an example. -->

Android Fixed - Fixed error "Duplicate resources" while building APK file in Android

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
