### PR TITLE
bump android gradle plugin to 3.5.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:3.4.2")
+        classpath("com.android.tools.build:gradle:3.5.0")
         classpath("de.undercouch:gradle-download-task:4.0.0")
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/template/android/build.gradle
+++ b/template/android/build.gradle
@@ -12,7 +12,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:3.4.2")
+        classpath("com.android.tools.build:gradle:3.5.0")
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
## Summary

Android Gradle Plugin 3.5.0 released with a lot of improvements and bug fixes. It's important to have this change merged before 0.61 release. See https://developer.android.com/studio/releases/gradle-plugin

## Changelog

[Android] [Changed] - bump android gradle plugin to 3.5.0

## Test Plan

RNTester builds and runs as expected
