### PR TITLE
Use constructor attribute instead of +load objc method

### DIFF
--- a/React/Base/RCTBridgeModule.h
+++ b/React/Base/RCTBridgeModule.h
@@ -74,6 +74,17 @@ RCT_EXTERN void RCTRegisterModule(Class); \
 + (void)load { RCTRegisterModule(self); }
 
 /**
+ * Same as RCT_EXPORT_MODULE, but uses __attribute__((constructor)) for module
+ * registration. Useful for registering swift classes that forbids use of load
+ * Used in RCT_EXTERN_REMAP_MODULE
+ */
+#define RCT_EXPORT_MODULE_NO_LOAD(js_name, objc_name) \
+RCT_EXTERN void RCTRegisterModule(Class); \
++ (NSString *)moduleName { return @#js_name; } \
+__attribute__((constructor)) static void \
+RCT_CONCAT(initialize_, objc_name)() { RCTRegisterModule([objc_name class]); }
+
+/**
  * To improve startup performance users may want to generate their module lists
  * at build time and hook the delegate to merge with the runtime list. This
  * macro takes the place of the above for those cases by omitting the +load
@@ -250,7 +261,7 @@ RCT_EXTERN void RCTRegisterModule(Class); \
   @interface objc_name (RCTExternModule) <RCTBridgeModule> \
   @end \
   @implementation objc_name (RCTExternModule) \
-  RCT_EXPORT_MODULE(js_name)
+  RCT_EXPORT_MODULE_NO_LOAD(js_name, objc_name)
 
 /**
  * Use this macro in accordance with RCT_EXTERN_MODULE to export methods


### PR DESCRIPTION
## Summary

Xcode 10.2 forbids creating categories for swift class that uses `+load` method. In react-native categories like this are used to register swift classes as modules (macro `RCT_EXTERN_MODULE`) This PR changes it to use `__attribute__((constructor))` instead of objc `+load` method. 

I introduced new macro for this purpose, `RCT_EXPORT_MODULE_NO_LOAD`, it expands in something like:
```
void RCTRegisterModule(Class);

+ (NSString *)moduleName { 
  return @"jsNameFoo"; 
}

__attribute__((constructor)) static void initialize_ObjcClassFoo{ 
  RCTRegisterModule([ObjcClassFoo class]); 
}
```

Functions marked with `__attribute__((constructor))` are run before main and after all `+load` methods, so it seems like correct thing to do.

Fixes https://github.com/facebook/react-native/issues/24139
Doc about loading order https://developer.apple.com/documentation/objectivec/nsobject/1418815-load?language=objc

## Changelog

[iOS] [Fixed] - Fix runtime crash in xcode 10.2 when using RCT_EXTERN_MODULE for swift classes.

## Test Plan

Builds and runs successfully. 