### PR TITLE
Fix typos in comments about use_frameworks!

### DIFF
--- a/ReactCommon/ReactCommon.podspec
+++ b/ReactCommon/ReactCommon.podspec
@@ -31,7 +31,7 @@ Pod::Spec.new do |s|
   s.author                 = "Facebook, Inc. and its affiliates"
   s.platforms              = { :ios => "9.0", :tvos => "9.2" }
   s.source                 = source
-  s.header_dir             = "ReactCommon" # Use global header_dir for all subspecs for use_framework compatibility
+  s.header_dir             = "ReactCommon" # Use global header_dir for all subspecs for use_frameworks! compatibility
   s.compiler_flags         = folly_compiler_flags + ' ' + boost_compiler_flags
   s.pod_target_xcconfig    = { "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost-for-react-native\" \"$(PODS_ROOT)/Folly\" \"$(PODS_ROOT)/DoubleConversion\" \"$(PODS_ROOT)/Headers/Private/React-Core\"",
                                "USE_HEADERMAP" => "YES",

--- a/template/ios/Podfile
+++ b/template/ios/Podfile
@@ -78,8 +78,8 @@ target 'HelloWorld' do
   use_native_modules!
 
   # For enabling Flipper.
-  # Note that if you use_framework!, flipper will no work.
-  # Disable these lines if you are doing use_framework!
+  # Note that if you use_frameworks!, flipper will no work.
+  # Disable these lines if you are doing use_frameworks!
   flipper_pods()
   post_install do |installer|
     flipper_post_install(installer)


### PR DESCRIPTION
## Summary

Fixes typos in code comments about CocoaPods’s `use_frameworks!`.

## Changelog

[Internal] [Fixed] - Fix typos in comments about `use_frameworks!`

## Test Plan

Considering this only changes code comments, I don’t think this pull request needs a test plan.