### PR TITLE
Remove out-of-tree platform tests

### DIFF
--- a/.circleci/Dockerfiles/scripts/run-ci-e2e-tests.sh
+++ b/.circleci/Dockerfiles/scripts/run-ci-e2e-tests.sh
@@ -22,8 +22,6 @@ AVD_UUID=$(< /dev/urandom tr -dc 'a-zA-Z0-9' | fold -w 8 | head -n 1)
 ANDROID_NPM_DEPS="appium@1.5.1 mocha@2.4.5 wd@0.3.11 colors@1.0.3 pretty-data2@0.40.1"
 CLI_PACKAGE="$ROOT/react-native-cli/react-native-cli-*.tgz"
 PACKAGE="$ROOT/react-native-*.tgz"
-# Version of react-native-dummy to test against
-REACT_DUMMY_PLATFORM=react-native-dummy@0.1.0
 
 # solve issue with max user watches limit
 echo 65536 | tee -a /proc/sys/fs/inotify/max_user_watches
@@ -249,20 +247,6 @@ function e2e_suite() {
         echo "Could not build iOS bundle"
         return 1
       fi
-
-      if ! retry "$RETRY_COUNT" npm install --save "$REACT_DUMMY_PLATFORM" --silent >> /dev/null
-      then
-        echo "Failed to install react-native-dummy"
-        echo "Most common reason is npm registry connectivity, try again"
-        return 1
-      fi
-
-      if ! react-native bundle --max-workers 1 --platform dummy --dev true --entry-file index.js --bundle-output dummy-bundle.js
-      then
-        echo "Could not build dummy bundle"
-        return 1
-      fi
-    fi
 
     # directory cleanup
     rm "$IOS_MARKER"

--- a/jest/__tests__/hasteImpl-test.js
+++ b/jest/__tests__/hasteImpl-test.js
@@ -11,22 +11,8 @@
 'use strict';
 
 const path = require('path');
-const fs = require('fs');
 
 const {getHasteName} = require('../hasteImpl');
-
-// RNPM currently does not support plugins when using Yarn Plug 'n Play
-const testIfNotPnP = fs.existsSync(
-  path.join(
-    __dirname,
-    '../..',
-    'node_modules',
-    'react-native-dummy',
-    'package.json',
-  ),
-)
-  ? test
-  : test.skip;
 
 function getPath(...parts) {
   return path.join(__dirname, '..', '..', ...parts);
@@ -59,24 +45,6 @@ it('returns the correct haste name for a file with a platform suffix', () => {
     ).toEqual('AccessibilityInfo');
   }
 });
-
-testIfNotPnP(
-  'returns the correct haste name for a file with an out-of-tree platform suffix',
-  () => {
-    for (const platform of ['dummy']) {
-      expect(
-        getHasteName(
-          getPath(
-            'Libraries',
-            'Components',
-            'AccessibilityInfo',
-            `AccessibilityInfo.${platform}.js`,
-          ),
-        ),
-      ).toEqual('AccessibilityInfo');
-    }
-  },
-);
 
 it('returns the correct haste name for a file with a flow suffix', () => {
   expect(

--- a/package.json
+++ b/package.json
@@ -139,7 +139,6 @@
     "mkdirp": "^0.5.1",
     "prettier": "1.16.4",
     "react": "16.8.3",
-    "react-native-dummy": "0.2.0",
     "react-test-renderer": "16.8.3",
     "shelljs": "^0.7.8",
     "yargs": "^9.0.0",


### PR DESCRIPTION
## Summary

This pull request removes the tests for out-of-tree platforms and the dependency on the package `react-native-dummy` from the React Native repo.

The logic that this was meant to test was moved to the React Native CLI repo, and [it is being tested there](https://github.com/react-native-community/cli/blob/827daa4c1687f8d17eb7df46e1a2ec25640c7797/packages/cli/src/tools/config/__tests__/index-test.js#L125-L152) as well making this a bit redundant at this point.

The dependency on `react-native-dummy` was also an issue, because when the file structure under `Libraries/` changes, bundler errors could crop up if there wasn't an update made to the file structure of `react-native-dummy/Libraries/`.

This was an issue when [`TabBarIOS` was removed](https://github.com/facebook/react-native/commit/02697291ff41ddfac5b85d886e9cafa0261c8b98#diff-b9cfc7f2cdf78a7f4b91a753d10865a2) - `react-native-dummy` was causing Haste errors and was stopping the commit from being able to land, and I needed to cut a new version just for it. With Lean Core, I expect more issues like this happening in the future.

## Changelog

[General] [Removed] - Removed Out-of-Tree platform tests (functionality is tested in the RN-CLI repo now)

## Test Plan

No regressions have been noted.