### PR TITLE
remove android support annotations

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/modules/appearance/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/appearance/BUCK
@@ -9,7 +9,6 @@ rn_android_library(
     ],
     deps = [
         react_native_dep("third-party/java/jsr-305:jsr-305"),
-        react_native_dep("third-party/android/support-annotations:android-support-annotations"),
         react_native_dep("third-party/android/androidx:annotation"),
         react_native_target("java/com/facebook/react/bridge:bridge"),
         react_native_target("java/com/facebook/react/common:common"),


### PR DESCRIPTION
## Summary

Remove Android Support Library annotations dependency since we migrated to AndroidX.

## Changelog

[Android] [Changed] - remove android support annotations

## Test Plan

./scripts/circleci/buck_fetch.sh script completes without error.