### PR TITLE
Fix #23755 ("RCTImagePickerManager requires main queue setup" warning)

### DIFF
--- a/Libraries/CameraRoll/RCTImagePickerManager.m
+++ b/Libraries/CameraRoll/RCTImagePickerManager.m
@@ -52,9 +52,14 @@ RCT_EXPORT_MODULE(ImagePickerIOS);
   return self;
 }
 
++ (BOOL)requiresMainQueueSetup
+{
+  return NO;
+}
+
 - (void)dealloc
 {
-    [[NSNotificationCenter defaultCenter] removeObserver:self name:@"AVCaptureDeviceDidStartRunningNotification" object:nil];
+  [[NSNotificationCenter defaultCenter] removeObserver:self name:@"AVCaptureDeviceDidStartRunningNotification" object:nil];
 }
 
 - (dispatch_queue_t)methodQueue


### PR DESCRIPTION
## Summary

Fix #23755 - Which is to remove the warning:
```
Module RCTImagePickerManager requires main queue setup since it overrides `init` but doesn't implement `requiresMainQueueSetup`. In a future release React Native will default to initializing all native modules on a background thread unless explicitly opted-out of.
```

## Changelog

General Fixed - Warning "RCTImagePickerManager requires main queue setup

## Test Plan

Initialize a new react native project and use CameraRoll. Run it. Confirm that warning no longer shows.