### PR TITLE
[Fabric] Break retain cycle between view component and observer

### DIFF
--- a/React/Fabric/RCTImageResponseObserverProxy.h
+++ b/React/Fabric/RCTImageResponseObserverProxy.h
@@ -24,7 +24,7 @@ namespace facebook {
       void didReceiveFailure() override;
       
     private:
-      id<RCTImageResponseDelegate> delegate_;
+      __weak id<RCTImageResponseDelegate> delegate_;
     };
   }
 }


### PR DESCRIPTION
## Summary

Fixes potential memory leaks.

## Changelog

[iOS] [Fixed] - [Fabric] Break retain cycle between view component and observer

## Test Plan

N/A.
