### PR TITLE
Adds a ruby file in RN which reflects what Podspecs should be imported by default

### DIFF
--- a/RNTester/Podfile
+++ b/RNTester/Podfile
@@ -1,29 +1,21 @@
 platform :ios, '9.0'
 
+require_relative '../scripts/autolink-ios'
+
 target 'RNTester' do
   # Uncomment for Swift
   # use_frameworks!
 
   project 'RNTesterPods.xcodeproj'
+  use_react_native!(path: "..")
 
-  pod 'React', :path => '../'
-  pod 'React-ART', :path => '../Libraries/ART'
-  pod 'React-Core', :path => '../React'
-  pod 'React-DevSupport', :path => '../React'
-  pod 'React-fishhook', :path => '../Libraries/fishhook'
-  pod 'React-RCTActionSheet', :path => '../Libraries/ActionSheetIOS'
-  pod 'React-RCTAnimation', :path => '../Libraries/NativeAnimation'
-  pod 'React-RCTBlob', :path => '../Libraries/Blob'
+  # Additional Pods which aren't included in the default Podfile
   pod 'React-RCTCameraRoll', :path => '../Libraries/CameraRoll'
-  pod 'React-RCTImage', :path => '../Libraries/Image'
-  pod 'React-RCTLinking', :path => '../Libraries/LinkingIOS'
-  pod 'React-RCTNetwork', :path => '../Libraries/Network'
+  pod 'React-ART', :path => '../Libraries/ART'
   pod 'React-RCTPushNotification', :path => '../Libraries/PushNotificationIOS'
-  pod 'React-RCTSettings', :path => '../Libraries/Settings'
-  pod 'React-RCTText', :path => '../Libraries/Text'
-  pod 'React-RCTVibration', :path => '../Libraries/Vibration'
-  pod 'React-RCTWebSocket', :path => '../Libraries/WebSocket'
 
+  # Additional Pods which are classed as unstable
+  #
   # Fabric Pods, uncomment these to enable in RNTester
   # pod 'React-Fabric', :path => '../ReactCommon'
   # pod 'React-graphics', :path => '../ReactCommon/fabric/graphics'
@@ -31,18 +23,6 @@ target 'RNTester' do
   # pod 'React-RCTFabric', :path => '../React'
   # pod 'Folly/Fabric', :podspec => '../third-party-podspecs/Folly.podspec'
 
-  pod 'React-cxxreact', :path => '../ReactCommon/cxxreact'
-  pod 'React-jsi', :path => '../ReactCommon/jsi'
-  pod 'React-jsiexecutor', :path => '../ReactCommon/jsiexecutor'
-  pod 'React-jsinspector', :path => '../ReactCommon/jsinspector'
-  pod 'yoga', :path => '../ReactCommon/yoga'
-
   pod 'React-turbomodule-core', :path => '../ReactCommon/turbomodule/core'
   pod 'React-turbomodule-samples', :path => '../ReactCommon/turbomodule/samples'
-
-  # Third party deps podspec link
-  pod 'DoubleConversion', :podspec => '../third-party-podspecs/DoubleConversion.podspec'
-  pod 'glog', :podspec => '../third-party-podspecs/glog.podspec'
-  pod 'Folly', :podspec => '../third-party-podspecs/Folly.podspec'
-
 end

--- a/RNTester/Podfile.lock
+++ b/RNTester/Podfile.lock
@@ -208,31 +208,31 @@ SPEC CHECKSUMS:
   DoubleConversion: 5805e889d232975c086db112ece9ed034df7a0b2
   Folly: 30e7936e1c45c08d884aa59369ed951a8e68cf51
   glog: 1f3da668190260b06b429bb211bfbee5cd790c28
-  React: 7c652b87c228731c51ab5764de68b6c17e6342be
-  React-ART: 28f8815acbbc4816cec14866b59911a83eb780ed
-  React-Core: 85bf24f380e5228013f5f75d7c1b6338a003a2b2
-  React-cxxreact: 7e670bad16eb78fa889573d931c12bb1003a3598
-  React-DevSupport: f34768e3aad3e59ee9800c752a78bc6cb24d0f75
-  React-fishhook: d2a67f0eaeef9fe0dca0526812ca8fcff4b6f17b
-  React-jsi: ae62f3eff7357d3c11722653d13d0c6399b5c372
-  React-jsiexecutor: ee776181a1ba315dbae9500c4dba5cb94ea3c5d2
-  React-jsinspector: ea0a218071a11c3687cef2480580180caa6a64c0
-  React-RCTActionSheet: caf6532394bdbbe0fc0ec2363c84f26bcfcdd36a
-  React-RCTAnimation: b324c6eb699637c735650c6180e13d003eeb0e56
-  React-RCTBlob: 069290c8db758bb1d77523a06d117dd668b6cef3
-  React-RCTCameraRoll: 353af870a0acd5ebb0bcf6a8187ed78d94c4c65e
-  React-RCTImage: 012d845d919177e2726743ad06052dda66592760
-  React-RCTLinking: c6fe7b82bed97ce72203b2ce2f4aac87b1e2647f
-  React-RCTNetwork: 2a2b22a17cd965de53ba21c5ca392d0da84ef322
-  React-RCTPushNotification: 13729b4a2b63b191f42ba7230a69f462f3b5a7f9
-  React-RCTSettings: e36d7f7d566b80d4363176c2f76cc5eccfdd0ae1
-  React-RCTText: 469ec754592c92fc639825e558908c2f0e783e2c
-  React-RCTVibration: ade3c169b54f3bc16c9a9918e17e48ef66aee6ba
-  React-RCTWebSocket: 90b78ed51d53d17db417d3956decba3f7ace58e4
-  React-turbomodule-core: 67a461c91319c0bf2228dc46c7dafbbb921eebee
-  React-turbomodule-samples: b28927d482d6fcfc3cbe2fd25f304799d2ff9bb7
-  yoga: 542cb34fe3bca476487e08eb516dd640ea996a65
+  React: e7b61c9123f89c4cd9becea2122af02568be6e13
+  React-ART: 3dba78ec04b585a82456d1df4bda7a08dbc83a8d
+  React-Core: d1c3aa4b1c5c57bf839de3c83396b59c1efbf1ba
+  React-cxxreact: 5f2b678adbe8ff5256801603e1b496e481bc2430
+  React-DevSupport: 9bde3ce4f7707d9487759101ea3188f4f07c9003
+  React-fishhook: a9a43c2c84ab2519809810bcdd363e2774007c69
+  React-jsi: cdf32eb002ff3e243364a1abb71925e0e93003db
+  React-jsiexecutor: 6e53c44a5371297f0c9cc39780f12cb3efba3b81
+  React-jsinspector: 2f42a591151e828d0422cbd3b609eedcb920d58e
+  React-RCTActionSheet: 4ad4bfac1ba9ec020edf278362855448d607cafd
+  React-RCTAnimation: f050e9fbe85e5616f74cea7a2557bdfb6be73cee
+  React-RCTBlob: 9f907aab3417a43bbda84aef76f88ee528e877d4
+  React-RCTCameraRoll: 288b1007d8e540771b917f89d7d99118a3477ee1
+  React-RCTImage: 4234a754ebdb922416f5f77cff121c680fd3ccbe
+  React-RCTLinking: 3a52500942cc73999df19f541b7bda5887c3c43d
+  React-RCTNetwork: 2042d2648e1160770ac0e5068bb5b648c03296a5
+  React-RCTPushNotification: 3cfbf863d0597b5da80a15c9a9285a0ad89b23ba
+  React-RCTSettings: 8099c9d904c0fbe46c463de8791478b5bc72809e
+  React-RCTText: c4a643a08fce4727316366fea5ad17fa14f72f54
+  React-RCTVibration: c5933466242187bffe55fa5496f841e04db66c8a
+  React-RCTWebSocket: 233c66a6394de3816ee46861bbe0dba9f83e45a0
+  React-turbomodule-core: 7ae77c38b85f6f81be40c0c3dc456d3a5fda4797
+  React-turbomodule-samples: 483f2c80e81b89197737828405a0ac27c77f58b5
+  yoga: 56698cdff46e3dbb7aa71fd2fd7dc0ce650dc0fb
 
-PODFILE CHECKSUM: f7d0a09c9ea25315395b7248591d4a372b87cf3f
+PODFILE CHECKSUM: bb578b8286c0068879a41ac092c9690cc3ede523
 
-COCOAPODS: 1.6.1
+COCOAPODS: 1.6.3

--- a/scripts/autolink-ios.rb
+++ b/scripts/autolink-ios.rb
@@ -1,0 +1,37 @@
+def use_react_native! (options={})
+
+  # The prefix to the react-native
+  prefix = options[:path] ||= "../node_modules/react-native"
+
+  # Include DevSupport dependency
+  production = options[:production] ||= false
+
+  # The Pods which should be included in all projects
+  pod 'React', :path => "#{prefix}/"
+  pod 'React-Core', :path => "#{prefix}/React"
+  pod 'React-fishhook', :path => "#{prefix}/Libraries/fishhook"
+  pod 'React-RCTActionSheet', :path => "#{prefix}/Libraries/ActionSheetIOS"
+  pod 'React-RCTAnimation', :path => "#{prefix}/Libraries/NativeAnimation"
+  pod 'React-RCTBlob', :path => "#{prefix}/Libraries/Blob"
+  pod 'React-RCTImage', :path => "#{prefix}/Libraries/Image"
+  pod 'React-RCTLinking', :path => "#{prefix}/Libraries/LinkingIOS"
+  pod 'React-RCTNetwork', :path => "#{prefix}/Libraries/Network"
+  pod 'React-RCTSettings', :path => "#{prefix}/Libraries/Settings"
+  pod 'React-RCTText', :path => "#{prefix}/Libraries/Text"
+  pod 'React-RCTVibration', :path => "#{prefix}/Libraries/Vibration"
+  pod 'React-RCTWebSocket', :path => "#{prefix}/Libraries/WebSocket"
+  
+  unless production
+    pod 'React-DevSupport', :path => "#{prefix}/React"
+  end
+
+  pod 'React-cxxreact', :path => "#{prefix}/ReactCommon/cxxreact"
+  pod 'React-jsi', :path => "#{prefix}/ReactCommon/jsi"
+  pod 'React-jsiexecutor', :path => "#{prefix}/ReactCommon/jsiexecutor"
+  pod 'React-jsinspector', :path => "#{prefix}/ReactCommon/jsinspector"
+  pod 'yoga', :path => "#{prefix}/ReactCommon/yoga"
+
+  pod 'DoubleConversion', :podspec => "#{prefix}/third-party-podspecs/DoubleConversion.podspec"
+  pod 'glog', :podspec => "#{prefix}/third-party-podspecs/glog.podspec"
+  pod 'Folly', :podspec => "#{prefix}/third-party-podspecs/Folly.podspec"
+end


### PR DESCRIPTION
## Summary

Simplifies the code anyone on iOS using RN has _to see_. In this case, React Native knows that everyone probably wants all these imports (unless they're using dev mode) and so we can auto-import the pod specs for a user from inside the lib.

Basically auto-link for the React side.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See http://facebook.github.io/react-native/docs/contributing#changelog for an example. -->

[iOS] [Added] - Adds a ruby function which imports the Pods for RN, so that users only have to include this function and it can change per RN version.

## Test Plan

I did a `pod install` with RNTester, and I don't think it makes sense for writing tests for the Ruby code

/cc @grabbou @alloy 