### PR TITLE
use docker image version 2019-5-16

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,7 +157,7 @@ js_defaults: &js_defaults
 android_defaults: &android_defaults
   <<: *defaults
   docker:
-    - image: reactnativecommunity/react-native-android:2019-5-7
+    - image: reactnativecommunity/react-native-android:2019-5-16
   resource_class: "large"
   environment:
     - TERM: "dumb"

--- a/scripts/android-setup.sh
+++ b/scripts/android-setup.sh
@@ -17,7 +17,7 @@ function getAndroidPackages {
   # Package names can be obtained using `sdkmanager --list`
   if [ ! -e "$DEPS" ] || [ ! "$CI" ]; then
     echo "Installing Android API level $ANDROID_SDK_TARGET_API_LEVEL, Google APIs, $AVD_ABI system image..."
-    sdkmanager "system-images;android-$ANDROID_SDK_TARGET_API_LEVEL;google_apis;$AVD_ABI"
+    sdkmanager "system-images;android-$ANDROID_SDK_TARGET_API_LEVEL;default;$AVD_ABI"
     echo "Installing build SDK for Android API level $ANDROID_SDK_BUILD_API_LEVEL..."
     sdkmanager "platforms;android-$ANDROID_SDK_BUILD_API_LEVEL"
     echo "Installing target SDK for Android API level $ANDROID_SDK_TARGET_API_LEVEL..."
@@ -49,7 +49,7 @@ function getAndroidNDK {
 }
 
 function createAVD {
-  AVD_PACKAGES="system-images;android-$ANDROID_SDK_TARGET_API_LEVEL;google_apis;$AVD_ABI"
+  AVD_PACKAGES="system-images;android-$ANDROID_SDK_TARGET_API_LEVEL;default;$AVD_ABI"
   echo "Creating AVD with packages $AVD_PACKAGES"
   echo no | avdmanager create avd --name "$AVD_NAME" --force --package "$AVD_PACKAGES" --tag google_apis --abi "$AVD_ABI"
 }

--- a/scripts/android-setup.sh
+++ b/scripts/android-setup.sh
@@ -51,7 +51,7 @@ function getAndroidNDK {
 function createAVD {
   AVD_PACKAGES="system-images;android-$ANDROID_SDK_TARGET_API_LEVEL;default;$AVD_ABI"
   echo "Creating AVD with packages $AVD_PACKAGES"
-  echo no | avdmanager create avd --name "$AVD_NAME" --force --package "$AVD_PACKAGES" --tag google_apis --abi "$AVD_ABI"
+  echo no | avdmanager create avd --name "$AVD_NAME" --force --package "$AVD_PACKAGES" --tag default --abi "$AVD_ABI"
 }
 
 function launchAVD {


### PR DESCRIPTION
## Summary

Docker image version 2019-5-16 includes latest buck (2019.05.14.01) and latest version of Android emulator. Latest emulator includes headless version, which improves CI usage.

## Changelog

[Android] [Changed] - use Docker image version 2019-5-16 for CI

## Test Plan

CI is broken due to another issue. This image has no significant changes that would affect CI.