### PR TITLE
Fix PushNotificationIOS listeners

### DIFF
--- a/Libraries/EventEmitter/NativeEventEmitter.js
+++ b/Libraries/EventEmitter/NativeEventEmitter.js
@@ -16,7 +16,7 @@ const RCTDeviceEventEmitter = require('RCTDeviceEventEmitter');
 
 const invariant = require('invariant');
 
-import type EmitterSubscription from 'EmitterSubscription';
+import type EmitterSubscription from '../vendor/emitter/EmitterSubscription';
 
 type NativeModule = {
   +addListener: (eventType: string) => void,

--- a/Libraries/EventEmitter/NativeEventEmitter.js
+++ b/Libraries/EventEmitter/NativeEventEmitter.js
@@ -16,7 +16,7 @@ const RCTDeviceEventEmitter = require('RCTDeviceEventEmitter');
 
 const invariant = require('invariant');
 
-import type EmitterSubscription from '../vendor/emitter/EmitterSubscription';
+import type EmitterSubscription from 'EmitterSubscription';
 
 type NativeModule = {
   +addListener: (eventType: string) => void,

--- a/Libraries/PushNotificationIOS/PushNotificationIOS.js
+++ b/Libraries/PushNotificationIOS/PushNotificationIOS.js
@@ -187,43 +187,45 @@ class PushNotificationIOS {
   static addEventListener(
     type: PushNotificationEventName,
     handler: Function,
-  ): {remove: () => void} {
-    invariant(
-      type === 'notification' ||
-        type === 'register' ||
-        type === 'registrationError' ||
-        type === 'localNotification',
-      'PushNotificationIOS only supports `notification`, `register`, `registrationError`, and `localNotification` events',
-    );
+  ): {+remove: () => void} {
     let listener;
-    if (type === 'notification') {
-      listener = PushNotificationEmitter.addListener(
-        DEVICE_NOTIF_EVENT,
-        notifData => {
-          handler(new PushNotificationIOS(notifData));
-        },
-      );
-    } else if (type === 'localNotification') {
-      listener = PushNotificationEmitter.addListener(
-        DEVICE_LOCAL_NOTIF_EVENT,
-        notifData => {
-          handler(new PushNotificationIOS(notifData));
-        },
-      );
-    } else if (type === 'register') {
-      listener = PushNotificationEmitter.addListener(
-        NOTIF_REGISTER_EVENT,
-        registrationInfo => {
-          handler(registrationInfo.deviceToken);
-        },
-      );
-    } else if (type === 'registrationError') {
-      listener = PushNotificationEmitter.addListener(
-        NOTIF_REGISTRATION_ERROR_EVENT,
-        errorInfo => {
-          handler(errorInfo);
-        },
-      );
+    switch (type) {
+      case 'notification':
+        listener = PushNotificationEmitter.addListener(
+          DEVICE_NOTIF_EVENT,
+          notifData => {
+            handler(new PushNotificationIOS(notifData));
+          },
+        );
+        break;
+      case 'register':
+        listener = PushNotificationEmitter.addListener(
+          DEVICE_LOCAL_NOTIF_EVENT,
+          notifData => {
+            handler(new PushNotificationIOS(notifData));
+          },
+        );
+        break;
+      case 'register':
+        listener = PushNotificationEmitter.addListener(
+          NOTIF_REGISTER_EVENT,
+          registrationInfo => {
+            handler(registrationInfo.deviceToken);
+          },
+        );
+        break;
+      case 'registrationError':
+        listener = PushNotificationEmitter.addListener(
+          NOTIF_REGISTRATION_ERROR_EVENT,
+          errorInfo => {
+            handler(errorInfo);
+          },
+        );
+        break;
+      default:
+        throw new Error(
+          'PushNotificationIOS only supports `notification`, `register`, `registrationError`, and `localNotification` events',
+        );
     }
     _notifHandlers.set(handler, listener);
     return listener;

--- a/Libraries/PushNotificationIOS/PushNotificationIOS.js
+++ b/Libraries/PushNotificationIOS/PushNotificationIOS.js
@@ -247,7 +247,7 @@ class PushNotificationIOS {
       return;
     }
     listener.remove();
-    _notifHandlers.delete(type);
+    _notifHandlers.delete(handler);
   }
 
   /**

--- a/Libraries/PushNotificationIOS/PushNotificationIOS.js
+++ b/Libraries/PushNotificationIOS/PushNotificationIOS.js
@@ -198,7 +198,7 @@ class PushNotificationIOS {
           },
         );
         break;
-      case 'register':
+      case 'localNotification':
         listener = PushNotificationEmitter.addListener(
           DEVICE_LOCAL_NOTIF_EVENT,
           notifData => {

--- a/Libraries/PushNotificationIOS/PushNotificationIOS.js
+++ b/Libraries/PushNotificationIOS/PushNotificationIOS.js
@@ -222,7 +222,7 @@ class PushNotificationIOS {
         },
       );
     }
-    _notifHandlers.set(type, listener);
+    _notifHandlers.set(handler, listener);
   }
 
   /**
@@ -242,7 +242,7 @@ class PushNotificationIOS {
         type === 'localNotification',
       'PushNotificationIOS only supports `notification`, `register`, `registrationError`, and `localNotification` events',
     );
-    const listener = _notifHandlers.get(type);
+    const listener = _notifHandlers.get(handler);
     if (!listener) {
       return;
     }

--- a/Libraries/PushNotificationIOS/PushNotificationIOS.js
+++ b/Libraries/PushNotificationIOS/PushNotificationIOS.js
@@ -184,7 +184,10 @@ class PushNotificationIOS {
    *
    * See https://facebook.github.io/react-native/docs/pushnotificationios.html#addeventlistener
    */
-  static addEventListener(type: PushNotificationEventName, handler: Function) {
+  static addEventListener(
+    type: PushNotificationEventName,
+    handler: Function,
+  ): {remove: () => void} {
     invariant(
       type === 'notification' ||
         type === 'register' ||
@@ -223,6 +226,7 @@ class PushNotificationIOS {
       );
     }
     _notifHandlers.set(handler, listener);
+    return listener;
   }
 
   /**


### PR DESCRIPTION
## Summary

Fixes https://github.com/facebook/react-native/issues/23868

Turns out if you set multiple PushNotificationIOS event handlers (for different types or two functions for same type), calling `removeEventHandler` will only remove the last one set.

This can cause some leaks and is just kind of behaviour that you wouldn't expect.

We also return listener itself from the `addEventListener` so that you can call `remove()`, just like for `BackButton`.

## Changelog

[iOS] [Fixed] - PushNotificationIOS properly remove listeners for registered events

## Test Plan

Set multiple listeners and then, remove each of them.
