### PR TITLE
iOS13 status bar has now 3 styles

### DIFF
--- a/React/Modules/RCTStatusBarManager.m
+++ b/React/Modules/RCTStatusBarManager.m
@@ -19,35 +19,39 @@
   static NSDictionary *mapping;
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{
-      if(@available(iOS 13.0, *)){
-        mapping=@{
-          @"default": @(UIStatusBarStyleDefault),
-          @"light-content": @(UIStatusBarStyleLightContent),
+    if (@available(iOS 13.0, *)) {
+      mapping = @{
+        @"default" : @(UIStatusBarStyleDefault),
+        @"light-content" : @(UIStatusBarStyleLightContent),
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_13_0) && \
-          __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
-          @"dark-content": @(UIStatusBarStyleDarkContent)
+    __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
+        @"dark-content" : @(UIStatusBarStyleDarkContent)
 #else
           @"dark-content": @(UIStatusBarStyleDefault)
 #endif
-        };
+      };
 
-      }else{
-          mapping=@{
-          @"default": @(UIStatusBarStyleDefault),
-          @"light-content": @(UIStatusBarStyleLightContent),
-          @"dark-content": @(UIStatusBarStyleDefault)
-          };
-      }
-      
+    } else {
+      mapping = @{
+        @"default" : @(UIStatusBarStyleDefault),
+        @"light-content" : @(UIStatusBarStyleLightContent),
+        @"dark-content" : @(UIStatusBarStyleDefault)
+      };
+    }
   });
-  return _RCT_CAST(type, [RCTConvertEnumValue("UIStatusBarStyle", mapping, @(UIStatusBarStyleDefault), json) integerValue]);
+  return _RCT_CAST(
+      type, [RCTConvertEnumValue("UIStatusBarStyle", mapping, @(UIStatusBarStyleDefault), json) integerValue]);
 }
 
-RCT_ENUM_CONVERTER(UIStatusBarAnimation, (@{
-  @"none": @(UIStatusBarAnimationNone),
-  @"fade": @(UIStatusBarAnimationFade),
-  @"slide": @(UIStatusBarAnimationSlide),
-}), UIStatusBarAnimationNone, integerValue);
+RCT_ENUM_CONVERTER(
+    UIStatusBarAnimation,
+    (@{
+      @"none" : @(UIStatusBarAnimationNone),
+      @"fade" : @(UIStatusBarAnimationFade),
+      @"slide" : @(UIStatusBarAnimationSlide),
+    }),
+    UIStatusBarAnimationNone,
+    integerValue);
 
 @end
 #endif
@@ -59,8 +63,9 @@ static BOOL RCTViewControllerBasedStatusBarAppearance()
   static BOOL value;
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{
-    value = [[[NSBundle mainBundle] objectForInfoDictionaryKey:
-              @"UIViewControllerBasedStatusBarAppearance"] ?: @YES boolValue];
+    value =
+        [[[NSBundle mainBundle] objectForInfoDictionaryKey:@"UIViewControllerBasedStatusBarAppearance"]
+                ?: @YES boolValue];
   });
 
   return value;
@@ -70,8 +75,7 @@ RCT_EXPORT_MODULE()
 
 - (NSArray<NSString *> *)supportedEvents
 {
-  return @[@"statusBarFrameDidChange",
-           @"statusBarFrameWillChange"];
+  return @[ @"statusBarFrameDidChange", @"statusBarFrameWillChange" ];
 }
 
 #if !TARGET_OS_TV
@@ -79,8 +83,14 @@ RCT_EXPORT_MODULE()
 - (void)startObserving
 {
   NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
-  [nc addObserver:self selector:@selector(applicationDidChangeStatusBarFrame:) name:UIApplicationDidChangeStatusBarFrameNotification object:nil];
-  [nc addObserver:self selector:@selector(applicationWillChangeStatusBarFrame:) name:UIApplicationWillChangeStatusBarFrameNotification object:nil];
+  [nc addObserver:self
+         selector:@selector(applicationDidChangeStatusBarFrame:)
+             name:UIApplicationDidChangeStatusBarFrameNotification
+           object:nil];
+  [nc addObserver:self
+         selector:@selector(applicationWillChangeStatusBarFrame:)
+             name:UIApplicationWillChangeStatusBarFrameNotification
+           object:nil];
 }
 
 - (void)stopObserving
@@ -97,11 +107,11 @@ RCT_EXPORT_MODULE()
 {
   CGRect frame = [notification.userInfo[UIApplicationStatusBarFrameUserInfoKey] CGRectValue];
   NSDictionary *event = @{
-    @"frame": @{
-      @"x": @(frame.origin.x),
-      @"y": @(frame.origin.y),
-      @"width": @(frame.size.width),
-      @"height": @(frame.size.height),
+    @"frame" : @{
+      @"x" : @(frame.origin.x),
+      @"y" : @(frame.origin.y),
+      @"width" : @(frame.size.width),
+      @"height" : @(frame.size.height),
     },
   };
   [self sendEventWithName:eventName body:event];
@@ -117,30 +127,14 @@ RCT_EXPORT_MODULE()
   [self emitEvent:@"statusBarFrameWillChange" forNotification:notification];
 }
 
-RCT_EXPORT_METHOD(getHeight:(RCTResponseSenderBlock)callback)
+RCT_EXPORT_METHOD(getHeight : (RCTResponseSenderBlock)callback)
 {
-  callback(@[@{
-    @"height": @(RCTSharedApplication().statusBarFrame.size.height),
-  }]);
+  callback(@[ @{
+    @"height" : @(RCTSharedApplication().statusBarFrame.size.height),
+  } ]);
 }
 
-RCT_EXPORT_METHOD(setStyle:(UIStatusBarStyle)statusBarStyle
-                  animated:(BOOL)animated)
-{
-  if (RCTViewControllerBasedStatusBarAppearance()) {
-    RCTLogError(@"RCTStatusBarManager module requires that the \
-                UIViewControllerBasedStatusBarAppearance key in the Info.plist is set to NO");
-  } else {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    [RCTSharedApplication() setStatusBarStyle:statusBarStyle
-                                     animated:animated];
-  }
-#pragma clang diagnostic pop
-}
-
-RCT_EXPORT_METHOD(setHidden:(BOOL)hidden
-                  withAnimation:(UIStatusBarAnimation)animation)
+RCT_EXPORT_METHOD(setStyle : (UIStatusBarStyle)statusBarStyle animated : (BOOL)animated)
 {
   if (RCTViewControllerBasedStatusBarAppearance()) {
     RCTLogError(@"RCTStatusBarManager module requires that the \
@@ -148,17 +142,29 @@ RCT_EXPORT_METHOD(setHidden:(BOOL)hidden
   } else {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    [RCTSharedApplication() setStatusBarHidden:hidden
-                                 withAnimation:animation];
+    [RCTSharedApplication() setStatusBarStyle:statusBarStyle animated:animated];
+  }
+#pragma clang diagnostic pop
+}
+
+RCT_EXPORT_METHOD(setHidden : (BOOL)hidden withAnimation : (UIStatusBarAnimation)animation)
+{
+  if (RCTViewControllerBasedStatusBarAppearance()) {
+    RCTLogError(@"RCTStatusBarManager module requires that the \
+                UIViewControllerBasedStatusBarAppearance key in the Info.plist is set to NO");
+  } else {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    [RCTSharedApplication() setStatusBarHidden:hidden withAnimation:animation];
 #pragma clang diagnostic pop
   }
 }
 
-RCT_EXPORT_METHOD(setNetworkActivityIndicatorVisible:(BOOL)visible)
+RCT_EXPORT_METHOD(setNetworkActivityIndicatorVisible : (BOOL)visible)
 {
   RCTSharedApplication().networkActivityIndicatorVisible = visible;
 }
 
-#endif //TARGET_OS_TV
+#endif // TARGET_OS_TV
 
 @end

--- a/React/Modules/RCTStatusBarManager.m
+++ b/React/Modules/RCTStatusBarManager.m
@@ -14,11 +14,24 @@
 #if !TARGET_OS_TV
 @implementation RCTConvert (UIStatusBar)
 
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_13_0) && \
+__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
+
 RCT_ENUM_CONVERTER(UIStatusBarStyle, (@{
-  @"default": @(UIStatusBarStyleDefault),
-  @"light-content": @(UIStatusBarStyleLightContent),
-  @"dark-content": @(UIStatusBarStyleDefault),
+    @"default": @(UIStatusBarStyleDefault),
+    @"light-content": @(UIStatusBarStyleLightContent),
+    @"dark-content": @available(iOS 13.0, *) ? @(UIStatusBarStyleDarkContent):@(UIStatusBarStyleDefault)
 }), UIStatusBarStyleDefault, integerValue);
+
+#else
+
+RCT_ENUM_CONVERTER(UIStatusBarStyle, (@{
+                                        @"default": @(UIStatusBarStyleDefault),
+                                        @"light-content": @(UIStatusBarStyleLightContent),
+                                        @"dark-content": @(UIStatusBarStyleDefault)
+                                        }), UIStatusBarStyleDefault, integerValue);
+
+#endif
 
 RCT_ENUM_CONVERTER(UIStatusBarAnimation, (@{
   @"none": @(UIStatusBarAnimationNone),

--- a/React/Modules/RCTStatusBarManager.m
+++ b/React/Modules/RCTStatusBarManager.m
@@ -14,24 +14,34 @@
 #if !TARGET_OS_TV
 @implementation RCTConvert (UIStatusBar)
 
++ (UIStatusBarStyle)UIStatusBarStyle:(id)json RCT_DYNAMIC
+{
+  static NSDictionary *mapping;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+      if(@available(iOS 13.0, *)){
+        mapping=@{
+          @"default": @(UIStatusBarStyleDefault),
+          @"light-content": @(UIStatusBarStyleLightContent),
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_13_0) && \
-__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
-
-RCT_ENUM_CONVERTER(UIStatusBarStyle, (@{
-    @"default": @(UIStatusBarStyleDefault),
-    @"light-content": @(UIStatusBarStyleLightContent),
-    @"dark-content": @available(iOS 13.0, *) ? @(UIStatusBarStyleDarkContent):@(UIStatusBarStyleDefault)
-}), UIStatusBarStyleDefault, integerValue);
-
+          __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
+          @"dark-content": @(UIStatusBarStyleDarkContent)
 #else
-
-RCT_ENUM_CONVERTER(UIStatusBarStyle, (@{
-                                        @"default": @(UIStatusBarStyleDefault),
-                                        @"light-content": @(UIStatusBarStyleLightContent),
-                                        @"dark-content": @(UIStatusBarStyleDefault)
-                                        }), UIStatusBarStyleDefault, integerValue);
-
+          @"dark-content": @(UIStatusBarStyleDefault)
 #endif
+        };
+
+      }else{
+          mapping=@{
+          @"default": @(UIStatusBarStyleDefault),
+          @"light-content": @(UIStatusBarStyleLightContent),
+          @"dark-content": @(UIStatusBarStyleDefault)
+          };
+      }
+      
+  });
+  return _RCT_CAST(type, [RCTConvertEnumValue("UIStatusBarStyle", mapping, @(UIStatusBarStyleDefault), json) integerValue]);
+}
 
 RCT_ENUM_CONVERTER(UIStatusBarAnimation, (@{
   @"none": @(UIStatusBarAnimationNone),


### PR DESCRIPTION
iOS13 status bar has now 3 styles
UIStatusBarStyleDefault, UIStatusBarStyleLightContent, UIStatusBarStyleDarkContent


<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
UIStatusBarStyleDefault now acts as an automatic style which will set it’s value dynamically based on the the userinterfacestyle(One of the traits) of the viewcontroller that controls the status bar appearance.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->
[iOS] [Fixed] - iOS13 new status bar style UIStatusBarStyleDarkContent


## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
