### PR TITLE
Prevent scrollView to scroll with dpad when scrollEnabled property is set to false.

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.java
@@ -18,6 +18,7 @@ import android.hardware.SensorManager;
 import androidx.core.view.ViewCompat;
 import androidx.core.text.TextUtilsCompat;
 import android.util.Log;
+import android.view.KeyEvent;
 import android.view.FocusFinder;
 import android.view.MotionEvent;
 import android.view.View;
@@ -409,6 +410,16 @@ public class ReactHorizontalScrollView extends HorizontalScrollView implements
     }
 
     return super.onTouchEvent(ev);
+  }
+
+  @Override
+  public boolean executeKeyEvent(KeyEvent event) {
+    int eventKeyCode = event.getKeyCode();
+    if (!mScrollEnabled && (eventKeyCode == KeyEvent.KEYCODE_DPAD_LEFT ||
+      eventKeyCode == KeyEvent.KEYCODE_DPAD_RIGHT)) {
+      return false;
+    }
+    return super.executeKeyEvent(event);
   }
 
   @Override

--- a/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
@@ -14,6 +14,7 @@ import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.Drawable;
 import androidx.core.view.ViewCompat;
 import android.util.Log;
+import android.view.KeyEvent;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
@@ -298,6 +299,16 @@ public class ReactScrollView extends ScrollView implements ReactClippingViewGrou
     }
 
     return super.onTouchEvent(ev);
+  }
+
+  @Override
+  public boolean executeKeyEvent(KeyEvent event) {
+    int eventKeyCode = event.getKeyCode();
+    if (!mScrollEnabled && (eventKeyCode == KeyEvent.KEYCODE_DPAD_UP ||
+      eventKeyCode == KeyEvent.KEYCODE_DPAD_DOWN)) {
+      return false;
+    }
+    return super.executeKeyEvent(event);
   }
 
   @Override


### PR DESCRIPTION
## Summary

ScrollView doesn't handle the scrollEnabled property using dpad. When set to false, the directionnal pad still allows to scroll in the view.

## Changelog

[ANDROID] [ADDED] - Prevent scrollView to scroll with dpad when scrollEnabled property is set to false.

## Test Plan

No test added