### PR TITLE
imp: Add titlePlaceholder in template.config.js

### DIFF
--- a/template.config.js
+++ b/template.config.js
@@ -1,4 +1,5 @@
 module.exports = {
   placeholderName: 'HelloWorld',
+  titlePlaceholder: 'Hello App Display Name',
   templateDir: './template',
 };


### PR DESCRIPTION
## Summary

In the latest `react-native-cli` we've added more flexibility for setting application title. New config key was introduced - `titlePlaceholder` - which will be changed during init process.

PR: https://github.com/react-native-community/cli/pull/650

## Changelog

[General] [Added] - Introduce `titlePlaceholder` for template configuration.

## Test Plan

Initialization works with the default template
