### PR TITLE
[iOS] Remove asl_log (Fixes #25380)

### DIFF
--- a/React/Base/RCTLog.mm
+++ b/React/Base/RCTLog.mm
@@ -7,7 +7,6 @@
 
 #import "RCTLog.h"
 
-#include <asl.h>
 #include <cxxabi.h>
 
 #import "RCTAssert.h"

--- a/React/Base/RCTLog.mm
+++ b/React/Base/RCTLog.mm
@@ -56,26 +56,6 @@ RCTLogFunction RCTDefaultLogFunction = ^(
   NSString *log = RCTFormatLog([NSDate date], level, fileName, lineNumber, message);
   fprintf(stderr, "%s\n", log.UTF8String);
   fflush(stderr);
-
-  int aslLevel;
-  switch(level) {
-    case RCTLogLevelTrace:
-      aslLevel = ASL_LEVEL_DEBUG;
-      break;
-    case RCTLogLevelInfo:
-      aslLevel = ASL_LEVEL_NOTICE;
-      break;
-    case RCTLogLevelWarning:
-      aslLevel = ASL_LEVEL_WARNING;
-      break;
-    case RCTLogLevelError:
-      aslLevel = ASL_LEVEL_ERR;
-      break;
-    case RCTLogLevelFatal:
-      aslLevel = ASL_LEVEL_CRIT;
-      break;
-  }
-  asl_log(NULL, NULL, aslLevel, "%s", message.UTF8String);
 };
 
 void RCTSetLogFunction(RCTLogFunction logFunction)


### PR DESCRIPTION
## Summary

By default absolutely everything gets logged twice (#25380).
This was introduced over 4 years ago here:

[React Native Log to ASL · facebook/react-native@d1b14ef · GitHub](https://github.com/facebook/react-native/commit/d1b14ef0627dc04847500faa7fef75fd3c22c900)

with the reason to support ASL.
With this PR the support for that will be removed but I believe this is justified because:

- the benefit of not having every log message twice far outweighs the benefit of having Apple System Log.
- ASL was superseded by "unified logging" (yellow box on https://developer.apple.com/documentation/os/logging).
- I assume that people who use asl_log is very small. There is also very little information about it on the internet

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[iOS] [Fixed] - Logs would get printed twice
