### PR TITLE
[Internal] [Fixed] - Publish `react-native.config.js`

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "Libraries",
     "LICENSE",
     "packager",
+    "react-native.config.js",
     "react.gradle",
     "React.podspec",
     "React",


### PR DESCRIPTION
## Summary

Looks we forgot to add this file to publish list. By adding it, we can remove some code in CLI that special-cases `react-native` package, since it now announces itself as a proper platform.

cc @kelset, we'd like to have this cherry-picked for 0.60.

## Changelog

[Internal] [Fixed] - Publish `react-native.config.js`

## Test Plan

`npm pack` shows `react-native.config.js`
