### PR TITLE
Default textColor of #000000 on Android

### DIFF
--- a/RNTester/android/app/src/main/res/values/styles.xml
+++ b/RNTester/android/app/src/main/res/values/styles.xml
@@ -3,6 +3,7 @@
     <!-- Base application theme. -->
     <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar">
         <!-- Customize your theme here. -->
+        <item name="android:textColor">#000000</item>
     </style>
 
 </resources>

--- a/template/android/app/src/main/res/values/styles.xml
+++ b/template/android/app/src/main/res/values/styles.xml
@@ -3,6 +3,7 @@
     <!-- Base application theme. -->
     <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar">
         <!-- Customize your theme here. -->
+        <item name="android:textColor">#000000</item>
     </style>
 
 </resources>


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

By default, the text color is `#000000` on iOS and different on Android, e.g. `#808080`, depending on the manufactorer.

This PR changes it so that newly created projects all have the text color `#000000` by default on both iOS and Android.

The argument for this is to make the app by default be more consistent between platforms.

Expo also does this: https://github.com/expo/expo/blob/master/android/expoview/src/main/res/values/styles.xml#L31

---

For context and for your consideration, I have started a discussion here with the topic of whether React Native should try to use OS defaults or be consistent between platforms:

https://github.com/react-native-community/discussions-and-proposals/issues/121

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See http://facebook.github.io/react-native/docs/contributing#changelog for an example. -->

[Android] [Changed] - New projects have a `#000000` by default.

## Test Plan
I have added this line to my project and it would set the default color to black.
