### PR TITLE
[Android] Remove source map from release APK

### DIFF
--- a/react.gradle
+++ b/react.gradle
@@ -76,10 +76,11 @@ afterEvaluate {
         def resourcesDir = file("$buildDir/generated/res/react/${targetPath}")
 
         def jsBundleFile = file("$jsBundleDir/$bundleAssetName")
-        def jsSourceMapsDir = file("$buildDir/intermediates/sourcemaps/${targetPath}")
-        def jsPackagerSourceMapFile = file("$jsSourceMapsDir/${bundleAssetName}.packager.map")
-        def jsCompilerSourceMapFile = file("$jsSourceMapsDir/${bundleAssetName}.compiler.map")
-        def jsOutputSourceMapFile = file("$jsBundleDir/${bundleAssetName}.map")
+        def jsSourceMapsDir = file("$buildDir/generated/sourcemaps/react/${targetPath}")
+        def jsIntermediateSourceMapsDir = file("$buildDir/intermediates/sourcemaps/react/${targetPath}")
+        def jsPackagerSourceMapFile = file("$jsIntermediateSourceMapsDir/${bundleAssetName}.packager.map")
+        def jsCompilerSourceMapFile = file("$jsIntermediateSourceMapsDir/${bundleAssetName}.compiler.map")
+        def jsOutputSourceMapFile = file("$jsSourceMapsDir/${bundleAssetName}.map")
 
         // Additional node and packager commandline arguments
         def nodeExecutableAndArgs = config.nodeExecutableAndArgs ?: ["node"]
@@ -99,6 +100,8 @@ afterEvaluate {
                 jsBundleDir.mkdirs()
                 resourcesDir.deleteDir()
                 resourcesDir.mkdirs()
+                jsIntermediateSourceMapsDir.deleteDir()
+                jsIntermediateSourceMapsDir.mkdirs()
                 jsSourceMapsDir.deleteDir()
                 jsSourceMapsDir.mkdirs()
             }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

As @HazAT pointed out (thanks!) in https://github.com/facebook/react-native/issues/25693#issuecomment-512713367, we are currently unintentionally including the source map in the release APK. This PR changes the source map output path, e.g.
```diff
-build/generated/assets/react/release/index.android.bundle.map
+build/generated/sourcemaps/react/release/index.android.bundle.map
```

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[Android] [Fixed] - Remove source map from release APK

## Test Plan

1. `react-native init test`
2. `cd test/android`
3. `./gradlew assembleRelease`
4. Check that a source map exists in `app/build/generated/sourcemaps/react/release/index.android.bundle.map`.
5. `unzip -l ./app/build/outputs/apk/release/app-release.apk | grep '\.map'` - output is empty.
6. Set `enableHermes` to `true` in `app/build.gradle`, `./gradlew clean` and repeat steps 3-5.