### PR TITLE
fix useWindowDimensions hook

### DIFF
--- a/Libraries/Utilities/useWindowDimensions.js
+++ b/Libraries/Utilities/useWindowDimensions.js
@@ -15,10 +15,10 @@ import {type DisplayMetrics} from './NativeDeviceInfo';
 import * as React from 'react';
 
 export default function useWindowDimensions(): DisplayMetrics {
-  const [dims, setDims] =  React.useState(Dimensions.get('window')); // set initial value
+  const [dims, setDims] = React.useState(Dimensions.get('window')); // set initial value
   React.useEffect(() => {
     function handleChange({window}) {
-      setDims(window)
+      setDims(window);
     }
     Dimensions.addEventListener('change', handleChange);
     return () => {

--- a/Libraries/Utilities/useWindowDimensions.js
+++ b/Libraries/Utilities/useWindowDimensions.js
@@ -17,7 +17,7 @@ import * as React from 'react';
 export default function useWindowDimensions(): DisplayMetrics {
   const [dims, setDims] =  React.useState(Dimensions.get('window')); // set initial value
   React.useEffect(() => {
-    function handleChange({ window}) {
+    function handleChange({window}) {
       setDims(window)
     }
     Dimensions.addEventListener('change', handleChange);

--- a/Libraries/Utilities/useWindowDimensions.js
+++ b/Libraries/Utilities/useWindowDimensions.js
@@ -15,21 +15,15 @@ import {type DisplayMetrics} from './NativeDeviceInfo';
 import * as React from 'react';
 
 export default function useWindowDimensions(): DisplayMetrics {
-  const dims = Dimensions.get('window'); // always read the latest value
-  const forceUpdate = React.useState(false)[1].bind(null, v => !v);
-  const initialDims = React.useState(dims)[0];
+  const [dims, setDims] =  React.useState(Dimensions.get('window')); // set initial value
   React.useEffect(() => {
-    Dimensions.addEventListener('change', forceUpdate);
-
-    const latestDims = Dimensions.get('window');
-    if (latestDims !== initialDims) {
-      // We missed an update between calling `get` in render and
-      // `addEventListener` in this handler...
-      forceUpdate();
+    function handleChange({ window}) {
+      setDims(window)
     }
+    Dimensions.addEventListener('change', handleChange);
     return () => {
-      Dimensions.removeEventListener('change', forceUpdate);
+      Dimensions.removeEventListener('change', handleChange);
     };
-  }, [forceUpdate, initialDims]);
+  }, []);
   return dims;
 }


### PR DESCRIPTION
## Summary

I found useWindowDimensions hook, and thought that it would solve many issues for me, but implementation looked interesting. So I created a new project, copy pasted the code and console.log dimentions returned from the hook, then rotated iOS simulator and it's printing dimentions non-stop.

Below is my fix for useWindowDimensions, and it works for me.

## Changelog

[GENERAL] [CHANGED] - fix useWindowDimensions hook

## Test Plan

Copy paste the code to RN project and console.log the return value, and rotate screen it'll log new dimensions.
