### PR TITLE
fix: use proper timestamp in frameElapsed calculation

### DIFF
--- a/React/Modules/RCTTiming.m
+++ b/React/Modules/RCTTiming.m
@@ -268,9 +268,9 @@ RCT_EXPORT_MODULE()
   }
 
   if (_sendIdleEvents) {
-    NSTimeInterval frameElapsed = (CACurrentMediaTime() - update.timestamp);
+    NSTimeInterval currentTimestamp = [[NSDate date] timeIntervalSince1970];
+    NSTimeInterval frameElapsed = currentTimestamp - update.timestamp;
     if (kFrameDuration - frameElapsed >= kIdleCallbackFrameDeadline) {
-      NSTimeInterval currentTimestamp = [[NSDate date] timeIntervalSince1970];
       NSNumber *absoluteFrameStartMS = @((currentTimestamp - frameElapsed) * 1000);
       [_bridge enqueueJSCall:@"JSTimers"
                       method:@"callIdleCallbacks"


### PR DESCRIPTION
## Summary

Fix a bug where `CACurrentMediaTime` was being used to calculate the elapsed frame time, even though it's not comparable to `NSDate.timeIntervalSince1970` time.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[iOS] [Fixed] - callIdleCallbacks deadline calculation

## Test Plan

None
