### PR TITLE
Open links from new app screen in computer's browser

### DIFF
--- a/Libraries/Core/Devtools/openURLInBrowser.js
+++ b/Libraries/Core/Devtools/openURLInBrowser.js
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow strict-local
+ */
+
+'use strict';
+
+const getDevServer = require('./getDevServer');
+
+function openURLInBrowser(url: string) {
+  fetch(getDevServer().url + 'open-url', {
+    method: 'POST',
+    body: JSON.stringify({url}),
+  });
+}
+
+module.exports = openURLInBrowser;

--- a/Libraries/NewAppScreen/components/LearnMoreLinks.js
+++ b/Libraries/NewAppScreen/components/LearnMoreLinks.js
@@ -11,7 +11,8 @@
 'use strict';
 
 import React from 'react';
-import {View, Text, StyleSheet, TouchableOpacity, Linking} from 'react-native';
+import {View, Text, StyleSheet, TouchableOpacity} from 'react-native';
+import openURLInBrowser from 'react-native/Libraries/Core/Devtools/openURLInBrowser';
 import Colors from './Colors';
 
 const links = [
@@ -70,7 +71,7 @@ const LinkList = () => (
           <View style={styles.separator} />
           <TouchableOpacity
             accessibilityRole={'button'}
-            onPress={() => Linking.openURL(item.link)}
+            onPress={() => openURLInBrowser(item.link)}
             style={styles.linkContainer}>
             <Text style={styles.link}>{item.title}</Text>
             <Text style={styles.description}>{item.description}</Text>

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.0.0",
-    "@react-native-community/cli": "^2.0.0-alpha.19",
+    "@react-native-community/cli": "2.0.0-alpha.19",
     "@react-native-community/cli-platform-android": "2.0.0-alpha.15",
     "@react-native-community/cli-platform-ios": "2.0.0-alpha.15",
     "abort-controller": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -79,9 +79,9 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.0.0",
-    "@react-native-community/cli": "2.0.0-alpha.16",
-    "@react-native-community/cli-platform-ios": "2.0.0-alpha.15",
+    "@react-native-community/cli": "^2.0.0-alpha.19",
     "@react-native-community/cli-platform-android": "2.0.0-alpha.15",
+    "@react-native-community/cli-platform-ios": "2.0.0-alpha.15",
     "abort-controller": "^3.0.0",
     "art": "^0.10.0",
     "base64-js": "^1.1.2",


### PR DESCRIPTION
## Summary

This PR is related to #24760 and adds the `openURLInBrowser` functionality introduced on react-native-community/cli#383.

## Changelog

[General] [Changed] - Open links from new app in computer's browser.

## Test Plan

1. Run `npm i` to install the new dep (bumped `@react-native-community/cli` to `v2.0.0-alpha.19`);
1. Open and run `RNTester/RNTesterPods.xcworkspace`;
1. Search for `new` in the list of the `RNTester`, tap the first item and click on any link, that link should open in your computer's default browser.

If any of these steps don't work please let me know and we will fix them.

cc @cpojer.
