### PR TITLE
[iOS] Timing: Fixes timer when app get into background

### DIFF
--- a/React/Modules/RCTTiming.m
+++ b/React/Modules/RCTTiming.m
@@ -185,10 +185,7 @@ RCT_EXPORT_MODULE()
 
 - (void)appDidMoveToForeground
 {
-  if (self->_backgroundTaskIdentifier != UIBackgroundTaskInvalid) {
-    [[UIApplication sharedApplication] endBackgroundTask:self->_backgroundTaskIdentifier];
-    _backgroundTaskIdentifier = UIBackgroundTaskInvalid;
-  }
+  [self markEndOfBackgroundTaskIfNeeded];
   _inBackground = NO;
   [self startTimers];
 }

--- a/React/Modules/RCTTiming.m
+++ b/React/Modules/RCTTiming.m
@@ -150,7 +150,7 @@ RCT_EXPORT_MODULE()
     _backgroundTaskIdentifier = [[UIApplication sharedApplication] beginBackgroundTaskWithExpirationHandler:^{
       typeof(self) strongSelf = weakSelf;
       if (!strongSelf) {
-        return ;
+        return;
       }
       // Mark the end of background task
       [strongSelf markEndOfBackgroundTaskIfNeeded];


### PR DESCRIPTION
## Summary

Related #23674, in that PR, we imported background timer support, but it's not sufficient, I think the reason that works is because it enable the `Background Modes` and do some background tasks, for the users who don't enable it, timer would pause immediately before goes into background.

To fix it, we can mark a background task when goes into background, it can keep app active for minutes, try best to support timing when in background.

cc. @cpojer .

## Changelog


[iOS] [Fixed] - Timing: Fixes timer when app get into background

## Test Plan

Run code in background like the code below, console can log correctly.
```
    setInterval(() => {
      console.log("Timer run");
    }, 1000);
```