### PR TITLE
[iOS] Resubmit #24714 and fixes kvo crash

### DIFF
--- a/Libraries/Text/TextInput/Singleline/RCTUITextField.m
+++ b/Libraries/Text/TextInput/Singleline/RCTUITextField.m
@@ -176,6 +176,16 @@
 
 #pragma mark - Overrides
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
+// Overrides selectedTextRange setter to get notify when selectedTextRange changed.
+- (void)setSelectedTextRange:(UITextRange *)selectedTextRange
+{
+  [super setSelectedTextRange:selectedTextRange];
+  [_textInputDelegateAdapter selectedTextRangeWasSet];
+}
+#pragma clang diagnostic pop
+
 - (void)setSelectedTextRange:(UITextRange *)selectedTextRange notifyDelegate:(BOOL)notifyDelegate
 {
   if (!notifyDelegate) {


### PR DESCRIPTION
## Summary

Resubmit #24714. 
From the https://github.com/facebook/react-native/pull/24714#issuecomment-491962489, seems it would crash sometimes. @JoshuaGross Hi :) I added a method to let `UITextField` call the cleanup explicitly. Please check again, thanks! 

## Changelog

[iOS] [Fixed] - Fixes selection of single line text input

## Test Plan

Create a single line textInput, then do some selection, `onSelectionChange` can be called.