### PR TITLE
[Android] [Added] - Add DevSetting native module (making it cross-platform)

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/CoreModulesPackage.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/CoreModulesPackage.java
@@ -23,6 +23,7 @@ import com.facebook.react.modules.core.ExceptionsManagerModule;
 import com.facebook.react.modules.core.Timing;
 import com.facebook.react.modules.core.DefaultHardwareBackBtnHandler;
 import com.facebook.react.modules.core.HeadlessJsTaskSupportModule;
+import com.facebook.react.modules.debug.DevSettingsModule;
 import com.facebook.react.modules.debug.SourceCodeModule;
 import com.facebook.react.modules.deviceinfo.DeviceInfoModule;
 import com.facebook.react.modules.systeminfo.AndroidInfoModule;
@@ -49,6 +50,7 @@ import static com.facebook.react.bridge.ReactMarkerConstants.*;
       AndroidInfoModule.class,
       DeviceEventManagerModule.class,
       DeviceInfoModule.class,
+      DevSettingsModule.class,
       ExceptionsManagerModule.class,
       HeadlessJsTaskSupportModule.class,
       SourceCodeModule.class,
@@ -93,6 +95,7 @@ import static com.facebook.react.bridge.ReactMarkerConstants.*;
             AndroidInfoModule.class,
             DeviceEventManagerModule.class,
             DeviceInfoModule.class,
+            DevSettingsModule.class,
             ExceptionsManagerModule.class,
             HeadlessJsTaskSupportModule.class,
             SourceCodeModule.class,
@@ -138,6 +141,8 @@ import static com.facebook.react.bridge.ReactMarkerConstants.*;
         return new AndroidInfoModule(reactContext);
       case DeviceEventManagerModule.NAME:
         return new DeviceEventManagerModule(reactContext, mHardwareBackBtnHandler);
+      case DevSettingsModule.NAME:
+        return new DevSettingsModule(mReactInstanceManager.getDevSupportManager());
       case ExceptionsManagerModule.NAME:
         return new ExceptionsManagerModule(mReactInstanceManager.getDevSupportManager());
       case HeadlessJsTaskSupportModule.NAME:

--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerImpl.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerImpl.java
@@ -1040,6 +1040,80 @@ public class DevSupportManagerImpl implements
     mDevServerHelper.closeInspectorConnection();
   }
 
+  @Override
+  public void setHotModuleReplacementEnabled(boolean enableHotModuleReplacement) {
+    if (!mIsDevSupportEnabled) return;
+
+    UiThreadUtil.runOnUiThread(
+      new Runnable() {
+        @Override
+        public void run() {
+          mDevSettings.setHotModuleReplacementEnabled(enableHotModuleReplacement);
+          handleReloadJS();
+        }
+      }
+    );
+  }
+
+  @Override
+  public void setRemoteJSDebugEnabled(boolean isRemoteJSDebugEnabled) {
+    if (!mIsDevSupportEnabled) return;
+
+    UiThreadUtil.runOnUiThread(
+      new Runnable() {
+        @Override
+        public void run() {
+          mDevSettings.setRemoteJSDebugEnabled(isRemoteJSDebugEnabled);
+          handleReloadJS();
+        }
+      }
+    );
+  }
+
+  @Override
+  public void setReloadOnJSChangeEnabled(boolean isReloadOnJSChangeEnabled) {
+    if (!mIsDevSupportEnabled) return;
+
+    UiThreadUtil.runOnUiThread(
+      new Runnable() {
+        @Override
+        public void run() {
+          mDevSettings.setReloadOnJSChangeEnabled(isReloadOnJSChangeEnabled);
+          handleReloadJS();
+        }
+      }
+    );
+  }
+
+  @Override
+  public void setFpsDebugEnabled(boolean isFpsDebugEnabled) {
+    if (!mIsDevSupportEnabled) return;
+
+    UiThreadUtil.runOnUiThread(
+      new Runnable() {
+        @Override
+        public void run() {
+          mDevSettings.setFpsDebugEnabled(isFpsDebugEnabled);
+        }
+      }
+    );
+  }
+
+  @Override
+  public void toggleElementInspector() {
+    if (!mIsDevSupportEnabled) return;
+
+    UiThreadUtil.runOnUiThread(
+      new Runnable() {
+        @Override
+        public void run() {
+          mDevSettings.setElementInspectorEnabled(!mDevSettings.isElementInspectorEnabled());
+          mReactInstanceManagerHelper.toggleElementInspector();
+        }
+      }
+    );
+  }
+
   private void reload() {
     UiThreadUtil.assertOnUiThread();
 

--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerImpl.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerImpl.java
@@ -1041,7 +1041,7 @@ public class DevSupportManagerImpl implements
   }
 
   @Override
-  public void setHotModuleReplacementEnabled(boolean enableHotModuleReplacement) {
+  public void setHotModuleReplacementEnabled(final boolean isHotModuleReplacementEnabled) {
     if (!mIsDevSupportEnabled) {
       return;
     }
@@ -1050,7 +1050,7 @@ public class DevSupportManagerImpl implements
       new Runnable() {
         @Override
         public void run() {
-          mDevSettings.setHotModuleReplacementEnabled(enableHotModuleReplacement);
+          mDevSettings.setHotModuleReplacementEnabled(isHotModuleReplacementEnabled);
           handleReloadJS();
         }
       }
@@ -1058,7 +1058,7 @@ public class DevSupportManagerImpl implements
   }
 
   @Override
-  public void setRemoteJSDebugEnabled(boolean isRemoteJSDebugEnabled) {
+  public void setRemoteJSDebugEnabled(final boolean isRemoteJSDebugEnabled) {
     if (!mIsDevSupportEnabled) {
       return;
     }
@@ -1075,7 +1075,7 @@ public class DevSupportManagerImpl implements
   }
 
   @Override
-  public void setReloadOnJSChangeEnabled(boolean isReloadOnJSChangeEnabled) {
+  public void setReloadOnJSChangeEnabled(final boolean isReloadOnJSChangeEnabled) {
     if (!mIsDevSupportEnabled) {
       return;
     }
@@ -1092,7 +1092,7 @@ public class DevSupportManagerImpl implements
   }
 
   @Override
-  public void setFpsDebugEnabled(boolean isFpsDebugEnabled) {
+  public void setFpsDebugEnabled(final boolean isFpsDebugEnabled) {
     if (!mIsDevSupportEnabled) {
       return;
     }

--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerImpl.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerImpl.java
@@ -1042,7 +1042,9 @@ public class DevSupportManagerImpl implements
 
   @Override
   public void setHotModuleReplacementEnabled(boolean enableHotModuleReplacement) {
-    if (!mIsDevSupportEnabled) return;
+    if (!mIsDevSupportEnabled) {
+      return;
+    }
 
     UiThreadUtil.runOnUiThread(
       new Runnable() {
@@ -1057,7 +1059,9 @@ public class DevSupportManagerImpl implements
 
   @Override
   public void setRemoteJSDebugEnabled(boolean isRemoteJSDebugEnabled) {
-    if (!mIsDevSupportEnabled) return;
+    if (!mIsDevSupportEnabled) {
+      return;
+    }
 
     UiThreadUtil.runOnUiThread(
       new Runnable() {
@@ -1072,7 +1076,9 @@ public class DevSupportManagerImpl implements
 
   @Override
   public void setReloadOnJSChangeEnabled(boolean isReloadOnJSChangeEnabled) {
-    if (!mIsDevSupportEnabled) return;
+    if (!mIsDevSupportEnabled) {
+      return;
+    }
 
     UiThreadUtil.runOnUiThread(
       new Runnable() {
@@ -1087,7 +1093,9 @@ public class DevSupportManagerImpl implements
 
   @Override
   public void setFpsDebugEnabled(boolean isFpsDebugEnabled) {
-    if (!mIsDevSupportEnabled) return;
+    if (!mIsDevSupportEnabled) {
+      return;
+    }
 
     UiThreadUtil.runOnUiThread(
       new Runnable() {
@@ -1101,7 +1109,9 @@ public class DevSupportManagerImpl implements
 
   @Override
   public void toggleElementInspector() {
-    if (!mIsDevSupportEnabled) return;
+    if (!mIsDevSupportEnabled) {
+      return;
+    }
 
     UiThreadUtil.runOnUiThread(
       new Runnable() {

--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/DisabledDevSupportManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/DisabledDevSupportManager.java
@@ -79,6 +79,31 @@ public class DisabledDevSupportManager implements DevSupportManager {
   }
 
   @Override
+  public void setHotModuleReplacementEnabled(boolean isHotModuleReplacementEnabled) {
+
+  }
+
+  @Override
+  public void setRemoteJSDebugEnabled(boolean isRemoteJSDebugEnabled) {
+
+  }
+
+  @Override
+  public void setReloadOnJSChangeEnabled(boolean isReloadOnJSChangeEnabled) {
+
+  }
+
+  @Override
+  public void setFpsDebugEnabled(boolean isFpsDebugEnabled) {
+
+  }
+
+  @Override
+  public void toggleElementInspector() {
+
+  }
+
+  @Override
   public boolean getDevSupportEnabled() {
     return false;
   }
@@ -162,7 +187,7 @@ public class DisabledDevSupportManager implements DevSupportManager {
 
   @Override
   public void registerErrorCustomizer(ErrorCustomizer errorCustomizer) {
-    
+
   }
 
   @Override

--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/interfaces/DevSupportManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/interfaces/DevSupportManager.java
@@ -45,10 +45,10 @@ public interface DevSupportManager extends NativeModuleCallExceptionHandler {
   void handleReloadJS();
   void reloadJSFromServer(final String bundleURL);
   void isPackagerRunning(PackagerStatusCallback callback);
-  void setHotModuleReplacementEnabled(boolean isHotModuleReplacementEnabled);
-  void setRemoteJSDebugEnabled(boolean isRemoteJSDebugEnabled);
-  void setReloadOnJSChangeEnabled(boolean isReloadOnJSChangeEnabled);
-  void setFpsDebugEnabled(boolean isFpsDebugEnabled);
+  void setHotModuleReplacementEnabled(final boolean isHotModuleReplacementEnabled);
+  void setRemoteJSDebugEnabled(final boolean isRemoteJSDebugEnabled);
+  void setReloadOnJSChangeEnabled(final boolean isReloadOnJSChangeEnabled);
+  void setFpsDebugEnabled(final boolean isFpsDebugEnabled);
   void toggleElementInspector();
   @Nullable File downloadBundleResourceFromUrlSync(
       final String resourceURL,

--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/interfaces/DevSupportManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/interfaces/DevSupportManager.java
@@ -45,6 +45,11 @@ public interface DevSupportManager extends NativeModuleCallExceptionHandler {
   void handleReloadJS();
   void reloadJSFromServer(final String bundleURL);
   void isPackagerRunning(PackagerStatusCallback callback);
+  void setHotModuleReplacementEnabled(boolean isHotModuleReplacementEnabled);
+  void setRemoteJSDebugEnabled(boolean isRemoteJSDebugEnabled);
+  void setReloadOnJSChangeEnabled(boolean isReloadOnJSChangeEnabled);
+  void setFpsDebugEnabled(boolean isFpsDebugEnabled);
+  void toggleElementInspector();
   @Nullable File downloadBundleResourceFromUrlSync(
       final String resourceURL,
       final File outputFile);

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/debug/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/debug/BUCK
@@ -12,6 +12,7 @@ rn_android_library(
         react_native_dep("third-party/java/jsr-305:jsr-305"),
         react_native_target("java/com/facebook/react/bridge:bridge"),
         react_native_target("java/com/facebook/react/common:common"),
+        react_native_target("java/com/facebook/react/devsupport:interfaces"),
         react_native_target("java/com/facebook/react/module/annotations:annotations"),
         react_native_target("java/com/facebook/react/modules/core:core"),
         react_native_target("java/com/facebook/react/modules/debug:interfaces"),

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/debug/DevSettingsModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/debug/DevSettingsModule.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.modules.debug;
+
+import com.facebook.react.bridge.BaseJavaModule;
+import com.facebook.react.bridge.ReactContextBaseJavaModule;
+import com.facebook.react.bridge.ReactMethod;
+import com.facebook.react.devsupport.interfaces.DevSupportManager;
+import com.facebook.react.module.annotations.ReactModule;
+import com.facebook.react.bridge.UiThreadUtil;
+
+/**
+ * Module that exposes the URL to the source code map (used for exception stack trace parsing) to JS
+ */
+@ReactModule(name = DevSettingsModule.NAME)
+public class DevSettingsModule extends BaseJavaModule {
+
+  public static final String NAME = "DevSettings";
+
+  private final DevSupportManager mDevSupportManager;
+
+  public DevSettingsModule(DevSupportManager devSupportManager) {
+    mDevSupportManager = devSupportManager;
+  }
+
+  @Override
+  public String getName() {
+    return NAME;
+  }
+
+  @ReactMethod
+  public void reload() {
+    if (mDevSupportManager.getDevSupportEnabled()) {
+      UiThreadUtil.runOnUiThread(new Runnable() {
+        @Override
+        public void run() {
+          mDevSupportManager.handleReloadJS();
+        }
+      });
+    }
+  }
+
+  @ReactMethod
+  public void setHotLoadingEnabled(boolean isHotLoadingEnabled) {
+    mDevSupportManager.setHotModuleReplacementEnabled(isHotLoadingEnabled);
+  }
+
+  @ReactMethod
+  public void setIsDebuggingRemotely(boolean isDebugginRemotelyEnabled) {
+    mDevSupportManager.setRemoteJSDebugEnabled(isDebugginRemotelyEnabled);
+  }
+
+  @ReactMethod
+  public void setLiveReloadEnabled(boolean isLiveReloadEnabled) {
+    mDevSupportManager.setReloadOnJSChangeEnabled(isLiveReloadEnabled);
+  }
+
+  @ReactMethod
+  public void setProfilingEnabled(boolean isProfilingEnabled) {
+    mDevSupportManager.setFpsDebugEnabled(isProfilingEnabled);
+  }
+
+  @ReactMethod
+  public void toggleElementInspector() {
+    mDevSupportManager.toggleElementInspector();
+  }
+}


### PR DESCRIPTION
## Summary

React Native has a `NativeModule` to manipulate programmatically the dev menu options (live reload, hot reload, remote debugging, etc), called [`DevSettings`](https://github.com/facebook/react-native/blob/master/React/Modules/RCTDevSettings.mm#L120). However this module is only available for iOS.

This PR brings the same `DevSettings` for Android, making it a cross-platform NativeModule.

Motivation: Right now if your app needs to programmatically reload RN, one option is to install [`react-native-restart`](https://www.npmjs.com/package/react-native-restart). It's a tiny dependency, but it's annoying to have to install it, while the code to do so is inside RN codebase. According to NPM, react-native-restart has ~12k weekly downloads, shows it's a recurring feature for many apps (my case).

Thus making `NativeModules.DevSettings` is a small increment in the codebase, just exposing the dev menu methods, to improve the Development Experience

## Changelog

[Android] [Added] - Add DevSetting native module (making it cross-platform)

With expection of `setIsShakeToShowDevMenuEnabled`, the following methods will be available for both platforms: 
* reload
* setHotLoadingEnabled
* setIsDebuggingRemotely
* setIsShakeToShowDevMenuEnabled
* setLiveReloadEnabled
* setProfilingEnabled
* toggleElementInspector

## Test Plan

The following buttons should work for both iOS and Android.

```js
<View>
  <Button
    onPress={() => {
      NativeModules.DevSettings.reload();
    }}
    title="Reload"
  />
  <Button
    onPress={() => {
      NativeModules.DevSettings.setHotLoadingEnabled(true);
    }}
    title="setHotLoadingEnabled"
  />
  <Button
    onPress={() => {
      NativeModules.DevSettings.setIsDebuggingRemotely(true);
    }}
    title="setIsDebuggingRemotely"
  />
  <Button
    onPress={() => {
      NativeModules.DevSettings.setLiveReloadEnabled(true);
    }}
    title="setLiveReloadEnabled"
  />
  <Button
    onPress={() => {
      NativeModules.DevSettings.setProfilingEnabled(true);
    }}
    title="setProfilingEnabled"
  />
  <Button
    onPress={() => {
      NativeModules.DevSettings.toggleElementInspector();
    }}
    title="toggleElementInspector"
  />
</View>
```

P.S DevSettings is only available via NativeModules (it doesn't have a Library, `import { DevSetting } from "react-native"`). But I think It'd useful to have it and add documentation for it to make these features more well known. In case this PR gets approved, please let me know if making a `DevSetting` library looks ok. I'd be happy to do it.


Possible features to be included into DevSettings module: 
  * Expose a method to add a custom item into the dev menu (via `RCTDevMenuItem` and `DevSupportManager.addCustomDevOption`);
  * Expose a method to register a custom keyboard shortcut, e.g: CMD+B to open Storybook (via `RCTKeyCommands` and)