### PR TITLE
Add ErrorUtils to global variables

### DIFF
--- a/packages/eslint-config-react-native-community/index.js
+++ b/packages/eslint-config-react-native-community/index.js
@@ -82,6 +82,7 @@ module.exports = {
     clearTimeout: false,
     console: false,
     document: false,
+    ErrorUtils: false,
     escape: false,
     Event: false,
     EventTarget: false,


### PR DESCRIPTION
## Summary
ErrorUtils is giving an error by eslint. ('ErrorUtils is not defined'). 

## Changelog
[General] [Fixed] - Add ErrorUtils to eslint globals

## Test Plan
Run eslint on a react native project using ErrorUtils. Eslint verification should pass.

