### PR TITLE
[iOS] Add convert compatible of NSString for bridge message data

### DIFF
--- a/React/Base/RCTConvert.m
+++ b/React/Base/RCTConvert.m
@@ -53,11 +53,20 @@ RCT_NUMBER_CONVERTER(NSUInteger, unsignedIntegerValue)
 
 RCT_JSON_CONVERTER(NSArray)
 RCT_JSON_CONVERTER(NSDictionary)
-RCT_JSON_CONVERTER(NSString)
 RCT_JSON_CONVERTER(NSNumber)
 
 RCT_CUSTOM_CONVERTER(NSSet *, NSSet, [NSSet setWithArray:json])
 RCT_CUSTOM_CONVERTER(NSData *, NSData, [json dataUsingEncoding:NSUTF8StringEncoding])
+
++ (NSString *)NSString:(id)json
+{
+  if ([json isKindOfClass:NSString.class]) {
+    return json;
+  } else if (json) {
+    return [NSString stringWithFormat:@"%@",json];
+  }
+  return json;
+}
 
 + (NSIndexSet *)NSIndexSet:(id)json
 {

--- a/React/Base/RCTConvert.m
+++ b/React/Base/RCTConvert.m
@@ -62,10 +62,10 @@ RCT_CUSTOM_CONVERTER(NSData *, NSData, [json dataUsingEncoding:NSUTF8StringEncod
 {
   if ([json isKindOfClass:NSString.class]) {
     return json;
-  } else if (json) {
+  } else if (json && json != (id)kCFNull) {
     return [NSString stringWithFormat:@"%@",json];
   }
-  return json;
+  return nil;
 }
 
 + (NSIndexSet *)NSIndexSet:(id)json


### PR DESCRIPTION
## Summary

Fixes https://twitter.com/estevao_lucas/status/1117572702083190785?s=215 in #24626 . Now we try to convert any id to `NSString`, not throw error.

cc. @cpojer .

## Changelog

[iOS] [Fixed] - Add convert compatible of NSString for bridge message data

## Test Plan

If we set other types like number, we can convert it to `NSString` and not throw error.