### PR TITLE
Make Alert not cancelable by default on Android

### DIFF
--- a/Libraries/Alert/Alert.js
+++ b/Libraries/Alert/Alert.js
@@ -56,7 +56,7 @@ class Alert {
       let config = {
         title: title || '',
         message: message || '',
-        cancelable: false
+        cancelable: false,
       };
 
       if (options) {

--- a/Libraries/Alert/Alert.js
+++ b/Libraries/Alert/Alert.js
@@ -56,6 +56,7 @@ class Alert {
       let config = {
         title: title || '',
         message: message || '',
+        cancelable: false
       };
 
       if (options) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

By default, an alert is `cancelable` on Android but not on iOS.
This PR changes the behavior so that the Alert is not dismissable on Android by default.

The motivation is that many developers develop on iOS and test on Android, and do forget to consider the case that the alert is dismissable.
Consistent behavior by default makes it easier to develop cross-platform apps in general.

---

For context and for your consideration, I have started a discussion here with the topic of whether React Native should try to use OS defaults or be consistent between platforms:

https://github.com/react-native-community/discussions-and-proposals/issues/121

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

---

If this PR gets merged, the docs should be updated as well:

https://github.com/facebook/react-native-website/blob/master/docs/alert.md#android

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See http://facebook.github.io/react-native/docs/contributing#changelog for an example. -->

[Android] [Changed] - By default, alerts are not dismissable

## Test Plan

By testing out the change in `node_modules`, I have found that the change has the intended effect.