### PR TITLE
Fix PerfMonitor appearance when reloading JS

### DIFF
--- a/React/Profiler/RCTPerfMonitor.m
+++ b/React/Profiler/RCTPerfMonitor.m
@@ -156,6 +156,7 @@ RCT_EXPORT_MODULE()
   if (!_devMenuItem) {
     __weak __typeof__(self) weakSelf = self;
     __weak RCTDevSettings *devSettings = self.bridge.devSettings;
+    if (devSettings.isPerfMonitorShown) [weakSelf show];
     _devMenuItem =
     [RCTDevMenuItem buttonItemWithTitleBlock:^NSString *{
       return (devSettings.isPerfMonitorShown) ?

--- a/React/Profiler/RCTPerfMonitor.m
+++ b/React/Profiler/RCTPerfMonitor.m
@@ -156,7 +156,9 @@ RCT_EXPORT_MODULE()
   if (!_devMenuItem) {
     __weak __typeof__(self) weakSelf = self;
     __weak RCTDevSettings *devSettings = self.bridge.devSettings;
-    if (devSettings.isPerfMonitorShown) [weakSelf show];
+    if (devSettings.isPerfMonitorShown) {
+      [weakSelf show];
+    }
     _devMenuItem =
     [RCTDevMenuItem buttonItemWithTitleBlock:^NSString *{
       return (devSettings.isPerfMonitorShown) ?


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
Fix for this issue I rasied: https://github.com/facebook/react-native/issues/24024
When I toggle `Show Perf Monitor` and reload JS `CMD+R` the Perf Monitor will be hidden, but settings in dev menu will persist. So to fix this state and need to `Hide Perf Monitor` and `Show Perf Monitor` again to see it.

## Changelog
[iOS] [Fixed] - Show Perf Monitor, after reloading JS

## Test Plan

Toggle Perf Monitor to be visible. Reload JS (CMD+R). If Perf Monitor visible all good.
