### PR TITLE
[Fabric] Add enumerateWithBlock: for surface registry

### DIFF
--- a/React/Fabric/Mounting/RCTMountingManager.h
+++ b/React/Fabric/Mounting/RCTMountingManager.h
@@ -26,7 +26,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong) RCTComponentViewRegistry *componentViewRegistry;
 
 /**
- * Transfroms mutation instructions to mount items and execute them.
+ * Transfroms mutation instructions to mount items and executes them.
  * The order of mutation instructions matters.
  * Can be called from any thread.
  */

--- a/React/Fabric/Mounting/RCTMountingManager.h
+++ b/React/Fabric/Mounting/RCTMountingManager.h
@@ -26,7 +26,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong) RCTComponentViewRegistry *componentViewRegistry;
 
 /**
- * Transfroms mutation insturctions to mount items and execute them.
+ * Transfroms mutation instructions to mount items and execute them.
  * The order of mutation insturctions matters.
  * Can be called from any thread.
  */

--- a/React/Fabric/Mounting/RCTMountingManager.h
+++ b/React/Fabric/Mounting/RCTMountingManager.h
@@ -27,7 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Transfroms mutation insturctions to mount items and execute them.
- * The order of mutation tnstructions matters.
+ * The order of mutation insturctions matters.
  * Can be called from any thread.
  */
 - (void)performTransactionWithMutations:(facebook::react::ShadowViewMutationList)mutations rootTag:(ReactTag)rootTag;

--- a/React/Fabric/Mounting/RCTMountingManager.h
+++ b/React/Fabric/Mounting/RCTMountingManager.h
@@ -27,7 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Transfroms mutation instructions to mount items and execute them.
- * The order of mutation insturctions matters.
+ * The order of mutation instructions matters.
  * Can be called from any thread.
  */
 - (void)performTransactionWithMutations:(facebook::react::ShadowViewMutationList)mutations rootTag:(ReactTag)rootTag;

--- a/React/Fabric/RCTSurfacePresenter.mm
+++ b/React/Fabric/RCTSurfacePresenter.mm
@@ -283,7 +283,7 @@ using namespace facebook::react;
 
 - (void)_startAllSurfaces
 {
-  [_surfaceRegistry enumerateSurfaceWithBlock:^(NSEnumerator<RCTFabricSurface *> * enumerator) {
+  [_surfaceRegistry enumerateWithBlock:^(NSEnumerator<RCTFabricSurface *> *enumerator) {
     for (RCTFabricSurface *surface in enumerator) {
       [self _startSurface:surface];
     }
@@ -292,7 +292,7 @@ using namespace facebook::react;
 
 - (void)_stopAllSurfaces
 {
-  [_surfaceRegistry enumerateSurfaceWithBlock:^(NSEnumerator<RCTFabricSurface *> * enumerator) {
+  [_surfaceRegistry enumerateWithBlock:^(NSEnumerator<RCTFabricSurface *> *enumerator) {
     for (RCTFabricSurface *surface in enumerator) {
       [self _stopSurface:surface];
     }

--- a/React/Fabric/RCTSurfacePresenter.mm
+++ b/React/Fabric/RCTSurfacePresenter.mm
@@ -283,16 +283,20 @@ using namespace facebook::react;
 
 - (void)_startAllSurfaces
 {
-  for (RCTFabricSurface *surface in _surfaceRegistry.enumerator) {
-    [self _startSurface:surface];
-  }
+  [_surfaceRegistry enumerateSurfaceWithBlock:^(NSEnumerator<RCTFabricSurface *> * enumerator) {
+    for (RCTFabricSurface *surface in enumerator) {
+      [self _startSurface:surface];
+    }
+  }];
 }
 
 - (void)_stopAllSurfaces
 {
-  for (RCTFabricSurface *surface in _surfaceRegistry.enumerator) {
-    [self _stopSurface:surface];
-  }
+  [_surfaceRegistry enumerateSurfaceWithBlock:^(NSEnumerator<RCTFabricSurface *> * enumerator) {
+    for (RCTFabricSurface *surface in enumerator) {
+      [self _stopSurface:surface];
+    }
+  }];
 }
 
 #pragma mark - RCTSchedulerDelegate

--- a/React/Fabric/RCTSurfaceRegistry.h
+++ b/React/Fabric/RCTSurfaceRegistry.h
@@ -13,6 +13,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @class RCTFabricSurface;
 
+typedef void(^RCTSurfaceEnumeratorBlock)(NSEnumerator<RCTFabricSurface *> *enumerator);
+
 /**
  * Registry of Surfaces.
  * Incapsulates storing Surface objects and quering them by root tag.
@@ -21,7 +23,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface RCTSurfaceRegistry : NSObject
 
-- (NSEnumerator<RCTFabricSurface *> *)enumerator;
+- (void)enumerateSurfaceWithBlock:(RCTSurfaceEnumeratorBlock)block;
 
 /**
  * Adds Surface object into the registry.

--- a/React/Fabric/RCTSurfaceRegistry.h
+++ b/React/Fabric/RCTSurfaceRegistry.h
@@ -23,7 +23,7 @@ typedef void(^RCTSurfaceEnumeratorBlock)(NSEnumerator<RCTFabricSurface *> *enume
  */
 @interface RCTSurfaceRegistry : NSObject
 
-- (void)enumerateSurfaceWithBlock:(RCTSurfaceEnumeratorBlock)block;
+- (void)enumerateWithBlock:(RCTSurfaceEnumeratorBlock)block;
 
 /**
  * Adds Surface object into the registry.

--- a/React/Fabric/RCTSurfaceRegistry.mm
+++ b/React/Fabric/RCTSurfaceRegistry.mm
@@ -26,7 +26,7 @@
   return self;
 }
 
-- (void)enumerateSurfaceWithBlock:(RCTSurfaceEnumeratorBlock)block
+- (void)enumerateWithBlock:(RCTSurfaceEnumeratorBlock)block
 {
   std::lock_guard<std::mutex> lock(_mutex);
   block([_registry objectEnumerator]);

--- a/React/Fabric/RCTSurfaceRegistry.mm
+++ b/React/Fabric/RCTSurfaceRegistry.mm
@@ -26,11 +26,10 @@
   return self;
 }
 
-- (NSEnumerator<RCTFabricSurface *> *)enumerator
+- (void)enumerateSurfaceWithBlock:(RCTSurfaceEnumeratorBlock)block
 {
   std::lock_guard<std::mutex> lock(_mutex);
-
-  return [[_registry copy] objectEnumerator];
+  block([_registry objectEnumerator]);
 }
 
 - (void)registerSurface:(RCTFabricSurface *)surface

--- a/React/Fabric/RCTSurfaceRegistry.mm
+++ b/React/Fabric/RCTSurfaceRegistry.mm
@@ -30,7 +30,7 @@
 {
   std::lock_guard<std::mutex> lock(_mutex);
 
-  return [_registry objectEnumerator];
+  return [[_registry copy] objectEnumerator];
 }
 
 - (void)registerSurface:(RCTFabricSurface *)surface


### PR DESCRIPTION
## Summary

To ensure all methods in surface registry thread safe, add copy to enumerator method.
cc. @shergin .

## Changelog

[iOS] [Fixed] - Add copy for surface registry when return enumerator

## Test Plan

N/A.