### PR TITLE
Added userInterfaceStyle prop to ActionSheetmanager to override user interface style for iOS 13

### DIFF
--- a/Libraries/ActionSheetIOS/ActionSheetIOS.js
+++ b/Libraries/ActionSheetIOS/ActionSheetIOS.js
@@ -45,6 +45,7 @@ const ActionSheetIOS = {
       +cancelButtonIndex?: ?number,
       +anchor?: ?number,
       +tintColor?: number | string,
+      +userInterfaceStyle?: string,
     |},
     callback: (buttonIndex: number) => void,
   ) {

--- a/Libraries/ActionSheetIOS/NativeActionSheetManager.js
+++ b/Libraries/ActionSheetIOS/NativeActionSheetManager.js
@@ -25,7 +25,7 @@ export interface Spec extends TurboModule {
       +cancelButtonIndex?: ?number,
       +anchor?: ?number,
       +tintColor?: ?number,
-      userInterfaceStyle?: ?string,
+      +userInterfaceStyle?: ?string,
     |},
     callback: (buttonIndex: number) => void,
   ) => void;
@@ -37,7 +37,7 @@ export interface Spec extends TurboModule {
       +anchor?: ?number,
       +tintColor?: ?number,
       +excludedActivityTypes?: ?Array<string>,
-      userInterfaceStyle?: ?string,
+      +userInterfaceStyle?: ?string,
     |},
     failureCallback: (error: {|
       +domain: string,

--- a/Libraries/ActionSheetIOS/NativeActionSheetManager.js
+++ b/Libraries/ActionSheetIOS/NativeActionSheetManager.js
@@ -25,6 +25,7 @@ export interface Spec extends TurboModule {
       +cancelButtonIndex?: ?number,
       +anchor?: ?number,
       +tintColor?: ?number,
+      userInterfaceStyle?: ?string,
     |},
     callback: (buttonIndex: number) => void,
   ) => void;
@@ -36,6 +37,7 @@ export interface Spec extends TurboModule {
       +anchor?: ?number,
       +tintColor?: ?number,
       +excludedActivityTypes?: ?Array<string>,
+      userInterfaceStyle?: ?string,
     |},
     failureCallback: (error: {|
       +domain: string,

--- a/Libraries/ActionSheetIOS/RCTActionSheetManager.m
+++ b/Libraries/ActionSheetIOS/RCTActionSheetManager.m
@@ -112,6 +112,18 @@ RCT_EXPORT_METHOD(showActionSheetWithOptions:(NSDictionary *)options
   }
 
   alertController.view.tintColor = [RCTConvert UIColor:options[@"tintColor"]];
+  if([alertController respondsToSelector:NSSelectorFromString(@"overrideUserInterfaceStyle")])
+  {
+    NSString *userInterfaceStyle = [RCTConvert NSString:options[@"userInterfaceStyle"]];
+
+    if(userInterfaceStyle == nil || [userInterfaceStyle isEqualToString:@""])
+      alertController.overrideUserInterfaceStyle = UIUserInterfaceStyleUnspecified;
+    else if ([userInterfaceStyle isEqualToString:@"dark"])
+      alertController.overrideUserInterfaceStyle = UIUserInterfaceStyleDark;
+    else if ([userInterfaceStyle isEqualToString:@"light"])
+      alertController.overrideUserInterfaceStyle = UIUserInterfaceStyleLight;
+  }
+  
   [self presentViewController:alertController onParentViewController:controller anchorViewTag:anchorViewTag];
 }
 
@@ -173,6 +185,17 @@ RCT_EXPORT_METHOD(showShareActionSheetWithOptions:(NSDictionary *)options
 
   NSNumber *anchorViewTag = [RCTConvert NSNumber:options[@"anchor"]];
   shareController.view.tintColor = [RCTConvert UIColor:options[@"tintColor"]];
+  if([shareController respondsToSelector:NSSelectorFromString(@"overrideUserInterfaceStyle")])
+  {
+    NSString *userInterfaceStyle = [RCTConvert NSString:options[@"userInterfaceStyle"]];
+
+    if(userInterfaceStyle == nil || [userInterfaceStyle isEqualToString:@""])
+      shareController.overrideUserInterfaceStyle = UIUserInterfaceStyleUnspecified;
+    else if ([userInterfaceStyle isEqualToString:@"dark"])
+      shareController.overrideUserInterfaceStyle = UIUserInterfaceStyleDark;
+    else if ([userInterfaceStyle isEqualToString:@"light"])
+      shareController.overrideUserInterfaceStyle = UIUserInterfaceStyleLight;
+  }
   
   [self presentViewController:shareController onParentViewController:controller anchorViewTag:anchorViewTag];
 }

--- a/Libraries/ActionSheetIOS/RCTActionSheetManager.m
+++ b/Libraries/ActionSheetIOS/RCTActionSheetManager.m
@@ -112,16 +112,16 @@ RCT_EXPORT_METHOD(showActionSheetWithOptions:(NSDictionary *)options
   }
 
   alertController.view.tintColor = [RCTConvert UIColor:options[@"tintColor"]];
-  if([alertController respondsToSelector:NSSelectorFromString(@"overrideUserInterfaceStyle")])
-  {
+  if ([alertController respondsToSelector:NSSelectorFromString(@"overrideUserInterfaceStyle")]) {
     NSString *userInterfaceStyle = [RCTConvert NSString:options[@"userInterfaceStyle"]];
 
-    if(userInterfaceStyle == nil || [userInterfaceStyle isEqualToString:@""])
+    if (userInterfaceStyle == nil || [userInterfaceStyle isEqualToString:@""]) {
       alertController.overrideUserInterfaceStyle = UIUserInterfaceStyleUnspecified;
-    else if ([userInterfaceStyle isEqualToString:@"dark"])
+    } else if ([userInterfaceStyle isEqualToString:@"dark"]) {
       alertController.overrideUserInterfaceStyle = UIUserInterfaceStyleDark;
-    else if ([userInterfaceStyle isEqualToString:@"light"])
+    } else if ([userInterfaceStyle isEqualToString:@"light"]) {
       alertController.overrideUserInterfaceStyle = UIUserInterfaceStyleLight;
+    }
   }
   
   [self presentViewController:alertController onParentViewController:controller anchorViewTag:anchorViewTag];
@@ -185,16 +185,16 @@ RCT_EXPORT_METHOD(showShareActionSheetWithOptions:(NSDictionary *)options
 
   NSNumber *anchorViewTag = [RCTConvert NSNumber:options[@"anchor"]];
   shareController.view.tintColor = [RCTConvert UIColor:options[@"tintColor"]];
-  if([shareController respondsToSelector:NSSelectorFromString(@"overrideUserInterfaceStyle")])
-  {
+  if ([shareController respondsToSelector:NSSelectorFromString(@"overrideUserInterfaceStyle")]) {
     NSString *userInterfaceStyle = [RCTConvert NSString:options[@"userInterfaceStyle"]];
 
-    if(userInterfaceStyle == nil || [userInterfaceStyle isEqualToString:@""])
+    if (userInterfaceStyle == nil || [userInterfaceStyle isEqualToString:@""]) {
       shareController.overrideUserInterfaceStyle = UIUserInterfaceStyleUnspecified;
-    else if ([userInterfaceStyle isEqualToString:@"dark"])
+    } else if ([userInterfaceStyle isEqualToString:@"dark"]) {
       shareController.overrideUserInterfaceStyle = UIUserInterfaceStyleDark;
-    else if ([userInterfaceStyle isEqualToString:@"light"])
+    } else if ([userInterfaceStyle isEqualToString:@"light"]) {
       shareController.overrideUserInterfaceStyle = UIUserInterfaceStyleLight;
+    }
   }
   
   [self presentViewController:shareController onParentViewController:controller anchorViewTag:anchorViewTag];


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Support to override actionsheet and share interface style to match your app. For example, when your app has it's own theming you want to match the stying on actionsheet and the share menu.

## Changelog

[iOS] [Added] - Added userInterfaceStyle for ActionSheetIOS and Share to override user interface style on IOS 13

## Test Plan

Set dark style
![dark](https://user-images.githubusercontent.com/30040390/64685321-12a53080-d487-11e9-8846-f2ef89e114a2.jpg)
Set light style
![light](https://user-images.githubusercontent.com/30040390/64685322-12a53080-d487-11e9-9dfd-1e07b9fe0ce2.jpg)