### PR TITLE
Test RNTesterPods on CI with use_frameworks! enabled

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,15 +122,19 @@ commands:
       steps:
         type: steps
     steps:
+      - run:
+          name: Setup CocoaPods cache
+          # Copy RNTester/Podfile.lock since it can be changed by pod install
+          command: cp RNTester/Podfile.lock RNTester/Podfile.lock.bak
       - restore_cache:
           keys:
-            - v1-pods-{{ checksum "RNTester/Podfile.lock" }}
-            - v1-pods-
+            - v1-pods-{{ .Environment.CIRCLE_JOB }}-{{ checksum "RNTester/Podfile.lock.bak" }}
+            - v1-pods-{{ .Environment.CIRCLE_JOB }}-
       - steps: << parameters.steps >>
       - save_cache:
           paths:
             - RNTester/Pods
-          key: v1-pods-{{ checksum "RNTester/Podfile.lock" }}
+          key: v1-pods-{{ .Environment.CIRCLE_JOB }}-{{ checksum "RNTester/Podfile.lock.bak" }}
 
   download_gradle_dependencies:
     steps:
@@ -301,6 +305,10 @@ jobs:
   # Runs unit tests on iOS devices
   test_ios:
     executor: reactnativeios
+    parameters:
+      use_frameworks:
+        type: boolean
+        default: false
     environment:
       - REPORTS_DIR: "./reports"
     steps:
@@ -320,6 +328,13 @@ jobs:
           name: Fetch CocoaPods Specs
           command: |
             curl https://cocoapods-specs.circleci.com/fetch-cocoapods-repo-from-s3.sh | bash -s cf
+
+      - when:
+          condition: << parameters.use_frameworks >>
+          steps:
+            - run:
+                name: Set USE_FRAMEWORKS=1
+                command: echo "export USE_FRAMEWORKS=1" >> $BASH_ENV
 
       - with_pods_cache_span:
           steps:
@@ -607,6 +622,11 @@ workflows:
           requires:
             - setup_android
       - test_ios:
+          requires:
+            - setup_ios
+      - test_ios:
+          name: test_ios_frameworks
+          use_frameworks: true
           requires:
             - setup_ios
       - test_ios_e2e:

--- a/RNTester/Podfile
+++ b/RNTester/Podfile
@@ -2,10 +2,12 @@ platform :ios, '9.0'
 
 require_relative '../scripts/autolink-ios'
 
-def pods()
-  # Uncomment for Swift
-  # use_frameworks!
+if ENV['USE_FRAMEWORKS'] == '1'
+  puts "Installing pods with use_frameworks!"
+  use_frameworks!
+end
 
+def pods()
   project 'RNTesterPods.xcodeproj'
 
   # Enable TurboModule

--- a/RNTester/Podfile.lock
+++ b/RNTester/Podfile.lock
@@ -354,36 +354,36 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   DoubleConversion: 5805e889d232975c086db112ece9ed034df7a0b2
-  FBLazyVector: 34431b7e61740bed29b082ff81500b0ffafaffa0
-  FBReactNativeSpec: 0c434153f44d4a1cbd111fbde1502580475e9132
+  FBLazyVector: e38af664187698e33919cd2a190970acbca68630
+  FBReactNativeSpec: e734dea0614646e9b863785cf236c465fbcaf72d
   Folly: 30e7936e1c45c08d884aa59369ed951a8e68cf51
   glog: 1f3da668190260b06b429bb211bfbee5cd790c28
-  RCTRequired: 770d733d8b6881e0ecd1085d0eb7f57dfacc5d93
-  RCTTypeSafety: 8540a73bafd032be534cb683471f985dc656bfb6
-  React: 7c652b87c228731c51ab5764de68b6c17e6342be
-  React-ART: 84555d2fcff922e3fed8ce70b5fb2536fb7c163e
-  React-Core: 266e5912bbfd0bddb866782b9bb560d82c5b8ef4
-  React-CoreModules: 018c3d55a5bfbd04655489942a8c606527176eed
-  React-cxxreact: 8cbb09bfdf4241546c5f4a9f46d92f63295281e0
-  React-DevSupport: f5349e286c067443895e6ae60d808eeaabedf472
-  React-jsi: ec7bccfadb03c9aa26db7ba880a02b983b921316
-  React-jsiexecutor: 173df46fcbafe60986cd5e42bde45e693c783af9
-  React-jsinspector: 426757e28a6909b49f7dd126f6f1dbd2783764f8
-  React-RCTActionSheet: a172ba63176ca80d7440f29fdd65515b442e4232
-  React-RCTAnimation: 276dde8150bb1a7d9eef8f3b44db66bddebedec3
-  React-RCTBlob: d60bf36ef77d3fb9e39a46443ea89c68381b4650
-  React-RCTImage: 29cbf7ccc2b89ac7ac6d9f2c84c15cfabaeabe6b
-  React-RCTLinking: 387d21f8fd4423dde220bf18be9715054cfc7cf5
-  React-RCTNetwork: ad750ce9bd98d382020174b14537d2ffa09427e0
-  React-RCTPushNotification: 90e1127e8f243296eef48c35dba370588405728b
-  React-RCTSettings: 405b277fb5afed794564af2d99ab71315806768d
-  React-RCTTest: c999df66263f36ddd63328356ac5898f2089e91e
-  React-RCTText: 667603cc6464856a6314a05b3d605da0a7fbf8e3
-  React-RCTVibration: 775cffcf1040bfa92fea6982f43d5f1a438edf05
-  React-RCTWebSocket: c10d7eecfc66d58ece635508dc1e8ecf6b548c60
-  ReactCommon: 7fd06e02cb448d0260cb7219cf0057984b49de17
-  yoga: b72aa5b3708cc93c5897f8297122d6eba1331e07
+  RCTRequired: 7711d9275d5c0e42a206d7c251936872679e0458
+  RCTTypeSafety: e8c4cae99363d9e004b6c1b1f2cc715d6ecf27ec
+  React: 151c2d50cd2703df319f27b79aea0e8003e71615
+  React-ART: 9b5b3f76d93544a09978cada717812babeaeaa6d
+  React-Core: 420b5dc0cff0242b8bd5c331a4f2efee630237a3
+  React-CoreModules: b6a9dc54c8e3c629bdd6475c866389ae62ceb05b
+  React-cxxreact: 159ceb3562b5c5a23cc9adf04f9f5a1e2cf5777d
+  React-DevSupport: 92043cdd0bbc710627bd3953d436819ff2754662
+  React-jsi: 153570811fc3cabe0cf90e9735b4ad42e64527ae
+  React-jsiexecutor: ee27f3e41e7bd2050e610631f0df4a146837cf9b
+  React-jsinspector: 568d71aea32345fa4a0d2ce23d32cb69f95eb477
+  React-RCTActionSheet: 0e76057a8d8f08e8e71b9002d7056f60150099e5
+  React-RCTAnimation: 87f0c96d027ec119ece5d4213790939cee851d94
+  React-RCTBlob: a13ca69a347e46a4ac8064e00b77fc45fb9fbe8f
+  React-RCTImage: b8490067d5106720e860bb9489521c575102f34b
+  React-RCTLinking: 17465b61b5dbc5d35c8ceed30e3c59f50ffa37e2
+  React-RCTNetwork: 9d0cf31226f6f2a7bff04ecd4a0d01019a29a1d3
+  React-RCTPushNotification: ca598eb8d5800c298481b0c95e6e34920973cb3b
+  React-RCTSettings: 56615bc7d341fffa5822c2e25e7eff31e22b651f
+  React-RCTTest: c52f327cec2a817e0a16168e8c74c6e4b6332221
+  React-RCTText: 1be4e2a223c5eab5dbd7df76586a669fd6625f28
+  React-RCTVibration: a7b9a5a71bac83da9c522a7065299691e30ddd39
+  React-RCTWebSocket: e3609f7e304d8f6937309f63dc75f488fe6d8d01
+  ReactCommon: d7177961935f44dfc7656b5cdbd682a514941ceb
+  yoga: 6dbd12d26e6b6726ef4fe59093938a542407ce98
 
-PODFILE CHECKSUM: f866eab42001b1d59349bce6b20d00912cdc700c
+PODFILE CHECKSUM: 060903e270072f1e192b064848e6c34528af1c87
 
 COCOAPODS: 1.7.1


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

This adds a `test_ios_frameworks` job to CircleCI to test the `RNTesterPods` project with `use_frameworks!` enabled. It will ensure the issue in https://github.com/facebook/react-native/issues/25349 is not reintroduced as suggested in https://github.com/facebook/react-native/pull/25619#issuecomment-514380653.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[iOS] [Internal] - Added CircleCI job for testing `RNTesterPods` with `use_frameworks!` enabled.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Tests seem to be failing on `master` at the moment but you can see that the new job builds successfully [here](https://circleci.com/gh/facebook/react-native/103929?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link). You can confirm it installs the pods with `use_frameworks!` by seeing that `Installing pods with use_frameworks!` is at the start of the log for the `Generate RNTesterPods Workspace` step.