### PR TITLE
[Fabric] Add valid check for shadow tree and component view

### DIFF
--- a/React/Fabric/RCTSurfacePresenter.mm
+++ b/React/Fabric/RCTSurfacePresenter.mm
@@ -271,9 +271,11 @@ using namespace facebook::react;
 
   UIView<RCTComponentViewProtocol> *rootView =
     [_mountingManager.componentViewRegistry componentViewByTag:surface.rootTag];
-  [_mountingManager.componentViewRegistry enqueueComponentViewWithComponentHandle:RootShadowNode::Handle()
-                                                                              tag:surface.rootTag
-                                                                    componentView:rootView];
+  if (rootView) {
+    [_mountingManager.componentViewRegistry enqueueComponentViewWithComponentHandle:RootShadowNode::Handle()
+                                                                                tag:surface.rootTag
+                                                                      componentView:rootView];
+  }
 
   [surface _unsetStage:(RCTSurfaceStagePrepared | RCTSurfaceStageMounted)];
 }


### PR DESCRIPTION
## Summary

The reason why we need add these checks is sometimes js bundle may not run successful, in these cases ,`rootView` or `shadowTree` may not created.

cc. @shergin 

## Changelog

[General] [Fixed] - Add valid check for shadow tree and component view

## Test Plan

N/A.