### PR TITLE
Add Follow us on Twitter link to new app screen

### DIFF
--- a/Libraries/NewAppScreen/components/LearnMoreLinks.js
+++ b/Libraries/NewAppScreen/components/LearnMoreLinks.js
@@ -54,6 +54,12 @@ const links = [
     description:
       'Need more help? There are many other React Native developers who may have the answer.',
   },
+  {
+    title: 'Follow us on Twitter',
+    link: 'https://twitter.com/reactnative',
+    description:
+      'Stay in touch with the community, join in on Q&As and more by following React Native on Twitter.',
+  },
 ];
 
 const LinkList = () => (


### PR DESCRIPTION
## Summary

This adds in a link to the @reactnative Twitter handle so our users can follow along with the latest and greatest of React Native!

Related to #24760

## Changelog

[General] [Added] - Added link to @reactnative Twitter handle to Learn More section

## Test Plan

1. Fire up RNTester
1. Navigate to the `NewAppScreen`
1. Scroll to "Follow us on Twitter" link
1. Tap touchable and verify that `https://twitter.com/reactnative` is opened