### PR TITLE
call onValueChange only when value changes

### DIFF
--- a/Libraries/Components/Picker/PickerAndroid.android.js
+++ b/Libraries/Components/Picker/PickerAndroid.android.js
@@ -119,9 +119,11 @@ class PickerAndroid extends React.Component<
         const value = children[position].props.value;
         /* $FlowFixMe(>=0.78.0 site=react_native_android_fb) This issue was
          * found when making Flow check .android.js files. */
-        this.props.onValueChange(value, position);
+        if( this.props.selectedValue != value)
+          this.props.onValueChange(value, position);
       } else {
-        this.props.onValueChange(null, position);
+        if( this.props.selectedValue != value)
+          this.props.onValueChange(null, position);
       }
     }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
`OnValueChange` function of `Picker` is called when Picker is initialized. 
## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See http://facebook.github.io/react-native/docs/contributing#changelog for an example. -->

[Android][fixed] - `OnValueChange` will be called only when the `selectedValue` changes.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
```
export default class App extends Component<Props> {
  constructor(props) {
    super(props);
    this.state = {language:"js",test:1}
  }
  render() {
    return (
      <View style={styles.container}>
        <Picker
          selectedValue={this.state.language}
          style={{height: 50, width: 100}}
          onValueChange={(itemValue, itemIndex) =>{
            this.setState({language: itemValue,test:2});
          }
        }>
          <Picker.Item label="Java" value="java" />
          <Picker.Item label="JavaScript" value="js" />
        </Picker>
        <Text>{this.state.test}</Text>
      </View>
    );
  }
}
```
Here `state.test` must be 1 when the app loads. But the `onValueChange` is called initially which changes `state.test`to 2. This pull request fixes the issue.