### PR TITLE
Fix incorrect unhooking for UI manager views in RCTProfileUnhookModules

### DIFF
--- a/React/Profiler/RCTProfile.m
+++ b/React/Profiler/RCTProfile.m
@@ -350,7 +350,7 @@ void RCTProfileUnhookModules(RCTBridge *bridge)
   if ([bridge moduleIsInitialized:[RCTUIManager class]]) {
     dispatch_async(dispatch_get_main_queue(), ^{
       for (id view in [bridge.uiManager valueForKey:@"viewRegistry"]) {
-        RCTProfileUnhookInstance(view);
+        RCTProfileUnhookInstance([bridge.uiManager viewForReactTag:view]);
       }
 
       dispatch_group_leave(RCTProfileGetUnhookGroup());


### PR DESCRIPTION
## Summary

This PR fixes incorrect unhooking for UI manager views in `RCTProfileUnhookModules`. `view` is actually a key, not the view itself; instead, use `viewForReactTag:` to obtain the view itself.

This fixes issue #24952.

## Changelog

[iOS] [Fixed] - Fix incorrect unhooking for UI manager views in `RCTProfileUnhookModules`, causing an infinite `RCTProfileTrampoline ` recursion (#24952)

## Test Plan

N/A
