### PR TITLE
[iOS] Using presentingViewController to dismiss Modal

### DIFF
--- a/React/Views/RCTModalHostViewManager.m
+++ b/React/Views/RCTModalHostViewManager.m
@@ -89,7 +89,7 @@ RCT_EXPORT_MODULE()
   if (_dismissalBlock) {
     _dismissalBlock([modalHostView reactViewController], viewController, animated, completionBlock);
   } else {
-    [viewController dismissViewControllerAnimated:animated completion:completionBlock];
+    [viewController.presentingViewController dismissViewControllerAnimated:animated completion:completionBlock];
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes https://github.com/facebook/react-native/issues/23463.
Using `presentingViewController` to dismiss Modal VC directly, don't let Modal VC to find `presentingViewController`, then dismiss.

## Changelog

[iOS] [Fixed] - Using presentingViewController to dismiss Modal

## Test Plan

Sample code please see https://github.com/facebook/react-native/issues/23463, it should works.