### PR TITLE
Fix conversion errors between bitfields and enums in yoga

### DIFF
--- a/ReactCommon/yoga/yoga/YGMacros.h
+++ b/ReactCommon/yoga/yoga/YGMacros.h
@@ -24,10 +24,11 @@
 // Cannot use NSInteger as NSInteger has a different size than int (which is the
 // default type of a enum). Therefor when linking the Yoga C library into obj-c
 // the header is a missmatch for the Yoga ABI.
-#define YG_ENUM_BEGIN(name) NS_ENUM(int, name)
+// We're using unsigned int explicitly because sign of enums and bitfields is implementation specific.
+#define YG_ENUM_BEGIN(name) NS_ENUM(unsigned int, name)
 #define YG_ENUM_END(name)
 #else
-#define YG_ENUM_BEGIN(name) enum name
+#define YG_ENUM_BEGIN(name) enum name: unsigned int
 #define YG_ENUM_END(name) name
 #endif
 


### PR DESCRIPTION
## Summary

Compiler: LLVM version 10.0.1

My hypothesis: When I was running RNTester it crashed immediately because of a sign issue when storing YG Enum values inside bitfields. In my specific case, I set `flexDirection()` to `0b10` (`YGFlexDirectionColumnReverse`) which resulted in `-2` because bitfields are signed with my compiler.

```
  YGFlexDirection flexDirection() const { return flexDirection_; }
  BITFIELD_REF(flexDirection) flexDirection() { return {*this}; }
```

I'm not sure what's the "proper" way to address this issue. It seems a bit invasive to change the type of all enums and I'm not sure if there are any other concerns (I've seen ABI stability mentioned occasionally in yoga context).

I'm open to suggestions/concerns. I haven't been using C++ much and I might have misunderstood something.

### Minimal repro

```obj-c++
#include <iostream>
#import <Foundation/Foundation.h>

typedef NS_ENUM(int, YGFlexDirection) {
    YGFlexDirectionRow,
    YGFlexDirectionRowReverse,
    YGFlexDirectionColumn,
    YGFlexDirectionColumnReverse,
};

struct ClassWithBitfields {
    YGFlexDirection direction: 2;
};

int main(int argc, const char * argv[]) {
    ClassWithBitfields instance;
    // This line produces a warning:
    // Implicit truncation from 'YGFlexDirection' to bit-field changes value from 2 to -2
    instance.direction = YGFlexDirectionColumn;
}
```
## Changelog

[Internal] [Fixed] - Fixed conversion errors between bitfields and enums in yoga

## Test Plan

Build and run RNTester with fabric enabled. The result probably differs between targets and compilers.