### PR TITLE
Add ability to customise WebSocket OkHttp client and fallback to existing implementation

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/modules/network/OkHttpClientProvider.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/network/OkHttpClientProvider.java
@@ -42,6 +42,10 @@ public class OkHttpClientProvider {
     sFactory = factory;
   }
 
+  public static boolean hasOkHttpClient() {
+    return sClient != null;
+  }
+
   public static OkHttpClient getOkHttpClient() {
     if (sClient == null) {
       sClient = createClient();

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/websocket/WebSocketModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/websocket/WebSocketModule.java
@@ -85,14 +85,14 @@ public final class WebSocketModule extends ReactContextBaseJavaModule {
     @Nullable final ReadableArray protocols,
     @Nullable final ReadableMap options,
     final int id) {
-    OkHttpClient client;
+    OkHttpClient.Builder builder;
     if (OkHttpClientProvider.hasOkHttpClient()) {
-      client = OkHttpClientProvider.getOkHttpClient().newBuilder();
+      builder = OkHttpClientProvider.getOkHttpClient().newBuilder();
     } else {
-      client = new OkHttpClient.Builder();
+      builder = new OkHttpClient.Builder();
     }
 
-    client
+    OkHttpClient client = builder
       .connectTimeout(10, TimeUnit.SECONDS)
       .writeTimeout(10, TimeUnit.SECONDS)
       .readTimeout(0, TimeUnit.MINUTES) // Disable timeouts for read

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/websocket/WebSocketModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/websocket/WebSocketModule.java
@@ -84,7 +84,14 @@ public final class WebSocketModule extends ReactContextBaseJavaModule {
     @Nullable final ReadableArray protocols,
     @Nullable final ReadableMap options,
     final int id) {
-    OkHttpClient client = new OkHttpClient.Builder()
+    OkHttpClient client;
+    if (OkHttpClientProvider.hasOkHttpClient()) {
+      client = OkHttpClientProvider.getOkHttpClient().newBuilder();
+    } else {
+      client = new OkHttpClient.Builder();
+    }
+
+    client
       .connectTimeout(10, TimeUnit.SECONDS)
       .writeTimeout(10, TimeUnit.SECONDS)
       .readTimeout(0, TimeUnit.MINUTES) // Disable timeouts for read

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/websocket/WebSocketModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/websocket/WebSocketModule.java
@@ -85,14 +85,14 @@ public final class WebSocketModule extends ReactContextBaseJavaModule {
     @Nullable final ReadableArray protocols,
     @Nullable final ReadableMap options,
     final int id) {
-    OkHttpClient.Builder builder;
+    OkHttpClient.Builder cBuilder;
     if (OkHttpClientProvider.hasOkHttpClient()) {
-      builder = OkHttpClientProvider.getOkHttpClient().newBuilder();
+      cBuilder = OkHttpClientProvider.getOkHttpClient().newBuilder();
     } else {
-      builder = new OkHttpClient.Builder();
+      cBuilder = new OkHttpClient.Builder();
     }
 
-    OkHttpClient client = builder
+    OkHttpClient client = cBuilder
       .connectTimeout(10, TimeUnit.SECONDS)
       .writeTimeout(10, TimeUnit.SECONDS)
       .readTimeout(0, TimeUnit.MINUTES) // Disable timeouts for read

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/websocket/WebSocketModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/websocket/WebSocketModule.java
@@ -22,6 +22,7 @@ import com.facebook.react.common.ReactConstants;
 import com.facebook.react.module.annotations.ReactModule;
 import com.facebook.react.modules.core.DeviceEventManagerModule;
 import com.facebook.react.modules.network.ForwardingCookieHandler;
+import com.facebook.react.modules.network.OkHttpClientProvider;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
This is a follow-up PR to #19632 for which @cpojer [called upon](https://github.com/facebook/react-native/pull/19632#issuecomment-476693393). Disclaimer: I don't have much experience in the Android/Java field.

Quoting the original PR:
> Prior to 22efd95, users could customise the OkHttp client used by React Native on Android by calling setOkHttpClientFactory in OkHttpClientProvider.

> This functionality has a variety of legitimate applications from changing connection timeouts or pool size to Stetho integration. In this commit also provide the ability for WebSocket.

I believe I found a work-around but was not able validate the failing tests @cpojer experienced. Because of that I would label my PR as WIP.

Closes #18920

## Fix Description
[`getOkHttpClient`](https://github.com/facebook/react-native/blob/master/ReactAndroid/src/main/java/com/facebook/react/modules/network/OkHttpClientProvider.java) creates a client in-place, if a `sClient == null`.
```java
public static OkHttpClient getOkHttpClient() {
    if (sClient == null) {
      sClient = createClient();
    }
    return sClient;
  }
```
[`connect`](https://github.com/facebook/react-native/blob/master/ReactAndroid/src/main/java/com/facebook/react/modules/websocket/WebSocketModule.java) of the `WebSocketModule` makes no use of this in-place client, it initalizes a client by itself (uses a "virgin" client).
```java
  @ReactMethod
  public void connect(
    final String url,
    @Nullable final ReadableArray protocols,
    @Nullable final ReadableMap options,
    final int id) {
    OkHttpClient client = new OkHttpClient.Builder()
      .connectTimeout(10, TimeUnit.SECONDS)
      .writeTimeout(10, TimeUnit.SECONDS)
      .readTimeout(0, TimeUnit.MINUTES) // Disable timeouts for read
      .build();

 //...
```
[The original fix](https://github.com/facebook/react-native/pull/19632/files) uses `getOkHttpClient` thus `WebSocketModule` implicitly receives a pre-loaded client, if no explicit `sClient` is set.

This PR adds a `hasOkHttpClient` Method to the `OkHttpClientProvider`, so that the `WebSocketModule` can select if it will use the explicitly set client from the provider or fall back to using the "virgin" client.

## Changelog

[ANDROID] [Changed] - Added custom OkHttpClient injection into WebSocketModule only if custom OkHttpClient is configured

## Test Plan

Quoting the original PR:
> Create React Native application and set a custom factory in the constructor, e.g. OkHttpClientProvider.setOkHttpClientFactory(new CustomNetworkModule());

> Where a custom factory would look like:
> ```java
> class CustomNetworkModule implements OkHttpClientFactory {
>    public OkHttpClient createNewNetworkModuleClient() {
>        return new OkHttpClient.Builder().build();
>    }
>}
>```

I was unable to locate the existing unit or integration test files for the `OkHttpClientProvider` and `WebSocketModule`, so I am unsure if unit tests are expected.