### PR TITLE
improve dev mode and HMR interop

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevInternalSettings.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevInternalSettings.java
@@ -88,6 +88,10 @@ public class DevInternalSettings implements
     return mPreferences.getBoolean(PREFS_JS_DEV_MODE_DEBUG_KEY, true);
   }
 
+  public void setJSDevModeEnabled(boolean value) {
+    mPreferences.edit().putBoolean(PREFS_JS_DEV_MODE_DEBUG_KEY, value).apply();
+  }
+
   @Override
   public boolean isJSMinifyEnabled() {
     return mPreferences.getBoolean(PREFS_JS_MINIFY_DEBUG_KEY, false);

--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerImpl.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerImpl.java
@@ -514,7 +514,7 @@ public class DevSupportManagerImpl implements
               @Override
               public void onOptionSelected() {
                 if (!mDevSettings.isHotModuleReplacementEnabled() && !mDevSettings.isJSDevModeEnabled()) {
-                  Toast.makeText(mApplicationContext, "You're trying to enable HMR while Dev mode is off. Turning the Dev mode on...", Toast.LENGTH_LONG).show();
+                  Toast.makeText(mApplicationContext, "You're trying to enable HMR while Dev mode is off. Turning both HMR and the Dev mode on...", Toast.LENGTH_LONG).show();
                   mDevSettings.setJSDevModeEnabled(true);
                 }
                 mDevSettings.setHotModuleReplacementEnabled(!mDevSettings.isHotModuleReplacementEnabled());

--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerImpl.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerImpl.java
@@ -459,8 +459,8 @@ public class DevSupportManagerImpl implements
         new DevOptionHandler() {
           @Override
           public void onOptionSelected() {
-            if (mDevSettings.isHotModuleReplacementEnabled()) {
-              Toast.makeText(mApplicationContext, "Dev mode and HRM cannot be both enabled at once. Disabling HMR...", Toast.LENGTH_LONG).show();
+            if (!mDevSettings.isJSDevModeEnabled() && mDevSettings.isHotModuleReplacementEnabled()) {
+              Toast.makeText(mApplicationContext, "HMR cannot be enabled when Dev mode is off. Disabling HMR...", Toast.LENGTH_LONG).show();
               mDevSettings.setHotModuleReplacementEnabled(false);
             }
             handleReloadJS();
@@ -514,7 +514,7 @@ public class DevSupportManagerImpl implements
               @Override
               public void onOptionSelected() {
                 if (!mDevSettings.isJSDevModeEnabled()) {
-                  Toast.makeText(mApplicationContext, "Dev mode needs to be turned on to enable HRM.", Toast.LENGTH_LONG).show();
+                  Toast.makeText(mApplicationContext, "Dev mode needs to be turned on to enable HMR.", Toast.LENGTH_LONG).show();
                   return;
                 }
                 mDevSettings.setHotModuleReplacementEnabled(!mDevSettings.isHotModuleReplacementEnabled());

--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerImpl.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerImpl.java
@@ -459,6 +459,10 @@ public class DevSupportManagerImpl implements
         new DevOptionHandler() {
           @Override
           public void onOptionSelected() {
+            if (mDevSettings.isHotModuleReplacementEnabled()) {
+              Toast.makeText(mApplicationContext, "Dev mode and HRM cannot be both enabled at once. Disabling HMR...", Toast.LENGTH_LONG).show();
+              mDevSettings.setHotModuleReplacementEnabled(false);
+            }
             handleReloadJS();
           }
         });
@@ -509,6 +513,10 @@ public class DevSupportManagerImpl implements
             new DevOptionHandler() {
               @Override
               public void onOptionSelected() {
+                if (!mDevSettings.isJSDevModeEnabled()) {
+                  Toast.makeText(mApplicationContext, "Dev mode needs to be turned on to enable HRM.", Toast.LENGTH_LONG).show();
+                  return;
+                }
                 mDevSettings.setHotModuleReplacementEnabled(!mDevSettings.isHotModuleReplacementEnabled());
                 handleReloadJS();
               }

--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerImpl.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerImpl.java
@@ -514,8 +514,8 @@ public class DevSupportManagerImpl implements
               @Override
               public void onOptionSelected() {
                 if (!mDevSettings.isHotModuleReplacementEnabled() && !mDevSettings.isJSDevModeEnabled()) {
-                  Toast.makeText(mApplicationContext, "Dev mode needs to be turned on to enable HMR. Enable Dev mode first to enable HMR.", Toast.LENGTH_LONG).show();
-                  return;
+                  Toast.makeText(mApplicationContext, "You're trying to enable HMR while Dev mode is off. Turning the Dev mode on...", Toast.LENGTH_LONG).show();
+                  mDevSettings.setJSDevModeEnabled(true);
                 }
                 mDevSettings.setHotModuleReplacementEnabled(!mDevSettings.isHotModuleReplacementEnabled());
                 handleReloadJS();

--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerImpl.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerImpl.java
@@ -513,7 +513,7 @@ public class DevSupportManagerImpl implements
             new DevOptionHandler() {
               @Override
               public void onOptionSelected() {
-                if (!mDevSettings.isJSDevModeEnabled()) {
+                if (!mDevSettings.isHotModuleReplacementEnabled() && !mDevSettings.isJSDevModeEnabled()) {
                   Toast.makeText(mApplicationContext, "Dev mode needs to be turned on to enable HMR.", Toast.LENGTH_LONG).show();
                   return;
                 }

--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerImpl.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerImpl.java
@@ -514,7 +514,7 @@ public class DevSupportManagerImpl implements
               @Override
               public void onOptionSelected() {
                 if (!mDevSettings.isHotModuleReplacementEnabled() && !mDevSettings.isJSDevModeEnabled()) {
-                  Toast.makeText(mApplicationContext, "Dev mode needs to be turned on to enable HMR.", Toast.LENGTH_LONG).show();
+                  Toast.makeText(mApplicationContext, "Dev mode needs to be turned on to enable HMR. Enable Dev mode first to enable HMR.", Toast.LENGTH_LONG).show();
                   return;
                 }
                 mDevSettings.setHotModuleReplacementEnabled(!mDevSettings.isHotModuleReplacementEnabled());

--- a/ReactAndroid/src/main/res/devsupport/xml/rn_dev_preferences.xml
+++ b/ReactAndroid/src/main/res/devsupport/xml/rn_dev_preferences.xml
@@ -10,7 +10,7 @@
     <CheckBoxPreference
         android:key="js_dev_mode_debug"
         android:title="JS Dev Mode"
-        android:summary="Load JavaScript bundle with __DEV__ = true for easier debugging.  Disable for performance testing. Reload for the change to take effect."
+        android:summary="Load JavaScript bundle with __DEV__ = true for easier debugging. Disable for performance testing. Reload for the change to take effect."
         android:defaultValue="true"
         />
     <CheckBoxPreference


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Motivation is following - I'm sure many people encountered this because it has been like this for a long time. 

1 . you're developing something on android, HMR and dev mode is enabled
2 . you go to dev settings, you disable dev mode because you want to see how something behaves
3 . you reload the app because that's what is required for the change to take effect
4 . you wait for the bundle to be compiled and served, and when that is done, you get an error message about HMR not being a registered callable module - because HMR is not available when `__DEV__ === false` (todo screenshot)

this fixes the described case by checking if HMR is enabled and dev mode disabled when reloading (step 3) and disables HMR in that case.

this also fixes the case when dev mode is disabled and without knowing it, you try to enable HRM (will enable both dev hmr and dev mode).


## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See http://facebook.github.io/react-native/docs/contributing#changelog for an example. -->

[Android] [Changed] - improve developer experience around Dev mode and HMR interop

## Test Plan

I used the RN tester app and manually verified it works as intended. See gifs where I proceeded as in the steps given above:

current master - you need to be patient to get to the error screen

![master](https://user-images.githubusercontent.com/1566403/55916101-a7abb100-5beb-11e9-9500-50999f3af3cc.gif)

this branch - HMR gets disabled

![fixed](https://user-images.githubusercontent.com/1566403/55916009-674c3300-5beb-11e9-9dc7-be2e0e97fca9.gif)
