### PR TITLE
Fix eslint glob for `.test.js` and `.spec.js` files.

### DIFF
--- a/packages/eslint-config-react-native-community/index.js
+++ b/packages/eslint-config-react-native-community/index.js
@@ -31,7 +31,7 @@ module.exports = {
   },
 
   overrides: {
-    files: ['**/__tests__/**/*.js', '**/?(*.)(spec|test).js'],
+    files: ['**/__tests__/**/*.js', '**/*.spec.js', '**/*.test.js'],
     env: {
       jest: true,
       'jest/globals': true,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Existing glob might not work very well with `spec.js` and `test.js` files unless they're placed in `__tests__` directory. This PR aims to bring back the support of `jest` globals in these files, even if they're outside of `__tests__` directory.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See http://facebook.github.io/react-native/docs/contributing#changelog for an example. -->

[General] [Fixed] - Fixed globs for `spec.js` and `test.js` files.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Use one of the `jest` globals, for example, `it()` in `spec.js` or `test.js` file, that are not placed in `__tests__` direcotry while using `@react-native-community/eslint-config`.
