### PR TITLE
[iOS] Change ReactNetworkForceWifiOnly from String to Boolean

### DIFF
--- a/Libraries/Network/RCTHTTPRequestHandler.mm
+++ b/Libraries/Network/RCTHTTPRequestHandler.mm
@@ -62,20 +62,19 @@ RCT_EXPORT_MODULE()
   if (!_session && [self isValid]) {
     // You can override default NSURLSession instance property allowsCellularAccess (default value YES)
     //  by providing the following key to your RN project (edit ios/project/Info.plist file in Xcode):
-    // <key>ReactNetworkForceWifiOnly</key>    <string>YES</string>
+    // <key>ReactNetworkForceWifiOnly</key>    <Boolean>YES</Boolean>
     // This will set allowsCellularAccess to NO and force Wifi only for all network calls on iOS
-    // If you do not want to override default behavior, do nothing or set key with value "NO"
+    // If you do not want to override default behavior, do nothing or set key with value NO
     NSDictionary *infoDictionary = [[NSBundle mainBundle] infoDictionary];
-    NSString *useWifiOnly = [infoDictionary objectForKey:@"ReactNetworkForceWifiOnly"];
+    NSNumber *useWifiOnly = [infoDictionary objectForKey:@"ReactNetworkForceWifiOnly"];
     
     NSOperationQueue *callbackQueue = [NSOperationQueue new];
     callbackQueue.maxConcurrentOperationCount = 1;
     callbackQueue.underlyingQueue = [[_bridge networking] methodQueue];
     NSURLSessionConfiguration *configuration = [NSURLSessionConfiguration defaultSessionConfiguration];
-    // set allowsCellularAccess to NO ONLY if key ReactNetworkForceWifiOnly exists AND string value is "YES"
-    NSString *compareKeyToForceWifiOnly = @"YES";
+    // Set allowsCellularAccess to NO ONLY if key ReactNetworkForceWifiOnly exists AND its value is YES
     if (useWifiOnly) {
-      configuration.allowsCellularAccess = ![compareKeyToForceWifiOnly isEqualToString:useWifiOnly];
+      configuration.allowsCellularAccess = ![useWifiOnly boolValue];
     }
     [configuration setHTTPShouldSetCookies:YES];
     [configuration setHTTPCookieAcceptPolicy:NSHTTPCookieAcceptPolicyAlways];

--- a/Libraries/Network/RCTHTTPRequestHandler.mm
+++ b/Libraries/Network/RCTHTTPRequestHandler.mm
@@ -62,9 +62,9 @@ RCT_EXPORT_MODULE()
   if (!_session && [self isValid]) {
     // You can override default NSURLSession instance property allowsCellularAccess (default value YES)
     //  by providing the following key to your RN project (edit ios/project/Info.plist file in Xcode):
-    // <key>ReactNetworkForceWifiOnly</key>    <Boolean>YES</Boolean>
+    // <key>ReactNetworkForceWifiOnly</key>    <true/>
     // This will set allowsCellularAccess to NO and force Wifi only for all network calls on iOS
-    // If you do not want to override default behavior, do nothing or set key with value NO
+    // If you do not want to override default behavior, do nothing or set key with value false
     NSDictionary *infoDictionary = [[NSBundle mainBundle] infoDictionary];
     NSNumber *useWifiOnly = [infoDictionary objectForKey:@"ReactNetworkForceWifiOnly"];
     


### PR DESCRIPTION
## Summary

We provided `ReactNetworkForceWifiOnly` in https://github.com/facebook/react-native/pull/24242, but it's a string type, actually the value only YES or NO, so let's change it to Boolean type, we can benefit from:
1. Users don't need to type string `YES`, just select bool YES or NO directly by click the button:
<img width="789" alt="image" src="https://user-images.githubusercontent.com/5061845/57634311-a8af7400-75d7-11e9-9f8a-ebf865d672e3.png">

2. Don't need to do string compare.

3. More looks what it should looks, Boolean is the Boolean. :)

cc. @cpojer @ericlewis .

## Changelog

[iOS] [Changed] - Change ReactNetworkForceWifiOnly from String to Boolean

## Test Plan

CI passes.