### PR TITLE
[Text] Add onPressIn and onPressOut

### DIFF
--- a/Libraries/Text/Text.js
+++ b/Libraries/Text/Text.js
@@ -93,8 +93,8 @@ class TouchableText extends React.Component<Props, State> {
   };
 
   touchableGetPressRectOffset: ?() => PressRetentionOffset;
-  touchableHandleActivePressIn: ?() => void;
-  touchableHandleActivePressOut: ?() => void;
+  touchableHandleActivePressIn: ?(event: PressEvent) => void;
+  touchableHandleActivePressOut: ?(event: PressEvent) => void;
   touchableHandleLongPress: ?(event: PressEvent) => void;
   touchableHandlePress: ?(event: PressEvent) => void;
   touchableHandleResponderGrant: ?(
@@ -227,14 +227,20 @@ class TouchableText extends React.Component<Props, State> {
         (this: any)[key] = Touchable.Mixin[key].bind(this);
       }
     }
-    this.touchableHandleActivePressIn = (): void => {
+    this.touchableHandleActivePressIn = (event: PressEvent): void => {
       if (!this.props.suppressHighlighting && isTouchable(this.props)) {
         this.setState({isHighlighted: true});
       }
+      if (this.props.onPressIn != null) {
+        this.props.onPressIn(event);
+      }
     };
-    this.touchableHandleActivePressOut = (): void => {
+    this.touchableHandleActivePressOut = (event: PressEvent): void => {
       if (!this.props.suppressHighlighting && isTouchable(this.props)) {
         this.setState({isHighlighted: false});
+      }
+      if (this.props.onPressOut != null) {
+        this.props.onPressOut(event);
       }
     };
     this.touchableHandlePress = (event: PressEvent): void => {

--- a/Libraries/Text/TextProps.js
+++ b/Libraries/Text/TextProps.js
@@ -110,6 +110,21 @@ export type TextProps = $ReadOnly<{|
    * See https://facebook.github.io/react-native/docs/text.html#onpress
    */
   onPress?: ?(event: PressEvent) => mixed,
+
+  /**
+   * This function is called on press in.
+   *
+   * See https://facebook.github.io/react-native/docs/text.html#onpressin
+   */
+  onPressIn?: ?(event: PressEvent) => mixed,
+
+  /**
+   * This function is called on press out.
+   *
+   * See https://facebook.github.io/react-native/docs/text.html#onpressout
+   */
+  onPressOut?: ?(event: PressEvent) => mixed,
+
   onResponderGrant?: ?(event: PressEvent, dispatchID: string) => void,
   onResponderMove?: ?(event: PressEvent) => void,
   onResponderRelease?: ?(event: PressEvent) => void,


### PR DESCRIPTION
## Summary

We wanted to add a special style on a Text component when it's pressed.
Instead of wrapping it in a `TouchableOpacity` (which prevents `Text`s nesting) I added `onPressIn` and `onPressOut` to listen to touch events.

## Changelog

[General] [Added] - Add `onPressIn` and `onPressOut` on `Text` component

## Test Plan

- `yarn lint` ✅ 
- `yarn test` ✅ 
