### PR TITLE
Add tests for Geolocation module

### DIFF
--- a/Libraries/Geolocation/Geolocation.js
+++ b/Libraries/Geolocation/Geolocation.js
@@ -57,7 +57,7 @@ const Geolocation = {
   },
 
   /*
-   * Requests suitable Location permission based on the key configured on pList.
+   * Requests Location permissions based on the key configured on pList.
    *
    * See https://facebook.github.io/react-native/docs/geolocation.html#requestauthorization
    */

--- a/Libraries/Geolocation/Geolocation.js
+++ b/Libraries/Geolocation/Geolocation.js
@@ -57,7 +57,7 @@ const Geolocation = {
   },
 
   /*
-   * Request suitable Location permission based on the key configured on pList.
+   * Requests suitable Location permission based on the key configured on pList.
    *
    * See https://facebook.github.io/react-native/docs/geolocation.html#requestauthorization
    */
@@ -126,6 +126,11 @@ const Geolocation = {
     return watchID;
   },
 
+  /*
+   * Unsubscribes the watcher with the given watchID.
+   *
+   * See https://facebook.github.io/react-native/docs/geolocation.html#clearwatch
+   */
   clearWatch: function(watchID: number) {
     const sub = subscriptions[watchID];
     if (!sub) {
@@ -150,6 +155,11 @@ const Geolocation = {
     }
   },
 
+  /*
+   * Stops observing for device location changes and removes all registered listeners.
+   *
+   * See https://facebook.github.io/react-native/docs/geolocation.html#stopobserving
+   */
   stopObserving: function() {
     if (updatesEnabled) {
       RCTLocationObserver.stopObserving();

--- a/Libraries/Geolocation/__tests__/Geolocation-test.js
+++ b/Libraries/Geolocation/__tests__/Geolocation-test.js
@@ -25,50 +25,68 @@ describe('Geolocation', () => {
 
   it('should set the location observer configuration', () => {
     Geolocation.setRNConfiguration({skipPermissionRequests: true});
-    expect(NativeModules.LocationObserver.setConfiguration.mock.calls.length).toEqual(1);
+    expect(
+      NativeModules.LocationObserver.setConfiguration.mock.calls.length,
+    ).toEqual(1);
   });
 
   it('should request authorization for location requests', () => {
     Geolocation.requestAuthorization();
-    expect(NativeModules.LocationObserver.requestAuthorization.mock.calls.length).toEqual(1);
+    expect(
+      NativeModules.LocationObserver.requestAuthorization.mock.calls.length,
+    ).toEqual(1);
   });
 
   it('should get the current position and pass it to the given callback', () => {
     const callback = () => {};
     Geolocation.getCurrentPosition(callback);
-    expect(NativeModules.LocationObserver.getCurrentPosition.mock.calls.length).toEqual(1);
-    expect(NativeModules.LocationObserver.getCurrentPosition.mock.calls[0][1]).toBe(callback);
+    expect(
+      NativeModules.LocationObserver.getCurrentPosition.mock.calls.length,
+    ).toEqual(1);
+    expect(
+      NativeModules.LocationObserver.getCurrentPosition.mock.calls[0][1],
+    ).toBe(callback);
   });
 
   it('should add a success listener to the geolocation', () => {
     const watchID = Geolocation.watchPosition(() => {});
     expect(watchID).toEqual(0);
-    expect(NativeModules.LocationObserver.addListener.mock.calls[0][0]).toBe('geolocationDidChange');
+    expect(NativeModules.LocationObserver.addListener.mock.calls[0][0]).toBe(
+      'geolocationDidChange',
+    );
   });
 
   it('should add an error listener to the geolocation', () => {
     const watchID = Geolocation.watchPosition(() => {}, () => {});
     expect(watchID).toEqual(0);
-    expect(NativeModules.LocationObserver.addListener.mock.calls[1][0]).toBe('geolocationError');
+    expect(NativeModules.LocationObserver.addListener.mock.calls[1][0]).toBe(
+      'geolocationError',
+    );
   });
 
   it('should clear the listeners associated with a watchID', () => {
     const watchID = Geolocation.watchPosition(() => {}, () => {});
     Geolocation.clearWatch(watchID);
-    expect(NativeModules.LocationObserver.stopObserving.mock.calls.length).toBe(1);
+    expect(NativeModules.LocationObserver.stopObserving.mock.calls.length).toBe(
+      1,
+    );
   });
 
   it('should correctly assess if all listeners have been cleared', () => {
     const watchID = Geolocation.watchPosition(() => {}, () => {});
     Geolocation.watchPosition(() => {}, () => {});
     Geolocation.clearWatch(watchID);
-    expect(NativeModules.LocationObserver.stopObserving.mock.calls.length).toBe(0);
+    expect(NativeModules.LocationObserver.stopObserving.mock.calls.length).toBe(
+      0,
+    );
   });
 
   it('should not fail if the watchID one wants to clear does not exist', () => {
     Geolocation.watchPosition(() => {}, () => {});
     Geolocation.clearWatch(42);
-    expect(NativeModules.LocationObserver.stopObserving.mock.calls.length).toBe(0);
+    expect(NativeModules.LocationObserver.stopObserving.mock.calls.length).toBe(
+      0,
+    );
   });
 
   it('should stop observing and warn about removing existing subscriptions', () => {
@@ -76,7 +94,9 @@ describe('Geolocation', () => {
     jest.mock('fbjs/lib/warning', () => warningCallback);
     Geolocation.watchPosition(() => {}, () => {});
     Geolocation.stopObserving();
-    expect(NativeModules.LocationObserver.stopObserving.mock.calls.length).toBe(1);
+    expect(NativeModules.LocationObserver.stopObserving.mock.calls.length).toBe(
+      1,
+    );
     expect(warningCallback.mock.calls.length).toBeGreaterThanOrEqual(1);
   });
 });

--- a/Libraries/Geolocation/__tests__/Geolocation-test.js
+++ b/Libraries/Geolocation/__tests__/Geolocation-test.js
@@ -58,7 +58,7 @@ describe('Geolocation', () => {
     expect(NativeModules.LocationObserver.stopObserving.mock.calls.length).toBe(1);
   });
 
-  it('should correctly identify if all listeners have been cleared', () => {
+  it('should correctly assess if all listeners have been cleared', () => {
     const watchID = Geolocation.watchPosition(() => {}, () => {});
     Geolocation.watchPosition(() => {}, () => {});
     Geolocation.clearWatch(watchID);

--- a/Libraries/Geolocation/__tests__/Geolocation-test.js
+++ b/Libraries/Geolocation/__tests__/Geolocation-test.js
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @emails oncall+react_native
+ */
+
+'use strict';
+
+describe('Geolocation', () => {
+  let Geolocation;
+  const NativeModules = require('NativeModules');
+
+  beforeEach(() => {
+    jest.resetModules();
+    Geolocation = jest.requireActual('Geolocation');
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should set the location observer configuration', () => {
+    Geolocation.setRNConfiguration({skipPermissionRequests: true});
+    expect(NativeModules.LocationObserver.setConfiguration.mock.calls.length).toEqual(1);
+  });
+
+  it('should request authorization for location requests', () => {
+    Geolocation.requestAuthorization();
+    expect(NativeModules.LocationObserver.requestAuthorization.mock.calls.length).toEqual(1);
+  });
+
+  it('should get the current position and pass it to the given callback', () => {
+    const callback = () => {};
+    Geolocation.getCurrentPosition(callback);
+    expect(NativeModules.LocationObserver.getCurrentPosition.mock.calls.length).toEqual(1);
+    expect(NativeModules.LocationObserver.getCurrentPosition.mock.calls[0][1]).toBe(callback);
+  });
+
+  it('should add a success listener to the geolocation', () => {
+    const watchID = Geolocation.watchPosition(() => {});
+    expect(watchID).toEqual(0);
+    expect(NativeModules.LocationObserver.addListener.mock.calls[0][0]).toBe('geolocationDidChange');
+  });
+
+  it('should add an error listener to the geolocation', () => {
+    const watchID = Geolocation.watchPosition(() => {}, () => {});
+    expect(watchID).toEqual(0);
+    expect(NativeModules.LocationObserver.addListener.mock.calls[1][0]).toBe('geolocationError');
+  });
+
+  it('should clear the listeners associated with a watchID', () => {
+    const watchID = Geolocation.watchPosition(() => {}, () => {});
+    Geolocation.clearWatch(watchID);
+    expect(NativeModules.LocationObserver.stopObserving.mock.calls.length).toBe(1);
+  });
+
+  it('should correctly identify if all listeners have been cleared', () => {
+    const watchID = Geolocation.watchPosition(() => {}, () => {});
+    Geolocation.watchPosition(() => {}, () => {});
+    Geolocation.clearWatch(watchID);
+    expect(NativeModules.LocationObserver.stopObserving.mock.calls.length).toBe(0);
+  });
+
+  it('should not fail if the watchID one wants to clear does not exist', () => {
+    Geolocation.watchPosition(() => {}, () => {});
+    Geolocation.clearWatch(42);
+    expect(NativeModules.LocationObserver.stopObserving.mock.calls.length).toBe(0);
+  });
+
+  it('should stop observing and warn about removing existing subscriptions', () => {
+    const warningCallback = jest.fn();
+    jest.mock('fbjs/lib/warning', () => warningCallback);
+    Geolocation.watchPosition(() => {}, () => {});
+    Geolocation.stopObserving();
+    expect(NativeModules.LocationObserver.stopObserving.mock.calls.length).toBe(1);
+    expect(warningCallback.mock.calls.length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/jest/setup.js
+++ b/jest/setup.js
@@ -158,7 +158,11 @@ const mockNativeModules = {
     sendIntent: jest.fn(),
   },
   LocationObserver: {
+    addListener: jest.fn(),
     getCurrentPosition: jest.fn(),
+    removeListeners: jest.fn(),
+    requestAuthorization: jest.fn(),
+    setConfiguration: jest.fn(),
     startObserving: jest.fn(),
     stopObserving: jest.fn(),
   },


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

This PR adds a number of unit tests for the Geolocation module, as a follow-up of #23903. I also added two missing documentation strings to that module, with references to the online documentation, for consistency with the other methods in the same module.

## Changelog

Not applicable, since it only adds tests.

## Test Plan

Not applicable, since it only adds tests (this PR is its own testing plan 😛).