### PR TITLE
Adding the debug.keystore file back

### DIFF
--- a/template/_gitignore
+++ b/template/_gitignore
@@ -40,6 +40,7 @@ yarn-error.log
 buck-out/
 \.buckd/
 *.keystore
+!debug.keystore
 
 # fastlane
 #


### PR DESCRIPTION
Fixes https://github.com/facebook/react-native/issues/25629 that happened after v60 upgrade when using the diff tool https://react-native-community.github.io/upgrade-helper/?from=0.59.10&to=0.60.4

## Summary

When following the diff for upgrading to react native 60. The debug.keystore is missing. It's added in the repository but ignored in the .gitignore, so it does not show. This adds an exception for this file.

## Changelog

[Android] [Fixed] - Add exception in .gitignore for `debug.keystore` to the android template.

## Test Plan

Create a new project from template and check that debug.keystore will be checked in when committing.