### PR TITLE
Remove jsc dep from blob native library

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/modules/blob/jni/Android.mk
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/blob/jni/Android.mk
@@ -15,7 +15,7 @@ LOCAL_C_INCLUDES := $(LOCAL_PATH)
 
 LOCAL_CFLAGS += -fvisibility=hidden -fexceptions -frtti
 
-LOCAL_STATIC_LIBRARIES := libjsi libjsireact jscruntime
+LOCAL_STATIC_LIBRARIES := libjsi libjsireact
 LOCAL_SHARED_LIBRARIES := libfolly_json libfb libreactnativejni
 
 include $(BUILD_SHARED_LIBRARY)

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/blob/jni/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/blob/jni/BUCK
@@ -16,7 +16,6 @@ rn_xplat_cxx_library(
         "fbsource//xplat/folly:molly",
         FBJNI_TARGET,
         react_native_target("jni/react/jni:jni"),
-        react_native_xplat_target("jsi:JSCRuntime"),
         react_native_xplat_target("jsiexecutor:jsiexecutor"),
     ],
 )

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/blob/jni/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/blob/jni/BUCK
@@ -16,6 +16,6 @@ rn_xplat_cxx_library(
         "fbsource//xplat/folly:molly",
         FBJNI_TARGET,
         react_native_target("jni/react/jni:jni"),
-        react_native_xplat_target("jsiexecutor:jsiexecutor"),
+        react_native_xplat_target("jsi:jsi"),
     ],
 )


### PR DESCRIPTION
## Summary

The blob native lib should not include JSC, otherwise it causes a crash when using Hermes.

This actually doesn't depend on the Hermes PR so we can land it now.

## Changelog

[Android] [Fixed] - Remove jsc dep from blob native library

## Test Plan

Tested that is no crash with hermes enabled and disabled
