### PR TITLE
Fix building on tvOS when using CocoaPods

### DIFF
--- a/Libraries/ActionSheetIOS/React-RCTActionSheet.podspec
+++ b/Libraries/ActionSheetIOS/React-RCTActionSheet.podspec
@@ -25,7 +25,7 @@ Pod::Spec.new do |s|
   s.documentation_url      = "https://facebook.github.io/react-native/docs/actionsheetios"
   s.license                = package["license"]
   s.author                 = "Facebook, Inc. and its affiliates"
-  s.platforms              = { :ios => "9.0", :tvos => "9.2" }
+  s.platforms              = { :ios => "9.0" }
   s.source                 = source
   s.source_files           = "*.{h,m}"
   s.preserve_paths          = "package.json", "LICENSE", "LICENSE-docs"

--- a/Libraries/LinkingIOS/React-RCTLinking.podspec
+++ b/Libraries/LinkingIOS/React-RCTLinking.podspec
@@ -25,7 +25,7 @@ Pod::Spec.new do |s|
   s.documentation_url      = "https://facebook.github.io/react-native/docs/linking"
   s.license                = package["license"]
   s.author                 = "Facebook, Inc. and its affiliates"
-  s.platforms              = { :ios => "9.0", :tvos => "9.2" }
+  s.platforms              = { :ios => "9.0" }
   s.source                 = source
   s.source_files           = "*.{h,m}"
   s.preserve_paths         = "package.json", "LICENSE", "LICENSE-docs"

--- a/React.podspec
+++ b/React.podspec
@@ -44,11 +44,11 @@ Pod::Spec.new do |s|
 
   s.dependency "React-Core", version
   s.dependency "React-DevSupport", version
-  s.dependency "React-RCTActionSheet", version
+  s.ios.dependency "React-RCTActionSheet", version
   s.dependency "React-RCTAnimation", version
   s.dependency "React-RCTBlob", version
   s.dependency "React-RCTImage", version
-  s.dependency "React-RCTLinking", version
+  s.ios.dependency "React-RCTLinking", version
   s.dependency "React-RCTNetwork", version
   s.dependency "React-RCTSettings", version
   s.dependency "React-RCTText", version


### PR DESCRIPTION
## Summary

This PR makes it possible to build on tvOS again, when using CocoaPods.

When RN moved from a subspec to multiple podspecs (#23559) all dependencies were added to `React` as "generic", but two of them as actually iOS only (`React-RCTActionSheet` and `React-RCTLinking`).

This change meant that `pod install` still works, since all dependencies are satisfied, but tvOS targets would fail to build since CocoaPods would create static libraries for both platform variants.

Previously this wasn't a problem since subspecs can be included individually for each platform.

## Changelog

[iOS] [Fixed] - Fix building on tvOS when using CocoaPods

## Test Plan

1. Create sample project with iOS and tvOS targets
2. Use CocoaPods to inject a React Native dependency
3. Run `pod install`
4. Open the workspace and build both targets
5. Smile