### PR TITLE
Add missing mock for AccessibilityInfo

### DIFF
--- a/jest/setup.js
+++ b/jest/setup.js
@@ -67,6 +67,19 @@ jest
   .mock('ensureComponentIsNative', () => () => true);
 
 const mockNativeModules = {
+  AccessibilityInfo: {
+    addEventListener: jest.fn(),
+    announceForAccessibility: jest.fn(),
+    fetch: jest.fn(),
+    isBoldTextEnabled: jest.fn(),
+    isGrayscaleEnabled: jest.fn(),
+    isInvertColorsEnabled: jest.fn(),
+    isReduceMotionEnabled: jest.fn(),
+    isReduceTransparencyEnabled: jest.fn(),
+    isScreenReaderEnabled: jest.fn(),
+    removeEventListener: jest.fn(),
+    setAccessibilityFocus: jest.fn(),
+  },
   AlertManager: {
     alertWithArgs: jest.fn(),
   },


### PR DESCRIPTION
## Summary

I've realized after #23839 got merged, that `AccessibilityInfo` doesn't have a jest mock the same way as the other frameworks do.

## Changelog

This PR adds the testing mock for `AccessibilityInfo`.

## Test Plan

N/A