### PR TITLE
fix shouldComponentUpdate in YellowBox

### DIFF
--- a/Libraries/YellowBox/UI/YellowBoxListRow.js
+++ b/Libraries/YellowBox/UI/YellowBoxListRow.js
@@ -38,7 +38,7 @@ class YellowBoxListRow extends React.Component<Props> {
       prevProps.onPress !== nextProps.onPress ||
       prevProps.warnings.length !== nextProps.warnings.length ||
       prevProps.warnings.some(
-        (prevWarning, index) => prevWarning !== nextProps[index],
+        (prevWarning, index) => prevWarning !== nextProps.warnings[index],
       )
     );
   }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

The previous comparison does not make sense (accessing props by index) - and always returns true. I'm going to assume there was a reason for implementing `shouldComponentUpdate` - although personally I'd just go for PureComponent (even if it may not be 100% accurate). 


## Changelog

not needed

## Test Plan

Quickly tested locally.