### PR TITLE
chore: update Jest preset to align with Jest 24

### DIFF
--- a/jest-preset.js
+++ b/jest-preset.js
@@ -18,7 +18,6 @@ module.exports = {
     hasteImplModulePath: require.resolve('./jest/hasteImpl.js'),
     providesModuleNodeModules: ['react-native'],
   },
-  moduleFileExtensions: ['js', 'json', 'jsx', 'node', 'ts', 'tsx'],
   moduleNameMapper: {
     '^React$': require.resolve('react'),
   },
@@ -30,10 +29,6 @@ module.exports = {
     ),
   },
   transformIgnorePatterns: ['node_modules/(?!(jest-)?react-native)'],
-  testMatch: [
-    '**/__tests__/**/*.(js|ts|tsx)',
-    '**/?(*.)+(spec|test).(js|ts|tsx)',
-  ],
   setupFiles: [require.resolve('./jest/setup.js')],
   testEnvironment: 'node',
 };


### PR DESCRIPTION
## Summary

Jest 24 includes [`testMatch` and `moduleFileExtensions`](https://github.com/facebook/jest/blob/c5fd7aae93764c13c259ae9a73846c10e84ae2a3/packages/jest-config/src/Defaults.ts#L70) that align with the ones that are currently there on master, because it added default handling for TypeScript as well. I think it's time for us to move to Jest 24. Is there a way we can tell users to upgrade Jest to certain version?

Fixes https://github.com/facebook/react-native/issues/24060

## Changelog

[General] [Changed] - update Jest preset to align with Jest 24

## Test Plan

Tested on a fresh project with renaming `.js` -> `.ts` -> `.tsx`
