### PR TITLE
[Android] [Fixed] - Fix missing whitespace in debug instructions

### DIFF
--- a/Libraries/NewAppScreen/components/DebugInstructions.js
+++ b/Libraries/NewAppScreen/components/DebugInstructions.js
@@ -27,7 +27,7 @@ const DebugInstructions = Platform.select({
   ),
   default: () => (
     <Text>
-      Press <Text style={styles.highlight}>menu button</Text> or
+      Press <Text style={styles.highlight}>menu button</Text> or{' '}
       <Text style={styles.highlight}>Shake</Text> your device to open the React
       Native debug menu.
     </Text>


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
Fixes minor whitespace issue with the new new-app template.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[Android] [Fixed] - Fix missing whitespace in debug instructions

## Test Plan

Create a new app with react-native init, run it on an android device, see that there is a space between 'or' and 'Shake' in the Debug section.
