### PR TITLE
[standards] Migrate "Libraries" from Haste to standard path-based requires (sans vendor & renderers)

### DIFF
--- a/Libraries/ART/ReactNativeART.js
+++ b/Libraries/ART/ReactNativeART.js
@@ -10,15 +10,15 @@
 'use strict';
 
 const Color = require('art/core/color');
-const Path = require('ARTSerializablePath');
+const Path = require('./ARTSerializablePath');
 const Transform = require('art/core/transform');
 
-const React = require('React');
+const React = require('react');
 const PropTypes = require('prop-types');
-const ReactNativeViewAttributes = require('ReactNativeViewAttributes');
+const ReactNativeViewAttributes = require('../Components/View/ReactNativeViewAttributes');
 
-const createReactNativeComponentClass = require('createReactNativeComponentClass');
-const merge = require('merge');
+const createReactNativeComponentClass = require('../Renderer/shims/createReactNativeComponentClass');
+const merge = require('../vendor/core/merge');
 const invariant = require('invariant');
 
 // Diff Helpers

--- a/Libraries/ActionSheetIOS/ActionSheetIOS.js
+++ b/Libraries/ActionSheetIOS/ActionSheetIOS.js
@@ -9,10 +9,11 @@
  */
 'use strict';
 
-const RCTActionSheetManager = require('NativeModules').ActionSheetManager;
+const RCTActionSheetManager = require('../BatchedBridge/NativeModules')
+  .ActionSheetManager;
 
 const invariant = require('invariant');
-const processColor = require('processColor');
+const processColor = require('../StyleSheet/processColor');
 
 /**
  * Display action sheets and share sheets on iOS.

--- a/Libraries/Alert/Alert.js
+++ b/Libraries/Alert/Alert.js
@@ -10,9 +10,9 @@
 
 'use strict';
 
-const NativeModules = require('NativeModules');
+const NativeModules = require('../BatchedBridge/NativeModules');
 const RCTAlertManager = NativeModules.AlertManager;
-const Platform = require('Platform');
+const Platform = require('../Utilities/Platform');
 
 export type Buttons = Array<{
   text?: string,

--- a/Libraries/Alert/RCTAlertManager.android.js
+++ b/Libraries/Alert/RCTAlertManager.android.js
@@ -9,7 +9,7 @@
 
 'use strict';
 
-const NativeModules = require('NativeModules');
+const NativeModules = require('../BatchedBridge/NativeModules');
 
 function emptyCallback() {}
 

--- a/Libraries/Alert/RCTAlertManager.ios.js
+++ b/Libraries/Alert/RCTAlertManager.ios.js
@@ -10,6 +10,6 @@
 
 'use strict';
 
-const RCTAlertManager = require('NativeModules').AlertManager;
+const RCTAlertManager = require('../BatchedBridge/NativeModules').AlertManager;
 
 module.exports = RCTAlertManager;

--- a/Libraries/Animated/src/Animated.js
+++ b/Libraries/Animated/src/Animated.js
@@ -10,30 +10,30 @@
 
 'use strict';
 
-import Platform from 'Platform';
+import Platform from '../../Utilities/Platform';
 
 const AnimatedImplementation = Platform.isTesting
-  ? require('AnimatedMock')
-  : require('AnimatedImplementation');
+  ? require('./AnimatedMock')
+  : require('./AnimatedImplementation');
 
 module.exports = {
   get FlatList() {
-    return require('AnimatedFlatList');
+    return require('./components/AnimatedFlatList');
   },
   get Image() {
-    return require('AnimatedImage');
+    return require('./components/AnimatedImage');
   },
   get ScrollView() {
-    return require('AnimatedScrollView');
+    return require('./components/AnimatedScrollView');
   },
   get SectionList() {
-    return require('AnimatedSectionList');
+    return require('./components/AnimatedSectionList');
   },
   get Text() {
-    return require('AnimatedText');
+    return require('./components/AnimatedText');
   },
   get View() {
-    return require('AnimatedView');
+    return require('./components/AnimatedView');
   },
   ...AnimatedImplementation,
 };

--- a/Libraries/Animated/src/AnimatedEvent.js
+++ b/Libraries/Animated/src/AnimatedEvent.js
@@ -11,7 +11,7 @@
 
 const AnimatedValue = require('./nodes/AnimatedValue');
 const NativeAnimatedHelper = require('./NativeAnimatedHelper');
-const ReactNative = require('ReactNative');
+const ReactNative = require('../../Renderer/shims/ReactNative');
 
 const invariant = require('invariant');
 const {shouldUseNativeDriver} = require('./NativeAnimatedHelper');

--- a/Libraries/Animated/src/AnimatedMock.js
+++ b/Libraries/Animated/src/AnimatedMock.js
@@ -10,7 +10,7 @@
 'use strict';
 
 const {AnimatedEvent, attachNativeEvent} = require('./AnimatedEvent');
-const AnimatedImplementation = require('AnimatedImplementation');
+const AnimatedImplementation = require('./AnimatedImplementation');
 const AnimatedInterpolation = require('./nodes/AnimatedInterpolation');
 const AnimatedNode = require('./nodes/AnimatedNode');
 const AnimatedProps = require('./nodes/AnimatedProps');

--- a/Libraries/Animated/src/AnimatedWeb.js
+++ b/Libraries/Animated/src/AnimatedWeb.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const AnimatedImplementation = require('AnimatedImplementation');
+const AnimatedImplementation = require('./AnimatedImplementation');
 
 module.exports = {
   ...AnimatedImplementation,

--- a/Libraries/Animated/src/Easing.js
+++ b/Libraries/Animated/src/Easing.js
@@ -216,7 +216,7 @@ class Easing {
     x2: number,
     y2: number,
   ): (t: number) => number {
-    const _bezier = require('bezier');
+    const _bezier = require('./bezier');
     return _bezier(x1, y1, x2, y2);
   }
 

--- a/Libraries/Animated/src/NativeAnimatedHelper.js
+++ b/Libraries/Animated/src/NativeAnimatedHelper.js
@@ -9,8 +9,9 @@
  */
 'use strict';
 
-const NativeAnimatedModule = require('NativeModules').NativeAnimatedModule;
-const NativeEventEmitter = require('NativeEventEmitter');
+const NativeAnimatedModule = require('../../BatchedBridge/NativeModules')
+  .NativeAnimatedModule;
+const NativeEventEmitter = require('../../EventEmitter/NativeEventEmitter');
 
 const invariant = require('invariant');
 

--- a/Libraries/Animated/src/__tests__/Animated-test.js
+++ b/Libraries/Animated/src/__tests__/Animated-test.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-let Animated = require('Animated');
+let Animated = require('../Animated');
 describe('Animated tests', () => {
   beforeEach(() => {
     jest.resetModules();
@@ -645,13 +645,13 @@ describe('Animated tests', () => {
     let InteractionManager;
 
     beforeEach(() => {
-      jest.mock('InteractionManager');
-      Animated = require('Animated');
-      InteractionManager = require('InteractionManager');
+      jest.mock('../../../Interaction/InteractionManager');
+      Animated = require('../Animated');
+      InteractionManager = require('../../../Interaction/InteractionManager');
     });
 
     afterEach(() => {
-      jest.unmock('InteractionManager');
+      jest.unmock('../../../Interaction/InteractionManager');
     });
 
     it('registers an interaction by default', () => {

--- a/Libraries/Animated/src/__tests__/AnimatedMock-test.js
+++ b/Libraries/Animated/src/__tests__/AnimatedMock-test.js
@@ -10,8 +10,8 @@
 
 'use strict';
 
-const AnimatedMock = require('AnimatedMock');
-const AnimatedImplementation = require('AnimatedImplementation');
+const AnimatedMock = require('../AnimatedMock');
+const AnimatedImplementation = require('../AnimatedImplementation');
 
 describe('Animated Mock', () => {
   it('matches implementation keys', () => {

--- a/Libraries/Animated/src/__tests__/AnimatedNative-test.js
+++ b/Libraries/Animated/src/__tests__/AnimatedNative-test.js
@@ -15,22 +15,22 @@ ClassComponentMock.prototype.isReactComponent = true;
 
 jest
   .clearAllMocks()
-  .setMock('Text', ClassComponentMock)
-  .setMock('View', ClassComponentMock)
-  .setMock('Image', ClassComponentMock)
-  .setMock('ScrollView', ClassComponentMock)
-  .setMock('FlatList', ClassComponentMock)
-  .setMock('SectionList', ClassComponentMock)
-  .setMock('React', {Component: class {}})
-  .setMock('NativeModules', {
+  .setMock('../../../Text/Text', ClassComponentMock)
+  .setMock('../../../Components/View/View', ClassComponentMock)
+  .setMock('../../../Image/Image', ClassComponentMock)
+  .setMock('../../../Components/ScrollView/ScrollView', ClassComponentMock)
+  .setMock('../../../Lists/FlatList', ClassComponentMock)
+  .setMock('../../../Lists/SectionList', ClassComponentMock)
+  .setMock('react', {Component: class {}})
+  .setMock('../../../BatchedBridge/NativeModules', {
     NativeAnimatedModule: {},
   })
-  .mock('NativeEventEmitter')
+  .mock('../../../EventEmitter/NativeEventEmitter')
   // findNodeHandle is imported from ReactNative so mock that whole module.
-  .setMock('ReactNative', {findNodeHandle: () => 1});
+  .setMock('../../../Renderer/shims/ReactNative', {findNodeHandle: () => 1});
 
-const Animated = require('Animated');
-const NativeAnimatedHelper = require('NativeAnimatedHelper');
+const Animated = require('../Animated');
+const NativeAnimatedHelper = require('../NativeAnimatedHelper');
 
 function createAndMountComponent(ComponentClass, props) {
   const component = new ComponentClass();
@@ -43,7 +43,8 @@ function createAndMountComponent(ComponentClass, props) {
 }
 
 describe('Native Animated', () => {
-  const nativeAnimatedModule = require('NativeModules').NativeAnimatedModule;
+  const nativeAnimatedModule = require('../../../BatchedBridge/NativeModules')
+    .NativeAnimatedModule;
 
   beforeEach(() => {
     nativeAnimatedModule.addAnimatedEventToView = jest.fn();

--- a/Libraries/Animated/src/__tests__/Easing-test.js
+++ b/Libraries/Animated/src/__tests__/Easing-test.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const Easing = require('Easing');
+const Easing = require('../Easing');
 describe('Easing', () => {
   it('should work with linear', () => {
     const easing = Easing.linear;

--- a/Libraries/Animated/src/__tests__/Interpolation-test.js
+++ b/Libraries/Animated/src/__tests__/Interpolation-test.js
@@ -11,7 +11,7 @@
 'use strict';
 
 const AnimatedInterpolation = require('../nodes/AnimatedInterpolation');
-const Easing = require('Easing');
+const Easing = require('../Easing');
 
 describe('Interpolation', () => {
   it('should work with defaults', () => {

--- a/Libraries/Animated/src/__tests__/bezier-test.js
+++ b/Libraries/Animated/src/__tests__/bezier-test.js
@@ -15,7 +15,7 @@
 
 'use strict';
 
-const bezier = require('bezier');
+const bezier = require('../bezier');
 
 const identity = function(x) {
   return x;

--- a/Libraries/Animated/src/animations/Animation.js
+++ b/Libraries/Animated/src/animations/Animation.js
@@ -9,7 +9,7 @@
  */
 'use strict';
 
-const NativeAnimatedHelper = require('NativeAnimatedHelper');
+const NativeAnimatedHelper = require('../NativeAnimatedHelper');
 
 import type AnimatedValue from '../nodes/AnimatedValue';
 

--- a/Libraries/Animated/src/animations/TimingAnimation.js
+++ b/Libraries/Animated/src/animations/TimingAnimation.js
@@ -34,7 +34,7 @@ export type TimingAnimationConfigSingle = AnimationConfig & {
 let _easeInOut;
 function easeInOut() {
   if (!_easeInOut) {
-    const Easing = require('Easing');
+    const Easing = require('../Easing');
     _easeInOut = Easing.inOut(Easing.ease);
   }
   return _easeInOut;

--- a/Libraries/Animated/src/components/AnimatedFlatList.js
+++ b/Libraries/Animated/src/components/AnimatedFlatList.js
@@ -10,8 +10,8 @@
 
 'use strict';
 
-const FlatList = require('FlatList');
+const FlatList = require('../../../Lists/FlatList');
 
-const createAnimatedComponent = require('createAnimatedComponent');
+const createAnimatedComponent = require('../createAnimatedComponent');
 
 module.exports = createAnimatedComponent(FlatList);

--- a/Libraries/Animated/src/components/AnimatedImage.js
+++ b/Libraries/Animated/src/components/AnimatedImage.js
@@ -10,8 +10,8 @@
 
 'use strict';
 
-const Image = require('Image');
+const Image = require('../../../Image/Image');
 
-const createAnimatedComponent = require('createAnimatedComponent');
+const createAnimatedComponent = require('../createAnimatedComponent');
 
 module.exports = createAnimatedComponent(Image);

--- a/Libraries/Animated/src/components/AnimatedScrollView.js
+++ b/Libraries/Animated/src/components/AnimatedScrollView.js
@@ -10,9 +10,9 @@
 
 'use strict';
 
-const ScrollView = require('ScrollView');
+const ScrollView = require('../../../Components/ScrollView/ScrollView');
 
-const createAnimatedComponent = require('createAnimatedComponent');
+const createAnimatedComponent = require('../createAnimatedComponent');
 
 module.exports = createAnimatedComponent(ScrollView, {
   scrollEventThrottle: 0.0001,

--- a/Libraries/Animated/src/components/AnimatedSectionList.js
+++ b/Libraries/Animated/src/components/AnimatedSectionList.js
@@ -10,8 +10,8 @@
 
 'use strict';
 
-const SectionList = require('SectionList');
+const SectionList = require('../../../Lists/SectionList');
 
-const createAnimatedComponent = require('createAnimatedComponent');
+const createAnimatedComponent = require('../createAnimatedComponent');
 
 module.exports = createAnimatedComponent(SectionList);

--- a/Libraries/Animated/src/components/AnimatedText.js
+++ b/Libraries/Animated/src/components/AnimatedText.js
@@ -10,8 +10,8 @@
 
 'use strict';
 
-const Text = require('Text');
+const Text = require('../../../Text/Text');
 
-const createAnimatedComponent = require('createAnimatedComponent');
+const createAnimatedComponent = require('../createAnimatedComponent');
 
 module.exports = createAnimatedComponent(Text);

--- a/Libraries/Animated/src/components/AnimatedView.js
+++ b/Libraries/Animated/src/components/AnimatedView.js
@@ -10,8 +10,8 @@
 
 'use strict';
 
-const View = require('View');
+const View = require('../../../Components/View/View');
 
-const createAnimatedComponent = require('createAnimatedComponent');
+const createAnimatedComponent = require('../createAnimatedComponent');
 
 module.exports = createAnimatedComponent(View);

--- a/Libraries/Animated/src/createAnimatedComponent.js
+++ b/Libraries/Animated/src/createAnimatedComponent.js
@@ -11,8 +11,8 @@
 
 const {AnimatedEvent} = require('./AnimatedEvent');
 const AnimatedProps = require('./nodes/AnimatedProps');
-const React = require('React');
-const DeprecatedViewStylePropTypes = require('DeprecatedViewStylePropTypes');
+const React = require('react');
+const DeprecatedViewStylePropTypes = require('../../DeprecatedPropTypes/DeprecatedViewStylePropTypes');
 
 const invariant = require('invariant');
 

--- a/Libraries/Animated/src/nodes/AnimatedInterpolation.js
+++ b/Libraries/Animated/src/nodes/AnimatedInterpolation.js
@@ -15,7 +15,7 @@ const AnimatedWithChildren = require('./AnimatedWithChildren');
 const NativeAnimatedHelper = require('../NativeAnimatedHelper');
 
 const invariant = require('invariant');
-const normalizeColor = require('normalizeColor');
+const normalizeColor = require('../../../Color/normalizeColor');
 
 type ExtrapolateType = 'extend' | 'identity' | 'clamp';
 

--- a/Libraries/Animated/src/nodes/AnimatedProps.js
+++ b/Libraries/Animated/src/nodes/AnimatedProps.js
@@ -13,7 +13,7 @@ const {AnimatedEvent} = require('../AnimatedEvent');
 const AnimatedNode = require('./AnimatedNode');
 const AnimatedStyle = require('./AnimatedStyle');
 const NativeAnimatedHelper = require('../NativeAnimatedHelper');
-const ReactNative = require('ReactNative');
+const ReactNative = require('../../../Renderer/shims/ReactNative');
 
 const invariant = require('invariant');
 

--- a/Libraries/Animated/src/nodes/AnimatedStyle.js
+++ b/Libraries/Animated/src/nodes/AnimatedStyle.js
@@ -14,7 +14,7 @@ const AnimatedTransform = require('./AnimatedTransform');
 const AnimatedWithChildren = require('./AnimatedWithChildren');
 const NativeAnimatedHelper = require('../NativeAnimatedHelper');
 
-const flattenStyle = require('flattenStyle');
+const flattenStyle = require('../../../StyleSheet/flattenStyle');
 
 class AnimatedStyle extends AnimatedWithChildren {
   _style: Object;

--- a/Libraries/Animated/src/nodes/AnimatedValue.js
+++ b/Libraries/Animated/src/nodes/AnimatedValue.js
@@ -11,7 +11,7 @@
 
 const AnimatedInterpolation = require('./AnimatedInterpolation');
 const AnimatedWithChildren = require('./AnimatedWithChildren');
-const InteractionManager = require('InteractionManager');
+const InteractionManager = require('../../../Interaction/InteractionManager');
 const NativeAnimatedHelper = require('../NativeAnimatedHelper');
 
 import type Animation, {EndCallback} from '../animations/Animation';

--- a/Libraries/AppState/AppState.js
+++ b/Libraries/AppState/AppState.js
@@ -10,12 +10,12 @@
 
 'use strict';
 
-const EventEmitter = require('EventEmitter');
-const NativeEventEmitter = require('NativeEventEmitter');
-const NativeModules = require('NativeModules');
+const EventEmitter = require('../vendor/emitter/EventEmitter');
+const NativeEventEmitter = require('../EventEmitter/NativeEventEmitter');
+const NativeModules = require('../BatchedBridge/NativeModules');
 const RCTAppState = NativeModules.AppState;
 
-const logError = require('logError');
+const logError = require('../Utilities/logError');
 const invariant = require('invariant');
 
 /**

--- a/Libraries/BatchedBridge/BatchedBridge.js
+++ b/Libraries/BatchedBridge/BatchedBridge.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const MessageQueue = require('MessageQueue');
+const MessageQueue = require('./MessageQueue');
 
 const BatchedBridge = new MessageQueue();
 

--- a/Libraries/BatchedBridge/MessageQueue.js
+++ b/Libraries/BatchedBridge/MessageQueue.js
@@ -10,12 +10,12 @@
 
 'use strict';
 
-const ErrorUtils = require('ErrorUtils');
-const Systrace = require('Systrace');
+const ErrorUtils = require('../vendor/core/ErrorUtils');
+const Systrace = require('../Performance/Systrace');
 
-const deepFreezeAndThrowOnMutationInDev = require('deepFreezeAndThrowOnMutationInDev');
+const deepFreezeAndThrowOnMutationInDev = require('../Utilities/deepFreezeAndThrowOnMutationInDev');
 const invariant = require('invariant');
-const stringifySafe = require('stringifySafe');
+const stringifySafe = require('../Utilities/stringifySafe');
 
 export type SpyData = {
   type: number,

--- a/Libraries/BatchedBridge/NativeModules.js
+++ b/Libraries/BatchedBridge/NativeModules.js
@@ -10,11 +10,11 @@
 
 'use strict';
 
-const BatchedBridge = require('BatchedBridge');
+const BatchedBridge = require('./BatchedBridge');
 
 const invariant = require('invariant');
 
-import type {ExtendedError} from 'parseErrorStack';
+import type {ExtendedError} from '../Core/Devtools/parseErrorStack';
 
 type ModuleConfig = [
   string /* name */,
@@ -164,7 +164,7 @@ if (global.nativeModuleProxy) {
     '__fbBatchedBridgeConfig is not set, cannot invoke native modules',
   );
 
-  const defineLazyObjectProperty = require('defineLazyObjectProperty');
+  const defineLazyObjectProperty = require('../Utilities/defineLazyObjectProperty');
   (bridgeConfig.remoteModuleConfig || []).forEach(
     (config: ModuleConfig, moduleID: number) => {
       // Initially this config will only contain the module name when running in JSC. The actual

--- a/Libraries/BatchedBridge/__tests__/MessageQueue-test.js
+++ b/Libraries/BatchedBridge/__tests__/MessageQueue-test.js
@@ -32,7 +32,7 @@ const assertQueue = (flushedQueue, index, moduleID, methodID, params) => {
 describe('MessageQueue', function() {
   beforeEach(function() {
     jest.resetModules();
-    MessageQueue = require('MessageQueue');
+    MessageQueue = require('../MessageQueue');
     MessageQueueTestModule = require('MessageQueueTestModule');
     queue = new MessageQueue();
     queue.registerCallableModule(

--- a/Libraries/BatchedBridge/__tests__/NativeModules-test.js
+++ b/Libraries/BatchedBridge/__tests__/NativeModules-test.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-jest.unmock('NativeModules');
+jest.unmock('../NativeModules');
 
 let BatchedBridge;
 let NativeModules;
@@ -41,8 +41,8 @@ describe('MessageQueue', function() {
     jest.resetModules();
 
     global.__fbBatchedBridgeConfig = require('MessageQueueTestConfig');
-    BatchedBridge = require('BatchedBridge');
-    NativeModules = require('NativeModules');
+    BatchedBridge = require('../BatchedBridge');
+    NativeModules = require('../NativeModules');
   });
 
   it('should generate native modules', () => {

--- a/Libraries/Blob/Blob.js
+++ b/Libraries/Blob/Blob.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-import type {BlobData, BlobOptions} from 'BlobTypes';
+import type {BlobData, BlobOptions} from './BlobTypes';
 
 /**
  * Opaque JS representation of some binary data in native.
@@ -58,7 +58,7 @@ class Blob {
    * Reference: https://developer.mozilla.org/en-US/docs/Web/API/Blob/Blob
    */
   constructor(parts: Array<Blob | string> = [], options?: BlobOptions) {
-    const BlobManager = require('BlobManager');
+    const BlobManager = require('./BlobManager');
     this.data = BlobManager.createFromParts(parts, options).data;
   }
 
@@ -80,7 +80,7 @@ class Blob {
   }
 
   slice(start?: number, end?: number): Blob {
-    const BlobManager = require('BlobManager');
+    const BlobManager = require('./BlobManager');
     let {offset, size} = this.data;
 
     if (typeof start === 'number') {
@@ -117,7 +117,7 @@ class Blob {
    * `new Blob([blob, ...])` actually copies the data in memory.
    */
   close() {
-    const BlobManager = require('BlobManager');
+    const BlobManager = require('./BlobManager');
     BlobManager.release(this.data.blobId);
     this.data = null;
   }

--- a/Libraries/Blob/BlobManager.js
+++ b/Libraries/Blob/BlobManager.js
@@ -10,11 +10,11 @@
 
 'use strict';
 
-const Blob = require('Blob');
-const BlobRegistry = require('BlobRegistry');
-const {BlobModule} = require('NativeModules');
+const Blob = require('./Blob');
+const BlobRegistry = require('./BlobRegistry');
+const {BlobModule} = require('../BatchedBridge/NativeModules');
 
-import type {BlobData, BlobOptions} from 'BlobTypes';
+import type {BlobData, BlobOptions} from './BlobTypes';
 
 /*eslint-disable no-bitwise */
 /*eslint-disable eqeqeq */

--- a/Libraries/Blob/File.js
+++ b/Libraries/Blob/File.js
@@ -9,11 +9,11 @@
  */
 'use strict';
 
-const Blob = require('Blob');
+const Blob = require('./Blob');
 
 const invariant = require('invariant');
 
-import type {BlobOptions} from 'BlobTypes';
+import type {BlobOptions} from './BlobTypes';
 
 /**
  * The File interface provides information about files.

--- a/Libraries/Blob/FileReader.js
+++ b/Libraries/Blob/FileReader.js
@@ -11,8 +11,8 @@
 'use strict';
 
 const EventTarget = require('event-target-shim');
-const Blob = require('Blob');
-const {FileReaderModule} = require('NativeModules');
+const Blob = require('./Blob');
+const {FileReaderModule} = require('../BatchedBridge/NativeModules');
 
 type ReadyState =
   | 0 // EMPTY

--- a/Libraries/Blob/URL.js
+++ b/Libraries/Blob/URL.js
@@ -9,9 +9,9 @@
 
 'use strict';
 
-const Blob = require('Blob');
+const Blob = require('./Blob');
 
-const {BlobModule} = require('NativeModules');
+const {BlobModule} = require('../BatchedBridge/NativeModules');
 
 let BLOB_URL_PREFIX = null;
 

--- a/Libraries/Blob/__tests__/Blob-test.js
+++ b/Libraries/Blob/__tests__/Blob-test.js
@@ -9,11 +9,11 @@
  */
 'use strict';
 
-jest.setMock('NativeModules', {
+jest.setMock('../../BatchedBridge/NativeModules', {
   BlobModule: require('../__mocks__/BlobModule'),
 });
 
-const Blob = require('Blob');
+const Blob = require('../Blob');
 
 describe('Blob', function() {
   it('should create empty blob', () => {

--- a/Libraries/Blob/__tests__/BlobManager-test.js
+++ b/Libraries/Blob/__tests__/BlobManager-test.js
@@ -9,12 +9,12 @@
  */
 'use strict';
 
-jest.setMock('NativeModules', {
+jest.setMock('../../BatchedBridge/NativeModules', {
   BlobModule: require('../__mocks__/BlobModule'),
 });
 
-const Blob = require('Blob');
-const BlobManager = require('BlobManager');
+const Blob = require('../Blob');
+const BlobManager = require('../BlobManager');
 
 describe('BlobManager', function() {
   it('should create blob from parts', () => {

--- a/Libraries/Blob/__tests__/File-test.js
+++ b/Libraries/Blob/__tests__/File-test.js
@@ -9,12 +9,12 @@
  */
 'use strict';
 
-jest.setMock('NativeModules', {
+jest.setMock('../../BatchedBridge/NativeModules', {
   BlobModule: require('../__mocks__/BlobModule'),
 });
 
-const Blob = require('Blob');
-const File = require('File');
+const Blob = require('../Blob');
+const File = require('../File');
 
 describe('babel 7 smoke test', function() {
   it('should be able to extend a class with native name', function() {

--- a/Libraries/Blob/__tests__/FileReader-test.js
+++ b/Libraries/Blob/__tests__/FileReader-test.js
@@ -9,13 +9,13 @@
  */
 'use strict';
 
-jest.unmock('event-target-shim').setMock('NativeModules', {
+jest.unmock('event-target-shim').setMock('../../BatchedBridge/NativeModules', {
   BlobModule: require('../__mocks__/BlobModule'),
   FileReaderModule: require('../__mocks__/FileReaderModule'),
 });
 
-const Blob = require('Blob');
-const FileReader = require('FileReader');
+const Blob = require('../Blob');
+const FileReader = require('../FileReader');
 
 describe('FileReader', function() {
   it('should read blob as text', async () => {

--- a/Libraries/Blob/__tests__/URL-test.js
+++ b/Libraries/Blob/__tests__/URL-test.js
@@ -9,7 +9,7 @@
  */
 'use strict';
 
-const URL = require('URL').URL;
+const URL = require('../URL').URL;
 
 describe('URL', function() {
   it('should pass Mozilla Dev Network examples', () => {

--- a/Libraries/BugReporting/BugReporting.js
+++ b/Libraries/BugReporting/BugReporting.js
@@ -10,10 +10,10 @@
 
 'use strict';
 
-const RCTDeviceEventEmitter = require('RCTDeviceEventEmitter');
-const infoLog = require('infoLog');
+const RCTDeviceEventEmitter = require('../EventEmitter/RCTDeviceEventEmitter');
+const infoLog = require('../Utilities/infoLog');
 
-import type EmitterSubscription from 'EmitterSubscription';
+import type EmitterSubscription from '../vendor/emitter/EmitterSubscription';
 
 type ExtraData = {[key: string]: string};
 type SourceCallback = () => string;
@@ -21,7 +21,7 @@ type DebugData = {extras: ExtraData, files: ExtraData};
 
 function defaultExtras() {
   BugReporting.addFileSource('react_hierarchy.txt', () =>
-    require('dumpReactTree')(),
+    require('./dumpReactTree')(),
   );
 }
 
@@ -121,12 +121,13 @@ class BugReporting {
       fileData[key] = callback();
     }
     infoLog('BugReporting extraData:', extraData);
-    const BugReportingNativeModule = require('NativeModules').BugReporting;
+    const BugReportingNativeModule = require('../BatchedBridge/NativeModules')
+      .BugReporting;
     BugReportingNativeModule &&
       BugReportingNativeModule.setExtraData &&
       BugReportingNativeModule.setExtraData(extraData, fileData);
 
-    const RedBoxNativeModule = require('NativeModules').RedBox;
+    const RedBoxNativeModule = require('../BatchedBridge/NativeModules').RedBox;
     RedBoxNativeModule &&
       RedBoxNativeModule.setExtraData &&
       RedBoxNativeModule.setExtraData(extraData, 'From BugReporting.js');

--- a/Libraries/CameraRoll/CameraRoll.js
+++ b/Libraries/CameraRoll/CameraRoll.js
@@ -11,9 +11,10 @@
 
 const PropTypes = require('prop-types');
 const {checkPropTypes} = PropTypes;
-const RCTCameraRollManager = require('NativeModules').CameraRollManager;
+const RCTCameraRollManager = require('../BatchedBridge/NativeModules')
+  .CameraRollManager;
 
-const deprecatedCreateStrictShapeTypeChecker = require('deprecatedCreateStrictShapeTypeChecker');
+const deprecatedCreateStrictShapeTypeChecker = require('../DeprecatedPropTypes/deprecatedCreateStrictShapeTypeChecker');
 const invariant = require('invariant');
 
 const GROUP_TYPES_OPTIONS = {

--- a/Libraries/CameraRoll/ImagePickerIOS.js
+++ b/Libraries/CameraRoll/ImagePickerIOS.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const RCTImagePicker = require('NativeModules').ImagePickerIOS;
+const RCTImagePicker = require('../BatchedBridge/NativeModules').ImagePickerIOS;
 
 const ImagePickerIOS = {
   canRecordVideos: function(callback: Function) {

--- a/Libraries/Components/AccessibilityInfo/AccessibilityInfo.android.js
+++ b/Libraries/Components/AccessibilityInfo/AccessibilityInfo.android.js
@@ -10,9 +10,9 @@
 
 'use strict';
 
-const NativeModules = require('NativeModules');
-const RCTDeviceEventEmitter = require('RCTDeviceEventEmitter');
-const UIManager = require('UIManager');
+const NativeModules = require('../../BatchedBridge/NativeModules');
+const RCTDeviceEventEmitter = require('../../EventEmitter/RCTDeviceEventEmitter');
+const UIManager = require('../../ReactNative/UIManager');
 
 const RCTAccessibilityInfo = NativeModules.AccessibilityInfo;
 

--- a/Libraries/Components/AccessibilityInfo/AccessibilityInfo.ios.js
+++ b/Libraries/Components/AccessibilityInfo/AccessibilityInfo.ios.js
@@ -10,9 +10,9 @@
 
 'use strict';
 
-const NativeModules = require('NativeModules');
-const Promise = require('Promise');
-const RCTDeviceEventEmitter = require('RCTDeviceEventEmitter');
+const NativeModules = require('../../BatchedBridge/NativeModules');
+const Promise = require('../../Promise');
+const RCTDeviceEventEmitter = require('../../EventEmitter/RCTDeviceEventEmitter');
 
 const AccessibilityManager = NativeModules.AccessibilityManager;
 

--- a/Libraries/Components/ActivityIndicator/ActivityIndicator.js
+++ b/Libraries/Components/ActivityIndicator/ActivityIndicator.js
@@ -10,19 +10,19 @@
 
 'use strict';
 
-const Platform = require('Platform');
-const React = require('React');
-const StyleSheet = require('StyleSheet');
-const View = require('View');
+const Platform = require('../../Utilities/Platform');
+const React = require('react');
+const StyleSheet = require('../../StyleSheet/StyleSheet');
+const View = require('../View/View');
 
-const RCTActivityIndicatorViewNativeComponent = require('RCTActivityIndicatorViewNativeComponent');
+const RCTActivityIndicatorViewNativeComponent = require('./RCTActivityIndicatorViewNativeComponent');
 
-import type {NativeComponent} from 'ReactNative';
-import type {ViewProps} from 'ViewPropTypes';
+import type {NativeComponent} from '../../Renderer/shims/ReactNative';
+import type {ViewProps} from '../View/ViewPropTypes';
 
 const RCTActivityIndicator =
   Platform.OS === 'android'
-    ? require('ProgressBarAndroid')
+    ? require('../ProgressBarAndroid/ProgressBarAndroid')
     : RCTActivityIndicatorViewNativeComponent;
 
 const GRAY = '#999999';

--- a/Libraries/Components/ActivityIndicator/RCTActivityIndicatorViewNativeComponent.js
+++ b/Libraries/Components/ActivityIndicator/RCTActivityIndicatorViewNativeComponent.js
@@ -10,11 +10,11 @@
 
 'use strict';
 
-const requireNativeComponent = require('requireNativeComponent');
+const requireNativeComponent = require('../../ReactNative/requireNativeComponent');
 
-import type {ViewProps} from 'ViewPropTypes';
-import type {ViewStyleProp} from 'StyleSheet';
-import type {NativeComponent} from 'ReactNative';
+import type {ViewProps} from '../View/ViewPropTypes';
+import type {ViewStyleProp} from '../../StyleSheet/StyleSheet';
+import type {NativeComponent} from '../../Renderer/shims/ReactNative';
 
 type NativeProps = $ReadOnly<{|
   ...ViewProps,

--- a/Libraries/Components/ActivityIndicator/__tests__/ActivityIndicator-test.js
+++ b/Libraries/Components/ActivityIndicator/__tests__/ActivityIndicator-test.js
@@ -11,8 +11,8 @@
 
 'use strict';
 
-const React = require('React');
-const ActivityIndicator = require('ActivityIndicator');
+const React = require('react');
+const ActivityIndicator = require('../ActivityIndicator');
 const render = require('../../../../jest/renderer');
 
 describe('<ActivityIndicator />', () => {
@@ -35,7 +35,7 @@ describe('<ActivityIndicator />', () => {
   });
 
   it('should shallow render as <ForwardRef(ActivityIndicator)> when not mocked', () => {
-    jest.dontMock('ActivityIndicator');
+    jest.dontMock('../ActivityIndicator');
 
     const output = render.shallow(
       <ActivityIndicator size="large" color="#0000ff" />,
@@ -44,7 +44,7 @@ describe('<ActivityIndicator />', () => {
   });
 
   it('should render as <View> when not mocked', () => {
-    jest.dontMock('ActivityIndicator');
+    jest.dontMock('../ActivityIndicator');
 
     const instance = render.create(
       <ActivityIndicator size="large" color="#0000ff" />,

--- a/Libraries/Components/AppleTV/TVEventHandler.js
+++ b/Libraries/Components/AppleTV/TVEventHandler.js
@@ -10,10 +10,10 @@
 
 'use strict';
 
-const Platform = require('Platform');
-const TVNavigationEventEmitter = require('NativeModules')
+const Platform = require('../../Utilities/Platform');
+const TVNavigationEventEmitter = require('../../BatchedBridge/NativeModules')
   .TVNavigationEventEmitter;
-const NativeEventEmitter = require('NativeEventEmitter');
+const NativeEventEmitter = require('../../EventEmitter/NativeEventEmitter');
 
 function TVEventHandler() {
   this.__nativeTVNavigationEventListener = null;

--- a/Libraries/Components/Button.js
+++ b/Libraries/Components/Button.js
@@ -10,17 +10,17 @@
 
 'use strict';
 
-const Platform = require('Platform');
-const React = require('React');
-const StyleSheet = require('StyleSheet');
-const Text = require('Text');
-const TouchableNativeFeedback = require('TouchableNativeFeedback');
-const TouchableOpacity = require('TouchableOpacity');
-const View = require('View');
+const Platform = require('../Utilities/Platform');
+const React = require('react');
+const StyleSheet = require('../StyleSheet/StyleSheet');
+const Text = require('../Text/Text');
+const TouchableNativeFeedback = require('./Touchable/TouchableNativeFeedback');
+const TouchableOpacity = require('./Touchable/TouchableOpacity');
+const View = require('./View/View');
 
 const invariant = require('invariant');
 
-import type {PressEvent} from 'CoreEventTypes';
+import type {PressEvent} from '../Types/CoreEventTypes';
 
 type ButtonProps = $ReadOnly<{|
   /**

--- a/Libraries/Components/CheckBox/AndroidCheckBoxNativeComponent.js
+++ b/Libraries/Components/CheckBox/AndroidCheckBoxNativeComponent.js
@@ -9,11 +9,11 @@
  */
 'use strict';
 
-const requireNativeComponent = require('requireNativeComponent');
+const requireNativeComponent = require('../../ReactNative/requireNativeComponent');
 
-import type {ViewProps} from 'ViewPropTypes';
-import type {SyntheticEvent} from 'CoreEventTypes';
-import type {NativeComponent} from 'ReactNative';
+import type {ViewProps} from '../View/ViewPropTypes';
+import type {SyntheticEvent} from '../../Types/CoreEventTypes';
+import type {NativeComponent} from '../../Renderer/shims/ReactNative';
 
 type CheckBoxEvent = SyntheticEvent<
   $ReadOnly<{|

--- a/Libraries/Components/CheckBox/CheckBox.android.js
+++ b/Libraries/Components/CheckBox/CheckBox.android.js
@@ -9,18 +9,18 @@
  */
 'use strict';
 
-const React = require('React');
-const StyleSheet = require('StyleSheet');
-const processColor = require('processColor');
+const React = require('react');
+const StyleSheet = require('../../StyleSheet/StyleSheet');
+const processColor = require('../../StyleSheet/processColor');
 
-const AndroidCheckBoxNativeComponent = require('AndroidCheckBoxNativeComponent');
+const AndroidCheckBoxNativeComponent = require('./AndroidCheckBoxNativeComponent');
 const nullthrows = require('nullthrows');
-const setAndForwardRef = require('setAndForwardRef');
+const setAndForwardRef = require('../../Utilities/setAndForwardRef');
 
-import type {ViewProps} from 'ViewPropTypes';
-import type {SyntheticEvent} from 'CoreEventTypes';
-import type {NativeComponent} from 'ReactNative';
-import type {ColorValue} from 'StyleSheetTypes';
+import type {ViewProps} from '../View/ViewPropTypes';
+import type {SyntheticEvent} from '../../Types/CoreEventTypes';
+import type {NativeComponent} from '../../Renderer/shims/ReactNative';
+import type {ColorValue} from '../../StyleSheet/StyleSheetTypes';
 
 type CheckBoxEvent = SyntheticEvent<
   $ReadOnly<{|

--- a/Libraries/Components/CheckBox/CheckBox.ios.js
+++ b/Libraries/Components/CheckBox/CheckBox.ios.js
@@ -9,4 +9,4 @@
  */
 'use strict';
 
-module.exports = require('UnimplementedView');
+module.exports = require('../UnimplementedViews/UnimplementedView');

--- a/Libraries/Components/Clipboard/Clipboard.js
+++ b/Libraries/Components/Clipboard/Clipboard.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const Clipboard = require('NativeModules').Clipboard;
+const Clipboard = require('../../BatchedBridge/NativeModules').Clipboard;
 
 /**
  * `Clipboard` gives you an interface for setting and getting content from Clipboard on both iOS and Android

--- a/Libraries/Components/DatePicker/DatePickerIOS.android.js
+++ b/Libraries/Components/DatePicker/DatePickerIOS.android.js
@@ -9,10 +9,10 @@
 
 'use strict';
 
-const React = require('React');
-const StyleSheet = require('StyleSheet');
-const Text = require('Text');
-const View = require('View');
+const React = require('react');
+const StyleSheet = require('../../StyleSheet/StyleSheet');
+const Text = require('../../Text/Text');
+const View = require('../View/View');
 
 class DummyDatePickerIOS extends React.Component {
   render() {

--- a/Libraries/Components/DatePicker/DatePickerIOS.ios.js
+++ b/Libraries/Components/DatePicker/DatePickerIOS.ios.js
@@ -13,16 +13,16 @@
 
 'use strict';
 
-const React = require('React');
-const StyleSheet = require('StyleSheet');
-const View = require('View');
+const React = require('react');
+const StyleSheet = require('../../StyleSheet/StyleSheet');
+const View = require('../View/View');
 
 const invariant = require('invariant');
 
-import type {ViewProps} from 'ViewPropTypes';
-import type {SyntheticEvent} from 'CoreEventTypes';
+import type {ViewProps} from '../View/ViewPropTypes';
+import type {SyntheticEvent} from '../../Types/CoreEventTypes';
 
-const RCTDatePickerNativeComponent = require('RCTDatePickerNativeComponent');
+const RCTDatePickerNativeComponent = require('./RCTDatePickerNativeComponent');
 
 type Event = SyntheticEvent<
   $ReadOnly<{|

--- a/Libraries/Components/DatePicker/RCTDatePickerNativeComponent.js
+++ b/Libraries/Components/DatePicker/RCTDatePickerNativeComponent.js
@@ -10,11 +10,11 @@
 
 'use strict';
 
-const requireNativeComponent = require('requireNativeComponent');
+const requireNativeComponent = require('../../ReactNative/requireNativeComponent');
 
-import type {SyntheticEvent} from 'CoreEventTypes';
-import type {ViewProps} from 'ViewPropTypes';
-import type {NativeComponent} from 'ReactNative';
+import type {SyntheticEvent} from '../../Types/CoreEventTypes';
+import type {ViewProps} from '../View/ViewPropTypes';
+import type {NativeComponent} from '../../Renderer/shims/ReactNative';
 
 type Event = SyntheticEvent<
   $ReadOnly<{|

--- a/Libraries/Components/DatePicker/__tests__/DatePickerIOS-test.js
+++ b/Libraries/Components/DatePicker/__tests__/DatePickerIOS-test.js
@@ -11,8 +11,8 @@
 
 'use strict';
 
-const React = require('React');
-const DatePickerIOS = require('DatePickerIOS');
+const React = require('react');
+const DatePickerIOS = require('../DatePickerIOS');
 const render = require('../../../../jest/renderer');
 
 describe('DatePickerIOS', () => {
@@ -39,7 +39,7 @@ describe('DatePickerIOS', () => {
   });
 
   it('should shallow render as <DatePickerIOS> when not mocked', () => {
-    jest.dontMock('DatePickerIOS');
+    jest.dontMock('../DatePickerIOS');
 
     const output = render.shallow(
       <DatePickerIOS
@@ -52,7 +52,7 @@ describe('DatePickerIOS', () => {
   });
 
   it('should render as <View> when not mocked', () => {
-    jest.dontMock('DatePickerIOS');
+    jest.dontMock('../DatePickerIOS');
 
     const instance = render.create(
       <DatePickerIOS

--- a/Libraries/Components/DatePickerAndroid/DatePickerAndroid.android.js
+++ b/Libraries/Components/DatePickerAndroid/DatePickerAndroid.android.js
@@ -10,8 +10,9 @@
 
 'use strict';
 
-const DatePickerModule = require('NativeModules').DatePickerAndroid;
-import type {Options, DatePickerOpenAction} from 'DatePickerAndroidTypes';
+const DatePickerModule = require('../../BatchedBridge/NativeModules')
+  .DatePickerAndroid;
+import type {Options, DatePickerOpenAction} from './DatePickerAndroidTypes';
 
 /**
  * Convert a Date to a timestamp.

--- a/Libraries/Components/DatePickerAndroid/DatePickerAndroid.ios.js
+++ b/Libraries/Components/DatePickerAndroid/DatePickerAndroid.ios.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-import type {Options, DatePickerOpenAction} from 'DatePickerAndroidTypes';
+import type {Options, DatePickerOpenAction} from './DatePickerAndroidTypes';
 
 class DatePickerAndroid {
   static async open(options: ?Options): Promise<DatePickerOpenAction> {

--- a/Libraries/Components/DrawerAndroid/AndroidDrawerLayoutNativeComponent.js
+++ b/Libraries/Components/DrawerAndroid/AndroidDrawerLayoutNativeComponent.js
@@ -10,12 +10,12 @@
 
 'use strict';
 
-const requireNativeComponent = require('requireNativeComponent');
+const requireNativeComponent = require('../../ReactNative/requireNativeComponent');
 
-import type {NativeComponent} from 'ReactNative';
-import type {SyntheticEvent} from 'CoreEventTypes';
-import type {ViewStyleProp} from 'StyleSheet';
-import type React from 'React';
+import type {NativeComponent} from '../../Renderer/shims/ReactNative';
+import type {SyntheticEvent} from '../../Types/CoreEventTypes';
+import type {ViewStyleProp} from '../../StyleSheet/StyleSheet';
+import type {Element, Node} from 'react';
 
 type ColorValue = null | string;
 
@@ -101,7 +101,7 @@ type NativeProps = $ReadOnly<{|
   /**
    * The navigation view that will be rendered to the side of the screen and can be pulled in.
    */
-  renderNavigationView: () => React.Element<any>,
+  renderNavigationView: () => Element<any>,
 
   /**
    * Make the drawer take the entire screen and draw the background of the
@@ -110,7 +110,7 @@ type NativeProps = $ReadOnly<{|
    */
   statusBarBackgroundColor?: ?ColorValue,
 
-  children?: React.Node,
+  children?: Node,
   style?: ?ViewStyleProp,
 |}>;
 

--- a/Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.android.js
+++ b/Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.android.js
@@ -10,30 +10,30 @@
 
 'use strict';
 
-const Platform = require('Platform');
-const React = require('React');
-const ReactNative = require('ReactNative');
-const StatusBar = require('StatusBar');
-const StyleSheet = require('StyleSheet');
-const UIManager = require('UIManager');
-const View = require('View');
+const Platform = require('../../Utilities/Platform');
+const React = require('react');
+const ReactNative = require('../../Renderer/shims/ReactNative');
+const StatusBar = require('../StatusBar/StatusBar');
+const StyleSheet = require('../../StyleSheet/StyleSheet');
+const UIManager = require('../../ReactNative/UIManager');
+const View = require('../View/View');
 const nullthrows = require('nullthrows');
 
 const DrawerConsts = UIManager.getViewManagerConfig('AndroidDrawerLayout')
   .Constants;
-const dismissKeyboard = require('dismissKeyboard');
-const AndroidDrawerLayoutNativeComponent = require('AndroidDrawerLayoutNativeComponent');
+const dismissKeyboard = require('../../Utilities/dismissKeyboard');
+const AndroidDrawerLayoutNativeComponent = require('./AndroidDrawerLayoutNativeComponent');
 
 const DRAWER_STATES = ['Idle', 'Dragging', 'Settling'];
 
-import type {ViewStyleProp} from 'StyleSheet';
-import type {ColorValue} from 'StyleSheetTypes';
-import type {SyntheticEvent} from 'CoreEventTypes';
+import type {ViewStyleProp} from '../../StyleSheet/StyleSheet';
+import type {ColorValue} from '../../StyleSheet/StyleSheetTypes';
+import type {SyntheticEvent} from '../../Types/CoreEventTypes';
 import type {
   MeasureOnSuccessCallback,
   MeasureInWindowOnSuccessCallback,
   MeasureLayoutOnSuccessCallback,
-} from 'ReactNativeTypes';
+} from '../../Renderer/shims/ReactNativeTypes';
 
 type DrawerStates = 'Idle' | 'Dragging' | 'Settling';
 

--- a/Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.ios.js
+++ b/Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.ios.js
@@ -9,4 +9,4 @@
 
 'use strict';
 
-module.exports = require('UnimplementedView');
+module.exports = require('../UnimplementedViews/UnimplementedView');

--- a/Libraries/Components/DrawerAndroid/__tests__/DrawerAndroid-test.js
+++ b/Libraries/Components/DrawerAndroid/__tests__/DrawerAndroid-test.js
@@ -11,10 +11,10 @@
 
 'use strict';
 
-const React = require('React');
+const React = require('react');
 // $FlowFixMe
 const DrawerLayoutAndroid = require('../DrawerLayoutAndroid.android');
-const View = require('View');
+const View = require('../../View/View');
 
 const render = require('../../../../jest/renderer');
 
@@ -42,7 +42,7 @@ describe('<DrawerLayoutAndroid />', () => {
   });
 
   it('should shallow render as <DrawerLayoutAndroid> when not mocked', () => {
-    jest.dontMock('DrawerLayoutAndroid');
+    jest.dontMock('../DrawerLayoutAndroid');
 
     const output = render.shallow(
       <DrawerLayoutAndroid
@@ -55,7 +55,7 @@ describe('<DrawerLayoutAndroid />', () => {
   });
 
   it('should render as <DrawerLayoutAndroid> when not mocked', () => {
-    jest.dontMock('DrawerLayoutAndroid');
+    jest.dontMock('../DrawerLayoutAndroid');
 
     const instance = render.create(
       <DrawerLayoutAndroid

--- a/Libraries/Components/Keyboard/Keyboard.js
+++ b/Libraries/Components/Keyboard/Keyboard.js
@@ -10,11 +10,12 @@
 
 'use strict';
 
-const LayoutAnimation = require('LayoutAnimation');
+const LayoutAnimation = require('../../LayoutAnimation/LayoutAnimation');
 const invariant = require('invariant');
-const NativeEventEmitter = require('NativeEventEmitter');
-const KeyboardObserver = require('NativeModules').KeyboardObserver;
-const dismissKeyboard = require('dismissKeyboard');
+const NativeEventEmitter = require('../../EventEmitter/NativeEventEmitter');
+const KeyboardObserver = require('../../BatchedBridge/NativeModules')
+  .KeyboardObserver;
+const dismissKeyboard = require('../../Utilities/dismissKeyboard');
 const KeyboardEventEmitter = new NativeEventEmitter(KeyboardObserver);
 
 export type KeyboardEventName =

--- a/Libraries/Components/Keyboard/KeyboardAvoidingView.js
+++ b/Libraries/Components/Keyboard/KeyboardAvoidingView.js
@@ -10,17 +10,21 @@
 
 'use strict';
 
-const Keyboard = require('Keyboard');
-const LayoutAnimation = require('LayoutAnimation');
-const Platform = require('Platform');
-const React = require('React');
-const StyleSheet = require('StyleSheet');
-const View = require('View');
+const Keyboard = require('./Keyboard');
+const LayoutAnimation = require('../../LayoutAnimation/LayoutAnimation');
+const Platform = require('../../Utilities/Platform');
+const React = require('react');
+const StyleSheet = require('../../StyleSheet/StyleSheet');
+const View = require('../View/View');
 
-import type EmitterSubscription from 'EmitterSubscription';
-import type {ViewStyleProp} from 'StyleSheet';
-import type {ViewProps, ViewLayout, ViewLayoutEvent} from 'ViewPropTypes';
-import type {KeyboardEvent} from 'Keyboard';
+import type EmitterSubscription from '../../vendor/emitter/EmitterSubscription';
+import type {ViewStyleProp} from '../../StyleSheet/StyleSheet';
+import type {
+  ViewProps,
+  ViewLayout,
+  ViewLayoutEvent,
+} from '../View/ViewPropTypes';
+import type {KeyboardEvent} from './Keyboard';
 
 type Props = $ReadOnly<{|
   ...ViewProps,

--- a/Libraries/Components/Keyboard/__tests__/Keyboard-test.js
+++ b/Libraries/Components/Keyboard/__tests__/Keyboard-test.js
@@ -11,14 +11,14 @@
 
 'use strict';
 
-const Keyboard = require('Keyboard');
-const dismissKeyboard = require('dismissKeyboard');
-const LayoutAnimation = require('LayoutAnimation');
+const Keyboard = require('../Keyboard');
+const dismissKeyboard = require('../../../Utilities/dismissKeyboard');
+const LayoutAnimation = require('../../../LayoutAnimation/LayoutAnimation');
 
-const NativeEventEmitter = require('NativeEventEmitter');
-const NativeModules = require('NativeModules');
+const NativeEventEmitter = require('../../../EventEmitter/NativeEventEmitter');
+const NativeModules = require('../../../BatchedBridge/NativeModules');
 
-jest.mock('LayoutAnimation');
+jest.mock('../../../LayoutAnimation/LayoutAnimation');
 
 describe('Keyboard', () => {
   beforeEach(() => {

--- a/Libraries/Components/MaskedView/MaskedViewIOS.android.js
+++ b/Libraries/Components/MaskedView/MaskedViewIOS.android.js
@@ -10,4 +10,4 @@
 
 'use strict';
 
-module.exports = require('UnimplementedView');
+module.exports = require('../UnimplementedViews/UnimplementedView');

--- a/Libraries/Components/MaskedView/MaskedViewIOS.ios.js
+++ b/Libraries/Components/MaskedView/MaskedViewIOS.ios.js
@@ -8,12 +8,12 @@
  * @flow
  */
 
-const React = require('React');
-const StyleSheet = require('StyleSheet');
-const View = require('View');
-const RCTMaskedViewNativeComponent = require('RCTMaskedViewNativeComponent');
+const React = require('react');
+const StyleSheet = require('../../StyleSheet/StyleSheet');
+const View = require('../View/View');
+const RCTMaskedViewNativeComponent = require('./RCTMaskedViewNativeComponent');
 
-import type {ViewProps} from 'ViewPropTypes';
+import type {ViewProps} from '../View/ViewPropTypes';
 
 type Props = $ReadOnly<{|
   ...ViewProps,

--- a/Libraries/Components/MaskedView/RCTMaskedViewNativeComponent.js
+++ b/Libraries/Components/MaskedView/RCTMaskedViewNativeComponent.js
@@ -8,10 +8,10 @@
  * @flow
  */
 
-const requireNativeComponent = require('requireNativeComponent');
+const requireNativeComponent = require('../../ReactNative/requireNativeComponent');
 
-import type {ViewProps} from 'ViewPropTypes';
-import type {NativeComponent} from 'ReactNative';
+import type {ViewProps} from '../View/ViewPropTypes';
+import type {NativeComponent} from '../../Renderer/shims/ReactNative';
 
 type NativeProps = $ReadOnly<{|
   ...ViewProps,

--- a/Libraries/Components/MaskedView/__tests__/MaskedViewIOS-test.js
+++ b/Libraries/Components/MaskedView/__tests__/MaskedViewIOS-test.js
@@ -11,10 +11,10 @@
 
 'use strict';
 
-const React = require('React');
-const Text = require('Text');
-const View = require('View');
-const MaskedViewIOS = require('MaskedViewIOS');
+const React = require('react');
+const Text = require('../../../Text/Text');
+const View = require('../../View/View');
+const MaskedViewIOS = require('../MaskedViewIOS');
 
 const render = require('../../../../jest/renderer');
 
@@ -48,7 +48,7 @@ describe('<MaskedViewIOS />', () => {
   });
 
   it('should shallow render as <MaskedViewIOS> when not mocked', () => {
-    jest.dontMock('MaskedViewIOS');
+    jest.dontMock('../MaskedViewIOS');
 
     const output = render.shallow(
       <MaskedViewIOS
@@ -64,7 +64,7 @@ describe('<MaskedViewIOS />', () => {
   });
 
   it('should render as <RCTMaskedView> when not mocked', () => {
-    jest.dontMock('MaskedViewIOS');
+    jest.dontMock('../MaskedViewIOS');
 
     const instance = render.create(
       <MaskedViewIOS

--- a/Libraries/Components/Picker/AndroidDialogPickerNativeComponent.js
+++ b/Libraries/Components/Picker/AndroidDialogPickerNativeComponent.js
@@ -10,11 +10,11 @@
 
 'use strict';
 
-const requireNativeComponent = require('requireNativeComponent');
+const requireNativeComponent = require('../../ReactNative/requireNativeComponent');
 
-import type {SyntheticEvent} from 'CoreEventTypes';
-import type {TextStyleProp} from 'StyleSheet';
-import type {NativeComponent} from 'ReactNative';
+import type {SyntheticEvent} from '../../Types/CoreEventTypes';
+import type {TextStyleProp} from '../../StyleSheet/StyleSheet';
+import type {NativeComponent} from '../../Renderer/shims/ReactNative';
 
 type PickerAndroidChangeEvent = SyntheticEvent<
   $ReadOnly<{|

--- a/Libraries/Components/Picker/AndroidDropdownPickerNativeComponent.js
+++ b/Libraries/Components/Picker/AndroidDropdownPickerNativeComponent.js
@@ -10,11 +10,11 @@
 
 'use strict';
 
-const requireNativeComponent = require('requireNativeComponent');
+const requireNativeComponent = require('../../ReactNative/requireNativeComponent');
 
-import type {SyntheticEvent} from 'CoreEventTypes';
-import type {TextStyleProp} from 'StyleSheet';
-import type {NativeComponent} from 'ReactNative';
+import type {SyntheticEvent} from '../../Types/CoreEventTypes';
+import type {TextStyleProp} from '../../StyleSheet/StyleSheet';
+import type {NativeComponent} from '../../Renderer/shims/ReactNative';
 
 type PickerAndroidChangeEvent = SyntheticEvent<
   $ReadOnly<{|

--- a/Libraries/Components/Picker/Picker.js
+++ b/Libraries/Components/Picker/Picker.js
@@ -10,14 +10,14 @@
 
 'use strict';
 
-const PickerAndroid = require('PickerAndroid');
-const PickerIOS = require('PickerIOS');
-const Platform = require('Platform');
-const React = require('React');
-const UnimplementedView = require('UnimplementedView');
+const PickerAndroid = require('./PickerAndroid');
+const PickerIOS = require('./PickerIOS');
+const Platform = require('../../Utilities/Platform');
+const React = require('react');
+const UnimplementedView = require('../UnimplementedViews/UnimplementedView');
 
-import type {TextStyleProp} from 'StyleSheet';
-import type {ColorValue} from 'StyleSheetTypes';
+import type {TextStyleProp} from '../../StyleSheet/StyleSheet';
+import type {ColorValue} from '../../StyleSheet/StyleSheetTypes';
 
 const MODE_DIALOG = 'dialog';
 const MODE_DROPDOWN = 'dropdown';

--- a/Libraries/Components/Picker/PickerAndroid.android.js
+++ b/Libraries/Components/Picker/PickerAndroid.android.js
@@ -10,18 +10,18 @@
 
 'use strict';
 
-const AndroidDropdownPickerNativeComponent = require('AndroidDropdownPickerNativeComponent');
-const AndroidDialogPickerNativeComponent = require('AndroidDialogPickerNativeComponent');
-const React = require('React');
-const StyleSheet = require('StyleSheet');
+const AndroidDropdownPickerNativeComponent = require('./AndroidDropdownPickerNativeComponent');
+const AndroidDialogPickerNativeComponent = require('./AndroidDialogPickerNativeComponent');
+const React = require('react');
+const StyleSheet = require('../../StyleSheet/StyleSheet');
 
-const processColor = require('processColor');
+const processColor = require('../../StyleSheet/processColor');
 
 const REF_PICKER = 'picker';
 const MODE_DROPDOWN = 'dropdown';
 
-import type {SyntheticEvent} from 'CoreEventTypes';
-import type {TextStyleProp} from 'StyleSheet';
+import type {SyntheticEvent} from '../../Types/CoreEventTypes';
+import type {TextStyleProp} from '../../StyleSheet/StyleSheet';
 
 type PickerAndroidChangeEvent = SyntheticEvent<
   $ReadOnly<{|

--- a/Libraries/Components/Picker/PickerAndroid.ios.js
+++ b/Libraries/Components/Picker/PickerAndroid.ios.js
@@ -9,4 +9,4 @@
 
 'use strict';
 
-module.exports = require('UnimplementedView');
+module.exports = require('../UnimplementedViews/UnimplementedView');

--- a/Libraries/Components/Picker/PickerIOS.android.js
+++ b/Libraries/Components/Picker/PickerIOS.android.js
@@ -12,4 +12,4 @@
 
 'use strict';
 
-module.exports = require('UnimplementedView');
+module.exports = require('../UnimplementedViews/UnimplementedView');

--- a/Libraries/Components/Picker/PickerIOS.ios.js
+++ b/Libraries/Components/Picker/PickerIOS.ios.js
@@ -13,17 +13,17 @@
 
 'use strict';
 
-const React = require('React');
-const ReactNative = require('ReactNative');
-const StyleSheet = require('StyleSheet');
-const View = require('View');
-const processColor = require('processColor');
-const RCTPickerNativeComponent = require('RCTPickerNativeComponent');
+const React = require('react');
+const ReactNative = require('../../Renderer/shims/ReactNative');
+const StyleSheet = require('../../StyleSheet/StyleSheet');
+const View = require('../View/View');
+const processColor = require('../../StyleSheet/processColor');
+const RCTPickerNativeComponent = require('./RCTPickerNativeComponent');
 
-import type {SyntheticEvent} from 'CoreEventTypes';
-import type {ColorValue} from 'StyleSheetTypes';
-import type {ViewProps} from 'ViewPropTypes';
-import type {TextStyleProp} from 'StyleSheet';
+import type {SyntheticEvent} from '../../Types/CoreEventTypes';
+import type {ColorValue} from '../../StyleSheet/StyleSheetTypes';
+import type {ViewProps} from '../View/ViewPropTypes';
+import type {TextStyleProp} from '../../StyleSheet/StyleSheet';
 
 type PickerIOSChangeEvent = SyntheticEvent<
   $ReadOnly<{|

--- a/Libraries/Components/Picker/RCTPickerNativeComponent.js
+++ b/Libraries/Components/Picker/RCTPickerNativeComponent.js
@@ -9,11 +9,11 @@
  */
 'use strict';
 
-const requireNativeComponent = require('requireNativeComponent');
+const requireNativeComponent = require('../../ReactNative/requireNativeComponent');
 
-import type {SyntheticEvent} from 'CoreEventTypes';
-import type {TextStyleProp} from 'StyleSheet';
-import type {NativeComponent} from 'ReactNative';
+import type {SyntheticEvent} from '../../Types/CoreEventTypes';
+import type {TextStyleProp} from '../../StyleSheet/StyleSheet';
+import type {NativeComponent} from '../../Renderer/shims/ReactNative';
 
 type PickerIOSChangeEvent = SyntheticEvent<
   $ReadOnly<{|

--- a/Libraries/Components/Picker/__tests__/Picker-test.js
+++ b/Libraries/Components/Picker/__tests__/Picker-test.js
@@ -11,7 +11,7 @@
 
 'use strict';
 
-const React = require('React');
+const React = require('react');
 const Picker = require('../Picker');
 
 const render = require('../../../../jest/renderer');
@@ -38,7 +38,7 @@ describe('<Picker />', () => {
   });
 
   it('should shallow render as <Picker> when not mocked', () => {
-    jest.dontMock('Picker');
+    jest.dontMock('../Picker');
 
     const output = render.shallow(
       <Picker selectedValue="foo" onValueChange={jest.fn()}>
@@ -50,7 +50,7 @@ describe('<Picker />', () => {
   });
 
   it('should render as <View> when not mocked', () => {
-    jest.dontMock('Picker');
+    jest.dontMock('../Picker');
 
     const instance = render.create(
       <Picker selectedValue="foo" onValueChange={jest.fn()}>

--- a/Libraries/Components/ProgressBarAndroid/ProgressBarAndroid.android.js
+++ b/Libraries/Components/ProgressBarAndroid/ProgressBarAndroid.android.js
@@ -10,11 +10,11 @@
 
 'use strict';
 
-const React = require('React');
+const React = require('react');
 
-const ProgressBarAndroidNativeComponent = require('ProgressBarAndroidNativeComponent');
+const ProgressBarAndroidNativeComponent = require('./ProgressBarAndroidNativeComponent');
 
-import type {ViewProps} from 'ViewPropTypes';
+import type {ViewProps} from '../View/ViewPropTypes';
 
 export type ProgressBarAndroidProps = $ReadOnly<{|
   ...ViewProps,

--- a/Libraries/Components/ProgressBarAndroid/ProgressBarAndroid.ios.js
+++ b/Libraries/Components/ProgressBarAndroid/ProgressBarAndroid.ios.js
@@ -9,4 +9,4 @@
 
 'use strict';
 
-module.exports = require('UnimplementedView');
+module.exports = require('../UnimplementedViews/UnimplementedView');

--- a/Libraries/Components/ProgressBarAndroid/ProgressBarAndroidNativeComponent.js
+++ b/Libraries/Components/ProgressBarAndroid/ProgressBarAndroidNativeComponent.js
@@ -10,10 +10,10 @@
 
 'use strict';
 
-const requireNativeComponent = require('requireNativeComponent');
+const requireNativeComponent = require('../../ReactNative/requireNativeComponent');
 
-import type {ViewProps} from 'ViewPropTypes';
-import type {NativeComponent} from 'ReactNative';
+import type {ViewProps} from '../View/ViewPropTypes';
+import type {NativeComponent} from '../../Renderer/shims/ReactNative';
 
 type NativeProps = $ReadOnly<{|
   ...ViewProps,

--- a/Libraries/Components/ProgressBarAndroid/__tests__/ProgressBarAndroid-test.js
+++ b/Libraries/Components/ProgressBarAndroid/__tests__/ProgressBarAndroid-test.js
@@ -11,7 +11,7 @@
 
 'use strict';
 
-const React = require('React');
+const React = require('react');
 // $FlowFixMe
 const ProgressBarAndroid = require('../ProgressBarAndroid.android');
 
@@ -33,7 +33,7 @@ describe('<ProgressBarAndroid />', () => {
   });
 
   it('should shallow render as <ForwardRef(ProgressBarAndroid)> when not mocked', () => {
-    jest.dontMock('ProgressBarAndroid');
+    jest.dontMock('../ProgressBarAndroid');
 
     const output = render.shallow(
       <ProgressBarAndroid styleAttr="Horizontal" />,
@@ -42,7 +42,7 @@ describe('<ProgressBarAndroid />', () => {
   });
 
   it('should render as <ProgressBarAndroid> when not mocked', () => {
-    jest.dontMock('ProgressBarAndroid');
+    jest.dontMock('../ProgressBarAndroid');
 
     const instance = render.create(
       <ProgressBarAndroid styleAttr="Horizontal" />,

--- a/Libraries/Components/ProgressViewIOS/ProgressViewIOS.android.js
+++ b/Libraries/Components/ProgressViewIOS/ProgressViewIOS.android.js
@@ -9,10 +9,10 @@
 
 'use strict';
 
-const React = require('React');
-const StyleSheet = require('StyleSheet');
-const Text = require('Text');
-const View = require('View');
+const React = require('react');
+const StyleSheet = require('../../StyleSheet/StyleSheet');
+const Text = require('../../Text/Text');
+const View = require('../View/View');
 
 class DummyProgressViewIOS extends React.Component {
   render() {

--- a/Libraries/Components/ProgressViewIOS/ProgressViewIOS.ios.js
+++ b/Libraries/Components/ProgressViewIOS/ProgressViewIOS.ios.js
@@ -10,14 +10,14 @@
 
 'use strict';
 
-const React = require('React');
-const StyleSheet = require('StyleSheet');
+const React = require('react');
+const StyleSheet = require('../../StyleSheet/StyleSheet');
 
-const RCTProgressViewNativeComponent = require('RCTProgressViewNativeComponent');
+const RCTProgressViewNativeComponent = require('./RCTProgressViewNativeComponent');
 
-import type {ImageSource} from 'ImageSource';
-import type {ColorValue} from 'StyleSheetTypes';
-import type {ViewProps} from 'ViewPropTypes';
+import type {ImageSource} from '../../Image/ImageSource';
+import type {ColorValue} from '../../StyleSheet/StyleSheetTypes';
+import type {ViewProps} from '../View/ViewPropTypes';
 
 type Props = $ReadOnly<{|
   ...ViewProps,

--- a/Libraries/Components/ProgressViewIOS/RCTProgressViewNativeComponent.js
+++ b/Libraries/Components/ProgressViewIOS/RCTProgressViewNativeComponent.js
@@ -10,12 +10,12 @@
 
 'use strict';
 
-const requireNativeComponent = require('requireNativeComponent');
+const requireNativeComponent = require('../../ReactNative/requireNativeComponent');
 
-import type {NativeComponent} from 'ReactNative';
-import type {ImageSource} from 'ImageSource';
-import type {ColorValue} from 'StyleSheetTypes';
-import type {ViewProps} from 'ViewPropTypes';
+import type {NativeComponent} from '../../Renderer/shims/ReactNative';
+import type {ImageSource} from '../../Image/ImageSource';
+import type {ColorValue} from '../../StyleSheet/StyleSheetTypes';
+import type {ViewProps} from '../View/ViewPropTypes';
 
 type NativeProps = $ReadOnly<{|
   ...ViewProps,

--- a/Libraries/Components/ProgressViewIOS/__tests__/ProgressViewIOS-test.js
+++ b/Libraries/Components/ProgressViewIOS/__tests__/ProgressViewIOS-test.js
@@ -11,7 +11,7 @@
 
 'use strict';
 
-const React = require('React');
+const React = require('react');
 const ProgressViewIOS = require('../ProgressViewIOS');
 
 const render = require('../../../../jest/renderer');
@@ -28,14 +28,14 @@ describe('<ProgressViewIOS />', () => {
   });
 
   it('should shallow render as <ForwardRef(ProgressViewIOS)> when not mocked', () => {
-    jest.dontMock('ProgressViewIOS');
+    jest.dontMock('../ProgressViewIOS');
 
     const output = render.shallow(<ProgressViewIOS progress={90} />);
     expect(output).toMatchSnapshot();
   });
 
   it('should render as <RCTProgressView> when not mocked', () => {
-    jest.dontMock('ProgressViewIOS');
+    jest.dontMock('../ProgressViewIOS');
 
     const instance = render.create(<ProgressViewIOS progress={90} />);
     expect(instance).toMatchSnapshot();

--- a/Libraries/Components/RefreshControl/AndroidSwipeRefreshLayoutNativeComponent.js
+++ b/Libraries/Components/RefreshControl/AndroidSwipeRefreshLayoutNativeComponent.js
@@ -10,13 +10,13 @@
 
 'use strict';
 
-const requireNativeComponent = require('requireNativeComponent');
+const requireNativeComponent = require('../../ReactNative/requireNativeComponent');
 
-import type {ColorValue} from 'StyleSheetTypes';
-import type {ViewProps} from 'ViewPropTypes';
-import type {NativeComponent} from 'ReactNative';
+import type {ColorValue} from '../../StyleSheet/StyleSheetTypes';
+import type {ViewProps} from '../View/ViewPropTypes';
+import type {NativeComponent} from '../../Renderer/shims/ReactNative';
 
-const AndroidSwipeRefreshLayout = require('UIManager').getViewManagerConfig(
+const AndroidSwipeRefreshLayout = require('../../ReactNative/UIManager').getViewManagerConfig(
   'AndroidSwipeRefreshLayout',
 );
 const RefreshLayoutConsts = AndroidSwipeRefreshLayout

--- a/Libraries/Components/RefreshControl/RCTRefreshControlNativeComponent.js
+++ b/Libraries/Components/RefreshControl/RCTRefreshControlNativeComponent.js
@@ -10,11 +10,11 @@
 
 'use strict';
 
-const requireNativeComponent = require('requireNativeComponent');
+const requireNativeComponent = require('../../ReactNative/requireNativeComponent');
 
-import type {ColorValue} from 'StyleSheetTypes';
-import type {ViewProps} from 'ViewPropTypes';
-import type {NativeComponent} from 'ReactNative';
+import type {ColorValue} from '../../StyleSheet/StyleSheetTypes';
+import type {ViewProps} from '../View/ViewPropTypes';
+import type {NativeComponent} from '../../Renderer/shims/ReactNative';
 
 export type NativeProps = $ReadOnly<{|
   ...ViewProps,

--- a/Libraries/Components/RefreshControl/RefreshControl.js
+++ b/Libraries/Components/RefreshControl/RefreshControl.js
@@ -10,20 +10,20 @@
 
 'use strict';
 
-const Platform = require('Platform');
-const React = require('React');
-const {NativeComponent} = require('ReactNative');
+const Platform = require('../../Utilities/Platform');
+const React = require('react');
+const {NativeComponent} = require('../../Renderer/shims/ReactNative');
 
-const AndroidSwipeRefreshLayoutNativeComponent = require('AndroidSwipeRefreshLayoutNativeComponent');
-const RCTRefreshControlNativeComponent = require('RCTRefreshControlNativeComponent');
+const AndroidSwipeRefreshLayoutNativeComponent = require('./AndroidSwipeRefreshLayoutNativeComponent');
+const RCTRefreshControlNativeComponent = require('./RCTRefreshControlNativeComponent');
 const nullthrows = require('nullthrows');
 
-import type {ColorValue} from 'StyleSheetTypes';
-import type {ViewProps} from 'ViewPropTypes';
+import type {ColorValue} from '../../StyleSheet/StyleSheetTypes';
+import type {ViewProps} from '../View/ViewPropTypes';
 
 let RefreshLayoutConsts;
 if (Platform.OS === 'android') {
-  const AndroidSwipeRefreshLayout = require('UIManager').getViewManagerConfig(
+  const AndroidSwipeRefreshLayout = require('../../ReactNative/UIManager').getViewManagerConfig(
     'AndroidSwipeRefreshLayout',
   );
   RefreshLayoutConsts = AndroidSwipeRefreshLayout

--- a/Libraries/Components/RefreshControl/__mocks__/RefreshControlMock.js
+++ b/Libraries/Components/RefreshControl/__mocks__/RefreshControlMock.js
@@ -10,9 +10,9 @@
 
 'use strict';
 
-const React = require('React');
+const React = require('react');
 
-const requireNativeComponent = require('requireNativeComponent');
+const requireNativeComponent = require('../../../ReactNative/requireNativeComponent');
 
 const RCTRefreshControl = requireNativeComponent('RCTRefreshControl');
 

--- a/Libraries/Components/SafeAreaView/RCTSafeAreaViewNativeComponent.js
+++ b/Libraries/Components/SafeAreaView/RCTSafeAreaViewNativeComponent.js
@@ -8,10 +8,10 @@
  * @flow
  */
 
-const requireNativeComponent = require('requireNativeComponent');
+const requireNativeComponent = require('../../ReactNative/requireNativeComponent');
 
-import type {ViewProps} from 'ViewPropTypes';
-import type {NativeComponent} from 'ReactNative';
+import type {ViewProps} from '../View/ViewPropTypes';
+import type {NativeComponent} from '../../Renderer/shims/ReactNative';
 
 type NativeProps = $ReadOnly<{|
   ...ViewProps,

--- a/Libraries/Components/SafeAreaView/SafeAreaView.js
+++ b/Libraries/Components/SafeAreaView/SafeAreaView.js
@@ -8,12 +8,12 @@
  * @format
  */
 
-const Platform = require('Platform');
-const React = require('React');
-const View = require('View');
+const Platform = require('../../Utilities/Platform');
+const React = require('react');
+const View = require('../View/View');
 
-import type {ViewProps} from 'ViewPropTypes';
-import type {NativeComponent} from 'ReactNative';
+import type {ViewProps} from '../View/ViewPropTypes';
+import type {NativeComponent} from '../../Renderer/shims/ReactNative';
 
 type Props = $ReadOnly<{|
   ...ViewProps,
@@ -44,7 +44,7 @@ if (Platform.OS === 'android') {
   SafeAreaViewRef.displayName = 'SafeAreaView';
   exported = ((SafeAreaViewRef: any): Class<React.Component<Props>>);
 } else {
-  const RCTSafeAreaViewNativeComponent = require('RCTSafeAreaViewNativeComponent');
+  const RCTSafeAreaViewNativeComponent = require('./RCTSafeAreaViewNativeComponent');
 
   const SafeAreaView = (
     props: Props,

--- a/Libraries/Components/SafeAreaView/__tests__/SafeAreaView-test.js
+++ b/Libraries/Components/SafeAreaView/__tests__/SafeAreaView-test.js
@@ -11,11 +11,11 @@
 
 'use strict';
 
-const React = require('React');
-const SafeAreaView = require('SafeAreaView');
+const React = require('react');
+const SafeAreaView = require('../SafeAreaView');
 const render = require('../../../../jest/renderer');
-const View = require('View');
-const Text = require('Text');
+const View = require('../../View/View');
+const Text = require('../../../Text/Text');
 
 describe('<SafeAreaView />', () => {
   it('should render as <SafeAreaView> when mocked', () => {
@@ -41,7 +41,7 @@ describe('<SafeAreaView />', () => {
   });
 
   it('should shallow render as <ForwardRef(SafeAreaView)> when not mocked', () => {
-    jest.dontMock('SafeAreaView');
+    jest.dontMock('../SafeAreaView');
 
     const output = render.shallow(
       <SafeAreaView>
@@ -54,7 +54,7 @@ describe('<SafeAreaView />', () => {
   });
 
   it('should render as <SafeAreaView> when not mocked', () => {
-    jest.dontMock('SafeAreaView');
+    jest.dontMock('../SafeAreaView');
 
     const instance = render.create(
       <SafeAreaView>

--- a/Libraries/Components/ScrollResponder.js
+++ b/Libraries/Components/ScrollResponder.js
@@ -10,23 +10,23 @@
 
 'use strict';
 
-const Dimensions = require('Dimensions');
-const FrameRateLogger = require('FrameRateLogger');
-const Keyboard = require('Keyboard');
-const ReactNative = require('ReactNative');
-const TextInputState = require('TextInputState');
-const UIManager = require('UIManager');
+const Dimensions = require('../Utilities/Dimensions');
+const FrameRateLogger = require('../Interaction/FrameRateLogger');
+const Keyboard = require('./Keyboard/Keyboard');
+const ReactNative = require('../Renderer/shims/ReactNative');
+const TextInputState = require('./TextInput/TextInputState');
+const UIManager = require('../ReactNative/UIManager');
 
 const invariant = require('invariant');
 const nullthrows = require('nullthrows');
 const performanceNow = require('fbjs/lib/performanceNow');
 const warning = require('fbjs/lib/warning');
 
-const {ScrollViewManager} = require('NativeModules');
+const {ScrollViewManager} = require('../BatchedBridge/NativeModules');
 
-import type {PressEvent, ScrollEvent} from 'CoreEventTypes';
-import type {KeyboardEvent} from 'Keyboard';
-import type EmitterSubscription from 'EmitterSubscription';
+import type {PressEvent, ScrollEvent} from '../Types/CoreEventTypes';
+import type {KeyboardEvent} from './Keyboard/Keyboard';
+import type EmitterSubscription from '../vendor/emitter/EmitterSubscription';
 
 /**
  * Mixin that can be integrated in order to handle scrolling that plays well

--- a/Libraries/Components/ScrollView/ScrollView.js
+++ b/Libraries/Components/ScrollView/ScrollView.js
@@ -10,31 +10,35 @@
 
 'use strict';
 
-const AnimatedImplementation = require('AnimatedImplementation');
-const Platform = require('Platform');
-const React = require('React');
-const ReactNative = require('ReactNative');
-const ScrollResponder = require('ScrollResponder');
-const ScrollViewStickyHeader = require('ScrollViewStickyHeader');
-const StyleSheet = require('StyleSheet');
-const View = require('View');
+const AnimatedImplementation = require('../../Animated/src/AnimatedImplementation');
+const Platform = require('../../Utilities/Platform');
+const React = require('react');
+const ReactNative = require('../../Renderer/shims/ReactNative');
+const ScrollResponder = require('../ScrollResponder');
+const ScrollViewStickyHeader = require('./ScrollViewStickyHeader');
+const StyleSheet = require('../../StyleSheet/StyleSheet');
+const View = require('../View/View');
 
-const dismissKeyboard = require('dismissKeyboard');
-const flattenStyle = require('flattenStyle');
+const dismissKeyboard = require('../../Utilities/dismissKeyboard');
+const flattenStyle = require('../../StyleSheet/flattenStyle');
 const invariant = require('invariant');
-const processDecelerationRate = require('processDecelerationRate');
-const requireNativeComponent = require('requireNativeComponent');
-const resolveAssetSource = require('resolveAssetSource');
+const processDecelerationRate = require('./processDecelerationRate');
+const requireNativeComponent = require('../../ReactNative/requireNativeComponent');
+const resolveAssetSource = require('../../Image/resolveAssetSource');
 
-import type {PressEvent, ScrollEvent, LayoutEvent} from 'CoreEventTypes';
-import type {EdgeInsetsProp} from 'EdgeInsetsPropType';
-import type {NativeMethodsMixinType} from 'ReactNativeTypes';
-import type {ViewStyleProp} from 'StyleSheet';
-import type {ViewProps} from 'ViewPropTypes';
-import type {PointProp} from 'PointPropType';
+import type {
+  PressEvent,
+  ScrollEvent,
+  LayoutEvent,
+} from '../../Types/CoreEventTypes';
+import type {EdgeInsetsProp} from '../../StyleSheet/EdgeInsetsPropType';
+import type {NativeMethodsMixinType} from '../../Renderer/shims/ReactNativeTypes';
+import type {ViewStyleProp} from '../../StyleSheet/StyleSheet';
+import type {ViewProps} from '../View/ViewPropTypes';
+import type {PointProp} from '../../StyleSheet/PointPropType';
 
-import type {ColorValue} from 'StyleSheetTypes';
-import type {State as ScrollResponderState} from 'ScrollResponder';
+import type {ColorValue} from '../../StyleSheet/StyleSheetTypes';
+import type {State as ScrollResponderState} from '../ScrollResponder';
 
 let AndroidScrollView;
 let AndroidHorizontalScrollContentView;

--- a/Libraries/Components/ScrollView/ScrollViewStickyHeader.js
+++ b/Libraries/Components/ScrollView/ScrollViewStickyHeader.js
@@ -9,12 +9,12 @@
  */
 'use strict';
 
-const AnimatedImplementation = require('AnimatedImplementation');
-const React = require('React');
-const StyleSheet = require('StyleSheet');
-const View = require('View');
+const AnimatedImplementation = require('../../Animated/src/AnimatedImplementation');
+const React = require('react');
+const StyleSheet = require('../../StyleSheet/StyleSheet');
+const View = require('../View/View');
 
-import type {LayoutEvent} from 'CoreEventTypes';
+import type {LayoutEvent} from '../../Types/CoreEventTypes';
 
 const AnimatedView = AnimatedImplementation.createAnimatedComponent(View);
 

--- a/Libraries/Components/ScrollView/__mocks__/ScrollViewMock.js
+++ b/Libraries/Components/ScrollView/__mocks__/ScrollViewMock.js
@@ -12,14 +12,14 @@
 
 'use strict';
 
-const React = require('React');
-const View = require('View');
+const React = require('react');
+const View = require('../../View/View');
 
-const requireNativeComponent = require('requireNativeComponent');
+const requireNativeComponent = require('../../../ReactNative/requireNativeComponent');
 
 const RCTScrollView = requireNativeComponent('RCTScrollView');
 
-const ScrollViewComponent = jest.genMockFromModule('ScrollView');
+const ScrollViewComponent = jest.genMockFromModule('../ScrollView');
 
 class ScrollViewMock extends ScrollViewComponent {
   render() {

--- a/Libraries/Components/ScrollView/processDecelerationRate.js
+++ b/Libraries/Components/ScrollView/processDecelerationRate.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const Platform = require('Platform');
+const Platform = require('../../Utilities/Platform');
 
 function processDecelerationRate(
   decelerationRate: number | 'normal' | 'fast',

--- a/Libraries/Components/SegmentedControlIOS/RCTSegmentedControlNativeComponent.js
+++ b/Libraries/Components/SegmentedControlIOS/RCTSegmentedControlNativeComponent.js
@@ -9,11 +9,11 @@
  */
 'use strict';
 
-const requireNativeComponent = require('requireNativeComponent');
+const requireNativeComponent = require('../../ReactNative/requireNativeComponent');
 
-import type {ViewProps} from 'ViewPropTypes';
-import type {SyntheticEvent} from 'CoreEventTypes';
-import type {NativeComponent} from 'ReactNative';
+import type {ViewProps} from '../View/ViewPropTypes';
+import type {SyntheticEvent} from '../../Types/CoreEventTypes';
+import type {NativeComponent} from '../../Renderer/shims/ReactNative';
 
 type Event = SyntheticEvent<
   $ReadOnly<{|

--- a/Libraries/Components/SegmentedControlIOS/SegmentedControlIOS.android.js
+++ b/Libraries/Components/SegmentedControlIOS/SegmentedControlIOS.android.js
@@ -9,10 +9,10 @@
 
 'use strict';
 
-const React = require('React');
-const StyleSheet = require('StyleSheet');
-const Text = require('Text');
-const View = require('View');
+const React = require('react');
+const StyleSheet = require('../../StyleSheet/StyleSheet');
+const Text = require('../../Text/Text');
+const View = require('../View/View');
 
 class DummySegmentedControlIOS extends React.Component {
   render() {

--- a/Libraries/Components/SegmentedControlIOS/SegmentedControlIOS.ios.js
+++ b/Libraries/Components/SegmentedControlIOS/SegmentedControlIOS.ios.js
@@ -10,13 +10,13 @@
 
 'use strict';
 
-const React = require('React');
-const StyleSheet = require('StyleSheet');
+const React = require('react');
+const StyleSheet = require('../../StyleSheet/StyleSheet');
 
-const RCTSegmentedControlNativeComponent = require('RCTSegmentedControlNativeComponent');
+const RCTSegmentedControlNativeComponent = require('./RCTSegmentedControlNativeComponent');
 
-import type {SyntheticEvent} from 'CoreEventTypes';
-import type {ViewProps} from 'ViewPropTypes';
+import type {SyntheticEvent} from '../../Types/CoreEventTypes';
+import type {ViewProps} from '../View/ViewPropTypes';
 
 type Event = SyntheticEvent<
   $ReadOnly<{|

--- a/Libraries/Components/Slider/RCTSliderNativeComponent.js
+++ b/Libraries/Components/Slider/RCTSliderNativeComponent.js
@@ -10,13 +10,13 @@
 
 'use strict';
 
-const requireNativeComponent = require('requireNativeComponent');
+const requireNativeComponent = require('../../ReactNative/requireNativeComponent');
 
-import type {ColorValue} from 'StyleSheetTypes';
-import type {ImageSource} from 'ImageSource';
-import type {NativeComponent} from 'ReactNative';
-import type {SyntheticEvent} from 'CoreEventTypes';
-import type {ViewProps} from 'ViewPropTypes';
+import type {ColorValue} from '../../StyleSheet/StyleSheetTypes';
+import type {ImageSource} from '../../Image/ImageSource';
+import type {NativeComponent} from '../../Renderer/shims/ReactNative';
+import type {SyntheticEvent} from '../../Types/CoreEventTypes';
+import type {ViewProps} from '../View/ViewPropTypes';
 
 type Event = SyntheticEvent<
   $ReadOnly<{|

--- a/Libraries/Components/Slider/Slider.js
+++ b/Libraries/Components/Slider/Slider.js
@@ -10,17 +10,17 @@
 
 'use strict';
 
-const Platform = require('Platform');
-const RCTSliderNativeComponent = require('RCTSliderNativeComponent');
-const React = require('React');
-const ReactNative = require('ReactNative');
-const StyleSheet = require('StyleSheet');
+const Platform = require('../../Utilities/Platform');
+const RCTSliderNativeComponent = require('./RCTSliderNativeComponent');
+const React = require('react');
+const ReactNative = require('../../Renderer/shims/ReactNative');
+const StyleSheet = require('../../StyleSheet/StyleSheet');
 
-import type {ImageSource} from 'ImageSource';
-import type {ViewStyleProp} from 'StyleSheet';
-import type {ColorValue} from 'StyleSheetTypes';
-import type {ViewProps} from 'ViewPropTypes';
-import type {SyntheticEvent} from 'CoreEventTypes';
+import type {ImageSource} from '../../Image/ImageSource';
+import type {ViewStyleProp} from '../../StyleSheet/StyleSheet';
+import type {ColorValue} from '../../StyleSheet/StyleSheetTypes';
+import type {ViewProps} from '../View/ViewPropTypes';
+import type {SyntheticEvent} from '../../Types/CoreEventTypes';
 
 type Event = SyntheticEvent<
   $ReadOnly<{|

--- a/Libraries/Components/StaticContainer.react.js
+++ b/Libraries/Components/StaticContainer.react.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const React = require('React');
+const React = require('react');
 
 /**
  * Renders static content efficiently by allowing React to short-circuit the

--- a/Libraries/Components/StaticRenderer.js
+++ b/Libraries/Components/StaticRenderer.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const React = require('React');
+const React = require('react');
 
 type Props = $ReadOnly<{|
   /**

--- a/Libraries/Components/StatusBar/StatusBar.js
+++ b/Libraries/Components/StatusBar/StatusBar.js
@@ -10,12 +10,13 @@
 
 'use strict';
 
-const React = require('React');
-const Platform = require('Platform');
+const React = require('react');
+const Platform = require('../../Utilities/Platform');
 
-const processColor = require('processColor');
+const processColor = require('../../StyleSheet/processColor');
 
-const StatusBarManager = require('NativeModules').StatusBarManager;
+const StatusBarManager = require('../../BatchedBridge/NativeModules')
+  .StatusBarManager;
 
 /**
  * Status bar style

--- a/Libraries/Components/StatusBar/StatusBarIOS.android.js
+++ b/Libraries/Components/StatusBar/StatusBarIOS.android.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const NativeEventEmitter = require('NativeEventEmitter');
+const NativeEventEmitter = require('../../EventEmitter/NativeEventEmitter');
 
 /* $FlowFixMe(>=0.78.0 site=react_native_android_fb) This issue was found when
  * making Flow check .android.js files. */

--- a/Libraries/Components/StatusBar/StatusBarIOS.ios.js
+++ b/Libraries/Components/StatusBar/StatusBarIOS.ios.js
@@ -10,8 +10,8 @@
 
 'use strict';
 
-const NativeEventEmitter = require('NativeEventEmitter');
-const {StatusBarManager} = require('NativeModules');
+const NativeEventEmitter = require('../../EventEmitter/NativeEventEmitter');
+const {StatusBarManager} = require('../../BatchedBridge/NativeModules');
 
 /**
  * Use `StatusBar` for mutating the status bar.

--- a/Libraries/Components/Switch/Switch.js
+++ b/Libraries/Components/Switch/Switch.js
@@ -10,15 +10,15 @@
 
 'use strict';
 
-const SwitchNativeComponent = require('SwitchNativeComponent');
-const Platform = require('Platform');
-const React = require('React');
-const StyleSheet = require('StyleSheet');
+const SwitchNativeComponent = require('./SwitchNativeComponent');
+const Platform = require('../../Utilities/Platform');
+const React = require('react');
+const StyleSheet = require('../../StyleSheet/StyleSheet');
 
-import type {SwitchChangeEvent} from 'CoreEventTypes';
-import type {ColorValue} from 'StyleSheetTypes';
-import type {ViewProps} from 'ViewPropTypes';
-import type {NativeAndroidProps, NativeIOSProps} from 'SwitchNativeComponent';
+import type {SwitchChangeEvent} from '../../Types/CoreEventTypes';
+import type {ColorValue} from '../../StyleSheet/StyleSheetTypes';
+import type {ViewProps} from '../View/ViewPropTypes';
+import type {NativeAndroidProps, NativeIOSProps} from './SwitchNativeComponent';
 
 export type Props = $ReadOnly<{|
   ...ViewProps,

--- a/Libraries/Components/Switch/SwitchNativeComponent.js
+++ b/Libraries/Components/Switch/SwitchNativeComponent.js
@@ -10,13 +10,13 @@
 
 'use strict';
 
-const Platform = require('Platform');
-const ReactNative = require('ReactNative');
+const Platform = require('../../Utilities/Platform');
+const ReactNative = require('../../Renderer/shims/ReactNative');
 
-const requireNativeComponent = require('requireNativeComponent');
+const requireNativeComponent = require('../../ReactNative/requireNativeComponent');
 
-import type {SwitchChangeEvent} from 'CoreEventTypes';
-import type {ViewProps} from 'ViewPropTypes';
+import type {SwitchChangeEvent} from '../../Types/CoreEventTypes';
+import type {ViewProps} from '../View/ViewPropTypes';
 
 type SwitchProps = $ReadOnly<{|
   ...ViewProps,

--- a/Libraries/Components/TextInput/InputAccessoryView.js
+++ b/Libraries/Components/TextInput/InputAccessoryView.js
@@ -9,14 +9,14 @@
  */
 'use strict';
 
-const DeprecatedColorPropType = require('DeprecatedColorPropType');
-const Platform = require('Platform');
-const React = require('React');
-const StyleSheet = require('StyleSheet');
+const DeprecatedColorPropType = require('../../DeprecatedPropTypes/DeprecatedColorPropType');
+const Platform = require('../../Utilities/Platform');
+const React = require('react');
+const StyleSheet = require('../../StyleSheet/StyleSheet');
 
-const RCTInputAccessoryViewNativeComponent = require('RCTInputAccessoryViewNativeComponent');
+const RCTInputAccessoryViewNativeComponent = require('./RCTInputAccessoryViewNativeComponent');
 
-import type {ViewStyleProp} from 'StyleSheet';
+import type {ViewStyleProp} from '../../StyleSheet/StyleSheet';
 
 /**
  * Note: iOS only

--- a/Libraries/Components/TextInput/RCTInputAccessoryViewNativeComponent.js
+++ b/Libraries/Components/TextInput/RCTInputAccessoryViewNativeComponent.js
@@ -9,12 +9,12 @@
  */
 'use strict';
 
-import type {NativeComponent} from 'ReactNative';
-import type {ColorValue} from 'StyleSheetTypes';
-import type {ViewStyleProp} from 'StyleSheet';
+import type {NativeComponent} from '../../Renderer/shims/ReactNative';
+import type {ColorValue} from '../../StyleSheet/StyleSheetTypes';
+import type {ViewStyleProp} from '../../StyleSheet/StyleSheet';
 
-const React = require('React');
-const requireNativeComponent = require('requireNativeComponent');
+const React = require('react');
+const requireNativeComponent = require('../../ReactNative/requireNativeComponent');
 
 type NativeProps = $ReadOnly<{|
   +children: React.Node,

--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -9,31 +9,31 @@
  */
 'use strict';
 
-const DeprecatedColorPropType = require('DeprecatedColorPropType');
-const DeprecatedViewPropTypes = require('DeprecatedViewPropTypes');
-const DocumentSelectionState = require('DocumentSelectionState');
-const NativeMethodsMixin = require('NativeMethodsMixin');
-const Platform = require('Platform');
+const DeprecatedColorPropType = require('../../DeprecatedPropTypes/DeprecatedColorPropType');
+const DeprecatedViewPropTypes = require('../../DeprecatedPropTypes/DeprecatedViewPropTypes');
+const DocumentSelectionState = require('../../vendor/document/selection/DocumentSelectionState');
+const NativeMethodsMixin = require('../../Renderer/shims/NativeMethodsMixin');
+const Platform = require('../../Utilities/Platform');
 const PropTypes = require('prop-types');
-const React = require('React');
-const ReactNative = require('ReactNative');
-const StyleSheet = require('StyleSheet');
-const Text = require('Text');
-const TextAncestor = require('TextAncestor');
-const TextInputState = require('TextInputState');
-const TouchableWithoutFeedback = require('TouchableWithoutFeedback');
-const UIManager = require('UIManager');
+const React = require('react');
+const ReactNative = require('../../Renderer/shims/ReactNative');
+const StyleSheet = require('../../StyleSheet/StyleSheet');
+const Text = require('../../Text/Text');
+const TextAncestor = require('../../Text/TextAncestor');
+const TextInputState = require('./TextInputState');
+const TouchableWithoutFeedback = require('../Touchable/TouchableWithoutFeedback');
+const UIManager = require('../../ReactNative/UIManager');
 
 const createReactClass = require('create-react-class');
 const invariant = require('invariant');
-const requireNativeComponent = require('requireNativeComponent');
+const requireNativeComponent = require('../../ReactNative/requireNativeComponent');
 const warning = require('fbjs/lib/warning');
 
-import type {TextStyleProp, ViewStyleProp} from 'StyleSheet';
-import type {ColorValue} from 'StyleSheetTypes';
-import type {ViewProps} from 'ViewPropTypes';
-import type {SyntheticEvent, ScrollEvent} from 'CoreEventTypes';
-import type {PressEvent} from 'CoreEventTypes';
+import type {TextStyleProp, ViewStyleProp} from '../../StyleSheet/StyleSheet';
+import type {ColorValue} from '../../StyleSheet/StyleSheetTypes';
+import type {ViewProps} from '../View/ViewPropTypes';
+import type {SyntheticEvent, ScrollEvent} from '../../Types/CoreEventTypes';
+import type {PressEvent} from '../../Types/CoreEventTypes';
 
 let AndroidTextInput;
 let RCTMultilineTextInputView;

--- a/Libraries/Components/TextInput/TextInputState.js
+++ b/Libraries/Components/TextInput/TextInputState.js
@@ -15,8 +15,8 @@
 
 'use strict';
 
-const Platform = require('Platform');
-const UIManager = require('UIManager');
+const Platform = require('../../Utilities/Platform');
+const UIManager = require('../../ReactNative/UIManager');
 
 let currentlyFocusedID: ?number = null;
 const inputs = new Set();

--- a/Libraries/Components/TextInput/__tests__/InputAccessoryView-test.js
+++ b/Libraries/Components/TextInput/__tests__/InputAccessoryView-test.js
@@ -11,9 +11,9 @@
 
 'use strict';
 
-const React = require('React');
-const View = require('View');
-const InputAccessoryView = require('InputAccessoryView');
+const React = require('react');
+const View = require('../../View/View');
+const InputAccessoryView = require('../InputAccessoryView');
 const render = require('../../../../jest/renderer');
 
 describe('<InputAccessoryView />', () => {
@@ -36,7 +36,7 @@ describe('<InputAccessoryView />', () => {
   });
 
   it('should shallow render as <InputAccessoryView> when not mocked', () => {
-    jest.dontMock('InputAccessoryView');
+    jest.dontMock('../InputAccessoryView');
 
     const output = render.shallow(
       <InputAccessoryView nativeID="1">
@@ -47,7 +47,7 @@ describe('<InputAccessoryView />', () => {
   });
 
   it('should render as <RCTInputAccessoryView> when not mocked', () => {
-    jest.dontMock('InputAccessoryView');
+    jest.dontMock('../InputAccessoryView');
 
     const instance = render.create(
       <InputAccessoryView nativeID="1">

--- a/Libraries/Components/TextInput/__tests__/TextInput-test.js
+++ b/Libraries/Components/TextInput/__tests__/TextInput-test.js
@@ -11,15 +11,15 @@
 
 'use strict';
 
-const React = require('React');
+const React = require('react');
 const ReactTestRenderer = require('react-test-renderer');
-const TextInput = require('TextInput');
+const TextInput = require('../TextInput');
 
 import Component from '@reactions/component';
 
-const {enter} = require('ReactNativeTestTools');
+const {enter} = require('../../../Utilities/ReactNativeTestTools');
 
-jest.unmock('TextInput');
+jest.unmock('../TextInput');
 
 describe('TextInput tests', () => {
   let input;

--- a/Libraries/Components/TimePickerAndroid/TimePickerAndroid.android.js
+++ b/Libraries/Components/TimePickerAndroid/TimePickerAndroid.android.js
@@ -10,7 +10,8 @@
 
 'use strict';
 
-const TimePickerModule = require('NativeModules').TimePickerAndroid;
+const TimePickerModule = require('../../BatchedBridge/NativeModules')
+  .TimePickerAndroid;
 
 import type {
   TimePickerOptions,

--- a/Libraries/Components/ToastAndroid/ToastAndroid.android.js
+++ b/Libraries/Components/ToastAndroid/ToastAndroid.android.js
@@ -10,7 +10,8 @@
 
 'use strict';
 
-const RCTToastAndroid = require('NativeModules').ToastAndroid;
+const RCTToastAndroid = require('../../BatchedBridge/NativeModules')
+  .ToastAndroid;
 
 /**
  * This exposes the native ToastAndroid module as a JS module. This has a function 'show'

--- a/Libraries/Components/ToolbarAndroid/ToolbarAndroid.android.js
+++ b/Libraries/Components/ToolbarAndroid/ToolbarAndroid.android.js
@@ -10,17 +10,17 @@
 
 'use strict';
 
-const React = require('React');
-const UIManager = require('UIManager');
+const React = require('react');
+const UIManager = require('../../ReactNative/UIManager');
 
-const ToolbarAndroidNativeComponent = require('ToolbarAndroidNativeComponent');
-const resolveAssetSource = require('resolveAssetSource');
+const ToolbarAndroidNativeComponent = require('./ToolbarAndroidNativeComponent');
+const resolveAssetSource = require('../../Image/resolveAssetSource');
 
-import type {SyntheticEvent} from 'CoreEventTypes';
-import type {ImageSource} from 'ImageSource';
-import type {ColorValue} from 'StyleSheetTypes';
-import type {ViewProps} from 'ViewPropTypes';
-import type {NativeComponent} from 'ReactNative';
+import type {SyntheticEvent} from '../../Types/CoreEventTypes';
+import type {ImageSource} from '../../Image/ImageSource';
+import type {ColorValue} from '../../StyleSheet/StyleSheetTypes';
+import type {ViewProps} from '../View/ViewPropTypes';
+import type {NativeComponent} from '../../Renderer/shims/ReactNative';
 
 /**
  * React component that wraps the Android-only [`Toolbar` widget][0]. A Toolbar can display a logo,

--- a/Libraries/Components/ToolbarAndroid/ToolbarAndroid.ios.js
+++ b/Libraries/Components/ToolbarAndroid/ToolbarAndroid.ios.js
@@ -9,4 +9,4 @@
 
 'use strict';
 
-module.exports = require('UnimplementedView');
+module.exports = require('../UnimplementedViews/UnimplementedView');

--- a/Libraries/Components/ToolbarAndroid/ToolbarAndroidNativeComponent.js
+++ b/Libraries/Components/ToolbarAndroid/ToolbarAndroidNativeComponent.js
@@ -10,12 +10,12 @@
 
 'use strict';
 
-const requireNativeComponent = require('requireNativeComponent');
+const requireNativeComponent = require('../../ReactNative/requireNativeComponent');
 
-import type {SyntheticEvent} from 'CoreEventTypes';
-import type {ImageSource} from 'ImageSource';
-import type {ViewProps} from 'ViewPropTypes';
-import type {NativeComponent} from 'ReactNative';
+import type {SyntheticEvent} from '../../Types/CoreEventTypes';
+import type {ImageSource} from '../../Image/ImageSource';
+import type {ViewProps} from '../View/ViewPropTypes';
+import type {NativeComponent} from '../../Renderer/shims/ReactNative';
 
 type Action = $ReadOnly<{|
   title: string,

--- a/Libraries/Components/Touchable/BoundingDimensions.js
+++ b/Libraries/Components/Touchable/BoundingDimensions.js
@@ -9,7 +9,7 @@
 
 'use strict';
 
-const PooledClass = require('PooledClass');
+const PooledClass = require('./PooledClass');
 
 const twoArgumentPooler = PooledClass.twoArgumentPooler;
 

--- a/Libraries/Components/Touchable/Position.js
+++ b/Libraries/Components/Touchable/Position.js
@@ -9,7 +9,7 @@
 
 'use strict';
 
-const PooledClass = require('PooledClass');
+const PooledClass = require('./PooledClass');
 
 const twoArgumentPooler = PooledClass.twoArgumentPooler;
 

--- a/Libraries/Components/Touchable/Touchable.js
+++ b/Libraries/Components/Touchable/Touchable.js
@@ -10,21 +10,21 @@
 
 'use strict';
 
-const BoundingDimensions = require('BoundingDimensions');
-const Platform = require('Platform');
-const Position = require('Position');
-const React = require('React');
-const ReactNative = require('ReactNative');
-const StyleSheet = require('StyleSheet');
-const TVEventHandler = require('TVEventHandler');
-const UIManager = require('UIManager');
-const View = require('View');
+const BoundingDimensions = require('./BoundingDimensions');
+const Platform = require('../../Utilities/Platform');
+const Position = require('./Position');
+const React = require('react');
+const ReactNative = require('../../Renderer/shims/ReactNative');
+const StyleSheet = require('../../StyleSheet/StyleSheet');
+const TVEventHandler = require('../AppleTV/TVEventHandler');
+const UIManager = require('../../ReactNative/UIManager');
+const View = require('../View/View');
 
 const keyMirror = require('fbjs/lib/keyMirror');
-const normalizeColor = require('normalizeColor');
+const normalizeColor = require('../../Color/normalizeColor');
 
-import type {PressEvent} from 'CoreEventTypes';
-import type {EdgeInsetsProp} from 'EdgeInsetsPropType';
+import type {PressEvent} from '../../Types/CoreEventTypes';
+import type {EdgeInsetsProp} from '../../StyleSheet/EdgeInsetsPropType';
 
 const extractSingleTouch = nativeEvent => {
   const touches = nativeEvent.touches;

--- a/Libraries/Components/Touchable/TouchableBounce.js
+++ b/Libraries/Components/Touchable/TouchableBounce.js
@@ -9,22 +9,22 @@
  */
 'use strict';
 
-const Animated = require('Animated');
-const DeprecatedViewPropTypes = require('DeprecatedViewPropTypes');
-const DeprecatedEdgeInsetsPropType = require('DeprecatedEdgeInsetsPropType');
-const NativeMethodsMixin = require('NativeMethodsMixin');
-const Platform = require('Platform');
+const Animated = require('../../Animated/src/Animated');
+const DeprecatedViewPropTypes = require('../../DeprecatedPropTypes/DeprecatedViewPropTypes');
+const DeprecatedEdgeInsetsPropType = require('../../DeprecatedPropTypes/DeprecatedEdgeInsetsPropType');
+const NativeMethodsMixin = require('../../Renderer/shims/NativeMethodsMixin');
+const Platform = require('../../Utilities/Platform');
 const PropTypes = require('prop-types');
-const React = require('React');
-const Touchable = require('Touchable');
-const TouchableWithoutFeedback = require('TouchableWithoutFeedback');
+const React = require('react');
+const Touchable = require('./Touchable');
+const TouchableWithoutFeedback = require('./TouchableWithoutFeedback');
 
 const createReactClass = require('create-react-class');
 
-import type {EdgeInsetsProp} from 'EdgeInsetsPropType';
-import type {ViewStyleProp} from 'StyleSheet';
-import type {Props as TouchableWithoutFeedbackProps} from 'TouchableWithoutFeedback';
-import type {PressEvent} from 'CoreEventTypes';
+import type {EdgeInsetsProp} from '../../StyleSheet/EdgeInsetsPropType';
+import type {ViewStyleProp} from '../../StyleSheet/StyleSheet';
+import type {Props as TouchableWithoutFeedbackProps} from './TouchableWithoutFeedback';
+import type {PressEvent} from '../../Types/CoreEventTypes';
 
 type State = {
   animationID: ?number,

--- a/Libraries/Components/Touchable/TouchableHighlight.js
+++ b/Libraries/Components/Touchable/TouchableHighlight.js
@@ -9,26 +9,26 @@
  */
 'use strict';
 
-const DeprecatedColorPropType = require('DeprecatedColorPropType');
-const DeprecatedViewPropTypes = require('DeprecatedViewPropTypes');
-const NativeMethodsMixin = require('NativeMethodsMixin');
-const Platform = require('Platform');
+const DeprecatedColorPropType = require('../../DeprecatedPropTypes/DeprecatedColorPropType');
+const DeprecatedViewPropTypes = require('../../DeprecatedPropTypes/DeprecatedViewPropTypes');
+const NativeMethodsMixin = require('../../Renderer/shims/NativeMethodsMixin');
+const Platform = require('../../Utilities/Platform');
 const PropTypes = require('prop-types');
-const React = require('React');
-const ReactNativeViewAttributes = require('ReactNativeViewAttributes');
-const StyleSheet = require('StyleSheet');
-const Touchable = require('Touchable');
-const TouchableWithoutFeedback = require('TouchableWithoutFeedback');
-const View = require('View');
+const React = require('react');
+const ReactNativeViewAttributes = require('../View/ReactNativeViewAttributes');
+const StyleSheet = require('../../StyleSheet/StyleSheet');
+const Touchable = require('./Touchable');
+const TouchableWithoutFeedback = require('./TouchableWithoutFeedback');
+const View = require('../View/View');
 
 const createReactClass = require('create-react-class');
-const ensurePositiveDelayProps = require('ensurePositiveDelayProps');
+const ensurePositiveDelayProps = require('./ensurePositiveDelayProps');
 
-import type {PressEvent} from 'CoreEventTypes';
-import type {ViewStyleProp} from 'StyleSheet';
-import type {ColorValue} from 'StyleSheetTypes';
-import type {Props as TouchableWithoutFeedbackProps} from 'TouchableWithoutFeedback';
-import type {TVParallaxPropertiesType} from 'TVViewPropTypes';
+import type {PressEvent} from '../../Types/CoreEventTypes';
+import type {ViewStyleProp} from '../../StyleSheet/StyleSheet';
+import type {ColorValue} from '../../StyleSheet/StyleSheetTypes';
+import type {Props as TouchableWithoutFeedbackProps} from './TouchableWithoutFeedback';
+import type {TVParallaxPropertiesType} from '../AppleTV/TVViewPropTypes';
 
 const DEFAULT_PROPS = {
   activeOpacity: 0.85,

--- a/Libraries/Components/Touchable/TouchableNativeFeedback.android.js
+++ b/Libraries/Components/Touchable/TouchableNativeFeedback.android.js
@@ -10,20 +10,20 @@
 
 'use strict';
 
-const Platform = require('Platform');
-const React = require('React');
+const Platform = require('../../Utilities/Platform');
+const React = require('react');
 const PropTypes = require('prop-types');
-const ReactNative = require('ReactNative');
-const Touchable = require('Touchable');
-const TouchableWithoutFeedback = require('TouchableWithoutFeedback');
-const UIManager = require('UIManager');
-const View = require('View');
+const ReactNative = require('../../Renderer/shims/ReactNative');
+const Touchable = require('./Touchable');
+const TouchableWithoutFeedback = require('./TouchableWithoutFeedback');
+const UIManager = require('../../ReactNative/UIManager');
+const View = require('../View/View');
 
 const createReactClass = require('create-react-class');
-const ensurePositiveDelayProps = require('ensurePositiveDelayProps');
-const processColor = require('processColor');
+const ensurePositiveDelayProps = require('./ensurePositiveDelayProps');
+const processColor = require('../../StyleSheet/processColor');
 
-import type {PressEvent} from 'CoreEventTypes';
+import type {PressEvent} from '../../Types/CoreEventTypes';
 
 const rippleBackgroundPropType = PropTypes.shape({
   type: PropTypes.oneOf(['RippleAndroid']),

--- a/Libraries/Components/Touchable/TouchableNativeFeedback.ios.js
+++ b/Libraries/Components/Touchable/TouchableNativeFeedback.ios.js
@@ -9,10 +9,10 @@
 
 'use strict';
 
-const React = require('React');
-const StyleSheet = require('StyleSheet');
-const Text = require('Text');
-const View = require('View');
+const React = require('react');
+const StyleSheet = require('../../StyleSheet/StyleSheet');
+const Text = require('../../Text/Text');
+const View = require('../View/View');
 
 class DummyTouchableNativeFeedback extends React.Component {
   static SelectableBackground = () => ({});

--- a/Libraries/Components/Touchable/TouchableOpacity.js
+++ b/Libraries/Components/Touchable/TouchableOpacity.js
@@ -10,23 +10,23 @@
 
 'use strict';
 
-const Animated = require('Animated');
-const Easing = require('Easing');
-const NativeMethodsMixin = require('NativeMethodsMixin');
-const Platform = require('Platform');
-const React = require('React');
+const Animated = require('../../Animated/src/Animated');
+const Easing = require('../../Animated/src/Easing');
+const NativeMethodsMixin = require('../../Renderer/shims/NativeMethodsMixin');
+const Platform = require('../../Utilities/Platform');
+const React = require('react');
 const PropTypes = require('prop-types');
-const Touchable = require('Touchable');
-const TouchableWithoutFeedback = require('TouchableWithoutFeedback');
+const Touchable = require('./Touchable');
+const TouchableWithoutFeedback = require('./TouchableWithoutFeedback');
 
 const createReactClass = require('create-react-class');
-const ensurePositiveDelayProps = require('ensurePositiveDelayProps');
-const flattenStyle = require('flattenStyle');
+const ensurePositiveDelayProps = require('./ensurePositiveDelayProps');
+const flattenStyle = require('../../StyleSheet/flattenStyle');
 
-import type {Props as TouchableWithoutFeedbackProps} from 'TouchableWithoutFeedback';
-import type {ViewStyleProp} from 'StyleSheet';
-import type {TVParallaxPropertiesType} from 'TVViewPropTypes';
-import type {PressEvent} from 'CoreEventTypes';
+import type {Props as TouchableWithoutFeedbackProps} from './TouchableWithoutFeedback';
+import type {ViewStyleProp} from '../../StyleSheet/StyleSheet';
+import type {TVParallaxPropertiesType} from '../AppleTV/TVViewPropTypes';
+import type {PressEvent} from '../../Types/CoreEventTypes';
 
 const PRESS_RETENTION_OFFSET = {top: 20, left: 20, right: 20, bottom: 30};
 

--- a/Libraries/Components/Touchable/TouchableWithoutFeedback.js
+++ b/Libraries/Components/Touchable/TouchableWithoutFeedback.js
@@ -10,23 +10,30 @@
 
 'use strict';
 
-const DeprecatedEdgeInsetsPropType = require('DeprecatedEdgeInsetsPropType');
-const React = require('React');
+const DeprecatedEdgeInsetsPropType = require('../../DeprecatedPropTypes/DeprecatedEdgeInsetsPropType');
+const React = require('react');
 const PropTypes = require('prop-types');
-const Touchable = require('Touchable');
-const View = require('View');
+const Touchable = require('./Touchable');
+const View = require('../View/View');
 
 const createReactClass = require('create-react-class');
-const ensurePositiveDelayProps = require('ensurePositiveDelayProps');
+const ensurePositiveDelayProps = require('./ensurePositiveDelayProps');
 
 const {
   DeprecatedAccessibilityRoles,
   DeprecatedAccessibilityStates,
-} = require('DeprecatedViewAccessibility');
+} = require('../../DeprecatedPropTypes/DeprecatedViewAccessibility');
 
-import type {SyntheticEvent, LayoutEvent, PressEvent} from 'CoreEventTypes';
-import type {EdgeInsetsProp} from 'EdgeInsetsPropType';
-import type {AccessibilityRole, AccessibilityStates} from 'ViewAccessibility';
+import type {
+  SyntheticEvent,
+  LayoutEvent,
+  PressEvent,
+} from '../../Types/CoreEventTypes';
+import type {EdgeInsetsProp} from '../../StyleSheet/EdgeInsetsPropType';
+import type {
+  AccessibilityRole,
+  AccessibilityStates,
+} from '../View/ViewAccessibility';
 
 type TargetEvent = SyntheticEvent<
   $ReadOnly<{|

--- a/Libraries/Components/Touchable/__tests__/TouchableHighlight-test.js
+++ b/Libraries/Components/Touchable/__tests__/TouchableHighlight-test.js
@@ -10,10 +10,10 @@
 
 'use strict';
 
-const React = require('React');
+const React = require('react');
 const ReactTestRenderer = require('react-test-renderer');
-const Text = require('Text');
-const TouchableHighlight = require('TouchableHighlight');
+const Text = require('../../../Text/Text');
+const TouchableHighlight = require('../TouchableHighlight');
 
 describe('TouchableHighlight', () => {
   it('renders correctly', () => {

--- a/Libraries/Components/UnimplementedViews/UnimplementedNativeView.js
+++ b/Libraries/Components/UnimplementedViews/UnimplementedNativeView.js
@@ -10,11 +10,11 @@
 
 'use strict';
 
-const requireNativeComponent = require('requireNativeComponent');
+const requireNativeComponent = require('../../ReactNative/requireNativeComponent');
 
-import type {ViewProps} from 'ViewPropTypes';
-import type {ViewStyleProp} from 'StyleSheet';
-import type {NativeComponent} from 'ReactNative';
+import type {ViewProps} from '../View/ViewPropTypes';
+import type {ViewStyleProp} from '../../StyleSheet/StyleSheet';
+import type {NativeComponent} from '../../Renderer/shims/ReactNative';
 
 type NativeProps = $ReadOnly<{|
   ...ViewProps,

--- a/Libraries/Components/UnimplementedViews/UnimplementedView.js
+++ b/Libraries/Components/UnimplementedViews/UnimplementedView.js
@@ -9,8 +9,8 @@
  */
 'use strict';
 
-const React = require('React');
-const StyleSheet = require('StyleSheet');
+const React = require('react');
+const StyleSheet = require('../../StyleSheet/StyleSheet');
 
 /**
  * Common implementation for a simple stubbed view. Simply applies the view's styles to the inner
@@ -25,7 +25,7 @@ class UnimplementedView extends React.Component<$FlowFixMeProps> {
 
   render() {
     // Workaround require cycle from requireNativeComponent
-    const View = require('View');
+    const View = require('../View/View');
     return (
       <View style={[styles.unimplementedView, this.props.style]}>
         {this.props.children}

--- a/Libraries/Components/View/PlatformViewPropTypes.ios.js
+++ b/Libraries/Components/View/PlatformViewPropTypes.ios.js
@@ -11,6 +11,6 @@
 
 'use strict';
 
-import type {TVViewProps} from 'TVViewPropTypes';
+import type {TVViewProps} from '../AppleTV/TVViewPropTypes';
 
 export type PlatformViewPropTypes = TVViewProps;

--- a/Libraries/Components/View/ReactNativeStyleAttributes.js
+++ b/Libraries/Components/View/ReactNativeStyleAttributes.js
@@ -10,13 +10,13 @@
 
 'use strict';
 
-const DeprecatedImageStylePropTypes = require('DeprecatedImageStylePropTypes');
-const TextStylePropTypes = require('TextStylePropTypes');
-const DeprecatedViewStylePropTypes = require('DeprecatedViewStylePropTypes');
+const DeprecatedImageStylePropTypes = require('../../DeprecatedPropTypes/DeprecatedImageStylePropTypes');
+const TextStylePropTypes = require('../../Text/TextStylePropTypes');
+const DeprecatedViewStylePropTypes = require('../../DeprecatedPropTypes/DeprecatedViewStylePropTypes');
 
-const processColor = require('processColor');
-const processTransform = require('processTransform');
-const sizesDiffer = require('sizesDiffer');
+const processColor = require('../../StyleSheet/processColor');
+const processTransform = require('../../StyleSheet/processTransform');
+const sizesDiffer = require('../../Utilities/differ/sizesDiffer');
 
 const ReactNativeStyleAttributes = {};
 

--- a/Libraries/Components/View/ReactNativeViewAttributes.js
+++ b/Libraries/Components/View/ReactNativeViewAttributes.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const ReactNativeStyleAttributes = require('ReactNativeStyleAttributes');
+const ReactNativeStyleAttributes = require('./ReactNativeStyleAttributes');
 
 const ReactNativeViewAttributes = {};
 

--- a/Libraries/Components/View/View.js
+++ b/Libraries/Components/View/View.js
@@ -10,10 +10,10 @@
 
 'use strict';
 
-const React = require('React');
-const ViewNativeComponent = require('ViewNativeComponent');
+const React = require('react');
+const ViewNativeComponent = require('./ViewNativeComponent');
 
-import type {ViewProps} from 'ViewPropTypes';
+import type {ViewProps} from './ViewPropTypes';
 
 export type Props = ViewProps;
 

--- a/Libraries/Components/View/ViewNativeComponent.js
+++ b/Libraries/Components/View/ViewNativeComponent.js
@@ -10,11 +10,11 @@
 
 'use strict';
 
-const ReactNative = require('ReactNative');
+const ReactNative = require('../../Renderer/shims/ReactNative');
 
-const requireNativeComponent = require('requireNativeComponent');
+const requireNativeComponent = require('../../ReactNative/requireNativeComponent');
 
-import type {ViewProps} from 'ViewPropTypes';
+import type {ViewProps} from './ViewPropTypes';
 
 type ViewNativeComponentType = Class<ReactNative.NativeComponent<ViewProps>>;
 

--- a/Libraries/Components/View/ViewPropTypes.js
+++ b/Libraries/Components/View/ViewPropTypes.js
@@ -10,12 +10,12 @@
 
 'use strict';
 
-import type {PressEvent, Layout, LayoutEvent} from 'CoreEventTypes';
-import type {EdgeInsetsProp} from 'EdgeInsetsPropType';
-import type React from 'React';
-import type {ViewStyleProp} from 'StyleSheet';
-import type {TVViewProps} from 'TVViewPropTypes';
-import type {AccessibilityRole, AccessibilityStates} from 'ViewAccessibility';
+import type {PressEvent, Layout, LayoutEvent} from '../../Types/CoreEventTypes';
+import type {EdgeInsetsProp} from '../../StyleSheet/EdgeInsetsPropType';
+import type {Node} from 'react';
+import type {ViewStyleProp} from '../../StyleSheet/StyleSheet';
+import type {TVViewProps} from '../AppleTV/TVViewPropTypes';
+import type {AccessibilityRole, AccessibilityStates} from './ViewAccessibility';
 
 export type ViewLayout = Layout;
 export type ViewLayoutEvent = LayoutEvent;
@@ -377,7 +377,7 @@ export type ViewProps = $ReadOnly<{|
   // so we must include TVViewProps
   ...TVViewProps,
 
-  children?: React.Node,
+  children?: Node,
   style?: ?ViewStyleProp,
 
   /**

--- a/Libraries/Components/ViewPager/AndroidViewPagerNativeComponent.js
+++ b/Libraries/Components/ViewPager/AndroidViewPagerNativeComponent.js
@@ -10,12 +10,12 @@
 
 'use strict';
 
-const requireNativeComponent = require('requireNativeComponent');
+const requireNativeComponent = require('../../ReactNative/requireNativeComponent');
 
-import type {SyntheticEvent} from 'CoreEventTypes';
-import type {NativeComponent} from 'ReactNative';
-import type {Node} from 'React';
-import type {ViewStyleProp} from 'StyleSheet';
+import type {SyntheticEvent} from '../../Types/CoreEventTypes';
+import type {NativeComponent} from '../../Renderer/shims/ReactNative';
+import type {Node} from 'react';
+import type {ViewStyleProp} from '../../StyleSheet/StyleSheet';
 
 type PageScrollState = 'idle' | 'dragging' | 'settling';
 

--- a/Libraries/Components/ViewPager/ViewPagerAndroid.android.js
+++ b/Libraries/Components/ViewPager/ViewPagerAndroid.android.js
@@ -10,16 +10,16 @@
 
 'use strict';
 
-const React = require('React');
-const ReactNative = require('ReactNative');
-const UIManager = require('UIManager');
+const React = require('react');
+const ReactNative = require('../../Renderer/shims/ReactNative');
+const UIManager = require('../../ReactNative/UIManager');
 
-const dismissKeyboard = require('dismissKeyboard');
+const dismissKeyboard = require('../../Utilities/dismissKeyboard');
 
-const NativeAndroidViewPager = require('AndroidViewPagerNativeComponent');
+const NativeAndroidViewPager = require('./AndroidViewPagerNativeComponent');
 
-import type {SyntheticEvent} from 'CoreEventTypes';
-import type {ViewStyleProp} from 'StyleSheet';
+import type {SyntheticEvent} from '../../Types/CoreEventTypes';
+import type {ViewStyleProp} from '../../StyleSheet/StyleSheet';
 
 const VIEWPAGER_REF = 'viewPager';
 

--- a/Libraries/Components/ViewPager/ViewPagerAndroid.ios.js
+++ b/Libraries/Components/ViewPager/ViewPagerAndroid.ios.js
@@ -9,4 +9,4 @@
 
 'use strict';
 
-module.exports = require('UnimplementedView');
+module.exports = require('../UnimplementedViews/UnimplementedView');

--- a/Libraries/Core/Devtools/__tests__/parseErrorStack-test.js
+++ b/Libraries/Core/Devtools/__tests__/parseErrorStack-test.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const parseErrorStack = require('parseErrorStack');
+const parseErrorStack = require('../parseErrorStack');
 
 function getFakeError() {
   return new Error('Happy Cat');

--- a/Libraries/Core/Devtools/getDevServer.js
+++ b/Libraries/Core/Devtools/getDevServer.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const {SourceCode} = require('NativeModules');
+const {SourceCode} = require('../../BatchedBridge/NativeModules');
 
 let _cachedDevServerURL: ?string;
 const FALLBACK = 'http://localhost:8081/';

--- a/Libraries/Core/Devtools/openFileInEditor.js
+++ b/Libraries/Core/Devtools/openFileInEditor.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const getDevServer = require('getDevServer');
+const getDevServer = require('./getDevServer');
 
 function openFileInEditor(file: string, lineNumber: number) {
   fetch(getDevServer().url + 'open-stack-frame', {

--- a/Libraries/Core/Devtools/setupDevtools.js
+++ b/Libraries/Core/Devtools/setupDevtools.js
@@ -15,9 +15,9 @@ let register = function() {
 };
 
 if (__DEV__) {
-  const AppState = require('AppState');
+  const AppState = require('../../AppState/AppState');
   const reactDevTools = require('react-devtools-core');
-  const getDevServer = require('getDevServer');
+  const getDevServer = require('./getDevServer');
 
   // Don't steal the DevTools from currently active app.
   // Note: if you add any AppState subscriptions to this file,
@@ -37,7 +37,7 @@ if (__DEV__) {
     // Read the optional global variable for backward compatibility.
     // It was added in https://github.com/facebook/react-native/commit/bf2b435322e89d0aeee8792b1c6e04656c2719a0.
     port: window.__REACT_DEVTOOLS_PORT__,
-    resolveRNStyle: require('flattenStyle'),
+    resolveRNStyle: require('../../StyleSheet/flattenStyle'),
   });
 }
 

--- a/Libraries/Core/Devtools/symbolicateStackTrace.js
+++ b/Libraries/Core/Devtools/symbolicateStackTrace.js
@@ -10,14 +10,14 @@
 
 'use strict';
 
-const getDevServer = require('getDevServer');
+const getDevServer = require('./getDevServer');
 
-const {SourceCode} = require('NativeModules');
+const {SourceCode} = require('../../BatchedBridge/NativeModules');
 
 // Avoid requiring fetch on load of this module; see symbolicateStackTrace
 let fetch;
 
-import type {StackFrame} from 'parseErrorStack';
+import type {StackFrame} from './parseErrorStack';
 
 function isSourcedFromDisk(sourcePath: string): boolean {
   return !/^http/.test(sourcePath) && /[\\/]/.test(sourcePath);
@@ -38,7 +38,7 @@ async function symbolicateStackTrace(
   // The fix below postpones trying to load fetch until the first call to symbolicateStackTrace.
   // At that time, we will have either global.fetch (whatwg-fetch) or RN's fetch.
   if (!fetch) {
-    fetch = global.fetch || require('fetch').fetch;
+    fetch = global.fetch || require('../../Network/fetch').fetch;
   }
 
   const devServer = getDevServer();

--- a/Libraries/Core/ExceptionsManager.js
+++ b/Libraries/Core/ExceptionsManager.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-import type {ExtendedError} from 'parseErrorStack';
+import type {ExtendedError} from './Devtools/parseErrorStack';
 
 const INTERNAL_CALLSITES_REGEX = new RegExp(
   [
@@ -24,9 +24,9 @@ const INTERNAL_CALLSITES_REGEX = new RegExp(
  */
 let exceptionID = 0;
 function reportException(e: ExtendedError, isFatal: boolean) {
-  const {ExceptionsManager} = require('NativeModules');
+  const {ExceptionsManager} = require('../BatchedBridge/NativeModules');
   if (ExceptionsManager) {
-    const parseErrorStack = require('parseErrorStack');
+    const parseErrorStack = require('./Devtools/parseErrorStack');
     const stack = parseErrorStack(e);
     const currentExceptionID = ++exceptionID;
     const message =
@@ -41,7 +41,7 @@ function reportException(e: ExtendedError, isFatal: boolean) {
       ExceptionsManager.reportSoftException(message, stack, currentExceptionID);
     }
     if (__DEV__) {
-      const symbolicateStackTrace = require('symbolicateStackTrace');
+      const symbolicateStackTrace = require('./Devtools/symbolicateStackTrace');
       symbolicateStackTrace(stack)
         .then(prettyStack => {
           if (prettyStack) {
@@ -97,7 +97,7 @@ function reactConsoleErrorHandler() {
   if (arguments[0] && arguments[0].stack) {
     reportException(arguments[0], /* isFatal */ false);
   } else {
-    const stringifySafe = require('stringifySafe');
+    const stringifySafe = require('../Utilities/stringifySafe');
     const str = Array.prototype.map.call(arguments, stringifySafe).join(', ');
     if (str.slice(0, 10) === '"Warning: ') {
       // React warnings use console.error so that a stack trace is shown, but

--- a/Libraries/Core/InitializeCore.js
+++ b/Libraries/Core/InitializeCore.js
@@ -27,24 +27,24 @@
 
 const start = Date.now();
 
-require('setUpGlobals');
-require('polyfillES6Collections');
-require('setUpSystrace');
-require('setUpErrorHandling');
-require('checkNativeVersion');
-require('polyfillPromise');
-require('setUpRegeneratorRuntime');
-require('setUpTimers');
-require('setUpXHR');
-require('setUpAlert');
-require('setUpNavigator');
-require('setUpBatchedBridge');
-require('setUpSegmentFetcher');
+require('./setUpGlobals');
+require('./polyfillES6Collections');
+require('./setUpSystrace');
+require('./setUpErrorHandling');
+require('./checkNativeVersion');
+require('./polyfillPromise');
+require('./setUpRegeneratorRuntime');
+require('./setUpTimers');
+require('./setUpXHR');
+require('./setUpAlert');
+require('./setUpNavigator');
+require('./setUpBatchedBridge');
+require('./setUpSegmentFetcher');
 if (__DEV__) {
-  require('setUpDeveloperTools');
+  require('./setUpDeveloperTools');
 }
 
-const GlobalPerformanceLogger = require('GlobalPerformanceLogger');
+const GlobalPerformanceLogger = require('../Utilities/GlobalPerformanceLogger');
 // We could just call GlobalPerformanceLogger.markPoint at the top of the file,
 // but then we'd be excluding the time it took to require the logger.
 // Instead, we just use Date.now and backdate the timestamp.

--- a/Libraries/Core/ReactNativeVersionCheck.js
+++ b/Libraries/Core/ReactNativeVersionCheck.js
@@ -9,8 +9,8 @@
  */
 'use strict';
 
-const {PlatformConstants} = require('NativeModules');
-const ReactNativeVersion = require('ReactNativeVersion');
+const {PlatformConstants} = require('../BatchedBridge/NativeModules');
+const ReactNativeVersion = require('./ReactNativeVersion');
 
 /**
  * Checks that the version of this React Native JS is compatible with the native

--- a/Libraries/Core/SegmentFetcher/NativeSegmentFetcher.js
+++ b/Libraries/Core/SegmentFetcher/NativeSegmentFetcher.js
@@ -9,8 +9,8 @@
  */
 'use strict';
 
-import type {TurboModule} from 'RCTExport';
-import * as TurboModuleRegistry from 'TurboModuleRegistry';
+import type {TurboModule} from '../../TurboModule/RCTExport';
+import * as TurboModuleRegistry from '../../TurboModule/TurboModuleRegistry';
 
 export interface Spec extends TurboModule {
   +fetchSegment: (

--- a/Libraries/Core/Timers/JSTimers.js
+++ b/Libraries/Core/Timers/JSTimers.js
@@ -9,14 +9,14 @@
  */
 'use strict';
 
-const Platform = require('Platform');
-const Systrace = require('Systrace');
+const Platform = require('../../Utilities/Platform');
+const Systrace = require('../../Performance/Systrace');
 
 const invariant = require('invariant');
-const {Timing} = require('NativeModules');
-const BatchedBridge = require('BatchedBridge');
+const {Timing} = require('../../BatchedBridge/NativeModules');
+const BatchedBridge = require('../../BatchedBridge/BatchedBridge');
 
-import type {ExtendedError} from 'parseErrorStack';
+import type {ExtendedError} from '../Devtools/parseErrorStack';
 
 let _performanceNow = null;
 function performanceNow() {
@@ -82,7 +82,7 @@ function _allocateCallback(func: Function, type: JSTimerType): number {
   callbacks[freeIndex] = func;
   types[freeIndex] = type;
   if (__DEV__) {
-    const parseErrorStack = require('parseErrorStack');
+    const parseErrorStack = require('../Devtools/parseErrorStack');
     const error: ExtendedError = new Error();
     error.framesToPop = 1;
     const stack = parseErrorStack(error);

--- a/Libraries/Core/__tests__/MapAndSetPolyfills-test.js
+++ b/Libraries/Core/__tests__/MapAndSetPolyfills-test.js
@@ -23,7 +23,7 @@ function cleanup() {
 describe('Map polyfill', () => {
   setup();
 
-  const Map = require('Map');
+  const Map = require('../../vendor/core/Map');
 
   it('is not native', () => {
     const getCode = Function.prototype.toString.call(Map.prototype.get);
@@ -63,7 +63,7 @@ describe('Map polyfill', () => {
 describe('Set polyfill', () => {
   setup();
 
-  const Set = require('Set');
+  const Set = require('../../vendor/core/Set');
 
   it('is not native', () => {
     const addCode = Function.prototype.toString.call(Set.prototype.add);

--- a/Libraries/Core/__tests__/ReactNativeVersionCheck-test.js
+++ b/Libraries/Core/__tests__/ReactNativeVersionCheck-test.js
@@ -59,8 +59,8 @@ function _defineCheckVersionTests() {
     _mockJsVersion(0, 0, 0);
     _mockNativeVersion(0, 0, 0);
 
-    const ReactNativeVersion = require('ReactNativeVersion');
-    const ReactNativeVersionCheck = require('ReactNativeVersionCheck');
+    const ReactNativeVersion = require('../ReactNativeVersion');
+    const ReactNativeVersionCheck = require('../ReactNativeVersionCheck');
     expect(ReactNativeVersion).toMatchObject({
       version: {major: 0, minor: 0, patch: 0, prerelease: null},
     });
@@ -71,7 +71,7 @@ function _defineCheckVersionTests() {
     _mockJsVersion(0, 1, 0);
     _mockNativeVersion(0, 1, 0);
 
-    const ReactNativeVersionCheck = require('ReactNativeVersionCheck');
+    const ReactNativeVersionCheck = require('../ReactNativeVersionCheck');
     expect(() => ReactNativeVersionCheck.checkVersions()).not.toThrow();
   });
 
@@ -79,7 +79,7 @@ function _defineCheckVersionTests() {
     _mockJsVersion(0, 1, 0);
     _mockNativeVersion(0, 2, 0);
 
-    const ReactNativeVersionCheck = require('ReactNativeVersionCheck');
+    const ReactNativeVersionCheck = require('../ReactNativeVersionCheck');
 
     ReactNativeVersionCheck.checkVersions();
     expect(spyOnConsoleError).toHaveBeenCalledTimes(1);
@@ -90,7 +90,7 @@ function _defineCheckVersionTests() {
     _mockJsVersion(1, 0, 0);
     _mockNativeVersion(2, 0, 0);
 
-    const ReactNativeVersionCheck = require('ReactNativeVersionCheck');
+    const ReactNativeVersionCheck = require('../ReactNativeVersionCheck');
     ReactNativeVersionCheck.checkVersions();
     expect(spyOnConsoleError).toHaveBeenCalledTimes(1);
     expect(consoleOutput).toMatch(/React Native version mismatch/);
@@ -100,7 +100,7 @@ function _defineCheckVersionTests() {
     _mockJsVersion(0, 1, 0);
     _mockNativeVersion(0, 1, 2);
 
-    const ReactNativeVersionCheck = require('ReactNativeVersionCheck');
+    const ReactNativeVersionCheck = require('../ReactNativeVersionCheck');
     ReactNativeVersionCheck.checkVersions();
     expect(spyOnConsoleError).toHaveBeenCalledTimes(0);
   });
@@ -109,14 +109,14 @@ function _defineCheckVersionTests() {
     _mockJsVersion(0, 1, 0, 'beta.0');
     _mockNativeVersion(0, 1, 0, 'alpha.1');
 
-    const ReactNativeVersionCheck = require('ReactNativeVersionCheck');
+    const ReactNativeVersionCheck = require('../ReactNativeVersionCheck');
     ReactNativeVersionCheck.checkVersions();
     expect(spyOnConsoleError).toHaveBeenCalledTimes(0);
   });
 }
 
 function _mockJsVersion(major = 0, minor = 0, patch = 0, prerelease = null) {
-  jest.doMock('ReactNativeVersion', () => ({
+  jest.doMock('../ReactNativeVersion', () => ({
     version: {major, minor, patch, prerelease},
   }));
 }
@@ -127,7 +127,7 @@ function _mockNativeVersion(
   patch = 0,
   prerelease = null,
 ) {
-  jest.doMock('NativeModules', () => ({
+  jest.doMock('../../BatchedBridge/NativeModules', () => ({
     PlatformConstants: {
       reactNativeVersion: {major, minor, patch, prerelease},
     },

--- a/Libraries/Core/checkNativeVersion.js
+++ b/Libraries/Core/checkNativeVersion.js
@@ -13,5 +13,5 @@
  * Check for compatibility between the JS and native code.
  * You can use this module directly, or just require InitializeCore.
  */
-const ReactNativeVersionCheck = require('ReactNativeVersionCheck');
+const ReactNativeVersionCheck = require('./ReactNativeVersionCheck');
 ReactNativeVersionCheck.checkVersions();

--- a/Libraries/Core/polyfillES6Collections.js
+++ b/Libraries/Core/polyfillES6Collections.js
@@ -9,17 +9,19 @@
  */
 'use strict';
 
-const {polyfillGlobal} = require('PolyfillFunctions');
+const {polyfillGlobal} = require('../Utilities/PolyfillFunctions');
 
 /**
  * Polyfill ES6 collections (Map and Set).
  * If you don't need these polyfills, don't use InitializeCore; just directly
  * require the modules you need from InitializeCore for setup.
  */
-const _shouldPolyfillCollection = require('_shouldPolyfillES6Collection');
+const _shouldPolyfillCollection = require('../vendor/core/_shouldPolyfillES6Collection');
 if (_shouldPolyfillCollection('Map')) {
-  polyfillGlobal('Map', () => require('Map'));
+  // $FlowFixMe: even in strict-local mode Flow expects Map to be Flow-typed
+  polyfillGlobal('Map', () => require('../vendor/core/Map'));
 }
 if (_shouldPolyfillCollection('Set')) {
-  polyfillGlobal('Set', () => require('Set'));
+  // $FlowFixMe: even in strict-local mode Flow expects Set to be Flow-typed
+  polyfillGlobal('Set', () => require('../vendor/core/Set'));
 }

--- a/Libraries/Core/polyfillPromise.js
+++ b/Libraries/Core/polyfillPromise.js
@@ -9,7 +9,7 @@
  */
 'use strict';
 
-const {polyfillGlobal} = require('PolyfillFunctions');
+const {polyfillGlobal} = require('../Utilities/PolyfillFunctions');
 
 /**
  * Set up Promise. The native Promise implementation throws the following error:
@@ -18,4 +18,4 @@ const {polyfillGlobal} = require('PolyfillFunctions');
  * If you don't need these polyfills, don't use InitializeCore; just directly
  * require the modules you need from InitializeCore for setup.
  */
-polyfillGlobal('Promise', () => require('Promise'));
+polyfillGlobal('Promise', () => require('../Promise'));

--- a/Libraries/Core/setUpAlert.js
+++ b/Libraries/Core/setUpAlert.js
@@ -17,6 +17,6 @@ if (!global.alert) {
   global.alert = function(text) {
     // Require Alert on demand. Requiring it too early can lead to issues
     // with things like Platform not being fully initialized.
-    require('Alert').alert('Alert', '' + text);
+    require('../Alert/Alert').alert('Alert', '' + text);
   };
 }

--- a/Libraries/Core/setUpBatchedBridge.js
+++ b/Libraries/Core/setUpBatchedBridge.js
@@ -14,29 +14,38 @@
  * InitializeCore to ensure that the JS environment has been initialized.
  * You can use this module directly, or just require InitializeCore.
  */
-const BatchedBridge = require('BatchedBridge');
-BatchedBridge.registerLazyCallableModule('Systrace', () => require('Systrace'));
-BatchedBridge.registerLazyCallableModule('JSTimers', () => require('JSTimers'));
+const BatchedBridge = require('../BatchedBridge/BatchedBridge');
+BatchedBridge.registerLazyCallableModule('Systrace', () =>
+  require('../Performance/Systrace'),
+);
+BatchedBridge.registerLazyCallableModule('JSTimers', () =>
+  require('./Timers/JSTimers'),
+);
 BatchedBridge.registerLazyCallableModule('HeapCapture', () =>
-  require('HeapCapture'),
+  require('../Utilities/HeapCapture'),
 );
 BatchedBridge.registerLazyCallableModule('SamplingProfiler', () =>
-  require('SamplingProfiler'),
+  require('../Performance/SamplingProfiler'),
 );
-BatchedBridge.registerLazyCallableModule('RCTLog', () => require('RCTLog'));
+BatchedBridge.registerLazyCallableModule('RCTLog', () =>
+  require('../Utilities/RCTLog'),
+);
 BatchedBridge.registerLazyCallableModule('RCTDeviceEventEmitter', () =>
-  require('RCTDeviceEventEmitter'),
+  require('../EventEmitter/RCTDeviceEventEmitter'),
 );
 BatchedBridge.registerLazyCallableModule('RCTNativeAppEventEmitter', () =>
-  require('RCTNativeAppEventEmitter'),
+  require('../EventEmitter/RCTNativeAppEventEmitter'),
 );
 BatchedBridge.registerLazyCallableModule('GlobalPerformanceLogger', () =>
-  require('GlobalPerformanceLogger'),
+  require('../Utilities/GlobalPerformanceLogger'),
 );
 BatchedBridge.registerLazyCallableModule('JSDevSupportModule', () =>
-  require('JSDevSupportModule'),
+  require('../Utilities/JSDevSupportModule'),
 );
 
 if (__DEV__ && !global.__RCTProfileIsProfiling) {
-  BatchedBridge.registerCallableModule('HMRClient', require('HMRClient'));
+  BatchedBridge.registerCallableModule(
+    'HMRClient',
+    require('../Utilities/HMRClient'),
+  );
 }

--- a/Libraries/Core/setUpDeveloperTools.js
+++ b/Libraries/Core/setUpDeveloperTools.js
@@ -18,11 +18,11 @@ if (__DEV__) {
     // not when debugging in chrome
     // TODO(t12832058) This check is broken
     if (!window.document) {
-      require('setupDevtools');
+      require('./Devtools/setupDevtools');
     }
 
     // Set up inspector
-    const JSInspector = require('JSInspector');
-    JSInspector.registerAgent(require('NetworkAgent'));
+    const JSInspector = require('../JSInspector/JSInspector');
+    JSInspector.registerAgent(require('../JSInspector/NetworkAgent'));
   }
 }

--- a/Libraries/Core/setUpErrorHandling.js
+++ b/Libraries/Core/setUpErrorHandling.js
@@ -13,7 +13,7 @@
  * Sets up the console and exception handling (redbox) for React Native.
  * You can use this module directly, or just require InitializeCore.
  */
-const ExceptionsManager = require('ExceptionsManager');
+const ExceptionsManager = require('./ExceptionsManager');
 ExceptionsManager.installConsoleErrorReporter();
 
 // Set up error handler
@@ -27,6 +27,6 @@ if (!global.__fbDisableExceptionsManager) {
     }
   };
 
-  const ErrorUtils = require('ErrorUtils');
+  const ErrorUtils = require('../vendor/core/ErrorUtils');
   ErrorUtils.setGlobalHandler(handleError);
 }

--- a/Libraries/Core/setUpNavigator.js
+++ b/Libraries/Core/setUpNavigator.js
@@ -9,7 +9,7 @@
  */
 'use strict';
 
-const {polyfillObjectProperty} = require('PolyfillFunctions');
+const {polyfillObjectProperty} = require('../Utilities/PolyfillFunctions');
 
 let navigator = global.navigator;
 if (navigator === undefined) {

--- a/Libraries/Core/setUpRegeneratorRuntime.js
+++ b/Libraries/Core/setUpRegeneratorRuntime.js
@@ -9,7 +9,7 @@
  */
 'use strict';
 
-const {polyfillGlobal} = require('PolyfillFunctions');
+const {polyfillGlobal} = require('../Utilities/PolyfillFunctions');
 
 /**
  * Set up regenerator.

--- a/Libraries/Core/setUpSegmentFetcher.js
+++ b/Libraries/Core/setUpSegmentFetcher.js
@@ -18,7 +18,8 @@ global.__fetchSegment = function(
   options: {|+otaBuildNumber: ?string|},
   callback: (?Error) => void,
 ) {
-  const SegmentFetcher = require('NativeSegmentFetcher').default;
+  const SegmentFetcher = require('./SegmentFetcher/NativeSegmentFetcher')
+    .default;
   SegmentFetcher.fetchSegment(
     segmentId,
     options,

--- a/Libraries/Core/setUpSystrace.js
+++ b/Libraries/Core/setUpSystrace.js
@@ -14,7 +14,7 @@
  * You can use this module directly, or just require InitializeCore.
  */
 if (global.__RCTProfileIsProfiling) {
-  const Systrace = require('Systrace');
+  const Systrace = require('../Performance/Systrace');
   Systrace.installReactHook();
   Systrace.setEnabled(true);
 }

--- a/Libraries/Core/setUpTimers.js
+++ b/Libraries/Core/setUpTimers.js
@@ -9,14 +9,14 @@
  */
 'use strict';
 
-const {polyfillGlobal} = require('PolyfillFunctions');
+const {polyfillGlobal} = require('../Utilities/PolyfillFunctions');
 
 /**
  * Set up timers.
  * You can use this module directly, or just require InitializeCore.
  */
 const defineLazyTimer = name => {
-  polyfillGlobal(name, () => require('JSTimers')[name]);
+  polyfillGlobal(name, () => require('./Timers/JSTimers')[name]);
 };
 defineLazyTimer('setTimeout');
 defineLazyTimer('setInterval');

--- a/Libraries/Core/setUpXHR.js
+++ b/Libraries/Core/setUpXHR.js
@@ -9,7 +9,7 @@
  */
 'use strict';
 
-const {polyfillGlobal} = require('PolyfillFunctions');
+const {polyfillGlobal} = require('../Utilities/PolyfillFunctions');
 
 /**
  * Set up XMLHttpRequest. The native XMLHttpRequest in Chrome dev tools is CORS
@@ -17,19 +17,19 @@ const {polyfillGlobal} = require('PolyfillFunctions');
  *
  * You can use this module directly, or just require InitializeCore.
  */
-polyfillGlobal('XMLHttpRequest', () => require('XMLHttpRequest'));
-polyfillGlobal('FormData', () => require('FormData'));
+polyfillGlobal('XMLHttpRequest', () => require('../Network/XMLHttpRequest'));
+polyfillGlobal('FormData', () => require('../Network/FormData'));
 
-polyfillGlobal('fetch', () => require('fetch').fetch); // flowlint-line untyped-import:off
-polyfillGlobal('Headers', () => require('fetch').Headers); // flowlint-line untyped-import:off
-polyfillGlobal('Request', () => require('fetch').Request); // flowlint-line untyped-import:off
-polyfillGlobal('Response', () => require('fetch').Response); // flowlint-line untyped-import:off
-polyfillGlobal('WebSocket', () => require('WebSocket'));
-polyfillGlobal('Blob', () => require('Blob'));
-polyfillGlobal('File', () => require('File'));
-polyfillGlobal('FileReader', () => require('FileReader'));
-polyfillGlobal('URL', () => require('URL').URL); // flowlint-line untyped-import:off
-polyfillGlobal('URLSearchParams', () => require('URL').URLSearchParams); // flowlint-line untyped-import:off
+polyfillGlobal('fetch', () => require('../Network/fetch').fetch); // flowlint-line untyped-import:off
+polyfillGlobal('Headers', () => require('../Network/fetch').Headers); // flowlint-line untyped-import:off
+polyfillGlobal('Request', () => require('../Network/fetch').Request); // flowlint-line untyped-import:off
+polyfillGlobal('Response', () => require('../Network/fetch').Response); // flowlint-line untyped-import:off
+polyfillGlobal('WebSocket', () => require('../WebSocket/WebSocket'));
+polyfillGlobal('Blob', () => require('../Blob/Blob'));
+polyfillGlobal('File', () => require('../Blob/File'));
+polyfillGlobal('FileReader', () => require('../Blob/FileReader'));
+polyfillGlobal('URL', () => require('../Blob/URL').URL); // flowlint-line untyped-import:off
+polyfillGlobal('URLSearchParams', () => require('../Blob/URL').URLSearchParams); // flowlint-line untyped-import:off
 polyfillGlobal(
   'AbortController',
   () => require('abort-controller/dist/abort-controller').AbortController, // flowlint-line untyped-import:off

--- a/Libraries/DeprecatedPropTypes/DeprecatedColorPropType.js
+++ b/Libraries/DeprecatedPropTypes/DeprecatedColorPropType.js
@@ -9,7 +9,7 @@
 
 'use strict';
 
-const normalizeColor = require('normalizeColor');
+const normalizeColor = require('../Color/normalizeColor');
 
 const colorPropType = function(
   isRequired,

--- a/Libraries/DeprecatedPropTypes/DeprecatedImagePropType.js
+++ b/Libraries/DeprecatedPropTypes/DeprecatedImagePropType.js
@@ -10,10 +10,10 @@
 
 'use strict';
 
-const DeprecatedEdgeInsetsPropType = require('DeprecatedEdgeInsetsPropType');
-const DeprecatedImageSourcePropType = require('DeprecatedImageSourcePropType');
-const DeprecatedImageStylePropTypes = require('DeprecatedImageStylePropTypes');
-const DeprecatedStyleSheetPropType = require('DeprecatedStyleSheetPropType');
+const DeprecatedEdgeInsetsPropType = require('./DeprecatedEdgeInsetsPropType');
+const DeprecatedImageSourcePropType = require('./DeprecatedImageSourcePropType');
+const DeprecatedImageStylePropTypes = require('./DeprecatedImageStylePropTypes');
+const DeprecatedStyleSheetPropType = require('./DeprecatedStyleSheetPropType');
 const PropTypes = require('prop-types');
 
 module.exports = {

--- a/Libraries/DeprecatedPropTypes/DeprecatedImageStylePropTypes.js
+++ b/Libraries/DeprecatedPropTypes/DeprecatedImageStylePropTypes.js
@@ -9,11 +9,11 @@
  */
 'use strict';
 
-const DeprecatedColorPropType = require('DeprecatedColorPropType');
-const DeprecatedLayoutPropTypes = require('DeprecatedLayoutPropTypes');
+const DeprecatedColorPropType = require('./DeprecatedColorPropType');
+const DeprecatedLayoutPropTypes = require('./DeprecatedLayoutPropTypes');
 const ReactPropTypes = require('prop-types');
-const DeprecatedShadowPropTypesIOS = require('DeprecatedShadowPropTypesIOS');
-const DeprecatedTransformPropTypes = require('DeprecatedTransformPropTypes');
+const DeprecatedShadowPropTypesIOS = require('./DeprecatedShadowPropTypesIOS');
+const DeprecatedTransformPropTypes = require('./DeprecatedTransformPropTypes');
 
 const ImageStylePropTypes = {
   ...DeprecatedLayoutPropTypes,

--- a/Libraries/DeprecatedPropTypes/DeprecatedShadowPropTypesIOS.js
+++ b/Libraries/DeprecatedPropTypes/DeprecatedShadowPropTypesIOS.js
@@ -9,7 +9,7 @@
  */
 'use strict';
 
-const DeprecatedColorPropType = require('DeprecatedColorPropType');
+const DeprecatedColorPropType = require('./DeprecatedColorPropType');
 const ReactPropTypes = require('prop-types');
 
 const DeprecatedShadowPropTypesIOS = {

--- a/Libraries/DeprecatedPropTypes/DeprecatedStyleSheetPropType.js
+++ b/Libraries/DeprecatedPropTypes/DeprecatedStyleSheetPropType.js
@@ -10,8 +10,8 @@
 
 'use strict';
 
-const deprecatedCreateStrictShapeTypeChecker = require('deprecatedCreateStrictShapeTypeChecker');
-const flattenStyle = require('flattenStyle');
+const deprecatedCreateStrictShapeTypeChecker = require('./deprecatedCreateStrictShapeTypeChecker');
+const flattenStyle = require('../StyleSheet/flattenStyle');
 
 function DeprecatedStyleSheetPropType(shape: {
   [key: string]: ReactPropsCheckType,

--- a/Libraries/DeprecatedPropTypes/DeprecatedTextPropTypes.js
+++ b/Libraries/DeprecatedPropTypes/DeprecatedTextPropTypes.js
@@ -10,11 +10,11 @@
 
 'use strict';
 
-const DeprecatedColorPropType = require('DeprecatedColorPropType');
-const DeprecatedEdgeInsetsPropType = require('DeprecatedEdgeInsetsPropType');
-const DeprecatedStyleSheetPropType = require('DeprecatedStyleSheetPropType');
+const DeprecatedColorPropType = require('./DeprecatedColorPropType');
+const DeprecatedEdgeInsetsPropType = require('./DeprecatedEdgeInsetsPropType');
+const DeprecatedStyleSheetPropType = require('./DeprecatedStyleSheetPropType');
 const PropTypes = require('prop-types');
-const TextStylePropTypes = require('TextStylePropTypes');
+const TextStylePropTypes = require('../Text/TextStylePropTypes');
 
 const stylePropType = DeprecatedStyleSheetPropType(TextStylePropTypes);
 

--- a/Libraries/DeprecatedPropTypes/DeprecatedTransformPropTypes.js
+++ b/Libraries/DeprecatedPropTypes/DeprecatedTransformPropTypes.js
@@ -12,7 +12,7 @@
 
 const ReactPropTypes = require('prop-types');
 
-const deprecatedPropType = require('deprecatedPropType');
+const deprecatedPropType = require('../Utilities/deprecatedPropType');
 
 const TransformMatrixPropType = function(
   props: Object,

--- a/Libraries/DeprecatedPropTypes/DeprecatedViewPropTypes.js
+++ b/Libraries/DeprecatedPropTypes/DeprecatedViewPropTypes.js
@@ -10,16 +10,16 @@
 
 'use strict';
 
-const DeprecatedEdgeInsetsPropType = require('DeprecatedEdgeInsetsPropType');
-const PlatformViewPropTypes = require('PlatformViewPropTypes');
+const DeprecatedEdgeInsetsPropType = require('./DeprecatedEdgeInsetsPropType');
+const PlatformViewPropTypes = require('../Components/View/PlatformViewPropTypes');
 const PropTypes = require('prop-types');
-const DeprecatedStyleSheetPropType = require('DeprecatedStyleSheetPropType');
-const DeprecatedViewStylePropTypes = require('DeprecatedViewStylePropTypes');
+const DeprecatedStyleSheetPropType = require('./DeprecatedStyleSheetPropType');
+const DeprecatedViewStylePropTypes = require('./DeprecatedViewStylePropTypes');
 
 const {
   DeprecatedAccessibilityRoles,
   DeprecatedAccessibilityStates,
-} = require('DeprecatedViewAccessibility');
+} = require('./DeprecatedViewAccessibility');
 
 const stylePropType = DeprecatedStyleSheetPropType(
   DeprecatedViewStylePropTypes,

--- a/Libraries/DeprecatedPropTypes/DeprecatedViewStylePropTypes.js
+++ b/Libraries/DeprecatedPropTypes/DeprecatedViewStylePropTypes.js
@@ -10,11 +10,11 @@
 
 'use strict';
 
-const DeprecatedColorPropType = require('DeprecatedColorPropType');
-const DeprecatedLayoutPropTypes = require('DeprecatedLayoutPropTypes');
+const DeprecatedColorPropType = require('./DeprecatedColorPropType');
+const DeprecatedLayoutPropTypes = require('./DeprecatedLayoutPropTypes');
 const ReactPropTypes = require('prop-types');
-const DeprecatedShadowPropTypesIOS = require('DeprecatedShadowPropTypesIOS');
-const DeprecatedTransformPropTypes = require('DeprecatedTransformPropTypes');
+const DeprecatedShadowPropTypesIOS = require('./DeprecatedShadowPropTypesIOS');
+const DeprecatedTransformPropTypes = require('./DeprecatedTransformPropTypes');
 
 /**
  * Warning: Some of these properties may not be supported in all releases.

--- a/Libraries/DeprecatedPropTypes/deprecatedCreateStrictShapeTypeChecker.js
+++ b/Libraries/DeprecatedPropTypes/deprecatedCreateStrictShapeTypeChecker.js
@@ -11,7 +11,7 @@
 'use strict';
 
 const invariant = require('invariant');
-const merge = require('merge');
+const merge = require('../vendor/core/merge');
 
 function deprecatedCreateStrictShapeTypeChecker(shapeTypes: {
   [key: string]: ReactPropsCheckType,

--- a/Libraries/EventEmitter/NativeEventEmitter.js
+++ b/Libraries/EventEmitter/NativeEventEmitter.js
@@ -10,13 +10,13 @@
 
 'use strict';
 
-const EventEmitter = require('EventEmitter');
-const Platform = require('Platform');
-const RCTDeviceEventEmitter = require('RCTDeviceEventEmitter');
+const EventEmitter = require('../vendor/emitter/EventEmitter');
+const Platform = require('../Utilities/Platform');
+const RCTDeviceEventEmitter = require('./RCTDeviceEventEmitter');
 
 const invariant = require('invariant');
 
-import type EmitterSubscription from 'EmitterSubscription';
+import type EmitterSubscription from '../vendor/emitter/EmitterSubscription';
 
 type NativeModule = {
   +addListener: (eventType: string) => void,

--- a/Libraries/EventEmitter/RCTDeviceEventEmitter.js
+++ b/Libraries/EventEmitter/RCTDeviceEventEmitter.js
@@ -10,10 +10,10 @@
 
 'use strict';
 
-const EventEmitter = require('EventEmitter');
-const EventSubscriptionVendor = require('EventSubscriptionVendor');
+const EventEmitter = require('../vendor/emitter/EventEmitter');
+const EventSubscriptionVendor = require('../vendor/emitter/EventSubscriptionVendor');
 
-import type EmitterSubscription from 'EmitterSubscription';
+import type EmitterSubscription from '../vendor/emitter/EmitterSubscription';
 
 function checkNativeEventModule(eventType: ?string) {
   if (eventType) {

--- a/Libraries/EventEmitter/RCTEventEmitter.js
+++ b/Libraries/EventEmitter/RCTEventEmitter.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const BatchedBridge = require('BatchedBridge');
+const BatchedBridge = require('../BatchedBridge/BatchedBridge');
 
 const RCTEventEmitter = {
   register(eventEmitter: any) {

--- a/Libraries/EventEmitter/RCTNativeAppEventEmitter.js
+++ b/Libraries/EventEmitter/RCTNativeAppEventEmitter.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const RCTDeviceEventEmitter = require('RCTDeviceEventEmitter');
+const RCTDeviceEventEmitter = require('./RCTDeviceEventEmitter');
 
 /**
  * Deprecated - subclass NativeEventEmitter to create granular event modules instead of

--- a/Libraries/EventEmitter/__mocks__/NativeEventEmitter.js
+++ b/Libraries/EventEmitter/__mocks__/NativeEventEmitter.js
@@ -10,8 +10,8 @@
 
 'use strict';
 
-const EventEmitter = require('EventEmitter');
-const RCTDeviceEventEmitter = require('RCTDeviceEventEmitter');
+const EventEmitter = require('../../vendor/emitter/EventEmitter');
+const RCTDeviceEventEmitter = require('../RCTDeviceEventEmitter');
 
 /**
  * Mock the NativeEventEmitter as a normal JS EventEmitter.

--- a/Libraries/Experimental/Incremental.js
+++ b/Libraries/Experimental/Incremental.js
@@ -10,12 +10,12 @@
 
 'use strict';
 
-const InteractionManager = require('InteractionManager');
-const React = require('React');
+const InteractionManager = require('../Interaction/InteractionManager');
+const React = require('react');
 
 const PropTypes = require('prop-types');
 
-const infoLog = require('infoLog');
+const infoLog = require('../Utilities/infoLog');
 
 const DEBUG = false;
 

--- a/Libraries/Experimental/IncrementalExample.js
+++ b/Libraries/Experimental/IncrementalExample.js
@@ -21,11 +21,11 @@ const {
   View,
 } = ReactNative;
 
-const Incremental = require('Incremental');
-const IncrementalGroup = require('IncrementalGroup');
-const IncrementalPresenter = require('IncrementalPresenter');
+const Incremental = require('./Incremental');
+const IncrementalGroup = require('./IncrementalGroup');
+const IncrementalPresenter = require('./IncrementalPresenter');
 
-const JSEventLoopWatchdog = require('JSEventLoopWatchdog');
+const JSEventLoopWatchdog = require('../Interaction/JSEventLoopWatchdog');
 
 const performanceNow = require('fbjs/lib/performanceNow');
 

--- a/Libraries/Experimental/IncrementalGroup.js
+++ b/Libraries/Experimental/IncrementalGroup.js
@@ -10,17 +10,17 @@
 
 'use strict';
 
-const Incremental = require('Incremental');
-const React = require('React');
+const Incremental = require('./Incremental');
+const React = require('react');
 
 const PropTypes = require('prop-types');
 
-const infoLog = require('infoLog');
+const infoLog = require('../Utilities/infoLog');
 
 let _groupCounter = -1;
 const DEBUG = false;
 
-import type {Props, Context} from 'Incremental';
+import type {Props, Context} from './Incremental';
 
 /**
  * WARNING: EXPERIMENTAL. Breaking changes will probably happen a lot and will

--- a/Libraries/Experimental/IncrementalPresenter.js
+++ b/Libraries/Experimental/IncrementalPresenter.js
@@ -10,14 +10,14 @@
 
 'use strict';
 
-const IncrementalGroup = require('IncrementalGroup');
+const IncrementalGroup = require('./IncrementalGroup');
 const PropTypes = require('prop-types');
-const React = require('React');
-const View = require('View');
+const React = require('react');
+const View = require('../Components/View/View');
 
-import type {Context} from 'Incremental';
-import type {ViewStyleProp} from 'StyleSheet';
-import type {LayoutEvent} from 'CoreEventTypes';
+import type {Context} from './Incremental';
+import type {ViewStyleProp} from '../StyleSheet/StyleSheet';
+import type {LayoutEvent} from '../Types/CoreEventTypes';
 
 /**
  * WARNING: EXPERIMENTAL. Breaking changes will probably happen a lot and will

--- a/Libraries/Experimental/WindowedListView.js
+++ b/Libraries/Experimental/WindowedListView.js
@@ -10,22 +10,22 @@
 
 'use strict';
 
-const Batchinator = require('Batchinator');
-const IncrementalGroup = require('IncrementalGroup');
-const React = require('React');
-const ScrollView = require('ScrollView');
-const StyleSheet = require('StyleSheet');
-const Systrace = require('Systrace');
-const View = require('View');
-const ViewabilityHelper = require('ViewabilityHelper');
+const Batchinator = require('../Interaction/Batchinator');
+const IncrementalGroup = require('./IncrementalGroup');
+const React = require('react');
+const ScrollView = require('../Components/ScrollView/ScrollView');
+const StyleSheet = require('../StyleSheet/StyleSheet');
+const Systrace = require('../Performance/Systrace');
+const View = require('../Components/View/View');
+const ViewabilityHelper = require('../Lists/ViewabilityHelper');
 
-const clamp = require('clamp');
-const deepDiffer = require('deepDiffer');
-const infoLog = require('infoLog');
+const clamp = require('../Utilities/clamp');
+const deepDiffer = require('../Utilities/differ/deepDiffer');
+const infoLog = require('../Utilities/infoLog');
 const invariant = require('invariant');
 const nullthrows = require('nullthrows');
 
-import type {NativeMethodsMixinType} from 'ReactNativeTypes';
+import type {NativeMethodsMixinType} from '../Renderer/shims/ReactNativeTypes';
 
 const DEBUG = false;
 
@@ -777,7 +777,7 @@ class CellRenderer extends React.Component<CellProps> {
     let debug;
     if (DEBUG) {
       infoLog('render cell ' + this.props.rowIndex);
-      const Text = require('Text');
+      const Text = require('../Text/Text');
       debug = <Text style={styles.debug}>Row: {this.props.rowIndex}</Text>;
     }
     const style = this._includeInLayoutLatch ? styles.include : styles.remove;

--- a/Libraries/Image/AssetSourceResolver.js
+++ b/Libraries/Image/AssetSourceResolver.js
@@ -17,10 +17,10 @@ export type ResolvedAssetSource = {|
   +scale: number,
 |};
 
-import type {PackagerAsset} from 'AssetRegistry';
+import type {PackagerAsset} from './AssetRegistry';
 
-const PixelRatio = require('PixelRatio');
-const Platform = require('Platform');
+const PixelRatio = require('../Utilities/PixelRatio');
+const Platform = require('../Utilities/Platform');
 
 const assetPathUtils = require('./assetPathUtils');
 const invariant = require('invariant');

--- a/Libraries/Image/Image.android.js
+++ b/Libraries/Image/Image.android.js
@@ -10,26 +10,26 @@
 
 'use strict';
 
-const DeprecatedImageStylePropTypes = require('DeprecatedImageStylePropTypes');
-const DeprecatedStyleSheetPropType = require('DeprecatedStyleSheetPropType');
-const DeprecatedViewPropTypes = require('DeprecatedViewPropTypes');
-const ImageViewNativeComponent = require('ImageViewNativeComponent');
-const NativeModules = require('NativeModules');
+const DeprecatedImageStylePropTypes = require('../DeprecatedPropTypes/DeprecatedImageStylePropTypes');
+const DeprecatedStyleSheetPropType = require('../DeprecatedPropTypes/DeprecatedStyleSheetPropType');
+const DeprecatedViewPropTypes = require('../DeprecatedPropTypes/DeprecatedViewPropTypes');
+const ImageViewNativeComponent = require('./ImageViewNativeComponent');
+const NativeModules = require('../BatchedBridge/NativeModules');
 const PropTypes = require('prop-types');
-const React = require('React');
-const ReactNative = require('ReactNative'); // eslint-disable-line no-unused-vars
-const StyleSheet = require('StyleSheet');
-const TextAncestor = require('TextAncestor');
+const React = require('react');
+const ReactNative = require('../Renderer/shims/ReactNative'); // eslint-disable-line no-unused-vars
+const StyleSheet = require('../StyleSheet/StyleSheet');
+const TextAncestor = require('../Text/TextAncestor');
 
-const flattenStyle = require('flattenStyle');
-const merge = require('merge');
-const resolveAssetSource = require('resolveAssetSource');
+const flattenStyle = require('../StyleSheet/flattenStyle');
+const merge = require('../vendor/core/merge');
+const resolveAssetSource = require('./resolveAssetSource');
 
 const {ImageLoader} = NativeModules;
 
-const TextInlineImageNativeComponent = require('TextInlineImageNativeComponent');
+const TextInlineImageNativeComponent = require('./TextInlineImageNativeComponent');
 
-import type {ImageProps as ImagePropsType} from 'ImageProps';
+import type {ImageProps as ImagePropsType} from './ImageProps';
 
 let _requestId = 1;
 function generateRequestId() {

--- a/Libraries/Image/Image.ios.js
+++ b/Libraries/Image/Image.ios.js
@@ -9,23 +9,23 @@
  */
 'use strict';
 
-const DeprecatedImagePropType = require('DeprecatedImagePropType');
-const NativeModules = require('NativeModules');
-const React = require('React');
-const ReactNative = require('ReactNative'); // eslint-disable-line no-unused-vars
-const StyleSheet = require('StyleSheet');
+const DeprecatedImagePropType = require('../DeprecatedPropTypes/DeprecatedImagePropType');
+const NativeModules = require('../BatchedBridge/NativeModules');
+const React = require('react');
+const ReactNative = require('../Renderer/shims/ReactNative'); // eslint-disable-line no-unused-vars
+const StyleSheet = require('../StyleSheet/StyleSheet');
 
-const flattenStyle = require('flattenStyle');
-const requireNativeComponent = require('requireNativeComponent');
-const resolveAssetSource = require('resolveAssetSource');
+const flattenStyle = require('../StyleSheet/flattenStyle');
+const requireNativeComponent = require('../ReactNative/requireNativeComponent');
+const resolveAssetSource = require('./resolveAssetSource');
 
 const ImageViewManager = NativeModules.ImageViewManager;
 
 const RCTImageView = requireNativeComponent('RCTImageView');
 
-import type {ImageProps as ImagePropsType} from 'ImageProps';
+import type {ImageProps as ImagePropsType} from './ImageProps';
 
-import type {ImageStyleProp} from 'StyleSheet';
+import type {ImageStyleProp} from '../StyleSheet/StyleSheet';
 
 function getSize(
   uri: string,

--- a/Libraries/Image/ImageBackground.js
+++ b/Libraries/Image/ImageBackground.js
@@ -9,12 +9,12 @@
  */
 'use strict';
 
-const Image = require('Image');
-const React = require('React');
-const StyleSheet = require('StyleSheet');
-const View = require('View');
+const Image = require('./Image');
+const React = require('react');
+const StyleSheet = require('../StyleSheet/StyleSheet');
+const View = require('../Components/View/View');
 
-const ensureComponentIsNative = require('ensureComponentIsNative');
+const ensureComponentIsNative = require('../Components/Touchable/ensureComponentIsNative');
 
 /**
  * Very simple drop-in replacement for <Image> which supports nesting views.

--- a/Libraries/Image/ImageEditor.js
+++ b/Libraries/Image/ImageEditor.js
@@ -9,7 +9,8 @@
  */
 'use strict';
 
-const RCTImageEditingManager = require('NativeModules').ImageEditingManager;
+const RCTImageEditingManager = require('../BatchedBridge/NativeModules')
+  .ImageEditingManager;
 
 type ImageCropData = {
   /**

--- a/Libraries/Image/ImageProps.js
+++ b/Libraries/Image/ImageProps.js
@@ -10,12 +10,12 @@
 
 'use strict';
 
-import type {SyntheticEvent, LayoutEvent} from 'CoreEventTypes';
-import type {EdgeInsetsProp} from 'EdgeInsetsPropType';
-import type {ImageSource} from 'ImageSource';
-import type {ViewStyleProp, ImageStyleProp} from 'StyleSheet';
-import type {DimensionValue} from 'StyleSheetTypes';
-import type {ViewProps} from 'ViewPropTypes';
+import type {SyntheticEvent, LayoutEvent} from '../Types/CoreEventTypes';
+import type {EdgeInsetsProp} from '../StyleSheet/EdgeInsetsPropType';
+import type {ImageSource} from './ImageSource';
+import type {ViewStyleProp, ImageStyleProp} from '../StyleSheet/StyleSheet';
+import type {DimensionValue} from '../StyleSheet/StyleSheetTypes';
+import type {ViewProps} from '../Components/View/ViewPropTypes';
 
 export type ImageLoadEvent = SyntheticEvent<
   $ReadOnly<{|

--- a/Libraries/Image/ImageStore.js
+++ b/Libraries/Image/ImageStore.js
@@ -9,11 +9,12 @@
  */
 'use strict';
 
-const RCTImageStoreManager = require('NativeModules').ImageStoreManager;
+const RCTImageStoreManager = require('../BatchedBridge/NativeModules')
+  .ImageStoreManager;
 
-const Platform = require('Platform');
+const Platform = require('../Utilities/Platform');
 
-const warnOnce = require('warnOnce');
+const warnOnce = require('../Utilities/warnOnce');
 
 function warnUnimplementedMethod(methodName: string): void {
   warnOnce(

--- a/Libraries/Image/ImageViewNativeComponent.js
+++ b/Libraries/Image/ImageViewNativeComponent.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const requireNativeComponent = require('requireNativeComponent');
+const requireNativeComponent = require('../ReactNative/requireNativeComponent');
 
 const ImageViewNativeComponent = requireNativeComponent('RCTImageView');
 

--- a/Libraries/Image/RelativeImageStub.js
+++ b/Libraries/Image/RelativeImageStub.js
@@ -13,7 +13,7 @@
 // This is a stub for flow to make it understand require('./icon.png')
 // See metro/src/Bundler/index.js
 
-const AssetRegistry = require('AssetRegistry');
+const AssetRegistry = require('./AssetRegistry');
 
 module.exports = AssetRegistry.registerAsset({
   __packager_asset: true,

--- a/Libraries/Image/TextInlineImageNativeComponent.js
+++ b/Libraries/Image/TextInlineImageNativeComponent.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const requireNativeComponent = require('requireNativeComponent');
+const requireNativeComponent = require('../ReactNative/requireNativeComponent');
 
 const TextInlineImage = requireNativeComponent('RCTTextInlineImage');
 

--- a/Libraries/Image/__tests__/Image-test.js
+++ b/Libraries/Image/__tests__/Image-test.js
@@ -11,8 +11,8 @@
 
 'use strict';
 
-const React = require('React');
-const Image = require('Image');
+const React = require('react');
+const Image = require('../Image');
 const render = require('../../../jest/renderer');
 
 describe('<Image />', () => {
@@ -27,14 +27,14 @@ describe('<Image />', () => {
   });
 
   it('should shallow render as <ForwardRef(Image)> when not mocked', () => {
-    jest.dontMock('Image');
+    jest.dontMock('../Image');
 
     const output = render.shallow(<Image source={{uri: 'foo-bar.jpg'}} />);
     expect(output).toMatchSnapshot();
   });
 
   it('should render as <RCTImageView> when not mocked', () => {
-    jest.dontMock('Image');
+    jest.dontMock('../Image');
 
     const instance = render.create(<Image source={{uri: 'foo-bar.jpg'}} />);
     expect(instance).toMatchSnapshot();

--- a/Libraries/Image/__tests__/assetRelativePathInSnapshot-test.js
+++ b/Libraries/Image/__tests__/assetRelativePathInSnapshot-test.js
@@ -12,10 +12,10 @@
 
 jest.disableAutomock();
 
-const React = require('React');
+const React = require('react');
 const ReactTestRenderer = require('react-test-renderer');
-const Image = require('Image');
-const View = require('View');
+const Image = require('../Image');
+const View = require('../../Components/View/View');
 
 it('renders assets based on relative path', () => {
   expect(

--- a/Libraries/Image/__tests__/resolveAssetSource-test.js
+++ b/Libraries/Image/__tests__/resolveAssetSource-test.js
@@ -10,9 +10,9 @@
 
 'use strict';
 
-const AssetRegistry = require('AssetRegistry');
-const Platform = require('Platform');
-const NativeModules = require('NativeModules');
+const AssetRegistry = require('../AssetRegistry');
+const Platform = require('../../Utilities/Platform');
+const NativeModules = require('../../BatchedBridge/NativeModules');
 const resolveAssetSource = require('../resolveAssetSource');
 
 function expectResolvesAsset(input, expectedSource) {

--- a/Libraries/Image/nativeImageSource.js
+++ b/Libraries/Image/nativeImageSource.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const Platform = require('Platform');
+const Platform = require('../Utilities/Platform');
 
 // TODO: Change `nativeImageSource` to return this type.
 export type NativeImageSource = {|

--- a/Libraries/Image/resolveAssetSource.js
+++ b/Libraries/Image/resolveAssetSource.js
@@ -13,10 +13,10 @@
 
 'use strict';
 
-const AssetRegistry = require('AssetRegistry');
-const AssetSourceResolver = require('AssetSourceResolver');
+const AssetRegistry = require('./AssetRegistry');
+const AssetSourceResolver = require('./AssetSourceResolver');
 
-import type {ResolvedAssetSource} from 'AssetSourceResolver';
+import type {ResolvedAssetSource} from './AssetSourceResolver';
 
 let _customSourceTransformer, _serverURL, _scriptURL;
 
@@ -29,7 +29,7 @@ function getSourceCodeScriptURL(): ?string {
   let sourceCode =
     global.nativeExtensions && global.nativeExtensions.SourceCode;
   if (!sourceCode) {
-    const NativeModules = require('NativeModules');
+    const NativeModules = require('../BatchedBridge/NativeModules');
     sourceCode = NativeModules && NativeModules.SourceCode;
   }
   _sourceCodeScriptURL = sourceCode.scriptURL;

--- a/Libraries/Inspector/BorderBox.js
+++ b/Libraries/Inspector/BorderBox.js
@@ -10,8 +10,8 @@
 
 'use strict';
 
-const React = require('React');
-const View = require('View');
+const React = require('react');
+const View = require('../Components/View/View');
 
 class BorderBox extends React.Component<$FlowFixMeProps> {
   render() {

--- a/Libraries/Inspector/BoxInspector.js
+++ b/Libraries/Inspector/BoxInspector.js
@@ -10,11 +10,11 @@
 
 'use strict';
 
-const React = require('React');
-const StyleSheet = require('StyleSheet');
-const Text = require('Text');
-const View = require('View');
-const resolveBoxStyle = require('resolveBoxStyle');
+const React = require('react');
+const StyleSheet = require('../StyleSheet/StyleSheet');
+const Text = require('../Text/Text');
+const View = require('../Components/View/View');
+const resolveBoxStyle = require('./resolveBoxStyle');
 
 const blank = {
   top: 0,

--- a/Libraries/Inspector/ElementBox.js
+++ b/Libraries/Inspector/ElementBox.js
@@ -10,14 +10,14 @@
 
 'use strict';
 
-const BorderBox = require('BorderBox');
-const React = require('React');
-const StyleSheet = require('StyleSheet');
-const View = require('View');
-const Dimensions = require('Dimensions');
+const BorderBox = require('./BorderBox');
+const React = require('react');
+const StyleSheet = require('../StyleSheet/StyleSheet');
+const View = require('../Components/View/View');
+const Dimensions = require('../Utilities/Dimensions');
 
-const flattenStyle = require('flattenStyle');
-const resolveBoxStyle = require('resolveBoxStyle');
+const flattenStyle = require('../StyleSheet/flattenStyle');
+const resolveBoxStyle = require('./resolveBoxStyle');
 
 class ElementBox extends React.Component<$FlowFixMeProps> {
   render() {

--- a/Libraries/Inspector/ElementProperties.js
+++ b/Libraries/Inspector/ElementProperties.js
@@ -10,20 +10,20 @@
 
 'use strict';
 
-const BoxInspector = require('BoxInspector');
-const React = require('React');
-const StyleInspector = require('StyleInspector');
-const StyleSheet = require('StyleSheet');
-const Text = require('Text');
-const TouchableHighlight = require('TouchableHighlight');
-const TouchableWithoutFeedback = require('TouchableWithoutFeedback');
-const View = require('View');
+const BoxInspector = require('./BoxInspector');
+const React = require('react');
+const StyleInspector = require('./StyleInspector');
+const StyleSheet = require('../StyleSheet/StyleSheet');
+const Text = require('../Text/Text');
+const TouchableHighlight = require('../Components/Touchable/TouchableHighlight');
+const TouchableWithoutFeedback = require('../Components/Touchable/TouchableWithoutFeedback');
+const View = require('../Components/View/View');
 
-const flattenStyle = require('flattenStyle');
-const mapWithSeparator = require('mapWithSeparator');
-const openFileInEditor = require('openFileInEditor');
+const flattenStyle = require('../StyleSheet/flattenStyle');
+const mapWithSeparator = require('../Utilities/mapWithSeparator');
+const openFileInEditor = require('../Core/Devtools/openFileInEditor');
 
-import type {ViewStyleProp} from 'StyleSheet';
+import type {ViewStyleProp} from '../StyleSheet/StyleSheet';
 
 type Props = $ReadOnly<{|
   hierarchy: Array<{|name: string|}>,

--- a/Libraries/Inspector/Inspector.js
+++ b/Libraries/Inspector/Inspector.js
@@ -10,16 +10,16 @@
 
 'use strict';
 
-const Dimensions = require('Dimensions');
-const InspectorOverlay = require('InspectorOverlay');
-const InspectorPanel = require('InspectorPanel');
-const Platform = require('Platform');
-const React = require('React');
-const ReactNative = require('ReactNative');
-const StyleSheet = require('StyleSheet');
-const Touchable = require('Touchable');
-const UIManager = require('UIManager');
-const View = require('View');
+const Dimensions = require('../Utilities/Dimensions');
+const InspectorOverlay = require('./InspectorOverlay');
+const InspectorPanel = require('./InspectorPanel');
+const Platform = require('../Utilities/Platform');
+const React = require('react');
+const ReactNative = require('../Renderer/shims/ReactNative');
+const StyleSheet = require('../StyleSheet/StyleSheet');
+const Touchable = require('../Components/Touchable/Touchable');
+const UIManager = require('../ReactNative/UIManager');
+const View = require('../Components/View/View');
 
 const invariant = require('invariant');
 
@@ -31,7 +31,7 @@ const hook = window.__REACT_DEVTOOLS_GLOBAL_HOOK__;
 const renderers = findRenderers();
 
 // required for devtools to be able to edit react native styles
-hook.resolveRNStyle = require('flattenStyle');
+hook.resolveRNStyle = require('../StyleSheet/flattenStyle');
 
 function findRenderers(): $ReadOnlyArray<ReactRenderer> {
   const allRenderers = Object.keys(hook._renderers).map(

--- a/Libraries/Inspector/InspectorOverlay.js
+++ b/Libraries/Inspector/InspectorOverlay.js
@@ -10,15 +10,15 @@
 
 'use strict';
 
-const Dimensions = require('Dimensions');
-const ElementBox = require('ElementBox');
-const React = require('React');
-const StyleSheet = require('StyleSheet');
-const UIManager = require('UIManager');
-const View = require('View');
+const Dimensions = require('../Utilities/Dimensions');
+const ElementBox = require('./ElementBox');
+const React = require('react');
+const StyleSheet = require('../StyleSheet/StyleSheet');
+const UIManager = require('../ReactNative/UIManager');
+const View = require('../Components/View/View');
 
-import type {PressEvent} from 'CoreEventTypes';
-import type {ViewStyleProp} from 'StyleSheet';
+import type {PressEvent} from '../Types/CoreEventTypes';
+import type {ViewStyleProp} from '../StyleSheet/StyleSheet';
 
 type Inspected = $ReadOnly<{|
   frame?: Object,

--- a/Libraries/Inspector/InspectorPanel.js
+++ b/Libraries/Inspector/InspectorPanel.js
@@ -10,17 +10,17 @@
 
 'use strict';
 
-const ElementProperties = require('ElementProperties');
-const NetworkOverlay = require('NetworkOverlay');
-const PerformanceOverlay = require('PerformanceOverlay');
-const React = require('React');
-const ScrollView = require('ScrollView');
-const StyleSheet = require('StyleSheet');
-const Text = require('Text');
-const TouchableHighlight = require('TouchableHighlight');
-const View = require('View');
+const ElementProperties = require('./ElementProperties');
+const NetworkOverlay = require('./NetworkOverlay');
+const PerformanceOverlay = require('./PerformanceOverlay');
+const React = require('react');
+const ScrollView = require('../Components/ScrollView/ScrollView');
+const StyleSheet = require('../StyleSheet/StyleSheet');
+const Text = require('../Text/Text');
+const TouchableHighlight = require('../Components/Touchable/TouchableHighlight');
+const View = require('../Components/View/View');
 
-import type {ViewStyleProp} from 'StyleSheet';
+import type {ViewStyleProp} from '../StyleSheet/StyleSheet';
 
 type Props = $ReadOnly<{|
   devtoolsIsOpen: boolean,

--- a/Libraries/Inspector/NetworkOverlay.js
+++ b/Libraries/Inspector/NetworkOverlay.js
@@ -10,15 +10,15 @@
 
 'use strict';
 
-const FlatList = require('FlatList');
-const React = require('React');
-const ScrollView = require('ScrollView');
-const StyleSheet = require('StyleSheet');
-const Text = require('Text');
-const TouchableHighlight = require('TouchableHighlight');
-const View = require('View');
-const WebSocketInterceptor = require('WebSocketInterceptor');
-const XHRInterceptor = require('XHRInterceptor');
+const FlatList = require('../Lists/FlatList');
+const React = require('react');
+const ScrollView = require('../Components/ScrollView/ScrollView');
+const StyleSheet = require('../StyleSheet/StyleSheet');
+const Text = require('../Text/Text');
+const TouchableHighlight = require('../Components/Touchable/TouchableHighlight');
+const View = require('../Components/View/View');
+const WebSocketInterceptor = require('../WebSocket/WebSocketInterceptor');
+const XHRInterceptor = require('../Network/XHRInterceptor');
 
 const LISTVIEW_CELL_HEIGHT = 15;
 

--- a/Libraries/Inspector/PerformanceOverlay.js
+++ b/Libraries/Inspector/PerformanceOverlay.js
@@ -10,11 +10,11 @@
 
 'use strict';
 
-const PerformanceLogger = require('GlobalPerformanceLogger');
-const React = require('React');
-const StyleSheet = require('StyleSheet');
-const Text = require('Text');
-const View = require('View');
+const PerformanceLogger = require('../Utilities/GlobalPerformanceLogger');
+const React = require('react');
+const StyleSheet = require('../StyleSheet/StyleSheet');
+const Text = require('../Text/Text');
+const View = require('../Components/View/View');
 
 class PerformanceOverlay extends React.Component<{}> {
   render() {

--- a/Libraries/Inspector/StyleInspector.js
+++ b/Libraries/Inspector/StyleInspector.js
@@ -10,10 +10,10 @@
 
 'use strict';
 
-const React = require('React');
-const StyleSheet = require('StyleSheet');
-const Text = require('Text');
-const View = require('View');
+const React = require('react');
+const StyleSheet = require('../StyleSheet/StyleSheet');
+const Text = require('../Text/Text');
+const View = require('../Components/View/View');
 
 class StyleInspector extends React.Component<$FlowFixMeProps> {
   render() {

--- a/Libraries/Inspector/resolveBoxStyle.js
+++ b/Libraries/Inspector/resolveBoxStyle.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const I18nManager = require('I18nManager');
+const I18nManager = require('../ReactNative/I18nManager');
 
 /**
  * Resolve a style property into its component parts.

--- a/Libraries/Interaction/Batchinator.js
+++ b/Libraries/Interaction/Batchinator.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const InteractionManager = require('InteractionManager');
+const InteractionManager = require('./InteractionManager');
 
 /**
  * A simple class for batching up invocations of a low-pri callback. A timeout is set to run the

--- a/Libraries/Interaction/BridgeSpyStallHandler.js
+++ b/Libraries/Interaction/BridgeSpyStallHandler.js
@@ -10,10 +10,10 @@
 
 'use strict';
 
-const JSEventLoopWatchdog = require('JSEventLoopWatchdog');
-const MessageQueue = require('MessageQueue');
+const JSEventLoopWatchdog = require('./JSEventLoopWatchdog');
+const MessageQueue = require('../BatchedBridge/MessageQueue');
 
-const infoLog = require('infoLog');
+const infoLog = require('../Utilities/infoLog');
 
 const BridgeSpyStallHandler = {
   register: function() {

--- a/Libraries/Interaction/FrameRateLogger.js
+++ b/Libraries/Interaction/FrameRateLogger.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const NativeModules = require('NativeModules');
+const NativeModules = require('../BatchedBridge/NativeModules');
 
 const invariant = require('invariant');
 

--- a/Libraries/Interaction/InteractionManager.js
+++ b/Libraries/Interaction/InteractionManager.js
@@ -10,16 +10,16 @@
 
 'use strict';
 
-const BatchedBridge = require('BatchedBridge');
-const EventEmitter = require('EventEmitter');
-const TaskQueue = require('TaskQueue');
+const BatchedBridge = require('../BatchedBridge/BatchedBridge');
+const EventEmitter = require('../vendor/emitter/EventEmitter');
+const TaskQueue = require('./TaskQueue');
 
-const infoLog = require('infoLog');
+const infoLog = require('../Utilities/infoLog');
 const invariant = require('invariant');
 const keyMirror = require('fbjs/lib/keyMirror');
 
 type Handle = number;
-import type {Task} from 'TaskQueue';
+import type {Task} from './TaskQueue';
 
 const _emitter = new EventEmitter();
 

--- a/Libraries/Interaction/InteractionMixin.js
+++ b/Libraries/Interaction/InteractionMixin.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const InteractionManager = require('InteractionManager');
+const InteractionManager = require('./InteractionManager');
 
 /**
  * This mixin provides safe versions of InteractionManager start/end methods

--- a/Libraries/Interaction/InteractionStallDebugger.js
+++ b/Libraries/Interaction/InteractionStallDebugger.js
@@ -10,8 +10,8 @@
 
 'use strict';
 
-const BridgeSpyStallHandler = require('BridgeSpyStallHandler');
-const JSEventLoopWatchdog = require('JSEventLoopWatchdog');
+const BridgeSpyStallHandler = require('./BridgeSpyStallHandler');
+const JSEventLoopWatchdog = require('./JSEventLoopWatchdog');
 
 const InteractionStallDebugger = {
   install(options: {thresholdMS: number}): void {

--- a/Libraries/Interaction/JSEventLoopWatchdog.js
+++ b/Libraries/Interaction/JSEventLoopWatchdog.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const infoLog = require('infoLog');
+const infoLog = require('../Utilities/infoLog');
 const performanceNow = require('fbjs/lib/performanceNow');
 
 type Handler = {

--- a/Libraries/Interaction/PanResponder.js
+++ b/Libraries/Interaction/PanResponder.js
@@ -13,7 +13,7 @@
 const InteractionManager = require('./InteractionManager');
 const TouchHistoryMath = require('./TouchHistoryMath');
 
-import type {PressEvent} from 'CoreEventTypes';
+import type {PressEvent} from '../Types/CoreEventTypes';
 
 const currentCentroidXOfTouchesChangedAfter =
   TouchHistoryMath.currentCentroidXOfTouchesChangedAfter;

--- a/Libraries/Interaction/TaskQueue.js
+++ b/Libraries/Interaction/TaskQueue.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const infoLog = require('infoLog');
+const infoLog = require('../Utilities/infoLog');
 const invariant = require('invariant');
 
 type SimpleTask = {

--- a/Libraries/Interaction/__tests__/Batchinator-test.js
+++ b/Libraries/Interaction/__tests__/Batchinator-test.js
@@ -10,14 +10,16 @@
 
 'use strict';
 
-jest.mock('ErrorUtils').mock('BatchedBridge');
+jest
+  .mock('../../vendor/core/ErrorUtils')
+  .mock('../../BatchedBridge/BatchedBridge');
 
 function expectToBeCalledOnce(fn) {
   expect(fn.mock.calls.length).toBe(1);
 }
 
 describe('Batchinator', () => {
-  const Batchinator = require('Batchinator');
+  const Batchinator = require('../Batchinator');
 
   it('executes vanilla tasks', () => {
     const callback = jest.fn();

--- a/Libraries/Interaction/__tests__/InteractionManager-test.js
+++ b/Libraries/Interaction/__tests__/InteractionManager-test.js
@@ -10,7 +10,9 @@
 
 'use strict';
 
-jest.mock('ErrorUtils').mock('BatchedBridge');
+jest
+  .mock('../../vendor/core/ErrorUtils')
+  .mock('../../BatchedBridge/BatchedBridge');
 
 const isWindows = process.platform === 'win32';
 function expectToBeCalledOnce(fn) {
@@ -28,7 +30,7 @@ describe('InteractionManager', () => {
 
   beforeEach(() => {
     jest.resetModules();
-    InteractionManager = require('InteractionManager');
+    InteractionManager = require('../InteractionManager');
 
     interactionStart = jest.fn();
     interactionComplete = jest.fn();
@@ -167,8 +169,8 @@ describe('promise tasks', () => {
   beforeEach(() => {
     jest.resetModules();
     jest.useFakeTimers();
-    InteractionManager = require('InteractionManager');
-    BatchedBridge = require('BatchedBridge');
+    InteractionManager = require('../InteractionManager');
+    BatchedBridge = require('../../BatchedBridge/BatchedBridge');
     sequenceId = 0;
   });
 

--- a/Libraries/Interaction/__tests__/InteractionMixin-test.js
+++ b/Libraries/Interaction/__tests__/InteractionMixin-test.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-jest.mock('InteractionManager');
+jest.mock('../InteractionManager');
 
 describe('InteractionMixin', () => {
   let InteractionManager;
@@ -19,8 +19,8 @@ describe('InteractionMixin', () => {
 
   beforeEach(() => {
     jest.resetModules();
-    InteractionManager = require('InteractionManager');
-    InteractionMixin = require('InteractionMixin');
+    InteractionManager = require('../InteractionManager');
+    InteractionMixin = require('../InteractionMixin');
 
     component = Object.create(InteractionMixin);
   });

--- a/Libraries/Interaction/__tests__/TaskQueue-test.js
+++ b/Libraries/Interaction/__tests__/TaskQueue-test.js
@@ -36,7 +36,7 @@ describe('TaskQueue', () => {
   beforeEach(() => {
     jest.resetModules();
     onMoreTasks = jest.fn();
-    const TaskQueue = require('TaskQueue');
+    const TaskQueue = require('../TaskQueue');
     taskQueue = new TaskQueue({onMoreTasks});
     sequenceId = 0;
   });

--- a/Libraries/JSInspector/JSInspector.js
+++ b/Libraries/JSInspector/JSInspector.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-import type {EventSender} from 'InspectorAgent';
+import type {EventSender} from './InspectorAgent';
 
 interface Agent {
   constructor(eventSender: EventSender): void;

--- a/Libraries/JSInspector/NetworkAgent.js
+++ b/Libraries/JSInspector/NetworkAgent.js
@@ -10,11 +10,11 @@
 
 'use strict';
 
-const InspectorAgent = require('InspectorAgent');
-const JSInspector = require('JSInspector');
-const XMLHttpRequest = require('XMLHttpRequest');
+const InspectorAgent = require('./InspectorAgent');
+const JSInspector = require('./JSInspector');
+const XMLHttpRequest = require('../Network/XMLHttpRequest');
 
-import type EventSender from 'InspectorAgent';
+import type EventSender from './InspectorAgent';
 
 type RequestId = string;
 

--- a/Libraries/LayoutAnimation/LayoutAnimation.js
+++ b/Libraries/LayoutAnimation/LayoutAnimation.js
@@ -10,8 +10,8 @@
 
 'use strict';
 
-import Platform from 'Platform';
-const UIManager = require('UIManager');
+import Platform from '../Utilities/Platform';
+const UIManager = require('../ReactNative/UIManager');
 
 type Type =
   | 'spring'

--- a/Libraries/Linking/Linking.js
+++ b/Libraries/Linking/Linking.js
@@ -10,9 +10,9 @@
 
 'use strict';
 
-const NativeEventEmitter = require('NativeEventEmitter');
-const NativeModules = require('NativeModules');
-const Platform = require('Platform');
+const NativeEventEmitter = require('../EventEmitter/NativeEventEmitter');
+const NativeModules = require('../BatchedBridge/NativeModules');
+const Platform = require('../Utilities/Platform');
 
 const invariant = require('invariant');
 

--- a/Libraries/Lists/FlatList.js
+++ b/Libraries/Lists/FlatList.js
@@ -9,22 +9,22 @@
  */
 'use strict';
 
-const Platform = require('Platform');
-const deepDiffer = require('deepDiffer');
-const React = require('React');
-const View = require('View');
-const VirtualizedList = require('VirtualizedList');
-const StyleSheet = require('StyleSheet');
+const Platform = require('../Utilities/Platform');
+const deepDiffer = require('../Utilities/differ/deepDiffer');
+const React = require('react');
+const View = require('../Components/View/View');
+const VirtualizedList = require('./VirtualizedList');
+const StyleSheet = require('../StyleSheet/StyleSheet');
 
 const invariant = require('invariant');
 
-import type {ViewStyleProp} from 'StyleSheet';
+import type {ViewStyleProp} from '../StyleSheet/StyleSheet';
 import type {
   ViewabilityConfig,
   ViewToken,
   ViewabilityConfigCallbackPair,
-} from 'ViewabilityHelper';
-import type {Props as VirtualizedListProps} from 'VirtualizedList';
+} from './ViewabilityHelper';
+import type {Props as VirtualizedListProps} from './VirtualizedList';
 
 export type SeparatorsObj = {
   highlight: () => void,

--- a/Libraries/Lists/SectionList.js
+++ b/Libraries/Lists/SectionList.js
@@ -9,16 +9,16 @@
  */
 'use strict';
 
-const Platform = require('Platform');
-const React = require('React');
-const ScrollView = require('ScrollView');
-const VirtualizedSectionList = require('VirtualizedSectionList');
+const Platform = require('../Utilities/Platform');
+const React = require('react');
+const ScrollView = require('../Components/ScrollView/ScrollView');
+const VirtualizedSectionList = require('./VirtualizedSectionList');
 
-import type {ViewToken} from 'ViewabilityHelper';
+import type {ViewToken} from './ViewabilityHelper';
 import type {
   SectionBase as _SectionBase,
   Props as VirtualizedSectionListProps,
-} from 'VirtualizedSectionList';
+} from './VirtualizedSectionList';
 
 type Item = any;
 

--- a/Libraries/Lists/VirtualizedList.js
+++ b/Libraries/Lists/VirtualizedList.js
@@ -9,31 +9,31 @@
  */
 'use strict';
 
-const Batchinator = require('Batchinator');
-const FillRateHelper = require('FillRateHelper');
+const Batchinator = require('../Interaction/Batchinator');
+const FillRateHelper = require('./FillRateHelper');
 const PropTypes = require('prop-types');
-const React = require('React');
-const ReactNative = require('ReactNative');
-const RefreshControl = require('RefreshControl');
-const ScrollView = require('ScrollView');
-const StyleSheet = require('StyleSheet');
-const UIManager = require('UIManager');
-const View = require('View');
-const ViewabilityHelper = require('ViewabilityHelper');
+const React = require('react');
+const ReactNative = require('../Renderer/shims/ReactNative');
+const RefreshControl = require('../Components/RefreshControl/RefreshControl');
+const ScrollView = require('../Components/ScrollView/ScrollView');
+const StyleSheet = require('../StyleSheet/StyleSheet');
+const UIManager = require('../ReactNative/UIManager');
+const View = require('../Components/View/View');
+const ViewabilityHelper = require('./ViewabilityHelper');
 
-const flattenStyle = require('flattenStyle');
-const infoLog = require('infoLog');
+const flattenStyle = require('../StyleSheet/flattenStyle');
+const infoLog = require('../Utilities/infoLog');
 const invariant = require('invariant');
 const warning = require('fbjs/lib/warning');
 
-const {computeWindowedRenderLimits} = require('VirtualizeUtils');
+const {computeWindowedRenderLimits} = require('./VirtualizeUtils');
 
-import type {ViewStyleProp} from 'StyleSheet';
+import type {ViewStyleProp} from '../StyleSheet/StyleSheet';
 import type {
   ViewabilityConfig,
   ViewToken,
   ViewabilityConfigCallbackPair,
-} from 'ViewabilityHelper';
+} from './ViewabilityHelper';
 
 type Item = any;
 

--- a/Libraries/Lists/VirtualizedSectionList.js
+++ b/Libraries/Lists/VirtualizedSectionList.js
@@ -9,15 +9,15 @@
  */
 'use strict';
 
-const Platform = require('Platform');
-const React = require('React');
-const View = require('View');
-const VirtualizedList = require('VirtualizedList');
+const Platform = require('../Utilities/Platform');
+const React = require('react');
+const View = require('../Components/View/View');
+const VirtualizedList = require('./VirtualizedList');
 
 const invariant = require('invariant');
 
-import type {ViewToken} from 'ViewabilityHelper';
-import type {Props as VirtualizedListProps} from 'VirtualizedList';
+import type {ViewToken} from './ViewabilityHelper';
+import type {Props as VirtualizedListProps} from './VirtualizedList';
 
 type Item = any;
 

--- a/Libraries/Lists/__flowtests__/FlatList-flowtest.js
+++ b/Libraries/Lists/__flowtests__/FlatList-flowtest.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const FlatList = require('FlatList');
+const FlatList = require('../FlatList');
 const React = require('react');
 
 function renderMyListItem(info: {item: {title: string}, index: number}) {

--- a/Libraries/Lists/__flowtests__/SectionList-flowtest.js
+++ b/Libraries/Lists/__flowtests__/SectionList-flowtest.js
@@ -11,7 +11,7 @@
 'use strict';
 
 const React = require('react');
-const SectionList = require('SectionList');
+const SectionList = require('../SectionList');
 
 function renderMyListItem(info: {item: {title: string}, index: number}) {
   return <span />;

--- a/Libraries/Lists/__tests__/FillRateHelper-test.js
+++ b/Libraries/Lists/__tests__/FillRateHelper-test.js
@@ -10,7 +10,7 @@
  */
 'use strict';
 
-const FillRateHelper = require('FillRateHelper');
+const FillRateHelper = require('../FillRateHelper');
 
 let rowFramesGlobal;
 const dataGlobal = [

--- a/Libraries/Lists/__tests__/FlatList-test.js
+++ b/Libraries/Lists/__tests__/FlatList-test.js
@@ -10,10 +10,10 @@
  */
 'use strict';
 
-const React = require('React');
+const React = require('react');
 const ReactTestRenderer = require('react-test-renderer');
 
-const FlatList = require('FlatList');
+const FlatList = require('../FlatList');
 
 describe('FlatList', () => {
   it('renders simple list', () => {

--- a/Libraries/Lists/__tests__/SectionList-test.js
+++ b/Libraries/Lists/__tests__/SectionList-test.js
@@ -10,10 +10,10 @@
  */
 'use strict';
 
-const React = require('React');
+const React = require('react');
 const ReactTestRenderer = require('react-test-renderer');
 
-const SectionList = require('SectionList');
+const SectionList = require('../SectionList');
 
 describe('SectionList', () => {
   it('renders empty list', () => {

--- a/Libraries/Lists/__tests__/ViewabilityHelper-test.js
+++ b/Libraries/Lists/__tests__/ViewabilityHelper-test.js
@@ -10,7 +10,7 @@
  */
 'use strict';
 
-const ViewabilityHelper = require('ViewabilityHelper');
+const ViewabilityHelper = require('../ViewabilityHelper');
 
 let rowFrames;
 let data;

--- a/Libraries/Lists/__tests__/VirtualizeUtils-test.js
+++ b/Libraries/Lists/__tests__/VirtualizeUtils-test.js
@@ -10,7 +10,10 @@
  */
 'use strict';
 
-const {elementsThatOverlapOffsets, newRangeCount} = require('VirtualizeUtils');
+const {
+  elementsThatOverlapOffsets,
+  newRangeCount,
+} = require('../VirtualizeUtils');
 
 describe('newRangeCount', function() {
   it('handles subset', function() {

--- a/Libraries/Lists/__tests__/VirtualizedList-test.js
+++ b/Libraries/Lists/__tests__/VirtualizedList-test.js
@@ -10,10 +10,10 @@
  */
 'use strict';
 
-const React = require('React');
+const React = require('react');
 const ReactTestRenderer = require('react-test-renderer');
 
-const VirtualizedList = require('VirtualizedList');
+const VirtualizedList = require('../VirtualizedList');
 
 describe('VirtualizedList', () => {
   it('renders simple list', () => {

--- a/Libraries/Lists/__tests__/VirtualizedSectionList-test.js
+++ b/Libraries/Lists/__tests__/VirtualizedSectionList-test.js
@@ -10,10 +10,10 @@
  */
 'use strict';
 
-const React = require('React');
+const React = require('react');
 const ReactTestRenderer = require('react-test-renderer');
 
-const VirtualizedSectionList = require('VirtualizedSectionList');
+const VirtualizedSectionList = require('../VirtualizedSectionList');
 
 describe('VirtualizedSectionList', () => {
   it('renders simple list', () => {

--- a/Libraries/Modal/Modal.js
+++ b/Libraries/Modal/Modal.js
@@ -10,26 +10,26 @@
 
 'use strict';
 
-const AppContainer = require('AppContainer');
-const I18nManager = require('I18nManager');
-const NativeEventEmitter = require('NativeEventEmitter');
-const NativeModules = require('NativeModules');
-const Platform = require('Platform');
-const React = require('React');
+const AppContainer = require('../ReactNative/AppContainer');
+const I18nManager = require('../ReactNative/I18nManager');
+const NativeEventEmitter = require('../EventEmitter/NativeEventEmitter');
+const NativeModules = require('../BatchedBridge/NativeModules');
+const Platform = require('../Utilities/Platform');
+const React = require('react');
 const PropTypes = require('prop-types');
-const StyleSheet = require('StyleSheet');
-const View = require('View');
+const StyleSheet = require('../StyleSheet/StyleSheet');
+const View = require('../Components/View/View');
 
-const RCTModalHostView = require('RCTModalHostViewNativeComponent');
+const RCTModalHostView = require('./RCTModalHostViewNativeComponent');
 
 const ModalEventEmitter =
   Platform.OS === 'ios' && NativeModules.ModalManager
     ? new NativeEventEmitter(NativeModules.ModalManager)
     : null;
 
-import type EmitterSubscription from 'EmitterSubscription';
-import type {ViewProps} from 'ViewPropTypes';
-import type {SyntheticEvent} from 'CoreEventTypes';
+import type EmitterSubscription from '../vendor/emitter/EmitterSubscription';
+import type {ViewProps} from '../Components/View/ViewPropTypes';
+import type {SyntheticEvent} from '../Types/CoreEventTypes';
 
 /**
  * The Modal component is a simple way to present content above an enclosing view.

--- a/Libraries/Modal/RCTModalHostViewNativeComponent.js
+++ b/Libraries/Modal/RCTModalHostViewNativeComponent.js
@@ -10,11 +10,11 @@
 
 'use strict';
 
-const requireNativeComponent = require('requireNativeComponent');
+const requireNativeComponent = require('../ReactNative/requireNativeComponent');
 
-import type {ViewProps} from 'ViewPropTypes';
-import type {SyntheticEvent} from 'CoreEventTypes';
-import type {NativeComponent} from 'ReactNative';
+import type {ViewProps} from '../Components/View/ViewPropTypes';
+import type {SyntheticEvent} from '../Types/CoreEventTypes';
+import type {NativeComponent} from '../Renderer/shims/ReactNative';
 
 type OrientationChangeEvent = SyntheticEvent<
   $ReadOnly<{|

--- a/Libraries/Modal/__tests__/Modal-test.js
+++ b/Libraries/Modal/__tests__/Modal-test.js
@@ -11,8 +11,8 @@
 
 'use strict';
 
-const React = require('React');
-const View = require('View');
+const React = require('react');
+const View = require('../../Components/View/View');
 const Modal = require('../Modal');
 
 const render = require('../../../jest/renderer');
@@ -37,7 +37,7 @@ describe('<Modal />', () => {
   });
 
   it('should shallow render as <Modal> when not mocked', () => {
-    jest.dontMock('Modal');
+    jest.dontMock('../Modal');
 
     const output = render.shallow(
       <Modal>
@@ -48,7 +48,7 @@ describe('<Modal />', () => {
   });
 
   it('should render as <RCTModalHostView> when not mocked', () => {
-    jest.dontMock('Modal');
+    jest.dontMock('../Modal');
 
     const instance = render.create(
       <Modal>

--- a/Libraries/Network/NetInfo.js
+++ b/Libraries/Network/NetInfo.js
@@ -10,9 +10,9 @@
 
 'use strict';
 
-const NativeEventEmitter = require('NativeEventEmitter');
-const NativeModules = require('NativeModules');
-const Platform = require('Platform');
+const NativeEventEmitter = require('../EventEmitter/NativeEventEmitter');
+const NativeModules = require('../BatchedBridge/NativeModules');
+const Platform = require('../Utilities/Platform');
 const RCTNetInfo = NativeModules.NetInfo;
 
 const NetInfoEventEmitter = new NativeEventEmitter(RCTNetInfo);

--- a/Libraries/Network/RCTNetworking.android.js
+++ b/Libraries/Network/RCTNetworking.android.js
@@ -12,11 +12,12 @@
 
 // Do not require the native RCTNetworking module directly! Use this wrapper module instead.
 // It will add the necessary requestId, so that you don't have to generate it yourself.
-const NativeEventEmitter = require('NativeEventEmitter');
-const RCTNetworkingNative = require('NativeModules').Networking;
-const convertRequestBody = require('convertRequestBody');
+const NativeEventEmitter = require('../EventEmitter/NativeEventEmitter');
+const RCTNetworkingNative = require('../BatchedBridge/NativeModules')
+  .Networking;
+const convertRequestBody = require('./convertRequestBody');
 
-import type {RequestBody} from 'convertRequestBody';
+import type {RequestBody} from './convertRequestBody';
 
 type Header = [string, string];
 

--- a/Libraries/Network/RCTNetworking.ios.js
+++ b/Libraries/Network/RCTNetworking.ios.js
@@ -10,11 +10,12 @@
 
 'use strict';
 
-const NativeEventEmitter = require('NativeEventEmitter');
-const RCTNetworkingNative = require('NativeModules').Networking;
-const convertRequestBody = require('convertRequestBody');
+const NativeEventEmitter = require('../EventEmitter/NativeEventEmitter');
+const RCTNetworkingNative = require('../BatchedBridge/NativeModules')
+  .Networking;
+const convertRequestBody = require('./convertRequestBody');
 
-import type {RequestBody} from 'convertRequestBody';
+import type {RequestBody} from './convertRequestBody';
 
 import type {NativeResponseType} from './XMLHttpRequest';
 

--- a/Libraries/Network/XHRInterceptor.js
+++ b/Libraries/Network/XHRInterceptor.js
@@ -9,7 +9,7 @@
 
 'use strict';
 
-const XMLHttpRequest = require('XMLHttpRequest');
+const XMLHttpRequest = require('./XMLHttpRequest');
 const originalXHROpen = XMLHttpRequest.prototype.open;
 const originalXHRSend = XMLHttpRequest.prototype.send;
 const originalXHRSetRequestHeader = XMLHttpRequest.prototype.setRequestHeader;

--- a/Libraries/Network/XMLHttpRequest.js
+++ b/Libraries/Network/XMLHttpRequest.js
@@ -11,12 +11,12 @@
 'use strict';
 
 const EventTarget = require('event-target-shim');
-const RCTNetworking = require('RCTNetworking');
+const RCTNetworking = require('./RCTNetworking');
 
 const base64 = require('base64-js');
 const invariant = require('invariant');
 const warning = require('fbjs/lib/warning');
-const BlobManager = require('BlobManager');
+const BlobManager = require('../Blob/BlobManager');
 
 export type NativeResponseType = 'base64' | 'blob' | 'text';
 export type ResponseType =

--- a/Libraries/Network/__tests__/FormData-test.js
+++ b/Libraries/Network/__tests__/FormData-test.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const FormData = require('FormData');
+const FormData = require('../FormData');
 
 describe('FormData', function() {
   var formData;

--- a/Libraries/Network/__tests__/XMLHttpRequest-test.js
+++ b/Libraries/Network/__tests__/XMLHttpRequest-test.js
@@ -9,8 +9,8 @@
  */
 
 'use strict';
-jest.unmock('Platform');
-const Platform = require('Platform');
+jest.unmock('../../Utilities/Platform');
+const Platform = require('../../Utilities/Platform');
 let requestId = 1;
 
 function setRequestId(id) {
@@ -20,21 +20,23 @@ function setRequestId(id) {
   requestId = id;
 }
 
-jest.dontMock('event-target-shim').setMock('NativeModules', {
-  Networking: {
-    addListener: function() {},
-    removeListeners: function() {},
-    sendRequest(options, callback) {
-      if (typeof callback === 'function') {
-        // android does not pass a callback
-        callback(requestId);
-      }
+jest
+  .dontMock('event-target-shim')
+  .setMock('../../BatchedBridge/NativeModules', {
+    Networking: {
+      addListener: function() {},
+      removeListeners: function() {},
+      sendRequest(options, callback) {
+        if (typeof callback === 'function') {
+          // android does not pass a callback
+          callback(requestId);
+        }
+      },
+      abortRequest: function() {},
     },
-    abortRequest: function() {},
-  },
-});
+  });
 
-const XMLHttpRequest = require('XMLHttpRequest');
+const XMLHttpRequest = require('../XMLHttpRequest');
 
 describe('XMLHttpRequest', function() {
   let xhr;

--- a/Libraries/Network/convertRequestBody.js
+++ b/Libraries/Network/convertRequestBody.js
@@ -9,10 +9,10 @@
  */
 'use strict';
 
-const binaryToBase64 = require('binaryToBase64');
+const binaryToBase64 = require('../Utilities/binaryToBase64');
 
-const Blob = require('Blob');
-const FormData = require('FormData');
+const Blob = require('../Blob/Blob');
+const FormData = require('./FormData');
 
 export type RequestBody =
   | string

--- a/Libraries/Network/fetch.js
+++ b/Libraries/Network/fetch.js
@@ -11,7 +11,7 @@
 
 'use strict';
 
-const whatwg = require('whatwg-fetch');
+const whatwg = require('../vendor/core/whatwg-fetch');
 
 if (whatwg && whatwg.fetch) {
   module.exports = whatwg;

--- a/Libraries/Performance/PureComponentDebug.js
+++ b/Libraries/Performance/PureComponentDebug.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const React = require('React');
+const React = require('react');
 
 opaque type DoNotCommitUsageOfPureComponentDebug = {};
 

--- a/Libraries/Performance/SamplingProfiler.js
+++ b/Libraries/Performance/SamplingProfiler.js
@@ -28,7 +28,7 @@ const SamplingProfiler = {
       error = e.toString();
     }
 
-    const {JSCSamplingProfiler} = require('NativeModules');
+    const {JSCSamplingProfiler} = require('../BatchedBridge/NativeModules');
     JSCSamplingProfiler.operationComplete(token, result, error);
   },
 };

--- a/Libraries/PermissionsAndroid/PermissionsAndroid.js
+++ b/Libraries/PermissionsAndroid/PermissionsAndroid.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const NativeModules = require('NativeModules');
+const NativeModules = require('../BatchedBridge/NativeModules');
 
 export type Rationale = {
   title: string,

--- a/Libraries/PushNotificationIOS/PushNotificationIOS.js
+++ b/Libraries/PushNotificationIOS/PushNotificationIOS.js
@@ -10,8 +10,8 @@
 
 'use strict';
 
-const NativeEventEmitter = require('NativeEventEmitter');
-const RCTPushNotificationManager = require('NativeModules')
+const NativeEventEmitter = require('../EventEmitter/NativeEventEmitter');
+const RCTPushNotificationManager = require('../BatchedBridge/NativeModules')
   .PushNotificationManager;
 const invariant = require('invariant');
 

--- a/Libraries/ReactNative/AppContainer.js
+++ b/Libraries/ReactNative/AppContainer.js
@@ -10,13 +10,13 @@
 
 'use strict';
 
-const EmitterSubscription = require('EmitterSubscription');
+const EmitterSubscription = require('../vendor/emitter/EmitterSubscription');
 const PropTypes = require('prop-types');
-const RCTDeviceEventEmitter = require('RCTDeviceEventEmitter');
-const React = require('React');
-const ReactNative = require('ReactNative');
-const StyleSheet = require('StyleSheet');
-const View = require('View');
+const RCTDeviceEventEmitter = require('../EventEmitter/RCTDeviceEventEmitter');
+const React = require('react');
+const ReactNative = require('../Renderer/shims/ReactNative');
+const StyleSheet = require('../StyleSheet/StyleSheet');
+const View = require('../Components/View/View');
 
 type Context = {
   rootTag: number,
@@ -57,7 +57,7 @@ class AppContainer extends React.Component<Props, State> {
         this._subscription = RCTDeviceEventEmitter.addListener(
           'toggleElementInspector',
           () => {
-            const Inspector = require('Inspector');
+            const Inspector = require('../Inspector/Inspector');
             const inspector = this.state.inspector ? null : (
               <Inspector
                 inspectedViewTag={ReactNative.findNodeHandle(this._mainRef)}
@@ -89,7 +89,7 @@ class AppContainer extends React.Component<Props, State> {
     let yellowBox = null;
     if (__DEV__) {
       if (!global.__RCTProfileIsProfiling) {
-        const YellowBox = require('YellowBox');
+        const YellowBox = require('../YellowBox/YellowBox');
         yellowBox = <YellowBox />;
       }
     }
@@ -129,7 +129,7 @@ const styles = StyleSheet.create({
 
 if (__DEV__) {
   if (!global.__RCTProfileIsProfiling) {
-    const YellowBox = require('YellowBox');
+    const YellowBox = require('../YellowBox/YellowBox');
     YellowBox.install();
   }
 }

--- a/Libraries/ReactNative/AppRegistry.js
+++ b/Libraries/ReactNative/AppRegistry.js
@@ -9,17 +9,17 @@
  */
 'use strict';
 
-const BatchedBridge = require('BatchedBridge');
-const BugReporting = require('BugReporting');
-const NativeModules = require('NativeModules');
-const ReactNative = require('ReactNative');
-const SceneTracker = require('SceneTracker');
+const BatchedBridge = require('../BatchedBridge/BatchedBridge');
+const BugReporting = require('../BugReporting/BugReporting');
+const NativeModules = require('../BatchedBridge/NativeModules');
+const ReactNative = require('../Renderer/shims/ReactNative');
+const SceneTracker = require('../Utilities/SceneTracker');
 
-const infoLog = require('infoLog');
+const infoLog = require('../Utilities/infoLog');
 const invariant = require('invariant');
-const renderApplication = require('renderApplication');
-const createPerformanceLogger = require('createPerformanceLogger');
-import type {IPerformanceLogger} from 'createPerformanceLogger';
+const renderApplication = require('./renderApplication');
+const createPerformanceLogger = require('../Utilities/createPerformanceLogger');
+import type {IPerformanceLogger} from '../Utilities/createPerformanceLogger';
 
 type Task = (taskData: any) => Promise<void>;
 type TaskProvider = () => Task;

--- a/Libraries/ReactNative/FabricUIManager.js
+++ b/Libraries/ReactNative/FabricUIManager.js
@@ -13,7 +13,7 @@ import type {
   MeasureOnSuccessCallback,
   MeasureInWindowOnSuccessCallback,
   MeasureLayoutOnSuccessCallback,
-} from 'ReactNativeTypes';
+} from '../Renderer/shims/ReactNativeTypes';
 
 // TODO: type these properly.
 type Node = {};

--- a/Libraries/ReactNative/I18nManager.js
+++ b/Libraries/ReactNative/I18nManager.js
@@ -17,7 +17,8 @@ type I18nManagerStatus = {
   swapLeftAndRightInRTL: (flipStyles: boolean) => {},
 };
 
-const I18nManager: I18nManagerStatus = require('NativeModules').I18nManager || {
+const I18nManager: I18nManagerStatus = require('../BatchedBridge/NativeModules')
+  .I18nManager || {
   isRTL: false,
   doLeftAndRightSwapInRTL: true,
   allowRTL: () => {},

--- a/Libraries/ReactNative/ReactFabricIndicator.js
+++ b/Libraries/ReactNative/ReactFabricIndicator.js
@@ -10,10 +10,10 @@
 
 'use strict';
 
-const React = require('React');
-const StyleSheet = require('StyleSheet');
-const Text = require('Text');
-const View = require('View');
+const React = require('react');
+const StyleSheet = require('../StyleSheet/StyleSheet');
+const Text = require('../Text/Text');
+const View = require('../Components/View/View');
 
 function ReactFabricIndicator(): React.Node {
   return (

--- a/Libraries/ReactNative/ReactFabricInternals.js
+++ b/Libraries/ReactNative/ReactFabricInternals.js
@@ -12,10 +12,10 @@
 
 const {
   __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED,
-} = require('ReactFabric');
-const createReactNativeComponentClass = require('createReactNativeComponentClass');
+} = require('../Renderer/shims/ReactFabric');
+const createReactNativeComponentClass = require('../Renderer/shims/createReactNativeComponentClass');
 
-import type {NativeMethodsMixinType} from 'ReactNativeTypes';
+import type {NativeMethodsMixinType} from '../Renderer/shims/ReactNativeTypes';
 
 const {NativeMethodsMixin} = __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED;
 

--- a/Libraries/ReactNative/UIManager.js
+++ b/Libraries/ReactNative/UIManager.js
@@ -9,11 +9,11 @@
  */
 'use strict';
 
-const NativeModules = require('NativeModules');
-const Platform = require('Platform');
-const UIManagerProperties = require('UIManagerProperties');
+const NativeModules = require('../BatchedBridge/NativeModules');
+const Platform = require('../Utilities/Platform');
+const UIManagerProperties = require('./UIManagerProperties');
 
-const defineLazyObjectProperty = require('defineLazyObjectProperty');
+const defineLazyObjectProperty = require('../Utilities/defineLazyObjectProperty');
 const invariant = require('invariant');
 
 const {UIManager} = NativeModules;

--- a/Libraries/ReactNative/UIManagerStatTracker.js
+++ b/Libraries/ReactNative/UIManagerStatTracker.js
@@ -9,7 +9,7 @@
  */
 'use strict';
 
-const UIManager = require('UIManager');
+const UIManager = require('./UIManager');
 
 let installed = false;
 const UIManagerStatTracker = {

--- a/Libraries/ReactNative/getNativeComponentAttributes.js
+++ b/Libraries/ReactNative/getNativeComponentAttributes.js
@@ -10,15 +10,15 @@
 
 'use strict';
 
-const ReactNativeStyleAttributes = require('ReactNativeStyleAttributes');
-const UIManager = require('UIManager');
+const ReactNativeStyleAttributes = require('../Components/View/ReactNativeStyleAttributes');
+const UIManager = require('./UIManager');
 
-const insetsDiffer = require('insetsDiffer');
-const matricesDiffer = require('matricesDiffer');
-const pointsDiffer = require('pointsDiffer');
-const processColor = require('processColor');
-const resolveAssetSource = require('resolveAssetSource');
-const sizesDiffer = require('sizesDiffer');
+const insetsDiffer = require('../Utilities/differ/insetsDiffer');
+const matricesDiffer = require('../Utilities/differ/matricesDiffer');
+const pointsDiffer = require('../Utilities/differ/pointsDiffer');
+const processColor = require('../StyleSheet/processColor');
+const resolveAssetSource = require('../Image/resolveAssetSource');
+const sizesDiffer = require('../Utilities/differ/sizesDiffer');
 const invariant = require('invariant');
 const warning = require('fbjs/lib/warning');
 

--- a/Libraries/ReactNative/queryLayoutByID.js
+++ b/Libraries/ReactNative/queryLayoutByID.js
@@ -9,7 +9,7 @@
  */
 'use strict';
 
-const UIManager = require('UIManager');
+const UIManager = require('./UIManager');
 
 type OnSuccessCallback = (
   left: number,

--- a/Libraries/ReactNative/renderApplication.js
+++ b/Libraries/ReactNative/renderApplication.js
@@ -10,17 +10,17 @@
 
 'use strict';
 
-const AppContainer = require('AppContainer');
-import GlobalPerformanceLogger from 'GlobalPerformanceLogger';
-import type {IPerformanceLogger} from 'createPerformanceLogger';
-import PerformanceLoggerContext from 'PerformanceLoggerContext';
-const React = require('React');
-const ReactFabricIndicator = require('ReactFabricIndicator');
+const AppContainer = require('./AppContainer');
+import GlobalPerformanceLogger from '../Utilities/GlobalPerformanceLogger';
+import type {IPerformanceLogger} from '../Utilities/createPerformanceLogger';
+import PerformanceLoggerContext from '../Utilities/PerformanceLoggerContext';
+const React = require('react');
+const ReactFabricIndicator = require('./ReactFabricIndicator');
 
 const invariant = require('invariant');
 
 // require BackHandler so it sets the default handler that exits the app if no listeners respond
-require('BackHandler');
+require('../Utilities/BackHandler');
 
 function renderApplication<Props: Object>(
   RootComponent: React.ComponentType<Props>,
@@ -62,9 +62,9 @@ function renderApplication<Props: Object>(
 
   GlobalPerformanceLogger.startTimespan('renderApplication_React_render');
   if (fabric) {
-    require('ReactFabric').render(renderable, rootTag);
+    require('../Renderer/shims/ReactFabric').render(renderable, rootTag);
   } else {
-    require('ReactNative').render(renderable, rootTag);
+    require('../Renderer/shims/ReactNative').render(renderable, rootTag);
   }
   GlobalPerformanceLogger.stopTimespan('renderApplication_React_render');
 }

--- a/Libraries/ReactNative/requireNativeComponent.js
+++ b/Libraries/ReactNative/requireNativeComponent.js
@@ -10,8 +10,8 @@
 
 'use strict';
 
-const createReactNativeComponentClass = require('createReactNativeComponentClass');
-const getNativeComponentAttributes = require('getNativeComponentAttributes');
+const createReactNativeComponentClass = require('../Renderer/shims/createReactNativeComponentClass');
+const getNativeComponentAttributes = require('./getNativeComponentAttributes');
 
 /**
  * Creates values that can be used like React components which represent native

--- a/Libraries/Renderer/shims/NativeMethodsMixin.js
+++ b/Libraries/Renderer/shims/NativeMethodsMixin.js
@@ -12,9 +12,9 @@
 
 const {
   __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED,
-} = require('ReactNative');
+} = require('./ReactNative');
 
-import type {NativeMethodsMixinType} from 'ReactNativeTypes';
+import type {NativeMethodsMixinType} from './ReactNativeTypes';
 
 const {NativeMethodsMixin} = __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED;
 

--- a/Libraries/Renderer/shims/ReactFabric.js
+++ b/Libraries/Renderer/shims/ReactFabric.js
@@ -10,17 +10,17 @@
 
 'use strict';
 
-const BatchedBridge = require('BatchedBridge');
+const BatchedBridge = require('../../BatchedBridge/BatchedBridge');
 
 // TODO @sema: Adjust types
-import type {ReactNativeType} from 'ReactNativeTypes';
+import type {ReactNativeType} from './ReactNativeTypes';
 
 let ReactFabric;
 
 if (__DEV__) {
-  ReactFabric = require('ReactFabric-dev');
+  ReactFabric = require('../oss/ReactFabric-dev');
 } else {
-  ReactFabric = require('ReactFabric-prod');
+  ReactFabric = require('../oss/ReactFabric-prod');
 }
 
 BatchedBridge.registerCallableModule('ReactFabric', ReactFabric);

--- a/Libraries/Renderer/shims/ReactNative.js
+++ b/Libraries/Renderer/shims/ReactNative.js
@@ -10,14 +10,14 @@
 
 'use strict';
 
-import type {ReactNativeType} from 'ReactNativeTypes';
+import type {ReactNativeType} from './ReactNativeTypes';
 
 let ReactNative;
 
 if (__DEV__) {
-  ReactNative = require('ReactNativeRenderer-dev');
+  ReactNative = require('../oss/ReactNativeRenderer-dev');
 } else {
-  ReactNative = require('ReactNativeRenderer-prod');
+  ReactNative = require('../oss/ReactNativeRenderer-prod');
 }
 
 module.exports = (ReactNative: ReactNativeType);

--- a/Libraries/Renderer/shims/createReactNativeComponentClass.js
+++ b/Libraries/Renderer/shims/createReactNativeComponentClass.js
@@ -12,7 +12,7 @@
 
 import type {ViewConfigGetter} from './ReactNativeTypes';
 
-const {register} = require('ReactNativeViewConfigRegistry');
+const {register} = require('./ReactNativeViewConfigRegistry');
 
 /**
  * Creates a renderable ReactNative host component.

--- a/Libraries/Sample/Sample.ios.js
+++ b/Libraries/Sample/Sample.ios.js
@@ -12,7 +12,7 @@
 
 'use strict';
 
-const NativeSample = require('NativeModules').Sample;
+const NativeSample = require('../BatchedBridge/NativeModules').Sample;
 
 /**
  * High-level docs for the Sample iOS API can be written here.

--- a/Libraries/Settings/Settings.ios.js
+++ b/Libraries/Settings/Settings.ios.js
@@ -10,8 +10,9 @@
 
 'use strict';
 
-const RCTDeviceEventEmitter = require('RCTDeviceEventEmitter');
-const RCTSettingsManager = require('NativeModules').SettingsManager;
+const RCTDeviceEventEmitter = require('../EventEmitter/RCTDeviceEventEmitter');
+const RCTSettingsManager = require('../BatchedBridge/NativeModules')
+  .SettingsManager;
 
 const invariant = require('invariant');
 

--- a/Libraries/Share/Share.js
+++ b/Libraries/Share/Share.js
@@ -10,12 +10,15 @@
 
 'use strict';
 
-const Platform = require('Platform');
+const Platform = require('../Utilities/Platform');
 
 const invariant = require('invariant');
-const processColor = require('processColor');
+const processColor = require('../StyleSheet/processColor');
 
-const {ActionSheetManager, ShareModule} = require('NativeModules');
+const {
+  ActionSheetManager,
+  ShareModule,
+} = require('../BatchedBridge/NativeModules');
 
 type Content =
   | {title?: string, message: string}

--- a/Libraries/Storage/AsyncStorage.js
+++ b/Libraries/Storage/AsyncStorage.js
@@ -12,7 +12,7 @@
 
 'use strict';
 
-const NativeModules = require('NativeModules');
+const NativeModules = require('../BatchedBridge/NativeModules');
 
 // Use RocksDB if available, then SQLite, then file storage.
 const RCTAsyncStorage =

--- a/Libraries/StyleSheet/StyleSheet.js
+++ b/Libraries/StyleSheet/StyleSheet.js
@@ -9,11 +9,11 @@
  */
 'use strict';
 
-const PixelRatio = require('PixelRatio');
-const ReactNativeStyleAttributes = require('ReactNativeStyleAttributes');
-const StyleSheetValidation = require('StyleSheetValidation');
+const PixelRatio = require('../Utilities/PixelRatio');
+const ReactNativeStyleAttributes = require('../Components/View/ReactNativeStyleAttributes');
+const StyleSheetValidation = require('./StyleSheetValidation');
 
-const flatten = require('flattenStyle');
+const flatten = require('./flattenStyle');
 
 import type {
   ____Styles_Internal,
@@ -25,7 +25,7 @@ import type {
   ____TextStyleProp_Internal,
   ____ImageStyle_Internal,
   ____ImageStyleProp_Internal,
-} from 'StyleSheetTypes';
+} from './StyleSheetTypes';
 
 /**
  * This type should be used as the type for a prop that is passed through

--- a/Libraries/StyleSheet/StyleSheetTypes.js
+++ b/Libraries/StyleSheet/StyleSheetTypes.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const AnimatedNode = require('AnimatedNode');
+const AnimatedNode = require('../Animated/src/nodes/AnimatedNode');
 
 export type ColorValue = null | string;
 export type DimensionValue = null | number | string | AnimatedNode;

--- a/Libraries/StyleSheet/StyleSheetValidation.js
+++ b/Libraries/StyleSheet/StyleSheetValidation.js
@@ -10,9 +10,9 @@
 
 'use strict';
 
-const DeprecatedImageStylePropTypes = require('DeprecatedImageStylePropTypes');
-const TextStylePropTypes = require('TextStylePropTypes');
-const DeprecatedViewStylePropTypes = require('DeprecatedViewStylePropTypes');
+const DeprecatedImageStylePropTypes = require('../DeprecatedPropTypes/DeprecatedImageStylePropTypes');
+const TextStylePropTypes = require('../Text/TextStylePropTypes');
+const DeprecatedViewStylePropTypes = require('../DeprecatedPropTypes/DeprecatedViewStylePropTypes');
 
 const invariant = require('invariant');
 

--- a/Libraries/StyleSheet/__flowtests__/StyleSheet-flowtest.js
+++ b/Libraries/StyleSheet/__flowtests__/StyleSheet-flowtest.js
@@ -10,9 +10,9 @@
 
 'use strict';
 
-const StyleSheet = require('StyleSheet');
+const StyleSheet = require('../StyleSheet');
 
-import type {ImageStyleProp, TextStyleProp} from 'StyleSheet';
+import type {ImageStyleProp, TextStyleProp} from '../StyleSheet';
 const imageStyle = {tintColor: 'rgb(0, 0, 0)'};
 const textStyle = {color: 'rgb(0, 0, 0)'};
 

--- a/Libraries/StyleSheet/__tests__/flattenStyle-test.js
+++ b/Libraries/StyleSheet/__tests__/flattenStyle-test.js
@@ -10,9 +10,9 @@
 
 'use strict';
 
-const StyleSheet = require('StyleSheet');
-const StyleSheetValidation = require('StyleSheetValidation');
-const flattenStyle = require('flattenStyle');
+const StyleSheet = require('../StyleSheet');
+const StyleSheetValidation = require('../StyleSheetValidation');
+const flattenStyle = require('../flattenStyle');
 
 function getFixture() {
   StyleSheetValidation.addValidStylePropTypes({

--- a/Libraries/StyleSheet/__tests__/normalizeColor-test.js
+++ b/Libraries/StyleSheet/__tests__/normalizeColor-test.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const normalizeColor = require('normalizeColor');
+const normalizeColor = require('../../Color/normalizeColor');
 
 describe('normalizeColor', function() {
   it('should accept only spec compliant colors', function() {

--- a/Libraries/StyleSheet/__tests__/processColor-test.js
+++ b/Libraries/StyleSheet/__tests__/processColor-test.js
@@ -10,8 +10,8 @@
 
 'use strict';
 
-const {OS} = require('Platform');
-const processColor = require('processColor');
+const {OS} = require('../../Utilities/Platform');
+const processColor = require('../processColor');
 
 const platformSpecific =
   OS === 'android'

--- a/Libraries/StyleSheet/__tests__/processTransform-test.js
+++ b/Libraries/StyleSheet/__tests__/processTransform-test.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const processTransform = require('processTransform');
+const processTransform = require('../processTransform');
 
 describe('processTransform', () => {
   describe('validation', () => {

--- a/Libraries/StyleSheet/__tests__/setNormalizedColorAlpha-test.js
+++ b/Libraries/StyleSheet/__tests__/setNormalizedColorAlpha-test.js
@@ -10,8 +10,8 @@
 
 'use strict';
 
-const setNormalizedColorAlpha = require('setNormalizedColorAlpha');
-const normalizeColor = require('normalizeColor');
+const setNormalizedColorAlpha = require('../setNormalizedColorAlpha');
+const normalizeColor = require('../../Color/normalizeColor');
 
 describe('setNormalizedColorAlpha', function() {
   it('should adjust the alpha of the color passed in', function() {

--- a/Libraries/StyleSheet/flattenStyle.js
+++ b/Libraries/StyleSheet/flattenStyle.js
@@ -12,7 +12,7 @@
 import type {
   DangerouslyImpreciseStyle,
   DangerouslyImpreciseStyleProp,
-} from 'StyleSheet';
+} from './StyleSheet';
 
 function flattenStyle(
   style: ?DangerouslyImpreciseStyleProp,

--- a/Libraries/StyleSheet/processColor.js
+++ b/Libraries/StyleSheet/processColor.js
@@ -10,9 +10,9 @@
 
 'use strict';
 
-const Platform = require('Platform');
+const Platform = require('../Utilities/Platform');
 
-const normalizeColor = require('normalizeColor');
+const normalizeColor = require('../Color/normalizeColor');
 
 /* eslint no-bitwise: 0 */
 function processColor(color?: ?(string | number)): ?number {

--- a/Libraries/StyleSheet/processTransform.js
+++ b/Libraries/StyleSheet/processTransform.js
@@ -10,11 +10,11 @@
 
 'use strict';
 
-const MatrixMath = require('MatrixMath');
-const Platform = require('Platform');
+const MatrixMath = require('../Utilities/MatrixMath');
+const Platform = require('../Utilities/Platform');
 
 const invariant = require('invariant');
-const stringifySafe = require('stringifySafe');
+const stringifySafe = require('../Utilities/stringifySafe');
 
 /**
  * Generate a transform matrix based on the provided transforms, and use that

--- a/Libraries/Text/Text.js
+++ b/Libraries/Text/Text.js
@@ -10,20 +10,20 @@
 
 'use strict';
 
-const DeprecatedTextPropTypes = require('DeprecatedTextPropTypes');
-const React = require('React');
-const ReactNativeViewAttributes = require('ReactNativeViewAttributes');
-const TextAncestor = require('TextAncestor');
-const Touchable = require('Touchable');
-const UIManager = require('UIManager');
+const DeprecatedTextPropTypes = require('../DeprecatedPropTypes/DeprecatedTextPropTypes');
+const React = require('react');
+const ReactNativeViewAttributes = require('../Components/View/ReactNativeViewAttributes');
+const TextAncestor = require('./TextAncestor');
+const Touchable = require('../Components/Touchable/Touchable');
+const UIManager = require('../ReactNative/UIManager');
 
-const createReactNativeComponentClass = require('createReactNativeComponentClass');
+const createReactNativeComponentClass = require('../Renderer/shims/createReactNativeComponentClass');
 const nullthrows = require('nullthrows');
-const processColor = require('processColor');
+const processColor = require('../StyleSheet/processColor');
 
-import type {PressEvent} from 'CoreEventTypes';
-import type {NativeComponent} from 'ReactNative';
-import type {PressRetentionOffset, TextProps} from 'TextProps';
+import type {PressEvent} from '../Types/CoreEventTypes';
+import type {NativeComponent} from '../Renderer/shims/ReactNative';
+import type {PressRetentionOffset, TextProps} from './TextProps';
 
 type ResponseHandlers = $ReadOnly<{|
   onStartShouldSetResponder: () => boolean,

--- a/Libraries/Text/TextAncestor.js
+++ b/Libraries/Text/TextAncestor.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const React = require('React');
+const React = require('react');
 
 /**
  * Whether the current element is the descendant of a <Text> element.

--- a/Libraries/Text/TextPropTypes.js
+++ b/Libraries/Text/TextPropTypes.js
@@ -10,11 +10,11 @@
 
 'use strict';
 
-const DeprecatedColorPropType = require('DeprecatedColorPropType');
-const DeprecatedEdgeInsetsPropType = require('DeprecatedEdgeInsetsPropType');
+const DeprecatedColorPropType = require('../DeprecatedPropTypes/DeprecatedColorPropType');
+const DeprecatedEdgeInsetsPropType = require('../DeprecatedPropTypes/DeprecatedEdgeInsetsPropType');
 const PropTypes = require('prop-types');
-const DeprecatedStyleSheetPropType = require('DeprecatedStyleSheetPropType');
-const TextStylePropTypes = require('TextStylePropTypes');
+const DeprecatedStyleSheetPropType = require('../DeprecatedPropTypes/DeprecatedStyleSheetPropType');
+const TextStylePropTypes = require('./TextStylePropTypes');
 
 const stylePropType = DeprecatedStyleSheetPropType(TextStylePropTypes);
 

--- a/Libraries/Text/TextProps.js
+++ b/Libraries/Text/TextProps.js
@@ -10,10 +10,17 @@
 
 'use strict';
 
-import type {LayoutEvent, PressEvent, TextLayoutEvent} from 'CoreEventTypes';
-import type React from 'React';
-import type {TextStyleProp} from 'StyleSheet';
-import type {AccessibilityRole, AccessibilityStates} from 'ViewAccessibility';
+import type {
+  LayoutEvent,
+  PressEvent,
+  TextLayoutEvent,
+} from '../Types/CoreEventTypes';
+import type {Node} from 'react';
+import type {TextStyleProp} from '../StyleSheet/StyleSheet';
+import type {
+  AccessibilityRole,
+  AccessibilityStates,
+} from '../Components/View/ViewAccessibility';
 
 export type PressRetentionOffset = $ReadOnly<{|
   top: number,
@@ -50,7 +57,7 @@ export type TextProps = $ReadOnly<{|
    * See https://facebook.github.io/react-native/docs/text.html#allowfontscaling
    */
   allowFontScaling?: ?boolean,
-  children?: ?React.Node,
+  children?: ?Node,
 
   /**
    * When `numberOfLines` is set, this prop defines how text will be

--- a/Libraries/Text/TextStylePropTypes.js
+++ b/Libraries/Text/TextStylePropTypes.js
@@ -10,9 +10,9 @@
 
 'use strict';
 
-const DeprecatedColorPropType = require('DeprecatedColorPropType');
+const DeprecatedColorPropType = require('../DeprecatedPropTypes/DeprecatedColorPropType');
 const ReactPropTypes = require('prop-types');
-const DeprecatedViewStylePropTypes = require('DeprecatedViewStylePropTypes');
+const DeprecatedViewStylePropTypes = require('../DeprecatedPropTypes/DeprecatedViewStylePropTypes');
 
 const TextStylePropTypes = {
   ...DeprecatedViewStylePropTypes,

--- a/Libraries/TurboModule/TurboModuleRegistry.js
+++ b/Libraries/TurboModule/TurboModuleRegistry.js
@@ -10,9 +10,9 @@
 
 'use strict';
 
-const NativeModules = require('NativeModules');
+const NativeModules = require('../BatchedBridge/NativeModules');
 
-import type {TurboModule} from 'RCTExport';
+import type {TurboModule} from './RCTExport';
 import invariant from 'invariant';
 
 const turboModuleProxy = global.__turboModuleProxy;

--- a/Libraries/TurboModule/samples/NativeSampleTurboModule.js
+++ b/Libraries/TurboModule/samples/NativeSampleTurboModule.js
@@ -10,8 +10,8 @@
 
 'use strict';
 
-import type {TurboModule} from 'RCTExport';
-import * as TurboModuleRegistry from 'TurboModuleRegistry';
+import type {TurboModule} from '../RCTExport';
+import * as TurboModuleRegistry from '../TurboModuleRegistry';
 
 export interface Spec extends TurboModule {
   // Exported methods.

--- a/Libraries/UTFSequence.js
+++ b/Libraries/UTFSequence.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const deepFreezeAndThrowOnMutationInDev = require('deepFreezeAndThrowOnMutationInDev');
+const deepFreezeAndThrowOnMutationInDev = require('./Utilities/deepFreezeAndThrowOnMutationInDev');
 
 /**
  * A collection of Unicode sequences for various characters and emoji.

--- a/Libraries/Utilities/BackHandler.android.js
+++ b/Libraries/Utilities/BackHandler.android.js
@@ -10,8 +10,9 @@
 
 'use strict';
 
-const DeviceEventManager = require('NativeModules').DeviceEventManager;
-const RCTDeviceEventEmitter = require('RCTDeviceEventEmitter');
+const DeviceEventManager = require('../BatchedBridge/NativeModules')
+  .DeviceEventManager;
+const RCTDeviceEventEmitter = require('../EventEmitter/RCTDeviceEventEmitter');
 
 const DEVICE_BACK_EVENT = 'hardwareBackPress';
 

--- a/Libraries/Utilities/BackHandler.ios.js
+++ b/Libraries/Utilities/BackHandler.ios.js
@@ -13,8 +13,8 @@
 
 'use strict';
 
-const Platform = require('Platform');
-const TVEventHandler = require('TVEventHandler');
+const Platform = require('./Platform');
+const TVEventHandler = require('../Components/AppleTV/TVEventHandler');
 
 type BackPressEventName = 'backPress' | 'hardwareBackPress';
 

--- a/Libraries/Utilities/DeviceInfo.js
+++ b/Libraries/Utilities/DeviceInfo.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const DeviceInfo = require('NativeModules').DeviceInfo;
+const DeviceInfo = require('../BatchedBridge/NativeModules').DeviceInfo;
 
 const invariant = require('invariant');
 

--- a/Libraries/Utilities/Dimensions.js
+++ b/Libraries/Utilities/Dimensions.js
@@ -10,9 +10,9 @@
 
 'use strict';
 
-const EventEmitter = require('EventEmitter');
-const Platform = require('Platform');
-const RCTDeviceEventEmitter = require('RCTDeviceEventEmitter');
+const EventEmitter = require('../vendor/emitter/EventEmitter');
+const Platform = require('./Platform');
+const RCTDeviceEventEmitter = require('../EventEmitter/RCTDeviceEventEmitter');
 
 const invariant = require('invariant');
 
@@ -128,7 +128,7 @@ let dims: ?{[key: string]: any} =
   global.nativeExtensions.DeviceInfo.Dimensions;
 let nativeExtensionsEnabled = true;
 if (!dims) {
-  const DeviceInfo = require('DeviceInfo');
+  const DeviceInfo = require('./DeviceInfo');
   dims = DeviceInfo.Dimensions;
   nativeExtensionsEnabled = false;
 }

--- a/Libraries/Utilities/GlobalPerformanceLogger.js
+++ b/Libraries/Utilities/GlobalPerformanceLogger.js
@@ -9,7 +9,7 @@
  */
 'use strict';
 
-const createPerformanceLogger = require('createPerformanceLogger');
+const createPerformanceLogger = require('./createPerformanceLogger');
 
 /**
  * This is a global shared instance of IPerformanceLogger that is created with

--- a/Libraries/Utilities/HMRClient.js
+++ b/Libraries/Utilities/HMRClient.js
@@ -9,7 +9,7 @@
  */
 'use strict';
 
-const Platform = require('Platform');
+const Platform = require('./Platform');
 const invariant = require('invariant');
 
 const MetroHMRClient = require('metro/src/lib/bundle-modules/HMRClient');
@@ -25,7 +25,7 @@ const HMRClient = {
     invariant(host, 'Missing required paramenter `host`');
 
     // Moving to top gives errors due to NativeModules not being initialized
-    const HMRLoadingView = require('HMRLoadingView');
+    const HMRLoadingView = require('./HMRLoadingView');
 
     /* $FlowFixMe(>=0.84.0 site=react_native_fb) This comment suppresses an
      * error found when Flow v0.84 was deployed. To see the error, delete this
@@ -73,10 +73,11 @@ Error: ${e.message}`;
 
     hmrClient.on('update', () => {
       if (Platform.OS === 'ios') {
-        const RCTRedBox = require('NativeModules').RedBox;
+        const RCTRedBox = require('../BatchedBridge/NativeModules').RedBox;
         RCTRedBox && RCTRedBox.dismiss && RCTRedBox.dismiss();
       } else {
-        const RCTExceptionsManager = require('NativeModules').ExceptionsManager;
+        const RCTExceptionsManager = require('../BatchedBridge/NativeModules')
+          .ExceptionsManager;
         RCTExceptionsManager &&
           RCTExceptionsManager.dismissRedbox &&
           RCTExceptionsManager.dismissRedbox();

--- a/Libraries/Utilities/HMRLoadingView.android.js
+++ b/Libraries/Utilities/HMRLoadingView.android.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const ToastAndroid = require('ToastAndroid');
+const ToastAndroid = require('../Components/ToastAndroid/ToastAndroid');
 
 const TOAST_SHORT_DELAY = 2000;
 

--- a/Libraries/Utilities/HMRLoadingView.ios.js
+++ b/Libraries/Utilities/HMRLoadingView.ios.js
@@ -10,8 +10,8 @@
 
 'use strict';
 
-const processColor = require('processColor');
-const {DevLoadingView} = require('NativeModules');
+const processColor = require('../StyleSheet/processColor');
+const {DevLoadingView} = require('../BatchedBridge/NativeModules');
 
 class HMRLoadingView {
   static showMessage(message: string) {

--- a/Libraries/Utilities/HeapCapture.js
+++ b/Libraries/Utilities/HeapCapture.js
@@ -20,7 +20,10 @@ const HeapCapture = {
       console.log('HeapCapture.captureHeap error: ' + e.toString());
       error = e.toString();
     }
-    require('NativeModules').JSCHeapCapture.captureComplete(path, error);
+    require('../BatchedBridge/NativeModules').JSCHeapCapture.captureComplete(
+      path,
+      error,
+    );
   },
 };
 

--- a/Libraries/Utilities/JSDevSupportModule.js
+++ b/Libraries/Utilities/JSDevSupportModule.js
@@ -10,8 +10,8 @@
 
 'use strict';
 
-const JSDevSupport = require('NativeModules').JSDevSupport;
-const ReactNative = require('ReactNative');
+const JSDevSupport = require('../BatchedBridge/NativeModules').JSDevSupport;
+const ReactNative = require('../Renderer/shims/ReactNative');
 
 const JSDevSupportModule = {
   getJSHierarchy: function(tag: number) {

--- a/Libraries/Utilities/PerformanceLoggerContext.js
+++ b/Libraries/Utilities/PerformanceLoggerContext.js
@@ -11,8 +11,8 @@
 'use strict';
 
 import * as React from 'react';
-import GlobalPerformanceLogger from 'GlobalPerformanceLogger';
-import type {IPerformanceLogger} from 'createPerformanceLogger';
+import GlobalPerformanceLogger from './GlobalPerformanceLogger';
+import type {IPerformanceLogger} from './createPerformanceLogger';
 
 /**
  * This is a React Context that provides a scoped instance of IPerformanceLogger.

--- a/Libraries/Utilities/PixelRatio.js
+++ b/Libraries/Utilities/PixelRatio.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const Dimensions = require('Dimensions');
+const Dimensions = require('./Dimensions');
 
 /**
  * PixelRatio class gives access to the device pixel density.

--- a/Libraries/Utilities/Platform.android.js
+++ b/Libraries/Utilities/Platform.android.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const NativeModules = require('NativeModules');
+const NativeModules = require('../BatchedBridge/NativeModules');
 
 export type PlatformSelectSpec<A, D> = {
   android?: A,

--- a/Libraries/Utilities/Platform.ios.js
+++ b/Libraries/Utilities/Platform.ios.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const NativeModules = require('NativeModules');
+const NativeModules = require('../BatchedBridge/NativeModules');
 
 export type PlatformSelectSpec<D, I> = {
   default?: D,

--- a/Libraries/Utilities/PolyfillFunctions.js
+++ b/Libraries/Utilities/PolyfillFunctions.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const defineLazyObjectProperty = require('defineLazyObjectProperty');
+const defineLazyObjectProperty = require('./defineLazyObjectProperty');
 
 /**
  * Sets an object's property. If a property with the same name exists, this will

--- a/Libraries/Utilities/ReactNativeTestTools.js
+++ b/Libraries/Utilities/ReactNativeTestTools.js
@@ -12,7 +12,7 @@
 
 'use strict';
 
-const React = require('React');
+const React = require('react');
 const ReactTestRenderer = require('react-test-renderer');
 
 const {Switch, Text, TextInput, VirtualizedList} = require('react-native');

--- a/Libraries/Utilities/__mocks__/GlobalPerformanceLogger.js
+++ b/Libraries/Utilities/__mocks__/GlobalPerformanceLogger.js
@@ -10,7 +10,7 @@
 'use strict';
 
 const GlobalPerformanceLogger = jest
-  .unmock('createPerformanceLogger')
-  .genMockFromModule('GlobalPerformanceLogger');
+  .unmock('../createPerformanceLogger')
+  .genMockFromModule('../GlobalPerformanceLogger');
 
 module.exports = GlobalPerformanceLogger;

--- a/Libraries/Utilities/__tests__/DeviceInfo-test.js
+++ b/Libraries/Utilities/__tests__/DeviceInfo-test.js
@@ -11,7 +11,7 @@
 'use strict';
 
 describe('DeviceInfo', () => {
-  const DeviceInfo = require('DeviceInfo');
+  const DeviceInfo = require('../DeviceInfo');
 
   it('should give device info', () => {
     expect(DeviceInfo).toHaveProperty('Dimensions');

--- a/Libraries/Utilities/__tests__/Dimensions-test.js
+++ b/Libraries/Utilities/__tests__/Dimensions-test.js
@@ -11,8 +11,8 @@
 'use strict';
 
 describe('Dimensions', () => {
-  const Dimensions = require('Dimensions');
-  const Platform = require('Platform');
+  const Dimensions = require('../Dimensions');
+  const Platform = require('../Platform');
 
   it('should set window dimensions', () => {
     Dimensions.set({

--- a/Libraries/Utilities/__tests__/MatrixMath-test.js
+++ b/Libraries/Utilities/__tests__/MatrixMath-test.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const MatrixMath = require('MatrixMath');
+const MatrixMath = require('../MatrixMath');
 
 function degreesToRadians(degrees) {
   return (degrees * Math.PI) / 180;

--- a/Libraries/Utilities/__tests__/PerformanceLogger-test.js
+++ b/Libraries/Utilities/__tests__/PerformanceLogger-test.js
@@ -9,9 +9,9 @@
 
 'use strict';
 
-import GlobalPerformanceLogger from 'GlobalPerformanceLogger';
-import createPerformanceLogger from 'createPerformanceLogger';
-import type {IPerformanceLogger} from 'createPerformanceLogger';
+import GlobalPerformanceLogger from '../GlobalPerformanceLogger';
+import createPerformanceLogger from '../createPerformanceLogger';
+import type {IPerformanceLogger} from '../createPerformanceLogger';
 
 const TIMESPAN_1 = '<timespan_1>';
 const TIMESPAN_2 = '<timespan_2>';

--- a/Libraries/Utilities/__tests__/PixelRatio-test.js
+++ b/Libraries/Utilities/__tests__/PixelRatio-test.js
@@ -11,8 +11,8 @@
 'use strict';
 
 describe('PixelRatio', () => {
-  const Dimensions = require('Dimensions');
-  const PixelRatio = require('PixelRatio');
+  const Dimensions = require('../Dimensions');
+  const PixelRatio = require('../PixelRatio');
 
   beforeEach(() => {
     Dimensions.set({

--- a/Libraries/Utilities/__tests__/SceneTracker-test.js
+++ b/Libraries/Utilities/__tests__/SceneTracker-test.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const SceneTracker = require('SceneTracker');
+const SceneTracker = require('../SceneTracker');
 
 describe('setActiveScene', function() {
   it('can handle multiple listeners and unsubscribe', function() {

--- a/Libraries/Utilities/__tests__/binaryToBase64-test.js
+++ b/Libraries/Utilities/__tests__/binaryToBase64-test.js
@@ -14,7 +14,7 @@ const base64 = require('base64-js');
 const {TextEncoder, TextDecoder} = require('util');
 
 describe('binaryToBase64', () => {
-  const binaryToBase64 = require('binaryToBase64');
+  const binaryToBase64 = require('../binaryToBase64');
 
   it('should encode a Uint8Array', () => {
     const input = new TextEncoder().encode('Test string');

--- a/Libraries/Utilities/__tests__/buildStyleInterpolator-test.js
+++ b/Libraries/Utilities/__tests__/buildStyleInterpolator-test.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const buildStyleInterpolator = require('buildStyleInterpolator');
+const buildStyleInterpolator = require('../buildStyleInterpolator');
 
 const validateEmpty = function(interpolator, value, validator) {
   const emptyObject = {};

--- a/Libraries/Utilities/__tests__/clamp-test.js
+++ b/Libraries/Utilities/__tests__/clamp-test.js
@@ -11,7 +11,7 @@
 'use strict';
 
 describe('clamp', () => {
-  const clamp = require('clamp');
+  const clamp = require('../clamp');
 
   it('should return the value if the value does not exceed boundaries', () => {
     expect(clamp(0, 5, 10)).toEqual(5);

--- a/Libraries/Utilities/__tests__/deepFreezeAndThrowOnMutationInDev-test.js
+++ b/Libraries/Utilities/__tests__/deepFreezeAndThrowOnMutationInDev-test.js
@@ -8,7 +8,7 @@
  * @emails oncall+react_native
  */
 
-const deepFreezeAndThrowOnMutationInDev = require('deepFreezeAndThrowOnMutationInDev');
+const deepFreezeAndThrowOnMutationInDev = require('../deepFreezeAndThrowOnMutationInDev');
 
 describe('deepFreezeAndThrowOnMutationInDev', function() {
   it('should be a noop on non object values', () => {

--- a/Libraries/Utilities/__tests__/groupByEveryN-test.js
+++ b/Libraries/Utilities/__tests__/groupByEveryN-test.js
@@ -11,7 +11,7 @@
 'use strict';
 
 describe('groupByEveryN', () => {
-  const groupByEveryN = require('groupByEveryN');
+  const groupByEveryN = require('../groupByEveryN');
 
   it('should group by with different n', () => {
     expect(groupByEveryN([1, 2, 3, 4, 5, 6, 7, 8, 9], 1)).toEqual([

--- a/Libraries/Utilities/__tests__/infoLog-test.js
+++ b/Libraries/Utilities/__tests__/infoLog-test.js
@@ -11,7 +11,7 @@
 'use strict';
 
 describe('infoLog', () => {
-  const infoLog = require('infoLog');
+  const infoLog = require('../infoLog');
 
   it('logs messages to the console', () => {
     console.log = jest.fn();

--- a/Libraries/Utilities/__tests__/logError-test.js
+++ b/Libraries/Utilities/__tests__/logError-test.js
@@ -11,7 +11,7 @@
 'use strict';
 
 describe('logError', () => {
-  const logError = require('logError');
+  const logError = require('../logError');
 
   it('logs error messages to the console', () => {
     console.error.apply = jest.fn();

--- a/Libraries/Utilities/__tests__/mapWithSeparator-test.js
+++ b/Libraries/Utilities/__tests__/mapWithSeparator-test.js
@@ -11,7 +11,7 @@
 'use strict';
 
 describe('mapWithSeparator', () => {
-  const mapWithSeparator = require('mapWithSeparator');
+  const mapWithSeparator = require('../mapWithSeparator');
 
   it('mapWithSeparator returns expected results', () => {
     const array = [1, 2, 3];

--- a/Libraries/Utilities/__tests__/mergeIntoFast-test.js
+++ b/Libraries/Utilities/__tests__/mergeIntoFast-test.js
@@ -11,7 +11,7 @@
 'use strict';
 
 describe('mergeIntoFast', () => {
-  const mergeIntoFast = require('mergeIntoFast');
+  const mergeIntoFast = require('../mergeIntoFast');
 
   it('should merge two objects', () => {
     const a = {fontScale: 2, height: 1334};

--- a/Libraries/Utilities/__tests__/setAndForwardRef-test.js
+++ b/Libraries/Utilities/__tests__/setAndForwardRef-test.js
@@ -11,10 +11,10 @@
 
 'use strict';
 
-const React = require('React');
+const React = require('react');
 const ReactTestRenderer = require('react-test-renderer');
 
-const setAndForwardRef = require('setAndForwardRef');
+const setAndForwardRef = require('../setAndForwardRef');
 
 describe('setAndForwardRef', () => {
   let innerFuncCalled = false;

--- a/Libraries/Utilities/__tests__/stringifySafe-test.js
+++ b/Libraries/Utilities/__tests__/stringifySafe-test.js
@@ -11,7 +11,7 @@
 'use strict';
 
 describe('stringifySafe', () => {
-  const stringifySafe = require('stringifySafe');
+  const stringifySafe = require('../stringifySafe');
 
   it('stringifySafe stringifies undefined values', () => {
     expect(stringifySafe(undefined)).toEqual('undefined');

--- a/Libraries/Utilities/__tests__/truncate-test.js
+++ b/Libraries/Utilities/__tests__/truncate-test.js
@@ -11,7 +11,7 @@
 'use strict';
 
 describe('truncate', () => {
-  const truncate = require('truncate');
+  const truncate = require('../truncate');
 
   it('should truncate', () => {
     expect(truncate('Hello, world.', 5)).toBe('He...');

--- a/Libraries/Utilities/__tests__/warnOnce-test.js
+++ b/Libraries/Utilities/__tests__/warnOnce-test.js
@@ -11,7 +11,7 @@
 'use strict';
 
 describe('warnOnce', () => {
-  const warnOnce = require('warnOnce');
+  const warnOnce = require('../warnOnce');
 
   it('logs warning messages to the console exactly once', () => {
     console.error = jest.fn();

--- a/Libraries/Utilities/createPerformanceLogger.js
+++ b/Libraries/Utilities/createPerformanceLogger.js
@@ -9,9 +9,9 @@
  */
 'use strict';
 
-const Systrace = require('Systrace');
+const Systrace = require('../Performance/Systrace');
 
-const infoLog = require('infoLog');
+const infoLog = require('./infoLog');
 const performanceNow =
   global.nativeQPLTimestamp ||
   global.nativePerformanceNow ||

--- a/Libraries/Utilities/deprecatedPropType.js
+++ b/Libraries/Utilities/deprecatedPropType.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const UIManager = require('UIManager');
+const UIManager = require('../ReactNative/UIManager');
 
 /**
  * Adds a deprecation warning when the prop is used.

--- a/Libraries/Utilities/differ/__tests__/deepDiffer-test.js
+++ b/Libraries/Utilities/differ/__tests__/deepDiffer-test.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const deepDiffer = require('deepDiffer');
+const deepDiffer = require('../deepDiffer');
 
 describe('deepDiffer', function() {
   it('should diff primitives of the same type', () => {

--- a/Libraries/Utilities/dismissKeyboard.js
+++ b/Libraries/Utilities/dismissKeyboard.js
@@ -13,7 +13,7 @@
 
 'use strict';
 
-const TextInputState = require('TextInputState');
+const TextInputState = require('../Components/TextInput/TextInputState');
 
 function dismissKeyboard() {
   TextInputState.blurTextInput(TextInputState.currentlyFocusedField());

--- a/Libraries/Utilities/setAndForwardRef.js
+++ b/Libraries/Utilities/setAndForwardRef.js
@@ -10,11 +10,11 @@
 
 'use strict';
 
-import type React from 'React';
+import type {ElementRef, Ref} from 'react';
 
 type Args = $ReadOnly<{|
-  getForwardedRef: () => ?React.Ref<any>,
-  setLocalRef: (ref: React.ElementRef<any>) => mixed,
+  getForwardedRef: () => ?Ref<any>,
+  setLocalRef: (ref: ElementRef<any>) => mixed,
 |}>;
 
 /**
@@ -49,7 +49,7 @@ type Args = $ReadOnly<{|
  */
 
 function setAndForwardRef({getForwardedRef, setLocalRef}: Args) {
-  return function forwardRef(ref: React.ElementRef<any>) {
+  return function forwardRef(ref: ElementRef<any>) {
     const forwardedRef = getForwardedRef();
 
     setLocalRef(ref);

--- a/Libraries/Vibration/Vibration.js
+++ b/Libraries/Vibration/Vibration.js
@@ -11,8 +11,8 @@
 
 'use strict';
 
-const RCTVibration = require('NativeModules').Vibration;
-const Platform = require('Platform');
+const RCTVibration = require('../BatchedBridge/NativeModules').Vibration;
+const Platform = require('../Utilities/Platform');
 
 /**
  * Vibration API

--- a/Libraries/WebSocket/WebSocket.js
+++ b/Libraries/WebSocket/WebSocket.js
@@ -10,21 +10,21 @@
 
 'use strict';
 
-const Blob = require('Blob');
+const Blob = require('../Blob/Blob');
 const EventTarget = require('event-target-shim');
-const NativeEventEmitter = require('NativeEventEmitter');
-const BlobManager = require('BlobManager');
-const NativeModules = require('NativeModules');
-const Platform = require('Platform');
-const WebSocketEvent = require('WebSocketEvent');
+const NativeEventEmitter = require('../EventEmitter/NativeEventEmitter');
+const BlobManager = require('../Blob/BlobManager');
+const NativeModules = require('../BatchedBridge/NativeModules');
+const Platform = require('../Utilities/Platform');
+const WebSocketEvent = require('./WebSocketEvent');
 
 const base64 = require('base64-js');
-const binaryToBase64 = require('binaryToBase64');
+const binaryToBase64 = require('../Utilities/binaryToBase64');
 const invariant = require('invariant');
 
 const {WebSocketModule} = NativeModules;
 
-import type EventSubscription from 'EventSubscription';
+import type EventSubscription from '../vendor/emitter/EventSubscription';
 
 type ArrayBufferView =
   | Int8Array

--- a/Libraries/WebSocket/WebSocketInterceptor.js
+++ b/Libraries/WebSocket/WebSocketInterceptor.js
@@ -9,8 +9,9 @@
 
 'use strict';
 
-const RCTWebSocketModule = require('NativeModules').WebSocketModule;
-const NativeEventEmitter = require('NativeEventEmitter');
+const RCTWebSocketModule = require('../BatchedBridge/NativeModules')
+  .WebSocketModule;
+const NativeEventEmitter = require('../EventEmitter/NativeEventEmitter');
 
 const base64 = require('base64-js');
 

--- a/Libraries/WebSocket/__tests__/WebSocket-test.js
+++ b/Libraries/WebSocket/__tests__/WebSocket-test.js
@@ -10,14 +10,14 @@
 
 'use strict';
 
-jest.mock('NativeEventEmitter');
-jest.setMock('NativeModules', {
+jest.mock('../../EventEmitter/NativeEventEmitter');
+jest.setMock('../../BatchedBridge/NativeModules', {
   WebSocketModule: {
     connect: () => {},
   },
 });
 
-const WebSocket = require('WebSocket');
+const WebSocket = require('../WebSocket');
 
 describe('WebSocket', function() {
   it('should have connection lifecycle constants defined on the class', () => {

--- a/Libraries/YellowBox/Data/YellowBoxCategory.js
+++ b/Libraries/YellowBox/Data/YellowBoxCategory.js
@@ -10,13 +10,13 @@
 
 'use strict';
 
-const React = require('React');
-const Text = require('Text');
-const UTFSequence = require('UTFSequence');
+const React = require('react');
+const Text = require('../../Text/Text');
+const UTFSequence = require('../../UTFSequence');
 
-const stringifySafe = require('stringifySafe');
+const stringifySafe = require('../../Utilities/stringifySafe');
 
-import type {TextStyleProp} from 'StyleSheet';
+import type {TextStyleProp} from '../../StyleSheet/StyleSheet';
 
 export type Category = string;
 export type Message = $ReadOnly<{|

--- a/Libraries/YellowBox/Data/YellowBoxRegistry.js
+++ b/Libraries/YellowBox/Data/YellowBoxRegistry.js
@@ -10,9 +10,9 @@
 
 'use strict';
 
-const YellowBoxWarning = require('YellowBoxWarning');
+const YellowBoxWarning = require('./YellowBoxWarning');
 
-import type {Category} from 'YellowBoxCategory';
+import type {Category} from './YellowBoxCategory';
 
 export type Registry = Map<Category, $ReadOnlyArray<YellowBoxWarning>>;
 

--- a/Libraries/YellowBox/Data/YellowBoxSymbolication.js
+++ b/Libraries/YellowBox/Data/YellowBoxSymbolication.js
@@ -10,9 +10,9 @@
 
 'use strict';
 
-const symbolicateStackTrace = require('symbolicateStackTrace');
+const symbolicateStackTrace = require('../../Core/Devtools/symbolicateStackTrace');
 
-import type {StackFrame} from 'parseErrorStack';
+import type {StackFrame} from '../../Core/Devtools/parseErrorStack';
 
 type CacheKey = string;
 

--- a/Libraries/YellowBox/Data/YellowBoxWarning.js
+++ b/Libraries/YellowBox/Data/YellowBoxWarning.js
@@ -10,13 +10,13 @@
 
 'use strict';
 
-const YellowBoxCategory = require('YellowBoxCategory');
-const YellowBoxSymbolication = require('YellowBoxSymbolication');
+const YellowBoxCategory = require('./YellowBoxCategory');
+const YellowBoxSymbolication = require('./YellowBoxSymbolication');
 
-const parseErrorStack = require('parseErrorStack');
+const parseErrorStack = require('../../Core/Devtools/parseErrorStack');
 
-import type {Category, Message} from 'YellowBoxCategory';
-import type {Stack} from 'YellowBoxSymbolication';
+import type {Category, Message} from './YellowBoxCategory';
+import type {Stack} from './YellowBoxSymbolication';
 
 export type SymbolicationRequest = $ReadOnly<{|
   abort: () => void,

--- a/Libraries/YellowBox/Data/__tests__/YellowBoxCategory-test.js
+++ b/Libraries/YellowBox/Data/__tests__/YellowBoxCategory-test.js
@@ -11,7 +11,7 @@
 
 'use strict';
 
-const YellowBoxCategory = require('YellowBoxCategory');
+const YellowBoxCategory = require('../YellowBoxCategory');
 
 describe('YellowBoxCategory', () => {
   it('parses strings', () => {

--- a/Libraries/YellowBox/Data/__tests__/YellowBoxRegistry-test.js
+++ b/Libraries/YellowBox/Data/__tests__/YellowBoxRegistry-test.js
@@ -11,8 +11,8 @@
 
 'use strict';
 
-const YellowBoxCategory = require('YellowBoxCategory');
-const YellowBoxRegistry = require('YellowBoxRegistry');
+const YellowBoxCategory = require('../YellowBoxCategory');
+const YellowBoxRegistry = require('../YellowBoxRegistry');
 
 const registry = () => {
   const observer = jest.fn();

--- a/Libraries/YellowBox/Data/__tests__/YellowBoxSymbolication-test.js
+++ b/Libraries/YellowBox/Data/__tests__/YellowBoxSymbolication-test.js
@@ -11,16 +11,16 @@
 
 'use strict';
 
-import type {StackFrame} from 'parseErrorStack';
+import type {StackFrame} from '../../../Core/Devtools/parseErrorStack';
 
-jest.mock('symbolicateStackTrace');
+jest.mock('../../../Core/Devtools/symbolicateStackTrace');
 
-const YellowBoxSymbolication = require('YellowBoxSymbolication');
+const YellowBoxSymbolication = require('../YellowBoxSymbolication');
 
 const symbolicateStackTrace: JestMockFn<
   $ReadOnlyArray<Array<StackFrame>>,
   Promise<Array<StackFrame>>,
-> = (require('symbolicateStackTrace'): any);
+> = (require('../../../Core/Devtools/symbolicateStackTrace'): any);
 
 const createStack = methodNames =>
   methodNames.map(methodName => ({

--- a/Libraries/YellowBox/Data/__tests__/YellowBoxWarning-test.js
+++ b/Libraries/YellowBox/Data/__tests__/YellowBoxWarning-test.js
@@ -11,17 +11,17 @@
 
 'use strict';
 
-import type {StackFrame} from 'parseErrorStack';
+import type {StackFrame} from '../../../Core/Devtools/parseErrorStack';
 
-jest.mock('YellowBoxSymbolication');
+jest.mock('../YellowBoxSymbolication');
 
 const YellowBoxSymbolication: {|
   symbolicate: JestMockFn<
     $ReadOnlyArray<Array<StackFrame>>,
     Promise<Array<StackFrame>>,
   >,
-|} = (require('YellowBoxSymbolication'): any);
-const YellowBoxWarning = require('YellowBoxWarning');
+|} = (require('../YellowBoxSymbolication'): any);
+const YellowBoxWarning = require('../YellowBoxWarning');
 
 const createStack = methodNames =>
   methodNames.map(methodName => ({

--- a/Libraries/YellowBox/UI/YellowBoxButton.js
+++ b/Libraries/YellowBox/UI/YellowBoxButton.js
@@ -10,13 +10,13 @@
 
 'use strict';
 
-const React = require('React');
-const StyleSheet = require('StyleSheet');
-const Text = require('Text');
-const YellowBoxPressable = require('YellowBoxPressable');
-const YellowBoxStyle = require('YellowBoxStyle');
+const React = require('react');
+const StyleSheet = require('../../StyleSheet/StyleSheet');
+const Text = require('../../Text/Text');
+const YellowBoxPressable = require('./YellowBoxPressable');
+const YellowBoxStyle = require('./YellowBoxStyle');
 
-import type {EdgeInsetsProp} from 'EdgeInsetsPropType';
+import type {EdgeInsetsProp} from '../../StyleSheet/EdgeInsetsPropType';
 
 type Props = $ReadOnly<{|
   hitSlop?: ?EdgeInsetsProp,

--- a/Libraries/YellowBox/UI/YellowBoxImageSource.js
+++ b/Libraries/YellowBox/UI/YellowBoxImageSource.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const PixelRatio = require('PixelRatio');
+const PixelRatio = require('../../Utilities/PixelRatio');
 
 const scale = PixelRatio.get();
 

--- a/Libraries/YellowBox/UI/YellowBoxInspector.js
+++ b/Libraries/YellowBox/UI/YellowBoxInspector.js
@@ -10,23 +10,23 @@
 
 'use strict';
 
-const Platform = require('Platform');
-const React = require('React');
-const ScrollView = require('ScrollView');
-const StyleSheet = require('StyleSheet');
-const Text = require('Text');
-const View = require('View');
-const YellowBoxCategory = require('YellowBoxCategory');
-const YellowBoxInspectorFooter = require('YellowBoxInspectorFooter');
-const YellowBoxInspectorHeader = require('YellowBoxInspectorHeader');
-const YellowBoxInspectorSourceMapStatus = require('YellowBoxInspectorSourceMapStatus');
-const YellowBoxInspectorStackFrame = require('YellowBoxInspectorStackFrame');
-const YellowBoxStyle = require('YellowBoxStyle');
+const Platform = require('../../Utilities/Platform');
+const React = require('react');
+const ScrollView = require('../../Components/ScrollView/ScrollView');
+const StyleSheet = require('../../StyleSheet/StyleSheet');
+const Text = require('../../Text/Text');
+const View = require('../../Components/View/View');
+const YellowBoxCategory = require('../Data/YellowBoxCategory');
+const YellowBoxInspectorFooter = require('./YellowBoxInspectorFooter');
+const YellowBoxInspectorHeader = require('./YellowBoxInspectorHeader');
+const YellowBoxInspectorSourceMapStatus = require('./YellowBoxInspectorSourceMapStatus');
+const YellowBoxInspectorStackFrame = require('./YellowBoxInspectorStackFrame');
+const YellowBoxStyle = require('./YellowBoxStyle');
 
-const openFileInEditor = require('openFileInEditor');
+const openFileInEditor = require('../../Core/Devtools/openFileInEditor');
 
-import type YellowBoxWarning from 'YellowBoxWarning';
-import type {SymbolicationRequest} from 'YellowBoxWarning';
+import type YellowBoxWarning from '../Data/YellowBoxWarning';
+import type {SymbolicationRequest} from '../Data/YellowBoxWarning';
 
 type Props = $ReadOnly<{|
   onDismiss: () => void,

--- a/Libraries/YellowBox/UI/YellowBoxInspectorFooter.js
+++ b/Libraries/YellowBox/UI/YellowBoxInspectorFooter.js
@@ -10,13 +10,13 @@
 
 'use strict';
 
-const React = require('React');
-const SafeAreaView = require('SafeAreaView');
-const StyleSheet = require('StyleSheet');
-const Text = require('Text');
-const View = require('View');
-const YellowBoxPressable = require('YellowBoxPressable');
-const YellowBoxStyle = require('YellowBoxStyle');
+const React = require('react');
+const SafeAreaView = require('../../Components/SafeAreaView/SafeAreaView');
+const StyleSheet = require('../../StyleSheet/StyleSheet');
+const Text = require('../../Text/Text');
+const View = require('../../Components/View/View');
+const YellowBoxPressable = require('./YellowBoxPressable');
+const YellowBoxStyle = require('./YellowBoxStyle');
 
 type Props = $ReadOnly<{|
   onDismiss: () => void,

--- a/Libraries/YellowBox/UI/YellowBoxInspectorHeader.js
+++ b/Libraries/YellowBox/UI/YellowBoxInspectorHeader.js
@@ -10,18 +10,18 @@
 
 'use strict';
 
-const Image = require('Image');
-const Platform = require('Platform');
-const React = require('React');
-const SafeAreaView = require('SafeAreaView');
-const StyleSheet = require('StyleSheet');
-const Text = require('Text');
-const View = require('View');
-const YellowBoxImageSource = require('YellowBoxImageSource');
-const YellowBoxPressable = require('YellowBoxPressable');
-const YellowBoxStyle = require('YellowBoxStyle');
+const Image = require('../../Image/Image');
+const Platform = require('../../Utilities/Platform');
+const React = require('react');
+const SafeAreaView = require('../../Components/SafeAreaView/SafeAreaView');
+const StyleSheet = require('../../StyleSheet/StyleSheet');
+const Text = require('../../Text/Text');
+const View = require('../../Components/View/View');
+const YellowBoxImageSource = require('./YellowBoxImageSource');
+const YellowBoxPressable = require('./YellowBoxPressable');
+const YellowBoxStyle = require('./YellowBoxStyle');
 
-import type YellowBoxWarning from 'YellowBoxWarning';
+import type YellowBoxWarning from '../Data/YellowBoxWarning';
 
 type Props = $ReadOnly<{|
   onSelectIndex: (selectedIndex: number) => void,

--- a/Libraries/YellowBox/UI/YellowBoxInspectorSourceMapStatus.js
+++ b/Libraries/YellowBox/UI/YellowBoxInspectorSourceMapStatus.js
@@ -10,18 +10,18 @@
 
 'use strict';
 
-const Animated = require('Animated');
-const Easing = require('Easing');
-const React = require('React');
-const StyleSheet = require('StyleSheet');
-const Text = require('Text');
-const YellowBoxImageSource = require('YellowBoxImageSource');
-const YellowBoxPressable = require('YellowBoxPressable');
-const YellowBoxStyle = require('YellowBoxStyle');
+const Animated = require('../../Animated/src/Animated');
+const Easing = require('../../Animated/src/Easing');
+const React = require('react');
+const StyleSheet = require('../../StyleSheet/StyleSheet');
+const Text = require('../../Text/Text');
+const YellowBoxImageSource = require('./YellowBoxImageSource');
+const YellowBoxPressable = require('./YellowBoxPressable');
+const YellowBoxStyle = require('./YellowBoxStyle');
 
-import type {CompositeAnimation} from 'AnimatedImplementation';
-import type AnimatedInterpolation from 'AnimatedInterpolation';
-import type {PressEvent} from 'CoreEventTypes';
+import type {CompositeAnimation} from '../../Animated/src/AnimatedImplementation';
+import type AnimatedInterpolation from '../../Animated/src/nodes/AnimatedInterpolation';
+import type {PressEvent} from '../../Types/CoreEventTypes';
 
 type Props = $ReadOnly<{|
   onPress?: ?(event: PressEvent) => void,

--- a/Libraries/YellowBox/UI/YellowBoxInspectorStackFrame.js
+++ b/Libraries/YellowBox/UI/YellowBoxInspectorStackFrame.js
@@ -10,14 +10,14 @@
 
 'use strict';
 
-const React = require('React');
-const StyleSheet = require('StyleSheet');
-const Text = require('Text');
-const YellowBoxPressable = require('YellowBoxPressable');
-const YellowBoxStyle = require('YellowBoxStyle');
+const React = require('react');
+const StyleSheet = require('../../StyleSheet/StyleSheet');
+const Text = require('../../Text/Text');
+const YellowBoxPressable = require('./YellowBoxPressable');
+const YellowBoxStyle = require('./YellowBoxStyle');
 
-import type {PressEvent} from 'CoreEventTypes';
-import type {StackFrame} from 'parseErrorStack';
+import type {PressEvent} from '../../Types/CoreEventTypes';
+import type {StackFrame} from '../../Core/Devtools/parseErrorStack';
 
 type Props = $ReadOnly<{|
   frame: StackFrame,

--- a/Libraries/YellowBox/UI/YellowBoxList.js
+++ b/Libraries/YellowBox/UI/YellowBoxList.js
@@ -10,19 +10,19 @@
 
 'use strict';
 
-const Dimensions = require('Dimensions');
-const React = require('React');
-const FlatList = require('FlatList');
-const SafeAreaView = require('SafeAreaView');
-const StyleSheet = require('StyleSheet');
-const View = require('View');
-const YellowBoxButton = require('YellowBoxButton');
-const YellowBoxInspector = require('YellowBoxInspector');
-const YellowBoxListRow = require('YellowBoxListRow');
-const YellowBoxStyle = require('YellowBoxStyle');
+const Dimensions = require('../../Utilities/Dimensions');
+const React = require('react');
+const FlatList = require('../../Lists/FlatList');
+const SafeAreaView = require('../../Components/SafeAreaView/SafeAreaView');
+const StyleSheet = require('../../StyleSheet/StyleSheet');
+const View = require('../../Components/View/View');
+const YellowBoxButton = require('./YellowBoxButton');
+const YellowBoxInspector = require('./YellowBoxInspector');
+const YellowBoxListRow = require('./YellowBoxListRow');
+const YellowBoxStyle = require('./YellowBoxStyle');
 
-import type {Category} from 'YellowBoxCategory';
-import type {Registry} from 'YellowBoxRegistry';
+import type {Category} from '../Data/YellowBoxCategory';
+import type {Registry} from '../Data/YellowBoxRegistry';
 
 type Props = $ReadOnly<{|
   onDismiss: (category: Category) => void,

--- a/Libraries/YellowBox/UI/YellowBoxListRow.js
+++ b/Libraries/YellowBox/UI/YellowBoxListRow.js
@@ -10,16 +10,16 @@
 
 'use strict';
 
-const React = require('React');
-const StyleSheet = require('StyleSheet');
-const Text = require('Text');
-const YellowBoxPressable = require('YellowBoxPressable');
-const View = require('View');
-const YellowBoxCategory = require('YellowBoxCategory');
-const YellowBoxStyle = require('YellowBoxStyle');
-const YellowBoxWarning = require('YellowBoxWarning');
+const React = require('react');
+const StyleSheet = require('../../StyleSheet/StyleSheet');
+const Text = require('../../Text/Text');
+const YellowBoxPressable = require('./YellowBoxPressable');
+const View = require('../../Components/View/View');
+const YellowBoxCategory = require('../Data/YellowBoxCategory');
+const YellowBoxStyle = require('./YellowBoxStyle');
+const YellowBoxWarning = require('../Data/YellowBoxWarning');
 
-import type {Category} from 'YellowBoxCategory';
+import type {Category} from '../Data/YellowBoxCategory';
 
 type Props = $ReadOnly<{|
   category: Category,

--- a/Libraries/YellowBox/UI/YellowBoxPressable.js
+++ b/Libraries/YellowBox/UI/YellowBoxPressable.js
@@ -10,15 +10,15 @@
 
 'use strict';
 
-const React = require('React');
-const StyleSheet = require('StyleSheet');
-const TouchableWithoutFeedback = require('TouchableWithoutFeedback');
-const View = require('View');
-const YellowBoxStyle = require('YellowBoxStyle');
+const React = require('react');
+const StyleSheet = require('../../StyleSheet/StyleSheet');
+const TouchableWithoutFeedback = require('../../Components/Touchable/TouchableWithoutFeedback');
+const View = require('../../Components/View/View');
+const YellowBoxStyle = require('./YellowBoxStyle');
 
-import type {PressEvent} from 'CoreEventTypes';
-import type {EdgeInsetsProp} from 'EdgeInsetsPropType';
-import type {ViewStyleProp} from 'StyleSheet';
+import type {PressEvent} from '../../Types/CoreEventTypes';
+import type {EdgeInsetsProp} from '../../StyleSheet/EdgeInsetsPropType';
+import type {ViewStyleProp} from '../../StyleSheet/StyleSheet';
 
 type Props = $ReadOnly<{|
   backgroundColor: $ReadOnly<{|

--- a/Libraries/YellowBox/YellowBox.js
+++ b/Libraries/YellowBox/YellowBox.js
@@ -10,10 +10,14 @@
 
 'use strict';
 
-const React = require('React');
+const React = require('react');
 
-import type {Category} from 'YellowBoxCategory';
-import type {Registry, Subscription, IgnorePattern} from 'YellowBoxRegistry';
+import type {Category} from './Data/YellowBoxCategory';
+import type {
+  Registry,
+  Subscription,
+  IgnorePattern,
+} from './Data/YellowBoxRegistry';
 
 type Props = $ReadOnly<{||}>;
 type State = {|
@@ -41,10 +45,10 @@ let YellowBox;
  * the ignored warning messages.
  */
 if (__DEV__) {
-  const Platform = require('Platform');
-  const RCTLog = require('RCTLog');
-  const YellowBoxList = require('YellowBoxList');
-  const YellowBoxRegistry = require('YellowBoxRegistry');
+  const Platform = require('../Utilities/Platform');
+  const RCTLog = require('../Utilities/RCTLog');
+  const YellowBoxList = require('./UI/YellowBoxList');
+  const YellowBoxRegistry = require('./Data/YellowBoxRegistry');
 
   const {error, warn} = console;
 

--- a/Libraries/YellowBox/__tests__/YellowBox-test.js
+++ b/Libraries/YellowBox/__tests__/YellowBox-test.js
@@ -11,8 +11,8 @@
 
 'use strict';
 
-const YellowBox = require('YellowBox');
-const YellowBoxRegistry = require('YellowBoxRegistry');
+const YellowBox = require('../YellowBox');
+const YellowBoxRegistry = require('../Data/YellowBoxRegistry');
 
 describe('YellowBox', () => {
   const {error, warn} = console;
@@ -54,7 +54,7 @@ describe('YellowBox', () => {
   });
 
   it('registers warnings', () => {
-    jest.mock('YellowBoxRegistry');
+    jest.mock('../Data/YellowBoxRegistry');
 
     YellowBox.install();
 
@@ -64,7 +64,7 @@ describe('YellowBox', () => {
   });
 
   it('registers errors beginning with "Warning: "', () => {
-    jest.mock('YellowBoxRegistry');
+    jest.mock('../Data/YellowBoxRegistry');
 
     YellowBox.install();
 

--- a/Libraries/promiseRejectionIsError.js
+++ b/Libraries/promiseRejectionIsError.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-require('Promise'); // make sure the default rejection handler is installed
+require('./Promise'); // make sure the default rejection handler is installed
 const rejectionTracking = require('promise/setimmediate/rejection-tracking');
 
 module.exports = () => {

--- a/Libraries/react-native/react-native-implementation.js
+++ b/Libraries/react-native/react-native-implementation.js
@@ -11,22 +11,22 @@
 'use strict';
 
 const invariant = require('invariant');
-const warnOnce = require('warnOnce');
+const warnOnce = require('../Utilities/warnOnce');
 
 // Export React, plus some native additions.
 module.exports = {
   // Components
   get AccessibilityInfo() {
-    return require('AccessibilityInfo');
+    return require('../Components/AccessibilityInfo/AccessibilityInfo');
   },
   get ActivityIndicator() {
-    return require('ActivityIndicator');
+    return require('../Components/ActivityIndicator/ActivityIndicator');
   },
   get ART() {
-    return require('ReactNativeART');
+    return require('../ART/ReactNativeART');
   },
   get Button() {
-    return require('Button');
+    return require('../Components/Button');
   },
   get CheckBox() {
     warnOnce(
@@ -35,22 +35,22 @@ module.exports = {
         "It can now be installed and imported from '@react-native-community/checkbox' instead of 'react-native'. " +
         'See https://github.com/react-native-community/react-native-checkbox',
     );
-    return require('CheckBox');
+    return require('../Components/CheckBox/CheckBox');
   },
   get DatePickerIOS() {
-    return require('DatePickerIOS');
+    return require('../Components/DatePicker/DatePickerIOS');
   },
   get DrawerLayoutAndroid() {
-    return require('DrawerLayoutAndroid');
+    return require('../Components/DrawerAndroid/DrawerLayoutAndroid');
   },
   get FlatList() {
-    return require('FlatList');
+    return require('../Lists/FlatList');
   },
   get Image() {
-    return require('Image');
+    return require('../Image/Image');
   },
   get ImageBackground() {
-    return require('ImageBackground');
+    return require('../Image/ImageBackground');
   },
   get ImageEditor() {
     warnOnce(
@@ -59,7 +59,7 @@ module.exports = {
         "It can now be installed and imported from '@react-native-community/image-editor' instead of 'react-native'. " +
         'See https://github.com/react-native-community/react-native-image-editor',
     );
-    return require('ImageEditor');
+    return require('../Image/ImageEditor');
   },
   get ImageStore() {
     warnOnce(
@@ -69,13 +69,13 @@ module.exports = {
         "* expo-file-system: `readAsStringAsync(filepath, 'base64')`" +
         "* react-native-fs: `readFile(filepath, 'base64')`",
     );
-    return require('ImageStore');
+    return require('../Image/ImageStore');
   },
   get InputAccessoryView() {
-    return require('InputAccessoryView');
+    return require('../Components/TextInput/InputAccessoryView');
   },
   get KeyboardAvoidingView() {
-    return require('KeyboardAvoidingView');
+    return require('../Components/Keyboard/KeyboardAvoidingView');
   },
   get MaskedViewIOS() {
     warnOnce(
@@ -84,34 +84,34 @@ module.exports = {
         "It can now be installed and imported from '@react-native-community/masked-view' instead of 'react-native'. " +
         'See https://github.com/react-native-community/react-native-masked-view',
     );
-    return require('MaskedViewIOS');
+    return require('../Components/MaskedView/MaskedViewIOS');
   },
   get Modal() {
-    return require('Modal');
+    return require('../Modal/Modal');
   },
   get Picker() {
-    return require('Picker');
+    return require('../Components/Picker/Picker');
   },
   get PickerIOS() {
-    return require('PickerIOS');
+    return require('../Components/Picker/PickerIOS');
   },
   get ProgressBarAndroid() {
-    return require('ProgressBarAndroid');
+    return require('../Components/ProgressBarAndroid/ProgressBarAndroid');
   },
   get ProgressViewIOS() {
-    return require('ProgressViewIOS');
+    return require('../Components/ProgressViewIOS/ProgressViewIOS');
   },
   get SafeAreaView() {
-    return require('SafeAreaView');
+    return require('../Components/SafeAreaView/SafeAreaView');
   },
   get ScrollView() {
-    return require('ScrollView');
+    return require('../Components/ScrollView/ScrollView');
   },
   get SectionList() {
-    return require('SectionList');
+    return require('../Lists/SectionList');
   },
   get SegmentedControlIOS() {
-    return require('SegmentedControlIOS');
+    return require('../Components/SegmentedControlIOS/SegmentedControlIOS');
   },
   get Slider() {
     warnOnce(
@@ -120,13 +120,13 @@ module.exports = {
         "It can now be installed and imported from '@react-native-community/slider' instead of 'react-native'. " +
         'See https://github.com/react-native-community/react-native-slider',
     );
-    return require('Slider');
+    return require('../Components/Slider/Slider');
   },
   get Switch() {
-    return require('Switch');
+    return require('../Components/Switch/Switch');
   },
   get RefreshControl() {
-    return require('RefreshControl');
+    return require('../Components/RefreshControl/RefreshControl');
   },
   get StatusBar() {
     warnOnce(
@@ -135,34 +135,34 @@ module.exports = {
         "It can now be installed and imported from '@react-native-community/status-bar' instead of 'react-native'. " +
         'https://github.com/react-native-community/react-native-statusbar',
     );
-    return require('StatusBar');
+    return require('../Components/StatusBar/StatusBar');
   },
   get Text() {
-    return require('Text');
+    return require('../Text/Text');
   },
   get TextInput() {
-    return require('TextInput');
+    return require('../Components/TextInput/TextInput');
   },
   get ToolbarAndroid() {
-    return require('ToolbarAndroid');
+    return require('../Components/ToolbarAndroid/ToolbarAndroid');
   },
   get Touchable() {
-    return require('Touchable');
+    return require('../Components/Touchable/Touchable');
   },
   get TouchableHighlight() {
-    return require('TouchableHighlight');
+    return require('../Components/Touchable/TouchableHighlight');
   },
   get TouchableNativeFeedback() {
-    return require('TouchableNativeFeedback');
+    return require('../Components/Touchable/TouchableNativeFeedback');
   },
   get TouchableOpacity() {
-    return require('TouchableOpacity');
+    return require('../Components/Touchable/TouchableOpacity');
   },
   get TouchableWithoutFeedback() {
-    return require('TouchableWithoutFeedback');
+    return require('../Components/Touchable/TouchableWithoutFeedback');
   },
   get View() {
-    return require('View');
+    return require('../Components/View/View');
   },
   get ViewPagerAndroid() {
     warnOnce(
@@ -171,30 +171,30 @@ module.exports = {
         "It can now be installed and imported from '@react-native-community/viewpager' instead of 'react-native'. " +
         'See https://github.com/react-native-community/react-native-viewpager',
     );
-    return require('ViewPagerAndroid');
+    return require('../Components/ViewPager/ViewPagerAndroid');
   },
   get VirtualizedList() {
-    return require('VirtualizedList');
+    return require('../Lists/VirtualizedList');
   },
   get VirtualizedSectionList() {
-    return require('VirtualizedSectionList');
+    return require('../Lists/VirtualizedSectionList');
   },
 
   // APIs
   get ActionSheetIOS() {
-    return require('ActionSheetIOS');
+    return require('../ActionSheetIOS/ActionSheetIOS');
   },
   get Alert() {
-    return require('Alert');
+    return require('../Alert/Alert');
   },
   get Animated() {
-    return require('Animated');
+    return require('../Animated/src/Animated');
   },
   get AppRegistry() {
-    return require('AppRegistry');
+    return require('../ReactNative/AppRegistry');
   },
   get AppState() {
-    return require('AppState');
+    return require('../AppState/AppState');
   },
   get AsyncStorage() {
     warnOnce(
@@ -203,10 +203,10 @@ module.exports = {
         "It can now be installed and imported from '@react-native-community/async-storage' instead of 'react-native'. " +
         'See https://github.com/react-native-community/react-native-async-storage',
     );
-    return require('AsyncStorage');
+    return require('../Storage/AsyncStorage');
   },
   get BackHandler() {
-    return require('BackHandler');
+    return require('../Utilities/BackHandler');
   },
   get CameraRoll() {
     warnOnce(
@@ -215,46 +215,46 @@ module.exports = {
         "It can now be installed and imported from '@react-native-community/cameraroll' instead of 'react-native'. " +
         'See https://github.com/react-native-community/react-native-cameraroll',
     );
-    return require('CameraRoll');
+    return require('../CameraRoll/CameraRoll');
   },
   get Clipboard() {
-    return require('Clipboard');
+    return require('../Components/Clipboard/Clipboard');
   },
   get DatePickerAndroid() {
-    return require('DatePickerAndroid');
+    return require('../Components/DatePickerAndroid/DatePickerAndroid');
   },
   get DeviceInfo() {
-    return require('DeviceInfo');
+    return require('../Utilities/DeviceInfo');
   },
   get Dimensions() {
-    return require('Dimensions');
+    return require('../Utilities/Dimensions');
   },
   get Easing() {
-    return require('Easing');
+    return require('../Animated/src/Easing');
   },
   get findNodeHandle() {
-    return require('ReactNative').findNodeHandle;
+    return require('../Renderer/shims/ReactNative').findNodeHandle;
   },
   get I18nManager() {
-    return require('I18nManager');
+    return require('../ReactNative/I18nManager');
   },
   get ImagePickerIOS() {
-    return require('ImagePickerIOS');
+    return require('../CameraRoll/ImagePickerIOS');
   },
   get InteractionManager() {
-    return require('InteractionManager');
+    return require('../Interaction/InteractionManager');
   },
   get Keyboard() {
-    return require('Keyboard');
+    return require('../Components/Keyboard/Keyboard');
   },
   get LayoutAnimation() {
-    return require('LayoutAnimation');
+    return require('../LayoutAnimation/LayoutAnimation');
   },
   get Linking() {
-    return require('Linking');
+    return require('../Linking/Linking');
   },
   get NativeEventEmitter() {
-    return require('NativeEventEmitter');
+    return require('../EventEmitter/NativeEventEmitter');
   },
   get NetInfo() {
     warnOnce(
@@ -263,16 +263,16 @@ module.exports = {
         "It can now be installed and imported from '@react-native-community/netinfo' instead of 'react-native'. " +
         'See https://github.com/react-native-community/react-native-netinfo',
     );
-    return require('NetInfo');
+    return require('../Network/NetInfo');
   },
   get PanResponder() {
-    return require('PanResponder');
+    return require('../Interaction/PanResponder');
   },
   get PermissionsAndroid() {
-    return require('PermissionsAndroid');
+    return require('../PermissionsAndroid/PermissionsAndroid');
   },
   get PixelRatio() {
-    return require('PixelRatio');
+    return require('../Utilities/PixelRatio');
   },
   get PushNotificationIOS() {
     warnOnce(
@@ -281,83 +281,83 @@ module.exports = {
         "It can now be installed and imported from '@react-native-community/push-notification-ios' instead of 'react-native'. " +
         'See https://github.com/react-native-community/react-native-push-notification-ios',
     );
-    return require('PushNotificationIOS');
+    return require('../PushNotificationIOS/PushNotificationIOS');
   },
   get Settings() {
-    return require('Settings');
+    return require('../Settings/Settings');
   },
   get Share() {
-    return require('Share');
+    return require('../Share/Share');
   },
   get StatusBarIOS() {
-    return require('StatusBarIOS');
+    return require('../Components/StatusBar/StatusBarIOS');
   },
   get StyleSheet() {
-    return require('StyleSheet');
+    return require('../StyleSheet/StyleSheet');
   },
   get Systrace() {
-    return require('Systrace');
+    return require('../Performance/Systrace');
   },
   get TimePickerAndroid() {
-    return require('TimePickerAndroid');
+    return require('../Components/TimePickerAndroid/TimePickerAndroid');
   },
   get ToastAndroid() {
-    return require('ToastAndroid');
+    return require('../Components/ToastAndroid/ToastAndroid');
   },
   get TurboModuleRegistry() {
-    return require('TurboModuleRegistry');
+    return require('../TurboModule/TurboModuleRegistry');
   },
   get TVEventHandler() {
-    return require('TVEventHandler');
+    return require('../Components/AppleTV/TVEventHandler');
   },
   get UIManager() {
-    return require('UIManager');
+    return require('../ReactNative/UIManager');
   },
   get unstable_batchedUpdates() {
-    return require('ReactNative').unstable_batchedUpdates;
+    return require('../Renderer/shims/ReactNative').unstable_batchedUpdates;
   },
   get UTFSequence() {
-    return require('UTFSequence');
+    return require('../UTFSequence');
   },
   get Vibration() {
-    return require('Vibration');
+    return require('../Vibration/Vibration');
   },
   get YellowBox() {
-    return require('YellowBox');
+    return require('../YellowBox/YellowBox');
   },
 
   // Plugins
   get DeviceEventEmitter() {
-    return require('RCTDeviceEventEmitter');
+    return require('../EventEmitter/RCTDeviceEventEmitter');
   },
   get NativeAppEventEmitter() {
-    return require('RCTNativeAppEventEmitter');
+    return require('../EventEmitter/RCTNativeAppEventEmitter');
   },
   get NativeModules() {
-    return require('NativeModules');
+    return require('../BatchedBridge/NativeModules');
   },
   get Platform() {
-    return require('Platform');
+    return require('../Utilities/Platform');
   },
   get processColor() {
-    return require('processColor');
+    return require('../StyleSheet/processColor');
   },
   get requireNativeComponent() {
-    return require('requireNativeComponent');
+    return require('../ReactNative/requireNativeComponent');
   },
 
   // Prop Types
   get ColorPropType() {
-    return require('DeprecatedColorPropType');
+    return require('../DeprecatedPropTypes/DeprecatedColorPropType');
   },
   get EdgeInsetsPropType() {
-    return require('DeprecatedEdgeInsetsPropType');
+    return require('../DeprecatedPropTypes/DeprecatedEdgeInsetsPropType');
   },
   get PointPropType() {
-    return require('DeprecatedPointPropType');
+    return require('../DeprecatedPropTypes/DeprecatedPointPropType');
   },
   get ViewPropTypes() {
-    return require('DeprecatedViewPropTypes');
+    return require('../DeprecatedPropTypes/DeprecatedViewPropTypes');
   },
 };
 


### PR DESCRIPTION
## Summary

This is the next step in moving RN towards standard path-based requires. All the requires in `Libraries` have been rewritten to use relative requires with a few exceptions, namely, `vendor` and `Renderer/oss` since those need to be changed upstream. This commit uses relative requires instead of `react-native/...` so that if Facebook were to stop syncing out certain folders and therefore remove code from the react-native package, internal code at Facebook would not need to change.

See the umbrella issue at https://github.com/facebook/react-native/issues/24316 for more detail.

## Changelog

[General] [Changed] - Migrate "Libraries" from Haste to standard path-based requires

## Test Plan

Prettier/Lint, Flow, Jest tests, loaded RNTester