### PR TITLE
[general][changed] cleanup RedBox message and stack output

### DIFF
--- a/Libraries/Core/ExceptionsManager.js
+++ b/Libraries/Core/ExceptionsManager.js
@@ -12,6 +12,8 @@
 
 import type {ExtendedError} from 'parseErrorStack';
 
+const INTERNAL_CALLSITES_REGEX = /ReactNativeRenderer-dev\.js|MessageQueue\.js/;
+
 /**
  * Handles the developer-visible aspect of errors and exceptions
  */
@@ -38,9 +40,12 @@ function reportException(e: ExtendedError, isFatal: boolean) {
       symbolicateStackTrace(stack)
         .then(prettyStack => {
           if (prettyStack) {
+            const stackWithoutInternalCallsites = prettyStack.filter(
+              frame => frame.file.match(INTERNAL_CALLSITES_REGEX) === null,
+            );
             ExceptionsManager.updateExceptionMessage(
               e.message,
-              prettyStack,
+              stackWithoutInternalCallsites,
               currentExceptionID,
             );
           } else {

--- a/Libraries/Core/ExceptionsManager.js
+++ b/Libraries/Core/ExceptionsManager.js
@@ -26,7 +26,6 @@ function reportException(e: ExtendedError, isFatal: boolean) {
     const currentExceptionID = ++exceptionID;
     const message =
       e.jsEngine == null ? e.message : `${e.message}, js engine: ${e.jsEngine}`;
-    console.log('reportException', message);
     if (isFatal) {
       ExceptionsManager.reportFatalException(
         message,
@@ -73,7 +72,6 @@ function handleException(e: Error, isFatal: boolean) {
   // Unfortunately there is no way to figure out the stacktrace in this
   // case, so if you ended up here trying to trace an error, look for
   // `throw '<error message>'` somewhere in your codebase.
-  console.warn('abc', e.message);
   if (!e.message) {
     e = new Error(e);
   }

--- a/Libraries/Core/ExceptionsManager.js
+++ b/Libraries/Core/ExceptionsManager.js
@@ -26,6 +26,7 @@ function reportException(e: ExtendedError, isFatal: boolean) {
     const currentExceptionID = ++exceptionID;
     const message =
       e.jsEngine == null ? e.message : `${e.message}, js engine: ${e.jsEngine}`;
+    console.log('reportException', message);
     if (isFatal) {
       ExceptionsManager.reportFatalException(
         message,
@@ -72,6 +73,7 @@ function handleException(e: Error, isFatal: boolean) {
   // Unfortunately there is no way to figure out the stacktrace in this
   // case, so if you ended up here trying to trace an error, look for
   // `throw '<error message>'` somewhere in your codebase.
+  console.warn('abc', e.message);
   if (!e.message) {
     e = new Error(e);
   }

--- a/Libraries/Core/ExceptionsManager.js
+++ b/Libraries/Core/ExceptionsManager.js
@@ -12,7 +12,12 @@
 
 import type {ExtendedError} from 'parseErrorStack';
 
-const INTERNAL_CALLSITES_REGEX = /ReactNativeRenderer-dev\.js|MessageQueue\.js/;
+const INTERNAL_CALLSITES_REGEX = new RegExp(
+  [
+    '/Libraries/Renderer/oss/ReactNativeRenderer-dev\\.js$',
+    '/Libraries/BatchedBridge/MessageQueue\\.js$',
+  ].join('|'),
+);
 
 /**
  * Handles the developer-visible aspect of errors and exceptions

--- a/RNTester/Podfile.lock
+++ b/RNTester/Podfile.lock
@@ -208,31 +208,31 @@ SPEC CHECKSUMS:
   DoubleConversion: 5805e889d232975c086db112ece9ed034df7a0b2
   Folly: 30e7936e1c45c08d884aa59369ed951a8e68cf51
   glog: 1f3da668190260b06b429bb211bfbee5cd790c28
-  React: e7b61c9123f89c4cd9becea2122af02568be6e13
-  React-ART: 3dba78ec04b585a82456d1df4bda7a08dbc83a8d
-  React-Core: d1c3aa4b1c5c57bf839de3c83396b59c1efbf1ba
-  React-cxxreact: 5f2b678adbe8ff5256801603e1b496e481bc2430
-  React-DevSupport: 9bde3ce4f7707d9487759101ea3188f4f07c9003
-  React-fishhook: a9a43c2c84ab2519809810bcdd363e2774007c69
-  React-jsi: cdf32eb002ff3e243364a1abb71925e0e93003db
-  React-jsiexecutor: 6e53c44a5371297f0c9cc39780f12cb3efba3b81
-  React-jsinspector: 2f42a591151e828d0422cbd3b609eedcb920d58e
-  React-RCTActionSheet: 4ad4bfac1ba9ec020edf278362855448d607cafd
-  React-RCTAnimation: f050e9fbe85e5616f74cea7a2557bdfb6be73cee
-  React-RCTBlob: 9f907aab3417a43bbda84aef76f88ee528e877d4
-  React-RCTCameraRoll: 288b1007d8e540771b917f89d7d99118a3477ee1
-  React-RCTImage: 4234a754ebdb922416f5f77cff121c680fd3ccbe
-  React-RCTLinking: 3a52500942cc73999df19f541b7bda5887c3c43d
-  React-RCTNetwork: 2042d2648e1160770ac0e5068bb5b648c03296a5
-  React-RCTPushNotification: 3cfbf863d0597b5da80a15c9a9285a0ad89b23ba
-  React-RCTSettings: 8099c9d904c0fbe46c463de8791478b5bc72809e
-  React-RCTText: c4a643a08fce4727316366fea5ad17fa14f72f54
-  React-RCTVibration: c5933466242187bffe55fa5496f841e04db66c8a
-  React-RCTWebSocket: 233c66a6394de3816ee46861bbe0dba9f83e45a0
-  React-turbomodule-core: 7ae77c38b85f6f81be40c0c3dc456d3a5fda4797
-  React-turbomodule-samples: 483f2c80e81b89197737828405a0ac27c77f58b5
-  yoga: 56698cdff46e3dbb7aa71fd2fd7dc0ce650dc0fb
+  React: 84543adb151c2b244a1382acec0104ea9cbb38fc
+  React-ART: 360f7a59b61fe6056f5cc4e5a8573903151559d6
+  React-Core: 7be8ff1284429a89e13d015a4d9414564925f3d2
+  React-cxxreact: b08b3cff60a301b270c7c5a1e02317fb5d8cba9b
+  React-DevSupport: 8f690a6d645029ad190218c37e9378f3c905874e
+  React-fishhook: cf960afa914669a0351eda11ab7512d1c296db63
+  React-jsi: 3656bc6c1341ee603608948efc2380cb07e74acd
+  React-jsiexecutor: c06e0f954c05443804d84c26be49648af43f9910
+  React-jsinspector: 869004d1f504f6cc5297ca3b9cb4bb47d39fd0eb
+  React-RCTActionSheet: a5fc6f20b792851e27b1e96e6d64428b52a4e24e
+  React-RCTAnimation: 5bb31cfe6b00b707231e427d50ddde0c7412b3bb
+  React-RCTBlob: 56020ff9ef8aaefc95eef38918a7163dc510bc7a
+  React-RCTCameraRoll: e4bf746166884d2d79d2910b53ef5fb13183edd4
+  React-RCTImage: 392bb126b12a84d79f8dec1e467c19cd75e368a8
+  React-RCTLinking: 599fce0beee82c68a12605d34b1b55b818157331
+  React-RCTNetwork: eadd43c90aab2155b4565ce0eb687f5fd38a3f08
+  React-RCTPushNotification: 07c0f8be59febfe4bee3813356b5c31078c34463
+  React-RCTSettings: 8b0aa49573ef8759f9994367f728c75a37348c3c
+  React-RCTText: 31e7540066861f65affd2f74cd8be4ede373ea6e
+  React-RCTVibration: a26e8ae219df6a6306de02c874f6c8c049a1707d
+  React-RCTWebSocket: 26aea8a78a2e773c513962eb01f9716af66c2872
+  React-turbomodule-core: cd96486b1130d3e059b0234f2e13b1b0ae1f088a
+  React-turbomodule-samples: 61ffa1c3be772f867bb549b7a9815d7dfe1cf634
+  yoga: 51596049049479ed6836b4db62cea7359d34bc7b
 
-PODFILE CHECKSUM: bb578b8286c0068879a41ac092c9690cc3ede523
+PODFILE CHECKSUM: c921c70e8550c87a0959fb567b283545966c082c
 
-COCOAPODS: 1.6.3
+COCOAPODS: 1.6.1

--- a/RNTester/Podfile.lock
+++ b/RNTester/Podfile.lock
@@ -208,31 +208,31 @@ SPEC CHECKSUMS:
   DoubleConversion: 5805e889d232975c086db112ece9ed034df7a0b2
   Folly: 30e7936e1c45c08d884aa59369ed951a8e68cf51
   glog: 1f3da668190260b06b429bb211bfbee5cd790c28
-  React: 84543adb151c2b244a1382acec0104ea9cbb38fc
-  React-ART: 360f7a59b61fe6056f5cc4e5a8573903151559d6
-  React-Core: 7be8ff1284429a89e13d015a4d9414564925f3d2
-  React-cxxreact: b08b3cff60a301b270c7c5a1e02317fb5d8cba9b
-  React-DevSupport: 8f690a6d645029ad190218c37e9378f3c905874e
-  React-fishhook: cf960afa914669a0351eda11ab7512d1c296db63
-  React-jsi: 3656bc6c1341ee603608948efc2380cb07e74acd
-  React-jsiexecutor: c06e0f954c05443804d84c26be49648af43f9910
-  React-jsinspector: 869004d1f504f6cc5297ca3b9cb4bb47d39fd0eb
-  React-RCTActionSheet: a5fc6f20b792851e27b1e96e6d64428b52a4e24e
-  React-RCTAnimation: 5bb31cfe6b00b707231e427d50ddde0c7412b3bb
-  React-RCTBlob: 56020ff9ef8aaefc95eef38918a7163dc510bc7a
-  React-RCTCameraRoll: e4bf746166884d2d79d2910b53ef5fb13183edd4
-  React-RCTImage: 392bb126b12a84d79f8dec1e467c19cd75e368a8
-  React-RCTLinking: 599fce0beee82c68a12605d34b1b55b818157331
-  React-RCTNetwork: eadd43c90aab2155b4565ce0eb687f5fd38a3f08
-  React-RCTPushNotification: 07c0f8be59febfe4bee3813356b5c31078c34463
-  React-RCTSettings: 8b0aa49573ef8759f9994367f728c75a37348c3c
-  React-RCTText: 31e7540066861f65affd2f74cd8be4ede373ea6e
-  React-RCTVibration: a26e8ae219df6a6306de02c874f6c8c049a1707d
-  React-RCTWebSocket: 26aea8a78a2e773c513962eb01f9716af66c2872
-  React-turbomodule-core: cd96486b1130d3e059b0234f2e13b1b0ae1f088a
-  React-turbomodule-samples: 61ffa1c3be772f867bb549b7a9815d7dfe1cf634
-  yoga: 51596049049479ed6836b4db62cea7359d34bc7b
+  React: e7b61c9123f89c4cd9becea2122af02568be6e13
+  React-ART: 3dba78ec04b585a82456d1df4bda7a08dbc83a8d
+  React-Core: d1c3aa4b1c5c57bf839de3c83396b59c1efbf1ba
+  React-cxxreact: 5f2b678adbe8ff5256801603e1b496e481bc2430
+  React-DevSupport: 9bde3ce4f7707d9487759101ea3188f4f07c9003
+  React-fishhook: a9a43c2c84ab2519809810bcdd363e2774007c69
+  React-jsi: cdf32eb002ff3e243364a1abb71925e0e93003db
+  React-jsiexecutor: 6e53c44a5371297f0c9cc39780f12cb3efba3b81
+  React-jsinspector: 2f42a591151e828d0422cbd3b609eedcb920d58e
+  React-RCTActionSheet: 4ad4bfac1ba9ec020edf278362855448d607cafd
+  React-RCTAnimation: f050e9fbe85e5616f74cea7a2557bdfb6be73cee
+  React-RCTBlob: 9f907aab3417a43bbda84aef76f88ee528e877d4
+  React-RCTCameraRoll: 288b1007d8e540771b917f89d7d99118a3477ee1
+  React-RCTImage: 4234a754ebdb922416f5f77cff121c680fd3ccbe
+  React-RCTLinking: 3a52500942cc73999df19f541b7bda5887c3c43d
+  React-RCTNetwork: 2042d2648e1160770ac0e5068bb5b648c03296a5
+  React-RCTPushNotification: 3cfbf863d0597b5da80a15c9a9285a0ad89b23ba
+  React-RCTSettings: 8099c9d904c0fbe46c463de8791478b5bc72809e
+  React-RCTText: c4a643a08fce4727316366fea5ad17fa14f72f54
+  React-RCTVibration: c5933466242187bffe55fa5496f841e04db66c8a
+  React-RCTWebSocket: 233c66a6394de3816ee46861bbe0dba9f83e45a0
+  React-turbomodule-core: 7ae77c38b85f6f81be40c0c3dc456d3a5fda4797
+  React-turbomodule-samples: 483f2c80e81b89197737828405a0ac27c77f58b5
+  yoga: 56698cdff46e3dbb7aa71fd2fd7dc0ce650dc0fb
 
-PODFILE CHECKSUM: c921c70e8550c87a0959fb567b283545966c082c
+PODFILE CHECKSUM: bb578b8286c0068879a41ac092c9690cc3ede523
 
-COCOAPODS: 1.6.1
+COCOAPODS: 1.6.3

--- a/React/Modules/RCTRedBox.m
+++ b/React/Modules/RCTRedBox.m
@@ -186,7 +186,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
 - (void)showErrorMessage:(NSString *)message withStack:(NSArray<RCTJSStackFrame *> *)stack isUpdate:(BOOL)isUpdate
 {
     // Remove ANSI color codes from the message
-    NSString * messageWithoutAnsi = [self stripAnsi:message];
+    NSString *messageWithoutAnsi = [self stripAnsi:message];
 
     // Show if this is a new message, or if we're updating the previous message
     if ((self.hidden && !isUpdate) || (!self.hidden && isUpdate && [_lastErrorMessage isEqualToString:messageWithoutAnsi])) {

--- a/React/Modules/RCTRedBox.m
+++ b/React/Modules/RCTRedBox.m
@@ -180,8 +180,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
 {
     NSError *error = nil;
     NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:@"\\x1b\\[[0-9;]*m" options:NSRegularExpressionCaseInsensitive error:&error];
-    NSString *messageWithoutAnsi = [regex stringByReplacingMatchesInString:text options:0 range:NSMakeRange(0, [text length]) withTemplate:@""];
-    return messageWithoutAnsi;
+    return [regex stringByReplacingMatchesInString:text options:0 range:NSMakeRange(0, [text length]) withTemplate:@""];
 }
 
 - (void)showErrorMessage:(NSString *)message withStack:(NSArray<RCTJSStackFrame *> *)stack isUpdate:(BOOL)isUpdate

--- a/React/Modules/RCTRedBox.m
+++ b/React/Modules/RCTRedBox.m
@@ -134,7 +134,7 @@
 
         CGFloat buttonWidth = self.bounds.size.width / 4;
         CGFloat bottomButtonHeight = self.bounds.size.height - buttonHeight - [self bottomSafeViewHeight];
-    
+
         dismissButton.frame = CGRectMake(0, bottomButtonHeight, buttonWidth, buttonHeight);
         reloadButton.frame = CGRectMake(buttonWidth, bottomButtonHeight, buttonWidth, buttonHeight);
         copyButton.frame = CGRectMake(buttonWidth * 2, bottomButtonHeight, buttonWidth, buttonHeight);
@@ -148,11 +148,11 @@
         [rootView addSubview:copyButton];
         [rootView addSubview:extraButton];
         [rootView addSubview:topBorder];
-        
+
         UIView *bottomSafeView = [UIView new];
         bottomSafeView.backgroundColor = [UIColor colorWithRed:0.1 green:0.1 blue:0.1 alpha:1];
         bottomSafeView.frame = CGRectMake(0, self.bounds.size.height - [self bottomSafeViewHeight], self.bounds.size.width, [self bottomSafeViewHeight]);
-        
+
         [rootView addSubview:bottomSafeView];
     }
     return self;
@@ -176,14 +176,25 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
     [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
+- (NSString *)stripAnsi:(NSString *)text
+{
+    NSError *error = nil;
+    NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:@"\\x1b\\[[0-9;]*m" options:NSRegularExpressionCaseInsensitive error:&error];
+    NSString *messageWithoutAnsi = [regex stringByReplacingMatchesInString:text options:0 range:NSMakeRange(0, [text length]) withTemplate:@""];
+    return messageWithoutAnsi;
+}
+
 - (void)showErrorMessage:(NSString *)message withStack:(NSArray<RCTJSStackFrame *> *)stack isUpdate:(BOOL)isUpdate
 {
+    // Remove ANSI color codes from the message
+    NSString * messageWithoutAnsi = [self stripAnsi:message];
+
     // Show if this is a new message, or if we're updating the previous message
-    if ((self.hidden && !isUpdate) || (!self.hidden && isUpdate && [_lastErrorMessage isEqualToString:message])) {
+    if ((self.hidden && !isUpdate) || (!self.hidden && isUpdate && [_lastErrorMessage isEqualToString:messageWithoutAnsi])) {
         _lastStackTrace = stack;
         // message is displayed using UILabel, which is unable to render text of
         // unlimited length, so we truncate it
-        _lastErrorMessage = [message substringToIndex:MIN((NSUInteger)10000, message.length)];
+        _lastErrorMessage = [messageWithoutAnsi substringToIndex:MIN((NSUInteger)10000, messageWithoutAnsi.length)];
 
         [_stackTraceTableView reloadData];
 

--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/RedBoxDialog.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/RedBoxDialog.java
@@ -169,7 +169,8 @@ import org.json.JSONObject;
             ? (TextView) convertView
             : (TextView) LayoutInflater.from(parent.getContext())
                 .inflate(R.layout.redbox_item_title, parent, false);
-        title.setText(mTitle);
+        // Remove ANSI color codes from the title
+        title.setText(mTitle.replaceAll("\\x1b\\[[0-9;]*m", ""));
         return title;
       } else {
         if (convertView == null) {


### PR DESCRIPTION
## Summary

Cleanup RedBox messages and stack traces. This PR consists of 2 changes (I'm good with splitting them up if you'd like):

- [general] filter out some of the internal callsites from the symbolicated stack (I thought about using monospace font for title with code frame, but it looks weird)
- [ios][android] strip ANSI characters (coming from colored Babel code frame) from the error message


I think it's ok to strip it inside native handlers so we can still have a colorful code frame in the terminal output.

**JS Code frame:**

|before|after|
|--|--|
|<img width="400" alt="Screenshot 2019-04-30 at 12 32 05" src="https://user-images.githubusercontent.com/5106466/56956590-ef678d80-6b44-11e9-9019-6801f050ab0d.png">|<img width="400" alt="Screenshot 2019-04-30 at 12 52 43" src="https://user-images.githubusercontent.com/5106466/56957302-f42d4100-6b46-11e9-869b-ea9c7ce5b90f.png">|

|before|after|
|--|--|
|![image](https://user-images.githubusercontent.com/5106466/56959472-c8618980-6b4d-11e9-84be-6261d8375f4a.png)|![image](https://user-images.githubusercontent.com/5106466/56959463-bc75c780-6b4d-11e9-9d8b-25ffe46c87cf.png)|

**Filtered stack traces:**

|before|after|
|--|--|
|<img width="50%" alt="Screenshot 2019-04-30 at 12 27 21" src="https://user-images.githubusercontent.com/5106466/56956641-0908d500-6b45-11e9-8cdc-8c2a34a071e5.png"><img width="50%" alt="Screenshot 2019-04-30 at 12 27 28" src="https://user-images.githubusercontent.com/5106466/56956642-0908d500-6b45-11e9-921c-fabfb8515cc0.png">|<img width="100%" alt="Screenshot 2019-04-30 at 12 26 55" src="https://user-images.githubusercontent.com/5106466/56956650-0efeb600-6b45-11e9-9f5f-f10dd69580d1.png">|

There's still a lot of places that are hard to read, but I think this is a good start towards more readable errors.

cc @cpojer 

## Changelog

[General][Changed] - Cleanup RedBox message and stack output

## Test Plan

Played around in RNTester
