### PR TITLE
[iOS] Fixes ScrollView centerContent not work in some cases

### DIFF
--- a/React/Views/ScrollView/RCTScrollView.m
+++ b/React/Views/ScrollView/RCTScrollView.m
@@ -298,7 +298,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
 - (void)setContentOffset:(CGPoint)contentOffset
 {
   UIView *contentView = [self contentView];
-  if (contentView && _centerContent) {
+  if (contentView && _centerContent && !CGSizeEqualToSize(contentView.frame.size, CGSizeZero)) {
     CGSize subviewSize = contentView.frame.size;
     CGSize scrollViewSize = self.bounds.size;
     if (subviewSize.width <= scrollViewSize.width) {


### PR DESCRIPTION
## Summary

The bug description can see https://github.com/facebook/react-native/issues/24688, we add `contentView` size check before center the content, because in some cases, the contentView's size not yet be calculated, in those cases, we don't adjust the `contentOffset`.

cc. @cpojer .

## Changelog

[iOS] [Fixed] - Fixes ScrollView centerContent not work in some cases

## Test Plan

`centerContent` can works on iPhoneX when using the code like below:

```
import React, {Component} from 'react';
import {ScrollView, View} from 'react-native';

export default class App extends Component {
    render() {
        return (
            <View
                style={{
                    flex: 1,
                    backgroundColor: "blue",
                    justifyContent: "center",
                    alignItems: "center",
                    flexDirection: "row"
                }}
            >
                <View style={{width: 100,
                    backgroundColor: "red",
                    height: 400}}>
                    <ScrollView
                        contentContainerStyle={{justifyContent: "center", alignItems: "center"}}
                        style={{backgroundColor: "green"}}
                        centerContent={true}
                    >
                        <View style={{backgroundColor: "orange", width: 50, height: 50}} />
                    </ScrollView>
                </View>
                <View style={{width: 100,
                    backgroundColor: "indigo",
                    height: 400}}>
                    <ScrollView
                        contentContainerStyle={{justifyContent: "center", alignItems: "center"}}
                        style={{backgroundColor: "purple"}}
                        centerContent={true}
                    >
                        <View style={{backgroundColor: "violet", width: 50, height: 50}} />
                    </ScrollView>
                </View>
            </View>
        );
    }
}
```