### PR TITLE
Remove incorrect constexpr specifier in YGLayout

### DIFF
--- a/ReactCommon/yoga/yoga/YGLayout.cpp
+++ b/ReactCommon/yoga/yoga/YGLayout.cpp
@@ -9,6 +9,9 @@
 
 using namespace facebook;
 
+const std::array<float, 2> kYGDefaultDimensionValues = {
+    {YGUndefined, YGUndefined}};
+
 bool YGLayout::operator==(YGLayout layout) const {
   bool isEqual = YGFloatArrayEqual(position, layout.position) &&
       YGFloatArrayEqual(dimensions, layout.dimensions) &&

--- a/ReactCommon/yoga/yoga/YGLayout.h
+++ b/ReactCommon/yoga/yoga/YGLayout.h
@@ -8,8 +8,7 @@
 #include "YGFloatOptional.h"
 #include "Yoga-internal.h"
 
-constexpr std::array<float, 2> kYGDefaultDimensionValues = {
-    {YGUndefined, YGUndefined}};
+extern const std::array<float, 2> kYGDefaultDimensionValues;
 
 struct YGLayout {
   std::array<float, 4> position = {};


### PR DESCRIPTION
Summary:
* According to C++ standard values which produce undefined behavior cannot be declared as `constexpr`.
* Expressions which evaluate to `nan, infinity, etc` are undefined behavior.

For more details you can checkout this Stackoverflow answer: https://stackoverflow.com/a/46373136

Differential Revision: D16055108

