### PR TITLE
Correctly bypass sync calls in UIManager during remote debugging

### DIFF
--- a/Libraries/ReactNative/UIManager.js
+++ b/Libraries/ReactNative/UIManager.js
@@ -78,10 +78,8 @@ const UIManagerJS: UIManagerJSInterface = {
 
     // If we're in the Chrome Debugger, let's not even try calling the sync
     // method.
-    if (__DEV__) {
-      if (!global.nativeCallSyncHook) {
-        return config;
-      }
+    if (!global.nativeCallSyncHook) {
+      return config;
     }
 
     if (
@@ -182,7 +180,7 @@ if (Platform.OS === 'ios') {
   }
 }
 
-if (__DEV__) {
+if (!global.nativeCallSyncHook) {
   Object.keys(getConstants()).forEach(viewManagerName => {
     if (!UIManagerProperties.includes(viewManagerName)) {
       if (!viewManagerConfigs[viewManagerName]) {


### PR DESCRIPTION
## Summary

Remote debugging stopped working (since 0.58, according to #23254). See https://github.com/facebook/react-native/issues/23254#issuecomment-474692753 for repro steps.

The root cause is incorrect checks for Chrome debugging environment in `UIManager.js`.
- In one place where sync function `lazilyLoadView` should be avoided, we effectively use `if (__DEV__ && !global.nativeCallSyncHook)` to check remote debugging, which misses ship flavor (i.e. `__DEV__` is false).
- In another place where we want to pre-populate view managers' constants to avoid calling sync function `getConstantsForViewManager`, `if (__DEV__)` is used, also missing ship flavor.

This PR fixes both checks, only using the absense of `global.nativeCallSyncHook` to determine remote debugging environments.

## Changelog

[JavaScript] [Fixed] - Correctly bypass sync calls in UIManager during remote debugging

## Test Plan

(Copying repro steps from https://github.com/facebook/react-native/issues/23254#issuecomment-474692753)

On a freshly created project by `react-native-cli` in android:

1. Shake phone -> Dev Settings -> Uncheck JS Dev Mode and Use JS Deltas. Then back.
2. Shake phone -> Turn on Debug JS Remotely. Then back
3. Reload

**Current behavior**: Invariant Violation: requireNativeComponent: "RCTView" was not found in the UIManager.

**Fixed (expected) behavior**: No errors, app executes correctly.