### PR TITLE
fix Android CI

### DIFF
--- a/tools/build_defs/oss/rn_defs.bzl
+++ b/tools/build_defs/oss/rn_defs.bzl
@@ -179,6 +179,7 @@ def rn_plugin_apple_library(**kwargs):
     native.apple_library(**kwargs)
 
 def rn_java_library(*args, **kwargs):
+    is_androidx = kwargs.pop("is_androidx", False)
     native.java_library(*args, **kwargs)
 
 def rn_java_annotation_processor(*args, **kwargs):


### PR DESCRIPTION
## Summary

This PR adds dummy **is_androidx** option to **rn_java_library** buck rule, and fix feature parity with FB.

## Changelog

[Android] [Changed] - add is_androidx option to rn_java_library buck rule

## Test Plan

Android CI is green