### PR TITLE
Update detox to 12.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "test-android-unit": "yarn run docker-build-android && yarn run test-android-run-unit",
     "test-android-e2e": "yarn run docker-build-android && yarn run test-android-run-e2e",
     "build-ios-e2e": "detox build -c ios.sim.release",
-    "test-ios-e2e": "detox test -c ios.sim.release"
+    "test-ios-e2e": "detox test -c ios.sim.release RNTester/e2e"
   },
   "peerDependencies": {
     "react": "16.8.3"
@@ -118,7 +118,7 @@
     "babel-eslint": "10.0.1",
     "clang-format": "^1.2.4",
     "coveralls": "^3.0.2",
-    "detox": "12.1.1",
+    "detox": "12.2.0",
     "eslint": "5.1.0",
     "eslint-config-fb-strict": "24.3.0",
     "eslint-config-fbjs": "2.1.0",
@@ -148,7 +148,7 @@
   "detox": {
     "test-runner": "jest",
     "runner-config": "RNTester/e2e/config.json",
-    "specs": "RNTester/e2e",
+    "specs": "",
     "configurations": {
       "ios.sim.release": {
         "binaryPath": "RNTester/build/Build/Products/Release-iphonesimulator/RNTester.app/",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2359,10 +2359,10 @@ detect-newline@^2.1.0:
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-2.1.0.tgz#f41f1c10be4b00e87b5f13da680759f2c5bfd3e2"
   integrity sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=
 
-detox@12.1.1:
-  version "12.1.1"
-  resolved "https://registry.yarnpkg.com/detox/-/detox-12.1.1.tgz#98fd44ee003b4ed159cc6a3d68d34598e4ae26a9"
-  integrity sha512-QbZ9F+XD4UFsEIn4QTiObhiEXs1Tq5nvPt3UIG9123uAfp4WHFTVnCJomQliMwJu6flK4JP9fXYHfzwcccyFug==
+detox@12.2.0:
+  version "12.2.0"
+  resolved "https://registry.yarnpkg.com/detox/-/detox-12.2.0.tgz#73f3a1dd39b740fe37078b50cce19ced9fbf9a8e"
+  integrity sha512-6M5jWGxXbop+sOzZD/IhL4TgNKFPS4OJbe5mvNQyDWQL901jUsCHj+6lE/9vTcS/tNnGC/HLXHlDiTuTP38/Tg==
   dependencies:
     bunyan "^1.8.12"
     bunyan-debug-stream "^1.1.0"
@@ -2375,7 +2375,7 @@ detox@12.1.1:
     proper-lockfile "^3.0.2"
     sanitize-filename "^1.6.1"
     shell-utils "^1.0.9"
-    tail "^1.2.3"
+    tail "^2.0.0"
     telnet-client "0.15.3"
     tempfile "^2.0.0"
     ws "^1.1.1"
@@ -6789,10 +6789,10 @@ table@^4.0.3:
     slice-ansi "1.0.0"
     string-width "^2.1.1"
 
-tail@^1.2.3:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/tail/-/tail-1.4.0.tgz#884b216220b90804bfe87a4c8174c2efed0e2661"
-  integrity sha512-wjwfZw6wcMFTB1Po7NFUf4TdCDwX8duZjdTMhnHBEC677Q6mFRcVZE7f/nZDhG2Fpf/wEEKOJP9L7/b11/vlHQ==
+tail@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/tail/-/tail-2.0.2.tgz#86073f3a9a568807b7fd886897a7350314275b5f"
+  integrity sha512-raFipiKWdGKEzxbvZwnhUGqjvsv0gpa/1A479rL//NOxnNwYZDN4MPk6xJJdUFs8P2Xrff3nbH5fcyYRLU4UHQ==
 
 tar@^4:
   version "4.4.6"


### PR DESCRIPTION
## Summary

This updates `detox` from `12.1.1` to `12.2.0`.
It includes (amongst other things) the following fixes, as described on the [12.1.4 release page](https://github.com/wix/Detox/releases/tag/12.1.4):

- hotfix: redundant logs in the folder
- fix: stabilize simulator log recording

It also updates the detox test script and config in `packages.json` (which was previously missed when detox was updated to 12.1.x). It will remove the following deprecation warnings:

```
detox[6416] WARN:  [test.js] Deprecation warning: "file" and "specs" support will be dropped in the next Detox version.
detox[6416] WARN:  [test.js] Please edit your package.json according to the migration guide: https://wix.to/I0DOAK0
```

Instead of extra preprocessing the test folder by `detox`, it will now be passed straight to `jest`.

More information in the [migration guide](https://github.com/wix/Detox/blob/master/docs/Guide.Migration.md).

## Changelog

[General] [Changed] - Update detox to 12.2.0

## Test Plan

Successfully ran:

```
yarn build-ios-e2e
yarn test-ios-e2e
```