### PR TITLE
[iOS] Remove explicitly add png file extension when load local image

### DIFF
--- a/Libraries/Image/RCTImageLoader.m
+++ b/Libraries/Image/RCTImageLoader.m
@@ -353,11 +353,6 @@ static UIImage *RCTResizeImageIfNeeded(UIImage *image,
     [NSURLProtocol setProperty:@"RCTImageLoader"
                         forKey:@"trackingName"
                      inRequest:mutableRequest];
-    
-    // Add missing png extension
-    if (request.URL.fileURL && request.URL.pathExtension.length == 0) {
-      mutableRequest.URL = [request.URL URLByAppendingPathExtension:@"png"];
-    }
     if (_redirectDelegate != nil) {
       mutableRequest.URL = [_redirectDelegate redirectAssetsURL:mutableRequest.URL];
     }

--- a/React/Base/RCTUtils.m
+++ b/React/Base/RCTUtils.m
@@ -711,9 +711,6 @@ UIImage *__nullable RCTImageFromLocalAssetURL(NSURL *imageURL)
   if (!image) {
     // Attempt to load from the file system
     NSString *filePath = [NSString stringWithUTF8String:[imageURL fileSystemRepresentation]];
-    if (filePath.pathExtension.length == 0) {
-      filePath = [filePath stringByAppendingPathExtension:@"png"];
-    }
     image = [UIImage imageWithContentsOfFile:filePath];
   }
 


### PR DESCRIPTION
## Summary

We need to remove adding png file extension when path has not extension. Two reasons:
1. `imageWithContentsOfFile` or other `UIKit` methods can load png image correctly, even if path has not `png` file extension.
2. Sometimes, people may have file that actually not have file extension, it's the designated behavior for user. Like #23844 .

CC. @sahrens @cpojer .

Fixes #23844 .

## Changelog

[iOS] [Fixed] - Remove explicitly add png file extension when load local image

## Test Plan

For png image which not have file extension, it still can load success.
