### PR TITLE
Fix TouchableWithoutFeedback's Lack of View

### DIFF
--- a/Libraries/Components/Touchable/TouchableWithoutFeedback.js
+++ b/Libraries/Components/Touchable/TouchableWithoutFeedback.js
@@ -14,7 +14,9 @@ const React = require('React');
 const PropTypes = require('prop-types');
 const Touchable = require('Touchable');
 const View = require('View');
-const EdgeInsetsPropType = require('EdgeInsetsPropType');
+
+var EdgeInsetsPropType = require('EdgeInsetsPropType');
+var Animated = require('Animated');
 
 const createReactClass = require('create-react-class');
 const ensurePositiveDelayProps = require('ensurePositiveDelayProps');

--- a/Libraries/Components/Touchable/TouchableWithoutFeedback.js
+++ b/Libraries/Components/Touchable/TouchableWithoutFeedback.js
@@ -99,7 +99,6 @@ const TouchableWithoutFeedback = ((createReactClass({
       PropTypes.oneOf(DeprecatedAccessibilityTraits),
       PropTypes.arrayOf(PropTypes.oneOf(DeprecatedAccessibilityTraits)),
     ]),
-    children: React.Node,
     /**
      * When `accessible` is true (which is the default) this may be called when
      * the OS-specific concept of "focus" occurs. Some platforms may not have
@@ -232,7 +231,7 @@ const TouchableWithoutFeedback = ((createReactClass({
     // Note(avik): remove dynamic typecast once Flow has been upgraded
     // $FlowFixMe(>=0.41.0)
     return (
-      <View
+      <Animated.View
         accessible={this.props.accessible !== false}
         accessibilityLabel={this.props.accessibilityLabel}
         accessibilityHint={this.props.accessibilityHint}
@@ -257,7 +256,7 @@ const TouchableWithoutFeedback = ((createReactClass({
           color: 'red',
           hitSlop: this.props.hitSlop,
         })}
-      </View>
+      </Animated.View>
     );
   },
 }): any): React.ComponentType<Props>);

--- a/Libraries/Components/Touchable/TouchableWithoutFeedback.js
+++ b/Libraries/Components/Touchable/TouchableWithoutFeedback.js
@@ -232,35 +232,37 @@ const TouchableWithoutFeedback = ((createReactClass({
     // Note(avik): remove dynamic typecast once Flow has been upgraded
     // $FlowFixMe(>=0.41.0)
     const child = React.Children.only(this.props.children);
-    let children = child.props.children;
-    if (Touchable.TOUCH_TARGET_DEBUG && child.type === View) {
-      children = React.Children.toArray(children);
-      children.push(
-        Touchable.renderDebugView({color: 'red', hitSlop: this.props.hitSlop}),
-      );
-    }
-    return (React: any).cloneElement(child, {
-      accessible: this.props.accessible !== false,
-      accessibilityLabel: this.props.accessibilityLabel,
-      accessibilityHint: this.props.accessibilityHint,
-      accessibilityComponentType: this.props.accessibilityComponentType,
-      accessibilityRole: this.props.accessibilityRole,
-      accessibilityStates: this.props.accessibilityStates,
-      accessibilityTraits: this.props.accessibilityTraits,
-      nativeID: this.props.nativeID,
-      testID: this.props.testID,
-      onLayout: this.props.onLayout,
-      hitSlop: this.props.hitSlop,
-      onStartShouldSetResponder: this.touchableHandleStartShouldSetResponder,
-      onResponderTerminationRequest: this
-        .touchableHandleResponderTerminationRequest,
-      onResponderGrant: this.touchableHandleResponderGrant,
-      onResponderMove: this.touchableHandleResponderMove,
-      onResponderRelease: this.touchableHandleResponderRelease,
-      onResponderTerminate: this.touchableHandleResponderTerminate,
-      children,
-    });
-  },
-}): any): React.ComponentType<Props>);
+    const style = (Touchable.TOUCH_TARGET_DEBUG && child.type && child.type.displayName === 'Text') ?
+      [child.props.style, {color: 'red'}] :
+      child.props.style;
+    return (
+      <View
+        accessible={this.props.accessible !== false}
+        accessibilityLabel={this.props.accessibilityLabel}
+        accessibilityHint={this.props.accessibilityHint}
+        accessibilityComponentType={this.props.accessibilityComponentType}
+        accessibilityRole={this.props.accessibilityRole}
+        accessibilityStates={this.props.accessibilityStates}
+        accessibilityTraits={this.props.accessibilityTraits}
+        nativeID={this.props.nativeID}
+        testID={this.props.testID}
+        onLayout={this.props.onLayout}
+        hitSlop={this.props.hitStop}
+        onStartShouldSetResponder={this.touchableHandleStartShouldSetResponder}
+        onResponderTerminationRequest={this.touchableHandleResponderTerminationRequest}
+        onResponderGrant={this.touchableHandleResponderGrant}
+        onResponderMove={this.touchableHandleResponderMove}
+        onResponderRelease={this.touchableHandleResponderRelease}
+        onResponderTerminate={this.touchableHandleResponderTerminate}
+        style={style}>
+        {React.cloneElement(
+          /* $FlowFixMe(>=0.53.0 site=react_native_fb,react_native_oss) This
+           * comment suppresses an error when upgrading Flow's support for
+           * React. To see the error delete this comment and run Flow. */
+          child
+        )}
+      </View>
+    );
+  }
 
 module.exports = TouchableWithoutFeedback;

--- a/Libraries/Components/Touchable/TouchableWithoutFeedback.js
+++ b/Libraries/Components/Touchable/TouchableWithoutFeedback.js
@@ -10,7 +10,6 @@
 
 'use strict';
 
-const DeprecatedEdgeInsetsPropType = require('DeprecatedEdgeInsetsPropType');
 const React = require('React');
 const PropTypes = require('prop-types');
 const Touchable = require('Touchable');
@@ -100,6 +99,7 @@ const TouchableWithoutFeedback = ((createReactClass({
       PropTypes.oneOf(DeprecatedAccessibilityTraits),
       PropTypes.arrayOf(PropTypes.oneOf(DeprecatedAccessibilityTraits)),
     ]),
+    children: React.Node,
     /**
      * When `accessible` is true (which is the default) this may be called when
      * the OS-specific concept of "focus" occurs. Some platforms may not have

--- a/Libraries/Components/Touchable/TouchableWithoutFeedback.js
+++ b/Libraries/Components/Touchable/TouchableWithoutFeedback.js
@@ -15,6 +15,7 @@ const React = require('React');
 const PropTypes = require('prop-types');
 const Touchable = require('Touchable');
 const View = require('View');
+const EdgeInsetsPropType = require('EdgeInsetsPropType');
 
 const createReactClass = require('create-react-class');
 const ensurePositiveDelayProps = require('ensurePositiveDelayProps');
@@ -27,7 +28,6 @@ const {
 } = require('DeprecatedViewAccessibility');
 
 import type {SyntheticEvent, LayoutEvent, PressEvent} from 'CoreEventTypes';
-import type {EdgeInsetsProp} from 'EdgeInsetsPropType';
 import type {
   AccessibilityComponentType,
   AccessibilityRole,
@@ -60,7 +60,7 @@ export type Props = $ReadOnly<{|
   delayPressIn?: ?number,
   delayPressOut?: ?number,
   disabled?: ?boolean,
-  hitSlop?: ?EdgeInsetsProp,
+  hitSlop?: ?EdgeInsetsPropType,
   nativeID?: ?string,
   onBlur?: ?(e: BlurEvent) => void,
   onFocus?: ?(e: FocusEvent) => void,
@@ -69,7 +69,7 @@ export type Props = $ReadOnly<{|
   onPress?: ?(event: PressEvent) => mixed,
   onPressIn?: ?(event: PressEvent) => mixed,
   onPressOut?: ?(event: PressEvent) => mixed,
-  pressRetentionOffset?: ?EdgeInsetsProp,
+  pressRetentionOffset?: ?EdgeInsetsPropType,
   rejectResponderTermination?: ?boolean,
   testID?: ?string,
 |}>;
@@ -161,7 +161,7 @@ const TouchableWithoutFeedback = ((createReactClass({
      * reactivated! Move it back and forth several times while the scroll view
      * is disabled. Ensure you pass in a constant to reduce memory allocations.
      */
-    pressRetentionOffset: DeprecatedEdgeInsetsPropType,
+    pressRetentionOffset: EdgeInsetsPropType,
     /**
      * This defines how far your touch can start away from the button. This is
      * added to `pressRetentionOffset` when moving off of the button.
@@ -170,7 +170,7 @@ const TouchableWithoutFeedback = ((createReactClass({
      * of sibling views always takes precedence if a touch hits two overlapping
      * views.
      */
-    hitSlop: DeprecatedEdgeInsetsPropType,
+    hitSlop: EdgeInsetsPropType,
   },
 
   getInitialState: function() {
@@ -231,30 +231,32 @@ const TouchableWithoutFeedback = ((createReactClass({
   render: function(): React.Element<any> {
     // Note(avik): remove dynamic typecast once Flow has been upgraded
     // $FlowFixMe(>=0.41.0)
-    const that = this;
     return (
       <View
-        accessible={that.props.accessible !== false}
-        accessibilityLabel={that.props.accessibilityLabel}
-        accessibilityHint={that.props.accessibilityHint}
-        accessibilityComponentType={that.props.accessibilityComponentType}
-        accessibilityRole={that.props.accessibilityRole}
-        accessibilityStates={that.props.accessibilityStates}
-        accessibilityTraits={that.props.accessibilityTraits}
-        nativeID={that.props.nativeID}
-        testID={that.props.testID}
-        onLayout={that.props.onLayout}
-        hitSlop={that.props.hitSlop}
-        onStartShouldSetResponder={that.touchableHandleStartShouldSetResponder}
+        accessible={this.props.accessible !== false}
+        accessibilityLabel={this.props.accessibilityLabel}
+        accessibilityHint={this.props.accessibilityHint}
+        accessibilityComponentType={this.props.accessibilityComponentType}
+        accessibilityRole={this.props.accessibilityRole}
+        accessibilityStates={this.props.accessibilityStates}
+        accessibilityTraits={this.props.accessibilityTraits}
+        nativeID={this.props.nativeID}
+        testID={this.props.testID}
+        onLayout={this.props.onLayout}
+        hitSlop={this.props.hitSlop}
+        onStartShouldSetResponder={this.touchableHandleStartShouldSetResponder}
         onResponderTerminationRequest={
-          that.touchableHandleResponderTerminationRequest
+          this.touchableHandleResponderTerminationRequest
         }
-        onResponderGrant={that.touchableHandleResponderGrant}
-        onResponderMove={that.touchableHandleResponderMove}
-        onResponderRelease={that.touchableHandleResponderRelease}
-        onResponderTerminate={that.touchableHandleResponderTerminate}>
-        {that.props.children}
-        {Touchable.renderDebugView({color: 'red', hitSlop: that.props.hitSlop})}
+        onResponderGrant={this.touchableHandleResponderGrant}
+        onResponderMove={this.touchableHandleResponderMove}
+        onResponderRelease={this.touchableHandleResponderRelease}
+        onResponderTerminate={this.touchableHandleResponderTerminate}>
+        {this.props.children}
+        {Touchable.renderDebugView({
+          color: 'red',
+          hitSlop: this.props.hitSlop,
+        })}
       </View>
     );
   },

--- a/Libraries/Components/Touchable/TouchableWithoutFeedback.js
+++ b/Libraries/Components/Touchable/TouchableWithoutFeedback.js
@@ -243,18 +243,17 @@ const TouchableWithoutFeedback = ((createReactClass({
         nativeID={this.props.nativeID}
         testID={this.props.testID}
         onLayout={this.props.onLayout}
-        hitSlop={this.props.hitStop}
+        hitSlop={this.props.hitSlop}
         onStartShouldSetResponder={this.touchableHandleStartShouldSetResponder}
-        onResponderTerminationRequest={this.touchableHandleResponderTerminationRequest}
+        onResponderTerminationRequest={
+          this.touchableHandleResponderTerminationRequest
+        }
         onResponderGrant={this.touchableHandleResponderGrant}
         onResponderMove={this.touchableHandleResponderMove}
         onResponderRelease={this.touchableHandleResponderRelease}
         onResponderTerminate={this.touchableHandleResponderTerminate}>
         {this.props.children}
-        {Touchable.renderDebugView({
-          color: 'red',
-          hitSlop: this.props.hitSlop
-        })}
+        {Touchable.renderDebugView({color: 'red', hitSlop: this.props.hitSlop})}
       </View>
     );
   },

--- a/Libraries/Components/Touchable/TouchableWithoutFeedback.js
+++ b/Libraries/Components/Touchable/TouchableWithoutFeedback.js
@@ -231,29 +231,30 @@ const TouchableWithoutFeedback = ((createReactClass({
   render: function(): React.Element<any> {
     // Note(avik): remove dynamic typecast once Flow has been upgraded
     // $FlowFixMe(>=0.41.0)
+    const that = this;
     return (
       <View
-        accessible={this.props.accessible !== false}
-        accessibilityLabel={this.props.accessibilityLabel}
-        accessibilityHint={this.props.accessibilityHint}
-        accessibilityComponentType={this.props.accessibilityComponentType}
-        accessibilityRole={this.props.accessibilityRole}
-        accessibilityStates={this.props.accessibilityStates}
-        accessibilityTraits={this.props.accessibilityTraits}
-        nativeID={this.props.nativeID}
-        testID={this.props.testID}
-        onLayout={this.props.onLayout}
-        hitSlop={this.props.hitSlop}
-        onStartShouldSetResponder={this.touchableHandleStartShouldSetResponder}
+        accessible={that.props.accessible !== false}
+        accessibilityLabel={that.props.accessibilityLabel}
+        accessibilityHint={that.props.accessibilityHint}
+        accessibilityComponentType={that.props.accessibilityComponentType}
+        accessibilityRole={that.props.accessibilityRole}
+        accessibilityStates={that.props.accessibilityStates}
+        accessibilityTraits={that.props.accessibilityTraits}
+        nativeID={that.props.nativeID}
+        testID={that.props.testID}
+        onLayout={that.props.onLayout}
+        hitSlop={ththatis.props.hitSlop}
+        onStartShouldSetResponder={that.touchableHandleStartShouldSetResponder}
         onResponderTerminationRequest={
-          this.touchableHandleResponderTerminationRequest
+          that.touchableHandleResponderTerminationRequest
         }
-        onResponderGrant={this.touchableHandleResponderGrant}
-        onResponderMove={this.touchableHandleResponderMove}
-        onResponderRelease={this.touchableHandleResponderRelease}
-        onResponderTerminate={this.touchableHandleResponderTerminate}>
-        {this.props.children}
-        {Touchable.renderDebugView({color: 'red', hitSlop: this.props.hitSlop})}
+        onResponderGrant={that.touchableHandleResponderGrant}
+        onResponderMove={that.touchableHandleResponderMove}
+        onResponderRelease={that.touchableHandleResponderRelease}
+        onResponderTerminate={that.touchableHandleResponderTerminate}>
+        {that.props.children}
+        {Touchable.renderDebugView({color: 'red', hitSlop: that.props.hitSlop})}
       </View>
     );
   },

--- a/Libraries/Components/Touchable/TouchableWithoutFeedback.js
+++ b/Libraries/Components/Touchable/TouchableWithoutFeedback.js
@@ -251,9 +251,10 @@ const TouchableWithoutFeedback = ((createReactClass({
         onResponderRelease={this.touchableHandleResponderRelease}
         onResponderTerminate={this.touchableHandleResponderTerminate}>
         {this.props.children}
-        <Optional {Touchable.TOUCH_TARGET_DEBUG && child.type === View}>
-          {Touchable.renderDebugView({color: 'red', hitSlop: this.props.hitSlop})}
-        </Optional>
+        {Touchable.renderDebugView({
+          color: 'red',
+          hitSlop: this.props.hitSlop
+        })}
       </View>
     );
   },

--- a/Libraries/Components/Touchable/TouchableWithoutFeedback.js
+++ b/Libraries/Components/Touchable/TouchableWithoutFeedback.js
@@ -244,7 +244,7 @@ const TouchableWithoutFeedback = ((createReactClass({
         nativeID={that.props.nativeID}
         testID={that.props.testID}
         onLayout={that.props.onLayout}
-        hitSlop={ththatis.props.hitSlop}
+        hitSlop={that.props.hitSlop}
         onStartShouldSetResponder={that.touchableHandleStartShouldSetResponder}
         onResponderTerminationRequest={
           that.touchableHandleResponderTerminationRequest

--- a/Libraries/Components/Touchable/TouchableWithoutFeedback.js
+++ b/Libraries/Components/Touchable/TouchableWithoutFeedback.js
@@ -231,10 +231,6 @@ const TouchableWithoutFeedback = ((createReactClass({
   render: function(): React.Element<any> {
     // Note(avik): remove dynamic typecast once Flow has been upgraded
     // $FlowFixMe(>=0.41.0)
-    const child = React.Children.only(this.props.children);
-    const style = (Touchable.TOUCH_TARGET_DEBUG && child.type && child.type.displayName === 'Text') ?
-      [child.props.style, {color: 'red'}] :
-      child.props.style;
     return (
       <View
         accessible={this.props.accessible !== false}
@@ -255,14 +251,12 @@ const TouchableWithoutFeedback = ((createReactClass({
         onResponderRelease={this.touchableHandleResponderRelease}
         onResponderTerminate={this.touchableHandleResponderTerminate}
         style={style}>
-        {React.cloneElement(
-          /* $FlowFixMe(>=0.53.0 site=react_native_fb,react_native_oss) This
-           * comment suppresses an error when upgrading Flow's support for
-           * React. To see the error delete this comment and run Flow. */
-          child
-        )}
+        {this.props.children}
+        <Optional {Touchable.TOUCH_TARGET_DEBUG && child.type === View}>
+          {Touchable.renderDebugView({color: 'red', hitSlop: this.props.hitSlop})}
+        </Optional>
       </View>
     );
-  }
+  }): any): React.ComponentType<Props>);
 
 module.exports = TouchableWithoutFeedback;

--- a/Libraries/Components/Touchable/TouchableWithoutFeedback.js
+++ b/Libraries/Components/Touchable/TouchableWithoutFeedback.js
@@ -249,14 +249,14 @@ const TouchableWithoutFeedback = ((createReactClass({
         onResponderGrant={this.touchableHandleResponderGrant}
         onResponderMove={this.touchableHandleResponderMove}
         onResponderRelease={this.touchableHandleResponderRelease}
-        onResponderTerminate={this.touchableHandleResponderTerminate}
-        style={style}>
+        onResponderTerminate={this.touchableHandleResponderTerminate}>
         {this.props.children}
         <Optional {Touchable.TOUCH_TARGET_DEBUG && child.type === View}>
           {Touchable.renderDebugView({color: 'red', hitSlop: this.props.hitSlop})}
         </Optional>
       </View>
     );
-  }): any): React.ComponentType<Props>);
+  },
+}): any): React.ComponentType<Props>);
 
 module.exports = TouchableWithoutFeedback;


### PR DESCRIPTION
## Summary
This PR addresses the issue regarding `TouchableWithoutFeedback` components not correctly working without a `<View>` embedded within them. The most current [issue can be found here](https://github.com/facebook/react-native/issues/23740).

`render()` now returns a `View` -- rather than just cloning the children -- with all of the props passed into the TouchableWithoutFeedback component, as well as all children. This addresses the issue where the children's props weren't being properly passed down into a `View`.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See http://facebook.github.io/react-native/docs/contributing#changelog for an example. -->

[General] [Fixed] - `render()` now wraps all props and child props correctly in a view

## Test Plan

Pass all CircleCI Tests
