### PR TITLE
[Android] Fix compile error for native debug build

### DIFF
--- a/ReactCommon/hermes/inspector/Inspector.cpp
+++ b/ReactCommon/hermes/inspector/Inspector.cpp
@@ -19,6 +19,7 @@
 // this.
 
 template class folly::Future<folly::Unit>;
+template class folly::Future<bool>;
 
 namespace folly {
 namespace futures {


### PR DESCRIPTION
## Summary

Fix Android gradle build error for native debug build.
`NATIVE_BUILD_TYPE=Debug ./gradlew :ReactAndroid:installArchives`
The root cause is `folly::Future<bool>` not declared.
As we don't include true folly::Future implementation in OSS build but to use a forward declaration,
the fix is pretty much like to original declaration as `folly::Future<folly::Unit>`.

## Changelog

[Android] [Fixed] - Fix compile error for native debug build
This change could be ignored from changelog which is only for internal development.

## Test Plan

Makes sure `NATIVE_BUILD_TYPE=Debug ./gradlew :ReactAndroid:installArchives` build without errors.
