### PR TITLE
fix VirtualizedSectionList.scrollToSection ignoring viewOffset param

### DIFF
--- a/Libraries/Lists/VirtualizedSectionList.js
+++ b/Libraries/Lists/VirtualizedSectionList.js
@@ -143,17 +143,18 @@ class VirtualizedSectionList<
     itemIndex: number,
     sectionIndex: number,
     viewPosition?: number,
+    viewOffset?: number,
   }) {
     let index = params.itemIndex;
     for (let i = 0; i < params.sectionIndex; i++) {
       index += this.props.getItemCount(this.props.sections[i].data) + 2;
     }
-    let viewOffset = 0;
+    let viewOffset = params.viewOffset || 0;
     if (params.itemIndex > 0 && this.props.stickySectionHeadersEnabled) {
       const frame = this._listRef._getFrameMetricsApprox(
         index - params.itemIndex,
       );
-      viewOffset = frame.length;
+      viewOffset = viewOffset + frame.length;
     }
     const toIndexParams = {
       ...params,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

PR #24735 introduced commit d376a44 to handle sticky headers gracefully. But it missed taking into account user-provided `viewOffset` parameter, overwriting it.

This is a straightforward change, adding the sticky header offset to the existing user provided `viewOffset` value. Also, I added `viewOffset` which was missing from the method signature [while described on the official documentation](https://facebook.github.io/react-native/docs/sectionlist#scrolltolocation).

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[Javascript] [Fixed] - Fix VirtualizedSectionList.scrollToSection ignoring viewOffset param

## Test Plan

I believe it is too trivial to require screenshots. Just look at the 3 changed lines.
