### PR TITLE
Update the license for RCTWrapperExample

### DIFF
--- a/Libraries/Wrapper/Example/RCTWrapperExampleView.h
+++ b/Libraries/Wrapper/Example/RCTWrapperExampleView.h
@@ -1,7 +1,10 @@
-// Copyright (c) Facebook, Inc. and its affiliates.
-//
-// This source code is licensed under the license found in the
-// LICENSE-examples file in the root directory of this source tree.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
 
 #import <UIKit/UIKit.h>
 

--- a/Libraries/Wrapper/Example/RCTWrapperExampleView.m
+++ b/Libraries/Wrapper/Example/RCTWrapperExampleView.m
@@ -1,7 +1,10 @@
-// Copyright (c) Facebook, Inc. and its affiliates.
-//
-// This source code is licensed under the license found in the
-// LICENSE-examples file in the root directory of this source tree.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
 
 #import "RCTWrapperExampleView.h"
 

--- a/Libraries/Wrapper/Example/RCTWrapperExampleViewController.h
+++ b/Libraries/Wrapper/Example/RCTWrapperExampleViewController.h
@@ -1,7 +1,10 @@
-// Copyright (c) Facebook, Inc. and its affiliates.
-//
-// This source code is licensed under the license found in the
-// LICENSE-examples file in the root directory of this source tree.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
 
 #import <UIKit/UIKit.h>
 

--- a/Libraries/Wrapper/Example/RCTWrapperExampleViewController.m
+++ b/Libraries/Wrapper/Example/RCTWrapperExampleViewController.m
@@ -1,7 +1,10 @@
-// Copyright (c) Facebook, Inc. and its affiliates.
-//
-// This source code is licensed under the license found in the
-// LICENSE-examples file in the root directory of this source tree.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
 
 #import "RCTWrapperExampleViewController.h"
 

--- a/Libraries/Wrapper/Example/RCTWrapperReactRootViewController.h
+++ b/Libraries/Wrapper/Example/RCTWrapperReactRootViewController.h
@@ -1,7 +1,10 @@
-// Copyright (c) Facebook, Inc. and its affiliates.
-//
-// This source code is licensed under the license found in the
-// LICENSE-examples file in the root directory of this source tree.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
 
 #import <UIKit/UIKit.h>
 

--- a/Libraries/Wrapper/Example/RCTWrapperReactRootViewController.m
+++ b/Libraries/Wrapper/Example/RCTWrapperReactRootViewController.m
@@ -1,7 +1,10 @@
-// Copyright (c) Facebook, Inc. and its affiliates.
-//
-// This source code is licensed under the license found in the
-// LICENSE-examples file in the root directory of this source tree.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
 
 #import "RCTWrapperReactRootViewController.h"
 

--- a/Libraries/Wrapper/Example/RCTWrapperReactRootViewManager.h
+++ b/Libraries/Wrapper/Example/RCTWrapperReactRootViewManager.h
@@ -1,7 +1,10 @@
-// Copyright (c) Facebook, Inc. and its affiliates.
-//
-// This source code is licensed under the license found in the
-// LICENSE-examples file in the root directory of this source tree.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
 
 #import <UIKit/UIKit.h>
 

--- a/Libraries/Wrapper/Example/RCTWrapperReactRootViewManager.m
+++ b/Libraries/Wrapper/Example/RCTWrapperReactRootViewManager.m
@@ -1,7 +1,10 @@
-// Copyright (c) Facebook, Inc. and its affiliates.
-//
-// This source code is licensed under the license found in the
-// LICENSE-examples file in the root directory of this source tree.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
 
 #import "RCTWrapperReactRootViewManager.h"
 


### PR DESCRIPTION
## Summary

The copyright headers in the Wrapper example referenced a license file that doesn't exist anymore. This PR updates the copyright header to match other example files in the repo

Fixes https://github.com/facebook/react-native/issues/23215

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See http://facebook.github.io/react-native/docs/contributing#changelog for an example. -->

[General] [Changed] Updated the license of RCTWrapperExample to match the rest of the Examples

## Test Plan
 
n/a