### PR TITLE
[iOS] [added] - add more iOS flags into AccessibilityInfo

### DIFF
--- a/Libraries/Components/AccessibilityInfo/AccessibilityInfo.android.js
+++ b/Libraries/Components/AccessibilityInfo/AccessibilityInfo.android.js
@@ -38,10 +38,38 @@ const _subscriptions = new Map();
  */
 
 const AccessibilityInfo = {
+  /**
+   * iOS only
+   */
+  isBoldTextEnabled: function(): Promise<boolean> {
+    return Promise.resolve(false);
+  },
+
+  /**
+   * iOS only
+   */
+  isGrayscaleEnabled: function(): Promise<boolean> {
+    return Promise.resolve(false);
+  },
+
+  /**
+   * iOS only
+   */
+  isInvertColorsEnabled: function(): Promise<boolean> {
+    return Promise.resolve(false);
+  },
+
   isReduceMotionEnabled: function(): Promise<boolean> {
     return new Promise((resolve, reject) => {
       RCTAccessibilityInfo.isReduceMotionEnabled(resolve);
     });
+  },
+
+  /**
+   * iOS only
+   */
+  isReduceTransparencyEnabled: function(): Promise<boolean> {
+    return Promise.resolve(false);
   },
 
   isScreenReaderEnabled: function(): Promise<boolean> {

--- a/Libraries/Components/AccessibilityInfo/AccessibilityInfo.ios.js
+++ b/Libraries/Components/AccessibilityInfo/AccessibilityInfo.ios.js
@@ -16,14 +16,24 @@ const RCTDeviceEventEmitter = require('RCTDeviceEventEmitter');
 
 const AccessibilityManager = NativeModules.AccessibilityManager;
 
-const ANNOUNCEMENT_DID_FINISH_EVENT = 'announcementDidFinish';
-const REDUCE_MOTION_EVENT = 'reduceMotionDidChange';
-const VOICE_OVER_EVENT = 'voiceOverDidChange';
+const CHANGE_EVENT_NAME = {
+  announcementFinished: 'announcementFinished',
+  boldTextChanged: 'boldTextChanged',
+  grayscaleChanged: 'grayscaleChanged',
+  invertColorsChanged: 'invertColorsChanged',
+  reduceMotionChanged: 'reduceMotionChanged',
+  reduceTransparencyChanged: 'reduceTransparencyChanged',
+  screenReaderChanged: 'screenReaderChanged',
+};
 
 type ChangeEventName = $Enum<{
   announcementFinished: string,
+  boldTextChanged: string,
   change: string,
+  grayscaleChanged: string,
+  invertColorsChanged: string,
   reduceMotionChanged: string,
+  reduceTransparencyChanged: string,
   screenReaderChanged: string,
 }>;
 
@@ -40,16 +50,72 @@ const _subscriptions = new Map();
  */
 const AccessibilityInfo = {
   /**
+   * Query whether a bold text is currently enabled.
+   *
+   * Returns a promise which resolves to a boolean.
+   * The result is `true` when bold text is enabled and `false` otherwise.
+   *
+   * See http://facebook.github.io/react-native/docs/accessibilityinfo.html#isBoldTextEnabled
+   */
+  isBoldTextEnabled: function(): Promise<boolean> {
+    return new Promise((resolve, reject) => {
+      AccessibilityManager.getCurrentBoldTextState(resolve, reject);
+    });
+  },
+
+  /**
+   * Query whether a grayscale is currently enabled.
+   *
+   * Returns a promise which resolves to a boolean.
+   * The result is `true` when grayscale is enabled and `false` otherwise.
+   *
+   * See http://facebook.github.io/react-native/docs/accessibilityinfo.html#isGrayscaleEnabled
+   */
+  isGrayscaleEnabled: function(): Promise<boolean> {
+    return new Promise((resolve, reject) => {
+      AccessibilityManager.getCurrentGrayscaleState(resolve, reject);
+    });
+  },
+
+  /**
+   * Query whether a invert colors is currently enabled.
+   *
+   * Returns a promise which resolves to a boolean.
+   * The result is `true` when invert color is enabled and `false` otherwise.
+   *
+   * See http://facebook.github.io/react-native/docs/accessibilityinfo.html#isInvertColorsEnabled
+   */
+  isInvertColorsEnabled: function(): Promise<boolean> {
+    return new Promise((resolve, reject) => {
+      AccessibilityManager.getCurrentInvertColorsState(resolve, reject);
+    });
+  },
+
+  /**
    * Query whether a reduce motion is currently enabled.
    *
    * Returns a promise which resolves to a boolean.
-   * The result is `true` when a screen reader is enabledand `false` otherwise.
+   * The result is `true` when a reduce motion is enabled and `false` otherwise.
    *
    * See http://facebook.github.io/react-native/docs/accessibilityinfo.html#isReduceMotionEnabled
    */
-  isReduceMotionEnabled: function(): Promise {
+  isReduceMotionEnabled: function(): Promise<boolean> {
     return new Promise((resolve, reject) => {
-      AccessibilityManager.getReduceMotionState(resolve, reject);
+      AccessibilityManager.getCurrentReduceMotionState(resolve, reject);
+    });
+  },
+
+  /**
+   * Query whether a reduce transparency is currently enabled.
+   *
+   * Returns a promise which resolves to a boolean.
+   * The result is `true` when a reduce transparency is enabled and `false` otherwise.
+   *
+   * See http://facebook.github.io/react-native/docs/accessibilityinfo.html#isReduceTransparencyEnabled
+   */
+  isReduceTransparencyEnabled: function(): Promise<boolean> {
+    return new Promise((resolve, reject) => {
+      AccessibilityManager.getCurrentReduceTransparencyState(resolve, reject);
     });
   },
 
@@ -61,7 +127,7 @@ const AccessibilityInfo = {
    *
    * See http://facebook.github.io/react-native/docs/accessibilityinfo.html#isScreenReaderEnabled
    */
-  isScreenReaderEnabled: function(): Promise {
+  isScreenReaderEnabled: function(): Promise<boolean> {
     return new Promise((resolve, reject) => {
       AccessibilityManager.getCurrentVoiceOverState(resolve, reject);
     });
@@ -79,10 +145,22 @@ const AccessibilityInfo = {
   /**
    * Add an event handler. Supported events:
    *
+   * - `boldTextChanged`: iOS-only event. Fires when the state of the bold text toggle changes.
+   *   The argument to the event handler is a boolean. The boolean is `true` when a bold text
+   *   is enabled and `false` otherwise.
+   * - `grayscaleChanged`: iOS-only event. Fires when the state of the gray scale toggle changes.
+   *   The argument to the event handler is a boolean. The boolean is `true` when a gray scale
+   *   is enabled and `false` otherwise.
+   * - `invertColorsChanged`: iOS-only event. Fires when the state of the invert colors toggle
+   *   changes. The argument to the event handler is a boolean. The boolean is `true` when a invert
+   *   colors is enabled and `false` otherwise.
    * - `reduceMotionChanged`: Fires when the state of the reduce motion toggle changes.
    *   The argument to the event handler is a boolean. The boolean is `true` when a reduce
    *   motion is enabled (or when "Transition Animation Scale" in "Developer options" is
    *   "Animation off") and `false` otherwise.
+   * - `reduceTransparencyChanged`: iOS-only event. Fires when the state of the reduce transparency
+   *   toggle changes.  The argument to the event handler is a boolean. The boolean is `true`
+   *   when a reduce transparency is enabled and `false` otherwise.
    * - `screenReaderChanged`: Fires when the state of the screen reader changes. The argument
    *   to the event handler is a boolean. The boolean is `true` when a screen
    *   reader is enabled and `false` otherwise.
@@ -101,18 +179,13 @@ const AccessibilityInfo = {
   ): Object {
     let listener;
 
-    if (eventName === 'change' || eventName === 'screenReaderChanged') {
-      listener = RCTDeviceEventEmitter.addListener(VOICE_OVER_EVENT, handler);
-    } else if (eventName === 'reduceMotionChanged') {
+    if (eventName === 'change') {
       listener = RCTDeviceEventEmitter.addListener(
-        REDUCE_MOTION_EVENT,
+        CHANGE_EVENT_NAME.screenReaderChanged,
         handler,
       );
-    } else if (eventName === 'announcementFinished') {
-      listener = RCTDeviceEventEmitter.addListener(
-        ANNOUNCEMENT_DID_FINISH_EVENT,
-        handler,
-      );
+    } else if (CHANGE_EVENT_NAME[eventName]) {
+      listener = RCTDeviceEventEmitter.addListener(eventName, handler);
     }
 
     _subscriptions.set(handler, listener);

--- a/Libraries/Components/AccessibilityInfo/AccessibilityInfo.ios.js
+++ b/Libraries/Components/AccessibilityInfo/AccessibilityInfo.ios.js
@@ -50,7 +50,7 @@ const _subscriptions = new Map();
  */
 const AccessibilityInfo = {
   /**
-   * Query whether a bold text is currently enabled.
+   * Query whether bold text is currently enabled.
    *
    * Returns a promise which resolves to a boolean.
    * The result is `true` when bold text is enabled and `false` otherwise.
@@ -64,7 +64,7 @@ const AccessibilityInfo = {
   },
 
   /**
-   * Query whether a grayscale is currently enabled.
+   * Query whether grayscale is currently enabled.
    *
    * Returns a promise which resolves to a boolean.
    * The result is `true` when grayscale is enabled and `false` otherwise.
@@ -78,7 +78,7 @@ const AccessibilityInfo = {
   },
 
   /**
-   * Query whether a invert colors is currently enabled.
+   * Query whether inverted colors are currently enabled.
    *
    * Returns a promise which resolves to a boolean.
    * The result is `true` when invert color is enabled and `false` otherwise.
@@ -92,7 +92,7 @@ const AccessibilityInfo = {
   },
 
   /**
-   * Query whether a reduce motion is currently enabled.
+   * Query whether reduced motion is currently enabled.
    *
    * Returns a promise which resolves to a boolean.
    * The result is `true` when a reduce motion is enabled and `false` otherwise.
@@ -106,7 +106,7 @@ const AccessibilityInfo = {
   },
 
   /**
-   * Query whether a reduce transparency is currently enabled.
+   * Query whether reduced transparency is currently enabled.
    *
    * Returns a promise which resolves to a boolean.
    * The result is `true` when a reduce transparency is enabled and `false` otherwise.

--- a/React/Modules/RCTAccessibilityManager.h
+++ b/React/Modules/RCTAccessibilityManager.h
@@ -19,7 +19,11 @@ extern NSString *const RCTAccessibilityManagerDidUpdateMultiplierNotification; /
 /// map from UIKit categories to multipliers
 @property (nonatomic, copy) NSDictionary<NSString *, NSNumber *> *multipliers;
 
+@property (nonatomic, assign) BOOL isBoldTextEnabled;
+@property (nonatomic, assign) BOOL isGrayscaleEnabled;
+@property (nonatomic, assign) BOOL isInvertColorsEnabled;
 @property (nonatomic, assign) BOOL isReduceMotionEnabled;
+@property (nonatomic, assign) BOOL isReduceTransparencyEnabled;
 @property (nonatomic, assign) BOOL isVoiceOverEnabled;
 
 @end

--- a/React/Modules/RCTAccessibilityManager.m
+++ b/React/Modules/RCTAccessibilityManager.m
@@ -67,13 +67,23 @@ RCT_EXPORT_MODULE()
                                                object:nil];
 
     [[NSNotificationCenter defaultCenter] addObserver:self
-                                             selector:@selector(didReceiveNewVoiceOverStatus:)
-                                                 name:UIAccessibilityVoiceOverStatusChanged
+                                             selector:@selector(accessibilityAnnouncementDidFinish:)
+                                                 name:UIAccessibilityAnnouncementDidFinishNotification
                                                object:nil];
 
     [[NSNotificationCenter defaultCenter] addObserver:self
-                                             selector:@selector(accessibilityAnnouncementDidFinish:)
-                                                 name:UIAccessibilityAnnouncementDidFinishNotification
+                                             selector:@selector(boldTextStatusDidChange:)
+                                                 name:UIAccessibilityBoldTextStatusDidChangeNotification
+                                               object:nil];
+
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(grayscaleStatusDidChange:)
+                                                 name:UIAccessibilityGrayscaleStatusDidChangeNotification
+                                               object:nil];
+
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(invertColorsStatusDidChange:)
+                                                 name:UIAccessibilityInvertColorsStatusDidChangeNotification
                                                object:nil];
 
     [[NSNotificationCenter defaultCenter] addObserver:self
@@ -81,8 +91,22 @@ RCT_EXPORT_MODULE()
                                                  name:UIAccessibilityReduceMotionStatusDidChangeNotification
                                                object:nil];
 
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(reduceTransparencyStatusDidChange:)
+                                                 name:UIAccessibilityReduceTransparencyStatusDidChangeNotification
+                                               object:nil];
+
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(voiceVoiceOverStatusDidChange:)
+                                                 name:UIAccessibilityVoiceOverStatusChanged
+                                               object:nil];
+
     self.contentSizeCategory = RCTSharedApplication().preferredContentSizeCategory;
+    _isBoldTextEnabled = UIAccessibilityIsBoldTextEnabled();
+    _isGrayscaleEnabled = UIAccessibilityIsGrayscaleEnabled();
+    _isInvertColorsEnabled = UIAccessibilityIsInvertColorsEnabled();
     _isReduceMotionEnabled = UIAccessibilityIsReduceMotionEnabled();
+    _isReduceTransparencyEnabled = UIAccessibilityIsReduceTransparencyEnabled();
     _isVoiceOverEnabled = UIAccessibilityIsVoiceOverRunning();
   }
   return self;
@@ -98,19 +122,6 @@ RCT_EXPORT_MODULE()
   self.contentSizeCategory = note.userInfo[UIContentSizeCategoryNewValueKey];
 }
 
-- (void)didReceiveNewVoiceOverStatus:(__unused NSNotification *)notification
-{
-  BOOL newIsVoiceOverEnabled = UIAccessibilityIsVoiceOverRunning();
-  if (_isVoiceOverEnabled != newIsVoiceOverEnabled) {
-    _isVoiceOverEnabled = newIsVoiceOverEnabled;
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    [_bridge.eventDispatcher sendDeviceEventWithName:@"voiceOverDidChange"
-                                                body:@(_isVoiceOverEnabled)];
-#pragma clang diagnostic pop
-  }
-}
-
 - (void)accessibilityAnnouncementDidFinish:(__unused NSNotification *)notification
 {
   NSDictionary *userInfo = notification.userInfo;
@@ -120,9 +131,48 @@ RCT_EXPORT_MODULE()
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-  [_bridge.eventDispatcher sendDeviceEventWithName:@"announcementDidFinish"
+  [_bridge.eventDispatcher sendDeviceEventWithName:@"announcementFinished"
                                               body:response];
 #pragma clang diagnostic pop
+}
+
+- (void)boldTextStatusDidChange:(__unused NSNotification *)notification
+{
+  BOOL newBoldTextEnabled = UIAccessibilityIsBoldTextEnabled();
+  if (_isBoldTextEnabled != newBoldTextEnabled) {
+    _isBoldTextEnabled = newBoldTextEnabled;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    [_bridge.eventDispatcher sendDeviceEventWithName:@"boldTextChanged"
+                                                body:@(_isBoldTextEnabled)];
+#pragma clang diagnostic pop
+  }
+}
+
+- (void)grayscaleStatusDidChange:(__unused NSNotification *)notification
+{
+  BOOL newGrayscaleEnabled = UIAccessibilityIsGrayscaleEnabled();
+  if (_isGrayscaleEnabled != newGrayscaleEnabled) {
+    _isGrayscaleEnabled = newGrayscaleEnabled;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    [_bridge.eventDispatcher sendDeviceEventWithName:@"grayscaleChanged"
+                                                body:@(_isGrayscaleEnabled)];
+#pragma clang diagnostic pop
+  }
+}
+
+- (void)invertColorsStatusDidChange:(__unused NSNotification *)notification
+{
+  BOOL newInvertColorsEnabled = UIAccessibilityIsInvertColorsEnabled();
+  if (_isInvertColorsEnabled != newInvertColorsEnabled) {
+    _isInvertColorsEnabled = newInvertColorsEnabled;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    [_bridge.eventDispatcher sendDeviceEventWithName:@"invertColorsChanged"
+                                                body:@(_isInvertColorsEnabled)];
+#pragma clang diagnostic pop
+  }
 }
 
 - (void)reduceMotionStatusDidChange:(__unused NSNotification *)notification
@@ -132,8 +182,34 @@ RCT_EXPORT_MODULE()
     _isReduceMotionEnabled = newReduceMotionEnabled;
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    [_bridge.eventDispatcher sendDeviceEventWithName:@"reduceMotionDidChange"
+    [_bridge.eventDispatcher sendDeviceEventWithName:@"reduceMotionChanged"
                                                 body:@(_isReduceMotionEnabled)];
+#pragma clang diagnostic pop
+  }
+}
+
+- (void)reduceTransparencyStatusDidChange:(__unused NSNotification *)notification
+{
+  BOOL newReduceTransparencyEnabled = UIAccessibilityIsReduceTransparencyEnabled();
+  if (_isReduceTransparencyEnabled != newReduceTransparencyEnabled) {
+    _isReduceTransparencyEnabled = newReduceTransparencyEnabled;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    [_bridge.eventDispatcher sendDeviceEventWithName:@"reduceTransparencyChanged"
+                                                body:@(_isReduceTransparencyEnabled)];
+#pragma clang diagnostic pop
+  }
+}
+
+- (void)voiceVoiceOverStatusDidChange:(__unused NSNotification *)notification
+{
+  BOOL newIsVoiceOverEnabled = UIAccessibilityIsVoiceOverRunning();
+  if (_isVoiceOverEnabled != newIsVoiceOverEnabled) {
+    _isVoiceOverEnabled = newIsVoiceOverEnabled;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    [_bridge.eventDispatcher sendDeviceEventWithName:@"screenReaderChanged"
+                                                body:@(_isVoiceOverEnabled)];
 #pragma clang diagnostic pop
   }
 }
@@ -220,16 +296,40 @@ RCT_EXPORT_METHOD(getMultiplier:(RCTResponseSenderBlock)callback)
   }
 }
 
+RCT_EXPORT_METHOD(getCurrentBoldTextState:(RCTResponseSenderBlock)callback
+                  error:(__unused RCTResponseSenderBlock)error)
+{
+  callback(@[@(_isBoldTextEnabled)]);
+}
+
+RCT_EXPORT_METHOD(getCurrentGrayscaleState:(RCTResponseSenderBlock)callback
+                  error:(__unused RCTResponseSenderBlock)error)
+{
+  callback(@[@(_isGrayscaleEnabled)]);
+}
+
+RCT_EXPORT_METHOD(getCurrentInvertColorsState:(RCTResponseSenderBlock)callback
+                  error:(__unused RCTResponseSenderBlock)error)
+{
+  callback(@[@(_isInvertColorsEnabled)]);
+}
+
+RCT_EXPORT_METHOD(getCurrentReduceMotionState:(RCTResponseSenderBlock)callback
+                  error:(__unused RCTResponseSenderBlock)error)
+{
+  callback(@[@(_isReduceMotionEnabled)]);
+}
+
+RCT_EXPORT_METHOD(getCurrentReduceTransparencyState:(RCTResponseSenderBlock)callback
+                  error:(__unused RCTResponseSenderBlock)error)
+{
+  callback(@[@(_isReduceTransparencyEnabled)]);
+}
+
 RCT_EXPORT_METHOD(getCurrentVoiceOverState:(RCTResponseSenderBlock)callback
                   error:(__unused RCTResponseSenderBlock)error)
 {
   callback(@[@(_isVoiceOverEnabled)]);
-}
-
-RCT_EXPORT_METHOD(getReduceMotionState:(RCTResponseSenderBlock)callback
-                  error:(__unused RCTResponseSenderBlock)error)
-{
-  callback(@[@(_isReduceMotionEnabled)]);
 }
 
 @end


### PR DESCRIPTION
## Summary

As a follow-up to this other PR #23839, it adds support for other, iOS only, flags into `AccessibilityInfo`.

## Changelog

It adds these other 4 methods: 
* `isBoldTextEnabled()`
* `isGrayscaleEnabled()`
* `isInvertColorsEnabled()`
* `isReduceTransparencyEnabled()`

P.S: Android implementation for those methods just return `false` (with `Promise.resolve(false)`)

And the corresponding event listeners:
* `boldTextChanged`
* `grayscaleChanged`,
* `invertColorsChanged`,
* `reduceTransparencyChanged`

## Test Plan

`isBoldTextEnabled` and `isReduceTransparencyEnabled` can be tested on iOS Simulator, by enabling the respective flags in Settings > General > Accessibility

For `isInvertColorsEnabled` and `isReduceTransparencyEnabled` only on iOS device. iOS Simulator's accessibility is just a subset of device's one. To test those two flags: 

* Settings > General > Accessibility > Display Accommodations > Invert Colors > enable Smart Invert;
* Settings > General > Accessibility > Display Accommodations > Color Filters > enable Color Filters;

Documentation PR: https://github.com/facebook/react-native-website/pull/835
