### PR TITLE
Fix crash when `reactAccessibilityElement` is not a `RCTView`

### DIFF
--- a/React/Views/RCTViewManager.m
+++ b/React/Views/RCTViewManager.m
@@ -199,10 +199,13 @@ RCT_CUSTOM_VIEW_PROPERTY(accessibilityStates, NSArray<NSString *>, RCTView)
       [newStates addObject:state];
     }
   }
-  if (newStates.count > 0) {
-    ((RCTView *)view.reactAccessibilityElement).accessibilityStates = newStates;
-  } else {
+  
+  if ([view.reactAccessibilityElement isKindOfClass:[RCTView class]]) {
+    if (newStates.count > 0) {
+      ((RCTView *)view.reactAccessibilityElement).accessibilityStates = newStates;
+    } else {
       ((RCTView *)view.reactAccessibilityElement).accessibilityStates = nil;
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

React Native Gesture Handler uses a `RCTViewManager` subclass to manage `UIControl` so the cast there is not safe. Not sure if there is a better solution but this prevents the crash.

![image](https://user-images.githubusercontent.com/2677334/57042641-46e42700-6c33-11e9-9a97-76661ad5d14d.png)

## Changelog

[General] [Fixed] - Fix crash when `reactAccessibilityElement` is not a `RCTView`

## Test Plan

Tested that it fixes the crash