### PR TITLE
[iOS] Fixes animated gifs incorrectly looping

### DIFF
--- a/Libraries/Image/RCTAnimatedImage.m
+++ b/Libraries/Image/RCTAnimatedImage.m
@@ -87,6 +87,10 @@
     NSNumber *gifLoopCount = gifProperties[(__bridge NSString *)kCGImagePropertyGIFLoopCount];
     if (gifLoopCount != nil) {
       loopCount = gifLoopCount.unsignedIntegerValue;
+      // A loop count of 1 means it should repeat twice, 2 means, thrice, etc.
+      if (loopCount != 0) {
+        loopCount++;
+      }
     }
   }
   return loopCount;


### PR DESCRIPTION
## Summary

[After migrate to new GIF implementation](https://github.com/facebook/react-native/pull/24822), we need to do some cleanup, before, we already unify the gif loop count between iOS and Android, more details please see https://github.com/facebook/react-native/pull/21999, so let's unify it again.

## Changelog

[iOS] [Fixed] - Fixes animated gifs incorrectly looping

## Test Plan
 example gif should repeat playback twice.
```
        <Image
          style={styles.gif}
          source={{uri: "https://user-images.githubusercontent.com/475235/47662061-77011f00-db57-11e8-904f-a1824912ace9.gif"}}
        />
```
