### PR TITLE
[standards] Migrate "androidTest" JS from Haste to path-based requires

### DIFF
--- a/ReactAndroid/src/androidTest/js/AnimatedTransformTestModule.js
+++ b/ReactAndroid/src/androidTest/js/AnimatedTransformTestModule.js
@@ -9,13 +9,17 @@
 
 'use strict';
 
-var BatchedBridge = require('BatchedBridge');
-var React = require('React');
-var StyleSheet = require('StyleSheet');
-var View = require('View');
-var TouchableOpacity = require('TouchableOpacity');
-var Text = require('Text');
-var RecordingModule = require('NativeModules').Recording;
+const React = require('react');
+const {
+  NativeModules,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} = require('react-native');
+const BatchedBridge = require('react-native/Libraries/BatchedBridge/BatchedBridge');
+
+const {Recording: RecordingModule} = NativeModules;
 
 const styles = StyleSheet.create({
   base: {

--- a/ReactAndroid/src/androidTest/js/Asserts.js
+++ b/ReactAndroid/src/androidTest/js/Asserts.js
@@ -9,7 +9,9 @@
 
 'use strict';
 
-const Assert = require('NativeModules').Assert;
+const {NativeModules} = require('react-native');
+
+const {Assert} = NativeModules;
 
 const Asserts = {
   assertEquals: function(expected, actual, msg) {

--- a/ReactAndroid/src/androidTest/js/CatalystRootViewTestModule.js
+++ b/ReactAndroid/src/androidTest/js/CatalystRootViewTestModule.js
@@ -9,11 +9,11 @@
 
 'use strict';
 
-const BatchedBridge = require('BatchedBridge');
-const React = require('React');
-const Recording = require('NativeModules').Recording;
-const StyleSheet = require('StyleSheet');
-const View = require('View');
+const React = require('react');
+const {NativeModules, StyleSheet, View} = require('react-native');
+const BatchedBridge = require('react-native/Libraries/BatchedBridge/BatchedBridge');
+
+const {Recording} = NativeModules;
 
 let that;
 

--- a/ReactAndroid/src/androidTest/js/DatePickerDialogTestModule.js
+++ b/ReactAndroid/src/androidTest/js/DatePickerDialogTestModule.js
@@ -9,12 +9,11 @@
 
 'use strict';
 
-const BatchedBridge = require('BatchedBridge');
-const DatePickerAndroid = require('DatePickerAndroid');
-const React = require('React');
-const RecordingModule = require('NativeModules')
-  .DatePickerDialogRecordingModule;
-const View = require('View');
+const React = require('react');
+const {DatePickerAndroid, NativeModules, View} = require('react-native');
+const BatchedBridge = require('react-native/Libraries/BatchedBridge/BatchedBridge');
+
+const {DatePickerDialogRecordingModule: RecordingModule} = NativeModules;
 
 class DatePickerDialogTestApp extends React.Component {
   render() {

--- a/ReactAndroid/src/androidTest/js/ImageErrorTestApp.js
+++ b/ReactAndroid/src/androidTest/js/ImageErrorTestApp.js
@@ -9,12 +9,10 @@
 
 'use strict';
 
-const React = require('React');
-const Image = require('Image');
-const StyleSheet = require('StyleSheet');
-const View = require('View');
+const React = require('react');
+const {Image, NativeModules, StyleSheet, View} = require('react-native');
 
-const RecordingModule = require('NativeModules').Recording;
+const {Recording: RecordingModule} = NativeModules;
 
 class ImageErrorTestApp extends React.Component {
   onError = e => {

--- a/ReactAndroid/src/androidTest/js/ImageOverlayColorTestApp.js
+++ b/ReactAndroid/src/androidTest/js/ImageOverlayColorTestApp.js
@@ -9,8 +9,8 @@
 
 'use strict';
 
-const React = require('React');
-const Image = require('Image');
+const React = require('react');
+const {Image} = require('react-native');
 
 class ImageOverlayColorTestApp extends React.Component {
   render() {

--- a/ReactAndroid/src/androidTest/js/InitialPropsTestApp.js
+++ b/ReactAndroid/src/androidTest/js/InitialPropsTestApp.js
@@ -9,9 +9,10 @@
 
 'use strict';
 
-const React = require('React');
-const RecordingModule = require('NativeModules').InitialPropsRecordingModule;
-const Text = require('Text');
+const React = require('react');
+const {NativeModules, Text} = require('react-native');
+
+const {Recording: RecordingModule} = NativeModules;
 
 class InitialPropsTestApp extends React.Component {
   componentDidMount() {

--- a/ReactAndroid/src/androidTest/js/JSResponderTestApp.js
+++ b/ReactAndroid/src/androidTest/js/JSResponderTestApp.js
@@ -9,12 +9,14 @@
 
 'use strict';
 
-const React = require('React');
-const StyleSheet = require('StyleSheet');
-const View = require('View');
-const Text = require('Text');
-const PanResponder = require('PanResponder');
-const ScrollView = require('ScrollView');
+const React = require('react');
+const {
+  PanResponder,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} = require('react-native');
 
 class JSResponderTestApp extends React.Component {
   _handleMoveShouldSetPanResponder = (e, gestureState) => {

--- a/ReactAndroid/src/androidTest/js/LayoutEventsTestApp.js
+++ b/ReactAndroid/src/androidTest/js/LayoutEventsTestApp.js
@@ -9,11 +9,10 @@
 
 'use strict';
 
-const React = require('React');
-const View = require('View');
-const StyleSheet = require('StyleSheet');
+const React = require('react');
+const {NativeModules, StyleSheet, View} = require('react-native');
 
-const RecordingModule = require('NativeModules').Recording;
+const {Recording: RecordingModule} = NativeModules;
 
 const LAYOUT_SPECS = [
   [10, 10, 100, 100],

--- a/ReactAndroid/src/androidTest/js/MeasureLayoutTestModule.js
+++ b/ReactAndroid/src/androidTest/js/MeasureLayoutTestModule.js
@@ -9,14 +9,11 @@
 
 'use strict';
 
-const BatchedBridge = require('BatchedBridge');
-const React = require('React');
-const ReactNative = require('ReactNative');
-const View = require('View');
-const StyleSheet = require('StyleSheet');
-const UIManager = require('UIManager');
+const React = require('react');
+const {StyleSheet, UIManager, View, findNodeHandle} = require('react-native');
+const BatchedBridge = require('react-native/Libraries/BatchedBridge/BatchedBridge');
 
-const assertEquals = require('Asserts').assertEquals;
+const assertEquals = require('./Asserts').assertEquals;
 
 const styles = StyleSheet.create({
   A: {
@@ -50,10 +47,10 @@ let A, B, C, D;
 
 class MeasureLayoutTestApp extends React.Component {
   componentDidMount() {
-    A = ReactNative.findNodeHandle(this.refs.A);
-    B = ReactNative.findNodeHandle(this.refs.B);
-    C = ReactNative.findNodeHandle(this.refs.C);
-    D = ReactNative.findNodeHandle(this.refs.D);
+    A = findNodeHandle(this.refs.A);
+    B = findNodeHandle(this.refs.B);
+    C = findNodeHandle(this.refs.C);
+    D = findNodeHandle(this.refs.D);
   }
 
   render() {

--- a/ReactAndroid/src/androidTest/js/MultitouchHandlingTestAppModule.js
+++ b/ReactAndroid/src/androidTest/js/MultitouchHandlingTestAppModule.js
@@ -9,10 +9,10 @@
 
 'use strict';
 
-const React = require('React');
-const Recording = require('NativeModules').Recording;
-const StyleSheet = require('StyleSheet');
-const View = require('View');
+const React = require('react');
+const {NativeModules, StyleSheet, View} = require('react-native');
+
+const {Recording} = NativeModules;
 
 const extractSingleTouch = nativeEvent => {
   const touches = nativeEvent.touches;

--- a/ReactAndroid/src/androidTest/js/NativeIdTestModule.js
+++ b/ReactAndroid/src/androidTest/js/NativeIdTestModule.js
@@ -10,16 +10,18 @@
 
 'use strict';
 
-const Image = require('Image');
-const React = require('React');
-const StyleSheet = require('StyleSheet');
-const Text = require('Text');
-const TextInput = require('TextInput');
-const TouchableBounce = require('TouchableBounce');
-const TouchableHighlight = require('TouchableHighlight');
-const TouchableOpacity = require('TouchableOpacity');
-const TouchableWithoutFeedback = require('TouchableWithoutFeedback');
-const View = require('View');
+const React = require('react');
+const {
+  Image,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableHighlight,
+  TouchableOpacity,
+  TouchableWithoutFeedback,
+  View,
+} = require('react-native');
+const TouchableBounce = require('react-native/Libraries/Components/Touchable/TouchableBounce');
 
 /**
  * All the views implemented on Android, each with the nativeID property set.

--- a/ReactAndroid/src/androidTest/js/PickerAndroidTestModule.js
+++ b/ReactAndroid/src/androidTest/js/PickerAndroidTestModule.js
@@ -9,12 +9,11 @@
 
 'use strict';
 
-const BatchedBridge = require('BatchedBridge');
-const React = require('React');
-const RecordingModule = require('NativeModules').PickerAndroidRecordingModule;
-const Picker = require('Picker');
-const View = require('View');
+const React = require('react');
+const {NativeModules, Picker, View} = require('react-native');
+const BatchedBridge = require('react-native/Libraries/BatchedBridge/BatchedBridge');
 
+const {Recording: RecordingModule} = NativeModules;
 const Item = Picker.Item;
 
 let appInstance;

--- a/ReactAndroid/src/androidTest/js/ProgressBarTestModule.js
+++ b/ReactAndroid/src/androidTest/js/ProgressBarTestModule.js
@@ -9,14 +9,14 @@
 
 'use strict';
 
-const BatchedBridge = require('BatchedBridge');
-const React = require('React');
-const ReactNative = require('react-native');
-const {StyleSheet} = ReactNative;
-const ProgressBar = require('ProgressBarAndroid');
-const View = require('View');
-
-const renderApplication = require('renderApplication');
+const React = require('react');
+const {
+  ProgressBarAndroid: ProgressBar,
+  StyleSheet,
+  View,
+} = require('react-native');
+const BatchedBridge = require('react-native/Libraries/BatchedBridge/BatchedBridge');
+const renderApplication = require('react-native/Libraries/ReactNative/renderApplication');
 
 class ProgressBarSampleApp extends React.Component {
   state = {};

--- a/ReactAndroid/src/androidTest/js/ScrollViewTestModule.js
+++ b/ReactAndroid/src/androidTest/js/ScrollViewTestModule.js
@@ -10,14 +10,18 @@
 
 'use strict';
 
-const BatchedBridge = require('BatchedBridge');
-const React = require('React');
-const View = require('View');
-const ScrollView = require('ScrollView');
-const Text = require('Text');
-const StyleSheet = require('StyleSheet');
-const TouchableWithoutFeedback = require('TouchableWithoutFeedback');
-const ScrollListener = require('NativeModules').ScrollListener;
+const React = require('react');
+const {
+  NativeModules,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableWithoutFeedback,
+  View,
+} = require('react-native');
+const BatchedBridge = require('react-native/Libraries/BatchedBridge/BatchedBridge');
+
+const {ScrollListener} = NativeModules;
 
 const NUM_ITEMS = 100;
 

--- a/ReactAndroid/src/androidTest/js/ShareTestModule.js
+++ b/ReactAndroid/src/androidTest/js/ShareTestModule.js
@@ -9,11 +9,11 @@
 
 'use strict';
 
-const BatchedBridge = require('BatchedBridge');
-const React = require('React');
-const RecordingModule = require('NativeModules').ShareRecordingModule;
-const Share = require('Share');
-const View = require('View');
+const React = require('react');
+const {NativeModules, Share, View} = require('react-native');
+const BatchedBridge = require('react-native/Libraries/BatchedBridge/BatchedBridge');
+
+const {ShareRecordingModule: RecordingModule} = NativeModules;
 
 class ShareTestApp extends React.Component {
   render() {

--- a/ReactAndroid/src/androidTest/js/SubviewsClippingTestModule.js
+++ b/ReactAndroid/src/androidTest/js/SubviewsClippingTestModule.js
@@ -9,13 +9,14 @@
 
 'use strict';
 
-const BatchedBridge = require('BatchedBridge');
-const React = require('React');
-const ScrollView = require('ScrollView');
-const StyleSheet = require('StyleSheet');
-const View = require('View');
-
-const requireNativeComponent = require('requireNativeComponent');
+const React = require('react');
+const {
+  ScrollView,
+  StyleSheet,
+  View,
+  requireNativeComponent,
+} = require('react-native');
+const BatchedBridge = require('react-native/Libraries/BatchedBridge/BatchedBridge');
 
 const ClippableView = requireNativeComponent('ClippableView');
 

--- a/ReactAndroid/src/androidTest/js/SwipeRefreshLayoutTestModule.js
+++ b/ReactAndroid/src/androidTest/js/SwipeRefreshLayoutTestModule.js
@@ -9,16 +9,19 @@
 
 'use strict';
 
-const BatchedBridge = require('BatchedBridge');
-const React = require('React');
-const RecordingModule = require('NativeModules')
-  .SwipeRefreshLayoutRecordingModule;
-const ScrollView = require('ScrollView');
-const StyleSheet = require('StyleSheet');
-const RefreshControl = require('RefreshControl');
-const Text = require('Text');
-const TouchableWithoutFeedback = require('TouchableWithoutFeedback');
-const View = require('View');
+const React = require('react');
+const {
+  NativeModules,
+  RefreshControl,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableWithoutFeedback,
+  View,
+} = require('react-native');
+const BatchedBridge = require('react-native/Libraries/BatchedBridge/BatchedBridge');
+
+const {SwipeRefreshLayoutRecordingModule: RecordingModule} = NativeModules;
 
 class Row extends React.Component {
   state = {

--- a/ReactAndroid/src/androidTest/js/TestBundle.js
+++ b/ReactAndroid/src/androidTest/js/TestBundle.js
@@ -13,117 +13,117 @@
 console.disableYellowBox = true;
 
 // Include callable JS modules first, in case one of the other ones below throws
-require('ProgressBarTestModule');
-require('ViewRenderingTestModule');
-require('TestJavaToJSArgumentsModule');
-require('TestJSLocaleModule');
-require('TestJSToJavaParametersModule');
-require('TestJavaToJSReturnValuesModule');
-require('UIManagerTestModule');
+require('./ProgressBarTestModule');
+require('./ViewRenderingTestModule');
+require('./TestJavaToJSArgumentsModule');
+require('./TestJSLocaleModule');
+require('./TestJSToJavaParametersModule');
+require('./TestJavaToJSReturnValuesModule');
+require('./UIManagerTestModule');
 
-require('CatalystRootViewTestModule');
-require('DatePickerDialogTestModule');
-require('MeasureLayoutTestModule');
-require('PickerAndroidTestModule');
-require('ScrollViewTestModule');
-require('ShareTestModule');
-require('SwipeRefreshLayoutTestModule');
-require('TextInputTestModule');
-require('TimePickerDialogTestModule');
+require('./CatalystRootViewTestModule');
+require('./DatePickerDialogTestModule');
+require('./MeasureLayoutTestModule');
+require('./PickerAndroidTestModule');
+require('./ScrollViewTestModule');
+require('./ShareTestModule');
+require('./SwipeRefreshLayoutTestModule');
+require('./TextInputTestModule');
+require('./TimePickerDialogTestModule');
 
 // Define catalyst test apps used in integration tests
-const AppRegistry = require('AppRegistry');
+const {AppRegistry} = require('react-native');
 
 const apps = [
   {
     appKey: 'AnimatedTransformTestApp',
     component: () =>
-      require('AnimatedTransformTestModule').AnimatedTransformTestApp,
+      require('./AnimatedTransformTestModule').AnimatedTransformTestApp,
   },
   {
     appKey: 'CatalystRootViewTestApp',
     component: () =>
-      require('CatalystRootViewTestModule').CatalystRootViewTestApp,
+      require('./CatalystRootViewTestModule').CatalystRootViewTestApp,
   },
   {
     appKey: 'DatePickerDialogTestApp',
     component: () =>
-      require('DatePickerDialogTestModule').DatePickerDialogTestApp,
+      require('./DatePickerDialogTestModule').DatePickerDialogTestApp,
   },
   {
     appKey: 'JSResponderTestApp',
-    component: () => require('JSResponderTestApp'),
+    component: () => require('./JSResponderTestApp'),
   },
   {
     appKey: 'HorizontalScrollViewTestApp',
     component: () =>
-      require('ScrollViewTestModule').HorizontalScrollViewTestApp,
+      require('./ScrollViewTestModule').HorizontalScrollViewTestApp,
   },
   {
     appKey: 'ImageOverlayColorTestApp',
-    component: () => require('ImageOverlayColorTestApp'),
+    component: () => require('./ImageOverlayColorTestApp'),
   },
   {
     appKey: 'ImageErrorTestApp',
-    component: () => require('ImageErrorTestApp'),
+    component: () => require('./ImageErrorTestApp'),
   },
   {
     appKey: 'InitialPropsTestApp',
-    component: () => require('InitialPropsTestApp'),
+    component: () => require('./InitialPropsTestApp'),
   },
   {
     appKey: 'LayoutEventsTestApp',
-    component: () => require('LayoutEventsTestApp'),
+    component: () => require('./LayoutEventsTestApp'),
   },
   {
     appKey: 'MeasureLayoutTestApp',
-    component: () => require('MeasureLayoutTestModule').MeasureLayoutTestApp,
+    component: () => require('./MeasureLayoutTestModule').MeasureLayoutTestApp,
   },
   {
     appKey: 'MultitouchHandlingTestAppModule',
-    component: () => require('MultitouchHandlingTestAppModule'),
+    component: () => require('./MultitouchHandlingTestAppModule'),
   },
   {
     appKey: 'NativeIdTestApp',
-    component: () => require('NativeIdTestModule').NativeIdTestApp,
+    component: () => require('./NativeIdTestModule').NativeIdTestApp,
   },
   {
     appKey: 'PickerAndroidTestApp',
-    component: () => require('PickerAndroidTestModule').PickerAndroidTestApp,
+    component: () => require('./PickerAndroidTestModule').PickerAndroidTestApp,
   },
   {
     appKey: 'ScrollViewTestApp',
-    component: () => require('ScrollViewTestModule').ScrollViewTestApp,
+    component: () => require('./ScrollViewTestModule').ScrollViewTestApp,
   },
   {
     appKey: 'ShareTestApp',
-    component: () => require('ShareTestModule').ShareTestApp,
+    component: () => require('./ShareTestModule').ShareTestApp,
   },
   {
     appKey: 'SubviewsClippingTestApp',
-    component: () => require('SubviewsClippingTestModule').App,
+    component: () => require('./SubviewsClippingTestModule').App,
   },
   {
     appKey: 'SwipeRefreshLayoutTestApp',
     component: () =>
-      require('SwipeRefreshLayoutTestModule').SwipeRefreshLayoutTestApp,
+      require('./SwipeRefreshLayoutTestModule').SwipeRefreshLayoutTestApp,
   },
   {
     appKey: 'TextInputTestApp',
-    component: () => require('TextInputTestModule').TextInputTestApp,
+    component: () => require('./TextInputTestModule').TextInputTestApp,
   },
   {
     appKey: 'TestIdTestApp',
-    component: () => require('TestIdTestModule').TestIdTestApp,
+    component: () => require('./TestIdTestModule').TestIdTestApp,
   },
   {
     appKey: 'TimePickerDialogTestApp',
     component: () =>
-      require('TimePickerDialogTestModule').TimePickerDialogTestApp,
+      require('./TimePickerDialogTestModule').TimePickerDialogTestApp,
   },
   {
     appKey: 'TouchBubblingTestAppModule',
-    component: () => require('TouchBubblingTestAppModule'),
+    component: () => require('./TouchBubblingTestAppModule'),
   },
 ];
 

--- a/ReactAndroid/src/androidTest/js/TestIdTestModule.js
+++ b/ReactAndroid/src/androidTest/js/TestIdTestModule.js
@@ -9,16 +9,18 @@
 
 'use strict';
 
-const Image = require('Image');
-const React = require('React');
-const StyleSheet = require('StyleSheet');
-const Text = require('Text');
-const TextInput = require('TextInput');
-const TouchableBounce = require('TouchableBounce');
-const TouchableHighlight = require('TouchableHighlight');
-const TouchableOpacity = require('TouchableOpacity');
-const TouchableWithoutFeedback = require('TouchableWithoutFeedback');
-const View = require('View');
+const React = require('react');
+const {
+  Image,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableHighlight,
+  TouchableOpacity,
+  TouchableWithoutFeedback,
+  View,
+} = require('react-native');
+const TouchableBounce = require('react-native/Libraries/Components/Touchable/TouchableBounce');
 
 /**
  * All the views implemented on Android, each with the testID property set.

--- a/ReactAndroid/src/androidTest/js/TestJSLocaleModule.js
+++ b/ReactAndroid/src/androidTest/js/TestJSLocaleModule.js
@@ -9,8 +9,10 @@
 
 'use strict';
 
-const BatchedBridge = require('BatchedBridge');
-const Recording = require('NativeModules').Recording;
+const {NativeModules} = require('react-native');
+const BatchedBridge = require('react-native/Libraries/BatchedBridge/BatchedBridge');
+
+const {Recording} = NativeModules;
 
 const TestJSLocaleModule = {
   toUpper: function(s) {

--- a/ReactAndroid/src/androidTest/js/TestJSToJavaParametersModule.js
+++ b/ReactAndroid/src/androidTest/js/TestJSToJavaParametersModule.js
@@ -9,8 +9,10 @@
 
 'use strict';
 
-const BatchedBridge = require('BatchedBridge');
-const Recording = require('NativeModules').Recording;
+const {NativeModules} = require('react-native');
+const BatchedBridge = require('react-native/Libraries/BatchedBridge/BatchedBridge');
+
+const {Recording} = NativeModules;
 
 const TestJSToJavaParametersModule = {
   returnBasicTypes: function() {

--- a/ReactAndroid/src/androidTest/js/TestJavaToJSArgumentsModule.js
+++ b/ReactAndroid/src/androidTest/js/TestJavaToJSArgumentsModule.js
@@ -9,8 +9,8 @@
 
 'use strict';
 
-const BatchedBridge = require('BatchedBridge');
-const {assertEquals, assertTrue} = require('Asserts');
+const BatchedBridge = require('react-native/Libraries/BatchedBridge/BatchedBridge');
+const {assertEquals, assertTrue} = require('./Asserts');
 
 function strictStringCompare(a, b) {
   if (typeof a !== 'string' || typeof b !== 'string' || a.length !== b.length) {

--- a/ReactAndroid/src/androidTest/js/TestJavaToJSReturnValuesModule.js
+++ b/ReactAndroid/src/androidTest/js/TestJavaToJSReturnValuesModule.js
@@ -9,10 +9,11 @@
 
 'use strict';
 
-const BatchedBridge = require('BatchedBridge');
+const {NativeModules} = require('react-native');
+const BatchedBridge = require('react-native/Libraries/BatchedBridge/BatchedBridge');
 
-const {assertEquals, assertTrue} = require('Asserts');
-const {TestModule} = require('NativeModules');
+const {assertEquals, assertTrue} = require('./Asserts');
+const {TestModule} = NativeModules;
 
 const TestJavaToJSReturnValuesModule = {
   callMethod: function(methodName, expectedType, expectedJSON) {

--- a/ReactAndroid/src/androidTest/js/TextInputTestModule.js
+++ b/ReactAndroid/src/androidTest/js/TextInputTestModule.js
@@ -9,14 +9,17 @@
 
 'use strict';
 
-const BatchedBridge = require('BatchedBridge');
-const React = require('React');
-const StyleSheet = require('StyleSheet');
-const Text = require('Text');
-const TextInput = require('TextInput');
-const View = require('View');
+const React = require('react');
+const {
+  NativeModules,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} = require('react-native');
+const BatchedBridge = require('react-native/Libraries/BatchedBridge/BatchedBridge');
 
-const Recording = require('NativeModules').Recording;
+const {Recording} = NativeModules;
 
 let app;
 

--- a/ReactAndroid/src/androidTest/js/TimePickerDialogTestModule.js
+++ b/ReactAndroid/src/androidTest/js/TimePickerDialogTestModule.js
@@ -9,12 +9,11 @@
 
 'use strict';
 
-const BatchedBridge = require('BatchedBridge');
-const TimePickerAndroid = require('TimePickerAndroid');
-const React = require('React');
-const RecordingModule = require('NativeModules')
-  .TimePickerDialogRecordingModule;
-const View = require('View');
+const React = require('react');
+const {NativeModules, TimePickerAndroid, View} = require('react-native');
+const BatchedBridge = require('react-native/Libraries/BatchedBridge/BatchedBridge');
+
+const {TimePickerDialogRecordingModule: RecordingModule} = NativeModules;
 
 class TimePickerDialogTestApp extends React.Component {
   render() {

--- a/ReactAndroid/src/androidTest/js/TouchBubblingTestAppModule.js
+++ b/ReactAndroid/src/androidTest/js/TouchBubblingTestAppModule.js
@@ -9,12 +9,15 @@
 
 'use strict';
 
-const Recording = require('NativeModules').Recording;
+const React = require('react');
+const {
+  NativeModules,
+  StyleSheet,
+  TouchableWithoutFeedback,
+  View,
+} = require('react-native');
 
-const React = require('React');
-const StyleSheet = require('StyleSheet');
-const View = require('View');
-const TouchableWithoutFeedback = require('TouchableWithoutFeedback');
+const {Recording} = NativeModules;
 
 class TouchBubblingTestApp extends React.Component {
   handlePress = record => {

--- a/ReactAndroid/src/androidTest/js/UIManagerTestModule.js
+++ b/ReactAndroid/src/androidTest/js/UIManagerTestModule.js
@@ -10,13 +10,10 @@
 
 'use strict';
 
-const BatchedBridge = require('BatchedBridge');
-const React = require('React');
-const StyleSheet = require('StyleSheet');
-const View = require('View');
-const Text = require('Text');
-
-const renderApplication = require('renderApplication');
+const React = require('react');
+const {StyleSheet, Text, View} = require('react-native');
+const BatchedBridge = require('react-native/Libraries/BatchedBridge/BatchedBridge');
+const renderApplication = require('react-native/Libraries/ReactNative/renderApplication');
 
 type FlexTestAppProps = $ReadOnly<{||}>;
 class FlexTestApp extends React.Component<FlexTestAppProps> {

--- a/ReactAndroid/src/androidTest/js/ViewRenderingTestModule.js
+++ b/ReactAndroid/src/androidTest/js/ViewRenderingTestModule.js
@@ -9,12 +9,11 @@
 
 'use strict';
 
-const BatchedBridge = require('BatchedBridge');
-const React = require('React');
-const View = require('View');
-const StyleSheet = require('StyleSheet');
+const React = require('react');
+const {StyleSheet, View} = require('react-native');
+const BatchedBridge = require('react-native/Libraries/BatchedBridge/BatchedBridge');
+const renderApplication = require('react-native/Libraries/ReactNative/renderApplication');
 
-const renderApplication = require('renderApplication');
 class ViewSampleApp extends React.Component {
   state = {};
 


### PR DESCRIPTION
## Summary

The files in `ReactAndroid/src/androidTest/js` use Haste names; this commit migrates them to use path-based imports. This helps us move RN towards standard path-based requires. All the requires in `androidTest` have been rewritten to use relative requires.

## Changelog

[General] [Changed] - Migrate "androidTest" JS from Haste to path-based requires

## Test Plan

Run lint, Flow, and Android tests:

```
node cli.js bundle --platform android --dev true --entry-file ReactAndroid/src/androidTest/js/TestBundle.js --bundle-output ReactAndroid/src/androidTest/assets/AndroidTestBundle.js
buck install ReactAndroid/src/androidTest/buck-runner:instrumentation-tests
```

Also run CI.
