### PR TITLE
[iOS] Don't apply empty attributed string for TextInput

### DIFF
--- a/Libraries/Text/TextInput/RCTBaseTextInputShadowView.m
+++ b/Libraries/Text/TextInput/RCTBaseTextInputShadowView.m
@@ -174,7 +174,12 @@
     baseTextInputView.reactPaddingInsets = paddingInsets;
 
     if (isAttributedTextChanged) {
-      baseTextInputView.attributedText = attributedText;
+      // Don't set `attributedText` if length equal to zero, otherwise it would shrink when attributes contain like `lineHeight`.
+      if (attributedText.length != 0) {
+        baseTextInputView.attributedText = attributedText;
+      } else {
+        baseTextInputView.attributedText = nil;
+      }
     }
   }];
 }

--- a/Libraries/Text/TextInput/RCTBaseTextInputView.h
+++ b/Libraries/Text/TextInput/RCTBaseTextInputView.h
@@ -46,7 +46,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign) BOOL secureTextEntry;
 @property (nonatomic, copy) RCTTextSelection *selection;
 @property (nonatomic, strong, nullable) NSNumber *maxLength;
-@property (nonatomic, copy) NSAttributedString *attributedText;
+@property (nonatomic, copy, nullable) NSAttributedString *attributedText;
 @property (nonatomic, copy) NSString *inputAccessoryViewID;
 @property (nonatomic, assign) UIKeyboardType keyboardType;
 


### PR DESCRIPTION
## Summary

Issue reported by @Titozzz , `TextInput` would shrink when we have attributes like `lineHeight`. 
Demonstration can see GIF like below:
https://giphy.com/gifs/KGNs1qIMHF3DIk1EPK

I think the reason is we apply an empty attributed string to `UITextField`, now if the length is 0, we just nil the `attributedText` instead.

## Changelog

[iOS] [Fixed] - Don't apply empty attributed string for TextInput

## Test Plan

Demo code:
```
import React from 'react';
import { StyleSheet, TextInput, View } from 'react-native';

export default (App = () => {
  return (
    <View style={styles.container}>
      <View
        style={{
          padding: 20,
          backgroundColor: 'purple',
          flexDirection: 'row',
        }}
      >
        <TextInput
          style={{
            backgroundColor: 'cyan',
            flex: 1,
            lineHeight: 24,
            fontSize: 16,
          }}
        />
      </View>
    </View>
  );
});

const styles = StyleSheet.create({
  container: {
    flex: 1,
    justifyContent: 'center',
    alignItems: 'center',
    backgroundColor: '#F5FCFF',
  },
});
```