### PR TITLE
Fix indentation in Gradle files

### DIFF
--- a/RNTester/android/app/build.gradle
+++ b/RNTester/android/app/build.gradle
@@ -110,12 +110,12 @@ android {
 
     flavorDimensions "vm"
     productFlavors {
-      hermes {
-        dimension "vm"
-      }
-      jsc {
-        dimension "vm"
-      }
+        hermes {
+            dimension "vm"
+        }
+        jsc {
+            dimension "vm"
+        }
     }
 
     defaultConfig {

--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -99,8 +99,8 @@ task prepareHermes() {
         hermesAAR = file("$projectDir/../../hermes-engine/android/hermes-debug.aar")
 
         if (!hermesAAR.exists()) {
-          // At Facebook, this file is in a different folder
-          hermesAAR = file("$projectDir/../../node_modules/hermes-engine/android/hermes-debug.aar")
+            // At Facebook, this file is in a different folder
+            hermesAAR = file("$projectDir/../../node_modules/hermes-engine/android/hermes-debug.aar")
         }
     }
     def soFiles = zipTree(hermesAAR).matching({ it.include "**/*.so" })

--- a/ReactAndroid/release.gradle
+++ b/ReactAndroid/release.gradle
@@ -62,11 +62,11 @@ def configureReactNativePom(def pom) {
 }
 
 if (JavaVersion.current().isJava8Compatible()) {
-  allprojects {
-    tasks.withType(Javadoc) {
-      options.addStringOption("Xdoclint:none", "-quiet")
+    allprojects {
+        tasks.withType(Javadoc) {
+            options.addStringOption("Xdoclint:none", "-quiet")
+        }
     }
-  }
 }
 
 afterEvaluate { project ->

--- a/react.gradle
+++ b/react.gradle
@@ -29,31 +29,31 @@ def reactNativeInspectorProxyPort() {
 }
 
 def getHermesOSBin() {
-  if (Os.isFamily(Os.FAMILY_WINDOWS)) return "win64-bin";
-  if (Os.isFamily(Os.FAMILY_MAC)) return "osx-bin";
-  if (Os.isOs(null, "linux", "amd64", null)) return "linux64-bin";
-  throw new Exception("OS not recognized. Please set project.ext.react.hermesCommand " +
-                      "to the path of a working Hermes compiler.");
+    if (Os.isFamily(Os.FAMILY_WINDOWS)) return "win64-bin";
+    if (Os.isFamily(Os.FAMILY_MAC)) return "osx-bin";
+    if (Os.isOs(null, "linux", "amd64", null)) return "linux64-bin";
+    throw new Exception("OS not recognized. Please set project.ext.react.hermesCommand " +
+                        "to the path of a working Hermes compiler.");
 }
 
 // Make sure not to inspect the Hermes config unless we need it,
 // to avoid breaking any JSC-only setups.
 def getHermesCommand = {
-  // If the project specifies a Hermes command, don't second guess it.
-  if (!hermesCommand.contains("%OS-BIN%")) {
-    return hermesCommand
-  }
+    // If the project specifies a Hermes command, don't second guess it.
+    if (!hermesCommand.contains("%OS-BIN%")) {
+        return hermesCommand
+    }
 
-  // Execution on Windows fails with / as separator
-  return hermesCommand
-      .replaceAll("%OS-BIN%", getHermesOSBin())
-      .replace('/' as char, File.separatorChar);
+    // Execution on Windows fails with / as separator
+    return hermesCommand
+            .replaceAll("%OS-BIN%", getHermesOSBin())
+            .replace('/' as char, File.separatorChar);
 }
 
 // Set enableHermesForVariant to a function to configure per variant,
 // or set `enableHermes` to True/False to set all of them
 def enableHermesForVariant = config.enableHermesForVariant ?: {
-      def variant -> config.enableHermes ?: false
+    def variant -> config.enableHermes ?: false
 }
 
 android {
@@ -177,10 +177,10 @@ afterEvaluate {
             }
 
             enabled config."bundleIn${targetName}" != null
-              ? config."bundleIn${targetName}"
-              : config."bundleIn${variant.buildType.name.capitalize()}" != null
-                ? config."bundleIn${variant.buildType.name.capitalize()}"
-                : targetName.toLowerCase().contains("release")
+                ? config."bundleIn${targetName}"
+                : config."bundleIn${variant.buildType.name.capitalize()}" != null
+                    ? config."bundleIn${variant.buildType.name.capitalize()}"
+                    : targetName.toLowerCase().contains("release")
         }
 
         // Expose a minimal interface on the application variant and the task itself:
@@ -297,7 +297,7 @@ afterEvaluate {
                 def targetVariant = ".*/transforms/[^/]*/${targetPath}/.*"
                 def path = details.file.getAbsolutePath().replace(File.separatorChar, '/' as char)
                 if (path.matches(targetVariant) && details.file.isFile()) {
-                  details.file.delete()
+                    details.file.delete()
                 }
             }
         }

--- a/template/android/app/build.gradle
+++ b/template/android/app/build.gradle
@@ -192,11 +192,11 @@ dependencies {
     implementation "com.facebook.react:react-native:+"  // From node_modules
 
     if (enableHermes) {
-      def hermesPath = "../../node_modules/hermes-engine/android/";
-      debugImplementation files(hermesPath + "hermes-debug.aar")
-      releaseImplementation files(hermesPath + "hermes-release.aar")
+        def hermesPath = "../../node_modules/hermes-engine/android/";
+        debugImplementation files(hermesPath + "hermes-debug.aar")
+        releaseImplementation files(hermesPath + "hermes-release.aar")
     } else {
-      implementation jscFlavor
+        implementation jscFlavor
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes indentation in `*.gradle` files by using four-space indents [as specified in `.editorconfig`](https://github.com/facebook/react-native/blob/0ccedf3964b1ebff43e4631d1e60b3e733096e56/.editorconfig#L13-L14).

## Changelog

[Internal] [Fixed] - Fix indentation in Gradle files

## Test Plan

Considering [the diff consists of whitespace changes only](https://github.com/facebook/react-native/compare/master...sonicdoe:gradle-indentation?w=1), I think this is safe to merge if the test suite passes.