### PR TITLE
[Android] Fix scrolling issues with TextInputs in ScrollViews

### DIFF
--- a/RNTester/js/examples/ScrollView/ScrollViewTextInputsExample.js
+++ b/RNTester/js/examples/ScrollView/ScrollViewTextInputsExample.js
@@ -1,0 +1,130 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow
+ */
+
+'use strict';
+
+const React = require('react');
+const {ScrollView, TextInput} = require('react-native');
+
+exports.title = 'ScrollView with TextInputs';
+exports.description = 'Displays a list of TextInputs in a ScrollView';
+exports.examples = [
+  {
+    title: 'ScrollView with TextInputs - vertical',
+    description:
+      'Displays a list of scrollable TextInputs in a vertical ScrollView',
+    render(): React.Element<any> {
+      return (
+        <ScrollView style={{flex: 1}}>
+          <TextInput placeholder="default" />
+          <TextInput placeholder="center" style={{textAlign: 'center'}} />
+          <TextInput placeholder="right" style={{textAlign: 'right'}} />
+          <TextInput placeholder="left" style={{textAlign: 'left'}} />
+          <TextInput value="[default] even with large content, this TextInput is still horizontally scrollable" />
+          <TextInput
+            style={{textAlign: 'center'}}
+            value="[center] even with large content, this TextInput is still horizontally scrollable"
+          />
+          <TextInput
+            style={{textAlign: 'right'}}
+            value="[right] even with large content, this TextInput is still horizontally scrollable"
+          />
+          <TextInput
+            value="[left] even with large content, this TextInput is still horizontally scrollable"
+            style={{textAlign: 'left'}}
+          />
+          <TextInput
+            multiline
+            value={
+              "[multiline-default] possible to scroll from me, because I don't scroll internally"
+            }
+          />
+          <TextInput
+            multiline
+            style={{textAlign: 'center'}}
+            value="[multiline-center] possible to scroll from me, because I don't scroll internally"
+          />
+          <TextInput
+            multiline
+            style={{textAlign: 'right'}}
+            value="[multiline-right] possible to scroll from me, because I don't scroll internally"
+          />
+          <TextInput
+            multiline
+            style={{textAlign: 'left'}}
+            value="[multiline-left] possible to scroll from me, because I don't scroll internally"
+          />
+        </ScrollView>
+      );
+    },
+  },
+  {
+    title: 'ScrollView with TextInputs - horizontal',
+    description:
+      'Displays a list of scrollable TextInputs in a horizontal ScrollView',
+    render(): React.Element<any> {
+      return (
+        <ScrollView horizontal style={{flex: 1}}>
+          <TextInput placeholder="default" style={{width: 40}} />
+          <TextInput
+            placeholder="center"
+            style={{textAlign: 'center', width: 40}}
+          />
+          <TextInput
+            placeholder="right"
+            style={{textAlign: 'right', width: 40}}
+          />
+          <TextInput
+            placeholder="left"
+            style={{textAlign: 'left', width: 40}}
+          />
+          <TextInput
+            value="[default] even with large content, this TextInput is still horizontally scrollable"
+            style={{width: 40}}
+          />
+          <TextInput
+            style={{textAlign: 'center', width: 40}}
+            value="[center] even with large content, this TextInput is not horizontally scrollable"
+          />
+          <TextInput
+            style={{textAlign: 'right', width: 40}}
+            value="[right] even with large content, this TextInput is not horizontally scrollable"
+          />
+          <TextInput
+            value="[left]with large content, this TextInput is not horizontally scrollable"
+            style={{textAlign: 'left', width: 40}}
+          />
+          <TextInput
+            multiline
+            style={{width: 40}}
+            value={
+              "[multiline-default] possible to scroll from me, because I don't scroll internally"
+            }
+          />
+          <TextInput
+            multiline
+            style={{textAlign: 'center', width: 40}}
+            value="[multiline-center] possible to scroll from me, because I don't scroll internally"
+          />
+          <TextInput
+            multiline
+            style={{textAlign: 'right', width: 40}}
+            value="[multiline-right] possible to scroll from me, because I don't scroll internally"
+          />
+          <TextInput
+            multiline
+            style={{textAlign: 'left', width: 40}}
+            value="[multiline-left] possible to scroll from me, because I don't scroll internally"
+          />
+        </ScrollView>
+      );
+    },
+  },
+];

--- a/RNTester/js/utils/RNTesterList.android.js
+++ b/RNTester/js/utils/RNTesterList.android.js
@@ -74,6 +74,10 @@ const ComponentExamples: Array<RNTesterExample> = [
     module: require('../examples/ScrollView/ScrollViewAnimatedExample'),
   },
   {
+    key: 'ScrollViewTextInputsExample',
+    module: require('../examples/ScrollView/ScrollViewTextInputsExample'),
+  },
+  {
     key: 'SectionListExample',
     module: require('../examples/SectionList/SectionListExample'),
   },

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
@@ -23,7 +23,6 @@ import android.text.method.QwertyKeyListener;
 import android.util.TypedValue;
 import android.view.Gravity;
 import android.view.KeyEvent;
-import android.view.MotionEvent;
 import android.view.View;
 import android.view.accessibility.AccessibilityNodeInfo;
 import android.view.inputmethod.EditorInfo;
@@ -80,7 +79,6 @@ public class ReactEditText extends EditText {
   private @Nullable ContentSizeWatcher mContentSizeWatcher;
   private @Nullable ScrollWatcher mScrollWatcher;
   private final InternalKeyListener mKeyListener;
-  private boolean mDetectScrollMovement = false;
   private boolean mOnKeyPress = false;
   private TextAttributes mTextAttributes;
 
@@ -151,31 +149,6 @@ public class ReactEditText extends EditText {
   @Override
   protected void onLayout(boolean changed, int left, int top, int right, int bottom) {
     onContentSizeChange();
-  }
-
-  @Override
-  public boolean onTouchEvent(MotionEvent ev) {
-    switch (ev.getAction()) {
-      case MotionEvent.ACTION_DOWN:
-        mDetectScrollMovement = true;
-        // Disallow parent views to intercept touch events, until we can detect if we should be
-        // capturing these touches or not.
-        this.getParent().requestDisallowInterceptTouchEvent(true);
-        break;
-      case MotionEvent.ACTION_MOVE:
-        if (mDetectScrollMovement) {
-          if (!canScrollVertically(-1)
-              && !canScrollVertically(1)
-              && !canScrollHorizontally(-1)
-              && !canScrollHorizontally(1)) {
-            // We cannot scroll, let parent views take care of these touches.
-            this.getParent().requestDisallowInterceptTouchEvent(false);
-          }
-          mDetectScrollMovement = false;
-        }
-        break;
-    }
-    return super.onTouchEvent(ev);
   }
 
   // Consume 'Enter' key events: TextView tries to give focus to the next TextInput, but it can't


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

_This is my first PR to this repository and I would appreciate any feedback. Thanks_

## Summary

This change fixes https://github.com/facebook/react-native/issues/25594

The motivation is to allow `ScrollView` components to be correctly scrollable on Android when the touch falls on a `TextInput` component.
When a given `TextInput` component has `textAlign` property set to `center` or `right`, or when its value is long enough that the `TextInput` becomes horizontally scrollable, it is no longer possible to use it as an anchor for a touch aiming at scrolling the parent `ScrollView`.

Here is a [Snack](https://snack.expo.io/@markuscosinus/https:-github.com-facebook-react-native-issues-25594) showing this behaviour (run it for Android, iOS is fine).

Here is a video (in GIF form) to show the behaviour in an example in RNTester (sadly, the touches don't really show, but I'm trying to take each input field as an anchor point to scroll vertically in the first half of the video, and horizontally in the second half of the video).

<p align="center">
<img src="https://user-images.githubusercontent.com/22741774/61580976-97736e00-ab18-11e9-90ab-53b4131ba396.gif" alt="No Scrolling from specific TextInputs"/>
</p>

Even though the original implementation seems completely reasonable, the way Android seems to compute `canScrollHorizontally` or `canScrollVertically` seems non-functional when the text is centered or aligned to the right.

I first tried to relax the condition to be "can't scroll vertically OR can't scroll horizontally", which yielded the desired behaviour, and commenting out the whole condition yielded the same. Upon inspection of the commit history, this change is more or less reverting this commit https://github.com/facebook/react-native/commit/372d001a5d5e24b68d194e01c356d973642fac86

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[Android] [Fixed] - TextInput components can be valid anchors to scroll within a ScrollView component

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

I ran my changes on RNTester on the Android emulator (Nexus_5X_API_27) but could not test on an Android device since I don't have one handy.

I added an example called "ScrollView with TextInputs".

Here is a video (in GIF form) to show the new behaviour: `TextInput` components can be taken as anchor points to scroll down the view, or sideways in the second example. (Sadly once again, touches aren't visible and the same comment as above applies)

<p align="center">
<img src="https://user-images.githubusercontent.com/22741774/61581116-59774980-ab1a-11e9-84a4-fc24ed7d83bc.gif" alt="Can scroll from TextInputs" />
</p>

The only "downside" to this fix is that it is no longer possible to scroll horizontally single-line `TextInput` components' content if it is within a horizontal `ScrollView`.

