### PR TITLE
Add jetifier to the template to ease migration to Android X

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "scripts": {
     "start": "react-native start",
-    "test": "jest"
+    "test": "jest",
+    "postinstall": "jetify"
   },
   "dependencies": {
     "react": "16.8.1",
@@ -16,6 +17,7 @@
     "@react-native-community/eslint-config": "^0.0.3",
     "babel-jest": "^24.1.0",
     "jest": "^24.1.0",
+    "jetifier": "^1.6.2",
     "metro-react-native-babel-preset": "^0.51.1",
     "react-test-renderer": "16.8.1"
   },


### PR DESCRIPTION
Currently the ecosystem is going through a lot of churn due to the Android X upgrade as lots of third party modules are not updated to use Android X yet. Adding `jetifier` to the default template makes this automatic during the migration period.