### PR TITLE
[CI] Fix e2e detox build step

### DIFF
--- a/RNTester/RNTester.xcodeproj/project.pbxproj
+++ b/RNTester/RNTester.xcodeproj/project.pbxproj
@@ -1107,7 +1107,7 @@
 				13B07F871A680F5B00A75B9A /* Sources */,
 				13B07F8C1A680F5B00A75B9A /* Frameworks */,
 				13B07F8E1A680F5B00A75B9A /* Resources */,
-				68CD48B71D2BCB2C007E06A9 /* Run Script */,
+				68CD48B71D2BCB2C007E06A9 /* Bundle React Native code and images */,
 				EDEBC7DE214C68E400DD5AC8 /* Embed Frameworks */,
 			);
 			buildRules = (
@@ -1707,19 +1707,19 @@
 			shellPath = /bin/sh;
 			shellScript = "export NODE_BINARY=node\n$SRCROOT/../scripts/react-native-xcode.sh RNTester/js/RNTesterApp.ios.js";
 		};
-		68CD48B71D2BCB2C007E06A9 /* Run Script */ = {
+		68CD48B71D2BCB2C007E06A9 /* Bundle React Native code and images */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Run Script";
+			name = "Bundle React Native code and images";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "export NODE_BINARY=node\n$SRCROOT/../scripts/react-native-xcode.sh RNTester/js/RNTesterApp.ios.js\n";
+			shellScript = "export NODE_BINARY=node\n$SRCROOT/../scripts/react-native-xcode.sh RNTester/js/RNTesterApp.ios.js $SRCROOT/..\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/RNTester/RNTester.xcodeproj/project.pbxproj
+++ b/RNTester/RNTester.xcodeproj/project.pbxproj
@@ -1719,7 +1719,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "export NODE_BINARY=node\n$SRCROOT/../scripts/react-native-xcode.sh RNTester/js/RNTesterApp.ios.js $SRCROOT/..\n";
+			shellScript = "export NODE_BINARY=node\nPROJECT_ROOT_OVERRIDE=$SRCROOT/.. $SRCROOT/../scripts/react-native-xcode.sh RNTester/js/RNTesterApp.ios.js\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/RNTester/RNTester.xcodeproj/project.pbxproj
+++ b/RNTester/RNTester.xcodeproj/project.pbxproj
@@ -1719,7 +1719,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "export NODE_BINARY=node\nPROJECT_ROOT_OVERRIDE=$SRCROOT/.. $SRCROOT/../scripts/react-native-xcode.sh RNTester/js/RNTesterApp.ios.js\n";
+			shellScript = "export NODE_BINARY=node\nPROJECT_ROOT=$SRCROOT/.. $SRCROOT/../scripts/react-native-xcode.sh RNTester/js/RNTesterApp.ios.js\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/scripts/react-native-xcode.sh
+++ b/scripts/react-native-xcode.sh
@@ -57,7 +57,6 @@ REACT_NATIVE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 # in node_modules.
 PROJECT_ROOT=${PROJECT_ROOT:-"$REACT_NATIVE_DIR/../.."}
 
-PROJECT_ROOT_OVERRIDE=$2
 if [ "$PROJECT_ROOT_OVERRIDE" != "" ]; then
   PROJECT_ROOT=$PROJECT_ROOT_OVERRIDE
 fi

--- a/scripts/react-native-xcode.sh
+++ b/scripts/react-native-xcode.sh
@@ -57,6 +57,11 @@ REACT_NATIVE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 # in node_modules.
 PROJECT_ROOT=${PROJECT_ROOT:-"$REACT_NATIVE_DIR/../.."}
 
+PROJECT_ROOT_OVERRIDE=$2
+if [ "$PROJECT_ROOT_OVERRIDE" != "" ]; then
+  PROJECT_ROOT=$PROJECT_ROOT_OVERRIDE
+fi
+
 cd "$PROJECT_ROOT" || exit
 
 # Define NVM_DIR and source the nvm.sh setup script

--- a/scripts/react-native-xcode.sh
+++ b/scripts/react-native-xcode.sh
@@ -57,10 +57,6 @@ REACT_NATIVE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 # in node_modules.
 PROJECT_ROOT=${PROJECT_ROOT:-"$REACT_NATIVE_DIR/../.."}
 
-if [ "$PROJECT_ROOT_OVERRIDE" != "" ]; then
-  PROJECT_ROOT=$PROJECT_ROOT_OVERRIDE
-fi
-
 cd "$PROJECT_ROOT" || exit
 
 # Define NVM_DIR and source the nvm.sh setup script


### PR DESCRIPTION
## Summary

Fixes the e2e detox build step by manually overriding `PROJECT_ROOT` for the project's JS bundle build step. 

After seeing [quite](https://github.com/facebook/react-native/issues/18472#issuecomment-428996279) [a](https://github.com/facebook/react-native/issues/18472#issuecomment-450485004) [few](https://github.com/facebook/react-native/issues/15432#issuecomment-417310668) [comments](https://stackoverflow.com/a/49506072) suggesting running some variant of the `react-native bundle` manually on your own so as to build the jsbundle required as part of the build step for RNTester project...

The main issue I found was that the working directory in which `react-native-xcode.sh` executed the CLI bundle step was not correct. The `PROJECT_ROOT` was not resolving to the root of the `react-native` project directory, but instead to something to the effect of `/Users/gibson.cheng/IdeaProjects/react-native/../..` - of which of course the build step would not be able to find the `react-native` project to run the build against.

I'm not sure if new generated `react-native` projects require this manual override, so I only applied it to the RNTester project. Reviewers are welcome to correct my understanding and solutioning to this matter :)

@hramos, if this works, perhaps there would not be a need to push through with #24936. Also, this  contributes to #23561.

## Changelog

[Internal] [Fixed] - Fix build-ios-e2e build step

## Test Plan

1. `build-ios-e2e` should work now