### PR TITLE
Fix compatibility with CocoaPods frameworks

### DIFF
--- a/Libraries/ART/React-ART.podspec
+++ b/Libraries/ART/React-ART.podspec
@@ -28,7 +28,7 @@ Pod::Spec.new do |s|
   s.source                 = source
   s.source_files           = "**/*.{h,m}"
   s.preserve_paths         = "package.json", "LICENSE", "LICENSE-docs"
-  s.header_dir             = "React"
+  s.header_dir             = "ART"
 
   s.dependency "React-Core", version
 end

--- a/Libraries/ActionSheetIOS/React-RCTActionSheet.podspec
+++ b/Libraries/ActionSheetIOS/React-RCTActionSheet.podspec
@@ -29,7 +29,7 @@ Pod::Spec.new do |s|
   s.source                 = source
   s.source_files           = "*.{h,m}"
   s.preserve_paths          = "package.json", "LICENSE", "LICENSE-docs"
-  s.header_dir             = "React"
+  s.header_dir             = "RCTActionSheet"
 
   s.dependency "React-Core", version
 end

--- a/Libraries/Blob/RCTBlobManager.mm
+++ b/Libraries/Blob/RCTBlobManager.mm
@@ -10,10 +10,20 @@
 #import <mutex>
 
 #import <React/RCTConvert.h>
-#import <RCTNetwork/RCTNetworking.h>
 #import <React/RCTUtils.h>
-#import <RCTWebSocket/RCTWebSocketModule.h>
 #import "RCTBlobCollector.h"
+
+#if __has_include(<React/RCTNetworking.h>)
+#import <React/RCTNetworking.h>
+#else
+#import <RCTNetwork/RCTNetworking.h>
+#endif
+
+#if __has_include(<React/RCTWebSocketModule.h>)
+#import <React/RCTWebSocketModule.h>
+#else
+#import <RCTWebSocket/RCTWebSocketModule.h>
+#endif
 
 static NSString *const kBlobURIScheme = @"blob";
 

--- a/Libraries/Blob/RCTBlobManager.mm
+++ b/Libraries/Blob/RCTBlobManager.mm
@@ -10,9 +10,9 @@
 #import <mutex>
 
 #import <React/RCTConvert.h>
-#import <React/RCTNetworking.h>
+#import <RCTNetwork/RCTNetworking.h>
 #import <React/RCTUtils.h>
-#import <React/RCTWebSocketModule.h>
+#import <RCTWebSocket/RCTWebSocketModule.h>
 #import "RCTBlobCollector.h"
 
 static NSString *const kBlobURIScheme = @"blob";

--- a/Libraries/Blob/React-RCTBlob.podspec
+++ b/Libraries/Blob/React-RCTBlob.podspec
@@ -28,9 +28,10 @@ Pod::Spec.new do |s|
   s.source                 = source
   s.source_files           = "*.{h,m,mm}"
   s.preserve_paths         = "package.json", "LICENSE", "LICENSE-docs"
-  s.header_dir             = "React"
+  s.header_dir             = "RCTBlob"
 
   s.dependency "React-Core", version
+  s.dependency "React-jsi", version
   s.dependency "React-RCTNetwork", version
   s.dependency "React-RCTWebSocket", version
 end

--- a/Libraries/Image/RCTGIFImageDecoder.h
+++ b/Libraries/Image/RCTGIFImageDecoder.h
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#import <React/RCTImageLoader.h>
+#import "RCTImageLoader.h"
 
 @interface RCTGIFImageDecoder : NSObject <RCTImageDataDecoder>
 

--- a/Libraries/Image/RCTImage.xcodeproj/project.pbxproj
+++ b/Libraries/Image/RCTImage.xcodeproj/project.pbxproj
@@ -13,6 +13,8 @@
 		139A38841C4D587C00862840 /* RCTResizeMode.m in Sources */ = {isa = PBXBuildFile; fileRef = 139A38831C4D587C00862840 /* RCTResizeMode.m */; };
 		13EF7F7F1BC825B1003F47DD /* RCTLocalAssetImageLoader.m in Sources */ = {isa = PBXBuildFile; fileRef = 13EF7F7E1BC825B1003F47DD /* RCTLocalAssetImageLoader.m */; };
 		143879381AAD32A300F088A5 /* RCTImageLoader.m in Sources */ = {isa = PBXBuildFile; fileRef = 143879371AAD32A300F088A5 /* RCTImageLoader.m */; };
+		1ADE600C22C26D790062EAE9 /* RCTResizeMode.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = 3D5FA63E1DE4B44A0058FD77 /* RCTResizeMode.h */; };
+		1ADE601022C26DB60062EAE9 /* RCTResizeMode.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = 3D5FA63E1DE4B44A0058FD77 /* RCTResizeMode.h */; };
 		2D3B5F1A1D9B0D0400451313 /* RCTImageCache.m in Sources */ = {isa = PBXBuildFile; fileRef = CCD34C261D4B8FE900268922 /* RCTImageCache.m */; };
 		2D3B5F1B1D9B0D0700451313 /* RCTImageBlurUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = EEF314711C9B0DD30049118E /* RCTImageBlurUtils.m */; };
 		2D3B5F1C1D9B0D1300451313 /* RCTResizeMode.m in Sources */ = {isa = PBXBuildFile; fileRef = 139A38831C4D587C00862840 /* RCTResizeMode.m */; };
@@ -70,6 +72,7 @@
 			dstPath = include/RCTImage;
 			dstSubfolderSpec = 16;
 			files = (
+				1ADE600C22C26D790062EAE9 /* RCTResizeMode.h in Copy Headers */,
 				3D302E181DF8228100D6DDAE /* RCTImageUtils.h in Copy Headers */,
 			);
 			name = "Copy Headers";
@@ -81,6 +84,7 @@
 			dstPath = include/RCTImage;
 			dstSubfolderSpec = 16;
 			files = (
+				1ADE601022C26DB60062EAE9 /* RCTResizeMode.h in Copy Headers */,
 				3D302F211DF8269200D6DDAE /* RCTImageUtils.h in Copy Headers */,
 			);
 			name = "Copy Headers";

--- a/Libraries/Image/RCTImageCache.h
+++ b/Libraries/Image/RCTImageCache.h
@@ -7,7 +7,7 @@
 
 #import <Foundation/Foundation.h>
 
-#import <React/RCTImageLoader.h>
+#import "RCTImageLoader.h"
 
 @interface RCTImageCache : NSObject <RCTImageCache>
 @end

--- a/Libraries/Image/RCTImageCache.m
+++ b/Libraries/Image/RCTImageCache.m
@@ -12,9 +12,9 @@
 #import <ImageIO/ImageIO.h>
 
 #import <React/RCTConvert.h>
-#import <React/RCTNetworking.h>
+#import <RCTNetwork/RCTNetworking.h>
 #import <React/RCTUtils.h>
-#import <React/RCTResizeMode.h>
+#import "RCTResizeMode.h"
 
 #import "RCTImageUtils.h"
 

--- a/Libraries/Image/RCTImageCache.m
+++ b/Libraries/Image/RCTImageCache.m
@@ -12,9 +12,14 @@
 #import <ImageIO/ImageIO.h>
 
 #import <React/RCTConvert.h>
-#import <RCTNetwork/RCTNetworking.h>
 #import <React/RCTUtils.h>
 #import "RCTResizeMode.h"
+
+#if __has_include(<React/RCTNetworking.h>)
+#import <React/RCTNetworking.h>
+#else
+#import <RCTNetwork/RCTNetworking.h>
+#endif
 
 #import "RCTImageUtils.h"
 

--- a/Libraries/Image/RCTImageLoader.h
+++ b/Libraries/Image/RCTImageLoader.h
@@ -8,7 +8,7 @@
 #import <UIKit/UIKit.h>
 
 #import <React/RCTBridge.h>
-#import <React/RCTResizeMode.h>
+#import "RCTResizeMode.h"
 #import <React/RCTURLRequestHandler.h>
 
 typedef void (^RCTImageLoaderProgressBlock)(int64_t progress, int64_t total);

--- a/Libraries/Image/RCTImageLoader.m
+++ b/Libraries/Image/RCTImageLoader.m
@@ -12,9 +12,9 @@
 
 #import <React/RCTConvert.h>
 #import <React/RCTDefines.h>
-#import <React/RCTImageLoader.h>
+#import "RCTImageLoader.h"
 #import <React/RCTLog.h>
-#import <React/RCTNetworking.h>
+#import <RCTNetwork/RCTNetworking.h>
 #import <React/RCTUtils.h>
 
 #import "RCTImageCache.h"

--- a/Libraries/Image/RCTImageLoader.m
+++ b/Libraries/Image/RCTImageLoader.m
@@ -14,8 +14,13 @@
 #import <React/RCTDefines.h>
 #import "RCTImageLoader.h"
 #import <React/RCTLog.h>
-#import <RCTNetwork/RCTNetworking.h>
 #import <React/RCTUtils.h>
+
+#if __has_include(<React/RCTNetworking.h>)
+#import <React/RCTNetworking.h>
+#else
+#import <RCTNetwork/RCTNetworking.h>
+#endif
 
 #import "RCTImageCache.h"
 #import "RCTImageUtils.h"

--- a/Libraries/Image/RCTImageUtils.h
+++ b/Libraries/Image/RCTImageUtils.h
@@ -9,7 +9,7 @@
 #import <UIKit/UIKit.h>
 
 #import <React/RCTDefines.h>
-#import <React/RCTResizeMode.h>
+#import "RCTResizeMode.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Libraries/Image/RCTImageView.h
+++ b/Libraries/Image/RCTImageView.h
@@ -7,7 +7,7 @@
 
 #import <UIKit/UIKit.h>
 #import <React/RCTView.h>
-#import <React/RCTResizeMode.h>
+#import "RCTResizeMode.h"
 
 @class RCTBridge;
 @class RCTImageSource;

--- a/Libraries/Image/RCTLocalAssetImageLoader.h
+++ b/Libraries/Image/RCTLocalAssetImageLoader.h
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#import <React/RCTImageLoader.h>
+#import "RCTImageLoader.h"
 
 @interface RCTLocalAssetImageLoader : NSObject <RCTImageURLLoader>
 

--- a/Libraries/Image/React-RCTImage.podspec
+++ b/Libraries/Image/React-RCTImage.podspec
@@ -29,7 +29,7 @@ Pod::Spec.new do |s|
   s.source                 = source
   s.source_files           = "*.{h,m}"
   s.preserve_paths         = "package.json", "LICENSE", "LICENSE-docs"
-  s.header_dir             = "React"
+  s.header_dir             = "RCTImage"
 
   s.dependency "React-Core", version
   s.dependency "React-RCTNetwork", version

--- a/Libraries/LinkingIOS/React-RCTLinking.podspec
+++ b/Libraries/LinkingIOS/React-RCTLinking.podspec
@@ -29,7 +29,7 @@ Pod::Spec.new do |s|
   s.source                 = source
   s.source_files           = "*.{h,m}"
   s.preserve_paths         = "package.json", "LICENSE", "LICENSE-docs"
-  s.header_dir             = "React"
+  s.header_dir             = "RCTLinking"
 
   s.dependency "React-Core", version
 end

--- a/Libraries/NativeAnimation/React-RCTAnimation.podspec
+++ b/Libraries/NativeAnimation/React-RCTAnimation.podspec
@@ -28,7 +28,7 @@ Pod::Spec.new do |s|
   s.source                 = source
   s.source_files           = "{Drivers/*,Nodes/*,*}.{h,m}"
   s.preserve_paths         = "package.json", "LICENSE", "LICENSE-docs"
-  s.header_dir             = "React"
+  s.header_dir             = "RCTAnimation"
 
   s.dependency "React-Core", version
 end

--- a/Libraries/Network/RCTNetworkTask.m
+++ b/Libraries/Network/RCTNetworkTask.m
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#import "RCTNetworkTask.h"
 #import <React/RCTLog.h>
-#import <React/RCTNetworkTask.h>
 #import <React/RCTUtils.h>
 
 @implementation RCTNetworkTask

--- a/Libraries/Network/RCTNetworking.h
+++ b/Libraries/Network/RCTNetworking.h
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#import "RCTNetworkTask.h"
 #import <React/RCTEventEmitter.h>
-#import <React/RCTNetworkTask.h>
 #import <React/RCTURLRequestHandler.h>
 
 @protocol RCTNetworkingRequestHandler <NSObject>

--- a/Libraries/Network/RCTNetworking.mm
+++ b/Libraries/Network/RCTNetworking.mm
@@ -12,8 +12,8 @@
 #import <React/RCTConvert.h>
 #import <React/RCTEventDispatcher.h>
 #import <React/RCTLog.h>
-#import <React/RCTNetworkTask.h>
-#import <React/RCTNetworking.h>
+#import "RCTNetworkTask.h"
+#import "RCTNetworking.h"
 #import <React/RCTUtils.h>
 
 #import "RCTHTTPRequestHandler.h"

--- a/Libraries/Network/React-RCTNetwork.podspec
+++ b/Libraries/Network/React-RCTNetwork.podspec
@@ -28,7 +28,7 @@ Pod::Spec.new do |s|
   s.source                 = source
   s.source_files           = "*.{h,m,mm}"
   s.preserve_paths         = "package.json", "LICENSE", "LICENSE-docs"
-  s.header_dir             = "React"
+  s.header_dir             = "RCTNetwork"
 
   s.dependency "React-Core", version
 end

--- a/Libraries/PushNotificationIOS/React-RCTPushNotification.podspec
+++ b/Libraries/PushNotificationIOS/React-RCTPushNotification.podspec
@@ -29,7 +29,7 @@ Pod::Spec.new do |s|
   s.source                 = source
   s.source_files           = "*.{h,m}"
   s.preserve_paths         = "package.json", "LICENSE", "LICENSE-docs"
-  s.header_dir             = "React"
+  s.header_dir             = "RCTPushNotification"
 
   s.dependency "React-Core", version
 end

--- a/Libraries/Settings/React-RCTSettings.podspec
+++ b/Libraries/Settings/React-RCTSettings.podspec
@@ -29,7 +29,7 @@ Pod::Spec.new do |s|
   s.source                 = source
   s.source_files           = "*.{h,m}"
   s.preserve_paths         = "package.json", "LICENSE", "LICENSE-docs"
-  s.header_dir             = "React"
+  s.header_dir             = "RCTSettings"
 
   s.dependency "React-Core", version
 end

--- a/Libraries/Text/React-RCTText.podspec
+++ b/Libraries/Text/React-RCTText.podspec
@@ -29,7 +29,7 @@ Pod::Spec.new do |s|
   s.source                 = source
   s.source_files           = "**/*.{h,m}"
   s.preserve_paths         = "package.json", "LICENSE", "LICENSE-docs"
-  s.header_dir             = "React"
+  s.header_dir             = "RCTText"
 
   s.dependency "React-Core", version
 end

--- a/Libraries/Vibration/React-RCTVibration.podspec
+++ b/Libraries/Vibration/React-RCTVibration.podspec
@@ -29,7 +29,7 @@ Pod::Spec.new do |s|
   s.source                 = source
   s.source_files           = "*.{h,m}"
   s.preserve_paths         = "package.json", "LICENSE", "LICENSE-docs"
-  s.header_dir             = "React"
+  s.header_dir             = "RCTVibration"
 
   s.dependency "React-Core", version
 end

--- a/Libraries/WebSocket/React-RCTWebSocket.podspec
+++ b/Libraries/WebSocket/React-RCTWebSocket.podspec
@@ -29,7 +29,7 @@ Pod::Spec.new do |s|
   s.source                 = source
   s.source_files           = "*.{h,m}"
   s.preserve_paths         = "package.json", "LICENSE", "LICENSE-docs"
-  s.header_dir             = "React"
+  s.header_dir             = "RCTWebSocket"
 
   s.dependency "React-Core", version
 end

--- a/RNTester/RCTTest/React-RCTTest.podspec
+++ b/RNTester/RCTTest/React-RCTTest.podspec
@@ -29,7 +29,7 @@ Pod::Spec.new do |s|
   s.source_files           = "**/*.{h,m}"
   s.preserve_paths         = "package.json", "LICENSE", "LICENSE-docs"
   s.framework              = "XCTest"
-  s.header_dir             = "React"
+  s.header_dir             = "RCTTest"
 
   s.dependency "React-Core", version
 end

--- a/RNTester/RNTesterUnitTests/RCTAnimationUtilsTests.m
+++ b/RNTester/RNTesterUnitTests/RCTAnimationUtilsTests.m
@@ -8,7 +8,11 @@
 
 #import <XCTest/XCTest.h>
 
+#if __has_include(<React/RCTAnimationUtils.h>)
 #import <RCTAnimation/RCTAnimationUtils.h>
+#else
+#import <RCTAnimation/RCTAnimationUtils.h>
+#endif
 
 @interface RCTAnimationUtilsTests : XCTestCase
 

--- a/RNTester/RNTesterUnitTests/RCTAnimationUtilsTests.m
+++ b/RNTester/RNTesterUnitTests/RCTAnimationUtilsTests.m
@@ -8,11 +8,7 @@
 
 #import <XCTest/XCTest.h>
 
-#if __has_include(<React/RCTAnimationUtils.h>)
 #import <RCTAnimation/RCTAnimationUtils.h>
-#else
-#import <RCTAnimation/RCTAnimationUtils.h>
-#endif
 
 @interface RCTAnimationUtilsTests : XCTestCase
 

--- a/RNTester/RNTesterUnitTests/RCTBlobManagerTests.m
+++ b/RNTester/RNTesterUnitTests/RCTBlobManagerTests.m
@@ -8,7 +8,11 @@
 
 #import <XCTest/XCTest.h>
 
+#if __has_include(<React/RCTBlobManager.h>)
+#import <React/RCTBlobManager.h>
+#else
 #import <RCTBlob/RCTBlobManager.h>
+#endif
 
 @interface RCTBlobManagerTests : XCTestCase
 

--- a/RNTester/RNTesterUnitTests/RCTBlobManagerTests.m
+++ b/RNTester/RNTesterUnitTests/RCTBlobManagerTests.m
@@ -8,11 +8,7 @@
 
 #import <XCTest/XCTest.h>
 
-#if __has_include(<React/RCTBlobManager.h>)
-#import <React/RCTBlobManager.h>
-#else
 #import <RCTBlob/RCTBlobManager.h>
-#endif
 
 @interface RCTBlobManagerTests : XCTestCase
 

--- a/RNTester/RNTesterUnitTests/RCTNativeAnimatedNodesManagerTests.m
+++ b/RNTester/RNTesterUnitTests/RCTNativeAnimatedNodesManagerTests.m
@@ -10,15 +10,9 @@
 
 #import <OCMock/OCMock.h>
 
-#import <React/RCTUIManager.h>
-
-#if __has_include(<React/RCTValueAnimatedNode.h>)
-#import <React/RCTNativeAnimatedNodesManager.h>
-#import <React/RCTValueAnimatedNode.h>
-#else
 #import <RCTAnimation/RCTNativeAnimatedNodesManager.h>
 #import <RCTAnimation/RCTValueAnimatedNode.h>
-#endif
+#import <React/RCTUIManager.h>
 
 static const NSTimeInterval FRAME_LENGTH = 1.0 / 60.0;
 

--- a/RNTester/RNTesterUnitTests/RCTNativeAnimatedNodesManagerTests.m
+++ b/RNTester/RNTesterUnitTests/RCTNativeAnimatedNodesManagerTests.m
@@ -10,9 +10,15 @@
 
 #import <OCMock/OCMock.h>
 
+#import <React/RCTUIManager.h>
+
+#if __has_include(<React/RCTValueAnimatedNode.h>)
+#import <React/RCTNativeAnimatedNodesManager.h>
+#import <React/RCTValueAnimatedNode.h>
+#else
 #import <RCTAnimation/RCTNativeAnimatedNodesManager.h>
 #import <RCTAnimation/RCTValueAnimatedNode.h>
-#import <React/RCTUIManager.h>
+#endif
 
 static const NSTimeInterval FRAME_LENGTH = 1.0 / 60.0;
 

--- a/React/DevSupport/RCTInspectorDevServerHelper.h
+++ b/React/DevSupport/RCTInspectorDevServerHelper.h
@@ -7,7 +7,7 @@
 #import <UIKit/UIKit.h>
 
 #import <React/RCTDefines.h>
-#import <React/RCTInspectorPackagerConnection.h>
+#import "RCTInspectorPackagerConnection.h"
 
 #if RCT_DEV
 

--- a/React/DevSupport/RCTPackagerClient.m
+++ b/React/DevSupport/RCTPackagerClient.m
@@ -8,8 +8,13 @@
 #import "RCTPackagerClient.h"
 
 #import <React/RCTLog.h>
-#import <RCTWebSocket/RCTReconnectingWebSocket.h>
 #import <React/RCTUtils.h>
+
+#if __has_include(<React/RCTReconnectingWebSocket.h>)
+#import <React/RCTReconnectingWebSocket.h>
+#else
+#import <RCTWebSocket/RCTReconnectingWebSocket.h>
+#endif
 
 #if RCT_DEV // Only supported in dev mode
 

--- a/React/DevSupport/RCTPackagerClient.m
+++ b/React/DevSupport/RCTPackagerClient.m
@@ -8,7 +8,7 @@
 #import "RCTPackagerClient.h"
 
 #import <React/RCTLog.h>
-#import <React/RCTReconnectingWebSocket.h>
+#import <RCTWebSocket/RCTReconnectingWebSocket.h>
 #import <React/RCTUtils.h>
 
 #if RCT_DEV // Only supported in dev mode

--- a/React/DevSupport/RCTPackagerConnection.mm
+++ b/React/DevSupport/RCTPackagerConnection.mm
@@ -17,9 +17,9 @@
 #import <React/RCTConvert.h>
 #import <React/RCTDefines.h>
 #import <React/RCTLog.h>
-#import <React/RCTPackagerClient.h>
-#import <React/RCTReconnectingWebSocket.h>
-#import <React/RCTSRWebSocket.h>
+#import "RCTPackagerClient.h"
+#import <RCTWebSocket/RCTReconnectingWebSocket.h>
+#import <RCTWebSocket/RCTSRWebSocket.h>
 #import <React/RCTUtils.h>
 
 #if RCT_DEV

--- a/React/DevSupport/RCTPackagerConnection.mm
+++ b/React/DevSupport/RCTPackagerConnection.mm
@@ -18,9 +18,15 @@
 #import <React/RCTDefines.h>
 #import <React/RCTLog.h>
 #import "RCTPackagerClient.h"
+#import <React/RCTUtils.h>
+
+#if __has_include(<React/RCTReconnectingWebSocket.h>)
+#import <React/RCTReconnectingWebSocket.h>
+#import <React/RCTSRWebSocket.h>
+#else
 #import <RCTWebSocket/RCTReconnectingWebSocket.h>
 #import <RCTWebSocket/RCTSRWebSocket.h>
-#import <React/RCTUtils.h>
+#endif
 
 #if RCT_DEV
 @interface RCTPackagerConnection () <RCTReconnectingWebSocketDelegate>

--- a/React/Fabric/RCTSurfacePresenter.mm
+++ b/React/Fabric/RCTSurfacePresenter.mm
@@ -18,7 +18,7 @@
 #import <React/RCTComponentViewRegistry.h>
 #import <React/RCTFabricSurface.h>
 #import <React/RCTFollyConvert.h>
-#import <React/RCTImageLoader.h>
+#import <RCTImage/RCTImageLoader.h>
 #import <React/RCTMountingManager.h>
 #import <React/RCTMountingManagerDelegate.h>
 #import <React/RCTScheduler.h>

--- a/React/Fabric/RCTSurfacePresenter.mm
+++ b/React/Fabric/RCTSurfacePresenter.mm
@@ -18,6 +18,7 @@
 #import <React/RCTComponentViewRegistry.h>
 #import <React/RCTFabricSurface.h>
 #import <React/RCTFollyConvert.h>
+#import <RCTImage/RCTImageLoader.h>
 #import <React/RCTMountingManager.h>
 #import <React/RCTMountingManagerDelegate.h>
 #import <React/RCTScheduler.h>
@@ -25,12 +26,6 @@
 #import <React/RCTSurfaceView+Internal.h>
 #import <React/RCTSurfaceView.h>
 #import <React/RCTUtils.h>
-
-#if __has_include(<React/RCTImageLoader.h>)
-#import <React/RCTImageLoader.h>
-#else
-#import <RCTImage/RCTImageLoader.h>
-#endif
 
 #import <react/components/root/RootShadowNode.h>
 #import <react/core/LayoutConstraints.h>

--- a/React/Fabric/RCTSurfacePresenter.mm
+++ b/React/Fabric/RCTSurfacePresenter.mm
@@ -18,7 +18,6 @@
 #import <React/RCTComponentViewRegistry.h>
 #import <React/RCTFabricSurface.h>
 #import <React/RCTFollyConvert.h>
-#import <RCTImage/RCTImageLoader.h>
 #import <React/RCTMountingManager.h>
 #import <React/RCTMountingManagerDelegate.h>
 #import <React/RCTScheduler.h>
@@ -26,6 +25,12 @@
 #import <React/RCTSurfaceView+Internal.h>
 #import <React/RCTSurfaceView.h>
 #import <React/RCTUtils.h>
+
+#if __has_include(<React/RCTImageLoader.h>)
+#import <React/RCTImageLoader.h>
+#else
+#import <RCTImage/RCTImageLoader.h>
+#endif
 
 #import <react/components/root/RootShadowNode.h>
 #import <react/core/LayoutConstraints.h>

--- a/React/React-Core.podspec
+++ b/React/React-Core.podspec
@@ -40,12 +40,23 @@ Pod::Spec.new do |s|
                              "Views/RCTPicker*",
                              "Views/RCTRefreshControl*",
                              "Views/RCTSlider*",
-                             "Views/RCTSwitch*",
+                             "Views/RCTSwitch*"
+  s.private_header_files   = "Cxx*/*.h"
   s.compiler_flags         = folly_compiler_flags + ' ' + boost_compiler_flags
   s.header_dir             = "React"
   s.framework              = "JavaScriptCore"
   s.library                = "stdc++"
   s.pod_target_xcconfig    = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/boost-for-react-native\" \"$(PODS_ROOT)/DoubleConversion\" \"$(PODS_ROOT)/Folly\"" }
+  s.default_subspec         = "Default"
+
+  s.subspec "Default" do |ss|
+    # no-op
+  end
+
+  s.subspec "CxxBridge" do |ss|
+    # Make the C++ headers visible if they are needed
+    ss.public_header_files   = "**/*.{h}"
+  end
 
   s.dependency "Folly", folly_version
   s.dependency "React-cxxreact", version

--- a/React/React-Core.podspec
+++ b/React/React-Core.podspec
@@ -49,6 +49,8 @@ Pod::Spec.new do |s|
 
   s.dependency "Folly", folly_version
   s.dependency "React-cxxreact", version
+  s.dependency "React-jsi", version
   s.dependency "React-jsiexecutor", version
   s.dependency "yoga", "#{version}.React"
+  s.dependency "glog"
 end

--- a/React/React-DevSupport.podspec
+++ b/React/React-DevSupport.podspec
@@ -28,8 +28,9 @@ Pod::Spec.new do |s|
   s.source                 = source
   s.source_files           = "DevSupport/*",
                              "Inspector/*"
-  s.header_dir             = "React"
+  s.header_dir             = "DevSupport"
 
   s.dependency "React-Core", version
+  s.dependency "React-jsinspector", version
   s.dependency "React-RCTWebSocket", version
 end

--- a/React/React-RCTFabric.podspec
+++ b/React/React-RCTFabric.podspec
@@ -42,7 +42,7 @@ Pod::Spec.new do |s|
   s.xcconfig               = { "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost-for-react-native\" \"$(PODS_ROOT)/glog\" \"$(PODS_ROOT)/Folly\"", 
                                "OTHER_CFLAGS" => "$(inherited) -DRN_FABRIC_ENABLED" + " " + folly_flags  }
 
-  s.dependency "React-Core", version
+  s.dependency "React-Core/CxxBridge", version
   s.dependency "React-Fabric", version
   s.dependency "React-RCTImage", version
   s.dependency "Folly/Fabric", folly_version

--- a/ReactCommon/cxxreact/React-cxxreact.podspec
+++ b/ReactCommon/cxxreact/React-cxxreact.podspec
@@ -33,7 +33,7 @@ Pod::Spec.new do |s|
   s.source_files           = "*.{cpp,h}"
   s.exclude_files          = "SampleCxxModule.*"
   s.compiler_flags         = folly_compiler_flags + ' ' + boost_compiler_flags
-  s.pod_target_xcconfig    = { "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost-for-react-native\" \"$(PODS_ROOT)/Folly\"" }
+  s.pod_target_xcconfig    = { "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost-for-react-native\" \"$(PODS_ROOT)/Folly\" \"$(PODS_ROOT)/DoubleConversion\"" }
   s.header_dir             = "cxxreact"
 
   s.dependency "boost-for-react-native", "1.63.0"

--- a/ReactCommon/fabric/imagemanager/platform/ios/ImageManager.mm
+++ b/ReactCommon/fabric/imagemanager/platform/ios/ImageManager.mm
@@ -7,13 +7,8 @@
 
 #include "ImageManager.h"
 
-#import <react/utils/ManagedObjectWrapper.h>
-
-#if __has_include(<React/RCTImageLoader.h>)
-#import <React/RCTImageLoader.h>
-#else
 #import <RCTImage/RCTImageLoader.h>
-#endif
+#import <react/utils/ManagedObjectWrapper.h>
 
 #import "RCTImageManager.h"
 

--- a/ReactCommon/fabric/imagemanager/platform/ios/ImageManager.mm
+++ b/ReactCommon/fabric/imagemanager/platform/ios/ImageManager.mm
@@ -7,8 +7,13 @@
 
 #include "ImageManager.h"
 
-#import <RCTImage/RCTImageLoader.h>
 #import <react/utils/ManagedObjectWrapper.h>
+
+#if __has_include(<React/RCTImageLoader.h>)
+#import <React/RCTImageLoader.h>
+#else
+#import <RCTImage/RCTImageLoader.h>
+#endif
 
 #import "RCTImageManager.h"
 

--- a/ReactCommon/fabric/imagemanager/platform/ios/ImageManager.mm
+++ b/ReactCommon/fabric/imagemanager/platform/ios/ImageManager.mm
@@ -7,7 +7,7 @@
 
 #include "ImageManager.h"
 
-#import <React/RCTImageLoader.h>
+#import <RCTImage/RCTImageLoader.h>
 #import <react/utils/ManagedObjectWrapper.h>
 
 #import "RCTImageManager.h"

--- a/ReactCommon/fabric/imagemanager/platform/ios/RCTImageManager.mm
+++ b/ReactCommon/fabric/imagemanager/platform/ios/RCTImageManager.mm
@@ -10,14 +10,9 @@
 #import <react/debug/SystraceSection.h>
 #import <react/utils/SharedFunction.h>
 
+#import <RCTImage/RCTImageLoader.h>
 #import <react/imagemanager/ImageResponse.h>
 #import <react/imagemanager/ImageResponseObserver.h>
-
-#if __has_include(<React/RCTImageLoader.h>)
-#import <React/RCTImageLoader.h>
-#else
-#import <RCTImage/RCTImageLoader.h>
-#endif
 
 #import "RCTImagePrimitivesConversions.h"
 

--- a/ReactCommon/fabric/imagemanager/platform/ios/RCTImageManager.mm
+++ b/ReactCommon/fabric/imagemanager/platform/ios/RCTImageManager.mm
@@ -10,7 +10,7 @@
 #import <react/debug/SystraceSection.h>
 #import <react/utils/SharedFunction.h>
 
-#import <React/RCTImageLoader.h>
+#import <RCTImage/RCTImageLoader.h>
 #import <react/imagemanager/ImageResponse.h>
 #import <react/imagemanager/ImageResponseObserver.h>
 

--- a/ReactCommon/fabric/imagemanager/platform/ios/RCTImageManager.mm
+++ b/ReactCommon/fabric/imagemanager/platform/ios/RCTImageManager.mm
@@ -10,9 +10,14 @@
 #import <react/debug/SystraceSection.h>
 #import <react/utils/SharedFunction.h>
 
-#import <RCTImage/RCTImageLoader.h>
 #import <react/imagemanager/ImageResponse.h>
 #import <react/imagemanager/ImageResponseObserver.h>
+
+#if __has_include(<React/RCTImageLoader.h>)
+#import <React/RCTImageLoader.h>
+#else
+#import <RCTImage/RCTImageLoader.h>
+#endif
 
 #import "RCTImagePrimitivesConversions.h"
 

--- a/ReactCommon/fabric/imagemanager/platform/ios/RCTImagePrimitivesConversions.h
+++ b/ReactCommon/fabric/imagemanager/platform/ios/RCTImagePrimitivesConversions.h
@@ -7,13 +7,8 @@
 
 #import <UIKit/UIKit.h>
 
-#import <react/imagemanager/primitives.h>
-
-#if __has_include(<React/RCTImageLoader.h>)
-#import <React/RCTImageLoader.h>
-#else
 #import <RCTImage/RCTImageLoader.h>
-#endif
+#import <react/imagemanager/primitives.h>
 
 using namespace facebook::react;
 

--- a/ReactCommon/fabric/imagemanager/platform/ios/RCTImagePrimitivesConversions.h
+++ b/ReactCommon/fabric/imagemanager/platform/ios/RCTImagePrimitivesConversions.h
@@ -7,8 +7,13 @@
 
 #import <UIKit/UIKit.h>
 
-#import <RCTImage/RCTImageLoader.h>
 #import <react/imagemanager/primitives.h>
+
+#if __has_include(<React/RCTImageLoader.h>)
+#import <React/RCTImageLoader.h>
+#else
+#import <RCTImage/RCTImageLoader.h>
+#endif
 
 using namespace facebook::react;
 

--- a/ReactCommon/fabric/imagemanager/platform/ios/RCTImagePrimitivesConversions.h
+++ b/ReactCommon/fabric/imagemanager/platform/ios/RCTImagePrimitivesConversions.h
@@ -7,7 +7,7 @@
 
 #import <UIKit/UIKit.h>
 
-#import <React/RCTImageLoader.h>
+#import <RCTImage/RCTImageLoader.h>
 #import <react/imagemanager/primitives.h>
 
 using namespace facebook::react;

--- a/ReactCommon/jscallinvoker/React-jscallinvoker.podspec
+++ b/ReactCommon/jscallinvoker/React-jscallinvoker.podspec
@@ -33,7 +33,7 @@ Pod::Spec.new do |s|
   s.source_files         = "jsireact/*.{cpp,h}"
   s.compiler_flags         = folly_compiler_flags + ' ' + boost_compiler_flags
   s.header_dir             = "jsireact"
-  s.pod_target_xcconfig    = { "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost-for-react-native\" \"$(PODS_ROOT)/Folly\"" }
+  s.pod_target_xcconfig    = { "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost-for-react-native\" \"$(PODS_ROOT)/Folly\" \"$(PODS_ROOT)/DoubleConversion\"" }
 
   s.dependency "React-cxxreact", version
   s.dependency "Folly", folly_version

--- a/ReactCommon/jscallinvoker/React-jscallinvoker.podspec
+++ b/ReactCommon/jscallinvoker/React-jscallinvoker.podspec
@@ -32,7 +32,7 @@ Pod::Spec.new do |s|
   s.source                 = source
   s.source_files         = "jsireact/*.{cpp,h}"
   s.compiler_flags         = folly_compiler_flags + ' ' + boost_compiler_flags
-  s.header_dir             = "jsireact"
+  s.header_dir             = "jscallinvoker"
   s.pod_target_xcconfig    = { "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost-for-react-native\" \"$(PODS_ROOT)/Folly\" \"$(PODS_ROOT)/DoubleConversion\"" }
 
   s.dependency "React-cxxreact", version

--- a/ReactCommon/jscallinvoker/jsireact/BridgeJSCallInvoker.cpp
+++ b/ReactCommon/jscallinvoker/jsireact/BridgeJSCallInvoker.cpp
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <jsireact/BridgeJSCallInvoker.h>
+#include "BridgeJSCallInvoker.h"
 #include <cxxreact/Instance.h>
 
 namespace facebook {

--- a/ReactCommon/jscallinvoker/jsireact/BridgeJSCallInvoker.h
+++ b/ReactCommon/jscallinvoker/jsireact/BridgeJSCallInvoker.h
@@ -10,7 +10,7 @@
 #include <functional>
 #include <memory>
 
-#include <jsireact/JSCallInvoker.h>
+#include "JSCallInvoker.h"
 
 namespace facebook {
 namespace react {

--- a/ReactCommon/jsi/React-jsi.podspec
+++ b/ReactCommon/jsi/React-jsi.podspec
@@ -34,7 +34,7 @@ Pod::Spec.new do |s|
   s.exclude_files          = "**/test/*"
   s.framework              = "JavaScriptCore"
   s.compiler_flags         = folly_compiler_flags + ' ' + boost_compiler_flags
-  s.pod_target_xcconfig    = { "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost-for-react-native\" \"$(PODS_ROOT)/Folly\"" }
+  s.pod_target_xcconfig    = { "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost-for-react-native\" \"$(PODS_ROOT)/Folly\" \"$(PODS_ROOT)/DoubleConversion\"" }
   s.header_dir             = "jsi"
   s.default_subspec        = "Default"
 

--- a/ReactCommon/jsiexecutor/React-jsiexecutor.podspec
+++ b/ReactCommon/jsiexecutor/React-jsiexecutor.podspec
@@ -32,7 +32,7 @@ Pod::Spec.new do |s|
   s.source                 = source
   s.source_files         = "jsireact/*.{cpp,h}"
   s.compiler_flags         = folly_compiler_flags + ' ' + boost_compiler_flags
-  s.pod_target_xcconfig    = { "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost-for-react-native\" \"$(PODS_ROOT)/Folly\"" }
+  s.pod_target_xcconfig    = { "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost-for-react-native\" \"$(PODS_ROOT)/Folly\" \"$(PODS_ROOT)/DoubleConversion\"" }
   s.header_dir             = "jsireact"
 
   s.dependency "React-cxxreact", version

--- a/ReactCommon/turbomodule/core/React-turbomodule-core.podspec
+++ b/ReactCommon/turbomodule/core/React-turbomodule-core.podspec
@@ -32,8 +32,8 @@ Pod::Spec.new do |s|
   s.source                 = source
   s.source_files           = "*.{cpp,h}"
   s.compiler_flags         = folly_compiler_flags + ' ' + boost_compiler_flags
-  s.header_dir             = "jsireact"
   s.pod_target_xcconfig    = { "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost-for-react-native\" \"$(PODS_ROOT)/Folly\" \"$(PODS_ROOT)/DoubleConversion\"" }
+  s.header_dir             = "turbomodule"
   s.xcconfig               = { "OTHER_CFLAGS" => "$(inherited) -DRN_TURBO_MODULE_ENABLED" }
 
   s.dependency "React-Core", version
@@ -44,6 +44,5 @@ Pod::Spec.new do |s|
 
   s.subspec "core-ios" do |ss|
     ss.source_files   = "platform/ios/*.{mm,cpp,h}"
-    ss.header_dir     = "jsireact"
   end
 end

--- a/ReactCommon/turbomodule/core/React-turbomodule-core.podspec
+++ b/ReactCommon/turbomodule/core/React-turbomodule-core.podspec
@@ -32,8 +32,8 @@ Pod::Spec.new do |s|
   s.source                 = source
   s.source_files           = "*.{cpp,h}"
   s.compiler_flags         = folly_compiler_flags + ' ' + boost_compiler_flags
-  s.pod_target_xcconfig    = { "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost-for-react-native\" \"$(PODS_ROOT)/Folly\"" }
   s.header_dir             = "jsireact"
+  s.pod_target_xcconfig    = { "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost-for-react-native\" \"$(PODS_ROOT)/Folly\" \"$(PODS_ROOT)/DoubleConversion\"" }
   s.xcconfig               = { "OTHER_CFLAGS" => "$(inherited) -DRN_TURBO_MODULE_ENABLED" }
 
   s.dependency "React-Core", version

--- a/ReactCommon/turbomodule/core/TurboCxxModule.cpp
+++ b/ReactCommon/turbomodule/core/TurboCxxModule.cpp
@@ -10,7 +10,7 @@
 #include <vector>
 
 #include <jsi/JSIDynamic.h>
-#include <jsireact/TurboModuleUtils.h>
+#include "TurboModuleUtils.h"
 
 using namespace facebook;
 using namespace facebook::xplat::module;

--- a/ReactCommon/turbomodule/core/TurboModule.h
+++ b/ReactCommon/turbomodule/core/TurboModule.h
@@ -12,7 +12,7 @@
 
 #include <jsi/jsi.h>
 
-#include <jsireact/JSCallInvoker.h>
+#include <jscallinvoker/JSCallInvoker.h>
 
 namespace facebook {
 namespace react {

--- a/ReactCommon/turbomodule/core/TurboModuleBinding.cpp
+++ b/ReactCommon/turbomodule/core/TurboModuleBinding.cpp
@@ -10,7 +10,7 @@
 #include <string>
 
 #include <cxxreact/SystraceSection.h>
-#include <jsireact/LongLivedObject.h>
+#include "LongLivedObject.h"
 
 using namespace facebook;
 

--- a/ReactCommon/turbomodule/core/TurboModuleBinding.h
+++ b/ReactCommon/turbomodule/core/TurboModuleBinding.h
@@ -10,7 +10,7 @@
 #include <string>
 
 #include <jsi/jsi.h>
-#include <jsireact/TurboModule.h>
+#include <turbomodule/TurboModule.h>
 
 namespace facebook {
 namespace react {

--- a/ReactCommon/turbomodule/core/TurboModuleUtils.h
+++ b/ReactCommon/turbomodule/core/TurboModuleUtils.h
@@ -11,7 +11,7 @@
 
 #include <jsi/jsi.h>
 
-#include <jsireact/JSCallInvoker.h>
+#include <jscallinvoker/JSCallInvoker.h>
 
 using namespace facebook;
 

--- a/ReactCommon/turbomodule/core/platform/ios/RCTTurboModule.h
+++ b/ReactCommon/turbomodule/core/platform/ios/RCTTurboModule.h
@@ -13,8 +13,8 @@
 #import <React/RCTBridgeModule.h>
 #import <React/RCTModuleMethod.h>
 #import <cxxreact/MessageQueueThread.h>
-#import <jsireact/JSCallInvoker.h>
-#import <jsireact/TurboModule.h>
+#import <jscallinvoker/JSCallInvoker.h>
+#import "TurboModule.h"
 #import <unordered_map>
 #import <string>
 

--- a/ReactCommon/turbomodule/core/platform/ios/RCTTurboModule.mm
+++ b/ReactCommon/turbomodule/core/platform/ios/RCTTurboModule.mm
@@ -16,10 +16,10 @@
 #import <React/RCTBridgeModule.h>
 #import <React/RCTModuleMethod.h>
 #import <React/RCTUtils.h>
-#import <jsireact/JSCallInvoker.h>
-#import <jsireact/LongLivedObject.h>
-#import <jsireact/TurboModule.h>
-#import <jsireact/TurboModuleUtils.h>
+#import <jscallinvoker/JSCallInvoker.h>
+#import "LongLivedObject.h"
+#import "TurboModule.h"
+#import "TurboModuleUtils.h"
 #import <React/RCTCxxConvert.h>
 #import <React/RCTManagedPointer.h>
 

--- a/ReactCommon/turbomodule/core/platform/ios/RCTTurboModuleManager.mm
+++ b/ReactCommon/turbomodule/core/platform/ios/RCTTurboModuleManager.mm
@@ -16,9 +16,9 @@
 #import <React/RCTCxxModule.h>
 #import <React/RCTLog.h>
 #import <React/RCTPerformanceLogger.h>
-#import <jsireact/BridgeJSCallInvoker.h>
-#import <jsireact/TurboCxxModule.h>
-#import <jsireact/TurboModuleBinding.h>
+#import <jscallinvoker/BridgeJSCallInvoker.h>
+#import "TurboCxxModule.h"
+#import "TurboModuleBinding.h"
 
 using namespace facebook;
 

--- a/ReactCommon/turbomodule/samples/NativeSampleTurboCxxModuleSpecJSI.h
+++ b/ReactCommon/turbomodule/samples/NativeSampleTurboCxxModuleSpecJSI.h
@@ -10,7 +10,7 @@
 #include <memory>
 #include <string>
 
-#include <jsireact/TurboModule.h>
+#include <turbomodule/TurboModule.h>
 
 namespace facebook {
 namespace react {

--- a/ReactCommon/turbomodule/samples/React-turbomodule-samples.podspec
+++ b/ReactCommon/turbomodule/samples/React-turbomodule-samples.podspec
@@ -32,8 +32,8 @@ Pod::Spec.new do |s|
   s.source                 = source
   s.source_files           = "*.{cpp,h}"
   s.compiler_flags         = folly_compiler_flags + ' ' + boost_compiler_flags
-  s.pod_target_xcconfig    = { "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost-for-react-native\" \"$(PODS_ROOT)/Folly\"" }
   s.header_dir             = "jsireact"
+  s.pod_target_xcconfig    = { "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost-for-react-native\" \"$(PODS_ROOT)/Folly\" \"$(PODS_ROOT)/DoubleConversion\"" }
   s.xcconfig               = { "OTHER_CFLAGS" => "$(inherited) -DRN_TURBO_MODULE_ENABLED" }
 
   s.dependency "React-Core", version
@@ -41,6 +41,7 @@ Pod::Spec.new do |s|
   s.dependency "React-jsi", version
   s.dependency "React-turbomodule-core", version
   s.dependency "Folly", folly_version
+  s.dependency "DoubleConversion"
 
   s.subspec "samples-ios" do |ss|
     ss.source_files   = "platform/ios/*.{mm,cpp,h}"

--- a/ReactCommon/turbomodule/samples/React-turbomodule-samples.podspec
+++ b/ReactCommon/turbomodule/samples/React-turbomodule-samples.podspec
@@ -32,8 +32,8 @@ Pod::Spec.new do |s|
   s.source                 = source
   s.source_files           = "*.{cpp,h}"
   s.compiler_flags         = folly_compiler_flags + ' ' + boost_compiler_flags
-  s.header_dir             = "jsireact"
   s.pod_target_xcconfig    = { "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost-for-react-native\" \"$(PODS_ROOT)/Folly\" \"$(PODS_ROOT)/DoubleConversion\"" }
+  s.header_dir             = "turbomodule-samples"
   s.xcconfig               = { "OTHER_CFLAGS" => "$(inherited) -DRN_TURBO_MODULE_ENABLED" }
 
   s.dependency "React-Core", version
@@ -42,9 +42,10 @@ Pod::Spec.new do |s|
   s.dependency "React-turbomodule-core", version
   s.dependency "Folly", folly_version
   s.dependency "DoubleConversion"
+  s.dependency "glog"
 
   s.subspec "samples-ios" do |ss|
     ss.source_files   = "platform/ios/*.{mm,cpp,h}"
-    ss.header_dir     = "jsireact"
+    ss.header_dir     = "turbomodule-samples"
   end
 end

--- a/ReactCommon/turbomodule/samples/SampleTurboCxxModule.cpp
+++ b/ReactCommon/turbomodule/samples/SampleTurboCxxModule.cpp
@@ -7,7 +7,7 @@
 
 #import "SampleTurboCxxModule.h"
 
-#import <jsireact/TurboModuleUtils.h>
+#import <turbomodule/TurboModuleUtils.h>
 
 using namespace facebook;
 

--- a/ReactCommon/turbomodule/samples/platform/ios/RCTNativeSampleTurboModuleSpec.h
+++ b/ReactCommon/turbomodule/samples/platform/ios/RCTNativeSampleTurboModuleSpec.h
@@ -14,7 +14,7 @@
 #import <React/RCTBridgeModule.h>
 
 #ifdef RN_TURBO_MODULE_ENABLED
-#import <jsireact/RCTTurboModule.h>
+#import <turbomodule/RCTTurboModule.h>
 #endif
 
 /**

--- a/ReactCommon/turbomodule/samples/platform/ios/RCTSampleTurboCxxModule.h
+++ b/ReactCommon/turbomodule/samples/platform/ios/RCTSampleTurboCxxModule.h
@@ -8,7 +8,7 @@
 #pragma once
 
 #import <React/RCTCxxModule.h>
-#import <jsireact/RCTTurboModule.h>
+#import <turbomodule/RCTTurboModule.h>
 
 /**
  * Sample backward-compatible RCTCxxModule-based module.

--- a/ReactCommon/turbomodule/samples/platform/ios/RCTSampleTurboCxxModule.mm
+++ b/ReactCommon/turbomodule/samples/platform/ios/RCTSampleTurboCxxModule.mm
@@ -8,7 +8,7 @@
 #import "RCTSampleTurboCxxModule.h"
 
 #import <cxxreact/CxxModule.h>
-#import <jsireact/SampleTurboCxxModule.h>
+#import "SampleTurboCxxModule.h"
 #import "SampleTurboCxxModuleLegacyImpl.h"
 
 using namespace facebook;

--- a/ReactCommon/yoga/yoga.podspec
+++ b/ReactCommon/yoga/yoga.podspec
@@ -47,7 +47,7 @@ Pod::Spec.new do |spec|
   source_files = File.join('ReactCommon/yoga', source_files) if ENV['INSTALL_YOGA_WITHOUT_PATH_OPTION']
   spec.source_files = source_files
 
-  header_files = 'yoga/{Yoga,YGEnums,YGMacros,YGValue,YGStyle,CompactValue,YGFloatOptional,Yoga-internal,YGNode,YGConfig,YGLayout,YGMarker}.h'
+  header_files = 'yoga/{Yoga,YGEnums,YGMacros,YGValue}.h'
   header_files = File.join('ReactCommon/yoga', header_files) if ENV['INSTALL_YOGA_WITHOUT_PATH_OPTION']
   spec.public_header_files = header_files
 end


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

This fixes https://github.com/facebook/react-native/issues/25349. It allows React and the related pods to be integrated into `Podfile`s that use `use_frameworks!`. Some more background is explained in the issue.

The fix involves a number of changes:

- All podspecs now have different values for `s.header_dir` to avoid conflicts with `#import <React/X>` imports. **This may be a breaking change if these are imported externally.**
- Made C++ headers in `React-Core` private by default so that ObjC files can import the module without failures.
- Reduced the number of `yoga` headers that are exposed for the same reason as above. As far as I can see this doesn't cause issues but we can find another solution if it does.
- Adding some missing dependencies to fix undefined symbols errors.
- Added `DoubleConversion` to `HEADER_SEARCH_PATHS` where it was missing.

**Note:** The `React-RCTFabric` and `React-Fabric` pods are still incompatible with `use_frameworks!`, but work fine without it. Some more updates will be needed there.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[iOS] [Fixed] - Fixed compatibility with CocoaPods frameworks.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Everything should work exactly as before, where `use_frameworks!` is not in `Podfile`s. I have a branch on my [sample project](https://github.com/jtreanor/react-native-cocoapods-frameworks) here which has `use_frameworks!` in its `Podfile` to demonstrate this is fixed.

You can see that it works with these steps:

1. `git clone git@github.com:jtreanor/react-native-cocoapods-frameworks.git`
2. `git checkout fix-frameworks`
3. `cd ios && pod install`
4. `cd .. && react-native run-ios`

The sample app will build and run successfully. To see that it still works without frameworks, remove `use_frameworks!` from the `Podfile` and do steps 3 and 4 again.