### PR TITLE
land androidx in gradle

### DIFF
--- a/RNTester/android/app/build.gradle
+++ b/RNTester/android/app/build.gradle
@@ -136,7 +136,6 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'com.android.support:appcompat-v7:28.0.0'
 
     // Build React Native from source
     implementation project(':ReactAndroid')

--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -319,7 +319,7 @@ android {
 dependencies {
     api("com.facebook.infer.annotation:infer-annotation:0.11.2")
     api("javax.inject:javax.inject:1")
-    api("com.android.support:appcompat-v7:28.0.0")
+    api("androidx.appcompat:appcompat:1.0.2")
     api("com.facebook.fresco:fresco:${FRESCO_VERSION}")
     api("com.facebook.fresco:imagepipeline-okhttp3:${FRESCO_VERSION}")
     api("com.facebook.soloader:soloader:${SO_LOADER_VERSION}")

--- a/template/android/app/build.gradle
+++ b/template/android/app/build.gradle
@@ -153,7 +153,6 @@ android {
 
 dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
-    implementation "com.android.support:appcompat-v7:${rootProject.ext.supportLibVersion}"
     implementation "com.facebook.react:react-native:+"  // From node_modules
 }
 


### PR DESCRIPTION
## Summary

Use AndroidX in ReactAndroid/build.gradle, and remove androidx dependency from template and RNTester app because it's already exposed/exported from ReactAndroid.

## Changelog

[Android] [Changed] - Land AndroidX in gradle

## Test Plan

CI is green