### PR TITLE
Don't reference null android.ndkDirectory in build.gradle

### DIFF
--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -193,7 +193,7 @@ def findNdkBuildFullPath() {
     def ndkDir = android.hasProperty("plugin") ? android.plugin.ndkFolder :
             plugins.getPlugin("com.android.library").hasProperty("sdkHandler") ?
                     plugins.getPlugin("com.android.library").sdkHandler.getNdkFolder() :
-                    android.ndkDirectory.absolutePath
+                    android.ndkDirectory ? android.ndkDirectory.absolutePath : null
     if (ndkDir) {
         return new File(ndkDir, getNdkBuildName()).getAbsolutePath()
     }


### PR DESCRIPTION
## Summary

If you (try to) build React Native for Android without having the NDK properly installed and referenced, you get the following error:

>A problem occurred evaluating project ':ReactAndroid'.
\> Cannot get property 'absolutePath' on null object

This is not an overly helpful diagnostic. This PR results in this message instead:

>ndk-build binary cannot be found, check if you've set $ANDROID_NDK environment variable correctly or if ndk.dir is setup in local.properties

Fixes #25087

## Changelog

[Android] [Fixed] - Show proper error message instead of throwing a NullReferenceException if Gradle cannot find the NDK

## Test Plan

Manual testing. Ensure that the Android NDK is improperly referenced (it doesn't matter whether it's actually installed somewhere), then try to sync Android Studio's project with the Gradle files. This will fail with or without this change, but **with** the change, the developer gets a proper error message instead of an NRE.