### PR TITLE
[CI] Fix Docker Android tests container issue related to the JSC

### DIFF
--- a/.circleci/Dockerfiles/Dockerfile.android
+++ b/.circleci/Dockerfiles/Dockerfile.android
@@ -8,10 +8,10 @@
 #
 # The base image is expected to remain relatively stable, and only
 # needs to be updated when major dependencies such as the Android
-# SDK or NDK are updated. 
+# SDK or NDK are updated.
 #
-# In this Android Test image, we download the latest dependencies 
-# and build a Android application that can be used to run the 
+# In this Android Test image, we download the latest dependencies
+# and build a Android application that can be used to run the
 # tests specified in the scripts/ directory.
 #
 FROM reactnativecommunity/react-native-android
@@ -42,16 +42,11 @@ RUN buck fetch ReactAndroid/src/androidTest/...
 RUN buck build ReactAndroid/src/main/java/com/facebook/react
 RUN buck build ReactAndroid/src/main/java/com/facebook/react/shell
 
-ADD gradle /app/gradle
-ADD gradlew /app/gradlew
-ADD settings.gradle /app/settings.gradle
-ADD build.gradle /app/build.gradle
-ADD react.gradle /app/react.gradle
-
-RUN ./gradlew :ReactAndroid:downloadBoost :ReactAndroid:downloadDoubleConversion :ReactAndroid:downloadFolly :ReactAndroid:downloadGlog :ReactAndroid:downloadJSC
-
-RUN ./gradlew :ReactAndroid:packageReactNdkLibsForBuck -Pjobs=1
-
 ADD . /app
 
 RUN yarn
+
+RUN ./gradlew :ReactAndroid:downloadBoost :ReactAndroid:downloadDoubleConversion :ReactAndroid:downloadFolly :ReactAndroid:downloadGlog
+
+RUN ./gradlew :ReactAndroid:packageReactNdkLibsForBuck -Pjobs=1
+


### PR DESCRIPTION
## Summary

[Fixes an issue where the Docker Android tests container cannot be built.](https://github.com/facebook/react-native/pull/24276#issuecomment-480915232) The JSC is now pulled from the npm registry, so we need to run `yarn` prior to pulling the Gradle dependencies.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See http://facebook.github.io/react-native/docs/contributing#changelog for an example. -->

[Android] [Fixed] - Fixed React Native Android tests Docker container issue related to the JSC

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Ran `yarn docker-build-android` locally and verified the container was built successfully.