### PR TITLE
Starts simulator when prefix is included

### DIFF
--- a/local-cli/runIOS/findMatchingSimulator.js
+++ b/local-cli/runIOS/findMatchingSimulator.js
@@ -39,7 +39,7 @@ function findMatchingSimulator(simulators, simulatorString) {
   var match;
   for (let version in devices) {
     // Making sure the version of the simulator is an iOS or tvOS (Removes Apple Watch, etc)
-    if (!version.startsWith('iOS') && !version.startsWith('tvOS')) {
+    if (!version.includes('iOS') && !version.includes('tvOS')) {
       continue;
     }
     if (simulatorVersion && !version.endsWith(simulatorVersion)) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
Fixes issue https://github.com/facebook/react-native/issues/23282 for `0.57.x`. Where `react-native run-ios` fails with error `Could not find iPhone X simulator react native`.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See http://facebook.github.io/react-native/docs/contributing#changelog for an example. -->

[iOS] [Fixed] - Fix starting iOS simulator after xcode 10.2 update.

## Test Plan

Update xcode to version 10.2, run `react-native run-ios`, and see if simulator starts.
