### PR TITLE
[iOS] Fixes text style lost when enable maxLength

### DIFF
--- a/Libraries/Text/TextInput/RCTBaseTextInputView.m
+++ b/Libraries/Text/TextInput/RCTBaseTextInputView.m
@@ -381,7 +381,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithFrame:(CGRect)frame)
         // Truncate the input string so the result is exactly maxLength
         NSString *limitedString = [text substringToIndex:allowedLength];
         NSMutableAttributedString *newAttributedText = [backedTextInputView.attributedText mutableCopy];
-        // Apply text attributes if original input view don't have text.
+        // Apply text attributes if original input view doesn't have text.
         if (backedTextInputView.attributedText.length == 0) {
           newAttributedText = [[NSMutableAttributedString alloc] initWithString:[self.textAttributes applyTextAttributesToText:limitedString] attributes:self.textAttributes.effectiveTextAttributes];
         } else {

--- a/Libraries/Text/TextInput/RCTBaseTextInputView.m
+++ b/Libraries/Text/TextInput/RCTBaseTextInputView.m
@@ -381,7 +381,12 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithFrame:(CGRect)frame)
         // Truncate the input string so the result is exactly maxLength
         NSString *limitedString = [text substringToIndex:allowedLength];
         NSMutableAttributedString *newAttributedText = [backedTextInputView.attributedText mutableCopy];
-        [newAttributedText replaceCharactersInRange:range withString:limitedString];
+        // Apply text attributes if original input view don't have text.
+        if (backedTextInputView.attributedText.length == 0) {
+          newAttributedText = [[NSMutableAttributedString alloc] initWithString:[self.textAttributes applyTextAttributesToText:limitedString] attributes:self.textAttributes.effectiveTextAttributes];
+        } else {
+          [newAttributedText replaceCharactersInRange:range withString:limitedString];
+        }
         backedTextInputView.attributedText = newAttributedText;
         _predictedText = newAttributedText.string;
 


### PR DESCRIPTION
## Summary

To fix https://github.com/facebook/react-native/issues/24983, we lost text style when `maxLength` enabled.

## Changelog

[iOS] [Fixed] - Fixes text style lost when enable maxLength

## Test Plan

Try to paste text which length greater than `maxLength`. Style of input should apply to pasted text.
```
        <TextInput
          style={{
            width:300,
            height: 100,
            borderBottomColor: '#008CC6',
            borderBottomWidth: 2,
            fontSize: 20,
            color: 'blue'
          }}
          maxLength={10}
          multiline={true}
        />
```
