### PR TITLE
Fix accessibilityActions accessors

### DIFF
--- a/React/Views/UIView+React.m
+++ b/React/Views/UIView+React.m
@@ -297,12 +297,12 @@
   return self;
 }
 
-- (NSArray<NSString *> *)accessibilityActions
+- (NSArray<NSDictionary *> *)accessibilityActions
 {
   return objc_getAssociatedObject(self, _cmd);
 }
 
-- (void)setAccessibilityActions:(NSArray<NSString *> *)accessibilityActions
+- (void)setAccessibilityActions:(NSArray<NSDictionary *> *)accessibilityActions
 {
   objc_setAssociatedObject(self, @selector(accessibilityActions), accessibilityActions, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

The accessibilityActions accessors  in UIView+React.m are not aligned with the property declaration in the header file. 

## Changelog

[General] [Fixed] - Fix accessibilityActions accessors

## Test Plan

Tested that RNTester accessibility examples still work.
