### PR TITLE
[Android][A11y] AccessibilityInfo.announceForAccessibility

### DIFF
--- a/Libraries/Components/AccessibilityInfo/AccessibilityInfo.android.js
+++ b/Libraries/Components/AccessibilityInfo/AccessibilityInfo.android.js
@@ -135,6 +135,15 @@ const AccessibilityInfo = {
       UIManager.AccessibilityEventTypes.typeViewFocused,
     );
   },
+
+  /**
+   * Post a string to be announced by the screen reader.
+   *
+   * See http://facebook.github.io/react-native/docs/accessibilityinfo.html#announceforaccessibility
+   */
+  announceForAccessibility: function(announcement: string): void {
+    RCTAccessibilityInfo.announceForAccessibility(announcement);
+  },
 };
 
 module.exports = AccessibilityInfo;

--- a/Libraries/Components/AccessibilityInfo/AccessibilityInfo.ios.js
+++ b/Libraries/Components/AccessibilityInfo/AccessibilityInfo.ios.js
@@ -210,8 +210,6 @@ const AccessibilityInfo = {
   /**
    * Post a string to be announced by the screen reader.
    *
-   * @platform ios
-   *
    * See http://facebook.github.io/react-native/docs/accessibilityinfo.html#announceforaccessibility
    */
   announceForAccessibility: function(announcement: string): void {

--- a/RNTester/js/AccessibilityExample.js
+++ b/RNTester/js/AccessibilityExample.js
@@ -452,9 +452,9 @@ class ScreenReaderStatusExample extends React.Component<{}> {
   }
 }
 
-
 class AnnounceForAccessibility extends React.Component<{}> {
-  _handleOnPress = () => AccessibilityInfo.announceForAccessibility('Announcement Test')
+  _handleOnPress = () =>
+    AccessibilityInfo.announceForAccessibility('Announcement Test');
 
   render() {
     return (
@@ -464,7 +464,7 @@ class AnnounceForAccessibility extends React.Component<{}> {
           title="Announce for Accessibility"
         />
       </View>
-    )
+    );
   }
 }
 

--- a/RNTester/js/AccessibilityExample.js
+++ b/RNTester/js/AccessibilityExample.js
@@ -452,6 +452,22 @@ class ScreenReaderStatusExample extends React.Component<{}> {
   }
 }
 
+
+class AnnounceForAccessibility extends React.Component<{}> {
+  _handleOnPress = () => AccessibilityInfo.announceForAccessibility('Announcement Test')
+
+  render() {
+    return (
+      <View>
+        <Button
+          onPress={this._handleOnPress}
+          title="Announce for Accessibility"
+        />
+      </View>
+    )
+  }
+}
+
 exports.title = 'Accessibility';
 exports.description = 'Examples of using Accessibility APIs.';
 exports.examples = [
@@ -471,6 +487,12 @@ exports.examples = [
     title: 'Check if the screen reader is enabled',
     render(): React.Element<typeof ScreenReaderStatusExample> {
       return <ScreenReaderStatusExample />;
+    },
+  },
+  {
+    title: 'Check if the screen reader announces',
+    render(): React.Element<typeof AnnounceForAccessibility> {
+      return <AnnounceForAccessibility />;
     },
   },
 ];

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/accessibilityinfo/AccessibilityInfoModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/accessibilityinfo/AccessibilityInfoModule.java
@@ -16,6 +16,7 @@ import android.os.Build;
 import android.os.Handler;
 import android.os.Looper;
 import android.provider.Settings;
+import android.view.accessibility.AccessibilityEvent;
 import android.view.accessibility.AccessibilityManager;
 
 import com.facebook.react.bridge.Callback;
@@ -169,5 +170,19 @@ public class AccessibilityInfoModule extends ReactContextBaseJavaModule
 
     @Override
     public void onHostDestroy() {
+    }
+
+    @ReactMethod
+    public void announceForAccessibility(String message) {
+        if (mAccessibilityManager == null || !mAccessibilityManager.isEnabled()) {
+            return;
+        }
+
+        AccessibilityEvent event = AccessibilityEvent.obtain(AccessibilityEvent.TYPE_ANNOUNCEMENT);
+        event.getText().add(message);
+        event.setClassName(AccessibilityInfoModule.class.getName());
+        event.setPackageName(getReactApplicationContext().getPackageName());
+
+        mAccessibilityManager.sendAccessibilityEvent(event);
     }
 }


### PR DESCRIPTION
## Summary

AccessibilityInfo.announceForAccessibility is currently only available on iOS. I've added the Android specific implementation, updated RNTester, and the documentation.

## Changelog

[Android] [Added] - Added AccessibilityInfo.announceForAccessibility for Android
[General] [Added] - RNTester example for AccessibilityInfo.announceForAccessibility

## Test Plan

- Created a new example in the RNTester App
- Updated docs - facebook/react-native-website#913
