### PR TITLE
[iOS] [Added] – Bring back autolinking to the iOS template

### DIFF
--- a/template/ios/Podfile
+++ b/template/ios/Podfile
@@ -1,4 +1,5 @@
 platform :ios, '9.0'
+require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'
 
 target 'HelloWorld' do
   # Pods for HelloWorld
@@ -31,6 +32,7 @@ target 'HelloWorld' do
     # Pods for testing
   end
 
+  use_native_modules!
 end
 
 target 'HelloWorld-tvOS' do


### PR DESCRIPTION
## Summary

Bringing back iOS autolinking to the template after reverting: https://github.com/facebook/react-native/commit/261197d85705dad1a362cc4637aa308c0382dcbe#commitcomment-33479829

## Changelog

[iOS] [Added] – Bring back autolinking to the iOS template

## Test Plan

`test_ios_e2e` should still pass