### PR TITLE
build(gradle): update build.gradle

### DIFF
--- a/template/android/build.gradle
+++ b/template/android/build.gradle
@@ -6,7 +6,6 @@ buildscript {
         minSdkVersion = 16
         compileSdkVersion = 28
         targetSdkVersion = 28
-        supportLibVersion = "28.0.0"
     }
     repositories {
         google()


### PR DESCRIPTION
Remove obsolete supportLibVersion - no longer required with AndroidX

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
Removing the `supportLibVersion` variable that was used in `app/build.gradle` to suffix version numbers on android support libraries. 
As react-native moved to androidX with the release of `0.60` this is no longer necessary.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[Android] [Removed] - Remove supportLibVersion variable in build.gradle

## Test Plan
No tests were run locally