### PR TITLE
Fix caching of task bundleJsAndAssets

### DIFF
--- a/react.gradle
+++ b/react.gradle
@@ -42,9 +42,7 @@ afterEvaluate {
 
             // Create dirs if they are not there (e.g. the "clean" task just ran)
             doFirst {
-                jsBundleDir.deleteDir()
                 jsBundleDir.mkdirs()
-                resourcesDir.deleteDir()
                 resourcesDir.mkdirs()
             }
 


### PR DESCRIPTION
## Summary
Fixes https://github.com/facebook/react-native/issues/24330

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See http://facebook.github.io/react-native/docs/contributing#changelog for an example. -->

[Android] [fixed] - Fixed https://github.com/facebook/react-native/issues/24330

## Test Plan

1. Build the app via `./gradlew assembleRelease`
2. Build the app again via `./gradlew assembleRelease` without changes
3. Task `bundleReleaseJsAndAssets` is UP-TO-DATE

I tested with multiple flavors. It works when cleaning the build before and with all subsequent builds.
