### PR TITLE
[emitter] Fix sparse array handling in `EventEmitter#listeners()`

### DIFF
--- a/Libraries/vendor/emitter/EventEmitter.js
+++ b/Libraries/vendor/emitter/EventEmitter.js
@@ -16,6 +16,8 @@ const EventSubscriptionVendor = require('EventSubscriptionVendor');
 
 const invariant = require('invariant');
 
+const sparseFilterPredicate = () => true;
+
 /**
  * @class EventEmitter
  * @description
@@ -151,7 +153,13 @@ class EventEmitter {
   listeners(eventType: string): [EmitterSubscription] {
     const subscriptions = this._subscriber.getSubscriptionsForType(eventType);
     return subscriptions
-      ? subscriptions.map(subscription => subscription.listener)
+      ? subscriptions
+          // We filter out missing entries because the array is sparse.
+          // "callbackfn is called only for elements of the array which actually
+          // exist; it is not called for missing elements of the array."
+          // https://www.ecma-international.org/ecma-262/9.0/index.html#sec-array.prototype.filter
+          .filter(sparseFilterPredicate)
+          .map(subscription => subscription.listener)
       : [];
   }
 


### PR DESCRIPTION
## Summary

Fixes a regression in https://github.com/facebook/react-native/commit/1f8b46a2fc191e2899735fbdcdbb535a91b63724. The internal subscription vendor uses a sparse array to track listeners, which makes listener removal fast. When querying listeners, the sparse entries need to be removed. `Array#filter` is a built-in way to do this -> linked to the JS spec, which explains this.

## Changelog

[General] [Fixed] - Fixed sparse array handling in `EventEmitter#listeners()` 

## Test Plan

Ran tests outside of this repo that now pass
