### PR TITLE
[jest] Explicitly separate mocked native modules from mocked JS modules

### DIFF
--- a/Libraries/Image/__tests__/resolveAssetSource-test.js
+++ b/Libraries/Image/__tests__/resolveAssetSource-test.js
@@ -10,20 +10,19 @@
 
 'use strict';
 
-const AssetRegistry = require('../AssetRegistry');
-const Platform = require('../../Utilities/Platform');
-const resolveAssetSource = require('../resolveAssetSource');
-
-import NativeSourceCode from '../../NativeModules/specs/NativeSourceCode';
-
-function expectResolvesAsset(input, expectedSource) {
-  const assetId = AssetRegistry.registerAsset(input);
-  expect(resolveAssetSource(assetId)).toEqual(expectedSource);
-}
-
 describe('resolveAssetSource', () => {
+  let AssetRegistry;
+  let resolveAssetSource;
+  let NativeSourceCode;
+  let Platform;
+
   beforeEach(() => {
     jest.resetModules();
+
+    AssetRegistry = require('../AssetRegistry');
+    resolveAssetSource = require('../resolveAssetSource');
+    NativeSourceCode = require('../../NativeModules/specs/NativeSourceCode').default;
+    Platform = require('../../Utilities/Platform');
   });
 
   it('returns same source for simple static and network images', () => {
@@ -303,9 +302,16 @@ describe('resolveAssetSource', () => {
       );
     });
   });
+
+  function expectResolvesAsset(input, expectedSource) {
+    const assetId = AssetRegistry.registerAsset(input);
+    expect(resolveAssetSource(assetId)).toEqual(expectedSource);
+  }
 });
 
 describe('resolveAssetSource.pickScale', () => {
+  const resolveAssetSource = require('../resolveAssetSource');
+
   it('picks matching scale', () => {
     expect(resolveAssetSource.pickScale([1], 2)).toBe(1);
     expect(resolveAssetSource.pickScale([1, 2, 3], 2)).toBe(2);

--- a/jest/setup.js
+++ b/jest/setup.js
@@ -52,6 +52,19 @@ jest
   .mock('../Libraries/Components/View/View', () =>
     mockComponent('../Libraries/Components/View/View', MockNativeMethods),
   )
+  .mock('../Libraries/Components/AccessibilityInfo/AccessibilityInfo', () => ({
+    addEventListener: jest.fn(),
+    announceForAccessibility: jest.fn(),
+    fetch: jest.fn(),
+    isBoldTextEnabled: jest.fn(),
+    isGrayscaleEnabled: jest.fn(),
+    isInvertColorsEnabled: jest.fn(),
+    isReduceMotionEnabled: jest.fn(),
+    isReduceTransparencyEnabled: jest.fn(),
+    isScreenReaderEnabled: jest.fn(),
+    removeEventListener: jest.fn(),
+    setAccessibilityFocus: jest.fn(),
+  }))
   .mock('../Libraries/Components/RefreshControl/RefreshControl', () =>
     jest.requireActual(
       '../Libraries/Components/RefreshControl/__mocks__/RefreshControlMock',
@@ -82,6 +95,19 @@ jest
     };
     return AnimatedImplementation;
   })
+  .mock('../Libraries/AppState/AppState', () => ({
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+  }))
+  .mock('../Libraries/Linking/Linking', () => ({
+    openURL: jest.fn(),
+    canOpenURL: jest.fn(() => Promise.resolve(true)),
+    openSettings: jest.fn(),
+    addEventListener: jest.fn(),
+    getInitialURL: jest.fn(() => Promise.resolve()),
+    removeEventListener: jest.fn(),
+    sendIntent: jest.fn(),
+  }))
   .mock('../Libraries/Renderer/shims/ReactNative', () => {
     const ReactNative = jest.requireActual(
       '../Libraries/Renderer/shims/ReactNative',
@@ -97,278 +123,189 @@ jest
   })
   .mock('../Libraries/Components/Touchable/ensureComponentIsNative', () => () =>
     true,
-  );
-
-const mockNativeModules = {
-  AccessibilityInfo: {
-    addEventListener: jest.fn(),
-    announceForAccessibility: jest.fn(),
-    fetch: jest.fn(),
-    isBoldTextEnabled: jest.fn(),
-    isGrayscaleEnabled: jest.fn(),
-    isInvertColorsEnabled: jest.fn(),
-    isReduceMotionEnabled: jest.fn(),
-    isReduceTransparencyEnabled: jest.fn(),
-    isScreenReaderEnabled: jest.fn(),
-    removeEventListener: jest.fn(),
-    setAccessibilityFocus: jest.fn(),
-  },
-  AlertManager: {
-    alertWithArgs: jest.fn(),
-  },
-  AppState: {
-    addEventListener: jest.fn(),
-    removeEventListener: jest.fn(),
-  },
-  AsyncLocalStorage: {
-    multiGet: jest.fn((keys, callback) =>
-      process.nextTick(() => callback(null, [])),
-    ),
-    multiSet: jest.fn((entries, callback) =>
-      process.nextTick(() => callback(null)),
-    ),
-    multiRemove: jest.fn((keys, callback) =>
-      process.nextTick(() => callback(null)),
-    ),
-    multiMerge: jest.fn((entries, callback) =>
-      process.nextTick(() => callback(null)),
-    ),
-    clear: jest.fn(callback => process.nextTick(() => callback(null))),
-    getAllKeys: jest.fn(callback => process.nextTick(() => callback(null, []))),
-  },
-  BuildInfo: {
-    appVersion: '0',
-    buildVersion: '0',
-    getConstants() {
-      return {
-        appVersion: '0',
-        buildVersion: '0',
-      };
+  )
+  // Mock modules defined by the native layer (ex: Objective-C, Java)
+  .mock('../Libraries/BatchedBridge/NativeModules', () => ({
+    AlertManager: {
+      alertWithArgs: jest.fn(),
     },
-  },
-  Clipboard: {
-    setString: jest.fn(),
-  },
-  DataManager: {
-    queryData: jest.fn(),
-  },
-  DeviceInfo: {
-    getConstants() {
-      return {
-        Dimensions: {
-          window: {
-            fontScale: 2,
-            height: 1334,
-            scale: 2,
-            width: 750,
-          },
-          screen: {
-            fontScale: 2,
-            height: 1334,
-            scale: 2,
-            width: 750,
-          },
-        },
-      };
+    AsyncLocalStorage: {
+      multiGet: jest.fn((keys, callback) =>
+        process.nextTick(() => callback(null, [])),
+      ),
+      multiSet: jest.fn((entries, callback) =>
+        process.nextTick(() => callback(null)),
+      ),
+      multiRemove: jest.fn((keys, callback) =>
+        process.nextTick(() => callback(null)),
+      ),
+      multiMerge: jest.fn((entries, callback) =>
+        process.nextTick(() => callback(null)),
+      ),
+      clear: jest.fn(callback => process.nextTick(() => callback(null))),
+      getAllKeys: jest.fn(callback =>
+        process.nextTick(() => callback(null, [])),
+      ),
     },
-  },
-  FacebookSDK: {
-    login: jest.fn(),
-    logout: jest.fn(),
-    queryGraphPath: jest.fn((path, method, params, callback) => callback()),
-  },
-  GraphPhotoUpload: {
-    upload: jest.fn(),
-  },
-  I18n: {
-    translationsDictionary: JSON.stringify({
-      'Good bye, {name}!|Bye message': '\u{00A1}Adi\u{00F3}s {name}!',
-    }),
-  },
-  ImageLoader: {
-    getSize: jest.fn(url => Promise.resolve({width: 320, height: 240})),
-    prefetchImage: jest.fn(),
-  },
-  ImageViewManager: {
-    getSize: jest.fn((uri, success) =>
-      process.nextTick(() => success(320, 240)),
-    ),
-    prefetchImage: jest.fn(),
-  },
-  KeyboardObserver: {
-    addListener: jest.fn(),
-    removeListeners: jest.fn(),
-  },
-  Linking: {
-    openURL: jest.fn(),
-    canOpenURL: jest.fn(() => Promise.resolve(true)),
-    openSettings: jest.fn(),
-    addEventListener: jest.fn(),
-    getInitialURL: jest.fn(() => Promise.resolve()),
-    removeEventListener: jest.fn(),
-    sendIntent: jest.fn(),
-  },
-  LocationObserver: {
-    addListener: jest.fn(),
-    getCurrentPosition: jest.fn(),
-    removeListeners: jest.fn(),
-    requestAuthorization: jest.fn(),
-    setConfiguration: jest.fn(),
-    startObserving: jest.fn(),
-    stopObserving: jest.fn(),
-  },
-  ModalFullscreenViewManager: {},
-  NetInfo: {
-    fetch: jest.fn(() => Promise.resolve()),
-    getConnectionInfo: jest.fn(() => Promise.resolve()),
-    addEventListener: jest.fn(),
-    removeEventListener: jest.fn(),
-    isConnected: {
-      fetch: jest.fn(() => Promise.resolve()),
-      addEventListener: jest.fn(),
-      removeEventListener: jest.fn(),
+    Clipboard: {
+      getString: jest.fn(() => ''),
+      setString: jest.fn(),
     },
-    isConnectionExpensive: jest.fn(() => Promise.resolve()),
-  },
-  Networking: {
-    sendRequest: jest.fn(),
-    abortRequest: jest.fn(),
-    addListener: jest.fn(),
-    removeListeners: jest.fn(),
-  },
-  PushNotificationManager: {
-    presentLocalNotification: jest.fn(),
-    scheduleLocalNotification: jest.fn(),
-    cancelAllLocalNotifications: jest.fn(),
-    removeAllDeliveredNotifications: jest.fn(),
-    getDeliveredNotifications: jest.fn(callback => process.nextTick(() => [])),
-    removeDeliveredNotifications: jest.fn(),
-    setApplicationIconBadgeNumber: jest.fn(),
-    getApplicationIconBadgeNumber: jest.fn(callback =>
-      process.nextTick(() => callback(0)),
-    ),
-    cancelLocalNotifications: jest.fn(),
-    getScheduledLocalNotifications: jest.fn(callback =>
-      process.nextTick(() => callback()),
-    ),
-    requestPermissions: jest.fn(() =>
-      Promise.resolve({alert: true, badge: true, sound: true}),
-    ),
-    abandonPermissions: jest.fn(),
-    checkPermissions: jest.fn(callback =>
-      process.nextTick(() => callback({alert: true, badge: true, sound: true})),
-    ),
-    getInitialNotification: jest.fn(() => Promise.resolve(null)),
-    addListener: jest.fn(),
-    removeListeners: jest.fn(),
-  },
-  SourceCode: {
-    getConstants() {
-      return {
-        scriptURL: null,
-      };
-    },
-  },
-  StatusBarManager: {
-    HEIGHT: 42,
-    setColor: jest.fn(),
-    setStyle: jest.fn(),
-    setHidden: jest.fn(),
-    setNetworkActivityIndicatorVisible: jest.fn(),
-    setBackgroundColor: jest.fn(),
-    setTranslucent: jest.fn(),
-  },
-  Timing: {
-    createTimer: jest.fn(),
-    deleteTimer: jest.fn(),
-  },
-  UIManager: {
-    AndroidViewPager: {
-      Commands: {
-        setPage: jest.fn(),
-        setPageWithoutAnimation: jest.fn(),
-      },
-    },
-    blur: jest.fn(),
-    createView: jest.fn(),
-    dispatchViewManagerCommand: jest.fn(),
-    focus: jest.fn(),
-    getViewManagerConfig: jest.fn(name => {
-      if (name === 'AndroidDrawerLayout') {
+    DeviceInfo: {
+      getConstants() {
         return {
-          Constants: {
-            DrawerPosition: {
-              Left: 10,
+          Dimensions: {
+            window: {
+              fontScale: 2,
+              height: 1334,
+              scale: 2,
+              width: 750,
+            },
+            screen: {
+              fontScale: 2,
+              height: 1334,
+              scale: 2,
+              width: 750,
             },
           },
         };
-      }
-    }),
-    setChildren: jest.fn(),
-    manageChildren: jest.fn(),
-    updateView: jest.fn(),
-    removeSubviewsFromContainerWithID: jest.fn(),
-    replaceExistingNonRootView: jest.fn(),
-    customBubblingEventTypes: {},
-    customDirectEventTypes: {},
-    AndroidTextInput: {
-      Commands: {},
+      },
     },
-    ModalFullscreenView: {
-      Constants: {},
+    ImageLoader: {
+      getSize: jest.fn(url => Promise.resolve({width: 320, height: 240})),
+      prefetchImage: jest.fn(),
     },
-    ScrollView: {
-      Constants: {},
+    ImageViewManager: {
+      getSize: jest.fn((uri, success) =>
+        process.nextTick(() => success(320, 240)),
+      ),
+      prefetchImage: jest.fn(),
     },
-    View: {
-      Constants: {},
+    KeyboardObserver: {
+      addListener: jest.fn(),
+      removeListeners: jest.fn(),
     },
-  },
-  BlobModule: {
-    getConstants: () => ({BLOB_URI_SCHEME: 'content', BLOB_URI_HOST: null}),
-    addNetworkingHandler: jest.fn(),
-    enableBlobSupport: jest.fn(),
-    disableBlobSupport: jest.fn(),
-    createFromParts: jest.fn(),
-    sendBlob: jest.fn(),
-    release: jest.fn(),
-  },
-  WebSocketModule: {
-    connect: jest.fn(),
-    send: jest.fn(),
-    sendBinary: jest.fn(),
-    ping: jest.fn(),
-    close: jest.fn(),
-    addListener: jest.fn(),
-    removeListeners: jest.fn(),
-  },
-};
+    Networking: {
+      sendRequest: jest.fn(),
+      abortRequest: jest.fn(),
+      addListener: jest.fn(),
+      removeListeners: jest.fn(),
+    },
+    PushNotificationManager: {
+      presentLocalNotification: jest.fn(),
+      scheduleLocalNotification: jest.fn(),
+      cancelAllLocalNotifications: jest.fn(),
+      removeAllDeliveredNotifications: jest.fn(),
+      getDeliveredNotifications: jest.fn(callback =>
+        process.nextTick(() => []),
+      ),
+      removeDeliveredNotifications: jest.fn(),
+      setApplicationIconBadgeNumber: jest.fn(),
+      getApplicationIconBadgeNumber: jest.fn(callback =>
+        process.nextTick(() => callback(0)),
+      ),
+      cancelLocalNotifications: jest.fn(),
+      getScheduledLocalNotifications: jest.fn(callback =>
+        process.nextTick(() => callback()),
+      ),
+      requestPermissions: jest.fn(() =>
+        Promise.resolve({alert: true, badge: true, sound: true}),
+      ),
+      abandonPermissions: jest.fn(),
+      checkPermissions: jest.fn(callback =>
+        process.nextTick(() =>
+          callback({alert: true, badge: true, sound: true}),
+        ),
+      ),
+      getInitialNotification: jest.fn(() => Promise.resolve(null)),
+      addListener: jest.fn(),
+      removeListeners: jest.fn(),
+    },
+    SourceCode: {
+      getConstants() {
+        return {
+          scriptURL: null,
+        };
+      },
+    },
+    StatusBarManager: {
+      HEIGHT: 42,
+      setColor: jest.fn(),
+      setStyle: jest.fn(),
+      setHidden: jest.fn(),
+      setNetworkActivityIndicatorVisible: jest.fn(),
+      setBackgroundColor: jest.fn(),
+      setTranslucent: jest.fn(),
+    },
+    Timing: {
+      createTimer: jest.fn(),
+      deleteTimer: jest.fn(),
+    },
+    UIManager: {
+      AndroidViewPager: {
+        Commands: {
+          setPage: jest.fn(),
+          setPageWithoutAnimation: jest.fn(),
+        },
+      },
+      blur: jest.fn(),
+      createView: jest.fn(),
+      dispatchViewManagerCommand: jest.fn(),
+      focus: jest.fn(),
+      setChildren: jest.fn(),
+      manageChildren: jest.fn(),
+      updateView: jest.fn(),
+      removeSubviewsFromContainerWithID: jest.fn(),
+      replaceExistingNonRootView: jest.fn(),
+      customBubblingEventTypes: {},
+      customDirectEventTypes: {},
+      AndroidDrawerLayout: {
+        Constants: {
+          DrawerPosition: {
+            Left: 10,
+          },
+        },
+      },
+      AndroidTextInput: {
+        Commands: {},
+      },
+      ScrollView: {
+        Constants: {},
+      },
+      View: {
+        Constants: {},
+      },
+    },
+    BlobModule: {
+      getConstants: () => ({BLOB_URI_SCHEME: 'content', BLOB_URI_HOST: null}),
+      addNetworkingHandler: jest.fn(),
+      enableBlobSupport: jest.fn(),
+      disableBlobSupport: jest.fn(),
+      createFromParts: jest.fn(),
+      sendBlob: jest.fn(),
+      release: jest.fn(),
+    },
+    WebSocketModule: {
+      connect: jest.fn(),
+      send: jest.fn(),
+      sendBinary: jest.fn(),
+      ping: jest.fn(),
+      close: jest.fn(),
+      addListener: jest.fn(),
+      removeListeners: jest.fn(),
+    },
+  }))
+  .mock('../Libraries/ReactNative/requireNativeComponent', () => {
+    const React = require('react');
 
-Object.keys(mockNativeModules).forEach(module => {
-  try {
-    jest.doMock(module, () => mockNativeModules[module]); // needed by FacebookSDK-test
-  } catch (e) {
-    jest.doMock(module, () => mockNativeModules[module], {virtual: true});
-  }
-});
-
-jest.doMock(
-  '../Libraries/BatchedBridge/NativeModules',
-  () => mockNativeModules,
-);
-
-jest.doMock('../Libraries/ReactNative/requireNativeComponent', () => {
-  const React = require('react');
-
-  return viewName =>
-    class extends React.Component {
-      render() {
-        return React.createElement(viewName, this.props, this.props.children);
-      }
-    };
-});
-
-jest.doMock(
-  '../Libraries/Utilities/verifyComponentAttributeEquivalence',
-  () => function() {},
-);
+    return viewName =>
+      class extends React.Component {
+        render() {
+          return React.createElement(viewName, this.props, this.props.children);
+        }
+      };
+  })
+  .mock(
+    '../Libraries/Utilities/verifyComponentAttributeEquivalence',
+    () => function() {},
+  );


### PR DESCRIPTION
## Summary

This commit more clearly defines the mocks RN sets up and uses paths instead of Haste names to define the mocks. The Jest setup script defined mocks for native modules (Obj-C, Java) and mocks for JS modules in the same data structure. This meant that some non-native modules (that is, JS modules) were in the `mockNativeModules` map -- this commit splits them out and mocks them in typical `jest.mock` fashion.

Additionally, the setup script used to mock the modules using the Haste names. As one of the steps toward migrating to standard path-based imports, the setup script now mocks JS modules using paths (native modules don't need a Haste name nor path since they are just entries in `NativeModules`). This gets us closer to being able to remove `hasteImpl`. (Tracking in https://github.com/facebook/react-native/issues/24772.)

Also, this commit removes mocks that are not referenced anywhere in the RN and React repositories (grepped for the names and found no entries outside of the Jest setup scripts).

## Changelog

[General] [Changed] - Explicitly separate mocked native modules from mocked JS modules

## Test Plan

Test plan: Ran all unit tests to ensure they pass. Additionally copied the RN setup script into `jest-expo`, which tests some more complex mocking setups with view manager and all tests passed without any modification to `jest-expo`.
