### PR TITLE
[iOS] Fixes Podfile and bump FlipperKit to 0.23.7

### DIFF
--- a/RNTester/Podfile
+++ b/RNTester/Podfile
@@ -9,12 +9,12 @@ end
 
 # Add Flipper Poods
 def flipper_pods()
-  flipperkit_version = '0.23.4'
+  flipperkit_version = '0.23.7'
   pod 'FlipperKit', '~>' + flipperkit_version, :configuration => 'Debug'
   pod 'FlipperKit/FlipperKitLayoutPlugin', '~>' + flipperkit_version, :configuration => 'Debug'
   pod 'FlipperKit/SKIOSNetworkPlugin', '~>' + flipperkit_version, :configuration => 'Debug'
   pod 'FlipperKit/FlipperKitUserDefaultsPlugin', '~>' + flipperkit_version, :configuration => 'Debug'
-  pod 'FlipperKit/FlipperKitReactPlugin' '~>' + flipperkit_version, :configuration => 'Debug'
+  pod 'FlipperKit/FlipperKitReactPlugin', '~>' + flipperkit_version, :configuration => 'Debug'
 end
 
 # Post Install processing for Flipper


### PR DESCRIPTION
## Summary

We added FlipperKit to iOS from https://github.com/facebook/react-native/commit/6a9ea48a8cbd5a80d2d79c1c014fceb0b154d671, but seems `FlipperKitReactPlugin` not published until 0.23.7, now we bump it and fix the wrong Podfile format.

## Changelog


[iOS] [Fixed] - Fixes Podfile and bump FlipperKit to 0.23.7

## Test Plan

RNTesterPods project can build successfully.
