### PR TITLE
fix: add "transformsDiffer" for CATransform3D props

### DIFF
--- a/Libraries/ReactNative/getNativeComponentAttributes.js
+++ b/Libraries/ReactNative/getNativeComponentAttributes.js
@@ -15,13 +15,13 @@ const UIManager = require('./UIManager');
 
 const insetsDiffer = require('../Utilities/differ/insetsDiffer');
 const invariant = require('invariant');
-const matricesDiffer = require('../Utilities/differ/matricesDiffer');
 const pointsDiffer = require('../Utilities/differ/pointsDiffer');
 const processColor = require('../StyleSheet/processColor');
 const processColorArray = require('../StyleSheet/processColorArray');
 const processTransform = require('../StyleSheet/processTransform');
 const resolveAssetSource = require('../Image/resolveAssetSource');
 const sizesDiffer = require('../Utilities/differ/sizesDiffer');
+const transformsDiffer = require('../Utilities/differ/transformsDiffer');
 const warning = require('fbjs/lib/warning');
 
 function getNativeComponentAttributes(uiViewClassName: string): any {
@@ -149,7 +149,7 @@ function getDifferForType(
   switch (typeName) {
     // iOS Types
     case 'CATransform3D':
-      return matricesDiffer;
+      return transformsDiffer;
     case 'CGPoint':
       return pointsDiffer;
     case 'CGSize':
@@ -180,8 +180,6 @@ function getProcessorForType(typeName: string): ?(nextProp: any) => any {
       return processColor;
     case 'ColorArray':
       return processColorArray;
-    case 'CATransform3D':
-      return processTransform;
   }
   return null;
 }

--- a/Libraries/ReactNative/getNativeComponentAttributes.js
+++ b/Libraries/ReactNative/getNativeComponentAttributes.js
@@ -19,6 +19,7 @@ const matricesDiffer = require('../Utilities/differ/matricesDiffer');
 const pointsDiffer = require('../Utilities/differ/pointsDiffer');
 const processColor = require('../StyleSheet/processColor');
 const processColorArray = require('../StyleSheet/processColorArray');
+const processTransform = require('../StyleSheet/processTransform');
 const resolveAssetSource = require('../Image/resolveAssetSource');
 const sizesDiffer = require('../Utilities/differ/sizesDiffer');
 const warning = require('fbjs/lib/warning');
@@ -179,6 +180,8 @@ function getProcessorForType(typeName: string): ?(nextProp: any) => any {
       return processColor;
     case 'ColorArray':
       return processColorArray;
+    case 'CATransform3D':
+      return processTransform;
   }
   return null;
 }

--- a/Libraries/ReactNative/getNativeComponentAttributes.js
+++ b/Libraries/ReactNative/getNativeComponentAttributes.js
@@ -18,7 +18,6 @@ const invariant = require('invariant');
 const pointsDiffer = require('../Utilities/differ/pointsDiffer');
 const processColor = require('../StyleSheet/processColor');
 const processColorArray = require('../StyleSheet/processColorArray');
-const processTransform = require('../StyleSheet/processTransform');
 const resolveAssetSource = require('../Image/resolveAssetSource');
 const sizesDiffer = require('../Utilities/differ/sizesDiffer');
 const transformsDiffer = require('../Utilities/differ/transformsDiffer');

--- a/Libraries/Utilities/differ/transformsDiffer.js
+++ b/Libraries/Utilities/differ/transformsDiffer.js
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow
+ */
+'use strict';
+
+const transformsDiffer = function(one, two) {
+  return one !== two ||
+    !one || !two ||
+    one.length !== two.length ||
+    JSON.stringify(one) !== JSON.stringify(two);
+};
+
+module.exports = transformsDiffer;

--- a/Libraries/Utilities/differ/transformsDiffer.js
+++ b/Libraries/Utilities/differ/transformsDiffer.js
@@ -10,10 +10,18 @@
 'use strict';
 
 const transformsDiffer = function(one, two) {
-  return one !== two ||
-    !one || !two ||
+  if (one === two) {
+    return false;
+  }
+  return (
+    !one ||
+    !two ||
     one.length !== two.length ||
-    JSON.stringify(one) !== JSON.stringify(two);
+    // Transform arrays are non-commutative (eg: "translate" operations 
+    // affect "scale" operations). Using JSON.stringify is the lightest 
+    // way to check both order and values, and it's pretty fast.
+    JSON.stringify(one) !== JSON.stringify(two)
+  );
 };
 
 module.exports = transformsDiffer;


### PR DESCRIPTION
## Summary

<s>Native props with `CATransform3D` type were not being processed before being diffed, which resulted in `matricesDiffer` always returning `false` after first render.</s>

Replace `matricesDiffer` comparison (for `CATransform3D` props) with new `transformsDiffer` function. The native `[RCTConvert CATransform3D:]` function has deprecated matrix arrays.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[iOS] [Fixed] - add "transformsDiffer" for CATransform3D props

## Test Plan

None
