### PR TITLE
allow custom StickyHeader in ScrollView-based components

### DIFF
--- a/Libraries/Components/ScrollView/ScrollView.js
+++ b/Libraries/Components/ScrollView/ScrollView.js
@@ -37,7 +37,7 @@ import type {NativeMethodsMixinType} from '../../Renderer/shims/ReactNativeTypes
 import type {ViewStyleProp} from '../../StyleSheet/StyleSheet';
 import type {ViewProps} from '../View/ViewPropTypes';
 import type {PointProp} from '../../StyleSheet/PointPropType';
-import type {ScrolViewStickyHeaderProps} from './ScrollViewStickyHeader';
+import type {Props as ScrollViewStickyHeaderProps} from './ScrollViewStickyHeader';
 
 import type {ColorValue} from '../../StyleSheet/StyleSheetTypes';
 import type {State as ScrollResponderState} from '../ScrollResponder';
@@ -354,7 +354,7 @@ type VRProps = $ReadOnly<{|
   scrollBarThumbImage?: ?($ReadOnly<{||}> | number), // Opaque type returned by import IMAGE from './image.jpg'
 |}>;
 
-type StickyHeaderComponentType = React.ComponentType<ScrolViewStickyHeaderProps> & {
+type StickyHeaderComponentType = React.ComponentType<ScrollViewStickyHeaderProps> & {
   setNextHeaderY: number => void,
 };
 

--- a/Libraries/Components/ScrollView/ScrollView.js
+++ b/Libraries/Components/ScrollView/ScrollView.js
@@ -509,7 +509,7 @@ export type Props = $ReadOnly<{|
   /**
    * A React Component that will be used to render sticky headers.
    * To be used together with `stickyHeaderIndices` or with `SectionList`, defaults to `ScrollViewStickyHeader`.
-   * You may need to set this if your sticky header implementes custom transforms (eg. translation),
+   * You may need to set this if your sticky header uses custom transforms (eg. translation),
    * for example when you want your list to have an animated hidable header.
    */
   StickyHeaderComponent: StickyHeaderComponentType,

--- a/Libraries/Components/ScrollView/ScrollView.js
+++ b/Libraries/Components/ScrollView/ScrollView.js
@@ -37,6 +37,7 @@ import type {NativeMethodsMixinType} from '../../Renderer/shims/ReactNativeTypes
 import type {ViewStyleProp} from '../../StyleSheet/StyleSheet';
 import type {ViewProps} from '../View/ViewPropTypes';
 import type {PointProp} from '../../StyleSheet/PointPropType';
+import type {ScrolViewStickyHeaderProps} from './ScrollViewStickyHeader';
 
 import type {ColorValue} from '../../StyleSheet/StyleSheetTypes';
 import type {State as ScrollResponderState} from '../ScrollResponder';
@@ -353,6 +354,10 @@ type VRProps = $ReadOnly<{|
   scrollBarThumbImage?: ?($ReadOnly<{||}> | number), // Opaque type returned by import IMAGE from './image.jpg'
 |}>;
 
+type StickyHeaderComponentType = React.ComponentType<ScrolViewStickyHeaderProps> & {
+  setNextHeaderY: number => void,
+};
+
 export type Props = $ReadOnly<{|
   ...ViewProps,
   ...TouchableProps,
@@ -502,6 +507,13 @@ export type Props = $ReadOnly<{|
    */
   stickyHeaderIndices?: ?$ReadOnlyArray<number>,
   /**
+   * A React Component that will be used to render sticky headers.
+   * To be used together with `stickyHeaderIndices` or with `SectionList`, defaults to `ScrollViewStickyHeader`.
+   * You may need to set this if your sticky header implementes custom transforms (eg. translation),
+   * for example when you want your list to have an animated hidable header.
+   */
+  StickyHeaderComponent: StickyHeaderComponentType,
+  /**
    * When set, causes the scroll view to stop at multiples of the value of
    * `snapToInterval`. This can be used for paginating through children
    * that have lengths smaller than the scroll view. Typically used in
@@ -623,6 +635,10 @@ class ScrollView extends React.Component<Props, State> {
    */
   _scrollResponder: typeof ScrollResponder.Mixin = createScrollResponder(this);
 
+  static defaultProps = {
+    StickyHeaderComponent: ScrollViewStickyHeader,
+  };
+
   constructor(props: Props) {
     super(props);
 
@@ -665,7 +681,7 @@ class ScrollView extends React.Component<Props, State> {
     0,
   );
   _scrollAnimatedValueAttachment: ?{detach: () => void} = null;
-  _stickyHeaderRefs: Map<number, ScrollViewStickyHeader> = new Map();
+  _stickyHeaderRefs: Map<string, StickyHeaderComponentType> = new Map();
   _headerLayoutYs: Map<string, number> = new Map();
 
   state = {
@@ -835,7 +851,7 @@ class ScrollView extends React.Component<Props, State> {
     }
   }
 
-  _setStickyHeaderRef(key, ref) {
+  _setStickyHeaderRef(key: string, ref: ?StickyHeaderComponentType) {
     if (ref) {
       this._stickyHeaderRefs.set(key, ref);
     } else {
@@ -863,7 +879,9 @@ class ScrollView extends React.Component<Props, State> {
       const previousHeader = this._stickyHeaderRefs.get(
         this._getKeyForIndex(previousHeaderIndex, childArray),
       );
-      previousHeader && previousHeader.setNextHeaderY(layoutY);
+      previousHeader &&
+        previousHeader.setNextHeaderY &&
+        previousHeader.setNextHeaderY(layoutY);
     }
   }
 
@@ -980,9 +998,11 @@ class ScrollView extends React.Component<Props, State> {
         if (indexOfIndex > -1) {
           const key = child.key;
           const nextIndex = stickyHeaderIndices[indexOfIndex + 1];
+          const {StickyHeaderComponent} = this.props;
           return (
-            <ScrollViewStickyHeader
+            <StickyHeaderComponent
               key={key}
+              // $FlowFixMe - inexact mixed is incompatible with exact React.Element
               ref={ref => this._setStickyHeaderRef(key, ref)}
               nextHeaderLayoutY={this._headerLayoutYs.get(
                 this._getKeyForIndex(nextIndex, childArray),
@@ -992,7 +1012,7 @@ class ScrollView extends React.Component<Props, State> {
               inverted={this.props.invertStickyHeaders}
               scrollViewHeight={this.state.layoutHeight}>
               {child}
-            </ScrollViewStickyHeader>
+            </StickyHeaderComponent>
           );
         } else {
           return child;

--- a/Libraries/Components/ScrollView/ScrollViewStickyHeader.js
+++ b/Libraries/Components/ScrollView/ScrollViewStickyHeader.js
@@ -18,7 +18,7 @@ import type {LayoutEvent} from '../../Types/CoreEventTypes';
 
 const AnimatedView = AnimatedImplementation.createAnimatedComponent(View);
 
-type Props = {
+export type ScrolViewStickyHeaderProps = {
   children?: React.Element<any>,
   nextHeaderLayoutY: ?number,
   onLayout: (event: LayoutEvent) => void,
@@ -37,7 +37,10 @@ type State = {
   nextHeaderLayoutY: ?number,
 };
 
-class ScrollViewStickyHeader extends React.Component<Props, State> {
+class ScrollViewStickyHeader extends React.Component<
+  ScrolViewStickyHeaderProps,
+  State,
+> {
   state = {
     measured: false,
     layoutY: 0,

--- a/Libraries/Components/ScrollView/ScrollViewStickyHeader.js
+++ b/Libraries/Components/ScrollView/ScrollViewStickyHeader.js
@@ -18,7 +18,7 @@ import type {LayoutEvent} from '../../Types/CoreEventTypes';
 
 const AnimatedView = AnimatedImplementation.createAnimatedComponent(View);
 
-export type ScrolViewStickyHeaderProps = {
+export type Props = {
   children?: React.Element<any>,
   nextHeaderLayoutY: ?number,
   onLayout: (event: LayoutEvent) => void,
@@ -37,10 +37,7 @@ type State = {
   nextHeaderLayoutY: ?number,
 };
 
-class ScrollViewStickyHeader extends React.Component<
-  ScrolViewStickyHeaderProps,
-  State,
-> {
+class ScrollViewStickyHeader extends React.Component<Props, State> {
   state = {
     measured: false,
     layoutY: 0,

--- a/Libraries/Lists/__tests__/__snapshots__/FlatList-test.js.snap
+++ b/Libraries/Lists/__tests__/__snapshots__/FlatList-test.js.snap
@@ -6,6 +6,7 @@ exports[`FlatList renders all the bells and whistles 1`] = `
   ListEmptyComponent={[Function]}
   ListFooterComponent={[Function]}
   ListHeaderComponent={[Function]}
+  StickyHeaderComponent={[MockFunction]}
   data={
     Array [
       Object {
@@ -128,6 +129,7 @@ exports[`FlatList renders all the bells and whistles 1`] = `
 
 exports[`FlatList renders empty list 1`] = `
 <RCTScrollView
+  StickyHeaderComponent={[MockFunction]}
   data={Array []}
   disableVirtualization={false}
   getItem={[Function]}
@@ -158,6 +160,7 @@ exports[`FlatList renders empty list 1`] = `
 
 exports[`FlatList renders null list 1`] = `
 <RCTScrollView
+  StickyHeaderComponent={[MockFunction]}
   disableVirtualization={false}
   getItem={[Function]}
   getItemCount={[Function]}
@@ -187,6 +190,7 @@ exports[`FlatList renders null list 1`] = `
 
 exports[`FlatList renders simple list (multiple columns) 1`] = `
 <RCTScrollView
+  StickyHeaderComponent={[MockFunction]}
   data={
     Array [
       Object {
@@ -265,6 +269,7 @@ exports[`FlatList renders simple list (multiple columns) 1`] = `
 
 exports[`FlatList renders simple list 1`] = `
 <RCTScrollView
+  StickyHeaderComponent={[MockFunction]}
   data={
     Array [
       Object {
@@ -333,6 +338,7 @@ exports[`FlatList renders simple list 1`] = `
 exports[`FlatList renders simple list using ListItemComponent (multiple columns) 1`] = `
 <RCTScrollView
   ListItemComponent={[Function]}
+  StickyHeaderComponent={[MockFunction]}
   data={
     Array [
       Object {
@@ -411,6 +417,7 @@ exports[`FlatList renders simple list using ListItemComponent (multiple columns)
 exports[`FlatList renders simple list using ListItemComponent 1`] = `
 <RCTScrollView
   ListItemComponent={[Function]}
+  StickyHeaderComponent={[MockFunction]}
   data={
     Array [
       Object {

--- a/Libraries/Lists/__tests__/__snapshots__/SectionList-test.js.snap
+++ b/Libraries/Lists/__tests__/__snapshots__/SectionList-test.js.snap
@@ -2,6 +2,7 @@
 
 exports[`SectionList rendering empty section headers is fine 1`] = `
 <RCTScrollView
+  StickyHeaderComponent={[MockFunction]}
   data={
     Array [
       Object {
@@ -89,6 +90,7 @@ exports[`SectionList rendering empty section headers is fine 1`] = `
 
 exports[`SectionList renders a footer when there is no data 1`] = `
 <RCTScrollView
+  StickyHeaderComponent={[MockFunction]}
   data={
     Array [
       Object {
@@ -155,6 +157,7 @@ exports[`SectionList renders a footer when there is no data 1`] = `
 
 exports[`SectionList renders a footer when there is no data and no header 1`] = `
 <RCTScrollView
+  StickyHeaderComponent={[MockFunction]}
   data={
     Array [
       Object {
@@ -220,6 +223,7 @@ exports[`SectionList renders all the bells and whistles 1`] = `
   ListFooterComponent={[Function]}
   ListHeaderComponent={[Function]}
   SectionSeparatorComponent={[Function]}
+  StickyHeaderComponent={[MockFunction]}
   data={
     Array [
       Object {
@@ -494,6 +498,7 @@ exports[`SectionList renders all the bells and whistles 1`] = `
 
 exports[`SectionList renders empty list 1`] = `
 <RCTScrollView
+  StickyHeaderComponent={[MockFunction]}
   data={Array []}
   disableVirtualization={false}
   getItem={[Function]}

--- a/Libraries/Lists/__tests__/__snapshots__/VirtualizedList-test.js.snap
+++ b/Libraries/Lists/__tests__/__snapshots__/VirtualizedList-test.js.snap
@@ -2,6 +2,7 @@
 
 exports[`VirtualizedList handles nested lists 1`] = `
 <RCTScrollView
+  StickyHeaderComponent={[MockFunction]}
   data={
     Array [
       Object {
@@ -91,6 +92,7 @@ exports[`VirtualizedList handles nested lists 1`] = `
       style={null}
     >
       <RCTScrollView
+        StickyHeaderComponent={[MockFunction]}
         data={
           Array [
             Object {
@@ -162,6 +164,7 @@ exports[`VirtualizedList handles nested lists 1`] = `
 exports[`VirtualizedList handles separators correctly 1`] = `
 <RCTScrollView
   ItemSeparatorComponent={[Function]}
+  StickyHeaderComponent={[MockFunction]}
   data={
     Array [
       Object {
@@ -243,6 +246,7 @@ exports[`VirtualizedList handles separators correctly 1`] = `
 exports[`VirtualizedList handles separators correctly 2`] = `
 <RCTScrollView
   ItemSeparatorComponent={[Function]}
+  StickyHeaderComponent={[MockFunction]}
   data={
     Array [
       Object {
@@ -324,6 +328,7 @@ exports[`VirtualizedList handles separators correctly 2`] = `
 exports[`VirtualizedList handles separators correctly 3`] = `
 <RCTScrollView
   ItemSeparatorComponent={[Function]}
+  StickyHeaderComponent={[MockFunction]}
   data={
     Array [
       Object {
@@ -409,6 +414,7 @@ exports[`VirtualizedList renders all the bells and whistles 1`] = `
   ListEmptyComponent={[Function]}
   ListFooterComponent={[Function]}
   ListHeaderComponent={[Function]}
+  StickyHeaderComponent={[MockFunction]}
   data={
     Array [
       Object {
@@ -611,6 +617,7 @@ exports[`VirtualizedList renders all the bells and whistles 1`] = `
 
 exports[`VirtualizedList renders empty list 1`] = `
 <RCTScrollView
+  StickyHeaderComponent={[MockFunction]}
   data={Array []}
   disableVirtualization={false}
   getItem={[Function]}
@@ -641,6 +648,7 @@ exports[`VirtualizedList renders empty list with empty component 1`] = `
   ListEmptyComponent={[Function]}
   ListFooterComponent={[Function]}
   ListHeaderComponent={[Function]}
+  StickyHeaderComponent={[MockFunction]}
   data={Array []}
   disableVirtualization={false}
   getItem={[Function]}
@@ -681,6 +689,7 @@ exports[`VirtualizedList renders empty list with empty component 1`] = `
 exports[`VirtualizedList renders list with empty component 1`] = `
 <RCTScrollView
   ListEmptyComponent={[Function]}
+  StickyHeaderComponent={[MockFunction]}
   data={
     Array [
       Object {
@@ -723,6 +732,7 @@ exports[`VirtualizedList renders list with empty component 1`] = `
 
 exports[`VirtualizedList renders null list 1`] = `
 <RCTScrollView
+  StickyHeaderComponent={[MockFunction]}
   disableVirtualization={false}
   getItem={[Function]}
   getItemCount={[Function]}
@@ -749,6 +759,7 @@ exports[`VirtualizedList renders null list 1`] = `
 
 exports[`VirtualizedList renders simple list 1`] = `
 <RCTScrollView
+  StickyHeaderComponent={[MockFunction]}
   data={
     Array [
       Object {
@@ -814,6 +825,7 @@ exports[`VirtualizedList renders simple list 1`] = `
 exports[`VirtualizedList renders simple list using ListItemComponent 1`] = `
 <RCTScrollView
   ListItemComponent={[Function]}
+  StickyHeaderComponent={[MockFunction]}
   data={
     Array [
       Object {
@@ -877,6 +889,7 @@ exports[`VirtualizedList renders simple list using ListItemComponent 1`] = `
 
 exports[`VirtualizedList test getItem functionality where data is not an Array 1`] = `
 <RCTScrollView
+  StickyHeaderComponent={[MockFunction]}
   data={
     Map {
       "id_0" => Object {
@@ -920,6 +933,7 @@ exports[`VirtualizedList test getItem functionality where data is not an Array 1
 exports[`VirtualizedList warns if both renderItem or ListItemComponent are specified. Uses ListItemComponent 1`] = `
 <RCTScrollView
   ListItemComponent={[Function]}
+  StickyHeaderComponent={[MockFunction]}
   data={
     Array [
       Object {

--- a/Libraries/Lists/__tests__/__snapshots__/VirtualizedSectionList-test.js.snap
+++ b/Libraries/Lists/__tests__/__snapshots__/VirtualizedSectionList-test.js.snap
@@ -2,6 +2,7 @@
 
 exports[`VirtualizedSectionList handles nested lists 1`] = `
 <RCTScrollView
+  StickyHeaderComponent={[MockFunction]}
   data={
     Array [
       Object {
@@ -143,6 +144,7 @@ exports[`VirtualizedSectionList handles nested lists 1`] = `
       style={null}
     >
       <RCTScrollView
+        StickyHeaderComponent={[MockFunction]}
         data={
           Array [
             Object {
@@ -259,6 +261,7 @@ exports[`VirtualizedSectionList handles nested lists 1`] = `
 
 exports[`VirtualizedSectionList handles separators correctly 1`] = `
 <RCTScrollView
+  StickyHeaderComponent={[MockFunction]}
   data={
     Array [
       Object {
@@ -416,6 +419,7 @@ exports[`VirtualizedSectionList handles separators correctly 1`] = `
 
 exports[`VirtualizedSectionList handles separators correctly 2`] = `
 <RCTScrollView
+  StickyHeaderComponent={[MockFunction]}
   data={
     Array [
       Object {
@@ -573,6 +577,7 @@ exports[`VirtualizedSectionList handles separators correctly 2`] = `
 
 exports[`VirtualizedSectionList handles separators correctly 3`] = `
 <RCTScrollView
+  StickyHeaderComponent={[MockFunction]}
   data={
     Array [
       Object {
@@ -734,6 +739,7 @@ exports[`VirtualizedSectionList renders all the bells and whistles 1`] = `
   ListEmptyComponent={[Function]}
   ListFooterComponent={[Function]}
   ListHeaderComponent={[Function]}
+  StickyHeaderComponent={[MockFunction]}
   data={
     Array [
       Object {
@@ -1005,6 +1011,7 @@ exports[`VirtualizedSectionList renders all the bells and whistles 1`] = `
 
 exports[`VirtualizedSectionList renders empty list 1`] = `
 <RCTScrollView
+  StickyHeaderComponent={[MockFunction]}
   data={Array []}
   disableVirtualization={false}
   getItem={[Function]}
@@ -1036,6 +1043,7 @@ exports[`VirtualizedSectionList renders empty list with empty component 1`] = `
   ListEmptyComponent={[Function]}
   ListFooterComponent={[Function]}
   ListHeaderComponent={[Function]}
+  StickyHeaderComponent={[MockFunction]}
   data={Array []}
   disableVirtualization={false}
   getItem={[Function]}
@@ -1077,6 +1085,7 @@ exports[`VirtualizedSectionList renders empty list with empty component 1`] = `
 exports[`VirtualizedSectionList renders list with empty component 1`] = `
 <RCTScrollView
   ListEmptyComponent={[Function]}
+  StickyHeaderComponent={[MockFunction]}
   data={
     Array [
       Object {
@@ -1144,6 +1153,7 @@ exports[`VirtualizedSectionList renders list with empty component 1`] = `
 
 exports[`VirtualizedSectionList renders null list 1`] = `
 <RCTScrollView
+  StickyHeaderComponent={[MockFunction]}
   disableVirtualization={false}
   getItem={[Function]}
   getItemCount={[Function]}
@@ -1170,6 +1180,7 @@ exports[`VirtualizedSectionList renders null list 1`] = `
 
 exports[`VirtualizedSectionList renders simple list 1`] = `
 <RCTScrollView
+  StickyHeaderComponent={[MockFunction]}
   data={
     Array [
       Object {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

This PR adds support for custom `StickyHeaderComponent` to be used in ScrollView (and by extension in FlatList, SectionList..).

Motivation: I've been working on a FlatList with hidable header that has a search field in it. Something like https://medium.com/appandflow/react-native-collapsible-navbar-e51a049b560a but using a FlatList w/ pull-to-refresh. The implementation can be found at https://snack.expo.io/@vonovak/hidable-header-flatlist .

I used the `ListHeaderComponent` prop to render the custom header - as opposed to absolute positioning which is used in the linked article because I also need the loading indicator (I added `refreshing` and `onRefresh` for that) to show up above the header.
I proceeded by adding `stickyHeaderIndices={[0]}` to keep the header at the top, which seems to be the idiomatic way to do so. Then I added `Animated.View` with custom translation logic to the rendered header.

All appears to be working fine at the first sight - when you tap any item, you'll see it react to touch (red underlay). You'll also see the header becomes hidden if I scroll far enough and appears again after scrolling up. BUT - when you scroll down so that the header becomes hidden and tap the first visible item in the list, it will not react to touches! The reason is that `ScrollViewStickyHeader`

https://github.com/facebook/react-native/blob/9a84970c35d22b68fb3d8eac019c7f415a14c888/Libraries/Components/ScrollView/ScrollView.js#L984

has its own translation logic and when I tap onto the item at the top of the list, it seems like I'm tapping the item but I'm in fact tapping that `ScrollViewStickyHeader`.

I tried working around this by not specifying `stickyHeaderIndices={[0]}` and using `ListHeaderComponentStyle` prop (this needed some additional changes in https://github.com/facebook/react-native/blob/9a84970c35d22b68fb3d8eac019c7f415a14c888/Libraries/Lists/VirtualizedList.js#L786, and the animation is junky for some reason - as if the header always needed to "catch up" with the scroll offset, causing jitter) and `CellRendererComponent` (junky animations too), but concluded that allowing to specify custom `StickyHeaderComponent` is the cleanest way to make something like this work. I'm slightly surprised I needed to do all this to make such a usual pattern work - am I missing something?


## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[GENERAL] [ADDED] - allow custom StickyHeader in ScrollView-based components

## Test Plan

This is a minor change that should not break anything; tested locally.