### PR TITLE
Fix `includeFontPadding` for `TextInput` placeholder

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
@@ -291,6 +291,11 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
     }
   }
 
+  @ReactProp(name = ViewProps.INCLUDE_FONT_PADDING, defaultBoolean = true)
+  public void setIncludeFontPadding(ReactEditText view, boolean includepad) {
+    view.setIncludeFontPadding(includepad);
+  }
+
   @ReactProp(name = "importantForAutofill")
   public void setImportantForAutofill(ReactEditText view, @Nullable String value) {
     int mode = View.IMPORTANT_FOR_AUTOFILL_AUTO;


### PR DESCRIPTION
## Summary

The custom font I'm using requires using `includeFontPadding={false}` to be correctly centered vertically. The only case where this is not working is with the placeholder of `TextInput`. To fix it we call `setIncludeFontPadding` on the `EditText` instance, like we do for `Text`.

## Changelog

[Android] [Fixed] - Fix `includeFontPadding` for `TextInput` placeholder

## Test Plan

Tested the fix in an app.

Before

![image](https://user-images.githubusercontent.com/2677334/64898120-f1de0600-d653-11e9-97b3-f53416d5f9fe.png)

After

![image](https://user-images.githubusercontent.com/2677334/64897961-5b114980-d653-11e9-8897-baa14fc0f56c.png)

