### PR TITLE
[standards][flow] Set up .flowconfig to support Haste and path-based imports

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -63,6 +63,10 @@ module.system.haste.paths.whitelist=<PROJECT_ROOT>/IntegrationTests/.*
 module.system.haste.paths.blacklist=<PROJECT_ROOT>/Libraries/react-native/react-native-implementation.js
 module.system.haste.paths.blacklist=<PROJECT_ROOT>/Libraries/Animated/src/polyfills/.*
 
+module.file_ext=.js
+module.file_ext=.json
+module.file_ext=.ios.js
+
 munge_underscores=true
 
 module.name_mapper='^[./a-zA-Z0-9$_-]+\.\(bmp\|gif\|jpg\|jpeg\|png\|psd\|svg\|webp\|m4v\|mov\|mp4\|mpeg\|mpg\|webm\|aac\|aiff\|caf\|m4a\|mp3\|wav\|html\|pdf\)$' -> 'RelativeImageStub'

--- a/.flowconfig.android
+++ b/.flowconfig.android
@@ -44,6 +44,10 @@ emoji=true
 esproposal.optional_chaining=enable
 esproposal.nullish_coalescing=enable
 
+module.file_ext=.js
+module.file_ext=.json
+module.file_ext=.android.js
+
 module.system=haste
 module.system.haste.use_name_reducers=true
 # keep the following in sync with server/haste/hasteImpl.js


### PR DESCRIPTION
## Summary

See https://github.com/facebook/react-native/issues/24316 for the motivation.

By adding the .android.js and .ios.js extensions to the respective .flowconfig files, Flow is able to find files that either:

- Are required using Haste
- Are required using standard paths and have a .js extension
- Are required using standard paths and have a .platform.js subextension

## Changelog

[General] [Changed] - Adjusted .flowconfig to support both Haste and standard path-based requires

## Test Plan

After replacing some Haste-style requires with path-based requires, this change to the Flow config made Flow pass.
