### PR TITLE
 [iOS] Fixes syntax of autolink script

### DIFF
--- a/RNTester/Podfile
+++ b/RNTester/Podfile
@@ -7,7 +7,10 @@ target 'RNTester' do
   # use_frameworks!
 
   project 'RNTesterPods.xcodeproj'
+  
+  # Enable TurboModule
   use_react_native!(path: "..", turbo_modules_enabled: true)
+  pod 'React-turbomodule-samples', :path => '../ReactCommon/turbomodule/samples'
 
   # Additional Pods which aren't included in the default Podfile
   pod 'React-RCTCameraRoll', :path => '../Libraries/CameraRoll'
@@ -16,7 +19,6 @@ target 'RNTester' do
 
   # Additional Pods which are classed as unstable
   #
-  # To use fabric: add `fabric_enabled` option to the use_react_native method above
-
-  pod 'React-turbomodule-samples', :path => '../ReactCommon/turbomodule/samples'
+  # To use fabric: uncomment the line below
+  # use_react_native!(path: "..", fabric_enabled: true)
 end

--- a/RNTester/Podfile
+++ b/RNTester/Podfile
@@ -19,6 +19,6 @@ target 'RNTester' do
 
   # Additional Pods which are classed as unstable
   #
-  # To use fabric: uncomment the line below
-  # use_react_native!(path: "..", fabric_enabled: true)
+  # To use fabric: add `fabric_enabled` option to the use_react_native method above, like below
+  # use_react_native!(path: "..", turbo_modules_enabled: true, fabric_enabled: true)
 end

--- a/scripts/autolink-ios.rb
+++ b/scripts/autolink-ios.rb
@@ -7,7 +7,7 @@ def use_react_native! (options={})
   fabric_enabled = options[:fabric_enabled] ||= false
   
   # Include Turbo Modules dependencies
-  turbo_modules_enabled = options[:turbo_modules_enabled ||= false
+  turbo_modules_enabled = options[:turbo_modules_enabled] ||= false
 
   # Include DevSupport dependency
   production = options[:production] ||= false


### PR DESCRIPTION
## Summary

Oops, fixes syntax of autolink script landed in https://github.com/facebook/react-native/pull/24867.

## Changelog

[iOS] [Fixed] - Fixes syntax of autolink script

## Test Plan

`RNTesterPods` project run success.