### PR TITLE
[iOS] optimize layout block iteration for root view

### DIFF
--- a/React/Modules/RCTUIManager.m
+++ b/React/Modules/RCTUIManager.m
@@ -516,51 +516,46 @@ static NSDictionary *deviceOrientationEventBody(UIDeviceOrientation orientation)
   NSUInteger count = affectedShadowViews.count;
   NSMutableArray *reactTags = [[NSMutableArray alloc] initWithCapacity:count];
   NSMutableData *framesData = [[NSMutableData alloc] initWithLength:sizeof(RCTFrameData) * count];
-  {
-    NSUInteger index = 0;
-    RCTFrameData *frameDataArray = (RCTFrameData *)framesData.mutableBytes;
-    for (RCTShadowView *shadowView in affectedShadowViews) {
-      reactTags[index] = shadowView.reactTag;
-      RCTLayoutMetrics layoutMetrics = shadowView.layoutMetrics;
-      frameDataArray[index++] = (RCTFrameData){
-        layoutMetrics.frame,
-        layoutMetrics.layoutDirection,
-        shadowView.isNewView,
-        shadowView.superview.isNewView,
-        layoutMetrics.displayType
-      };
-    }
-  }
-
+  NSUInteger index = 0;
+  RCTFrameData *frameDataMutableArray = (RCTFrameData *)framesData.mutableBytes;
   for (RCTShadowView *shadowView in affectedShadowViews) {
-
-    // We have to do this after we build the parentsAreNew array.
+    reactTags[index] = shadowView.reactTag;
+    RCTLayoutMetrics layoutMetrics = shadowView.layoutMetrics;
+    frameDataMutableArray[index++] = (RCTFrameData){
+      layoutMetrics.frame,
+      layoutMetrics.layoutDirection,
+      shadowView.isNewView,
+      shadowView.superview.isNewView,
+      layoutMetrics.displayType
+    };
+    
+    // After this layout pass, it's not new anymore.
     shadowView.newView = NO;
-
+    
     NSNumber *reactTag = shadowView.reactTag;
-
+    
     if (shadowView.onLayout) {
       CGRect frame = shadowView.layoutMetrics.frame;
       shadowView.onLayout(@{
-        @"layout": @{
-          @"x": @(frame.origin.x),
-          @"y": @(frame.origin.y),
-          @"width": @(frame.size.width),
-          @"height": @(frame.size.height),
-        },
-      });
+                            @"layout": @{
+                                @"x": @(frame.origin.x),
+                                @"y": @(frame.origin.y),
+                                @"width": @(frame.size.width),
+                                @"height": @(frame.size.height),
+                                },
+                            });
     }
-
+    
     if (
         RCTIsReactRootView(reactTag) &&
         [shadowView isKindOfClass:[RCTRootShadowView class]]
-    ) {
+        ) {
       CGSize contentSize = shadowView.layoutMetrics.frame.size;
-
+      
       RCTExecuteOnMainQueue(^{
         UIView *view = self->_viewRegistry[reactTag];
         RCTAssert(view != nil, @"view (for ID %@) not found", reactTag);
-
+        
         RCTRootView *rootView = (RCTRootView *)[view superview];
         if ([rootView isKindOfClass:[RCTRootView class]]) {
           rootView.intrinsicContentSize = contentSize;
@@ -577,9 +572,9 @@ static NSDictionary *deviceOrientationEventBody(UIDeviceOrientation orientation)
 
     __block NSUInteger completionsCalled = 0;
 
-    NSInteger index = 0;
+    NSInteger idx = 0;
     for (NSNumber *reactTag in reactTags) {
-      RCTFrameData frameData = frameDataArray[index++];
+      RCTFrameData frameData = frameDataArray[idx++];
 
       UIView *view = viewRegistry[reactTag];
       CGRect frame = frameData.frame;


### PR DESCRIPTION
## Summary

No logical changed, the goal is to eliminate iteration from O(2N) to O(N).
We iterate `affectedShadowViews` array repeated, it's unnecessary and we can consolidate them.

## Changelog

[iOS] [Changed] - optimize layout block iteration for root view

## Test Plan

CI passes.
