### PR TITLE
bump react-native-android docker image to 2019-5-7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,7 +157,7 @@ js_defaults: &js_defaults
 android_defaults: &android_defaults
   <<: *defaults
   docker:
-    - image: reactnativecommunity/react-native-android:2019-1-19
+    - image: reactnativecommunity/react-native-android:2019-5-7
   resource_class: "large"
   environment:
     - TERM: "dumb"


### PR DESCRIPTION
## Summary

Bump react-native-android Docker image used to 2019-5-7, which contains Buck v2019.05.06.01.

## Changelog

[CI] [Changed] - Bump react-native-android Docker image used to 2019-5-7, which contains Buck v2019.05.06.01

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
