### PR TITLE
Add proguard rules for Hermes

### DIFF
--- a/template/android/app/proguard-rules.pro
+++ b/template/android/app/proguard-rules.pro
@@ -8,3 +8,6 @@
 #   http://developer.android.com/guide/developing/tools/proguard.html
 
 # Add any project specific keep options here:
+
+# Hermes specific rules (uncomment only if you have hermes enabled):
+# -keep class com.facebook.hermes.unicode.* { *; }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
This adds Proguard rules for retaining the unicode classes of Hermes (if R8/Proguard is enabled). This basically fixes a `ClassNotFound` exception in release builds.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[Internal] [Added] - Added Proguard rules for Hermes

## Test Plan

Tested on RN 0.60.4 project with Hermes 0.1.1 enabled.
