### PR TITLE
Picker Items should filter NULL child

### DIFF
--- a/Libraries/Components/Picker/PickerIOS.ios.js
+++ b/Libraries/Components/Picker/PickerIOS.ios.js
@@ -91,7 +91,7 @@ class PickerIOS extends React.Component<Props, State> {
   static getDerivedStateFromProps(props: Props): State {
     let selectedIndex = 0;
     const items = [];
-    React.Children.toArray(props.children).forEach(function(child, index) {
+    React.Children.toArray(props.children).filter(child => child !== null).forEach(function(child, index) {
       if (child.props.value === props.selectedValue) {
         selectedIndex = index;
       }


### PR DESCRIPTION
## Summary

when conditional rendering is used then picker breaks when the child is null in iOS

This conditional rendering inside Picker fails when someBooleanValue variable is false
```
{
   this.state.someBooleanValue && <Picker.Item label="value" value="value" />
}
```

## Changelog

[iOS] [Fixed] - null check on children by using filter

## Test Plan

```
{
   this.state.someBooleanValue && <Picker.Item label="value" value="value" />
}
```
