### PR TITLE
Add e2e tests skeleton for generated cpp code

### DIFF
--- a/packages/react-native-codegen/BUCK
+++ b/packages/react-native-codegen/BUCK
@@ -38,6 +38,7 @@ fb_native.genrule(
     srcs = glob(
         [
             "**/e2e/__test_fixtures__/*NativeComponent.js",
+            "**/e2e/__test_fixtures__/Native*.js",
         ],
     ),
     cmd = "$(exe fbsource//xplat/js/react-native-github/packages/react-native-codegen:write_to_json) $OUT $SRCS",
@@ -66,6 +67,7 @@ fb_xplat_cxx_binary(
     visibility = ["PUBLIC"],
     deps = [
         ":generated_components-codegen_tests",
+        ":generated_modules-codegen_tests",
     ],
 )
 
@@ -89,6 +91,7 @@ rn_xplat_cxx_library(
     ],
     deps = [
         ":generated_components-codegen_tests",
+        ":generated_modules-codegen_tests",
     ],
 )
 

--- a/packages/react-native-codegen/buck_tests/emptyFile.cpp
+++ b/packages/react-native-codegen/buck_tests/emptyFile.cpp
@@ -1,4 +1,6 @@
 #import <react/components/codegen_tests/ComponentDescriptors.h>
+#import <react/modules/codegen_tests/NativeModules.h>
+#import <react/modules/codegen_tests/NativeModules.cpp>
 
 // TODO: Import every prop and event to asset they're generated
 

--- a/packages/react-native-codegen/buck_tests/generate-tests.js
+++ b/packages/react-native-codegen/buck_tests/generate-tests.js
@@ -44,5 +44,14 @@ try {
 
 RNCodegen.generate(
   {libraryName, schema, outputDirectory},
-  {generators: ['descriptors', 'events', 'props', 'tests', 'shadow-nodes']},
+  {
+    generators: [
+      'descriptors',
+      'events',
+      'props',
+      'tests',
+      'shadow-nodes',
+      'modules',
+    ],
+  },
 );

--- a/packages/react-native-codegen/e2e/__test_fixtures__/NativeSampleTurboModule.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/NativeSampleTurboModule.js
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ */
+
+'use strict';
+
+import type {TurboModule} from 'react-native/Libraries/TurboModule/RCTExport';
+import * as TurboModuleRegistry from 'react-native/Libraries/TurboModule/TurboModuleRegistry';
+
+export interface Spec extends TurboModule {
+  // Exported methods.
+  +getConstants: () => {|
+    const1: boolean,
+    const2: number,
+    const3: string,
+  |};
+  +voidFunc: () => void;
+  +getBool: (arg: boolean) => boolean;
+  +getNumber: (arg: number) => number;
+  +getString: (arg: string) => string;
+  +getArray: (arg: Array<any>) => Array<any>;
+  +getObject: (arg: Object) => Object;
+  +getValue: (x: number, y: string, z: Object) => Object;
+  +getValueWithCallback: (callback: (value: string) => void) => void;
+  +getValueWithPromise: (error: boolean) => Promise<string>;
+}
+
+export default TurboModuleRegistry.getEnforcing<Spec>('SampleTurboModule');

--- a/packages/react-native-codegen/src/cli/combine/combine-js-to-schema.js
+++ b/packages/react-native-codegen/src/cli/combine/combine-js-to-schema.js
@@ -20,7 +20,8 @@ function combineSchemas(files: Array<string>): SchemaType {
       const contents = fs.readFileSync(filename, 'utf8');
       if (
         contents &&
-        /export\s+default\s+codegenNativeComponent</.test(contents)
+        (/export\s+default\s+codegenNativeComponent</.test(contents) ||
+          /extends TurboModule/.test(contents))
       ) {
         const schema = FlowParser.parseFile(filename);
 

--- a/packages/react-native-codegen/src/generators/RNCodegen.js
+++ b/packages/react-native-codegen/src/generators/RNCodegen.js
@@ -22,6 +22,8 @@ const generateEventEmitterCpp = require('./components/GenerateEventEmitterCpp.js
 const generateEventEmitterH = require('./components/GenerateEventEmitterH.js');
 const generatePropsCpp = require('./components/GeneratePropsCpp.js');
 const generatePropsH = require('./components/GeneratePropsH.js');
+const generateModuleH = require('./modules/GenerateModuleH.js');
+const generateModuleCpp = require('./modules/GenerateModuleCpp.js');
 const generateTests = require('./components/GenerateTests.js');
 const generateShadowNodeCpp = require('./components/GenerateShadowNodeCpp.js');
 const generateShadowNodeH = require('./components/GenerateShadowNodeH.js');
@@ -43,6 +45,7 @@ type Generators =
   | 'props'
   | 'tests'
   | 'shadow-nodes'
+  | 'modules'
   | 'view-configs';
 
 type Config = $ReadOnly<{|
@@ -54,6 +57,7 @@ const GENERATORS = {
   descriptors: [generateComponentDescriptorH.generate],
   events: [generateEventEmitterCpp.generate, generateEventEmitterH.generate],
   props: [generatePropsCpp.generate, generatePropsH.generate],
+  modules: [generateModuleCpp.generate, generateModuleH.generate],
   tests: [generateTests.generate],
   'shadow-nodes': [
     generateShadowNodeCpp.generate,

--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleH.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleH.js
@@ -19,9 +19,9 @@ import type {
 type FilesOutput = Map<string, string>;
 
 const moduleTemplate = `
-class JSI_EXPORT Native::_MODULE_NAME_::TurboCxxModuleSpecJSI : public TurboModule {
+class JSI_EXPORT Native::_MODULE_NAME_::SpecJSI : public TurboModule {
 protected:
-  Native::_MODULE_NAME_::TurboCxxModuleSpecJSI(std::shared_ptr<JSCallInvoker> jsInvoker);
+  Native::_MODULE_NAME_::SpecJSI(std::shared_ptr<JSCallInvoker> jsInvoker);
 
 public:
 ::_MODULE_PROPERTIES_::
@@ -38,7 +38,7 @@ const template = `
 
 #pragma once
 
-#include <jsireact/TurboModule.h>
+#include <ReactCommon/TurboModule.h>
 
 namespace facebook {
 namespace react {
@@ -137,7 +137,7 @@ module.exports = {
           .join('\n');
         return moduleTemplate
           .replace(/::_MODULE_PROPERTIES_::/g, traversedProperties)
-          .replace(/::_MODULE_NAME_::/g, name.slice(0, -11)) // FIXME
+          .replace(/::_MODULE_NAME_::/g, name)
           .replace('::_PROPERTIES_MAP_::', '');
       })
       .join('\n');

--- a/packages/react-native-codegen/src/generators/modules/__tests__/__snapshots__/GenerateModuleCpp-test.js.snap
+++ b/packages/react-native-codegen/src/generators/modules/__tests__/__snapshots__/GenerateModuleCpp-test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`GenerateModuleCpp can generate fixture EMPTY_NATIVE_MODULES 1`] = `
 Map {
-  "NativeModules.h" => "
+  "NativeModules.cpp" => "
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
@@ -10,19 +10,17 @@ Map {
  * LICENSE file in the root directory of this source tree.
  */
 
-#include \\"Native::_MODULE_NAME_::TurboCxxModuleSpecJSI.h\\"
+#include <react/modules/EMPTY_NATIVE_MODULES/NativeModules.h>
 
 namespace facebook {
 namespace react {
 
 
-​
 
-NativeSampleTurboCxxModuleSpecJSI::NativeSampleTurboCxxModuleSpecJSI(std::shared_ptr<JSCallInvoker> jsInvoker)
-  : TurboModule(\\"SampleTurboCxxModule\\", jsInvoker) {
+NativeSampleTurboModuleSpecJSI::NativeSampleTurboModuleSpecJSI(std::shared_ptr<JSCallInvoker> jsInvoker)
+  : TurboModule(\\"SampleTurboModule\\", jsInvoker) {
 
 }
-
 
 
 } // namespace react
@@ -33,7 +31,7 @@ NativeSampleTurboCxxModuleSpecJSI::NativeSampleTurboCxxModuleSpecJSI(std::shared
 
 exports[`GenerateModuleCpp can generate fixture SIMPLE_NATIVE_MODULES 1`] = `
 Map {
-  "NativeModules.h" => "
+  "NativeModules.cpp" => "
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
@@ -41,69 +39,59 @@ Map {
  * LICENSE file in the root directory of this source tree.
  */
 
-#include \\"Native::_MODULE_NAME_::TurboCxxModuleSpecJSI.h\\"
+#include <react/modules/SIMPLE_NATIVE_MODULES/NativeModules.h>
 
 namespace facebook {
 namespace react {
 
-
-
-static jsi::Value __hostFunction_NativeSampleTurboCxxModuleSpecJSI_getConstants(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboCxxModuleSpecJSI *>(&turboModule)->getConstants(rt);
+static jsi::Value __hostFunction_NativeSampleTurboModuleSpecJSI_getConstants(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
+  return static_cast<NativeSampleTurboModuleSpecJSI *>(&turboModule)->getConstants(rt);
 }
 
-static jsi::Value __hostFunction_NativeSampleTurboCxxModuleSpecJSI_voidFunc(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  static_cast<NativeSampleTurboCxxModuleSpecJSI *>(&turboModule)->voidFunc(rt);
+static jsi::Value __hostFunction_NativeSampleTurboModuleSpecJSI_voidFunc(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
+  static_cast<NativeSampleTurboModuleSpecJSI *>(&turboModule)->voidFunc(rt);
   return jsi::Value::undefined();
 }
-
-static jsi::Value __hostFunction_NativeSampleTurboCxxModuleSpecJSI_getBool(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboCxxModuleSpecJSI *>(&turboModule)->getBool(rt, args[0].getBool(rt));
+static jsi::Value __hostFunction_NativeSampleTurboModuleSpecJSI_getBool(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
+  return static_cast<NativeSampleTurboModuleSpecJSI *>(&turboModule)->getBool(rt, args[0].getBool());
+}
+static jsi::Value __hostFunction_NativeSampleTurboModuleSpecJSI_getNumber(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
+  return static_cast<NativeSampleTurboModuleSpecJSI *>(&turboModule)->getNumber(rt, args[0].getNumber());
+}
+static jsi::Value __hostFunction_NativeSampleTurboModuleSpecJSI_getString(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
+  return static_cast<NativeSampleTurboModuleSpecJSI *>(&turboModule)->getString(rt, args[0].getString(rt));
+}
+static jsi::Value __hostFunction_NativeSampleTurboModuleSpecJSI_getArray(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
+  return static_cast<NativeSampleTurboModuleSpecJSI *>(&turboModule)->getArray(rt, args[0].getObject(rt).getArray(rt));
+}
+static jsi::Value __hostFunction_NativeSampleTurboModuleSpecJSI_getObject(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
+  return static_cast<NativeSampleTurboModuleSpecJSI *>(&turboModule)->getObject(rt, args[0].getObject(rt));
+}
+static jsi::Value __hostFunction_NativeSampleTurboModuleSpecJSI_getValue(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
+  return static_cast<NativeSampleTurboModuleSpecJSI *>(&turboModule)->getValue(rt, args[0].getNumber(), args[1].getString(rt), args[2].getObject(rt));
 }
 
-static jsi::Value __hostFunction_NativeSampleTurboCxxModuleSpecJSI_getNumber(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboCxxModuleSpecJSI *>(&turboModule)->getNumber(rt, args[0].getNumber(rt));
-}
-
-static jsi::Value __hostFunction_NativeSampleTurboCxxModuleSpecJSI_getString(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboCxxModuleSpecJSI *>(&turboModule)->getString(rt, args[0].getString(rt));
-}
-
-static jsi::Value __hostFunction_NativeSampleTurboCxxModuleSpecJSI_getArray(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboCxxModuleSpecJSI *>(&turboModule)->getArray(rt, args[0].getObject(rt).getArray(rt));
-}
-
-static jsi::Value __hostFunction_NativeSampleTurboCxxModuleSpecJSI_getObject(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboCxxModuleSpecJSI *>(&turboModule)->getObject(rt, args[0].getObject(rt));
-}
-
-static jsi::Value __hostFunction_NativeSampleTurboCxxModuleSpecJSI_getValue(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboCxxModuleSpecJSI *>(&turboModule)->getValue(rt, args[0].getNumber(rt), args[1].getString(rt), args[2].getObject(rt));
-}
-
-static jsi::Value __hostFunction_NativeSampleTurboCxxModuleSpecJSI_getValueWithCallback(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  static_cast<NativeSampleTurboCxxModuleSpecJSI *>(&turboModule)->getValueWithCallback(rt, std::move(args[0].getObject(rt).getFunction(rt)));
+static jsi::Value __hostFunction_NativeSampleTurboModuleSpecJSI_getValueWithCallback(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
+  static_cast<NativeSampleTurboModuleSpecJSI *>(&turboModule)->getValueWithCallback(rt, std::move(args[0].getObject(rt).getFunction(rt)));
   return jsi::Value::undefined();
 }
-
-static jsi::Value __hostFunction_NativeSampleTurboCxxModuleSpecJSI_getValueWithPromise(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  return static_cast<NativeSampleTurboCxxModuleSpecJSI *>(&turboModule)->getValueWithPromise(rt, args[0].getBool(rt));
-}​
-
-NativeSampleTurboCxxModuleSpecJSI::NativeSampleTurboCxxModuleSpecJSI(std::shared_ptr<JSCallInvoker> jsInvoker)
-  : TurboModule(\\"SampleTurboCxxModule\\", jsInvoker) {
-  methodMap_[\\"getConstants\\"] = MethodMetadata {0, __hostFunction_NativeSampleTurboCxxModuleSpecJSI_getConstants};
-  methodMap_[\\"voidFunc\\"] = MethodMetadata {0, __hostFunction_NativeSampleTurboCxxModuleSpecJSI_voidFunc};
-  methodMap_[\\"getBool\\"] = MethodMetadata {1, __hostFunction_NativeSampleTurboCxxModuleSpecJSI_getBool};
-  methodMap_[\\"getNumber\\"] = MethodMetadata {1, __hostFunction_NativeSampleTurboCxxModuleSpecJSI_getNumber};
-  methodMap_[\\"getString\\"] = MethodMetadata {1, __hostFunction_NativeSampleTurboCxxModuleSpecJSI_getString};
-  methodMap_[\\"getArray\\"] = MethodMetadata {1, __hostFunction_NativeSampleTurboCxxModuleSpecJSI_getArray};
-  methodMap_[\\"getObject\\"] = MethodMetadata {1, __hostFunction_NativeSampleTurboCxxModuleSpecJSI_getObject};
-  methodMap_[\\"getValue\\"] = MethodMetadata {3, __hostFunction_NativeSampleTurboCxxModuleSpecJSI_getValue};
-  methodMap_[\\"getValueWithCallback\\"] = MethodMetadata {1, __hostFunction_NativeSampleTurboCxxModuleSpecJSI_getValueWithCallback};
-  methodMap_[\\"getValueWithPromise\\"] = MethodMetadata {1, __hostFunction_NativeSampleTurboCxxModuleSpecJSI_getValueWithPromise};
+static jsi::Value __hostFunction_NativeSampleTurboModuleSpecJSI_getValueWithPromise(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
+  return static_cast<NativeSampleTurboModuleSpecJSI *>(&turboModule)->getValueWithPromise(rt, args[0].getBool());
 }
 
+NativeSampleTurboModuleSpecJSI::NativeSampleTurboModuleSpecJSI(std::shared_ptr<JSCallInvoker> jsInvoker)
+  : TurboModule(\\"SampleTurboModule\\", jsInvoker) {
+  methodMap_[\\"getConstants\\"] = MethodMetadata {0, __hostFunction_NativeSampleTurboModuleSpecJSI_getConstants};
+  methodMap_[\\"voidFunc\\"] = MethodMetadata {0, __hostFunction_NativeSampleTurboModuleSpecJSI_voidFunc};
+  methodMap_[\\"getBool\\"] = MethodMetadata {1, __hostFunction_NativeSampleTurboModuleSpecJSI_getBool};
+  methodMap_[\\"getNumber\\"] = MethodMetadata {1, __hostFunction_NativeSampleTurboModuleSpecJSI_getNumber};
+  methodMap_[\\"getString\\"] = MethodMetadata {1, __hostFunction_NativeSampleTurboModuleSpecJSI_getString};
+  methodMap_[\\"getArray\\"] = MethodMetadata {1, __hostFunction_NativeSampleTurboModuleSpecJSI_getArray};
+  methodMap_[\\"getObject\\"] = MethodMetadata {1, __hostFunction_NativeSampleTurboModuleSpecJSI_getObject};
+  methodMap_[\\"getValue\\"] = MethodMetadata {3, __hostFunction_NativeSampleTurboModuleSpecJSI_getValue};
+  methodMap_[\\"getValueWithCallback\\"] = MethodMetadata {1, __hostFunction_NativeSampleTurboModuleSpecJSI_getValueWithCallback};
+  methodMap_[\\"getValueWithPromise\\"] = MethodMetadata {1, __hostFunction_NativeSampleTurboModuleSpecJSI_getValueWithPromise};
+}
 
 
 } // namespace react
@@ -114,7 +102,7 @@ NativeSampleTurboCxxModuleSpecJSI::NativeSampleTurboCxxModuleSpecJSI(std::shared
 
 exports[`GenerateModuleCpp can generate fixture TWO_MODULES_DIFFERENT_FILES 1`] = `
 Map {
-  "NativeModules.h" => "
+  "NativeModules.cpp" => "
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
@@ -122,35 +110,31 @@ Map {
  * LICENSE file in the root directory of this source tree.
  */
 
-#include \\"Native::_MODULE_NAME_::TurboCxxModuleSpecJSI.h\\"
+#include <react/modules/TWO_MODULES_DIFFERENT_FILES/NativeModules.h>
 
 namespace facebook {
 namespace react {
 
 
-
-static jsi::Value __hostFunction_NativeSampleTurboCxxModuleSpecJSI_voidFunc(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  static_cast<NativeSampleTurboCxxModuleSpecJSI *>(&turboModule)->voidFunc(rt);
+static jsi::Value __hostFunction_NativeSampleTurboModuleSpecJSI_voidFunc(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
+  static_cast<NativeSampleTurboModuleSpecJSI *>(&turboModule)->voidFunc(rt);
   return jsi::Value::undefined();
-}​
-
-NativeSampleTurboCxxModuleSpecJSI::NativeSampleTurboCxxModuleSpecJSI(std::shared_ptr<JSCallInvoker> jsInvoker)
-  : TurboModule(\\"SampleTurboCxxModule\\", jsInvoker) {
-  methodMap_[\\"voidFunc\\"] = MethodMetadata {0, __hostFunction_NativeSampleTurboCxxModuleSpecJSI_voidFunc};
 }
 
-
-
-static jsi::Value __hostFunction_NativeSample2TurboCxxModuleSpecJSI_voidFunc(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  static_cast<NativeSample2TurboCxxModuleSpecJSI *>(&turboModule)->voidFunc(rt);
-  return jsi::Value::undefined();
-}​
-
-NativeSample2TurboCxxModuleSpecJSI::NativeSample2TurboCxxModuleSpecJSI(std::shared_ptr<JSCallInvoker> jsInvoker)
-  : TurboModule(\\"Sample2TurboCxxModule\\", jsInvoker) {
-  methodMap_[\\"voidFunc\\"] = MethodMetadata {0, __hostFunction_NativeSample2TurboCxxModuleSpecJSI_voidFunc};
+NativeSampleTurboModuleSpecJSI::NativeSampleTurboModuleSpecJSI(std::shared_ptr<JSCallInvoker> jsInvoker)
+  : TurboModule(\\"SampleTurboModule\\", jsInvoker) {
+  methodMap_[\\"voidFunc\\"] = MethodMetadata {0, __hostFunction_NativeSampleTurboModuleSpecJSI_voidFunc};
 }
 
+static jsi::Value __hostFunction_NativeSample2TurboModuleSpecJSI_voidFunc(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
+  static_cast<NativeSample2TurboModuleSpecJSI *>(&turboModule)->voidFunc(rt);
+  return jsi::Value::undefined();
+}
+
+NativeSample2TurboModuleSpecJSI::NativeSample2TurboModuleSpecJSI(std::shared_ptr<JSCallInvoker> jsInvoker)
+  : TurboModule(\\"Sample2TurboModule\\", jsInvoker) {
+  methodMap_[\\"voidFunc\\"] = MethodMetadata {0, __hostFunction_NativeSample2TurboModuleSpecJSI_voidFunc};
+}
 
 
 } // namespace react
@@ -161,7 +145,7 @@ NativeSample2TurboCxxModuleSpecJSI::NativeSample2TurboCxxModuleSpecJSI(std::shar
 
 exports[`GenerateModuleCpp can generate fixture TWO_MODULES_SAME_FILE 1`] = `
 Map {
-  "NativeModules.h" => "
+  "NativeModules.cpp" => "
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
@@ -169,35 +153,31 @@ Map {
  * LICENSE file in the root directory of this source tree.
  */
 
-#include \\"Native::_MODULE_NAME_::TurboCxxModuleSpecJSI.h\\"
+#include <react/modules/TWO_MODULES_SAME_FILE/NativeModules.h>
 
 namespace facebook {
 namespace react {
 
 
-
-static jsi::Value __hostFunction_NativeSampleTurboCxxModuleSpecJSI_voidFunc(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  static_cast<NativeSampleTurboCxxModuleSpecJSI *>(&turboModule)->voidFunc(rt);
+static jsi::Value __hostFunction_NativeSampleTurboModuleSpecJSI_voidFunc(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
+  static_cast<NativeSampleTurboModuleSpecJSI *>(&turboModule)->voidFunc(rt);
   return jsi::Value::undefined();
-}​
-
-NativeSampleTurboCxxModuleSpecJSI::NativeSampleTurboCxxModuleSpecJSI(std::shared_ptr<JSCallInvoker> jsInvoker)
-  : TurboModule(\\"SampleTurboCxxModule\\", jsInvoker) {
-  methodMap_[\\"voidFunc\\"] = MethodMetadata {0, __hostFunction_NativeSampleTurboCxxModuleSpecJSI_voidFunc};
 }
 
-
-
-static jsi::Value __hostFunction_NativeSample2TurboCxxModuleSpecJSI_voidFunc(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
-  static_cast<NativeSample2TurboCxxModuleSpecJSI *>(&turboModule)->voidFunc(rt);
-  return jsi::Value::undefined();
-}​
-
-NativeSample2TurboCxxModuleSpecJSI::NativeSample2TurboCxxModuleSpecJSI(std::shared_ptr<JSCallInvoker> jsInvoker)
-  : TurboModule(\\"Sample2TurboCxxModule\\", jsInvoker) {
-  methodMap_[\\"voidFunc\\"] = MethodMetadata {0, __hostFunction_NativeSample2TurboCxxModuleSpecJSI_voidFunc};
+NativeSampleTurboModuleSpecJSI::NativeSampleTurboModuleSpecJSI(std::shared_ptr<JSCallInvoker> jsInvoker)
+  : TurboModule(\\"SampleTurboModule\\", jsInvoker) {
+  methodMap_[\\"voidFunc\\"] = MethodMetadata {0, __hostFunction_NativeSampleTurboModuleSpecJSI_voidFunc};
 }
 
+static jsi::Value __hostFunction_NativeSample2TurboModuleSpecJSI_voidFunc(jsi::Runtime &rt, TurboModule &turboModule, const jsi::Value* args, size_t count) {
+  static_cast<NativeSample2TurboModuleSpecJSI *>(&turboModule)->voidFunc(rt);
+  return jsi::Value::undefined();
+}
+
+NativeSample2TurboModuleSpecJSI::NativeSample2TurboModuleSpecJSI(std::shared_ptr<JSCallInvoker> jsInvoker)
+  : TurboModule(\\"Sample2TurboModule\\", jsInvoker) {
+  methodMap_[\\"voidFunc\\"] = MethodMetadata {0, __hostFunction_NativeSample2TurboModuleSpecJSI_voidFunc};
+}
 
 
 } // namespace react

--- a/packages/react-native-codegen/src/generators/modules/__tests__/__snapshots__/GenerateModuleH-test.js.snap
+++ b/packages/react-native-codegen/src/generators/modules/__tests__/__snapshots__/GenerateModuleH-test.js.snap
@@ -12,14 +12,14 @@ Map {
 
 #pragma once
 
-#include <jsireact/TurboModule.h>
+#include <ReactCommon/TurboModule.h>
 
 namespace facebook {
 namespace react {
 
-class JSI_EXPORT NativeSampleTurboCxxModuleSpecJSI : public TurboModule {
+class JSI_EXPORT NativeSampleTurboModuleSpecJSI : public TurboModule {
 protected:
-  NativeSampleTurboCxxModuleSpecJSI(std::shared_ptr<JSCallInvoker> jsInvoker);
+  NativeSampleTurboModuleSpecJSI(std::shared_ptr<JSCallInvoker> jsInvoker);
 
 public:
 
@@ -44,14 +44,14 @@ Map {
 
 #pragma once
 
-#include <jsireact/TurboModule.h>
+#include <ReactCommon/TurboModule.h>
 
 namespace facebook {
 namespace react {
 
-class JSI_EXPORT NativeSampleTurboCxxModuleSpecJSI : public TurboModule {
+class JSI_EXPORT NativeSampleTurboModuleSpecJSI : public TurboModule {
 protected:
-  NativeSampleTurboCxxModuleSpecJSI(std::shared_ptr<JSCallInvoker> jsInvoker);
+  NativeSampleTurboModuleSpecJSI(std::shared_ptr<JSCallInvoker> jsInvoker);
 
 public:
 virtual jsi::Object getConstants(jsi::Runtime &rt) = 0;
@@ -85,23 +85,23 @@ Map {
 
 #pragma once
 
-#include <jsireact/TurboModule.h>
+#include <ReactCommon/TurboModule.h>
 
 namespace facebook {
 namespace react {
 
-class JSI_EXPORT NativeSampleTurboCxxModuleSpecJSI : public TurboModule {
+class JSI_EXPORT NativeSampleTurboModuleSpecJSI : public TurboModule {
 protected:
-  NativeSampleTurboCxxModuleSpecJSI(std::shared_ptr<JSCallInvoker> jsInvoker);
+  NativeSampleTurboModuleSpecJSI(std::shared_ptr<JSCallInvoker> jsInvoker);
 
 public:
 virtual void voidFunc(jsi::Runtime &rt) = 0;
 
 };
 
-class JSI_EXPORT NativeSample2TurboCxxModuleSpecJSI : public TurboModule {
+class JSI_EXPORT NativeSample2TurboModuleSpecJSI : public TurboModule {
 protected:
-  NativeSample2TurboCxxModuleSpecJSI(std::shared_ptr<JSCallInvoker> jsInvoker);
+  NativeSample2TurboModuleSpecJSI(std::shared_ptr<JSCallInvoker> jsInvoker);
 
 public:
 virtual void voidFunc(jsi::Runtime &rt) = 0;
@@ -126,23 +126,23 @@ Map {
 
 #pragma once
 
-#include <jsireact/TurboModule.h>
+#include <ReactCommon/TurboModule.h>
 
 namespace facebook {
 namespace react {
 
-class JSI_EXPORT NativeSampleTurboCxxModuleSpecJSI : public TurboModule {
+class JSI_EXPORT NativeSampleTurboModuleSpecJSI : public TurboModule {
 protected:
-  NativeSampleTurboCxxModuleSpecJSI(std::shared_ptr<JSCallInvoker> jsInvoker);
+  NativeSampleTurboModuleSpecJSI(std::shared_ptr<JSCallInvoker> jsInvoker);
 
 public:
 virtual void voidFunc(jsi::Runtime &rt) = 0;
 
 };
 
-class JSI_EXPORT NativeSample2TurboCxxModuleSpecJSI : public TurboModule {
+class JSI_EXPORT NativeSample2TurboModuleSpecJSI : public TurboModule {
 protected:
-  NativeSample2TurboCxxModuleSpecJSI(std::shared_ptr<JSCallInvoker> jsInvoker);
+  NativeSample2TurboModuleSpecJSI(std::shared_ptr<JSCallInvoker> jsInvoker);
 
 public:
 virtual void voidFunc(jsi::Runtime &rt) = 0;


### PR DESCRIPTION
NOTE: This PR was done in order to validate buck build on CI. Do not merge!
Summary:
This diff add e2e code generator validation. I added proper buck roles and added tests.

Also, fixed few minor problems:
`getBool` and `getNumber` shouldn't have `rt` param.

Generators now start considering whole module name instead of sliced part of their name.

Fixed import structure.

Fixed filename in generate cpp code (previously was `NativeModules.h`, now it's cpp file)

renamed `jsireact` to `ReactCommon` following D16231697

Differential Revision: D16221277

