### PR TITLE
[General] fixes fetch module credentials

### DIFF
--- a/Libraries/vendor/core/whatwg-fetch.js
+++ b/Libraries/vendor/core/whatwg-fetch.js
@@ -384,7 +384,7 @@
       this.url = String(input);
     }
 
-    this.credentials = options.credentials || this.credentials || 'omit';
+    this.credentials = options.credentials || this.credentials || 'same-origin';
     if (options.headers || !this.headers) {
       this.headers = new Headers(options.headers);
     }
@@ -510,10 +510,10 @@
 
       xhr.open(request.method, request.url, true);
 
-      if (request.credentials === 'include') {
-        xhr.withCredentials = true;
-      } else if (request.credentials === 'omit') {
+      if (request.credentials === 'omit') {
         xhr.withCredentials = false;
+      } else {
+        xhr.withCredentials = true;
       }
 
       if ('responseType' in xhr && support.blob) {


### PR DESCRIPTION
## Summary

In https://github.com/facebook/react-native/issues/14063, we decided to set `withCredential` to `true` by default, now if we use `XMLHttpRequest`, it works, but for fetch polyfill, `withCredential` is be set to `false` because we use `Request`'s credentials https://github.com/facebook/react-native/blob/master/Libraries/vendor/core/whatwg-fetch.js#L515.

So we have inconsistency about  `withCrendential`. My fix is to change `Request` `credentials` default value to `same-origin`, it reasonable because refer to [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials), the default value is `same-origin`.

cc. @cpojer.

## Changelog

[General] [Fixed] - fixes fetch module credentials

## Test Plan

For any request from either XMLHttpRequest or fetch, we set `withCredential` to true by default.