### PR TITLE
[iOS] Fixed minuteInterval invalid in time mode

### DIFF
--- a/RNTester/js/DatePickerIOSExample.js
+++ b/RNTester/js/DatePickerIOSExample.js
@@ -131,16 +131,16 @@ exports.examples = [
     },
   },
   {
-    title: 'Picker with 20-minute interval',
+    title: 'Time only picker, 20-minute interval',
     render: function(): React.Element<any> {
       return (
         <WithDatePickerData>
           {(state, onDateChange) => (
             <DatePickerIOS
-              testID="date-and-time-with-interval"
+              testID="time-with-interval"
               date={state.date}
               minuteInterval={20}
-              mode="datetime"
+              mode="time"
               onDateChange={onDateChange}
             />
           )}

--- a/React/Views/RCTDatePicker.m
+++ b/React/Views/RCTDatePicker.m
@@ -13,6 +13,7 @@
 @interface RCTDatePicker ()
 
 @property (nonatomic, copy) RCTBubblingEventBlock onChange;
+@property (nonatomic, assign) NSInteger reactMinuteInterval;
 
 @end
 
@@ -23,6 +24,7 @@
   if ((self = [super initWithFrame:frame])) {
     [self addTarget:self action:@selector(didChange)
                forControlEvents:UIControlEventValueChanged];
+    _reactMinuteInterval = 1;
   }
   return self;
 }
@@ -34,6 +36,19 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
   if (_onChange) {
     _onChange(@{ @"timestamp": @(self.date.timeIntervalSince1970 * 1000.0) });
   }
+}
+
+- (void)setDatePickerMode:(UIDatePickerMode)datePickerMode
+{
+  [super setDatePickerMode:datePickerMode];
+  // We need to ensure set minuteInterval after set datePickerMode, otherwise minuteInterval invalid in time mode.
+  self.minuteInterval = _reactMinuteInterval;
+}
+
+- (void)setMinuteInterval:(NSInteger)minuteInterval
+{
+  [super setMinuteInterval:minuteInterval];
+  _reactMinuteInterval = minuteInterval;
 }
 
 @end

--- a/React/Views/RCTDatePicker.m
+++ b/React/Views/RCTDatePicker.m
@@ -41,7 +41,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
 - (void)setDatePickerMode:(UIDatePickerMode)datePickerMode
 {
   [super setDatePickerMode:datePickerMode];
-  // We need to ensure set minuteInterval after set datePickerMode, otherwise minuteInterval invalid in time mode.
+  // We need to set minuteInterval after setting datePickerMode, otherwise minuteInterval is invalid in time mode.
   self.minuteInterval = _reactMinuteInterval;
 }
 


### PR DESCRIPTION
## Summary

From https://github.com/facebook/react-native/pull/23861#issue-260337314
> changing "interval" example from "time-only" to "datetime" because there's a known bug that prevented the previous example from working

We need to ensure set minuteInterval after set datePickerMode, otherwise minuteInterval invalid in time mode.

cc. @grabbou @cpojer .

## Changelog

[iOS] [Fixed] - Fixed minuteInterval invalid in time mode

## Test Plan

minuteInterval can work in time mode.
```
            <DatePickerIOS
              testID="date-and-time-with-interval"
              date={state.date}
              minuteInterval={20}
              mode="time"
              onDateChange={onDateChange}
            />
```

