### PR TITLE
Remove `-p` calls from `shasum`.

### DIFF
--- a/scripts/ios-install-third-party.sh
+++ b/scripts/ios-install-third-party.sh
@@ -32,12 +32,12 @@ function fetch_and_unpack () {
 
     while true; do
         if [ -f "$cachedir/$file" ]; then
-           if shasum -p "$cachedir/$file" |
+           if shasum "$cachedir/$file" |
                awk -v hash="$hash" '{exit $1 != hash}'; then
                break
            else
                echo "Incorrect hash:" 2>&1
-               shasum -p "$cachedir/$file" 2>&1
+               shasum "$cachedir/$file" 2>&1
                echo "Retrying..." 2>&1
            fi
         fi


### PR DESCRIPTION
## Summary

Fixes #22873. Given that this code is meant to only work on macOS, we should be fine not using a portable hash. In the packages for which this matters at the bottom of this file, it produces the same hashes so it should be fine.

## Changelog

[General] [Fixed] - Don't use `-p` when invoking shasum.

## Test Plan

Verified that the shasum on macOS for the currently listed packages on the bottom of the file are the same using `-p` and not using it.