### PR TITLE
[iOS] Removed locks && ensure everything runs on JS Thread

### DIFF
--- a/React/Modules/RCTTiming.m
+++ b/React/Modules/RCTTiming.m
@@ -178,6 +178,7 @@ RCT_EXPORT_MODULE()
   _bridge = nil;
 }
 
+// Called from main thread
 - (void)appDidMoveToBackground
 {
   [_bridge dispatchBlock:^{
@@ -191,6 +192,7 @@ RCT_EXPORT_MODULE()
   } queue:RCTJSThread];
 }
 
+// Called from main thread
 - (void)appDidMoveToForeground
 {
   [_bridge dispatchBlock:^{

--- a/React/Modules/RCTTiming.m
+++ b/React/Modules/RCTTiming.m
@@ -171,14 +171,14 @@ RCT_EXPORT_MODULE()
   return RCTJSThread;
 }
 
-// Called from JS Thread.
 - (void)invalidate
 {
-  [self stopTimers];
-  _bridge = nil;
+  [_bridge dispatchBlock:^{
+    [self stopTimers];
+    self->_bridge = nil;
+  } queue:RCTJSThread];
 }
 
-// Called from main thread
 - (void)appDidMoveToBackground
 {
   [_bridge dispatchBlock:^{
@@ -192,7 +192,6 @@ RCT_EXPORT_MODULE()
   } queue:RCTJSThread];
 }
 
-// Called from main thread
 - (void)appDidMoveToForeground
 {
   [_bridge dispatchBlock:^{


### PR DESCRIPTION
## Summary

Before, we add the lock to prevent race condition, it would happen because there has two threads can access concurrently, main thread and JS Thread, actually, most of the time, only JS Thread would call it, and main thread would access it only when app state changed, like in/out background.

Now, we only need to dispatch operations to JS Thread when app state changed, then we can remove all locks. Timer module is time sensitive, so I think remove locks is better. :)

## Changelog

[iOS] [Enhancement] - Removed locks && ensure everything runs on JS Thread

## Test Plan

CI passed.