### PR TITLE
Fix addition of comma at the end of accessibility labels on Android.

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
@@ -6,11 +6,14 @@
 package com.facebook.react.uimanager;
 
 import android.graphics.Color;
+import android.text.TextUtils;
 import android.view.View;
 import android.view.ViewParent;
 import androidx.core.view.ViewCompat;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 
 import com.facebook.react.R;
 import com.facebook.react.bridge.ReadableArray;
@@ -173,23 +176,23 @@ public abstract class BaseViewManager<T extends View, C extends LayoutShadowNode
     final String accessibilityLabel = (String) view.getTag(R.id.accessibility_label);
     final ReadableArray accessibilityStates = (ReadableArray) view.getTag(R.id.accessibility_states);
     final String accessibilityHint = (String) view.getTag(R.id.accessibility_hint);
-    StringBuilder contentDescription = new StringBuilder();
+    final List<String> contentDescription = new ArrayList<>();
     if (accessibilityLabel != null) {
-      contentDescription.append(accessibilityLabel + ", ");
+      contentDescription.add(accessibilityLabel);
     }
     if (accessibilityStates != null) {
       for (int i = 0; i < accessibilityStates.size(); i++) {
         String state = accessibilityStates.getString(i);
         if (sStateDescription.containsKey(state)) {
-          contentDescription.append(view.getContext().getString(sStateDescription.get(state)) + ", ");
+          contentDescription.add(view.getContext().getString(sStateDescription.get(state)));
         }
       }
     }
     if (accessibilityHint != null) {
-      contentDescription.append(accessibilityHint + ", ");
+      contentDescription.add(accessibilityHint);
     }
-    if (contentDescription.length() > 0) {
-      view.setContentDescription(contentDescription.toString());
+    if (contentDescription.size() > 0) {
+      view.setContentDescription(TextUtils.join(", ", contentDescription));
     }
   }
 


### PR DESCRIPTION
## Summary

Commit 1aeac1c625 erroneously added a comma and space to the end of accessibilityLabels for components which did not have additional state and hint information. This commit corrects this behavior.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[Android] [Fix] - Remove extra comma and space from accessibilityLabels on Android.

## Test Plan

Using TalkBack's display of spoken labels, ensured that no extra symbols are added to accessibilityLabels.
