### PR TITLE
use Conscrypt as security provider if available

### DIFF
--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -324,6 +324,7 @@ dependencies {
     api("com.facebook.fresco:imagepipeline-okhttp3:${FRESCO_VERSION}")
     api("com.facebook.soloader:soloader:${SO_LOADER_VERSION}")
     api("com.google.code.findbugs:jsr305:3.0.2")
+    implementation('org.conscrypt:conscrypt-android:2.0.0')
     api("com.squareup.okhttp3:okhttp:${OKHTTP_VERSION}")
     api("com.squareup.okhttp3:okhttp-urlconnection:${OKHTTP_VERSION}")
     api("com.squareup.okio:okio:1.15.0")

--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -324,7 +324,6 @@ dependencies {
     api("com.facebook.fresco:imagepipeline-okhttp3:${FRESCO_VERSION}")
     api("com.facebook.soloader:soloader:${SO_LOADER_VERSION}")
     api("com.google.code.findbugs:jsr305:3.0.2")
-    implementation('org.conscrypt:conscrypt-android:2.0.0')
     api("com.squareup.okhttp3:okhttp:${OKHTTP_VERSION}")
     api("com.squareup.okhttp3:okhttp-urlconnection:${OKHTTP_VERSION}")
     api("com.squareup.okio:okio:1.15.0")

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/network/OkHttpClientProvider.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/network/OkHttpClientProvider.java
@@ -13,6 +13,8 @@ import android.os.Build;
 import com.facebook.common.logging.FLog;
 
 import java.io.File;
+import java.security.Provider;
+import java.security.Security;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -69,7 +71,14 @@ public class OkHttpClientProvider {
       .writeTimeout(0, TimeUnit.MILLISECONDS)
       .cookieJar(new ReactCookieJarContainer());
 
-    return enableTls12OnPreLollipop(client);
+    try {
+      Class ConscryptProvider = Class.forName("org.conscrypt.OpenSSLProvider");
+      Security.insertProviderAt(
+        (Provider) ConscryptProvider.newInstance(), 1);
+      return client;
+    } catch (Exception e) {
+      return enableTls12OnPreLollipop(client);
+    }
   }
 
   public static OkHttpClient.Builder createClientBuilder(Context context) {


### PR DESCRIPTION
## Summary

This PR adds support to use Conscrypt as Security Provider if available runtime. Consscrypt supports TLS 1.2 on Android 4.x and TLS 1.3 on all Android versions. Fixes issues (ex https://github.com/facebook/react-native/issues/23151) with HTTPS connections on Android 4.x.

Just add below to your project build.gradle and it'll use it.

```gradle
implementation('org.conscrypt:conscrypt-android:2.0.0')
```

## Changelog

[Android] [Changed] - Add TLS 1.3 support to all Android versions using Conscrypt.

## Test Plan

CI is green and TLS 1.2 connections work on Android, 