### PR TITLE
[Android] fix: set js delta bundle default value to false

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevInternalSettings.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevInternalSettings.java
@@ -136,7 +136,7 @@ public class DevInternalSettings implements
 
   @SuppressLint("SharedPreferencesUse")
   public boolean isBundleDeltasEnabled() {
-    return mPreferences.getBoolean(PREFS_JS_BUNDLE_DELTAS_KEY, true);
+    return mPreferences.getBoolean(PREFS_JS_BUNDLE_DELTAS_KEY, false);
   }
 
   @SuppressLint("SharedPreferencesUse")


### PR DESCRIPTION
## Summary

When running Android app for the first time, the packager is requesting delta bundles from metro instead of a bundle (in dev settings delta bundles are disabled by default and marked as experimental). UI of dev settings is not consistent with the current state, to turn off delta bundles you have to enable them and then disable.

## Changelog

[Android] [Fixed] - Disable delta bundles on the first app run

## Test Plan

Run android app and packager should use bundle instead of delta bundle.
