### PR TITLE
mock Animated components with versions that skipSetNativeProps

### DIFF
--- a/jest/setup.js
+++ b/jest/setup.js
@@ -127,6 +127,12 @@ jest
       '../Libraries/Components/ActivityIndicator/ActivityIndicator',
     ),
   )
+  .mock('../Libraries/Animated/src/Animated', () => {
+    const Animated = jest.requireActual('../Libraries/Animated/src/Animated');
+    Animated.Text.__skipSetNativeProps_FOR_TESTS_ONLY = true;
+    Animated.View.__skipSetNativeProps_FOR_TESTS_ONLY = true;
+    return Animated;
+  })
   .mock('../Libraries/Animated/src/AnimatedImplementation', () => {
     const AnimatedImplementation = jest.requireActual(
       '../Libraries/Animated/src/AnimatedImplementation',


### PR DESCRIPTION
## Summary

Using Animated components like View and Image do not get created with __skipSetNativeProps_FOR_TESTS_ONLY = true since they get created before the jest mock can be applied to createAnimatedComponent. For these components mock getters to create versions that properly skip set native props.

Jest tests that render these components get warnings the setNativeProps gets called even though using a testRenderer this should not happen.

## Changelog

[Javascript] [Fixed] - Define Animated Components for react-native/jest/setup that properly skip setNativeProps

## Test Plan

Run tests