### PR TITLE
Set minimum width and height for views

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
@@ -38,6 +38,8 @@ public abstract class BaseViewManager<T extends View, C extends LayoutShadowNode
   private static final String PROP_TRANSFORM = "transform";
   private static final String PROP_ELEVATION = "elevation";
   private static final String PROP_Z_INDEX = "zIndex";
+  private static final String PROP_MIN_WIDTH = ViewProps.MIN_WIDTH;
+  private static final String PROP_MIN_HEIGHT = ViewProps.MIN_HEIGHT;
   private static final String PROP_RENDER_TO_HARDWARE_TEXTURE = "renderToHardwareTextureAndroid";
   private static final String PROP_ACCESSIBILITY_LABEL = "accessibilityLabel";
   private static final String PROP_ACCESSIBILITY_HINT = "accessibilityHint";
@@ -116,6 +118,16 @@ public abstract class BaseViewManager<T extends View, C extends LayoutShadowNode
     if (parent instanceof ReactZIndexedViewGroup) {
       ((ReactZIndexedViewGroup) parent).updateDrawingOrder();
     }
+  }
+
+  @ReactProp(name = PROP_MIN_WIDTH)
+  public void setMinWidth(@Nonnull T view, int minWidth) {
+    view.setMinimumWidth((int) PixelUtil.toPixelFromDIP(minWidth));
+  }
+
+  @ReactProp(name = PROP_MIN_HEIGHT)
+  public void setMinHeight(@Nonnull T view, int minHeight) {
+    view.setMinimumHeight((int) PixelUtil.toPixelFromDIP(minHeight));
   }
 
   @ReactProp(name = PROP_RENDER_TO_HARDWARE_TEXTURE)


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
This can help when creating custom ViewGroups (in native modules).
For example: images need to have size in order to be shown, and if the minimum size (width\height) is not set their size is 0.

## Changelog
[Android] [Added] - add `setMinWidth` and `setMinHeight` to `BaseViewManager`.

[CATEGORY] [TYPE] - Message

## Test Plan

