### PR TITLE
Set rounded rectangle mask on TouchableNativeFeedback's ripples

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactDrawableHelper.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactDrawableHelper.java
@@ -9,8 +9,6 @@ package com.facebook.react.views.view;
 import android.annotation.TargetApi;
 import android.content.Context;
 import android.content.res.ColorStateList;
-import android.graphics.Color;
-import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.RippleDrawable;
 import android.os.Build;
@@ -30,7 +28,9 @@ public class ReactDrawableHelper {
 
   @TargetApi(Build.VERSION_CODES.LOLLIPOP)
   public static Drawable createDrawableFromJSDescription(
-      Context context, ReadableMap drawableDescriptionDict) {
+      ReactViewGroup view,
+      ReadableMap drawableDescriptionDict) {
+    Context context = view.getContext();
     String type = drawableDescriptionDict.getString("type");
     if ("ThemeAttrAndroid".equals(type)) {
       String attr = drawableDescriptionDict.getString("attribute");
@@ -75,7 +75,7 @@ public class ReactDrawableHelper {
       if (!drawableDescriptionDict.hasKey("borderless")
           || drawableDescriptionDict.isNull("borderless")
           || !drawableDescriptionDict.getBoolean("borderless")) {
-        mask = new ColorDrawable(Color.WHITE);
+        mask = view.getBorderRadiusMask();
       }
       ColorStateList colorStateList =
           new ColorStateList(new int[][] {new int[] {}}, new int[] {color});

--- a/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
@@ -18,6 +18,8 @@ import android.graphics.Rect;
 import android.graphics.RectF;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.LayerDrawable;
+import android.graphics.drawable.ShapeDrawable;
+import android.graphics.drawable.shapes.RoundRectShape;
 import android.os.Build;
 import android.view.MotionEvent;
 import android.view.View;
@@ -282,8 +284,44 @@ public class ReactViewGroup extends ViewGroup
     }
   }
 
+  public float[] getBorderRadius() {
+    final float borderRadius = mReactBackgroundDrawable.getFullBorderRadius();
+    float topLeftBorderRadius =
+            mReactBackgroundDrawable.getBorderRadiusOrDefaultTo(
+                    borderRadius, ReactViewBackgroundDrawable.BorderRadiusLocation.TOP_LEFT);
+    float topRightBorderRadius =
+            mReactBackgroundDrawable.getBorderRadiusOrDefaultTo(
+                    borderRadius, ReactViewBackgroundDrawable.BorderRadiusLocation.TOP_RIGHT);
+    float bottomLeftBorderRadius =
+            mReactBackgroundDrawable.getBorderRadiusOrDefaultTo(
+                    borderRadius, ReactViewBackgroundDrawable.BorderRadiusLocation.BOTTOM_LEFT);
+    float bottomRightBorderRadius =
+            mReactBackgroundDrawable.getBorderRadiusOrDefaultTo(
+                    borderRadius, ReactViewBackgroundDrawable.BorderRadiusLocation.BOTTOM_RIGHT);
+
+    return new float[] {
+            topLeftBorderRadius,
+            topLeftBorderRadius,
+            topRightBorderRadius,
+            topRightBorderRadius,
+            bottomRightBorderRadius,
+            bottomRightBorderRadius,
+            bottomLeftBorderRadius,
+            bottomLeftBorderRadius
+    };
+  }
+
   public void setBorderStyle(@Nullable String style) {
     getOrCreateReactViewBackground().setBorderStyle(style);
+  }
+
+  public Drawable getBorderRadiusMask() {
+    RoundRectShape r = new RoundRectShape(getBorderRadius(), null, null);
+
+    ShapeDrawable shapeDrawable = new ShapeDrawable(r);
+    shapeDrawable.getPaint().setColor(Color.WHITE);
+
+    return shapeDrawable;
   }
 
   @Override

--- a/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.java
@@ -52,6 +52,9 @@ public class ReactViewManager extends ViewGroupManager<ReactViewGroup> {
   private static final int CMD_SET_PRESSED = 2;
   private static final String HOTSPOT_UPDATE_KEY = "hotspotUpdate";
 
+  private ReadableMap mBg = null;
+  private ReadableMap mFg = null;
+
   @ReactProp(name = "accessible")
   public void setAccessible(ReactViewGroup view, boolean accessible) {
     view.setFocusable(accessible);
@@ -118,6 +121,14 @@ public class ReactViewManager extends ViewGroupManager<ReactViewGroup> {
     } else {
       view.setBorderRadius(borderRadius, index - 1);
     }
+
+    if (mBg != null) {
+      setNativeBackground(view, mBg);
+    }
+
+    if (mFg != null) {
+      setNativeForeground(view, mFg);
+    }
   }
 
   @ReactProp(name = "borderStyle")
@@ -158,19 +169,21 @@ public class ReactViewManager extends ViewGroupManager<ReactViewGroup> {
 
   @ReactProp(name = "nativeBackgroundAndroid")
   public void setNativeBackground(ReactViewGroup view, @Nullable ReadableMap bg) {
+    mBg = bg;
     view.setTranslucentBackgroundDrawable(
         bg == null
             ? null
-            : ReactDrawableHelper.createDrawableFromJSDescription(view.getContext(), bg));
+            : ReactDrawableHelper.createDrawableFromJSDescription(view, bg));
   }
 
   @TargetApi(Build.VERSION_CODES.M)
   @ReactProp(name = "nativeForegroundAndroid")
   public void setNativeForeground(ReactViewGroup view, @Nullable ReadableMap fg) {
+    mFg = fg;
     view.setForeground(
         fg == null
             ? null
-            : ReactDrawableHelper.createDrawableFromJSDescription(view.getContext(), fg));
+            : ReactDrawableHelper.createDrawableFromJSDescription(view, fg));
   }
 
   @ReactProp(


### PR DESCRIPTION
## Summary

This commit fixes an issue where ripple touch feedback extends beyond the border radius of a view.

### Before

<img src="https://user-images.githubusercontent.com/590904/59892832-9cb19180-938f-11e9-8239-b2d5f0e1ce56.png" width="300" />


### After

<img src="https://user-images.githubusercontent.com/590904/59925227-766e0f00-93ec-11e9-9efe-c41e696f8c3c.gif" width="300" />

### The fix

It achieves this by adding a mask to the RippleDrawable background, collecting that information from two new methods on ReactViewGroup:

1. getBorderRadiusMask() returns a drawable rounded rectangle matching the view's border radius properties
2. getBorderRadius() produces a float[] with the border radius information required to build a RoundedRectShape in getBorderRadiusMask()

Additionally, this commit updates setBorderRadius in ReactViewManager to re-apply the background whenever it is set, which is necessary to update the mask on the RippleDrawable background image as the border radius changes.

Related issues:
https://github.com/facebook/react-native/issues/6480

## Changelog

[Android][fixed] - Adding border radius styles to TouchableNative react-native run-android --port <x> correctly connects to dev server and related error messages display the correct port

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

## Test Plan

Link this branch to a new React native project with the following App.js class:

``` 
import React, { Component } from "react";
import { StyleSheet, Text, View, TouchableNativeFeedback } from "react-native";

export default class App extends Component {
  render() {
    const ripple = TouchableNativeFeedback.Ripple("#ff0000");

    return (
      <View style={styles.container}>
        <TouchableNativeFeedback background={ripple}>
          <View
            style={{
              width: 96,
              borderRadius: 12,
              borderTopLeftRadius: 10,
              borderBottomRightRadius: 37,
              height: 96,
              alignItems: "center",
              justifyContent: "center",
              borderColor: "black",
              borderWidth: 2
            }}
          >
            <Text>{"CLICK CLICK"}</Text>
          </View>
        </TouchableNativeFeedback>
      </View>
    );
  }
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    justifyContent: "center",
    alignItems: "center",
    backgroundColor: "#F5FCFF"
  }
});
```

It's important to ensure that updates to border radius are accounted for. I did this by enabling hot module reloading and updating the border radius styles to verify that the ripple remains correct.