### PR TITLE
Bump create-react-class

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "art": "^0.10.0",
     "base64-js": "^1.1.2",
     "connect": "^3.6.5",
-    "create-react-class": "^15.6.3",
+    "create-react-class": "^16.8.6",
     "escape-string-regexp": "^1.0.5",
     "event-target-shim": "^5.0.1",
     "fbjs": "^1.0.0",


### PR DESCRIPTION
## Summary

Besides aligning with actual React version that react-native depends on, this eliminates this warning in every yarn/npm install:
```warning react-native > create-react-class > fbjs > core-js@1.2.7: core-js@<2.6.5 is no longer maintained. Please, upgrade to core-js@3 or at least to actual version of core-js@2.
```


## Changelog

[internal][chore] - Eliminate annoying warning about core-js being deprecated.

## Test Plan

