### PR TITLE
Declare a dependency on scheduler

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,6 +134,7 @@
     "prettier": "1.17.0",
     "react": "16.8.6",
     "react-test-renderer": "16.8.6",
+    "scheduler": "0.14.0",
     "shelljs": "^0.7.8",
     "ws": "^6.1.4",
     "yargs": "^9.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6480,6 +6480,14 @@ sax@~1.1.1:
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.1.6.tgz#5d616be8a5e607d54e114afae55b7eaf2fcc3240"
   integrity sha1-XWFr6KXmB9VOEUr65Vt+ry/MMkA=
 
+scheduler@0.14.0:
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.14.0.tgz#b392c23c9c14bfa2933d4740ad5603cc0d59ea5b"
+  integrity sha512-9CgbS06Kki2f4R9FjLSITjZo5BZxPsryiRNyL3LpvrM9WxcVmhlqAOc9E+KQbeI2nqej4JIIbOsfdL51cNb4Iw==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+
 scheduler@^0.13.6:
   version "0.13.6"
   resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.13.6.tgz#466a4ec332467b31a91b9bf74e5347072e4cd889"


### PR DESCRIPTION
ReactNativeRenderer has `require('scheduler')` in it but we don't seem to declare a dependency. As a result, the latest sync broke `useEffect` in open source master:

```js
function Counter() {
  const [count, setCount] = useState(0);
  useEffect(() => {
    const id = setInterval(() => {
      setCount(c => c + 1);
    }, 1000)
    return () => clearInterval(id);
  }, [])
  return <View><Text>{count}</Text></View>
}
```

<img width="535" alt="Screen Shot 2019-05-10 at 3 26 05 PM" src="https://user-images.githubusercontent.com/810438/57535832-e04dc000-733a-11e9-8e3e-d685171ec55a.png">

This adds an explicit dependency on the same version we're currently using internally.

<img width="535" alt="Screen Shot 2019-05-10 at 3 47 42 PM" src="https://user-images.githubusercontent.com/810438/57535886-f65b8080-733a-11e9-82c3-78e6c3a3888b.png">
