### PR TITLE
Move accessibility props to UIView+React

### DIFF
--- a/React/Views/RCTView.h
+++ b/React/Views/RCTView.h
@@ -29,13 +29,6 @@ extern const UIAccessibilityTraits SwitchAccessibilityTrait;
 @property (nonatomic, copy) RCTDirectEventBlock onAccessibilityEscape;
 
 /**
- * Accessibility properties
- */
-@property (nonatomic, copy) NSArray <NSString *> *accessibilityActions;
-@property (nonatomic, copy) NSString *accessibilityRole;
-@property (nonatomic, copy) NSArray <NSString *> *accessibilityStates;
-
-/**
  * Used to control how touch events are processed.
  */
 @property (nonatomic, assign) RCTPointerEvents pointerEvents;

--- a/React/Views/RCTView.m
+++ b/React/Views/RCTView.m
@@ -158,12 +158,12 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:unused)
 
 - (NSArray <UIAccessibilityCustomAction *> *)accessibilityCustomActions
 {
-  if (!_accessibilityActions.count) {
+  if (!self.accessibilityActions.count) {
     return nil;
   }
 
   NSMutableArray *actions = [NSMutableArray array];
-  for (NSString *action in _accessibilityActions) {
+  for (NSString *action in self.accessibilityActions) {
     [actions addObject:[[UIAccessibilityCustomAction alloc] initWithName:action
                                                                   target:self
                                                                 selector:@selector(didActivateAccessibilityCustomAction:)]];
@@ -189,7 +189,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:unused)
 - (NSString *)accessibilityValue
 {
   if ((self.accessibilityTraits & SwitchAccessibilityTrait) == SwitchAccessibilityTrait) {
-    for (NSString *state in _accessibilityStates) {
+    for (NSString *state in self.accessibilityStates) {
       if ([state isEqualToString:@"checked"]) {
         return @"1";
       } else if ([state isEqualToString:@"unchecked"]) {
@@ -231,11 +231,11 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:unused)
                           @"collapsed" : @"collapsed",
                           };
   });
-  NSString *roleDescription = _accessibilityRole ? roleDescriptions[_accessibilityRole]: nil;
+  NSString *roleDescription = self.accessibilityRole ? roleDescriptions[self.accessibilityRole]: nil;
   if (roleDescription) {
     [valueComponents addObject:roleDescription];
   }
-  for (NSString *state in _accessibilityStates) {
+  for (NSString *state in self.accessibilityStates) {
     NSString *stateDescription = state ? stateDescriptions[state] : nil;
     if (stateDescription) {
       [valueComponents addObject:stateDescription];

--- a/React/Views/RCTViewManager.m
+++ b/React/Views/RCTViewManager.m
@@ -174,7 +174,7 @@ RCT_CUSTOM_VIEW_PROPERTY(accessibilityRole, UIAccessibilityTraits, RCTView)
     view.reactAccessibilityElement.accessibilityTraits |= maskedTraits;
   } else {
     NSString *role = json ? [RCTConvert NSString:json] : @"";
-    ((RCTView *)view.reactAccessibilityElement).accessibilityRole = role;
+    view.reactAccessibilityElement.accessibilityRole = role;
   }
 }
 

--- a/React/Views/RCTViewManager.m
+++ b/React/Views/RCTViewManager.m
@@ -200,9 +200,9 @@ RCT_CUSTOM_VIEW_PROPERTY(accessibilityStates, NSArray<NSString *>, RCTView)
     }
   }
   if (newStates.count > 0) {
-    ((RCTView *)view.reactAccessibilityElement).accessibilityStates = newStates;
+    view.reactAccessibilityElement.accessibilityStates = newStates;
   } else {
-      ((RCTView *)view.reactAccessibilityElement).accessibilityStates = nil;
+    view.reactAccessibilityElement.accessibilityStates = nil;
   }
 }
 

--- a/React/Views/UIView+React.h
+++ b/React/Views/UIView+React.h
@@ -114,6 +114,13 @@
 @property (nonatomic, readonly) UIView *reactAccessibilityElement;
 
 /**
+ * Accessibility properties
+ */
+@property (nonatomic, copy) NSArray <NSString *> *accessibilityActions;
+@property (nonatomic, copy) NSString *accessibilityRole;
+@property (nonatomic, copy) NSArray <NSString *> *accessibilityStates;
+
+/**
  * Used in debugging to get a description of the view hierarchy rooted at
  * the current view.
  */

--- a/React/Views/UIView+React.m
+++ b/React/Views/UIView+React.m
@@ -297,6 +297,36 @@
   return self;
 }
 
+- (NSArray<NSString *> *)accessibilityActions
+{
+  return objc_getAssociatedObject(self, _cmd);
+}
+
+- (void)setAccessibilityActions:(NSArray<NSString *> *)accessibilityActions
+{
+  objc_setAssociatedObject(self, @selector(accessibilityActions), accessibilityActions, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
+- (NSString *)accessibilityRole
+{
+  return objc_getAssociatedObject(self, _cmd);
+}
+
+- (void)setAccessibilityRole:(NSString *)accessibilityRole
+{
+  objc_setAssociatedObject(self, @selector(accessibilityRole), accessibilityRole, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
+- (NSArray<NSString *> *)accessibilityStates
+{
+  return objc_getAssociatedObject(self, _cmd);
+}
+
+- (void)setAccessibilityStates:(NSArray<NSString *> *)accessibilityStates
+{
+  objc_setAssociatedObject(self, @selector(accessibilityStates), accessibilityStates, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
 #pragma mark - Debug
 
 - (void)react_addRecursiveDescriptionToString:(NSMutableString *)string atLevel:(NSUInteger)level


### PR DESCRIPTION
## Summary

React Native Gesture Handler uses a `RCTViewManager` subclass to manage `UIControl` so the cast to set accessibility props is not safe. This moves the accessibility props we set to `UIView+React` so they can be used safely on any `UIView`.

![image](https://user-images.githubusercontent.com/2677334/57042641-46e42700-6c33-11e9-9a97-76661ad5d14d.png)

## Changelog

[General] [Fixed] - Move accessibility props to UIView+React

## Test Plan

Tested that it fixes the crash and that RNTester accessibility examples still work.