### PR TITLE
[iOS] Fixed crash when textinput's default value exceeds maxLength

### DIFF
--- a/Libraries/Text/TextInput/RCTBaseTextInputView.m
+++ b/Libraries/Text/TextInput/RCTBaseTextInputView.m
@@ -373,9 +373,9 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithFrame:(CGRect)frame)
   }
 
   if (_maxLength) {
-    NSInteger allowedLength = _maxLength.integerValue - backedTextInputView.attributedText.string.length + range.length;
+    NSInteger allowedLength = MAX(_maxLength.integerValue - (NSInteger)backedTextInputView.attributedText.string.length + (NSInteger)range.length, 0);
 
-    if (allowedLength < 0 || text.length > allowedLength) {
+    if (text.length > allowedLength) {
       // If we typed/pasted more than one character, limit the text inputted.
       if (text.length > 1) {
         // Truncate the input string so the result is exactly maxLength


### PR DESCRIPTION
## Summary

Bug comes from #23545, if `allowedLength < 0`, it would crash if `text.length > 1`.

cc. @cpojer 

## Changelog

[iOS] [Fixed] - Fixed crash when textinput's default value exceeds maxLength

## Test Plan

paste text which length bigger than 1, it would not crash.
```
      <View style={styles.exampleContainer}>
        <Header title="RNTester" />
        <TextInput value={'12345678'} maxLength={6}/>
      </View>
```