### PR TITLE
Fix exception when attempt to load image from file system

### DIFF
--- a/React/Base/RCTUtils.m
+++ b/React/Base/RCTUtils.m
@@ -741,8 +741,8 @@ UIImage *__nullable RCTImageFromLocalAssetURL(NSURL *imageURL)
   if (!image) {
     // Attempt to load from the file system
     const char* fileSystemCString = [imageURL fileSystemRepresentation];
-    if (fileSystemCString != nil) {
-      NSString *filePath = [NSString stringWithUTF8String:[imageURL fileSystemRepresentation]];
+    if (fileSystemCString != NULL) {
+      NSString *filePath = [NSString stringWithUTF8String:fileSystemCString];
       if (filePath.pathExtension.length == 0) {
         filePath = [filePath stringByAppendingPathExtension:@"png"];
       }

--- a/React/Base/RCTUtils.m
+++ b/React/Base/RCTUtils.m
@@ -740,11 +740,14 @@ UIImage *__nullable RCTImageFromLocalAssetURL(NSURL *imageURL)
 
   if (!image) {
     // Attempt to load from the file system
-    NSString *filePath = [NSString stringWithUTF8String:[imageURL fileSystemRepresentation]];
-    if (filePath.pathExtension.length == 0) {
-      filePath = [filePath stringByAppendingPathExtension:@"png"];
+    const char* fileSystemCString = [imageURL fileSystemRepresentation];
+    if (fileSystemCString != nil) {
+      NSString *filePath = [NSString stringWithUTF8String:[imageURL fileSystemRepresentation]];
+      if (filePath.pathExtension.length == 0) {
+        filePath = [filePath stringByAppendingPathExtension:@"png"];
+      }
+      image = [UIImage imageWithContentsOfFile:filePath];
     }
-    image = [UIImage imageWithContentsOfFile:filePath];
   }
 
   if (!image && !bundle) {


### PR DESCRIPTION
## Summary

When trying to load image using method "RCTImageFromLocalAssetURL", if URL's path in file system representation return null (in my case, imageUrl is base64 format returned from server so it's always null) then method "stringWithUTF8String" will raise an exception.

## Changelog

[iOS] [Fixed] - Fix exception when attempt to load image from file system

## Test Plan

If we have base64 image with imageURL is something like "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAASABIAAD/4QBYRXhpZg...." and using RCTImageFromLocalAssetURL to load it, we can load the correct image without any exception.
