### PR TITLE
Add `Gemfile.lock` to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,4 @@ RNTester/build
 /template/ios/Pods/
 /template/ios/Podfile.lock
 /RNTester/Pods/
+/RNTester/Gemfile.lock


### PR DESCRIPTION
## Summary

When installing pods for RNTester with `bundle run pod install` this file is generated and can be ignored.

## Changelog

[Internal] [Fixed] - Add `Gemfile.lock` to gitignore

## Test Plan

N/A