### PR TITLE
[CI] Test collection step should not fail if unit tests fail

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -500,7 +500,9 @@ jobs:
             find . -type f -regex ".*/build/test-results/debug/.*xml" -exec cp {} ~/reports/build/ \;
             find . -type f -regex ".*/outputs/androidTest-results/connected/.*xml" -exec cp {} ~/reports/outputs/ \;
             find . -type f -regex ".*/buck-out/gen/ReactAndroid/src/test/.*/.*xml" -exec cp {} ~/reports/buck/ \;
-            ~/okbuck/tooling/junit/buck_to_junit.sh ~/reports/buck/all-results-raw.xml ~/reports/junit/all-results-junit.xml
+            if [ -f ~/react-native/reports/buck/all-results-raw.xml ]; then
+              ./tooling/junit/buck_to_junit.sh ~/react-native/reports/buck/all-results-raw.xml ~/react-native/reports/junit/all-results-junit.xml
+            fi
           when: always
 
       - store_test_results:


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

This is a quick change to avoid having "Collect Test Results" fail on `test_android` when unit tests have not run. If the raw Buck results are not available, avoid running the buck-to-junit conversion tool.

You can find an example of the situation we want to avoid here: https://circleci.com/gh/facebook/react-native/101397?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link


<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[Internal] [Changed] - Do not fail test collection step when unit tests fail

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Verified on macOS + bash, the conditional will fail if all-results-raw.xml does not exist.