### PR TITLE
Use class canonical name for PARTIAL_WAKE_LOCK tag

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/HeadlessJsTaskService.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/HeadlessJsTaskService.java
@@ -75,7 +75,7 @@ public abstract class HeadlessJsTaskService extends Service implements HeadlessJ
         Assertions.assertNotNull((PowerManager) context.getSystemService(POWER_SERVICE));
       sWakeLock = powerManager.newWakeLock(
         PowerManager.PARTIAL_WAKE_LOCK,
-        HeadlessJsTaskService.class.getSimpleName());
+        HeadlessJsTaskService.class.getCanonicalName());
       sWakeLock.setReferenceCounted(false);
       sWakeLock.acquire();
     }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

When acquiring the `PARTIAL_WAKE_LOCK`, Android requires a tag to identify the source, normally the class name. This tag will show on dumpsys call and Google Play developer console.

`getSimpleName` will work fine as long as not enable ProGuard, in my case, it transformed the class name to just `"c"`, and I take my half day to find where the `c` comes from.

`getCanonicalName` will add the package path, which is more friendly for developers.

Later we can even let the developer choose the tag name, but this will require API break changes.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See http://facebook.github.io/react-native/docs/contributing#changelog for an example. -->

[Android] [Changed] - Use class canonical name for PARTIAL_WAKE_LOCK tag

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

N/A
