### PR TITLE
Move unistd.h include to cpp where its used

### DIFF
--- a/ReactCommon/cxxreact/JSBigString.cpp
+++ b/ReactCommon/cxxreact/JSBigString.cpp
@@ -6,6 +6,7 @@
 #include "JSBigString.h"
 
 #include <fcntl.h>
+#include <unistd.h>
 #include <sys/stat.h>
 
 #include <glog/logging.h>

--- a/ReactCommon/cxxreact/JSBigString.h
+++ b/ReactCommon/cxxreact/JSBigString.h
@@ -6,7 +6,6 @@
 #pragma once
 
 #include <fcntl.h>
-#include <unistd.h>
 #include <sys/mman.h>
 
 #include <folly/Exception.h>


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

unistd.h isn't a header available in the windows SDK, so we can't include it from react-native-windows.

I moved the usage of dup, to JSBigString.cpp in a previous PR, so this header should only be needed in the cpp file, not the header.  (And react-native-windows doesn't use the cpp file)

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[Internal] [Fixed] - Header cleanup

## Test Plan

Does it build?