### PR TITLE
fixed wrong path on install script - #22703

### DIFF
--- a/scripts/ios-install-third-party.sh
+++ b/scripts/ios-install-third-party.sh
@@ -69,7 +69,7 @@ function fetch_and_unpack () {
 
 mkdir -p third-party
 
-SCRIPTDIR=$(dirname "$0")
+SCRIPTDIR=$(pwd)
 
 fetch_and_unpack glog-0.3.5.tar.gz https://github.com/google/glog/archive/v0.3.5.tar.gz 61067502c5f9769d111ea1ee3f74e6ddf0a5f9cc "\"$SCRIPTDIR/ios-configure-glog.sh\""
 fetch_and_unpack double-conversion-1.1.6.tar.gz https://github.com/google/double-conversion/archive/v1.1.6.tar.gz 1c7d88afde3aaeb97bb652776c627b49e132e8e0


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

On installing Pods on Mac OS, the script fails on downloading the dependencies.

```
cd "$dir"
eval "${cmd:-true}" && touch .installed)
```

will fail, because the workdir is wrong here. 
cd "$dir" is accessing the extracted folder of the source but the script call on

```
fetch_and_unpack glog-0.3.5.tar.gz https://github.com/google/glog/archive/v0.3.5.tar.gz 61067502c5f9769d111ea1ee3f74e6ddf0a5f9cc "\"$SCRIPTDIR/ios-configure-glog.sh\""
```

is referencing on ./ios-configure-glog.sh

this is fixing the 'glog/logging.h' file not found error on build.
on the most users the error will not occur, because glog was compiled before 
or the ~/.rncache already has all files.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->


## Changelog

- changed relative path to a correct absolute to fix non fetching third-party libs on pod install

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

iOS Changed - pod build script for third party libs

## Test Plan

- clone fresh repo
- install node dependencies
- pod install (to fetch glog, etc.)
- build

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
