### PR TITLE
Feature to listen on window focus events

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/ReactActivity.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactActivity.java
@@ -125,6 +125,12 @@ public abstract class ReactActivity extends AppCompatActivity
     mDelegate.onRequestPermissionsResult(requestCode, permissions, grantResults);
   }
 
+  @Override
+  public void onWindowFocusChanged(boolean hasFocus) {
+    super.onWindowFocusChanged(hasFocus);
+    mDelegate.onWindowFocusChanged(hasFocus);
+  }
+
   protected final ReactNativeHost getReactNativeHost() {
     return mDelegate.getReactNativeHost();
   }

--- a/ReactAndroid/src/main/java/com/facebook/react/ReactActivityDelegate.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactActivityDelegate.java
@@ -182,6 +182,12 @@ public class ReactActivityDelegate {
     return false;
   }
 
+  public void onWindowFocusChanged(boolean hasFocus) {
+    if (getReactNativeHost().hasInstance()) {
+      getReactNativeHost().getReactInstanceManager().onWindowFocusChange(hasFocus);
+    }
+  }
+
   @TargetApi(Build.VERSION_CODES.M)
   public void requestPermissions(
     String[] permissions,

--- a/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
@@ -710,6 +710,15 @@ public class ReactInstanceManager {
   }
 
   @ThreadConfined(UI)
+  public void onWindowFocusChange(boolean hasFocus) {
+    UiThreadUtil.assertOnUiThread();
+    ReactContext currentContext = getCurrentReactContext();
+    if (currentContext != null) {
+      currentContext.onWindowFocusChange(hasFocus);
+    }
+  }
+
+  @ThreadConfined(UI)
   public void showDevOptionsDialog() {
     UiThreadUtil.assertOnUiThread();
     mDevSupportManager.showDevOptionsDialog();

--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactContext.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactContext.java
@@ -36,6 +36,8 @@ public class ReactContext extends ContextWrapper {
       new CopyOnWriteArraySet<>();
   private final CopyOnWriteArraySet<ActivityEventListener> mActivityEventListeners =
       new CopyOnWriteArraySet<>();
+  private final CopyOnWriteArraySet<WindowFocusChangeListener> mWindowFocusEventListeners =
+    new CopyOnWriteArraySet<>();
 
   private LifecycleState mLifecycleState = LifecycleState.BEFORE_CREATE;
 
@@ -196,6 +198,14 @@ public class ReactContext extends ContextWrapper {
     mActivityEventListeners.remove(listener);
   }
 
+  public void addWindowFocusChangeListener(WindowFocusChangeListener listener) {
+    mWindowFocusEventListeners.add(listener);
+  }
+
+  public void removeWindowFocusChangeListener(WindowFocusChangeListener listener) {
+    mWindowFocusEventListeners.remove(listener);
+  }
+
   /**
    * Should be called by the hosting Fragment in {@link Fragment#onResume}
    */
@@ -275,6 +285,17 @@ public class ReactContext extends ContextWrapper {
     for (ActivityEventListener listener : mActivityEventListeners) {
       try {
         listener.onActivityResult(activity, requestCode, resultCode, data);
+      } catch (RuntimeException e) {
+        handleException(e);
+      }
+    }
+  }
+
+  public void onWindowFocusChange(boolean hasFocus) {
+    UiThreadUtil.assertOnUiThread();
+    for (WindowFocusChangeListener listener : mWindowFocusEventListeners) {
+      try {
+        listener.onWindowFocusChange(hasFocus);
       } catch (RuntimeException e) {
         handleException(e);
       }

--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/WindowFocusChangeListener.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/WindowFocusChangeListener.java
@@ -1,0 +1,15 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+
+package com.facebook.react.bridge;
+
+
+/*
+ * Listener for receiving window focus events.
+ */
+public interface WindowFocusChangeListener {
+  void onWindowFocusChange(boolean hasFocus);
+}

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/appstate/AppStateModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/appstate/AppStateModule.java
@@ -13,6 +13,7 @@ import com.facebook.react.bridge.LifecycleEventListener;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
+import com.facebook.react.bridge.WindowFocusChangeListener;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.common.LifecycleState;
 import com.facebook.react.module.annotations.ReactModule;
@@ -23,7 +24,7 @@ import java.util.Map;
 
 @ReactModule(name = AppStateModule.NAME)
 public class AppStateModule extends ReactContextBaseJavaModule
-        implements LifecycleEventListener {
+        implements LifecycleEventListener, WindowFocusChangeListener {
 
   protected static final String NAME = "AppState";
 
@@ -37,6 +38,7 @@ public class AppStateModule extends ReactContextBaseJavaModule
   public AppStateModule(ReactApplicationContext reactContext) {
     super(reactContext);
     reactContext.addLifecycleEventListener(this);
+    reactContext.addWindowFocusChangeListener(this);
     mAppState = (reactContext.getLifecycleState() == LifecycleState.RESUMED ?
             APP_STATE_ACTIVE : APP_STATE_BACKGROUND);
   }
@@ -74,6 +76,12 @@ public class AppStateModule extends ReactContextBaseJavaModule
   public void onHostDestroy() {
     // do not set state to destroyed, do not send an event. By the current implementation, the
     // catalyst instance is going to be immediately dropped, and all JS calls with it.
+  }
+
+  @Override
+  public void onWindowFocusChange(boolean hasFocus) {
+    getReactApplicationContext().getJSModule(RCTDeviceEventEmitter.class)
+      .emit("appStateFocusChange", hasFocus);
   }
 
   private WritableMap createAppStateEventMap() {


### PR DESCRIPTION
## Summary

Addressed issue: https://github.com/facebook/react-native/issues/24149

On Android, activity's lifecycle events are not triggered when the user pulls down the Status Bar (opening Notification Drawer). In order to know that, you need to override [onWindowFocusChanged method](https://developer.android.com/reference/android/app/Activity.html#onWindowFocusChanged(boolean)).


## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[Android] [Added] - Adds a new listener for `onWindowFocusChanged`
[JavaScript] [Added] - New event, `focusChanged`, to listen on focus gain/loss

## Test Plan


```javascript

AppState.addEventListener("focusChanged", hasFocus => {
   if(hasFocus) {
       // do something while we have focus
   } else {
       // unfocused
   }
});
```

![appfocusg](https://user-images.githubusercontent.com/6444719/58372557-5c412e00-7f1f-11e9-85bb-81607bad131a.gif)
