### PR TITLE
Add indent for event emitter header generation of codegen

### DIFF
--- a/packages/react-native-codegen/src/generators/GenerateEventEmitterH.js
+++ b/packages/react-native-codegen/src/generators/GenerateEventEmitterH.js
@@ -108,7 +108,7 @@ function generateStruct(
         structNameParts,
       )} ${property.name};`;
     })
-    .join('\n');
+    .join('\n' + '  ');
 
   properties.forEach((property: ObjectPropertyType) => {
     const name = property.name;
@@ -165,7 +165,7 @@ function generateEvent(componentName: string, event: EventTypeShape): string {
 function generateEvents(componentName: string, component): string {
   return component.events
     .map(event => generateEvent(componentName, event))
-    .join('\n\n');
+    .join('\n\n' + '  ');
 }
 
 module.exports = {

--- a/packages/react-native-codegen/src/generators/__tests__/__snapshots__/GenerateEventEmitterH-test.js.snap
+++ b/packages/react-native-codegen/src/generators/__tests__/__snapshots__/GenerateEventEmitterH-test.js.snap
@@ -118,8 +118,8 @@ struct EventsNestedObjectNativeComponentOnChangeLocationSourceStruct {
 
 struct EventsNestedObjectNativeComponentOnChangeLocationStruct {
   EventsNestedObjectNativeComponentOnChangeLocationSourceStruct source;
-int x;
-int y;
+  int x;
+  int y;
 };
 
 struct EventsNestedObjectNativeComponentOnChangeStruct {
@@ -157,9 +157,9 @@ namespace react {
 
 struct EventsNativeComponentOnChangeStruct {
   bool value;
-std::string source;
-int progress;
-Float scale;
+  std::string source;
+  int progress;
+  Float scale;
 };
 
 struct EventsNativeComponentOnEventDirectStruct {
@@ -172,7 +172,7 @@ class EventsNativeComponentEventEmitter : public ViewEventEmitter {
 
   void onChange(EventsNativeComponentOnChangeStruct value) const;
 
-void onEventDirect(EventsNativeComponentOnEventDirectStruct value) const;
+  void onEventDirect(EventsNativeComponentOnEventDirectStruct value) const;
 };
 
 } // namespace react


### PR DESCRIPTION
## Summary

Part of #24438, add indent foe event emitter header codegen.
cc. @cpojer @rickhanlonii.

## Changelog

[General] [Fixed] - Add indent for event emitter header generation of codegen

## Test Plan

CI passes.