### PR TITLE
add support for stringifying error object messages to stringifySafe

### DIFF
--- a/Libraries/Utilities/__tests__/stringifySafe-test.js
+++ b/Libraries/Utilities/__tests__/stringifySafe-test.js
@@ -47,4 +47,10 @@ describe('stringifySafe', () => {
     const result = stringifySafe(arg);
     expect(result).toEqual('["object" failed to stringify]');
   });
+
+  it('stringifySafe stringifies error messages', () => {
+    const error = new Error('error');
+    const result = stringifySafe(error);
+    expect(result).toEqual('Error: error');
+  });
 });

--- a/Libraries/Utilities/stringifySafe.js
+++ b/Libraries/Utilities/stringifySafe.js
@@ -29,6 +29,8 @@ function stringifySafe(arg: any): string {
     } catch (e) {
       ret = '[function unknown]';
     }
+  } else if (arg instanceof Error) {
+    ret = arg.name + ': ' + arg.message;
   } else {
     // Perform a try catch, just in case the object has a circular
     // reference or stringify throws for some other reason.


### PR DESCRIPTION
## Summary

Error objects logged as part of the arguments to `console.error` such as from [rejected es6 promises](https://github.com/zloirock/core-js/blob/v2/modules/es6.promise.js#L110) contain the error that the user would want to see as the error object's message, but is not captured by `stringifySafe`. Here we modify it to if the logged value is an error object print the error similar to chrome:

```
const error = new Error('error');
stringifySafe(error); // Error: error
```

Versus the current behavior which does not recognize the error type and instead tries to stringify the it as an object:

```
JSON.stringify(new Error('error')) // "{}"
```

## Changelog

[JavaScript] [Changed] - Add support for stringifying error object messages to safeStringify

## Test Plan

Tests:
<img width="802" alt="Screen Shot 2019-07-18 at 8 39 52 PM" src="https://user-images.githubusercontent.com/2192930/61501171-39218080-a99c-11e9-8e87-48ea413b3d01.png">

Lint:
<img width="406" alt="Screen Shot 2019-07-18 at 8 43 35 PM" src="https://user-images.githubusercontent.com/2192930/61501318-dc729580-a99c-11e9-9264-c0232515352c.png">
