### PR TITLE
Fixes button partially showing when parent view height is 0

### DIFF
--- a/Libraries/Components/Button.js
+++ b/Libraries/Components/Button.js
@@ -204,7 +204,7 @@ const styles = StyleSheet.create({
   }),
   text: {
     textAlign: 'center',
-    padding: 8,
+    margin: 8,
     ...Platform.select({
       ios: {
         // iOS blue from https://developer.apple.com/ios/human-interface-guidelines/visual-design/color/


### PR DESCRIPTION
## Summary

When the parent view that wraps a button has height 0, the button is still shown partially because of the padding given for text inside Button component for iOS. Here is the issue raised for that: 
https://github.com/facebook/react-native/issues/26421

Probably, we should not hard code these values, rather provide a way to provide custom style ? This is my first PR so not making big change. :D

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[iOS] [Fixed] - Give margin instead of padding to text in Button component

## Test Plan

When using this block of code, 
```
<View style={{height:0}}>
    <Button title="There is an issue"></Button>
</View>
```
Before: 
<img width="284" alt="image" src="https://user-images.githubusercontent.com/5866078/64905271-6c129700-d6f5-11e9-86c1-c301eb8123f3.png">

After:
<img width="283" alt="image" src="https://user-images.githubusercontent.com/5866078/64905284-8cdaec80-d6f5-11e9-9589-28d8d01c8ba1.png">


