### PR TITLE
[CI][test_end_to_end] Partially back out #24506, fixing iOS e2e tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -499,12 +499,22 @@ jobs:
 
       - run:
           name: Run JavaScript End-to-End Tests
-          command: node ./scripts/run-ci-e2e-tests.js --js --retries 3
+          command: |
+            # free up port 8081 for the packager before running tests
+            set +eo pipefail
+            lsof -i tcp:8081 | awk 'NR!=1 {print $2}' | xargs kill
+            set -eo pipefail
+            node ./scripts/run-ci-e2e-tests.js --js --retries 3
           when: always
 
       - run:
           name: Run iOS End-to-End Tests
-          command: node ./scripts/run-ci-e2e-tests.js --ios --retries 3;
+          command: |
+            # free up port 8081 for the packager before running tests
+            set +eo pipefail
+            lsof -i tcp:8081 | awk 'NR!=1 {print $2}' | xargs kill
+            set -eo pipefail
+            node ./scripts/run-ci-e2e-tests.js --ios --retries 3;
           when: always
 
 

--- a/template/ios/Podfile
+++ b/template/ios/Podfile
@@ -1,5 +1,4 @@
 platform :ios, '9.0'
-require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'
 
 target 'HelloWorld' do
   # Pods for HelloWorld
@@ -33,7 +32,6 @@ target 'HelloWorld' do
     # Pods for testing
   end
 
-  use_native_modules!
 end
 
 target 'HelloWorld-tvOS' do


### PR DESCRIPTION
## Summary

The iOS End-to-End tests started failing with the updates made to the iOS template's Podfile in https://github.com/facebook/react-native/commit/261197d85705dad1a362cc4637aa308c0382dcbe. Undoing these gets our CI iOS e2e test step back to green.

## Changelog

[iOS] [Removed] - Revert auto-linking related changes to the iOS template Podfile

## Test Plan

`test_end_to_end` is still red, but the individual "iOS End-to-End" step is now green: https://circleci.com/gh/hramos/react-native/5659
