### PR TITLE
Deeplink url error will not handled

### DIFF
--- a/Libraries/Components/WebView/WebView.ios.js
+++ b/Libraries/Components/WebView/WebView.ios.js
@@ -496,7 +496,7 @@ class WebView extends React.Component {
       );
       shouldStart = shouldStart && passesWhitelist;
       if (!passesWhitelist) {
-        Linking.openURL(url);
+         Linking.openURL(url).catch(err => this.props.onError && this.props.onError(err));
       }
       if (this.props.onShouldStartLoadWithRequest) {
         shouldStart =

--- a/Libraries/Components/WebView/WebView.ios.js
+++ b/Libraries/Components/WebView/WebView.ios.js
@@ -496,7 +496,9 @@ class WebView extends React.Component {
       );
       shouldStart = shouldStart && passesWhitelist;
       if (!passesWhitelist) {
-         Linking.openURL(url).catch(err => this.props.onError && this.props.onError(err));
+        Linking.openURL(url).catch(
+          err => this.props.onError && this.props.onError(err),
+        );
       }
       if (this.props.onShouldStartLoadWithRequest) {
         shouldStart =


### PR DESCRIPTION
when url that open another app like open app store url (https://apps.apple.com/in/app/facebook/id284882215). webview not able to handle error

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[CATEGORY] [TYPE] - Message

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
