### PR TITLE
default methods in LifecycleEventListener interface

### DIFF
--- a/.buckconfig
+++ b/.buckconfig
@@ -5,6 +5,10 @@
 [download]
   max_number_of_retries = 3
 
+[java]
+  source_level = 8
+  target_level = 8
+
 [maven_repositories]
   central = https://repo1.maven.org/maven2
   google = https://dl.google.com/dl/android/maven2/

--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/LifecycleEventListener.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/LifecycleEventListener.java
@@ -31,17 +31,17 @@ public interface LifecycleEventListener {
    * if the native module that implements this is initialized while the host activity is already
    * resumed. Always called for the most current activity.
    */
-  void onHostResume();
+  default void onHostResume() {}
 
   /**
    * Called when host activity receives pause event (e.g. {@link Activity#onPause}. Always called
    * for the most current activity.
    */
-  void onHostPause();
+  default void onHostPause() {}
 
   /**
    * Called when host activity receives destroy event (e.g. {@link Activity#onDestroy}. Only called
    * for the last React activity to be destroyed.
    */
-  void onHostDestroy();
+  default  void onHostDestroy() {}
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
@@ -477,9 +477,6 @@ public class FabricUIManager implements UIManager, LifecycleEventListener {
   }
 
   @Override
-  public void onHostDestroy() {}
-
-  @Override
   public void dispatchCommand(
       final int reactTag, final int commandId, @Nullable final ReadableArray commandArgs) {
     synchronized (mMountItemsLock) {

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/accessibilityinfo/AccessibilityInfoModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/accessibilityinfo/AccessibilityInfoModule.java
@@ -168,10 +168,6 @@ public class AccessibilityInfoModule extends ReactContextBaseJavaModule
         getReactApplicationContext().removeLifecycleEventListener(this);
     }
 
-    @Override
-    public void onHostDestroy() {
-    }
-
     @ReactMethod
     public void announceForAccessibility(String message) {
         if (mAccessibilityManager == null || !mAccessibilityManager.isEnabled()) {

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/appstate/AppStateModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/appstate/AppStateModule.java
@@ -73,12 +73,6 @@ public class AppStateModule extends ReactContextBaseJavaModule
   }
 
   @Override
-  public void onHostDestroy() {
-    // do not set state to destroyed, do not send an event. By the current implementation, the
-    // catalyst instance is going to be immediately dropped, and all JS calls with it.
-  }
-
-  @Override
   public void onWindowFocusChange(boolean hasFocus) {
     getReactApplicationContext().getJSModule(RCTDeviceEventEmitter.class)
       .emit("appStateFocusChange", hasFocus);

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/deviceinfo/DeviceInfoModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/deviceinfo/DeviceInfoModule.java
@@ -73,14 +73,6 @@ public class DeviceInfoModule extends BaseJavaModule implements
     }
   }
 
-  @Override
-  public void onHostPause() {
-  }
-
-  @Override
-  public void onHostDestroy() {
-  }
-
   public void emitUpdateDimensionsEvent() {
     if (mReactApplicationContext == null) {
       return;

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/dialog/DialogModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/dialog/DialogModule.java
@@ -167,10 +167,6 @@ public class DialogModule extends ReactContextBaseJavaModule implements Lifecycl
   }
 
   @Override
-  public void onHostDestroy() {
-  }
-
-  @Override
   public void onHostResume() {
     mIsInForeground = true;
     // Check if a dialog has been created while the host was paused, so that we can show it now.

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/fresco/FrescoModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/fresco/FrescoModule.java
@@ -165,14 +165,6 @@ public class FrescoModule extends ReactContextBaseJavaModule implements
   }
 
   @Override
-  public void onHostResume() {
-  }
-
-  @Override
-  public void onHostPause() {
-  }
-
-  @Override
   public void onHostDestroy() {
     // According to the javadoc for LifecycleEventListener#onHostDestroy, this is only called when
     // the 'last' ReactActivity is being destroyed, which effectively means the app is being

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/image/ImageLoaderModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/image/ImageLoaderModule.java
@@ -280,14 +280,6 @@ public class ImageLoaderModule extends ReactContextBaseJavaModule implements
   }
 
   @Override
-  public void onHostResume() {
-  }
-
-  @Override
-  public void onHostPause() {
-  }
-
-  @Override
   public void onHostDestroy() {
     // cancel all requests
     synchronized (mEnqueuedRequestMonitor) {

--- a/ReactAndroid/src/main/java/com/facebook/react/views/art/ARTSurfaceViewShadowNode.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/art/ARTSurfaceViewShadowNode.java
@@ -133,12 +133,6 @@ public class ARTSurfaceViewShadowNode extends LayoutShadowNode
   }
 
   @Override
-  public void onHostPause() {}
-
-  @Override
-  public void onHostDestroy() {}
-
-  @Override
   public void onSurfaceTextureAvailable(SurfaceTexture surface, int width, int height) {
     mSurface = new Surface(surface);
     drawOutput(false);

--- a/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.java
@@ -176,11 +176,6 @@ public class ReactModalHostView extends ViewGroup implements LifecycleEventListe
   }
 
   @Override
-  public void onHostPause() {
-    // do nothing
-  }
-
-  @Override
   public void onHostDestroy() {
     // Drop the instance if the host is destroyed which will dismiss the dialog
     onDropInstance();


### PR DESCRIPTION
## Summary

Java 8 added support for default methods in interfaces. This PR adds default methods for LifecycleEventListener interface and remove empty overrides.

## Changelog

[Android] [Changed] - default methods in LifecycleEventListener interface

## Test Plan

CI is green, and RNTester builds and runs as expected