### PR TITLE
Resolve issue #23816, updated with recent merges

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/modules/image/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/image/BUCK
@@ -17,5 +17,6 @@ rn_android_library(
         react_native_target("java/com/facebook/react/common:common"),
         react_native_target("java/com/facebook/react/modules/fresco:fresco"),
         react_native_target("java/com/facebook/react/module/annotations:annotations"),
+	react_native_target("java/com/facebook/react/view/imagehelper:imagehelper"),
     ],
 )

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/image/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/image/BUCK
@@ -17,6 +17,6 @@ rn_android_library(
         react_native_target("java/com/facebook/react/common:common"),
         react_native_target("java/com/facebook/react/modules/fresco:fresco"),
         react_native_target("java/com/facebook/react/module/annotations:annotations"),
-        react_native_target("java/com/facebook/react/view/imagehelper:imagehelper"),
+        react_native_target("java/com/facebook/react/views/imagehelper:imagehelper"),
     ],
 )

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/image/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/image/BUCK
@@ -17,6 +17,6 @@ rn_android_library(
         react_native_target("java/com/facebook/react/common:common"),
         react_native_target("java/com/facebook/react/modules/fresco:fresco"),
         react_native_target("java/com/facebook/react/module/annotations:annotations"),
-	react_native_target("java/com/facebook/react/view/imagehelper:imagehelper"),
+        react_native_target("java/com/facebook/react/view/imagehelper:imagehelper"),
     ],
 )

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/image/ImageLoaderModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/image/ImageLoaderModule.java
@@ -34,7 +34,7 @@ import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.module.annotations.ReactModule;
-import com.facebook.react.views.iamgehelper.ImageSource;
+import com.facebook.react.views.imagehelper.ImageSource;
 
 @ReactModule(name = ImageLoaderModule.NAME)
 public class ImageLoaderModule extends ReactContextBaseJavaModule implements

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/image/ImageLoaderModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/image/ImageLoaderModule.java
@@ -141,7 +141,7 @@ public class ImageLoaderModule extends ReactContextBaseJavaModule implements
     }
 
     ImageSource source = new ImageSource(getReactApplicationContext(), uriString);
-    ImageRequest imageRequestBuilder = ImageRequestBuilder.newBuilderWithSource(source.getUri());
+    ImageRequestBuilder imageRequestBuilder = ImageRequestBuilder.newBuilderWithSource(source.getUri());
     ImageRequest request = ReactNetworkImageRequest.fromBuilderWithHeaders(imageRequestBuilder, headers);
 
     DataSource<CloseableReference<CloseableImage>> dataSource =

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/image/ImageLoaderModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/image/ImageLoaderModule.java
@@ -34,6 +34,7 @@ import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.module.annotations.ReactModule;
+import com.facebook.react.views.iamgehelper.ImageSource;
 
 @ReactModule(name = ImageLoaderModule.NAME)
 public class ImageLoaderModule extends ReactContextBaseJavaModule implements
@@ -79,8 +80,8 @@ public class ImageLoaderModule extends ReactContextBaseJavaModule implements
       return;
     }
 
-    Uri uri = Uri.parse(uriString);
-    ImageRequest request = ImageRequestBuilder.newBuilderWithSource(uri).build();
+    ImageSource source = new ImageSource(getReactApplicationContext(), uriString);
+    ImageRequest request = ImageRequestBuilder.newBuilderWithSource(source.getUri()).build();
 
     DataSource<CloseableReference<CloseableImage>> dataSource =
       Fresco.getImagePipeline().fetchDecodedImage(request, mCallerContext);
@@ -139,8 +140,8 @@ public class ImageLoaderModule extends ReactContextBaseJavaModule implements
       return;
     }
 
-    Uri uri = Uri.parse(uriString);
-    ImageRequestBuilder imageRequestBuilder = ImageRequestBuilder.newBuilderWithSource(uri);
+    ImageSource source = new ImageSource(getReactApplicationContext(), uriString);
+    ImageRequest imageRequestBuilder = ImageRequestBuilder.newBuilderWithSource(source.getUri());
     ImageRequest request = ReactNetworkImageRequest.fromBuilderWithHeaders(imageRequestBuilder, headers);
 
     DataSource<CloseableReference<CloseableImage>> dataSource =


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

This fixes #23816, which states that `getSize()` does not function correctly on Android. The original PR for this is now outdated as there have been merges into master that would create merge conflicts.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See http://facebook.github.io/react-native/docs/contributing#changelog for an example. -->

[Android] [Fixed] - Added correct handling for `getSize()` to avoid warnings being thrown.import 

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

```js
import React, { Component } from 'react';
import { View, Image } from 'react-native';

export default () => {
    console.log(JSON.stringify(Image.getSize('test_image')))

    return <View />
}
```

Running this on an android device, with an image named `test_image` in `Drawable`, will correctly log the image's dimensions and will not throw a warning saying `Failed to get size for image: test_image`.