### PR TITLE
Remove unnecessary flag when running JS server

### DIFF
--- a/scripts/launchPackager.bat
+++ b/scripts/launchPackager.bat
@@ -6,6 +6,7 @@
 @echo off
 title Metro Bundler
 call .packager.bat
+cd ../../../
 node "%~dp0..\cli.js" start
 pause
 exit

--- a/scripts/launchPackager.bat
+++ b/scripts/launchPackager.bat
@@ -6,6 +6,6 @@
 @echo off
 title Metro Bundler
 call .packager.bat
-node "%~dp0..\cli.js" --projectRoot ../../../ start
+node "%~dp0..\cli.js" start
 pause
 exit


### PR DESCRIPTION
## Summary
This removes the `--projectRoot` flag in `launchPackager.bat` as it was removed,  fixing [this bundler not opening issue on cli repo](https://github.com/react-native-community/cli/issues/484) when `yarn react-native run-android` is run. 

This is Windows related only so should be only tested on Windows.

## Changelog

[Internal] [Fixed] - Fixed Metro Bundler not opening when running `yarn react-native run-android`

## Test Plan
1. Create a new repo using `react-native init`
2. Edit the `launchPackager.bat` file
3. Run `yarn react-native run-android`
