### PR TITLE
TM: Backward compatibility of calling invalidate on module's method queue

### DIFF
--- a/ReactCommon/turbomodule/core/platform/ios/RCTTurboModuleManager.mm
+++ b/ReactCommon/turbomodule/core/platform/ios/RCTTurboModuleManager.mm
@@ -378,11 +378,27 @@ static Class getFallbackClassFromName(const char *name)
   }
 
   // Backward-compatibility: RCTInvalidating handling.
+  dispatch_group_t moduleInvalidationGroup = dispatch_group_create();
   for (const auto &p : _rctTurboModuleCache) {
     id<RCTTurboModule> module = p.second;
     if ([module respondsToSelector:@selector(invalidate)]) {
+      if ([module respondsToSelector:@selector(methodQueue)]) {
+        dispatch_queue_t methodQueue = [module performSelector:@selector(methodQueue)];
+        if (methodQueue) {
+          dispatch_group_enter(moduleInvalidationGroup);
+          [bridge dispatchBlock:^{
+            [((id<RCTInvalidating>)module) invalidate];
+            dispatch_group_leave(moduleInvalidationGroup);
+          } queue:methodQueue];
+          continue;
+        }
+      }
       [((id<RCTInvalidating>)module) invalidate];
     }
+  }
+  
+  if (dispatch_group_wait(moduleInvalidationGroup, dispatch_time(DISPATCH_TIME_NOW, 10 * NSEC_PER_SEC))) {
+    RCTLogError(@"Timed out waiting for modules to be invalidated");
   }
 
   _rctTurboModuleCache.clear();


### PR DESCRIPTION
## Summary

Backward compatibility for `invalidate` method, because for the old module system, we ensure call all methods of modules on `methodQueue`, we also need to keep this rule to avoid some race condition in module.

## Changelog

[iOS] [Fixed] - Backward compatibility of calling invalidate on module's method queue

## Test Plan

Ensure `invalidate` method of `module` be called on `methodQueue`.
