### PR TITLE
Fix regression of improper assets copy (revert #24518 #24778)

### DIFF
--- a/react.gradle
+++ b/react.gradle
@@ -64,33 +64,6 @@ afterEvaluate {
                 resourcesDir.mkdirs()
             }
 
-
-            // If there are flavors, remember the current flavor for use in the resource path we move from
-            def flavorPathSegment = ""
-            android.productFlavors.all { flavor ->
-                if (targetName.toLowerCase().contains(flavor.name)) {
-                    flavorPathSegment = flavor.name + "/"
-                }
-            }
-
-            // Address issue #22234 by moving generated resources into build dir so they are in one spot, not duplicated
-            doLast {
-                def moveFunc = { resSuffix ->
-                    File originalDir = file("$buildDir/generated/res/react/${flavorPathSegment}release/${resSuffix}")
-                    if (originalDir.exists()) {
-                        File destDir = file("$buildDir/../src/main/res/${resSuffix}")
-                        ant.move(file: originalDir, tofile: destDir);
-                    }
-                }
-                moveFunc.curry("drawable-ldpi").call()
-                moveFunc.curry("drawable-mdpi").call()
-                moveFunc.curry("drawable-hdpi").call()
-                moveFunc.curry("drawable-xhdpi").call()
-                moveFunc.curry("drawable-xxhdpi").call()
-                moveFunc.curry("drawable-xxxhdpi").call()
-                moveFunc.curry("raw").call()
-            }
-
             // Set up inputs and outputs so gradle can cache the result
             inputs.files fileTree(dir: reactRoot, excludes: inputExcludes)
             outputs.dir(jsBundleDir)


### PR DESCRIPTION
## Summary

Pull requests #24518 #24778 make Gradle copy all **generated** assets and resources into `android/app/src/res`, which is a bad behavior, because `src/res` goes into version control and should hold only those **original** resource files.

These changes in #24518 #24778 were merged into 0.60.0-rc release and cause regression.

This pull request will:

- Revert pull requests #24518 #24778
- Close #25325 

## Changelog

[Android] [Fixed] - Fix regression of improper assets copy (revert #24518 #24778)

## Test Plan

It is a revert pull request and the reverted script should work the same as it has in 0.59.x.