### PR TITLE
Added safety checks to fishhook.c

### DIFF
--- a/Libraries/fishhook/fishhook.c
+++ b/Libraries/fishhook/fishhook.c
@@ -103,7 +103,11 @@ static void perform_rebinding_with_section(struct rebindings_entry *rebindings,
               indirect_symbol_bindings[i] != cur->rebindings[j].replacement) {
             *(cur->rebindings[j].replaced) = indirect_symbol_bindings[i];
           }
-          indirect_symbol_bindings[i] = cur->rebindings[j].replacement;
+          if (i < ( sizeof(indirect_symbol_bindings) / sizeof(indirect_symbol_bindings[0]))) {
+            if (cur != NULL) {
+              indirect_symbol_bindings[i] = cur->rebindings[j].replacement;
+            }
+          }
           goto symbol_loop;
         }
       }

--- a/Libraries/fishhook/fishhook.c
+++ b/Libraries/fishhook/fishhook.c
@@ -104,9 +104,7 @@ static void perform_rebinding_with_section(struct rebindings_entry *rebindings,
             *(cur->rebindings[j].replaced) = indirect_symbol_bindings[i];
           }
           if (i < ( sizeof(indirect_symbol_bindings) / sizeof(indirect_symbol_bindings[0]))) {
-            if (cur != NULL) {
               indirect_symbol_bindings[i] = cur->rebindings[j].replacement;
-            }
           }
           goto symbol_loop;
         }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Fixes a crash that would occur on devices running iOS 13. `fishhook.c` would access bad memory, this adds safety checks to the offending line. This fixes #25182 
## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[iOS] [Fixed] - Add safety checks to `fishhook.c` to prevent bad memory access

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
Build and run test suite