### PR TITLE
[TM] Add spec for TVNavigationEventEmitter

### DIFF
--- a/Libraries/Components/AppleTV/NativeTVNavigationEventEmitter.js
+++ b/Libraries/Components/AppleTV/NativeTVNavigationEventEmitter.js
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ */
+
+'use strict';
+
+import type {TurboModule} from 'RCTExport';
+import * as TurboModuleRegistry from 'TurboModuleRegistry';
+
+export interface Spec extends TurboModule {
+  +addListener: (eventName: string) => void;
+  +removeListeners: (count: number) => void;
+}
+
+export default TurboModuleRegistry.getEnforcing<Spec>(
+  'TVNavigationEventEmitter',
+);

--- a/Libraries/Components/AppleTV/TVEventHandler.js
+++ b/Libraries/Components/AppleTV/TVEventHandler.js
@@ -11,9 +11,9 @@
 'use strict';
 
 const Platform = require('../../Utilities/Platform');
-const TVNavigationEventEmitter = require('../../BatchedBridge/NativeModules')
-  .TVNavigationEventEmitter;
 const NativeEventEmitter = require('../../EventEmitter/NativeEventEmitter');
+
+import NativeTVNavigationEventEmitter from './NativeTVNavigationEventEmitter';
 
 function TVEventHandler() {
   this.__nativeTVNavigationEventListener = null;
@@ -24,12 +24,12 @@ TVEventHandler.prototype.enable = function(
   component: ?any,
   callback: Function,
 ) {
-  if (Platform.OS === 'ios' && !TVNavigationEventEmitter) {
+  if (Platform.OS === 'ios' && !NativeTVNavigationEventEmitter) {
     return;
   }
 
   this.__nativeTVNavigationEventEmitter = new NativeEventEmitter(
-    TVNavigationEventEmitter,
+    NativeTVNavigationEventEmitter,
   );
   this.__nativeTVNavigationEventListener = this.__nativeTVNavigationEventEmitter.addListener(
     'onHWKeyEvent',


### PR DESCRIPTION
## Summary

Part of #24875

## Changelog

[General] [Added] - Add TurboModule spec for TVNavigationEventEmitter

## Test Plan

Run `yarn flow-check-ios` and `yarn flow-check-android` at the root level