### PR TITLE
Fix typo in Virtualized List's maxToRenderPerBatch

### DIFF
--- a/Libraries/Lists/VirtualizedList.js
+++ b/Libraries/Lists/VirtualizedList.js
@@ -160,7 +160,7 @@ type OptionalProps = {
   listKey?: string,
   /**
    * The maximum number of items to render in each incremental render batch. The more rendered at
-   * once, the better the fill rate, but responsiveness my suffer because rendering content may
+   * once, the better the fill rate, but responsiveness may suffer because rendering content may
    * interfere with responding to button taps or other interactions.
    */
   maxToRenderPerBatch: number,


### PR DESCRIPTION
## Summary
I was reading upon the `maxToRenderPerBatch`'s docs when I found the typo. Checked the [documentation website](https://facebook.github.io/react-native/docs/virtualizedlist#maxtorenderperbatch) and seems correct there. Found this when I hovered cursor over that prop in VSCode.

## Changelog
[General] [Fixed] - Fixed typo in `VirtualizedList#maxToRenderPerBatch`

## Test Plan
Ran `npm test` (and `npm run lint`).

<img width="1345" alt="Screen Shot 2019-07-13 at 12 54 31 AM" src="https://user-images.githubusercontent.com/19292575/61168992-3c83ba80-a50b-11e9-8db3-7e15b4a3b2f9.png">
