### PR TITLE
[iOS] Removed autoresizing mask for modal host container view

### DIFF
--- a/React/Views/RCTModalHostView.m
+++ b/React/Views/RCTModalHostView.m
@@ -129,8 +129,6 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:coder)
     [subview addGestureRecognizer:_menuButtonGestureRecognizer];
   }
 #endif
-  subview.autoresizingMask = UIViewAutoresizingFlexibleHeight |
-                             UIViewAutoresizingFlexibleWidth;
 
   [_modalViewController.view insertSubview:subview atIndex:0];
   _reactSubview = subview;


### PR DESCRIPTION
## Summary

Fixes #18177 . Related #24497. Autoresizing mask would conflict with `AutoLayout`. For example , it would impact `SafeAreaView`. And actually we don't need to use autoresizing mask,  we observe the bounds change notification and [update the frame manually](https://github.com/facebook/react-native/blob/1151c096dab17e5d9a6ac05b61aacecd4305f3db/React/Views/RCTModalHostView.m#L59). 

## Changelog

[iOS] [Fixed] - Removed autoresizing mask for modal host container view

## Test Plan

`SafeAreaView` works fine in Modal component, all others also need works.