### PR TITLE
[Trivial] Add test-ios command to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,8 @@
     "test-android-unit": "yarn run docker-build-android && yarn run test-android-run-unit",
     "test-android-e2e": "yarn run docker-build-android && yarn run test-android-run-e2e",
     "build-ios-e2e": "detox build -c ios.sim.release",
-    "test-ios-e2e": "detox test -c ios.sim.release RNTester/e2e"
+    "test-ios-e2e": "detox test -c ios.sim.release RNTester/e2e",
+    "test-ios": "./scripts/objc-test-ios.sh test"
   },
   "peerDependencies": {
     "react": "16.8.6"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

There is currently no entry point for running the RNTester tests in package.json. This adds a test-ios command which leverages the existing objc-test-ios.sh script.

With this change in place, our documentation for running tests locally can be simplified and made consistent with how JavaScript tests are run (yarn test).


## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[General] [Added] - Add a test-ios command to run iOS RNTester tests locally

## Test Plan

`yarn test-ios` invokes the objc-test-ios.sh script.

## Future work

The rest of the commands here should be cleaned up, but that's a non-goal for this pull request. In the future, I could see us having separate test-ios-unit and test-ios-integration commands, to match the existing Android docker commands.
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->