### PR TITLE
Add default scrollEventThrottle to Animated{FlatList, SectionList}

### DIFF
--- a/Libraries/Animated/src/components/AnimatedFlatList.js
+++ b/Libraries/Animated/src/components/AnimatedFlatList.js
@@ -14,4 +14,6 @@ const FlatList = require('../../../Lists/FlatList');
 
 const createAnimatedComponent = require('../createAnimatedComponent');
 
-module.exports = createAnimatedComponent(FlatList);
+module.exports = createAnimatedComponent(FlatList, {
+  scrollEventThrottle: 0.0001,
+});

--- a/Libraries/Animated/src/components/AnimatedSectionList.js
+++ b/Libraries/Animated/src/components/AnimatedSectionList.js
@@ -14,4 +14,6 @@ const SectionList = require('../../../Lists/SectionList');
 
 const createAnimatedComponent = require('../createAnimatedComponent');
 
-module.exports = createAnimatedComponent(SectionList);
+module.exports = createAnimatedComponent(SectionList, {
+  scrollEventThrottle: 0.0001,
+});


### PR DESCRIPTION
## Summary

`scrollEventThrottle` is often a source of confusion, especially when using native animated since users expect that it doesn't affect `Animated.event` but it does. We added a default prop to Animated.ScrollView but not to `Animated.FlatList` and `Animated.SectionList` so this adds it for those.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[JavaScript] [Added] - Add default scrollEventThrottle to Animated{FlatList, SectionList}

## Test Plan

Tested that it is no longer needed to pass `scrollEventThrottle` to have smooth `onScroll` animations on iOS
