### PR TITLE
Fix flow test case input in react-native-codegen package

### DIFF
--- a/packages/react-native-codegen/e2e/__test_fixtures__/components/ArrayPropsNativeComponent.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/components/ArrayPropsNativeComponent.js
@@ -12,13 +12,13 @@
 
 import type {
   PointValue,
-  ColorValue,
+  ColorValue
 } from '../../../../../Libraries/StyleSheet/StyleSheetTypes';
 import type {ImageSource} from '../../../../../Libraries/Image/ImageSource';
 import type {
   Int32,
   Float,
-  WithDefault,
+  WithDefault
 } from '../../../../../Libraries/Types/CodegenTypes';
 import type {ViewProps} from '../../../../../Libraries/Components/View/ViewPropTypes';
 import codegenNativeComponent from '../../../../../Libraries/Utilities/codegenNativeComponent';
@@ -40,5 +40,5 @@ type NativeProps = $ReadOnly<{|
 |}>;
 
 export default (codegenNativeComponent<NativeProps>(
-  'ArrayPropsNativeComponentView',
+  'ArrayPropsNativeComponentView'
 ): NativeComponentType<NativeProps>);

--- a/packages/react-native-codegen/e2e/__test_fixtures__/components/BooleanPropNativeComponent.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/components/BooleanPropNativeComponent.js
@@ -23,5 +23,5 @@ type NativeProps = $ReadOnly<{|
 |}>;
 
 export default (codegenNativeComponent<NativeProps>(
-  'BooleanPropNativeComponentView',
+  'BooleanPropNativeComponentView'
 ): NativeComponentType<NativeProps>);

--- a/packages/react-native-codegen/e2e/__test_fixtures__/components/ColorPropNativeComponent.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/components/ColorPropNativeComponent.js
@@ -23,5 +23,5 @@ type NativeProps = $ReadOnly<{|
 |}>;
 
 export default (codegenNativeComponent<NativeProps>(
-  'ColorPropNativeComponentView',
+  'ColorPropNativeComponentView'
 ): NativeComponentType<NativeProps>);

--- a/packages/react-native-codegen/e2e/__test_fixtures__/components/EnumPropNativeComponent.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/components/EnumPropNativeComponent.js
@@ -23,5 +23,5 @@ type NativeProps = $ReadOnly<{|
 |}>;
 
 export default (codegenNativeComponent<NativeProps>(
-  'EnumPropNativeComponentView',
+  'EnumPropNativeComponentView'
 ): NativeComponentType<NativeProps>);

--- a/packages/react-native-codegen/e2e/__test_fixtures__/components/EventNestedObjectPropsNativeComponent.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/components/EventNestedObjectPropsNativeComponent.js
@@ -13,7 +13,7 @@
 import type {
   Int32,
   BubblingEventHandler,
-  WithDefault,
+  WithDefault
 } from '../../../../../Libraries/Types/CodegenTypes';
 import type {ViewProps} from '../../../../../Libraries/Components/View/ViewPropTypes';
 import codegenNativeComponent from '../../../../../Libraries/Utilities/codegenNativeComponent';
@@ -40,5 +40,5 @@ type NativeProps = $ReadOnly<{|
 |}>;
 
 export default (codegenNativeComponent<NativeProps>(
-  'EventNestedObjectPropsNativeComponentView',
+  'EventNestedObjectPropsNativeComponentView'
 ): NativeComponentType<NativeProps>);

--- a/packages/react-native-codegen/e2e/__test_fixtures__/components/EventPropsNativeComponent.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/components/EventPropsNativeComponent.js
@@ -15,7 +15,7 @@ import type {
   Float,
   BubblingEventHandler,
   DirectEventHandler,
-  WithDefault,
+  WithDefault
 } from '../../../../../Libraries/Types/CodegenTypes';
 import type {ViewProps} from '../../../../../Libraries/Components/View/ViewPropTypes';
 import codegenNativeComponent from '../../../../../Libraries/Utilities/codegenNativeComponent';
@@ -47,19 +47,19 @@ type NativeProps = $ReadOnly<{|
   onEventDirect?: ?DirectEventHandler<OnEventDirect>,
   onEventDirectWithPaperName?: ?DirectEventHandler<
     OnEventDirect,
-    'paperDirectName',
+    'paperDirectName'
   >,
   onOrientationChange?: ?DirectEventHandler<
     OnOrientationChangeEvent,
-    'paperBubblingName',
+    'paperBubblingName'
   >,
   onEnd?: ?BubblingEventHandler<null>,
   onEventBubblingWithPaperName?: ?BubblingEventHandler<
     null,
-    'paperBubblingName',
+    'paperBubblingName'
   >,
 |}>;
 
 export default (codegenNativeComponent<NativeProps>(
-  'EventPropsNativeComponentView',
+  'EventPropsNativeComponentView'
 ): NativeComponentType<NativeProps>);

--- a/packages/react-native-codegen/e2e/__test_fixtures__/components/FloatPropsNativeComponent.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/components/FloatPropsNativeComponent.js
@@ -12,7 +12,7 @@
 
 import type {
   WithDefault,
-  Float,
+  Float
 } from '../../../../../Libraries/Types/CodegenTypes';
 import type {ViewProps} from '../../../../../Libraries/Components/View/ViewPropTypes';
 import codegenNativeComponent from '../../../../../Libraries/Utilities/codegenNativeComponent';
@@ -31,5 +31,5 @@ type NativeProps = $ReadOnly<{|
 |}>;
 
 export default (codegenNativeComponent<NativeProps>(
-  'FloatPropsNativeComponentView',
+  'FloatPropsNativeComponentView'
 ): NativeComponentType<NativeProps>);

--- a/packages/react-native-codegen/e2e/__test_fixtures__/components/ImagePropNativeComponent.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/components/ImagePropNativeComponent.js
@@ -23,5 +23,5 @@ type NativeProps = $ReadOnly<{|
 |}>;
 
 export default (codegenNativeComponent<NativeProps>(
-  'ImagePropNativeComponentView',
+  'ImagePropNativeComponentView'
 ): NativeComponentType<NativeProps>);

--- a/packages/react-native-codegen/e2e/__test_fixtures__/components/IntegerPropNativeComponent.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/components/IntegerPropNativeComponent.js
@@ -12,7 +12,7 @@
 
 import type {
   WithDefault,
-  Int32,
+  Int32
 } from '../../../../../Libraries/Types/CodegenTypes';
 import type {ViewProps} from '../../../../../Libraries/Components/View/ViewPropTypes';
 import codegenNativeComponent from '../../../../../Libraries/Utilities/codegenNativeComponent';
@@ -28,5 +28,5 @@ type NativeProps = $ReadOnly<{|
 |}>;
 
 export default (codegenNativeComponent<NativeProps>(
-  'IntegerPropNativeComponentView',
+  'IntegerPropNativeComponentView'
 ): NativeComponentType<NativeProps>);

--- a/packages/react-native-codegen/e2e/__test_fixtures__/components/InterfaceOnlyNativeComponent.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/components/InterfaceOnlyNativeComponent.js
@@ -12,7 +12,7 @@
 
 import type {
   BubblingEventHandler,
-  WithDefault,
+  WithDefault
 } from '../../../../../Libraries/Types/CodegenTypes';
 import type {ViewProps} from '../../../../../Libraries/Components/View/ViewPropTypes';
 import codegenNativeComponent from '../../../../../Libraries/Utilities/codegenNativeComponent';
@@ -33,5 +33,5 @@ export default (codegenNativeComponent<NativeProps>(
   {
     interfaceOnly: true,
     paperComponentName: 'RCTInterfaceOnlyComponent',
-  },
+  }
 ): NativeComponentType<NativeProps>);

--- a/packages/react-native-codegen/e2e/__test_fixtures__/components/MultiNativePropNativeComponent.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/components/MultiNativePropNativeComponent.js
@@ -12,7 +12,7 @@
 
 import type {
   PointValue,
-  ColorValue,
+  ColorValue
 } from '../../../../../Libraries/StyleSheet/StyleSheetTypes';
 import type {ImageSource} from '../../../../../Libraries/Image/ImageSource';
 import type {ViewProps} from '../../../../../Libraries/Components/View/ViewPropTypes';
@@ -30,5 +30,5 @@ type NativeProps = $ReadOnly<{|
 |}>;
 
 export default (codegenNativeComponent<NativeProps>(
-  'MultiNativePropNativeComponentView',
+  'MultiNativePropNativeComponentView'
 ): NativeComponentType<NativeProps>);

--- a/packages/react-native-codegen/e2e/__test_fixtures__/components/NoPropsNoEventsNativeComponent.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/components/NoPropsNoEventsNativeComponent.js
@@ -21,5 +21,5 @@ type NativeProps = $ReadOnly<{|
 |}>;
 
 export default (codegenNativeComponent<NativeProps>(
-  'NoPropsNoEventsNativeComponentView',
+  'NoPropsNoEventsNativeComponentView'
 ): NativeComponentType<NativeProps>);

--- a/packages/react-native-codegen/e2e/__test_fixtures__/components/ObjectPropsNativeComponent.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/components/ObjectPropsNativeComponent.js
@@ -14,12 +14,12 @@ import type {ViewProps} from '../../../../../Libraries/Components/View/ViewPropT
 import type {ImageSource} from '../../../../../Libraries/Image/ImageSource';
 import type {
   PointValue,
-  ColorValue,
+  ColorValue
 } from '../../../../../Libraries/StyleSheet/StyleSheetTypes';
 import type {
   Int32,
   Float,
-  WithDefault,
+  WithDefault
 } from '../../../../../Libraries/Types/CodegenTypes';
 import codegenNativeComponent from '../../../../../Libraries/Utilities/codegenNativeComponent';
 import type {NativeComponentType} from '../../../../../Libraries/Utilities/codegenNativeComponent';
@@ -48,5 +48,5 @@ type NativeProps = $ReadOnly<{|
 |}>;
 
 export default (codegenNativeComponent<NativeProps>(
-  'ObjectPropsNativeComponent',
+  'ObjectPropsNativeComponent'
 ): NativeComponentType<NativeProps>);

--- a/packages/react-native-codegen/e2e/__test_fixtures__/components/PointPropNativeComponent.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/components/PointPropNativeComponent.js
@@ -23,5 +23,5 @@ type NativeProps = $ReadOnly<{|
 |}>;
 
 export default (codegenNativeComponent<NativeProps>(
-  'PointPropNativeComponentView',
+  'PointPropNativeComponentView'
 ): NativeComponentType<NativeProps>);

--- a/packages/react-native-codegen/e2e/__test_fixtures__/components/StringPropNativeComponent.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/components/StringPropNativeComponent.js
@@ -24,5 +24,5 @@ type NativeProps = $ReadOnly<{|
 |}>;
 
 export default (codegenNativeComponent<NativeProps>(
-  'StringPropNativeComponentView',
+  'StringPropNativeComponentView'
 ): NativeComponentType<NativeProps>);

--- a/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativeArrayTurboModule.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativeArrayTurboModule.js
@@ -23,5 +23,5 @@ export interface Spec extends TurboModule {
 }
 
 export default (TurboModuleRegistry.getEnforcing<Spec>(
-  'SampleTurboModule',
+  'SampleTurboModule'
 ): Spec);

--- a/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativeBooleanTurboModule.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativeBooleanTurboModule.js
@@ -22,5 +22,5 @@ export interface Spec extends TurboModule {
 }
 
 export default (TurboModuleRegistry.getEnforcing<Spec>(
-  'SampleTurboModule',
+  'SampleTurboModule'
 ): Spec);

--- a/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativeCallbackTurboModule.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativeCallbackTurboModule.js
@@ -22,5 +22,5 @@ export interface Spec extends TurboModule {
 }
 
 export default (TurboModuleRegistry.getEnforcing<Spec>(
-  'SampleTurboModule',
+  'SampleTurboModule'
 ): Spec);

--- a/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativeNullableTurboModule.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativeNullableTurboModule.js
@@ -23,5 +23,5 @@ export interface Spec extends TurboModule {
 }
 
 export default (TurboModuleRegistry.getEnforcing<Spec>(
-  'SampleTurboModule',
+  'SampleTurboModule'
 ): Spec);

--- a/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativeNumberTurboModule.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativeNumberTurboModule.js
@@ -22,5 +22,5 @@ export interface Spec extends TurboModule {
 }
 
 export default (TurboModuleRegistry.getEnforcing<Spec>(
-  'SampleTurboModule',
+  'SampleTurboModule'
 ): Spec);

--- a/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativeObjectTurboModule.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativeObjectTurboModule.js
@@ -61,5 +61,5 @@ export interface Spec extends TurboModule {
 }
 
 export default (TurboModuleRegistry.getEnforcing<Spec>(
-  'SampleTurboModule',
+  'SampleTurboModule'
 ): Spec);

--- a/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativeOptionalObjectTurboModule.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativeOptionalObjectTurboModule.js
@@ -36,5 +36,5 @@ export interface Spec extends TurboModule {
 }
 
 export default (TurboModuleRegistry.getEnforcing<Spec>(
-  'SampleTurboModule',
+  'SampleTurboModule'
 ): Spec);

--- a/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativePromiseTurboModule.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativePromiseTurboModule.js
@@ -22,5 +22,5 @@ export interface Spec extends TurboModule {
 }
 
 export default (TurboModuleRegistry.getEnforcing<Spec>(
-  'SampleTurboModule',
+  'SampleTurboModule'
 ): Spec);

--- a/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativeSampleTurboModule.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativeSampleTurboModule.js
@@ -32,5 +32,5 @@ export interface Spec extends TurboModule {
 }
 
 export default (TurboModuleRegistry.getEnforcing<Spec>(
-  'SampleTurboModule',
+  'SampleTurboModule'
 ): Spec);

--- a/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativeStringTurboModule.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativeStringTurboModule.js
@@ -22,5 +22,5 @@ export interface Spec extends TurboModule {
 }
 
 export default (TurboModuleRegistry.getEnforcing<Spec>(
-  'SampleTurboModule',
+  'SampleTurboModule'
 ): Spec);

--- a/packages/react-native-codegen/src/parsers/flow/components/__test_fixtures__/failures.js
+++ b/packages/react-native-codegen/src/parsers/flow/components/__test_fixtures__/failures.js
@@ -42,7 +42,7 @@ export const Commands = codegenNativeCommands<{
 });
 
 export default (codegenNativeComponent<ModuleProps>(
-  'Module',
+  'Module'
 ): NativeComponent<ModuleProps>);
 `;
 
@@ -83,7 +83,7 @@ export const Commands2 = codegenNativeCommands<NativeCommands>({
 });
 
 export default (codegenNativeComponent<ModuleProps>(
-  'Module',
+  'Module'
 ): NativeComponent<ModuleProps>);
 `;
 
@@ -121,7 +121,7 @@ export const Commands = codegenNativeCommands<NativeCommands>({
 });
 
 export default (codegenNativeComponent<ModuleProps>(
-  'Module',
+  'Module'
 ): NativeComponent<ModuleProps>);
 `;
 
@@ -159,7 +159,7 @@ export const Commands = codegenNativeCommands<NativeCommands>({
 });
 
 export default (codegenNativeComponent<ModuleProps>(
-  'Module',
+  'Module'
 ): NativeComponent<ModuleProps>);
 `;
 
@@ -188,7 +188,7 @@ interface NativeCommands {
   +scrollTo: (
     viewRef: React.Ref<'RCTView'>,
     y: Int32,
-    animated: boolean,
+    animated: boolean
   ) => void;
 }
 
@@ -202,7 +202,7 @@ export const Commands = codegenNativeCommands<NativeCommands>({
 });
 
 export default (codegenNativeComponent<ModuleProps>(
-  'Module',
+  'Module'
 ): NativeComponent<ModuleProps>);
 `;
 
@@ -231,7 +231,7 @@ interface NativeCommands {
   +scrollTo: (
     viewRef: React.Ref<'RCTView'>,
     y: Int32,
-    animated: boolean,
+    animated: boolean
   ) => void;
 }
 
@@ -243,7 +243,7 @@ export type ModuleProps = $ReadOnly<{|
 export const Commands = codegenNativeCommands<NativeCommands>();
 
 export default (codegenNativeComponent<ModuleProps>(
-  'Module',
+  'Module'
 ): NativeComponent<ModuleProps>);
 `;
 
@@ -272,7 +272,7 @@ export type ModuleProps = $ReadOnly<{|
 |}>;
 
 export default (codegenNativeComponent<ModuleProps>(
-  'Module',
+  'Module'
 ): NativeComponent<ModuleProps>);
 `;
 
@@ -301,7 +301,7 @@ export type ModuleProps = $ReadOnly<{|
 |}>;
 
 export default (codegenNativeComponent<ModuleProps>(
-  'Module',
+  'Module'
 ): NativeComponent<ModuleProps>);
 `;
 
@@ -331,7 +331,7 @@ export type ModuleProps = $ReadOnly<{|
 |}>;
 
 export default (codegenNativeComponent<ModuleProps>(
-  'Module',
+  'Module'
 ): NativeComponent<ModuleProps>);
 `;
 
@@ -365,7 +365,7 @@ export type ModuleProps = $ReadOnly<{|
 |}>;
 
 export default (codegenNativeComponent<ModuleProps>(
-  'Module',
+  'Module'
 ): NativeComponent<ModuleProps>);
 `;
 
@@ -399,7 +399,7 @@ export type ModuleProps = $ReadOnly<{|
 |}>;
 
 export default (codegenNativeComponent<ModuleProps>(
-  'Module',
+  'Module'
 ): NativeComponent<ModuleProps>);
 `;
 
@@ -428,7 +428,7 @@ export type ModuleProps = $ReadOnly<{|
 |}>;
 
 export default (codegenNativeComponent<ModuleProps>(
-  'Module',
+  'Module'
 ): NativeComponent<ModuleProps>);
 `;
 

--- a/packages/react-native-codegen/src/parsers/flow/components/__test_fixtures__/fixtures.js
+++ b/packages/react-native-codegen/src/parsers/flow/components/__test_fixtures__/fixtures.js
@@ -43,19 +43,19 @@ const EVENT_DEFINITION = `
 
   object_required: {
     boolean_required: boolean,
-  }
+  },
 
   object_optional_key?: {
     string_optional_key?: string,
-  }
+  },
 
   object_optional_value: ?{
     float_optional_value: ?Float,
-  }
+  },
 
   object_optional_both?: ?{
     int32_optional_both?: ?Int32,
-  }
+  },
 
   object_required_nested_2_layers: {
     object_optional_nested_1_layer?: ?{
@@ -65,7 +65,7 @@ const EVENT_DEFINITION = `
       float_optional_value: ?Float,
       int32_optional_both?: ?Int32,
     }
-  }
+  },
 `;
 
 const ONE_OF_EACH_PROP_EVENT_DEFAULT_AND_OPTIONS = `
@@ -86,7 +86,7 @@ const codegenNativeComponent = require('codegenNativeComponent');
 import type {
   BubblingEventHandler,
   DirectEventHandler,
-  WithDefault,
+  WithDefault
 } from 'CodegenTypes';
 import type {ViewProps} from 'ViewPropTypes';
 import type {NativeComponent} from 'codegenNativeComponent';
@@ -126,7 +126,7 @@ const codegenNativeComponent = require('codegenNativeComponent');
 import type {
   BubblingEventHandler,
   DirectEventHandler,
-  WithDefault,
+  WithDefault
 } from 'CodegenTypes';
 import type {ViewProps} from 'ViewPropTypes';
 import type {NativeComponent} from 'codegenNativeComponent';
@@ -272,7 +272,7 @@ type ModuleProps = $ReadOnly<{|
 |}>;
 
 export default (codegenNativeComponent<ModuleProps, Options>(
-  'Module',
+  'Module'
 ): NativeComponent<ModuleProps>);
 `;
 
@@ -337,11 +337,11 @@ type ModuleProps = $ReadOnly<{|
   // String enum props
   array_enum_optional_key?: WithDefault<
     $ReadOnlyArray<'small' | 'large'>,
-    'small',
+    'small'
   >,
   array_enum_optional_both?: WithDefault<
     $ReadOnlyArray<'small' | 'large'>,
-    'small',
+    'small'
   >,
 
   // ImageSource props
@@ -396,7 +396,7 @@ type ModuleProps = $ReadOnly<{|
 |}>;
 
 export default (codegenNativeComponent<ModuleProps>(
-  'Module',
+  'Module'
 ): NativeComponent<ModuleProps>);
 `;
 
@@ -476,7 +476,7 @@ type ModuleProps = $ReadOnly<{|
 |}>;
 
 export default (codegenNativeComponent<ModuleProps>(
-  'Module',
+  'Module'
 ): NativeComponent<ModuleProps>);
 `;
 
@@ -500,7 +500,7 @@ const codegenNativeComponent = require('codegenNativeComponent');
 
 type DeepSpread = $ReadOnly<{|
   otherStringProp: string,
-|}>
+|}>;
 
 export type PropsInFile = $ReadOnly<{|
   ...DeepSpread,
@@ -511,17 +511,17 @@ export type PropsInFile = $ReadOnly<{|
 export type ModuleProps = $ReadOnly<{|
   ...ViewProps,
 
-  ...PropsInFile
+  ...PropsInFile,
 
   localType: $ReadOnly<{|
     ...PropsInFile
-  |}>
+  |}>,
 
-  localArr: $ReadOnlyArray<PropsInFile>
+  localArr: $ReadOnlyArray<PropsInFile>,
 |}>;
 
 export default (codegenNativeComponent<ModuleProps>(
-  'Module',
+  'Module'
 ): NativeComponent<ModuleProps>);
 `;
 
@@ -546,7 +546,7 @@ import type {
   Double,
   Float,
   BubblingEventHandler,
-  DirectEventHandler,
+  DirectEventHandler
 } from 'CodegenTypes';
 
 import type {ViewProps} from 'ViewPropTypes';
@@ -560,28 +560,28 @@ type ModuleProps = $ReadOnly<{|
     DirectEventHandler<
       $ReadOnly<{|
         ${EVENT_DEFINITION}
-      |}>,
+      |}>
     >,
 
   onDirectEventDefinedInlineOptionalKey?:
     DirectEventHandler<
       $ReadOnly<{|
         ${EVENT_DEFINITION}
-      |}>,
+      |}>
     >,
 
   onDirectEventDefinedInlineOptionalValue: ?
     DirectEventHandler<
       $ReadOnly<{|
         ${EVENT_DEFINITION}
-      |}>,
+      |}>
     >,
 
   onDirectEventDefinedInlineOptionalBoth?: ?
     DirectEventHandler<
       $ReadOnly<{|
         ${EVENT_DEFINITION}
-      |}>,
+      |}>
     >,
 
   onDirectEventDefinedInlineWithPaperName?: ?
@@ -589,35 +589,35 @@ type ModuleProps = $ReadOnly<{|
       $ReadOnly<{|
         ${EVENT_DEFINITION}
       |}>,
-      'paperDirectEventDefinedInlineWithPaperName',
+      'paperDirectEventDefinedInlineWithPaperName'
     >,
 
   onBubblingEventDefinedInline:
     BubblingEventHandler<
       $ReadOnly<{|
         ${EVENT_DEFINITION}
-      |}>,
+      |}>
     >,
 
   onBubblingEventDefinedInlineOptionalKey?:
     BubblingEventHandler<
       $ReadOnly<{|
         ${EVENT_DEFINITION}
-      |}>,
+      |}>
     >,
 
   onBubblingEventDefinedInlineOptionalValue: ?
     BubblingEventHandler<
       $ReadOnly<{|
         ${EVENT_DEFINITION}
-      |}>,
+      |}>
     >,
 
   onBubblingEventDefinedInlineOptionalBoth?: ?
     BubblingEventHandler<
       $ReadOnly<{|
         ${EVENT_DEFINITION}
-      |}>,
+      |}>
     >,
 
   onBubblingEventDefinedInlineWithPaperName?: ?
@@ -630,7 +630,7 @@ type ModuleProps = $ReadOnly<{|
 |}>;
 
 export default (codegenNativeComponent<ModuleProps>(
-  'Module',
+  'Module'
 ): NativeComponent<ModuleProps>);
 `;
 
@@ -665,7 +665,7 @@ type ModuleProps = $ReadOnly<{|
   onDirectEventDefinedInlineNullOptionalBoth?: DirectEventHandler<null>,
   onDirectEventDefinedInlineNullWithPaperName?: ?DirectEventHandler<
     null,
-    'paperDirectEventDefinedInlineNullWithPaperName',
+    'paperDirectEventDefinedInlineNullWithPaperName'
   >,
 
   onBubblingEventDefinedInlineNull: BubblingEventHandler<null>,
@@ -674,12 +674,12 @@ type ModuleProps = $ReadOnly<{|
   onBubblingEventDefinedInlineNullOptionalBoth?: ?BubblingEventHandler<null>,
   onBubblingEventDefinedInlineNullWithPaperName?: ?BubblingEventHandler<
     null,
-    'paperBubblingEventDefinedInlineNullWithPaperName',
+    'paperBubblingEventDefinedInlineNullWithPaperName'
   >,
 |}>;
 
 export default (codegenNativeComponent<ModuleProps>(
-  'Module',
+  'Module'
 ): NativeComponent<ModuleProps>);
 `;
 
@@ -698,7 +698,7 @@ const PROPS_AND_EVENTS_TYPES_EXPORTED = `
 
 import type {
   BubblingEventHandler,
-  DirectEventHandler,
+  DirectEventHandler
 } from 'CodegenTypes';
 import type {ViewProps} from 'ViewPropTypes';
 import type {NativeComponent} from 'codegenNativeComponent';
@@ -722,7 +722,7 @@ export type ModuleProps = $ReadOnly<{|
 |}>;
 
 export default (codegenNativeComponent<ModuleProps>(
-  'Module',
+  'Module'
 ): NativeComponent<ModuleProps>);
 `;
 
@@ -752,7 +752,7 @@ export type ModuleProps = $ReadOnly<{|
 |}>;
 
 export default (codegenNativeComponent<ModuleProps>(
-  'Module',
+  'Module'
 ): NativeComponent<ModuleProps>);
 `;
 
@@ -791,7 +791,7 @@ interface NativeCommands {
     x: Float,
     y: Int32,
     z: Double,
-    animated: boolean,
+    animated: boolean
   ) => void;
 }
 
@@ -800,7 +800,7 @@ export const Commands = codegenNativeCommands<NativeCommands>({
 });
 
 export default (codegenNativeComponent<ModuleProps>(
-  'Module',
+  'Module'
 ): NativeType);
 `;
 
@@ -838,7 +838,7 @@ type NativeType = NativeComponent<ModuleProps>;
 export type ScrollTo = (
   viewRef: React.ElementRef<NativeType>,
   y: Int,
-  animated: Boolean,
+  animated: Boolean
 ) => Void;
 
 interface NativeCommands {
@@ -850,7 +850,7 @@ export const Commands = codegenNativeCommands<NativeCommands>({
 });
 
 export default (codegenNativeComponent<ModuleProps>(
-  'Module',
+  'Module'
 ): NativeType);
 `;
 
@@ -869,7 +869,7 @@ const COMMANDS_AND_EVENTS_TYPES_EXPORTED = `
 
 import type {
   BubblingEventHandler,
-  DirectEventHandler,
+  DirectEventHandler
 } from 'CodegenTypes';
 import type {ViewProps} from 'ViewPropTypes';
 import type {NativeComponent} from 'codegenNativeComponent';
@@ -898,7 +898,7 @@ export type ModuleProps = $ReadOnly<{|
 
 type NativeType = NativeComponent<ModuleProps>;
 
-export type ScrollTo = (viewRef: React.ElementRef<NativeType>, y: Int, animated: Boolean) => Void
+export type ScrollTo = (viewRef: React.ElementRef<NativeType>, y: Int, animated: Boolean) => Void;
 
 interface NativeCommands {
   +scrollTo: ScrollTo;
@@ -909,7 +909,7 @@ export const Commands = codegenNativeCommands<NativeCommands>({
 });
 
 export default (codegenNativeComponent<ModuleProps>(
-  'Module',
+  'Module'
 ): NativeType);
 `;
 

--- a/packages/react-native-codegen/src/parsers/flow/modules/__test_fixtures__/failures.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/__test_fixtures__/failures.js
@@ -199,11 +199,11 @@ import type {TurboModule} from '../RCTExport';
 import * as TurboModuleRegistry from '../TurboModuleRegistry';
 
 export interface Spec extends TurboModule {
-  +getSth(a : ?number) => void
+  +getSth: (a : ?number) => void
 }
 
 export interface Spec2 extends TurboModule {
-  +getSth(a : ?number) => void
+  +getSth: (a : ?number) => void
 }
 
 

--- a/packages/react-native-codegen/src/parsers/flow/modules/__test_fixtures__/fixtures.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/__test_fixtures__/fixtures.js
@@ -50,7 +50,7 @@ const NATIVE_MODULE_WITH_COMPLEX_OBJECTS = `
 import type {TurboModule} from '../RCTExport';
 import * as TurboModuleRegistry from '../TurboModuleRegistry';
 
-export type String = string
+export type String = string;
 
 export interface Spec extends TurboModule {
   // Exported methods.
@@ -208,7 +208,7 @@ import type {TurboModule} from '../RCTExport';
 import * as TurboModuleRegistry from '../TurboModuleRegistry';
 
 export interface Spec extends TurboModule {
-  +getObject(o : Object) => Object,
+  +getObject: (o : Object) => Object,
 }
 
 export default TurboModuleRegistry.getEnforcing<Spec>('SampleTurboModule');
@@ -390,7 +390,7 @@ const NATIVE_MODULE_WITH_PROMISE = `/**
 import type {TurboModule} from '../RCTExport';
 import * as TurboModuleRegistry from '../TurboModuleRegistry';
 
-export type String = string
+export type String = string;
 export type SomeObj = {| a: string |};
 
 export interface Spec extends TurboModule {
@@ -422,7 +422,7 @@ import * as TurboModuleRegistry from '../TurboModuleRegistry';
 export interface Spec extends TurboModule {
   // Exported methods.
   +getValueWithCallback: (
-    callback: (value: string, arr: Array<Array<string>>) => void,
+    callback: (value: string, arr: Array<Array<string>>) => void
   ) => void;
 }
 


### PR DESCRIPTION
## Summary

Flow test case input in react-native-codegen package has syntax errors.
Missing ";" after `export type`,
Missing ";" or "," after interface/object type member signature,
Missing ":" in method signature,
Extra "," at the end of import list,
Extra "," at the end of parameters,
Extra "," at the end of type parameters,
etc

## Changelog

[General] [Fixed] - Fix flow test case input in react-native-codegen package

## Test Plan

Parsed files using flow parser, but some test cases are intended to have syntax error, in this case I fixed unexpected ones.
