### PR TITLE
Fix crash in XMLHttpRequest example on Android

### DIFF
--- a/RNTester/js/XHRExampleFormData.js
+++ b/RNTester/js/XHRExampleFormData.js
@@ -49,7 +49,7 @@ class XHRExampleFormData extends React.Component<Object, Object> {
   _fetchRandomPhoto = () => {
     CameraRoll.getPhotos({
       first: PAGE_SIZE,
-      groupTypes: 'All',
+      groupTypes: Platform.OS === 'ios' ? 'All' : undefined,
       assetType: 'All',
     }).then(
       data => {


### PR DESCRIPTION
## Summary

Fix crash in XMLHttpRequest example because `groupTypes` is not supported on android.

## Changelog

[Android] [Fixed] - Fix crash in XMLHttpRequest example on Android

## Test Plan

Test that the XMLHttpRequest example works on android
