### PR TITLE
Add RNTester Pods to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,5 +80,4 @@ RNTester/build
 # CocoaPods
 /template/ios/Pods/
 /template/ios/Podfile.lock
-RNTester/Pods/Local Podspecs
-RNTester/Pods/Target Support Files
+/RNTester/Pods/


### PR DESCRIPTION
## Summary

Pods directory showed up as untracked files after running `pod install`
in the `RNTester` directory. With this small change to `.gitignore`, it
will no longer show up.

## Changelog

Small repo-level change, no changelog needed (?)

## Test Plan

Run `pod install` in `/RNTester`, verify that "Pods" no longer show up
as untracked files in `git status`.