### PR TITLE
Fix rncore generation for React-Fabric.podspec following 98b03fa

### DIFF
--- a/scripts/generate-rncore.sh
+++ b/scripts/generate-rncore.sh
@@ -9,5 +9,6 @@
 # to a location that the podspecs expect.
 
 # shellcheck disable=SC2038
-find "$PWD/../Libraries" -name "*Schema.js" -print | xargs yarn flow-node packages/react-native-codegen/src/cli/combine/combine-js-to-schema-cli.js schema-rncore.json
+
+find "$PWD/../Libraries" -name "*NativeComponent.js" -print | xargs yarn flow-node packages/react-native-codegen/src/cli/combine/combine-js-to-schema-cli.js schema-rncore.json
 yarn flow-node packages/react-native-codegen/buck_tests/generate-tests.js schema-rncore.json rncore ReactCommon/fabric/components/rncore


### PR DESCRIPTION
## Summary

This PR adjusts rncore generation to the flow parser based approach introduced in 98b03fa.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[Internal] [Fixed] - Fix iOS build of RNTester with fabric_enabled

## Test Plan

As far as I see currently there's no automated testing for the RNTester build with `fabric_enbaled` set to `true`.

The quickest way to test this PR is building RNTester using cocoapods with `fabric_enabled`.