### PR TITLE
Fix PickerAndroid will reset selected value during items update.

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/picker/ReactPicker.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/picker/ReactPicker.java
@@ -13,6 +13,7 @@ import android.util.AttributeSet;
 import android.view.View;
 import android.widget.AdapterView;
 import android.widget.Spinner;
+import android.widget.SpinnerAdapter;
 
 import com.facebook.react.common.annotations.VisibleForTesting;
 
@@ -23,6 +24,7 @@ public class ReactPicker extends AppCompatSpinner {
   private int mMode = Spinner.MODE_DIALOG;
   private @Nullable Integer mPrimaryColor;
   private @Nullable OnSelectListener mOnSelectListener;
+  private @Nullable SpinnerAdapter mStagedAdapter;
   private @Nullable Integer mStagedSelection;
 
   private final OnItemSelectedListener mItemSelectedListener = new OnItemSelectedListener() {
@@ -111,33 +113,42 @@ public class ReactPicker extends AppCompatSpinner {
     return mOnSelectListener;
   }
 
+  /* package */ void setStagedAdapter(final SpinnerAdapter adapter) {
+   mStagedAdapter = adapter;
+  }
+
   /**
-   * Will cache "selection" value locally and set it only once {@link #updateStagedSelection} is
+   * Will cache "selection" value locally and set it only once {@link #commitStagedData} is
    * called
    */
-  public void setStagedSelection(int selection) {
+  /* package */ void setStagedSelection(int selection) {
     mStagedSelection = selection;
   }
 
-  public void updateStagedSelection() {
-    if (mStagedSelection != null) {
-      setSelectionWithSuppressEvent(mStagedSelection);
+  /**
+   * Used to commit staged data into ReactPicker view.
+   * During this period, we will disable {@link OnSelectListener#onItemSelected(int)} temporarily,
+   * so we don't get an event when changing the items/selection ourselves.
+   */
+  /* package */ void commitStagedData() {
+    setOnItemSelectedListener(null);
+
+    final int origSelection = getSelectedItemPosition();
+    if (mStagedAdapter != null && mStagedAdapter != getAdapter()) {
+      setAdapter(mStagedAdapter);
+      // After setAdapter(), Spinner will reset selection and cause unnecessary onValueChange event.
+      // Explicitly setup selection again to prevent this.
+      // Ref: https://android.googlesource.com/platform/frameworks/base/+/master/core/java/android/widget/AbsSpinner.java#123
+      setSelection(origSelection, false);
+      mStagedAdapter = null;
+    }
+
+    if (mStagedSelection != null && mStagedSelection != origSelection) {
+      setSelection(mStagedSelection, false);
       mStagedSelection = null;
     }
-  }
 
-  /**
-   * Set the selection while suppressing the follow-up {@link OnSelectListener#onItemSelected(int)}
-   * event. This is used so we don't get an event when changing the selection ourselves.
-   *
-   * @param position the position of the selected item
-   */
-  private void setSelectionWithSuppressEvent(int position) {
-    if (position != getSelectedItemPosition()) {
-      setOnItemSelectedListener(null);
-      setSelection(position, false);
-      setOnItemSelectedListener(mItemSelectedListener);
-    }
+    setOnItemSelectedListener(mItemSelectedListener);
   }
 
   public @Nullable Integer getPrimaryColor() {

--- a/ReactAndroid/src/main/java/com/facebook/react/views/picker/ReactPickerManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/picker/ReactPickerManager.java
@@ -44,9 +44,9 @@ public abstract class ReactPickerManager extends SimpleViewManager<ReactPicker> 
       }
       ReactPickerAdapter adapter = new ReactPickerAdapter(view.getContext(), data);
       adapter.setPrimaryTextColor(view.getPrimaryColor());
-      view.setAdapter(adapter);
+      view.setStagedAdapter(adapter);
     } else {
-      view.setAdapter(null);
+      view.setStagedAdapter(null);
     }
   }
 
@@ -77,7 +77,7 @@ public abstract class ReactPickerManager extends SimpleViewManager<ReactPicker> 
   @Override
   protected void onAfterUpdateTransaction(ReactPicker view) {
     super.onAfterUpdateTransaction(view);
-    view.updateStagedSelection();
+    view.commitStagedData();
   }
 
   @Override


### PR DESCRIPTION
## Summary
Fixes #13351

Two root causes:
1. Android Spinner will reset selection to undefined after setAdapter()
   which will trigger onValueChange().
   The behavior is not expected for RN.
   And the solution is to setSelection() explicitly

2. In original implementation, it setups `items` immediately,
   but delays the `selected` setup after update transaction.
   There will be some race condition and incosistency
   if update `items` only.
   The fix will do the setup all after update transaction.

## Changelog

[Android] [Fixed] - Fix #13351 PickerAndroid will reset selected value during items update.

## Test Plan

1. Test the test case as @stochris [reported](https://github.com/facebook/react-native/issues/13351#issue-219980433) in https://snack.expo.io/Sy1JClEag.
2. Test RNTester Picker sample