### PR TITLE
bump android gradle plugin to 3.4.0

### DIFF
--- a/ReactAndroid/gradle.properties
+++ b/ReactAndroid/gradle.properties
@@ -23,3 +23,4 @@ GLOG_VERSION=0.3.5
 
 android.useAndroidX=true
 android.enableJetifier=true
+android.enableR8=false

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:3.3.2")
+        classpath("com.android.tools.build:gradle:3.4.0")
         classpath("de.undercouch:gradle-download-task:3.4.3")
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/react.gradle
+++ b/react.gradle
@@ -148,6 +148,11 @@ afterEvaluate {
                 into ("merged_assets/${variant.name}/merge${targetName}Assets/out") {
                     from(jsBundleDir)
                 }
+
+                // Workaround for Android Gradle Plugin 3.4+ new asset directory
+                into ("merged_assets/${variant.name}/out") {
+                    from(jsBundleDir)
+                }
             }
 
             // mergeAssets must run first, as it clears the intermediates directory

--- a/template/android/build.gradle
+++ b/template/android/build.gradle
@@ -13,7 +13,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.0'
+        classpath("com.android.tools.build:gradle:3.4.0")
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/template/android/build.gradle
+++ b/template/android/build.gradle
@@ -13,7 +13,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.2'
+        classpath 'com.android.tools.build:gradle:3.4.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
## Summary

This PR bumps Android Gradle Plugin to 3.4.0, which enables R8 shrinker by default and improves build performance significantly.

Disabled R8 for ReactAndroid because it'll strip out AndroidX and other libraries bundled in ReactAndroid.

## Changelog

[Android] [Changed] - bump Android Gradle plugin to 3.4.0

## Test Plan

CI is green, and everything works as normal.