### PR TITLE
add warnings for DatePickerIOS and DatePickerAndroid

### DIFF
--- a/Libraries/react-native/react-native-implementation.js
+++ b/Libraries/react-native/react-native-implementation.js
@@ -44,6 +44,12 @@ module.exports = {
     return require('../Components/CheckBox/CheckBox');
   },
   get DatePickerIOS() {
+    warnOnce(
+      'DatePickerIOS-merged',
+      'DatePickerIOS has been merged with DatePickerAndroid and will be removed in a future release. ' +
+        "It can now be installed and imported from '@react-native-community/datetimepicker' instead of 'react-native'. " +
+        'See https://github.com/react-native-community/react-native-datetimepicker',
+    );
     return require('../Components/DatePicker/DatePickerIOS');
   },
   get DrawerLayoutAndroid() {
@@ -181,6 +187,12 @@ module.exports = {
     return require('../Components/Clipboard/Clipboard');
   },
   get DatePickerAndroid() {
+    warnOnce(
+      'DatePickerAndroid-merged',
+      'DatePickerAndroid has been merged with DatePickerIOS and will be removed in a future release. ' +
+        "It can now be installed and imported from '@react-native-community/datetimepicker' instead of 'react-native'. " +
+        'See https://github.com/react-native-community/react-native-datetimepicker',
+    );
     return require('../Components/DatePickerAndroid/DatePickerAndroid');
   },
   get DeviceInfo() {

--- a/Libraries/react-native/react-native-implementation.js
+++ b/Libraries/react-native/react-native-implementation.js
@@ -46,7 +46,7 @@ module.exports = {
   get DatePickerIOS() {
     warnOnce(
       'DatePickerIOS-merged',
-      'DatePickerIOS has been merged with DatePickerAndroid and will be removed in a future release. ' +
+      'DatePickerIOS has been merged with DatePickerAndroid and TimePickerAndroid and will be removed in a future release. ' +
         "It can now be installed and imported from '@react-native-community/datetimepicker' instead of 'react-native'. " +
         'See https://github.com/react-native-community/react-native-datetimepicker',
     );
@@ -189,7 +189,7 @@ module.exports = {
   get DatePickerAndroid() {
     warnOnce(
       'DatePickerAndroid-merged',
-      'DatePickerAndroid has been merged with DatePickerIOS and will be removed in a future release. ' +
+      'DatePickerAndroid has been merged with DatePickerIOS and TimePickerAndroid and will be removed in a future release. ' +
         "It can now be installed and imported from '@react-native-community/datetimepicker' instead of 'react-native'. " +
         'See https://github.com/react-native-community/react-native-datetimepicker',
     );
@@ -276,6 +276,12 @@ module.exports = {
     return require('../Performance/Systrace');
   },
   get TimePickerAndroid() {
+    warnOnce(
+      'TimePickerAndroid-merged',
+      'TimePickerAndroid has been merged with DatePickerIOS and DatePickerAndroid and will be removed in a future release. ' +
+        "It can now be installed and imported from '@react-native-community/datetimepicker' instead of 'react-native'. " +
+        'See https://github.com/react-native-community/react-native-datetimepicker',
+    );
     return require('../Components/TimePickerAndroid/TimePickerAndroid');
   },
   get ToastAndroid() {

--- a/Libraries/react-native/react-native-implementation.js
+++ b/Libraries/react-native/react-native-implementation.js
@@ -276,12 +276,6 @@ module.exports = {
     return require('../Performance/Systrace');
   },
   get TimePickerAndroid() {
-    warnOnce(
-      'TimePickerAndroid-merged',
-      'TimePickerAndroid has been merged with DatePickerIOS and DatePickerAndroid and will be removed in a future release. ' +
-        "It can now be installed and imported from '@react-native-community/datetimepicker' instead of 'react-native'. " +
-        'See https://github.com/react-native-community/react-native-datetimepicker',
-    );
     return require('../Components/TimePickerAndroid/TimePickerAndroid');
   },
   get ToastAndroid() {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

`DatePickerIOS` and `DatePickerAndroid` have been merged as part of Lean Core. See [repo](https://github.com/react-native-community/react-native-datetimepicker)

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[General] [Deprecate] -  Warning for `DatePickerIOS` and `DatePickerAndroid`

## Test Plan

Warning prints when user imports `DatePickerIOS` or `DatePickerAndroid`

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
