### PR TITLE
[Tests] Avoid failing Obj-C tests when xcpretty is not installed

### DIFF
--- a/scripts/objc-test-ios.sh
+++ b/scripts/objc-test-ios.sh
@@ -11,7 +11,7 @@
 # also run the RNTester integration test (needs JS and packager):
 # ./objc-test-ios.sh test
 
-set -ex
+set -e
 
 SCRIPTS=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 ROOT=$(dirname "$SCRIPTS")
@@ -25,6 +25,7 @@ export TEST_NAME="iOS"
 export SCHEME="RNTester"
 export SDK="iphonesimulator"
 export DESTINATION="platform=iOS Simulator,name=${IOS_DEVICE},OS=${IOS_TARGET_OS}"
+export USE_MODERN_BUILD_SYSTEM="NO"
 
 # If there's a "test" argument, pass it to the test script.
 ./scripts/objc-test.sh $1

--- a/scripts/objc-test-tvos.sh
+++ b/scripts/objc-test-tvos.sh
@@ -25,6 +25,7 @@ export TEST_NAME="tvOS"
 export SCHEME="RNTester-tvOS"
 export SDK="appletvsimulator"
 export DESTINATION="platform=tvOS Simulator,name=${TVOS_DEVICE},OS=${IOS_TARGET_OS}"
+export USE_MODERN_BUILD_SYSTEM="NO"
 
 # If there's a "test" argument, pass it to the test script.
 ./scripts/objc-test.sh $1


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Fixes an issue where `scripts/objc-test-ios.sh` would fail if `xcpretty` is not installed. As this tool is not bundled with macOS, and it's not explicitly called out in our docs on testing, the script should not fail if it's not present.

In a related change, JUnit reports are written to a more sensible location when the script is run outside of Circle CI.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog


<!-- Help reviewers and the release process by writing your own changelog entry. See http://facebook.github.io/react-native/docs/contributing#changelog for an example. -->

[iOS] [Fixed] - Fixed test script failure when xcpretty is not present

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Ran the script prior to installing xcpretty, and confirmed tests run to completion without issues.
