### PR TITLE
[iOS] Add ultrabold pairs for font weight

### DIFF
--- a/React/Views/RCTFont.mm
+++ b/React/Views/RCTFont.mm
@@ -32,6 +32,7 @@ static RCTFontWeight weightOfFont(UIFont *font)
       @"semibold",
       @"demibold",
       @"extrabold",
+      @"ultrabold",
       @"bold",
       @"heavy",
       @"black"
@@ -45,6 +46,7 @@ static RCTFontWeight weightOfFont(UIFont *font)
       @(UIFontWeightMedium),
       @(UIFontWeightSemibold),
       @(UIFontWeightSemibold),
+      @(UIFontWeightHeavy),
       @(UIFontWeightHeavy),
       @(UIFontWeightBold),
       @(UIFontWeightHeavy),


### PR DESCRIPTION
## Summary

Add `ultrabold` map of font weight, if not, `ultrabold` would map to `bold`.
Fixes https://github.com/facebook/react-native/issues/23512.

## Changelog

[iOS] [Fixed] - Add ultrabold pairs for font weight

## Test Plan
After:

`<Text style={{fontFamily: 'GillSans-UltraBold'}}>Hello</Text>`
<img width="361" alt="image" src="https://user-images.githubusercontent.com/5061845/57979297-7f1aa080-7a4e-11e9-95b7-1e9d4ae57c10.png">

`<Text style={{fontFamily: 'GillSans-Bold'}}>Hello</Text>`
<img width="358" alt="image" src="https://user-images.githubusercontent.com/5061845/57979323-cd2fa400-7a4e-11e9-9e25-38ee09330109.png">

Before:

`<Text style={{fontFamily: 'GillSans-UltraBold'}}>Hello</Text>`
<img width="358" alt="image" src="https://user-images.githubusercontent.com/5061845/57979342-09630480-7a4f-11e9-834f-e0e4438faa2a.png">

`<Text style={{fontFamily: 'GillSans-Bold'}}>Hello</Text>`
<img width="363" alt="image" src="https://user-images.githubusercontent.com/5061845/57979334-fa7c5200-7a4e-11e9-8d95-79ad4c26f8e6.png">