### PR TITLE
[iOS] Enhance search of directories when load local asset image

### DIFF
--- a/React/Base/RCTUtils.h
+++ b/React/Base/RCTUtils.h
@@ -126,36 +126,6 @@ RCT_EXTERN BOOL RCTIsBundleAssetURL(NSURL *__nullable imageURL);
 // Determines if a given image URL refers to a image in library
 RCT_EXTERN BOOL RCTIsLibraryAssetURL(NSURL *__nullable imageURL);
 
-// Returns the Path of tmp directory
-RCT_EXTERN NSString *__nullable RCTTmpPath(void);
-
-// Returns the relative path within the tmp for an absolute URL
-// (or nil, if the URL does not specify a path within the tmp directory)
-RCT_EXTERN NSString *__nullable RCTTmpPathForURL(NSURL *__nullable URL);
-
-// Determines if a given image URL refers to a image in tmp/
-RCT_EXTERN BOOL RCTIsTmpAssetURL(NSURL *__nullable imageURL);
-
-// Returns the Path of Home directory
-RCT_EXTERN NSString *__nullable RCTHomePath(void);
-
-// Returns the relative path within the Home for an absolute URL
-// (or nil, if the URL does not specify a path within the Home directory)
-RCT_EXTERN NSString *__nullable RCTHomePathForURL(NSURL *__nullable URL);
-
-// Determines if a given image URL refers to a image in Home directory (~)
-RCT_EXTERN BOOL RCTIsHomeAssetURL(NSURL *__nullable imageURL);
-
-// Returns the Path of Documents directory
-RCT_EXTERN NSString *__nullable RCTDocumentsPath(void);
-
-// Returns the relative path within the Documents for an absolute URL
-// (or nil, if the URL does not specify a path within the Documents directory)
-RCT_EXTERN NSString *__nullable RCTDocumentsPathForURL(NSURL *__nullable URL);
-
-// Determines if a given image URL refers to a image in Documents/
-RCT_EXTERN BOOL RCTIsDocumentsAssetURL(NSURL *__nullable imageURL);
-
 // Determines if a given image URL refers to a local image
 RCT_EXTERN BOOL RCTIsLocalAssetURL(NSURL *__nullable imageURL);
 

--- a/React/Base/RCTUtils.h
+++ b/React/Base/RCTUtils.h
@@ -126,6 +126,36 @@ RCT_EXTERN BOOL RCTIsBundleAssetURL(NSURL *__nullable imageURL);
 // Determines if a given image URL refers to a image in library
 RCT_EXTERN BOOL RCTIsLibraryAssetURL(NSURL *__nullable imageURL);
 
+// Returns the Path of tmp directory
+RCT_EXTERN NSString *__nullable RCTTmpPath(void);
+
+// Returns the relative path within the tmp for an absolute URL
+// (or nil, if the URL does not specify a path within the tmp directory)
+RCT_EXTERN NSString *__nullable RCTTmpPathForURL(NSURL *__nullable URL);
+
+// Determines if a given image URL refers to a image in tmp/
+RCT_EXTERN BOOL RCTIsTmpAssetURL(NSURL *__nullable imageURL);
+
+// Returns the Path of Home directory
+RCT_EXTERN NSString *__nullable RCTHomePath(void);
+
+// Returns the relative path within the Home for an absolute URL
+// (or nil, if the URL does not specify a path within the Home directory)
+RCT_EXTERN NSString *__nullable RCTHomePathForURL(NSURL *__nullable URL);
+
+// Determines if a given image URL refers to a image in Home directory (~)
+RCT_EXTERN BOOL RCTIsHomeAssetURL(NSURL *__nullable imageURL);
+
+// Returns the Path of Documents directory
+RCT_EXTERN NSString *__nullable RCTDocumentsPath(void);
+
+// Returns the relative path within the Documents for an absolute URL
+// (or nil, if the URL does not specify a path within the Documents directory)
+RCT_EXTERN NSString *__nullable RCTDocumentsPathForURL(NSURL *__nullable URL);
+
+// Determines if a given image URL refers to a image in Documents/
+RCT_EXTERN BOOL RCTIsDocumentsAssetURL(NSURL *__nullable imageURL);
+
 // Determines if a given image URL refers to a local image
 RCT_EXTERN BOOL RCTIsLocalAssetURL(NSURL *__nullable imageURL);
 

--- a/React/Base/RCTUtils.m
+++ b/React/Base/RCTUtils.m
@@ -22,6 +22,16 @@
 
 NSString *const RCTErrorUnspecified = @"EUNSPECIFIED";
 
+// Returns the Path of Home directory
+NSString *__nullable RCTHomePath(void);
+
+// Returns the relative path within the Home for an absolute URL
+// (or nil, if the URL does not specify a path within the Home directory)
+NSString *__nullable RCTHomePathForURL(NSURL *__nullable URL);
+
+// Determines if a given image URL refers to a image in Home directory (~)
+BOOL RCTIsHomeAssetURL(NSURL *__nullable imageURL);
+
 static NSString *__nullable _RCTJSONStringifyNoRetry(id __nullable jsonObject, NSError **error)
 {
   if (!jsonObject) {
@@ -624,26 +634,6 @@ NSString *__nullable RCTLibraryPath(void)
     return libraryPath;
 }
 
-NSString *__nullable RCTTmpPath(void)
-{
-  static NSString *tmpPath = nil;
-  static dispatch_once_t onceToken;
-  dispatch_once(&onceToken, ^{
-    tmpPath = NSTemporaryDirectory();
-  });
-  return tmpPath;
-}
-
-NSString *__nullable RCTDocumentsPath(void)
-{
-  static NSString *documentsPath = nil;
-  static dispatch_once_t onceToken;
-  dispatch_once(&onceToken, ^{
-    documentsPath = [NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES) lastObject];
-  });
-  return documentsPath;
-}
-
 NSString *__nullable RCTHomePath(void)
 {
   static NSString *homePath = nil;
@@ -665,16 +655,6 @@ NSString *__nullable RCTLibraryPathForURL(NSURL *__nullable URL)
   return RCTRelativePathForURL(RCTLibraryPath(), URL);
 }
 
-NSString *__nullable RCTTmpPathForURL(NSURL *__nullable URL)
-{
-  return RCTRelativePathForURL(RCTTmpPath(), URL);
-}
-
-NSString *__nullable RCTDocumentsPathForURL(NSURL *__nullable URL)
-{
-  return RCTRelativePathForURL(RCTDocumentsPath(), URL);
-}
-
 NSString *__nullable RCTHomePathForURL(NSURL *__nullable URL)
 {
   return RCTRelativePathForURL(RCTHomePath(), URL);
@@ -694,16 +674,6 @@ BOOL RCTIsBundleAssetURL(NSURL *__nullable imageURL)
 BOOL RCTIsLibraryAssetURL(NSURL *__nullable imageURL)
 {
   return RCTIsImageAssetsPath(RCTLibraryPathForURL(imageURL));
-}
-
-BOOL RCTIsTmpAssetURL(NSURL *__nullable imageURL)
-{
-  return RCTIsImageAssetsPath(RCTTmpPathForURL(imageURL));
-}
-
-BOOL RCTIsDocumentsAssetURL(NSURL *__nullable imageURL)
-{
-  return RCTIsImageAssetsPath(RCTDocumentsPathForURL(imageURL));
 }
 
 BOOL RCTIsHomeAssetURL(NSURL *__nullable imageURL)

--- a/React/Base/RCTUtils.m
+++ b/React/Base/RCTUtils.m
@@ -624,6 +624,36 @@ NSString *__nullable RCTLibraryPath(void)
     return libraryPath;
 }
 
+NSString *__nullable RCTTmpPath(void)
+{
+  static NSString *tmpPath = nil;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    tmpPath = NSTemporaryDirectory();
+  });
+  return tmpPath;
+}
+
+NSString *__nullable RCTDocumentsPath(void)
+{
+  static NSString *documentsPath = nil;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    documentsPath = [NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES) lastObject];
+  });
+  return documentsPath;
+}
+
+NSString *__nullable RCTHomePath(void)
+{
+  static NSString *homePath = nil;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    homePath = NSHomeDirectory();
+  });
+  return homePath;
+}
+
 NSString *__nullable RCTBundlePathForURL(NSURL *__nullable URL)
 {
   return RCTRelativePathForURL([[NSBundle mainBundle] resourcePath], URL);
@@ -633,6 +663,21 @@ NSString *__nullable RCTBundlePathForURL(NSURL *__nullable URL)
 NSString *__nullable RCTLibraryPathForURL(NSURL *__nullable URL)
 {
   return RCTRelativePathForURL(RCTLibraryPath(), URL);
+}
+
+NSString *__nullable RCTTmpPathForURL(NSURL *__nullable URL)
+{
+  return RCTRelativePathForURL(RCTTmpPath(), URL);
+}
+
+NSString *__nullable RCTDocumentsPathForURL(NSURL *__nullable URL)
+{
+  return RCTRelativePathForURL(RCTDocumentsPath(), URL);
+}
+
+NSString *__nullable RCTHomePathForURL(NSURL *__nullable URL)
+{
+  return RCTRelativePathForURL(RCTHomePath(), URL);
 }
 
 static BOOL RCTIsImageAssetsPath(NSString *path)
@@ -651,9 +696,24 @@ BOOL RCTIsLibraryAssetURL(NSURL *__nullable imageURL)
   return RCTIsImageAssetsPath(RCTLibraryPathForURL(imageURL));
 }
 
+BOOL RCTIsTmpAssetURL(NSURL *__nullable imageURL)
+{
+  return RCTIsImageAssetsPath(RCTTmpPathForURL(imageURL));
+}
+
+BOOL RCTIsDocumentsAssetURL(NSURL *__nullable imageURL)
+{
+  return RCTIsImageAssetsPath(RCTDocumentsPathForURL(imageURL));
+}
+
+BOOL RCTIsHomeAssetURL(NSURL *__nullable imageURL)
+{
+  return RCTIsImageAssetsPath(RCTHomePathForURL(imageURL));
+}
+
 BOOL RCTIsLocalAssetURL(NSURL *__nullable imageURL)
 {
-  return RCTIsBundleAssetURL(imageURL) || RCTIsLibraryAssetURL(imageURL);
+  return RCTIsBundleAssetURL(imageURL) || RCTIsHomeAssetURL(imageURL);
 }
 
 static NSString *bundleName(NSBundle *bundle)


### PR DESCRIPTION
## Summary

Currently, `RCTLocalAssetImageLoader` only support directory of `Library` and `App bundle`, actually, we need to support other directories like `tmp` or `Documents`. Otherwise, the local image load in `tmp` or `Documents` would be handled by `NSURLSession`, we don't need that.

<img width="405" alt="image" src="https://user-images.githubusercontent.com/5061845/54188126-0ba66100-44ea-11e9-9a7b-0f721100e9be.png">

## Changelog

[iOS] [Fixed] - Enhance search of directories when load local asset image

## Test Plan

For any image url which located in `Documents` or `tmp`, we can load it by `RCTLocalAssetImageLoader`.