### PR TITLE
[CI] Disable test_ios_e2e and test_js_e2e tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -657,20 +657,20 @@ workflows:
       - test_js:
           requires:
             - setup_js
-      - test_js_e2e:
-          requires:
-            - setup_js
-            - test_js
+      # - test_js_e2e:
+      #     requires:
+      #       - setup_js
+      #       - test_js
       - test_android:
           requires:
             - setup_android
       - test_ios:
           requires:
             - setup_ios
-      - test_ios_e2e:
-          requires:
-            - setup_ios
-            - test_js
+      # - test_ios_e2e:
+      #     requires:
+      #       - setup_ios
+      #       - test_js
       - test_js:
           name: test_js_lts
           executor: nodelts


### PR DESCRIPTION
Disables the `test_ios_e2e` and `test_js_e2e` tests temporarily until the regression introduced in https://github.com/facebook/react-native/pull/25190 is fixed. A fix has been identified and proposed at https://github.com/facebook/jest/pull/8558.

We can re-enable these once a release of Jest with a patched jest-haste-map is available.