### PR TITLE
[Fabric] Add NAN check for text font sizeMultiplier

### DIFF
--- a/ReactCommon/fabric/attributedstring/TextAttributes.cpp
+++ b/ReactCommon/fabric/attributedstring/TextAttributes.cpp
@@ -154,6 +154,7 @@ TextAttributes TextAttributes::defaultTextAttributes() {
     textAttributes.foregroundColor = blackColor();
     textAttributes.backgroundColor = clearColor();
     textAttributes.fontSize = 14.0;
+    textAttributes.fontSizeMultiplier = 1.0;
     return textAttributes;
   }();
   return textAttributes;

--- a/ReactCommon/fabric/textlayoutmanager/platform/ios/RCTFontUtils.mm
+++ b/ReactCommon/fabric/textlayoutmanager/platform/ios/RCTFontUtils.mm
@@ -137,8 +137,9 @@ UIFont *RCTFontWithFontProperties(RCTFontProperties fontProperties) {
   RCTFontProperties defaultFontProperties = RCTDefaultFontProperties();
   fontProperties = RCTResolveFontProperties(fontProperties);
 
-  CGFloat sizeMultiplier = !isnan(fontProperties.sizeMultiplier) ? fontProperties.sizeMultiplier : 1.0;
-  CGFloat effectiveFontSize = sizeMultiplier * fontProperties.size;
+  assert(!isnan(fontProperties.sizeMultiplier));
+  CGFloat effectiveFontSize =
+      fontProperties.sizeMultiplier * fontProperties.size;
   UIFont *font;
   if ([fontProperties.family isEqualToString:defaultFontProperties.family]) {
     // Handle system font as special case. This ensures that we preserve

--- a/ReactCommon/fabric/textlayoutmanager/platform/ios/RCTFontUtils.mm
+++ b/ReactCommon/fabric/textlayoutmanager/platform/ios/RCTFontUtils.mm
@@ -137,8 +137,8 @@ UIFont *RCTFontWithFontProperties(RCTFontProperties fontProperties) {
   RCTFontProperties defaultFontProperties = RCTDefaultFontProperties();
   fontProperties = RCTResolveFontProperties(fontProperties);
 
-  CGFloat effectiveFontSize =
-      fontProperties.sizeMultiplier * fontProperties.size;
+  CGFloat sizeMultiplier = !isnan(fontProperties.sizeMultiplier) ? fontProperties.sizeMultiplier : 1.0;
+  CGFloat effectiveFontSize = sizeMultiplier * fontProperties.size;
   UIFont *font;
   if ([fontProperties.family isEqualToString:defaultFontProperties.family]) {
     // Handle system font as special case. This ensures that we preserve


### PR DESCRIPTION
## Summary

Set `sizeMultiplier` to `1.0` if default value is `NAN`, otherwise, text cannot show properly.

## Changelog

[iOS] [Fixed] - Add NAN check for text font sizeMultiplier

## Test Plan

Code like `<Text style={{fontFamily: 'GillSans-Bold'}}>Hello</Text>`, can run properly.