### PR TITLE
[iOS] Fixes selection of single line text input

### DIFF
--- a/Libraries/Text/TextInput/RCTBackedTextInputDelegateAdapter.m
+++ b/Libraries/Text/TextInput/RCTBackedTextInputDelegateAdapter.m
@@ -36,7 +36,7 @@ static void *TextFieldSelectionObservingContext = &TextFieldSelectionObservingCo
 
 - (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context
 {
-  // UITextField don't have delegate like UITextView to get notification when user do selection, here we use KVO to observe changes.
+  // UITextField doesn't have a delegate like UITextView to get notified on selection. Use KVO to observe changes.
   if ([keyPath isEqualToString:@"selectedTextRange"]) {
     [self textFieldProbablyDidChangeSelection];
   } else {

--- a/Libraries/Text/TextInput/RCTBackedTextInputDelegateAdapter.m
+++ b/Libraries/Text/TextInput/RCTBackedTextInputDelegateAdapter.m
@@ -28,15 +28,27 @@ static void *TextFieldSelectionObservingContext = &TextFieldSelectionObservingCo
 
     [_backedTextInputView addTarget:self action:@selector(textFieldDidChange) forControlEvents:UIControlEventEditingChanged];
     [_backedTextInputView addTarget:self action:@selector(textFieldDidEndEditingOnExit) forControlEvents:UIControlEventEditingDidEndOnExit];
+    [_backedTextInputView addObserver:self forKeyPath:@"selectedTextRange" options:NSKeyValueObservingOptionNew context:NULL];
   }
 
   return self;
+}
+
+- (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context
+{
+  // UITextField don't have delegate like UITextView to get notification when user do selection, here we use KVO to observe changes.
+  if ([keyPath isEqualToString:@"selectedTextRange"]) {
+    [self textFieldProbablyDidChangeSelection];
+  } else {
+    [super observeValueForKeyPath:keyPath ofObject:object change:change context:context];
+  }
 }
 
 - (void)dealloc
 {
   [_backedTextInputView removeTarget:self action:nil forControlEvents:UIControlEventEditingChanged];
   [_backedTextInputView removeTarget:self action:nil forControlEvents:UIControlEventEditingDidEndOnExit];
+  [_backedTextInputView removeObserver:self forKeyPath:@"selectedTextRange"];
 }
 
 #pragma mark - UITextFieldDelegate


### PR DESCRIPTION
## Summary

`UITextField` don't have delegate to observe the selection changes of users(multiline text input `UITextView` have it), so we can add a KVO to observe selection changes.

@cpojer @shergin 

## Changelog

[iOS] [Fixed] - Fixes selection of single line text input

## Test Plan

Create a single line textInput, then do some selection, `onSelectionChange` can be called.