### PR TITLE
TM: Updates RNTester for TurboModule

### DIFF
--- a/RNTester/RNTester/AppDelegate.mm
+++ b/RNTester/RNTester/AppDelegate.mm
@@ -143,8 +143,8 @@
     __typeof(self) strongSelf = weakSelf;
     if (strongSelf) {
 #ifdef RN_TURBO_MODULE_ENABLED
-      strongSelf->_turboModuleManager = [[RCTTurboModuleManager alloc] initWithRuntime:&runtime bridge:bridge delegate:strongSelf];
-      [strongSelf->_turboModuleManager installJSBinding];
+      strongSelf->_turboModuleManager = [[RCTTurboModuleManager alloc] initWithBridge:bridge delegate:strongSelf];
+      [strongSelf->_turboModuleManager installJSBindingWithRuntime:&runtime];
 #endif
     }
   });


### PR DESCRIPTION
## Summary

We changed TM Manager API https://github.com/facebook/react-native/commit/0436f81595a932e469adcf029e07d787febe12a3, synced to update RNTester.

cc. @fkgozali 

## Changelog

[iOS] [Fixed] - Updates RNTester for TurboModule

## Test Plan

<img width="362" alt="image" src="https://user-images.githubusercontent.com/5061845/57603300-e5f21280-7593-11e9-9184-65c9be3759c7.png">
