### PR TITLE
Update App.js

### DIFF
--- a/template/App.js
+++ b/template/App.js
@@ -6,7 +6,7 @@
  * @flow
  */
 
-import React, {Fragment} from 'react';
+import React from 'react';
 import {
   SafeAreaView,
   StyleSheet,
@@ -26,7 +26,7 @@ import {
 
 const App = () => {
   return (
-    <Fragment>
+    <>
       <StatusBar barStyle="dark-content" />
       <SafeAreaView>
         <ScrollView
@@ -68,7 +68,7 @@ const App = () => {
           </View>
         </ScrollView>
       </SafeAreaView>
-    </Fragment>
+    </>
   );
 };
 


### PR DESCRIPTION
use "shorthand" of `Fragment`

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
No need to import `Fragment` as it can be used via `<></>` vs `<Fragment><Fragment />`

## Changelog
Use shorthand for Fragment in App.js

[General] [Changed] - Use shorthand for Fragment in App.js

## Test Plan
Ci Tests should be sufficient
