### PR TITLE
[CI] Fix ios/android e2e tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -507,16 +507,15 @@ jobs:
             node ./scripts/run-ci-e2e-tests.js --js --retries 3
           when: always
 
-      # - run:
-      #     name: Run iOS End-to-End Tests
-      #     command: |
-      #       # free up port 8081 for the packager before running tests
-      #       set +eo pipefail
-      #       lsof -i tcp:8081 | awk 'NR!=1 {print $2}' | xargs kill
-      #       set -eo pipefail
-      #       node ./scripts/run-ci-e2e-tests.js --ios --retries 3;
-      #     when: always
-
+      - run:
+          name: Run iOS End-to-End Tests
+          command: |
+            # free up port 8081 for the packager before running tests
+            set +eo pipefail
+            lsof -i tcp:8081 | awk 'NR!=1 {print $2}' | xargs kill
+            set -eo pipefail
+            node ./scripts/run-ci-e2e-tests.js --ios --retries 3;
+          when: always
 
   # -------------------------
   #    JOBS: Test Android

--- a/scripts/android-e2e-test.js
+++ b/scripts/android-e2e-test.js
@@ -110,15 +110,12 @@ describe('Android Test App', function() {
     return (
       driver
         .waitForElementByXPath(
-          '//android.widget.TextView[starts-with(@text, "Welcome to React Native!")]',
+          '//android.widget.TextView[starts-with(@text, "Welcome to React")]',
         )
         .then(() => {
           fs.writeFileSync(
             'App.js',
-            androidAppCode.replace(
-              'Welcome to React Native!',
-              'Welcome to React Native! Reloaded',
-            ),
+            androidAppCode.replace('Step One', 'Step 1'),
             'utf-8',
           );
         })
@@ -128,7 +125,7 @@ describe('Android Test App', function() {
         .pressDeviceKey(46)
         .sleep(2000)
         .waitForElementByXPath(
-          '//android.widget.TextView[starts-with(@text, "Welcome to React Native! Reloaded")]',
+          '//android.widget.TextView[starts-with(@text, "Step 1")]',
         )
         .finally(() => {
           clearInterval(intervalToUpdate);
@@ -145,7 +142,7 @@ describe('Android Test App', function() {
     return (
       driver
         .waitForElementByXPath(
-          '//android.widget.TextView[starts-with(@text, "Welcome to React Native!")]',
+          '//android.widget.TextView[starts-with(@text, "Welcome to React")]',
         )
         // http://developer.android.com/reference/android/view/KeyEvent.html#KEYCODE_MENU
         .pressDeviceKey(82)

--- a/scripts/run-ci-e2e-tests.js
+++ b/scripts/run-ci-e2e-tests.js
@@ -81,7 +81,7 @@ try {
     }
   }
 
-  if (exec('yarn pack').code) {
+  if (exec('npm pack').code) {
     echo('Failed to pack react-native');
     exitCode = 1;
     throw Error(exitCode);

--- a/template/ios/HelloWorldTests/HelloWorldTests.m
+++ b/template/ios/HelloWorldTests/HelloWorldTests.m
@@ -12,7 +12,7 @@
 #import <React/RCTRootView.h>
 
 #define TIMEOUT_SECONDS 600
-#define TEXT_TO_LOOK_FOR @"Welcome to React Native!"
+#define TEXT_TO_LOOK_FOR @"Welcome to React"
 
 @interface HelloWorldTests : XCTestCase
 


### PR DESCRIPTION
## Summary

Fixes broken ios/android e2e tests for CI.

Changes:
1. Use `npm pack` instead of `yarn pack` during e2e test
2. Update test string assertions in ios/android e2e tests
3. Use `Step One` as candidate for source code replacement to test for page changes (since the "Welcome to React Native" string exists in the `Header` component instead of being on `App.js`)

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[Internal] [Fixed] - Fix ios/android e2e tests

## Test Plan
1. ios/android e2e tests in CI stage should pass
