### PR TITLE
Extended accessibility actions support

### DIFF
--- a/Libraries/Components/View/ViewAccessibility.js
+++ b/Libraries/Components/View/ViewAccessibility.js
@@ -10,6 +10,8 @@
 
 'use strict';
 
+import type {SyntheticEvent} from 'CoreEventTypes';
+
 // This must be kept in sync with the AccessibilityRolesMask in RCTViewManager.m
 export type AccessibilityRole =
   | 'none'
@@ -50,4 +52,17 @@ export type AccessibilityStates = $ReadOnlyArray<
   | 'expanded'
   | 'collapsed'
   | 'hasPopup',
+>;
+
+// the info associated with an accessibility action
+export type AccessibilityActionInfo = $ReadOnly<{
+  name: string,
+  label?: string,
+}>;
+
+// The info included in the event sent to onAccessibilityAction
+export type AccessibilityActionEvent = SyntheticEvent<
+  $ReadOnly<{
+    actionName: string,
+  }>,
 >;

--- a/Libraries/Components/View/ViewPropTypes.js
+++ b/Libraries/Components/View/ViewPropTypes.js
@@ -25,9 +25,8 @@ type DirectEventProps = $ReadOnly<{|
    * When `accessible` is true, the system will try to invoke this function
    * when the user performs an accessibility custom action.
    *
-   * @platform ios
    */
-  onAccessibilityAction?: ?(string) => void,
+  onAccessibilityAction?: ?(event: AccessibilityActionEvent) => void,
 
   /**
    * When `accessible` is true, the system will try to invoke this function
@@ -322,13 +321,6 @@ type AndroidViewProps = $ReadOnly<{|
 
 type IOSViewProps = $ReadOnly<{|
   /**
-   * Provides an array of custom actions available for accessibility.
-   *
-   * @platform ios
-   */
-  accessibilityActions?: ?$ReadOnlyArray<string>,
-
-  /**
    * Prevents view from being inverted if set to true and color inversion is turned on.
    *
    * @platform ios
@@ -416,6 +408,12 @@ export type ViewProps = $ReadOnly<{|
    * Indicates to accessibility services that UI Component is in a specific State.
    */
   accessibilityStates?: ?AccessibilityStates,
+
+  /**
+   * Provides an array of custom actions available for accessibility.
+   *
+   */
+  accessibilityActions?: ?$ReadOnlyArray<AccessibilityActionInfo>,
 
   /**
    * Used to locate this view in end-to-end tests.

--- a/Libraries/Components/View/ViewPropTypes.js
+++ b/Libraries/Components/View/ViewPropTypes.js
@@ -15,7 +15,12 @@ import type {EdgeInsetsProp} from 'EdgeInsetsPropType';
 import type React from 'React';
 import type {ViewStyleProp} from 'StyleSheet';
 import type {TVViewProps} from 'TVViewPropTypes';
-import type {AccessibilityRole, AccessibilityStates} from 'ViewAccessibility';
+import type {
+  AccessibilityRole,
+  AccessibilityStates,
+  AccessibilityActionEvent,
+  AccessibilityActionInfo,
+} from 'ViewAccessibility';
 
 export type ViewLayout = Layout;
 export type ViewLayoutEvent = LayoutEvent;

--- a/RNTester/js/AccessibilityExample.js
+++ b/RNTester/js/AccessibilityExample.js
@@ -410,6 +410,72 @@ class AccessibilityRoleAndStateExample extends React.Component<{}> {
   }
 }
 
+class AccessibilityActionsExample extends React.Component {
+  render() {
+    return (
+      <View>
+        <RNTesterBlock title="Non-touchable with activate action">
+          <View
+            accessible={true}
+            accessibilityActions={[{name: 'activate'}]}
+            onAccessibilityAction={event => {
+              switch (event.nativeEvent.actionName) {
+                case 'activate':
+                  Alert.alert('Alert', 'View is clicked');
+                  break;
+              }
+            }}>
+            <Text>Click me</Text>
+          </View>
+        </RNTesterBlock>
+
+        <RNTesterBlock title="View with multiple actions">
+          <View
+            accessible={true}
+            accessibilityActions={[
+              {name: 'cut', label: 'cut label'},
+              {name: 'copy', label: 'copy label'},
+              {name: 'paste', label: 'paste label'},
+            ]}
+            onAccessibilityAction={event => {
+              switch (event.nativeEvent.actionName) {
+                case 'cut':
+                  Alert.alert('Alert', 'cut action success');
+                  break;
+                case 'copy':
+                  Alert.alert('Alert', 'copy action success');
+                  break;
+                case 'paste':
+                  Alert.alert('Alert', 'paste action success');
+                  break;
+              }
+            }}>
+            <Text>This view supports many actions.</Text>
+          </View>
+        </RNTesterBlock>
+
+        <RNTesterBlock title="Adjustable with increment/decrement actions">
+          <View
+            accessible={true}
+            accessibilityRole="adjustable"
+            accessibilityActions={[{name: 'increment'}, {name: 'decrement'}]}
+            onAccessibilityAction={event => {
+              switch (event.nativeEvent.actionName) {
+                case 'increment':
+                  Alert.alert('Alert', 'increment action success');
+                  break;
+                case 'decrement':
+                  Alert.alert('Alert', 'decrement action success');
+                  break;
+              }
+            }}>
+            <Text>Slider</Text>
+          </View>
+        </RNTesterBlock>
+        </View>
+    );
+  }
+}
 class ScreenReaderStatusExample extends React.Component<{}> {
   state = {
     screenReaderEnabled: false,
@@ -465,6 +531,12 @@ exports.examples = [
     title: 'New accessibility roles and states',
     render(): React.Element<typeof AccessibilityRoleAndStateExamples> {
       return <AccessibilityRoleAndStateExample />;
+    },
+  },
+  {
+    title: 'Accessibility action examples',
+    render(): React.Element<typeof AccessibilityActionsExample> {
+      return <AccessibilityActionsExample />;
     },
   },
   {

--- a/RNTester/js/AccessibilityExample.js
+++ b/RNTester/js/AccessibilityExample.js
@@ -472,7 +472,7 @@ class AccessibilityActionsExample extends React.Component {
             <Text>Slider</Text>
           </View>
         </RNTesterBlock>
-        </View>
+      </View>
     );
   }
 }

--- a/RNTester/js/AccessibilityIOSExample.js
+++ b/RNTester/js/AccessibilityIOSExample.js
@@ -43,7 +43,7 @@ class AccessibilityIOSExample extends React.Component<Props> {
         <View
           onAccessibilityAction={event => {
             if (event.nativeEvent.actionName === 'escape') {
-              alert('onAccessibilityEscape success');
+              Alert.alert('onAccessibilityEscape success');
             }
           }}
           accessible={true}

--- a/RNTester/js/AccessibilityIOSExample.js
+++ b/RNTester/js/AccessibilityIOSExample.js
@@ -21,22 +21,33 @@ class AccessibilityIOSExample extends React.Component<Props> {
     return (
       <RNTesterBlock title="Accessibility iOS APIs">
         <View
-          onAccessibilityTap={() =>
-            Alert.alert('Alert', 'onAccessibilityTap success')
-          }
-          accessible={true}>
+          onAccessibilityAction={event => {
+            if (event.nativeEvent.actionName === 'activate') {
+              Alert.alert('Alert', 'onAccessibilityTap success');
+            }
+          }}
+          accessible={true}
+          accessibilityActions={[{name: 'activate'}]}>
           <Text>Accessibility normal tap example</Text>
         </View>
         <View
-          onMagicTap={() => Alert.alert('Alert', 'onMagicTap success')}
-          accessible={true}>
+          onAccessibilityAction={event => {
+            if (event.nativeEvent.actionName === 'magicTap') {
+              Alert.alert('Alert', 'onMagicTap success');
+            }
+          }}
+          accessible={true}
+          accessibilityActions={[{name: 'magicTap'}]}>
           <Text>Accessibility magic tap example</Text>
         </View>
         <View
-          onAccessibilityEscape={() =>
-            Alert.alert('onAccessibilityEscape success')
-          }
-          accessible={true}>
+          onAccessibilityAction={event => {
+            if (event.nativeEvent.actionName === 'escape') {
+              alert('onAccessibilityEscape success');
+            }
+          }}
+          accessible={true}
+          accessibilityActions={[{name: 'escape'}]}>
           <Text>Accessibility escape example</Text>
         </View>
         <View accessibilityElementsHidden={true}>

--- a/React/Views/RCTView.h
+++ b/React/Views/RCTView.h
@@ -31,9 +31,10 @@ extern const UIAccessibilityTraits SwitchAccessibilityTrait;
 /**
  * Accessibility properties
  */
-@property (nonatomic, copy) NSArray <NSString *> *accessibilityActions;
 @property (nonatomic, copy) NSString *accessibilityRole;
 @property (nonatomic, copy) NSArray <NSString *> *accessibilityStates;
+@property (nonatomic, copy) NSArray <NSDictionary *> *accessibilityActions;
+@property (nonatomic, copy) NSDictionary *accessibilityActionsMap;
 
 /**
  * Used to control how touch events are processed.

--- a/React/Views/RCTView.h
+++ b/React/Views/RCTView.h
@@ -34,7 +34,6 @@ extern const UIAccessibilityTraits SwitchAccessibilityTrait;
 @property (nonatomic, copy) NSString *accessibilityRole;
 @property (nonatomic, copy) NSArray <NSString *> *accessibilityStates;
 @property (nonatomic, copy) NSArray <NSDictionary *> *accessibilityActions;
-@property (nonatomic, copy) NSDictionary *accessibilityActionsMap;
 
 /**
  * Used to control how touch events are processed.

--- a/React/Views/RCTView.m
+++ b/React/Views/RCTView.m
@@ -101,8 +101,8 @@ static NSString *RCTRecursiveAccessibilityLabel(UIView *view)
 @implementation RCTView
 {
   UIColor *_backgroundColor;
-  NSMutableDictionary *accessibilityActionsNameMap;
-  NSMutableDictionary *accessibilityActionsLabelMap;
+  NSMutableDictionary<NSString *, NSDictionary *> *accessibilityActionsNameMap;
+  NSMutableDictionary<NSString *, NSDictionary *> *accessibilityActionsLabelMap;
 }
 
 - (instancetype)initWithFrame:(CGRect)frame
@@ -160,10 +160,9 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:unused)
 
 -(void)setAccessibilityActions:(NSArray *)actions
 {
-  if (!actions || !actions.count) {
+  if (!actions) {
     return;
   }
-  _accessibilityActions = [NSMutableArray array];
   accessibilityActionsNameMap = [[NSMutableDictionary alloc] init];
   accessibilityActionsLabelMap = [[NSMutableDictionary alloc] init];
   for (NSDictionary *action in actions) {
@@ -179,7 +178,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:unused)
 
 - (NSArray <UIAccessibilityCustomAction *> *)accessibilityCustomActions
 {
-  if (!_accessibilityActions || !_accessibilityActions.count) {
+  if (!_accessibilityActions.count) {
     return nil;
   }
 
@@ -375,8 +374,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:unused)
   else if (_onAccessibilityTap) {
     _onAccessibilityTap(nil);
     return YES;
-  }
-       else {
+  } else {
     return NO;
        }
 }
@@ -385,12 +383,10 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:unused)
 {
   if ([self performAccessibilityAction:@"magicTap"]) {
     return YES;
-  }
-  else if (_onMagicTap) {
+  } else if (_onMagicTap) {
     _onMagicTap(nil);
     return YES;
-  }
-  else {
+  } else {
     return NO;
   }
 }
@@ -399,12 +395,10 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:unused)
 {
   if ([self performAccessibilityAction:@"escape"]) {
     return YES;
-  }
-  else if (_onAccessibilityEscape) {
+  } else if (_onAccessibilityEscape) {
     _onAccessibilityEscape(nil);
     return YES;
-  }
-  else {
+  } else {
     return NO;
   }
 }

--- a/React/Views/RCTViewManager.m
+++ b/React/Views/RCTViewManager.m
@@ -123,7 +123,10 @@ RCT_EXPORT_VIEW_PROPERTY(tvParallaxProperties, NSDictionary)
 
 // Acessibility related properties
 RCT_REMAP_VIEW_PROPERTY(accessible, reactAccessibilityElement.isAccessibilityElement, BOOL)
-RCT_REMAP_VIEW_PROPERTY(accessibilityActions, reactAccessibilityElement.accessibilityActions, NSArray<NSString *>)
+RCT_CUSTOM_VIEW_PROPERTY(accessibilityActions, NSArray<NSDictionary *> *, RCTView)
+{
+    view.accessibilityActions = json ? [RCTConvert NSDictionaryArray:json] : nil;
+}
 RCT_REMAP_VIEW_PROPERTY(accessibilityLabel, reactAccessibilityElement.accessibilityLabel, NSString)
 RCT_REMAP_VIEW_PROPERTY(accessibilityHint, reactAccessibilityElement.accessibilityHint, NSString)
 RCT_REMAP_VIEW_PROPERTY(accessibilityViewIsModal, reactAccessibilityElement.accessibilityViewIsModal, BOOL)

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/AccessibilityDelegateUtil.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/AccessibilityDelegateUtil.java
@@ -44,6 +44,7 @@ public class AccessibilityDelegateUtil {
   public static final HashMap<String, Integer> sActionIdMap= new HashMap<>();
   static {
       sActionIdMap.put("activate", AccessibilityActionCompat.ACTION_CLICK.getId());
+      sActionIdMap.put("longpress", AccessibilityActionCompat.ACTION_LONG_CLICK.getId());
       sActionIdMap.put("increment", AccessibilityActionCompat.ACTION_SCROLL_FORWARD.getId());
       sActionIdMap.put("decrement", AccessibilityActionCompat.ACTION_SCROLL_BACKWARD.getId());      
   }

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/AccessibilityDelegateUtil.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/AccessibilityDelegateUtil.java
@@ -5,10 +5,12 @@
 
 package com.facebook.react.uimanager;
 
+import android.os.Bundle;
 import android.content.Context;
 import androidx.core.view.AccessibilityDelegateCompat;
 import androidx.core.view.ViewCompat;
 import androidx.core.view.accessibility.AccessibilityNodeInfoCompat;
+import androidx.core.view.accessibility.AccessibilityNodeInfoCompat.AccessibilityActionCompat;
 import androidx.core.view.accessibility.AccessibilityNodeInfoCompat.CollectionItemInfoCompat;
 import android.text.SpannableString;
 import android.text.style.URLSpan;
@@ -17,8 +19,16 @@ import androidx.core.view.ViewCompat;
 import androidx.core.view.accessibility.AccessibilityNodeInfoCompat;
 import androidx.core.view.accessibility.AccessibilityNodeInfoCompat.CollectionItemInfoCompat;
 import android.view.View;
+
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReadableArray;
+import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.uimanager.events.RCTEventEmitter;
 import com.facebook.react.R;
+
+import java.util.HashMap;
 import java.util.Locale;
 import javax.annotation.Nullable;
 
@@ -28,6 +38,17 @@ import javax.annotation.Nullable;
  */
 
 public class AccessibilityDelegateUtil {
+
+  private static int sCounter = 0x3f000000;
+
+  public static final HashMap<String, Integer> sActionIdMap= new HashMap<>();
+  static {
+      sActionIdMap.put("activate", AccessibilityActionCompat.ACTION_CLICK.getId());
+      sActionIdMap.put("increment", AccessibilityActionCompat.ACTION_SCROLL_FORWARD.getId());
+      sActionIdMap.put("decrement", AccessibilityActionCompat.ACTION_SCROLL_BACKWARD.getId());      
+  }
+
+  public static HashMap<Integer, String> mAccessibilityActionsMap = new HashMap<>();
 
   /**
    * These roles are defined by Google's TalkBack screen reader, and this list
@@ -105,11 +126,13 @@ public class AccessibilityDelegateUtil {
 
   public static void setDelegate(final View view) {
     final AccessibilityRole accessibilityRole = (AccessibilityRole) view.getTag(R.id.accessibility_role);
+    final ReadableArray accessibilityActions = (ReadableArray) view.getTag(R.id.accessibility_actions);
+
     // if a view already has an accessibility delegate, replacing it could cause
     // problems,
     // so leave it alone.
     if (!ViewCompat.hasAccessibilityDelegate(view)
-        && (accessibilityRole != null || view.getTag(R.id.accessibility_states) != null)) {
+        && (accessibilityRole != null || view.getTag(R.id.accessibility_states) != null || accessibilityActions != null)) {
       ViewCompat.setAccessibilityDelegate(view, new AccessibilityDelegateCompat() {
         @Override
         public void onInitializeAccessibilityNodeInfo(View host, AccessibilityNodeInfoCompat info) {
@@ -120,6 +143,39 @@ public class AccessibilityDelegateUtil {
           if (accessibilityStates != null) {
             setState(info, accessibilityStates, view.getContext());
           }
+          if (accessibilityActions != null) {
+            for (int i = 0; i < accessibilityActions.size(); i++) {
+              ReadableMap action = accessibilityActions.getMap(i);
+              if (!action.hasKey("name")) {
+                throw new IllegalArgumentException("Unknown accessibility action.");
+              }
+              int actionId = sCounter;
+              String actionLabel = action.hasKey("label") ? action.getString("label") : null;
+              if (sActionIdMap.containsKey(action.getString("name"))) {
+                actionId = sActionIdMap.get(action.getString("name"));
+              } else {
+                sCounter++;
+              }
+              mAccessibilityActionsMap.put(actionId, action.getString("name"));
+              AccessibilityActionCompat accessibilityAction = new AccessibilityActionCompat(actionId, actionLabel);
+              info.addAction(accessibilityAction);
+            }
+          }
+        }
+
+        @Override
+        public boolean performAccessibilityAction(View host, int action, Bundle args) {
+          if (mAccessibilityActionsMap.containsKey(action)) {
+            WritableMap event = Arguments.createMap();
+            event.putString("actionName", mAccessibilityActionsMap.get(action));
+            ReactContext reactContext = (ReactContext)host.getContext();
+            reactContext.getJSModule(RCTEventEmitter.class).receiveEvent(
+                    host.getId(),
+                    "performAction",
+                    event);
+            return true;
+          }
+          return super.performAccessibilityAction(host, action, args);
         }
       });
     }

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
@@ -14,11 +14,13 @@ import java.util.HashMap;
 
 import com.facebook.react.R;
 import com.facebook.react.bridge.ReadableArray;
+import com.facebook.react.common.MapBuilder;
 import com.facebook.react.uimanager.AccessibilityDelegateUtil.AccessibilityRole;
 import com.facebook.react.uimanager.annotations.ReactProp;
 import com.facebook.react.uimanager.util.ReactFindViewUtil;
 
 import javax.annotation.Nonnull;
+import java.util.Map;
 import javax.annotation.Nullable;
 
 /**
@@ -38,6 +40,7 @@ public abstract class BaseViewManager<T extends View, C extends LayoutShadowNode
   private static final String PROP_ACCESSIBILITY_LIVE_REGION = "accessibilityLiveRegion";
   private static final String PROP_ACCESSIBILITY_ROLE = "accessibilityRole";
   private static final String PROP_ACCESSIBILITY_STATES = "accessibilityStates";
+  private static final String PROP_ACCESSIBILITY_ACTIONS = "accessibilityActions";
   private static final String PROP_IMPORTANT_FOR_ACCESSIBILITY = "importantForAccessibility";
 
   // DEPRECATED
@@ -178,6 +181,15 @@ public abstract class BaseViewManager<T extends View, C extends LayoutShadowNode
     }
   }
 
+  @ReactProp(name = PROP_ACCESSIBILITY_ACTIONS)
+  public void setAccessibilityActions(T view, ReadableArray accessibilityActions) {
+    if (accessibilityActions == null) {
+      return;
+    }
+
+    view.setTag(R.id.accessibility_actions, accessibilityActions);
+  }
+
   @ReactProp(name = PROP_IMPORTANT_FOR_ACCESSIBILITY)
   public void setImportantForAccessibility(@Nonnull T view, @Nullable String importantForAccessibility) {
     if (importantForAccessibility == null || importantForAccessibility.equals("auto")) {
@@ -287,5 +299,12 @@ public abstract class BaseViewManager<T extends View, C extends LayoutShadowNode
   protected void onAfterUpdateTransaction(@Nonnull T view) {
     super.onAfterUpdateTransaction(view);
     updateViewAccessibility(view);
+  }
+
+  @Override
+  public @Nullable Map<String, Object> getExportedCustomDirectEventTypeConstants() {
+    return MapBuilder.<String, Object>builder()
+          .put("performAction", MapBuilder.of("registrationName", "onAccessibilityAction"))
+          .build();
   }
 }

--- a/ReactAndroid/src/main/res/views/uimanager/values/ids.xml
+++ b/ReactAndroid/src/main/res/views/uimanager/values/ids.xml
@@ -21,4 +21,7 @@
   <!--tag is used to store accessibilityLabel tag-->
   <item type="id" name="accessibility_label"/>
 
+  <!--tag is used to store accessibilityActions tag-->
+  <item type="id" name="accessibility_actions"/>
+
 </resources>


### PR DESCRIPTION
## Summary

Extend accessibility actions to include both  name (non-localized) and label (localized). this lets components provide programmatic access to custom actions, as well as standard actions such as slider adjustment and scrolling. This also means that when applications process actions, they need not compare against a localized name, which will be different for every language.

## Changelog

[general] [change] - Extend accessibility actions support.

## Test Plan

We have added tests in RNTester which exercise both custom actions, as well as standard actions.