### PR TITLE
[iOS] Fixes renderingMode not applied to GIF images

### DIFF
--- a/Libraries/Image/RCTImageView.m
+++ b/Libraries/Image/RCTImageView.m
@@ -363,10 +363,16 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithFrame:(CGRect)frame)
       self->_pendingImageSource = nil;
     }
 
+    [self->_imageView.layer removeAnimationForKey:@"contents"];
     if (image.reactKeyframeAnimation) {
+      CGImageRef posterImageRef = (__bridge CGImageRef)[image.reactKeyframeAnimation.values firstObject];
+      if (!posterImageRef) {
+        return;
+      }
+      // Apply renderingMode to animated image.
+      self->_imageView.image = [[UIImage imageWithCGImage:posterImageRef] imageWithRenderingMode:self->_renderingMode];
       [self->_imageView.layer addAnimation:image.reactKeyframeAnimation forKey:@"contents"];
     } else {
-      [self->_imageView.layer removeAnimationForKey:@"contents"];
       self.image = image;
     }
 


### PR DESCRIPTION
## Summary

Bugs like https://github.com/facebook/react-native/issues/24789, we don't apply tintColor to GIF. We fixes it by setting a poster image before add animation.

cc. @cpojer .

## Changelog

[iOS] [Fixed] - Fixes renderingMode not applied to GIF images

## Test Plan

```
        <Image
              source={require('./test_tintColor.gif')}
              style={[styles.icon, {tintColor: 'blue'}]}
            />
```

Original gif:
![test_tintColor](https://user-images.githubusercontent.com/5061845/57513704-74228a80-7341-11e9-9209-aabe48384ad8.gif)

apply tintColor:
![2019-05-10 16_35_45](https://user-images.githubusercontent.com/5061845/57513829-c06dca80-7341-11e9-9e46-10a1d7a114fe.gif)
