### PR TITLE
Linking.getInitialURL() to work with NFC tags on Android

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/modules/intent/IntentModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/intent/IntentModule.java
@@ -12,6 +12,7 @@ import android.content.ComponentName;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.net.Uri;
+import android.nfc.NfcAdapter;
 import android.provider.Settings;
 
 import com.facebook.react.bridge.JSApplicationIllegalArgumentException;
@@ -59,7 +60,9 @@ public class IntentModule extends ReactContextBaseJavaModule {
         String action = intent.getAction();
         Uri uri = intent.getData();
 
-        if (Intent.ACTION_VIEW.equals(action) && uri != null) {
+        if (uri != null &&
+          (Intent.ACTION_VIEW.equals(action) ||
+           NfcAdapter.ACTION_NDEF_DISCOVERED.equals(action))) {
           initialURL = uri.toString();
         }
       }

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/intent/IntentModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/intent/IntentModule.java
@@ -60,9 +60,7 @@ public class IntentModule extends ReactContextBaseJavaModule {
         String action = intent.getAction();
         Uri uri = intent.getData();
 
-        if (uri != null &&
-          (Intent.ACTION_VIEW.equals(action) ||
-           NfcAdapter.ACTION_NDEF_DISCOVERED.equals(action))) {
+        if (uri != null && (Intent.ACTION_VIEW.equals(action) || NfcAdapter.ACTION_NDEF_DISCOVERED.equals(action))) {
           initialURL = uri.toString();
         }
       }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
This PR solves bug https://github.com/facebook/react-native/issues/24393 for Android. Allows an app to be opened with an NFC tag and getting the url trough Linking.getInitialURL()

## Changelog
[Android] [Fixed] - This branch checks also for `ACTION_NDEF_DISCOVERED` intent matches to set the initialURL

## Test Plan
Tested the code multiple times with both NFC tags and normal links
