### PR TITLE
[Fabric] Ensure runtime established before created contextContainer

### DIFF
--- a/React/Fabric/RCTSurfacePresenter.mm
+++ b/React/Fabric/RCTSurfacePresenter.mm
@@ -221,6 +221,11 @@ using namespace facebook::react;
   _contextContainer->registerInstance(_reactNativeConfig, "ReactNativeConfig");
 
   auto messageQueueThread = _batchedBridge.jsMessageThread;
+  if (messageQueueThread) {
+    // Make sure initializeBridge completed
+    messageQueueThread->runOnQueueSync([] {});
+  }
+  
   auto runtime = (facebook::jsi::Runtime *)((RCTCxxBridge *)_batchedBridge).runtime;
 
   RuntimeExecutor runtimeExecutor =


### PR DESCRIPTION
## Summary

Ensure bridge finished initialize before we access runtime.
cc. @shergin.

## Changelog

[iOS] [Fixed] - Ensure runtime established before created contextContainer

## Test Plan

N/A.
