### PR TITLE
Fixed incorrect opacity behaviour for <Text> component on iOS

### DIFF
--- a/Libraries/Text/Text/RCTTextShadowView.m
+++ b/Libraries/Text/Text/RCTTextShadowView.m
@@ -46,6 +46,7 @@
   // the RCTTextView backgroundColor to be used, without affecting nested Text
   // components.
   self.textAttributes.backgroundColor = nil;
+  self.textAttributes.opacity = NAN;
 }
 
 - (BOOL)isYogaLeafNode


### PR DESCRIPTION
## Summary
This PR fixes #24229.
Seems currently `opacity` props for Text is being applied twice (one for text color and one for the whole view). This PR disables applying the prop to the text.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See http://facebook.github.io/react-native/docs/contributing#changelog for an example. -->

[CATEGORY] [TYPE] - Fixed double applying opacity prop for Text

## Test Plan

See #24229 for more details.
