### PR TITLE
Fix some languages wrapped texts are cut off on android

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextShadowNode.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextShadowNode.java
@@ -115,6 +115,9 @@ public class ReactTextShadowNode extends ReactBaseTextShadowNode {
               if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                 builder.setJustificationMode(mJustificationMode);
               }
+              if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                  builder.setUseLineSpacingFromFallbacks(true);
+              }
               layout = builder.build();
             }
 
@@ -139,14 +142,18 @@ public class ReactTextShadowNode extends ReactBaseTextShadowNode {
                   new StaticLayout(
                       text, textPaint, (int) width, alignment, 1.f, 0.f, mIncludeFontPadding);
             } else {
-              layout =
+              StaticLayout.Builder builder =
                   StaticLayout.Builder.obtain(text, 0, text.length(), textPaint, (int) width)
                       .setAlignment(alignment)
                       .setLineSpacing(0.f, 1.f)
                       .setIncludePad(mIncludeFontPadding)
                       .setBreakStrategy(mTextBreakStrategy)
-                      .setHyphenationFrequency(Layout.HYPHENATION_FREQUENCY_NORMAL)
-                      .build();
+                      .setHyphenationFrequency(Layout.HYPHENATION_FREQUENCY_NORMAL);
+
+              if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                  builder.setUseLineSpacingFromFallbacks(true);
+              }
+              layout = builder.build();
             }
           }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Fix wrapped some languages (like Japanese, Chinese) texts are cut off on android. This p-r is based on @linjson [patch](https://github.com/facebook/react-native/issues/25275#issuecomment-502548807).

- related (maybe)
    - https://github.com/facebook/react-native/issues/25297
    - https://github.com/facebook/react-native/issues/25275
    - https://github.com/facebook/react-native/issues/24837
    - https://github.com/facebook/react-native/issues/25155

`setUseLineSpacingFromFallbacks` is recommended to set true on [document](https://developer.android.com/reference/android/text/StaticLayout.Builder#setUseLineSpacingFromFallbacks(boolean))

>For backward compatibility reasons, the default is false, but setting this to true is strongly recommended. It is required to be true if text could be in languages like Burmese or Tibetan where text is typically much taller or deeper than Latin text.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[Android] [Fixed] - Fix some languages wrapped texts are cut off.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->