### PR TITLE
Support bare hosts. Add missing / between url

### DIFF
--- a/Libraries/Blob/URL.js
+++ b/Libraries/Blob/URL.js
@@ -107,7 +107,7 @@ export class URLSearchParams {
 
 function validateBaseUrl(url: string) {
   // from this MIT-licensed gist: https://gist.github.com/dperini/729294
-  return /^(?:(?:(?:https?|ftp):)?\/\/)(?:(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)(?:\.(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)*(?:\.(?:[a-z\u00a1-\uffff]{2,})))(?::\d{2,5})?(?:[/?#]\S*)?$/i.test(
+  return /^(?:(?:(?:https?|ftp):)?\/\/)(?:(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)(?:\.(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)*(?:\.(?:[a-z\u00a1-\uffff]{2,}))?)(?::\d{2,5})?(?:[/?#]\S*)?$/i.test(
     url,
   );
 }
@@ -144,8 +144,11 @@ export class URL {
       } else if (typeof base === 'object') {
         baseUrl = base.toString();
       }
-      if (baseUrl.endsWith('/') && url.startsWith('/')) {
+      if (baseUrl.endsWith('/')) {
         baseUrl = baseUrl.slice(0, baseUrl.length - 1);
+      }
+      if (!url.startsWith('/')) {
+        url = `/${url}`;
       }
       if (baseUrl.endsWith(url)) {
         url = '';

--- a/Libraries/Blob/__tests__/URL-test.js
+++ b/Libraries/Blob/__tests__/URL-test.js
@@ -33,5 +33,11 @@ describe('URL', function() {
     expect(h.href).toBe('https://developer.mozilla.org/en-US/docs');
     const i = new URL('http://github.com', 'http://google.com');
     expect(i.href).toBe('http://github.com/');
+    // Support Bare Hosts
+    const j = new URL('home', 'http://localhost');
+    expect(j.href).toBe('http://localhost/home');
+    // Insert / between Base and Path if missing
+    const k = new URL('en-US/docs', 'https://developer.mozilla.org');
+    expect(k.href).toBe('https://developer.mozilla.org/en-US/docs');
   });
 });


### PR DESCRIPTION
## Summary

Fix for #26019 URL cannot handle "localhost" domain for base url. Also noticed another issue where `/` is not added between base URL and path if it is missing. Added fix for that too.

## Changelog

[Javascript] [Fixed] - `URL`: Bare Hosts are now supported.

## Test Plan

* `new URL('home', 'http://localhost')` now returns `http://localhost/home` instead of throwing an error.
* `new URL('en-US/docs', 'https://developer.mozilla.org')` now returns `https://developer.mozilla.org/en-US/docs` and not `https://developer.mozilla.orgen-US/docs`.