### PR TITLE
[General] [Fix] - update CLI to alpha.20 to fix Android tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,9 +79,9 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.0.0",
-    "@react-native-community/cli": "2.0.0-alpha.19",
-    "@react-native-community/cli-platform-android": "2.0.0-alpha.15",
-    "@react-native-community/cli-platform-ios": "2.0.0-alpha.15",
+    "@react-native-community/cli": "2.0.0-alpha.20",
+    "@react-native-community/cli-platform-android": "2.0.0-alpha.20",
+    "@react-native-community/cli-platform-ios": "2.0.0-alpha.20",
     "abort-controller": "^3.0.0",
     "art": "^0.10.0",
     "base64-js": "^1.1.2",


### PR DESCRIPTION
## Summary

PR https://github.com/facebook/react-native/pull/24843 broke Android tests because of a regression we introduced in terms of passing `reporter` argument to Metro config. This was fixed in latest `alpha.20` release of CLI

## Changelog

[General] [Fix] - update CLI to alpha.20 to fix Android tests

## Test Plan

CI will tell
