### PR TITLE
Move inline static styles at VirtualizedList to StyleSheet.create

### DIFF
--- a/Libraries/Lists/VirtualizedList.js
+++ b/Libraries/Lists/VirtualizedList.js
@@ -1849,10 +1849,10 @@ class CellRenderer extends React.Component<
     );
     const cellStyle = inversionStyle
       ? horizontal
-        ? [{flexDirection: 'row-reverse'}, inversionStyle]
-        : [{flexDirection: 'column-reverse'}, inversionStyle]
+        ? [styles.rowReverse, inversionStyle]
+        : [styles.columnReverse, inversionStyle]
       : horizontal
-      ? [{flexDirection: 'row'}, inversionStyle]
+      ? [styles.row, inversionStyle]
       : inversionStyle;
     if (!CellRendererComponent) {
       return (
@@ -1906,6 +1906,15 @@ const styles = StyleSheet.create({
   },
   horizontallyInverted: {
     transform: [{scaleX: -1}],
+  },
+  row: {
+    flexDirection: 'row',
+  },
+  rowReverse: {
+    flexDirection: 'row-reverse',
+  },
+  columnReverse: {
+    flexDirection: 'column-reverse',
   },
   debug: {
     flex: 1,


### PR DESCRIPTION
## Summary

I know StyleSheet.create doesn’t do anything special on react-native yet but it does on react-native-web and possibly other targets.

This small change is mainly so react-native-web don’t need to keep making this change on their code base when updating the rn version. 

## Changelog

[Internal] [Changed] - Move inline static styles at VirtualizedList to StyleSheet.create

## Test Plan

It’s basically the same code, just moved. 
Also it’s the same change that it’s on react-native-web project: https://github.com/necolas/react-native-web/blob/45f94eb43daa3cb3d7fae0295877345a176c04c4/packages/react-native-web/src/vendor/react-native/VirtualizedList/index.js#L1650-L1654 