### PR TITLE
Stops endless logging by packager client for debug builds that use static bundles.

### DIFF
--- a/Libraries/WebSocket/RCTReconnectingWebSocket.m
+++ b/Libraries/WebSocket/RCTReconnectingWebSocket.m
@@ -163,7 +163,9 @@ static void my_os_log_error_impl(void *dso, os_log_t log, os_log_type_t type, co
 - (void)webSocket:(RCTSRWebSocket *)webSocket didFailWithError:(NSError *)error
 {
   [_delegate reconnectingWebSocketDidClose:self];
-  [self reconnect];
+  if ([error code] != ECONNREFUSED) {
+    [self reconnect];
+  }
 }
 
 - (void)webSocket:(RCTSRWebSocket *)webSocket didCloseWithCode:(NSInteger)code reason:(NSString *)reason wasClean:(BOOL)wasClean


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

For the use-case where iOSdebug builds prefer to use static bundles over bundles served dynamically by metro. There's currently a bug caused by the packager client repeatedly attempting to connect to metro. This leads to endless log statements in xcode as well as other side effects: 
https://github.com/facebook/react-native/issues/21030. Fix is based off of https://github.com/facebook/react-native/issues/21030 which fixes the behavior for the inspector.

## Changelog

Stops endless logging by packager client for debug builds that use static bundles.

[CATEGORY] [TYPE] - Message

## Test Plan


