### PR TITLE
Update projectRoot in launchPackager.bat

### DIFF
--- a/scripts/launchPackager.bat
+++ b/scripts/launchPackager.bat
@@ -6,6 +6,6 @@
 @echo off
 title Metro Bundler
 call .packager.bat
-node "%~dp0..\cli.js" --reactNativePath ../ start
+node "%~dp0..\cli.js" --reactNativePath ../ --projectRoot ../../../ start
 pause
 exit


### PR DESCRIPTION
## Summary

`launchPackager.bat` starts metro server but does not pass projectRoot to it. So metro server starts in the wrong directory, It is because `startServerInNewWindow` pass `react-native` directory instead of `projectRoot` in the third argument of `spawn()` in `runAndroid.js`

Its working for people
See https://github.com/facebook/react-native/issues/23908#issuecomment-475889443

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->


<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See http://facebook.github.io/react-native/docs/contributing#changelog for an example. -->

[Android] [Fixed] - projectRoot in launchPackager.bat

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
