### PR TITLE
use Keep annotation instead of DoNotStrip

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/hermes/instrumentation/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/hermes/instrumentation/BUCK
@@ -13,7 +13,7 @@ rn_android_library(
     srcs = ["HermesSamplingProfiler.java"],
     visibility = ["PUBLIC"],
     deps = [
-        react_native_dep("java/com/facebook/proguard/annotations:annotations"),
+        react_native_dep("third-party/android/androidx:annotation"),
         react_native_dep("libraries/soloader/java/com/facebook/soloader:soloader"),
         react_native_dep("java/com/facebook/jni:jni"),
         ":jni_hermes_samplingprofiler",

--- a/ReactAndroid/src/main/java/com/facebook/hermes/reactexecutor/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/hermes/reactexecutor/BUCK
@@ -11,7 +11,7 @@ rn_android_library(
     ],
     deps = [
         react_native_dep("libraries/soloader/java/com/facebook/soloader:soloader"),
-        react_native_dep("third-party/java/jsr-305:jsr-305"),
+        react_native_dep("third-party/android/androidx:annotation"),
         react_native_target("java/com/facebook/hermes/instrumentation:instrumentation"),
         react_native_target("java/com/facebook/react/bridge:bridge"),
         ":jni",
@@ -28,7 +28,7 @@ rn_android_library(
         "PUBLIC",
     ],
     deps = [
-        react_native_dep("third-party/java/jsr-305:jsr-305"),
+        react_native_dep("third-party/android/androidx:annotation"),
         react_native_target("java/com/facebook/hermes/instrumentation:instrumentation"),
     ],
 )

--- a/ReactAndroid/src/main/java/com/facebook/hermes/reactexecutor/HermesExecutor.java
+++ b/ReactAndroid/src/main/java/com/facebook/hermes/reactexecutor/HermesExecutor.java
@@ -10,7 +10,7 @@ import com.facebook.hermes.instrumentation.HermesMemoryDumper;
 import com.facebook.jni.HybridData;
 import com.facebook.react.bridge.JavaScriptExecutor;
 import com.facebook.soloader.SoLoader;
-import javax.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 public class HermesExecutor extends JavaScriptExecutor {
   private static String mode_;

--- a/ReactAndroid/src/main/java/com/facebook/hermes/reactexecutor/RuntimeConfig.java
+++ b/ReactAndroid/src/main/java/com/facebook/hermes/reactexecutor/RuntimeConfig.java
@@ -7,7 +7,7 @@
 package com.facebook.hermes.reactexecutor;
 
 import com.facebook.hermes.instrumentation.HermesMemoryDumper;
-import javax.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 /** Holds runtime configuration for a Hermes VM instance (master or snapshot). */
 public final class RuntimeConfig {

--- a/ReactAndroid/src/main/java/com/facebook/hermes/unicode/AndroidUnicodeUtils.java
+++ b/ReactAndroid/src/main/java/com/facebook/hermes/unicode/AndroidUnicodeUtils.java
@@ -6,7 +6,7 @@
  */
 package com.facebook.hermes.unicode;
 
-import com.facebook.proguard.annotations.DoNotStrip;
+import androidx.annotation.Keep;
 import java.text.Collator;
 import java.text.DateFormat;
 import java.text.Normalizer;
@@ -15,15 +15,15 @@ import java.util.Locale;
 // TODO: use com.facebook.common.locale.Locales.getApplicationLocale() as the current locale,
 // rather than the device locale. This is challenging because getApplicationLocale() is only
 // available via DI.
-@DoNotStrip
+@Keep
 public class AndroidUnicodeUtils {
-  @DoNotStrip
+  @Keep
   public static int localeCompare(String left, String right) {
     Collator collator = Collator.getInstance();
     return collator.compare(left, right);
   }
 
-  @DoNotStrip
+  @Keep
   public static String dateFormat(double unixtimeMs, boolean formatDate, boolean formatTime) {
     DateFormat format;
     if (formatDate && formatTime) {
@@ -38,7 +38,7 @@ public class AndroidUnicodeUtils {
     return format.format((long) unixtimeMs).toString();
   }
 
-  @DoNotStrip
+  @Keep
   public static String convertToCase(String input, int targetCase, boolean useCurrentLocale) {
     // These values must match CaseConversion in PlatformUnicode.h
     final int targetUppercase = 0;
@@ -57,7 +57,7 @@ public class AndroidUnicodeUtils {
     }
   }
 
-  @DoNotStrip
+  @Keep
   public static String normalize(String input, int form) {
     // Values must match NormalizationForm in PlatformUnicode.h.
     final int formC = 0;

--- a/ReactAndroid/src/main/java/com/facebook/hermes/unicode/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/hermes/unicode/BUCK
@@ -7,6 +7,6 @@ rn_android_library(
         "PUBLIC",
     ],
     deps = [
-        react_native_dep("java/com/facebook/proguard/annotations:annotations"),
+        react_native_dep("third-party/android/androidx:annotation"),
     ],
 )

--- a/ReactAndroid/src/main/java/com/facebook/jni/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/jni/BUCK
@@ -9,7 +9,6 @@ rn_android_library(
     ],
     deps = [
         react_native_dep("third-party/android/androidx:annotation"),
-        react_native_dep("java/com/facebook/proguard/annotations:annotations"),
         react_native_dep("libraries/soloader/java/com/facebook/soloader:soloader"),
         react_native_dep("third-party/java/jsr-305:jsr-305"),
     ],

--- a/ReactAndroid/src/main/java/com/facebook/jni/Countable.java
+++ b/ReactAndroid/src/main/java/com/facebook/jni/Countable.java
@@ -5,7 +5,7 @@
 
 package com.facebook.jni;
 
-import com.facebook.proguard.annotations.DoNotStrip;
+import androidx.annotation.Keep;
 import com.facebook.soloader.SoLoader;
 
 /**
@@ -18,7 +18,7 @@ import com.facebook.soloader.SoLoader;
  * the system finalizer thread. If you manually call dispose on the Java object, the native object
  * will be deleted synchronously on that thread.
  */
-@DoNotStrip
+@Keep
 public class Countable {
 
   static {
@@ -26,7 +26,7 @@ public class Countable {
   }
 
   // Private C++ instance
-  @DoNotStrip private long mInstance = 0;
+  @Keep private long mInstance = 0;
 
   public native void dispose();
 

--- a/ReactAndroid/src/main/java/com/facebook/jni/CpuCapabilitiesJni.java
+++ b/ReactAndroid/src/main/java/com/facebook/jni/CpuCapabilitiesJni.java
@@ -5,23 +5,23 @@
 
 package com.facebook.jni;
 
-import com.facebook.proguard.annotations.DoNotStrip;
+import androidx.annotation.Keep;
 import com.facebook.soloader.SoLoader;
 
 /** Utility class to determine CPU capabilities */
-@DoNotStrip
+@Keep
 public class CpuCapabilitiesJni {
 
   static {
     SoLoader.loadLibrary("fb");
   }
 
-  @DoNotStrip
+  @Keep
   public static native boolean nativeDeviceSupportsNeon();
 
-  @DoNotStrip
+  @Keep
   public static native boolean nativeDeviceSupportsVFPFP16();
 
-  @DoNotStrip
+  @Keep
   public static native boolean nativeDeviceSupportsX86();
 }

--- a/ReactAndroid/src/main/java/com/facebook/jni/HybridClassBase.java
+++ b/ReactAndroid/src/main/java/com/facebook/jni/HybridClassBase.java
@@ -5,7 +5,7 @@
 
 package com.facebook.jni;
 
-import com.facebook.proguard.annotations.DoNotStrip;
+import androidx.annotation.Keep;
 
-@DoNotStrip
+@Keep
 public abstract class HybridClassBase extends HybridData {}

--- a/ReactAndroid/src/main/java/com/facebook/jni/HybridData.java
+++ b/ReactAndroid/src/main/java/com/facebook/jni/HybridData.java
@@ -5,7 +5,7 @@
 
 package com.facebook.jni;
 
-import com.facebook.proguard.annotations.DoNotStrip;
+import androidx.annotation.Keep;
 import com.facebook.soloader.SoLoader;
 
 /**
@@ -16,14 +16,14 @@ import com.facebook.soloader.SoLoader;
  * <p>{@link #resetNative} deletes the corresponding native object synchronously on whatever thread
  * the method is called on. Otherwise, deletion will occur on the {@link DestructorThread} thread.
  */
-@DoNotStrip
+@Keep
 public class HybridData {
 
   static {
     SoLoader.loadLibrary("fb");
   }
 
-  @DoNotStrip private Destructor mDestructor = new Destructor(this);
+  @Keep private Destructor mDestructor = new Destructor(this);
 
   /**
    * To explicitly delete the instance, call resetNative(). If the C++ instance is referenced after
@@ -56,7 +56,7 @@ public class HybridData {
   public static class Destructor extends DestructorThread.Destructor {
 
     // Private C++ instance
-    @DoNotStrip private long mNativePointer;
+    @Keep private long mNativePointer;
 
     Destructor(Object referent) {
       super(referent);

--- a/ReactAndroid/src/main/java/com/facebook/jni/IteratorHelper.java
+++ b/ReactAndroid/src/main/java/com/facebook/jni/IteratorHelper.java
@@ -6,8 +6,8 @@
  */
 package com.facebook.jni;
 
+import androidx.annotation.Keep;
 import androidx.annotation.Nullable;
-import com.facebook.proguard.annotations.DoNotStrip;
 import java.util.Iterator;
 
 /**
@@ -15,19 +15,19 @@ import java.util.Iterator;
  * helper reduces it to one call and one field get per entry. It does not use a generic argument,
  * since in C++, the types will be erased, anyway. This is *not* a {@link java.util.Iterator}.
  */
-@DoNotStrip
+@Keep
 public class IteratorHelper {
   private final Iterator mIterator;
 
   // This is private, but accessed via JNI.
-  @DoNotStrip private @Nullable Object mElement;
+  @Keep private @Nullable Object mElement;
 
-  @DoNotStrip
+  @Keep
   public IteratorHelper(Iterator iterator) {
     mIterator = iterator;
   }
 
-  @DoNotStrip
+  @Keep
   public IteratorHelper(Iterable iterable) {
     mIterator = iterable.iterator();
   }
@@ -36,7 +36,7 @@ public class IteratorHelper {
    * Moves the helper to the next entry in the map, if any. Returns true iff there is an entry to
    * read.
    */
-  @DoNotStrip
+  @Keep
   boolean hasNext() {
     if (mIterator.hasNext()) {
       mElement = mIterator.next();

--- a/ReactAndroid/src/main/java/com/facebook/jni/MapIteratorHelper.java
+++ b/ReactAndroid/src/main/java/com/facebook/jni/MapIteratorHelper.java
@@ -6,8 +6,8 @@
  */
 package com.facebook.jni;
 
+import androidx.annotation.Keep;
 import androidx.annotation.Nullable;
-import com.facebook.proguard.annotations.DoNotStrip;
 import java.util.Iterator;
 import java.util.Map;
 
@@ -17,13 +17,13 @@ import java.util.Map;
  * generic argument, since in C++, the types will be erased, anyway. This is *not* a {@link
  * java.util.Iterator}.
  */
-@DoNotStrip
+@Keep
 public class MapIteratorHelper {
-  @DoNotStrip private final Iterator<Map.Entry> mIterator;
-  @DoNotStrip private @Nullable Object mKey;
-  @DoNotStrip private @Nullable Object mValue;
+  @Keep private final Iterator<Map.Entry> mIterator;
+  @Keep private @Nullable Object mKey;
+  @Keep private @Nullable Object mValue;
 
-  @DoNotStrip
+  @Keep
   public MapIteratorHelper(Map map) {
     mIterator = map.entrySet().iterator();
   }
@@ -32,7 +32,7 @@ public class MapIteratorHelper {
    * Moves the helper to the next entry in the map, if any. Returns true iff there is an entry to
    * read.
    */
-  @DoNotStrip
+  @Keep
   boolean hasNext() {
     if (mIterator.hasNext()) {
       Map.Entry entry = mIterator.next();

--- a/ReactAndroid/src/main/java/com/facebook/jni/NativeRunnable.java
+++ b/ReactAndroid/src/main/java/com/facebook/jni/NativeRunnable.java
@@ -6,15 +6,15 @@
  */
 package com.facebook.jni;
 
-import com.facebook.proguard.annotations.DoNotStrip;
+import androidx.annotation.Keep;
 
 /** A Runnable that has a native run implementation. */
-@DoNotStrip
+@Keep
 public class NativeRunnable implements Runnable {
 
-  @DoNotStrip private final HybridData mHybridData;
+  @Keep private final HybridData mHybridData;
 
-  @DoNotStrip
+  @Keep
   private NativeRunnable(HybridData hybridData) {
     mHybridData = hybridData;
   }

--- a/ReactAndroid/src/main/java/com/facebook/jni/ThreadScopeSupport.java
+++ b/ReactAndroid/src/main/java/com/facebook/jni/ThreadScopeSupport.java
@@ -5,10 +5,10 @@
 
 package com.facebook.jni;
 
-import com.facebook.proguard.annotations.DoNotStrip;
+import androidx.annotation.Keep;
 import com.facebook.soloader.SoLoader;
 
-@DoNotStrip
+@Keep
 public class ThreadScopeSupport {
   static {
     SoLoader.loadLibrary("fb");
@@ -16,7 +16,7 @@ public class ThreadScopeSupport {
 
   // This is just used for ThreadScope::withClassLoader to have a java function
   // in the stack so that jni has access to the correct classloader.
-  @DoNotStrip
+  @Keep
   private static void runStdFunction(long ptr) {
     runStdFunctionImpl(ptr);
   }

--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/CatalystInstance.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/CatalystInstance.java
@@ -6,8 +6,8 @@
  */
 package com.facebook.react.bridge;
 
+import androidx.annotation.Keep;
 import androidx.annotation.Nullable;
-import com.facebook.proguard.annotations.DoNotStrip;
 import com.facebook.react.bridge.queue.ReactQueueConfiguration;
 import com.facebook.react.common.annotations.VisibleForTesting;
 import com.facebook.react.turbomodule.core.interfaces.JSCallInvokerHolder;
@@ -19,7 +19,7 @@ import java.util.List;
  * the invocation of JavaScript methods and lets a set of Java APIs be invokable from JavaScript as
  * well.
  */
-@DoNotStrip
+@Keep
 public interface CatalystInstance
     extends MemoryPressureListener, JSInstance, JSBundleLoaderDelegate {
   void runJSBundle();
@@ -37,10 +37,10 @@ public interface CatalystInstance
   // This is called from java code, so it won't be stripped anyway, but proguard will rename it,
   // which this prevents.
   @Override
-  @DoNotStrip
+  @Keep
   void invokeCallback(int callbackID, NativeArrayInterface arguments);
 
-  @DoNotStrip
+  @Keep
   void callFunction(String module, String method, NativeArray arguments);
   /**
    * Destroys this catalyst instance, waiting for any other threads in ReactQueueConfiguration

--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/CatalystInstanceImpl.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/CatalystInstanceImpl.java
@@ -11,11 +11,11 @@ import static com.facebook.systrace.Systrace.TRACE_TAG_REACT_JAVA_BRIDGE;
 import android.content.res.AssetManager;
 import android.os.AsyncTask;
 import android.util.Log;
+import androidx.annotation.Keep;
 import androidx.annotation.Nullable;
 import com.facebook.common.logging.FLog;
 import com.facebook.infer.annotation.Assertions;
 import com.facebook.jni.HybridData;
-import com.facebook.proguard.annotations.DoNotStrip;
 import com.facebook.react.bridge.queue.MessageQueueThread;
 import com.facebook.react.bridge.queue.QueueThreadExceptionHandler;
 import com.facebook.react.bridge.queue.ReactQueueConfiguration;
@@ -41,7 +41,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  * This provides an implementation of the public CatalystInstance instance. It is public because it
  * is built by XReactInstanceManager which is in a different package.
  */
-@DoNotStrip
+@Keep
 public class CatalystInstanceImpl implements CatalystInstance {
   static {
     ReactBridge.staticInit();

--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/CxxCallbackImpl.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/CxxCallbackImpl.java
@@ -7,15 +7,15 @@ package com.facebook.react.bridge;
 
 import static com.facebook.react.bridge.Arguments.*;
 
+import androidx.annotation.Keep;
 import com.facebook.jni.HybridData;
-import com.facebook.proguard.annotations.DoNotStrip;
 
 /** Callback impl that calls directly into the cxx bridge. Created from C++. */
-@DoNotStrip
+@Keep
 public class CxxCallbackImpl implements Callback {
-  @DoNotStrip private final HybridData mHybridData;
+  @Keep private final HybridData mHybridData;
 
-  @DoNotStrip
+  @Keep
   private CxxCallbackImpl(HybridData hybridData) {
     mHybridData = hybridData;
   }

--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/CxxModuleWrapper.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/CxxModuleWrapper.java
@@ -5,12 +5,12 @@
 
 package com.facebook.react.bridge;
 
+import androidx.annotation.Keep;
 import com.facebook.jni.HybridData;
-import com.facebook.proguard.annotations.DoNotStrip;
 import com.facebook.soloader.SoLoader;
 
 /** This does nothing interesting, except avoid breaking existing code. */
-@DoNotStrip
+@Keep
 public class CxxModuleWrapper extends CxxModuleWrapperBase {
   protected CxxModuleWrapper(HybridData hd) {
     super(hd);

--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/CxxModuleWrapperBase.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/CxxModuleWrapperBase.java
@@ -5,8 +5,8 @@
 
 package com.facebook.react.bridge;
 
+import androidx.annotation.Keep;
 import com.facebook.jni.HybridData;
-import com.facebook.proguard.annotations.DoNotStrip;
 
 /**
  * A Java Object which represents a cross-platform C++ module
@@ -14,13 +14,13 @@ import com.facebook.proguard.annotations.DoNotStrip;
  * <p>This module implements the NativeModule interface but will never be invoked from Java, instead
  * the underlying Cxx module will be extracted by the bridge and called directly.
  */
-@DoNotStrip
+@Keep
 public class CxxModuleWrapperBase implements NativeModule {
   static {
     ReactBridge.staticInit();
   }
 
-  @DoNotStrip private HybridData mHybridData;
+  @Keep private HybridData mHybridData;
 
   @Override
   public native String getName();

--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/Inspector.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/Inspector.java
@@ -5,15 +5,15 @@
 
 package com.facebook.react.bridge;
 
+import androidx.annotation.Keep;
 import com.facebook.common.logging.FLog;
 import com.facebook.jni.HybridData;
-import com.facebook.proguard.annotations.DoNotStrip;
 import com.facebook.react.common.ReactConstants;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-@DoNotStrip
+@Keep
 public class Inspector {
   static {
     ReactBridge.staticInit();
@@ -49,7 +49,7 @@ public class Inspector {
     mHybridData = hybridData;
   }
 
-  @DoNotStrip
+  @Keep
   public static class Page {
     private final int mId;
     private final String mTitle;
@@ -72,7 +72,7 @@ public class Inspector {
       return "Page{" + "mId=" + mId + ", mTitle='" + mTitle + '\'' + '}';
     }
 
-    @DoNotStrip
+    @Keep
     private Page(int id, String title, String vm) {
       mId = id;
       mTitle = title;
@@ -80,16 +80,16 @@ public class Inspector {
     }
   }
 
-  @DoNotStrip
+  @Keep
   public interface RemoteConnection {
-    @DoNotStrip
+    @Keep
     void onMessage(String message);
 
-    @DoNotStrip
+    @Keep
     void onDisconnect();
   }
 
-  @DoNotStrip
+  @Keep
   public static class LocalConnection {
     private final HybridData mHybridData;
 

--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/InvalidIteratorException.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/InvalidIteratorException.java
@@ -6,16 +6,16 @@
  */
 package com.facebook.react.bridge;
 
-import com.facebook.proguard.annotations.DoNotStrip;
+import androidx.annotation.Keep;
 
 /**
  * Exception thrown by {@link ReadableMapKeySetIterator#nextKey()} when the iterator tries to
  * iterate over elements after the end of the key set.
  */
-@DoNotStrip
+@Keep
 public class InvalidIteratorException extends RuntimeException {
 
-  @DoNotStrip
+  @Keep
   public InvalidIteratorException(String msg) {
     super(msg);
   }

--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/JSCJavaScriptExecutor.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/JSCJavaScriptExecutor.java
@@ -6,10 +6,10 @@
  */
 package com.facebook.react.bridge;
 
+import androidx.annotation.Keep;
 import com.facebook.jni.HybridData;
-import com.facebook.proguard.annotations.DoNotStrip;
 
-@DoNotStrip
+@Keep
 /* package */ class JSCJavaScriptExecutor extends JavaScriptExecutor {
   static {
     ReactBridge.staticInit();

--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/JavaJSExecutor.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/JavaJSExecutor.java
@@ -6,14 +6,14 @@
  */
 package com.facebook.react.bridge;
 
-import com.facebook.proguard.annotations.DoNotStrip;
+import androidx.annotation.Keep;
 
 /**
  * This is class represents java version of native js executor interface. When set through {@link
  * ProxyJavaScriptExecutor} as a {@link CatalystInstance} executor, native code will delegate js
  * calls to the given implementation of this interface.
  */
-@DoNotStrip
+@Keep
 public interface JavaJSExecutor {
   interface Factory {
     JavaJSExecutor create() throws Exception;
@@ -36,7 +36,7 @@ public interface JavaJSExecutor {
    *
    * @param sourceURL url or file location from which script content was loaded
    */
-  @DoNotStrip
+  @Keep
   void loadApplicationScript(String sourceURL) throws ProxyExecutorException;
 
   /**
@@ -46,9 +46,9 @@ public interface JavaJSExecutor {
    * @param jsonArgsArray json encoded array of arguments provided for the method call
    * @return json encoded value returned from the method call
    */
-  @DoNotStrip
+  @Keep
   String executeJSCall(String methodName, String jsonArgsArray) throws ProxyExecutorException;
 
-  @DoNotStrip
+  @Keep
   void setGlobalVariable(String propertyName, String jsonEncodedValue);
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/JavaModuleWrapper.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/JavaModuleWrapper.java
@@ -12,8 +12,8 @@ import static com.facebook.react.bridge.ReactMarkerConstants.GET_CONSTANTS_END;
 import static com.facebook.react.bridge.ReactMarkerConstants.GET_CONSTANTS_START;
 import static com.facebook.systrace.Systrace.TRACE_TAG_REACT_JAVA_BRIDGE;
 
+import androidx.annotation.Keep;
 import androidx.annotation.Nullable;
-import com.facebook.proguard.annotations.DoNotStrip;
 import com.facebook.systrace.Systrace;
 import com.facebook.systrace.SystraceMessage;
 import java.lang.reflect.Method;
@@ -28,14 +28,14 @@ import java.util.Set;
  * be in C++, but it's android-specific initialization code, and writing it this way is easier to
  * read and means fewer JNI calls.
  */
-@DoNotStrip
+@Keep
 public class JavaModuleWrapper {
-  @DoNotStrip
+  @Keep
   public class MethodDescriptor {
-    @DoNotStrip Method method;
-    @DoNotStrip String signature;
-    @DoNotStrip String name;
-    @DoNotStrip String type;
+    @Keep Method method;
+    @Keep String signature;
+    @Keep String name;
+    @Keep String type;
   }
 
   private final JSInstance mJSInstance;
@@ -50,17 +50,17 @@ public class JavaModuleWrapper {
     mDescs = new ArrayList();
   }
 
-  @DoNotStrip
+  @Keep
   public BaseJavaModule getModule() {
     return (BaseJavaModule) mModuleHolder.getModule();
   }
 
-  @DoNotStrip
+  @Keep
   public String getName() {
     return mModuleHolder.getName();
   }
 
-  @DoNotStrip
+  @Keep
   private void findMethods() {
     Systrace.beginSection(TRACE_TAG_REACT_JAVA_BRIDGE, "findMethods");
     Set<String> methodNames = new HashSet<>();
@@ -102,7 +102,7 @@ public class JavaModuleWrapper {
     Systrace.endSection(TRACE_TAG_REACT_JAVA_BRIDGE);
   }
 
-  @DoNotStrip
+  @Keep
   public List<MethodDescriptor> getMethodDescriptors() {
     if (mDescs.isEmpty()) {
       findMethods();
@@ -110,7 +110,7 @@ public class JavaModuleWrapper {
     return mDescs;
   }
 
-  @DoNotStrip
+  @Keep
   public @Nullable NativeMap getConstants() {
     if (!mModuleHolder.getHasConstants()) {
       return null;
@@ -141,7 +141,7 @@ public class JavaModuleWrapper {
     }
   }
 
-  @DoNotStrip
+  @Keep
   public void invoke(int methodId, ReadableNativeArray parameters) {
     if (mMethods == null || methodId >= mMethods.size()) {
       return;

--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/JavaScriptExecutor.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/JavaScriptExecutor.java
@@ -6,10 +6,10 @@
  */
 package com.facebook.react.bridge;
 
+import androidx.annotation.Keep;
 import com.facebook.jni.HybridData;
-import com.facebook.proguard.annotations.DoNotStrip;
 
-@DoNotStrip
+@Keep
 public abstract class JavaScriptExecutor {
   private final HybridData mHybridData;
 

--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/JavaScriptModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/JavaScriptModule.java
@@ -6,7 +6,7 @@
  */
 package com.facebook.react.bridge;
 
-import com.facebook.proguard.annotations.DoNotStrip;
+import androidx.annotation.Keep;
 
 /**
  * Interface denoting that a class is the interface to a module with the same name in JS. Calling
@@ -20,5 +20,5 @@ import com.facebook.proguard.annotations.DoNotStrip;
  * <p>NB: JavaScriptModule does not allow method name overloading because JS does not allow method
  * name overloading.
  */
-@DoNotStrip
+@Keep
 public interface JavaScriptModule {}

--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/ModuleHolder.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/ModuleHolder.java
@@ -11,11 +11,11 @@ import static com.facebook.react.bridge.ReactMarkerConstants.CREATE_MODULE_START
 import static com.facebook.systrace.Systrace.TRACE_TAG_REACT_JAVA_BRIDGE;
 
 import androidx.annotation.GuardedBy;
+import androidx.annotation.Keep;
 import androidx.annotation.Nullable;
 import com.facebook.debug.holder.PrinterHolder;
 import com.facebook.debug.tags.ReactDebugOverlayTags;
 import com.facebook.infer.annotation.Assertions;
-import com.facebook.proguard.annotations.DoNotStrip;
 import com.facebook.react.module.model.ReactModuleInfo;
 import com.facebook.react.turbomodule.core.interfaces.TurboModule;
 import com.facebook.systrace.SystraceMessage;
@@ -32,7 +32,7 @@ import javax.inject.Provider;
  * <p>Lifecycle events via a {@link LifecycleEventListener} will still always happen on the UI
  * thread.
  */
-@DoNotStrip
+@Keep
 public class ModuleHolder {
 
   private static final AtomicInteger sInstanceKeyCounter = new AtomicInteger(1);
@@ -108,7 +108,7 @@ public class ModuleHolder {
     }
   }
 
-  @DoNotStrip
+  @Keep
   public String getName() {
     return mName;
   }
@@ -133,7 +133,7 @@ public class ModuleHolder {
     return mReactModuleInfo.className();
   }
 
-  @DoNotStrip
+  @Keep
   public NativeModule getModule() {
     NativeModule module;
     boolean shouldCreate = false;

--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/NativeArray.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/NativeArray.java
@@ -6,11 +6,11 @@
  */
 package com.facebook.react.bridge;
 
+import androidx.annotation.Keep;
 import com.facebook.jni.HybridData;
-import com.facebook.proguard.annotations.DoNotStrip;
 
 /** Base class for an array whose members are stored in native code (C++). */
-@DoNotStrip
+@Keep
 public abstract class NativeArray implements NativeArrayInterface {
   static {
     ReactBridge.staticInit();
@@ -23,5 +23,5 @@ public abstract class NativeArray implements NativeArrayInterface {
   @Override
   public native String toString();
 
-  @DoNotStrip private HybridData mHybridData;
+  @Keep private HybridData mHybridData;
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/NativeMap.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/NativeMap.java
@@ -6,11 +6,11 @@
  */
 package com.facebook.react.bridge;
 
+import androidx.annotation.Keep;
 import com.facebook.jni.HybridData;
-import com.facebook.proguard.annotations.DoNotStrip;
 
 /** Base class for a Map whose keys and values are stored in native code (C++). */
-@DoNotStrip
+@Keep
 public abstract class NativeMap {
   static {
     ReactBridge.staticInit();
@@ -23,5 +23,5 @@ public abstract class NativeMap {
   @Override
   public native String toString();
 
-  @DoNotStrip private HybridData mHybridData;
+  @Keep private HybridData mHybridData;
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/NativeModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/NativeModule.java
@@ -6,8 +6,8 @@
  */
 package com.facebook.react.bridge;
 
+import androidx.annotation.Keep;
 import androidx.annotation.NonNull;
-import com.facebook.proguard.annotations.DoNotStrip;
 
 /**
  * A native module whose API can be provided to JS catalyst instances. {@link NativeModule}s whose
@@ -16,7 +16,7 @@ import com.facebook.proguard.annotations.DoNotStrip;
  * not provide any Java code (so they can be reused on other platforms), and instead should register
  * themselves using {@link CxxModuleWrapper}.
  */
-@DoNotStrip
+@Keep
 public interface NativeModule {
   interface NativeMethod {
     void invoke(JSInstance jsInstance, ReadableArray parameters);

--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/NoSuchKeyException.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/NoSuchKeyException.java
@@ -6,13 +6,13 @@
  */
 package com.facebook.react.bridge;
 
-import com.facebook.proguard.annotations.DoNotStrip;
+import androidx.annotation.Keep;
 
 /** Exception thrown by {@link ReadableNativeMap} when a key that does not exist is requested. */
-@DoNotStrip
+@Keep
 public class NoSuchKeyException extends RuntimeException {
 
-  @DoNotStrip
+  @Keep
   public NoSuchKeyException(String msg) {
     super(msg);
   }

--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/ObjectAlreadyConsumedException.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/ObjectAlreadyConsumedException.java
@@ -6,17 +6,17 @@
  */
 package com.facebook.react.bridge;
 
-import com.facebook.proguard.annotations.DoNotStrip;
+import androidx.annotation.Keep;
 
 /**
  * Exception thrown when a caller attempts to modify or use a {@link WritableNativeArray} or {@link
  * WritableNativeMap} after it has already been added to a parent array or map. This is unsafe since
  * we reuse the native memory so the underlying array/map is no longer valid.
  */
-@DoNotStrip
+@Keep
 public class ObjectAlreadyConsumedException extends RuntimeException {
 
-  @DoNotStrip
+  @Keep
   public ObjectAlreadyConsumedException(String detailMessage) {
     super(detailMessage);
   }

--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/ProxyJavaScriptExecutor.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/ProxyJavaScriptExecutor.java
@@ -6,9 +6,9 @@
  */
 package com.facebook.react.bridge;
 
+import androidx.annotation.Keep;
 import androidx.annotation.Nullable;
 import com.facebook.jni.HybridData;
-import com.facebook.proguard.annotations.DoNotStrip;
 
 /**
  * JavaScript executor that delegates JS calls processed by native code back to a java version of
@@ -18,7 +18,7 @@ import com.facebook.proguard.annotations.DoNotStrip;
  * delegate low level javascript calls to the implementation of {@link JavaJSExecutor} interface
  * provided with the constructor of this class.
  */
-@DoNotStrip
+@Keep
 public class ProxyJavaScriptExecutor extends JavaScriptExecutor {
   public static class Factory implements JavaScriptExecutorFactory {
     private final JavaJSExecutor.Factory mJavaJSExecutorFactory;

--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactCallback.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactCallback.java
@@ -6,16 +6,16 @@
  */
 package com.facebook.react.bridge;
 
-import com.facebook.proguard.annotations.DoNotStrip;
+import androidx.annotation.Keep;
 
-@DoNotStrip
+@Keep
 /* package */ interface ReactCallback {
-  @DoNotStrip
+  @Keep
   void onBatchComplete();
 
-  @DoNotStrip
+  @Keep
   void incrementPendingJSCalls();
 
-  @DoNotStrip
+  @Keep
   void decrementPendingJSCalls();
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactMarker.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactMarker.java
@@ -5,8 +5,8 @@
 
 package com.facebook.react.bridge;
 
+import androidx.annotation.Keep;
 import androidx.annotation.Nullable;
-import com.facebook.proguard.annotations.DoNotStrip;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
@@ -14,7 +14,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
  * Static class that allows markers to be placed in React code and responded to in a configurable
  * way
  */
-@DoNotStrip
+@Keep
 public class ReactMarker {
 
   public interface MarkerListener {
@@ -39,25 +39,25 @@ public class ReactMarker {
   private static final List<FabricMarkerListener> sFabricMarkerListeners =
       new CopyOnWriteArrayList<>();
 
-  @DoNotStrip
+  @Keep
   public static void addListener(MarkerListener listener) {
     if (!sListeners.contains(listener)) {
       sListeners.add(listener);
     }
   }
 
-  @DoNotStrip
+  @Keep
   public static void removeListener(MarkerListener listener) {
     sListeners.remove(listener);
   }
 
-  @DoNotStrip
+  @Keep
   public static void clearMarkerListeners() {
     sListeners.clear();
   }
 
   // Specific to Fabric marker listeners
-  @DoNotStrip
+  @Keep
   public static void addFabricListener(FabricMarkerListener listener) {
     if (!sFabricMarkerListeners.contains(listener)) {
       sFabricMarkerListeners.add(listener);
@@ -65,19 +65,19 @@ public class ReactMarker {
   }
 
   // Specific to Fabric marker listeners
-  @DoNotStrip
+  @Keep
   public static void removeFabricListener(FabricMarkerListener listener) {
     sFabricMarkerListeners.remove(listener);
   }
 
   // Specific to Fabric marker listeners
-  @DoNotStrip
+  @Keep
   public static void clearFabricMarkerListeners() {
     sFabricMarkerListeners.clear();
   }
 
   // Specific to Fabric marker listeners
-  @DoNotStrip
+  @Keep
   public static void logFabricMarker(
       ReactMarkerConstants name, @Nullable String tag, int instanceKey, long timestamp) {
     for (FabricMarkerListener listener : sFabricMarkerListeners) {
@@ -86,49 +86,49 @@ public class ReactMarker {
   }
 
   // Specific to Fabric marker listeners
-  @DoNotStrip
+  @Keep
   public static void logFabricMarker(
       ReactMarkerConstants name, @Nullable String tag, int instanceKey) {
     logFabricMarker(name, tag, instanceKey, -1);
   }
 
-  @DoNotStrip
+  @Keep
   public static void logMarker(String name) {
     logMarker(name, null);
   }
 
-  @DoNotStrip
+  @Keep
   public static void logMarker(String name, int instanceKey) {
     logMarker(name, null, instanceKey);
   }
 
-  @DoNotStrip
+  @Keep
   public static void logMarker(String name, @Nullable String tag) {
     logMarker(name, tag, 0);
   }
 
-  @DoNotStrip
+  @Keep
   public static void logMarker(String name, @Nullable String tag, int instanceKey) {
     ReactMarkerConstants marker = ReactMarkerConstants.valueOf(name);
     logMarker(marker, tag, instanceKey);
   }
 
-  @DoNotStrip
+  @Keep
   public static void logMarker(ReactMarkerConstants name) {
     logMarker(name, null, 0);
   }
 
-  @DoNotStrip
+  @Keep
   public static void logMarker(ReactMarkerConstants name, int instanceKey) {
     logMarker(name, null, instanceKey);
   }
 
-  @DoNotStrip
+  @Keep
   public static void logMarker(ReactMarkerConstants name, @Nullable String tag) {
     logMarker(name, tag, 0);
   }
 
-  @DoNotStrip
+  @Keep
   public static void logMarker(ReactMarkerConstants name, @Nullable String tag, int instanceKey) {
     logFabricMarker(name, tag, instanceKey);
     for (MarkerListener listener : sListeners) {

--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactModuleWithSpec.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactModuleWithSpec.java
@@ -6,11 +6,11 @@
  */
 package com.facebook.react.bridge;
 
-import com.facebook.proguard.annotations.DoNotStrip;
+import androidx.annotation.Keep;
 
 /**
  * An interface to be implemented by react modules that extends from the generated spec class. This
  * is experimental.
  */
-@DoNotStrip
+@Keep
 public interface ReactModuleWithSpec {}

--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/ReadableMapKeySetIterator.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/ReadableMapKeySetIterator.java
@@ -6,10 +6,10 @@
  */
 package com.facebook.react.bridge;
 
-import com.facebook.proguard.annotations.DoNotStrip;
+import androidx.annotation.Keep;
 
 /** Interface of a iterator for a {@link NativeMap}'s key set. */
-@DoNotStrip
+@Keep
 public interface ReadableMapKeySetIterator {
 
   boolean hasNextKey();

--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/ReadableNativeArray.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/ReadableNativeArray.java
@@ -6,11 +6,11 @@
  */
 package com.facebook.react.bridge;
 
+import androidx.annotation.Keep;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.facebook.infer.annotation.Assertions;
 import com.facebook.jni.HybridData;
-import com.facebook.proguard.annotations.DoNotStrip;
 import java.util.ArrayList;
 import java.util.Arrays;
 
@@ -18,7 +18,7 @@ import java.util.Arrays;
  * Implementation of a NativeArray that allows read-only access to its members. This will generally
  * be constructed and filled in native code so you shouldn't construct one yourself.
  */
-@DoNotStrip
+@Keep
 public class ReadableNativeArray extends NativeArray implements ReadableArray {
   static {
     ReactBridge.staticInit();

--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/ReadableNativeMap.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/ReadableNativeMap.java
@@ -6,11 +6,11 @@
  */
 package com.facebook.react.bridge;
 
+import androidx.annotation.Keep;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.facebook.infer.annotation.Assertions;
 import com.facebook.jni.HybridData;
-import com.facebook.proguard.annotations.DoNotStrip;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -19,7 +19,7 @@ import java.util.Map;
  * Implementation of a read-only map in native memory. This will generally be constructed and filled
  * in native code so you shouldn't construct one yourself.
  */
-@DoNotStrip
+@Keep
 public class ReadableNativeMap extends NativeMap implements ReadableMap {
   static {
     ReactBridge.staticInit();

--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/ReadableType.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/ReadableType.java
@@ -6,10 +6,10 @@
  */
 package com.facebook.react.bridge;
 
-import com.facebook.proguard.annotations.DoNotStrip;
+import androidx.annotation.Keep;
 
 /** Defines the type of an object stored in a {@link ReadableArray} or {@link ReadableMap}. */
-@DoNotStrip
+@Keep
 public enum ReadableType {
   Null,
   Boolean,

--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/Systrace.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/Systrace.java
@@ -5,11 +5,11 @@
 
 package com.facebook.react.bridge;
 
-import com.facebook.proguard.annotations.DoNotStrip;
+import androidx.annotation.Keep;
 
 /** Interface to the JavaScript Systrace Module */
-@DoNotStrip
+@Keep
 public interface Systrace extends JavaScriptModule {
-  @DoNotStrip
+  @Keep
   void setEnabled(boolean enabled);
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/UnexpectedNativeTypeException.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/UnexpectedNativeTypeException.java
@@ -6,16 +6,16 @@
  */
 package com.facebook.react.bridge;
 
-import com.facebook.proguard.annotations.DoNotStrip;
+import androidx.annotation.Keep;
 
 /**
  * Exception thrown from native code when a type retrieved from a map or array (e.g. via {@link
  * NativeArrayParameter#getString(int)}) does not match the expected type.
  */
-@DoNotStrip
+@Keep
 public class UnexpectedNativeTypeException extends RuntimeException {
 
-  @DoNotStrip
+  @Keep
   public UnexpectedNativeTypeException(String msg) {
     super(msg);
   }

--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/WritableNativeArray.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/WritableNativeArray.java
@@ -6,16 +6,16 @@
  */
 package com.facebook.react.bridge;
 
+import androidx.annotation.Keep;
 import androidx.annotation.Nullable;
 import com.facebook.infer.annotation.Assertions;
 import com.facebook.jni.HybridData;
-import com.facebook.proguard.annotations.DoNotStrip;
 
 /**
  * Implementation of a write-only array stored in native memory. Use {@link Arguments#createArray()}
  * if you need to stub out creating this class in a test. TODO(5815532): Check if consumed on read
  */
-@DoNotStrip
+@Keep
 public class WritableNativeArray extends ReadableNativeArray implements WritableArray {
   static {
     ReactBridge.staticInit();

--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/WritableNativeMap.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/WritableNativeMap.java
@@ -6,17 +6,17 @@
  */
 package com.facebook.react.bridge;
 
+import androidx.annotation.Keep;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.facebook.infer.annotation.Assertions;
 import com.facebook.jni.HybridData;
-import com.facebook.proguard.annotations.DoNotStrip;
 
 /**
  * Implementation of a write-only map stored in native memory. Use {@link Arguments#createMap()} if
  * you need to stub out creating this class in a test. TODO(5815532): Check if consumed on read
  */
-@DoNotStrip
+@Keep
 public class WritableNativeMap extends ReadableNativeMap implements WritableMap {
   static {
     ReactBridge.staticInit();

--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/queue/MessageQueueThread.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/queue/MessageQueueThread.java
@@ -6,45 +6,45 @@
  */
 package com.facebook.react.bridge.queue;
 
-import com.facebook.proguard.annotations.DoNotStrip;
+import androidx.annotation.Keep;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
 
 /** Encapsulates a Thread that can accept Runnables. */
-@DoNotStrip
+@Keep
 public interface MessageQueueThread {
   /**
    * Runs the given Runnable on this Thread. It will be submitted to the end of the event queue even
    * if it is being submitted from the same queue Thread.
    */
-  @DoNotStrip
+  @Keep
   void runOnQueue(Runnable runnable);
 
   /**
    * Runs the given Callable on this Thread. It will be submitted to the end of the event queue even
    * if it is being submitted from the same queue Thread.
    */
-  @DoNotStrip
+  @Keep
   <T> Future<T> callOnQueue(final Callable<T> callable);
 
   /**
    * @return whether the current Thread is also the Thread associated with this MessageQueueThread.
    */
-  @DoNotStrip
+  @Keep
   boolean isOnThread();
 
   /**
    * Asserts {@link #isOnThread()}, throwing a {@link AssertionException} (NOT an {@link
    * AssertionError}) if the assertion fails.
    */
-  @DoNotStrip
+  @Keep
   void assertIsOnThread();
 
   /**
    * Asserts {@link #isOnThread()}, throwing a {@link AssertionException} (NOT an {@link
    * AssertionError}) if the assertion fails. The given message is appended to the error.
    */
-  @DoNotStrip
+  @Keep
   void assertIsOnThread(String message);
 
   /**
@@ -52,20 +52,20 @@ public interface MessageQueueThread {
    * thing the thread runs. If called from a separate thread, this will block until the thread can
    * be quit and joined.
    */
-  @DoNotStrip
+  @Keep
   void quitSynchronous();
 
   /**
    * Returns the perf counters taken when the framework was started. This method is intended to be
    * used for instrumentation purposes.
    */
-  @DoNotStrip
+  @Keep
   MessageQueueThreadPerfStats getPerfStats();
 
   /**
    * Resets the perf counters. This is useful if the RN threads are being re-used. This method is
    * intended to be used for instrumentation purposes.
    */
-  @DoNotStrip
+  @Keep
   void resetPerfStats();
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/queue/MessageQueueThreadImpl.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/queue/MessageQueueThreadImpl.java
@@ -10,8 +10,8 @@ import android.os.Looper;
 import android.os.Process;
 import android.os.SystemClock;
 import android.util.Pair;
+import androidx.annotation.Keep;
 import com.facebook.common.logging.FLog;
-import com.facebook.proguard.annotations.DoNotStrip;
 import com.facebook.react.bridge.AssertionException;
 import com.facebook.react.bridge.SoftAssertions;
 import com.facebook.react.bridge.UiThreadUtil;
@@ -21,7 +21,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
 
 /** Encapsulates a Thread that has a {@link Looper} running on it that can accept Runnables. */
-@DoNotStrip
+@Keep
 public class MessageQueueThreadImpl implements MessageQueueThread {
 
   private final String mName;
@@ -52,7 +52,7 @@ public class MessageQueueThreadImpl implements MessageQueueThread {
    * Runs the given Runnable on this Thread. It will be submitted to the end of the event queue even
    * if it is being submitted from the same queue Thread.
    */
-  @DoNotStrip
+  @Keep
   @Override
   public void runOnQueue(Runnable runnable) {
     if (mIsFinished) {
@@ -65,7 +65,7 @@ public class MessageQueueThreadImpl implements MessageQueueThread {
     mHandler.post(runnable);
   }
 
-  @DoNotStrip
+  @Keep
   @Override
   public <T> Future<T> callOnQueue(final Callable<T> callable) {
     final SimpleSettableFuture<T> future = new SimpleSettableFuture<>();
@@ -86,7 +86,7 @@ public class MessageQueueThreadImpl implements MessageQueueThread {
   /**
    * @return whether the current Thread is also the Thread associated with this MessageQueueThread.
    */
-  @DoNotStrip
+  @Keep
   @Override
   public boolean isOnThread() {
     return mLooper.getThread() == Thread.currentThread();
@@ -96,7 +96,7 @@ public class MessageQueueThreadImpl implements MessageQueueThread {
    * Asserts {@link #isOnThread()}, throwing a {@link AssertionException} (NOT an {@link
    * AssertionError}) if the assertion fails.
    */
-  @DoNotStrip
+  @Keep
   @Override
   public void assertIsOnThread() {
     SoftAssertions.assertCondition(isOnThread(), mAssertionErrorMessage);
@@ -106,7 +106,7 @@ public class MessageQueueThreadImpl implements MessageQueueThread {
    * Asserts {@link #isOnThread()}, throwing a {@link AssertionException} (NOT an {@link
    * AssertionError}) if the assertion fails.
    */
-  @DoNotStrip
+  @Keep
   @Override
   public void assertIsOnThread(String message) {
     SoftAssertions.assertCondition(
@@ -118,7 +118,7 @@ public class MessageQueueThreadImpl implements MessageQueueThread {
    * Quits this queue's Looper. If that Looper was running on a different Thread than the current
    * Thread, also waits for the last message being processed to finish and the Thread to die.
    */
-  @DoNotStrip
+  @Keep
   @Override
   public void quitSynchronous() {
     mIsFinished = true;
@@ -132,13 +132,13 @@ public class MessageQueueThreadImpl implements MessageQueueThread {
     }
   }
 
-  @DoNotStrip
+  @Keep
   @Override
   public MessageQueueThreadPerfStats getPerfStats() {
     return mPerfStats;
   }
 
-  @DoNotStrip
+  @Keep
   @Override
   public void resetPerfStats() {
     assignToPerfStats(mPerfStats, -1, -1);

--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/queue/NativeRunnable.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/queue/NativeRunnable.java
@@ -6,16 +6,16 @@
  */
 package com.facebook.react.bridge.queue;
 
+import androidx.annotation.Keep;
 import com.facebook.jni.HybridData;
-import com.facebook.proguard.annotations.DoNotStrip;
 
 /** A Runnable that has a native run implementation. */
-@DoNotStrip
+@Keep
 public class NativeRunnable implements Runnable {
 
   private final HybridData mHybridData;
 
-  @DoNotStrip
+  @Keep
   private NativeRunnable(HybridData hybridData) {
     mHybridData = hybridData;
   }

--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/queue/NativeRunnableDeprecated.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/queue/NativeRunnableDeprecated.java
@@ -6,14 +6,14 @@
  */
 package com.facebook.react.bridge.queue;
 
+import androidx.annotation.Keep;
 import com.facebook.jni.Countable;
-import com.facebook.proguard.annotations.DoNotStrip;
 
 /** A Runnable that has a native run implementation. */
-@DoNotStrip
+@Keep
 public class NativeRunnableDeprecated extends Countable implements Runnable {
 
-  @DoNotStrip
+  @Keep
   private NativeRunnableDeprecated() {}
 
   public native void run();

--- a/ReactAndroid/src/main/java/com/facebook/react/devsupport/JSException.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/devsupport/JSException.java
@@ -6,17 +6,17 @@
  */
 package com.facebook.react.devsupport;
 
-import com.facebook.proguard.annotations.DoNotStrip;
+import androidx.annotation.Keep;
 
 /**
  * This represents an error evaluating JavaScript. It includes the usual message, and the raw JS
  * stack where the error occurred (which may be empty).
  */
-@DoNotStrip
+@Keep
 public class JSException extends Exception {
   private final String mStack;
 
-  @DoNotStrip
+  @Keep
   public JSException(String message, String stack, Throwable cause) {
     super(message, cause);
     mStack = stack;

--- a/ReactAndroid/src/main/java/com/facebook/react/fabric/Binding.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/fabric/Binding.java
@@ -7,15 +7,15 @@
 package com.facebook.react.fabric;
 
 import android.annotation.SuppressLint;
+import androidx.annotation.Keep;
 import com.facebook.jni.HybridData;
-import com.facebook.proguard.annotations.DoNotStrip;
 import com.facebook.react.bridge.JavaScriptContextHolder;
 import com.facebook.react.bridge.NativeMap;
 import com.facebook.react.bridge.queue.MessageQueueThread;
 import com.facebook.react.fabric.events.EventBeatManager;
 import com.facebook.react.uimanager.PixelUtil;
 
-@DoNotStrip
+@Keep
 @SuppressLint("MissingNativeLoadLibrary")
 public class Binding {
 
@@ -23,7 +23,7 @@ public class Binding {
     FabricSoLoader.staticInit();
   }
 
-  @DoNotStrip private final HybridData mHybridData;
+  @Keep private final HybridData mHybridData;
 
   private static native HybridData initHybrid();
 

--- a/ReactAndroid/src/main/java/com/facebook/react/fabric/ComponentFactoryDelegate.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/fabric/ComponentFactoryDelegate.java
@@ -2,19 +2,19 @@
 
 package com.facebook.react.fabric;
 
+import androidx.annotation.Keep;
 import com.facebook.jni.HybridData;
-import com.facebook.proguard.annotations.DoNotStrip;
 
-@DoNotStrip
+@Keep
 public class ComponentFactoryDelegate {
 
   static {
     FabricSoLoader.staticInit();
   }
 
-  @DoNotStrip private final HybridData mHybridData;
+  @Keep private final HybridData mHybridData;
 
-  @DoNotStrip
+  @Keep
   private static native HybridData initHybrid();
 
   public ComponentFactoryDelegate() {

--- a/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
@@ -18,13 +18,13 @@ import android.annotation.SuppressLint;
 import android.os.SystemClock;
 import android.view.View;
 import androidx.annotation.GuardedBy;
+import androidx.annotation.Keep;
 import androidx.annotation.Nullable;
 import androidx.annotation.UiThread;
 import com.facebook.common.logging.FLog;
 import com.facebook.debug.holder.PrinterHolder;
 import com.facebook.debug.tags.ReactDebugOverlayTags;
 import com.facebook.infer.annotation.ThreadConfined;
-import com.facebook.proguard.annotations.DoNotStrip;
 import com.facebook.react.bridge.LifecycleEventListener;
 import com.facebook.react.bridge.NativeMap;
 import com.facebook.react.bridge.ReactApplicationContext;
@@ -185,7 +185,7 @@ public class FabricUIManager implements UIManager, LifecycleEventListener {
   }
 
   /** Method called when an event has been dispatched on the C++ side. */
-  @DoNotStrip
+  @Keep
   @SuppressWarnings("unused")
   public void onRequestEventBeat() {
     mEventDispatcher.dispatchAllEvents();
@@ -212,7 +212,7 @@ public class FabricUIManager implements UIManager, LifecycleEventListener {
     ViewManagerPropertyUpdater.clear();
   }
 
-  @DoNotStrip
+  @Keep
   @SuppressWarnings("unused")
   private void preallocateView(
       int rootTag,
@@ -236,7 +236,7 @@ public class FabricUIManager implements UIManager, LifecycleEventListener {
     }
   }
 
-  @DoNotStrip
+  @Keep
   @SuppressWarnings("unused")
   private MountItem createMountItem(
       String componentName,
@@ -260,62 +260,62 @@ public class FabricUIManager implements UIManager, LifecycleEventListener {
         isLayoutable);
   }
 
-  @DoNotStrip
+  @Keep
   @SuppressWarnings("unused")
   private MountItem removeMountItem(int reactTag, int parentReactTag, int index) {
     return new RemoveMountItem(reactTag, parentReactTag, index);
   }
 
-  @DoNotStrip
+  @Keep
   @SuppressWarnings("unused")
   private MountItem insertMountItem(int reactTag, int parentReactTag, int index) {
     return new InsertMountItem(reactTag, parentReactTag, index);
   }
 
-  @DoNotStrip
+  @Keep
   @SuppressWarnings("unused")
   private MountItem deleteMountItem(int reactTag) {
     return new DeleteMountItem(reactTag);
   }
 
-  @DoNotStrip
+  @Keep
   @SuppressWarnings("unused")
   private MountItem updateLayoutMountItem(
       int reactTag, int x, int y, int width, int height, int layoutDirection) {
     return new UpdateLayoutMountItem(reactTag, x, y, width, height, layoutDirection);
   }
 
-  @DoNotStrip
+  @Keep
   @SuppressWarnings("unused")
   private MountItem updatePropsMountItem(int reactTag, ReadableMap map) {
     return new UpdatePropsMountItem(reactTag, map);
   }
 
-  @DoNotStrip
+  @Keep
   @SuppressWarnings("unused")
   private MountItem updateLocalDataMountItem(int reactTag, ReadableMap newLocalData) {
     return new UpdateLocalDataMountItem(reactTag, newLocalData);
   }
 
-  @DoNotStrip
+  @Keep
   @SuppressWarnings("unused")
   private MountItem updateStateMountItem(int reactTag, Object stateWrapper) {
     return new UpdateStateMountItem(reactTag, (StateWrapper) stateWrapper);
   }
 
-  @DoNotStrip
+  @Keep
   @SuppressWarnings("unused")
   private MountItem updateEventEmitterMountItem(int reactTag, Object eventEmitter) {
     return new UpdateEventEmitterMountItem(reactTag, (EventEmitterWrapper) eventEmitter);
   }
 
-  @DoNotStrip
+  @Keep
   @SuppressWarnings("unused")
   private MountItem createBatchMountItem(MountItem[] items, int size, int commitNumber) {
     return new BatchMountItem(items, size, commitNumber);
   }
 
-  @DoNotStrip
+  @Keep
   @SuppressWarnings("unused")
   private long measure(
       String componentName,
@@ -361,7 +361,7 @@ public class FabricUIManager implements UIManager, LifecycleEventListener {
    * This method enqueues UI operations directly to the UI thread. This might change in the future
    * to enforce execution order using {@link ReactChoreographer#CallbackType}.
    */
-  @DoNotStrip
+  @Keep
   @SuppressWarnings("unused")
   private void scheduleMountItem(
       final MountItem mountItem,
@@ -566,7 +566,7 @@ public class FabricUIManager implements UIManager, LifecycleEventListener {
    * @param initialReactTag React tag of the JS view that initiated the touch operation
    * @param blockNativeResponder If native responder should be blocked or not
    */
-  @DoNotStrip
+  @Keep
   public void setJSResponder(
       final int reactTag, final int initialReactTag, final boolean blockNativeResponder) {
     synchronized (mMountItemsLock) {
@@ -584,7 +584,7 @@ public class FabricUIManager implements UIManager, LifecycleEventListener {
    * Clears the JS Responder specified by {@link #setJSResponder(int, int, boolean)}. After this
    * method is called, all the touch events are going to be handled by JS.
    */
-  @DoNotStrip
+  @Keep
   public void clearJSResponder() {
     synchronized (mMountItemsLock) {
       mMountItems.add(

--- a/ReactAndroid/src/main/java/com/facebook/react/fabric/ReactNativeConfig.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/fabric/ReactNativeConfig.java
@@ -6,17 +6,17 @@
  */
 package com.facebook.react.fabric;
 
-import com.facebook.proguard.annotations.DoNotStrip;
+import androidx.annotation.Keep;
 
 // This is a wrapper for the ReactNativeConfig object in C++
-@DoNotStrip
+@Keep
 public interface ReactNativeConfig {
   /**
    * Get a boolean param by string name. Default should be false.
    *
    * @param param The string name of the parameter being requested.
    */
-  @DoNotStrip
+  @Keep
   boolean getBool(String param);
 
   /**
@@ -24,7 +24,7 @@ public interface ReactNativeConfig {
    *
    * @param param The string name of the parameter being requested.
    */
-  @DoNotStrip
+  @Keep
   int getInt64(String param);
 
   /**
@@ -32,7 +32,7 @@ public interface ReactNativeConfig {
    *
    * @param param The string name of the parameter being requested.
    */
-  @DoNotStrip
+  @Keep
   String getString(String param);
 
   /**
@@ -40,6 +40,6 @@ public interface ReactNativeConfig {
    *
    * @param param The string name of the parameter being requested.
    */
-  @DoNotStrip
+  @Keep
   double getDouble(String param);
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/fabric/StateWrapperImpl.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/fabric/StateWrapperImpl.java
@@ -7,8 +7,8 @@
 package com.facebook.react.fabric;
 
 import android.annotation.SuppressLint;
+import androidx.annotation.Keep;
 import com.facebook.jni.HybridData;
-import com.facebook.proguard.annotations.DoNotStrip;
 import com.facebook.react.bridge.NativeMap;
 import com.facebook.react.bridge.ReadableNativeMap;
 import com.facebook.react.bridge.WritableMap;
@@ -24,7 +24,7 @@ public class StateWrapperImpl implements StateWrapper {
     FabricSoLoader.staticInit();
   }
 
-  @DoNotStrip private final HybridData mHybridData;
+  @Keep private final HybridData mHybridData;
 
   private static native HybridData initHybrid();
 

--- a/ReactAndroid/src/main/java/com/facebook/react/fabric/events/EventBeatManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/fabric/events/EventBeatManager.java
@@ -7,8 +7,8 @@
 package com.facebook.react.fabric.events;
 
 import android.annotation.SuppressLint;
+import androidx.annotation.Keep;
 import com.facebook.jni.HybridData;
-import com.facebook.proguard.annotations.DoNotStrip;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.fabric.FabricSoLoader;
 import com.facebook.react.uimanager.events.BatchEventDispatchedListener;
@@ -23,7 +23,7 @@ public class EventBeatManager implements BatchEventDispatchedListener {
     FabricSoLoader.staticInit();
   }
 
-  @DoNotStrip private final HybridData mHybridData;
+  @Keep private final HybridData mHybridData;
   private final ReactApplicationContext mReactApplicationContext;
 
   private static native HybridData initHybrid();

--- a/ReactAndroid/src/main/java/com/facebook/react/fabric/events/EventEmitterWrapper.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/fabric/events/EventEmitterWrapper.java
@@ -7,9 +7,9 @@
 package com.facebook.react.fabric.events;
 
 import android.annotation.SuppressLint;
+import androidx.annotation.Keep;
 import androidx.annotation.Nullable;
 import com.facebook.jni.HybridData;
-import com.facebook.proguard.annotations.DoNotStrip;
 import com.facebook.react.bridge.NativeMap;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.bridge.WritableNativeMap;
@@ -26,7 +26,7 @@ public class EventEmitterWrapper {
     FabricSoLoader.staticInit();
   }
 
-  @DoNotStrip private final HybridData mHybridData;
+  @Keep private final HybridData mHybridData;
 
   private static native HybridData initHybrid();
 

--- a/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/mountitems/BatchMountItem.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/mountitems/BatchMountItem.java
@@ -9,8 +9,8 @@ package com.facebook.react.fabric.mounting.mountitems;
 import static com.facebook.react.fabric.FabricUIManager.DEBUG;
 import static com.facebook.react.fabric.FabricUIManager.TAG;
 
+import androidx.annotation.Keep;
 import com.facebook.common.logging.FLog;
-import com.facebook.proguard.annotations.DoNotStrip;
 import com.facebook.react.bridge.ReactMarker;
 import com.facebook.react.bridge.ReactMarkerConstants;
 import com.facebook.react.fabric.mounting.MountingManager;
@@ -25,7 +25,7 @@ import com.facebook.systrace.Systrace;
  * <p>The purpose of encapsulating the array of MountItems this way, is to reduce the amount of
  * allocations in C++
  */
-@DoNotStrip
+@Keep
 public class BatchMountItem implements MountItem {
 
   private final MountItem[] mMountItems;

--- a/ReactAndroid/src/main/java/com/facebook/react/jscexecutor/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/jscexecutor/BUCK
@@ -9,6 +9,7 @@ rn_android_library(
     deps = [
         ":jni",
         react_native_dep("libraries/soloader/java/com/facebook/soloader:soloader"),
+        react_native_dep("third-party/android/androidx:annotation"),
         react_native_target("java/com/facebook/react/bridge:bridge"),
     ],
 )

--- a/ReactAndroid/src/main/java/com/facebook/react/jscexecutor/JSCExecutor.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/jscexecutor/JSCExecutor.java
@@ -6,13 +6,13 @@
  */
 package com.facebook.react.jscexecutor;
 
+import androidx.annotation.Keep;
 import com.facebook.jni.HybridData;
-import com.facebook.proguard.annotations.DoNotStrip;
 import com.facebook.react.bridge.JavaScriptExecutor;
 import com.facebook.react.bridge.ReadableNativeMap;
 import com.facebook.soloader.SoLoader;
 
-@DoNotStrip
+@Keep
 /* package */ class JSCExecutor extends JavaScriptExecutor {
   static {
     SoLoader.loadLibrary("jscexecutor");

--- a/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/ReactPackageTurboModuleManagerDelegate.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/ReactPackageTurboModuleManagerDelegate.java
@@ -2,9 +2,9 @@
 
 package com.facebook.react.turbomodule.core;
 
+import androidx.annotation.Keep;
 import androidx.annotation.Nullable;
 import com.facebook.infer.annotation.Assertions;
-import com.facebook.proguard.annotations.DoNotStrip;
 import com.facebook.react.ReactPackage;
 import com.facebook.react.TurboReactPackage;
 import com.facebook.react.bridge.CxxModuleWrapper;
@@ -49,7 +49,7 @@ public abstract class ReactPackageTurboModuleManagerDelegate extends TurboModule
 
   @Nullable
   @Override
-  @DoNotStrip
+  @Keep
   public CxxModuleWrapper getLegacyCxxModule(String moduleName) {
     TurboModule module = resolveModule(moduleName);
     if (module == null) {

--- a/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/TurboModuleManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/TurboModuleManager.java
@@ -6,9 +6,9 @@
  */
 package com.facebook.react.turbomodule.core;
 
+import androidx.annotation.Keep;
 import androidx.annotation.Nullable;
 import com.facebook.jni.HybridData;
-import com.facebook.proguard.annotations.DoNotStrip;
 import com.facebook.react.bridge.JSIModule;
 import com.facebook.react.bridge.JavaScriptContextHolder;
 import com.facebook.react.bridge.NativeModule;
@@ -32,7 +32,7 @@ public class TurboModuleManager implements JSIModule, TurboModuleRegistry {
 
   private final Map<String, TurboModule> mTurboModules = new HashMap<>();
 
-  @DoNotStrip
+  @Keep
   @SuppressWarnings("unused")
   private final HybridData mHybridData;
 
@@ -45,7 +45,7 @@ public class TurboModuleManager implements JSIModule, TurboModuleRegistry {
     mTurbomoduleManagerDelegate = tmmDelegate;
   }
 
-  @DoNotStrip
+  @Keep
   @Nullable
   protected TurboModule getJavaModule(String name) {
     if (!mTurboModules.containsKey(name)) {


### PR DESCRIPTION
## Summary

This PR replaces custom DoNotStrip annotation uses with Keep annotation from AndroidX, because in ReactAndroid we use nullability annotations from AndroidX and AndroidX annotations are already in dependencies.

## Changelog

[Android] [Changed] - use Keep annotation instead of DoNotStrip

## Test Plan

RNTester builds and runs as expected.