### PR TITLE
Added check to handle all cases of MissingWebViewPackageException

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/modules/network/ForwardingCookieHandler.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/network/ForwardingCookieHandler.java
@@ -185,7 +185,7 @@ public class ForwardingCookieHandler extends CookieHandler {
         // class. This validates the exception's message to ensure we are only handling this
         // specific exception.
         // https://android.googlesource.com/platform/frameworks/base/+/master/core/java/android/webkit/WebViewFactory.java#348
-        if (message != null && (exception.getClass().getCanonicalName().equals("android.webkit.WebViewFactory.MissingWebViewPackageException"))) {
+        if (message != null && exception.getClass().getCanonicalName().equals("android.webkit.WebViewFactory.MissingWebViewPackageException")) {
           return null;
         } else {
           throw exception;

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/network/ForwardingCookieHandler.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/network/ForwardingCookieHandler.java
@@ -184,7 +184,7 @@ public class ForwardingCookieHandler extends CookieHandler {
         // We cannot catch MissingWebViewPackageException as it is in a private / system API
         // class. This validates the exception's message to ensure we are only handling this
         // specific exception.
-        // https://android.googlesource.com/platform/frameworks/base/+/master/core/java/android/webkit/WebViewFactory.java#98
+        // https://android.googlesource.com/platform/frameworks/base/+/master/core/java/android/webkit/WebViewFactory.java#348
         if (message != null && (message.toLowerCase().contains("webview") || message.contains("Failed to find donor package:"))) {
           return null;
         } else {

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/network/ForwardingCookieHandler.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/network/ForwardingCookieHandler.java
@@ -185,7 +185,7 @@ public class ForwardingCookieHandler extends CookieHandler {
         // class. This validates the exception's message to ensure we are only handling this
         // specific exception.
         // https://android.googlesource.com/platform/frameworks/base/+/master/core/java/android/webkit/WebViewFactory.java#98
-        if (message != null && (message.contains("com.google.android.webview") || message.contains("No WebView installed"))) {
+        if (message != null && (message.toLowerCase().contains("webview") || message.contains("Failed to find donor package:"))) {
           return null;
         } else {
           throw exception;

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/network/ForwardingCookieHandler.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/network/ForwardingCookieHandler.java
@@ -185,7 +185,7 @@ public class ForwardingCookieHandler extends CookieHandler {
         // class. This validates the exception's message to ensure we are only handling this
         // specific exception.
         // https://android.googlesource.com/platform/frameworks/base/+/master/core/java/android/webkit/WebViewFactory.java#98
-        if (message != null && message.contains("No WebView installed")) {
+        if (message != null && (message.contains("com.google.android.webview") || message.contains("No WebView installed"))) {
           return null;
         } else {
           throw exception;

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/network/ForwardingCookieHandler.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/network/ForwardingCookieHandler.java
@@ -185,7 +185,7 @@ public class ForwardingCookieHandler extends CookieHandler {
         // class. This validates the exception's message to ensure we are only handling this
         // specific exception.
         // https://android.googlesource.com/platform/frameworks/base/+/master/core/java/android/webkit/WebViewFactory.java#348
-        if (message != null && (exception.getClass().getCanonicalName().equals("android.webkit.WebViewFactory.MissingWebViewPackageException")) {
+        if (message != null && (exception.getClass().getCanonicalName().equals("android.webkit.WebViewFactory.MissingWebViewPackageException"))) {
           return null;
         } else {
           throw exception;

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/network/ForwardingCookieHandler.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/network/ForwardingCookieHandler.java
@@ -185,7 +185,7 @@ public class ForwardingCookieHandler extends CookieHandler {
         // class. This validates the exception's message to ensure we are only handling this
         // specific exception.
         // https://android.googlesource.com/platform/frameworks/base/+/master/core/java/android/webkit/WebViewFactory.java#348
-        if (message != null && (message.toLowerCase().contains("webview") || message.contains("Failed to find donor package:"))) {
+        if (message != null && (exception.getClass().getCanonicalName().equals("android.webkit.WebViewFactory.MissingWebViewPackageException")) {
           return null;
         } else {
           throw exception;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
We have been experiencing the below crashes in our Flipkart Android app:

![image](https://user-images.githubusercontent.com/16662518/63784983-2be9a100-c90d-11e9-998d-2e5085f1dec6.png)
![image](https://user-images.githubusercontent.com/16662518/63784988-3146eb80-c90d-11e9-89d4-18693b566284.png)

Stack overflow thread for the issue that is causing this crash: [https://stackoverflow.com/a/56246743](https://stackoverflow.com/a/56246743)

The change I have done is an enhancement on the following PR which got merged to master: [https://github.com/facebook/react-native/pull/24533](https://github.com/facebook/react-native/pull/24533) 

The exception handling for this crash already exists but it relies on having a specific string in the error message ("Webview not installed"). But the error message for the crashes above does not include this string.

I have added a check for all the crashes involving the `MissingWebViewPackageException`.
Refer the file: [https://android.googlesource.com/platform/frameworks/base/+/master/core/java/android/webkit/WebViewFactory.java#102](https://android.googlesource.com/platform/frameworks/base/+/master/core/java/android/webkit/WebViewFactory.java#102)

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[ANDROID] [Fixed] - The ReactCookieJarContainer/ForwardingCookieHandler now handles all the cases of missing WebView exceptions gracefully.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
No new tests have been added.
CI should pass.

This fix was made based on the exception stacktrace. I have not spent the time to acquire one of the devices that it is happening on.