### PR TITLE
[iOS] [Fixed] - Fixed code and reason arguments ignored on iOS when listening to WebSocket.onclose

### DIFF
--- a/Libraries/WebSocket/RCTSRWebSocket.m
+++ b/Libraries/WebSocket/RCTSRWebSocket.m
@@ -597,6 +597,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
       }
     }
 
+    [self.delegate webSocket:self didCloseWithCode:code reason:reason wasClean:YES];
     [self _sendFrameWithOpcode:RCTSROpCodeConnectionClose data:payload];
   });
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Websocket ignores `code` and `reason` from `onclose` listener.
Some work was done in #24950 to send them to `close`, but `onclose` always returns `1001` and `Stream end encountered`:
https://github.com/facebook/react-native/blob/master/Libraries/WebSocket/RCTSRWebSocket.m#L1391

This PR calls `didCloseWithCode` at the end of `closeWithCode` and `Websocket.onclose` now works.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[iOS] [Fixed] - Fixed `code` and `reason` arguments ignored on iOS when listening to `WebSocket.onclose`

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
Run integration tests.