### PR TITLE
Fix OSS Android build

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/BUCK
@@ -36,6 +36,6 @@ rn_android_library(
     deps = [
         react_native_dep("libraries/soloader/java/com/facebook/soloader:soloader"),
         react_native_target("java/com/facebook/react/turbomodule/core/interfaces:interfaces"),
-        react_native_dep("libraries/fbjni:java"),
+        react_native_dep("java/com/facebook/jni:jni"),
     ],
 )


### PR DESCRIPTION
Summary:
The `test_android` CI build was failing:

```
./scripts/circleci/buck_fetch.sh
+ buck fetch ReactAndroid/src/test/java/com/facebook/react/modules
Not using buckd because watchman isn't installed.
Picked up _JAVA_OPTIONS: -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap
PARSING BUCK FILES: FINISHED IN 1.1s
No build file at ReactAndroid/src/main/libraries/fbjni/BUCK when resolving target //ReactAndroid/src/main/libraries/fbjni:java.

This error happened while trying to get dependency '//ReactAndroid/src/main/libraries/fbjni:java' of target '//ReactAndroid/src/main/java/com/facebook/react/turbomodule/core:jscallinvokerholder'
Exited with code 1
```

The problem was that I was using `react_native_dep("libraries/fbjni:java")` to access JNI classes like `HybridData`. In open source this target translates to the path `//ReactAndroid/src/main/libraries/fbjni`, which doesn't exist. Instead, the actual classes are available at the path `//ReactAndroid/src/main/java/com/facebook/jni`. Therefore, I changed the target to `react_native_dep("java/com/facebook/jni:jni")`. This is exactly how the bridge (i.e: `//ReactAndroid/src/main/java/com/facebook/react/bridge:bridge`) accesses JNI clases.

Differential Revision: D15261218

