### PR TITLE
Added default values for cachedLayouts and cachedMeasures

### DIFF
--- a/ReactCommon/yoga/yoga/YGMarker.h
+++ b/ReactCommon/yoga/yoga/YGMarker.h
@@ -23,8 +23,8 @@ typedef struct {
   int layouts;
   int measures;
   int maxMeasureCache;
-  int cachedLayouts;
-  int cachedMeasures;
+  int cachedLayouts = 0;
+  int cachedMeasures = 0;
 } YGMarkerLayoutData;
 
 typedef struct {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

We were seeing this error when analyzing the project:
```The left expression of the compound assignment is an uninitialized value. The computed value will also be garbage```.

We believe this is related to this issue: https://github.com/facebook/react-native/issues/12159. This PR adds default values for `cachedLayouts` and `cachedMeasures` to avoid this issue.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See http://facebook.github.io/react-native/docs/contributing#changelog for an example. -->

[iOS] [Fixed] - Message

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
After adding the suggested changes, the analyzer no longer displays the attached error.
<img width="890" alt="error" src="https://user-images.githubusercontent.com/7763293/56385995-a7fd0b00-61ee-11e9-9b12-f9bb3451e3ab.png">

