### PR TITLE
Polish new app screen component styling

### DIFF
--- a/Libraries/NewAppScreen/components/Header.js
+++ b/Libraries/NewAppScreen/components/Header.js
@@ -27,7 +27,7 @@ const Header = () => (
 const styles = StyleSheet.create({
   background: {
     paddingBottom: 40,
-    paddingTop: 80,
+    paddingTop: 96,
     paddingHorizontal: 32,
     backgroundColor: Colors.lighter,
   },

--- a/Libraries/NewAppScreen/components/Header.js
+++ b/Libraries/NewAppScreen/components/Header.js
@@ -26,7 +26,8 @@ const Header = () => (
 
 const styles = StyleSheet.create({
   background: {
-    paddingVertical: 40,
+    paddingBottom: 40,
+    paddingTop: 80,
     paddingHorizontal: 32,
     backgroundColor: Colors.lighter,
   },

--- a/Libraries/NewAppScreen/components/Header.js
+++ b/Libraries/NewAppScreen/components/Header.js
@@ -38,9 +38,8 @@ const styles = StyleSheet.create({
     /*
      * These negative margins allow the image to be offset similarly across screen sizes and component sizes.
      *
-     * The source logo.png image is 512x512px. `marginLeft` of `-128` offsets the image offscreen to the left
-     * by a quarter of the image, while marginBottom of `-192` offsets the image such that the center of the logo
-     * intersects with the bottom of the view.
+     * The source logo.png image is 512x512px, so as such, these margins attempt to be relative to the
+     * source image's size.
      */
     marginLeft: -128,
     marginBottom: -192,

--- a/Libraries/NewAppScreen/components/Header.js
+++ b/Libraries/NewAppScreen/components/Header.js
@@ -11,28 +11,24 @@
 'use strict';
 
 import React from 'react';
-import {View, Text, StyleSheet, ImageBackground} from 'react-native';
+import {Text, StyleSheet, ImageBackground} from 'react-native';
 import Colors from './Colors';
 
 const Header = () => (
-  <View style={styles.container}>
-    <ImageBackground
-      accessibilityRole={'image'}
-      source={require('./logo.png')}
-      style={styles.background}
-      imageStyle={styles.logo}>
-      <Text style={styles.text}>Welcome to React Native</Text>
-    </ImageBackground>
-  </View>
+  <ImageBackground
+    accessibilityRole={'image'}
+    source={require('./logo.png')}
+    style={styles.background}
+    imageStyle={styles.logo}>
+    <Text style={styles.text}>Welcome to React Native</Text>
+  </ImageBackground>
 );
 
 const styles = StyleSheet.create({
-  container: {
-    backgroundColor: Colors.lighter,
-  },
   background: {
     paddingVertical: 40,
     paddingHorizontal: 32,
+    backgroundColor: Colors.lighter,
   },
   logo: {
     opacity: 0.2,

--- a/Libraries/NewAppScreen/components/Header.js
+++ b/Libraries/NewAppScreen/components/Header.js
@@ -19,31 +19,23 @@ const Header = () => (
     <ImageBackground
       accessibilityRole={'image'}
       source={require('./logo.png')}
-      style={styles.backgroundLogo}
-    />
-
-    <Text style={styles.text}>Welcome to React Native</Text>
+      style={styles.background}
+      imageStyle={styles.logo}>
+      <Text style={styles.text}>Welcome to React Native</Text>
+    </ImageBackground>
   </View>
 );
 
 const styles = StyleSheet.create({
   container: {
-    alignItems: 'center',
-    justifyContent: 'center',
-    paddingTop: 100,
-    paddingBottom: 40,
-    paddingHorizontal: 32,
     backgroundColor: Colors.lighter,
   },
-  backgroundLogo: {
-    position: 'absolute',
-    top: -20,
-    left: -200,
+  background: {
+    paddingVertical: 40,
+    paddingHorizontal: 32,
+  },
+  logo: {
     opacity: 0.2,
-    alignItems: 'center',
-    justifyContent: 'center',
-    height: 540,
-    width: 540,
   },
   text: {
     fontSize: 40,

--- a/Libraries/NewAppScreen/components/Header.js
+++ b/Libraries/NewAppScreen/components/Header.js
@@ -32,6 +32,17 @@ const styles = StyleSheet.create({
   },
   logo: {
     opacity: 0.2,
+    overflow: 'visible',
+    resizeMode: 'cover',
+    /*
+     * These negative margins allow the image to be offset similarly across screen sizes and component sizes.
+     *
+     * The source logo.png image is 512x512px. `marginLeft` of `-128` offsets the image offscreen to the left
+     * by a quarter of the image, while marginBottom of `-192` offsets the image such that the center of the logo
+     * intersects with the bottom of the view.
+     */
+    marginLeft: -128,
+    marginBottom: -192,
   },
   text: {
     fontSize: 40,

--- a/Libraries/NewAppScreen/index.js
+++ b/Libraries/NewAppScreen/index.js
@@ -18,7 +18,6 @@ import {
   Text,
   Platform,
   StatusBar,
-  SafeAreaView,
 } from 'react-native';
 
 import Header from './components/Header';
@@ -62,44 +61,39 @@ const DebugInstructions = () => {
 const App = () => {
   return (
     <Fragment>
-      <SafeAreaView style={styles.topSafeArea} />
+      <StatusBar barStyle="dark-content" />
+      <ScrollView contentInsetAdjustmentBehavior="automatic">
+        <Header />
+        <View style={styles.body}>
+          <Section>
+            <Text style={styles.sectionTitle}>Step One</Text>
+            <Text style={styles.sectionDescription}>
+              Edit <Text style={styles.highlight}>App.js</Text> to change this
+              screen and then come back to see your edits.
+            </Text>
+          </Section>
 
-      <SafeAreaView style={styles.bottomSafeArea}>
-        <StatusBar barStyle="dark-content" />
-        <ScrollView>
-          <Header />
-          <View style={styles.body}>
-            <Section>
-              <Text style={styles.sectionTitle}>Step One</Text>
-              <Text style={styles.sectionDescription}>
-                Edit <Text style={styles.highlight}>App.js</Text> to change this
-                screen and then come back to see your edits.
-              </Text>
-            </Section>
+          <Section>
+            <Text style={styles.sectionTitle}>See Your Changes</Text>
+            <Text style={styles.sectionDescription}>
+              <ReloadInstructions />
+            </Text>
+          </Section>
 
-            <Section>
-              <Text style={styles.sectionTitle}>See Your Changes</Text>
-              <Text style={styles.sectionDescription}>
-                <ReloadInstructions />
-              </Text>
-            </Section>
+          <Section>
+            <Text style={styles.sectionTitle}>Debug</Text>
+            <DebugInstructions />
+          </Section>
 
-            <Section>
-              <Text style={styles.sectionTitle}>Debug</Text>
-              <DebugInstructions />
-            </Section>
-
-            <Section>
-              <Text style={styles.sectionTitle}>Learn More</Text>
-              <Text style={styles.sectionDescription}>
-                Read the docs on what to do once seen how to work in React
-                Native.
-              </Text>
-            </Section>
-            <LearnMoreLinks />
-          </View>
-        </ScrollView>
-      </SafeAreaView>
+          <Section>
+            <Text style={styles.sectionTitle}>Learn More</Text>
+            <Text style={styles.sectionDescription}>
+              Read the docs on what to do once seen how to work in React Native.
+            </Text>
+          </Section>
+          <LearnMoreLinks />
+        </View>
+      </ScrollView>
     </Fragment>
   );
 };

--- a/Libraries/NewAppScreen/index.js
+++ b/Libraries/NewAppScreen/index.js
@@ -50,7 +50,7 @@ const DebugInstructions = () => {
       Native debug menu.
     </Text>
   ) : (
-    <Text>
+    <Text style={styles.sectionDescription}>
       Press <Text style={styles.highlight}>menu button</Text> or
       <Text style={styles.highlight}>Shake</Text> your device to open the React
       Native debug menu.
@@ -75,9 +75,7 @@ const App = () => {
 
           <Section>
             <Text style={styles.sectionTitle}>See Your Changes</Text>
-            <Text style={styles.sectionDescription}>
-              <ReloadInstructions />
-            </Text>
+            <ReloadInstructions />
           </Section>
 
           <Section>

--- a/Libraries/NewAppScreen/index.js
+++ b/Libraries/NewAppScreen/index.js
@@ -62,7 +62,9 @@ const App = () => {
   return (
     <Fragment>
       <StatusBar barStyle="dark-content" />
-      <ScrollView contentInsetAdjustmentBehavior="automatic">
+      <ScrollView
+        contentInsetAdjustmentBehavior="automatic"
+        style={styles.scrollView}>
         <Header />
         <View style={styles.body}>
           <Section>
@@ -97,20 +99,15 @@ const App = () => {
 };
 
 const styles = StyleSheet.create({
-  sectionContainer: {
-    marginTop: 32,
-    paddingHorizontal: 24,
-  },
-  topSafeArea: {
-    flex: 0,
+  scrollView: {
     backgroundColor: Colors.lighter,
-  },
-  bottomSafeArea: {
-    flex: 1,
-    backgroundColor: Colors.white,
   },
   body: {
     backgroundColor: Colors.white,
+  },
+  sectionContainer: {
+    marginTop: 32,
+    paddingHorizontal: 24,
   },
   sectionTitle: {
     fontSize: 24,


### PR DESCRIPTION
## Summary

Related to #24760 and #24737

This simplifies some styling within the components used for the New App Screen to help advocate for best practices when styling with CSS-like styles in React Native, as well as using React Native's own unique components.

There's a bit more detail in each commit. Let me know if you'd like me to pull that info out into the PR description here!

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See http://facebook.github.io/react-native/docs/contributing#changelog for an example. -->
[General] [Changed] - Polished up new app screen component styling

## Test Plan

| Device | Before | After |
| --- | --- | --- |
| iPhone Xʀ | ![Simulator Screen Shot - iPhone Xʀ - 2019-05-09 at 14 54 20](https://user-images.githubusercontent.com/1051453/57478996-63531580-726a-11e9-92c0-60c0e6e132ed.png) | ![Simulator Screen Shot - iPhone Xʀ - 2019-05-09 at 14 58 23](https://user-images.githubusercontent.com/1051453/57479253-01df7680-726b-11e9-9dc4-e588c6784604.png) |
| iPhone 5s | ![Simulator Screen Shot - iPhone 5s - 2019-05-09 at 15 01 02](https://user-images.githubusercontent.com/1051453/57481255-b380a680-726f-11e9-8abc-a94241d6807d.png) | ![Simulator Screen Shot - iPhone 5s - 2019-05-09 at 15 00 52](https://user-images.githubusercontent.com/1051453/57481261-b5e30080-726f-11e9-9fdd-1dec358127b3.png) |
| iPad Pro (11-inch) | ![Simulator Screen Shot - iPad Pro (11-inch) - 2019-05-09 at 15 34 26](https://user-images.githubusercontent.com/1051453/57481377-fa6e9c00-726f-11e9-8db0-d46873a57693.png) | ![Simulator Screen Shot - iPad Pro (11-inch) - 2019-05-09 at 15 34 14](https://user-images.githubusercontent.com/1051453/57481383-fe022300-726f-11e9-8d54-664792ba06a4.png) |