### PR TITLE
Fix prop overrides of TouchableWithoutFeedback

### DIFF
--- a/Libraries/Components/Touchable/TouchableWithoutFeedback.js
+++ b/Libraries/Components/Touchable/TouchableWithoutFeedback.js
@@ -50,11 +50,14 @@ const OVERRIDE_PROPS = [
   'accessibilityComponentType',
   'accessibilityLabel',
   'accessibilityHint',
+  'accessibilityIgnoresInvertColors',
   'accessibilityRole',
   'accessibilityStates',
   'accessibilityTraits',
   'hitSlop',
   'nativeID',
+  'onBlur',
+  'onFocus',
   'onLayout',
   'testID',
 ];
@@ -105,6 +108,7 @@ const TouchableWithoutFeedback = ((createReactClass({
     accessibilityComponentType: PropTypes.oneOf(
       DeprecatedAccessibilityComponentTypes,
     ),
+    accessibilityIgnoresInvertColors: PropTypes.bool,
     accessibilityRole: PropTypes.oneOf(DeprecatedAccessibilityRoles),
     accessibilityStates: PropTypes.arrayOf(
       PropTypes.oneOf(DeprecatedAccessibilityStates),

--- a/Libraries/Components/Touchable/TouchableWithoutFeedback.js
+++ b/Libraries/Components/Touchable/TouchableWithoutFeedback.js
@@ -46,6 +46,19 @@ type FocusEvent = TargetEvent;
 
 const PRESS_RETENTION_OFFSET = {top: 20, left: 20, right: 20, bottom: 30};
 
+const OVERRIDE_PROPS = [
+  'accessibilityComponentType',
+  'accessibilityLabel',
+  'accessibilityHint',
+  'accessibilityRole',
+  'accessibilityStates',
+  'accessibilityTraits',
+  'hitSlop',
+  'nativeID',
+  'onLayout',
+  'testID',
+];
+
 export type Props = $ReadOnly<{|
   accessible?: ?boolean,
   accessibilityComponentType?: ?AccessibilityComponentType,
@@ -239,18 +252,16 @@ const TouchableWithoutFeedback = ((createReactClass({
         Touchable.renderDebugView({color: 'red', hitSlop: this.props.hitSlop}),
       );
     }
+
+    const overrides = {};
+    for (const prop of OVERRIDE_PROPS) {
+      if (this.props[prop] !== undefined) {
+        overrides[prop] = this.props[prop];
+      }
+    }
+
     return (React: any).cloneElement(child, {
-      accessible: this.props.accessible !== false,
-      accessibilityLabel: this.props.accessibilityLabel,
-      accessibilityHint: this.props.accessibilityHint,
-      accessibilityComponentType: this.props.accessibilityComponentType,
-      accessibilityRole: this.props.accessibilityRole,
-      accessibilityStates: this.props.accessibilityStates,
-      accessibilityTraits: this.props.accessibilityTraits,
-      nativeID: this.props.nativeID,
-      testID: this.props.testID,
-      onLayout: this.props.onLayout,
-      hitSlop: this.props.hitSlop,
+      ...overrides,
       onStartShouldSetResponder: this.touchableHandleStartShouldSetResponder,
       onResponderTerminationRequest: this
         .touchableHandleResponderTerminationRequest,

--- a/Libraries/Components/Touchable/TouchableWithoutFeedback.js
+++ b/Libraries/Components/Touchable/TouchableWithoutFeedback.js
@@ -266,6 +266,7 @@ const TouchableWithoutFeedback = ((createReactClass({
 
     return (React: any).cloneElement(child, {
       ...overrides,
+      accessible: this.props.accessible !== false,
       onStartShouldSetResponder: this.touchableHandleStartShouldSetResponder,
       onResponderTerminationRequest: this
         .touchableHandleResponderTerminationRequest,


### PR DESCRIPTION
## Summary

Child props were being overridden by `<Touchable>` props even when the `<Touchable>` props were undefined.

## Changelog

[General] [Fixed] - Prevent prop override by TouchableWithoutFeedback when undefined

## Test Plan

None yet