### PR TITLE
allow custom attributedTextWithBaseTextAttributes in RCTBaseTextShadowView subclasses

### DIFF
--- a/Libraries/Text/BaseText/RCTBaseTextShadowView.h
+++ b/Libraries/Text/BaseText/RCTBaseTextShadowView.h
@@ -13,7 +13,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 extern NSString *const RCTBaseTextShadowViewEmbeddedShadowViewAttributeName;
 
-@interface RCTBaseTextShadowView : RCTShadowView
+@interface RCTBaseTextShadowView : RCTShadowView {
+  @protected NSAttributedString *_Nullable cachedAttributedText;
+  @protected RCTTextAttributes *_Nullable cachedTextAttributes;
+}
 
 @property (nonatomic, strong) RCTTextAttributes *textAttributes;
 

--- a/Libraries/Text/BaseText/RCTBaseTextShadowView.m
+++ b/Libraries/Text/BaseText/RCTBaseTextShadowView.m
@@ -29,10 +29,6 @@ static void RCTInlineViewYogaNodeDirtied(YGNodeRef node)
 }
 
 @implementation RCTBaseTextShadowView
-{
-  NSAttributedString *_Nullable _cachedAttributedText;
-  RCTTextAttributes *_Nullable _cachedTextAttributes;
-}
 
 - (instancetype)init
 {
@@ -86,8 +82,8 @@ static void RCTInlineViewYogaNodeDirtied(YGNodeRef node)
     textAttributes = [self.textAttributes copy];
   }
 
-  if (_cachedAttributedText && [_cachedTextAttributes isEqual:textAttributes]) {
-    return _cachedAttributedText;
+  if (cachedAttributedText && [cachedTextAttributes isEqual:textAttributes]) {
+    return cachedAttributedText;
   }
 
   NSMutableAttributedString *attributedText = [NSMutableAttributedString new];
@@ -133,17 +129,17 @@ static void RCTInlineViewYogaNodeDirtied(YGNodeRef node)
 
   [self clearLayout];
 
-  _cachedAttributedText = [attributedText copy];
-  _cachedTextAttributes = textAttributes;
+  cachedAttributedText = [attributedText copy];
+  cachedTextAttributes = textAttributes;
 
-  return _cachedAttributedText;
+  return cachedAttributedText;
 }
 
 - (void)dirtyLayout
 {
   [super dirtyLayout];
-  _cachedAttributedText = nil;
-  _cachedTextAttributes = nil;
+  cachedAttributedText = nil;
+  cachedTextAttributes = nil;
 }
 
 - (void)didUpdateReactSubviews


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

This is similar to https://github.com/facebook/react-native/pull/24995 but for iOS. 
Motivation: when building a custom Text or TextInput (eg with rich text support), one needs custom text processing logic (turning the JS text value to a `NSAttributedString`). 

RCTBaseTextShadowView contains `- (NSAttributedString *)attributedTextWithBaseTextAttributes:(nullable RCTTextAttributes *)baseTextAttributes;`

https://github.com/facebook/react-native/blob/853c667eb5a66612c33e0786ab6c458dcaee6133/Libraries/Text/BaseText/RCTBaseTextShadowView.m#L78

This method, given `self.reactSubviews` creates and returns an instance of [NSMutableAttributedString](https://developer.apple.com/documentation/foundation/nsmutableattributedstring?language=objc). It's currently possible to override this method in subclasses, but the original implementation reads and writes two cache fields which are private. This PR just changes the access modifiers so that subclasses of `RCTBaseTextShadowView` can also access the caching fields.

## Changelog

Not needed I guess.

## Test Plan

This will work just the same - works locally, CI should pass.
