### PR TITLE
Add Fabric/Turbo Modules flags to iOS autolinking script

### DIFF
--- a/RNTester/Podfile
+++ b/RNTester/Podfile
@@ -7,7 +7,7 @@ target 'RNTester' do
   # use_frameworks!
 
   project 'RNTesterPods.xcodeproj'
-  use_react_native!(path: "..")
+  use_react_native!(path: "..", turbo_modules_enabled: true)
 
   # Additional Pods which aren't included in the default Podfile
   pod 'React-RCTCameraRoll', :path => '../Libraries/CameraRoll'
@@ -16,13 +16,7 @@ target 'RNTester' do
 
   # Additional Pods which are classed as unstable
   #
-  # Fabric Pods, uncomment these to enable in RNTester
-  # pod 'React-Fabric', :path => '../ReactCommon'
-  # pod 'React-graphics', :path => '../ReactCommon/fabric/graphics'
-  # pod 'React-jsi/Fabric', :path => '../ReactCommon/jsi'
-  # pod 'React-RCTFabric', :path => '../React'
-  # pod 'Folly/Fabric', :podspec => '../third-party-podspecs/Folly.podspec'
+  # To use fabric: add `fabric_enabled` option to the use_react_native method above
 
-  pod 'React-turbomodule-core', :path => '../ReactCommon/turbomodule/core'
   pod 'React-turbomodule-samples', :path => '../ReactCommon/turbomodule/samples'
 end

--- a/scripts/autolink-ios.rb
+++ b/scripts/autolink-ios.rb
@@ -2,6 +2,12 @@ def use_react_native! (options={})
 
   # The prefix to the react-native
   prefix = options[:path] ||= "../node_modules/react-native"
+  
+  # Include Fabric dependencies
+  fabric_enabled = options[:fabric_enabled] ||= false
+  
+  # Include Turbo Modules dependencies
+  turbo_modules_enabled = options[:turbo_modules_enabled ||= false
 
   # Include DevSupport dependency
   production = options[:production] ||= false
@@ -35,4 +41,16 @@ def use_react_native! (options={})
   pod 'DoubleConversion', :podspec => "#{prefix}/third-party-podspecs/DoubleConversion.podspec"
   pod 'glog', :podspec => "#{prefix}/third-party-podspecs/glog.podspec"
   pod 'Folly', :podspec => "#{prefix}/third-party-podspecs/Folly.podspec"
+
+  if fabric_enabled
+    pod 'React-Fabric', :path => "#{prefix}/ReactCommon"
+    pod 'React-graphics', :path => "#{prefix}/ReactCommon/fabric/graphics"
+    pod 'React-jsi/Fabric', :path => "#{prefix}/ReactCommon/jsi"
+    pod 'React-RCTFabric', :path => "#{prefix}/React"
+    pod 'Folly/Fabric', :podspec => "#{prefix}/third-party-podspecs/Folly.podspec"
+  end
+  
+  if turbo_modules_enabled
+    pod 'React-turbomodule-core', :path => "#{prefix}/ReactCommon/turbomodule/core"
+  end
 end


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
This makes it easier to enable fabric / turbo modules with the new fancy autolinking script.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See http://facebook.github.io/react-native/docs/contributing#changelog for an example. -->

[iOS] [Added] - Add Fabric/Turbo Module flags to iOS autolinking script

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
RNTester's TurboModules still work