### PR TITLE
[CI] Cache CocoaPods specs-repo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,8 +59,8 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - v2-yarn-cache-{{ arch }}-{{ checksum "package.json" }}
-            - v2-yarn-cache-{{ arch }}
+            - v3-yarn-cache-{{ arch }}-{{ checksum "yarn.lock" }}
+            - v3-yarn-cache-{{ arch }}
       - run:
           name: Run Yarn
           command: |
@@ -72,7 +72,7 @@ commands:
       - save_cache:
           paths:
             - ~/.cache/yarn
-          key: v2-yarn-cache-{{ arch }}-{{ checksum "package.json" }}
+          key: v3-yarn-cache-{{ arch }}-{{ checksum "yarn.lock" }}
 
   install_buck_tooling:
     steps:
@@ -467,6 +467,7 @@ jobs:
           checkout_type: node
       - setup_artifacts
       - run_yarn
+      - run: sudo apt-get install rsync
 
       - run:
           name: Run JavaScript End-to-End Tests
@@ -716,10 +717,7 @@ workflows:
             branches:
               only: /^pull\/.*$/
 
-      # Gather coverage on master
+      # Gather coverage
       - js_coverage:
           requires:
             - setup
-          filters:
-            branches:
-              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -433,6 +433,13 @@ jobs:
       # Configure Watchman
       - run: touch .watchmanconfig
 
+      - restore_cache:
+          keys:
+            - v1-cocoapods-{{ checksum "template/ios/Podfile" }}
+            - v1-cocoapods-
+
+      - run: pod setup
+
       - run:
           name: Run Detox iOS End-to-End Tests
           command: yarn run build-ios-e2e && yarn run test-ios-e2e
@@ -447,6 +454,11 @@ jobs:
             set -eo pipefail
             node ./scripts/run-ci-e2e-tests.js --ios --retries 3;
           when: always
+
+      - save_cache:
+          paths:
+            - ~/.cocoapods/repos
+          key: v1-cocoapods-{{ checksum "template/ios/Podfile" }}
 
   test_js_e2e:
     executor: node8


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

The `test_end_to_end` job has been timing out due CocoaPods taking too long to check out the Specs repo. This repo is stored at `~/.cocoapods`, therefore by caching this folder we can keep the individual e2e test run from exceeding 10 minutes w/o output.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[Internal] [Added] - Cache CocoaPods

## Test Plan

CI: https://circleci.com/gh/hramos/react-native/6155
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

With empty cache:

![Screen Shot 2019-05-30 at 12 54 04 PM](https://user-images.githubusercontent.com/165856/58662481-27e2be80-82df-11e9-8dd3-cd0a763631c6.png)

After cache is ready:

![Screen Shot 2019-05-30 at 1 30 16 PM](https://user-images.githubusercontent.com/165856/58662499-2f09cc80-82df-11e9-96a0-e202cb4447b0.png)
