### PR TITLE
[Fabric] Reorder prepareForRecycle before adding recycle pool

### DIFF
--- a/React/Fabric/Mounting/RCTComponentViewRegistry.mm
+++ b/React/Fabric/Mounting/RCTComponentViewRegistry.mm
@@ -205,8 +205,6 @@ const NSInteger RCTComponentViewRegistryRecyclePoolMaxSize = 1024;
                                    componentView:(UIView<RCTComponentViewProtocol> *)componentView
 {
   RCTAssertMainQueue();
-  [componentView prepareForRecycle];
-
   NSHashTable<UIView<RCTComponentViewProtocol> *> *componentViews =
       [_recyclePool objectForKey:(__bridge id)(void *)componentHandle];
   if (!componentViews) {
@@ -218,6 +216,7 @@ const NSInteger RCTComponentViewRegistryRecyclePoolMaxSize = 1024;
     return;
   }
 
+  [componentView prepareForRecycle];
   [componentViews addObject:componentView];
 }
 


### PR DESCRIPTION
## Summary

Put `prepareForRecycle` to last before enqueue to recycle pool, ensure only call it when count lower than RCTComponentViewRegistryRecyclePoolMaxSize.

cc. @shergin .

## Changelog

[General] [Changed] - Reorder prepareForRecycle before adding recycle pool

## Test Plan

N/A.