### PR TITLE
[CI] Rename Detox job, collect all e2e steps under test_end_to_end

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -368,7 +368,7 @@ jobs:
 
       - run:
           name: Start Metro packager
-          command: yarn start --nonPersistent --max-workers=1 || echo "Can't start packager automatically"
+          command: yarn start --max-workers=1 || echo "Can't start packager automatically"
           background: true
 
       - run:
@@ -572,7 +572,7 @@ jobs:
       - run:
           name: Build JavaScript Bundle
           command: node cli.js bundle --max-workers 2 --platform android --dev true --entry-file ReactAndroid/src/androidTest/js/TestBundle.js --bundle-output ReactAndroid/src/androidTest/assets/AndroidTestBundle.js
-      
+
       # Wait for AVD to finish booting before running tests
       - run:
           name: Wait for Android Virtual Device

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -309,10 +309,6 @@ jobs:
           name: JavaScript Test Suite
           command: node ./scripts/run-ci-javascript-tests.js --maxWorkers 2
 
-      - run:
-          name: JavaScript End-to-End Test Suite
-          command: node ./scripts/run-ci-e2e-tests.js --js --retries 3
-
       - store_test_results:
           path: ~/react-native/reports/junit
 
@@ -453,15 +449,11 @@ jobs:
             # kill whatever is occupying port 5555 (web socket server)
             lsof -i tcp:5555 | awk 'NR!=1 {print $2}' | xargs kill
 
-      - run:
-          name: iOS End-to-End Test Suite
-          command: node ./scripts/run-ci-e2e-tests.js --ios --retries 3;
-
       - store_test_results:
           path: ~/react-native/reports/junit
 
-  # Runs end to end tests (Detox)
-  test_detox_end_to_end:
+  # Runs end-to-end tests
+  test_end_to_end:
     <<: *macos_defaults
     steps:
       - attach_workspace:
@@ -496,13 +488,25 @@ jobs:
 
       # Xcode build
       - run:
-          name: Build iOS app for simulator
+          name: Build app for Detox iOS End-to-End Tests
           command: yarn run build-ios-e2e
 
       # Test
       - run:
-          name: Run Detox Tests
+          name: Run Detox iOS End-to-End Tests
           command: yarn run test-ios-e2e
+          when: always
+
+      - run:
+          name: Run JavaScript End-to-End Tests
+          command: node ./scripts/run-ci-e2e-tests.js --js --retries 3
+          when: always
+
+      - run:
+          name: Run iOS End-to-End Tests
+          command: node ./scripts/run-ci-e2e-tests.js --ios --retries 3;
+          when: always
+
 
   # -------------------------
   #    JOBS: Test Android
@@ -707,7 +711,7 @@ workflows:
       - test_javascript: *run-after-checkout
       - test_android: *run-after-checkout
       - test_ios: *run-after-checkout
-      - test_detox_end_to_end: *run-after-checkout
+      - test_end_to_end: *run-after-checkout
       - test_docker_build:
           filters: *filter-ignore-gh-pages
 

--- a/scripts/run-ci-e2e-tests.js
+++ b/scripts/run-ci-e2e-tests.js
@@ -109,7 +109,12 @@ try {
     exitCode = 1;
     throw Error(exitCode);
   }
-  cp('metro.config.js', 'EndToEndTest/.');
+
+  const METRO_CONFIG = path.join(ROOT, 'metro.config.js');
+  const RN_POLYFILLS = path.join(ROOT, 'rn-get-polyfills.js');
+  cp(METRO_CONFIG, 'EndToEndTest/.');
+  cp(RN_POLYFILLS, 'EndToEndTest/.');
+
   cd('EndToEndTest');
   echo('Installing React Native package');
   exec(`npm install ${PACKAGE}`);
@@ -207,7 +212,7 @@ try {
     // shelljs exec('', {async: true}) does not emit stdout events, so we rely on good old spawn
     const packagerEnv = Object.create(process.env);
     packagerEnv.REACT_NATIVE_MAX_WORKERS = 1;
-    const packagerProcess = spawn('yarn', ['start', '--nonPersistent'], {
+    const packagerProcess = spawn('yarn', ['start'], {
       stdio: 'inherit',
       env: packagerEnv,
     });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Rename test_detox_end_to_end to test_end_to_end, then move JavaScript and iOS end-to-end tests to this job.

Fixes an issue in the end-to-end tests, but does not yet bring them back fully to green.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See http://facebook.github.io/react-native/docs/contributing#changelog for an example. -->

[General] [Changed] - Collect e2e tests under test_end_to_end job

## Test Plan

Circle CI. 
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->