### PR TITLE
Fix event ordering when combining coalescable and non-coalescable events

### DIFF
--- a/React/Base/RCTEventDispatcher.h
+++ b/React/Base/RCTEventDispatcher.h
@@ -35,6 +35,7 @@ RCT_EXTERN NSString *RCTNormalizeInputEventName(NSString *eventName);
 @protocol RCTEvent <NSObject>
 @required
 
+@property (nonatomic, strong, readonly) NSNumber *viewTag;
 @property (nonatomic, copy, readonly) NSString *eventName;
 
 - (BOOL)canCoalesce;
@@ -46,12 +47,6 @@ RCT_EXTERN NSString *RCTNormalizeInputEventName(NSString *eventName);
 - (NSArray *)arguments;
 
 @optional
-
-/**
- * Can be implemented for view based events that need to be coalesced
- * by it's viewTag.
- */
-@property (nonatomic, strong, readonly) NSNumber *viewTag;
 
 /**
  * Coalescing related methods must only be implemented if canCoalesce


### PR DESCRIPTION
## Summary

Fixes an issue introduced in https://github.com/facebook/react-native/pull/15894 that can cause events to be dispatched out of order.

Also reverted `viewTag` moved to optional property as it didn't actually work and makes code more complex.

## Changelog

[iOS] [Fixed] - Fix event ordering when combining coalescable and non-coalescable events

## Test Plan

Tested events still work, need to validate it fixes the crash seen @fb
