### PR TITLE
RNTesterIntegrationTests can fail due to the warning "Can't call setState (or forceUpdate) on an unmounted component."

### DIFF
--- a/RNTester/js/RNTesterApp.ios.js
+++ b/RNTester/js/RNTesterApp.ios.js
@@ -61,13 +61,19 @@ const Header = ({onBack, title}: {onBack?: () => mixed, title: string}) => (
 );
 
 class RNTesterApp extends React.Component<Props, RNTesterNavigationState> {
+  _mounted: boolean;
+
   UNSAFE_componentWillMount() {
     BackHandler.addEventListener('hardwareBackPress', this._handleBack);
   }
 
   componentDidMount() {
+    this._mounted = true; 
     Linking.getInitialURL().then(url => {
       AsyncStorage.getItem(APP_STATE_KEY, (err, storedString) => {
+        if (!this._mounted) {
+          return;
+        }
         const exampleAction = URIActionMap(
           this.props.exampleFromAppetizeParams,
         );
@@ -81,6 +87,10 @@ class RNTesterApp extends React.Component<Props, RNTesterNavigationState> {
     Linking.addEventListener('url', url => {
       this._handleAction(URIActionMap(url));
     });
+  }
+
+  componentWillUnmount() {
+    this._mounted = false;
   }
 
   _handleBack = () => {

--- a/RNTester/js/RNTesterApp.ios.js
+++ b/RNTester/js/RNTesterApp.ios.js
@@ -68,7 +68,7 @@ class RNTesterApp extends React.Component<Props, RNTesterNavigationState> {
   }
 
   componentDidMount() {
-    this._mounted = true; 
+    this._mounted = true;
     Linking.getInitialURL().then(url => {
       AsyncStorage.getItem(APP_STATE_KEY, (err, storedString) => {
         if (!this._mounted) {


### PR DESCRIPTION
## Summary

When running the RNTesterIntegrationTests from the XCode IDE or xcodebuild command line, its possible for tests to intermittently fail due to the warning `'Warning: Can\'t call setState (or forceUpdate) on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in the componentWillUnmount method.%s', '\n in RNTesterApp.` .

A setState() call could happen in the AsyncStorage callback after the component had unmounted: presumably because the test ran and concluded before AsyncStorage returned. Changed RNTesterApp.ios.js to maintain a _mounted field that is set and cleared in componentDidMount() and componentWillUnmount() and refrain from calling setState() if the flag is false.

## Changelog

[iOS] [Fixed] - Fixed RNTesterApp to not call setState() after the component has been unmounted.

## Test Plan

All tests pass. 

I have already made the same fix in the Microsoft fork of react-native: https://github.com/microsoft/react-native/pull/18.   The Microsoft Azure DevOps hosted CI loops also run RNTesterIntegrationTests.   Before this fix we had only about an 86% pass rate and most of the failures were due to this warning.   After this fix (and others) we are at a 98% pass rate. 
