### PR TITLE
[iOS][Fix] Do not override ActivityIndicator color when setting its size

### DIFF
--- a/React/Views/RCTActivityIndicatorViewManager.m
+++ b/React/Views/RCTActivityIndicatorViewManager.m
@@ -33,7 +33,17 @@ RCT_EXPORT_MODULE()
 
 RCT_EXPORT_VIEW_PROPERTY(color, UIColor)
 RCT_EXPORT_VIEW_PROPERTY(hidesWhenStopped, BOOL)
-RCT_REMAP_VIEW_PROPERTY(size, activityIndicatorViewStyle, UIActivityIndicatorViewStyle)
+RCT_CUSTOM_VIEW_PROPERTY(size, UIActivityIndicatorViewStyle, UIActivityIndicatorView)
+{
+  /*
+    Setting activityIndicatorViewStyle overrides the color, so restore the original color
+    after setting the indicator style.
+  */
+  UIColor *oldColor = view.color;
+  view.activityIndicatorViewStyle = json ? [RCTConvert UIActivityIndicatorViewStyle: json] : defaultView.activityIndicatorViewStyle;
+  view.color = oldColor;
+}
+
 RCT_CUSTOM_VIEW_PROPERTY(animating, BOOL, UIActivityIndicatorView)
 {
   BOOL animating = json ? [RCTConvert BOOL:json] : [defaultView isAnimating];


### PR DESCRIPTION
## Summary

The activityIndicatorViewStyle property overrides the previous set color
if it's changed. Depending on the property set order you may end in a state
that the color property will never be respected since it first sets
the color and then the activityIndicatorViewStyle property (which overrides
the color property). In order to prevent this problem
before setting the new activityIndicatorViewStyle save the old
color and override it after activityIndicatorViewStyle is set. Thus
always respecting the user's color.

## Changelog

[iOS] [Fixed] - Do not override ActivityIndicator color when setting its size

## Test Plan
Using the code below on iOS notice that the last ActivityIndicator will always have its color set to white while te testID is provided


### Without the patch
Notice the white -> blue transition when disabling the testID

![broken](https://user-images.githubusercontent.com/984610/61999339-16c2ed80-b095-11e9-80f7-81c38eca761a.gif)


### With the patch
Color remains unchanged 

![working](https://user-images.githubusercontent.com/984610/61999338-1165a300-b095-11e9-9cb6-e45999db1544.gif)


```javascript
import React from "react";
import { View, StyleSheet, ActivityIndicator, Button } from "react-native";

const App = () => {
  const [enableTestID, onSetEnableTestID] = React.useState(true);
  const onPress = React.useCallback(() => {
    onSetEnableTestID(!enableTestID);
  }, [enableTestID]);
  return (
    <View style={styles.container}>
      <ActivityIndicator size="large" color="red" />
      <ActivityIndicator size="small" color="red" />
      <ActivityIndicator size="small" />
      <ActivityIndicator color="green" />
      <ActivityIndicator
        key={enableTestID.toString()}
        size="large"
        color="blue"
        testID={enableTestID ? 'please work' : undefined}
      />
      <Button
        title={enableTestID ? 'Disable testID' : 'enable testID'}
        onPress={onPress}
      />
    </View>
  );
};

export default App;

const styles = StyleSheet.create({
  container: {
    flex: 1,
    alignItems: "center",
    justifyContent: "center",
    backgroundColor: "black"
  },
});

```

Closes https://github.com/facebook/react-native/issues/25319