### PR TITLE
Fix RNTester on iOS

### DIFF
--- a/RNTester/RNTester/AppDelegate.mm
+++ b/RNTester/RNTester/AppDelegate.mm
@@ -110,7 +110,8 @@
 - (NSURL *)sourceURLForBridge:(__unused RCTBridge *)bridge
 {
   NSString *bundlePrefix = @"";
-  if (getenv("CI_USE_BUNDLE_PREFIX")) {
+  NSString *usePrefix = @(getenv("CI_USE_BUNDLE_PREFIX"));
+  if (usePrefix && ![usePrefix isEqualToString:@"0"]) {
     bundlePrefix = @"react-native-github/";
   }
   NSString *bundleRoot = [NSString stringWithFormat:@"%@RNTester/js/RNTesterApp.ios", bundlePrefix];

--- a/RNTester/RNTesterIntegrationTests/RCTLoggingTests.m
+++ b/RNTester/RNTesterIntegrationTests/RCTLoggingTests.m
@@ -31,7 +31,8 @@
   NSURL *scriptURL;
   if (getenv("CI_USE_PACKAGER")) {
     NSString *bundlePrefix = @"";
-    if (getenv("CI_USE_BUNDLE_PREFIX")) {
+    NSString *usePrefix = @(getenv("CI_USE_BUNDLE_PREFIX"));
+    if (usePrefix && ![usePrefix isEqualToString:@"0"]) {
       bundlePrefix = @"react-native-github/";
     }
     NSString *app = @"IntegrationTests/IntegrationTestsApp";


### PR DESCRIPTION
## Summary
See e94b116d7675399af719ac58e36d3274a23feea4 which broke RNTester in open source. Environment variables are always strings, so "0" is a truthy value. This fixes it.

## Changelog

[iOS] [fixed] - Fixed broken RNTester

## Test Plan

Build RNTester with the env variable set to "0" and see it work in open source. Change to "1" and it breaks in open source (as expected).