### PR TITLE
Fabric: make getDebugProps of YogaStylableProps as virtual method

### DIFF
--- a/ReactCommon/fabric/components/view/yoga/YogaStylableProps.h
+++ b/ReactCommon/fabric/components/view/yoga/YogaStylableProps.h
@@ -19,7 +19,7 @@ class YogaStylableProps;
 
 typedef std::shared_ptr<const YogaStylableProps> SharedYogaStylableProps;
 
-class YogaStylableProps {
+class YogaStylableProps : public virtual DebugStringConvertible {
  public:
   YogaStylableProps() = default;
   YogaStylableProps(const YGStyle &yogaStyle);
@@ -38,7 +38,8 @@ class YogaStylableProps {
 #pragma mark - DebugStringConvertible (Partial)
 
  public:
-  virtual SharedDebugStringConvertibleList getDebugProps() const;
+  virtual ~YogaStylableProps() = default;
+  SharedDebugStringConvertibleList getDebugProps() const override;
 
 #endif
 };

--- a/ReactCommon/fabric/components/view/yoga/YogaStylableProps.h
+++ b/ReactCommon/fabric/components/view/yoga/YogaStylableProps.h
@@ -38,7 +38,7 @@ class YogaStylableProps {
 #pragma mark - DebugStringConvertible (Partial)
 
  public:
-  SharedDebugStringConvertibleList getDebugProps() const;
+  virtual SharedDebugStringConvertibleList getDebugProps() const;
 
 #endif
 };


### PR DESCRIPTION
## Summary

`YogaStylableProps`'s vtable not have `getDebugProps`, let's add it.

![image](https://user-images.githubusercontent.com/5061845/60082656-c50e0700-9766-11e9-8204-e0df53f190a3.png)

## Changelog

[General] [Fixed] - Fabric: make getDebugProps of YogaStylableProps as virtual method

## Test Plan

N/A.