### PR TITLE
Move accessibilityActions property to UIView+React

### DIFF
--- a/React/Views/RCTView.h
+++ b/React/Views/RCTView.h
@@ -23,7 +23,6 @@ extern const UIAccessibilityTraits SwitchAccessibilityTrait;
 /**
  * Accessibility event handlers
  */
-@property (nonatomic, copy) NSArray <NSDictionary *> *accessibilityActions;
 @property (nonatomic, copy) RCTDirectEventBlock onAccessibilityAction;
 @property (nonatomic, copy) RCTDirectEventBlock onAccessibilityTap;
 @property (nonatomic, copy) RCTDirectEventBlock onMagicTap;

--- a/React/Views/RCTView.m
+++ b/React/Views/RCTView.m
@@ -158,33 +158,21 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:unused)
   return RCTRecursiveAccessibilityLabel(self);
 }
 
--(void)setAccessibilityActions:(NSArray *)actions
-{
-  if (!actions) {
-    return;
-  }
-  accessibilityActionsNameMap = [[NSMutableDictionary alloc] init];
-  accessibilityActionsLabelMap = [[NSMutableDictionary alloc] init];
-  for (NSDictionary *action in actions) {
-    if (action[@"name"]) {
-      accessibilityActionsNameMap[action[@"name"]] = action;
-    }
-    if (action[@"label"]) {
-      accessibilityActionsLabelMap[action[@"label"]] = action;
-    }
-  }
-  _accessibilityActions = [actions copy];
-}
-
 - (NSArray <UIAccessibilityCustomAction *> *)accessibilityCustomActions
 {
   if (!self.accessibilityActions.count) {
     return nil;
   }
 
+  accessibilityActionsNameMap = [[NSMutableDictionary alloc] init];
+  accessibilityActionsLabelMap = [[NSMutableDictionary alloc] init];
   NSMutableArray *actions = [NSMutableArray array];
   for (NSDictionary *action in self.accessibilityActions) {
+    if (action[@"name"]) {
+      accessibilityActionsNameMap[action[@"name"]] = action;
+    }
     if (action[@"label"]) {
+      accessibilityActionsLabelMap[action[@"label"]] = action;
       [actions addObject:[[UIAccessibilityCustomAction alloc] initWithName:action[@"label"]
                                                                     target:self
                                                                   selector:@selector(didActivateAccessibilityCustomAction:)]];

--- a/React/Views/UIView+React.h
+++ b/React/Views/UIView+React.h
@@ -119,6 +119,7 @@
 @property (nonatomic, copy) NSString *accessibilityRole;
 @property (nonatomic, copy) NSArray <NSString *> *accessibilityStates;
 @property (nonatomic, copy) NSDictionary<NSString *, id> *accessibilityState;
+@property (nonatomic, copy) NSArray <NSDictionary *> *accessibilityActions;
 
 /**
  * Used in debugging to get a description of the view hierarchy rooted at


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

As PR [#24743](https://github.com/facebook/react-native/pull/24743) suggested, accessibility properties are better to set on UIView+React instead of RCTView so they can be used safely on any UIView.

## Changelog

[General] [Fixed] - Move accessibilityActions props to UIView+React

## Test Plan

Tested that RNTester accessibility examples still work.
