### PR TITLE
Remove unused argument in AppRegistry

### DIFF
--- a/Libraries/ReactNative/AppRegistry.js
+++ b/Libraries/ReactNative/AppRegistry.js
@@ -109,10 +109,7 @@ const AppRegistry = {
       componentProvider,
       run: appParameters => {
         renderApplication(
-          componentProviderInstrumentationHook(
-            componentProvider,
-            scopedPerformanceLogger,
-          ),
+          componentProviderInstrumentationHook(componentProvider),
           appParameters.initialProps,
           appParameters.rootTag,
           wrapperComponentProvider && wrapperComponentProvider(appParameters),


### PR DESCRIPTION
## Summary

The function `componentProviderInstrumentationHook` is defined in the same file and only accepts one argument, but is called with two. I've removed the second one, as it is not used (and might confuse readers).

For easier reference, this is the definition of that function:

```
let componentProviderInstrumentationHook: ComponentProviderInstrumentationHook = (
  component: ComponentProvider,
) => component();
```

## Changelog

Not necessary, as it does not change functionality.

## Test Plan

I would argue that this does not require testing: It removes a parameter that was not used before, so it should not change the behavior of the touched file in any way.
