### PR TITLE
[iOS] Don't call sharedApplication in App Extension

### DIFF
--- a/React/Modules/RCTRedBox.m
+++ b/React/Modules/RCTRedBox.m
@@ -161,7 +161,7 @@
 - (NSInteger)bottomSafeViewHeight
 {
     if (@available(iOS 11.0, *)) {
-        return [UIApplication sharedApplication].delegate.window.safeAreaInsets.bottom;
+        return RCTSharedApplication().delegate.window.safeAreaInsets.bottom;
     } else {
         return 0;
     }


### PR DESCRIPTION
## Summary

Fixes #25767 .

## Changelog

[iOS] [Fixed] - Don't call sharedApplication in App Extension

## Test Plan

RN works in App Extension.