### PR TITLE
Set duration=0 for android keyboard events

### DIFF
--- a/Libraries/Components/Keyboard/Keyboard.js
+++ b/Libraries/Components/Keyboard/Keyboard.js
@@ -50,6 +50,7 @@ type BaseKeyboardEvent = {|
 
 export type AndroidKeyboardEvent = $ReadOnly<{|
   ...BaseKeyboardEvent,
+  duration: 0,
   easing: 'keyboard',
 |}>;
 

--- a/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
@@ -770,6 +770,7 @@ public class ReactRootView extends FrameLayout implements RootView, ReactRoot {
 
       keyboardEventParams.putMap("endCoordinates", endCoordinates);
       keyboardEventParams.putString("easing", "keyboard");
+      keyboardEventParams.putDouble("duration", 0);
       return keyboardEventParams;
     }
   }


### PR DESCRIPTION
## Summary

Set duration=0 for android keyboard events. Brings actual implementation closer to existing flowtypes, and duration is set to 0 to minimize impact on existing keyboard event consumers.
Follow up to #24947, upon @cpojer's [input](https://github.com/facebook/react-native/pull/24947#issuecomment-494681618) :) 

## Changelog

[Android] [Added] - Set duration=0 for android keyboard events

## Test Plan

1. Android keyboard events should come with the `duration` property, which is always 0.
