### PR TITLE
Fix crash when borderXColor is null on Android

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewProps.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewProps.java
@@ -237,13 +237,13 @@ public class ViewProps {
         }
         return true;
       case BORDER_LEFT_COLOR:
-        return map.isNull(BORDER_LEFT_COLOR) || map.getInt(BORDER_LEFT_COLOR) == Color.TRANSPARENT;
+        return !map.isNull(BORDER_LEFT_COLOR) && map.getInt(BORDER_LEFT_COLOR) == Color.TRANSPARENT;
       case BORDER_RIGHT_COLOR:
-        return map.isNull(BORDER_RIGHT_COLOR) || map.getInt(BORDER_RIGHT_COLOR) == Color.TRANSPARENT;
+        return !map.isNull(BORDER_RIGHT_COLOR) && map.getInt(BORDER_RIGHT_COLOR) == Color.TRANSPARENT;
       case BORDER_TOP_COLOR:
-        return map.isNull(BORDER_TOP_COLOR) || map.getInt(BORDER_TOP_COLOR) == Color.TRANSPARENT;
+        return !map.isNull(BORDER_TOP_COLOR) && map.getInt(BORDER_TOP_COLOR) == Color.TRANSPARENT;
       case BORDER_BOTTOM_COLOR:
-        return map.isNull(BORDER_BOTTOM_COLOR) || map.getInt(BORDER_BOTTOM_COLOR) == Color.TRANSPARENT;
+        return !map.isNull(BORDER_BOTTOM_COLOR) && map.getInt(BORDER_BOTTOM_COLOR) == Color.TRANSPARENT;
       case BORDER_WIDTH:
         return map.isNull(BORDER_WIDTH) || map.getDouble(BORDER_WIDTH) == 0d;
       case BORDER_LEFT_WIDTH:

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewProps.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewProps.java
@@ -237,13 +237,13 @@ public class ViewProps {
         }
         return true;
       case BORDER_LEFT_COLOR:
-        return map.getInt(BORDER_LEFT_COLOR) == Color.TRANSPARENT;
+        return map.isNull(BORDER_LEFT_COLOR) || map.getInt(BORDER_LEFT_COLOR) == Color.TRANSPARENT;
       case BORDER_RIGHT_COLOR:
-        return map.getInt(BORDER_RIGHT_COLOR) == Color.TRANSPARENT;
+        return map.isNull(BORDER_RIGHT_COLOR) || map.getInt(BORDER_RIGHT_COLOR) == Color.TRANSPARENT;
       case BORDER_TOP_COLOR:
-        return map.getInt(BORDER_TOP_COLOR) == Color.TRANSPARENT;
+        return map.isNull(BORDER_TOP_COLOR) || map.getInt(BORDER_TOP_COLOR) == Color.TRANSPARENT;
       case BORDER_BOTTOM_COLOR:
-        return map.getInt(BORDER_BOTTOM_COLOR) == Color.TRANSPARENT;
+        return map.isNull(BORDER_BOTTOM_COLOR) || map.getInt(BORDER_BOTTOM_COLOR) == Color.TRANSPARENT;
       case BORDER_WIDTH:
         return map.isNull(BORDER_WIDTH) || map.getDouble(BORDER_WIDTH) == 0d;
       case BORDER_LEFT_WIDTH:


### PR DESCRIPTION
## Summary

On android when borderXColor is null it causes the app to crash with:

```
04-28 17:44:18.021 20114 20213 E unknown:ReactNative: com.facebook.react.bridge.NoSuchKeyException: borderBottomColor
04-28 17:44:18.021 20114 20213 E unknown:ReactNative: 	at com.facebook.react.bridge.ReadableNativeMap.getValue(ReadableNativeMap.java:111)
04-28 17:44:18.021 20114 20213 E unknown:ReactNative: 	at com.facebook.react.bridge.ReadableNativeMap.getValue(ReadableNativeMap.java:115)
04-28 17:44:18.021 20114 20213 E unknown:ReactNative: 	at com.facebook.react.bridge.ReadableNativeMap.getInt(ReadableNativeMap.java:158)
04-28 17:44:18.021 20114 20213 E unknown:ReactNative: 	at com.facebook.react.uimanager.ViewProps.isLayoutOnly(ViewProps.java:246)
04-28 17:44:18.021 20114 20213 E unknown:ReactNative: 	at com.facebook.react.uimanager.NativeViewHierarchyOptimizer.isLayoutOnlyAndCollapsable(NativeViewHierarchyOptimizer.java:482)
```

Basically it is missing a `isNull` check on the props map before trying to access the value.

Fixes #22727

## Changelog

[Android] [Fixed] - Fix a crash when borderXColor is null

## Test Plan

Tested that this no longer crashes `<View style={{borderBottomColor: null}} />`
