### PR TITLE
Added prefix to node_modules into Podfile template

### DIFF
--- a/template/ios/Podfile
+++ b/template/ios/Podfile
@@ -1,53 +1,14 @@
 platform :ios, '9.0'
 require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'
 
-# Add Flipper Poods
-def flipper_pods()
-  flipperkit_version = '0.23.4'
-  pod 'FlipperKit', '~>' + flipperkit_version, :configuration => 'Debug'
-  pod 'FlipperKit/FlipperKitLayoutPlugin', '~>' + flipperkit_version, :configuration => 'Debug'
-  pod 'FlipperKit/SKIOSNetworkPlugin', '~>' + flipperkit_version, :configuration => 'Debug'
-  pod 'FlipperKit/FlipperKitUserDefaultsPlugin', '~>' + flipperkit_version, :configuration => 'Debug'
-end
-
-# Post Install processing for Flipper
-def flipper_post_install(installer)
-  installer.pods_project.targets.each do |target|
-    if target.name == 'YogaKit'
-      target.build_configurations.each do |config|
-        config.build_settings['SWIFT_VERSION'] = '4.1'
-      end
-    end
-  end
-  file_name = Dir.glob("*.xcodeproj")[0]
-  app_project = Xcodeproj::Project.open(file_name)
-  app_project.native_targets.each do |target|
-    target.build_configurations.each do |config|
-      cflags = config.build_settings['OTHER_CFLAGS'] || '$(inherited) '
-      unless cflags.include? '-DFB_SONARKIT_ENABLED=1'
-        puts 'Adding -DFB_SONARKIT_ENABLED=1 in OTHER_CFLAGS...'
-        cflags << '-DFB_SONARKIT_ENABLED=1'
-      end
-      config.build_settings['OTHER_CFLAGS'] = cflags
-    end
-    app_project.save
-  end
-  installer.pods_project.save
-end
-
 # The prefix to the react-native
 prefix = "../node_modules/react-native"
 
-target 'HelloWorld' do
+target 'Oii' do
   # Pods for HelloWorld
-  pod 'FBLazyVector', :path => "#{prefix}/Libraries/FBLazyVector"
-  pod 'FBReactNativeSpec', :path => "#{prefix}/Libraries/FBReactNativeSpec"
-  pod 'RCTRequired', :path => "#{prefix}/Libraries/RCTRequired"
-  pod 'RCTTypeSafety', :path => "#{prefix}/Libraries/TypeSafety"
   pod 'React', :path => "#{prefix}/"
-  pod 'React-Core', :path => "#{prefix}/"
-  pod 'React-CoreModules', :path => "#{prefix}/React/CoreModules"
-  pod 'React-Core/DevSupport', :path => "#{prefix}/"
+  pod 'React-Core', :path => "#{prefix}/React"
+  pod 'React-DevSupport', :path => "#{prefix}/React"
   pod 'React-RCTActionSheet', :path => "#{prefix}/Libraries/ActionSheetIOS"
   pod 'React-RCTAnimation', :path => "#{prefix}/Libraries/NativeAnimation"
   pod 'React-RCTBlob', :path => "#{prefix}/Libraries/Blob"
@@ -57,41 +18,32 @@ target 'HelloWorld' do
   pod 'React-RCTSettings', :path => "#{prefix}/Libraries/Settings"
   pod 'React-RCTText', :path => "#{prefix}/Libraries/Text"
   pod 'React-RCTVibration', :path => "#{prefix}/Libraries/Vibration"
-  pod 'React-Core/RCTWebSocket', :path => "#{prefix}/"
+  pod 'React-RCTWebSocket', :path => "#{prefix}/Libraries/WebSocket"
 
   pod 'React-cxxreact', :path => "#{prefix}/ReactCommon/cxxreact"
   pod 'React-jsi', :path => "#{prefix}/ReactCommon/jsi"
   pod 'React-jsiexecutor', :path => "#{prefix}/ReactCommon/jsiexecutor"
   pod 'React-jsinspector', :path => "#{prefix}/ReactCommon/jsinspector"
-  pod 'ReactCommon/jscallinvoker', :path => "#{prefix}/ReactCommon"
-  pod 'ReactCommon/turbomodule/core', :path => "#{prefix}/ReactCommon"
-  pod 'Yoga', :path => "#{prefix}/ReactCommon/yoga"
+  pod 'yoga', :path => "#{prefix}/ReactCommon/yoga"
 
   pod 'DoubleConversion', :podspec => "#{prefix}/third-party-podspecs/DoubleConversion.podspec"
   pod 'glog', :podspec => "#{prefix}/third-party-podspecs/glog.podspec"
   pod 'Folly', :podspec => "#{prefix}/third-party-podspecs/Folly.podspec"
 
-  target 'HelloWorldTests' do
-    inherit! :complete
+  target 'OiiTests' do
+    inherit! :search_paths
     # Pods for testing
   end
 
   use_native_modules!
-
-  # For enabling Flipper.
-  # Note that if you use_framework!, flipper will no work.
-  # Disable these lines if you are doing use_framework!
-  flipper_pods()
-  post_install do |installer|
-    flipper_post_install(installer)
-  end
 end
 
-target 'HelloWorld-tvOS' do
+target 'Oii-tvOS' do
   # Pods for HelloWorld-tvOS
 
-  target 'HelloWorld-tvOSTests' do
+  target 'Oii-tvOSTests' do
     inherit! :search_paths
     # Pods for testing
   end
+
 end

--- a/template/ios/Podfile
+++ b/template/ios/Podfile
@@ -4,7 +4,7 @@ require_relative '../node_modules/@react-native-community/cli-platform-ios/nativ
 # The prefix to the react-native
 prefix = "../node_modules/react-native"
 
-target 'Oii' do
+target 'HelloWorld' do
   # Pods for HelloWorld
   pod 'React', :path => "#{prefix}/"
   pod 'React-Core', :path => "#{prefix}/React"
@@ -30,7 +30,7 @@ target 'Oii' do
   pod 'glog', :podspec => "#{prefix}/third-party-podspecs/glog.podspec"
   pod 'Folly', :podspec => "#{prefix}/third-party-podspecs/Folly.podspec"
 
-  target 'OiiTests' do
+  target 'HelloWorldTests' do
     inherit! :search_paths
     # Pods for testing
   end
@@ -38,10 +38,10 @@ target 'Oii' do
   use_native_modules!
 end
 
-target 'Oii-tvOS' do
+target 'HelloWorld-tvOS' do
   # Pods for HelloWorld-tvOS
 
-  target 'Oii-tvOSTests' do
+  target 'HelloWorld-tvOSTests' do
     inherit! :search_paths
     # Pods for testing
   end

--- a/template/ios/Podfile
+++ b/template/ios/Podfile
@@ -6,9 +6,9 @@ prefix = "../node_modules/react-native"
 
 target 'HelloWorld' do
   # Pods for HelloWorld
-  pod 'React', :path => "#{prefix}/"
-  pod 'React-Core', :path => "#{prefix}/React"
-  pod 'React-DevSupport', :path => "#{prefix}/React"
+  pod 'React', :path => "#{prefix}"
+  pod 'React-Core', :path => "#{prefix}"
+  pod 'React-Core/DevSupport', :path => "#{prefix}"
   pod 'React-RCTActionSheet', :path => "#{prefix}/Libraries/ActionSheetIOS"
   pod 'React-RCTAnimation', :path => "#{prefix}/Libraries/NativeAnimation"
   pod 'React-RCTBlob', :path => "#{prefix}/Libraries/Blob"
@@ -18,13 +18,13 @@ target 'HelloWorld' do
   pod 'React-RCTSettings', :path => "#{prefix}/Libraries/Settings"
   pod 'React-RCTText', :path => "#{prefix}/Libraries/Text"
   pod 'React-RCTVibration', :path => "#{prefix}/Libraries/Vibration"
-  pod 'React-RCTWebSocket', :path => "#{prefix}/Libraries/WebSocket"
+  pod 'React-Core/RCTWebSocket', :path => "#{prefix}"
 
   pod 'React-cxxreact', :path => "#{prefix}/ReactCommon/cxxreact"
   pod 'React-jsi', :path => "#{prefix}/ReactCommon/jsi"
   pod 'React-jsiexecutor', :path => "#{prefix}/ReactCommon/jsiexecutor"
   pod 'React-jsinspector', :path => "#{prefix}/ReactCommon/jsinspector"
-  pod 'yoga', :path => "#{prefix}/ReactCommon/yoga"
+  pod 'Yoga', :path => "#{prefix}/ReactCommon/yoga"
 
   pod 'DoubleConversion', :podspec => "#{prefix}/third-party-podspecs/DoubleConversion.podspec"
   pod 'glog', :podspec => "#{prefix}/third-party-podspecs/glog.podspec"

--- a/template/ios/Podfile
+++ b/template/ios/Podfile
@@ -35,39 +35,41 @@ def flipper_post_install(installer)
   installer.pods_project.save
 end
 
+# The prefix to the react-native
+prefix = "../node_modules/react-native"
 
 target 'HelloWorld' do
   # Pods for HelloWorld
-  pod 'FBLazyVector', :path => "../node_modules/react-native/Libraries/FBLazyVector"
-  pod 'FBReactNativeSpec', :path => "../node_modules/react-native/Libraries/FBReactNativeSpec"
-  pod 'RCTRequired', :path => "../node_modules/react-native/Libraries/RCTRequired"
-  pod 'RCTTypeSafety', :path => "../node_modules/react-native/Libraries/TypeSafety"
-  pod 'React', :path => '../node_modules/react-native/'
-  pod 'React-Core', :path => '../node_modules/react-native/'
-  pod 'React-CoreModules', :path => '../node_modules/react-native/React/CoreModules'
-  pod 'React-Core/DevSupport', :path => '../node_modules/react-native/'
-  pod 'React-RCTActionSheet', :path => '../node_modules/react-native/Libraries/ActionSheetIOS'
-  pod 'React-RCTAnimation', :path => '../node_modules/react-native/Libraries/NativeAnimation'
-  pod 'React-RCTBlob', :path => '../node_modules/react-native/Libraries/Blob'
-  pod 'React-RCTImage', :path => '../node_modules/react-native/Libraries/Image'
-  pod 'React-RCTLinking', :path => '../node_modules/react-native/Libraries/LinkingIOS'
-  pod 'React-RCTNetwork', :path => '../node_modules/react-native/Libraries/Network'
-  pod 'React-RCTSettings', :path => '../node_modules/react-native/Libraries/Settings'
-  pod 'React-RCTText', :path => '../node_modules/react-native/Libraries/Text'
-  pod 'React-RCTVibration', :path => '../node_modules/react-native/Libraries/Vibration'
-  pod 'React-Core/RCTWebSocket', :path => '../node_modules/react-native/'
+  pod 'FBLazyVector', :path => "#{prefix}/Libraries/FBLazyVector"
+  pod 'FBReactNativeSpec', :path => "#{prefix}/Libraries/FBReactNativeSpec"
+  pod 'RCTRequired', :path => "#{prefix}/Libraries/RCTRequired"
+  pod 'RCTTypeSafety', :path => "#{prefix}/Libraries/TypeSafety"
+  pod 'React', :path => "#{prefix}/"
+  pod 'React-Core', :path => "#{prefix}/"
+  pod 'React-CoreModules', :path => "#{prefix}/React/CoreModules"
+  pod 'React-Core/DevSupport', :path => "#{prefix}/"
+  pod 'React-RCTActionSheet', :path => "#{prefix}/Libraries/ActionSheetIOS"
+  pod 'React-RCTAnimation', :path => "#{prefix}/Libraries/NativeAnimation"
+  pod 'React-RCTBlob', :path => "#{prefix}/Libraries/Blob"
+  pod 'React-RCTImage', :path => "#{prefix}/Libraries/Image"
+  pod 'React-RCTLinking', :path => "#{prefix}/Libraries/LinkingIOS"
+  pod 'React-RCTNetwork', :path => "#{prefix}/Libraries/Network"
+  pod 'React-RCTSettings', :path => "#{prefix}/Libraries/Settings"
+  pod 'React-RCTText', :path => "#{prefix}/Libraries/Text"
+  pod 'React-RCTVibration', :path => "#{prefix}/Libraries/Vibration"
+  pod 'React-Core/RCTWebSocket', :path => "#{prefix}/"
 
-  pod 'React-cxxreact', :path => '../node_modules/react-native/ReactCommon/cxxreact'
-  pod 'React-jsi', :path => '../node_modules/react-native/ReactCommon/jsi'
-  pod 'React-jsiexecutor', :path => '../node_modules/react-native/ReactCommon/jsiexecutor'
-  pod 'React-jsinspector', :path => '../node_modules/react-native/ReactCommon/jsinspector'
-  pod 'ReactCommon/jscallinvoker', :path => "../node_modules/react-native/ReactCommon"
-  pod 'ReactCommon/turbomodule/core', :path => "../node_modules/react-native/ReactCommon"
-  pod 'Yoga', :path => '../node_modules/react-native/ReactCommon/yoga'
+  pod 'React-cxxreact', :path => "#{prefix}/ReactCommon/cxxreact"
+  pod 'React-jsi', :path => "#{prefix}/ReactCommon/jsi"
+  pod 'React-jsiexecutor', :path => "#{prefix}/ReactCommon/jsiexecutor"
+  pod 'React-jsinspector', :path => "#{prefix}/ReactCommon/jsinspector"
+  pod 'ReactCommon/jscallinvoker', :path => "#{prefix}/ReactCommon"
+  pod 'ReactCommon/turbomodule/core', :path => "#{prefix}/ReactCommon"
+  pod 'Yoga', :path => "#{prefix}/ReactCommon/yoga"
 
-  pod 'DoubleConversion', :podspec => '../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec'
-  pod 'glog', :podspec => '../node_modules/react-native/third-party-podspecs/glog.podspec'
-  pod 'Folly', :podspec => '../node_modules/react-native/third-party-podspecs/Folly.podspec'
+  pod 'DoubleConversion', :podspec => "#{prefix}/third-party-podspecs/DoubleConversion.podspec"
+  pod 'glog', :podspec => "#{prefix}/third-party-podspecs/glog.podspec"
+  pod 'Folly', :podspec => "#{prefix}/third-party-podspecs/Folly.podspec"
 
   target 'HelloWorldTests' do
     inherit! :complete
@@ -77,8 +79,8 @@ target 'HelloWorld' do
   use_native_modules!
 
   # For enabling Flipper.
-  # Note that if you use_framework!, flipper will no work. 
-  # Disable these lines if you are doing use_framework! 
+  # Note that if you use_framework!, flipper will no work.
+  # Disable these lines if you are doing use_framework!
   flipper_pods()
   post_install do |installer|
     flipper_post_install(installer)


### PR DESCRIPTION
## Summary

The Podfile used for HelloWorld template has verbose pod's paths. Adding a prefix variable for `"../node_modules/react-native"` improves readability and base path modification.

## Changelog

[iOS] [Added] - Added prefix to node_modules into Podfile template

## Test Plan

Run pod install in a 0.60 project with this Podfile (changing some paths to obey version) and verify that all pods are located and installed correctly.