### PR TITLE
Fresh RN projects fails ESLint / Prettier by default

### DIFF
--- a/template/_prettierrc.js
+++ b/template/_prettierrc.js
@@ -1,0 +1,6 @@
+module.exports = {
+  'singleQuote': true,
+  'trailingComma': 'all',
+  'bracketSpacing': false,
+  'jsxBracketSameLine': true,
+};

--- a/template/_prettierrc.js
+++ b/template/_prettierrc.js
@@ -1,6 +1,6 @@
 module.exports = {
-  'singleQuote': true,
-  'trailingComma': 'all',
-  'bracketSpacing': false,
-  'jsxBracketSameLine': true,
+  bracketSpacing: false,
+  jsxBracketSameLine: true,
+  singleQuote: true,
+  trailingComma: 'all',
 };


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
Fixes #25477

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

This PR adds a `.prettierrc.js` config file to the HelloWorld template.

`eslint-config-react-native-community` includes custom settings for some rules which conflict with Prettier's default settings.

Consequently, if you run `eslint` immediately after scaffolding a new app you get errors (see linked issue).

This PR configures Prettier to be compatible with both the existing ESLint config and the existing project template (with no code changes to the latter).

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[General] [Changed] - Added a default Prettier config for new projects

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

- The following screenshots show the output of `yarn lint` before and after these changes
- These were run immediate after running `npx react-native-cli init RN060`

### Without these changes

- Linting errors on new projects
- Unfixable automatically due to conflicting rules
<img width="1116" alt="Screenshot 2019-07-03 at 17 44 55" src="https://user-images.githubusercontent.com/2393035/60610078-f6b44d00-9dba-11e9-826f-1524b949e4fd.png">
<img width="1116" alt="Screenshot 2019-07-03 at 17 45 07" src="https://user-images.githubusercontent.com/2393035/60610085-fb790100-9dba-11e9-9a9c-33f4cfefd51e.png">

### With these changes

- Brand new projects will not produce lint errors out of the box
<img width="1116" alt="Screenshot 2019-07-03 at 17 48 25" src="https://user-images.githubusercontent.com/2393035/60610266-57dc2080-9dbb-11e9-8a55-fd09f3549c17.png">
