### PR TITLE
Better implementation for getItemCount on FlatList

### DIFF
--- a/Libraries/Lists/FlatList.js
+++ b/Libraries/Lists/FlatList.js
@@ -560,7 +560,12 @@ class FlatList<ItemT> extends React.PureComponent<Props<ItemT>, void> {
   };
 
   _getItemCount = (data: ?Array<ItemT>): number => {
-    return data ? Math.ceil(data.length / this.props.numColumns) : 0;
+    if (data) {
+      const {numColumns} = this.props;
+      return numColumns > 1 ? Math.ceil(data.length / numColumns) : data.length;
+    } else {
+      return 0;
+    }
   };
 
   _keyExtractor = (items: ItemT | Array<ItemT>, index: number) => {


### PR DESCRIPTION
## Summary
Flatlist's `getItemCount` function is frequently called internally by VirtualizedList.
As with other functions, we can remove unnecessary operations with the `numColumns` value.
This makes it much more efficient.

## Changelog
[Internal] [Changed] - Better implementation for getItemCount on FlatList

## Test Plan
Not required
