### PR TITLE
URL: Do not prepend baseUrl if the URL is not a relative URL

### DIFF
--- a/Libraries/Blob/URL.js
+++ b/Libraries/Blob/URL.js
@@ -130,13 +130,12 @@ export class URL {
 
   constructor(url: string, base: string) {
     let baseUrl = null;
-    if(!base || validateBaseUrl(url)) {
+    if (!base || validateBaseUrl(url)) {
       this._url = url;
       if (!this._url.endsWith('/')) {
         this._url += '/';
       }
-    }
-    else {
+    } else {
       if (typeof base === 'string') {
         baseUrl = base;
         if (!validateBaseUrl(baseUrl)) {

--- a/Libraries/Blob/URL.js
+++ b/Libraries/Blob/URL.js
@@ -130,7 +130,13 @@ export class URL {
 
   constructor(url: string, base: string) {
     let baseUrl = null;
-    if (base) {
+    if(!base || validateBaseUrl(url)) {
+      this._url = url;
+      if (!this._url.endsWith('/')) {
+        this._url += '/';
+      }
+    }
+    else {
       if (typeof base === 'string') {
         baseUrl = base;
         if (!validateBaseUrl(baseUrl)) {
@@ -146,11 +152,6 @@ export class URL {
         url = '';
       }
       this._url = `${baseUrl}${url}`;
-    } else {
-      this._url = url;
-      if (!this._url.endsWith('/')) {
-        this._url += '/';
-      }
     }
   }
 

--- a/Libraries/Blob/__tests__/URL-test.js
+++ b/Libraries/Blob/__tests__/URL-test.js
@@ -31,5 +31,7 @@ describe('URL', function() {
     // expect(g.href).toBe('https://developer.mozilla.org/en-US/docs');
     const h = new URL('/en-US/docs', a);
     expect(h.href).toBe('https://developer.mozilla.org/en-US/docs');
+    const i = new URL('http://github.com', 'http://google.com');
+    expect(i.href).toBe('http://github.com/');
   });
 });


### PR DESCRIPTION
## Summary

Fix for bug #26006 URL with base is always used, even when absolute URL is provided

## Changelog

[Javascript] [Fixed] - `URL`: Base url value is ignored when the input url is not a relative url.

## Test Plan

`new URL('http://github.com', 'http://google.com')` now returns `http://github.com/`
Added a test case to `URL-test.js` to verify the same.