### PR TITLE
TM iOS: Consolidate RCTDidInitializeModuleNotification sender to batchedBridge

### DIFF
--- a/ReactCommon/turbomodule/core/platform/ios/RCTTurboModuleManager.mm
+++ b/ReactCommon/turbomodule/core/platform/ios/RCTTurboModuleManager.mm
@@ -239,7 +239,7 @@ static Class getFallbackClassFromName(const char *name) {
    * TurboModules are rolled out
    */
   [[NSNotificationCenter defaultCenter] postNotificationName:RCTDidInitializeModuleNotification
-                                                      object:_bridge.parentBridge
+                                                      object:_bridge
                                                     userInfo:@{@"module": module, @"bridge": RCTNullIfNil(_bridge.parentBridge)}];
   return module;
 }


### PR DESCRIPTION
## Summary

Consolidate sender of notification to `batchedBridge` for TM and old module system, old module implementation can see https://github.com/facebook/react-native/blob/dc893756b82051d48d6a776aeef1186c31cf310d/React/Base/RCTModuleData.mm#L191-L193.

## Changelog

[iOS] [Fixed] - Conlidate RCTDidInitializeModuleNotification sender to batchedBridge

## Test Plan

N/A.