### PR TITLE
Fix broken perf marker logging for RN > 0.58 on Android

### DIFF
--- a/React/CxxBridge/JSCExecutorFactory.h
+++ b/React/CxxBridge/JSCExecutorFactory.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <jsireact/JSIExecutor.h>
+#include <cxxreact/ReactMarker.h>
 
 namespace facebook {
 namespace react {
@@ -15,8 +16,10 @@ namespace react {
 class JSCExecutorFactory : public JSExecutorFactory {
 public:
   explicit JSCExecutorFactory(
-      JSIExecutor::RuntimeInstaller runtimeInstaller)
-      : runtimeInstaller_(std::move(runtimeInstaller)) {}
+      JSIExecutor::RuntimeInstaller runtimeInstaller,
+      ReactMarker::LogTaggedMarker logTaggedMarker)
+      : runtimeInstaller_(std::move(runtimeInstaller)),
+      logTaggedMarker_(logTaggedMarker) {}
 
   std::unique_ptr<JSExecutor> createJSExecutor(
       std::shared_ptr<ExecutorDelegate> delegate,
@@ -24,6 +27,7 @@ public:
 
 private:
   JSIExecutor::RuntimeInstaller runtimeInstaller_;
+  ReactMarker::LogTaggedMarker logTaggedMarker_;
 };
 
 } // namespace react

--- a/React/CxxBridge/JSCExecutorFactory.h
+++ b/React/CxxBridge/JSCExecutorFactory.h
@@ -16,6 +16,10 @@ namespace react {
 class JSCExecutorFactory : public JSExecutorFactory {
 public:
   explicit JSCExecutorFactory(
+      JSIExecutor::RuntimeInstaller runtimeInstaller)
+      : runtimeInstaller_(std::move(runtimeInstaller)),
+      logTaggedMarker_(nullptr) {}
+  explicit JSCExecutorFactory(
       JSIExecutor::RuntimeInstaller runtimeInstaller,
       ReactMarker::LogTaggedMarker logTaggedMarker)
       : runtimeInstaller_(std::move(runtimeInstaller)),

--- a/React/CxxBridge/JSCExecutorFactory.mm
+++ b/React/CxxBridge/JSCExecutorFactory.mm
@@ -32,7 +32,8 @@ std::unique_ptr<JSExecutor> JSCExecutorFactory::createJSExecutor(
       facebook::jsc::makeJSCRuntime(),
       delegate,
       JSIExecutor::defaultTimeoutInvoker,
-      std::move(installBindings));
+      std::move(installBindings),
+      logTaggedMarker_);
 }
 
 } // namespace react

--- a/ReactAndroid/src/main/jni/react/jni/JReactMarker.cpp
+++ b/ReactAndroid/src/main/jni/react/jni/JReactMarker.cpp
@@ -11,11 +11,8 @@
 namespace facebook {
 namespace react {
 
-void JReactMarker::setLogPerfMarkerIfNeeded() {
-  static std::once_flag flag {};
-  std::call_once(flag, [](){
-    ReactMarker::logTaggedMarker = JReactMarker::logPerfMarker;
-  });
+ReactMarker::LogTaggedMarker JReactMarker::setLogPerfMarkerIfNeeded() {
+  return JReactMarker::logPerfMarker;
 }
 
 void JReactMarker::logMarker(const std::string& marker) {

--- a/ReactAndroid/src/main/jni/react/jni/JReactMarker.h
+++ b/ReactAndroid/src/main/jni/react/jni/JReactMarker.h
@@ -16,7 +16,7 @@ namespace react {
 class JReactMarker : public facebook::jni::JavaClass<JReactMarker> {
 public:
   static constexpr auto kJavaDescriptor = "Lcom/facebook/react/bridge/ReactMarker;";
-  static void setLogPerfMarkerIfNeeded();
+  static ReactMarker::LogTaggedMarker setLogPerfMarkerIfNeeded();
 
 private:
   static void logMarker(const std::string& marker);

--- a/ReactCommon/cxxreact/ReactMarker.cpp
+++ b/ReactCommon/cxxreact/ReactMarker.cpp
@@ -20,10 +20,6 @@ LogTaggedMarker logTaggedMarker = nullptr;
 #pragma clang diagnostic pop
 #endif
 
-void logMarker(const ReactMarkerId markerId) {
-  logTaggedMarker(markerId, nullptr);
-}
-
 }
 }
 }

--- a/ReactCommon/cxxreact/ReactMarker.h
+++ b/ReactCommon/cxxreact/ReactMarker.h
@@ -39,8 +39,6 @@ typedef void(*LogTaggedMarker)(const ReactMarkerId, const char* tag);
 
 extern RN_EXPORT LogTaggedMarker logTaggedMarker;
 
-extern RN_EXPORT void logMarker(const ReactMarkerId markerId);
-
 }
 }
 }

--- a/ReactCommon/jsiexecutor/jsireact/JSIExecutor.h
+++ b/ReactCommon/jsiexecutor/jsireact/JSIExecutor.h
@@ -13,6 +13,7 @@
 #include <jsi/jsi.h>
 #include <functional>
 #include <mutex>
+#include <cxxreact/ReactMarker.h>
 
 namespace facebook {
 namespace react {
@@ -74,7 +75,8 @@ class JSIExecutor : public JSExecutor {
       std::shared_ptr<jsi::Runtime> runtime,
       std::shared_ptr<ExecutorDelegate> delegate,
       const JSIScopedTimeoutInvoker &timeoutInvoker,
-      RuntimeInstaller runtimeInstaller);
+      RuntimeInstaller runtimeInstaller,
+      ReactMarker::LogTaggedMarker);
   void loadApplicationScript(
       std::unique_ptr<const JSBigString> script,
       std::string sourceURL) override;
@@ -120,6 +122,7 @@ class JSIExecutor : public JSExecutor {
   std::unique_ptr<RAMBundleRegistry> bundleRegistry_;
   JSIScopedTimeoutInvoker scopedTimeoutInvoker_;
   RuntimeInstaller runtimeInstaller_;
+  ReactMarker::LogTaggedMarker logTaggedMarker_;
 
   folly::Optional<jsi::Function> callFunctionReturnFlushedQueue_;
   folly::Optional<jsi::Function> invokeCallbackAndReturnFlushedQueue_;

--- a/ReactCommon/jsiexecutor/jsireact/JSINativeModules.cpp
+++ b/ReactCommon/jsiexecutor/jsireact/JSINativeModules.cpp
@@ -19,8 +19,10 @@ namespace facebook {
 namespace react {
 
 JSINativeModules::JSINativeModules(
-    std::shared_ptr<ModuleRegistry> moduleRegistry)
-    : m_moduleRegistry(std::move(moduleRegistry)) {}
+    std::shared_ptr<ModuleRegistry> moduleRegistry,
+    ReactMarker::LogTaggedMarker logTaggedMarker)
+    : m_moduleRegistry(std::move(moduleRegistry)),
+    logTaggedMarker_(logTaggedMarker) {}
 
 Value JSINativeModules::getModule(Runtime& rt, const PropNameID& name) {
   if (!m_moduleRegistry) {
@@ -54,9 +56,9 @@ void JSINativeModules::reset() {
 folly::Optional<Object> JSINativeModules::createModule(
     Runtime& rt,
     const std::string& name) {
-  bool hasLogger(ReactMarker::logTaggedMarker);
+  bool hasLogger(logTaggedMarker_);
   if (hasLogger) {
-    ReactMarker::logTaggedMarker(
+    logTaggedMarker_(
         ReactMarker::NATIVE_MODULE_SETUP_START, name.c_str());
   }
 
@@ -80,7 +82,7 @@ folly::Optional<Object> JSINativeModules::createModule(
       moduleInfo.asObject(rt).getPropertyAsObject(rt, "module"));
 
   if (hasLogger) {
-    ReactMarker::logTaggedMarker(
+    logTaggedMarker_(
         ReactMarker::NATIVE_MODULE_SETUP_STOP, name.c_str());
   }
 

--- a/ReactCommon/jsiexecutor/jsireact/JSINativeModules.h
+++ b/ReactCommon/jsiexecutor/jsireact/JSINativeModules.h
@@ -9,6 +9,7 @@
 #include <string>
 
 #include <cxxreact/ModuleRegistry.h>
+#include <cxxreact/ReactMarker.h>
 #include <folly/Optional.h>
 #include <jsi/jsi.h>
 
@@ -20,7 +21,9 @@ namespace react {
  */
 class JSINativeModules {
  public:
-  explicit JSINativeModules(std::shared_ptr<ModuleRegistry> moduleRegistry);
+  explicit JSINativeModules(
+    std::shared_ptr<ModuleRegistry> moduleRegistry,
+    ReactMarker::LogTaggedMarker);
   jsi::Value getModule(jsi::Runtime& rt, const jsi::PropNameID& name);
   void reset();
 
@@ -28,6 +31,7 @@ class JSINativeModules {
   folly::Optional<jsi::Function> m_genNativeModuleJS;
   std::shared_ptr<ModuleRegistry> m_moduleRegistry;
   std::unordered_map<std::string, jsi::Object> m_objects;
+  ReactMarker::LogTaggedMarker logTaggedMarker_;
 
   folly::Optional<jsi::Object> createModule(
       jsi::Runtime& rt,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Fixes #23771 

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See http://facebook.github.io/react-native/docs/contributing#changelog for an example. -->

[Android] [Fixed] - Fix broken perf marker logging for RN > 0.58 on Android

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

The relevant markers are now logged whenever you initialise RN bridge.