### PR TITLE
[iOS] Keep the order of Modals that we can dismiss in sequence

### DIFF
--- a/React/Views/RCTModalHostViewManager.m
+++ b/React/Views/RCTModalHostViewManager.m
@@ -49,7 +49,7 @@ RCT_ENUM_CONVERTER(UIModalPresentationStyle, (@{
 
 @implementation RCTModalHostViewManager
 {
-  NSHashTable *_hostViews;
+  NSPointerArray *_hostViews;
 }
 
 RCT_EXPORT_MODULE()
@@ -59,9 +59,9 @@ RCT_EXPORT_MODULE()
   RCTModalHostView *view = [[RCTModalHostView alloc] initWithBridge:self.bridge];
   view.delegate = self;
   if (!_hostViews) {
-    _hostViews = [NSHashTable weakObjectsHashTable];
+    _hostViews = [NSPointerArray weakObjectsPointerArray];
   }
-  [_hostViews addObject:view];
+  [_hostViews addPointer:(__bridge void *)view];
   return view;
 }
 
@@ -104,7 +104,7 @@ RCT_EXPORT_MODULE()
   for (RCTModalHostView *hostView in _hostViews) {
     [hostView invalidate];
   }
-  [_hostViews removeAllObjects];
+  _hostViews = [NSPointerArray weakObjectsPointerArray];
 }
 
 RCT_EXPORT_VIEW_PROPERTY(animationType, NSString)

--- a/React/Views/RCTModalHostViewManager.m
+++ b/React/Views/RCTModalHostViewManager.m
@@ -104,7 +104,7 @@ RCT_EXPORT_MODULE()
   for (RCTModalHostView *hostView in _hostViews) {
     [hostView invalidate];
   }
-  _hostViews = [NSPointerArray weakObjectsPointerArray];
+  _hostViews = nil;
 }
 
 RCT_EXPORT_VIEW_PROPERTY(animationType, NSString)


### PR DESCRIPTION
## Summary

Fixes https://github.com/facebook/react-native/issues/16037.
We need to keep the order of Modals, if we dismiss Modal randomly(before we use hash table), some Modals may not dismiss successfully.

This PR should based on https://github.com/facebook/react-native/pull/24959.

## Changelog

[iOS] [Fixed] - Keep the order of Modals that we can dismiss in sequence

## Test Plan

Code example, please see https://github.com/facebook/react-native/issues/16037, it should work. :)
