### PR TITLE
Mock createAnimatedComponent

### DIFF
--- a/jest/setup.js
+++ b/jest/setup.js
@@ -131,20 +131,18 @@ jest
     Animated.View.__skipSetNativeProps_FOR_TESTS_ONLY = true;
     return Animated;
   })
-  .mock('../Libraries/Animated/src/AnimatedImplementation', () => {
-    const AnimatedImplementation = jest.requireActual(
-      '../Libraries/Animated/src/AnimatedImplementation',
+  .mock('../Libraries/Animated/src/createAnimatedComponent', () => {
+    const createAnimatedComponent = jest.requireActual(
+      '../Libraries/Animated/src/createAnimatedComponent',
     );
-    const oldCreate = AnimatedImplementation.createAnimatedComponent;
-    AnimatedImplementation.createAnimatedComponent = function(
-      Component,
-      defaultProps,
-    ) {
-      const Wrapped = oldCreate(Component, defaultProps);
+
+    return (Component, defaultProps) => {
+      const Wrapped = createAnimatedComponent(Component, defaultProps);
+
       Wrapped.__skipSetNativeProps_FOR_TESTS_ONLY = true;
+
       return Wrapped;
     };
-    return AnimatedImplementation;
   })
   .mock('../Libraries/AppState/AppState', () => ({
     addEventListener: jest.fn(),


### PR DESCRIPTION
## Summary

Since react-native 0.58, I encountered some issues about snapshot with animated components. I opened an issue here : https://github.com/facebook/react-native/issues/25653

After hours of debugging, I finally found the problem:

In RN 0.57, an Animated View was created like this : 
`View: AnimatedImplementation.createAnimatedComponent(View)`

And `AnimatedImplementation` was mock like this : 
```
mock('../Libraries/Animated/src/AnimatedImplementation', () => {
  const AnimatedImplementation = jest.requireActual('../Libraries/Animated/src/AnimatedImplementation');
  const oldCreate = AnimatedImplementation.createAnimatedComponent;
    AnimatedImplementation.createAnimatedComponent = function(
      Component,
      defaultProps,
    ) {
      const Wrapped = oldCreate(Component, defaultProps);
      Wrapped.__skipSetNativeProps_FOR_TESTS_ONLY = true;
      return Wrapped;
    };
    return AnimatedImplementation;
  })
```

So thanks to this mock, the animated component had a props `__skipSetNativeProps_FOR_TESTS_ONLY` set to `true` and this was used to forceUpdate the component
```

if (AnimatedComponent.__skipSetNativeProps_FOR_TESTS_ONLY || typeof this._component.setNativeProps !== 'function') {
  this.forceUpdate();
}
```

But since RN 0.58, the way we create an animated component as changed into : 

```
const View = require('View');

const createAnimatedComponent = require('createAnimatedComponent');

module.exports = createAnimatedComponent(View);
```

As you can see, we directly use `createAnimatedComponent`, we don't use it through `AnimatedComponent` like before.
This caused the animated component had not anymore the props `__skipSetNativeProps_FOR_TESTS_ONLY`, so the component doesn't forceUpdate during the animation and breaks the snapshot.

Mocking `createAnimatedComponent` fix the problem

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[General] [Fixed] - Mock createAnimatedComponent to fix snapshot with animated component

## Test Plan

See the issue
