### PR TITLE
Consolidate OkHttp instances to only one instance

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/modules/fresco/FrescoModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/fresco/FrescoModule.java
@@ -149,7 +149,7 @@ public class FrescoModule extends ReactContextBaseJavaModule implements
     HashSet<RequestListener> requestListeners = new HashSet<>();
     requestListeners.add(new SystraceRequestListener());
 
-    OkHttpClient client = OkHttpClientProvider.createClient();
+    OkHttpClient client = OkHttpClientProvider.getOkHttpClient();
 
     // make sure to forward cookies for any requests via the okHttpClient
     // so that image requests to endpoints that use cookies still work


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

According to the official documentation of OkHttp (https://square.github.io/okhttp/3.x/okhttp/okhttp3/OkHttpClient.html), 

OkHttp performs best when you create a single OkHttpClient instance and reuse it for all of your HTTP calls. This is because each client holds its own connection pool and thread pools. Reusing connections and threads reduces latency and saves memory. Conversely, creating a client for each request wastes resources on idle pools.

## Changelog

[Android] [Fixed] - Consolidate OkHttp instances to only one instance for performance concerns

## Test Plan
Build the Android app with the change to make sure there's no regression related to any networking code