### PR TITLE
bump Gradle Android Plugin to 3.3.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:3.3.1")
+        classpath("com.android.tools.build:gradle:3.3.2")
         classpath("de.undercouch:gradle-download-task:3.4.3")
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/template/android/build.gradle
+++ b/template/android/build.gradle
@@ -13,7 +13,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.1'
+        classpath 'com.android.tools.build:gradle:3.3.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
## Summary

Gradle Android  Plugin version 3.3.2 includes many fixes and improvements.

## Changelog

[Android] [Changed] - bump Gradle Android Plugin to 3.3.2

## Test Plan

CI is green, and everything works as usual.