### PR TITLE
[standards] Migrate TurboModule example in RNTester to use path-based requires

### DIFF
--- a/RNTester/js/SampleTurboModuleExample.js
+++ b/RNTester/js/SampleTurboModuleExample.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-import NativeSampleTurboModule from 'NativeSampleTurboModule';
+import NativeSampleTurboModule from 'react-native/Libraries/TurboModule/samples/NativeSampleTurboModule';
 import {
   StyleSheet,
   Text,

--- a/RNTester/js/TurboModuleExample.js
+++ b/RNTester/js/TurboModuleExample.js
@@ -11,7 +11,7 @@
 'use strict';
 
 const React = require('react');
-const SampleTurboModuleExample = require('SampleTurboModuleExample');
+const SampleTurboModuleExample = require('./SampleTurboModuleExample');
 
 exports.displayName = (undefined: ?string);
 exports.title = 'TurboModule';


### PR DESCRIPTION
## Summary

See #24316 for the motivation. This commit rewrites a couple more new imports in the RNTester project so they use path-based requires.

## Changelog

[General] [Changed] - Migrate TurboModule example in RNTester to use path-based requires

## Test Plan

Run RNTester and ensure the TurboModule example loads.
