### PR TITLE
[CI] Consolidate test_end_to_end back into other jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -487,15 +487,15 @@ jobs:
       - save-cache: *save-yarn-cache
 
       # Xcode build
-      - run:
-          name: Build app for Detox iOS End-to-End Tests
-          command: yarn run build-ios-e2e
+      # - run:
+      #     name: Build app for Detox iOS End-to-End Tests
+      #     command: yarn run build-ios-e2e
 
       # Test
-      - run:
-          name: Run Detox iOS End-to-End Tests
-          command: yarn run test-ios-e2e
-          when: always
+      # - run:
+      #     name: Run Detox iOS End-to-End Tests
+      #     command: yarn run test-ios-e2e
+      #     when: always
 
       - run:
           name: Run JavaScript End-to-End Tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -721,7 +721,7 @@ workflows:
       - test_javascript: *run-after-checkout
       - test_android: *run-after-checkout
       - test_ios: *run-after-checkout
-      # - test_detox_ios: *run-after-checkout
+      - test_detox_ios: *run-after-checkout
       - test_docker_build:
           filters: *filter-ignore-gh-pages
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -309,6 +309,16 @@ jobs:
           name: JavaScript Test Suite
           command: node ./scripts/run-ci-javascript-tests.js --maxWorkers 2
 
+      - run:
+          name: JavaScript End-to-End Tests
+          command: |
+            # free up port 8081 for the packager before running tests
+            set +eo pipefail
+            lsof -i tcp:8081 | awk 'NR!=1 {print $2}' | xargs kill
+            set -eo pipefail
+            node ./scripts/run-ci-e2e-tests.js --js --retries 3
+          when: always
+
       - store_test_results:
           path: ~/react-native/reports/junit
 
@@ -449,11 +459,21 @@ jobs:
             # kill whatever is occupying port 5555 (web socket server)
             lsof -i tcp:5555 | awk 'NR!=1 {print $2}' | xargs kill
 
+      # - run:
+      #     name: Run iOS End-to-End Tests
+      #     command: |
+      #       # free up port 8081 for the packager before running tests
+      #       set +eo pipefail
+      #       lsof -i tcp:8081 | awk 'NR!=1 {print $2}' | xargs kill
+      #       set -eo pipefail
+      #       node ./scripts/run-ci-e2e-tests.js --ios --retries 3;
+      #     when: always
+
       - store_test_results:
           path: ~/react-native/reports/junit
 
-  # Runs end-to-end tests
-  test_end_to_end:
+  # Runs Detox iOS tests
+  test_detox_ios:
     <<: *macos_defaults
     steps:
       - attach_workspace:
@@ -487,34 +507,14 @@ jobs:
       - save-cache: *save-yarn-cache
 
       # Xcode build
-      # - run:
-      #     name: Build app for Detox iOS End-to-End Tests
-      #     command: yarn run build-ios-e2e
+      - run:
+          name: Build app for Detox iOS End-to-End Tests
+          command: yarn run build-ios-e2e
 
       # Test
-      # - run:
-      #     name: Run Detox iOS End-to-End Tests
-      #     command: yarn run test-ios-e2e
-      #     when: always
-
       - run:
-          name: Run JavaScript End-to-End Tests
-          command: |
-            # free up port 8081 for the packager before running tests
-            set +eo pipefail
-            lsof -i tcp:8081 | awk 'NR!=1 {print $2}' | xargs kill
-            set -eo pipefail
-            node ./scripts/run-ci-e2e-tests.js --js --retries 3
-          when: always
-
-      - run:
-          name: Run iOS End-to-End Tests
-          command: |
-            # free up port 8081 for the packager before running tests
-            set +eo pipefail
-            lsof -i tcp:8081 | awk 'NR!=1 {print $2}' | xargs kill
-            set -eo pipefail
-            node ./scripts/run-ci-e2e-tests.js --ios --retries 3;
+          name: Run Detox iOS End-to-End Tests
+          command: yarn run test-ios-e2e
           when: always
 
 
@@ -721,7 +721,7 @@ workflows:
       - test_javascript: *run-after-checkout
       - test_android: *run-after-checkout
       - test_ios: *run-after-checkout
-      - test_end_to_end: *run-after-checkout
+      # - test_detox_ios: *run-after-checkout
       - test_docker_build:
           filters: *filter-ignore-gh-pages
 

--- a/scripts/run-ci-e2e-tests.js
+++ b/scripts/run-ci-e2e-tests.js
@@ -32,6 +32,7 @@ const tryExecNTimes = require('./try-n-times');
 
 const TEMP = exec('mktemp -d /tmp/react-native-XXXXXXXX').stdout.trim();
 const numberOfRetries = argv.retries || 1;
+let PACKAGE;
 let SERVER_PID;
 let APPIUM_PID;
 let exitCode;
@@ -68,7 +69,7 @@ try {
     if (
       tryExecNTimes(
         () => {
-          return exec('npm install --save-dev flow-bin').code;
+          return exec('yarn add --dev flow-bin').code;
         },
         numberOfRetries,
         () => exec('sleep 10s'),
@@ -87,7 +88,7 @@ try {
     throw Error(exitCode);
   }
 
-  const PACKAGE = path.join(ROOT, 'react-native-*.tgz');
+  PACKAGE = path.join(ROOT, 'react-native-*.tgz');
   cd(TEMP);
 
   echo('Creating EndToEndTest React Native app');
@@ -122,13 +123,13 @@ try {
   if (
     tryExecNTimes(
       () => {
-        return exec('npm install').code;
+        return exec('yarn').code;
       },
       numberOfRetries,
       () => exec('sleep 10s'),
     )
   ) {
-    echo('Failed to execute npm install');
+    echo('Failed to execute yarn');
     echo('Most common reason is npm registry connectivity, try again');
     exitCode = 1;
     throw Error(exitCode);
@@ -319,6 +320,8 @@ try {
     echo(`Killing appium ${APPIUM_PID}`);
     exec(`kill -9 ${APPIUM_PID}`);
   }
+  echo('Cleaning up react-native package');
+  exec(`rm ${PACKAGE}`);
 }
 exit(exitCode);
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Move the iOS end-to-end tests to `test_ios` and the JavaScript end-to-end tests to `test_javascript`. The remaining Detox iOS tests form part of the now-renamed `test_detox_ios` job.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[Internal] [Removed] - Consolidate jobs

## Test Plan

Circle CI
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->