### PR TITLE
[DO NOT MERGE] Preview: Appearance Native Module

### DIFF
--- a/Libraries/FBReactNativeSpec/FBReactNativeSpec/FBReactNativeSpec-generated.mm
+++ b/Libraries/FBReactNativeSpec/FBReactNativeSpec/FBReactNativeSpec-generated.mm
@@ -12,6 +12,7 @@
  */
 #import "FBReactNativeSpec.h"
 
+#import <folly/Optional.h>
 
 
 namespace facebook {
@@ -452,6 +453,69 @@ namespace facebook {
 
   } // namespace react
 } // namespace facebook
+namespace facebook {
+  namespace react {
+
+    
+    static facebook::jsi::Value __hostFunction_NativeAppearanceSpecJSI_getColorScheme(facebook::jsi::Runtime& rt, TurboModule &turboModule, const facebook::jsi::Value* args, size_t count) {
+      return static_cast<ObjCTurboModule&>(turboModule).invokeObjCMethod(rt, StringKind, "getColorScheme", @selector(getColorScheme), args, count);
+    }
+
+    static facebook::jsi::Value __hostFunction_NativeAppearanceSpecJSI_addListener(facebook::jsi::Runtime& rt, TurboModule &turboModule, const facebook::jsi::Value* args, size_t count) {
+      return static_cast<ObjCTurboModule&>(turboModule).invokeObjCMethod(rt, VoidKind, "addListener", @selector(addListener:), args, count);
+    }
+
+    static facebook::jsi::Value __hostFunction_NativeAppearanceSpecJSI_removeListeners(facebook::jsi::Runtime& rt, TurboModule &turboModule, const facebook::jsi::Value* args, size_t count) {
+      return static_cast<ObjCTurboModule&>(turboModule).invokeObjCMethod(rt, VoidKind, "removeListeners", @selector(removeListeners:), args, count);
+    }
+
+
+    NativeAppearanceSpecJSI::NativeAppearanceSpecJSI(id<RCTTurboModule> instance, std::shared_ptr<JSCallInvoker> jsInvoker)
+      : ObjCTurboModule("Appearance", instance, jsInvoker) {
+        
+        methodMap_["getColorScheme"] = MethodMetadata {0, __hostFunction_NativeAppearanceSpecJSI_getColorScheme};
+        
+        
+        methodMap_["addListener"] = MethodMetadata {1, __hostFunction_NativeAppearanceSpecJSI_addListener};
+        
+        
+        methodMap_["removeListeners"] = MethodMetadata {1, __hostFunction_NativeAppearanceSpecJSI_removeListeners};
+        
+        
+
+    }
+
+  } // namespace react
+} // namespace facebook
+folly::Optional<NativeAppearanceColorSchemeName> NSStringToNativeAppearanceColorSchemeName(NSString *value) {
+  static NSDictionary *dict = nil;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    dict = @{
+      @"light": @0,
+      @"dark": @1,
+    };
+  });
+  return value ? (NativeAppearanceColorSchemeName)[dict[value] integerValue] : folly::Optional<NativeAppearanceColorSchemeName>{};
+}
+
+NSString *NativeAppearanceColorSchemeNameToNSString(folly::Optional<NativeAppearanceColorSchemeName> value) {
+  static NSDictionary *dict = nil;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    dict = @{
+      @0: @"light",
+      @1: @"dark",
+    };
+  });
+  return value.hasValue() ? dict[@(value.value())] : nil;
+}
+@implementation RCTCxxConvert (NativeAppearance_AppearancePreferences)
++ (RCTManagedPointer *)JS_NativeAppearance_AppearancePreferences:(id)json
+{
+  return facebook::react::managedPointer<JS::NativeAppearance::AppearancePreferences>(json);
+}
+@end
 @implementation RCTCxxConvert (NativeAsyncStorage_SpecMultiGetCallbackErrorsElement)
 + (RCTManagedPointer *)JS_NativeAsyncStorage_SpecMultiGetCallbackErrorsElement:(id)json
 {

--- a/Libraries/FBReactNativeSpec/FBReactNativeSpec/FBReactNativeSpec.h
+++ b/Libraries/FBReactNativeSpec/FBReactNativeSpec/FBReactNativeSpec.h
@@ -432,6 +432,49 @@ namespace facebook {
     };
   } // namespace react
 } // namespace facebook
+@protocol NativeAppearanceSpec <RCTBridgeModule, RCTTurboModule>
+
+- (NSString *)getColorScheme;
+- (void)addListener:(NSString *)eventName;
+- (void)removeListeners:(double)count;
+
+@end
+namespace facebook {
+  namespace react {
+    /**
+     * ObjC++ class for module 'Appearance'
+     */
+
+    class JSI_EXPORT NativeAppearanceSpecJSI : public ObjCTurboModule {
+    public:
+      NativeAppearanceSpecJSI(id<RCTTurboModule> instance, std::shared_ptr<JSCallInvoker> jsInvoker);
+
+    };
+  } // namespace react
+} // namespace facebook
+typedef NS_ENUM(NSInteger, NativeAppearanceColorSchemeName) {
+  NativeAppearanceColorSchemeNameLight = 0,
+  NativeAppearanceColorSchemeNameDark,
+};
+
+folly::Optional<NativeAppearanceColorSchemeName> NSStringToNativeAppearanceColorSchemeName(NSString *value);
+NSString *NativeAppearanceColorSchemeNameToNSString(folly::Optional<NativeAppearanceColorSchemeName> value);
+
+namespace JS {
+  namespace NativeAppearance {
+    struct AppearancePreferences {
+      NSString *colorScheme() const;
+
+      AppearancePreferences(NSDictionary *const v) : _v(v) {}
+    private:
+      NSDictionary *_v;
+    };
+  }
+}
+
+@interface RCTCxxConvert (NativeAppearance_AppearancePreferences)
++ (RCTManagedPointer *)JS_NativeAppearance_AppearancePreferences:(id)json;
+@end
 
 namespace JS {
   namespace NativeAsyncStorage {
@@ -2553,6 +2596,11 @@ inline JS::NativeAppState::Constants::Builder::Builder(const Input i) : _factory
 inline JS::NativeAppState::Constants::Builder::Builder(Constants i) : _factory(^{
   return i.unsafeRawValue();
 }) {}
+inline NSString *JS::NativeAppearance::AppearancePreferences::colorScheme() const
+{
+  id const p = _v[@"colorScheme"];
+  return RCTBridgingToString(p);
+}
 inline NSString *JS::NativeAsyncStorage::SpecMultiGetCallbackErrorsElement::message() const
 {
   id const p = _v[@"message"];

--- a/Libraries/Utilities/Appearance.js
+++ b/Libraries/Utilities/Appearance.js
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow
+ */
+
+'use strict';
+
+import EventEmitter from '../vendor/emitter/EventEmitter';
+import NativeEventEmitter from '../EventEmitter/NativeEventEmitter';
+import NativeAppearance, {
+  type AppearancePreferences,
+  type ColorSchemeName,
+} from './NativeAppearance';
+import invariant from 'invariant';
+
+type AppearanceListener = (preferences: AppearancePreferences) => void;
+const eventEmitter = new EventEmitter();
+
+const nativeColorScheme: ?string =
+  NativeAppearance == null ? null : NativeAppearance.getColorScheme();
+invariant(
+  nativeColorScheme === 'dark' ||
+    nativeColorScheme === 'light' ||
+    nativeColorScheme == null,
+  "Unrecognized color scheme. Did you mean 'dark' or 'light'?",
+);
+
+let currentColorScheme: ?ColorSchemeName = nativeColorScheme;
+
+if (NativeAppearance) {
+  const nativeEventEmitter = new NativeEventEmitter(NativeAppearance);
+  nativeEventEmitter.addListener(
+    'appearanceChanged',
+    (newAppearance: AppearancePreferences) => {
+      const {colorScheme} = newAppearance;
+      invariant(
+        colorScheme === 'dark' ||
+          colorScheme === 'light' ||
+          colorScheme == null,
+        "Unrecognized color scheme. Did you mean 'dark' or 'light'?",
+      );
+      currentColorScheme = colorScheme;
+      eventEmitter.emit('change', {colorScheme});
+    },
+  );
+}
+
+module.exports = {
+  /**
+   * Note: Although color scheme is available immediately, it may change at any
+   * time. Any rendering logic or styles that depend on this should try to call
+   * this function on every render, rather than caching the value (for example,
+   * using inline styles rather than setting a value in a `StyleSheet`).
+   *
+   * Example: `const colorScheme = Appearance.getColorScheme();`
+   *
+   * @returns {?ColorSchemeName} Value for the color scheme preference.
+   */
+  getColorScheme(): ?ColorSchemeName {
+    return currentColorScheme;
+  },
+  /**
+   * Add an event handler that is fired when appearance preferences change.
+   */
+  addChangeListener(listener: AppearanceListener): void {
+    eventEmitter.addListener('change', listener);
+  },
+  /**
+   * Remove an event handler.
+   */
+  removeChangeListener(listener: AppearanceListener): void {
+    eventEmitter.removeListener('change', listener);
+  },
+};

--- a/Libraries/Utilities/NativeAppearance.js
+++ b/Libraries/Utilities/NativeAppearance.js
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+'use strict';
+
+import type {TurboModule} from '../TurboModule/RCTExport';
+import * as TurboModuleRegistry from '../TurboModule/TurboModuleRegistry';
+
+export type ColorSchemeName = 'light' | 'dark';
+
+export type AppearancePreferences = {|
+  // TODO: (hramos) T52919652 Use ?ColorSchemeName once codegen supports union
+  // types.
+  /* 'light' | 'dark' */
+  colorScheme?: ?string,
+|};
+
+export interface Spec extends TurboModule {
+  // TODO: (hramos) T52919652 Use ?ColorSchemeName once codegen supports union
+  // types.
+  /* 'light' | 'dark' */
+  +getColorScheme: () => ?string;
+
+  // RCTEventEmitter
+  +addListener: (eventName: string) => void;
+  +removeListeners: (count: number) => void;
+}
+
+export default (TurboModuleRegistry.get<Spec>('Appearance'): ?Spec);

--- a/Libraries/Utilities/useColorScheme.js
+++ b/Libraries/Utilities/useColorScheme.js
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow
+ */
+
+'use strict';
+
+import {useMemo} from 'react';
+import {useSubscription} from 'use-subscription';
+import Appearance from './Appearance';
+import type {ColorSchemeName} from './NativeAppearance';
+
+export default function useColorScheme(): ?ColorSchemeName {
+  const subscription = useMemo(
+    () => ({
+      getCurrentValue: () => Appearance.getColorScheme(),
+      subscribe: callback => {
+        Appearance.addChangeListener(callback);
+        return () => Appearance.removeChangeListener(callback);
+      },
+    }),
+    [],
+  );
+
+  return useSubscription(subscription);
+}

--- a/Libraries/react-native/react-native-implementation.js
+++ b/Libraries/react-native/react-native-implementation.js
@@ -82,6 +82,7 @@ import typeof ToastAndroid from '../Components/ToastAndroid/ToastAndroid';
 import typeof * as TurboModuleRegistry from '../TurboModule/TurboModuleRegistry';
 import typeof TVEventHandler from '../Components/AppleTV/TVEventHandler';
 import typeof UIManager from '../ReactNative/UIManager';
+import typeof useColorScheme from '../Utilities/useColorScheme';
 import typeof useWindowDimensions from '../Utilities/useWindowDimensions';
 import typeof UTFSequence from '../UTFSequence';
 import typeof Vibration from '../Vibration/Vibration';
@@ -392,6 +393,9 @@ module.exports = {
     'unstable_batchedUpdates',
   > {
     return require('../Renderer/shims/ReactNative').unstable_batchedUpdates;
+  },
+  get useColorScheme(): useColorScheme {
+    return require('../Utilities/useColorScheme').default;
   },
   get useWindowDimensions(): useWindowDimensions {
     return require('../Utilities/useWindowDimensions').default;

--- a/Libraries/react-native/react-native-implementation.js
+++ b/Libraries/react-native/react-native-implementation.js
@@ -49,6 +49,7 @@ import typeof VirtualizedSectionList from '../Lists/VirtualizedSectionList';
 import typeof ActionSheetIOS from '../ActionSheetIOS/ActionSheetIOS';
 import typeof Alert from '../Alert/Alert';
 import typeof Animated from '../Animated/src/Animated';
+import typeof Appearance from '../Utilities/Appearance';
 import typeof AppRegistry from '../ReactNative/AppRegistry';
 import typeof AppState from '../AppState/AppState';
 import typeof AsyncStorage from '../Storage/AsyncStorage';
@@ -251,6 +252,9 @@ module.exports = {
   },
   get Animated(): Animated {
     return require('../Animated/src/Animated');
+  },
+  get Appearance(): Appearance {
+    return require('../Utilities/Appearance');
   },
   get AppRegistry(): AppRegistry {
     return require('../ReactNative/AppRegistry');

--- a/RNTester/android/app/build.gradle
+++ b/RNTester/android/app/build.gradle
@@ -101,7 +101,7 @@ def enableProguardInReleaseBuilds = true
 def useIntlJsc = false
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
@@ -121,7 +121,7 @@ android {
     defaultConfig {
         applicationId "com.facebook.react.uiapp"
         minSdkVersion 16
-        targetSdkVersion 28
+        targetSdkVersion 29
         versionCode 1
         versionName "1.0"
     }

--- a/RNTester/android/app/src/main/AndroidManifest.xml
+++ b/RNTester/android/app/src/main/AndroidManifest.xml
@@ -28,7 +28,7 @@
         android:name=".RNTesterActivity"
         android:label="@string/app_name"
         android:screenOrientation="fullSensor"
-        android:configChanges="orientation|screenSize" >
+        android:configChanges="orientation|screenSize|uiMode" >
       <intent-filter>
         <action android:name="android.intent.action.MAIN" />
         <category android:name="android.intent.category.LAUNCHER" />

--- a/RNTester/android/app/src/main/java/com/facebook/react/uiapp/RNTesterActivity.java
+++ b/RNTester/android/app/src/main/java/com/facebook/react/uiapp/RNTesterActivity.java
@@ -6,10 +6,12 @@
  */
 package com.facebook.react.uiapp;
 
+import android.content.res.Configuration;
 import android.os.Bundle;
 import androidx.annotation.Nullable;
 import com.facebook.react.ReactActivity;
 import com.facebook.react.ReactActivityDelegate;
+import com.facebook.react.ReactInstanceManager;
 
 public class RNTesterActivity extends ReactActivity {
   public static class RNTesterActivityDelegate extends ReactActivityDelegate {
@@ -52,5 +54,15 @@ public class RNTesterActivity extends ReactActivity {
   @Override
   protected String getMainComponentName() {
     return "RNTesterApp";
+  }
+
+  @Override
+  public void onConfigurationChanged(Configuration newConfig) {
+    super.onConfigurationChanged(newConfig);
+    ReactInstanceManager instanceManager = getReactInstanceManager();
+
+    if (instanceManager != null) {
+      instanceManager.onConfigurationChanged(newConfig);
+    }
   }
 }

--- a/RNTester/js/components/RNTesterBlock.js
+++ b/RNTester/js/components/RNTesterBlock.js
@@ -13,6 +13,7 @@
 const React = require('react');
 
 const {StyleSheet, Text, View} = require('react-native');
+import {RNTesterThemeContext} from './RNTesterTheme';
 
 type Props = $ReadOnly<{|
   children?: React.Node,
@@ -29,17 +30,47 @@ class RNTesterBlock extends React.Component<Props, State> {
 
   render(): React.Node {
     const description = this.props.description ? (
-      <Text style={styles.descriptionText}>{this.props.description}</Text>
+      <RNTesterThemeContext.Consumer>
+        {theme => {
+          return (
+            <Text style={[styles.descriptionText, {color: theme.LabelColor}]}>
+              {this.props.description}
+            </Text>
+          );
+        }}
+      </RNTesterThemeContext.Consumer>
     ) : null;
 
     return (
-      <View style={styles.container}>
-        <View style={styles.titleContainer}>
-          <Text style={styles.titleText}>{this.props.title}</Text>
-          {description}
-        </View>
-        <View style={styles.children}>{this.props.children}</View>
-      </View>
+      <RNTesterThemeContext.Consumer>
+        {theme => {
+          return (
+            <View
+              style={[
+                styles.container,
+                {
+                  borderColor: theme.SeparatorColor,
+                  backgroundColor: theme.SystemBackgroundColor,
+                },
+              ]}>
+              <View
+                style={[
+                  styles.titleContainer,
+                  {
+                    borderBottomColor: theme.SeparatorColor,
+                    backgroundColor: theme.QuaternarySystemFillColor,
+                  },
+                ]}>
+                <Text style={[styles.titleText, {color: theme.LabelColor}]}>
+                  {this.props.title}
+                </Text>
+                {description}
+              </View>
+              <View style={styles.children}>{this.props.children}</View>
+            </View>
+          );
+        }}
+      </RNTesterThemeContext.Consumer>
     );
   }
 }
@@ -48,8 +79,6 @@ const styles = StyleSheet.create({
   container: {
     borderRadius: 3,
     borderWidth: 0.5,
-    borderColor: '#d6d7da',
-    backgroundColor: '#ffffff',
     margin: 10,
     marginVertical: 5,
     overflow: 'hidden',
@@ -58,8 +87,6 @@ const styles = StyleSheet.create({
     borderBottomWidth: 0.5,
     borderTopLeftRadius: 3,
     borderTopRightRadius: 2.5,
-    borderBottomColor: '#d6d7da',
-    backgroundColor: '#f6f7f8',
     paddingHorizontal: 10,
     paddingVertical: 5,
   },

--- a/RNTester/js/components/RNTesterExampleFilter.js
+++ b/RNTester/js/components/RNTesterExampleFilter.js
@@ -13,6 +13,7 @@
 const React = require('react');
 
 const {StyleSheet, TextInput, View} = require('react-native');
+import {RNTesterThemeContext} from './RNTesterTheme';
 
 type Props = {
   filter: Function,
@@ -64,33 +65,48 @@ class RNTesterExampleFilter extends React.Component<Props, State> {
       return null;
     }
     return (
-      <View style={styles.searchRow}>
-        <TextInput
-          autoCapitalize="none"
-          autoCorrect={false}
-          clearButtonMode="always"
-          onChangeText={text => {
-            this.setState(() => ({filter: text}));
-          }}
-          placeholder="Search..."
-          underlineColorAndroid="transparent"
-          style={styles.searchTextInput}
-          testID={this.props.testID}
-          value={this.state.filter}
-        />
-      </View>
+      <RNTesterThemeContext.Consumer>
+        {theme => {
+          return (
+            <View
+              style={[
+                styles.searchRow,
+                {backgroundColor: theme.GroupedBackgroundColor},
+              ]}>
+              <TextInput
+                autoCapitalize="none"
+                autoCorrect={false}
+                clearButtonMode="always"
+                onChangeText={text => {
+                  this.setState(() => ({filter: text}));
+                }}
+                placeholder="Search..."
+                placeholderTextColor={theme.PlaceholderTextColor}
+                underlineColorAndroid="transparent"
+                style={[
+                  styles.searchTextInput,
+                  {
+                    color: theme.LabelColor,
+                    backgroundColor: theme.SecondaryGroupedBackgroundColor,
+                    borderColor: theme.QuaternaryLabelColor,
+                  },
+                ]}
+                testID={this.props.testID}
+                value={this.state.filter}
+              />
+            </View>
+          );
+        }}
+      </RNTesterThemeContext.Consumer>
     );
   }
 }
 
 const styles = StyleSheet.create({
   searchRow: {
-    backgroundColor: '#eeeeee',
     padding: 10,
   },
   searchTextInput: {
-    backgroundColor: 'white',
-    borderColor: '#cccccc',
     borderRadius: 3,
     borderWidth: 1,
     paddingLeft: 8,

--- a/RNTester/js/components/RNTesterExampleList.js
+++ b/RNTester/js/components/RNTesterExampleList.js
@@ -26,6 +26,8 @@ const {
 import type {ViewStyleProp} from '../../../Libraries/StyleSheet/StyleSheet';
 import type {RNTesterExample} from '../types/RNTesterTypes';
 
+import {RNTesterThemeContext} from './RNTesterTheme';
+
 type Props = {
   onNavigate: Function,
   list: {
@@ -52,21 +54,54 @@ class RowComponent extends React.PureComponent<{
   render() {
     const {item} = this.props;
     return (
-      <TouchableHighlight
-        onShowUnderlay={this.props.onShowUnderlay}
-        onHideUnderlay={this.props.onHideUnderlay}
-        onPress={this._onPress}>
-        <View style={styles.row}>
-          <Text style={styles.rowTitleText}>{item.module.title}</Text>
-          <Text style={styles.rowDetailText}>{item.module.description}</Text>
-        </View>
-      </TouchableHighlight>
+      <RNTesterThemeContext.Consumer>
+        {theme => {
+          return (
+            <TouchableHighlight
+              onShowUnderlay={this.props.onShowUnderlay}
+              onHideUnderlay={this.props.onHideUnderlay}
+              onPress={this._onPress}>
+              <View
+                style={[
+                  styles.row,
+                  {backgroundColor: theme.SystemBackgroundColor},
+                ]}>
+                <Text style={[styles.rowTitleText, {color: theme.LabelColor}]}>
+                  {item.module.title}
+                </Text>
+                <Text
+                  style={[
+                    styles.rowDetailText,
+                    {color: theme.SecondaryLabelColor},
+                  ]}>
+                  {item.module.description}
+                </Text>
+              </View>
+            </TouchableHighlight>
+          );
+        }}
+      </RNTesterThemeContext.Consumer>
     );
   }
 }
 
 const renderSectionHeader = ({section}) => (
-  <Text style={styles.sectionHeader}>{section.title}</Text>
+  <RNTesterThemeContext.Consumer>
+    {theme => {
+      return (
+        <Text
+          style={[
+            styles.sectionHeader,
+            {
+              color: theme.SecondaryLabelColor,
+              backgroundColor: theme.GroupedBackgroundColor,
+            },
+          ]}>
+          {section.title}
+        </Text>
+      );
+    }}
+  </RNTesterThemeContext.Consumer>
 );
 
 class RNTesterExampleList extends React.Component<Props, $FlowFixMeState> {
@@ -89,29 +124,46 @@ class RNTesterExampleList extends React.Component<Props, $FlowFixMeState> {
     ];
 
     return (
-      <View style={[styles.listContainer, this.props.style]}>
-        {this._renderTitleRow()}
-        <RNTesterExampleFilter
-          testID="explorer_search"
-          sections={sections}
-          filter={filter}
-          render={({filteredSections}) => (
-            <SectionList
-              ItemSeparatorComponent={ItemSeparator}
-              contentContainerStyle={styles.sectionListContentContainer}
-              style={styles.list}
-              sections={filteredSections}
-              renderItem={this._renderItem}
-              enableEmptySections={true}
-              itemShouldUpdate={this._itemShouldUpdate}
-              keyboardShouldPersistTaps="handled"
-              automaticallyAdjustContentInsets={false}
-              keyboardDismissMode="on-drag"
-              renderSectionHeader={renderSectionHeader}
-            />
-          )}
-        />
-      </View>
+      <RNTesterThemeContext.Consumer>
+        {theme => {
+          return (
+            <View
+              style={[
+                styles.listContainer,
+                this.props.style,
+                {backgroundColor: theme.SecondaryGroupedBackgroundColor},
+              ]}>
+              {this._renderTitleRow()}
+              <RNTesterExampleFilter
+                testID="explorer_search"
+                sections={sections}
+                filter={filter}
+                render={({filteredSections}) => (
+                  <SectionList
+                    ItemSeparatorComponent={ItemSeparator}
+                    contentContainerStyle={{
+                      backgroundColor: theme.SeparatorColor,
+                    }}
+                    style={{backgroundColor: theme.SystemBackgroundColor}}
+                    sections={filteredSections}
+                    renderItem={this._renderItem}
+                    enableEmptySections={true}
+                    itemShouldUpdate={this._itemShouldUpdate}
+                    keyboardShouldPersistTaps="handled"
+                    automaticallyAdjustContentInsets={false}
+                    keyboardDismissMode="on-drag"
+                    renderSectionHeader={renderSectionHeader}
+                    backgroundColor={Platform.select({
+                      ios: 'transparent',
+                      default: undefined,
+                    })}
+                  />
+                )}
+              />
+            </View>
+          );
+        }}
+      </RNTesterThemeContext.Consumer>
     );
   }
 
@@ -157,39 +209,44 @@ class RNTesterExampleList extends React.Component<Props, $FlowFixMeState> {
 }
 
 const ItemSeparator = ({highlighted}) => (
-  <View style={highlighted ? styles.separatorHighlighted : styles.separator} />
+  <RNTesterThemeContext.Consumer>
+    {theme => {
+      return (
+        <View
+          style={
+            highlighted
+              ? [
+                  styles.separatorHighlighted,
+                  {backgroundColor: theme.OpaqueSeparatorColor},
+                ]
+              : [styles.separator, {backgroundColor: theme.SeparatorColor}]
+          }
+        />
+      );
+    }}
+  </RNTesterThemeContext.Consumer>
 );
 
 const styles = StyleSheet.create({
   listContainer: {
     flex: 1,
   },
-  list: {
-    backgroundColor: '#eeeeee',
-  },
   sectionHeader: {
-    backgroundColor: '#eeeeee',
     padding: 5,
     fontWeight: '500',
     fontSize: 11,
   },
   row: {
-    backgroundColor: 'white',
     justifyContent: 'center',
     paddingHorizontal: 15,
     paddingVertical: 8,
   },
   separator: {
     height: StyleSheet.hairlineWidth,
-    backgroundColor: '#bbbbbb',
     marginLeft: 15,
   },
   separatorHighlighted: {
     height: StyleSheet.hairlineWidth,
-    backgroundColor: 'rgb(217, 217, 217)',
-  },
-  sectionListContentContainer: {
-    backgroundColor: 'white',
   },
   rowTitleText: {
     fontSize: 17,
@@ -197,7 +254,6 @@ const styles = StyleSheet.create({
   },
   rowDetailText: {
     fontSize: 15,
-    color: '#888888',
     lineHeight: 20,
   },
 });

--- a/RNTester/js/components/RNTesterPage.js
+++ b/RNTester/js/components/RNTesterPage.js
@@ -12,8 +12,8 @@
 
 const RNTesterTitle = require('./RNTesterTitle');
 const React = require('react');
-
 const {ScrollView, StyleSheet, View} = require('react-native');
+import {RNTesterThemeContext} from './RNTesterTheme';
 
 type Props = $ReadOnly<{|
   children?: React.Node,
@@ -39,20 +39,29 @@ class RNTesterPage extends React.Component<Props> {
     ) : null;
     const spacer = this.props.noSpacer ? null : <View style={styles.spacer} />;
     return (
-      <View style={styles.container}>
-        {title}
-        <ContentWrapper style={styles.wrapper} {...wrapperProps}>
-          {this.props.children}
-          {spacer}
-        </ContentWrapper>
-      </View>
+      <RNTesterThemeContext.Consumer>
+        {theme => {
+          return (
+            <View
+              style={[
+                styles.container,
+                {backgroundColor: theme.SecondarySystemBackgroundColor},
+              ]}>
+              {title}
+              <ContentWrapper style={styles.wrapper} {...wrapperProps}>
+                {this.props.children}
+                {spacer}
+              </ContentWrapper>
+            </View>
+          );
+        }}
+      </RNTesterThemeContext.Consumer>
     );
   }
 }
 
 const styles = StyleSheet.create({
   container: {
-    backgroundColor: '#e9eaed',
     flex: 1,
   },
   spacer: {

--- a/RNTester/js/components/RNTesterTheme.js
+++ b/RNTester/js/components/RNTesterTheme.js
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+'use strict';
+
+import * as React from 'react';
+import {Appearance} from 'react-native';
+
+export type RNTesterTheme = {
+  LabelColor: string,
+  SecondaryLabelColor: string,
+  TertiaryLabelColor: string,
+  QuaternaryLabelColor: string,
+  PlaceholderTextColor: string,
+  SystemBackgroundColor: string,
+  SecondarySystemBackgroundColor: string,
+  TertiarySystemBackgroundColor: string,
+  GroupedBackgroundColor: string,
+  SecondaryGroupedBackgroundColor: string,
+  TertiaryGroupedBackgroundColor: string,
+  SystemFillColor: string,
+  SecondarySystemFillColor: string,
+  TertiarySystemFillColor: string,
+  QuaternarySystemFillColor: string,
+  SeparatorColor: string,
+  OpaqueSeparatorColor: string,
+  LinkColor: string,
+  SystemPurpleColor: string,
+  ToolbarColor: string,
+};
+
+export const RNTesterLightTheme = {
+  LabelColor: '#000000ff',
+  SecondaryLabelColor: '#3c3c4399',
+  TertiaryLabelColor: '#3c3c434c',
+  QuaternaryLabelColor: '#3c3c432d',
+  PlaceholderTextColor: '#3c3c434c',
+  SystemBackgroundColor: '#ffffffff',
+  SecondarySystemBackgroundColor: '#f2f2f7ff',
+  TertiarySystemBackgroundColor: '#ffffffff',
+  GroupedBackgroundColor: '#f2f2f7ff',
+  SecondaryGroupedBackgroundColor: '#ffffffff',
+  TertiaryGroupedBackgroundColor: '#f2f2f7ff',
+  SystemFillColor: '#78788033',
+  SecondarySystemFillColor: '#78788028',
+  TertiarySystemFillColor: '#7676801e',
+  QuaternarySystemFillColor: '#74748014',
+  SeparatorColor: '#3c3c4349',
+  OpaqueSeparatorColor: '#c6c6c8ff',
+  LinkColor: '#007affff',
+  SystemPurpleColor: '#af52deff',
+  ToolbarColor: '#e9eaedff',
+};
+
+export const RNTesterDarkTheme = {
+  LabelColor: '#ffffffff',
+  SecondaryLabelColor: '#ebebf599',
+  TertiaryLabelColor: '#ebebf54c',
+  QuaternaryLabelColor: '#ebebf528',
+  PlaceholderTextColor: '#ebebf54c',
+  SystemBackgroundColor: '#000000ff',
+  SecondarySystemBackgroundColor: '#1c1c1eff',
+  TertiarySystemBackgroundColor: '#2c2c2eff',
+  GroupedBackgroundColor: '#000000ff',
+  SecondaryGroupedBackgroundColor: '#1c1c1eff',
+  TertiaryGroupedBackgroundColor: '#2c2c2eff',
+  SystemFillColor: '#7878805b',
+  SecondarySystemFillColor: '#78788051',
+  TertiarySystemFillColor: '#7676803d',
+  QuaternarySystemFillColor: '#7676802d',
+  SeparatorColor: '#54545899',
+  OpaqueSeparatorColor: '#38383aff',
+  LinkColor: '#0984ffff',
+  SystemPurpleColor: '#bf5af2ff',
+  ToolbarColor: '#3c3c43ff',
+};
+
+export const themes = {light: RNTesterLightTheme, dark: RNTesterDarkTheme};
+export const RNTesterThemeContext: React.Context<RNTesterTheme> = React.createContext(
+  Appearance.getColorScheme() === 'dark' ? themes.dark : themes.light,
+);

--- a/RNTester/js/components/RNTesterTitle.js
+++ b/RNTester/js/components/RNTesterTitle.js
@@ -13,13 +13,29 @@
 const React = require('react');
 
 const {StyleSheet, Text, View} = require('react-native');
+import {RNTesterThemeContext} from './RNTesterTheme';
 
 class RNTesterTitle extends React.Component<$FlowFixMeProps> {
   render(): React.Node {
     return (
-      <View style={styles.container}>
-        <Text style={styles.text}>{this.props.title}</Text>
-      </View>
+      <RNTesterThemeContext.Consumer>
+        {theme => {
+          return (
+            <View
+              style={[
+                styles.container,
+                {
+                  borderColor: theme.SeparatorColor,
+                  backgroundColor: theme.SystemBackgroundColor,
+                },
+              ]}>
+              <Text style={[styles.text, {color: theme.LabelColor}]}>
+                {this.props.title}
+              </Text>
+            </View>
+          );
+        }}
+      </RNTesterThemeContext.Consumer>
     );
   }
 }
@@ -28,12 +44,10 @@ const styles = StyleSheet.create({
   container: {
     borderRadius: 4,
     borderWidth: 0.5,
-    borderColor: '#d6d7da',
     margin: 10,
     marginBottom: 0,
     height: 45,
     padding: 10,
-    backgroundColor: 'white',
   },
   text: {
     fontSize: 19,

--- a/RNTester/js/examples/Appearance/AppearanceExample.js
+++ b/RNTester/js/examples/Appearance/AppearanceExample.js
@@ -11,9 +11,8 @@
 'use strict';
 
 import * as React from 'react';
-import {Appearance, Text, View} from 'react-native';
+import {Appearance, Text, useColorScheme, View} from 'react-native';
 import type {AppearancePreferences} from '../../../../Libraries/Utilities/NativeAppearance';
-
 import {RNTesterThemeContext, themes} from '../../components/RNTesterTheme';
 
 class ColorSchemeSubscription extends React.Component<
@@ -80,6 +79,23 @@ const ThemedText = props => (
 exports.title = 'Appearance';
 exports.description = 'Light and dark user interface examples.';
 exports.examples = [
+  {
+    title: 'useColorScheme hook',
+    render(): React.Node {
+      const AppearanceViaHook = () => {
+        const colorScheme = useColorScheme();
+        return (
+          <RNTesterThemeContext.Provider
+            value={colorScheme === 'dark' ? themes.dark : themes.light}>
+            <ThemedContainer>
+              <ThemedText>useColorScheme(): {colorScheme}</ThemedText>
+            </ThemedContainer>
+          </RNTesterThemeContext.Provider>
+        );
+      };
+      return <AppearanceViaHook />;
+    },
+  },
   {
     title: 'Non-component `getColorScheme` API',
     render(): React.Element<any> {

--- a/RNTester/js/examples/Appearance/AppearanceExample.js
+++ b/RNTester/js/examples/Appearance/AppearanceExample.js
@@ -1,0 +1,201 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow
+ */
+
+'use strict';
+
+import * as React from 'react';
+import {Appearance, Text, View} from 'react-native';
+import type {AppearancePreferences} from '../../../../Libraries/Utilities/NativeAppearance';
+
+import {RNTesterThemeContext, themes} from '../../components/RNTesterTheme';
+
+class ColorSchemeSubscription extends React.Component<
+  {},
+  {colorScheme: ?string},
+> {
+  state = {
+    colorScheme: Appearance.getColorScheme(),
+  };
+
+  componentDidMount() {
+    Appearance.addChangeListener(this._handleAppearanceChange);
+  }
+
+  componentWillUnmount() {
+    Appearance.removeChangeListener(this._handleAppearanceChange);
+  }
+
+  _handleAppearanceChange = (preferences: AppearancePreferences) => {
+    const {colorScheme} = preferences;
+    this.setState({colorScheme});
+  };
+
+  render() {
+    return (
+      <RNTesterThemeContext.Consumer>
+        {theme => {
+          return (
+            <ThemedContainer>
+              <ThemedText>{this.state.colorScheme}</ThemedText>
+            </ThemedContainer>
+          );
+        }}
+      </RNTesterThemeContext.Consumer>
+    );
+  }
+}
+
+const ThemedContainer = props => (
+  <RNTesterThemeContext.Consumer>
+    {theme => {
+      return (
+        <View
+          style={{
+            paddingHorizontal: 8,
+            paddingVertical: 16,
+            backgroundColor: theme.SystemBackgroundColor,
+          }}>
+          {props.children}
+        </View>
+      );
+    }}
+  </RNTesterThemeContext.Consumer>
+);
+
+const ThemedText = props => (
+  <RNTesterThemeContext.Consumer>
+    {theme => {
+      return <Text style={{color: theme.LabelColor}}>{props.children}</Text>;
+    }}
+  </RNTesterThemeContext.Consumer>
+);
+
+exports.title = 'Appearance';
+exports.description = 'Light and dark user interface examples.';
+exports.examples = [
+  {
+    title: 'Non-component `getColorScheme` API',
+    render(): React.Element<any> {
+      return <ColorSchemeSubscription />;
+    },
+  },
+  {
+    title: 'Consuming Context',
+    render(): React.Element<any> {
+      return (
+        <RNTesterThemeContext.Consumer>
+          {theme => {
+            return (
+              <ThemedContainer>
+                <ThemedText>
+                  This block of text inherits its theme via Context.
+                </ThemedText>
+              </ThemedContainer>
+            );
+          }}
+        </RNTesterThemeContext.Consumer>
+      );
+    },
+  },
+  {
+    title: 'Context forced to light theme',
+    render(): React.Element<any> {
+      return (
+        <RNTesterThemeContext.Provider value={themes.light}>
+          <ThemedContainer>
+            <ThemedText>
+              This block of text will always render with a light theme.
+            </ThemedText>
+          </ThemedContainer>
+        </RNTesterThemeContext.Provider>
+      );
+    },
+  },
+  {
+    title: 'Context forced to dark theme',
+    render(): React.Element<any> {
+      return (
+        <RNTesterThemeContext.Provider value={themes.dark}>
+          <ThemedContainer>
+            <ThemedText>
+              This block of text will always render with a dark theme.
+            </ThemedText>
+          </ThemedContainer>
+        </RNTesterThemeContext.Provider>
+      );
+    },
+  },
+  {
+    title: 'RNTester App Colors',
+    description: 'A light and a dark theme based on standard iOS 13 colors.',
+    render(): React.Element<any> {
+      const ColorShowcase = props => (
+        <RNTesterThemeContext.Consumer>
+          {theme => {
+            return (
+              <View
+                style={{
+                  marginVertical: 20,
+                  backgroundColor: theme.SystemBackgroundColor,
+                }}>
+                <Text style={{fontWeight: '700', color: theme.LabelColor}}>
+                  {props.themeName}
+                </Text>
+                {Object.keys(theme).map(key => (
+                  <View style={{flexDirection: 'row'}} key={key}>
+                    <View
+                      style={{
+                        width: 50,
+                        height: 50,
+                        paddingHorizontal: 8,
+                        paddingVertical: 2,
+                        backgroundColor: theme[key],
+                      }}
+                    />
+                    <View>
+                      <Text
+                        style={{
+                          paddingHorizontal: 16,
+                          paddingVertical: 2,
+                          color: theme.LabelColor,
+                          fontWeight: '600',
+                        }}>
+                        {key}
+                      </Text>
+                      <Text
+                        style={{
+                          paddingHorizontal: 16,
+                          paddingVertical: 2,
+                          color: theme.LabelColor,
+                        }}>
+                        {theme[key]}
+                      </Text>
+                    </View>
+                  </View>
+                ))}
+              </View>
+            );
+          }}
+        </RNTesterThemeContext.Consumer>
+      );
+
+      return (
+        <View>
+          <RNTesterThemeContext.Provider value={themes.light}>
+            <ColorShowcase themeName="Light Mode" />
+          </RNTesterThemeContext.Provider>
+          <RNTesterThemeContext.Provider value={themes.dark}>
+            <ColorShowcase themeName="Dark Mode" />
+          </RNTesterThemeContext.Provider>
+        </View>
+      );
+    },
+  },
+];

--- a/RNTester/js/examples/Button/ButtonExample.js
+++ b/RNTester/js/examples/Button/ButtonExample.js
@@ -13,6 +13,7 @@
 const React = require('react');
 
 const {Alert, Button, View, StyleSheet} = require('react-native');
+import {RNTesterThemeContext} from '../../components/RNTesterTheme';
 
 function onButtonPress(buttonName) {
   Alert.alert(`${buttonName} has been pressed!`);
@@ -31,12 +32,19 @@ exports.examples = [
       'everyone.': string),
     render: function(): React.Node {
       return (
-        <Button
-          onPress={() => onButtonPress('Simple')}
-          testID="simple_button"
-          title="Press Me"
-          accessibilityLabel="See an informative alert"
-        />
+        <RNTesterThemeContext.Consumer>
+          {theme => {
+            return (
+              <Button
+                onPress={() => onButtonPress('Simple')}
+                testID="simple_button"
+                color={theme.LinkColor}
+                title="Press Me"
+                accessibilityLabel="See an informative alert"
+              />
+            );
+          }}
+        </RNTesterThemeContext.Consumer>
       );
     },
   },
@@ -47,13 +55,19 @@ exports.examples = [
       'Android, the color adjusts the background color of the button.': string),
     render: function(): React.Node {
       return (
-        <Button
-          onPress={() => onButtonPress('Purple')}
-          testID="purple_button"
-          title="Press Purple"
-          color="#841584"
-          accessibilityLabel="Learn more about purple"
-        />
+        <RNTesterThemeContext.Consumer>
+          {theme => {
+            return (
+              <Button
+                onPress={() => onButtonPress('Purple')}
+                testID="purple_button"
+                color={theme.SystemPurpleColor}
+                title="Press Purple"
+                accessibilityLabel="Learn more about purple"
+              />
+            );
+          }}
+        </RNTesterThemeContext.Consumer>
       );
     },
   },
@@ -63,21 +77,28 @@ exports.examples = [
       'the button': string),
     render: function(): React.Node {
       return (
-        <View style={styles.container}>
-          <Button
-            onPress={() => onButtonPress('Left')}
-            testID="left_button"
-            title="This looks great!"
-            accessibilityLabel="This sounds great!"
-          />
-          <Button
-            onPress={() => onButtonPress('Right')}
-            testID="right_button"
-            title="Ok!"
-            color="#841584"
-            accessibilityLabel="Ok, Great!"
-          />
-        </View>
+        <RNTesterThemeContext.Consumer>
+          {theme => {
+            return (
+              <View style={styles.container}>
+                <Button
+                  onPress={() => onButtonPress('Left')}
+                  testID="left_button"
+                  color={theme.LinkColor}
+                  title="This looks great!"
+                  accessibilityLabel="This sounds great!"
+                />
+                <Button
+                  onPress={() => onButtonPress('Right')}
+                  testID="right_button"
+                  color={theme.SystemPurpleColor}
+                  title="Ok!"
+                  accessibilityLabel="Ok, Great!"
+                />
+              </View>
+            );
+          }}
+        </RNTesterThemeContext.Consumer>
       );
     },
   },

--- a/RNTester/js/utils/RNTesterActions.js
+++ b/RNTester/js/utils/RNTesterActions.js
@@ -25,16 +25,10 @@ export type RNTesterExampleAction = {
   openExample: string,
 };
 
-export type RNTesterThemeAction = {
-  type: 'RNTesterThemeAction',
-  theme: RNTesterTheme,
-};
-
 export type RNTesterAction =
   | RNTesterBackAction
   | RNTesterListAction
-  | RNTesterExampleAction
-  | RNTesterThemeAction;
+  | RNTesterExampleAction;
 
 function Back(): RNTesterBackAction {
   return {
@@ -55,18 +49,10 @@ function ExampleAction(openExample: string): RNTesterExampleAction {
   };
 }
 
-function ThemeAction(theme: RNTesterTheme): RNTesterThemeAction {
-  return {
-    type: 'RNTesterThemeAction',
-    theme,
-  };
-}
-
 const RNTesterActions = {
   Back,
   ExampleList,
   ExampleAction,
-  ThemeAction,
 };
 
 module.exports = RNTesterActions;

--- a/RNTester/js/utils/RNTesterActions.js
+++ b/RNTester/js/utils/RNTesterActions.js
@@ -5,10 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @flow strict
+ * @flow strict-local
  */
 
 'use strict';
+
+import type {RNTesterTheme} from '../components/RNTesterTheme';
 
 export type RNTesterBackAction = {
   type: 'RNTesterBackAction',
@@ -23,10 +25,16 @@ export type RNTesterExampleAction = {
   openExample: string,
 };
 
+export type RNTesterThemeAction = {
+  type: 'RNTesterThemeAction',
+  theme: RNTesterTheme,
+};
+
 export type RNTesterAction =
   | RNTesterBackAction
   | RNTesterListAction
-  | RNTesterExampleAction;
+  | RNTesterExampleAction
+  | RNTesterThemeAction;
 
 function Back(): RNTesterBackAction {
   return {
@@ -47,10 +55,18 @@ function ExampleAction(openExample: string): RNTesterExampleAction {
   };
 }
 
+function ThemeAction(theme: RNTesterTheme): RNTesterThemeAction {
+  return {
+    type: 'RNTesterThemeAction',
+    theme,
+  };
+}
+
 const RNTesterActions = {
   Back,
   ExampleList,
   ExampleAction,
+  ThemeAction,
 };
 
 module.exports = RNTesterActions;

--- a/RNTester/js/utils/RNTesterList.android.js
+++ b/RNTester/js/utils/RNTesterList.android.js
@@ -129,6 +129,10 @@ const APIExamples: Array<RNTesterExample> = [
     module: require('../examples/Animated/AnimatedExample'),
   },
   {
+    key: 'AppearanceExample',
+    module: require('../examples/Appearance/AppearanceExample'),
+  },
+  {
     key: 'AppStateExample',
     module: require('../examples/AppState/AppStateExample'),
   },

--- a/RNTester/js/utils/RNTesterList.ios.js
+++ b/RNTester/js/utils/RNTesterList.ios.js
@@ -206,6 +206,11 @@ const APIExamples: Array<RNTesterExample> = [
     supportsTVOS: true,
   },
   {
+    key: 'AppearanceExample',
+    module: require('../examples/Appearance/AppearanceExample'),
+    supportsTVOS: false,
+  },
+  {
     key: 'AppStateExample',
     module: require('../examples/AppState/AppStateExample'),
     supportsTVOS: true,

--- a/RNTester/js/utils/RNTesterNavigationReducer.js
+++ b/RNTester/js/utils/RNTesterNavigationReducer.js
@@ -10,15 +10,10 @@
 
 'use strict';
 
-import {themes} from '../components/RNTesterTheme';
-import type {RNTesterTheme} from '../components/RNTesterTheme';
-
 const RNTesterList = require('./RNTesterList');
-import {Appearance} from 'react-native';
 
 export type RNTesterNavigationState = {
   openExample: ?string,
-  theme: RNTesterTheme,
 };
 
 function RNTesterNavigationReducer(
@@ -36,8 +31,6 @@ function RNTesterNavigationReducer(
     return {
       // A null openExample will cause the views to display the RNTester example list
       openExample: null,
-      theme:
-        Appearance.getColorScheme() === 'dark' ? themes.dark : themes.light,
     };
   }
 
@@ -48,16 +41,6 @@ function RNTesterNavigationReducer(
     if (ExampleModule) {
       return {
         openExample: action.openExample,
-        theme: state.theme,
-      };
-    }
-  }
-
-  if (action.type === 'RNTesterThemeAction') {
-    if (action.colorScheme) {
-      return {
-        openExample: state.openExample,
-        theme: action.colorScheme === 'dark' ? themes.dark : themes.light,
       };
     }
   }

--- a/RNTester/js/utils/RNTesterNavigationReducer.js
+++ b/RNTester/js/utils/RNTesterNavigationReducer.js
@@ -10,10 +10,15 @@
 
 'use strict';
 
+import {themes} from '../components/RNTesterTheme';
+import type {RNTesterTheme} from '../components/RNTesterTheme';
+
 const RNTesterList = require('./RNTesterList');
+import {Appearance} from 'react-native';
 
 export type RNTesterNavigationState = {
   openExample: ?string,
+  theme: RNTesterTheme,
 };
 
 function RNTesterNavigationReducer(
@@ -31,6 +36,8 @@ function RNTesterNavigationReducer(
     return {
       // A null openExample will cause the views to display the RNTester example list
       openExample: null,
+      theme:
+        Appearance.getColorScheme() === 'dark' ? themes.dark : themes.light,
     };
   }
 
@@ -41,6 +48,16 @@ function RNTesterNavigationReducer(
     if (ExampleModule) {
       return {
         openExample: action.openExample,
+        theme: state.theme,
+      };
+    }
+  }
+
+  if (action.type === 'RNTesterThemeAction') {
+    if (action.colorScheme) {
+      return {
+        openExample: state.openExample,
+        theme: action.colorScheme === 'dark' ? themes.dark : themes.light,
       };
     }
   }

--- a/React/Base/RCTRootView.m
+++ b/React/Base/RCTRootView.m
@@ -33,6 +33,7 @@
 #endif
 
 NSString *const RCTContentDidAppearNotification = @"RCTContentDidAppearNotification";
+NSString *const RCTUserInterfaceStyleDidChangeNotification = @"RCTUserInterfaceStyleDidChangeNotification";
 
 @interface RCTUIManager (RCTRootView)
 
@@ -347,7 +348,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
   if (bothSizesHaveAZeroDimension || sizesAreEqual) {
     return;
   }
-  
+
   [self invalidateIntrinsicContentSize];
   [self.superview setNeedsLayout];
 
@@ -365,6 +366,22 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
   _contentView = nil;
   [self showLoadingView];
 }
+
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_13_0) && \
+    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
+- (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection
+{
+  [super traitCollectionDidChange:previousTraitCollection];
+
+  if (@available(iOS 13.0, *)) {
+    if ([previousTraitCollection hasDifferentColorAppearanceComparedToTraitCollection:self.traitCollection]) {
+      [[NSNotificationCenter defaultCenter] postNotificationName:RCTUserInterfaceStyleDidChangeNotification
+                                                          object:self
+                                                        userInfo:@{@"traitCollection": self.traitCollection}];
+    }
+  }
+}
+#endif
 
 - (void)dealloc
 {

--- a/React/CoreModules/BUCK
+++ b/React/CoreModules/BUCK
@@ -38,6 +38,10 @@ rn_apple_library(
         ["-D PIC_MODIFIER=@PLT"],
     )],
     plugins = react_module_plugin_providers(
+                  name = "AppearanceConstants",
+                  native_class_func = "RCTAppearanceCls",
+              ) +
+              react_module_plugin_providers(
                   name = "DeviceInfo",
                   native_class_func = "RCTDeviceInfoCls",
               ) +

--- a/React/CoreModules/CoreModulesPlugins.h
+++ b/React/CoreModules/CoreModulesPlugins.h
@@ -29,6 +29,7 @@ extern "C" {
 Class RCTCoreModulesClassProvider(const char *name);
 
 // Lookup functions
+Class RCTAppearanceCls(void);
 Class RCTDeviceInfoCls(void);
 Class RCTExceptionsManagerCls(void);
 Class RCTImageLoaderCls(void);

--- a/React/CoreModules/CoreModulesPlugins.mm
+++ b/React/CoreModules/CoreModulesPlugins.mm
@@ -17,7 +17,8 @@
 #import <unordered_map>
 
 static std::unordered_map<std::string, Class (*)(void)> sCoreModuleClassMap = {
-  {"DeviceInfo", RCTDeviceInfoCls},
+  {"AppearanceConstants", RCTAppearanceCls},
+{"DeviceInfo", RCTDeviceInfoCls},
 {"ExceptionsManager", RCTExceptionsManagerCls},
 {"ImageLoader", RCTImageLoaderCls},
 {"PlatformConstants", RCTPlatformCls},

--- a/React/CoreModules/RCTAppearance.h
+++ b/React/CoreModules/RCTAppearance.h
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <UIKit/UIKit.h>
+
+#import <React/RCTBridgeModule.h>
+#import <React/RCTEventEmitter.h>
+
+NSString *const RCTUserInterfaceStyleDidChangeNotification = @"RCTUserInterfaceStyleDidChangeNotification";
+
+@interface RCTAppearance : RCTEventEmitter <RCTBridgeModule>
+@end

--- a/React/CoreModules/RCTAppearance.mm
+++ b/React/CoreModules/RCTAppearance.mm
@@ -1,0 +1,107 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import "RCTAppearance.h"
+
+#import <FBReactNativeSpec/FBReactNativeSpec.h>
+#import <React/RCTEventEmitter.h>
+
+#import "CoreModulesPlugins.h"
+
+using namespace facebook::react;
+
+NSString *const RCTAppearanceColorSchemeLight = @"light";
+NSString *const RCTAppearanceColorSchemeDark = @"dark";
+
+static NSString *RCTColorSchemePreference(UITraitCollection *traitCollection)
+{
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_13_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
+  if (@available(iOS 13.0, *)) {
+    static NSDictionary *appearances;
+    static dispatch_once_t onceToken;
+
+    dispatch_once(&onceToken, ^{
+      appearances = @{
+                      @(UIUserInterfaceStyleLight): RCTAppearanceColorSchemeLight,
+                      @(UIUserInterfaceStyleDark): RCTAppearanceColorSchemeDark
+                      };
+    });
+
+    traitCollection = traitCollection ?: [UITraitCollection currentTraitCollection];
+    return appearances[@(traitCollection.userInterfaceStyle)] ?: nil;
+  }
+#endif
+
+  return nil;
+}
+
+@interface RCTAppearance () <NativeAppearanceSpec>
+@end
+
+@implementation RCTAppearance
+
+RCT_EXPORT_MODULE(AppearanceConstants)
+
++ (BOOL)requiresMainQueueSetup
+{
+  return YES;
+}
+
+- (dispatch_queue_t)methodQueue
+{
+  return dispatch_get_main_queue();
+}
+
+- (std::shared_ptr<TurboModule>)getTurboModuleWithJsInvoker:(std::shared_ptr<JSCallInvoker>)jsInvoker
+{
+  return std::make_shared<NativeAppearanceSpecJSI>(self, jsInvoker);
+}
+
+RCT_EXPORT_SYNCHRONOUS_TYPED_METHOD(NSString *, getColorScheme)
+{
+  return RCTColorSchemePreference(nil);
+}
+
+- (void)appearanceChanged:(NSNotification *)notification
+{
+  NSDictionary *userInfo = [notification userInfo];
+  UITraitCollection *traitCollection = nil;
+  if (userInfo) {
+    traitCollection = userInfo[@"traitCollection"];
+  }
+  [self sendEventWithName:@"appearanceChanged" body:@{@"colorScheme": RCTColorSchemePreference(traitCollection)}];
+}
+
+#pragma mark - RCTEventEmitter
+
+- (NSArray<NSString *> *)supportedEvents
+{
+  return @[@"appearanceChanged"];
+}
+
+- (void)startObserving
+{
+  if (@available(iOS 13.0, *)) {
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(appearanceChanged:)
+                                                 name:RCTUserInterfaceStyleDidChangeNotification
+                                               object:nil];
+  }
+}
+
+- (void)stopObserving
+{
+  if (@available(iOS 13.0, *)) {
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
+  }
+}
+
+@end
+
+Class RCTAppearanceCls(void) {
+  return RCTAppearance.class;
+}

--- a/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
@@ -34,6 +34,7 @@ import static com.facebook.systrace.Systrace.TRACE_TAG_REACT_JS_VM_CALLS;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
+import android.content.res.Configuration;
 import android.net.Uri;
 import android.os.Bundle;
 import android.os.Process;
@@ -78,6 +79,7 @@ import com.facebook.react.devsupport.RedBoxHandler;
 import com.facebook.react.devsupport.interfaces.DevBundleDownloadListener;
 import com.facebook.react.devsupport.interfaces.DevSupportManager;
 import com.facebook.react.devsupport.interfaces.PackagerStatusCallback;
+import com.facebook.react.modules.appearance.AppearanceModule;
 import com.facebook.react.modules.appregistry.AppRegistry;
 import com.facebook.react.modules.core.DefaultHardwareBackBtnHandler;
 import com.facebook.react.modules.core.DeviceEventManagerModule;
@@ -709,6 +711,17 @@ public class ReactInstanceManager {
     ReactContext currentContext = getCurrentReactContext();
     if (currentContext != null) {
       currentContext.onWindowFocusChange(hasFocus);
+    }
+  }
+
+  /** Call this from {@link Activity#onConfigurationChanged()}. */
+  @ThreadConfined(UI)
+  public void onConfigurationChanged(Configuration newConfig) {
+    UiThreadUtil.assertOnUiThread();
+
+    ReactContext currentContext = getCurrentReactContext();
+    if (currentContext != null) {
+      currentContext.getNativeModule(AppearanceModule.class).onConfigurationChanged();
     }
   }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/appearance/AppearanceModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/appearance/AppearanceModule.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * <p>This source code is licensed under the MIT license found in the LICENSE file in the root
+ * directory of this source tree.
+ */
+package com.facebook.react.modules.appearance;
+
+import android.content.Context;
+import android.content.res.Configuration;
+import android.os.Build;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.JavaScriptModule;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContextBaseJavaModule;
+import com.facebook.react.bridge.ReactMethod;
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.module.annotations.ReactModule;
+import com.facebook.react.modules.core.DeviceEventManagerModule.RCTDeviceEventEmitter;
+
+/** Module that exposes the user's preferred color scheme. For API >= 29. */
+@ReactModule(name = AppearanceModule.NAME)
+public class AppearanceModule extends ReactContextBaseJavaModule {
+  public static final String NAME = "Appearance";
+
+  private static final String APPEARANCE_CHANGED_EVENT_NAME = "appearanceChanged";
+  private static final int ANDROID_TEN = 29;
+
+  public interface RCTDeviceEventEmitter extends JavaScriptModule {
+    void emit(@NonNull String eventName, @Nullable Object data);
+  }
+
+  public AppearanceModule(ReactApplicationContext reactContext) {
+    super(reactContext);
+  }
+
+  private static boolean isNightModeAvailableAndOn(Context context) {
+    int currentNightMode =
+        context.getResources().getConfiguration().uiMode & Configuration.UI_MODE_NIGHT_MASK;
+    return currentNightMode == Configuration.UI_MODE_NIGHT_YES;
+  }
+
+  @Override
+  public String getName() {
+    return "Appearance";
+  }
+
+  @ReactMethod(isBlockingSynchronousMethod = true)
+  public String getColorScheme() {
+    // TODO: (hramos) T52929922: Switch to Build.VERSION_CODES.ANDROID_TEN or equivalent
+    if (Build.VERSION.SDK_INT >= ANDROID_TEN
+        && isNightModeAvailableAndOn(getReactApplicationContext())) {
+      return "dark";
+    }
+
+    return "light";
+  }
+
+  /** Stub */
+  @ReactMethod
+  public void addListener(String eventName) {}
+
+  /** Stub */
+  @ReactMethod
+  public void removeListeners(double count) {}
+
+  /** Sends an event to the JS instance that the preferred color scheme has changed. */
+  public void emitAppearanceChanged(String colorScheme) {
+    WritableMap appearancePreferences = Arguments.createMap();
+    appearancePreferences.putString("colorScheme", colorScheme);
+
+    getReactApplicationContext()
+        .getJSModule(RCTDeviceEventEmitter.class)
+        .emit(APPEARANCE_CHANGED_EVENT_NAME, appearancePreferences);
+  }
+}

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/appearance/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/appearance/BUCK
@@ -1,0 +1,19 @@
+load("//tools/build_defs/oss:rn_defs.bzl", "react_native_dep", "react_native_target", "rn_android_library")
+
+rn_android_library(
+    name = "appearance",
+    srcs = glob(["**/*.java"]),
+    is_androidx = True,
+    visibility = [
+        "PUBLIC",
+    ],
+    deps = [
+        react_native_dep("third-party/java/jsr-305:jsr-305"),
+        react_native_dep("third-party/android/support-annotations:android-support-annotations"),
+        react_native_dep("third-party/android/androidx:annotation"),
+        react_native_target("java/com/facebook/react/bridge:bridge"),
+        react_native_target("java/com/facebook/react/common:common"),
+        react_native_target("java/com/facebook/react/module/annotations:annotations"),
+        react_native_target("java/com/facebook/react/modules/core:core"),
+    ],
+)

--- a/ReactAndroid/src/main/java/com/facebook/react/shell/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/shell/BUCK
@@ -26,6 +26,7 @@ rn_android_library(
         react_native_target("java/com/facebook/react/devsupport:devsupport"),
         react_native_target("java/com/facebook/react/module/model:model"),
         react_native_target("java/com/facebook/react/modules/accessibilityinfo:accessibilityinfo"),
+        react_native_target("java/com/facebook/react/modules/appearance:appearance"),
         react_native_target("java/com/facebook/react/modules/appstate:appstate"),
         react_native_target("java/com/facebook/react/modules/blob:blob"),
         react_native_target("java/com/facebook/react/modules/camera:camera"),

--- a/ReactAndroid/src/main/java/com/facebook/react/shell/MainReactPackage.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/shell/MainReactPackage.java
@@ -16,6 +16,7 @@ import com.facebook.react.module.annotations.ReactModuleList;
 import com.facebook.react.module.model.ReactModuleInfo;
 import com.facebook.react.module.model.ReactModuleInfoProvider;
 import com.facebook.react.modules.accessibilityinfo.AccessibilityInfoModule;
+import com.facebook.react.modules.appearance.AppearanceModule;
 import com.facebook.react.modules.appstate.AppStateModule;
 import com.facebook.react.modules.blob.BlobModule;
 import com.facebook.react.modules.blob.FileReaderModule;
@@ -71,6 +72,7 @@ import java.util.Map;
 @ReactModuleList(
     nativeModules = {
       AccessibilityInfoModule.class,
+      AppearanceModule.class,
       AppStateModule.class,
       BlobModule.class,
       FileReaderModule.class,
@@ -112,6 +114,8 @@ public class MainReactPackage extends TurboReactPackage {
     switch (name) {
       case AccessibilityInfoModule.NAME:
         return new AccessibilityInfoModule(context);
+      case AppearanceModule.NAME:
+        return new AppearanceModule(context);
       case AppStateModule.NAME:
         return new AppStateModule(context);
       case BlobModule.NAME:
@@ -210,6 +214,7 @@ public class MainReactPackage extends TurboReactPackage {
       Class<? extends NativeModule>[] moduleList =
           new Class[] {
             AccessibilityInfoModule.class,
+            AppearanceModule.class,
             AppStateModule.class,
             BlobModule.class,
             FileReaderModule.class,

--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
     "regenerator-runtime": "^0.13.2",
     "scheduler": "0.15.0",
     "stacktrace-parser": "^0.1.3",
+    "use-subscription": "^1.0.0",
     "whatwg-fetch": "^3.0.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7003,6 +7003,11 @@ urix@^0.1.0:
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
   integrity sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
 
+use-subscription@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/use-subscription/-/use-subscription-1.0.0.tgz#25ed2161f75e9f6bd8c5c4acfe6087bfebfbfef4"
+  integrity sha512-PkDL9KSMN01nJYfa5c8O7Qbs7lmpzirfRWhWfIQN053hbIj5s1o5L7hrTzCfCCO2FsN2bKrU7ciRxxRcinmxAA==
+
 use@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"


### PR DESCRIPTION
Implements the Appearance native module as discussed in https://github.com/react-native-community/discussions-and-proposals/issues/126.

The purpose of the Appearance native module is to expose the user's appearance preferences. It provides a basic API that returns the user's preferred color scheme on iOS 13 and Android 10devices, also known as Dark Mode or Night theme. It also provides the ability to subscribe to events whenever an appearance preference changes.

The new useColorScheme hook is provided as the preferred way of accessing the user's preferred color scheme.

The name, "Appearance", was chosen purposefully to allow for future expansion to cover other appearance preferences such as reduced motion, reduced transparency, or high contrast modes.



Changelog:

[iOS] [Added] - The Appearance native module can be used to prepare your app for Dark Mode on iOS 13.
[Android] [Added] - The Appearance native module can be used to prepare your app for Night theme on Android 10.

## Android: Configuration Changes

The AppearanceModule now emits a `appearanceChanged` event when the current uiMode configuration changes.

To make your app handle Night mode changes, make sure to do the following:

* Declare your Activity can handle uiMode configuration changes (https://developer.android.com/preview/features/darktheme#java):
```
android:configChanges="uiMode"
```
* Make sure to pass the configuration changed activity lifecycle callback from your ReactActivity:
```
Override
protected void onConfigurationChanged(Configuration newConfig) {
    super.onConfigurationChanged();

    if (mReactInstanceManager != null) {
        mReactInstanceManager.onConfigurationChanged(newConfig);
    }
}
```

## iOS: Dark Mode changes

If your app does not use RCTRootView, you'll need to override one of the lifecycle view/view controller methods that get called when the trait collection changes (see https://developer.apple.com/documentation/appkit/supporting_dark_mode_in_your_interface). Then, post a notification with name "RCTUserInterfaceStyleDidChangeNotification" and the new color scheme in the payload. Refer to the contents of this PR for more details.

