### PR TITLE
[iOS] Fixes race condition of Network module

### DIFF
--- a/Libraries/Network/RCTHTTPRequestHandler.mm
+++ b/Libraries/Network/RCTHTTPRequestHandler.mm
@@ -58,7 +58,7 @@ RCT_EXPORT_MODULE()
 - (NSURLSessionDataTask *)sendRequest:(NSURLRequest *)request
                          withDelegate:(id<RCTURLRequestDelegate>)delegate
 {
-  std::lock_guard<std::mutex> sessionLock(_mutex);
+  std::lock_guard<std::mutex> lock(_mutex);
   // Lazy setup
   if (!_session && [self isValid]) {
     // You can override default NSURLSession instance property allowsCellularAccess (default value YES)


### PR DESCRIPTION
## Summary

There exists race condition in `sendRequest:withDelegate:` method, it can do the session creation multiple times, because we don't lock that, which would leads `EXC_BAD_ACCESS` because use and deallocated session concurrently, we can refer to how to create a singleton safely.

Related https://github.com/facebook/react-native/issues/25152.

## Changelog

[iOS] [Fixed] - Fixes race condition of Network module

## Test Plan

Race condition, reproduce not easy.
