### PR TITLE
bump gradle-download-task to 4.0.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ buildscript {
     }
     dependencies {
         classpath("com.android.tools.build:gradle:3.4.2")
-        classpath("de.undercouch:gradle-download-task:3.4.3")
+        classpath("de.undercouch:gradle-download-task:4.0.0")
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
## Summary

bump gradle-download-task to 4.0.0, works best and tests with Gradle 5.x.

## Changelog

[Android] [Changed] - bump gradle-download-task to 4.0.0

## Test Plan

RNTester builds and runs as expected