### PR TITLE
[Fabric] Fix invalid CGContext when invalidate layer

### DIFF
--- a/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -356,10 +356,12 @@ static RCTBorderStyle RCTBorderStyleFromBorderStyle(BorderStyle borderStyle)
 
 - (void)invalidateLayer
 {
+  CALayer *layer = self.layer;
+  if (CGSizeEqualToSize(layer.bounds.size, CGSizeZero)) {
+    return;
+  }
   const auto borderMetrics =
       _props->resolveBorderMetrics(_layoutMetrics.layoutDirection == LayoutDirection::RightToLeft);
-
-  CALayer *layer = self.layer;
 
   // Stage 1. Shadow Path
   BOOL layerHasShadow = layer.shadowOpacity > 0 && CGColorGetAlpha(layer.shadowColor) > 0;

--- a/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -357,9 +357,11 @@ static RCTBorderStyle RCTBorderStyleFromBorderStyle(BorderStyle borderStyle)
 - (void)invalidateLayer
 {
   CALayer *layer = self.layer;
+
   if (CGSizeEqualToSize(layer.bounds.size, CGSizeZero)) {
     return;
   }
+
   const auto borderMetrics =
       _props->resolveBorderMetrics(_layoutMetrics.layoutDirection == LayoutDirection::RightToLeft);
 


### PR DESCRIPTION
## Summary

If size is zero, the `CGContext` would invalid, so we need to filter zero things.
cc. @shergin 

## Changelog

[iOS] [Fixed] - Fix invalid CGContext when invalidate layer

## Test Plan

N/A