### PR TITLE
Don't call sharedApplication in App Extension

### DIFF
--- a/React/DevSupport/RCTDevLoadingView.m
+++ b/React/DevSupport/RCTDevLoadingView.m
@@ -74,7 +74,7 @@ RCT_EXPORT_METHOD(showMessage:(NSString *)message color:(UIColor *)color backgro
       CGSize screenSize = [UIScreen mainScreen].bounds.size;
 
       if (@available(iOS 11.0, *)) {
-        UIWindow *window = UIApplication.sharedApplication.keyWindow;
+        UIWindow *window = RCTSharedApplication().keyWindow;
         self->_window = [[UIWindow alloc] initWithFrame:CGRectMake(0, 0, screenSize.width, window.safeAreaInsets.top + 30)];
         self->_label = [[UILabel alloc] initWithFrame:CGRectMake(0, window.safeAreaInsets.top, screenSize.width, 30)];
       } else {


### PR DESCRIPTION
Related to this bug: https://github.com/facebook/react-native/pull/25769

Note I also had to add to the bottom of my podfile because RCTLinking had APPLICATION_EXTENSION_API_ONLY='YES' by default somehow.

```
post_install do |installer|
  installer.pods_project.targets.each do |target|
    target.build_configurations.each do |config|
      config.build_settings['APPLICATION_EXTENSION_API_ONLY'] = 'NO'
    end
  end
end
```
