### PR TITLE
[CI] [Dangerfile] Add Internal and JavaScript categories

### DIFF
--- a/bots/dangerfile.js
+++ b/bots/dangerfile.js
@@ -55,7 +55,7 @@ if (!includesTestPlan) {
 }
 
 // Regex looks for given categories, types, a file/framework/component, and a message - broken into 4 capture groups
-const changelogRegex = /\[\s?(ANDROID|GENERAL|IOS)\s?\]\s*?\[\s?(ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY)\s?\]\s*?\-?\s*?(.*)/gi;
+const changelogRegex = /\[\s?(ANDROID|GENERAL|IOS|JS|JAVASCRIPT|INTERNAL)\s?\]\s*?\[\s?(ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY)\s?\]\s*?\-?\s*?(.*)/gi;
 const includesChangelog =
   danger.github.pr.body &&
   (danger.github.pr.body.toLowerCase().includes('## changelog') ||
@@ -64,7 +64,7 @@ const correctlyFormattedChangelog = changelogRegex.test(danger.github.pr.body);
 
 // Provides advice if a changelog is missing
 const changelogInstructions =
-  'A changelog entry has the following format: `[CATEGORY] [TYPE] - Message`.\n\n<details>CATEGORY may be:\n\n- General\n- iOS\n- Android\n\nTYPE may be:\n\n- Added, for new features.\n- Changed, for changes in existing functionality.\n- Deprecated, for soon-to-be removed features.\n- Removed, for now removed features.\n- Fixed, for any bug fixes.\n- Security, in case of vulnerabilities.\n\nMESSAGE may answer "what and why" on a feature level.   Use this to briefly tell React Native users about notable changes.</details>';
+  'A changelog entry has the following format: `[CATEGORY] [TYPE] - Message`.\n\n<details>CATEGORY may be:\n\n- General\n- iOS\n- Android\n- JavaScript\n- Internal (for changes that do not need to be called out in the release notes)\n\nTYPE may be:\n\n- Added, for new features.\n- Changed, for changes in existing functionality.\n- Deprecated, for soon-to-be removed features.\n- Removed, for now removed features.\n- Fixed, for any bug fixes.\n- Security, in case of vulnerabilities.\n\nMESSAGE may answer "what and why" on a feature level.   Use this to briefly tell React Native users about notable changes.</details>';
 if (!includesChangelog) {
   const title = ':clipboard: Missing Changelog';
   const idea =
@@ -73,8 +73,8 @@ if (!includesChangelog) {
     changelogInstructions;
   message(`${title} - <i>${idea}</i>`);
 } else if (!correctlyFormattedChangelog) {
-  const title = ':clipboard: Changelog Format';
-  const idea = 'Did you include a Changelog? ' + changelogInstructions;
+  const title = ':clipboard: Verify Changelog Format';
+  const idea = changelogInstructions;
   message(`${title} - <i>${idea}</i>`);
 }
 


### PR DESCRIPTION
## Summary

So far we have only officially supported "iOS" and "Android" as categories, with a "General" catch all for everything else.
Let's add a "JavaScript" category for changes that only affect JavaScript, and an "Internal" category for things that do not make sense in a changelog (e.g. CI changes).


<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->


<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See http://facebook.github.io/react-native/docs/contributing#changelog for an example. -->

[Internal] [Added] - Added JavaScript and Internal categories to changelog regex


## Test Plan

Verified regexp matches the changelog in this PR.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->