### PR TITLE
[iOS] Add key for items in TextInputExample of RNTester

### DIFF
--- a/RNTester/js/TextInputExample.ios.js
+++ b/RNTester/js/TextInputExample.ios.js
@@ -822,9 +822,8 @@ exports.examples = [
       ];
       const examples = clearButtonModes.map(mode => {
         return (
-          <WithLabel label={mode}>
+          <WithLabel key={mode} label={mode}>
             <TextInput
-              key={mode}
               style={styles.default}
               clearButtonMode={mode}
               defaultValue={mode}


### PR DESCRIPTION
## Summary

We added the key at wrong places, so let's fix it.

CC. @cpojer 
<img width="365" alt="image" src="https://user-images.githubusercontent.com/5061845/54288501-894d9800-45e2-11e9-9a74-8bebf366aa04.png">

## Changelog

[iOS] [Fixed] - Add key for items in TextInputExample of RNTester

## Test Plan

TextInputExample runs no warnings.