### PR TITLE
Fix forceUpdate method on useWindowDimensions

### DIFF
--- a/Libraries/Utilities/useWindowDimensions.js
+++ b/Libraries/Utilities/useWindowDimensions.js
@@ -16,7 +16,7 @@ import * as React from 'react';
 
 export default function useWindowDimensions(): DisplayMetrics {
   const dims = Dimensions.get('window'); // always read the latest value
-  const forceUpdate = React.useState()[1];
+  const forceUpdate = React.useState(false)[1].bind(null, v => !v);
   const initialDims = React.useState(dims)[0];
   React.useEffect(() => {
     Dimensions.addEventListener('change', forceUpdate);


### PR DESCRIPTION
## Summary

useState won't trigger re-renders if the value passed is the same.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[Internal] [Fixed] - Fix forceUpdate method on useWindowDimensions

## Test Plan

Codesandbox: https://codesandbox.io/embed/elegant-cori-0ixbx
