### PR TITLE
Fix DatePickerAndroid with mode spinner on Android Nougat(7.0)

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/modules/datepicker/DismissableDatePickerDialog.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/datepicker/DismissableDatePickerDialog.java
@@ -8,11 +8,15 @@
 package com.facebook.react.modules.datepicker;
 
 import android.app.DatePickerDialog;
-import javax.annotation.Nullable;
-
-import android.app.DatePickerDialog;
 import android.content.Context;
 import android.os.Build;
+import android.content.res.TypedArray;
+import android.util.AttributeSet;
+import android.widget.DatePicker;
+
+import javax.annotation.Nullable;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 
 /**
  * <p>
@@ -33,6 +37,7 @@ public class DismissableDatePickerDialog extends DatePickerDialog {
       int monthOfYear,
       int dayOfMonth) {
     super(context, callback, year, monthOfYear, dayOfMonth);
+    fixSpinner(context, year, monthOfYear, dayOfMonth);
   }
 
   public DismissableDatePickerDialog(
@@ -43,6 +48,7 @@ public class DismissableDatePickerDialog extends DatePickerDialog {
       int monthOfYear,
       int dayOfMonth) {
     super(context, theme, callback, year, monthOfYear, dayOfMonth);
+    fixSpinner(context, year, monthOfYear, dayOfMonth);
   }
 
   @Override
@@ -52,5 +58,66 @@ public class DismissableDatePickerDialog extends DatePickerDialog {
     if (Build.VERSION.SDK_INT > Build.VERSION_CODES.KITKAT) {
       super.onStop();
     }
+  }
+
+  private void fixSpinner(Context context, int year, int month, int dayOfMonth) {
+    if (Build.VERSION.SDK_INT == Build.VERSION_CODES.N) {
+      try {
+        // Get the theme's android:datePickerMode
+        final int MODE_SPINNER = 2;
+        Class<?> styleableClass = Class.forName("com.android.internal.R$styleable");
+        Field datePickerStyleableField = styleableClass.getField("DatePicker");
+        int[] datePickerStyleable = (int[]) datePickerStyleableField.get(null);
+
+        final TypedArray a = context.obtainStyledAttributes(null, datePickerStyleable, android.R.attr.datePickerStyle, 0);
+        Field datePickerModeStyleableField = styleableClass.getField("DatePicker_datePickerMode");
+        int datePickerModeStyleable = datePickerModeStyleableField.getInt(null);
+        final int mode = a.getInt(datePickerModeStyleable, MODE_SPINNER);
+        a.recycle();
+
+        if (mode == MODE_SPINNER) {
+          DatePicker datePicker = (DatePicker) findField(DatePickerDialog.class, DatePicker.class, "mDatePicker").get(this);
+          Class<?> delegateClass = Class.forName("android.widget.DatePickerSpinnerDelegate");
+          Field delegateField = findField(DatePicker.class, delegateClass, "mDelegate");
+          Object delegate = delegateField.get(datePicker);
+          Class<?> spinnerDelegateClass;
+          spinnerDelegateClass = Class.forName("android.widget.DatePickerSpinnerDelegate");
+
+          // In 7.0 Nougat for some reason the datePickerMode is ignored and the delegate is DatePickerClockDelegate
+          if (delegate.getClass() != spinnerDelegateClass) {
+            delegateField.set(datePicker, null); // throw out the DatePickerClockDelegate!
+            datePicker.removeAllViews(); // remove the DatePickerClockDelegate views
+            Method createSpinnerUIDelegate = DatePicker.class.getDeclaredMethod("createSpinnerUIDelegate", Context.class, AttributeSet.class, int.class, int.class);
+            createSpinnerUIDelegate.setAccessible(true);
+
+            // Instantiate a DatePickerSpinnerDelegate throughout createSpinnerUIDelegate method
+            delegate = createSpinnerUIDelegate.invoke(datePicker, context, null, android.R.attr.datePickerStyle, 0);
+            delegateField.set(datePicker, delegate); // set the DatePicker.mDelegate to the spinner delegate
+            datePicker.setCalendarViewShown(false);
+            // Initialize the date for the DatePicker delegate again
+            datePicker.init(year, month, dayOfMonth, this);
+          }
+        }
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    }
+  }
+
+  private static Field findField(Class objectClass, Class fieldClass, String expectedName) {
+    try {
+      Field field = objectClass.getDeclaredField(expectedName);
+      field.setAccessible(true);
+      return field;
+    } catch (NoSuchFieldException e) {
+    } // ignore
+    // search for it if it wasn't found under the expected ivar name
+    for (Field searchField : objectClass.getDeclaredFields()) {
+      if (searchField.getType() == fieldClass) {
+        searchField.setAccessible(true);
+        return searchField;
+      }
+    }
+    return null;
   }
 }


### PR DESCRIPTION
When mode is spinner in Android Nougat the DatePicker shows calendar

## Summary

I got it from https://gist.github.com/jeffdgr8/6bc5f990bf0c13a7334ce385d482af9f and
did some adjustments in order to work with `DatePicker`. Workaround for this bug: https://code.google.com/p/android/issues/detail?id=222208. In Android 7.0 Nougat, spinner mode for the DatePicker in DatePickerDialog is incorrectly displayed as calendar.

## Changelog

[Android][Fixed] Fix date picker with mode spinner on Android Nougat (7.0)

## Test Plan

Run RNTester with Simulator that has Android Nougat (7.0)
Search DatePickerAndroid
Click in Simple spinner date picker

![datepicker_android](https://user-images.githubusercontent.com/7242605/57305673-d5372d80-70b7-11e9-8045-6227fda676eb.png)

