### PR TITLE
[CI] Disable Android tests on Appveyor

### DIFF
--- a/.appveyor/config.yml
+++ b/.appveyor/config.yml
@@ -38,7 +38,7 @@ build_script:
   - yarn run flow-check-android
   - yarn run flow-check-ios
   - yarn run test
-  - gradlew.bat RNTester:android:app:assembleRelease
+  # - gradlew.bat RNTester:android:app:assembleRelease
 
 cache:
   - node_modules


### PR DESCRIPTION
Android is failing on Appveyor. Removing to regain signal on Windows.

See https://ci.appveyor.com/project/Facebook/react-native/builds/24869333/job/tnif7yt4x0lfisju for an example.

