### PR TITLE
Fix #24053 prevent division by zero error in VirtualizedList debug overlay 

### DIFF
--- a/Libraries/Lists/VirtualizedList.js
+++ b/Libraries/Lists/VirtualizedList.js
@@ -1169,7 +1169,8 @@ class VirtualizedList extends React.PureComponent<Props, State> {
 
   _renderDebugOverlay() {
     const normalize =
-      this._scrollMetrics.visibleLength / this._scrollMetrics.contentLength;
+      this._scrollMetrics.visibleLength /
+      (this._scrollMetrics.contentLength || 1);
     const framesInLayout = [];
     const itemCount = this.props.getItemCount(this.props.data);
     for (let ii = 0; ii < itemCount; ii++) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

This PR fixes the case where the content a VirtualizedList loads with a contentLength of 0,  causing a crash in the `renderDebugOverlay` function. The result of that crash is a red screen when turning on debug on FlatList and other VirtualizedList components as described in #24053.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See http://facebook.github.io/react-native/docs/contributing#changelog for an example. -->
[LIST] [FIX] - Fix VirtualizedList debug mode crash

## Test Plan
This code will reproduce the problem:
```
import React, { Component } from 'react'
import { Text, FlatList } from 'react-native'

export default class App extends Component {
  render() {
    return (
      <FlatList
        //  ❌ Un-commit this line to see error
        debug={true}
        data={[1, 2, 3, 4, 5, 6]}
        renderItem={_ => {
          return <Text>123</Text>
        }}
        keyExtractor={item => item.toString()}
      />
    )
  }
}
```
Before:
<img width="429" alt="Screenshot 2019-03-20 at 07 54 34" src="https://user-images.githubusercontent.com/1605731/54667910-7f95ca00-4ae5-11e9-8002-cd97129a8d82.png">

After:
<img width="411" alt="Screenshot 2019-03-20 at 07 54 59" src="https://user-images.githubusercontent.com/1605731/54667926-86244180-4ae5-11e9-944e-b0081b51e353.png">

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
