### PR TITLE
[Fabric] Consolidate shared_mutex with better::shared_mutex

### DIFF
--- a/ReactCommon/fabric/imagemanager/ImageResponseObserverCoordinator.h
+++ b/ReactCommon/fabric/imagemanager/ImageResponseObserverCoordinator.h
@@ -10,8 +10,7 @@
 #include <react/imagemanager/ImageResponse.h>
 #include <react/imagemanager/ImageResponseObserver.h>
 
-#include <folly/SharedMutex.h>
-#include <shared_mutex>
+#include <better/mutex.h>
 #include <vector>
 
 namespace facebook {
@@ -84,7 +83,7 @@ class ImageResponseObserverCoordinator {
   /*
    * Observer and data mutex.
    */
-  mutable folly::SharedMutex mutex_;
+  mutable better::shared_mutex mutex_;
 };
 
 } // namespace react

--- a/ReactCommon/fabric/uimanager/ShadowTree.cpp
+++ b/ReactCommon/fabric/uimanager/ShadowTree.cpp
@@ -149,7 +149,7 @@ bool ShadowTree::tryCommit(
 
   {
     // Reading `rootShadowNode_` in shared manner.
-    std::shared_lock<folly::SharedMutex> lock(commitMutex_);
+    std::shared_lock<better::shared_mutex> lock(commitMutex_);
     oldRootShadowNode = rootShadowNode_;
   }
 
@@ -169,7 +169,7 @@ bool ShadowTree::tryCommit(
 
   {
     // Updating `rootShadowNode_` in unique manner if it hasn't changed.
-    std::unique_lock<folly::SharedMutex> lock(commitMutex_);
+    std::unique_lock<better::shared_mutex> lock(commitMutex_);
 
     if (rootShadowNode_ != oldRootShadowNode) {
       return false;

--- a/ReactCommon/fabric/uimanager/ShadowTree.h
+++ b/ReactCommon/fabric/uimanager/ShadowTree.h
@@ -5,9 +5,8 @@
 
 #pragma once
 
-#include <folly/SharedMutex.h>
+#include <better/mutex.h>
 #include <memory>
-#include <shared_mutex>
 
 #include <react/components/root/RootComponentDescriptor.h>
 #include <react/components/root/RootShadowNode.h>
@@ -84,7 +83,7 @@ class ShadowTree final {
   void emitLayoutEvents(const ShadowViewMutationList &mutations) const;
 
   const SurfaceId surfaceId_;
-  mutable folly::SharedMutex commitMutex_;
+  mutable better::shared_mutex commitMutex_;
   mutable SharedRootShadowNode rootShadowNode_; // Protected by `commitMutex_`.
   mutable int revision_{1}; // Protected by `commitMutex_`.
   ShadowTreeDelegate const *delegate_;

--- a/ReactCommon/fabric/uimanager/ShadowTreeRegistry.cpp
+++ b/ReactCommon/fabric/uimanager/ShadowTreeRegistry.cpp
@@ -9,14 +9,14 @@ namespace facebook {
 namespace react {
 
 void ShadowTreeRegistry::add(std::unique_ptr<ShadowTree> &&shadowTree) const {
-  std::unique_lock<folly::SharedMutex> lock(mutex_);
+  std::unique_lock<better::shared_mutex> lock(mutex_);
 
   registry_.emplace(shadowTree->getSurfaceId(), std::move(shadowTree));
 }
 
 std::unique_ptr<ShadowTree> ShadowTreeRegistry::remove(
     SurfaceId surfaceId) const {
-  std::unique_lock<folly::SharedMutex> lock(mutex_);
+  std::unique_lock<better::shared_mutex> lock(mutex_);
 
   auto iterator = registry_.find(surfaceId);
   auto shadowTree = std::unique_ptr<ShadowTree>(iterator->second.release());
@@ -27,7 +27,7 @@ std::unique_ptr<ShadowTree> ShadowTreeRegistry::remove(
 bool ShadowTreeRegistry::visit(
     SurfaceId surfaceId,
     std::function<void(const ShadowTree &shadowTree)> callback) const {
-  std::shared_lock<folly::SharedMutex> lock(mutex_);
+  std::shared_lock<better::shared_mutex> lock(mutex_);
 
   auto iterator = registry_.find(surfaceId);
 

--- a/ReactCommon/fabric/uimanager/ShadowTreeRegistry.h
+++ b/ReactCommon/fabric/uimanager/ShadowTreeRegistry.h
@@ -5,8 +5,7 @@
 
 #pragma once
 
-#include <folly/SharedMutex.h>
-#include <shared_mutex>
+#include <better/mutex.h>
 
 #include <react/core/ReactPrimitives.h>
 #include <react/uimanager/ShadowTree.h>
@@ -49,7 +48,7 @@ class ShadowTreeRegistry final {
       std::function<void(const ShadowTree &shadowTree)> callback) const;
 
  private:
-  mutable folly::SharedMutex mutex_;
+  mutable better::shared_mutex mutex_;
   mutable std::unordered_map<SurfaceId, std::unique_ptr<ShadowTree>>
       registry_; // Protected by `mutex_`.
 };


### PR DESCRIPTION
## Summary

Replace `folly::SharedMutex` with `better::shared_mutex`, consolidate the shared_mutex.
cc. @shergin .

## Changelog

[General] [Changed] - Consolidate shared_mutex with better::shared_mutex

## Test Plan

N/A.