### PR TITLE
Remove Hermes React Executor from BUCK file.

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/BUCK
@@ -21,7 +21,6 @@ rn_android_library(
         react_native_dep("libraries/soloader/java/com/facebook/soloader:soloader"),
         react_native_dep("third-party/java/infer-annotations:infer-annotations"),
         react_native_dep("third-party/java/jsr-305:jsr-305"),
-        react_native_dep("java/com/facebook/hermes/reactexecutor:reactexecutor"),
         react_native_target("java/com/facebook/debug/holder:holder"),
         react_native_target("java/com/facebook/debug/tags:tags"),
         react_native_target("java/com/facebook/react/bridge:bridge"),


### PR DESCRIPTION
## Summary

Currently CI is broken because of a missing BUCK file. We don't actually need to build these things with buck right now so I'm just gonna remove it until somebody figures out how to build the proper BUCK file.

## Test Plan

* buck test works again