### PR TITLE
fix: Start Metro packager from project root

### DIFF
--- a/scripts/packager.sh
+++ b/scripts/packager.sh
@@ -4,9 +4,20 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+# scripts directory
 THIS_DIR=$(cd -P "$(dirname "$(readlink "${BASH_SOURCE[0]}" || echo "${BASH_SOURCE[0]}")")" && pwd)
+REACT_NATIVE_ROOT="$THIS_DIR/.."
+# Application root directory - General use case: react-native is a dependency
+PROJECT_ROOT="$THIS_DIR/../../.."
 
 # shellcheck source=/dev/null
 source "${THIS_DIR}/.packager.env"
-cd "$THIS_DIR/.." || exit
-node "./cli.js" start "$@"
+
+# When running react-native tests, react-native doesn't live in node_modules but in the PROJECT_ROOT
+if [ ! -d "$PROJECT_ROOT/node_modules/react-native" ];
+then
+  PROJECT_ROOT="$THIS_DIR/.."
+fi
+# Start packager from PROJECT_ROOT
+cd "$PROJECT_ROOT" || exit
+node "$REACT_NATIVE_ROOT/cli.js" start "$@"


### PR DESCRIPTION
## Summary

Fixes #23342.

Since Metro [v0.47](https://github.com/facebook/metro/releases/tag/v0.47.0), some babel plugins such as [babel-plugin-module-resolver](https://github.com/tleunen/babel-plugin-module-resolver) or [babel-plugin-import-graphql](https://github.com/detrohutt/babel-plugin-import-graphql) fail to resolve files if the packager is started through Xcode. They receive wrong filenames from Babel such as `${projectRoot}/node_modules/react-native/src/index.js` instead of `${projectRoot}/src/index.js`.
	
It happens because the start command of the local-cli is not executed in the projectRoot directory. In this case, the cwd will be `${projectRoot}/node_modules/react-native`.
	
	
This issue doesn't occur if you start the packager yourself using `node node_modules/react-native/local-cli/cli.js start` from your project root.
	
It comes from this [line](https://github.com/facebook/react-native/blob/b640b6faf77f7af955e64bd03ae630ce2fb09627/scripts/packager.sh#L11). This script changed the working directory to `${projectRoot}/node_modules/react-native` and started Metro from there. 

Starting Metro from the project root fixes this issue.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See http://facebook.github.io/react-native/docs/contributing#changelog for an example. -->

[iOS] [Fixed] - Start Metro packager from project root

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
