### PR TITLE
Fix printing of false boolean values in the style inspector

### DIFF
--- a/Libraries/Inspector/StyleInspector.js
+++ b/Libraries/Inspector/StyleInspector.js
@@ -33,13 +33,12 @@ class StyleInspector extends React.Component<$FlowFixMeProps> {
 
         <View>
           {names.map(name => {
-            const value =
-              typeof this.props.style[name] !== 'string'
-                ? JSON.stringify(this.props.style[name])
-                : this.props.style[name];
+            const value = this.props.style[name];
             return (
               <Text key={name} style={styles.value}>
-                {value}
+                {typeof value !== 'string' && typeof value !== 'number'
+                  ? JSON.stringify(value)
+                  : value}
               </Text>
             );
           })}

--- a/Libraries/Inspector/StyleInspector.js
+++ b/Libraries/Inspector/StyleInspector.js
@@ -34,7 +34,7 @@ class StyleInspector extends React.Component<$FlowFixMeProps> {
         <View>
           {names.map(name => {
             const value =
-              typeof this.props.style[name] === 'object'
+              typeof this.props.style[name] !== 'string'
                 ? JSON.stringify(this.props.style[name])
                 : this.props.style[name];
             return (


### PR DESCRIPTION
## Summary

React can't print false, we can just use `JSON.stringify` for any values except string to avoid adding quotes.

## Changelog

[General] [Fixed] - Fix printing of false boolean values in the style inspector

## Test Plan

Before

![image](https://user-images.githubusercontent.com/2677334/64896741-e4724d00-d64e-11e9-82b2-57275754523b.png)

After

![image](https://user-images.githubusercontent.com/2677334/64896725-d8868b00-d64e-11e9-903b-8e5212456d78.png)

