### PR TITLE
[Lean Core] Add deprecation warning for status-bar

### DIFF
--- a/Libraries/react-native/react-native-implementation.js
+++ b/Libraries/react-native/react-native-implementation.js
@@ -123,6 +123,12 @@ module.exports = {
     return require('RefreshControl');
   },
   get StatusBar() {
+    warnOnce(
+      'statusbar-moved',
+      'StatusBar has been extracted from react-native core and will be removed in a future release. ' +
+        "It can now be installed and imported from '@react-native-community/status-bar' instead of 'react-native'. " +
+        'https://github.com/react-native-community/react-native-statusbar',
+    );
     return require('StatusBar');
   },
   get SwipeableFlatList() {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
Adds a deprecation warning for using status-bar package 

Lean Core Issue: #23313

## Changelog
[General] [Deprecated] - Deprecated StatusBar as it has now been moved to @react-native-community/statusbar

## Test Plan
Open the RNTester app to the StatusBar examples and see the deprecation warning yellow box.
