### PR TITLE
React Native Android Duplicate file error when generating apk

### DIFF
--- a/react.gradle
+++ b/react.gradle
@@ -48,6 +48,24 @@ afterEvaluate {
                 resourcesDir.mkdirs()
             }
 
+            // duplicate assets check
+
+            doLast {
+                def moveFunc = { resSuffix ->
+                    File originalDir = file("$buildDir/generated/res/react/release/drawable-${resSuffix}");
+                    if (originalDir.exists()) {
+                        File destDir = file("$buildDir/../src/main/res/drawable-${resSuffix}");
+                        ant.move(file: originalDir, tofile: destDir);
+                    }
+                }
+                moveFunc.curry("ldpi").call()
+                moveFunc.curry("mdpi").call()
+                moveFunc.curry("hdpi").call()
+                moveFunc.curry("xhdpi").call()
+                moveFunc.curry("xxhdpi").call()
+                moveFunc.curry("xxxhdpi").call()
+            }
+
             // Set up inputs and outputs so gradle can cache the result
             inputs.files fileTree(dir: reactRoot, excludes: inputExcludes)
             outputs.dir(jsBundleDir)


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

I was getting an error "~/React-Native/xxxx/android/app/build/intermediates/res/merged/release/drawable-mdpi-v4/icon_logo: error: Duplicate file...
Native/xxxx/android/app/build/intermediates/res/merged/release/drawable-mdpi-v4/icon_logo_main: error: Duplicate file.
"

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->


## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See http://facebook.github.io/react-native/docs/contributing#changelog for an example. -->

1. Changes on React.gradle 
[CATEGORY] [TYPE] - Message

## Test Plan
1. Generate apk from android studio
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
