### PR TITLE
Allow Animation EndResult callback to return Promise

### DIFF
--- a/Libraries/Animated/src/NativeAnimatedModule.js
+++ b/Libraries/Animated/src/NativeAnimatedModule.js
@@ -14,7 +14,7 @@ import type {TurboModule} from '../../TurboModule/RCTExport';
 import * as TurboModuleRegistry from '../../TurboModule/TurboModuleRegistry';
 
 type EndResult = {finished: boolean};
-type EndCallback = (result: EndResult) => void;
+type EndCallback = (result: EndResult) => any;
 
 export type EventMapping = {|
   nativeEventPath: Array<string>,

--- a/Libraries/Animated/src/NativeAnimatedModule.js
+++ b/Libraries/Animated/src/NativeAnimatedModule.js
@@ -14,7 +14,7 @@ import type {TurboModule} from '../../TurboModule/RCTExport';
 import * as TurboModuleRegistry from '../../TurboModule/TurboModuleRegistry';
 
 type EndResult = {finished: boolean};
-type EndCallback = (result: EndResult) => any;
+type EndCallback = (result: EndResult) => void | Promise<void>;
 
 export type EventMapping = {|
   nativeEventPath: Array<string>,

--- a/Libraries/Animated/src/animations/Animation.js
+++ b/Libraries/Animated/src/animations/Animation.js
@@ -14,7 +14,7 @@ const NativeAnimatedHelper = require('../NativeAnimatedHelper');
 import type AnimatedValue from '../nodes/AnimatedValue';
 
 export type EndResult = {finished: boolean};
-export type EndCallback = (result: EndResult) => void;
+export type EndCallback = (result: EndResult) => any;
 
 export type AnimationConfig = {
   isInteraction?: boolean,

--- a/Libraries/Animated/src/animations/Animation.js
+++ b/Libraries/Animated/src/animations/Animation.js
@@ -14,7 +14,7 @@ const NativeAnimatedHelper = require('../NativeAnimatedHelper');
 import type AnimatedValue from '../nodes/AnimatedValue';
 
 export type EndResult = {finished: boolean};
-export type EndCallback = (result: EndResult) => any;
+export type EndCallback = (result: EndResult) => void | Promise<void>;
 
 export type AnimationConfig = {
   isInteraction?: boolean,


### PR DESCRIPTION
## Summary

I am sending an asynchronous function as callback to the `.start` method of `Animation.parallel([...]).start(callback)`. Flow does not like this, as the `EndCallback` type is saying that these callbacks must return `void`. Since my callback returns `Promise<void>` this results in an error.

Does it really matter what the callback returns?

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[General] [Changed] - Make Animation EndCallback type allow any return value

## Test Plan

I have run `yarn flow`, which reported no errors.