### PR TITLE
Adjust scrollToLocation when using sticky section headers

### DIFF
--- a/Libraries/Lists/VirtualizedSectionList.js
+++ b/Libraries/Lists/VirtualizedSectionList.js
@@ -157,8 +157,8 @@ class VirtualizedSectionList<
       viewOffset = frame.length;
     }
     const toIndexParams = {
-      viewOffset,
       ...params,
+      viewOffset,
       index,
     };
     this._listRef.scrollToIndex(toIndexParams);

--- a/Libraries/Lists/VirtualizedSectionList.js
+++ b/Libraries/Lists/VirtualizedSectionList.js
@@ -149,7 +149,15 @@ class VirtualizedSectionList<
     for (let i = 0; i < params.sectionIndex; i++) {
       index += this.props.getItemCount(this.props.sections[i].data) + 2;
     }
+    let viewOffset = 0;
+    if (params.itemIndex > 0 && this.props.stickySectionHeadersEnabled) {
+      const frame = this._listRef._getFrameMetricsApprox(
+        index - params.itemIndex,
+      );
+      viewOffset = frame.length;
+    }
     const toIndexParams = {
+      viewOffset,
       ...params,
       index,
     };


### PR DESCRIPTION
## Summary

When using `scrollToLocation` together with `stickySectionHeadersEnabled` in a `SectionList`, the length of the section header is not accounted for when scrolling to any item except the header.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See http://facebook.github.io/react-native/docs/contributing#changelog for an example. -->

[General] [Fixed] - Adjust scrollToLocation when using sticky section headers

## Test Plan

Use any filled `SectionList` and call:
```
scrollToLocation({
  animated: true,
  itemIndex: 1,
  sectionIndex: 0,
});
```
Notice how the first item is not completely visible, it is partially covered by the section header. After this PR, the first item will be fully visible.

Before:

![Simulator Screen Shot - iPhone SE - 2019-05-07 at 15 02 11](https://user-images.githubusercontent.com/996231/57301477-71256100-70d9-11e9-8b63-3cdc0592c03a.png)

After:

![Simulator Screen Shot - iPhone SE - 2019-05-07 at 15 02 52](https://user-images.githubusercontent.com/996231/57301481-75517e80-70d9-11e9-87a7-13396782cb17.png)
