### PR TITLE
[iOS] Introduce TurboModule Setup Metric

### DIFF
--- a/React/Base/RCTBridge.h
+++ b/React/Base/RCTBridge.h
@@ -49,7 +49,7 @@ RCT_EXTERN NSString *const RCTJavaScriptDidFailToLoadNotification;
 RCT_EXTERN NSString *const RCTDidInitializeModuleNotification;
 
 /**
- * This notification fires each time a native module is setup after it is initialized. The
+ * This notification fires each time a module is setup after it is initialized. The
  * `RCTDidSetupModuleNotificationModuleNameKey` key will contain a reference to the module name and
  * `RCTDidSetupModuleNotificationSetupTimeKey` will contain the setup time in ms.
  */

--- a/React/Base/RCTPerformanceLogger.h
+++ b/React/Base/RCTPerformanceLogger.h
@@ -21,6 +21,7 @@ typedef NS_ENUM(NSUInteger, RCTPLTag) {
   RCTPLNativeModulePrepareConfig,
   RCTPLNativeModuleMainThreadUsesCount,
   RCTPLNativeModuleSetup,
+  RCTPLTurboModuleSetup,
   RCTPLJSCWrapperOpenLibrary,
   RCTPLBridgeStartup,
   RCTPLTTI,

--- a/React/Base/RCTPerformanceLogger.m
+++ b/React/Base/RCTPerformanceLogger.m
@@ -42,6 +42,7 @@
       @"NativeModuleInjectConfig",
       @"NativeModuleMainThreadUsesCount",
       @"NativeModuleSetup",
+      @"TurboModuleSetup",
       @"JSCWrapperOpenLibrary",
       @"JSCExecutorSetup",
       @"BridgeStartup",

--- a/ReactCommon/turbomodule/core/platform/ios/RCTTurboModuleManager.mm
+++ b/ReactCommon/turbomodule/core/platform/ios/RCTTurboModuleManager.mm
@@ -10,6 +10,7 @@
 #import <cassert>
 
 #import <React/RCTBridge+Private.h>
+#import <React/RCTPerformanceLogger.h>
 #import <React/RCTBridgeModule.h>
 #import <React/RCTCxxModule.h>
 #import <React/RCTLog.h>
@@ -67,17 +68,43 @@ static Class getFallbackClassFromName(const char *name) {
 
       __strong __typeof(self) strongSelf = weakSelf;
 
+      auto moduleName = name.c_str();
+      auto moduleWasNotInitialized = ![strongSelf moduleIsInitialized:moduleName];
+      if (moduleWasNotInitialized) {
+        [strongSelf->_bridge.performanceLogger markStartForTag:RCTPLTurboModuleSetup];
+      }
+
       /**
        * By default, all TurboModules are long-lived.
        * Additionally, if a TurboModule with the name `name` isn't found, then we
        * trigger an assertion failure.
        */
-      return [strongSelf provideTurboModule: name.c_str()];
+      auto turboModule = [strongSelf provideTurboModule:moduleName];
+
+      if (moduleWasNotInitialized && [strongSelf moduleIsInitialized:moduleName]) {
+        [strongSelf->_bridge.performanceLogger markStopForTag:RCTPLTurboModuleSetup];
+        [strongSelf notifyAboutTurboModuleSetup:moduleName];
+      }
+
+      return turboModule;
     };
 
     _binding = std::make_shared<react::TurboModuleBinding>(moduleProvider);
   }
   return self;
+}
+
+- (void)notifyAboutTurboModuleSetup:(const char*)name {
+    NSString *moduleName = [[NSString alloc] initWithUTF8String:name];
+    if (moduleName) {
+      int64_t setupTime = [self->_bridge.performanceLogger durationForTag:RCTPLTurboModuleSetup];
+      [[NSNotificationCenter defaultCenter] postNotificationName:RCTDidSetupModuleNotification
+                                                          object:nil
+                                                        userInfo:@{
+                                                                  RCTDidSetupModuleNotificationModuleNameKey: moduleName,
+                                                                  RCTDidSetupModuleNotificationSetupTimeKey: @(setupTime)
+                                                                  }];
+    }
 }
 
 /**


### PR DESCRIPTION
## Summary

With the introduction of TurboModules, it would be beneficial to measure the setup time of these modules, as we currently have it in place for NativeModules.

The instantiation of the TMs occurs in the `RCTTurboModuleManager`. In order to successfully measure the time it took to setup the module, we need to ensure that we don't take into account cached modules. As such, we need to:

1. Check if module is in `_turboModuleCache`
  a. Start mark for `RCTPLTurboModuleSetup` tag if not found
2. Get the TM via `[self provideTurboModule:]`
3. Check if module is in `_turboModuleCache`
   a. Stop mark for `RCTPLTurboModuleSetup` if we did not find module in cache prior to **step 2** and if it's now present in the cache.
   b. Notify about setup time if the above is true.
4. Return TM

## Changelog

[iOS] [Added] - Gain insights on the the turbo module setup times by observing `RCTDidSetupModuleNotification`. The userInfo dictionary will contain the module name and setup time in milliseconds. These values can be extracted via `RCTDidSetupModuleNotificationModuleNameKey` and `RCTDidSetupModuleNotificationSetupTimeKey`. 

## Test Plan

Observe for `RCTDidSetupModuleNotification `

```objc
- (void)setup {
    [_notificationCenter addObserver:self
                            selector:@selector(didSetupModule:)
                                name:RCTDidSetupModuleNotification
                              object:nil];
}

- (void)didSetupModule:(NSNotification *)notification {
    NSDictionary *userInfo = notification.userInfo;
    if (userInfo) {
        NSString *moduleName = userInfo[RCTDidSetupModuleNotificationModuleNameKey];
        NSNumber *setupTime = userInfo[RCTDidSetupModuleNotificationSetupTimeKey];
        NSLog(@"%@ setup took %li ms", moduleName, [setupTime integerValue]);
    }
}
```

### Output
```
TestTurboModule setup took 1 ms
```