### PR TITLE
Make AnimatedComponents and Touchables strict mode compatible

### DIFF
--- a/Libraries/Animated/src/createAnimatedComponent.js
+++ b/Libraries/Animated/src/createAnimatedComponent.js
@@ -35,6 +35,8 @@ function createAnimatedComponent(Component: any): any {
 
     constructor(props: Object) {
       super(props);
+
+      this._attachProps(this.props);
     }
 
     componentWillUnmount() {
@@ -44,10 +46,6 @@ function createAnimatedComponent(Component: any): any {
 
     setNativeProps(props) {
       this._component.setNativeProps(props);
-    }
-
-    UNSAFE_componentWillMount() {
-      this._attachProps(this.props);
     }
 
     componentDidMount() {
@@ -131,11 +129,9 @@ function createAnimatedComponent(Component: any): any {
       oldPropsAnimated && oldPropsAnimated.__detach();
     }
 
-    UNSAFE_componentWillReceiveProps(newProps) {
-      this._attachProps(newProps);
-    }
-
     componentDidUpdate(prevProps) {
+      this._attachProps(this.props);
+
       if (this._component !== this._prevComponent) {
         this._propsAnimated.setNativeView(this._component);
       }

--- a/Libraries/Components/Touchable/TouchableHighlight.js
+++ b/Libraries/Components/Touchable/TouchableHighlight.js
@@ -9,45 +9,78 @@
  */
 'use strict';
 
-const DeprecatedColorPropType = require('DeprecatedColorPropType');
-const DeprecatedViewPropTypes = require('DeprecatedViewPropTypes');
-const NativeMethodsMixin = require('NativeMethodsMixin');
 const Platform = require('Platform');
-const PropTypes = require('prop-types');
 const React = require('React');
 const ReactNativeViewAttributes = require('ReactNativeViewAttributes');
 const StyleSheet = require('StyleSheet');
 const Touchable = require('Touchable');
-const TouchableWithoutFeedback = require('TouchableWithoutFeedback');
 const View = require('View');
 
-const createReactClass = require('create-react-class');
 const ensurePositiveDelayProps = require('ensurePositiveDelayProps');
 
 import type {PressEvent} from 'CoreEventTypes';
 import type {ViewStyleProp} from 'StyleSheet';
 import type {ColorValue} from 'StyleSheetTypes';
+import type {BlurEvent, FocusEvent, TouchableState} from 'Touchable';
 import type {Props as TouchableWithoutFeedbackProps} from 'TouchableWithoutFeedback';
 import type {TVParallaxPropertiesType} from 'TVViewPropTypes';
-
-const DEFAULT_PROPS = {
-  activeOpacity: 0.85,
-  delayPressOut: 100,
-  underlayColor: 'black',
-};
 
 const PRESS_RETENTION_OFFSET = {top: 20, left: 20, right: 20, bottom: 30};
 
 type IOSProps = $ReadOnly<{|
-  hasTVPreferredFocus?: ?boolean,
-  tvParallaxProperties?: ?TVParallaxPropertiesType,
+  /**
+   * *(Apple TV only)* TV preferred focus (see documentation for the View component).
+   *
+   * @platform ios
+   */
+  hasTVPreferredFocus?: boolean,
+  /**
+   * *(Apple TV only)* Object with properties to control Apple TV parallax effects.
+   *
+   * enabled: If true, parallax effects are enabled.  Defaults to true.
+   * shiftDistanceX: Defaults to 2.0.
+   * shiftDistanceY: Defaults to 2.0.
+   * tiltAngle: Defaults to 0.05.
+   * magnification: Defaults to 1.0.
+   * pressMagnification: Defaults to 1.0.
+   * pressDuration: Defaults to 0.3.
+   * pressDelay: Defaults to 0.0.
+   *
+   * @platform ios
+   */
+  tvParallaxProperties?: TVParallaxPropertiesType,
 |}>;
 
 type AndroidProps = $ReadOnly<{|
+  /**
+   * TV next focus down (see documentation for the View component).
+   *
+   * @platform android
+   */
   nextFocusDown?: ?number,
+  /**
+   * TV next focus forward (see documentation for the View component).
+   *
+   * @platform android
+   */
   nextFocusForward?: ?number,
+  /**
+   * TV next focus left (see documentation for the View component).
+   *
+   * @platform android
+   */
   nextFocusLeft?: ?number,
+  /**
+   * TV next focus right (see documentation for the View component).
+   *
+   * @platform android
+   */
   nextFocusRight?: ?number,
+  /**
+   * TV next focus up (see documentation for the View component).
+   *
+   * @platform android
+   */
   nextFocusUp?: ?number,
 |}>;
 
@@ -56,13 +89,63 @@ type Props = $ReadOnly<{|
   ...IOSProps,
   ...AndroidProps,
 
-  activeOpacity?: ?number,
-  underlayColor?: ?ColorValue,
+  /**
+   * Determines what the opacity of the wrapped view should be when touch is
+   * active.
+   */
+  activeOpacity: number,
+  /**
+   * The color of the underlay that will show through when the touch is
+   * active.
+   */
+  underlayColor: ColorValue,
+  /**
+   * Delay in ms, from the release of the touch, before onPressOut is called.
+   */
+  delayPressOut: number,
+  /**
+   * Style to apply to the container/underlay. Most commonly used to make sure
+   * rounded corners match the wrapped component.
+   */
   style?: ?ViewStyleProp,
+  /**
+   * Called immediately after the underlay is shown
+   */
   onShowUnderlay?: ?() => void,
+  /**
+   * Called immediately after the underlay is hidden
+   */
   onHideUnderlay?: ?() => void,
+  /**
+   * Handy for snapshot tests.
+   */
   testOnly_pressed?: ?boolean,
 |}>;
+
+type State = {|
+  ...TouchableState,
+
+  extraChildStyle: ?{
+    opacity: number,
+  },
+  extraUnderlayStyle: ?{|
+    backgroundColor: ColorValue,
+  |},
+|};
+
+function createTouchMixin(
+  node: React.ElementRef<typeof TouchableHighlight>,
+): typeof Touchable.MixinWithoutDefaultFocusAndBlur {
+  const touchMixin = {...Touchable.MixinWithoutDefaultFocusAndBlur};
+
+  for (const key in touchMixin) {
+    if (typeof touchMixin[key] === 'function') {
+      touchMixin[key] = touchMixin[key].bind(node);
+    }
+  }
+
+  return touchMixin;
+}
 
 /**
  * A wrapper for making views respond properly to touches.
@@ -160,103 +243,46 @@ type Props = $ReadOnly<{|
  * ```
  *
  */
+class TouchableHighlight extends React.Component<Props, State> {
+  static defaultProps = {
+    activeOpacity: 0.85,
+    delayPressOut: 100,
+    underlayColor: 'black',
+  };
 
-const TouchableHighlight = ((createReactClass({
-  displayName: 'TouchableHighlight',
-  propTypes: {
-    /* $FlowFixMe(>=0.89.0 site=react_native_fb) This comment suppresses an
-     * error found when Flow v0.89 was deployed. To see the error, delete this
-     * comment and run Flow. */
-    ...TouchableWithoutFeedback.propTypes,
-    /**
-     * Determines what the opacity of the wrapped view should be when touch is
-     * active.
-     */
-    activeOpacity: PropTypes.number,
-    /**
-     * The color of the underlay that will show through when the touch is
-     * active.
-     */
-    underlayColor: DeprecatedColorPropType,
-    /**
-     * Style to apply to the container/underlay. Most commonly used to make sure
-     * rounded corners match the wrapped component.
-     */
-    style: DeprecatedViewPropTypes.style,
-    /**
-     * Called immediately after the underlay is shown
-     */
-    onShowUnderlay: PropTypes.func,
-    /**
-     * Called immediately after the underlay is hidden
-     */
-    onHideUnderlay: PropTypes.func,
-    /**
-     * *(Apple TV only)* TV preferred focus (see documentation for the View component).
-     *
-     * @platform ios
-     */
-    hasTVPreferredFocus: PropTypes.bool,
-    /**
-     * TV next focus down (see documentation for the View component).
-     *
-     * @platform android
-     */
-    nextFocusDown: PropTypes.number,
-    /**
-     * TV next focus forward (see documentation for the View component).
-     *
-     * @platform android
-     */
-    nextFocusForward: PropTypes.number,
-    /**
-     * TV next focus left (see documentation for the View component).
-     *
-     * @platform android
-     */
-    nextFocusLeft: PropTypes.number,
-    /**
-     * TV next focus right (see documentation for the View component).
-     *
-     * @platform android
-     */
-    nextFocusRight: PropTypes.number,
-    /**
-     * TV next focus up (see documentation for the View component).
-     *
-     * @platform android
-     */
-    nextFocusUp: PropTypes.number,
-    /**
-     * *(Apple TV only)* Object with properties to control Apple TV parallax effects.
-     *
-     * enabled: If true, parallax effects are enabled.  Defaults to true.
-     * shiftDistanceX: Defaults to 2.0.
-     * shiftDistanceY: Defaults to 2.0.
-     * tiltAngle: Defaults to 0.05.
-     * magnification: Defaults to 1.0.
-     * pressMagnification: Defaults to 1.0.
-     * pressDuration: Defaults to 0.3.
-     * pressDelay: Defaults to 0.0.
-     *
-     * @platform ios
-     */
-    tvParallaxProperties: PropTypes.object,
-    /**
-     * Handy for snapshot tests.
-     */
-    testOnly_pressed: PropTypes.bool,
-  },
+  _touchMixin: typeof Touchable.MixinWithoutDefaultFocusAndBlur = createTouchMixin(
+    this,
+  );
 
-  mixins: [NativeMethodsMixin, Touchable.Mixin.withoutDefaultFocusAndBlur],
+  _isMounted: boolean;
 
-  getDefaultProps: () => DEFAULT_PROPS,
+  _hideTimeout: ?TimeoutID;
 
-  getInitialState: function() {
+  constructor(props: Props) {
+    super(props);
+
+    const touchMixin = Touchable.MixinWithoutDefaultFocusAndBlur;
+    for (const key in touchMixin) {
+      if (
+        typeof touchMixin[key] === 'function' &&
+        (key.startsWith('_') || key.startsWith('touchable'))
+      ) {
+        // $FlowFixMe - dynamically adding properties to a class
+        (this: any)[key] = touchMixin[key].bind(this);
+      }
+    }
+
+    Object.keys(touchMixin)
+      .filter(key => typeof touchMixin[key] !== 'function')
+      .forEach(key => {
+        // $FlowFixMe - dynamically adding properties to a class
+        (this: any)[key] = touchMixin[key];
+      });
+
     this._isMounted = false;
     if (this.props.testOnly_pressed) {
-      return {
-        ...this.touchableGetInitialState(),
+      this.state = {
+        ...this._touchMixin.touchableGetInitialState(),
         extraChildStyle: {
           opacity: this.props.activeOpacity,
         },
@@ -265,66 +291,70 @@ const TouchableHighlight = ((createReactClass({
         },
       };
     } else {
-      return {
-        ...this.touchableGetInitialState(),
+      this.state = {
+        ...this._touchMixin.touchableGetInitialState(),
         extraChildStyle: null,
         extraUnderlayStyle: null,
       };
     }
-  },
+  }
 
-  componentDidMount: function() {
+  componentDidMount() {
     this._isMounted = true;
     ensurePositiveDelayProps(this.props);
-  },
 
-  componentWillUnmount: function() {
+    this._touchMixin.componentDidMount();
+  }
+
+  componentDidUpdate(prevProps: Props, prevState: State) {
+    ensurePositiveDelayProps(this.props);
+  }
+
+  componentWillUnmount() {
     this._isMounted = false;
     clearTimeout(this._hideTimeout);
-  },
 
-  UNSAFE_componentWillReceiveProps: function(nextProps) {
-    ensurePositiveDelayProps(nextProps);
-  },
+    this._touchMixin.componentWillUnmount();
+  }
 
-  viewConfig: {
+  static viewConfig = {
     uiViewClassName: 'RCTView',
     validAttributes: ReactNativeViewAttributes.RCTView,
-  },
+  };
 
   /**
    * `Touchable.Mixin` self callbacks. The mixin will invoke these if they are
    * defined on your component.
    */
-  touchableHandleActivePressIn: function(e: PressEvent) {
+  touchableHandleActivePressIn(e: PressEvent) {
     clearTimeout(this._hideTimeout);
     this._hideTimeout = null;
     this._showUnderlay();
     this.props.onPressIn && this.props.onPressIn(e);
-  },
+  }
 
-  touchableHandleActivePressOut: function(e: PressEvent) {
+  touchableHandleActivePressOut(e: PressEvent) {
     if (!this._hideTimeout) {
       this._hideUnderlay();
     }
     this.props.onPressOut && this.props.onPressOut(e);
-  },
+  }
 
-  touchableHandleFocus: function(e: Event) {
+  touchableHandleFocus(e: FocusEvent) {
     if (Platform.isTV) {
       this._showUnderlay();
     }
     this.props.onFocus && this.props.onFocus(e);
-  },
+  }
 
-  touchableHandleBlur: function(e: Event) {
+  touchableHandleBlur(e: BlurEvent) {
     if (Platform.isTV) {
       this._hideUnderlay();
     }
     this.props.onBlur && this.props.onBlur(e);
-  },
+  }
 
-  touchableHandlePress: function(e: PressEvent) {
+  touchableHandlePress(e: PressEvent) {
     clearTimeout(this._hideTimeout);
     if (!Platform.isTV) {
       this._showUnderlay();
@@ -334,33 +364,33 @@ const TouchableHighlight = ((createReactClass({
       );
     }
     this.props.onPress && this.props.onPress(e);
-  },
+  }
 
-  touchableHandleLongPress: function(e: PressEvent) {
+  touchableHandleLongPress(e: PressEvent) {
     this.props.onLongPress && this.props.onLongPress(e);
-  },
+  }
 
-  touchableGetPressRectOffset: function() {
+  touchableGetPressRectOffset() {
     return this.props.pressRetentionOffset || PRESS_RETENTION_OFFSET;
-  },
+  }
 
-  touchableGetHitSlop: function() {
+  touchableGetHitSlop() {
     return this.props.hitSlop;
-  },
+  }
 
-  touchableGetHighlightDelayMS: function() {
+  touchableGetHighlightDelayMS() {
     return this.props.delayPressIn;
-  },
+  }
 
-  touchableGetLongPressDelayMS: function() {
+  touchableGetLongPressDelayMS() {
     return this.props.delayLongPress;
-  },
+  }
 
-  touchableGetPressOutDelayMS: function() {
+  touchableGetPressOutDelayMS() {
     return this.props.delayPressOut;
-  },
+  }
 
-  _showUnderlay: function() {
+  _showUnderlay() {
     if (!this._isMounted || !this._hasPressHandler()) {
       return;
     }
@@ -373,9 +403,9 @@ const TouchableHighlight = ((createReactClass({
       },
     });
     this.props.onShowUnderlay && this.props.onShowUnderlay();
-  },
+  }
 
-  _hideUnderlay: function() {
+  _hideUnderlay = () => {
     clearTimeout(this._hideTimeout);
     this._hideTimeout = null;
     if (this.props.testOnly_pressed) {
@@ -388,18 +418,18 @@ const TouchableHighlight = ((createReactClass({
       });
       this.props.onHideUnderlay && this.props.onHideUnderlay();
     }
-  },
+  };
 
-  _hasPressHandler: function() {
+  _hasPressHandler() {
     return !!(
       this.props.onPress ||
       this.props.onPressIn ||
       this.props.onPressOut ||
       this.props.onLongPress
     );
-  },
+  }
 
-  render: function() {
+  render() {
     const child = React.Children.only(this.props.children);
     return (
       <View
@@ -422,14 +452,18 @@ const TouchableHighlight = ((createReactClass({
         nextFocusLeft={this.props.nextFocusLeft}
         nextFocusRight={this.props.nextFocusRight}
         nextFocusUp={this.props.nextFocusUp}
-        onStartShouldSetResponder={this.touchableHandleStartShouldSetResponder}
-        onResponderTerminationRequest={
-          this.touchableHandleResponderTerminationRequest
+        onStartShouldSetResponder={
+          this._touchMixin.touchableHandleStartShouldSetResponder
         }
-        onResponderGrant={this.touchableHandleResponderGrant}
-        onResponderMove={this.touchableHandleResponderMove}
-        onResponderRelease={this.touchableHandleResponderRelease}
-        onResponderTerminate={this.touchableHandleResponderTerminate}
+        onResponderTerminationRequest={
+          this._touchMixin.touchableHandleResponderTerminationRequest
+        }
+        onResponderGrant={this._touchMixin.touchableHandleResponderGrant}
+        onResponderMove={this._touchMixin.touchableHandleResponderMove}
+        onResponderRelease={this._touchMixin.touchableHandleResponderRelease}
+        onResponderTerminate={
+          this._touchMixin.touchableHandleResponderTerminate
+        }
         nativeID={this.props.nativeID}
         testID={this.props.testID}>
         {React.cloneElement(child, {
@@ -444,7 +478,7 @@ const TouchableHighlight = ((createReactClass({
         })}
       </View>
     );
-  },
-}): any): React.ComponentType<Props>);
+  }
+}
 
 module.exports = TouchableHighlight;

--- a/Libraries/Components/Touchable/TouchableOpacity.js
+++ b/Libraries/Components/Touchable/TouchableOpacity.js
@@ -12,17 +12,14 @@
 
 const Animated = require('Animated');
 const Easing = require('Easing');
-const NativeMethodsMixin = require('NativeMethodsMixin');
 const Platform = require('Platform');
 const React = require('React');
-const PropTypes = require('prop-types');
 const Touchable = require('Touchable');
-const TouchableWithoutFeedback = require('TouchableWithoutFeedback');
 
-const createReactClass = require('create-react-class');
 const ensurePositiveDelayProps = require('ensurePositiveDelayProps');
 const flattenStyle = require('flattenStyle');
 
+import type {BlurEvent, FocusEvent, TouchableState} from 'Touchable';
 import type {Props as TouchableWithoutFeedbackProps} from 'TouchableWithoutFeedback';
 import type {ViewStyleProp} from 'StyleSheet';
 import type {TVParallaxPropertiesType} from 'TVViewPropTypes';
@@ -31,21 +28,77 @@ import type {PressEvent} from 'CoreEventTypes';
 const PRESS_RETENTION_OFFSET = {top: 20, left: 20, right: 20, bottom: 30};
 
 type TVProps = $ReadOnly<{|
+  /**
+   * TV preferred focus (see documentation for the View component).
+   */
   hasTVPreferredFocus?: ?boolean,
+  /**
+   * TV next focus down (see documentation for the View component).
+   *
+   * @platform android
+   */
   nextFocusDown?: ?number,
+  /**
+   * TV next focus forward (see documentation for the View component).
+   *
+   * @platform android
+   */
   nextFocusForward?: ?number,
+  /**
+   * TV next focus left (see documentation for the View component).
+   *
+   * @platform android
+   */
   nextFocusLeft?: ?number,
+  /**
+   * TV next focus right (see documentation for the View component).
+   *
+   * @platform android
+   */
   nextFocusRight?: ?number,
+  /**
+   * TV next focus up (see documentation for the View component).
+   *
+   * @platform android
+   */
   nextFocusUp?: ?number,
+  /**
+   * Apple TV parallax effects
+   */
   tvParallaxProperties?: ?TVParallaxPropertiesType,
 |}>;
 
 type Props = $ReadOnly<{|
   ...TouchableWithoutFeedbackProps,
   ...TVProps,
-  activeOpacity?: ?number,
+
+  /**
+   * Determines what the opacity of the wrapped view should be when touch is
+   * active. Defaults to 0.2.
+   */
+  activeOpacity: number,
   style?: ?ViewStyleProp,
 |}>;
+
+type State = {|
+  ...TouchableState,
+
+  anim: Animated.Value,
+|};
+
+function createTouchMixin(
+  node: React.ElementRef<typeof TouchableOpacity>,
+): typeof Touchable.MixinWithoutDefaultFocusAndBlur {
+  const touchMixin = {...Touchable.MixinWithoutDefaultFocusAndBlur};
+
+  for (const key in touchMixin) {
+    if (typeof touchMixin[key] === 'function') {
+      touchMixin[key] = touchMixin[key].bind(node);
+    }
+  }
+
+  return touchMixin;
+}
 
 /**
  * A wrapper for making views respond properly to touches.
@@ -135,175 +188,157 @@ type Props = $ReadOnly<{|
  * ```
  *
  */
-const TouchableOpacity = ((createReactClass({
-  displayName: 'TouchableOpacity',
-  mixins: [Touchable.Mixin.withoutDefaultFocusAndBlur, NativeMethodsMixin],
+class TouchableOpacity extends React.Component<Props, State> {
+  static defaultProps = {
+    activeOpacity: 0.2,
+  };
 
-  propTypes: {
-    /* $FlowFixMe(>=0.89.0 site=react_native_fb) This comment suppresses an
-     * error found when Flow v0.89 was deployed. To see the error, delete this
-     * comment and run Flow. */
-    ...TouchableWithoutFeedback.propTypes,
-    /**
-     * Determines what the opacity of the wrapped view should be when touch is
-     * active. Defaults to 0.2.
-     */
-    activeOpacity: PropTypes.number,
-    /**
-     * TV preferred focus (see documentation for the View component).
-     */
-    hasTVPreferredFocus: PropTypes.bool,
-    /**
-     * TV next focus down (see documentation for the View component).
-     *
-     * @platform android
-     */
-    nextFocusDown: PropTypes.number,
-    /**
-     * TV next focus forward (see documentation for the View component).
-     *
-     * @platform android
-     */
-    nextFocusForward: PropTypes.number,
-    /**
-     * TV next focus left (see documentation for the View component).
-     *
-     * @platform android
-     */
-    nextFocusLeft: PropTypes.number,
-    /**
-     * TV next focus right (see documentation for the View component).
-     *
-     * @platform android
-     */
-    nextFocusRight: PropTypes.number,
-    /**
-     * TV next focus up (see documentation for the View component).
-     *
-     * @platform android
-     */
-    nextFocusUp: PropTypes.number,
-    /**
-     * Apple TV parallax effects
-     */
-    tvParallaxProperties: PropTypes.object,
-  },
+  _touchMixin: typeof Touchable.MixinWithoutDefaultFocusAndBlur = createTouchMixin(
+    this,
+  );
 
-  getDefaultProps: function() {
-    return {
-      activeOpacity: 0.2,
-    };
-  },
+  _isMounted: boolean;
 
-  getInitialState: function() {
-    return {
-      ...this.touchableGetInitialState(),
+  constructor(props: Props) {
+    super(props);
+
+    const touchMixin = Touchable.MixinWithoutDefaultFocusAndBlur;
+    for (const key in touchMixin) {
+      if (
+        typeof touchMixin[key] === 'function' &&
+        (key.startsWith('_') || key.startsWith('touchable'))
+      ) {
+        // $FlowFixMe - dynamically adding properties to a class
+        (this: any)[key] = touchMixin[key].bind(this);
+      }
+    }
+
+    Object.keys(touchMixin)
+      .filter(key => typeof touchMixin[key] !== 'function')
+      .forEach(key => {
+        // $FlowFixMe - dynamically adding properties to a class
+        (this: any)[key] = touchMixin[key];
+      });
+
+    this.state = {
+      ...this._touchMixin.touchableGetInitialState(),
+
       anim: new Animated.Value(this._getChildStyleOpacityWithDefault()),
     };
-  },
+  }
 
-  componentDidMount: function() {
+  componentDidMount() {
     ensurePositiveDelayProps(this.props);
-  },
 
-  UNSAFE_componentWillReceiveProps: function(nextProps) {
-    ensurePositiveDelayProps(nextProps);
-  },
+    this._touchMixin.componentDidMount();
+  }
 
-  componentDidUpdate: function(prevProps, prevState) {
+  componentDidUpdate(prevProps: Props, prevState: State) {
+    ensurePositiveDelayProps(this.props);
+
     if (this.props.disabled !== prevProps.disabled) {
       this._opacityInactive(250);
     }
-  },
+  }
+
+  componentWillUnmount() {
+    this._touchMixin.componentWillUnmount();
+  }
 
   /**
    * Animate the touchable to a new opacity.
    */
-  setOpacityTo: function(value: number, duration: number) {
+  setOpacityTo(value: number, duration: number) {
     Animated.timing(this.state.anim, {
       toValue: value,
       duration: duration,
       easing: Easing.inOut(Easing.quad),
       useNativeDriver: true,
     }).start();
-  },
+  }
 
   /**
    * `Touchable.Mixin` self callbacks. The mixin will invoke these if they are
    * defined on your component.
    */
-  touchableHandleActivePressIn: function(e: PressEvent) {
+  touchableHandleActivePressIn(e: PressEvent) {
     if (e.dispatchConfig.registrationName === 'onResponderGrant') {
       this._opacityActive(0);
     } else {
       this._opacityActive(150);
     }
     this.props.onPressIn && this.props.onPressIn(e);
-  },
+  }
 
-  touchableHandleActivePressOut: function(e: PressEvent) {
+  touchableHandleActivePressOut(e: PressEvent) {
     this._opacityInactive(250);
     this.props.onPressOut && this.props.onPressOut(e);
-  },
+  }
 
-  touchableHandleFocus: function(e: Event) {
+  touchableHandleFocus(e: FocusEvent) {
     if (Platform.isTV) {
       this._opacityActive(150);
     }
     this.props.onFocus && this.props.onFocus(e);
-  },
+  }
 
-  touchableHandleBlur: function(e: Event) {
+  touchableHandleBlur(e: BlurEvent) {
     if (Platform.isTV) {
       this._opacityInactive(250);
     }
     this.props.onBlur && this.props.onBlur(e);
-  },
+  }
 
-  touchableHandlePress: function(e: PressEvent) {
+  touchableHandlePress(e: PressEvent) {
     this.props.onPress && this.props.onPress(e);
-  },
+  }
 
-  touchableHandleLongPress: function(e: PressEvent) {
+  touchableHandleLongPress(e: PressEvent) {
     this.props.onLongPress && this.props.onLongPress(e);
-  },
+  }
 
-  touchableGetPressRectOffset: function() {
+  touchableGetPressRectOffset() {
     return this.props.pressRetentionOffset || PRESS_RETENTION_OFFSET;
-  },
+  }
 
-  touchableGetHitSlop: function() {
+  touchableGetHitSlop() {
     return this.props.hitSlop;
-  },
+  }
 
-  touchableGetHighlightDelayMS: function() {
+  touchableGetHighlightDelayMS() {
     return this.props.delayPressIn || 0;
-  },
+  }
 
-  touchableGetLongPressDelayMS: function() {
+  touchableGetLongPressDelayMS() {
     return this.props.delayLongPress === 0
       ? 0
       : this.props.delayLongPress || 500;
-  },
+  }
 
-  touchableGetPressOutDelayMS: function() {
+  touchableGetPressOutDelayMS() {
     return this.props.delayPressOut;
-  },
+  }
 
-  _opacityActive: function(duration: number) {
+  _opacityActive(duration: number) {
     this.setOpacityTo(this.props.activeOpacity, duration);
-  },
+  }
 
-  _opacityInactive: function(duration: number) {
+  _opacityInactive(duration: number) {
     this.setOpacityTo(this._getChildStyleOpacityWithDefault(), duration);
-  },
+  }
 
-  _getChildStyleOpacityWithDefault: function() {
+  _getChildStyleOpacityWithDefault(): number {
     const childStyle = flattenStyle(this.props.style) || {};
-    return childStyle.opacity == null ? 1 : childStyle.opacity;
-  },
 
-  render: function() {
+    // childStyle.opacity could be an AnimatedNode
+    if (typeof childStyle.opacity !== 'number') {
+      return 1;
+    }
+
+    return childStyle.opacity == null ? 1 : childStyle.opacity;
+  }
+
+  render() {
     return (
       <Animated.View
         accessible={this.props.accessible !== false}
@@ -324,14 +359,18 @@ const TouchableOpacity = ((createReactClass({
         hasTVPreferredFocus={this.props.hasTVPreferredFocus}
         tvParallaxProperties={this.props.tvParallaxProperties}
         hitSlop={this.props.hitSlop}
-        onStartShouldSetResponder={this.touchableHandleStartShouldSetResponder}
-        onResponderTerminationRequest={
-          this.touchableHandleResponderTerminationRequest
+        onStartShouldSetResponder={
+          this._touchMixin.touchableHandleStartShouldSetResponder
         }
-        onResponderGrant={this.touchableHandleResponderGrant}
-        onResponderMove={this.touchableHandleResponderMove}
-        onResponderRelease={this.touchableHandleResponderRelease}
-        onResponderTerminate={this.touchableHandleResponderTerminate}>
+        onResponderTerminationRequest={
+          this._touchMixin.touchableHandleResponderTerminationRequest
+        }
+        onResponderGrant={this._touchMixin.touchableHandleResponderGrant}
+        onResponderMove={this._touchMixin.touchableHandleResponderMove}
+        onResponderRelease={this._touchMixin.touchableHandleResponderRelease}
+        onResponderTerminate={
+          this._touchMixin.touchableHandleResponderTerminate
+        }>
         {this.props.children}
         {Touchable.renderDebugView({
           color: 'cyan',
@@ -339,7 +378,7 @@ const TouchableOpacity = ((createReactClass({
         })}
       </Animated.View>
     );
-  },
-}): any): React.ComponentType<Props>);
+  }
+}
 
 module.exports = TouchableOpacity;

--- a/Libraries/Components/View/ViewPropTypes.js
+++ b/Libraries/Components/View/ViewPropTypes.js
@@ -216,7 +216,7 @@ type AndroidDrawableRipple = $ReadOnly<{|
   borderless?: ?boolean,
 |}>;
 
-type AndroidDrawable = AndroidDrawableThemeAttr | AndroidDrawableRipple;
+export type AndroidDrawable = AndroidDrawableThemeAttr | AndroidDrawableRipple;
 
 type AndroidViewProps = $ReadOnly<{|
   nativeBackgroundAndroid?: ?AndroidDrawable,

--- a/RNTester/js/RNTesterList.android.js
+++ b/RNTester/js/RNTesterList.android.js
@@ -223,6 +223,10 @@ const APIExamples: Array<RNTesterExample> = [
     module: require('./ShareExample'),
   },
   {
+    key: 'StrictModeExample',
+    module: require('./StrictModeExample'),
+  },
+  {
     key: 'TimePickerAndroidExample',
     module: require('./TimePickerAndroidExample'),
   },

--- a/RNTester/js/RNTesterList.ios.js
+++ b/RNTester/js/RNTesterList.ios.js
@@ -317,6 +317,10 @@ const APIExamples: Array<RNTesterExample> = [
     supportsTVOS: true,
   },
   {
+    key: 'StrictModeExample',
+    module: require('./StrictModeExample'),
+  },
+  {
     key: 'TimerExample',
     module: require('./TimerExample'),
     supportsTVOS: true,

--- a/RNTester/js/StrictModeExample.js
+++ b/RNTester/js/StrictModeExample.js
@@ -1,0 +1,95 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow
+ */
+
+'use strict';
+
+const React = require('react');
+const {StrictMode} = React;
+const ReactNative = require('react-native');
+const {
+  Text,
+  TouchableHighlight,
+  TouchableNativeFeedback,
+  TouchableOpacity,
+  TouchableWithoutFeedback,
+  View,
+} = ReactNative;
+const TouchableBounce = require('TouchableBounce');
+
+type Props = $ReadOnly<{||}>;
+type State = {|result: string|};
+
+const componentsToTest = [
+  [
+    TouchableBounce,
+    {
+      onPress: () => console.warn('[press]'),
+    },
+  ],
+  [
+    TouchableHighlight,
+    {
+      onPress: () => console.warn('[press]'),
+    },
+  ],
+  [
+    // Caveat: Contains ReactNative.findNodeHandle which is not allowed in strict mode
+    TouchableNativeFeedback,
+    {
+      onPress: () => console.warn('[press]'),
+      background: TouchableNativeFeedback.Ripple('rgba(0, 0, 255, 0.4)', true),
+      children: (
+        <View style={{height: 100, backgroundColor: 'red'}}>
+          <Text style={{margin: 30}}>I am a TouchableNativeFeedback</Text>
+        </View>
+      ),
+    },
+  ],
+  [
+    TouchableOpacity,
+    {
+      onPress: () => console.warn('[press]'),
+    },
+  ],
+  [
+    TouchableWithoutFeedback,
+    {
+      onPress: () => console.warn('[press]'),
+    },
+  ],
+];
+
+class StrictModeExample extends React.Component<Props, State> {
+  render() {
+    return (
+      <View>
+        <StrictMode>
+          {componentsToTest.map(([Component, props]) => (
+            <Component key={Component.displayName} {...props}>
+              {props.children || <Text>I am a {Component.displayName}</Text>}
+            </Component>
+          ))}
+        </StrictMode>
+      </View>
+    );
+  }
+}
+
+exports.framework = 'React';
+exports.title = 'StrictMode';
+exports.description = 'See components in strict mode.';
+exports.examples = [
+  {
+    title: 'Strict Mode',
+    render() {
+      return <StrictModeExample />;
+    },
+  },
+];


### PR DESCRIPTION
## Summary

Convert all Touchables to be class based and remove UNSAFE props. Also renamed
Touchable.Mixin.withoutDefaultFocusAndBlur to Touchable.MixinWithoutDefaultFocusAndBlur
to improve flow automatic typings.

Note: TouchableNativeFeedback uses ReactNative.findNodeHandle which triggers a
warning in strict mode during a tap. I could not figure out how to remove the need for
that call.

Related to https://github.com/facebook/react-native/issues/22186

## Changelog

[General] [Fixed] - Converted createAnimatedComponent to be compatible with StrictMode
[General] [Fixed] - Converted Touchable.Mixin to be compatible with StrictMode and updated built-in Touchable components.
[General] [Changed] - Renamed Touchable.Mixin.withoutDefaultFocusAndBlur to Touchable.MixinWithoutDefaultFocusAndBlur

## Test Plan

Tested manually via RNTester by opening StrictMode example and ensuring no strict-mode warnings are rendered. Also made sure onPress handlers and effects still work for all of them.