### PR TITLE
Use Metro support for auto-collapsing internal stack frames

### DIFF
--- a/Libraries/Core/ExceptionsManager.js
+++ b/Libraries/Core/ExceptionsManager.js
@@ -12,13 +12,6 @@
 
 import type {ExtendedError} from './Devtools/parseErrorStack';
 
-const INTERNAL_CALLSITES_REGEX = new RegExp(
-  [
-    '/Libraries/Renderer/oss/ReactNativeRenderer-dev\\.js$',
-    '/Libraries/BatchedBridge/MessageQueue\\.js$',
-  ].join('|'),
-);
-
 /**
  * Handles the developer-visible aspect of errors and exceptions
  */
@@ -50,14 +43,12 @@ function reportException(e: ExtendedError, isFatal: boolean) {
       symbolicateStackTrace(stack)
         .then(prettyStack => {
           if (prettyStack) {
-            const stackWithoutInternalCallsites = prettyStack.filter(
-              frame =>
-                frame.file &&
-                frame.file.match(INTERNAL_CALLSITES_REGEX) === null,
+            const stackWithoutCollapsedFrames = prettyStack.filter(
+              frame => !frame.collapse,
             );
             NativeExceptionsManager.updateExceptionMessage(
               message,
-              stackWithoutInternalCallsites,
+              stackWithoutCollapsedFrames,
               currentExceptionID,
             );
           } else {

--- a/Libraries/Core/NativeExceptionsManager.js
+++ b/Libraries/Core/NativeExceptionsManager.js
@@ -18,6 +18,7 @@ export type StackFrame = {|
   file: string,
   lineNumber: number,
   methodName: string,
+  collapse?: boolean,
 |};
 
 export type ExceptionData = {

--- a/Libraries/FBReactNativeSpec/FBReactNativeSpec/FBReactNativeSpec.h
+++ b/Libraries/FBReactNativeSpec/FBReactNativeSpec/FBReactNativeSpec.h
@@ -912,6 +912,7 @@ namespace JS {
       NSString *file() const;
       double lineNumber() const;
       NSString *methodName() const;
+      folly::Optional<bool> collapse() const;
 
       StackFrame(NSDictionary *const v) : _v(v) {}
     private:
@@ -2648,6 +2649,11 @@ inline NSString *JS::NativeExceptionsManager::StackFrame::methodName() const
 {
   id const p = _v[@"methodName"];
   return RCTBridgingToString(p);
+}
+inline folly::Optional<bool> JS::NativeExceptionsManager::StackFrame::collapse() const
+{
+  id const p = _v[@"collapse"];
+  return RCTBridgingToOptionalBool(p);
 }
 
 inline NSString *JS::NativeExceptionsManager::ExceptionData::message() const


### PR DESCRIPTION
Summary:
Changes `ExceptionsManager` to respect the `collapse` field in each symbolicated stack frame returned from Metro, in preference to the client-side regex. This is ultimately driven by a Metro config option (now also set in the RN new project template). Note that the client-side regex is intentionally ignored for any frame where `collapse` is present ( = all of them if using Metro with https://github.com/facebook/metro/pull/435).

Also updates the client-side regex to match the new renderer paths.

This is part of a redesign of work done originally in https://github.com/facebook/react-native/pull/24662; I intend to eventually remove the client-side regex from RN.

Reviewed By: cpojer

Differential Revision: D16500277

