### PR TITLE
Use default OK on buttonPositive to prevent showing an alert without any buttons

### DIFF
--- a/Libraries/Alert/Alert.js
+++ b/Libraries/Alert/Alert.js
@@ -73,9 +73,10 @@ class Alert {
       }
       // At most three buttons (neutral, negative, positive). Ignore rest.
       // The text 'OK' should be probably localized. iOS Alert does that in native.
+      const defaultPositiveText = 'OK';
       const validButtons: Buttons = buttons
         ? buttons.slice(0, 3)
-        : [{text: 'OK'}];
+        : [{text: defaultPositiveText}];
       const buttonPositive = validButtons.pop();
       const buttonNegative = validButtons.pop();
       const buttonNeutral = validButtons.pop();
@@ -87,7 +88,7 @@ class Alert {
         config.buttonNegative = buttonNegative.text || '';
       }
       if (buttonPositive) {
-        config.buttonPositive = buttonPositive.text || '';
+        config.buttonPositive = buttonPositive.text || defaultPositiveText;
       }
 
       const onAction = (action, buttonKey) => {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Solve #25016

Use `OK` as default text for the affirmative button if no text is specified. When setting an alert on android with button configuration, and no `text` field specified no button is shown on the alert. This makes it impossible to dismiss. An example of how this can happen is creating a simple button where a `onPress` callback is used but no text is specified:

```
Alert.alert(
   'title',
   'message',
   [ { onPress: () => console.log('onPress') } ],
)
```

Does not change the current behavior of no text button configurations on iOS. On iOS at least one button is always shown, and buttons with no text can be displayed.

Behavior on setting multiple buttons is a little wonky, but this PR does not aim to solve it. I did test these cases and included some examples below.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[Android] [Fixed] - Use OK as default text on Android Alert if button configuration specified without text

## Test Plan

Tested alerts with varying configurations set


#### Configuration without text, one button:
```
Alert.alert(
'title',
'message',
[ {  onPress: () => console.log('first') } ])
```
![Screen Shot 2019-05-24 at 11 05 47 AM](https://user-images.githubusercontent.com/22333355/58348001-324f1500-7e14-11e9-9de9-d2ab6360c9bb.png)

#### Configuration without text, two button:
```
Alert.alert(
'title',
'message',
[
    {  onPress: () => console.log('first') },
    {  onPress: () => console.log('first') },
],
)
```
![Screen Shot 2019-05-24 at 11 42 38 AM](https://user-images.githubusercontent.com/22333355/58349782-0e420280-7e19-11e9-98d5-9b411654ae52.png)



#### Configuration without text, three buttons
```
Alert.alert(
'title',
'message',
[
    {  onPress: () => console.log('first') },
    {  onPress: () => console.log('second') },
    {  onPress: () => console.log('third') },
],
)
```

![Screen Shot 2019-05-24 at 11 43 25 AM](https://user-images.githubusercontent.com/22333355/58349858-3fbace00-7e19-11e9-8626-972194ba77fc.png)



#### Custom text for two of three buttons:
```
Alert.alert(
'title',
'message',
[
    {  text: 'first', onPress: () => console.log('first') },
    {  text: 'second', onPress: () => console.log('second') },
    {  onPress: () => console.log('third') },
],
)
```
![Screen Shot 2019-05-24 at 12 00 44 PM](https://user-images.githubusercontent.com/22333355/58350750-a7721880-7e1b-11e9-9430-0e1d536e1a18.png)

#### Custom text for first button only:
```
Alert.alert(
'title',
'message',
[
    {  text: 'first', onPress: () => console.log('first') },
    {  onPress: () => console.log('second') },
    {  onPress: () => console.log('third') },
],
)
```
![Screen Shot 2019-05-24 at 12 02 44 PM](https://user-images.githubusercontent.com/22333355/58350935-2e26f580-7e1c-11e9-8aa5-6db9c55b331c.png)


#### No button configuration:
```
Alert.alert(
'title',
'message',
)
```
![Screen Shot 2019-05-24 at 11 09 02 AM](https://user-images.githubusercontent.com/22333355/58349089-36c8fd00-7e17-11e9-9b58-c86f32cfcbec.png)
