### PR TITLE
There is a small gap in the SynchronizedWeakHashSet implementation. T…

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactContext.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactContext.java
@@ -176,14 +176,17 @@ public class ReactContext extends ContextWrapper {
               new Runnable() {
                 @Override
                 public void run() {
-                  if (!mLifecycleEventListeners.contains(listener)) {
-                    return;
-                  }
-                  try {
-                    listener.onHostResume();
-                  } catch (RuntimeException e) {
-                    handleException(e);
-                  }
+
+                  mLifecycleEventListeners.doIfContains(listener, new Runnable() {
+                    @Override
+                    public void run() {
+                      try {
+                        listener.onHostResume();
+                      } catch (RuntimeException e) {
+                        handleException(e);
+                      }
+                    }
+                  });
                 }
               });
           break;


### PR DESCRIPTION
## Summary
There is a small gap in the SynchronizedWeakHashSet implementation - the containsKey method of the WeakHashMap is modifying hence calling it during the iteration might cause ConcurrentModificationException. Added a command DO_IF_CONTAINS to safely handle this case.

## Changelog
[Android] [Bugfix] - Should fix a ConcurrentModificationException in onResume.

## Test Plan
It is hard to reproduce this problem as this is a race condition.
You rather need to have a good set of integration tests or check it in production.
