### PR TITLE
Fix: use NODE_BINARY when starting packager

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "scripts/launchPackager.command",
     "scripts/packager.sh",
     "scripts/react-native-xcode.sh",
+    "scripts/node-binary.sh",
     "jest-preset.js",
     "jest",
     "lib",

--- a/scripts/node-binary.sh
+++ b/scripts/node-binary.sh
@@ -8,11 +8,10 @@
 
 nodejs_not_found()
 {
-  echo "error: Can't find '$NODE_BINARY' binary to build React Native bundle." >&2
-  echo "If you have a non-standard nodejs installation, select your project in Xcode," >&2
-  echo "find 'Build Phases' - 'Bundle React Native code and images'" >&2
-  echo "and change NODE_BINARY to an absolute path to your node executable." >&2
-  echo "You can find it by invoking 'which node' in the terminal." >&2
+  echo "error: Can't find the '$NODE_BINARY' binary to build the React Native bundle. " \
+       "If you have a non-standard Node.js installation, select your project in Xcode, find "\
+       "'Build Phases' - 'Bundle React Native code and images' and change NODE_BINARY to an "\
+       "absolute path to your node executable. You can find it by invoking 'which node' in the terminal." >&2
   exit 2
 }
 

--- a/scripts/node-binary.sh
+++ b/scripts/node-binary.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+[ -z "$NODE_BINARY" ] && export NODE_BINARY="node"
+
+nodejs_not_found()
+{
+  echo "error: Can't find '$NODE_BINARY' binary to build React Native bundle" >&2
+  echo "If you have non-standard nodejs installation, select your project in Xcode," >&2
+  echo "find 'Build Phases' - 'Bundle React Native code and images'" >&2
+  echo "and change NODE_BINARY to absolute path to your node executable" >&2
+  echo "(you can find it by invoking 'which node' in the terminal)" >&2
+  exit 2
+}
+
+type "$NODE_BINARY" >/dev/null 2>&1 || nodejs_not_found

--- a/scripts/node-binary.sh
+++ b/scripts/node-binary.sh
@@ -8,11 +8,11 @@
 
 nodejs_not_found()
 {
-  echo "error: Can't find '$NODE_BINARY' binary to build React Native bundle" >&2
-  echo "If you have non-standard nodejs installation, select your project in Xcode," >&2
+  echo "error: Can't find '$NODE_BINARY' binary to build React Native bundle." >&2
+  echo "If you have a non-standard nodejs installation, select your project in Xcode," >&2
   echo "find 'Build Phases' - 'Bundle React Native code and images'" >&2
-  echo "and change NODE_BINARY to absolute path to your node executable" >&2
-  echo "(you can find it by invoking 'which node' in the terminal)" >&2
+  echo "and change NODE_BINARY to an absolute path to your node executable." >&2
+  echo "You can find it by invoking 'which node' in the terminal." >&2
   exit 2
 }
 

--- a/scripts/node-binary.sh
+++ b/scripts/node-binary.sh
@@ -9,8 +9,8 @@
 nodejs_not_found()
 {
   echo "error: Can't find the '$NODE_BINARY' binary to build the React Native bundle. " \
-       "If you have a non-standard Node.js installation, select your project in Xcode, find "\
-       "'Build Phases' - 'Bundle React Native code and images' and change NODE_BINARY to an "\
+       "If you have a non-standard Node.js installation, select your project in Xcode, find " \
+       "'Build Phases' - 'Bundle React Native code and images' and change NODE_BINARY to an " \
        "absolute path to your node executable. You can find it by invoking 'which node' in the terminal." >&2
   exit 2
 }

--- a/scripts/packager.sh
+++ b/scripts/packager.sh
@@ -14,7 +14,7 @@ PROJECT_ROOT="$THIS_DIR/../../.."
 source "${THIS_DIR}/.packager.env"
 
 # check and assign NODE_BINARY env
-# shellcheck source=node-binary.sh
+# shellcheck disable=SC1091
 source "${THIS_DIR}/node-binary.sh"
 
 # When running react-native tests, react-native doesn't live in node_modules but in the PROJECT_ROOT

--- a/scripts/packager.sh
+++ b/scripts/packager.sh
@@ -13,6 +13,9 @@ PROJECT_ROOT="$THIS_DIR/../../.."
 # shellcheck source=/dev/null
 source "${THIS_DIR}/.packager.env"
 
+# check and assign NODE_BINARY env
+source "${THIS_DIR}/node-binary.sh"
+
 # When running react-native tests, react-native doesn't live in node_modules but in the PROJECT_ROOT
 if [ ! -d "$PROJECT_ROOT/node_modules/react-native" ];
 then
@@ -20,4 +23,4 @@ then
 fi
 # Start packager from PROJECT_ROOT
 cd "$PROJECT_ROOT" || exit
-node "$REACT_NATIVE_ROOT/cli.js" start "$@"
+"$NODE_BINARY" "$REACT_NATIVE_ROOT/cli.js" start "$@"

--- a/scripts/packager.sh
+++ b/scripts/packager.sh
@@ -14,6 +14,7 @@ PROJECT_ROOT="$THIS_DIR/../../.."
 source "${THIS_DIR}/.packager.env"
 
 # check and assign NODE_BINARY env
+# shellcheck source=node-binary.sh
 source "${THIS_DIR}/node-binary.sh"
 
 # When running react-native tests, react-native doesn't live in node_modules but in the PROJECT_ROOT

--- a/scripts/react-native-xcode.sh
+++ b/scripts/react-native-xcode.sh
@@ -94,7 +94,7 @@ if [[ ! -x node && -d ${HOME}/.anyenv/bin ]]; then
 fi
 
 # check and assign NODE_BINARY env
-# shellcheck source=node-binary.sh
+# shellcheck disable=SC1091
 source './node-binary.sh'
 
 [ -z "$NODE_ARGS" ] && export NODE_ARGS=""

--- a/scripts/react-native-xcode.sh
+++ b/scripts/react-native-xcode.sh
@@ -93,7 +93,8 @@ if [[ ! -x node && -d ${HOME}/.anyenv/bin ]]; then
   fi
 fi
 
-[ -z "$NODE_BINARY" ] && export NODE_BINARY="node"
+# check and assign NODE_BINARY env
+source './node-binary.sh'
 
 [ -z "$NODE_ARGS" ] && export NODE_ARGS=""
 
@@ -106,18 +107,6 @@ if [[ -z "$BUNDLE_CONFIG" ]]; then
 else
   CONFIG_ARG="--config $BUNDLE_CONFIG"
 fi
-
-nodejs_not_found()
-{
-  echo "error: Can't find '$NODE_BINARY' binary to build React Native bundle" >&2
-  echo "If you have non-standard nodejs installation, select your project in Xcode," >&2
-  echo "find 'Build Phases' - 'Bundle React Native code and images'" >&2
-  echo "and change NODE_BINARY to absolute path to your node executable" >&2
-  echo "(you can find it by invoking 'which node' in the terminal)" >&2
-  exit 2
-}
-
-type "$NODE_BINARY" >/dev/null 2>&1 || nodejs_not_found
 
 BUNDLE_FILE="$DEST/main.jsbundle"
 

--- a/scripts/react-native-xcode.sh
+++ b/scripts/react-native-xcode.sh
@@ -94,6 +94,7 @@ if [[ ! -x node && -d ${HOME}/.anyenv/bin ]]; then
 fi
 
 # check and assign NODE_BINARY env
+# shellcheck source=node-binary.sh
 source './node-binary.sh'
 
 [ -z "$NODE_ARGS" ] && export NODE_ARGS=""


### PR DESCRIPTION
## Summary

Fix packager script to use `NODE_BINARY` env variable.

Should fix #22868 

## Changelog

[iOS] [Fixed] - Use `NODE_BINARY` env variable in `packager.sh` script

## Test Plan

A launched app in Debug and Release mode and running `packager.sh` directly from `node_modules`.

cc. @Nabellaleen - since I wasn't able to reproduce the crash, can you verify that this does work in your project?

