### PR TITLE
[Android][Keyboard] Return endCoordinates for keyboardDidHide keyboard event

### DIFF
--- a/Libraries/Components/Keyboard/Keyboard.js
+++ b/Libraries/Components/Keyboard/Keyboard.js
@@ -33,19 +33,26 @@ export type KeyboardEventEasing =
   | 'linear'
   | 'keyboard';
 
-type ScreenRect = $ReadOnly<{|
+type KeyboardEventCoordinates = $ReadOnly<{|
   screenX: number,
   screenY: number,
   width: number,
   height: number,
 |}>;
 
-export type KeyboardEvent = $ReadOnly<{|
-  duration: number,
+export type KeyboardEvent = AndroidKeyboardEvent | IOSKeyboardEvent;
+
+export type AndroidKeyboardEvent = $ReadOnly<{|
+  easing: 'keyboard',
+  endCoordinates: KeyboardEventCoordinates,
+|}>;
+
+export type IOSKeyboardEvent = $ReadOnly<{|
   easing: KeyboardEventEasing,
-  endCoordinates: ScreenRect,
-  startCoordinates: ScreenRect,
+  duration: number,
   isEventFromThisApp: boolean,
+  startCoordinates: KeyboardEventCoordinates,
+  endCoordinates: KeyboardEventCoordinates,
 |}>;
 
 type KeyboardEventListener = (e: KeyboardEvent) => void;
@@ -157,7 +164,7 @@ let Keyboard = {
    * Useful for syncing TextInput (or other keyboard accessory view) size of
    * position changes with keyboard movements.
    */
-  scheduleLayoutAnimation(event: KeyboardEvent) {
+  scheduleLayoutAnimation(event: $Shape<IOSKeyboardEvent>) {
     invariant(false, 'Dummy method used for documentation');
   },
 };
@@ -165,7 +172,7 @@ let Keyboard = {
 // Throw away the dummy object and reassign it to original module
 Keyboard = KeyboardEventEmitter;
 Keyboard.dismiss = dismissKeyboard;
-Keyboard.scheduleLayoutAnimation = function(event: KeyboardEvent) {
+Keyboard.scheduleLayoutAnimation = function(event: $Shape<IOSKeyboardEvent>) {
   const {duration, easing} = event;
   if (duration != null && duration !== 0) {
     LayoutAnimation.configureNext({

--- a/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
@@ -648,21 +648,33 @@ public class ReactRootView extends FrameLayout implements RootView, ReactRoot {
       getRootView().getWindowVisibleDisplayFrame(mVisibleViewArea);
       final int heightDiff =
         DisplayMetricsHolder.getWindowDisplayMetrics().heightPixels - mVisibleViewArea.bottom;
-      if (mKeyboardHeight != heightDiff && heightDiff > mMinKeyboardHeightDetected) {
-        // keyboard is now showing, or the keyboard height has changed
+
+      boolean isKeyboardShowingOrKeyboardHeightChanged =
+        mKeyboardHeight != heightDiff && heightDiff > mMinKeyboardHeightDetected;
+      if (isKeyboardShowingOrKeyboardHeightChanged) {
         mKeyboardHeight = heightDiff;
-        WritableMap params = Arguments.createMap();
-        WritableMap coordinates = Arguments.createMap();
-        coordinates.putDouble("screenY", PixelUtil.toDIPFromPixel(mVisibleViewArea.bottom));
-        coordinates.putDouble("screenX", PixelUtil.toDIPFromPixel(mVisibleViewArea.left));
-        coordinates.putDouble("width", PixelUtil.toDIPFromPixel(mVisibleViewArea.width()));
-        coordinates.putDouble("height", PixelUtil.toDIPFromPixel(mKeyboardHeight));
-        params.putMap("endCoordinates", coordinates);
-        sendEvent("keyboardDidShow", params);
-      } else if (mKeyboardHeight != 0 && heightDiff <= mMinKeyboardHeightDetected) {
-        // keyboard is now hidden
+        sendEvent("keyboardDidShow",
+          createKeyboardEventPayload(
+            PixelUtil.toDIPFromPixel(mVisibleViewArea.bottom),
+            PixelUtil.toDIPFromPixel(mVisibleViewArea.left),
+            PixelUtil.toDIPFromPixel(mVisibleViewArea.width()),
+            PixelUtil.toDIPFromPixel(mKeyboardHeight))
+        );
+        return;
+      }
+
+      boolean isKeyboardHidden =
+        mKeyboardHeight != 0 && heightDiff <= mMinKeyboardHeightDetected;
+      if (isKeyboardHidden) {
         mKeyboardHeight = 0;
-        sendEvent("keyboardDidHide", null);
+        sendEvent("keyboardDidHide",
+          createKeyboardEventPayload(
+            PixelUtil.toDIPFromPixel(mVisibleViewArea.height()),
+            0,
+            PixelUtil.toDIPFromPixel(mVisibleViewArea.width()),
+            0
+          )
+        );
       }
     }
 
@@ -745,6 +757,20 @@ public class ReactRootView extends FrameLayout implements RootView, ReactRoot {
           .getCurrentReactContext()
           .getNativeModule(DeviceInfoModule.class)
           .emitUpdateDimensionsEvent();
+    }
+
+    private WritableMap createKeyboardEventPayload(double screenY, double screenX, double width, double height) {
+      WritableMap keyboardEventParams = Arguments.createMap();
+      WritableMap endCoordinates = Arguments.createMap();
+
+      endCoordinates.putDouble("height", height);
+      endCoordinates.putDouble("screenX", screenX);
+      endCoordinates.putDouble("width", width);
+      endCoordinates.putDouble("screenY", screenY);
+
+      keyboardEventParams.putMap("endCoordinates", endCoordinates);
+      keyboardEventParams.putString("easing", "keyboard");
+      return keyboardEventParams;
     }
   }
 }


### PR DESCRIPTION
## Summary

This pull request enhances the Keyboard API event emitter for Android upon `keyboardDidHide` by returning a `KeyboardEvent` with a meaningful `endCoordinates` property (instead of emitting a `null` as of current implementation). This change standardizes the `keyboardDidHide` keyboard event emission across both iOS and Android, which makes it easier for developers to use the API.

In particular, the semantics of `endCoordinates` emitted during the `keyboardDidHide` event on Android will match nicely with semantics of the same event emitted on iOS:
- `screenY` will be height of the screen, as that the keyboard has collapsed to the bottom of the screen
- `screenX` will be 0, as the keyboard will always be flush to the sides of the screen
- `height` will be 0, as the keyboard has fully collapsed
- `width` will be the width of the screen, as the keyboard will always extend to the width of the screen

Also, the flowtypes for `KeyboardEvent` have been further improved and are more explicit to better highlight the different object shapes (see `IOSKeyboardEvent` and `AndroidKeyboardEvent`) depending on the platform.

## Changelog

[Android] [Added] - Return endCoordinates for keyboardDidHide keyboard event

## Test Plan

1. Listen to the `keyboardDidShow` and `keyboardDidHide` keyboard events, and log out the event details via `console.log`
1. Launch the App in both Android and iOS
1. Enter input in a text field
1. Close the keyboard
1. Compare the keyboard event details across both platforms. Most importantly, the `endCoordinates` property on both event details should share the same semantic meaning.

**`keyboardDidHide` event on iPhone 8**
<img width="742" alt="keyboardDidHide ios" src="https://user-images.githubusercontent.com/10845858/57971867-6666a800-79c6-11e9-8146-4a7cbc1f9a7d.png">

**`keyboardDidHide` event on Google Nexus 5X**
<img width="684" alt="keyboardDidHide android" src="https://user-images.githubusercontent.com/10845858/57971870-6b2b5c00-79c6-11e9-9f0d-f5dc81127487.png">