### PR TITLE
Resolve Promise to YES for Linking.openURL

### DIFF
--- a/Libraries/LinkingIOS/RCTLinkingManager.m
+++ b/Libraries/LinkingIOS/RCTLinkingManager.m
@@ -95,7 +95,7 @@ RCT_EXPORT_METHOD(openURL:(NSURL *)URL
   if (@available(iOS 10.0, *)) {
     [RCTSharedApplication() openURL:URL options:@{} completionHandler:^(BOOL success) {
       if (success) {
-        resolve(nil);
+        resolve(@YES);
       } else {
         reject(RCTErrorUnspecified, [NSString stringWithFormat:@"Unable to open URL: %@", URL], nil);
       }
@@ -103,7 +103,7 @@ RCT_EXPORT_METHOD(openURL:(NSURL *)URL
   } else {
     BOOL opened = [RCTSharedApplication() openURL:URL];
     if (opened) {
-      resolve(nil);
+      resolve(@YES);
     } else {
       reject(RCTErrorUnspecified, [NSString stringWithFormat:@"Unable to open URL: %@", URL], nil);
     }


### PR DESCRIPTION
## Summary

The `Linking.openURL()` method is supposed to resolve to a `true` `Promise` when the URL was properly open. However, in iOS, the `Promise` was resolving to `nil`. So I fixed this issue by making it resolve to `YES` (`true`), just like on Android.

## Changelog

[iOS] [Fixed] - Fix return value of `Linking.openURL()`

## Test Plan

Create a sample app, and use the Linking API to open a URL (I use Uber deeplinks: `uber://`, following 
[their deep-links docs](https://developer.uber.com/docs/riders/ride-requests/tutorials/deep-links/introduction#standard-deep-links)). Make sure that the Promise resolves to `true` on the JS side.

With the code from the version I use for my project (`0.59.1`), I received `undefined`. With these changes, I received `true` on the JS side.