### PR TITLE
[iOS] Remove old GIF code

### DIFF
--- a/Libraries/Image/RCTImageLoader.h
+++ b/Libraries/Image/RCTImageLoader.h
@@ -52,8 +52,6 @@ typedef dispatch_block_t RCTImageLoaderCancellationBlock;
 
 @interface UIImage (React)
 
-@property (nonatomic, copy) CAKeyframeAnimation *reactKeyframeAnimation;
-
 /**
  * Memory bytes of the image with the default calculation of static image or GIF. Custom calculations of decoded bytes can be assigned manually.
  */

--- a/Libraries/Image/RCTImageLoader.m
+++ b/Libraries/Image/RCTImageLoader.m
@@ -22,26 +22,11 @@
 
 static NSInteger RCTImageBytesForImage(UIImage *image)
 {
-  CAKeyframeAnimation *keyFrameAnimation = [image reactKeyframeAnimation];
   NSInteger singleImageBytes = image.size.width * image.size.height * image.scale * image.scale * 4;
-  if (keyFrameAnimation) {
-    return keyFrameAnimation.values.count * singleImageBytes;
-  } else {
-    return image.images ? image.images.count * singleImageBytes : singleImageBytes;
-  }
+  return image.images ? image.images.count * singleImageBytes : singleImageBytes;
 }
 
 @implementation UIImage (React)
-
-- (CAKeyframeAnimation *)reactKeyframeAnimation
-{
-  return objc_getAssociatedObject(self, _cmd);
-}
-
-- (void)setReactKeyframeAnimation:(CAKeyframeAnimation *)reactKeyframeAnimation
-{
-  objc_setAssociatedObject(self, @selector(reactKeyframeAnimation), reactKeyframeAnimation, OBJC_ASSOCIATION_COPY_NONATOMIC);
-}
 
 - (NSInteger)reactDecodedImageBytes
 {
@@ -280,11 +265,9 @@ static UIImage *RCTResizeImageIfNeeded(UIImage *image,
       CGSizeEqualToSize(image.size, size)) {
     return image;
   }
-  CAKeyframeAnimation *animation = image.reactKeyframeAnimation;
   CGRect targetSize = RCTTargetRect(image.size, size, scale, resizeMode);
   CGAffineTransform transform = RCTTransformFromTargetRect(image.size, targetSize);
   image = RCTTransformImage(image, size, scale, transform);
-  image.reactKeyframeAnimation = animation;
   return image;
 }
 

--- a/Libraries/Image/RCTImageView.m
+++ b/Libraries/Image/RCTImageView.m
@@ -225,7 +225,6 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithFrame:(CGRect)frame)
 - (void)clearImage
 {
   [self cancelImageLoad];
-  [_imageView.layer removeAnimationForKey:@"contents"];
   self.image = nil;
   _imageSource = nil;
 }
@@ -364,7 +363,6 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithFrame:(CGRect)frame)
       self->_pendingImageSource = nil;
     }
 
-    [self->_imageView.layer removeAnimationForKey:@"contents"];
     self.image = image;
 
     if (isPartialLoad) {

--- a/Libraries/Image/RCTImageView.m
+++ b/Libraries/Image/RCTImageView.m
@@ -365,17 +365,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithFrame:(CGRect)frame)
     }
 
     [self->_imageView.layer removeAnimationForKey:@"contents"];
-    if (image.reactKeyframeAnimation) {
-      CGImageRef posterImageRef = (__bridge CGImageRef)[image.reactKeyframeAnimation.values firstObject];
-      if (!posterImageRef) {
-        return;
-      }
-      // Apply renderingMode to animated image.
-      self->_imageView.image = [[UIImage imageWithCGImage:posterImageRef] imageWithRenderingMode:self->_renderingMode];
-      [self->_imageView.layer addAnimation:image.reactKeyframeAnimation forKey:@"contents"];
-    } else {
-      self.image = image;
-    }
+    self.image = image;
 
     if (isPartialLoad) {
       if (self->_onPartialLoad) {

--- a/Libraries/Image/RCTUIImageViewAnimated.m
+++ b/Libraries/Image/RCTUIImageViewAnimated.m
@@ -85,11 +85,11 @@ static NSUInteger RCTDeviceFreeMemory() {
   if (self.image == image) {
     return;
   }
+  
+  [self stop];
+  [self resetAnimatedImage];
 
   if ([image respondsToSelector:@selector(animatedImageFrameAtIndex:)]) {
-    [self stop];
-    [self resetAnimatedImage];
-    
     NSUInteger animatedImageFrameCount = ((UIImage<RCTAnimatedImage> *)image).animatedImageFrameCount;
     
     // Check the frame count


### PR DESCRIPTION
## Summary

[After we migrated to new GIF implementation](https://github.com/facebook/react-native/pull/24822), we can remove old implementation now.

## Changelog

[iOS] [Deprecated] - Remove old GIF code

## Test Plan

GIF still works.