### PR TITLE
Bump hermes to v0.1.1

### DIFF
--- a/RNTester/android/app/build.gradle
+++ b/RNTester/android/app/build.gradle
@@ -70,7 +70,7 @@ project.ext.react = [
     root: "$rootDir",
     inputExcludes: ["android/**", "./**", ".gradle/**"],
     composeSourceMapsPath: "$rootDir/scripts/compose-source-maps.js",
-    hermesCommand: "../../../node_modules/hermesvm/%OS-BIN%/hermes",
+    hermesCommand: "../../../node_modules/hermes-engine/%OS-BIN%/hermes",
     enableHermesForVariant: { def v -> v.name.contains("hermes") }
 ]
 
@@ -165,7 +165,7 @@ dependencies {
     // Build React Native from source
     implementation project(':ReactAndroid')
 
-    def hermesPath = '$projectDir/../../../../node_modules/hermesvm/android/'
+    def hermesPath = '$projectDir/../../../../node_modules/hermes-engine/android/'
     debugImplementation files(hermesPath + "hermes-debug.aar")
     releaseImplementation files(hermesPath + "hermes-release.aar")
 

--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -92,15 +92,15 @@ task prepareFolly(dependsOn: dependenciesPath ? [] : [downloadFolly], type: Copy
 }
 
 task prepareHermes() {
-    def hermesAAR = file("$projectDir/../node_modules/hermesvm/android/hermes-debug.aar")
+    def hermesAAR = file("$projectDir/../node_modules/hermes-engine/android/hermes-debug.aar")
     if (!hermesAAR.exists()) {
-        // For an app to build from RN source, hermesvm is located at /path/to/app/node_modules
+        // For an app to build from RN source, hermes-engine is located at /path/to/app/node_modules
         // and $projectDir is located at /path/to/app/node_modules/react-native/ReactAndroid
-        hermesAAR = file("$projectDir/../../hermesvm/android/hermes-debug.aar")
+        hermesAAR = file("$projectDir/../../hermes-engine/android/hermes-debug.aar")
 
         if (!hermesAAR.exists()) {
           // At Facebook, this file is in a different folder
-          hermesAAR = file("$projectDir/../../node_modules/hermesvm/android/hermes-debug.aar")
+          hermesAAR = file("$projectDir/../../node_modules/hermes-engine/android/hermes-debug.aar")
         }
     }
     def soFiles = zipTree(hermesAAR).matching({ it.include "**/*.so" })

--- a/ReactAndroid/src/main/java/com/facebook/hermes/reactexecutor/Android.mk
+++ b/ReactAndroid/src/main/java/com/facebook/hermes/reactexecutor/Android.mk
@@ -12,7 +12,7 @@ LOCAL_MODULE := hermes-executor-release
 
 LOCAL_SRC_FILES := $(wildcard $(LOCAL_PATH)/*.cpp)
 
-LOCAL_C_INCLUDES := $(LOCAL_PATH) $(REACT_NATIVE)/ReactCommon/jsi $(REACT_NATIVE)/node_modules/hermesvm/android/include $(REACT_NATIVE)/../hermesvm/android/include $(REACT_NATIVE)/../node_modules/hermesvm/include
+LOCAL_C_INCLUDES := $(LOCAL_PATH) $(REACT_NATIVE)/ReactCommon/jsi $(REACT_NATIVE)/node_modules/hermes-engine/android/include $(REACT_NATIVE)/../hermes-engine/android/include $(REACT_NATIVE)/../node_modules/hermes-engine/include
 
 LOCAL_CPP_FEATURES := exceptions
 
@@ -30,7 +30,7 @@ LOCAL_CFLAGS := -DHERMES_ENABLE_DEBUGGER=1
 
 LOCAL_SRC_FILES := $(wildcard $(LOCAL_PATH)/*.cpp)
 
-LOCAL_C_INCLUDES := $(LOCAL_PATH) $(REACT_NATIVE)/ReactCommon/jsi $(REACT_NATIVE)/node_modules/hermesvm/android/include $(REACT_NATIVE)/../hermesvm/android/include $(REACT_NATIVE)/../node_modules/hermesvm/include
+LOCAL_C_INCLUDES := $(LOCAL_PATH) $(REACT_NATIVE)/ReactCommon/jsi $(REACT_NATIVE)/node_modules/hermes-engine/android/include $(REACT_NATIVE)/../hermes-engine/android/include $(REACT_NATIVE)/../node_modules/hermes-engine/include
 
 LOCAL_CPP_FEATURES := exceptions
 

--- a/ReactCommon/hermes/inspector/Android.mk
+++ b/ReactCommon/hermes/inspector/Android.mk
@@ -15,7 +15,7 @@ LOCAL_SRC_FILES := $(wildcard $(LOCAL_PATH)/*.cpp $(LOCAL_PATH)/detail/*.cpp $(L
 LOCAL_C_ROOT := $(LOCAL_PATH)/../..
 
 LOCAL_CFLAGS := -DHERMES_ENABLE_DEBUGGER=1
-LOCAL_C_INCLUDES := $(LOCAL_C_ROOT) $(REACT_NATIVE)/ReactCommon/jsi $(REACT_NATIVE)/node_modules/hermesvm/android/include $(REACT_NATIVE)/../hermesvm/android/include $(REACT_NATIVE)/../node_modules/hermesvm/include
+LOCAL_C_INCLUDES := $(LOCAL_C_ROOT) $(REACT_NATIVE)/ReactCommon/jsi $(REACT_NATIVE)/node_modules/hermes-engine/android/include $(REACT_NATIVE)/../hermes-engine/android/include $(REACT_NATIVE)/../node_modules/hermes-engine/include
 LOCAL_EXPORT_C_INCLUDES := $(LOCAL_C_ROOT)
 
 LOCAL_CPP_FEATURES := exceptions

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "event-target-shim": "^5.0.1",
     "fbjs": "^1.0.0",
     "fbjs-scripts": "^1.1.0",
-    "hermesvm": "^0.1.0",
+    "hermes-engine": "^0.1.1",
     "invariant": "^2.2.4",
     "jsc-android": "^245459.0.0",
     "metro-babel-register": "0.54.1",

--- a/react.gradle
+++ b/react.gradle
@@ -16,7 +16,7 @@ def reactRoot = file(config.root ?: "../../")
 def inputExcludes = config.inputExcludes ?: ["android/**", "ios/**"]
 def bundleConfig = config.bundleConfig ? "${reactRoot}/${config.bundleConfig}" : null ;
 def enableVmCleanup = config.enableVmCleanup == null ? true : config.enableVmCleanup
-def hermesCommand = config.hermesCommand ?: "../../node_modules/hermesvm/%OS-BIN%/hermes"
+def hermesCommand = config.hermesCommand ?: "../../node_modules/hermes-engine/%OS-BIN%/hermes"
 
 def reactNativeDevServerPort() {
     def value = project.getProperties().get("reactNativeDevServerPort")

--- a/template/android/app/build.gradle
+++ b/template/android/app/build.gradle
@@ -192,7 +192,7 @@ dependencies {
     implementation "com.facebook.react:react-native:+"  // From node_modules
 
     if (enableHermes) {
-      def hermesPath = "../../node_modules/hermesvm/android/";
+      def hermesPath = "../../node_modules/hermes-engine/android/";
       debugImplementation files(hermesPath + "hermes-debug.aar")
       releaseImplementation files(hermesPath + "hermes-release.aar")
     } else {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3459,10 +3459,10 @@ has@^1.0.1, has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
-hermesvm@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/hermesvm/-/hermesvm-0.1.0.tgz#4bfaf4ac682a2fd407b862ab641eb8deb232de83"
-  integrity sha512-GbP6dKaVW/V2QpB+DZPxcmhBhJVFa9cHS/xRX7FD1MGfa6Z1aHHD83VDCwo3SgcqNj5yHlVbe9UgrK1PFGCXpw==
+hermes-engine@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/hermes-engine/-/hermes-engine-0.1.1.tgz#33d5da1a3b7289667f121dc1aca3566171e86fd8"
+  integrity sha512-5nPNtJg3ZiUT14SfU5KcETWrDFadn9R0hv2FCihiLZUeNHuLxaoiFy0bAMrXukKPyXG76XZ4zl5iGXr7E7Nhpw==
 
 home-or-tmp@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
## Summary

Hermes has been updated to [v0.1.1](https://github.com/facebook/hermes/releases/tag/v0.1.1) and [renamed from 'hermesvm' to 'hermes-engine'](https://github.com/facebook/hermes/commit/c74842ee5c4d11dc9fe3bf012f97a0e3fde6d54f)

## Changelog

[Android] [Changed] - Bump hermes to v0.1.1

## Test Plan

RNTester builds and runs as expected
