### PR TITLE
Make Jest transform @react-native-community packages by default

### DIFF
--- a/jest-preset.js
+++ b/jest-preset.js
@@ -28,7 +28,9 @@ module.exports = {
       './jest/assetFileTransformer.js',
     ),
   },
-  transformIgnorePatterns: ['node_modules/(?!(jest-)?react-native)'],
+  transformIgnorePatterns: [
+    'node_modules/(?!(jest-)?react-native|@react-native-community)',
+  ],
   setupFiles: [require.resolve('./jest/setup.js')],
   testEnvironment: 'node',
 };


### PR DESCRIPTION
## Summary

Currently, `react-native` Jest preset will not automatically transpile extracted Lean Core modules (all under `@react-native-community` org), so maintainers will likely need to update their docs on how to do that (it's a common pain in RN testing story). 

We can make it easier for users and maintainers by adding RNC modules to the `transformIgnorePatterns` whitelist we have in Jest preset. Some of them are not necessary to transpile, but I'd say it's a small sacrifice to make (having first test run possibly slower) for having less friction around migrating to extracted modules.

## Changelog

[General] [Added] - make Jest transform @react-native-community/ packages by default

## Test Plan

Check the regex: regexr.com/4bird
