### PR TITLE
[iOS] Excluded tests file from JSI pod

### DIFF
--- a/ReactCommon/React-Fabric.podspec
+++ b/ReactCommon/React-Fabric.podspec
@@ -69,7 +69,7 @@ Pod::Spec.new do |s|
     ss.dependency             folly_dep_name, folly_version
     ss.compiler_flags       = folly_compiler_flags + ' ' + boost_compiler_flags
     ss.source_files         = "fabric/core/**/*.{m,mm,cpp,h}"
-    ss.exclude_files        = "**/tests/*"
+    ss.exclude_files        = "**/tests/**/*"
     ss.header_dir           = "react/core"
     ss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost-for-react-native\" \"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/Folly\"" }
   end

--- a/ReactCommon/jsi/React-jsi.podspec
+++ b/ReactCommon/jsi/React-jsi.podspec
@@ -31,6 +31,7 @@ Pod::Spec.new do |s|
   s.platforms              = { :ios => "9.0", :tvos => "9.2" }
   s.source                 = source
   s.source_files           = "**/*.{cpp,h}"
+  s.exclude_files          = "**/test/*"
   s.framework              = "JavaScriptCore"
   s.compiler_flags         = folly_compiler_flags + ' ' + boost_compiler_flags
   s.pod_target_xcconfig    = { "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost-for-react-native\" \"$(PODS_ROOT)/Folly\"" }


### PR DESCRIPTION
## Summary

Tests file exposed in https://github.com/facebook/react-native/commit/608b1b5ea2d9861816aaf3c4289e4316d9304b87. This break e2e tests, so let's excluded them from JSI pod.

## Changelog

[iOS] [Fixed] - Excluded tests file from JSI pod

## Test Plan

CI green.
