### PR TITLE
iOS build - en0 and en1 used when generating ip.txt file

### DIFF
--- a/scripts/react-native-xcode.sh
+++ b/scripts/react-native-xcode.sh
@@ -16,7 +16,10 @@ DEST=$CONFIGURATION_BUILD_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH
 if [[ "$CONFIGURATION" = *Debug* && ! "$PLATFORM_NAME" == *simulator ]]; then
   IP=$(ipconfig getifaddr en0)
   if [ -z "$IP" ]; then
-    IP=$(ifconfig | grep 'inet ' | grep -v ' 127.' | cut -d\   -f2  | awk 'NR==1{print $1}')
+    IP=$(ipconfig getifaddr en1)
+  fi
+  if [ -z "$IP" ]; then
+    IP=$(ifconfig | grep 'inet ' | grep -v ' 127.' | grep -v ' 169.254.' |cut -d\   -f2  | awk 'NR==1{print $1}')
   fi
 
   echo "$IP" > "$DEST/ip.txt"


### PR DESCRIPTION
## Summary

When `en0` is not assigned and `en1` is in use along with another interface present on the machine that uses a self-assigned address (169.254.xxx.xxx), the ip.txt file contains the self-assigned address. This causes the app reload/debug actions to fail when deployed to a physical device. see #25460

Code change looks at the value assigned to `en1` if `en0` is not set. If `en1` is not available on the machine or not set, then it will be empty. If both `en0` and `en1` are not set, the existing code was modified exclude addresses that are self-assigned, as they will most likely be unavailable to the connected device (iPhone, iPad, etc.).

## Changelog

[Internal] [Fixed] - en0 and en1 are used when generating the ip.txt file for iOS device debug builds

## Test Plan

execute `ifconfig`:

```
lo0: flags=8049<UP,LOOPBACK,RUNNING,MULTICAST> mtu 16384
	options=1203<RXCSUM,TXCSUM,TXSTATUS,SW_TIMESTAMP>
	inet 127.0.0.1 netmask 0xff000000 
	inet6 ::1 prefixlen 128 
	inet6 fe80::1%lo0 prefixlen 64 scopeid 0x1 
	nd6 options=201<PERFORMNUD,DAD>
gif0: flags=8010<POINTOPOINT,MULTICAST> mtu 1280
stf0: flags=0<> mtu 1280
XHC20: flags=0<> mtu 0
XHC0: flags=0<> mtu 0
en0: flags=8863<UP,BROADCAST,SMART,RUNNING,SIMPLEX,MULTICAST> mtu 1500
	options=10b<RXCSUM,TXCSUM,VLAN_HWTAGGING,AV>
	ether 38:f9:d3:0d:aa:fe 
	nd6 options=201<PERFORMNUD,DAD>
	media: autoselect (none)
	status: inactive
en2: flags=8963<UP,BROADCAST,SMART,RUNNING,PROMISC,SIMPLEX,MULTICAST> mtu 1500
	options=60<TSO4,TSO6>
	ether 42:00:84:a8:f6:00 
	media: autoselect <full-duplex>
	status: inactive
en3: flags=8963<UP,BROADCAST,SMART,RUNNING,PROMISC,SIMPLEX,MULTICAST> mtu 1500
	options=60<TSO4,TSO6>
	ether 42:00:84:a8:f6:01 
	media: autoselect <full-duplex>
	status: active
bridge0: flags=8863<UP,BROADCAST,SMART,RUNNING,SIMPLEX,MULTICAST> mtu 1500
	options=63<RXCSUM,TXCSUM,TSO4,TSO6>
	ether 42:00:84:a8:f6:00 
	inet6 fe80::e:80be:b322:79b7%bridge0 prefixlen 64 secured scopeid 0x9 
	inet 169.254.209.63 netmask 0xffff0000 broadcast 169.254.255.255
	Configuration:
		id 0:0:0:0:0:0 priority 0 hellotime 0 fwddelay 0
		maxage 0 holdcnt 0 proto stp maxaddr 100 timeout 1200
		root id 0:0:0:0:0:0 priority 0 ifcost 0 port 0
		ipfilter disabled flags 0x2
	member: en2 flags=3<LEARNING,DISCOVER>
	        ifmaxaddr 0 port 7 priority 0 path cost 0
	member: en3 flags=3<LEARNING,DISCOVER>
	        ifmaxaddr 0 port 8 priority 0 path cost 0
	nd6 options=201<PERFORMNUD,DAD>
	media: autoselect
	status: active
ap1: flags=8802<BROADCAST,SIMPLEX,MULTICAST> mtu 1500
	ether 3a:f9:d3:9a:14:05 
	media: autoselect
	status: inactive
en1: flags=8863<UP,BROADCAST,SMART,RUNNING,SIMPLEX,MULTICAST> mtu 1500
	ether 38:f9:d3:9a:14:05 
	inet6 fe80::1444:113e:d65:5fb3%en1 prefixlen 64 secured scopeid 0xb 
	inet 192.168.1.115 netmask 0xffffff00 broadcast 192.168.1.255
	nd6 options=201<PERFORMNUD,DAD>
	media: autoselect
	status: active
p2p0: flags=8843<UP,BROADCAST,RUNNING,SIMPLEX,MULTICAST> mtu 2304
	ether 0a:f9:d3:9a:14:05 
	media: autoselect
	status: inactive
awdl0: flags=8943<UP,BROADCAST,RUNNING,PROMISC,SIMPLEX,MULTICAST> mtu 1484
	ether 6a:fe:9d:f0:39:3f 
	inet6 fe80::68fe:9dff:fef0:393f%awdl0 prefixlen 64 scopeid 0xd 
	nd6 options=201<PERFORMNUD,DAD>
	media: autoselect
	status: active
utun0: flags=8051<UP,POINTOPOINT,RUNNING,MULTICAST> mtu 2000
	inet6 fe80::c992:4ed:9399:85bc%utun0 prefixlen 64 scopeid 0xe 
	nd6 options=201<PERFORMNUD,DAD>
utun1: flags=8051<UP,POINTOPOINT,RUNNING,MULTICAST> mtu 1380
	inet6 fe80::f5de:860a:fd07:ee87%utun1 prefixlen 64 scopeid 0xf 
	nd6 options=201<PERFORMNUD,DAD>
utun2: flags=8051<UP,POINTOPOINT,RUNNING,MULTICAST> mtu 1380
	inet6 fe80::3115:b6a0:6625:23ee%utun2 prefixlen 64 scopeid 0x11 
	nd6 options=201<PERFORMNUD,DAD>
en5: flags=8863<UP,BROADCAST,SMART,RUNNING,SIMPLEX,MULTICAST> mtu 1500
	ether e2:33:8e:95:93:9b 
	inet6 fe80::cea:8f7a:b379:ebcd%en5 prefixlen 64 secured scopeid 0x10 
	inet 169.254.167.11 netmask 0xffff0000 broadcast 169.254.255.255
	nd6 options=201<PERFORMNUD,DAD>
	media: autoselect (100baseTX <full-duplex>)
	status: active
```

execute `ipconfig getifaddr en0`:  (produces nothing)

execute `ipconfig getifaddr en1`:
```
192.168.1.115
```

execute `ipconfig getifaddr en99`:  (produces nothing - non-existent case)

existing code `ifconfig | grep 'inet ' | grep -v ' 127.' | cut -d\   -f2  | awk 'NR==1{print $1}'` yields:

```
169.254.209.63
```

modified code ` ifconfig | grep 'inet ' | grep -v ' 127.' | grep -v ' 169.254.' | cut -d\   -f2  | awk 'NR==1{print $1}'` yields:

```
192.168.1.115
```


