### PR TITLE
WIP: Add hooks variant of createAnimatedComponent 

### DIFF
--- a/Libraries/Animated/src/AnimatedOnAFeeling.js
+++ b/Libraries/Animated/src/AnimatedOnAFeeling.js
@@ -1,0 +1,190 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ */
+'use strict';
+
+const {AnimatedEvent} = require('./AnimatedEvent');
+const AnimatedProps = require('./nodes/AnimatedProps');
+const React = require('React');
+const DeprecatedViewStylePropTypes = require('DeprecatedViewStylePropTypes');
+
+const {useCallback, useEffect, useState} = React;
+
+const invariant = require('invariant');
+
+function createAnimatedComponentWithHooks(Component: any): any {
+  invariant(
+    typeof Component !== 'function' ||
+      (Component.prototype && Component.prototype.isReactComponent),
+    '`createAnimatedComponent` does not support stateless functional components; ' +
+      'use a class component instead.',
+  );
+
+  const AnimatedOnAFeeling = props => {
+    const [initialized, setInitialized] = useState(false);
+    const [, forceUpdate] = useState();
+
+    let _invokeAnimatedPropsCallbackOnMount: boolean = false;
+    let _component: any = null;
+
+    let _eventDetachers: Array<Function> = [];
+
+    const _attachNativeEvents = () => {
+      // Make sure to get the scrollable node for components that implement
+      // `ScrollResponder.Mixin`.
+      const scrollableNode = _component.getScrollableNode
+        ? _component.getScrollableNode()
+        : _component;
+
+      for (const key in props) {
+        const prop = props[key];
+        if (prop instanceof AnimatedEvent && prop.__isNative) {
+          prop.__attach(scrollableNode, key);
+          _eventDetachers.push(() => prop.__detach(scrollableNode, key));
+        }
+      }
+    };
+
+    const _detachNativeEvents = () => {
+      _eventDetachers.forEach(remove => remove());
+      _eventDetachers = [];
+    };
+
+    // The system is best designed when setNativeProps is implemented. It is
+    // able to avoid re-rendering and directly set the attributes that changed.
+    // However, setNativeProps can only be implemented on leaf native
+    // components. If you want to animate a composite component, you need to
+    // re-render it. In this case, we have a fallback that uses forceUpdate.
+    const _animatedPropsCallback = () => {
+      if (_component == null) {
+        // AnimatedProps is created in will-mount because it's used in render.
+        // But this callback may be invoked before mount in async mode,
+        // In which case we should defer the setNativeProps() call.
+        // React may throw away uncommitted work in async mode,
+        // So a deferred call won't always be invoked.
+        _invokeAnimatedPropsCallbackOnMount = true;
+      } else if (
+        AnimatedOnAFeeling.__skipSetNativeProps_FOR_TESTS_ONLY ||
+        typeof _component.setNativeProps !== 'function'
+      ) {
+        forceUpdate();
+      } else if (!_propsAnimated.__isNative) {
+        _component.setNativeProps(_propsAnimated.__getAnimatedValue());
+      } else {
+        throw new Error(
+          'Attempting to run JS driven animation on animated ' +
+            'node that has been moved to "native" earlier by starting an ' +
+            'animation with `useNativeDriver: true`',
+        );
+      }
+    };
+
+    const _setComponentRef = useCallback(
+      node => {
+        if (node !== null) {
+          let _prevComponent = _component;
+          _component = node;
+
+          if (_component !== _prevComponent) {
+            _propsAnimated.setNativeView(_component);
+
+            if (!initialized) {
+              if (_invokeAnimatedPropsCallbackOnMount) {
+                _invokeAnimatedPropsCallbackOnMount = false;
+                _animatedPropsCallback();
+              }
+
+              _propsAnimated.setNativeView(_component);
+              _attachNativeEvents();
+            } else {
+              _detachNativeEvents();
+              _attachNativeEvents();
+            }
+          }
+        }
+      },
+      [initialized],
+    );
+
+    useEffect(() => {
+      if (!initialized) {
+        setInitialized(true);
+      }
+    }, []);
+
+    useEffect(() => {
+      if (initialized && _component) {
+        _detachNativeEvents();
+        _attachNativeEvents();
+      }
+
+      const oldPropsAnimated = _propsAnimated;
+
+      _propsAnimated = new AnimatedProps(props, _animatedPropsCallback);
+
+      // When you call detach, it removes the element from the parent list
+      // of children. If it goes to 0, then the parent also detaches itself
+      // and so on.
+      // An optimization is to attach the new elements and THEN detach the old
+      // ones instead of detaching and THEN attaching.
+      // This way the intermediate state isn't to go to 0 and trigger
+      // this expensive recursive detaching to then re-attach everything on
+      // the very next operation.
+      oldPropsAnimated && oldPropsAnimated.__detach();
+    }, [props]);
+
+    let _propsAnimated: AnimatedProps = new AnimatedProps(
+      props,
+      _animatedPropsCallback,
+    );
+    const animatedProps = _propsAnimated.__getValue();
+
+    return (
+      <Component
+        {...animatedProps}
+        ref={_setComponentRef}
+        // The native driver updates views directly through the UI thread so we
+        // have to make sure the view doesn't get optimized away because it cannot
+        // go through the NativeViewHierarchyManager since it operates on the shadow
+        // thread.
+        collapsable={
+          _propsAnimated.__isNative ? false : animatedProps.collapsable
+        }
+      />
+    );
+  };
+
+  const propTypes = Component.propTypes;
+
+  AnimatedOnAFeeling.propTypes = {
+    style: function(props, propName, componentName) {
+      if (!propTypes) {
+        return;
+      }
+
+      for (const key in DeprecatedViewStylePropTypes) {
+        if (!propTypes[key] && props[key] !== undefined) {
+          console.warn(
+            'You are setting the style `{ ' +
+              key +
+              ': ... }` as a prop. You ' +
+              'should nest it in a style object. ' +
+              'E.g. `{ style: { ' +
+              key +
+              ': ... } }`',
+          );
+        }
+      }
+    },
+  };
+
+  return AnimatedOnAFeeling;
+}
+
+module.exports = createAnimatedComponentWithHooks;

--- a/Libraries/Animated/src/AnimatedOnAFeeling.js
+++ b/Libraries/Animated/src/AnimatedOnAFeeling.js
@@ -118,6 +118,25 @@ function createAnimatedComponentWithHooks(Component: any): any {
       }
     }, []);
 
+    // Update ref when needed
+    useEffect(() => {
+      if (props.apiRef) {
+        props.apiRef.current = {
+          getNode() {
+            return _component;
+          },
+        };
+      }
+    }, [props.apiRef]);
+
+    useEffect(() => {
+      return () => {
+        if (props.apiRef) {
+          props.apiRef.current = null;
+        }
+      };
+    }, []);
+
     useEffect(() => {
       if (initialized && _component) {
         _detachNativeEvents();
@@ -184,7 +203,9 @@ function createAnimatedComponentWithHooks(Component: any): any {
     },
   };
 
-  return AnimatedOnAFeeling;
+  return React.forwardRef((props, ref) => {
+    return <AnimatedOnAFeeling {...props} apiRef={ref} />;
+  });
 }
 
 module.exports = createAnimatedComponentWithHooks;

--- a/Libraries/Animated/src/createAnimatedComponent.js
+++ b/Libraries/Animated/src/createAnimatedComponent.js
@@ -10,7 +10,7 @@
 'use strict';
 
 const {AnimatedEvent} = require('./AnimatedEvent');
-const createAnimatedComponentWithHooks = require('./AnimatedOnAFeeling');
+const createAnimatedComponentWithHooks = require('./createAnimatedComponentWithHooks');
 const AnimatedProps = require('./nodes/AnimatedProps');
 const React = require('React');
 const DeprecatedViewStylePropTypes = require('DeprecatedViewStylePropTypes');
@@ -202,7 +202,10 @@ function createAnimatedComponentOld(Component: any): any {
   return AnimatedComponent;
 }
 
-function createAnimatedComponent(Component: any, useHooks?: boolean): any {
+function createAnimatedComponent(
+  Component: any,
+  useHooks?: boolean = false, // can be set to true later on
+): any {
   if (useHooks === true) {
     return createAnimatedComponentWithHooks(Component);
   }

--- a/Libraries/Animated/src/createAnimatedComponent.js
+++ b/Libraries/Animated/src/createAnimatedComponent.js
@@ -10,15 +10,14 @@
 'use strict';
 
 const {AnimatedEvent} = require('./AnimatedEvent');
+const createAnimatedComponentWithHooks = require('./AnimatedOnAFeeling');
 const AnimatedProps = require('./nodes/AnimatedProps');
 const React = require('React');
 const DeprecatedViewStylePropTypes = require('DeprecatedViewStylePropTypes');
 
-const {useCallback, useEffect, useState} = React;
-
 const invariant = require('invariant');
 
-function createAnimatedComponent(Component: any): any {
+function createAnimatedComponentOld(Component: any): any {
   invariant(
     typeof Component !== 'function' ||
       (Component.prototype && Component.prototype.isReactComponent),
@@ -200,140 +199,15 @@ function createAnimatedComponent(Component: any): any {
     },
   };
 
-  const AnimatedOnAFeeling = props => {
-    const [initialized, setInitialized] = useState(false);
-    const [, forceUpdate] = useState();
+  return AnimatedComponent;
+}
 
-    let _invokeAnimatedPropsCallbackOnMount = false;
-    let _component = null;
+function createAnimatedComponent(Component: any, useHooks?: boolean): any {
+  if (useHooks === true) {
+    return createAnimatedComponentWithHooks(Component);
+  }
 
-    let _eventDetachers = [];
-
-    const _attachNativeEvents = () => {
-      // Make sure to get the scrollable node for components that implement
-      // `ScrollResponder.Mixin`.
-      const scrollableNode = _component.getScrollableNode
-        ? _component.getScrollableNode()
-        : _component;
-
-      for (const key in props) {
-        const prop = props[key];
-        if (prop instanceof AnimatedEvent && prop.__isNative) {
-          prop.__attach(scrollableNode, key);
-          _eventDetachers.push(() => prop.__detach(scrollableNode, key));
-        }
-      }
-    };
-
-    const _detachNativeEvents = () => {
-      _eventDetachers.forEach(remove => remove());
-      _eventDetachers = [];
-    };
-
-    // The system is best designed when setNativeProps is implemented. It is
-    // able to avoid re-rendering and directly set the attributes that changed.
-    // However, setNativeProps can only be implemented on leaf native
-    // components. If you want to animate a composite component, you need to
-    // re-render it. In this case, we have a fallback that uses forceUpdate.
-    const _animatedPropsCallback = () => {
-      if (_component == null) {
-        // AnimatedProps is created in will-mount because it's used in render.
-        // But this callback may be invoked before mount in async mode,
-        // In which case we should defer the setNativeProps() call.
-        // React may throw away uncommitted work in async mode,
-        // So a deferred call won't always be invoked.
-        _invokeAnimatedPropsCallbackOnMount = true;
-      } else if (
-        AnimatedComponent.__skipSetNativeProps_FOR_TESTS_ONLY ||
-        typeof _component.setNativeProps !== 'function'
-      ) {
-        forceUpdate();
-      } else if (!_propsAnimated.__isNative) {
-        _component.setNativeProps(_propsAnimated.__getAnimatedValue());
-      } else {
-        throw new Error(
-          'Attempting to run JS driven animation on animated ' +
-            'node that has been moved to "native" earlier by starting an ' +
-            'animation with `useNativeDriver: true`',
-        );
-      }
-    };
-
-    const _setComponentRef = useCallback(
-      node => {
-        if (node !== null) {
-          let _prevComponent = _component;
-          _component = node;
-
-          if (_component !== _prevComponent) {
-            _propsAnimated.setNativeView(_component);
-
-            if (!initialized) {
-              if (_invokeAnimatedPropsCallbackOnMount) {
-                _invokeAnimatedPropsCallbackOnMount = false;
-                _animatedPropsCallback();
-              }
-
-              _propsAnimated.setNativeView(_component);
-              _attachNativeEvents();
-            } else {
-              _detachNativeEvents();
-              _attachNativeEvents();
-            }
-          }
-        }
-      },
-      [initialized],
-    );
-
-    useEffect(() => {
-      if (!initialized) {
-        setInitialized(true);
-      }
-    }, []);
-
-    useEffect(() => {
-      if (initialized && _component) {
-        _detachNativeEvents();
-        _attachNativeEvents();
-      }
-
-      const oldPropsAnimated = _propsAnimated;
-
-      _propsAnimated = new AnimatedProps(props, _animatedPropsCallback);
-
-      // When you call detach, it removes the element from the parent list
-      // of children. If it goes to 0, then the parent also detaches itself
-      // and so on.
-      // An optimization is to attach the new elements and THEN detach the old
-      // ones instead of detaching and THEN attaching.
-      // This way the intermediate state isn't to go to 0 and trigger
-      // this expensive recursive detaching to then re-attach everything on
-      // the very next operation.
-      oldPropsAnimated && oldPropsAnimated.__detach();
-    }, [props]);
-
-    let _propsAnimated = new AnimatedProps(props, _animatedPropsCallback);
-    const animatedProps = _propsAnimated.__getValue();
-
-    return (
-      <Component
-        {...animatedProps}
-        ref={_setComponentRef}
-        // The native driver updates views directly through the UI thread so we
-        // have to make sure the view doesn't get optimized away because it cannot
-        // go through the NativeViewHierarchyManager since it operates on the shadow
-        // thread.
-        collapsable={
-          _propsAnimated.__isNative ? false : animatedProps.collapsable
-        }
-      />
-    );
-  };
-
-  AnimatedOnAFeeling.propTypes = AnimatedComponent.propTypes;
-
-  return AnimatedOnAFeeling;
+  return createAnimatedComponentOld(Component);
 }
 
 module.exports = createAnimatedComponent;

--- a/Libraries/Animated/src/createAnimatedComponent.js
+++ b/Libraries/Animated/src/createAnimatedComponent.js
@@ -204,7 +204,7 @@ function createAnimatedComponentOld(Component: any): any {
 
 function createAnimatedComponent(
   Component: any,
-  useHooks?: boolean = false, // can be set to true later on
+  useHooks?: boolean = true,
 ): any {
   if (useHooks === true) {
     return createAnimatedComponentWithHooks(Component);

--- a/Libraries/Animated/src/createAnimatedComponent.js
+++ b/Libraries/Animated/src/createAnimatedComponent.js
@@ -209,12 +209,7 @@ function createAnimatedComponent(Component: any): any {
 
     let _eventDetachers = [];
 
-    const _attachNativeEvents = (x) => {
-      if (_component === null) {
-        // TODO: Figure out why this is called when _component is null
-        throw new Error('should not be null' + x);
-      }
-
+    const _attachNativeEvents = () => {
       // Make sure to get the scrollable node for components that implement
       // `ScrollResponder.Mixin`.
       const scrollableNode = _component.getScrollableNode
@@ -280,10 +275,10 @@ function createAnimatedComponent(Component: any): any {
               }
 
               _propsAnimated.setNativeView(_component);
-              _attachNativeEvents('b');
+              _attachNativeEvents();
             } else {
               _detachNativeEvents();
-              _attachNativeEvents('c');
+              _attachNativeEvents();
             }
           }
         }
@@ -298,10 +293,9 @@ function createAnimatedComponent(Component: any): any {
     }, []);
 
     useEffect(() => {
-      if (initialized) {
+      if (initialized && _component) {
         _detachNativeEvents();
-        // TODO: this triggers the error. component is not set yet...
-        _attachNativeEvents('a');
+        _attachNativeEvents();
       }
 
       const oldPropsAnimated = _propsAnimated;
@@ -336,10 +330,6 @@ function createAnimatedComponent(Component: any): any {
       />
     );
   };
-
-  // ISSUES:
-  // - _component.getScrollableNode() - null is not an object
-  //   - see animated value listener example
 
   AnimatedOnAFeeling.propTypes = AnimatedComponent.propTypes;
 

--- a/Libraries/Animated/src/createAnimatedComponent.js
+++ b/Libraries/Animated/src/createAnimatedComponent.js
@@ -14,6 +14,8 @@ const AnimatedProps = require('./nodes/AnimatedProps');
 const React = require('React');
 const DeprecatedViewStylePropTypes = require('DeprecatedViewStylePropTypes');
 
+const {useCallback, useEffect, useState} = React;
+
 const invariant = require('invariant');
 
 function createAnimatedComponent(Component: any): any {
@@ -198,7 +200,150 @@ function createAnimatedComponent(Component: any): any {
     },
   };
 
-  return AnimatedComponent;
+  const AnimatedOnAFeeling = props => {
+    const [initialized, setInitialized] = useState(false);
+    const [, forceUpdate] = useState();
+
+    let _invokeAnimatedPropsCallbackOnMount = false;
+    let _component = null;
+
+    let _eventDetachers = [];
+
+    const _attachNativeEvents = (x) => {
+      if (_component === null) {
+        // TODO: Figure out why this is called when _component is null
+        throw new Error('should not be null' + x);
+      }
+
+      // Make sure to get the scrollable node for components that implement
+      // `ScrollResponder.Mixin`.
+      const scrollableNode = _component.getScrollableNode
+        ? _component.getScrollableNode()
+        : _component;
+
+      for (const key in props) {
+        const prop = props[key];
+        if (prop instanceof AnimatedEvent && prop.__isNative) {
+          prop.__attach(scrollableNode, key);
+          _eventDetachers.push(() => prop.__detach(scrollableNode, key));
+        }
+      }
+    };
+
+    const _detachNativeEvents = () => {
+      _eventDetachers.forEach(remove => remove());
+      _eventDetachers = [];
+    };
+
+    // The system is best designed when setNativeProps is implemented. It is
+    // able to avoid re-rendering and directly set the attributes that changed.
+    // However, setNativeProps can only be implemented on leaf native
+    // components. If you want to animate a composite component, you need to
+    // re-render it. In this case, we have a fallback that uses forceUpdate.
+    const _animatedPropsCallback = () => {
+      if (_component == null) {
+        // AnimatedProps is created in will-mount because it's used in render.
+        // But this callback may be invoked before mount in async mode,
+        // In which case we should defer the setNativeProps() call.
+        // React may throw away uncommitted work in async mode,
+        // So a deferred call won't always be invoked.
+        _invokeAnimatedPropsCallbackOnMount = true;
+      } else if (
+        AnimatedComponent.__skipSetNativeProps_FOR_TESTS_ONLY ||
+        typeof _component.setNativeProps !== 'function'
+      ) {
+        forceUpdate();
+      } else if (!_propsAnimated.__isNative) {
+        _component.setNativeProps(_propsAnimated.__getAnimatedValue());
+      } else {
+        throw new Error(
+          'Attempting to run JS driven animation on animated ' +
+            'node that has been moved to "native" earlier by starting an ' +
+            'animation with `useNativeDriver: true`',
+        );
+      }
+    };
+
+    const _setComponentRef = useCallback(
+      node => {
+        if (node !== null) {
+          let _prevComponent = _component;
+          _component = node;
+
+          if (_component !== _prevComponent) {
+            _propsAnimated.setNativeView(_component);
+
+            if (!initialized) {
+              if (_invokeAnimatedPropsCallbackOnMount) {
+                _invokeAnimatedPropsCallbackOnMount = false;
+                _animatedPropsCallback();
+              }
+
+              _propsAnimated.setNativeView(_component);
+              _attachNativeEvents('b');
+            } else {
+              _detachNativeEvents();
+              _attachNativeEvents('c');
+            }
+          }
+        }
+      },
+      [initialized],
+    );
+
+    useEffect(() => {
+      if (!initialized) {
+        setInitialized(true);
+      }
+    }, []);
+
+    useEffect(() => {
+      if (initialized) {
+        _detachNativeEvents();
+        // TODO: this triggers the error. component is not set yet...
+        _attachNativeEvents('a');
+      }
+
+      const oldPropsAnimated = _propsAnimated;
+
+      _propsAnimated = new AnimatedProps(props, _animatedPropsCallback);
+
+      // When you call detach, it removes the element from the parent list
+      // of children. If it goes to 0, then the parent also detaches itself
+      // and so on.
+      // An optimization is to attach the new elements and THEN detach the old
+      // ones instead of detaching and THEN attaching.
+      // This way the intermediate state isn't to go to 0 and trigger
+      // this expensive recursive detaching to then re-attach everything on
+      // the very next operation.
+      oldPropsAnimated && oldPropsAnimated.__detach();
+    }, [props]);
+
+    let _propsAnimated = new AnimatedProps(props, _animatedPropsCallback);
+    const animatedProps = _propsAnimated.__getValue();
+
+    return (
+      <Component
+        {...animatedProps}
+        ref={_setComponentRef}
+        // The native driver updates views directly through the UI thread so we
+        // have to make sure the view doesn't get optimized away because it cannot
+        // go through the NativeViewHierarchyManager since it operates on the shadow
+        // thread.
+        collapsable={
+          _propsAnimated.__isNative ? false : animatedProps.collapsable
+        }
+      />
+    );
+  };
+
+  // ISSUES:
+  // - _component.getScrollableNode() - null is not an object
+  //   - see animated value listener example
+
+  AnimatedOnAFeeling.propTypes = AnimatedComponent.propTypes;
+
+  return AnimatedOnAFeeling;
 }
 
 module.exports = createAnimatedComponent;

--- a/Libraries/Animated/src/createAnimatedComponentWithHooks.js
+++ b/Libraries/Animated/src/createAnimatedComponentWithHooks.js
@@ -26,7 +26,7 @@ function createAnimatedComponentWithHooks(Component: any): any {
       'use a class component instead.',
   );
 
-  const AnimatedOnAFeeling = props => {
+  const AnimatedComponent = props => {
     const [initialized, setInitialized] = useState(false);
     const [, forceUpdate] = useState();
 
@@ -70,7 +70,7 @@ function createAnimatedComponentWithHooks(Component: any): any {
         // So a deferred call won't always be invoked.
         _invokeAnimatedPropsCallbackOnMount = true;
       } else if (
-        AnimatedOnAFeeling.__skipSetNativeProps_FOR_TESTS_ONLY ||
+        AnimatedComponent.__skipSetNativeProps_FOR_TESTS_ONLY ||
         typeof _component.setNativeProps !== 'function'
       ) {
         forceUpdate();
@@ -181,7 +181,7 @@ function createAnimatedComponentWithHooks(Component: any): any {
 
   const propTypes = Component.propTypes;
 
-  AnimatedOnAFeeling.propTypes = {
+  AnimatedComponent.propTypes = {
     style: function(props, propName, componentName) {
       if (!propTypes) {
         return;
@@ -204,7 +204,7 @@ function createAnimatedComponentWithHooks(Component: any): any {
   };
 
   return React.forwardRef((props, ref) => {
-    return <AnimatedOnAFeeling {...props} apiRef={ref} />;
+    return <AnimatedComponent {...props} apiRef={ref} />;
   });
 }
 


### PR DESCRIPTION
## Summary

This is a continuation of https://github.com/facebook/react-native/pull/24218

As mentioned in that PR by maintainers, hooks based variant is preferred to make animated components strict-mode compatible. This PR adds that.

Note: The old variant still exists in the code and can be used by providing false as the second argument to createAnimatedComponent. 

related to https://github.com/facebook/react-native/issues/22186

Note: Will squash/cleanup history at the end

## Changelog

[General] [Fixed] - Converted createAnimatedComponent to be compatible with StrictMode. Old behaviour can be retained by providing false as the second argument.

## Test Plan

Tested all animation examples in RNTester to make sure they still work. Created a component that used refs to access `getNode` and it worked the same for both the old and new implementation. Finally I also ran some real-world apps that I have built at work with the code and did not notice any regressions.
