### PR TITLE
Fix duplicate resource error in Android gradle build (#22234)

### DIFF
--- a/react.gradle
+++ b/react.gradle
@@ -60,18 +60,19 @@ afterEvaluate {
             // Address issue #22234 by moving generated resources into build dir so they are in one spot, not duplicated
             doLast {
                 def moveFunc = { resSuffix ->
-                    File originalDir = file("$buildDir/generated/res/react/${flavorPathSegment}release/drawable-${resSuffix}")
+                    File originalDir = file("$buildDir/generated/res/react/${flavorPathSegment}release/${resSuffix}")
                     if (originalDir.exists()) {
-                        File destDir = file("$buildDir/../src/main/res/drawable-${resSuffix}")
+                        File destDir = file("$buildDir/../src/main/res/${resSuffix}")
                         ant.move(file: originalDir, tofile: destDir);
                     }
                 }
-                moveFunc.curry("ldpi").call()
-                moveFunc.curry("mdpi").call()
-                moveFunc.curry("hdpi").call()
-                moveFunc.curry("xhdpi").call()
-                moveFunc.curry("xxhdpi").call()
-                moveFunc.curry("xxxhdpi").call()
+                moveFunc.curry("drawable-ldpi").call()
+                moveFunc.curry("drawable-mdpi").call()
+                moveFunc.curry("drawable-hdpi").call()
+                moveFunc.curry("drawable-xhdpi").call()
+                moveFunc.curry("drawable-xxhdpi").call()
+                moveFunc.curry("drawable-xxxhdpi").call()
+                moveFunc.curry("raw").call()
             }
 
             // Set up inputs and outputs so gradle can cache the result


### PR DESCRIPTION
## Summary:

If `$buildDir/generated/res/react/${flavorPathSegment}release/raw` contains files during `gradle assembleRelease` script will fail with `Error: Duplicate resources` error.

This patch is based on this issue [22234](https://github.com/facebook/react-native/issues/22234) and pull request [24518](https://github.com/facebook/react-native/pull/24518).

## Changelog

[Android] [Fixed] - Fix duplicate resource error for raw folder in Android build

## Test plan 

[CC from Mike Hardy PR] 
Reports of success on the linked issue via use of the patch + patch-package for a couple months, I personally use it full time with all gradle builds (./gradlew clean assembleRelease or if you have a 'staging' flavor, e.g. ./gradlew clean assembleStagingRelease)

Related reading, also cross-links with the linked issue here:
https://stackoverflow.com/questions/53239705/react-native-error-duplicate-resources-android