### PR TITLE
[Android] Do not throw on empty registered headless task

### DIFF
--- a/Libraries/ReactNative/AppRegistry.js
+++ b/Libraries/ReactNative/AppRegistry.js
@@ -260,7 +260,11 @@ const AppRegistry = {
   startHeadlessTask(taskId: number, taskKey: string, data: any): void {
     const taskProvider = taskProviders.get(taskKey);
     if (!taskProvider) {
-      throw new Error(`No task registered for key ${taskKey}`);
+      console.warn(
+        `No task registered for key ${taskKey}`,
+      );
+      NativeModules.HeadlessJsTaskSupport.notifyTaskFinished(taskId);
+      return;
     }
     taskProvider()(data)
       .then(() =>

--- a/Libraries/ReactNative/AppRegistry.js
+++ b/Libraries/ReactNative/AppRegistry.js
@@ -260,9 +260,7 @@ const AppRegistry = {
   startHeadlessTask(taskId: number, taskKey: string, data: any): void {
     const taskProvider = taskProviders.get(taskKey);
     if (!taskProvider) {
-      console.warn(
-        `No task registered for key ${taskKey}`,
-      );
+      console.warn(`No task registered for key ${taskKey}`);
       NativeModules.HeadlessJsTaskSupport.notifyTaskFinished(taskId);
       return;
     }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Start a `HeadlessJsTaskService` on Android without registered is dangerous on apps because `HeadlessJsTaskService` will acquire a [`PARTIAL_WAKE_LOCK`](https://developer.android.com/topic/performance/vitals/wakelock), without calling `onHeadlessJsTaskFinish` this lock won't release until timeout(if exist). This lock will prevent the android device from sleeping.

Although on JS will throw an error if no headless tasks registered, but it's hard to notice while app in the background. No visual information is displayed.

This PR will log a warning instead of Error, and just mark the task to finished on native if nothing registered in order to release the wake lock.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See http://facebook.github.io/react-native/docs/contributing#changelog for an example. -->

[Android] [Fixed] - Fix unexpected PARTIAL_WAKE_LOCK when no headless tasks registered.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

WIll add later.
