### PR TITLE
[iOS] Fixes SafeAreaView when set emulateUnlessSupported on safeArea supported devices

### DIFF
--- a/React/Views/SafeAreaView/RCTSafeAreaView.m
+++ b/React/Views/SafeAreaView/RCTSafeAreaView.m
@@ -118,6 +118,10 @@ static BOOL UIEdgeInsetsEqualToEdgeInsetsWithThreshold(UIEdgeInsets insets1, UIE
   }
 
   _emulateUnlessSupported = emulateUnlessSupported;
+  
+  if ([self isSupportedByOS]) {
+    return;
+  }
 
   [self invalidateSafeAreaInsets];
 }


### PR DESCRIPTION
## Summary

On safeArea supported devices like `iPhoneX`, we need to forbid invalidate `safeAreaInsets` when set `emulateUnlessSupported` prop, otherwise `SafeAreaView` would broken.

cc. @cpojer @shergin .

Before:
![before](https://user-images.githubusercontent.com/5061845/56792861-33088180-683d-11e9-8183-a1c8a5c9cb37.gif)

After:
![after](https://user-images.githubusercontent.com/5061845/56792867-38fe6280-683d-11e9-9b4d-01848b42a9b0.gif)


## Changelog

[iOS] [Fixed] - Fixes SafeAreaView when set emulateUnlessSupported on safeArea supported devices

## Test Plan

Open RNTester, run `SafeAreaView` example, it works when switch `emulateUnlessSupported` on `iPhoneX`.