### PR TITLE
[iOS] Make logs shorter

### DIFF
--- a/React/Base/RCTLog.h
+++ b/React/Base/RCTLog.h
@@ -71,8 +71,6 @@ typedef void (^RCTLogFunction)(
  * particular data from the log, just pass nil or zero for the argument.
  */
 RCT_EXTERN NSString *RCTFormatLog(
-  NSDate *timestamp,
-  RCTLogLevel level,
   NSString *fileName,
   NSNumber *lineNumber,
   NSString *message

--- a/React/Base/RCTLog.mm
+++ b/React/Base/RCTLog.mm
@@ -53,7 +53,7 @@ RCTLogFunction RCTDefaultLogFunction = ^(
   NSString *message
 )
 {
-  NSString *log = RCTFormatLog([NSDate date], level, fileName, lineNumber, message);
+  NSString *log = RCTFormatLog(fileName, lineNumber, message);
   fprintf(stderr, "%s\n", log.UTF8String);
   fflush(stderr);
 
@@ -145,28 +145,16 @@ void RCTPerformBlockWithLogPrefix(void (^block)(void), NSString *prefix)
 }
 
 NSString *RCTFormatLog(
-  NSDate *timestamp,
-  RCTLogLevel level,
   NSString *fileName,
   NSNumber *lineNumber,
   NSString *message
 )
 {
   NSMutableString *log = [NSMutableString new];
-  if (timestamp) {
-    static NSDateFormatter *formatter;
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-      formatter = [NSDateFormatter new];
-      formatter.dateFormat = formatter.dateFormat = @"yyyy-MM-dd HH:mm:ss.SSS ";
-    });
-    [log appendString:[formatter stringFromDate:timestamp]];
-  }
-  if (level) {
-    [log appendFormat:@"[%s]", RCTLogLevels[level]];
-  }
 
-  [log appendFormat:@"[tid:%@]", RCTCurrentThreadName()];
+  if ([RCTCurrentThreadName() isEqualToString:@"com.facebook.react.JavaScript"]) {
+    [log appendFormat:@"[JS]"];
+  }
 
   if (fileName) {
     fileName = fileName.lastPathComponent;


### PR DESCRIPTION
## Summary

Currently all logs include current time, including timezone and nanoseconds, as well as the thread ID and the log level.

While it is detailed, I find that it is also very noisy. I rarely need those things.

- Most of the time timing is irrelevant, so I removed it completely. Developers can also add the current time to the logs themselves easily. I would at least remove nanaoseconds and timezone.

- Thread ID is often irrelevant (Prior to this PR I did not even know what `[tid:123]` meant). The only interesting case is when the Thread ID is com.facebook.react.JavaScript. Then I add [JS] in front of it.

- Log level I have also removed because as a developer I have very little control over it.



## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[iOS] [Changed] - Log format

## Test Plan

Tested it manually.