### PR TITLE
Export the DevSettings module, add `addMenuItem` method

### DIFF
--- a/Libraries/NativeModules/specs/NativeDevSettings.js
+++ b/Libraries/NativeModules/specs/NativeDevSettings.js
@@ -19,6 +19,7 @@ export interface Spec extends TurboModule {
   +setIsDebuggingRemotely: (isDebuggingRemotelyEnabled: boolean) => void;
   +setProfilingEnabled: (isProfilingEnabled: boolean) => void;
   +toggleElementInspector: () => void;
+  +addMenuItem: (title: string) => void;
 
   // iOS only.
   +setIsShakeToShowDevMenuEnabled: (enabled: boolean) => void;

--- a/Libraries/Utilities/DevSettings.js
+++ b/Libraries/Utilities/DevSettings.js
@@ -1,0 +1,46 @@
+import NativeDevSettings from '../NativeModules/specs/NativeDevSettings';
+import NativeEventEmitter from '../EventEmitter/NativeEventEmitter';
+
+class DevSettings extends NativeEventEmitter {
+  _menuItems: Map<string, () => mixed>;
+
+  constructor() {
+    super(NativeDevSettings);
+
+    this._menuItems = new Map();
+  }
+
+  addMenuItem(title: string, handler: () => mixed) {
+    // Make sure items are not added multiple times. This can
+    // happen when hot reloading the module that registers the
+    // menu items. The title is used as the id which means we
+    // don't support multiple items with the same name.
+    const oldHandler = this._menuItems.get(title);
+    if (oldHandler != null) {
+      this.removeListener('didPressMenuItem', oldHandler);
+    } else {
+      NativeDevSettings.addMenuItem(title);
+    }
+
+    this._menuItems.set(title, handler);
+    this.addListener('didPressMenuItem', (event) => {
+      if (event.title === title) {
+        handler();
+      }
+    });
+  }
+
+  reload() {
+    NativeDevSettings.reload();
+  }
+
+  // TODO: Add other dev setting methods exposed by the native module.
+}
+
+// Avoid including the full `NativeDevSettings` class in prod.
+class NoopDevSettings {
+  addMenuItem(title: string, handler: () => mixed) {}
+  reload() {}
+}
+
+module.exports = __DEV__ ? new DevSettings() : new NoopDevSettings();

--- a/RNTester/js/examples/DevSettings/DevSettingsExample.js
+++ b/RNTester/js/examples/DevSettings/DevSettingsExample.js
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow
+ */
+
+'use strict';
+
+import * as React from 'react';
+import {Alert, Button, DevSettings} from 'react-native';
+
+exports.title = 'DevSettings';
+exports.description = 'Customize the development settings';
+exports.examples = [
+  {
+    title: 'Add dev menu item',
+    render(): React.Element<any> {
+      return (
+        <Button
+          title="Add"
+          onPress={() => {
+            DevSettings.addMenuItem('Show Secret Dev Screen', () => {
+              Alert.alert('Showing secret dev screen!');
+            });
+          }}
+        />
+      );
+    },
+  },
+  {
+    title: 'Reload the app',
+    render(): React.Element<any> {
+      return (
+        <Button
+          title="Reload"
+          onPress={() => {
+            DevSettings.reload();
+          }}
+        />
+      );
+    },
+  },
+];

--- a/RNTester/js/utils/RNTesterList.android.js
+++ b/RNTester/js/utils/RNTesterList.android.js
@@ -157,6 +157,10 @@ const APIExamples: Array<RNTesterExample> = [
     module: require('../examples/DatePicker/DatePickerAndroidExample'),
   },
   {
+    key: 'DevSettings',
+    module: require('../examples/DevSettings/DevSettingsExample'),
+  },
+  {
     key: 'Dimensions',
     module: require('../examples/Dimensions/DimensionsExample'),
   },

--- a/RNTester/js/utils/RNTesterList.ios.js
+++ b/RNTester/js/utils/RNTesterList.ios.js
@@ -236,6 +236,10 @@ const APIExamples: Array<RNTesterExample> = [
     supportsTVOS: false,
   },
   {
+    key: 'DevSettings',
+    module: require('../examples/DevSettings/DevSettingsExample'),
+  },
+  {
     key: 'Dimensions',
     module: require('../examples/Dimensions/DimensionsExample'),
     supportsTVOS: true,

--- a/React/Modules/RCTDevSettings.h
+++ b/React/Modules/RCTDevSettings.h
@@ -7,6 +7,7 @@
 
 #import <React/RCTBridge.h>
 #import <React/RCTDefines.h>
+#import <React/RCTEventEmitter.h>
 
 @protocol RCTPackagerClientMethod;
 
@@ -29,7 +30,7 @@
 
 @end
 
-@interface RCTDevSettings : NSObject
+@interface RCTDevSettings : RCTEventEmitter
 
 - (instancetype)initWithDataSource:(id<RCTDevSettingsDataSource>)dataSource;
 

--- a/ReactAndroid/src/androidTest/java/com/facebook/react/testing/ReactSettingsForTests.java
+++ b/ReactAndroid/src/androidTest/java/com/facebook/react/testing/ReactSettingsForTests.java
@@ -52,4 +52,7 @@ public class ReactSettingsForTests implements DeveloperSettings {
   public boolean isStartSamplingProfilerOnInit() {
     return false;
   }
+
+  @Override
+  public void addMenuItem(String title) {}
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/CoreModulesPackage.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/CoreModulesPackage.java
@@ -139,7 +139,7 @@ import java.util.Map;
       case DeviceEventManagerModule.NAME:
         return new DeviceEventManagerModule(reactContext, mHardwareBackBtnHandler);
       case DevSettingsModule.NAME:
-        return new DevSettingsModule(mReactInstanceManager.getDevSupportManager());
+        return new DevSettingsModule(reactContext, mReactInstanceManager.getDevSupportManager());
       case ExceptionsManagerModule.NAME:
         return new ExceptionsManagerModule(mReactInstanceManager.getDevSupportManager());
       case HeadlessJsTaskSupportModule.NAME:

--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevInternalSettings.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevInternalSettings.java
@@ -123,6 +123,11 @@ public class DevInternalSettings
     return mPreferences.getBoolean(PREFS_START_SAMPLING_PROFILER_ON_INIT, false);
   }
 
+  @Override
+  public void addMenuItem(String title) {
+    // Not supported.
+  }
+
   public interface Listener {
     void onInternalSettingsChanged();
   }

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/debug/DevSettingsModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/debug/DevSettingsModule.java
@@ -6,23 +6,30 @@
  */
 package com.facebook.react.modules.debug;
 
-import com.facebook.react.bridge.BaseJavaModule;
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.UiThreadUtil;
+import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.devsupport.interfaces.DevSupportManager;
+import com.facebook.react.devsupport.interfaces.DevOptionHandler;
 import com.facebook.react.module.annotations.ReactModule;
+import com.facebook.react.modules.core.DeviceEventManagerModule.RCTDeviceEventEmitter;
 
 /**
  * Module that exposes the URL to the source code map (used for exception stack trace parsing) to JS
  */
 @ReactModule(name = DevSettingsModule.NAME)
-public class DevSettingsModule extends BaseJavaModule {
+public class DevSettingsModule extends ReactContextBaseJavaModule {
 
   public static final String NAME = "DevSettings";
 
   private final DevSupportManager mDevSupportManager;
 
-  public DevSettingsModule(DevSupportManager devSupportManager) {
+  public DevSettingsModule(ReactApplicationContext reactContext, DevSupportManager devSupportManager) {
+    super(reactContext);
+
     mDevSupportManager = devSupportManager;
   }
 
@@ -62,5 +69,19 @@ public class DevSettingsModule extends BaseJavaModule {
   @ReactMethod
   public void toggleElementInspector() {
     mDevSupportManager.toggleElementInspector();
+  }
+
+  @ReactMethod
+  public void addMenuItem(final String title) {
+    mDevSupportManager.addCustomDevOption(title, new DevOptionHandler() {
+      @Override
+      public void onOptionSelected() {
+        WritableMap data = Arguments.createMap();
+        data.putString("title", title);
+        getReactApplicationContext()
+          .getJSModule(RCTDeviceEventEmitter.class)
+          .emit("didPressMenuItem", data);
+      }
+    });
   }
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/debug/interfaces/DeveloperSettings.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/debug/interfaces/DeveloperSettings.java
@@ -35,4 +35,7 @@ public interface DeveloperSettings {
 
   /** @return Whether Start Sampling Profiler on App Start is enabled. */
   boolean isStartSamplingProfilerOnInit();
+
+  /** Add an item to the dev menu. */
+  void addMenuItem(String title);
 }

--- a/index.js
+++ b/index.js
@@ -56,6 +56,7 @@ import typeof BackHandler from './Libraries/Utilities/BackHandler';
 import typeof Clipboard from './Libraries/Components/Clipboard/Clipboard';
 import typeof DatePickerAndroid from './Libraries/Components/DatePickerAndroid/DatePickerAndroid';
 import typeof DeviceInfo from './Libraries/Utilities/DeviceInfo';
+import typeof DevSettings from './Libraries/Utilities/DevSettings';
 import typeof Dimensions from './Libraries/Utilities/Dimensions';
 import typeof Easing from './Libraries/Animated/src/Easing';
 import typeof ReactNative from './Libraries/Renderer/shims/ReactNative';
@@ -290,6 +291,9 @@ module.exports = {
   },
   get DeviceInfo(): DeviceInfo {
     return require('./Libraries/Utilities/DeviceInfo');
+  },
+  get DevSettings(): DevSettings {
+    return require('./Libraries/Utilities/DevSettings');
   },
   get Dimensions(): Dimensions {
     return require('./Libraries/Utilities/Dimensions');


### PR DESCRIPTION
## Summary

I wanted to configure the RN dev menu without having to write native code. This is pretty useful in a greenfield app since it avoids having to write a custom native module for both platforms (and might enable the feature for expo too).

This ended up a bit more involved than planned since callbacks can only be called once. I needed to convert the `DevSettings` module to a `NativeEventEmitter` and use events when buttons are clicked. This means creating a JS wrapper for it. Currently it does not export all methods, they can be added in follow ups as needed.

## Changelog

[General] [Added] - Export the DevSettings module, add `addMenuItem` method

## Test Plan

Tested in an app using the following code.

```js
if (__DEV__) {
 DevSettings.addMenuItem('Show Dev Screen', () => {
    dispatchNavigationAction(
      NavigationActions.navigate({
        routeName: 'dev',
      }),
    );
  });
}
```

Added an example in RN tester

![devmenu](https://user-images.githubusercontent.com/2677334/62000297-71624680-b0a1-11e9-8403-bc95c4747f0c.gif)

