### PR TITLE
Replace new app template with new app screen

### DIFF
--- a/Libraries/NewAppScreen/components/DebugInstructions.js
+++ b/Libraries/NewAppScreen/components/DebugInstructions.js
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ */
+
+import React from 'react';
+import {Platform, StyleSheet, Text} from 'react-native';
+
+const styles = StyleSheet.create({
+  highlight: {
+    fontWeight: '700',
+  },
+});
+
+const DebugInstructions = Platform.select({
+  ios: () => (
+    <Text>
+      Press <Text style={styles.highlight}>Cmd+D</Text> in the simulator or{' '}
+      <Text style={styles.highlight}>Shake</Text> your device to open the React
+      Native debug menu.
+    </Text>
+  ),
+  default: () => (
+    <Text>
+      Press <Text style={styles.highlight}>menu button</Text> or
+      <Text style={styles.highlight}>Shake</Text> your device to open the React
+      Native debug menu.
+    </Text>
+  ),
+});
+
+export default DebugInstructions;

--- a/Libraries/NewAppScreen/components/ReloadInstructions.js
+++ b/Libraries/NewAppScreen/components/ReloadInstructions.js
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ */
+
+import React from 'react';
+import {Platform, StyleSheet, Text} from 'react-native';
+
+const styles = StyleSheet.create({
+  highlight: {
+    fontWeight: '700',
+  },
+});
+
+const ReloadInstructions = Platform.select({
+  ios: () => (
+    <Text>
+      Press <Text style={styles.highlight}>Cmd+R</Text> in the simulator to
+      reload your app's code
+    </Text>
+  ),
+  default: () => (
+    <Text>
+      Double tap <Text style={styles.highlight}>R</Text> on your keyboard to
+      reload your app's code
+    </Text>
+  ),
+});
+
+export default ReloadInstructions;

--- a/Libraries/NewAppScreen/index.js
+++ b/Libraries/NewAppScreen/index.js
@@ -10,88 +10,10 @@
 
 'use strict';
 
-import React, {Fragment} from 'react';
-import {StyleSheet, ScrollView, View, Text, StatusBar} from 'react-native';
-
 import Header from './components/Header';
 import LearnMoreLinks from './components/LearnMoreLinks';
 import Colors from './components/Colors';
 import DebugInstructions from './components/DebugInstructions';
 import ReloadInstructions from './components/ReloadInstructions';
 
-const Section = ({children}) => (
-  <View style={styles.sectionContainer}>{children}</View>
-);
-
-const App = () => {
-  return (
-    <Fragment>
-      <StatusBar barStyle="dark-content" />
-      <ScrollView
-        contentInsetAdjustmentBehavior="automatic"
-        style={styles.scrollView}>
-        <Header />
-        <View style={styles.body}>
-          <Section>
-            <Text style={styles.sectionTitle}>Step One</Text>
-            <Text style={styles.sectionDescription}>
-              Edit <Text style={styles.highlight}>App.js</Text> to change this
-              screen and then come back to see your edits.
-            </Text>
-          </Section>
-
-          <Section>
-            <Text style={styles.sectionTitle}>See Your Changes</Text>
-            <Text style={styles.sectionDescription}>
-              <ReloadInstructions />
-            </Text>
-          </Section>
-
-          <Section>
-            <Text style={styles.sectionTitle}>Debug</Text>
-            <Text style={styles.sectionDescription}>
-              <DebugInstructions />
-            </Text>
-          </Section>
-
-          <Section>
-            <Text style={styles.sectionTitle}>Learn More</Text>
-            <Text style={styles.sectionDescription}>
-              Read the docs on what to do once seen how to work in React Native.
-            </Text>
-          </Section>
-          <LearnMoreLinks />
-        </View>
-      </ScrollView>
-    </Fragment>
-  );
-};
-
-const styles = StyleSheet.create({
-  scrollView: {
-    backgroundColor: Colors.lighter,
-  },
-  body: {
-    backgroundColor: Colors.white,
-  },
-  sectionContainer: {
-    marginTop: 32,
-    paddingHorizontal: 24,
-  },
-  sectionTitle: {
-    fontSize: 24,
-    fontWeight: '600',
-    color: Colors.black,
-  },
-  sectionDescription: {
-    marginTop: 8,
-    fontSize: 18,
-    fontWeight: '400',
-    color: Colors.dark,
-  },
-  highlight: {
-    fontWeight: '700',
-  },
-});
-
-export default App;
+export {Header, LearnMoreLinks, Colors, DebugInstructions, ReloadInstructions};

--- a/Libraries/NewAppScreen/index.js
+++ b/Libraries/NewAppScreen/index.js
@@ -11,52 +11,17 @@
 'use strict';
 
 import React, {Fragment} from 'react';
-import {
-  StyleSheet,
-  ScrollView,
-  View,
-  Text,
-  Platform,
-  StatusBar,
-} from 'react-native';
+import {StyleSheet, ScrollView, View, Text, StatusBar} from 'react-native';
 
 import Header from './components/Header';
 import LearnMoreLinks from './components/LearnMoreLinks';
 import Colors from './components/Colors';
+import DebugInstructions from './components/DebugInstructions';
+import ReloadInstructions from './components/ReloadInstructions';
 
 const Section = ({children}) => (
   <View style={styles.sectionContainer}>{children}</View>
 );
-
-const ReloadInstructions = () => {
-  return Platform.OS === 'ios' ? (
-    <Text style={styles.sectionDescription}>
-      Press <Text style={styles.highlight}>Cmd+R</Text> in the simulator to
-      reload your app's code
-    </Text>
-  ) : (
-    <Text style={styles.sectionDescription}>
-      Double tap <Text style={styles.highlight}>R</Text> on your keyboard to
-      reload your app's code
-    </Text>
-  );
-};
-
-const DebugInstructions = () => {
-  return Platform.OS === 'ios' ? (
-    <Text style={styles.sectionDescription}>
-      Press <Text style={styles.highlight}>Cmd+D</Text> in the simulator or{' '}
-      <Text style={styles.highlight}>Shake</Text> your device to open the React
-      Native debug menu.
-    </Text>
-  ) : (
-    <Text style={styles.sectionDescription}>
-      Press <Text style={styles.highlight}>menu button</Text> or
-      <Text style={styles.highlight}>Shake</Text> your device to open the React
-      Native debug menu.
-    </Text>
-  );
-};
 
 const App = () => {
   return (
@@ -77,12 +42,16 @@ const App = () => {
 
           <Section>
             <Text style={styles.sectionTitle}>See Your Changes</Text>
-            <ReloadInstructions />
+            <Text style={styles.sectionDescription}>
+              <ReloadInstructions />
+            </Text>
           </Section>
 
           <Section>
             <Text style={styles.sectionTitle}>Debug</Text>
-            <DebugInstructions />
+            <Text style={styles.sectionDescription}>
+              <DebugInstructions />
+            </Text>
           </Section>
 
           <Section>

--- a/RNTester/js/NewAppScreenExample.js
+++ b/RNTester/js/NewAppScreenExample.js
@@ -11,16 +11,66 @@
 'use strict';
 
 const React = require('react');
-const NewAppScreen = require('../../Libraries/NewAppScreen').default;
+const {View} = require('react-native');
+const {
+  Header,
+  LearnMoreLinks,
+  Colors,
+  DebugInstructions,
+  ReloadInstructions,
+} = require('../../Libraries/NewAppScreen');
 
 exports.title = 'New App Screen';
 exports.description = 'Displays the content of the new app screen';
 exports.examples = [
   {
-    title: 'New App Screen',
-    description: 'Displays the content of the new app screen',
+    title: 'New App Screen Header',
+    description: 'Displays a welcome to building a React Native app',
     render(): React.Element<any> {
-      return <NewAppScreen />;
+      return (
+        <View style={{overflow: 'hidden'}}>
+          <Header />
+        </View>
+      );
+    },
+  },
+  {
+    title: 'Learn More Links',
+    description:
+      'Learn more about the tools and techniques for building React Native apps.',
+    render(): React.Element<any> {
+      return <LearnMoreLinks />;
+    },
+  },
+  {
+    title: 'New App Screen Colors',
+    description: 'Consistent colors to use throughout the new app screen.',
+    render(): React.Element<any> {
+      return (
+        <View style={{flexDirection: 'row'}}>
+          {Object.keys(Colors).map(key => (
+            <View
+              style={{width: 50, height: 50, backgroundColor: Colors[key]}}
+            />
+          ))}
+        </View>
+      );
+    },
+  },
+  {
+    title: 'Debug Instructions',
+    description:
+      'Platform-specific instructions on how to start debugging a React Native app.',
+    render(): React.Element<any> {
+      return <DebugInstructions />;
+    },
+  },
+  {
+    title: 'Reload Instructions',
+    description:
+      'Platform-specific instructions on how to reload a React Native app.',
+    render(): React.Element<any> {
+      return <ReloadInstructions />;
     },
   },
 ];

--- a/template/App.js
+++ b/template/App.js
@@ -15,10 +15,6 @@ import Colors from 'react-native/Libraries/NewAppScreen/components/Colors';
 import DebugInstructions from 'react-native/Libraries/NewAppScreen/components/DebugInstructions';
 import ReloadInstructions from 'react-native/Libraries/NewAppScreen/components/ReloadInstructions';
 
-const Section = ({children}) => (
-  <View style={styles.sectionContainer}>{children}</View>
-);
-
 const App = () => {
   return (
     <Fragment>
@@ -28,31 +24,31 @@ const App = () => {
         style={styles.scrollView}>
         <Header />
         <View style={styles.body}>
-          <Section>
+          <View style={styles.sectionContainer}>
             <Text style={styles.sectionTitle}>Step One</Text>
             <Text style={styles.sectionDescription}>
               Edit <Text style={styles.highlight}>App.js</Text> to change this
               screen and then come back to see your edits.
             </Text>
-          </Section>
-          <Section>
+          </View>
+          <View style={styles.sectionContainer}>
             <Text style={styles.sectionTitle}>See Your Changes</Text>
             <Text style={styles.sectionDescription}>
               <ReloadInstructions />
             </Text>
-          </Section>
-          <Section>
+          </View>
+          <View style={styles.sectionContainer}>
             <Text style={styles.sectionTitle}>Debug</Text>
             <Text style={styles.sectionDescription}>
               <DebugInstructions />
             </Text>
-          </Section>
-          <Section>
+          </View>
+          <View style={styles.sectionContainer}>
             <Text style={styles.sectionTitle}>Learn More</Text>
             <Text style={styles.sectionDescription}>
               Read the docs on what to do once seen how to work in React Native.
             </Text>
-          </Section>
+          </View>
           <LearnMoreLinks />
         </View>
       </ScrollView>

--- a/template/App.js
+++ b/template/App.js
@@ -6,44 +6,116 @@
  * @flow
  */
 
-import React, {Component} from 'react';
-import {Platform, StyleSheet, Text, View} from 'react-native';
+import React, {Fragment} from 'react';
+import {
+  StyleSheet,
+  ScrollView,
+  View,
+  Text,
+  Platform,
+  StatusBar,
+} from 'react-native';
 
-const instructions = Platform.select({
-  ios: 'Press Cmd+R to reload,\n' + 'Cmd+D or shake for dev menu',
-  android:
-    'Double tap R on your keyboard to reload,\n' +
-    'Shake or press menu button for dev menu',
-});
+import Header from 'react-native/Libraries/NewAppScreen/components/Header';
+import LearnMoreLinks from 'react-native/Libraries/NewAppScreen/components/LearnMoreLinks';
+import Colors from 'react-native/Libraries/NewAppScreen/components/Colors';
 
-type Props = {};
-export default class App extends Component<Props> {
-  render() {
-    return (
-      <View style={styles.container}>
-        <Text style={styles.welcome}>Welcome to React Native!</Text>
-        <Text style={styles.instructions}>To get started, edit App.js</Text>
-        <Text style={styles.instructions}>{instructions}</Text>
-      </View>
-    );
-  }
-}
+const Section = ({children}) => (
+  <View style={styles.sectionContainer}>{children}</View>
+);
+
+const ReloadInstructions = () => {
+  return Platform.OS === 'ios' ? (
+    <Text style={styles.sectionDescription}>
+      Press <Text style={styles.highlight}>Cmd+R</Text> in the simulator to
+      reload your app's code
+    </Text>
+  ) : (
+    <Text style={styles.sectionDescription}>
+      Double tap <Text style={styles.highlight}>R</Text> on your keyboard to
+      reload your app's code
+    </Text>
+  );
+};
+
+const DebugInstructions = () => {
+  return Platform.OS === 'ios' ? (
+    <Text style={styles.sectionDescription}>
+      Press <Text style={styles.highlight}>Cmd+D</Text> in the simulator or{' '}
+      <Text style={styles.highlight}>Shake</Text> your device to open the React
+      Native debug menu.
+    </Text>
+  ) : (
+    <Text style={styles.sectionDescription}>
+      Press <Text style={styles.highlight}>menu button</Text> or
+      <Text style={styles.highlight}>Shake</Text> your device to open the React
+      Native debug menu.
+    </Text>
+  );
+};
+
+const App = () => {
+  return (
+    <Fragment>
+      <StatusBar barStyle="dark-content" />
+      <ScrollView
+        contentInsetAdjustmentBehavior="automatic"
+        style={styles.scrollView}>
+        <Header />
+        <View style={styles.body}>
+          <Section>
+            <Text style={styles.sectionTitle}>Step One</Text>
+            <Text style={styles.sectionDescription}>
+              Edit <Text style={styles.highlight}>App.js</Text> to change this
+              screen and then come back to see your edits.
+            </Text>
+          </Section>
+          <Section>
+            <Text style={styles.sectionTitle}>See Your Changes</Text>
+            <ReloadInstructions />
+          </Section>
+          <Section>
+            <Text style={styles.sectionTitle}>Debug</Text>
+            <DebugInstructions />
+          </Section>
+          <Section>
+            <Text style={styles.sectionTitle}>Learn More</Text>
+            <Text style={styles.sectionDescription}>
+              Read the docs on what to do once seen how to work in React Native.
+            </Text>
+          </Section>
+          <LearnMoreLinks />
+        </View>
+      </ScrollView>
+    </Fragment>
+  );
+};
 
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-    backgroundColor: '#F5FCFF',
+  scrollView: {
+    backgroundColor: Colors.lighter,
   },
-  welcome: {
-    fontSize: 20,
-    textAlign: 'center',
-    margin: 10,
+  body: {
+    backgroundColor: Colors.white,
   },
-  instructions: {
-    textAlign: 'center',
-    color: '#333333',
-    marginBottom: 5,
+  sectionContainer: {
+    marginTop: 32,
+    paddingHorizontal: 24,
+  },
+  sectionTitle: {
+    fontSize: 24,
+    fontWeight: '600',
+    color: Colors.black,
+  },
+  sectionDescription: {
+    marginTop: 8,
+    fontSize: 18,
+    fontWeight: '400',
+    color: Colors.dark,
+  },
+  highlight: {
+    fontWeight: '700',
   },
 });
+
+export default App;

--- a/template/App.js
+++ b/template/App.js
@@ -7,52 +7,17 @@
  */
 
 import React, {Fragment} from 'react';
-import {
-  StyleSheet,
-  ScrollView,
-  View,
-  Text,
-  Platform,
-  StatusBar,
-} from 'react-native';
+import {StyleSheet, ScrollView, View, Text, StatusBar} from 'react-native';
 
 import Header from 'react-native/Libraries/NewAppScreen/components/Header';
 import LearnMoreLinks from 'react-native/Libraries/NewAppScreen/components/LearnMoreLinks';
 import Colors from 'react-native/Libraries/NewAppScreen/components/Colors';
+import DebugInstructions from 'react-native/Libraries/NewAppScreen/components/DebugInstructions';
+import ReloadInstructions from 'react-native/Libraries/NewAppScreen/components/ReloadInstructions';
 
 const Section = ({children}) => (
   <View style={styles.sectionContainer}>{children}</View>
 );
-
-const ReloadInstructions = () => {
-  return Platform.OS === 'ios' ? (
-    <Text style={styles.sectionDescription}>
-      Press <Text style={styles.highlight}>Cmd+R</Text> in the simulator to
-      reload your app's code
-    </Text>
-  ) : (
-    <Text style={styles.sectionDescription}>
-      Double tap <Text style={styles.highlight}>R</Text> on your keyboard to
-      reload your app's code
-    </Text>
-  );
-};
-
-const DebugInstructions = () => {
-  return Platform.OS === 'ios' ? (
-    <Text style={styles.sectionDescription}>
-      Press <Text style={styles.highlight}>Cmd+D</Text> in the simulator or{' '}
-      <Text style={styles.highlight}>Shake</Text> your device to open the React
-      Native debug menu.
-    </Text>
-  ) : (
-    <Text style={styles.sectionDescription}>
-      Press <Text style={styles.highlight}>menu button</Text> or
-      <Text style={styles.highlight}>Shake</Text> your device to open the React
-      Native debug menu.
-    </Text>
-  );
-};
 
 const App = () => {
   return (
@@ -72,11 +37,15 @@ const App = () => {
           </Section>
           <Section>
             <Text style={styles.sectionTitle}>See Your Changes</Text>
-            <ReloadInstructions />
+            <Text style={styles.sectionDescription}>
+              <ReloadInstructions />
+            </Text>
           </Section>
           <Section>
             <Text style={styles.sectionTitle}>Debug</Text>
-            <DebugInstructions />
+            <Text style={styles.sectionDescription}>
+              <DebugInstructions />
+            </Text>
           </Section>
           <Section>
             <Text style={styles.sectionTitle}>Learn More</Text>

--- a/template/App.js
+++ b/template/App.js
@@ -9,11 +9,13 @@
 import React, {Fragment} from 'react';
 import {StyleSheet, ScrollView, View, Text, StatusBar} from 'react-native';
 
-import Header from 'react-native/Libraries/NewAppScreen/components/Header';
-import LearnMoreLinks from 'react-native/Libraries/NewAppScreen/components/LearnMoreLinks';
-import Colors from 'react-native/Libraries/NewAppScreen/components/Colors';
-import DebugInstructions from 'react-native/Libraries/NewAppScreen/components/DebugInstructions';
-import ReloadInstructions from 'react-native/Libraries/NewAppScreen/components/ReloadInstructions';
+import {
+  Header,
+  LearnMoreLinks,
+  Colors,
+  DebugInstructions,
+  ReloadInstructions,
+} from 'react-native/Libraries/NewAppScreen';
 
 const App = () => {
   return (


### PR DESCRIPTION
## Summary

This replaces the "new app screen" in the template with the new design from https://github.com/react-native-community/discussions-and-proposals/issues/122

This uses components that are shipped as part of the `react-native` module, but not necessarily as proper components exported by the main `react-native` module. To use these, we use absolute imports to those components.

Related to #24760

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See http://facebook.github.io/react-native/docs/contributing#changelog for an example. -->

[General] [Changed] - Updated new app template design 💖

## Test Plan

1. Checkout this pull request (`git fetch origin pull/ID/head:BRANCHNAME && git checkout BRANCHNAME`, see also: https://help.github.com/en/articles/checking-out-pull-requests-locally).
1. Change the `react-nativ`e field in `react-native/template/package.json` to the absolute path of the react native repo, for example: `"react-native": "file:///Users/username/react-native"`.
1. Run `npx @react-native-community/cli@next init TestApp --template file:///Users/username/react-native` (If you don't have `npx`, run `brew install npm`).
1. Note that a new app built with this template looks like the designs from https://github.com/react-native-community/discussions-and-proposals/issues/122 !

<img width="528" alt="Screen Shot 2019-05-10 at 12 29 25 PM" src="https://user-images.githubusercontent.com/1051453/57543264-e4b9af00-7321-11e9-9bdf-946958d08a6b.png">
