### PR TITLE
Fix unused attribute parsing for Xcode 11 beta

### DIFF
--- a/React/Base/RCTModuleMethod.mm
+++ b/React/Base/RCTModuleMethod.mm
@@ -91,6 +91,7 @@ static BOOL RCTParseSelectorPart(const char **input, NSMutableString *selector)
 static BOOL RCTParseUnused(const char **input)
 {
   return RCTReadString(input, "__attribute__((unused))") ||
+         RCTReadString(input, "__attribute__((__unused))") ||
          RCTReadString(input, "__unused");
 }
 


### PR DESCRIPTION
Fixes crash when any native method with unused attribute is called

## Summary

In latest Xcode 11 beta format of method signatures was changed a little and causes a crash for any method with unused attribute. This PR fixes the issue

## Changelog

[iOS] [Fixed] - Xcode 11 beta runtime crash for methods with unused attribute.