### PR TITLE
Update eslint-plugin-react-native dependency in eslint-config-react-native-community package

### DIFF
--- a/packages/eslint-config-react-native-community/package.json
+++ b/packages/eslint-config-react-native-community/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-native-community/eslint-config",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "ESLint config for React Native",
   "main": "index.js",
   "repository": {
@@ -17,7 +17,7 @@
     "eslint-plugin-prettier": "2.6.2",
     "eslint-plugin-react": "7.12.4",
     "eslint-plugin-react-hooks": "^1.5.1",
-    "eslint-plugin-react-native": "3.6.0",
+    "eslint-plugin-react-native": "3.7.0",
     "prettier": "1.16.4"
   },
   "peerDependencies": {

--- a/packages/eslint-config-react-native-community/package.json
+++ b/packages/eslint-config-react-native-community/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-native-community/eslint-config",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "ESLint config for React Native",
   "main": "index.js",
   "repository": {

--- a/packages/eslint-config-react-native-community/package.json
+++ b/packages/eslint-config-react-native-community/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-native-community/eslint-config",
-  "version": "0.0.6",
+  "version": "0.0.5",
   "description": "ESLint config for React Native",
   "main": "index.js",
   "repository": {

--- a/packages/eslint-config-react-native-community/yarn.lock
+++ b/packages/eslint-config-react-native-community/yarn.lock
@@ -365,10 +365,10 @@ eslint-plugin-react-native-globals@^0.1.1:
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-native-globals/-/eslint-plugin-react-native-globals-0.1.2.tgz#ee1348bc2ceb912303ce6bdbd22e2f045ea86ea2"
   integrity sha512-9aEPf1JEpiTjcFAmmyw8eiIXmcNZOqaZyHO77wgm0/dWfT/oxC1SrIq8ET38pMxHYrcB6Uew+TzUVsBeczF88g==
 
-eslint-plugin-react-native@3.6.0:
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react-native/-/eslint-plugin-react-native-3.6.0.tgz#7cad3b7c6159df6d26fe3252c6c5417a17f27b4b"
-  integrity sha512-BEQcHZ06hZSBYWFVuNEq0xuui5VEsWpHDsZGBtfadHfCRqRMUrkYPgdDb3bpc60qShHE83kqIv59uKdinEg91Q==
+eslint-plugin-react-native@3.7.0:
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-native/-/eslint-plugin-react-native-3.7.0.tgz#7e2cc1f3cf24919c4c0ea7fac13301e7444e105f"
+  integrity sha512-krLtQmGih/uJDPxF8DBpnU8J3kRUsDm/Dey5yEhOO8LN1I3Wesbk4PGCg8Zah57azKFU+9YtGooFjJcDJWUs+g==
   dependencies:
     eslint-plugin-react-native-globals "^0.1.1"
 


### PR DESCRIPTION
## Summary

I need this in my life because version 3.7.0 fixes [this](https://github.com/Intellicode/eslint-plugin-react-native/pull/220) issue.

## Changelog

[General][fixed] - Fix an issue with `no-raw-text` rule for TypeScript by updating the eslint-plugin-react-native dependency to 3.7.0

## Test Plan

Forking this repository, linking v3.7.0 inside and using it in my project fixed the issue. 
