### PR TITLE
improve RTL

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactBaseTextShadowNode.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactBaseTextShadowNode.java
@@ -315,10 +315,10 @@ public abstract class ReactBaseTextShadowNode extends LayoutShadowNode {
   private int getTextAlign() {
     int textAlign = mTextAlign;
     if (getLayoutDirection() == YogaDirection.RTL) {
-      if (textAlign == Gravity.RIGHT) {
-        textAlign = Gravity.LEFT;
-      } else if (textAlign == Gravity.LEFT) {
-        textAlign = Gravity.RIGHT;
+      if (textAlign == Gravity.END) {
+        textAlign = Gravity.START;
+      } else if (textAlign == Gravity.START) {
+        textAlign = Gravity.END;
       }
     }
     return textAlign;
@@ -364,7 +364,7 @@ public abstract class ReactBaseTextShadowNode extends LayoutShadowNode {
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
         mJustificationMode = Layout.JUSTIFICATION_MODE_INTER_WORD;
       }
-      mTextAlign = Gravity.LEFT;
+      mTextAlign = Gravity.START;
     } else {
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
         mJustificationMode = Layout.JUSTIFICATION_MODE_NONE;
@@ -373,9 +373,9 @@ public abstract class ReactBaseTextShadowNode extends LayoutShadowNode {
       if (textAlign == null || "auto".equals(textAlign)) {
         mTextAlign = Gravity.NO_GRAVITY;
       } else if ("left".equals(textAlign)) {
-        mTextAlign = Gravity.LEFT;
+        mTextAlign = Gravity.START;
       } else if ("right".equals(textAlign)) {
-        mTextAlign = Gravity.RIGHT;
+        mTextAlign = Gravity.END;
       } else if ("center".equals(textAlign)) {
         mTextAlign = Gravity.CENTER_HORIZONTAL;
       } else {

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextShadowNode.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextShadowNode.java
@@ -76,10 +76,10 @@ public class ReactTextShadowNode extends ReactBaseTextShadowNode {
 
           Layout.Alignment alignment = Layout.Alignment.ALIGN_NORMAL;
           switch (getTextAlign()) {
-            case Gravity.LEFT:
+            case Gravity.START:
               alignment = Layout.Alignment.ALIGN_NORMAL;
               break;
-            case Gravity.RIGHT:
+            case Gravity.END:
               alignment = Layout.Alignment.ALIGN_OPPOSITE;
               break;
             case Gravity.CENTER_HORIZONTAL:
@@ -179,10 +179,10 @@ public class ReactTextShadowNode extends ReactBaseTextShadowNode {
   private int getTextAlign() {
     int textAlign = mTextAlign;
     if (getLayoutDirection() == YogaDirection.RTL) {
-      if (textAlign == Gravity.RIGHT) {
-        textAlign = Gravity.LEFT;
-      } else if (textAlign == Gravity.LEFT) {
-        textAlign = Gravity.RIGHT;
+      if (textAlign == Gravity.END) {
+        textAlign = Gravity.START;
+      } else if (textAlign == Gravity.START) {
+        textAlign = Gravity.END;
       }
     }
     return textAlign;

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/TextAttributeProps.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/TextAttributeProps.java
@@ -164,10 +164,10 @@ public class TextAttributeProps {
   public int getTextAlign() {
     int textAlign = mTextAlign;
     if (getLayoutDirection() == YogaDirection.RTL) {
-      if (textAlign == Gravity.RIGHT) {
-        textAlign = Gravity.LEFT;
-      } else if (textAlign == Gravity.LEFT) {
-        textAlign = Gravity.RIGHT;
+      if (textAlign == Gravity.END) {
+        textAlign = Gravity.START;
+      } else if (textAlign == Gravity.START) {
+        textAlign = Gravity.END;
       }
     }
     return textAlign;
@@ -210,7 +210,7 @@ public class TextAttributeProps {
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
         mJustificationMode = Layout.JUSTIFICATION_MODE_INTER_WORD;
       }
-      mTextAlign = Gravity.LEFT;
+      mTextAlign = Gravity.START;
     } else {
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
         mJustificationMode = Layout.JUSTIFICATION_MODE_NONE;
@@ -219,9 +219,9 @@ public class TextAttributeProps {
       if (textAlign == null || "auto".equals(textAlign)) {
         mTextAlign = Gravity.NO_GRAVITY;
       } else if ("left".equals(textAlign)) {
-        mTextAlign = Gravity.LEFT;
+        mTextAlign = Gravity.START;
       } else if ("right".equals(textAlign)) {
-        mTextAlign = Gravity.RIGHT;
+        mTextAlign = Gravity.END;
       } else if ("center".equals(textAlign)) {
         mTextAlign = Gravity.CENTER_HORIZONTAL;
       } else {

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
@@ -7,6 +7,7 @@
 
 package com.facebook.react.views.textinput;
 
+import android.annotation.TargetApi;
 import android.graphics.PorterDuff;
 import android.graphics.Typeface;
 import android.graphics.drawable.Drawable;
@@ -478,7 +479,7 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
         view.setJustificationMode(Layout.JUSTIFICATION_MODE_INTER_WORD);
       }
-      view.setGravityHorizontal(Gravity.LEFT);
+      view.setGravityHorizontal(Gravity.START);
     } else {
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
         view.setJustificationMode(Layout.JUSTIFICATION_MODE_NONE);
@@ -487,9 +488,9 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
       if (textAlign == null || "auto".equals(textAlign)) {
         view.setGravityHorizontal(Gravity.NO_GRAVITY);
       } else if ("left".equals(textAlign)) {
-        view.setGravityHorizontal(Gravity.LEFT);
+        view.setGravityHorizontal(Gravity.START);
       } else if ("right".equals(textAlign)) {
-        view.setGravityHorizontal(Gravity.RIGHT);
+        view.setGravityHorizontal(Gravity.END);
       } else if ("center".equals(textAlign)) {
         view.setGravityHorizontal(Gravity.CENTER_HORIZONTAL);
       } else {


### PR DESCRIPTION
## Summary

Google recommends to use Gravity.START and Gravity.END instead of Gravity.LEFT and Gravity.RIGHT to support RTL better.

## Changelog

[Android] [Changed] - Improve RTL support

## Test Plan

CI is green, and RNTester works as expected