### PR TITLE
Fix and update end to end tests for Android

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,9 +91,6 @@ aliases:
   - &run-e2e-tests
     name: End-to-End Test Suite
     command: ./scripts/run-ci-e2e-tests.js --android --ios --js --retries 3;
-  - &run-android-e2e-tests
-    name: Android End-to-End Test Suite
-    command: node ./scripts/run-ci-e2e-tests.js --android --retries 3;
 
 
   # -------------------------
@@ -492,6 +489,10 @@ jobs:
             fi
             source scripts/android-setup.sh && NO_BUCKD=1 retry3 timeout 300 buck install ReactAndroid/src/androidTest/buck-runner:instrumentation-tests --config build.threads=$BUILD_THREADS
       
+      - run:
+          name: Android End-to-End Test Suite
+          command: node ./scripts/run-ci-e2e-tests.js --android --retries 3;
+
       - run:
           name: Build Android RNTester App
           command: ./gradlew RNTester:android:app:assembleRelease

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,6 +91,9 @@ aliases:
   - &run-e2e-tests
     name: End-to-End Test Suite
     command: ./scripts/run-ci-e2e-tests.js --android --ios --js --retries 3;
+  - &run-android-e2e-tests
+    name: Android End-to-End Test Suite
+    command: node ./scripts/run-ci-e2e-tests.js --android --retries 3;
 
 
   # -------------------------
@@ -489,10 +492,6 @@ jobs:
             fi
             source scripts/android-setup.sh && NO_BUCKD=1 retry3 timeout 300 buck install ReactAndroid/src/androidTest/buck-runner:instrumentation-tests --config build.threads=$BUILD_THREADS
       
-      - run:
-          name: Android End-to-End Test Suite
-          command: node ./scripts/run-ci-e2e-tests.js --android --retries 3;
-
       - run:
           name: Build Android RNTester App
           command: ./gradlew RNTester:android:app:assembleRelease

--- a/scripts/android-e2e-test.js
+++ b/scripts/android-e2e-test.js
@@ -94,7 +94,7 @@ describe('Android Test App', function() {
         err => {
           // ignoring if Reload JS button can't be located
         },
-      )
+      );
   });
 
   after(function() {

--- a/scripts/android-e2e-test.js
+++ b/scripts/android-e2e-test.js
@@ -84,7 +84,7 @@ describe('Android Test App', function() {
     // This is fixed by clicking Reload JS which will trigger a request to packager server
     return driver
       .init(desired)
-      .setImplicitWaitTimeout(5000, (a, b) => console.log(a, b))
+      .setImplicitWaitTimeout(5000)
       .waitForElementByXPath('//android.widget.Button[@text="Reload JS"]')
       .then(
         elem => {

--- a/scripts/android-e2e-test.js
+++ b/scripts/android-e2e-test.js
@@ -11,15 +11,15 @@
  *
  *
  * To set up:
- * - npm install --save-dev appium@1.5.1 mocha@2.4.5 wd@0.3.11 colors@1.0.3 pretty-data2@0.40.1
+ * - npm install --save-dev appium@1.11.1 mocha@2.4.5 wd@1.11.1 colors@1.0.3 pretty-data2@0.40.1
  * - cp <this file> <to app installation path>
- * - keytool -genkey -v -keystore android/keystores/debug.keystore -storepass android -alias androiddebugkey -keypass android -dname "CN=Android Debug,O=Android,C=US
+ * - keytool -genkey -v -keystore android/app/debug.keystore -storepass android -alias androiddebugkey -keypass android -keyalg RSA -keysize 2048 -validity 10000 -dname "CN=Android Debug,O=Android,C=US"
  *
  * To run this test:
  * - npm start
  * - node node_modules/.bin/appium
  * - (cd android && ./gradlew :app:copyDownloadableDepsToLibs)
- * - buck build android/app
+ * - react-native run-android
  * - node ../node_modules/.bin/_mocha ../android-e2e-test.js
  *
  * @format
@@ -77,24 +77,24 @@ describe('Android Test App', function() {
     const desired = {
       platformName: 'Android',
       deviceName: 'Android Emulator',
-      app: path.resolve('buck-out/gen/android/app/app.apk'),
+      app: path.resolve('android/app/build/outputs/apk/debug/app-debug.apk'),
     };
 
     // React Native in dev mode often starts with Red Box "Can't fibd variable __fbBatchedBridge..."
     // This is fixed by clicking Reload JS which will trigger a request to packager server
     return driver
       .init(desired)
-      .setImplicitWaitTimeout(5000)
+      .setImplicitWaitTimeout(5000, (a, b) => console.log(a, b))
       .waitForElementByXPath('//android.widget.Button[@text="Reload JS"]')
       .then(
         elem => {
           elem.click();
+          driver.sleep(2000);
         },
         err => {
           // ignoring if Reload JS button can't be located
         },
       )
-      .setImplicitWaitTimeout(150000);
   });
 
   after(function() {
@@ -104,9 +104,44 @@ describe('Android Test App', function() {
     return driver.quit();
   });
 
-  it('should have Hot Module Reloading working', function() {
-    const androidAppCode = fs.readFileSync('index.js', 'utf-8');
+  it('should display new content after a refresh', function() {
+    const androidAppCode = fs.readFileSync('App.js', 'utf-8');
     let intervalToUpdate;
+    return (
+      driver
+        .waitForElementByXPath(
+          '//android.widget.TextView[starts-with(@text, "Welcome to React Native!")]',
+        )
+        .then(() => {
+          fs.writeFileSync(
+            'App.js',
+            androidAppCode.replace(
+              'Welcome to React Native!',
+              'Welcome to React Native! Reloaded',
+            ),
+            'utf-8',
+          );
+        })
+        .sleep(1000)
+        // http://developer.android.com/reference/android/view/KeyEvent.html#KEYCODE_MENU
+        .pressDeviceKey(46)
+        .pressDeviceKey(46)
+        .sleep(2000)
+        .waitForElementByXPath(
+          '//android.widget.TextView[starts-with(@text, "Welcome to React Native! Reloaded")]',
+        )
+        .finally(() => {
+          clearInterval(intervalToUpdate);
+          fs.writeFileSync('App.js', androidAppCode, 'utf-8');
+          driver
+            .pressDeviceKey(46)
+            .pressDeviceKey(46)
+            .sleep(2000);
+        })
+    );
+  });
+
+  it('should have the menu available', function() {
     return (
       driver
         .waitForElementByXPath(
@@ -114,49 +149,9 @@ describe('Android Test App', function() {
         )
         // http://developer.android.com/reference/android/view/KeyEvent.html#KEYCODE_MENU
         .pressDeviceKey(82)
-        .elementByXPath(
-          '//android.widget.TextView[starts-with(@text, "Enable Hot Reloading")]',
-        )
-        .click()
         .waitForElementByXPath(
-          '//android.widget.TextView[starts-with(@text, "Welcome to React Native!")]',
+          '//android.widget.TextView[starts-with(@text, "Toggle Inspector")]',
         )
-        .then(() => {
-          let iteration = 0;
-          // CI environment can be quite slow and we can't guarantee that it can consistently motice a file change
-          // so we change the file every few seconds just in case
-          intervalToUpdate = setInterval(() => {
-            fs.writeFileSync(
-              'index.js',
-              androidAppCode.replace(
-                'Welcome to React Native!',
-                'Welcome to React Native with HMR!' + iteration,
-              ),
-              'utf-8',
-            );
-          }, 3000);
-        })
-        .waitForElementByXPath(
-          '//android.widget.TextView[starts-with(@text, "Welcome to React Native with HMR!")]',
-        )
-        .finally(() => {
-          clearInterval(intervalToUpdate);
-          fs.writeFileSync('index.js', androidAppCode, 'utf-8');
-        })
     );
-  });
-
-  it('should have Debug In Chrome working', function() {
-    // http://developer.android.com/reference/android/view/KeyEvent.html#KEYCODE_MENU
-    return driver
-      .waitForElementByXPath(
-        '//android.widget.TextView[starts-with(@text, "Welcome to React Native!")]',
-      )
-      .pressDeviceKey(82)
-      .elementByXPath('//android.widget.TextView[starts-with(@text, "Debug")]')
-      .click()
-      .waitForElementByXPath(
-        '//android.widget.TextView[starts-with(@text, "Welcome to React Native!")]',
-      );
   });
 });

--- a/scripts/run-ci-e2e-tests.js
+++ b/scripts/run-ci-e2e-tests.js
@@ -139,9 +139,6 @@ try {
     const appiumProcess = spawn('node', ['./node_modules/.bin/appium']);
     APPIUM_PID = appiumProcess.pid;
 
-    echo('Installing dependencies');
-    exec('yarn install');
-
     echo('Building the app');
     if (exec('react-native run-android').code) {
       echo('could not execute react-native run-android');

--- a/scripts/run-ci-e2e-tests.js
+++ b/scripts/run-ci-e2e-tests.js
@@ -107,7 +107,7 @@ try {
       tryExecNTimes(
         () =>
           exec(
-            'yarn add --dev appium@1.5.1 mocha@2.4.5 wd@0.3.11 colors@1.0.3 pretty-data2@0.40.1',
+            'yarn add --dev appium@1.11.1 mocha@2.4.5 wd@1.11.1 colors@1.0.3 pretty-data2@0.40.1',
             {silent: true},
           ).code,
         numberOfRetries,
@@ -123,17 +123,28 @@ try {
     echo('Downloading Maven deps');
     exec('./gradlew :app:copyDownloadableDepsToLibs');
     cd('..');
-    exec(
-      'keytool -genkey -v -keystore android/keystores/debug.keystore -storepass android -alias androiddebugkey -keypass android -dname "CN=Android Debug,O=Android,C=US"',
-    );
+
+    exec('rm android/app/debug.keystore');
+    if (
+      exec(
+        'keytool -genkey -v -keystore android/app/debug.keystore -storepass android -alias androiddebugkey -keypass android -keyalg RSA -keysize 2048 -validity 10000 -dname "CN=Android Debug,O=Android,C=US"',
+      ).code
+    ) {
+      echo('Key could not be generated');
+      exitCode = 1;
+      throw Error(exitCode);
+    }
 
     echo(`Starting appium server, ${APPIUM_PID}`);
     const appiumProcess = spawn('node', ['./node_modules/.bin/appium']);
     APPIUM_PID = appiumProcess.pid;
 
+    echo('Installing dependencies');
+    exec('yarn install');
+
     echo('Building the app');
-    if (exec('buck build android/app').code) {
-      echo('could not execute Buck build, is it installed and in PATH?');
+    if (exec('react-native run-android').code) {
+      echo('could not execute react-native run-android');
       exitCode = 1;
       throw Error(exitCode);
     }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
This PRs makes an attempt at fixing the set up of the Android end to end tests, and the tests themselves. The end goal is to re-enable the tests on CircleCI (see #23561 for more details).

The goal of this PR is to the end to end tests to a working state. Better tests can be added at a later point. 

I changed the tests using the menu button. These tests made something silently crash/hang, after which it was no longer possible to get an element or even get the source. A fix for this needs further investigation.

Also, I enabled the tests in the CircleCI config, however CircleCI is currently failing on them with the following error:
```
info Running /opt/android/platform-tools/adb -s emulator-5554 reverse tcp:8081 tcp:8081
error: closed
info Could not run adb reverse: Command failed: /opt/android/platform-tools/adb -s emulator-5554 reverse tcp:8081 tcp:8081
info Starting the app on emulator-5554 (/opt/android/platform-tools/adb -s emulator-5554 shell am start -n com.endtoendtest/com.endtoendtest.MainActivity)...
Starting: Intent { cmp=com.endtoendtest/.MainActivity }

Too long with no output (exceeded 10m0s)
```
Some help here would be appreciated. An alternative is to not enable the tests yet on CircleCI in this PR.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See http://facebook.github.io/react-native/docs/contributing#changelog for an example. -->

[Android] [fixed] - Fix and update end to end tests for Android

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
To 'test the tests' make sure you have an Android emulator running and execute `./scripts/run-ci-e2e-tests.js --android`. The setup takes quite a while, mostly due to `yarn pack`.

![Mar-15-2019 17-52-10](https://user-images.githubusercontent.com/15815208/54448086-36dbbb00-474b-11e9-9e0b-5c07f47a958f.gif)



