### PR TITLE
Fix accessibility event properties for TextInput

### DIFF
--- a/Libraries/Text/TextInput/RCTBaseTextInputView.m
+++ b/Libraries/Text/TextInput/RCTBaseTextInputView.m
@@ -283,16 +283,16 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithFrame:(CGRect)frame)
 
 - (void)setSecureTextEntry:(BOOL)secureTextEntry {
   UIView<RCTBackedTextInputViewProtocol> *textInputView = self.backedTextInputView;
-    
+
   if (textInputView.secureTextEntry != secureTextEntry) {
     textInputView.secureTextEntry = secureTextEntry;
-      
+
     // Fix #5859, see https://stackoverflow.com/questions/14220187/uitextfield-has-trailing-whitespace-after-securetextentry-toggle/22537788#22537788
     NSAttributedString *originalText = [textInputView.attributedText copy];
     self.backedTextInputView.attributedText = [NSAttributedString new];
     self.backedTextInputView.attributedText = originalText;
   }
-    
+
 }
 
 #pragma mark - RCTBackedTextInputDelegate
@@ -399,7 +399,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithFrame:(CGRect)frame)
   }
 
   NSString *previousText = backedTextInputView.attributedText.string ?: @"";
-  
+
   if (range.location + range.length > backedTextInputView.attributedText.string.length) {
     _predictedText = backedTextInputView.attributedText.string;
   } else {
@@ -503,13 +503,6 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithFrame:(CGRect)frame)
 
   // Returning value DOES include border and padding insets.
   return fittingSize;
-}
-
-#pragma mark - Accessibility
-
-- (UIView *)reactAccessibilityElement
-{
-  return self.backedTextInputView;
 }
 
 #pragma mark - Focus Control

--- a/Libraries/Text/TextInput/RCTBaseTextInputViewManager.m
+++ b/Libraries/Text/TextInput/RCTBaseTextInputViewManager.m
@@ -34,6 +34,7 @@ RCT_EXPORT_MODULE()
 
 #pragma mark - Unified <TextInput> properties
 
+RCT_REMAP_VIEW_PROPERTY(accessibilityLabel, reactAccessibilityElement.accessibilityLabel, NSString)
 RCT_REMAP_VIEW_PROPERTY(autoCapitalize, backedTextInputView.autocapitalizationType, UITextAutocapitalizationType)
 RCT_REMAP_VIEW_PROPERTY(autoCorrect, backedTextInputView.autocorrectionType, UITextAutocorrectionType)
 RCT_REMAP_VIEW_PROPERTY(contextMenuHidden, backedTextInputView.contextMenuHidden, BOOL)


### PR DESCRIPTION
## Summary

When a `TextInput` receives any accessibility event prop (`onAccessibilityTap`, `onMagicTap`, `onAccessibilityEscape`, `onAccessibilityEscape`), causes a crash.

<p align=center><img src=https://user-images.githubusercontent.com/20709038/56871548-84f00980-69ed-11e9-8906-0206899e5435.jpg width=300></p>

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See http://facebook.github.io/react-native/docs/contributing#changelog for an example. -->

[iOS] [Fixed] - Fix accessibility event properties for `TextInput`

## Test Plan

The following component shouldn't crash the app.
```js
<TextInput
  accessible={true}
  onMagicTap={() => {
    console.log("--onMagicTap works");
  }}
  onAccessibilityTap={() => {
    console.log("--onAccessibilityTap works");
  }}
  onAccessibilityEscape={() => {
    console.log("--onAccessibilityEscape works");
  }}
/>
```