### PR TITLE
[iOS] Remove debug version of RCT_JSON_ARRAY_CONVERTER_NAMED

### DIFF
--- a/React/Base/RCTConvert.m
+++ b/React/Base/RCTConvert.m
@@ -588,11 +588,7 @@ RCT_ARRAY_CONVERTER(UIColor)
  * This macro is used for creating converter functions for directly
  * representable json array values that require no conversion.
  */
-#if RCT_DEBUG
-#define RCT_JSON_ARRAY_CONVERTER_NAMED(type, name) RCT_ARRAY_CONVERTER_NAMED(type, name)
-#else
 #define RCT_JSON_ARRAY_CONVERTER_NAMED(type, name) + (NSArray *)name##Array:(id)json { return json; }
-#endif
 #define RCT_JSON_ARRAY_CONVERTER(type) RCT_JSON_ARRAY_CONVERTER_NAMED(type, type)
 
 RCT_JSON_ARRAY_CONVERTER(NSArray)


### PR DESCRIPTION
## Summary
This is attempt to fix issue described in https://github.com/facebook/react-native/issues/25339
In short, value conversion of `NSArray<String>` should work the same way in Release and Debug configurations.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[iOS] [Fixed] - Array of numbers (`NSNumber`) is automatically (mistakenly) converted to `NSString` but only in Debug.

## Test Plan

`AsyncAtorage.setItem('key', 123)` behaviour:
Release: crash
Debug: red screen with exception that reads:
```
Exception '-[__NSCFNumber length]: unrecognized selector sent to instance 0xa8e477b3c1a00abf' was thrown while invoking multiSet on target AsyncLocalStorage with params (
        (
                (
            "key",
            123
        )
    ),
    96099
)

```