### PR TITLE
Fix launch crash on iOS when using together with `react-native-unity-view`

### DIFF
--- a/ReactCommon/cxxreact/ModuleRegistry.cpp
+++ b/ReactCommon/cxxreact/ModuleRegistry.cpp
@@ -83,7 +83,7 @@ folly::Optional<ModuleConfig> ModuleRegistry::getConfig(const std::string& name)
 
   // Initialize modulesByName_
   if (modulesByName_.empty() && !modules_.empty()) {
-    moduleNames();
+    moduleNamesVec_ = moduleNames();
   }
 
   auto it = modulesByName_.find(name);

--- a/ReactCommon/cxxreact/ModuleRegistry.h
+++ b/ReactCommon/cxxreact/ModuleRegistry.h
@@ -52,6 +52,9 @@ class RN_EXPORT ModuleRegistry {
   // This is always populated
   std::vector<std::unique_ptr<NativeModule>> modules_;
 
+  // This is used to hold modlue names vector so that it's not freed up.
+  std::vector<std::string> moduleNamesVec_;
+
   // This is used to extend the population of modulesByName_ if registerModules is called after moduleNames
   void updateModuleNamesFromIndex(size_t size);
 

--- a/ReactCommon/cxxreact/ModuleRegistry.h
+++ b/ReactCommon/cxxreact/ModuleRegistry.h
@@ -52,7 +52,7 @@ class RN_EXPORT ModuleRegistry {
   // This is always populated
   std::vector<std::unique_ptr<NativeModule>> modules_;
 
-  // This is used to hold modlue names vector so that it's not freed up.
+  // This is used to hold module names vector so that it's not freed up.
   std::vector<std::string> moduleNamesVec_;
 
   // This is used to extend the population of modulesByName_ if registerModules is called after moduleNames


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
The issue was reported [here](https://github.com/facebook/react-native/issues/23465) and discussed. As @mtostenson found

> I have been able to narrow it down to this function: ModuleRegistry::moduleNames
When the vector that is returned from this function goes out of scope and the memory is freed, the app inexplicably crashes.

Adding a moduleNamesVec_ property to hold `moduleNames()` will address the issue by keeping a reference to the return results.
This will fix launch crash when using together with `react-native-unity-view`


## Changelog

[iOS] [Fixed] - Fix launch crash on iOS when integrated together with `react-native-unity-view`

