### PR TITLE
[iOS] fixes Xcode path issues containing whitespace when building Release

### DIFF
--- a/scripts/react-native-xcode.sh
+++ b/scripts/react-native-xcode.sh
@@ -57,7 +57,7 @@ REACT_NATIVE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 # in node_modules.
 PROJECT_ROOT=${PROJECT_ROOT:-"$REACT_NATIVE_DIR/../.."}
 
-cd "$PROJECT_ROOT"
+cd "$PROJECT_ROOT" || exit
 
 # Define NVM_DIR and source the nvm.sh setup script
 [ -z "$NVM_DIR" ] && export NVM_DIR="$HOME/.nvm"

--- a/scripts/react-native-xcode.sh
+++ b/scripts/react-native-xcode.sh
@@ -57,7 +57,7 @@ REACT_NATIVE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 # in node_modules.
 PROJECT_ROOT=${PROJECT_ROOT:-"$REACT_NATIVE_DIR/../.."}
 
-cd $PROJECT_ROOT
+cd "$PROJECT_ROOT"
 
 # Define NVM_DIR and source the nvm.sh setup script
 [ -z "$NVM_DIR" ] && export NVM_DIR="$HOME/.nvm"


### PR DESCRIPTION
## Summary

Some users (me included) have projects located in quirky places, resulting whitespaces in the path.
An example, , I symlink into my iCloud drive which result in the following path

```
/Users/r/Library/Mobile Documents/com~apple~CloudDocs/_/work/{a_company}/repos.nosync/app
```

This commit quotes the variable to make sure it gets properly passed to the CLI.

For reference, similar issue that has been resolved: https://github.com/react-native/react-native/commit/7d4e94edccfc2f642fcbd1d6aa00756f02e3a525


## Test Plan

I ran current tests without issues. 

Any suggestions how to write a test that catch these issues in the future? I couldn't find any tests related to xcode builds. 

## Changelog

[iOS] [Fixed] - Fixes whitespace issues when building Release from Xcode 
