### PR TITLE
Add `DEFINES_MODULE=YES` to the yoga podspec

### DIFF
--- a/ReactCommon/yoga/yoga.podspec
+++ b/ReactCommon/yoga/yoga.podspec
@@ -29,6 +29,9 @@ Pod::Spec.new do |spec|
 
   spec.module_name = 'yoga'
   spec.requires_arc = false
+  spec.pod_target_xcconfig = {
+      'DEFINES_MODULE' => 'YES'
+  }
   spec.compiler_flags = [
       '-fno-omit-frame-pointer',
       '-fexceptions',


### PR DESCRIPTION
## Summary

This fixes an error when using RN's version of yoga with Flipper.

```
[!] The following Swift pods cannot yet be integrated as static libraries:

The Swift pod `YogaKit` depends upon `Yoga`, which does not define modules. To opt into those targets generating module maps (which is necessary to import them from Swift when building as static libraries), you may set `use_modular_headers!` globally in your Podfile, or specify `:modular_headers => true` for particular dependencies.
```

Taken from https://github.com/facebook/yoga/blob/master/Yoga.podspec#L25

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[Internal] [Fixed] - Add `DEFINES_MODULE=YES` to the yoga podspec

## Test Plan

Tested that pod install now works in an app.
