### PR TITLE
Update image when default source changes

### DIFF
--- a/Libraries/Image/RCTImageView.mm
+++ b/Libraries/Image/RCTImageView.mm
@@ -196,6 +196,18 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithFrame:(CGRect)frame)
   }
 }
 
+- (void)setDefaultImage:(UIImage *)defaultImage
+{
+  if (_defaultImage == defaultImage) {
+    return;
+  }
+  BOOL update = self.image == nil || [self.image isEqual:_defaultImage];
+  _defaultImage = defaultImage;
+  if (update) {
+    [self updateWithImage:defaultImage];
+  }
+}
+
 - (void)setResizeMode:(RCTResizeMode)resizeMode
 {
   if (_resizeMode != resizeMode) {


### PR DESCRIPTION
## Summary

Changing the default source while it is being display does currently not lead to the new default source being displayed. When changing the default source (for example when the theme of the app changes), this should be respected and updated.

## Changelog

[iOS] [Fixed] - Update image when default source changes

## Test Plan

Use
```
<Image
        source={{ uri: undefined }}
        defaultSource={someDefaultImage} />
```
Now change `someDefaultImage` in runtime.

Old: Image will not update
New: Image will update and show the new default image.