### PR TITLE
[Android] Make Linking.getInitialURL works properly even if current activity is not initialized

### DIFF
--- a/Libraries/Linking/Linking.js
+++ b/Libraries/Linking/Linking.js
@@ -13,6 +13,7 @@
 const NativeEventEmitter = require('NativeEventEmitter');
 const NativeModules = require('NativeModules');
 const Platform = require('Platform');
+const InteractionManager = require('InteractionManager');
 
 const invariant = require('invariant');
 
@@ -87,7 +88,11 @@ class Linking extends NativeEventEmitter {
    * See https://facebook.github.io/react-native/docs/linking.html#getinitialurl
    */
   getInitialURL(): Promise<?string> {
-    return LinkingManager.getInitialURL();
+    return Platform.OS === 'android'
+      ? InteractionManager.runAfterInteractions().then(() =>
+          LinkingManager.getInitialURL(),
+        )
+      : LinkingManager.getInitialURL();
   }
 
   /*


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Solves #15961 - [ANDROID] Linking.getInitialURL() returns null after exiting the app with back button and using deep linking again (only in production!)

As the issue says, it seems that `currentActivity` is null in [IntentModule#getInitialURL](https://github.com/facebook/react-native/blob/1e8f3b11027fe0a7514b4fc97d0798d3c64bc895/ReactAndroid/src/main/java/com/facebook/react/modules/intent/IntentModule.java#L50). So I used the `InteractionManager` to wait until current activity to finish initializing.

## Changelog

[Android] [Fixed] - In `Linking.getInitialURL` method, use the `InteractionManager` to wait for the current activity to finish initializing.

## Test Plan

Here is an error case. After several trial, my app cannot open deep link.
Video link: https://youtu.be/0qppEs4O1Ls