### PR TITLE
Move Yargs to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,8 +107,7 @@
     "prop-types": "^15.7.2",
     "react-devtools-core": "^3.6.0",
     "regenerator-runtime": "^0.13.2",
-    "stacktrace-parser": "^0.1.3",
-    "yargs": "^9.0.0"
+    "stacktrace-parser": "^0.1.3"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",
@@ -143,6 +142,7 @@
     "react-native-dummy": "0.2.0",
     "react-test-renderer": "16.8.3",
     "shelljs": "^0.7.8",
+    "yargs": "^9.0.0",
     "ws": "^6.1.4"
   },
   "detox": {


### PR DESCRIPTION
## Summary

Yargs package is used only in test scripts and script for bumping version.
Based on this https://github.com/facebook/react-native/search?q=yargs&unscoped_q=yargs Yargs is not really required in production build and should be moved as development dependency.

## Changelog

[General] [Changed] - Moved Yargs to devDepencies

## Test Plan

CI Green