### PR TITLE
Remove log: Initializing <RCTCxxBridge: 0x7fded270fbf0>

### DIFF
--- a/React/CxxBridge/RCTCxxBridge.mm
+++ b/React/CxxBridge/RCTCxxBridge.mm
@@ -231,8 +231,6 @@ struct RCTInstanceCallback : public InstanceCallback {
 
     registerPerformanceLoggerHooks(_performanceLogger);
 
-    RCTLogInfo(@"Initializing %@ (parent: %@, executor: %@)", self, bridge, [self executorClass]);
-
     /**
      * Set Initial State
      */


### PR DESCRIPTION
## Summary

When starting a React Native app, one gets to see the message in the image.
I propose to remove it, because it provides little information to the developer and is noisy.

![image](https://user-images.githubusercontent.com/1629785/60040707-dc42eb00-96b9-11e9-8dad-e771ff8cca5c.png)

```
Initializing <RCTCxxBridge: 0x7fded270fbf0> (parent: <RCTBridge: 0x600001b95570>, executor: (null))
```

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[iOS] [Fixed] - Debug message was logging to the console

## Test Plan
-
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
