### PR TITLE
Implement URL standard and URLSearchParams spec compliant

### DIFF
--- a/Libraries/Blob/URL.js
+++ b/Libraries/Blob/URL.js
@@ -9,6 +9,8 @@
 
 'use strict';
 
+const {URL: whatwgUrl} = require('whatwg-url-without-unicode');
+
 const Blob = require('./Blob');
 
 import NativeBlobModule from './NativeBlobModule';
@@ -105,115 +107,17 @@ export class URLSearchParams {
   }
 }
 
-function validateBaseUrl(url: string) {
-  // from this MIT-licensed gist: https://gist.github.com/dperini/729294
-  return /^(?:(?:(?:https?|ftp):)?\/\/)(?:(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)(?:\.(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)*(?:\.(?:[a-z\u00a1-\uffff]{2,})))(?::\d{2,5})?(?:[/?#]\S*)?$/i.test(
-    url,
-  );
-}
-
-export class URL {
-  _searchParamsInstance = null;
-
-  static createObjectURL(blob: Blob) {
-    if (BLOB_URL_PREFIX === null) {
-      throw new Error('Cannot create URL for blob!');
-    }
-    return `${BLOB_URL_PREFIX}${blob.data.blobId}?offset=${
-      blob.data.offset
-    }&size=${blob.size}`;
+whatwgUrl.createObjectURL = function createObjectURL(blob: Blob) {
+  if (BLOB_URL_PREFIX === null) {
+    throw new Error('Cannot create URL for blob!');
   }
+  return `${BLOB_URL_PREFIX}${blob.data.blobId}?offset=${
+    blob.data.offset
+  }&size=${blob.size}`;
+};
 
-  static revokeObjectURL(url: string) {
-    // Do nothing.
-  }
+whatwgUrl.revokeObjectURL = function revokeObjectURL(url: string) {
+  // Do nothing.
+};
 
-  constructor(url: string, base: string) {
-    let baseUrl = null;
-    if (base) {
-      if (typeof base === 'string') {
-        baseUrl = base;
-        if (!validateBaseUrl(baseUrl)) {
-          throw new TypeError(`Invalid base URL: ${baseUrl}`);
-        }
-      } else if (typeof base === 'object') {
-        baseUrl = base.toString();
-      }
-      if (baseUrl.endsWith('/') && url.startsWith('/')) {
-        baseUrl = baseUrl.slice(0, baseUrl.length - 1);
-      }
-      if (baseUrl.endsWith(url)) {
-        url = '';
-      }
-      this._url = `${baseUrl}${url}`;
-    } else {
-      this._url = url;
-      if (!this._url.endsWith('/')) {
-        this._url += '/';
-      }
-    }
-  }
-
-  get hash() {
-    throw new Error('not implemented');
-  }
-
-  get host() {
-    throw new Error('not implemented');
-  }
-
-  get hostname() {
-    throw new Error('not implemented');
-  }
-
-  get href(): string {
-    return this.toString();
-  }
-
-  get origin() {
-    throw new Error('not implemented');
-  }
-
-  get password() {
-    throw new Error('not implemented');
-  }
-
-  get pathname() {
-    throw new Error('not implemented');
-  }
-
-  get port() {
-    throw new Error('not implemented');
-  }
-
-  get protocol() {
-    throw new Error('not implemented');
-  }
-
-  get search() {
-    throw new Error('not implemented');
-  }
-
-  get searchParams(): URLSearchParams {
-    if (this._searchParamsInstance == null) {
-      this._searchParamsInstance = new URLSearchParams();
-    }
-    return this._searchParamsInstance;
-  }
-
-  toJSON(): string {
-    return this.toString();
-  }
-
-  toString(): string {
-    if (this._searchParamsInstance === null) {
-      return this._url;
-    }
-    const separator = this._url.indexOf('?') > -1 ? '&' : '?';
-    return this._url + separator + this._searchParamsInstance.toString();
-  }
-
-  get username() {
-    throw new Error('not implemented');
-  }
-}
+export const URL = whatwgUrl;

--- a/Libraries/Blob/URL.js
+++ b/Libraries/Blob/URL.js
@@ -53,60 +53,6 @@ if (
  * ```
  */
 
-// Small subset from whatwg-url: https://github.com/jsdom/whatwg-url/tree/master/lib
-// The reference code bloat comes from Unicode issues with URLs, so those won't work here.
-export class URLSearchParams {
-  _searchParams = [];
-
-  constructor(params: any) {
-    if (typeof params === 'object') {
-      Object.keys(params).forEach(key => this.append(key, params[key]));
-    }
-  }
-
-  append(key: string, value: string) {
-    this._searchParams.push([key, value]);
-  }
-
-  delete(name) {
-    throw new Error('not implemented');
-  }
-
-  get(name) {
-    throw new Error('not implemented');
-  }
-
-  getAll(name) {
-    throw new Error('not implemented');
-  }
-
-  has(name) {
-    throw new Error('not implemented');
-  }
-
-  set(name, value) {
-    throw new Error('not implemented');
-  }
-
-  sort() {
-    throw new Error('not implemented');
-  }
-
-  [Symbol.iterator]() {
-    return this._searchParams[Symbol.iterator]();
-  }
-
-  toString() {
-    if (this._searchParams.length === 0) {
-      return '';
-    }
-    const last = this._searchParams.length - 1;
-    return this._searchParams.reduce((acc, curr, index) => {
-      return acc + curr.join('=') + (index === last ? '' : '&');
-    }, '');
-  }
-}
-
 whatwgUrl.createObjectURL = function createObjectURL(blob: Blob) {
   if (BLOB_URL_PREFIX === null) {
     throw new Error('Cannot create URL for blob!');

--- a/Libraries/Blob/URLSearchParams.js
+++ b/Libraries/Blob/URLSearchParams.js
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+'use strict';
+
+const {URLSearchParams: whatwgUrl} = require('whatwg-url-without-unicode');
+
+export const URLSearchParams = whatwgUrl;

--- a/Libraries/Blob/__tests__/URL-test.js
+++ b/Libraries/Blob/__tests__/URL-test.js
@@ -51,7 +51,7 @@ describe('URL', function() {
 
   it('should support unicode', () => {
     const a = new URL('https://r3---sn-p5qlsnz6.googlevideo.com');
-    expect(a.href).toBe('https://r3---sn-p5qlsnz6.googlevideo.com');
+    expect(a.href).toBe('https://r3---sn-p5qlsnz6.googlevideo.com/');
   });
 
   // https://github.com/facebook/react-native/issues/25717

--- a/Libraries/Blob/__tests__/URL-test.js
+++ b/Libraries/Blob/__tests__/URL-test.js
@@ -23,13 +23,53 @@ describe('URL', function() {
     expect(d.href).toBe('https://developer.mozilla.org/en-US/docs');
     const f = new URL('/en-US/docs', d);
     expect(f.href).toBe('https://developer.mozilla.org/en-US/docs');
-    // from original test suite, but requires complex implementation
-    // const g = new URL(
-    //   '/en-US/docs',
-    //   'https://developer.mozilla.org/fr-FR/toto',
-    // );
-    // expect(g.href).toBe('https://developer.mozilla.org/en-US/docs');
+    const g = new URL(
+      '/en-US/docs',
+      'https://developer.mozilla.org/fr-FR/toto',
+    );
+    expect(g.href).toBe('https://developer.mozilla.org/en-US/docs');
     const h = new URL('/en-US/docs', a);
     expect(h.href).toBe('https://developer.mozilla.org/en-US/docs');
+  });
+
+  it('should pass WHATWG spec examples', () => {
+    const a = new URL('https:example.org');
+    expect(a.href).toBe('https://example.org/');
+    const b = new URL('https://////example.com///');
+    expect(b.href).toBe('https://example.com///');
+    const c = new URL('https://example.com/././foo');
+    expect(c.href).toBe('https://example.com/foo');
+    const d = new URL('hello:world', 'https://example.com/');
+    expect(d.href).toBe('hello:world');
+    const e = new URL('https:example.org', 'https://example.com/');
+    expect(e.href).toBe('https://example.com/example.org');
+    const f = new URL('\\example\\..\\demo/.\\', 'https://example.com/');
+    expect(f.href).toBe('https://example.com/demo/');
+    const g = new URL('example', 'https://example.com/demo');
+    expect(g.href).toBe('https://example.com/example');
+  });
+
+  it('should support unicode', () => {
+    const a = new URL('https://r3---sn-p5qlsnz6.googlevideo.com');
+    expect(a.href).toBe('https://r3---sn-p5qlsnz6.googlevideo.com');
+  });
+
+  // https://github.com/facebook/react-native/issues/25717
+  it('should pass issue #25717 example', () => {
+    const a = new URL('about', 'https://www.mozilla.org');
+    expect(a.href).toBe('https://www.mozilla.org/about');
+
+    const b = new URL('dev', 'https://google.dev');
+    expect(b.href).toBe('https://google.dev/dev');
+  });
+
+  // https://github.com/facebook/react-native/issues/24428
+  it('should pass issue #24428 example', () => {
+    const url = new URL(
+      'https://facebook.github.io/react-native/img/header_logo.png',
+    );
+    expect(url.href).toBe(
+      'https://facebook.github.io/react-native/img/header_logo.png',
+    );
   });
 });

--- a/Libraries/Blob/__tests__/URLSearchParams-test.js
+++ b/Libraries/Blob/__tests__/URLSearchParams-test.js
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @emails oncall+react_native
+ */
+'use strict';
+
+const URLSearchParams = require('../URLSearchParams').URLSearchParams;
+
+describe('URL', function() {
+  // https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams#Examples
+  it('should pass Mozilla Dev Network examples', () => {
+    const paramsString = 'q=URLUtils.searchParams&topic=api';
+    const searchParams = new URLSearchParams(paramsString);
+
+    expect(searchParams.has('topic')).toBe(true);
+    expect(searchParams.get('topic')).toBe('api');
+    expect(searchParams.getAll('topic')).toEqual(['api']);
+    expect(searchParams.get('foo')).toBe(null);
+    searchParams.append('topic', 'webdev');
+    expect(searchParams.toString()).toBe(
+      'q=URLUtils.searchParams&topic=api&topic=webdev',
+    );
+    searchParams.set('topic', 'More webdev');
+    expect(searchParams.toString()).toBe(
+      'q=URLUtils.searchParams&topic=More+webdev',
+    );
+    searchParams.delete('topic');
+    expect(searchParams.toString()).toBe('q=URLUtils.searchParams');
+  });
+});

--- a/Libraries/Core/setUpXHR.js
+++ b/Libraries/Core/setUpXHR.js
@@ -38,3 +38,4 @@ polyfillGlobal(
   'AbortSignal',
   () => require('abort-controller/dist/abort-controller').AbortSignal, // flowlint-line untyped-import:off
 );
+polyfillGlobal('Buffer', () => require('buffer').Buffer);

--- a/Libraries/Core/setUpXHR.js
+++ b/Libraries/Core/setUpXHR.js
@@ -29,7 +29,10 @@ polyfillGlobal('Blob', () => require('../Blob/Blob'));
 polyfillGlobal('File', () => require('../Blob/File'));
 polyfillGlobal('FileReader', () => require('../Blob/FileReader'));
 polyfillGlobal('URL', () => require('../Blob/URL').URL); // flowlint-line untyped-import:off
-polyfillGlobal('URLSearchParams', () => require('../Blob/URL').URLSearchParams); // flowlint-line untyped-import:off
+polyfillGlobal(
+  'URLSearchParams',
+  () => require('../Blob/URLSearchParams').URLSearchParams, // flowlint-line untyped-import:off
+);
 polyfillGlobal(
   'AbortController',
   () => require('abort-controller/dist/abort-controller').AbortController, // flowlint-line untyped-import:off

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "abort-controller": "^3.0.0",
     "art": "^0.10.0",
     "base64-js": "^1.1.2",
+    "buffer": "^5.4.0",
     "connect": "^3.6.5",
     "create-react-class": "^15.6.3",
     "escape-string-regexp": "^1.0.5",
@@ -108,7 +109,8 @@
     "regenerator-runtime": "^0.13.2",
     "scheduler": "0.14.0",
     "stacktrace-parser": "^0.1.3",
-    "whatwg-fetch": "^3.0.0"
+    "whatwg-fetch": "^3.0.0",
+    "whatwg-url-without-unicode": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1745,6 +1745,11 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
+base64-js@^1.0.2:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.1.tgz#58ece8cb75dd07e71ed08c736abc5fac4dbf8df1"
+  integrity sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==
+
 base64-js@^1.1.2, base64-js@^1.2.3:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.0.tgz#cab1e6118f051095e58b5281aea8c1cd22bfc0e3"
@@ -1862,6 +1867,14 @@ buffer-from@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
   integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
+
+buffer@^5.4.0:
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.4.0.tgz#33294f5c1f26e08461e528b69fa06de3c45cbd8c"
+  integrity sha512-Xpgy0IwHK2N01ncykXTy6FpCWuM+CJSHoPVBLyNqyrWxsedpLvwsYUhf0ME3WRFNUhos0dMamz9cOS/xRDtU5g==
+  dependencies:
+    base64-js "^1.0.2"
+    ieee754 "^1.1.4"
 
 builtin-modules@^1.0.0:
   version "1.1.1"
@@ -3545,6 +3558,11 @@ iconv-lite@0.4.24, iconv-lite@^0.4.17, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
+
+ieee754@^1.1.4:
+  version "1.1.13"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.13.tgz#ec168558e95aa181fd87d37f55c32bbcb6708b84"
+  integrity sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==
 
 ignore-walk@^3.0.1:
   version "3.0.1"
@@ -7199,6 +7217,14 @@ whatwg-mimetype@^2.1.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-2.2.0.tgz#a3d58ef10b76009b042d03e25591ece89b88d171"
   integrity sha512-5YSO1nMd5D1hY3WzAQV3PzZL83W3YeyR1yW9PcH26Weh1t+Vzh9B6XkDh7aXm83HBZ4nSMvkjvN2H2ySWIvBgw==
+
+whatwg-url-without-unicode@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url-without-unicode/-/whatwg-url-without-unicode-7.0.0.tgz#7407e53cc3e48cebdbb7abd86b11fc529881170e"
+  integrity sha512-M3CqAI0US1lgiVCFm7LCEbt/ByGBjsz9ZN55y8eiXIXo5+j/HrRvJ/j7l1tRyBdTmWEP0+2jO/lTLGulgz+how==
+  dependencies:
+    lodash.sortby "^4.7.0"
+    webidl-conversions "^4.0.2"
 
 whatwg-url@^6.4.1:
   version "6.5.0"


### PR DESCRIPTION
Fixes #25717 
Fixes #24428
Fixes #16434

## Summary

Currently, our implementation of [`URL`](https://github.com/facebook/react-native/blob/master/Libraries/Blob/URL.js) is not spec-compliant and this is causing headaches to RN users.

Tests were added to `URL`, to be sure we're spec compliant with https://url.spec.whatwg.org/.

As a solution to those issues, we could do one of the following:

- Implement [`whatwg-url`](https://github.com/jsdom/whatwg-url) instead of our custom implementation. ⚠️ This would add [significant weight](https://bundlephobia.com/result?p=whatwg-url@7.0.0) to React Native.
- Fork `whatwg-url` and remove the support of unicode from there, because `tr46` dependency is like ~80% of `whatwg-url` size.
- Implement a lightweight polyfill. Those available on npm are not really trustworthy or depend heavily on the DOM.
- Fix RN's URL issues, case by case. IMO, this is not a viable solution. 🤷‍♂ 

I'll tackle an implementation of `whatwg-url` and compare what will be the increase of RN size with and without unicode support.

Let me know if you have any thoughts, concerns or ideas.

___

After looking at this, our best approach is to use `whatwg-url` to cover all the spec. But we can't use `whatwg-url` directly, because it's coming with a dependency to `tr46` to handle Unicode cases. I think we can live without Unicode, so I forked `whatwg-url`, and I removed the unicode support, edited tests, and published this as `whatwg-url-without-unicode`.

Here are some stats:

📦`whatwg-url` is taking 352.5 KB.
📦`whatwg-url-without-unicode` is taking 53.5 KB.

Then, `whatwg-url-without-unicode` requires `Buffer`, which is 142 B.

As `URLSearchParams` is bundled in `whatwg-url`, I replaced our custom implementation with the spec-compliant one and some tests to cover this.

## Changelog

[General] [Changed] - Implement spec compliant URL and URLSearchParams

## Test Plan

Added tests, ran RNTester, and called `new URL()`.
