### PR TITLE
[CI] Disable iOS end-to-end tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -507,15 +507,15 @@ jobs:
             node ./scripts/run-ci-e2e-tests.js --js --retries 3
           when: always
 
-      - run:
-          name: Run iOS End-to-End Tests
-          command: |
-            # free up port 8081 for the packager before running tests
-            set +eo pipefail
-            lsof -i tcp:8081 | awk 'NR!=1 {print $2}' | xargs kill
-            set -eo pipefail
-            node ./scripts/run-ci-e2e-tests.js --ios --retries 3;
-          when: always
+      # - run:
+      #     name: Run iOS End-to-End Tests
+      #     command: |
+      #       # free up port 8081 for the packager before running tests
+      #       set +eo pipefail
+      #       lsof -i tcp:8081 | awk 'NR!=1 {print $2}' | xargs kill
+      #       set -eo pipefail
+      #       node ./scripts/run-ci-e2e-tests.js --ios --retries 3;
+      #     when: always
 
 
   # -------------------------


### PR DESCRIPTION
## Summary

The iOS end-to-end tests are currently broken. I'm disabling them to bring the tests back to green and unblock other PRs, until they can be fixed.

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->


<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

[Internal] [Removed] - Disable iOS e2e test
<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->


## Test Plan

Circle
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->