### PR TITLE
Add indent for props generation of codegen

### DIFF
--- a/packages/react-native-codegen/src/generators/GeneratePropsCpp.js
+++ b/packages/react-native-codegen/src/generators/GeneratePropsCpp.js
@@ -51,7 +51,7 @@ function generatePropsString(component: ComponentShape) {
         prop.name
       }", sourceProps.${prop.name}, ${prop.name}))`;
     })
-    .join(',\n');
+    .join(',\n' + '    ');
 }
 
 function getClassExtendString(component): string {

--- a/packages/react-native-codegen/src/generators/GeneratePropsH.js
+++ b/packages/react-native-codegen/src/generators/GeneratePropsH.js
@@ -200,7 +200,7 @@ function generateEnumString(componentName: string, component): string {
               value,
             )}; return; }`,
         )
-        .join('\n');
+        .join('\n' + '  ');
 
       const toCases = values
         .map(
@@ -209,7 +209,7 @@ function generateEnumString(componentName: string, component): string {
               value,
             )}: return "${value}";`,
         )
-        .join('\n');
+        .join('\n' + '    ');
 
       return enumTemplate
         .replace(/::_ENUM_NAME_::/g, enumName)
@@ -232,7 +232,7 @@ function generatePropsString(
 
       return `const ${nativeType} ${prop.name}{${defaultValue}};`;
     })
-    .join('\n');
+    .join('\n' + '  ');
 }
 
 function getImports(component): Set<string> {

--- a/packages/react-native-codegen/src/generators/__tests__/__snapshots__/GeneratePropsCpp-test.js.snap
+++ b/packages/react-native-codegen/src/generators/__tests__/__snapshots__/GeneratePropsCpp-test.js.snap
@@ -22,12 +22,12 @@ ArrayPropsNativeComponentProps::ArrayPropsNativeComponentProps(
     const RawProps &rawProps): ViewProps(sourceProps, rawProps),
 
     names(convertRawProp(rawProps, \\"names\\", sourceProps.names, names)),
-disableds(convertRawProp(rawProps, \\"disableds\\", sourceProps.disableds, disableds)),
-progress(convertRawProp(rawProps, \\"progress\\", sourceProps.progress, progress)),
-radii(convertRawProp(rawProps, \\"radii\\", sourceProps.radii, radii)),
-colors(convertRawProp(rawProps, \\"colors\\", sourceProps.colors, colors)),
-srcs(convertRawProp(rawProps, \\"srcs\\", sourceProps.srcs, srcs)),
-points(convertRawProp(rawProps, \\"points\\", sourceProps.points, points))
+    disableds(convertRawProp(rawProps, \\"disableds\\", sourceProps.disableds, disableds)),
+    progress(convertRawProp(rawProps, \\"progress\\", sourceProps.progress, progress)),
+    radii(convertRawProp(rawProps, \\"radii\\", sourceProps.radii, radii)),
+    colors(convertRawProp(rawProps, \\"colors\\", sourceProps.colors, colors)),
+    srcs(convertRawProp(rawProps, \\"srcs\\", sourceProps.srcs, srcs)),
+    points(convertRawProp(rawProps, \\"points\\", sourceProps.points, points))
       {}
 
 } // namespace react
@@ -202,11 +202,11 @@ FloatPropNativeComponentProps::FloatPropNativeComponentProps(
     const RawProps &rawProps): ViewProps(sourceProps, rawProps),
 
     blurRadius(convertRawProp(rawProps, \\"blurRadius\\", sourceProps.blurRadius, blurRadius)),
-blurRadius2(convertRawProp(rawProps, \\"blurRadius2\\", sourceProps.blurRadius2, blurRadius2)),
-blurRadius3(convertRawProp(rawProps, \\"blurRadius3\\", sourceProps.blurRadius3, blurRadius3)),
-blurRadius4(convertRawProp(rawProps, \\"blurRadius4\\", sourceProps.blurRadius4, blurRadius4)),
-blurRadius5(convertRawProp(rawProps, \\"blurRadius5\\", sourceProps.blurRadius5, blurRadius5)),
-blurRadius6(convertRawProp(rawProps, \\"blurRadius6\\", sourceProps.blurRadius6, blurRadius6))
+    blurRadius2(convertRawProp(rawProps, \\"blurRadius2\\", sourceProps.blurRadius2, blurRadius2)),
+    blurRadius3(convertRawProp(rawProps, \\"blurRadius3\\", sourceProps.blurRadius3, blurRadius3)),
+    blurRadius4(convertRawProp(rawProps, \\"blurRadius4\\", sourceProps.blurRadius4, blurRadius4)),
+    blurRadius5(convertRawProp(rawProps, \\"blurRadius5\\", sourceProps.blurRadius5, blurRadius5)),
+    blurRadius6(convertRawProp(rawProps, \\"blurRadius6\\", sourceProps.blurRadius6, blurRadius6))
       {}
 
 } // namespace react
@@ -266,8 +266,8 @@ IntegerPropNativeComponentProps::IntegerPropNativeComponentProps(
     const RawProps &rawProps): ViewProps(sourceProps, rawProps),
 
     progress1(convertRawProp(rawProps, \\"progress1\\", sourceProps.progress1, progress1)),
-progress2(convertRawProp(rawProps, \\"progress2\\", sourceProps.progress2, progress2)),
-progress3(convertRawProp(rawProps, \\"progress3\\", sourceProps.progress3, progress3))
+    progress2(convertRawProp(rawProps, \\"progress2\\", sourceProps.progress2, progress2)),
+    progress3(convertRawProp(rawProps, \\"progress3\\", sourceProps.progress3, progress3))
       {}
 
 } // namespace react
@@ -327,9 +327,9 @@ ImageColorPropNativeComponentProps::ImageColorPropNativeComponentProps(
     const RawProps &rawProps): ViewProps(sourceProps, rawProps),
 
     thumbImage(convertRawProp(rawProps, \\"thumbImage\\", sourceProps.thumbImage, thumbImage)),
-color(convertRawProp(rawProps, \\"color\\", sourceProps.color, color)),
-thumbTintColor(convertRawProp(rawProps, \\"thumbTintColor\\", sourceProps.thumbTintColor, thumbTintColor)),
-point(convertRawProp(rawProps, \\"point\\", sourceProps.point, point))
+    color(convertRawProp(rawProps, \\"color\\", sourceProps.color, color)),
+    thumbTintColor(convertRawProp(rawProps, \\"thumbTintColor\\", sourceProps.thumbTintColor, thumbTintColor)),
+    point(convertRawProp(rawProps, \\"point\\", sourceProps.point, point))
       {}
 
 } // namespace react

--- a/packages/react-native-codegen/src/generators/__tests__/__snapshots__/GeneratePropsH-test.js.snap
+++ b/packages/react-native-codegen/src/generators/__tests__/__snapshots__/GeneratePropsH-test.js.snap
@@ -28,12 +28,12 @@ class ArrayPropsNativeComponentProps final : public ViewProps {
 #pragma mark - Props
 
   const std::vector<std::string> names{};
-const std::vector<bool> disableds{};
-const std::vector<int> progress{};
-const std::vector<Float> radii{};
-const std::vector<SharedColor> colors{};
-const std::vector<ImageSource> srcs{};
-const std::vector<Point> points{};
+  const std::vector<bool> disableds{};
+  const std::vector<int> progress{};
+  const std::vector<Float> radii{};
+  const std::vector<SharedColor> colors{};
+  const std::vector<ImageSource> srcs{};
+  const std::vector<Point> points{};
 };
 
 } // namespace react
@@ -128,16 +128,16 @@ enum class EnumPropsNativeComponentAlignment { Top, Center, Bottom };
 static inline void fromRawValue(const RawValue &value, EnumPropsNativeComponentAlignment &result) {
   auto string = (std::string)value;
   if (string == \\"top\\") { result = EnumPropsNativeComponentAlignment::Top; return; }
-if (string == \\"center\\") { result = EnumPropsNativeComponentAlignment::Center; return; }
-if (string == \\"bottom\\") { result = EnumPropsNativeComponentAlignment::Bottom; return; }
+  if (string == \\"center\\") { result = EnumPropsNativeComponentAlignment::Center; return; }
+  if (string == \\"bottom\\") { result = EnumPropsNativeComponentAlignment::Bottom; return; }
   abort();
 }
 
 static inline std::string toString(const EnumPropsNativeComponentAlignment &value) {
   switch (value) {
     case EnumPropsNativeComponentAlignment::Top: return \\"top\\";
-case EnumPropsNativeComponentAlignment::Center: return \\"center\\";
-case EnumPropsNativeComponentAlignment::Bottom: return \\"bottom\\";
+    case EnumPropsNativeComponentAlignment::Center: return \\"center\\";
+    case EnumPropsNativeComponentAlignment::Bottom: return \\"bottom\\";
   }
 }
 
@@ -245,11 +245,11 @@ class FloatPropNativeComponentProps final : public ViewProps {
 #pragma mark - Props
 
   const Float blurRadius{0.0};
-const Float blurRadius2{0.001};
-const Float blurRadius3{2.1};
-const Float blurRadius4{0.0};
-const Float blurRadius5{1.0};
-const Float blurRadius6{0.0};
+  const Float blurRadius2{0.001};
+  const Float blurRadius3{2.1};
+  const Float blurRadius4{0.0};
+  const Float blurRadius5{1.0};
+  const Float blurRadius6{0.0};
 };
 
 } // namespace react
@@ -315,8 +315,8 @@ class IntegerPropNativeComponentProps final : public ViewProps {
 #pragma mark - Props
 
   const int progress1{0};
-const int progress2{-1};
-const int progress3{10};
+  const int progress2{-1};
+  const int progress3{10};
 };
 
 } // namespace react
@@ -384,9 +384,9 @@ class ImageColorPropNativeComponentProps final : public ViewProps {
 #pragma mark - Props
 
   const ImageSource thumbImage{};
-const SharedColor color{};
-const SharedColor thumbTintColor{};
-const Point point{};
+  const SharedColor color{};
+  const SharedColor thumbTintColor{};
+  const Point point{};
 };
 
 } // namespace react


### PR DESCRIPTION
## Summary
Add correct indent when run codegen.
Before:
<img width="686" alt="image" src="https://user-images.githubusercontent.com/5061845/56078952-41f43a80-5e20-11e9-998e-e386f54b0b95.png">
<img width="655" alt="image" src="https://user-images.githubusercontent.com/5061845/56078955-491b4880-5e20-11e9-9935-561039806e48.png">

After:
<img width="692" alt="image" src="https://user-images.githubusercontent.com/5061845/56078931-18d3aa00-5e20-11e9-9865-126b18fbeb58.png">
<img width="658" alt="image" src="https://user-images.githubusercontent.com/5061845/56078940-225d1200-5e20-11e9-9ec7-374cf5c83768.png">

cc. @cpojer @rickhanlonii

## Changelog

[General] [Fixed] - Add indent for props generation of codegen

## Test Plan

N/A.