### PR TITLE
Fix smooth scrolling on old devices (SDK >=16)

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
@@ -314,15 +314,11 @@ public class ReactScrollView extends ScrollView implements ReactClippingViewGrou
     //
     // Hence, we can use the absolute value from whatever the OS gives
     // us and use the sign of what mOnScrollDispatchHelper has tracked.
-    //final int correctedVelocityY = (int)(Math.abs(velocityY) * Math.signum(mOnScrollDispatchHelper.getYFlingVelocity()));
-
-    //BEGIN pavel.rotek wrong velocity on old phones
     float signum = Math.signum(mOnScrollDispatchHelper.getYFlingVelocity());
     if (signum == 0) {
       signum = Math.signum(velocityY);
     }
     final int correctedVelocityY = (int)(Math.abs(velocityY) * signum);
-    //END
 
     if (mPagingEnabled) {
       flingAndSnap(correctedVelocityY);

--- a/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
@@ -314,8 +314,15 @@ public class ReactScrollView extends ScrollView implements ReactClippingViewGrou
     //
     // Hence, we can use the absolute value from whatever the OS gives
     // us and use the sign of what mOnScrollDispatchHelper has tracked.
-    final int correctedVelocityY = (int)(Math.abs(velocityY) * Math.signum(mOnScrollDispatchHelper.getYFlingVelocity()));
+    //final int correctedVelocityY = (int)(Math.abs(velocityY) * Math.signum(mOnScrollDispatchHelper.getYFlingVelocity()));
 
+    //BEGIN pavel.rotek wrong velocity on old phones
+    float signum = Math.signum(mOnScrollDispatchHelper.getYFlingVelocity());
+    if (signum == 0) {
+      signum = Math.signum(velocityY);
+    }
+    final int correctedVelocityY = (int)(Math.abs(velocityY) * signum);
+    //END
 
     if (mPagingEnabled) {
       flingAndSnap(correctedVelocityY);


### PR DESCRIPTION
## Environment
  React Native Environment Info:
    System:
      OS: Linux 4.15 Ubuntu 18.04.1 LTS (Bionic Beaver)
      CPU: (4) x64 Intel(R) Core(TM) i5-7300U CPU @ 2.60GHz
      Memory: 1.12 GB / 15.55 GB
      Shell: 4.4.19 - /bin/bash
    Binaries:
      Node: 8.10.0 - /usr/bin/node
      Yarn: 1.13.0 - /usr/local/bin/yarn
      npm: 3.5.2 - /usr/bin/npm
    SDKs:
      Android SDK:
        API Levels: 16, 19, 22, 23, 24, 25, 26, 27, 28
        Build Tools: 23.0.1, 23.0.3, 25.0.0, 25.0.2, 25.0.3, 26.0.1, 26.0.3, 27.0.3, 28.0.2, 28.0.3
        System Images: android-16 | Google APIs Intel x86 Atom, android-19 | Google APIs Intel x86 Atom, android-24 | Google Play Intel x86 Atom, android-27 | Google APIs Intel x86 Atom, android-28 | Intel x86 Atom_64, android-28 | Google APIs Intel x86 Atom, android-28 | Google Play Intel x86 Atom
    npmPackages:
      react: 16.8.6 => 16.8.6 
      react-native: git+https://github.com/facebook/react-native.git#v0.59.5 => 0.59.5 
    npmGlobalPackages:
      react-native-cli: 2.0.1
      react-native-git-upgrade: 0.2.7

## Description
The workaround implemented in https://github.com/facebook/react-native/pull/21117 tries to fix 
https://issuetracker.google.com/issues/112385925 scroll direction (according to the latest comments, the scroll direction problem has been reverted in security patches so not sure if the workaround is still valid).
 
But... proposed solution in fling method is using signum which leads to zero computedVelocityY in case of zero mOnScrollDispatchHelper.getYFlingVelocity() on old devices(Samsung s4 mini) even when real velocityY is non zero

```
final int correctedVelocityY = (int)(Math.abs(velocityY) * Math.signum(mOnScrollDispatchHelper.getYFlingVelocity()));
```

Proposed solution is to take signum from original velocityY in case of zero
```
float signum = Math.signum(mOnScrollDispatchHelper.getYFlingVelocity());
if (signum == 0) {
  signum = Math.signum(velocityY);
}
final int correctedVelocityY = (int)(Math.abs(velocityY) * signum);
```

The symptoms are the same as described in issue https://github.com/facebook/react-native/issues/22925, but proposed workaround doesn't work.

## Changelog
[Android][fixed] - Fix smooth scrolling on old devices (SDK >=16)
## Test Plan
Install and test on old device. Works on Samsung S4 mini