### PR TITLE
[cleanup] Remove react-clone-referenced-element dependency

### DIFF
--- a/jest-preset.js
+++ b/jest-preset.js
@@ -29,9 +29,7 @@ module.exports = {
       './jest/assetFileTransformer.js',
     ),
   },
-  transformIgnorePatterns: [
-    'node_modules/(?!(jest-)?react-native|react-clone-referenced-element)',
-  ],
+  transformIgnorePatterns: ['node_modules/(?!(jest-)?react-native)'],
   testMatch: [
     '**/__tests__/**/*.(js|ts|tsx)',
     '**/?(*.)+(spec|test).(js|ts|tsx)',

--- a/package.json
+++ b/package.json
@@ -98,7 +98,6 @@
     "pretty-format": "24.0.0-alpha.6",
     "promise": "^7.1.1",
     "prop-types": "^15.5.8",
-    "react-clone-referenced-element": "^1.1.0",
     "react-devtools-core": "^3.6.0",
     "regenerator-runtime": "^0.11.0",
     "stacktrace-parser": "^0.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5700,11 +5700,6 @@ rc@^1.2.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-clone-referenced-element@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/react-clone-referenced-element/-/react-clone-referenced-element-1.1.0.tgz#9cdda7f2aeb54fea791f3ab8c6ab96c7a77d0158"
-  integrity sha512-FKOsfKbBkPxYE8576EM6uAfHC4rnMpLyH6/TJUL4WcHUEB3EUn8AxPjnnV/IiwSSzsClvHYK+sDELKN/EJ0WYg==
-
 react-deep-force-update@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/react-deep-force-update/-/react-deep-force-update-1.1.2.tgz#3d2ae45c2c9040cbb1772be52f8ea1ade6ca2ee1"


### PR DESCRIPTION
## Summary

This package was a dependency for ListView, which is no longer part of RN. Removed the dependency from package.json and yarn.lock.

Also removed its pattern from the Jest preset -- ListView is not in this repo and also react-clone-referenced-element was written at a time when Node did not support the same modern JS features as RN. The latest Node 8+ supports the features that react-clone-referenced-element uses so we don't need to transform it.

## Changelog

[General] [Removed] - Removed unused react-clone-referenced-element dependency 

## Test Plan

- `rg react-clone-referenced-element`
- Ensure CI passes
