### PR TITLE
[Fabric] Call designated initializer for SurfaceHostingProxyRootView

### DIFF
--- a/React/Base/Surface/SurfaceHostingView/RCTSurfaceHostingProxyRootView.h
+++ b/React/Base/Surface/SurfaceHostingView/RCTSurfaceHostingProxyRootView.h
@@ -45,6 +45,10 @@ NS_ASSUME_NONNULL_BEGIN
                 initialProperties:(NSDictionary *)initialProperties
                     launchOptions:(NSDictionary *)launchOptions;
 
+- (instancetype)initWithSurface:(RCTSurface *)surface
+                sizeMeasureMode:(RCTSurfaceSizeMeasureMode)sizeMeasureMode
+                  NS_UNAVAILABLE;
+
 - (void)cancelTouches;
 
 @end

--- a/React/Base/Surface/SurfaceHostingView/RCTSurfaceHostingProxyRootView.mm
+++ b/React/Base/Surface/SurfaceHostingView/RCTSurfaceHostingProxyRootView.mm
@@ -67,9 +67,10 @@ static RCTRootViewSizeFlexibility convertToRootViewSizeFlexibility(RCTSurfaceSiz
   // `RCTRootViewSizeFlexibilityNone` is the RCTRootView's default.
   RCTSurfaceSizeMeasureMode sizeMeasureMode = convertToSurfaceSizeMeasureMode(RCTRootViewSizeFlexibilityNone);
 
-  if (self = [super initWithBridge:bridge moduleName:moduleName initialProperties:initialProperties sizeMeasureMode:sizeMeasureMode]) {
+  RCTSurface *surface = [[self class] createSurfaceWithBridge:bridge moduleName:moduleName initialProperties:initialProperties];
+  [surface start];
+  if (self = [super initWithSurface:surface sizeMeasureMode:sizeMeasureMode]) {
     self.backgroundColor = [UIColor whiteColor];
-    [super.surface start];
   }
 
   RCT_PROFILE_END_EVENT(RCTProfileTagAlways, @"");


### PR DESCRIPTION
## Summary

1. Call designated initializer for SurfaceHostingProxyRootView.
2. Make super class designated initializer `-initWithSurface:sizeMeasureMode:` `NS_UNAVAILABLE`.

cc. @shergin

## Changelog

[iOS] [Fixed] - Call designated initializer for SurfaceHostingProxyRootView

## Test Plan

N/A.