### PR TITLE
allow creating custom ReactTextUpdate in ReactTextInputShadowNode subclasses

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputShadowNode.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputShadowNode.java
@@ -18,14 +18,9 @@ import com.facebook.infer.annotation.Assertions;
 import com.facebook.react.bridge.JSApplicationIllegalArgumentException;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.common.annotations.VisibleForTesting;
-import com.facebook.react.uimanager.LayoutShadowNode;
-import com.facebook.react.uimanager.NativeViewHierarchyOptimizer;
-import com.facebook.react.uimanager.PixelUtil;
-import com.facebook.react.uimanager.ReactShadowNodeImpl;
 import com.facebook.react.uimanager.Spacing;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.UIViewOperationQueue;
-import com.facebook.react.uimanager.ViewDefaults;
 import com.facebook.react.uimanager.annotations.ReactProp;
 import com.facebook.react.views.text.ReactBaseTextShadowNode;
 import com.facebook.react.views.text.ReactTextUpdate;
@@ -157,6 +152,10 @@ public class ReactTextInputShadowNode extends ReactBaseTextShadowNode
     mMostRecentEventCount = mostRecentEventCount;
   }
 
+  public int getMostRecentEventCount() {
+    return mMostRecentEventCount;
+  }
+
   @ReactProp(name = PROP_TEXT)
   public void setText(@Nullable String text) {
     mText = text;
@@ -188,6 +187,14 @@ public class ReactTextInputShadowNode extends ReactBaseTextShadowNode
       mSelectionEnd = selection.getInt("end");
       markUpdated();
     }
+  }
+
+  public int getSelectionStart() {
+    return mSelectionStart;
+  }
+
+  public int getSelectionEnd() {
+    return mSelectionEnd;
   }
 
   @Override


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Motivation is the same as in https://github.com/facebook/react-native/pull/24927 - when building a custom textinput (eg with rich text editing), one needs custom text processing logic. `ReactTextInputShadowNode` contains https://github.com/facebook/react-native/blob/6671165f69e37a49af8b709b4807f9049f7606c3/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputShadowNode.java#L211

where an instance of `ReactTextUpdate` is created. For the custom use case, we'd like to just change the usage of [`spannedFromShadowNode()`](https://github.com/facebook/react-native/blob/6671165f69e37a49af8b709b4807f9049f7606c3/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputShadowNode.java#L217) to our own implementation. It's easy to subclass `ReactTextInputShadowNode` and override `public void onCollectExtraUpdates()` but the problem is that the method accesses private members. This PR just adds getters for them and removes some old unused imports.

In the previous PR, I just changed the accessors from private to protected. Here I instead use getters because the private values already have setters. It looks a little weird to have unused getters hanging around though, so let me know what you think. Last, not-so-nice alternative is to copy-paste the `ReactTextInputShadowNode` into own class.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[Android] [Added] - allow creating custom ReactTextUpdate in ReactTextInputShadowNode subclasses

## Test Plan

this will work just the same
