### PR TITLE
Upgrade jsc-android to r245459 and fix crash on Samsung S7 Edge

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "fbjs": "^1.0.0",
     "fbjs-scripts": "^1.1.0",
     "invariant": "^2.2.4",
-    "jsc-android": "^241213.1.0",
+    "jsc-android": "^245459.0.0",
     "metro-babel-register": "0.54.1",
     "metro-react-native-babel-transformer": "0.54.1",
     "nullthrows": "^1.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4417,10 +4417,10 @@ jsbn@~0.1.0:
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
   integrity sha1-peZUwuWi3rXyAdls77yoDA7y9RM=
 
-jsc-android@^241213.1.0:
-  version "241213.1.0"
-  resolved "https://registry.yarnpkg.com/jsc-android/-/jsc-android-241213.1.0.tgz#8f940d7c7f6bebf14eda32bef42a76182e336452"
-  integrity sha512-AH8NYyMNLNhcUEF97QbMxPNLNW+oiSBlvm1rsMNzgJ1d5TQzdh/AOJGsxeeESp3m9YIWGLCgUvGTVoVLs0p68A==
+jsc-android@^245459.0.0:
+  version "245459.0.0"
+  resolved "https://registry.yarnpkg.com/jsc-android/-/jsc-android-245459.0.0.tgz#e584258dd0b04c9159a27fb104cd5d491fd202c9"
+  integrity sha512-wkjURqwaB1daNkDi2OYYbsLnIdC/lUM2nPXQKRs5pqEU9chDg435bjvo+LSaHotDENygHQDHe+ntUkkw2gwMtg==
 
 jscodeshift@^0.6.2:
   version "0.6.2"


### PR DESCRIPTION
## Summary

Upgrade bundled jsc-android that should fix the native JSC crash addressed for #24261.
Major changes after r241213 are:
1. Disable DFG JIT.
2. Upgrade WebKitGTK to 2.24.2, this version includes the [new bytecode format enhancement](https://webkit.org/blog/9329/a-new-bytecode-format-for-javascriptcore/).
3. Workaround LLVM __clear_cache issue which may have some problems on ARM Cortex A-53.

For details, please refer to the PRs in https://github.com/react-native-community/jsc-android-buildscripts.

In #24261, there were many experimented JSC deliveries and thank to people in RN community helping me verify the final version which solve the crash issues.

## Changelog

[Android] [Fixed] - Upgrade jsc-android to r245459 and fix crash on Samsung S7 Edge

## Test Plan

1. Run [measure scripts](https://github.com/react-native-community/jsc-android-buildscripts/tree/master/measure) on my Samsung Note 5.
2. Provide an [experimented version](https://www.npmjs.com/package/@kudo-ci/jsc-android/v/245459.9000.0) for community who previously reported JSC crash and seems no more crashes happened, see that thread in #24261 

