### PR TITLE
Ensure RCTRootView.cancelTouches() immediately sends termination event to JS

### DIFF
--- a/React/Base/RCTTouchHandler.m
+++ b/React/Base/RCTTouchHandler.m
@@ -368,6 +368,7 @@ static BOOL RCTAnyTouchesChanged(NSSet<UITouch *> *touches)
 {
   self.enabled = NO;
   self.enabled = YES;
+  [self reset];
 }
 
 #pragma mark - UIGestureRecognizerDelegate


### PR DESCRIPTION
Addresses https://github.com/facebook/react-native/issues/25191

## Summary

When this function is called, we force our gesture handler to cancel. However, we don't send a termination event to JS until `reset()` is called, and iOS does not automatically call `reset()` until all touches have ended. This means the JS code is unable to detect or respond to the cancellation immediately.

This PR fixes the problem by calling `reset()` manually after the gesture is cancelled. This is safe to do as `reset()` is idempotent.

## Changelog

[iOS] [Changed] - RCTRootView.cancelTouches() now takes effect immediately

## Test Plan

Tested manually.