### PR TITLE
ReactAndroid: JS errors during bundle load were reported as UnknownCppException

### DIFF
--- a/ReactAndroid/src/main/jni/Application.mk
+++ b/ReactAndroid/src/main/jni/Application.mk
@@ -27,7 +27,7 @@ NDK_MODULE_PATH := $(APP_MK_DIR)$(HOST_DIRSEP)$(THIRD_PARTY_NDK_DIR)$(HOST_DIRSE
 APP_STL := c++_shared
 
 # Make sure every shared lib includes a .note.gnu.build-id header
-APP_CFLAGS := -Wall -Werror
+APP_CFLAGS := -Wall -Werror -fexceptions -frtti
 APP_CPPFLAGS := -std=c++1y
 APP_LDFLAGS := -Wl,--build-id
 


### PR DESCRIPTION
## Summary

This fixes a regression on Android introduced by f3e5cce where JS errors thrown during bundle load were lost (shown only as UnknownCppException). It is especially tough to debug (custom) bundling errors without seeing the javascript error.

Root cause hypothesis: since switching to clang, `JSError`s thrown in ReactCommon's `JSCRuntime::checkException` were never matched as `std::exception` in ReactAndroid's `convertCppExceptionToJavaException` due to these missing flags.

I'm a bit shy on low-level details concerning how C++ rtti works exactly around catching exceptions thrown in other libraries. All I can say that with this change, a `bundle.android.js` that only contains `throw new Error("wtf");` now nicely outputs a message and stack trace in the logcat. Before (and since @DanielZlotin's switch to clang) it just outputted:

```
2019-04-29 12:17:59.365 1162-1306/com.rntest E/unknown:ReactNative: Exception in native call
    com.facebook.jni.UnknownCppException: Unknown
        at com.facebook.react.bridge.queue.NativeRunnable.run(Native Method)
        at android.os.Handler.handleCallback(Handler.java:873)
        at android.os.Handler.dispatchMessage(Handler.java:99)
        at com.facebook.react.bridge.queue.MessageQueueThreadHandler.dispatchMessage(MessageQueueThreadHandler.java:29)
        at android.os.Looper.loop(Looper.java:214)
        at com.facebook.react.bridge.queue.MessageQueueThreadImpl$4.run(MessageQueueThreadImpl.java:232)
        at java.lang.Thread.run(Thread.java:764)
```

## Changelog

[Android] [Fixed] - JS errors during bundle load were reported as UnknownCppException.

## Test Plan

Might be tricky to test, although an end-to-end on an Android emulator test that checks the logcat for a proper JS stacktrace when the bundle contains invalid JS. No idea if there is infrastructure in place to add this. Any hints?
