### PR TITLE
Fix concatenation of accessibility labels in automated tests on iOS

### DIFF
--- a/React/Views/RCTView.m
+++ b/React/Views/RCTView.m
@@ -151,7 +151,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:unused)
   if (label) {
     return label;
   }
-  return RCTRecursiveAccessibilityLabel(self);
+  return RCTRecursiveAccessibilityLabel(nil);
 }
 
 - (NSArray <UIAccessibilityCustomAction *> *)accessibilityCustomActions

--- a/React/Views/RCTView.m
+++ b/React/Views/RCTView.m
@@ -81,17 +81,19 @@
 static NSString *RCTRecursiveAccessibilityLabel(UIView *view)
 {
   NSMutableString *str = [NSMutableString stringWithString:@""];
-  for (UIView *subview in view.subviews) {
-    NSString *label = subview.accessibilityLabel;
-    if (!label) {
-      label = RCTRecursiveAccessibilityLabel(subview);
-    }
-    if (label && label.length > 0) {
-      if (str.length > 0) {
-        [str appendString:@" "];
+  if (view) {
+    for (UIView *subview in view.subviews) {
+      NSString *label = subview.accessibilityLabel;
+      if (!label) {
+        label = RCTRecursiveAccessibilityLabel(subview);
       }
-      [str appendString:label];
-    }
+      if (label && label.length > 0) {
+        if (str.length > 0) {
+          [str appendString:@" "];
+        }
+        [str appendString:label];
+      }
+    }  
   }
   return str;
 }
@@ -151,7 +153,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:unused)
   if (label) {
     return label;
   }
-  return RCTRecursiveAccessibilityLabel(self);
+  return RCTRecursiveAccessibilityLabel(nil);
 }
 
 - (NSArray <UIAccessibilityCustomAction *> *)accessibilityCustomActions

--- a/React/Views/RCTView.m
+++ b/React/Views/RCTView.m
@@ -81,19 +81,17 @@
 static NSString *RCTRecursiveAccessibilityLabel(UIView *view)
 {
   NSMutableString *str = [NSMutableString stringWithString:@""];
-  if (view) {
-    for (UIView *subview in view.subviews) {
-      NSString *label = subview.accessibilityLabel;
-      if (!label) {
-        label = RCTRecursiveAccessibilityLabel(subview);
+   for (UIView *subview in view.subviews) {
+     NSString *label = subview.accessibilityLabel;
+     if (!label) {
+       label = RCTRecursiveAccessibilityLabel(subview);
+     }
+     if (label && label.length > 0) {
+      if (str.length > 0) {
+        [str appendString:@" "];
       }
-      if (label && label.length > 0) {
-        if (str.length > 0) {
-          [str appendString:@" "];
-        }
-        [str appendString:label];
-      }
-    }  
+      [str appendString:label];
+    }
   }
   return str;
 }
@@ -153,7 +151,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:unused)
   if (label) {
     return label;
   }
-  return RCTRecursiveAccessibilityLabel(nil);
+  return nil;
 }
 
 - (NSArray <UIAccessibilityCustomAction *> *)accessibilityCustomActions

--- a/React/Views/RCTView.m
+++ b/React/Views/RCTView.m
@@ -151,7 +151,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:unused)
   if (label) {
     return label;
   }
-  return RCTRecursiveAccessibilityLabel(nil);
+  return RCTRecursiveAccessibilityLabel(self);
 }
 
 - (NSArray <UIAccessibilityCustomAction *> *)accessibilityCustomActions


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

When using Appium in order to provide automated tests a unique accessibility label has to be specified for a single element in order to be identified in the Appium inspector tool. However, on iOS, the accessibility label for a single element contained the labels of all the elements on the screen concatenated into one string. 

I have provided a fix that would stop concatenating the accessibility labels of other elements from the screen.

## Changelog

[IOS][Changed] - Fix concatenation of accessibilityLabels for an element

## Test Plan
Before the fix, the accessibility labels were showing like this in the Appium inspector.
https://ibb.co/Nxq4Cdh

I have run the following tests in order to make sure that the current modifications are working and that the old functionality is still working.
1. I have run the integration test locally from ./scripts/objc-test-ios.sh and the results have passed 
2. I have also run the RNTester module on a simulator and all the components were working as expected
3. We have run automated tests on our local changes and it has been confirmed that the accessibility labels were no longer concatenated and that every element contained the label that was set in the project.