### PR TITLE
[Fabric] Remove `accessibilityTraits` prop (accessibility)

### DIFF
--- a/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -221,12 +221,6 @@ using namespace facebook::react;
     self.accessibilityElement.accessibilityHint = RCTNSStringFromStringNilIfEmpty(newViewProps.accessibilityHint);
   }
 
-  // `accessibilityTraits`
-  if (oldViewProps.accessibilityTraits != newViewProps.accessibilityTraits) {
-    self.accessibilityElement.accessibilityTraits =
-        RCTUIAccessibilityTraitsFromAccessibilityTraits(newViewProps.accessibilityTraits);
-  }
-
   // `accessibilityViewIsModal`
   if (oldViewProps.accessibilityViewIsModal != newViewProps.accessibilityViewIsModal) {
     self.accessibilityElement.accessibilityViewIsModal = newViewProps.accessibilityViewIsModal;

--- a/ReactCommon/fabric/components/view/accessibility/AccessibilityProps.cpp
+++ b/ReactCommon/fabric/components/view/accessibility/AccessibilityProps.cpp
@@ -20,10 +20,6 @@ AccessibilityProps::AccessibilityProps(
     const RawProps &rawProps)
     : accessible(
           convertRawProp(rawProps, "accessible", sourceProps.accessible)),
-      accessibilityTraits(convertRawProp(
-          rawProps,
-          "accessibilityTraits",
-          sourceProps.accessibilityTraits)),
       accessibilityLabel(convertRawProp(
           rawProps,
           "accessibilityLabel",


### PR DESCRIPTION
## Summary

`accessibilityTraits` and `accessibilityComponentType` were removed on #24344. This PR removes `accessibilityTraits` prop from Fabric as well.

## Changelog

[General] [Removed] - Remove `accessibilityTraits` prop from Fabric.

## Test Plan

I need help to test it. cc @cpojer 