### PR TITLE
Add bin to package.json

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
  *

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "react-native",
   "version": "1000.0.0",
+  "bin": "./cli.js",
   "description": "A framework for building native apps using React",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary

Add `bin` field to `package.json`. It will be required for initializing `react-native` with `npx`:
```sh
npx react-native init ProjectName
```

## Changelog

[General] [Added] - Added bin to package.json

cc @thymikee @cpojer 
