### PR TITLE
Fix ShareSheet crash on iOS 13

### DIFF
--- a/Libraries/ActionSheetIOS/RCTActionSheetManager.m
+++ b/Libraries/ActionSheetIOS/RCTActionSheetManager.m
@@ -166,7 +166,7 @@ RCT_EXPORT_METHOD(showShareActionSheetWithOptions:(NSDictionary *)options
   shareController.completionWithItemsHandler = ^(NSString *activityType, BOOL completed, __unused NSArray *returnedItems, NSError *activityError) {
     if (activityError) {
       failureCallback(activityError);
-    } else {
+    } else if (completed) {
       successCallback(@[@(completed), RCTNullIfNil(activityType)]);
     }
   };


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Currently on iOS 13 the app will crash if you:
- Open the share sheet
- Tap something like messages or photos
- Cancel the dialog
- Perform any other action

This is because `shareController.completionWithItemsHandler` is called when the dialog box is canceled and currently `failureCallback` or `successCallback` will always be called. In the situation above, `activityError` is `nil` so `successCallback` will be called even though `completed` is false. This leaves us in a state where the callback has been invoked but the ShareSheet is still active, meaning the success or error callback will be invoked again, leading to the crash.

This PR adds a check to make sure `completed` is true before calling `successCallback`. This way `successCallback` will only be called when the user has successfully completed an action and the ShareSheet is closed.



## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[iOS] [Fixed] - Fix crash in RCTActionSheetManager.m on iOS 13

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
- Saved an image successfully
- Opened and dismissed the `Photos` dialog multiple times without crashing