### PR TITLE
[Fabric] Add lock for surface presenter observers

### DIFF
--- a/React/Fabric/RCTSurfacePresenter.mm
+++ b/React/Fabric/RCTSurfacePresenter.mm
@@ -331,12 +331,8 @@ using namespace facebook::react;
 {
   RCTAssertMainQueue();
 
-  NSArray<id<RCTSurfacePresenterObserver>> *observers;
-  {
-    std::shared_lock<better::shared_mutex> lock(_observerListMutex);
-    observers = [_observers copy];
-  }
-  for (id<RCTSurfacePresenterObserver> observer in observers) {
+  std::shared_lock<better::shared_mutex> lock(_observerListMutex);
+  for (id<RCTSurfacePresenterObserver> observer in _observers) {
     if ([observer respondsToSelector:@selector(willMountComponentsWithRootTag:)]) {
       [observer willMountComponentsWithRootTag:rootTag];
     }
@@ -356,12 +352,9 @@ using namespace facebook::react;
       surface.view.rootView = (RCTSurfaceRootView *)rootComponentView;
     }
   }
-  NSArray<id<RCTSurfacePresenterObserver>> *observers;
-  {
-    std::shared_lock<better::shared_mutex> lock(_observerListMutex);
-    observers = [_observers copy];
-  }
-  for (id<RCTSurfacePresenterObserver> observer in observers) {
+
+  std::shared_lock<better::shared_mutex> lock(_observerListMutex);
+  for (id<RCTSurfacePresenterObserver> observer in _observers) {
     if ([observer respondsToSelector:@selector(didMountComponentsWithRootTag:)]) {
       [observer didMountComponentsWithRootTag:rootTag];
     }

--- a/React/Fabric/RCTSurfacePresenter.mm
+++ b/React/Fabric/RCTSurfacePresenter.mm
@@ -331,7 +331,10 @@ using namespace facebook::react;
 {
   RCTAssertMainQueue();
 
-  for (id<RCTSurfacePresenterObserver> observer in _observers) {
+  std::unique_lock<std::mutex> lock(_observerListMutex);
+  NSArray<id<RCTSurfacePresenterObserver>> *observers = [_observers copy];
+  lock.unlock();
+  for (id<RCTSurfacePresenterObserver> observer in observers) {
     if ([observer respondsToSelector:@selector(willMountComponentsWithRootTag:)]) {
       [observer willMountComponentsWithRootTag:rootTag];
     }
@@ -351,7 +354,10 @@ using namespace facebook::react;
       surface.view.rootView = (RCTSurfaceRootView *)rootComponentView;
     }
   }
-  for (id<RCTSurfacePresenterObserver> observer in _observers) {
+  std::unique_lock<std::mutex> lock(_observerListMutex);
+  NSArray<id<RCTSurfacePresenterObserver>> *observers = [_observers copy];
+  lock.unlock();
+  for (id<RCTSurfacePresenterObserver> observer in observers) {
     if ([observer respondsToSelector:@selector(didMountComponentsWithRootTag:)]) {
       [observer didMountComponentsWithRootTag:rootTag];
     }


### PR DESCRIPTION
## Summary

Add lock for observers when do enumeration.
cc. @shergin .

## Changelog

[iOS] [Fixed] - Add lock for surface presenter observers

## Test Plan

N/A.