### PR TITLE
[iOS] Fixes wrong time unit of scroll event throttle

### DIFF
--- a/React/Views/ScrollView/RCTScrollView.m
+++ b/React/Views/ScrollView/RCTScrollView.m
@@ -706,10 +706,10 @@ RCT_SCROLL_EVENT_HANDLER(scrollViewDidScrollToTop, onScrollToTop)
    * warnings, and behave strangely (ListView works fine however), so don't fix it unless you fix that too!
    *
    * We limit the delta to 17ms so that small throttles intended to enable 60fps updates will not
-   * inadvertantly filter out any scroll events.
+   * inadvertently filter out any scroll events.
    */
   if (_allowNextScrollNoMatterWhat ||
-      (_scrollEventThrottle > 0 && _scrollEventThrottle < MAX(17, now - _lastScrollDispatchTime))) {
+      (_scrollEventThrottle > 0 && _scrollEventThrottle < MAX(0.017, now - _lastScrollDispatchTime))) {
 
     if (_DEPRECATED_sendUpdatedChildFrames) {
       // Calculate changed frames


### PR DESCRIPTION
## Summary

We need to use second for calculation, so change 17ms to 0.017s instead.

## Changelog

[iOS] [Fixed] - Fixes wrong time unit of scroll event throttle

## Test Plan

N/A.
