### PR TITLE
[standards] Migrate vendored code from Haste to path-based imports

### DIFF
--- a/Libraries/vendor/core/Map.js
+++ b/Libraries/vendor/core/Map.js
@@ -13,9 +13,9 @@
 
 'use strict';
 
-const _shouldPolyfillES6Collection = require('_shouldPolyfillES6Collection');
-const guid = require('guid');
-const toIterator = require('toIterator');
+const _shouldPolyfillES6Collection = require('./_shouldPolyfillES6Collection');
+const guid = require('./guid');
+const toIterator = require('./toIterator');
 
 module.exports = (function(global, undefined) {
   // Since our implementation is spec-compliant for the most part we can safely

--- a/Libraries/vendor/core/Set.js
+++ b/Libraries/vendor/core/Set.js
@@ -13,10 +13,10 @@
 
 'use strict';
 
-const Map = require('Map');
+const Map = require('./Map');
 
-const _shouldPolyfillES6Collection = require('_shouldPolyfillES6Collection');
-const toIterator = require('toIterator');
+const _shouldPolyfillES6Collection = require('./_shouldPolyfillES6Collection');
+const toIterator = require('./toIterator');
 
 module.exports = (function(global) {
   // Since our implementation is spec-compliant for the most part we can safely

--- a/Libraries/vendor/core/merge.js
+++ b/Libraries/vendor/core/merge.js
@@ -7,7 +7,7 @@
 
 "use strict";
 
-const mergeInto = require('mergeInto');
+const mergeInto = require('./mergeInto');
 
 /**
  * Shallow merges two structures into a return value, without mutating either.

--- a/Libraries/vendor/core/mergeInto.js
+++ b/Libraries/vendor/core/mergeInto.js
@@ -7,7 +7,7 @@
 
 "use strict";
 
-var mergeHelpers = require('mergeHelpers');
+var mergeHelpers = require('./mergeHelpers');
 
 var checkMergeObjectArg = mergeHelpers.checkMergeObjectArg;
 var checkMergeIntoObjectArg = mergeHelpers.checkMergeIntoObjectArg;

--- a/Libraries/vendor/document/selection/DocumentSelectionState.js
+++ b/Libraries/vendor/document/selection/DocumentSelectionState.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const mixInEventEmitter = require('mixInEventEmitter');
+const mixInEventEmitter = require('../../emitter/mixInEventEmitter');
 
 /**
  * DocumentSelectionState is responsible for maintaining selection information

--- a/Libraries/vendor/emitter/EmitterSubscription.js
+++ b/Libraries/vendor/emitter/EmitterSubscription.js
@@ -10,10 +10,10 @@
 
 'use strict';
 
-const EventSubscription = require('EventSubscription');
+const EventSubscription = require('./EventSubscription');
 
-import type EventEmitter from 'EventEmitter';
-import type EventSubscriptionVendor from 'EventSubscriptionVendor';
+import type EventEmitter from './EventEmitter';
+import type EventSubscriptionVendor from './EventSubscriptionVendor';
 
 /**
  * EmitterSubscription represents a subscription with listener and context data.

--- a/Libraries/vendor/emitter/EventEmitter.js
+++ b/Libraries/vendor/emitter/EventEmitter.js
@@ -11,8 +11,8 @@
 
 'use strict';
 
-const EmitterSubscription = require('EmitterSubscription');
-const EventSubscriptionVendor = require('EventSubscriptionVendor');
+const EmitterSubscription = require('./EmitterSubscription');
+const EventSubscriptionVendor = require('./EventSubscriptionVendor');
 
 const invariant = require('invariant');
 

--- a/Libraries/vendor/emitter/EventEmitterWithHolding.js
+++ b/Libraries/vendor/emitter/EventEmitterWithHolding.js
@@ -10,9 +10,9 @@
 
 'use strict';
 
-import type EmitterSubscription from 'EmitterSubscription';
-import type EventEmitter from 'EventEmitter';
-import type EventHolder from 'EventHolder';
+import type EmitterSubscription from './EmitterSubscription';
+import type EventEmitter from './EventEmitter';
+import type EventHolder from './EventHolder';
 
 /**
  * @class EventEmitterWithHolding

--- a/Libraries/vendor/emitter/EventSubscription.js
+++ b/Libraries/vendor/emitter/EventSubscription.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-import type EventSubscriptionVendor from 'EventSubscriptionVendor';
+import type EventSubscriptionVendor from './EventSubscriptionVendor';
 
 /**
  * EventSubscription represents a subscription to a particular event. It can

--- a/Libraries/vendor/emitter/EventSubscriptionVendor.js
+++ b/Libraries/vendor/emitter/EventSubscriptionVendor.js
@@ -12,7 +12,7 @@
 
 const invariant = require('invariant');
 
-import type EventSubscription from 'EventSubscription';
+import type EventSubscription from './EventSubscription';
 
 /**
  * EventSubscriptionVendor stores a set of EventSubscriptions that are

--- a/Libraries/vendor/emitter/mixInEventEmitter.js
+++ b/Libraries/vendor/emitter/mixInEventEmitter.js
@@ -10,14 +10,14 @@
 
 'use strict';
 
-const EventEmitter = require('EventEmitter');
-const EventEmitterWithHolding = require('EventEmitterWithHolding');
-const EventHolder = require('EventHolder');
+const EventEmitter = require('./EventEmitter');
+const EventEmitterWithHolding = require('./EventEmitterWithHolding');
+const EventHolder = require('./EventHolder');
 
 const invariant = require('invariant');
 const keyOf = require('fbjs/lib/keyOf');
 
-import type EmitterSubscription from 'EmitterSubscription';
+import type EmitterSubscription from './EmitterSubscription';
 
 const TYPES_KEY = keyOf({__types: true});
 
@@ -120,7 +120,7 @@ const EventEmitterMixin = {
     if (!this.__eventEmitter) {
       let emitter = new EventEmitter();
       if (__DEV__) {
-        const EventValidator = require('EventValidator');
+        const EventValidator = require('./EventValidator');
         emitter = EventValidator.addValidation(emitter, this.__types);
       }
 


### PR DESCRIPTION
## Summary

This is the next step in moving RN towards standard path-based requires. All the requires in `Libraries/vendor` have been rewritten to use relative requires. Talking to cpojer, the vendored code in RN can be modified directly.

This commit uses relative requires instead of `react-native/...` so that if Facebook were to stop syncing out certain folders and therefore remove code from the react-native package, internal code at Facebook would not need to change.

Closes #24769.

## Changelog

[General] [Changed] - Migrate vendored code from Haste to path-based imports

## Test Plan

Test Plan: Prettier/Lint, Flow, Jest tests, loaded RNTester

