### PR TITLE
Skip lint check for dynamic react-native version

### DIFF
--- a/template/android/app/build.gradle
+++ b/template/android/app/build.gradle
@@ -189,6 +189,7 @@ android {
 
 dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
+    //noinspection GradleDynamicVersion
     implementation "com.facebook.react:react-native:+"  // From node_modules
 
     if (enableHermes) {


### PR DESCRIPTION
## Summary

The `dependencies` section in the `build.gradle` Android template contains this line:

    implementation "com.facebook.react:react-native:+"  // From node_modules

It causes the following Gradle Lint warning:

> Avoid using '+' in version numbers, can lead to unpredictable or unrepeatable builds

In this case, as the `// From node_modules` comment suggests, the version is _not_ determined by Gradle but by the version specified in `package.json` - Using "+" is completely fine and intentional.

Therefore it can safely be ignored, which is what the added `//noinspection` does.

## Changelog

[Android] [Fixed] - Skip lint check for dynamic react-native version

## Test Plan

Projects generated with the new template no longer cause the warning.