### PR TITLE
revert gradle download plugin import

### DIFF
--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -6,7 +6,7 @@
 plugins {
     id("com.android.library")
     id("maven")
-    id("de.undercouch.download") version "3.4.3"
+    id("de.undercouch.download")
 }
 
 import de.undercouch.gradle.tasks.download.Download

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,6 +11,7 @@ buildscript {
     }
     dependencies {
         classpath("com.android.tools.build:gradle:3.4.0")
+        classpath("de.undercouch:gradle-download-task:3.4.3")
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
## Summary

Revert Gradle download plugin import, because new way is causing some issues when building from source.

## Changelog

[Android] [Changed] - revert Gradle download plugin import

## Test Plan

CI is green, and RNTester works as expected