### PR TITLE
Add `Platform.nightMode` for Android

### DIFF
--- a/Libraries/Utilities/Platform.android.js
+++ b/Libraries/Utilities/Platform.android.js
@@ -16,6 +16,7 @@ export type PlatformSelectSpec<A, D> = {
   android?: A,
   default?: D,
 };
+export type NightMode = "yes" | "no" | "auto" | "unknown" | false;
 
 const Platform = {
   OS: 'android',
@@ -33,6 +34,10 @@ const Platform = {
   get isTV(): boolean {
     const constants = NativeModules.PlatformConstants;
     return constants && constants.uiMode === 'tv';
+  },
+  get nightMode(): NightMode {
+    const constants = NativeModules.PlatformConstants;
+    return constants && constants.nightMode;
   },
   select: <A, D>(spec: PlatformSelectSpec<A, D>): A | D =>
     'android' in spec ? spec.android : spec.default,

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/systeminfo/AndroidInfoModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/systeminfo/AndroidInfoModule.java
@@ -60,6 +60,20 @@ public class AndroidInfoModule extends ReactContextBaseJavaModule {
     }
   }
 
+  private String nightMode() {
+    UiModeManager uiModeManager = (UiModeManager) getReactApplicationContext().getSystemService(UI_MODE_SERVICE);
+    switch (uiModeManager.getNightMode()) {
+      case UiModeManager.MODE_NIGHT_NO:
+        return "no";
+      case UiModeManager.MODE_NIGHT_YES:
+        return "yes";
+      case UiModeManager.MODE_NIGHT_AUTO:
+        return "auto";
+      default:
+        return "unknown";
+    }
+  }
+
   @Override
   public String getName() {
     return "PlatformConstants";
@@ -80,6 +94,7 @@ public class AndroidInfoModule extends ReactContextBaseJavaModule {
     || isRunningScreenshotTest());
     constants.put("reactNativeVersion", ReactNativeVersion.VERSION);
     constants.put("uiMode", uiMode());
+    constants.put("nightMode", nightMode());
     return constants;
   }
 


### PR DESCRIPTION
## Summary

Android Q is raising Dark Mode to prominence across the ecosystem. One of the expectations is to be able to respond to the system-wide dark theme setting. I've followed their documentation, added the flag to the InfoModule, and then presented this value to the RN user space via an Android-specific Platform value `nightMode`. There are rumors that similar functionality may come soon for iOS, and we may want to consider refactoring the JS side at that point for consistency between the two platforms.

## Changelog

[Android] [Added] - Add ability to check what system preference is set for dark mode

## Test Plan

I added `Platform.nightMode` to a sample app and saw it get "yes" and "no" based off of whether I'd selected light theme or dark theme on the Q beta.
