### PR TITLE
Remove wrapper around ListEmptyComponent

### DIFF
--- a/Libraries/Lists/VirtualizedList.js
+++ b/Libraries/Lists/VirtualizedList.js
@@ -873,17 +873,19 @@ class VirtualizedList extends React.PureComponent<Props, State> {
         <ListEmptyComponent />
       )): any);
       cells.push(
-        <View key="$empty" style={inversionStyle}>
-          {React.cloneElement(element, {
-            onLayout: event => {
-              this._onLayoutEmpty(event);
-              if (element.props.onLayout) {
-                element.props.onLayout(event);
-              }
-            },
-            style: element.props.style,
-          })}
-        </View>,
+        React.cloneElement(element, {
+          key: '$empty',
+          onLayout: event => {
+            this._onLayoutEmpty(event);
+            if (element.props.onLayout) {
+              element.props.onLayout(event);
+            }
+          },
+          style: StyleSheet.compose(
+            inversionStyle,
+            element.props.style,
+          ),
+        }),
       );
     }
     if (ListFooterComponent) {

--- a/Libraries/Lists/__tests__/__snapshots__/VirtualizedList-test.js.snap
+++ b/Libraries/Lists/__tests__/__snapshots__/VirtualizedList-test.js.snap
@@ -668,11 +668,7 @@ exports[`VirtualizedList renders empty list with empty component 1`] = `
     >
       <header />
     </View>
-    <View
-      style={null}
-    >
-      <empty />
-    </View>
+    <empty />
     <View
       onLayout={[Function]}
     >


### PR DESCRIPTION
## Summary

This pull request fixes #24257.

The wrapper around ListEmptyComponent doesn't allow to use flex on the ListEmptyComponent.
The wrapper was removed in this [commit](https://github.com/facebook/react-native/commit/db061ea8c7b78d7e9df4a450c9e7a24d9b2382b4), and then put back in this [commit](https://github.com/facebook/react-native/commit/e94d3444dcface90bd20234d13143462690ff23c) but I think the relevant part was removing the condition on `itemCount !== 0` to apply the inversionStyle on the ScrollView and everything is still working without the wrapper.

## Changelog


[GENERAL] [FIXED] - Remove wrapper around ListEmptyComponent

## Test Plan

Here is the code I used to test:
```
<FlatList
  data={[]}
  keyExtractor={item => item}
  contentContainerStyle={{ flex: 1 }}
  ListEmptyComponent={
    <View
      style={{
        flex: 1,
        backgroundColor: 'red',
      }}
    >
      <Text>Empty</Text>
    </View>
  }
  ListFooterComponent={
    <View
      style={{
        backgroundColor: '#D6D6D6',
        paddingVertical: 6,
        marginVertical: 6,
        borderRadius: 20,
        alignItems: 'center',
        paddingHorizontal: 15,
      }}
    >
      <Text>FOOTER</Text>
    </View>
  }
  ListHeaderComponent={
    <View
      style={{
        backgroundColor: '#D6D6D6',
        paddingVertical: 6,
        marginVertical: 6,
        borderRadius: 20,
        alignItems: 'center',
        paddingHorizontal: 15,
      }}
    >
      <Text>HEADER</Text>
    </View>
  }
  renderItem={({item}) => <Text>{item}</Text>}
/>
```

The ListEmptyComponent is taking the full height (or full width in horizontal mode) as expected. And it is not rendered upside down when the FlatList is inverted:

Vertical, not inverted:
![image](https://user-images.githubusercontent.com/17070498/55681734-2245a980-592a-11e9-993c-78887bed2eed.png)

Vertical, inverted:
![image](https://user-images.githubusercontent.com/17070498/55681740-32f61f80-592a-11e9-86b3-0cb830158cf6.png)

Horizontal, not inverted:
![image](https://user-images.githubusercontent.com/17070498/55681815-f24ad600-592a-11e9-8a02-5f86ab0fc092.png)

Horizontal, inverted:
![image](https://user-images.githubusercontent.com/17070498/55681809-e5c67d80-592a-11e9-86fc-cd0b0a2a66a7.png)

