### PR TITLE
Fix native implementation of `Animated.modulo`

### DIFF
--- a/Libraries/NativeAnimation/Nodes/RCTModuloAnimatedNode.m
+++ b/Libraries/NativeAnimation/Nodes/RCTModuloAnimatedNode.m
@@ -15,7 +15,8 @@
   NSNumber *inputNode = self.config[@"input"];
   NSNumber *modulus = self.config[@"modulus"];
   RCTValueAnimatedNode *parent = (RCTValueAnimatedNode *)[self.parentNodes objectForKey:inputNode];
-  self.value = fmodf(parent.value, modulus.floatValue);
+  const float m = modulus.floatValue;
+  self.value = fmodf(fmodf(parent.value, m) + m, m);
 }
 
 @end

--- a/ReactAndroid/src/main/java/com/facebook/react/animated/ModulusAnimatedNode.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/animated/ModulusAnimatedNode.java
@@ -29,7 +29,8 @@ import com.facebook.react.bridge.ReadableMap;
   public void update() {
     AnimatedNode animatedNode = mNativeAnimatedNodesManager.getNodeById(mInputNode);
     if (animatedNode != null && animatedNode instanceof ValueAnimatedNode) {
-      mValue = ((ValueAnimatedNode) animatedNode).getValue() % mModulus;
+      final double value = ((ValueAnimatedNode) animatedNode).getValue();
+      mValue = (value % mModulus + mModulus) % mModulus;
     } else {
       throw new JSApplicationCausedNativeException("Illegal node ID set as an input for " +
         "Animated.modulus node");


### PR DESCRIPTION
fixes #23875
[ios,android][fixes] incorrect behavior of `Animated.modulo`

Use the same formula as used in js: `mod(a,m)=>(a % m + m) % m` (https://github.com/facebook/react-native/blob/master/Libraries/Animated/src/nodes/AnimatedModulo.js#L35)

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Native implementation of `Animated.modulo` was different from what was used in javascript, more details available here: https://github.com/facebook/react-native/issues/23875

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See http://facebook.github.io/react-native/docs/contributing#changelog for an example. -->

[iOS] [Fixed] incorrect behavior of Animated.modulo
[Android] [Fixed] incorrect behavior of Animated.modulo




## Test Plan

1. `$ git clone https://github.com/maxkomarychev/rn-animated-modulo-bug.git --branch=with-fix`
2. `$ yarn`
3. in separate terminal: `$ yarn start`
4. `$ react-native run-ios` and observe boxes are moving identically for native and js drivers.