### PR TITLE
Rename ios project name with new template

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,10 @@
     "third-party-podspecs",
     "template",
     "local-cli",
-    "template.config.js"
+    "template.config.js",
+    "!template/node_modules",
+    "!template/yarn.lock",
+    "!template/package-lock.json"
   ],
   "scripts": {
     "start": "react-native start --reactNativePath .",

--- a/template/ios/HelloWorld.xcodeproj/project.pbxproj
+++ b/template/ios/HelloWorld.xcodeproj/project.pbxproj
@@ -193,7 +193,7 @@
 			dependencies = (
 			);
 			name = HelloWorld;
-			productName = "Hello World";
+			productName = "HelloWorld";
 			productReference = 13B07F961A680F5B00A75B9A /* HelloWorld.app */;
 			productType = "com.apple.product-type.application";
 		};


### PR DESCRIPTION
## Summary

With new `init` implementation we replace all occurrences of the project name (`HelloWorld`) inside `ios` and `android` directories. For some reason, a product name field in `ios` was named wrongly. This shouldn't impact initialization using `global-cli`

## Changelog

[iOS] [Fixed] - Change productName in iOS in new init.

## Test Plan

Initialize new project using new initialization flow, replace `react-native` in a newly initialized project to point to `master` version. Run app on `iOS` and check application name.

cc @grabbou @cpojer 

