### PR TITLE
Fixed code and reason arguments ignored when closing a WebSocket on iOS

### DIFF
--- a/Libraries/WebSocket/RCTWebSocketModule.m
+++ b/Libraries/WebSocket/RCTWebSocketModule.m
@@ -112,9 +112,9 @@ RCT_EXPORT_METHOD(ping:(nonnull NSNumber *)socketID)
   [_sockets[socketID] sendPing:NULL];
 }
 
-RCT_EXPORT_METHOD(close:(nonnull NSNumber *)socketID)
+RCT_EXPORT_METHOD(close:(NSInteger)code reason:(NSString *)reason socketID:(nonnull NSNumber *)socketID)
 {
-  [_sockets[socketID] close];
+  [_sockets[socketID] closeWithCode:code reason:reason];
   [_sockets removeObjectForKey:socketID];
 }
 

--- a/Libraries/WebSocket/WebSocket.js
+++ b/Libraries/WebSocket/WebSocket.js
@@ -201,14 +201,10 @@ class WebSocket extends EventTarget(...WEBSOCKET_EVENTS) {
   }
 
   _close(code?: number, reason?: string): void {
-    if (Platform.OS === 'android') {
-      // See https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent
-      const statusCode = typeof code === 'number' ? code : CLOSE_NORMAL;
-      const closeReason = typeof reason === 'string' ? reason : '';
-      WebSocketModule.close(statusCode, closeReason, this._socketId);
-    } else {
-      WebSocketModule.close(this._socketId);
-    }
+    // See https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent
+    const statusCode = typeof code === 'number' ? code : CLOSE_NORMAL;
+    const closeReason = typeof reason === 'string' ? reason : '';
+    WebSocketModule.close(statusCode, closeReason, this._socketId);
 
     if (BlobManager.isAvailable && this._binaryType === 'blob') {
       BlobManager.removeWebSocketHandler(this._socketId);


### PR DESCRIPTION
## Summary

While working on https://github.com/facebook/react-native/pull/24893 I noticed the `WebSocket` module implementation on iOS was ignoring the code and reason arguments for the `close` method.
The Android implementation already handled those arguments properly.
So this PR brings iOS implementation on par with Android for the `WebSocket` module.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[iOS] [Fixed] - Fixed `code` and `reason` arguments ignored on iOS when calling `WebSocket.close`

## Test Plan

Run integration tests.