### PR TITLE
[Android] Fix Android Camera Roll crash on mime type guessing

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/modules/camera/CameraRollManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/camera/CameraRollManager.java
@@ -50,7 +50,6 @@ import java.nio.channels.ReadableByteChannel;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nullable;
-import java.net.URLConnection;
 import java.net.URL;
 
 // TODO #6015104: rename to something less iOSish
@@ -388,7 +387,8 @@ public class CameraRollManager extends ReactContextBaseJavaModule {
       WritableMap edge = new WritableNativeMap();
       WritableMap node = new WritableNativeMap();
       boolean imageInfoSuccess =
-          putImageInfo(resolver, media, node, idIndex, widthIndex, heightIndex, dataIndex);
+          putImageInfo(resolver, media, node, idIndex, widthIndex, heightIndex, dataIndex,
+                  mimeTypeIndex);
       if (imageInfoSuccess) {
         putBasicNodeInfo(media, node, mimeTypeIndex, groupNameIndex, dateTakenIndex);
         putLocationInfo(media, node, longitudeIndex, latitudeIndex);
@@ -423,20 +423,15 @@ public class CameraRollManager extends ReactContextBaseJavaModule {
       int idIndex,
       int widthIndex,
       int heightIndex,
-      int dataIndex) {
+      int dataIndex,
+      int mimeTypeIndex) {
     WritableMap image = new WritableNativeMap();
     Uri photoUri = Uri.parse("file://" + media.getString(dataIndex));
     image.putString("uri", photoUri.toString());
     float width = media.getInt(widthIndex);
     float height = media.getInt(heightIndex);
 
-    String mimeType;
-    try {
-      mimeType = URLConnection.guessContentTypeFromName(photoUri.toString());
-    } catch (StringIndexOutOfBoundsException e) {
-      FLog.e(ReactConstants.TAG, "Unable to guess content type from " + photoUri.toString(), e);
-      throw e;
-    }
+    String mimeType = media.getString(mimeTypeIndex);
 
     if (mimeType != null
         && mimeType.startsWith("video")) {


### PR DESCRIPTION
## Summary

Fixes this issue:
https://github.com/facebook/react-native/issues/24468
It was incorrectly closed by a fix on react-native-community CameraRoll implementation. CameraRoll in react-native still crashes when finding a file with # sign

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See http://facebook.github.io/react-native/docs/contributing#changelog for an example. -->

[Android] [Fix] - Fix Android Camera Roll crash on mime type guessing

## Test Plan

1. Rename a photo file to contain # sign
2. Open CameraRoll

ER: Doesn't crash
AR: Crashes