### PR TITLE
onKeyPress is not fired on Android when entering an Emoji 

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditTextInputConnectionWrapper.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditTextInputConnectionWrapper.java
@@ -113,9 +113,13 @@ class ReactEditTextInputConnectionWrapper extends InputConnectionWrapper {
       if (key.equals("")) {
         key = BACKSPACE_KEY_VALUE;
       }
+
       dispatchKeyEventOrEnqueue(key);
     }
-
+    // Detect, if text is unicode
+    if (key.length() == 2) {
+        dispatchKeyEventOrEnqueue(key);
+    }
     return super.commitText(text, newCursorPosition);
   }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditTextInputConnectionWrapper.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditTextInputConnectionWrapper.java
@@ -108,17 +108,13 @@ class ReactEditTextInputConnectionWrapper extends InputConnectionWrapper {
   @Override
   public boolean commitText(CharSequence text, int newCursorPosition) {
     String key = text.toString();
-    // Assume not a keyPress if length > 1
-    if (key.length() <= 1) {
+    // Assume not a keyPress if length > 1 (or 2 if unicode)
+    if (key.length() <= 2) {
       if (key.equals("")) {
         key = BACKSPACE_KEY_VALUE;
       }
 
       dispatchKeyEventOrEnqueue(key);
-    }
-    // Detect, if text is unicode
-    if (key.length() == 2) {
-        dispatchKeyEventOrEnqueue(key);
     }
     return super.commitText(text, newCursorPosition);
   }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditTextInputConnectionWrapper.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditTextInputConnectionWrapper.java
@@ -113,9 +113,9 @@ class ReactEditTextInputConnectionWrapper extends InputConnectionWrapper {
       if (key.equals("")) {
         key = BACKSPACE_KEY_VALUE;
       }
-
       dispatchKeyEventOrEnqueue(key);
     }
+
     return super.commitText(text, newCursorPosition);
   }
 


### PR DESCRIPTION
## Summary
Resolve #24690

## Question
This is very simple unicode detecting. Should I improve this solution creating StringsUtils for detecting unicodes in whole react-native project ? 

## Changelog
[Android][Fixed] onKeyPress method is calling, when user type emoji  

## Test Plan
* Run RNTester 
* Click on Cell with TextInput title 
* Go to Event handling section 
* Type emoji and check, if onKeyPress method is calling 