### PR TITLE
Add package.json scripts ro run android and ios in template

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -3,9 +3,9 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
-    "start": "react-native start",
     "android": "react-native run-android",
     "ios": "react-native run-ios",
+    "start": "react-native start",
     "test": "jest"
   },
   "dependencies": {

--- a/template/package.json
+++ b/template/package.json
@@ -4,6 +4,8 @@
   "private": true,
   "scripts": {
     "start": "react-native start",
+    "android": "react-native run-android",
+    "ios": "react-native run-ios",
     "test": "jest"
   },
   "dependencies": {


### PR DESCRIPTION
Currently users have to use the global `react-native` command or run `yarn react-native run-x` which isn't very nice.

This PR adds `android` and `ios` scripts to `package.json` so users can run `yarn android` or `yarn ios` directly.