### PR TITLE
add docker test to circle-ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -514,13 +514,15 @@ jobs:
   # -------------------------
   test-docker-build:
     machine: true
-    filters: *filter-ignore-gh-pages
     steps:
       - checkout
-      - npx envinfo@latest
-      - yarn run docker-setup-android
-      - yarn run docker-build-android
-      -
+      - run: npx envinfo@latest
+      - run:
+          name: Build Android RNTester App
+          command: |
+            yarn run docker-setup-android
+            yarn run docker-build-android
+
   # -------------------------
   #      JOBS: Coverage
   # -------------------------

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,15 +139,6 @@ aliases:
     requires:
       - checkout_code
 
-  - &test-docker-build
-    machine: true
-    filters: *filter-ignore-gh-pages
-    steps:
-      - checkout
-      - npx envinfo@latest
-      - yarn run docker-setup-android
-      - yarn run docker-build-android
-
 # -------------------------
 #        DEFAULTS
 # -------------------------
@@ -517,7 +508,19 @@ jobs:
       
       - store_test_results:
           path: ~/react-native/reports/junit
-  
+
+  # -------------------------
+  #    JOBS: Test Docker Build
+  # -------------------------
+  test-docker-build:
+    machine: true
+    filters: *filter-ignore-gh-pages
+    steps:
+      - checkout
+      - npx envinfo@latest
+      - yarn run docker-setup-android
+      - yarn run docker-build-android
+      -
   # -------------------------
   #      JOBS: Coverage
   # -------------------------
@@ -601,7 +604,7 @@ workflows:
       - test_android: *run-after-checkout
       - test_ios: *run-after-checkout
       - test_detox_end_to_end: *run-after-checkout
-      - test_docker_build: *test-docker-build
+      - test_docker_build
 
   releases:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -512,7 +512,7 @@ jobs:
   # -------------------------
   #    JOBS: Test Docker Build
   # -------------------------
-  test-docker-build:
+  test_docker_build:
     machine: true
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,6 +139,15 @@ aliases:
     requires:
       - checkout_code
 
+  - &test-docker-build
+    machine: true
+    filters: *filter-ignore-gh-pages
+    steps:
+      - checkout
+      - npx envinfo@latest
+      - yarn run docker-setup-android
+      - yarn run docker-build-android
+
 # -------------------------
 #        DEFAULTS
 # -------------------------
@@ -157,7 +166,7 @@ js_defaults: &js_defaults
 android_defaults: &android_defaults
   <<: *defaults
   docker:
-  - image: reactnativecommunity/react-native-android:2019-1-19
+    - image: reactnativecommunity/react-native-android:2019-1-19
   resource_class: "large"
   environment:
     - TERM: "dumb"
@@ -592,6 +601,7 @@ workflows:
       - test_android: *run-after-checkout
       - test_ios: *run-after-checkout
       - test_detox_end_to_end: *run-after-checkout
+      - test_docker_build: *test-docker-build
 
   releases:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -516,10 +516,13 @@ jobs:
     machine: true
     steps:
       - checkout
-      - run: npx envinfo@latest
       - run:
           name: Build Android RNTester App
           command: |
+            source ~/.bashrc
+            nvm i node
+            npm i -g yarn
+            npx envinfo@latest
             yarn run docker-setup-android
             yarn run docker-build-android
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -517,7 +517,7 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Build Android RNTester App
+          name: Build Docker container for Android RNTester App
           command: |
             source ~/.bashrc
             nvm i node


### PR DESCRIPTION
## Summary

add docker related test to ci (only build part), prevent future regression like https://github.com/facebook/react-native/pull/24360

## Changelog

[General] [Added] - add docker related test to ci


## Test Plan

pas current ci
