### PR TITLE
Add debug build support for Android native code

### DIFF
--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -33,6 +33,9 @@ def dependenciesPath = System.getenv("REACT_NATIVE_DEPENDENCIES")
 // and the build will use that.
 def boostPath = dependenciesPath ?: System.getenv("REACT_NATIVE_BOOST_PATH")
 
+// Setup build type for NDK, supported values: {debug, release}
+def nativeBuildType = System.getenv("NATIVE_BUILD_TYPE") ?: "release"
+
 task createNativeDepsDirectories {
     downloadsDir.mkdirs()
     thirdPartyNdkDir.mkdirs()
@@ -225,6 +228,7 @@ task buildReactNdkLib(dependsOn: [prepareJSC, prepareBoost, prepareDoubleConvers
     inputs.dir("src/main/java/com/facebook/react/modules/blob")
     outputs.dir("$buildDir/react-ndk/all")
     commandLine(getNdkBuildFullPath(),
+            "NDK_DEBUG=" + (nativeBuildType.equalsIgnoreCase("debug") ? "1" : "0"),
             "NDK_PROJECT_PATH=null",
             "NDK_APPLICATION_MK=$projectDir/src/main/jni/Application.mk",
             "NDK_OUT=" + temporaryDir,

--- a/ReactAndroid/src/main/jni/react/jni/Android.mk
+++ b/ReactAndroid/src/main/jni/react/jni/Android.mk
@@ -36,6 +36,14 @@ LOCAL_MODULE := reactnativejni
 # Compile all local c++ files.
 LOCAL_SRC_FILES := $(wildcard *.cpp)
 
+ifeq ($(APP_OPTIM),debug)
+  # Keep symbols by overriding strip command invoked by ndk-build.
+  # Note that this will take effect to all shared libraries,
+  # i.e. all shared libraries will NOT be stripped
+  # even we only override in this Android.mk
+  cmd-strip :=
+endif
+
 # Build the files in this directory as a shared library
 include $(BUILD_SHARED_LIBRARY)
 

--- a/ReactAndroid/src/main/jni/react/jni/Android.mk
+++ b/ReactAndroid/src/main/jni/react/jni/Android.mk
@@ -37,10 +37,10 @@ LOCAL_MODULE := reactnativejni
 LOCAL_SRC_FILES := $(wildcard *.cpp)
 
 ifeq ($(APP_OPTIM),debug)
-  # Keep symbols by overriding strip command invoked by ndk-build.
-  # Note that this will take effect to all shared libraries,
-  # i.e. all shared libraries will NOT be stripped
-  # even we only override in this Android.mk
+  # Keep symbols by overriding the strip command invoked by ndk-build.
+  # Note that this will apply to all shared libraries,
+  # i.e. shared libraries will NOT be stripped
+  # even though we override it in this Android.mk
   cmd-strip :=
 endif
 

--- a/ReactAndroid/src/main/jni/third-party/folly/Android.mk
+++ b/ReactAndroid/src/main/jni/third-party/folly/Android.mk
@@ -17,6 +17,14 @@ LOCAL_SRC_FILES:= \
   folly/container/detail/F14Table.cpp \
   folly/ScopeGuard.cpp \
 
+ifeq ($(APP_OPTIM),debug)
+  LOCAL_SRC_FILES += \
+    folly/lang/Assume.cpp \
+    folly/lang/SafeAssert.cpp \
+    folly/FileUtil.cpp \
+    folly/portability/SysUio.cpp
+endif
+
 LOCAL_C_INCLUDES := $(LOCAL_PATH)
 LOCAL_EXPORT_C_INCLUDES := $(LOCAL_PATH)
 


### PR DESCRIPTION
## Summary

With JSI based architecture, there will be more and more C++ native code involved.
Original NDK builder in RN only supports release build and that's not reasonable for native debugging.
This change introduces a way to build native code in debuggable version.

Simply add `NATIVE_BUILD_TYPE=Debug` environment variable during gradle build,
e.g.
`NATIVE_BUILD_TYPE=Debug ./gradlew clean :ReactAndroid:assembleDebug`

## Changelog

[Android] [Added] - Add native debug build support to improve debugging DX

## Test Plan

1. Check original gradle build works:
`./gradlew clean :ReactAndroid:installArchives`

2. Check debug build works:
`NATIVE_BUILD_TYPE=Debug ./gradlew clean :ReactAndroid:assembleDebug` and verify *.so is not stripped
`file ReactAndroid/build/react-ndk/all/armeabi-v7a/lib*.so`
