### PR TITLE
fix switch trackColor on Android. fixes #23962

### DIFF
--- a/RNTester/js/SwitchExample.js
+++ b/RNTester/js/SwitchExample.js
@@ -54,6 +54,10 @@ class BasicSwitchExample extends React.Component<
           <Switch
             testID="on-off-initial-off"
             onValueChange={value => this.setState({falseSwitchIsOn: value})}
+            trackColor={{
+              true: "yellow",
+              false: "purple",
+            }}
             value={this.state.falseSwitchIsOn}
           />
           <OnOffIndicator

--- a/RNTester/js/SwitchExample.js
+++ b/RNTester/js/SwitchExample.js
@@ -55,8 +55,8 @@ class BasicSwitchExample extends React.Component<
             testID="on-off-initial-off"
             onValueChange={value => this.setState({falseSwitchIsOn: value})}
             trackColor={{
-              true: "yellow",
-              false: "purple",
+              true: 'yellow',
+              false: 'purple',
             }}
             value={this.state.falseSwitchIsOn}
           />

--- a/ReactAndroid/src/main/java/com/facebook/react/views/switchview/ReactSwitch.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/switchview/ReactSwitch.java
@@ -36,6 +36,7 @@ import javax.annotation.Nullable;
     if (mAllowChange && isChecked() != checked) {
       mAllowChange = false;
       super.setChecked(checked);
+      setTrackColor(checked);
     }
   }
 
@@ -59,12 +60,7 @@ import javax.annotation.Nullable;
     // If the switch has a different value than the value sent by JS, we must change it.
     if (isChecked() != on) {
       super.setChecked(on);
-      if (mTrackColorForTrue != null || mTrackColorForFalse != null) {
-        // Update the track color to reflect the new value. We only want to do this if these
-        // props were actually set from JS; otherwise we'll just reset the color to the default.
-        Integer currentTrackColor = on ? mTrackColorForTrue : mTrackColorForFalse;
-        setTrackColor(currentTrackColor);
-      }
+      setTrackColor(on);
     }
     mAllowChange = true;
   }
@@ -88,6 +84,15 @@ import javax.annotation.Nullable;
     mTrackColorForFalse = color;
     if (!isChecked()) {
       setTrackColor(mTrackColorForFalse);
+    }
+  }
+
+  private void setTrackColor(boolean checked) {
+    if (mTrackColorForTrue != null || mTrackColorForFalse != null) {
+      // Update the track color to reflect the new value. We only want to do this if these
+      // props were actually set from JS; otherwise we'll just reset the color to the default.
+      Integer currentTrackColor = checked ? mTrackColorForTrue : mTrackColorForFalse;
+      setTrackColor(currentTrackColor);
     }
   }
 }


### PR DESCRIPTION
## Summary

fixes #23962, where trackColor is reset when value changed. This PR will set trackColor corresponding trackColor every-time value changes.

## Changelog

[Android] [Changed] - Fix Switch trackColor

## Test Plan

CI is green, and added example to RNTester app.