### PR TITLE
Adjust test manual e2e script to work with new init

### DIFF
--- a/scripts/bump-oss-version.js
+++ b/scripts/bump-oss-version.js
@@ -114,9 +114,7 @@ if (
 }
 
 // Change react-native version in the template's package.json
-let templatePackageJson = JSON.parse(cat('template/package.json'));
-templatePackageJson.dependencies['react-native'] = version;
-fs.writeFileSync('./template/package.json', JSON.stringify(templatePackageJson, null, 2) + '\n', 'utf-8');
+exec(`node scripts/set-rn-template-version.js ${version}`);
 
 // Verify that files changed, we just do a git diff and check how many times version is added across files
 let numberOfChangedLinesWithNewVersion = exec(

--- a/scripts/set-rn-template-version.js
+++ b/scripts/set-rn-template-version.js
@@ -15,7 +15,7 @@ const path = require('path');
 const version = process.argv[2];
 
 if (!version) {
-  console.error('You need to provide react-native version');
+  console.error('Please provide a react-native version.');
   process.exit(1);
 }
 

--- a/scripts/set-rn-template-version.js
+++ b/scripts/set-rn-template-version.js
@@ -1,5 +1,16 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+'use strict';
+
 const fs = require('fs');
-const {cat} = require('shelljs');
+const path = require('path');
 
 const version = process.argv[2];
 
@@ -8,6 +19,12 @@ if (!version) {
   process.exit(1);
 }
 
-let templatePackageJson = JSON.parse(cat('template/package.json'));
+const jsonPath = path.join(__dirname, '../template/package.json');
+
+let templatePackageJson = require(jsonPath);
 templatePackageJson.dependencies['react-native'] = version;
-fs.writeFileSync('./template/package.json', JSON.stringify(templatePackageJson, null, 2) + '\n', 'utf-8');
+fs.writeFileSync(
+  jsonPath,
+  JSON.stringify(templatePackageJson, null, 2) + '\n',
+  'utf-8',
+);

--- a/scripts/set-rn-template-version.js
+++ b/scripts/set-rn-template-version.js
@@ -1,0 +1,13 @@
+const fs = require('fs');
+const {cat} = require('shelljs');
+
+const version = process.argv[2];
+
+if (!version) {
+  console.error('You need to provide react-native version');
+  process.exit(1);
+}
+
+let templatePackageJson = JSON.parse(cat('template/package.json'));
+templatePackageJson.dependencies['react-native'] = version;
+fs.writeFileSync('./template/package.json', JSON.stringify(templatePackageJson, null, 2) + '\n', 'utf-8');

--- a/scripts/test-manual-e2e.sh
+++ b/scripts/test-manual-e2e.sh
@@ -83,7 +83,7 @@ project_name="RNTestProject"
 
 cd /tmp/
 rm -rf "$project_name"
-npx @react-native-community/cli init $project_name --template $repo_root
+npx @react-native-community/cli init "$project_name" --template "$repo_root"
 
 info "Double checking the versions in package.json are correct:"
 grep "\"react-native\": \".*react-native-$PACKAGE_VERSION.tgz\"" "/tmp/${project_name}/package.json" || error "Incorrect version number in /tmp/${project_name}/package.json"

--- a/scripts/test-manual-e2e.sh
+++ b/scripts/test-manual-e2e.sh
@@ -76,11 +76,14 @@ npm pack
 PACKAGE=$(pwd)/react-native-$PACKAGE_VERSION.tgz
 success "Package bundled ($PACKAGE)"
 
+node set-rn-template-version.js "file://$PACKAGE"
+success "React Native version changed in the template"
+
 project_name="RNTestProject"
 
 cd /tmp/
 rm -rf "$project_name"
-react-native init "$project_name" --version $PACKAGE
+npx @react-native-community/cli init $project_name --template $repo_root
 
 info "Double checking the versions in package.json are correct:"
 grep "\"react-native\": \".*react-native-$PACKAGE_VERSION.tgz\"" "/tmp/${project_name}/package.json" || error "Incorrect version number in /tmp/${project_name}/package.json"

--- a/scripts/test-manual-e2e.sh
+++ b/scripts/test-manual-e2e.sh
@@ -83,7 +83,7 @@ project_name="RNTestProject"
 
 cd /tmp/
 rm -rf "$project_name"
-npx @react-native-community/cli init "$project_name" --template "$repo_root"
+node "$repo_root/cli.js" "$project_name" --template "$repo_root"
 
 info "Double checking the versions in package.json are correct:"
 grep "\"react-native\": \".*react-native-$PACKAGE_VERSION.tgz\"" "/tmp/${project_name}/package.json" || error "Incorrect version number in /tmp/${project_name}/package.json"

--- a/scripts/test-manual-e2e.sh
+++ b/scripts/test-manual-e2e.sh
@@ -76,14 +76,14 @@ npm pack
 PACKAGE=$(pwd)/react-native-$PACKAGE_VERSION.tgz
 success "Package bundled ($PACKAGE)"
 
-node set-rn-template-version.js "file://$PACKAGE"
+node scripts/set-rn-template-version.js "file:$PACKAGE"
 success "React Native version changed in the template"
 
 project_name="RNTestProject"
 
 cd /tmp/
 rm -rf "$project_name"
-node "$repo_root/cli.js" "$project_name" --template "$repo_root"
+node "$repo_root/cli.js" init "$project_name" --template "$repo_root"
 
 info "Double checking the versions in package.json are correct:"
 grep "\"react-native\": \".*react-native-$PACKAGE_VERSION.tgz\"" "/tmp/${project_name}/package.json" || error "Incorrect version number in /tmp/${project_name}/package.json"


### PR DESCRIPTION
## Summary

Since initialisation flow changed with default template, we need to adjust the script to make it work properly.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See http://facebook.github.io/react-native/docs/contributing#changelog for an example. -->

[General] [Fixed] - Adjust text manual e2e script to work with new init.

## Test Plan

I wasn't able to run whole script, but I've tested a part that I have written.

cc @grabbou Can you test this script in `0.60-stable` branch?
