### PR TITLE
[Android] [Added] Add showSoftInputOnFocus to TextInput

### DIFF
--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -253,6 +253,7 @@ type AndroidProps = $ReadOnly<{|
     | 'yes'
     | 'yesExcludeDescendants'
   ),
+  showSoftInputOnFocus?: ?boolean,
 |}>;
 
 type Props = $ReadOnly<{|
@@ -926,6 +927,12 @@ const TextInput = createReactClass({
       'newPassword',
       'oneTimeCode',
     ]),
+    /**
+     * When `false`, it will prevent the soft keyboard from showing when the field is focused.
+     * Defaults to `true`.
+     * @platform android
+     */
+    showSoftInputOnFocus: PropTypes.bool,
   },
   getDefaultProps() {
     return {

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
@@ -213,7 +213,9 @@ public class ReactEditText extends EditText {
     }
     setFocusableInTouchMode(true);
     boolean focused = super.requestFocus(direction, previouslyFocusedRect);
-    showSoftKeyboard();
+    if (getShowSoftInputOnFocus()) {
+      showSoftKeyboard();
+    }
     return focused;
   }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
@@ -715,6 +715,12 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
     view.setBorderStyle(borderStyle);
   }
 
+  @ReactProp(name = "showSoftInputOnFocus", defaultBoolean = true)
+  public void showKeyboardOnFocus(ReactEditText view, boolean showKeyboardOnFocus) {
+    view.setShowSoftInputOnFocus(showKeyboardOnFocus);
+  }
+
+
   @ReactPropGroup(names = {
       ViewProps.BORDER_WIDTH,
       ViewProps.BORDER_LEFT_WIDTH,


### PR DESCRIPTION
## Summary

Add prop showSoftInputOnFocus to TextInput. This fixes #14045. This prop can be used to prevent the system keyboard from displaying at all when focusing an input text, for example if a custom keyboard component needs to be displayed instead.

On Android, currently TextInput always open the soft keyboard when focused. This is because `requestFocus` calls `showSoftKeyboard`, which in turn instructs `InputMethodManager` to show the soft keyboard.

Unfortunately even if we were to define a new input type that extends ReactEditText, there is no way to overcome this issue. 
This is because `showSoftKeyboard` is a private method so it can't be overriden. And at the same time `requestFocus` needs to invoke `super.requestFocus` to properly instruct Android that the field has gained focused, so overriding `requestFocus` in a subclass of ReactEditText is also not an option, as when invoking `super.requestFocus` we would end up calling again the one defined in ReactEditText.

So currently the only way of doing this is to basically add a listener on the focus event that will close the soft keyboard immediately after. But for a split second it will still be displayed.

The code in the PR changes `requestFocus` to honor showSoftInputOnFocus as defined in Android TextView, displaying the soft keyboard unless instructed otherwise.

## Changelog

[Android] [Added] - Add showSoftInputOnFocus to TextInput

## Test Plan

Changed the sample app adding the following TextInput:

```
<TextInput showSoftInputOnFocus={false} style={{backgroundColor: 'pink'}} />
<TextInput style={{backgroundColor: 'green'}} />
```

The following video demonstrates the new behavior

https://drive.google.com/file/d/1OAQTMdb64UQTDotOnNTOsTTbLlormkNA/view?usp=sharing

