### PR TITLE
[Android][TextInput] Update types for autoComplete prop.

### DIFF
--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -227,7 +227,7 @@ type IOSProps = $ReadOnly<{|
 |}>;
 
 type AndroidProps = $ReadOnly<{|
-  autoCompleteType?: ?(
+  autoComplete?: ?(
     | 'cc-csc'
     | 'cc-exp'
     | 'cc-exp-month'
@@ -464,7 +464,7 @@ const TextInput = createReactClass({
      *
      * @platform android
      */
-    autoCompleteType: PropTypes.oneOf([
+    autoComplete: PropTypes.oneOf([
       'cc-csc',
       'cc-exp',
       'cc-exp-month',

--- a/Libraries/Components/TextInput/TextInput.js
+++ b/Libraries/Components/TextInput/TextInput.js
@@ -227,7 +227,7 @@ type IOSProps = $ReadOnly<{|
 |}>;
 
 type AndroidProps = $ReadOnly<{|
-  autoComplete?: ?(
+  autoCompleteType?: ?(
     | 'cc-csc'
     | 'cc-exp'
     | 'cc-exp-month'
@@ -464,7 +464,7 @@ const TextInput = createReactClass({
      *
      * @platform android
      */
-    autoComplete: PropTypes.oneOf([
+    autoCompleteType: PropTypes.oneOf([
       'cc-csc',
       'cc-exp',
       'cc-exp-month',

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
@@ -591,7 +591,7 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
     view.setFilters(newFilters);
   }
 
-  @ReactProp(name = "autoComplete")
+  @ReactProp(name = "autoCompleteType")
   public void setTextContentType(ReactEditText view, @Nullable String autocomplete) {
     if (autocomplete == null) {
       setImportantForAutofill(view, View.IMPORTANT_FOR_AUTOFILL_NO);

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
@@ -592,38 +592,38 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
   }
 
   @ReactProp(name = "autoCompleteType")
-  public void setTextContentType(ReactEditText view, @Nullable String autocomplete) {
-    if (autocomplete == null) {
+  public void setTextContentType(ReactEditText view, @Nullable String autoCompleteType) {
+    if (autoCompleteType == null) {
       setImportantForAutofill(view, View.IMPORTANT_FOR_AUTOFILL_NO);
-    } else if ("username".equals(autocomplete)) {
+    } else if ("username".equals(autoCompleteType)) {
       setAutofillHints(view, View.AUTOFILL_HINT_USERNAME);
-    } else if ("password".equals(autocomplete)) {
+    } else if ("password".equals(autoCompleteType)) {
       setAutofillHints(view, View.AUTOFILL_HINT_PASSWORD);
-    } else if ("email".equals(autocomplete)) {
+    } else if ("email".equals(autoCompleteType)) {
       setAutofillHints(view, View.AUTOFILL_HINT_EMAIL_ADDRESS);
-    } else if ("name".equals(autocomplete)) {
+    } else if ("name".equals(autoCompleteType)) {
       setAutofillHints(view, View.AUTOFILL_HINT_NAME);
-    } else if ("tel".equals(autocomplete)) {
+    } else if ("tel".equals(autoCompleteType)) {
       setAutofillHints(view, View.AUTOFILL_HINT_PHONE);
-    } else if ("street-address".equals(autocomplete)) {
+    } else if ("street-address".equals(autoCompleteType)) {
       setAutofillHints(view, View.AUTOFILL_HINT_POSTAL_ADDRESS);
-    } else if ("postal-code".equals(autocomplete)) {
+    } else if ("postal-code".equals(autoCompleteType)) {
       setAutofillHints(view, View.AUTOFILL_HINT_POSTAL_CODE);
-    } else if ("cc-number".equals(autocomplete)) {
+    } else if ("cc-number".equals(autoCompleteType)) {
       setAutofillHints(view, View.AUTOFILL_HINT_CREDIT_CARD_NUMBER);
-    } else if ("cc-csc".equals(autocomplete)) {
+    } else if ("cc-csc".equals(autoCompleteType)) {
       setAutofillHints(view, View.AUTOFILL_HINT_CREDIT_CARD_SECURITY_CODE);
-    } else if ("cc-exp".equals(autocomplete)) {
+    } else if ("cc-exp".equals(autoCompleteType)) {
       setAutofillHints(view, View.AUTOFILL_HINT_CREDIT_CARD_EXPIRATION_DATE);
-    } else if ("cc-exp-month".equals(autocomplete)) {
+    } else if ("cc-exp-month".equals(autoCompleteType)) {
       setAutofillHints(view, View.AUTOFILL_HINT_CREDIT_CARD_EXPIRATION_MONTH);
-    } else if ("cc-exp-year".equals(autocomplete)) {
+    } else if ("cc-exp-year".equals(autoCompleteType)) {
       setAutofillHints(view, View.AUTOFILL_HINT_CREDIT_CARD_EXPIRATION_YEAR);
-    } else if ("off".equals(autocomplete)) {
+    } else if ("off".equals(autoCompleteType)) {
       setImportantForAutofill(view, View.IMPORTANT_FOR_AUTOFILL_NO);
     } else {
       throw new JSApplicationIllegalArgumentException(
-          "Invalid autocomplete option: " + autocomplete);
+          "Invalid autoCompleteType: " + autoCompleteType);
     }
   }
 


### PR DESCRIPTION
## Summary

I believe there's a mismatch between the type definitions and the expected prop in Android for `TextInput`'s `autoComplete` prop.

* Android is expecting `autoComplete`.
* JS types are expecting `autoCompleteType`.
* Latest documentation documents `autoCompleteType`.

Prop added here: https://github.com/facebook/react-native/commit/179d490607620a988a53aacb01031ed300d4ac66

This change updates the JS types to match what Android is expecting (`autoComplete`). Can update documentation if this is the approach we'd prefer (rather than updating Android to expect `autoCompleteType`).


## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[Javascript] [Fixed] - Update types for `TextInput`'s `autoComplete` prop.

## Test Plan

Before:

* Pass invalid value to `TextInput`'s `autoComplete` prop, see no type errors on JS side, and Android blows up with:

```sh
Invalid autocomplete option: foobar
updateViewProp
    ViewManagersPropertyCache.java:95
setProperty
    ViewManagerPropertyUpdater.java:132
updateProps
    ViewManagerPropertyUpdater.java:51
updateProperties
    ViewManager.java:37
```

After:

* Pass invalid value to `TextInput`'s `autoComplete` prop, see PropType warning for `autoComplete` prop.
