### PR TITLE
Allow jest globals in __mocks__ directories

### DIFF
--- a/packages/eslint-config-react-native-community/index.js
+++ b/packages/eslint-config-react-native-community/index.js
@@ -58,7 +58,7 @@ module.exports = {
       },
     },
     {
-      files: ['*.{spec,test}.{js,ts,tsx}', '**/__tests__/**/*.{js,ts,tsx}'],
+      files: ['*.{spec,test}.{js,ts,tsx}', '**/__{mocks,tests}__/**/*.{js,ts,tsx}'],
       env: {
         jest: true,
         'jest/globals': true,

--- a/packages/eslint-config-react-native-community/index.js
+++ b/packages/eslint-config-react-native-community/index.js
@@ -58,7 +58,10 @@ module.exports = {
       },
     },
     {
-      files: ['*.{spec,test}.{js,ts,tsx}', '**/__{mocks,tests}__/**/*.{js,ts,tsx}'],
+      files: [
+        '*.{spec,test}.{js,ts,tsx}',
+        '**/__{mocks,tests}__/**/*.{js,ts,tsx}',
+      ],
       env: {
         jest: true,
         'jest/globals': true,


### PR DESCRIPTION
## Summary

The `__mocks__` directories should be treated the same as `__tests__`
for the purpose of linting. See https://jestjs.io/docs/en/manual-mocks

## Changelog

[Internal] [Changed] - eslint: allow jest globals in `__mocks__` directories

## Test Plan

I installed the updated package locally in my project and verified
that the `no-undef` rule no longer fires for references to `jest` in
`__mocks__` directories.
