### PR TITLE
Adds Logic To Catch MissingWebViewPackageException

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/modules/network/ForwardingCookieHandler.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/network/ForwardingCookieHandler.java
@@ -182,6 +182,18 @@ public class ForwardingCookieHandler extends CookieHandler {
       } catch (IllegalArgumentException ex) {
         // https://bugs.chromium.org/p/chromium/issues/detail?id=559720
         return null;
+      } catch (Exception exception) {
+        String message = exception.getMessage();
+        // We cannot catch MissingWebViewPackageException as it is in a private / system API
+        // class. This validates the exception's message to ensure we are only handling this
+        // specific exception.
+        // https://android.googlesource.com/platform/frameworks/base/+/master/core/java/android/
+        // webkit/WebViewFactory.java#98
+        if (message != null && message.contains("No WebView installed")) {
+          return null;
+        } else {
+          throw exception;
+        }
       }
 
       if (USES_LEGACY_STORE) {

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/network/ForwardingCookieHandler.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/network/ForwardingCookieHandler.java
@@ -187,8 +187,7 @@ public class ForwardingCookieHandler extends CookieHandler {
         // We cannot catch MissingWebViewPackageException as it is in a private / system API
         // class. This validates the exception's message to ensure we are only handling this
         // specific exception.
-        // https://android.googlesource.com/platform/frameworks/base/+/master/core/java/android/
-        // webkit/WebViewFactory.java#98
+        // https://android.googlesource.com/platform/frameworks/base/+/master/core/java/android/webkit/WebViewFactory.java#98
         if (message != null && message.contains("No WebView installed")) {
           return null;
         } else {


### PR DESCRIPTION
## Summary

We are seeing crash reports that the webview is missing. In this case
it should fail gracefully so that a missing webview does not block
from using an app built with React Native.

The contains could also be changed to check for "webview" in general
to catch all webview related exception. It's currently checking on
for the specific string that I'm seeing in our app's crashreporting tool.

<img width="1507" alt="Screen Shot 2019-04-19 at 11 26 19 AM" src="https://user-images.githubusercontent.com/741767/56438307-5e1c2f80-6297-11e9-970b-a5095d18e9d7.png">

<img width="935" alt="Screen Shot 2019-04-19 at 11 32 58 AM" src="https://user-images.githubusercontent.com/741767/56438213-fa920200-6296-11e9-8008-5eb344eca8a8.png">

## Changelog

[Android] [Fixed] - The ReactCookieJarContainer/ForwardingCookieHandler now handles the missing WebView  gracefully.

## Test Plan

No new tests have been added.
CI should pass.

This fix was made based on the exception stacktrace. I have not spent the time to acquire one of the devices that it is happening on.