### PR TITLE
fix: check "sendIdleEvents" before calling "stopTimers"

### DIFF
--- a/React/Modules/RCTTiming.m
+++ b/React/Modules/RCTTiming.m
@@ -383,7 +383,7 @@ RCT_EXPORT_METHOD(deleteTimer:(nonnull NSNumber *)timerID)
   @synchronized (_timers) {
     [_timers removeObjectForKey:timerID];
   }
-  if (![self hasPendingTimers]) {
+  if (!_sendIdleEvents && ![self hasPendingTimers]) {
     [self stopTimers];
   }
 }


### PR DESCRIPTION
## Summary

Avoid calling `stopTimers` when `sendIdleEvents` is true, since that's how `setSendIdleEvents` works.

## Changelog

[iOS] [Fixed] - avoid stopTimers when sendIdleEvents is true

## Test Plan

None