### PR TITLE
Update Android view state when accessibility states are changed.

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
@@ -146,11 +146,22 @@ public abstract class BaseViewManager<T extends View, C extends LayoutShadowNode
       return;
     }
     view.setTag(R.id.accessibility_states, accessibilityStates);
+    view.setSelected(false);
+    view.setEnabled(true);
+    boolean shouldUpdateContentDescription = false;
     for (int i = 0; i < accessibilityStates.size(); i++) {
       String state = accessibilityStates.getString(i);
       if (sStateDescription.containsKey(state)) {
-        updateViewContentDescription(view);
+	  shouldUpdateContentDescription = true;
       }
+      if (state.equals("selected")) {
+	  view.setSelected(true);
+      } else if (state.equals("disabled")) {
+	  view.setEnabled(false);
+      }
+    }
+    if (shouldUpdateContentDescription) {
+	updateViewContentDescription(view);
     }
   }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
@@ -152,16 +152,16 @@ public abstract class BaseViewManager<T extends View, C extends LayoutShadowNode
     for (int i = 0; i < accessibilityStates.size(); i++) {
       String state = accessibilityStates.getString(i);
       if (sStateDescription.containsKey(state)) {
-	  shouldUpdateContentDescription = true;
+        shouldUpdateContentDescription = true;
       }
       if (state.equals("selected")) {
-	  view.setSelected(true);
+        view.setSelected(true);
       } else if (state.equals("disabled")) {
-	  view.setEnabled(false);
+        view.setEnabled(false);
       }
     }
     if (shouldUpdateContentDescription) {
-	updateViewContentDescription(view);
+      updateViewContentDescription(view);
     }
   }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

#24095 introduced a regression in an internal test case. Without access to the test case code, my best guess is that the test instantiates a button, and sets its "disabled" state to true. In the original code, when the button is rendered, if "disabled" is true, "disabled" is added to the accessibility states of the button, which causes the Android view's enabled state to be set to false.

In #24095, we removed the code that changes the underlying Android view's enabled state to false when "disabled" is included in the accessibility states, which seems correct. The Android view's state shouldn't mirror the accessibility state, it should be the other way round-- the accessibility state should represent the state of the view.

It seems that the existing test is brokenly setting the disabled state in the Javascript object, and then querying the Android view's enabled state to confirm the change. If the Button implementation is actually the culprit, then IMHO, the correct fix would be to have the Button implementation manipulate the Android View's enabled state, not the accessibilityStates code.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog
[android] [fix] - Fix internal test case around disabled state of buttons

<!-- Help reviewers and the release process by writing your own changelog entry. See http://facebook.github.io/react-native/docs/contributing#changelog for an example. -->


## Test Plan

Verified that existing RNTester cases still work as expected.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
