### PR TITLE
Fix RNTester Lint errors

### DIFF
--- a/RNTester/android/app/src/main/AndroidManifest.xml
+++ b/RNTester/android/app/src/main/AndroidManifest.xml
@@ -3,6 +3,13 @@
   xmlns:android="http://schemas.android.com/apk/res/android"
   package="com.facebook.react.uiapp">
 
+  <uses-feature
+    android:name="android.software.leanback"
+    android:required="false" />
+  <uses-feature
+    android:name="android.hardware.touchscreen"
+    android:required="false" />
+
   <uses-permission android:name="android.permission.INTERNET" />
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
   <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>


### PR DESCRIPTION
## Summary

Trying to build the Android RNTester app using Gradle fails with the following error:

```
  Errors found:
  
  [...]/RNTester/android/app/src/main/AndroidManifest.xml:2: Error: Hardware feature android.hardware.touchscreen not explicitly marked as optional  [ImpliedTouchscreenHardware]
  <manifest
   ~~~~~~~~
  [...]/RNTester/android/app/src/main/AndroidManifest.xml:2: Error: Expecting <uses-feature android:name="android.software.leanback" android:required="false" /> tag. [MissingLeanbackSupport]
  <manifest
   ~~~~~~~~
```

This PR adds the two missing `uses-feature` tags to AndroidManifest of RNTester.

## Changelog

[Android] [Fixed] - Fix RNTester Lint errors

## Test Plan

After adding the tags, the build is successful again.