### PR TITLE
[standards] Rewrite imports in YellowBox to use standard paths

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -63,6 +63,10 @@ module.system.haste.paths.whitelist=<PROJECT_ROOT>/IntegrationTests/.*
 module.system.haste.paths.blacklist=<PROJECT_ROOT>/Libraries/react-native/react-native-implementation.js
 module.system.haste.paths.blacklist=<PROJECT_ROOT>/Libraries/Animated/src/polyfills/.*
 
+module.file_ext=.js
+module.file_ext=.json
+module.file_ext=.ios.js
+
 munge_underscores=true
 
 module.name_mapper='^[./a-zA-Z0-9$_-]+\.\(bmp\|gif\|jpg\|jpeg\|png\|psd\|svg\|webp\|m4v\|mov\|mp4\|mpeg\|mpg\|webm\|aac\|aiff\|caf\|m4a\|mp3\|wav\|html\|pdf\)$' -> 'RelativeImageStub'

--- a/.flowconfig.android
+++ b/.flowconfig.android
@@ -44,6 +44,10 @@ emoji=true
 esproposal.optional_chaining=enable
 esproposal.nullish_coalescing=enable
 
+module.file_ext=.js
+module.file_ext=.json
+module.file_ext=.android.js
+
 module.system=haste
 module.system.haste.use_name_reducers=true
 # keep the following in sync with server/haste/hasteImpl.js

--- a/Libraries/YellowBox/Data/YellowBoxCategory.js
+++ b/Libraries/YellowBox/Data/YellowBoxCategory.js
@@ -10,13 +10,13 @@
 
 'use strict';
 
-const React = require('React');
-const Text = require('Text');
-const UTFSequence = require('UTFSequence');
+const React = require('react');
+const Text = require('../../Text/Text');
+const UTFSequence = require('../../UTFSequence');
 
-const stringifySafe = require('stringifySafe');
+const stringifySafe = require('../../Utilities/stringifySafe');
 
-import type {TextStyleProp} from 'StyleSheet';
+import type {TextStyleProp} from '../../StyleSheet/StyleSheet';
 
 export type Category = string;
 export type Message = $ReadOnly<{|

--- a/Libraries/YellowBox/Data/YellowBoxRegistry.js
+++ b/Libraries/YellowBox/Data/YellowBoxRegistry.js
@@ -10,9 +10,9 @@
 
 'use strict';
 
-const YellowBoxWarning = require('YellowBoxWarning');
+const YellowBoxWarning = require('./YellowBoxWarning');
 
-import type {Category} from 'YellowBoxCategory';
+import type {Category} from './YellowBoxCategory';
 
 export type Registry = Map<Category, $ReadOnlyArray<YellowBoxWarning>>;
 

--- a/Libraries/YellowBox/Data/YellowBoxSymbolication.js
+++ b/Libraries/YellowBox/Data/YellowBoxSymbolication.js
@@ -10,9 +10,9 @@
 
 'use strict';
 
-const symbolicateStackTrace = require('symbolicateStackTrace');
+const symbolicateStackTrace = require('../../Core/Devtools/symbolicateStackTrace');
 
-import type {StackFrame} from 'parseErrorStack';
+import type {StackFrame} from '../../Core/Devtools/parseErrorStack';
 
 type CacheKey = string;
 

--- a/Libraries/YellowBox/Data/YellowBoxWarning.js
+++ b/Libraries/YellowBox/Data/YellowBoxWarning.js
@@ -10,13 +10,13 @@
 
 'use strict';
 
-const YellowBoxCategory = require('YellowBoxCategory');
-const YellowBoxSymbolication = require('YellowBoxSymbolication');
+const YellowBoxCategory = require('./YellowBoxCategory');
+const YellowBoxSymbolication = require('./YellowBoxSymbolication');
 
-const parseErrorStack = require('parseErrorStack');
+const parseErrorStack = require('../../Core/Devtools/parseErrorStack');
 
-import type {Category, Message} from 'YellowBoxCategory';
-import type {Stack} from 'YellowBoxSymbolication';
+import type {Category, Message} from './YellowBoxCategory';
+import type {Stack} from './YellowBoxSymbolication';
 
 export type SymbolicationRequest = $ReadOnly<{|
   abort: () => void,

--- a/Libraries/YellowBox/Data/__tests__/YellowBoxCategory-test.js
+++ b/Libraries/YellowBox/Data/__tests__/YellowBoxCategory-test.js
@@ -11,7 +11,7 @@
 
 'use strict';
 
-const YellowBoxCategory = require('YellowBoxCategory');
+const YellowBoxCategory = require('../YellowBoxCategory');
 
 describe('YellowBoxCategory', () => {
   it('parses strings', () => {

--- a/Libraries/YellowBox/Data/__tests__/YellowBoxRegistry-test.js
+++ b/Libraries/YellowBox/Data/__tests__/YellowBoxRegistry-test.js
@@ -11,8 +11,8 @@
 
 'use strict';
 
-const YellowBoxCategory = require('YellowBoxCategory');
-const YellowBoxRegistry = require('YellowBoxRegistry');
+const YellowBoxCategory = require('../YellowBoxCategory');
+const YellowBoxRegistry = require('../YellowBoxRegistry');
 
 const registry = () => {
   const observer = jest.fn();

--- a/Libraries/YellowBox/Data/__tests__/YellowBoxSymbolication-test.js
+++ b/Libraries/YellowBox/Data/__tests__/YellowBoxSymbolication-test.js
@@ -11,16 +11,16 @@
 
 'use strict';
 
-import type {StackFrame} from 'parseErrorStack';
+import type {StackFrame} from '../../../Core/Devtools/parseErrorStack';
 
-jest.mock('symbolicateStackTrace');
+jest.mock('../../../Core/Devtools/symbolicateStackTrace');
 
-const YellowBoxSymbolication = require('YellowBoxSymbolication');
+const YellowBoxSymbolication = require('../YellowBoxSymbolication');
 
 const symbolicateStackTrace: JestMockFn<
   $ReadOnlyArray<Array<StackFrame>>,
   Promise<Array<StackFrame>>,
-> = (require('symbolicateStackTrace'): any);
+> = (require('../../../Core/Devtools/symbolicateStackTrace'): any);
 
 const createStack = methodNames =>
   methodNames.map(methodName => ({

--- a/Libraries/YellowBox/Data/__tests__/YellowBoxWarning-test.js
+++ b/Libraries/YellowBox/Data/__tests__/YellowBoxWarning-test.js
@@ -11,17 +11,17 @@
 
 'use strict';
 
-import type {StackFrame} from 'parseErrorStack';
+import type {StackFrame} from '../../../Core/Devtools/parseErrorStack';
 
-jest.mock('YellowBoxSymbolication');
+jest.mock('../YellowBoxSymbolication');
 
 const YellowBoxSymbolication: {|
   symbolicate: JestMockFn<
     $ReadOnlyArray<Array<StackFrame>>,
     Promise<Array<StackFrame>>,
   >,
-|} = (require('YellowBoxSymbolication'): any);
-const YellowBoxWarning = require('YellowBoxWarning');
+|} = (require('../YellowBoxSymbolication'): any);
+const YellowBoxWarning = require('../YellowBoxWarning');
 
 const createStack = methodNames =>
   methodNames.map(methodName => ({

--- a/Libraries/YellowBox/UI/YellowBoxButton.js
+++ b/Libraries/YellowBox/UI/YellowBoxButton.js
@@ -10,13 +10,13 @@
 
 'use strict';
 
-const React = require('React');
-const StyleSheet = require('StyleSheet');
-const Text = require('Text');
-const YellowBoxPressable = require('YellowBoxPressable');
-const YellowBoxStyle = require('YellowBoxStyle');
+const React = require('react');
+const StyleSheet = require('../../StyleSheet/StyleSheet');
+const Text = require('../../Text/Text');
+const YellowBoxPressable = require('./YellowBoxPressable');
+const YellowBoxStyle = require('./YellowBoxStyle');
 
-import type {EdgeInsetsProp} from 'EdgeInsetsPropType';
+import type {EdgeInsetsProp} from '../../StyleSheet/EdgeInsetsPropType';
 
 type Props = $ReadOnly<{|
   hitSlop?: ?EdgeInsetsProp,

--- a/Libraries/YellowBox/UI/YellowBoxImageSource.js
+++ b/Libraries/YellowBox/UI/YellowBoxImageSource.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const PixelRatio = require('PixelRatio');
+const PixelRatio = require('../../Utilities/PixelRatio');
 
 const scale = PixelRatio.get();
 

--- a/Libraries/YellowBox/UI/YellowBoxInspector.js
+++ b/Libraries/YellowBox/UI/YellowBoxInspector.js
@@ -10,23 +10,23 @@
 
 'use strict';
 
-const Platform = require('Platform');
-const React = require('React');
-const ScrollView = require('ScrollView');
-const StyleSheet = require('StyleSheet');
-const Text = require('Text');
-const View = require('View');
-const YellowBoxCategory = require('YellowBoxCategory');
-const YellowBoxInspectorFooter = require('YellowBoxInspectorFooter');
-const YellowBoxInspectorHeader = require('YellowBoxInspectorHeader');
-const YellowBoxInspectorSourceMapStatus = require('YellowBoxInspectorSourceMapStatus');
-const YellowBoxInspectorStackFrame = require('YellowBoxInspectorStackFrame');
-const YellowBoxStyle = require('YellowBoxStyle');
+const Platform = require('../../Utilities/Platform');
+const React = require('react');
+const ScrollView = require('../../Components/ScrollView/ScrollView');
+const StyleSheet = require('../../StyleSheet/StyleSheet');
+const Text = require('../../Text/Text');
+const View = require('../../Components/View/View');
+const YellowBoxCategory = require('../Data/YellowBoxCategory');
+const YellowBoxInspectorFooter = require('./YellowBoxInspectorFooter');
+const YellowBoxInspectorHeader = require('./YellowBoxInspectorHeader');
+const YellowBoxInspectorSourceMapStatus = require('./YellowBoxInspectorSourceMapStatus');
+const YellowBoxInspectorStackFrame = require('./YellowBoxInspectorStackFrame');
+const YellowBoxStyle = require('./YellowBoxStyle');
 
-const openFileInEditor = require('openFileInEditor');
+const openFileInEditor = require('../../Core/Devtools/openFileInEditor');
 
-import type YellowBoxWarning from 'YellowBoxWarning';
-import type {SymbolicationRequest} from 'YellowBoxWarning';
+import type YellowBoxWarning from '../Data/YellowBoxWarning';
+import type {SymbolicationRequest} from '../Data/YellowBoxWarning';
 
 type Props = $ReadOnly<{|
   onDismiss: () => void,

--- a/Libraries/YellowBox/UI/YellowBoxInspectorFooter.js
+++ b/Libraries/YellowBox/UI/YellowBoxInspectorFooter.js
@@ -10,13 +10,13 @@
 
 'use strict';
 
-const React = require('React');
-const SafeAreaView = require('SafeAreaView');
-const StyleSheet = require('StyleSheet');
-const Text = require('Text');
-const View = require('View');
-const YellowBoxPressable = require('YellowBoxPressable');
-const YellowBoxStyle = require('YellowBoxStyle');
+const React = require('react');
+const SafeAreaView = require('../../Components/SafeAreaView/SafeAreaView');
+const StyleSheet = require('../../StyleSheet/StyleSheet');
+const Text = require('../../Text/Text');
+const View = require('../../Components/View/View');
+const YellowBoxPressable = require('./YellowBoxPressable');
+const YellowBoxStyle = require('./YellowBoxStyle');
 
 type Props = $ReadOnly<{|
   onDismiss: () => void,

--- a/Libraries/YellowBox/UI/YellowBoxInspectorHeader.js
+++ b/Libraries/YellowBox/UI/YellowBoxInspectorHeader.js
@@ -10,18 +10,18 @@
 
 'use strict';
 
-const Image = require('Image');
-const Platform = require('Platform');
-const React = require('React');
-const SafeAreaView = require('SafeAreaView');
-const StyleSheet = require('StyleSheet');
-const Text = require('Text');
-const View = require('View');
-const YellowBoxImageSource = require('YellowBoxImageSource');
-const YellowBoxPressable = require('YellowBoxPressable');
-const YellowBoxStyle = require('YellowBoxStyle');
+const Image = require('../../Image/Image');
+const Platform = require('../../Utilities/Platform');
+const React = require('react');
+const SafeAreaView = require('../../Components/SafeAreaView/SafeAreaView');
+const StyleSheet = require('../../StyleSheet/StyleSheet');
+const Text = require('../../Text/Text');
+const View = require('../../Components/View/View');
+const YellowBoxImageSource = require('./YellowBoxImageSource');
+const YellowBoxPressable = require('./YellowBoxPressable');
+const YellowBoxStyle = require('./YellowBoxStyle');
 
-import type YellowBoxWarning from 'YellowBoxWarning';
+import type YellowBoxWarning from '../Data/YellowBoxWarning';
 
 type Props = $ReadOnly<{|
   onSelectIndex: (selectedIndex: number) => void,

--- a/Libraries/YellowBox/UI/YellowBoxInspectorSourceMapStatus.js
+++ b/Libraries/YellowBox/UI/YellowBoxInspectorSourceMapStatus.js
@@ -10,18 +10,18 @@
 
 'use strict';
 
-const Animated = require('Animated');
-const Easing = require('Easing');
-const React = require('React');
-const StyleSheet = require('StyleSheet');
-const Text = require('Text');
-const YellowBoxImageSource = require('YellowBoxImageSource');
-const YellowBoxPressable = require('YellowBoxPressable');
-const YellowBoxStyle = require('YellowBoxStyle');
+const Animated = require('../../Animated/src/Animated');
+const Easing = require('../../Animated/src/Easing');
+const React = require('react');
+const StyleSheet = require('../../StyleSheet/StyleSheet');
+const Text = require('../../Text/Text');
+const YellowBoxImageSource = require('./YellowBoxImageSource');
+const YellowBoxPressable = require('./YellowBoxPressable');
+const YellowBoxStyle = require('./YellowBoxStyle');
 
-import type {CompositeAnimation} from 'AnimatedImplementation';
-import type AnimatedInterpolation from 'AnimatedInterpolation';
-import type {PressEvent} from 'CoreEventTypes';
+import type {CompositeAnimation} from '../../Animated/src/AnimatedImplementation';
+import type AnimatedInterpolation from '../../Animated/src/nodes/AnimatedInterpolation';
+import type {PressEvent} from '../../Types/CoreEventTypes';
 
 type Props = $ReadOnly<{|
   onPress?: ?(event: PressEvent) => void,

--- a/Libraries/YellowBox/UI/YellowBoxInspectorStackFrame.js
+++ b/Libraries/YellowBox/UI/YellowBoxInspectorStackFrame.js
@@ -10,14 +10,14 @@
 
 'use strict';
 
-const React = require('React');
-const StyleSheet = require('StyleSheet');
-const Text = require('Text');
-const YellowBoxPressable = require('YellowBoxPressable');
-const YellowBoxStyle = require('YellowBoxStyle');
+const React = require('react');
+const StyleSheet = require('../../StyleSheet/StyleSheet');
+const Text = require('../../Text/Text');
+const YellowBoxPressable = require('./YellowBoxPressable');
+const YellowBoxStyle = require('./YellowBoxStyle');
 
-import type {PressEvent} from 'CoreEventTypes';
-import type {StackFrame} from 'parseErrorStack';
+import type {PressEvent} from '../../Types/CoreEventTypes';
+import type {StackFrame} from '../../Core/Devtools/parseErrorStack';
 
 type Props = $ReadOnly<{|
   frame: StackFrame,

--- a/Libraries/YellowBox/UI/YellowBoxList.js
+++ b/Libraries/YellowBox/UI/YellowBoxList.js
@@ -10,19 +10,19 @@
 
 'use strict';
 
-const Dimensions = require('Dimensions');
-const React = require('React');
-const FlatList = require('FlatList');
-const SafeAreaView = require('SafeAreaView');
-const StyleSheet = require('StyleSheet');
-const View = require('View');
-const YellowBoxButton = require('YellowBoxButton');
-const YellowBoxInspector = require('YellowBoxInspector');
-const YellowBoxListRow = require('YellowBoxListRow');
-const YellowBoxStyle = require('YellowBoxStyle');
+const Dimensions = require('../../Utilities/Dimensions');
+const React = require('react');
+const FlatList = require('../../Lists/FlatList');
+const SafeAreaView = require('../../Components/SafeAreaView/SafeAreaView');
+const StyleSheet = require('../../StyleSheet/StyleSheet');
+const View = require('../../Components/View/View');
+const YellowBoxButton = require('./YellowBoxButton');
+const YellowBoxInspector = require('./YellowBoxInspector');
+const YellowBoxListRow = require('./YellowBoxListRow');
+const YellowBoxStyle = require('./YellowBoxStyle');
 
-import type {Category} from 'YellowBoxCategory';
-import type {Registry} from 'YellowBoxRegistry';
+import type {Category} from '../Data/YellowBoxCategory';
+import type {Registry} from '../Data/YellowBoxRegistry';
 
 type Props = $ReadOnly<{|
   onDismiss: (category: Category) => void,

--- a/Libraries/YellowBox/UI/YellowBoxListRow.js
+++ b/Libraries/YellowBox/UI/YellowBoxListRow.js
@@ -10,16 +10,16 @@
 
 'use strict';
 
-const React = require('React');
-const StyleSheet = require('StyleSheet');
-const Text = require('Text');
-const YellowBoxPressable = require('YellowBoxPressable');
-const View = require('View');
-const YellowBoxCategory = require('YellowBoxCategory');
-const YellowBoxStyle = require('YellowBoxStyle');
-const YellowBoxWarning = require('YellowBoxWarning');
+const React = require('react');
+const StyleSheet = require('../../StyleSheet/StyleSheet');
+const Text = require('../../Text/Text');
+const YellowBoxPressable = require('./YellowBoxPressable');
+const View = require('../../Components/View/View');
+const YellowBoxCategory = require('../Data/YellowBoxCategory');
+const YellowBoxStyle = require('./YellowBoxStyle');
+const YellowBoxWarning = require('../Data/YellowBoxWarning');
 
-import type {Category} from 'YellowBoxCategory';
+import type {Category} from '../Data/YellowBoxCategory';
 
 type Props = $ReadOnly<{|
   category: Category,

--- a/Libraries/YellowBox/UI/YellowBoxPressable.js
+++ b/Libraries/YellowBox/UI/YellowBoxPressable.js
@@ -10,15 +10,15 @@
 
 'use strict';
 
-const React = require('React');
-const StyleSheet = require('StyleSheet');
-const TouchableWithoutFeedback = require('TouchableWithoutFeedback');
-const View = require('View');
-const YellowBoxStyle = require('YellowBoxStyle');
+const React = require('react');
+const StyleSheet = require('../../StyleSheet/StyleSheet');
+const TouchableWithoutFeedback = require('../../Components/Touchable/TouchableWithoutFeedback');
+const View = require('../../Components/View/View');
+const YellowBoxStyle = require('./YellowBoxStyle');
 
-import type {PressEvent} from 'CoreEventTypes';
-import type {EdgeInsetsProp} from 'EdgeInsetsPropType';
-import type {ViewStyleProp} from 'StyleSheet';
+import type {PressEvent} from '../../Types/CoreEventTypes';
+import type {EdgeInsetsProp} from '../../StyleSheet/EdgeInsetsPropType';
+import type {ViewStyleProp} from '../../StyleSheet/StyleSheet';
 
 type Props = $ReadOnly<{|
   backgroundColor: $ReadOnly<{|

--- a/Libraries/YellowBox/YellowBox.js
+++ b/Libraries/YellowBox/YellowBox.js
@@ -10,10 +10,10 @@
 
 'use strict';
 
-const React = require('React');
+const React = require('react');
 
-import type {Category} from 'YellowBoxCategory';
-import type {Registry, Subscription, IgnorePattern} from 'YellowBoxRegistry';
+import type {Category} from './Data/YellowBoxCategory';
+import type {Registry, Subscription, IgnorePattern} from './Data/YellowBoxRegistry';
 
 type Props = $ReadOnly<{||}>;
 type State = {|
@@ -41,10 +41,10 @@ let YellowBox;
  * the ignored warning messages.
  */
 if (__DEV__) {
-  const Platform = require('Platform');
-  const RCTLog = require('RCTLog');
-  const YellowBoxList = require('YellowBoxList');
-  const YellowBoxRegistry = require('YellowBoxRegistry');
+  const Platform = require('../Utilities/Platform');
+  const RCTLog = require('../Utilities/RCTLog');
+  const YellowBoxList = require('./UI/YellowBoxList');
+  const YellowBoxRegistry = require('./Data/YellowBoxRegistry');
 
   const {error, warn} = console;
 

--- a/Libraries/YellowBox/__tests__/YellowBox-test.js
+++ b/Libraries/YellowBox/__tests__/YellowBox-test.js
@@ -11,8 +11,8 @@
 
 'use strict';
 
-const YellowBox = require('YellowBox');
-const YellowBoxRegistry = require('YellowBoxRegistry');
+const YellowBox = require('../YellowBox');
+const YellowBoxRegistry = require('../Data/YellowBoxRegistry');
 
 describe('YellowBox', () => {
   const {error, warn} = console;
@@ -54,7 +54,7 @@ describe('YellowBox', () => {
   });
 
   it('registers warnings', () => {
-    jest.mock('YellowBoxRegistry');
+    jest.mock('../Data/YellowBoxRegistry');
 
     YellowBox.install();
 
@@ -64,7 +64,7 @@ describe('YellowBox', () => {
   });
 
   it('registers errors beginning with "Warning: "', () => {
-    jest.mock('YellowBoxRegistry');
+    jest.mock('../Data/YellowBoxRegistry');
 
     YellowBox.install();
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

See https://github.com/facebook/react-native/issues/24316 for the motivation. This commit rewrites the imports in the YellowBox component.

## Changelog

[General] [Changed] - Replaced Haste-style imports with standard path-style imports for YellowBox

## Test Plan

Run RNTester and verify that it loads without any issues when it display a warning.