### PR TITLE
VirtualizedList.RenderItem throws when using function component with hooks

### DIFF
--- a/Libraries/Inspector/NetworkOverlay.js
+++ b/Libraries/Inspector/NetworkOverlay.js
@@ -325,7 +325,7 @@ class NetworkOverlay extends React.Component<Props, State> {
     WebSocketInterceptor.disableInterception();
   }
 
-  _renderItem = ({item, index}): ?React.Element<any> => {
+  _renderItem = ({item, index}): React.Element<any> => {
     const tableRowViewStyle = [
       styles.tableRow,
       index % 2 === 1 ? styles.tableRowOdd : styles.tableRowEven,

--- a/Libraries/Lists/FlatList.js
+++ b/Libraries/Lists/FlatList.js
@@ -34,6 +34,13 @@ export type SeparatorsObj = {
 
 type RequiredProps<ItemT> = {
   /**
+   * For simplicity, data is just a plain array. If you want to use something else, like an
+   * immutable list, use the underlying `VirtualizedList` directly.
+   */
+  data: ?$ReadOnlyArray<ItemT>,
+};
+type OptionalProps<ItemT> = {
+  /**
    * Takes an item from `data` and renders it into the list. Example usage:
    *
    *     <FlatList
@@ -65,19 +72,39 @@ type RequiredProps<ItemT> = {
     separators: SeparatorsObj,
   }) => ?React.Node,
   /**
-   * For simplicity, data is just a plain array. If you want to use something else, like an
-   * immutable list, use the underlying `VirtualizedList` directly.
-   */
-  data: ?$ReadOnlyArray<ItemT>,
-};
-type OptionalProps<ItemT> = {
-  /**
    * Rendered in between each item, but not at the top or bottom. By default, `highlighted` and
    * `leadingItem` props are provided. `renderItem` provides `separators.highlight`/`unhighlight`
    * which will update the `highlighted` prop, but you can also add custom props with
    * `separators.updateProps`.
    */
   ItemSeparatorComponent?: ?React.ComponentType<any>,
+  /**
+   * Takes an item from `data` and renders it into the list. Example usage:
+   *
+   *     <FlatList
+   *       ItemSeparatorComponent={Platform.OS !== 'android' && ({highlighted}) => (
+   *         <View style={[style.separator, highlighted && {marginLeft: 0}]} />
+   *       )}
+   *       data={[{title: 'Title Text', key: 'item1'}]}
+   *       ListItemComponent={({item, separators}) => (
+   *         <TouchableHighlight
+   *           onPress={() => this._onPress(item)}
+   *           onShowUnderlay={separators.highlight}
+   *           onHideUnderlay={separators.unhighlight}>
+   *           <View style={{backgroundColor: 'white'}}>
+   *             <Text>{item.title}</Text>
+   *           </View>
+   *         </TouchableHighlight>
+   *       )}
+   *     />
+   *
+   * Provides additional metadata like `index` if you need it, as well as a more generic
+   * `separators.updateProps` function which let's you set whatever props you want to change the
+   * rendering of either the leading separator or trailing separator in case the more common
+   * `highlight` and `unhighlight` (which set the `highlighted: boolean` prop) are insufficient for
+   * your use-case.
+   */
+  ListItemComponent?: ?(React.ComponentType<any> | React.Element<any>),
   /**
    * Rendered when the list is empty. Can be a React Component Class, a render function, or
    * a rendered element.

--- a/Libraries/Lists/FlatList.js
+++ b/Libraries/Lists/FlatList.js
@@ -622,7 +622,9 @@ class FlatList<ItemT> extends React.PureComponent<Props<ItemT>, void> {
   _renderItem = (info: RenderItemProps<ItemT>) => {
     const {renderItem, numColumns, columnWrapperStyle} = this.props;
 
-    if (!renderItem) return null;
+    if (!renderItem) {
+      return null;
+    }
 
     if (numColumns > 1) {
       const {item, index} = info;
@@ -656,7 +658,9 @@ class FlatList<ItemT> extends React.PureComponent<Props<ItemT>, void> {
   _listItemComponent = (info: RenderItemProps<ItemT>) => {
     const {ListItemComponent, numColumns, columnWrapperStyle} = this.props;
 
-    if (!ListItemComponent) return null;
+    if (!ListItemComponent) {
+      return null;
+    }
 
     if (numColumns > 1) {
       const {item, index} = info;

--- a/Libraries/Lists/FlatList.js
+++ b/Libraries/Lists/FlatList.js
@@ -24,13 +24,14 @@ import type {
   ViewToken,
   ViewabilityConfigCallbackPair,
 } from './ViewabilityHelper';
-import type {Props as VirtualizedListProps} from './VirtualizedList';
+import type {Props as VirtualizedListProps, SeparatorsObj} from './VirtualizedList';
 
-export type SeparatorsObj = {
-  highlight: () => void,
-  unhighlight: () => void,
-  updateProps: (select: 'leading' | 'trailing', newProps: Object) => void,
-};
+export type RenderItemType<ItemT> = (
+  info: {
+    item: ItemT,
+    index: number,
+    separators: SeparatorsObj
+  }) => React.Element<any>;
 
 type RequiredProps<ItemT> = {
   /**
@@ -66,11 +67,7 @@ type OptionalProps<ItemT> = {
    * `highlight` and `unhighlight` (which set the `highlighted: boolean` prop) are insufficient for
    * your use-case.
    */
-  renderItem: (info: {
-    item: ItemT,
-    index: number,
-    separators: SeparatorsObj,
-  }) => ?React.Node,
+  renderItem: RenderItemType<ItemT>,
   /**
    * Rendered in between each item, but not at the top or bottom. By default, `highlighted` and
    * `leadingItem` props are provided. `renderItem` provides `separators.highlight`/`unhighlight`

--- a/Libraries/Lists/VirtualizedList.js
+++ b/Libraries/Lists/VirtualizedList.js
@@ -37,7 +37,7 @@ import type {
 
 type Item = any;
 
-export type renderItemType = (info: any) => ?React.Element<any>;
+export type renderItemType = (info: any) => React.Element<any>;
 
 type ViewabilityHelperCallbackTuple = {
   viewabilityHelper: ViewabilityHelper,
@@ -1738,7 +1738,7 @@ class CellRenderer extends React.Component<
     } = this.props;
     const {renderItem, getItemLayout} = parentProps;
     invariant(renderItem, 'no renderItem!');
-    const element = renderItem({
+    const element = React.createElement(renderItem, {
       item,
       index,
       separators: this._separators,

--- a/Libraries/Lists/VirtualizedList.js
+++ b/Libraries/Lists/VirtualizedList.js
@@ -1670,6 +1670,7 @@ class CellRenderer extends React.Component<
     parentProps: {
       getItemLayout?: ?Function,
       renderItem: renderItemType,
+      ListItemComponent?: ?(React.ComponentType<any> | React.Element<any>),
     },
     prevCellKey: ?string,
   },
@@ -1731,13 +1732,15 @@ class CellRenderer extends React.Component<
   }
 
   _renderElement(renderItem, ListItemComponent, item, index) {
-    console.warn(
-      'VirtualizedList: Both ListItemComponent and renderItem props are present. ListItemComponent will take' +
-        ' precedence over renderItem.',
-    );
+    if (renderItem && ListItemComponent) {
+      console.warn(
+        'VirtualizedList: Both ListItemComponent and renderItem props are present. ListItemComponent will take' +
+          ' precedence over renderItem.',
+      );
+    }
 
     if (ListItemComponent) {
-      return React.createElement(renderItem, {
+      return React.createElement(ListItemComponent, {
         item,
         index,
         separators: this._separators,
@@ -1752,7 +1755,8 @@ class CellRenderer extends React.Component<
       });
     }
 
-    console.error(
+    invariant(
+      false,
       'VirtualizedList: Either ListItemComponent or renderItem props are required but none were found.',
     );
   }
@@ -1775,6 +1779,7 @@ class CellRenderer extends React.Component<
       item,
       index,
     );
+
     const onLayout =
       /* $FlowFixMe(>=0.68.0 site=react_native_fb) This comment suppresses an
        * error found when Flow v0.68 was deployed. To see the error delete this

--- a/Libraries/Lists/VirtualizedList.js
+++ b/Libraries/Lists/VirtualizedList.js
@@ -17,7 +17,6 @@ const ReactNative = require('../Renderer/shims/ReactNative');
 const RefreshControl = require('../Components/RefreshControl/RefreshControl');
 const ScrollView = require('../Components/ScrollView/ScrollView');
 const StyleSheet = require('../StyleSheet/StyleSheet');
-const UIManager = require('../ReactNative/UIManager');
 const View = require('../Components/View/View');
 const ViewabilityHelper = require('./ViewabilityHelper');
 
@@ -37,7 +36,18 @@ import type {
 
 type Item = any;
 
-export type renderItemType = (info: any) => React.Element<any>;
+export type SeparatorsObj = {
+  highlight: () => void,
+  unhighlight: () => void,
+  updateProps: (select: 'leading' | 'trailing', newProps: Object) => void,
+};
+
+export type RenderItemType = (
+  info: {
+    item: Item,
+    index: number,
+    separators: SeparatorsObj
+  }) => React.Element<any>;
 
 type ViewabilityHelperCallbackTuple = {
   viewabilityHelper: ViewabilityHelper,
@@ -65,7 +75,7 @@ type RequiredProps = {
 type OptionalProps = {
   // TODO: Conflicts with the optional `renderItem` in
   // `VirtualizedSectionList`'s props.
-  renderItem: $FlowFixMe<renderItemType>,
+  renderItem: $FlowFixMe<RenderItemType>,
   /**
    * `debug` will turn on extra logging and visual overlays to aid with debugging both usage and
    * implementation, but with a significant perf hit.
@@ -1669,7 +1679,7 @@ class CellRenderer extends React.Component<
     onUpdateSeparators: (cellKeys: Array<?string>, props: Object) => void,
     parentProps: {
       getItemLayout?: ?Function,
-      renderItem: renderItemType,
+      renderItem: RenderItemType,
       ListItemComponent?: ?(React.ComponentType<any> | React.Element<any>),
     },
     prevCellKey: ?string,

--- a/Libraries/Lists/VirtualizedList.js
+++ b/Libraries/Lists/VirtualizedList.js
@@ -42,12 +42,15 @@ export type SeparatorsObj = {
   updateProps: (select: 'leading' | 'trailing', newProps: Object) => void,
 };
 
-export type RenderItemType = (
-  info: {
-    item: Item,
-    index: number,
-    separators: SeparatorsObj
-  }) => React.Element<any>;
+export type RenderItemProps<ItemT> = {
+  item: ItemT,
+  index: number,
+  separators: SeparatorsObj,
+};
+
+export type RenderItemType<ItemT> = (
+  info: RenderItemProps<ItemT>,
+) => React.Element<any>;
 
 type ViewabilityHelperCallbackTuple = {
   viewabilityHelper: ViewabilityHelper,
@@ -75,7 +78,7 @@ type RequiredProps = {
 type OptionalProps = {
   // TODO: Conflicts with the optional `renderItem` in
   // `VirtualizedSectionList`'s props.
-  renderItem: $FlowFixMe<RenderItemType>,
+  renderItem?: $FlowFixMe<?RenderItemType<Item>>,
   /**
    * `debug` will turn on extra logging and visual overlays to aid with debugging both usage and
    * implementation, but with a significant perf hit.
@@ -125,7 +128,7 @@ type OptionalProps = {
    * Each data item is rendered using this element. Can be a React Component Class,
    * or a render function.
    */
-  ListItemComponent?: ?(React.ComponentType<any> | React.Element<any>),
+  ListItemComponent?: ?React.ComponentType<any>,
   /**
    * Rendered when the list is empty. Can be a React Component Class, a render function, or
    * a rendered element.
@@ -1679,7 +1682,7 @@ class CellRenderer extends React.Component<
     onUpdateSeparators: (cellKeys: Array<?string>, props: Object) => void,
     parentProps: {
       getItemLayout?: ?Function,
-      renderItem: RenderItemType,
+      renderItem?: ?RenderItemType<Item>,
       ListItemComponent?: ?(React.ComponentType<any> | React.Element<any>),
     },
     prevCellKey: ?string,

--- a/Libraries/Lists/VirtualizedList.js
+++ b/Libraries/Lists/VirtualizedList.js
@@ -48,9 +48,6 @@ type ViewabilityHelperCallbackTuple = {
 };
 
 type RequiredProps = {
-  // TODO: Conflicts with the optional `renderItem` in
-  // `VirtualizedSectionList`'s props.
-  renderItem: $FlowFixMe<renderItemType>,
   /**
    * The default accessor functions assume this is an Array<{key: string} | {id: string}> but you can override
    * getItem, getItemCount, and keyExtractor to handle any type of index-based data.
@@ -66,6 +63,9 @@ type RequiredProps = {
   getItemCount: (data: any) => number,
 };
 type OptionalProps = {
+  // TODO: Conflicts with the optional `renderItem` in
+  // `VirtualizedSectionList`'s props.
+  renderItem: $FlowFixMe<renderItemType>,
   /**
    * `debug` will turn on extra logging and visual overlays to aid with debugging both usage and
    * implementation, but with a significant perf hit.
@@ -111,6 +111,11 @@ type OptionalProps = {
    * or a render function. Defaults to using View.
    */
   CellRendererComponent?: ?React.ComponentType<any>,
+  /**
+   * Each data item is rendered using this element. Can be a React Component Class,
+   * or a render function.
+   */
+  ListItemComponent?: ?(React.ComponentType<any> | React.Element<any>),
   /**
    * Rendered when the list is empty. Can be a React Component Class, a render function, or
    * a rendered element.
@@ -1725,6 +1730,33 @@ class CellRenderer extends React.Component<
     this.props.onUnmount(this.props.cellKey);
   }
 
+  _renderElement(renderItem, ListItemComponent, item, index) {
+    console.warn(
+      'VirtualizedList: Both ListItemComponent and renderItem props are present. ListItemComponent will take' +
+        ' precedence over renderItem.',
+    );
+
+    if (ListItemComponent) {
+      return React.createElement(renderItem, {
+        item,
+        index,
+        separators: this._separators,
+      });
+    }
+
+    if (renderItem) {
+      return renderItem({
+        item,
+        index,
+        separators: this._separators,
+      });
+    }
+
+    console.error(
+      'VirtualizedList: Either ListItemComponent or renderItem props are required but none were found.',
+    );
+  }
+
   render() {
     const {
       CellRendererComponent,
@@ -1736,13 +1768,13 @@ class CellRenderer extends React.Component<
       inversionStyle,
       parentProps,
     } = this.props;
-    const {renderItem, getItemLayout} = parentProps;
-    invariant(renderItem, 'no renderItem!');
-    const element = React.createElement(renderItem, {
+    const {renderItem, getItemLayout, ListItemComponent} = parentProps;
+    const element = this._renderElement(
+      renderItem,
+      ListItemComponent,
       item,
       index,
-      separators: this._separators,
-    });
+    );
     const onLayout =
       /* $FlowFixMe(>=0.68.0 site=react_native_fb) This comment suppresses an
        * error found when Flow v0.68 was deployed. To see the error delete this

--- a/Libraries/Lists/__tests__/FlatList-test.js
+++ b/Libraries/Lists/__tests__/FlatList-test.js
@@ -25,6 +25,41 @@ describe('FlatList', () => {
     );
     expect(component).toMatchSnapshot();
   });
+  it('renders simple list (multiple columns)', () => {
+    const component = ReactTestRenderer.create(
+      <FlatList
+        data={[{key: 'i1'}, {key: 'i2'}, {key: 'i3'}]}
+        renderItem={({item}) => <item value={item.key} />}
+        numColumns={2}
+      />,
+    );
+    expect(component).toMatchSnapshot();
+  });
+  it('renders simple list using ListItemComponent', () => {
+    function ListItemComponent({item}) {
+      return <item value={item.key} />;
+    }
+    const component = ReactTestRenderer.create(
+      <FlatList
+        data={[{key: 'i1'}, {key: 'i2'}, {key: 'i3'}]}
+        ListItemComponent={ListItemComponent}
+      />,
+    );
+    expect(component).toMatchSnapshot();
+  });
+  it('renders simple list using ListItemComponent (multiple columns)', () => {
+    function ListItemComponent({item}) {
+      return <item value={item.key} />;
+    }
+    const component = ReactTestRenderer.create(
+      <FlatList
+        data={[{key: 'i1'}, {key: 'i2'}, {key: 'i3'}]}
+        ListItemComponent={ListItemComponent}
+        numColumns={2}
+      />,
+    );
+    expect(component).toMatchSnapshot();
+  });
   it('renders empty list', () => {
     const component = ReactTestRenderer.create(
       <FlatList data={[]} renderItem={({item}) => <item value={item.key} />} />,

--- a/Libraries/Lists/__tests__/VirtualizedList-test.js
+++ b/Libraries/Lists/__tests__/VirtualizedList-test.js
@@ -67,7 +67,6 @@ describe('VirtualizedList', () => {
     ]);
     expect(component).toMatchSnapshot();
     console.warn.mockRestore();
-    console.log(console.warn);
   });
 
   it('throws if no renderItem or ListItemComponent', () => {

--- a/Libraries/Lists/__tests__/VirtualizedList-test.js
+++ b/Libraries/Lists/__tests__/VirtualizedList-test.js
@@ -28,6 +28,24 @@ describe('VirtualizedList', () => {
     expect(component).toMatchSnapshot();
   });
 
+  it('renders simple list with hooks renderItem', () => {
+    function RenderItem({item}) {
+      const key = React.useMemo(() => item.key, [item]);
+
+      return <item value={key} />;
+    }
+
+    const component = ReactTestRenderer.create(
+      <VirtualizedList
+        data={[{key: 'i1'}, {key: 'i2'}, {key: 'i3'}]}
+        renderItem={RenderItem}
+        getItem={(data, index) => data[index]}
+        getItemCount={data => data.length}
+      />,
+    );
+    expect(component).toMatchSnapshot();
+  });
+
   it('renders empty list', () => {
     const component = ReactTestRenderer.create(
       <VirtualizedList

--- a/Libraries/Lists/__tests__/VirtualizedList-test.js
+++ b/Libraries/Lists/__tests__/VirtualizedList-test.js
@@ -28,22 +28,53 @@ describe('VirtualizedList', () => {
     expect(component).toMatchSnapshot();
   });
 
-  it('renders simple list with hooks renderItem', () => {
+  it('renders simple list renderItem component using hooks', () => {
     function RenderItem({item}) {
-      const key = React.useMemo(() => item.key, [item]);
+      const {value, onPress} = item;
+      const key = React.useMemo(() => value.key, [value]);
+      const handleOnPress = React.useCallback(() => onPress(value.key), [
+        value,
+        onPress,
+      ]);
 
-      return <item value={key} />;
+      return <item value={key} onPress={handleOnPress} />;
     }
+
+    const items = [
+      {
+        value: {key: 'i1'},
+        onPress: jest.fn(),
+      },
+      {
+        value: {key: 'i2'},
+        onPress: jest.fn(),
+      },
+      {
+        value: {key: 'i3'},
+        onPress: jest.fn(),
+      },
+    ];
 
     const component = ReactTestRenderer.create(
       <VirtualizedList
-        data={[{key: 'i1'}, {key: 'i2'}, {key: 'i3'}]}
+        data={items}
         renderItem={RenderItem}
         getItem={(data, index) => data[index]}
         getItemCount={data => data.length}
       />,
     );
     expect(component).toMatchSnapshot();
+
+    const instance = component.root;
+
+    instance.findByProps({value: 'i1'}).props.onPress();
+    expect(items[0].onPress.mock.calls).toEqual([['i1']]);
+
+    instance.findByProps({value: 'i2'}).props.onPress();
+    expect(items[1].onPress.mock.calls).toEqual([['i2']]);
+
+    instance.findByProps({value: 'i3'}).props.onPress();
+    expect(items[2].onPress.mock.calls).toEqual([['i3']]);
   });
 
   it('renders empty list', () => {

--- a/Libraries/Lists/__tests__/__snapshots__/FlatList-test.js.snap
+++ b/Libraries/Lists/__tests__/__snapshots__/FlatList-test.js.snap
@@ -185,6 +185,84 @@ exports[`FlatList renders null list 1`] = `
 </RCTScrollView>
 `;
 
+exports[`FlatList renders simple list (multiple columns) 1`] = `
+<RCTScrollView
+  data={
+    Array [
+      Object {
+        "key": "i1",
+      },
+      Object {
+        "key": "i2",
+      },
+      Object {
+        "key": "i3",
+      },
+    ]
+  }
+  disableVirtualization={false}
+  getItem={[Function]}
+  getItemCount={[Function]}
+  horizontal={false}
+  initialNumToRender={10}
+  keyExtractor={[Function]}
+  maxToRenderPerBatch={10}
+  numColumns={2}
+  onContentSizeChange={[Function]}
+  onEndReachedThreshold={2}
+  onLayout={[Function]}
+  onMomentumScrollEnd={[Function]}
+  onScroll={[Function]}
+  onScrollBeginDrag={[Function]}
+  onScrollEndDrag={[Function]}
+  removeClippedSubviews={false}
+  renderItem={[Function]}
+  scrollEventThrottle={50}
+  stickyHeaderIndices={Array []}
+  updateCellsBatchingPeriod={50}
+  viewabilityConfigCallbackPairs={Array []}
+  windowSize={21}
+>
+  <View>
+    <View
+      onLayout={[Function]}
+      style={null}
+    >
+      <View
+        style={
+          Object {
+            "flexDirection": "row",
+          }
+        }
+      >
+        <item
+          value="i1"
+        />
+        <item
+          value="i2"
+        />
+      </View>
+    </View>
+    <View
+      onLayout={[Function]}
+      style={null}
+    >
+      <View
+        style={
+          Object {
+            "flexDirection": "row",
+          }
+        }
+      >
+        <item
+          value="i3"
+        />
+      </View>
+    </View>
+  </View>
+</RCTScrollView>
+`;
+
 exports[`FlatList renders simple list 1`] = `
 <RCTScrollView
   data={
@@ -217,6 +295,151 @@ exports[`FlatList renders simple list 1`] = `
   onScrollEndDrag={[Function]}
   removeClippedSubviews={false}
   renderItem={[Function]}
+  scrollEventThrottle={50}
+  stickyHeaderIndices={Array []}
+  updateCellsBatchingPeriod={50}
+  viewabilityConfigCallbackPairs={Array []}
+  windowSize={21}
+>
+  <View>
+    <View
+      onLayout={[Function]}
+      style={null}
+    >
+      <item
+        value="i1"
+      />
+    </View>
+    <View
+      onLayout={[Function]}
+      style={null}
+    >
+      <item
+        value="i2"
+      />
+    </View>
+    <View
+      onLayout={[Function]}
+      style={null}
+    >
+      <item
+        value="i3"
+      />
+    </View>
+  </View>
+</RCTScrollView>
+`;
+
+exports[`FlatList renders simple list using ListItemComponent (multiple columns) 1`] = `
+<RCTScrollView
+  ListItemComponent={[Function]}
+  data={
+    Array [
+      Object {
+        "key": "i1",
+      },
+      Object {
+        "key": "i2",
+      },
+      Object {
+        "key": "i3",
+      },
+    ]
+  }
+  disableVirtualization={false}
+  getItem={[Function]}
+  getItemCount={[Function]}
+  horizontal={false}
+  initialNumToRender={10}
+  keyExtractor={[Function]}
+  maxToRenderPerBatch={10}
+  numColumns={2}
+  onContentSizeChange={[Function]}
+  onEndReachedThreshold={2}
+  onLayout={[Function]}
+  onMomentumScrollEnd={[Function]}
+  onScroll={[Function]}
+  onScrollBeginDrag={[Function]}
+  onScrollEndDrag={[Function]}
+  removeClippedSubviews={false}
+  scrollEventThrottle={50}
+  stickyHeaderIndices={Array []}
+  updateCellsBatchingPeriod={50}
+  viewabilityConfigCallbackPairs={Array []}
+  windowSize={21}
+>
+  <View>
+    <View
+      onLayout={[Function]}
+      style={null}
+    >
+      <View
+        style={
+          Object {
+            "flexDirection": "row",
+          }
+        }
+      >
+        <item
+          value="i1"
+        />
+        <item
+          value="i2"
+        />
+      </View>
+    </View>
+    <View
+      onLayout={[Function]}
+      style={null}
+    >
+      <View
+        style={
+          Object {
+            "flexDirection": "row",
+          }
+        }
+      >
+        <item
+          value="i3"
+        />
+      </View>
+    </View>
+  </View>
+</RCTScrollView>
+`;
+
+exports[`FlatList renders simple list using ListItemComponent 1`] = `
+<RCTScrollView
+  ListItemComponent={[Function]}
+  data={
+    Array [
+      Object {
+        "key": "i1",
+      },
+      Object {
+        "key": "i2",
+      },
+      Object {
+        "key": "i3",
+      },
+    ]
+  }
+  disableVirtualization={false}
+  getItem={[Function]}
+  getItemCount={[Function]}
+  horizontal={false}
+  initialNumToRender={10}
+  keyExtractor={[Function]}
+  maxToRenderPerBatch={10}
+  numColumns={1}
+  onContentSizeChange={[Function]}
+  onEndReachedThreshold={2}
+  onLayout={[Function]}
+  onMomentumScrollEnd={[Function]}
+  onScroll={[Function]}
+  onScrollBeginDrag={[Function]}
+  onScrollEndDrag={[Function]}
+  removeClippedSubviews={false}
   scrollEventThrottle={50}
   stickyHeaderIndices={Array []}
   updateCellsBatchingPeriod={50}

--- a/Libraries/Lists/__tests__/__snapshots__/VirtualizedList-test.js.snap
+++ b/Libraries/Lists/__tests__/__snapshots__/VirtualizedList-test.js.snap
@@ -811,18 +811,27 @@ exports[`VirtualizedList renders simple list 1`] = `
 </RCTScrollView>
 `;
 
-exports[`VirtualizedList renders simple list with hooks renderItem 1`] = `
+exports[`VirtualizedList renders simple list renderItem component using hooks 1`] = `
 <RCTScrollView
   data={
     Array [
       Object {
-        "key": "i1",
+        "onPress": [MockFunction],
+        "value": Object {
+          "key": "i1",
+        },
       },
       Object {
-        "key": "i2",
+        "onPress": [MockFunction],
+        "value": Object {
+          "key": "i2",
+        },
       },
       Object {
-        "key": "i3",
+        "onPress": [MockFunction],
+        "value": Object {
+          "key": "i3",
+        },
       },
     ]
   }
@@ -852,6 +861,7 @@ exports[`VirtualizedList renders simple list with hooks renderItem 1`] = `
       style={null}
     >
       <item
+        onPress={[Function]}
         value="i1"
       />
     </View>
@@ -860,6 +870,7 @@ exports[`VirtualizedList renders simple list with hooks renderItem 1`] = `
       style={null}
     >
       <item
+        onPress={[Function]}
         value="i2"
       />
     </View>
@@ -868,6 +879,7 @@ exports[`VirtualizedList renders simple list with hooks renderItem 1`] = `
       style={null}
     >
       <item
+        onPress={[Function]}
         value="i3"
       />
     </View>

--- a/Libraries/Lists/__tests__/__snapshots__/VirtualizedList-test.js.snap
+++ b/Libraries/Lists/__tests__/__snapshots__/VirtualizedList-test.js.snap
@@ -811,6 +811,70 @@ exports[`VirtualizedList renders simple list 1`] = `
 </RCTScrollView>
 `;
 
+exports[`VirtualizedList renders simple list with hooks renderItem 1`] = `
+<RCTScrollView
+  data={
+    Array [
+      Object {
+        "key": "i1",
+      },
+      Object {
+        "key": "i2",
+      },
+      Object {
+        "key": "i3",
+      },
+    ]
+  }
+  disableVirtualization={false}
+  getItem={[Function]}
+  getItemCount={[Function]}
+  horizontal={false}
+  initialNumToRender={10}
+  keyExtractor={[Function]}
+  maxToRenderPerBatch={10}
+  onContentSizeChange={[Function]}
+  onEndReachedThreshold={2}
+  onLayout={[Function]}
+  onMomentumScrollEnd={[Function]}
+  onScroll={[Function]}
+  onScrollBeginDrag={[Function]}
+  onScrollEndDrag={[Function]}
+  renderItem={[Function]}
+  scrollEventThrottle={50}
+  stickyHeaderIndices={Array []}
+  updateCellsBatchingPeriod={50}
+  windowSize={21}
+>
+  <View>
+    <View
+      onLayout={[Function]}
+      style={null}
+    >
+      <item
+        value="i1"
+      />
+    </View>
+    <View
+      onLayout={[Function]}
+      style={null}
+    >
+      <item
+        value="i2"
+      />
+    </View>
+    <View
+      onLayout={[Function]}
+      style={null}
+    >
+      <item
+        value="i3"
+      />
+    </View>
+  </View>
+</RCTScrollView>
+`;
+
 exports[`VirtualizedList test getItem functionality where data is not an Array 1`] = `
 <RCTScrollView
   data={

--- a/Libraries/Lists/__tests__/__snapshots__/VirtualizedList-test.js.snap
+++ b/Libraries/Lists/__tests__/__snapshots__/VirtualizedList-test.js.snap
@@ -811,27 +811,19 @@ exports[`VirtualizedList renders simple list 1`] = `
 </RCTScrollView>
 `;
 
-exports[`VirtualizedList renders simple list renderItem component using hooks 1`] = `
+exports[`VirtualizedList renders simple list using ListItemComponent 1`] = `
 <RCTScrollView
+  ListItemComponent={[Function]}
   data={
     Array [
       Object {
-        "onPress": [MockFunction],
-        "value": Object {
-          "key": "i1",
-        },
+        "key": "i1",
       },
       Object {
-        "onPress": [MockFunction],
-        "value": Object {
-          "key": "i2",
-        },
+        "key": "i2",
       },
       Object {
-        "onPress": [MockFunction],
-        "value": Object {
-          "key": "i3",
-        },
+        "key": "i3",
       },
     ]
   }
@@ -849,7 +841,6 @@ exports[`VirtualizedList renders simple list renderItem component using hooks 1`
   onScroll={[Function]}
   onScrollBeginDrag={[Function]}
   onScrollEndDrag={[Function]}
-  renderItem={[Function]}
   scrollEventThrottle={50}
   stickyHeaderIndices={Array []}
   updateCellsBatchingPeriod={50}
@@ -861,7 +852,6 @@ exports[`VirtualizedList renders simple list renderItem component using hooks 1`
       style={null}
     >
       <item
-        onPress={[Function]}
         value="i1"
       />
     </View>
@@ -870,7 +860,6 @@ exports[`VirtualizedList renders simple list renderItem component using hooks 1`
       style={null}
     >
       <item
-        onPress={[Function]}
         value="i2"
       />
     </View>
@@ -879,7 +868,6 @@ exports[`VirtualizedList renders simple list renderItem component using hooks 1`
       style={null}
     >
       <item
-        onPress={[Function]}
         value="i3"
       />
     </View>
@@ -923,6 +911,50 @@ exports[`VirtualizedList test getItem functionality where data is not an Array 1
     >
       <item
         value="item_0"
+      />
+    </View>
+  </View>
+</RCTScrollView>
+`;
+
+exports[`VirtualizedList warns if both renderItem or ListItemComponent are specified. Uses ListItemComponent 1`] = `
+<RCTScrollView
+  ListItemComponent={[Function]}
+  data={
+    Array [
+      Object {
+        "key": "i1",
+      },
+    ]
+  }
+  disableVirtualization={false}
+  getItem={[Function]}
+  getItemCount={[Function]}
+  horizontal={false}
+  initialNumToRender={10}
+  keyExtractor={[Function]}
+  maxToRenderPerBatch={10}
+  onContentSizeChange={[Function]}
+  onEndReachedThreshold={2}
+  onLayout={[Function]}
+  onMomentumScrollEnd={[Function]}
+  onScroll={[Function]}
+  onScrollBeginDrag={[Function]}
+  onScrollEndDrag={[Function]}
+  renderItem={[Function]}
+  scrollEventThrottle={50}
+  stickyHeaderIndices={Array []}
+  updateCellsBatchingPeriod={50}
+  windowSize={21}
+>
+  <View>
+    <View
+      onLayout={[Function]}
+      style={null}
+    >
+      <item
+        testID="i1-ListItemComponent"
+        value="i1"
       />
     </View>
   </View>

--- a/RNTester/js/FlatListExample.js
+++ b/RNTester/js/FlatListExample.js
@@ -51,6 +51,7 @@ type State = {|
   logViewable: boolean,
   virtualized: boolean,
   empty: boolean,
+  useFlatListItemComponent: boolean,
 |};
 
 class FlatListExample extends React.PureComponent<Props, State> {
@@ -64,6 +65,7 @@ class FlatListExample extends React.PureComponent<Props, State> {
     logViewable: false,
     virtualized: true,
     empty: false,
+    useFlatListItemComponent: false,
   };
 
   _onChangeFilterText = filterText => {
@@ -95,6 +97,7 @@ class FlatListExample extends React.PureComponent<Props, State> {
     const filter = item =>
       filterRegex.test(item.text) || filterRegex.test(item.title);
     const filteredData = this.state.data.filter(filter);
+    const flatListItemRendererProps = this._renderItemComponent();
     return (
       <RNTesterPage noSpacer={true} noScroll={true}>
         <View style={styles.container}>
@@ -118,6 +121,7 @@ class FlatListExample extends React.PureComponent<Props, State> {
               {renderSmallSwitchOption(this, 'inverted')}
               {renderSmallSwitchOption(this, 'empty')}
               {renderSmallSwitchOption(this, 'debug')}
+              {renderSmallSwitchOption(this, 'useFlatListItemComponent')}
               <Spindicator value={this._scrollPos} />
             </View>
           </View>
@@ -150,9 +154,9 @@ class FlatListExample extends React.PureComponent<Props, State> {
             onViewableItemsChanged={this._onViewableItemsChanged}
             ref={this._captureRef}
             refreshing={false}
-            renderItem={this._renderItemComponent}
             contentContainerStyle={styles.list}
             viewabilityConfig={VIEWABILITY_CONFIG}
+            {...flatListItemRendererProps}
           />
         </View>
       </RNTesterPage>
@@ -173,17 +177,26 @@ class FlatListExample extends React.PureComponent<Props, State> {
     }));
   };
   _onRefresh = () => Alert.alert('onRefresh: nothing to refresh :P');
-  _renderItemComponent = ({item, separators}) => {
-    return (
-      <ItemComponent
-        item={item}
-        horizontal={this.state.horizontal}
-        fixedHeight={this.state.fixedHeight}
-        onPress={this._pressItem}
-        onShowUnderlay={separators.highlight}
-        onHideUnderlay={separators.unhighlight}
-      />
-    );
+  _renderItemComponent = () => {
+    const flatListPropKey = this.state.useFlatListItemComponent
+      ? 'ListItemComponent'
+      : 'renderItem';
+
+    return {
+      renderItem: undefined,
+      [flatListPropKey]: ({item, separators}) => {
+        return (
+          <ItemComponent
+            item={item}
+            horizontal={this.state.horizontal}
+            fixedHeight={this.state.fixedHeight}
+            onPress={this._pressItem}
+            onShowUnderlay={separators.highlight}
+            onHideUnderlay={separators.unhighlight}
+          />
+        );
+      },
+    };
   };
   // This is called when items change viewability by scrolling into or out of
   // the viewable area.

--- a/template/package.json
+++ b/template/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "react": "16.8.1",
-    "react-native": "1000.0.0"
+    "react-native": "file:/Users/akenyon/repos/react-native/react-native-1000.0.0.tgz"
   },
   "devDependencies": {
     "@babel/core": "^7.3.3",

--- a/template/package.json
+++ b/template/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "react": "16.8.1",
-    "react-native": "file:/Users/akenyon/repos/react-native/react-native-1000.0.0.tgz"
+    "react-native": "1000.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.3.3",


### PR DESCRIPTION
## Summary

`<VirtualizedList />` will throw an error if the `renderItem` Prop component uses hooks. Function components without hooks and class components work without issue.

Super contrived Example
```{js}
function FlatListItem({ item }) {
  React.useEffect(() => console.log(item),[])

 return (<Text>{item}</Text>);
}

<FlatList data={[1, 2, 3]} renderItem={FlatListItem} />
```

Example Error:
```
Invariant Violation: Hooks can only be called inside the body of a function component. (https://fb.me/react-invalid-hook-call)

This error is located at:
    in CellRenderer (at VirtualizedList.js:688)
    in RCTScrollContentView (at ScrollView.js:976)
    in RCTScrollView (at ScrollView.js:1115)
    in ScrollView (at VirtualizedList.js:1081)
    in VirtualizedList (at FlatList.js:632)
    in FlatList (at WithoutScrollbars.js:21)
    ...
```

## Changelog

[General] [Added] - VirtualizedList ListItemComponent. An alternative to renderItem that accepts function components with hooks.
[General][Added] - FlatList ListItemComponent. An alternative to renderItem that accepts function components with hooks.
[General][Added] - VirtualizedList and FlatList tests and updated RNTester example

## Test Plan

Updated JS tests for VirtualizedList and tested on local build.
