### PR TITLE
[General] [Fixed] Fix incorrect `module.name_mapper` in template .flowconfig

### DIFF
--- a/template/_flowconfig
+++ b/template/_flowconfig
@@ -36,9 +36,9 @@ module.file_ext=.ios.js
 
 munge_underscores=true
 
-module.name_mapper='^react-native$' -> '<PROJECT_ROOT>/Libraries/react-native/react-native-implementation'
-module.name_mapper='^react-native/\(.*\)$' -> '<PROJECT_ROOT>/\1'
-module.name_mapper='^[./a-zA-Z0-9$_-]+\.\(bmp\|gif\|jpg\|jpeg\|png\|psd\|svg\|webp\|m4v\|mov\|mp4\|mpeg\|mpg\|webm\|aac\|aiff\|caf\|m4a\|mp3\|wav\|html\|pdf\)$' -> '<PROJECT_ROOT>/Libraries/Image/RelativeImageStub'
+module.name_mapper='^react-native$' -> '<PROJECT_ROOT>/node_modules/react-native/Libraries/react-native/react-native-implementation'
+module.name_mapper='^react-native/\(.*\)$' -> '<PROJECT_ROOT>/node_modules/react-native/\1'
+module.name_mapper='^[./a-zA-Z0-9$_-]+\.\(bmp\|gif\|jpg\|jpeg\|png\|psd\|svg\|webp\|m4v\|mov\|mp4\|mpeg\|mpg\|webm\|aac\|aiff\|caf\|m4a\|mp3\|wav\|html\|pdf\)$' -> '<PROJECT_ROOT>/node_modules/react-native/Libraries/Image/RelativeImageStub'
 
 suppress_type=$FlowIssue
 suppress_type=$FlowFixMe


### PR DESCRIPTION
## Summary

Has explained in https://github.com/facebook/react-native/issues/26233, current template is incorrect & can create error, like having require() of png that are considered as `string` instead of `number. This can probably hide tons of similar mistakes.

The change in this PR should resolve the previous behavior (& for example, some places in previous version of the flowconfig have the full path like here https://github.com/facebook/react-native/blob/35300147ca66677f42e8544264be72ac0e9d1b45/template/_flowconfig#L61)

Closes #26233

## Changelog

```
[General] [Fixed] Fix incorrect `module.name_mapper` in template .flowconfig
```

Alternatively, message could be

```
[General] [Internal] Fix incorrect `module.name_mapper` in template .flowconfig
```

As it hasn't this "bug" hasn't been released in a public stable release. You decide


## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

I just tested this in my project, @thymikee might be able to confirm & approve this PR.
