### PR TITLE
Workaround for long text rendering bug in YellowBox

### DIFF
--- a/Libraries/YellowBox/UI/YellowBoxInspector.js
+++ b/Libraries/YellowBox/UI/YellowBoxInspector.js
@@ -66,12 +66,16 @@ class YellowBoxInspector extends React.Component<Props, State> {
             <View style={styles.bodyHeading}>
               <Text style={styles.bodyHeadingText}>Warning</Text>
             </View>
-            <Text style={styles.bodyText}>
+            {/* There is a bug on iOS that causes very long text to
+                render incorrectly. As a workaround we can use a non-editable
+                multiline TextInput which does not have the bug.
+                See https://github.com/facebook/react-native/issues/19453 */}
+            <TextInput style={styles.bodyText} multiline editable={false}>
               {YellowBoxCategory.render(
                 warning.message,
                 styles.substitutionText,
               )}
-            </Text>
+            </TextInput>
           </View>
           <View style={styles.bodySection}>
             <View style={styles.bodyHeading}>

--- a/Libraries/YellowBox/UI/YellowBoxInspector.js
+++ b/Libraries/YellowBox/UI/YellowBoxInspector.js
@@ -15,6 +15,7 @@ const React = require('React');
 const ScrollView = require('ScrollView');
 const StyleSheet = require('StyleSheet');
 const Text = require('Text');
+const TextInput = require('TextInput');
 const View = require('View');
 const YellowBoxCategory = require('YellowBoxCategory');
 const YellowBoxInspectorFooter = require('YellowBoxInspectorFooter');


### PR DESCRIPTION
## Summary

On iOS simulator there is an issue where very long text is not rendered properly. See https://github.com/facebook/react-native/issues/19453 for more context. A workaround is to use a non-editable TextInput instead of a Text component.

## Changelog

[iOS] [Fixed] - Workaround for long text rendering bug in YellowBox

## Test Plan

Tested that warnings shown in YellowBox display properly on both iOS and Android when using a very long text (15k+ chars)
