### PR TITLE
Fixed regression in SectionList caused by #21577 not being able to scroll to top on android

### DIFF
--- a/Libraries/Lists/VirtualizedSectionList.js
+++ b/Libraries/Lists/VirtualizedSectionList.js
@@ -146,7 +146,7 @@ class VirtualizedSectionList<SectionT: SectionBase> extends React.PureComponent<
     sectionIndex: number,
     viewPosition?: number,
   }) {
-    let index = Platform.OS === 'ios' ? params.itemIndex : params.itemIndex - 1;
+    let index = Platform.OS === 'ios' ? params.itemIndex : params.itemIndex + 1;
     for (let ii = 0; ii < params.sectionIndex; ii++) {
       index += this.props.sections[ii].data.length + 2;
     }


### PR DESCRIPTION
## Summary

#21577 (@melina7890, @cpojer) changed the statement 
```
let index = params.itemIndex + 1;
```
to 
```
let index = Platform.OS === 'ios' ? params.itemIndex : params.itemIndex - 1;
```
to fix an issue on iOS. Note however, how the sign for non iOS changed from `+` to `-` causing a crash on Android when trying to scroll to index 0 as that will be evaluated to -1 instead of 1 and thus be out of bounds.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See http://facebook.github.io/react-native/docs/contributing#changelog for an example. -->

[Android] [Fixed] - Fixed regression in SectionList caused by #21577 not being able to scroll to top on android

## Test Plan

Scroll a SectionList to the top with 
```
scrollToLocation({
  animated: true,
  itemIndex: 0,
  sectionIndex: 0,
});
```
Crashes on Android. Does not crash when this patch is applied. Other than that see #21577 for previous Testplan