### PR TITLE
Fix jsc-android not found if building from source

### DIFF
--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -136,11 +136,15 @@ task prepareGlog(dependsOn: dependenciesPath ? [] : [downloadGlog], type: Copy) 
 // Create Android.mk library module based on jsc from npm
 task prepareJSC {
     doLast {
-        def jscPackageRoot = fileTree("$projectDir/../node_modules/jsc-android/dist")
-        def jscAAR = jscPackageRoot.matching({ it.include "**/android-jsc/**/*.aar" }).singleFile
+        def jscPackageRoot = file("$projectDir/../node_modules/jsc-android/dist")
+        if (!jscPackageRoot.exists()) {
+            // For an app to build from RN source, the jsc-android is located at /path/to/app/node_modules
+            jscPackageRoot = file("$rootDir/../node_modules/jsc-android/dist")
+        }
+        def jscAAR = fileTree(jscPackageRoot).matching({ it.include "**/android-jsc/**/*.aar" }).singleFile
         def soFiles = zipTree(jscAAR).matching({ it.include "**/*.so" })
 
-        def headerFiles = jscPackageRoot.matching({ it.include "**/include/*.h" })
+        def headerFiles = fileTree(jscPackageRoot).matching({ it.include "**/include/*.h" })
 
         copy {
             from(soFiles)

--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -139,7 +139,8 @@ task prepareJSC {
         def jscPackageRoot = file("$projectDir/../node_modules/jsc-android/dist")
         if (!jscPackageRoot.exists()) {
             // For an app to build from RN source, the jsc-android is located at /path/to/app/node_modules
-            jscPackageRoot = file("$rootDir/../node_modules/jsc-android/dist")
+            // and $projectDir may located at /path/to/app/node_modules/react-native/ReactAndroid
+            jscPackageRoot = file("$projectDir/../../jsc-android/dist")
         }
         def jscAAR = fileTree(jscPackageRoot).matching({ it.include "**/android-jsc/**/*.aar" }).singleFile
         def soFiles = zipTree(jscAAR).matching({ it.include "**/*.so" })


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

If an app [builds from RN source](https://facebook.github.io/react-native/docs/building-from-source), there was an error for jsc-android not found.
It is a side effect of my previous [JSC as node dependency change](https://github.com/facebook/react-native/commit/8e375850de73d1b998a83279e6c4ba238867a453)
For building from RN source case, the jsc-android is located at `/path/to/app/node_modules/jsc-android`.
Original gradle task will try to find it at `/path/to/app/node_modules/react-native/ReactAndroid/../node_modules/jsc-android`, as ReactAndroid project path was being override inside node_modules.
The change fixes the building from source case.

## Changelog

N/A
This change does not need to publish into changelog, as it is a master branch building fix.

## Test Plan


1. Test building RN AAR: `./gradlew :ReactAndroid:installArchives`
2. Test an app to build from source as described at https://facebook.github.io/react-native/docs/building-from-source
