### PR TITLE
change jest native method mocks to jest functions

### DIFF
--- a/Libraries/Components/TextInput/__tests__/TextInput-test.js
+++ b/Libraries/Components/TextInput/__tests__/TextInput-test.js
@@ -50,12 +50,14 @@ describe('TextInput tests', () => {
   it('has expected instance functions', () => {
     expect(input.instance.isFocused).toBeInstanceOf(Function); // Would have prevented S168585
     expect(input.instance.clear).toBeInstanceOf(Function);
-    expect(input.instance.focus).toBeInstanceOf(Function);
-    expect(input.instance.blur).toBeInstanceOf(Function);
-    expect(input.instance.setNativeProps).toBeInstanceOf(Function);
-    expect(input.instance.measure).toBeInstanceOf(Function);
-    expect(input.instance.measureInWindow).toBeInstanceOf(Function);
-    expect(input.instance.measureLayout).toBeInstanceOf(Function);
+    expect(input.instance.focus).toBeInstanceOf(jest.fn().constructor);
+    expect(input.instance.blur).toBeInstanceOf(jest.fn().constructor);
+    expect(input.instance.setNativeProps).toBeInstanceOf(jest.fn().constructor);
+    expect(input.instance.measure).toBeInstanceOf(jest.fn().constructor);
+    expect(input.instance.measureInWindow).toBeInstanceOf(
+      jest.fn().constructor,
+    );
+    expect(input.instance.measureLayout).toBeInstanceOf(jest.fn().constructor);
   });
   it('calls onChange callbacks', () => {
     expect(input.props.value).toBe(initialValue);

--- a/jest/MockNativeMethods.js
+++ b/jest/MockNativeMethods.js
@@ -9,30 +9,13 @@
 
 'use strict';
 
-const mockNativeFunction = methodName => {
-  let warned = false;
-  return function() {
-    if (warned) {
-      return;
-    }
-    warned = true;
-    console.warn(
-      'Calling .' +
-        methodName +
-        '() in the test renderer environment is not supported. Instead, mock ' +
-        'out your components that use findNodeHandle with replacements that ' +
-        "don't rely on the native environment.",
-    );
-  };
-};
-
 const MockNativeMethods = {
-  measure: mockNativeFunction('measure'),
-  measureInWindow: mockNativeFunction('measureInWindow'),
-  measureLayout: mockNativeFunction('measureLayout'),
-  setNativeProps: mockNativeFunction('setNativeProps'),
-  focus: mockNativeFunction('focus'),
-  blur: mockNativeFunction('blur'),
+  measure: jest.fn(),
+  measureInWindow: jest.fn(),
+  measureLayout: jest.fn(),
+  setNativeProps: jest.fn(),
+  focus: jest.fn(),
+  blur: jest.fn(),
 };
 
 module.exports = MockNativeMethods;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Currently calling native methods on internal react native components throw a warning. I believe this is problematic because _users_ aren't calling native methods on internal components, the _component_ is making the call.

So for instance, if I unmount a component that has a form with a few uses of `TextInput`, which is a perfectly valid test case, my test output will be full of warnings that I can't call `.blur()` in the test renderer environment. That's very misleading, because I didn't, the internal component did. In fact, as far as I can tell, there's not really even anything I can do to stop that call or use the output from it, its all internal. `TextInput` is a black box, and 99% of users writing tests probably won't even know it calls `.blur()` under the hood on unmount.

I want to change these to `jest.fn()` because I think this eliminates a lot of chatter in test output, but also doesn't send users down a rabbit hole of trying to find workarounds that may involve filtering console output, which could potentially lead them to inadvertently filter out real warnings that they should see.

So I'm willing to change the implementation of how I did this, but I don't think its right to warn users that they called a native method when they didn't. If they build a component that calls these methods, I believe it's on them to do something similar to this, and maybe we can make this exposed as a helper that can be used for third party component mocks?

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See http://facebook.github.io/react-native/docs/contributing#changelog for an example. -->

[General] [Changes] - Changed MockNativeMethods for core components to `jest.fn()` instead of function that warns about calling native methods.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

TextInput tests checked that nativeProps were `instanceOf(Function)`, changed so that they expect `instanceOf(jest.fn().constructor)`, and the test suite still passes. No lint issues were introduced by this, and prettier was run on changes.
