### PR TITLE
Fix: text shadow displays on iOS when textShadowOffset is {0,0}

### DIFF
--- a/Libraries/Text/RCTTextAttributes.m
+++ b/Libraries/Text/RCTTextAttributes.m
@@ -170,7 +170,7 @@ NSString *const RCTTextAttributesTagAttributeName = @"RCTTextAttributesTagAttrib
   }
 
   // Shadow
-  if (!CGSizeEqualToSize(_textShadowOffset, CGSizeZero)) {
+  if (!isnan(_textShadowRadius)) {
     NSShadow *shadow = [NSShadow new];
     shadow.shadowOffset = _textShadowOffset;
     shadow.shadowBlurRadius = _textShadowRadius;


### PR DESCRIPTION
## Summary

There is a problem rendering text shadows on iOS. If the offset of the text shadow is `{width:0,height:0}`, the shadow does not display. This prevents you from representing a light directly above the text. This occurs because a text shadow only renders if the offset is a non-zero CGRect `{width:0,height:0}`. 

My change checks `textShadowRadius` instead. If `textShadowRadius` is not nan then the user is rendering a text shadow. There are no situations to render a shadow without `textShadowRadius` making it a good variable to check. 

This PR fixes this stale issue: https://github.com/facebook/react-native/issues/17277

## Changelog

[iOS] [Fixed] - Text shadow now displays when the textShadowOffset is {width:0,height:0}

## Test Plan

    textShadowOffset: {width:0,height: 0},
    textShadowRadius: 10,
    textShadowColor: "black"

Before, without fix: 
![Screen Shot 2019-04-10 at 2 12 16 PM](https://user-images.githubusercontent.com/22600052/55913906-aaca8100-5b9a-11e9-85d7-acab96ace0ba.png)

After with fix:
![Screen Shot 2019-04-10 at 2 04 18 PM](https://user-images.githubusercontent.com/22600052/55913482-989c1300-5b99-11e9-92f2-ddfd449f3587.png)

