### PR TITLE
Fix `ClassNotFound` exception in Android during Release builds

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/hermes/unicode/AndroidUnicodeUtils.java
+++ b/ReactAndroid/src/main/java/com/facebook/hermes/unicode/AndroidUnicodeUtils.java
@@ -6,6 +6,7 @@
  */
 package com.facebook.hermes.unicode;
 
+import com.facebook.proguard.annotations.DoNotStrip;
 import java.text.Collator;
 import java.text.DateFormat;
 import java.text.Normalizer;

--- a/ReactAndroid/src/main/java/com/facebook/hermes/unicode/AndroidUnicodeUtils.java
+++ b/ReactAndroid/src/main/java/com/facebook/hermes/unicode/AndroidUnicodeUtils.java
@@ -16,11 +16,13 @@ import java.util.Locale;
 // available via DI.
 @DoNotStrip
 public class AndroidUnicodeUtils {
+  @DoNotStrip
   public static int localeCompare(String left, String right) {
     Collator collator = Collator.getInstance();
     return collator.compare(left, right);
   }
 
+  @DoNotStrip
   public static String dateFormat(double unixtimeMs, boolean formatDate, boolean formatTime) {
     DateFormat format;
     if (formatDate && formatTime) {
@@ -35,6 +37,7 @@ public class AndroidUnicodeUtils {
     return format.format((long) unixtimeMs).toString();
   }
 
+  @DoNotStrip
   public static String convertToCase(String input, int targetCase, boolean useCurrentLocale) {
     // These values must match CaseConversion in PlatformUnicode.h
     final int targetUppercase = 0;
@@ -53,6 +56,7 @@ public class AndroidUnicodeUtils {
     }
   }
 
+  @DoNotStrip
   public static String normalize(String input, int form) {
     // Values must match NormalizationForm in PlatformUnicode.h.
     final int formC = 0;

--- a/ReactAndroid/src/main/java/com/facebook/hermes/unicode/AndroidUnicodeUtils.java
+++ b/ReactAndroid/src/main/java/com/facebook/hermes/unicode/AndroidUnicodeUtils.java
@@ -14,6 +14,7 @@ import java.util.Locale;
 // TODO: use com.facebook.common.locale.Locales.getApplicationLocale() as the current locale,
 // rather than the device locale. This is challenging because getApplicationLocale() is only
 // available via DI.
+@DoNotStrip
 public class AndroidUnicodeUtils {
   public static int localeCompare(String left, String right) {
     Collator collator = Collator.getInstance();


### PR DESCRIPTION
## Summary

This adds the `@DoNotStrip` annotation to disallow Proguard/R8 from stripping the `AndroidUnicodeUtils` class during release build and causing a `ClassNotFound` crash.

## Changelog

[Internal] [Fixed] - Fixed `ClassNotFound` exception in Android during Release builds

## Test Plan