### PR TITLE
Update the "nativeStackAndroid"

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/PromiseImpl.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/PromiseImpl.java
@@ -20,7 +20,7 @@ import javax.annotation.Nullable;
 public class PromiseImpl implements Promise {
   // Number of stack frames to parse and return to mReject.invoke
   // for ERROR_MAP_KEY_NATIVE_STACK
-  private static final int ERROR_STACK_FRAME_LIMIT = 10;
+  private static final int ERROR_STACK_FRAME_LIMIT = 50;
 
   private static final String ERROR_DEFAULT_CODE = "EUNSPECIFIED";
   private static final String ERROR_DEFAULT_MESSAGE = "Error not specified.";
@@ -32,6 +32,7 @@ public class PromiseImpl implements Promise {
   private static final String ERROR_MAP_KEY_NATIVE_STACK = "nativeStackAndroid";
 
   // Keys for ERROR_MAP_KEY_NATIVE_STACK's StackFrame maps
+  private static final String STACK_FRAME_KEY_CLASS = "class";
   private static final String STACK_FRAME_KEY_FILE = "file";
   private static final String STACK_FRAME_KEY_LINE_NUMBER = "lineNumber";
   private static final String STACK_FRAME_KEY_METHOD_NAME = "methodName";
@@ -218,6 +219,7 @@ public class PromiseImpl implements Promise {
         StackTraceElement frame = stackTrace[i];
         WritableMap frameMap = new WritableNativeMap();
         // NOTE: no column number exists StackTraceElement
+        frameMap.putString(STACK_FRAME_KEY_CLASS, frame.getClassName());
         frameMap.putString(STACK_FRAME_KEY_FILE, frame.getFileName());
         frameMap.putInt(STACK_FRAME_KEY_LINE_NUMBER, frame.getLineNumber());
         frameMap.putString(STACK_FRAME_KEY_METHOD_NAME, frame.getMethodName());


### PR DESCRIPTION
Update the "nativeStackAndroid" frame limit to 50 and include the class name on the "nativeStackAndroid".

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

nativeStackAndroid only contains up to 10 lines of stack traces. This is due to the "ERROR_STACK_FRAME_LIMIT" set to 10 on https://github.com/facebook/react-native/blob/master/ReactAndroid/src/main/java/com/facebook/react/bridge/PromiseImpl.java.

![2019-05-22_10-33-23](https://user-images.githubusercontent.com/14658357/58291337-eba8de80-7d71-11e9-9524-5bd6814c9f4a.png)

nativeStackAndroid should contain a more reasonable number of the native stack traces. (nativeStackIOS includes all of them). another improvement could be adding the "declaringClass" on top of the "methodName", "LineNumber", and "file" on the stack trace frameMap.

![2019-05-22_13-38-43](https://user-images.githubusercontent.com/14658357/58290869-1b56e700-7d70-11e9-9e63-2149fd1486c7.png)

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[Android] [Added] - Update the "nativeStackAndroid" frame limit to 50 and include class name

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
