### PR TITLE
fix: ios detox date picker test

### DIFF
--- a/RNTester/e2e/__tests__/DatePickerIOS-test.js
+++ b/RNTester/e2e/__tests__/DatePickerIOS-test.js
@@ -43,7 +43,7 @@ describe('DatePickerIOS', () => {
     await testElement.setColumnToValue(2, '10');
     await testElement.setColumnToValue(3, 'AM');
 
-    await expect(dateIndicator).toHaveText('12/4/2005');
+    await expect(dateIndicator).toHaveText('12/4/2006');
     await expect(timeIndicator).toHaveText('4:10 AM');
   });
 


### PR DESCRIPTION
## Summary

iOS e2e tests using Detox are failing on CI:
https://circleci.com/gh/facebook/react-native/107417#tests/containers/0
https://circleci.com/gh/facebook/react-native/107390

## Changelog

[INTERNAL] [FIXED] - Date Picker iOS test

## Test Plan

` yarn build-ios-e2e && yarn test-ios-e2e`
