### PR TITLE
fix: avoid calling Timing.deleteTimer for setImmediate and requestIdleCallback

### DIFF
--- a/Libraries/Core/Timers/JSTimers.js
+++ b/Libraries/Core/Timers/JSTimers.js
@@ -218,8 +218,8 @@ function _freeCallback(timerID: number) {
   const index = timerIDs.indexOf(timerID);
   // See corresponding comment in `callTimers` for reasoning behind this
   if (index !== -1) {
-    _clearIndex(index);
     const type = types[index];
+    _clearIndex(index);
     if (type !== 'setImmediate' && type !== 'requestIdleCallback') {
       deleteTimer(timerID);
     }


### PR DESCRIPTION
## Summary

Fix a simple error where `types[index]` was being accessed after it was cleared, instead of before.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[iOS] [Fixed] - never call deleteTimer for setImmediate and requestIdleCallback

## Test Plan

None