### PR TITLE
fix: prevent activity recreation on theme change

### DIFF
--- a/template/android/app/src/main/AndroidManifest.xml
+++ b/template/android/app/src/main/AndroidManifest.xml
@@ -13,7 +13,7 @@
       <activity
         android:name=".MainActivity"
         android:label="@string/app_name"
-        android:configChanges="keyboard|keyboardHidden|orientation|screenSize"
+        android:configChanges="keyboard|keyboardHidden|orientation|screenSize|uiMode"
         android:windowSoftInputMode="adjustResize">
         <intent-filter>
             <action android:name="android.intent.action.MAIN" />


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

On Android 10 whole activity is recreated when the user changes system theme. We should prevent it by adding `uiMode` in `android:configChanges` key in the default template.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[Android] [Fixed] - Android 10: Prevent activity recreation on theme change

## Test Plan

NOOP
