### PR TITLE
Add missing available guard to RCTInputAccessoryViewContent

### DIFF
--- a/Libraries/Text/TextInput/RCTInputAccessoryViewContent.m
+++ b/Libraries/Text/TextInput/RCTInputAccessoryViewContent.m
@@ -30,7 +30,7 @@
     _heightConstraint = [_safeAreaContainer.heightAnchor constraintEqualToConstant:0];
     _heightConstraint.active = YES;
 
-    if (@available(iOS 11.0, *)) {
+    if (@available(iOS 11.0, tvOS 11.0, *)) {
       [_safeAreaContainer.bottomAnchor constraintEqualToAnchor:self.safeAreaLayoutGuide.bottomAnchor].active = YES;
       [_safeAreaContainer.topAnchor constraintEqualToAnchor:self.safeAreaLayoutGuide.topAnchor].active = YES;
       [_safeAreaContainer.leadingAnchor constraintEqualToAnchor:self.safeAreaLayoutGuide.leadingAnchor].active = YES;


### PR DESCRIPTION
## Summary

The new podspec includes all .h and .m files, `RCTInputAccessoryViewContent` was missing a tvOS guard.

## Changelog

[iOS] [Fixed] - Restore RCTText tvOS pod compatibility 

## Test Plan
Build RCTText for tvOS
