### PR TITLE
Add Animated mocks to jest

### DIFF
--- a/jest/setup.js
+++ b/jest/setup.js
@@ -65,6 +65,34 @@ jest
     };
     return DataSource;
   })
+  .mock('Animated', () => {
+    const AnimatedImplementation = jest.requireActual('AnimatedImplementation');
+    const oldCreate = AnimatedImplementation.createAnimatedComponent;
+    const Animated = jest.requireActual('Animated');
+     function createAnimatedComponent(
+      Component,
+      defaultProps,
+    ) {
+      const Wrapped = oldCreate(Component, defaultProps);
+      Wrapped.__skipSetNativeProps_FOR_TESTS_ONLY = true;
+      return Wrapped;
+    };
+    const FlatList = createAnimatedComponent(jest.requireActual('FlatList'));
+    const Image = createAnimatedComponent(mockComponent('Image'));
+    const ScrollView = createAnimatedComponent(jest.requireMock('ScrollViewMock'));
+    const SectionList = createAnimatedComponent(jest.requireActual('SectionList'));
+    const Text = createAnimatedComponent(mockComponent('Text', MockNativeMethods));
+    const View = createAnimatedComponent(mockComponent('View', MockNativeMethods));
+    return {
+      ...Animated,
+      FlatList,
+      Image,
+      ScrollView,
+      SectionList,
+      Text,
+      View
+    };
+  })
   .mock('AnimatedImplementation', () => {
     const AnimatedImplementation = jest.requireActual('AnimatedImplementation');
     const oldCreate = AnimatedImplementation.createAnimatedComponent;


### PR DESCRIPTION
## Summary

Using Animated components like View and Image do not get created with `__skipSetNativeProps_FOR_TESTS_ONLY = true` since they get created before the jest mock can be applied to `createAnimatedComponent`. For these components mock their getters to create versions that properly skip set native props.

Jest tests that render these components get warnings the `setNativeProps` gets called even though using a testRenderer this should not happen.

## Changelog

[JavaScript] [Fixed] - Define Animated Components for `react-native/jest/setup` that properly skip setNativeProps

## TestPlan