### PR TITLE
Set the Prettier config so it is not forced on users of @react-native-community/eslint-config

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "requirePragma": true,
+  "singleQuote": true,
+  "trailingComma": "all",
+  "bracketSpacing": false,
+  "jsxBracketSameLine": true
+}

--- a/package.json
+++ b/package.json
@@ -11,14 +11,6 @@
   "engines": {
     "node": ">=8.3"
   },
-  "prettier": {
-    "requirePragma": true,
-    "singleQuote": true,
-    "trailingComma": "all",
-    "bracketSpacing": false,
-    "jsxBracketSameLine": true,
-    "parser": "flow"
-  },
   "jest-junit": {
     "outputDirectory": "reports/junit",
     "outputName": "js-test-results.xml"

--- a/packages/eslint-config-react-native-community/index.js
+++ b/packages/eslint-config-react-native-community/index.js
@@ -216,7 +216,7 @@ module.exports = {
 
     // Prettier Plugin
     // https://github.com/prettier/eslint-plugin-prettier
-    'prettier/prettier': [2, 'fb', '@format'],
+    'prettier/prettier': 2,
 
     // Stylistic Issues
     // These rules are purely matters of style and are quite subjective.

--- a/yarn.lock
+++ b/yarn.lock
@@ -6033,11 +6033,6 @@ react-is@^16.8.3:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.3.tgz#4ad8b029c2a718fc0cfc746c8d4e1b7221e5387d"
   integrity sha512-Y4rC1ZJmsxxkkPuMLwvKvlL1Zfpbcu+Bf4ZigkHup3v9EfdYhAlWAaVyA19olXq2o2mGn0w+dFKvk3pVVlYcIA==
 
-react-native-dummy@0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/react-native-dummy/-/react-native-dummy-0.2.0.tgz#fbf0ff7607506882648f1b07f76e57951b7b8f8a"
-  integrity sha512-8efApfdopDKGdxbG8aMmYDXt33aZUoFIU+kRxrsdvVAtV2m121tVFrgV8pHr7M+Y7iuOl80wuxt6Xx8zclCIpQ==
-
 react-proxy@^1.1.7:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/react-proxy/-/react-proxy-1.1.8.tgz#9dbfd9d927528c3aa9f444e4558c37830ab8c26a"


### PR DESCRIPTION
## Summary

This fixes an issue where the Prettier config was set to the `fb` (Facebook) values for all users of the `@react-native-community/eslint-config` package. This was due to [this line](https://github.com/facebook/react-native/blob/8f186b84aeeb2613bf6ae08f20a8547d40179007/packages/eslint-config-react-native-community/index.js#L219) in the config file.

It was causing issues like these:

* Errors when using newer versions of `eslint-plugin-prettier` (you had to use a version that was >1 year old): https://github.com/facebook/react-native/issues/24564
* Errors due to the Prettier parser being forced to be `flow` when using Typescript: https://github.com/typescript-eslint/typescript-eslint/issues/481

This PR:

* Changes that line to remove the explicit `fb` config so users can set their own.
* Moves the React Native Prettier config to `.prettierrc` so ESLint, Prettier, and code editors can all read from the same place.
* Upgrades both `prettier` and the `eslint-plugin-prettier` to the latest versions.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See http://facebook.github.io/react-native/docs/contributing#changelog for an example. -->

[General] [Fixed] - Stopped the Prettier config being set for all users of @react-native-community/eslint-config

## Test Plan

* ✅ Ensure there is no difference on this repo (no ESLint errors, same number of warnings, and no changes when running prettier.
* ✅ Test that the new config does not set the Prettier settings on projects which use it.