### PR TITLE
[standards] Migrate IntegrationTests from Haste to path-based requires

### DIFF
--- a/IntegrationTests/AccessibilityManagerTest.js
+++ b/IntegrationTests/AccessibilityManagerTest.js
@@ -13,7 +13,7 @@
 const React = require('react');
 const ReactNative = require('react-native');
 const {View} = ReactNative;
-const RCTDeviceEventEmitter = require('RCTDeviceEventEmitter');
+const RCTDeviceEventEmitter = require('react-native/Libraries/EventEmitter/RCTDeviceEventEmitter');
 const {TestModule, AccessibilityManager} = ReactNative.NativeModules;
 
 class AccessibilityManagerTest extends React.Component<{}> {

--- a/IntegrationTests/AppEventsTest.js
+++ b/IntegrationTests/AppEventsTest.js
@@ -15,7 +15,7 @@ const ReactNative = require('react-native');
 const {NativeAppEventEmitter, StyleSheet, Text, View} = ReactNative;
 const {TestModule} = ReactNative.NativeModules;
 
-const deepDiffer = require('deepDiffer');
+const deepDiffer = require('react-native/Libraries/Utilities/differ/deepDiffer');
 
 const TEST_PAYLOAD = {foo: 'bar'};
 

--- a/IntegrationTests/AsyncStorageTest.js
+++ b/IntegrationTests/AsyncStorageTest.js
@@ -15,7 +15,7 @@ const ReactNative = require('react-native');
 const {AsyncStorage, Text, View, StyleSheet} = ReactNative;
 const {TestModule} = ReactNative.NativeModules;
 
-const deepDiffer = require('deepDiffer');
+const deepDiffer = require('react-native/Libraries/Utilities/differ/deepDiffer');
 
 const DEBUG = false;
 

--- a/IntegrationTests/IntegrationTestsApp.js
+++ b/IntegrationTests/IntegrationTestsApp.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-require('InitializeCore');
+require('react-native/Libraries/Core/InitializeCore');
 const React = require('react');
 const ReactNative = require('react-native');
 const {
@@ -46,7 +46,7 @@ TESTS.forEach(
 );
 
 // Modules required for integration tests
-require('LoggingTestModule');
+require('./LoggingTestModule');
 
 type Test = any;
 

--- a/IntegrationTests/LayoutEventsTest.js
+++ b/IntegrationTests/LayoutEventsTest.js
@@ -15,15 +15,18 @@ const ReactNative = require('react-native');
 const {Image, LayoutAnimation, StyleSheet, Text, View} = ReactNative;
 const {TestModule} = ReactNative.NativeModules;
 
-import type {ViewStyleProp} from 'StyleSheet';
+import type {ViewStyleProp} from 'react-native/Libraries/StyleSheet/StyleSheet';
 
-const deepDiffer = require('deepDiffer');
+const deepDiffer = require('react-native/Libraries/Utilities/differ/deepDiffer');
 
 function debug(...args) {
   // console.log.apply(null, arguments);
 }
 
-import type {Layout, LayoutEvent} from 'CoreEventTypes';
+import type {
+  Layout,
+  LayoutEvent,
+} from 'react-native/Libraries/Types/CoreEventTypes';
 
 type Props = $ReadOnly<{||}>;
 

--- a/IntegrationTests/LoggingTestModule.js
+++ b/IntegrationTests/LoggingTestModule.js
@@ -9,7 +9,7 @@
 
 'use strict';
 
-const BatchedBridge = require('BatchedBridge');
+const BatchedBridge = require('react-native/Libraries/BatchedBridge/BatchedBridge');
 
 const warning = require('fbjs/lib/warning');
 const invariant = require('invariant');

--- a/IntegrationTests/ReactContentSizeUpdateTest.js
+++ b/IntegrationTests/ReactContentSizeUpdateTest.js
@@ -12,12 +12,12 @@
 
 const React = require('react');
 const ReactNative = require('react-native');
-const RCTNativeAppEventEmitter = require('RCTNativeAppEventEmitter');
+const RCTNativeAppEventEmitter = require('react-native/Libraries/EventEmitter/RCTNativeAppEventEmitter');
 
 const {View} = ReactNative;
 
 const {TestModule} = ReactNative.NativeModules;
-import type EmitterSubscription from 'EmitterSubscription';
+import type EmitterSubscription from 'react-native/Libraries/vendor/emitter/EmitterSubscription';
 
 const reactViewWidth = 101;
 const reactViewHeight = 102;

--- a/IntegrationTests/SizeFlexibilityUpdateTest.js
+++ b/IntegrationTests/SizeFlexibilityUpdateTest.js
@@ -12,11 +12,11 @@
 
 const React = require('react');
 const ReactNative = require('react-native');
-const RCTNativeAppEventEmitter = require('RCTNativeAppEventEmitter');
+const RCTNativeAppEventEmitter = require('react-native/Libraries/EventEmitter/RCTNativeAppEventEmitter');
 const {View} = ReactNative;
 
 const {TestModule} = ReactNative.NativeModules;
-import type EmitterSubscription from 'EmitterSubscription';
+import type EmitterSubscription from 'react-native/Libraries/vendor/emitter/EmitterSubscription';
 
 const reactViewWidth = 111;
 const reactViewHeight = 222;


### PR DESCRIPTION
## Summary

This is another step in moving RN towards standard path-based requires. All the requires in `IntegrationTests` have been rewritten to use relative requires. This commit uses requires that are relative to `react-native/...` assuming that IntegrationTests are meant to try consuming RN rather than being part of it.

See the umbrella issue at https://github.com/facebook/react-native/issues/24316 for more detail.

## Changelog

[General] [Changed] - Migrate IntegrationTests from Haste to path-based requires

## Test Plan

Run OSS CI