### PR TITLE
Change console error to warning for untracked touch end event

### DIFF
--- a/Libraries/Renderer/implementations/ReactFabric-dev.fb.js
+++ b/Libraries/Renderer/implementations/ReactFabric-dev.fb.js
@@ -2389,7 +2389,7 @@ var ResponderEventPlugin = {
       if (trackedTouchCount >= 0) {
         trackedTouchCount -= 1;
       } else {
-        console.error(
+        console.warn(
           "Ended a touch event which was not counted in `trackedTouchCount`."
         );
         return null;

--- a/Libraries/Renderer/implementations/ReactFabric-dev.js
+++ b/Libraries/Renderer/implementations/ReactFabric-dev.js
@@ -2390,7 +2390,7 @@ var ResponderEventPlugin = {
       if (trackedTouchCount >= 0) {
         trackedTouchCount -= 1;
       } else {
-        console.error(
+        console.warn(
           "Ended a touch event which was not counted in `trackedTouchCount`."
         );
         return null;

--- a/Libraries/Renderer/implementations/ReactFabric-prod.fb.js
+++ b/Libraries/Renderer/implementations/ReactFabric-prod.fb.js
@@ -710,7 +710,7 @@ var eventTypes = {
         if (0 <= trackedTouchCount) --trackedTouchCount;
         else
           return (
-            console.error(
+            console.warn(
               "Ended a touch event which was not counted in `trackedTouchCount`."
             ),
             null

--- a/Libraries/Renderer/implementations/ReactFabric-prod.js
+++ b/Libraries/Renderer/implementations/ReactFabric-prod.js
@@ -711,7 +711,7 @@ var eventTypes = {
         if (0 <= trackedTouchCount) --trackedTouchCount;
         else
           return (
-            console.error(
+            console.warn(
               "Ended a touch event which was not counted in `trackedTouchCount`."
             ),
             null

--- a/Libraries/Renderer/implementations/ReactFabric-profiling.fb.js
+++ b/Libraries/Renderer/implementations/ReactFabric-profiling.fb.js
@@ -711,7 +711,7 @@ var eventTypes = {
         if (0 <= trackedTouchCount) --trackedTouchCount;
         else
           return (
-            console.error(
+            console.warn(
               "Ended a touch event which was not counted in `trackedTouchCount`."
             ),
             null

--- a/Libraries/Renderer/implementations/ReactFabric-profiling.js
+++ b/Libraries/Renderer/implementations/ReactFabric-profiling.js
@@ -712,7 +712,7 @@ var eventTypes = {
         if (0 <= trackedTouchCount) --trackedTouchCount;
         else
           return (
-            console.error(
+            console.warn(
               "Ended a touch event which was not counted in `trackedTouchCount`."
             ),
             null

--- a/Libraries/Renderer/implementations/ReactNativeRenderer-dev.fb.js
+++ b/Libraries/Renderer/implementations/ReactNativeRenderer-dev.fb.js
@@ -2389,7 +2389,7 @@ var ResponderEventPlugin = {
       if (trackedTouchCount >= 0) {
         trackedTouchCount -= 1;
       } else {
-        console.error(
+        console.warn(
           "Ended a touch event which was not counted in `trackedTouchCount`."
         );
         return null;

--- a/Libraries/Renderer/implementations/ReactNativeRenderer-dev.js
+++ b/Libraries/Renderer/implementations/ReactNativeRenderer-dev.js
@@ -2390,7 +2390,7 @@ var ResponderEventPlugin = {
       if (trackedTouchCount >= 0) {
         trackedTouchCount -= 1;
       } else {
-        console.error(
+        console.warn(
           "Ended a touch event which was not counted in `trackedTouchCount`."
         );
         return null;

--- a/Libraries/Renderer/implementations/ReactNativeRenderer-prod.fb.js
+++ b/Libraries/Renderer/implementations/ReactNativeRenderer-prod.fb.js
@@ -710,7 +710,7 @@ var eventTypes = {
         if (0 <= trackedTouchCount) --trackedTouchCount;
         else
           return (
-            console.error(
+            console.warn(
               "Ended a touch event which was not counted in `trackedTouchCount`."
             ),
             null

--- a/Libraries/Renderer/implementations/ReactNativeRenderer-prod.js
+++ b/Libraries/Renderer/implementations/ReactNativeRenderer-prod.js
@@ -711,7 +711,7 @@ var eventTypes = {
         if (0 <= trackedTouchCount) --trackedTouchCount;
         else
           return (
-            console.error(
+            console.warn(
               "Ended a touch event which was not counted in `trackedTouchCount`."
             ),
             null

--- a/Libraries/Renderer/implementations/ReactNativeRenderer-profiling.fb.js
+++ b/Libraries/Renderer/implementations/ReactNativeRenderer-profiling.fb.js
@@ -711,7 +711,7 @@ var eventTypes = {
         if (0 <= trackedTouchCount) --trackedTouchCount;
         else
           return (
-            console.error(
+            console.warn(
               "Ended a touch event which was not counted in `trackedTouchCount`."
             ),
             null

--- a/Libraries/Renderer/implementations/ReactNativeRenderer-profiling.js
+++ b/Libraries/Renderer/implementations/ReactNativeRenderer-profiling.js
@@ -712,7 +712,7 @@ var eventTypes = {
         if (0 <= trackedTouchCount) --trackedTouchCount;
         else
           return (
-            console.error(
+            console.warn(
               "Ended a touch event which was not counted in `trackedTouchCount`."
             ),
             null


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Currently if more touch end events are received than tracked touches, the app will crash with a `console.error`. This PR changes the error to a `console.warn`, which matches other touch event errors. This fixes #15059, where an OS bug in certain Android devices means only two touchstart events, but three touchcancel events are received when performing a three finger screenshot gesture.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[General] [Fixed] - Change error to warning for untracked touch end event

## Test Plan

On a device listed in #15059, enable three-finger screenshots. Open the RNTester app and perform three-finger screenshot gesture. Observe YellowBox warning for `"Ended a touch event which was not counted in 'trackedTouchCount'"`.

Tested on a OnePlus 6 running Android 9.
