### PR TITLE
Install local react-native package in e2e

### DIFF
--- a/scripts/run-ci-e2e-tests.js
+++ b/scripts/run-ci-e2e-tests.js
@@ -77,11 +77,14 @@ try {
   if (
     tryExecNTimes(
       () => {
-        exec('sleep 10s');
-        return exec('react-native init EndToEndTest').code;
+        return exec(`react-native init EndToEndTest --version ${PACKAGE} --npm`)
+          .code;
       },
       numberOfRetries,
-      () => rm('-rf', E2E_APP_ROOT),
+      () => {
+        rm('-rf', 'EndToEndTest');
+        exec('sleep 10s');
+      },
     )
   ) {
     echo('Failed to execute react-native init');
@@ -95,11 +98,10 @@ try {
   if (
     tryExecNTimes(
       () => {
-        exec('sleep 10s');
         return exec('npm install --save-dev flow-bin').code;
       },
       numberOfRetries,
-      () => rm('-rf', E2E_APP_ROOT),
+      () => exec('sleep 10s'),
     )
   ) {
     echo('Failed to install Flow');
@@ -111,11 +113,10 @@ try {
   if (
     tryExecNTimes(
       () => {
-        exec('sleep 10s');
         return exec('npm install').code;
       },
       numberOfRetries,
-      () => rm('-rf', E2E_APP_ROOT),
+      () => exec('sleep 10s'),
     )
   ) {
     echo('Failed to execute npm install');
@@ -180,10 +181,13 @@ try {
     exec('sleep 15s');
     describe('Test: Android end-to-end test');
     if (
-      tryExecNTimes(() => {
-        exec('sleep 10s');
-        return exec('node node_modules/.bin/_mocha android-e2e-test.js').code;
-      }, numberOfRetries)
+      tryExecNTimes(
+        () => {
+          return exec('node node_modules/.bin/_mocha android-e2e-test.js').code;
+        },
+        numberOfRetries,
+        () => exec('sleep 10s'),
+      )
     ) {
       echo('Failed to run Android end-to-end tests');
       echo('Most likely the code is broken');
@@ -214,43 +218,46 @@ try {
     exec('pod install');
     describe('Test: ' + iosTestType + ' end-to-end test');
     if (
-      tryExecNTimes(() => {
-        exec('sleep 10s');
-        let destination = 'platform=iOS Simulator,name=iPhone 6s,OS=12.1';
-        let sdk = 'iphonesimulator';
-        let scheme = 'EndToEndTest';
+      tryExecNTimes(
+        () => {
+          let destination = 'platform=iOS Simulator,name=iPhone 6s,OS=12.1';
+          let sdk = 'iphonesimulator';
+          let scheme = 'EndToEndTest';
 
-        if (argv.tvos) {
-          destination = 'platform=tvOS Simulator,name=Apple TV,OS=11.4';
-          sdk = 'appletvsimulator';
-          scheme = 'EndToEndTest-tvOS';
-        }
+          if (argv.tvos) {
+            destination = 'platform=tvOS Simulator,name=Apple TV,OS=11.4';
+            sdk = 'appletvsimulator';
+            scheme = 'EndToEndTest-tvOS';
+          }
 
-        return exec(
-          [
-            'xcodebuild',
-            '-workspace',
-            '"EndToEndTest.xcworkspace"',
-            '-destination',
-            `"${destination}"`,
-            '-scheme',
-            `"${scheme}"`,
-            '-sdk',
-            sdk,
-            '-UseModernBuildSystem=NO',
-            'test',
-          ].join(' ') +
-            ' | ' +
+          return exec(
             [
-              'xcpretty',
-              '--report',
-              'junit',
-              '--output',
-              `"~/react-native/reports/junit/${iosTestType}-e2e/results.xml"`,
+              'xcodebuild',
+              '-workspace',
+              '"EndToEndTest.xcworkspace"',
+              '-destination',
+              `"${destination}"`,
+              '-scheme',
+              `"${scheme}"`,
+              '-sdk',
+              sdk,
+              '-UseModernBuildSystem=NO',
+              'test',
             ].join(' ') +
-            ' && exit ${PIPESTATUS[0]}',
-        ).code;
-      }, numberOfRetries)
+              ' | ' +
+              [
+                'xcpretty',
+                '--report',
+                'junit',
+                '--output',
+                `"~/react-native/reports/junit/${iosTestType}-e2e/results.xml"`,
+              ].join(' ') +
+              ' && exit ${PIPESTATUS[0]}',
+          ).code;
+        },
+        numberOfRetries,
+        () => exec('sleep 10s'),
+      )
     ) {
       echo('Failed to run ' + iosTestType + ' end-to-end tests');
       echo('Most likely the code is broken');


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Following 6df2edeb2a33d529e4b13a5b6767f300d08aeb0a, the template for a new app no longer refers to a specific version of React Native, as the React Native CLI will set the correct version when `react-native init` is run. As it happens, the CLI cannot find a local react-native@1000 version when run as part of the JavaScript e2e tests. Therefore, I am working around using the CLI directly, and instead we're copying the contents of `template/` into a temporary directory for e2e tests. This is not dissimilar to what we already test internally at Facebook.


## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See http://facebook.github.io/react-native/docs/contributing#changelog for an example. -->

[General] [Fixed] - Fixed JavaScript e2e tests

## Test Plan

Local:
```
node ./scripts/run-ci-e2e-tests.js --js --retries 3 --skip-cli-install
echo $?
0
```

Circle CI: [✅ `test_javascript`](https://circleci.com/gh/hramos/react-native/5286)

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
