### PR TITLE
Fixed android bounding box

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeViewHierarchyManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeViewHierarchyManager.java
@@ -660,18 +660,18 @@ public class NativeViewHierarchyManager {
     outputBuffer[1] -= rootY;
   }
 
-  void computeBoundingBox(View v, int[] outputBuffer) {
+  private void computeBoundingBox(View v, int[] outputBuffer) {
     mBoundingBox.set(0, 0, v.getWidth(), v.getHeight());
     mapRectFromViewToWindowCoords(v, mBoundingBox);
 
-    outputBuffer[0] = (int) mBoundingBox.left;
-    outputBuffer[1] = (int) mBoundingBox.top;
-    outputBuffer[2] = (int) (mBoundingBox.right - mBoundingBox.left);
-    outputBuffer[3] = (int) (mBoundingBox.bottom - mBoundingBox.top);
+    outputBuffer[0] = Math.round(mBoundingBox.left);
+    outputBuffer[1] = Math.round(mBoundingBox.top);
+    outputBuffer[2] = Math.round(mBoundingBox.right - mBoundingBox.left);
+    outputBuffer[3] = Math.round(mBoundingBox.bottom - mBoundingBox.top);
   }
 
   // simplified version of the hidden Android method View.mapRectFromViewToScreenCoords()
-  void mapRectFromViewToWindowCoords(View v, RectF rect) {
+  private void mapRectFromViewToWindowCoords(View v, RectF rect) {
     Matrix m = v.getMatrix();
     if (!m.isIdentity()) {
       m.mapRect(rect);

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeViewHierarchyManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeViewHierarchyManager.java
@@ -660,6 +660,12 @@ public class NativeViewHierarchyManager {
     outputBuffer[1] -= rootY;
   }
 
+  /**
+   * Fills the outputBuffer with the view's bounding box [x, y, width, height]
+   *
+   * @param v
+   * @param outputBuffer
+   */
   private void computeBoundingBox(View v, int[] outputBuffer) {
     mBoundingBox.set(0, 0, v.getWidth(), v.getHeight());
     mapRectFromViewToWindowCoords(v, mBoundingBox);
@@ -670,7 +676,14 @@ public class NativeViewHierarchyManager {
     outputBuffer[3] = Math.round(mBoundingBox.bottom - mBoundingBox.top);
   }
 
-  // simplified version of the hidden Android method View.mapRectFromViewToScreenCoords()
+  /**
+   * Map a rectangle from view-relative coordinates to root-view-relative coordinates.
+   * This is a simplified version of the hidden Android method View.mapRectFromViewToScreenCoords()
+   * @see {@link View#mapRectFromViewToScreenCoords}
+   *
+   * @param v The view the coordinates are relative to
+   * @param rect The rectangle to be mapped
+   */
   private void mapRectFromViewToWindowCoords(View v, RectF rect) {
     Matrix m = v.getMatrix();
     if (!m.isIdentity()) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

This PR fixes #19637. 

Summary of the issue: on Android, transformed touchables have press issues because the touchable's measurements are incorrect in the release phase. `UIManager.measure()` returns an incorrect size and position as explained [here](https://github.com/facebook/react-native/issues/19637#issuecomment-396065914)

This is easily seen with the inspector : 

**Screenshot of a { scale: 2 } transform**
The real view (scaled) is in pink, the incorrect touchable area is in blue.
<img src="https://user-images.githubusercontent.com/110431/41190133-8d07ad02-6bd9-11e8-873d-93776a007309.png" width="200"/>

**Screenshot of a { rotateZ: "-45deg" } transform**
The real view (rotated) is in pink, the incorrect touchable area is in blue.
<img src="https://user-images.githubusercontent.com/110431/41190136-a1a079a6-6bd9-11e8-906d-729015bcab6b.png" width="200"/>

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[Android] [Fixed] - Fix UIManager.measure()

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Android now produces the same results as iOS as seen on these screenshots

| Android without fix | Android with fix | iOS |
| --- | --- | --- |
| ![Screenshot_1564133103](https://user-images.githubusercontent.com/110431/61941632-28729b00-af98-11e9-9706-b13968b79df5.png) | ![Screenshot_1564130198](https://user-images.githubusercontent.com/110431/61941631-28729b00-af98-11e9-9ff3-5f2748077dbe.png) | ![Simulator Screen Shot - iPhone X - 2019-07-26 at 11 19 34](https://user-images.githubusercontent.com/110431/61941633-28729b00-af98-11e9-8dc4-22b61178242e.png) |
