### PR TITLE
Memory Leak due to JSStringRelease not called in multiple places in JSCRuntime.cpp

### DIFF
--- a/ReactCommon/jsi/JSCRuntime.cpp
+++ b/ReactCommon/jsi/JSCRuntime.cpp
@@ -630,7 +630,9 @@ jsi::String JSCRuntime::createStringFromUtf8(
     size_t length) {
   std::string tmp(reinterpret_cast<const char*>(str), length);
   JSStringRef stringRef = JSStringCreateWithUTF8CString(tmp.c_str());
-  return createString(stringRef);
+  auto result = createString(stringRef);
+  JSStringRelease(stringRef);
+  return result;
 }
 
 std::string JSCRuntime::utf8(const jsi::String& str) {


### PR DESCRIPTION
## Summary
Memory Leak due to JSStringRelease not called in multiple places in JSCRuntime.cpp
Issue: https://github.com/facebook/react-native/issues/25664
Reproducible repo: https://github.com/bhandarijiwan/memory_issue_repro

## Changelog
[JSC] [JSCRuntime.cpp] - Added missing JSStringRelease calls in missing places

## Test Plan
Tested that is no memory leak with various NativeModule to JS call flows



