### PR TITLE
Add document describing the RN ecosystem.

### DIFF
--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -12,21 +12,22 @@ There are three types of stakeholders:
 
 Partners are companies that are significantly invested in React Native and have been for years. Informed by their use of React Native, they push for improvements of the core and/or the ecosystem around it. Facebook's partners think of React Native as a product: they understand the trade offs that the project makes as well as future plans and goals. Together we shape the vision for React Native to make it the best way to build applications.
 
-Our current set of partners include Callstack, Expo, Infinite Red, Microsoft and Software Mansion. Besides many engineers from these companies being core contributors, their responsibilities include:
+Our current set of partners include Callstack, Expo, Infinite Red, Microsoft and Software Mansion. Many engineers from these companies are core contributors, and their partner responsibilities also include:
 
 * **[Callstack](https://callstack.com/):** Manages releases, maintains the [React Native CLI](https://github.com/react-native-community/react-native-cli) and organizes [React Native EU](https://react-native.eu/)
 * **[Expo](https://expo.io/):** Builds [expo](https://github.com/expo/expo) on top of React Native to simplify app development
 * **[Infinite Red](https://infinite.red/):** Maintains the [ignite cli/boilerplate](https://github.com/infinitered/ignite), organizes [Chain React Conf](https://infinite.red/ChainReactConf)
-* **[Microsoft](https://www.microsoft.com/en-gb/):** Develops [React Native Windows](https://github.com/Microsoft/react-native-windows) for the UWP platform
-* **[Software Mansion](https://swmansion.com/):** Maintain core RN infrastructure, like JSC, Animated and popular third-party plugins.
+* **[Microsoft](https://www.microsoft.com/en-gb/):** Develops [React Native Windows](https://github.com/Microsoft/react-native-windows) for the Universal Windows Platform (UWP)
+* **[Software Mansion](https://swmansion.com/):** Maintain core infrastructure including JSC, Animated, and other popular third-party plugins.
 
 In terms of open source work, pull requests from partners are commonly prioritized. When you are contributing to React Native, you'll most likely meet somebody who works at one of the partner companies and who is a core contributor:
 
 ## Core Contributors
 
-Core contributors are individual people who contribute to the React Native project. A core contributor is somebody who displayed a lasting commitment to the evolution and maintenance of React Native. The work done by core contributors includes responsibilities mentioned in the “Partners” section above, and concretely means that they:
+Core contributors are individuals who contribute to the React Native project. A core contributor is somebody who displayed a lasting commitment to the evolution and maintenance of React Native. The work done by core contributors includes responsibilities mentioned in the “Partners” section above, and concretely means that they:
 
-* Consistently contribute high quality changes, fixes and improvements as well as reviewing changes from others
+* Consistently contribute high quality changes, fixes and improvements
+* Actively review changes and provide quality feedback to contributors
 * Manage the release process of React Native by maintaining release branches, communicating changes to users and publishing releases
 * Love to help out other users with issues on GitHub
 * Mentor and encourage first time contributors
@@ -36,7 +37,7 @@ Core contributors are individual people who contribute to the React Native proje
 
 These are behaviors we have observed in our existing core contributors. They aren't strict rules but rather outline their usual responsibilities. We do not expect every core contributor to do all of the above things all the time. Most importantly, we want to create a supportive and friendly environment that fosters collaboration. Above all else, **we are always polite and friendly.**
 
-Core contributor status is attained after consistently contributing and taking on the responsibilities mentioned above and granted by other core contributors. Similarly, after a long period of inactivity (6+ months), a core contributor may be removed.
+Core contributor status is attained after consistently contributing and taking on the responsibilities outlined above and granted by other core contributors. Similarly, after a long period of inactivity, a core contributor may be removed.
 
 We aim to make contributing to React Native as easy and transparent as possible. All important topics are handled through a [discussion or RFC process on GitHub](https://github.com/react-native-community/discussions-and-proposals). We are always looking for active, enthusiastic members of the React Native community to become core contributors.
 
@@ -44,7 +45,7 @@ We aim to make contributing to React Native as easy and transparent as possible.
 
 Community contributors are individuals who support projects in the [react-native-community](https://github.com/react-native-community) organization. This organization exists as an incubator for high quality components that extend the capabilities of React Native with functionality that many but not all applications require. Facebook engineers will provide guidance to help build a vibrant community of people and components that make React Native better.
 
-This has multiple benefits because we can:
+This structure has multiple benefits:
 
 * Keep the core of React Native small, which improves performance and reduces the surface area
 * Provide visibility to projects through shared representation, for example on the React Native website or on Twitter

--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -1,0 +1,57 @@
+# The React Native Ecosystem
+
+We aim to build a vibrant and inclusive ecosystem of partners, core contributors, and community that goes beyond the main React Native GitHub repository. This document/blog post explains the roles and responsibilities of various stakeholders and provides guidelines for the community organization. The structure outlined in this document has been in place for a while but hadn't been written down before.
+
+There are three types of stakeholders:
+
+* **Partners:** Companies that are significantly invested in React Native and have been for years.
+* **Core Contributors:** Individual people who contribute to the React Native project.
+* **Community Contributors:** Individuals who support projects in the [react-native-community](https://github.com/react-native-community) organization.
+
+## Partners
+
+Partners are companies that are significantly invested in React Native and have been for years. Informed by their use of React Native, they push for improvements of the core and/or the ecosystem around it. Facebook's partners think of React Native as a product: they understand the trade offs that the project makes as well as future plans and goals. Together we shape the vision for React Native to make it the best way to build applications.
+
+Our current set of partners include Callstack, Expo, Infinite Red, Microsoft and Software Mansion. Besides many engineers from these companies being core contributors, their responsibilities include:
+
+* **[Callstack](https://callstack.com/):** Manages releases, maintains the [React Native CLI](https://github.com/react-native-community/react-native-cli) and organizes [React Native EU](https://react-native.eu/)
+* **[Expo](https://expo.io/):** Builds [expo](https://github.com/expo/expo) on top of React Native to simplify app development
+* **[Infinite Red](https://infinite.red/):** Maintains the [ignite cli/boilerplate](https://github.com/infinitered/ignite), organizes [Chain React Conf](https://infinite.red/ChainReactConf)
+* **[Microsoft](https://www.microsoft.com/en-gb/):** Develops [React Native Windows](https://github.com/Microsoft/react-native-windows) for the UWP platform
+* **[Software Mansion](https://swmansion.com/):** Maintain core RN infrastructure, like JSC, Animated and popular third-party plugins.
+
+In terms of open source work, pull requests from partners are commonly prioritized. When you are contributing to React Native, you'll most likely meet somebody who works at one of the partner companies and who is a core contributor:
+
+## Core Contributors
+
+Core contributors are individual people who contribute to the React Native project. A core contributor is somebody who displayed a lasting commitment to the evolution and maintenance of React Native. The work done by core contributors includes responsibilities mentioned in the “Partners” section above, and concretely means that they:
+
+* Consistently contribute high quality changes, fixes and improvements as well as reviewing changes from others
+* Manage the release process of React Native by maintaining release branches, communicating changes to users and publishing releases
+* Love to help out other users with issues on GitHub
+* Mentor and encourage first time contributors
+* Identify React Native community members who could be effective core contributors
+* Help build an inclusive community with people from all backgrounds
+* Are great at communicating with other contributors and the community in general
+
+These are behaviors we have observed in our existing core contributors. They aren't strict rules but rather outline their usual responsibilities. We do not expect every core contributor to do all of the above things all the time. Most importantly, we want to create a supportive and friendly environment that fosters collaboration. Above all else, **we are always polite and friendly.**
+
+Core contributor status is attained after consistently contributing and taking on the responsibilities mentioned above and granted by other core contributors. Similarly, after a long period of inactivity (6+ months), a core contributor may be removed.
+
+We aim to make contributing to React Native as easy and transparent as possible. All important topics are handled through a [discussion or RFC process on GitHub](https://github.com/react-native-community/discussions-and-proposals). We are always looking for active, enthusiastic members of the React Native community to become core contributors.
+
+## Community Contributors
+
+Community contributors are individuals who support projects in the [react-native-community](https://github.com/react-native-community) organization. This organization exists as an incubator for high quality components that extend the capabilities of React Native with functionality that many but not all applications require. Facebook engineers will provide guidance to help build a vibrant community of people and components that make React Native better.
+
+This has multiple benefits because we can:
+
+* Keep the core of React Native small, which improves performance and reduces the surface area
+* Provide visibility to projects through shared representation, for example on the React Native website or on Twitter
+* Ensure a consistent and high standard for code, documentation, user experience, stability and contributions for third-party components
+* Upgrade the most important components right away when we make breaking changes and move the ecosystem forward at a fast pace
+* Find new maintainers for projects that are important but were abandoned by previous owners
+
+Additionally, some companies may choose to sponsor the development of one or many of the packages that are part of the community organization. They will commit to maintain projects, triage issues, fix bugs and develop features. In turn, they will be able to gain visibility for their work, for example through a mention of active maintainers in the README of individual projects after a consistent period of contributions. Such a mention may be removed if maintainers abandon the project.
+
+If you are working on a popular component and would like to move it to the React Native community, please create an issue on the [discussions-and-proposals repository](https://github.com/react-native-community/discussions-and-proposals).

--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -1,6 +1,6 @@
 # The React Native Ecosystem
 
-We aim to build a vibrant and inclusive ecosystem of partners, core contributors, and community that goes beyond the main React Native GitHub repository. This document/blog post explains the roles and responsibilities of various stakeholders and provides guidelines for the community organization. The structure outlined in this document has been in place for a while but hadn't been written down before.
+We aim to build a vibrant and inclusive ecosystem of partners, core contributors, and community that goes beyond the main React Native GitHub repository. This document explains the roles and responsibilities of various stakeholders and provides guidelines for the community organization. The structure outlined in this document has been in place for a while but hadn't been written down before.
 
 There are three types of stakeholders:
 

--- a/README.md
+++ b/README.md
@@ -51,8 +51,11 @@ React Native brings [**React**'s][r] declarative UI framework to iOS and Android
 - **Developer Velocity.** See local changes in seconds. Changes to JavaScript code can be live reloaded without rebuilding the native app.
 - **Portability.** Reuse code across iOS, Android, and [other platforms][p].
 
+React Native is developed and supported by many companies and individual core contributors. Find out more in our [ecosystem overview][e].
+
 [r]: https://reactjs.org/
 [p]: https://facebook.github.io/react-native/docs/out-of-tree-platforms
+[e]: https://github.com/facebook/react-native/blob/master/ECOSYSTEM.md
 
 ## Contents
 


### PR DESCRIPTION
## Summary

This change adds a document outlining the main stakeholders in React Native and their responsibilities: Partners, core contributors and community contributors

It serves as an overview for companies and individuals who are interested in contributing, to get a better understand of how the project is set up, who supports it, and what they do.

This is the first version and I am hoping to integrate it into more places in the future as well as I'd like to keep it up-to-date as things change. Hector is working on a detailed document outlining what it means to be a core contributor and we'll make a list of existing core contributors soon as well.

## Test Plan

yolo