### PR TITLE
Text: Fix inline views sometimes have the wrong size/position after the text content changes

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactShadowNode.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactShadowNode.java
@@ -128,6 +128,7 @@ public interface ReactShadowNode<T extends ReactShadowNode> {
   /* package */ boolean dispatchUpdates(
       float absoluteX,
       float absoluteY,
+      ViewManager viewManager,
       UIViewOperationQueue uiViewOperationQueue,
       NativeViewHierarchyOptimizer nativeViewHierarchyOptimizer);
 

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIImplementation.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIImplementation.java
@@ -941,6 +941,7 @@ public class UIImplementation {
       boolean frameDidChange = cssNode.dispatchUpdates(
           absoluteX,
           absoluteY,
+          resolveViewManager(cssNode.getViewClass()),
           mOperationsQueue,
           mNativeViewHierarchyOptimizer);
 

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
@@ -280,7 +280,9 @@ public class ReactTextView extends AppCompatTextView implements ReactCompoundVie
       }
     }
 
-    // Ensure onLayout is called so the inline views can be repositioned.
+    // Ensure `onLayout` is called so the inline views can be repositioned. Without this, when React
+    // Native calls `layout` on this view, it could be a no-op if Android doesn't consider this
+    // view's layout to be dirty.
     requestLayout();
   }
 


### PR DESCRIPTION
I'm especially interested in feedback on the section titled "Is this a sign of a more general problem?".

## Summary

Sometimes after a `<Text>` changes, its inline views have the wrong size or location. More specifically, the bug occurs when a `<Text>` that contains inline views updates but the `<Text>'s` dimensions don't change. Here's an example repro:

```js
import React, { Component } from 'react';
import { ScrollView, StyleSheet, Button, Text, TextInput, View, UIManager } from 'react-native';

type Props = {};
export default class Test extends Component<Props> {
  state = { atBeginning: false }

  _renderText() {
    if (this.state.atBeginning) {
      return (
        <Text style={{backgroundColor: 'lightgrey'}}>
          <View style={{backgroundColor: 'steelblue', width: 50, height: 50}} /> I  have an inline view
        </Text>
      );
    } else {
      return (
        <Text style={{backgroundColor: 'lightgrey'}}>
          I have an inline view <View style={{backgroundColor: 'steelblue', width: 50, height: 50}} />
        </Text>
      );
    }
  }
  render() {
    return (
      <View>
        <Button title="Toggle inline view position" onPress={() => this.setState({atBeginning: !this.state.atBeginning})} />
        {this._renderText()}
      </View>
    );
  }
}
```

Everything looks good when the app launches. After you press the "Toggle inline view position", the blue inline view disappears. It never comes back no matter how many times you push the button.

## Background

Here's an explaination of how Android's native view layout system works based on the [docs](https://developer.android.com/guide/topics/ui/how-android-draws) and some code (e.g. [Android's View class](https://github.com/aosp-mirror/platform_frameworks_base/blob/faf31f86381122507398624698b7c89273f01ff5/core/java/android/view/View.java#L19644-L19659)). Layout happens from top to bottom. `layout` is the public API that causes a view to lay itself out. `requestLayout` is how you can mark yourself and your ancestors as dirty so you'll be included in the next layout pass. Views that want to do custom layout should implement `onLayout` and call `layout` on the children. You shouldn't override `layout`. The Android framework's `layout` implementation calls `onLayout` if necessary.

React Native circumvents Android's layout system. Normally, an `onLayout` implementation should call `layout` on each of its children. Instead, `ReactViewGroup` provides a no-op implementation for `onLayout`. The way `layout` gets called on views is React Native schedules `layout` calls via `nativeViewHierarchyOptimizer.handleUpdateLayout(this)`.

React Native's `Text` component positions inline views in [`ReactTextView.onLayout`](https://github.com/facebook/react-native/blob/2cdf9694b56e76477dde572eb3dc38be31361eab/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java#L95).

## Cause & Fix

When the bug repros, `ReactTextView.onLayout` is skipped. The reason it gets skipped is that [ReactShadowNodeImpl.dispatchUpdates](https://github.com/facebook/react-native/blob/2cdf9694b56e76477dde572eb3dc38be31361eab/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactShadowNodeImpl.java#L362-L376) chooses not to call `nativeViewHierarchyOptimizer.handleUpdateLayout(this)` on the `<Text>` because the `<Text>'s` dimensions haven't changed.

Skipping `nativeViewHierarchyOptimizer.handleUpdateLayout(this)` when a node's dimensions haven't changed is usually a safe optimization. However, this is not the case when the node lays out its own children in `onLayout`. In React Native, such views are represented by returning `true` in `needsCustomLayoutForChildren` so we disable the optimization for these views.

Note that we attempted to cover this case by scheduling a layout via `requestLayout` in `setText`. However, this wasn't sufficient for rerunning layout because, as described earlier, React Native circumvents Android's native layout system. `requestLayout` is needed in addition to this PR's fix. For details, see the comment above `requestLayout`.

## Is this a sign of a more general problem?

I have now seen 4 cases where code wants to force a view to be relaid out and has to resort to tricky solutions. Examples:
  1. `ReactTextView` (what this PR is about)
    - Scenario: Text content changes on a `<Text>` that has inline views
    - Symptom: Inline views have the wrong size/position because `ReactTextView.onLayout` didn't run.
    - Solution: Change React Native internals to disable an optimization which skips layout when a view's dimensions haven't changed (disabled only for views that layout their own children).
  2. `ReactToolbar`
    - Scenario: Certain properties (e.g. `setLogo`) are updated.
    - Symptom: `Toolbar's` UI isn't updated becaues it expects layout to run.
    - Solution: Schedule `measure` and `layout` calls in `requestLayout` ([code](https://github.com/facebook/react-native/blob/8d5ac8de766b9e435cbfa9bfa6b8a2b75b0e2a19/ReactAndroid/src/main/java/com/facebook/react/views/toolbar/ReactToolbar.java#L164-L181)).
  3. `ReactPicker`
    - Scenario: Not sure
    - Symptom: The widget doesn't update selection or call the appropriate listeners.
    - Solution: Same as `ReactToolbar`: schedule `measure` and `layout` calls in `requestLayout` ([code](https://github.com/facebook/react-native/blob/310cc38a5acb79ba0f1cda22913bd1d0cb296034/ReactAndroid/src/main/java/com/facebook/react/views/picker/ReactPicker.java#L75-L94)).
  4. Custom `RecyclerView` subclass (I'm recalling this from memory so there may be inaccuracies)
    - Scenario: Custom view properties are changed which affect the set of items shown in the `RecyclerView`.
    - Symptom: `RecyclerView` continues showing the old set of items.
    - Solution: Force the `RecyclerView` to be relaid out by scheduling a layout with `UIViewOperationQueue.enqueueUpdateLayout` in `onCollectExtraUpdates` (but be careful not to schedule one if React Native already scheduled one -- we don't want to do extra work).
    - Additional Details: The `ReactToolbar/ReactPicker` solution of scheduling `measure` and `layout` calls in `requestLayout` was insufficient because it resulted in flickering. In our use case, we'd set some properties on the `RecyclerView` and then reveal it to the user. However, when the `RecyclerView` was revealed to the user, it would briefly show its old items. After `mesaure` and `layout` ran, it finally showed its new items.

Should React Native have one easy solution for all of these problems? Here's one idea: a React Native mechanism to say "schedule a layout on my view if one isn't already scheduled (if there's already a layout scheduled on my view, I don't want to schedule 2 of them)".

I think such a mechanism could solve most of the problems above. For example, the inline view problem could be solved by ensuring a layout is scheduled in `setText` like we tried with `requestLayout`. Similarly, `ReactToolbar` and the custom `RecylerView` could ensure a layout is scheduled whenever a relevant view property changes.

@shergin, @mdvacca, and others: what are your thoughts on this?

## Changelog

[Android] [Fixed] - Text: Fix inline views sometimes have the wrong size/position after the text content changes

## Test Plan

Used the example from this PR to verify that the bug no longer repros after the fix.

Adam Comella
Microsoft Corp.