### PR TITLE
Bump Android NDK to r19c

### DIFF
--- a/.appveyor/config.yml
+++ b/.appveyor/config.yml
@@ -1,13 +1,13 @@
 environment:
   ANDROID_HOME: "C:\\android-sdk-windows"
-  ANDROID_NDK: "C:\\android-sdk-windows\\android-ndk-r17c"
+  ANDROID_NDK: "C:\\android-sdk-windows\\android-ndk-r19c"
   ANDROID_BUILD_VERSION: 28
   ANDROID_TOOLS_VERSION: 28.0.3
 
   GRADLE_OPTS: -Dorg.gradle.daemon=false
 
   SDK_TOOLS_URL: https://dl.google.com/android/repository/sdk-tools-windows-3859397.zip
-  NDK_TOOLS_URL: https://dl.google.com/android/repository/android-ndk-r17c-windows-x86_64.zip
+  NDK_TOOLS_URL: https://dl.google.com/android/repository/android-ndk-r19c-windows-x86_64.zip
 
   matrix:
     - nodejs_version: 8

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ executors:
   reactnativeandroid:
     <<: *defaults
     docker:
-      - image: reactnativecommunity/react-native-android:2019-5-29
+      - image: reactnativecommunity/react-native-android:2019-6-4
     resource_class: "large"
     environment:
       - TERM: "dumb"

--- a/scripts/android-setup.sh
+++ b/scripts/android-setup.sh
@@ -40,7 +40,7 @@ function getAndroidNDK {
   if [ ! -e $DEPS ]; then
     cd $NDK_HOME || exit
     echo "Downloading NDK..."
-    curl -o ndk.zip https://dl.google.com/android/repository/android-ndk-r17c-linux-x86_64.zip
+    curl -o ndk.zip https://dl.google.com/android/repository/android-ndk-r19c-linux-x86_64.zip
     unzip -o -q ndk.zip
     echo "Installed Android NDK at $NDK_HOME"
     touch $DEPS


### PR DESCRIPTION
## Summary

In 2019-6-4 version of Docker Android image, we've added Android NDK r19c. So this PR will change CI to use NDK r19c.

I'll create a PR to website once this merged.

Note: I tried to build RN with NDK 19 while I was setting up my laptop after format, and it worked.

## Changelog

[Android] [Changed] - Bump Android NDK to r19c

## Test Plan

CI is green and RNTester works as expected.