### PR TITLE
iOS: Fix SafeAreaView in Modals

### DIFF
--- a/React/Views/SafeAreaView/RCTSafeAreaView.m
+++ b/React/Views/SafeAreaView/RCTSafeAreaView.m
@@ -101,6 +101,10 @@ static BOOL UIEdgeInsetsEqualToEdgeInsetsWithThreshold(UIEdgeInsets insets1, UIE
 
 - (void)setSafeAreaInsets:(UIEdgeInsets)safeAreaInsets
 {
+  // HACK: enforces a bottom safe area inset when there isn't one being set.
+  // related issue: https://github.com/facebook/react-native/issues/18177
+  safeAreaInsets.bottom = safeAreaInsets.bottom == 0 && safeAreaInsets.left == 0 ? 34 : safeAreaInsets.bottom;
+  
   if (UIEdgeInsetsEqualToEdgeInsetsWithThreshold(safeAreaInsets, _currentSafeAreaInsets, 1.0 / RCTScreenScale())) {
     return;
   }

--- a/React/Views/SafeAreaView/RCTSafeAreaView.m
+++ b/React/Views/SafeAreaView/RCTSafeAreaView.m
@@ -101,9 +101,16 @@ static BOOL UIEdgeInsetsEqualToEdgeInsetsWithThreshold(UIEdgeInsets insets1, UIE
 
 - (void)setSafeAreaInsets:(UIEdgeInsets)safeAreaInsets
 {
-  // HACK: enforces a bottom safe area inset when there isn't one being set.
-  // related issue: https://github.com/facebook/react-native/issues/18177
-  safeAreaInsets.bottom = safeAreaInsets.bottom == 0 && safeAreaInsets.left == 0 ? 34 : safeAreaInsets.bottom;
+
+// Use the app's key window to determine Safe area insets.
+// fixes: https://github.com/facebook/react-native/issues/18177
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 110000 /* __IPHONE_11_0 */
+  if (self.isSupportedByOS) {
+    if (@available(iOS 11.0, *)) {
+      safeAreaInsets = UIApplication.sharedApplication.keyWindow.safeAreaInsets;
+    }
+  }
+#endif
   
   if (UIEdgeInsetsEqualToEdgeInsetsWithThreshold(safeAreaInsets, _currentSafeAreaInsets, 1.0 / RCTScreenScale())) {
     return;


### PR DESCRIPTION
## Summary

This is a fix for #18177.
## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See http://facebook.github.io/react-native/docs/contributing#changelog for an example. -->

[iOS] [Fixed] - SafeAreaView bottom not respected in Modal

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
Poke around RNTester, open the SafeAreaView example and view the bottom spacing of the modal being correct.