### PR TITLE
fix display problems when image fails to load

### DIFF
--- a/Libraries/Image/RCTImageView.m
+++ b/Libraries/Image/RCTImageView.m
@@ -347,6 +347,14 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithFrame:(CGRect)frame)
   }
 
   if (error) {
+    if (_pendingImageSource.request && _imageSource.request && ![_pendingImageSource.request.URL.absoluteString isEqual: _imageSource.request.URL.absoluteString]) {
+        RCTExecuteOnMainQueue(^{
+            [self.layer removeAnimationForKey:@"contents"];
+            self.image = loadedImage;
+            self->_imageSource = source;
+            self->_pendingImageSource = nil;
+        });
+    }
     if (_onError) {
       _onError(@{ @"error": error.localizedDescription });
     }


### PR DESCRIPTION
## Summary

When the image resource is changed and the new image resource fails to load, we expect the display image to fail to load, but the image still shows the image that was successfully loaded last time.

## Changelog

[iOS] [Fixed] - fix display problems when image fails to load

## Test Plan
I found that the old image resource of ImageView was not cleaned up when the image failed to load, so I added the cleanup of the old resource in the logic of image loading failure.
```
- (void)imageLoaderLoadedImage:(UIImage *)loadedImage error:(NSError *)error forImageSource:(RCTImageSource *)source partial:(BOOL)isPartialLoad
{
  if (![source isEqual:_pendingImageSource]) {
    // Bail out if source has changed since we started loading
    return;
  }

  if (error) {
    if (_onError) {
      _onError(@{ @"error": error.localizedDescription });
    }
    if (_onLoadEnd) {
      _onLoadEnd(nil);
    }
    return;
  }
  ……
}
```

Before fix：
![before](https://user-images.githubusercontent.com/6712399/62608263-21517280-b932-11e9-8114-ecd622418777.gif)
After fix:
![after](https://user-images.githubusercontent.com/6712399/62608325-3a5a2380-b932-11e9-91fc-55e81b0335e0.gif)





