### PR TITLE
allow HTTP in debug builds

### DIFF
--- a/RNTester/android/app/src/debug/AndroidManifest.xml
+++ b/RNTester/android/app/src/debug/AndroidManifest.xml
@@ -4,5 +4,5 @@
 
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
 
-    <application tools:targetApi="28" tools:ignore="GoogleAppIndexingWarning" android:networkSecurityConfig="@xml/react_native_config" />
+    <application android:usesCleartextTraffic="true" tools:targetApi="28" tools:ignore="GoogleAppIndexingWarning" />
 </manifest>

--- a/RNTester/android/app/src/debug/res/xml/react_native_config.xml
+++ b/RNTester/android/app/src/debug/res/xml/react_native_config.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<network-security-config>
-    <domain-config cleartextTrafficPermitted="true">
-        <domain includeSubdomains="false">localhost</domain>
-        <domain includeSubdomains="false">10.0.2.2</domain>
-        <domain includeSubdomains="false">10.0.3.2</domain>
-    </domain-config>
-</network-security-config>

--- a/template/android/app/src/debug/AndroidManifest.xml
+++ b/template/android/app/src/debug/AndroidManifest.xml
@@ -4,5 +4,5 @@
 
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
 
-    <application tools:targetApi="28" tools:ignore="GoogleAppIndexingWarning" android:networkSecurityConfig="@xml/react_native_config" />
+    <application android:usesCleartextTraffic="true" tools:targetApi="28" tools:ignore="GoogleAppIndexingWarning" />
 </manifest>

--- a/template/android/app/src/debug/res/xml/react_native_config.xml
+++ b/template/android/app/src/debug/res/xml/react_native_config.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<network-security-config>
-  <domain-config cleartextTrafficPermitted="true">
-    <domain includeSubdomains="false">localhost</domain>
-    <domain includeSubdomains="false">10.0.2.2</domain>
-    <domain includeSubdomains="false">10.0.3.2</domain>
-  </domain-config>
-</network-security-config>


### PR DESCRIPTION
## Summary

It allows HTTP connections in debug builds, and requires no configuration compared to previous/current solution where you need to edit config file to test on device.

Consulted with @Salakar about this.

## Changelog

[Android] [Changed] - Allow HTTP in debug builds

## Test Plan

CI is green