### PR TITLE
Ignore unexpected style prop value on Android

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/LayoutShadowNode.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/LayoutShadowNode.java
@@ -60,7 +60,8 @@ public class LayoutShadowNode extends ReactShadowNodeImpl {
           unit = YogaUnit.PERCENT;
           value = Float.parseFloat(s.substring(0, s.length() - 1));
         } else {
-          throw new IllegalArgumentException("Unknown value: " + s);
+          unit = YogaUnit.UNDEFINED;
+          value = YogaConstants.UNDEFINED;
         }
       } else {
         unit = YogaUnit.POINT;


### PR DESCRIPTION
## Summary

Android crash the app when a style prop receives an unexpected value.

E.g.: the possible values for `width` or`height` is `"auto"`, `"100%"` or `100`. Passing a `"100"` (neight number nor percent string) throw an error - which crashes the app in release mode.

The propose in this PR is just to ignore any unexpected value. Which will be the same as not set any value for the style prop.

## Changelog

[Android] [Fix] - Ignore wrong style value on Android

## Test Plan

The following code shouldn't crash
```js
<View style={{ backgroundColor: "red", width: "50", height: "ignoreit" }} />
```
