### PR TITLE
[RNTester] Commit IDEWorkspaceChecks.plist [trivial]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,4 +78,3 @@ RNTester/build
 /template/ios/Pods/
 /template/ios/Podfile.lock
 RNTester/Pods/
-RNTester/RNTesterPods.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist

--- a/RNTester/RNTesterPods.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/RNTester/RNTesterPods.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

According to Apple documentation: https://developer.apple.com/library/archive/releasenotes/DeveloperTools/RN-Xcode/Chapters/Introduction.html#//apple_ref/doc/uid/TP40001051-CH1-DontLinkElementID_7 - IDEWorkspaceChecks.plist ought to be committed to the repository. This is a trivial change and shouldn't have any functional effect other than performance & future resilience

## Changelog

[Internal] [Changed] Commit IDEWorkspaceChecks.plist

## Test Plan

no functional change